### PR TITLE
feat(chat): 멀티프로젝트 inbound true-routing (agent_inbox payload·ws_chat DM) — 2c457a06

### DIFF
--- a/backend/app/routers/agent_inbox.py
+++ b/backend/app/routers/agent_inbox.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import logging
 import uuid
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
@@ -20,6 +21,7 @@ from app.dependencies.database import get_db
 from app.models.event import Event
 from app.models.team import TeamMember
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v2/agent-inbox", tags=["agent-inbox"])
 
 
@@ -46,30 +48,43 @@ async def receive_inbox_webhook(
     if not _verify_signature(raw_body, x_sprintable_signature):
         raise HTTPException(status_code=401, detail="Invalid webhook signature")
 
-    # team_members 는 projection VIEW — org-agent 멀티프로젝트 grant 면 같은 agent_id 가 N 행이라
-    # 무필터 one_or_none 은 MultipleResultsFound 로 깨진다. 이 inbox webhook 은 단일 글로벌 secret
-    # (per-webhook-config 없음)이고 members anchor 엔 home project 가 없어 "올바른" project 를 도출할
-    # 컨텍스트가 없다. → deterministic grant-pick(order_by(project_id) limit 1)으로 크래시를 막고
-    # 안정적 default project 로 Event 를 적재한다.
-    # ⚠️ known-limitation: 멀티프로젝트 agent inbox 의 project 라우팅은 default(최저 project_id) 고정.
-    #   진짜 라우팅(payload 가 타겟 project 명시)은 follow-up story(멀티프로젝트 inbox routing).
-    result = await db.execute(
+    # 2c457a06 true-routing: 에이전트의 전 grant 조회(team_members projection VIEW — 멀티프로젝트면
+    # org_id 동형·project_id 다양). payload 가 타겟 project_id 를 **명시**하고 그게 grant 에 속하면 그
+    # project 로 Event 라우팅, 아니면 deterministic default(최저 project_id). org_id 는 전 행 동형.
+    rows = (await db.execute(
         select(TeamMember.org_id, TeamMember.project_id).where(
             TeamMember.id == agent_id,
             TeamMember.type == "agent",
             TeamMember.is_active.is_(True),
-        ).order_by(TeamMember.project_id).limit(1)
-    )
-    row = result.one_or_none()
-    if row is None:
+        ).order_by(TeamMember.project_id)
+    )).all()
+    if not rows:
         raise HTTPException(status_code=404, detail="Agent not found")
-
-    org_id, project_id = row
+    org_id = rows[0][0]
+    granted_project_ids = [r[1] for r in rows]
 
     try:
         payload: dict = json.loads(raw_body) if raw_body else {}
     except (ValueError, UnicodeDecodeError):
         payload = {"raw": raw_body.decode("utf-8", errors="replace")}
+
+    # 명시 project_id 우선 — 단 ⚠️ grant 에 속한 project 만 허용(외부 발신자가 임의 project 로 Event 를
+    # 심는 IDOR 차단). 미명시/미grant/파싱불가 = deterministic default(전달은 무중단·default 도 agent
+    # 가 속한 project 라 안전). 결정: 미grant 명시값은 reject 아닌 default fallback(best-effort 전달 우선).
+    project_id = granted_project_ids[0]
+    _raw_pid = payload.get("project_id")
+    if _raw_pid:
+        try:
+            _req_pid = uuid.UUID(str(_raw_pid))
+            if _req_pid in granted_project_ids:
+                project_id = _req_pid
+            else:
+                logger.warning(
+                    "agent_inbox: payload project_id=%s 가 agent=%s grant 밖 — default 라우팅",
+                    _req_pid, agent_id,
+                )
+        except (ValueError, TypeError):
+            logger.warning("agent_inbox: payload project_id 파싱 실패(%r) — default 라우팅", _raw_pid)
 
     event_type = str(payload.get("event_type", "inbox_webhook"))
     source_entity_type: str | None = payload.get("source_entity_type")

--- a/backend/app/routers/ws_chat.py
+++ b/backend/app/routers/ws_chat.py
@@ -76,9 +76,15 @@ async def _get_or_create_conversation(
     agent_id: uuid.UUID,
     caller_id: uuid.UUID,
     org_id: uuid.UUID,
-    project_id: uuid.UUID,
+    default_project_id: uuid.UUID,
 ) -> uuid.UUID:
-    """에이전트↔사용자 쌍의 DM conversation 조회 또는 생성. conversation.id 반환."""
+    """에이전트↔사용자 쌍의 DM conversation 조회 또는 생성. conversation.id 반환.
+
+    2c457a06 true-routing: 기존 (agent, caller) DM 이 있으면 **그 conversation 의 project 를 그대로**
+    쓴다(대화가 자기 project 스코프를 소유·임의 grant row 아님·[[Member-SSOT No team_member Coercion]]).
+    신규 생성 시에만 default_project_id(멀티프로젝트 agent 의 deterministic default) 사용. 다중 DM
+    (멀티룸 정책) 공존 시 최古(created_at)=canonical 결정적 선택.
+    """
     async with async_session_factory() as db:
         # 에이전트가 참가한 conversation_id 서브쿼리
         agent_conv_ids = (
@@ -86,7 +92,7 @@ async def _get_or_create_conversation(
             .where(ConversationParticipant.member_id == agent_id)
             .scalar_subquery()
         )
-        # 두 멤버가 모두 참가한 DM conversation 조회
+        # 두 멤버가 모두 참가한 DM conversation 조회 — project 필터 없이(기존 DM 의 project 가 곧 스코프).
         conv = (await db.execute(
             select(Conversation)
             .join(ConversationParticipant, and_(
@@ -97,16 +103,16 @@ async def _get_or_create_conversation(
                 Conversation.id.in_(agent_conv_ids),
                 Conversation.type == "dm",
                 Conversation.org_id == org_id,
-                Conversation.project_id == project_id,
                 Conversation.status != "deleted",
             )
+            .order_by(Conversation.created_at)  # 다중 DM 공존 시 최古=canonical(결정적)
             .limit(1)
         )).scalar_one_or_none()
 
         if conv is None:
             conv = Conversation(
                 org_id=org_id,
-                project_id=project_id,
+                project_id=default_project_id,  # 신규 DM 만 default project 로 스코프
                 type="dm",
                 title=None,
                 created_by=agent_id,

--- a/backend/tests/test_s_comm_07.py
+++ b/backend/tests/test_s_comm_07.py
@@ -86,7 +86,7 @@ async def test_receive_inbox_webhook_404_when_agent_not_found():
 
     mock_db = AsyncMock()
     mock_result = MagicMock()
-    mock_result.one_or_none.return_value = None
+    mock_result.all.return_value = []  # 2c457a06: grant 전수 조회(.all) — 없으면 404
     mock_db.execute = AsyncMock(return_value=mock_result)
 
     with patch("app.routers.agent_inbox.settings") as mock_settings:
@@ -141,11 +141,9 @@ async def test_receive_inbox_webhook_creates_event():
 
     mock_db = AsyncMock()
 
-    # execute: agent lookup 반환
-    agent_row = MagicMock()
-    agent_row.__iter__ = MagicMock(return_value=iter([org_id, project_id]))
+    # execute: agent grant 전수 조회(.all) — 단일 grant
     lookup_result = MagicMock()
-    lookup_result.one_or_none.return_value = (org_id, project_id)
+    lookup_result.all.return_value = [(org_id, project_id)]
     mock_db.execute = AsyncMock(return_value=lookup_result)
 
     mock_event = MagicMock()
@@ -223,7 +221,7 @@ async def test_receive_inbox_webhook_calls_push_to_agent():
 
     mock_db = AsyncMock()
     lookup_result = MagicMock()
-    lookup_result.one_or_none.return_value = (org_id, project_id)
+    lookup_result.all.return_value = [(org_id, project_id)]
     mock_db.execute = AsyncMock(return_value=lookup_result)
 
     mock_event = MagicMock()
@@ -255,3 +253,73 @@ def test_agent_inbox_webhook_secret_in_config():
     s = Settings()
     assert hasattr(s, "agent_inbox_webhook_secret")
     assert s.agent_inbox_webhook_secret == ""
+
+
+# ─── 2c457a06 true-routing: payload project_id 우선(grant 검증)·없으면 default ──────
+async def _run_inbox_with_grants(payload: dict, grants: list[tuple]):
+    """주어진 grant 목록 + payload 로 receive_inbox_webhook 실행 → 생성 Event 의 project_id 반환."""
+    from app.routers.agent_inbox import receive_inbox_webhook
+
+    agent_id = uuid.uuid4()
+    body = json.dumps(payload).encode()
+    mock_request = MagicMock()
+    mock_request.body = AsyncMock(return_value=body)
+
+    mock_db = AsyncMock()
+    lookup_result = MagicMock()
+    lookup_result.all.return_value = grants  # (org_id, project_id) 행들
+    mock_db.execute = AsyncMock(return_value=lookup_result)
+    mock_db.add = MagicMock(side_effect=lambda obj: setattr(obj, "id", uuid.uuid4()))
+    mock_db.commit = AsyncMock()
+    mock_db.refresh = AsyncMock()
+
+    secret = "testsecret"
+    sig = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+    captured: dict = {}
+    with patch("app.routers.agent_inbox.settings") as mock_settings:
+        mock_settings.agent_inbox_webhook_secret = secret
+        with patch("app.routers.agent_inbox.Event") as MockEvent:
+            def _capture(**kwargs):
+                captured.update(kwargs)
+                m = MagicMock()
+                m.id = uuid.uuid4()
+                return m
+            MockEvent.side_effect = _capture
+            with patch("app.routers.events._push_to_agent"):
+                await receive_inbox_webhook(
+                    agent_id=agent_id, request=mock_request, db=mock_db, x_sprintable_signature=sig,
+                )
+    return captured.get("project_id")
+
+
+@pytest.mark.anyio
+async def test_inbox_explicit_granted_project_id_routes():
+    """payload 가 명시한 project_id 가 grant 에 속하면 그 project 로 Event 라우팅."""
+    org = uuid.uuid4()
+    p1, p2 = uuid.uuid4(), uuid.uuid4()
+    grants = sorted([(org, p1), (org, p2)], key=lambda r: str(r[1]))  # order_by(project_id)
+    target = p2
+    result_pid = await _run_inbox_with_grants({"event_type": "x", "project_id": str(target)}, grants)
+    assert result_pid == target
+
+
+@pytest.mark.anyio
+async def test_inbox_ungranted_project_id_falls_back_to_default():
+    """payload project_id 가 grant 밖이면 deterministic default(첫 행) 로 fallback(IDOR 차단·전달 무중단)."""
+    org = uuid.uuid4()
+    p1, p2 = uuid.uuid4(), uuid.uuid4()
+    grants = sorted([(org, p1), (org, p2)], key=lambda r: str(r[1]))
+    outsider = uuid.uuid4()  # grant 밖
+    result_pid = await _run_inbox_with_grants({"event_type": "x", "project_id": str(outsider)}, grants)
+    assert result_pid == grants[0][1]  # default = 첫(정렬) grant
+
+
+@pytest.mark.anyio
+async def test_inbox_no_project_id_uses_default():
+    """payload 에 project_id 없으면 default(첫 grant)."""
+    org = uuid.uuid4()
+    p1, p2 = uuid.uuid4(), uuid.uuid4()
+    grants = sorted([(org, p1), (org, p2)], key=lambda r: str(r[1]))
+    result_pid = await _run_inbox_with_grants({"event_type": "x"}, grants)
+    assert result_pid == grants[0][1]

--- a/backend/tests/test_sweep_multiproject_teammember_orderby.py
+++ b/backend/tests/test_sweep_multiproject_teammember_orderby.py
@@ -24,8 +24,10 @@ def _get_func():
     }
 
 
+# ws_chat_hub 의 agent_member 조회는 default project(room init)용 deterministic grant-pick 유지.
+# agent_inbox 는 2c457a06 에서 true-routing(payload project_id 우선·grant 검증·없으면 default)으로
+# 졸업 → order_by 는 default 결정성에 유지하되 .limit(1)→.all() 이라 이 가드서 제외(test_s_comm_07 가 커버).
 @pytest.mark.parametrize("name", [
-    "agent_inbox.receive_inbox_webhook",
     "ws_chat.ws_chat_hub",
 ])
 def test_project_id_site_uses_deterministic_grant_pick(name: str):

--- a/backend/tests/test_ws_chat_true_routing.py
+++ b/backend/tests/test_ws_chat_true_routing.py
@@ -1,0 +1,88 @@
+"""2c457a06 ws_chat true-routing: 기존 (agent,caller) DM 이 있으면 그 conversation 의 project 를
+재사용(project 필터 없이 조회)·신규 DM 생성 시에만 default_project_id 사용.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class _DB:
+    def __init__(self, existing):
+        self._existing = existing
+        self.added: list = []
+
+    async def execute(self, *a, **k):
+        r = MagicMock()
+        r.scalar_one_or_none.return_value = self._existing
+        return r
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def flush(self):
+        pass
+
+    async def commit(self):
+        pass
+
+    async def refresh(self, obj):
+        pass
+
+
+def _factory(db):
+    class _F:
+        async def __aenter__(self):
+            return db
+
+        async def __aexit__(self, *a):
+            return False
+
+    return lambda: _F()
+
+
+@pytest.mark.anyio
+async def test_existing_dm_project_reused_not_default():
+    """기존 DM 이 있으면 default_project_id 무관하게 그 conversation 을 재사용(project=대화 스코프)."""
+    from app.routers import ws_chat
+
+    existing = MagicMock()
+    existing.id = uuid.uuid4()
+    db = _DB(existing)
+
+    with patch.object(ws_chat, "async_session_factory", _factory(db)):
+        conv_id = await ws_chat._get_or_create_conversation(
+            uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), default_project_id=uuid.uuid4()
+        )
+
+    assert conv_id == existing.id   # 기존 DM 재사용
+    assert db.added == []           # 신규 생성 없음(그 conversation 의 project 그대로)
+
+
+@pytest.mark.anyio
+async def test_new_dm_uses_default_project():
+    """기존 DM 없으면 신규 생성 — default_project_id 로 스코프."""
+    from app.models.conversation import Conversation
+    from app.routers import ws_chat
+
+    db = _DB(None)  # 기존 DM 없음
+    default_pid = uuid.uuid4()
+
+    # Conversation/ConversationParticipant 는 패치 안 함 — select(Conversation)·select(...conversation_id)
+    # 쿼리 구성에 실 엔티티/컬럼 필요(db.execute 는 mock·생성 객체는 db.add 로 captured).
+    with patch.object(ws_chat, "async_session_factory", _factory(db)):
+        await ws_chat._get_or_create_conversation(
+            uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), default_project_id=default_pid
+        )
+
+    convs = [o for o in db.added if isinstance(o, Conversation)]
+    assert len(convs) == 1                       # 신규 DM 1건 생성
+    assert convs[0].project_id == default_pid    # default project 로 스코프
+    assert convs[0].type == "dm"


### PR DESCRIPTION
**Ⓑ multi-project inbound true-routing**(`2c457a06`·#1583 stopgap follow-up) — dev·마이그 없음.

## 배경
#1583 가 멀티프로젝트 agent 의 inbound project 라우팅을 **deterministic default**(최저 project_id) stopgap 으로 막았다. 이제 **컨텍스트 기반 proper routing**.

## agent_inbox.receive_inbox_webhook
- 에이전트 전 grant 조회(`.all()`·`order_by(project_id)`) → **payload 가 명시한 `project_id`** 가 **grant 에 속하면** 그 project 로 Event 라우팅.
- ⚠️ **grant 검증**(외부 발신자가 임의 project 로 Event 심는 IDOR 차단). 미명시/미grant/파싱불가 → deterministic default fallback(전달 무중단).
- **결정①**: 미grant 명시값은 **reject 아닌 default fallback**(best-effort 전달 우선·로그 경고). reject(403) 선호 시 알려주세요.

## ws_chat._get_or_create_conversation
- 기존 (agent,caller) DM 조회서 **project 필터 제거** → 기존 DM 있으면 **그 conversation 의 project 재사용**(대화가 자기 스코프 소유). 신규 생성 시에만 `default_project_id`.
- **결정②**: 다중 DM(멀티룸 정책) 공존 시 `order_by(created_at)` **최古=canonical**.

## [[Member-SSOT No team_member Coercion]]
컨텍스트(webhook payload / conversation)가 project 를 소유 — 임의 grant projection 행 아님.

## 검증
회귀: agent_inbox 명시-grant/미grant-fallback/무명시-default(3) + ws_chat 기존-재사용/신규-default(2) + s_comm_07 `.all()` 갱신·orderby-stopgap 가드서 agent_inbox 졸업. 110 무회귀·import OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)