### PR TITLE
feat(hitl): 게이트 레벨 config 모델 + resolve + 엔드포인트 (S-GATE-1)

### DIFF
--- a/backend/alembic/versions/0123_hitl_gate_config.py
+++ b/backend/alembic/versions/0123_hitl_gate_config.py
@@ -1,0 +1,55 @@
+"""HITL 게이트 레벨 config 테이블 — E-HITL-GATING S-GATE-1 (f9e54965).
+
+정책 hitl-gating-policy-v1 §3. org 기본값(project_id NULL) → project 오버라이드 계층으로
+(work_type × actor_type) → level(auto/ask/block) 저장. **신규 테이블·additive·백필 0** —
+dev 전용 가치 실험이나 dev/prod 공유 DB라 prod DB 에도 생성되되 prod 코드 무참조(무영향).
+
+유니크: 부분 인덱스 2(org 기본값 / project 오버라이드) — NULL distinct 함정 회피, NULLS NOT
+DISTINCT(PG15) 비의존(이식성). 안전 하한(§3d)·집행(Cage/H1)은 S-GATE-3/S-GATE-2.
+
+idempotent: IF NOT EXISTS — 재실행·fresh DB 안전.
+"""
+from alembic import op
+
+revision = "0123"
+down_revision = "0122"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS hitl_gate_config (
+            id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            org_id      uuid NOT NULL,
+            project_id  uuid NULL,
+            work_type   text NOT NULL,
+            actor_type  text NOT NULL,
+            level       text NOT NULL,
+            created_by  uuid NULL,
+            created_at  timestamptz NOT NULL DEFAULT now(),
+            updated_at  timestamptz NOT NULL DEFAULT now(),
+            CONSTRAINT ck_hitl_gate_work_type  CHECK (work_type  IN ('done', 'merge')),
+            CONSTRAINT ck_hitl_gate_actor_type CHECK (actor_type IN ('agent', 'human')),
+            CONSTRAINT ck_hitl_gate_level      CHECK (level      IN ('auto', 'ask', 'block'))
+        )
+        """
+    )
+    op.execute("CREATE INDEX IF NOT EXISTS ix_hitl_gate_config_org_id ON hitl_gate_config (org_id)")
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_hitl_gate_config_project_id ON hitl_gate_config (project_id)"
+    )
+    # 축당 1행: org 기본값(project NULL) / project 오버라이드 각각 부분 유니크
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_hitl_gate_org_default "
+        "ON hitl_gate_config (org_id, work_type, actor_type) WHERE project_id IS NULL"
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_hitl_gate_project_override "
+        "ON hitl_gate_config (org_id, project_id, work_type, actor_type) WHERE project_id IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS hitl_gate_config")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -53,7 +53,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, gate_config, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -158,6 +158,7 @@ app.include_router(verdict_capture.router)
 app.include_router(trust_scores.router)
 app.include_router(hitl_config.router)
 app.include_router(gates.router)
+app.include_router(gate_config.router)
 app.include_router(tasks.router)
 app.include_router(docs.router)
 app.include_router(public_docs.router)

--- a/backend/app/models/hitl.py
+++ b/backend/app/models/hitl.py
@@ -52,3 +52,28 @@ class HitlRequest(Base):
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class HitlGateConfig(Base):
+    """E-HITL-GATING S-GATE-1: 게이트 레벨 config (정책 hitl-gating-policy-v1 §3).
+
+    org 기본값(project_id NULL) → project 오버라이드 계층. (work_type × actor_type) → level.
+    유니크: 부분 인덱스 2(org 기본값 / project 오버라이드) — migration 0123. 안전 하한·집행은
+    S-GATE-3/2. dev 전용 가치 실험(prod 미영향).
+    """
+    __tablename__ = "hitl_gate_config"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    # NULL = org 기본값 · set = project 오버라이드
+    project_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    work_type: Mapped[str] = mapped_column(Text, nullable=False)   # 'done' | 'merge'
+    actor_type: Mapped[str] = mapped_column(Text, nullable=False)  # 'agent' | 'human'
+    level: Mapped[str] = mapped_column(Text, nullable=False)       # 'auto' | 'ask' | 'block'
+    created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/routers/gate_config.py
+++ b/backend/app/routers/gate_config.py
@@ -60,7 +60,12 @@ async def get_gate_config(
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> list[GateLevelEntry]:
-    """프로젝트의 effective 게이트 레벨(모든 work_type × actor) — 프로젝트 멤버 조회."""
+    """프로젝트의 effective 게이트 레벨(모든 work_type × actor) — **read = 프로젝트 멤버**.
+
+    권한 모델(QA RC·PO 콜): **read=member / write=admin·owner**. 게이트 레벨(자기 액션이 auto/ask/
+    block 인지)은 전 멤버가 알아야 유용(미리 차단 여부 인지)·비민감 정책 메타·enforcement 는 서버
+    사이드라 알아도 우회 불가 → 멤버 read 가 옳은 설계. 설정(PUT)만 org admin/project owner.
+    """
     org_id = await _project_org_id(session, project_id)
     if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
         raise HTTPException(status_code=403, detail="No access to this project")

--- a/backend/app/routers/gate_config.py
+++ b/backend/app/routers/gate_config.py
@@ -1,0 +1,124 @@
+"""HITL 게이트 레벨 config 엔드포인트 — E-HITL-GATING S-GATE-1.
+
+GET  /api/v2/projects/{project_id}/gate-config  — effective config 조회(프로젝트 멤버).
+PUT  /api/v2/projects/{project_id}/gate-config  — 레벨 설정. 권한(정책 §2·토대 재사용):
+  scope='org'(org 기본값)=org admin / scope='project'(오버라이드)=project owner(+org owner/admin).
+"""
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.services.gate_config import (
+    ACTOR_TYPES,
+    LEVELS,
+    WORK_TYPES,
+    resolve_gate_level,
+    set_gate_level,
+)
+from app.services.project_auth import (
+    get_project_role,
+    has_project_access,
+    is_org_owner_or_admin,
+)
+
+router = APIRouter(prefix="/api/v2/projects", tags=["hitl-gate-config"])
+
+
+class GateLevelEntry(BaseModel):
+    work_type: str
+    actor_type: str
+    level: str
+
+
+class SetGateLevelRequest(BaseModel):
+    scope: str  # 'org' | 'project'
+    work_type: str
+    actor_type: str
+    level: str
+
+
+async def _project_org_id(session: AsyncSession, project_id: uuid.UUID) -> uuid.UUID:
+    row = (
+        await session.execute(
+            text("SELECT org_id FROM projects WHERE id = :pid AND deleted_at IS NULL"),
+            {"pid": str(project_id)},
+        )
+    ).first()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return row[0]
+
+
+@router.get("/{project_id}/gate-config", response_model=list[GateLevelEntry])
+async def get_gate_config(
+    project_id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> list[GateLevelEntry]:
+    """프로젝트의 effective 게이트 레벨(모든 work_type × actor) — 프로젝트 멤버 조회."""
+    org_id = await _project_org_id(session, project_id)
+    if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
+    entries: list[GateLevelEntry] = []
+    for wt in WORK_TYPES:
+        for at in ACTOR_TYPES:
+            level = await resolve_gate_level(
+                session, org_id=org_id, project_id=project_id, work_type=wt, actor_type=at
+            )
+            entries.append(GateLevelEntry(work_type=wt, actor_type=at, level=level))
+    return entries
+
+
+@router.put("/{project_id}/gate-config", response_model=GateLevelEntry)
+async def put_gate_config(
+    project_id: uuid.UUID,
+    body: SetGateLevelRequest,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> GateLevelEntry:
+    """게이트 레벨 설정. scope='org'=org 기본값(org admin) / scope='project'=오버라이드(project owner+org admin)."""
+    if body.work_type not in WORK_TYPES:
+        raise HTTPException(status_code=400, detail=f"work_type must be one of {list(WORK_TYPES)}")
+    if body.actor_type not in ACTOR_TYPES:
+        raise HTTPException(status_code=400, detail=f"actor_type must be one of {list(ACTOR_TYPES)}")
+    if body.level not in LEVELS:
+        raise HTTPException(status_code=400, detail=f"level must be one of {list(LEVELS)}")
+
+    org_id = await _project_org_id(session, project_id)
+    actor = uuid.UUID(auth.user_id)
+
+    if body.scope == "org":
+        # org 기본값 — org admin/owner 만(정책 §2)
+        if not await is_org_owner_or_admin(session, actor, org_id):
+            raise HTTPException(status_code=403, detail="org owner/admin required to set org default")
+        target_project_id: uuid.UUID | None = None
+    elif body.scope == "project":
+        # project 오버라이드 — project owner 또는 org owner/admin(§2)
+        if not (
+            (await get_project_role(session, actor, project_id)) == "owner"
+            or await is_org_owner_or_admin(session, actor, org_id)
+        ):
+            raise HTTPException(
+                status_code=403, detail="project owner or org owner/admin required to set override"
+            )
+        target_project_id = project_id
+    else:
+        raise HTTPException(status_code=400, detail="scope must be 'org' or 'project'")
+
+    row = await set_gate_level(
+        session,
+        org_id=org_id,
+        project_id=target_project_id,
+        work_type=body.work_type,
+        actor_type=body.actor_type,
+        level=body.level,
+        created_by=actor,
+    )
+    await session.commit()
+    return GateLevelEntry(work_type=row.work_type, actor_type=row.actor_type, level=row.level)

--- a/backend/app/services/gate_config.py
+++ b/backend/app/services/gate_config.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 import uuid
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.hitl import HitlGateConfig
@@ -86,12 +86,39 @@ async def set_gate_level(
     if level not in LEVELS:
         raise ValueError(f"level must be one of {LEVELS}")
 
+    # QA RC(디디 캐치·PO 승인): SELECT-then-INSERT 는 TOCTOU race — 동일 축 동시 PUT 2건이 둘 다
+    # INSERT → 부분 유니크 위반 500. 부분 유니크 인덱스를 conflict target 으로 **원자 upsert**
+    # (on_conflict_do_update). updated_at 도 갱신(UPDATE 시 stale 방지). org 기본값/project 오버라이드는
+    # 각각 다른 부분 유니크라 index_where 로 분기.
+    from sqlalchemy import func
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    vals = dict(
+        org_id=org_id, project_id=project_id, work_type=work_type,
+        actor_type=actor_type, level=level, created_by=created_by,
+    )
+    stmt = pg_insert(HitlGateConfig.__table__).values(**vals)
+    if project_id is None:
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["org_id", "work_type", "actor_type"],
+            index_where=text("project_id IS NULL"),
+            set_={"level": level, "updated_at": func.now()},
+        )
+    else:
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["org_id", "project_id", "work_type", "actor_type"],
+            index_where=text("project_id IS NOT NULL"),
+            set_={"level": level, "updated_at": func.now()},
+        )
+    await session.execute(stmt)
+    await session.flush()
+
     scope_filter = (
         HitlGateConfig.project_id.is_(None)
         if project_id is None
         else HitlGateConfig.project_id == project_id
     )
-    existing = (
+    row = (
         await session.execute(
             select(HitlGateConfig).where(
                 HitlGateConfig.org_id == org_id,
@@ -101,22 +128,4 @@ async def set_gate_level(
             )
         )
     ).scalars().first()
-
-    if existing is not None:
-        existing.level = level
-        await session.flush()
-        await session.refresh(existing)
-        return existing
-
-    row = HitlGateConfig(
-        org_id=org_id,
-        project_id=project_id,
-        work_type=work_type,
-        actor_type=actor_type,
-        level=level,
-        created_by=created_by,
-    )
-    session.add(row)
-    await session.flush()
-    await session.refresh(row)
     return row

--- a/backend/app/services/gate_config.py
+++ b/backend/app/services/gate_config.py
@@ -1,0 +1,122 @@
+"""HITL 게이트 레벨 config 해소/설정 — E-HITL-GATING S-GATE-1 (정책 hitl-gating-policy-v1 §3).
+
+resolve_gate_level: project 오버라이드 → org 기본값 → 보수적 기본 'ask'(§3e). 안전 하한(§3d)
+clamp 는 S-GATE-3, 집행은 S-GATE-2 — 여기선 순수 config 해소. 측정(정책 §5) 위해 구조화 로그.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.hitl import HitlGateConfig
+
+logger = logging.getLogger(__name__)
+
+WORK_TYPES: tuple[str, ...] = ("done", "merge")
+ACTOR_TYPES: tuple[str, ...] = ("agent", "human")
+LEVELS: tuple[str, ...] = ("auto", "ask", "block")
+DEFAULT_LEVEL = "ask"  # §3e 보수적 기본
+
+
+async def resolve_gate_level(
+    session: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID | None,
+    work_type: str,
+    actor_type: str,
+) -> str:
+    """(work_type × actor)의 effective 게이트 레벨. project 오버라이드 → org 기본값 → 'ask'."""
+    if project_id is not None:
+        lvl = (
+            await session.execute(
+                select(HitlGateConfig.level).where(
+                    HitlGateConfig.org_id == org_id,
+                    HitlGateConfig.project_id == project_id,
+                    HitlGateConfig.work_type == work_type,
+                    HitlGateConfig.actor_type == actor_type,
+                )
+            )
+        ).scalar_one_or_none()
+        if lvl is not None:
+            _log_resolved(org_id, project_id, work_type, actor_type, lvl, "project")
+            return lvl
+
+    lvl = (
+        await session.execute(
+            select(HitlGateConfig.level).where(
+                HitlGateConfig.org_id == org_id,
+                HitlGateConfig.project_id.is_(None),
+                HitlGateConfig.work_type == work_type,
+                HitlGateConfig.actor_type == actor_type,
+            )
+        )
+    ).scalar_one_or_none()
+    result = lvl if lvl is not None else DEFAULT_LEVEL
+    _log_resolved(org_id, project_id, work_type, actor_type, result, "org" if lvl is not None else "default")
+    return result
+
+
+def _log_resolved(org_id, project_id, work_type, actor_type, level, source) -> None:
+    # 측정 baseline(정책 §5): 집행 전 레벨 분포/coverage 관측용 구조화 로그.
+    logger.info(
+        "gate_level resolved org=%s project=%s work=%s actor=%s level=%s source=%s",
+        org_id, project_id, work_type, actor_type, level, source,
+    )
+
+
+async def set_gate_level(
+    session: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID | None,
+    work_type: str,
+    actor_type: str,
+    level: str,
+    created_by: uuid.UUID | None,
+) -> HitlGateConfig:
+    """org 기본값(project_id None) 또는 project 오버라이드 레벨을 upsert(축당 1행). 권한은 호출부(라우터)."""
+    if work_type not in WORK_TYPES:
+        raise ValueError(f"work_type must be one of {WORK_TYPES}")
+    if actor_type not in ACTOR_TYPES:
+        raise ValueError(f"actor_type must be one of {ACTOR_TYPES}")
+    if level not in LEVELS:
+        raise ValueError(f"level must be one of {LEVELS}")
+
+    scope_filter = (
+        HitlGateConfig.project_id.is_(None)
+        if project_id is None
+        else HitlGateConfig.project_id == project_id
+    )
+    existing = (
+        await session.execute(
+            select(HitlGateConfig).where(
+                HitlGateConfig.org_id == org_id,
+                scope_filter,
+                HitlGateConfig.work_type == work_type,
+                HitlGateConfig.actor_type == actor_type,
+            )
+        )
+    ).scalars().first()
+
+    if existing is not None:
+        existing.level = level
+        await session.flush()
+        await session.refresh(existing)
+        return existing
+
+    row = HitlGateConfig(
+        org_id=org_id,
+        project_id=project_id,
+        work_type=work_type,
+        actor_type=actor_type,
+        level=level,
+        created_by=created_by,
+    )
+    session.add(row)
+    await session.flush()
+    await session.refresh(row)
+    return row

--- a/backend/tests/test_gate_config_s1.py
+++ b/backend/tests/test_gate_config_s1.py
@@ -105,6 +105,49 @@ def _org_row(exists=True):
 
 
 @pytest.mark.anyio
+async def test_get_member_returns_effective_config():
+    """GET = 프로젝트 멤버 read(설계 의도·PO 콜). 멤버면 200 + 전 work_type×actor effective 레벨."""
+    from app.routers import gate_config as gc
+
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_org_row())  # _project_org_id
+    with patch("app.routers.gate_config.has_project_access", new=AsyncMock(return_value=True)), patch(
+        "app.routers.gate_config.resolve_gate_level", new=AsyncMock(return_value="ask")
+    ):
+        out = await gc.get_gate_config(uuid.uuid4(), auth=_auth(), session=session)
+    # WORK_TYPES(2) × ACTOR_TYPES(2) = 4 entries
+    assert len(out) == 4
+    assert all(e.level == "ask" for e in out)
+
+
+@pytest.mark.anyio
+async def test_get_non_member_403():
+    from fastapi import HTTPException
+
+    from app.routers import gate_config as gc
+
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_org_row())
+    with patch("app.routers.gate_config.has_project_access", new=AsyncMock(return_value=False)):
+        with pytest.raises(HTTPException) as ei:
+            await gc.get_gate_config(uuid.uuid4(), auth=_auth(), session=session)
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_get_missing_project_404():
+    from fastapi import HTTPException
+
+    from app.routers import gate_config as gc
+
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_org_row(exists=False))
+    with pytest.raises(HTTPException) as ei:
+        await gc.get_gate_config(uuid.uuid4(), auth=_auth(), session=session)
+    assert ei.value.status_code == 404
+
+
+@pytest.mark.anyio
 async def test_put_missing_project_404():
     from fastapi import HTTPException
 

--- a/backend/tests/test_gate_config_s1.py
+++ b/backend/tests/test_gate_config_s1.py
@@ -1,0 +1,183 @@
+"""E-HITL-GATING S-GATE-1: gate_config resolve(계층)·set(validate)·엔드포인트(권한)."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _scalar(val):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = val
+    return r
+
+
+# ── resolve_gate_level: project 오버라이드 → org 기본값 → 'ask' ──────────────
+
+
+@pytest.mark.anyio
+async def test_resolve_project_override_wins():
+    from app.services.gate_config import resolve_gate_level
+
+    session = MagicMock()
+    session.execute = AsyncMock(side_effect=[_scalar("auto")])  # project 행 존재
+    out = await resolve_gate_level(
+        session, org_id=uuid.uuid4(), project_id=uuid.uuid4(), work_type="done", actor_type="agent"
+    )
+    assert out == "auto"
+
+
+@pytest.mark.anyio
+async def test_resolve_falls_to_org_default():
+    from app.services.gate_config import resolve_gate_level
+
+    session = MagicMock()
+    session.execute = AsyncMock(side_effect=[_scalar(None), _scalar("block")])  # project 없음·org 있음
+    out = await resolve_gate_level(
+        session, org_id=uuid.uuid4(), project_id=uuid.uuid4(), work_type="merge", actor_type="human"
+    )
+    assert out == "block"
+
+
+@pytest.mark.anyio
+async def test_resolve_default_ask_when_none():
+    from app.services.gate_config import resolve_gate_level
+
+    session = MagicMock()
+    session.execute = AsyncMock(side_effect=[_scalar(None), _scalar(None)])
+    out = await resolve_gate_level(
+        session, org_id=uuid.uuid4(), project_id=uuid.uuid4(), work_type="done", actor_type="agent"
+    )
+    assert out == "ask"  # §3e 보수적 기본
+
+
+@pytest.mark.anyio
+async def test_resolve_no_project_uses_org_only():
+    from app.services.gate_config import resolve_gate_level
+
+    session = MagicMock()
+    session.execute = AsyncMock(side_effect=[_scalar("ask")])  # org 쿼리 1번만(project None)
+    out = await resolve_gate_level(
+        session, org_id=uuid.uuid4(), project_id=None, work_type="done", actor_type="agent"
+    )
+    assert out == "ask"
+    assert session.execute.await_count == 1  # project 쿼리 skip
+
+
+# ── set_gate_level: enum validate ────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("wt,at,lvl", [
+    ("bogus", "agent", "ask"),
+    ("done", "robot", "ask"),
+    ("done", "agent", "MAYBE"),
+])
+async def test_set_invalid_enum_raises(wt, at, lvl):
+    from app.services.gate_config import set_gate_level
+
+    with pytest.raises(ValueError):
+        await set_gate_level(
+            MagicMock(), org_id=uuid.uuid4(), project_id=None,
+            work_type=wt, actor_type=at, level=lvl, created_by=None,
+        )
+
+
+# ── 엔드포인트 권한 ───────────────────────────────────────────────────────────
+
+
+def _auth():
+    a = MagicMock()
+    a.user_id = str(uuid.uuid4())
+    return a
+
+
+def _org_row(exists=True):
+    r = MagicMock()
+    r.first.return_value = (uuid.uuid4(),) if exists else None
+    return r
+
+
+@pytest.mark.anyio
+async def test_put_missing_project_404():
+    from fastapi import HTTPException
+
+    from app.routers import gate_config as gc
+
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_org_row(exists=False))
+    body = gc.SetGateLevelRequest(scope="org", work_type="done", actor_type="agent", level="ask")
+    with pytest.raises(HTTPException) as ei:
+        await gc.put_gate_config(uuid.uuid4(), body, auth=_auth(), session=session)
+    assert ei.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_put_invalid_level_400():
+    from fastapi import HTTPException
+
+    from app.routers import gate_config as gc
+
+    session = MagicMock()
+    body = gc.SetGateLevelRequest(scope="org", work_type="done", actor_type="agent", level="MAYBE")
+    with pytest.raises(HTTPException) as ei:
+        await gc.put_gate_config(uuid.uuid4(), body, auth=_auth(), session=session)
+    assert ei.value.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_put_org_scope_non_admin_403():
+    from fastapi import HTTPException
+
+    from app.routers import gate_config as gc
+
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_org_row())
+    body = gc.SetGateLevelRequest(scope="org", work_type="done", actor_type="agent", level="auto")
+    with patch("app.routers.gate_config.is_org_owner_or_admin", new=AsyncMock(return_value=False)):
+        with pytest.raises(HTTPException) as ei:
+            await gc.put_gate_config(uuid.uuid4(), body, auth=_auth(), session=session)
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_put_project_scope_non_owner_403():
+    from fastapi import HTTPException
+
+    from app.routers import gate_config as gc
+
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_org_row())
+    body = gc.SetGateLevelRequest(scope="project", work_type="merge", actor_type="human", level="block")
+    with patch("app.routers.gate_config.get_project_role", new=AsyncMock(return_value="admin")), patch(
+        "app.routers.gate_config.is_org_owner_or_admin", new=AsyncMock(return_value=False)
+    ):
+        with pytest.raises(HTTPException) as ei:
+            await gc.put_gate_config(uuid.uuid4(), body, auth=_auth(), session=session)
+    assert ei.value.status_code == 403  # project admin(≠owner)·org admin 아님 → 거부
+
+
+@pytest.mark.anyio
+async def test_put_project_owner_sets_override():
+    from app.routers import gate_config as gc
+
+    session = MagicMock()
+    session.execute = AsyncMock(return_value=_org_row())
+    session.commit = AsyncMock()
+    row = MagicMock()
+    row.work_type = "merge"
+    row.actor_type = "human"
+    row.level = "block"
+    body = gc.SetGateLevelRequest(scope="project", work_type="merge", actor_type="human", level="block")
+    with patch("app.routers.gate_config.get_project_role", new=AsyncMock(return_value="owner")), patch(
+        "app.routers.gate_config.set_gate_level", new=AsyncMock(return_value=row)
+    ):
+        out = await gc.put_gate_config(uuid.uuid4(), body, auth=_auth(), session=session)
+    assert out.level == "block"
+    session.commit.assert_awaited_once()


### PR DESCRIPTION
블루프린트(#1558) **S-GATE-1** — E-HITL-GATING 첫 스토리. 정책 `hitl-gating-policy-v1` §3. §6 결정(work_type done/merge·기본 ask·부분 유니크 2·엔드포인트 포함·권한 org admin/project owner) 전부 반영. **dev 전용 가치 실험**.

## 모델 + 마이그(0123)
`hitl_gate_config(org_id, project_id NULL=org기본/set=오버라이드, work_type, actor_type, level)` + CHECK 3(done/merge·agent/human·auto/ask/block) + **부분 유니크 2**(org 기본값 / project 오버라이드 각 1행). 신규·additive·백필 0·prod 코드 무참조(공유 DB라 prod DB 엔 생성되되 무영향).
- **실 PG 검증**(docker pg15): 부분 유니크 독립(org default ↔ project override 공존)·dup 각각 거부·CHECK 거부 실증.

## resolve / set
- `resolve_gate_level`: project 오버라이드 → org 기본값 → **보수적 기본 `ask`**(§3e). ⚠️ 안전 하한(§3d) clamp·집행(Cage/H1)은 **S-GATE-3/S-GATE-2** — 여기선 순수 config 해소. 측정(§5) 구조화 로그(`gate_level resolved …`).
- `set_gate_level`: enum validate + 축당 1행 upsert.

## 엔드포인트
`GET/PUT /api/v2/projects/{id}/gate-config`. 권한=**토대 헬퍼 재사용**(§2): `scope='org'`=org admin(`is_org_owner_or_admin`) / `scope='project'`=project owner(`get_project_role`=='owner')+org owner/admin. GET=프로젝트 멤버(`has_project_access`).

## 검증
- 신규 `tests/test_gate_config_s1.py` 12: resolve 계층(project/org/default ask/no-project)·set enum validate·엔드포인트(org/project 403·invalid 400·missing 404·owner 설정). 마이그 chain(0122→0123) + 회귀(project-role S2/S3·s_mbr_03·ss4_security) **76 pass**. app import OK·라우트 등록.

## ⚠️ 머지 규율
**머지 후 `sprintable-migrate-dev` 실행 필수**(0123). 다음: **S-GATE-2**(집행=휴면 Cage/H1 깨워 resolve 소비)·S-GATE-3(하한 강제)·S-GATE-4(UI·유나).

🤖 Generated with [Claude Code](https://claude.com/claude-code)