### PR TITLE
release: consolidated prod (develop→main) — af8d3641 세션타임아웃 + 이미지-멀티모달 + channel:68 + MCP per-call

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -226,9 +226,15 @@
       "incompletePreds": "{count} incomplete predecessor(s) — check before starting"
     }
   },
+  "session": {
+    "expiredTitle": "Your session expired",
+    "expiredBody": "For your security, your session expired. Sign in again to return to where you left off.",
+    "reloginCta": "Sign in again"
+  },
   "login": {
     "title": "Sprintable",
     "subtitle": "AI-powered sprint management",
+    "sessionExpired": "Your session expired and you were signed out. Please sign in again.",
     "google": "Continue with Google",
     "github": "Continue with GitHub",
     "email": "Email",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -226,9 +226,15 @@
       "incompletePreds": "미완료 선행 {count}건 — 시작 전 확인 권장"
     }
   },
+  "session": {
+    "expiredTitle": "세션이 만료되었습니다",
+    "expiredBody": "보안을 위해 세션이 만료되었습니다. 다시 로그인하면 보던 화면으로 돌아갑니다.",
+    "reloginCta": "다시 로그인"
+  },
   "login": {
     "title": "Sprintable",
     "subtitle": "AI 기반 스프린트 관리 도구",
+    "sessionExpired": "세션이 만료되어 로그아웃되었습니다. 다시 로그인해 주세요.",
     "google": "Google로 계속",
     "github": "GitHub로 계속",
     "email": "이메일",

--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -1,5 +1,7 @@
 import { redirect } from 'next/navigation';
+import { headers } from 'next/headers';
 import { getServerSession } from '@/lib/db/server';
+import { buildLoginRedirect } from '@/lib/auth/session-redirect';
 import { DashboardShell } from '../dashboard/dashboard-shell';
 
 interface MemberContext {
@@ -23,8 +25,11 @@ export default async function AuthenticatedLayout({
 }: {
   children: React.ReactNode;
 }) {
+  // AC3: proxy 가 주입한 x-pathname 으로 next 보존(server component 는 현재 경로 직접 못 읽음).
+  const currentPath = (await headers()).get('x-pathname') ?? '';
+
   const session = await getServerSession();
-  if (!session) redirect('/login');
+  if (!session) redirect(buildLoginRedirect(currentPath));
 
   const fastapiUrl = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
   const authHeader = { Authorization: `Bearer ${session.access_token}` };
@@ -36,7 +41,7 @@ export default async function AuthenticatedLayout({
   ]);
 
   // 401(인증 만료)만 /login 리다이렉트, 다른 에러(500 등)는 children 렌더링 유지
-  if (!meRes || meRes.status === 401) redirect('/login');
+  if (!meRes || meRes.status === 401) redirect(buildLoginRedirect(currentPath));
 
   // 🔴 org 없는 유저(신규 OAuth 가입자 등 — team_member 미생성 시 /me 404) → 온보딩으로.
   // auth/callback이 is_new_user 무관 /inbox 리다이렉트하는 결함을 layout에서 OAuth+email/pw 공통 커버

--- a/apps/web/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/web/src/app/api/auth/callback/[provider]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
+import { SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 import { resolveAppUrl } from '@/services/app-url';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
@@ -62,7 +63,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 
   const destination = inviteToken ? `${origin}/dashboard` : `${origin}/inbox`;
   const res = NextResponse.redirect(destination);
-  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: 15 * 60 });
+  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: SP_AT_MAX_AGE_SECONDS });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
   return res;
 }

--- a/apps/web/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/web/src/app/api/auth/callback/[provider]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
+import { safeNextPath } from '@/lib/auth/session-redirect';
 import { resolveAppUrl } from '@/services/app-url';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
@@ -33,9 +34,11 @@ export async function GET(request: Request, { params }: RouteParams) {
   const storedState = cookieStore.get(`oauth_state_${provider}`)?.value;
   const tosAccepted = cookieStore.get(`oauth_tos_${provider}`)?.value === 'true';
   const inviteToken = cookieStore.get(`oauth_invite_token_${provider}`)?.value ?? null;
+  const nextCookie = cookieStore.get(`oauth_next_${provider}`)?.value ?? null; // AC3 세션 만료 복귀
   cookieStore.delete(`oauth_state_${provider}`);
   cookieStore.delete(`oauth_tos_${provider}`);
   cookieStore.delete(`oauth_invite_token_${provider}`);
+  cookieStore.delete(`oauth_next_${provider}`);
 
   if (!storedState || storedState !== state) {
     return NextResponse.redirect(`${origin}/login?error=csrf_mismatch`);
@@ -61,7 +64,8 @@ export async function GET(request: Request, { params }: RouteParams) {
     return NextResponse.redirect(`${origin}/login?error=oauth_no_token`);
   }
 
-  const destination = inviteToken ? `${origin}/dashboard` : `${origin}/inbox`;
+  // AC3: 세션 만료로 OAuth 재로그인한 경우 작업 경로 복귀(safeNextPath 가드)·없으면 기존 /inbox.
+  const destination = inviteToken ? `${origin}/dashboard` : `${origin}${safeNextPath(nextCookie)}`;
   const res = NextResponse.redirect(destination);
   res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: SP_AT_MAX_AGE_SECONDS });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });

--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { verifyCsrfOrigin } from '@/lib/auth/csrf';
-import { cookieBase } from '@/lib/auth/cookies';
+import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -25,7 +25,7 @@ export async function POST(request: Request) {
 
   const { access_token, refresh_token } = json.data;
   const res = NextResponse.json({ data: { ok: true } });
-  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: 15 * 60 });
+  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: SP_AT_MAX_AGE_SECONDS });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
   return res;
 }

--- a/apps/web/src/app/api/auth/refresh/route.ts
+++ b/apps/web/src/app/api/auth/refresh/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { verifyCsrfOrigin } from '@/lib/auth/csrf';
-import { cookieBase } from '@/lib/auth/cookies';
+import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -30,7 +30,7 @@ export async function POST(request: Request) {
 
   const { access_token, refresh_token } = json.data;
   const res = NextResponse.json({ data: { ok: true } });
-  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: 15 * 60 });
+  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: SP_AT_MAX_AGE_SECONDS });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
   return res;
 }

--- a/apps/web/src/app/api/auth/register/route.ts
+++ b/apps/web/src/app/api/auth/register/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { verifyCsrfOrigin } from '@/lib/auth/csrf';
-import { cookieBase } from '@/lib/auth/cookies';
+import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -31,7 +31,7 @@ export async function POST(request: Request) {
 
   const { access_token, refresh_token } = json.data;
   const res = NextResponse.json({ data: { ok: true } }, { status: 201 });
-  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: 15 * 60 });
+  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: SP_AT_MAX_AGE_SECONDS });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
   return res;
 }

--- a/apps/web/src/app/api/switch-org/route.ts
+++ b/apps/web/src/app/api/switch-org/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { SP_AT_COOKIE, SP_RT_COOKIE, getServerSession } from '@/lib/db/server';
 import { CURRENT_PROJECT_COOKIE } from '@/lib/auth-helpers';
-import { cookieBase } from '@/lib/auth/cookies';
+import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -39,7 +39,7 @@ export async function POST(request: Request): Promise<Response> {
 
   const { access_token, refresh_token, project_id } = json.data;
   const res = NextResponse.json({ data: { ok: true } });
-  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: 15 * 60 });
+  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: SP_AT_MAX_AGE_SECONDS });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
   // 0746: 전환 시 current-project 쿠키를 항상 갱신해야 stale 잔존이 없다.
   // target org에 접근 가능 프로젝트가 있으면 그걸로 set, 없으면(미부여 멤버 등) 반드시 clear —

--- a/apps/web/src/app/api/switch-project/route.ts
+++ b/apps/web/src/app/api/switch-project/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { SP_AT_COOKIE, SP_RT_COOKIE, getServerSession } from '@/lib/db/server';
 import { CURRENT_PROJECT_COOKIE } from '@/lib/auth-helpers';
-import { cookieBase } from '@/lib/auth/cookies';
+import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -39,7 +39,7 @@ export async function POST(request: Request): Promise<Response> {
 
   const { access_token, refresh_token } = json.data;
   const res = NextResponse.json({ data: { ok: true } });
-  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: 15 * 60 });
+  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: SP_AT_MAX_AGE_SECONDS });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
   res.cookies.set(CURRENT_PROJECT_COOKIE, body.project_id, { path: '/', sameSite: 'lax', maxAge: 60 * 60 * 24 * 365 });
   return res;

--- a/apps/web/src/app/auth/login/route.ts
+++ b/apps/web/src/app/auth/login/route.ts
@@ -9,6 +9,7 @@ export async function GET(request: Request) {
   const provider = searchParams.get('provider');
   const tosAccepted = searchParams.get('tos_accepted') === 'true';
   const inviteToken = searchParams.get('invite_token');
+  const next = searchParams.get('next'); // AC3: 세션 만료 복귀 경로 — 콜백서 safeNextPath 로 검증 후 복귀
   const origin = resolveAppUrl(null);
 
   if (!provider || !['google', 'github'].includes(provider)) {
@@ -47,6 +48,15 @@ export async function GET(request: Request) {
   }
   if (inviteToken) {
     cookieStore.set(`oauth_invite_token_${provider}`, inviteToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 300,
+      path: '/',
+    });
+  }
+  if (next) {
+    cookieStore.set(`oauth_next_${provider}`, next, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
       sameSite: 'lax',

--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/lib/project-context-client';
 import { useTranslations } from 'next-intl';
 import { RealtimeProvider } from '@/components/realtime-provider';
+import { SessionExpiredDialog } from '@/components/auth/session-expired-dialog';
 import { AppSidebar } from '@/components/nav/app-sidebar';
 import { TopBar } from '@/components/nav/top-bar';
 import { TopBarProvider, useTopBar } from '@/components/nav/top-bar-context';
@@ -166,6 +167,7 @@ export function DashboardShell({
             </ScrollShell>
           </SidebarProvider>
         </TopBarProvider>
+        <SessionExpiredDialog />
       </RealtimeProvider>
       </RefreshProvider>
     </DashboardCtx.Provider>

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -6,12 +6,17 @@ import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
 import { loginWithPassword } from '@/lib/db/client';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { safeNextPath, SESSION_EXPIRED_REASON } from '@/lib/auth/session-redirect';
 
 export default function LoginPage() {
   const t = useTranslations('login');
   const router = useRouter();
   const searchParams = useSearchParams();
   const errorCode = searchParams.get('error');
+  // AC3: 세션 만료로 튕긴 경우 reason 배너 + next 로 작업 경로 복귀(오픈 리다이렉트 가드).
+  const sessionExpired = searchParams.get('reason') === SESSION_EXPIRED_REASON;
+  const nextParam = searchParams.get('next');
   const oauthErrors: Record<string, string> = {
     oauth_init_failed: t('oauthInitFailed'),
     oauth_missing_params: t('oauthMissingParams'),
@@ -43,7 +48,7 @@ export default function LoginPage() {
         setError(result.error.message);
         return;
       }
-      router.push('/inbox');
+      router.push(safeNextPath(nextParam));
       router.refresh();
     } catch {
       setError(t('loginFailed'));
@@ -64,6 +69,12 @@ export default function LoginPage() {
           />
           <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
         </div>
+
+        {sessionExpired && (
+          <Alert variant="warning">
+            <AlertDescription>{t('sessionExpired')}</AlertDescription>
+          </Alert>
+        )}
 
         <div className="space-y-3">
           <input
@@ -118,7 +129,7 @@ export default function LoginPage() {
               <div className="flex-grow border-t border-border/50" />
             </div>
 
-            <a href="/auth/login?provider=google&tos_accepted=true" className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-border bg-background px-4 py-3 text-sm font-medium text-foreground/80 transition hover:bg-muted/50">
+            <a href={`/auth/login?provider=google&tos_accepted=true${nextParam ? `&next=${encodeURIComponent(nextParam)}` : ''}`} className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-border bg-background px-4 py-3 text-sm font-medium text-foreground/80 transition hover:bg-muted/50">
               <svg className="h-5 w-5" viewBox="0 0 24 24">
                 <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
                 <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
@@ -128,7 +139,7 @@ export default function LoginPage() {
               {t('google')}
             </a>
 
-            <a href="/auth/login?provider=github&tos_accepted=true" className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-border bg-foreground px-4 py-3 text-sm font-medium text-background transition hover:bg-foreground/90">
+            <a href={`/auth/login?provider=github&tos_accepted=true${nextParam ? `&next=${encodeURIComponent(nextParam)}` : ''}`} className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-border bg-foreground px-4 py-3 text-sm font-medium text-background transition hover:bg-foreground/90">
               <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
                 <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
               </svg>

--- a/apps/web/src/components/auth/session-expired-dialog.tsx
+++ b/apps/web/src/components/auth/session-expired-dialog.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { subscribeSessionExpired } from '@/lib/auth/session-expired-signal';
+import { buildLoginRedirect } from '@/lib/auth/session-redirect';
+
+/**
+ * AC3(af8d3641): 세션 만료 모달. fetchWithAuth 의 refresh 최종 실패 신호(session-expired-signal)를 받아
+ * hard redirect 대신 graceful 안내 — "다시 로그인" 시 현재 경로를 next 로 보존해 §A 계약 redirect.
+ * (authenticated) 트리 전역(DashboardShell)에 1회 마운트. 신규 토큰 0(Dialog/Button 재사용).
+ */
+export function SessionExpiredDialog() {
+  const t = useTranslations('session');
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => subscribeSessionExpired(() => setOpen(true)), []);
+
+  const relogin = () => {
+    const path = typeof window !== 'undefined' ? window.location.pathname + window.location.search : '/inbox';
+    window.location.href = buildLoginRedirect(path);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('expiredTitle')}</DialogTitle>
+          <DialogDescription>{t('expiredBody')}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button onClick={relogin}>{t('reloginCta')}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/lib/auth/cookies.ts
+++ b/apps/web/src/lib/auth/cookies.ts
@@ -1,3 +1,11 @@
+/**
+ * sp_at(access) 쿠키 maxAge(초). AC2b(551bbbee): BE access TTL 60분(#1577)과 일치. ⚠️ refresh **빈도를
+ * 결정하는 게 이 쿠키 maxAge** — 쿠키가 15분에 만료되면 JWT 가 60분이어도 15분마다 refresh 강제
+ * (rotation 레이스 빈도 그대로). sp_at 를 set 하는 **모든 경로(7곳)**가 이 상수를 써야 드리프트
+ * (일부만 15분 잔존) 방지. sp_rt(30일)는 별개.
+ */
+export const SP_AT_MAX_AGE_SECONDS = 60 * 60;
+
 /** APP_BASE_URL 또는 NEXT_PUBLIC_APP_URL 기준으로 Secure 쿠키 여부 결정.
  *  HTTP(localhost, Tailscale, ngrok 등)에서는 false, HTTPS에서는 true.
  */

--- a/apps/web/src/lib/auth/session-expired-signal.ts
+++ b/apps/web/src/lib/auth/session-expired-signal.ts
@@ -1,0 +1,26 @@
+// AC3(af8d3641): 세션-만료 모듈 신호. fetchWithAuth(비-React 모듈 함수)가 refresh 최종 실패 시
+// bare `window.location.href` 대신 이 신호를 쏴 SessionExpiredDialog(React)를 띄운다. 동시 다중 401 은
+// **dedupe**(signaled 플래그) — 한 번만 모달을 연다.
+
+type Listener = () => void;
+
+let listener: Listener | null = null;
+let signaled = false;
+
+/** SessionExpiredDialog 가 마운트 시 구독. cleanup 반환. */
+export function subscribeSessionExpired(cb: Listener): () => void {
+  listener = cb;
+  return () => { if (listener === cb) listener = null; };
+}
+
+/** 세션 만료 신호(다중 호출은 1회로 dedupe). */
+export function signalSessionExpired(): void {
+  if (signaled) return;
+  signaled = true;
+  listener?.();
+}
+
+/** 재로그인 등으로 상태 초기화(다음 만료를 다시 잡도록). */
+export function resetSessionExpired(): void {
+  signaled = false;
+}

--- a/apps/web/src/lib/auth/session-redirect.test.ts
+++ b/apps/web/src/lib/auth/session-redirect.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { buildLoginRedirect, safeNextPath, SESSION_EXPIRED_REASON } from './session-redirect';
+
+describe('safeNextPath — 오픈 리다이렉트 가드 (AC3)', () => {
+  it('내부 절대경로는 그대로 허용', () => {
+    expect(safeNextPath('/board')).toBe('/board');
+    expect(safeNextPath('/stories/123?tab=detail')).toBe('/stories/123?tab=detail');
+    expect(safeNextPath(encodeURIComponent('/board?x=1'))).toBe('/board?x=1');
+  });
+
+  it('외부/프로토콜-상대/백슬래시 유도는 /inbox 로 차단', () => {
+    expect(safeNextPath('//evil.com')).toBe('/inbox');
+    expect(safeNextPath('https://evil.com')).toBe('/inbox');
+    expect(safeNextPath('http://evil.com')).toBe('/inbox');
+    expect(safeNextPath('/\\evil.com')).toBe('/inbox');
+    expect(safeNextPath('javascript:alert(1)')).toBe('/inbox');
+  });
+
+  it('빈/누락/디코드 불가는 /inbox', () => {
+    expect(safeNextPath(null)).toBe('/inbox');
+    expect(safeNextPath(undefined)).toBe('/inbox');
+    expect(safeNextPath('')).toBe('/inbox');
+    expect(safeNextPath('%')).toBe('/inbox'); // decodeURIComponent throw
+  });
+});
+
+describe('buildLoginRedirect (AC3)', () => {
+  it('next(encode) + reason 쿼리를 붙인 /login 경로', () => {
+    const r = buildLoginRedirect('/board?x=1');
+    expect(r).toContain('/login?');
+    expect(r).toContain(`next=${encodeURIComponent('/board?x=1')}`);
+    expect(r).toContain(`reason=${SESSION_EXPIRED_REASON}`);
+  });
+
+  it('내부경로 아니면 /inbox 로 fallback', () => {
+    expect(buildLoginRedirect('')).toContain(`next=${encodeURIComponent('/inbox')}`);
+  });
+});

--- a/apps/web/src/lib/auth/session-redirect.ts
+++ b/apps/web/src/lib/auth/session-redirect.ts
@@ -1,0 +1,23 @@
+// AC3(af8d3641): graceful 세션-만료 redirect 계약. 인증 실패 redirect 는 전부
+// `/login?next=<enc>&reason=session_expired` 로 통일 — login 이 reason 배너 + next 복귀(작업 손실
+// 최소화)에 사용. server(proxy·layout)·client(fetchWithAuth) 공용 순수 함수.
+
+export const SESSION_EXPIRED_REASON = 'session_expired';
+
+/** 현재 경로(pathname+search)를 next 로 보존한 /login redirect 경로. */
+export function buildLoginRedirect(currentPathAndSearch: string): string {
+  const target = currentPathAndSearch && currentPathAndSearch.startsWith('/') ? currentPathAndSearch : '/inbox';
+  return `/login?next=${encodeURIComponent(target)}&reason=${SESSION_EXPIRED_REASON}`;
+}
+
+/**
+ * 오픈 리다이렉트 가드 — next 가 **내부 절대경로**(`/` 시작·`//`(프로토콜-상대)·`/\` 아님)일 때만 허용,
+ * 아니면 `/inbox`. login 성공/콜백 복귀 시 외부 도메인 유도(`//evil.com`·`http://`)를 차단.
+ */
+export function safeNextPath(next: string | null | undefined): string {
+  if (!next) return '/inbox';
+  let decoded: string;
+  try { decoded = decodeURIComponent(next); } catch { return '/inbox'; }
+  if (!decoded.startsWith('/') || decoded.startsWith('//') || decoded.startsWith('/\\')) return '/inbox';
+  return decoded;
+}

--- a/apps/web/src/lib/db/client.ts
+++ b/apps/web/src/lib/db/client.ts
@@ -1,5 +1,7 @@
 'use client';
 
+import { signalSessionExpired } from '@/lib/auth/session-expired-signal';
+
 // ─── FastAPI Auth Utilities ───────────────────────────────────────────────────
 
 export interface AuthTokens {
@@ -65,13 +67,14 @@ export async function fetchWithAuth(input: RequestInfo | URL, init?: RequestInit
   try {
     await _refreshing;
   } catch {
-    if (typeof window !== 'undefined') window.location.href = '/login';
+    // AC3: refresh 최종 실패 → bare redirect 대신 세션-만료 신호(SessionExpiredDialog·다중 401 dedupe).
+    if (typeof window !== 'undefined') signalSessionExpired();
     return res;
   }
 
   const retried = await fetch(input, init);
   if (retried.status === 401 && typeof window !== 'undefined') {
-    window.location.href = '/login';
+    signalSessionExpired();
   }
   return retried;
 }

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -67,13 +67,21 @@ describe('proxy', () => {
     mockFetch.mockResolvedValue({ ok: false, json: async () => ({ error: { code: 'TOKEN_REVOKED' } }) });
     const response = await middleware(makeRequest('/dashboard'));
     expect(response.status).toBe(307);
-    expect(response.headers.get('location')).toBe('https://app.example.com/login');
+    // AC3(551bbbee): hard /login 대신 next 보존 + reason 배너 계약. graceful 세션 만료 UX.
+    const loc = response.headers.get('location') ?? '';
+    expect(loc).toContain('https://app.example.com/login?');
+    expect(loc).toContain(`next=${encodeURIComponent('/dashboard')}`);
+    expect(loc).toContain('reason=session_expired');
   });
 
   it('redirects to login when no sp_at and no sp_rt cookie', async () => {
     const response = await middleware(makeRequest('/dashboard'));
     expect(response.status).toBe(307);
-    expect(response.headers.get('location')).toBe('https://app.example.com/login');
+    // AC3(551bbbee): hard /login 대신 next 보존 + reason 배너 계약. graceful 세션 만료 UX.
+    const loc = response.headers.get('location') ?? '';
+    expect(loc).toContain('https://app.example.com/login?');
+    expect(loc).toContain(`next=${encodeURIComponent('/dashboard')}`);
+    expect(loc).toContain('reason=session_expired');
   });
 
   it('allows access with valid sp_at cookie', async () => {
@@ -85,7 +93,11 @@ describe('proxy', () => {
   it('redirects to login with invalid sp_at and no refresh token', async () => {
     const response = await middleware(makeRequest('/dashboard', { sp_at: 'not.a.valid.jwt' }));
     expect(response.status).toBe(307);
-    expect(response.headers.get('location')).toBe('https://app.example.com/login');
+    // AC3(551bbbee): hard /login 대신 next 보존 + reason 배너 계약. graceful 세션 만료 UX.
+    const loc = response.headers.get('location') ?? '';
+    expect(loc).toContain('https://app.example.com/login?');
+    expect(loc).toContain(`next=${encodeURIComponent('/dashboard')}`);
+    expect(loc).toContain('reason=session_expired');
   });
 
   it('refreshes token when sp_at is expiring soon', async () => {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,6 +1,6 @@
 import { jwtVerify } from 'jose';
 import { NextResponse, type NextRequest } from 'next/server';
-import { cookieBase } from '@/lib/auth/cookies';
+import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 
 const PUBLIC_EXACT = [
   '/',
@@ -72,13 +72,44 @@ async function tryRefreshViaFastapi(request: NextRequest): Promise<{ accessToken
   }
 }
 
+// AC1(551bbbee): single-flight refresh. refresh 는 single-use rotation(첫 건이 RT revoke)이라, 대시보드
+// 동시요청이 같은 RT 로 각자 refresh 하면 첫 건만 통과·나머지 401 → 강제 로그아웃("세션 너무 짧음")이던
+// 레이스를 제거. RT 기준 in-flight 1개로 dedupe(나머지는 그 promise 를 await/재사용) — 실제 refresh 호출은
+// 1회라 single-use 보안 유지.
+//   - **pending 동안은 시간 무관하게 그 promise 재사용**(refresh 가 10s 걸려도 1개만 — 시작-기준 grace 면
+//     느린 refresh 가 grace 넘겨 pending 중 신규 refresh 시작=레이스 재발, RC HIGH 봉합).
+//   - 해소(settled) 후엔 **해소 시각 기준 grace** 동안만 결과 재사용 — cookie 갱신 전 도착한 burst 꼬리
+//     요청도 옛 RT 로 새 refresh 안 함.
+// setTimeout 미사용(edge 런타임 post-response 실행 불확실)·size-cap lazy prune(무한증가 방지).
+const REFRESH_GRACE_MS = 5_000;
+type RefreshEntry = { p: Promise<{ accessToken: string; refreshToken: string } | null>; settledAt: number | null };
+const inflightRefresh = new Map<string, RefreshEntry>();
+
+function singleFlightRefresh(request: NextRequest): Promise<{ accessToken: string; refreshToken: string } | null> {
+  const rt = request.cookies.get(SP_RT_COOKIE)?.value;
+  if (!rt) return Promise.resolve(null);
+  const now = Date.now();
+  const existing = inflightRefresh.get(rt);
+  // pending(settledAt===null) → 시간 무관 재사용 / settled → 해소 시각 + grace 내에서만 재사용.
+  if (existing && (existing.settledAt === null || existing.settledAt + REFRESH_GRACE_MS > now)) {
+    return existing.p;
+  }
+  const entry: RefreshEntry = { p: tryRefreshViaFastapi(request), settledAt: null };
+  inflightRefresh.set(rt, entry);
+  void entry.p.finally(() => { entry.settledAt = Date.now(); }); // 해소 시각 기록 → grace 시작점
+  if (inflightRefresh.size > 64) { // settled + grace 지난 항목 lazy prune(pending 은 유지)
+    for (const [k, v] of inflightRefresh) if (v.settledAt !== null && v.settledAt + REFRESH_GRACE_MS <= now) inflightRefresh.delete(k);
+  }
+  return entry.p;
+}
+
 function applyTokenCookies(
   response: NextResponse,
   accessToken: string,
   refreshToken: string,
 ): void {
   const base = cookieBase();
-  response.cookies.set(SP_AT_COOKIE, accessToken, { ...base, maxAge: 15 * 60 });
+  response.cookies.set(SP_AT_COOKIE, accessToken, { ...base, maxAge: SP_AT_MAX_AGE_SECONDS });
   response.cookies.set(SP_RT_COOKIE, refreshToken, { ...base, maxAge: 30 * 24 * 60 * 60 });
 }
 
@@ -123,7 +154,7 @@ export async function proxy(request: NextRequest) {
   const accessToken = request.cookies.get(SP_AT_COOKIE)?.value;
 
   if (!accessToken) {
-    const tokens = await tryRefreshViaFastapi(request);
+    const tokens = await singleFlightRefresh(request);
     if (!tokens) {
       if (isApiPath) return NextResponse.next({ request }); // let handler return 401
       const url = request.nextUrl.clone();
@@ -140,7 +171,7 @@ export async function proxy(request: NextRequest) {
 
   if (!claims) {
     // access token invalid/expired — try refresh
-    const tokens = await tryRefreshViaFastapi(request);
+    const tokens = await singleFlightRefresh(request);
     if (!tokens) {
       if (isApiPath) return NextResponse.next({ request }); // let handler return 401
       const url = request.nextUrl.clone();
@@ -157,7 +188,7 @@ export async function proxy(request: NextRequest) {
   const now = Math.floor(Date.now() / 1000);
   const response = NextResponse.next({ request });
   if (claims.exp !== undefined && claims.exp - now < 300) {
-    const tokens = await tryRefreshViaFastapi(request);
+    const tokens = await singleFlightRefresh(request);
     if (tokens) {
       applyTokenCookies(response, tokens.accessToken, tokens.refreshToken);
     }

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,6 +1,7 @@
 import { jwtVerify } from 'jose';
 import { NextResponse, type NextRequest } from 'next/server';
 import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
+import { SESSION_EXPIRED_REASON } from '@/lib/auth/session-redirect';
 
 const PUBLIC_EXACT = [
   '/',
@@ -128,6 +129,17 @@ function buildRefreshedHeaders(
   return headers;
 }
 
+/** AC3: 인증 실패 → /login?next=<현재경로>&reason=session_expired (login 배너 + 작업 보존 복귀). */
+function loginRedirect(request: NextRequest): NextResponse {
+  const url = request.nextUrl.clone();
+  const nextTarget = request.nextUrl.pathname + request.nextUrl.search;
+  url.pathname = '/login';
+  url.search = '';
+  url.searchParams.set('next', nextTarget); // searchParams.set 이 encode
+  url.searchParams.set('reason', SESSION_EXPIRED_REASON);
+  return NextResponse.redirect(url);
+}
+
 export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
@@ -157,9 +169,7 @@ export async function proxy(request: NextRequest) {
     const tokens = await singleFlightRefresh(request);
     if (!tokens) {
       if (isApiPath) return NextResponse.next({ request }); // let handler return 401
-      const url = request.nextUrl.clone();
-      url.pathname = '/login';
-      return NextResponse.redirect(url);
+      return loginRedirect(request);
     }
     const headers = buildRefreshedHeaders(request, tokens);
     const response = NextResponse.next({ request: { headers } });
@@ -174,9 +184,7 @@ export async function proxy(request: NextRequest) {
     const tokens = await singleFlightRefresh(request);
     if (!tokens) {
       if (isApiPath) return NextResponse.next({ request }); // let handler return 401
-      const url = request.nextUrl.clone();
-      url.pathname = '/login';
-      return NextResponse.redirect(url);
+      return loginRedirect(request);
     }
     const headers = buildRefreshedHeaders(request, tokens);
     const response = NextResponse.next({ request: { headers } });
@@ -184,9 +192,13 @@ export async function proxy(request: NextRequest) {
     return response;
   }
 
-  // Proactive refresh if expiring within 5 minutes
+  // Proactive refresh if expiring within 5 minutes.
+  // AC3: x-pathname 주입 — (authenticated)/layout 이 /me 401 시 next 보존 redirect 에 사용(server component
+  // 는 현재 경로를 직접 못 읽음).
   const now = Math.floor(Date.now() / 1000);
-  const response = NextResponse.next({ request });
+  const fwdHeaders = new Headers(request.headers);
+  fwdHeaders.set('x-pathname', pathname + request.nextUrl.search);
+  const response = NextResponse.next({ request: { headers: fwdHeaders } });
   if (claims.exp !== undefined && claims.exp - now < 300) {
     const tokens = await singleFlightRefresh(request);
     if (tokens) {

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -23,7 +23,10 @@ __all__ = [
     "ACCESS_TOKEN_EXPIRE_MINUTES", "REFRESH_TOKEN_EXPIRE_DAYS",
 ]
 
-ACCESS_TOKEN_EXPIRE_MINUTES = 15
+# af8d3641 AC2: 15→60분 완화. 15분은 동시요청 refresh 빈도를 높여 rotation 레이스(→강제 로그아웃)를
+# 잦게 함(체감 "세션 너무 짧음"). 60분은 보안 통상 범위(access 15~60분 표준)·refresh 30일이 longevity 담당
+# (만료 시 silent refresh). 근본 동시성 fix는 FE single-flight(AC1·별 작업). dev/prod 공유 상수.
+ACCESS_TOKEN_EXPIRE_MINUTES = 60
 REFRESH_TOKEN_EXPIRE_DAYS = 30
 
 _pwd_context = CryptContext(schemes=["argon2", "bcrypt"], deprecated="auto")

--- a/backend/app/dependencies/ownership.py
+++ b/backend/app/dependencies/ownership.py
@@ -28,11 +28,13 @@ async def assert_agent_owner(
 ) -> TeamMember:
     """agent 존재 확인 + ownership guard. TeamMember를 반환."""
     result = await session.execute(
+        # team_members projection VIEW — multi-project agent N 행. 아래선 .created_by(동형) ownership
+        # guard + org_id 필터만 쓰므로 .limit(1) 로 MultipleResultsFound 회피(아무 projection 행 OK).
         select(TeamMember).where(
             TeamMember.id == agent_id,
             TeamMember.type == "agent",
             TeamMember.org_id == org_id,
-        )
+        ).limit(1)
     )
     agent = result.scalar_one_or_none()
     if agent is None:

--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -283,7 +283,10 @@ async def agent_stream(
         # 무필터 scalar_one_or_none 은 멀티프로젝트 agent 접속 시 MultipleResultsFound 로 stream 연결을
         # 막는다. 아래선 .org_id(동형)만 쓰므로 .limit(1) 로 안전(아무 projection 행 OK).
         tm = (await db.execute(
-            select(TeamMember).where(TeamMember.id == agent_id, TeamMember.type == "agent").limit(1)
+            select(TeamMember).where(
+                TeamMember.id == agent_id, TeamMember.type == "agent",
+                TeamMember.is_active.is_(True),  # deactivated agent 는 stream 연결 비도달(정합)
+            ).limit(1)
         )).scalar_one_or_none()
         if tm is None:
             raise HTTPException(status_code=404, detail="Agent not found")

--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -279,8 +279,11 @@ async def agent_stream(
 
     # agent_id ê²ì¦
     async with async_session_factory() as db:
+        # team_members 는 projection VIEW — 멀티프로젝트 grant 면 같은 agent_id 가 N 행이라
+        # 무필터 scalar_one_or_none 은 멀티프로젝트 agent 접속 시 MultipleResultsFound 로 stream 연결을
+        # 막는다. 아래선 .org_id(동형)만 쓰므로 .limit(1) 로 안전(아무 projection 행 OK).
         tm = (await db.execute(
-            select(TeamMember).where(TeamMember.id == agent_id, TeamMember.type == "agent")
+            select(TeamMember).where(TeamMember.id == agent_id, TeamMember.type == "agent").limit(1)
         )).scalar_one_or_none()
         if tm is None:
             raise HTTPException(status_code=404, detail="Agent not found")

--- a/backend/app/routers/agent_inbox.py
+++ b/backend/app/routers/agent_inbox.py
@@ -46,12 +46,19 @@ async def receive_inbox_webhook(
     if not _verify_signature(raw_body, x_sprintable_signature):
         raise HTTPException(status_code=401, detail="Invalid webhook signature")
 
+    # team_members 는 projection VIEW — org-agent 멀티프로젝트 grant 면 같은 agent_id 가 N 행이라
+    # 무필터 one_or_none 은 MultipleResultsFound 로 깨진다. 이 inbox webhook 은 단일 글로벌 secret
+    # (per-webhook-config 없음)이고 members anchor 엔 home project 가 없어 "올바른" project 를 도출할
+    # 컨텍스트가 없다. → deterministic grant-pick(order_by(project_id) limit 1)으로 크래시를 막고
+    # 안정적 default project 로 Event 를 적재한다.
+    # ⚠️ known-limitation: 멀티프로젝트 agent inbox 의 project 라우팅은 default(최저 project_id) 고정.
+    #   진짜 라우팅(payload 가 타겟 project 명시)은 follow-up story(멀티프로젝트 inbox routing).
     result = await db.execute(
         select(TeamMember.org_id, TeamMember.project_id).where(
             TeamMember.id == agent_id,
             TeamMember.type == "agent",
             TeamMember.is_active.is_(True),
-        )
+        ).order_by(TeamMember.project_id).limit(1)
     )
     row = result.one_or_none()
     if row is None:

--- a/backend/app/routers/agent_runs.py
+++ b/backend/app/routers/agent_runs.py
@@ -37,10 +37,12 @@ async def create_agent_run(
     _auth: AuthContext = Depends(get_current_user),
     repo: AgentRunRepository = Depends(_get_repo),
 ) -> AgentRunResponse:
+    # team_members 는 projection VIEW — 멀티프로젝트 grant 면 같은 agent_id 가 N 행. org_id 는 전
+    # projection 행에서 동형이라 .limit(1) 로 MultipleResultsFound 회피(아무 행 OK).
     member_r = await session.execute(
         select(TeamMember.org_id).where(
             TeamMember.id == body.agent_id, TeamMember.type == "agent"
-        )
+        ).limit(1)
     )
     org_id = member_r.scalar_one_or_none()
     if org_id is None:

--- a/backend/app/routers/agent_runs.py
+++ b/backend/app/routers/agent_runs.py
@@ -41,7 +41,8 @@ async def create_agent_run(
     # projection 행에서 동형이라 .limit(1) 로 MultipleResultsFound 회피(아무 행 OK).
     member_r = await session.execute(
         select(TeamMember.org_id).where(
-            TeamMember.id == body.agent_id, TeamMember.type == "agent"
+            TeamMember.id == body.agent_id, TeamMember.type == "agent",
+            TeamMember.is_active.is_(True),  # deactivated agent 는 run 생성 비도달(정합)
         ).limit(1)
     )
     org_id = member_r.scalar_one_or_none()

--- a/backend/app/routers/channel.py
+++ b/backend/app/routers/channel.py
@@ -49,6 +49,7 @@ async def _resolve_agent(agent_id: uuid.UUID, caller: TeamMember) -> TeamMember:
             select(TeamMember).where(
                 TeamMember.id == agent_id,
                 TeamMember.type == "agent",
+                TeamMember.is_active.is_(True),  # deactivated agent 는 비도달(정합)
             ).order_by(TeamMember.project_id).limit(1)
         )).scalar_one_or_none()
     if agent is None:
@@ -65,7 +66,10 @@ async def _persist_and_broadcast(
     content: str,
     file_url: str | None = None,
 ) -> None:
-    conv_id = await _get_or_create_conversation(agent_id, agent.org_id, agent.project_id)
+    # ws_chat._get_or_create_conversation 시그니처 = (agent_id, caller_id, org_id, project_id) 4인자.
+    # 과거 caller_id 추가 전환 시 이 호출부 미갱신(한쪽만 전환)으로 3인자 → caller_id 누락 + 인자
+    # 미스얼라인(org_id↔caller_id·project_id↔org_id) → /deliver·/upload 호출 시 TypeError. caller.id 보강.
+    conv_id = await _get_or_create_conversation(agent_id, caller.id, agent.org_id, agent.project_id)
 
     msg_content = content
     if file_url:

--- a/backend/app/routers/channel.py
+++ b/backend/app/routers/channel.py
@@ -38,11 +38,18 @@ async def _require_caller(api_key: str | None, token: str | None) -> TeamMember:
 
 async def _resolve_agent(agent_id: uuid.UUID, caller: TeamMember) -> TeamMember:
     async with async_session_factory() as db:
+        # team_members 는 projection VIEW — org-agent 멀티프로젝트 grant 면 같은 id 가 N 행이라 무필터
+        # scalar_one_or_none 은 MultipleResultsFound. 이 결과의 .org_id(동형)뿐 아니라 .project_id 도
+        # _persist_and_broadcast → _get_or_create_conversation 에서 DM room 스코프에 소비되므로 임의
+        # .limit(1)(틀린 프로젝트 위험) 대신 deterministic grant-pick(order_by(project_id).limit(1))으로
+        # 크래시를 막고 안정적 default project 로 라우팅한다(ws_chat/agent_inbox Ⓑ stopgap 동형).
+        # ⚠️ known-limitation: 멀티프로젝트 agent 의 DM room 은 default(최저 project_id) project 로 스코프.
+        #   진짜 라우팅(기존 (agent,caller) DM 우선조회→그 conversation 의 project)은 follow-up story.
         agent = (await db.execute(
             select(TeamMember).where(
                 TeamMember.id == agent_id,
                 TeamMember.type == "agent",
-            )
+            ).order_by(TeamMember.project_id).limit(1)
         )).scalar_one_or_none()
     if agent is None:
         raise HTTPException(status_code=404, detail="Agent not found")

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -29,8 +29,9 @@ async def _resolve_notification_user_id(auth: AuthContext, db: AsyncSession) -> 
     """
     is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
     if is_api_key:
+        # team_members projection VIEW — multi-project member N 행. id/user_id 동형이라 .limit(1)(아무 행 OK).
         result = await db.execute(
-            select(TeamMember.id, TeamMember.user_id).where(TeamMember.id == uuid.UUID(auth.user_id))
+            select(TeamMember.id, TeamMember.user_id).where(TeamMember.id == uuid.UUID(auth.user_id)).limit(1)
         )
         row = result.one_or_none()
         if row is None:

--- a/backend/app/routers/workflow_executions.py
+++ b/backend/app/routers/workflow_executions.py
@@ -225,8 +225,9 @@ async def get_execution(
 
     agent_name: str | None = None
     if log.target_agent_id:
+        # team_members projection VIEW — multi-project agent N 행. name 동형이라 .limit(1)(아무 행 OK).
         ar = await db.execute(
-            select(TeamMember.name).where(TeamMember.id == log.target_agent_id)
+            select(TeamMember.name).where(TeamMember.id == log.target_agent_id).limit(1)
         )
         agent_name = ar.scalar_one_or_none()
 

--- a/backend/app/routers/ws_chat.py
+++ b/backend/app/routers/ws_chat.py
@@ -170,6 +170,7 @@ async def ws_chat_hub(
             select(TeamMember).where(
                 TeamMember.id == agent_id,
                 TeamMember.type == "agent",
+                TeamMember.is_active.is_(True),  # deactivated agent 는 DM room 비도달(정합)
             ).order_by(TeamMember.project_id).limit(1)
         )).scalar_one_or_none()
 

--- a/backend/app/routers/ws_chat.py
+++ b/backend/app/routers/ws_chat.py
@@ -42,10 +42,13 @@ async def _authenticate(api_key: str | None, token: str | None) -> TeamMember | 
             )).scalar_one_or_none()
             if not ak:
                 return None
+            # team_members 는 projection VIEW — 멀티프로젝트 grant 면 같은 id 가 N 행. 여기선 auth
+            # identity(.id/.org_id·동형) 해소라 .limit(1) 로 MultipleResultsFound 회피(아무 행 OK).
             return (await db.execute(
                 select(TeamMember)
                 .where(TeamMember.id == ak.team_member_id)
                 .where(TeamMember.is_active.is_(True))
+                .limit(1)
             )).scalar_one_or_none()
 
         if token:

--- a/backend/app/routers/ws_chat.py
+++ b/backend/app/routers/ws_chat.py
@@ -155,12 +155,19 @@ async def ws_chat_hub(
     logger.info("ws_chat: connected agent_id=%s caller=%s", agent_id, caller.id)
 
     # agent의 org_id/project_id 조회 (room 초기화용) — type='agent' 한정
+    # team_members 는 projection VIEW — 멀티프로젝트 grant 면 같은 agent_id 가 N 행이라 무필터
+    # scalar_one_or_none 은 MultipleResultsFound 로 깨진다. DM room 은 여기서 _get_or_create_conversation
+    # 으로 생성(project_id 가 입력)되므로 신규 DM 엔 도출할 pre-existing conversation project 가 없다.
+    # → deterministic grant-pick(order_by(project_id) limit 1)으로 크래시를 막고 안정적 default project
+    # 로 room 을 스코프한다. org_id 는 전 projection 행 동형이라 정확.
+    # ⚠️ known-limitation: 멀티프로젝트 agent 의 DM room 은 default(최저 project_id) project 로 스코프.
+    #   진짜 라우팅(기존 (agent,caller) DM 우선조회→그 conversation 의 project)은 follow-up story.
     async with async_session_factory() as db:
         agent_member = (await db.execute(
             select(TeamMember).where(
                 TeamMember.id == agent_id,
                 TeamMember.type == "agent",
-            )
+            ).order_by(TeamMember.project_id).limit(1)
         )).scalar_one_or_none()
 
     if agent_member is None:

--- a/backend/app/services/attachment_context.py
+++ b/backend/app/services/attachment_context.py
@@ -16,6 +16,7 @@ import asyncio
 import io
 import logging
 import os
+from datetime import timedelta
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +26,10 @@ _PUBLIC_PREFIX = f"https://storage.googleapis.com/{_BUCKET}/"
 _PER_ATTACHMENT_CAP = 8000   # §7-3 첨부당 자수 cap
 _TOTAL_CAP = 24000           # §7-3 총합 cap
 _TRUNC_MARK = "…(잘림)"
+
+# f3ccb40c 이미지-멀티모달: 이미지는 텍스트 추출 대신 단기 V4 read 서명 URL 을 payload 에 실어
+# 에이전트 런타임이 fetch→멀티모달 모델이 직접 view(백엔드 vision 안 함). 30분 = 에이전트 async 처리 윈도.
+_SIGNED_URL_TTL = timedelta(minutes=30)
 
 _DOC_EXTS = frozenset({"pdf", "docx", "txt", "csv", "md"})
 _IMAGE_EXTS = frozenset({"jpg", "jpeg", "png", "gif", "webp"})
@@ -80,6 +85,37 @@ async def _download_object(object_path: str) -> bytes:
     return await asyncio.to_thread(_blocking)
 
 
+async def _signed_read_url(object_path: str) -> str | None:
+    """scoped GCS 객체에 대한 단기 V4 read 서명 URL. 실패 시 None(best-effort).
+
+    Cloud Run ADC(키파일 없음)에서는 runtime SA 가 자신에 대해 signBlob(roles/iam.serviceAccountTokenCreator)
+    권한을 가지면 IAM SignBlob 으로 V4 서명이 가능하다(creds.refresh→service_account_email+access_token 전달).
+    blocking 호출은 thread 로 격리. 호출 전 _is_scoped_to_conversation 으로 IDOR 게이트를 통과한 path 만 받는다.
+    """
+
+    def _blocking() -> str:
+        import google.auth
+        from google.auth.transport.requests import Request as _AuthRequest
+        from google.cloud import storage
+
+        creds, _ = google.auth.default()
+        creds.refresh(_AuthRequest())  # access_token 확보(IAM SignBlob 용)
+        blob = storage.Client().bucket(_BUCKET).blob(object_path)
+        return blob.generate_signed_url(
+            version="v4",
+            expiration=_SIGNED_URL_TTL,
+            method="GET",
+            service_account_email=getattr(creds, "service_account_email", None),
+            access_token=creds.token,
+        )
+
+    try:
+        return await asyncio.to_thread(_blocking)
+    except Exception:
+        logger.warning("attachment_context: signed url 생성 실패 path=%s", object_path, exc_info=True)
+        return None
+
+
 def _extract_text(ext: str, data: bytes) -> str:
     """확장자별 텍스트 추출. 미지원/실패 시 빈 문자열."""
     if ext in ("txt", "csv", "md"):
@@ -113,18 +149,24 @@ async def build_attachment_context(
     *,
     project_id,
     conversation_id,
-) -> str:
-    """메시지 attachments(list of {url,name,content_type,size}) → 에이전트 주입용 텍스트 블록.
+) -> tuple[str, list[dict]]:
+    """메시지 attachments(list of {url,name,content_type,size}) → (에이전트 주입용 텍스트 블록, 이미지 목록).
 
-    문서=GCS fetch+추출, 이미지=메타 안내(v1), 미지원/실패=안내 라인. 총량 cap(헤더·마커·안내 라인
-    포함)·도달 시 중단. 빈 결과면 "" (주입 무영향). best-effort — 개별 첨부 실패는 안내 라인으로 흡수.
+    문서=GCS fetch+추출, 이미지=단기 V4 서명 URL(f3ccb40c·백엔드 vision 안 함), 미지원/실패=안내 라인.
+    총량 cap(헤더·마커·안내 라인 포함)·도달 시 중단. best-effort — 개별 첨부 실패는 안내 라인으로 흡수.
 
-    ⚠️ 보안: 문서 fetch 는 object path 가 **이 (project, conversation)에 스코프된 chat 첨부**일
-    때만 수행(_is_scoped_to_conversation). 타 대화/외부 객체 URL 은 거부(IDOR 차단·QA RC HIGH).
+    반환:
+      - text: content 에 주입할 텍스트 블록(이미지는 `![name](signed-url)` 마크다운 — 멀티모달 에이전트 fetch+view).
+        빈 결과면 "".
+      - images: 구조화 이미지 목록 `[{url, name, mime}]`(payload `images` 필드용·Hermes 등 런타임 clean 계약).
+
+    ⚠️ 보안: 문서 fetch·이미지 서명 모두 object path 가 **이 (project, conversation)에 스코프된 chat
+    첨부**일 때만 수행(_is_scoped_to_conversation). 타 대화/외부 객체 URL 은 거부(IDOR 차단·QA RC HIGH).
     """
     if not attachments:
-        return ""
+        return "", []
     blocks: list[str] = []
+    images: list[dict] = []
     total = len(_HEADER)  # 헤더도 총량에 카운트(LOW)
 
     def _append(line: str) -> bool:
@@ -149,10 +191,22 @@ async def build_attachment_context(
         ctype = (a.get("content_type") or "").strip()
         ext = _ext(name)
 
-        # 이미지 — v1 은 메타 안내(본격 분석=S2 백엔드 Vision 캡션)
+        # 이미지(f3ccb40c) — 백엔드 vision 안 함. scope 통과 객체에 단기 V4 서명 URL 발급 →
+        # content 엔 `![name](url)` 마크다운(멀티모달 에이전트 fetch+view) + images 목록(구조화 계약).
         if ctype.startswith("image/") or ext in _IMAGE_EXTS:
-            if not _append(f"[이미지 첨부: {name} ({ctype or 'image'}) — 이미지 분석은 준비 중]"):
+            obj = _canonical_object_path(a.get("url") or "")
+            if obj is None or not _is_scoped_to_conversation(obj, project_id, conversation_id):
+                if not _append(f"[이미지 첨부(접근 범위 밖): {name}]"):
+                    break
+                continue
+            signed = await _signed_read_url(obj)
+            if not signed:
+                if not _append(f"[이미지 첨부: {name} — URL 생성 실패]"):
+                    break
+                continue
+            if not _append(f"![{name}]({signed})"):
                 break
+            images.append({"url": signed, "name": name, "mime": ctype or f"image/{ext or 'png'}"})
             continue
 
         # 미지원 형식 안내
@@ -194,5 +248,5 @@ async def build_attachment_context(
             break
 
     if not blocks:
-        return ""
-    return _HEADER + "\n\n".join(blocks)
+        return "", images
+    return _HEADER + "\n\n".join(blocks), images

--- a/backend/app/services/channel_router.py
+++ b/backend/app/services/channel_router.py
@@ -47,10 +47,14 @@ async def route_message(
             raise ChannelRouterError(f"Message {message_id} not found")
 
         # 2. 발신자 type 확인
+        # ⚠️ team_members 는 0088 이후 projection VIEW — org-agent 멀티프로젝트 grant(project_access)면
+        # 같은 member.id 가 프로젝트 수만큼 행을 낸다. 무필터 scalar_one_or_none 은 MultipleResultsFound
+        # 로 route_message 전체를 깨 chat→agent dispatch 가 멈춘다. type 은 전 행 동형이라 .limit(1) 로
+        # 한 행만 취해 안전(_resolve_api_key 동일 패턴). 단일프로젝트 agent·휴먼은 1행이라 거동 무변경.
         sender_type: str | None = None
         if msg.sender_id:
             sender_type = (await db.execute(
-                select(TeamMember.type).where(TeamMember.id == msg.sender_id)
+                select(TeamMember.type).where(TeamMember.id == msg.sender_id).limit(1)
             )).scalar_one_or_none()
 
         # 3. conversation participants (발신자 제외)

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -245,8 +245,11 @@ async def deliver_conversation_message_webhook(
             sender_name = None
             if sender_id is not None:
                 from app.models.team import TeamMember
+                # team_members 는 projection VIEW — multi-project sender(owner 등·N projection 행)면
+                # 무필터 scalar_one_or_none 이 MultipleResultsFound → deliver_conversation_message_webhook
+                # 전체 크래시 → 전 수신자 미수신. name 은 전 행 동형이라 .limit(1) 로 안전(아무 행 OK).
                 sender_name = (await db.execute(
-                    select(TeamMember.name).where(TeamMember.id == sender_id)
+                    select(TeamMember.name).where(TeamMember.id == sender_id).limit(1)
                 )).scalar_one_or_none()
 
             # R2 S1(9d130c01): 첨부 내용을 에이전트-facing content 에 주입(균일·런타임 무변경).

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -257,6 +257,7 @@ async def deliver_conversation_message_webhook(
             # 스코프된 객체만(IDOR 차단). best-effort — 조회/추출 실패는 전달에 무영향.
             # MED(QA RC): 주입 없으면 원 content 그대로 보존(None→"" 변환 금지 — 기존 거동 무변경).
             effective_content = content
+            attachment_images: list[dict] = []  # f3ccb40c: payload images 필드(구조화·서명 URL)
             try:
                 from app.models.conversation import ConversationMessage
                 _atts = (await db.execute(
@@ -266,15 +267,16 @@ async def deliver_conversation_message_webhook(
                 )).scalar_one_or_none()
                 if _atts:
                     from app.services.attachment_context import build_attachment_context
-                    _ctx = await build_attachment_context(
+                    _ctx, attachment_images = await build_attachment_context(
                         _atts, project_id=project_id, conversation_id=conversation_id
                     )
                     if _ctx:
                         _base = content or ""
                         effective_content = (_base + _ctx) if _base else _ctx.lstrip()
+                    if _ctx or attachment_images:
                         logger.info(
-                            "attachment_context injected message_id=%s attachment_count=%d",
-                            message_id, len(_atts),
+                            "attachment_context injected message_id=%s attachment_count=%d images=%d",
+                            message_id, len(_atts), len(attachment_images),
                         )
             except Exception:
                 logger.warning(
@@ -295,6 +297,8 @@ async def deliver_conversation_message_webhook(
                 "org_id": str(org_id),
                 "conversation_title": conv_title,
                 "sender_name": sender_name,
+                # f3ccb40c: 이미지 첨부 구조화 목록([{url,name,mime}]·서명 URL·런타임 멀티모달 계약·additive).
+                "images": attachment_images,
             }
 
             for wh in target_webhooks:

--- a/backend/sprintable_mcp/api_client.py
+++ b/backend/sprintable_mcp/api_client.py
@@ -1,12 +1,28 @@
 """SprintableClient — httpx 기반 PM API HTTP 클라이언트."""
 from __future__ import annotations
 
+import contextvars
 import logging
 from typing import Any
 
 import httpx
 
 logger = logging.getLogger(__name__)
+
+# 85429ee0: per-call 프로젝트 override(org-agent 멀티프로젝트 grant). server._flat 가 tool-call 스코프로
+# set/reset. 설정 시 client.project_id(쿼리/바디) + X-Project-Id 헤더에 반영. 미설정 시 키 default(무회귀).
+_project_override: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "mcp_project_override", default=None
+)
+
+
+def set_project_override(project_id: str | None):
+    """per-call 프로젝트 override 설정 — 반환 token 으로 reset(server _flat wrapper 가 tool 호출 스코프로 사용)."""
+    return _project_override.set(project_id or None)
+
+
+def reset_project_override(token) -> None:
+    _project_override.reset(token)
 
 # 백엔드 에러 본문을 MCP 에러 문자열에 노출할 때, 비정상적으로 큰 body가
 # 에이전트 컨텍스트를 잠식하지 않도록 자르는 상한.
@@ -155,7 +171,8 @@ class SprintableClient:
 
     @property
     def project_id(self) -> str:
-        return self._project_id
+        # per-call override(85429ee0) 우선 — 없으면 키 default(무회귀).
+        return _project_override.get() or self._project_id
 
     async def request(
         self,
@@ -171,11 +188,17 @@ class SprintableClient:
             "x-agent-api-key": self._api_key,
             "Content-Type": "application/json",
         }
+        # 85429ee0: per-call override 시 X-Project-Id 헤더 전송 — 백엔드 get_verified_org_id 가
+        # has_project_access 로 멤버십 검증 후 그 프로젝트로 컨텍스트 전환(mutation 라우트). 미설정 시
+        # 헤더 미전송(키 default·무회귀).
+        _override = _project_override.get()
+        if _override:
+            headers["X-Project-Id"] = _override
 
-        # POST/PUT/PATCH body에 context 필드 자동 주입
+        # POST/PUT/PATCH body에 context 필드 자동 주입(project_id 는 override 반영된 effective).
         if method.upper() in ("POST", "PUT", "PATCH") and json is not None:
-            if not json.get("project_id") and self._project_id:
-                json = {**json, "project_id": self._project_id}
+            if not json.get("project_id") and self.project_id:
+                json = {**json, "project_id": self.project_id}
             if not json.get("org_id") and self._org_id:
                 json = {**json, "org_id": self._org_id}
             if not json.get("created_by") and self._member_id:

--- a/backend/sprintable_mcp/schemas.py
+++ b/backend/sprintable_mcp/schemas.py
@@ -69,8 +69,11 @@ class HypothesisConfirmStatus(str, Enum):
 class SprintableInput(BaseModel):
     """모든 Sprintable 도구 입력 공통 베이스.
 
-    project_id/org_id는 SprintableClient context에서 자동 주입하므로 스키마에서 제외.
+    org_id는 SprintableClient context에서 자동 주입. project_id는 **선택적 per-call override** —
+    org-agent 멀티프로젝트 grant(ProjectAccess) 시 특정 프로젝트를 타겟(미지정=키 default project·무회귀).
+    설정 시 client.project_id(쿼리/바디) + X-Project-Id 헤더에 반영(85429ee0).
     Optional 필드는 기본값 None → MCP schema required에서 제외.
     """
 
     model_config = ConfigDict(extra="ignore")
+    project_id: str | None = None

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -14,7 +14,7 @@ from mcp.types import TextContent
 from pydantic import BaseModel
 from pydantic.fields import PydanticUndefined
 
-from .api_client import client
+from .api_client import client, reset_project_override, set_project_override
 from .config import settings
 from .response import ok
 from .schemas import SprintableInput
@@ -172,12 +172,23 @@ def _flat(name: str, doc: str, input_cls: type[BaseModel], fn):
             )
         )
 
+    # 85429ee0: base SprintableInput.project_id(기본값 有)가 subclass 필수필드보다 앞서면
+    # inspect.Signature 가 "non-default argument follows default argument"로 깨진다 → 기본값 없는
+    # 파라미터를 앞으로 안정 정렬(MCP 는 keyword 호출이라 순서 변경 무해).
+    params.sort(key=lambda p: p.default is not inspect.Parameter.empty)
+
     async def wrapper(**kwargs):
         # E-MCP S2: call-time enforcement — 키 허용 밖 도구는 호출 차단(403-shape).
         await _load_scope()
         if not is_tool_allowed(name, _key_scope):
             return _denied(name)
-        result = await fn(input_cls(**kwargs))
+        # 85429ee0: per-call project_id override → contextvar(tool 호출 스코프). client.project_id +
+        # X-Project-Id 헤더에 반영(org-agent 멀티프로젝트 grant). 미지정이면 키 default(무회귀).
+        _tok = set_project_override(kwargs.get("project_id"))
+        try:
+            result = await fn(input_cls(**kwargs))
+        finally:
+            reset_project_override(_tok)
         asyncio.create_task(_heartbeat_fire_forget())
         return result
 

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -99,12 +99,16 @@ def test_all_expected_tools_registered():
     "sprintable_list_meetings",
     "sprintable_list_retro_sessions",
 ])
-def test_project_id_not_in_schema(tool_name: str):
-    """project_id/org_id는 context 자동 주입 — 스키마에 노출 금지."""
+def test_org_id_not_in_schema_project_id_optional(tool_name: str):
+    """org_id는 context 자동 주입 — 스키마 비노출. project_id는 85429ee0 후 **선택적 per-call override**
+    로 스키마에 노출(org-agent 멀티프로젝트 grant 타겟팅·미지정 시 키 default·무회귀)."""
     schema = _TOOLS[tool_name].parameters
     schema_str = str(schema)
-    assert "project_id" not in schema_str
-    assert "org_id" not in schema_str
+    assert "org_id" not in schema_str           # org 는 여전히 context 주입
+    assert "project_id" in schema_str           # 85429ee0: per-call override 로 노출
+    # required 아님(optional·미지정 시 default project)
+    required = schema.get("required", []) if isinstance(schema, dict) else []
+    assert "project_id" not in required
 
 
 @pytest.mark.parametrize("tool_name,optional_field", [

--- a/backend/tests/test_attachment_context.py
+++ b/backend/tests/test_attachment_context.py
@@ -1,4 +1,7 @@
-"""R2 S1: attachment_context.build_attachment_context — 분류/추출/cap/스코프(IDOR) (GCS·추출 mock)."""
+"""attachment_context.build_attachment_context — 분류/추출/cap/스코프(IDOR) + 이미지 서명 URL(f3ccb40c).
+
+반환 = (text, images). 문서=GCS fetch+추출, 이미지=단기 V4 서명 URL(백엔드 vision 안 함·scope IDOR 게이트).
+"""
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock
@@ -24,28 +27,69 @@ def _att(name, content_type="", url=None):
 
 
 async def _build(ac, attachments):
+    """(text, images) 튜플 반환."""
     return await ac.build_attachment_context(
         attachments, project_id=PROJ, conversation_id=CONV
     )
+
+
+async def _text(ac, attachments):
+    text, _images = await _build(ac, attachments)
+    return text
 
 
 @pytest.mark.anyio
 async def test_empty_returns_blank():
     from app.services import attachment_context as ac
 
-    assert await _build(ac, None) == ""
-    assert await _build(ac, []) == ""
+    assert await _build(ac, None) == ("", [])
+    assert await _build(ac, []) == ("", [])
 
 
+# ── 이미지(f3ccb40c): scope 통과 → 서명 URL 마크다운 + 구조화 images ──────────────
 @pytest.mark.anyio
-async def test_image_meta_line_no_fetch(monkeypatch):
+async def test_image_emits_signed_url_markdown_and_struct(monkeypatch):
     from app.services import attachment_context as ac
 
     fetch = AsyncMock()
     monkeypatch.setattr(ac, "_download_object", fetch)
-    out = await _build(ac, [_att("chart.png", "image/png")])
-    assert "이미지 첨부: chart.png" in out
-    fetch.assert_not_awaited()
+    monkeypatch.setattr(ac, "_signed_read_url", AsyncMock(return_value="https://signed/url?sig=abc"))
+
+    text, images = await _build(ac, [_att("chart.png", "image/png")])
+
+    # content: 마크다운 이미지 링크(멀티모달 에이전트 fetch+view)
+    assert "![chart.png](https://signed/url?sig=abc)" in text
+    assert "이미지 분석은 준비 중" not in text  # 옛 placeholder 제거
+    # 구조화 images 필드
+    assert images == [{"url": "https://signed/url?sig=abc", "name": "chart.png", "mime": "image/png"}]
+    fetch.assert_not_awaited()  # 이미지는 백엔드 다운로드/vision 안 함
+
+
+@pytest.mark.anyio
+async def test_image_out_of_scope_rejected_no_sign(monkeypatch):
+    """타 대화 이미지 객체 → scope 밖 → 서명 안 함·거부 라인·images 비움(IDOR 차단)."""
+    from app.services import attachment_context as ac
+
+    sign = AsyncMock(return_value="https://should/not/be/called")
+    monkeypatch.setattr(ac, "_signed_read_url", sign)
+
+    text, images = await _build(
+        ac, [_att("leak.png", "image/png", url=f"chat/{PROJ}/OTHERCONV/leak.png")]
+    )
+    assert "접근 범위 밖): leak.png" in text
+    assert images == []
+    sign.assert_not_awaited()  # scope 밖은 서명 자체를 안 함
+
+
+@pytest.mark.anyio
+async def test_image_sign_failure_guidance(monkeypatch):
+    """서명 URL 생성 실패(None) → 안내 라인·images 비움(전달 무중단)."""
+    from app.services import attachment_context as ac
+
+    monkeypatch.setattr(ac, "_signed_read_url", AsyncMock(return_value=None))
+    text, images = await _build(ac, [_att("x.png", "image/png")])
+    assert "URL 생성 실패" in text
+    assert images == []
 
 
 @pytest.mark.anyio
@@ -54,7 +98,7 @@ async def test_unsupported_format_line(monkeypatch):
 
     fetch = AsyncMock()
     monkeypatch.setattr(ac, "_download_object", fetch)
-    out = await _build(ac, [_att("data.bin", "application/octet-stream")])
+    out = await _text(ac, [_att("data.bin", "application/octet-stream")])
     assert "미지원 형식): data.bin" in out
     fetch.assert_not_awaited()
 
@@ -65,7 +109,7 @@ async def test_doc_extraction_injected(monkeypatch):
 
     monkeypatch.setattr(ac, "_download_object", AsyncMock(return_value=b"x"))
     monkeypatch.setattr(ac, "_extract_text", MagicMock(return_value="hello world"))
-    out = await _build(ac, [_att("report.pdf", "application/pdf")])
+    out = await _text(ac, [_att("report.pdf", "application/pdf")])
     assert "--- 첨부 내용 ---" in out
     assert "[첨부: report.pdf]" in out
     assert "hello world" in out
@@ -81,13 +125,12 @@ async def test_other_conversation_url_rejected_no_fetch(monkeypatch):
 
     fetch = AsyncMock(return_value=b"secret")
     monkeypatch.setattr(ac, "_download_object", fetch)
-    # 같은 project 지만 *다른 conversation* 객체를 첨부에 심음
-    out = await _build(
+    out = await _text(
         ac, [_att("leak.pdf", "application/pdf", url=f"chat/{PROJ}/OTHERCONV/leak.pdf")]
     )
     assert "접근 범위 밖): leak.pdf" in out
     assert "secret" not in out
-    fetch.assert_not_awaited()  # 스코프 밖은 다운로드 자체를 안 함
+    fetch.assert_not_awaited()
 
 
 @pytest.mark.anyio
@@ -96,7 +139,7 @@ async def test_external_url_rejected(monkeypatch):
 
     fetch = AsyncMock()
     monkeypatch.setattr(ac, "_download_object", fetch)
-    out = await _build(
+    out = await _text(
         ac, [{"name": "x.txt", "content_type": "text/plain", "url": "https://evil.com/x.txt"}]
     )
     assert "접근 범위 밖): x.txt" in out
@@ -110,7 +153,7 @@ async def test_story_path_rejected(monkeypatch):
 
     fetch = AsyncMock()
     monkeypatch.setattr(ac, "_download_object", fetch)
-    out = await _build(
+    out = await _text(
         ac, [_att("s.pdf", "application/pdf", url=f"story/{PROJ}/story123/s.pdf")]
     )
     assert "접근 범위 밖): s.pdf" in out
@@ -126,7 +169,7 @@ async def test_per_attachment_cap_truncates(monkeypatch):
 
     monkeypatch.setattr(ac, "_download_object", AsyncMock(return_value=b"x"))
     monkeypatch.setattr(ac, "_extract_text", MagicMock(return_value="a" * 9000))
-    out = await _build(ac, [_att("big.txt", "text/plain")])
+    out = await _text(ac, [_att("big.txt", "text/plain")])
     assert ac._TRUNC_MARK in out
     body = out.split("[첨부: big.txt]\n", 1)[1]
     assert len(body) <= ac._PER_ATTACHMENT_CAP  # 마커 포함 cap 이내
@@ -139,7 +182,7 @@ async def test_total_cap_includes_markers_and_stops(monkeypatch):
     monkeypatch.setattr(ac, "_download_object", AsyncMock(return_value=b"x"))
     monkeypatch.setattr(ac, "_extract_text", MagicMock(return_value="a" * 8000))
     atts = [_att(f"d{i}.txt", "text/plain") for i in range(5)]
-    out = await _build(ac, atts)
+    out = await _text(ac, atts)
     assert len(out) <= ac._TOTAL_CAP  # 헤더·마커·구분자 포함 총량 엄수
     assert "d4.txt" not in out  # 총량 한도로 후속 첨부 생략(누적 중단)
 
@@ -147,12 +190,12 @@ async def test_total_cap_includes_markers_and_stops(monkeypatch):
 @pytest.mark.anyio
 async def test_first_line_overflow_bounded(monkeypatch):
     """QA RC LOW: 첫 첨부(blocks 빈) 라인이 24k 초과해도 총량 ≤ cap (blocks 가드 제거 검증).
-    긴 파일명 이미지 라인(미fetch)으로 첫 라인만으로 초과 유발."""
+    긴 파일명 이미지 마크다운 라인으로 첫 라인만으로 초과 유발."""
     from app.services import attachment_context as ac
 
-    monkeypatch.setattr(ac, "_download_object", AsyncMock())
+    monkeypatch.setattr(ac, "_signed_read_url", AsyncMock(return_value="https://s/u"))
     huge_name = "x" * (ac._TOTAL_CAP + 5000) + ".png"
-    out = await _build(ac, [_att(huge_name, "image/png")])
+    out = await _text(ac, [_att(huge_name, "image/png")])
     assert len(out) <= ac._TOTAL_CAP  # 첫 라인도 한도 엄수
 
 
@@ -161,7 +204,7 @@ async def test_fetch_failure_guidance(monkeypatch):
     from app.services import attachment_context as ac
 
     monkeypatch.setattr(ac, "_download_object", AsyncMock(side_effect=RuntimeError("gcs down")))
-    out = await _build(ac, [_att("report.pdf", "application/pdf")])
+    out = await _text(ac, [_att("report.pdf", "application/pdf")])
     assert "추출 실패): report.pdf" in out
 
 
@@ -171,5 +214,5 @@ async def test_empty_text_guidance(monkeypatch):
 
     monkeypatch.setattr(ac, "_download_object", AsyncMock(return_value=b""))
     monkeypatch.setattr(ac, "_extract_text", MagicMock(return_value="   "))
-    out = await _build(ac, [_att("empty.txt", "text/plain")])
+    out = await _text(ac, [_att("empty.txt", "text/plain")])
     assert "추출 텍스트 없음" in out

--- a/backend/tests/test_channel_get_or_create_conversation_args.py
+++ b/backend/tests/test_channel_get_or_create_conversation_args.py
@@ -1,0 +1,79 @@
+"""회귀 — channel._persist_and_broadcast 가 ws_chat._get_or_create_conversation 을 올바른 4인자
+(agent_id, caller_id, org_id, project_id)로 호출하는지.
+
+배경: ws_chat._get_or_create_conversation 시그니처가 caller_id 추가로 4인자가 됐는데 channel 호출부가
+3인자(agent_id, org_id, project_id)로 남아(한쪽만 전환) → caller_id 누락 + 인자 미스얼라인 →
+/deliver·/upload 호출 시 TypeError. #1581 codex CRITICAL(pre-existing≠benign)로 적출.
+"""
+from __future__ import annotations
+
+import inspect
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_persist_passes_caller_id_to_get_or_create():
+    """_persist_and_broadcast → _get_or_create_conversation(agent_id, caller.id, org_id, project_id)."""
+    from app.routers import channel
+
+    captured: dict = {}
+
+    class _Stop(Exception):
+        pass
+
+    async def _fake_goc(*args):
+        captured["args"] = args
+        raise _Stop()  # 호출 직후 short-circuit — downstream(msg/broadcast) mock 불요
+
+    agent = MagicMock()
+    agent.org_id = "ORG"
+    agent.project_id = "PROJ"
+    caller = MagicMock()
+    caller.id = "CALLER_ID"
+    agent_id = uuid.uuid4()
+
+    with patch.object(channel, "_get_or_create_conversation", _fake_goc):
+        with pytest.raises(_Stop):
+            await channel._persist_and_broadcast(agent_id, agent, caller, "hi")
+
+    # 4인자·올바른 정렬: caller_id 자리에 caller.id(org_id 아님)·project_id 누락 0
+    assert captured["args"] == (agent_id, "CALLER_ID", "ORG", "PROJ")
+
+
+def test_call_arity_matches_callee():
+    """callee 시그니처(4 위치인자)와 caller 인자수 일치 — 미스얼라인 회귀 방지."""
+    from app.routers.ws_chat import _get_or_create_conversation
+
+    params = list(inspect.signature(_get_or_create_conversation).parameters.values())
+    positional = [p for p in params if p.default is inspect.Parameter.empty]
+    assert len(positional) == 4, "callee 시그니처 변경 — channel 호출부도 동반 갱신 필요"
+
+
+# ── is_active 정합: agent 해소 lookup 은 deactivated agent 비도달(crash 아닌 soft correctness 갭) ──
+@pytest.mark.parametrize("name", [
+    "ws_chat.ws_chat_hub",
+    "channel._resolve_agent",
+    "agent_runs.create_agent_run",
+    "agent_gateway.agent_stream",
+])
+def test_agent_lookup_filters_is_active(name: str):
+    """agent 해소 쿼리는 is_active.is_(True) 로 deactivated agent 를 배제(정합·ws_chat:46/agent_inbox 동형)."""
+    from app.routers import agent_gateway, agent_runs, channel, ws_chat
+
+    fns = {
+        "ws_chat.ws_chat_hub": ws_chat.ws_chat_hub,
+        "channel._resolve_agent": channel._resolve_agent,
+        "agent_runs.create_agent_run": agent_runs.create_agent_run,
+        "agent_gateway.agent_stream": agent_gateway.agent_stream,
+    }
+    src = inspect.getsource(fns[name])
+    assert "is_active.is_(True)" in src, \
+        f"{name}: is_active 필터 누락 — deactivated agent 도달 가능(정합 회귀)"

--- a/backend/tests/test_channel_router_multiproject_sender.py
+++ b/backend/tests/test_channel_router_multiproject_sender.py
@@ -1,0 +1,70 @@
+"""채널 라우터 회귀 — org-agent 멀티프로젝트 sender 가 team_members VIEW 다중 행을 내도
+route_message 가 MultipleResultsFound 로 안 깨지고 dispatch 되는지(sender_type 쿼리 .limit(1)).
+
+배경: team_members 는 0088 이후 projection VIEW. org-agent 멀티프로젝트 grant(project_access)면
+같은 member.id 가 프로젝트 수만큼 행 → sender_type 의 무필터 scalar_one_or_none 이 MultipleResultsFound
+→ route_message 전체가 ChannelRouterError 로 깨져 chat→agent dispatch 정지. .limit(1) 로 봉합.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _scalar(val):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = val
+    return r
+
+
+def _scalars(items):
+    r = MagicMock()
+    r.scalars.return_value.all.return_value = items
+    return r
+
+
+def _all(rows):
+    r = MagicMock()
+    r.all.return_value = rows
+    return r
+
+
+@pytest.mark.anyio
+async def test_multiproject_agent_sender_dispatches_without_crash():
+    """멀티프로젝트 agent 발신 → sender_type .limit(1)='agent' → agent↔agent SSE dispatch(크래시 0)."""
+    from app.services.channel_router import route_message
+
+    sender = uuid.uuid4()       # 멀티프로젝트 agent(team_members 뷰 다중행)
+    recipient = uuid.uuid4()    # agent 수신자
+    conv = uuid.uuid4()
+    proj = uuid.uuid4()
+
+    msg = MagicMock()
+    msg.id = uuid.uuid4()
+    msg.sender_id = sender
+    msg.conversation_id = conv
+    msg.thread_id = None
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=[
+        _scalar(msg),                       # 1 메시지
+        _scalar("agent"),                   # 2 sender_type — .limit(1)로 단일 행(뷰 다중에도 안전)
+        _scalars([sender, recipient]),      # 3 participants(발신자 포함)
+        _all([(recipient, "agent")]),       # 4 수신자 type 배치
+        _scalar(proj),                      # 5 conv project_id
+        _scalars([]),                       # 6 preferences
+    ])
+
+    decisions = await route_message(msg.id, db)
+    # 발신자 제외·agent↔agent 강제 SSE → 1 decision(크래시/ChannelRouterError 없이)
+    assert len(decisions) == 1
+    assert decisions[0].member_id == recipient
+    assert decisions[0].channel == "sse"
+    assert decisions[0].reason == "agent-to-agent forced sse"

--- a/backend/tests/test_mcp_per_call_project_85429ee0.py
+++ b/backend/tests/test_mcp_per_call_project_85429ee0.py
@@ -1,0 +1,116 @@
+"""85429ee0: MCP per-call project_id override(org-agent 멀티프로젝트) — contextvar·X-Project-Id·signature."""
+from __future__ import annotations
+
+import inspect
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _seed_client():
+    from sprintable_mcp.api_client import client
+
+    client._base_url = "http://x"
+    client._api_key = "k"
+    client._project_id = "DEFAULT"
+    client._org_id = "ORG"
+    client._member_id = "MEM"
+    return client
+
+
+def test_project_override_contextvar():
+    from sprintable_mcp.api_client import (
+        client,
+        reset_project_override,
+        set_project_override,
+    )
+
+    _seed_client()
+    assert client.project_id == "DEFAULT"  # override 없음 → 키 default
+    tok = set_project_override("OVR")
+    assert client.project_id == "OVR"  # override 우선
+    reset_project_override(tok)
+    assert client.project_id == "DEFAULT"  # reset → default
+    tok2 = set_project_override(None)  # None → default(무회귀)
+    assert client.project_id == "DEFAULT"
+    reset_project_override(tok2)
+
+
+def test_sprintable_input_has_project_id():
+    from sprintable_mcp.schemas import SprintableInput
+
+    assert "project_id" in SprintableInput.model_fields
+    assert SprintableInput.model_fields["project_id"].default is None  # optional·무회귀
+
+
+def test_flat_signature_required_before_default():
+    """base project_id(기본값 有)가 subclass 필수필드보다 앞서면 signature 깨짐 → 정렬로 봉합."""
+    from sprintable_mcp.server import _flat
+    from sprintable_mcp.tools.stories import AddStoryInput, add_story
+
+    w = _flat("add_story", "doc", AddStoryInput, add_story)
+    sig = inspect.signature(w)  # 깨지면 여기서 ValueError
+    names = list(sig.parameters)
+    assert "project_id" in names
+    assert names[0] == "title"  # 필수필드가 앞(기본값 없음)
+    # 기본값 없는 param 이 기본값 있는 param 보다 앞(inspect.Signature 규칙)
+    seen_default = False
+    for n in names:
+        has_default = sig.parameters[n].default is not inspect.Parameter.empty
+        if has_default:
+            seen_default = True
+        else:
+            assert not seen_default, f"non-default '{n}' follows default"
+
+
+@pytest.mark.anyio
+async def test_request_sets_x_project_id_on_override():
+    from sprintable_mcp.api_client import (
+        client,
+        reset_project_override,
+        set_project_override,
+    )
+
+    _seed_client()
+    captured: dict = {}
+
+    class _Resp:
+        status_code = 200
+        is_success = True
+        text = "{}"
+
+        def json(self):
+            return {"ok": 1}
+
+    class _FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def request(self, method, url, json=None, params=None, headers=None):
+            captured["headers"] = headers
+            captured["params"] = params
+            captured["json"] = json
+            return _Resp()
+
+    with patch("sprintable_mcp.api_client.httpx.AsyncClient", return_value=_FakeClient()):
+        # override 없음 → X-Project-Id 미전송·effective=default
+        await client.request("GET", "/api/v2/stories", params={"project_id": client.project_id})
+        assert "X-Project-Id" not in captured["headers"]
+        assert captured["params"]["project_id"] == "DEFAULT"
+
+        # override 있음 → X-Project-Id 전송·effective=override(쿼리·바디)
+        tok = set_project_override("OVR")
+        await client.request("GET", "/api/v2/stories", params={"project_id": client.project_id})
+        assert captured["headers"].get("X-Project-Id") == "OVR"
+        assert captured["params"]["project_id"] == "OVR"
+        await client.request("POST", "/api/v2/stories", json={"title": "t"})
+        assert captured["json"]["project_id"] == "OVR"  # body 주입도 effective
+        reset_project_override(tok)

--- a/backend/tests/test_sweep_multiproject_teammember_limit.py
+++ b/backend/tests/test_sweep_multiproject_teammember_limit.py
@@ -1,0 +1,96 @@
+"""광역 sweep 회귀 — team_members projection VIEW 다중행(org-agent 멀티프로젝트 grant)에서
+TeamMember.id == X scalar_one_or_none 이 MultipleResultsFound 로 안 깨지게 .limit(1) 가드.
+
+Ⓐ 분류(identity/type/org_id 동형 소비 → .limit(1) 안전·아무 projection 행 OK):
+  - channel._resolve_agent          (.org_id 소비)
+  - agent_gateway.agent_stream      (.org_id 소비·agent CONNECT 경로)
+  - agent_runs.create_agent_run     (select org_id)
+  - ws_chat._authenticate           (auth identity)
+
+#1579(channel_router.route_message sender_type)와 동일 패턴의 잔여 site 봉쇄.
+project_id 를 소비하는 Ⓑ(agent_inbox/ws_chat room init)는 컨텍스트-derive 가 정답이라 별도 처리.
+"""
+from __future__ import annotations
+
+import inspect
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── Ⓐ 4 site 소스 가드: TeamMember.id 쿼리에 .limit(1) 유지 ──────────────────────
+def _get_func():
+    from app.routers import agent_gateway, agent_runs, channel, ws_chat
+
+    return {
+        "channel._resolve_agent": channel._resolve_agent,
+        "agent_gateway.agent_stream": agent_gateway.agent_stream,
+        "agent_runs.create_agent_run": agent_runs.create_agent_run,
+        "ws_chat._authenticate": ws_chat._authenticate,
+    }
+
+
+# identity/type/org_id 만 소비하는 진짜 Ⓐ 3곳 → .limit(1)(아무 행 OK).
+# channel._resolve_agent 는 .project_id 도 소비(_persist_and_broadcast → DM room)라 Ⓑ 로 재분류 →
+# 아래 deterministic 가드로 별도 검증.
+@pytest.mark.parametrize("name", [
+    "agent_gateway.agent_stream",
+    "agent_runs.create_agent_run",
+    "ws_chat._authenticate",
+])
+def test_teammember_query_has_limit_guard(name: str):
+    """각 Ⓐ 함수 소스에 TeamMember 쿼리 + .limit(1) 동시 존재(가드 제거 회귀 방지)."""
+    fn = _get_func()[name]
+    src = inspect.getsource(fn)
+    assert "TeamMember" in src, f"{name}: TeamMember 쿼리 사라짐(테스트 갱신 필요)"
+    assert ".limit(1)" in src, f"{name}: .limit(1) 가드 누락 — 멀티프로젝트 agent 크래시 회귀"
+
+
+def test_channel_resolve_agent_is_deterministic_grant_pick():
+    """channel._resolve_agent 는 .project_id 소비(Ⓑ) → order_by(project_id)+limit(1)+known-limitation."""
+    from app.routers import channel
+
+    src = inspect.getsource(channel._resolve_agent)
+    assert "order_by(TeamMember.project_id)" in src, \
+        "channel._resolve_agent: order_by(project_id) 누락 — project_id 비결정적(틀린 프로젝트)"
+    assert ".limit(1)" in src, "channel._resolve_agent: .limit(1) 누락 — MultipleResultsFound 회귀"
+    assert "known-limitation" in src, "channel._resolve_agent: known-limitation 주석 누락"
+
+
+# ── 행동 테스트: 멀티프로젝트 agent(뷰 N행)도 _resolve_agent 가 크래시 없이 해소 ──────
+@pytest.mark.anyio
+async def test_resolve_agent_multiproject_no_crash():
+    """멀티프로젝트 agent → .limit(1) 로 단일 행 → org 검증 통과(MultipleResultsFound 0)."""
+    from app.routers import channel
+
+    agent = MagicMock()
+    agent.org_id = "ORG"
+    agent.type = "agent"
+    caller = MagicMock()
+    caller.org_id = "ORG"
+
+    class _Result:
+        def scalar_one_or_none(self):
+            return agent  # .limit(1) 결과(뷰 N행이어도 1행)
+
+    class _DB:
+        async def execute(self, *a, **k):
+            return _Result()
+
+    class _Factory:
+        async def __aenter__(self):
+            return _DB()
+
+        async def __aexit__(self, *a):
+            return False
+
+    with patch.object(channel, "async_session_factory", lambda: _Factory()):
+        result = await channel._resolve_agent(uuid.uuid4(), caller)
+
+    assert result is agent  # 해소 성공·org 동형 검증 통과

--- a/backend/tests/test_sweep_multiproject_teammember_orderby.py
+++ b/backend/tests/test_sweep_multiproject_teammember_orderby.py
@@ -1,0 +1,41 @@
+"""광역 sweep Ⓑ stopgap 회귀 — project_id 를 소비하는 사이트는 임의 .limit(1)(틀린 프로젝트 위험)
+대신 deterministic grant-pick(order_by(project_id).limit(1))으로 멀티프로젝트 agent 크래시를 막고
+안정적 default project 로 라우팅.
+
+대상(project_id 소비):
+  - agent_inbox.receive_inbox_webhook  (Event.project_id 적재)
+  - ws_chat.ws_chat_hub                (DM room project 스코프)
+
+true 라우팅(payload-project / 기존-conversation derive)은 follow-up story. 여기선 결정적 stopgap.
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+def _get_func():
+    from app.routers import agent_inbox, ws_chat
+
+    return {
+        "agent_inbox.receive_inbox_webhook": agent_inbox.receive_inbox_webhook,
+        "ws_chat.ws_chat_hub": ws_chat.ws_chat_hub,
+    }
+
+
+@pytest.mark.parametrize("name", [
+    "agent_inbox.receive_inbox_webhook",
+    "ws_chat.ws_chat_hub",
+])
+def test_project_id_site_uses_deterministic_grant_pick(name: str):
+    """project_id 소비 사이트는 order_by(project_id)+limit(1)로 결정적(MultipleResultsFound 0·non-random)."""
+    fn = _get_func()[name]
+    src = inspect.getsource(fn)
+    assert "TeamMember" in src, f"{name}: TeamMember 쿼리 사라짐(테스트 갱신 필요)"
+    # 결정적 grant-pick: order_by(project_id) + limit(1) 동시 — 임의 행(틀린 프로젝트) 방지
+    assert "order_by(TeamMember.project_id)" in src, \
+        f"{name}: order_by(project_id) 누락 — 멀티프로젝트 agent 라우팅이 비결정적/크래시"
+    assert ".limit(1)" in src, f"{name}: .limit(1) 누락 — MultipleResultsFound 회귀"
+    # known-limitation 주석 박제(stopgap 의도·follow-up 추적)
+    assert "known-limitation" in src, f"{name}: known-limitation 주석 누락(stopgap 의도 박제 필요)"

--- a/backend/tests/test_sweep_multiproject_teammember_services.py
+++ b/backend/tests/test_sweep_multiproject_teammember_services.py
@@ -1,0 +1,60 @@
+"""광역 sweep 2차 — 라우터 외(services/repositories/dependencies)의 TeamMember.id scalar 잔여 site.
+
+1차 sweep(#1581/#1583/#1585)이 라우터만 드릴다운해 놓친 site. multi-project SENDER(선생님=owner·N
+projection 행)가 deliver_conversation_message_webhook 의 sender_name 조회(.limit 없음)서 MultipleResultsFound
+→ 전 수신자 미수신(인앱 메시지 P0). exhaustive grep 으로 잔여 전수 봉쇄.
+
+CRASH → .limit(1)(전 행 동형 컬럼 소비):
+  - conversation_webhook.deliver_conversation_message_webhook  (sender name·P0)
+  - workflow_executions.get_execution                          (agent name)
+  - notifications._resolve_notification_user_id                (id/user_id)
+  - ownership.assert_agent_owner                               (created_by ownership guard)
+
+SAFE(project_id == 필터로 1행 확정·무변경):
+  - current_project.set_current_project / reward.create_reward
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+def _fns():
+    from app.dependencies import ownership
+    from app.routers import notifications, workflow_executions
+    from app.services import conversation_webhook
+
+    return {
+        "conversation_webhook.deliver_conversation_message_webhook":
+            conversation_webhook.deliver_conversation_message_webhook,
+        "workflow_executions.get_execution": workflow_executions.get_execution,
+        "notifications._resolve_notification_user_id": notifications._resolve_notification_user_id,
+        "ownership.assert_agent_owner": ownership.assert_agent_owner,
+    }
+
+
+@pytest.mark.parametrize("name", [
+    "conversation_webhook.deliver_conversation_message_webhook",
+    "workflow_executions.get_execution",
+    "notifications._resolve_notification_user_id",
+    "ownership.assert_agent_owner",
+])
+def test_teammember_scalar_site_has_limit(name: str):
+    """각 잔여 site 가 TeamMember.id scalar 조회에 .limit(1) — multi-project MultipleResultsFound 회귀 방지."""
+    src = inspect.getsource(_fns()[name])
+    assert "TeamMember" in src, f"{name}: TeamMember 쿼리 사라짐(테스트 갱신 필요)"
+    assert ".limit(1)" in src, f"{name}: .limit(1) 누락 — multi-project 행에서 MultipleResultsFound 크래시"
+
+
+@pytest.mark.parametrize("module,fn,expr", [
+    ("app.routers.current_project", "set_current_project", "TeamMember.project_id == body.project_id"),
+    ("app.repositories.reward", None, "TeamMember.project_id == project_id"),
+])
+def test_safe_sites_disambiguated_by_project_filter(module: str, fn: str, expr: str):
+    """SAFE 분류 site 는 project_id == 필터로 1행 확정(disambig) — .limit 없이도 안전함을 박제."""
+    import importlib
+
+    mod = importlib.import_module(module)
+    src = inspect.getsource(mod)
+    assert expr in src, f"{module}: '{expr}' disambig 필터 사라짐 — 재분류 필요(이제 crash-prone)"


### PR DESCRIPTION
선생님 승인 🅰 consolidated prod 릴리스. dev 완료·prod 미반영분 일괄: af8d3641(TTL60+쿠키7곳+single-flight+graceful UX·#1577/#1578/#1580)·#1585(channel:68 caller_id TypeError+is_active)·#1588(이미지-멀티모달 V4 서명URL)·#1576(MCP per-call). 마이그레이션 0(전부 코드). dispatch P0 fix는 이미 prod cherry-pick(#1582/#1584/#1587)·develop 원본과 reconcile. dev CI green·e2e 검증 완.

🤖 Generated with [Claude Code](https://claude.com/claude-code)