### PR TITLE
[SID:f1910a31] 보드 ?view=new → 백로그 인라인 컴포저 auto-open

### DIFF
--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -382,6 +382,17 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
     router.replace(params.toString() ? `?${params.toString()}` : window.location.pathname, { scroll: false });
   }, [searchParams, router]);
 
+  // f1910a31: ?view=new → 백로그 인라인 컴포저 auto-open(client nav·풀로드 둘 다). nonce로 신호 전달해
+  // 반복 진입도 재오픈되게 한다. one-shot으로 ?view=new를 즉시 제거(뒤로가기/재렌더 재오픈 방지·URL 정리).
+  const [autoComposeNonce, setAutoComposeNonce] = useState(0);
+  useEffect(() => {
+    if (searchParams.get('view') !== 'new') return;
+    setAutoComposeNonce((n) => n + 1);
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete('view');
+    router.replace(`/board${params.size > 0 ? `?${params.toString()}` : ''}`, { scroll: false });
+  }, [searchParams, router]);
+
   // URL에서 스토리 ID 읽어서 자동으로 패널 열기
   useEffect(() => {
     const storyId = searchParams.get('story');
@@ -1186,6 +1197,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
                     onLoadMore={() => handleLoadMore(col.id)}
                     collapsed={col.id === 'done' ? doneCollapsed : undefined}
                     onToggleCollapse={col.id === 'done' ? handleToggleDoneCollapse : undefined}
+                    autoComposeSignal={col.id === 'backlog' ? autoComposeNonce : 0}
                   />
                 );
               })}

--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ComponentType } from 'react';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useDroppable } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { useTranslations } from 'next-intl';
@@ -67,6 +67,8 @@ interface KanbanColumnProps {
   // BOARD-03: done column collapse
   collapsed?: boolean;
   onToggleCollapse?: () => void;
+  // f1910a31: ?view=new → 인라인 컴포저 auto-open. nonce가 바뀔 때마다(0→1, 1→2…) 재오픈.
+  autoComposeSignal?: number;
 }
 
 export function KanbanColumn({
@@ -77,6 +79,7 @@ export function KanbanColumn({
   onCreateStory, projectId, onKickoffStory, executionMap, blockedByMap, storyLabelsMap, storyGatesMap,
   totalCount, hasMore, loadingMore, onLoadMore,
   collapsed, onToggleCollapse,
+  autoComposeSignal,
 }: KanbanColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id });
   const t = useTranslations('board');
@@ -84,6 +87,11 @@ export function KanbanColumn({
   const [composing, setComposing] = useState(false);
   const [draftTitle, setDraftTitle] = useState('');
   const [submitting, setSubmitting] = useState(false);
+
+  // f1910a31: ?view=new 신호(nonce>0)면 인라인 컴포저 open. 컴포저 input의 autoFocus가 포커스 처리.
+  useEffect(() => {
+    if (autoComposeSignal && autoComposeSignal > 0) setComposing(true);
+  }, [autoComposeSignal]);
 
   const startCompose = () => {
     setDraftTitle('');


### PR DESCRIPTION
## 요약
보드 '새 스토리' 진입(`?view=new`)에서 **컴포저가 안 열리는** 버그(story `f1910a31`) 수정.

## 근본
- ⑴ `kanban-board`가 `view` 파라미터 미처리(`sprint_id`/`epic_id`/`story`만 읽음) → `?view=new` 무시.
- ⑵ 보드 story 생성은 컬럼별 인라인 컴포저뿐(story-create 모달 부재).

## 수정 (디자인 콜 ⒜ PO 확정 — 모달 신설 ✗·백로그 인라인 컴포저 auto-open)
- **`kanban-board`**: `searchParams.get('view')==='new'` 감지 useEffect(client nav·풀로드 둘 다) → `autoComposeNonce++` → **one-shot으로 `router.replace`로 `?view=new` 제거**(타 param 보존·뒤로가기/재렌더 재오픈 방지·URL 정리).
- **`KanbanColumn`**: `autoComposeSignal`(nonce) prop → `signal>0`이면 `setComposing(true)`. nonce라 **반복 `?view=new` 진입도 재오픈**. 포커스 = 기존 컴포저 input `autoFocus` 자동.
- 백로그만 신호 수신(`col.id==='backlog'`). **생성 자체는 기존 `handleCreateStory`(#1514 카운트/append 검증분) 재사용·무변경.**

## AC
①`?view=new`(직접 URL + 대시보드 클릭) → 컴포저 open+focus ②컴포저 생성 → 보드 반영 ③회귀: 일반 `/board` 미발동(view 가드)·one-shot 후 재오픈 X.

## 검증
- `pnpm build` ✅(exit 0)·ESLint ✅ 0·`tsc --noEmit` ✅ · Base **develop** · diff +21/−1·2파일.
- ⚠️ 라이브 "?view=new→컴포저 open+focus"는 render-reflect 질문이라 **유나 약속한 post-deploy 모바일/데스크탑 픽셀이 권위**(내 synthetic 하니스는 그 가시성에 보조). 머지→dev 후 실측.

## QA 가이드 (까심군)
`?view=new` 직접 URL + 대시보드 '새 스토리' 클릭 둘 다 → 백로그 컴포저 열림+포커스. 생성 시 카드 보드 반영. 일반 `/board`·새로고침·뒤로가기서 컴포저 안 열림(one-shot/view 가드).

🤖 Generated with [Claude Code](https://claude.com/claude-code)