### PR TITLE
fix(auth): access token TTL 15→60분 완화 (af8d3641 AC2)

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -23,7 +23,10 @@ __all__ = [
     "ACCESS_TOKEN_EXPIRE_MINUTES", "REFRESH_TOKEN_EXPIRE_DAYS",
 ]
 
-ACCESS_TOKEN_EXPIRE_MINUTES = 15
+# af8d3641 AC2: 15→60분 완화. 15분은 동시요청 refresh 빈도를 높여 rotation 레이스(→강제 로그아웃)를
+# 잦게 함(체감 "세션 너무 짧음"). 60분은 보안 통상 범위(access 15~60분 표준)·refresh 30일이 longevity 담당
+# (만료 시 silent refresh). 근본 동시성 fix는 FE single-flight(AC1·별 작업). dev/prod 공유 상수.
+ACCESS_TOKEN_EXPIRE_MINUTES = 60
 REFRESH_TOKEN_EXPIRE_DAYS = 30
 
 _pwd_context = CryptContext(schemes=["argon2", "bcrypt"], deprecated="auto")


### PR DESCRIPTION
**af8d3641** 세션 타임아웃 fix(story `551bbbee`) **AC2(BE 완화)**. dev·마이그 없음·1줄.

## 진단(코드 grounded·라이브 0)
15분 access TTL + refresh **single-use rotation**(쓰면 old revoke) → 대시보드 동시요청이 만료/5분창서 **같은 refresh token으로 동시 refresh** → 첫 건이 rotation으로 revoke → 나머지 401 `TOKEN_REVOKED` → `proxy.ts` 미들웨어가 `/login` 리다이렉트 = **강제 로그아웃**. 15분이라 refresh 창이 잦아 레이스 빈발 = "세션 너무 짧음" 체감.

## AC2 (이 PR)
`ACCESS_TOKEN_EXPIRE_MINUTES` **15→60**(`security.py:26`). refresh 빈도↓→레이스 빈도↓(완화). 60분은 보안 통상 범위(access 15~60분 표준)·refresh 30일 유지가 longevity 담당. dev/prod 공유 상수→양쪽 적용·`expires_in`(=TTL*60) 자동 3600.

## 분담
- **AC1 [근본]** FE `proxy.ts` single-flight refresh(동시 refresh dedupe·single-use 보안 유지·레이스 제거) — 미르코.
- **AC3 [UX]** refresh 최종 실패 시 hard `/login` 대신 graceful — 유나.
- 셋 합쳐 af8d3641 해소.

## 검증
TTL=60·`create_tokens` expires_in=3600 확認. auth/security/switch_org **159 passed 회귀 0**(테스트의 `expires_in:900`은 mock 값·실 상수 비파생). ⚠️ 머지 후 **prod 재배포** 시 적용(env 아닌 코드 상수).

🤖 Generated with [Claude Code](https://claude.com/claude-code)