### PR TITLE
fix(hypothesis): cross-project 링크 가드 service 레벨 — create/draft/links 패리티 (54a8bd8a)

### DIFF
--- a/backend/app/routers/hypotheses.py
+++ b/backend/app/routers/hypotheses.py
@@ -5,14 +5,14 @@ main.py 핸들러가 {data:null,error:{code,message,...},meta:null}로 감싼다
 
 라우트 선언 순서: `/draft`를 `/{id}` 계열보다 먼저 선언한다(§3.9.7 — /bulk shadow #1386 재발 방지).
 
-라우터 레벨 가드(S2에서 인계·AC⑥):
-- §3.7.2 cross-project 링크 금지 — 대상 epic/story의 project가 hypothesis와 같아야 한다.
-- §3.1.7 'active' 전이는 owner 휴먼 또는 org owner/admin만.
+가드 위치:
+- §3.7.2 cross-project 링크 금지 — service(hypothesis._assert_targets_same_project)가
+  create/draft/link 공통 처리(54a8bd8a: 라우터-only 갭으로 create/draft 우회되던 것 차단).
+- §3.1.7 'active' 전이는 owner 휴먼 또는 org owner/admin만 — 라우터에서 보강.
 """
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import (
@@ -22,7 +22,6 @@ from app.dependencies.auth import (
     get_verified_org_id,
 )
 from app.dependencies.database import get_db
-from app.models.pm import Epic, Story
 from app.repositories.hypothesis import HypothesisRepository
 from app.schemas.hypothesis import (
     HypothesisCreate,
@@ -59,35 +58,6 @@ def _raise(err: svc.HypothesisServiceError) -> None:
         status_code=_ERROR_STATUS.get(err.code, 400),
         detail={"code": err.code, "message": err.message},
     )
-
-
-async def _assert_targets_same_project(
-    session: AsyncSession,
-    project_id: uuid.UUID,
-    epic_ids: list[uuid.UUID],
-    story_ids: list[uuid.UUID],
-) -> None:
-    """§3.7.2 — 링크 대상 epic/story가 hypothesis와 다른 project면 403."""
-    if epic_ids:
-        rows = (await session.execute(
-            select(Epic.id, Epic.project_id).where(Epic.id.in_(epic_ids))
-        )).all()
-        if any(pid != project_id for _id, pid in rows) or len(rows) != len(set(epic_ids)):
-            raise HTTPException(
-                status_code=403,
-                detail={"code": "CROSS_PROJECT_LINK_FORBIDDEN",
-                        "message": "다른 프로젝트의 에픽에는 연결할 수 없습니다."},
-            )
-    if story_ids:
-        rows = (await session.execute(
-            select(Story.id, Story.project_id).where(Story.id.in_(story_ids))
-        )).all()
-        if any(pid != project_id for _id, pid in rows) or len(rows) != len(set(story_ids)):
-            raise HTTPException(
-                status_code=403,
-                detail={"code": "CROSS_PROJECT_LINK_FORBIDDEN",
-                        "message": "다른 프로젝트의 스토리에는 연결할 수 없습니다."},
-            )
 
 
 def _assert_active_authorized(caller: ResolvedMember, owner_member_id: uuid.UUID) -> None:
@@ -216,15 +186,7 @@ async def link_hypothesis(
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> HypothesisResponse:
-    # §3.7.2 cross-project 링크 금지는 라우터에서 — 대상 epic/story project 대조.
-    repo = HypothesisRepository(session, org_id)
-    hyp = await repo.get(hypothesis_id)
-    if hyp is None:
-        raise HTTPException(
-            status_code=404,
-            detail={"code": "HYPOTHESIS_NOT_FOUND", "message": "가설을 찾을 수 없습니다."},
-        )
-    await _assert_targets_same_project(session, hyp.project_id, body.epic_ids, body.story_ids)
+    # §3.7.2 cross-project 링크 금지 + 존재 검증은 service(link_hypothesis)가 단일 처리.
     try:
         return await svc.link_hypothesis(session, org_id, hypothesis_id, body)
     except svc.HypothesisServiceError as err:

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -14,9 +14,11 @@ import logging
 import uuid
 from datetime import datetime, timedelta, timezone
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.hypothesis import HYPOTHESIS_STATUSES, Hypothesis, is_valid_transition
+from app.models.pm import Epic, Story
 
 logger = logging.getLogger(__name__)
 from app.repositories.hypothesis import HypothesisRepository
@@ -80,6 +82,36 @@ async def _to_response(
     return HypothesisResponse.from_model(hyp, epic_ids, story_ids)
 
 
+async def _assert_targets_same_project(
+    session: AsyncSession,
+    project_id: uuid.UUID,
+    epic_ids: list[uuid.UUID],
+    story_ids: list[uuid.UUID],
+) -> None:
+    """§3.7.2 — 링크 대상 epic/story가 hypothesis와 다른 project면 거부.
+
+    create/draft/link 공통 service 가드. 이전엔 라우터(link 라우트)에만 있어 create·draft
+    경로의 add_epic_links/add_story_links가 same-org cross-project blind INSERT로 우회됐다.
+    존재하지 않는 대상도 same-project 검증 불가라 거부한다(rowcount 대조).
+    """
+    if epic_ids:
+        rows = (await session.execute(
+            select(Epic.id, Epic.project_id).where(Epic.id.in_(epic_ids))
+        )).all()
+        if len(rows) != len(set(epic_ids)) or any(pid != project_id for _id, pid in rows):
+            raise HypothesisServiceError(
+                "CROSS_PROJECT_LINK_FORBIDDEN", "다른 프로젝트의 에픽에는 연결할 수 없습니다."
+            )
+    if story_ids:
+        rows = (await session.execute(
+            select(Story.id, Story.project_id).where(Story.id.in_(story_ids))
+        )).all()
+        if len(rows) != len(set(story_ids)) or any(pid != project_id for _id, pid in rows):
+            raise HypothesisServiceError(
+                "CROSS_PROJECT_LINK_FORBIDDEN", "다른 프로젝트의 스토리에는 연결할 수 없습니다."
+            )
+
+
 async def create_hypothesis(
     session: AsyncSession,
     org_id: uuid.UUID,
@@ -104,6 +136,9 @@ async def create_hypothesis(
         raise HypothesisServiceError(
             "INVALID_CREATE_STATUS", "생성 시 status는 proposed|active만 허용됩니다."
         )
+
+    # cross-project epic/story 링크 차단(§3.7.2) — repo.create 전이라 거부 시 orphan 가설 0.
+    await _assert_targets_same_project(session, payload.project_id, payload.epic_ids, payload.story_ids)
 
     repo = HypothesisRepository(session, org_id)
     hyp = await repo.create(
@@ -236,7 +271,8 @@ async def link_hypothesis(
     hyp = await repo.get(hypothesis_id)
     if hyp is None:
         raise HypothesisServiceError("HYPOTHESIS_NOT_FOUND", "가설을 찾을 수 없습니다.")
-    # cross-project 링크 금지(§3.7.2)는 대상 epic/story 조회가 필요 — 라우터(S3)에서 보강.
+    # cross-project epic/story 링크 차단(§3.7.2) — service 공통 가드(라우터 위임 제거).
+    await _assert_targets_same_project(session, hyp.project_id, payload.epic_ids, payload.story_ids)
     await repo.add_epic_links(hypothesis_id, payload.epic_ids, payload.link_type or "primary")
     await repo.add_story_links(hypothesis_id, payload.story_ids, payload.link_type or "supports")
     return await _to_response(repo, hyp)

--- a/backend/tests/test_hypotheses_router.py
+++ b/backend/tests/test_hypotheses_router.py
@@ -13,6 +13,7 @@ import pytest
 
 from app.routers import hypotheses as r
 from app.schemas.hypothesis import HypothesisDraftRequest, HypothesisResponse
+from app.services import hypothesis as svc
 from app.services.hypothesis import HypothesisServiceError
 from app.services.member_resolver import ResolvedMember
 
@@ -92,29 +93,27 @@ def _session_returning(rows):
     return s
 
 
+# 54a8bd8a: cross-project 가드가 라우터 → service로 이동. 가드 단위 검증은 service 함수 대상.
 async def test_link_same_project_ok():
     eid = uuid.uuid4()
     s = _session_returning([(eid, PROJECT_ID)])
-    await r._assert_targets_same_project(s, PROJECT_ID, [eid], [])  # no raise
+    await svc._assert_targets_same_project(s, PROJECT_ID, [eid], [])  # no raise
 
 
 async def test_link_cross_project_forbidden():
-    from fastapi import HTTPException
     eid = uuid.uuid4()
     s = _session_returning([(eid, uuid.uuid4())])  # 다른 project
-    with pytest.raises(HTTPException) as ei:
-        await r._assert_targets_same_project(s, PROJECT_ID, [eid], [])
-    assert ei.value.status_code == 403
-    assert ei.value.detail["code"] == "CROSS_PROJECT_LINK_FORBIDDEN"
+    with pytest.raises(HypothesisServiceError) as ei:
+        await svc._assert_targets_same_project(s, PROJECT_ID, [eid], [])
+    assert ei.value.code == "CROSS_PROJECT_LINK_FORBIDDEN"
 
 
 async def test_link_missing_target_forbidden():
-    from fastapi import HTTPException
     eid = uuid.uuid4()
     s = _session_returning([])  # 대상 epic 없음(len mismatch)
-    with pytest.raises(HTTPException) as ei:
-        await r._assert_targets_same_project(s, PROJECT_ID, [eid], [])
-    assert ei.value.status_code == 403
+    with pytest.raises(HypothesisServiceError) as ei:
+        await svc._assert_targets_same_project(s, PROJECT_ID, [eid], [])
+    assert ei.value.code == "CROSS_PROJECT_LINK_FORBIDDEN"
 
 
 # ── ⓒ draft (§3.9) ────────────────────────────────────────────────────────────

--- a/backend/tests/test_hypothesis_service.py
+++ b/backend/tests/test_hypothesis_service.py
@@ -17,6 +17,7 @@ import pytest
 from app.models.hypothesis import is_valid_transition
 from app.schemas.hypothesis import (
     HypothesisCreate,
+    HypothesisDraftRequest,
     HypothesisLinkRequest,
     HypothesisResponse,
     HypothesisTransition,
@@ -341,13 +342,85 @@ async def test_link_adds_epic_and_story():
     repo = _repo_mock(_hyp_stub())
     p_repo, p_lookup = _patch(repo, "human")
     eid, sid = uuid.uuid4(), uuid.uuid4()
+    # 54a8bd8a: link_hypothesis가 cross-project 가드 쿼리(epic→story)를 탄다 — same-project 반환.
+    session = MagicMock()
+    epic_res, story_res = MagicMock(), MagicMock()
+    epic_res.all = MagicMock(return_value=[(eid, PROJECT_ID)])
+    story_res.all = MagicMock(return_value=[(sid, PROJECT_ID)])
+    session.execute = AsyncMock(side_effect=[epic_res, story_res])
     with p_repo, p_lookup:
         await svc.link_hypothesis(
-            MagicMock(), ORG_ID, HYP_ID,
+            session, ORG_ID, HYP_ID,
             HypothesisLinkRequest(epic_ids=[eid], story_ids=[sid]),
         )
     repo.add_epic_links.assert_awaited_once_with(HYP_ID, [eid], "primary")
     repo.add_story_links.assert_awaited_once_with(HYP_ID, [sid], "supports")
+
+
+# ── 54a8bd8a: cross-project 가드 service 레벨 — create/draft 경로 패리티 ─────────
+
+def _session_one_result(rows):
+    """session.execute → .all()=rows 인 mock 세션(가드 쿼리 1회용)."""
+    session = MagicMock()
+    res = MagicMock()
+    res.all = MagicMock(return_value=rows)
+    session.execute = AsyncMock(return_value=res)
+    return session
+
+
+async def test_create_cross_project_epic_forbidden():
+    """create 경로도 cross-project epic 링크 거부 — repo.create 전 차단(orphan 0)."""
+    repo = _repo_mock(_hyp_stub())
+    p_repo, p_lookup = _patch(repo, "human")
+    eid = uuid.uuid4()
+    session = _session_one_result([(eid, uuid.uuid4())])  # 다른 project epic
+    payload = HypothesisCreate(
+        project_id=PROJECT_ID, statement="s", metric_definition=VALID_METRIC,
+        measure_after=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        owner_member_id=OWNER_ID, epic_ids=[eid],
+    )
+    with p_repo, p_lookup, pytest.raises(svc.HypothesisServiceError) as ei:
+        await svc.create_hypothesis(session, ORG_ID, _caller("human"), payload)
+    assert ei.value.code == "CROSS_PROJECT_LINK_FORBIDDEN"
+    repo.create.assert_not_awaited()  # 가드가 repo.create 전 → orphan 가설 미생성
+
+
+async def test_create_same_project_epic_ok():
+    """same-project epic 링크는 정상 — 가드 통과 후 링크 생성(회귀 무영향)."""
+    repo = _repo_mock(_hyp_stub())
+    p_repo, p_lookup = _patch(repo, "human")
+    eid = uuid.uuid4()
+    session = _session_one_result([(eid, PROJECT_ID)])  # 동일 project epic
+    payload = HypothesisCreate(
+        project_id=PROJECT_ID, statement="s", metric_definition=VALID_METRIC,
+        measure_after=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        owner_member_id=OWNER_ID, epic_ids=[eid],
+    )
+    with p_repo, p_lookup:
+        await svc.create_hypothesis(session, ORG_ID, _caller("human"), payload)
+    repo.create.assert_awaited_once()
+    repo.add_epic_links.assert_awaited_once_with(HYP_ID, [eid], "primary")
+
+
+async def test_draft_persist_cross_project_source_forbidden():
+    """draft(persist) 도 source→story 링크가 cross-project면 거부(create 경유 가드)."""
+    repo = _repo_mock(_hyp_stub())
+    sid = uuid.uuid4()
+    session = _session_one_result([(sid, uuid.uuid4())])  # 다른 project story
+    members = {CALLER_HUMAN_ID: ResolvedMember(
+        id=CALLER_HUMAN_ID, user_id=uuid.uuid4(), name="o", type="human",
+        role="member", org_id=ORG_ID,
+    )}
+    payload = HypothesisDraftRequest(
+        project_id=PROJECT_ID, source_type="story", source_id=sid,
+        persist=True, context={"title": "x"},
+    )
+    with patch.object(svc, "HypothesisRepository", return_value=repo), \
+         patch.object(svc, "lookup_members_by_ids", AsyncMock(return_value=members)), \
+         pytest.raises(svc.HypothesisServiceError) as ei:
+        await svc.draft_hypothesis(session, ORG_ID, _caller("human"), payload)
+    assert ei.value.code == "CROSS_PROJECT_LINK_FORBIDDEN"
+    repo.create.assert_not_awaited()
 
 
 def test_response_exposes_draft_fields():


### PR DESCRIPTION
## 스토리
[BE·security] 54a8bd8a — hypothesis 링크 cross-project 가드 service 레벨 이동. 까심 #1461 QA **CP⑤ CONFIRMED REAL**.

## 근본
`_assert_targets_same_project`(§3.7.2)가 `POST /hypotheses/{id}/links` **라우터에만** 있고 — `POST /hypotheses` create 라우트·`create_hypothesis` 서비스·`draft_hypothesis`(#1461 후 source→epic/story 링크 생성)엔 **부재** → `add_epic_links`/`add_story_links`가 blind INSERT라 **same-org cross-project epic/story 링크 bypass**(다른 프로젝트 epic/story에 가설 링크 row 생성 — 무결성 위반).

## fix
가드를 **service 레벨**로 이동(`hypothesis._assert_targets_same_project`, `HypothesisServiceError("CROSS_PROJECT_LINK_FORBIDDEN")` → 라우터 `_raise`가 403 매핑):
- `create_hypothesis`: `repo.create` **전** 호출 → 거부 시 orphan 가설 0.
- `link_hypothesis`: `add_*_links` 전 호출.
- `draft_hypothesis`: `create_hypothesis` 재사용이라 자동 커버.
→ **create/draft/links 3경로 패리티.**
- 라우터의 중복 가드 함수 + link 라우트의 가드/존재검증 제거(service 단일화), 미사용 import(`select`·`Epic`·`Story`) 정리.

## AC
- ① create·draft·link 전 경로 cross-project 링크 시 403(CROSS_PROJECT_LINK_FORBIDDEN) ✅
- ② same-org 동일-프로젝트 정상 링크 무영향 ✅
- ③ 회귀 테스트(cross-project 거부·same-project 통과·존재X 거부) ✅
- ④ 까심 cross-model QA — 대기

## 검증
- 신규: `test_create_cross_project_epic_forbidden`(repo.create 미호출=orphan 0)·`test_create_same_project_epic_ok`·`test_draft_persist_cross_project_source_forbidden`. 기존 link 가드 테스트는 service 대상으로 갱신.
- hypothesis **51 passed**, 전체 backend **2089 passed·회귀 0**(잔여 3 실패는 MCP e2e 연결·contract 파일 부재 등 env 의존, 본 변경 미접촉 파일).
- 변경 2 app파일(라우터 -48 / 서비스 +38).

까심 cross-model QA + PO 게이트 대기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)