### PR TITLE
fix(hitl): request_type CHECK에 gate_approval 추가 (0124·라이브 버그)

### DIFF
--- a/backend/alembic/versions/0124_hitl_gate_approval_request_type.py
+++ b/backend/alembic/versions/0124_hitl_gate_approval_request_type.py
@@ -1,0 +1,44 @@
+"""hitl: agent_hitl_requests.request_type CHECK에 'gate_approval' 추가 (S-GATE-2 라이브 버그)
+
+E-HITL-GATING dogfood가 적출한 라이브 버그: enforce_gate(S-GATE-2) ask 분기가
+HitlRequest(request_type='gate_approval')로 INSERT 하는데, baseline CHECK 제약
+`agent_hitl_requests_request_type_check`(approval·input·confirmation·escalation)이 'gate_approval'을
+미허용 → asyncpg CheckViolationError → **모든 ask park 경로 500**. CI SQLite가 PG CHECK 제약을
+강제 안 해 유닛 테스트가 못 잡음(asyncpg/PG 블라인드스팟).
+
+fix: 허용집합에 'gate_approval' 추가(**확대**라 기존 행 전부 통과 → 검증 즉시·prod-safe).
+제약은 baseline 출신이라 마이그레이션으로 DROP+ADD.
+
+Revision ID: 0124
+Revises: 0123
+"""
+from alembic import op
+
+revision = "0124"
+down_revision = "0123"
+branch_labels = None
+depends_on = None
+
+_ALLOWED_NEW = "ARRAY['approval', 'input', 'confirmation', 'escalation', 'gate_approval']"
+_ALLOWED_OLD = "ARRAY['approval', 'input', 'confirmation', 'escalation']"
+
+
+def _set_constraint(allowed: str) -> None:
+    op.execute(
+        "ALTER TABLE agent_hitl_requests "
+        "DROP CONSTRAINT IF EXISTS agent_hitl_requests_request_type_check"
+    )
+    op.execute(
+        "ALTER TABLE agent_hitl_requests "
+        "ADD CONSTRAINT agent_hitl_requests_request_type_check "
+        f"CHECK (request_type = ANY ({allowed}::text[]))"
+    )
+
+
+def upgrade() -> None:
+    _set_constraint(_ALLOWED_NEW)
+
+
+def downgrade() -> None:
+    # 주의: downgrade 전 'gate_approval' 행이 있으면 ADD 가 실패한다(역방향은 축소).
+    _set_constraint(_ALLOWED_OLD)


### PR DESCRIPTION
**E-HITL-GATING dogfood가 적출한 라이브 버그** — GATE-5 측정의 가치 그대로(라이브 게이트 버그 포착). **마이그레이션 1개·코드 무변경.**

## 근본
`enforce_gate`(S-GATE-2) ask 분기가 `HitlRequest(request_type='gate_approval')`로 INSERT하는데, baseline CHECK 제약 `agent_hitl_requests_request_type_check`(허용=approval·input·confirmation·escalation)이 **'gate_approval' 미허용** → `asyncpg CheckViolationError` → **모든 ask park 경로 500**(test org flag-on 후 실 done 시도서 cloud log 실측).

**왜 유닛 통과?** S-GATE-2 테스트는 CI **SQLite**라 PG CHECK 제약을 강제 안 함(asyncpg/PG 블라인드스팟·session mock도 실 INSERT 미타). dogfood(라이브 PG)가 비로소 포착.

## fix (0124)
제약이 baseline 출신이라 마이그레이션으로 `DROP + ADD` — 허용집합에 'gate_approval' 추가. **확대**라 기존 행 전부 통과 → 검증 즉시·prod-safe(dev/prod 공유 DB 안전).

## real-PG 검증 (docker postgres:15)
- PRE(baseline 제약): `gate_approval` INSERT → CHECK 위반(**버그 재현**) ✓
- APPLY 0124 → POST: `gate_approval` INSERT → `INSERT 0 1`(**통과**) ✓
- POST: `bogus` INSERT → 여전히 차단(제약 무손상) ✓

⚠️ 머지 후 **migrate-dev(0124)** 필요 — 라이브 dev ask 경로 복구. 그 후 dogfood 시나리오 재개.

🤖 Generated with [Claude Code](https://claude.com/claude-code)