### PR TITLE
feat(epic): list 응답에 story count 집계 부착 (0d4c89e8)

### DIFF
--- a/backend/app/repositories/epic.py
+++ b/backend/app/repositories/epic.py
@@ -35,11 +35,13 @@ class EpicRepository(BaseRepository[Epic]):
         order_by: str = "created_at",
         **filters: Any,
     ) -> tuple[list[Epic], int]:
-        """기본 페이지네이션 + 연결 가설 집계(hypothesis_count·risky_status) 부착."""
+        """기본 페이지네이션 + 연결 가설 집계(hypothesis_count·risky_status) + 스토리 집계
+        (total_stories·done_stories) 부착."""
         epics, total = await super().list_paginated(
             limit=limit, cursor=cursor, order_by=order_by, **filters
         )
         await self._attach_hypothesis_aggregates(epics)
+        await self._attach_story_aggregates(epics)
         return epics, total
 
     async def _attach_hypothesis_aggregates(self, epics: Sequence[Epic]) -> None:
@@ -82,6 +84,42 @@ class EpicRepository(BaseRepository[Epic]):
             rank = row.risk_rank
             if rank is not None and 0 <= rank < len(_RISK_ORDER):
                 epic.risky_status = _RISK_ORDER[rank]  # type: ignore[attr-defined]
+
+    async def _attach_story_aggregates(self, epics: Sequence[Epic]) -> None:
+        """페이지 전체 epic의 연결 스토리 수(total/done)를 단일 쿼리로 집계해 부착.
+
+        N+1 회피: epic_id IN (page) GROUP BY로 1회 집계(get_progress 집계 SQL 동형).
+        deleted_at IS NULL·org 스코프. 스토리 없으면 0/0. 비-매핑 인스턴스 속성이라
+        읽기 경로에서 flush 영향 없음. FE 에픽 카드(total/done) 바인딩용 — stories
+        배열은 부착 안 함(payload bloat 방지·detail은 별도 /progress 유지).
+        """
+        for epic in epics:
+            epic.total_stories = 0  # type: ignore[attr-defined]
+            epic.done_stories = 0  # type: ignore[attr-defined]
+        if not epics:
+            return
+
+        epic_ids = [epic.id for epic in epics]
+        result = await self.session.execute(
+            select(
+                Story.epic_id.label("epic_id"),
+                func.count(Story.id).label("total_stories"),
+                func.count(Story.id).filter(Story.status == "done").label("done_stories"),
+            )
+            .where(
+                Story.epic_id.in_(epic_ids),
+                Story.org_id == self.org_id,
+                Story.deleted_at.is_(None),
+            )
+            .group_by(Story.epic_id)
+        )
+        by_epic = {row.epic_id: row for row in result.all()}
+        for epic in epics:
+            row = by_epic.get(epic.id)
+            if row is None:
+                continue
+            epic.total_stories = int(row.total_stories or 0)  # type: ignore[attr-defined]
+            epic.done_stories = int(row.done_stories or 0)  # type: ignore[attr-defined]
 
     async def get_progress(self, id: uuid.UUID) -> EpicProgressResponse:
         result = await self.session.execute(

--- a/backend/app/schemas/epic.py
+++ b/backend/app/schemas/epic.py
@@ -64,6 +64,11 @@ class EpicResponse(BaseModel):
     # proposed>verified>killed>archived). 미부착 경로(get/create/update)는 기본값.
     hypothesis_count: int = 0
     risky_status: str | None = None
+    # 0d4c89e8: 연결 스토리 집계(list 응답서 N+1 없이 부착·hypothesis_count 동형). additive —
+    # 스토리 0건이면 0/0. FE 에픽 카드(total/done)가 이 필드 바인딩(stories 배열 미부착·payload
+    # bloat 방지). 미부착 경로(get/create/update)는 기본값. detail은 별도 /progress 유지.
+    total_stories: int = 0
+    done_stories: int = 0
     created_at: datetime
     updated_at: datetime
 

--- a/backend/tests/test_epics.py
+++ b/backend/tests/test_epics.py
@@ -35,6 +35,9 @@ def _mock_epic(status: str = "active") -> MagicMock:
     # 신규 필드를 명시 세팅(기본값 동형). _attach_hypothesis_aggregates가 덮어쓸 수 있음.
     e.hypothesis_count = 0
     e.risky_status = None
+    # 0d4c89e8: 연결 스토리 집계. 동일 사유(MagicMock auto-attr 방지)로 명시 세팅.
+    e.total_stories = 0
+    e.done_stories = 0
     e.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     e.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     return e
@@ -81,10 +84,22 @@ def _agg_row(epic_id, cnt: int, risk_rank: int | None):
     return row
 
 
-def _paginated_execute(total: int, rows: list, agg_rows: list | None = None):
+def _story_agg_row(epic_id, total_stories: int, done_stories: int):
+    """EpicRepository._attach_story_aggregates 집계 한 행(epic_id·total_stories·done_stories)."""
+    row = MagicMock()
+    row.epic_id = epic_id
+    row.total_stories = total_stories
+    row.done_stories = done_stories
+    return row
+
+
+def _paginated_execute(
+    total: int, rows: list, agg_rows: list | None = None, story_rows: list | None = None
+):
     """EpicRepository.list_paginated의 execute 순서를 모킹.
 
-    1=count(scalar_one), 2=list(scalars().all()), 3=가설 집계(_attach.. → result.all()).
+    1=count(scalar_one), 2=list(scalars().all()), 3=가설 집계(_attach_hypothesis.. → result.all()),
+    4=스토리 집계(_attach_story.. → result.all()).
     """
     state = {"n": 0}
 
@@ -95,8 +110,10 @@ def _paginated_execute(total: int, rows: list, agg_rows: list | None = None):
             r.scalar_one.return_value = total
         elif state["n"] == 2:
             r.scalars.return_value.all.return_value = rows
-        else:
+        elif state["n"] == 3:
             r.all.return_value = agg_rows or []
+        else:
+            r.all.return_value = story_rows or []
         return r
 
     return _exec
@@ -150,6 +167,40 @@ async def test_list_epics_zero_hypotheses_defaults_count0_risky_null():
         body = resp.json()
         assert body[0]["hypothesis_count"] == 0
         assert body[0]["risky_status"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_epics_includes_story_aggregates():
+    """0d4c89e8: list 응답에 total_stories/done_stories(단일쿼리 집계)가 실린다(E-HO-TRUST 9/11형)."""
+    client, session, app = await _client()
+    try:
+        session.execute = _paginated_execute(
+            1, [_mock_epic()], story_rows=[_story_agg_row(EPIC_ID, 11, 9)]
+        )
+        async with client as c:
+            resp = await c.get("/api/v2/epics")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body[0]["total_stories"] == 11
+        assert body[0]["done_stories"] == 9
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_epics_zero_stories_defaults_0_0():
+    """0d4c89e8 additive: 연결 스토리 0건이면 total/done 0/0(회귀 0·payload bloat 없음)."""
+    client, session, app = await _client()
+    try:
+        session.execute = _paginated_execute(1, [_mock_epic()], story_rows=[])
+        async with client as c:
+            resp = await c.get("/api/v2/epics")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body[0]["total_stories"] == 0
+        assert body[0]["done_stories"] == 0
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## 0d4c89e8 BE — epic list story-count aggregate

> non-gcloud·마이그 무관. 유나 그라운딩 ⒜ BE 실측 확정. 머지 후 미르코 FE 바인딩 핸드오프.

### 근본
`EpicRepository.list_paginated`가 `hypothesis_count`만 부착하고 **story count는 미부착**. `EpicResponse`(list+detail 공용)에 story 집계 필드 전무 → FE 에픽 카드(`epic.stories.length`)가 list 미제공 stories에 의존 → **전 에픽 카드 0/0**(상세는 별도 `/progress` fetch로 9/11). count는 `get_progress`에만 존재.

### fix (`hypothesis_count` 선례 동형)
- **`_attach_story_aggregates`**: `Story.epic_id IN(page) GROUP BY epic_id` **단일쿼리**로 `total_stories`(count)·`done_stories`(count filter `status='done'`) 집계 부착. **N+1 회피**·`get_progress` 집계 SQL 동형·org 스코프·`deleted_at IS NULL`. 비매핑 인스턴스 속성(읽기 경로 flush 무영향). **stories 배열 미부착**(payload bloat 방지·detail은 `/progress` 유지).
- `list_paginated`가 hypothesis 부착 뒤 story 부착 호출.
- `EpicResponse`에 `total_stories: int = 0`·`done_stories: int = 0` **additive** 필드. 미부착 경로(get/create/update)는 기본값.

### 계약
필드명 **`total_stories`/`done_stories` 고정** — 미르코 FE가 이 필드 바인딩(끝단 일치 필수).

### AC
- ① epic list 응답에 total_stories/done_stories 정확(E-HO-TRUST 9/11형). ✅
- ② 단일쿼리 N+1 회피. ✅
- ③ detail/progress 무영향·additive 회귀 0. ✅

### 테스트
- 신규 2종: list 집계 정확(11/9)·zero 디폴트(0/0). `_paginated_execute`에 4번째 execute(story agg) 모킹 추가.
- 기존 hypothesis/epic 테스트 동반 green.
- **전체 2100 passed**(2098+2)·3 failed는 표준 env-only(McpError x2·contract FileNotFound, 회귀 아님).

🤖 Generated with [Claude Code](https://claude.com/claude-code)