### PR TITLE
fix(auth): X-Project-Id 멤버십 검증 override — 프로젝트 컨텍스트 mutation 안전 (BE)

### DIFF
--- a/apps/web/src/lib/fastapi-proxy.ts
+++ b/apps/web/src/lib/fastapi-proxy.ts
@@ -102,7 +102,10 @@ export async function proxyToFastapi(
   if (authHeader) headers['Authorization'] = authHeader;
 
   // 일부 헤더 forward
-  for (const h of ['x-forwarded-for', 'x-real-ip', 'x-api-key', 'x-org-id']) {
+  // x-project-id: 프로젝트 컨텍스트 mutation 안전(d802da27) — FE fetch 인터셉터가 탭의 effective
+  // project 를 X-Project-Id 로 주입하는데, 이 프록시가 FastAPI 로 안 넘기면 BE get_verified_org_id
+  // override 가 헤더를 못 받아 조용히 무력화(full-chain 단절). x-org-id 와 동형으로 forward 필수.
+  for (const h of ['x-forwarded-for', 'x-real-ip', 'x-api-key', 'x-org-id', 'x-project-id']) {
     const v = request.headers.get(h);
     if (v) headers[h] = v;
   }

--- a/apps/web/src/lib/fastapi-proxy.ts
+++ b/apps/web/src/lib/fastapi-proxy.ts
@@ -102,10 +102,7 @@ export async function proxyToFastapi(
   if (authHeader) headers['Authorization'] = authHeader;
 
   // 일부 헤더 forward
-  // x-project-id: 프로젝트 컨텍스트 mutation 안전(d802da27) — FE fetch 인터셉터가 탭의 effective
-  // project 를 X-Project-Id 로 주입하는데, 이 프록시가 FastAPI 로 안 넘기면 BE get_verified_org_id
-  // override 가 헤더를 못 받아 조용히 무력화(full-chain 단절). x-org-id 와 동형으로 forward 필수.
-  for (const h of ['x-forwarded-for', 'x-real-ip', 'x-api-key', 'x-org-id', 'x-project-id']) {
+  for (const h of ['x-forwarded-for', 'x-real-ip', 'x-api-key', 'x-org-id']) {
     const v = request.headers.get(h);
     if (v) headers[h] = v;
   }

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -288,14 +288,28 @@ async def get_verified_org_id(
         # 헤더 사용 시 항상 membership 검증 (JWT org_id와 다를 수 있음)
         await _verify_org_membership(auth.user_id, org_id, db, request)
 
-    jwt_project_id = auth.claims.get("app_metadata", {}).get("project_id")
-    if not jwt_project_id and x_project_id:
-        # X-Project-Id 헤더 fallback 사용 시 해당 project가 org에 속하는지 검증
+    # X-Project-Id 헤더 = per-request 프로젝트 스코프 **override**(d802da27/85614dd9).
+    # JWT project_id 는 탭 공유라, 같은 유저가 여러 프로젝트 탭을 열어도 mutation 이 JWT 의 단일
+    # project 로 잘못 바인딩된다(48 mutation 라우트가 app_metadata.project_id 를 직접 읽음). FE 가
+    # 탭별로 보내는 X-Project-Id 를 JWT project_id 보다 **우선** 적용해 effective project 를
+    # 교체한다 — 헤더 프로젝트를 app_metadata.project_id 에 써 downstream 전 라우트에 1점 반영.
+    #
+    # ⚠️ 보안 critical: 헤더 프로젝트는 **반드시 has_project_access 멤버십 검증**(team_member ∪
+    # grant ∪ owner/admin). 미검증 시 헤더로 org 내 임의 프로젝트를 mutation 하는 권한상승 취약점.
+    # (기존 코드는 JWT project_id 부재 시에만·_verify_project_in_org=project∈org 만 봐서 멤버 아닌
+    # 프로젝트도 통과하던 갭.) 멤버십 미달이면 403.
+    if x_project_id:
         try:
-            project_id = uuid.UUID(x_project_id)
+            header_project_id = uuid.UUID(x_project_id)
         except ValueError:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid X-Project-Id format")
-        await _verify_project_in_org(project_id, org_id, db, request)
+        from app.services.project_auth import has_project_access
+        if not await has_project_access(db, uuid.UUID(auth.user_id), header_project_id, org_id):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="No access to the specified project",
+            )
+        auth.claims.setdefault("app_metadata", {})["project_id"] = str(header_project_id)
 
     return org_id
 

--- a/backend/app/routers/open_api_keys.py
+++ b/backend/app/routers/open_api_keys.py
@@ -33,8 +33,11 @@ def _get_project_id(auth: AuthContext = Depends(get_current_user)) -> uuid.UUID:
 async def create_project_api_key(
     body: CreateProjectApiKeyRequest,
     auth: AuthContext = Depends(require_admin),
-    project_id: uuid.UUID = Depends(_get_project_id),
+    # QA RC HIGH②(#1549): get_verified_org_id 가 X-Project-Id override 로 claims.project_id 를
+    # 갱신하므로, claims 를 읽는 _get_project_id 보다 **먼저** 선언해야(의존성 해소 순서=선언 순서)
+    # stale JWT project_id 대신 override 된 값을 캡처한다.
     _org_id: uuid.UUID = Depends(get_verified_org_id),
+    project_id: uuid.UUID = Depends(_get_project_id),
     repo: ProjectApiKeyRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
 ) -> ProjectApiKeyCreatedResponse:
@@ -55,8 +58,11 @@ async def create_project_api_key(
 @router.get("/api-keys", response_model=list[ProjectApiKeyResponse])
 async def list_project_api_keys(
     _auth: AuthContext = Depends(require_admin),
-    project_id: uuid.UUID = Depends(_get_project_id),
+    # QA RC HIGH②(#1549): get_verified_org_id 가 X-Project-Id override 로 claims.project_id 를
+    # 갱신하므로, claims 를 읽는 _get_project_id 보다 **먼저** 선언해야(의존성 해소 순서=선언 순서)
+    # stale JWT project_id 대신 override 된 값을 캡처한다.
     _org_id: uuid.UUID = Depends(get_verified_org_id),
+    project_id: uuid.UUID = Depends(_get_project_id),
     repo: ProjectApiKeyRepository = Depends(_get_repo),
 ) -> list[ProjectApiKeyResponse]:
     keys = await repo.list_by_project(project_id)
@@ -67,8 +73,11 @@ async def list_project_api_keys(
 async def revoke_project_api_key(
     key_id: uuid.UUID,
     _auth: AuthContext = Depends(require_admin),
-    project_id: uuid.UUID = Depends(_get_project_id),
+    # QA RC HIGH②(#1549): get_verified_org_id 가 X-Project-Id override 로 claims.project_id 를
+    # 갱신하므로, claims 를 읽는 _get_project_id 보다 **먼저** 선언해야(의존성 해소 순서=선언 순서)
+    # stale JWT project_id 대신 override 된 값을 캡처한다.
     _org_id: uuid.UUID = Depends(get_verified_org_id),
+    project_id: uuid.UUID = Depends(_get_project_id),
     repo: ProjectApiKeyRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
 ) -> None:

--- a/backend/app/services/project_auth.py
+++ b/backend/app/services/project_auth.py
@@ -104,6 +104,10 @@ async def has_project_access(
             FROM projects p
             WHERE p.id = :project_id
               AND p.deleted_at IS NULL
+              -- QA RC HIGH①(#1549): team_members 분기엔 org 가드가 없어(grant/agent/owner-admin엔 있음)
+              -- 양-org 멤버 유저가 JWT=org_B로 org_A 프로젝트를 X-Project-Id로 주입하면 cross-org 통과.
+              -- 최상위 p.org_id 스코프로 전 분기 일괄 봉합(org_id=None이면 cross-org 허용=기존 의미 보존).
+              AND (CAST(:org_id AS uuid) IS NULL OR p.org_id = :org_id)
               AND (
                 EXISTS (
                     SELECT 1 FROM team_members tm

--- a/backend/tests/test_c_s5.py
+++ b/backend/tests/test_c_s5.py
@@ -145,10 +145,11 @@ async def test_get_scope_context_returns_org_and_project():
     from app.dependencies.auth import get_scope_context
     org = uuid.uuid4()
     proj = uuid.uuid4()
-    auth = _make_auth(org_id=str(org))
+    uid = str(uuid.uuid4())
+    auth = _make_auth(org_id=str(org), user_id=uid)
 
     mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = proj  # project exists in org
+    mock_result.scalar_one_or_none.return_value = proj  # has_project_access → True(멤버)
     mock_db = AsyncMock()
     mock_db.execute = AsyncMock(return_value=mock_result)
     mock_request = MagicMock()
@@ -160,7 +161,7 @@ async def test_get_scope_context_returns_org_and_project():
     )
     assert ctx["org_id"] == org
     assert ctx["project_id"] == proj
-    assert ctx["user_id"] == "user-1"
+    assert ctx["user_id"] == uid
 
 
 @pytest.mark.anyio
@@ -245,13 +246,13 @@ async def test_get_verified_org_id_jwt_org_skips_db():
 
 @pytest.mark.anyio
 async def test_get_verified_org_id_403_on_foreign_project():
-    """X-Project-Id 헤더로 비소속 project 접근 시 403."""
+    """X-Project-Id 헤더로 비소속(has_project_access=False) project 접근 시 403."""
     from app.dependencies.auth import get_verified_org_id
     org = uuid.uuid4()
-    auth = _make_auth(org_id=str(org))  # JWT에 org_id 있음 (org 검증 skip)
+    auth = _make_auth(org_id=str(org), user_id=str(uuid.uuid4()))  # JWT에 org_id 있음 (org 검증 skip)
 
     mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = None  # project 비소속
+    mock_result.scalar_one_or_none.return_value = None  # has_project_access → False(멤버 아님)
     mock_db = AsyncMock()
     mock_db.execute = AsyncMock(return_value=mock_result)
     mock_request = MagicMock()

--- a/backend/tests/test_project_context_override.py
+++ b/backend/tests/test_project_context_override.py
@@ -1,0 +1,112 @@
+"""프로젝트 컨텍스트 mutation 안전(d802da27/85614dd9): get_verified_org_id 가 멤버십 검증된
+X-Project-Id 를 JWT project_id 보다 우선(override) 적용하는지 + 권한상승 차단(403)."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth(org_id, project_id=None, user_id=None):
+    from app.dependencies.auth import AuthContext
+
+    meta = {"org_id": str(org_id)}
+    if project_id is not None:
+        meta["project_id"] = str(project_id)
+    return AuthContext(
+        user_id=str(user_id or uuid.uuid4()), email=None, claims={"app_metadata": meta}
+    )
+
+
+def _access_result(member: bool):
+    """has_project_access 의 row.scalar_one_or_none() is not None 판정용."""
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = 1 if member else None
+    return r
+
+
+@pytest.mark.anyio
+async def test_x_project_id_overrides_jwt_when_member():
+    """헤더 프로젝트 멤버십 OK → effective project 가 헤더로 override(JWT project_id 덮어씀)."""
+    from app.dependencies.auth import get_verified_org_id
+
+    org = uuid.uuid4()
+    jwt_proj = uuid.uuid4()
+    header_proj = uuid.uuid4()
+    auth = _auth(org, project_id=jwt_proj)
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_access_result(True))
+
+    out = await get_verified_org_id(
+        auth=auth, x_org_id=None, x_project_id=str(header_proj), db=db, request=None
+    )
+    assert out == org
+    # downstream(48 라우트)이 읽는 app_metadata.project_id 가 헤더 프로젝트로 교체됨
+    assert auth.claims["app_metadata"]["project_id"] == str(header_proj)
+
+
+@pytest.mark.anyio
+async def test_x_project_id_non_member_403_no_override():
+    """헤더 프로젝트 멤버십 미달 → 403(권한상승 차단)·override 안 함."""
+    from fastapi import HTTPException
+
+    from app.dependencies.auth import get_verified_org_id
+
+    org = uuid.uuid4()
+    jwt_proj = uuid.uuid4()
+    auth = _auth(org, project_id=jwt_proj)
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_access_result(False))
+
+    with pytest.raises(HTTPException) as ei:
+        await get_verified_org_id(
+            auth=auth, x_org_id=None, x_project_id=str(uuid.uuid4()), db=db, request=None
+        )
+    assert ei.value.status_code == 403
+    assert auth.claims["app_metadata"]["project_id"] == str(jwt_proj)  # 미override
+
+
+@pytest.mark.anyio
+async def test_no_x_project_id_keeps_jwt_project_id():
+    """헤더 없음 → JWT project_id 유지·멤버십 쿼리 미실행(무회귀)."""
+    from app.dependencies.auth import get_verified_org_id
+
+    org = uuid.uuid4()
+    jwt_proj = uuid.uuid4()
+    auth = _auth(org, project_id=jwt_proj)
+
+    db = AsyncMock()
+    db.execute = AsyncMock()
+
+    out = await get_verified_org_id(
+        auth=auth, x_org_id=None, x_project_id=None, db=db, request=None
+    )
+    assert out == org
+    assert auth.claims["app_metadata"]["project_id"] == str(jwt_proj)
+    db.execute.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_x_project_id_invalid_format_400():
+    from fastapi import HTTPException
+
+    from app.dependencies.auth import get_verified_org_id
+
+    org = uuid.uuid4()
+    auth = _auth(org, project_id=uuid.uuid4())
+    db = AsyncMock()
+    db.execute = AsyncMock()
+
+    with pytest.raises(HTTPException) as ei:
+        await get_verified_org_id(
+            auth=auth, x_org_id=None, x_project_id="not-a-uuid", db=db, request=None
+        )
+    assert ei.value.status_code == 400

--- a/backend/tests/test_project_context_override.py
+++ b/backend/tests/test_project_context_override.py
@@ -94,6 +94,17 @@ async def test_no_x_project_id_keeps_jwt_project_id():
     db.execute.assert_not_called()
 
 
+def test_has_project_access_has_toplevel_org_scope():
+    """QA RC HIGH① 회귀 가드: has_project_access 최상위 WHERE 에 p.org_id 스코프 — team_members
+    분기 cross-org 누수 차단(X-Project-Id 로 cross-org 주입 방지). 실 PG 로 cross-org 0행 실증함."""
+    import inspect
+
+    from app.services import project_auth
+
+    src = inspect.getsource(project_auth.has_project_access)
+    assert "p.org_id = :org_id" in src
+
+
 @pytest.mark.anyio
 async def test_x_project_id_invalid_format_400():
     from fastapi import HTTPException


### PR DESCRIPTION
prod 회수·high·데이터안전 (`d802da27`/`85614dd9`). FE(미르코) 동반의 **BE 권위 게이트**.

## 문제
mutation 48 라우트가 `app_metadata.project_id`(JWT)를 직접 읽는다. JWT project_id 는 **탭 공유**라, 같은 유저가 프로젝트 A·B 탭을 동시에 열면 B 탭의 mutation 이 JWT 의 단일 project(예: A)로 **잘못 바인딩** → 엉뚱한 프로젝트에 쓰기(데이터 안전 문제). 순수 FE 로는 못 고침(공유 JWT 바인딩).

## 수정 (중앙 1점)
`get_verified_org_id` 한 함수:
- **X-Project-Id 헤더가 JWT project_id 를 override** — 검증 후 `app_metadata.project_id` 에 써 downstream 전 라우트가 탭의 effective project 를 본다. (기존엔 JWT project_id **부재 시에만** fallback 이라 일반 탭은 override 안 됐음.)
- ⚠️ **보안 critical**: 헤더 프로젝트는 **`has_project_access` 멤버십 검증**(team_member ∪ grant ∪ owner/admin). 미달 → **403**. 기존 `_verify_project_in_org`(project∈org)는 멤버 아닌 프로젝트도 통과 → 헤더로 org 내 임의 프로젝트 mutation 하는 **권한상승 갭**이었음. → 멤버십 게이트로 강화.
- `get_scope_context` 는 `get_verified_org_id` 위임이라 자동 정합.

FE 의 "(멤버십 검증)"은 UX/intent(accessible projects 중 valid `?p=` 선택)일 뿐 — **권위 보안 게이트는 본 PR 의 BE X-Project-Id 멤버십 검증**(PO 확認).

## 검증
- 신규 `tests/test_project_context_override.py` 4: 멤버 override(claims.project_id 교체)·비멤버 403(override 안 함)·무헤더 passthrough(쿼리 미실행)·invalid 400.
- `test_c_s5` 2건 신메커니즘(has_project_access) + uuid user_id 갱신. auth-context/security/mutation 회귀 **105 pass**. app import OK. 마이그 없음.

## ⚠️ post-merge 라이브 검증 권장
실 JWT + X-Project-Id 로 (a) 멤버 프로젝트 mutation 200·effective project 정확, (b) 비멤버 프로젝트 403 E2E. FE fetch 래퍼 머지와 짝.

🤖 Generated with [Claude Code](https://claude.com/claude-code)