### PR TITLE
fix(hitl): GET /hitl/requests·policy UUID 직렬화 500 (dogfood 적출)

### DIFF
--- a/backend/app/routers/hitl.py
+++ b/backend/app/routers/hitl.py
@@ -42,7 +42,7 @@ async def get_hitl_policy(
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
     snapshot = await repo.get_policy(org_id, project_id)
-    return _ok(snapshot.model_dump())
+    return _ok(snapshot.model_dump(mode="json"))
 
 
 @router.patch("/policy")
@@ -61,7 +61,7 @@ async def update_hitl_policy(
         approval_rules=body.approval_rules,
         timeout_classes=body.timeout_classes,
     )
-    return _ok(snapshot.model_dump())
+    return _ok(snapshot.model_dump(mode="json"))
 
 
 @router.get("/requests")
@@ -74,7 +74,9 @@ async def list_hitl_requests(
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
     requests = await repo.list_requests(org_id=org_id, project_id=project_id, status=status)
-    return _ok([r.model_dump() for r in requests])
+    # _ok 는 raw JSONResponse(json.dumps) — model_dump() 는 UUID/datetime 객체를 그대로 둬 직렬화
+    # 불가(500). mode="json" 으로 UUID→str·datetime→ISO 직렬화(resolve 엔드포인트의 str() 우회와 정합).
+    return _ok([r.model_dump(mode="json") for r in requests])
 
 
 @router.patch("/requests/{request_id}")


### PR DESCRIPTION
**dogfood가 적출한 잠복 버그** — `GET /api/v2/hitl/requests`(+/policy)가 500.

## 근본
`_ok`는 raw `JSONResponse({"data": ...})`(starlette `json.dumps`). list/policy 엔드포인트가 `model_dump()`(mode 없음 → `id: UUID`·`created_at: datetime` 등 **Python 객체 그대로**)를 넘김 → `json.dumps`가 UUID 직렬화 불가 → **500**. resolve 엔드포인트는 `str(row.id)`로 우회했으나 list/policy는 누락 → 잠복.

## fix
`model_dump(mode="json")`(UUID→str·datetime→ISO). 3곳: policy GET·policy PATCH·requests list. 어떤 request_type든 list 호출 시 500이던 버그(gate dogfood가 처음 list 경로 행사해 노출).

## 검증
hitl 테스트 23 passed(회귀 0). dogfood 시나리오는 done 409 detail의 request_id로 우회해 무관하게 완주했으나, 이 fix로 list 엔드포인트 자체 복구.

🤖 Generated with [Claude Code](https://claude.com/claude-code)