### PR TITLE
fix(gate): claim_story가 implementation participation 생성 — attribution 갭 차단 (3414b6d7)

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -138,15 +138,13 @@ async def _attach_assignee_ids(
 async def _upsert_assignee_participation(
     session: AsyncSession, org_id: uuid.UUID, story_id: uuid.UUID, assignee_id: uuid.UUID
 ) -> None:
-    """assignee 설정 시 implementation(default) 역할 participation 자동 upsert (멱등)."""
-    from app.repositories.participation import ParticipationRepository, ParticipationRoleRepository
-    role_repo = ParticipationRoleRepository(session, org_id)
-    default_role = await role_repo.get_default()
-    if default_role is None:
-        return
-    p_repo = ParticipationRepository(session, org_id)
-    if not await p_repo.exists(story_id, assignee_id, default_role.id):
-        await p_repo.create(story_id=story_id, member_id=assignee_id, role_id=default_role.id)
+    """assignee 설정 시 implementation(default) 역할 participation 자동 upsert (멱등).
+
+    3414b6d7: 로직은 공유 helper로 추출 — claim 경로(team_members)와 동일 attribution 진입점.
+    """
+    from app.services.participation_helpers import ensure_implementation_participation
+
+    await ensure_implementation_participation(session, org_id, story_id, assignee_id)
 
 
 async def _preflight_merge_gate(

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -398,6 +398,10 @@ async def claim_story(
     # AC3-4 2-2: anchor-only — agent_project_profiles가 presence 유일 소스.
     from app.services.agent_anchor_sync import sync_agent_profile_presence
     await sync_agent_profile_presence(session, id, active_story_id=body.story_id, agent_status="online", last_seen_at=now)
+    # 3414b6d7: claim=일 시작=실작업자 → implementation participation 멱등 생성(게이트/verdict
+    # attribution). assignee(board)는 안 건드림 — participation만(claim만 하고 done해도 평가 가능).
+    from app.services.participation_helpers import ensure_implementation_participation
+    await ensure_implementation_participation(session, org_id, body.story_id, id)
     return {"claimed": True, "story_id": str(body.story_id)}
 
 

--- a/backend/app/services/participation_helpers.py
+++ b/backend/app/services/participation_helpers.py
@@ -1,0 +1,36 @@
+"""implementation participation 보장 공유 helper (3414b6d7).
+
+assignee 설정(stories.py)·story claim(team_members.py) 양 경로가 동일하게 implementation(default)
+역할 participation을 멱등 생성하도록 단일 helper로 추출 — 게이트/verdict attribution의 단일 진입점.
+claim만 하고 done해도 participation이 있어야 merge gate가 평가하고 outcome verdict가 귀속된다.
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def ensure_implementation_participation(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    story_id: uuid.UUID,
+    member_id: uuid.UUID,
+) -> bool:
+    """story에 member의 implementation(default) 역할 participation을 멱등 생성.
+
+    이미 있으면 no-op. default role 미시드면 skip(False). 생성/존재 시 True.
+    """
+    from app.repositories.participation import (
+        ParticipationRepository,
+        ParticipationRoleRepository,
+    )
+
+    role_repo = ParticipationRoleRepository(session, org_id)
+    default_role = await role_repo.get_default()
+    if default_role is None:
+        return False
+    p_repo = ParticipationRepository(session, org_id)
+    if not await p_repo.exists(story_id, member_id, default_role.id):
+        await p_repo.create(story_id=story_id, member_id=member_id, role_id=default_role.id)
+    return True

--- a/backend/tests/test_claim_participation.py
+++ b/backend/tests/test_claim_participation.py
@@ -1,0 +1,122 @@
+"""3414b6d7: claim/assignee가 implementation participation을 멱등 생성.
+
+claim=일 시작=실작업자 → 게이트/verdict attribution을 위해 implementation(default) 역할
+participation이 있어야 한다. ensure_implementation_participation(claim·assignee 공유 helper)이
+멱등 생성하는지 실DB로 검증.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(
+    not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)"
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _count_part(session, org, story_id, member_id):
+    from sqlalchemy import text as _text
+
+    return (await session.execute(
+        _text("SELECT count(*) FROM participation WHERE org_id=:o AND story_id=:s AND member_id=:m"),
+        {"o": org, "s": story_id, "m": member_id},
+    )).scalar()
+
+
+@pytest.mark.anyio
+async def test_ensure_implementation_participation_idempotent():
+    from sqlalchemy import text as _text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    from app.models.participation import ParticipationRole
+    from app.models.pm import Story
+    from app.services.participation_helpers import ensure_implementation_participation
+
+    url = _REAL_DB_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+        "postgresql://", "postgresql+asyncpg://"
+    )
+    engine = create_async_engine(url)
+    org, project, story_id, member = (uuid.uuid4() for _ in range(4))
+
+    async with engine.begin() as c:
+        await c.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add_all([
+                ParticipationRole(id=uuid.uuid4(), org_id=org, key="implementation", label="구현",
+                                  is_default=True),
+                Story(id=story_id, org_id=org, project_id=project, title="S", status="backlog"),
+            ])
+            await s.commit()
+
+        # ① claimer participation 생성(1건).
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            ok = await ensure_implementation_participation(s, org, story_id, member)
+            await s.commit()
+            assert ok is True
+        async with Session() as s:
+            assert await _count_part(s, org, story_id, member) == 1
+
+        # 멱등: 재호출해도 1건(중복 0).
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            await ensure_implementation_participation(s, org, story_id, member)
+            await s.commit()
+        async with Session() as s:
+            assert await _count_part(s, org, story_id, member) == 1
+    finally:
+        async with engine.begin() as c:
+            await c.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ensure_skips_when_no_default_role():
+    from sqlalchemy import text as _text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    from app.models.pm import Story
+    from app.services.participation_helpers import ensure_implementation_participation
+
+    url = _REAL_DB_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+        "postgresql://", "postgresql+asyncpg://"
+    )
+    engine = create_async_engine(url)
+    org, project, story_id, member = (uuid.uuid4() for _ in range(4))
+
+    async with engine.begin() as c:
+        await c.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add(Story(id=story_id, org_id=org, project_id=project, title="S", status="backlog"))
+            await s.commit()
+        # default role 미시드 → skip(False)·participation 0(거짓 attribution 금지).
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            ok = await ensure_implementation_participation(s, org, story_id, member)
+            await s.commit()
+            assert ok is False
+        async with Session() as s:
+            assert await _count_part(s, org, story_id, member) == 0
+    finally:
+        async with engine.begin() as c:
+            await c.run_sync(Base.metadata.drop_all)
+        await engine.dispose()


### PR DESCRIPTION
## 3414b6d7 — claim_story participation attribution 갭

**forward-verify 라이브 실측**: MCP `update_story(assignee_id)`는 participation 생성(**이미 정상**·06-12 이후 fix). 핵심 갭은 **`claim_story`** — `POST /team-members/{id}/claim`이 `active_story_id`만 갱신하고 implementation participation을 안 만들어, **claim만 하고 done하면 merge gate row 0(평가 불가)·outcome verdict 귀속 실패**(닫힌루프 attribution 구멍).

### Changes
- **`services/participation_helpers.ensure_implementation_participation`** 추출: default 역할 participation 멱등 생성. assignee 설정(stories.py)·claim(team_members.py) **단일 진입점·드리프트 0**.
- **claim 엔드포인트**: `active_story_id` sync 후 `ensure_implementation_participation(claimer)` 호출. **assignee(board)는 안 건드림** — participation만(claim=실작업자 attribution).
- `stories.py _upsert_assignee_participation`는 helper로 위임(동작 동형).

### AC
- ① claim 후 claimer implementation participation 1건 ② claim→done 시 gate가 participation 기반 발화 ③ update_story 경로 미회귀 ④ default 미시드면 skip(거짓 attribution 금지) ⑤ DB 0.

### Validation
- ⭐**실DB 2**(claim helper 멱등 생성·default 없으면 skip+0) + claim/participation 회귀 **73 PASS**·`app.main` import OK.

> 라이브 실측(throwaway 2개·정리됨): update_story(assignee_id)→gate row 1(participation 有)·claim_story→gate row 0/assignee None(participation 無). 이 fix로 claim 경로도 participation 생성. 까심 QA(5.5)→PO 머지. A 마지막 real 조각.

🤖 Generated with [Claude Code](https://claude.com/claude-code)