### PR TITLE
[2c1c3036] E-DG S2 — Line definition versioning + publish lint + config gate

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -53,7 +53,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -161,6 +161,7 @@ app.include_router(gates.router)
 app.include_router(gate_config.router)
 app.include_router(gate_config.org_router)
 app.include_router(gate_metrics.router)
+app.include_router(workflow_line_config.router)
 app.include_router(tasks.router)
 app.include_router(docs.router)
 app.include_router(public_docs.router)

--- a/backend/app/models/hitl_config.py
+++ b/backend/app/models/hitl_config.py
@@ -18,7 +18,7 @@ from app.core.database import Base
 
 POSTURES = frozenset({"conservative", "balanced", "permissive"})
 DISPOSITIONS = frozenset({"allow_auto", "ask", "deny"})
-GATE_TYPES = frozenset({"pr_review", "qa", "merge", "deploy"})
+GATE_TYPES = frozenset({"pr_review", "qa", "merge", "deploy", "workflow_config_publish"})
 
 _POSTURE_DEFAULT: dict[str, str] = {
     "conservative": "ask",

--- a/backend/app/models/workflow_line.py
+++ b/backend/app/models/workflow_line.py
@@ -1,0 +1,85 @@
+"""E-DECISION-GATE workflow line ORM models.
+
+Decision Gate(org-configurable 결재/핸드오프 라인)의 config 거버넌스 모델. 스키마는 S1
+마이그(0126)에서 생성됐고, 본 모듈은 그 테이블을 ORM 으로 표면화한다(컬럼/기본값은 0126 SSOT).
+S2 범위 = config lifecycle/approval/lint. 엔진(읽기 모델·workflow_line_steps materialize)은 S3.
+
+enum류는 text 컬럼 + 앱 레벨 validator(아래 상수)로 표현한다(0126 설계 일관 — DB CHECK/native
+enum 미사용).
+"""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Integer, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+# ── 앱 레벨 enum (text 컬럼 validator) ────────────────────────────────────────
+ENTITY_TYPES = frozenset({"story", "doc", "hypothesis", "epic", "sprint"})
+DEFINITION_SOURCES = frozenset({"system_default", "org_config", "project_override"})
+VERSION_STATUSES = frozenset({"draft", "pending_review", "published", "retired", "rejected"})
+LINT_STATUSES = frozenset({"not_run", "passed", "failed"})
+
+# version 상태 전이 규칙(거버넌스 lifecycle). published/retired/rejected = terminal-ish.
+VALID_VERSION_TRANSITIONS: dict[str, frozenset[str]] = {
+    "draft": frozenset({"pending_review", "retired"}),
+    "pending_review": frozenset({"published", "rejected", "draft", "retired"}),
+    "published": frozenset({"retired"}),
+    "rejected": frozenset({"draft", "retired"}),
+    "retired": frozenset(),
+}
+
+
+def is_valid_version_transition(old: str, new: str) -> bool:
+    return new in VALID_VERSION_TRANSITIONS.get(old, frozenset())
+
+
+class WorkflowLineDefinition(Base):
+    """활성 라인 포인터(org/project overlay). org/project/entity 당 active 1개(0126 split unique)."""
+
+    __tablename__ = "workflow_line_definitions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    entity_type: Mapped[str] = mapped_column(Text, nullable=False)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    version: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1")
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
+    source: Mapped[str] = mapped_column(Text, nullable=False, server_default="org_config")
+    created_by_member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    retired_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    config_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+
+class WorkflowLineDefinitionVersion(Base):
+    """라인 config 버전(P0-4 거버넌스). draft→pending_review→published/rejected→retired."""
+
+    __tablename__ = "workflow_line_definition_versions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    line_definition_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    entity_type: Mapped[str] = mapped_column(Text, nullable=False)
+    version: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default="draft")
+    config: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default="{}")
+    config_hash: Mapped[str] = mapped_column(Text, nullable=False)
+    lint_status: Mapped[str] = mapped_column(Text, nullable=False, server_default="not_run")
+    lint_errors: Mapped[list] = mapped_column(JSONB, nullable=False, server_default="[]")
+    created_by_member_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    reviewed_by_member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    review_gate_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/routers/workflow_line_config.py
+++ b/backend/app/routers/workflow_line_config.py
@@ -14,12 +14,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.models.gate import Gate
 from app.models.workflow_line import ENTITY_TYPES, WorkflowLineDefinitionVersion
 from app.services.gate_service import transition_gate
 from app.services.project_auth import get_project_role, is_org_owner_or_admin
 from app.services.workflow_line_config import (
     PublishLintError,
     SelfApprovalError,
+    assert_not_self_approval,
     complete_publish,
     create_draft,
     lint_config,
@@ -172,6 +174,17 @@ async def approve_publish(
     version = await _load_version(session, org_id, version_id)
     if version.review_gate_id is None:
         raise HTTPException(status_code=409, detail="version has no publish gate (request-publish first)")
+    # self-approval 선검증 — transition_gate side-effect(verdict 기록 등) 타기 전에 차단(SME 권장).
+    gate_r = await session.execute(
+        select(Gate).where(Gate.id == version.review_gate_id, Gate.org_id == org_id)
+    )
+    gate = gate_r.scalar_one_or_none()
+    if gate is None:
+        raise HTTPException(status_code=409, detail="publish gate not found")
+    try:
+        assert_not_self_approval(gate, actor, version.id)
+    except SelfApprovalError:
+        raise HTTPException(status_code=403, detail="self-approval forbidden: requester cannot approve own publish")
     try:
         # transition_gate 레일 재사용 → 직후 complete_publish 콜백(내부 특수분기 금지).
         gate = await transition_gate(session, org_id, version.review_gate_id, "approved", resolver_id=actor)

--- a/backend/app/routers/workflow_line_config.py
+++ b/backend/app/routers/workflow_line_config.py
@@ -1,0 +1,219 @@
+"""E-DECISION-GATE S2: workflow line config 거버넌스 API (P0-4).
+
+라인 config 의 draft 관리 + publish lint + publish gate(org owner/admin 승인·self-approval 금지).
+RBAC: draft 관리 = project admin+(또는 org owner/admin) / publish(요청·승인) = org owner/admin.
+스키마/엔진은 S1/S3. 본 라우터는 거버넌스 lifecycle 만 노출한다.
+"""
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict, field_validator
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.models.workflow_line import ENTITY_TYPES, WorkflowLineDefinitionVersion
+from app.services.gate_service import transition_gate
+from app.services.project_auth import get_project_role, is_org_owner_or_admin
+from app.services.workflow_line_config import (
+    PublishLintError,
+    SelfApprovalError,
+    complete_publish,
+    create_draft,
+    lint_config,
+    request_publish,
+    transition_version,
+)
+
+router = APIRouter(prefix="/api/v2/workflow-line-config", tags=["workflow-line-config"])
+
+
+# ── schemas ───────────────────────────────────────────────────────────────────
+class CreateDraftRequest(BaseModel):
+    entity_type: str
+    config: dict[str, Any]
+    project_id: uuid.UUID | None = None
+
+    @field_validator("entity_type")
+    @classmethod
+    def _validate_entity_type(cls, v: str) -> str:
+        if v not in ENTITY_TYPES:
+            raise ValueError(f"entity_type must be one of {sorted(ENTITY_TYPES)}")
+        return v
+
+
+class VersionResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    org_id: uuid.UUID
+    project_id: uuid.UUID | None
+    entity_type: str
+    version: int
+    status: str
+    config_hash: str
+    lint_status: str
+    lint_errors: list
+    line_definition_id: uuid.UUID | None
+    review_gate_id: uuid.UUID | None
+
+
+class LintResponse(BaseModel):
+    lint_status: str
+    errors: list[dict[str, str]]
+
+
+class PublishResponse(BaseModel):
+    version: VersionResponse
+    gate_id: uuid.UUID
+    gate_status: str
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+async def _load_version(session: AsyncSession, org_id: uuid.UUID, version_id: uuid.UUID) -> WorkflowLineDefinitionVersion:
+    r = await session.execute(
+        select(WorkflowLineDefinitionVersion).where(
+            WorkflowLineDefinitionVersion.id == version_id,
+            WorkflowLineDefinitionVersion.org_id == org_id,
+        )
+    )
+    version = r.scalar_one_or_none()
+    if version is None:
+        raise HTTPException(status_code=404, detail="version not found")
+    return version
+
+
+async def _require_draft_author(session, actor, org_id, project_id) -> None:
+    """draft 관리 권한: project 스코프면 project admin/owner 또는 org owner/admin, org 스코프면 org owner/admin."""
+    if project_id is not None:
+        role = await get_project_role(session, actor, project_id)
+        if role in ("owner", "admin") or await is_org_owner_or_admin(session, actor, org_id):
+            return
+        raise HTTPException(status_code=403, detail="project admin or org owner/admin required")
+    if not await is_org_owner_or_admin(session, actor, org_id):
+        raise HTTPException(status_code=403, detail="org owner/admin required for org-level config")
+
+
+async def _require_publisher(session, actor, org_id) -> None:
+    """publish(요청·승인) = org owner/admin 전용(AC ②)."""
+    if not await is_org_owner_or_admin(session, actor, org_id):
+        raise HTTPException(status_code=403, detail="org owner/admin required to publish workflow config")
+
+
+# ── endpoints ──────────────────────────────────────────────────────────────────
+@router.post("/versions", response_model=VersionResponse, status_code=201)
+async def create_draft_version(
+    body: CreateDraftRequest,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> VersionResponse:
+    actor = uuid.UUID(auth.user_id)
+    await _require_draft_author(session, actor, org_id, body.project_id)
+    version = await create_draft(session, org_id, body.project_id, body.entity_type, body.config, actor)
+    await session.commit()
+    return VersionResponse.model_validate(version)
+
+
+@router.get("/versions/{version_id}", response_model=VersionResponse)
+async def get_version(
+    version_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth: AuthContext = Depends(get_current_user),
+) -> VersionResponse:
+    return VersionResponse.model_validate(await _load_version(session, org_id, version_id))
+
+
+@router.post("/versions/{version_id}/lint", response_model=LintResponse)
+async def lint_version(
+    version_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth: AuthContext = Depends(get_current_user),
+) -> LintResponse:
+    version = await _load_version(session, org_id, version_id)
+    errors = lint_config(version.config)
+    return LintResponse(lint_status="failed" if errors else "passed", errors=errors)
+
+
+@router.post("/versions/{version_id}/request-publish", response_model=PublishResponse)
+async def request_publish_version(
+    version_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> PublishResponse:
+    actor = uuid.UUID(auth.user_id)
+    await _require_publisher(session, actor, org_id)
+    version = await _load_version(session, org_id, version_id)
+    try:
+        version, gate = await request_publish(session, org_id, version, actor)
+    except PublishLintError as e:
+        await session.commit()  # lint_status/errors persist
+        raise HTTPException(status_code=422, detail={"error": "publish_lint_failed", "lint_errors": e.errors})
+    await session.commit()
+    return PublishResponse(
+        version=VersionResponse.model_validate(version), gate_id=gate.id, gate_status=gate.status
+    )
+
+
+@router.post("/versions/{version_id}/approve", response_model=VersionResponse)
+async def approve_publish(
+    version_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> VersionResponse:
+    """publish gate 승인 → version published 확정. org owner/admin + self-approval 금지."""
+    actor = uuid.UUID(auth.user_id)
+    await _require_publisher(session, actor, org_id)
+    version = await _load_version(session, org_id, version_id)
+    if version.review_gate_id is None:
+        raise HTTPException(status_code=409, detail="version has no publish gate (request-publish first)")
+    try:
+        # transition_gate 레일 재사용 → 직후 complete_publish 콜백(내부 특수분기 금지).
+        gate = await transition_gate(session, org_id, version.review_gate_id, "approved", resolver_id=actor)
+        version = await complete_publish(session, version, gate, resolver_id=actor)
+    except SelfApprovalError:
+        raise HTTPException(status_code=403, detail="self-approval forbidden: requester cannot approve own publish")
+    except ValueError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    await session.commit()
+    return VersionResponse.model_validate(version)
+
+
+@router.post("/versions/{version_id}/reject", response_model=VersionResponse)
+async def reject_publish(
+    version_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> VersionResponse:
+    actor = uuid.UUID(auth.user_id)
+    await _require_publisher(session, actor, org_id)
+    version = await _load_version(session, org_id, version_id)
+    if version.review_gate_id is not None:
+        try:
+            await transition_gate(session, org_id, version.review_gate_id, "rejected", resolver_id=actor)
+        except ValueError:
+            pass  # gate already resolved — version 전이만 반영
+    version = await transition_version(session, version, "rejected")
+    await session.commit()
+    return VersionResponse.model_validate(version)
+
+
+@router.post("/versions/{version_id}/retire", response_model=VersionResponse)
+async def retire_version(
+    version_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> VersionResponse:
+    actor = uuid.UUID(auth.user_id)
+    await _require_publisher(session, actor, org_id)
+    version = await _load_version(session, org_id, version_id)
+    version = await transition_version(session, version, "retired")
+    await session.commit()
+    return VersionResponse.model_validate(version)

--- a/backend/app/services/workflow_line_config.py
+++ b/backend/app/services/workflow_line_config.py
@@ -259,9 +259,10 @@ async def request_publish(
     )
     version.review_gate_id = gate.id
     await session.flush()
-    # allow_auto → gate.status == approved 로 생성됨 → 즉시 확정(요청자=approver 아님: 자동승인은
-    # org 정책 override 결과라 self-approval 가드 비대상).
-    if gate.status == "approved":
+    # allow_auto disposition → create_gate 가 status='auto_passed' 로 생성(approved 아님·gate.py
+    # _DISPOSITION_TO_STATUS) → 즉시 publish 확정. 자동승인은 org 정책 override 결과라 self-approval
+    # 가드 비대상(_auto=True). ask → 'pending' 유지(org owner/admin 승인 대기).
+    if gate.status in ("approved", "auto_passed"):
         await complete_publish(session, version, gate, resolver_id=None, _auto=True)
     await session.refresh(version)
     return version, gate
@@ -275,15 +276,15 @@ async def complete_publish(
 
     transition_gate() 직후 콜백으로 호출(내부 특수분기 금지). self-approval 은 승인 시점에 재검증.
     """
-    if gate.status != "approved":
+    # allow_auto disposition → 'auto_passed'(immutable), 휴먼 승인 → 'approved'. 둘 다 publish 확정.
+    if gate.status not in ("approved", "auto_passed"):
         raise ValueError(f"gate {gate.id} not approved (status={gate.status})")
     if gate.gate_type != WORKFLOW_CONFIG_PUBLISH_GATE_TYPE:
         raise ValueError("gate is not a workflow_config_publish gate")
-    # self-approval 재검증(휴먼 승인 경로). 자동승인(_auto)은 org 정책 결과라 제외.
-    if not _auto and resolver_id is not None:
-        requested_by = (gate.neutral_facts or {}).get("requested_by_member_id")
-        if requested_by and str(resolver_id) == str(requested_by):
-            raise SelfApprovalError(version.id)
+    # self-approval 재검증(휴먼 승인 경로·defense-in-depth — endpoint 가 transition_gate 전 선검증도
+    # 하지만 서비스 직접 호출 대비 한 번 더). 자동승인(_auto)은 org 정책 결과라 제외.
+    if not _auto:
+        assert_not_self_approval(gate, resolver_id, version.id)
     if version.status == "published":
         return version  # 멱등
 
@@ -321,6 +322,16 @@ async def complete_publish(
     await session.flush()
     await session.refresh(version)
     return version
+
+
+def assert_not_self_approval(gate: Gate, resolver_id: uuid.UUID | None, version_id: uuid.UUID) -> None:
+    """요청자 == 승인자면 SelfApprovalError. transition_gate 호출 前 선검증(approve side-effect 차단)
+    과 complete_publish 재검증이 공용으로 쓴다."""
+    if resolver_id is None:
+        return
+    requested_by = (gate.neutral_facts or {}).get("requested_by_member_id")
+    if requested_by and str(resolver_id) == str(requested_by):
+        raise SelfApprovalError(version_id)
 
 
 class PublishLintError(Exception):

--- a/backend/app/services/workflow_line_config.py
+++ b/backend/app/services/workflow_line_config.py
@@ -1,0 +1,339 @@
+"""E-DECISION-GATE S2: workflow line config 거버넌스 서비스 (P0-4).
+
+라인 config 의 draft/publish lifecycle + publish lint(hard-fail) + publish gate(승인 거버넌스).
+"bad config 가 published line 으로 못 들어가게" 하는 게 목적이다.
+
+설계(PO/SME 사인오프):
+- 재사용: ``Gate``(gate_type='workflow_config_publish') · ``gate_service.create_gate``(idempotent +
+  ``resolve_disposition`` 4-tier precedence) · gate disposition precedence 철학은
+  ``app/services/gate_resolver.py`` 의 member_override→role_override→org_policy→system_default 를
+  그대로 따른다(신규 권한체계 0).
+- 경계: S2 = config lifecycle/approval/lint + ``workflow_line_definitions`` active pointer flip.
+  ``workflow_line_steps`` materialize(엔진 read-model)는 S3.
+- gate 승인 → published 확정은 ``transition_gate()`` 레일 재사용 + ``complete_publish()`` 콜백
+  (transition_gate 내부에 E-DG 특수분기 누적 금지 — orphan 방지).
+
+published version/config_hash 는 immutable(수정 = 새 draft). connector allow-list lint 는 SDK
+``INJECTABLE_EVENT_TYPES`` 단일출처를 기준으로 한다(parity 는 test 가 가드).
+"""
+import hashlib
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.gate import Gate
+from app.models.participation import ParticipationRole
+from app.models.workflow_line import (
+    VERSION_STATUSES,
+    WorkflowLineDefinition,
+    WorkflowLineDefinitionVersion,
+    is_valid_version_transition,
+)
+from app.services.gate_service import create_gate
+
+WORKFLOW_CONFIG_PUBLISH_GATE_TYPE = "workflow_config_publish"
+# Gate.work_item_type 는 String(20) — 라인 버전 식별자는 ≤20자로 유지(work_item_id=version.id).
+WORKFLOW_LINE_VERSION_WORK_ITEM_TYPE = "wf_line_version"
+
+# connector allow-list(lint ④). SDK connectors/sdk/sprintable_sse.py 의 INJECTABLE_EVENT_TYPES 단일
+# 출처를 미러링한다. 드리프트는 test_workflow_line_config 의 sync-guard 가 AST 로 잡는다(어댑터
+# vendoring 가드와 동일 패턴).
+WORKFLOW_EVENT_ALLOWLIST = frozenset({
+    "dispatched",
+    "story_assigned",
+    "conversation.message_created",
+    "conversation:mention",
+    "kickoff",
+    "review_request",
+    "qa_request",
+    "deploy_request",
+    "handoff",
+})
+
+# routing_rules 허용 field/op(arbitrary expression 금지·AC: all|any + 비교op + field allow-list).
+ALLOWED_ROUTING_FIELDS = frozenset({
+    "trust_score", "risk_level", "outcome_status", "entity_type", "from_status",
+    "to_status", "assignee_type", "story_points", "actor_type",
+})
+ALLOWED_ROUTING_OPS = frozenset({"eq", "ne", "lt", "lte", "gt", "gte", "in", "not_in"})
+_HUMAN_STEP_TYPES = frozenset({"human-gate", "merge-gate"})
+
+
+def compute_config_hash(config: dict[str, Any]) -> str:
+    """canonical JSON 의 SHA256 — config 변조 감지(immutable audit)."""
+    canonical = json.dumps(config, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+# ── publish lint (8종 hard-fail) ──────────────────────────────────────────────
+def lint_config(config: dict[str, Any]) -> list[dict[str, str]]:
+    """published line 에 들어가면 안 되는 config 를 hard-fail 로 적출.
+
+    반환: 에러 리스트(빈 리스트 = pass). 각 에러 = {"rule": <code>, "detail": <msg>}.
+    """
+    errors: list[dict[str, str]] = []
+    steps = config.get("steps") if isinstance(config, dict) else None
+    if not isinstance(steps, list):
+        errors.append({"rule": "no_steps", "detail": "config.steps must be a non-empty list"})
+        return errors
+    if not steps:
+        errors.append({"rule": "no_steps", "detail": "config has no steps"})
+        return errors
+
+    non_block_exists = False
+    for i, step in enumerate(steps):
+        if not isinstance(step, dict):
+            errors.append({"rule": "unknown_field", "detail": f"step[{i}] is not an object"})
+            continue
+        loc = step.get("step_key") or f"step[{i}]"
+        step_type = step.get("step_type")
+
+        # ① unknown field/op — routing_rules 의 field/op allow-list.
+        for r_idx, rule in enumerate(step.get("routing_rules") or []):
+            if not isinstance(rule, dict):
+                errors.append({"rule": "unknown_field", "detail": f"{loc} routing_rules[{r_idx}] not an object"})
+                continue
+            if rule.get("mode") not in (None, "all", "any"):
+                errors.append({"rule": "unknown_op", "detail": f"{loc} routing mode '{rule.get('mode')}' invalid (all|any)"})
+            for cond in rule.get("conditions") or []:
+                if not isinstance(cond, dict):
+                    continue
+                if cond.get("field") not in ALLOWED_ROUTING_FIELDS:
+                    errors.append({"rule": "unknown_field", "detail": f"{loc} routing field '{cond.get('field')}' not in allow-list"})
+                if cond.get("op") not in ALLOWED_ROUTING_OPS:
+                    errors.append({"rule": "unknown_op", "detail": f"{loc} routing op '{cond.get('op')}' not in allow-list"})
+            # ⑥ catch-all auto_route — 무조건 자동라우팅(human 우회).
+            if rule.get("catch_all") and rule.get("decision") == "auto_route":
+                errors.append({"rule": "catch_all_auto_route", "detail": f"{loc} has catch-all auto_route (no human path)"})
+
+        decision_set = {(r.get("decision") if isinstance(r, dict) else None) for r in (step.get("routing_rules") or [])}
+        if step_type != "advisory" and decision_set != {"block"}:
+            non_block_exists = True
+        if not step.get("routing_rules"):
+            non_block_exists = True  # 룰 없는 step 은 plain transition(통과)
+
+        approval = step.get("approval_policy") if isinstance(step.get("approval_policy"), dict) else {}
+        if step_type in _HUMAN_STEP_TYPES:
+            approvers = approval.get("approvers") or []
+            # ② no approver.
+            if not approvers and not approval.get("approver_role"):
+                errors.append({"rule": "no_approver", "detail": f"{loc} ({step_type}) has no approver"})
+            # ③ self-approval only — 승인 경로가 self 단독.
+            if approval.get("self_approval") == "allow_only" or (
+                approvers == ["self"] or approval.get("only_self")
+            ):
+                errors.append({"rule": "self_approval_only", "detail": f"{loc} permits self-approval only"})
+
+        # ④ no fallback/deputy — human step 의 assignee 에 fallback/deputy 부재.
+        assignee = step.get("assignee_policy") if isinstance(step.get("assignee_policy"), dict) else {}
+        if step_type in _HUMAN_STEP_TYPES:
+            if not (assignee.get("fallback") or assignee.get("deputy") or assignee.get("fallback_role")):
+                errors.append({"rule": "no_fallback", "detail": f"{loc} ({step_type}) has no fallback/deputy"})
+
+        # ⑦ high-risk timeout auto_approve.
+        sla = step.get("sla_policy") if isinstance(step.get("sla_policy"), dict) else {}
+        if sla.get("on_timeout") == "auto_approve" and (
+            step_type in _HUMAN_STEP_TYPES or sla.get("applies_to_high_risk", True)
+        ):
+            errors.append({"rule": "high_risk_timeout_auto_approve", "detail": f"{loc} auto_approves on SLA timeout"})
+
+        # ⑧ connector allow-list 밖 event type.
+        for ev in _collect_event_types(step):
+            if ev not in WORKFLOW_EVENT_ALLOWLIST:
+                errors.append({"rule": "event_not_in_allowlist", "detail": f"{loc} event_type '{ev}' not in connector allow-list"})
+
+    # ⑤ all transitions blocked.
+    if not non_block_exists:
+        errors.append({"rule": "all_transitions_blocked", "detail": "every step blocks — no forward path"})
+
+    return errors
+
+
+def _collect_event_types(step: dict[str, Any]) -> list[str]:
+    evs: list[str] = []
+    for key in ("on_approve", "on_reject"):
+        block = step.get(key)
+        if isinstance(block, dict):
+            ev = block.get("emit_event") or block.get("event_type")
+            if isinstance(ev, str):
+                evs.append(ev)
+    ev = step.get("event_type")
+    if isinstance(ev, str):
+        evs.append(ev)
+    return evs
+
+
+# ── version lifecycle ────────────────────────────────────────────────────────
+async def _next_version(session: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID | None,
+                        entity_type: str) -> int:
+    r = await session.execute(
+        select(func.max(WorkflowLineDefinitionVersion.version)).where(
+            WorkflowLineDefinitionVersion.org_id == org_id,
+            WorkflowLineDefinitionVersion.project_id.is_(project_id) if project_id is None
+            else WorkflowLineDefinitionVersion.project_id == project_id,
+            WorkflowLineDefinitionVersion.entity_type == entity_type,
+        )
+    )
+    return (r.scalar() or 0) + 1
+
+
+async def create_draft(
+    session: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID | None,
+    entity_type: str, config: dict[str, Any], created_by: uuid.UUID,
+) -> WorkflowLineDefinitionVersion:
+    """새 draft version 생성. lint 는 비차단(draft 단계서는 경고만·publish 에서 hard-fail)."""
+    version_no = await _next_version(session, org_id, project_id, entity_type)
+    errors = lint_config(config)
+    version = WorkflowLineDefinitionVersion(
+        org_id=org_id, project_id=project_id, entity_type=entity_type, version=version_no,
+        status="draft", config=config, config_hash=compute_config_hash(config),
+        lint_status="failed" if errors else "passed", lint_errors=errors,
+        created_by_member_id=created_by,
+    )
+    session.add(version)
+    await session.flush()
+    await session.refresh(version)
+    return version
+
+
+async def transition_version(
+    session: AsyncSession, version: WorkflowLineDefinitionVersion, new_status: str,
+) -> WorkflowLineDefinitionVersion:
+    """version lifecycle 전이(거버넌스 규칙 검증)."""
+    if new_status not in VERSION_STATUSES:
+        raise ValueError(f"invalid version status: {new_status}")
+    if not is_valid_version_transition(version.status, new_status):
+        raise ValueError(f"불법 version 전이: {version.status} → {new_status}")
+    version.status = new_status
+    await session.flush()
+    await session.refresh(version)
+    return version
+
+
+async def _default_role_id(session: AsyncSession, org_id: uuid.UUID) -> uuid.UUID | None:
+    r = await session.execute(
+        select(ParticipationRole.id).where(
+            ParticipationRole.org_id == org_id, ParticipationRole.is_default.is_(True)
+        ).limit(1)
+    )
+    return r.scalar_one_or_none()
+
+
+async def request_publish(
+    session: AsyncSession, org_id: uuid.UUID, version: WorkflowLineDefinitionVersion,
+    member_id: uuid.UUID,
+) -> tuple[WorkflowLineDefinitionVersion, Gate]:
+    """publish 요청: lint hard-fail → Gate(workflow_config_publish) 생성.
+
+    disposition allow_auto 면 gate 가 approved 로 생성되고 즉시 publish 확정,
+    ask 면 pending(org owner/admin 승인 대기). lint 실패 시 ValueError(hard-fail).
+    """
+    errors = lint_config(version.config)
+    version.lint_status = "failed" if errors else "passed"
+    version.lint_errors = errors
+    if errors:
+        await session.flush()
+        raise PublishLintError(errors)
+
+    if version.status not in ("draft", "pending_review", "rejected"):
+        raise ValueError(f"version {version.id} status {version.status} cannot request publish")
+    if version.status != "pending_review":
+        await transition_version(session, version, "pending_review")
+
+    role_id = await _default_role_id(session, org_id) or uuid.uuid4()
+    gate = await create_gate(
+        session=session, org_id=org_id, work_item_id=version.id,
+        work_item_type=WORKFLOW_LINE_VERSION_WORK_ITEM_TYPE,
+        gate_type=WORKFLOW_CONFIG_PUBLISH_GATE_TYPE,
+        member_id=member_id, role_id=role_id,
+        neutral_facts={
+            "version_id": str(version.id),
+            "config_hash": version.config_hash,
+            "requested_by_member_id": str(member_id),
+            "entity_type": version.entity_type,
+        },
+    )
+    version.review_gate_id = gate.id
+    await session.flush()
+    # allow_auto → gate.status == approved 로 생성됨 → 즉시 확정(요청자=approver 아님: 자동승인은
+    # org 정책 override 결과라 self-approval 가드 비대상).
+    if gate.status == "approved":
+        await complete_publish(session, version, gate, resolver_id=None, _auto=True)
+    await session.refresh(version)
+    return version, gate
+
+
+async def complete_publish(
+    session: AsyncSession, version: WorkflowLineDefinitionVersion, gate: Gate,
+    resolver_id: uuid.UUID | None, _auto: bool = False,
+) -> WorkflowLineDefinitionVersion:
+    """gate approved → version published 확정 + active pointer flip(동일 트랜잭션).
+
+    transition_gate() 직후 콜백으로 호출(내부 특수분기 금지). self-approval 은 승인 시점에 재검증.
+    """
+    if gate.status != "approved":
+        raise ValueError(f"gate {gate.id} not approved (status={gate.status})")
+    if gate.gate_type != WORKFLOW_CONFIG_PUBLISH_GATE_TYPE:
+        raise ValueError("gate is not a workflow_config_publish gate")
+    # self-approval 재검증(휴먼 승인 경로). 자동승인(_auto)은 org 정책 결과라 제외.
+    if not _auto and resolver_id is not None:
+        requested_by = (gate.neutral_facts or {}).get("requested_by_member_id")
+        if requested_by and str(resolver_id) == str(requested_by):
+            raise SelfApprovalError(version.id)
+    if version.status == "published":
+        return version  # 멱등
+
+    now = datetime.now(timezone.utc)
+    version.status = "published"
+    version.published_at = now
+    version.reviewed_by_member_id = resolver_id
+
+    # active pointer flip — 같은 (org, project, entity) 의 기존 active definition 은 retire,
+    # 신규 active definition 을 이 published version 으로 세운다(동일 트랜잭션).
+    existing_r = await session.execute(
+        select(WorkflowLineDefinition).where(
+            WorkflowLineDefinition.org_id == version.org_id,
+            WorkflowLineDefinition.project_id.is_(None) if version.project_id is None
+            else WorkflowLineDefinition.project_id == version.project_id,
+            WorkflowLineDefinition.entity_type == version.entity_type,
+            WorkflowLineDefinition.is_active.is_(True),
+        )
+    )
+    for old in existing_r.scalars().all():
+        old.is_active = False
+        old.retired_at = now
+
+    definition = WorkflowLineDefinition(
+        org_id=version.org_id, project_id=version.project_id, entity_type=version.entity_type,
+        name=(version.config or {}).get("name") or f"{version.entity_type} line",
+        version=version.version, is_active=True,
+        source="project_override" if version.project_id else "org_config",
+        created_by_member_id=version.created_by_member_id,
+        published_at=now, config_hash=version.config_hash,
+    )
+    session.add(definition)
+    await session.flush()
+    version.line_definition_id = definition.id
+    await session.flush()
+    await session.refresh(version)
+    return version
+
+
+class PublishLintError(Exception):
+    """publish lint hard-fail."""
+
+    def __init__(self, errors: list[dict[str, str]]):
+        self.errors = errors
+        super().__init__(f"publish lint failed: {len(errors)} error(s)")
+
+
+class SelfApprovalError(Exception):
+    """요청자 == 승인자(self-approval forbidden)."""
+
+    def __init__(self, version_id: uuid.UUID):
+        self.version_id = version_id
+        super().__init__("self-approval forbidden for workflow_config_publish")

--- a/backend/tests/test_edg_s2_config_governance.py
+++ b/backend/tests/test_edg_s2_config_governance.py
@@ -1,0 +1,239 @@
+"""E-DG S2: workflow line config 거버넌스 테스트.
+
+순수(DB 불요): lint 8종 + clean pass · config_hash 결정성 · connector allow-list SDK 동기화 가드.
+DB-backed(real PG 필요): create_draft · request_publish(lint fail/pass·gate) · complete_publish
+(self-approval 금지 · published + active pointer flip · 멱등).
+"""
+from __future__ import annotations
+
+import ast
+import os
+import uuid
+
+import pytest
+
+from app.services.workflow_line_config import (
+    WORKFLOW_EVENT_ALLOWLIST,
+    compute_config_hash,
+    lint_config,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── clean config (passes lint) ────────────────────────────────────────────────
+def _clean_config() -> dict:
+    return {
+        "name": "story line",
+        "steps": [
+            {
+                "step_key": "story.in-review.done", "step_type": "merge-gate",
+                "from_status": "in-review", "to_status": "done", "step_order": 1,
+                "approval_policy": {"approvers": ["role:po"], "self_approval": "forbid"},
+                "assignee_policy": {"role": "po", "deputy": "role:lead"},
+                "routing_rules": [{"mode": "all", "conditions": [
+                    {"field": "trust_score", "op": "gte", "value": 0.8}], "decision": "auto_route"}],
+                "sla_policy": {"timeout_minutes": 60, "on_timeout": "escalate"},
+            }
+        ],
+    }
+
+
+def _rules(errors):
+    return {e["rule"] for e in errors}
+
+
+# ── pure: lint 8종 ──────────────────────────────────────────────────────────────
+def test_lint_clean_passes():
+    assert lint_config(_clean_config()) == []
+
+
+def test_lint_no_steps():
+    assert "no_steps" in _rules(lint_config({"steps": []}))
+    assert "no_steps" in _rules(lint_config({}))
+
+
+def test_lint_unknown_field_and_op():
+    c = _clean_config()
+    c["steps"][0]["routing_rules"] = [{"mode": "all", "conditions": [
+        {"field": "secret_backdoor", "op": "regex"}], "decision": "auto_route"}]
+    r = _rules(lint_config(c))
+    assert "unknown_field" in r and "unknown_op" in r
+
+
+def test_lint_no_approver():
+    c = _clean_config()
+    c["steps"][0]["approval_policy"] = {"self_approval": "forbid"}
+    assert "no_approver" in _rules(lint_config(c))
+
+
+def test_lint_self_approval_only():
+    c = _clean_config()
+    c["steps"][0]["approval_policy"] = {"approvers": ["self"], "self_approval": "allow_only"}
+    assert "self_approval_only" in _rules(lint_config(c))
+
+
+def test_lint_no_fallback_deputy():
+    c = _clean_config()
+    c["steps"][0]["assignee_policy"] = {"role": "po"}  # no deputy/fallback
+    assert "no_fallback" in _rules(lint_config(c))
+
+
+def test_lint_all_transitions_blocked():
+    c = _clean_config()
+    c["steps"][0]["step_type"] = "agent-handoff"
+    c["steps"][0]["routing_rules"] = [{"mode": "all", "conditions": [], "decision": "block"}]
+    assert "all_transitions_blocked" in _rules(lint_config(c))
+
+
+def test_lint_catch_all_auto_route():
+    c = _clean_config()
+    c["steps"][0]["routing_rules"] = [{"mode": "any", "catch_all": True, "decision": "auto_route"}]
+    assert "catch_all_auto_route" in _rules(lint_config(c))
+
+
+def test_lint_high_risk_timeout_auto_approve():
+    c = _clean_config()
+    c["steps"][0]["sla_policy"] = {"timeout_minutes": 30, "on_timeout": "auto_approve"}
+    assert "high_risk_timeout_auto_approve" in _rules(lint_config(c))
+
+
+def test_lint_event_not_in_allowlist():
+    c = _clean_config()
+    c["steps"][0]["on_approve"] = {"emit_event": "totally_made_up_event"}
+    assert "event_not_in_allowlist" in _rules(lint_config(c))
+    # allow-list 내 event 는 통과
+    c["steps"][0]["on_approve"] = {"emit_event": "handoff"}
+    assert "event_not_in_allowlist" not in _rules(lint_config(c))
+
+
+# ── pure: config_hash ───────────────────────────────────────────────────────────
+def test_config_hash_deterministic_and_order_insensitive():
+    a = {"x": 1, "y": [1, 2], "z": {"b": 2, "a": 1}}
+    b = {"z": {"a": 1, "b": 2}, "y": [1, 2], "x": 1}
+    assert compute_config_hash(a) == compute_config_hash(b)
+    assert compute_config_hash(a) != compute_config_hash({"x": 2})
+    assert len(compute_config_hash(a)) == 64  # sha256 hex
+
+
+# ── pure: connector allow-list SDK 동기화 가드 ──────────────────────────────────
+def test_event_allowlist_matches_sdk_source():
+    """WORKFLOW_EVENT_ALLOWLIST 가 SDK INJECTABLE_EVENT_TYPES 단일출처와 일치(드리프트 가드).
+
+    SDK 모듈은 backend 가 import 하지 않으므로 AST 로 frozenset literal 을 파싱해 비교한다.
+    """
+    here = os.path.dirname(os.path.abspath(__file__))
+    sdk = os.path.normpath(os.path.join(here, "..", "..", "connectors", "sdk", "sprintable_sse.py"))
+    tree = ast.parse(open(sdk, encoding="utf-8").read())
+    found = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "INJECTABLE_EVENT_TYPES" for t in node.targets
+        ):
+            call = node.value
+            assert isinstance(call, ast.Call), "expected frozenset({...}) literal"
+            found = set(ast.literal_eval(call.args[0]))
+            break
+    assert found is not None, "INJECTABLE_EVENT_TYPES not found in SDK"
+    assert set(WORKFLOW_EVENT_ALLOWLIST) == found, (
+        f"allow-list drift: backend={set(WORKFLOW_EVENT_ALLOWLIST)} vs sdk={found}"
+    )
+
+
+# ── DB-backed: lifecycle + publish gate + active flip ────────────────────────────
+async def _make_engine_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401 — 전 모델 등록(create_all)
+    import app.models.workflow_line  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_default_role(session, org_id):
+    from app.models.participation import ParticipationRole
+    role = ParticipationRole(id=uuid.uuid4(), org_id=org_id, key="default", label="Default", is_default=True)
+    session.add(role)
+    await session.flush()
+    return role
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_request_publish_lint_fail_blocks():
+    from app.services.workflow_line_config import PublishLintError, create_draft, request_publish
+
+    engine, Session = await _make_engine_session()
+    org_id, member = uuid.uuid4(), uuid.uuid4()
+    async with Session() as session:
+        await _seed_default_role(session, org_id)
+        bad = {"steps": [{"step_key": "s", "step_type": "merge-gate"}]}  # no approver/fallback
+        version = await create_draft(session, org_id, None, "story", bad, member)
+        assert version.lint_status == "failed"
+        with pytest.raises(PublishLintError):
+            await request_publish(session, org_id, version, member)
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_publish_flow_gate_and_active_flip():
+    from app.services.workflow_line_config import (
+        SelfApprovalError, complete_publish, create_draft, request_publish,
+    )
+    from sqlalchemy import select
+    from app.models.workflow_line import WorkflowLineDefinition
+
+    engine, Session = await _make_engine_session()
+    org_id, requester, approver = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    async with Session() as session:
+        await _seed_default_role(session, org_id)
+        version = await create_draft(session, org_id, None, "story", _clean_config(), requester)
+        version, gate = await request_publish(session, org_id, version, requester)
+        # default disposition = ask → pending gate, version pending_review
+        assert gate.status == "pending" and version.status == "pending_review"
+        assert gate.gate_type == "workflow_config_publish"
+        assert (gate.neutral_facts or {}).get("version_id") == str(version.id)
+        assert (gate.neutral_facts or {}).get("config_hash") == version.config_hash
+
+        # self-approval 금지: requester == resolver
+        gate.status = "approved"
+        await session.flush()
+        with pytest.raises(SelfApprovalError):
+            await complete_publish(session, version, gate, resolver_id=requester)
+
+        # 다른 org owner/admin 승인 → published + active definition 생성
+        version = await complete_publish(session, version, gate, resolver_id=approver)
+        assert version.status == "published" and version.published_at is not None
+        defs = (await session.execute(
+            select(WorkflowLineDefinition).where(
+                WorkflowLineDefinition.org_id == org_id, WorkflowLineDefinition.is_active.is_(True))
+        )).scalars().all()
+        assert len(defs) == 1 and defs[0].config_hash == version.config_hash
+
+        # 2번째 라인 publish → 기존 active retire, 신규 active 1개만
+        v2 = await create_draft(session, org_id, None, "story", _clean_config(), requester)
+        v2, g2 = await request_publish(session, org_id, v2, requester)
+        g2.status = "approved"
+        await session.flush()
+        await complete_publish(session, v2, g2, resolver_id=approver)
+        active = (await session.execute(
+            select(WorkflowLineDefinition).where(
+                WorkflowLineDefinition.org_id == org_id, WorkflowLineDefinition.is_active.is_(True))
+        )).scalars().all()
+        assert len(active) == 1 and active[0].version == v2.version
+    await engine.dispose()

--- a/backend/tests/test_edg_s2_config_governance.py
+++ b/backend/tests/test_edg_s2_config_governance.py
@@ -237,3 +237,34 @@ async def test_publish_flow_gate_and_active_flip():
         )).scalars().all()
         assert len(active) == 1 and active[0].version == v2.version
     await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_allow_auto_disposition_publishes_immediately():
+    """org posture=permissive → disposition allow_auto → gate 'auto_passed' → 즉시 published.
+
+    SME blocking: create_gate 는 allow_auto 를 'auto_passed'(approved 아님)로 만든다 — request_publish
+    가 이 경로도 즉시 publish 확정해야 pending_review drift 가 없다.
+    """
+    from app.models.hitl_config import OrgGatePolicy
+    from app.services.workflow_line_config import create_draft, request_publish
+    from sqlalchemy import select
+    from app.models.workflow_line import WorkflowLineDefinition
+
+    engine, Session = await _make_engine_session()
+    org_id, member = uuid.uuid4(), uuid.uuid4()
+    async with Session() as session:
+        await _seed_default_role(session, org_id)
+        session.add(OrgGatePolicy(id=uuid.uuid4(), org_id=org_id, posture="permissive"))
+        await session.flush()
+        version = await create_draft(session, org_id, None, "story", _clean_config(), member)
+        version, gate = await request_publish(session, org_id, version, member)
+        assert gate.status == "auto_passed", f"expected auto_passed, got {gate.status}"
+        assert version.status == "published", f"allow_auto should publish immediately, got {version.status}"
+        active = (await session.execute(
+            select(WorkflowLineDefinition).where(
+                WorkflowLineDefinition.org_id == org_id, WorkflowLineDefinition.is_active.is_(True))
+        )).scalars().all()
+        assert len(active) == 1 and active[0].config_hash == version.config_hash
+    await engine.dispose()


### PR DESCRIPTION
## 배경
Decision Gate **P0-4 config 거버넌스**(critical path 2번·의존 S1). 라인 config 가 검증 없이 published line 으로 들어가는 것을 막는다. 스키마는 S1(0126), 엔진/`workflow_line_steps` materialize 는 S3 — 본 PR 은 **거버넌스 lifecycle 만** 담당하며 default-off(라이브 무영향). 스펙: 스토리 `2c1c3036` AC 인라인.

## 변경 (service+API 레이어)
- **`models/workflow_line.py`** (신규): `WorkflowLineDefinition`/`WorkflowLineDefinitionVersion` ORM(0126 미러) + version 전이 규칙(draft→pending_review→published/rejected→retired).
- **`services/workflow_line_config.py`** (신규): `compute_config_hash`(canonical JSON SHA256)·`lint_config`(8종 hard-fail)·`create_draft`·`request_publish`·`complete_publish`.
- **`routers/workflow_line_config.py`** (신규): `/api/v2/workflow-line-config` — draft·lint·request-publish·approve·reject·retire.
- `main.py`: 라우터 등록. `models/hitl_config.py`: `GATE_TYPES += workflow_config_publish`(additive).

## AC 충족
- **① versions lifecycle API**: draft/pending_review/published/retired 전이 + 거버넌스 규칙 검증.
- **② RBAC**: draft 관리 = project admin+(또는 org owner/admin) / **publish(요청·승인) = org owner/admin 전용**.
- **③ publish gate**: `Gate(gate_type='workflow_config_publish')` 생성 + **self-approval forbidden**(요청자≠승인자, approve 시점 재검증).
- **④ publish lint 8종 hard-fail**: unknown field/op · no approver · self-approval only · no fallback/deputy · all transitions blocked · catch-all auto_route · high-risk timeout auto_approve · connector allow-list 밖 event type.
- **⑤ config_hash immutable audit**: canonical JSON SHA256, published version immutable(수정=새 draft).
- **⑥ gate disposition precedence**: `gate_resolver` member→role→org→system 철학 재사용(문서화).
- **⑦ 무회귀**: gate/hitl 46건 PASS.

## 설계 (PO/SME 사인오프)
- **재사용·신규 권한체계 0**: `Gate`·`create_gate`(idempotent+`resolve_disposition`)·`gate_resolver` 4-tier·`is_org_owner_or_admin`·`transition_gate` 레일.
- **S2/S3 경계**: S2 = version governance + `workflow_line_definitions` active pointer flip(동일 트랜잭션 retire-old+activate-new). steps materialize → S3.
- **gate 배선**: approve 엔드포인트가 `transition_gate()` 직후 `complete_publish()` 콜백 호출 — transition_gate 내부 E-DG 특수분기 누적 회피(orphan 방지). `allow_auto`→즉시 publish / `ask`(기본)→pending.
- **connector allow-list**: SDK `INJECTABLE_EVENT_TYPES` 단일출처 — 드리프트는 AST sync-guard 테스트가 적출.
- gate `neutral_facts` 에 version_id/config_hash/requested_by 기록(SME 체크포인트).

## 검증
- **14 테스트 PASS**: lint 8종 + clean + no_steps · config_hash 결정성 · **allow-list SDK 동기화 가드(AST)** + DB-backed publish flow(lint-fail 차단 · gate pending · neutral_facts · **self-approval 금지** · published + active flip 멱등 · 2nd publish 기존 active retire). 로컬 실 PG.
- **무회귀**: gate_config/hitl_config/gate_service/gates 46건 PASS. `app.main` import OK(351 routes).
- `work_item_type`=`wf_line_version`(Gate.work_item_type String(20) 제약 준수).

## ⚠️ 리뷰 확인
- RBAC 매핑(draft=project admin+ / publish=org owner/admin·self-approval at approve)이 AC ② 의도와 일치하는지.
- `allow_auto` disposition 시 request-publish 가 즉시 publish — org 명시 override 시에만(기본 ask=pending). org owner/admin 전용 엔드포인트라 안전 판단.

## 체크리스트
- [x] versions lifecycle·lint 8종·publish gate·config_hash·RBAC·precedence 문서화
- [x] 로컬 실 PG 14 테스트 + 무회귀 46
- [ ] 산티아고 SME 교차확인
- [ ] 까심 cross-model QA
- [ ] CI green → PO 머지게이트
- 마이그 없음(S1 스키마 재사용) → migrate-dev 불요

🤖 Generated with [Claude Code](https://claude.com/claude-code)