### PR TITLE
feat(chat): 이미지 첨부 멀티모달 — placeholder → V4 서명 URL (f3ccb40c)

### DIFF
--- a/backend/app/services/attachment_context.py
+++ b/backend/app/services/attachment_context.py
@@ -16,6 +16,7 @@ import asyncio
 import io
 import logging
 import os
+from datetime import timedelta
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +26,10 @@ _PUBLIC_PREFIX = f"https://storage.googleapis.com/{_BUCKET}/"
 _PER_ATTACHMENT_CAP = 8000   # §7-3 첨부당 자수 cap
 _TOTAL_CAP = 24000           # §7-3 총합 cap
 _TRUNC_MARK = "…(잘림)"
+
+# f3ccb40c 이미지-멀티모달: 이미지는 텍스트 추출 대신 단기 V4 read 서명 URL 을 payload 에 실어
+# 에이전트 런타임이 fetch→멀티모달 모델이 직접 view(백엔드 vision 안 함). 30분 = 에이전트 async 처리 윈도.
+_SIGNED_URL_TTL = timedelta(minutes=30)
 
 _DOC_EXTS = frozenset({"pdf", "docx", "txt", "csv", "md"})
 _IMAGE_EXTS = frozenset({"jpg", "jpeg", "png", "gif", "webp"})
@@ -80,6 +85,37 @@ async def _download_object(object_path: str) -> bytes:
     return await asyncio.to_thread(_blocking)
 
 
+async def _signed_read_url(object_path: str) -> str | None:
+    """scoped GCS 객체에 대한 단기 V4 read 서명 URL. 실패 시 None(best-effort).
+
+    Cloud Run ADC(키파일 없음)에서는 runtime SA 가 자신에 대해 signBlob(roles/iam.serviceAccountTokenCreator)
+    권한을 가지면 IAM SignBlob 으로 V4 서명이 가능하다(creds.refresh→service_account_email+access_token 전달).
+    blocking 호출은 thread 로 격리. 호출 전 _is_scoped_to_conversation 으로 IDOR 게이트를 통과한 path 만 받는다.
+    """
+
+    def _blocking() -> str:
+        import google.auth
+        from google.auth.transport.requests import Request as _AuthRequest
+        from google.cloud import storage
+
+        creds, _ = google.auth.default()
+        creds.refresh(_AuthRequest())  # access_token 확보(IAM SignBlob 용)
+        blob = storage.Client().bucket(_BUCKET).blob(object_path)
+        return blob.generate_signed_url(
+            version="v4",
+            expiration=_SIGNED_URL_TTL,
+            method="GET",
+            service_account_email=getattr(creds, "service_account_email", None),
+            access_token=creds.token,
+        )
+
+    try:
+        return await asyncio.to_thread(_blocking)
+    except Exception:
+        logger.warning("attachment_context: signed url 생성 실패 path=%s", object_path, exc_info=True)
+        return None
+
+
 def _extract_text(ext: str, data: bytes) -> str:
     """확장자별 텍스트 추출. 미지원/실패 시 빈 문자열."""
     if ext in ("txt", "csv", "md"):
@@ -113,18 +149,24 @@ async def build_attachment_context(
     *,
     project_id,
     conversation_id,
-) -> str:
-    """메시지 attachments(list of {url,name,content_type,size}) → 에이전트 주입용 텍스트 블록.
+) -> tuple[str, list[dict]]:
+    """메시지 attachments(list of {url,name,content_type,size}) → (에이전트 주입용 텍스트 블록, 이미지 목록).
 
-    문서=GCS fetch+추출, 이미지=메타 안내(v1), 미지원/실패=안내 라인. 총량 cap(헤더·마커·안내 라인
-    포함)·도달 시 중단. 빈 결과면 "" (주입 무영향). best-effort — 개별 첨부 실패는 안내 라인으로 흡수.
+    문서=GCS fetch+추출, 이미지=단기 V4 서명 URL(f3ccb40c·백엔드 vision 안 함), 미지원/실패=안내 라인.
+    총량 cap(헤더·마커·안내 라인 포함)·도달 시 중단. best-effort — 개별 첨부 실패는 안내 라인으로 흡수.
 
-    ⚠️ 보안: 문서 fetch 는 object path 가 **이 (project, conversation)에 스코프된 chat 첨부**일
-    때만 수행(_is_scoped_to_conversation). 타 대화/외부 객체 URL 은 거부(IDOR 차단·QA RC HIGH).
+    반환:
+      - text: content 에 주입할 텍스트 블록(이미지는 `![name](signed-url)` 마크다운 — 멀티모달 에이전트 fetch+view).
+        빈 결과면 "".
+      - images: 구조화 이미지 목록 `[{url, name, mime}]`(payload `images` 필드용·Hermes 등 런타임 clean 계약).
+
+    ⚠️ 보안: 문서 fetch·이미지 서명 모두 object path 가 **이 (project, conversation)에 스코프된 chat
+    첨부**일 때만 수행(_is_scoped_to_conversation). 타 대화/외부 객체 URL 은 거부(IDOR 차단·QA RC HIGH).
     """
     if not attachments:
-        return ""
+        return "", []
     blocks: list[str] = []
+    images: list[dict] = []
     total = len(_HEADER)  # 헤더도 총량에 카운트(LOW)
 
     def _append(line: str) -> bool:
@@ -149,10 +191,22 @@ async def build_attachment_context(
         ctype = (a.get("content_type") or "").strip()
         ext = _ext(name)
 
-        # 이미지 — v1 은 메타 안내(본격 분석=S2 백엔드 Vision 캡션)
+        # 이미지(f3ccb40c) — 백엔드 vision 안 함. scope 통과 객체에 단기 V4 서명 URL 발급 →
+        # content 엔 `![name](url)` 마크다운(멀티모달 에이전트 fetch+view) + images 목록(구조화 계약).
         if ctype.startswith("image/") or ext in _IMAGE_EXTS:
-            if not _append(f"[이미지 첨부: {name} ({ctype or 'image'}) — 이미지 분석은 준비 중]"):
+            obj = _canonical_object_path(a.get("url") or "")
+            if obj is None or not _is_scoped_to_conversation(obj, project_id, conversation_id):
+                if not _append(f"[이미지 첨부(접근 범위 밖): {name}]"):
+                    break
+                continue
+            signed = await _signed_read_url(obj)
+            if not signed:
+                if not _append(f"[이미지 첨부: {name} — URL 생성 실패]"):
+                    break
+                continue
+            if not _append(f"![{name}]({signed})"):
                 break
+            images.append({"url": signed, "name": name, "mime": ctype or f"image/{ext or 'png'}"})
             continue
 
         # 미지원 형식 안내
@@ -194,5 +248,5 @@ async def build_attachment_context(
             break
 
     if not blocks:
-        return ""
-    return _HEADER + "\n\n".join(blocks)
+        return "", images
+    return _HEADER + "\n\n".join(blocks), images

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -257,6 +257,7 @@ async def deliver_conversation_message_webhook(
             # 스코프된 객체만(IDOR 차단). best-effort — 조회/추출 실패는 전달에 무영향.
             # MED(QA RC): 주입 없으면 원 content 그대로 보존(None→"" 변환 금지 — 기존 거동 무변경).
             effective_content = content
+            attachment_images: list[dict] = []  # f3ccb40c: payload images 필드(구조화·서명 URL)
             try:
                 from app.models.conversation import ConversationMessage
                 _atts = (await db.execute(
@@ -266,15 +267,16 @@ async def deliver_conversation_message_webhook(
                 )).scalar_one_or_none()
                 if _atts:
                     from app.services.attachment_context import build_attachment_context
-                    _ctx = await build_attachment_context(
+                    _ctx, attachment_images = await build_attachment_context(
                         _atts, project_id=project_id, conversation_id=conversation_id
                     )
                     if _ctx:
                         _base = content or ""
                         effective_content = (_base + _ctx) if _base else _ctx.lstrip()
+                    if _ctx or attachment_images:
                         logger.info(
-                            "attachment_context injected message_id=%s attachment_count=%d",
-                            message_id, len(_atts),
+                            "attachment_context injected message_id=%s attachment_count=%d images=%d",
+                            message_id, len(_atts), len(attachment_images),
                         )
             except Exception:
                 logger.warning(
@@ -295,6 +297,8 @@ async def deliver_conversation_message_webhook(
                 "org_id": str(org_id),
                 "conversation_title": conv_title,
                 "sender_name": sender_name,
+                # f3ccb40c: 이미지 첨부 구조화 목록([{url,name,mime}]·서명 URL·런타임 멀티모달 계약·additive).
+                "images": attachment_images,
             }
 
             for wh in target_webhooks:

--- a/backend/tests/test_attachment_context.py
+++ b/backend/tests/test_attachment_context.py
@@ -1,4 +1,7 @@
-"""R2 S1: attachment_context.build_attachment_context — 분류/추출/cap/스코프(IDOR) (GCS·추출 mock)."""
+"""attachment_context.build_attachment_context — 분류/추출/cap/스코프(IDOR) + 이미지 서명 URL(f3ccb40c).
+
+반환 = (text, images). 문서=GCS fetch+추출, 이미지=단기 V4 서명 URL(백엔드 vision 안 함·scope IDOR 게이트).
+"""
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
@@ -24,28 +27,69 @@ def _att(name, content_type="", url=None):
 
 
 async def _build(ac, attachments):
+    """(text, images) 튜플 반환."""
     return await ac.build_attachment_context(
         attachments, project_id=PROJ, conversation_id=CONV
     )
+
+
+async def _text(ac, attachments):
+    text, _images = await _build(ac, attachments)
+    return text
 
 
 @pytest.mark.anyio
 async def test_empty_returns_blank():
     from app.services import attachment_context as ac
 
-    assert await _build(ac, None) == ""
-    assert await _build(ac, []) == ""
+    assert await _build(ac, None) == ("", [])
+    assert await _build(ac, []) == ("", [])
 
 
+# ── 이미지(f3ccb40c): scope 통과 → 서명 URL 마크다운 + 구조화 images ──────────────
 @pytest.mark.anyio
-async def test_image_meta_line_no_fetch(monkeypatch):
+async def test_image_emits_signed_url_markdown_and_struct(monkeypatch):
     from app.services import attachment_context as ac
 
     fetch = AsyncMock()
     monkeypatch.setattr(ac, "_download_object", fetch)
-    out = await _build(ac, [_att("chart.png", "image/png")])
-    assert "이미지 첨부: chart.png" in out
-    fetch.assert_not_awaited()
+    monkeypatch.setattr(ac, "_signed_read_url", AsyncMock(return_value="https://signed/url?sig=abc"))
+
+    text, images = await _build(ac, [_att("chart.png", "image/png")])
+
+    # content: 마크다운 이미지 링크(멀티모달 에이전트 fetch+view)
+    assert "![chart.png](https://signed/url?sig=abc)" in text
+    assert "이미지 분석은 준비 중" not in text  # 옛 placeholder 제거
+    # 구조화 images 필드
+    assert images == [{"url": "https://signed/url?sig=abc", "name": "chart.png", "mime": "image/png"}]
+    fetch.assert_not_awaited()  # 이미지는 백엔드 다운로드/vision 안 함
+
+
+@pytest.mark.anyio
+async def test_image_out_of_scope_rejected_no_sign(monkeypatch):
+    """타 대화 이미지 객체 → scope 밖 → 서명 안 함·거부 라인·images 비움(IDOR 차단)."""
+    from app.services import attachment_context as ac
+
+    sign = AsyncMock(return_value="https://should/not/be/called")
+    monkeypatch.setattr(ac, "_signed_read_url", sign)
+
+    text, images = await _build(
+        ac, [_att("leak.png", "image/png", url=f"chat/{PROJ}/OTHERCONV/leak.png")]
+    )
+    assert "접근 범위 밖): leak.png" in text
+    assert images == []
+    sign.assert_not_awaited()  # scope 밖은 서명 자체를 안 함
+
+
+@pytest.mark.anyio
+async def test_image_sign_failure_guidance(monkeypatch):
+    """서명 URL 생성 실패(None) → 안내 라인·images 비움(전달 무중단)."""
+    from app.services import attachment_context as ac
+
+    monkeypatch.setattr(ac, "_signed_read_url", AsyncMock(return_value=None))
+    text, images = await _build(ac, [_att("x.png", "image/png")])
+    assert "URL 생성 실패" in text
+    assert images == []
 
 
 @pytest.mark.anyio
@@ -54,7 +98,7 @@ async def test_unsupported_format_line(monkeypatch):
 
     fetch = AsyncMock()
     monkeypatch.setattr(ac, "_download_object", fetch)
-    out = await _build(ac, [_att("data.bin", "application/octet-stream")])
+    out = await _text(ac, [_att("data.bin", "application/octet-stream")])
     assert "미지원 형식): data.bin" in out
     fetch.assert_not_awaited()
 
@@ -65,7 +109,7 @@ async def test_doc_extraction_injected(monkeypatch):
 
     monkeypatch.setattr(ac, "_download_object", AsyncMock(return_value=b"x"))
     monkeypatch.setattr(ac, "_extract_text", MagicMock(return_value="hello world"))
-    out = await _build(ac, [_att("report.pdf", "application/pdf")])
+    out = await _text(ac, [_att("report.pdf", "application/pdf")])
     assert "--- 첨부 내용 ---" in out
     assert "[첨부: report.pdf]" in out
     assert "hello world" in out
@@ -81,13 +125,12 @@ async def test_other_conversation_url_rejected_no_fetch(monkeypatch):
 
     fetch = AsyncMock(return_value=b"secret")
     monkeypatch.setattr(ac, "_download_object", fetch)
-    # 같은 project 지만 *다른 conversation* 객체를 첨부에 심음
-    out = await _build(
+    out = await _text(
         ac, [_att("leak.pdf", "application/pdf", url=f"chat/{PROJ}/OTHERCONV/leak.pdf")]
     )
     assert "접근 범위 밖): leak.pdf" in out
     assert "secret" not in out
-    fetch.assert_not_awaited()  # 스코프 밖은 다운로드 자체를 안 함
+    fetch.assert_not_awaited()
 
 
 @pytest.mark.anyio
@@ -96,7 +139,7 @@ async def test_external_url_rejected(monkeypatch):
 
     fetch = AsyncMock()
     monkeypatch.setattr(ac, "_download_object", fetch)
-    out = await _build(
+    out = await _text(
         ac, [{"name": "x.txt", "content_type": "text/plain", "url": "https://evil.com/x.txt"}]
     )
     assert "접근 범위 밖): x.txt" in out
@@ -110,7 +153,7 @@ async def test_story_path_rejected(monkeypatch):
 
     fetch = AsyncMock()
     monkeypatch.setattr(ac, "_download_object", fetch)
-    out = await _build(
+    out = await _text(
         ac, [_att("s.pdf", "application/pdf", url=f"story/{PROJ}/story123/s.pdf")]
     )
     assert "접근 범위 밖): s.pdf" in out
@@ -126,7 +169,7 @@ async def test_per_attachment_cap_truncates(monkeypatch):
 
     monkeypatch.setattr(ac, "_download_object", AsyncMock(return_value=b"x"))
     monkeypatch.setattr(ac, "_extract_text", MagicMock(return_value="a" * 9000))
-    out = await _build(ac, [_att("big.txt", "text/plain")])
+    out = await _text(ac, [_att("big.txt", "text/plain")])
     assert ac._TRUNC_MARK in out
     body = out.split("[첨부: big.txt]\n", 1)[1]
     assert len(body) <= ac._PER_ATTACHMENT_CAP  # 마커 포함 cap 이내
@@ -139,7 +182,7 @@ async def test_total_cap_includes_markers_and_stops(monkeypatch):
     monkeypatch.setattr(ac, "_download_object", AsyncMock(return_value=b"x"))
     monkeypatch.setattr(ac, "_extract_text", MagicMock(return_value="a" * 8000))
     atts = [_att(f"d{i}.txt", "text/plain") for i in range(5)]
-    out = await _build(ac, atts)
+    out = await _text(ac, atts)
     assert len(out) <= ac._TOTAL_CAP  # 헤더·마커·구분자 포함 총량 엄수
     assert "d4.txt" not in out  # 총량 한도로 후속 첨부 생략(누적 중단)
 
@@ -147,12 +190,12 @@ async def test_total_cap_includes_markers_and_stops(monkeypatch):
 @pytest.mark.anyio
 async def test_first_line_overflow_bounded(monkeypatch):
     """QA RC LOW: 첫 첨부(blocks 빈) 라인이 24k 초과해도 총량 ≤ cap (blocks 가드 제거 검증).
-    긴 파일명 이미지 라인(미fetch)으로 첫 라인만으로 초과 유발."""
+    긴 파일명 이미지 마크다운 라인으로 첫 라인만으로 초과 유발."""
     from app.services import attachment_context as ac
 
-    monkeypatch.setattr(ac, "_download_object", AsyncMock())
+    monkeypatch.setattr(ac, "_signed_read_url", AsyncMock(return_value="https://s/u"))
     huge_name = "x" * (ac._TOTAL_CAP + 5000) + ".png"
-    out = await _build(ac, [_att(huge_name, "image/png")])
+    out = await _text(ac, [_att(huge_name, "image/png")])
     assert len(out) <= ac._TOTAL_CAP  # 첫 라인도 한도 엄수
 
 
@@ -161,7 +204,7 @@ async def test_fetch_failure_guidance(monkeypatch):
     from app.services import attachment_context as ac
 
     monkeypatch.setattr(ac, "_download_object", AsyncMock(side_effect=RuntimeError("gcs down")))
-    out = await _build(ac, [_att("report.pdf", "application/pdf")])
+    out = await _text(ac, [_att("report.pdf", "application/pdf")])
     assert "추출 실패): report.pdf" in out
 
 
@@ -171,5 +214,5 @@ async def test_empty_text_guidance(monkeypatch):
 
     monkeypatch.setattr(ac, "_download_object", AsyncMock(return_value=b""))
     monkeypatch.setattr(ac, "_extract_text", MagicMock(return_value="   "))
-    out = await _build(ac, [_att("empty.txt", "text/plain")])
+    out = await _text(ac, [_att("empty.txt", "text/plain")])
     assert "추출 텍스트 없음" in out


### PR DESCRIPTION
**이미지-멀티모달 스토리 f3ccb40c**(선생님 directed) — dev·마이그 없음·PO 3-결정 사인오프.

## 설계 (PO 사인오프)
- ① **서명 creds**: dev backend SA 가 `roles/iam.serviceAccountTokenCreator` 보유(PO gcloud 확認) → Cloud Run ADC + V4 `generate_signed_url`(IAM SignBlob) 그대로 작동·키파일 불요.
- ② **payload 포맷: 둘 다** — content `![name](signed-url)` 마크다운(멀티모달 에이전트[오르테가] fetch+view) + 구조화 `images:[{url,name,mime}]` 필드(Hermes 등 런타임 clean 계약·additive).
- ③ **TTL 30분**(에이전트 async 처리 윈도).

## 변경
`attachment_context.build_attachment_context` → **(text, images) 튜플**:
- 이미지: 옛 placeholder 제거 → `_is_scoped_to_conversation` **IDOR 게이트 통과 객체만** V4 서명 → 마크다운 + 구조화 images.
- 서명 실패/scope 밖 = 안내 라인·images 비움(전달 무중단).
- **백엔드 vision 안 함**(URL 만 전달).
`conversation_webhook`: 튜플 언팩 + `payload.images`(additive·Discord/BYOA 등 기존 consumer 무영향).

## 보안
이미지 서명도 docs fetch 와 **동일 IDOR 게이트**(`chat/<proj>/<conv>/<file>` 정확 segment). 타 대화/외부/story 객체 = 서명 안 함·거부 라인.

## 무회귀
docs 텍스트추출·미지원/cap/스코프 로직 그대로. 회귀 테스트 14(이미지 서명 마크다운·구조화·scope-reject·sign-fail + 기존 doc/cap/IDOR 전부)·관련 38 무회귀.

## 후속
prod 배포 시 prod backend SA 의 signBlob 권한 확認 필요(PO·infra). 런타임 이미지 consumption 은 이 레포 밖(Hermes/에이전트)·E2E 로 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)