### PR TITLE
feat(member-policy): 멤버 per-project 역할 지정 엔드포인트 (S3 / AC#1)

### DIFF
--- a/backend/app/routers/project_access.py
+++ b/backend/app/routers/project_access.py
@@ -34,6 +34,8 @@ class ProjectAccessResponse(BaseModel):
     # E-MEMBER-SSOT AC2-1 canonical 앵커 — 에이전트 행은 org_member_id 대신 member_id 로 식별.
     member_id: uuid.UUID | None = None
     permission: str
+    # E-MEMBER-POLICY S3: per-project 역할(owner/admin/member) 노출 — FE 가 owner 지정 UI 에 사용.
+    role: str = "member"
     created_at: datetime
 
 
@@ -194,3 +196,83 @@ async def delete_project_access(
     await session.delete(record)
     await session.commit()
     return {"ok": True}
+
+
+class SetProjectRoleRequest(BaseModel):
+    role: str  # 'owner' | 'admin' | 'member'
+
+
+@router.put("/{project_id}/access/{member_id}/role", response_model=ProjectAccessResponse)
+async def set_project_role(
+    project_id: uuid.UUID,
+    member_id: uuid.UUID,
+    body: SetProjectRoleRequest,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> ProjectAccessResponse:
+    """멤버의 per-project 역할(owner/admin/member) 지정 — E-MEMBER-POLICY S3 / AC#1(owner 지정).
+
+    권한(§9-3): **project owner** 또는 **org owner/admin**(project admin 은 역할 지정 불가).
+    대상은 해당 프로젝트에 project_access 행이 있는 멤버(휴먼=member_id 또는 org_member_id 매칭,
+    에이전트=member_id). 행 없으면 404. role 은 enum 검증(비-enum 400) — 0122 CHECK 정합.
+    """
+    from sqlalchemy import text
+    from sqlalchemy import update as sa_update
+
+    from app.services.project_auth import (
+        PROJECT_ROLES,
+        get_project_role,
+        is_org_owner_or_admin,
+    )
+
+    if body.role not in PROJECT_ROLES:
+        raise HTTPException(
+            status_code=400, detail=f"role must be one of {list(PROJECT_ROLES)}"
+        )
+
+    # 프로젝트 → org 역추적(존재 404)
+    org_row = (
+        await session.execute(
+            text("SELECT org_id FROM projects WHERE id = :pid AND deleted_at IS NULL"),
+            {"pid": str(project_id)},
+        )
+    ).first()
+    if org_row is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    org_id = org_row[0]
+
+    # 권한(§9-3): project owner OR org owner/admin. project admin 은 불가(get_project_role!=owner
+    # AND not org owner/admin). org owner 는 effective owner(floor)라 첫 조건으로 통과.
+    actor = uuid.UUID(auth.user_id)
+    is_proj_owner = (await get_project_role(session, actor, project_id)) == "owner"
+    if not (is_proj_owner or await is_org_owner_or_admin(session, actor, org_id)):
+        raise HTTPException(
+            status_code=403, detail="project owner or org owner/admin required"
+        )
+
+    # 대상 project_access 행 role 갱신 — 휴먼(member_id|org_member_id)·에이전트(member_id) 모두 매칭.
+    result = await session.execute(
+        sa_update(ProjectAccess)
+        .where(
+            ProjectAccess.project_id == project_id,
+            (ProjectAccess.member_id == member_id)
+            | (ProjectAccess.org_member_id == member_id),
+        )
+        .values(role=body.role)
+    )
+    if result.rowcount == 0:
+        raise HTTPException(
+            status_code=404, detail="Member has no access record in this project"
+        )
+    await session.commit()
+
+    record = (
+        await session.execute(
+            select(ProjectAccess).where(
+                ProjectAccess.project_id == project_id,
+                (ProjectAccess.member_id == member_id)
+                | (ProjectAccess.org_member_id == member_id),
+            )
+        )
+    ).scalars().first()
+    return ProjectAccessResponse.model_validate(record)

--- a/backend/tests/test_agent_multiproject_grant_18073a52.py
+++ b/backend/tests/test_agent_multiproject_grant_18073a52.py
@@ -74,10 +74,14 @@ async def _call_create(body_dict, execute_results):
     session.add = MagicMock()
     session.commit = AsyncMock()
 
-    async def _refresh(rec):  # DB가 채울 id/created_at을 model_validate 통과하도록 채움
+    async def _refresh(rec):  # DB가 채울 id/created_at/role을 model_validate 통과하도록 채움
         if getattr(rec, "id", None) is None:
             rec.id = uuid.uuid4()
         rec.created_at = datetime.now(timezone.utc)
+        # S3: ProjectAccessResponse.role 노출 추가 — transient 행은 role 미설정(DB default 'member'는
+        # flush 시 적용·refresh 가 로드). mock refresh 가 실 DB 처럼 default 'member' 미러.
+        if not isinstance(getattr(rec, "role", None), str):
+            rec.role = "member"
     session.refresh = AsyncMock(side_effect=_refresh)
 
     auth = MagicMock()

--- a/backend/tests/test_e_entity_cleanup_s3_project_access.py
+++ b/backend/tests/test_e_entity_cleanup_s3_project_access.py
@@ -156,6 +156,7 @@ def test_response_accepts_null_org_member_id():
     r.org_member_id = None  # 에이전트는 org_member 없음
     r.member_id = uuid.uuid4()  # canonical 앵커로 식별
     r.permission = "granted"
+    r.role = "member"  # S3: ProjectAccessResponse.role 노출 추가 — mock 에 명시(str)
     r.created_at = datetime.now(timezone.utc)
 
     v = ProjectAccessResponse.model_validate(r)
@@ -177,6 +178,7 @@ def test_response_accepts_human_org_member_id():
     r.org_member_id = uuid.uuid4()
     r.member_id = None
     r.permission = "granted"
+    r.role = "member"  # S3: ProjectAccessResponse.role 노출 추가 — mock 에 명시(str)
     r.created_at = datetime.now(timezone.utc)
 
     v = ProjectAccessResponse.model_validate(r)

--- a/backend/tests/test_project_role_s3_designate.py
+++ b/backend/tests/test_project_role_s3_designate.py
@@ -1,0 +1,149 @@
+"""E-MEMBER-POLICY S3 / AC#1: 멤버 per-project 역할 지정 엔드포인트(set_project_role).
+
+권한(§9-3): project owner 또는 org owner/admin. role enum 검증. 대상 행 없으면 404.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _org_row(exists=True):
+    r = MagicMock()
+    r.first.return_value = (uuid.uuid4(),) if exists else None
+    return r
+
+
+def _update_result(rowcount):
+    r = MagicMock()
+    r.rowcount = rowcount
+    return r
+
+
+def _record(role):
+    from app.models.project_access import ProjectAccess
+
+    return ProjectAccess(
+        id=uuid.uuid4(),
+        project_id=uuid.uuid4(),
+        org_member_id=None,
+        member_id=uuid.uuid4(),
+        permission="granted",
+        role=role,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def _select_result(record):
+    r = MagicMock()
+    r.scalars.return_value.first.return_value = record
+    return r
+
+
+def _session(side_effect):
+    s = MagicMock()
+    s.execute = AsyncMock(side_effect=side_effect)
+    s.commit = AsyncMock()
+    return s
+
+
+def _auth():
+    a = MagicMock()
+    a.user_id = str(uuid.uuid4())
+    return a
+
+
+def _patch_authz(proj_role, is_org_admin):
+    return (
+        patch("app.services.project_auth.get_project_role", new=AsyncMock(return_value=proj_role)),
+        patch("app.services.project_auth.is_org_owner_or_admin", new=AsyncMock(return_value=is_org_admin)),
+    )
+
+
+@pytest.mark.anyio
+async def test_invalid_role_400():
+    from fastapi import HTTPException
+
+    from app.routers import project_access as pa
+
+    body = pa.SetProjectRoleRequest(role="manager")  # 비-enum
+    session = _session([])
+    with pytest.raises(HTTPException) as ei:
+        await pa.set_project_role(uuid.uuid4(), uuid.uuid4(), body, auth=_auth(), session=session)
+    assert ei.value.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_missing_project_404():
+    from fastapi import HTTPException
+
+    from app.routers import project_access as pa
+
+    body = pa.SetProjectRoleRequest(role="owner")
+    session = _session([_org_row(exists=False)])
+    with pytest.raises(HTTPException) as ei:
+        await pa.set_project_role(uuid.uuid4(), uuid.uuid4(), body, auth=_auth(), session=session)
+    assert ei.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_unauthorized_403():
+    """project owner 아님 + org owner/admin 아님 → 403 (project admin 도 불가)."""
+    from fastapi import HTTPException
+
+    from app.routers import project_access as pa
+
+    body = pa.SetProjectRoleRequest(role="owner")
+    session = _session([_org_row()])
+    p1, p2 = _patch_authz(proj_role="admin", is_org_admin=False)
+    with p1, p2, pytest.raises(HTTPException) as ei:
+        await pa.set_project_role(uuid.uuid4(), uuid.uuid4(), body, auth=_auth(), session=session)
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_project_owner_can_set_role():
+    from app.routers import project_access as pa
+
+    body = pa.SetProjectRoleRequest(role="admin")
+    session = _session([_org_row(), _update_result(1), _select_result(_record("admin"))])
+    p1, p2 = _patch_authz(proj_role="owner", is_org_admin=False)
+    with p1, p2:
+        out = await pa.set_project_role(uuid.uuid4(), uuid.uuid4(), body, auth=_auth(), session=session)
+    assert out.role == "admin"
+    session.commit.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_org_admin_can_set_role():
+    """org admin(project owner 아님)도 지정 가능(§9-3)."""
+    from app.routers import project_access as pa
+
+    body = pa.SetProjectRoleRequest(role="owner")
+    session = _session([_org_row(), _update_result(1), _select_result(_record("owner"))])
+    p1, p2 = _patch_authz(proj_role="member", is_org_admin=True)
+    with p1, p2:
+        out = await pa.set_project_role(uuid.uuid4(), uuid.uuid4(), body, auth=_auth(), session=session)
+    assert out.role == "owner"
+
+
+@pytest.mark.anyio
+async def test_member_not_in_project_404():
+    from fastapi import HTTPException
+
+    from app.routers import project_access as pa
+
+    body = pa.SetProjectRoleRequest(role="admin")
+    session = _session([_org_row(), _update_result(0)])  # rowcount 0 = 대상 행 없음
+    p1, p2 = _patch_authz(proj_role="owner", is_org_admin=False)
+    with p1, p2, pytest.raises(HTTPException) as ei:
+        await pa.set_project_role(uuid.uuid4(), uuid.uuid4(), body, auth=_auth(), session=session)
+    assert ei.value.status_code == 404


### PR DESCRIPTION
블루프린트(#1543) **S3** / **AC#1**(project owner 지정 가능). S1(0122 enum)·S2(role 헬퍼) 위에서 동작. 마이그 없음.

## 엔드포인트
`PUT /api/v2/projects/{project_id}/access/{member_id}/role` — 멤버의 per-project 역할(`owner`/`admin`/`member`) 지정.
- **권한(§9-3)**: project owner **또는** org owner/admin. (project admin 은 역할 지정 불가 — get_project_role≠owner AND not org owner/admin → 403.) S2 헬퍼 `get_project_role`(effective)·`is_org_owner_or_admin` 소비.
- role **enum 검증**(비-enum → 400) — 0122 CHECK 정합. 대상 project_access 행(휴먼=`member_id`|`org_member_id` 매칭·에이전트=`member_id`) 없으면 404.
- `ProjectAccessResponse` 에 `role` 노출(FE owner 지정 UI 용 — 기존 미노출이라 추가).

## 검증
- 신규 테스트 6: invalid role 400·missing project 404·unauthorized(project admin·non-admin) 403·project owner 지정·org admin 지정·대상 행 없음 404.
- 회귀(project_access·s_mbr_03/10·ss4_security·member_ssot·org_agent) **91 pass**. app import OK·라우트 등록 확認.

## 비고
- 다음 **S4**: 게이트 config 소비(`can_manage_members` enforcement → role 헬퍼 전환) — HITL 게이트(S-GATE-1+)가 이 토대 위에 앉음.
- post-merge: project owner 지정 → 그 멤버가 자기 프로젝트 access 관리(S2 `_require_owner_or_admin` additive) E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)