### PR TITLE
feat(hitl): org-scoped gate-config PUT 엔드포인트 (S-GATE-4 후속)

### DIFF
--- a/backend/app/routers/gate_config.py
+++ b/backend/app/routers/gate_config.py
@@ -202,3 +202,48 @@ async def get_org_gate_config(
             )
             entries.append(GateLevelEntry(work_type=wt, actor_type=at, level=level, source=source))
     return entries
+
+
+class OrgGateLevelRequest(BaseModel):
+    work_type: str
+    actor_type: str
+    level: str
+
+
+@org_router.put("/{org_id}/gate-config", response_model=GateLevelEntry)
+async def put_org_gate_config(
+    org_id: uuid.UUID,
+    body: OrgGateLevelRequest,
+    session: AsyncSession = Depends(get_db),
+    verified_org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> GateLevelEntry:
+    """S-GATE-4: org **기본값** 설정(project override 아님·project_id=None). 권한=org owner/admin.
+
+    org-scoped PUT — 기존 project 라우트 scope='org' 우회(미르코 #1567 워크어라운드·project 0개 org
+    편집 불가)를 대체. path org_id 는 caller org 와 일치해야(타org 차단).
+    """
+    if body.work_type not in WORK_TYPES:
+        raise HTTPException(status_code=400, detail=f"work_type must be one of {list(WORK_TYPES)}")
+    if body.actor_type not in ACTOR_TYPES:
+        raise HTTPException(status_code=400, detail=f"actor_type must be one of {list(ACTOR_TYPES)}")
+    if body.level not in LEVELS:
+        raise HTTPException(status_code=400, detail=f"level must be one of {list(LEVELS)}")
+    if org_id != verified_org_id:
+        raise HTTPException(status_code=403, detail="org_id mismatch")
+    if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
+        raise HTTPException(status_code=403, detail="org owner/admin required to set org default")
+
+    row = await set_gate_level(
+        session,
+        org_id=org_id,
+        project_id=None,  # org 기본값(project override 아님)
+        work_type=body.work_type,
+        actor_type=body.actor_type,
+        level=body.level,
+        created_by=uuid.UUID(auth.user_id),
+    )
+    await session.commit()
+    return GateLevelEntry(
+        work_type=row.work_type, actor_type=row.actor_type, level=row.level, source="org_default"
+    )

--- a/backend/tests/test_gate_config_s4.py
+++ b/backend/tests/test_gate_config_s4.py
@@ -216,3 +216,74 @@ async def test_org_gate_config_non_admin_403():
                 oid, session=MagicMock(), verified_org_id=oid, auth=_auth()
             )
     assert ei.value.status_code == 403  # 비-admin 차단
+
+
+# ── org-PUT (org 기본값 설정·org-scoped) ───────────────────────────────────────
+
+
+def _org_body():
+    from app.routers import gate_config as gc
+
+    return gc.OrgGateLevelRequest(work_type="done", actor_type="agent", level="ask")
+
+
+@pytest.mark.anyio
+async def test_org_put_admin_sets_default():
+    from app.routers import gate_config as gc
+
+    oid = uuid.uuid4()
+    session = MagicMock()
+    session.commit = AsyncMock()
+    row = MagicMock(work_type="done", actor_type="agent", level="ask")
+    with patch("app.routers.gate_config.is_org_owner_or_admin", new=AsyncMock(return_value=True)), patch(
+        "app.routers.gate_config.set_gate_level", new=AsyncMock(return_value=row)
+    ):
+        out = await gc.put_org_gate_config(
+            oid, _org_body(), session=session, verified_org_id=oid, auth=_auth()
+        )
+    assert out.level == "ask"
+    assert out.source == "org_default"
+    session.commit.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_org_put_non_admin_403():
+    from fastapi import HTTPException
+
+    from app.routers import gate_config as gc
+
+    oid = uuid.uuid4()
+    with patch("app.routers.gate_config.is_org_owner_or_admin", new=AsyncMock(return_value=False)):
+        with pytest.raises(HTTPException) as ei:
+            await gc.put_org_gate_config(
+                oid, _org_body(), session=MagicMock(), verified_org_id=oid, auth=_auth()
+            )
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_org_put_mismatch_403():
+    from fastapi import HTTPException
+
+    from app.routers import gate_config as gc
+
+    with pytest.raises(HTTPException) as ei:
+        await gc.put_org_gate_config(
+            uuid.uuid4(), _org_body(), session=MagicMock(), verified_org_id=uuid.uuid4(), auth=_auth()
+        )
+    assert ei.value.status_code == 403  # 타 org 차단
+
+
+@pytest.mark.anyio
+async def test_org_put_invalid_level_400():
+    from fastapi import HTTPException
+
+    from app.routers import gate_config as gc
+
+    oid = uuid.uuid4()
+    body = gc.OrgGateLevelRequest(work_type="done", actor_type="agent", level="MAYBE")
+    with pytest.raises(HTTPException) as ei:
+        await gc.put_org_gate_config(
+            oid, body, session=MagicMock(), verified_org_id=oid, auth=_auth()
+        )
+    assert ei.value.status_code == 400


### PR DESCRIPTION
S-GATE-4 후속(저우선 BE) — **org-scoped gate-config PUT**. dev·마이그 없음·국소.

## 무엇
`PUT /api/v2/organizations/{org_id}/gate-config` — org 기본값(project_id=None) 1셀 설정. 권한 = org owner/admin·path org_id==caller org(타org 차단·403). `set_gate_level(project_id=None)` 재사용·기존 project PUT scope='org' authz 미러.

## 왜
미르코 #1567 2계층 FE가 org PUT을 **project 라우트 scope='org' 경유**로 우회(대표 project 필요·project 0개 org는 org 기본값 편집 불가)했는데, 이 org-scoped PUT이 그 워크어라운드를 대체. org_router가 GET(#1565)+source+DELETE에 이어 **PUT까지 대칭** 완성.

## 테스트
`test_gate_config_s4.py` +4(admin set·non-admin 403·org mismatch 403·invalid level 400). gate config **32 passed 회귀 0**. route 등록 확認.

🤖 Generated with [Claude Code](https://claude.com/claude-code)