### PR TITLE
feat(realtime): conversation.working + presence SSE 이벤트 발행 (R2·BE)

### DIFF
--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -111,12 +111,15 @@ async def _mark_agent_disconnected(
                 # d5de8e08 안전망: 연결 완전 종료 → 이 에이전트의 chat working 신호도 즉시 정리
                 # (offline 인데 "...typing" 잔존 방지·TTL backstop 기다리지 않음).
                 from app.services import chat_presence
-                chat_presence.clear_member(str(agent_id))
+                _cleared_convs = chat_presence.clear_member(str(agent_id))
             await db.commit()
-            # R2(da9d1781): 마지막 연결 종료=offline 강등 시 presence SSE 발행(FE 3s 폴링 대체·best-effort).
+            # R2(da9d1781): 마지막 연결 종료=offline 강등 시 presence + 영향받은 대화의 conversation.working
+            # SSE 발행(FE 폴링 대체·best-effort). working 비운 대화에 push 안 하면 "...typing" 영구 stale(QA HIGH).
             if remaining is None and org_id:
-                from app.services.presence_events import emit_presence
+                from app.services.presence_events import emit_conversation_working, emit_presence
                 emit_presence(org_id)
+                for _conv in _cleared_convs:
+                    emit_conversation_working(org_id, _conv)
     except Exception:
         logger.warning("presence disconnect cleanup failed agent=%s", agent_id, exc_info=True)
 

--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -72,7 +72,9 @@ async def _mark_agent_online(agent_id: uuid.UUID, session_id: uuid.UUID) -> None
         logger.warning("presence online tick failed agent=%s", agent_id, exc_info=True)
 
 
-async def _mark_agent_disconnected(agent_id: uuid.UUID, session_id: uuid.UUID) -> None:
+async def _mark_agent_disconnected(
+    agent_id: uuid.UUID, session_id: uuid.UUID, org_id: str | None = None
+) -> None:
     """49fed0a1 AC2/AC3: SSE 연결 종료 cleanup — 연결-도출 offline 강등.
 
     이 세션 행 삭제 후, 같은 에이전트의 **다른 활성(last_seen TTL 이내) 세션**이 없으면 presence를
@@ -111,6 +113,10 @@ async def _mark_agent_disconnected(agent_id: uuid.UUID, session_id: uuid.UUID) -
                 from app.services import chat_presence
                 chat_presence.clear_member(str(agent_id))
             await db.commit()
+            # R2(da9d1781): 마지막 연결 종료=offline 강등 시 presence SSE 발행(FE 3s 폴링 대체·best-effort).
+            if remaining is None and org_id:
+                from app.services.presence_events import emit_presence
+                emit_presence(org_id)
     except Exception:
         logger.warning("presence disconnect cleanup failed agent=%s", agent_id, exc_info=True)
 
@@ -280,6 +286,7 @@ async def agent_stream(
         org_plan = (await db.execute(
             select(Organization.plan).where(Organization.id == tm.org_id)
         )).scalar_one_or_none() or "free"
+        org_id_str = str(tm.org_id)  # R2: presence SSE 발행용(generate 클로저 캡처).
 
         # acked_seq DB ì¡°í
         cursor = (await db.execute(
@@ -356,6 +363,9 @@ async def agent_stream(
                 )
                 await _pdb.commit()
             _presence_wired = True
+            # R2(da9d1781): 연결 online 진입 → presence SSE 발행(FE 3s 폴링 대체·best-effort).
+            from app.services.presence_events import emit_presence
+            emit_presence(org_id_str)
 
             yield "event: heartbeat\ndata: {}\n\n"
 
@@ -424,7 +434,7 @@ async def agent_stream(
             # 49fed0a1 AC2/AC3: 연결 종료 → 세션 행 삭제 + 마지막 세션이면 presence offline 강등.
             # (presence 배선 성공한 연결만 — 세션 미생성 시 타 세션 presence 오염 방지.)
             if _presence_wired:
-                await _mark_agent_disconnected(agent_id, session_id)
+                await _mark_agent_disconnected(agent_id, session_id, org_id_str)
 
     return StreamingResponse(
         generate(),

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -293,6 +293,7 @@ async def _dispatch_conversation_event(
     member_type_map = {r[0]: r[1] for r in member_rows}
 
     events_to_push: list[tuple[str, Event]] = []
+    _set_working_any = False
     for pid in sorted(participant_ids):  # deadlock 방지: 일관 락 순서
         m_type = member_type_map.get(pid, "human")
         event = Event(
@@ -313,9 +314,15 @@ async def _dispatch_conversation_event(
         # 그 agent 가 reply 를 보내면 send_message 에서 clear, 안 보내면 TTL 자동 소멸(ephemeral).
         if m_type == "agent":
             chat_presence.set_working(str(conversation.id), str(pid))
+            _set_working_any = True
 
     # flush로 event.id 확보
     await db.flush()
+    # R2(da9d1781): working 변경 → conversation.working + presence SSE 발행(폴링 대체·best-effort).
+    if _set_working_any:
+        from app.services.presence_events import emit_conversation_working, emit_presence
+        emit_conversation_working(org_id, conversation.id)
+        emit_presence(org_id)
     # per-recipient dense seq 발급 (agent recipient만)
     for pid_str, event in events_to_push:
         if member_type_map.get(event.recipient_id, "human") == "agent":
@@ -1101,6 +1108,10 @@ async def send_message(
     # fork 분기(아래) 전 **원본 conversation_id** 기준 — working 은 그 conversation 에 set 됐다.
     # 휴먼 sender 면 set 된 적 없어 no-op(무해). agent reply 면 즉시 "...typing" 해제.
     chat_presence.clear_working(str(conversation_id), str(sender.id))
+    # R2(da9d1781): working clear → conversation.working + presence SSE 발행(폴링 대체·best-effort).
+    from app.services.presence_events import emit_conversation_working, emit_presence
+    emit_conversation_working(org_id, conversation_id)
+    emit_presence(org_id)
 
     # cross-org 차단: mentioned_ids를 현재 org 소속 member로 일괄 필터링 (QA B1).
     # E-MEMBER-SSOT Phase 0: 저장·DM포크·group 멘션 발송 모든 경로에 org 필터를 한 번 적용.

--- a/backend/app/services/chat_presence.py
+++ b/backend/app/services/chat_presence.py
@@ -74,18 +74,25 @@ def clear_working(conversation_id: str, member_id: str) -> None:
         _working_store.pop(conversation_id, None)
 
 
-def clear_member(member_id: str) -> None:
+def clear_member(member_id: str) -> list[str]:
     """d5de8e08 안전망: member 의 **전 conversation** working 신호 제거.
 
     SSE 연결이 끊길 때(disconnect/크래시→offline·agent_gateway) 호출 — 연결이 사라지면 그 에이전트는
     더 이상 생성 중일 수 없으므로 즉시 정리(TTL backstop 기다리지 않음). 없으면 무해(no-op).
+
+    R2: working 이 실제로 제거된 conversation_id 목록을 반환 — 호출부(agent_gateway)가 각 conversation 에
+    conversation.working SSE 를 발행해 "...typing" 잔존을 막는다(기존 caller 는 반환 무시·무영향).
     """
+    affected = []
     empty_convs = []
     for conv, store in _working_store.items():
-        if store.pop(member_id, None) is not None and not store:
-            empty_convs.append(conv)
+        if store.pop(member_id, None) is not None:
+            affected.append(conv)
+            if not store:
+                empty_convs.append(conv)
     for conv in empty_convs:
         _working_store.pop(conv, None)
+    return affected
 
 
 def list_working(conversation_id: str) -> list[dict]:

--- a/backend/app/services/presence_events.py
+++ b/backend/app/services/presence_events.py
@@ -1,0 +1,45 @@
+"""R2(da9d1781): 실시간 presence/working SSE 이벤트 발행 — 폴링 대체.
+
+기존 event-stream(events.publish_event·pg_pubsub 멀티인스턴스 backplane) 위에 **이벤트 타입만 추가**:
+- `conversation.working` — 채팅 typing 인디케이터(FE 1.5s 폴링 `/conversations/{id}/working` 대체)
+- `presence` — 팀 presence 변경 트리거(FE 3s 폴링 `/team-presence` 대체)
+
+best-effort: 발행 실패가 caller(메시지 dispatch·reply·SSE 연결 lifecycle)를 절대 깨지 않는다(try/except).
+publish_event 는 sync — 동기 발행점(chat_presence transition 등)에서도 호출 가능.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def emit_conversation_working(org_id, conversation_id) -> None:
+    """해당 conversation 의 현재 working member 목록을 push(채팅 typing). FE 가 폴링 없이 이벤트로 갱신."""
+    try:
+        from app.routers.events import publish_event
+        from app.services import chat_presence
+
+        publish_event(
+            str(org_id),
+            "conversation.working",
+            {
+                "conversation_id": str(conversation_id),
+                "working": chat_presence.list_working(str(conversation_id)),
+            },
+        )
+    except Exception:
+        logger.warning("emit conversation.working failed conv=%s", conversation_id, exc_info=True)
+
+
+def emit_presence(org_id) -> None:
+    """팀 presence(online/idle/working) 변경 트리거. FE 가 /team-presence 를 1회 refetch(폴링 대체).
+
+    경량 트리거(스냅샷 미포함) — presence 집계는 DB 조회라 sync 발행점에서 산출하지 않고 FE refetch 에 위임.
+    """
+    try:
+        from app.routers.events import publish_event
+
+        publish_event(str(org_id), "presence", {})
+    except Exception:
+        logger.warning("emit presence failed org=%s", org_id, exc_info=True)

--- a/backend/tests/test_presence_events_r2.py
+++ b/backend/tests/test_presence_events_r2.py
@@ -1,0 +1,56 @@
+"""R2(da9d1781): presence/working SSE 발행 헬퍼 — shape + best-effort(실패 swallow)."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_emit_conversation_working_publishes_shape():
+    from app.services import presence_events
+
+    org = uuid.uuid4()
+    conv = uuid.uuid4()
+    with patch("app.routers.events.publish_event") as pub, patch(
+        "app.services.chat_presence.list_working", return_value=[{"member_id": "m1"}]
+    ):
+        presence_events.emit_conversation_working(org, conv)
+    pub.assert_called_once()
+    args = pub.call_args.args
+    assert args[0] == str(org)
+    assert args[1] == "conversation.working"
+    assert args[2]["conversation_id"] == str(conv)
+    assert args[2]["working"] == [{"member_id": "m1"}]
+
+
+def test_emit_presence_publishes_trigger():
+    from app.services import presence_events
+
+    org = uuid.uuid4()
+    with patch("app.routers.events.publish_event") as pub:
+        presence_events.emit_presence(org)
+    pub.assert_called_once()
+    args = pub.call_args.args
+    assert args[0] == str(org)
+    assert args[1] == "presence"
+    assert args[2] == {}
+
+
+def test_emit_best_effort_swallows_publish_failure():
+    """발행 실패가 caller 흐름을 깨면 안 됨(메시지 dispatch/reply 보호) — 예외 swallow."""
+    from app.services import presence_events
+
+    with patch("app.routers.events.publish_event", side_effect=RuntimeError("bus down")):
+        # 예외 전파 없이 정상 반환해야 한다.
+        presence_events.emit_presence(uuid.uuid4())
+        presence_events.emit_conversation_working(uuid.uuid4(), uuid.uuid4())
+
+
+def test_emit_working_swallows_list_working_failure():
+    from app.services import presence_events
+
+    with patch("app.routers.events.publish_event"), patch(
+        "app.services.chat_presence.list_working", side_effect=RuntimeError("boom")
+    ):
+        presence_events.emit_conversation_working(uuid.uuid4(), uuid.uuid4())  # no raise

--- a/backend/tests/test_presence_events_r2.py
+++ b/backend/tests/test_presence_events_r2.py
@@ -54,3 +54,21 @@ def test_emit_working_swallows_list_working_failure():
         "app.services.chat_presence.list_working", side_effect=RuntimeError("boom")
     ):
         presence_events.emit_conversation_working(uuid.uuid4(), uuid.uuid4())  # no raise
+
+
+def test_clear_member_returns_affected_conversations():
+    """QA HIGH(#1570): disconnect 시 working 비운 대화 목록 반환 → caller 가 conversation.working 발행."""
+    from app.services import chat_presence
+
+    conv_a, conv_b, conv_c = "conv-a", "conv-b", "conv-c"
+    mid = "agent-x"
+    other = "agent-y"
+    chat_presence.set_working(conv_a, mid)
+    chat_presence.set_working(conv_b, mid)
+    chat_presence.set_working(conv_b, other)  # conv_b 엔 다른 agent 도 working
+    chat_presence.set_working(conv_c, other)  # mid 와 무관
+
+    affected = chat_presence.clear_member(mid)
+    assert set(affected) == {conv_a, conv_b}  # mid 가 working 이던 대화만(conv_c 제외)
+    # conv_b 는 other 가 남아 비지 않음·conv_a 는 비워짐 — 둘 다 affected(working 변경됨)
+    chat_presence.clear_member(other)  # cleanup


### PR DESCRIPTION
**R2(da9d1781) 실시간/polling 최적화 — measure-first 결과 BE 발행분.** PO 결재 GO(working+presence SSE 전환·국소).

## 측정 baseline(req/min/client at rest)
- 채팅 working 폴 **1.5s = 40 req/min**(open-chat·최대 단일 offender) · 팀 presence **3s = 20 req/min**(전 화면·가장 pervasive) · 합 ~70~120.
- BE SSE infra(`/api/event-stream`·pg_pubsub 멀티인스턴스)는 있으나 저활용.

## 무엇 (BE)
신규 `presence_events.py` — 기존 `publish_event`(event-stream) 위에 **이벤트 타입만 추가**(best-effort):
- **`conversation.working`** — 해당 conversation working 목록 push(채팅 typing). 발행점: dispatch `set_working`(conversations.py) + reply `clear_working`.
- **`presence`** — 팀 presence 변경 트리거(FE refetch). 발행점: working set/clear + agent_gateway SSE connect(online)/disconnect(offline 강등).

FE(미르코·별 PR)가 consume + 1.5s/3s 폴 제거. best-effort라 발행 실패가 메시지 dispatch/reply/SSE 연결 흐름을 절대 안 깸.

## 가설/메트릭
at-rest req/min 70~120 → ~30~60(**~50%↓**)·체감 갱신 폴 lag→push 즉시. measure_after·스토리 `da9d1781`(req/min은 FE puppeteer 측정).

## 검증
`test_presence_events_r2.py` 4(shape·best-effort swallow) + conversations/agent_gateway/presence/chat **143 passed 회귀 0**. import OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)