### PR TITLE
chore: 코드 주석 내부 멤버명 제거 follow-up — 전역 0 (비-비즈니스 언어 규칙)

### DIFF
--- a/apps/web/src/app/api/conversations/[conversation_id]/working/route.ts
+++ b/apps/web/src/app/api/conversations/[conversation_id]/working/route.ts
@@ -2,7 +2,7 @@ import { type NextRequest } from 'next/server';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // 1aeecdde P2: GET /api/v2/conversations/{id}/working 프록시 — 지금 답장 생성 중(working) member 목록.
-// 디디 P2 BE(#1353 chat_presence·in-memory ephemeral) 폴링. FE는 이 결과로 "...is typing"/working ring 렌더.
+// P2 BE(#1353 chat_presence·in-memory ephemeral) 폴링. FE는 이 결과로 "...is typing"/working ring 렌더.
 export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ conversation_id: string }> },

--- a/apps/web/src/app/api/mcp/toolset-catalog/route.ts
+++ b/apps/web/src/app/api/mcp/toolset-catalog/route.ts
@@ -2,7 +2,7 @@ import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // E-MCP-RIGHT S1 (2da32fbf): toolset 권한 picker용 그룹 카탈로그 (SSOT).
-// BE `GET /api/v2/mcp/toolset-catalog` (디디 BE / S2 연장) 프록시. 미준비 시 BE 404 →
+// BE `GET /api/v2/mcp/toolset-catalog` (BE / S2 연장) 프록시. 미준비 시 BE 404 →
 // FE 훅(fetchToolsetCatalog)이 임시 상수로 폴백한다.
 export async function GET(request: Request) {
   const _r = await proxyToFastapi(request, '/api/v2/mcp/toolset-catalog');

--- a/apps/web/src/app/api/team-presence/route.ts
+++ b/apps/web/src/app/api/team-presence/route.ts
@@ -2,7 +2,7 @@ import { type NextRequest } from 'next/server';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // 2505d27d: GET /api/v2/team-presence 프록시 — org 전 에이전트 presence(연결)+working(작업) 집계.
-// 디디 #1356(team_presence.py)·폴링 GET. 팀 presence 패널이 소비. (/working 프록시 패턴 동형)
+// #1356(team_presence.py)·폴링 GET. 팀 presence 패널이 소비. (/working 프록시 패턴 동형)
 export async function GET(request: NextRequest): Promise<Response> {
   return proxyToFastapi(request, '/api/v2/team-presence');
 }

--- a/apps/web/src/components/activity/team-activity-view.tsx
+++ b/apps/web/src/components/activity/team-activity-view.tsx
@@ -12,7 +12,7 @@ import { getEventTypeCopy, KNOWN_EVENT_TYPE_VERBS } from '@/services/notificatio
 import { getEntityHref } from '@/components/chat/embed-card';
 import { cn } from '@/lib/utils';
 
-// ─── Types (BE ActivityStreamItem flat 실측 — 유나 doc §10 정정 정합) ──────────────
+// ─── Types (BE ActivityStreamItem flat 실측 — doc §10 정정 정합) ──────────────
 interface ActivityStreamItem {
   activity_id: string;
   project_id: string;

--- a/apps/web/src/components/cage/gate-evidence.tsx
+++ b/apps/web/src/components/cage/gate-evidence.tsx
@@ -13,8 +13,8 @@ import type { GateItem } from '@/components/kanban/types';
  * 플랫폼은 위험도 판단을 하지 않는다(neutral_facts = 관찰 사실).
  *
  * decision 배지 3종(BE decision = auto_merge|ask_human|block). gate status=pending(미transition)은
- * ask_human "확인 필요"로 통합(유나 정합 노트 — 별도 "대기" 배지 불필요). 리뷰 증거는 gate 응답에
- * 미노출이라 v1 제외(억지 "없음"=오정보·디디 follow-up). evidence_status는 배지 X·맥락 보조만.
+ * ask_human "확인 필요"로 통합(정합 노트 — 별도 "대기" 배지 불필요). 리뷰 증거는 gate 응답에
+ * 미노출이라 v1 제외(억지 "없음"=오정보·follow-up). evidence_status는 배지 X·맥락 보조만.
  */
 
 type Decision = 'auto_merge' | 'ask_human' | 'block';

--- a/apps/web/src/components/cage/story-merge-gate.tsx
+++ b/apps/web/src/components/cage/story-merge-gate.tsx
@@ -13,7 +13,7 @@ const MERGE_GATE_TYPE = 'merge';
  * (빈 섹션 미표시). 액션(승인/반려)은 surface①(GateInbox)에만 — 여기는 표시만.
  *
  * 데이터: GET /api/gates?work_item_id=<story>&work_item_type=story (raw 배열 패스스루). story↔gate
- * 매핑 단순(BE list_gates work_item_id 필터)이라 v1 포함(유나 기준·추가 BE 0).
+ * 매핑 단순(BE list_gates work_item_id 필터)이라 v1 포함(기준·추가 BE 0).
  */
 export function StoryMergeGate({ storyId }: { storyId: string }) {
   const t = useTranslations('cage');

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -55,7 +55,7 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   // S5: 미지원 런타임 커맨드 차단 hint — 트리거 메시지 id에 keyed된 ephemeral state.
   // POST 응답 command_gate.blocked에서만 적재(persist 안 함·reload 시 소멸).
   const [commandHints, setCommandHints] = useState<Record<string, BlockedHint[]>>({});
-  // 1aeecdde P2: 답장 생성 중 에이전트 typing — 디디 #1353 GET /working 폴링(BE 45s TTL) 결과.
+  // 1aeecdde P2: 답장 생성 중 에이전트 typing — #1353 GET /working 폴링(BE 45s TTL) 결과.
   const [typingAgents, setTypingAgents] = useState<{ id: string; name: string }[]>([]);
   // CB-S9: 스레드 패널 상태
   const [activeThread, setActiveThread] = useState<ChatMessage | null>(null);
@@ -191,7 +191,7 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
     fetchMessages();
   }, [fetchMessages]);
 
-  // 1aeecdde P2: working 폴링(디디 #1353 GET /working·in-memory 45s TTL) → typingAgents.
+  // 1aeecdde P2: working 폴링(#1353 GET /working·in-memory 45s TTL) → typingAgents.
   // 이름=commandTargets(없으면 미표시 graceful). poll이 BE working 셋 그대로 반영(클라 TTL 불요).
   const fetchWorking = useCallback(async () => {
     try {

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -266,7 +266,7 @@ turndown.addRule('blockquote', {
 // Order: <code> class (markdownToHtml output) → <pre> data-language / class (tiptap
 // getHTML + legacy). Belt-and-suspenders with the renderHTML fix in code-block-copy.tsx.
 // Find the <code> via element children rather than firstChild so a whitespace text node
-// between <pre> and <code> doesn't drop the rule to Turndown's default (디디 review note;
+// between <pre> and <code> doesn't drop the rule to Turndown's default (review note;
 // `children` is used instead of `:scope > code` which domino does not reliably support).
 const fenceCodeChild = (pre: HTMLElement): HTMLElement | null =>
   (Array.from(pre.children).find((c) => c.nodeName === 'CODE') as HTMLElement | undefined) ?? null;

--- a/apps/web/src/components/hypotheses/hypothesis-row.tsx
+++ b/apps/web/src/components/hypotheses/hypothesis-row.tsx
@@ -33,7 +33,7 @@ export function HypothesisRow({
   const t = useTranslations('hypotheses');
   const md = hypothesis.metric_definition;
   // 초안 = AI 템플릿 초안(draft_metadata.template===true)·아직 미확인. 핸드오프 §5 ⓐ 기준
-  // (PO 콜: FE 인터임 hack 금지. 디디 BE가 HypothesisResponse에 draft_metadata/drafted_by를
+  // (PO 콜: FE 인터임 hack 금지. BE가 HypothesisResponse에 draft_metadata/drafted_by를
   // additive 노출). 필드 노출 전엔 template이 undefined라 모든 proposed가 비-draft로 떨어져
   // [활성화] flow가 정상 동작하고, 노출되면 AI 초안만 핀/확인이 자연히 살아난다(revert 불필요).
   const draftMeta = hypothesis.draft_metadata as { template?: boolean; confirmed?: boolean } | null;

--- a/apps/web/src/components/presence/use-team-presence.ts
+++ b/apps/web/src/components/presence/use-team-presence.ts
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { PresenceStatus } from '@/components/chat/presence-dot';
 
-// 2505d27d: 디디 #1356 `GET /api/v2/team-presence` 응답 계약(검증 완료·mismatch 0).
+// 2505d27d: #1356 `GET /api/v2/team-presence` 응답 계약(검증 완료·mismatch 0).
 export interface TeamPresenceItem {
   member_id: string;
   name: string;

--- a/apps/web/src/lib/toolset-catalog.ts
+++ b/apps/web/src/lib/toolset-catalog.ts
@@ -2,7 +2,7 @@
  * E-MCP-RIGHT S1 (2da32fbf) — toolset 카탈로그 계약 (picker 데이터 SSOT).
  *
  * picker는 선택지(전체 그룹 + 그룹별 멤버 툴 + core/destructive 플래그)를 이 계약으로 받는다.
- * SSOT = BE `GET /api/v2/mcp/toolset-catalog` (디디 BE / S2 연장). FE 하드코딩 금지.
+ * SSOT = BE `GET /api/v2/mcp/toolset-catalog` (BE / S2 연장). FE 하드코딩 금지.
  *
  * BE 엔드포인트 준비 전까지는 골격 렌더용 임시 상수(TEMP_TOOLSET_CATALOG)로 폴백한다.
  * 그룹키·core/destructive 플래그는 `backend/app/services/mcp_toolset.py`(SSOT)와 정합하며,

--- a/backend/alembic/versions/0112_drop_redundant_project_access_member_index.py
+++ b/backend/alembic/versions/0112_drop_redundant_project_access_member_index.py
@@ -2,7 +2,7 @@
 
 0110(18073a52)이 `uq_project_access_project_member_id`(project_id, member_id WHERE member_id NOT NULL)
 를 신설했으나, baseline(0075)에 동일 정의 `uq_project_access_project_member_v2`가 이미 존재해 100%
-중복이었다(까심 CP2·기능 영향 0). 유일성은 v2 가 계속 enforce 하므로 0110 신설본만 drop.
+중복이었다(CP2·기능 영향 0). 유일성은 v2 가 계속 enforce 하므로 0110 신설본만 drop.
 
 backward-safe: 데이터 변화 0·v2 가 (project_id, member_id) 유일성 유지·구/신 코드 무영향.
 


### PR DESCRIPTION
## hygiene follow-up (#1509) — 멤버명 전역 0

#1509 후속. 언어 스캔 grep으로 추가 발견된 멤버명 주석을 **기술 설명으로 치환**(주석 의미 동일·**코드 로직 무변**·diff는 주석만). **전역 grep 결과 소스(비-test) 멤버명 0** 달성.

### Changes (12파일·+14/-14·전부 주석)
- **apps/web 11**: api 프록시 주석(toolset-catalog·working·team-presence)·hypothesis-row·chat-view·team-activity-view·story-merge-gate·gate-evidence·content-converter·use-team-presence·toolset-catalog. **이슈번호(#1353/#1356)·기술 맥락 유지·이름만 제거**.
- **alembic 0112**: 주석서 멤버명 제거(revision-id 추적이라 주석 편집 안전·로직 절대 무변).

### 범위 외 (별도 판단)
- 테스트 픽스처(@-mention 파싱 **기능 입력 데이터**·#1509에서 PO 확정=위반 아님).
- `backend/scripts` RUNBOOK(ops **역할분담 RACI** 문서·크레딧 주석과 성격 다름) — 정리 원하시면 별도.

🤖 Generated with [Claude Code](https://claude.com/claude-code)