### PR TITLE
[SID:934c1fbb] 채팅 입력 placeholder 하드코딩 한글 → t() (en 버그)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2301,6 +2301,8 @@
     "empty": "No agents to show"
   },
   "chats": {
+    "inputPlaceholderMobile": "Type a message… (@ mention)",
+    "inputPlaceholderFull": "Type a message… (Enter to send / Shift+Enter for new line / @ mention / # entity)",
     "isTyping": "{name} is typing",
     "othersTyping": "{name} and {count} others are typing",
     "presenceOnline": "Online",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2301,6 +2301,8 @@
     "empty": "표시할 에이전트가 없습니다"
   },
   "chats": {
+    "inputPlaceholderMobile": "메시지를 입력하세요… (@ 멘션)",
+    "inputPlaceholderFull": "메시지를 입력하세요… (Enter 전송 / Shift+Enter 줄바꿈 / @ 멘션 / # 엔티티)",
     "isTyping": "{name} 님이 입력 중",
     "othersTyping": "{name} 외 {count}명 입력 중",
     "presenceOnline": "온라인",

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -458,7 +458,7 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
             }, 150);
           }}
           disabled={disabled || sending}
-          placeholder={placeholder ?? '메시지를 입력하세요… (@ 멘션 / # 엔티티)'}
+          placeholder={placeholder ?? t('inputPlaceholderMobile')}
           className="flex-1 resize-none rounded-xl border border-border bg-muted/30 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-40"
           style={{ minHeight: '36px', maxHeight: '160px' }}
         />

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -515,9 +515,7 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
             onUploadFile={handleUploadFile}
             projectId={projectId}
             commandTargets={commandTargets}
-            placeholder={isMobile
-              ? '메시지를 입력하세요… (@ 멘션)'
-              : '메시지를 입력하세요… (Enter 전송 / Shift+Enter 줄바꿈 / @ 멘션 / # 엔티티)'}
+            placeholder={isMobile ? t('inputPlaceholderMobile') : t('inputPlaceholderFull')}
           />
         </div>
 


### PR DESCRIPTION
## 요약
채팅 입력 placeholder가 **하드코딩 한글**이라 en 로케일 유저가 한글을 보던 버그(story `934c1fbb` 재스코핑·시각변경=en만, ko 동일).

> 재스코핑: 원 증상 'placeholder 잘림'은 stale-done(라이브 390/360px 무잘림·`chat-view.tsx`가 이미 isMobile 반응형). **진짜 버그 = 하드코딩 한글 placeholder.**

## 수정 (i18n·반응형 보존·ko visible 무변경)
- **`chats` 네임스페이스에 새 키 2종**(ko = 기존 하드코딩 문자열 그대로·en 신규):
  - `inputPlaceholderMobile` (ko "메시지를 입력하세요… (@ 멘션)" / en "Type a message… (@ mention)")
  - `inputPlaceholderFull` (ko/en 풀버전)
  - ⚠️ 컴포넌트가 `useTranslations('chats')`라 키는 **`chats`(:2303)**에 추가 — `channel`(:86)의 `inputPlaceholder`와 **별개 네임스페이스**.
- `chat-view.tsx:518`: `placeholder={isMobile ? t('inputPlaceholderMobile') : t('inputPlaceholderFull')}` (이미 `t`/`isMobile` 보유).
- `chat-input.tsx:461` 폴백: `?? t('inputPlaceholderMobile')` (이미 `t` 보유).
- **반응형 `isMobile` 분기 유지**(모바일 짧은버전 = truncation 무회귀).
- **`channel.inputPlaceholder`(:86) 미변경**(`channel/page.tsx` 사용·AC⑤).

## 검증 (끝단)
- JSON 파싱 OK·`chats.inputPlaceholderMobile/Full` 실재·`channel.inputPlaceholder` 보존·channel 신규키 0·**top/chats parity(ko==en)**·하드코딩 '메시지를 입력' 잔재 0.
- `pnpm build` ✅(exit 0)·ESLint ✅ 0·`tsc --noEmit` ✅ · Base **develop** · diff +6/−4·4파일.
> 📌 끝단 검증이 네임스페이스 오배치(channel↔chats)를 적출 — 빌드만 봤으면 런타임 미해소 놓칠 뻔.

## AC
①t() 경유 ②en 동작 ③ko 무변경(visible) ④반응형 보존(390px 무잘림) ⑤channel/`:86` 무영향.

## QA 가이드 (까심군)
en 로케일: 채팅 입력 placeholder = 영문(데스크탑 풀버전 / 모바일 짧은버전). ko: 기존 한글 동일. 390px 무잘림. channel 화면 회귀 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)