### PR TITLE
test(ho): score-hypotheses cron smoke (HO-S1)

### DIFF
--- a/backend/tests/test_ho_s1_score_hypotheses_smoke.py
+++ b/backend/tests/test_ho_s1_score_hypotheses_smoke.py
@@ -1,0 +1,80 @@
+"""HO-S1: score-hypotheses cron 스모크(서비스 레벨).
+
+운영 cron은 Cloud Scheduler→backend POST /api/v2/internal/cron/score-hypotheses(PO lane). 여기선
+score_hypotheses 서비스를 실 Postgres로 스모크 — due active 가설이 채점 패스 후 measuring(또는
+verified/falsified)으로 전이함을 검증(AC④). DB 스키마 변경 0(AC⑤).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_score_hypotheses_transitions_due_active_real_db():
+    from sqlalchemy import text as _text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    from app.models.hypothesis import Hypothesis
+    from app.services.hypothesis_scorer import score_hypotheses
+
+    url = _REAL_DB_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+        "postgresql://", "postgresql+asyncpg://"
+    )
+    engine = create_async_engine(url)
+    org, project, owner = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    due = datetime.now(timezone.utc) - timedelta(hours=1)
+    future = datetime.now(timezone.utc) + timedelta(days=7)
+    h_due = uuid.uuid4()       # due active(manual) → measuring 전이 기대.
+    h_future = uuid.uuid4()    # measure_after 미도래 → 무전이(active 유지).
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+
+    def _hyp(hid, status, measure_after):
+        return Hypothesis(
+            id=hid, org_id=org, project_id=project, owner_member_id=owner,
+            statement="가설", metric_definition={"metric": "x", "source": "manual", "target": 10, "direction": "up"},
+            measure_after=measure_after, status=status,
+        )
+
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add_all([_hyp(h_due, "active", due), _hyp(h_future, "active", future)])
+            await s.commit()
+
+        async with Session() as s:
+            summary = await score_hypotheses(s)
+            await s.commit()
+
+        # due active(manual) → measuring 전이(채점은 measuring 유지=pending), 미도래는 무전이.
+        assert str(h_due) in summary["to_measuring"], summary
+        assert str(h_due) in summary["pending"]  # manual → 자동 채점 안 함·measuring 유지.
+        assert str(h_future) not in summary["to_measuring"]  # 미도래 active 무전이.
+
+        async with Session() as s:
+            statuses = dict((await s.execute(
+                _text("SELECT id::text, status FROM hypotheses WHERE org_id=:o"), {"o": org}
+            )).all())
+        # AC④: due active 가설이 cron 후 measuring 전이·미도래는 active 유지.
+        assert statuses[str(h_due)] == "measuring"
+        assert statuses[str(h_future)] == "active"
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()


### PR DESCRIPTION
## HO-S1 — score-hypotheses 운영 cron 가동 (backend smoke)

E-HO-TRUST HO-S1. forward-verify로 **기존 cron 인프라가 dormant**(Cloud Scheduler 미활성·트리거 전무·기존 FE cron 라우트 미작동)임을 확인 → **FE 라우트 답습 X**. PO 확정: 운영 cron = **Cloud Scheduler(GCP) → dev backend `POST /api/v2/internal/cron/score-hypotheses` 직접**(PO lane). 본 PR = **backend smoke codify**.

### 검증
- **로컬 실DB 스모크**(`test_ho_s1_score_hypotheses_smoke.py`): due active(manual) 가설 seed → `score_hypotheses` → **measuring 전이**·`measure_after` 미도래는 active 유지(**AC④**). DB 스키마 변경 0(**AC⑤**). temp PG 실증·CI alembic-fresh-db 재검증.
- **라이브 검증**(보고용): dev backend **CRON_SECRET 미설정 적발**(무인증 POST→200·`verify_cron`은 미설정 시 open) → PO 선제 set. set 後 **무인증 POST→401**·**bearer POST→200**(`score_hypotheses` 실행·total:0·현재 due 없음).

### forward-verify
cron 라우터 prefix=`/api/v2/internal/cron`(단일)·`verify_cron`(CRON_SECRET bearer)·`hypothesis_scorer.score_hypotheses` 실재 확인. broader 갭(기존 cron 전부 dormant)은 backlog.

> smoke OK → PO가 Cloud Scheduler 등록해 HO-S1 끝단 닫음. 까심 QA(codex 5.5)→PO 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)