### PR TITLE
feat(auth): _build_app_metadata de-fallback 단계2 — 추측 제거 + side-effect 호출부 이관 (908075db)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -328,6 +328,19 @@ async def _resolve_explicit_app_metadata(
     }
 
 
+def _persist_resolved_context(user: User, md: dict) -> None:
+    """908075db 단계2: flag-on 시 _build_app_metadata가 user를 mutate하지 않고 순수 해소만 하므로,
+    login/refresh 호출부가 해소 결과(md)를 user.last_project_id/last_org_id에 명시 영속한다(책임 이관).
+
+    project_id 비면(접근 가능 project 없음) last_project_id=None으로 stale 제거. org_id는 있으면만
+    갱신(빈 dict {} 해소 시 last_org_id 유지). 추측 없이 deterministic 해소 결과만 영속."""
+    pid = md.get("project_id") or None
+    user.last_project_id = uuid.UUID(pid) if pid else None
+    oid = md.get("org_id") or None
+    if oid:
+        user.last_org_id = uuid.UUID(oid)
+
+
 async def _build_app_metadata(
     user: User, session: AsyncSession, org_id: uuid.UUID | None = None,
     project_id: uuid.UUID | None = None,
@@ -369,9 +382,11 @@ async def _build_app_metadata(
             q = q.where(TeamMember.org_id == org_id)
         member = (await session.execute(q.limit(1))).scalar_one_or_none()
 
-    if not member:
+    if not member and not settings.build_app_metadata_defallback:
         # fallback: 가장 오래된 team_member (ASC) — 최초 가입 project 우선.
         # ⚠️0746: org_id 지정 시 그 org로 스코프(미지정이면 org 무관 → cross-org 옛 프로젝트 누수).
+        # 908075db 단계2(flag-on): 이 **추측** 제거 — flag on이면 member None 유지 → 아래 deterministic
+        # 경로(first_accessible/invite/Path4)로 해소. flag off면 기존 추측 그대로(거동 무변경).
         q = select(TeamMember).where(
             or_(TeamMember.user_id == user.id, TeamMember.id == user.id),
             TeamMember.is_active.is_(True),
@@ -384,10 +399,13 @@ async def _build_app_metadata(
     # cross-org invite/Path4 폴백 금지. 그 org의 first_accessible(없으면 null)로 스코프 해소.
     if org_id is not None and member is None:
         pid = await first_accessible_project_id(session, user.id, org_id)
-        if getattr(user, "last_project_id", None) != pid:
-            user.last_project_id = pid  # in-org project or None — cross-org 절대 금지
-        if getattr(user, "last_org_id", None) != org_id:
-            user.last_org_id = org_id  # 현재 org 추적 — 다음 refresh가 이 org 유지
+        # 908075db 단계2(flag-on): in-function last_project_id/org_id mutation 제거 → 호출부 책임
+        # (_persist_resolved_context). flag off면 기존대로 영속(거동 무변경).
+        if not settings.build_app_metadata_defallback:
+            if getattr(user, "last_project_id", None) != pid:
+                user.last_project_id = pid  # in-org project or None — cross-org 절대 금지
+            if getattr(user, "last_org_id", None) != org_id:
+                user.last_org_id = org_id  # 현재 org 추적 — 다음 refresh가 이 org 유지
         om_role = (
             await session.execute(
                 select(OrgMember.role).where(
@@ -458,12 +476,16 @@ async def _build_app_metadata(
             }
         return {}
 
-    # login 시 last_project_id 자동 갱신 — 다음 로그인부터 last_project_id 우선 경로 사용
-    if getattr(user, "last_project_id", None) != member.project_id:
-        user.last_project_id = member.project_id
-    # 현재 org 추적(0746 후속) — 다음 refresh가 org_id 없이도 이 org로 스코프
-    if getattr(user, "last_org_id", None) != member.org_id:
-        user.last_org_id = member.org_id
+    # login 시 last_project_id 자동 갱신 — 다음 로그인부터 last_project_id 우선 경로 사용.
+    # 908075db 단계2(flag-on): 이 side-effect 제거 → 호출부 책임(_persist_resolved_context). flag off
+    # 면 기존대로 영속(거동 무변경). flag on에선 member가 명시 last_project_id 룩업(360-370)서만 와
+    # member.project_id == last_project_id라 영속 결과는 동일(호출부가 md.project_id로 재확정).
+    if not settings.build_app_metadata_defallback:
+        if getattr(user, "last_project_id", None) != member.project_id:
+            user.last_project_id = member.project_id
+        # 현재 org 추적(0746 후속) — 다음 refresh가 org_id 없이도 이 org로 스코프
+        if getattr(user, "last_org_id", None) != member.org_id:
+            user.last_org_id = member.org_id
 
     # S-MBR-03: org owner/admin → project role 상속 (AC1/AC2)
     # org_members.role이 team_members.role보다 높으면 org role을 effective role로 사용.
@@ -560,7 +582,10 @@ async def register(
     if body.invite_token:
         await _auto_accept_invitation(session, user, body.invite_token)
 
-    tokens = create_tokens(str(user.id), email=user.email, app_metadata=await _build_app_metadata(user, session))
+    _md = await _build_app_metadata(user, session)
+    if settings.build_app_metadata_defallback:
+        _persist_resolved_context(user, _md)  # 908075db 단계2: side-effect 호출부 이관
+    tokens = create_tokens(str(user.id), email=user.email, app_metadata=_md)
     _, refresh_exp = create_refresh_token(str(user.id), expires_delta=timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS))
     await _store_refresh_token(session, user, tokens["refresh_token"], refresh_exp)
 
@@ -688,7 +713,10 @@ async def login(
             update(User).where(User.id == user.id).values(login_fail_count=0, login_locked_until=None)
         )
 
-    tokens = create_tokens(str(user.id), email=user.email, app_metadata=await _build_app_metadata(user, session))
+    _md = await _build_app_metadata(user, session)
+    if settings.build_app_metadata_defallback:
+        _persist_resolved_context(user, _md)  # 908075db 단계2: side-effect 호출부 이관
+    tokens = create_tokens(str(user.id), email=user.email, app_metadata=_md)
     _, refresh_exp = create_refresh_token(str(user.id), expires_delta=timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS))
     await _store_refresh_token(session, user, tokens["refresh_token"], refresh_exp)
 
@@ -747,7 +775,10 @@ async def refresh_token(
         .values(revoked_at=datetime.now(timezone.utc))
     )
 
-    tokens = create_tokens(str(user.id), email=user.email, app_metadata=await _build_app_metadata(user, session))
+    _md = await _build_app_metadata(user, session)
+    if settings.build_app_metadata_defallback:
+        _persist_resolved_context(user, _md)  # 908075db 단계2: side-effect 호출부 이관
+    tokens = create_tokens(str(user.id), email=user.email, app_metadata=_md)
     _, refresh_exp = create_refresh_token(str(user.id), expires_delta=timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS))
     await _store_refresh_token(session, user, tokens["refresh_token"], refresh_exp)
 
@@ -998,7 +1029,10 @@ async def oauth_callback(
     from datetime import timedelta
     from app.core.security import ACCESS_TOKEN_EXPIRE_MINUTES, REFRESH_TOKEN_EXPIRE_DAYS
 
-    tokens = create_tokens(str(user.id), user.email, await _build_app_metadata(user, session))
+    _md = await _build_app_metadata(user, session)
+    if settings.build_app_metadata_defallback:
+        _persist_resolved_context(user, _md)  # 908075db 단계2: side-effect 호출부 이관
+    tokens = create_tokens(str(user.id), user.email, _md)
     raw_refresh = tokens["refresh_token"]
     expires_at = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
     await _store_refresh_token(session, user, raw_refresh, expires_at)

--- a/backend/tests/test_908075db_build_app_metadata_defallback.py
+++ b/backend/tests/test_908075db_build_app_metadata_defallback.py
@@ -1,9 +1,14 @@
-"""908075db 단계1: _build_app_metadata de-fallback (flag-gated 명시존중).
+"""908075db 단계1+2: _build_app_metadata de-fallback (flag-gated).
 
-flag on이면 명시 의도(switch target project_id 또는 저장된 last_project_id)에 has_project_access
-(35a0691e grant-aware)가 있을 때 가장-오래된-team_member 추측을 타지 않고 그 project를 존중한다.
-side-effect(last_project_id 덮어쓰기)는 단계2서 제거 — 단계1 명시존중 분기 자체는 부수효과 없음.
-flag off(기본)면 분기 통째 skip → 기존 거동 100% 유지(회귀 0).
+단계1: flag on이면 명시 의도(switch target project_id ∥ 저장 last_project_id)에 has_project_access
+(35a0691e grant-aware) 있으면 가장-오래된-team_member 추측 안 타고 그 project 존중.
+
+단계2(flag on): ① 추측 fallback(가장 오래된 team_member) 제거 → deterministic first_accessible로
+해소. ② _build_app_metadata in-function last_project_id/last_org_id mutation 제거(순수) → login
+호출부가 _persist_resolved_context로 해소 결과 영속(책임 이관).
+
+flag off(기본)면 단계1·2 모두 skip → 기존 거동 100% 유지(회귀 0). 실험중이라 dev 잔류·flag-on
+관측 통과 후 머지.
 """
 from __future__ import annotations
 
@@ -108,27 +113,46 @@ async def test_flag_on_switch_target_param_wins_over_last_project():
 
 
 @pytest.mark.anyio
-async def test_flag_on_inaccessible_explicit_falls_through_to_legacy():
-    """flag on + 명시 pid가 has_project_access 없음 → 명시존중 skip, 기존 추측 경로로 폴스루."""
+async def test_flag_on_inaccessible_explicit_deterministic_no_guess():
+    """908075db 단계2: flag on + 명시 pid 접근불가 → **추측 안 타고** deterministic first_accessible로
+    해소. in-function user mutation 없음(불변·호출부 책임)."""
     from app.routers.auth import _build_app_metadata
 
-    user = _user(last_project_id=PID_EXPLICIT, last_org_id=ORG_A)
-    # 폴스루 후 기존 경로: q1(last_project team_member, org scope)=None, q2(fallback ASC)=None,
-    # 그 뒤 org_id+member None 분기 → om_role. first_accessible/_user_projects_claim은 patch.
-    q1 = MagicMock(); q1.scalar_one_or_none.return_value = None
-    q2 = MagicMock(); q2.scalar_one_or_none.return_value = None
-    om_role = MagicMock(); om_role.scalar_one_or_none.return_value = "member"
+    PID_DET = uuid.uuid4()
+    user = _user(last_project_id=PID_OLD, last_org_id=ORG_A)
+    # 단계2: 추측(가장 오래된 team_member) execute 없음 → q_360(last_project team_member None) + om_role 2회만.
+    q_360 = MagicMock(); q_360.scalar_one_or_none.return_value = None
+    q_om = MagicMock(); q_om.scalar_one_or_none.return_value = "member"
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[q1, q2, om_role])
+    session.execute = AsyncMock(side_effect=[q_360, q_om])
 
     with patch("app.routers.auth.settings.build_app_metadata_defallback", True), \
          patch("app.routers.auth.has_project_access", new=AsyncMock(return_value=False)), \
-         patch("app.routers.auth.first_accessible_project_id", new=AsyncMock(return_value=None)), \
+         patch("app.routers.auth.first_accessible_project_id", new=AsyncMock(return_value=PID_DET)), \
          patch("app.routers.auth._user_projects_claim", new=AsyncMock(return_value=[])):
         md = await _build_app_metadata(user, session, org_id=ORG_A)
 
-    # 명시존중 안 함 → 기존 org-scope 해소(접근 프로젝트 0 → project_id="")
-    assert md["project_id"] == ""
+    assert md["project_id"] == str(PID_DET)         # 추측 아닌 first_accessible(deterministic)
+    assert md["role"] == "member"
+    assert session.execute.await_count == 2         # 추측 쿼리 미발생(360 + om_role만)
+    assert user.last_project_id == PID_OLD          # 단계2: 함수가 mutate 안 함(호출부 책임)
+
+
+def test_persist_resolved_context_helper():
+    """908075db 단계2: 호출부가 md로 last_project_id/last_org_id 영속. project_id 비면 None(stale 제거),
+    org_id 비면 last_org_id 유지."""
+    from app.routers.auth import _persist_resolved_context
+
+    PID = uuid.uuid4(); OID = uuid.uuid4()
+    u = _user(last_project_id=PID_OLD, last_org_id=ORG_A)
+    _persist_resolved_context(u, {"project_id": str(PID), "org_id": str(OID)})
+    assert u.last_project_id == PID
+    assert u.last_org_id == OID
+
+    u2 = _user(last_project_id=PID_OLD, last_org_id=ORG_A)
+    _persist_resolved_context(u2, {"project_id": "", "org_id": ""})
+    assert u2.last_project_id is None               # 접근 project 0 → stale 제거
+    assert u2.last_org_id == ORG_A                  # 빈 org_id → 유지
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## 908075db 단계2 — `_build_app_metadata` de-fallback (추측 제거 + side-effect 호출부 이관)

> 단계1(flag-gated 명시존중·#1525) 후속. **flag-gated 유지** → flag off=거동 100% 무변경(회귀 0).
> ⚠️ **실험 stage·draft**: dev 잔류·**flag-on dev 관측 통과 후 머지**(prod 미적용). 관측 셋업은 PO(gcloud).

### 단계2 변경 (flag on에서만)
1. **추측 fallback 제거** — `가장 오래된 team_member(ASC)` 추측을 flag-on서 skip → `member` None 유지 → **deterministic 경로**(first_accessible/invite/Path4)로 해소. grant-only 명시 전환이 엉뚱한 project로 추측되던 근본 종결(2026-06-01 switch 인시던트).
2. **side-effect 제거 + 호출부 책임 이관** — `_build_app_metadata`의 in-function `last_project_id`/`last_org_id` mutation(추측-driven 덮어쓰기·385블록·login 갱신)을 flag-on서 제거 → 함수는 **순수 해소**. login/refresh 호출부(4곳)가 `_persist_resolved_context(user, md)`로 해소 결과 명시 영속(project_id 비면 None=stale 제거·org_id 비면 유지).

flag off면 추측·side-effect 그대로(거동 무변경). `switch_*` 밴드에이드 제거는 **단계3**.

### gating 포인트
- `auth.py`: 추측(`if not member and not flag`)·385블록 mutation(`if not flag`)·login side-effect(`if not flag`).
- 호출부 4곳(login/refresh/oauth): `if flag: _persist_resolved_context(user, md)`.
- `_resolve_explicit_app_metadata`(단계1)는 이미 side-effect-free → 일관.

### 테스트
- 신규/정정: flag-on 추측 제거→deterministic(distinct PID·execute 2회·추측쿼리 0)·in-function mutation 없음(불변)·`_persist_resolved_context` helper(영속·빈 project_id→None).
- flag-off 회귀 0(기존 추측·side-effect 테스트 그대로 green).
- **전체 2101 passed**(3 failed=표준 env-only McpError x2·contract FileNotFound).

### 머지 게이트
CI green → 까심 cross-model QA → **flag-on dev 관측(PO gcloud)** 통과 → 머지. flag off 디폴트라 머지 자체는 무동작.

🤖 Generated with [Claude Code](https://claude.com/claude-code)