### PR TITLE
hotfix: prod dispatch sweep — agent_gateway 멀티프로젝트 수신스트림 크래시 (#1581+#1583)

### DIFF
--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -279,8 +279,11 @@ async def agent_stream(
 
     # agent_id ê²ì¦
     async with async_session_factory() as db:
+        # team_members 는 projection VIEW — 멀티프로젝트 grant 면 같은 agent_id 가 N 행이라
+        # 무필터 scalar_one_or_none 은 멀티프로젝트 agent 접속 시 MultipleResultsFound 로 stream 연결을
+        # 막는다. 아래선 .org_id(동형)만 쓰므로 .limit(1) 로 안전(아무 projection 행 OK).
         tm = (await db.execute(
-            select(TeamMember).where(TeamMember.id == agent_id, TeamMember.type == "agent")
+            select(TeamMember).where(TeamMember.id == agent_id, TeamMember.type == "agent").limit(1)
         )).scalar_one_or_none()
         if tm is None:
             raise HTTPException(status_code=404, detail="Agent not found")

--- a/backend/app/routers/agent_inbox.py
+++ b/backend/app/routers/agent_inbox.py
@@ -46,12 +46,19 @@ async def receive_inbox_webhook(
     if not _verify_signature(raw_body, x_sprintable_signature):
         raise HTTPException(status_code=401, detail="Invalid webhook signature")
 
+    # team_members 는 projection VIEW — org-agent 멀티프로젝트 grant 면 같은 agent_id 가 N 행이라
+    # 무필터 one_or_none 은 MultipleResultsFound 로 깨진다. 이 inbox webhook 은 단일 글로벌 secret
+    # (per-webhook-config 없음)이고 members anchor 엔 home project 가 없어 "올바른" project 를 도출할
+    # 컨텍스트가 없다. → deterministic grant-pick(order_by(project_id) limit 1)으로 크래시를 막고
+    # 안정적 default project 로 Event 를 적재한다.
+    # ⚠️ known-limitation: 멀티프로젝트 agent inbox 의 project 라우팅은 default(최저 project_id) 고정.
+    #   진짜 라우팅(payload 가 타겟 project 명시)은 follow-up story(멀티프로젝트 inbox routing).
     result = await db.execute(
         select(TeamMember.org_id, TeamMember.project_id).where(
             TeamMember.id == agent_id,
             TeamMember.type == "agent",
             TeamMember.is_active.is_(True),
-        )
+        ).order_by(TeamMember.project_id).limit(1)
     )
     row = result.one_or_none()
     if row is None:

--- a/backend/app/routers/agent_runs.py
+++ b/backend/app/routers/agent_runs.py
@@ -37,10 +37,12 @@ async def create_agent_run(
     _auth: AuthContext = Depends(get_current_user),
     repo: AgentRunRepository = Depends(_get_repo),
 ) -> AgentRunResponse:
+    # team_members 는 projection VIEW — 멀티프로젝트 grant 면 같은 agent_id 가 N 행. org_id 는 전
+    # projection 행에서 동형이라 .limit(1) 로 MultipleResultsFound 회피(아무 행 OK).
     member_r = await session.execute(
         select(TeamMember.org_id).where(
             TeamMember.id == body.agent_id, TeamMember.type == "agent"
-        )
+        ).limit(1)
     )
     org_id = member_r.scalar_one_or_none()
     if org_id is None:

--- a/backend/app/routers/channel.py
+++ b/backend/app/routers/channel.py
@@ -38,11 +38,18 @@ async def _require_caller(api_key: str | None, token: str | None) -> TeamMember:
 
 async def _resolve_agent(agent_id: uuid.UUID, caller: TeamMember) -> TeamMember:
     async with async_session_factory() as db:
+        # team_members 는 projection VIEW — org-agent 멀티프로젝트 grant 면 같은 id 가 N 행이라 무필터
+        # scalar_one_or_none 은 MultipleResultsFound. 이 결과의 .org_id(동형)뿐 아니라 .project_id 도
+        # _persist_and_broadcast → _get_or_create_conversation 에서 DM room 스코프에 소비되므로 임의
+        # .limit(1)(틀린 프로젝트 위험) 대신 deterministic grant-pick(order_by(project_id).limit(1))으로
+        # 크래시를 막고 안정적 default project 로 라우팅한다(ws_chat/agent_inbox Ⓑ stopgap 동형).
+        # ⚠️ known-limitation: 멀티프로젝트 agent 의 DM room 은 default(최저 project_id) project 로 스코프.
+        #   진짜 라우팅(기존 (agent,caller) DM 우선조회→그 conversation 의 project)은 follow-up story.
         agent = (await db.execute(
             select(TeamMember).where(
                 TeamMember.id == agent_id,
                 TeamMember.type == "agent",
-            )
+            ).order_by(TeamMember.project_id).limit(1)
         )).scalar_one_or_none()
     if agent is None:
         raise HTTPException(status_code=404, detail="Agent not found")

--- a/backend/app/routers/ws_chat.py
+++ b/backend/app/routers/ws_chat.py
@@ -42,10 +42,13 @@ async def _authenticate(api_key: str | None, token: str | None) -> TeamMember | 
             )).scalar_one_or_none()
             if not ak:
                 return None
+            # team_members 는 projection VIEW — 멀티프로젝트 grant 면 같은 id 가 N 행. 여기선 auth
+            # identity(.id/.org_id·동형) 해소라 .limit(1) 로 MultipleResultsFound 회피(아무 행 OK).
             return (await db.execute(
                 select(TeamMember)
                 .where(TeamMember.id == ak.team_member_id)
                 .where(TeamMember.is_active.is_(True))
+                .limit(1)
             )).scalar_one_or_none()
 
         if token:

--- a/backend/app/routers/ws_chat.py
+++ b/backend/app/routers/ws_chat.py
@@ -155,12 +155,19 @@ async def ws_chat_hub(
     logger.info("ws_chat: connected agent_id=%s caller=%s", agent_id, caller.id)
 
     # agent의 org_id/project_id 조회 (room 초기화용) — type='agent' 한정
+    # team_members 는 projection VIEW — 멀티프로젝트 grant 면 같은 agent_id 가 N 행이라 무필터
+    # scalar_one_or_none 은 MultipleResultsFound 로 깨진다. DM room 은 여기서 _get_or_create_conversation
+    # 으로 생성(project_id 가 입력)되므로 신규 DM 엔 도출할 pre-existing conversation project 가 없다.
+    # → deterministic grant-pick(order_by(project_id) limit 1)으로 크래시를 막고 안정적 default project
+    # 로 room 을 스코프한다. org_id 는 전 projection 행 동형이라 정확.
+    # ⚠️ known-limitation: 멀티프로젝트 agent 의 DM room 은 default(최저 project_id) project 로 스코프.
+    #   진짜 라우팅(기존 (agent,caller) DM 우선조회→그 conversation 의 project)은 follow-up story.
     async with async_session_factory() as db:
         agent_member = (await db.execute(
             select(TeamMember).where(
                 TeamMember.id == agent_id,
                 TeamMember.type == "agent",
-            )
+            ).order_by(TeamMember.project_id).limit(1)
         )).scalar_one_or_none()
 
     if agent_member is None:

--- a/backend/tests/test_sweep_multiproject_teammember_limit.py
+++ b/backend/tests/test_sweep_multiproject_teammember_limit.py
@@ -1,0 +1,96 @@
+"""광역 sweep 회귀 — team_members projection VIEW 다중행(org-agent 멀티프로젝트 grant)에서
+TeamMember.id == X scalar_one_or_none 이 MultipleResultsFound 로 안 깨지게 .limit(1) 가드.
+
+Ⓐ 분류(identity/type/org_id 동형 소비 → .limit(1) 안전·아무 projection 행 OK):
+  - channel._resolve_agent          (.org_id 소비)
+  - agent_gateway.agent_stream      (.org_id 소비·agent CONNECT 경로)
+  - agent_runs.create_agent_run     (select org_id)
+  - ws_chat._authenticate           (auth identity)
+
+#1579(channel_router.route_message sender_type)와 동일 패턴의 잔여 site 봉쇄.
+project_id 를 소비하는 Ⓑ(agent_inbox/ws_chat room init)는 컨텍스트-derive 가 정답이라 별도 처리.
+"""
+from __future__ import annotations
+
+import inspect
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── Ⓐ 4 site 소스 가드: TeamMember.id 쿼리에 .limit(1) 유지 ──────────────────────
+def _get_func():
+    from app.routers import agent_gateway, agent_runs, channel, ws_chat
+
+    return {
+        "channel._resolve_agent": channel._resolve_agent,
+        "agent_gateway.agent_stream": agent_gateway.agent_stream,
+        "agent_runs.create_agent_run": agent_runs.create_agent_run,
+        "ws_chat._authenticate": ws_chat._authenticate,
+    }
+
+
+# identity/type/org_id 만 소비하는 진짜 Ⓐ 3곳 → .limit(1)(아무 행 OK).
+# channel._resolve_agent 는 .project_id 도 소비(_persist_and_broadcast → DM room)라 Ⓑ 로 재분류 →
+# 아래 deterministic 가드로 별도 검증.
+@pytest.mark.parametrize("name", [
+    "agent_gateway.agent_stream",
+    "agent_runs.create_agent_run",
+    "ws_chat._authenticate",
+])
+def test_teammember_query_has_limit_guard(name: str):
+    """각 Ⓐ 함수 소스에 TeamMember 쿼리 + .limit(1) 동시 존재(가드 제거 회귀 방지)."""
+    fn = _get_func()[name]
+    src = inspect.getsource(fn)
+    assert "TeamMember" in src, f"{name}: TeamMember 쿼리 사라짐(테스트 갱신 필요)"
+    assert ".limit(1)" in src, f"{name}: .limit(1) 가드 누락 — 멀티프로젝트 agent 크래시 회귀"
+
+
+def test_channel_resolve_agent_is_deterministic_grant_pick():
+    """channel._resolve_agent 는 .project_id 소비(Ⓑ) → order_by(project_id)+limit(1)+known-limitation."""
+    from app.routers import channel
+
+    src = inspect.getsource(channel._resolve_agent)
+    assert "order_by(TeamMember.project_id)" in src, \
+        "channel._resolve_agent: order_by(project_id) 누락 — project_id 비결정적(틀린 프로젝트)"
+    assert ".limit(1)" in src, "channel._resolve_agent: .limit(1) 누락 — MultipleResultsFound 회귀"
+    assert "known-limitation" in src, "channel._resolve_agent: known-limitation 주석 누락"
+
+
+# ── 행동 테스트: 멀티프로젝트 agent(뷰 N행)도 _resolve_agent 가 크래시 없이 해소 ──────
+@pytest.mark.anyio
+async def test_resolve_agent_multiproject_no_crash():
+    """멀티프로젝트 agent → .limit(1) 로 단일 행 → org 검증 통과(MultipleResultsFound 0)."""
+    from app.routers import channel
+
+    agent = MagicMock()
+    agent.org_id = "ORG"
+    agent.type = "agent"
+    caller = MagicMock()
+    caller.org_id = "ORG"
+
+    class _Result:
+        def scalar_one_or_none(self):
+            return agent  # .limit(1) 결과(뷰 N행이어도 1행)
+
+    class _DB:
+        async def execute(self, *a, **k):
+            return _Result()
+
+    class _Factory:
+        async def __aenter__(self):
+            return _DB()
+
+        async def __aexit__(self, *a):
+            return False
+
+    with patch.object(channel, "async_session_factory", lambda: _Factory()):
+        result = await channel._resolve_agent(uuid.uuid4(), caller)
+
+    assert result is agent  # 해소 성공·org 동형 검증 통과

--- a/backend/tests/test_sweep_multiproject_teammember_orderby.py
+++ b/backend/tests/test_sweep_multiproject_teammember_orderby.py
@@ -1,0 +1,41 @@
+"""광역 sweep Ⓑ stopgap 회귀 — project_id 를 소비하는 사이트는 임의 .limit(1)(틀린 프로젝트 위험)
+대신 deterministic grant-pick(order_by(project_id).limit(1))으로 멀티프로젝트 agent 크래시를 막고
+안정적 default project 로 라우팅.
+
+대상(project_id 소비):
+  - agent_inbox.receive_inbox_webhook  (Event.project_id 적재)
+  - ws_chat.ws_chat_hub                (DM room project 스코프)
+
+true 라우팅(payload-project / 기존-conversation derive)은 follow-up story. 여기선 결정적 stopgap.
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+def _get_func():
+    from app.routers import agent_inbox, ws_chat
+
+    return {
+        "agent_inbox.receive_inbox_webhook": agent_inbox.receive_inbox_webhook,
+        "ws_chat.ws_chat_hub": ws_chat.ws_chat_hub,
+    }
+
+
+@pytest.mark.parametrize("name", [
+    "agent_inbox.receive_inbox_webhook",
+    "ws_chat.ws_chat_hub",
+])
+def test_project_id_site_uses_deterministic_grant_pick(name: str):
+    """project_id 소비 사이트는 order_by(project_id)+limit(1)로 결정적(MultipleResultsFound 0·non-random)."""
+    fn = _get_func()[name]
+    src = inspect.getsource(fn)
+    assert "TeamMember" in src, f"{name}: TeamMember 쿼리 사라짐(테스트 갱신 필요)"
+    # 결정적 grant-pick: order_by(project_id) + limit(1) 동시 — 임의 행(틀린 프로젝트) 방지
+    assert "order_by(TeamMember.project_id)" in src, \
+        f"{name}: order_by(project_id) 누락 — 멀티프로젝트 agent 라우팅이 비결정적/크래시"
+    assert ".limit(1)" in src, f"{name}: .limit(1) 누락 — MultipleResultsFound 회귀"
+    # known-limitation 주석 박제(stopgap 의도·follow-up 추적)
+    assert "known-limitation" in src, f"{name}: known-limitation 주석 누락(stopgap 의도 박제 필요)"


### PR DESCRIPTION
🔴 P0 prod dispatch — #1579(channel_router) 후에도 prod agent_gateway.py:284(agent_stream 수신 SSE)서 멀티프로젝트 agent MultipleResultsFound 지속(='세션 전달 안됨' 핵심 경로). #1581(.limit(1) 4곳+channel.py Ⓑ)·#1583(agent_inbox/ws_chat Ⓑ deterministic) cherry-pick. dev 검증·까심 APPROVE. 선생님 승인(둘다 빨리·grant-off 불충분→코드 durable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)