### PR TITLE
[SID:8e4e0aba] 모달 스크롤 근본 — 공통 Dialog dvh 바운드 + 에픽 모달

### DIFF
--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -681,7 +681,7 @@ function CreateModal({ projectId, orgId, onCreated, onClose }: CreateModalProps)
         onClick={onClose}
         aria-label={t('cancel')}
       />
-      <div className="relative z-10 flex max-h-[calc(100vh-2rem)] w-full max-w-md flex-col rounded-2xl border border-border bg-card shadow-xl">
+      <div className="relative z-10 flex max-h-[calc(100dvh-2rem)] w-full max-w-md flex-col rounded-2xl border border-border bg-card shadow-xl">
         <div className="flex flex-shrink-0 items-center justify-between px-6 pb-4 pt-6">
           <h2 className="text-base font-bold text-foreground">{t('createEpic')}</h2>
           <button

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -53,7 +53,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 grid max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 overflow-y-auto rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           className
         )}
         {...props}


### PR DESCRIPTION
## 요약
아버님 "메인 정신병 근원"으로 지목된 **모달 스크롤 클리핑** 근본 처리 (story `8e4e0aba`, E-POLISH, HIGH). 오르테가군 AC③ = 공통 모달 근본 처리.

## 근본 2겹
**표면 A (AC③ 근본):** 공통 `DialogContent`(`components/ui/dialog.tsx`)에 `max-height`·`overflow` 부재 → DialogContent 사용 **14곳 중 13곳**이 뷰포트 넘침 시 클리핑(하단 필드/버튼 접근불가). 예외 1곳 = `standup-feedback-dialog`(per-usage 스크롤 보유).

**표면 B (보고 버그):** 에픽 생성 커스텀 모달(`epics-client.tsx`) 셸 `max-h-[calc(100vh-2rem)]` — flex+스크롤 바디(S5 #1377)는 OK지만 `100vh`가 모바일 large-viewport/소프트키보드 미반영 → 하단 접근불가.

## 수정 (디자인 계약 = dvh 바운드 + 넘침 스크롤)
- **⒜ `dialog.tsx`** DialogContent Popup className에 `max-h-[calc(100dvh-2rem)] overflow-y-auto` 추가 → **13모달 일괄 교정**
- **⒝ `epics-client.tsx`** `max-h-[calc(100vh-2rem)]` → `100dvh` (한 토큰 교체, S5 구조 유지)
- dvh 선례: `app/share/layout.tsx`·`components/docs/doc-editor.tsx`

## 회귀 무파손 근거
- per-usage `max-h`/`overflow`를 가진 모달(standup-feedback 등)은 `cn()`+tailwind-merge로 **per-usage override가 승계** → 더블 스크롤·중복 바운드 없음
- 짧은 모달은 `max-h` 도달 안 하므로 스크롤바 미출현·데스크탑 중앙정렬 무변경
- 레이아웃 무변경 — 넘침 시에만 뷰포트-바운드+스크롤 발동

## 닫기 버튼 결정 (DOM 구조 = 내 판단)
`<Close>`는 `absolute top-2 right-2` **유지**(최소변경). 넘침 스크롤 시 X가 콘텐츠와 함께 밀리나 — Esc/backdrop 닫기 유효·스크롤 top 복귀 시 재노출. sticky/in-flow 전환은 grid `gap-4`에 행을 추가해 "짧은 모달 중앙·레이아웃 무변경" 계약을 깨므로 채택 안 함.

## 검증
- `pnpm build` ✅ (exit 0) · ESLint ✅ 경고 0 · `tsc --noEmit` ✅
- Base: **develop**

## QA 가이드 (까심군)
모바일 뷰포트 실탭: 에픽 생성(필드 여러개→스크롤→하단 입력/제출 도달) + 대표 DialogContent 모달 회귀(짧은 모달 스크롤바 미출현·데스크탑 중앙정렬 무변경). blast 13모달.

🤖 Generated with [Claude Code](https://claude.com/claude-code)