### PR TITLE
fix(kanban): show comment author in story detail panel

### DIFF
--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -1294,9 +1294,11 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                       {comments.map((comment) => (
                         <li key={comment.id} className="rounded-md border border-border bg-muted/30 p-3">
                           <p className="whitespace-pre-wrap text-sm text-foreground">{comment.content}</p>
-                          <p className="mt-2 text-[10px] font-mono text-muted-foreground">
-                            {new Date(comment.created_at).toLocaleString()}
-                          </p>
+                          <div className="mt-2 flex items-center gap-2 text-[10px] font-mono text-muted-foreground">
+                            <span>{memberMap[comment.created_by]?.name ?? '—'}</span>
+                            <span>·</span>
+                            <span>{new Date(comment.created_at).toLocaleString()}</span>
+                          </div>
                         </li>
                       ))}
                     </ul>


### PR DESCRIPTION
## 배경
prod dogfood 유저 보고 — 스토리 디테일 패널의 코멘트에 **작성자가 보이지 않음**. 내용과 타임스탬프만 노출되어 누가 작성했는지 식별 불가.

(prod story `8e523747` / 내부 `41df3aa1`)

## 근본 원인
코멘트 렌더는 `content` + `created_at`만 표시했고, `created_by`는 payload에 존재했으나 화면에 그려지지 않았다. (`Comment` 인터페이스에 `created_by: string` 선언되어 있고, 코멘트 API 라우트는 백엔드 응답을 그대로 전달하는 thin-proxy.)

## 변경
같은 파일의 **Activity 탭 푸터 패턴을 그대로 복제** — `memberMap[created_by]?.name`으로 작성자명을 해소하고 `작성자 · 타임스탬프` 형태로 렌더. 미해소 actor는 `—`로 graceful fallback.

- 신규 디자인 토큰/스타일 도입 없음 (`text-[10px] font-mono text-muted-foreground` 등 기존 메타 라인 스타일 재사용).
- `memberMap`은 이미 컴포넌트 prop이며 멤버 `id`/`userId` 양쪽 키로 빌드됨 → 휴먼/에이전트 작성자 모두 해소.
- 매직 hex·하드코딩 색상 0.

## 디자인 판단
작성자를 별도 헤더로 승격하는 안도 검토했으나, **바로 인접한 Activity 탭과의 시각적 일관성**을 우선해 동일한 메타 라인(`작성자 · 시각`) 형식을 채택. (일관성 > 미학)

## 검증
- diff: `story-detail-panel.tsx` 1파일, +5/−3.
- 타입: `memberMap: Record<string, KanbanMember>`, `created_by: string`, `KanbanMember.name: string` → 타입 안전. Activity 탭의 동일 패턴이 이미 라이브.
- dev 배포 후 라이브 픽셀로 작성자 표시 정합 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)