### PR TITLE
fix(mcp): get_doc 본문(content) surface — 에이전트 doc 공유 (8a8e881a)

### DIFF
--- a/backend/sprintable_mcp/tools/docs.py
+++ b/backend/sprintable_mcp/tools/docs.py
@@ -64,9 +64,21 @@ async def list_docs(args: ListDocsInput) -> list[TextContent]:
 
 
 async def get_doc(args: GetDocInput) -> list[TextContent]:
-    """slug로 문서 단건 조회."""
+    """slug로 문서 단건 조회 — 본문(content) 포함.
+
+    8a8e881a: list 엔드포인트(/api/v2/docs?slug=)는 DocSummary(메타·snippet만·content 미포함)를
+    반환해 에이전트가 서로의 doc 본문을 못 읽었다. slug→id 해소 후 GET /{id}(DocResponse·content
+    보유)를 surface한다. 메타데이터(id·title·slug·tags·updated_at)는 DocResponse에 그대로 있어
+    기존 소비자 무영향(content 필드만 추가).
+    """
     try:
-        return ok(await client.get("/api/v2/docs", params={"project_id": client.project_id, "slug": args.slug}))
+        summaries = await client.get(
+            "/api/v2/docs", params={"project_id": client.project_id, "slug": args.slug}
+        )
+        if not summaries:
+            return err(f"Doc not found: {args.slug}")
+        doc_id = summaries[0]["id"]
+        return ok(await client.get(f"/api/v2/docs/{doc_id}"))
     except Exception as exc:
         return err(str(exc))
 

--- a/backend/tests/test_mcp_get_doc_8a8e881a.py
+++ b/backend/tests/test_mcp_get_doc_8a8e881a.py
@@ -1,0 +1,61 @@
+"""8a8e881a: MCP get_doc 본문(content) surface 회귀 가드.
+
+기존: get_doc이 list 엔드포인트(/api/v2/docs?slug=)=DocSummary(메타·snippet만)를 반환 →
+에이전트가 서로의 doc 본문을 못 읽음. 수정: slug→id 해소 후 GET /{id}(DocResponse·content) surface.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_get_doc_surfaces_content():
+    from sprintable_mcp.tools.docs import GetDocInput, get_doc
+
+    doc_id = "11111111-1111-1111-1111-111111111111"
+    list_resp = [{"id": doc_id, "title": "Handoff", "slug": "handoff", "snippet": "intro..."}]
+    doc_resp = {
+        "id": doc_id, "title": "Handoff", "slug": "handoff", "tags": [],
+        "content": "FULL BODY — 핸드오프 계약 내용", "content_format": "markdown",
+        "updated_at": "2026-06-15T00:00:00Z",
+    }
+    calls: list[tuple] = []
+
+    async def fake_get(path, params=None):
+        calls.append((path, params))
+        return list_resp if path == "/api/v2/docs" else doc_resp
+
+    with patch("sprintable_mcp.tools.docs.client") as mock_client:
+        mock_client.project_id = "proj"
+        mock_client.get = AsyncMock(side_effect=fake_get)
+        out = await get_doc(GetDocInput(slug="handoff"))
+
+    parsed = json.loads(out[0].text)
+    # 본문(content) surface — 핵심 AC
+    assert parsed["content"] == "FULL BODY — 핸드오프 계약 내용"
+    # 메타데이터 유지(기존 소비자 무영향)
+    assert parsed["id"] == doc_id
+    assert parsed["title"] == "Handoff"
+    assert parsed["slug"] == "handoff"
+    # slug→id 해소 후 GET /{id} 경로 호출 확인
+    assert any(p == f"/api/v2/docs/{doc_id}" for p, _ in calls)
+
+
+@pytest.mark.anyio
+async def test_get_doc_not_found_returns_error():
+    from sprintable_mcp.tools.docs import GetDocInput, get_doc
+
+    with patch("sprintable_mcp.tools.docs.client") as mock_client:
+        mock_client.project_id = "proj"
+        mock_client.get = AsyncMock(return_value=[])
+        out = await get_doc(GetDocInput(slug="nope"))
+
+    assert "not found" in out[0].text.lower()


### PR DESCRIPTION
## 스토리
[tooling/bug] 8a8e881a — MCP `get_doc(slug)`이 메타데이터(id·title·slug·tags·updated_at)만 반환하고 **본문/content 미surface**(snippet=null) → 에이전트가 서로의 doc(핸드오프 계약·설계doc) 못 읽음. (2026-06-05 디디가 유나 `e-mcp-toolset-picker-handoff` 카탈로그 계약 못 읽어 PO 채팅 릴레이로 우회한 그 건.)

## 근본
`get_doc`이 `GET /api/v2/docs?slug=`(**list 엔드포인트 = `DocSummaryResponse`**, "content 미포함으로 페이로드 최소화"·snippet만)를 호출. backend엔 `GET /api/v2/docs/{id}` = `DocResponse`(`content: str` 보유)가 있으나 get_doc이 안 탐.

## 수정 (additive)
`get_doc`: slug→id 해소(list-by-slug로 id 획득) 후 **`GET /{id}`(DocResponse·content)** surface. 메타데이터는 DocResponse에 그대로 있어 **기존 소비자 무영향**(content 필드만 추가). 미존재 slug는 명시 not-found 에러.

```python
summaries = await client.get("/api/v2/docs", params={..., "slug": args.slug})
if not summaries: return err("Doc not found: ...")
doc_id = summaries[0]["id"]
return ok(await client.get(f"/api/v2/docs/{doc_id}"))  # DocResponse·content
```

## AC
- ① get_doc이 doc 본문(content) 반환 ✅
- ② create_doc→타 에이전트 get_doc 본문 수신 — 유닛(slug→id→content) 커버, 라이브 라운드트립은 QA.
- ③ 회귀: 기존 메타데이터 반환·소비자 무영향 ✅ (DocResponse 전 메타 보유, MCP contract/toolset 39 passed)

## 검증
`test_mcp_get_doc_8a8e881a`(content surface·slug→id 경로·not-found) + MCP contract/toolset 회귀 **39 passed**. 마이그·gcloud 무관.

까심 cross-model QA(에이전트 doc 라운드트립) + PO 게이트 대기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)