### PR TITLE
feat(hitl): coverage audit 테이블 + outcome 메트릭 (S-GATE-5.1)

### DIFF
--- a/backend/alembic/versions/0125_hitl_gate_audit.py
+++ b/backend/alembic/versions/0125_hitl_gate_audit.py
@@ -1,0 +1,40 @@
+"""E-HITL-GATING S-GATE-5.1: hitl_gate_audit 테이블 — enforce_gate 1건당 audit 1행.
+
+coverage("전이 중 게이트 친 비율")·auto-pass 카운트가 DB 불가이던 한계 해소(auto/block 미persist 였음).
+additive 신규 테이블(prod-safe). flag-gated(enforce active) 시에만 write.
+
+Revision ID: 0125
+Revises: 0124
+"""
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+revision = "0125"
+down_revision = "0124"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "hitl_gate_audit",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("work_type", sa.Text(), nullable=False),
+        sa.Column("actor_type", sa.Text(), nullable=True),
+        sa.Column("resolved_level", sa.Text(), nullable=False),
+        sa.Column("outcome", sa.Text(), nullable=False),
+        sa.Column("work_item_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("actor_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    # 메트릭 쿼리: org 스코프 + created_at window(+project filter).
+    op.create_index("ix_hitl_gate_audit_org_created", "hitl_gate_audit", ["org_id", "created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_hitl_gate_audit_org_created", table_name="hitl_gate_audit")
+    op.drop_table("hitl_gate_audit")

--- a/backend/app/models/hitl.py
+++ b/backend/app/models/hitl.py
@@ -77,3 +77,28 @@ class HitlGateConfig(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
+
+
+class HitlGateAudit(Base):
+    """E-HITL-GATING S-GATE-5.1: enforce_gate 1건당 audit 1행 — coverage/outcome 분포 측정용.
+
+    auto/block 은 미persist(HitlRequest 는 ask 만)라 coverage·auto-pass 카운트가 DB 불가이던 한계 해소.
+    ⚠️ §2: block/ask 같은 raise outcome 은 409→세션 rollback 이라 enforce_gate 가 raise 전 독립 commit
+    해야 보존된다(return outcome=auto/resumed 는 전이와 함께 commit). flag-gated(enforce active) 시에만.
+    """
+
+    __tablename__ = "hitl_gate_audit"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    work_type: Mapped[str] = mapped_column(Text, nullable=False)        # 'done' | 'merge'
+    actor_type: Mapped[str | None] = mapped_column(Text, nullable=True)  # 'agent' | 'human' | None
+    resolved_level: Mapped[str] = mapped_column(Text, nullable=False)    # 'auto' | 'ask' | 'block'
+    # outcome: auto | blocked | ask_queued | resumed | rejected_blocked | self_blocked
+    outcome: Mapped[str] = mapped_column(Text, nullable=False)
+    work_item_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    actor_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
+    )

--- a/backend/app/routers/gate_metrics.py
+++ b/backend/app/routers/gate_metrics.py
@@ -30,7 +30,11 @@ class HitlGateMetricsResponse(BaseModel):
     ask_resolution_minutes: float | None = None
     rubber_stamp_rate: float | None = None
     self_approval_caught: int = 0
-    coverage: float | None = None  # v1 항상 null — auto/block 미persist(소스 한계)
+    coverage: float | None = None  # true ratio(enforced/전체)는 stories 분모 필요 — §3 deferred
+    # S-GATE-5.1: hitl_gate_audit 기반(auto/block 포함 전 outcome)
+    enforced_total: int = 0
+    outcomes: dict | None = None
+    auto_rate: float | None = None
     project_id: str | None = None
     window: dict
 
@@ -64,6 +68,9 @@ async def get_hitl_gate_metrics(
         rubber_stamp_rate=m.rubber_stamp_rate,
         self_approval_caught=m.self_approval_caught,
         coverage=m.coverage,
+        enforced_total=m.enforced_total,
+        outcomes=m.outcomes,
+        auto_rate=m.auto_rate,
         project_id=str(project_id) if project_id else None,
         window={
             "start": start.isoformat() if start else None,

--- a/backend/app/services/gate_enforce.py
+++ b/backend/app/services/gate_enforce.py
@@ -95,6 +95,37 @@ def gate_config_enforce_active(org_id: uuid.UUID) -> bool:
     return (not allow) or (org_id in allow)
 
 
+async def _record_audit(
+    session: AsyncSession,
+    *,
+    org_id, project_id, work_type, actor_type, actor_id, work_item_id,
+    resolved_level: str,
+    outcome: str,
+    persist: bool,
+) -> None:
+    """S-GATE-5.1: enforce outcome 1행 audit(coverage/분포 측정).
+
+    ⚠️ §2: **persist=True(raise outcome=block/ask_queued/rejected/self)** 는 raise 전 **독립 commit** —
+    409→세션 rollback 에서 audit 가 유실되면 coverage 가 정작 핵심 가치 이벤트를 못 잡는 자기모순(HitlRequest
+    생존 패턴 미러). **persist=False(return outcome=auto/resumed)** 는 add 만(전이가 함께 commit). best-effort.
+    """
+    try:
+        from app.models.hitl import HitlGateAudit
+
+        session.add(HitlGateAudit(
+            org_id=org_id, project_id=project_id, work_type=work_type, actor_type=actor_type,
+            resolved_level=resolved_level, outcome=outcome,
+            work_item_id=work_item_id, actor_id=actor_id,
+        ))
+        if persist:
+            await session.commit()
+    except Exception:
+        logger.warning(
+            "gate audit record failed org=%s work=%s outcome=%s", org_id, work_type, outcome,
+            exc_info=True,
+        )
+
+
 async def enforce_gate(
     session: AsyncSession,
     *,
@@ -122,17 +153,27 @@ async def enforce_gate(
             "gate_enforced org=%s work=%s floor_clamp %s→%s", org_id, work_type, level, floored
         )
     level = floored
+
+    async def _audit(outcome: str, persist: bool) -> None:
+        await _record_audit(
+            session, org_id=org_id, project_id=project_id, work_type=work_type,
+            actor_type=actor_type, actor_id=actor_id, work_item_id=work_item_id,
+            resolved_level=level, outcome=outcome, persist=persist,
+        )
+
     if level == "auto":
         logger.info(
             "gate_enforced org=%s project=%s work=%s actor=%s level=auto outcome=auto",
             org_id, project_id, work_type, actor_type,
         )
+        await _audit("auto", persist=False)  # return outcome — 전이가 commit
         return
     if level == "block":
         logger.info(
             "gate_enforced org=%s project=%s work=%s actor=%s level=block outcome=blocked",
             org_id, project_id, work_type, actor_type,
         )
+        await _audit("blocked", persist=True)  # raise outcome — commit-before-raise(§2)
         raise HTTPException(
             status_code=409,
             detail={
@@ -179,6 +220,7 @@ async def enforce_gate(
                     "gate_enforced org=%s work=%s outcome=blocked_self_approval request=%s actor=%s",
                     org_id, work_type, req_id, orig_actor_id,
                 )
+                await _audit("self_blocked", persist=True)  # raise outcome — §2
                 raise HTTPException(
                     status_code=409,
                     detail={
@@ -194,12 +236,14 @@ async def enforce_gate(
                 "gate_enforced org=%s work=%s level=ask outcome=resumed approved_request=%s",
                 org_id, work_type, req_id,
             )
+            await _audit("resumed", persist=False)  # return outcome — 전이가 commit
             return
         if req_status == "rejected":
             logger.info(
                 "gate_enforced org=%s work=%s level=ask outcome=blocked_rejected request=%s",
                 org_id, work_type, req_id,
             )
+            await _audit("rejected_blocked", persist=True)  # raise outcome — §2
             raise HTTPException(
                 status_code=409,
                 detail={
@@ -216,6 +260,7 @@ async def enforce_gate(
             "gate_enforced org=%s work=%s level=ask outcome=ask_pending request_id=%s",
             org_id, work_type, req_id,
         )
+        await _audit("ask_queued", persist=True)  # raise outcome — §2
         raise HTTPException(
             status_code=409,
             detail={
@@ -247,6 +292,8 @@ async def enforce_gate(
         },
     )
     session.add(req)
+    # audit 도 같은 commit 으로 persist(409 rollback 생존·§2) — 신규 park 는 기존 commit 이 둘 다 보존.
+    await _audit("ask_queued", persist=False)
     await session.commit()  # raise 전 persist(_preflight_merge_gate 동형·get_db 예외 rollback 대비)
     await session.refresh(req)
     logger.info(

--- a/backend/app/services/gate_metrics.py
+++ b/backend/app/services/gate_metrics.py
@@ -19,10 +19,12 @@ from datetime import datetime
 from sqlalchemy import String, cast, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.hitl import HitlRequest
+from app.models.hitl import HitlGateAudit, HitlRequest
 
 _GATE_REQUEST_TYPE = "gate_approval"
 _RUBBER_STAMP_SECONDS = 30  # gate_service._RUBBER_STAMP_SECONDS 와 동일 임계(동형)
+# S-GATE-5.1 audit outcome 집합(enforce_gate 가 기록하는 전 outcome).
+_OUTCOMES = ("auto", "blocked", "ask_queued", "resumed", "rejected_blocked", "self_blocked")
 
 
 def _ratio(num: int, denom: int) -> float | None:
@@ -50,7 +52,11 @@ class HitlGateMetrics:
     ask_resolution_minutes: float | None
     rubber_stamp_rate: float | None
     self_approval_caught: int
-    coverage: float | None  # v1: 항상 None — auto/block 미persist(소스 한계·audit 테이블 후속)
+    coverage: float | None  # true ratio(enforced/전체 전이)는 stories 분모 필요 — §3 2차/skip(None)
+    # S-GATE-5.1: hitl_gate_audit 기반(auto/block 포함 전 outcome).
+    enforced_total: int = 0  # 게이트 친 전이 수(flag active 시 enforce 호출 = audit 1행)
+    outcomes: dict | None = None  # outcome 분포(auto·blocked·ask_queued·resumed·rejected_blocked·self_blocked)
+    auto_rate: float | None = None  # auto / enforced_total(게이트가 그냥 통과시킨 비율)
 
 
 async def compute_hitl_gate_metrics(
@@ -109,6 +115,18 @@ async def compute_hitl_gate_metrics(
     )
     approved_resolved, rubber_count, self_approval = (await session.execute(rs_stmt)).one()
 
+    # S-GATE-5.1: hitl_gate_audit 기반 outcome 분포(auto/block 포함·created_at window).
+    audit_filters = [HitlGateAudit.org_id == org_id]
+    if project_id is not None:
+        audit_filters.append(HitlGateAudit.project_id == project_id)
+    audit_stmt = _window(
+        select(HitlGateAudit.outcome, func.count()).where(*audit_filters).group_by(HitlGateAudit.outcome),
+        HitlGateAudit.created_at, start, end,
+    )
+    audit_counts = {o: int(c) for o, c in (await session.execute(audit_stmt)).all()}
+    outcomes = {k: audit_counts.get(k, 0) for k in _OUTCOMES}
+    enforced_total = sum(outcomes.values())
+
     return HitlGateMetrics(
         ask_total=ask_total,
         pending=pending,
@@ -118,5 +136,8 @@ async def compute_hitl_gate_metrics(
         ask_resolution_minutes=float(avg_minutes) if avg_minutes is not None else None,
         rubber_stamp_rate=_ratio(int(rubber_count or 0), int(approved_resolved or 0)),
         self_approval_caught=int(self_approval or 0),
-        coverage=None,
+        coverage=None,  # true ratio(enforced/전체 전이)는 stories 분모 필요 — §3 deferred
+        enforced_total=enforced_total,
+        outcomes=outcomes,
+        auto_rate=_ratio(outcomes["auto"], enforced_total),
     )

--- a/backend/tests/test_gate_enforce_s2.py
+++ b/backend/tests/test_gate_enforce_s2.py
@@ -29,6 +29,13 @@ def _session(execute_side_effect=None):
     return s
 
 
+def _hitl_reqs_added(session):
+    """S-GATE-5.1 후 session.add 는 HitlGateAudit 도 받으므로 — HitlRequest park 만 카운트."""
+    from app.models.hitl import HitlRequest
+
+    return sum(1 for c in session.add.call_args_list if isinstance(c.args[0], HitlRequest))
+
+
 async def _enforce(ge, session, actor_type="agent", work_type="done"):
     return await ge.enforce_gate(
         session, org_id=uuid.uuid4(), project_id=uuid.uuid4(),
@@ -58,7 +65,7 @@ async def test_auto_passes():
         ge, "resolve_gate_level", new=AsyncMock(return_value="auto")
     ):
         await _enforce(ge, session)  # 예외 없음
-    session.add.assert_not_called()
+    assert _hitl_reqs_added(session) == 0
 
 
 @pytest.mark.anyio
@@ -93,7 +100,7 @@ async def test_ask_creates_request_and_409():
     assert ei.value.status_code == 409
     assert ei.value.detail["code"] == "GATE_ASK"
     assert ei.value.detail["requires_human"] is True
-    session.add.assert_called_once()  # HitlRequest 생성
+    assert _hitl_reqs_added(session) == 1  # HitlRequest 생성
     session.commit.assert_awaited()   # raise 전 persist
 
 
@@ -110,7 +117,7 @@ async def test_ask_resumes_on_approved():
         ge, "resolve_gate_level", new=AsyncMock(return_value="ask")
     ):
         await _enforce(ge, session)  # 예외 없음
-    session.add.assert_not_called()  # 승인 있으면 신규 생성 안 함
+    assert _hitl_reqs_added(session) == 0  # 승인 있으면 신규 생성 안 함
 
 
 @pytest.mark.anyio
@@ -128,7 +135,7 @@ async def test_ask_rejected_remains_blocked():
             await _enforce(ge, session)
     assert ei.value.status_code == 409
     assert ei.value.detail["code"] == "GATE_REJECTED"
-    session.add.assert_not_called()  # reject → 재-ask 안 함(차단 유지)
+    assert _hitl_reqs_added(session) == 0  # reject → 재-ask 안 함(차단 유지)
 
 
 @pytest.mark.anyio
@@ -146,7 +153,7 @@ async def test_ask_existing_pending_no_dup_409():
             await _enforce(ge, session)
     assert ei.value.status_code == 409
     assert ei.value.detail["code"] == "GATE_ASK"
-    session.add.assert_not_called()  # 기존 pending 재사용
+    assert _hitl_reqs_added(session) == 0  # 기존 pending 재사용
 
 
 # ── HIGH②: fail-closed (actor_type 불명) ──────────────────────────────────────
@@ -203,7 +210,7 @@ async def test_floor_clamp_merge_auto_becomes_ask():
             await _enforce(ge, session, work_type="merge")
     assert ei.value.status_code == 409
     assert ei.value.detail["code"] == "GATE_ASK"  # auto 였지만 floor가 ask로 끌어올림
-    session.add.assert_called_once()
+    assert _hitl_reqs_added(session) == 1
 
 
 def test_clamp_to_floor_unit():
@@ -233,7 +240,7 @@ async def test_self_approval_blocked():
             await _enforce(ge, session)
     assert ei.value.status_code == 409
     assert ei.value.detail["code"] == "GATE_SELF_APPROVAL"
-    session.add.assert_not_called()  # self-approval → 통과 안 함·재park도 안 함
+    assert _hitl_reqs_added(session) == 0  # self-approval → 통과 안 함·재park도 안 함
 
 
 # ── gate_config_enforce_active flag ──────────────────────────────────────────

--- a/backend/tests/test_gate_metrics_s5.py
+++ b/backend/tests/test_gate_metrics_s5.py
@@ -54,6 +54,7 @@ async def test_compute_full():
         _res_all([("pending", 2), ("approved", 5), ("rejected", 3)]),  # 볼륨
         _res_scalar(12.5),                                             # 해소시간(분)
         _res_one((5, 2, 1)),  # approved_resolved=5·rubber=2·self_approval=1
+        _res_all([("auto", 7), ("blocked", 2), ("ask_queued", 3)]),    # S-GATE-5.1 audit outcome
     ])
     m = await compute_hitl_gate_metrics(session, org_id=uuid.uuid4())
     assert m.ask_total == 10
@@ -62,7 +63,12 @@ async def test_compute_full():
     assert m.ask_resolution_minutes == 12.5
     assert m.rubber_stamp_rate == 2 / 5         # rubber/approved_resolved
     assert m.self_approval_caught == 1
-    assert m.coverage is None                   # 소스 한계
+    assert m.coverage is None                   # true ratio deferred(§3)
+    # S-GATE-5.1 audit 기반
+    assert m.enforced_total == 12               # 7+2+3
+    assert m.outcomes["auto"] == 7 and m.outcomes["blocked"] == 2 and m.outcomes["ask_queued"] == 3
+    assert m.outcomes["resumed"] == 0           # 미발생 outcome 은 0
+    assert m.auto_rate == 7 / 12                # auto / enforced_total
 
 
 @pytest.mark.anyio
@@ -74,6 +80,7 @@ async def test_compute_empty():
         _res_all([]),            # 볼륨 없음
         _res_scalar(None),       # 해소 데이터 없음
         _res_one((0, 0, 0)),     # approved_resolved 0
+        _res_all([]),            # audit 없음
     ])
     m = await compute_hitl_gate_metrics(session, org_id=uuid.uuid4())
     assert m.ask_total == 0
@@ -81,6 +88,9 @@ async def test_compute_empty():
     assert m.ask_resolution_minutes is None
     assert m.rubber_stamp_rate is None          # denom 0 → null(0.0 아님)
     assert m.self_approval_caught == 0
+    assert m.enforced_total == 0
+    assert m.auto_rate is None                  # enforced 0 → null
+    assert all(v == 0 for v in m.outcomes.values())
 
 
 # ── 엔드포인트 shape ───────────────────────────────────────────────────────────


### PR DESCRIPTION
E-HITL-GATING **S-GATE-5.1** — coverage/outcome 측정 denominator. PO §1~5 사인오프(§2 정정 반영). **dev·마이그 0125 동반·flag-gated 무회귀**.

## 무엇
auto/block 이 미persist(HitlRequest 는 ask 만)라 coverage·auto-pass 카운트 DB 불가이던 한계 해소.
- **HitlGateAudit 모델 + 0125**(`hitl_gate_audit`·additive·prod-safe).
- **enforce_gate 매 호출 audit 1행** — org/project/work_type/actor/resolved_level/outcome/work_item/actor_id/ts.
- **gate_metrics 확장**: `enforced_total`·`outcomes`(분포)·`auto_rate` 추가(GET /gate/metrics).

## ⚠️ §2(PO 정정) — block/ask audit 가 409 rollback 서 생존
**return outcome(auto·resumed)** = session.add 만(전이가 함께 commit). **raise outcome(blocked·ask_queued·rejected_blocked·self_blocked)** = **raise 전 독립 commit**(HitlRequest 생존 패턴 미러). 안 하면 409→rollback 에 audit 유실 = coverage 가 정작 핵심 가치 이벤트(blocked·ask)를 못 잡는 자기모순.

## §3 coverage
outcome 분포 + auto_rate 가 가치(우선). true coverage ratio(enforced/전체 전이)는 stories 분모 필요 — deferred(coverage=None).

## 검증
- **§2 real-PG(docker pg15)**: enforce_gate(block)→409→`session.rollback()` 후 `hitl_gate_audit` 에 `('blocked','block')` **생존** ✓(자기모순 회피 실증).
- 0125 alembic chain head·DDL real-PG 검증.
- enforce/metrics 테스트 갱신(audit add를 HitlRequest park 와 타입 구분)·gate/hitl/metrics **193 passed 회귀 0**.

머지 후 **migrate-dev(0125)** 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)