### PR TITLE
fix(authz): 게이트 approve/reject는 휴먼 member만 (93fc7aeb·에이전트 우회 차단)

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -12,6 +12,10 @@ from app.dependencies.auth import get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.gate import Gate, is_valid_transition
 from app.services.gate_service import create_gate, transition_gate
+from app.services.member_resolver import resolve_member
+
+# 사람 검증 행위(approve/reject) — "human-validated" 웨지 integrity상 휴먼 member만 허용.
+_HUMAN_REVIEW_STATUSES = frozenset({"approved", "rejected"})
 
 router = APIRouter(prefix="/api/v2/gates", tags=["gates"])
 
@@ -116,8 +120,18 @@ async def transition_gate_endpoint(
     body: GateTransitionRequest,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth=Depends(get_current_user),
 ) -> GateResponse:
+    # authz(93fc7aeb): 게이트 approve/reject는 **휴먼 member만**. 에이전트(API key)가 사람 검증
+    # 게이트를 승인하면 "agent-assisted·human-validated" 웨지 전제가 무너지므로 차단(403).
+    # 시스템 auto-resolution(resolve_gate_from_verdict)은 transition_gate 서비스 직호출이라 무영향.
+    if body.status in _HUMAN_REVIEW_STATUSES:
+        resolved = await resolve_member(auth, org_id, session)
+        if resolved.type != "human":
+            raise HTTPException(
+                status_code=403,
+                detail="게이트 승인/거부는 휴먼 멤버만 가능합니다 (에이전트 승인 불가).",
+            )
     try:
         gate = await transition_gate(session, org_id, id, body.status, body.resolver_id, body.note)
         await session.commit()

--- a/backend/tests/test_gate_transition_human_only.py
+++ b/backend/tests/test_gate_transition_human_only.py
@@ -1,0 +1,90 @@
+"""authz 93fc7aeb: 게이트 transition(approve/reject)는 휴먼 member만.
+
+에이전트(API key)가 merge 게이트를 승인하면 "agent-assisted·human-validated" 웨지 전제가 무너진다.
+엔드포인트에서 resolve_member.type!="human"이면 403으로 차단(transition_gate 서비스/system
+auto-resolution은 불변).
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.routers import gates as gates_mod
+from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+from app.services.member_resolver import ResolvedMember
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _resolved(member_type: str) -> ResolvedMember:
+    return ResolvedMember(
+        id=uuid.uuid4(), user_id=(uuid.uuid4() if member_type == "human" else None),
+        name="m", type=member_type, role="member", org_id=uuid.uuid4(),
+    )
+
+
+async def _call(status: str, member_type: str):
+    org_id = uuid.uuid4()
+    body = GateTransitionRequest(status=status, resolver_id=uuid.uuid4())
+    session = AsyncMock()
+    transition = AsyncMock(return_value=SimpleNamespace())
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=_resolved(member_type))), \
+         patch.object(gates_mod, "transition_gate", transition), \
+         patch.object(gates_mod.GateResponse, "model_validate", lambda g: "OK"):
+        result = await transition_gate_endpoint(
+            id=uuid.uuid4(), body=body, session=session, org_id=org_id, auth=SimpleNamespace(),
+        )
+    return result, transition
+
+
+# ── AC①④: 에이전트 approve/reject → 403 ──────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_agent_approve_forbidden():
+    with pytest.raises(HTTPException) as ei:
+        await _call("approved", "agent")
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_agent_reject_forbidden():
+    with pytest.raises(HTTPException) as ei:
+        await _call("rejected", "agent")
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_agent_approve_does_not_call_transition():
+    # 403 차단이 transition_gate 호출 前(상태 변경 0).
+    transition = AsyncMock()
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=_resolved("agent"))), \
+         patch.object(gates_mod, "transition_gate", transition):
+        with pytest.raises(HTTPException):
+            await transition_gate_endpoint(
+                id=uuid.uuid4(), body=GateTransitionRequest(status="approved"),
+                session=AsyncMock(), org_id=uuid.uuid4(), auth=SimpleNamespace(),
+            )
+    transition.assert_not_awaited()
+
+
+# ── AC③: 휴먼 approve/reject 정상 ────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_human_approve_allowed():
+    result, transition = await _call("approved", "human")
+    assert result == "OK"
+    transition.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_human_reject_allowed():
+    result, transition = await _call("rejected", "human")
+    assert result == "OK"
+    transition.assert_awaited_once()


### PR DESCRIPTION
## authz 93fc7aeb — 게이트 approve/reject human-only

H1-FIX-2 라이브 재검증 중 발견: **에이전트**(API key·`members.type=agent`)가 merge 게이트 transition을 `approved`로 호출 → 스토리 done 도달. 웨지 전제 **'agent-assisted·human-validated'**가 무너지는 인가 갭. **선생님 결정 A(human-only).**

### Changes
- `transition_gate_endpoint`에서 `status∈(approved,rejected)`일 때 **`resolve_member`(canonical SSOT 리졸버)로 caller type 판별 → `type!="human"`이면 403**. `members.type` 재사용·**DB 변경/마이그 0**.
- `transition_gate` 서비스는 **불변** → 엔드포인트 미경유 경로 무영향(AC⑤):
  - system auto-resolution(`resolve_gate_from_verdict`·resolver_id None·CI/PR verdict)
  - report-done(evaluate만)·auto_merge(evidence-gated HO-S6)
  - cold-start seed(HO-S7)는 resolver=휴먼 keep/kill이라 human-only와 **정합**.

### AC
- ① transition(approved/rejected)는 휴먼만(에이전트=403) ② resolve_member로 caller 휴먼 검증 ③ 휴먼 keep/kill 정상 ④ **에이전트 approve 음성 테스트(403)** ⑤ 기존 게이트 미회귀.

### Validation
- 단위 **5 PASS**(에이전트 approve/reject→403·차단이 transition 호출 前=상태변경 0·휴먼 approve/reject 정상).
- 기존 게이트/H1 **73 PASS**·`app.main` import OK·no cycle.

> forward-verify: `members.type`(human/agent)·`resolve_member`→`ResolvedMember.type`·transition 유일 human-approve 경로=이 엔드포인트·system/report-done/auto_merge 미경유 develop 실재 확인. 까심 QA(5.5)→PO 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)