### PR TITLE
feat(settings): org-agent 멀티프로젝트 접근 관리 UI — 단일키 grant (088987d8)

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
@@ -664,7 +664,14 @@ export default function AgentDetailPage() {
       </SectionCard>
 
       {/* 프로젝트 접근 (org-agent 멀티프로젝트 단일키 grant) — 088987d8 */}
-      <AgentProjectAccessSection agentMemberId={id} projects={projects} canEdit={canEdit} />
+      {/* 프로젝트 grant 게이트는 page canEdit(creator 포함)보다 엄격 — creator라도 비-admin이면 과권한
+          (RC①). org admin/owner 만 page-wide 허용(org admin 은 org 전 프로젝트 grant 가능 = BE
+          _require_owner_or_admin 정합·403 surprise 0; 단일 project owner-non-admin 은 안전하게 미노출). */}
+      <AgentProjectAccessSection
+        agentMemberId={id}
+        projects={projects}
+        canEdit={orgRole === 'admin' || orgRole === 'owner'}
+      />
     </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
-import { AlertTriangle, ArrowLeft, Check, Copy, MinusCircle, Pencil, Plus, X, XCircle } from 'lucide-react';
+import { AlertTriangle, ArrowLeft, Check, Copy, MinusCircle, Pencil, X, XCircle } from 'lucide-react';
 import { Switch } from '@/components/ui/switch';
 import { AgentApiKeyManager } from '@/components/agents/agent-api-key-manager';
 import { MessagingPolicySection } from '@/components/agents/messaging-policy-section';
@@ -13,6 +13,7 @@ import { Button } from '@/components/ui/button';
 import { OperatorInput } from '@/components/ui/operator-control';
 import { OperatorDropdownSelect } from '@/components/ui/operator-dropdown-select';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
+import { AgentProjectAccessSection } from '@/components/settings/agent-project-access-section';
 import { useToast } from '@/components/ui/toast';
 import {
   RUNTIME_REGISTRY,
@@ -78,15 +79,6 @@ interface ProjectOption {
   name: string;
 }
 
-interface NewProjectResult {
-  agentId: string;
-  projectId: string;
-  projectName: string;
-  apiKey: string;
-  webhookUrl: string;
-  savingWebhook: boolean;
-}
-
 function buildMcpConfig(apiKey: string) {
   return JSON.stringify(
     {
@@ -145,12 +137,6 @@ export default function AgentDetailPage() {
   const [fakechatMcpCopied, setFakechatMcpCopied] = useState(false);
 
   const [projects, setProjects] = useState<ProjectOption[]>([]);
-  const [sameNameAgents, setSameNameAgents] = useState<AgentMember[]>([]);
-  const [showAddToProject, setShowAddToProject] = useState(false);
-  const [selectedAddProjectId, setSelectedAddProjectId] = useState('');
-  const [addingToProject, setAddingToProject] = useState(false);
-  const [newProjectResult, setNewProjectResult] = useState<NewProjectResult | null>(null);
-  const [orgId, setOrgId] = useState<string | null>(null);
 
   const fetchAgent = useCallback(async () => {
     const res = await fetch(`/api/team-members/${id}`);
@@ -160,18 +146,13 @@ export default function AgentDetailPage() {
   }, [id, router]);
 
   const fetchOrgContext = useCallback(async () => {
-    const [projectRes, contextRes, meRes] = await Promise.all([
+    const [projectRes, meRes] = await Promise.all([
       fetch('/api/projects'),
-      fetch('/api/current-project'),
       fetch('/api/me'),
     ]);
     if (projectRes.ok) {
       const json = await projectRes.json() as { data: ProjectOption[] };
       setProjects((json.data ?? []).slice().sort((a, b) => a.name.localeCompare(b.name)));
-    }
-    if (contextRes.ok) {
-      const json = await contextRes.json() as { data?: { org_id?: string } };
-      setOrgId(json.data?.org_id ?? null);
     }
     if (meRes.ok) {
       const json = await meRes.json() as { data?: { user_id?: string | null; role?: string } };
@@ -179,13 +160,6 @@ export default function AgentDetailPage() {
       setOrgRole(json.data?.role ?? 'member');
     }
   }, []);
-
-  const fetchSameNameAgents = useCallback(async (agentName: string) => {
-    const res = await fetch('/api/team-members?type=agent&include_inactive=true');
-    if (!res.ok) return;
-    const json = await res.json() as { data: AgentMember[] };
-    setSameNameAgents((json.data ?? []).filter((a) => a.name === agentName && a.id !== id));
-  }, [id]);
 
   const fetchWebhookConfigs = useCallback(async (projectId: string) => {
     const res = await fetch(`/api/webhooks/config?project_id=${encodeURIComponent(projectId)}`);
@@ -213,8 +187,7 @@ export default function AgentDetailPage() {
   useEffect(() => {
     if (!agent) return;
     void fetchWebhookConfigs(agent.project_id);
-    void fetchSameNameAgents(agent.name);
-  }, [agent, fetchWebhookConfigs, fetchSameNameAgents]);
+  }, [agent, fetchWebhookConfigs]);
 
   useEffect(() => {
     setWebhookActive(webhookConfigs[0]?.is_active ?? false);
@@ -224,17 +197,6 @@ export default function AgentDetailPage() {
   useEffect(() => {
     setSelectedRuntime(agent?.runtime_type ?? '');
   }, [agent?.runtime_type]);
-
-  const assignedProjectIds = useMemo(() => {
-    const ids = new Set(sameNameAgents.map((a) => a.project_id));
-    if (agent) ids.add(agent.project_id);
-    return ids;
-  }, [sameNameAgents, agent]);
-
-  const availableProjects = useMemo(
-    () => projects.filter((p) => !assignedProjectIds.has(p.id)),
-    [projects, assignedProjectIds],
-  );
 
   const handleSaveEdit = async () => {
     if (!editName.trim()) return;
@@ -322,68 +284,6 @@ export default function AgentDetailPage() {
       addToast({ type: 'error', title: tc('error') });
     } finally {
       setSavingWebhook(false);
-    }
-  };
-
-  const handleAddToProject = async () => {
-    if (!selectedAddProjectId || !agent || !orgId) return;
-    setAddingToProject(true);
-    try {
-      const memberRes = await fetch('/api/team-members', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ org_id: orgId, project_id: selectedAddProjectId, name: agent.name, type: 'agent', role: agent.role }),
-      });
-      if (!memberRes.ok) {
-        const json = await memberRes.json().catch(() => null) as { error?: { message?: string } } | null;
-        addToast({ type: 'error', title: json?.error?.message ?? tc('error') });
-        return;
-      }
-      const memberJson = await memberRes.json() as { data: AgentMember };
-      const newAgentId = memberJson.data.id;
-
-      const keyRes = await fetch(`/api/agents/${newAgentId}/api-keys`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ scope: ['read', 'write'] }),
-      });
-      if (!keyRes.ok) {
-        addToast({ type: 'error', title: 'API Key 자동 생성 실패. 상세 페이지에서 수동으로 발급하세요.' });
-        await fetchSameNameAgents(agent.name);
-        return;
-      }
-      const rawKey = (await keyRes.json() as { data?: { api_key?: string } }).data?.api_key ?? '';
-
-      const projectName = projects.find((p) => p.id === selectedAddProjectId)?.name ?? selectedAddProjectId;
-      setNewProjectResult({ agentId: newAgentId, projectId: selectedAddProjectId, projectName, apiKey: rawKey, webhookUrl: '', savingWebhook: false });
-      setSelectedAddProjectId('');
-      setShowAddToProject(false);
-      await fetchSameNameAgents(agent.name);
-    } finally {
-      setAddingToProject(false);
-    }
-  };
-
-  const handleSaveNewProjectWebhook = async () => {
-    if (!newProjectResult) return;
-    const trimmed = newProjectResult.webhookUrl.trim();
-    if (trimmed && !isWebhookUrlAllowed(trimmed)) {
-      addToast({ type: 'error', title: t('webhookUrlInvalid') });
-      return;
-    }
-    setNewProjectResult((prev) => prev ? { ...prev, savingWebhook: true } : null);
-    try {
-      if (trimmed) {
-        await fetch('/api/webhooks/config', {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ member_id: newProjectResult.agentId, url: trimmed, project_id: newProjectResult.projectId }),
-        });
-      }
-      addToast({ type: 'success', title: `${newProjectResult.projectName} 프로젝트 추가 완료` });
-      setNewProjectResult(null);
-    } finally {
-      setNewProjectResult((prev) => prev ? { ...prev, savingWebhook: false } : null);
     }
   };
 
@@ -763,102 +663,8 @@ export default function AgentDetailPage() {
         </SectionCardBody>
       </SectionCard>
 
-      {/* 다른 프로젝트에 추가 */}
-      <SectionCard>
-        <SectionCardHeader>
-          <div className="flex items-center justify-between w-full">
-            <div className="space-y-1">
-              <h2 className="text-base font-semibold text-foreground">다른 프로젝트에 추가</h2>
-              <p className="text-sm text-muted-foreground">
-                동일 이름으로 다른 프로젝트에 격리 배포합니다. 프로젝트별 독립 API Key와 Webhook이 발급됩니다.
-              </p>
-            </div>
-            {!showAddToProject && availableProjects.length > 0 ? (
-              <Button variant="outline" size="sm" onClick={() => setShowAddToProject(true)}>
-                <Plus className="h-3.5 w-3.5 mr-1" />
-                프로젝트 추가
-              </Button>
-            ) : null}
-          </div>
-        </SectionCardHeader>
-        <SectionCardBody className="space-y-4">
-          {/* 이미 할당된 프로젝트 목록 */}
-          {sameNameAgents.length > 0 ? (
-            <div className="space-y-2">
-              <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">할당된 프로젝트</p>
-              {sameNameAgents.map((a) => {
-                const pName = projects.find((p) => p.id === a.project_id)?.name ?? a.project_id;
-                return (
-                  <div key={a.id} className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/30 px-3 py-2 text-sm">
-                    <span className="text-foreground font-medium">{pName}</span>
-                    <div className="flex items-center gap-2">
-                      {!a.is_active ? <Badge variant="destructive">inactive</Badge> : null}
-                      <Link href={`/settings/members/agents/${a.id}`} className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline">
-                        상세
-                      </Link>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          ) : null}
-
-          {/* 추가 폼 */}
-          {showAddToProject ? (
-            <div className="flex gap-2 items-center">
-              <OperatorDropdownSelect
-                value={selectedAddProjectId}
-                onValueChange={(v) => setSelectedAddProjectId(v)}
-                options={[
-                  { value: '', label: '프로젝트 선택' },
-                  ...availableProjects.map((p) => ({ value: p.id, label: p.name })),
-                ]}
-              />
-              <Button variant="hero" size="sm" onClick={() => void handleAddToProject()} disabled={!selectedAddProjectId || addingToProject}>
-                {addingToProject ? '...' : '추가'}
-              </Button>
-              <Button variant="ghost" size="sm" onClick={() => { setShowAddToProject(false); setSelectedAddProjectId(''); }}>
-                취소
-              </Button>
-            </div>
-          ) : availableProjects.length === 0 ? (
-            <p className="text-xs text-muted-foreground">추가 가능한 프로젝트가 없습니다.</p>
-          ) : null}
-
-          {/* 신규 추가 결과: API Key + Webhook 입력 */}
-          {newProjectResult ? (
-            <div className="rounded-md border border-emerald-500/30 bg-emerald-500/5 p-4 space-y-3">
-              <p className="text-sm font-semibold text-emerald-500">{newProjectResult.projectName} 프로젝트 추가 완료</p>
-              {newProjectResult.apiKey ? (
-                <div className="space-y-1">
-                  <p className="text-xs font-medium text-foreground">API Key — 지금만 표시됩니다. 복사해 두세요.</p>
-                  <code className="block break-all rounded bg-background border border-border p-2 text-xs text-foreground/80 font-mono">
-                    {newProjectResult.apiKey}
-                  </code>
-                </div>
-              ) : null}
-              <div className="space-y-1">
-                <p className="text-xs font-medium text-foreground">Webhook URL (선택)</p>
-                <div className="flex gap-2">
-                  <OperatorInput
-                    type="url"
-                    value={newProjectResult.webhookUrl}
-                    onChange={(e) => setNewProjectResult((prev) => prev ? { ...prev, webhookUrl: e.target.value } : null)}
-                    placeholder="https://your-agent.example.com/webhook"
-                    className="flex-1 font-mono text-xs"
-                  />
-                  <Button variant="hero" size="sm" onClick={() => void handleSaveNewProjectWebhook()} disabled={newProjectResult.savingWebhook}>
-                    {newProjectResult.savingWebhook ? '...' : tc('save')}
-                  </Button>
-                  <Button variant="ghost" size="sm" onClick={() => setNewProjectResult(null)}>
-                    건너뛰기
-                  </Button>
-                </div>
-              </div>
-            </div>
-          ) : null}
-        </SectionCardBody>
-      </SectionCard>
+      {/* 프로젝트 접근 (org-agent 멀티프로젝트 단일키 grant) — 088987d8 */}
+      <AgentProjectAccessSection agentMemberId={id} projects={projects} canEdit={canEdit} />
     </div>
   );
 }

--- a/apps/web/src/components/settings/agent-project-access-section.tsx
+++ b/apps/web/src/components/settings/agent-project-access-section.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Shield, ShieldOff, Loader2 } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
@@ -40,41 +40,43 @@ export function AgentProjectAccessSection({ agentMemberId, projects, canEdit }: 
   const [grantMap, setGrantMap] = useState<Record<string, string>>({});
   // GET access 가 403 인 프로젝트(read 권한 없음) — "grant 없음(차단)"과 구분(RC③). 잘못된 '차단' 표시 방지.
   const [readDeniedIds, setReadDeniedIds] = useState<Set<string>>(new Set());
+  // 일시 오류(500/네트워크 등 non-403)로 상태 미확정인 프로젝트 — "grant 없음"으로 단정하지 않고 재시도 노출.
+  const [errorIds, setErrorIds] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
   const [togglingId, setTogglingId] = useState<string | null>(null);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
   const projectsKey = projects.map((p) => p.id).join(',');
 
-  useEffect(() => {
-    let cancelled = false;
-    async function loadGrants() {
-      setLoading(true);
-      // v1 fan-out: org 전체 프로젝트 access 조회 → member_id===agent 필터로 grant 맵 구성.
-      // 403(read 권한 없음)은 별도 추적해 "grant 없음(차단)"으로 오해석하지 않는다(RC③).
-      const results = await Promise.all(projects.map(async (p) => {
-        const res = await fetch(`/api/projects/${p.id}/access`).catch(() => null);
-        if (res?.status === 403) return { projectId: p.id, readDenied: true } as const;
-        if (!res?.ok) return { projectId: p.id } as const; // 일시 오류 — granted/denied 단정 안 함
-        const json = await res.json() as { data?: AccessRecord[] };
-        const rec = (json.data ?? []).find((r) => r.member_id === agentMemberId);
-        return { projectId: p.id, recordId: rec?.id } as const;
-      }));
-      if (cancelled) return;
-      const map: Record<string, string> = {};
-      const denied = new Set<string>();
-      for (const r of results) {
-        if ('readDenied' in r && r.readDenied) denied.add(r.projectId);
-        else if ('recordId' in r && r.recordId) map[r.projectId] = r.recordId;
-      }
-      setGrantMap(map);
-      setReadDeniedIds(denied);
-      setLoading(false);
+  const loadGrants = useCallback(async () => {
+    setLoading(true);
+    // v1 fan-out: org 전체 프로젝트 access 조회 → member_id===agent 필터로 grant 맵 구성.
+    // 403(read 권한 없음)·일시 오류(500/네트워크)는 각각 별도 추적 — "grant 없음(차단)"으로
+    // 오해석해 잘못된 토글/POST 를 유발하지 않는다(RC③·일시오류 fall-through RC).
+    const results = await Promise.all(projects.map(async (p) => {
+      const res = await fetch(`/api/projects/${p.id}/access`).catch(() => null);
+      if (res?.status === 403) return { projectId: p.id, readDenied: true } as const;
+      if (!res?.ok) return { projectId: p.id, error: true } as const; // transient — granted/denied 단정 안 함
+      const json = await res.json() as { data?: AccessRecord[] };
+      const rec = (json.data ?? []).find((r) => r.member_id === agentMemberId);
+      return { projectId: p.id, recordId: rec?.id } as const;
+    }));
+    const map: Record<string, string> = {};
+    const denied = new Set<string>();
+    const errored = new Set<string>();
+    for (const r of results) {
+      if ('readDenied' in r) denied.add(r.projectId);
+      else if ('error' in r) errored.add(r.projectId);
+      else if (r.recordId) map[r.projectId] = r.recordId;
     }
-    void loadGrants();
-    return () => { cancelled = true; };
+    setGrantMap(map);
+    setReadDeniedIds(denied);
+    setErrorIds(errored);
+    setLoading(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agentMemberId, projectsKey]);
+
+  useEffect(() => { void loadGrants(); }, [loadGrants]);
 
   const handleToggle = async (projectId: string) => {
     if (!canEdit || togglingId) return;
@@ -163,13 +165,22 @@ export function AgentProjectAccessSection({ agentMemberId, projects, canEdit }: 
         ) : (
           <div className="max-h-72 divide-y divide-border overflow-y-auto overflow-x-hidden rounded-md border border-border">
             {projects.map((project) => {
+              const errored = errorIds.has(project.id);
               const readDenied = readDeniedIds.has(project.id);
               const granted = project.id in grantMap;
               const toggling = togglingId === project.id;
               return (
                 <div key={project.id} className="flex items-center justify-between gap-3 px-3 py-3 text-sm">
                   <span className="min-w-0 truncate font-medium text-foreground">{project.name}</span>
-                  {readDenied ? (
+                  {errored ? (
+                    <button
+                      type="button"
+                      onClick={() => void loadGrants()}
+                      className="inline-flex shrink-0 items-center gap-1 text-xs text-destructive hover:underline"
+                    >
+                      로드 실패 · 재시도
+                    </button>
+                  ) : readDenied ? (
                     <span
                       className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground"
                       title="이 프로젝트의 접근 상태를 조회할 권한이 없습니다."

--- a/apps/web/src/components/settings/agent-project-access-section.tsx
+++ b/apps/web/src/components/settings/agent-project-access-section.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Shield, ShieldOff, Loader2 } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
+import { cn } from '@/lib/utils';
+
+/**
+ * org-agent 멀티프로젝트 접근 관리 (story 088987d8).
+ *
+ * 휴먼용 ProjectAccessSection("한 프로젝트 × 멤버 토글")을 **에이전트-중심으로 반전**한다 —
+ * "한 에이전트 × org 전체 프로젝트, 각 행에 허용/차단 grant 토글". add/remove 를 토글 하나로 통합.
+ * 단일 키 grant 모델: grant/revoke 가 API 키에 영향 없음(키 1개 유지). 신규 토큰 0.
+ *
+ * grant 식별자 = 에이전트의 member id(= team_member.id = anchor members.id; org_agent 가 grant 시
+ * member_id=member.id 로 fan-out 한 그 값). 에이전트-중심 조회 엔드포인트가 없어 org 전체 프로젝트를
+ * 순회(`GET .../access`)하며 member_id 일치 grant 맵(project_id→record_id)을 구성한다(v1 fan-out).
+ */
+
+interface ProjectOption {
+  id: string;
+  name: string;
+}
+
+interface AccessRecord {
+  id: string;
+  member_id?: string | null;
+}
+
+interface AgentProjectAccessSectionProps {
+  agentMemberId: string;
+  projects: ProjectOption[];
+  canEdit: boolean;
+}
+
+export function AgentProjectAccessSection({ agentMemberId, projects, canEdit }: AgentProjectAccessSectionProps) {
+  // project_id → grant record_id (granted 프로젝트만 키 보유).
+  const [grantMap, setGrantMap] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(true);
+  const [togglingId, setTogglingId] = useState<string | null>(null);
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  const projectsKey = projects.map((p) => p.id).join(',');
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadGrants() {
+      setLoading(true);
+      // v1 fan-out: org 전체 프로젝트 access 조회 → member_id===agent 필터로 grant 맵 구성.
+      const entries = await Promise.all(projects.map(async (p) => {
+        const res = await fetch(`/api/projects/${p.id}/access`).catch(() => null);
+        if (!res?.ok) return null;
+        const json = await res.json() as { data?: AccessRecord[] };
+        const rec = (json.data ?? []).find((r) => r.member_id === agentMemberId);
+        return rec ? ([p.id, rec.id] as const) : null;
+      }));
+      if (cancelled) return;
+      const map: Record<string, string> = {};
+      for (const e of entries) if (e) map[e[0]] = e[1];
+      setGrantMap(map);
+      setLoading(false);
+    }
+    void loadGrants();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentMemberId, projectsKey]);
+
+  const handleToggle = async (projectId: string) => {
+    if (!canEdit || togglingId) return;
+    setTogglingId(projectId);
+    setMessage(null);
+    const recordId = grantMap[projectId];
+    const projectName = projects.find((p) => p.id === projectId)?.name ?? projectId;
+    try {
+      if (recordId) {
+        // 차단 — DELETE grant (키 불변).
+        const res = await fetch(`/api/projects/${projectId}/access/${recordId}`, { method: 'DELETE' });
+        if (res.ok) {
+          setGrantMap((m) => { const n = { ...m }; delete n[projectId]; return n; });
+          setMessage({ type: 'success', text: `${projectName} 접근을 차단했습니다.` });
+        } else {
+          setMessage({ type: 'error', text: `${projectName} 차단에 실패했습니다.` });
+        }
+      } else {
+        // 허용 — POST grant (새 API 키 발급 없음).
+        const res = await fetch(`/api/projects/${projectId}/access`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ member_id: agentMemberId, org_member_id: null, permission: 'granted' }),
+        });
+        if (res.ok) {
+          let recId = (await res.json().catch(() => null) as { data?: AccessRecord } | null)?.data?.id;
+          if (!recId) {
+            // 응답에 record id 없으면 해당 프로젝트만 재조회(1콜)로 확보.
+            const g = await fetch(`/api/projects/${projectId}/access`).catch(() => null);
+            if (g?.ok) {
+              const j = await g.json() as { data?: AccessRecord[] };
+              recId = (j.data ?? []).find((r) => r.member_id === agentMemberId)?.id;
+            }
+          }
+          if (recId) setGrantMap((m) => ({ ...m, [projectId]: recId! }));
+          setMessage({ type: 'success', text: `${projectName} 접근을 허용했습니다.` });
+        } else {
+          setMessage({ type: 'error', text: `${projectName} 허용에 실패했습니다.` });
+        }
+      }
+    } finally {
+      setTogglingId(null);
+    }
+  };
+
+  const grantedCount = Object.keys(grantMap).length;
+
+  return (
+    <SectionCard>
+      <SectionCardHeader>
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-1">
+            <h2 className="text-base font-semibold text-foreground">프로젝트 접근</h2>
+            <p className="text-sm text-muted-foreground">
+              이 에이전트는 API 키 1개로 아래 프로젝트들에 접근합니다. 프로젝트를 추가/제거해도 키는 그대로 유지됩니다.
+            </p>
+          </div>
+          {!loading && projects.length > 0 ? (
+            <div className="shrink-0 text-right text-xs text-muted-foreground tabular-nums">
+              <div className="font-medium text-foreground">{grantedCount} / {projects.length}</div>
+              <div>허용됨</div>
+            </div>
+          ) : null}
+        </div>
+      </SectionCardHeader>
+      <SectionCardBody className="space-y-3">
+        {message && (
+          <Alert variant={message.type === 'success' ? 'success' : 'destructive'}>
+            <AlertDescription>{message.text}</AlertDescription>
+          </Alert>
+        )}
+
+        {loading ? (
+          <div className="space-y-1 divide-y divide-border">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="flex items-center gap-3 px-3 py-3">
+                <div className="h-4 w-32 flex-1 animate-pulse rounded bg-muted" />
+                <div className="h-7 w-20 animate-pulse rounded bg-muted" />
+              </div>
+            ))}
+          </div>
+        ) : projects.length === 0 ? (
+          <p className="rounded-md border border-dashed border-border px-3 py-6 text-sm text-muted-foreground">
+            접근 가능한 프로젝트가 없습니다.
+          </p>
+        ) : (
+          <div className="max-h-72 divide-y divide-border overflow-y-auto overflow-x-hidden rounded-md border border-border">
+            {projects.map((project) => {
+              const granted = project.id in grantMap;
+              const toggling = togglingId === project.id;
+              return (
+                <div key={project.id} className="flex items-center justify-between gap-3 px-3 py-3 text-sm">
+                  <span className="min-w-0 truncate font-medium text-foreground">{project.name}</span>
+                  {canEdit ? (
+                    <Button
+                      variant="glass"
+                      size="sm"
+                      disabled={toggling}
+                      onClick={() => void handleToggle(project.id)}
+                      className={cn(
+                        'min-w-[72px] shrink-0 gap-1 transition-colors',
+                        granted
+                          ? 'border-success/40 bg-success-tint text-success hover:bg-success/15'
+                          : 'border-border text-muted-foreground hover:bg-muted/40',
+                      )}
+                    >
+                      {toggling ? (
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                      ) : granted ? (
+                        <><Shield className="h-3 w-3" />허용</>
+                      ) : (
+                        <><ShieldOff className="h-3 w-3" />차단</>
+                      )}
+                    </Button>
+                  ) : (
+                    <span className={cn(
+                      'inline-flex shrink-0 items-center gap-1 text-xs',
+                      granted ? 'text-success' : 'text-muted-foreground',
+                    )}>
+                      {granted ? <Shield className="h-3 w-3" /> : <ShieldOff className="h-3 w-3" />}
+                      {granted ? '허용' : '차단'}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </SectionCardBody>
+    </SectionCard>
+  );
+}

--- a/apps/web/src/components/settings/agent-project-access-section.tsx
+++ b/apps/web/src/components/settings/agent-project-access-section.tsx
@@ -38,6 +38,8 @@ interface AgentProjectAccessSectionProps {
 export function AgentProjectAccessSection({ agentMemberId, projects, canEdit }: AgentProjectAccessSectionProps) {
   // project_id → grant record_id (granted 프로젝트만 키 보유).
   const [grantMap, setGrantMap] = useState<Record<string, string>>({});
+  // GET access 가 403 인 프로젝트(read 권한 없음) — "grant 없음(차단)"과 구분(RC③). 잘못된 '차단' 표시 방지.
+  const [readDeniedIds, setReadDeniedIds] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
   const [togglingId, setTogglingId] = useState<string | null>(null);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
@@ -49,17 +51,24 @@ export function AgentProjectAccessSection({ agentMemberId, projects, canEdit }: 
     async function loadGrants() {
       setLoading(true);
       // v1 fan-out: org 전체 프로젝트 access 조회 → member_id===agent 필터로 grant 맵 구성.
-      const entries = await Promise.all(projects.map(async (p) => {
+      // 403(read 권한 없음)은 별도 추적해 "grant 없음(차단)"으로 오해석하지 않는다(RC③).
+      const results = await Promise.all(projects.map(async (p) => {
         const res = await fetch(`/api/projects/${p.id}/access`).catch(() => null);
-        if (!res?.ok) return null;
+        if (res?.status === 403) return { projectId: p.id, readDenied: true } as const;
+        if (!res?.ok) return { projectId: p.id } as const; // 일시 오류 — granted/denied 단정 안 함
         const json = await res.json() as { data?: AccessRecord[] };
         const rec = (json.data ?? []).find((r) => r.member_id === agentMemberId);
-        return rec ? ([p.id, rec.id] as const) : null;
+        return { projectId: p.id, recordId: rec?.id } as const;
       }));
       if (cancelled) return;
       const map: Record<string, string> = {};
-      for (const e of entries) if (e) map[e[0]] = e[1];
+      const denied = new Set<string>();
+      for (const r of results) {
+        if ('readDenied' in r && r.readDenied) denied.add(r.projectId);
+        else if ('recordId' in r && r.recordId) map[r.projectId] = r.recordId;
+      }
       setGrantMap(map);
+      setReadDeniedIds(denied);
       setLoading(false);
     }
     void loadGrants();
@@ -154,12 +163,20 @@ export function AgentProjectAccessSection({ agentMemberId, projects, canEdit }: 
         ) : (
           <div className="max-h-72 divide-y divide-border overflow-y-auto overflow-x-hidden rounded-md border border-border">
             {projects.map((project) => {
+              const readDenied = readDeniedIds.has(project.id);
               const granted = project.id in grantMap;
               const toggling = togglingId === project.id;
               return (
                 <div key={project.id} className="flex items-center justify-between gap-3 px-3 py-3 text-sm">
                   <span className="min-w-0 truncate font-medium text-foreground">{project.name}</span>
-                  {canEdit ? (
+                  {readDenied ? (
+                    <span
+                      className="inline-flex shrink-0 items-center gap-1 text-xs text-muted-foreground"
+                      title="이 프로젝트의 접근 상태를 조회할 권한이 없습니다."
+                    >
+                      확인 권한 없음
+                    </span>
+                  ) : canEdit ? (
                     <Button
                       variant="glass"
                       size="sm"


### PR DESCRIPTION
## 무엇을

유나양 디자인 핸드오프 — 에이전트 상세(설정→Members→Agents→[에이전트])의 옛 **"다른 프로젝트에 추가"**(프로젝트마다 새 team_member 레코드 + 새 API 키 발급) 섹션을 **단일 키 grant 모델**(키 1개 유지·프로젝트 접근만 grant/revoke)로 교체. (story `088987d8`·high·아버님 적출, doc `org-agent-multiproject-access-handoff`)

**BE grant 계약·Next 프록시(`api/projects/[id]/access`·`[recordId]`) 모두 기존 존재 → FE만.**

## 변경 (Option A — 락)

- **신규 `AgentProjectAccessSection`**(`components/settings/`): 휴먼용 `ProjectAccessSection`("한 프로젝트 × 멤버 토글")을 **에이전트-중심 반전**("한 에이전트 × org 전체 프로젝트, 각 행 허용/차단 토글"). add/remove를 **토글 하나로 통합**.
  - 행 패턴·토큰 미러: granted `border-success/40 bg-success-tint text-success`+Shield "허용" / not `border-border text-muted-foreground hover:bg-muted/40`+ShieldOff "차단" / toggling `Loader2`. 컨테이너 `divide-y rounded-md border` + `max-h-72 overflow-y-auto`.
  - 무-확인 즉시 토글 + 성공/실패 Alert(가역·원본 정합·확인 다이얼로그 없음).
- **grant 식별자 = agent member id** (= route `id` = team_member.id = anchor members.id). org_agent 가 `member_id=member.id` 로 grant fan-out 한 값과 동일 — **BE(`org_agent.py`) 교차확인**(추측 없이).
- **현재 grant 조회 = v1 FE fan-out**(org 전체 프로젝트 `GET .../access` → `member_id` 일치 grant 맵 `project_id→record_id`). 에이전트-중심 `GET /agents/{id}/projects`는 디디군 BE 후속(§Q3).
- 토글 ON = `POST .../access {member_id, org_member_id:null, permission:"granted"}` (**새 API 키 0**), OFF = `DELETE .../access/{recordId}`. 옵티미스틱 맵 갱신(전체 재fetch 없이 단일 프로젝트만).
- 권한 게이트 `canEdit`(creator/admin/owner) — 비권한자 읽기전용 허용/차단 텍스트.
- 헤더 카피로 단일키 모델 명시: "이 에이전트는 API 키 1개로 아래 프로젝트들에 접근합니다. 프로젝트를 추가/제거해도 키는 그대로 유지됩니다."
- **옛 결과 카드(emerald-500 매직컬러) 소멸** + 옛 add 머시너리(`handleAddToProject`·`sameNameAgents`·`availableProjects`·`newProjectResult`·`orgId` 등) 전량 제거.

## AC 커버

- AC1 org 전체 프로젝트 grant 상태 표시 ✅ / AC2 토글 grant POST·revoke DELETE·**새 키 0** ✅ / AC3 canEdit 게이트·비권한 읽기전용 ✅ / AC4 단일 키 유지(카피 명시) ✅ / AC5 신규 토큰/매직 hex 0(결과카드 emerald 제거) ✅

> ⚠️ 페이지 내 **무관 선존 emerald-500 2건**(저장 체크 L406·키 복사 안내 L607)은 이 스토리 밖 UI라 스코프 외로 잔존(결과 카드 emerald만 제거 대상). 필요시 별 정리.

## 검증

- `pnpm type-check` ✅ / `pnpm lint`(대상 2파일) ✅ 0 warning / `pnpm build` ✅ EXIT 0
- base=`origin/develop`(`2c659583`)

까심 QA(grant/revoke·키 불변·권한 org admin·fan-out)→머지게이트→**유나양 가디언 시각 정합 리뷰**→dev 픽셀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)