### PR TITLE
[8fe3667b] E-DG S1 — Workflow line schema expand migration

### DIFF
--- a/backend/alembic/versions/0126_workflow_line_schema_expand.py
+++ b/backend/alembic/versions/0126_workflow_line_schema_expand.py
@@ -19,16 +19,19 @@ Decision Gate(org-configurable 결재/핸드오프 라인)의 기반 스키마. 
   만들 때이며, 그때는 CONCURRENTLY(트랜잭션 밖) 로 친다 — 본 파일은 fresh-DB 경로라 일반
   CREATE INDEX 로 둔다.
 
-리뷰 확인 요청(AC가 명시하지 않아 코히어런스로 결정한 지점):
-- ``entity_type`` 을 모든 테이블에서 NOT NULL 로 둔다(AC는 definitions 에만 NN 명시). steps/
-  step_runs/versions 의 unique 제약에 entity_type 이 포함되는데, nullable 이면 NULL-distinct 로
-  unique 의도가 깨지므로 NN 으로 통일했다.
-- definitions / step_runs 의 partial unique 는 project_id·from_status 가 nullable 이라 Postgres
-  의 NULL-distinct 규칙상 "org-default(project_id NULL)" 또는 "from_status NULL" 행은 중복이
-  허용된다. AC 문구 그대로 구현했고, org-default 단일성을 강제하려면 COALESCE 표현식 인덱스가
-  필요하다 — 의도 확인 필요(S2 config 거버넌스에서 정리 가능).
+코히어런스 결정 + 산티아고 SME 리뷰(PR #1595) 반영:
+- ``entity_type`` 전 테이블 NOT NULL(SME 동의). unique 제약 포함 컬럼이라 nullable 이면
+  NULL-distinct 로 의도가 깨진다.
+- [SME #3] definitions active unique 는 단일 partial 로는 org-default(project_id NULL) 중복을
+  못 막는다(NULL-distinct) → ``IS NULL`` / ``IS NOT NULL`` split partial unique 두 개로 보강.
+  step_runs 의 from_status NULL 케이스는 Phase1(story-only) 범위라 현 partial unique 유지(추후
+  doc/virtual transition 도입 시 COALESCE/split 재검토 — SME 합의).
+- [SME #1] step_runs.mode 는 NOT NULL(S3 엔진 분기 SSOT·insert-contract).
+- [SME #2] spec 상 객체/배열인 JSONB 는 NOT NULL + server_default 로 통일(null-vs-empty 분기
+  제거): steps.metadata · step_runs.routing_context/trust_snapshot/risk_snapshot/quorum_policy ·
+  step_run_events.payload · role_assignments.delegation_policy/metadata.
 - table 8 ``workflow_delivery_outbox`` 는 AC done ①의 "(+8 optional)" 에 따라 additive 로 함께
-  생성한다(빈 테이블·무해·S7 핸드오프 relay 재마이그 회피). 실제 사용은 S7 에서
+  생성(빈 테이블·무해·S7 재마이그 회피·SME 동의). 실제 사용은 S7 에서
   dispatch_entity_to_assignee(commit=False) 가능 여부로 결정.
 
 Revision ID: 0126
@@ -99,9 +102,18 @@ def upgrade() -> None:
             sa.Column("config_hash", sa.Text(), nullable=True),
             *_timestamps(),
         )
+    # active 라인 single-source 보장. project_id 가 nullable 이라 단일 partial unique 로는
+    # Postgres NULL-distinct 규칙상 org-default(project_id NULL) 중복이 안 막힌다(SME #3).
+    # → IS NULL / IS NOT NULL 로 split:
+    #   org-default: (org_id, entity_type) 당 active 1개
     _create_index(
-        bind, "uq_wf_line_def_active", "workflow_line_definitions",
-        ["org_id", "project_id", "entity_type"], unique=True, where="is_active",
+        bind, "uq_wf_line_def_active_org", "workflow_line_definitions",
+        ["org_id", "entity_type"], unique=True, where="is_active AND project_id IS NULL",
+    )
+    #   project-override: (org_id, project_id, entity_type) 당 active 1개
+    _create_index(
+        bind, "uq_wf_line_def_active_proj", "workflow_line_definitions",
+        ["org_id", "project_id", "entity_type"], unique=True, where="is_active AND project_id IS NOT NULL",
     )
     _create_index(
         bind, "ix_wf_line_def_org_entity_active", "workflow_line_definitions",
@@ -158,7 +170,7 @@ def upgrade() -> None:
             sa.Column("sla_policy", JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
             sa.Column("approval_policy", JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
             sa.Column("recall_policy", JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
-            sa.Column("metadata", JSONB(), nullable=True),
+            sa.Column("metadata", JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
             *_timestamps(),
         )
     _create_index(
@@ -181,14 +193,16 @@ def upgrade() -> None:
             sa.Column("from_status", sa.Text(), nullable=True),
             sa.Column("to_status", sa.Text(), nullable=False),
             sa.Column("status", sa.Text(), server_default=sa.text("'pending'"), nullable=False),
-            sa.Column("mode", sa.Text(), nullable=True),
+            # mode = S3 엔진 분기 SSOT. NN(엔진이 insert 시점에 항상 분류해 제공 — correlation_id/
+            # transition_id 와 동일한 insert-contract). server_default 없음(enum에 'unset' 값 없음).
+            sa.Column("mode", sa.Text(), nullable=False),
             sa.Column("effective_step_type", sa.Text(), nullable=True),
             sa.Column("effective_gate_type", sa.Text(), nullable=True),
             sa.Column("routing_decision", sa.Text(), nullable=True),
             sa.Column("routing_reason", sa.Text(), nullable=True),
-            sa.Column("routing_context", JSONB(), nullable=True),
-            sa.Column("trust_snapshot", JSONB(), nullable=True),
-            sa.Column("risk_snapshot", JSONB(), nullable=True),
+            sa.Column("routing_context", JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
+            sa.Column("trust_snapshot", JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
+            sa.Column("risk_snapshot", JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
             sa.Column("resolved_member_id", UUID(as_uuid=True), nullable=True),
             sa.Column("resolved_member_type", sa.Text(), nullable=True),
             sa.Column("gate_id", UUID(as_uuid=True), nullable=True),
@@ -198,7 +212,7 @@ def upgrade() -> None:
             sa.Column("delivery_status", sa.Text(), server_default=sa.text("'not_required'"), nullable=False),
             sa.Column("delivery_error", sa.Text(), nullable=True),
             sa.Column("approval_group_id", UUID(as_uuid=True), nullable=True),
-            sa.Column("quorum_policy", JSONB(), nullable=True),
+            sa.Column("quorum_policy", JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
             sa.Column("sla_due_at", sa.DateTime(timezone=True), nullable=True),
             sa.Column("next_reminder_at", sa.DateTime(timezone=True), nullable=True),
             sa.Column("reminder_count", sa.Integer(), server_default=sa.text("0"), nullable=False),
@@ -292,7 +306,7 @@ def upgrade() -> None:
             sa.Column("event_type", sa.Text(), nullable=False),
             sa.Column("actor_member_id", UUID(as_uuid=True), nullable=True),
             sa.Column("target_member_id", UUID(as_uuid=True), nullable=True),
-            sa.Column("payload", JSONB(), nullable=True),
+            sa.Column("payload", JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
             sa.Column("correlation_id", UUID(as_uuid=True), nullable=False),
             sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
         )
@@ -320,8 +334,8 @@ def upgrade() -> None:
             sa.Column("availability_status", sa.Text(), server_default=sa.text("'available'"), nullable=False),
             sa.Column("effective_from", sa.DateTime(timezone=True), nullable=True),
             sa.Column("effective_to", sa.DateTime(timezone=True), nullable=True),
-            sa.Column("delegation_policy", JSONB(), nullable=True),
-            sa.Column("metadata", JSONB(), nullable=True),
+            sa.Column("delegation_policy", JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
+            sa.Column("metadata", JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
             *_timestamps(),
         )
     _create_index(

--- a/backend/alembic/versions/0126_workflow_line_schema_expand.py
+++ b/backend/alembic/versions/0126_workflow_line_schema_expand.py
@@ -1,0 +1,379 @@
+"""E-DECISION-GATE S1 (8fe3667b): Workflow line schema — expand migration.
+
+Decision Gate(org-configurable 결재/핸드오프 라인)의 기반 스키마. 신규 테이블만 추가하는
+순수 expand 마이그레이션이며 기존 Gate / Event / Story.status 머신은 일절 건드리지 않는다.
+라인 엔진은 default-off로 S3/S18에서 도입되므로 본 스토리는 스키마만 깐다(런타임 무영향).
+
+스펙 출처: 스토리 8fe3667b AC(= build-guide §1.2 전체 스키마 + §3 S1 done AC).
+
+설계 노트:
+- enum류(status·delivery_status·step_type·event_type 등)는 모두 ``text`` 컬럼 + 애플리케이션
+  레벨 validator로 표현한다. DB CHECK / native enum 을 쓰지 않는다 → 새 enum 값 추가 시
+  baseline schema.sql CHECK 갱신 누락(CI SQLite blindspot) 위험을 원천 차단하고, S2~ 에서
+  값 확장이 마이그 없이 가능하다.
+- idempotent: 모든 create_table / create_index 를 inspector 가드로 감싼다. alembic 자체가
+  revision 추적으로 재실행을 막지만, 부분 적용/수동 재시도(migrate-dev) 안전을 위해.
+- expand-contract(P1-5): 신규 테이블은 비어 있으므로 인덱스 생성이 기존 행을 잠그지 않는다.
+  따라서 본 마이그는 CREATE INDEX CONCURRENTLY 가 불필요하다(빈 테이블=즉시). 운영상 큰
+  partial unique 가 문제되는 시점은 S19 backfill 이 이 테이블들을 채운 "이후" 인덱스를 다시
+  만들 때이며, 그때는 CONCURRENTLY(트랜잭션 밖) 로 친다 — 본 파일은 fresh-DB 경로라 일반
+  CREATE INDEX 로 둔다.
+
+리뷰 확인 요청(AC가 명시하지 않아 코히어런스로 결정한 지점):
+- ``entity_type`` 을 모든 테이블에서 NOT NULL 로 둔다(AC는 definitions 에만 NN 명시). steps/
+  step_runs/versions 의 unique 제약에 entity_type 이 포함되는데, nullable 이면 NULL-distinct 로
+  unique 의도가 깨지므로 NN 으로 통일했다.
+- definitions / step_runs 의 partial unique 는 project_id·from_status 가 nullable 이라 Postgres
+  의 NULL-distinct 규칙상 "org-default(project_id NULL)" 또는 "from_status NULL" 행은 중복이
+  허용된다. AC 문구 그대로 구현했고, org-default 단일성을 강제하려면 COALESCE 표현식 인덱스가
+  필요하다 — 의도 확인 필요(S2 config 거버넌스에서 정리 가능).
+- table 8 ``workflow_delivery_outbox`` 는 AC done ①의 "(+8 optional)" 에 따라 additive 로 함께
+  생성한다(빈 테이블·무해·S7 핸드오프 relay 재마이그 회피). 실제 사용은 S7 에서
+  dispatch_entity_to_assignee(commit=False) 가능 여부로 결정.
+
+Revision ID: 0126
+Revises: 0125
+"""
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from alembic import op
+
+revision = "0126"
+down_revision = "0125"
+branch_labels = None
+depends_on = None
+
+
+def _has_table(bind, name: str) -> bool:
+    return sa.inspect(bind).has_table(name)
+
+
+def _has_index(bind, table: str, index: str) -> bool:
+    insp = sa.inspect(bind)
+    if not insp.has_table(table):
+        return False
+    return any(ix["name"] == index for ix in insp.get_indexes(table))
+
+
+def _uuid_pk() -> sa.Column:
+    return sa.Column(
+        "id", UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")
+    )
+
+
+def _timestamps() -> list[sa.Column]:
+    return [
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    ]
+
+
+def _create_index(bind, name: str, table: str, cols, *, unique: bool = False, where: str | None = None) -> None:
+    if _has_index(bind, table, name):
+        return
+    kwargs: dict = {"unique": unique}
+    if where is not None:
+        kwargs["postgresql_where"] = sa.text(where)
+    op.create_index(name, table, cols, **kwargs)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # ── 1) workflow_line_definitions ────────────────────────────────────────
+    if not _has_table(bind, "workflow_line_definitions"):
+        op.create_table(
+            "workflow_line_definitions",
+            _uuid_pk(),
+            sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("project_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("entity_type", sa.Text(), nullable=False),
+            sa.Column("name", sa.Text(), nullable=False),
+            sa.Column("version", sa.Integer(), server_default=sa.text("1"), nullable=False),
+            sa.Column("is_active", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+            sa.Column("source", sa.Text(), server_default=sa.text("'org_config'"), nullable=False),
+            sa.Column("created_by_member_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("published_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("retired_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("config_hash", sa.Text(), nullable=True),
+            *_timestamps(),
+        )
+    _create_index(
+        bind, "uq_wf_line_def_active", "workflow_line_definitions",
+        ["org_id", "project_id", "entity_type"], unique=True, where="is_active",
+    )
+    _create_index(
+        bind, "ix_wf_line_def_org_entity_active", "workflow_line_definitions",
+        ["org_id", "entity_type", "is_active"],
+    )
+    _create_index(bind, "ix_wf_line_def_project", "workflow_line_definitions", ["project_id"])
+
+    # ── 2) workflow_line_definition_versions [P0-4 거버넌스] ─────────────────
+    if not _has_table(bind, "workflow_line_definition_versions"):
+        op.create_table(
+            "workflow_line_definition_versions",
+            _uuid_pk(),
+            sa.Column("line_definition_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("project_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("entity_type", sa.Text(), nullable=False),
+            sa.Column("version", sa.Integer(), nullable=False),
+            sa.Column("status", sa.Text(), server_default=sa.text("'draft'"), nullable=False),
+            sa.Column("config", JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
+            sa.Column("config_hash", sa.Text(), nullable=False),
+            sa.Column("lint_status", sa.Text(), server_default=sa.text("'not_run'"), nullable=False),
+            sa.Column("lint_errors", JSONB(), server_default=sa.text("'[]'::jsonb"), nullable=False),
+            sa.Column("created_by_member_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("reviewed_by_member_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("review_gate_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("published_at", sa.DateTime(timezone=True), nullable=True),
+            *_timestamps(),
+        )
+    _create_index(
+        bind, "uq_wf_line_def_ver", "workflow_line_definition_versions",
+        ["org_id", "project_id", "entity_type", "version"], unique=True,
+    )
+    _create_index(bind, "ix_wf_line_def_ver_project", "workflow_line_definition_versions", ["project_id"])
+    _create_index(bind, "ix_wf_line_def_ver_def", "workflow_line_definition_versions", ["line_definition_id"])
+
+    # ── 3) workflow_line_steps ──────────────────────────────────────────────
+    if not _has_table(bind, "workflow_line_steps"):
+        op.create_table(
+            "workflow_line_steps",
+            _uuid_pk(),
+            sa.Column("line_definition_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("entity_type", sa.Text(), nullable=False),
+            sa.Column("from_status", sa.Text(), nullable=True),
+            sa.Column("to_status", sa.Text(), nullable=False),
+            sa.Column("step_order", sa.Integer(), nullable=False),
+            sa.Column("step_key", sa.Text(), nullable=False),
+            sa.Column("step_type", sa.Text(), nullable=False),
+            sa.Column("assignee_policy", JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
+            sa.Column("on_approve", JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
+            sa.Column("on_reject", JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
+            sa.Column("gate_type", sa.Text(), nullable=True),
+            sa.Column("routing_rules", JSONB(), server_default=sa.text("'[]'::jsonb"), nullable=False),
+            sa.Column("sla_policy", JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
+            sa.Column("approval_policy", JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
+            sa.Column("recall_policy", JSONB(), server_default=sa.text("'{}'::jsonb"), nullable=False),
+            sa.Column("metadata", JSONB(), nullable=True),
+            *_timestamps(),
+        )
+    _create_index(
+        bind, "uq_wf_line_step", "workflow_line_steps",
+        ["line_definition_id", "entity_type", "from_status", "to_status"], unique=True,
+    )
+    _create_index(bind, "ix_wf_line_step_org", "workflow_line_steps", ["org_id"])
+
+    # ── 4) workflow_line_step_runs [전이 1건 route/audit/delivery] ───────────
+    if not _has_table(bind, "workflow_line_step_runs"):
+        op.create_table(
+            "workflow_line_step_runs",
+            _uuid_pk(),
+            sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("project_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("line_definition_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("line_step_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("entity_type", sa.Text(), nullable=False),
+            sa.Column("entity_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("from_status", sa.Text(), nullable=True),
+            sa.Column("to_status", sa.Text(), nullable=False),
+            sa.Column("status", sa.Text(), server_default=sa.text("'pending'"), nullable=False),
+            sa.Column("mode", sa.Text(), nullable=True),
+            sa.Column("effective_step_type", sa.Text(), nullable=True),
+            sa.Column("effective_gate_type", sa.Text(), nullable=True),
+            sa.Column("routing_decision", sa.Text(), nullable=True),
+            sa.Column("routing_reason", sa.Text(), nullable=True),
+            sa.Column("routing_context", JSONB(), nullable=True),
+            sa.Column("trust_snapshot", JSONB(), nullable=True),
+            sa.Column("risk_snapshot", JSONB(), nullable=True),
+            sa.Column("resolved_member_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("resolved_member_type", sa.Text(), nullable=True),
+            sa.Column("gate_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("h1_gate_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("event_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("recipient_seq", sa.BigInteger(), nullable=True),
+            sa.Column("delivery_status", sa.Text(), server_default=sa.text("'not_required'"), nullable=False),
+            sa.Column("delivery_error", sa.Text(), nullable=True),
+            sa.Column("approval_group_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("quorum_policy", JSONB(), nullable=True),
+            sa.Column("sla_due_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("next_reminder_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("reminder_count", sa.Integer(), server_default=sa.text("0"), nullable=False),
+            sa.Column("escalated_to_member_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("failure_class", sa.Text(), nullable=True),
+            sa.Column("failure_message", sa.Text(), nullable=True),
+            sa.Column("degraded_to_plain", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+            sa.Column("correlation_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("transition_id", sa.Text(), nullable=False),
+            sa.Column("attempt", sa.Integer(), server_default=sa.text("1"), nullable=False),
+            sa.Column("started_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.Column("resolved_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("withdrawn_by_member_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("withdrawn_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("withdraw_reason", sa.Text(), nullable=True),
+            *_timestamps(),
+        )
+    # 활성 1전이 1행 보장(중복 in-flight 방지). status가 terminal이면 제외.
+    _create_index(
+        bind, "uq_wf_step_run_active", "workflow_line_step_runs",
+        ["org_id", "entity_type", "entity_id", "from_status", "to_status", "attempt"], unique=True,
+        where="status NOT IN ('applied','rejected','failed','engine_failed','withdrawn','timed_out','cancelled','grandfathered')",
+    )
+    # 이중 pending gate 방지(P0-2 duplicate_pending_gate_count=0).
+    _create_index(
+        bind, "uq_wf_step_run_pending_gate", "workflow_line_step_runs",
+        ["org_id", "entity_type", "entity_id", "from_status", "to_status", "effective_gate_type"], unique=True,
+        where="status IN ('waiting_gate','waiting_parallel','reminded','escalated','held')",
+    )
+    _create_index(
+        bind, "ix_wf_step_run_org_proj_status", "workflow_line_step_runs",
+        ["org_id", "project_id", "status", sa.text("started_at DESC")],
+    )
+    _create_index(
+        bind, "ix_wf_step_run_org_entity", "workflow_line_step_runs",
+        ["org_id", "entity_type", "entity_id", sa.text("started_at DESC")],
+    )
+    _create_index(bind, "ix_wf_step_run_project", "workflow_line_step_runs", ["project_id"])
+    _create_index(bind, "ix_wf_step_run_def", "workflow_line_step_runs", ["line_definition_id"])
+    _create_index(bind, "ix_wf_step_run_step", "workflow_line_step_runs", ["line_step_id"])
+    _create_index(bind, "ix_wf_step_run_gate", "workflow_line_step_runs", ["gate_id"])
+    _create_index(bind, "ix_wf_step_run_h1_gate", "workflow_line_step_runs", ["h1_gate_id"])
+    _create_index(bind, "ix_wf_step_run_event", "workflow_line_step_runs", ["event_id"])
+    _create_index(bind, "ix_wf_step_run_approval_group", "workflow_line_step_runs", ["approval_group_id"])
+
+    # ── 5) workflow_step_approvals [parallel/quorum/consult/deputy] ──────────
+    if not _has_table(bind, "workflow_step_approvals"):
+        op.create_table(
+            "workflow_step_approvals",
+            _uuid_pk(),
+            sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("project_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("step_run_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("gate_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("approval_group_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("approver_member_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("approver_member_type", sa.Text(), nullable=False),
+            sa.Column("original_approver_member_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("requested_by_member_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("implementation_member_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("role_key", sa.Text(), nullable=True),
+            sa.Column("kind", sa.Text(), server_default=sa.text("'approver'"), nullable=False),
+            sa.Column("blocking", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+            sa.Column("status", sa.Text(), server_default=sa.text("'pending'"), nullable=False),
+            sa.Column("decision_note", sa.Text(), nullable=True),
+            sa.Column("resolved_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("held_until", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("reassigned_from_member_id", UUID(as_uuid=True), nullable=True),
+            *_timestamps(),
+        )
+    _create_index(
+        bind, "uq_wf_step_approval", "workflow_step_approvals",
+        ["step_run_id", "approver_member_id", "kind"], unique=True,
+    )
+    _create_index(
+        bind, "ix_wf_step_approval_org_approver", "workflow_step_approvals",
+        ["org_id", "approver_member_id", "status", sa.text("created_at DESC")],
+    )
+    _create_index(bind, "ix_wf_step_approval_project", "workflow_step_approvals", ["project_id"])
+    _create_index(bind, "ix_wf_step_approval_gate", "workflow_step_approvals", ["gate_id"])
+    _create_index(bind, "ix_wf_step_approval_group", "workflow_step_approvals", ["approval_group_id"])
+
+    # ── 6) workflow_step_run_events [append-only audit] ─────────────────────
+    if not _has_table(bind, "workflow_step_run_events"):
+        op.create_table(
+            "workflow_step_run_events",
+            _uuid_pk(),
+            sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("project_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("step_run_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("event_type", sa.Text(), nullable=False),
+            sa.Column("actor_member_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("target_member_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("payload", JSONB(), nullable=True),
+            sa.Column("correlation_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        )
+    _create_index(
+        bind, "ix_wf_step_run_event_org_run", "workflow_step_run_events",
+        ["org_id", "step_run_id", sa.text("created_at ASC")],
+    )
+    _create_index(bind, "ix_wf_step_run_event_run", "workflow_step_run_events", ["step_run_id"])
+    _create_index(bind, "ix_wf_step_run_event_project", "workflow_step_run_events", ["project_id"])
+
+    # ── 7) workflow_role_assignments [route candidate] ──────────────────────
+    if not _has_table(bind, "workflow_role_assignments"):
+        op.create_table(
+            "workflow_role_assignments",
+            _uuid_pk(),
+            sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("project_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("role_key", sa.Text(), nullable=False),
+            sa.Column("member_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("member_type", sa.Text(), nullable=False),
+            sa.Column("priority", sa.Integer(), server_default=sa.text("100"), nullable=False),
+            sa.Column("is_active", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+            sa.Column("deputy_member_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("deputy_member_type", sa.Text(), nullable=True),
+            sa.Column("availability_status", sa.Text(), server_default=sa.text("'available'"), nullable=False),
+            sa.Column("effective_from", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("effective_to", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("delegation_policy", JSONB(), nullable=True),
+            sa.Column("metadata", JSONB(), nullable=True),
+            *_timestamps(),
+        )
+    _create_index(
+        bind, "ix_wf_role_assign_lookup", "workflow_role_assignments",
+        ["org_id", "project_id", "role_key", "is_active", "priority"],
+    )
+    _create_index(
+        bind, "uq_wf_role_assign_member", "workflow_role_assignments",
+        ["org_id", "project_id", "role_key", "member_id"], unique=True,
+    )
+    _create_index(bind, "ix_wf_role_assign_project", "workflow_role_assignments", ["project_id"])
+
+    # ── 8) workflow_delivery_outbox [P1-2 · optional · S7 사용 결정] ─────────
+    if not _has_table(bind, "workflow_delivery_outbox"):
+        op.create_table(
+            "workflow_delivery_outbox",
+            _uuid_pk(),
+            sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("project_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("step_run_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("event_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("recipient_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("recipient_type", sa.Text(), nullable=False),
+            sa.Column("recipient_seq", sa.BigInteger(), nullable=True),
+            sa.Column("status", sa.Text(), server_default=sa.text("'pending'"), nullable=False),
+            sa.Column("wake_after", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.Column("attempt_count", sa.Integer(), server_default=sa.text("0"), nullable=False),
+            sa.Column("last_error", sa.Text(), nullable=True),
+            *_timestamps(),
+        )
+    # outbox worker poll: pending 중 wake_after 도래분.
+    _create_index(
+        bind, "ix_wf_delivery_outbox_poll", "workflow_delivery_outbox",
+        ["status", "wake_after"],
+    )
+    _create_index(bind, "ix_wf_delivery_outbox_step_run", "workflow_delivery_outbox", ["step_run_id"])
+    _create_index(bind, "ix_wf_delivery_outbox_event", "workflow_delivery_outbox", ["event_id"])
+    _create_index(bind, "ix_wf_delivery_outbox_org", "workflow_delivery_outbox", ["org_id"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    # 생성 역순으로 drop(테이블 drop 시 소속 인덱스 동반 제거).
+    for table in (
+        "workflow_delivery_outbox",
+        "workflow_role_assignments",
+        "workflow_step_run_events",
+        "workflow_step_approvals",
+        "workflow_line_step_runs",
+        "workflow_line_steps",
+        "workflow_line_definition_versions",
+        "workflow_line_definitions",
+    ):
+        if _has_table(bind, table):
+            op.drop_table(table)


### PR DESCRIPTION
## 배경
Decision Gate(E-DECISION-GATE·org-configurable 결재/핸드오프 라인) 빌드의 **critical path 1번·기반 스토리**. 신규 워크플로우 라인 테이블을 **additive(expand)** 로 추가한다. 라인 엔진은 default-off로 S3/S18에서 도입되므로 본 PR은 **스키마만** 깔며 런타임 무영향이다. 스펙 출처: 스토리 `8fe3667b` AC(= build-guide §1.2 전체 스키마 + §3 S1 done AC).

## 변경
`backend/alembic/versions/0126_workflow_line_schema_expand.py` (revision 0126, down_revision 0125) — **신규 테이블만 생성**, 기존 Gate/Event/Story.status 무변경.

생성 테이블 (7 필수 + outbox 1 optional):
| 테이블 | 역할 |
|---|---|
| `workflow_line_definitions` | 라인 정의(org/project overlay·partial unique active) |
| `workflow_line_definition_versions` | P0-4 config 거버넌스(draft→published·lint) |
| `workflow_line_steps` | step 정의(routing_rules/sla_policy/approval_policy/recall_policy = **JSONB 컬럼**) |
| `workflow_line_step_runs` | 전이 1건 route/audit/delivery(partial unique 2종) |
| `workflow_step_approvals` | parallel/quorum/consult/deputy + SoD 가드 컬럼 |
| `workflow_step_run_events` | append-only audit |
| `workflow_role_assignments` | route candidate(priority·deputy) |
| `workflow_delivery_outbox` | P1-2 **optional**(S7 사용 결정·additive 선반영) |

## 설계 결정
- **enum류 = `text` + 앱 validator** (status·delivery_status·step_type·event_type 등). DB CHECK/native enum 미사용 → ① baseline schema.sql CHECK 갱신 누락(CI SQLite blindspot) 원천 차단 ② S2~ 값 확장이 마이그 없이 가능. (AC ⑤ 기존 Gate enum 무변경 준수.)
- **idempotent**: 모든 create_table/create_index를 `inspector` 가드로 감쌈(alembic revision 추적에 더해 부분 적용·수동 migrate-dev 재시도 안전).
- **expand-contract(P1-5)**: 신규 테이블은 비어 있어 인덱스 생성이 기존 행을 잠그지 않음 → **CONCURRENTLY 불필요**(빈 테이블=즉시). S19 backfill이 채운 *이후* 재인덱싱 시 CONCURRENTLY(트랜잭션 밖) 전략은 docstring에 문서화.
- **partial unique 2종**: `uq_wf_step_run_active`(중복 in-flight 방지) / `uq_wf_step_run_pending_gate`(P0-2 duplicate_pending_gate=0).
- FK 미선언(AC 미명시) — 모든 member/gate/event 참조는 plain uuid 컬럼.

## ⚠️ 리뷰 확인 요청 (AC 미명시·코히어런스로 결정)
1. **`entity_type` NN 통일**: AC는 definitions에만 NN 명시. steps/step_runs/versions의 unique 제약에 entity_type이 포함되어 nullable이면 NULL-distinct로 unique 의도가 깨지므로 **전 테이블 NN**으로 통일.
2. **partial unique NULL-distinct**: definitions(project_id null)·step_runs(from_status null)는 PG NULL-distinct 규칙상 org-default/NULL-from 행 중복이 허용됨. AC 문구 그대로 구현. org-default 단일성 강제하려면 COALESCE 표현식 인덱스 필요 — 의도 확인(S2 거버넌스서 정리 가능).
3. **`workflow_delivery_outbox`(table 8)**: AC done ①의 "(+8 optional)"에 따라 additive 선반영(빈 테이블·무해·S7 재마이그 회피). 실제 사용은 S7에서 `dispatch_entity_to_assignee(commit=False)` 가능 여부로 결정 — S7로 defer가 낫다면 빼겠음.

## 검증
- **로컬 실 PostgreSQL**(격리 test DB·dev/prod 0접촉): Operations 직구동(env.py 우회)으로 `upgrade()` **2회 idempotent**·8/8 테이블·partial unique WHERE 확認·status TEXT+default(CHECK 0건)·JSONB policy 컬럼·`downgrade()` clean 전수 PASS.
- `alembic heads` = 0126(head)·chain 0125→0126 인식·py_compile OK.
- **CI `alembic-fresh-db`**(baseline 0096→…→0126) = 머지 게이트.

## 머지 후 (필수)
- 마이그 동반 PR → 머지=deploy=migrate-dev 원자. 머지 후 **`sprintable-migrate-dev` job 수동 실행** 필요(Cloud Build는 Alembic 자동 실행 안 함).
- dev/prod 공유 Cloud SQL: dev migrate가 prod DB에 즉시 적용되나, 본 마이그는 순수 additive(신규 테이블·기존 무변경)라 prod 코드 호환 — breaking 아님.

## 체크리스트
- [x] additive expand 마이그(7+outbox)·기존 무변경
- [x] idempotent inspect 가드
- [x] 로컬 실 PG upgrade(2회)/downgrade 검증
- [x] enum=text(CHECK 0·blindspot 차단)·CONCURRENTLY 전략 문서화
- [ ] 산티아고 SME 교차확인(범위·JSONB·enum/제약/partial unique·default-off)
- [ ] 까심 cross-model QA
- [ ] CI alembic-fresh-db green
- [ ] PO 머지게이트 → migrate-dev 수동 실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)