### PR TITLE
hotfix: prod multi-project sender deliver webhook 크래시 (conversation_webhook + 3 sites .limit(1))

### DIFF
--- a/backend/app/dependencies/ownership.py
+++ b/backend/app/dependencies/ownership.py
@@ -28,11 +28,13 @@ async def assert_agent_owner(
 ) -> TeamMember:
     """agent 존재 확인 + ownership guard. TeamMember를 반환."""
     result = await session.execute(
+        # team_members projection VIEW — multi-project agent N 행. 아래선 .created_by(동형) ownership
+        # guard + org_id 필터만 쓰므로 .limit(1) 로 MultipleResultsFound 회피(아무 projection 행 OK).
         select(TeamMember).where(
             TeamMember.id == agent_id,
             TeamMember.type == "agent",
             TeamMember.org_id == org_id,
-        )
+        ).limit(1)
     )
     agent = result.scalar_one_or_none()
     if agent is None:

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -29,8 +29,9 @@ async def _resolve_notification_user_id(auth: AuthContext, db: AsyncSession) -> 
     """
     is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
     if is_api_key:
+        # team_members projection VIEW — multi-project member N 행. id/user_id 동형이라 .limit(1)(아무 행 OK).
         result = await db.execute(
-            select(TeamMember.id, TeamMember.user_id).where(TeamMember.id == uuid.UUID(auth.user_id))
+            select(TeamMember.id, TeamMember.user_id).where(TeamMember.id == uuid.UUID(auth.user_id)).limit(1)
         )
         row = result.one_or_none()
         if row is None:

--- a/backend/app/routers/workflow_executions.py
+++ b/backend/app/routers/workflow_executions.py
@@ -225,8 +225,9 @@ async def get_execution(
 
     agent_name: str | None = None
     if log.target_agent_id:
+        # team_members projection VIEW — multi-project agent N 행. name 동형이라 .limit(1)(아무 행 OK).
         ar = await db.execute(
-            select(TeamMember.name).where(TeamMember.id == log.target_agent_id)
+            select(TeamMember.name).where(TeamMember.id == log.target_agent_id).limit(1)
         )
         agent_name = ar.scalar_one_or_none()
 

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -245,8 +245,11 @@ async def deliver_conversation_message_webhook(
             sender_name = None
             if sender_id is not None:
                 from app.models.team import TeamMember
+                # team_members 는 projection VIEW — multi-project sender(owner 등·N projection 행)면
+                # 무필터 scalar_one_or_none 이 MultipleResultsFound → deliver_conversation_message_webhook
+                # 전체 크래시 → 전 수신자 미수신. name 은 전 행 동형이라 .limit(1) 로 안전(아무 행 OK).
                 sender_name = (await db.execute(
-                    select(TeamMember.name).where(TeamMember.id == sender_id)
+                    select(TeamMember.name).where(TeamMember.id == sender_id).limit(1)
                 )).scalar_one_or_none()
 
             # R2 S1(9d130c01): 첨부 내용을 에이전트-facing content 에 주입(균일·런타임 무변경).

--- a/backend/tests/test_sweep_multiproject_teammember_services.py
+++ b/backend/tests/test_sweep_multiproject_teammember_services.py
@@ -1,0 +1,60 @@
+"""광역 sweep 2차 — 라우터 외(services/repositories/dependencies)의 TeamMember.id scalar 잔여 site.
+
+1차 sweep(#1581/#1583/#1585)이 라우터만 드릴다운해 놓친 site. multi-project SENDER(선생님=owner·N
+projection 행)가 deliver_conversation_message_webhook 의 sender_name 조회(.limit 없음)서 MultipleResultsFound
+→ 전 수신자 미수신(인앱 메시지 P0). exhaustive grep 으로 잔여 전수 봉쇄.
+
+CRASH → .limit(1)(전 행 동형 컬럼 소비):
+  - conversation_webhook.deliver_conversation_message_webhook  (sender name·P0)
+  - workflow_executions.get_execution                          (agent name)
+  - notifications._resolve_notification_user_id                (id/user_id)
+  - ownership.assert_agent_owner                               (created_by ownership guard)
+
+SAFE(project_id == 필터로 1행 확정·무변경):
+  - current_project.set_current_project / reward.create_reward
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+def _fns():
+    from app.dependencies import ownership
+    from app.routers import notifications, workflow_executions
+    from app.services import conversation_webhook
+
+    return {
+        "conversation_webhook.deliver_conversation_message_webhook":
+            conversation_webhook.deliver_conversation_message_webhook,
+        "workflow_executions.get_execution": workflow_executions.get_execution,
+        "notifications._resolve_notification_user_id": notifications._resolve_notification_user_id,
+        "ownership.assert_agent_owner": ownership.assert_agent_owner,
+    }
+
+
+@pytest.mark.parametrize("name", [
+    "conversation_webhook.deliver_conversation_message_webhook",
+    "workflow_executions.get_execution",
+    "notifications._resolve_notification_user_id",
+    "ownership.assert_agent_owner",
+])
+def test_teammember_scalar_site_has_limit(name: str):
+    """각 잔여 site 가 TeamMember.id scalar 조회에 .limit(1) — multi-project MultipleResultsFound 회귀 방지."""
+    src = inspect.getsource(_fns()[name])
+    assert "TeamMember" in src, f"{name}: TeamMember 쿼리 사라짐(테스트 갱신 필요)"
+    assert ".limit(1)" in src, f"{name}: .limit(1) 누락 — multi-project 행에서 MultipleResultsFound 크래시"
+
+
+@pytest.mark.parametrize("module,fn,expr", [
+    ("app.routers.current_project", "set_current_project", "TeamMember.project_id == body.project_id"),
+    ("app.repositories.reward", None, "TeamMember.project_id == project_id"),
+])
+def test_safe_sites_disambiguated_by_project_filter(module: str, fn: str, expr: str):
+    """SAFE 분류 site 는 project_id == 필터로 1행 확정(disambig) — .limit 없이도 안전함을 박제."""
+    import importlib
+
+    mod = importlib.import_module(module)
+    src = inspect.getsource(mod)
+    assert expr in src, f"{module}: '{expr}' disambig 필터 사라짐 — 재분류 필요(이제 crash-prone)"


### PR DESCRIPTION
🔴 P0 prod — multi-project SENDER(예: 선생님=owner·N projection행)가 인앱 메시지 보내면 conversation_webhook.py sender_name scalar_one_or_none → MultipleResultsFound → deliver_conversation_message_webhook 전체 크래시 → 전 수신자 미수신. real-time trace로 確定. #1586(4 site .limit(1)·exhaustive sweep) cherry-pick. 까심 APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)