### PR TITLE
feat(agent-gateway): SSE/webhook 페이로드에 project_id·org_id·conversation_title 추가 (d0bca260)

### DIFF
--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -189,13 +189,16 @@ async def _fetch_events(
                 e.created_at,
                 e.project_id::text    AS project_id,
                 e.org_id::text        AS org_id,
-                c.title               AS conversation_title
+                c.title               AS conversation_title,
+                tm.name               AS sender_name
             FROM events e
             -- d0bca260: conversation_title 도출. payload.conversation_id가 uuid 형태일 때만 join
             -- (비-대화 이벤트는 NULL → 안전). 36자 uuid 패턴 가드로 ::uuid 캐스트 에러 0.
             LEFT JOIN conversations c
-                ON e.payload->>'conversation_id' ~ '^[0-9a-fA-F-]{36}$'
+                ON e.payload->>'conversation_id' ~ '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
                AND c.id = (e.payload->>'conversation_id')::uuid
+            -- d0bca260 AC3: sender_name. events.sender_id는 team_members FK라 직접 join(canonical 무관).
+            LEFT JOIN team_members tm ON tm.id = e.sender_id
             WHERE e.recipient_id = CAST(:agent_id AS uuid)
               AND e.recipient_seq > :after_seq
             ORDER BY e.recipient_seq ASC
@@ -228,6 +231,7 @@ def _row_to_payload(row: object) -> dict:
         "project_id": getattr(row, "project_id", None),
         "org_id": getattr(row, "org_id", None),
         "conversation_title": getattr(row, "conversation_title", None),
+        "sender_name": getattr(row, "sender_name", None),
     }
 
 

--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -186,8 +186,16 @@ async def _fetch_events(
                 e.source_entity_id::text AS source_entity_id,
                 e.sender_id::text     AS sender_id,
                 e.payload,
-                e.created_at
+                e.created_at,
+                e.project_id::text    AS project_id,
+                e.org_id::text        AS org_id,
+                c.title               AS conversation_title
             FROM events e
+            -- d0bca260: conversation_title 도출. payload.conversation_id가 uuid 형태일 때만 join
+            -- (비-대화 이벤트는 NULL → 안전). 36자 uuid 패턴 가드로 ::uuid 캐스트 에러 0.
+            LEFT JOIN conversations c
+                ON e.payload->>'conversation_id' ~ '^[0-9a-fA-F-]{36}$'
+               AND c.id = (e.payload->>'conversation_id')::uuid
             WHERE e.recipient_id = CAST(:agent_id AS uuid)
               AND e.recipient_seq > :after_seq
             ORDER BY e.recipient_seq ASC
@@ -215,6 +223,11 @@ def _row_to_payload(row: object) -> dict:
         # E-EVENT-INJECT S1: content를 SSE top-level로 노출 → connector 드롭 방지.
         "content": (_payload or {}).get("content"),
         "created_at": row.created_at.isoformat(),  # type: ignore[attr-defined]
+        # d0bca260: BYOA 어댑터 컨텍스트 — project_id·org_id·conversation_title top-level(additive).
+        # Event는 project_id·org_id 보유(미직렬화였음)·title은 conversations join. BYOA 온보딩 매끄러움.
+        "project_id": getattr(row, "project_id", None),
+        "org_id": getattr(row, "org_id", None),
+        "conversation_title": getattr(row, "conversation_title", None),
     }
 
 

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -237,6 +237,11 @@ async def deliver_conversation_message_webhook(
                 return
 
             mentioned_id_strs = [str(m) for m in (mentioned_ids or [])]
+            # d0bca260: conversation_title 도출(additive 컨텍스트).
+            from app.models.conversation import Conversation
+            conv_title = (await db.execute(
+                select(Conversation.title).where(Conversation.id == conversation_id)
+            )).scalar_one_or_none()
             payload = {
                 "event_type": _EVENT_TYPE,
                 "message_id": str(message_id),
@@ -246,6 +251,10 @@ async def deliver_conversation_message_webhook(
                 "created_at": created_at.isoformat(),
                 "mentioned_ids": mentioned_id_strs,
                 "content": content,
+                # d0bca260: BYOA 어댑터 컨텍스트 — project_id·org_id·conversation_title top-level(additive).
+                "project_id": str(project_id),
+                "org_id": str(org_id),
+                "conversation_title": conv_title,
             }
 
             for wh in target_webhooks:

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -237,11 +237,17 @@ async def deliver_conversation_message_webhook(
                 return
 
             mentioned_id_strs = [str(m) for m in (mentioned_ids or [])]
-            # d0bca260: conversation_title 도출(additive 컨텍스트).
+            # d0bca260: conversation_title + sender_name 도출(additive 컨텍스트).
             from app.models.conversation import Conversation
             conv_title = (await db.execute(
                 select(Conversation.title).where(Conversation.id == conversation_id)
             )).scalar_one_or_none()
+            sender_name = None
+            if sender_id is not None:
+                from app.models.team import TeamMember
+                sender_name = (await db.execute(
+                    select(TeamMember.name).where(TeamMember.id == sender_id)
+                )).scalar_one_or_none()
             payload = {
                 "event_type": _EVENT_TYPE,
                 "message_id": str(message_id),
@@ -251,10 +257,11 @@ async def deliver_conversation_message_webhook(
                 "created_at": created_at.isoformat(),
                 "mentioned_ids": mentioned_id_strs,
                 "content": content,
-                # d0bca260: BYOA 어댑터 컨텍스트 — project_id·org_id·conversation_title top-level(additive).
+                # d0bca260: BYOA 어댑터 컨텍스트(additive top-level).
                 "project_id": str(project_id),
                 "org_id": str(org_id),
                 "conversation_title": conv_title,
+                "sender_name": sender_name,
             }
 
             for wh in target_webhooks:

--- a/backend/tests/test_agent_gateway.py
+++ b/backend/tests/test_agent_gateway.py
@@ -461,3 +461,46 @@ async def test_disconnect_keeps_chat_working_when_other_session_active():
          patch("app.services.chat_presence.clear_member") as mock_clear:
         await _mark_agent_disconnected(AGENT_ID, uuid.uuid4())
     mock_clear.assert_not_called()
+
+
+# d0bca260: SSE payload BYOA 컨텍스트 — project_id·org_id·conversation_title top-level
+def test_row_to_payload_includes_project_org_conversation_title():
+    from types import SimpleNamespace
+    from datetime import datetime, timezone
+    from app.routers.agent_gateway import _row_to_payload
+
+    pid, oid = str(uuid.uuid4()), str(uuid.uuid4())
+    row = SimpleNamespace(
+        event_id="ev1", event_type="conversation.message_created", recipient_seq=42,
+        source_entity_type="member", source_entity_id="m1", sender_id="s1",
+        payload={"conversation_id": "c1", "content": "hi"},
+        created_at=datetime(2026, 6, 15, tzinfo=timezone.utc),
+        project_id=pid, org_id=oid, conversation_title="Sprintable QA",
+    )
+    out = _row_to_payload(row)
+    # 신규 top-level 3필드
+    assert out["project_id"] == pid
+    assert out["org_id"] == oid
+    assert out["conversation_title"] == "Sprintable QA"
+    # 기존 키 무파손(additive)
+    assert out["event_id"] == "ev1"
+    assert out["recipient_seq"] == 42
+    assert out["content"] == "hi"
+    assert out["source"]["id"] == "m1"
+
+
+def test_row_to_payload_missing_new_attrs_safe():
+    """구 row(컬럼 미포함)에도 getattr 기본 None — AttributeError 0(하위호환)."""
+    from types import SimpleNamespace
+    from datetime import datetime, timezone
+    from app.routers.agent_gateway import _row_to_payload
+
+    row = SimpleNamespace(
+        event_id="ev2", event_type="dispatched", recipient_seq=1,
+        source_entity_type=None, source_entity_id=None, sender_id=None,
+        payload={}, created_at=datetime(2026, 6, 15, tzinfo=timezone.utc),
+    )
+    out = _row_to_payload(row)
+    assert out["project_id"] is None
+    assert out["org_id"] is None
+    assert out["conversation_title"] is None

--- a/backend/tests/test_agent_gateway.py
+++ b/backend/tests/test_agent_gateway.py
@@ -476,12 +476,14 @@ def test_row_to_payload_includes_project_org_conversation_title():
         payload={"conversation_id": "c1", "content": "hi"},
         created_at=datetime(2026, 6, 15, tzinfo=timezone.utc),
         project_id=pid, org_id=oid, conversation_title="Sprintable QA",
+        sender_name="디디 은와추쿠",
     )
     out = _row_to_payload(row)
-    # 신규 top-level 3필드
+    # 신규 top-level 4필드
     assert out["project_id"] == pid
     assert out["org_id"] == oid
     assert out["conversation_title"] == "Sprintable QA"
+    assert out["sender_name"] == "디디 은와추쿠"
     # 기존 키 무파손(additive)
     assert out["event_id"] == "ev1"
     assert out["recipient_seq"] == 42
@@ -504,3 +506,4 @@ def test_row_to_payload_missing_new_attrs_safe():
     assert out["project_id"] is None
     assert out["org_id"] is None
     assert out["conversation_title"] is None
+    assert out["sender_name"] is None


### PR DESCRIPTION
## 스토리
d0bca260 — 빅터/산티아고 Hermes 온보딩 도출. 에이전트 inbound 페이로드(`agent_gateway._row_to_payload` SSE + `conversation_webhook`)가 conversation_id·sender·recipient_seq·thread_id는 주나 **project_id·org_id·conversation_title은 top-level 미포함**(Event 모델엔 project_id·org_id 있으나 미직렬화) → BYOA 어댑터가 프로젝트 컨텍스트 못 받음.

> 내 hermes 어댑터(#1512)는 이미 `payload.conversation_title`을 chat_name으로 기대 중 — backend 미제공이라 fallback만 타던 그 갭을 정확히 메움.

## 변경 (additive·마이그 무관)
- **SSE `_row_to_payload`**: `_fetch_events` SELECT에 `e.project_id`·`e.org_id` + `conversations` LEFT JOIN(payload.conversation_id 36자 uuid 가드 → 비-대화 이벤트 NULL·캐스트 에러 0)으로 `conversation_title` 도출 → payload **top-level 3필드**. 구 row 대비 `getattr` 기본 None(하위호환).
- **`deliver_conversation_message_webhook`**: payload에 project_id·org_id(파라미터 보유) + conversation_title(conversations 조회) 추가.
- 기존 키 전부 무파손.

## 검증
- `test_agent_gateway`: `_row_to_payload` 3필드 노출 + 구 row 하위호환(getattr None) 테스트 2종 추가.
- 전체 backend **2091 passed·회귀 0**(잔여 3 실패는 MCP e2e 연결·contract 파일 env 의존, 본 변경 미접촉).

## AC
- ① SSE + conversation_webhook payload에 project_id·org_id·conversation_title top-level 추가 ✅
- additive·기존 소비자 무파손 ✅ · 회귀 0 ✅

까심 cross-model QA + PO 게이트 대기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)