### PR TITLE
perf(realtime): working/presence 폴링 제거 → SSE 이벤트 consume (da9d1781)

### DIFF
--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -55,8 +55,9 @@ function ScrollShell({ showTopBar, children }: { showTopBar: boolean; children: 
   const t = useTranslations('presence');
   // 2505d27d: 상시 팀 presence 패널 — 2xl=inline right-rail / <2xl=drawer. storageKey로 open 영속.
   const panel = useContextualPanelState({ storageKey: 'team-presence', defaultOpen: true });
-  // 폴 상향(단일 폴) — 헤더 토글 working-count 배지가 패널 닫힘 상태서도 갱신돼야 하므로 상시 폴(document.hidden 가드는 hook 내).
-  const items = useTeamPresence(true);
+  // R2(da9d1781): presence SSE event-driven(3s 폴 제거). member_id 로 event-stream 구독.
+  const { currentTeamMemberId } = useDashboardContext();
+  const items = useTeamPresence(true, currentTeamMemberId);
   const workingCount = items.filter((i) => i.working).length;
 
   return (

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -11,7 +11,7 @@ import { ChatInput, type CommandTarget } from './chat-input';
 import { ThreadPanel } from './thread-panel';
 import type { ChatMessage, SendAttachment } from '@/hooks/use-chat-sse';
 import { useIsMobile } from '@/hooks/use-mobile';
-import { normalizeToMessage, useChatSse } from '@/hooks/use-chat-sse';
+import { normalizeToMessage, useChatSse, type SseWorkingPayload } from '@/hooks/use-chat-sse';
 import { EmptyState } from '@/components/ui/empty-state';
 
 interface ChatViewProps {
@@ -205,18 +205,24 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
     } catch { /* non-critical */ }
   }, [threadId, commandTargets]);
 
-  // 마운트 1회 + 1.5s 폴링(typing snappiness·선생님 피드백 "빠릿빠릿"·연결 dot 15s보다 훨씬 민감).
+  // R2(da9d1781): 1.5s working 폴 제거 → conversation.working SSE 이벤트로 typing 갱신(payload 가
+  // working 목록을 실음). 마운트 1회 fetch 로 초기 상태만(이벤트는 변경 시 push). 재연결 시도 catch-up.
+  const handleWorking = useCallback((payload: SseWorkingPayload) => {
+    if (payload.conversation_id !== threadId) return;
+    const next = (payload.working ?? [])
+      .map((w) => ({ id: w.member_id, name: (commandTargets ?? []).find((tg) => tg.agentId === w.member_id)?.agentName }))
+      .filter((a): a is { id: string; name: string } => !!a.name);
+    setTypingAgents(next);
+  }, [threadId, commandTargets]);
+
   useEffect(() => { void fetchWorking(); }, [fetchWorking]);
-  useEffect(() => {
-    const interval = setInterval(() => { void fetchWorking(); }, 1500);
-    return () => clearInterval(interval);
-  }, [fetchWorking]);
 
   useChatSse({
     currentTeamMemberId,
     onNewMessage: handleNewMessage,
     onReplyCreated: handleReplyCreated,
     onConversationMessage: handleConversationMessage,
+    onWorking: handleWorking,
     onReconnect: handleReconnect,
   });
 

--- a/apps/web/src/components/presence/use-team-presence.ts
+++ b/apps/web/src/components/presence/use-team-presence.ts
@@ -15,15 +15,13 @@ export interface TeamPresenceItem {
   active_story?: { id: string; title: string; status: string } | null;
 }
 
-// ~3s 절충 폴(PO) — 전 유저 상시 폴이라 request 폭증 회피 + working 충분히 snappy. 단일 폴을 FAB 배지+패널 공유(중복0).
-const POLL_MS = 3000;
-
 /**
- * 2505d27d: 팀 presence 폴 — ScrollShell(전역)에서 1회 폴해 FAB working-count 배지 + 패널에 공급.
- * 배지가 패널 닫힘 상태서도 "N 작업 중"을 보여야 하므로(선생님) **패널 open 무관 상시 폴**(active 시).
- * 단 `document.hidden`(백그라운드 탭)이면 0폴(낭비 가드).
+ * 2505d27d: 팀 presence — ScrollShell(전역)에서 FAB working-count 배지 + 패널에 공급.
+ * R2(da9d1781): 3s 폴 제거 → `presence` SSE 이벤트로 refetch(폴→push·~20req/min→0). 초기 1회 +
+ * 이벤트 + 탭 visible 복귀 catch-up(hidden 중 누락 이벤트 보정). presence 이벤트 payload 는 trigger({})라
+ * 스냅샷은 refetch 로 확보(BE 계약). `document.hidden` 이면 fetch 0(낭비 가드 유지).
  */
-export function useTeamPresence(active: boolean): TeamPresenceItem[] {
+export function useTeamPresence(active: boolean, memberId?: string): TeamPresenceItem[] {
   const [items, setItems] = useState<TeamPresenceItem[]>([]);
 
   const fetchPresence = useCallback(async () => {
@@ -39,12 +37,17 @@ export function useTeamPresence(active: boolean): TeamPresenceItem[] {
   }, []);
 
   useEffect(() => {
-    if (!active) return;
+    if (!active || typeof window === 'undefined' || typeof EventSource === 'undefined') return;
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    void fetchPresence();
-    const interval = setInterval(() => { void fetchPresence(); }, POLL_MS);
-    return () => clearInterval(interval);
-  }, [active, fetchPresence]);
+    void fetchPresence(); // 초기 스냅샷
+    const url = new URL('/api/event-stream', window.location.origin);
+    if (memberId) url.searchParams.set('member_id', memberId);
+    const es = new EventSource(url.toString(), { withCredentials: true });
+    es.addEventListener('presence', () => { void fetchPresence(); }); // 변경 시 push → refetch
+    const onVisible = () => { if (!document.hidden) void fetchPresence(); }; // hidden 중 누락 보정
+    document.addEventListener('visibilitychange', onVisible);
+    return () => { es.close(); document.removeEventListener('visibilitychange', onVisible); };
+  }, [active, fetchPresence, memberId]);
 
   return items;
 }

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -57,17 +57,25 @@ interface SseChatPayload {
   created_at: string;
 }
 
+/** R2(da9d1781): conversation.working SSE payload — `chat_presence.list_working` 목록. */
+export interface SseWorkingPayload {
+  conversation_id: string;
+  working: Array<{ member_id: string; state?: string }>;
+}
+
 interface UseChatSseOptions {
   currentTeamMemberId?: string;
   onNewMessage?: (message: ChatMessage) => void;
   onReplyCreated?: (memoId: string) => void;
   onConversationMessage?: (payload: Record<string, unknown>) => void;
+  // R2: 채팅 working/typing — 1.5s 폴(/conversations/{id}/working) 대체.
+  onWorking?: (payload: SseWorkingPayload) => void;
   onReconnect?: () => void;
 }
 
 const RECONNECT_DELAYS_MS = [5_000, 30_000, 60_000, 300_000];
 
-export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, onConversationMessage, onReconnect }: UseChatSseOptions) {
+export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, onConversationMessage, onWorking, onReconnect }: UseChatSseOptions) {
   const [connected, setConnected] = useState(false);
   const sourceRef = useRef<EventSource | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -76,6 +84,7 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
   const onNewMessageRef = useRef(onNewMessage);
   const onReplyCreatedRef = useRef(onReplyCreated);
   const onConversationMessageRef = useRef(onConversationMessage);
+  const onWorkingRef = useRef(onWorking);
   const onReconnectRef = useRef(onReconnect);
   const memberIdRef = useRef(currentTeamMemberId);
 
@@ -84,6 +93,7 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
   useLayoutEffect(() => { onNewMessageRef.current = onNewMessage; }, [onNewMessage]);
   useLayoutEffect(() => { onReplyCreatedRef.current = onReplyCreated; }, [onReplyCreated]);
   useLayoutEffect(() => { onConversationMessageRef.current = onConversationMessage; }, [onConversationMessage]);
+  useLayoutEffect(() => { onWorkingRef.current = onWorking; }, [onWorking]);
   useLayoutEffect(() => { onReconnectRef.current = onReconnect; }, [onReconnect]);
   useLayoutEffect(() => { memberIdRef.current = currentTeamMemberId; }, [currentTeamMemberId]);
 
@@ -149,6 +159,16 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
         try {
           const payload = JSON.parse(e.data as string) as Record<string, unknown>;
           onConversationMessageRef.current?.(payload);
+        } catch { /* ignore parse errors */ }
+      });
+
+      // R2(da9d1781): conversation.working — typing 인디케이터 1.5s 폴(/conversations/{id}/working) 대체.
+      // payload 가 working 목록을 실어 보내므로 refetch 없이 직접 갱신.
+      source.addEventListener('conversation.working', (e: MessageEvent) => {
+        if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
+        try {
+          const payload = JSON.parse(e.data as string) as SseWorkingPayload;
+          if (payload.conversation_id) onWorkingRef.current?.(payload);
         } catch { /* ignore parse errors */ }
       });
 


### PR DESCRIPTION
## 무엇을 / 측정 근거

R2 실시간/polling 최적화 **FE 몫** (BE emit **#1570** 페어, prod 회수 마지막). measure-first(dev FE·puppeteer):
- **chat working/typing: 1.5s 폴**(`/api/conversations/{id}/working`·~40req/min/open-chat)
- **team-presence: 3s 폴**(`/api/team-presence`·~20req/min·전 인증화면)
→ 둘 다 **SSE-pushable 인데 폴링**. 두 폴 제거 → #1570 의 `conversation.working`·`presence` SSE 이벤트로 전환.

## 변경 (기존 EventSource 위·이벤트 타입만 추가·광범위 리팩터 X)

- **chat working** (`use-chat-sse` + `chat-view`): `conversation.working` 리스너 + `onWorking` 콜백 추가. chat-view 의 **1.5s `setInterval` 제거** → 이벤트로 `typingAgents` 직접 갱신(payload 가 `{conversation_id, working:[{member_id}]}` 실음·refetch 불요). 마운트 1회 fetch 로 초기 상태만. (disconnect 시 BE 가 빈 working push → "...typing" 즉시 해제 — #1570 QA fix 와 정합.)
- **team presence** (`use-team-presence` + `dashboard-shell`): **3s `setInterval` 제거** → `/api/event-stream` 의 `presence` 이벤트 구독 → `/team-presence` refetch(이벤트는 trigger·스냅샷은 refetch). **탭 visible 복귀 catch-up**(hidden 중 누락 이벤트 보정)·`document.hidden` fetch 0 가드 유지. ScrollShell 이 `currentTeamMemberId` 전달(event-stream `member_id` 구독).

## 가설 + measure_after

- open-chat working **~40req/min → ~0** · presence **~20req/min → ~0** · at-rest 총 **~50%↓** · 폴 lag → push 즉시.
- **measure_after**: BE #1570 dev 배포 후 동일 puppeteer 시나리오 재측정으로 실증. 스토리 `da9d1781`.

## ⚠️ 페어 / 스코프

- BE 이벤트 = **#1570**(머지·dev 배포 후 발행). 보드→event-stream 구독(staleness)은 **별 follow-up**(이 PR 스코프 외·req 본체는 working+presence).

## 검증

- `pnpm type-check` ✅ / `pnpm lint`(대상 4파일) ✅ 0 / `pnpm build` ✅ EXIT 0
- base=`origin/develop`(#1570 포함)

까심 QA(폴 제거·SSE 이벤트 수신·갱신 누락0·typing 즉시해제)→머지→dev 재측정(~50%↓).

🤖 Generated with [Claude Code](https://claude.com/claude-code)