### PR TITLE
fix(h1): merge gate approve advances story to done (H1-FIX-2)

### DIFF
--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -114,9 +114,30 @@ async def transition_gate(
     # H1-S7: 사람 게이트 해소(approve/reject)를 verdict로 기록 — trust로 환류.
     await _record_gate_review_verdict(session, org_id, gate, new_status, resolver_id)
 
+    # H1-FIX-2: merge 게이트 approve → work item 스토리를 done으로 진행(_preflight 재평가 우회).
+    # S7은 verdict만 기록하고 →done 진행을 안 박아, 사람이 approve해도 일이 done에 도달 못 하고
+    # done 재시도 시 재평가→ask_human 재발로 막히던 dogfood 갭을 닫는다.
+    await _advance_story_on_merge_approve(session, gate, new_status)
+
     await session.flush()
     await session.refresh(gate)
     return gate
+
+
+async def _advance_story_on_merge_approve(session: AsyncSession, gate: Gate, new_status: str) -> None:
+    """merge 게이트 approve 시 work_item 스토리를 done으로 진행(H1-FIX-2).
+
+    사람이 이미 approve했으므로 done PATCH의 _preflight 재평가를 우회해 직접 전이한다. reject나
+    비-merge 게이트는 진행하지 않는다(reject→in-review 유지). 이미 done이면 no-op(멱등).
+    """
+    if gate.gate_type != "merge" or gate.work_item_type != "story" or new_status != "approved":
+        return
+    from app.models.pm import Story  # 순환 회피 lazy import.
+
+    story = await session.get(Story, gate.work_item_id)
+    if story is not None and story.status != "done":
+        story.status = "done"
+        await session.flush()
 
 
 # gate_type → verdict source (qa→qa·merge→merge·deploy→design·pr_review→pr).

--- a/backend/tests/test_h1_fix2_approve_advances_done.py
+++ b/backend/tests/test_h1_fix2_approve_advances_done.py
@@ -1,0 +1,125 @@
+"""H1-FIX-2: merge 게이트 approve → 스토리 done 진행.
+
+S7이 verdict만 기록하고 →done 진행을 안 박아, 사람이 approve해도 일이 done 도달 못 하던 dogfood
+갭을 닫는다. approve→done·reject→유지·비-merge→미진행·멱등.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.gate_service import _advance_story_on_merge_approve
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _gate(gate_type="merge", work_item_type="story"):
+    return SimpleNamespace(gate_type=gate_type, work_item_type=work_item_type, work_item_id=uuid.uuid4())
+
+
+# ── 단위 ───────────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_merge_approve_advances_story_to_done():
+    story = SimpleNamespace(status="in-review")
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=story)
+    await _advance_story_on_merge_approve(session, _gate("merge"), "approved")
+    assert story.status == "done"  # approve → done 진행.
+
+
+@pytest.mark.anyio
+async def test_reject_keeps_status():
+    session = AsyncMock()
+    session.get = AsyncMock()
+    await _advance_story_on_merge_approve(session, _gate("merge"), "rejected")
+    session.get.assert_not_awaited()  # reject → 진행 안 함(in-review 유지).
+
+
+@pytest.mark.anyio
+async def test_non_merge_gate_no_advance():
+    session = AsyncMock()
+    session.get = AsyncMock()
+    await _advance_story_on_merge_approve(session, _gate("qa"), "approved")
+    session.get.assert_not_awaited()  # 비-merge 게이트는 미진행.
+
+
+@pytest.mark.anyio
+async def test_already_done_noop():
+    story = SimpleNamespace(status="done")
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=story)
+    await _advance_story_on_merge_approve(session, _gate("merge"), "approved")
+    assert story.status == "done"  # 멱등 no-op.
+
+
+@pytest.mark.anyio
+async def test_non_story_workitem_no_advance():
+    session = AsyncMock()
+    session.get = AsyncMock()
+    await _advance_story_on_merge_approve(session, _gate("merge", work_item_type="epic"), "approved")
+    session.get.assert_not_awaited()
+
+
+# ── 실DB E2E: transition_gate(approve) → 스토리 done 도달 ──────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_transition_approve_drives_story_done_real_db():
+    from sqlalchemy import text as _text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    from app.models.gate import Gate
+    from app.models.participation import Participation, ParticipationRole
+    from app.models.pm import Story
+    from app.models.verdict import Verdict  # noqa: F401 — create_all 테이블 등록(S7 verdict 기록).
+    from app.services.gate_service import transition_gate
+
+    url = _REAL_DB_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+        "postgresql://", "postgresql+asyncpg://"
+    )
+    engine = create_async_engine(url)
+    org, project, story_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    member, role_id, resolver, gate_id = (uuid.uuid4() for _ in range(4))
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add_all([
+                ParticipationRole(id=role_id, org_id=org, key="implementation", label="구현", is_default=True),
+                Story(id=story_id, org_id=org, project_id=project, title="S", status="in-review", story_points=3),
+                Participation(id=uuid.uuid4(), org_id=org, story_id=story_id, member_id=member, role_id=role_id),
+                Gate(id=gate_id, org_id=org, work_item_id=story_id, work_item_type="story",
+                     gate_type="merge", status="pending"),
+            ])
+            await s.commit()
+
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            await transition_gate(s, org, gate_id, "approved", resolver_id=resolver)
+            await s.commit()
+
+        async with Session() as s:
+            status = (await s.execute(
+                _text("SELECT status FROM stories WHERE id=:id"), {"id": story_id}
+            )).scalar()
+            # dogfood 갭 해소: 사람 approve만으로 스토리가 done에 도달(재시도/재평가 불요).
+            assert status == "done", f"approve 후 스토리가 done이어야, got {status}"
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()


### PR DESCRIPTION
## H1-FIX-2 — merge 게이트 approve → 스토리 done 진행 (dogfood 적발)

선생님이 merge 게이트 approve(`011c2098`)해도 **verdict는 기록되나 스토리가 done 안 됨**(in-review 잔류). done 재시도하면 **재평가→CI unknown→ask_human 재발**로 또 막힘 → **사람 approve해도 일이 done 도달 경로 없음**(루프 '사람 판정'은 닫히나 '일 완료' 미완결). S7이 verdict만 기록하고 →done 진행을 안 박은 갭.

### Fix (옵션 A 채택)
`transition_gate`에서 merge 게이트 approve 시 work_item 스토리를 **done으로 직접 진행**(`_advance_story_on_merge_approve`). 사람이 이미 approve했으므로 done PATCH의 `_preflight` 재평가를 **우회**(재시도 불요). reject→in-review 유지·비-merge/non-story→미진행·이미 done이면 멱등 no-op. lazy import 순환 회피.

### A vs B 의견
- **A**(채택): approve→done **1액션**·갭 직접 해소·게이트 semantic 일치(approve=완료 승인).
- **B**: done 재시도가 직전 approved gate 소비 → **2액션**·consume 추적 + stale-approval 엣지.
- → **A** 채택(dogfood UX·루프 즉시 닫음). 단 A는 done status-change side effects(events/webhook)를 우회하므로, gate-driven done에 알림이 필요하면 follow-up.

### Validation
신규 단위 5(merge approve→done·reject 유지·비-merge/non-story 미진행·멱등) + **실DB E2E 1**(`transition_gate` approve→스토리 done 도달) + gate/S7/S10 무회귀·`app.main` import OK·no cycle.

> dogfood 2번째 버그. 까심 QA(codex 5.5)→PO 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)