### PR TITLE
fix(mcp): per-call project_id override → X-Project-Id (85429ee0)

### DIFF
--- a/backend/sprintable_mcp/api_client.py
+++ b/backend/sprintable_mcp/api_client.py
@@ -1,12 +1,28 @@
 """SprintableClient — httpx 기반 PM API HTTP 클라이언트."""
 from __future__ import annotations
 
+import contextvars
 import logging
 from typing import Any
 
 import httpx
 
 logger = logging.getLogger(__name__)
+
+# 85429ee0: per-call 프로젝트 override(org-agent 멀티프로젝트 grant). server._flat 가 tool-call 스코프로
+# set/reset. 설정 시 client.project_id(쿼리/바디) + X-Project-Id 헤더에 반영. 미설정 시 키 default(무회귀).
+_project_override: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "mcp_project_override", default=None
+)
+
+
+def set_project_override(project_id: str | None):
+    """per-call 프로젝트 override 설정 — 반환 token 으로 reset(server _flat wrapper 가 tool 호출 스코프로 사용)."""
+    return _project_override.set(project_id or None)
+
+
+def reset_project_override(token) -> None:
+    _project_override.reset(token)
 
 # 백엔드 에러 본문을 MCP 에러 문자열에 노출할 때, 비정상적으로 큰 body가
 # 에이전트 컨텍스트를 잠식하지 않도록 자르는 상한.
@@ -155,7 +171,8 @@ class SprintableClient:
 
     @property
     def project_id(self) -> str:
-        return self._project_id
+        # per-call override(85429ee0) 우선 — 없으면 키 default(무회귀).
+        return _project_override.get() or self._project_id
 
     async def request(
         self,
@@ -171,11 +188,17 @@ class SprintableClient:
             "x-agent-api-key": self._api_key,
             "Content-Type": "application/json",
         }
+        # 85429ee0: per-call override 시 X-Project-Id 헤더 전송 — 백엔드 get_verified_org_id 가
+        # has_project_access 로 멤버십 검증 후 그 프로젝트로 컨텍스트 전환(mutation 라우트). 미설정 시
+        # 헤더 미전송(키 default·무회귀).
+        _override = _project_override.get()
+        if _override:
+            headers["X-Project-Id"] = _override
 
-        # POST/PUT/PATCH body에 context 필드 자동 주입
+        # POST/PUT/PATCH body에 context 필드 자동 주입(project_id 는 override 반영된 effective).
         if method.upper() in ("POST", "PUT", "PATCH") and json is not None:
-            if not json.get("project_id") and self._project_id:
-                json = {**json, "project_id": self._project_id}
+            if not json.get("project_id") and self.project_id:
+                json = {**json, "project_id": self.project_id}
             if not json.get("org_id") and self._org_id:
                 json = {**json, "org_id": self._org_id}
             if not json.get("created_by") and self._member_id:

--- a/backend/sprintable_mcp/schemas.py
+++ b/backend/sprintable_mcp/schemas.py
@@ -69,8 +69,11 @@ class HypothesisConfirmStatus(str, Enum):
 class SprintableInput(BaseModel):
     """모든 Sprintable 도구 입력 공통 베이스.
 
-    project_id/org_id는 SprintableClient context에서 자동 주입하므로 스키마에서 제외.
+    org_id는 SprintableClient context에서 자동 주입. project_id는 **선택적 per-call override** —
+    org-agent 멀티프로젝트 grant(ProjectAccess) 시 특정 프로젝트를 타겟(미지정=키 default project·무회귀).
+    설정 시 client.project_id(쿼리/바디) + X-Project-Id 헤더에 반영(85429ee0).
     Optional 필드는 기본값 None → MCP schema required에서 제외.
     """
 
     model_config = ConfigDict(extra="ignore")
+    project_id: str | None = None

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -14,7 +14,7 @@ from mcp.types import TextContent
 from pydantic import BaseModel
 from pydantic.fields import PydanticUndefined
 
-from .api_client import client
+from .api_client import client, reset_project_override, set_project_override
 from .config import settings
 from .response import ok
 from .schemas import SprintableInput
@@ -172,12 +172,23 @@ def _flat(name: str, doc: str, input_cls: type[BaseModel], fn):
             )
         )
 
+    # 85429ee0: base SprintableInput.project_id(기본값 有)가 subclass 필수필드보다 앞서면
+    # inspect.Signature 가 "non-default argument follows default argument"로 깨진다 → 기본값 없는
+    # 파라미터를 앞으로 안정 정렬(MCP 는 keyword 호출이라 순서 변경 무해).
+    params.sort(key=lambda p: p.default is not inspect.Parameter.empty)
+
     async def wrapper(**kwargs):
         # E-MCP S2: call-time enforcement — 키 허용 밖 도구는 호출 차단(403-shape).
         await _load_scope()
         if not is_tool_allowed(name, _key_scope):
             return _denied(name)
-        result = await fn(input_cls(**kwargs))
+        # 85429ee0: per-call project_id override → contextvar(tool 호출 스코프). client.project_id +
+        # X-Project-Id 헤더에 반영(org-agent 멀티프로젝트 grant). 미지정이면 키 default(무회귀).
+        _tok = set_project_override(kwargs.get("project_id"))
+        try:
+            result = await fn(input_cls(**kwargs))
+        finally:
+            reset_project_override(_tok)
         asyncio.create_task(_heartbeat_fire_forget())
         return result
 

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -99,12 +99,16 @@ def test_all_expected_tools_registered():
     "sprintable_list_meetings",
     "sprintable_list_retro_sessions",
 ])
-def test_project_id_not_in_schema(tool_name: str):
-    """project_id/org_id는 context 자동 주입 — 스키마에 노출 금지."""
+def test_org_id_not_in_schema_project_id_optional(tool_name: str):
+    """org_id는 context 자동 주입 — 스키마 비노출. project_id는 85429ee0 후 **선택적 per-call override**
+    로 스키마에 노출(org-agent 멀티프로젝트 grant 타겟팅·미지정 시 키 default·무회귀)."""
     schema = _TOOLS[tool_name].parameters
     schema_str = str(schema)
-    assert "project_id" not in schema_str
-    assert "org_id" not in schema_str
+    assert "org_id" not in schema_str           # org 는 여전히 context 주입
+    assert "project_id" in schema_str           # 85429ee0: per-call override 로 노출
+    # required 아님(optional·미지정 시 default project)
+    required = schema.get("required", []) if isinstance(schema, dict) else []
+    assert "project_id" not in required
 
 
 @pytest.mark.parametrize("tool_name,optional_field", [

--- a/backend/tests/test_mcp_per_call_project_85429ee0.py
+++ b/backend/tests/test_mcp_per_call_project_85429ee0.py
@@ -1,0 +1,116 @@
+"""85429ee0: MCP per-call project_id override(org-agent 멀티프로젝트) — contextvar·X-Project-Id·signature."""
+from __future__ import annotations
+
+import inspect
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _seed_client():
+    from sprintable_mcp.api_client import client
+
+    client._base_url = "http://x"
+    client._api_key = "k"
+    client._project_id = "DEFAULT"
+    client._org_id = "ORG"
+    client._member_id = "MEM"
+    return client
+
+
+def test_project_override_contextvar():
+    from sprintable_mcp.api_client import (
+        client,
+        reset_project_override,
+        set_project_override,
+    )
+
+    _seed_client()
+    assert client.project_id == "DEFAULT"  # override 없음 → 키 default
+    tok = set_project_override("OVR")
+    assert client.project_id == "OVR"  # override 우선
+    reset_project_override(tok)
+    assert client.project_id == "DEFAULT"  # reset → default
+    tok2 = set_project_override(None)  # None → default(무회귀)
+    assert client.project_id == "DEFAULT"
+    reset_project_override(tok2)
+
+
+def test_sprintable_input_has_project_id():
+    from sprintable_mcp.schemas import SprintableInput
+
+    assert "project_id" in SprintableInput.model_fields
+    assert SprintableInput.model_fields["project_id"].default is None  # optional·무회귀
+
+
+def test_flat_signature_required_before_default():
+    """base project_id(기본값 有)가 subclass 필수필드보다 앞서면 signature 깨짐 → 정렬로 봉합."""
+    from sprintable_mcp.server import _flat
+    from sprintable_mcp.tools.stories import AddStoryInput, add_story
+
+    w = _flat("add_story", "doc", AddStoryInput, add_story)
+    sig = inspect.signature(w)  # 깨지면 여기서 ValueError
+    names = list(sig.parameters)
+    assert "project_id" in names
+    assert names[0] == "title"  # 필수필드가 앞(기본값 없음)
+    # 기본값 없는 param 이 기본값 있는 param 보다 앞(inspect.Signature 규칙)
+    seen_default = False
+    for n in names:
+        has_default = sig.parameters[n].default is not inspect.Parameter.empty
+        if has_default:
+            seen_default = True
+        else:
+            assert not seen_default, f"non-default '{n}' follows default"
+
+
+@pytest.mark.anyio
+async def test_request_sets_x_project_id_on_override():
+    from sprintable_mcp.api_client import (
+        client,
+        reset_project_override,
+        set_project_override,
+    )
+
+    _seed_client()
+    captured: dict = {}
+
+    class _Resp:
+        status_code = 200
+        is_success = True
+        text = "{}"
+
+        def json(self):
+            return {"ok": 1}
+
+    class _FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def request(self, method, url, json=None, params=None, headers=None):
+            captured["headers"] = headers
+            captured["params"] = params
+            captured["json"] = json
+            return _Resp()
+
+    with patch("sprintable_mcp.api_client.httpx.AsyncClient", return_value=_FakeClient()):
+        # override 없음 → X-Project-Id 미전송·effective=default
+        await client.request("GET", "/api/v2/stories", params={"project_id": client.project_id})
+        assert "X-Project-Id" not in captured["headers"]
+        assert captured["params"]["project_id"] == "DEFAULT"
+
+        # override 있음 → X-Project-Id 전송·effective=override(쿼리·바디)
+        tok = set_project_override("OVR")
+        await client.request("GET", "/api/v2/stories", params={"project_id": client.project_id})
+        assert captured["headers"].get("X-Project-Id") == "OVR"
+        assert captured["params"]["project_id"] == "OVR"
+        await client.request("POST", "/api/v2/stories", json={"title": "t"})
+        assert captured["json"]["project_id"] == "OVR"  # body 주입도 effective
+        reset_project_override(tok)


### PR DESCRIPTION
**85429ee0** — MCP per-call project context lock. 산티아고 prod 실증으로 grounded 확定(cross-org 아닌·내 오진 정정 후 데이터로 본 진짜 버그).

## 근본
org-agent 멀티프로젝트 grant(`project_access`)로 N 프로젝트 접근권(authz 200)을 받아도, MCP 툴이 **startup 1회 resolve한 default project에 lock** — tool에 `project_id` param 없음·HTTP에 `X-Project-Id` 미전송. → granted 보드(1d3bfded) 못 잡고 default(ZeroGo)만 반환. (direct-API+X-Project-Id는 200·내 dev 실측대로.)

## fix (contextvar·**22 tool 파일 무변경**)
- `schemas.py` `SprintableInput`에 선택적 `project_id` — per-call 타겟 override(미지정=키 default·무회귀).
- `api_client.py`: `_project_override` contextvar + set/reset·`project_id` property override·`request()`가 override 시 **`X-Project-Id` 헤더 전송**(backend `get_verified_org_id`→`has_project_access` 검증·이미 준비됨)·body project_id 주입도 effective.
- `server._flat`: tool 호출 스코프로 contextvar set/reset(`kwargs.project_id`). + ⚠️ base `project_id`(기본값 有)가 subclass 필수필드보다 앞서 `inspect.Signature` "non-default follows default" 깨지던 것 → **기본값 없는 param 앞 정렬**로 봉합.

## 검증
신규 4 테스트(contextvar override·X-Project-Id 헤더 on/off·signature 정렬·SprintableInput.project_id) + 계약 테스트 갱신(`project_id`는 85429ee0 후 의도적 노출·`org_id`는 여전히 context 주입) + **MCP 140 passed**. 미설정 시 default(무회귀).

배포 후 산티아고가 `list_stories(project_id=1d3bfded…)`로 granted 보드 타겟 → 9티켓 정상 MCP 마감.

🤖 Generated with [Claude Code](https://claude.com/claude-code)