### PR TITLE
fix(chat): 멀티프로젝트 agent project_id-소비 사이트 deterministic grant-pick (sweep Ⓑ stopgap)

### DIFF
--- a/backend/app/routers/agent_inbox.py
+++ b/backend/app/routers/agent_inbox.py
@@ -46,12 +46,19 @@ async def receive_inbox_webhook(
     if not _verify_signature(raw_body, x_sprintable_signature):
         raise HTTPException(status_code=401, detail="Invalid webhook signature")
 
+    # team_members 는 projection VIEW — org-agent 멀티프로젝트 grant 면 같은 agent_id 가 N 행이라
+    # 무필터 one_or_none 은 MultipleResultsFound 로 깨진다. 이 inbox webhook 은 단일 글로벌 secret
+    # (per-webhook-config 없음)이고 members anchor 엔 home project 가 없어 "올바른" project 를 도출할
+    # 컨텍스트가 없다. → deterministic grant-pick(order_by(project_id) limit 1)으로 크래시를 막고
+    # 안정적 default project 로 Event 를 적재한다.
+    # ⚠️ known-limitation: 멀티프로젝트 agent inbox 의 project 라우팅은 default(최저 project_id) 고정.
+    #   진짜 라우팅(payload 가 타겟 project 명시)은 follow-up story(멀티프로젝트 inbox routing).
     result = await db.execute(
         select(TeamMember.org_id, TeamMember.project_id).where(
             TeamMember.id == agent_id,
             TeamMember.type == "agent",
             TeamMember.is_active.is_(True),
-        )
+        ).order_by(TeamMember.project_id).limit(1)
     )
     row = result.one_or_none()
     if row is None:

--- a/backend/app/routers/ws_chat.py
+++ b/backend/app/routers/ws_chat.py
@@ -155,12 +155,19 @@ async def ws_chat_hub(
     logger.info("ws_chat: connected agent_id=%s caller=%s", agent_id, caller.id)
 
     # agent의 org_id/project_id 조회 (room 초기화용) — type='agent' 한정
+    # team_members 는 projection VIEW — 멀티프로젝트 grant 면 같은 agent_id 가 N 행이라 무필터
+    # scalar_one_or_none 은 MultipleResultsFound 로 깨진다. DM room 은 여기서 _get_or_create_conversation
+    # 으로 생성(project_id 가 입력)되므로 신규 DM 엔 도출할 pre-existing conversation project 가 없다.
+    # → deterministic grant-pick(order_by(project_id) limit 1)으로 크래시를 막고 안정적 default project
+    # 로 room 을 스코프한다. org_id 는 전 projection 행 동형이라 정확.
+    # ⚠️ known-limitation: 멀티프로젝트 agent 의 DM room 은 default(최저 project_id) project 로 스코프.
+    #   진짜 라우팅(기존 (agent,caller) DM 우선조회→그 conversation 의 project)은 follow-up story.
     async with async_session_factory() as db:
         agent_member = (await db.execute(
             select(TeamMember).where(
                 TeamMember.id == agent_id,
                 TeamMember.type == "agent",
-            )
+            ).order_by(TeamMember.project_id).limit(1)
         )).scalar_one_or_none()
 
     if agent_member is None:

--- a/backend/tests/test_sweep_multiproject_teammember_orderby.py
+++ b/backend/tests/test_sweep_multiproject_teammember_orderby.py
@@ -1,0 +1,41 @@
+"""광역 sweep Ⓑ stopgap 회귀 — project_id 를 소비하는 사이트는 임의 .limit(1)(틀린 프로젝트 위험)
+대신 deterministic grant-pick(order_by(project_id).limit(1))으로 멀티프로젝트 agent 크래시를 막고
+안정적 default project 로 라우팅.
+
+대상(project_id 소비):
+  - agent_inbox.receive_inbox_webhook  (Event.project_id 적재)
+  - ws_chat.ws_chat_hub                (DM room project 스코프)
+
+true 라우팅(payload-project / 기존-conversation derive)은 follow-up story. 여기선 결정적 stopgap.
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+def _get_func():
+    from app.routers import agent_inbox, ws_chat
+
+    return {
+        "agent_inbox.receive_inbox_webhook": agent_inbox.receive_inbox_webhook,
+        "ws_chat.ws_chat_hub": ws_chat.ws_chat_hub,
+    }
+
+
+@pytest.mark.parametrize("name", [
+    "agent_inbox.receive_inbox_webhook",
+    "ws_chat.ws_chat_hub",
+])
+def test_project_id_site_uses_deterministic_grant_pick(name: str):
+    """project_id 소비 사이트는 order_by(project_id)+limit(1)로 결정적(MultipleResultsFound 0·non-random)."""
+    fn = _get_func()[name]
+    src = inspect.getsource(fn)
+    assert "TeamMember" in src, f"{name}: TeamMember 쿼리 사라짐(테스트 갱신 필요)"
+    # 결정적 grant-pick: order_by(project_id) + limit(1) 동시 — 임의 행(틀린 프로젝트) 방지
+    assert "order_by(TeamMember.project_id)" in src, \
+        f"{name}: order_by(project_id) 누락 — 멀티프로젝트 agent 라우팅이 비결정적/크래시"
+    assert ".limit(1)" in src, f"{name}: .limit(1) 누락 — MultipleResultsFound 회귀"
+    # known-limitation 주석 박제(stopgap 의도·follow-up 추적)
+    assert "known-limitation" in src, f"{name}: known-limitation 주석 누락(stopgap 의도 박제 필요)"


### PR DESCRIPTION
**#1581(Ⓐ) follow-up — sweep Ⓑ stopgap** — dev·마이그 없음·PO 2단계 GO.

## 배경
team_members projection VIEW 다중행 크래시 sweep 의 **Ⓑ(project_id 소비)** 분류. Ⓐ(#1581·identity/org 소비→`.limit(1)`)와 달리 **임의 `.limit(1)`은 "틀린 프로젝트"로 라우팅**될 수 있어 부적합(PO 경고).

## tractability 조사 결과 (데이터모델 실측)
올바른 project 의 **컨텍스트-derive 가 둘 다 막힘**:
- `members` anchor 에 **home project 컬럼 없음**(canonical home 부재)
- `agent_inbox` 는 **단일 글로벌 secret**(per-webhook-config 없음)→ webhook-project 도출원 없음
- `Event.project_id` **required**(org-level 불가)
- `ws_chat` 는 DM room 을 여기서 **생성**(project_id 입력·신규 DM 엔 pre-existing conversation project 없음)

## stopgap (이 PR)
**deterministic grant-pick** `order_by(TeamMember.project_id).limit(1)` — 크래시 0·**안정적 default project**(최저 project_id)·임의 `.limit` 보다 결정적·non-random:
- `agent_inbox.receive_inbox_webhook` (Event.project_id 적재)
- `ws_chat.ws_chat_hub` (DM room project 스코프)

`known-limitation` 주석으로 stopgap 의도 박제.

## follow-up (PO backlog story)
true 라우팅 — agent_inbox=**payload 가 타겟 project 명시**·ws_chat=**기존 (agent,caller) DM 우선조회→그 conversation 의 project**.

## 검증
회귀 테스트 2(order_by+limit(1)+주석 가드)·관련 모듈 14 무회귀·import OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)