### PR TITLE
chore: 코드 주석서 내부 멤버명 제거 — 기술 설명만 (비-비즈니스 언어 규칙)

### DIFF
--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -109,7 +109,7 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
     }
 
     setOrgId(json.data.id);
-    // E-ONB S5 FINAL(까심 진단): org 생성 시 org_member가 최초 생성됨 → 즉시 토큰 refresh로
+    // E-ONB S5 FINAL: org 생성 시 org_member가 최초 생성됨 → 즉시 토큰 refresh로
     // 새 JWT에 org_id(BE auth Path4 org_member fallback) 반영. 이래야 다음 단계 project 생성의
     // getAuthContext(/api/v2/me)가 통과한다(미refresh 시 fresh JWT엔 team_member 없어 me null → 401).
     await fetch('/api/auth/refresh', { method: 'POST' }).catch(() => null);

--- a/apps/web/src/components/settings/add-member-modal.tsx
+++ b/apps/web/src/components/settings/add-member-modal.tsx
@@ -45,7 +45,7 @@ export function AddMemberModal({ open, onClose, orgId, projects, defaultType = '
   };
   const close = () => { reset(); onClose(); };
 
-  // CP4(까심): 모달은 열릴 때마다 fresh state로 — type을 현 defaultType(활성 subtab)에 동기화 +
+  // CP4: 모달은 열릴 때마다 fresh state로 — type을 현 defaultType(활성 subtab)에 동기화 +
   // 폼/error 초기화. close→reopen 시 직전 선택(예: 에이전트) persist 방지.
   useEffect(() => {
     if (!open) return;

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -105,7 +105,7 @@ function buildPreview(content: string, maxLength = 50) {
   return `${normalized.slice(0, maxLength)}…`;
 }
 
-// Korean honorific suffixes that may follow a first-name mention (e.g. "@까심군" for "까심 아르야")
+// Korean honorific suffixes that may follow a first-name mention (e.g. "@민준군" for a member "민준 김")
 const KOREAN_HONORIFIC_RE = /^(군|신|쿤|님|씨)/u;
 
 function hasMentionWithHonorific(content: string, namePart: string): boolean {

--- a/backend/app/routers/attachments.py
+++ b/backend/app/routers/attachments.py
@@ -4,7 +4,7 @@
 **전에** 이 엔드포인트로 요청자 권한을 확인한다. message 첨부 → conversation 참가자, story 첨부
 → has_project_access. team_member 봐주기 없음(resolve_member·has_project_access SSOT 재사용).
 
-보안(까심 P1): path 소속 검증은 **substring 금지·정확 매치**.
+보안(P1): path 소속 검증은 **substring 금지·정확 매치**.
 - ① 구조적 스코프: 업로드 경로가 `chat/<proj>/<conv_id>/<file>` / `story/<proj>/<story_id>/<file>`
   로 resource 에 스코프되므로, 요청 path 의 segment 에 해당 resource id 가 있어야 한다
   (metadata 에 임의 URL 을 심어도 victim path 는 victim 의 id 를 가지므로 차단).

--- a/backend/app/routers/public_docs.py
+++ b/backend/app/routers/public_docs.py
@@ -3,7 +3,7 @@
 ⚠️ 인증 Depends 를 의도적으로 생략한다(글로벌 auth 미들웨어 부재·per-route Depends 구조라
    생략=공개). opaque share token 만으로 단일 문서 read. 메타 누출 0·내부링크 비resolve 는
    FE 공개 뷰어가 담당. FE 프록시(`/api/public/docs/[token]`) + proxy.ts `PUBLIC_PREFIX` 등록은
-   미르코군 FE 레인.
+   FE 레인.
 """
 import uuid
 

--- a/backend/app/routers/team_presence.py
+++ b/backend/app/routers/team_presence.py
@@ -8,7 +8,7 @@
 ⚠️ working 집계는 멀티인스턴스 per-instance best-effort(`chat_presence` in-memory 한계 동일).
 마이그 불요(읽기 집계).
 
-응답 계약(FE 미르코 정합):
+응답 계약(FE 정합):
   GET /api/v2/team-presence → [
     {member_id, name, avatar_url, agent_role, runtime_type,
      presence_status: "online"|"idle"|"offline", working: bool,

--- a/backend/app/services/chat_presence.py
+++ b/backend/app/services/chat_presence.py
@@ -18,7 +18,7 @@ online")가 있어 ~180s 로 상향(env `CHAT_WORKING_TTL_SEC`). reply→즉시 
 
 ⚠️ 멀티인스턴스 한계: presence.py 와 동일하게 인스턴스-로컬 in-memory. 같은 인스턴스가 emit·GET
 을 처리해야 보인다. 크로스-인스턴스 실시간(Cloud Run 다인스턴스)은 pubsub/SSE 브로드캐스트가
-필요하며 FE 전송 설계(유나/미르코)와 함께 후속(P3)으로 다룬다.
+필요하며 FE 전송 설계와 함께 후속(P3)으로 다룬다.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## hygiene — 코드 주석 내부 멤버명 제거

production 코드/주석에 내부 멤버명 잔류 금지(비-비즈니스 언어 규칙·즉결대상)에 따른 sweep. 리뷰어/담당 크레딧으로 박힌 멤버명을 **기술 설명으로 치환**(주석 의미 동일·**코드 로직 무변**·diff는 주석/문자열만).

### Changes (7파일)
- **backend**: `team_presence.py`(FE 정합)·`public_docs.py`(FE 레인)·`attachments.py`(보안 P1)·`chat_presence.py`(FE 전송 설계).
- **apps/web**: `onboarding-form.tsx`(E-ONB S5 FINAL)·`add-member-modal.tsx`(CP4)·`memo-reply-webhook-dispatch.ts`(honorific 예시를 가공 이름으로).

### Scope
- 전역 grep 스윕 결과 **소스(비-test) 멤버명 0** 확인. `backend` import OK.
- ⚠️ **테스트 픽스처 제외**: `chat-input.test.ts`·`doc-comment-notifications.test.ts`·`memo-reply-webhook-dispatch.test.ts`가 @-mention 파싱 테스트에 실제 멤버명을 **기능적 입력 데이터**로 사용(크레딧 아님). 본 PR 범위 외 — 가공 이름으로 교체할지 별도 판단 필요(교체해도 테스트 semantics 동일하나 변경량↑).

🤖 Generated with [Claude Code](https://claude.com/claude-code)