### PR TITLE
feat(ho): trust score outcome source 전환 (HO-S5·substance)

### DIFF
--- a/backend/app/services/trust_score.py
+++ b/backend/app/services/trust_score.py
@@ -1,11 +1,15 @@
-"""E-CAGE-REFEREE P2: 신뢰 점수 집계 엔진.
+"""E-CAGE-REFEREE P2 + E-HO-TRUST(HO-S5): 신뢰 점수 집계 엔진.
 
-(member, role)별 무정정 통과율 × SP 가중.
-  - 무정정 통과 = verdict.result='pass' AND (rounds IS NULL OR rounds=0)
-  - SP 가중 = story_points (null→1 fallback). is_excluded 스토리 제외.
+(member, role)별 가설 outcome 적중 이력 기반 신뢰.
+  - 기본 source = hypothesis_outcome_bet/execution(가설 적중 이력=substance). HO-S5에서
+    CI/pr/qa/design은 기본 trust에서 제외(효과≠실행품질의 substance 전환). legacy 전 source
+    합산은 include_legacy=True 명시 opt-in.
+  - hit_rate = pass / (pass+fail)(resolved). pass=hit·fail=miss·null=pending.
+  - 무정정 통과(clean_pass) = verdict.result='pass' AND (rounds IS NULL OR rounds=0). SP 가중 =
+    story_points (null→1 fallback). is_excluded 스토리 제외. (per-role 보조 지표로 유지)
   - 온더플라이 집계 (마이그 없음) — verdict 조인 쿼리.
-  - outcome(hit/miss)은 포함 안 함 — 효과≠실행품질.
-  - 빈데이터 graceful: verdict 없으면 score=None (0 아님, 구분 필요).
+  - 빈데이터 graceful: 표본 없으면 rate=None (0 아님, cold-start 구분). source_breakdown으로
+    제외된 source도 관측.
   - MVP 이진 산식. 데이터 쌓인 뒤 튜닝.
 
 반환 구조:
@@ -41,6 +45,11 @@ from app.models.verdict import Verdict
 
 DEFAULT_WINDOW_DAYS = 90
 
+# HO-S5: 신뢰의 1차(primary) source = 가설 outcome verdict(가설 적중 이력=substance).
+# 기본 집계는 이 source들만 trust로 환산하고 CI/pr/qa/design은 제외(legacy clean_pass는
+# include_legacy=True 명시 옵션). outcome verdict의 result: pass=hit·fail=miss·null=pending.
+OUTCOME_SOURCES = frozenset({"hypothesis_outcome_bet", "hypothesis_outcome_execution"})
+
 
 def _is_clean_pass(result: str | None, rounds: int | None) -> bool:
     """무정정 통과 판정: pass + 정정 라운드 없음."""
@@ -53,15 +62,25 @@ async def compute_member_trust_scores(
     member_id: uuid.UUID,
     role_key: str | None = None,
     window_days: int = DEFAULT_WINDOW_DAYS,
+    *,
+    include_legacy: bool = False,
 ) -> dict[str, Any]:
     """(member, role)별 신뢰점수 온더플라이 집계.
+
+    HO-S5: 기본 집계 source를 가설 outcome(hypothesis_outcome_bet/execution)로 제한한다.
+    CI/pr/qa/design verdict는 신뢰로 환산하지 않는다(효과≠실행품질의 substance 전환). 결과
+    표본이 없으면 clean_pass_rate=None=cold-start(표본부족). legacy 전 source 합산은
+    include_legacy=True로 명시 opt-in.
 
     Args:
         role_key: 특정 역할만 집계. None이면 전 역할.
         window_days: verdict 기준 최근 N일 윈도우.
+        include_legacy: True면 모든 source를 신뢰로 합산(구 동작·명시 옵션).
 
     Returns:
-        {"member_id": ..., "scores": [...], "window_days": ..., "computed_at": ...}
+        {"member_id", "scores", "window_days", "primary_source",
+         "hypothesis_hit_rate", "resolved", "hit", "pending", "source_breakdown"}.
+        scores[*]에는 기존 키(clean_pass_rate 등) + outcome 키(hit/resolved/pending/hit_rate).
     """
     window_start = datetime.now(timezone.utc) - timedelta(days=window_days)
 
@@ -88,6 +107,12 @@ async def compute_member_trust_scores(
             "member_id": str(member_id),
             "scores": [],
             "window_days": window_days,
+            "primary_source": "hypothesis_outcome",
+            "hypothesis_hit_rate": None,
+            "resolved": 0,
+            "hit": 0,
+            "pending": 0,
+            "source_breakdown": {},
         }
 
     # participation_id → (story_points, role_key, role_label) 매핑
@@ -121,11 +146,22 @@ async def compute_member_trust_scores(
                 "total_verdicts": 0,
                 "clean_sp": 0,
                 "total_sp": 0,
+                # outcome 중심(가설 적중 이력): pass=hit·fail=miss·null=pending.
+                "hit": 0,
+                "resolved": 0,
+                "pending": 0,
             }
 
+    # source_breakdown은 윈도우 내 모든 verdict로 산출(제외된 source도 관측 가능·AC④ 진단).
+    source_breakdown: dict[str, int] = {}
     for v in verdicts:
+        source_breakdown[v.source] = source_breakdown.get(v.source, 0) + 1
         meta = p_map.get(v.participation_id)
         if meta is None:
+            continue
+        is_outcome = v.source in OUTCOME_SOURCES
+        # 기본: outcome source만 신뢰로 환산(AC①·②). legacy는 명시 opt-in일 때만 합산.
+        if not is_outcome and not include_legacy:
             continue
         rk = meta["role_key"]
         sp = meta["story_points"]
@@ -135,17 +171,34 @@ async def compute_member_trust_scores(
         if _is_clean_pass(v.result, v.rounds):
             bucket["clean_pass_verdicts"] += 1
             bucket["clean_sp"] += sp
+        if is_outcome:
+            if v.result in ("pass", "fail"):
+                bucket["resolved"] += 1
+                if v.result == "pass":
+                    bucket["hit"] += 1
+            else:
+                bucket["pending"] += 1
 
     # 4. 점수 계산
     scores: list[dict[str, Any]] = []
+    total_hit = 0
+    total_resolved = 0
+    total_pending = 0
     for rk, b in role_buckets.items():
         tv = b["total_verdicts"]
         tsp = b["total_sp"]
         cp = b["clean_pass_verdicts"]
         csp = b["clean_sp"]
+        hit = b["hit"]
+        resolved = b["resolved"]
+        pending = b["pending"]
+        total_hit += hit
+        total_resolved += resolved
+        total_pending += pending
 
         clean_pass_rate: float | None = (cp / tv) if tv > 0 else None
         weighted_score: float | None = (csp / tsp) if tsp > 0 else None
+        hit_rate: float | None = (hit / resolved) if resolved > 0 else None
 
         scores.append({
             "role_key": b["role_key"],
@@ -156,10 +209,24 @@ async def compute_member_trust_scores(
             "total_sp": tsp,
             "clean_sp": csp,
             "weighted_score": round(weighted_score, 4) if weighted_score is not None else None,
+            # HO-S5 outcome 중심(가설 적중 이력).
+            "hit": hit,
+            "resolved": resolved,
+            "pending": pending,
+            "hit_rate": round(hit_rate, 4) if hit_rate is not None else None,
         })
+
+    hypothesis_hit_rate: float | None = (total_hit / total_resolved) if total_resolved > 0 else None
 
     return {
         "member_id": str(member_id),
         "scores": scores,
         "window_days": window_days,
+        # primary 신뢰 신호는 가설 outcome(legacy 합산은 include_legacy 시에만).
+        "primary_source": "legacy_all" if include_legacy else "hypothesis_outcome",
+        "hypothesis_hit_rate": round(hypothesis_hit_rate, 4) if hypothesis_hit_rate is not None else None,
+        "resolved": total_resolved,
+        "hit": total_hit,
+        "pending": total_pending,
+        "source_breakdown": source_breakdown,
     }

--- a/backend/tests/test_e_cage_referee_p2_trust_score.py
+++ b/backend/tests/test_e_cage_referee_p2_trust_score.py
@@ -69,11 +69,14 @@ def _mock_role(key="implementation", label="구현"):
     return r
 
 
-def _mock_verdict(p_id, result="pass", rounds=0):
+def _mock_verdict(p_id, result="pass", rounds=0, source="hypothesis_outcome_execution"):
+    # HO-S5: 기본 신뢰 집계 source는 가설 outcome(hypothesis_outcome_*). clean_pass×SP 수학은
+    # source 무관이므로 기본을 outcome source로 둬 새 기본 경로에서 동일 검증.
     v = MagicMock()
     v.participation_id = p_id
     v.result = result
     v.rounds = rounds
+    v.source = source
     v.recorded_at = datetime.now(timezone.utc)
     return v
 
@@ -318,3 +321,94 @@ async def test_get_trust_scores_endpoint_200():
         assert "window_days" in body
     finally:
         app.dependency_overrides.clear()
+
+
+# ── HO-S5: trust source 전환(가설 outcome primary) ─────────────────────────────
+
+def _session_with(rows, verdicts):
+    """1차 호출=participation 조인 rows, 2차=verdict scalars."""
+    session = AsyncMock()
+    state = {"n": 0}
+
+    async def mock_execute(stmt, *args, **kwargs):
+        state["n"] += 1
+        result = MagicMock()
+        if state["n"] == 1:
+            result.all.return_value = rows
+        else:
+            result.scalars.return_value.all.return_value = verdicts
+        return result
+
+    session.execute = mock_execute
+    return session
+
+
+@pytest.mark.anyio
+async def test_ho_s5_ci_only_yields_no_trust():
+    """AC①④: source=ci만(outcome 0) → trust None=cold-start. breakdown엔 ci 관측."""
+    p, s, r = _mock_participation(), _mock_story(sp=5), _mock_role()
+    verdicts = [_mock_verdict(p.id, result="pass", rounds=0, source="ci") for _ in range(10)]
+    session = _session_with([(p, s, r)], verdicts)
+
+    res = await compute_member_trust_scores(session, ORG_ID, MEMBER_ID)
+
+    score = res["scores"][0]
+    assert score["total_verdicts"] == 0          # ci는 신뢰 미환산.
+    assert score["clean_pass_rate"] is None       # cold-start(표본부족).
+    assert score["hit_rate"] is None and score["resolved"] == 0
+    assert res["hypothesis_hit_rate"] is None and res["resolved"] == 0
+    assert res["primary_source"] == "hypothesis_outcome"
+    assert res["source_breakdown"] == {"ci": 10}   # 제외돼도 관측(AC④ 진단).
+
+
+@pytest.mark.anyio
+async def test_ho_s5_outcome_pass_fail_hit_rate():
+    """AC②: outcome pass/fail만 hit_rate(2 hit / 3 resolved)."""
+    p, s, r = _mock_participation(), _mock_story(sp=4), _mock_role(key="hypothesis_owner", label="가설책임")
+    r.key = "hypothesis_owner"
+    verdicts = [
+        _mock_verdict(p.id, result="pass", source="hypothesis_outcome_bet"),
+        _mock_verdict(p.id, result="pass", source="hypothesis_outcome_bet"),
+        _mock_verdict(p.id, result="fail", source="hypothesis_outcome_bet"),
+        _mock_verdict(p.id, result=None, source="hypothesis_outcome_bet"),  # pending(보류).
+    ]
+    session = _session_with([(p, s, r)], verdicts)
+
+    res = await compute_member_trust_scores(session, ORG_ID, MEMBER_ID)
+
+    assert res["hit"] == 2 and res["resolved"] == 3 and res["pending"] == 1
+    assert res["hypothesis_hit_rate"] == round(2 / 3, 4)
+    score = res["scores"][0]
+    assert score["hit_rate"] == round(2 / 3, 4) and score["pending"] == 1
+
+
+@pytest.mark.anyio
+async def test_ho_s5_include_legacy_restores_ci():
+    """legacy opt-in: include_legacy=True면 ci도 신뢰 합산(구 동작 보존)."""
+    p, s, r = _mock_participation(), _mock_story(sp=5), _mock_role()
+    verdicts = [_mock_verdict(p.id, result="pass", rounds=0, source="ci") for _ in range(4)]
+    session = _session_with([(p, s, r)], verdicts)
+
+    res = await compute_member_trust_scores(session, ORG_ID, MEMBER_ID, include_legacy=True)
+
+    score = res["scores"][0]
+    assert score["total_verdicts"] == 4 and score["clean_pass_rate"] == 1.0
+    assert res["primary_source"] == "legacy_all"
+
+
+@pytest.mark.anyio
+async def test_ho_s5_mixed_only_outcome_counts():
+    """혼합(ci+outcome): 신뢰는 outcome만·breakdown은 둘 다."""
+    p, s, r = _mock_participation(), _mock_story(sp=3), _mock_role()
+    verdicts = [
+        _mock_verdict(p.id, result="pass", source="hypothesis_outcome_execution"),
+        _mock_verdict(p.id, result="fail", source="ci"),
+        _mock_verdict(p.id, result="pass", source="qa"),
+    ]
+    session = _session_with([(p, s, r)], verdicts)
+
+    res = await compute_member_trust_scores(session, ORG_ID, MEMBER_ID)
+
+    assert res["scores"][0]["total_verdicts"] == 1   # outcome 1건만.
+    assert res["hit"] == 1 and res["resolved"] == 1
+    assert res["source_breakdown"] == {"hypothesis_outcome_execution": 1, "ci": 1, "qa": 1}


### PR DESCRIPTION
## HO-S5 — trust score outcome source 전환 (실제 substance 전환)

E-HO-TRUST HO-S5(블루프린트 §3.4). **`compute_member_trust_scores` 기본 집계 source를 가설 outcome(`hypothesis_outcome_bet`/`execution`)로 제한** — 신뢰의 substance를 **'가설 적중 이력'**으로 전환. CI/pr/qa/design verdict는 기본 trust 미환산(효과≠실행품질). legacy 전 source 합산은 `include_legacy=True` 명시 opt-in.

### Changes (`services/trust_score.py`)
- `OUTCOME_SOURCES = {hypothesis_outcome_bet, hypothesis_outcome_execution}` + `include_legacy: bool = False` keyword-only 파라미터.
- 집계 루프: outcome source만 role 버킷에 환산(default). outcome verdict result로 **hit_rate = pass/(pass+fail)** (pass=hit·fail=miss·null=pending).

### AC
- **①④**: outcome 표본 없으면(예: CI pass 10건만) `clean_pass_rate`/`hit_rate`=**None=cold-start**. 소비처(`_impl_trust`·`disposition_advisor`)가 None을 보수적으로 처리(ask_human) → **코드 변경 없이 outcome trust로 전환되는 substance 효과**.
- **②**: `hit_rate`=pass/(pass+fail). top-level `hypothesis_hit_rate`/`resolved`/`hit`/`pending`.
- **③**: `/trust-scores` 응답은 **기존 키 전부 보존**(clean_pass_rate 등) + outcome 키 additive 추가. 빈응답 shape도 동일 키. **소비처(merge_gate·disposition·라우터) 회귀 48 무파손**.
- **⑤**: 마이그 0·**DB 변경 0**(온더플라이 쿼리에 source 필터만). `source_breakdown`은 윈도우 내 전 verdict로 산출 → 제외된 source도 관측(진단).

### Validation
- trust 테스트 **17 PASS**(신규 4: ci-only→cold-start·outcome hit_rate·legacy opt-in 복원·혼합 시 outcome만 환산+breakdown 관측).
- merge_gate/disposition/h1 소비처 **48 PASS**·`app.main` import OK.

> forward-verify: `compute_member_trust_scores` 4 소비처(`trust_scores`·`disposition_advisor`·`merge_verdict_gate`·self) develop 실재 확인. 둘 다 role별 `clean_pass_rate` 읽음 → 버킷 outcome-only화로 substance 전환이 자동 전파. 다음 HO-S6(H1 게이트가 outcome trust 명시 연결). 까심 QA(codex 5.5)→PO 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)