### PR TITLE
[SID:0d4c89e8] 에픽 카드 스토리 카운트 BE 집계 바인딩

### DIFF
--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -46,6 +46,9 @@ interface Epic {
   // E1 S8b: BE EpicResponse가 list 응답에 부착하는 연결 가설 집계(미부착 경로는 기본값).
   hypothesis_count?: number;
   risky_status?: string | null;
+  // 0d4c89e8: BE list 응답 story count 집계(#1527). detail/미부착 경로는 stories 폴백.
+  total_stories?: number;
+  done_stories?: number;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -411,7 +414,11 @@ interface EpicRowProps {
 function EpicRow({ epic, isSelected, onClick, onDeleteRequest }: EpicRowProps) {
   const t = useTranslations('epics');
   const stories = epic.stories ?? [];
-  const { done, total } = calcStoryProgress(stories);
+  // 0d4c89e8: BE 집계(total_stories/done_stories·#1527) 우선·detail-shape(집계 미부착)는 stories 폴백.
+  // list 응답은 stories 미부착이라 폴백만으론 0/0 → BE 집계로 카드 카운트/진행바 정상화.
+  const fb = calcStoryProgress(stories);
+  const total = epic.total_stories ?? fb.total;
+  const done = epic.done_stories ?? fb.done;
   const pct = total > 0 ? Math.round((done / total) * 100) : 0;
   const spProgress = calcSpProgress(stories);
   const spExceeded = typeof epic.target_sp === 'number' && epic.target_sp > 0 && spProgress.total > epic.target_sp;


### PR DESCRIPTION
## 요약
에픽 목록 카드의 **스토리 카운트/진행바가 0/0**으로 잘못 표시되던 버그(story `0d4c89e8` FE) 수정. BE #1527(`e3338bef`) 집계 부착분을 FE 바인딩.

## 근본
list 응답(`/api/epics`)은 `stories[]` **미부착**인데 `EpicRow`가 `calcStoryProgress(epic.stories ?? [])`로 계산 → 빈 배열 → **0/0**. BE #1527이 `EpicResponse.total_stories`/`done_stories` 집계를 list 응답에 부착.

## 수정 (EpicRow만·시각변경 0)
- 로컬 `Epic` interface에 `total_stories?: number; done_stories?: number;` 추가.
- `EpicRow`: BE 집계 우선·`stories` 폴백
  ```ts
  const fb = calcStoryProgress(stories);
  const total = epic.total_stories ?? fb.total;
  const done  = epic.done_stories ?? fb.done;
  ```
  → `{done}/{total} 스토리` + 진행바(`pct`) 자동 정상화.
- **`EpicDetailPanel` 무변경**: 상세는 `getByIdWithStories`로 `stories` populated·집계 미부착(`total_stories` undefined)이라 EpicRow의 `?? fb` 폴백이 **detail-shape 안전** 보장.

## 끝단 일치 확인 (PO 요구·실측)
실 dev `/api/v2/epics` payload 확인:
```
total_stories/done_stories present=True, vals=44/16·11/9·23/16·9/8
has stories[] in list payload? False  ← 0/0 근본 + 폴백 필요성 실증
```

## 스코프 밖
`spExceeded`(calcSpProgress)는 BE SP 집계 부재로 list 미표시·별건(flag만). 변경 없음.

## 검증
- `pnpm build` ✅(exit 0)·ESLint ✅ 0·`tsc --noEmit` ✅ · Base **develop** · diff +8/−1·1파일.

## QA 가이드 (까심군)
에픽 목록 카드 카운트/진행바 = 에픽 상세 카운트 일치(예: 9/11). 빈 에픽 0/0 정상. 시각 변경 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)