### PR TITLE
feat(member-policy): project_access.role 1급 enum 토대 — 백필+CHECK (S1)

### DIFF
--- a/backend/alembic/versions/0122_project_access_role_enum.py
+++ b/backend/alembic/versions/0122_project_access_role_enum.py
@@ -1,0 +1,55 @@
+"""project_access.role 1급 enum 토대 — 백필 + CHECK (E-MEMBER-POLICY S1, 44434ce9).
+
+HITL 게이팅(hitl-gating-policy-v1 §2)의 선행 토대. project_access.role 을 free-text →
+enum(owner/admin/member)으로 제약한다. role 은 프로젝트 역할의 단일 SSOT(projects.owner 컬럼
+신설 안 함 — dual-SSOT 트랩 회피).
+
+prod-safe 순서(dev/prod 공유 Cloud SQL — "dev" migrate 가 prod DB 에도 적용):
+  1. 값 백필 먼저 — 비-enum role(레거시 'manager'·junk·NULL) → 'member'.
+  2. can_manage_members=true 인데 role='member' → 'admin' (AC#3 실값 매핑; owner 다운그레이드 안 함).
+  3. CHECK ADD NOT VALID → VALIDATE (lock-light; 백필 후라 검증 통과 보장).
+컬럼 drop 없음 · can_manage_members 유지(무회귀·role 에서 derived) · 초기 owner stamp 안 함
+(org-owner 상속·§9-1, guess-backfill 회피). 모든 write 경로는 clamp_project_role 로 enum 보장(선행 게이트).
+
+idempotent: 재실행·fresh DB 안전 — 백필 UPDATE 멱등, CHECK 는 부재 시에만 ADD.
+"""
+from alembic import op
+
+revision = "0122"
+down_revision = "0121"
+branch_labels = None
+depends_on = None
+
+_CK = "ck_project_access_role"
+
+
+def upgrade() -> None:
+    # 1. 비-enum role → member (레거시 'manager'·junk·NULL 정규화)
+    op.execute(
+        "UPDATE project_access SET role = 'member' "
+        "WHERE role IS NULL OR role NOT IN ('owner', 'admin', 'member')"
+    )
+    # 2. can_manage_members=true & role='member' → admin (AC#3: 관리권 보유=admin 실값 매핑)
+    op.execute(
+        "UPDATE project_access SET role = 'admin' "
+        "WHERE can_manage_members = true AND role = 'member'"
+    )
+    # 3. CHECK NOT VALID → VALIDATE (멱등: 이미 있으면 skip)
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint WHERE conname = '{_CK}'
+            ) THEN
+                ALTER TABLE project_access
+                  ADD CONSTRAINT {_CK} CHECK (role IN ('owner', 'admin', 'member')) NOT VALID;
+                ALTER TABLE project_access VALIDATE CONSTRAINT {_CK};
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(f"ALTER TABLE project_access DROP CONSTRAINT IF EXISTS {_CK}")

--- a/backend/app/repositories/team_member.py
+++ b/backend/app/repositories/team_member.py
@@ -96,6 +96,11 @@ class TeamMemberRepository(BaseRepository[TeamMember]):
         m_set = {k: v for k, v in data.items() if k in _MEMBERS_FIELDS}
         a_set = {k: v for k, v in data.items() if k in _ACCESS_FIELDS}
         p_set = {k: v for k, v in data.items() if k in _PROFILE_FIELDS}
+        # E-MEMBER-POLICY S1: project_access.role 은 enum(owner/admin/member)만 — PATCH 로 비-enum
+        # (예: 레거시 'manager')이 들어오면 0122 CHECK 위반(500) → clamp 로 정규화.
+        if "role" in a_set:
+            from app.services.project_auth import clamp_project_role
+            a_set["role"] = clamp_project_role(a_set["role"])
         if m_set:
             await self.session.execute(
                 sa_update(Member)

--- a/backend/app/services/agent_anchor_sync.py
+++ b/backend/app/services/agent_anchor_sync.py
@@ -138,7 +138,9 @@ async def write_agent_project_placement(
     # project_access direct placement (AC3-4 2-1, G3): 0075 §5 에이전트 placement 동형.
     #    AC3-4 뷰가 role/can_manage를 project_access서 읽으므로 grant 필요. member_id=canonical,
     #    org_member_id=NULL(에이전트). ON CONFLICT 멱등.
+    # E-MEMBER-POLICY S1: role 은 enum(owner/admin/member)으로 clamp — 0122 CHECK 위반 방지.
     from app.models.project_access import ProjectAccess
+    from app.services.project_auth import clamp_project_role
     await session.execute(
         pg_insert(ProjectAccess.__table__)
         .values(
@@ -147,7 +149,7 @@ async def write_agent_project_placement(
             org_member_id=None,
             member_id=member_id,
             permission="granted",
-            role=role,
+            role=clamp_project_role(role),
             color=color,
             can_manage_members=can_manage_members,
             access_source="direct",

--- a/backend/app/services/project_auth.py
+++ b/backend/app/services/project_auth.py
@@ -10,6 +10,21 @@ import uuid
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+# E-MEMBER-POLICY S1: 프로젝트 역할 1급 enum(owner/admin/member). org 역할의 'manager'는 project
+# 레벨엔 없음(§9-2 결정). project_access.role 은 0122 CHECK 로 이 집합만 허용 → 모든 write 경로가
+# 이 집합으로 clamp 돼야 CHECK 위반(500)이 없다. 랭크: owner > admin > member.
+PROJECT_ROLES: tuple[str, ...] = ("owner", "admin", "member")
+PROJECT_ROLE_RANK: dict[str, int] = {"owner": 3, "admin": 2, "member": 1}
+
+
+def clamp_project_role(role: str | None) -> str:
+    """project_access.role 로 쓸 값을 enum 으로 정규화 — 비-enum(예: 레거시 'manager'·빈값)은 'member'.
+
+    0122 CHECK(role IN owner/admin/member) 위반 방지의 단일 정규화 지점. write 경로(앵커 placement·
+    PATCH anchor update)가 이걸 통과시켜 비-enum 값이 DB 에 들어가지 않게 한다.
+    """
+    return role if role in PROJECT_ROLES else "member"
+
 
 async def has_project_access(
     session: AsyncSession,

--- a/backend/tests/test_project_role_enum_s1.py
+++ b/backend/tests/test_project_role_enum_s1.py
@@ -1,0 +1,112 @@
+"""E-MEMBER-POLICY S1: project_access.role enum 토대 — clamp + write 경로 + 마이그 구조."""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ─── clamp_project_role ───────────────────────────────────────────────────────
+
+
+def test_clamp_passthrough_enum():
+    from app.services.project_auth import clamp_project_role
+
+    assert clamp_project_role("owner") == "owner"
+    assert clamp_project_role("admin") == "admin"
+    assert clamp_project_role("member") == "member"
+
+
+def test_clamp_non_enum_to_member():
+    from app.services.project_auth import clamp_project_role
+
+    assert clamp_project_role("manager") == "member"  # 레거시 org 랭크 → project 엔 없음
+    assert clamp_project_role("") == "member"
+    assert clamp_project_role(None) == "member"
+    assert clamp_project_role("OWNER") == "member"  # 대소문자 엄격
+
+
+# ─── write_agent_project_placement: role clamp ────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_placement_clamps_role(monkeypatch):
+    from app.services import agent_anchor_sync as a
+
+    spy = MagicMock(return_value="member")
+    monkeypatch.setattr("app.services.project_auth.clamp_project_role", spy)
+
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=MagicMock())
+
+    await a.write_agent_project_placement(
+        session, member_id=uuid.uuid4(), project_id=uuid.uuid4(), role="manager"
+    )
+    spy.assert_called_once_with("manager")  # grant role 이 clamp 통과
+
+
+# ─── apply_anchor_update(PATCH): role clamp ───────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_patch_anchor_update_clamps_role(monkeypatch):
+    from app.repositories.team_member import TeamMemberRepository
+
+    spy = MagicMock(return_value="member")
+    monkeypatch.setattr("app.services.project_auth.clamp_project_role", spy)
+
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=MagicMock())
+    session.flush = AsyncMock()
+    repo = TeamMemberRepository(session, uuid.uuid4())
+
+    member = MagicMock()
+    member.id = uuid.uuid4()
+    member.project_id = uuid.uuid4()
+
+    await repo.apply_anchor_update(member, {"role": "manager", "color": "#fff"})
+    spy.assert_called_once_with("manager")  # PATCH role 이 clamp 통과
+
+
+@pytest.mark.anyio
+async def test_patch_anchor_update_no_role_skips_clamp(monkeypatch):
+    from app.repositories.team_member import TeamMemberRepository
+
+    spy = MagicMock(return_value="member")
+    monkeypatch.setattr("app.services.project_auth.clamp_project_role", spy)
+
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=MagicMock())
+    session.flush = AsyncMock()
+    repo = TeamMemberRepository(session, uuid.uuid4())
+    member = MagicMock()
+    member.id = uuid.uuid4()
+    member.project_id = uuid.uuid4()
+
+    await repo.apply_anchor_update(member, {"color": "#fff"})
+    spy.assert_not_called()  # role 미포함 → clamp 미호출
+
+
+# ─── 마이그 0122 구조 ─────────────────────────────────────────────────────────
+
+
+def test_migration_0122_chain_and_callables():
+    p = (
+        pathlib.Path(__file__).parent.parent
+        / "alembic/versions/0122_project_access_role_enum.py"
+    )
+    spec = importlib.util.spec_from_file_location("m0122", p)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    assert mod.revision == "0122"
+    assert mod.down_revision == "0121"
+    assert callable(mod.upgrade)
+    assert callable(mod.downgrade)


### PR DESCRIPTION
블루프린트(#1543) **S1** — HITL 게이팅 토대 `44434ce9`의 마이그 슬라이스. `project_access.role` 을 free-text → **enum(owner/admin/member)** 으로 제약. 프로젝트 역할 **단일 SSOT**(별도 `projects.owner` 컬럼 안 만듦).

## migration 0122 (prod-safe 순서)
1. 값 백필 먼저: 비-enum role(레거시 `manager`·junk·NULL) → `member`
2. `can_manage_members=true AND role='member'` → `admin` (**AC#3** 실값 매핑·owner 다운그레이드 안 함)
3. CHECK `role IN (owner,admin,member)` **NOT VALID → VALIDATE** (lock-light)
- 컬럼 drop 없음 · `can_manage_members` 유지(무회귀·role 에서 derived) · 초기 owner stamp **안 함**(org-owner 상속·§9-1, guess-backfill 회피).

## 선행 게이트 — "role 비-enum write 0" (PO 강조)
감사 결과 `project_access.role` write 3경로 중 2개가 비-enum(레거시 `manager` 등) 쓸 수 있었음:
- `write_agent_project_placement`(INSERT), `apply_anchor_update`(PATCH UPDATE). (`create_project_access` 는 기본 `member` — 안전.)
- → `clamp_project_role`(`project_auth`) 신설, 두 경로에서 clamp → CHECK 위반(500) 차단. `PROJECT_ROLES`/`PROJECT_ROLE_RANK` 상수 도입(S2 헬퍼 토대).

## 검증
- **실 Postgres 적용 검증**(docker pg15): 백필 정확(manager/junk→member·member+cm→admin·manager+cm→admin 2-step·owner/admin 불변), CHECK 가 `manager` INSERT **거부**·`owner` 허용, downgrade 후 복구. 
- 신규 테스트 6(clamp·write 두 경로 clamp 호출·PATCH no-role skip·마이그 구조) + 회귀(team_members·member_ssot·ss4_security·org_agent·s_mbr_03/10) **90 pass**. app import OK.

## ⚠️ 머지 규율
**머지 후 `sprintable-migrate-dev` 실행 필수**(Cloud Build 자동 Alembic 안 함). 머지+migrate 원자(`[[no_merge_without_migration]]`). dev/prod 공유 DB라 0122 는 prod DB 에도 적용되나 additive+백필+CHECK 라 prod 코드 무영향(prod 엔 비-enum role 데이터 없음 가정 — migrate 직전 audit 1쿼리 권장).

다음: S2 project_auth role 헬퍼(get_project_role/has_project_role) → S3 owner 지정 엔드포인트 → S4 게이팅 소비자 배선.

🤖 Generated with [Claude Code](https://claude.com/claude-code)