### PR TITLE
[SID:673d9b2b] 대시보드 '최근 문서'·'활성 스프린트' 위젯 실 데이터 연결

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -3,6 +3,10 @@ import { redirect } from 'next/navigation';
 import { FileText } from 'lucide-react';
 import { getServerSession } from '@/lib/db/server';
 import { fastapiCall } from '@sprintable/storage-api';
+import { DocsService } from '@/services/docs';
+import { SprintService } from '@/services/sprint';
+import { createDocRepository, createSprintRepository } from '@/lib/storage/factory';
+import { buildCursorPageMeta } from '@/lib/pagination';
 import { getLocale, getTranslations } from 'next-intl/server';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -71,8 +75,39 @@ export default async function DashboardPage() {
     { query: { member_id: teamMemberId, project_id: projectId } },
   ).catch(() => null);
 
-  const activeSprints: Array<{ id: string; title: string; status: string; start_date: string; end_date: string }> = [];
-  const docs: Array<{ id: string; title: string; slug: string }> = [];
+  // 활성 스프린트: /api/sprints route와 동일 데이터 경로(SprintService.list, status='active') 미러.
+  const activeSprints: Array<{ id: string; title: string; status: string; start_date: string; end_date: string }> = await (async () => {
+    try {
+      const repo = await createSprintRepository();
+      const service = new SprintService(repo, undefined);
+      const rows = await service.list({ project_id: projectId, status: 'active' });
+      return (rows ?? []).map((s) => ({
+        id: s.id,
+        title: s.title,
+        status: s.status,
+        start_date: s.start_date,
+        end_date: s.end_date,
+      }));
+    } catch {
+      return [];
+    }
+  })();
+  // '최근 문서' 위젯: /api/docs route와 동일 데이터 경로(DocsService.list→updated_at 최근순) 미러, limit 5.
+  const docs: Array<{ id: string; title: string; slug: string }> = await (async () => {
+    try {
+      const repo = await createDocRepository();
+      const service = new DocsService(repo, undefined);
+      const rows = await service.list(projectId, { limit: 5 });
+      const { page } = buildCursorPageMeta(
+        rows as Array<{ id: string; title: string; slug: string; updated_at: string }>,
+        5,
+        'updated_at',
+      );
+      return page.map((d) => ({ id: d.id, title: d.title, slug: d.slug }));
+    } catch {
+      return [];
+    }
+  })();
   const assignedStories = dashboardData?.my_stories ?? [];
 
   const activeSprint = activeSprints[0] ?? null;


### PR DESCRIPTION
## 요약
대시보드 **'최근 문서' 위젯이 항상 빈칸**인 버그(story `673d9b2b`, FE·E-POLISH) + **인접 '활성 스프린트' 위젯**도 같은 원인(PO bundle 판단으로 동봉).

## 근본
`dashboard/page.tsx`의 데이터 소스 2줄이 하드코딩 빈배열:
- `const docs = []` → 위젯 render(`docs.length>0 ? map : EmptyState`)는 정상이나 소스가 항상 `[]` → 무조건 EmptyState.
- `const activeSprints = []` → 동일(스프린트 위젯 빈상태).

## 수정 (render 무변경, 데이터 소스 2곳만 교체)
- **docs**: `DocsService.list(projectId, {limit:5})` — `/api/docs` route 데이터경로 미러(`createDocRepository` + `buildCursorPageMeta(rows, 5, 'updated_at')`로 updated_at 최근순)·`{id,title,slug}` 매핑.
- **activeSprints**: `SprintService.list({ project_id, status:'active' })` — `/api/sprints` route 미러(standup/page.tsx도 동일 경로 사용). shape `{id,title,status,start_date,end_date}`가 기존 `:74` 타입과 일치 → `sprintProgress` 계산 자동 동작.
- 둘 다 `.catch(()=>[])`. 서버 컴포넌트 직접 호출(대시보드 me/members와 동형 server-side).

## 검증
- `pnpm build` ✅ (exit 0) · ESLint ✅ 0 · `tsc --noEmit` ✅
- Base: **develop**
- render(`:374-399` 최근문서 + sprint 진행률) 무변경 → 회귀0.

## AC
①최근문서 실문서 ②active sprint 실스프린트 ③0건/무활성 시에만 EmptyState ④docs 최근순·limit 5 ⑤render 무변경.

## QA 가이드
문서/활성스프린트 있는 프로젝트 → 위젯에 실 데이터 노출·문서 클릭 시 `/docs/{slug}` 이동. 0건/무활성 org → EmptyState 정상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)