### PR TITLE
release(prod): project-context mutation 안전 cherry-pick (#1549+#1550, #1547 격리)

### DIFF
--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -1,7 +1,13 @@
 'use client';
 
-import { createContext, useContext, useCallback } from 'react';
-import { usePathname } from 'next/navigation';
+import { createContext, useContext, useCallback, useEffect, useMemo } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import {
+  TAB_PROJECT_STORAGE_KEY,
+  installProjectHeaderInterceptor,
+  resolveEffectiveProjectId,
+  setEffectiveProjectId,
+} from '@/lib/project-context-client';
 import { useTranslations } from 'next-intl';
 import { RealtimeProvider } from '@/components/realtime-provider';
 import { AppSidebar } from '@/components/nav/app-sidebar';
@@ -85,6 +91,42 @@ function ScrollShell({ showTopBar, children }: { showTopBar: boolean; children: 
   );
 }
 
+/**
+ * R2 프로젝트 컨텍스트 SSOT — URL `?p=` 를 탭별 선택 프로젝트의 source of truth 로 삼는다.
+ * effective = `?p=`(accessible) → sessionStorage backstop → 서버 prop(쿠키 유래). 모든
+ * `useDashboardContext().projectId` 소비부가 이 값으로 자동 URL-aware 가 된다. fetch 인터셉터가
+ * 같은 값을 `X-Project-Id` 헤더로 실어 mutation 을 탭의 URL 프로젝트에 바인딩(BE 가 멤버십 검증).
+ */
+function useProjectSsot(serverProjectId: string | undefined, memberships: DashboardProjectOption[]): string | undefined {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const urlProjectId = searchParams.get('p');
+
+  const accessibleIds = useMemo(() => new Set(memberships.map((m) => m.projectId)), [memberships]);
+  const effectiveProjectId = resolveEffectiveProjectId(urlProjectId, serverProjectId, accessibleIds);
+
+  // ref 동기화 + 인터셉터 설치를 **렌더 단계**에서 — effect(자식→부모 순)에 두면 부모(DashboardShell)
+  // 설치 effect 가 자식(app-sidebar·use-team-presence·kanban-board) 초기 fetch *후* 실행돼 첫 로드
+  // fetch 가 X-Project-Id 없이 나간다(첫 페이지 무력화 RC). 부모 render 는 자식 render·effect 보다
+  // 먼저 실행되므로 여기서 설치하면 첫 자식 fetch 전에 패치 완료. 멱등 guard + SSR 가드라 render 호출 안전.
+  setEffectiveProjectId(effectiveProjectId);
+  installProjectHeaderInterceptor();
+
+  // 탭별 backstop 영속 + URL 정규화(`?p=` 누락/불일치 시 effective 로 replace → 링크 드롭에도 stale 방지).
+  useEffect(() => {
+    if (!effectiveProjectId || typeof window === 'undefined') return;
+    window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, effectiveProjectId);
+    if (urlProjectId !== effectiveProjectId) {
+      const sp = new URLSearchParams(Array.from(searchParams.entries()));
+      sp.set('p', effectiveProjectId);
+      router.replace(`${pathname}?${sp.toString()}`);
+    }
+  }, [effectiveProjectId, urlProjectId, pathname, searchParams, router]);
+
+  return effectiveProjectId;
+}
+
 export function DashboardShell({
   currentTeamMemberId,
   orgId,
@@ -98,15 +140,19 @@ export function DashboardShell({
   const pathname = usePathname();
   const showTopBar = !pathname.startsWith('/settings');
 
+  // R2: URL `?p=` = 탭별 SSOT. 서버 prop 대신 effective 를 컨텍스트/사이드바에 공급.
+  const effectiveProjectId = useProjectSsot(projectId, projectMemberships);
+  const effectiveProjectName = projectMemberships.find((m) => m.projectId === effectiveProjectId)?.projectName ?? projectName;
+
   return (
-    <DashboardCtx.Provider value={{ currentTeamMemberId, orgId, projectId, projectName, userName, projectMemberships, orgMemberships }}>
+    <DashboardCtx.Provider value={{ currentTeamMemberId, orgId, projectId: effectiveProjectId, projectName: effectiveProjectName, userName, projectMemberships, orgMemberships }}>
       <RefreshProvider>
       <RealtimeProvider currentTeamMemberId={currentTeamMemberId}>
         <TopBarProvider>
           <SidebarProvider className="h-svh">
             <AppSidebar
               currentTeamMemberId={currentTeamMemberId}
-              projectId={projectId}
+              projectId={effectiveProjectId}
               projectMemberships={projectMemberships}
               orgId={orgId}
               orgMemberships={orgMemberships}

--- a/apps/web/src/components/nav/unified-switcher.tsx
+++ b/apps/web/src/components/nav/unified-switcher.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { TAB_PROJECT_STORAGE_KEY } from '@/lib/project-context-client';
 import { Check, ChevronDown, Loader2, Plus, Settings } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
@@ -61,6 +62,8 @@ export function UnifiedSwitcher({
   className,
 }: UnifiedSwitcherProps) {
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const [pending, setPending] = useState(false);
   const [open, setOpen] = useState(false);
   const [createOrgOpen, setCreateOrgOpen] = useState(false);
@@ -158,6 +161,11 @@ export function UnifiedSwitcher({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ project_id: projectId }),
       }).catch(() => null);
+      // R2: 랜딩 탭의 per-tab SSOT(sessionStorage + `?p=`)도 새 프로젝트로 동기.
+      if (typeof window !== 'undefined') window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, projectId);
+      const sp = new URLSearchParams(Array.from(searchParams.entries()));
+      sp.set('p', projectId);
+      router.push(`${pathname}?${sp.toString()}`);
       router.refresh();
     } finally {
       setPending(false);
@@ -168,14 +176,20 @@ export function UnifiedSwitcher({
     if (!nextProjectId || nextProjectId === currentProjectId || pending) return;
     setPending(true);
     try {
-      const res = await fetch('/api/switch-project', {
+      // R2 per-tab SSOT: 전역 reload 대신 이 탭의 sessionStorage backstop + URL `?p=` 갱신.
+      // → 탭별 독립(85614dd9) + 화면/컨텍스트 동기(d802da27). 다른 탭은 자기 `?p=`로 안 흔들림.
+      if (typeof window !== 'undefined') window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, nextProjectId);
+      const sp = new URLSearchParams(Array.from(searchParams.entries()));
+      sp.set('p', nextProjectId);
+      router.push(`${pathname}?${sp.toString()}`);
+      // 쿠키/JWT 동기화(이 탭 RSC·첫 렌더용). 공유 쿠키가 덮여도 per-tab 정합은 `?p=`+sessionStorage+
+      // fetch X-Project-Id 헤더가 보장하므로 무해.
+      await fetch('/api/switch-project', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ project_id: nextProjectId }),
-      });
-      if (res.ok) {
-        window.location.reload();
-      }
+      }).catch(() => null);
+      router.refresh();
     } finally {
       setPending(false);
     }

--- a/apps/web/src/lib/fastapi-proxy.ts
+++ b/apps/web/src/lib/fastapi-proxy.ts
@@ -101,8 +101,9 @@ export async function proxyToFastapi(
   };
   if (authHeader) headers['Authorization'] = authHeader;
 
-  // 일부 헤더 forward
-  for (const h of ['x-forwarded-for', 'x-real-ip', 'x-api-key', 'x-org-id']) {
+  // 일부 헤더 forward — x-project-id(R2): 브라우저 fetch 인터셉터가 주입한 탭 effective project를
+  // FastAPI get_verified_org_id override까지 도달시킨다. 빠지면 이 중간 hop이 헤더를 드롭해 무력화.
+  for (const h of ['x-forwarded-for', 'x-real-ip', 'x-api-key', 'x-org-id', 'x-project-id']) {
     const v = request.headers.get(h);
     if (v) headers[h] = v;
   }

--- a/apps/web/src/lib/project-context-client.ts
+++ b/apps/web/src/lib/project-context-client.ts
@@ -1,0 +1,78 @@
+'use client';
+
+/**
+ * 프로젝트 컨텍스트 SSOT (R2: d802da27 stale context / 85614dd9 멀티탭 독립).
+ *
+ * 기존 SSOT = 쿠키 `sprintable_current_project_id`(브라우저 전역, 탭 공유) → 탭A 전환이 탭B에
+ * 새서 stale·잘못된 프로젝트 mutation 위험. 이 모듈은 **URL `?p=` 를 탭별 SSOT** 로 삼고,
+ * 링크가 `?p=` 를 떨궈도 stale 로 안 빠지게 **sessionStorage(탭별) backstop** 을 둔다.
+ *
+ * mutation 안전의 권위 게이트는 BE — fetch 인터셉터가 same-origin `/api/*` 요청에
+ * `X-Project-Id` 헤더(탭의 effective project)를 실어 보내고, BE 가 멤버십 검증해 그 프로젝트로
+ * 스코프한다(미달 403). FE 의 멤버십 필터는 UX/intent(valid `?p=` 선택)일 뿐 보안 게이트가 아니다.
+ */
+
+/** 탭별 선택 프로젝트 backstop 키 — sessionStorage 는 탭 스코프라 멀티탭 독립이 자연 성립. */
+export const TAB_PROJECT_STORAGE_KEY = 'sprintable_tab_project_id';
+
+/** fetch 인터셉터가 읽는 현재 탭 effective projectId (provider 가 갱신). */
+const effectiveProjectIdRef: { current: string | undefined } = { current: undefined };
+
+export function setEffectiveProjectId(id: string | undefined): void {
+  effectiveProjectIdRef.current = id;
+}
+
+let interceptorInstalled = false;
+
+/**
+ * same-origin `/api/*` 요청에 `X-Project-Id`(탭 effective project)를 주입하는 단일 chokepoint.
+ * 호출부 전수 마이그레이션 대신 window.fetch 1점 패치 — raw fetch 호출까지 빠짐없이 커버.
+ *
+ * - string/URL input 만 처리(코드베이스 호출 패턴). Request input 은 body 유실 방지 위해 무가공 통과.
+ * - 이미 `X-Project-Id`/`X-Org-Id` 를 명시한 요청(예: switcher 의 cross-org 프로젝트 로드)은
+ *   스킵 — 명시 스코프를 덮지 않는다.
+ */
+export function installProjectHeaderInterceptor(): void {
+  if (interceptorInstalled || typeof window === 'undefined') return;
+  interceptorInstalled = true;
+  const originalFetch = window.fetch.bind(window);
+
+  window.fetch = function patchedFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    try {
+      if (typeof input === 'string' || input instanceof URL) {
+        const url = typeof input === 'string' ? input : input.href;
+        const path = url.startsWith('http') ? new URL(url).pathname : url.split('?')[0];
+        const projectId = effectiveProjectIdRef.current;
+        // 컨텍스트 제어 엔드포인트(`/api/switch-*`)는 자체 컨텍스트를 관리하므로 주입 제외.
+        const isApi = path.startsWith('/api/') && !path.startsWith('/api/switch-');
+        if (isApi && projectId) {
+          const headers = new Headers(init?.headers);
+          if (!headers.has('X-Project-Id') && !headers.has('X-Org-Id')) {
+            headers.set('X-Project-Id', projectId);
+            return originalFetch(input, { ...init, headers });
+          }
+        }
+      }
+    } catch {
+      // 인터셉터 실패는 원본 fetch 로 폴백 — 네트워크 동작을 절대 깨지 않는다.
+    }
+    return originalFetch(input, init);
+  };
+}
+
+/**
+ * 탭 effective project 해소 — 우선순위: URL `?p=` → sessionStorage backstop → 서버 prop(쿠키 유래).
+ * 후보가 accessible(`accessibleIds`)일 때만 채택(UX/intent 필터, 보안 아님). 무효면 다음 우선순위.
+ */
+export function resolveEffectiveProjectId(
+  urlProjectId: string | null,
+  serverProjectId: string | undefined,
+  accessibleIds: ReadonlySet<string>,
+): string | undefined {
+  if (urlProjectId && accessibleIds.has(urlProjectId)) return urlProjectId;
+  if (typeof window !== 'undefined') {
+    const stored = window.sessionStorage.getItem(TAB_PROJECT_STORAGE_KEY);
+    if (stored && accessibleIds.has(stored)) return stored;
+  }
+  return serverProjectId;
+}

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -288,14 +288,28 @@ async def get_verified_org_id(
         # 헤더 사용 시 항상 membership 검증 (JWT org_id와 다를 수 있음)
         await _verify_org_membership(auth.user_id, org_id, db, request)
 
-    jwt_project_id = auth.claims.get("app_metadata", {}).get("project_id")
-    if not jwt_project_id and x_project_id:
-        # X-Project-Id 헤더 fallback 사용 시 해당 project가 org에 속하는지 검증
+    # X-Project-Id 헤더 = per-request 프로젝트 스코프 **override**(d802da27/85614dd9).
+    # JWT project_id 는 탭 공유라, 같은 유저가 여러 프로젝트 탭을 열어도 mutation 이 JWT 의 단일
+    # project 로 잘못 바인딩된다(48 mutation 라우트가 app_metadata.project_id 를 직접 읽음). FE 가
+    # 탭별로 보내는 X-Project-Id 를 JWT project_id 보다 **우선** 적용해 effective project 를
+    # 교체한다 — 헤더 프로젝트를 app_metadata.project_id 에 써 downstream 전 라우트에 1점 반영.
+    #
+    # ⚠️ 보안 critical: 헤더 프로젝트는 **반드시 has_project_access 멤버십 검증**(team_member ∪
+    # grant ∪ owner/admin). 미검증 시 헤더로 org 내 임의 프로젝트를 mutation 하는 권한상승 취약점.
+    # (기존 코드는 JWT project_id 부재 시에만·_verify_project_in_org=project∈org 만 봐서 멤버 아닌
+    # 프로젝트도 통과하던 갭.) 멤버십 미달이면 403.
+    if x_project_id:
         try:
-            project_id = uuid.UUID(x_project_id)
+            header_project_id = uuid.UUID(x_project_id)
         except ValueError:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid X-Project-Id format")
-        await _verify_project_in_org(project_id, org_id, db, request)
+        from app.services.project_auth import has_project_access
+        if not await has_project_access(db, uuid.UUID(auth.user_id), header_project_id, org_id):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="No access to the specified project",
+            )
+        auth.claims.setdefault("app_metadata", {})["project_id"] = str(header_project_id)
 
     return org_id
 

--- a/backend/app/routers/open_api_keys.py
+++ b/backend/app/routers/open_api_keys.py
@@ -33,8 +33,11 @@ def _get_project_id(auth: AuthContext = Depends(get_current_user)) -> uuid.UUID:
 async def create_project_api_key(
     body: CreateProjectApiKeyRequest,
     auth: AuthContext = Depends(require_admin),
-    project_id: uuid.UUID = Depends(_get_project_id),
+    # QA RC HIGH②(#1549): get_verified_org_id 가 X-Project-Id override 로 claims.project_id 를
+    # 갱신하므로, claims 를 읽는 _get_project_id 보다 **먼저** 선언해야(의존성 해소 순서=선언 순서)
+    # stale JWT project_id 대신 override 된 값을 캡처한다.
     _org_id: uuid.UUID = Depends(get_verified_org_id),
+    project_id: uuid.UUID = Depends(_get_project_id),
     repo: ProjectApiKeyRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
 ) -> ProjectApiKeyCreatedResponse:
@@ -55,8 +58,11 @@ async def create_project_api_key(
 @router.get("/api-keys", response_model=list[ProjectApiKeyResponse])
 async def list_project_api_keys(
     _auth: AuthContext = Depends(require_admin),
-    project_id: uuid.UUID = Depends(_get_project_id),
+    # QA RC HIGH②(#1549): get_verified_org_id 가 X-Project-Id override 로 claims.project_id 를
+    # 갱신하므로, claims 를 읽는 _get_project_id 보다 **먼저** 선언해야(의존성 해소 순서=선언 순서)
+    # stale JWT project_id 대신 override 된 값을 캡처한다.
     _org_id: uuid.UUID = Depends(get_verified_org_id),
+    project_id: uuid.UUID = Depends(_get_project_id),
     repo: ProjectApiKeyRepository = Depends(_get_repo),
 ) -> list[ProjectApiKeyResponse]:
     keys = await repo.list_by_project(project_id)
@@ -67,8 +73,11 @@ async def list_project_api_keys(
 async def revoke_project_api_key(
     key_id: uuid.UUID,
     _auth: AuthContext = Depends(require_admin),
-    project_id: uuid.UUID = Depends(_get_project_id),
+    # QA RC HIGH②(#1549): get_verified_org_id 가 X-Project-Id override 로 claims.project_id 를
+    # 갱신하므로, claims 를 읽는 _get_project_id 보다 **먼저** 선언해야(의존성 해소 순서=선언 순서)
+    # stale JWT project_id 대신 override 된 값을 캡처한다.
     _org_id: uuid.UUID = Depends(get_verified_org_id),
+    project_id: uuid.UUID = Depends(_get_project_id),
     repo: ProjectApiKeyRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
 ) -> None:

--- a/backend/app/services/project_auth.py
+++ b/backend/app/services/project_auth.py
@@ -44,6 +44,10 @@ async def has_project_access(
             FROM projects p
             WHERE p.id = :project_id
               AND p.deleted_at IS NULL
+              -- QA RC HIGH①(#1549): team_members 분기엔 org 가드가 없어(grant/agent/owner-admin엔 있음)
+              -- 양-org 멤버 유저가 JWT=org_B로 org_A 프로젝트를 X-Project-Id로 주입하면 cross-org 통과.
+              -- 최상위 p.org_id 스코프로 전 분기 일괄 봉합(org_id=None이면 cross-org 허용=기존 의미 보존).
+              AND (CAST(:org_id AS uuid) IS NULL OR p.org_id = :org_id)
               AND (
                 EXISTS (
                     SELECT 1 FROM team_members tm

--- a/backend/tests/test_c_s5.py
+++ b/backend/tests/test_c_s5.py
@@ -145,10 +145,11 @@ async def test_get_scope_context_returns_org_and_project():
     from app.dependencies.auth import get_scope_context
     org = uuid.uuid4()
     proj = uuid.uuid4()
-    auth = _make_auth(org_id=str(org))
+    uid = str(uuid.uuid4())
+    auth = _make_auth(org_id=str(org), user_id=uid)
 
     mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = proj  # project exists in org
+    mock_result.scalar_one_or_none.return_value = proj  # has_project_access → True(멤버)
     mock_db = AsyncMock()
     mock_db.execute = AsyncMock(return_value=mock_result)
     mock_request = MagicMock()
@@ -160,7 +161,7 @@ async def test_get_scope_context_returns_org_and_project():
     )
     assert ctx["org_id"] == org
     assert ctx["project_id"] == proj
-    assert ctx["user_id"] == "user-1"
+    assert ctx["user_id"] == uid
 
 
 @pytest.mark.anyio
@@ -245,13 +246,13 @@ async def test_get_verified_org_id_jwt_org_skips_db():
 
 @pytest.mark.anyio
 async def test_get_verified_org_id_403_on_foreign_project():
-    """X-Project-Id 헤더로 비소속 project 접근 시 403."""
+    """X-Project-Id 헤더로 비소속(has_project_access=False) project 접근 시 403."""
     from app.dependencies.auth import get_verified_org_id
     org = uuid.uuid4()
-    auth = _make_auth(org_id=str(org))  # JWT에 org_id 있음 (org 검증 skip)
+    auth = _make_auth(org_id=str(org), user_id=str(uuid.uuid4()))  # JWT에 org_id 있음 (org 검증 skip)
 
     mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = None  # project 비소속
+    mock_result.scalar_one_or_none.return_value = None  # has_project_access → False(멤버 아님)
     mock_db = AsyncMock()
     mock_db.execute = AsyncMock(return_value=mock_result)
     mock_request = MagicMock()

--- a/backend/tests/test_project_context_override.py
+++ b/backend/tests/test_project_context_override.py
@@ -1,0 +1,123 @@
+"""프로젝트 컨텍스트 mutation 안전(d802da27/85614dd9): get_verified_org_id 가 멤버십 검증된
+X-Project-Id 를 JWT project_id 보다 우선(override) 적용하는지 + 권한상승 차단(403)."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth(org_id, project_id=None, user_id=None):
+    from app.dependencies.auth import AuthContext
+
+    meta = {"org_id": str(org_id)}
+    if project_id is not None:
+        meta["project_id"] = str(project_id)
+    return AuthContext(
+        user_id=str(user_id or uuid.uuid4()), email=None, claims={"app_metadata": meta}
+    )
+
+
+def _access_result(member: bool):
+    """has_project_access 의 row.scalar_one_or_none() is not None 판정용."""
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = 1 if member else None
+    return r
+
+
+@pytest.mark.anyio
+async def test_x_project_id_overrides_jwt_when_member():
+    """헤더 프로젝트 멤버십 OK → effective project 가 헤더로 override(JWT project_id 덮어씀)."""
+    from app.dependencies.auth import get_verified_org_id
+
+    org = uuid.uuid4()
+    jwt_proj = uuid.uuid4()
+    header_proj = uuid.uuid4()
+    auth = _auth(org, project_id=jwt_proj)
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_access_result(True))
+
+    out = await get_verified_org_id(
+        auth=auth, x_org_id=None, x_project_id=str(header_proj), db=db, request=None
+    )
+    assert out == org
+    # downstream(48 라우트)이 읽는 app_metadata.project_id 가 헤더 프로젝트로 교체됨
+    assert auth.claims["app_metadata"]["project_id"] == str(header_proj)
+
+
+@pytest.mark.anyio
+async def test_x_project_id_non_member_403_no_override():
+    """헤더 프로젝트 멤버십 미달 → 403(권한상승 차단)·override 안 함."""
+    from fastapi import HTTPException
+
+    from app.dependencies.auth import get_verified_org_id
+
+    org = uuid.uuid4()
+    jwt_proj = uuid.uuid4()
+    auth = _auth(org, project_id=jwt_proj)
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_access_result(False))
+
+    with pytest.raises(HTTPException) as ei:
+        await get_verified_org_id(
+            auth=auth, x_org_id=None, x_project_id=str(uuid.uuid4()), db=db, request=None
+        )
+    assert ei.value.status_code == 403
+    assert auth.claims["app_metadata"]["project_id"] == str(jwt_proj)  # 미override
+
+
+@pytest.mark.anyio
+async def test_no_x_project_id_keeps_jwt_project_id():
+    """헤더 없음 → JWT project_id 유지·멤버십 쿼리 미실행(무회귀)."""
+    from app.dependencies.auth import get_verified_org_id
+
+    org = uuid.uuid4()
+    jwt_proj = uuid.uuid4()
+    auth = _auth(org, project_id=jwt_proj)
+
+    db = AsyncMock()
+    db.execute = AsyncMock()
+
+    out = await get_verified_org_id(
+        auth=auth, x_org_id=None, x_project_id=None, db=db, request=None
+    )
+    assert out == org
+    assert auth.claims["app_metadata"]["project_id"] == str(jwt_proj)
+    db.execute.assert_not_called()
+
+
+def test_has_project_access_has_toplevel_org_scope():
+    """QA RC HIGH① 회귀 가드: has_project_access 최상위 WHERE 에 p.org_id 스코프 — team_members
+    분기 cross-org 누수 차단(X-Project-Id 로 cross-org 주입 방지). 실 PG 로 cross-org 0행 실증함."""
+    import inspect
+
+    from app.services import project_auth
+
+    src = inspect.getsource(project_auth.has_project_access)
+    assert "p.org_id = :org_id" in src
+
+
+@pytest.mark.anyio
+async def test_x_project_id_invalid_format_400():
+    from fastapi import HTTPException
+
+    from app.dependencies.auth import get_verified_org_id
+
+    org = uuid.uuid4()
+    auth = _auth(org, project_id=uuid.uuid4())
+    db = AsyncMock()
+    db.execute = AsyncMock()
+
+    with pytest.raises(HTTPException) as ei:
+        await get_verified_org_id(
+            auth=auth, x_org_id=None, x_project_id="not-a-uuid", db=db, request=None
+        )
+    assert ei.value.status_code == 400


### PR DESCRIPTION
프로젝트 컨텍스트 mutation 안전(d802da27·85614dd9) prod 승격 — #1549(BE X-Project-Id 멤버십 override)+#1550(FE URL ?p= SSOT). dev 검증 완료(?p= 컨텍스트 바인딩·cross-org 403·full-chain). **#1547(HITL S2 dev 전용) 격리**(cherry-pick으로 이 둘만). 마이그 없음. 롤백 ref: 6c7af23a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)