### PR TITLE
feat(gate): H1 게이트 advisory(B) 모드 — eval+기록 유지·차단 면제

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -71,6 +71,10 @@ class Settings(BaseSettings):
     # 접는조건 後 의도적으로. allowlist 지정 시 해당 org만 게이트(점진 rollout).
     h1_merge_gate_enabled: bool = False
     h1_merge_gate_org_allowlist: str = ""  # CSV org_id — 비면 enabled 시 전 org, 지정 시 해당 org만
+    # advisory(B): set 시 게이트 eval + decision/gate row/metrics는 기록하되 →done 차단(409/202)을
+    # 면제(done 통과·관측만). cold-start 동안 coverage/우회율/seed 데이터 계속 쌓되 고마찰 차단은 면제.
+    # 정책은 A(human-only enforcing)·advisory는 개발/관측용 임시 모드(미설정=enforcing 보존).
+    h1_merge_gate_advisory: bool = False
 
     # E-MEMBER-SSOT AC2-3: 신원 해소를 anchor(members+member_identity_aliases) 기반으로 전환하는
     # shadow 플래그. off(기본)=레거시 resolver(org_members/team_members). on=anchor resolver.

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -18,7 +18,12 @@ from app.routers.events import publish_event
 from app.services.event_seq import assign_recipient_seq
 from app.schemas.story import StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
 from app.services.member_resolver import canonicalize_member_id
-from app.services.merge_verdict_gate import AUTO_MERGE, evaluate_merge_gate, merge_gate_active
+from app.services.merge_verdict_gate import (
+    AUTO_MERGE,
+    evaluate_merge_gate,
+    merge_gate_active,
+    merge_gate_advisory,
+)
 from app.services.verdict_capture import resolve_implementation_participation
 from app.services.notification_dispatch import dispatch_notification
 from app.services.webhook_dispatch import fire_webhooks
@@ -169,6 +174,9 @@ async def _preflight_merge_gate(
     )
     if decision.decision != AUTO_MERGE:
         await db.commit()  # gate audit 보존(get_db는 예외 시 rollback).
+        # advisory(B): eval/gate row/metrics는 이미 기록됨 — 차단만 면제하고 done 통과(관측만).
+        if merge_gate_advisory():
+            return
         raise HTTPException(
             status_code=409,
             detail={

--- a/backend/app/routers/workflow_report.py
+++ b/backend/app/routers/workflow_report.py
@@ -23,6 +23,7 @@ from app.services.merge_verdict_gate import (
     MergeGateDecision,
     evaluate_merge_gate,
     merge_gate_active,
+    merge_gate_advisory,
 )
 
 logger = logging.getLogger(__name__)
@@ -170,7 +171,9 @@ async def report_done(
             pr_result=ctx.get("pr_result"),
         )
         await _record_gate_evidence(session, gate_info)
-        if gate_info.decision != AUTO_MERGE:
+        # advisory(B): eval/gate evidence/metrics는 기록(위)하되 차단(409/202·done 보류)은 면제 →
+        # decision 무관 done 통과(관측만). enforcing(미설정)은 아래 분기 그대로.
+        if gate_info.decision != AUTO_MERGE and not merge_gate_advisory():
             story_status = None  # done 전이 차단 — 현재 status 유지(AC①③).
             if gate_info.decision == BLOCK:
                 # gate audit를 보존하고 차단(get_db는 예외 시 rollback이라 명시 commit).

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -81,6 +81,12 @@ def merge_gate_active(org_id: uuid.UUID) -> bool:
     return (not allow) or (org_id in allow)
 
 
+def merge_gate_advisory() -> bool:
+    """advisory(B) 모드 여부. True면 게이트가 eval/decision/gate row/metrics는 그대로 기록하되
+    →done 차단(409/202)을 면제한다(관측만·done 통과). 미설정=enforcing(A) 보존."""
+    return bool(settings.h1_merge_gate_advisory)
+
+
 @dataclass(frozen=True)
 class MergeGateDecision:
     """머지 게이트 평가 결과. decision을 S3 merge hook가 소비한다."""

--- a/backend/tests/test_h1_s5_board_gate.py
+++ b/backend/tests/test_h1_s5_board_gate.py
@@ -132,3 +132,45 @@ async def test_preflight_blocks_409_when_not_auto_merge():
     assert ei.value.status_code == 409  # AC②: active+증거부족 → 전이 차단.
     assert ei.value.detail["code"] == "MERGE_GATE_PENDING"
     db.commit.assert_awaited_once()  # gate audit 보존.
+
+
+# ── [gate] advisory(B) 모드: eval/record는 하되 차단(409) 면제 ─────────────────────
+
+@pytest.mark.anyio
+async def test_merge_gate_advisory_flag():
+    from app.services.merge_verdict_gate import merge_gate_advisory
+    with patch("app.services.merge_verdict_gate.settings") as s:
+        s.h1_merge_gate_advisory = True
+        assert merge_gate_advisory() is True
+        s.h1_merge_gate_advisory = False
+        assert merge_gate_advisory() is False
+
+
+@pytest.mark.anyio
+async def test_preflight_advisory_passes_without_block():
+    # AC①④: advisory=true면 decision≠AUTO_MERGE여도 차단 0(done 통과)·단 eval/gate audit은 수행.
+    from app.routers.stories import _preflight_merge_gate
+    db = AsyncMock()
+    ev = AsyncMock(return_value=_decision(ASK_HUMAN))
+    with patch("app.routers.stories.merge_gate_active", return_value=True), \
+         patch("app.routers.stories.resolve_implementation_participation", new=AsyncMock(return_value=_PART)), \
+         patch("app.routers.stories.evaluate_merge_gate", new=ev), \
+         patch("app.routers.stories.merge_gate_advisory", return_value=True):
+        await _preflight_merge_gate(db, uuid.uuid4(), _story("ready-for-dev"), "done")  # 예외 없음.
+    ev.assert_awaited_once()        # eval은 그대로 수행(decision/gate row/metrics 기록·AC③).
+    db.commit.assert_awaited_once()  # gate audit 보존.
+
+
+@pytest.mark.anyio
+async def test_preflight_enforcing_still_blocks_when_advisory_off():
+    # AC②: advisory=false면 현 enforcing 보존(409 차단).
+    from fastapi import HTTPException
+
+    from app.routers.stories import _preflight_merge_gate
+    with patch("app.routers.stories.merge_gate_active", return_value=True), \
+         patch("app.routers.stories.resolve_implementation_participation", new=AsyncMock(return_value=_PART)), \
+         patch("app.routers.stories.evaluate_merge_gate", new=AsyncMock(return_value=_decision(ASK_HUMAN))), \
+         patch("app.routers.stories.merge_gate_advisory", return_value=False):
+        with pytest.raises(HTTPException) as ei:
+            await _preflight_merge_gate(AsyncMock(), uuid.uuid4(), _story("in-review"), "done")
+    assert ei.value.status_code == 409


### PR DESCRIPTION
## [gate] H1 게이트 advisory(B) 모드

선생님 결정: **정책=A(human-only enforcing)·지금은 B(advisory)로 개발.** fc06fa8d 후 게이트가 모든 실작업 →done 차단(cold-start ask_human + human-only authz)=고마찰. advisory는 cold-start 동안 coverage/우회율/seed 데이터를 계속 쌓되 **차단만 면제**하는 임시 관측 모드.

### Changes
- config `h1_merge_gate_advisory: bool = False` + `merge_gate_advisory()` helper.
- 차단 2지점에서 **eval/gate row/metrics는 그대로 기록**(`evaluate_merge_gate`/`_record_gate_evidence`가 항상 수행)하되 advisory 시 차단 면제:
  - `stories.py _preflight_merge_gate`: `decision != AUTO_MERGE` → commit(audit) 후 **advisory면 return(done 통과)**·아니면 409.
  - `workflow_report.py` merge stage: `decision != AUTO_MERGE and not advisory`일 때만 done 보류+409/202. **advisory면 story_status 유지(done 진행)**.

### AC
- ① advisory→eval/기록 but 차단0(done 통과) ② 미설정/false→enforcing(A) 보존 ③ decision/neutral_facts 동일 기록(관측 일관) ④ advisory 통과·enforcing 차단 테스트 ⑤ 기존 미회귀. **DB 0**.

### Validation
- H1-S5 **13 PASS**(advisory 3: helper·advisory 통과[eval 수행]·enforcing 차단) + 게이트 광역 **52 PASS**·`app.main` import OK.

> 머지+배포되면 PO가 `h1_merge_gate_advisory=true`로 게이트 재활성(관측 재개·차단 X)·나중 선생님 콜로 A(enforcing) 복귀. 까심 QA(5.5)→PO 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
