### PR TITLE
feat(cron): retry-agent-runs ?dry_run=true preview (surge 안전 점검)

### DIFF
--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -9,11 +9,11 @@ import os
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 
 logger = logging.getLogger(__name__)
 from fastapi.responses import JSONResponse
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.database import get_db
@@ -147,21 +147,33 @@ async def inbox_outbox(
 @router.get("/retry-agent-runs")
 async def retry_agent_runs(
     request: Request,
+    dry_run: bool = Query(default=False),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     verify_cron(request)
     try:
         now = datetime.now(timezone.utc)
 
-        # next_retry_at이 도래한 failed run 조회
-        result = await session.execute(
-            select(AgentRun).where(
-                AgentRun.status == "failed",
-                AgentRun.next_retry_at.is_not(None),
-                AgentRun.next_retry_at <= now,
-                AgentRun.retry_count < AgentRun.max_retries,
-            )
+        # next_retry_at이 도래한 failed run의 retry-eligible 필터. dry_run/실행이 **동일 필터**를
+        # 써야 preview 수 == 실제 처리 건수가 보장된다(스케줄 가동 전 surge 규모 정확).
+        eligible_filter = (
+            AgentRun.status == "failed",
+            AgentRun.next_retry_at.is_not(None),
+            AgentRun.next_retry_at <= now,
+            AgentRun.retry_count < AgentRun.max_retries,
         )
+
+        # dry_run: read-only preview — eligible count만 반환·mutate/commit 0(가동 전 안전 점검).
+        if dry_run:
+            count = (
+                await session.execute(
+                    select(func.count()).select_from(AgentRun).where(*eligible_filter)
+                )
+            ).scalar_one()
+            return _ok({"dry_run": True, "eligible_count": int(count)})
+
+        # next_retry_at이 도래한 failed run 조회
+        result = await session.execute(select(AgentRun).where(*eligible_filter))
         pending = list(result.scalars().all())
 
         retried: list[dict] = []

--- a/backend/tests/test_cron_retry_dry_run.py
+++ b/backend/tests/test_cron_retry_dry_run.py
@@ -38,9 +38,11 @@ async def test_dry_run_counts_without_mutating_and_matches_real_filter():
     )
     engine = create_async_engine(url)
     org, project, agent = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
-    now = datetime(2026, 6, 13, 12, 0, tzinfo=timezone.utc)
+    # 핸들러는 실 wall clock(datetime.now())로 eligible를 판정한다. 시드 시각도 실 now 기준으로
+    # 잡아야(까심 CP④ time-bomb 회피) future run이 wall clock 경과로 eligible 전환되지 않는다.
+    now = datetime.now(timezone.utc)
     past = now - timedelta(hours=1)
-    future = now + timedelta(hours=1)
+    future = now + timedelta(days=1)
 
     def _run(status, nra, rc, mx):
         return AgentRun(id=uuid.uuid4(), org_id=org, project_id=project, agent_id=agent,

--- a/backend/tests/test_cron_retry_dry_run.py
+++ b/backend/tests/test_cron_retry_dry_run.py
@@ -1,0 +1,96 @@
+"""cron retry-agent-runs ?dry_run=true preview 테스트.
+
+dry_run은 retry-eligible count만 반환하고 아무것도 mutate하지 않는다(스케줄 가동 전 surge 규모
+점검용 read-only 안전 프리미티브). dry_run 필터 == 실제 처리 필터(동형)임을 실DB로 입증.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(
+    not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)"
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_dry_run_counts_without_mutating_and_matches_real_filter():
+    from sqlalchemy import text as _text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    from app.models.agent_run import AgentRun
+    from app.routers import cron as cron_mod
+
+    url = _REAL_DB_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+        "postgresql://", "postgresql+asyncpg://"
+    )
+    engine = create_async_engine(url)
+    org, project, agent = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    now = datetime(2026, 6, 13, 12, 0, tzinfo=timezone.utc)
+    past = now - timedelta(hours=1)
+    future = now + timedelta(hours=1)
+
+    def _run(status, nra, rc, mx):
+        return AgentRun(id=uuid.uuid4(), org_id=org, project_id=project, agent_id=agent,
+                        status=status, next_retry_at=nra, retry_count=rc, max_retries=mx)
+
+    async with engine.begin() as c:
+        await c.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add_all([
+                _run("failed", past, 0, 3),       # ✅ eligible
+                _run("failed", past, 1, 3),       # ✅ eligible
+                _run("failed", future, 0, 3),     # ✗ 아직 retry 시각 전
+                _run("failed", past, 3, 3),        # ✗ retry 소진(rc>=max)
+                _run("failed", None, 0, 3),        # ✗ next_retry_at 없음
+                _run("queued", past, 0, 3),        # ✗ failed 아님
+            ])
+            await s.commit()
+
+        # dry_run: eligible count만 반환·mutate 0.
+        class _Req:
+            headers: dict = {}
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            # CRON_SECRET 미설정 환경이면 verify_cron 통과(로컬). 설정 시 헤더 필요하나 테스트는 미설정 가정.
+            resp = await cron_mod.retry_agent_runs(_Req(), dry_run=True, session=s)
+        import json
+        body = json.loads(resp.body)
+        assert body["data"]["dry_run"] is True
+        assert body["data"]["eligible_count"] == 2  # 정확히 eligible 2건.
+
+        # mutate 0 검증: 모든 failed run이 그대로 failed(queued로 안 바뀜).
+        async with Session() as s:
+            failed_cnt = (await s.execute(
+                _text("SELECT count(*) FROM agent_runs WHERE status='failed'")
+            )).scalar()
+            queued_cnt = (await s.execute(
+                _text("SELECT count(*) FROM agent_runs WHERE status='queued'")
+            )).scalar()
+        assert failed_cnt == 5 and queued_cnt == 1  # dry_run 전과 동일(아무 전이 없음).
+
+        # 동형 검증: 실제 실행 시 eligible_count(2)만큼 retried 처리.
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            resp2 = await cron_mod.retry_agent_runs(_Req(), dry_run=False, session=s)
+        body2 = json.loads(resp2.body)
+        assert len(body2["data"]["retried"]) == 2  # preview 수 == 실제 처리 수(동형).
+    finally:
+        async with engine.begin() as c:
+            await c.run_sync(Base.metadata.drop_all)
+        await engine.dispose()


### PR DESCRIPTION
## retry-agent-runs `?dry_run=true` preview

cron 스케줄러 인프라(35347ee2)의 **retry-agent-runs 안전 가동 조각**. dormant가 오래라 첫 run에 밀린 failed run이 일괄 re-queue되면 **에이전트 run 버스트**(비용/부하) 가능 — 켜기 전 surge 규모를 read-only로 미리 보는 안전 프리미티브.

### Changes
- `GET /api/v2/internal/cron/retry-agent-runs?dry_run=true` → `{dry_run: true, eligible_count: N}`만 반환·**mutate/commit 0**. CRON_SECRET-gated(`verify_cron`).
- retry-eligible 필터(`status=failed AND next_retry_at<=now AND retry_count<max_retries`)를 dry_run/실행이 **공유 튜플로 동일 사용** → **preview 수 == 실제 처리 건수 보장**(동형·forward-verify).

### Validation (실DB)
- 6건 시드(eligible 2·future/retry소진/null/non-failed 4) → `dry_run` **eligible_count=2**·**mutate 0**(failed 5·queued 1 불변) → 실제 실행 시 **retried 2**(preview==처리·동형). `app.main` import OK.

### 운영
머지 후 내가 CRON_SECRET로 `dry_run` 호출 → surge 규모 확인 → 판단(0~수십=그냥 스케줄·수백+=per-run LIMIT batch fix 후 스케줄). retry 안전 가동의 마지막 조각.

🤖 Generated with [Claude Code](https://claude.com/claude-code)