### PR TITLE
perf(chat): 채팅 진입 eager 비기본탭 fetch + /me 재호출 제거 (17960f86)

### DIFF
--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -8,6 +8,7 @@ interface MemberContext {
   project_id: string;
   project_name: string;
   name: string;
+  role?: string;
 }
 
 interface OrgMembership {
@@ -72,6 +73,7 @@ export default async function AuthenticatedLayout({
       projectId={me?.project_id}
       projectName={me?.project_name ?? undefined}
       userName={me?.name}
+      role={me?.role}
       projectMemberships={projectMemberships}
       orgMemberships={orgMemberships}
     >

--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -32,6 +32,7 @@ interface DashboardContext {
   projectId?: string;
   projectName?: string;
   userName?: string;
+  role?: string;
   projectMemberships: DashboardProjectOption[];
   orgMemberships: OrgSwitcherItem[];
 }
@@ -133,6 +134,7 @@ export function DashboardShell({
   projectId,
   projectName,
   userName,
+  role,
   projectMemberships,
   orgMemberships,
   children,
@@ -145,7 +147,7 @@ export function DashboardShell({
   const effectiveProjectName = projectMemberships.find((m) => m.projectId === effectiveProjectId)?.projectName ?? projectName;
 
   return (
-    <DashboardCtx.Provider value={{ currentTeamMemberId, orgId, projectId: effectiveProjectId, projectName: effectiveProjectName, userName, projectMemberships, orgMemberships }}>
+    <DashboardCtx.Provider value={{ currentTeamMemberId, orgId, projectId: effectiveProjectId, projectName: effectiveProjectName, userName, role, projectMemberships, orgMemberships }}>
       <RefreshProvider>
       <RealtimeProvider currentTeamMemberId={currentTeamMemberId}>
         <TopBarProvider>

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -234,6 +234,11 @@ export function ChatListView({ projectId, currentTeamMemberId, open, onOpenChang
   const convsRef = useRef(conversations);
   useEffect(() => { convsRef.current = conversations; }, [conversations]);
 
+  // 전환 in-flight 경합 가드(RC): fetch 응답 적용 시점에 여전히 같은 프로젝트인지 검증해 stale 응답을
+  // drop 한다. render 단계 동기라 async resolve 시 항상 최신 projectId 를 가리킨다(assignee last-write-wins 동류).
+  const projectIdRef = useRef(projectId);
+  projectIdRef.current = projectId;
+
   const fetchConversations = useCallback(async (nextOffset = 0, append = false) => {
     try {
       const res = await fetch(
@@ -241,6 +246,7 @@ export function ChatListView({ projectId, currentTeamMemberId, open, onOpenChang
       );
       if (!res.ok) return;
       const json = await res.json() as { data: ConversationItem[]; total: number };
+      if (projectId !== projectIdRef.current) return; // 전환됨 — stale 응답 drop(현 화면 안 덮음)
       const items = json.data ?? [];
       setConversations((prev) => append ? [...prev, ...items] : items);
       setMyOffset(nextOffset + items.length);
@@ -257,6 +263,7 @@ export function ChatListView({ projectId, currentTeamMemberId, open, onOpenChang
     );
     if (!res.ok) return;
     const json = await res.json() as { data: ConversationItem[]; total: number };
+    if (projectId !== projectIdRef.current) return; // 전환됨 — stale 응답 drop(B 화면 안 덮음)
     const items = json.data ?? [];
     setAllConversations((prev) => append ? [...prev, ...items] : items);
     setAgentOffset(nextOffset + items.length);

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -273,6 +273,18 @@ export function ChatListView({ projectId, currentTeamMemberId, open, onOpenChang
     void fetchAllConversations(0, false);
   }, [fetchAllConversations]);
 
+  // 프로젝트 전환 시 agent 탭 stale 방지(RC): ref-guard 가 re-render 에 안 리셋되므로 projectId 변경마다
+  // 명시 리셋 + agent 리스트 클리어. 이미 열려있던 탭이면 새 프로젝트로 재로드(기존 자동 refetch 동작 보존),
+  // 한 번도 안 연 탭이면 lazy 유지. 마운트(첫 projectId)엔 wasLoaded=false 라 무fetch.
+  useEffect(() => {
+    const wasLoaded = agentLoadedRef.current;
+    agentLoadedRef.current = false;
+    setAllConversations([]);
+    setAgentOffset(0);
+    setAgentTotal(0);
+    if (wasLoaded) loadAgentConversationsOnce();
+  }, [projectId, loadAgentConversationsOnce]);
+
   const handleConversationMessage = useCallback((payload: { conversation_id?: string; content?: string; created_at?: string }) => {
     setConversations((prev) => applyConversationMessageUpdate(prev, payload, () => void fetchConversations(0, false)));
     // agent 탭을 아직 안 연 상태에선 allConversations 를 reactive 로드하지 않는다(lazy 유지) —

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -8,6 +8,7 @@ import { EmptyState } from '@/components/ui/empty-state';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { NewConversationModal } from './new-conversation-modal';
 import { useChatSse } from '@/hooks/use-chat-sse';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 
 interface Participant {
   member_id: string;
@@ -212,9 +213,14 @@ const PAGE_LIMIT = 30;
 export function ChatListView({ projectId, currentTeamMemberId, open, onOpenChange }: ChatListViewProps) {
   const t = useTranslations('chats');
   const router = useRouter();
+  // perf(17960f86): role 은 DashboardContext(서버 /api/v2/me 투영)에서 — 채팅 진입마다 `/api/me`
+  // 재호출하던 round-trip 제거. /me checkRole 과 동일한 effective role 이라 게이트 의미 보존.
+  const { role } = useDashboardContext();
+  const isAdminOrOwner = role === 'admin' || role === 'owner';
   const [conversations, setConversations] = useState<ConversationItem[]>([]);
   const [allConversations, setAllConversations] = useState<ConversationItem[]>([]);
-  const [isAdminOrOwner, setIsAdminOrOwner] = useState(false);
+  // agent 탭(allConversations·include_agent_conversations) 첫 활성화 1회만 fetch 하기 위한 가드.
+  const agentLoadedRef = useRef(false);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [myOffset, setMyOffset] = useState(0);
@@ -227,17 +233,6 @@ export function ChatListView({ projectId, currentTeamMemberId, open, onOpenChang
 
   const convsRef = useRef(conversations);
   useEffect(() => { convsRef.current = conversations; }, [conversations]);
-
-  useEffect(() => {
-    async function checkRole() {
-      const res = await fetch('/api/me');
-      if (!res.ok) return;
-      const json = await res.json() as { data?: { role?: string } };
-      const role = json.data?.role ?? 'member';
-      setIsAdminOrOwner(role === 'admin' || role === 'owner');
-    }
-    void checkRole();
-  }, []);
 
   const fetchConversations = useCallback(async (nextOffset = 0, append = false) => {
     try {
@@ -270,13 +265,21 @@ export function ChatListView({ projectId, currentTeamMemberId, open, onOpenChang
 
   useEffect(() => { void fetchConversations(0, false); }, [fetchConversations]);
 
-  useEffect(() => {
-    if (isAdminOrOwner) void fetchAllConversations(0, false);
-  }, [isAdminOrOwner, fetchAllConversations]);
+  // perf(17960f86): agent 탭("전체/에이전트", include_agent_conversations=true)은 비기본 탭이라
+  // mount 시 eager fetch(측정 ~663ms 낭비) 하지 않고, 사용자가 탭을 처음 열 때 1회만 lazy 로드.
+  const loadAgentConversationsOnce = useCallback(() => {
+    if (agentLoadedRef.current) return;
+    agentLoadedRef.current = true;
+    void fetchAllConversations(0, false);
+  }, [fetchAllConversations]);
 
   const handleConversationMessage = useCallback((payload: { conversation_id?: string; content?: string; created_at?: string }) => {
     setConversations((prev) => applyConversationMessageUpdate(prev, payload, () => void fetchConversations(0, false)));
-    setAllConversations((prev) => applyConversationMessageUpdate(prev, payload, () => void fetchAllConversations(0, false)));
+    // agent 탭을 아직 안 연 상태에선 allConversations 를 reactive 로드하지 않는다(lazy 유지) —
+    // 탭 첫 활성화 시 loadAgentConversationsOnce 가 최신본을 받으므로 누락 없음.
+    if (agentLoadedRef.current) {
+      setAllConversations((prev) => applyConversationMessageUpdate(prev, payload, () => void fetchAllConversations(0, false)));
+    }
   }, [fetchConversations, fetchAllConversations]);
 
   useChatSse({
@@ -365,7 +368,7 @@ export function ChatListView({ projectId, currentTeamMemberId, open, onOpenChang
   return (
     <div className="flex h-full flex-col">
       {isAdminOrOwner ? (
-        <Tabs defaultValue="my" className="flex min-h-0 flex-1 flex-col">
+        <Tabs defaultValue="my" onValueChange={(v) => { if (v === 'agent') loadAgentConversationsOnce(); }} className="flex min-h-0 flex-1 flex-col">
           <TabsList className="mx-4 mt-2 w-auto self-start">
             <TabsTrigger value="my">{t('myChatsTab')}</TabsTrigger>
             <TabsTrigger value="agent">{t('agentChatsTab')}</TabsTrigger>


### PR DESCRIPTION
## 무엇을 / 측정 근거

R2 프론트 성능 — **measure-first**(dev FE 실측·puppeteer, PO 승인 #1 only). dosunyun신 "Linear 수준 사용성" 드라이버. (story `17960f86`·prod `f85aa23d`)

**측정 baseline (보드→채팅 전환, dev):** 채팅 진입 즉시 3콜 —
- `/api/me`(role 확인·75ms)
- `/api/conversations?project_id=...`(내 대화·184ms)
- `/api/conversations?...&include_agent_conversations=true`(전체/에이전트·**663ms**)
- → 채팅리스트 settle **~800ms**.

**병목:** 뒤 둘은 **비기본 탭(agent)** 데이터인데 admin 이면 mount 시 **eager fetch** → 사용자가 안 본 탭에 663ms 낭비. role 도 서버 `/api/v2/me` 에 이미 있는데 클라서 재호출.

(보드 5× per-column `/api/stories` 는 **concurrent라 latency-neutral**로 측정돼 PO 결정상 이번 스코프 제외 — 서버부하가 측정될 때 별 backlog.)

## fix (측정이 가리킨 #1만)

- **role → DashboardContext**: `layout` 의 `/api/v2/me`(이미 fetch) 에서 role 투영(MemberContext·DashboardShell·context 에 `role` 추가). 채팅 진입마다 `/api/me` round-trip 제거. `_effective_role` 동일값이라 admin 게이트 의미 보존.
- **agent 탭 lazy-load**: mount eager 대신 **탭 첫 활성화 1회**(`Tabs onValueChange` + `agentLoadedRef` 가드). SSE 의 `allConversations` reactive 갱신도 탭 오픈 전엔 스킵(lazy 유지·탭 오픈 시 최신본 수신이라 누락 0).

→ 채팅 진입 API **3콜 → 1콜**(기본 "내 대화"만).

## 가설 + measure_after

- **가설: 채팅 진입 데이터 settle ~800ms → ~250ms** (eager 663ms + /me 75ms 제거, 기본 탭 my-list 184ms만 남음).
- **measure_after**: 머지·dev 배포 후 동일 puppeteer 시나리오(보드→채팅 전환, 진입 API settle) 재측정으로 Zms 실증해 닫음.

## 검증

- `pnpm type-check` ✅ / `pnpm lint`(대상 3파일) ✅ / `pnpm build` ✅ EXIT 0
- base=`origin/develop`(`66894556`)

라이브 픽셀/재측정은 dev 배포 후 까심 QA → 머지게이트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)