### PR TITLE
fix(h1): branch-safe SID linking for CI webhook events (H1-S6 견고성)

### DIFF
--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -179,7 +179,10 @@ def _candidate_texts(payload: dict) -> list[str]:
         texts.append(node.get("head_branch") or "")
         for p in node.get("pull_requests") or []:
             texts.append((p.get("head") or {}).get("ref") or "")
-    texts.append(payload.get("ref") or "")  # status/push
+    texts.append(payload.get("ref") or "")  # push
+    # status 이벤트는 ref 대신 branches[].name으로 브랜치를 싣는다.
+    for b in payload.get("branches") or []:
+        texts.append(b.get("name") or "")
     return [t for t in texts if t]
 
 

--- a/backend/app/services/verdict_capture.py
+++ b/backend/app/services/verdict_capture.py
@@ -21,18 +21,24 @@ from app.services.verdict_recorder import record_verdict
 
 logger = logging.getLogger(__name__)
 
-_SID_RE = re.compile(r"\[SID:([0-9a-f\-]{36})\]", re.IGNORECASE)
+# [SID:uuid](PR 제목/본문·콜론) 또는 sid-uuid/sid_uuid/sid/uuid(브랜치-안전·콜론 불가). CI 이벤트
+# (workflow_run/check_suite/status)는 PR title/body가 없고 head_branch만 와서, 콜론을 못 쓰는
+# git 브랜치명에 SID를 실으려면 sid-<uuid> 마커가 필요하다(H1-S6 링킹 견고성).
+_SID_RE = re.compile(r"\[SID:([0-9a-f\-]{36})\]|sid[-_/]([0-9a-f\-]{36})", re.IGNORECASE)
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
 
 
 def parse_story_id(text: str) -> uuid.UUID | None:
-    """PR/커밋 제목에서 [SID:uuid] 태그 파싱. 없으면 None(skip 신호)."""
+    """텍스트(PR 제목/본문 또는 브랜치명)에서 SID 태그 파싱.
+
+    `[SID:uuid]`(PR 제목/본문) 또는 `sid-<uuid>`/`sid/<uuid>`(브랜치) 모두 인식. 없으면 None(skip).
+    """
     m = _SID_RE.search(text)
     if not m:
         return None
     try:
-        return uuid.UUID(m.group(1))
-    except ValueError:
+        return uuid.UUID(m.group(1) or m.group(2))
+    except (ValueError, TypeError):
         return None
 
 

--- a/backend/tests/test_h1_s6_github_webhook.py
+++ b/backend/tests/test_h1_s6_github_webhook.py
@@ -167,3 +167,36 @@ async def test_duplicate_webhook_calls_capture_each_time():
         await _post(payload, event="pull_request")
         await _post(payload, event="pull_request")
     assert cap.await_count == 2  # 두 번 호출되나 record_verdict가 upsert로 1 verdict 유지.
+
+
+# ── SID 브랜치 링킹 견고성(CI 이벤트 — PR title 없는 경우) ──────────────────────
+
+def test_parse_story_id_branch_safe_formats():
+    from app.services.verdict_capture import parse_story_id
+
+    sid = uuid.uuid4()
+    assert parse_story_id(f"feat [SID:{sid}]") == sid       # PR 제목(콜론).
+    assert parse_story_id(f"feat/h1-sid-{sid}") == sid      # 브랜치 sid-uuid.
+    assert parse_story_id(f"sid/{sid}") == sid              # 브랜치 sid/uuid.
+    assert parse_story_id(f"feat/h1-sid_{sid}") == sid      # sid_uuid.
+    assert parse_story_id("feat/h1-fix-3") is None          # 태그 없으면 None.
+
+
+def test_candidate_texts_status_branches():
+    sid = uuid.uuid4()
+    texts = _candidate_texts({"state": "success", "branches": [{"name": f"feat/h1-sid-{sid}"}]})
+    assert f"feat/h1-sid-{sid}" in texts  # status는 branches[].name로 브랜치 노출.
+
+
+@pytest.mark.anyio
+async def test_workflow_run_branch_sid_links_capture():
+    """CI 이벤트(workflow_run)는 PR title 없이 head_branch의 sid-<uuid>로 verdict 연결."""
+    sid = STORY_ID
+    payload = {"repository": {"full_name": "o/r"},
+               "workflow_run": {"conclusion": "failure", "head_branch": f"feat/h1-sid-{sid}", "pull_requests": []}}
+    with patch.object(mod, "capture_pr_ci_verdict",
+                      new=AsyncMock(return_value={"recorded": ["ci"], "skipped_reason": None})) as cap:
+        resp = await _post(payload, event="workflow_run")
+    assert resp.status_code == 200
+    kw = cap.await_args.kwargs
+    assert kw["story_id"] == sid and kw["ci_result"] == "failure"  # 브랜치 SID로 링킹 성공.


### PR DESCRIPTION
## H1-S6 견고성 — CI 이벤트 SID 링킹 (오르테가군 요청 ①)

**진단: 현재 CI 이벤트는 `[SID:uuid]` 링킹 불가.** workflow_run/check_suite/status 이벤트는 PR title/body가 **없고** head_branch만 온다. 그런데 `[SID:uuid]`는 콜론(`:`)을 포함해 **git 브랜치명에 못 실음**(콜론 불가). → CI 이벤트로는 SID를 못 잡는 갭 2개 적발·교정.

### Fix
- **`_SID_RE` 브랜치-안전 마커 추가**: `[SID:uuid]`(PR 제목/본문) **또는** `sid-<uuid>`/`sid_<uuid>`/`sid/<uuid>`(브랜치). `parse_story_id`가 둘 다 인식(group1|group2)·**`[SID:uuid]` 하위호환 유지**.
- **`_candidate_texts` status 교정**: status 이벤트는 `ref` 대신 `branches[].name`로 브랜치를 싣는데 미추출이던 것 추가. → `workflow_run.head_branch`·`check_suite.head_branch`·`status.branches[].name` 전부 SID 추출.

### 권장 컨벤션 (요청 ②)
- **PR 제목/본문**: `[SID:<스토리uuid>]` — `pull_request` 이벤트가 title로 연결.
- **브랜치명**: `...sid-<스토리uuid>...` — CI 이벤트(workflow_run/check_suite/status)가 head_branch로 연결.
- 둘 중 하나만 있어도 링킹. 실 PR엔 **둘 다** 넣으면 PR-이벤트·CI-이벤트 양쪽 견고.

### Validation
신규 3(브랜치 4형식 파싱·status `branches[]` 추출·workflow_run `head_branch` SID→capture 링킹) + 기존 webhook/verdict capture **25 무회귀**.

> H1-S6 후속(웹훅 인프라 라이브). 까심 QA(codex 5.5)→PO 머지. 머지+배포 후 내 PR부터 `[SID]`+`sid-` 태그 적용해 실 PR 1개로 webhook→verdict 끝단 검증 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)