### PR TITLE
feat(settings): HITL 게이트 레벨 매트릭스 v1 (S-GATE-4)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2465,6 +2465,21 @@
     "metric_completion_pct": "Completion %",
     "hypothesisPlaceholder_epic": "What outcome do we expect by completing this epic?"
   },
+  "gateConfig": {
+    "title": "Gate Policy",
+    "description": "Set whether work proceeds automatically, requires human review, or is blocked.",
+    "levelAuto": "Auto",
+    "levelAsk": "Ask",
+    "levelBlock": "Block",
+    "work_done": "Done",
+    "work_merge": "Merge",
+    "actor_agent": "Agent",
+    "actor_human": "Human",
+    "mergeFloorNote": "Safety floor: merge requires at least Ask · self-approval blocked",
+    "floorDisabledHint": "Disabled by safety floor",
+    "saved": "Saved",
+    "saveFailed": "Failed to save."
+  },
   "cage": {
     "gatePending": "gate pending",
     "gateApprove": "Approve",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2465,6 +2465,21 @@
     "metric_completion_pct": "완료율 %",
     "hypothesisPlaceholder_epic": "이 에픽을 완수하면 어떤 성과를 기대하는가?"
   },
+  "gateConfig": {
+    "title": "게이트 정책",
+    "description": "작업이 자동으로 진행될지, 사람 검토를 거칠지, 차단될지 설정합니다.",
+    "levelAuto": "자동",
+    "levelAsk": "확인",
+    "levelBlock": "차단",
+    "work_done": "완료",
+    "work_merge": "병합",
+    "actor_agent": "에이전트",
+    "actor_human": "사람",
+    "mergeFloorNote": "안전 하한: 병합은 최소 '확인' · 자기 승인 차단",
+    "floorDisabledHint": "안전 하한으로 비활성화됨",
+    "saved": "저장됨",
+    "saveFailed": "저장에 실패했습니다."
+  },
   "cage": {
     "gatePending": "게이트 대기",
     "gateApprove": "승인",

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -22,6 +22,7 @@ import { WorkflowTemplateGallerySection } from '@/components/settings/workflow-t
 import { ThemeSettings } from '@/components/settings/theme-settings';
 import { RefreshSettings } from '@/components/settings/refresh-settings';
 import { StandupDeadlineSection } from '@/components/settings/standup-deadline-section';
+import { GateLevelMatrix } from '@/components/settings/gate-level-matrix';
 import { TwoFactorSection } from '@/components/settings/two-factor-section';
 import { SetPasswordSection } from '@/components/settings/set-password-section';
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -1031,6 +1032,17 @@ export default function SettingsPage() {
               {currentProjectId ? (
                 <div className="mt-6">
                   <StandupDeadlineSection projectId={currentProjectId} />
+                </div>
+              ) : null}
+              {/* S-GATE-4: 프로젝트 게이트 정책(승인 레벨) 매트릭스. scope=project override. canEdit 은
+                  안전 subset(org admin/owner) — BE 는 project owner 도 허용하나 FE 는 보수적 게이트(과권한 0). */}
+              {currentProjectId ? (
+                <div className="mt-6">
+                  <GateLevelMatrix
+                    projectId={currentProjectId}
+                    scope="project"
+                    canEdit={currentOrgRole === 'owner' || currentOrgRole === 'admin'}
+                  />
                 </div>
               ) : null}
               <div className="mt-6">

--- a/apps/web/src/app/api/projects/[id]/gate-config/route.ts
+++ b/apps/web/src/app/api/projects/[id]/gate-config/route.ts
@@ -1,0 +1,24 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/**
+ * HITL 게이트 레벨 config 프록시 (S-GATE-4). BE `GET/PUT /api/v2/projects/{id}/gate-config`.
+ * GET = effective 레벨 목록(`{work_type,actor_type,level}[]`) / PUT = 셀 1개 설정
+ * (`{scope:'org'|'project',work_type,actor_type,level}`). 권한·안전하한은 BE 강제.
+ */
+export async function GET(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/projects/[id]/gate-config', { id });
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess([]);
+  return apiSuccess(await _r.json());
+}
+
+export async function PUT(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/projects/[id]/gate-config', { id });
+  if (!_r.ok) return _r;
+  return apiSuccess(await _r.json());
+}

--- a/apps/web/src/components/settings/gate-level-matrix.tsx
+++ b/apps/web/src/components/settings/gate-level-matrix.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Lock } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
+import { cn } from '@/lib/utils';
+
+/**
+ * HITL 게이트 레벨 매트릭스 (S-GATE-4). (work_type done·merge) × (actor agent·human) → level
+ * (auto·ask·block) 를 설정. 레벨 컬러/마크는 `components/cage/gate-evidence` DECISION_META 와
+ * **verbatim 미러**(설정한 것 = 인박스에서 보는 것).
+ *
+ * v1(이 PR): effective 레벨 표시 + 셀 즉시 PUT(낙관적·실패 롤백). 2계층 상속/재정의 시각·↺복귀는
+ * BE(org-layer GET·셀별 source·override DELETE) 랜딩 후 와이어 — 컴포넌트는 그때 source-aware 확장.
+ * 안전 하한(merge≥ask·self-approval 차단)은 BE(S-GATE-3) 강제 — UI 는 floor 를 **표현만**(우회 금지).
+ */
+
+type Level = 'auto' | 'ask' | 'block';
+type WorkType = 'done' | 'merge';
+type ActorType = 'agent' | 'human';
+
+interface GateLevelEntry { work_type: string; actor_type: string; level: string }
+
+const WORK_TYPES: WorkType[] = ['done', 'merge'];
+const ACTOR_TYPES: ActorType[] = ['agent', 'human'];
+const LEVELS: Level[] = ['auto', 'ask', 'block'];
+
+// GateEvidence DECISION_META 미러: auto→success ✓ / ask→warning ⏸ / block→destructive ⛔.
+const LEVEL_META: Record<Level, { selected: string; badge: 'success' | 'warning' | 'destructive'; mark: string; labelKey: string }> = {
+  auto: { selected: 'border-success-border bg-success-tint text-success', badge: 'success', mark: '✓', labelKey: 'levelAuto' },
+  ask: { selected: 'border-warning-border bg-warning-tint text-warning', badge: 'warning', mark: '⏸', labelKey: 'levelAsk' },
+  block: { selected: 'border-destructive/40 bg-destructive/10 text-destructive', badge: 'destructive', mark: '⛔', labelKey: 'levelBlock' },
+};
+
+// 안전 하한(S-GATE-3 BE 강제): merge 는 최소 'ask' — 'auto' 비활성(UI 표현만, BE 가 우회 차단).
+const isLevelDisabled = (workType: WorkType, level: Level): boolean => workType === 'merge' && level === 'auto';
+
+const cellKey = (w: string, a: string) => `${w}:${a}`;
+
+interface GateLevelMatrixProps {
+  projectId: string;
+  scope: 'org' | 'project';
+  canEdit: boolean;
+}
+
+export function GateLevelMatrix({ projectId, scope, canEdit }: GateLevelMatrixProps) {
+  const t = useTranslations('gateConfig');
+  const [levels, setLevels] = useState<Record<string, Level>>({});
+  const [loading, setLoading] = useState(true);
+  const [savingCell, setSavingCell] = useState<string | null>(null);
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      const res = await fetch(`/api/projects/${projectId}/gate-config`).catch(() => null);
+      if (cancelled) return;
+      if (res?.ok) {
+        const json = await res.json() as { data?: GateLevelEntry[] };
+        const map: Record<string, Level> = {};
+        for (const e of json.data ?? []) {
+          if ((LEVELS as string[]).includes(e.level)) map[cellKey(e.work_type, e.actor_type)] = e.level as Level;
+        }
+        setLevels(map);
+      }
+      setLoading(false);
+    }
+    void load();
+    return () => { cancelled = true; };
+  }, [projectId]);
+
+  const handleSet = async (workType: WorkType, actorType: ActorType, level: Level) => {
+    if (!canEdit || isLevelDisabled(workType, level) || savingCell) return;
+    const key = cellKey(workType, actorType);
+    if (levels[key] === level) return;
+    const prev = levels[key];
+    setSavingCell(key);
+    setMessage(null);
+    setLevels((m) => ({ ...m, [key]: level })); // 낙관적(assignee #1539 패턴)
+    try {
+      const res = await fetch(`/api/projects/${projectId}/gate-config`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ scope, work_type: workType, actor_type: actorType, level }),
+      });
+      if (res.ok) {
+        const json = await res.json().catch(() => null) as { data?: GateLevelEntry } | null;
+        const applied = json?.data?.level;
+        if (applied && (LEVELS as string[]).includes(applied)) setLevels((m) => ({ ...m, [key]: applied as Level }));
+        setMessage({ type: 'success', text: t('saved') });
+      } else {
+        setLevels((m) => (prev ? { ...m, [key]: prev } : (() => { const n = { ...m }; delete n[key]; return n; })()));
+        setMessage({ type: 'error', text: t('saveFailed') });
+      }
+    } catch {
+      setLevels((m) => (prev ? { ...m, [key]: prev } : (() => { const n = { ...m }; delete n[key]; return n; })()));
+      setMessage({ type: 'error', text: t('saveFailed') });
+    } finally {
+      setSavingCell(null);
+    }
+  };
+
+  return (
+    <SectionCard>
+      <SectionCardHeader>
+        <div className="space-y-1">
+          <h2 className="text-base font-semibold text-foreground">{t('title')}</h2>
+          <p className="text-sm text-muted-foreground">{t('description')}</p>
+        </div>
+      </SectionCardHeader>
+      <SectionCardBody className="space-y-4">
+        {message && (
+          <Alert variant={message.type === 'success' ? 'success' : 'destructive'}>
+            <AlertDescription>{message.text}</AlertDescription>
+          </Alert>
+        )}
+
+        {/* 레전드 */}
+        <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+          {LEVELS.map((lv) => (
+            <span key={lv} className="inline-flex items-center gap-1">
+              <span aria-hidden>{LEVEL_META[lv].mark}</span>{t(LEVEL_META[lv].labelKey)}
+            </span>
+          ))}
+        </div>
+
+        {loading ? (
+          <div className="space-y-1 divide-y divide-border">
+            {[1, 2, 3, 4].map((i) => (
+              <div key={i} className="flex items-center justify-between gap-3 px-3 py-3">
+                <div className="h-4 w-20 animate-pulse rounded bg-muted" />
+                <div className="h-7 w-48 animate-pulse rounded bg-muted" />
+              </div>
+            ))}
+          </div>
+        ) : (
+          WORK_TYPES.map((wt) => (
+            <div key={wt} className="space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="text-sm font-semibold text-foreground">{t(`work_${wt}`)}</p>
+                {wt === 'merge' ? (
+                  <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                    <Lock className="h-3 w-3" />
+                    {t('mergeFloorNote')}
+                  </span>
+                ) : null}
+              </div>
+              <div className="divide-y divide-border overflow-hidden rounded-md border border-border">
+                {ACTOR_TYPES.map((at) => {
+                  const key = cellKey(wt, at);
+                  const current = levels[key];
+                  const saving = savingCell === key;
+                  return (
+                    <div key={at} className="flex items-center justify-between gap-3 px-3 py-2.5 text-sm">
+                      <span className="font-medium text-foreground">{t(`actor_${at}`)}</span>
+                      {canEdit ? (
+                        <div className="flex shrink-0 gap-1" role="group" aria-label={t(`actor_${at}`)}>
+                          {LEVELS.map((lv) => {
+                            const selected = current === lv;
+                            const floorDisabled = isLevelDisabled(wt, lv);
+                            return (
+                              <Button
+                                key={lv}
+                                type="button"
+                                variant="glass"
+                                size="sm"
+                                disabled={floorDisabled || saving}
+                                title={floorDisabled ? t('floorDisabledHint') : undefined}
+                                onClick={() => void handleSet(wt, at, lv)}
+                                className={cn(
+                                  'min-w-[60px] gap-1 transition-colors',
+                                  selected ? LEVEL_META[lv].selected : 'border-border text-muted-foreground hover:bg-muted/40',
+                                  floorDisabled && 'opacity-40',
+                                )}
+                              >
+                                <span aria-hidden>{LEVEL_META[lv].mark}</span>{t(LEVEL_META[lv].labelKey)}
+                              </Button>
+                            );
+                          })}
+                        </div>
+                      ) : current ? (
+                        <Badge variant={LEVEL_META[current].badge} className="shrink-0">
+                          <span aria-hidden className="mr-0.5">{LEVEL_META[current].mark}</span>
+                          {t(LEVEL_META[current].labelKey)}
+                        </Badge>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">—</span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))
+        )}
+      </SectionCardBody>
+    </SectionCard>
+  );
+}

--- a/apps/web/src/components/settings/gate-level-matrix.tsx
+++ b/apps/web/src/components/settings/gate-level-matrix.tsx
@@ -33,7 +33,7 @@ const LEVELS: Level[] = ['auto', 'ask', 'block'];
 const LEVEL_META: Record<Level, { selected: string; badge: 'success' | 'warning' | 'destructive'; mark: string; labelKey: string }> = {
   auto: { selected: 'border-success-border bg-success-tint text-success', badge: 'success', mark: '✓', labelKey: 'levelAuto' },
   ask: { selected: 'border-warning-border bg-warning-tint text-warning', badge: 'warning', mark: '⏸', labelKey: 'levelAsk' },
-  block: { selected: 'border-destructive/40 bg-destructive/10 text-destructive', badge: 'destructive', mark: '⛔', labelKey: 'levelBlock' },
+  block: { selected: 'border-destructive-border bg-destructive-tint text-destructive', badge: 'destructive', mark: '⛔', labelKey: 'levelBlock' },
 };
 
 // 안전 하한(S-GATE-3 BE 강제): merge 는 최소 'ask' — 'auto' 비활성(UI 표현만, BE 가 우회 차단).


### PR DESCRIPTION
## 무엇을

유나양 디자인 핸드오프 — owner가 게이트 레벨을 설정하는 UI 부재("API만 있고 UI 없는" 재발) 해소. **게이트 레벨 매트릭스**: (work_type `done`·`merge`) × (actor `agent`·`human`) → level(`auto`·`ask`·`block`). (story S-GATE-4, doc `hitl-gate-config-ui-handoff`, policy `hitl-gating-policy-v1`)

**PO 콜대로 v1 스코프** = effective 매트릭스 + 셀 즉시 PUT(현 BE `#1559`로 가능). **2계층 리치니스는 BE 후속**(아래 ⚠️).

## 변경

- **Next 프록시 신설** `apps/web/src/app/api/projects/[id]/gate-config/route.ts`(GET/PUT) → BE `/api/v2/projects/{id}/gate-config`(#1559). access 프록시 패턴 미러(body·헤더 forward).
- **신규 `GateLevelMatrix`**(`components/settings/`): 작업종류 **그룹-행 레이아웃**(2D 그리드 회피·반응형). 셀당 **3-way 세그먼트**(auto/ask/block).
  - 레벨 컬러/마크 = **`cage/gate-evidence` DECISION_META verbatim 미러**: `auto→success ✓` / `ask→warning ⏸` / `block→destructive ⛔`. "설정한 것 = 인박스에서 보는 것."
  - **안전 하한 시각**(S-GATE-3 BE 강제): `merge`의 `auto` pill 비활성 + "🔒 최소 확인·자기승인 차단" 안내. UI는 floor 표현만(BE가 우회 차단).
  - 셀 변경 즉시 `PUT {scope:'project',work_type,actor_type,level}` 낙관적 + 실패 롤백 + Alert(assignee #1539 패턴).
- **권한 게이트**: org admin/owner만 편집(BE는 project owner도 허용하나 **FE 보수적 게이트로 과권한 0** — #1562 RC 교훈). 비권한 = 레벨 배지 읽기전용(GateEvidence 동형). project settings 마운트(`currentProjectId` 조건부·StandupDeadlineSection 패턴).
- **i18n** `gateConfig` ns ko/en 페어. **신규 디자인 토큰/매직 hex 0.**

## ⚠️ 2계층 = BE 의존 (디디군·후속 와이어)

GET이 **effective-only**라 FE가 "이 셀이 상속이냐 재정의냐"를 알 수 없음(PO 확인·FE fallback 불가). **상속/재정의 태그·↺기본값 복귀·org-default surface는 BE 랜딩 후**:
- ⓐ 셀별 `source`(org_default/override) · ⓑ override 해제 DELETE · ⓒ org-layer 단독 GET — **디디군 라우팅됨**.
- 랜딩 후 `GateLevelMatrix`를 source-aware로 확장 + org 탭 surface 추가(별 PR). **이 v1은 회귀 0**(effective 매트릭스+set만).

## AC 커버 (v1)

- AC1 (done·merge)×(agent·human) 4셀 현재 레벨 표시(auto✓/ask⏸/block⛔) ✅
- AC2 셀 변경 PUT·즉시 반영·실패 롤백 ✅
- AC3 merge auto 비활성 + 안전 하한 안내(self-approval 포함) ✅
- AC5 권한 게이팅·비권한 읽기전용 ✅
- AC6 GateEvidence 시각 정합·신규 토큰/매직 hex 0 ✅
- AC4(2계층 상속/override) — **BE 후속**(⚠️)

## 검증

- `pnpm type-check` ✅ / `pnpm lint`(신규 파일) ✅ 0 / `pnpm build` ✅ EXIT 0 / JSON parity ✅
- base=`origin/develop`(`15f58330`)

까심 QA(매트릭스·floor 시각·PUT·권한)→**유나양 가디언 시각 정합**→오르테가 머지게이트→dev 픽셀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)