### PR TITLE
feat(settings): HITL 게이트 매트릭스 2계층 source-aware + org surface (S-GATE-4)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2478,7 +2478,14 @@
     "mergeFloorNote": "Safety floor: merge requires at least Ask · self-approval blocked",
     "floorDisabledHint": "Disabled by safety floor",
     "saved": "Saved",
-    "saveFailed": "Failed to save."
+    "saveFailed": "Failed to save.",
+    "titleOrg": "Organization Gate Policy (Defaults)",
+    "descriptionOrg": "Organization-wide defaults. Each project can override these.",
+    "sourceInherited": "Inherited",
+    "sourceOverride": "Overridden",
+    "revertToDefault": "Revert to org default",
+    "reverted": "Reverted to org default.",
+    "noProjectForOrgEdit": "At least one project is required to set organization defaults."
   },
   "cage": {
     "gatePending": "gate pending",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2478,7 +2478,14 @@
     "mergeFloorNote": "안전 하한: 병합은 최소 '확인' · 자기 승인 차단",
     "floorDisabledHint": "안전 하한으로 비활성화됨",
     "saved": "저장됨",
-    "saveFailed": "저장에 실패했습니다."
+    "saveFailed": "저장에 실패했습니다.",
+    "titleOrg": "조직 게이트 정책 (기본값)",
+    "descriptionOrg": "조직 전체에 적용되는 기본값입니다. 각 프로젝트에서 재정의할 수 있습니다.",
+    "sourceInherited": "상속",
+    "sourceOverride": "재정의",
+    "revertToDefault": "조직 기본값으로 복귀",
+    "reverted": "조직 기본값으로 되돌렸습니다.",
+    "noProjectForOrgEdit": "조직 기본값을 설정하려면 프로젝트가 하나 이상 필요합니다."
   },
   "cage": {
     "gatePending": "게이트 대기",

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -446,9 +446,6 @@ export default function SettingsPage() {
         const meJson = meRes.ok ? await meRes.json() : null;
         const role = (meJson?.data?.role ?? 'member') as string;
         setIsAdmin(role === 'admin' || role === 'owner');
-        // S-GATE-4 RC: /api/me role = 현재 프로젝트(currentProjectId)의 effective role. gate-config 편집
-        // 권한이 org admin/owner 외에 **project owner**도 포함(BE gate_config 정합)이라 별도 보관.
-        setCurrentProjectRole(role);
         setCurrentUserId((meJson?.data?.user_id as string | null) ?? null);
       } catch {
         setIsAdmin(false);
@@ -506,6 +503,22 @@ export default function SettingsPage() {
     void refreshInvitations().catch((err) => { console.error('초대 목록 로드 실패', err); });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentProjectId, orgId]);
+
+  // S-GATE-4 RC: 현재 프로젝트의 내 role 을 **그 프로젝트의 team-members**에서 도출(/api/me 는 JWT
+  // project_id 기준이라 탭≠JWT 면 부정확). team-members 는 project_id 쿼리 기준·user_id 로 매칭 가능·
+  // 멤버 read 가능. project owner 면 gate-config 편집 허용에 사용(canEdit).
+  useEffect(() => {
+    if (!currentProjectId || !currentUserId) { setCurrentProjectRole('member'); return; }
+    let cancelled = false;
+    void (async () => {
+      const res = await fetch(`/api/team-members?project_id=${currentProjectId}&type=human`).catch(() => null);
+      if (cancelled || !res?.ok) return;
+      const json = await res.json() as { data?: Array<{ user_id?: string | null; role?: string }> };
+      const mine = (json.data ?? []).find((m) => m.user_id === currentUserId);
+      setCurrentProjectRole(mine?.role ?? 'member');
+    })();
+    return () => { cancelled = true; };
+  }, [currentProjectId, currentUserId]);
 
   useEffect(() => {
     if (!memberProjectId) return;

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -1039,8 +1039,8 @@ export default function SettingsPage() {
               {currentProjectId ? (
                 <div className="mt-6">
                   <GateLevelMatrix
+                    surface="project"
                     projectId={currentProjectId}
-                    scope="project"
                     canEdit={currentOrgRole === 'owner' || currentOrgRole === 'admin'}
                   />
                 </div>
@@ -1143,6 +1143,18 @@ export default function SettingsPage() {
                   )}
                 </SectionCardBody>
               </SectionCard>
+              {/* S-GATE-4 2계층: 조직 게이트 정책(기본값) surface. scope='org'. PUT 은 대표 project 경유
+                  (org_router 는 GET 만)·canEdit=org admin/owner. project 0개면 컴포넌트가 편집 불가 안내. */}
+              {orgInfo ? (
+                <div className="mt-6">
+                  <GateLevelMatrix
+                    surface="org"
+                    orgId={orgInfo.id}
+                    projectId={currentProjectId ?? projects[0]?.id}
+                    canEdit={currentOrgRole === 'owner' || currentOrgRole === 'admin'}
+                  />
+                </div>
+              ) : null}
               {currentOrgRole === 'owner' && (
                 <SectionCard className="border-destructive/20 bg-destructive/10 mt-6">
                   <SectionCardHeader className="border-b border-destructive/20">

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -187,6 +187,7 @@ export default function SettingsPage() {
   const [removingMemberId, setRemovingMemberId] = useState<string | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
   const [adminChecked, setAdminChecked] = useState(false);
+  const [currentProjectRole, setCurrentProjectRole] = useState<string>('member'); // S-GATE-4: 현재 프로젝트 effective role
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [deletingProjectId, setDeletingProjectId] = useState<string | null>(null);
   const [deleteProjectConfirmId, setDeleteProjectConfirmId] = useState<string | null>(null);
@@ -445,6 +446,9 @@ export default function SettingsPage() {
         const meJson = meRes.ok ? await meRes.json() : null;
         const role = (meJson?.data?.role ?? 'member') as string;
         setIsAdmin(role === 'admin' || role === 'owner');
+        // S-GATE-4 RC: /api/me role = 현재 프로젝트(currentProjectId)의 effective role. gate-config 편집
+        // 권한이 org admin/owner 외에 **project owner**도 포함(BE gate_config 정합)이라 별도 보관.
+        setCurrentProjectRole(role);
         setCurrentUserId((meJson?.data?.user_id as string | null) ?? null);
       } catch {
         setIsAdmin(false);
@@ -1034,14 +1038,16 @@ export default function SettingsPage() {
                   <StandupDeadlineSection projectId={currentProjectId} />
                 </div>
               ) : null}
-              {/* S-GATE-4: 프로젝트 게이트 정책(승인 레벨) 매트릭스. scope=project override. canEdit 은
-                  안전 subset(org admin/owner) — BE 는 project owner 도 허용하나 FE 는 보수적 게이트(과권한 0). */}
+              {/* S-GATE-4: 프로젝트 게이트 정책 매트릭스. canEdit = org admin/owner OR **이 프로젝트의 owner**
+                  — BE gate_config(PUT/DELETE scope='project')가 project owner 도 허용하므로 정합(RC①). project
+                  admin 은 BE 비허용이라 제외(meRole==='owner'만 — over-permission 0). cross-project 인 #1562
+                  grant 와 달리 자기 프로젝트 편집이라 보수적 org-admin-only 가 오히려 under-permissive 였음. */}
               {currentProjectId ? (
                 <div className="mt-6">
                   <GateLevelMatrix
                     surface="project"
                     projectId={currentProjectId}
-                    canEdit={currentOrgRole === 'owner' || currentOrgRole === 'admin'}
+                    canEdit={currentOrgRole === 'owner' || currentOrgRole === 'admin' || currentProjectRole === 'owner'}
                   />
                 </div>
               ) : null}

--- a/apps/web/src/app/api/organizations/[id]/gate-config/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/gate-config/route.ts
@@ -1,0 +1,17 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/**
+ * org 기본값 게이트 config 프록시 (S-GATE-4 2계층). BE `GET /api/v2/organizations/{org_id}/gate-config`
+ * — org-default 단독 매트릭스(project override 무시). 권한 org admin/owner(BE 강제). 설정(PUT scope='org')은
+ * project gate-config 라우트 경유.
+ */
+export async function GET(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/organizations/[id]/gate-config', { id });
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess([]);
+  return apiSuccess(await _r.json());
+}

--- a/apps/web/src/app/api/projects/[id]/gate-config/route.ts
+++ b/apps/web/src/app/api/projects/[id]/gate-config/route.ts
@@ -5,8 +5,8 @@ type RouteParams = { params: Promise<{ id: string }> };
 
 /**
  * HITL 게이트 레벨 config 프록시 (S-GATE-4). BE `GET/PUT /api/v2/projects/{id}/gate-config`.
- * GET = effective 레벨 목록(`{work_type,actor_type,level}[]`) / PUT = 셀 1개 설정
- * (`{scope:'org'|'project',work_type,actor_type,level}`). 권한·안전하한은 BE 강제.
+ * GET = effective 레벨+source 목록 / PUT = 셀 1개 설정 (`{scope,work_type,actor_type,level}`) /
+ * DELETE = project override 해제(`?work_type=&actor_type=` → 상속 복귀). 권한·안전하한은 BE 강제.
  */
 export async function GET(request: Request, { params }: RouteParams) {
   const { id } = await params;
@@ -17,6 +17,15 @@ export async function GET(request: Request, { params }: RouteParams) {
 }
 
 export async function PUT(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/projects/[id]/gate-config', { id });
+  if (!_r.ok) return _r;
+  return apiSuccess(await _r.json());
+}
+
+// DELETE — project override 해제(↺ 기본값). query `?work_type=&actor_type=` 는 proxyToFastapi 가
+// url.search 로 보존 전달. 응답 = 삭제 후 effective 레벨+source(상속).
+export async function DELETE(request: Request, { params }: RouteParams) {
   const { id } = await params;
   const _r = await proxyToFastapiWithParams(request, '/api/v2/projects/[id]/gate-config', { id });
   if (!_r.ok) return _r;

--- a/apps/web/src/components/settings/gate-level-matrix.tsx
+++ b/apps/web/src/components/settings/gate-level-matrix.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Lock } from 'lucide-react';
+import { Lock, RotateCcw } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
@@ -11,19 +11,24 @@ import { cn } from '@/lib/utils';
 
 /**
  * HITL 게이트 레벨 매트릭스 (S-GATE-4). (work_type done·merge) × (actor agent·human) → level
- * (auto·ask·block) 를 설정. 레벨 컬러/마크는 `components/cage/gate-evidence` DECISION_META 와
- * **verbatim 미러**(설정한 것 = 인박스에서 보는 것).
+ * (auto·ask·block). 레벨 컬러/마크는 `components/cage/gate-evidence` DECISION_META **verbatim 미러**.
  *
- * v1(이 PR): effective 레벨 표시 + 셀 즉시 PUT(낙관적·실패 롤백). 2계층 상속/재정의 시각·↺복귀는
- * BE(org-layer GET·셀별 source·override DELETE) 랜딩 후 와이어 — 컴포넌트는 그때 source-aware 확장.
- * 안전 하한(merge≥ask·self-approval 차단)은 BE(S-GATE-3) 강제 — UI 는 floor 를 **표현만**(우회 금지).
+ * 2계층(S-GATE-4 BE #1565): 셀별 `source`(org_default=상속 / override=재정의).
+ * - project surface: GET `/projects/{id}/gate-config`(effective+source). 설정=PUT scope='project'(override),
+ *   ↺ 복귀=DELETE(override 해제→상속). 상속=muted "상속" 태그 / 재정의=강조 태그 + ↺.
+ * - org surface: GET `/organizations/{org_id}/gate-config`(org 기본값 단독). 설정=PUT scope='org'(대표
+ *   project 경유). override 개념 없음 → source 태그 없음.
+ *
+ * 안전 하한(S-GATE-3 BE 강제): merge≥ask — auto 비활성(UI 표현만·BE 가 우회 차단).
  */
 
 type Level = 'auto' | 'ask' | 'block';
 type WorkType = 'done' | 'merge';
 type ActorType = 'agent' | 'human';
+type Source = 'org_default' | 'override';
 
-interface GateLevelEntry { work_type: string; actor_type: string; level: string }
+interface GateLevelEntry { work_type: string; actor_type: string; level: string; source?: string }
+interface GateCell { level: Level; source: Source }
 
 const WORK_TYPES: WorkType[] = ['done', 'merge'];
 const ACTOR_TYPES: ActorType[] = ['agent', 'human'];
@@ -40,68 +45,104 @@ const LEVEL_META: Record<Level, { selected: string; badge: 'success' | 'warning'
 const isLevelDisabled = (workType: WorkType, level: Level): boolean => workType === 'merge' && level === 'auto';
 
 const cellKey = (w: string, a: string) => `${w}:${a}`;
+const toSource = (s?: string): Source => (s === 'override' ? 'override' : 'org_default');
 
 interface GateLevelMatrixProps {
-  projectId: string;
-  scope: 'org' | 'project';
+  surface: 'org' | 'project';
+  /** project surface: 대상 project. org surface: PUT scope='org' 경유용 대표 project(없으면 편집 불가). */
+  projectId?: string;
+  /** org surface: org 기본값 GET 경로. */
+  orgId?: string;
   canEdit: boolean;
 }
 
-export function GateLevelMatrix({ projectId, scope, canEdit }: GateLevelMatrixProps) {
+export function GateLevelMatrix({ surface, projectId, orgId, canEdit }: GateLevelMatrixProps) {
   const t = useTranslations('gateConfig');
-  const [levels, setLevels] = useState<Record<string, Level>>({});
+  const [cells, setCells] = useState<Record<string, GateCell>>({});
   const [loading, setLoading] = useState(true);
-  const [savingCell, setSavingCell] = useState<string | null>(null);
+  const [busyCell, setBusyCell] = useState<string | null>(null);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  // org 기본값 설정도 project 라우트(scope='org')를 경유하므로 대표 projectId 가 있어야 쓰기 가능.
+  const canWrite = canEdit && !!projectId;
+  const getUrl = surface === 'org'
+    ? (orgId ? `/api/organizations/${orgId}/gate-config` : null)
+    : (projectId ? `/api/projects/${projectId}/gate-config` : null);
 
   useEffect(() => {
     let cancelled = false;
     async function load() {
+      if (!getUrl) { setLoading(false); return; }
       setLoading(true);
-      const res = await fetch(`/api/projects/${projectId}/gate-config`).catch(() => null);
+      const res = await fetch(getUrl).catch(() => null);
       if (cancelled) return;
       if (res?.ok) {
         const json = await res.json() as { data?: GateLevelEntry[] };
-        const map: Record<string, Level> = {};
+        const map: Record<string, GateCell> = {};
         for (const e of json.data ?? []) {
-          if ((LEVELS as string[]).includes(e.level)) map[cellKey(e.work_type, e.actor_type)] = e.level as Level;
+          if ((LEVELS as string[]).includes(e.level)) map[cellKey(e.work_type, e.actor_type)] = { level: e.level as Level, source: toSource(e.source) };
         }
-        setLevels(map);
+        setCells(map);
       }
       setLoading(false);
     }
     void load();
     return () => { cancelled = true; };
-  }, [projectId]);
+  }, [getUrl]);
 
-  const handleSet = async (workType: WorkType, actorType: ActorType, level: Level) => {
-    if (!canEdit || isLevelDisabled(workType, level) || savingCell) return;
-    const key = cellKey(workType, actorType);
-    if (levels[key] === level) return;
-    const prev = levels[key];
-    setSavingCell(key);
+  const applyEntry = (key: string, e?: GateLevelEntry | null) => {
+    if (e && (LEVELS as string[]).includes(e.level)) setCells((m) => ({ ...m, [key]: { level: e.level as Level, source: toSource(e.source) } }));
+  };
+  const rollback = (key: string, prev?: GateCell) =>
+    setCells((m) => (prev ? { ...m, [key]: prev } : (() => { const n = { ...m }; delete n[key]; return n; })()));
+
+  const handleSet = async (wt: WorkType, at: ActorType, level: Level) => {
+    if (!canWrite || !projectId || isLevelDisabled(wt, level) || busyCell) return;
+    const key = cellKey(wt, at);
+    // org surface: 같은 레벨 noop. project surface: 같은 레벨이라도 상속이면 override 생성 의미 있음.
+    if (cells[key]?.level === level && (surface === 'org' || cells[key]?.source === 'override')) return;
+    const prev = cells[key];
+    setBusyCell(key);
     setMessage(null);
-    setLevels((m) => ({ ...m, [key]: level })); // 낙관적(assignee #1539 패턴)
+    setCells((m) => ({ ...m, [key]: { level, source: surface === 'org' ? 'org_default' : 'override' } })); // 낙관적(#1539)
     try {
       const res = await fetch(`/api/projects/${projectId}/gate-config`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ scope, work_type: workType, actor_type: actorType, level }),
+        body: JSON.stringify({ scope: surface === 'org' ? 'org' : 'project', work_type: wt, actor_type: at, level }),
       });
       if (res.ok) {
-        const json = await res.json().catch(() => null) as { data?: GateLevelEntry } | null;
-        const applied = json?.data?.level;
-        if (applied && (LEVELS as string[]).includes(applied)) setLevels((m) => ({ ...m, [key]: applied as Level }));
+        applyEntry(key, (await res.json().catch(() => null) as { data?: GateLevelEntry } | null)?.data);
         setMessage({ type: 'success', text: t('saved') });
       } else {
-        setLevels((m) => (prev ? { ...m, [key]: prev } : (() => { const n = { ...m }; delete n[key]; return n; })()));
+        rollback(key, prev);
         setMessage({ type: 'error', text: t('saveFailed') });
       }
     } catch {
-      setLevels((m) => (prev ? { ...m, [key]: prev } : (() => { const n = { ...m }; delete n[key]; return n; })()));
+      rollback(key, prev);
       setMessage({ type: 'error', text: t('saveFailed') });
     } finally {
-      setSavingCell(null);
+      setBusyCell(null);
+    }
+  };
+
+  const handleRevert = async (wt: WorkType, at: ActorType) => {
+    if (!canWrite || !projectId || busyCell) return;
+    const key = cellKey(wt, at);
+    setBusyCell(key);
+    setMessage(null);
+    try {
+      const res = await fetch(`/api/projects/${projectId}/gate-config?work_type=${wt}&actor_type=${at}`, { method: 'DELETE' });
+      if (res.ok) {
+        applyEntry(key, (await res.json().catch(() => null) as { data?: GateLevelEntry } | null)?.data);
+        setMessage({ type: 'success', text: t('reverted') });
+      } else {
+        setMessage({ type: 'error', text: t('saveFailed') });
+      }
+    } catch {
+      setMessage({ type: 'error', text: t('saveFailed') });
+    } finally {
+      setBusyCell(null);
     }
   };
 
@@ -109,8 +150,8 @@ export function GateLevelMatrix({ projectId, scope, canEdit }: GateLevelMatrixPr
     <SectionCard>
       <SectionCardHeader>
         <div className="space-y-1">
-          <h2 className="text-base font-semibold text-foreground">{t('title')}</h2>
-          <p className="text-sm text-muted-foreground">{t('description')}</p>
+          <h2 className="text-base font-semibold text-foreground">{surface === 'org' ? t('titleOrg') : t('title')}</h2>
+          <p className="text-sm text-muted-foreground">{surface === 'org' ? t('descriptionOrg') : t('description')}</p>
         </div>
       </SectionCardHeader>
       <SectionCardBody className="space-y-4">
@@ -119,8 +160,12 @@ export function GateLevelMatrix({ projectId, scope, canEdit }: GateLevelMatrixPr
             <AlertDescription>{message.text}</AlertDescription>
           </Alert>
         )}
+        {canEdit && !projectId ? (
+          <Alert variant="default">
+            <AlertDescription>{t('noProjectForOrgEdit')}</AlertDescription>
+          </Alert>
+        ) : null}
 
-        {/* 레전드 */}
         <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
           {LEVELS.map((lv) => (
             <span key={lv} className="inline-flex items-center gap-1">
@@ -153,44 +198,69 @@ export function GateLevelMatrix({ projectId, scope, canEdit }: GateLevelMatrixPr
               <div className="divide-y divide-border overflow-hidden rounded-md border border-border">
                 {ACTOR_TYPES.map((at) => {
                   const key = cellKey(wt, at);
-                  const current = levels[key];
-                  const saving = savingCell === key;
+                  const cell = cells[key];
+                  const busy = busyCell === key;
+                  const isOverride = surface === 'project' && cell?.source === 'override';
                   return (
-                    <div key={at} className="flex items-center justify-between gap-3 px-3 py-2.5 text-sm">
+                    <div key={at} className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 px-3 py-2.5 text-sm">
                       <span className="font-medium text-foreground">{t(`actor_${at}`)}</span>
-                      {canEdit ? (
-                        <div className="flex shrink-0 gap-1" role="group" aria-label={t(`actor_${at}`)}>
-                          {LEVELS.map((lv) => {
-                            const selected = current === lv;
-                            const floorDisabled = isLevelDisabled(wt, lv);
-                            return (
-                              <Button
-                                key={lv}
-                                type="button"
-                                variant="glass"
-                                size="sm"
-                                disabled={floorDisabled || saving}
-                                title={floorDisabled ? t('floorDisabledHint') : undefined}
-                                onClick={() => void handleSet(wt, at, lv)}
-                                className={cn(
-                                  'min-w-[60px] gap-1 transition-colors',
-                                  selected ? LEVEL_META[lv].selected : 'border-border text-muted-foreground hover:bg-muted/40',
-                                  floorDisabled && 'opacity-40',
-                                )}
-                              >
-                                <span aria-hidden>{LEVEL_META[lv].mark}</span>{t(LEVEL_META[lv].labelKey)}
-                              </Button>
-                            );
-                          })}
-                        </div>
-                      ) : current ? (
-                        <Badge variant={LEVEL_META[current].badge} className="shrink-0">
-                          <span aria-hidden className="mr-0.5">{LEVEL_META[current].mark}</span>
-                          {t(LEVEL_META[current].labelKey)}
-                        </Badge>
-                      ) : (
-                        <span className="text-xs text-muted-foreground">—</span>
-                      )}
+                      <div className="flex shrink-0 items-center gap-2">
+                        {/* project surface: 상속/재정의 source 표시(+ override 면 ↺ 복귀). org surface: 없음. */}
+                        {surface === 'project' && cell ? (
+                          isOverride ? (
+                            <span className="inline-flex items-center gap-1">
+                              <Badge variant="outline" className="border-primary/40 text-primary">{t('sourceOverride')}</Badge>
+                              {canWrite ? (
+                                <button
+                                  type="button"
+                                  onClick={() => void handleRevert(wt, at)}
+                                  disabled={busy}
+                                  title={t('revertToDefault')}
+                                  aria-label={t('revertToDefault')}
+                                  className="inline-flex items-center text-muted-foreground hover:text-foreground disabled:opacity-50"
+                                >
+                                  <RotateCcw className="h-3.5 w-3.5" />
+                                </button>
+                              ) : null}
+                            </span>
+                          ) : (
+                            <span className="text-xs text-muted-foreground">{t('sourceInherited')}</span>
+                          )
+                        ) : null}
+                        {canWrite ? (
+                          <div className="flex gap-1" role="group" aria-label={t(`actor_${at}`)}>
+                            {LEVELS.map((lv) => {
+                              const selected = cell?.level === lv;
+                              const floorDisabled = isLevelDisabled(wt, lv);
+                              return (
+                                <Button
+                                  key={lv}
+                                  type="button"
+                                  variant="glass"
+                                  size="sm"
+                                  disabled={floorDisabled || busy}
+                                  title={floorDisabled ? t('floorDisabledHint') : undefined}
+                                  onClick={() => void handleSet(wt, at, lv)}
+                                  className={cn(
+                                    'min-w-[60px] gap-1 transition-colors',
+                                    selected ? LEVEL_META[lv].selected : 'border-border text-muted-foreground hover:bg-muted/40',
+                                    floorDisabled && 'opacity-40',
+                                  )}
+                                >
+                                  <span aria-hidden>{LEVEL_META[lv].mark}</span>{t(LEVEL_META[lv].labelKey)}
+                                </Button>
+                              );
+                            })}
+                          </div>
+                        ) : cell ? (
+                          <Badge variant={LEVEL_META[cell.level].badge} className="shrink-0">
+                            <span aria-hidden className="mr-0.5">{LEVEL_META[cell.level].mark}</span>
+                            {t(LEVEL_META[cell.level].labelKey)}
+                          </Badge>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">—</span>
+                        )}
+                      </div>
                     </div>
                   );
                 })}

--- a/apps/web/src/components/settings/gate-level-matrix.tsx
+++ b/apps/web/src/components/settings/gate-level-matrix.tsx
@@ -129,17 +129,22 @@ export function GateLevelMatrix({ surface, projectId, orgId, canEdit }: GateLeve
   const handleRevert = async (wt: WorkType, at: ActorType) => {
     if (!canWrite || !projectId || busyCell) return;
     const key = cellKey(wt, at);
+    const prev = cells[key]; // override 스냅샷
     setBusyCell(key);
     setMessage(null);
+    // 낙관적(PUT 미러): source 를 즉시 org_default 로(재정의 배지·↺ 즉시 사라짐). 상속 레벨은 응답이 확정.
+    setCells((m) => (prev ? { ...m, [key]: { ...prev, source: 'org_default' } } : m));
     try {
       const res = await fetch(`/api/projects/${projectId}/gate-config?work_type=${wt}&actor_type=${at}`, { method: 'DELETE' });
       if (res.ok) {
         applyEntry(key, (await res.json().catch(() => null) as { data?: GateLevelEntry } | null)?.data);
         setMessage({ type: 'success', text: t('reverted') });
       } else {
+        rollback(key, prev); // 실패 → override 복원
         setMessage({ type: 'error', text: t('saveFailed') });
       }
     } catch {
+      rollback(key, prev);
       setMessage({ type: 'error', text: t('saveFailed') });
     } finally {
       setBusyCell(null);


### PR DESCRIPTION
## 무엇을

#1566 v1(effective 매트릭스+set) 위에 **BE #1565**(source 필드·override DELETE·org-layer GET) 랜딩분으로 **2계층 리치니스 완성**. (S-GATE-4, 유나양 핸드오프 §4·§2)

## 변경

- **프록시**:
  - project gate-config 에 **DELETE**(override 해제·`?work_type=&actor_type=` → 상속 복귀) 추가. query 는 `proxyToFastapi` 의 `url.search` 보존으로 전달.
  - **org GET 신설** `api/organizations/[id]/gate-config` → BE `/api/v2/organizations/{id}/gate-config`(org 기본값 단독).
- **`GateLevelMatrix` → surface-aware(org/project) + source-aware**:
  - **project surface**: 셀별 `source` 표시 — 상속(`org_default`)="상속" muted / 재정의(`override`)="재정의" 강조 배지 + **↺ 조직 기본값 복귀**(DELETE). 설정=PUT `scope='project'`.
  - **org surface**(organization 탭): GET `/organizations/{id}/gate-config`. 설정=PUT `scope='org'`(org_router 는 GET만이라 **대표 project 경유**). override 개념 없어 source 태그 없음. **project 0개 org 는 편집 불가 안내**(`noProjectForOrgEdit`).
  - 낙관적 PUT/DELETE + 응답 source 재반영 + 실패 롤백. 레벨 컬러 GateEvidence verbatim 미러 유지.
- **권한**: project=org admin/owner(보수적·#1562 교훈)·org=org admin/owner. 비권한 읽기전용 배지.
- **i18n** gateConfig ns 신규 키(titleOrg/sourceInherited/sourceOverride/revertToDefault…) ko/en. **신규 토큰/매직 hex 0.**

## AC 커버 (2계층 완성)

- AC4 2계층 — project surface 상속/재정의 구분 + ↺ override 해제 + org-default surface ✅
- AC1·2·3·5·6 (v1) 유지 — 매트릭스·PUT·merge 하한·권한·GateEvidence 정합 ✅

## ⚠️ 설계 노트

- **org PUT 은 project 라우트(scope='org') 경유** — BE org_router 가 GET only 라 대표 project(currentProjectId ?? projects[0])로 PUT. project 0개 org 는 org 기본값 편집 불가(안내 표시). BE 에 org-scoped PUT 추가되면 단순화 가능(후속).

## 검증

- `pnpm type-check` ✅ / `pnpm lint`(신규 파일) ✅ 0 / `pnpm build` ✅ EXIT 0 / JSON parity ✅
- base=`origin/develop`(#1565 BE + #1566 v1 포함)

까심 QA(상속/재정의·↺복귀·org surface·권한·낙관적)→유나양 가디언→오르테가 머지게이트→dev 픽셀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)