### PR TITLE
fix(kanban): assignee 즉시 반영 — optimistic local state (52083b02)

### DIFF
--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -140,7 +140,17 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   const attachInputRef = useRef<HTMLInputElement>(null);
 
   const [editingAssignee, setEditingAssignee] = useState(false);
-  const [savingAssignee, setSavingAssignee] = useState(false);
+  // E-BOARD: assignee optimistic local state — mirrors localStatus (L130). Checkmark/collapsed
+  // render read this, so a click reflects immediately instead of waiting for the PATCH round-trip
+  // + parent `onStoryUpdate` prop push. Decoupling from the `story` prop is what fixes "됐다 안됐다".
+  const [localAssigneeIds, setLocalAssigneeIds] = useState<string[]>(() =>
+    story.assignee_ids && story.assignee_ids.length > 0
+      ? story.assignee_ids
+      : story.assignee_id ? [story.assignee_id] : []
+  );
+  // 연타 race 가드: 옵티미스틱 토글의 source-of-truth. 클릭마다 동기 갱신해 같은 틱 더블클릭에서도
+  // 직전 stale snapshot이 아닌 최신값 기준으로 next를 계산(함수형 업데이트와 동등한 보장).
+  const assigneeIdsRef = useRef<string[]>(localAssigneeIds);
 
   const [deps, setDeps] = useState<DependencyEdge[]>([]);
   const [loadingDeps, setLoadingDeps] = useState(false);
@@ -381,23 +391,50 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     ? story.assignee_ids
     : (story.assignee_id ? [story.assignee_id] : []);
 
+  // prop이 바뀌면(네비게이션·외부 갱신·dispatch 패널 onAssigneePatched 경로) 로컬을 재동기화 — localStatus(L319) 미러.
+  // 배열 ref가 아닌 내용(join) 기준 → 부모 리렌더가 in-flight 옵티미스틱 값을 덮지 않음.
+  const assigneeSyncKey = currentAssigneeIds.join(',');
+  useEffect(() => {
+    assigneeIdsRef.current = currentAssigneeIds;
+    setLocalAssigneeIds(currentAssigneeIds);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [assigneeSyncKey]);
+
   const handleToggleAssignee = async (memberId: string) => {
-    const set = new Set(currentAssigneeIds);
-    if (set.has(memberId)) set.delete(memberId); else set.add(memberId);
-    const next = Array.from(set);
-    setSavingAssignee(true);
+    const prev = assigneeIdsRef.current;
+    const next = prev.includes(memberId)
+      ? prev.filter((id) => id !== memberId)
+      : [...prev, memberId];
+    assigneeIdsRef.current = next;   // 동기 갱신 → 연타 시 다음 클릭이 최신 기준으로 계산
+    setLocalAssigneeIds(next);       // 옵티미스틱 — 체크마크/표시 즉시 반영
+    // assignee_ids 전체 배열 교체(서버 last-write-wins) → 연타 시 마지막 로컬과 정합.
     const updated = await patchStory({ assignee_ids: next });
-    setSavingAssignee(false);
-    // BE가 assignee_id(주담당)를 assignee_ids[0]로 동기화 → 응답 우선, 없으면 로컬 계산.
-    if (updated) onStoryUpdate?.({ ...story, assignee_ids: updated.assignee_ids ?? next, assignee_id: updated.assignee_id ?? next[0] ?? null });
+    if (updated) {
+      // BE가 assignee_id(주담당)를 assignee_ids[0]로 동기화 → 응답 우선, 없으면 로컬 계산.
+      const resolved = updated.assignee_ids ?? next;
+      assigneeIdsRef.current = resolved;
+      setLocalAssigneeIds(resolved);
+      onStoryUpdate?.({ ...story, assignee_ids: resolved, assignee_id: updated.assignee_id ?? resolved[0] ?? null });
+    } else {
+      assigneeIdsRef.current = prev; // PATCH 실패 → 직전 값 롤백
+      setLocalAssigneeIds(prev);
+      addToast({ type: 'error', title: '담당자 변경에 실패했습니다.' });
+    }
   };
 
   const handleClearAssignees = async () => {
-    setSavingAssignee(true);
+    const prev = assigneeIdsRef.current;
+    assigneeIdsRef.current = [];
+    setLocalAssigneeIds([]);         // 옵티미스틱
     setEditingAssignee(false);
     const updated = await patchStory({ assignee_ids: [] });
-    setSavingAssignee(false);
-    if (updated) onStoryUpdate?.({ ...story, assignee_ids: [], assignee_id: null });
+    if (updated) {
+      onStoryUpdate?.({ ...story, assignee_ids: [], assignee_id: null });
+    } else {
+      assigneeIdsRef.current = prev; // 롤백
+      setLocalAssigneeIds(prev);
+      addToast({ type: 'error', title: '담당자 변경에 실패했습니다.' });
+    }
   };
 
   const handleSaveDescription = async () => {
@@ -721,7 +758,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                     — {t('clearAssignees')}
                   </button>
                   {members.filter((m, i, arr) => arr.findIndex((x) => x.id === m.id) === i).map((m) => {
-                    const selected = currentAssigneeIds.includes(m.id);
+                    const selected = localAssigneeIds.includes(m.id);
                     return (
                       <button
                         key={m.id}
@@ -747,11 +784,9 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 </div>
               ) : (
                 <p className="mt-1 text-sm text-foreground">
-                  {savingAssignee
-                    ? t('loading')
-                    : currentAssigneeIds.length > 0
-                      ? currentAssigneeIds.map((id) => memberMap[id]?.name ?? '—').join(', ')
-                      : '—'}
+                  {localAssigneeIds.length > 0
+                    ? localAssigneeIds.map((id) => memberMap[id]?.name ?? '—').join(', ')
+                    : '—'}
                 </p>
               )}
             </div>
@@ -764,7 +799,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   entityType="story"
                   entityId={story.id}
                   projectId={projectId}
-                  currentAssigneeId={currentAssigneeIds.length > 1 ? undefined : story.assignee_id}
+                  currentAssigneeId={localAssigneeIds.length > 1 ? undefined : story.assignee_id}
                   onAssigneePatched={(aid) => onStoryUpdate?.({ ...story, assignee_id: aid })}
                 />
               </div>


### PR DESCRIPTION
## 무엇을

보드 스토리 상세에서 휴먼 담당자(assignee) 토글이 즉시 반영되지 않고 "됐다 안됐다" 하던 버그 수정. (story `52083b02`, 유나양 핸드오프 thread `c1b51126`)

BE는 정상(디디군 dispatch 200, email→실명 #1535 해결). 남은 FE 로직 버그.

## 근본

`apps/web/src/components/kanban/story-detail-panel.tsx`
- `handleToggleAssignee`·`handleClearAssignees`에 옵티미스틱 local state 부재.
- 체크마크(`selected`)·collapsed 표시가 전부 `currentAssigneeIds`(story prop 파생)에서 읽힘 → `patchStory` await + 부모 `onStoryUpdate` prop 푸시가 끝나야 갱신 → 왕복 동안 화면 무변동 → 실패로 인식.
- 같은 파일 `handleChangeStatus`는 이미 `localStatus` 옵티미스틱 패턴(즉시 set + 실패 롤백)을 쓰는데 **assignee만 누락 — 이 비대칭이 버그.**
- "됐다 안됐다": stale prop snapshot(`new Set(currentAssigneeIds)`) 기준 toggle → 연타 race로 유실/오결과.

## 수정 (handleChangeStatus 미러)

1. **`localAssigneeIds` 옵티미스틱 state 도입** — 체크마크·collapsed 표시·dispatch 패널 length 체크를 모두 local 기준 렌더 → 클릭 즉시 반영.
2. **연타 race 제거** — `assigneeIdsRef`를 동기 source-of-truth로 두어 같은 틱 더블클릭에서도 최신값 기준으로 `next` 계산(함수형 업데이트와 동등 보장). `assignee_ids` 전체 배열 교체(서버 last-write-wins)라 마지막 로컬과 정합.
3. **실패 롤백 + 에러 토스트** — PATCH 실패 시 직전 값 복원 + `addToast`(기존 패턴).
4. **prop sync** — `assignee_ids`/`assignee_id` 내용(join-key) 변경 시 재동기화. 배열 ref가 아닌 내용 기준이라 부모 리렌더가 in-flight 옵티미스틱 값을 덮지 않음. 네비게이션·외부 갱신·dispatch `onAssigneePatched` 경로 모두 커버. `localStatus`(L319) 미러.
5. `savingAssignee` 로딩 게이트 제거 — 옵티미스틱 값이 즉시 명을 보여주고 실패는 토스트가 알리므로 로딩 텍스트가 오히려 즉시반영을 가림.

## 검증

- `pnpm type-check` ✅
- `pnpm lint` (대상 파일) ✅ 0 warning
- `pnpm build` ✅ EXIT 0

라이브 픽셀 검증(클릭 즉시반영·연타·카드교차 안정)은 dev 배포 후 까심 cross-model QA → 머지게이트 → 선생님 플로우.

## 디자인 검수

시각 회귀·assignee 칩 표시 거리는 유나양 가디언 리뷰 요청 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)