### PR TITLE
[8532294d] E-DG S7 — agent-handoff relay transaction + delivery status

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -643,9 +643,39 @@ async def update_story_status(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
+    # E-DG S7: agent-handoff relay — status 적용 후 같은 트랜잭션에서 dispatch(commit=False)·step_run
+    # delivery 기록(원자). wake/CC delivery 는 commit(아래) 후 recipient_seq 확정 후 발화(P1-2 불변식).
+    # relay 실패도 전이 비차단(fail-open).
+    _relay_wake = None
+    _relay_sr_id = (
+        _line_decision.relay_step_run_id
+        if (story_before is not None and _line_decision is not None) else None
+    )
+    if _relay_sr_id is not None:
+        from app.services.workflow_line_resolution import relay_agent_handoff
+        try:
+            _relay_wake = await relay_agent_handoff(db, _relay_sr_id, sender_id=_line_actor_id)
+        except Exception:  # noqa: BLE001 — relay 실패도 전이 비차단(fail-open).
+            _relay_wake = None
+
     # status 변경을 side effects 실행 전에 먼저 commit — process_event/webhook
     # 내부 DB 에러가 트랜잭션을 aborted 상태로 만들어 status 변경까지 rollback하는 버그 방지
     await db.commit()
+
+    # E-DG S7: relay wake — commit(recipient_seq 확정) 후 agent wake + CC delivery 발화(이중전달 방지).
+    if _relay_wake is not None:
+        _aw = _relay_wake.get("agent_wake")
+        if _aw:
+            wake_agent(_aw["recipient_id"], _aw["recipient_seq"])
+        _dl = _relay_wake.get("delivery")
+        if _dl:
+            from app.services.conversation_webhook import deliver_injected_event_webhook
+            background_tasks.add_task(
+                deliver_injected_event_webhook,
+                org_id=_dl["org_id"], recipient_id=_dl["recipient_id"], content=_dl["content"],
+                event_type=_dl["event_type"], source_entity_type=_dl["source_entity_type"],
+                source_entity_id=_dl["source_entity_id"],
+            )
 
     # S-C2: 모든 스토리 업데이트에서 actor resolve — status 변경 여부와 무관하게 공통 적용
     actor_id: uuid.UUID | None = None

--- a/backend/app/services/agent_dispatch.py
+++ b/backend/app/services/agent_dispatch.py
@@ -36,6 +36,8 @@ class DispatchResponse(BaseModel):
     # 7f8066a3: dispatched=False 사유 구분 → FE 가 no_assignee(담당자 미지정·info 안내)와
     # unresolved_assignee(신원 해소 실패·error)를 다르게 표시. additive·null default 하위호환.
     reason: str | None = None
+    # E-DG S7: commit=False 호출자가 commit 후 wake 하려면 recipient_seq 필요(agent). additive.
+    recipient_seq: int | None = None
 
 
 async def _fetch_entity(
@@ -82,6 +84,7 @@ async def dispatch_entity_to_assignee(
     message: str | None = None,
     trigger_metadata: dict[str, Any] | None = None,
     sender_id: uuid.UUID | None = None,
+    commit: bool = True,
 ) -> tuple[DispatchResponse, dict[str, Any] | None]:
     """entity의 assignee에게 dispatched 이벤트 생성 + 알림 전달 + (agent) wake.
 
@@ -166,20 +169,24 @@ async def dispatch_entity_to_assignee(
             reference_id=entity_id,
         )
 
-    await db.commit()  # commit 후 seq 확정
-
-    # agent: commit 후 wake (gateway_seq 확정 보장, 이중전달 방지)
-    if member_type == "agent":
-        if event.recipient_seq is not None:
-            wake_agent(str(assignee_id), event.recipient_seq)
-        else:
-            _push_to_agent(str(assignee_id), _event_to_payload(event))
+    # E-DG S7: commit=False면 호출자 트랜잭션에 합류 — 여기서 commit/wake 하지 않는다(P1-2
+    # partial-failure 방지). 호출자가 status/step_run/event 를 한 트랜잭션으로 commit 한 뒤 wake 한다
+    # (recipient_seq 확정 commit 후 wake 불변식). event.id/recipient_seq 는 위 flush 로 이미 확정.
+    if commit:
+        await db.commit()  # commit 후 seq 확정
+        # agent: commit 후 wake (gateway_seq 확정 보장, 이중전달 방지)
+        if member_type == "agent":
+            if event.recipient_seq is not None:
+                wake_agent(str(assignee_id), event.recipient_seq)
+            else:
+                _push_to_agent(str(assignee_id), _event_to_payload(event))
 
     response = DispatchResponse(
         dispatched=True,
         event_id=event.id,
         assignee_id=assignee_id,
         assignee_type=member_type,
+        recipient_seq=event.recipient_seq,
         reason="ok",
     )
     # 1f01c1ad: CC 릴레이(member webhook) 주입 파라미터 — 호출자가 스케줄(라우터=background_tasks).

--- a/backend/app/services/workflow_line_engine.py
+++ b/backend/app/services/workflow_line_engine.py
@@ -44,6 +44,8 @@ class LineDecision:
     blocking_reason: str | None = None
     http_status: int | None = None
     degraded_to_plain: bool = False
+    # S7: enforcing agent-handoff step 의 step_run id — 라우터가 status 적용 후 relay 한다(set 시에만).
+    relay_step_run_id: uuid.UUID | None = None
 
     @property
     def proceeds(self) -> bool:
@@ -199,9 +201,16 @@ async def evaluate_line_for_transition(
             routing_context=routing_context, trust_snapshot=trust_snapshot,
             transition_id=transition_id, correlation_id=correlation_id,
         )
+        # S7: enforcing agent-handoff step 은 status 적용 후 라우터가 relay(다음 actor dispatch).
+        # shadow/advisory 모드는 관측만(relay 안 함). step_run 기록 실패(None)면 relay 대상 없음.
+        _relay_id = (
+            step_run.id if (step_run is not None and mode == "enforcing"
+                            and step.get("step_type") == "agent-handoff") else None
+        )
         return LineDecision(
             mode="advisory_only", status_to_apply=to_status,
             step_run_id=step_run.id if step_run else None,
+            relay_step_run_id=_relay_id,
         )
     except Exception as exc:  # noqa: BLE001 — ⭐P0-1: 어떤 예외도 전이를 막지 않는다.
         # engine_failed step_run 기록은 best-effort(기록 실패도 전이 비차단·SME 체크포인트).

--- a/backend/app/services/workflow_line_resolution.py
+++ b/backend/app/services/workflow_line_resolution.py
@@ -164,12 +164,19 @@ async def relay_agent_handoff(
         "to_status": sr.to_status,
         "correlation_id": str(sr.correlation_id),
     }
+    # ⭐P0-3 fail-open: dispatch 호출을 SAVEPOINT(begin_nested)로 격리. dispatch 내부 DB 예외
+    # (event flush·assign_recipient_seq·notification·L1)가 outer 트랜잭션을 aborted 로 poison하면,
+    # 예외를 catch 해도 이후 dead_letter 기록·라우터 db.commit() 가 PendingRollbackError 로 깨져
+    # status 전이까지 막힌다(S3 [[feedback_savepoint_failopen_session_poison]] 동류·SME 적출). savepoint
+    # 면 dispatch 실패가 nested tx 로만 롤백되고 outer 는 살아있어 dead_letter 기록·전이가 진행된다.
     try:
-        resp, delivery = await dispatch_entity_to_assignee(
-            session, sr.org_id, sr.entity_type, sr.entity_id,
-            trigger_metadata=trigger_metadata, sender_id=sender_id, commit=False,
-        )
+        async with session.begin_nested():
+            resp, delivery = await dispatch_entity_to_assignee(
+                session, sr.org_id, sr.entity_type, sr.entity_id,
+                trigger_metadata=trigger_metadata, sender_id=sender_id, commit=False,
+            )
     except Exception as exc:  # noqa: BLE001 — ⭐relay 실패도 전이 비차단(fail-open)·가시화.
+        # savepoint rollback 으로 outer 트랜잭션 보존됨 → dead_letter 기록이 성공한다.
         sr.delivery_status = "dead_letter"
         sr.delivery_error = f"dispatch_create: {str(exc)[:400]}"
         sr.failure_class = "dispatch_exception"

--- a/backend/app/services/workflow_line_resolution.py
+++ b/backend/app/services/workflow_line_resolution.py
@@ -134,3 +134,64 @@ async def apply_workflow_line_resolution(
 def _now():
     from datetime import datetime, timezone
     return datetime.now(tz=timezone.utc)
+
+
+async def relay_agent_handoff(
+    session: AsyncSession, step_run_id: uuid.UUID, sender_id: uuid.UUID | None = None,
+) -> dict[str, Any] | None:
+    """S7(P0-3): agent-handoff — 다음 actor 에게 dispatched relay + delivery status 가시화.
+
+    ``dispatch_entity_to_assignee(commit=False)`` 로 호출자 트랜잭션에 합류(P1-2 partial-failure
+    방지·status/step_run/event 한 트랜잭션). step_run 에 event_id/recipient_seq/delivery_status/
+    delivery_error 기록. no_assignee/unresolved_assignee 는 silent pass 가 아니라 delivery_status 로
+    가시화. relay 예외·미배정도 전이는 비차단(fail-open) — 호출자가 commit 후 wake 한다.
+
+    반환: after-commit wake/delivery payload({agent_wake, delivery}) 또는 None(미배정/실패).
+    """
+    from app.services.agent_dispatch import dispatch_entity_to_assignee
+
+    sr = (await session.execute(
+        select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == step_run_id).with_for_update()
+    )).scalar_one_or_none()
+    if sr is None or sr.entity_type != "story":  # Phase1 = story-only
+        return None
+
+    trigger_metadata = {
+        "source": "workflow_line",
+        "line_step_id": str(sr.line_step_id) if sr.line_step_id else None,
+        "step_run_id": str(sr.id),
+        "from_status": sr.from_status,
+        "to_status": sr.to_status,
+        "correlation_id": str(sr.correlation_id),
+    }
+    try:
+        resp, delivery = await dispatch_entity_to_assignee(
+            session, sr.org_id, sr.entity_type, sr.entity_id,
+            trigger_metadata=trigger_metadata, sender_id=sender_id, commit=False,
+        )
+    except Exception as exc:  # noqa: BLE001 — ⭐relay 실패도 전이 비차단(fail-open)·가시화.
+        sr.delivery_status = "dead_letter"
+        sr.delivery_error = f"dispatch_create: {str(exc)[:400]}"
+        sr.failure_class = "dispatch_exception"
+        await session.flush()
+        return None
+
+    if not resp.dispatched:
+        # ⭐no_assignee/unresolved_assignee = silent pass 아님·delivery_status 로 가시화(AC⑤).
+        sr.delivery_status = resp.reason or "no_assignee"
+        await session.flush()
+        return None
+
+    sr.event_id = resp.event_id
+    sr.recipient_seq = resp.recipient_seq
+    sr.delivery_status = "queued"  # event 생성·commit 후 wake 로 전달(ACK 확정은 S8 watchdog).
+    sr.status = "dispatched"
+    await session.flush()
+
+    return {
+        "agent_wake": (
+            {"recipient_id": str(resp.assignee_id), "recipient_seq": resp.recipient_seq}
+            if resp.assignee_type == "agent" and resp.recipient_seq is not None else None
+        ),
+        "delivery": delivery,
+    }

--- a/backend/tests/test_edg_s7_handoff_relay.py
+++ b/backend/tests/test_edg_s7_handoff_relay.py
@@ -135,6 +135,34 @@ async def test_relay_exception_failopen_dead_letter():
     await engine.dispose()
 
 
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_relay_db_poison_isolated_by_savepoint():
+    """⭐SME blocking 회귀(S3 동류): dispatch 중 DB 예외가 outer 트랜잭션을 poison하면 안 된다.
+    SAVEPOINT 격리로 outer tx 보존 → dead_letter 기록 + 후속 commit 성공(전이 비차단)."""
+    import sqlalchemy as sa
+    from app.services.workflow_line_resolution import relay_agent_handoff
+    from app.models.workflow_line import WorkflowLineStepRun
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr = await _seed_step_run(s, org)
+
+        async def _poison(*a, **k):
+            await s.execute(sa.text("SELECT 1/0"))  # DB 에러 → 서브트랜잭션 abort
+
+        with patch("app.services.agent_dispatch.dispatch_entity_to_assignee", side_effect=_poison):
+            wake = await relay_agent_handoff(s, sr.id)  # ⭐예외도 raise 안 함
+        assert wake is None
+        row = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id))).scalar_one()
+        assert row.delivery_status == "dead_letter"
+        # ⭐outer tx 살아있음: 후속 read/write/commit 성공(poison이면 PendingRollbackError)
+        assert (await s.execute(sa.text("SELECT 1"))).scalar() == 1
+        await s.commit()
+    await engine.dispose()
+
+
 # ── 엔진 relay 플래그 (enforcing agent-handoff만) ────────────────────────────
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio

--- a/backend/tests/test_edg_s7_handoff_relay.py
+++ b/backend/tests/test_edg_s7_handoff_relay.py
@@ -1,0 +1,169 @@
+"""E-DG S7: agent-handoff relay transaction + delivery status 테스트.
+
+핵심: relay_agent_handoff(dispatch commit=False)·delivery_status step_run 기록·no_assignee/
+unresolved 가시화·예외 fail-open · 엔진이 enforcing agent-handoff 에 relay_step_run_id 세팅.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_step_run(s, org, *, from_status="ready-for-dev", to_status="in-progress"):
+    from app.models.workflow_line import WorkflowLineStepRun
+    sr = WorkflowLineStepRun(
+        org_id=org, project_id=uuid.uuid4(), entity_type="story", entity_id=uuid.uuid4(),
+        from_status=from_status, to_status=to_status, status="routing_resolved", mode="advisory_only",
+        correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex)
+    s.add(sr); await s.flush()
+    return sr
+
+
+def _resp(dispatched, **kw):
+    from app.services.agent_dispatch import DispatchResponse
+    return DispatchResponse(dispatched=dispatched, **kw)
+
+
+# ── relay_agent_handoff (dispatch patch로 격리) ──────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_relay_dispatched_records_delivery_and_returns_wake():
+    from app.services.workflow_line_resolution import relay_agent_handoff
+    from app.models.workflow_line import WorkflowLineStepRun
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr = await _seed_step_run(s, org)
+        ev, aid = uuid.uuid4(), uuid.uuid4()
+        ok = _resp(True, event_id=ev, assignee_id=aid, assignee_type="agent", recipient_seq=7, reason="ok")
+        delivery = {"org_id": org, "recipient_id": aid, "content": "x", "event_type": "dispatched",
+                    "source_entity_type": "story", "source_entity_id": sr.entity_id, "hypothesis_anchor": None}
+        with patch("app.services.agent_dispatch.dispatch_entity_to_assignee",
+                   return_value=(ok, delivery)) as m:
+            wake = await relay_agent_handoff(s, sr.id, sender_id=uuid.uuid4())
+        # commit=False 로 호출됐는지
+        assert m.await_count == 1 and m.call_args.kwargs.get("commit") is False
+        tm = m.call_args.kwargs.get("trigger_metadata") or {}
+        assert tm.get("source") == "workflow_line" and tm.get("step_run_id") == str(sr.id)
+        row = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id))).scalar_one()
+        assert row.delivery_status == "queued" and row.event_id == ev and row.recipient_seq == 7
+        assert row.status == "dispatched"
+        # after-commit wake payload(agent)
+        assert wake["agent_wake"] == {"recipient_id": str(aid), "recipient_seq": 7}
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_relay_no_assignee_visible_not_silent():
+    from app.services.workflow_line_resolution import relay_agent_handoff
+    from app.models.workflow_line import WorkflowLineStepRun
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr = await _seed_step_run(s, org)
+        with patch("app.services.agent_dispatch.dispatch_entity_to_assignee",
+                   return_value=(_resp(False, reason="no_assignee"), None)):
+            wake = await relay_agent_handoff(s, sr.id)
+        row = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id))).scalar_one()
+        assert row.delivery_status == "no_assignee" and wake is None  # ⭐silent pass 아님(AC⑤)
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_relay_unresolved_assignee_visible():
+    from app.services.workflow_line_resolution import relay_agent_handoff
+    from app.models.workflow_line import WorkflowLineStepRun
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr = await _seed_step_run(s, org)
+        with patch("app.services.agent_dispatch.dispatch_entity_to_assignee",
+                   return_value=(_resp(False, reason="unresolved_assignee"), None)):
+            await relay_agent_handoff(s, sr.id)
+        row = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id))).scalar_one()
+        assert row.delivery_status == "unresolved_assignee"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_relay_exception_failopen_dead_letter():
+    from app.services.workflow_line_resolution import relay_agent_handoff
+    from app.models.workflow_line import WorkflowLineStepRun
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr = await _seed_step_run(s, org)
+        with patch("app.services.agent_dispatch.dispatch_entity_to_assignee",
+                   side_effect=RuntimeError("boom")):
+            wake = await relay_agent_handoff(s, sr.id)  # ⭐예외도 raise 안 함(fail-open)
+        row = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id))).scalar_one()
+        assert row.delivery_status == "dead_letter" and row.failure_class == "dispatch_exception"
+        assert wake is None
+    await engine.dispose()
+
+
+# ── 엔진 relay 플래그 (enforcing agent-handoff만) ────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_engine_sets_relay_only_for_enforcing_agent_handoff():
+    from app.services.workflow_line_engine import evaluate_line_for_transition
+    from app.models.workflow_line import WorkflowLineDefinition, WorkflowLineDefinitionVersion
+
+    async def _seed_line(s, org, mode):
+        defn = WorkflowLineDefinition(org_id=org, project_id=None, entity_type="story",
+                                      name="L", is_active=True, version=1)
+        s.add(defn); await s.flush()
+        s.add(WorkflowLineDefinitionVersion(
+            line_definition_id=defn.id, org_id=org, project_id=None, entity_type="story", version=1,
+            status="published", config_hash="h", created_by_member_id=uuid.uuid4(),
+            config={"rollout_mode": mode, "steps": [{
+                "from_status": "ready-for-dev", "to_status": "in-progress", "step_type": "agent-handoff"}]}))
+        await s.flush()
+
+    engine, Session = await _session()
+    async with Session() as s:
+        org_enf, org_shadow = uuid.uuid4(), uuid.uuid4()
+        await _seed_line(s, org_enf, "enforcing")
+        await _seed_line(s, org_shadow, "shadow")
+        d_enf = await evaluate_line_for_transition(
+            s, org_id=org_enf, project_id=None, entity_type="story", entity_id=uuid.uuid4(),
+            from_status="ready-for-dev", to_status="in-progress")
+        d_shadow = await evaluate_line_for_transition(
+            s, org_id=org_shadow, project_id=None, entity_type="story", entity_id=uuid.uuid4(),
+            from_status="ready-for-dev", to_status="in-progress")
+        assert d_enf.mode == "advisory_only" and d_enf.proceeds and d_enf.relay_step_run_id is not None
+        assert d_shadow.relay_step_run_id is None  # shadow=관측만·relay 안 함
+    await engine.dispose()


### PR DESCRIPTION
## 배경
Decision Gate ⭐**P0-3: agent-handoff relay + delivery status 가시화**(critical path 7번·의존 S3+S4·BE 디디 + 게이트웨이 산티아고 SME). status 전이 후 owner relay → 기존 dispatch 레일로 다음 actor 무중단 킥 + delivery 상태 추적. 챗킥 제거가 silent stall로 이어지지 않게 한다. 마이그 없음·default-off(enforcing 라인 + agent-handoff step에서만 활성). 스펙: 스토리 `8532294d` AC 인라인. 산티아고 dispatch SME 사인오프(commit=False 최소침습 + caller after-commit wake).

## 변경
- **`agent_dispatch.py`**: `dispatch_entity_to_assignee(commit: bool = True)` — commit=False면 내부 commit/wake skip(P1-2 partial-failure 방지·호출자 트랜잭션 합류)·`recipient_seq`를 `DispatchResponse`로 반환. **기존 caller(commit=True)는 무변경**.
- **`workflow_line_resolution.py`**: `relay_agent_handoff()` — dispatch(commit=False·trigger_metadata) → step_run delivery 기록 + no_assignee/unresolved 가시화 + fail-open + after-commit wake payload.
- **`workflow_line_engine.py`**: enforcing agent-handoff step → `LineDecision.relay_step_run_id`.
- **`stories.py`**: set_status 후 같은 트랜잭션 relay(commit=False)·commit 후 wake_agent + CC delivery(background_tasks).

## AC 충족
- **① status apply + relay + dispatch event + step_run update 원자**(같은 트랜잭션, commit 후 wake).
- **② dispatch 내부 commit 문제 해결**: `commit=False`(agent_dispatch.py).
- **③ Event payload** trigger_metadata.source='workflow_line'·line_step_id·step_run_id·from_status·to_status·correlation_id.
- **④ delivery result → step_run**: event_id·recipient_seq·delivery_status·delivery_error.
- **⑤ ⭐no_assignee/unresolved_assignee = 가시 delivery state**(silent pass X).
- **⑥ 신규 event type 0** — EventType.dispatched만.
- **⑦ commit 후 wake**(caller after-commit·recipient_seq 확정 후). *(step_run_events phase 레코딩은 S8 watchdog 범위로 두고 실패정보는 step_run delivery_error/failure_class에 기록 — 리뷰 확인.)*
- **⑧ S3 fail-open 보존**(relay 실패도 전이 비차단).

## 검증 (로컬 실 PG·S7 5 PASS)
- relay dispatched(**commit=False·trigger_metadata·step_run queued+event_id+recipient_seq·agent wake 반환**)·no_assignee/unresolved 가시화·**예외 fail-open(dead_letter)**·엔진 relay 플래그(enforcing agent-handoff만·shadow None).
- 무회귀: dispatch/stories/S3-S6 line/gate **117**·app.main OK.

## ⚠️ 리뷰 확인
- step_run_events phase(status_apply/dispatch_create/wake) 레코딩을 S8(watchdog/ACK reconciliation)로 deferred·S7은 step_run delivery_error/failure_class로 실패 audit — S8 스코프 맞는지 SME 확인.
- delivery_status: dispatched→`queued`(ACK 확정은 S8), 예외→`dead_letter`(0126 enum 내).

## 체크리스트
- [x] commit=False·relay·delivery 가시화·fail-open·after-commit wake·엔진 플래그·legacy 무변경
- [x] S7 5 + 무회귀 117
- [ ] 산티아고 SME(commit 경계·dispatch payload/ACK·delivery 상태·no_assignee 가시화·fail-open)
- [ ] 까심 QA
- [ ] CI green → PO 머지게이트

🤖 Generated with [Claude Code](https://claude.com/claude-code)