### PR TITLE
fix(auth): 세션 타임아웃 — single-flight refresh(AC1) + sp_at 쿠키 maxAge 60분 7곳(AC2b) (551bbbee)

### DIFF
--- a/apps/web/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/web/src/app/api/auth/callback/[provider]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
+import { SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 import { resolveAppUrl } from '@/services/app-url';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
@@ -62,7 +63,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 
   const destination = inviteToken ? `${origin}/dashboard` : `${origin}/inbox`;
   const res = NextResponse.redirect(destination);
-  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: 15 * 60 });
+  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: SP_AT_MAX_AGE_SECONDS });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
   return res;
 }

--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { verifyCsrfOrigin } from '@/lib/auth/csrf';
-import { cookieBase } from '@/lib/auth/cookies';
+import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -25,7 +25,7 @@ export async function POST(request: Request) {
 
   const { access_token, refresh_token } = json.data;
   const res = NextResponse.json({ data: { ok: true } });
-  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: 15 * 60 });
+  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: SP_AT_MAX_AGE_SECONDS });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
   return res;
 }

--- a/apps/web/src/app/api/auth/refresh/route.ts
+++ b/apps/web/src/app/api/auth/refresh/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { verifyCsrfOrigin } from '@/lib/auth/csrf';
-import { cookieBase } from '@/lib/auth/cookies';
+import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -30,7 +30,7 @@ export async function POST(request: Request) {
 
   const { access_token, refresh_token } = json.data;
   const res = NextResponse.json({ data: { ok: true } });
-  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: 15 * 60 });
+  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: SP_AT_MAX_AGE_SECONDS });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
   return res;
 }

--- a/apps/web/src/app/api/auth/register/route.ts
+++ b/apps/web/src/app/api/auth/register/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { verifyCsrfOrigin } from '@/lib/auth/csrf';
-import { cookieBase } from '@/lib/auth/cookies';
+import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -31,7 +31,7 @@ export async function POST(request: Request) {
 
   const { access_token, refresh_token } = json.data;
   const res = NextResponse.json({ data: { ok: true } }, { status: 201 });
-  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: 15 * 60 });
+  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: SP_AT_MAX_AGE_SECONDS });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
   return res;
 }

--- a/apps/web/src/app/api/switch-org/route.ts
+++ b/apps/web/src/app/api/switch-org/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { SP_AT_COOKIE, SP_RT_COOKIE, getServerSession } from '@/lib/db/server';
 import { CURRENT_PROJECT_COOKIE } from '@/lib/auth-helpers';
-import { cookieBase } from '@/lib/auth/cookies';
+import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -39,7 +39,7 @@ export async function POST(request: Request): Promise<Response> {
 
   const { access_token, refresh_token, project_id } = json.data;
   const res = NextResponse.json({ data: { ok: true } });
-  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: 15 * 60 });
+  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: SP_AT_MAX_AGE_SECONDS });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
   // 0746: 전환 시 current-project 쿠키를 항상 갱신해야 stale 잔존이 없다.
   // target org에 접근 가능 프로젝트가 있으면 그걸로 set, 없으면(미부여 멤버 등) 반드시 clear —

--- a/apps/web/src/app/api/switch-project/route.ts
+++ b/apps/web/src/app/api/switch-project/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { SP_AT_COOKIE, SP_RT_COOKIE, getServerSession } from '@/lib/db/server';
 import { CURRENT_PROJECT_COOKIE } from '@/lib/auth-helpers';
-import { cookieBase } from '@/lib/auth/cookies';
+import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -39,7 +39,7 @@ export async function POST(request: Request): Promise<Response> {
 
   const { access_token, refresh_token } = json.data;
   const res = NextResponse.json({ data: { ok: true } });
-  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: 15 * 60 });
+  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: SP_AT_MAX_AGE_SECONDS });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
   res.cookies.set(CURRENT_PROJECT_COOKIE, body.project_id, { path: '/', sameSite: 'lax', maxAge: 60 * 60 * 24 * 365 });
   return res;

--- a/apps/web/src/lib/auth/cookies.ts
+++ b/apps/web/src/lib/auth/cookies.ts
@@ -1,3 +1,11 @@
+/**
+ * sp_at(access) 쿠키 maxAge(초). AC2b(551bbbee): BE access TTL 60분(#1577)과 일치. ⚠️ refresh **빈도를
+ * 결정하는 게 이 쿠키 maxAge** — 쿠키가 15분에 만료되면 JWT 가 60분이어도 15분마다 refresh 강제
+ * (rotation 레이스 빈도 그대로). sp_at 를 set 하는 **모든 경로(7곳)**가 이 상수를 써야 드리프트
+ * (일부만 15분 잔존) 방지. sp_rt(30일)는 별개.
+ */
+export const SP_AT_MAX_AGE_SECONDS = 60 * 60;
+
 /** APP_BASE_URL 또는 NEXT_PUBLIC_APP_URL 기준으로 Secure 쿠키 여부 결정.
  *  HTTP(localhost, Tailscale, ngrok 등)에서는 false, HTTPS에서는 true.
  */

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -74,25 +74,33 @@ async function tryRefreshViaFastapi(request: NextRequest): Promise<{ accessToken
 
 // AC1(551bbbee): single-flight refresh. refresh 는 single-use rotation(첫 건이 RT revoke)이라, 대시보드
 // 동시요청이 같은 RT 로 각자 refresh 하면 첫 건만 통과·나머지 401 → 강제 로그아웃("세션 너무 짧음")이던
-// 레이스를 제거. RT 기준 in-flight 1개로 dedupe(나머지는 그 결과 await/재사용) — 실제 refresh 호출은 1회라
-// single-use 보안 유지. grace(시작 기준 5s) 동안 결과 캐시 — cookie 갱신 전 도착한 burst 꼬리 요청도 옛 RT
-// 로 새 refresh 하지 않고 재사용. setTimeout 미사용(edge 런타임서 post-response 실행 불확실) — timestamp
-// lazy 만료 + size-cap prune(무한증가 방지).
+// 레이스를 제거. RT 기준 in-flight 1개로 dedupe(나머지는 그 promise 를 await/재사용) — 실제 refresh 호출은
+// 1회라 single-use 보안 유지.
+//   - **pending 동안은 시간 무관하게 그 promise 재사용**(refresh 가 10s 걸려도 1개만 — 시작-기준 grace 면
+//     느린 refresh 가 grace 넘겨 pending 중 신규 refresh 시작=레이스 재발, RC HIGH 봉합).
+//   - 해소(settled) 후엔 **해소 시각 기준 grace** 동안만 결과 재사용 — cookie 갱신 전 도착한 burst 꼬리
+//     요청도 옛 RT 로 새 refresh 안 함.
+// setTimeout 미사용(edge 런타임 post-response 실행 불확실)·size-cap lazy prune(무한증가 방지).
 const REFRESH_GRACE_MS = 5_000;
-const inflightRefresh = new Map<string, { p: Promise<{ accessToken: string; refreshToken: string } | null>; expiresAt: number }>();
+type RefreshEntry = { p: Promise<{ accessToken: string; refreshToken: string } | null>; settledAt: number | null };
+const inflightRefresh = new Map<string, RefreshEntry>();
 
 function singleFlightRefresh(request: NextRequest): Promise<{ accessToken: string; refreshToken: string } | null> {
   const rt = request.cookies.get(SP_RT_COOKIE)?.value;
   if (!rt) return Promise.resolve(null);
   const now = Date.now();
   const existing = inflightRefresh.get(rt);
-  if (existing && existing.expiresAt > now) return existing.p; // 진행 중 or 최근 결과 재사용
-  const p = tryRefreshViaFastapi(request);
-  inflightRefresh.set(rt, { p, expiresAt: now + REFRESH_GRACE_MS });
-  if (inflightRefresh.size > 64) { // 만료 항목 lazy prune(무한증가 방지)
-    for (const [k, v] of inflightRefresh) if (v.expiresAt <= now) inflightRefresh.delete(k);
+  // pending(settledAt===null) → 시간 무관 재사용 / settled → 해소 시각 + grace 내에서만 재사용.
+  if (existing && (existing.settledAt === null || existing.settledAt + REFRESH_GRACE_MS > now)) {
+    return existing.p;
   }
-  return p;
+  const entry: RefreshEntry = { p: tryRefreshViaFastapi(request), settledAt: null };
+  inflightRefresh.set(rt, entry);
+  void entry.p.finally(() => { entry.settledAt = Date.now(); }); // 해소 시각 기록 → grace 시작점
+  if (inflightRefresh.size > 64) { // settled + grace 지난 항목 lazy prune(pending 은 유지)
+    for (const [k, v] of inflightRefresh) if (v.settledAt !== null && v.settledAt + REFRESH_GRACE_MS <= now) inflightRefresh.delete(k);
+  }
+  return entry.p;
 }
 
 function applyTokenCookies(

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -72,6 +72,29 @@ async function tryRefreshViaFastapi(request: NextRequest): Promise<{ accessToken
   }
 }
 
+// AC1(551bbbee): single-flight refresh. refresh 는 single-use rotation(첫 건이 RT revoke)이라, 대시보드
+// 동시요청이 같은 RT 로 각자 refresh 하면 첫 건만 통과·나머지 401 → 강제 로그아웃("세션 너무 짧음")이던
+// 레이스를 제거. RT 기준 in-flight 1개로 dedupe(나머지는 그 결과 await/재사용) — 실제 refresh 호출은 1회라
+// single-use 보안 유지. grace(시작 기준 5s) 동안 결과 캐시 — cookie 갱신 전 도착한 burst 꼬리 요청도 옛 RT
+// 로 새 refresh 하지 않고 재사용. setTimeout 미사용(edge 런타임서 post-response 실행 불확실) — timestamp
+// lazy 만료 + size-cap prune(무한증가 방지).
+const REFRESH_GRACE_MS = 5_000;
+const inflightRefresh = new Map<string, { p: Promise<{ accessToken: string; refreshToken: string } | null>; expiresAt: number }>();
+
+function singleFlightRefresh(request: NextRequest): Promise<{ accessToken: string; refreshToken: string } | null> {
+  const rt = request.cookies.get(SP_RT_COOKIE)?.value;
+  if (!rt) return Promise.resolve(null);
+  const now = Date.now();
+  const existing = inflightRefresh.get(rt);
+  if (existing && existing.expiresAt > now) return existing.p; // 진행 중 or 최근 결과 재사용
+  const p = tryRefreshViaFastapi(request);
+  inflightRefresh.set(rt, { p, expiresAt: now + REFRESH_GRACE_MS });
+  if (inflightRefresh.size > 64) { // 만료 항목 lazy prune(무한증가 방지)
+    for (const [k, v] of inflightRefresh) if (v.expiresAt <= now) inflightRefresh.delete(k);
+  }
+  return p;
+}
+
 function applyTokenCookies(
   response: NextResponse,
   accessToken: string,
@@ -123,7 +146,7 @@ export async function proxy(request: NextRequest) {
   const accessToken = request.cookies.get(SP_AT_COOKIE)?.value;
 
   if (!accessToken) {
-    const tokens = await tryRefreshViaFastapi(request);
+    const tokens = await singleFlightRefresh(request);
     if (!tokens) {
       if (isApiPath) return NextResponse.next({ request }); // let handler return 401
       const url = request.nextUrl.clone();
@@ -140,7 +163,7 @@ export async function proxy(request: NextRequest) {
 
   if (!claims) {
     // access token invalid/expired — try refresh
-    const tokens = await tryRefreshViaFastapi(request);
+    const tokens = await singleFlightRefresh(request);
     if (!tokens) {
       if (isApiPath) return NextResponse.next({ request }); // let handler return 401
       const url = request.nextUrl.clone();
@@ -157,7 +180,7 @@ export async function proxy(request: NextRequest) {
   const now = Math.floor(Date.now() / 1000);
   const response = NextResponse.next({ request });
   if (claims.exp !== undefined && claims.exp - now < 300) {
-    const tokens = await tryRefreshViaFastapi(request);
+    const tokens = await singleFlightRefresh(request);
     if (tokens) {
       applyTokenCookies(response, tokens.accessToken, tokens.refreshToken);
     }

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,6 +1,6 @@
 import { jwtVerify } from 'jose';
 import { NextResponse, type NextRequest } from 'next/server';
-import { cookieBase } from '@/lib/auth/cookies';
+import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 
 const PUBLIC_EXACT = [
   '/',
@@ -101,7 +101,7 @@ function applyTokenCookies(
   refreshToken: string,
 ): void {
   const base = cookieBase();
-  response.cookies.set(SP_AT_COOKIE, accessToken, { ...base, maxAge: 15 * 60 });
+  response.cookies.set(SP_AT_COOKIE, accessToken, { ...base, maxAge: SP_AT_MAX_AGE_SECONDS });
   response.cookies.set(SP_RT_COOKIE, refreshToken, { ...base, maxAge: 30 * 24 * 60 * 60 });
 }
 


### PR DESCRIPTION
## 무엇을 / 근본

세션 타임아웃 fix FE package (story `551bbbee`·아버님 "근본까지", 유나양 핸드오프). 순수 로직(디자인 무관). **AC1 + AC2b** 묶음(AC3=유나양 UX 별도·AC2 BE TTL=디디군 #1577).

**근본:** 15분 access TTL + refresh single-use rotation → 대시보드 동시요청이 같은 RT 로 각자 refresh → 첫 건 revoke → 나머지 401 → 강제 로그아웃.

## AC1 — single-flight refresh (`proxy.ts`)

3개 refresh 경로(no-access·만료 reactive·proactive)를 **single-flight dedupe** — RT 기준 in-flight 1개만 실제 호출, 나머지 await/재사용. single-use 보안 유지·rotation 레이스 제거. **timestamp grace(5s)·setTimeout 미사용(edge/node robust)·size-cap prune.** `:147-150` redirect는 **AC3 경계라 미변경.**

## AC2b — sp_at 쿠키 maxAge 15→60분 (**7곳 전수** + 상수화)

BE TTL 60(#1577) 효과 위해 **쿠키 maxAge** 도 60분이어야(쿠키가 refresh 빈도를 결정·15분이면 JWT 60분이어도 15분마다 refresh 강제).

⚠️ **핸드오프 3→6곳 지목이었으나 repo-wide grep 으로 7곳 확정**(유나양 grep 과 일치): `callback`·`login`·`refresh`·`register`·**`switch-org`·`switch-project`**·`proxy.ts`. switch-org/project 는 **전환 직후 sp_at 를 도로 15분으로 리셋**하던 누락분 — 빠지면 전환 경로서 버그 재발.

fix: **`SP_AT_MAX_AGE_SECONDS = 60*60` 상수**(`lib/auth/cookies.ts`) → 7곳 전수 통일. **드리프트(일부만 15분 잔존 = 이 버그의 근본 패턴) 방지.** sp_rt(30일) 유지.

## 검증

- 잔여 `maxAge: 15 * 60`(sp_at) **0** · `pnpm type-check` ✅ / `pnpm lint` ✅ 0 / `pnpm build` ✅ EXIT 0
- base=`origin/develop`

까심 QA: **15분 경과 후 세션 안 끊김** + 멀티탭/동시요청 강제 로그아웃 0 + single-use 보안 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)