### PR TITLE
feat(ho): seed hypothesis_owner participation role (HO-S3·migration 0119)

### DIFF
--- a/backend/alembic/versions/0119_seed_hypothesis_owner_role.py
+++ b/backend/alembic/versions/0119_seed_hypothesis_owner_role.py
@@ -1,0 +1,48 @@
+"""HO-S3: bet owner participation role seed (hypothesis_owner).
+
+Revision ID: 0119
+Revises: 0118
+Create Date: 2026-06-13
+
+블루프린트 §3.3 Story3. HO-S2의 outcome→verdict 배선이 bet verdict를 기록하려면 각 org에
+`ParticipationRole.key='hypothesis_owner'` 역할이 있어야 한다(없으면 ensure_review_participation이
+None을 반환해 bet verdict graceful skip). 본 마이그가 모든 org에 그 역할을 보장한다.
+
+- org-custom role 구조 재사용 — enum 하드코딩 0(participation_role은 범용 역할 테이블).
+- 멱등: 0063이 만든 uq_participation_role_org_key(org_id,key)로 ON CONFLICT DO NOTHING → 기존
+  org 중복 0·이미 가진 org skip. 데이터 seed만(스키마 변경 0).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0119"
+down_revision = "0118"
+branch_labels = None
+depends_on = None
+
+_ROLE_KEY = "hypothesis_owner"
+_ROLE_LABEL = "가설 책임자"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    if "participation_role" not in insp.get_table_names() or "organizations" not in insp.get_table_names():
+        return  # 테이블 부재(이론상 없음) — no-op.
+
+    # 각 org에 hypothesis_owner 역할 1행 보장. uq(org_id,key)로 멱등(중복 org skip).
+    op.execute(
+        sa.text(
+            "INSERT INTO participation_role (id, org_id, key, label, is_default, created_at) "
+            "SELECT gen_random_uuid(), o.id, :key, :label, false, now() FROM organizations o "
+            "ON CONFLICT (org_id, key) DO NOTHING"
+        ).bindparams(key=_ROLE_KEY, label=_ROLE_LABEL)
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text("DELETE FROM participation_role WHERE key = :key").bindparams(key=_ROLE_KEY)
+    )

--- a/backend/tests/test_ho_s3_hypothesis_owner_seed.py
+++ b/backend/tests/test_ho_s3_hypothesis_owner_seed.py
@@ -1,0 +1,84 @@
+"""HO-S3: hypothesis_owner role seed 마이그(0119) 테스트.
+
+각 org에 ParticipationRole.key='hypothesis_owner' 보장·중복 없음·멱등·downgrade. 실 PG로 마이그
+upgrade/downgrade를 직접 구동(0117/0118 검증 패턴). HO-S2 bet verdict가 이 역할에 의존.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+_MIG = os.path.join(
+    os.path.dirname(__file__), "..", "alembic", "versions", "0119_seed_hypothesis_owner_role.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("mig0119", _MIG)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_seed_hypothesis_owner_per_org_idempotent():
+    import sqlalchemy as sa
+    from alembic.operations import Operations
+    from alembic.runtime.migration import MigrationContext
+
+    sync_url = _REAL_DB_URL.replace("postgresql+asyncpg://", "postgresql+psycopg2://").replace(
+        "postgresql://", "postgresql+psycopg2://"
+    )
+    eng = sa.create_engine(sync_url)
+    mig = _load_migration()
+    org_a, org_b = uuid.uuid4(), uuid.uuid4()
+
+    def _run(fn):
+        with eng.begin() as c:
+            with Operations.context(MigrationContext.configure(c)):
+                getattr(mig, fn)()
+
+    try:
+        with eng.begin() as c:
+            # 마이그가 의존하는 테이블이 없으면 만든다(fresh DB 격리 — CI는 마이그 체인으로 존재).
+            c.execute(sa.text("CREATE TABLE IF NOT EXISTS organizations (id uuid PRIMARY KEY)"))
+            c.execute(sa.text(
+                "CREATE TABLE IF NOT EXISTS participation_role (id uuid PRIMARY KEY, org_id uuid NOT NULL, "
+                "key varchar(50) NOT NULL, label text NOT NULL, is_default boolean NOT NULL DEFAULT false, "
+                "created_at timestamptz NOT NULL DEFAULT now())"
+            ))
+            c.execute(sa.text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS uq_participation_role_org_key "
+                "ON participation_role (org_id, key)"
+            ))
+            c.execute(sa.text("INSERT INTO organizations(id) VALUES (:a),(:b)"), {"a": org_a, "b": org_b})
+            # org_a는 이미 hypothesis_owner 보유(중복 방지 검증).
+            c.execute(sa.text(
+                "INSERT INTO participation_role(id,org_id,key,label) VALUES (:i,:o,'hypothesis_owner','기존')"
+            ), {"i": uuid.uuid4(), "o": org_a})
+
+        _run("upgrade")
+        _run("upgrade")  # 멱등(2회).
+
+        with eng.begin() as c:
+            cnt = lambda o: c.execute(sa.text(
+                "SELECT count(*) FROM participation_role WHERE org_id=:o AND key='hypothesis_owner'"
+            ), {"o": o}).scalar()
+            assert cnt(org_a) == 1, "기존 보유 org도 정확히 1(중복 0)"  # AC②
+            assert cnt(org_b) == 1, "신규 org에 1 보장"                # AC①
+
+        _run("downgrade")
+        with eng.begin() as c:
+            left = c.execute(sa.text(
+                "SELECT count(*) FROM participation_role WHERE org_id IN (:a,:b) AND key='hypothesis_owner'"
+            ), {"a": org_a, "b": org_b}).scalar()
+            assert left == 0  # downgrade 후 제거.
+    finally:
+        with eng.begin() as c:
+            c.execute(sa.text("DELETE FROM participation_role WHERE org_id IN (:a,:b)"), {"a": org_a, "b": org_b})
+            c.execute(sa.text("DELETE FROM organizations WHERE id IN (:a,:b)"), {"a": org_a, "b": org_b})
+        eng.dispose()


### PR DESCRIPTION
## HO-S3 — bet owner participation role seed (migration 0119)

E-HO-TRUST HO-S3(블루프린트 §3.3). HO-S2의 **bet verdict가 `ParticipationRole.key='hypothesis_owner'`에 의존**(없으면 `ensure_review_participation` None→graceful skip). 본 마이그가 **각 org에 그 역할을 보장** → bet verdict 발화.

### `0119` (head 0118 → 0119)
- 모든 org에 `participation_role(key=hypothesis_owner·label=가설 책임자·is_default=false)` seed.
- `INSERT...SELECT FROM organizations ON CONFLICT (org_id, key) DO NOTHING` — 0063의 `uq_participation_role_org_key`로 **멱등**(기존 보유 org skip·**중복 0**·**AC②**). **org-custom role 구조 재사용·enum 하드코딩 0**.
- **데이터 seed만(스키마 변경 0)**. downgrade = `key='hypothesis_owner'` 행 삭제.

### Validation (실 PG·Operations API)
- upgrade **x2 멱등**·3 org → **org당 정확히 1**(기존 보유 org **중복 0**·**AC①**)·downgrade 후 0.
- 신규 마이그 테스트(`test_ho_s3_hypothesis_owner_seed`): org당 보장·중복 0·멱등·downgrade(**AC③ migration AC codify**). 단일 head `0119`←`0118`.

> ⚠️ **머지 후 `migrate-dev 0119` 적용 필요**(머지=migrate 원자성). 적용되면 HO-S2 bet verdict 발화 시작. forward-verify: `participation_role`·`organizations`·`uq_participation_role_org_key`·HO-S2 role_key 정렬 확인. 까심 QA(codex 5.5)→PO 머지→migrate-dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)