### PR TITLE
feat(dispatch): 멀티프로젝트 에이전트 알림 트리거-프로젝트 라우팅 (S2)

### DIFF
--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -91,7 +91,7 @@ async def update_task(
     # E-EVENTBUS P3 S9: task_completed → story assignee에게 알림
     if old_status != "done" and task.status == "done" and task.story_id:
         story_result = await db.execute(
-            select(Story.assignee_id, Story.title, Story.org_id).where(Story.id == task.story_id)
+            select(Story.assignee_id, Story.title, Story.org_id, Story.project_id).where(Story.id == task.story_id)
         )
         story_row = story_result.one_or_none()
         if story_row and story_row.assignee_id:
@@ -104,6 +104,8 @@ async def update_task(
                 body=f"스토리: {story_row.title}" if story_row.title else None,
                 reference_type="task",
                 reference_id=task.id,
+                # S2: 멀티프로젝트 에이전트 assignee를 스토리 프로젝트로 정확 라우팅
+                source_project_id=story_row.project_id,
             )
     return TaskResponse.model_validate(task)
 

--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -102,6 +102,7 @@ async def dispatch_notification(
     body: str | None = None,
     reference_type: str | None = None,
     reference_id: uuid.UUID | None = None,
+    source_project_id: uuid.UUID | None = None,
 ) -> None:
     """notification_settings 필터 후 enabled member에게 알림 발송.
 
@@ -111,6 +112,11 @@ async def dispatch_notification(
 
     설정이 없는 member는 기본 enabled (opt-out).
     channel 기준: 'in_app'.
+
+    source_project_id: 알림을 촉발한 프로젝트(org-level 멀티프로젝트 에이전트 대응). team_members
+    뷰가 멀티프로젝트 멤버를 N행(동일 id)으로 내는데, 주어지면 dedup에서 그 프로젝트 행을 우선
+    선택하고 에이전트 Event를 그 프로젝트로 스코프한다 — 임의 first-project로 떨구는 오라우팅 방지.
+    미지정 시 기존 거동(첫 행) 유지 → 휴먼 1-알림 dedup 무회귀(additive·하위호환).
     """
     if not target_member_ids:
         return
@@ -186,14 +192,16 @@ async def dispatch_notification(
         # 반환한다. dedup 없이 루프하면 멀티프로젝트 멤버에게 알림이 **프로젝트 수만큼 중복 생성**됨
         # (Story Assign 시 Inbox 알림 3개 증상 = 담당자가 3개 프로젝트 소속). member id로 dedup해
         # 멤버당 1 알림/이벤트만 생성. (view-cutover multi-row 트랩)
-        _seen_member_ids: set = set()
-        _deduped = []
+        # source_project_id 주어지면 그 프로젝트 행을 우선(멀티프로젝트 에이전트 = 트리거 프로젝트로
+        # 정확 라우팅). 미지정 시 첫 행(기존 거동). 어느 경우든 member당 정확히 1행 → 휴먼 N-알림 무회귀.
+        _picked: dict[uuid.UUID, object] = {}
         for _m in members:
-            if _m.id in _seen_member_ids:
-                continue
-            _seen_member_ids.add(_m.id)
-            _deduped.append(_m)
-        members = _deduped
+            cur = _picked.get(_m.id)
+            if cur is None:
+                _picked[_m.id] = _m
+            elif source_project_id is not None and getattr(_m, "project_id", None) == source_project_id:
+                _picked[_m.id] = _m  # 트리거 프로젝트 행으로 교체
+        members = list(_picked.values())
 
         inserted = False
         created_events: list[Event] = []  # L1 BE-3: fan-out 수렴용 event 수집
@@ -205,10 +213,13 @@ async def dispatch_notification(
                         "dispatch_notification: skip agent %s — has active webhook", member_row.id
                     )
                     continue
-                # BUG-3 수정: agent → Notification 대신 events 테이블 INSERT
-                if member_row.project_id:
+                # BUG-3 수정: agent → Notification 대신 events 테이블 INSERT.
+                # 트리거 프로젝트(source_project_id) 우선 — 멀티프로젝트 에이전트가 임의 프로젝트로
+                # 이벤트 받는 오라우팅 방지. 미지정 시 뷰 행의 project_id(기존 거동).
+                _agent_proj = source_project_id or member_row.project_id
+                if _agent_proj:
                     event = Event(
-                        project_id=member_row.project_id,
+                        project_id=_agent_proj,
                         org_id=org_id,
                         event_type="dispatched",
                         source_entity_type=reference_type,

--- a/backend/app/services/story_status_events.py
+++ b/backend/app/services/story_status_events.py
@@ -115,6 +115,8 @@ async def emit_story_status_changed(
                 body=None,
                 reference_type="story",
                 reference_id=story.id,
+                # S2: 멀티프로젝트 에이전트 assignee를 스토리 프로젝트로 정확 라우팅
+                source_project_id=story.project_id,
             )
         except Exception:
             pass

--- a/backend/tests/test_notification_dispatch.py
+++ b/backend/tests/test_notification_dispatch.py
@@ -267,3 +267,90 @@ async def test_dispatch_dedups_multiproject_view_rows(mock_session, org_id):
     assert notifs[0].user_id == user_id
 
 
+def _agent_members_result(member_id, project_ids: list) -> MagicMock:
+    """멀티프로젝트 에이전트 = 같은 id, 프로젝트별 1행(뷰 N행)."""
+    result = MagicMock()
+    rows = []
+    for pid in project_ids:
+        row = MagicMock()
+        row.id = member_id
+        row.user_id = None
+        row.type = "agent"
+        row.project_id = pid
+        rows.append(row)
+    result.all.return_value = rows
+    return result
+
+
+@pytest.mark.anyio
+async def test_dispatch_agent_routed_to_source_project(mock_session, org_id, monkeypatch):
+    """S2: 멀티프로젝트 에이전트(뷰 N행)는 source_project_id 행으로 라우팅 — 임의 first-project가
+    아니라 트리거 프로젝트로 Event 1건 생성."""
+    from app.models.event import Event
+    from app.services import notification_dispatch as nd
+
+    # extract_activities_best_effort 는 별도 db 작업 → 격리(patch)
+    monkeypatch.setattr(
+        "app.services.activity_stream.extract_activities_best_effort",
+        AsyncMock(return_value=None),
+    )
+
+    member_id = uuid.uuid4()
+    p1, p2, p3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    settings = _settings_result([])
+    wh_result = MagicMock()
+    wh_result.scalars.return_value.all.return_value = []
+    members = _agent_members_result(member_id, [p1, p2, p3])
+    mock_session.execute.side_effect = [settings, wh_result, members]
+
+    await nd.dispatch_notification(
+        mock_session,
+        org_id=org_id,
+        event_type="dispatched",
+        target_member_ids=[member_id],
+        title="작업 전달",
+        reference_type="story",
+        reference_id=uuid.uuid4(),
+        source_project_id=p2,  # 트리거 프로젝트
+    )
+
+    events = [c.args[0] for c in mock_session.add.call_args_list if isinstance(c.args[0], Event)]
+    assert len(events) == 1, f"에이전트 Event {len(events)}개 (멤버당 1건이어야)"
+    assert events[0].project_id == p2, "Event가 트리거 프로젝트(p2)로 라우팅돼야"
+    assert events[0].recipient_id == member_id
+
+
+@pytest.mark.anyio
+async def test_dispatch_agent_no_source_falls_back_first_row(mock_session, org_id, monkeypatch):
+    """source_project_id 미지정 시 기존 거동(첫 행) — 하위호환."""
+    from app.models.event import Event
+    from app.services import notification_dispatch as nd
+
+    monkeypatch.setattr(
+        "app.services.activity_stream.extract_activities_best_effort",
+        AsyncMock(return_value=None),
+    )
+
+    member_id = uuid.uuid4()
+    p1, p2 = uuid.uuid4(), uuid.uuid4()
+    settings = _settings_result([])
+    wh_result = MagicMock()
+    wh_result.scalars.return_value.all.return_value = []
+    members = _agent_members_result(member_id, [p1, p2])
+    mock_session.execute.side_effect = [settings, wh_result, members]
+
+    await nd.dispatch_notification(
+        mock_session,
+        org_id=org_id,
+        event_type="dispatched",
+        target_member_ids=[member_id],
+        title="작업 전달",
+        reference_type="story",
+        reference_id=uuid.uuid4(),
+    )
+
+    events = [c.args[0] for c in mock_session.add.call_args_list if isinstance(c.args[0], Event)]
+    assert len(events) == 1
+    assert events[0].project_id == p1  # 첫 행
+
+


### PR DESCRIPTION
블루프린트(#1536) §4 **G2** 구현. org-level 멀티프로젝트 에이전트 5단계 중 **S2**.

## 문제
`dispatch_notification` 은 `team_members`(0088 projection VIEW)에서 멤버를 조회하는데, 멀티프로젝트 멤버는 같은 id 로 **프로젝트별 N행**을 낸다. 기존 코드는 `member_id` 로만 dedup → 에이전트 Event 가 **임의 first-project** 로 생성되어, org-level 에이전트가 트리거된 프로젝트가 아닌 엉뚱한 프로젝트에서 작업을 수신.

## 변경
- `source_project_id` 파라미터 추가(default `None` → 하위호환). 주어지면:
  - dedup 에서 **그 프로젝트 행을 우선 선택**(여전히 member 당 1행 유지),
  - 에이전트 Event 를 **그 프로젝트로 스코프**(`source_project_id or member_row.project_id`).
- 호출부 배선(assignee 가 에이전트일 수 있는 경로): `story_status_events`(상태변경)·`tasks`(task_completed) 에 스토리 `project_id` 전달. 휴먼 전용 호출부(sprints·team_members admin·stories 휴먼 브랜치·agent_dispatch 휴먼 브랜치)는 무변경.

## 회귀 안전 (휴먼 "알림 3개" P0)
- dedup 은 source 유무와 무관하게 **member 당 정확히 1행** → 기존 `test_dispatch_dedups_multiproject_view_rows`(멀티프로젝트 휴먼 1알림) 그대로 통과.
- 휴먼 Notification/Event 경로·grant-only 휴먼 org_member 폴백 무변경.

## 검증
- 신규 테스트 2: `test_dispatch_agent_routed_to_source_project`(트리거 프로젝트로 Event 1건)·`..._no_source_falls_back_first_row`(하위호환).
- `test_notification_dispatch · eventbus_s3 · dispatch_reason_7f8066a3 · e_event_inject_s3_assignment_wake · member_ssot_ac2_2 · emit_story_status_changed_isolation · agent_dispatch` → **통과**(합 29+16).
- 마이그레이션 없음.

S1(#1537)·S2 는 파일 무중첩 독립 PR. 다음: **S3** org-level create(`scope_mode: org|projects`, 빌링=에이전트 1카운트).

🤖 Generated with [Claude Code](https://claude.com/claude-code)