### PR TITLE
feat(ho): wire scorer to outcome verdict (HO-S4·chain close)

### DIFF
--- a/backend/app/services/hypothesis_scorer.py
+++ b/backend/app/services/hypothesis_scorer.py
@@ -64,6 +64,10 @@ async def score_hypotheses(session: AsyncSession) -> dict[str, Any]:
     falsified: list[str] = []
     pending: list[str] = []
     failed: list[dict] = []
+    # HO-S4: 해소(verified/falsified) 직후 outcome verdict 배선 결과(가설 적중 이력→trust).
+    verdicts_recorded: list[dict] = []
+    verdicts_skipped: list[dict] = []
+    from app.services.hypothesis_outcome_verdict import record_outcome_verdicts
 
     hyps = (await session.execute(
         select(Hypothesis).where(
@@ -100,6 +104,17 @@ async def score_hypotheses(session: AsyncSession) -> dict[str, Any]:
             hyp.status = new_status
             hyp.outcome_result = scoring["outcome_result"]
             (verified if new_status == "verified" else falsified).append(str(hyp.id))
+            # HO-S4(AC①): 해소 직후 outcome→verdict 배선(체인: scorer→verdict→trust 닫힘).
+            # manual/pending은 여기 도달 안 함(new_status None)이라 verdict 0(AC④).
+            vres = await record_outcome_verdicts(session, hyp)
+            if vres.get("skipped_reason"):
+                verdicts_skipped.append({"hypothesis_id": str(hyp.id), "reason": vres["skipped_reason"]})
+            else:
+                verdicts_recorded.append({
+                    "hypothesis_id": str(hyp.id),
+                    "bet": vres.get("bet", []),
+                    "execution": vres.get("execution", []),
+                })
         else:
             pending.append(str(hyp.id))  # measuring 유지
 
@@ -110,4 +125,7 @@ async def score_hypotheses(session: AsyncSession) -> dict[str, Any]:
         "pending": pending,
         "failed": failed,
         "total": len(hyps),
+        # HO-S4(AC②): outcome verdict 배선 결과를 cron response에 노출.
+        "verdicts_recorded": verdicts_recorded,
+        "verdicts_skipped": verdicts_skipped,
     }

--- a/backend/tests/test_ho_s4_scorer_verdict_wiring.py
+++ b/backend/tests/test_ho_s4_scorer_verdict_wiring.py
@@ -1,0 +1,136 @@
+"""HO-S4: scorer→outcome verdict 배선 호출 테스트.
+
+score_hypotheses가 verified/falsified 해소 직후 record_outcome_verdicts를 호출하고 결과를 cron
+response(verdicts_recorded/skipped)에 노출하는지. manual/pending은 verdict 0(AC④). 끝단 실DB.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import hypothesis_scorer as sc
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _hyp(status="active", source="ga4"):
+    return SimpleNamespace(
+        id=uuid.uuid4(), status=status, outcome_result=None,
+        metric_definition={"metric": "m", "source": source, "target": 100, "direction": "up"},
+    )
+
+
+# ── AC①②④: 해소 시 배선 호출·response 노출·manual 미호출 ─────────────────────
+
+@pytest.mark.anyio
+async def test_resolved_calls_wiring_manual_does_not():
+    verified_hyp = _hyp("active", "ga4")     # ga4 hit → verified → 배선 호출.
+    manual_hyp = _hyp("measuring", "manual")  # manual → pending → 배선 미호출(AC④).
+
+    session = AsyncMock()
+    res = MagicMock()
+    res.scalars.return_value.all.return_value = [verified_hyp, manual_hyp]
+    session.execute = AsyncMock(return_value=res)
+
+    spy = AsyncMock(return_value={"skipped_reason": None, "bet": ["b1"], "execution": ["e1"]})
+    with patch.object(sc, "score_ga4_outcome", return_value={"outcome_status": "hit", "outcome_result": {"x": 1}}), \
+         patch("app.services.hypothesis_outcome_verdict.record_outcome_verdicts", new=spy):
+        summary = await sc.score_hypotheses(session)
+
+    # AC①: verified 가설에만 배선 호출(manual 미호출·AC④).
+    assert spy.await_count == 1
+    assert spy.await_args.args[1] is verified_hyp
+    # AC②: cron response에 verdicts_recorded/skipped.
+    assert summary["verdicts_recorded"] == [{"hypothesis_id": str(verified_hyp.id), "bet": ["b1"], "execution": ["e1"]}]
+    assert summary["verdicts_skipped"] == []
+    assert str(verified_hyp.id) in summary["verified"]
+
+
+@pytest.mark.anyio
+async def test_skipped_wiring_goes_to_verdicts_skipped():
+    h = _hyp("active", "ga4")
+    session = AsyncMock()
+    res = MagicMock()
+    res.scalars.return_value.all.return_value = [h]
+    session.execute = AsyncMock(return_value=res)
+    spy = AsyncMock(return_value={"skipped_reason": "no_linked_story", "bet": [], "execution": []})
+    with patch.object(sc, "score_ga4_outcome", return_value={"outcome_status": "miss", "outcome_result": {}}), \
+         patch("app.services.hypothesis_outcome_verdict.record_outcome_verdicts", new=spy):
+        summary = await sc.score_hypotheses(session)
+    assert str(h.id) in summary["falsified"]
+    assert summary["verdicts_skipped"] == [{"hypothesis_id": str(h.id), "reason": "no_linked_story"}]
+    assert summary["verdicts_recorded"] == []
+
+
+# ── 끝단 실DB: scorer 해소 → 실 outcome verdict 기록 ──────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_scorer_to_verdict_chain_real_db():
+    from sqlalchemy import text as _text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    from app.models.hypothesis import Hypothesis, HypothesisStoryLink
+    from app.models.participation import Participation, ParticipationRole
+    from app.models.pm import Story
+    from app.models.verdict import Verdict  # noqa: F401
+    from app.services.hypothesis_outcome_verdict import BET_ROLE_KEY, BET_SOURCE, EXECUTION_SOURCE
+    from app.services.hypothesis_scorer import score_hypotheses
+
+    url = _REAL_DB_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+        "postgresql://", "postgresql+asyncpg://"
+    )
+    engine = create_async_engine(url)
+    org, project, story_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    owner, impl_member, impl_role, bet_role, hyp_id = (uuid.uuid4() for _ in range(5))
+    past = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add_all([
+                ParticipationRole(id=impl_role, org_id=org, key="implementation", label="구현", is_default=True),
+                ParticipationRole(id=bet_role, org_id=org, key=BET_ROLE_KEY, label="가설책임", is_default=False),
+                Story(id=story_id, org_id=org, project_id=project, title="S", status="done", story_points=3),
+                Participation(id=uuid.uuid4(), org_id=org, story_id=story_id, member_id=impl_member, role_id=impl_role),
+                # internal_ops·completion_pct·target=50·up + done 링크 1개(100%) → hit → verified.
+                Hypothesis(id=hyp_id, org_id=org, project_id=project, owner_member_id=owner,
+                           statement="H", measure_after=past, status="active",
+                           metric_definition={"metric": "completion_pct", "source": "internal_ops",
+                                              "target": 50, "direction": "up"}),
+                HypothesisStoryLink(id=uuid.uuid4(), hypothesis_id=hyp_id, story_id=story_id, link_type="supports"),
+            ])
+            await s.commit()
+
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            summary = await score_hypotheses(s)
+            await s.commit()
+
+        # scorer가 verified로 해소하고 배선이 verdict를 기록했다.
+        assert str(hyp_id) in summary["verified"]
+        assert summary["verdicts_recorded"], summary
+        async with Session() as s:
+            status = (await s.execute(_text("SELECT status FROM hypotheses WHERE id=:id"), {"id": hyp_id})).scalar()
+            rows = dict((await s.execute(_text("SELECT source, result FROM verdict WHERE org_id=:o"), {"o": org})).all())
+        assert status == "verified"
+        assert rows[EXECUTION_SOURCE] == "pass" and rows[BET_SOURCE] == "pass"  # 끝단 닫힘.
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()

--- a/backend/tests/test_hypothesis_scorer.py
+++ b/backend/tests/test_hypothesis_scorer.py
@@ -18,6 +18,17 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+def _mock_outcome_verdicts():
+    """HO-S4: scorer가 해소 직후 record_outcome_verdicts를 호출하므로, 전이 로직만 검증하는 기존
+    테스트(mock session)에서는 배선 호출을 격리한다(scorer 불변식 어서션 유지·AC③)."""
+    with patch(
+        "app.services.hypothesis_outcome_verdict.record_outcome_verdicts",
+        new=AsyncMock(return_value={"skipped_reason": "no_linked_story", "bet": [], "execution": []}),
+    ):
+        yield
+
+
 def _hyp(status="active", source="ga4", **ov):
     md = {"metric": "signups", "source": source, "target": 100, "direction": "up"}
     base = dict(


### PR DESCRIPTION
## HO-S4 — scorer → outcome verdict 배선 호출 (체인 닫음)

E-HO-TRUST HO-S4(블루프린트 §3.3). **`score_hypotheses`가 verified/falsified 해소 직후 `record_outcome_verdicts(session, hyp)`를 호출** → scorer가 가설을 해소하면 자동으로 outcome verdict를 기록. **끝단 닫힘**: 가설 `measure_after` → scorer → outcome verdict → trust 흐름.

### Changes
- **AC①**: `new_status`가 verified/falsified로 확정된 직후 `record_outcome_verdicts` 호출(lazy import 순환 회피).
- **AC②**: cron response에 `verdicts_recorded`/`verdicts_skipped` 추가(배선 결과 관측).
- **AC④**: manual/pending은 `new_status=None`이라 도달 안 함 → verdict 0(`record_outcome_verdicts`도 status 게이트로 이중 안전).
- **AC③**: 기존 scorer 테스트는 전이 로직만 검증(mock session)이라, autouse fixture로 배선 호출을 격리(`record_outcome_verdicts` mock)해 어서션 유지.

### Validation
- 신규 단위 2(verified→배선 호출·manual 미호출·response 노출 / skip→`verdicts_skipped`).
- **끝단 실DB**(`test_scorer_to_verdict_chain_real_db`): internal_ops `completion_pct` 100%(done 링크) → **verified** → execution `pass`+bet `pass` 실기록 = **scorer→verdict 체인 닫힘**.
- 기존 scorer **8 무파손**·`app.main` import OK·no cycle.

> forward-verify: `score_hypotheses` 전이 지점·`record_outcome_verdicts` 시그니처·`score_epic_outcome` internal_ops 로직 develop 실재 확인. E-HO-TRUST 체인: S1(cron)→S2(verdict)→S3(role)→**S4(호출)**. 다음 HO-S5(trust source 전환·CI 제외). 까심 QA(codex 5.5)→PO 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)