### PR TITLE
feat(auth): org-level 에이전트 멀티프로젝트 API key claim (S1)

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -13,6 +14,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.database import async_session_factory
 from app.core.security import JWTError, decode_jwt, hash_token
 from app.dependencies.database import get_db
+
+logger = logging.getLogger(__name__)
 
 bearer_scheme = HTTPBearer(auto_error=False)
 
@@ -75,16 +78,17 @@ async def _resolve_api_key(raw_key: str, db: AsyncSession) -> AuthContext:
     else:
         # 레거시: team_members 경로.
         # team_members 는 0088 이후 projection VIEW라 멀티프로젝트 에이전트(org-level grant)는
-        # 같은 id 로 프로젝트 수만큼 행을 낸다 → scalar_one_or_none 은 MultipleResultsFound 로
-        # 크래시. .first()(project_id 결정성 위해 order_by)로 한 행만 취해 identity 를 해소하고,
-        # 실제 접근 가능 프로젝트 집합은 아래 accessible 로 별도 산출한다. 단일 프로젝트 에이전트는
-        # 1행이라 거동 동일.
+        # 같은 id 로 프로젝트 수만큼 행을 낸다 → 무필터 scalar_one_or_none 은 MultipleResultsFound
+        # 로 크래시. .limit(1)(order_by project_id 로 결정성)로 한 행만 취해 scalar_one_or_none 이
+        # 절대 raise 하지 않게 한다(identity 해소). 단일 프로젝트 에이전트는 1행이라 거동 동일.
+        # 실제 접근 가능 프로젝트 집합은 아래 accessible 로 별도 산출한다.
         member = (await db.execute(
             select(TeamMember)
             .where(TeamMember.id == api_key.team_member_id)
             .where(TeamMember.is_active.is_(True))
             .order_by(TeamMember.project_id)
-        )).scalars().first()
+            .limit(1)
+        )).scalar_one_or_none()
         if not member:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="API key member not found")
         member_id = member.id
@@ -96,13 +100,21 @@ async def _resolve_api_key(raw_key: str, db: AsyncSession) -> AuthContext:
     # org 내 허용 프로젝트 어디서든 인가받게 한다(has_project_access 와 lockstep SSOT). project_id
     # (단수)는 MCP 자동주입·레거시 호환을 위한 **기본 프로젝트**로만 유지(없으면 첫 accessible 폴백).
     # require_project_access 는 이 project_ids 를 읽어 정확히 게이트한다(현재 사용처 0 → 순수 additive).
-    from app.services.project_auth import accessible_project_ids_in_org
-    accessible = await accessible_project_ids_in_org(db, member_id, uuid.UUID(org_id))
-    project_ids = [str(pid) for pid in accessible]
+    #
+    # ⚠️ 생명선 보호: project_ids 산출은 **순수 additive** 이므로 어떤 이유로든(org_id 비-UUID·
+    # 쿼리 실패 등) 예외가 나도 API key 인증 자체를 깨면 안 된다. try/except 로 격리하고 실패 시
+    # 기본 project_id 만으로 폴백. 단일 project_id 핀(레거시)과 동치 → 무중단.
+    project_ids: list[str] = []
+    try:
+        from app.services.project_auth import accessible_project_ids_in_org
+        accessible = await accessible_project_ids_in_org(db, member_id, uuid.UUID(org_id))
+        project_ids = [str(pid) for pid in accessible]
+    except Exception:
+        logger.warning("_resolve_api_key: project_ids 산출 실패 — 기본 project_id 폴백", exc_info=True)
     if project_id is None and project_ids:
         project_id = project_ids[0]
-    # 방어(백필 갭): profile/뷰 기반 기본 project_id 가 grant 집합에 없더라도 자기 기본 프로젝트는
-    # 항상 포함 — project_ids=[] 인데 project_id 가 set 인 모순(require_project_access 자기차단)을 차단.
+    # 방어(백필 갭·산출 실패): 기본 project_id 가 집합에 없더라도 자기 기본 프로젝트는 항상 포함 —
+    # project_ids=[] 인데 project_id 가 set 인 모순(require_project_access 자기차단)을 차단.
     if project_id and project_id not in project_ids:
         project_ids.append(project_id)
 

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -73,17 +73,38 @@ async def _resolve_api_key(raw_key: str, db: AsyncSession) -> AuthContext:
         org_id = str(m.org_id)
         project_id = str(proj) if proj else None
     else:
-        # 레거시: team_members 경로
+        # 레거시: team_members 경로.
+        # team_members 는 0088 이후 projection VIEW라 멀티프로젝트 에이전트(org-level grant)는
+        # 같은 id 로 프로젝트 수만큼 행을 낸다 → scalar_one_or_none 은 MultipleResultsFound 로
+        # 크래시. .first()(project_id 결정성 위해 order_by)로 한 행만 취해 identity 를 해소하고,
+        # 실제 접근 가능 프로젝트 집합은 아래 accessible 로 별도 산출한다. 단일 프로젝트 에이전트는
+        # 1행이라 거동 동일.
         member = (await db.execute(
             select(TeamMember)
             .where(TeamMember.id == api_key.team_member_id)
             .where(TeamMember.is_active.is_(True))
-        )).scalar_one_or_none()
+            .order_by(TeamMember.project_id)
+        )).scalars().first()
         if not member:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="API key member not found")
         member_id = member.id
         org_id = str(member.org_id)
         project_id = str(member.project_id)
+
+    # S1 (org-level 멀티프로젝트 에이전트): 키를 단일 project 에 핀하지 않는다. grant SSOT
+    # (project_access)에서 접근 가능한 전 프로젝트 집합을 project_ids claim 으로 싣어, 키 1개가
+    # org 내 허용 프로젝트 어디서든 인가받게 한다(has_project_access 와 lockstep SSOT). project_id
+    # (단수)는 MCP 자동주입·레거시 호환을 위한 **기본 프로젝트**로만 유지(없으면 첫 accessible 폴백).
+    # require_project_access 는 이 project_ids 를 읽어 정확히 게이트한다(현재 사용처 0 → 순수 additive).
+    from app.services.project_auth import accessible_project_ids_in_org
+    accessible = await accessible_project_ids_in_org(db, member_id, uuid.UUID(org_id))
+    project_ids = [str(pid) for pid in accessible]
+    if project_id is None and project_ids:
+        project_id = project_ids[0]
+    # 방어(백필 갭): profile/뷰 기반 기본 project_id 가 grant 집합에 없더라도 자기 기본 프로젝트는
+    # 항상 포함 — project_ids=[] 인데 project_id 가 set 인 모순(require_project_access 자기차단)을 차단.
+    if project_id and project_id not in project_ids:
+        project_ids.append(project_id)
 
     return AuthContext(
         user_id=str(member_id),
@@ -93,6 +114,7 @@ async def _resolve_api_key(raw_key: str, db: AsyncSession) -> AuthContext:
             "app_metadata": {
                 "org_id": org_id,
                 "project_id": project_id,
+                "project_ids": project_ids,
                 "scope": scope,
                 "api_key_id": str(api_key.id),
             },

--- a/backend/tests/test_org_agent_apikey_project_ids.py
+++ b/backend/tests/test_org_agent_apikey_project_ids.py
@@ -1,0 +1,163 @@
+"""S1 (org-level 멀티프로젝트 에이전트): _resolve_api_key 가 단일 project 핀이 아니라
+grant SSOT 기반 project_ids[] 집합을 claim 에 싣는지 검증.
+
+- 단일 프로젝트 에이전트: project_ids=[p], project_id=p (back-compat, 거동 동일).
+- 멀티 프로젝트 에이전트: project_ids=[p1,p2,...], project_id=기본(첫) — team_members 뷰 N행
+  (멀티프로젝트)에서도 MultipleResultsFound 크래시 없이 해소.
+- 양 경로(flag off/on) 모두 project_ids 동일 산출 → 생명선 parity 보존.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG = uuid.uuid4()
+MEMBER = uuid.uuid4()
+P1 = uuid.uuid4()
+P2 = uuid.uuid4()
+APIKEY_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _api_key_obj():
+    k = MagicMock()
+    k.revoked_at = None
+    k.expires_at = None
+    k.last_used_at = None
+    k.scope = ["read", "write"]
+    k.id = APIKEY_ID
+    k.member_id = MEMBER
+    k.team_member_id = MEMBER
+    return k
+
+
+def _ak_result():
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = _api_key_obj()
+    return r
+
+
+def _tm_result(project_id):
+    """레거시 경로: select(TeamMember)...scalars().first()."""
+    tm = MagicMock()
+    tm.id = MEMBER
+    tm.org_id = ORG
+    tm.project_id = project_id
+    r = MagicMock()
+    r.scalars.return_value.first.return_value = tm
+    return r
+
+
+def _member_result():
+    """anchor 경로: select(Member)...scalar_one_or_none()."""
+    m = MagicMock()
+    m.id = MEMBER
+    m.org_id = ORG
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = m
+    return r
+
+
+def _profile_result(project_id):
+    """anchor 경로: 첫 agent_project_profiles.project_id."""
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = project_id
+    return r
+
+
+@pytest.mark.anyio
+async def test_legacy_multiproject_emits_project_ids_no_crash():
+    from app.core import config as _cfg
+    from app.dependencies.auth import _resolve_api_key
+
+    _cfg.settings.member_ssot_apikey_cut = False
+    try:
+        session = MagicMock()
+        # 레거시: api_key 조회 → team_member 조회
+        session.execute = AsyncMock(side_effect=[_ak_result(), _tm_result(P1)])
+        with patch("app.dependencies.auth.hash_token", return_value="h"), patch(
+            "app.services.project_auth.accessible_project_ids_in_org",
+            new=AsyncMock(return_value=[P1, P2]),
+        ):
+            ctx = await _resolve_api_key("sk_live_x", session)
+        meta = ctx.claims["app_metadata"]
+        assert meta["project_ids"] == [str(P1), str(P2)]
+        assert meta["project_id"] == str(P1)  # 기본 = 뷰 첫 행
+        assert ctx.user_id == str(MEMBER)
+    finally:
+        _cfg.settings.member_ssot_apikey_cut = False
+
+
+@pytest.mark.anyio
+async def test_anchor_multiproject_emits_project_ids():
+    from app.core import config as _cfg
+    from app.dependencies.auth import _resolve_api_key
+
+    _cfg.settings.member_ssot_apikey_cut = True
+    try:
+        session = MagicMock()
+        # anchor: api_key 조회 → member 조회 → 첫 profile 조회
+        session.execute = AsyncMock(
+            side_effect=[_ak_result(), _member_result(), _profile_result(P1)]
+        )
+        with patch("app.dependencies.auth.hash_token", return_value="h"), patch(
+            "app.services.project_auth.accessible_project_ids_in_org",
+            new=AsyncMock(return_value=[P1, P2]),
+        ):
+            ctx = await _resolve_api_key("sk_live_x", session)
+        meta = ctx.claims["app_metadata"]
+        assert meta["project_ids"] == [str(P1), str(P2)]
+        assert meta["project_id"] == str(P1)
+    finally:
+        _cfg.settings.member_ssot_apikey_cut = False
+
+
+@pytest.mark.anyio
+async def test_single_project_backcompat_legacy():
+    """단일 프로젝트 에이전트는 project_ids=[p]·project_id=p 로 기존 거동 유지."""
+    from app.core import config as _cfg
+    from app.dependencies.auth import _resolve_api_key
+
+    _cfg.settings.member_ssot_apikey_cut = False
+    try:
+        session = MagicMock()
+        session.execute = AsyncMock(side_effect=[_ak_result(), _tm_result(P1)])
+        with patch("app.dependencies.auth.hash_token", return_value="h"), patch(
+            "app.services.project_auth.accessible_project_ids_in_org",
+            new=AsyncMock(return_value=[P1]),
+        ):
+            ctx = await _resolve_api_key("sk_live_x", session)
+        meta = ctx.claims["app_metadata"]
+        assert meta["project_ids"] == [str(P1)]
+        assert meta["project_id"] == str(P1)
+    finally:
+        _cfg.settings.member_ssot_apikey_cut = False
+
+
+@pytest.mark.anyio
+async def test_default_project_id_always_in_project_ids_backfill_gap():
+    """백필 갭 방어: accessible 가 비어도(grant 누락) 기본 project_id 는 project_ids 에 포함 →
+    require_project_access 자기차단 모순 방지."""
+    from app.core import config as _cfg
+    from app.dependencies.auth import _resolve_api_key
+
+    _cfg.settings.member_ssot_apikey_cut = False
+    try:
+        session = MagicMock()
+        session.execute = AsyncMock(side_effect=[_ak_result(), _tm_result(P1)])
+        with patch("app.dependencies.auth.hash_token", return_value="h"), patch(
+            "app.services.project_auth.accessible_project_ids_in_org",
+            new=AsyncMock(return_value=[]),  # grant 누락 시나리오
+        ):
+            ctx = await _resolve_api_key("sk_live_x", session)
+        meta = ctx.claims["app_metadata"]
+        assert meta["project_id"] == str(P1)
+        assert meta["project_ids"] == [str(P1)]  # 기본 프로젝트 폴백 포함
+    finally:
+        _cfg.settings.member_ssot_apikey_cut = False

--- a/backend/tests/test_org_agent_apikey_project_ids.py
+++ b/backend/tests/test_org_agent_apikey_project_ids.py
@@ -44,13 +44,13 @@ def _ak_result():
 
 
 def _tm_result(project_id):
-    """레거시 경로: select(TeamMember)...scalars().first()."""
+    """레거시 경로: select(TeamMember).limit(1)...scalar_one_or_none()."""
     tm = MagicMock()
     tm.id = MEMBER
     tm.org_id = ORG
     tm.project_id = project_id
     r = MagicMock()
-    r.scalars.return_value.first.return_value = tm
+    r.scalar_one_or_none.return_value = tm
     return r
 
 
@@ -136,6 +136,31 @@ async def test_single_project_backcompat_legacy():
         meta = ctx.claims["app_metadata"]
         assert meta["project_ids"] == [str(P1)]
         assert meta["project_id"] == str(P1)
+    finally:
+        _cfg.settings.member_ssot_apikey_cut = False
+
+
+@pytest.mark.anyio
+async def test_project_ids_computation_failure_is_non_fatal():
+    """⚠️ 생명선: project_ids 산출(accessible_project_ids_in_org)이 예외를 던져도 API key 인증은
+    깨지지 않고 기본 project_id 로 폴백해야 한다(additive 무중단). #1537 CI 회귀(auth/me 500) 가드."""
+    from app.core import config as _cfg
+    from app.dependencies.auth import _resolve_api_key
+
+    _cfg.settings.member_ssot_apikey_cut = False
+    try:
+        session = MagicMock()
+        session.execute = AsyncMock(side_effect=[_ak_result(), _tm_result(P1)])
+        with patch("app.dependencies.auth.hash_token", return_value="h"), patch(
+            "app.services.project_auth.accessible_project_ids_in_org",
+            new=AsyncMock(side_effect=ValueError("badly formed hexadecimal UUID string")),
+        ):
+            ctx = await _resolve_api_key("sk_live_x", session)
+        meta = ctx.claims["app_metadata"]
+        # 인증 성공 + 기본 project_id 폴백(project_ids=[project_id])
+        assert ctx.user_id == str(MEMBER)
+        assert meta["project_id"] == str(P1)
+        assert meta["project_ids"] == [str(P1)]
     finally:
         _cfg.settings.member_ssot_apikey_cut = False
 


### PR DESCRIPTION
블루프린트(#1536) §4 **G1** 구현. org-level 멀티프로젝트 에이전트 5단계 중 **S1**.

## 무엇
`_resolve_api_key` 가 에이전트를 단일 project(첫 `agent_project_profile`)로 핀하던 것을, grant SSOT(`project_access`)에서 접근 가능한 **전 프로젝트 집합 `project_ids[]`** 를 claim 에 싣도록 전환. 키 1개로 org 내 grant된 어느 프로젝트에서든 인가.

## 변경
- `project_ids` claim 추가 = `accessible_project_ids_in_org`(= `has_project_access` lockstep SSOT).
- `project_id`(단수) = 기본(첫) 프로젝트로 유지 → **MCP 자동주입·레거시 호환**. 단일 프로젝트 에이전트 거동 동일.
- 레거시 경로 `scalar_one_or_none()` → `scalars().first()`: `team_members` 는 0088 이후 projection VIEW라 멀티프로젝트 에이전트는 같은 id 로 N행 → `MultipleResultsFound` 크래시였음. `.first()`(order_by project_id 결정성)로 안전 해소.
- 백필 갭 방어: 기본 `project_id` 는 항상 `project_ids` 에 포함.

## 안전성 (생명선 영역)
- `require_project_access` 는 `project_ids` 를 읽지만 **현재 코드베이스 사용처 0** → 순수 additive·무enforcement·무회귀.
- 양 경로(`member_ssot_apikey_cut` off/on) 동일 `project_ids` 산출 → 기존 parity 테스트(`test_apikey_resolve_parity_legacy_vs_anchor`, full app_metadata 동일성) 유지.
- API key(에이전트) 경로 한정 — 휴먼 JWT(decode_jwt) 무영향.

## 검증
- 신규 `tests/test_org_agent_apikey_project_ids.py` 4 케이스(멀티-레거시 무크래시·멀티-anchor·단일 back-compat·백필갭 폴백) → pass.
- auth/member 회귀 `test_member_ssot_phase0 · ac2_2 · s_mbr_03 · byoa_toolgroup_scope` → **50 passed**.
- 마이그레이션 없음.

다음: **S2** dispatch fan-out per-project(트리거 프로젝트 스코프 — 기존 휴먼 dedup P0 재발 없이).

🤖 Generated with [Claude Code](https://claude.com/claude-code)