### PR TITLE
[ab41535a] E-DG S4 — routing context + trust snapshot resolver

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -590,12 +590,24 @@ async def update_story_status(
     if story_before is not None:
         from app.services.workflow_line_engine import evaluate_line_for_transition
 
+        # S4: actor 전파 — 라우터가 actor_id/type 을 안 넘기면 resolver 가 항상 no_member→cold_start 로
+        # 고정돼 실 actor trust 가 snapshot 에 안 담긴다(SME 적출). 인증 컨텍스트에서 신뢰 도출.
+        _line_actor_type = (
+            "agent" if auth.claims.get("app_metadata", {}).get("api_key_id") else "human"
+        )
+        _line_actor_id: uuid.UUID | None = None
+        try:
+            _line_actor_id = await _resolve_team_member_id(auth, repo.org_id, db)
+        except Exception:  # noqa: BLE001 — actor 해소 실패도 전이 비차단(엔진은 None→cold_start 처리).
+            _line_actor_id = None
+
         _line_decision = None
         try:
             _line_decision = await evaluate_line_for_transition(
                 db, org_id=repo.org_id, project_id=getattr(story_before, "project_id", None),
                 entity_type="story", entity_id=story_before.id,
                 from_status=old_status, to_status=body.status,
+                actor_id=_line_actor_id, actor_type=_line_actor_type,
             )
         except Exception:  # noqa: BLE001 — ⭐P0-1 절대보장: 엔진 실패가 전이를 freeze하지 않음.
             _line_decision = None

--- a/backend/app/services/workflow_line_engine.py
+++ b/backend/app/services/workflow_line_engine.py
@@ -111,6 +111,7 @@ async def evaluate_line_for_transition(
     from_status: str | None,
     to_status: str,
     actor_id: uuid.UUID | None = None,
+    actor_type: str | None = None,
     transition_id: str | None = None,
 ) -> LineDecision:
     """전이 직전 라인 평가. ⭐절대 예외를 raise하지 않는다(P0-1 fail-open)."""
@@ -134,7 +135,8 @@ async def evaluate_line_for_transition(
         # (trust-before-capture — autoflush 가 pending step_run 을 trust 쿼리에 끌어들이는 것 방지).
         # resolver 예외도 바깥 try/except 가 잡아 engine_failed→plain 으로 degrade(fail-open 유지).
         routing_context = await resolve_routing_context(
-            session, org_id, entity_type=entity_type, entity_id=entity_id, actor_member_id=actor_id,
+            session, org_id, entity_type=entity_type, entity_id=entity_id,
+            actor_member_id=actor_id, actor_type=actor_type,
         )
         trust_snapshot = routing_context.get("trust") if isinstance(routing_context, dict) else None
 

--- a/backend/app/services/workflow_line_engine.py
+++ b/backend/app/services/workflow_line_engine.py
@@ -28,6 +28,7 @@ from app.models.workflow_line import (
     WorkflowLineDefinitionVersion,
     WorkflowLineStepRun,
 )
+from app.services.workflow_line_resolver import resolve_routing_context
 
 _TERMINAL_PROCEED_MODES = frozenset({"plain_transition", "advisory_only", "engine_failed"})
 
@@ -129,6 +130,14 @@ async def evaluate_line_for_transition(
         if step is None:
             return _plain()  # 이 전이를 거버닝하는 step 없음 → plain
 
+        # S4: routing_context + trust snapshot 구성. ⭐step_run insert *전에* 계산한다
+        # (trust-before-capture — autoflush 가 pending step_run 을 trust 쿼리에 끌어들이는 것 방지).
+        # resolver 예외도 바깥 try/except 가 잡아 engine_failed→plain 으로 degrade(fail-open 유지).
+        routing_context = await resolve_routing_context(
+            session, org_id, entity_type=entity_type, entity_id=entity_id, actor_member_id=actor_id,
+        )
+        trust_snapshot = routing_context.get("trust") if isinstance(routing_context, dict) else None
+
         # enforcing + 정적 policy block → blocked_by_policy(전이 차단·예외 아님·⑤).
         if mode == "enforcing" and step.get("enforcement") == "block":
             step_run = await _record_step_run(
@@ -136,6 +145,7 @@ async def evaluate_line_for_transition(
                 entity_type=entity_type, entity_id=entity_id, from_status=from_status,
                 to_status=to_status, status="blocked_by_policy", run_mode="blocked_by_policy",
                 routing_decision="block", routing_reason="static policy block",
+                routing_context=routing_context, trust_snapshot=trust_snapshot,
                 transition_id=transition_id, correlation_id=correlation_id,
             )
             return LineDecision(
@@ -151,6 +161,7 @@ async def evaluate_line_for_transition(
             to_status=to_status, status="routing_resolved", run_mode="advisory_only",
             routing_decision="would_" + str(step.get("step_type") or "advisory"),
             routing_reason=f"shadow/advisory record (mode={mode})",
+            routing_context=routing_context, trust_snapshot=trust_snapshot,
             transition_id=transition_id, correlation_id=correlation_id,
         )
         return LineDecision(
@@ -181,7 +192,7 @@ async def _record_step_run(
     session: AsyncSession, *, org_id, project_id, definition, step, entity_type, entity_id,
     from_status, to_status, status, run_mode, transition_id, correlation_id,
     routing_decision=None, routing_reason=None, failure_class=None, failure_message=None,
-    degraded_to_plain=False,
+    degraded_to_plain=False, routing_context=None, trust_snapshot=None,
 ) -> WorkflowLineStepRun | None:
     """step_run 기록. 호출자가 best-effort 로 감싼다(기록 실패도 전이 비차단)."""
     sr = WorkflowLineStepRun(
@@ -189,6 +200,8 @@ async def _record_step_run(
         line_definition_id=definition.id if definition is not None else None,
         entity_type=entity_type, entity_id=entity_id, from_status=from_status, to_status=to_status,
         status=status, mode=run_mode, routing_decision=routing_decision, routing_reason=routing_reason,
+        routing_context=routing_context if routing_context is not None else {},  # S4: trust-routing 입력
+        trust_snapshot=trust_snapshot if trust_snapshot is not None else {},     # S4: outcome-trust(이력만)
         effective_step_type=(step or {}).get("step_type") if step else None,
         failure_class=failure_class, failure_message=failure_message, degraded_to_plain=degraded_to_plain,
         correlation_id=correlation_id, transition_id=transition_id,

--- a/backend/app/services/workflow_line_resolver.py
+++ b/backend/app/services/workflow_line_resolver.py
@@ -1,0 +1,113 @@
+"""E-DECISION-GATE S4: trust-routing resolver (우리 moat).
+
+라인 라우팅 입력(routing_context) + outcome-trust snapshot 을 구성한다. ERP 는 금액으로 분기하지만
+우리는 **검증된 신뢰(hypothesis outcome)** 로 분기하는 게 차별점이다. S4 는 context/snapshot
+**생산 + shadow 관측 기록**까지이며, 실제 auto/ask/block enforcement 는 S5(gate 통합)다.
+
+핵심 불변식:
+- ⭐**cold-start ≠ 0점**: outcome 표본이 없으면 ``cold_start=True``·``hypothesis_hit_rate=None`` 으로
+  내려보낸다. 0.0 으로 깔면 신규 멤버가 "신뢰 낮음"으로 오판돼 잘못 라우팅된다.
+- ⭐**trust-before-capture**(P1-3 gaming 방어): trust 는 **이전 이력만** 본다. resolver 는 어떤
+  verdict 도 session 에 add 하지 않으며, 엔진은 step_run insert *전에* trust 를 계산한다(autoflush 가
+  pending row 를 trust 쿼리에 끌어들여 자기-부트스트랩하는 것 방지·merge_verdict_gate.py:254-260 동형).
+- ⭐**risk 불확실 → safe default**: prod-touch 여부를 판정할 수 없으면 ``None``(False 로 추정 금지)·
+  ``uncertain=True`` → ``suggested_default='ask_human'``. 단 S4 에서는 snapshot/decision material 로만
+  남기고 board 전이는 막지 않는다(S3 fail-open 정합).
+"""
+import uuid
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.pm import Story
+from app.services.trust_score import compute_member_trust_scores
+
+# story_points 가 이 이상이면 high-effort 신호(휴리스틱·S5 에서 정교화).
+_HIGH_EFFORT_POINTS = 8
+
+
+def _story_predicate(story: Story | None) -> dict[str, Any]:
+    """라우팅 입력으로 쓰는 현 Story 모델 필드(pm.py:101-115)."""
+    if story is None:
+        return {}
+    return {
+        "priority": story.priority,
+        "story_points": story.story_points,
+        "has_success_hypothesis": bool(story.success_hypothesis),
+        "has_metric_definition": story.metric_definition is not None,
+        "has_measure_after": story.measure_after is not None,
+        "outcome_status": story.outcome_status,
+        "has_outcome_result": story.outcome_result is not None,
+        "is_excluded": bool(getattr(story, "is_excluded", False)),
+    }
+
+
+def _risk_flags(story: Story | None) -> dict[str, Any]:
+    """위험 신호. ⭐prod-touch 는 본 컨텍스트서 판정 불가 → None(False 추정 금지·AC⑤)."""
+    sp = story.story_points if story is not None else None
+    return {
+        "prod_touch": None,                       # 불명 — False 로 추정하지 않는다
+        "high_effort": sp is not None and sp >= _HIGH_EFFORT_POINTS,
+        "story_points": sp,
+        "uncertain": story is None or sp is None,  # 정보 부족 = 불확실 → safe default
+    }
+
+
+async def resolve_trust_snapshot(
+    session: AsyncSession, org_id: uuid.UUID, member_id: uuid.UUID | None, role_key: str | None = None
+) -> dict[str, Any]:
+    """outcome-trust snapshot(이전 이력만·현 verdict 미포함). cold-start 는 None 으로 보존."""
+    if member_id is None:
+        return {
+            "primary_source": "hypothesis_outcome", "cold_start": True, "reason": "no_member",
+            "hypothesis_hit_rate": None, "resolved": 0, "hit": 0, "pending": 0,
+            "captured_before_verdict": True,
+        }
+    # trust-before-capture: resolver 는 verdict 를 add 하지 않고 이력만 읽는다.
+    result = await compute_member_trust_scores(session, org_id, member_id, role_key=role_key)
+    resolved = int(result.get("resolved") or 0)
+    return {
+        "primary_source": result.get("primary_source"),        # hypothesis_outcome
+        "hypothesis_hit_rate": result.get("hypothesis_hit_rate"),  # None if cold-start (⭐0점 금지)
+        "resolved": resolved,
+        "hit": int(result.get("hit") or 0),
+        "pending": int(result.get("pending") or 0),
+        "cold_start": resolved == 0,                            # ⭐AC④ outcome 표본 없음
+        "role_key": role_key,
+        "captured_before_verdict": True,                        # ⭐AC⑥ trust-before-capture marker
+    }
+
+
+async def resolve_routing_context(
+    session: AsyncSession, org_id: uuid.UUID, *, entity_type: str, entity_id: uuid.UUID,
+    actor_member_id: uuid.UUID | None = None, actor_type: str | None = None,
+    role_key: str | None = None,
+) -> dict[str, Any]:
+    """라우팅 컨텍스트 = entity · story predicate · actor · risk_flags · trust.
+
+    비-story entity 는 Phase1 범위 밖 → unsupported context 로 안전하게 내려보낸다(무리 확장 X).
+    """
+    if entity_type != "story":
+        return {
+            "entity_type": entity_type, "entity_id": str(entity_id),
+            "supported": False, "reason": "unsupported_entity_type",
+            "risk_flags": {"prod_touch": None, "uncertain": True},
+            "trust": {"cold_start": True, "captured_before_verdict": True},
+            "suggested_default": "ask_human",
+        }
+    story = await session.get(Story, entity_id)
+    risk_flags = _risk_flags(story)
+    trust = await resolve_trust_snapshot(session, org_id, actor_member_id, role_key)
+    # safe default: 위험 불확실 또는 cold-start → ask_human 제안(S4 는 표기만·비차단).
+    suggested = "ask_human" if (risk_flags.get("uncertain") or trust.get("cold_start")) else None
+    return {
+        "entity_type": "story", "entity_id": str(entity_id), "supported": True,
+        "story": _story_predicate(story),
+        "actor": {
+            "member_id": str(actor_member_id) if actor_member_id else None,
+            "type": actor_type,
+        },
+        "risk_flags": risk_flags,
+        "trust": trust,
+        "suggested_default": suggested,
+    }

--- a/backend/tests/test_edg_s4_resolver.py
+++ b/backend/tests/test_edg_s4_resolver.py
@@ -176,3 +176,42 @@ async def test_engine_shadow_records_routing_context_and_trust():
         assert sr.trust_snapshot.get("cold_start") is True
         assert sr.trust_snapshot.get("captured_before_verdict") is True
     await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_actor_propagates_to_step_run_snapshot():
+    """⭐SME blocking 회귀: 엔진에 actor_id/actor_type 을 넘기면 resolver→step_run.routing_context.actor
+    까지 전파돼야 한다(라우터가 actor 미전달 시 항상 no_member 로 고정되던 통합 갭). actor.member_id 가
+    실제 actor 로 채워져야 trust 가 그 actor 이력 기반(non-cold-start 가능)이 된다."""
+    from sqlalchemy import select
+    from app.services.workflow_line_engine import evaluate_line_for_transition
+    from app.models.workflow_line import (
+        WorkflowLineDefinition, WorkflowLineDefinitionVersion, WorkflowLineStepRun,
+    )
+    from app.models.pm import Story
+    from app.models.project import Project
+    engine, Session = await _session()
+    async with Session() as s:
+        org, proj, actor = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        s.add(Project(id=proj, org_id=org, name="p")); await s.flush()
+        defn = WorkflowLineDefinition(org_id=org, project_id=None, entity_type="story",
+                                      name="L", is_active=True, version=1)
+        s.add(defn); await s.flush()
+        s.add(WorkflowLineDefinitionVersion(
+            line_definition_id=defn.id, org_id=org, project_id=None, entity_type="story",
+            version=1, status="published", config_hash="h", created_by_member_id=uuid.uuid4(),
+            config={"rollout_mode": "shadow",
+                    "steps": [{"from_status": "in-review", "to_status": "done", "step_type": "merge-gate"}]}))
+        story = Story(org_id=org, project_id=proj, title="t", status="in-review", priority="high")
+        s.add(story); await s.flush()
+        await evaluate_line_for_transition(
+            s, org_id=org, project_id=proj, entity_type="story", entity_id=story.id,
+            from_status="in-review", to_status="done", actor_id=actor, actor_type="human")
+        sr = (await s.execute(select(WorkflowLineStepRun).where(
+            WorkflowLineStepRun.entity_id == story.id))).scalar_one()
+        # ⭐actor 가 no_member 로 고정되지 않고 실제 actor 로 전파됨
+        assert sr.routing_context["actor"]["member_id"] == str(actor)
+        assert sr.routing_context["actor"]["type"] == "human"
+        assert sr.trust_snapshot.get("reason") != "no_member"  # 실 actor 기반(이력 있으면 non-cold-start)
+    await engine.dispose()

--- a/backend/tests/test_edg_s4_resolver.py
+++ b/backend/tests/test_edg_s4_resolver.py
@@ -1,0 +1,178 @@
+"""E-DG S4: trust-routing resolver 테스트.
+
+핵심: cold-start≠0점(None 보존)·risk 불확실→prod_touch None+ask_human·trust-before-capture(현
+verdict 미포함)·routing_context shape·엔진 shadow 가 routing_context/trust_snapshot 기록.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from app.services.workflow_line_resolver import _risk_flags, _story_predicate
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class _FakeStory:
+    def __init__(self, **kw):
+        self.priority = kw.get("priority", "medium")
+        self.story_points = kw.get("story_points")
+        self.success_hypothesis = kw.get("success_hypothesis")
+        self.metric_definition = kw.get("metric_definition")
+        self.measure_after = kw.get("measure_after")
+        self.outcome_status = kw.get("outcome_status", "n_a")
+        self.outcome_result = kw.get("outcome_result")
+        self.is_excluded = kw.get("is_excluded", False)
+
+
+# ── pure ──────────────────────────────────────────────────────────────────────
+def test_risk_flags_prod_touch_never_assumed_false():
+    rf = _risk_flags(_FakeStory(story_points=3))
+    assert rf["prod_touch"] is None  # ⭐불명 — False 추정 금지(AC⑤)
+    assert rf["uncertain"] is False  # story_points 있음
+    assert rf["high_effort"] is False
+
+
+def test_risk_flags_uncertain_when_no_points_or_no_story():
+    assert _risk_flags(_FakeStory(story_points=None))["uncertain"] is True
+    assert _risk_flags(None)["uncertain"] is True
+    assert _risk_flags(_FakeStory(story_points=13))["high_effort"] is True
+
+
+def test_story_predicate_shape():
+    p = _story_predicate(_FakeStory(priority="high", story_points=5, success_hypothesis="x"))
+    assert p["priority"] == "high" and p["story_points"] == 5
+    assert p["has_success_hypothesis"] is True
+    assert p["has_metric_definition"] is False and p["outcome_status"] == "n_a"
+
+
+# ── DB-backed ─────────────────────────────────────────────────────────────────
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_trust_snapshot_cold_start_is_none_not_zero():
+    from app.services.workflow_line_resolver import resolve_trust_snapshot
+    engine, Session = await _session()
+    async with Session() as s:
+        org, member = uuid.uuid4(), uuid.uuid4()
+        snap = await resolve_trust_snapshot(s, org, member)
+        # ⭐outcome 표본 없음 → cold-start·None(0점 아님)
+        assert snap["cold_start"] is True
+        assert snap["hypothesis_hit_rate"] is None  # NOT 0.0
+        assert snap["resolved"] == 0
+        assert snap["primary_source"] == "hypothesis_outcome"
+        assert snap["captured_before_verdict"] is True  # ⭐AC⑥
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_trust_snapshot_no_member():
+    from app.services.workflow_line_resolver import resolve_trust_snapshot
+    engine, Session = await _session()
+    async with Session() as s:
+        snap = await resolve_trust_snapshot(s, uuid.uuid4(), None)
+        assert snap["cold_start"] is True and snap["reason"] == "no_member"
+        assert snap["captured_before_verdict"] is True
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_routing_context_story_shape_and_cold_start_ask_human():
+    from app.services.workflow_line_resolver import resolve_routing_context
+    from app.models.pm import Story
+    from app.models.project import Project
+    engine, Session = await _session()
+    async with Session() as s:
+        org, proj, member = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        s.add(Project(id=proj, org_id=org, name="p")); await s.flush()
+        story = Story(org_id=org, project_id=proj, title="t", status="in-review",
+                      priority="high", story_points=3)
+        s.add(story)
+        await s.flush()
+        ctx = await resolve_routing_context(
+            s, org, entity_type="story", entity_id=story.id, actor_member_id=member, actor_type="agent")
+        assert ctx["supported"] is True
+        assert set(ctx) >= {"entity_type", "story", "actor", "risk_flags", "trust", "suggested_default"}
+        assert ctx["story"]["priority"] == "high" and ctx["story"]["story_points"] == 3
+        assert ctx["actor"]["type"] == "agent"
+        assert ctx["trust"]["cold_start"] is True
+        # cold-start → safe default ask_human
+        assert ctx["suggested_default"] == "ask_human"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_routing_context_non_story_unsupported():
+    from app.services.workflow_line_resolver import resolve_routing_context
+    engine, Session = await _session()
+    async with Session() as s:
+        ctx = await resolve_routing_context(
+            s, uuid.uuid4(), entity_type="epic", entity_id=uuid.uuid4())
+        assert ctx["supported"] is False and ctx["reason"] == "unsupported_entity_type"
+        assert ctx["suggested_default"] == "ask_human"  # 불명=safe default
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_engine_shadow_records_routing_context_and_trust():
+    """S3 엔진 shadow 경로가 S4 resolver 산출(routing_context+trust_snapshot)을 step_run 에 기록."""
+    from sqlalchemy import select
+    from app.services.workflow_line_engine import evaluate_line_for_transition
+    from app.models.workflow_line import (
+        WorkflowLineDefinition, WorkflowLineDefinitionVersion, WorkflowLineStepRun,
+    )
+    from app.models.pm import Story
+    from app.models.project import Project
+    engine, Session = await _session()
+    async with Session() as s:
+        org, proj, member = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        s.add(Project(id=proj, org_id=org, name="p")); await s.flush()
+        defn = WorkflowLineDefinition(org_id=org, project_id=None, entity_type="story",
+                                      name="L", is_active=True, version=1)
+        s.add(defn); await s.flush()
+        s.add(WorkflowLineDefinitionVersion(
+            line_definition_id=defn.id, org_id=org, project_id=None, entity_type="story",
+            version=1, status="published", config_hash="h", created_by_member_id=uuid.uuid4(),
+            config={"rollout_mode": "shadow",
+                    "steps": [{"from_status": "in-review", "to_status": "done", "step_type": "merge-gate"}]}))
+        story = Story(org_id=org, project_id=proj, title="t", status="in-review",
+                      priority="high", story_points=3)
+        s.add(story); await s.flush()
+        d = await evaluate_line_for_transition(
+            s, org_id=org, project_id=proj, entity_type="story", entity_id=story.id,
+            from_status="in-review", to_status="done", actor_id=member)
+        assert d.mode == "advisory_only" and d.proceeds
+        sr = (await s.execute(select(WorkflowLineStepRun).where(
+            WorkflowLineStepRun.entity_id == story.id))).scalar_one()
+        # ⭐routing_context + trust_snapshot 가 빈 {} 가 아니라 resolver 산출로 채워짐
+        assert sr.routing_context.get("supported") is True
+        assert sr.routing_context.get("story", {}).get("priority") == "high"
+        assert sr.trust_snapshot.get("cold_start") is True
+        assert sr.trust_snapshot.get("captured_before_verdict") is True
+    await engine.dispose()


### PR DESCRIPTION
## 배경
Decision Gate ⭐**trust-routing resolver(우리 moat)**(critical path 4번·의존 S3). 라인 라우팅 입력(routing_context) + outcome-trust snapshot 구성. ERP는 금액으로 분기하지만 우리는 **검증된 신뢰(hypothesis outcome)**로 분기한다. S4 = context/snapshot 생산 + shadow 관측 기록까지, 실 auto/ask/block enforcement는 S5. 마이그 없음·default-off. 스펙: 스토리 `ab41535a` AC 인라인.

## 변경
- **`services/workflow_line_resolver.py`** (신규): `resolve_routing_context()` + `resolve_trust_snapshot()` + risk_flags/story_predicate.
- **`services/workflow_line_engine.py`**: shadow/block 경로에서 매칭 step 확정 후 resolver 호출(step_run insert 전)→ `step_run.routing_context` + `trust_snapshot` 채움.

## AC 충족
- **① routing_context** = entity · story predicate · actor · risk_flags · trust.
- **② Story predicate** = priority/story_points/has_success_hypothesis/has_metric/has_measure_after/outcome_status/has_outcome_result (pm.py:101-115).
- **③ trust** = `compute_member_trust_scores`(primary_source=hypothesis_outcome) snapshot 기록.
- **④ ⭐cold-start ≠ 0점**: outcome 표본 없음(resolved==0)→ `cold_start=True`·`hypothesis_hit_rate=None`(0.0 아님).
- **⑤ risk safe default**: `prod_touch`는 불명 시 `None`(False 추정 금지)·정보 부족=`uncertain`→`suggested_default='ask_human'`. S4는 표기만·board 전이 비차단.
- **⑥ ⭐trust-before-capture**(P1-3 gaming 방어): resolver는 verdict를 add하지 않고 이력만 read·엔진은 step_run insert *전에* trust 계산(autoflush 자기-부트스트랩 방지·merge_verdict_gate.py:254-260 동형). `captured_before_verdict=True` marker.

## 설계 (PO/SME 사인오프)
- **fork①** 비-story entity → `unsupported` context로 안전 하강(Phase1 story-only·무리 확장 X).
- **fork②** routing enforcement(auto/ask/block 적용) = S5. S4는 snapshot/decision material + shadow 기록만·전이 비차단(S3 fail-open 정합).
- resolver 예외도 기존 엔진 fail-open try/except가 잡아 engine_failed→plain degrade.

## 검증 (로컬 실 PG·8 테스트 PASS)
- risk_flags(prod_touch None·uncertain) · story_predicate · **cold-start(resolved0→hit_rate None·0점 아님)** · no_member · routing_context shape+**cold-start→ask_human** · non-story unsupported · **엔진 shadow가 routing_context/trust_snapshot 기록(captured_before_verdict)**.
- 무회귀: S3 7 · stories PATCH 27 · app.main import OK.

## 체크리스트
- [x] routing_context·trust snapshot·cold-start≠0·risk safe default·trust-before-capture·엔진 shadow 배선
- [x] 8 테스트 + 무회귀
- [ ] 산티아고 SME(resolver 경계·cold-start·verdict-exclusion·S3 fail-open 결합)
- [ ] 까심 cross-model QA
- [ ] CI green → PO 머지게이트 → S5

🤖 Generated with [Claude Code](https://claude.com/claude-code)