### PR TITLE
fix(cron): FE proxy 경로 교정 — /api/v2/cron → /api/v2/internal/cron (404 해소)

### DIFF
--- a/apps/web/src/app/api/cron/agent-session-recovery/route.test.ts
+++ b/apps/web/src/app/api/cron/agent-session-recovery/route.test.ts
@@ -6,7 +6,7 @@ vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
 
-const PATH = '/api/v2/cron/agent-session-recovery';
+const PATH = '/api/v2/internal/cron/agent-session-recovery';
 const okRes = (b: unknown = { ok: 1 }) =>
   new Response(JSON.stringify(b), { status: 200, headers: { 'content-type': 'application/json' } });
 const req = () => new Request('http://localhost/api/cron/agent-session-recovery');

--- a/apps/web/src/app/api/cron/agent-session-recovery/route.ts
+++ b/apps/web/src/app/api/cron/agent-session-recovery/route.ts
@@ -2,7 +2,7 @@ import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
-  const _r = await proxyToFastapi(request, '/api/v2/cron/agent-session-recovery');
+  const _r = await proxyToFastapi(request, '/api/v2/internal/cron/agent-session-recovery');
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });
     return apiSuccess(await _r.json());

--- a/apps/web/src/app/api/cron/anonymize/route.ts
+++ b/apps/web/src/app/api/cron/anonymize/route.ts
@@ -2,7 +2,7 @@ import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function POST(request: Request) {
-  const _r = await proxyToFastapi(request, '/api/v2/cron/anonymize');
+  const _r = await proxyToFastapi(request, '/api/v2/internal/cron/anonymize');
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });
     return apiSuccess(await _r.json());

--- a/apps/web/src/app/api/cron/hitl-timeouts/route.test.ts
+++ b/apps/web/src/app/api/cron/hitl-timeouts/route.test.ts
@@ -6,7 +6,7 @@ vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
 
-const PATH = '/api/v2/cron/hitl-timeouts';
+const PATH = '/api/v2/internal/cron/hitl-timeouts';
 const okRes = (b: unknown = { ok: 1 }) =>
   new Response(JSON.stringify(b), { status: 200, headers: { 'content-type': 'application/json' } });
 const req = () => new Request('http://localhost/api/cron/hitl-timeouts');

--- a/apps/web/src/app/api/cron/hitl-timeouts/route.ts
+++ b/apps/web/src/app/api/cron/hitl-timeouts/route.ts
@@ -2,7 +2,7 @@ import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
-  const _r = await proxyToFastapi(request, '/api/v2/cron/hitl-timeouts');
+  const _r = await proxyToFastapi(request, '/api/v2/internal/cron/hitl-timeouts');
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });
     return apiSuccess(await _r.json());

--- a/apps/web/src/app/api/cron/inbox-outbox/route.test.ts
+++ b/apps/web/src/app/api/cron/inbox-outbox/route.test.ts
@@ -6,7 +6,7 @@ vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
 
-const PATH = '/api/v2/cron/inbox-outbox';
+const PATH = '/api/v2/internal/cron/inbox-outbox';
 const okRes = (b: unknown = { ok: 1 }) =>
   new Response(JSON.stringify(b), { status: 200, headers: { 'content-type': 'application/json' } });
 const req = () => new Request('http://localhost/api/cron/inbox-outbox');

--- a/apps/web/src/app/api/cron/inbox-outbox/route.ts
+++ b/apps/web/src/app/api/cron/inbox-outbox/route.ts
@@ -2,7 +2,7 @@ import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
-  const _r = await proxyToFastapi(request, '/api/v2/cron/inbox-outbox');
+  const _r = await proxyToFastapi(request, '/api/v2/internal/cron/inbox-outbox');
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });
     return apiSuccess(await _r.json());

--- a/apps/web/src/app/api/cron/retry-agent-runs/route.ts
+++ b/apps/web/src/app/api/cron/retry-agent-runs/route.ts
@@ -2,7 +2,7 @@ import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
-  const _r = await proxyToFastapi(request, '/api/v2/cron/retry-agent-runs');
+  const _r = await proxyToFastapi(request, '/api/v2/internal/cron/retry-agent-runs');
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });
     return apiSuccess(await _r.json());


### PR DESCRIPTION
## cron 스케줄러 인프라 갭 (35347ee2) — BE-스코프 조각

HO-S1 forward-verify에서 발견된 cron-dormant 갭의 BE-스코프 부분. **FE cron 프록시 경로 404 교정.**

### 문제
FE cron 프록시 라우트 5개가 `proxyToFastapi`로 **`/api/v2/cron/<name>`**을 호출하나, backend cron 라우터 prefix는 **`/api/v2/internal/cron`** → 경로 불일치로 호출 시 **404**. 백엔드 엔드포인트는 전부 실재(`verify_cron`·`CRON_SECRET` 인증).

### Changes
- `route.ts` 5개(agent-session-recovery·anonymize·hitl-timeouts·inbox-outbox·retry-agent-runs): 프록시 경로 `/api/v2/cron/*` → `/api/v2/internal/cron/*`.
- `route.test.ts` 3개: `PATH` 상수 동기화.

### Validation
- cron route **vitest 9/9 PASS**(3 파일·proxy 위임·204→{ok}·error passthrough).
- FE-facing 경로(`/api/cron/*`)·미들웨어 no-JWT 목록 불변.

### 스코프 분리 (참고)
- **본 PR(BE-스코프·디디)**: FE→backend 프록시 경로 404 교정.
- **PO lane(gcloud)**: 실 주기 트리거는 **Cloud Scheduler → backend 직타**(score-hypotheses 패턴·`CRON_SECRET` Bearer)로 등록. 권장 주기(검토): hitl-timeouts/inbox-outbox/agent-session-recovery/retry-agent-runs=고빈도(5~15분)·anonymize=일·score-ga4-outcomes=시간. cron 경로 dormant의 근본 해소는 스케줄러 잡 등록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)