### PR TITLE
[SID:4dad38d3] 모바일 nav 드로어 메뉴선택 후 auto-close

### DIFF
--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -38,6 +38,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
   SidebarRail,
+  useSidebar,
 } from '@/components/ui/sidebar';
 
 interface AppSidebarProps {
@@ -66,6 +67,14 @@ export function AppSidebar({
 }: AppSidebarProps) {
   const pathname = usePathname();
   const t = useTranslations('nav');
+  const { isMobile, setOpenMobile } = useSidebar();
+
+  // 4dad38d3: 모바일 nav 아이템 선택 후 드로어 auto-close. route 변경 시 닫는다(전 아이템 DRY 커버).
+  // 데스크탑은 isMobile 가드로 no-op·백드롭 탭 닫기(Sheet onOpenChange)는 무영향.
+  useEffect(() => {
+    if (isMobile) setOpenMobile(false);
+  }, [pathname, isMobile, setOpenMobile]);
+
   const [inboxUnreadCount, setInboxUnreadCount] = useState(0);
   const [paletteOpen, setPaletteOpen] = useState(false);
 


### PR DESCRIPTION
## 요약
모바일 nav 드로어에서 **메뉴 선택 후 드로어가 안 닫히는** 버그(story `4dad38d3`, FE·모바일) 수정.

## 근본
`app-sidebar.tsx` nav 아이템(`SidebarMenuButton render={<Link/>}`)이 Link 네비만 하고 **모바일 Sheet 드로어 close를 미호출**. 백드롭 탭 닫기(Sheet `onOpenChange`)는 작동 → **아이템 선택 close만 누락**.

## 수정 (디자인 권장 — route-change effect·DRY)
- `useSidebar()`에서 `isMobile`/`setOpenMobile` 취득(`AppSidebar`는 `SidebarProvider` 내부라 가용).
- route 변경 시 모바일 드로어 닫기:
  ```ts
  useEffect(() => { if (isMobile) setOpenMobile(false); }, [pathname, isMobile, setOpenMobile]);
  ```
- 전 nav 아이템(inbox~activity ~11개) **일괄 커버**·기존 `usePathname`/`useEffect` 패턴 일관·신규 핸들러 0.
- **데스크탑 상시 사이드바는 `isMobile` 가드로 no-op**·**백드롭 탭 닫기 보존**.

## AC
①모바일 메뉴 선택 → nav + 드로어 닫힘 ②데스크탑 무영향 + 백드롭 닫기 유지.

## 검증
- `pnpm build` ✅(exit 0)·ESLint ✅ 0·`tsc --noEmit` ✅ · Base **develop** · diff +9·1파일.
- ⚠️ 라이브 "드로어 auto-close"는 render/인터랙션이라 **유나 post-deploy 모바일 픽셀(390px)이 권위**. 머지→dev 후 실측.

## QA 가이드 (까심군)
모바일 390px: nav 아이템 탭 → 라우트 이동 + 드로어 닫힘. 백드롭 탭 닫기 유지. 데스크탑: 사이드바 상시·무영향.

🤖 Generated with [Claude Code](https://claude.com/claude-code)