### PR TITLE
fix(gate): →done 우회 차단 — participation-gated, 출발 status 무관 (fc06fa8d·④)

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -19,6 +19,7 @@ from app.services.event_seq import assign_recipient_seq
 from app.schemas.story import StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
 from app.services.member_resolver import canonicalize_member_id
 from app.services.merge_verdict_gate import AUTO_MERGE, evaluate_merge_gate, merge_gate_active
+from app.services.verdict_capture import resolve_implementation_participation
 from app.services.notification_dispatch import dispatch_notification
 from app.services.webhook_dispatch import fire_webhooks
 from app.services.workflow_pipeline import process_event
@@ -145,15 +146,23 @@ async def _upsert_assignee_participation(
 async def _preflight_merge_gate(
     db: AsyncSession, org_id: uuid.UUID, story, new_status: str | None
 ) -> None:
-    """H1-S5: board 직접 PATCH로 in-review→done 전이 시 merge verdict gate preflight.
+    """H1-S5 + fc06fa8d(④): board PATCH로 →done 전이 시 merge verdict gate preflight.
 
-    게이트 active(`merge_gate_active`·flag+allowlist)이고 in-review→done일 때만 동작 — auto_merge가
-    아니면 409로 전이 차단(status 유지). 플래그 off면 즉시 반환해 기존 PATCH 동작 무변경(AC①).
-    board PATCH엔 PR/CI 컨텍스트가 없으므로(ci_result=None) 증거 없이 done 시도는 보류된다.
+    게이트 active(`merge_gate_active`·flag+allowlist)이고 **impl participation(=실작업) 보유**
+    스토리의 →done 전이일 때 동작 — auto_merge가 아니면 409로 차단(status 유지).
+
+    fc06fa8d: in-review→done뿐 아니라 **출발 status 무관 모든 →done**을 게이트(rfd/in-progress→done
+    우회 박멸·라이브 coverage 0.0 실측). 단 participation 없는 trivial todo→done은 skip(마찰 0).
+    게이트 목적(머지=코드작업 검증)과 정렬. 플래그 off면 즉시 반환(기존 PATCH 무변경). board PATCH엔
+    PR/CI 컨텍스트 없으므로(ci_result=None) 증거 없는 done은 보류된다.
     """
-    if new_status != "done" or story is None or getattr(story, "status", None) != "in-review":
+    if new_status != "done" or story is None or getattr(story, "status", None) == "done":
         return
     if not merge_gate_active(org_id):
+        return
+    # ④: impl participation(실작업) 보유 스토리만 게이트. 없으면 trivial → skip(마찰 0).
+    participation = await resolve_implementation_participation(db, org_id, story.id)
+    if participation is None:
         return
     decision = await evaluate_merge_gate(
         db, org_id, story.id, pr_number=0, repo="", ci_result=None, pr_result=None
@@ -164,7 +173,7 @@ async def _preflight_merge_gate(
             status_code=409,
             detail={
                 "code": "MERGE_GATE_PENDING",
-                "message": f"in-review→done은 merge 게이트 통과 필요: {decision.reason}",
+                "message": f"done 전이는 merge 게이트 통과 필요: {decision.reason}",
                 "decision": decision.decision,
                 "gate_id": str(decision.gate_id) if decision.gate_id else None,
                 "requires_human": True,

--- a/backend/tests/test_h1_s5_board_gate.py
+++ b/backend/tests/test_h1_s5_board_gate.py
@@ -73,12 +73,30 @@ async def test_preflight_noop_when_not_done():
     ev.assert_not_awaited()  # done 아니면 게이트 0.
 
 
+_PART = SimpleNamespace(id=uuid.uuid4(), member_id=uuid.uuid4(), role_id=uuid.uuid4())
+
+
 @pytest.mark.anyio
-async def test_preflight_noop_when_not_in_review():
+async def test_preflight_noop_when_no_participation():
+    # fc06fa8d(④·AC②): impl participation 없는 trivial todo→done은 skip(마찰 0).
     from app.routers.stories import _preflight_merge_gate
-    with patch("app.routers.stories.evaluate_merge_gate", new=AsyncMock()) as ev:
+    with patch("app.routers.stories.merge_gate_active", return_value=True), \
+         patch("app.routers.stories.resolve_implementation_participation", new=AsyncMock(return_value=None)), \
+         patch("app.routers.stories.evaluate_merge_gate", new=AsyncMock()) as ev:
         await _preflight_merge_gate(AsyncMock(), uuid.uuid4(), _story("todo"), "done")
-    ev.assert_not_awaited()  # in-review→done만 대상.
+    ev.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_preflight_gates_non_in_review_with_participation():
+    # fc06fa8d(④·AC①③): 출발 status 무관(rfd/todo→done)도 participation 보유면 게이트 발화(우회 박멸).
+    from app.routers.stories import _preflight_merge_gate
+    with patch("app.routers.stories.merge_gate_active", return_value=True), \
+         patch("app.routers.stories.resolve_implementation_participation", new=AsyncMock(return_value=_PART)), \
+         patch("app.routers.stories.evaluate_merge_gate",
+               new=AsyncMock(return_value=_decision(AUTO_MERGE))) as ev:
+        await _preflight_merge_gate(AsyncMock(), uuid.uuid4(), _story("ready-for-dev"), "done")
+    ev.assert_awaited_once()  # in-review 아닌 경로도 게이트 통과 강제.
 
 
 @pytest.mark.anyio
@@ -87,13 +105,14 @@ async def test_preflight_noop_when_flag_off():
     with patch("app.routers.stories.merge_gate_active", return_value=False), \
          patch("app.routers.stories.evaluate_merge_gate", new=AsyncMock()) as ev:
         await _preflight_merge_gate(AsyncMock(), uuid.uuid4(), _story("in-review"), "done")
-    ev.assert_not_awaited()  # AC①: 플래그 off면 in-review→done이어도 게이트 0(기존 PATCH 무변경).
+    ev.assert_not_awaited()  # AC①: 플래그 off면 게이트 0(기존 PATCH 무변경).
 
 
 @pytest.mark.anyio
 async def test_preflight_passes_when_auto_merge():
     from app.routers.stories import _preflight_merge_gate
     with patch("app.routers.stories.merge_gate_active", return_value=True), \
+         patch("app.routers.stories.resolve_implementation_participation", new=AsyncMock(return_value=_PART)), \
          patch("app.routers.stories.evaluate_merge_gate", new=AsyncMock(return_value=_decision(AUTO_MERGE))):
         await _preflight_merge_gate(AsyncMock(), uuid.uuid4(), _story("in-review"), "done")
     # 예외 없음 = 전이 허용.
@@ -106,6 +125,7 @@ async def test_preflight_blocks_409_when_not_auto_merge():
     from app.routers.stories import _preflight_merge_gate
     db = AsyncMock()
     with patch("app.routers.stories.merge_gate_active", return_value=True), \
+         patch("app.routers.stories.resolve_implementation_participation", new=AsyncMock(return_value=_PART)), \
          patch("app.routers.stories.evaluate_merge_gate", new=AsyncMock(return_value=_decision(ASK_HUMAN))):
         with pytest.raises(HTTPException) as ei:
             await _preflight_merge_gate(db, uuid.uuid4(), _story("in-review"), "done")


### PR DESCRIPTION
## fc06fa8d — H1 게이트 우회 차단 (in-review 미경유 done 직행)

dogfood 관찰: `_preflight_merge_gate`가 **in-review→done에서만 발화** → rfd/in-progress→done 직행은 게이트 우회(authz human-only도 경로 스킵으로 무력화). **라이브 `merge_gate_coverage=0.0`**(done 중 게이트 경유 0%·near-total 우회) 실측 → 닫을 근거 압도적.

### 옵션 ④ (participation-gated·마찰 최소·선생님/PO confirm)
- `_preflight`에서 **in-review 가드 제거** → impl participation(=실작업) 보유 스토리는 **출발 status 무관 모든 →done**을 게이트(rfd/in-progress/in-review→done 전부 닫음·우회 박멸).
- participation 없는 **trivial todo→done은 skip**(마찰 0). 게이트 목적(머지=코드작업 검증)과 정렬.
- 이미 done이면 no-op. **DB 변경 0**(`resolve_implementation_participation` 재사용). 409 메시지 경로-무관화.
- report-done은 stage=merge 별도 게이팅이라 **무변경**(우회 아님)·transition 서비스/system auto-resolution 무영향.

### AC
- ① impl participation 보유 →done 전부 게이트(in-review 외 경로 포함) ② participation 없는 trivial →done skip ③ rfd→done 스킵 시도→게이트 발화(우회 차단) ④ 기존 정상 미회귀.

### Validation
- H1-S5 **10 PASS**(신규 ④ 2: participation 없으면 skip·rfd→done+participation이면 게이트 발화) + H1 광역 **49 PASS**·`app.main` import OK·no cycle.

> 라이브 검증(PO/배포 후): rfd→done 스킵 시도 → 차단(409) 확인. forward-verify: `_preflight` 호출처 2곳·update_story_status transition-check 부재·report-done stage=merge 분리·coverage 0.0 develop/dev 실측. 까심 QA(5.5)→PO 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)