### PR TITLE
feat(ho): cold-start human seed 기록 + calibration (HO-S7)

### DIFF
--- a/backend/app/services/cold_start_seed.py
+++ b/backend/app/services/cold_start_seed.py
@@ -1,0 +1,133 @@
+"""HO-S7: cold-start human seed 기록 + calibration (블루프린트 E-HO-TRUST §3.5/Story7).
+
+outcome trust 표본이 부족한 cold-start에서 머지 게이트는 ask_human이 된다([[merge_verdict_gate]]
+AC④). 이때 사람이 내리는 keep(approve)/kill(reject) 결정을 **seed**로 기록한다 — 가설 적중 이력이
+없는 동안의 임시 예측. seed는:
+
+- **verdict source 재사용**(source="human_seed") — 신규 테이블/마이그 0(AC⑤). Verdict.source는
+  free-form String(50)이라 enum 변경도 없다.
+- **outcome trust 본점수 미포함**(AC②): trust_score.OUTCOME_SOURCES={bet,execution}만 집계하므로
+  human_seed는 자동 제외된다(코드 변경 0). seed는 신뢰 환산이 아니라 calibration 관측용.
+- outcome 해소 후 **seed_calibration**(AC③): 사람의 keep/kill 예측이 실제 verified/falsified와
+  맞았는지 대조. cold-start 판단 품질을 사후 계측.
+
+FE는 cold-start seed로 머지된 건을 "임시 예측"으로 표시한다(AC④) — gate.neutral_facts의
+cold_start_seed/seed_prediction 플래그를 데이터 계약으로 제공한다.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.gate import Gate
+
+# human keep/kill 예측 seed의 verdict source. OUTCOME_SOURCES에 없으므로 trust 본점수에서 제외된다.
+SEED_SOURCE = "human_seed"
+
+
+def _is_cold_start(gate: Gate) -> bool:
+    """게이트가 cold-start(outcome 표본 부족으로 ask_human이 된 상태)였는지.
+
+    evaluate_merge_gate(HO-S6)가 neutral_facts에 남긴 outcome_resolved/min_outcome_sample로 판단.
+    표본이 충분했다면(>=min) 사람 결정은 seed가 아니라 일반 review verdict로만 남는다.
+    """
+    facts = gate.neutral_facts or {}
+    resolved = facts.get("outcome_resolved")
+    min_sample = facts.get("min_outcome_sample")
+    if resolved is None or min_sample is None:
+        return False
+    try:
+        return int(resolved) < int(min_sample)
+    except (TypeError, ValueError):
+        return False
+
+
+async def record_cold_start_seed(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    gate: Gate,
+    new_status: str,
+    resolver_id: uuid.UUID | None,
+) -> bool:
+    """merge 게이트가 cold-start에서 사람에 의해 해소되면 keep/kill 예측을 seed로 기록.
+
+    approve→keep(result=pass) / reject→kill(result=fail). source=human_seed라 trust 본점수
+    미포함(AC②). uq(participation, source)로 멱등. FE 표시용 플래그를 neutral_facts에 남긴다(AC④).
+    기록했으면 True.
+    """
+    if gate.gate_type != "merge" or gate.work_item_type != "story":
+        return False
+    if new_status not in ("approved", "rejected") or resolver_id is None:
+        return False
+    if not _is_cold_start(gate):
+        return False
+
+    # lazy import — verdict_capture/recorder가 gate_service를 import하므로 순환 회피(gate_service 경유).
+    from app.services.verdict_capture import resolve_implementation_participation
+    from app.services.verdict_recorder import record_verdict
+
+    participation = await resolve_implementation_participation(session, org_id, gate.work_item_id)
+    if participation is None:
+        return False  # participation 없으면 거짓기록 금지.
+
+    result = "pass" if new_status == "approved" else "fail"  # keep / kill
+    await record_verdict(session, org_id, participation.id, SEED_SOURCE, result)
+
+    # AC④: FE "임시 예측" 표시용 데이터 계약. neutral_facts에 플래그(판정 아님·관측).
+    facts = dict(gate.neutral_facts or {})
+    facts["cold_start_seed"] = True
+    facts["seed_prediction"] = "keep" if new_status == "approved" else "kill"
+    gate.neutral_facts = facts
+    return True
+
+
+async def compute_seed_calibration(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    member_id: uuid.UUID | None = None,
+) -> dict[str, Any]:
+    """outcome 해소 후 seed 예측의 정확도(seed_calibration)를 계산(AC③).
+
+    seed(human_seed verdict) → participation → story → 가설을 거쳐, keep/kill 예측이 실제
+    verified/falsified와 일치했는지 대조한다. 가설이 아직 미해소면 calibration 보류(resolved 제외).
+
+    keep(result=pass) 예측 ↔ verified 일치 / kill(result=fail) 예측 ↔ falsified 일치.
+    반환: {total_seeds, resolved, calibrated, calibration_rate}.
+    """
+    from app.models.hypothesis import Hypothesis, HypothesisStoryLink
+    from app.models.participation import Participation
+    from app.models.verdict import Verdict
+
+    # member 범위의 seed verdict + 그 participation의 story + story가 연결된 가설 status.
+    q = (
+        select(Verdict.result, Hypothesis.status)
+        .join(Participation, Participation.id == Verdict.participation_id)
+        .join(HypothesisStoryLink, HypothesisStoryLink.story_id == Participation.story_id)
+        .join(Hypothesis, Hypothesis.id == HypothesisStoryLink.hypothesis_id)
+        .where(Verdict.org_id == org_id, Verdict.source == SEED_SOURCE)
+    )
+    if member_id is not None:
+        q = q.where(Participation.member_id == member_id)
+
+    rows = (await session.execute(q)).all()
+    total_seeds = len(rows)
+    resolved = 0
+    calibrated = 0
+    for seed_result, hyp_status in rows:
+        if hyp_status not in ("verified", "falsified"):
+            continue  # 미해소 → calibration 보류.
+        resolved += 1
+        predicted_verified = seed_result == "pass"  # keep
+        actual_verified = hyp_status == "verified"
+        if predicted_verified == actual_verified:
+            calibrated += 1
+
+    return {
+        "total_seeds": total_seeds,
+        "resolved": resolved,
+        "calibrated": calibrated,
+        "calibration_rate": round(calibrated / resolved, 4) if resolved > 0 else None,
+    }

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -114,6 +114,12 @@ async def transition_gate(
     # H1-S7: 사람 게이트 해소(approve/reject)를 verdict로 기록 — trust로 환류.
     await _record_gate_review_verdict(session, org_id, gate, new_status, resolver_id)
 
+    # HO-S7: cold-start(outcome 표본 부족)에서 사람의 keep/kill 결정을 seed로 기록(trust 본점수
+    # 미포함·outcome 해소 후 calibration). merge·cold-start가 아니면 no-op.
+    from app.services.cold_start_seed import record_cold_start_seed  # 순환 회피 lazy import.
+
+    await record_cold_start_seed(session, org_id, gate, new_status, resolver_id)
+
     # H1-FIX-2: merge 게이트 approve → work item 스토리를 done으로 진행(_preflight 재평가 우회).
     # S7은 verdict만 기록하고 →done 진행을 안 박아, 사람이 approve해도 일이 done에 도달 못 하고
     # done 재시도 시 재평가→ask_human 재발로 막히던 dogfood 갭을 닫는다.

--- a/backend/tests/test_ho_s7_cold_start_seed.py
+++ b/backend/tests/test_ho_s7_cold_start_seed.py
@@ -1,0 +1,170 @@
+"""HO-S7: cold-start human seed 기록 + calibration.
+
+cold-start(outcome 표본 부족)에서 사람의 keep/kill 결정을 seed로 기록(trust 본점수 미포함·AC②),
+outcome 해소 후 calibration 계산(AC③). verdict source 재사용·마이그 0(AC⑤).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.cold_start_seed import SEED_SOURCE, _is_cold_start, record_cold_start_seed
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _gate(*, gate_type="merge", work_item_type="story", facts=None):
+    return SimpleNamespace(
+        gate_type=gate_type, work_item_type=work_item_type,
+        work_item_id=uuid.uuid4(), neutral_facts=facts,
+    )
+
+
+# ── _is_cold_start 판정 ─────────────────────────────────────────────────────────
+
+def test_is_cold_start_true_when_sample_below_min():
+    assert _is_cold_start(_gate(facts={"outcome_resolved": 1, "min_outcome_sample": 3})) is True
+
+
+def test_is_cold_start_false_when_sufficient():
+    assert _is_cold_start(_gate(facts={"outcome_resolved": 5, "min_outcome_sample": 3})) is False
+
+
+def test_is_cold_start_false_when_facts_missing():
+    assert _is_cold_start(_gate(facts=None)) is False
+    assert _is_cold_start(_gate(facts={"outcome_resolved": 0})) is False  # min 없음 → 판단 불가.
+
+
+# ── record_cold_start_seed 게이팅 ────────────────────────────────────────────────
+
+async def _record(gate, new_status, resolver_id):
+    part = SimpleNamespace(id=uuid.uuid4(), member_id=uuid.uuid4())
+    rec = AsyncMock()
+    with patch("app.services.verdict_capture.resolve_implementation_participation",
+               AsyncMock(return_value=part)), \
+         patch("app.services.verdict_recorder.record_verdict", rec):
+        out = await record_cold_start_seed(AsyncMock(), uuid.uuid4(), gate, new_status, resolver_id)
+    return out, rec, gate
+
+
+@pytest.mark.anyio
+async def test_seed_recorded_on_cold_start_approve():
+    gate = _gate(facts={"outcome_resolved": 0, "min_outcome_sample": 3})
+    out, rec, gate = await _record(gate, "approved", uuid.uuid4())
+    assert out is True
+    # keep 예측 → result=pass·source=human_seed(AC①·⑤).
+    assert rec.await_args.args[3] == SEED_SOURCE and rec.await_args.args[4] == "pass"
+    # AC④: FE "임시 예측" 데이터 계약.
+    assert gate.neutral_facts["cold_start_seed"] is True
+    assert gate.neutral_facts["seed_prediction"] == "keep"
+
+
+@pytest.mark.anyio
+async def test_seed_recorded_on_cold_start_reject_is_kill():
+    gate = _gate(facts={"outcome_resolved": 2, "min_outcome_sample": 3})
+    out, rec, gate = await _record(gate, "rejected", uuid.uuid4())
+    assert out is True and rec.await_args.args[4] == "fail"
+    assert gate.neutral_facts["seed_prediction"] == "kill"
+
+
+@pytest.mark.anyio
+async def test_no_seed_when_sufficient_sample():
+    gate = _gate(facts={"outcome_resolved": 9, "min_outcome_sample": 3})
+    out, rec, _ = await _record(gate, "approved", uuid.uuid4())
+    assert out is False and rec.await_count == 0  # 표본 충분 → seed 아님.
+
+
+@pytest.mark.anyio
+async def test_no_seed_for_non_merge_or_no_resolver():
+    out, rec, _ = await _record(_gate(gate_type="qa", facts={"outcome_resolved": 0, "min_outcome_sample": 3}),
+                                "approved", uuid.uuid4())
+    assert out is False and rec.await_count == 0
+    out2, rec2, _ = await _record(_gate(facts={"outcome_resolved": 0, "min_outcome_sample": 3}),
+                                  "approved", None)  # resolver 없음(시스템).
+    assert out2 is False and rec2.await_count == 0
+
+
+# ── 끝단 실DB: seed 기록 → trust 제외(AC②) → calibration(AC③) ──────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_seed_excluded_from_trust_and_calibrated_real_db():
+    from datetime import datetime, timezone
+
+    from sqlalchemy import text as _text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    from app.models.gate import Gate
+    from app.models.hypothesis import Hypothesis, HypothesisStoryLink
+    from app.models.participation import Participation, ParticipationRole
+    from app.models.pm import Story
+    from app.models.verdict import Verdict  # noqa: F401
+    from app.services.cold_start_seed import compute_seed_calibration, record_cold_start_seed
+    from app.services.trust_score import compute_member_trust_scores
+
+    url = _REAL_DB_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+        "postgresql://", "postgresql+asyncpg://"
+    )
+    engine = create_async_engine(url)
+    org, project, role_id, member = (uuid.uuid4() for _ in range(4))
+    story_id, hyp_id, gate_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add_all([
+                ParticipationRole(id=role_id, org_id=org, key="implementation", label="구현", is_default=True),
+                Story(id=story_id, org_id=org, project_id=project, title="S", status="in_review", story_points=3),
+                Participation(id=uuid.uuid4(), org_id=org, story_id=story_id, member_id=member, role_id=role_id),
+                # active 가설(미해소) — 링크로 seed↔outcome 연결.
+                Hypothesis(id=hyp_id, org_id=org, project_id=project, owner_member_id=member,
+                           statement="H", measure_after=datetime(2026, 6, 1, tzinfo=timezone.utc),
+                           status="active",
+                           metric_definition={"metric": "completion_pct", "source": "internal_ops",
+                                              "target": 50, "direction": "up"}),
+                HypothesisStoryLink(id=uuid.uuid4(), hypothesis_id=hyp_id, story_id=story_id, link_type="supports"),
+                Gate(id=gate_id, org_id=org, work_item_id=story_id, work_item_type="story",
+                     gate_type="merge", status="pending",
+                     neutral_facts={"outcome_resolved": 0, "min_outcome_sample": 3}),
+            ])
+            await s.commit()
+
+        # 1) cold-start approve → seed 기록(keep).
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            gate = await s.get(Gate, gate_id)
+            ok = await record_cold_start_seed(s, org, gate, "approved", member)
+            await s.commit()
+            assert ok is True
+
+        # 2) AC②: seed는 outcome trust 본점수에 미포함(human_seed source 제외).
+        async with Session() as s:
+            trust = await compute_member_trust_scores(s, org, member, role_key="implementation")
+            assert trust["resolved"] == 0, "seed가 trust outcome 표본에 새면 안 됨"
+            assert trust["source_breakdown"].get(SEED_SOURCE) == 1  # 관측은 됨.
+
+        # 3) AC③: 가설 해소(verified) 후 calibration — keep 예측 ↔ verified 일치 → calibrated 1/1.
+        async with Session() as s:
+            await s.execute(_text("UPDATE hypotheses SET status='verified' WHERE id=:id"), {"id": hyp_id})
+            await s.commit()
+        async with Session() as s:
+            cal = await compute_seed_calibration(s, org, member)
+            assert cal == {"total_seeds": 1, "resolved": 1, "calibrated": 1, "calibration_rate": 1.0}
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()


### PR DESCRIPTION
## HO-S7 — cold-start human seed 기록 + calibration

E-HO-TRUST HO-S7(블루프린트 §3.5/Story7). outcome trust 표본이 부족한 **cold-start**에서 머지 게이트는 ask_human(HO-S6). 이때 사람의 **keep(approve)/kill(reject)** 결정을 **seed**로 기록 — 가설 적중 이력이 없는 동안의 임시 예측.

### Changes
- **`services/cold_start_seed.py`** (신규)
  - `record_cold_start_seed` — merge 게이트가 cold-start(`outcome_resolved < min_outcome_sample`)에서 사람에 의해 해소되면 keep→`pass`/kill→`fail` seed 기록. **`transition_gate`에 배선**(lazy import 순환 회피).
  - `compute_seed_calibration` — seed→participation→story→가설 status로 keep/kill 예측 vs verified/falsified 대조.
- **`services/gate_service.py`** — `transition_gate`에서 `_record_gate_review_verdict` 직후 `record_cold_start_seed` 호출(merge·cold-start 아니면 no-op).

### AC
- **①⑤**: keep→pass·kill→fail seed 기록. **verdict source 재사용**(`source="human_seed"`) — `Verdict.source`는 free-form `String(50)`이라 **신규 테이블/마이그/enum 변경 0**(AC⑤).
- **②**: `human_seed`는 `trust_score.OUTCOME_SOURCES`(bet/execution)에 없어 **outcome trust 본점수에서 자동 제외**(코드 변경 0). seed는 calibration 관측용.
- **③**: `compute_seed_calibration` — outcome 해소 후 예측 정확도(미해소는 보류). `calibration_rate` 반환.
- **④**: FE "임시 예측" 표시용 **데이터 계약** — `gate.neutral_facts.cold_start_seed`/`seed_prediction` 플래그 노출. (배지 렌더는 FE 영역.)

### Validation
- 단위 7(`_is_cold_start` 3분기·approve→keep/reject→kill·표본충분 no-op·비-merge/no-resolver no-op).
- ⭐**끝단 실DB**: cold-start approve → seed 기록 → trust outcome 표본 0 유지(`source_breakdown`엔 관측) → 가설 verified 후 **calibration 1/1**.
- gate_service/transition·H1 소비처 **189 PASS**·`app.main` import OK·no cycle.

> ⚠️ **AC④ FE "임시 예측" 배지 렌더는 FE 영역**(유나/미르코) — BE는 `cold_start_seed`/`seed_prediction` 데이터 계약 제공. forward-verify: `transition_gate` 해소 경로·`Verdict.source` free-form·`OUTCOME_SOURCES` 제외·`HypothesisStoryLink` 조인 develop 실재 확인. 다음 S8(UI 유나)·S9(E2E). 까심 QA(codex 5.5)→PO 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)