### PR TITLE
[39e0a69e] 멀티모달 webhook images[] consume — dev hermes 어댑터 + py SDK

### DIFF
--- a/connectors/hermes-sprintable/adapter.py
+++ b/connectors/hermes-sprintable/adapter.py
@@ -74,6 +74,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    cache_media_bytes,
 )
 
 logger = logging.getLogger(__name__)
@@ -212,6 +213,54 @@ class SprintableAdapter(BasePlatformAdapter):
                 elif line.startswith("data:"):
                     data_lines.append(line[5:].lstrip())
 
+    async def _fetch_image_attachments(
+        self,
+        images: Any,
+    ) -> tuple[list[str], list[str], list[str]]:
+        """Fetch Sprintable signed image URLs into Hermes' local media cache.
+
+        Hermes gateway image routing expects ``MessageEvent.media_urls`` to be
+        agent-visible local cache paths. Passing the short-lived signed URL as a
+        "path" breaks native multimodal routing because the final
+        ``build_native_content_parts`` step opens local files before encoding
+        pixels. Fetch at consume time while the V4 URL is fresh.
+        """
+        if not isinstance(images, list) or not self._http_client:
+            return [], [], []
+
+        media_urls: list[str] = []
+        media_types: list[str] = []
+        notes: list[str] = []
+        for idx, item in enumerate(images, start=1):
+            if not isinstance(item, dict):
+                continue
+            url = str(item.get("url") or "").strip()
+            name = str(item.get("name") or f"sprintable-image-{idx}").strip()
+            mime = str(item.get("mime") or item.get("mime_type") or "").strip()
+            if not url:
+                continue
+            if mime and not mime.startswith("image/"):
+                continue
+            try:
+                resp = await self._http_client.get(url, timeout=20.0)
+                resp.raise_for_status()
+                cached = cache_media_bytes(
+                    resp.content,
+                    filename=name,
+                    mime_type=mime,
+                    default_kind="image",
+                )
+                if cached and cached.kind == "image":
+                    media_urls.append(cached.path)
+                    media_types.append(cached.media_type)
+                else:
+                    notes.append(f"[Sprintable image '{name}' could not be cached as a supported image]")
+            except Exception as exc:
+                logger.warning("[%s] image fetch failed name=%s url=%s: %s", self.name, name, url[:120], exc)
+                notes.append(f"[Sprintable image '{name}' could not be fetched before its signed URL expired]")
+
+        return media_urls, media_types, notes
+
     async def _on_event(self, ev_type: str, ev_id: str, data_str: str) -> None:
         if ev_type == "heartbeat":
             return
@@ -227,8 +276,9 @@ class SprintableAdapter(BasePlatformAdapter):
         if event_type not in INJECTABLE_EVENT_TYPES:
             return  # not a recommended inject type (e.g. status_changed FYI)
         content = (data.get("content") or payload.get("content") or "").strip()
-        if not content:
-            return  # nothing to inject (e.g. dispatched/system event without text)
+        images = data.get("images") or payload.get("images") or []
+        if not content and not images:
+            return  # nothing to inject (e.g. dispatched/system event without text/media)
 
         event_id = data.get("event_id") or payload.get("id") or ev_id or uuid.uuid4().hex
         if self._is_duplicate(event_id):
@@ -269,12 +319,18 @@ class SprintableAdapter(BasePlatformAdapter):
             user_id=sender_id,
             user_name=sender_name,
         )
+        media_urls, media_types, attachment_notes = await self._fetch_image_attachments(images)
+        if attachment_notes:
+            content = "\n".join(attachment_notes + ([content] if content else []))
+
         message_event = MessageEvent(
             text=content,
-            message_type=MessageType.TEXT,
+            message_type=MessageType.PHOTO if media_urls else MessageType.TEXT,
             source=source,
             message_id=event_id,
             raw_message=data,
+            media_urls=media_urls,
+            media_types=media_types,
             timestamp=datetime.now(tz=timezone.utc),
         )
         logger.info("[%s] inbound seq=%s conv=%s: %s", self.name, seq, conversation_id, content[:80])

--- a/connectors/hermes-sprintable/adapter.py
+++ b/connectors/hermes-sprintable/adapter.py
@@ -79,6 +79,29 @@ from gateway.platforms.base import (
 
 logger = logging.getLogger(__name__)
 
+
+def _normalize_image_items(images: Any) -> list[dict[str, str]]:
+    """Normalize Sprintable payload ``images[]`` to fetchable image metadata."""
+    if not isinstance(images, list):
+        return []
+    normalized: list[dict[str, str]] = []
+    for idx, item in enumerate(images, start=1):
+        if not isinstance(item, dict):
+            continue
+        url = str(item.get("url") or "").strip()
+        if not url:
+            continue
+        mime = str(item.get("mime") or item.get("mime_type") or "").strip()
+        if mime and not mime.startswith("image/"):
+            continue
+        normalized.append({
+            "url": url,
+            "name": str(item.get("name") or f"sprintable-image-{idx}").strip(),
+            "mime": mime,
+        })
+    return normalized
+
+
 DEFAULT_API_URL = "https://sprintable-backend-dev-57iommnikq-du.a.run.app"
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 STREAM_READ_TIMEOUT = 90  # gateway heartbeats keep the stream alive
@@ -225,22 +248,17 @@ class SprintableAdapter(BasePlatformAdapter):
         ``build_native_content_parts`` step opens local files before encoding
         pixels. Fetch at consume time while the V4 URL is fresh.
         """
-        if not isinstance(images, list) or not self._http_client:
+        normalized_images = _normalize_image_items(images)
+        if not normalized_images or not self._http_client:
             return [], [], []
 
         media_urls: list[str] = []
         media_types: list[str] = []
         notes: list[str] = []
-        for idx, item in enumerate(images, start=1):
-            if not isinstance(item, dict):
-                continue
-            url = str(item.get("url") or "").strip()
-            name = str(item.get("name") or f"sprintable-image-{idx}").strip()
-            mime = str(item.get("mime") or item.get("mime_type") or "").strip()
-            if not url:
-                continue
-            if mime and not mime.startswith("image/"):
-                continue
+        for item in normalized_images:
+            url = item["url"]
+            name = item["name"]
+            mime = item["mime"]
             try:
                 resp = await self._http_client.get(url, timeout=20.0)
                 resp.raise_for_status()
@@ -276,7 +294,7 @@ class SprintableAdapter(BasePlatformAdapter):
         if event_type not in INJECTABLE_EVENT_TYPES:
             return  # not a recommended inject type (e.g. status_changed FYI)
         content = (data.get("content") or payload.get("content") or "").strip()
-        images = data.get("images") or payload.get("images") or []
+        images = _normalize_image_items(data.get("images") or payload.get("images"))
         if not content and not images:
             return  # nothing to inject (e.g. dispatched/system event without text/media)
 

--- a/connectors/sdk/sprintable_sse.py
+++ b/connectors/sdk/sprintable_sse.py
@@ -63,6 +63,13 @@ INJECTABLE_EVENT_TYPES = frozenset({
 # ── Public types ─────────────────────────────────────────────────────────────
 
 @dataclass
+class MessageImage:
+    url: str
+    name: str = ""
+    mime: str = ""
+
+
+@dataclass
 class MessageContext:
     """어댑터 `on_message` 콜백에 전달되는 메시지 컨텍스트."""
     content: str
@@ -72,6 +79,7 @@ class MessageContext:
     event_id: str
     seq: int
     is_backfill: bool
+    images: list[MessageImage]
     raw: dict[str, Any]
 
     # reply() 지원을 위해 내부 주입
@@ -93,6 +101,27 @@ class MessageContext:
 
 
 MessageHandler = Callable[[MessageContext], Awaitable[None]]
+
+
+def _normalize_images(value: Any) -> list[MessageImage]:
+    if not isinstance(value, list):
+        return []
+    images: list[MessageImage] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        url = str(item.get("url") or "").strip()
+        if not url:
+            continue
+        mime = str(item.get("mime") or item.get("mime_type") or "").strip()
+        if mime and not mime.startswith("image/"):
+            continue
+        images.append(MessageImage(
+            url=url,
+            name=str(item.get("name") or ""),
+            mime=mime,
+        ))
+    return images
 
 
 # ── SDK client ────────────────────────────────────────────────────────────────
@@ -157,7 +186,8 @@ class SprintableSSEClient:
         if event_type not in INJECTABLE_EVENT_TYPES:
             return None
         content = (data.get("content") or payload.get("content") or "").strip()
-        if not content:
+        images = _normalize_images(data.get("images") or payload.get("images"))
+        if not content and not images:
             return None
 
         event_id = str(data.get("event_id") or payload.get("id") or ev_id or uuid.uuid4())
@@ -201,6 +231,7 @@ class SprintableSSEClient:
             event_id=event_id,
             seq=seq,
             is_backfill=is_backfill,
+            images=images,
             raw=data,
             _reply_url=reply_url,
             _api_key=self._api_key,

--- a/connectors/sdk/test_inject_allowlist.py
+++ b/connectors/sdk/test_inject_allowlist.py
@@ -12,7 +12,12 @@ import sys
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from sprintable_sse import INJECTABLE_EVENT_TYPES, SprintableSSEClient  # noqa: E402
+from sprintable_sse import (  # noqa: E402
+    INJECTABLE_EVENT_TYPES,
+    MessageImage,
+    SprintableSSEClient,
+    _normalize_images,
+)
 
 
 @pytest.fixture
@@ -95,3 +100,115 @@ def test_adapter_vendored_allowlist_matches_sdk(adapter):
     here = os.path.dirname(os.path.abspath(__file__))
     adapter_path = os.path.join(here, "..", adapter, "adapter.py")
     assert _vendored_allowlist(adapter_path) == set(INJECTABLE_EVENT_TYPES)
+
+
+# ── 39e0a69e: webhook payload images[] consume ───────────────────────────────
+# BE(#1588) emits images:[{url(signed V4),name,mime}] alongside content.  The
+# SDK surfaces them as MessageContext.images so SDK-based connectors can fetch
+# and route them to a multimodal model instead of dropping them on the floor.
+def test_normalize_images_happy_path():
+    imgs = _normalize_images([
+        {"url": "https://x/a.jpg", "name": "a.jpg", "mime": "image/jpeg"},
+        {"url": "https://x/b.png", "name": "b.png", "mime": "image/png"},
+    ])
+    assert imgs == [
+        MessageImage(url="https://x/a.jpg", name="a.jpg", mime="image/jpeg"),
+        MessageImage(url="https://x/b.png", name="b.png", mime="image/png"),
+    ]
+
+
+def test_normalize_images_non_list_returns_empty():
+    for bad in (None, "https://x/a.jpg", {"url": "x"}, 42):
+        assert _normalize_images(bad) == []
+
+
+def test_normalize_images_skips_garbage_items():
+    imgs = _normalize_images([
+        "not-a-dict",
+        {"name": "no-url"},          # missing url → skip
+        {"url": "   "},              # blank url → skip
+        {"url": "https://x/ok.gif", "mime": "image/gif"},
+    ])
+    assert imgs == [MessageImage(url="https://x/ok.gif", name="", mime="image/gif")]
+
+
+def test_normalize_images_filters_non_image_mime():
+    imgs = _normalize_images([
+        {"url": "https://x/doc.pdf", "mime": "application/pdf"},
+        {"url": "https://x/p.png", "mime": "image/png"},
+    ])
+    assert imgs == [MessageImage(url="https://x/p.png", name="", mime="image/png")]
+
+
+def test_normalize_images_accepts_mime_type_alias():
+    imgs = _normalize_images([{"url": "https://x/a.webp", "mime_type": "image/webp"}])
+    assert imgs == [MessageImage(url="https://x/a.webp", name="", mime="image/webp")]
+
+
+@pytest.mark.anyio
+async def test_image_only_message_is_injected():
+    # content 없어도 image 첨부가 있으면 work-turn으로 주입돼야 함 (AC: image-only inject)
+    c = SprintableSSEClient(api_key="x")
+    data = json.dumps({
+        "event_type": "conversation.message_created",
+        "content": "",
+        "event_id": "evt-img-only",
+        "images": [{"url": "https://x/a.jpg", "name": "a.jpg", "mime": "image/jpeg"}],
+    })
+    ctx = await c._parse_event("message", "10", data)
+    assert ctx is not None
+    assert ctx.content == ""
+    assert ctx.images == [MessageImage(url="https://x/a.jpg", name="a.jpg", mime="image/jpeg")]
+
+
+@pytest.mark.anyio
+async def test_text_plus_images_surfaces_both():
+    c = SprintableSSEClient(api_key="x")
+    data = json.dumps({
+        "event_type": "dispatched",
+        "content": "look at this",
+        "event_id": "evt-txt-img",
+        "images": [{"url": "https://x/a.png", "mime": "image/png"}],
+    })
+    ctx = await c._parse_event("message", "11", data)
+    assert ctx is not None
+    assert ctx.content == "look at this"
+    assert len(ctx.images) == 1 and ctx.images[0].url == "https://x/a.png"
+
+
+@pytest.mark.anyio
+async def test_text_only_has_empty_images_no_regression():
+    # AC5 무회귀: 이미지 없는 텍스트 메시지는 images == [] 로 정상 주입
+    c = SprintableSSEClient(api_key="x")
+    ctx = await c._parse_event("message", "12", _data("dispatched"))
+    assert ctx is not None
+    assert ctx.images == []
+
+
+@pytest.mark.anyio
+async def test_images_nested_in_payload_surfaced():
+    c = SprintableSSEClient(api_key="x")
+    data = json.dumps({
+        "event_type": "dispatched",
+        "event_id": "evt-payload-img",
+        "payload": {
+            "content": "",
+            "images": [{"url": "https://x/n.jpg", "mime": "image/jpeg"}],
+        },
+    })
+    ctx = await c._parse_event("message", "13", data)
+    assert ctx is not None
+    assert len(ctx.images) == 1 and ctx.images[0].url == "https://x/n.jpg"
+
+
+@pytest.mark.anyio
+async def test_non_image_attachment_only_is_dropped():
+    # 이미지가 아닌 mime만 있고 content도 없으면 normalize 후 images==[] → 드롭
+    c = SprintableSSEClient(api_key="x")
+    data = json.dumps({
+        "event_type": "dispatched",
+        "content": "",
+        "event_id": "evt-nonimg",
+        "images": [{"url": "https://x/doc.pdf", "mime": "application/pdf"}],
+    })
+    assert await c._parse_event("message", "14", data) is None


### PR DESCRIPTION
## 배경
BE(#1588)가 conversation webhook payload에 `images:[{url(V4 서명),name,mime}]` 구조화 필드를 `content`와 함께 방출하지만, 런타임 consume 경로 4곳이 전부 `content`만 읽어 `images[]`를 무시한다. content 마크다운에 박힌 긴 V4 서명 URL은 display-relay(Discord 등)에서 truncate되어 에이전트가 fetch 불가하다(스토리 `39e0a69e`). 본 PR은 **dev hermes 어댑터 + py SDK**가 `images[]`를 소비하도록 한다(산티아고 SME 설계 기반).

## 변경 사항 (py lane)
- **`connectors/sdk/sprintable_sse.py`**
  - `MessageImage` dataclass 추가, `MessageContext.images: list[MessageImage]` 표면화.
  - `_normalize_images()`: list·dict·`url`·image-mime 검증(`mime`/`mime_type` 별칭) 후 정규화.
  - content가 없어도 `images`가 있으면 work-turn으로 주입(`if not content and not images: return`).
- **`connectors/hermes-sprintable/adapter.py`**
  - `_fetch_image_attachments()`: consume 시점에 서명 URL을 즉시 fetch → `cache_media_bytes(default_kind='image')`로 Hermes 로컬 미디어 캐시에 저장 → 로컬 경로를 `MessageEvent.media_urls/media_types`에 실어 `MessageType.PHOTO`로 라우팅.
  - **왜 fetch가 필요한가**: Hermes native multimodal 끝단 `build_native_content_parts()`가 로컬 파일을 직접 열어 픽셀을 인코딩하므로, 단명 서명 URL을 `media_urls`에 경로로 그대로 넣으면 '없는 로컬파일'로 스킵된다. 서명 URL이 신선할 때 consume 시점 fetch가 정답(SME 판단).
  - fetch 실패/비이미지 캐시 실패는 **fail-soft**(안내 노트 prepend·전달 무중단).

## 스코프 (의도적 분리)
- ⏸ **prod 어댑터**(`hermes-sprintable-prod/adapter.py`) 동형 반영 = dev E2E 입증 + 선생님 prod 승인 후 별도 PR.
- ⏸ **TS**(`fakechat/server.ts`, `sdk/sprintable-sse.ts`) = 미르코 lane(py E2E 패턴 입증 후).

## 테스트
- `test_inject_allowlist.py` **17/17 PASS**(신규 10): `_normalize_images` happy/non-list/garbage-skip/non-image-filter/mime_type-alias + image-only 주입 + text+images + **text-only 무회귀(AC5)** + payload 중첩 + 비이미지 드롭.
- 어댑터는 Hermes `gateway` 패키지(외부) 의존이라 connectors-only 환경에서 import 불가 → 기존 AST 가드 테스트로 파싱·allowlist 불변 검증, py_compile 통과.

## ⚠️ 검증 한계 / AC4
- **gateway 내부 계약**(`cache_media_bytes` 시그니처·`MessageEvent.media_urls/media_types`·`MessageType.PHOTO`)은 외부 Hermes 모듈이라 로컬 검증 불가 — SME 설계 신뢰 + E2E 입증.
- **AC4 E2E**(실 이미지 첨부 → dev hermes 어댑터 → 이미지 turn 실 모델 도달 로그)는 dev hermes 커넥터가 본 코드를 구동해야 관측 가능 = **머지/배포 후 Hermes 런타임에서 확인**. done은 AC4 로그 확認 전 금지.

## 체크리스트
- [x] dev py 구현(어댑터 + SDK)
- [x] 단위 테스트 17/17
- [x] py_compile / import 안전(Any import 확認)
- [ ] 까심 cross-model QA
- [ ] AC4 E2E(이미지 모델 도달 로그) — 배포 후
- [ ] PO 머지 게이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)