### PR TITLE
feat(member-policy): project_auth role 헬퍼 + owner/admin 인가 소비 (S2)

### DIFF
--- a/backend/app/routers/project_access.py
+++ b/backend/app/routers/project_access.py
@@ -44,7 +44,12 @@ def _get_org_repo(session: AsyncSession = Depends(get_db)) -> OrganizationReposi
 async def _require_owner_or_admin(
     project_id: uuid.UUID, auth: AuthContext, session: AsyncSession
 ) -> None:
-    """project_id → org_id 역추적 후 owner/admin 확인."""
+    """프로젝트 관리 권한(owner/admin) 확인.
+
+    E-MEMBER-POLICY S2: org_members.role 만 보던 것을 **effective 프로젝트 역할**로 전환(소비 시작).
+    has_project_role(min_role='admin') = project_access.role(owner/admin) OR org owner/admin floor →
+    기존(org owner/admin 통과)은 floor 로 보존(무회귀), project owner/admin 추가 통과(additive).
+    """
     from sqlalchemy import text
     result = await session.execute(
         text("SELECT org_id FROM projects WHERE id = :pid AND deleted_at IS NULL"),
@@ -53,10 +58,10 @@ async def _require_owner_or_admin(
     row = result.first()
     if row is None:
         raise HTTPException(status_code=404, detail="Project not found")
-    org_id = row[0]
-    repo = OrganizationRepository(session)
-    role = await repo.get_member_role(org_id=org_id, user_id=uuid.UUID(auth.user_id))
-    if role not in ("owner", "admin"):
+    from app.services.project_auth import has_project_role
+    if not await has_project_role(
+        session, uuid.UUID(auth.user_id), project_id, min_role="admin"
+    ):
         raise HTTPException(status_code=403, detail="owner or admin role required")
 
 

--- a/backend/app/services/project_auth.py
+++ b/backend/app/services/project_auth.py
@@ -26,6 +26,66 @@ def clamp_project_role(role: str | None) -> str:
     return role if role in PROJECT_ROLES else "member"
 
 
+async def get_project_role(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    project_id: uuid.UUID,
+) -> str | None:
+    """프로젝트에서 user(휴먼 JWT user_id | 에이전트 member_id)의 **effective** 프로젝트 역할.
+
+    effective = max_rank(project_access.role, org owner/admin floor). 즉 명시 project 역할과
+    org owner/admin 의 org-wide 권한 중 높은 것. `_effective_role`(auth.py)의 max(org,project)와 정합.
+    역할/접근이 전혀 없으면 None. org member/manager 는 project authority 를 *부여하지 않음*(floor 아님).
+
+    휴먼: project_access 는 org_member_id→users.id 로, 에이전트: member_id 로 매칭(둘 다 OR). asyncpg
+    text 함정 회피 위해 uuid.UUID 를 직접 바인딩(:param IS NULL/::uuid syntax 회피).
+    """
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT
+                  (SELECT om.role FROM org_members om
+                     JOIN projects p ON p.org_id = om.org_id
+                    WHERE p.id = :pid AND om.user_id = :uid AND om.deleted_at IS NULL
+                    LIMIT 1) AS org_role,
+                  (SELECT pa.role FROM project_access pa
+                     LEFT JOIN org_members om2 ON pa.org_member_id = om2.id
+                    WHERE pa.project_id = :pid AND pa.permission = 'granted'
+                      AND (om2.user_id = :uid OR pa.member_id = :uid)
+                    LIMIT 1) AS proj_role
+                """
+            ),
+            {"pid": project_id, "uid": user_id},
+        )
+    ).one_or_none()
+    if row is None:
+        return None
+    org_role, proj_role = row[0], row[1]
+    candidates: list[str] = []
+    if proj_role is not None:
+        candidates.append(clamp_project_role(proj_role))
+    if org_role in ("owner", "admin"):  # org owner/admin 만 project authority floor(org-wide)
+        candidates.append(org_role)
+    if not candidates:
+        return None
+    return max(candidates, key=lambda r: PROJECT_ROLE_RANK[r])
+
+
+async def has_project_role(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    project_id: uuid.UUID,
+    *,
+    min_role: str,
+) -> bool:
+    """effective 프로젝트 역할이 min_role 랭크 이상인지(owner>admin>member). 역할 없으면 False."""
+    role = await get_project_role(session, user_id, project_id)
+    if role is None:
+        return False
+    return PROJECT_ROLE_RANK.get(role, 0) >= PROJECT_ROLE_RANK.get(min_role, 99)
+
+
 async def has_project_access(
     session: AsyncSession,
     user_id: uuid.UUID,

--- a/backend/tests/test_project_role_s2_helpers.py
+++ b/backend/tests/test_project_role_s2_helpers.py
@@ -1,0 +1,135 @@
+"""E-MEMBER-POLICY S2: project_auth role 헬퍼(get_project_role/has_project_role) + 소비(_require_owner_or_admin)."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _role_result(org_role, proj_role):
+    """get_project_role 의 SELECT (org_role, proj_role) 한 행."""
+    r = MagicMock()
+    r.one_or_none.return_value = (org_role, proj_role)
+    return r
+
+
+# ─── get_project_role: effective = max(project_access.role, org owner/admin floor) ──
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "org_role,proj_role,expected",
+    [
+        ("owner", None, "owner"),       # org owner → owner (floor)
+        ("admin", None, "admin"),       # org admin → admin (floor)
+        ("member", "owner", "owner"),   # project owner(org member) → owner
+        ("member", "admin", "admin"),   # project admin(org member) → admin
+        (None, "member", "member"),     # grant-only member
+        ("member", "member", "member"), # org member + project member
+        ("owner", "member", "owner"),   # org owner floors above project member (max)
+        ("manager", "member", "member"),# org manager 는 floor 아님 → project member
+        (None, None, None),             # 접근/역할 없음
+        ("member", None, None),         # org member + project_access 행 없음 → 역할 없음
+    ],
+)
+async def test_get_project_role_matrix(org_role, proj_role, expected):
+    from app.services import project_auth as pa
+
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_role_result(org_role, proj_role))
+    out = await pa.get_project_role(session, uuid.uuid4(), uuid.uuid4())
+    assert out == expected
+
+
+@pytest.mark.anyio
+async def test_get_project_role_clamps_legacy_manager_proj_role():
+    """project_access.role 에 레거시 'manager' 가 남아있어도(0122 전 행) clamp → member."""
+    from app.services import project_auth as pa
+
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_role_result(None, "manager"))
+    out = await pa.get_project_role(session, uuid.uuid4(), uuid.uuid4())
+    assert out == "member"
+
+
+# ─── has_project_role ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "org_role,proj_role,min_role,expected",
+    [
+        ("owner", None, "admin", True),
+        ("admin", None, "admin", True),
+        ("member", "owner", "admin", True),
+        ("member", "admin", "admin", True),
+        ("member", "member", "admin", False),
+        (None, None, "admin", False),
+        ("member", "member", "member", True),
+        (None, None, "member", False),
+        ("member", "admin", "owner", False),  # admin < owner
+    ],
+)
+async def test_has_project_role(org_role, proj_role, min_role, expected):
+    from app.services import project_auth as pa
+
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_role_result(org_role, proj_role))
+    assert await pa.has_project_role(
+        session, uuid.uuid4(), uuid.uuid4(), min_role=min_role
+    ) is expected
+
+
+# ─── _require_owner_or_admin 소비: 무회귀 + additive ─────────────────────────
+
+
+async def _call_require(org_role, proj_role, project_exists=True):
+    from app.routers import project_access as pr
+
+    proj_res = MagicMock()
+    proj_res.first.return_value = (uuid.uuid4(),) if project_exists else None
+    role_res = _role_result(org_role, proj_role)
+    session = MagicMock()
+    session.execute = AsyncMock(side_effect=[proj_res, role_res])
+    auth = MagicMock()
+    auth.user_id = str(uuid.uuid4())
+    await pr._require_owner_or_admin(uuid.uuid4(), auth, session)
+
+
+@pytest.mark.anyio
+async def test_require_org_owner_passes_no_regression():
+    await _call_require("owner", None)  # 통과(예외 없음)
+
+
+@pytest.mark.anyio
+async def test_require_org_admin_passes_no_regression():
+    await _call_require("admin", None)
+
+
+@pytest.mark.anyio
+async def test_require_project_owner_passes_additive():
+    await _call_require("member", "owner")  # org member 지만 project owner → 통과(신규)
+
+
+@pytest.mark.anyio
+async def test_require_plain_member_403():
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _call_require("member", "member")
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_require_missing_project_404():
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as ei:
+        await _call_require("owner", None, project_exists=False)
+    assert ei.value.status_code == 404


### PR DESCRIPTION
블루프린트(#1543) **S2** — 0122(#1544) enum 토대 위에서 **project 역할을 인가에 소비 시작**. 마이그 없음.

## 헬퍼 (project_auth)
- `get_project_role(session, user_id, project_id) -> owner|admin|member|None`: **effective** = `max_rank(project_access.role, org owner/admin floor)`. `_effective_role`(auth.py)의 `max(org,project)`와 정합. org member/manager 는 floor 아님(project 권한 부여 X). 휴먼(org_member→user_id)·에이전트(member_id) OR 매칭. asyncpg 함정 회피 위해 uuid 직접 바인딩. proj_role 은 `clamp`(0122 전 'manager' 잔존행 방어).
- `has_project_role(min_role)`: effective 랭크 ≥ min_role.

## 소비 (무회귀 + additive)
`_require_owner_or_admin`(project_access grant 관리 가드): `org_members.role`-only → `has_project_role(min='admin')`.
- 기존 **org owner/admin 은 floor 로 그대로 통과(무회귀)**.
- **project owner/admin 추가 통과(additive)** — 이게 "org_members.role만 보던 걸 project role도 보게"의 핵심.
- 더 permissive 하기만 함(기존 통과자 중 새로 막히는 사람 0).

## 검증
- 신규 테스트 25: get_project_role 매트릭스 10(org owner/admin floor·project owner/admin·grant-only·manager 비-floor·clamp 잔존행·no-access) + has_project_role 9 + `_require_owner_or_admin` 무회귀(org owner/admin)·additive(project owner)·member 403·missing 404.
- **무회귀 핫패스 회귀** (PO 요구: login/switch/grant-only/owner) — `auth_switch_project`·`ss1_auth_context`·`e_onboarding_policyb_invite_grant`·`s_mbr_03/10`·`ss4_security_regression`·`projects` 등 합 **132 pass**. app import OK.

## 비고
- **post-merge 라이브 검증 권장**: org owner/admin grant 관리 무회귀 + (S3 후) project owner 가 자기 프로젝트 access 관리 가능 E2E.
- 다음: S3 owner 지정 엔드포인트(AC#1) → S4 게이트 config 소비.

🤖 Generated with [Claude Code](https://claude.com/claude-code)