### PR TITLE
fix(board): 모바일 카드 가로 스와이프=보드 스크롤 — touch-action pan-x pan-y (0a36762d)

### DIFF
--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -95,11 +95,14 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,
-    // Touch dnd: pan-y keeps vertical column scroll working (a quick swipe scrolls,
-    // aborting the TouchSensor's 250ms delay) while a press-and-hold still starts a drag
-    // (dnd-kit preventDefaults once active). `none` would have killed scroll-on-card;
-    // pan-y is the scroll-preserving fix for the overflow-y-auto columns (S6 root cause).
-    touchAction: 'pan-y' as const,
+    // Touch dnd: pan-x pan-y lets a quick swipe scroll natively in BOTH axes (aborting the
+    // TouchSensor's 250ms delay) while a press-and-hold still starts a drag (dnd-kit
+    // preventDefaults once active). `none` would kill scroll-on-card.
+    // 0a36762d: pan-y alone (S6) preserved vertical column scroll but BLOCKED horizontal board
+    // scroll — columns sit in an `overflow-x-auto` row (scrollW>clientW), so a horizontal swipe
+    // starting on a card had no native scroll and got captured. pan-x pan-y restores horizontal
+    // board scroll (superset of pan-y → no regression to vertical scroll or desktop drag).
+    touchAction: 'pan-x pan-y' as const,
   };
 
   // Close menu on click outside


### PR DESCRIPTION
## 무엇을

모바일 칸반 가로 스와이프-드래그 버그(`0a36762d`·prod `469db8ca` 에스컬·high)의 **scroll 축 잔여** 수정.

## validity-first 경과 (772c1af7·false-RED 교훈)

PO 제안 fix(`TouchSensor delay:250 + tolerance`)는 **이미 S6(#1378)에 존재** → 근본 아님. **drag 축은 stale 확정**(swipe<250ms→no-drag·hold→drag·PATCH 0, dev 모바일 emulation 재현). 

**단 scroll 축이 미검증이었고 — deterministic 측정(PO·미르코 dev 390px deployed 실측)으로 잔여 CONFIRMED:**
- 보드 컬럼-행 `div.flex overflow-x-auto`: **scrollW 1272 > clientW 390**(5컬럼·882px 가로 overflow)·`scrollLeft` 세팅/readback = **가로스크롤 실존·scrollable**.
- 카드: computed `touch-action: pan-y`·width 216px(240 컬럼 폭 대부분 점유).
- **CSS 스펙(결정적): `pan-y`는 가로 pan 차단** → 카드 위 가로 swipe 가 보드 가로스크롤도 드래그도 못 함(469db8ca '기대=swipe는 스크롤' 미충족). S6 pan-y 는 세로 컬럼 스크롤만 보존.

## fix

카드 `touch-action: 'pan-y'` → **`'pan-x pan-y'`**(양축 네이티브 스크롤 허용).
- hold≥250ms=drag 는 `TouchSensor` delay 로 유지(touch-action 무관·활성 시 dnd preventDefault).
- **pan-y 의 superset** → 세로 컬럼 스크롤·데스크탑 `PointerSensor`(distance:8) drag 무회귀.

story-card.tsx 1줄(+주석). 신규 토큰/컴포넌트 0.

## 검증

- `type-check`·`lint`·`build`(EXIT 0) 그린. kanban 단위테스트 없음(touch-action=라이브 픽셀 영역).
- **배포 후 동일 모바일 emulation 하니스로 재측정**: 카드 위 가로/세로 swipe=scroll(보드 `scrollLeft` 변화)·hold=drag·의도치않은 status/position PATCH 0.
- base=`origin/develop`.

⚠️ 모바일 보드 UX = **유나양 디자인 가디언** 리뷰. 까심 QA(가로/세로 swipe=scroll·hold=drag·PATCH 0)→머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)