### PR TITLE
fix(activity-log): actor_name 해석 + 생성 이벤트 기록 (404f9958)

### DIFF
--- a/backend/app/routers/activity_logs.py
+++ b/backend/app/routers/activity_logs.py
@@ -132,15 +132,16 @@ async def list_activity_logs(
     )
     items = items_result.scalars().all()
 
-    # batch resolve actor_name via team_members
+    # batch resolve actor_name. actor_id는 canonical member id로, 0085(member SSOT) 후
+    # team_members.id와 다를 수 있다(grant-only/canonical 휴먼). 직접 TeamMember.id 조회는
+    # 이들을 놓쳐 actor_name=null → 피드가 '시스템'/'—'으로 표시되던 근본. lookup_members_by_ids
+    # 는 anchor/legacy 모두 해소하고 휴먼 이름을 user.email로 정합(member→user/email).
     actor_ids = {item.actor_id for item in items if item.actor_id}
     actor_name_map: dict[uuid.UUID, str] = {}
     if actor_ids:
-        from app.models.team import TeamMember
-        tm_rows = (await db.execute(
-            select(TeamMember.id, TeamMember.name).where(TeamMember.id.in_(actor_ids))
-        )).all()
-        actor_name_map = {row.id: row.name for row in tm_rows}
+        from app.services.member_resolver import lookup_members_by_ids
+        resolved = await lookup_members_by_ids(actor_ids, db)
+        actor_name_map = {mid: rm.name for mid, rm in resolved.items() if rm and rm.name}
 
     # batch resolve entity_title per entity_type
     entity_ids_by_type: dict[str, set[uuid.UUID]] = defaultdict(set)

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -2,7 +2,7 @@ import os
 import uuid
 from datetime import datetime
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -72,6 +72,7 @@ async def list_docs(
 @router.post("", response_model=DocResponse, status_code=201)
 async def create_doc(
     body: DocCreate,
+    background_tasks: BackgroundTasks,
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
@@ -99,6 +100,13 @@ async def create_doc(
         doc_type=body.doc_type,
         content_format=body.content_format,
         tags=body.tags,
+    )
+    # 활동로그: doc 생성 이벤트 기록 (생성류 미기록 갭 — 피드 정상화)
+    from app.services.activity_log import record_created_activity
+    await record_created_activity(
+        background_tasks, auth=auth, org_id=org_id, db=session,
+        entity_type="doc", entity_id=doc.id, project_id=body.project_id,
+        title=doc.title,
     )
     return DocResponse.model_validate(doc)
 

--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import date as date_type
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -41,8 +41,9 @@ async def list_sprints(
 @router.post("", response_model=SprintResponse, status_code=201)
 async def create_sprint(
     body: SprintCreate,
+    background_tasks: BackgroundTasks,
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> SprintResponse:
     repo = SprintRepository(session, org_id)
@@ -60,6 +61,13 @@ async def create_sprint(
         metric_definition=body.metric_definition,
         measure_after=body.measure_after,
         **({"duration": _dur} if _dur is not None else {}),
+    )
+    # 활동로그: sprint 생성 이벤트 기록 (생성류 미기록 갭 — 피드 정상화)
+    from app.services.activity_log import record_created_activity
+    await record_created_activity(
+        background_tasks, auth=auth, org_id=org_id, db=session,
+        entity_type="sprint", entity_id=sprint.id, project_id=sprint.project_id,
+        title=sprint.title,
     )
     return SprintResponse.model_validate(sprint)
 

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -191,6 +191,7 @@ async def _preflight_merge_gate(
 @router.post("", response_model=StoryResponse, status_code=201)
 async def create_story(
     body: StoryCreate,
+    background_tasks: BackgroundTasks,
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
@@ -238,6 +239,13 @@ async def create_story(
     if primary_assignee:
         await _upsert_assignee_participation(session, org_id, story.id, primary_assignee)
     story.assignee_ids = saved_ids or ([story.assignee_id] if story.assignee_id else [])
+    # 활동로그: story 생성 이벤트 기록 (생성류 미기록 갭 — 피드 정상화)
+    from app.services.activity_log import record_created_activity
+    await record_created_activity(
+        background_tasks, auth=auth, org_id=org_id, db=session,
+        entity_type="story", entity_id=story.id, project_id=story.project_id,
+        title=story.title,
+    )
     return StoryResponse.model_validate(story)
 
 

--- a/backend/app/services/activity_log.py
+++ b/backend/app/services/activity_log.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 
 import uuid
 import logging
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.activity_log import ActivityLog
+
+if TYPE_CHECKING:
+    from fastapi import BackgroundTasks
+
+    from app.dependencies.auth import AuthContext
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +57,41 @@ async def record_activity_bg(
             await db.commit()
     except Exception:
         logger.warning("record_activity_bg failed action=%s actor_id=%s", action, actor_id, exc_info=True)
+
+
+async def record_created_activity(
+    background_tasks: BackgroundTasks,
+    *,
+    auth: AuthContext,
+    org_id: uuid.UUID,
+    db: AsyncSession,
+    entity_type: str,
+    entity_id: uuid.UUID,
+    project_id: uuid.UUID | None,
+    title: str | None = None,
+) -> None:
+    """create 엔드포인트용 헬퍼: actor(canonical member)를 해석해 ``{entity_type}_created``
+    activity log를 BackgroundTask로 큐잉한다. story/sprint/doc 생성이 피드에 0건 잡히던 갭을
+    메운다. caller에 예외 전파 없음(record_activity_bg와 동일 best-effort)."""
+    actor_id: uuid.UUID | None = None
+    try:
+        from app.services.member_resolver import resolve_member
+        actor_id = (await resolve_member(auth, org_id, db)).id
+    except Exception:
+        logger.warning(
+            "record_created_activity: actor resolve 실패 entity=%s id=%s", entity_type, entity_id,
+            exc_info=True,
+        )
+    background_tasks.add_task(
+        record_activity_bg,
+        org_id=org_id,
+        action=f"{entity_type}_created",
+        actor_id=actor_id,
+        project_id=project_id,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        context={"title": title} if title else {},
+    )
 
 
 class ActivityLogService:

--- a/backend/tests/test_activity_created_and_actor_404f9958.py
+++ b/backend/tests/test_activity_created_and_actor_404f9958.py
@@ -29,10 +29,10 @@ class _FakeBG:
         self.tasks.append((fn, kwargs))
 
 
-def _resolved(actor_id, org_id, name="x"):
+def _resolved(actor_id, org_id, name="x", mtype="human"):
     from app.services.member_resolver import ResolvedMember
     return ResolvedMember(
-        id=actor_id, user_id=None, name=name, type="human",
+        id=actor_id, user_id=None, name=name, type=mtype,
         role="member", org_id=org_id, project_id=None,
     )
 
@@ -93,14 +93,20 @@ async def test_record_created_activity_best_effort_on_resolve_failure(monkeypatc
 # ── Bug1: list_activity_logs actor_name 해소 ─────────────────────────────────
 
 @pytest.mark.anyio
-async def test_list_activity_logs_resolves_actor_name_via_member_resolver(monkeypatch):
+@pytest.mark.parametrize("actor_type,resolved_name", [
+    ("human", "alice@example.com"),   # 휴먼: user.email로 정합
+    ("agent", "디디 은와추쿠"),         # 에이전트: member name — canonical 경로가 둘 다 커버
+])
+async def test_list_activity_logs_resolves_actor_name_via_member_resolver(
+    monkeypatch, actor_type, resolved_name,
+):
     from app.models.activity_log import ActivityLog
     from app.routers import activity_logs as router
 
     org, actor, eid = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
     log = ActivityLog(
         id=uuid.uuid4(), org_id=org, project_id=uuid.uuid4(),
-        actor_id=actor, actor_type="human", action="story_created",
+        actor_id=actor, actor_type=actor_type, action="story_created",
         entity_type="story", entity_id=eid, context={},
         created_at=datetime.now(tz=timezone.utc),
     )
@@ -115,9 +121,10 @@ async def test_list_activity_logs_resolves_actor_name_via_member_resolver(monkey
     db = AsyncMock()
     db.execute = AsyncMock(side_effect=[count_res, items_res, entity_res])
 
-    # canonical 휴먼: actor_id가 team_members.id와 달라도 anchor resolver가 user.email로 해소
+    # canonical actor(휴먼/에이전트): actor_id가 team_members.id와 달라도 anchor resolver가
+    # 이름을 해소(휴먼=user.email, 에이전트=member name).
     async def _fake_lookup(ids, session):
-        return {actor: _resolved(actor, org, name="alice@example.com")}
+        return {actor: _resolved(actor, org, name=resolved_name, mtype=actor_type)}
 
     monkeypatch.setattr("app.services.member_resolver.lookup_members_by_ids", _fake_lookup)
 
@@ -129,5 +136,5 @@ async def test_list_activity_logs_resolves_actor_name_via_member_resolver(monkey
 
     assert resp.total == 1
     assert len(resp.items) == 1
-    assert resp.items[0].actor_name == "alice@example.com"   # '시스템'/null 아님
+    assert resp.items[0].actor_name == resolved_name   # '시스템'/null 아님 — 휴먼·에이전트 공통
     assert resp.items[0].entity_title == "My Story"

--- a/backend/tests/test_activity_created_and_actor_404f9958.py
+++ b/backend/tests/test_activity_created_and_actor_404f9958.py
@@ -1,0 +1,133 @@
+"""404f9958: 활동로그 actor_name 미해석 + 생성 이벤트 미기록 회귀 가드.
+
+- Bug1: list_activity_logs가 actor_name을 lookup_members_by_ids(canonical/legacy+user.email)로
+  해소한다(직접 team_members 조회 → canonical 휴먼 누락 → '시스템' 표시 회귀 차단).
+- Bug2: story/sprint/doc 생성이 record_created_activity로 {entity}_created 활동을 큐잉한다.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── Bug2: record_created_activity ────────────────────────────────────────────
+
+class _FakeBG:
+    def __init__(self):
+        self.tasks: list[tuple] = []
+
+    def add_task(self, fn, **kwargs):
+        self.tasks.append((fn, kwargs))
+
+
+def _resolved(actor_id, org_id, name="x"):
+    from app.services.member_resolver import ResolvedMember
+    return ResolvedMember(
+        id=actor_id, user_id=None, name=name, type="human",
+        role="member", org_id=org_id, project_id=None,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("entity_type", ["story", "sprint", "doc"])
+async def test_record_created_activity_queues_created_event(monkeypatch, entity_type):
+    from app.services import activity_log as mod
+
+    actor, org, proj, eid = (uuid.uuid4() for _ in range(4))
+
+    async def _fake_resolve(auth, org_id, db):
+        return _resolved(actor, org_id)
+
+    monkeypatch.setattr("app.services.member_resolver.resolve_member", _fake_resolve)
+
+    bg = _FakeBG()
+    await mod.record_created_activity(
+        bg, auth=MagicMock(), org_id=org, db=AsyncMock(),
+        entity_type=entity_type, entity_id=eid, project_id=proj, title="T",
+    )
+
+    assert len(bg.tasks) == 1
+    fn, kw = bg.tasks[0]
+    assert fn is mod.record_activity_bg
+    assert kw["action"] == f"{entity_type}_created"
+    assert kw["actor_id"] == actor
+    assert kw["entity_type"] == entity_type
+    assert kw["entity_id"] == eid
+    assert kw["project_id"] == proj
+    assert kw["context"] == {"title": "T"}
+
+
+@pytest.mark.anyio
+async def test_record_created_activity_best_effort_on_resolve_failure(monkeypatch):
+    """actor 해석 실패해도 이벤트는 큐잉(best-effort) — 생성 이벤트 누락 0."""
+    from app.services import activity_log as mod
+
+    async def _boom(auth, org_id, db):
+        raise RuntimeError("resolve down")
+
+    monkeypatch.setattr("app.services.member_resolver.resolve_member", _boom)
+
+    bg = _FakeBG()
+    eid = uuid.uuid4()
+    await mod.record_created_activity(
+        bg, auth=MagicMock(), org_id=uuid.uuid4(), db=AsyncMock(),
+        entity_type="story", entity_id=eid, project_id=uuid.uuid4(), title=None,
+    )
+
+    assert len(bg.tasks) == 1
+    _, kw = bg.tasks[0]
+    assert kw["action"] == "story_created"
+    assert kw["actor_id"] is None          # 해석 실패 → None 이나 이벤트는 기록
+    assert kw["context"] == {}             # title 없음 → {}
+
+
+# ── Bug1: list_activity_logs actor_name 해소 ─────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_activity_logs_resolves_actor_name_via_member_resolver(monkeypatch):
+    from app.models.activity_log import ActivityLog
+    from app.routers import activity_logs as router
+
+    org, actor, eid = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    log = ActivityLog(
+        id=uuid.uuid4(), org_id=org, project_id=uuid.uuid4(),
+        actor_id=actor, actor_type="human", action="story_created",
+        entity_type="story", entity_id=eid, context={},
+        created_at=datetime.now(tz=timezone.utc),
+    )
+
+    count_res = MagicMock()
+    count_res.scalar_one.return_value = 1
+    items_res = MagicMock()
+    items_res.scalars.return_value.all.return_value = [log]
+    entity_res = MagicMock()
+    entity_res.all.return_value = [SimpleNamespace(id=eid, title="My Story")]
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[count_res, items_res, entity_res])
+
+    # canonical 휴먼: actor_id가 team_members.id와 달라도 anchor resolver가 user.email로 해소
+    async def _fake_lookup(ids, session):
+        return {actor: _resolved(actor, org, name="alice@example.com")}
+
+    monkeypatch.setattr("app.services.member_resolver.lookup_members_by_ids", _fake_lookup)
+
+    resp = await router.list_activity_logs(
+        project_id=None, actor_id=None, action=None, entity_type=None,
+        entity_id=None, from_=None, to=None, limit=30, offset=0,
+        db=db, org_id=org, _auth=MagicMock(user_id=str(uuid.uuid4())),
+    )
+
+    assert resp.total == 1
+    assert len(resp.items) == 1
+    assert resp.items[0].actor_name == "alice@example.com"   # '시스템'/null 아님
+    assert resp.items[0].entity_title == "My Story"


### PR DESCRIPTION
## 스토리
[BE] 활동로그 actor_name 미해석 + 생성 이벤트 미기록 (404f9958, E-POLISH) — prod E2E(2026-06-08) 적출.

## 근본 & 수정

### 1) actor_name null → '시스템'/'—' 표시
`GET /api/v2/activity-logs` 피드가 `actor_name`을 **`TeamMember.id` 직접 조회**로 해소(`activity_logs.py`). 0085(member SSOT) 이후 canonical 휴먼은 `actor_id ≠ team_members.id`라 직접 조회가 놓쳐 → `actor_name=null` → 피드/대시보드 '최근활동'서 actor가 '시스템'/'—'/'?'로 표시(`actor_id`는 세팅됨).

**수정**: `lookup_members_by_ids`(anchor/legacy 모두 해소 + 휴먼 이름을 `user.email`로 정합 = AC의 member→user/email)로 교체. `record_activity_bg`가 actor_type 해석에 이미 쓰는 동일 canonical 경로라 정합.

### 2) story/sprint/doc created 미기록
생성 시 활동로그 0건(현재 `story_updated`/assignee/status 등 updated류만 `record_activity_bg`). 피드가 비어 보임.

**수정**: `activity_log` 서비스에 `record_created_activity` 헬퍼 신설(actor canonical 해석 + `{entity}_created` BackgroundTask 큐잉, caller 예외 전파 0 best-effort) → `create_story`/`create_sprint`/`create_doc`에 배선. action=`story_created`/`sprint_created`/`doc_created`.

## 검증
- 신규 `tests/test_activity_created_and_actor_404f9958.py` **5 passed**: actor_name canonical 해소(라우터 직접호출) + created 3종(story/sprint/doc) + actor 해석 실패 시 best-effort 큐잉.
- 전체 backend 스위트 **2085 passed · 회귀 0**. (로컬 잔여 3 실패는 env 의존 — MCP e2e 연결·contract 파일 부재, 본 변경 미접촉 파일이라 무관.)
- 변경 최소(5파일 +75): 라우터 1줄 해소 교체 + 헬퍼 + create 3곳 배선.

## AC
- actor_name 정상 해석(member→user/email) ✅
- 생성류(story/sprint/doc created) 이벤트 기록 ✅
- 회귀 0 ✅

까심 cross-model QA + PO 게이트 대기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)