### PR TITLE
fix(member-policy): 초대 수락 project_access role clamp (0122 차단 #3)

### DIFF
--- a/backend/app/repositories/org_invite.py
+++ b/backend/app/repositories/org_invite.py
@@ -312,6 +312,11 @@ class OrgInviteRepository:
                 Project.deleted_at.is_(None),
             )
         )
+        # E-MEMBER-POLICY S1 fix: project_access.role 은 enum(owner/admin/member)만 — 초대 수락 시
+        # 신규 INSERT 라 0122 백필(기존 행만)이 못 잡는다. invite.role(라우터 미validation·org enum
+        # 'manager' 가능)을 clamp 해 0122 CHECK 위반(수락 500) 차단. project_access.role write 의
+        # 단일 관문(clamp_project_role)으로 수렴 — 전 경로(placement·PATCH·invite) clamp 일치.
+        from app.services.project_auth import clamp_project_role
         for (pid,) in valid_rows.all():
             await self.session.execute(
                 pg_insert(ProjectAccess.__table__)
@@ -320,7 +325,7 @@ class OrgInviteRepository:
                     project_id=pid,
                     org_member_id=om_id,
                     permission="granted",
-                    role=invite.role,
+                    role=clamp_project_role(invite.role),
                     access_source="direct",
                 )
                 .on_conflict_do_nothing(constraint="uq_project_access_project_member")

--- a/backend/tests/test_project_role_invite_clamp.py
+++ b/backend/tests/test_project_role_invite_clamp.py
@@ -1,0 +1,63 @@
+"""E-MEMBER-POLICY S1 fix: 초대 수락 project_access INSERT 가 role 을 enum 으로 clamp 하는지.
+
+re-QA 적출(3번째 미clamp write 경로): org_invite._grant_invite_project_access 가 invite.role
+(라우터 미validation·org 'manager' 가능)을 그대로 INSERT → 0122 CHECK 위반(수락 500). clamp 로 차단.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_grant_invite_project_access_clamps_role(monkeypatch):
+    from app.repositories.org_invite import OrgInviteRepository
+
+    spy = MagicMock(return_value="member")
+    monkeypatch.setattr("app.services.project_auth.clamp_project_role", spy)
+
+    pid = uuid.uuid4()
+    user_id = uuid.uuid4()
+    invite = MagicMock()
+    invite.organization_id = uuid.uuid4()
+    invite.project_ids = [str(pid)]
+    invite.role = "manager"  # org enum — project 엔 없음 → clamp 대상
+
+    om_res = MagicMock()
+    om_res.scalar_one_or_none.return_value = uuid.uuid4()  # om_id 해소됨
+    valid_res = MagicMock()
+    valid_res.all.return_value = [(pid,)]  # invite org 소속 프로젝트 1개
+
+    session = MagicMock()
+    session.execute = AsyncMock(side_effect=[om_res, valid_res, MagicMock()])
+    session.flush = AsyncMock()
+
+    repo = OrgInviteRepository(session)
+    await repo._grant_invite_project_access(invite, user_id)
+
+    spy.assert_called_once_with("manager")  # INSERT role 이 clamp 통과
+
+
+@pytest.mark.anyio
+async def test_grant_invite_no_projects_skips(monkeypatch):
+    from app.repositories.org_invite import OrgInviteRepository
+
+    spy = MagicMock(return_value="member")
+    monkeypatch.setattr("app.services.project_auth.clamp_project_role", spy)
+
+    invite = MagicMock()
+    invite.project_ids = []  # 선택 프로젝트 없음 → early return
+
+    session = MagicMock()
+    session.execute = AsyncMock()
+    repo = OrgInviteRepository(session)
+    await repo._grant_invite_project_access(invite, uuid.uuid4())
+
+    spy.assert_not_called()


### PR DESCRIPTION
**#1544 re-QA 블로커 수정.** 0122 적용 **전** 머지 필수(머지→재QA→0122 migrate-dev 순서).

## 문제
re-QA(codex cross-model)가 S1 감사(2경로)가 놓친 **3번째 미clamp `project_access.role` write** 적출: `org_invite._grant_invite_project_access`(`org_invite.py:323`)가 `invite.role` 을 그대로 INSERT. `org_invites.py:83` 라우터가 validation 없이 `role=body.role` 받아 `manager` 초대 생성 가능 → 수락 시 신규 INSERT. **0122 백필은 *기존* 행만** 처리하므로 초대 수락 INSERT 는 미커버 → VALIDATE 후 `CHECK` 위반(수락 **500**).

## 수정
`role=clamp_project_role(invite.role)` — enum(owner/admin/member) 정규화.

## 전수 grep (PO 지시 — 4번째 없음 확認)
`project_access.role` write **5경로 전부** 확인:
| 경로 | 상태 |
|---|---|
| `project_access.py:117` 에이전트 grant | 기본 `member` ✓ |
| `project_access.py:137` 휴먼 grant | 기본 `member` ✓ |
| `agent_anchor_sync.py:102` placement INSERT | clamp ✓ (S1) |
| `team_member.py:107` PATCH UPDATE | clamp ✓ (S1) |
| `org_invite.py:323` 초대 수락 INSERT | **clamp (본 PR)** |
→ raw SQL 0건. `clamp_project_role` 가 단일 관문. **4번째 경로 없음.**

## 검증
신규 테스트 2(invite clamp·빈 프로젝트 skip) + `test_project_role_enum_s1`·`test_e_onboarding_policyb_invite_grant` 회귀 **13 pass**.

## ⚠️ 순서
이 PR 머지 → 까심 재QA → **그 다음** `sprintable-migrate-dev`(gcloud 재인증 후). 0122 가 아직 미적용이라 현재 라이브 영향 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)