### PR TITLE
[6fef4ae6] E-DG S3 — evaluate_line_for_transition() fail-open core

### DIFF
--- a/backend/app/models/workflow_line.py
+++ b/backend/app/models/workflow_line.py
@@ -10,11 +10,16 @@ enum 미사용).
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, Integer, Text, func
+from sqlalchemy import BigInteger, Boolean, DateTime, Integer, Text, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
+
+# step_run 모드/상태 (0126 SSOT·text+app validator).
+STEP_RUN_MODES = frozenset({
+    "plain_transition", "advisory_only", "gate_pending", "blocked_by_policy", "engine_failed",
+})
 
 # ── 앱 레벨 enum (text 컬럼 validator) ────────────────────────────────────────
 ENTITY_TYPES = frozenset({"story", "doc", "hypothesis", "epic", "sprint"})
@@ -79,6 +84,60 @@ class WorkflowLineDefinitionVersion(Base):
     reviewed_by_member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     review_gate_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+
+class WorkflowLineStepRun(Base):
+    """전이 1건의 route/audit/delivery 기록(0126 미러). S3 엔진이 shadow/engine_failed 시 기록."""
+
+    __tablename__ = "workflow_line_step_runs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    line_definition_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    line_step_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    entity_type: Mapped[str] = mapped_column(Text, nullable=False)
+    entity_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    from_status: Mapped[str | None] = mapped_column(Text, nullable=True)
+    to_status: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default="pending")
+    mode: Mapped[str] = mapped_column(Text, nullable=False)
+    effective_step_type: Mapped[str | None] = mapped_column(Text, nullable=True)
+    effective_gate_type: Mapped[str | None] = mapped_column(Text, nullable=True)
+    routing_decision: Mapped[str | None] = mapped_column(Text, nullable=True)
+    routing_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    routing_context: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default="{}")
+    trust_snapshot: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default="{}")
+    risk_snapshot: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default="{}")
+    resolved_member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    resolved_member_type: Mapped[str | None] = mapped_column(Text, nullable=True)
+    gate_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    h1_gate_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    event_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    recipient_seq: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    delivery_status: Mapped[str] = mapped_column(Text, nullable=False, server_default="not_required")
+    delivery_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    approval_group_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    quorum_policy: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default="{}")
+    sla_due_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    next_reminder_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    reminder_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    escalated_to_member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    failure_class: Mapped[str | None] = mapped_column(Text, nullable=True)
+    failure_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    degraded_to_plain: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
+    correlation_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    transition_id: Mapped[str] = mapped_column(Text, nullable=False)
+    attempt: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1")
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    withdrawn_by_member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    withdrawn_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    withdraw_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -584,6 +584,28 @@ async def update_story_status(
             work_item_id=story_before.id, work_item_title=getattr(story_before, "title", None),
         )
 
+    # E-DG S3: 워크플로우 라인 엔진(P0-1 fail-open). check_transition 후 / set_status 전. 활성 라인이
+    # 없으면 plain(현 default-off=무영향). 엔진은 내부에서 모든 예외를 삼키지만, 호출부도 방어적으로
+    # 한 번 더 감싼다(belt-and-suspenders — 엔진에 버그가 있어도 board 전이를 절대 막지 않음).
+    if story_before is not None:
+        from app.services.workflow_line_engine import evaluate_line_for_transition
+
+        _line_decision = None
+        try:
+            _line_decision = await evaluate_line_for_transition(
+                db, org_id=repo.org_id, project_id=getattr(story_before, "project_id", None),
+                entity_type="story", entity_id=story_before.id,
+                from_status=old_status, to_status=body.status,
+            )
+        except Exception:  # noqa: BLE001 — ⭐P0-1 절대보장: 엔진 실패가 전이를 freeze하지 않음.
+            _line_decision = None
+        # blocked_by_policy/gate_pending = 정상 차단 decision(예외 아님). engine_failed/advisory/plain은 진행.
+        if _line_decision is not None and not _line_decision.proceeds:
+            raise HTTPException(
+                status_code=_line_decision.http_status or 409,
+                detail=_line_decision.blocking_reason or "워크플로우 라인 정책으로 상태 전이가 차단되었습니다.",
+            )
+
     try:
         # AC2: violation_level 전달 → warn 모드이면 set_status hard block 우회
         story = await repo.set_status(id, body.status, violation_level=_violation_level)

--- a/backend/app/services/workflow_line_engine.py
+++ b/backend/app/services/workflow_line_engine.py
@@ -1,0 +1,198 @@
+"""E-DECISION-GATE S3: 전이=step 실행 엔진 (P0-1 fail-open core).
+
+``evaluate_line_for_transition()`` 는 board status 전이 직전에 호출돼, 활성 워크플로우 라인이
+있으면 그 step 을 평가한다. ⭐**핵심 불변식(P0-1)**: 이 엔진의 *어떤* 내부 실패도 board status
+전이를 freeze해선 안 된다. resolver/config/trust 예외는 router 밖으로 나가지 않고
+``engine_failed`` + ``degraded_to_plain`` 로 기록된 뒤 ``plain_transition`` 으로 graceful degrade
+한다(보드 freeze·dispatch P0 cascade 방지).
+
+S3 범위 = fail-open 코어 + shadow 모드. 모드:
+- 활성 라인 없음 / ``off`` / 매칭 step 없음 → ``plain_transition`` (step_run 미생성).
+- ``shadow`` / ``advisory`` → step_run + would-decision 기록, 전이 **비차단**(``advisory_only``).
+- ``enforcing`` → 정적 policy block(step config ``enforcement='block'``)은 ``blocked_by_policy``
+  (전이 차단·예외와 명확히 구분, fail-open 대상 아님). 그 외 enforcing(gate/route 실집행)은 trust
+  resolver(S4)·gate 통합(S5)·runtime mode(S18) 도입 전까지 dormant → step_run 기록 후 비차단.
+- 내부 예외 → ``engine_failed`` + ``degraded_to_plain`` → plain.
+
+policy block(``blocked_by_policy``)은 정상 decision이므로 fail-open(예외 처리)과 섞지 않는다.
+"""
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.workflow_line import (
+    WorkflowLineDefinition,
+    WorkflowLineDefinitionVersion,
+    WorkflowLineStepRun,
+)
+
+_TERMINAL_PROCEED_MODES = frozenset({"plain_transition", "advisory_only", "engine_failed"})
+
+
+@dataclass
+class LineDecision:
+    """엔진 평가 결과. ``mode`` 가 board 전이 진행/차단을 가른다."""
+
+    mode: str  # plain_transition | advisory_only | gate_pending | blocked_by_policy | engine_failed
+    status_to_apply: str | None
+    gate_id: uuid.UUID | None = None
+    step_run_id: uuid.UUID | None = None
+    blocking_reason: str | None = None
+    http_status: int | None = None
+    degraded_to_plain: bool = False
+
+    @property
+    def proceeds(self) -> bool:
+        """board status 전이를 진행해도 되는지(set_status 호출 여부)."""
+        return self.mode in _TERMINAL_PROCEED_MODES
+
+
+def _plain() -> LineDecision:
+    return LineDecision(mode="plain_transition", status_to_apply=None)
+
+
+async def _active_definition(
+    session: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID | None, entity_type: str
+) -> WorkflowLineDefinition | None:
+    """(org, project, entity) 활성 라인. project override 우선, 없으면 org-default."""
+    r = await session.execute(
+        select(WorkflowLineDefinition).where(
+            WorkflowLineDefinition.org_id == org_id,
+            WorkflowLineDefinition.entity_type == entity_type,
+            WorkflowLineDefinition.is_active.is_(True),
+        )
+    )
+    candidates = r.scalars().all()
+    if not candidates:
+        return None
+    if project_id is not None:
+        for d in candidates:
+            if d.project_id == project_id:
+                return d
+    for d in candidates:
+        if d.project_id is None:
+            return d
+    return None
+
+
+async def _published_config(
+    session: AsyncSession, definition: WorkflowLineDefinition
+) -> dict[str, Any]:
+    r = await session.execute(
+        select(WorkflowLineDefinitionVersion).where(
+            WorkflowLineDefinitionVersion.line_definition_id == definition.id,
+            WorkflowLineDefinitionVersion.status == "published",
+        ).order_by(WorkflowLineDefinitionVersion.version.desc()).limit(1)
+    )
+    version = r.scalar_one_or_none()
+    return dict(version.config) if version and isinstance(version.config, dict) else {}
+
+
+def _match_step(config: dict[str, Any], from_status: str | None, to_status: str) -> dict | None:
+    for step in config.get("steps") or []:
+        if not isinstance(step, dict):
+            continue
+        if step.get("to_status") == to_status and step.get("from_status") in (from_status, None):
+            return step
+    return None
+
+
+async def evaluate_line_for_transition(
+    session: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID | None,
+    entity_type: str,
+    entity_id: uuid.UUID,
+    from_status: str | None,
+    to_status: str,
+    actor_id: uuid.UUID | None = None,
+    transition_id: str | None = None,
+) -> LineDecision:
+    """전이 직전 라인 평가. ⭐절대 예외를 raise하지 않는다(P0-1 fail-open)."""
+    transition_id = transition_id or uuid.uuid4().hex
+    correlation_id = uuid.uuid4()
+    try:
+        definition = await _active_definition(session, org_id, project_id, entity_type)
+        if definition is None:
+            return _plain()  # 활성 라인 없음 = 현 default-off 현실 → 무영향
+
+        config = await _published_config(session, definition)
+        mode = str(config.get("rollout_mode") or "shadow").strip()
+        if mode == "off":
+            return _plain()
+
+        step = _match_step(config, from_status, to_status)
+        if step is None:
+            return _plain()  # 이 전이를 거버닝하는 step 없음 → plain
+
+        # enforcing + 정적 policy block → blocked_by_policy(전이 차단·예외 아님·⑤).
+        if mode == "enforcing" and step.get("enforcement") == "block":
+            step_run = await _record_step_run(
+                session, org_id=org_id, project_id=project_id, definition=definition, step=step,
+                entity_type=entity_type, entity_id=entity_id, from_status=from_status,
+                to_status=to_status, status="blocked_by_policy", run_mode="blocked_by_policy",
+                routing_decision="block", routing_reason="static policy block",
+                transition_id=transition_id, correlation_id=correlation_id,
+            )
+            return LineDecision(
+                mode="blocked_by_policy", status_to_apply=None,
+                step_run_id=step_run.id if step_run else None,
+                blocking_reason="workflow line policy blocks this transition", http_status=409,
+            )
+
+        # shadow/advisory(+ S3 dormant enforcing) → step_run 기록 후 비차단.
+        step_run = await _record_step_run(
+            session, org_id=org_id, project_id=project_id, definition=definition, step=step,
+            entity_type=entity_type, entity_id=entity_id, from_status=from_status,
+            to_status=to_status, status="routing_resolved", run_mode="advisory_only",
+            routing_decision="would_" + str(step.get("step_type") or "advisory"),
+            routing_reason=f"shadow/advisory record (mode={mode})",
+            transition_id=transition_id, correlation_id=correlation_id,
+        )
+        return LineDecision(
+            mode="advisory_only", status_to_apply=to_status,
+            step_run_id=step_run.id if step_run else None,
+        )
+    except Exception as exc:  # noqa: BLE001 — ⭐P0-1: 어떤 예외도 전이를 막지 않는다.
+        # engine_failed step_run 기록은 best-effort(기록 실패도 전이 비차단·SME 체크포인트).
+        step_run_id = None
+        try:
+            sr = await _record_step_run(
+                session, org_id=org_id, project_id=project_id, definition=None, step=None,
+                entity_type=entity_type, entity_id=entity_id, from_status=from_status,
+                to_status=to_status, status="engine_failed", run_mode="engine_failed",
+                failure_class=type(exc).__name__, failure_message=str(exc)[:500],
+                degraded_to_plain=True, transition_id=transition_id, correlation_id=correlation_id,
+            )
+            step_run_id = sr.id if sr else None
+        except Exception:  # noqa: BLE001 — 기록 실패도 무시(전이 우선).
+            step_run_id = None
+        return LineDecision(
+            mode="engine_failed", status_to_apply=to_status, step_run_id=step_run_id,
+            degraded_to_plain=True, blocking_reason=None,
+        )
+
+
+async def _record_step_run(
+    session: AsyncSession, *, org_id, project_id, definition, step, entity_type, entity_id,
+    from_status, to_status, status, run_mode, transition_id, correlation_id,
+    routing_decision=None, routing_reason=None, failure_class=None, failure_message=None,
+    degraded_to_plain=False,
+) -> WorkflowLineStepRun | None:
+    """step_run 기록. 호출자가 best-effort 로 감싼다(기록 실패도 전이 비차단)."""
+    sr = WorkflowLineStepRun(
+        org_id=org_id, project_id=project_id or org_id,  # project_id NN — org-level 라인은 org_id로 대체 표기
+        line_definition_id=definition.id if definition is not None else None,
+        entity_type=entity_type, entity_id=entity_id, from_status=from_status, to_status=to_status,
+        status=status, mode=run_mode, routing_decision=routing_decision, routing_reason=routing_reason,
+        effective_step_type=(step or {}).get("step_type") if step else None,
+        failure_class=failure_class, failure_message=failure_message, degraded_to_plain=degraded_to_plain,
+        correlation_id=correlation_id, transition_id=transition_id,
+    )
+    session.add(sr)
+    await session.flush()
+    return sr

--- a/backend/app/services/workflow_line_engine.py
+++ b/backend/app/services/workflow_line_engine.py
@@ -193,6 +193,18 @@ async def _record_step_run(
         failure_class=failure_class, failure_message=failure_message, degraded_to_plain=degraded_to_plain,
         correlation_id=correlation_id, transition_id=transition_id,
     )
-    session.add(sr)
-    await session.flush()
+    # ⭐P0-1: step_run insert 를 SAVEPOINT 로 격리. flush 실패(active partial unique 충돌=double-fire·
+    # 제약 위반 등)가 outer 트랜잭션을 aborted 로 poison하면, 엔진이 engine_failed 를 반환해도 이후
+    # repo.set_status() 가 PendingRollbackError 로 깨져 board 전이가 freeze된다(레드팀 적출). savepoint 면
+    # 실패가 nested tx 로만 롤백되고 outer 는 보존돼 set_status 가 정상 진행한다.
+    try:
+        async with session.begin_nested():
+            session.add(sr)
+            await session.flush()
+    except Exception:  # noqa: BLE001 — 기록 실패는 격리·비차단. 재flush 방지 위해 expunge.
+        try:
+            session.expunge(sr)
+        except Exception:  # noqa: BLE001
+            pass
+        return None
     return sr

--- a/backend/tests/test_edg_s3_engine.py
+++ b/backend/tests/test_edg_s3_engine.py
@@ -178,3 +178,32 @@ async def test_fault_injection_engine_failure_degrades_to_plain():
             select(WorkflowLineStepRun).where(WorkflowLineStepRun.entity_id == eid))).scalar_one()
         assert sr.status == "engine_failed" and sr.failure_class == "RuntimeError"
     await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_step_run_flush_failure_savepoint_does_not_poison_session():
+    """⭐P0-1(레드팀 적출): step_run insert flush 실패(active partial unique 충돌=double-fire)가
+    outer 트랜잭션을 poison하면 안 된다. SAVEPOINT 격리로 outer tx 보존 → 후속 set_status/commit 정상.
+    """
+    import sqlalchemy as sa
+    from app.services.workflow_line_engine import evaluate_line_for_transition
+    engine, Session = await _engine_session()
+    async with Session() as session:
+        org, eid, eid2 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        await _seed_active_line(session, org, "story", {
+            "rollout_mode": "shadow",
+            "steps": [{"from_status": "in-review", "to_status": "done", "step_type": "merge-gate"}]})
+        kw = dict(org_id=org, project_id=None, entity_type="story",
+                  from_status="in-review", to_status="done")
+        d1 = await evaluate_line_for_transition(session, entity_id=eid, **kw)
+        assert d1.mode == "advisory_only" and d1.step_run_id is not None
+        # 동일 전이 재평가 → 2번째 step_run insert가 active partial unique 충돌(non-terminal 'routing_resolved').
+        d2 = await evaluate_line_for_transition(session, entity_id=eid, **kw)
+        assert d2.proceeds is True  # ⭐충돌해도 전이는 진행(비차단)
+        # ⭐session 비-poison 증명: 후속 read/write/commit 모두 성공(poison이면 PendingRollbackError).
+        assert (await session.execute(sa.text("SELECT 1"))).scalar() == 1
+        d3 = await evaluate_line_for_transition(session, entity_id=eid2, **kw)  # 다른 entity write 정상
+        assert d3.mode == "advisory_only" and d3.step_run_id is not None
+        await session.commit()  # commit 성공 = outer tx 살아있음
+    await engine.dispose()

--- a/backend/tests/test_edg_s3_engine.py
+++ b/backend/tests/test_edg_s3_engine.py
@@ -1,0 +1,180 @@
+"""E-DG S3: workflow line engine (P0-1 fail-open core) 테스트.
+
+핵심: 엔진의 어떤 실패도 board 전이를 freeze하지 않는다(fail-open). + off/no-line→plain,
+shadow→advisory_only+step_run, enforcing 정적 block→blocked_by_policy.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from app.services.workflow_line_engine import LineDecision
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── pure: proceeds 분류 ──────────────────────────────────────────────────────
+def test_decision_proceeds_classification():
+    assert LineDecision("plain_transition", None).proceeds
+    assert LineDecision("advisory_only", "done").proceeds
+    assert LineDecision("engine_failed", "done", degraded_to_plain=True).proceeds
+    assert not LineDecision("blocked_by_policy", None, http_status=409).proceeds
+    assert not LineDecision("gate_pending", None).proceeds
+
+
+# ── DB-backed ────────────────────────────────────────────────────────────────
+async def _engine_session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_active_line(session, org_id, entity_type, config, project_id=None):
+    from app.models.workflow_line import WorkflowLineDefinition, WorkflowLineDefinitionVersion
+    defn = WorkflowLineDefinition(
+        org_id=org_id, project_id=project_id, entity_type=entity_type, name="line",
+        is_active=True, version=1,
+    )
+    session.add(defn)
+    await session.flush()
+    ver = WorkflowLineDefinitionVersion(
+        line_definition_id=defn.id, org_id=org_id, project_id=project_id, entity_type=entity_type,
+        version=1, status="published", config=config, config_hash="hash",
+        created_by_member_id=uuid.uuid4(),
+    )
+    session.add(ver)
+    await session.flush()
+    return defn
+
+
+async def _count_step_runs(session, entity_id):
+    from sqlalchemy import func, select
+    from app.models.workflow_line import WorkflowLineStepRun
+    r = await session.execute(
+        select(func.count()).select_from(WorkflowLineStepRun).where(
+            WorkflowLineStepRun.entity_id == entity_id)
+    )
+    return r.scalar()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_no_active_line_plain_no_step_run():
+    from app.services.workflow_line_engine import evaluate_line_for_transition
+    engine, Session = await _engine_session()
+    async with Session() as session:
+        org, eid = uuid.uuid4(), uuid.uuid4()
+        d = await evaluate_line_for_transition(
+            session, org_id=org, project_id=None, entity_type="story", entity_id=eid,
+            from_status="in-review", to_status="done")
+        assert d.mode == "plain_transition" and d.proceeds
+        assert await _count_step_runs(session, eid) == 0  # step_run 미생성
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_off_mode_plain():
+    from app.services.workflow_line_engine import evaluate_line_for_transition
+    engine, Session = await _engine_session()
+    async with Session() as session:
+        org, eid = uuid.uuid4(), uuid.uuid4()
+        await _seed_active_line(session, org, "story", {
+            "rollout_mode": "off",
+            "steps": [{"from_status": "in-review", "to_status": "done", "step_type": "merge-gate"}]})
+        d = await evaluate_line_for_transition(
+            session, org_id=org, project_id=None, entity_type="story", entity_id=eid,
+            from_status="in-review", to_status="done")
+        assert d.mode == "plain_transition" and d.proceeds
+        assert await _count_step_runs(session, eid) == 0
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_shadow_mode_records_step_run_but_proceeds():
+    from app.services.workflow_line_engine import evaluate_line_for_transition
+    from app.models.workflow_line import WorkflowLineStepRun
+    from sqlalchemy import select
+    engine, Session = await _engine_session()
+    async with Session() as session:
+        org, eid = uuid.uuid4(), uuid.uuid4()
+        await _seed_active_line(session, org, "story", {
+            "rollout_mode": "shadow",
+            "steps": [{"from_status": "in-review", "to_status": "done", "step_type": "merge-gate"}]})
+        d = await evaluate_line_for_transition(
+            session, org_id=org, project_id=None, entity_type="story", entity_id=eid,
+            from_status="in-review", to_status="done")
+        assert d.mode == "advisory_only" and d.proceeds  # shadow는 전이 비차단
+        sr = (await session.execute(
+            select(WorkflowLineStepRun).where(WorkflowLineStepRun.entity_id == eid))).scalar_one()
+        assert sr.mode == "advisory_only" and sr.to_status == "done"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_enforcing_static_block_blocked_by_policy():
+    from app.services.workflow_line_engine import evaluate_line_for_transition
+    engine, Session = await _engine_session()
+    async with Session() as session:
+        org, eid = uuid.uuid4(), uuid.uuid4()
+        await _seed_active_line(session, org, "story", {
+            "rollout_mode": "enforcing",
+            "steps": [{"from_status": "in-review", "to_status": "done", "enforcement": "block"}]})
+        d = await evaluate_line_for_transition(
+            session, org_id=org, project_id=None, entity_type="story", entity_id=eid,
+            from_status="in-review", to_status="done")
+        # 정상 차단 decision — 예외(engine_failed)와 구분.
+        assert d.mode == "blocked_by_policy" and not d.proceeds
+        assert d.http_status == 409 and not d.degraded_to_plain
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_fault_injection_engine_failure_degrades_to_plain():
+    """⭐P0-1: 엔진 내부 예외 → engine_failed + degraded_to_plain → 전이 진행(proceeds=True)."""
+    from app.services import workflow_line_engine as eng
+    engine, Session = await _engine_session()
+    async with Session() as session:
+        org, eid = uuid.uuid4(), uuid.uuid4()
+        await _seed_active_line(session, org, "story", {
+            "rollout_mode": "shadow",
+            "steps": [{"from_status": "in-review", "to_status": "done"}]})
+        # _published_config 가 터지도록 강제 주입(resolver/config 예외 시뮬레이션).
+        with patch.object(eng, "_published_config", side_effect=RuntimeError("boom")):
+            d = await eng.evaluate_line_for_transition(
+                session, org_id=org, project_id=None, entity_type="story", entity_id=eid,
+                from_status="in-review", to_status="done")
+        assert d.mode == "engine_failed"
+        assert d.degraded_to_plain is True
+        assert d.proceeds is True  # ⭐엔진이 터져도 전이는 진행
+        assert d.status_to_apply == "done"
+        # best-effort engine_failed step_run 기록 확인
+        from sqlalchemy import select
+        from app.models.workflow_line import WorkflowLineStepRun
+        sr = (await session.execute(
+            select(WorkflowLineStepRun).where(WorkflowLineStepRun.entity_id == eid))).scalar_one()
+        assert sr.status == "engine_failed" and sr.failure_class == "RuntimeError"
+    await engine.dispose()


### PR DESCRIPTION
## 배경
Decision Gate **P0-1 fail-open 전이 엔진**(critical path 3번·의존 S1+S2). board status 전이 직전 활성 워크플로우 라인을 평가하되, ⭐**엔진의 어떤 내부 실패도 board 전이를 freeze하지 않는다**(보드 freeze·dispatch P0 cascade 방지). S3 = fail-open 코어 + shadow 모드. 스펙: 스토리 `6fef4ae6` AC 인라인.

## 변경
- **`services/workflow_line_engine.py`** (신규): `LineDecision`(mode/status_to_apply/gate_id/step_run_id/blocking_reason/http_status/degraded_to_plain) + `evaluate_line_for_transition()`.
- **`models/workflow_line.py`**: `WorkflowLineStepRun` ORM(0126 미러) + `STEP_RUN_MODES`.
- **`routers/stories.py`**: `check_transition` 후 / `repo.set_status` 전 엔진 호출(enforce_gate 옆).

## AC 충족
- **① LineDecision** dataclass + `mode ∈ (plain_transition|advisory_only|gate_pending|blocked_by_policy|engine_failed)`.
- **② off/disabled** → `plain_transition`·step_run 미생성.
- **③ shadow/advisory** → step_run + would-decision 기록·전이 **비차단**(`advisory_only`).
- **④ ⭐resolver/config/trust 예외 → router 밖으로 안 나감**: `engine_failed` + `degraded_to_plain=true` + `failure_class`/`failure_message` 기록 → `plain_transition` degrade(`set_status` 호출됨). step_run 기록 실패조차 전이 비차단(이중 best-effort).
- **⑤ policy block = `blocked_by_policy`**(전이 차단 가능)·**exception failure와 명확히 구분**(fail-open 대상 아님). enforcing 정적 block(step `enforcement='block'`)으로 구체 producer.
- **⑥ 삽입 위치**: stories.py PATCH `check_transition` 후 / `set_status` 전. ⭐**호출부도 방어적 try/except**(belt-and-suspenders).
- **⑦ idempotency**: transition_id·correlation_id·S1 active partial unique(double-fire 차단).

## 설계 (PO/SME 사인오프)
- **활성 라인 없음 → plain·step_run 0**(현 default-off=무영향): 모든 기존 전이는 plain pass-through.
- **fork①** rollout_mode = published version `config.rollout_mode`(기본 shadow·별도 컬럼 X). **fork②** enforcing = 구조만·default dormant(실 gate/route 집행 = S4 resolver/S5 gate/S18 runtime).
- **이중 fail-open**: 엔진 내부 try/except + 호출부 try/except. `blocked_by_policy`는 정상 decision이라 fail-open에 안 섞임.

## 검증 (로컬 실 PG)
- **S3 6 테스트 PASS**: proceeds 분류 / no-line·off→plain(step_run 0) / shadow→advisory_only+step_run / enforcing static block→blocked_by_policy(409·degraded=false) / ⭐**fault injection**(`_published_config` 강제 throw→`engine_failed`+`degraded_to_plain`+**전이 진행**·engine_failed step_run 기록).
- **무회귀**: stories PATCH 전이(`test_stories.py` `in-review→done` 포함) **45 PASS** · S2 15 · gate/hitl 46.
- 마이그 없음(S1 스키마 재사용) → migrate-dev 불요.

## ⚠️ 참고
- 로컬에서 h1/ho `*_real_db` 테스트 6건이 실패하나 **본 변경과 무관**(`compute_member_trust_scores` clean_pass_rate 환경 이슈·내 변경 파일 무경유·`test_ho_gate_done_side_effects`는 격리 시 PASS=batch 풀루션). CI Postgres가 authoritative.

## 체크리스트
- [x] LineDecision·fail-open(이중)·shadow step_run·blocked_by_policy·삽입·idempotency
- [x] fault injection 테스트(엔진 throw→전이 100% 성공) + 무회귀 45
- [ ] 산티아고 SME(fail-open 경계·삽입위치·fault/degrade·idempotency)
- [ ] 까심 cross-model QA(fault injection 실거동)
- [ ] CI green → PO 머지게이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)