### PR TITLE
[HO-S8] feat(cage): outcome trust UI — "통과했다 ≠ 옳았다" 신뢰 재정의

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2601,6 +2601,16 @@
     "reasonLabel": "Reason",
     "gateReadonlyBlock": "Auto-blocked · read-only",
     "gateReadonlyAuto": "Auto-passed · no action needed",
-    "mergeGateTitle": "Merge gate"
+    "mergeGateTitle": "Merge gate",
+    "outcomeTrustLabel": "Outcome trust",
+    "outcomeSummary": "{hit} hit · {resolved} resolved · last {days}d",
+    "pendingSummary": "{pending} pending · {resolved} resolved",
+    "deliverySignalLabel": "Delivery signal",
+    "deliveryColLabel": "CI · delivery",
+    "outcomeColLabel": "Outcome · verdict",
+    "coldStartProvisional": "Provisional",
+    "seedKeep": "Keep",
+    "seedKill": "Kill",
+    "outcomeAccumulating": "Awaiting verdict data"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2601,6 +2601,16 @@
     "reasonLabel": "사유",
     "gateReadonlyBlock": "자동 차단 · 읽기 전용",
     "gateReadonlyAuto": "자동 통과 · 액션 불필요",
-    "mergeGateTitle": "머지 게이트"
+    "mergeGateTitle": "머지 게이트",
+    "outcomeTrustLabel": "가설 적중",
+    "outcomeSummary": "적중 {hit} · 판정 {resolved} · 최근 {days}일",
+    "pendingSummary": "측정 대기 {pending}건 · 판정 완료 {resolved}건",
+    "deliverySignalLabel": "납품 신호",
+    "deliveryColLabel": "CI · 납품",
+    "outcomeColLabel": "Outcome · 판단",
+    "coldStartProvisional": "임시 예측",
+    "seedKeep": "유지 예측",
+    "seedKill": "중단 예측",
+    "outcomeAccumulating": "판정 데이터 누적 중"
   }
 }

--- a/apps/web/src/components/cage/gate-evidence.tsx
+++ b/apps/web/src/components/cage/gate-evidence.tsx
@@ -57,6 +57,10 @@ export function GateEvidence({ gate, className }: { gate: GateItem; className?: 
   const trust = trustScore(gate);
   const selfReportOnly = gate.neutral_facts?.['self_report_only'] === true;
   const reason = gate.decision_basis ?? gate.auto_decision_reason ?? null;
+  // HO-S8 cold-start: 미확정 outcome은 "임시 예측"(keep/kill)으로만 — 판정/% 환원 절대 X.
+  const coldStartSeed = gate.neutral_facts?.['cold_start_seed'] === true;
+  const seedPrediction = gate.neutral_facts?.['seed_prediction'];
+  const seedKey = seedPrediction === 'keep' ? 'seedKeep' : seedPrediction === 'kill' ? 'seedKill' : null;
 
   return (
     <div className={className}>
@@ -67,36 +71,57 @@ export function GateEvidence({ gate, className }: { gate: GateItem; className?: 
         </Badge>
       ) : null}
 
-      {/* facts: CI · 신뢰도 (배지 아래·muted·· 구분). 리뷰는 gate 미노출이라 v1 제외. */}
-      <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11.5px] text-muted-foreground">
-        <span>
-          {t('ciLabel')}:{' '}
-          {ci === 'pass' ? (
-            <span className="text-success">✓ {t('ciPass')}</span>
-          ) : ci === 'fail' ? (
-            <span className="text-destructive">✗ {t('ciFail')}</span>
-          ) : (
-            <span>? {t('ciUnknown')}</span>
-          )}
-        </span>
-        <span aria-hidden>·</span>
-        <span className="inline-flex items-center gap-1">
-          {t('trustLabel')}:{' '}
-          {trust === null ? (
-            <span className="italic text-muted-foreground">{t('trustScoreNoData')}</span>
-          ) : (
-            <span className="text-foreground">{t('trustScorePercent', { score: Math.round(trust * 100) })}</span>
-          )}
-          {/* 증거가 자기보고뿐(독립 CI verdict 부재) — 신뢰 맥락 보조 신호(보너스). */}
-          {selfReportOnly ? (
-            <span className="rounded bg-muted px-1 py-px text-[10px] text-muted-foreground">{t('selfReportTag')}</span>
-          ) : null}
-        </span>
+      {/* HO-S8 AC①: CI(납품·"통과했다") ↔ Outcome(판단·"옳았다") 2열 분리 — "통과≠옳음" 명시. */}
+      <div className="mt-1.5 grid grid-cols-1 gap-2 text-[11.5px] sm:grid-cols-2 sm:gap-3">
+        {/* 좌: CI · 납품(delivery 신호 — 기계 검증). 신뢰도=clean_pass(delivery)·리뷰는 gate 미노출이라 제외. */}
+        <div className="space-y-0.5">
+          <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">{t('deliveryColLabel')}</p>
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-muted-foreground">
+            <span>
+              {t('ciLabel')}:{' '}
+              {ci === 'pass' ? (
+                <span className="text-success">✓ {t('ciPass')}</span>
+              ) : ci === 'fail' ? (
+                <span className="text-destructive">✗ {t('ciFail')}</span>
+              ) : (
+                <span>? {t('ciUnknown')}</span>
+              )}
+            </span>
+            <span aria-hidden>·</span>
+            <span className="inline-flex items-center gap-1">
+              {t('trustLabel')}:{' '}
+              {trust === null ? (
+                <span className="italic text-muted-foreground">{t('trustScoreNoData')}</span>
+              ) : (
+                <span className="text-foreground">{t('trustScorePercent', { score: Math.round(trust * 100) })}</span>
+              )}
+              {selfReportOnly ? (
+                <span className="rounded bg-muted px-1 py-px text-[10px] text-muted-foreground">{t('selfReportTag')}</span>
+              ) : null}
+            </span>
+          </div>
+        </div>
+        {/* 우: Outcome · 판단("옳았다 판정"). gate엔 정밀 hit_rate 없음 → 임시 예측 / 누적 중만(억지 % X·hit_rate %는 TrustScoreCard). */}
+        <div className="space-y-0.5">
+          <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">{t('outcomeColLabel')}</p>
+          <div className="text-muted-foreground">
+            {coldStartSeed ? (
+              <span className="inline-flex items-center gap-1.5">
+                <span className="italic">{t('coldStartProvisional')}</span>
+                {seedKey ? (
+                  <Badge variant="chip" className="shrink-0">{t(seedKey)}</Badge>
+                ) : null}
+              </span>
+            ) : (
+              <span className="italic text-muted-foreground/80">{t('outcomeAccumulating')}</span>
+            )}
+          </div>
+        </div>
       </div>
 
       {/* 사유 1줄(decision_basis·AC①②) */}
       {reason ? (
-        <p className="mt-1 text-[11.5px] text-muted-foreground">
+        <p className="mt-1.5 text-[11.5px] text-muted-foreground">
           {t('reasonLabel')} · {reason}
         </p>
       ) : null}

--- a/apps/web/src/components/cage/trust-score-card.tsx
+++ b/apps/web/src/components/cage/trust-score-card.tsx
@@ -12,6 +12,11 @@ interface RoleScore {
   total_sp: number;
   clean_sp: number;
   weighted_score: number | null;
+  // HO-S5/S8 outcome(가설 적중 이력) — 1급 신뢰 신호.
+  hit?: number;
+  resolved?: number;
+  pending?: number;
+  hit_rate?: number | null;
 }
 
 interface TrustScoreData {
@@ -19,6 +24,13 @@ interface TrustScoreData {
   scores: RoleScore[];
   window_days: number;
   computed_at: string;
+  // HO-S8: outcome trust(가설 적중) 집계 — 1급. clean_pass는 delivery signal로 격하(2급).
+  primary_source?: string;
+  hypothesis_hit_rate?: number | null; // 표본0=null=cold-start (0 아님·환원 X)
+  resolved?: number;
+  hit?: number;
+  pending?: number;
+  source_breakdown?: Record<string, number>;
 }
 
 interface TrustScoreCardProps {
@@ -65,83 +77,82 @@ export function TrustScoreCard({ memberId, compact = false }: TrustScoreCardProp
     return compact ? null : <div className="h-20 animate-pulse rounded-xl bg-muted/30" />;
   }
 
-  const hasData = (data?.scores ?? []).some((s) => s.total_verdicts > 0);
+  const scores = data?.scores ?? [];
+  const totalVerdicts = scores.reduce((s, r) => s + r.total_verdicts, 0);
+  const cleanPasses = scores.reduce((s, r) => s + r.clean_pass_verdicts, 0);
+  const deliveryRate = totalVerdicts > 0 ? cleanPasses / totalVerdicts : null; // 납품 신호(2급·delivery)
 
+  // 1급: outcome trust(가설 적중). null(표본0)=cold-start → "데이터 없음"(0/낮음/빨강 환원 X·AC③).
+  const hitRate = data?.hypothesis_hit_rate ?? null;
+  const resolved = data?.resolved ?? 0;
+  const hit = data?.hit ?? 0;
+  const pending = data?.pending ?? 0;
+
+  const hasData = resolved > 0 || pending > 0 || totalVerdicts > 0;
   if (!hasData) {
     return <TrustScoreEmpty compact={compact} />;
   }
 
-  const scores = data!.scores;
-  const totalVerdicts = scores.reduce((s, r) => s + r.total_verdicts, 0);
-  const cleanPasses = scores.reduce((s, r) => s + r.clean_pass_verdicts, 0);
-  const corrections = totalVerdicts - cleanPasses;
-  const overallRate = totalVerdicts > 0 ? cleanPasses / totalVerdicts : null;
-
   if (compact) {
-    const hasCorrections = corrections > 0;
+    // 1급=outcome 적중률. 미측정(null)이면 pending 톤(0%/빨강 환원 X).
     return (
       <span
         className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium tabular-nums ${
-          hasCorrections
-            ? 'border-warning-border bg-warning-tint text-warning'
+          hitRate === null
+            ? 'border-dashed border-border text-muted-foreground'
             : 'border-border bg-muted/40 text-foreground'
         }`}
       >
-        {pct(overallRate)}
+        {hitRate === null ? t('trustScorePending') : pct(hitRate)}
       </span>
     );
   }
 
+  const roleScores = scores.filter((s) => s.total_verdicts > 0);
+
   return (
     <div className="space-y-4 rounded-xl border border-border bg-card p-4">
-      {/* 주지표 */}
-      <div className="flex items-end justify-between">
-        <div>
-          <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">{t('trustScoreLabel')}</p>
-          <p className="mt-1 text-3xl font-bold tabular-nums text-foreground">{pct(overallRate)}</p>
-          <p className="text-xs text-muted-foreground">{t('trustScoreWindowHint', { days: data!.window_days })}</p>
-        </div>
-        {corrections > 0 && (
-          <span className="rounded-md border border-warning-border bg-warning-tint px-2 py-1 text-xs font-medium text-warning">
-            {t('correctionRounds', { count: corrections })}
-          </span>
+      {/* 1급 주지표 — outcome trust(가설 적중). "통과했다 ≠ 옳았다" */}
+      <div>
+        <p className="text-[10px] font-mono uppercase tracking-wider text-info">{t('outcomeTrustLabel')}</p>
+        {hitRate === null ? (
+          <p className="mt-1 text-2xl font-bold italic text-muted-foreground">{t('trustScoreNoData')}</p>
+        ) : (
+          <p className="mt-1 text-3xl font-bold tabular-nums text-foreground">{pct(hitRate)}</p>
         )}
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          {t('outcomeSummary', { hit, resolved, days: data!.window_days })}
+        </p>
+        <p className="text-xs text-muted-foreground">{t('pendingSummary', { pending, resolved })}</p>
       </div>
 
-      {/* 전적 trio */}
-      <div className="grid grid-cols-3 gap-2">
-        {([
-          { label: t('totalReviews'), value: totalVerdicts },
-          { label: t('cleanPasses'), value: cleanPasses },
-          { label: t('corrections'), value: corrections },
-        ] as { label: string; value: number }[]).map(({ label, value }) => (
-          <div key={label} className="rounded-lg border border-border bg-muted/30 p-2 text-center">
-            <p className="text-lg font-bold tabular-nums text-foreground">{value}</p>
-            <p className="text-[10px] text-muted-foreground">{label}</p>
-          </div>
-        ))}
-      </div>
-
-      {/* 역할별 bar */}
-      {scores.filter((s) => s.total_verdicts > 0).length > 0 && (
-        <div className="space-y-2">
-          <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">{t('byRole')}</p>
-          {scores.filter((s) => s.total_verdicts > 0).map((role) => (
-            <div key={role.role_key} className="space-y-1">
-              <div className="flex items-center justify-between text-xs">
-                <span className="text-muted-foreground">{role.role_label}</span>
-                <span className="tabular-nums text-foreground">{pct(role.clean_pass_rate)}</span>
-              </div>
-              <div className="h-1.5 w-full overflow-hidden rounded-full bg-border">
-                <div
-                  className="h-full rounded-full bg-foreground/40 transition-all"
-                  style={{ width: role.clean_pass_rate !== null ? `${Math.round(role.clean_pass_rate * 100)}%` : '0%' }}
-                />
-              </div>
-            </div>
-          ))}
+      {/* 2급 delivery signal — clean_pass 격하(납품 신호). 큰 위계 X·muted. */}
+      <div className="rounded-lg border border-border bg-muted/30 p-2.5">
+        <div className="flex items-center justify-between">
+          <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            {t('deliverySignalLabel')}
+          </span>
+          <span className="text-sm font-semibold tabular-nums text-muted-foreground">{pct(deliveryRate)}</span>
         </div>
-      )}
+        {roleScores.length > 0 ? (
+          <div className="mt-2 space-y-1.5">
+            {roleScores.map((role) => (
+              <div key={role.role_key} className="space-y-0.5">
+                <div className="flex items-center justify-between text-[11px]">
+                  <span className="text-muted-foreground">{role.role_label}</span>
+                  <span className="tabular-nums text-muted-foreground">{pct(role.clean_pass_rate)}</span>
+                </div>
+                <div className="h-1 w-full overflow-hidden rounded-full bg-border">
+                  <div
+                    className="h-full rounded-full bg-muted-foreground/40 transition-all"
+                    style={{ width: role.clean_pass_rate !== null ? `${Math.round(role.clean_pass_rate * 100)}%` : '0%' }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 무엇을 (유나양 핸드오프 `ho-s8-outcome-trust-handoff` · E-HO-TRUST 마지막 FE)

**신뢰 재정의 — "통과했다 ≠ 옳았다"**. `clean_pass`(납품 통과)를 **delivery signal로 격하**하고 **outcome trust(가설 적중률)를 1급 신뢰 신호로 승격**. 신규 화면 0 — 기존 `TrustScoreCard`·`gate-evidence.tsx`(H1-S8)·E1 `HypothesisStatusBadge` 확장.

## BE 계약 (코드 실측 · develop)

trust-scores top-level: `hypothesis_hit_rate`(float|null·**표본0=null=cold-start**)·`resolved`·`hit`·`pending`·`source_breakdown`(dict[source,count]). scores[*]: `clean_pass_rate`(delivery)·`hit_rate`·... cold-start: gate `neutral_facts.cold_start_seed`(bool)·`seed_prediction`(keep|kill).

## 구현 (3 surface)

- **Surface 1 — TrustScoreCard 위계 재편**: **outcome trust 1급**(text-3xl·`text-info` "가설 적중"·`적중 N · 판정 N · 최근 90일`) / **clean_pass 2급 delivery signal**(muted box·역할별 bar 격하) / pending = `측정 대기 N건 · 판정 완료 M건`. 🔑 `hypothesis_hit_rate` null(표본0)=cold-start → **"데이터 없음"**(0%/낮음/빨강 환원 X·null≠0·AC③).
- **Surface 2 — gate-evidence CI↔outcome 2열 분리(AC①)**: 좌=**CI · 납품**(delivery·"통과했다"·CI ✓/✗/? + clean_pass) | 우=**Outcome · 판단**("옳았다"). gate엔 정밀 hit_rate 없음 → `cold_start_seed`→**"임시 예측" + keep/kill**(neutral muted 배지) / else→**"판정 데이터 누적 중"** placeholder. **억지 % 금지**(trust None 가드 동형) — % 없어도 "통과≠옳음" 개념 분리 명확.
- **Surface 3 — verdict 배선**: 기존 `HypothesisStatusBadge`(verified=success녹 ✓ / falsified=info청 ⊘ · **destructive X**·소울락) + `HypothesesSection` 사용 그대로 **재사용**(신규 0).
- i18n `cage` ns 10키 en/ko.

## 유나 결정/실측 반영

- **Surface2 억지 % 금지**(gate별 outcome 근거 0 → 임시예측/placeholder만). mockup "73%"는 정정(member 집계값 오인) — 정밀 %는 Surface1에만.
- **pending = 카운트**(trust 응답에 last_resolved_at 없음 → 시점 생략·디디 follow-up).
- **hit_rate null** = cold-start면 임시예측 / 아니면 "데이터 없음".
- **seed_prediction**: keep="유지 예측"·kill="중단 예측"(판정 아닌 "임시 예측" 프레이밍).

## AC

- [x] ① CI↔outcome 분리(2열·"통과≠옳음") · [x] ② pending/resolved 노출 · [x] ③ work-about-work 0(판단 필드만)
- [x] cold-start 미확정 → 0/낮음/판정 환원 X (임시 예측·neutral)

## 검증

BE 계약 **코드 실측** · `tsc` 0 · `eslint` 0 · `next build` PASS · i18n 키 패리티.

## 리뷰

base `develop`. 게이팅: **유나 가디언 픽셀 → 까심 QA(5.5) + PO grep → 머지 → 유나 라이브 픽셀(닫힌 루프 시각 완성)**. 열린항목(BE follow-up): last_resolved_at·gate outcome hit_rate·source_breakdown 보조 표시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)