### PR TITLE
[c1da5a63] E-DG S8 — handoff watchdog + ACK reconciliation

### DIFF
--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -130,6 +130,25 @@ async def hitl_timeouts(
         return _err("INTERNAL_ERROR", "Internal server error", 500)
 
 
+# ─── GET /api/v2/internal/cron/workflow-handoff-watchdog ──────────────────────
+# E-DG S8: handoff watchdog + ACK reconciliation(P0-3). silent handoff stall 을 observable
+# incident 로 전환 — ACK 대사 → acked / 10분 미ACK → timed_out(board badge) + fallback notification.
+
+@router.get("/workflow-handoff-watchdog")
+async def workflow_handoff_watchdog(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    verify_cron(request)
+    try:
+        from app.services.workflow_handoff_watchdog import reconcile_handoffs
+        counts = await reconcile_handoffs(session)
+        return _ok(counts)
+    except Exception as exc:
+        logger.exception("cron error: %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)
+
+
 # ─── GET /api/v2/internal/cron/inbox-outbox ────────────────────────────────────
 
 @router.get("/inbox-outbox")

--- a/backend/app/services/workflow_handoff_watchdog.py
+++ b/backend/app/services/workflow_handoff_watchdog.py
@@ -53,11 +53,15 @@ async def reconcile_handoffs(
     """미해소 handoff step_run 을 ACK 대사·stuck 판정한다. 반환: 카운트."""
     now = now or datetime.now(timezone.utc)
     cutoff = now - timedelta(minutes=stuck_after_minutes)
+    # ⭐동시성(SME blocking): cron invocation 이 겹치면 두 watchdog 이 같은 stale row 를 동시에 읽고
+    # 둘 다 timed_out + dispatch_notification 하여 재notify 0/idempotent 가 깨진다. FOR UPDATE
+    # SKIP LOCKED 로 각 invocation 이 disjoint row 집합만 claim → 한 쪽이 잠근 row 는 다른 쪽이 건너뛰고,
+    # 잠긴 row 는 이 트랜잭션 commit(terminal 전환) 까지 보호되어 정확히 1회만 처리·notify 된다.
     rows = (await session.execute(
         select(WorkflowLineStepRun).where(
             WorkflowLineStepRun.delivery_status.in_(_OPEN_DELIVERY),
             WorkflowLineStepRun.created_at < cutoff,
-        )
+        ).with_for_update(skip_locked=True)
     )).scalars().all()
 
     acked = stuck = missing = 0

--- a/backend/app/services/workflow_handoff_watchdog.py
+++ b/backend/app/services/workflow_handoff_watchdog.py
@@ -1,0 +1,104 @@
+"""E-DECISION-GATE S8: handoff watchdog + ACK reconciliation (P0-3 마무리).
+
+S7 가 agent-handoff relay 의 delivery_status 를 기록(queued)했으니, S8 watchdog 가 주기적으로:
+- agent ACK cursor(``AgentEventCursor.acked_seq``)와 대사 → ACK 됐으면 ``delivery_status='acked'``.
+- 10분 초과 미ACK → ``delivery_status='timed_out'``(board badge) + fallback human notification.
+silent handoff stall 을 observable incident 로 전환한다.
+
+설계(산티아고 ACK/connector SME 사인오프):
+- recipient 는 ``step_run.event_id → Event.recipient_id`` 로 해소(Event = source of truth·resolved_member_id
+  백필 안 함).
+- ⭐wake 성공 ≠ delivered: S7 의 queued 를 그대로 두고 ACK cursor 로만 acked 판정.
+- 신규 EventType 0(``dispatch_notification`` 의 notification 카테고리만 사용).
+- idempotent: queued/delivered 만 픽 → acked/timed_out 전환 즉시 재처리·재notify 제외.
+- 방어: event 없음→missing_dispatch_event·recipient_type≠agent→ACK skip·recipient_seq null→missing_recipient_seq.
+- dispatch_notification 실패는 watchdog 전체 실패로 올리지 않고 해당 run best-effort 후 계속.
+- workflow_step_run_events phase 행은 모델 부재로 S8 범위 밖(관측성 S9+)·delivery_status/error 로 충분.
+"""
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.agent_gateway import AgentEventCursor
+from app.models.event import Event
+from app.models.workflow_line import WorkflowLineStepRun
+
+_OPEN_DELIVERY = ("queued", "delivered")
+DEFAULT_STUCK_MINUTES = 10
+
+
+async def _fallback_notify(session: AsyncSession, sr: WorkflowLineStepRun,
+                           recipient_id: uuid.UUID | None) -> None:
+    """stuck handoff 의 fallback human notification(best-effort·실패는 삼킴)."""
+    if recipient_id is None:
+        return
+    try:
+        from app.services.notification_dispatch import dispatch_notification
+        await dispatch_notification(
+            session, org_id=sr.org_id, event_type="handoff_stuck",
+            target_member_ids=[recipient_id],
+            title="Handoff stalled — no ACK within SLA",
+            body=f"{sr.entity_type} {sr.entity_id} {sr.from_status}→{sr.to_status} handoff unacked",
+            reference_type=sr.entity_type, reference_id=sr.entity_id,
+        )
+    except Exception:  # noqa: BLE001 — notification 실패는 watchdog 비중단(best-effort).
+        sr.delivery_error = (sr.delivery_error or "") + "; notify_failed"
+
+
+async def reconcile_handoffs(
+    session: AsyncSession, now: datetime | None = None, stuck_after_minutes: int = DEFAULT_STUCK_MINUTES,
+) -> dict[str, int]:
+    """미해소 handoff step_run 을 ACK 대사·stuck 판정한다. 반환: 카운트."""
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(minutes=stuck_after_minutes)
+    rows = (await session.execute(
+        select(WorkflowLineStepRun).where(
+            WorkflowLineStepRun.delivery_status.in_(_OPEN_DELIVERY),
+            WorkflowLineStepRun.created_at < cutoff,
+        )
+    )).scalars().all()
+
+    acked = stuck = missing = 0
+    for sr in rows:
+        try:
+            # 방어: dispatch event 없음 → ACK 대사 불가. 진단 남기고 stuck 처리(idempotent 전환).
+            if sr.event_id is None:
+                sr.delivery_status = "timed_out"
+                sr.delivery_error = "missing_dispatch_event"
+                sr.failure_class = "schema_gap"
+                missing += 1
+                continue
+            event = (await session.execute(
+                select(Event).where(Event.id == sr.event_id)
+            )).scalar_one_or_none()
+            if event is None:
+                sr.delivery_status = "timed_out"
+                sr.delivery_error = "missing_dispatch_event"
+                sr.failure_class = "schema_gap"
+                missing += 1
+                continue
+
+            recipient_id = event.recipient_id
+            # recipient_type != agent → ACK cursor 대상 아님 → 미ACK 인 채 SLA 초과면 stuck(human fallback).
+            if event.recipient_type == "agent" and sr.recipient_seq is not None:
+                cursor = (await session.execute(
+                    select(AgentEventCursor).where(AgentEventCursor.agent_id == recipient_id)
+                )).scalar_one_or_none()
+                if cursor is not None and cursor.acked_seq >= sr.recipient_seq:
+                    sr.delivery_status = "acked"  # ⭐ACK 대사 성공(notification 불요)
+                    acked += 1
+                    continue
+            elif event.recipient_type == "agent" and sr.recipient_seq is None:
+                sr.delivery_error = "missing_recipient_seq"  # ACK 비교 불가·가시화
+
+            # 미ACK·SLA 초과 → stuck(board badge) + fallback notification.
+            sr.delivery_status = "timed_out"
+            await _fallback_notify(session, sr, recipient_id)
+            stuck += 1
+        except Exception as exc:  # noqa: BLE001 — run 단위 실패는 watchdog 비중단(다음 run 계속).
+            sr.delivery_error = f"watchdog: {str(exc)[:200]}"
+
+    await session.commit()
+    return {"acked": acked, "stuck": stuck, "missing_event": missing, "scanned": len(rows)}

--- a/backend/tests/test_edg_s8_watchdog.py
+++ b/backend/tests/test_edg_s8_watchdog.py
@@ -1,0 +1,170 @@
+"""E-DG S8: handoff watchdog + ACK reconciliation 테스트.
+
+핵심: ACK 대사(cursor acked_seq>=recipient_seq→acked)·10m 미ACK→timed_out+fallback notification·
+방어(missing event/recipient_seq·human recipient)·idempotent(terminal 제외)·not-yet-stuck 제외.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+_NOW = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_run(s, org, *, delivery_status="queued", recipient_seq=5, recipient_type="agent",
+                    with_event=True, age_min=20, recipient_id=None):
+    from app.models.event import Event
+    from app.models.project import Project
+    from app.models.team import TeamMember
+    from app.models.workflow_line import WorkflowLineStepRun
+    recipient_id = recipient_id or uuid.uuid4()
+    proj = uuid.uuid4()
+    s.add(Project(id=proj, org_id=org, name="p"))
+    s.add(TeamMember(id=recipient_id, org_id=org, project_id=proj, type=recipient_type, name="rcpt"))
+    await s.flush()
+    event_id = None
+    if with_event:
+        ev = Event(org_id=org, project_id=proj, event_type="dispatched",
+                   source_entity_type="story", source_entity_id=uuid.uuid4(),
+                   recipient_id=recipient_id, recipient_type=recipient_type, payload={}, status="pending")
+        s.add(ev); await s.flush()
+        event_id = ev.id
+    sr = WorkflowLineStepRun(
+        org_id=org, project_id=proj, entity_type="story", entity_id=uuid.uuid4(),
+        from_status="ready-for-dev", to_status="in-progress", status="dispatched", mode="advisory_only",
+        delivery_status=delivery_status, event_id=event_id, recipient_seq=recipient_seq,
+        correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex,
+        created_at=_NOW - timedelta(minutes=age_min))
+    s.add(sr); await s.flush()
+    return sr, recipient_id
+
+
+async def _seed_cursor(s, agent_id, acked_seq):
+    from app.models.agent_gateway import AgentEventCursor
+    s.add(AgentEventCursor(agent_id=agent_id, acked_seq=acked_seq)); await s.flush()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_ack_reconciled_to_acked():
+    from app.services.workflow_handoff_watchdog import reconcile_handoffs
+    from app.models.workflow_line import WorkflowLineStepRun
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr, rid = await _seed_run(s, org, recipient_seq=5)
+        await _seed_cursor(s, rid, acked_seq=7)  # acked_seq >= recipient_seq
+        with patch("app.services.notification_dispatch.dispatch_notification", new=AsyncMock()) as notify:
+            counts = await reconcile_handoffs(s, now=_NOW)
+        row = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id))).scalar_one()
+        assert row.delivery_status == "acked" and counts["acked"] == 1
+        assert notify.await_count == 0  # ACK 됨 → notification 불요
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_stuck_agent_no_ack_timed_out_and_notify():
+    from app.services.workflow_handoff_watchdog import reconcile_handoffs
+    from app.models.workflow_line import WorkflowLineStepRun
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr, rid = await _seed_run(s, org, recipient_seq=5)
+        await _seed_cursor(s, rid, acked_seq=3)  # acked_seq < recipient_seq → 미ACK
+        with patch("app.services.notification_dispatch.dispatch_notification", new=AsyncMock()) as notify:
+            counts = await reconcile_handoffs(s, now=_NOW)
+        row = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id))).scalar_one()
+        assert row.delivery_status == "timed_out" and counts["stuck"] == 1
+        assert notify.await_count == 1  # fallback notification
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_stuck_human_recipient():
+    from app.services.workflow_handoff_watchdog import reconcile_handoffs
+    from app.models.workflow_line import WorkflowLineStepRun
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr, rid = await _seed_run(s, org, recipient_type="human")  # ACK cursor N/A
+        with patch("app.services.notification_dispatch.dispatch_notification", new=AsyncMock()) as notify:
+            await reconcile_handoffs(s, now=_NOW)
+        row = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id))).scalar_one()
+        assert row.delivery_status == "timed_out" and notify.await_count == 1
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_missing_event_and_recipient_seq_defensive():
+    from app.services.workflow_handoff_watchdog import reconcile_handoffs
+    from app.models.workflow_line import WorkflowLineStepRun
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr_noevent, _ = await _seed_run(s, org, with_event=False)
+        sr_noseq, rid = await _seed_run(s, org, recipient_seq=None)
+        with patch("app.services.notification_dispatch.dispatch_notification", new=AsyncMock()):
+            counts = await reconcile_handoffs(s, now=_NOW)
+        r1 = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr_noevent.id))).scalar_one()
+        r2 = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr_noseq.id))).scalar_one()
+        assert r1.delivery_status == "timed_out" and r1.delivery_error == "missing_dispatch_event"
+        assert r2.delivery_status == "timed_out" and r2.delivery_error == "missing_recipient_seq"
+        assert counts["missing_event"] == 1
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_idempotent_and_not_yet_stuck_excluded():
+    from app.services.workflow_handoff_watchdog import reconcile_handoffs
+    from app.models.workflow_line import WorkflowLineStepRun
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        # 이미 terminal(acked/timed_out) → 재처리 안 함
+        sr_acked, _ = await _seed_run(s, org, delivery_status="acked")
+        sr_to, _ = await _seed_run(s, org, delivery_status="timed_out")
+        # 아직 10분 안 지남(age 3m) → 제외
+        sr_fresh, rid = await _seed_run(s, org, age_min=3)
+        await _seed_cursor(s, rid, acked_seq=1)
+        with patch("app.services.notification_dispatch.dispatch_notification", new=AsyncMock()) as notify:
+            counts = await reconcile_handoffs(s, now=_NOW)
+        assert counts["scanned"] == 0  # 셋 다 제외(terminal 2 + fresh 1)
+        fresh = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr_fresh.id))).scalar_one()
+        assert fresh.delivery_status == "queued"  # 아직 미처리
+        assert notify.await_count == 0
+    await engine.dispose()

--- a/backend/tests/test_edg_s8_watchdog.py
+++ b/backend/tests/test_edg_s8_watchdog.py
@@ -148,6 +148,43 @@ async def test_missing_event_and_recipient_seq_defensive():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
+async def test_concurrent_invocations_skip_locked_notify_once():
+    """⭐SME blocking 회귀: cron 겹침 시 두 invocation 이 같은 stuck row 를 동시 처리하면
+    재notify 0/idempotent 가 깨진다. FOR UPDATE SKIP LOCKED 로 잠긴 row 는 건너뛰고 1회만 처리·notify."""
+    from app.services.workflow_handoff_watchdog import reconcile_handoffs
+    from app.models.workflow_line import WorkflowLineStepRun
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as seed:
+        org = uuid.uuid4()
+        sr, rid = await _seed_run(seed, org, recipient_seq=5)
+        await _seed_cursor(seed, rid, acked_seq=3)  # 미ACK → stuck 후보
+        await seed.commit()
+
+    # 다른 cron invocation 모사: s_lock 이 같은 row 를 SKIP LOCKED 로 잠그고 트랜잭션 보류.
+    async with Session() as s_lock, Session() as s_work:
+        held = (await s_lock.execute(
+            select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id).with_for_update(skip_locked=True)
+        )).scalar_one_or_none()
+        assert held is not None  # s_lock 이 row 잠금 보유
+        with patch("app.services.notification_dispatch.dispatch_notification", new=AsyncMock()) as notify:
+            counts = await reconcile_handoffs(s_work, now=_NOW)
+        assert counts["scanned"] == 0  # ⭐잠긴 row 는 건너뜀(중복 처리 0)
+        assert notify.await_count == 0
+        await s_lock.rollback()  # 잠금 해제
+
+    # 잠금 해제 후 재실행 → 정확히 1회 처리·notify 1회.
+    async with Session() as s2:
+        with patch("app.services.notification_dispatch.dispatch_notification", new=AsyncMock()) as notify2:
+            counts2 = await reconcile_handoffs(s2, now=_NOW)
+        assert counts2["stuck"] == 1 and notify2.await_count == 1
+        row = (await s2.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id))).scalar_one()
+        assert row.delivery_status == "timed_out"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
 async def test_idempotent_and_not_yet_stuck_excluded():
     from app.services.workflow_handoff_watchdog import reconcile_handoffs
     from app.models.workflow_line import WorkflowLineStepRun


### PR DESCRIPTION
## E-DECISION-GATE S8 — Handoff watchdog + ACK reconciliation (P0-3 마무리)

스토리 `c1da5a63` · 3pt · 의존 S7(#1601·merged). **마이그 없음.**

S7 이 agent-handoff relay 의 `delivery_status`(queued)를 기록 → S8 watchdog 가 주기적으로 대사해 **silent handoff stall 을 observable incident 로** 전환한다.

### 변경
- `app/services/workflow_handoff_watchdog.py` (신규) — `reconcile_handoffs()`:
  - 대상: `delivery_status in ('queued','delivered')` & `created_at > 10m` step_run.
  - **ACK 대사**: `step_run.event_id → Event.recipient_id` + `recipient_seq` → `AgentEventCursor.acked_seq >= recipient_seq` 면 `delivery_status='acked'`.
  - **stuck**(미ACK·SLA 초과) → `delivery_status='timed_out'`(board badge) + **fallback `dispatch_notification`**(best-effort·실패 비중단).
  - 방어: event 없음→`missing_dispatch_event`·`recipient_type != 'agent'`→ACK skip(human fallback)·`recipient_seq` null→`missing_recipient_seq`.
- `app/routers/cron.py` — `GET /api/v2/internal/cron/workflow-handoff-watchdog`(verify_cron·기존 cron 레일).

### 설계 보장 (산티아고 ACK/connector SME 사인오프)
- ⭐**wake 성공 ≠ delivered** — S7 의 queued 를 그대로 두고 ACK cursor 로만 acked 판정(pg_notify fire-and-forget).
- **idempotent** — queued/delivered 만 픽 → acked/timed_out 전환 즉시 재처리·재notify 제외.
- **신규 EventType 0** — `dispatch_notification` 의 notification 카테고리만 사용(connector allow-list 무영향).
- `dispatch_notification` 실패는 watchdog 전체 비중단(해당 run best-effort).
- `workflow_step_run_events` phase 행은 모델 부재로 S8 범위 밖(관측성 S9+)·`delivery_status/error` 로 board badge 충분.

### 테스트 (5/5 PASS · 실 PG)
- ACK 대사 → acked(notification 0)
- 미ACK → timed_out + fallback notification
- human recipient → ACK skip → timed_out + notification
- missing event / recipient_seq 방어
- idempotent(terminal 제외) + not-yet-stuck(10m 미만) 제외

🤖 Generated with [Claude Code](https://claude.com/claude-code)