### PR TITLE
feat(chat): 첨부 문서 텍스트 추출 → 에이전트 컨텍스트 주입 (R2 S1)

### DIFF
--- a/backend/app/services/attachment_context.py
+++ b/backend/app/services/attachment_context.py
@@ -1,0 +1,143 @@
+"""채팅 첨부 → 에이전트 컨텍스트 텍스트 추출 (R2 S1, story 9d130c01 / af66acee).
+
+문서(pdf/docx/txt/csv/md) 텍스트를 추출해 에이전트-facing content 에 주입할 텍스트 블록으로
+변환한다. 이미지·미지원 형식은 안내 라인. 블루프린트 §3 결정 = **백엔드 텍스트 추출·균일 주입**
+(이질 런타임에 런타임 무변경으로 균일 적용). 이미지 Vision 캡션은 S2.
+
+§7 결정 반영: 추출 v1=pdf/docx/txt/csv/md · cap 첨부당 8k자/총 24k자·truncate 표시 ·
+GCS 서비스계정 직접 read · 보안=기존 authorize 전달 경로(webhook/SSE→참가자) 상속(추가검증 불요).
+
+⚠️ 배포 전제(infra/PO lane): 백엔드 서비스계정에 버킷 read 권한 + google-cloud-storage·pypdf·
+python-docx 의존 설치(pyproject). GCS fetch 실패/미지원은 best-effort(전달 무영향·안내 라인).
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_BUCKET = os.environ.get("GCS_MEMO_ATTACHMENTS_BUCKET", "sprintable-memo-attachments")
+_PUBLIC_PREFIX = f"https://storage.googleapis.com/{_BUCKET}/"
+
+_PER_ATTACHMENT_CAP = 8000   # §7-3 첨부당 자수 cap
+_TOTAL_CAP = 24000           # §7-3 총합 cap
+_TRUNC_MARK = "…(잘림)"
+
+_DOC_EXTS = frozenset({"pdf", "docx", "txt", "csv", "md"})
+_IMAGE_EXTS = frozenset({"jpg", "jpeg", "png", "gif", "webp"})
+_HEADER = "\n\n--- 첨부 내용 ---\n"
+
+
+def _canonical_object_path(stored_url: str) -> str | None:
+    """stored attachment url → canonical GCS object path. 우리 버킷 외/비정상이면 None.
+
+    attachments.py 의 동일 규칙(신규=bare path·legacy=public prefix·외부 도메인=None).
+    """
+    if not stored_url:
+        return None
+    if stored_url.startswith(_PUBLIC_PREFIX):
+        return stored_url[len(_PUBLIC_PREFIX):]
+    if "://" in stored_url:
+        return None
+    return stored_url
+
+
+def _ext(name: str) -> str:
+    return name.rsplit(".", 1)[-1].lower() if "." in name else ""
+
+
+async def _download_object(object_path: str) -> bytes:
+    """GCS 객체 bytes 다운로드 — 서비스계정(ADC) 직접 read. blocking client 는 thread 로 격리."""
+
+    def _blocking() -> bytes:
+        from google.cloud import storage  # 지연 import(의존 없을 때 모듈 로드 무영향)
+
+        client = storage.Client()
+        return client.bucket(_BUCKET).blob(object_path).download_as_bytes()
+
+    return await asyncio.to_thread(_blocking)
+
+
+def _extract_text(ext: str, data: bytes) -> str:
+    """확장자별 텍스트 추출. 미지원/실패 시 빈 문자열."""
+    if ext in ("txt", "csv", "md"):
+        return data.decode("utf-8", errors="replace")
+    if ext == "pdf":
+        from pypdf import PdfReader
+
+        reader = PdfReader(io.BytesIO(data))
+        return "\n".join((page.extract_text() or "") for page in reader.pages)
+    if ext == "docx":
+        import docx  # python-docx
+
+        document = docx.Document(io.BytesIO(data))
+        return "\n".join(p.text for p in document.paragraphs)
+    return ""
+
+
+def _cap(text: str, limit: int) -> str:
+    if limit <= 0:
+        return ""
+    if len(text) <= limit:
+        return text
+    return text[:limit] + _TRUNC_MARK
+
+
+async def build_attachment_context(attachments: list[dict] | None) -> str:
+    """메시지 attachments(list of {url,name,content_type,size}) → 에이전트 주입용 텍스트 블록.
+
+    문서=GCS fetch+추출, 이미지=메타 안내(v1), 미지원/실패=안내 라인. 총량 cap 도달 시 중단.
+    빈 결과면 "" (주입 무영향). best-effort — 개별 첨부 실패는 안내 라인으로 흡수.
+    """
+    if not attachments:
+        return ""
+    blocks: list[str] = []
+    total = 0
+    for a in attachments:
+        if not isinstance(a, dict):
+            continue
+        name = (a.get("name") or "첨부").strip() or "첨부"
+        ctype = (a.get("content_type") or "").strip()
+        ext = _ext(name)
+
+        # 이미지 — v1 은 메타 안내(본격 분석=S2 백엔드 Vision 캡션)
+        if ctype.startswith("image/") or ext in _IMAGE_EXTS:
+            blocks.append(f"[이미지 첨부: {name} ({ctype or 'image'}) — 이미지 분석은 준비 중]")
+            continue
+
+        # 미지원 형식 안내
+        if ext not in _DOC_EXTS:
+            blocks.append(f"[첨부(미지원 형식): {name} ({ctype or ext or 'unknown'})]")
+            continue
+
+        obj = _canonical_object_path(a.get("url") or "")
+        if obj is None:
+            blocks.append(f"[첨부(읽기 불가 경로): {name}]")
+            continue
+
+        try:
+            data = await _download_object(obj)
+            text = _extract_text(ext, data).strip()
+        except Exception:
+            logger.warning("attachment_context: 추출 실패 name=%s", name, exc_info=True)
+            blocks.append(f"[첨부(추출 실패): {name}]")
+            continue
+
+        if not text:
+            blocks.append(f"[첨부: {name} — 추출 텍스트 없음]")
+            continue
+
+        remaining = _TOTAL_CAP - total
+        capped = _cap(text, min(_PER_ATTACHMENT_CAP, remaining))
+        total += len(capped)
+        blocks.append(f"[첨부: {name}]\n{capped}")
+        if total >= _TOTAL_CAP:
+            blocks.append("[…첨부 컨텍스트 총량 한도 도달 — 이후 첨부 생략]")
+            break
+
+    if not blocks:
+        return ""
+    return _HEADER + "\n\n".join(blocks)

--- a/backend/app/services/attachment_context.py
+++ b/backend/app/services/attachment_context.py
@@ -131,7 +131,8 @@ async def build_attachment_context(
         """line 추가. 총량(헤더+블록+구분자+마커) 한도 초과면 한도 라인(자리 있으면) 후 중단(False)."""
         nonlocal total
         sep = 2 if blocks else 0  # "\n\n" join
-        if blocks and total + sep + len(line) > _TOTAL_CAP:
+        # QA RC LOW: blocks 가드 제거 — 첫 첨부(blocks 빈)도 overflow 체크(긴 파일명 첫 라인 24k 초과 방지).
+        if total + sep + len(line) > _TOTAL_CAP:
             marker = "[…첨부 컨텍스트 총량 한도 도달 — 이후 첨부 생략]"
             if total + sep + len(marker) <= _TOTAL_CAP:  # 마커도 한도 내일 때만(총량 엄수)
                 blocks.append(marker)

--- a/backend/app/services/attachment_context.py
+++ b/backend/app/services/attachment_context.py
@@ -49,6 +49,25 @@ def _ext(name: str) -> str:
     return name.rsplit(".", 1)[-1].lower() if "." in name else ""
 
 
+def _is_scoped_to_conversation(object_path: str, project_id, conversation_id) -> bool:
+    """canonical object path 가 **이 대화**에 스코프됐는지(`chat/<project_id>/<conversation_id>/<file>`).
+
+    ⚠️ 보안(QA RC HIGH·object-scope IDOR): 저장 URL 을 그대로 믿고 fetch 하면, 참가자가 *타 대화*
+    객체 URL 을 첨부에 심어 백엔드 SA(objectAdmin) 권한으로 임의 객체를 읽어 그 내용을 에이전트
+    컨텍스트로 누출시킬 수 있다(attachments.py 스코프 게이트 우회). 업로드 경로가 resource 에
+    스코프되므로(`chat/<proj>/<conv>/<file>`), path segment 가 정확히 이 conversation 을 가리킬
+    때만 fetch 한다(substring 금지·정확 segment 매치). 다른 conversation/story/외부 = 거부.
+    """
+    parts = object_path.split("/")
+    return (
+        len(parts) >= 4
+        and parts[0] == "chat"
+        and parts[1] == str(project_id)
+        and parts[2] == str(conversation_id)
+        and parts[3] != ""
+    )
+
+
 async def _download_object(object_path: str) -> bytes:
     """GCS 객체 bytes 다운로드 — 서비스계정(ADC) 직접 read. blocking client 는 thread 로 격리."""
 
@@ -79,23 +98,49 @@ def _extract_text(ext: str, data: bytes) -> str:
 
 
 def _cap(text: str, limit: int) -> str:
+    """text 를 limit 자 이내로 — 잘릴 때 마커 포함 길이도 limit 이내(QA RC LOW: 마커 미카운트로
+    총량 초과 방지)."""
     if limit <= 0:
         return ""
     if len(text) <= limit:
         return text
-    return text[:limit] + _TRUNC_MARK
+    keep = max(0, limit - len(_TRUNC_MARK))
+    return text[:keep] + _TRUNC_MARK
 
 
-async def build_attachment_context(attachments: list[dict] | None) -> str:
+async def build_attachment_context(
+    attachments: list[dict] | None,
+    *,
+    project_id,
+    conversation_id,
+) -> str:
     """메시지 attachments(list of {url,name,content_type,size}) → 에이전트 주입용 텍스트 블록.
 
-    문서=GCS fetch+추출, 이미지=메타 안내(v1), 미지원/실패=안내 라인. 총량 cap 도달 시 중단.
-    빈 결과면 "" (주입 무영향). best-effort — 개별 첨부 실패는 안내 라인으로 흡수.
+    문서=GCS fetch+추출, 이미지=메타 안내(v1), 미지원/실패=안내 라인. 총량 cap(헤더·마커·안내 라인
+    포함)·도달 시 중단. 빈 결과면 "" (주입 무영향). best-effort — 개별 첨부 실패는 안내 라인으로 흡수.
+
+    ⚠️ 보안: 문서 fetch 는 object path 가 **이 (project, conversation)에 스코프된 chat 첨부**일
+    때만 수행(_is_scoped_to_conversation). 타 대화/외부 객체 URL 은 거부(IDOR 차단·QA RC HIGH).
     """
     if not attachments:
         return ""
     blocks: list[str] = []
-    total = 0
+    total = len(_HEADER)  # 헤더도 총량에 카운트(LOW)
+
+    def _append(line: str) -> bool:
+        """line 추가. 총량(헤더+블록+구분자+마커) 한도 초과면 한도 라인(자리 있으면) 후 중단(False)."""
+        nonlocal total
+        sep = 2 if blocks else 0  # "\n\n" join
+        if blocks and total + sep + len(line) > _TOTAL_CAP:
+            marker = "[…첨부 컨텍스트 총량 한도 도달 — 이후 첨부 생략]"
+            if total + sep + len(marker) <= _TOTAL_CAP:  # 마커도 한도 내일 때만(총량 엄수)
+                blocks.append(marker)
+                total += sep + len(marker)
+            return False
+        blocks.append(line)
+        total += sep + len(line)
+        return True
+
     for a in attachments:
         if not isinstance(a, dict):
             continue
@@ -105,17 +150,21 @@ async def build_attachment_context(attachments: list[dict] | None) -> str:
 
         # 이미지 — v1 은 메타 안내(본격 분석=S2 백엔드 Vision 캡션)
         if ctype.startswith("image/") or ext in _IMAGE_EXTS:
-            blocks.append(f"[이미지 첨부: {name} ({ctype or 'image'}) — 이미지 분석은 준비 중]")
+            if not _append(f"[이미지 첨부: {name} ({ctype or 'image'}) — 이미지 분석은 준비 중]"):
+                break
             continue
 
         # 미지원 형식 안내
         if ext not in _DOC_EXTS:
-            blocks.append(f"[첨부(미지원 형식): {name} ({ctype or ext or 'unknown'})]")
+            if not _append(f"[첨부(미지원 형식): {name} ({ctype or ext or 'unknown'})]"):
+                break
             continue
 
         obj = _canonical_object_path(a.get("url") or "")
-        if obj is None:
-            blocks.append(f"[첨부(읽기 불가 경로): {name}]")
+        # ⚠️ 보안: 우리 버킷 객체 + 이 대화에 스코프된 path 만 fetch(타 대화/story/외부 거부)
+        if obj is None or not _is_scoped_to_conversation(obj, project_id, conversation_id):
+            if not _append(f"[첨부(접근 범위 밖): {name}]"):
+                break
             continue
 
         try:
@@ -123,19 +172,24 @@ async def build_attachment_context(attachments: list[dict] | None) -> str:
             text = _extract_text(ext, data).strip()
         except Exception:
             logger.warning("attachment_context: 추출 실패 name=%s", name, exc_info=True)
-            blocks.append(f"[첨부(추출 실패): {name}]")
+            if not _append(f"[첨부(추출 실패): {name}]"):
+                break
             continue
 
         if not text:
-            blocks.append(f"[첨부: {name} — 추출 텍스트 없음]")
+            if not _append(f"[첨부: {name} — 추출 텍스트 없음]"):
+                break
             continue
 
-        remaining = _TOTAL_CAP - total
+        # per-attachment cap + 남은 총량 내로(마커 포함 길이 _cap 이 보장)
+        prefix = f"[첨부: {name}]\n"
+        remaining = _TOTAL_CAP - total - (2 if blocks else 0) - len(prefix)
         capped = _cap(text, min(_PER_ATTACHMENT_CAP, remaining))
-        total += len(capped)
-        blocks.append(f"[첨부: {name}]\n{capped}")
-        if total >= _TOTAL_CAP:
-            blocks.append("[…첨부 컨텍스트 총량 한도 도달 — 이후 첨부 생략]")
+        if not capped:
+            if not _append(f"[첨부: {name} — 총량 한도로 생략]"):
+                break
+            continue
+        if not _append(prefix + capped):
             break
 
     if not blocks:

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -250,9 +250,10 @@ async def deliver_conversation_message_webhook(
                 )).scalar_one_or_none()
 
             # R2 S1(9d130c01): 첨부 내용을 에이전트-facing content 에 주입(균일·런타임 무변경).
-            # 기존 authorize 된 전달 경로(이 webhook=참가자 대상)에 그대로 올라타므로 추가 검증 불요.
-            # best-effort — 조회/추출 실패는 전달에 무영향(원 content 유지).
-            effective_content = content or ""
+            # 기존 authorize 된 전달 경로(이 webhook=참가자 대상)에 올라타고, fetch 는 이 대화에
+            # 스코프된 객체만(IDOR 차단). best-effort — 조회/추출 실패는 전달에 무영향.
+            # MED(QA RC): 주입 없으면 원 content 그대로 보존(None→"" 변환 금지 — 기존 거동 무변경).
+            effective_content = content
             try:
                 from app.models.conversation import ConversationMessage
                 _atts = (await db.execute(
@@ -262,9 +263,12 @@ async def deliver_conversation_message_webhook(
                 )).scalar_one_or_none()
                 if _atts:
                     from app.services.attachment_context import build_attachment_context
-                    _ctx = await build_attachment_context(_atts)
+                    _ctx = await build_attachment_context(
+                        _atts, project_id=project_id, conversation_id=conversation_id
+                    )
                     if _ctx:
-                        effective_content = (effective_content + _ctx) if effective_content else _ctx.lstrip()
+                        _base = content or ""
+                        effective_content = (_base + _ctx) if _base else _ctx.lstrip()
                         logger.info(
                             "attachment_context injected message_id=%s attachment_count=%d",
                             message_id, len(_atts),

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -248,6 +248,32 @@ async def deliver_conversation_message_webhook(
                 sender_name = (await db.execute(
                     select(TeamMember.name).where(TeamMember.id == sender_id)
                 )).scalar_one_or_none()
+
+            # R2 S1(9d130c01): 첨부 내용을 에이전트-facing content 에 주입(균일·런타임 무변경).
+            # 기존 authorize 된 전달 경로(이 webhook=참가자 대상)에 그대로 올라타므로 추가 검증 불요.
+            # best-effort — 조회/추출 실패는 전달에 무영향(원 content 유지).
+            effective_content = content or ""
+            try:
+                from app.models.conversation import ConversationMessage
+                _atts = (await db.execute(
+                    select(ConversationMessage.attachments).where(
+                        ConversationMessage.id == message_id
+                    )
+                )).scalar_one_or_none()
+                if _atts:
+                    from app.services.attachment_context import build_attachment_context
+                    _ctx = await build_attachment_context(_atts)
+                    if _ctx:
+                        effective_content = (effective_content + _ctx) if effective_content else _ctx.lstrip()
+                        logger.info(
+                            "attachment_context injected message_id=%s attachment_count=%d",
+                            message_id, len(_atts),
+                        )
+            except Exception:
+                logger.warning(
+                    "attachment_context injection failed message_id=%s", message_id, exc_info=True
+                )
+
             payload = {
                 "event_type": _EVENT_TYPE,
                 "message_id": str(message_id),
@@ -256,7 +282,7 @@ async def deliver_conversation_message_webhook(
                 "thread_id": str(thread_id) if thread_id else None,
                 "created_at": created_at.isoformat(),
                 "mentioned_ids": mentioned_id_strs,
-                "content": content,
+                "content": effective_content,
                 # d0bca260: BYOA 어댑터 컨텍스트(additive top-level).
                 "project_id": str(project_id),
                 "org_id": str(org_id),

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -22,6 +22,10 @@ dependencies = [
     "mcp>=1.0.0",
     "resend>=2.0.0",
     "google-analytics-data>=0.18.0",
+    # R2 채팅 첨부 AI 컨텍스트(9d130c01): GCS 서비스계정 read + 문서 텍스트 추출
+    "google-cloud-storage>=2.18.0",
+    "pypdf>=5.0.0",
+    "python-docx>=1.1.0",
 ]
 
 [dependency-groups]

--- a/backend/tests/test_attachment_context.py
+++ b/backend/tests/test_attachment_context.py
@@ -1,0 +1,114 @@
+"""R2 S1: attachment_context.build_attachment_context — 분류/추출/cap/안내 (GCS·추출 mock)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _att(name, content_type="", url=None):
+    return {"name": name, "content_type": content_type, "url": url or f"chat/p/c/{name}", "size": 1}
+
+
+@pytest.mark.anyio
+async def test_empty_returns_blank():
+    from app.services import attachment_context as ac
+
+    assert await ac.build_attachment_context(None) == ""
+    assert await ac.build_attachment_context([]) == ""
+
+
+@pytest.mark.anyio
+async def test_image_meta_line_no_fetch(monkeypatch):
+    from app.services import attachment_context as ac
+
+    fetch = AsyncMock()
+    monkeypatch.setattr(ac, "_download_object", fetch)
+    out = await ac.build_attachment_context([_att("chart.png", "image/png")])
+    assert "이미지 첨부: chart.png" in out
+    fetch.assert_not_awaited()  # 이미지는 v1 fetch 안 함
+
+
+@pytest.mark.anyio
+async def test_unsupported_format_line(monkeypatch):
+    from app.services import attachment_context as ac
+
+    fetch = AsyncMock()
+    monkeypatch.setattr(ac, "_download_object", fetch)
+    out = await ac.build_attachment_context([_att("data.bin", "application/octet-stream")])
+    assert "미지원 형식): data.bin" in out
+    fetch.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_doc_extraction_injected(monkeypatch):
+    from app.services import attachment_context as ac
+
+    monkeypatch.setattr(ac, "_download_object", AsyncMock(return_value=b"x"))
+    monkeypatch.setattr(ac, "_extract_text", MagicMock(return_value="hello world"))
+    out = await ac.build_attachment_context([_att("report.pdf", "application/pdf")])
+    assert "--- 첨부 내용 ---" in out
+    assert "[첨부: report.pdf]" in out
+    assert "hello world" in out
+
+
+@pytest.mark.anyio
+async def test_per_attachment_cap_truncates(monkeypatch):
+    from app.services import attachment_context as ac
+
+    monkeypatch.setattr(ac, "_download_object", AsyncMock(return_value=b"x"))
+    monkeypatch.setattr(ac, "_extract_text", MagicMock(return_value="a" * 9000))
+    out = await ac.build_attachment_context([_att("big.txt", "text/plain")])
+    assert ac._TRUNC_MARK in out
+    # 본문은 per-attachment cap(8000) 이하 + 표시
+    body = out.split("[첨부: big.txt]\n", 1)[1]
+    assert len(body) <= ac._PER_ATTACHMENT_CAP + len(ac._TRUNC_MARK)
+
+
+@pytest.mark.anyio
+async def test_total_cap_stops(monkeypatch):
+    from app.services import attachment_context as ac
+
+    monkeypatch.setattr(ac, "_download_object", AsyncMock(return_value=b"x"))
+    monkeypatch.setattr(ac, "_extract_text", MagicMock(return_value="a" * 8000))
+    atts = [_att(f"d{i}.txt", "text/plain") for i in range(4)]
+    out = await ac.build_attachment_context(atts)
+    assert "총량 한도 도달" in out
+    assert "d3.txt" not in out  # 총량 도달로 4번째 생략
+
+
+@pytest.mark.anyio
+async def test_fetch_failure_guidance(monkeypatch):
+    from app.services import attachment_context as ac
+
+    monkeypatch.setattr(ac, "_download_object", AsyncMock(side_effect=RuntimeError("gcs down")))
+    out = await ac.build_attachment_context([_att("report.pdf", "application/pdf")])
+    assert "추출 실패): report.pdf" in out
+
+
+@pytest.mark.anyio
+async def test_empty_text_guidance(monkeypatch):
+    from app.services import attachment_context as ac
+
+    monkeypatch.setattr(ac, "_download_object", AsyncMock(return_value=b""))
+    monkeypatch.setattr(ac, "_extract_text", MagicMock(return_value="   "))
+    out = await ac.build_attachment_context([_att("empty.txt", "text/plain")])
+    assert "추출 텍스트 없음" in out
+
+
+@pytest.mark.anyio
+async def test_external_url_unreadable(monkeypatch):
+    from app.services import attachment_context as ac
+
+    fetch = AsyncMock()
+    monkeypatch.setattr(ac, "_download_object", fetch)
+    out = await ac.build_attachment_context(
+        [{"name": "x.txt", "content_type": "text/plain", "url": "https://evil.com/x.txt"}]
+    )
+    assert "읽기 불가 경로): x.txt" in out
+    fetch.assert_not_awaited()

--- a/backend/tests/test_attachment_context.py
+++ b/backend/tests/test_attachment_context.py
@@ -145,6 +145,18 @@ async def test_total_cap_includes_markers_and_stops(monkeypatch):
 
 
 @pytest.mark.anyio
+async def test_first_line_overflow_bounded(monkeypatch):
+    """QA RC LOW: 첫 첨부(blocks 빈) 라인이 24k 초과해도 총량 ≤ cap (blocks 가드 제거 검증).
+    긴 파일명 이미지 라인(미fetch)으로 첫 라인만으로 초과 유발."""
+    from app.services import attachment_context as ac
+
+    monkeypatch.setattr(ac, "_download_object", AsyncMock())
+    huge_name = "x" * (ac._TOTAL_CAP + 5000) + ".png"
+    out = await _build(ac, [_att(huge_name, "image/png")])
+    assert len(out) <= ac._TOTAL_CAP  # 첫 라인도 한도 엄수
+
+
+@pytest.mark.anyio
 async def test_fetch_failure_guidance(monkeypatch):
     from app.services import attachment_context as ac
 

--- a/backend/tests/test_attachment_context.py
+++ b/backend/tests/test_attachment_context.py
@@ -1,9 +1,12 @@
-"""R2 S1: attachment_context.build_attachment_context — 분류/추출/cap/안내 (GCS·추출 mock)."""
+"""R2 S1: attachment_context.build_attachment_context — 분류/추출/cap/스코프(IDOR) (GCS·추출 mock)."""
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
+PROJ = "proj1"
+CONV = "conv1"
 
 
 @pytest.fixture
@@ -12,15 +15,26 @@ def anyio_backend():
 
 
 def _att(name, content_type="", url=None):
-    return {"name": name, "content_type": content_type, "url": url or f"chat/p/c/{name}", "size": 1}
+    return {
+        "name": name,
+        "content_type": content_type,
+        "url": url if url is not None else f"chat/{PROJ}/{CONV}/{name}",
+        "size": 1,
+    }
+
+
+async def _build(ac, attachments):
+    return await ac.build_attachment_context(
+        attachments, project_id=PROJ, conversation_id=CONV
+    )
 
 
 @pytest.mark.anyio
 async def test_empty_returns_blank():
     from app.services import attachment_context as ac
 
-    assert await ac.build_attachment_context(None) == ""
-    assert await ac.build_attachment_context([]) == ""
+    assert await _build(ac, None) == ""
+    assert await _build(ac, []) == ""
 
 
 @pytest.mark.anyio
@@ -29,9 +43,9 @@ async def test_image_meta_line_no_fetch(monkeypatch):
 
     fetch = AsyncMock()
     monkeypatch.setattr(ac, "_download_object", fetch)
-    out = await ac.build_attachment_context([_att("chart.png", "image/png")])
+    out = await _build(ac, [_att("chart.png", "image/png")])
     assert "이미지 첨부: chart.png" in out
-    fetch.assert_not_awaited()  # 이미지는 v1 fetch 안 함
+    fetch.assert_not_awaited()
 
 
 @pytest.mark.anyio
@@ -40,7 +54,7 @@ async def test_unsupported_format_line(monkeypatch):
 
     fetch = AsyncMock()
     monkeypatch.setattr(ac, "_download_object", fetch)
-    out = await ac.build_attachment_context([_att("data.bin", "application/octet-stream")])
+    out = await _build(ac, [_att("data.bin", "application/octet-stream")])
     assert "미지원 형식): data.bin" in out
     fetch.assert_not_awaited()
 
@@ -51,10 +65,59 @@ async def test_doc_extraction_injected(monkeypatch):
 
     monkeypatch.setattr(ac, "_download_object", AsyncMock(return_value=b"x"))
     monkeypatch.setattr(ac, "_extract_text", MagicMock(return_value="hello world"))
-    out = await ac.build_attachment_context([_att("report.pdf", "application/pdf")])
+    out = await _build(ac, [_att("report.pdf", "application/pdf")])
     assert "--- 첨부 내용 ---" in out
     assert "[첨부: report.pdf]" in out
     assert "hello world" in out
+
+
+# ── 보안(QA RC HIGH·object-scope IDOR) ───────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_other_conversation_url_rejected_no_fetch(monkeypatch):
+    """타 대화 객체 URL 첨부 → 스코프 밖 → fetch 안 함·거부 라인(IDOR 차단)."""
+    from app.services import attachment_context as ac
+
+    fetch = AsyncMock(return_value=b"secret")
+    monkeypatch.setattr(ac, "_download_object", fetch)
+    # 같은 project 지만 *다른 conversation* 객체를 첨부에 심음
+    out = await _build(
+        ac, [_att("leak.pdf", "application/pdf", url=f"chat/{PROJ}/OTHERCONV/leak.pdf")]
+    )
+    assert "접근 범위 밖): leak.pdf" in out
+    assert "secret" not in out
+    fetch.assert_not_awaited()  # 스코프 밖은 다운로드 자체를 안 함
+
+
+@pytest.mark.anyio
+async def test_external_url_rejected(monkeypatch):
+    from app.services import attachment_context as ac
+
+    fetch = AsyncMock()
+    monkeypatch.setattr(ac, "_download_object", fetch)
+    out = await _build(
+        ac, [{"name": "x.txt", "content_type": "text/plain", "url": "https://evil.com/x.txt"}]
+    )
+    assert "접근 범위 밖): x.txt" in out
+    fetch.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_story_path_rejected(monkeypatch):
+    """story 첨부 경로(chat 아님)도 이 대화 스코프 밖 → 거부."""
+    from app.services import attachment_context as ac
+
+    fetch = AsyncMock()
+    monkeypatch.setattr(ac, "_download_object", fetch)
+    out = await _build(
+        ac, [_att("s.pdf", "application/pdf", url=f"story/{PROJ}/story123/s.pdf")]
+    )
+    assert "접근 범위 밖): s.pdf" in out
+    fetch.assert_not_awaited()
+
+
+# ── cap (QA RC LOW: 마커·헤더 포함 총량) ──────────────────────────────────────
 
 
 @pytest.mark.anyio
@@ -63,23 +126,22 @@ async def test_per_attachment_cap_truncates(monkeypatch):
 
     monkeypatch.setattr(ac, "_download_object", AsyncMock(return_value=b"x"))
     monkeypatch.setattr(ac, "_extract_text", MagicMock(return_value="a" * 9000))
-    out = await ac.build_attachment_context([_att("big.txt", "text/plain")])
+    out = await _build(ac, [_att("big.txt", "text/plain")])
     assert ac._TRUNC_MARK in out
-    # 본문은 per-attachment cap(8000) 이하 + 표시
     body = out.split("[첨부: big.txt]\n", 1)[1]
-    assert len(body) <= ac._PER_ATTACHMENT_CAP + len(ac._TRUNC_MARK)
+    assert len(body) <= ac._PER_ATTACHMENT_CAP  # 마커 포함 cap 이내
 
 
 @pytest.mark.anyio
-async def test_total_cap_stops(monkeypatch):
+async def test_total_cap_includes_markers_and_stops(monkeypatch):
     from app.services import attachment_context as ac
 
     monkeypatch.setattr(ac, "_download_object", AsyncMock(return_value=b"x"))
     monkeypatch.setattr(ac, "_extract_text", MagicMock(return_value="a" * 8000))
-    atts = [_att(f"d{i}.txt", "text/plain") for i in range(4)]
-    out = await ac.build_attachment_context(atts)
-    assert "총량 한도 도달" in out
-    assert "d3.txt" not in out  # 총량 도달로 4번째 생략
+    atts = [_att(f"d{i}.txt", "text/plain") for i in range(5)]
+    out = await _build(ac, atts)
+    assert len(out) <= ac._TOTAL_CAP  # 헤더·마커·구분자 포함 총량 엄수
+    assert "d4.txt" not in out  # 총량 한도로 후속 첨부 생략(누적 중단)
 
 
 @pytest.mark.anyio
@@ -87,7 +149,7 @@ async def test_fetch_failure_guidance(monkeypatch):
     from app.services import attachment_context as ac
 
     monkeypatch.setattr(ac, "_download_object", AsyncMock(side_effect=RuntimeError("gcs down")))
-    out = await ac.build_attachment_context([_att("report.pdf", "application/pdf")])
+    out = await _build(ac, [_att("report.pdf", "application/pdf")])
     assert "추출 실패): report.pdf" in out
 
 
@@ -97,18 +159,5 @@ async def test_empty_text_guidance(monkeypatch):
 
     monkeypatch.setattr(ac, "_download_object", AsyncMock(return_value=b""))
     monkeypatch.setattr(ac, "_extract_text", MagicMock(return_value="   "))
-    out = await ac.build_attachment_context([_att("empty.txt", "text/plain")])
+    out = await _build(ac, [_att("empty.txt", "text/plain")])
     assert "추출 텍스트 없음" in out
-
-
-@pytest.mark.anyio
-async def test_external_url_unreadable(monkeypatch):
-    from app.services import attachment_context as ac
-
-    fetch = AsyncMock()
-    monkeypatch.setattr(ac, "_download_object", fetch)
-    out = await ac.build_attachment_context(
-        [{"name": "x.txt", "content_type": "text/plain", "url": "https://evil.com/x.txt"}]
-    )
-    assert "읽기 불가 경로): x.txt" in out
-    fetch.assert_not_awaited()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -515,6 +515,71 @@ wheels = [
 ]
 
 [[package]]
+name = "google-cloud-core"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/dd/1eef226e470369b26824a505c34482c0b493bc35fe8e0c6b003b5feca21a/google_cloud_core-2.6.0.tar.gz", hash = "sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83", size = 36001, upload-time = "2026-05-07T08:04:04.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl", hash = "sha256:6d63ac8e5eca6d9e4319d0a1e2265fadcd7f1049904378caecfa01cf52dd869e", size = 29390, upload-time = "2026-05-07T08:02:34.672Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "3.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/72/86f94e1639a8bcd9d33e8e01b49afcaa1c3a13bda7683c681717e0901e15/google_cloud_storage-3.12.0.tar.gz", hash = "sha256:03ae9847c6babb368f35f054126b8a08cbc0e3266efb990eb17b9926a45cf3be", size = 17338620, upload-time = "2026-06-12T18:03:29.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/bd/a89eaebd2f9db5f92ddcc8e4f23c266be1dbd11058bb83451d8dd029f34c/google_cloud_storage-3.12.0-py3-none-any.whl", hash = "sha256:3880773754ddf7c27567b04e2a4d193950b6b99429f37b9097d873686e95b09c", size = 340605, upload-time = "2026-06-12T18:03:12.677Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/f8/1ca5781d6be9cb9f73f7d40f4958c4bd1226a60598e3e39e1d6aaf838c4b/google_resumable_media-2.10.0.tar.gz", hash = "sha256:e324bc9d0fdae4c52a08ae90456edc4e71ece858399e1217ac0eb3a51d6bc6ee", size = 2164570, upload-time = "2026-06-03T16:14:26.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/d8/00c6854ac1512bb9eaf13bd3f8f28222f7674947fc510a4ff7616f2efc80/google_resumable_media-2.10.0-py3-none-any.whl", hash = "sha256:88152884bee37b2bf36a0ab81ad8c7fd12212c9803dd981d77c1b35b02d34e7c", size = 81533, upload-time = "2026-06-03T16:13:12.51Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
@@ -760,6 +825,86 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/6e/c4add832b6fc1e887125b96f880d7b9b70aae5248718e046b1704bcac4b9/lxml-6.1.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:104c09bda8d2a562824c0e319d0768ce26a779b7601e0931d33b09b53c392ef7", size = 8570821, upload-time = "2026-05-18T19:17:42.068Z" },
+    { url = "https://files.pythonhosted.org/packages/22/00/ff3009c88e65de8011630acf8ab5a09cb2becd2aaf47fba2f3449f6224e9/lxml-6.1.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25c6997a9a534e016695a0ba06b2f07945de682731ff01065b6d5a4474179da1", size = 4624252, upload-time = "2026-05-18T19:17:47.897Z" },
+    { url = "https://files.pythonhosted.org/packages/42/95/bb63f0fd62e554fe078e1fb3c8fe9083c14ddc7ad7fa178d10e57e071ac7/lxml-6.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c921ba5c51e4e9f63b8b00267d06566e1f63407408a0496da2d1d0bfc819c7fc", size = 4930746, upload-time = "2026-05-18T19:18:29.637Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/99/0013e8d9b5960f4f041cf0b73e2f80c23eb5205b1f7bfb20203243651359/lxml-6.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:54a7f95e4de5fb94e2f9f4b9055c6ba33bf3d628fd77a1d647c5923caa2cdcdc", size = 5093723, upload-time = "2026-05-18T19:18:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/29/91/317b332636bfc7bddcff828d41b3307f50043f4b237e40849c333d80fa1a/lxml-6.1.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f2ec43df44b1f76249ee0a615334f9b5b060e1c8bd90e706dad2d14d02f383", size = 5005557, upload-time = "2026-05-18T19:18:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/42/2f/cc9bf06afe70f9c9093ae60855d9759da9db601ec4080f7473319666ffd7/lxml-6.1.1-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:70ef8a7e102a1508f8121aae5b0867abd663f72c14f0a9c937e6554cb4587b7b", size = 5631036, upload-time = "2026-05-18T19:18:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f6/af32e23e563971ffb0fb86be52bc5be5c2c118858ffc119bf6a9039b173d/lxml-6.1.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ebe6af670449830d6d9b752c256a983291c766a1365ba5d5460048f9e33a7818", size = 5240367, upload-time = "2026-05-18T19:18:49.217Z" },
+    { url = "https://files.pythonhosted.org/packages/78/83/8555d40948b09ce86f1bd0c68a7ac31d07b1929f92cc1b074006c97ef2d2/lxml-6.1.1-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:27acc820660aaffa4f7c087f29120e12980f7779d56d8492d263170111284740", size = 5350171, upload-time = "2026-05-18T19:18:52.779Z" },
+    { url = "https://files.pythonhosted.org/packages/63/75/5d92da93729b7bad783689e6496049fa40927b45bec7bf183c981de3ca70/lxml-6.1.1-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:1db753c9115ec7100d073b744d17e25e88a8f90f5c39b2f5dd878149af59671f", size = 4694874, upload-time = "2026-05-18T19:18:55.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b5/3aad415a9a25b822e783f15deeb4dffccf5113030f1afa2222dd929313d9/lxml-6.1.1-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c4f469aebd783bb741c2ecb2a681008fd26bfe5c16a9a72ed5467f834e810df2", size = 5244492, upload-time = "2026-05-18T19:19:01.28Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a1/5fcf7eb9904b80086aa47dcf0027de07b1bb990afad2e6823144c368ae04/lxml-6.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:766b010012d59470072c1816b5b6c69f1d243e5db36ea5968e94accf430a4635", size = 5048232, upload-time = "2026-05-18T19:18:12.67Z" },
+    { url = "https://files.pythonhosted.org/packages/77/74/1f601b63c7a69fcdf10fa9b148c81da8442204194f6c55509cc485c786b9/lxml-6.1.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b8d812c6011c08b8111a15e54dd990b8923692d80adf35488bee34026c35accf", size = 4777023, upload-time = "2026-05-18T19:18:15.928Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/b9/7a78f51aec95b1bf780d78e12705a9f6533284f8693dc5c0e6724fa53d3f/lxml-6.1.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:fe0306bd29505a9177aac19f1877174b0e7422c222a59f70b2cd41633448c3dc", size = 5645773, upload-time = "2026-05-18T19:18:23.223Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6e/98a7b7ad54e4e74fa1f20fff776913980619d0ebe5558232d7da6580bdd8/lxml-6.1.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:5ba186ad207446c65d3bb3d3e0412b032b1d9f595e59861e2354798c5703d955", size = 5233088, upload-time = "2026-05-18T19:18:31.433Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d1/bc0ed2427bf609f2ee10da303a6a226f9c8bce94f945dc29a32ce55de6e4/lxml-6.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:aa366a1e55b8ebfe8ca8ddc3cfe75c8ebade181aeb0f661d0cb05986b647f72a", size = 5260995, upload-time = "2026-05-18T19:18:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/69/8b/6772e1a4b513fc50a8d931f19edde0e13ae6918510a1e13ff67864f3e5ed/lxml-6.1.1-cp312-cp312-win32.whl", hash = "sha256:126c93f7f56f0eda92f6d8c619edc463a4f23d9252f1c9d0405a76f25fa9f11a", size = 3596382, upload-time = "2026-05-18T19:17:18.37Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/89/45198e9624762af2dfd2cb8782598477ceb29f6e59caab560388ae1f4ec1/lxml-6.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:26e6eda8d38c1fcab1090dd196ee87cbd13788e531937610e2589085de074e77", size = 3997255, upload-time = "2026-05-18T19:17:56.781Z" },
+    { url = "https://files.pythonhosted.org/packages/90/a9/7a54b6834088d9ae528a7b780584ba6a39a9457b0ac330479f20ffbc9449/lxml-6.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:6540377fbd53fe1b629172288c464fb18db11ce1fa7dc15891da10aa9dcc3e7f", size = 3659610, upload-time = "2026-05-19T19:22:50.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780, upload-time = "2026-05-18T19:17:57.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006, upload-time = "2026-05-18T19:18:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139, upload-time = "2026-05-18T19:19:04.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329, upload-time = "2026-05-18T19:19:09.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564, upload-time = "2026-05-18T19:19:13.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467, upload-time = "2026-05-18T19:19:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304, upload-time = "2026-05-18T19:19:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607, upload-time = "2026-05-18T19:19:22.297Z" },
+    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168, upload-time = "2026-05-18T19:19:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487, upload-time = "2026-05-18T19:19:28.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231, upload-time = "2026-05-18T19:18:42.246Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450, upload-time = "2026-05-18T19:18:48.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874, upload-time = "2026-05-18T19:18:51.914Z" },
+    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987, upload-time = "2026-05-18T19:18:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276, upload-time = "2026-05-18T19:19:03.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
 ]
 
 [[package]]
@@ -1132,6 +1277,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pypdf"
+version = "6.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/0a/48fe05c6bb3aa4bb4d2a4079a383d33c0dfec1edf613a642f07d8b8b5c2e/pypdf-6.13.2.tar.gz", hash = "sha256:5a96a17dbdfbf9c2ab24c0a13fa0aba182be22ba6f283098712c16fc242f509f", size = 6479250, upload-time = "2026-06-10T16:42:34.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/17/378943705992f74e451a06de3401ce68e3213763c81e44d0614559c45599/pypdf-6.13.2-py3-none-any.whl", hash = "sha256:6eeb9e57693f29d41bd01255d02660cbbb41fd7fc818a982677389a35e4f2083", size = 346555, upload-time = "2026-06-10T16:42:32.37Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1183,6 +1337,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "python-docx"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/f7/eddfe33871520adab45aaa1a71f0402a2252050c14c7e3009446c8f4701c/python_docx-1.2.0.tar.gz", hash = "sha256:7bc9d7b7d8a69c9c02ca09216118c86552704edc23bac179283f2e38f86220ce", size = 5723256, upload-time = "2025-06-16T20:46:27.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/00/1e03a4989fa5795da308cd774f05b704ace555a70f9bf9d3be057b680bcf/python_docx-1.2.0-py3-none-any.whl", hash = "sha256:3fd478f3250fbbbfd3b94fe1e985955737c145627498896a8a6bf81f4baf66c7", size = 252987, upload-time = "2025-06-16T20:46:22.506Z" },
 ]
 
 [[package]]
@@ -1449,6 +1616,7 @@ dependencies = [
     { name = "asyncpg" },
     { name = "fastapi" },
     { name = "google-analytics-data" },
+    { name = "google-cloud-storage" },
     { name = "httpx" },
     { name = "mcp" },
     { name = "passlib", extra = ["argon2", "bcrypt"] },
@@ -1456,6 +1624,8 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyotp" },
+    { name = "pypdf" },
+    { name = "python-docx" },
     { name = "python-dotenv" },
     { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
@@ -1481,6 +1651,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "google-analytics-data", specifier = ">=0.18.0" },
+    { name = "google-cloud-storage", specifier = ">=2.18.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "passlib", extras = ["argon2", "bcrypt"], specifier = ">=1.7.4" },
@@ -1488,6 +1659,8 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pyotp", specifier = ">=2.9.0" },
+    { name = "pypdf", specifier = ">=5.0.0" },
+    { name = "python-docx", specifier = ">=1.1.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },


### PR DESCRIPTION
블루프린트(#1553) **S1** — R2 prod 회수(`9d130c01`·`af66acee`). 채팅 첨부 내용을 에이전트가 답변에 반영하도록 — **백엔드 텍스트 추출·균일 주입**(이질 런타임 무변경, §3 결정).

## 무엇
- 신규 `app/services/attachment_context.py` — `build_attachment_context(attachments)`:
  - **문서**(pdf/docx/txt/csv/md): GCS 서비스계정 fetch → 텍스트 추출 → 주입 블록.
  - **이미지**: v1 메타 안내(`[이미지 첨부: …]`) — 본격 Vision 캡션은 **S2**.
  - **미지원/실패/외부url**: 안내 라인(증상의 "미지원 형식 안내" 충족).
  - **cap**(§7-3): 첨부당 8k자·총 24k자·초과 시 `…(잘림)`·총량 도달 시 중단.
  - GCS=서비스계정 직접 read(§7-4)·blocking client는 `asyncio.to_thread` 격리·의존 lazy import.
- 주입 지점: `deliver_conversation_message_webhook`(**주 에이전트 전달 경로**=CC relay)에 **best-effort** 주입(실패는 전달 무영향). 기존 authorize 경로 상속이라 추가검증 불요(§7-5). 주입 시 metric 로그(`attachment_context injected …`).
- deps: `google-cloud-storage`·`pypdf`·`python-docx`(uv.lock 동기화).

## 검증
- 신규 `tests/test_attachment_context.py` 9: empty·이미지 메타(미fetch)·미지원·외부url·문서 추출·per/총 cap truncate·fetch 실패·빈 텍스트. (GCS·추출 mock — 실 lib/네트워크 불요.)
- app import OK + webhook 회귀(event_inject_webhook 등) **63 pass**.

## ⚠️ 배포 전제 (infra/PO lane)
1. 백엔드 **서비스계정에 버킷(`GCS_MEMO_ATTACHMENTS_BUCKET`) read 권한** 부여.
2. 이미지 컨테이너 빌드에 새 deps 설치(`uv sync` — Dockerfile 기존 흐름).

## 후속 (이 에픽)
- **SSE 경로 주입**(agent_gateway content) — webhook 외 SSE 수신 런타임 커버.
- **S2 이미지 Vision 캡션**(백엔드, §7-1=A) + **S3 메트릭 대시/판정**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)