### PR TITLE
feat(agents): org-level 멀티프로젝트 에이전트 생성 POST /api/v2/agents (S3)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -53,7 +53,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -166,6 +166,7 @@ app.include_router(stories.router)
 app.include_router(projects.router)
 app.include_router(project_access.router)
 app.include_router(team_members.router)
+app.include_router(agents.router)
 app.include_router(team_presence.router)
 app.include_router(org_members.router)
 app.include_router(standups.router)

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -1,0 +1,118 @@
+"""S3 (org-level 멀티프로젝트 에이전트): org 범위 에이전트 생성 엔드포인트.
+
+`POST /api/v2/agents` — 단일 project 종속(team-members create)과 달리 scope_mode 로 프로젝트
+집합을 받아 members/api_key 1개 + N 프로젝트 grant 를 fan-out 한다(빌링=에이전트 1카운트).
+인가/권한 규칙은 create_team_member 와 동일(agent actor can_manage_members + role rank + self-name).
+
+블루프린트 docs/org-level-agent-multiproject-blueprint.md §4 G3 / §5.
+"""
+import os
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.models.project import Project
+from app.schemas.team_member import OrgAgentCreate, TeamMemberResponse
+from app.services.org_agent import create_org_level_agent
+
+router = APIRouter(prefix="/api/v2/agents", tags=["agents"])
+
+_FAKECHAT_BASE_PORT = 8787
+
+
+async def _resolve_org_project_ids(
+    body: OrgAgentCreate, session: AsyncSession, org_id: uuid.UUID
+) -> list[uuid.UUID]:
+    """scope_mode → grant 대상 프로젝트 id 리스트(org 소속·≥1·중복제거·순서보존)."""
+    org_projects = [
+        r[0]
+        for r in (
+            await session.execute(
+                select(Project.id)
+                .where(Project.org_id == org_id, Project.deleted_at.is_(None))
+                .order_by(Project.created_at.asc())
+            )
+        ).all()
+    ]
+    if body.scope_mode == "org":
+        # v1: 현재 org 의 모든 프로젝트. 미래 프로젝트 자동 grant 는 follow-up(project-create 훅).
+        project_ids = org_projects
+    elif body.scope_mode == "projects":
+        if not body.project_ids:
+            raise HTTPException(status_code=400, detail="project_ids required when scope_mode='projects'")
+        valid = set(org_projects)
+        invalid = [str(p) for p in body.project_ids if p not in valid]
+        if invalid:
+            raise HTTPException(status_code=400, detail=f"project_ids not in org: {invalid}")
+        seen: set[uuid.UUID] = set()
+        project_ids = []
+        for p in body.project_ids:  # 순서 보존 + 중복 제거
+            if p not in seen:
+                seen.add(p)
+                project_ids.append(p)
+    else:
+        raise HTTPException(status_code=400, detail="scope_mode must be 'org' or 'projects'")
+
+    if not project_ids:
+        raise HTTPException(status_code=400, detail="org has no projects to grant the agent into")
+    return project_ids
+
+
+@router.post("", status_code=201)
+async def create_org_agent(
+    body: OrgAgentCreate,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """org-level 에이전트 생성 + scope_mode 프로젝트 집합 grant. 응답에 api_key 1회 노출."""
+    # 권한: create_team_member 와 동일 규칙 재사용(agent actor 제약).
+    from app.routers.team_members import _ROLE_RANK, _resolve_actor
+
+    actor = await _resolve_actor(auth, session, org_id)
+    if actor is not None and actor.type == "agent":
+        if not actor.can_manage_members:
+            raise HTTPException(status_code=403, detail="Agent does not have can_manage_members permission")
+        if _ROLE_RANK.get(body.role, 1) > _ROLE_RANK.get(actor.role, 1):
+            raise HTTPException(status_code=403, detail="Cannot assign role higher than your own")
+        if body.name == actor.name:
+            raise HTTPException(status_code=400, detail="Agent cannot create a member with the same name as itself")
+
+    project_ids = await _resolve_org_project_ids(body, session, org_id)
+
+    created_by = uuid.UUID(auth.user_id)  # 휴먼=user_id / 에이전트=member.id (anchor sync 가 휴먼만 owner 매칭)
+    member, api_key_plaintext = await create_org_level_agent(
+        session,
+        org_id=org_id,
+        created_by=created_by,
+        name=body.name,
+        role=body.role,
+        agent_config=body.agent_config,
+        agent_role=body.agent_role,
+        color=body.color,
+        avatar_url=body.avatar_url,
+        project_ids=project_ids,
+    )
+
+    response = TeamMemberResponse.model_validate(member).model_dump()
+    response["member_id"] = str(member.id)
+    response["project_ids"] = [str(p) for p in project_ids]
+    response["scope_mode"] = body.scope_mode
+    effective_port = member.fakechat_port or int(os.environ.get("FAKECHAT_PORT", _FAKECHAT_BASE_PORT))
+    response["fakechat_port"] = effective_port
+    response["api_key_created"] = bool(api_key_plaintext)
+    response["mcp_config"] = {
+        "mcpServers": {
+            "sprintable": {
+                "type": "sse",
+                "url": f"http://localhost:{effective_port}/sse",
+            }
+        }
+    }
+    if api_key_plaintext:
+        response["api_key"] = api_key_plaintext
+    return response

--- a/backend/app/schemas/team_member.py
+++ b/backend/app/schemas/team_member.py
@@ -27,6 +27,23 @@ class TeamMemberCreate(BaseModel):
     agent_role: str | None = None
 
 
+class OrgAgentCreate(BaseModel):
+    """org-level 에이전트 생성 요청. 단일 project 종속이 아니라 scope_mode 로 프로젝트 집합 지정.
+
+    scope_mode='org'   → org 의 현재 모든 프로젝트에 grant (v1; 미래 프로젝트 자동 grant 는 follow-up).
+    scope_mode='projects' → project_ids 에 명시한 프로젝트에만 grant (≥1 필수, 모두 org 소속).
+    role 은 grant 별 부여(기본 member) — project_access.role 로 per-project 적용.
+    """
+    name: str
+    role: str = "member"
+    agent_config: dict[str, Any] | None = None
+    agent_role: str | None = None
+    color: str = "#3385f8"
+    avatar_url: str | None = None
+    scope_mode: str = "projects"  # 'org' | 'projects'
+    project_ids: list[uuid.UUID] = []
+
+
 class TeamMemberUpdate(BaseModel):
     name: str | None = None
     role: str | None = None

--- a/backend/app/services/agent_anchor_sync.py
+++ b/backend/app/services/agent_anchor_sync.py
@@ -77,45 +77,83 @@ async def sync_agent_anchor_on_create(
         .on_conflict_do_nothing(index_elements=["id"])
     )
 
-    # 2. agent_project_profiles (member_id=team_member.id) — 런타임/설정 미러
+    # 2·3. per-project 앵커(agent_project_profiles + project_access placement) — 공유 헬퍼.
+    await write_agent_project_placement(
+        session,
+        member_id=team_member.id,
+        project_id=team_member.project_id,
+        agent_config=team_member.agent_config,
+        agent_role=team_member.agent_role,
+        fakechat_port=team_member.fakechat_port,
+        role=team_member.role,
+        color=team_member.color,
+        can_manage_members=team_member.can_manage_members,
+        last_seen_at=team_member.last_seen_at,
+        active_story_id=team_member.active_story_id,
+        agent_status=team_member.agent_status,
+    )
+
+    # api_key 자동생성(create_team_member)이 같은 트랜잭션에서 members FK를 즉시 보도록 flush
+    await session.flush()
+
+
+async def write_agent_project_placement(
+    session: AsyncSession,
+    *,
+    member_id: uuid.UUID,
+    project_id: uuid.UUID,
+    agent_config: dict | None = None,
+    agent_role: str | None = None,
+    fakechat_port: int | None = None,
+    role: str = "member",
+    color: str = "#3385f8",
+    can_manage_members: bool = False,
+    last_seen_at=None,
+    active_story_id: uuid.UUID | None = None,
+    agent_status: str | None = None,
+) -> None:
+    """에이전트의 per-project 앵커(agent_project_profiles 런타임 + project_access grant)를 멱등 write.
+
+    members 행은 호출부(sync_agent_anchor_on_create / org-level create)에서 보장한다. org-level
+    멀티프로젝트 에이전트가 추가 프로젝트로 접근을 확장할 때 이 헬퍼를 프로젝트마다 재호출한다.
+    둘 다 ON CONFLICT DO NOTHING — 재호출/백필 중복 안전.
+    """
+    # agent_project_profiles (member_id) — 런타임/설정 미러
     await session.execute(
         pg_insert(AgentProjectProfile.__table__)
         .values(
             id=uuid.uuid4(),
-            member_id=team_member.id,
-            project_id=team_member.project_id,
-            agent_config=team_member.agent_config,
-            agent_role=team_member.agent_role,
-            fakechat_port=team_member.fakechat_port,
-            last_seen_at=team_member.last_seen_at,
-            active_story_id=team_member.active_story_id,
-            agent_status=team_member.agent_status,
+            member_id=member_id,
+            project_id=project_id,
+            agent_config=agent_config,
+            agent_role=agent_role,
+            fakechat_port=fakechat_port,
+            last_seen_at=last_seen_at,
+            active_story_id=active_story_id,
+            agent_status=agent_status,
         )
         .on_conflict_do_nothing()  # (project_id, member_id) UNIQUE + (project_id, fakechat_port) 부분 UNIQUE 모두 흡수
     )
 
-    # 3. project_access direct placement (AC3-4 2-1, G3): 0075 §5 에이전트 placement 동형.
-    #    AC3-4 뷰가 role/can_manage를 project_access서 읽으므로 신규 agent도 placement 필요(누락 시 뷰서
-    #    role 기본값). member_id=tm.id(canonical), org_member_id=NULL(에이전트). ON CONFLICT 멱등.
+    # project_access direct placement (AC3-4 2-1, G3): 0075 §5 에이전트 placement 동형.
+    #    AC3-4 뷰가 role/can_manage를 project_access서 읽으므로 grant 필요. member_id=canonical,
+    #    org_member_id=NULL(에이전트). ON CONFLICT 멱등.
     from app.models.project_access import ProjectAccess
     await session.execute(
         pg_insert(ProjectAccess.__table__)
         .values(
             id=uuid.uuid4(),
-            project_id=team_member.project_id,
+            project_id=project_id,
             org_member_id=None,
-            member_id=team_member.id,
+            member_id=member_id,
             permission="granted",
-            role=team_member.role,
-            color=team_member.color,
-            can_manage_members=team_member.can_manage_members,
+            role=role,
+            color=color,
+            can_manage_members=can_manage_members,
             access_source="direct",
         )
         .on_conflict_do_nothing()  # (project_id, member_id) 부분 UNIQUE 흡수(멱등)
     )
-
-    # api_key 자동생성(create_team_member)이 같은 트랜잭션에서 members FK를 즉시 보도록 flush
-    await session.flush()
 
 
 async def ensure_human_member(session: AsyncSession, org_member_id: uuid.UUID) -> bool:

--- a/backend/app/services/org_agent.py
+++ b/backend/app/services/org_agent.py
@@ -1,0 +1,130 @@
+"""S3 (org-level 멀티프로젝트 에이전트): org 범위 에이전트 1개 생성 + N 프로젝트 grant fan-out.
+
+members/api_key 는 **1회만** 생성하고(빌링=에이전트 1카운트), project_ids 전체에 per-project
+앵커(agent_project_profiles + project_access grant)를 멱등 write 한다. project_ids[0] 를 앵커
+프로젝트로 기존 `sync_agent_anchor_on_create`(members+profile+grant)를 태우고, 나머지는
+`write_agent_project_placement`(profile+grant)만 추가한다 — members 중복 생성 0(identity 안정).
+
+블루프린트 docs/org-level-agent-multiproject-blueprint.md §4 G3.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.team import TeamMember
+from app.services.agent_anchor_sync import (
+    sync_agent_anchor_on_create,
+    write_agent_project_placement,
+)
+
+_FAKECHAT_BASE_PORT = 8787
+
+
+async def _allocate_fakechat_port(session: AsyncSession, project_id: uuid.UUID) -> int:
+    """프로젝트 내 미사용 fakechat 포트 — create_team_member 와 동일 규칙(프로젝트별 유일)."""
+    existing = {
+        r[0]
+        for r in (
+            await session.execute(
+                select(TeamMember.fakechat_port).where(
+                    TeamMember.project_id == project_id,
+                    TeamMember.type == "agent",
+                    TeamMember.fakechat_port.isnot(None),
+                )
+            )
+        ).all()
+    }
+    port = _FAKECHAT_BASE_PORT
+    while port in existing:
+        port += 1
+    return port
+
+
+async def create_org_level_agent(
+    session: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    created_by: uuid.UUID | None,
+    name: str,
+    role: str = "member",
+    agent_config: dict | None = None,
+    agent_role: str | None = None,
+    color: str = "#3385f8",
+    avatar_url: str | None = None,
+    project_ids: list[uuid.UUID],
+) -> tuple[TeamMember, str | None]:
+    """org-level 에이전트 1개 생성 후 project_ids 전체에 grant fan-out.
+
+    project_ids 는 호출부에서 **org 소속·≥1·중복제거** 검증 완료를 가정(순서 보존). 반환:
+    (transient TeamMember, api_key 평문). 영속은 앵커 write-sync(members/profile/grant)·api_key
+    로만 — get_db 가 커밋한다(엔드포인트 명시 커밋 없음).
+    """
+    if not project_ids:
+        raise ValueError("project_ids must be non-empty")
+
+    anchor_project = project_ids[0]
+    now = datetime.now(timezone.utc)
+    member = TeamMember(
+        id=uuid.uuid4(),
+        project_id=anchor_project,
+        org_id=org_id,
+        type="agent",
+        name=name,
+        role=role,
+        user_id=None,
+        avatar_url=avatar_url,
+        agent_config=agent_config,
+        color=color,
+        agent_role=agent_role,
+        created_by=created_by,
+        fakechat_port=await _allocate_fakechat_port(session, anchor_project),
+        is_active=True,
+        can_manage_members=False,
+        last_seen_at=None,
+        active_story_id=None,
+        agent_status=None,
+        created_at=now,
+        updated_at=now,
+    )  # NOT session.add — 앵커 write-sync 가 유일 영속 경로
+
+    # 앵커 프로젝트: members + agent_project_profiles + project_access grant
+    await sync_agent_anchor_on_create(session, member, created_by)
+
+    # 추가 프로젝트: per-project placement(profile + grant)만 — members 는 위에서 1회 생성됨.
+    for pid in project_ids[1:]:
+        await write_agent_project_placement(
+            session,
+            member_id=member.id,
+            project_id=pid,
+            agent_config=agent_config,
+            agent_role=agent_role,
+            fakechat_port=await _allocate_fakechat_port(session, pid),
+            role=role,
+            color=color,
+            can_manage_members=False,
+        )
+    await session.flush()
+
+    # default 알림 설정(멤버당 1회)
+    from app.services.notification_preference_defaults import insert_default_preferences
+
+    await insert_default_preferences(session, member.id, "agent")
+
+    # API key 1개(전 비파괴 툴그룹 scope) — create_team_member 와 동일 모델
+    from app.repositories.api_key import ApiKeyRepository
+    from app.services.mcp_toolset import ALL_GROUPS
+
+    _key, api_key_plaintext = await ApiKeyRepository(session).create(
+        team_member_id=member.id, scope=list(ALL_GROUPS)
+    )
+
+    # 생성자를 agent allow_list 에 자동 등록(멱등)
+    from app.services.agent_message_policy import ensure_creator_allowlisted
+
+    await ensure_creator_allowlisted(session, member.id)
+
+    return member, api_key_plaintext

--- a/backend/tests/test_org_agent_create.py
+++ b/backend/tests/test_org_agent_create.py
@@ -1,0 +1,161 @@
+"""S3: org-level 멀티프로젝트 에이전트 생성(POST /api/v2/agents) + 서비스 fan-out 테스트."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _projects_result(project_ids):
+    r = MagicMock()
+    r.all.return_value = [(p,) for p in project_ids]
+    return r
+
+
+# ─── _resolve_org_project_ids: scope_mode 해소 ────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_resolve_scope_org_returns_all_projects():
+    from app.routers.agents import _resolve_org_project_ids
+    from app.schemas.team_member import OrgAgentCreate
+
+    p1, p2 = uuid.uuid4(), uuid.uuid4()
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_projects_result([p1, p2]))
+    body = OrgAgentCreate(name="CoS", scope_mode="org")
+    out = await _resolve_org_project_ids(body, session, uuid.uuid4())
+    assert out == [p1, p2]
+
+
+@pytest.mark.anyio
+async def test_resolve_scope_projects_validates_subset_and_dedups():
+    from app.routers.agents import _resolve_org_project_ids
+    from app.schemas.team_member import OrgAgentCreate
+
+    p1, p2, p3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_projects_result([p1, p2, p3]))
+    # 중복 포함 + 순서 보존
+    body = OrgAgentCreate(name="CoS", scope_mode="projects", project_ids=[p2, p1, p2])
+    out = await _resolve_org_project_ids(body, session, uuid.uuid4())
+    assert out == [p2, p1]
+
+
+@pytest.mark.anyio
+async def test_resolve_scope_projects_rejects_foreign_project():
+    from fastapi import HTTPException
+
+    from app.routers.agents import _resolve_org_project_ids
+    from app.schemas.team_member import OrgAgentCreate
+
+    p1, foreign = uuid.uuid4(), uuid.uuid4()
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_projects_result([p1]))
+    body = OrgAgentCreate(name="CoS", scope_mode="projects", project_ids=[foreign])
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_org_project_ids(body, session, uuid.uuid4())
+    assert ei.value.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_resolve_scope_projects_requires_ids():
+    from fastapi import HTTPException
+
+    from app.routers.agents import _resolve_org_project_ids
+    from app.schemas.team_member import OrgAgentCreate
+
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_projects_result([uuid.uuid4()]))
+    body = OrgAgentCreate(name="CoS", scope_mode="projects", project_ids=[])
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_org_project_ids(body, session, uuid.uuid4())
+    assert ei.value.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_resolve_invalid_scope_mode():
+    from fastapi import HTTPException
+
+    from app.routers.agents import _resolve_org_project_ids
+    from app.schemas.team_member import OrgAgentCreate
+
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_projects_result([uuid.uuid4()]))
+    body = OrgAgentCreate(name="CoS", scope_mode="bogus")
+    with pytest.raises(HTTPException) as ei:
+        await _resolve_org_project_ids(body, session, uuid.uuid4())
+    assert ei.value.status_code == 400
+
+
+# ─── create_org_level_agent: members/api_key 1회 + N grant fan-out ────────────
+
+
+@pytest.mark.anyio
+async def test_create_org_level_agent_fans_out_grants(monkeypatch):
+    from app.services import org_agent
+
+    session = MagicMock()
+    port_res = MagicMock()
+    port_res.all.return_value = []  # 미사용 포트 조회 → 빈
+    session.execute = AsyncMock(return_value=port_res)
+    session.flush = AsyncMock()
+
+    calls = {"sync": 0, "placement": []}
+
+    async def fake_sync(_s, member, _cb):
+        calls["sync"] += 1
+
+    async def fake_place(_s, **kw):
+        calls["placement"].append(kw["project_id"])
+
+    monkeypatch.setattr(org_agent, "sync_agent_anchor_on_create", fake_sync)
+    monkeypatch.setattr(org_agent, "write_agent_project_placement", fake_place)
+    monkeypatch.setattr(
+        "app.services.notification_preference_defaults.insert_default_preferences",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "app.services.agent_message_policy.ensure_creator_allowlisted", AsyncMock()
+    )
+
+    class _FakeApiKeyRepo:
+        def __init__(self, _s):
+            pass
+
+        async def create(self, team_member_id, scope):
+            return (MagicMock(), "sk_live_test")
+
+    monkeypatch.setattr("app.repositories.api_key.ApiKeyRepository", _FakeApiKeyRepo)
+
+    p1, p2, p3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    member, key = await org_agent.create_org_level_agent(
+        session,
+        org_id=uuid.uuid4(),
+        created_by=uuid.uuid4(),
+        name="Chief of Staff",
+        project_ids=[p1, p2, p3],
+    )
+
+    assert calls["sync"] == 1  # 앵커 프로젝트는 anchor write-sync 1회
+    assert calls["placement"] == [p2, p3]  # 나머지 프로젝트만 placement
+    assert member.project_id == p1  # 앵커 프로젝트
+    assert member.type == "agent"
+    assert key == "sk_live_test"
+
+
+@pytest.mark.anyio
+async def test_create_org_level_agent_empty_projects_raises(monkeypatch):
+    from app.services import org_agent
+
+    session = MagicMock()
+    with pytest.raises(ValueError):
+        await org_agent.create_org_level_agent(
+            session, org_id=uuid.uuid4(), created_by=None, name="x", project_ids=[]
+        )


### PR DESCRIPTION
블루프린트(#1536) §4 **G3** 구현. org-level 멀티프로젝트 에이전트 5단계 중 **S3**(S1 #1537·S2 #1538 위에서 동작).

## 무엇
단일 project 종속(`POST /api/v2/team-members`)과 달리 **scope_mode 로 프로젝트 집합**을 받아, `members`/`api_key` **1개**(빌링=에이전트 1카운트)에 **N 프로젝트 grant 를 fan-out** 한다.

## 구성
- **schema** `OrgAgentCreate`: `scope_mode('org'|'projects')` + `project_ids[]` + `role`(grant별, 기본 `member`).
- **service** `create_org_level_agent`: `project_ids[0]` 를 앵커로 기존 `sync_agent_anchor_on_create`(members+profile+grant) 1회 → 나머지는 `write_agent_project_placement`(profile+grant)만. `members` 중복 생성 0(identity 안정). per-project placement 를 `agent_anchor_sync` 에서 **공유 헬퍼로 추출**(기존 거동 무변경, 회귀 테스트 통과).
- **endpoint** `POST /api/v2/agents`: 권한(can_manage_members·role rank·self-name)은 `create_team_member` 규칙 재사용. `scope_mode='org'` = 현재 org 전 프로젝트(v1), `='projects'` = org 소속 검증·중복제거·순서보존. 응답에 `project_ids`·`scope_mode`·`api_key`(1회)·`mcp_config`.

## §9 결정 반영
scope=**현재 프로젝트만**(미래 자동 grant 는 follow-up) / role=**grant별 기본 member**(`project_access.role` → 44434ce9 역할 enum forward-compatible) / 빌링=**에이전트 1카운트**.

## 검증
- 신규 `tests/test_org_agent_create.py` 7케이스: scope 해소(org/projects/foreign reject/빈/invalid) + 서비스 fan-out(anchor 1 + 나머지 placement) + 빈 projects ValueError.
- `app.main` import OK·`/api/v2/agents` 라우트 등록 확인. anchor/team_members 회귀(`member_ssot_ac3_1b`·`team_members`·`onboarding_member_anchor`) 통과.
- 마이그레이션 없음(멀티프로젝트 멤버십 = N project_access 행).

## 비고
- **post-merge 라이브 검증 권장**: org-agent 생성 → 여러 프로젝트에서 보임 + 프로젝트 간 dispatch 정상(S1·S2 머지 후 실 JWT/Key E2E).
- 후속 S4(grant/revoke ergonomics)·S5(list/show + FE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)