### PR TITLE
fix(db): docs 참조 FK 복구 — 0007 소실 7개 (5b246134)

### DIFF
--- a/backend/alembic/versions/0121_restore_docs_reference_fks.py
+++ b/backend/alembic/versions/0121_restore_docs_reference_fks.py
@@ -1,0 +1,69 @@
+"""docs 참조 FK 복구 — baseline 소실 FK 7개 (story 5b246134).
+
+5b246134 감사서 적출: docs(.id)를 참조하는 7개 (table.column)에 FK 부재 — 0007 등에서
+정의됐을 FK가 baseline schema.sql(0096)에 소실(0007 doc_comments/doc_revisions 가설 확증).
+docs PK는 0107(#1366) 복원돼 FK 성립 가능. dev 실측: 복구 대상 7개 FK 전무 + **orphan 전
+테이블 0**(FK ADD 전부 SAFE·cleanup 불요). 기존 2개(doc_share_tokens·doc_slug_aliases)는
+post-0096라 이미 FK 보유 → IF NOT EXISTS skip.
+
+ondelete(ORM 원안/5b246134 결정):
+  doc_comments.doc_id      → CASCADE   (doc 삭제 시 댓글 삭제)
+  doc_revisions.doc_id     → CASCADE   (doc 삭제 시 리비전 삭제)
+  epic_docs.doc_id         → CASCADE   (link — doc 삭제 시 링크 삭제)
+  story_docs.doc_id        → CASCADE   (link)
+  memo_doc_links.doc_id    → CASCADE   (link)
+  docs.parent_id           → SET NULL  (부모 doc 삭제 시 자식은 최상위로)
+  sprints.report_doc_id    → SET NULL  (회고 doc 삭제 시 sprint 참조만 해제)
+
+⚠️ idempotent — constraint 명(<table>_<col>_fkey, 기존 2개와 동일 컨벤션) 부재 시에만 ADD.
+재실행·fresh DB(이미 ORM이 FK 생성)서도 안전(IF NOT EXISTS skip). orphan 0이라 ADD 시 검증
+통과(orphan>0이면 ADD 실패하므로 prod-apply 전 preflight 필수 — docs_fk_parity_audit.sql §2).
+"""
+from alembic import op
+
+revision = "0121"
+down_revision = "0120"
+branch_labels = None
+depends_on = None
+
+
+# (table, column, ondelete) — 복구 대상 7. constraint 명 = <table>_<column>_fkey.
+_FKS = [
+    ("doc_comments", "doc_id", "CASCADE"),
+    ("doc_revisions", "doc_id", "CASCADE"),
+    ("epic_docs", "doc_id", "CASCADE"),
+    ("story_docs", "doc_id", "CASCADE"),
+    ("memo_doc_links", "doc_id", "CASCADE"),
+    ("docs", "parent_id", "SET NULL"),
+    ("sprints", "report_doc_id", "SET NULL"),
+]
+
+
+def upgrade() -> None:
+    for table, column, ondelete in _FKS:
+        fk_name = f"{table}_{column}_fkey"
+        op.execute(
+            f"""
+            DO $$
+            BEGIN
+                IF to_regclass('public.{table}') IS NOT NULL
+                   AND NOT EXISTS (
+                       SELECT 1 FROM pg_constraint
+                       WHERE conname = '{fk_name}'
+                         AND conrelid = 'public.{table}'::regclass
+                   ) THEN
+                    ALTER TABLE public.{table}
+                        ADD CONSTRAINT {fk_name}
+                        FOREIGN KEY ({column}) REFERENCES public.docs(id)
+                        ON DELETE {ondelete};
+                END IF;
+            END $$;
+            """
+        )
+
+
+def downgrade() -> None:
+    # 드리프트(소실 FK) 복구이므로 되돌리지 않는다 — FK를 drop하면 원래 결함(참조 무결성
+    # 부재)을 재현한다. (0107 docs_pkey / 0113 epics_pkey / 0114 / 0120 plan_features_pkey와
+    # 동일 정책: 드리프트 교정 마이그는 no-op downgrade.)
+    pass

--- a/backend/scripts/preflight/docs_fk_parity_audit.sql
+++ b/backend/scripts/preflight/docs_fk_parity_audit.sql
@@ -1,0 +1,71 @@
+-- docs 참조 FK 패리티 감사 + orphan preflight (story 5b246134 · docs 참조 FK 복구)
+--
+-- 목적:
+--   (1) docs(.id)를 참조해야 할 컬럼들의 실 DB FK 실태 — baseline schema.sql엔 docs 참조 FK 전무
+--       (0007 doc_comments.doc_id/doc_revisions.doc_id FK 소실 추정). 어떤 게 실재/소실인지 확정.
+--   (2) orphan row 수 — doc_id(또는 참조 컬럼)가 non-NULL인데 docs에 매칭 없는 깨진 참조. FK ADD는
+--       orphan 있으면 실패하므로 복구 마이그 전 전수. orphan>0이면 정리/보존 결정 선행(머지 블로커).
+--
+-- ⚠️ READ-ONLY. SELECT만 — 데이터/스키마 변경 없음. dev(at head) 실행 — doc_slug_aliases·
+--    doc_share_tokens는 post-0096 마이그 산물이라 baseline엔 없으나 head DB엔 존재.
+-- 실행: Private-IP DB → Cloud Run 일회성 잡(psql/SQL 러너). 순수 SQL·section 라벨 자기설명.
+-- 참조: [[reference_privateip_db_diag_and_project_authz]] · plan_features_schema_audit.sql 동형.
+--
+-- 후보(table.column → docs.id, ORM ondelete):
+--   doc_comments.doc_id(CASCADE NN)·doc_revisions.doc_id(CASCADE NN)·doc_slug_aliases.doc_id
+--   (CASCADE NN)·doc_share_tokens.doc_id(CASCADE NN)·docs.parent_id(SET NULL null)·
+--   sprints.report_doc_id(SET NULL null)·epic_docs.doc_id(link NN)·story_docs.doc_id(link NN)·
+--   memo_doc_links.doc_id(link NN)
+
+-- ── [1] 현존 docs-참조 FK 일람 (전무 가설 검증 — 비면 0건 = 전 FK 소실) ────────────
+SELECT
+    '1_existing_fks'                AS section,
+    conrelid::regclass::text        AS table_name,
+    conname                         AS fk_name,
+    pg_get_constraintdef(oid)       AS definition
+FROM pg_constraint
+WHERE contype = 'f'
+  AND confrelid = to_regclass('public.docs')
+ORDER BY conrelid::regclass::text, conname;
+
+-- ── [2] orphan 감사 (orphan_cnt>0 = FK ADD 블로커·정리/보존 결정 필요) ───────────
+SELECT '2_orphans' AS section, t.table_name, t.column_name, t.total_nonnull, t.orphan_cnt
+FROM (
+    SELECT 'doc_comments'::text AS table_name, 'doc_id'::text AS column_name,
+        (SELECT count(*) FROM doc_comments WHERE doc_id IS NOT NULL) AS total_nonnull,
+        (SELECT count(*) FROM doc_comments x WHERE x.doc_id IS NOT NULL
+            AND NOT EXISTS (SELECT 1 FROM docs d WHERE d.id = x.doc_id)) AS orphan_cnt
+    UNION ALL SELECT 'doc_revisions', 'doc_id',
+        (SELECT count(*) FROM doc_revisions WHERE doc_id IS NOT NULL),
+        (SELECT count(*) FROM doc_revisions x WHERE x.doc_id IS NOT NULL
+            AND NOT EXISTS (SELECT 1 FROM docs d WHERE d.id = x.doc_id))
+    UNION ALL SELECT 'doc_slug_aliases', 'doc_id',
+        (SELECT count(*) FROM doc_slug_aliases WHERE doc_id IS NOT NULL),
+        (SELECT count(*) FROM doc_slug_aliases x WHERE x.doc_id IS NOT NULL
+            AND NOT EXISTS (SELECT 1 FROM docs d WHERE d.id = x.doc_id))
+    UNION ALL SELECT 'doc_share_tokens', 'doc_id',
+        (SELECT count(*) FROM doc_share_tokens WHERE doc_id IS NOT NULL),
+        (SELECT count(*) FROM doc_share_tokens x WHERE x.doc_id IS NOT NULL
+            AND NOT EXISTS (SELECT 1 FROM docs d WHERE d.id = x.doc_id))
+    UNION ALL SELECT 'docs', 'parent_id',
+        (SELECT count(*) FROM docs WHERE parent_id IS NOT NULL),
+        (SELECT count(*) FROM docs x WHERE x.parent_id IS NOT NULL
+            AND NOT EXISTS (SELECT 1 FROM docs d WHERE d.id = x.parent_id))
+    UNION ALL SELECT 'sprints', 'report_doc_id',
+        (SELECT count(*) FROM sprints WHERE report_doc_id IS NOT NULL),
+        (SELECT count(*) FROM sprints x WHERE x.report_doc_id IS NOT NULL
+            AND NOT EXISTS (SELECT 1 FROM docs d WHERE d.id = x.report_doc_id))
+    UNION ALL SELECT 'epic_docs', 'doc_id',
+        (SELECT count(*) FROM epic_docs WHERE doc_id IS NOT NULL),
+        (SELECT count(*) FROM epic_docs x WHERE x.doc_id IS NOT NULL
+            AND NOT EXISTS (SELECT 1 FROM docs d WHERE d.id = x.doc_id))
+    UNION ALL SELECT 'story_docs', 'doc_id',
+        (SELECT count(*) FROM story_docs WHERE doc_id IS NOT NULL),
+        (SELECT count(*) FROM story_docs x WHERE x.doc_id IS NOT NULL
+            AND NOT EXISTS (SELECT 1 FROM docs d WHERE d.id = x.doc_id))
+    UNION ALL SELECT 'memo_doc_links', 'doc_id',
+        (SELECT count(*) FROM memo_doc_links WHERE doc_id IS NOT NULL),
+        (SELECT count(*) FROM memo_doc_links x WHERE x.doc_id IS NOT NULL
+            AND NOT EXISTS (SELECT 1 FROM docs d WHERE d.id = x.doc_id))
+) t
+ORDER BY t.table_name, t.column_name;


### PR DESCRIPTION
## 5b246134 — docs 참조 FK 패리티 복구

> DB 마이그(FK only·idempotent). dev 실측 기반. plan_features 0120과 동일 패턴(감사→preflight→복구).

### 근본
`baseline/schema.sql`(0096)에 **docs(.id) 참조 FK 전무** — 0007 등에서 정의됐을 FK가 소실(0007 `doc_comments`/`doc_revisions` 가설 확증). docs PK는 0107(#1366)로 복원돼 FK 성립 가능 — 이건 **잔여 FK 복구**.

### dev 실측 (오르테가 Cloud Run read-only 잡 · `docs_fk_parity_audit.sql`)
- **현존 FK 2** (post-0096): `doc_share_tokens.doc_id_fkey`·`doc_slug_aliases.doc_id_fkey` (CASCADE) → IF NOT EXISTS skip.
- **복구 대상 7** (FK 전무): doc_comments·doc_revisions·epic_docs·story_docs·memo_doc_links(.doc_id)·docs.parent_id·sprints.report_doc_id.
- **orphan 전 테이블 0** → FK ADD 전부 SAFE·cleanup 불요.

### 0121 (idempotent FK 복구)
| table.column | ondelete |
|---|---|
| doc_comments.doc_id / doc_revisions.doc_id | CASCADE |
| epic_docs.doc_id / story_docs.doc_id / memo_doc_links.doc_id (link) | CASCADE |
| docs.parent_id / sprints.report_doc_id | SET NULL |

- constraint 명 `<table>_<col>_fkey`(기존 2개 컨벤션). `to_regclass` 가드 + `IF NOT EXISTS` → 재실행·fresh DB(ORM이 FK 생성) 안전.
- **downgrade no-op** (드리프트 교정 — 0107/0113/0114/0120 동일 정책).

### 검증
- 로컬 pgvector(baseline + docs PK sim): **1차 FK 7개 정확 생성**(ondelete 일치)·**2차 멱등**(중복 0·에러 0).
- orphan 0 실측이라 ADD 검증 통과. CI Alembic upgrade head(fresh DB)로 체인 검증.
- prod-apply 전 `docs_fk_parity_audit.sql` §2 orphan 재확인 필수(분리 DB·선생님 승인).

🤖 Generated with [Claude Code](https://claude.com/claude-code)