### PR TITLE
refactor(storage-api): Supabase*Repository → Api*Repository 단일 명명 (fc7bce47)

### DIFF
--- a/apps/web/src/services/agent-builtin-tools.test.ts
+++ b/apps/web/src/services/agent-builtin-tools.test.ts
@@ -258,7 +258,7 @@ function createContext() {
 
 // AgentBuiltinToolService의 단위 경계는 dispatch/scope-guard/audit/presentation이다.
 // MemoService/StoryService/EpicService는 OSS에서 stub repo(MemoService 무repo) 또는
-// FastAPI HTTP(Story/Epic의 SupabaseXRepository.fastapiCall) 위임이라 in-memory db
+// FastAPI HTTP(Story/Epic의 ApiXRepository.fastapiCall) 위임이라 in-memory db
 // stub만으로는 동작하지 않는다. 따라서 의존 서비스를 db-stub 백드 fake로 주입해 실
 // persistence가 아닌 서비스 계약(메서드 시그니처·반환 shape)만 재현한다.
 function makeService(db: any, options: Record<string, unknown> = {}) {

--- a/packages/storage-api/src/ApiDocRepository.ts
+++ b/packages/storage-api/src/ApiDocRepository.ts
@@ -1,7 +1,7 @@
 import type { IDocRepository, Doc, DocSummary, CreateDocInput, UpdateDocInput, DocListFilters, RepositoryScopeContext } from '@sprintable/core-storage';
 import { fastapiCall } from './utils';
 
-export class SupabaseDocRepository implements IDocRepository {
+export class ApiDocRepository implements IDocRepository {
   constructor(private readonly accessToken: string = '') {}
 
   async list(filters: DocListFilters): Promise<DocSummary[]> {

--- a/packages/storage-api/src/ApiEpicRepository.ts
+++ b/packages/storage-api/src/ApiEpicRepository.ts
@@ -1,7 +1,7 @@
 import type { IEpicRepository, Epic, CreateEpicInput, UpdateEpicInput, EpicListFilters, RepositoryScopeContext } from '@sprintable/core-storage';
 import { fastapiCall } from './utils';
 
-export class SupabaseEpicRepository implements IEpicRepository {
+export class ApiEpicRepository implements IEpicRepository {
   constructor(private readonly accessToken: string = '') {}
 
   async create(input: CreateEpicInput): Promise<Epic> {

--- a/packages/storage-api/src/ApiInboxItemRepository.ts
+++ b/packages/storage-api/src/ApiInboxItemRepository.ts
@@ -2,7 +2,7 @@ import type { IInboxItemRepository, InboxItem, CreateInboxItemInput, InboxListFi
 import { NotFoundError } from '@sprintable/core-storage';
 import { fastapiCall } from './utils';
 
-export class SupabaseInboxItemRepository implements IInboxItemRepository {
+export class ApiInboxItemRepository implements IInboxItemRepository {
   constructor(private readonly accessToken: string = '') {}
 
   async create(input: CreateInboxItemInput): Promise<InboxItem> {

--- a/packages/storage-api/src/ApiNotificationRepository.ts
+++ b/packages/storage-api/src/ApiNotificationRepository.ts
@@ -1,7 +1,7 @@
 import type { INotificationRepository, Notification, CreateNotificationInput, NotificationListFilters } from '@sprintable/core-storage';
 import { fastapiCall } from './utils';
 
-export class SupabaseNotificationRepository implements INotificationRepository {
+export class ApiNotificationRepository implements INotificationRepository {
   constructor(private readonly accessToken: string = '') {}
 
   async create(input: CreateNotificationInput): Promise<Notification> {

--- a/packages/storage-api/src/ApiProjectRepository.ts
+++ b/packages/storage-api/src/ApiProjectRepository.ts
@@ -1,7 +1,7 @@
 import type { IProjectRepository, Project, CreateProjectInput, UpdateProjectInput, ProjectListFilters, RepositoryScopeContext } from '@sprintable/core-storage';
 import { fastapiCall } from './utils';
 
-export class SupabaseProjectRepository implements IProjectRepository {
+export class ApiProjectRepository implements IProjectRepository {
   constructor(private readonly accessToken: string = '') {}
 
   async list(_filters: ProjectListFilters): Promise<Project[]> {

--- a/packages/storage-api/src/ApiSprintRepository.ts
+++ b/packages/storage-api/src/ApiSprintRepository.ts
@@ -1,7 +1,7 @@
 import type { ISprintRepository, Sprint, CreateSprintInput, UpdateSprintInput, SprintListFilters, RepositoryScopeContext } from '@sprintable/core-storage';
 import { fastapiCall } from './utils';
 
-export class SupabaseSprintRepository implements ISprintRepository {
+export class ApiSprintRepository implements ISprintRepository {
   constructor(private readonly accessToken: string = '') {}
 
   async create(input: CreateSprintInput): Promise<Sprint> {

--- a/packages/storage-api/src/ApiStoryRepository.ts
+++ b/packages/storage-api/src/ApiStoryRepository.ts
@@ -2,7 +2,7 @@ import type { IStoryRepository, Story, CreateStoryInput, UpdateStoryInput, BulkU
 import type { PaginationOptions } from '@sprintable/core-storage';
 import { fastapiCall } from './utils';
 
-export class SupabaseStoryRepository implements IStoryRepository {
+export class ApiStoryRepository implements IStoryRepository {
   constructor(private readonly accessToken: string = '') {}
 
   async create(input: CreateStoryInput): Promise<Story> {

--- a/packages/storage-api/src/ApiTaskRepository.ts
+++ b/packages/storage-api/src/ApiTaskRepository.ts
@@ -1,7 +1,7 @@
 import type { ITaskRepository, Task, CreateTaskInput, UpdateTaskInput, TaskListFilters, RepositoryScopeContext } from '@sprintable/core-storage';
 import { fastapiCall } from './utils';
 
-export class SupabaseTaskRepository implements ITaskRepository {
+export class ApiTaskRepository implements ITaskRepository {
   constructor(private readonly accessToken: string = '') {}
 
   async create(input: CreateTaskInput): Promise<Task> {

--- a/packages/storage-api/src/ApiTeamMemberRepository.ts
+++ b/packages/storage-api/src/ApiTeamMemberRepository.ts
@@ -1,7 +1,7 @@
 import type { ITeamMemberRepository, TeamMember, CreateTeamMemberInput, UpdateTeamMemberInput, TeamMemberListFilters } from '@sprintable/core-storage';
 import { fastapiCall } from './utils';
 
-export class SupabaseTeamMemberRepository implements ITeamMemberRepository {
+export class ApiTeamMemberRepository implements ITeamMemberRepository {
   constructor(private readonly accessToken: string = '') {}
 
   async list(filters: TeamMemberListFilters): Promise<TeamMember[]> {

--- a/packages/storage-api/src/index.ts
+++ b/packages/storage-api/src/index.ts
@@ -1,24 +1,14 @@
 export { fastapiCall, mapApiError } from './utils';
-export { SupabaseEpicRepository } from './SupabaseEpicRepository';
-export { SupabaseStoryRepository } from './SupabaseStoryRepository';
-export { SupabaseTaskRepository } from './SupabaseTaskRepository';
-export { SupabaseDocRepository } from './SupabaseDocRepository';
-export { SupabaseProjectRepository } from './SupabaseProjectRepository';
-export { SupabaseSprintRepository } from './SupabaseSprintRepository';
-export { SupabaseNotificationRepository } from './SupabaseNotificationRepository';
-export { SupabaseTeamMemberRepository } from './SupabaseTeamMemberRepository';
-export { SupabaseInboxItemRepository } from './SupabaseInboxItemRepository';
 
-// Api* 명명 신규(Supabase* 레거시 alias 없음): hypotheses FastAPI 직타 레포지토리 (E1-S7).
+// FastAPI(/api/v2/*) 직타 레포지토리. 과거 `Supabase*Repository` 명명은 실동작(FastAPI HTTP)
+// 과 어긋나 'Supabase 직접 경로' 헛가설을 유발했다 → fc7bce47에서 Api* 단일 명명으로 정정.
+export { ApiEpicRepository } from './ApiEpicRepository';
+export { ApiStoryRepository } from './ApiStoryRepository';
+export { ApiTaskRepository } from './ApiTaskRepository';
+export { ApiDocRepository } from './ApiDocRepository';
+export { ApiProjectRepository } from './ApiProjectRepository';
+export { ApiSprintRepository } from './ApiSprintRepository';
+export { ApiNotificationRepository } from './ApiNotificationRepository';
+export { ApiTeamMemberRepository } from './ApiTeamMemberRepository';
+export { ApiInboxItemRepository } from './ApiInboxItemRepository';
 export { ApiHypothesisRepository } from './ApiHypothesisRepository';
-
-// Alias: supabase 없는 이름으로 re-export
-export { SupabaseEpicRepository as ApiEpicRepository } from './SupabaseEpicRepository';
-export { SupabaseStoryRepository as ApiStoryRepository } from './SupabaseStoryRepository';
-export { SupabaseTaskRepository as ApiTaskRepository } from './SupabaseTaskRepository';
-export { SupabaseDocRepository as ApiDocRepository } from './SupabaseDocRepository';
-export { SupabaseProjectRepository as ApiProjectRepository } from './SupabaseProjectRepository';
-export { SupabaseSprintRepository as ApiSprintRepository } from './SupabaseSprintRepository';
-export { SupabaseNotificationRepository as ApiNotificationRepository } from './SupabaseNotificationRepository';
-export { SupabaseTeamMemberRepository as ApiTeamMemberRepository } from './SupabaseTeamMemberRepository';
-export { SupabaseInboxItemRepository as ApiInboxItemRepository } from './SupabaseInboxItemRepository';


### PR DESCRIPTION
## 스토리
[TECH-DEBT][BE/Infra] fc7bce47 — Supabase 잔재 제거(vestigial naming). **선생님 질책 건**: storage-api `Supabase*Repository`가 실은 FastAPI HTTP 래퍼인데 `Supabase` 명명이라 slug done-blocker 추적서 팀+PO를 'Supabase 직접 경로' 헛가설로 수시간 헛수고하게 함.

## 착수 전 git 검증 (잉여작업 방지)
- **AC1**(`_get_secret` supabase_jwt_secret fallback 제거)·**AC2 코드분**(supabase config 필드)은 **이미 #1382 [SID:fc7bce47]로 develop 머지 완료** → 추가 작업 없음.
- 진짜 잔여 = **AC3-BE(TypeScript)**: storage-api `Supabase*Repository` 미스리딩 명명.

## 변경 (이번 PR = naming 근원 박멸, 스코프 ⓑ)
- storage-api **9종** `Supabase*Repository` → `Api*Repository` rename(파일+클래스): Doc·Epic·Story·Task·Project·Sprint·Notification·TeamMember·InboxItem. `ApiHypothesisRepository` 선례와 정합.
- `index.ts`: `Supabase*` + `Api* as` **이중 export 제거 → Api* 단일** export.
- 소비자는 이미 `Api*` 별칭 사용(직접 `Supabase*` 참조 **0건**) → 무파손.
- 미스리딩 코멘트 잔재(agent-builtin-tools.test.ts) Api 명명 정합.

## 검증 (AC4 회귀)
- storage-api **type-check 0** · web **type-check 0**(소비자 Api* 해소) · vitest **24 passed**(docs/storage 경로).
- login·OAuth·token refresh·docs/story/task/epic/sprint CRUD dev 무영향(소비 배선 무변경).

## 분리 (별도 후속 — E-POLISH 티켓 등록됨)
- `DocsService`의 `if(this.db){.from().eq()}`는 **dead 아님**: `sprints/[id]/close/route.ts:82`가 실 db 전달·`docs.test.ts`가 db 분기 테스트 → 제거 시 회귀.
- `RetroSessionService`는 db-only **dead 서비스**(라우트 proxy 위임).
- → 둘 다 naming root와 직교·entangled 회귀 위험이라 focused 후속 PR로 분리(회귀분석 후 처분).

## 분리(스코프 외, 기킥오프 명시)
- AC2 **prod env/시크릿 제거** = prod 승인 필요 → 오르테가군 별도.
- AC3① **ee/ FE dead 라우트** = 유나양 follow-up.

까심 cross-model QA(전 repo 소비 경로 회귀) + PO 게이트 대기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)