### PR TITLE
[dc06bf53] E-DG S5 — H1 merge-gate wrapper unification (P0-2)

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -563,26 +563,41 @@ async def update_story_status(
     if _violation.violated and _violation_level == "block":
         raise HTTPException(status_code=400, detail=_violation.reason or "워크플로우 위반으로 상태 전이가 거부되었습니다.")
 
-    # H1-S5: in-review→done 직접 PATCH는 merge verdict gate preflight(플래그 active 시·AC②).
-    # transition rule(check_transition)과 직교 — 전이 유효성 통과 후 증거 게이트를 얹는다(AC④).
-    await _preflight_merge_gate(db, repo.org_id, story_before, body.status)
-    # S-GATE-2: config 게이트 집행(done) — flag-off면 no-op(무회귀). block→409·ask→HitlRequest park.
-    if body.status == "done" and story_before is not None:
-        from app.services.gate_enforce import enforce_gate
-        # HIGH②: actor_type 은 인증 컨텍스트에서 신뢰 도출(API 키=agent / JWT=human)·None→human 묵시 금지.
-        _g_actor_type = (
-            "agent" if auth.claims.get("app_metadata", {}).get("api_key_id") else "human"
-        )
-        _g_actor_id: uuid.UUID | None = None
-        try:  # actor_id 는 HitlRequest 귀속용(비보안)·best-effort.
-            _g_actor_id = await _resolve_team_member_id(auth, repo.org_id, db)
-        except Exception:
-            pass
-        await enforce_gate(
-            db, org_id=repo.org_id, project_id=getattr(story_before, "project_id", None),
-            work_type="done", actor_type=_g_actor_type, actor_id=_g_actor_id,
-            work_item_id=story_before.id, work_item_title=getattr(story_before, "title", None),
-        )
+    # E-DG S5(P0-2): enforcing 라인의 merge-gate step이 이 전이를 거버닝하면, 아래 라인 엔진이
+    # evaluate_merge_gate를 단일 평가한다 → 여기 _preflight_merge_gate/enforce_gate(done)는 skip해
+    # 이중 evaluate/이중 pending gate를 방지(AC⑦). 비-enforcing/비활성/예외는 False=현행 게이트 유지.
+    _line_owns_done_gate = False
+    if story_before is not None:
+        try:
+            from app.services.workflow_line_engine import line_merge_gate_active
+            _line_owns_done_gate = await line_merge_gate_active(
+                db, org_id=repo.org_id, project_id=getattr(story_before, "project_id", None),
+                entity_type="story", from_status=old_status, to_status=body.status,
+            )
+        except Exception:  # noqa: BLE001 — 불명 시 현행 게이트 유지(skip 안 함).
+            _line_owns_done_gate = False
+
+    if not _line_owns_done_gate:
+        # H1-S5: in-review→done 직접 PATCH는 merge verdict gate preflight(플래그 active 시·AC②).
+        # transition rule(check_transition)과 직교 — 전이 유효성 통과 후 증거 게이트를 얹는다(AC④).
+        await _preflight_merge_gate(db, repo.org_id, story_before, body.status)
+        # S-GATE-2: config 게이트 집행(done) — flag-off면 no-op(무회귀). block→409·ask→HitlRequest park.
+        if body.status == "done" and story_before is not None:
+            from app.services.gate_enforce import enforce_gate
+            # HIGH②: actor_type 은 인증 컨텍스트에서 신뢰 도출(API 키=agent / JWT=human)·None→human 묵시 금지.
+            _g_actor_type = (
+                "agent" if auth.claims.get("app_metadata", {}).get("api_key_id") else "human"
+            )
+            _g_actor_id: uuid.UUID | None = None
+            try:  # actor_id 는 HitlRequest 귀속용(비보안)·best-effort.
+                _g_actor_id = await _resolve_team_member_id(auth, repo.org_id, db)
+            except Exception:
+                pass
+            await enforce_gate(
+                db, org_id=repo.org_id, project_id=getattr(story_before, "project_id", None),
+                work_type="done", actor_type=_g_actor_type, actor_id=_g_actor_id,
+                work_item_id=story_before.id, work_item_title=getattr(story_before, "title", None),
+            )
 
     # E-DG S3: 워크플로우 라인 엔진(P0-1 fail-open). check_transition 후 / set_status 전. 활성 라인이
     # 없으면 plain(현 default-off=무영향). 엔진은 내부에서 모든 예외를 삼키지만, 호출부도 방어적으로

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -628,6 +628,10 @@ async def update_story_status(
             _line_decision = None
         # blocked_by_policy/gate_pending = 정상 차단 decision(예외 아님). engine_failed/advisory/plain은 진행.
         if _line_decision is not None and not _line_decision.proceeds:
+            # ⭐S5: raise 前 commit — engine 이 만든 H1 Gate·evidence write-back·step_run(h1_gate_id)
+            # audit 를 보존한다. get_db 는 예외 시 rollback 하므로, commit 없이 raise 하면 flush 된
+            # gate/step_run 이 사라진다(_preflight_merge_gate 가 raise 前 commit 하는 것과 동형·SME 적출).
+            await db.commit()
             raise HTTPException(
                 status_code=_line_decision.http_status or 409,
                 detail=_line_decision.blocking_reason or "워크플로우 라인 정책으로 상태 전이가 차단되었습니다.",

--- a/backend/app/services/workflow_line_engine.py
+++ b/backend/app/services/workflow_line_engine.py
@@ -101,6 +101,30 @@ def _match_step(config: dict[str, Any], from_status: str | None, to_status: str)
     return None
 
 
+def _is_merge_gate_step(step: dict) -> bool:
+    return step.get("step_type") == "merge-gate" or step.get("gate_type") == "merge"
+
+
+async def line_merge_gate_active(
+    session: AsyncSession, *, org_id: uuid.UUID, project_id: uuid.UUID | None,
+    entity_type: str, from_status: str | None, to_status: str,
+) -> bool:
+    """이 전이가 **enforcing 라인의 merge-gate step**에 거버닝되는지(라우터가 _preflight_merge_gate/
+    enforce_gate skip 여부 결정·이중 evaluate_merge_gate 방지·S5 AC⑦). 예외/비활성/non-enforcing 은
+    False(현행 게이트 유지·fail-safe)."""
+    try:
+        definition = await _active_definition(session, org_id, project_id, entity_type)
+        if definition is None:
+            return False
+        config = await _published_config(session, definition)
+        if str(config.get("rollout_mode") or "shadow").strip() != "enforcing":
+            return False
+        step = _match_step(config, from_status, to_status)
+        return bool(step and _is_merge_gate_step(step))
+    except Exception:  # noqa: BLE001 — 불명 시 현행 게이트 유지(라우터 skip 안 함).
+        return False
+
+
 async def evaluate_line_for_transition(
     session: AsyncSession,
     *,
@@ -156,6 +180,15 @@ async def evaluate_line_for_transition(
                 blocking_reason="workflow line policy blocks this transition", http_status=409,
             )
 
+        # S5(P0-2): enforcing + merge-gate step → H1 merge gate 단일 통합(이중게이트 방지).
+        if mode == "enforcing" and _is_merge_gate_step(step):
+            return await _merge_gate_wrapper(
+                session, org_id=org_id, project_id=project_id, definition=definition, step=step,
+                entity_type=entity_type, entity_id=entity_id, from_status=from_status,
+                to_status=to_status, routing_context=routing_context, trust_snapshot=trust_snapshot,
+                transition_id=transition_id, correlation_id=correlation_id,
+            )
+
         # shadow/advisory(+ S3 dormant enforcing) → step_run 기록 후 비차단.
         step_run = await _record_step_run(
             session, org_id=org_id, project_id=project_id, definition=definition, step=step,
@@ -195,6 +228,7 @@ async def _record_step_run(
     from_status, to_status, status, run_mode, transition_id, correlation_id,
     routing_decision=None, routing_reason=None, failure_class=None, failure_message=None,
     degraded_to_plain=False, routing_context=None, trust_snapshot=None,
+    gate_id=None, h1_gate_id=None, effective_gate_type=None,
 ) -> WorkflowLineStepRun | None:
     """step_run 기록. 호출자가 best-effort 로 감싼다(기록 실패도 전이 비차단)."""
     sr = WorkflowLineStepRun(
@@ -205,6 +239,8 @@ async def _record_step_run(
         routing_context=routing_context if routing_context is not None else {},  # S4: trust-routing 입력
         trust_snapshot=trust_snapshot if trust_snapshot is not None else {},     # S4: outcome-trust(이력만)
         effective_step_type=(step or {}).get("step_type") if step else None,
+        effective_gate_type=effective_gate_type,                                  # S5: merge-gate 통합
+        gate_id=gate_id, h1_gate_id=h1_gate_id,                                   # S5: H1 대표 gate
         failure_class=failure_class, failure_message=failure_message, degraded_to_plain=degraded_to_plain,
         correlation_id=correlation_id, transition_id=transition_id,
     )
@@ -223,3 +259,48 @@ async def _record_step_run(
             pass
         return None
     return sr
+
+
+async def _merge_gate_wrapper(
+    session: AsyncSession, *, org_id, project_id, definition, step, entity_type, entity_id,
+    from_status, to_status, routing_context, trust_snapshot, transition_id, correlation_id,
+) -> LineDecision:
+    """S5(P0-2): in-review→done merge-gate step = H1 merge gate 단일 통합.
+
+    ``evaluate_merge_gate()`` 를 정확히 1회 호출(라우터는 line_merge_gate_active 시 _preflight/enforce
+    skip)하고 H1 decision 을 line decision 으로 매핑한다. ASK_HUMAN 은 **H1 gate id 를 대표 gate_id**
+    로 재사용해 별도 line human-gate Gate 를 만들지 않는다(이중 pending 방지). H1 evidence metadata 는
+    evaluate_merge_gate 가 gate row 에 write-back(유지). 예외는 바깥 try/except 가 engine_failed→plain.
+    """
+    from app.services.merge_verdict_gate import AUTO_MERGE, BLOCK, evaluate_merge_gate
+
+    decision = await evaluate_merge_gate(
+        session, org_id, entity_id, pr_number=0, repo="", ci_result=None, pr_result=None
+    )
+    gate_id = decision.gate_id
+
+    def _common(status: str, run_mode: str, routing_decision: str):
+        return _record_step_run(
+            session, org_id=org_id, project_id=project_id, definition=definition, step=step,
+            entity_type=entity_type, entity_id=entity_id, from_status=from_status, to_status=to_status,
+            status=status, run_mode=run_mode, routing_decision=routing_decision,
+            routing_reason=f"merge-gate wrapper: {decision.decision}",
+            routing_context=routing_context, trust_snapshot=trust_snapshot,
+            gate_id=gate_id, h1_gate_id=gate_id, effective_gate_type="merge",
+            transition_id=transition_id, correlation_id=correlation_id,
+        )
+
+    if decision.decision == AUTO_MERGE:
+        sr = await _common("applied", "advisory_only", "auto_route")
+        return LineDecision(mode="advisory_only", status_to_apply=to_status,
+                            step_run_id=sr.id if sr else None, gate_id=gate_id)
+    if decision.decision == BLOCK:
+        sr = await _common("blocked_by_policy", "blocked_by_policy", "block")
+        return LineDecision(mode="blocked_by_policy", status_to_apply=None,
+                            step_run_id=sr.id if sr else None, gate_id=gate_id,
+                            blocking_reason="merge gate blocks this transition", http_status=409)
+    # ASK_HUMAN → gate_pending(대표 gate_id = H1 gate·별도 Gate 미생성).
+    sr = await _common("waiting_gate", "gate_pending", "ask_human")
+    return LineDecision(mode="gate_pending", status_to_apply=None,
+                        step_run_id=sr.id if sr else None, gate_id=gate_id,
+                        blocking_reason="merge gate requires human approval", http_status=409)

--- a/backend/tests/test_edg_s5_merge_gate.py
+++ b/backend/tests/test_edg_s5_merge_gate.py
@@ -1,0 +1,153 @@
+"""E-DG S5: H1 merge-gate wrapper unification (P0-2) 테스트.
+
+핵심: enforcing 라인 merge-gate step → evaluate_merge_gate 정확히 1회 + AUTO_MERGE/ASK_HUMAN/BLOCK
+매핑(ASK_HUMAN은 H1 gate_id 대표·별도 Gate 미생성) + line_merge_gate_active(라우터 skip 판정) +
+S3 fail-open 보존(merge-gate 평가 예외도 plain degrade).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_line(s, org, mode, *, step_type="merge-gate", from_status="in-review", to_status="done"):
+    from app.models.workflow_line import WorkflowLineDefinition, WorkflowLineDefinitionVersion
+    defn = WorkflowLineDefinition(org_id=org, project_id=None, entity_type="story",
+                                  name="L", is_active=True, version=1)
+    s.add(defn); await s.flush()
+    s.add(WorkflowLineDefinitionVersion(
+        line_definition_id=defn.id, org_id=org, project_id=None, entity_type="story",
+        version=1, status="published", config_hash="h", created_by_member_id=uuid.uuid4(),
+        config={"rollout_mode": mode,
+                "steps": [{"from_status": from_status, "to_status": to_status, "step_type": step_type}]}))
+    await s.flush()
+
+
+def _decision(decision, gate_id):
+    from app.services.merge_verdict_gate import MergeGateDecision
+    return MergeGateDecision(
+        decision=decision, reason="test", gate_id=gate_id, gate_status="pending",
+        disposition="ask", trust=None, ci_result=None,
+    )
+
+
+# ── line_merge_gate_active (라우터 skip 판정) ─────────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_line_merge_gate_active_only_for_enforcing_merge_gate():
+    from app.services.workflow_line_engine import line_merge_gate_active
+    engine, Session = await _session()
+    kw = dict(entity_type="story", from_status="in-review", to_status="done")
+    async with Session() as s:
+        org_off, org_shadow, org_enf, org_enf_nonmerge, org_none = (uuid.uuid4() for _ in range(5))
+        await _seed_line(s, org_off, "off")
+        await _seed_line(s, org_shadow, "shadow")
+        await _seed_line(s, org_enf, "enforcing")
+        await _seed_line(s, org_enf_nonmerge, "enforcing", step_type="agent-handoff")
+        assert await line_merge_gate_active(s, org_id=org_enf, project_id=None, **kw) is True
+        assert await line_merge_gate_active(s, org_id=org_off, project_id=None, **kw) is False
+        assert await line_merge_gate_active(s, org_id=org_shadow, project_id=None, **kw) is False
+        assert await line_merge_gate_active(s, org_id=org_enf_nonmerge, project_id=None, **kw) is False
+        assert await line_merge_gate_active(s, org_id=org_none, project_id=None, **kw) is False
+        # 다른 전이(in-review→done 아님)는 False
+        assert await line_merge_gate_active(
+            s, org_id=org_enf, project_id=None, entity_type="story",
+            from_status="backlog", to_status="ready-for-dev") is False
+    await engine.dispose()
+
+
+# ── wrapper decision 매핑 (evaluate_merge_gate patch로 결정 격리) ─────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_merge_gate_wrapper_ask_human_uses_h1_gate_no_double():
+    from sqlalchemy import func, select
+    from app.services import workflow_line_engine as eng
+    from app.services.merge_verdict_gate import ASK_HUMAN
+    from app.models.workflow_line import WorkflowLineStepRun
+    from app.models.gate import Gate
+    engine, Session = await _session()
+    async with Session() as s:
+        org, eid = uuid.uuid4(), uuid.uuid4()
+        await _seed_line(s, org, "enforcing")
+        h1_gate = uuid.uuid4()
+        with patch("app.services.merge_verdict_gate.evaluate_merge_gate",
+                   return_value=_decision(ASK_HUMAN, h1_gate)) as m:
+            d = await eng.evaluate_line_for_transition(
+                s, org_id=org, project_id=None, entity_type="story", entity_id=eid,
+                from_status="in-review", to_status="done", actor_id=uuid.uuid4())
+        assert m.call_count == 1  # ⭐evaluate_merge_gate 정확히 1회(AC②)
+        assert d.mode == "gate_pending" and not d.proceeds
+        assert d.gate_id == h1_gate and d.http_status == 409  # ⭐H1 gate id 대표
+        sr = (await s.execute(select(WorkflowLineStepRun).where(
+            WorkflowLineStepRun.entity_id == eid))).scalar_one()
+        assert sr.effective_gate_type == "merge" and sr.effective_step_type == "merge-gate"
+        assert sr.h1_gate_id == h1_gate and sr.gate_id == h1_gate
+        # ⭐wrapper 자체는 Gate 를 안 만든다(evaluate_merge_gate patch라 0)·이중 Gate 방지
+        assert (await s.execute(select(func.count()).select_from(Gate))).scalar() == 0
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_merge_gate_wrapper_auto_merge_and_block():
+    from app.services import workflow_line_engine as eng
+    from app.services.merge_verdict_gate import AUTO_MERGE, BLOCK
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        await _seed_line(s, org, "enforcing")
+        g = uuid.uuid4()
+        with patch("app.services.merge_verdict_gate.evaluate_merge_gate", return_value=_decision(AUTO_MERGE, g)):
+            d = await eng.evaluate_line_for_transition(
+                s, org_id=org, project_id=None, entity_type="story", entity_id=uuid.uuid4(),
+                from_status="in-review", to_status="done")
+        assert d.mode == "advisory_only" and d.proceeds and d.status_to_apply == "done"
+        with patch("app.services.merge_verdict_gate.evaluate_merge_gate", return_value=_decision(BLOCK, g)):
+            d2 = await eng.evaluate_line_for_transition(
+                s, org_id=org, project_id=None, entity_type="story", entity_id=uuid.uuid4(),
+                from_status="in-review", to_status="done")
+        assert d2.mode == "blocked_by_policy" and not d2.proceeds and d2.http_status == 409
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_merge_gate_wrapper_failopen():
+    """⭐S3 fail-open 보존: merge-gate 평가(evaluate_merge_gate) 예외도 engine_failed→plain(전이 진행)."""
+    from app.services import workflow_line_engine as eng
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        await _seed_line(s, org, "enforcing")
+        with patch("app.services.merge_verdict_gate.evaluate_merge_gate", side_effect=RuntimeError("boom")):
+            d = await eng.evaluate_line_for_transition(
+                s, org_id=org, project_id=None, entity_type="story", entity_id=uuid.uuid4(),
+                from_status="in-review", to_status="done")
+        assert d.mode == "engine_failed" and d.degraded_to_plain and d.proceeds
+    await engine.dispose()

--- a/backend/tests/test_edg_s5_merge_gate.py
+++ b/backend/tests/test_edg_s5_merge_gate.py
@@ -151,3 +151,32 @@ async def test_merge_gate_wrapper_failopen():
                 from_status="in-review", to_status="done")
         assert d.mode == "engine_failed" and d.degraded_to_plain and d.proceeds
     await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_merge_gate_audit_persists_after_raise_commit():
+    """⭐SME blocking 회귀: gate_pending(라우터가 raise 前 db.commit) 후 engine 이 만든 step_run audit
+    이 살아남아야 한다. commit 없이 raise 하면 get_db rollback 으로 사라지던 갭."""
+    from sqlalchemy import select
+    from app.services import workflow_line_engine as eng
+    from app.services.merge_verdict_gate import ASK_HUMAN
+    from app.models.workflow_line import WorkflowLineStepRun
+    engine, Session = await _session()
+    org, eid, gid = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    async with Session() as s:
+        await _seed_line(s, org, "enforcing")
+        await s.commit()
+    async with Session() as s:  # 라우터 트랜잭션 모사
+        with patch("app.services.merge_verdict_gate.evaluate_merge_gate",
+                   return_value=_decision(ASK_HUMAN, gid)):
+            d = await eng.evaluate_line_for_transition(
+                s, org_id=org, project_id=None, entity_type="story", entity_id=eid,
+                from_status="in-review", to_status="done")
+        assert not d.proceeds  # gate_pending → 라우터가 raise
+        await s.commit()  # ⭐라우터의 raise-前 commit 모사
+    async with Session() as s2:  # 새 세션 — audit 영속 확認(rollback 됐으면 None)
+        sr = (await s2.execute(select(WorkflowLineStepRun).where(
+            WorkflowLineStepRun.entity_id == eid))).scalar_one_or_none()
+        assert sr is not None and sr.h1_gate_id == gid and sr.mode == "gate_pending"
+    await engine.dispose()


### PR DESCRIPTION
## 배경
Decision Gate ⭐**P0-2: in-review→done 단일 merge-gate 통합**(critical path 5번·의존 S3+S4). H1 merge gate와 라인 human-gate가 따로 pending gate를 만드는 **이중게이트**를 방지한다. enforcing 라인의 merge-gate step이 이 전이를 거버닝하면 라인 엔진이 `evaluate_merge_gate`를 **단일 평가**하고 라우터의 `_preflight_merge_gate`/`enforce_gate(done)`는 skip한다. default-off(비-enforcing)면 현행 그대로·라이브 무영향. 스펙: 스토리 `dc06bf53` AC 인라인.

## 변경
- **`services/workflow_line_engine.py`**: `_merge_gate_wrapper()` + `line_merge_gate_active()` + `_record_step_run` gate 파라미터.
- **`routers/stories.py`**: `line_merge_gate_active` 사전체크 → enforcing merge-gate면 `_preflight_merge_gate`+`enforce_gate(done)` skip.

## AC 충족
- **① merge-gate step** = effective_step_type='merge-gate'·effective_gate_type='merge'·h1_gate_id (step_run 기록).
- **② evaluate_merge_gate 정확히 1회**(라우터 skip + 엔진 단일 호출·테스트 call_count==1).
- **③ AUTO_MERGE** → advisory_only/proceed(done 적용).
- **④ ASK_HUMAN** → gate_pending·**대표 gate_id = H1 decision.gate_id**·별도 line human-gate Gate 미생성(이중 방지).
- **⑤ BLOCK** → blocked_by_policy(status 유지).
- **⑥ H1 evidence metadata** 유지(evaluate_merge_gate가 gate row write-back).
- **⑦ ⭐_preflight/enforce 중복 skip**(line enforcing mode·라우터 한 번만).
- **⑧ S3 fail-open 보존**(merge-gate 평가 예외도 engine_failed→plain).

## 설계 (PO/SME 사인오프)
- `line_merge_gate_active`: published config mode=enforcing + merge-gate step + 해당 전이일 때만 True. 예외/비활성/non-enforcing/타전이 = False(현행 게이트 유지·fail-safe).
- ASK_HUMAN은 H1 gate를 대표로 재사용 → wrapper 자체는 Gate 미생성(이중 pending 0).

## 검증 (로컬 실 PG·S5 4 PASS)
- `line_merge_gate_active`(enforcing merge-gate만 True·shadow/off/non-merge/no-line/타전이 False) · ASK_HUMAN→gate_pending(**H1 gate_id 대표·evaluate 1회·이중 Gate 0**) · AUTO_MERGE→advisory_only/proceed · BLOCK→blocked_by_policy · ⭐**fail-open**(evaluate_merge_gate throw→engine_failed→plain).
- 무회귀: S3 7·S4 9·stories PATCH+gate enforce 40·app.main OK. 마이그 없음.

## 체크리스트
- [x] merge-gate wrapper·단일 evaluate·H1 대표 gate·라우터 skip·fail-open·default-off 무변경
- [x] S5 4 + 무회귀
- [ ] 산티아고 SME(이중게이트 방지·H1 통합·evaluate 1회·skip·fail-open)
- [ ] 까심 cross-model QA
- [ ] CI green → PO 머지게이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)