### PR TITLE
fix(project-context): URL ?p= 를 탭별 프로젝트 SSOT 로 (d802da27, 85614dd9)

### DIFF
--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -106,10 +106,12 @@ function useProjectSsot(serverProjectId: string | undefined, memberships: Dashbo
   const accessibleIds = useMemo(() => new Set(memberships.map((m) => m.projectId)), [memberships]);
   const effectiveProjectId = resolveEffectiveProjectId(urlProjectId, serverProjectId, accessibleIds);
 
-  // 인터셉터가 읽는 ref 를 렌더 단계에서 동기화 — 자식 effect/핸들러의 fetch 가 항상 최신 project 를
-  // 싣도록(effect 동기화는 자식 effect 가 먼저 실행돼 첫 fetch 가 stale 일 수 있어 render 단계에서 set).
+  // ref 동기화 + 인터셉터 설치를 **렌더 단계**에서 — effect(자식→부모 순)에 두면 부모(DashboardShell)
+  // 설치 effect 가 자식(app-sidebar·use-team-presence·kanban-board) 초기 fetch *후* 실행돼 첫 로드
+  // fetch 가 X-Project-Id 없이 나간다(첫 페이지 무력화 RC). 부모 render 는 자식 render·effect 보다
+  // 먼저 실행되므로 여기서 설치하면 첫 자식 fetch 전에 패치 완료. 멱등 guard + SSR 가드라 render 호출 안전.
   setEffectiveProjectId(effectiveProjectId);
-  useEffect(() => { installProjectHeaderInterceptor(); }, []);
+  installProjectHeaderInterceptor();
 
   // 탭별 backstop 영속 + URL 정규화(`?p=` 누락/불일치 시 effective 로 replace → 링크 드롭에도 stale 방지).
   useEffect(() => {

--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -1,7 +1,13 @@
 'use client';
 
-import { createContext, useContext, useCallback } from 'react';
-import { usePathname } from 'next/navigation';
+import { createContext, useContext, useCallback, useEffect, useMemo } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import {
+  TAB_PROJECT_STORAGE_KEY,
+  installProjectHeaderInterceptor,
+  resolveEffectiveProjectId,
+  setEffectiveProjectId,
+} from '@/lib/project-context-client';
 import { useTranslations } from 'next-intl';
 import { RealtimeProvider } from '@/components/realtime-provider';
 import { AppSidebar } from '@/components/nav/app-sidebar';
@@ -85,6 +91,40 @@ function ScrollShell({ showTopBar, children }: { showTopBar: boolean; children: 
   );
 }
 
+/**
+ * R2 프로젝트 컨텍스트 SSOT — URL `?p=` 를 탭별 선택 프로젝트의 source of truth 로 삼는다.
+ * effective = `?p=`(accessible) → sessionStorage backstop → 서버 prop(쿠키 유래). 모든
+ * `useDashboardContext().projectId` 소비부가 이 값으로 자동 URL-aware 가 된다. fetch 인터셉터가
+ * 같은 값을 `X-Project-Id` 헤더로 실어 mutation 을 탭의 URL 프로젝트에 바인딩(BE 가 멤버십 검증).
+ */
+function useProjectSsot(serverProjectId: string | undefined, memberships: DashboardProjectOption[]): string | undefined {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const urlProjectId = searchParams.get('p');
+
+  const accessibleIds = useMemo(() => new Set(memberships.map((m) => m.projectId)), [memberships]);
+  const effectiveProjectId = resolveEffectiveProjectId(urlProjectId, serverProjectId, accessibleIds);
+
+  // 인터셉터가 읽는 ref 를 렌더 단계에서 동기화 — 자식 effect/핸들러의 fetch 가 항상 최신 project 를
+  // 싣도록(effect 동기화는 자식 effect 가 먼저 실행돼 첫 fetch 가 stale 일 수 있어 render 단계에서 set).
+  setEffectiveProjectId(effectiveProjectId);
+  useEffect(() => { installProjectHeaderInterceptor(); }, []);
+
+  // 탭별 backstop 영속 + URL 정규화(`?p=` 누락/불일치 시 effective 로 replace → 링크 드롭에도 stale 방지).
+  useEffect(() => {
+    if (!effectiveProjectId || typeof window === 'undefined') return;
+    window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, effectiveProjectId);
+    if (urlProjectId !== effectiveProjectId) {
+      const sp = new URLSearchParams(Array.from(searchParams.entries()));
+      sp.set('p', effectiveProjectId);
+      router.replace(`${pathname}?${sp.toString()}`);
+    }
+  }, [effectiveProjectId, urlProjectId, pathname, searchParams, router]);
+
+  return effectiveProjectId;
+}
+
 export function DashboardShell({
   currentTeamMemberId,
   orgId,
@@ -98,15 +138,19 @@ export function DashboardShell({
   const pathname = usePathname();
   const showTopBar = !pathname.startsWith('/settings');
 
+  // R2: URL `?p=` = 탭별 SSOT. 서버 prop 대신 effective 를 컨텍스트/사이드바에 공급.
+  const effectiveProjectId = useProjectSsot(projectId, projectMemberships);
+  const effectiveProjectName = projectMemberships.find((m) => m.projectId === effectiveProjectId)?.projectName ?? projectName;
+
   return (
-    <DashboardCtx.Provider value={{ currentTeamMemberId, orgId, projectId, projectName, userName, projectMemberships, orgMemberships }}>
+    <DashboardCtx.Provider value={{ currentTeamMemberId, orgId, projectId: effectiveProjectId, projectName: effectiveProjectName, userName, projectMemberships, orgMemberships }}>
       <RefreshProvider>
       <RealtimeProvider currentTeamMemberId={currentTeamMemberId}>
         <TopBarProvider>
           <SidebarProvider className="h-svh">
             <AppSidebar
               currentTeamMemberId={currentTeamMemberId}
-              projectId={projectId}
+              projectId={effectiveProjectId}
               projectMemberships={projectMemberships}
               orgId={orgId}
               orgMemberships={orgMemberships}

--- a/apps/web/src/components/nav/unified-switcher.tsx
+++ b/apps/web/src/components/nav/unified-switcher.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { TAB_PROJECT_STORAGE_KEY } from '@/lib/project-context-client';
 import { Check, ChevronDown, Loader2, Plus, Settings } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
@@ -61,6 +62,8 @@ export function UnifiedSwitcher({
   className,
 }: UnifiedSwitcherProps) {
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const [pending, setPending] = useState(false);
   const [open, setOpen] = useState(false);
   const [createOrgOpen, setCreateOrgOpen] = useState(false);
@@ -158,6 +161,11 @@ export function UnifiedSwitcher({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ project_id: projectId }),
       }).catch(() => null);
+      // R2: 랜딩 탭의 per-tab SSOT(sessionStorage + `?p=`)도 새 프로젝트로 동기.
+      if (typeof window !== 'undefined') window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, projectId);
+      const sp = new URLSearchParams(Array.from(searchParams.entries()));
+      sp.set('p', projectId);
+      router.push(`${pathname}?${sp.toString()}`);
       router.refresh();
     } finally {
       setPending(false);
@@ -168,14 +176,20 @@ export function UnifiedSwitcher({
     if (!nextProjectId || nextProjectId === currentProjectId || pending) return;
     setPending(true);
     try {
-      const res = await fetch('/api/switch-project', {
+      // R2 per-tab SSOT: 전역 reload 대신 이 탭의 sessionStorage backstop + URL `?p=` 갱신.
+      // → 탭별 독립(85614dd9) + 화면/컨텍스트 동기(d802da27). 다른 탭은 자기 `?p=`로 안 흔들림.
+      if (typeof window !== 'undefined') window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, nextProjectId);
+      const sp = new URLSearchParams(Array.from(searchParams.entries()));
+      sp.set('p', nextProjectId);
+      router.push(`${pathname}?${sp.toString()}`);
+      // 쿠키/JWT 동기화(이 탭 RSC·첫 렌더용). 공유 쿠키가 덮여도 per-tab 정합은 `?p=`+sessionStorage+
+      // fetch X-Project-Id 헤더가 보장하므로 무해.
+      await fetch('/api/switch-project', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ project_id: nextProjectId }),
-      });
-      if (res.ok) {
-        window.location.reload();
-      }
+      }).catch(() => null);
+      router.refresh();
     } finally {
       setPending(false);
     }

--- a/apps/web/src/lib/fastapi-proxy.ts
+++ b/apps/web/src/lib/fastapi-proxy.ts
@@ -101,8 +101,9 @@ export async function proxyToFastapi(
   };
   if (authHeader) headers['Authorization'] = authHeader;
 
-  // 일부 헤더 forward
-  for (const h of ['x-forwarded-for', 'x-real-ip', 'x-api-key', 'x-org-id']) {
+  // 일부 헤더 forward — x-project-id(R2): 브라우저 fetch 인터셉터가 주입한 탭 effective project를
+  // FastAPI get_verified_org_id override까지 도달시킨다. 빠지면 이 중간 hop이 헤더를 드롭해 무력화.
+  for (const h of ['x-forwarded-for', 'x-real-ip', 'x-api-key', 'x-org-id', 'x-project-id']) {
     const v = request.headers.get(h);
     if (v) headers[h] = v;
   }

--- a/apps/web/src/lib/project-context-client.ts
+++ b/apps/web/src/lib/project-context-client.ts
@@ -1,0 +1,78 @@
+'use client';
+
+/**
+ * 프로젝트 컨텍스트 SSOT (R2: d802da27 stale context / 85614dd9 멀티탭 독립).
+ *
+ * 기존 SSOT = 쿠키 `sprintable_current_project_id`(브라우저 전역, 탭 공유) → 탭A 전환이 탭B에
+ * 새서 stale·잘못된 프로젝트 mutation 위험. 이 모듈은 **URL `?p=` 를 탭별 SSOT** 로 삼고,
+ * 링크가 `?p=` 를 떨궈도 stale 로 안 빠지게 **sessionStorage(탭별) backstop** 을 둔다.
+ *
+ * mutation 안전의 권위 게이트는 BE — fetch 인터셉터가 same-origin `/api/*` 요청에
+ * `X-Project-Id` 헤더(탭의 effective project)를 실어 보내고, BE 가 멤버십 검증해 그 프로젝트로
+ * 스코프한다(미달 403). FE 의 멤버십 필터는 UX/intent(valid `?p=` 선택)일 뿐 보안 게이트가 아니다.
+ */
+
+/** 탭별 선택 프로젝트 backstop 키 — sessionStorage 는 탭 스코프라 멀티탭 독립이 자연 성립. */
+export const TAB_PROJECT_STORAGE_KEY = 'sprintable_tab_project_id';
+
+/** fetch 인터셉터가 읽는 현재 탭 effective projectId (provider 가 갱신). */
+const effectiveProjectIdRef: { current: string | undefined } = { current: undefined };
+
+export function setEffectiveProjectId(id: string | undefined): void {
+  effectiveProjectIdRef.current = id;
+}
+
+let interceptorInstalled = false;
+
+/**
+ * same-origin `/api/*` 요청에 `X-Project-Id`(탭 effective project)를 주입하는 단일 chokepoint.
+ * 호출부 전수 마이그레이션 대신 window.fetch 1점 패치 — raw fetch 호출까지 빠짐없이 커버.
+ *
+ * - string/URL input 만 처리(코드베이스 호출 패턴). Request input 은 body 유실 방지 위해 무가공 통과.
+ * - 이미 `X-Project-Id`/`X-Org-Id` 를 명시한 요청(예: switcher 의 cross-org 프로젝트 로드)은
+ *   스킵 — 명시 스코프를 덮지 않는다.
+ */
+export function installProjectHeaderInterceptor(): void {
+  if (interceptorInstalled || typeof window === 'undefined') return;
+  interceptorInstalled = true;
+  const originalFetch = window.fetch.bind(window);
+
+  window.fetch = function patchedFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    try {
+      if (typeof input === 'string' || input instanceof URL) {
+        const url = typeof input === 'string' ? input : input.href;
+        const path = url.startsWith('http') ? new URL(url).pathname : url.split('?')[0];
+        const projectId = effectiveProjectIdRef.current;
+        // 컨텍스트 제어 엔드포인트(`/api/switch-*`)는 자체 컨텍스트를 관리하므로 주입 제외.
+        const isApi = path.startsWith('/api/') && !path.startsWith('/api/switch-');
+        if (isApi && projectId) {
+          const headers = new Headers(init?.headers);
+          if (!headers.has('X-Project-Id') && !headers.has('X-Org-Id')) {
+            headers.set('X-Project-Id', projectId);
+            return originalFetch(input, { ...init, headers });
+          }
+        }
+      }
+    } catch {
+      // 인터셉터 실패는 원본 fetch 로 폴백 — 네트워크 동작을 절대 깨지 않는다.
+    }
+    return originalFetch(input, init);
+  };
+}
+
+/**
+ * 탭 effective project 해소 — 우선순위: URL `?p=` → sessionStorage backstop → 서버 prop(쿠키 유래).
+ * 후보가 accessible(`accessibleIds`)일 때만 채택(UX/intent 필터, 보안 아님). 무효면 다음 우선순위.
+ */
+export function resolveEffectiveProjectId(
+  urlProjectId: string | null,
+  serverProjectId: string | undefined,
+  accessibleIds: ReadonlySet<string>,
+): string | undefined {
+  if (urlProjectId && accessibleIds.has(urlProjectId)) return urlProjectId;
+  if (typeof window !== 'undefined') {
+    const stored = window.sessionStorage.getItem(TAB_PROJECT_STORAGE_KEY);
+    if (stored && accessibleIds.has(stored)) return stored;
+  }
+  return serverProjectId;
+}


### PR DESCRIPTION
## 무엇을 / 왜

prod 회수 R2 — **프로젝트 컨텍스트 mutation 안전** (2버그 한 묶음, PO conv `99852ce5`·FE+BE 공유 `910225af`).

기존 SSOT = 쿠키 `sprintable_current_project_id`(**브라우저 전역·탭 공유**)라:
1. `d802da27` 전환 시 화면(view)은 이전 프로젝트로 남고 컨텍스트만 바뀜 → **잘못된 프로젝트에 mutation 위험**.
2. `85614dd9` 탭별 다른 프로젝트 동시작업 불가(전역 selected project 간섭).

둘 다 같은 뿌리(쿠키=전역 SSOT). **mutation 48라우터가 공유 JWT `app_metadata.project_id`에 바인딩**이라 순수-FE로는 mutation 안전이 안 서고 **BE 권위 게이트(#1549)와 페어**로 닫는다.

## FE 변경 (이 PR)

- **ProjectProvider override** (`dashboard-shell.tsx`): effective projectId = URL `?p=`(accessible) → **sessionStorage(탭별) backstop** → 서버 prop. 모든 `useDashboardContext().projectId` 소비부가 한 점에서 자동 URL-aware. 마운트 시 `?p=` 누락/불일치면 `router.replace` 정규화 → **화면·컨텍스트 동기**(d802da27).
- **sessionStorage backstop**(탭 스코프): 링크가 `?p=`를 떨궈도 탭별 저장값으로 복원(공유 쿠키 폴백 X) → **멀티탭 독립**(85614dd9). PO 원안 "nav-helper 전수 보존"의 fragility(링크 1곳 누락→stale 재발) 없이 동일 no-stale 보장 — PO 채택.
- **단일 fetch 인터셉터**(`window.fetch` 1점 패치, same-origin `/api/*` 한정): 탭의 effective project를 **`X-Project-Id` 헤더**로 주입 → BE(#1549)가 `has_project_access` 검증해 mutation을 그 프로젝트에 바인딩. 명시적 `X-Project-Id`/`X-Org-Id` 요청·`/api/switch-*`는 제외. raw `fetch('/api/..')` 호출까지 호출부 마이그 없이 커버.
- **switch 플로우**: `window.location.reload()` 제거 → sessionStorage + `?p=` push(per-tab). 쿠키 POST는 이 탭 RSC 동기용 유지(공유돼도 per-tab 정합은 `?p=`+sessionStorage+헤더가 보장).

## ⚠️ BE 페어 / 안전

- **BE 권위 게이트 = #1549**(디디군): `get_verified_org_id`가 멤버십 검증된 `X-Project-Id`를 JWT project_id보다 우선(미달 403). **FE 멤버십 필터는 UX/intent용일 뿐, 권위 보안 게이트는 BE**(PO 못박음).
- **FE 단독 회귀 0**: #1549 머지 전엔 X-Project-Id가 무시(JWT 폴백=기존 동작)·`?p=` SSOT는 view/read만 고침. **mutation 안전 done은 #1549 동반**.

## 검증

- `pnpm type-check` ✅ / `pnpm lint`(대상 3파일) ✅ 0 warning / `pnpm build` ✅ EXIT 0
- base=`origin/develop`(`473dfd1b`)

라이브 픽셀(전환 즉시 동기·멀티탭 교차 안정·mutation 타겟)은 #1549 동반 dev 배포 후 까심 QA → 머지게이트 → 선생님 플로우.

🤖 Generated with [Claude Code](https://claude.com/claude-code)