### PR TITLE
fix(members): 휴먼 assignee email→실명 표시 (/api/v2/members 이름 해소)

### DIFF
--- a/backend/app/routers/members.py
+++ b/backend/app/routers/members.py
@@ -37,13 +37,22 @@ async def list_members(
 
     # Human members — org owner/admin은 grant 없이도 항상 포함 (S-MBR-03).
     # Org member는 명시적 granted 레코드가 있어야 포함 (S-MBR-10).
+    #
+    # name 해소: canonical members.name → users.display_name → email 순(LEFT JOIN members).
+    # 기존 `COALESCE(u.email,'')`는 휴먼을 항상 raw 이메일로 노출해, 동일 휴먼을
+    # 실명(display_name)으로 보여주는 org 로스터(team_member.py list_org_human_members)와
+    # 어긋났다(보드/Dispatch assignee 가 email 노출). 두 경로를 동일 COALESCE 로 정렬한다.
     human_rows = await session.execute(
         text(
             """
-            SELECT om.id, COALESCE(u.email, '') AS name, om.role
+            SELECT om.id,
+                   COALESCE(NULLIF(m.name, ''), NULLIF(u.display_name, ''), u.email, '') AS name,
+                   om.role
             FROM org_members om
             JOIN users u ON u.id = om.user_id
             JOIN projects p ON p.org_id = om.org_id AND p.id = :project_id
+            LEFT JOIN members m ON m.org_id = om.org_id AND m.user_id = om.user_id
+                               AND m.type = 'human' AND m.deleted_at IS NULL
             WHERE om.deleted_at IS NULL
               AND (
                 om.role IN ('owner', 'admin')

--- a/backend/tests/test_s_mbr_03.py
+++ b/backend/tests/test_s_mbr_03.py
@@ -253,3 +253,19 @@ async def test_list_members_owner_always_included():
     roles = {r.role for r in result}
     assert "owner" in roles
     assert "member" in roles
+
+
+def test_list_members_human_name_prefers_real_name_over_email():
+    """버그픽스(휴먼 assignee email→이름): list_members 휴먼 name 해소가 email-only 가 아니라
+    members.name → users.display_name → email 순으로 COALESCE 한다.
+
+    보드/Dispatch assignee 가 /api/v2/members 를 소비하는데, 기존 `COALESCE(u.email,'')` 는
+    실명(display_name)이 있어도 raw 이메일을 노출해 org 로스터(team_member.list_org_human_members)
+    와 어긋났다. 동일 해소로 정렬돼야 회귀하지 않음 — 구조 가드.
+    """
+    import app.routers.members as members_module
+    source = inspect.getsource(members_module.list_members)
+    assert "display_name" in source
+    assert "LEFT JOIN members" in source
+    # email 단독 폴백(도메인 포함 raw 노출)로의 회귀 금지
+    assert "COALESCE(u.email, '')" not in source


### PR DESCRIPTION
## 배경
prod dogfood 보고(story 5ef68273): **담당자가 Human일 때 assignee 표시가 email 로 나옴 — 이름으로 보여야 함.** ("Dispatch 불가" 동반 보고 → 아래 검증 참고)

## 근본 원인
보드·Dispatch assignee UI는 `/api/v2/members`(`app/routers/members.py`)를 소비한다. 이 엔드포인트의 휴먼 name SQL이 `COALESCE(u.email, '')` 로 **항상 raw 이메일**을 반환했다. 같은 휴먼을 실명으로 노출하는 org 로스터(`team_member.list_org_human_members`: `COALESCE(m.name, u.display_name, u.email)`)와 어긋나 있었다.

## 변경
- `members` LEFT JOIN 추가 후 휴먼 name = `COALESCE(NULLIF(members.name,''), NULLIF(users.display_name,''), email, '')` 로 해소 — 두 멤버 경로의 표시명을 일치.
- 컬럼 순서·grant 가시성(owner/admin OR granted) 무변경. email 은 **최종 폴백**으로만 유지(display_name/members.name 미설정 휴먼 하위호환).
- 회귀 가드 테스트 추가(`test_list_members_human_name_prefers_real_name_over_email`).

## 검증
- `pytest tests/test_s_mbr_03.py tests/test_s_mbr_10.py tests/test_e_entity_cleanup_s4_members_api.py` → **39 passed**.
- 라이브 dev 등가 증거: `/api/v2/team-members`(동일 COALESCE 사용)는 이미 `송윤재`(display_name) / `bongheecha`(local) 로 실명 해소됨 — 본 변경은 그 해소를 `/api/v2/members` 로 이식.
- **Dispatch 검증**: `POST /api/v2/dispatch`(story + 휴먼 assignee) → `{"dispatched":true,"assignee_type":"human","reason":"ok"}` HTTP 200. BE dispatch-to-human 경로는 정상 동작(차단 없음). "Dispatch 불가" 증상은 BE 차단이 아니라 FE 또는 prod grant 가시성 영역으로 보임.

## 비고
- email→이름 **FE 렌더링**은 유나양 핸드오프(assignee/이니셜 표기). 본 PR은 그 BE 데이터 소스를 실명으로 교정.
- 마이그레이션 없음(read-only SQL 변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)