### PR TITLE
fix(authz): project_auth team_member 분기 tm.type='human' lockstep 정합 (35a0691e)

### DIFF
--- a/backend/app/services/project_auth.py
+++ b/backend/app/services/project_auth.py
@@ -35,6 +35,10 @@ async def has_project_access(
                     WHERE tm.project_id = p.id
                       AND (tm.id = :user_id OR tm.user_id = :user_id)
                       AND tm.is_active = true
+                      -- 35a0691e: me/memberships(me.py)와 동일 기준 — team_member 분기는 휴먼만.
+                      -- 에이전트는 아래 project_access grant 분기(member_id)로 인가(SSOT 정합·드리프트
+                      -- 방지). 온보딩이 agent grant를 생성하므로 휴먼-필터가 에이전트 access 무영향. #1125 후속.
+                      AND tm.type = 'human'
                 )
                 OR EXISTS (
                     SELECT 1 FROM project_access pa
@@ -123,6 +127,8 @@ async def first_accessible_project_id(
             WHERE tm.org_id = :org_id
               AND (tm.id = :user_id OR tm.user_id = :user_id)
               AND tm.is_active = true
+              -- 35a0691e: has_project_access lockstep — team_member 분기 휴먼만(에이전트는 grant).
+              AND tm.type = 'human'
               AND p.deleted_at IS NULL
             ORDER BY tm.created_at ASC
             LIMIT 1
@@ -204,6 +210,8 @@ async def accessible_project_ids_in_org(
                     WHERE tm.project_id = p.id
                       AND (tm.id = :user_id OR tm.user_id = :user_id)
                       AND tm.is_active = true
+                      -- 35a0691e: has_project_access lockstep — team_member 분기 휴먼만(에이전트는 grant).
+                      AND tm.type = 'human'
                 )
                 OR EXISTS (
                     SELECT 1 FROM project_access pa


### PR DESCRIPTION
## 스토리
35a0691e — #1125 인시던트 QA 후속. `project_auth.py`의 SSOT 인가 헬퍼가 team_member 분기에서 `me/memberships`(me.py)와 달리 **`tm.type='human'` 필터 부재** → 드리프트. switch_* 외에도 attachments/projects/dependencies가 호출하는 SSOT 헬퍼라 양 사용처서 글자 그대로 같아야 진짜 SSOT.

## 변경 (lockstep — 세 함수 일괄, ⓐ)
정독서 **team_member 분기 가진 3 함수 전부** 동일 drift 적출(docstring이 셋 "lockstep" 명시 → has만 고치면 새 drift). 일괄 정합:
- `has_project_access` · `first_accessible_project_id` · `accessible_project_ids_in_org` 각 team_member 분기에 `AND tm.type = 'human'`.

**agent-safe**: 에이전트는 `project_access` grant 분기(member_id·m.type='agent')로 인가 유지 — 온보딩이 agent grant 생성·member-SSOT 컷오버로 agent=grant 기반이 설계. 휴먼-필터가 agent access 무영향. grant-less 레거시 에이전트는 grant 부여로 풀 데이터갭(별건)이지 드리프트 유지 사유 아님.

마이그·gcloud 무관(로직 only).

## 검증
- 전체 backend **2093 passed·회귀 0** (switch/projects/memberships/grant 경로 통과 = 휴먼·agent-grant access 보존). 잔여 3 실패는 MCP e2e·contract 파일 env 의존, 본 변경 미접촉.
- ⚠️ **까심 cross-model QA 3케이스 필수**(gcloud 만료라 live agent-grant 직접확인 불가): (a)휴먼 access 무변경 (b)agent grant 경로 access 유지 (c)grant-less 셋 일관 차단.
- 배포 후 agent access 1건이라도 깨지면 즉시 fast-follow.

까심 cross-model QA(3케이스) + PO 게이트 대기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)