### PR TITLE
feat(access): org-agent grant profile-on-grant + revoke 제거 (S4)

### DIFF
--- a/backend/app/routers/project_access.py
+++ b/backend/app/routers/project_access.py
@@ -120,6 +120,12 @@ async def create_project_access(
             member_id=body.member_id,
             permission=body.permission,
         )
+        # S4 (org-level 멀티프로젝트): grant 확장 시 per-project 런타임(agent_project_profiles)도
+        # 멱등 생성 — 안 하면 뷰 branch3(런타임 NULL)로만 떠 presence/런타임 write 가 0행 무음 누락.
+        from app.services.agent_anchor_sync import ensure_agent_project_profile
+        await ensure_agent_project_profile(
+            session, member_id=body.member_id, project_id=project_id
+        )
     else:
         existing = await session.execute(
             select(ProjectAccess).where(
@@ -164,6 +170,22 @@ async def delete_project_access(
     record = result.scalar_one_or_none()
     if record is None:
         raise HTTPException(status_code=404, detail="Access record not found")
+
+    # S4: 에이전트 grant 회수 시 per-project 런타임 행(agent_project_profiles)도 제거 — 안 하면
+    # team_members 뷰 branch2(profile join)가 회수된 에이전트를 계속 노출(grant↔뷰 불일치·한쪽만
+    # 전환 트랩). 에이전트 grant = org_member_id NULL + member_id set. 휴먼이면 매칭 profile 0행이라
+    # 무해하지만 guard 로 의도 명시.
+    if record.org_member_id is None and record.member_id is not None:
+        from sqlalchemy import delete as sa_delete
+
+        from app.models.member import AgentProjectProfile
+        await session.execute(
+            sa_delete(AgentProjectProfile.__table__).where(
+                AgentProjectProfile.__table__.c.member_id == record.member_id,
+                AgentProjectProfile.__table__.c.project_id == project_id,
+            )
+        )
+
     await session.delete(record)
     await session.commit()
     return {"ok": True}

--- a/backend/app/services/agent_anchor_sync.py
+++ b/backend/app/services/agent_anchor_sync.py
@@ -156,6 +156,66 @@ async def write_agent_project_placement(
     )
 
 
+_FAKECHAT_BASE_PORT = 8787
+
+
+async def allocate_fakechat_port(session: AsyncSession, project_id: uuid.UUID) -> int:
+    """프로젝트 내 미사용 fakechat 포트 — create_team_member 와 동일 규칙(프로젝트별 유일)."""
+    from app.models.team import TeamMember
+
+    existing = {
+        r[0]
+        for r in (
+            await session.execute(
+                select(TeamMember.fakechat_port).where(
+                    TeamMember.project_id == project_id,
+                    TeamMember.type == "agent",
+                    TeamMember.fakechat_port.isnot(None),
+                )
+            )
+        ).all()
+    }
+    port = _FAKECHAT_BASE_PORT
+    while port in existing:
+        port += 1
+    return port
+
+
+async def ensure_agent_project_profile(
+    session: AsyncSession,
+    *,
+    member_id: uuid.UUID,
+    project_id: uuid.UUID,
+    agent_config: dict | None = None,
+    agent_role: str | None = None,
+    fakechat_port: int | None = None,
+) -> None:
+    """에이전트의 per-project agent_project_profiles 행만 멱등 보장(grant 는 호출부가 관리).
+
+    S4: grant-only 에이전트(team_members 뷰 branch3 = 런타임 컬럼 NULL)에 per-project profile 을
+    부여해 presence/런타임 write(sync_agent_profile_presence 의 UPDATE)가 실제 행에 반영되게 한다.
+    profile 부재 시 presence UPDATE 가 0행(무음 누락)이 되는 문제 해소. fakechat_port 미지정 시
+    프로젝트 내 미사용 포트를 자동 할당(create 경로와 동일 규칙). ON CONFLICT 멱등.
+    """
+    if fakechat_port is None:
+        fakechat_port = await allocate_fakechat_port(session, project_id)
+    await session.execute(
+        pg_insert(AgentProjectProfile.__table__)
+        .values(
+            id=uuid.uuid4(),
+            member_id=member_id,
+            project_id=project_id,
+            agent_config=agent_config,
+            agent_role=agent_role,
+            fakechat_port=fakechat_port,
+            last_seen_at=None,
+            active_story_id=None,
+            agent_status=None,
+        )
+        .on_conflict_do_nothing()  # (project_id, member_id) UNIQUE + (project_id, fakechat_port) 부분 UNIQUE 흡수
+    )
+
+
 async def ensure_human_member(session: AsyncSession, org_member_id: uuid.UUID) -> bool:
     """휴먼 org_member의 앵커 members 행을 멱등 보장(AC3-2c grant write-sync).
 

--- a/backend/app/services/org_agent.py
+++ b/backend/app/services/org_agent.py
@@ -12,36 +12,14 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.team import TeamMember
 from app.services.agent_anchor_sync import (
+    allocate_fakechat_port,
     sync_agent_anchor_on_create,
     write_agent_project_placement,
 )
-
-_FAKECHAT_BASE_PORT = 8787
-
-
-async def _allocate_fakechat_port(session: AsyncSession, project_id: uuid.UUID) -> int:
-    """프로젝트 내 미사용 fakechat 포트 — create_team_member 와 동일 규칙(프로젝트별 유일)."""
-    existing = {
-        r[0]
-        for r in (
-            await session.execute(
-                select(TeamMember.fakechat_port).where(
-                    TeamMember.project_id == project_id,
-                    TeamMember.type == "agent",
-                    TeamMember.fakechat_port.isnot(None),
-                )
-            )
-        ).all()
-    }
-    port = _FAKECHAT_BASE_PORT
-    while port in existing:
-        port += 1
-    return port
 
 
 async def create_org_level_agent(
@@ -81,7 +59,7 @@ async def create_org_level_agent(
         color=color,
         agent_role=agent_role,
         created_by=created_by,
-        fakechat_port=await _allocate_fakechat_port(session, anchor_project),
+        fakechat_port=await allocate_fakechat_port(session, anchor_project),
         is_active=True,
         can_manage_members=False,
         last_seen_at=None,
@@ -102,7 +80,7 @@ async def create_org_level_agent(
             project_id=pid,
             agent_config=agent_config,
             agent_role=agent_role,
-            fakechat_port=await _allocate_fakechat_port(session, pid),
+            fakechat_port=await allocate_fakechat_port(session, pid),
             role=role,
             color=color,
             can_manage_members=False,

--- a/backend/tests/test_org_agent_grant_profile.py
+++ b/backend/tests/test_org_agent_grant_profile.py
@@ -1,0 +1,101 @@
+"""S4: org-level 에이전트 grant 시 per-project profile 생성 + 회수 시 profile 제거(grant↔뷰 lockstep)."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ─── ensure_agent_project_profile: 멱등 profile 생성 + 포트 자동 할당 ──────────
+
+
+@pytest.mark.anyio
+async def test_ensure_profile_inserts_and_auto_allocates_port(monkeypatch):
+    from app.services import agent_anchor_sync as a
+
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=MagicMock())
+    monkeypatch.setattr(a, "allocate_fakechat_port", AsyncMock(return_value=8800))
+
+    await a.ensure_agent_project_profile(
+        session, member_id=uuid.uuid4(), project_id=uuid.uuid4()
+    )
+    a.allocate_fakechat_port.assert_awaited_once()  # 포트 미지정 → 자동 할당
+    assert session.execute.await_count == 1  # profile pg_insert 1회
+
+
+@pytest.mark.anyio
+async def test_ensure_profile_respects_given_port(monkeypatch):
+    from app.services import agent_anchor_sync as a
+
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=MagicMock())
+    monkeypatch.setattr(a, "allocate_fakechat_port", AsyncMock(return_value=9999))
+
+    await a.ensure_agent_project_profile(
+        session, member_id=uuid.uuid4(), project_id=uuid.uuid4(), fakechat_port=8801
+    )
+    a.allocate_fakechat_port.assert_not_awaited()  # 주어진 포트 사용 → 미할당
+
+
+# ─── delete_project_access: 에이전트 grant 회수 시 profile 제거 ───────────────
+
+
+@pytest.mark.anyio
+async def test_revoke_agent_grant_removes_profile(monkeypatch):
+    from app.routers import project_access as pa
+
+    monkeypatch.setattr(pa, "_require_owner_or_admin", AsyncMock())
+
+    project_id = uuid.uuid4()
+    record = MagicMock()
+    record.org_member_id = None  # 에이전트 grant
+    record.member_id = uuid.uuid4()
+    sel_res = MagicMock()
+    sel_res.scalar_one_or_none.return_value = record
+
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=sel_res)
+    session.delete = AsyncMock()
+    session.commit = AsyncMock()
+
+    out = await pa.delete_project_access(
+        project_id, uuid.uuid4(), auth=MagicMock(), session=session
+    )
+    assert out == {"ok": True}
+    # execute 2회: record select + agent_project_profiles delete
+    assert session.execute.await_count == 2
+    session.delete.assert_awaited_once_with(record)
+
+
+@pytest.mark.anyio
+async def test_revoke_human_grant_skips_profile_delete(monkeypatch):
+    from app.routers import project_access as pa
+
+    monkeypatch.setattr(pa, "_require_owner_or_admin", AsyncMock())
+
+    project_id = uuid.uuid4()
+    record = MagicMock()
+    record.org_member_id = uuid.uuid4()  # 휴먼 grant
+    record.member_id = uuid.uuid4()
+    sel_res = MagicMock()
+    sel_res.scalar_one_or_none.return_value = record
+
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=sel_res)
+    session.delete = AsyncMock()
+    session.commit = AsyncMock()
+
+    out = await pa.delete_project_access(
+        project_id, uuid.uuid4(), auth=MagicMock(), session=session
+    )
+    assert out == {"ok": True}
+    # execute 1회: record select 만 (profile delete 없음)
+    assert session.execute.await_count == 1
+    session.delete.assert_awaited_once_with(record)


### PR DESCRIPTION
블루프린트(#1536) §4 **G4** 구현. org-level 멀티프로젝트 에이전트 **S4**. grant ↔ `team_members` 뷰 lockstep 보강.

## 배경
S3 이후 org-admin 이 `POST /projects/{id}/access` 로 에이전트를 추가 프로젝트에 grant 할 수 있다. 하지만 grant 만으로는 `agent_project_profiles`(per-project 런타임) 행이 없어:
- 뷰 branch3 로만 떠 런타임 컬럼이 NULL,
- presence write(`sync_agent_profile_presence` UPDATE)가 **0행 무음 누락**.
역으로 grant 회수 시 profile 이 남으면 뷰 branch2(profile join)가 **회수된 에이전트를 계속 노출**(grant↔뷰 불일치).

## 변경
- `agent_anchor_sync`: `allocate_fakechat_port`(프로젝트별 포트)·`ensure_agent_project_profile`(profile-only 멱등 생성) 헬퍼 추출. `org_agent` 가 포트 헬퍼를 공유(로컬 중복 제거).
- `create_project_access`(에이전트 grant): grant 직후 `ensure_agent_project_profile` 멱등 호출 → per-project 런타임 행 부여.
- `delete_project_access`(에이전트 grant 회수): `org_member_id IS NULL + member_id` 인 에이전트 grant 면 해당 `(member_id, project_id)` profile 도 삭제 → 뷰에서도 사라짐. 휴먼 grant 는 무영향(매칭 profile 0행).

## 검증
- 신규 `tests/test_org_agent_grant_profile.py` 4: profile 생성+포트 자동할당/주어진 포트 존중, 회수 시 agent profile 제거 vs human skip.
- grant/members/security 회귀(`team_members`·`member_ssot_phase0`·`e_entity_cleanup_s4_members_api`·`ss4_security_regression`·`member_ssot_ac3_1b`·`org_agent_create`) → **77 pass**. app import OK. 마이그 없음.

## 비고
- 기존 grant/revoke 엔드포인트(`POST/DELETE /projects/{id}/access`)는 이미 존재 → S4 는 그 위에 profile lockstep 만 추가(엔드포인트 신설 없음).
- S5(org-agent 생성/리스트 FE)는 유나양 경로. org-agent 에픽 BE 코어(S1~S4) 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)