### PR TITLE
feat(auth): graceful 세션 만료 UX — next 보존 redirect + 만료 모달/배너 (551bbbee AC3)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -226,9 +226,15 @@
       "incompletePreds": "{count} incomplete predecessor(s) — check before starting"
     }
   },
+  "session": {
+    "expiredTitle": "Your session expired",
+    "expiredBody": "For your security, your session expired. Sign in again to return to where you left off.",
+    "reloginCta": "Sign in again"
+  },
   "login": {
     "title": "Sprintable",
     "subtitle": "AI-powered sprint management",
+    "sessionExpired": "Your session expired and you were signed out. Please sign in again.",
     "google": "Continue with Google",
     "github": "Continue with GitHub",
     "email": "Email",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -226,9 +226,15 @@
       "incompletePreds": "미완료 선행 {count}건 — 시작 전 확인 권장"
     }
   },
+  "session": {
+    "expiredTitle": "세션이 만료되었습니다",
+    "expiredBody": "보안을 위해 세션이 만료되었습니다. 다시 로그인하면 보던 화면으로 돌아갑니다.",
+    "reloginCta": "다시 로그인"
+  },
   "login": {
     "title": "Sprintable",
     "subtitle": "AI 기반 스프린트 관리 도구",
+    "sessionExpired": "세션이 만료되어 로그아웃되었습니다. 다시 로그인해 주세요.",
     "google": "Google로 계속",
     "github": "GitHub로 계속",
     "email": "이메일",

--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -1,5 +1,7 @@
 import { redirect } from 'next/navigation';
+import { headers } from 'next/headers';
 import { getServerSession } from '@/lib/db/server';
+import { buildLoginRedirect } from '@/lib/auth/session-redirect';
 import { DashboardShell } from '../dashboard/dashboard-shell';
 
 interface MemberContext {
@@ -23,8 +25,11 @@ export default async function AuthenticatedLayout({
 }: {
   children: React.ReactNode;
 }) {
+  // AC3: proxy 가 주입한 x-pathname 으로 next 보존(server component 는 현재 경로 직접 못 읽음).
+  const currentPath = (await headers()).get('x-pathname') ?? '';
+
   const session = await getServerSession();
-  if (!session) redirect('/login');
+  if (!session) redirect(buildLoginRedirect(currentPath));
 
   const fastapiUrl = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
   const authHeader = { Authorization: `Bearer ${session.access_token}` };
@@ -36,7 +41,7 @@ export default async function AuthenticatedLayout({
   ]);
 
   // 401(인증 만료)만 /login 리다이렉트, 다른 에러(500 등)는 children 렌더링 유지
-  if (!meRes || meRes.status === 401) redirect('/login');
+  if (!meRes || meRes.status === 401) redirect(buildLoginRedirect(currentPath));
 
   // 🔴 org 없는 유저(신규 OAuth 가입자 등 — team_member 미생성 시 /me 404) → 온보딩으로.
   // auth/callback이 is_new_user 무관 /inbox 리다이렉트하는 결함을 layout에서 OAuth+email/pw 공통 커버

--- a/apps/web/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/web/src/app/api/auth/callback/[provider]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
+import { safeNextPath } from '@/lib/auth/session-redirect';
 import { resolveAppUrl } from '@/services/app-url';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
@@ -33,9 +34,11 @@ export async function GET(request: Request, { params }: RouteParams) {
   const storedState = cookieStore.get(`oauth_state_${provider}`)?.value;
   const tosAccepted = cookieStore.get(`oauth_tos_${provider}`)?.value === 'true';
   const inviteToken = cookieStore.get(`oauth_invite_token_${provider}`)?.value ?? null;
+  const nextCookie = cookieStore.get(`oauth_next_${provider}`)?.value ?? null; // AC3 세션 만료 복귀
   cookieStore.delete(`oauth_state_${provider}`);
   cookieStore.delete(`oauth_tos_${provider}`);
   cookieStore.delete(`oauth_invite_token_${provider}`);
+  cookieStore.delete(`oauth_next_${provider}`);
 
   if (!storedState || storedState !== state) {
     return NextResponse.redirect(`${origin}/login?error=csrf_mismatch`);
@@ -61,7 +64,8 @@ export async function GET(request: Request, { params }: RouteParams) {
     return NextResponse.redirect(`${origin}/login?error=oauth_no_token`);
   }
 
-  const destination = inviteToken ? `${origin}/dashboard` : `${origin}/inbox`;
+  // AC3: 세션 만료로 OAuth 재로그인한 경우 작업 경로 복귀(safeNextPath 가드)·없으면 기존 /inbox.
+  const destination = inviteToken ? `${origin}/dashboard` : `${origin}${safeNextPath(nextCookie)}`;
   const res = NextResponse.redirect(destination);
   res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: SP_AT_MAX_AGE_SECONDS });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });

--- a/apps/web/src/app/auth/login/route.ts
+++ b/apps/web/src/app/auth/login/route.ts
@@ -9,6 +9,7 @@ export async function GET(request: Request) {
   const provider = searchParams.get('provider');
   const tosAccepted = searchParams.get('tos_accepted') === 'true';
   const inviteToken = searchParams.get('invite_token');
+  const next = searchParams.get('next'); // AC3: 세션 만료 복귀 경로 — 콜백서 safeNextPath 로 검증 후 복귀
   const origin = resolveAppUrl(null);
 
   if (!provider || !['google', 'github'].includes(provider)) {
@@ -47,6 +48,15 @@ export async function GET(request: Request) {
   }
   if (inviteToken) {
     cookieStore.set(`oauth_invite_token_${provider}`, inviteToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 300,
+      path: '/',
+    });
+  }
+  if (next) {
+    cookieStore.set(`oauth_next_${provider}`, next, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',

--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/lib/project-context-client';
 import { useTranslations } from 'next-intl';
 import { RealtimeProvider } from '@/components/realtime-provider';
+import { SessionExpiredDialog } from '@/components/auth/session-expired-dialog';
 import { AppSidebar } from '@/components/nav/app-sidebar';
 import { TopBar } from '@/components/nav/top-bar';
 import { TopBarProvider, useTopBar } from '@/components/nav/top-bar-context';
@@ -166,6 +167,7 @@ export function DashboardShell({
             </ScrollShell>
           </SidebarProvider>
         </TopBarProvider>
+        <SessionExpiredDialog />
       </RealtimeProvider>
       </RefreshProvider>
     </DashboardCtx.Provider>

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -6,12 +6,17 @@ import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
 import { loginWithPassword } from '@/lib/db/client';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { safeNextPath, SESSION_EXPIRED_REASON } from '@/lib/auth/session-redirect';
 
 export default function LoginPage() {
   const t = useTranslations('login');
   const router = useRouter();
   const searchParams = useSearchParams();
   const errorCode = searchParams.get('error');
+  // AC3: 세션 만료로 튕긴 경우 reason 배너 + next 로 작업 경로 복귀(오픈 리다이렉트 가드).
+  const sessionExpired = searchParams.get('reason') === SESSION_EXPIRED_REASON;
+  const nextParam = searchParams.get('next');
   const oauthErrors: Record<string, string> = {
     oauth_init_failed: t('oauthInitFailed'),
     oauth_missing_params: t('oauthMissingParams'),
@@ -43,7 +48,7 @@ export default function LoginPage() {
         setError(result.error.message);
         return;
       }
-      router.push('/inbox');
+      router.push(safeNextPath(nextParam));
       router.refresh();
     } catch {
       setError(t('loginFailed'));
@@ -64,6 +69,12 @@ export default function LoginPage() {
           />
           <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
         </div>
+
+        {sessionExpired && (
+          <Alert variant="warning">
+            <AlertDescription>{t('sessionExpired')}</AlertDescription>
+          </Alert>
+        )}
 
         <div className="space-y-3">
           <input
@@ -118,7 +129,7 @@ export default function LoginPage() {
               <div className="flex-grow border-t border-border/50" />
             </div>
 
-            <a href="/auth/login?provider=google&tos_accepted=true" className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-border bg-background px-4 py-3 text-sm font-medium text-foreground/80 transition hover:bg-muted/50">
+            <a href={`/auth/login?provider=google&tos_accepted=true${nextParam ? `&next=${encodeURIComponent(nextParam)}` : ''}`} className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-border bg-background px-4 py-3 text-sm font-medium text-foreground/80 transition hover:bg-muted/50">
               <svg className="h-5 w-5" viewBox="0 0 24 24">
                 <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
                 <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
@@ -128,7 +139,7 @@ export default function LoginPage() {
               {t('google')}
             </a>
 
-            <a href="/auth/login?provider=github&tos_accepted=true" className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-border bg-foreground px-4 py-3 text-sm font-medium text-background transition hover:bg-foreground/90">
+            <a href={`/auth/login?provider=github&tos_accepted=true${nextParam ? `&next=${encodeURIComponent(nextParam)}` : ''}`} className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-border bg-foreground px-4 py-3 text-sm font-medium text-background transition hover:bg-foreground/90">
               <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
               </svg>

--- a/apps/web/src/components/auth/session-expired-dialog.tsx
+++ b/apps/web/src/components/auth/session-expired-dialog.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { subscribeSessionExpired } from '@/lib/auth/session-expired-signal';
+import { buildLoginRedirect } from '@/lib/auth/session-redirect';
+
+/**
+ * AC3(af8d3641): 세션 만료 모달. fetchWithAuth 의 refresh 최종 실패 신호(session-expired-signal)를 받아
+ * hard redirect 대신 graceful 안내 — "다시 로그인" 시 현재 경로를 next 로 보존해 §A 계약 redirect.
+ * (authenticated) 트리 전역(DashboardShell)에 1회 마운트. 신규 토큰 0(Dialog/Button 재사용).
+ */
+export function SessionExpiredDialog() {
+  const t = useTranslations('session');
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => subscribeSessionExpired(() => setOpen(true)), []);
+
+  const relogin = () => {
+    const path = typeof window !== 'undefined' ? window.location.pathname + window.location.search : '/inbox';
+    window.location.href = buildLoginRedirect(path);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('expiredTitle')}</DialogTitle>
+          <DialogDescription>{t('expiredBody')}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button onClick={relogin}>{t('reloginCta')}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/lib/auth/session-expired-signal.ts
+++ b/apps/web/src/lib/auth/session-expired-signal.ts
@@ -1,0 +1,26 @@
+// AC3(af8d3641): 세션-만료 모듈 신호. fetchWithAuth(비-React 모듈 함수)가 refresh 최종 실패 시
+// bare `window.location.href` 대신 이 신호를 쏴 SessionExpiredDialog(React)를 띄운다. 동시 다중 401 은
+// **dedupe**(signaled 플래그) — 한 번만 모달을 연다.
+
+type Listener = () => void;
+
+let listener: Listener | null = null;
+let signaled = false;
+
+/** SessionExpiredDialog 가 마운트 시 구독. cleanup 반환. */
+export function subscribeSessionExpired(cb: Listener): () => void {
+  listener = cb;
+  return () => { if (listener === cb) listener = null; };
+}
+
+/** 세션 만료 신호(다중 호출은 1회로 dedupe). */
+export function signalSessionExpired(): void {
+  if (signaled) return;
+  signaled = true;
+  listener?.();
+}
+
+/** 재로그인 등으로 상태 초기화(다음 만료를 다시 잡도록). */
+export function resetSessionExpired(): void {
+  signaled = false;
+}

--- a/apps/web/src/lib/auth/session-redirect.test.ts
+++ b/apps/web/src/lib/auth/session-redirect.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { buildLoginRedirect, safeNextPath, SESSION_EXPIRED_REASON } from './session-redirect';
+
+describe('safeNextPath — 오픈 리다이렉트 가드 (AC3)', () => {
+  it('내부 절대경로는 그대로 허용', () => {
+    expect(safeNextPath('/board')).toBe('/board');
+    expect(safeNextPath('/stories/123?tab=detail')).toBe('/stories/123?tab=detail');
+    expect(safeNextPath(encodeURIComponent('/board?x=1'))).toBe('/board?x=1');
+  });
+
+  it('외부/프로토콜-상대/백슬래시 유도는 /inbox 로 차단', () => {
+    expect(safeNextPath('//evil.com')).toBe('/inbox');
+    expect(safeNextPath('https://evil.com')).toBe('/inbox');
+    expect(safeNextPath('http://evil.com')).toBe('/inbox');
+    expect(safeNextPath('/\\evil.com')).toBe('/inbox');
+    expect(safeNextPath('javascript:alert(1)')).toBe('/inbox');
+  });
+
+  it('빈/누락/디코드 불가는 /inbox', () => {
+    expect(safeNextPath(null)).toBe('/inbox');
+    expect(safeNextPath(undefined)).toBe('/inbox');
+    expect(safeNextPath('')).toBe('/inbox');
+    expect(safeNextPath('%')).toBe('/inbox'); // decodeURIComponent throw
+  });
+});
+
+describe('buildLoginRedirect (AC3)', () => {
+  it('next(encode) + reason 쿼리를 붙인 /login 경로', () => {
+    const r = buildLoginRedirect('/board?x=1');
+    expect(r).toContain('/login?');
+    expect(r).toContain(`next=${encodeURIComponent('/board?x=1')}`);
+    expect(r).toContain(`reason=${SESSION_EXPIRED_REASON}`);
+  });
+
+  it('내부경로 아니면 /inbox 로 fallback', () => {
+    expect(buildLoginRedirect('')).toContain(`next=${encodeURIComponent('/inbox')}`);
+  });
+});

--- a/apps/web/src/lib/auth/session-redirect.ts
+++ b/apps/web/src/lib/auth/session-redirect.ts
@@ -1,0 +1,23 @@
+// AC3(af8d3641): graceful 세션-만료 redirect 계약. 인증 실패 redirect 는 전부
+// `/login?next=<enc>&reason=session_expired` 로 통일 — login 이 reason 배너 + next 복귀(작업 손실
+// 최소화)에 사용. server(proxy·layout)·client(fetchWithAuth) 공용 순수 함수.
+
+export const SESSION_EXPIRED_REASON = 'session_expired';
+
+/** 현재 경로(pathname+search)를 next 로 보존한 /login redirect 경로. */
+export function buildLoginRedirect(currentPathAndSearch: string): string {
+  const target = currentPathAndSearch && currentPathAndSearch.startsWith('/') ? currentPathAndSearch : '/inbox';
+  return `/login?next=${encodeURIComponent(target)}&reason=${SESSION_EXPIRED_REASON}`;
+}
+
+/**
+ * 오픈 리다이렉트 가드 — next 가 **내부 절대경로**(`/` 시작·`//`(프로토콜-상대)·`/\` 아님)일 때만 허용,
+ * 아니면 `/inbox`. login 성공/콜백 복귀 시 외부 도메인 유도(`//evil.com`·`http://`)를 차단.
+ */
+export function safeNextPath(next: string | null | undefined): string {
+  if (!next) return '/inbox';
+  let decoded: string;
+  try { decoded = decodeURIComponent(next); } catch { return '/inbox'; }
+  if (!decoded.startsWith('/') || decoded.startsWith('//') || decoded.startsWith('/\\')) return '/inbox';
+  return decoded;
+}

--- a/apps/web/src/lib/db/client.ts
+++ b/apps/web/src/lib/db/client.ts
@@ -1,5 +1,7 @@
 'use client';
 
+import { signalSessionExpired } from '@/lib/auth/session-expired-signal';
+
 // ─── FastAPI Auth Utilities ───────────────────────────────────────────────────
 
 export interface AuthTokens {
@@ -65,13 +67,14 @@ export async function fetchWithAuth(input: RequestInfo | URL, init?: RequestInit
   try {
     await _refreshing;
   } catch {
-    if (typeof window !== 'undefined') window.location.href = '/login';
+    // AC3: refresh 최종 실패 → bare redirect 대신 세션-만료 신호(SessionExpiredDialog·다중 401 dedupe).
+    if (typeof window !== 'undefined') signalSessionExpired();
     return res;
   }
 
   const retried = await fetch(input, init);
   if (retried.status === 401 && typeof window !== 'undefined') {
-    window.location.href = '/login';
+    signalSessionExpired();
   }
   return retried;
 }

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -67,13 +67,21 @@ describe('proxy', () => {
     mockFetch.mockResolvedValue({ ok: false, json: async () => ({ error: { code: 'TOKEN_REVOKED' } }) });
     const response = await middleware(makeRequest('/dashboard'));
     expect(response.status).toBe(307);
-    expect(response.headers.get('location')).toBe('https://app.example.com/login');
+    // AC3(551bbbee): hard /login 대신 next 보존 + reason 배너 계약. graceful 세션 만료 UX.
+    const loc = response.headers.get('location') ?? '';
+    expect(loc).toContain('https://app.example.com/login?');
+    expect(loc).toContain(`next=${encodeURIComponent('/dashboard')}`);
+    expect(loc).toContain('reason=session_expired');
   });
 
   it('redirects to login when no sp_at and no sp_rt cookie', async () => {
     const response = await middleware(makeRequest('/dashboard'));
     expect(response.status).toBe(307);
-    expect(response.headers.get('location')).toBe('https://app.example.com/login');
+    // AC3(551bbbee): hard /login 대신 next 보존 + reason 배너 계약. graceful 세션 만료 UX.
+    const loc = response.headers.get('location') ?? '';
+    expect(loc).toContain('https://app.example.com/login?');
+    expect(loc).toContain(`next=${encodeURIComponent('/dashboard')}`);
+    expect(loc).toContain('reason=session_expired');
   });
 
   it('allows access with valid sp_at cookie', async () => {
@@ -85,7 +93,11 @@ describe('proxy', () => {
   it('redirects to login with invalid sp_at and no refresh token', async () => {
     const response = await middleware(makeRequest('/dashboard', { sp_at: 'not.a.valid.jwt' }));
     expect(response.status).toBe(307);
-    expect(response.headers.get('location')).toBe('https://app.example.com/login');
+    // AC3(551bbbee): hard /login 대신 next 보존 + reason 배너 계약. graceful 세션 만료 UX.
+    const loc = response.headers.get('location') ?? '';
+    expect(loc).toContain('https://app.example.com/login?');
+    expect(loc).toContain(`next=${encodeURIComponent('/dashboard')}`);
+    expect(loc).toContain('reason=session_expired');
   });
 
   it('refreshes token when sp_at is expiring soon', async () => {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,6 +1,7 @@
 import { jwtVerify } from 'jose';
 import { NextResponse, type NextRequest } from 'next/server';
 import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
+import { SESSION_EXPIRED_REASON } from '@/lib/auth/session-redirect';
 
 const PUBLIC_EXACT = [
   '/',
@@ -128,6 +129,17 @@ function buildRefreshedHeaders(
   return headers;
 }
 
+/** AC3: 인증 실패 → /login?next=<현재경로>&reason=session_expired (login 배너 + 작업 보존 복귀). */
+function loginRedirect(request: NextRequest): NextResponse {
+  const url = request.nextUrl.clone();
+  const nextTarget = request.nextUrl.pathname + request.nextUrl.search;
+  url.pathname = '/login';
+  url.search = '';
+  url.searchParams.set('next', nextTarget); // searchParams.set 이 encode
+  url.searchParams.set('reason', SESSION_EXPIRED_REASON);
+  return NextResponse.redirect(url);
+}
+
 export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
@@ -157,9 +169,7 @@ export async function proxy(request: NextRequest) {
     const tokens = await singleFlightRefresh(request);
     if (!tokens) {
       if (isApiPath) return NextResponse.next({ request }); // let handler return 401
-      const url = request.nextUrl.clone();
-      url.pathname = '/login';
-      return NextResponse.redirect(url);
+      return loginRedirect(request);
     }
     const headers = buildRefreshedHeaders(request, tokens);
     const response = NextResponse.next({ request: { headers } });
@@ -174,9 +184,7 @@ export async function proxy(request: NextRequest) {
     const tokens = await singleFlightRefresh(request);
     if (!tokens) {
       if (isApiPath) return NextResponse.next({ request }); // let handler return 401
-      const url = request.nextUrl.clone();
-      url.pathname = '/login';
-      return NextResponse.redirect(url);
+      return loginRedirect(request);
     }
     const headers = buildRefreshedHeaders(request, tokens);
     const response = NextResponse.next({ request: { headers } });
@@ -184,9 +192,13 @@ export async function proxy(request: NextRequest) {
     return response;
   }
 
-  // Proactive refresh if expiring within 5 minutes
+  // Proactive refresh if expiring within 5 minutes.
+  // AC3: x-pathname 주입 — (authenticated)/layout 이 /me 401 시 next 보존 redirect 에 사용(server component
+  // 는 현재 경로를 직접 못 읽음).
   const now = Math.floor(Date.now() / 1000);
-  const response = NextResponse.next({ request });
+  const fwdHeaders = new Headers(request.headers);
+  fwdHeaders.set('x-pathname', pathname + request.nextUrl.search);
+  const response = NextResponse.next({ request: { headers: fwdHeaders } });
   if (claims.exp !== undefined && claims.exp - now < 300) {
     const tokens = await singleFlightRefresh(request);
     if (tokens) {


### PR DESCRIPTION
## 무엇을

세션 타임아웃 fix **AC3 [graceful 세션 만료 UX]** — af8d3641 마지막 조각(유나양 blueprint `session-expiry-graceful-ux-handoff` §A·§B·§C). refresh 최종 실패 시 **hard `/login` redirect(작업 손실)** 를 graceful 만료 UX 로: 작업 경로(`next`) 보존 + reason 배너 + 세션 만료 모달.

> AC1(single-flight)·AC2b(쿠키 7곳)는 #1578 머지 완료. 이 PR 은 UX 조각.

## §A 파라미터 계약 (인증 실패 redirect 통일)

- **신규 `lib/auth/session-redirect.ts`** — `buildLoginRedirect`(`/login?next=<enc>&reason=session_expired`)·`safeNextPath`(**오픈 리다이렉트 가드**: 내부 절대경로만, `//`·`http`·`/\` → `/inbox`).
- `proxy.ts` **2개 redirect**(no-access·expired) → next+reason. `(authenticated)/layout.tsx` **2개 redirect** 동일 — server component 는 현재 경로를 못 읽으니 **proxy 가 `x-pathname` 주입** → layout 이 소비. (AC1 에서 의도적으로 안 건드린 redirect **분기**는 유지, URL 쿼리만 추가 — 경계 그대로.)

## §B login

- `reason=session_expired` → **`Alert`(warning) 배너**. `next` → 로그인 성공 시 `safeNextPath` 복귀(hard `/inbox` 대체).
- **OAuth 복귀**: 로그인 hrefs 에 `next` 부착 → `/auth/login` 이 `oauth_next_*` 쿠키 stash → 콜백이 `safeNextPath` 로 복귀(없으면 기존 `/inbox`).

## §C 클라 모달

- **신규 `session-expired-signal.ts`**(모듈 신호·**다중 401 dedupe**). `fetchWithAuth` 가 bare `window.location` 대신 신호 → **신규 `SessionExpiredDialog`**(Dialog/Button 재사용·"다시 로그인" 시 §A redirect). `DashboardShell` 전역 1회 마운트.

## 디자인/검증

- **i18n ko/en**(`session.*`·`login.sessionExpired`·비즈니스 톤)·**신규 시각 토큰 0**(Dialog/Alert/Button·warning 토큰 재사용).
- `pnpm type-check` ✅ / `pnpm lint`(신규 0) ✅ / `pnpm build` ✅ EXIT 0 / i18n parity ✅
- base=`origin/develop`(#1578 포함)

## 리뷰/QA

⚠️ **시각 surface(만료 모달·login 배너·복귀 플로우)는 유나양 가디언 시각 정합 리뷰 필수.** 까심 QA: 세션 만료→모달→다시 로그인→배너+작업 경로 복귀·오픈 리다이렉트 차단(`//evil`·`http`)·다중 401 모달 1회·OAuth 복귀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)