### PR TITLE
fix(gate): gate-driven done이 status-change side-effects 발화 (41a6e294)

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -21,6 +21,7 @@ from app.services.member_resolver import canonicalize_member_id
 from app.services.merge_verdict_gate import AUTO_MERGE, evaluate_merge_gate, merge_gate_active
 from app.services.verdict_capture import resolve_implementation_participation
 from app.services.notification_dispatch import dispatch_notification
+from app.services.story_status_events import emit_story_status_changed
 from app.services.webhook_dispatch import fire_webhooks
 from app.services.workflow_pipeline import process_event
 from app.services.rule_evaluator import EventContext
@@ -578,73 +579,12 @@ async def update_story_status(
             except Exception:
                 pass
         epic_title: str | None = None
-        try:
-            epic_title = await _resolve_epic_title(db, story.epic_id)
-        except Exception:
-            pass
-        event_data = {
-            "story_id": str(id),
-            "story_title": story.title,
-            "story_priority": story.priority,
-            "epic_id": str(story.epic_id) if story.epic_id else None,
-            "epic_title": epic_title,
-            "status": story.status,
-            "new_status": story.status,
-            "old_status": old_status,
-            "project_id": str(story.project_id),
-            "org_id": str(org_id),
-            "actor_id": str(actor_id) if actor_id else None,
-            "actor_name": actor_name,
-            "actor_role": actor_role,
-            "source_agent_id": str(actor_id) if (actor_id and actor_type == "agent") else None,
-            "assignees": [str(story.assignee_id)] if story.assignee_id else [],
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-        }
-        publish_event(str(org_id), "story.status_changed", event_data)
-        try:
-            await fire_webhooks(db, org_id, "story.status_changed", event_data)
-        except Exception:
-            pass
-        try:
-            await process_event(db, org_id, story.project_id, EventContext(
-                event_type="story.status_changed",
-                trigger_type_slug="status_changed",
-                actor_id=str(actor_id) if actor_id else None,
-                metadata=event_data,
-            ))
-        except Exception:
-            pass
-        # E-EVENTBUS P3 S9: story_status_changed → assignee + actor에게 알림
-        notify_ids: set[uuid.UUID] = set()
-        if story.assignee_id:
-            notify_ids.add(story.assignee_id)
-        if actor_id and actor_id != story.assignee_id:
-            notify_ids.add(actor_id)
-        if notify_ids:
-            await dispatch_notification(
-                db,
-                org_id=org_id,
-                event_type="story_status_changed",
-                target_member_ids=list(notify_ids),
-                title=f"스토리 상태 변경: {story.title} → {story.status}",
-                body=None,
-                reference_type="story",
-                reference_id=story.id,
-            )
-        if actor_id:
-            try:
-                db.add(StoryActivity(
-                    story_id=id,
-                    org_id=org_id,
-                    project_id=story.project_id,
-                    activity_type="status_changed",
-                    old_value=old_status,
-                    new_value=story.status,
-                    created_by=(await canonicalize_member_id(actor_id, db)),  # AC3-2d(1b) canonical
-                ))
-                await db.flush()
-            except Exception:
-                pass
+        # 41a6e294: status_changed side-effects(events→L1·webhook·L2·notif·activity)는 공유 helper로
+        # 발화 — gate-driven done(gate_service)과 동일 경로(parity·드리프트 0).
+        await emit_story_status_changed(
+            db, org_id, story, old_status,
+            actor_id=actor_id, actor_name=actor_name, actor_role=actor_role, actor_type=actor_type,
+        )
 
     # S-C2: story_updated — actor가 agent인 경우 기록 (AC2, AC6)
     if actor_id:

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -142,8 +142,19 @@ async def _advance_story_on_merge_approve(session: AsyncSession, gate: Gate, new
 
     story = await session.get(Story, gate.work_item_id)
     if story is not None and story.status != "done":
+        old_status = story.status
         story.status = "done"
         await session.flush()
+        # 41a6e294: gate-driven done도 정상 status-change side-effects를 발화 — events(→L1
+        # activity_events 캡처=verdict 증거원)·webhook·L2 trigger·notification·activity. status만
+        # 직접 set하면 활동그래프 누락(게이트가 만든 done이 게이트 증거에 안 잡히는 자기모순).
+        # actor=resolver(승인 휴먼·#1504로 휴먼 보장). 정상 board 경로와 공유 helper(parity).
+        from app.services.story_status_events import emit_story_status_changed
+
+        await emit_story_status_changed(
+            session, gate.org_id, story, old_status,
+            actor_id=gate.resolver_id, actor_type="human",
+        )
 
 
 # gate_type → verdict source (qa→qa·merge→merge·deploy→design·pr_review→pr).

--- a/backend/app/services/story_status_events.py
+++ b/backend/app/services/story_status_events.py
@@ -1,0 +1,132 @@
+"""스토리 status_changed side-effects 공유 발화 (41a6e294).
+
+정상 board PATCH 경로와 gate-driven done(merge approve)이 **동일 side-effects**를 내도록 단일 helper로
+추출 — events(publish→eventbus 소비=L1 `activity_events` 캡처)·webhook·L2 trigger·notification·
+StoryActivity. gate-driven done이 status만 직접 set해 활동그래프에 누락되던 자기모순(게이트가 만든
+done이 게이트 증거에 안 잡힘)을 닫고, 정상 경로와 parity(드리프트 0)를 보장한다.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def _epic_title(db: AsyncSession, epic_id: uuid.UUID | None) -> str | None:
+    if not epic_id:
+        return None
+    from app.models.pm import Epic
+
+    result = await db.execute(select(Epic).where(Epic.id == epic_id).limit(1))
+    epic = result.scalar_one_or_none()
+    return epic.title if epic else None
+
+
+async def emit_story_status_changed(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    story,
+    old_status: str | None,
+    *,
+    actor_id: uuid.UUID | None = None,
+    actor_name: str | None = None,
+    actor_role: str | None = None,
+    actor_type: str | None = None,
+) -> None:
+    """story status_changed의 side-effects 5종을 발화. old==new면 no-op.
+
+    호출자가 story.status를 이미 새 값으로 설정한 뒤 호출한다. 각 side-effect는 best-effort(실패
+    격리)로 status 전이 자체를 깨지 않는다. publish_event는 eventbus→L1 activity_events 캡처의
+    진입점이므로 gate-driven done도 이걸 타야 활동그래프(=verdict 증거원)에 잡힌다.
+    """
+    if old_status == story.status:
+        return
+    # lazy import — service→router/pipeline 순환 회피.
+    from app.models.pm import StoryActivity
+    from app.routers.events import publish_event
+    from app.services.member_resolver import canonicalize_member_id
+    from app.services.notification_dispatch import dispatch_notification
+    from app.services.rule_evaluator import EventContext
+    from app.services.webhook_dispatch import fire_webhooks
+    from app.services.workflow_pipeline import process_event
+
+    epic_title: str | None = None
+    try:
+        epic_title = await _epic_title(db, story.epic_id)
+    except Exception:
+        pass
+
+    event_data = {
+        "story_id": str(story.id),
+        "story_title": story.title,
+        "story_priority": story.priority,
+        "epic_id": str(story.epic_id) if story.epic_id else None,
+        "epic_title": epic_title,
+        "status": story.status,
+        "new_status": story.status,
+        "old_status": old_status,
+        "project_id": str(story.project_id),
+        "org_id": str(org_id),
+        "actor_id": str(actor_id) if actor_id else None,
+        "actor_name": actor_name,
+        "actor_role": actor_role,
+        "source_agent_id": str(actor_id) if (actor_id and actor_type == "agent") else None,
+        "assignees": [str(story.assignee_id)] if story.assignee_id else [],
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+    publish_event(str(org_id), "story.status_changed", event_data)
+    try:
+        await fire_webhooks(db, org_id, "story.status_changed", event_data)
+    except Exception:
+        pass
+    try:
+        await process_event(
+            db,
+            org_id,
+            story.project_id,
+            EventContext(
+                event_type="story.status_changed",
+                trigger_type_slug="status_changed",
+                actor_id=str(actor_id) if actor_id else None,
+                metadata=event_data,
+            ),
+        )
+    except Exception:
+        pass
+
+    notify_ids: set[uuid.UUID] = set()
+    if story.assignee_id:
+        notify_ids.add(story.assignee_id)
+    if actor_id and actor_id != story.assignee_id:
+        notify_ids.add(actor_id)
+    if notify_ids:
+        await dispatch_notification(
+            db,
+            org_id=org_id,
+            event_type="story_status_changed",
+            target_member_ids=list(notify_ids),
+            title=f"스토리 상태 변경: {story.title} → {story.status}",
+            body=None,
+            reference_type="story",
+            reference_id=story.id,
+        )
+
+    if actor_id:
+        try:
+            db.add(
+                StoryActivity(
+                    story_id=story.id,
+                    org_id=org_id,
+                    project_id=story.project_id,
+                    activity_type="status_changed",
+                    old_value=old_status,
+                    new_value=story.status,
+                    created_by=(await canonicalize_member_id(actor_id, db)),
+                )
+            )
+            await db.flush()
+        except Exception:
+            pass

--- a/backend/tests/test_h1_fix2_approve_advances_done.py
+++ b/backend/tests/test_h1_fix2_approve_advances_done.py
@@ -22,8 +22,21 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+def _mock_status_side_effects():
+    """41a6e294: _advance_story_on_merge_approve가 done 진행 후 status_changed side-effects를
+    발화하므로, status 진행 로직만 검증하는 단위 테스트에서는 emit을 격리(실제 발화는 별도 실DB로 검증)."""
+    with patch(
+        "app.services.story_status_events.emit_story_status_changed", new=AsyncMock()
+    ):
+        yield
+
+
 def _gate(gate_type="merge", work_item_type="story"):
-    return SimpleNamespace(gate_type=gate_type, work_item_type=work_item_type, work_item_id=uuid.uuid4())
+    return SimpleNamespace(
+        gate_type=gate_type, work_item_type=work_item_type,
+        work_item_id=uuid.uuid4(), org_id=uuid.uuid4(), resolver_id=uuid.uuid4(),
+    )
 
 
 # ── 단위 ───────────────────────────────────────────────────────────────────────

--- a/backend/tests/test_ho_gate_done_side_effects.py
+++ b/backend/tests/test_ho_gate_done_side_effects.py
@@ -1,0 +1,90 @@
+"""41a6e294: gate-driven done이 정상 status-change side-effects를 발화.
+
+merge approve→done이 status만 직접 set하던 갭을 닫고, 정상 board 경로와 동일 helper
+(emit_story_status_changed)로 events(story.status_changed→L1 진입점)·StoryActivity를 발화하는지
+실DB로 검증. publish_event는 eventbus→L1 activity_events 캡처의 진입점이다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(
+    not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)"
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_gate_driven_done_emits_status_changed_side_effects():
+    from sqlalchemy import text as _text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    from app.models.participation import ParticipationRole  # noqa: F401 — org_gate_override FK 해소.
+    from app.models.member import Member
+    from app.models.pm import Story, StoryActivity
+    from app.services.gate_service import _advance_story_on_merge_approve
+
+    url = _REAL_DB_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+        "postgresql://", "postgresql+asyncpg://"
+    )
+    engine = create_async_engine(url)
+    org, project, story_id, resolver = (uuid.uuid4() for _ in range(4))
+
+    async with engine.begin() as c:
+        await c.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add_all([
+                Member(id=resolver, org_id=org, type="human", user_id=uuid.uuid4(), name="h"),
+                Story(id=story_id, org_id=org, project_id=project, title="S", status="in-review",
+                      story_points=3),
+            ])
+            await s.commit()
+
+        gate = SimpleNamespace(
+            gate_type="merge", work_item_type="story", work_item_id=story_id,
+            org_id=org, resolver_id=resolver,
+        )
+        spy = MagicMock()
+        with patch("app.routers.events.publish_event", spy):
+            async with Session() as s:
+                await s.execute(_text("SET session_replication_role = replica"))
+                await _advance_story_on_merge_approve(s, gate, "approved")
+                await s.commit()
+
+        # ① 상태 진행.
+        async with Session() as s:
+            status = (await s.execute(
+                _text("SELECT status FROM stories WHERE id=:i"), {"i": story_id}
+            )).scalar()
+            act = (await s.execute(
+                _text("SELECT old_value, new_value, activity_type FROM story_activities "
+                      "WHERE story_id=:i"), {"i": story_id}
+            )).all()
+        assert status == "done"
+        # ② publish_event("story.status_changed") 발화 = L1 activity_events 캡처 진입점.
+        assert spy.called
+        evt_types = [c.args[1] for c in spy.call_args_list if len(c.args) >= 2]
+        assert "story.status_changed" in evt_types
+        # ③ StoryActivity status_changed 행(in-review→done) — 정상 경로와 parity.
+        assert any(a.activity_type == "status_changed" and a.old_value == "in-review"
+                   and a.new_value == "done" for a in act)
+    finally:
+        async with engine.begin() as c:
+            await c.run_sync(Base.metadata.drop_all)
+        await engine.dispose()


### PR DESCRIPTION
## 41a6e294 — gate-driven done의 status-change side effects 발화

H1-FIX-2(`_advance_story_on_merge_approve`)가 merge approve→`story.status=done`을 **직접 set**해 정상 done 전이의 side-effects를 우회: events(publish→eventbus=**L1 `activity_events` 캡처**)·webhook·L2 trigger·notification·StoryActivity 미발생 → **gate-driven done이 L1 활동그래프에 누락**(게이트가 만든 done이 게이트 증거에 안 잡히는 자기모순·verdict 증거원 일관성 깨짐).

### Changes
- **신규 `services/story_status_events.emit_story_status_changed`**: status_changed side-effects 5종을 단일 helper로 추출(publish_event→L1 진입점·fire_webhooks·process_event[L2]·dispatch_notification·StoryActivity). best-effort(실패 격리)로 전이 자체는 안 깸.
- **stories.py 정상 경로**: 인라인 emit 블록을 helper 호출로 교체(동작 동형).
- **gate_service `_advance_story_on_merge_approve`**: done set 후 helper 호출(actor=resolver·#1504로 휴먼 보장·old_status=전이 전). **정상 경로와 공유 = parity·드리프트 0**.
- DB 변경 0(emit만). report-done/system auto-resolution 무영향.

### AC
- gate-driven done이 정상 status-change 경로(동등) 경유 → events/`activity_events`(L1 진입)/webhook/L2/notification emit. 정상 경로와 parity.

### Validation
- ⭐**실DB**: gate-driven done → story done + `publish_event("story.status_changed")` 발화(L1 진입점) + `StoryActivity` status_changed[in-review→done] 행.
- H1-FIX-2 단위(emit 격리 fixture) + status/gate/eventbus 회귀 **130 PASS**·`app.main` import OK·no cycle.

> publish_event는 eventbus→L1 activity_events 캡처의 진입점(동기 write 아님·E-L1 다운스트림). 본 PR은 gate-driven done이 그 진입점을 타게 해 L1 누락을 닫음. 까심 QA(5.5)→PO 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)