### PR TITLE
hotfix: prod dispatch P0 — channel_router 멀티프로젝트 sender 다중행 크래시 (.limit(1))

### DIFF
--- a/backend/app/services/channel_router.py
+++ b/backend/app/services/channel_router.py
@@ -47,10 +47,14 @@ async def route_message(
             raise ChannelRouterError(f"Message {message_id} not found")
 
         # 2. 발신자 type 확인
+        # ⚠️ team_members 는 0088 이후 projection VIEW — org-agent 멀티프로젝트 grant(project_access)면
+        # 같은 member.id 가 프로젝트 수만큼 행을 낸다. 무필터 scalar_one_or_none 은 MultipleResultsFound
+        # 로 route_message 전체를 깨 chat→agent dispatch 가 멈춘다. type 은 전 행 동형이라 .limit(1) 로
+        # 한 행만 취해 안전(_resolve_api_key 동일 패턴). 단일프로젝트 agent·휴먼은 1행이라 거동 무변경.
         sender_type: str | None = None
         if msg.sender_id:
             sender_type = (await db.execute(
-                select(TeamMember.type).where(TeamMember.id == msg.sender_id)
+                select(TeamMember.type).where(TeamMember.id == msg.sender_id).limit(1)
             )).scalar_one_or_none()
 
         # 3. conversation participants (발신자 제외)

--- a/backend/tests/test_channel_router_multiproject_sender.py
+++ b/backend/tests/test_channel_router_multiproject_sender.py
@@ -1,0 +1,70 @@
+"""채널 라우터 회귀 — org-agent 멀티프로젝트 sender 가 team_members VIEW 다중 행을 내도
+route_message 가 MultipleResultsFound 로 안 깨지고 dispatch 되는지(sender_type 쿼리 .limit(1)).
+
+배경: team_members 는 0088 이후 projection VIEW. org-agent 멀티프로젝트 grant(project_access)면
+같은 member.id 가 프로젝트 수만큼 행 → sender_type 의 무필터 scalar_one_or_none 이 MultipleResultsFound
+→ route_message 전체가 ChannelRouterError 로 깨져 chat→agent dispatch 정지. .limit(1) 로 봉합.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _scalar(val):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = val
+    return r
+
+
+def _scalars(items):
+    r = MagicMock()
+    r.scalars.return_value.all.return_value = items
+    return r
+
+
+def _all(rows):
+    r = MagicMock()
+    r.all.return_value = rows
+    return r
+
+
+@pytest.mark.anyio
+async def test_multiproject_agent_sender_dispatches_without_crash():
+    """멀티프로젝트 agent 발신 → sender_type .limit(1)='agent' → agent↔agent SSE dispatch(크래시 0)."""
+    from app.services.channel_router import route_message
+
+    sender = uuid.uuid4()       # 멀티프로젝트 agent(team_members 뷰 다중행)
+    recipient = uuid.uuid4()    # agent 수신자
+    conv = uuid.uuid4()
+    proj = uuid.uuid4()
+
+    msg = MagicMock()
+    msg.id = uuid.uuid4()
+    msg.sender_id = sender
+    msg.conversation_id = conv
+    msg.thread_id = None
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=[
+        _scalar(msg),                       # 1 메시지
+        _scalar("agent"),                   # 2 sender_type — .limit(1)로 단일 행(뷰 다중에도 안전)
+        _scalars([sender, recipient]),      # 3 participants(발신자 포함)
+        _all([(recipient, "agent")]),       # 4 수신자 type 배치
+        _scalar(proj),                      # 5 conv project_id
+        _scalars([]),                       # 6 preferences
+    ])
+
+    decisions = await route_message(msg.id, db)
+    # 발신자 제외·agent↔agent 강제 SSE → 1 decision(크래시/ChannelRouterError 없이)
+    assert len(decisions) == 1
+    assert decisions[0].member_id == recipient
+    assert decisions[0].channel == "sse"
+    assert decisions[0].reason == "agent-to-agent forced sse"


### PR DESCRIPTION
🔴 P0 prod dispatch 복구. prod 백엔드 ChannelRouterError(Multiple rows) 20건/2h 발화 中 — team_members projection VIEW상 멀티프로젝트 agent(산티아고 1d3bfded grant) member.id가 N행 → channel_router.route_message sender_type scalar_one_or_none MultipleResultsFound → 전 chat→agent dispatch 정지. #1579(.limit(1))를 develop에서 cherry-pick. dev 배포 후 0건 확認. 선생님 승인(둘다 빨리).

🤖 Generated with [Claude Code](https://claude.com/claude-code)