### PR TITLE
fix(inject-adapters)[P1·어댑터A]: hermes 어댑터 fresh-install 온보딩 보완 (8d823891)

### DIFF
--- a/apps/web/public/onboarding-guide.txt
+++ b/apps/web/public/onboarding-guide.txt
@@ -182,7 +182,10 @@ hermes plugins enable sprintable-platform
 
 # 3. Env (required + optional).
 export AGENT_API_KEY=sk_live_...                # required
-export SPRINTABLE_API_URL=https://app.sprintable.ai
+# Leave SPRINTABLE_API_URL UNSET for the dev backend (the default). To pin it,
+# use the DEV backend base URL — not the app/prod domain — so a dev onboard
+# never dials out to prod. Prod is the separate hermes-sprintable-prod plugin.
+# export SPRINTABLE_API_URL=https://sprintable-backend-dev-57iommnikq-du.a.run.app
 # Multi-agent teams: leave the allowlist UNSET so the agent receives messages from ALL
 # members (recommended default). Setting SPRINTABLE_ALLOWED_USERS restricts inbound to only
 # those sender member_ids — every other teammate (human or agent) is then silently ignored.

--- a/apps/web/public/onboarding-guide.txt
+++ b/apps/web/public/onboarding-guide.txt
@@ -159,14 +159,28 @@ and backoff are handled by the shared SDK; you only supply the runtime's injecti
 
 ### Example: Hermes
 
+> **The gateway adapter is not the MCP server.** A successful `sprintable` MCP
+> `ping` only proves the PM API tools are reachable — it does NOT mean the agent
+> is *receiving* conversation messages. Receiving requires this plugin loaded and
+> dialed out; verify with the checklist below, not with an MCP ping. The two
+> channels use different env vars: gateway = `AGENT_API_KEY`, MCP =
+> `PM_API_KEY`/`PM_API_URL`/`PM_PROJECT_ID`.
+
+The plugin folder is **self-contained** (the inject allow-list is vendored), so
+copying just the folder is enough — no separate `connectors/sdk` step. Requires
+**Hermes ≥ v0.13.0**.
+
 ```bash
-git pull origin main
+git pull origin develop
 
-# Deploy the plugin (symlink recommended)
-ln -sf "$(pwd)/connectors/hermes-sprintable" ~/.hermes/plugins/sprintable
+# 1. Deploy the plugin folder (copy is safest on a fresh box).
+cp -r connectors/hermes-sprintable ~/.hermes/plugins/sprintable
+#    or, from a full checkout: ln -sf "$(pwd)/connectors/hermes-sprintable" ~/.hermes/plugins/sprintable
 
+# 2. Enable by the plugin.yaml `name:` (sprintable-platform), NOT the folder name.
 hermes plugins enable sprintable-platform
 
+# 3. Env (required + optional).
 export AGENT_API_KEY=sk_live_...                # required
 export SPRINTABLE_API_URL=https://app.sprintable.ai
 # Multi-agent teams: leave the allowlist UNSET so the agent receives messages from ALL
@@ -175,8 +189,20 @@ export SPRINTABLE_API_URL=https://app.sprintable.ai
 # export SPRINTABLE_ALLOWED_USERS=0caee743,...  # OPTIONAL — restrict to specific sender member_ids
 # export SPRINTABLE_ALLOW_ALL_USERS=1           # explicit allow-all (same effect as leaving it unset)
 
+# 4. Restart, then confirm the gateway side is live.
 hermes gateway restart
 ```
+
+**Verify (the real "connected" test)** — tail `~/.hermes/gateway.log` and expect,
+in order: `dial-out …/api/v2/agent/stream` → `stream open` → (send a test message)
+`inbound seq=N` → one reply posted back → `ack seq=N`. After a restart there must
+be **no re-injection** of already-acked messages.
+
+**Dev + prod side by side:** install `connectors/hermes-sprintable-prod` as a
+second plugin (enable `sprintable-prod-platform`). It uses `SPRINTABLE_PROD_*`
+env vars so prod credentials/home channel never cross with dev.
+
+Full detail, env-group reference and troubleshooting: `connectors/hermes-sprintable/README.md`.
 
 ### Direct integration — shared SDK
 

--- a/connectors/README.md
+++ b/connectors/README.md
@@ -8,12 +8,22 @@ connectors/
     sprintable_sse.py       # Python SDK
     sprintable-sse.ts       # TypeScript/Bun SDK
     README.md
-  hermes-sprintable/        # 카테고리 A: Hermes Agent 어댑터
+  hermes-sprintable/        # 카테고리 A: Hermes Agent 어댑터 (dev backend)
     plugin.yaml
+    __init__.py
+    adapter.py              # self-contained — inject allow-list vendored
+    README.md
+  hermes-sprintable-prod/   # 카테고리 A: Hermes Agent 어댑터 (prod backend)
+    plugin.yaml             # SPRINTABLE_PROD_* 전용 self-contained 클론
     __init__.py
     adapter.py
     README.md
 ```
+
+> 각 어댑터 폴더는 **자기완결**이다. fresh 온보딩은 폴더 하나만 복사하므로 sibling
+> `sdk`를 import하면 ImportError로 미로딩된다(과거 P0). 주입 allow-list는 SDK가
+> canonical 출처이되 어댑터에 vendor하며, `sdk/test_inject_allowlist.py`가 양측
+> 동기를 가드한다.
 
 ---
 
@@ -79,7 +89,8 @@ POST /api/v2/agent/events/ack
 
 | 카테고리 | 런타임 | 주입 방식 | 디렉토리 |
 |----------|--------|-----------|----------|
-| **A** | Hermes Agent (Python) | `handle_message()` → 세션 주입 | `connectors/hermes-sprintable/` |
+| **A** | Hermes Agent — dev (Python) | `handle_message()` → 세션 주입 | `connectors/hermes-sprintable/` |
+| **A** | Hermes Agent — prod (Python) | `handle_message()` → 세션 주입 (`SPRINTABLE_PROD_*`) | `connectors/hermes-sprintable-prod/` |
 | **B** | Claude Code (MCP) | `notifications/claude/channel` emit | `packages/fakechat/server.ts` |
 | **C** | 기타 (Codex, Gemini, Cursor, OpenClaw 등) | 런타임별 주입 API | `connectors/{runtime}-sprintable/` |
 

--- a/connectors/hermes-sprintable-prod/README.md
+++ b/connectors/hermes-sprintable-prod/README.md
@@ -1,0 +1,44 @@
+# Sprintable Prod Adapter for Hermes Agent
+
+Prod-backend variant of [`../hermes-sprintable`](../hermes-sprintable/README.md).
+Behaviour is identical; it is a **self-contained clone** keyed entirely on
+`SPRINTABLE_PROD_*` env vars so prod credentials, home channel and cron delivery
+never cross with the dev plugin. Install this **in addition** to the dev plugin
+when one Hermes agent must run dev and prod side by side.
+
+> Why a clone and not a shared module? AC1 requires each plugin folder to load
+> standalone from a single-folder copy (no sibling imports), so the two adapters
+> cannot share a Python module. Keep behavioural changes in sync with the dev
+> adapter; the inject allow-list is guarded against drift by
+> `connectors/sdk/test_inject_allowlist.py`.
+
+## Install
+
+```bash
+cp -r connectors/hermes-sprintable-prod ~/.hermes/plugins/sprintable_prod
+hermes plugins enable sprintable-prod-platform      # plugin.yaml `name:`, not folder
+
+export SPRINTABLE_PROD_AGENT_API_KEY=sk_live_...     # required (prod key)
+export SPRINTABLE_PROD_API_URL=https://...           # default: prod backend
+
+hermes gateway restart
+tail -f ~/.hermes/gateway.log                        # watch [sprintable_prod] dial-out → stream open
+```
+
+## Environment variables
+
+| Var | Req | Meaning |
+|-----|-----|---------|
+| `SPRINTABLE_PROD_AGENT_API_KEY` | ✅ | Prod agent API key (Bearer) |
+| `SPRINTABLE_PROD_API_URL` | — | Prod backend base URL (default: prod backend) |
+| `SPRINTABLE_PROD_ALLOWED_USERS` | — | Comma-sep member IDs allowed. Unset = all |
+| `SPRINTABLE_PROD_ALLOW_ALL_USERS` | — | `1` = explicit allow-all |
+| `SPRINTABLE_PROD_HOME_CHANNEL` | — | Default conversation_id for cron/notify (`/sethome`) |
+| `SPRINTABLE_PROD_HOME_CHANNEL_THREAD_ID` | — | Thread id for the prod home channel |
+
+Platform name: `sprintable_prod`. Cron delivery target: `deliver=sprintable_prod`.
+
+For the channel-vs-MCP distinction, the full onboarding path and the verification
+checklist, see the dev plugin's
+[README](../hermes-sprintable/README.md) — everything there applies, just with
+the `SPRINTABLE_PROD_*` env names and `[sprintable_prod]` log lines.

--- a/connectors/hermes-sprintable-prod/__init__.py
+++ b/connectors/hermes-sprintable-prod/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import register
+
+__all__ = ["register"]

--- a/connectors/hermes-sprintable-prod/adapter.py
+++ b/connectors/hermes-sprintable-prod/adapter.py
@@ -1,6 +1,6 @@
-"""Sprintable platform adapter (Hermes plugin).
+"""Sprintable **prod** platform adapter (Hermes plugin).
 
-Dial-out last-mile injection adapter for the Sprintable Agent Gateway.
+Dial-out last-mile injection adapter for the Sprintable prod Agent Gateway.
 Holds a long-lived OUTBOUND SSE connection to ``GET /api/v2/agent/stream``
 (no inbound domain / tunnel required), injects each delivered platform
 message into the running hermes session as a new turn via
@@ -12,16 +12,20 @@ Mirrors the ntfy plugin's HTTP-streaming pattern; the only differences are
 SSE framing (event:/id:/data:) and the ack POST.
 
 Config (env wins over config.yaml ``extra``):
-    AGENT_API_KEY                  Agent API key (Bearer) — required
-    SPRINTABLE_API_URL             Backend base URL (default: dev backend)
-    SPRINTABLE_ALLOWED_USERS       Comma-sep member IDs allowed to trigger (opt)
-    SPRINTABLE_ALLOW_ALL_USERS     "1" to bypass the allowlist (opt)
-    SPRINTABLE_HOME_CHANNEL        Default conversation_id for cron/notify (opt)
-    SPRINTABLE_HOME_CHANNEL_THREAD_ID  Thread id for the home channel (opt)
+    SPRINTABLE_PROD_AGENT_API_KEY           Agent API key (Bearer) — required
+    SPRINTABLE_PROD_API_URL                 Backend base URL (default: prod backend)
+    SPRINTABLE_PROD_ALLOWED_USERS           Comma-sep member IDs allowed (opt)
+    SPRINTABLE_PROD_ALLOW_ALL_USERS         "1" to bypass the allowlist (opt)
+    SPRINTABLE_PROD_HOME_CHANNEL            Default conversation_id for cron/notify (opt)
+    SPRINTABLE_PROD_HOME_CHANNEL_THREAD_ID  Thread id for the home channel (opt)
 
-This is the **dev** Sprintable platform.  The prod backend uses a separate,
-self-contained plugin (``connectors/hermes-sprintable-prod``) with
-``SPRINTABLE_PROD_*`` env vars so dev and prod credentials never cross.
+This is the **prod** Sprintable platform.  It is a self-contained clone of
+``connectors/hermes-sprintable`` (the dev plugin) keyed entirely on
+``SPRINTABLE_PROD_*`` env vars so dev and prod credentials, home channels and
+cron delivery targets never cross.  The duplication is intentional: AC1
+requires each plugin folder to load standalone (no sibling imports), so the
+two adapters cannot share a module.  Keep behavioural changes in sync with
+the dev adapter.
 """
 
 import asyncio
@@ -78,42 +82,42 @@ from gateway.platforms.base import (
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_API_URL = "https://sprintable-backend-dev-57iommnikq-du.a.run.app"
+DEFAULT_API_URL = "https://sprintable-backend-prod-57iommnikq-du.a.run.app"
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 STREAM_READ_TIMEOUT = 90  # gateway heartbeats keep the stream alive
 DEDUP_MAX_SIZE = 1000
 
 
 def _api_url() -> str:
-    return (os.getenv("SPRINTABLE_API_URL", DEFAULT_API_URL) or DEFAULT_API_URL).rstrip("/")
+    return (os.getenv("SPRINTABLE_PROD_API_URL", DEFAULT_API_URL) or DEFAULT_API_URL).rstrip("/")
 
 
 def check_requirements() -> bool:
     if not HTTPX_AVAILABLE:
         return False
-    return bool(os.getenv("AGENT_API_KEY", "").strip())
+    return bool(os.getenv("SPRINTABLE_PROD_AGENT_API_KEY", "").strip())
 
 
 def validate_config(config) -> bool:
     extra = getattr(config, "extra", {}) or {}
-    return bool(extra.get("api_key") or os.getenv("AGENT_API_KEY", "").strip())
+    return bool(extra.get("api_key") or os.getenv("SPRINTABLE_PROD_AGENT_API_KEY", "").strip())
 
 
 def is_connected(config) -> bool:
     extra = getattr(config, "extra", {}) or {}
-    return bool(extra.get("api_key") or os.getenv("AGENT_API_KEY", "").strip())
+    return bool(extra.get("api_key") or os.getenv("SPRINTABLE_PROD_AGENT_API_KEY", "").strip())
 
 
-class SprintableAdapter(BasePlatformAdapter):
+class SprintableProdAdapter(BasePlatformAdapter):
     """Sprintable Agent Gateway dial-out adapter."""
 
     def __init__(self, config: PlatformConfig):
-        platform = Platform("sprintable")
+        platform = Platform("sprintable_prod")
         super().__init__(config=config, platform=platform)
 
         extra = config.extra or {}
         self._api_url: str = (extra.get("api_url") or _api_url()).rstrip("/")
-        self._api_key: str = extra.get("api_key") or os.getenv("AGENT_API_KEY", "")
+        self._api_key: str = extra.get("api_key") or os.getenv("SPRINTABLE_PROD_AGENT_API_KEY", "")
 
         self._stream_task: Optional[asyncio.Task] = None
         self._http_client: Optional["httpx.AsyncClient"] = None
@@ -128,7 +132,7 @@ class SprintableAdapter(BasePlatformAdapter):
             logger.warning("[%s] httpx not installed", self.name)
             return False
         if not self._api_key:
-            logger.warning("[%s] AGENT_API_KEY not configured", self.name)
+            logger.warning("[%s] SPRINTABLE_PROD_AGENT_API_KEY not configured", self.name)
             return False
         try:
             self._http_client = httpx.AsyncClient(timeout=None)
@@ -263,7 +267,7 @@ class SprintableAdapter(BasePlatformAdapter):
         # /conversations/{chat_id}/messages.
         source = self.build_source(
             chat_id=conversation_id,
-            chat_name=payload.get("conversation_title") or "Sprintable",
+            chat_name=payload.get("conversation_title") or "Sprintable Prod",
             chat_type="thread",
             thread_id=conversation_id,
             user_id=sender_id,
@@ -345,22 +349,22 @@ class SprintableAdapter(BasePlatformAdapter):
 # ---------------------------------------------------------------------------
 
 def _env_enablement() -> dict | None:
-    key = os.getenv("AGENT_API_KEY", "").strip()
+    key = os.getenv("SPRINTABLE_PROD_AGENT_API_KEY", "").strip()
     if not key:
         return None
     seed = {"api_url": _api_url(), "api_key": key}
 
     # AC2/AC3: let ``/sethome`` persist for this plugin platform the same way it
-    # does for built-ins.  ``gateway.run`` saves SPRINTABLE_HOME_CHANNEL(_THREAD_ID)
+    # does for built-ins.  ``gateway.run`` saves SPRINTABLE_PROD_HOME_CHANNEL(_THREAD_ID)
     # to .env and ``gateway.config`` promotes this dict into
     # ``PlatformConfig.home_channel`` on the next load/restart, so cron/notify
     # delivery has a default target without a manual edit.
-    home_channel = os.getenv("SPRINTABLE_HOME_CHANNEL", "").strip()
+    home_channel = os.getenv("SPRINTABLE_PROD_HOME_CHANNEL", "").strip()
     if home_channel:
         seed["home_channel"] = {
             "chat_id": home_channel,
-            "name": os.getenv("SPRINTABLE_HOME_CHANNEL_NAME", "Sprintable"),
-            "thread_id": os.getenv("SPRINTABLE_HOME_CHANNEL_THREAD_ID") or None,
+            "name": os.getenv("SPRINTABLE_PROD_HOME_CHANNEL_NAME", "Sprintable Prod"),
+            "thread_id": os.getenv("SPRINTABLE_PROD_HOME_CHANNEL_THREAD_ID") or None,
         }
 
     return seed
@@ -369,18 +373,18 @@ def _env_enablement() -> dict | None:
 def register(ctx) -> None:
     """Plugin entry point — called by the Hermes plugin system at startup."""
     ctx.register_platform(
-        name="sprintable",
-        label="Sprintable",
-        adapter_factory=lambda cfg: SprintableAdapter(cfg),
+        name="sprintable_prod",
+        label="Sprintable Prod",
+        adapter_factory=lambda cfg: SprintableProdAdapter(cfg),
         check_fn=check_requirements,
         validate_config=validate_config,
         is_connected=is_connected,
-        required_env=["AGENT_API_KEY"],
-        allowed_users_env="SPRINTABLE_ALLOWED_USERS",
-        allow_all_env="SPRINTABLE_ALLOW_ALL_USERS",
+        required_env=["SPRINTABLE_PROD_AGENT_API_KEY"],
+        allowed_users_env="SPRINTABLE_PROD_ALLOWED_USERS",
+        allow_all_env="SPRINTABLE_PROD_ALLOW_ALL_USERS",
         install_hint="pip install httpx   # already a Hermes dependency",
         env_enablement_fn=_env_enablement,
-        cron_deliver_env_var="SPRINTABLE_HOME_CHANNEL",
+        cron_deliver_env_var="SPRINTABLE_PROD_HOME_CHANNEL",
         emoji="🏃",
         pii_safe=False,
         allow_update_command=True,

--- a/connectors/hermes-sprintable-prod/plugin.yaml
+++ b/connectors/hermes-sprintable-prod/plugin.yaml
@@ -1,0 +1,38 @@
+name: sprintable-prod-platform
+label: Sprintable Prod
+kind: platform
+version: 1.0.0
+description: >
+  Prod Sprintable Agent Gateway dial-out adapter for Hermes Agent.
+  Self-contained clone of the dev `sprintable-platform` plugin, keyed entirely
+  on SPRINTABLE_PROD_* env vars so prod SSE/API credentials, home channel and
+  cron delivery stay isolated from the dev Sprintable plugin. Install this in
+  ADDITION to the dev plugin when an agent must run dev and prod side by side.
+  httpx only.
+author: ortega/santiago
+requires_env:
+  - name: SPRINTABLE_PROD_AGENT_API_KEY
+    description: "Sprintable prod agent API key (Bearer)"
+    prompt: "Sprintable prod agent API key"
+    password: true
+optional_env:
+  - name: SPRINTABLE_PROD_API_URL
+    description: "Sprintable prod backend base URL (default: prod backend)"
+    prompt: "Sprintable prod API URL (or empty for prod default)"
+    password: false
+  - name: SPRINTABLE_PROD_ALLOWED_USERS
+    description: "Comma-separated Sprintable team_member IDs allowed to trigger replies. Empty = allow all."
+    prompt: "Allowed Sprintable prod member IDs (comma-sep, or empty for all)"
+    password: false
+  - name: SPRINTABLE_PROD_ALLOW_ALL_USERS
+    description: "Set to '1' or 'true' to allow all senders regardless of SPRINTABLE_PROD_ALLOWED_USERS."
+    prompt: "Allow all users? (1=yes)"
+    password: false
+  - name: SPRINTABLE_PROD_HOME_CHANNEL
+    description: "Default conversation_id for cron/notification delivery (deliver=sprintable_prod). Usually set via /sethome."
+    prompt: "Prod home conversation_id (or empty)"
+    password: false
+  - name: SPRINTABLE_PROD_HOME_CHANNEL_THREAD_ID
+    description: "Thread id for the prod home channel (Sprintable conversations are thread-scoped)."
+    prompt: "Prod home channel thread_id (or empty)"
+    password: false

--- a/connectors/hermes-sprintable/README.md
+++ b/connectors/hermes-sprintable/README.md
@@ -1,53 +1,198 @@
 # Sprintable Adapter for Hermes Agent
 
-Hermes Agent용 Sprintable Gateway dial-out 어댑터.
-SSE dial-out → 세션 주입 → ack → 응답 전 체인. 웹훅·터널 불필요.
+Dial-out gateway adapter that connects a **Hermes Agent** runtime to a Sprintable
+project: it holds a long-lived OUTBOUND SSE connection to the Sprintable Agent
+Gateway, injects each delivered message into the running Hermes session as a new
+turn, posts the agent's reply back, and acks consumed events. No inbound domain,
+webhook, or tunnel is required (works behind NAT).
 
-라이브 검증 완료: 산티아고(Santiago) 환경에서 dial-out→주입→ack→응답 전 체인 실증됨.
+```
+GET /api/v2/agent/stream (SSE, long-lived dial-out)
+  → _on_event() → handle_message()        # inject as a Hermes turn
+  → send() → POST /api/v2/conversations/{id}/messages   # reply
+  → _send_ack(seq) → POST /api/v2/agent/events/ack       # advance cursor
+```
 
-## 설치
+---
+
+## ⚠️ The gateway adapter is NOT the MCP server
+
+A Hermes agent talks to Sprintable through **two independent channels**. Getting
+one working does not mean the other is:
+
+| | Gateway adapter (this plugin) | MCP server (`sprintable` tools) |
+|---|---|---|
+| Purpose | **Receives** messages, **replies** | Calls PM API tools (create story, send chat, …) |
+| Transport | Outbound SSE `GET /api/v2/agent/stream` | MCP stdio / tool calls |
+| Auth env | `AGENT_API_KEY` (`sk_live_…`) | `PM_API_KEY`, `PM_API_URL`, `PM_PROJECT_ID` |
+| "It works" signal | `stream open` in `gateway.log` + a real reply round-trip | `ping` returns ok |
+
+> **A successful MCP `ping` does NOT mean the agent is connected to the gateway.**
+> MCP ping only proves the PM API tools are reachable. If this plugin is not
+> loaded and dialed out, the agent will never *receive* a single conversation
+> message — it can only push. Verify the gateway side with the checklist below,
+> not with an MCP ping.
+
+---
+
+## Requirements
+
+- **Hermes Agent ≥ v0.13.0** — needs the plugin platform registry with the
+  `env_enablement_fn` / `cron_deliver_env_var` hooks and `home_channel`
+  promotion (introduced in v0.13.0, #21306/#21331). On older builds the plugin
+  still injects/replies, but env-only auto-enable, `/sethome` and cron delivery
+  won't surface — see [Vendoring fallback](#vendoring-fallback-pre-v0130).
+- `httpx` (already a Hermes dependency).
+- An agent **API key** (`sk_live_…`) issued by your operator. See the public
+  onboarding guide (`apps/web/public/onboarding-guide.txt`, Step 1) for how a
+  human operator registers the agent and mints the key — an agent cannot mint
+  its own.
+
+---
+
+## Install (full path — do every step)
+
+The plugin folder is **self-contained**: the inject allow-list is vendored into
+`adapter.py`, so copying this one folder is enough (no sibling `connectors/sdk`
+needed). The earlier "symlink the folder" instruction used to break here because
+the adapter imported `sprintable_sse` from `../sdk`, which is absent in a
+single-folder install — that is fixed; the folder now loads standalone.
 
 ```bash
-# 1. git pull (레포 최신화)
+# 1. Get the adapter onto the machine (full repo checkout OR copy this folder)
 git pull origin develop
 
-# 2. 플러그인 배포 (심링크 권장)
-ln -sf "$(pwd)/connectors/hermes-sprintable" ~/.hermes/plugins/sprintable
-
-# 또는 복사
+# 2. Deploy the plugin into the Hermes plugin dir.
+#    Copy is the safest for a fresh box; symlink is fine from a full checkout.
 cp -r connectors/hermes-sprintable ~/.hermes/plugins/sprintable
+#   or, from a full repo checkout:
+# ln -sf "$(pwd)/connectors/hermes-sprintable" ~/.hermes/plugins/sprintable
 
-# 3. Hermes에서 활성화
+# 3. Enable by the plugin.yaml `name:` — NOT the folder name.
+#    The folder is "sprintable"; the plugin name is "sprintable-platform".
 hermes plugins enable sprintable-platform
 
-# 4. 환경 변수 설정
-export AGENT_API_KEY=sk_live_...            # Sprintable agent API key (필수)
-export SPRINTABLE_API_URL=https://...       # Backend URL (미설정 시 dev 기본값)
-export SPRINTABLE_ALLOWED_USERS=0caee743,...  # 허용 member_id (comma-sep, 미설정 시 전체 허용)
-# export SPRINTABLE_ALLOW_ALL_USERS=1       # 모든 발신자 허용 (allowlist 우회)
+# 4. Configure env (see the env table below).
+export AGENT_API_KEY=sk_live_...                       # required
+export SPRINTABLE_API_URL=https://app.sprintable.ai    # dev backend if unset
 
-# 5. Hermes 재시작
+# 5. Restart the gateway so the plugin loads and dials out.
 hermes gateway restart
+
+# 6. Confirm the gateway side is actually live (do NOT rely on an MCP ping).
+tail -f ~/.hermes/gateway.log    # watch for the lines in the checklist below
 ```
 
-## 동작 원리
+> Direct (non-Hermes) integration only: if instead of this plugin you build on
+> the shared SDK, also copy `connectors/sdk/`. The Hermes plugin does **not**
+> need it.
+
+### Enable target gotcha
+
+`hermes plugins enable <X>` takes the **`name:` from `plugin.yaml`**
+(`sprintable-platform`), not the install folder name (`sprintable`). Enabling
+`sprintable` (the folder) is a silent no-op.
+
+---
+
+## Environment variables — keep the three groups separate
+
+Mixing these three is the most common onboarding failure. They are NOT
+interchangeable.
+
+### Group 1 — dev gateway adapter (this plugin)
+
+| Var | Req | Meaning |
+|-----|-----|---------|
+| `AGENT_API_KEY` | ✅ | Agent API key (Bearer), `sk_live_…` |
+| `SPRINTABLE_API_URL` | — | Backend base URL (default: dev backend) |
+| `SPRINTABLE_ALLOWED_USERS` | — | Comma-sep member IDs allowed to trigger. **Unset = all** |
+| `SPRINTABLE_ALLOW_ALL_USERS` | — | `1` = explicit allow-all (same as unset) |
+| `SPRINTABLE_HOME_CHANNEL` | — | Default conversation_id for cron/notify. Usually set via `/sethome` |
+| `SPRINTABLE_HOME_CHANNEL_THREAD_ID` | — | Thread id for the home channel |
+
+### Group 2 — prod gateway adapter (separate `hermes-sprintable-prod` plugin)
+
+Install `connectors/hermes-sprintable-prod` **in addition** to run dev and prod
+side by side. It is keyed entirely on `SPRINTABLE_PROD_*`
+(`SPRINTABLE_PROD_AGENT_API_KEY`, `SPRINTABLE_PROD_API_URL`,
+`SPRINTABLE_PROD_HOME_CHANNEL[_THREAD_ID]`) so credentials, home channel and
+cron delivery never cross with dev. See
+[`../hermes-sprintable-prod/README.md`](../hermes-sprintable-prod/README.md).
+
+### Group 3 — MCP server (PM API tools — a different channel)
+
+`PM_API_URL`, `PM_API_KEY`, `PM_PROJECT_ID`. These configure the `sprintable`
+MCP tools, **not** this adapter. Setting them does nothing for message delivery;
+setting `AGENT_API_KEY` does nothing for the MCP tools.
+
+---
+
+## Verification checklist (this is the real "connected" test)
+
+Watch `~/.hermes/gateway.log` after `hermes gateway restart`. A healthy onboard
+shows every line, in order:
 
 ```
-GET /api/v2/agent/stream (SSE, long-lived)
-  → _on_event() → handle_message() → 세션 주입
-  → send() → POST /api/v2/conversations/{id}/messages
-  → _send_ack(seq) → POST /api/v2/agent/events/ack
+[sprintable] Connected — dial-out to https://.../api/v2/agent/stream
+[sprintable] stream open
+[sprintable] inbound seq=N conv=<id>: <message text>     # after you send a test message
+[sprintable] ack seq=N
 ```
 
-- `Last-Event-ID` 헤더로 reconnect 커서 유지
-- contiguous-ack: seq <= _last_acked 중복 skip
-- event_id 기반 dedup (300s TTL)
-- Exponential backoff 재연결
+1. **dial-out** line appears → plugin loaded + API key accepted.
+2. **stream open** → the SSE connection is live (this, not MCP ping, is "connected").
+3. Send a message into a conversation the agent belongs to → **inbound seq=N** appears.
+4. The agent replies → exactly **one** message posts back to the conversation.
+5. **ack seq=N** appears → cursor advanced.
+6. Restart the gateway → on reconnect there is **no re-injection** of already-acked
+   messages (no backfill flood). If old messages re-inject, ack is not landing.
 
-## 파일
+If you see `dial-out` but never `stream open`, the API key/URL is wrong. If you
+see neither, the plugin did not load — re-check step 3 (enabled by `name:`, not
+folder) and the import (`grep -i sprintable ~/.hermes/gateway.log` for a
+traceback).
 
-| 파일 | 역할 |
+---
+
+## Behaviour notes
+
+- **Session model**: a Sprintable conversation is mapped to a shared Hermes
+  *thread* (`chat_type="thread"`, `thread_id == conversation_id`), so all
+  participants share one conversation-scoped session instead of Hermes' default
+  per-sender group split.
+- **Inject allow-list**: only "recommended" event types are injected as work
+  turns (`dispatched`, `story_assigned`, `conversation.message_created`,
+  `conversation:mention`, `kickoff`, `review_request`, `qa_request`,
+  `deploy_request`, `handoff`). FYI events (status changes, etc.) are dropped
+  even if they carry text. The canonical list lives in
+  `connectors/sdk/sprintable_sse.py` and is vendored here; a contract test
+  (`connectors/sdk/test_inject_allowlist.py`) guards the two against drift.
+- **Dedup / ack / reconnect**: `event_id` dedup (300s TTL), contiguous ack
+  (`seq <= last_acked` is a no-op), `Last-Event-ID` reconnect cursor,
+  exponential backoff.
+- **One inbound channel only**: if an external webhook (e.g. Discord) is already
+  delivering the same conversation, don't also dial out — keep exactly one
+  active to avoid double delivery.
+
+---
+
+## Vendoring fallback (pre-v0.13.0)
+
+If you must run an older Hermes that lacks `env_enablement_fn` /
+`cron_deliver_env_var` / `home_channel` promotion, the adapter still loads and
+injects/replies, but you lose env-only auto-enable, `/sethome` persistence and
+`deliver=sprintable` cron routing. Either upgrade to ≥ v0.13.0 (recommended), or
+register the platform manually in your gateway bootstrap and set the home
+channel directly in `config.yaml`. The inject allow-list is already vendored, so
+there is never a `sprintable_sse` import to satisfy.
+
+---
+
+## Files
+
+| File | Role |
 |------|------|
-| `plugin.yaml` | Hermes 플러그인 메타데이터 |
-| `__init__.py` | 플러그인 entry point |
-| `adapter.py` | SprintableAdapter 구현 |
+| `plugin.yaml` | Hermes plugin metadata (`name: sprintable-platform`) |
+| `__init__.py` | Plugin entry point (`register`) |
+| `adapter.py` | `SprintableAdapter` — self-contained (allow-list vendored) |

--- a/connectors/hermes-sprintable/README.md
+++ b/connectors/hermes-sprintable/README.md
@@ -74,7 +74,11 @@ hermes plugins enable sprintable-platform
 
 # 4. Configure env (see the env table below).
 export AGENT_API_KEY=sk_live_...                       # required
-export SPRINTABLE_API_URL=https://app.sprintable.ai    # dev backend if unset
+# Leave SPRINTABLE_API_URL UNSET for the dev backend (the default). Only pin it
+# to the DEV backend base URL — never the app/prod domain — or a dev onboard
+# would silently dial out to prod:
+# export SPRINTABLE_API_URL=https://sprintable-backend-dev-57iommnikq-du.a.run.app
+# (Prod is a separate plugin: connectors/hermes-sprintable-prod, SPRINTABLE_PROD_*.)
 
 # 5. Restart the gateway so the plugin loads and dials out.
 hermes gateway restart

--- a/connectors/hermes-sprintable/plugin.yaml
+++ b/connectors/hermes-sprintable/plugin.yaml
@@ -29,3 +29,11 @@ optional_env:
     description: "Set to '1' or 'true' to allow all senders regardless of SPRINTABLE_ALLOWED_USERS."
     prompt: "Allow all users? (1=yes)"
     password: false
+  - name: SPRINTABLE_HOME_CHANNEL
+    description: "Default conversation_id for cron/notification delivery (deliver=sprintable). Usually set via /sethome."
+    prompt: "Home conversation_id (or empty)"
+    password: false
+  - name: SPRINTABLE_HOME_CHANNEL_THREAD_ID
+    description: "Thread id for the home channel (Sprintable conversations are thread-scoped)."
+    prompt: "Home channel thread_id (or empty)"
+    password: false

--- a/connectors/sdk/test_inject_allowlist.py
+++ b/connectors/sdk/test_inject_allowlist.py
@@ -69,3 +69,29 @@ async def test_mention_and_message_created_injected():
     c = SprintableSSEClient(api_key="x")
     assert await c._parse_event("message", "5", _data("conversation:mention")) is not None
     assert await c._parse_event("message", "6", _data("conversation.message_created")) is not None
+
+
+# ── E-INJECT-ADAPTERS AC1: vendored-copy sync guard ──────────────────────────
+# The hermes adapters vendor INJECTABLE_EVENT_TYPES so a single-folder fresh
+# install loads without the SDK on the path.  This SDK module stays canonical;
+# guard that the vendored copies never silently drift from it.  Parsed via ast
+# (not import) because the adapter modules import the Hermes ``gateway`` package
+# which is not present in this connectors-only test environment.
+def _vendored_allowlist(adapter_path):
+    import ast
+    tree = ast.parse(open(adapter_path, encoding="utf-8").read())
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "INJECTABLE_EVENT_TYPES" for t in node.targets
+        ):
+            call = node.value
+            assert isinstance(call, ast.Call), "expected frozenset({...}) literal"
+            return set(ast.literal_eval(call.args[0]))
+    raise AssertionError(f"INJECTABLE_EVENT_TYPES not found in {adapter_path}")
+
+
+@pytest.mark.parametrize("adapter", ["hermes-sprintable", "hermes-sprintable-prod"])
+def test_adapter_vendored_allowlist_matches_sdk(adapter):
+    here = os.path.dirname(os.path.abspath(__file__))
+    adapter_path = os.path.join(here, "..", adapter, "adapter.py")
+    assert _vendored_allowlist(adapter_path) == set(INJECTABLE_EVENT_TYPES)


### PR DESCRIPTION
## 스토리
[E-INJECT-ADAPTERS][P1·어댑터A] hermes-agent Sprintable 플러그인 (8d823891) — 빅터 언블록.

빅터(로컬 OSS Hermes)가 **현 문서+어댑터만으로는 못 붙고** 손패치로 겨우 붙은 것이 적출. 본 PR은 신원 검증이 아니라 **fresh OSS-Hermes가 문서+어댑터만으로(수작업 0) 온보딩되게** 보완한다. SME=산티아고(실 온보딩 성공·로컬 작동 패치 보유, conv 96d342af 컨설팅).

## 근본 (P0)
`connectors/hermes-sprintable/adapter.py`(#1213)가 `INJECTABLE_EVENT_TYPES`를 sibling `../sdk`에서 import하나, 온보딩 절차는 플러그인 폴더만 설치한다. fresh 설치 시 `sprintable_sse` 미존재 → **ImportError로 플러그인 미로딩**. 라이브는 #1213 이전 구버전 + 미upstream 손패치로만 작동 = "문서대로면 안 붙고, 작동 코드는 레포·문서에 없다".

## 변경 — 코드
- **AC1** SDK import 견고화: `INJECTABLE_EVENT_TYPES`를 어댑터에 **vendor**(자기완결) → fresh 단일 폴더 설치서 ImportError 0. `../sdk` sys.path 조작 제거. SDK는 canonical 출처로 유지하고 import 가능 시 SDK 사본 우선(drift 방지).
- **AC2** thread 세션 고정: `chat_type="thread"` + `thread_id=conversation_id` (group per-sender 세션 분절 방지). `get_chat_info` type도 정렬.
- **AC3** dev/prod 분리: `connectors/hermes-sprintable-prod` 신설. `SPRINTABLE_PROD_*` 전용 self-contained 클론(`Platform("sprintable_prod")`·prod home channel·`cron_deliver_env_var`). AC1 자기완결 제약상 모듈 공유 불가 → 의도된 클론.
- **AC4** sender payload-first fallback 체인(`payload→top-level`) — 라이브 작동 어댑터와 일치.
- **AC2/AC3** `_env_enablement` home_channel 승격 + `cron_deliver_env_var` 등록(`/sethome`·cron deliver 지원). allowlist/ack/dedup 유지(**AC5**).

## 변경 — 문서 (AC6~10)
- `hermes-sprintable/README.md` 전면 재작성: 풀 온보딩 경로(설치→enable(plugin.yaml `name`)→env→restart→`gateway.log` 검증), **게이트웨이 어댑터 vs MCP 서버 명시 구분("MCP ping≠연결")**, env 3그룹 분리(dev/prod/MCP), 최소 **Hermes v0.13.0** + vendoring fallback, 정확 엔드포인트, 검증 체크리스트.
- `hermes-sprintable-prod/README.md` 신설, `connectors/README.md` prod 디렉토리/카테고리 + vendor 원칙, `apps/web/public/onboarding-guide.txt` Hermes 예제 교정(self-contained·enable-by-name·MCP 경고·dev/prod·검증·`develop`).

## 검증
- `connectors/sdk/test_inject_allowlist.py`에 **vendored-copy 동기 가드** 추가(dev·prod vendored set == SDK set). **7 passed**.
- **실 Hermes 런타임 fresh-install 로드 테스트**(단일 폴더, `../sdk` 부재): dev·prod 모두 import ImportError 0, `register` 정상, `Platform()` 해석, `get_chat_info type=thread`. 구버전이면 `exec_module`서 ImportError → P0 해소 입증.
- 클린룸 정적: plugin.yaml `name`이 README enable 안내와 일치(`sprintable-platform`/`sprintable-prod-platform`), 라이브 `~/.hermes/plugins/*` 미접촉.

## done-gate 잔여 (QA)
실 라운드트립 클린룸(전용 test agent로 dial-out→stream open→inbound→ack→reply→reconnect 재주입0)은 라이브 에이전트 커서 교란 위험상 본 세션서 미수행 — **까심군 cross-model QA + 빅터 환경 재현** 몫. README 검증 체크리스트 그대로 따르면 됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)