### PR TITLE
[7526aac9] E-DG S6 — gate transition hook → generic line resolution

### DIFF
--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -120,10 +120,20 @@ async def transition_gate(
 
     await record_cold_start_seed(session, org_id, gate, new_status, resolver_id)
 
-    # H1-FIX-2: merge 게이트 approve → work item 스토리를 done으로 진행(_preflight 재평가 우회).
-    # S7은 verdict만 기록하고 →done 진행을 안 박아, 사람이 approve해도 일이 done에 도달 못 하고
-    # done 재시도 시 재평가→ask_human 재발로 막히던 dogfood 갭을 닫는다.
-    await _advance_story_on_merge_approve(session, gate, new_status)
+    # E-DG S6: gate 전이를 범용 line resolution 에 배선. gate 에 묶인 active line step_run 이 있으면
+    # apply_workflow_line_resolution(H1/line approve 동일 status side-effect 경로)·없으면 legacy
+    # _advance_story_on_merge_approve 유지(무회귀). 신규 승인경로 0.
+    from app.services.workflow_line_resolution import (
+        apply_workflow_line_resolution,
+        find_active_step_run_for_gate,
+    )
+
+    _line_step_run_id = await find_active_step_run_for_gate(session, org_id, gate.id)
+    if _line_step_run_id is not None:
+        await apply_workflow_line_resolution(session, _line_step_run_id, new_status, resolver_id=resolver_id)
+    else:
+        # H1-FIX-2: merge 게이트 approve → work item 스토리를 done으로 진행(_preflight 재평가 우회).
+        await _advance_story_on_merge_approve(session, gate, new_status)
 
     await session.flush()
     await session.refresh(gate)

--- a/backend/app/services/workflow_line_resolution.py
+++ b/backend/app/services/workflow_line_resolution.py
@@ -1,0 +1,136 @@
+"""E-DECISION-GATE S6: gate 전이 → 범용 line resolution 배선.
+
+gate 승인/반려가 ``transition_gate()`` 를 타면, 그 gate 에 묶인 active line step_run 을 찾아 line
+정책대로 status 를 적용한다. H1 approve 와 line approve 가 **동일 status side-effect 경로**
+(``emit_story_status_changed``)를 타도록 통일한다(신규 승인경로 0). line run 이 없으면 호출부가
+legacy ``_advance_story_on_merge_approve`` 로 폴백한다(무회귀).
+
+P1-1 idempotency: story/run 을 row lock(SELECT FOR UPDATE)하고, stale ``from_status``(story 가 이미
+다른 status 로 이동)면 적용하지 않는다. 이미 목표 status 면 no-op.
+"""
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.workflow_line import (
+    WorkflowLineDefinition,
+    WorkflowLineDefinitionVersion,
+    WorkflowLineStepRun,
+)
+
+# 이 gate 에 묶인 step_run 이 아직 미해소(승인/반려 대기) 상태로 볼 수 있는 집합.
+_OPEN_STEP_RUN_STATUSES = frozenset({
+    "pending", "routing_resolved", "dispatched", "waiting_gate", "waiting_parallel",
+    "gate_pending", "reminded", "escalated", "held",
+})
+
+
+async def find_active_step_run_for_gate(
+    session: AsyncSession, org_id: uuid.UUID, gate_id: uuid.UUID
+) -> uuid.UUID | None:
+    """gate_id(또는 h1_gate_id)에 묶인 미해소 line step_run id. 없으면 None(→legacy 폴백)."""
+    r = await session.execute(
+        select(WorkflowLineStepRun.id).where(
+            WorkflowLineStepRun.org_id == org_id,
+            (WorkflowLineStepRun.gate_id == gate_id) | (WorkflowLineStepRun.h1_gate_id == gate_id),
+            WorkflowLineStepRun.status.in_(_OPEN_STEP_RUN_STATUSES),
+        ).order_by(WorkflowLineStepRun.started_at.desc()).limit(1)
+    )
+    return r.scalar_one_or_none()
+
+
+async def _step_config(session: AsyncSession, step_run: WorkflowLineStepRun) -> dict[str, Any]:
+    """step_run 이 가리키는 published config 의 매칭 step(on_approve/on_reject 등)."""
+    if step_run.line_definition_id is None:
+        return {}
+    r = await session.execute(
+        select(WorkflowLineDefinitionVersion).where(
+            WorkflowLineDefinitionVersion.line_definition_id == step_run.line_definition_id,
+            WorkflowLineDefinitionVersion.status == "published",
+        ).order_by(WorkflowLineDefinitionVersion.version.desc()).limit(1)
+    )
+    version = r.scalar_one_or_none()
+    config = dict(version.config) if version and isinstance(version.config, dict) else {}
+    for step in config.get("steps") or []:
+        if (isinstance(step, dict) and step.get("to_status") == step_run.to_status
+                and step.get("from_status") in (step_run.from_status, None)):
+            return step
+    return {}
+
+
+async def apply_workflow_line_resolution(
+    session: AsyncSession, step_run_id: uuid.UUID, new_status: str,
+    resolver_id: uuid.UUID | None = None,
+) -> None:
+    """gate 해소(approved|rejected)를 line step_run 정책대로 적용.
+
+    approve + ``on_approve.apply_transition=true`` → story 를 step_run.to_status 로 전이(H1 과 동일
+    ``emit_story_status_changed`` 경로). reject → Phase1 기본 in-review 유지(status set/relay 안 함).
+    row lock + stale from_status 미적용(P1-1).
+    """
+    sr = (await session.execute(
+        select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == step_run_id).with_for_update()
+    )).scalar_one_or_none()
+    if sr is None or sr.entity_type != "story":  # Phase1 = story-only
+        return
+    step = await _step_config(session, sr)
+
+    if new_status == "rejected":
+        # on_reject Phase1 기본: in-review 유지·status 변경/relay 안 함(AC⑥).
+        sr.status = "rejected"
+        sr.resolved_at = _now()
+        await session.flush()
+        return
+
+    if new_status != "approved":
+        return
+
+    on_approve = step.get("on_approve") if isinstance(step.get("on_approve"), dict) else {}
+    if not on_approve.get("apply_transition"):  # AC⑤: 명시 true 일 때만 status 변경.
+        sr.status = "approved"
+        sr.resolved_at = _now()
+        await session.flush()
+        return
+
+    from app.models.pm import Story  # 순환 회피 lazy import.
+
+    story = (await session.execute(
+        select(Story).where(Story.id == sr.entity_id).with_for_update()
+    )).scalar_one_or_none()
+    if story is None:
+        sr.status = "approved"
+        sr.resolved_at = _now()
+        await session.flush()
+        return
+
+    # 이미 목표 status 면 멱등 applied(다른 경로로 도달했어도 결과 동일). 그 외 stale from_status
+    # (story 가 제3 status 로 이동)면 미적용(P1-1). 순서: 멱등 우선 → stale.
+    if story.status == sr.to_status:
+        sr.status = "applied"
+        sr.resolved_at = _now()
+        await session.flush()
+        return
+    if sr.from_status is not None and story.status != sr.from_status:
+        sr.status = "skipped"
+        sr.resolved_at = _now()
+        await session.flush()
+        return
+
+    old_status = story.status
+    story.status = sr.to_status
+    sr.status = "applied"
+    sr.resolved_at = _now()
+    await session.flush()
+    # H1 경로와 동일 side-effect(event/webhook/L1/notification·shared helper·parity·AC⑦).
+    from app.services.story_status_events import emit_story_status_changed
+
+    await emit_story_status_changed(
+        session, sr.org_id, story, old_status, actor_id=resolver_id, actor_type="human",
+    )
+
+
+def _now():
+    from datetime import datetime, timezone
+    return datetime.now(tz=timezone.utc)

--- a/backend/tests/test_edg_s6_gate_hook.py
+++ b/backend/tests/test_edg_s6_gate_hook.py
@@ -1,0 +1,161 @@
+"""E-DG S6: gate transition hook → generic line resolution 테스트.
+
+핵심: find_active_step_run_for_gate(gate→step_run)·apply_workflow_line_resolution(approve+
+apply_transition→to_status+emit / no-apply·stale·reject→미적용 / row lock·idempotent) ·
+emit_story_status_changed = H1 동일 경로.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(s, org, *, apply_transition=True, story_status="in-review",
+                from_status="in-review", to_status="done", gate_id=None, run_status="waiting_gate"):
+    from app.models.project import Project
+    from app.models.pm import Story
+    from app.models.workflow_line import (
+        WorkflowLineDefinition, WorkflowLineDefinitionVersion, WorkflowLineStepRun,
+    )
+    proj = uuid.uuid4()
+    s.add(Project(id=proj, org_id=org, name="p")); await s.flush()
+    defn = WorkflowLineDefinition(org_id=org, project_id=None, entity_type="story",
+                                  name="L", is_active=True, version=1)
+    s.add(defn); await s.flush()
+    s.add(WorkflowLineDefinitionVersion(
+        line_definition_id=defn.id, org_id=org, project_id=None, entity_type="story", version=1,
+        status="published", config_hash="h", created_by_member_id=uuid.uuid4(),
+        config={"rollout_mode": "enforcing", "steps": [{
+            "from_status": from_status, "to_status": to_status, "step_type": "merge-gate",
+            "on_approve": {"apply_transition": apply_transition}}]}))
+    story = Story(org_id=org, project_id=proj, title="t", status=story_status, priority="high")
+    s.add(story); await s.flush()
+    sr = WorkflowLineStepRun(
+        org_id=org, project_id=proj, line_definition_id=defn.id, entity_type="story",
+        entity_id=story.id, from_status=from_status, to_status=to_status, status=run_status,
+        mode="gate_pending", gate_id=gate_id or uuid.uuid4(), h1_gate_id=gate_id,
+        correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex)
+    s.add(sr); await s.flush()
+    return defn, story, sr
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_find_active_step_run_for_gate():
+    from app.services.workflow_line_resolution import find_active_step_run_for_gate
+    engine, Session = await _session()
+    async with Session() as s:
+        org, gid = uuid.uuid4(), uuid.uuid4()
+        _, _, sr = await _seed(s, org, gate_id=gid)
+        assert await find_active_step_run_for_gate(s, org, gid) == sr.id
+        assert await find_active_step_run_for_gate(s, org, uuid.uuid4()) is None  # 다른 gate
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_apply_approve_with_apply_transition_advances_story():
+    from app.services.workflow_line_resolution import apply_workflow_line_resolution
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        _, story, sr = await _seed(s, org, apply_transition=True)
+        with patch("app.services.story_status_events.emit_story_status_changed",
+                   new=AsyncMock()) as emit:
+            await apply_workflow_line_resolution(s, sr.id, "approved", resolver_id=uuid.uuid4())
+        await s.refresh(story); await s.refresh(sr)
+        assert story.status == "done" and sr.status == "applied"
+        assert emit.await_count == 1  # H1 동일 side-effect 경로
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_apply_approve_without_apply_transition_no_status_change():
+    from app.services.workflow_line_resolution import apply_workflow_line_resolution
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        _, story, sr = await _seed(s, org, apply_transition=False)
+        with patch("app.services.story_status_events.emit_story_status_changed",
+                   new=AsyncMock()) as emit:
+            await apply_workflow_line_resolution(s, sr.id, "approved")
+        await s.refresh(story); await s.refresh(sr)
+        assert story.status == "in-review" and sr.status == "approved"
+        assert emit.await_count == 0  # apply_transition=false → status 변경 안 함(AC⑤)
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_apply_stale_from_status_skipped():
+    from app.services.workflow_line_resolution import apply_workflow_line_resolution
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        # story 가 이미 다른 status(done)로 이동 → from_status(in-review) stale → 미적용(P1-1).
+        _, story, sr = await _seed(s, org, apply_transition=True, story_status="done")
+        with patch("app.services.story_status_events.emit_story_status_changed", new=AsyncMock()) as emit:
+            await apply_workflow_line_resolution(s, sr.id, "approved")
+        await s.refresh(sr)
+        # to_status==done == story.status → 이미 목표(멱등 applied)·emit 0. stale 케이스 별도 검증:
+        assert sr.status == "applied" and emit.await_count == 0
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_apply_stale_when_moved_elsewhere():
+    from app.services.workflow_line_resolution import apply_workflow_line_resolution
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        # from=in-review, to=done 인데 story 가 backlog 로 이동 → stale → skipped.
+        _, story, sr = await _seed(s, org, apply_transition=True, story_status="backlog")
+        with patch("app.services.story_status_events.emit_story_status_changed", new=AsyncMock()) as emit:
+            await apply_workflow_line_resolution(s, sr.id, "approved")
+        await s.refresh(story); await s.refresh(sr)
+        assert story.status == "backlog" and sr.status == "skipped" and emit.await_count == 0
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_apply_reject_keeps_in_review():
+    from app.services.workflow_line_resolution import apply_workflow_line_resolution
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        _, story, sr = await _seed(s, org, apply_transition=True)
+        with patch("app.services.story_status_events.emit_story_status_changed", new=AsyncMock()) as emit:
+            await apply_workflow_line_resolution(s, sr.id, "rejected")
+        await s.refresh(story); await s.refresh(sr)
+        assert story.status == "in-review" and sr.status == "rejected"  # Phase1 reject=in-review 유지
+        assert emit.await_count == 0
+    await engine.dispose()


### PR DESCRIPTION
## 배경
Decision Gate S6(critical path 6번·의존 S5). gate 승인/반려 전이를 **범용 line resolution에 배선** — H1 approve와 line approve가 동일 status side-effect 경로(`emit_story_status_changed`)를 타도록 통일한다. **신규 승인경로 0**·기존 `transition_gate` 재사용. 마이그 없음·default-off. 스펙: 스토리 `7526aac9` AC 인라인.

## 변경
- **`services/workflow_line_resolution.py`** (신규): `find_active_step_run_for_gate()` + `apply_workflow_line_resolution()`.
- **`services/gate_service.py`**: `transition_gate()`에 line-resolution hook(있으면 line, 없으면 legacy).

## AC 충족
- **① transition_gate 후 gate_id로 active step_run 조회**(gate_id 또는 h1_gate_id·미해소 status).
- **② line run 있으면** `apply_workflow_line_resolution(step_run_id, new_status)`.
- **③ line run 없으면** legacy `_advance_story_on_merge_approve`(무회귀).
- **④ row lock**(story/run SELECT FOR UPDATE) · **stale from_status 미적용**(P1-1 idempotency·제3 status 이동 시 skipped) · 이미 목표 status면 멱등 applied.
- **⑤ approve는 `on_approve.apply_transition=true`일 때만** status 변경.
- **⑥ reject는 Phase1 in-review 유지**(status set/relay 안 함).
- **⑦ emit_story_status_changed** = H1 경로와 동일 side-effect(event/webhook/L1/notification).

## 검증 (로컬 실 PG·S6 6 PASS)
- find_active_step_run_for_gate · approve+apply_transition→done+**emit 1회(H1 동일 경로)** · no-apply→status 무변경+emit 0 · 멱등(이미 done)→applied · **stale(backlog 이동)→skipped** · reject→in-review 유지.
- 무회귀: gate/hitl/gate_service/gate_transition/**h1_fix2** 57 · app.main OK. (line run 없으면 legacy _advance 그대로 → H1 경로 무변경.)

## 체크리스트
- [x] gate hook·apply_workflow_line_resolution·row lock·stale-guard·on_approve gating·reject·emit parity·legacy 무회귀
- [x] S6 6 + 무회귀 57
- [ ] 산티아고 SME(transition_gate 재사용·row lock·stale·legacy 무회귀·emit parity·gate_approved_without_status_apply=0)
- [ ] 까심 QA
- [ ] CI green → PO 머지게이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)