### PR TITLE
fix(db): 0120 plan_features PRIMARY KEY 복원 (e491d087)

### DIFF
--- a/backend/alembic/versions/0120_restore_plan_features_pk.py
+++ b/backend/alembic/versions/0120_restore_plan_features_pk.py
@@ -1,0 +1,50 @@
+"""plan_features PRIMARY KEY 복원 — 0114(#1403) 누락 drift (story e491d087).
+
+a74bdc84 트리아지서 적출: ORM(`app/models/plan_feature.py`)은 `id`를 PK로 정의하나
+DB(0096 baseline)에 부재. 0114(ORM-모델 39개 PK 복원, #1403)와 동일 클래스이나 그 목록에서
+누락됐다. 머지된 0114는 미수정 — 별도 0120으로 plan_features만 idempotent 복원.
+
+⚠️ ADD PRIMARY KEY는 대상 컬럼에 NULL/중복이 있으면 실패한다. fresh/clean DB에선 무조건
+성공하나 real dev/prod 적용 전 dup-id/NULL 전수 preflight 필수 —
+`backend/scripts/preflight/0120_plan_features_pk_preflight.sql` 동봉. preflight 0건 확인 후 머지.
+
+⚠️ 별개 drift(보고됨): baseline schema.sql의 plan_features 컬럼(tier_id/feature_key/enabled/
+limit_value)이 0049/ORM(code/name/tier/is_active/...)과 불일치한다 — 컬럼 정합은 본 PK 스토리와
+별 트랙. 본 마이그는 양 버전에 공통 존재하는 `id` 컬럼의 PRIMARY KEY만 복원한다.
+"""
+from alembic import op
+
+revision = "0120"
+down_revision = "0119"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    from sqlalchemy import inspect
+
+    if "plan_features" not in set(inspect(conn).get_table_names()):
+        # 방어: 환경 편차로 테이블 부재 시 건너뜀(본 마이그는 추가만, 생성 안 함).
+        return
+    # PK 부재 시에만 추가(idempotent). 0114(#1403) 동일 가드 패턴.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conrelid = 'public.plan_features'::regclass AND contype = 'p'
+            ) THEN
+                ALTER TABLE public.plan_features
+                    ADD CONSTRAINT plan_features_pkey PRIMARY KEY (id);
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # 드리프트 교정이므로 되돌리지 않는다 — PK를 drop하면 원래 결함(ORM↔DB 불일치)을 재현한다.
+    # (0114 / 0107 docs_pkey / 0113 epics_pkey와 동일 정책.)
+    pass

--- a/backend/scripts/preflight/0120_plan_features_pk_preflight.sql
+++ b/backend/scripts/preflight/0120_plan_features_pk_preflight.sql
@@ -1,0 +1,17 @@
+-- 0120 plan_features PRIMARY KEY 복원 — preflight (story e491d087 머지 게이트)
+--
+-- real dev/prod 양쪽에 실행. ADD PRIMARY KEY는 대상 컬럼에 NULL 또는 중복이 있으면 실패하므로,
+-- 0120 머지/적용 전 plan_features.id 를 점검한다. null_cnt>0 또는 dup_groups>0 이면 데이터
+-- 정리 선행이 필요(머지 블로커). 전 0이면 GO.
+--
+-- 실행: psql "$PROD_OR_DEV_URL" -f backend/scripts/preflight/0120_plan_features_pk_preflight.sql
+-- (cloud-sql-proxy 경유 — reference_prod_db_query 참조. 인프라 lane.)
+--
+-- ⚠️ 참고: plan_features 컬럼 자체가 baseline(tier_id/feature_key)↔0049/ORM(code/name/tier)으로
+-- drift돼 있다(별 트랙). 본 preflight는 양 버전 공통인 id 컬럼만 점검한다. real plan_features의
+-- 실 컬럼(\d plan_features)도 같이 확인해 0049 버전(code/name/tier)인지 교차검증 권장.
+
+\pset format aligned
+SELECT 'plan_features' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM plan_features WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM plan_features GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups;

--- a/backend/scripts/preflight/plan_features_schema_audit.sql
+++ b/backend/scripts/preflight/plan_features_schema_audit.sql
@@ -1,0 +1,57 @@
+-- plan_features 실스키마 감사 + 0120 PK preflight (story e491d087 · #1519)
+--
+-- 목적:
+--   (1) 실 컬럼 introspection으로 드리프트 확정 — Ⓐ ORM/0049(code/name/tier/is_active...)
+--       vs Ⓑ baseline schema.sql(tier_id/feature_key/enabled/limit_value). baseline 반영
+--       방향(0120 baseline 컬럼 정합 후속)을 이 결과로 결정.
+--   (2) 0120 ADD PRIMARY KEY(id) preflight — id NULL/중복 0건이어야 GO(있으면 머지 블로커).
+--
+-- ⚠️ READ-ONLY. SELECT만 — 데이터/스키마 변경 없음. dev·prod 양쪽 동일 실행.
+-- 실행: Private-IP DB라 로컬 psql 불가 → Cloud Run 일회성 잡(psql 또는 SQL 러너)로 주입.
+--       psql 백슬래시 메타명령 미사용(순수 SQL) — 어떤 실행기로도 동일 출력. 각 결과셋은
+--       section 라벨 컬럼으로 자기설명.
+-- 참조: [[reference_privateip_db_diag_and_project_authz]]
+
+-- ── [1] 컬럼 introspection (ⒶvsⒷ 판정의 1차 근거) ──────────────────────────────
+SELECT
+    '1_columns'        AS section,
+    ordinal_position   AS pos,
+    column_name,
+    data_type,
+    is_nullable,
+    column_default
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name = 'plan_features'
+ORDER BY ordinal_position;
+
+-- ── [2] 제약 (PK 존재 여부 = 0120 사유 직접 확인) ──────────────────────────────
+SELECT
+    '2_constraints'              AS section,
+    conname                      AS constraint_name,
+    contype                      AS type,  -- p=PK, u=unique, f=FK, c=check
+    pg_get_constraintdef(oid)    AS definition
+FROM pg_constraint
+WHERE conrelid = 'public.plan_features'::regclass
+ORDER BY contype, conname;
+
+-- ── [3] 인덱스 ────────────────────────────────────────────────────────────────
+SELECT
+    '3_indexes'  AS section,
+    indexname,
+    indexdef
+FROM pg_indexes
+WHERE schemaname = 'public'
+  AND tablename = 'plan_features'
+ORDER BY indexname;
+
+-- ── [4] 행 수 ─────────────────────────────────────────────────────────────────
+SELECT '4_rowcount' AS section, count(*) AS row_count FROM plan_features;
+
+-- ── [5] 0120 PK preflight (id_null_cnt·id_dup_groups 둘 다 0이어야 GO) ─────────
+SELECT
+    '5_pk_preflight' AS section,
+    (SELECT count(*) FROM plan_features WHERE id IS NULL) AS id_null_cnt,
+    (SELECT count(*) FROM (
+        SELECT id FROM plan_features GROUP BY id HAVING count(*) > 1
+    ) d) AS id_dup_groups;


### PR DESCRIPTION
## 스토리
e491d087 — baseline PK 드리프트 복원. **net-new = plan_features PK만**(39 본체는 `0114`/#1403로 기머지, git 검증).

## 변경
- **`0120_restore_plan_features_pk`**: plan_features `id` PRIMARY KEY idempotent 복원(`IF NOT EXISTS pg_constraint contype='p'` 가드, 0114/#1403 동일 패턴). 머지된 0114 미수정.
- **`scripts/preflight/0120_plan_features_pk_preflight.sql`**: id dup/NULL 전수 점검(ADD PK는 dup/NULL 시 실패).
- downgrade no-op(drift 재현 금지 정책 — 0114/0107/0113 동일).

## 검증 (fresh-DB)
pgvector:pg16 + `alembic upgrade head`→**0120 도달** · `plan_features_pkey` 추가 확인 · downgrade no-op(PK 유지) · 재upgrade idempotent(중복 add 0). green.

## ⚠️ 머지 게이트 (gcloud 대기)
- **gcloud preflight 0건**: real dev/prod에 `0120_plan_features_pk_preflight.sql` 실행해 id dup/NULL 0 확인 후 머지([[feedback_no_merge_without_migration_capability]]). **현재 gcloud 토큰 만료 — re-auth 대기**(오르테가군 조율).

## ⚠️ 별개 drift (본 PR 범위 밖·보고됨)
baseline schema.sql plan_features 컬럼(`tier_id/feature_key/enabled/limit_value`)이 **0049/ORM(`code/name/tier/...`)과 불일치**(동명이체). real dev/prod 실스키마가 0049인지 baseline인지 = **gcloud `\d plan_features` 확인 대기**:
- ⓐ real=0049 → baseline schema.sql plan_features를 0049로 정정 + PK 반영(별도 커밋).
- ⓑ real=baseline(billing) → ORM/라우터(`plan_features.py`) 깨진 상태라 컬럼 정합이 더 큰 별 스토리.
본 PR의 PK(id) 마이그는 양 버전 공통 id라 무관하게 유효. baseline 반영은 ⓐ/ⓑ 후속.

까심 QA(마이그 타당성) + gcloud preflight 후 PO 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)