### PR TITLE
feat(member-policy): can_manage_members enforcement → role 헬퍼 (S4 — 토대 완료)

### DIFF
--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -75,8 +75,10 @@ async def create_org_agent(
 
     actor = await _resolve_actor(auth, session, org_id)
     if actor is not None and actor.type == "agent":
-        if not actor.can_manage_members:
-            raise HTTPException(status_code=403, detail="Agent does not have can_manage_members permission")
+        # S4: can_manage_members → has_project_role(min='admin') 단일 경로(role 에서 derived).
+        from app.services.project_auth import has_project_role
+        if not await has_project_role(session, actor.id, actor.project_id, min_role="admin"):
+            raise HTTPException(status_code=403, detail="project admin/owner role required to manage members")
         if _ROLE_RANK.get(body.role, 1) > _ROLE_RANK.get(actor.role, 1):
             raise HTTPException(status_code=403, detail="Cannot assign role higher than your own")
         if body.name == actor.name:

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -151,11 +151,16 @@ async def create_team_member(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
-    # AC1/AC2: agent actor의 can_manage_members 체크
+    # AC1/AC2: agent actor의 멤버 관리 권한 체크.
+    # E-MEMBER-POLICY S4: can_manage_members 플래그 직접 읽기 → effective 프로젝트 역할(has_project_role)
+    # 단일 경로로 전환(블루프린트 §6). can_manage_members 는 role 에서 derived(0122 백필 can_manage=
+    # true→role admin). owner/admin 이 멤버 관리. 기존 통과자(can_manage=true→admin) 무회귀 +
+    # owner/admin 추가 통과(additive).
     actor = await _resolve_actor(auth, session, org_id)
     if actor is not None and actor.type == "agent":
-        if not actor.can_manage_members:
-            raise HTTPException(status_code=403, detail="Agent does not have can_manage_members permission")
+        from app.services.project_auth import has_project_role
+        if not await has_project_role(session, actor.id, actor.project_id, min_role="admin"):
+            raise HTTPException(status_code=403, detail="project admin/owner role required to manage members")
         # AC3: target.role > actor.role → 403 (격상 차단)
         target_rank = _ROLE_RANK.get(body.role, 1)
         actor_rank = _ROLE_RANK.get(actor.role, 1)

--- a/backend/tests/test_project_role_s4_can_manage.py
+++ b/backend/tests/test_project_role_s4_can_manage.py
@@ -1,0 +1,106 @@
+"""E-MEMBER-POLICY S4: can_manage_members enforcement → has_project_role(min='admin') 전환.
+
+agent actor 의 멤버 생성 권한을 can_manage_members 플래그 대신 effective 프로젝트 역할로 판정.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _agent_actor():
+    a = MagicMock()
+    a.type = "agent"
+    a.id = uuid.uuid4()
+    a.project_id = uuid.uuid4()
+    a.role = "admin"
+    a.name = "actor-agent"
+    return a
+
+
+def _auth():
+    a = MagicMock()
+    a.user_id = str(uuid.uuid4())
+    a.claims = {"app_metadata": {}}
+    return a
+
+
+# ── create_team_member (team_members.py) ─────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_team_member_create_agent_no_admin_403():
+    from fastapi import HTTPException
+
+    from app.routers.team_members import create_team_member
+    from app.schemas.team_member import TeamMemberCreate
+
+    org = uuid.uuid4()
+    body = TeamMemberCreate(project_id=uuid.uuid4(), org_id=org, type="agent", name="new-agent")
+    actor = _agent_actor()
+    session = MagicMock()
+
+    with patch("app.routers.team_members._resolve_actor", new=AsyncMock(return_value=actor)), patch(
+        "app.services.project_auth.has_project_role", new=AsyncMock(return_value=False)
+    ) as hpr:
+        with pytest.raises(HTTPException) as ei:
+            await create_team_member(body, session=session, auth=_auth(), org_id=org)
+    assert ei.value.status_code == 403
+    # role 경로 사용 확認: actor.id·actor.project_id·min='admin'
+    hpr.assert_awaited_once()
+    assert hpr.await_args.kwargs.get("min_role") == "admin"
+
+
+@pytest.mark.anyio
+async def test_team_member_create_human_actor_skips_gate():
+    """human actor 는 agent 전용 게이트 미적용(has_project_role 미호출) — 무회귀."""
+    from app.routers.team_members import create_team_member
+    from app.schemas.team_member import TeamMemberCreate
+
+    org = uuid.uuid4()
+    body = TeamMemberCreate(project_id=uuid.uuid4(), org_id=org, type="human", name="x")
+    human = MagicMock()
+    human.type = "human"
+    session = MagicMock()
+
+    with patch("app.routers.team_members._resolve_actor", new=AsyncMock(return_value=human)), patch(
+        "app.services.project_auth.has_project_role", new=AsyncMock(return_value=False)
+    ) as hpr:
+        # human create 는 410(deprecated)로 끊기지만 게이트(has_project_role) 전에 막힘 → 미호출
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException):
+            await create_team_member(body, session=session, auth=_auth(), org_id=org)
+    hpr.assert_not_awaited()
+
+
+# ── create_org_agent (agents.py) ─────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_org_agent_create_agent_no_admin_403():
+    from fastapi import HTTPException
+
+    from app.routers.agents import create_org_agent
+    from app.schemas.team_member import OrgAgentCreate
+
+    org = uuid.uuid4()
+    body = OrgAgentCreate(name="cos", scope_mode="org")
+    actor = _agent_actor()
+    session = MagicMock()
+
+    with patch("app.routers.team_members._resolve_actor", new=AsyncMock(return_value=actor)), patch(
+        "app.services.project_auth.has_project_role", new=AsyncMock(return_value=False)
+    ) as hpr:
+        with pytest.raises(HTTPException) as ei:
+            await create_org_agent(body, session=session, auth=_auth(), org_id=org)
+    assert ei.value.status_code == 403
+    hpr.assert_awaited_once()
+    assert hpr.await_args.kwargs.get("min_role") == "admin"


### PR DESCRIPTION
블루프린트(#1543) **S4** — 프로젝트 역할/owner 1급 모델 토대 **마무리**. 멤버 관리 인가를 `can_manage_members` 플래그 → **effective 프로젝트 역할 단일 경로**로 전환(§6). 마이그 없음.

## 무엇
`can_manage_members` 직접 읽기 → `has_project_role(min='admin')`:
- can_manage_members 는 role 에서 **derived**(0122 백필: `can_manage=true → role='admin'`) → 기존 통과자(can_manage=true)=role admin 으로 **무회귀**, owner/admin 추가 통과(**additive**·§6 derived 의미).
- 전환 지점 **2**(전수 grep): `team_members.create_team_member`·`agents.create_org_agent` 의 **agent actor** 게이트. 둘 다 `actor.can_manage_members` → `has_project_role(session, actor.id, actor.project_id, min='admin')`.
- human actor·비-agent 경로 **무변경**(게이트는 agent actor 한정). role rank·self-name 체크 유지.
- `can_manage_members` 컬럼/뷰/응답은 **유지**(마이그 없음·back-compat) — enforcement 만 role 경로로(derived).

## 검증
- 신규 `tests/test_project_role_s4_can_manage.py` 3: agent no-admin → 403·role 경로 사용(min='admin' 인자)·human actor skip(게이트 미적용).
- create/project-role(S2·S3)/security 회귀(`team_members`·`org_agent_create`·`s33`·`s_mbr_03`·`ss4_security`·`agent_multiproject_grant`) **98 pass**. app import OK.

## 토대 완료
S1(0122 enum)·S2(role 헬퍼+인가 소비)·S3(owner 지정)·**S4(can_manage→role)** = 프로젝트 역할/owner 1급 모델 완성. 그 위에 **HITL 게이트 config(S-GATE-1: org/project별 auto/ask/block)** 가 앉음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)