### PR TITLE
refactor(settings): org 게이트 PUT을 clean org-PUT(#1571)로 — 워크어라운드 제거 (S-GATE-4 f/u)

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -1162,14 +1162,13 @@ export default function SettingsPage() {
                   )}
                 </SectionCardBody>
               </SectionCard>
-              {/* S-GATE-4 2계층: 조직 게이트 정책(기본값) surface. scope='org'. PUT 은 대표 project 경유
-                  (org_router 는 GET 만)·canEdit=org admin/owner. project 0개면 컴포넌트가 편집 불가 안내. */}
+              {/* S-GATE-4: 조직 게이트 정책(기본값) surface. #1571 clean org-PUT(/organizations/{id})로
+                  org-scoped 설정 — 대표 project 경유 워크어라운드·project-0 엣지 제거. canEdit=org admin/owner. */}
               {orgInfo ? (
                 <div className="mt-6">
                   <GateLevelMatrix
                     surface="org"
                     orgId={orgInfo.id}
-                    projectId={currentProjectId ?? projects[0]?.id}
                     canEdit={currentOrgRole === 'owner' || currentOrgRole === 'admin'}
                   />
                 </div>

--- a/apps/web/src/app/api/organizations/[id]/gate-config/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/gate-config/route.ts
@@ -4,14 +4,21 @@ import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 type RouteParams = { params: Promise<{ id: string }> };
 
 /**
- * org 기본값 게이트 config 프록시 (S-GATE-4 2계층). BE `GET /api/v2/organizations/{org_id}/gate-config`
- * — org-default 단독 매트릭스(project override 무시). 권한 org admin/owner(BE 강제). 설정(PUT scope='org')은
- * project gate-config 라우트 경유.
+ * org 기본값 게이트 config 프록시 (S-GATE-4). BE `GET/PUT /api/v2/organizations/{org_id}/gate-config`.
+ * GET = org-default 단독 매트릭스(project override 무시) / PUT(#1571) = org 기본값 셀 설정
+ * (`{work_type,actor_type,level}`·scope 없음). 권한 org admin/owner(BE 강제).
  */
 export async function GET(request: Request, { params }: RouteParams) {
   const { id } = await params;
   const _r = await proxyToFastapiWithParams(request, '/api/v2/organizations/[id]/gate-config', { id });
   if (!_r.ok) return _r;
   if (_r.status === 204) return apiSuccess([]);
+  return apiSuccess(await _r.json());
+}
+
+export async function PUT(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/organizations/[id]/gate-config', { id });
+  if (!_r.ok) return _r;
   return apiSuccess(await _r.json());
 }

--- a/apps/web/src/components/settings/gate-level-matrix.tsx
+++ b/apps/web/src/components/settings/gate-level-matrix.tsx
@@ -63,8 +63,9 @@ export function GateLevelMatrix({ surface, projectId, orgId, canEdit }: GateLeve
   const [busyCell, setBusyCell] = useState<string | null>(null);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
-  // org 기본값 설정도 project 라우트(scope='org')를 경유하므로 대표 projectId 가 있어야 쓰기 가능.
-  const canWrite = canEdit && !!projectId;
+  // org surface = org-scoped PUT(/organizations/{id})·project surface = /projects/{id}. #1571 clean
+  // org-PUT 로 #1567 워크어라운드(project 라우트 scope='org'+대표 project) 제거 — org 는 orgId 만 필요.
+  const canWrite = canEdit && (surface === 'org' ? !!orgId : !!projectId);
   const getUrl = surface === 'org'
     ? (orgId ? `/api/organizations/${orgId}/gate-config` : null)
     : (projectId ? `/api/projects/${projectId}/gate-config` : null);
@@ -97,7 +98,7 @@ export function GateLevelMatrix({ surface, projectId, orgId, canEdit }: GateLeve
     setCells((m) => (prev ? { ...m, [key]: prev } : (() => { const n = { ...m }; delete n[key]; return n; })()));
 
   const handleSet = async (wt: WorkType, at: ActorType, level: Level) => {
-    if (!canWrite || !projectId || isLevelDisabled(wt, level) || busyCell) return;
+    if (!canWrite || isLevelDisabled(wt, level) || busyCell) return;
     const key = cellKey(wt, at);
     // org surface: 같은 레벨 noop. project surface: 같은 레벨이라도 상속이면 override 생성 의미 있음.
     if (cells[key]?.level === level && (surface === 'org' || cells[key]?.source === 'override')) return;
@@ -106,11 +107,18 @@ export function GateLevelMatrix({ surface, projectId, orgId, canEdit }: GateLeve
     setMessage(null);
     setCells((m) => ({ ...m, [key]: { level, source: surface === 'org' ? 'org_default' : 'override' } })); // 낙관적(#1539)
     try {
-      const res = await fetch(`/api/projects/${projectId}/gate-config`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ scope: surface === 'org' ? 'org' : 'project', work_type: wt, actor_type: at, level }),
-      });
+      // org = org-scoped PUT(#1571·scope 없음) / project = override PUT(scope='project').
+      const res = surface === 'org'
+        ? await fetch(`/api/organizations/${orgId}/gate-config`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ work_type: wt, actor_type: at, level }),
+          })
+        : await fetch(`/api/projects/${projectId}/gate-config`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ scope: 'project', work_type: wt, actor_type: at, level }),
+          });
       if (res.ok) {
         applyEntry(key, (await res.json().catch(() => null) as { data?: GateLevelEntry } | null)?.data);
         setMessage({ type: 'success', text: t('saved') });
@@ -165,11 +173,6 @@ export function GateLevelMatrix({ surface, projectId, orgId, canEdit }: GateLeve
             <AlertDescription>{message.text}</AlertDescription>
           </Alert>
         )}
-        {canEdit && !projectId ? (
-          <Alert variant="default">
-            <AlertDescription>{t('noProjectForOrgEdit')}</AlertDescription>
-          </Alert>
-        ) : null}
 
         <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
           {LEVELS.map((lv) => (


### PR DESCRIPTION
## 무엇을

S-GATE-4 follow-up ⓐ (PO 라우팅·저우선). #1567 2계층 PR이 BE `org_router`에 PUT 부재라 **project 라우트 `scope='org'` + 대표 project 경유** 워크어라운드를 썼고, **project 0개 org는 편집 불가**(`noProjectForOrgEdit` 안내)였다. **#1571**(org-scoped PUT `/api/v2/organizations/{id}/gate-config`) 머지로 그 핵을 통째 제거.

## 변경 (순수 정리·동작 동일)

- **org 프록시** `api/organizations/[id]/gate-config`에 **PUT 추가**(GET 옆).
- **`GateLevelMatrix.handleSet`**: org surface = `PUT /api/organizations/{orgId}/gate-config` body `{work_type,actor_type,level}`(**scope 없음**·#1571). project surface = 기존 `/projects/{id}` `scope='project'` 유지.
- **`canWrite`** = `canEdit && (surface==='org' ? !!orgId : !!projectId)` — org는 대표 projectId 불요.
- **`noProjectForOrgEdit` Alert 제거**(project-0 엣지 소멸) + settings org 마운트의 **대표 projectId prop 제거**.

권한·UX 동일(org owner/admin만 편집·상속/재정의·↺복귀 그대로). 워크어라운드 핵만 제거.

> 참고: `noProjectForOrgEdit` i18n 키는 미사용으로 남김(무해·gate-config 전용). 필요시 별 정리.

## 검증

- `pnpm type-check` ✅ / `pnpm lint`(신규 파일) ✅ 0 / `pnpm build` ✅ EXIT 0
- base=`origin/develop`(#1571 포함)

까심 QA(org 기본값 PUT·project-0 org 편집 가능·project surface 무회귀)→머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)