### PR TITLE
feat(sprints): 스프린트 삭제 버튼 + 확인 다이얼로그 (7ec628c3)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2288,7 +2288,12 @@
     "goalPlaceholder": "What will the team complete this sprint?",
     "capacityLabel": "Capacity",
     "teamSizeLabel": "Team Size",
-    "hypothesisSection": "Outcome Hypothesis"
+    "hypothesisSection": "Outcome Hypothesis",
+    "delete": "Delete Sprint",
+    "deleteConfirmTitle": "Delete this sprint?",
+    "deleteConfirmBody": "This action cannot be undone. Linked stories move to the backlog, and retro and standup links are cleared.",
+    "deleteConfirm": "Delete",
+    "deleteError": "Failed to delete sprint."
   },
   "presence": {
     "panelTitle": "Team presence",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2288,7 +2288,12 @@
     "goalPlaceholder": "이번 스프린트에서 무엇을 완수하는가?",
     "capacityLabel": "공수",
     "teamSizeLabel": "인원",
-    "hypothesisSection": "효과 가설"
+    "hypothesisSection": "효과 가설",
+    "delete": "스프린트 삭제",
+    "deleteConfirmTitle": "스프린트를 삭제할까요?",
+    "deleteConfirmBody": "이 작업은 되돌릴 수 없습니다. 연결된 스토리는 백로그로 이동되고 회고·스탠드업 연결이 해제됩니다.",
+    "deleteConfirm": "삭제",
+    "deleteError": "스프린트 삭제에 실패했습니다."
   },
   "presence": {
     "panelTitle": "팀 presence",

--- a/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
+++ b/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { Plus, X, Play, StopCircle, ChevronRight } from 'lucide-react';
+import { Plus, X, Play, StopCircle, ChevronRight, Trash2, AlertTriangle } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
@@ -235,6 +235,45 @@ function CreateDialog({ projectId, onCreated, onClose }: CreateDialogProps) {
   );
 }
 
+// ─── Delete Confirm Dialog ──────────────────────────────────────────────────────
+
+interface DeleteConfirmDialogProps {
+  sprintTitle: string;
+  deleting: boolean;
+  error: string | null;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+function DeleteConfirmDialog({ sprintTitle, deleting, error, onConfirm, onClose }: DeleteConfirmDialogProps) {
+  const t = useTranslations('sprints');
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <button type="button" className="absolute inset-0 bg-black/50 backdrop-blur-[2px]" onClick={onClose} aria-label={t('cancel')} />
+      <div role="alertdialog" aria-modal="true" className="relative z-10 w-full max-w-sm rounded-2xl border border-border bg-background p-6 shadow-xl">
+        <div className="mb-3 flex items-start gap-3">
+          <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-destructive/10 text-destructive">
+            <AlertTriangle className="size-5" />
+          </span>
+          <div className="min-w-0">
+            <h2 className="text-base font-bold text-foreground">{t('deleteConfirmTitle')}</h2>
+            <p className="mt-0.5 truncate text-sm font-medium text-muted-foreground">{sprintTitle}</p>
+          </div>
+        </div>
+        <p className="mb-4 text-sm text-muted-foreground">{t('deleteConfirmBody')}</p>
+        {error ? <p className="mb-3 text-xs text-destructive">{error}</p> : null}
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="ghost" size="sm" onClick={onClose} disabled={deleting}>{t('cancel')}</Button>
+          <Button type="button" variant="destructive" size="sm" onClick={onConfirm} disabled={deleting}>
+            <Trash2 className="size-4" />
+            {deleting ? '...' : t('deleteConfirm')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ─── Main Client ──────────────────────────────────────────────────────────────
 
 export function SprintsClient({ projectId }: SprintsClientProps) {
@@ -259,6 +298,9 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
   const [showCreate, setShowCreate] = useState(false);
   const [activating, setActivating] = useState(false);
   const [closing, setClosing] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
   const loadSprints = useCallback(async () => {
@@ -398,6 +440,29 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
     }
   };
 
+  const handleDelete = async () => {
+    if (!selected || deleting) return;
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      const res = await fetch(`/api/sprints/${selected.id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({})) as { error?: { message?: string } };
+        setDeleteError(json.error?.message ?? t('deleteError'));
+        return;
+      }
+      // 삭제 성공 — 목록에서 제거하고 상세 패널·다이얼로그를 닫는다.
+      const deletedId = selected.id;
+      setSprints((prev) => prev.filter((s) => s.id !== deletedId));
+      setShowDeleteConfirm(false);
+      setSelected(null);
+    } catch {
+      setDeleteError(t('deleteError'));
+    } finally {
+      setDeleting(false);
+    }
+  };
+
   const handleAssignStory = async (story: Story) => {
     try {
       const res = await fetch(`/api/stories/${story.id}`, {
@@ -494,9 +559,21 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
           <h2 className="text-lg font-semibold text-foreground">{selected.title}</h2>
           <Badge variant={statusVariant(selected.status)} className="mt-1">{selected.status}</Badge>
         </div>
-        <Button variant="ghost" size="sm" onClick={() => setSelected(null)}>
-          <X className="size-4" />
-        </Button>
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => { setDeleteError(null); setShowDeleteConfirm(true); }}
+            aria-label={t('delete')}
+            title={t('delete')}
+            className="text-muted-foreground hover:text-destructive"
+          >
+            <Trash2 className="size-4" />
+          </Button>
+          <Button variant="ghost" size="sm" onClick={() => setSelected(null)} aria-label={t('cancel')}>
+            <X className="size-4" />
+          </Button>
+        </div>
       </div>
 
       {/* Goal */}
@@ -683,6 +760,16 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
             setShowCreate(false);
           }}
           onClose={() => setShowCreate(false)}
+        />
+      ) : null}
+
+      {showDeleteConfirm && selected ? (
+        <DeleteConfirmDialog
+          sprintTitle={selected.title}
+          deleting={deleting}
+          error={deleteError}
+          onConfirm={() => void handleDelete()}
+          onClose={() => { if (!deleting) setShowDeleteConfirm(false); }}
         />
       ) : null}
     </>


### PR DESCRIPTION
## 무엇을

유저 보고 **"UI에서 스프린트 삭제 방법 없음"** 해소. (story `7ec628c3`, PO 직킥 conv `99852ce5`)

디디군 체인 점검 결과 BE·proxy·MCP는 이미 완비였고, **FE 진입점(삭제 버튼)만 빠져 있던 것** — 그 부분만 채움.
- `DELETE /api/v2/sprints/{id}` org-scoped hard delete (FK: stories/retro/standup = SET NULL, policy = CASCADE)
- FE proxy `apps/web/src/app/api/sprints/[id]/route.ts` DELETE 핸들러 존재

## 변경

- **스프린트 상세 패널 헤더에 삭제(🗑) 버튼** 추가 → 확인 다이얼로그 오픈.
- **`DeleteConfirmDialog`** — 되돌릴 수 없음 경고 + 스프린트명 노출 + `variant="destructive"` 삭제 버튼. 기존 `CreateDialog` 모달 셸 미러(디자인 토큰·radius·shadow 일관), `role="alertdialog"`·`aria-modal`·backdrop 클릭 닫기.
- **`handleDelete`** — 기존 DELETE 호출 → 성공 시 목록에서 제거 + 상세 패널 닫음, 실패 시 다이얼로그 내 에러 표시. 단발 액션이라 옵티미스틱/롤백 불요.
- **i18n(ko/en)** `delete`/`deleteConfirmTitle`/`deleteConfirmBody`/`deleteConfirm`/`deleteError`. 경고 문구는 BE FK 거동 반영(연결 스토리=백로그 이동, 회고·스탠드업 연결 해제).

## 배치 판단

삭제 버튼은 **상세 패널에 배치**했는 — 목록 행은 클릭=상세 선택이라 행 내 삭제 버튼은 오삭제 위험. 상세 진입 후 삭제가 안전·discoverable. (PO 메모 "목록/상세" 중 상세 채택. 목록 행 hover-delete도 원하면 추가 가능.)

## 검증

- `pnpm type-check` ✅
- `pnpm lint` (대상 파일) ✅ 0 warning
- `pnpm build` ✅ EXIT 0
- JSON(ko/en) 파싱 OK·키 parity 유지

라이브 동작 픽셀(삭제 클릭→다이얼로그→확정→목록 반영)은 dev 배포 후 까심 QA → 머지게이트 → PO 플로우.

## 디자인 검수

신규 `DeleteConfirmDialog` 모달이라 유나양 가디언 가벼운 픽셀 검수 요청 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)