### PR TITLE
feat(hitl): 안전 하한 clamp + self-approval 차단 (S-GATE-3)

### DIFF
--- a/backend/app/services/gate_enforce.py
+++ b/backend/app/services/gate_enforce.py
@@ -57,6 +57,20 @@ async def _resolve_level_failclosed(
     return chosen
 
 
+# S-GATE-3 §3d **hard floor** — config 밑으로 못 내리는 안전 하한(hard-enforce·org config 무관).
+# main 머지(work_type='merge')는 최소 'ask'(auto 금지). 'done'은 하한 없음(auto 허용). prod 액션은
+# 별 work_type 신설 시 여기 추가(현재 work_types=done/merge). org가 auto로 설정해도 floor가 이긴다.
+_SAFETY_FLOOR: dict[str, str] = {"merge": "ask"}
+
+
+def _clamp_to_floor(level: str, work_type: str) -> str:
+    """resolve 레벨을 안전 하한 위로 clamp(더 restrictive 채택). floor=ask면 auto→ask(다운 금지)."""
+    floor = _SAFETY_FLOOR.get(work_type)
+    if floor is None:
+        return level
+    return max((level, floor), key=lambda lv: _RESTRICT_RANK.get(lv, 1))
+
+
 def _enforce_allowlist() -> set[uuid.UUID]:
     out: set[uuid.UUID] = set()
     for tok in (settings.gate_config_enforce_org_allowlist or "").split(","):
@@ -101,6 +115,13 @@ async def enforce_gate(
         session, org_id=org_id, project_id=project_id,
         work_type=work_type, actor_type=actor_type,
     )
+    # S-GATE-3 ②③: 안전 하한 clamp(§3d hard) — floor 밑으로 못 내림(org config auto여도 floor가 이김).
+    floored = _clamp_to_floor(level, work_type)
+    if floored != level:
+        logger.info(
+            "gate_enforced org=%s work=%s floor_clamp %s→%s", org_id, work_type, level, floored
+        )
+    level = floored
     if level == "auto":
         logger.info(
             "gate_enforced org=%s project=%s work=%s actor=%s level=auto outcome=auto",
@@ -129,7 +150,12 @@ async def enforce_gate(
     #   pending  → 기존 request 재사용(dup park 방지) · 없음 → 신규 pending park.
     row = (
         await session.execute(
-            select(HitlRequest.id, HitlRequest.status).where(
+            select(
+                HitlRequest.id,
+                HitlRequest.status,
+                HitlRequest.responded_by,
+                HitlRequest.hitl_metadata["actor_id"].astext,
+            ).where(
                 HitlRequest.org_id == org_id,
                 HitlRequest.request_type == _GATE_REQUEST_TYPE,
                 HitlRequest.deleted_at.is_(None),
@@ -140,8 +166,30 @@ async def enforce_gate(
     ).first()
 
     if row is not None:
-        req_id, req_status = row[0], row[1]
+        req_id, req_status, responded_by, orig_actor_id = row[0], row[1], row[2], row[3]
         if req_status == "approved":
+            # S-GATE-3 ①: self-approval 차단(§3d hard) — 승인자(responded_by)가 원 트리거 actor
+            # (park 시 metadata.actor_id)와 동일하면 거부(다른 승인자 필요). 둘 다 known·동일일 때만.
+            if (
+                responded_by is not None
+                and orig_actor_id is not None
+                and str(responded_by) == str(orig_actor_id)
+            ):
+                logger.warning(
+                    "gate_enforced org=%s work=%s outcome=blocked_self_approval request=%s actor=%s",
+                    org_id, work_type, req_id, orig_actor_id,
+                )
+                raise HTTPException(
+                    status_code=409,
+                    detail={
+                        "code": "GATE_SELF_APPROVAL",
+                        "work_type": work_type,
+                        "level": "ask",
+                        "request_id": str(req_id),
+                        "requires_human": True,
+                        "message": f"{work_type} 승인자가 요청자와 동일 — self-approval 금지(다른 승인자 필요).",
+                    },
+                )
             logger.info(
                 "gate_enforced org=%s work=%s level=ask outcome=resumed approved_request=%s",
                 org_id, work_type, req_id,

--- a/backend/tests/test_gate_enforce_s2.py
+++ b/backend/tests/test_gate_enforce_s2.py
@@ -29,10 +29,10 @@ def _session(execute_side_effect=None):
     return s
 
 
-async def _enforce(ge, session, actor_type="agent"):
+async def _enforce(ge, session, actor_type="agent", work_type="done"):
     return await ge.enforce_gate(
         session, org_id=uuid.uuid4(), project_id=uuid.uuid4(),
-        work_type="done", actor_type=actor_type, actor_id=uuid.uuid4(),
+        work_type=work_type, actor_type=actor_type, actor_id=uuid.uuid4(),
         work_item_id=uuid.uuid4(), work_item_title="X",
     )
 
@@ -101,8 +101,11 @@ async def test_ask_creates_request_and_409():
 async def test_ask_resumes_on_approved():
     from app.services import gate_enforce as ge
 
-    # 최신 결정 = approved → 통과(재시도 통과·§6-2 A)
-    session = _session(execute_side_effect=[_first((uuid.uuid4(), "approved"))])
+    # 최신 결정 = approved·승인자≠요청자 → 통과(재시도 통과·§6-2 A)
+    # row = (id, status, responded_by, orig_actor_id)
+    session = _session(execute_side_effect=[
+        _first((uuid.uuid4(), "approved", uuid.uuid4(), uuid.uuid4()))
+    ])
     with patch.object(ge, "gate_config_enforce_active", return_value=True), patch.object(
         ge, "resolve_gate_level", new=AsyncMock(return_value="ask")
     ):
@@ -117,7 +120,7 @@ async def test_ask_rejected_remains_blocked():
 
     from app.services import gate_enforce as ge
 
-    session = _session(execute_side_effect=[_first((uuid.uuid4(), "rejected"))])
+    session = _session(execute_side_effect=[_first((uuid.uuid4(), "rejected", None, None))])
     with patch.object(ge, "gate_config_enforce_active", return_value=True), patch.object(
         ge, "resolve_gate_level", new=AsyncMock(return_value="ask")
     ):
@@ -135,7 +138,7 @@ async def test_ask_existing_pending_no_dup_409():
     from app.services import gate_enforce as ge
 
     # 최신 결정 = pending → 중복 생성 안 함·기존 request_id 로 409
-    session = _session(execute_side_effect=[_first((uuid.uuid4(), "pending"))])
+    session = _session(execute_side_effect=[_first((uuid.uuid4(), "pending", None, None))])
     with patch.object(ge, "gate_config_enforce_active", return_value=True), patch.object(
         ge, "resolve_gate_level", new=AsyncMock(return_value="ask")
     ):
@@ -179,6 +182,58 @@ async def test_failclosed_known_actor_single_resolve():
     ):
         await _enforce(ge, session, actor_type="agent")
     assert rgl.await_count == 1  # 알려진 actor → 1회만
+
+
+# ── S-GATE-3: 안전 하한(floor clamp) + self-approval 차단 ──────────────────────
+
+
+@pytest.mark.anyio
+async def test_floor_clamp_merge_auto_becomes_ask():
+    """§3d ②③: merge floor=ask — config auto여도 auto로 못 내림. auto→ask→park."""
+    from fastapi import HTTPException
+
+    from app.services import gate_enforce as ge
+
+    # merge·config=auto 이지만 floor=ask → ask 분기(이력 없음→park)
+    session = _session(execute_side_effect=[_first(None)])
+    with patch.object(ge, "gate_config_enforce_active", return_value=True), patch.object(
+        ge, "resolve_gate_level", new=AsyncMock(return_value="auto")
+    ):
+        with pytest.raises(HTTPException) as ei:
+            await _enforce(ge, session, work_type="merge")
+    assert ei.value.status_code == 409
+    assert ei.value.detail["code"] == "GATE_ASK"  # auto 였지만 floor가 ask로 끌어올림
+    session.add.assert_called_once()
+
+
+def test_clamp_to_floor_unit():
+    """floor clamp 단위 — merge: auto/ask→ask·block 유지. done: 하한 없음."""
+    from app.services.gate_enforce import _clamp_to_floor
+
+    assert _clamp_to_floor("auto", "merge") == "ask"
+    assert _clamp_to_floor("ask", "merge") == "ask"
+    assert _clamp_to_floor("block", "merge") == "block"  # 더 restrictive 유지
+    assert _clamp_to_floor("auto", "done") == "auto"  # done 하한 없음
+
+
+@pytest.mark.anyio
+async def test_self_approval_blocked():
+    """§3d ①: 승인자(responded_by)==원 트리거 actor(metadata.actor_id) → 409 GATE_SELF_APPROVAL."""
+    from fastapi import HTTPException
+
+    from app.services import gate_enforce as ge
+
+    same = uuid.uuid4()
+    # approved 인데 responded_by == orig_actor_id → self-approval
+    session = _session(execute_side_effect=[_first((uuid.uuid4(), "approved", same, same))])
+    with patch.object(ge, "gate_config_enforce_active", return_value=True), patch.object(
+        ge, "resolve_gate_level", new=AsyncMock(return_value="ask")
+    ):
+        with pytest.raises(HTTPException) as ei:
+            await _enforce(ge, session)
+    assert ei.value.status_code == 409
+    assert ei.value.detail["code"] == "GATE_SELF_APPROVAL"
+    session.add.assert_not_called()  # self-approval → 통과 안 함·재park도 안 함
 
 
 # ── gate_config_enforce_active flag ──────────────────────────────────────────


### PR DESCRIPTION
E-HITL-GATING **S-GATE-3**(안전 하한·정책 §3d hard floor). S-GATE-2(집행) 위. **dev 전용·마이그 없음·flag-gated**(S-GATE-2 enforce flag 공유).

## 무엇 — resolve_gate_level 위에 hard clamp
정책 §8 = **hard-enforce**(advisory 아님). enforce_gate 가 resolve 후 floor 적용:
- **① self-approval 차단** — approved HitlRequest 의 승인자(`responded_by`)가 **원 트리거 actor**(park 시 `metadata.actor_id`)와 동일하면 통과 거부 → 409 `GATE_SELF_APPROVAL`. 둘 다 known·동일일 때만(unverifiable 과오차단 회피).
- **② main 머지 최소 ask** — `work_type=merge` floor=`ask`. config 가 auto여도 `_clamp_to_floor` 가 auto→ask 로 끌어올림(auto 금지).
- **③ org 하한 밑 다운 불가** — floor 가 config 보다 restrictive면 floor 채택(block>ask>auto). org config 무관 hard.

## 설계 선택(사인오프 요청)
1. **floor map = `{merge: ask}`** — done 은 하한 없음(스토리 done≠prod 액션). prod 액션은 별 work_type 신설 시 추가(현재 work_types=done/merge).
2. **self-approval = 승인자==원 트리거 actor(metadata.actor_id)** 비교, 둘 다 known·동일일 때만 차단(orig/approver 불명이면 과오차단 안 함). enforce-time hard 게이트(승인 엔드포인트 별도 강화는 후속 가능).
3. **floor 하드코딩**(org-configurable 아님·§3d hard 안전망).
4. ⚠️ **H1 trust auto_merge 상호작용** — enforce flag on일 때 merge floor=ask 라 H1 의 trust 기반 auto_merge 가 ask 로 게이트됨(의도된 안전망·main 자동머지 금지). flag off면 H1 무변경.

## 테스트
`test_gate_enforce_s2.py` 13(+`test_floor_clamp_merge_auto_becomes_ask`·`test_clamp_to_floor_unit`·`test_self_approval_blocked`). 회귀 0(stories/workflow_report/gate/hitl/merge_gate **227 passed**). import OK.

QA 포커스: self-approval 음성(승인자≠요청자 통과·==차단)·floor clamp(merge auto→ask·done 무변경·block 유지)·flag off 무회귀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)