### PR TITLE
[0441f63c] E-DG S9 — parallel/quorum approval MVP

### DIFF
--- a/backend/app/models/workflow_line.py
+++ b/backend/app/models/workflow_line.py
@@ -142,3 +142,43 @@ class WorkflowLineStepRun(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
     )
+
+
+# ── S9 parallel/quorum approval (0126 SSOT·text+app validator) ────────────────
+APPROVAL_KINDS = frozenset({"approver", "consult", "deputy"})
+APPROVAL_STATUSES = frozenset({"pending", "approved", "rejected", "abstained", "withdrawn"})
+QUORUM_TYPES = frozenset({"all", "any", "count"})  # percent = Phase3 defer
+
+
+class WorkflowLineStepApproval(Base):
+    """S9 multi-approver gate: 대표 Gate 1개에 묶인 approver row N개(0126 미러).
+
+    blocking approver-kind row 들만 quorum 계산에 든다(consult/non-blocking 은 audit/notification
+    엔 남지만 제외·AC④). approval_group_id 로 한 그룹을 묶고 gate_id 는 대표 Gate(orphan 0·AC⑦).
+    """
+
+    __tablename__ = "workflow_step_approvals"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    step_run_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    gate_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    approval_group_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    approver_member_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    approver_member_type: Mapped[str] = mapped_column(Text, nullable=False)
+    original_approver_member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    requested_by_member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    implementation_member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    role_key: Mapped[str | None] = mapped_column(Text, nullable=True)
+    kind: Mapped[str] = mapped_column(Text, nullable=False, server_default="approver")
+    blocking: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default="pending")
+    decision_note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    held_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    reassigned_from_member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/services/workflow_parallel_approval.py
+++ b/backend/app/services/workflow_parallel_approval.py
@@ -1,0 +1,188 @@
+"""E-DECISION-GATE S9: parallel/quorum approval MVP.
+
+multi-approver gate 를 **대표 Gate 1개 + workflow_step_approvals approver row N개**로 표면화한다
+(Gate 단일 row UX 유지·AC①). blocking approver-kind row 만 quorum 에 들고(consult/non-blocking 은
+audit/notification 엔 남지만 제외·AC④), quorum 충족/any-reject 면 ``transition_gate()`` 단일 rail 로
+해소한다(S6 hook ``find_active_step_run_for_gate`` 가 라인 전이를 자동 적용·신규 승인경로 0·AC⑤).
+
+⭐SoD self-approval guard 는 **row 생성 시 + 해소 시 동시 검사**(AC⑥): approver/resolver 가
+requested_by / implementation / original_approver 와 동일하면 거부.
+"""
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.gate import Gate
+from app.models.workflow_line import (
+    QUORUM_TYPES,
+    WorkflowLineStepApproval,
+    WorkflowLineStepRun,
+)
+
+_TERMINAL_GATE = frozenset({"approved", "rejected"})
+_VALID_DECISIONS = frozenset({"approved", "rejected", "abstained"})
+
+
+class SelfApprovalError(Exception):
+    """SoD: approver/resolver 가 requested_by/implementation/original_approver 와 동일(self-approval forbidden)."""
+
+    def __init__(self, member_id: uuid.UUID | None):
+        self.member_id = member_id
+        super().__init__(f"self-approval forbidden (SoD): member {member_id}")
+
+
+def _sod_conflict(member_id: uuid.UUID | None, *sod_parties: uuid.UUID | None) -> bool:
+    if member_id is None:
+        return False
+    mid = str(member_id)
+    return any(p is not None and str(p) == mid for p in sod_parties)
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+async def create_parallel_gate(
+    session: AsyncSession, step_run: WorkflowLineStepRun, *,
+    approvers: list[dict[str, Any]], quorum: dict[str, Any],
+    member_id: uuid.UUID, role_id: uuid.UUID, gate_type: str = "merge",
+    requested_by_member_id: uuid.UUID | None = None,
+    implementation_member_id: uuid.UUID | None = None,
+) -> tuple[Gate, uuid.UUID]:
+    """대표 Gate 1개 + approver row N개를 만든다. step_run.gate_id 로 S6 hook 에 연결(orphan 0·AC⑦).
+
+    quorum: {type: all|any|count, count?: int, reject_policy?: any_reject_blocks}.
+    approvers[i]: {member_id, member_type?, kind?(approver|consult|deputy), blocking?, role_key?,
+    original_approver_member_id?}.
+    """
+    qtype = (quorum or {}).get("type", "all")
+    if qtype not in QUORUM_TYPES:
+        raise ValueError(f"unsupported quorum type: {qtype} (percent=Phase3 defer)")
+
+    from app.services.gate_service import create_gate
+    gate = await create_gate(
+        session, step_run.org_id, step_run.entity_id, step_run.entity_type, gate_type,
+        member_id, role_id,
+        neutral_facts={
+            "requested_by_member_id": str(requested_by_member_id) if requested_by_member_id else None,
+            "parallel": True,
+        },
+    )
+    group_id = uuid.uuid4()
+    step_run.gate_id = gate.id  # ⭐S6 hook 연결: transition_gate→find_active_step_run_for_gate→라인 전이
+    step_run.approval_group_id = group_id
+    step_run.quorum_policy = {
+        "type": qtype, "count": quorum.get("count"),
+        "reject_policy": quorum.get("reject_policy", "any_reject_blocks"),
+    }
+
+    for a in approvers:
+        kind = a.get("kind", "approver")
+        blocking = a.get("blocking", kind == "approver")
+        aid = a["member_id"]
+        # ⭐SoD(생성 시): blocking approver 는 SoD 당사자와 동일 불가(consult/non-blocking 은 정보용 허용).
+        if kind == "approver" and blocking and _sod_conflict(
+            aid, requested_by_member_id, implementation_member_id, a.get("original_approver_member_id"),
+        ):
+            raise SelfApprovalError(aid)
+        session.add(WorkflowLineStepApproval(
+            org_id=step_run.org_id, project_id=step_run.project_id, step_run_id=step_run.id,
+            gate_id=gate.id, approval_group_id=group_id,
+            approver_member_id=aid, approver_member_type=a.get("member_type", "human"),
+            original_approver_member_id=a.get("original_approver_member_id"),
+            requested_by_member_id=requested_by_member_id,
+            implementation_member_id=implementation_member_id,
+            role_key=a.get("role_key"), kind=kind, blocking=blocking, status="pending",
+        ))
+    await session.flush()
+    return gate, group_id
+
+
+def _quorum_met(approved: int, total_blocking: int, qtype: str, qcount: int | None) -> bool:
+    if total_blocking == 0:
+        return False
+    if qtype == "all":
+        return approved >= total_blocking
+    if qtype == "any":
+        return approved >= 1
+    if qtype == "count":
+        return qcount is not None and approved >= qcount
+    return False
+
+
+async def record_parallel_decision(
+    session: AsyncSession, approval_id: uuid.UUID, decision: str, resolver_id: uuid.UUID | None,
+) -> dict[str, Any]:
+    """approver row 1건 결정을 기록하고 그룹 quorum 을 재평가한다.
+
+    blocking approver-kind row 만 집계(consult/non-blocking 제외). any reject(any_reject_blocks)→
+    ``transition_gate(rejected)`` / quorum 충족→``transition_gate(approved)`` / else pending.
+    gate 가 이미 terminal 이면 멱등 skip(중복 해소 무시).
+    """
+    if decision not in _VALID_DECISIONS:
+        raise ValueError(f"invalid decision: {decision}")
+    appr = (await session.execute(
+        select(WorkflowLineStepApproval).where(
+            WorkflowLineStepApproval.id == approval_id
+        ).with_for_update()
+    )).scalar_one_or_none()
+    if appr is None:
+        raise ValueError(f"approval {approval_id} not found")
+
+    # resolver 는 본인 row 만 해소(대리 위임은 후속 Phase).
+    if resolver_id is not None and str(resolver_id) != str(appr.approver_member_id):
+        raise SelfApprovalError(resolver_id)
+    # ⭐SoD(해소 시·AC⑥ 2중): resolver 가 SoD 당사자면 거부.
+    if _sod_conflict(
+        resolver_id, appr.requested_by_member_id, appr.implementation_member_id,
+        appr.original_approver_member_id,
+    ):
+        raise SelfApprovalError(resolver_id)
+
+    appr.status = decision
+    appr.resolved_at = _now()
+    await session.flush()
+
+    # 그룹의 blocking approver-kind row 로 quorum 재계산(consult/non-blocking 제외·AC④).
+    rows = (await session.execute(
+        select(WorkflowLineStepApproval).where(
+            WorkflowLineStepApproval.approval_group_id == appr.approval_group_id,
+            WorkflowLineStepApproval.kind == "approver",
+            WorkflowLineStepApproval.blocking.is_(True),
+        )
+    )).scalars().all()
+    sr = (await session.execute(
+        select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == appr.step_run_id)
+    )).scalar_one_or_none()
+    policy = ((sr.quorum_policy if sr else None) or {})
+    qtype = policy.get("type", "all")
+    qcount = policy.get("count")
+    reject_policy = policy.get("reject_policy", "any_reject_blocks")
+
+    approved = sum(1 for r in rows if r.status == "approved")
+    rejected = sum(1 for r in rows if r.status == "rejected")
+    total = len(rows)
+
+    outcome = "pending"
+    target: str | None = None
+    if reject_policy == "any_reject_blocks" and rejected >= 1:
+        target = "rejected"
+    elif _quorum_met(approved, total, qtype, qcount):
+        target = "approved"
+
+    if target is not None and appr.gate_id is not None:
+        # gate 가 이미 terminal 이면 멱등 skip(중복/경합 해소 무시·불법 전이 회피).
+        gate = (await session.execute(
+            select(Gate).where(Gate.id == appr.gate_id, Gate.org_id == appr.org_id)
+        )).scalar_one_or_none()
+        if gate is not None and gate.status not in _TERMINAL_GATE:
+            from app.services.gate_service import transition_gate
+            await transition_gate(session, appr.org_id, appr.gate_id, target, resolver_id=resolver_id)
+            outcome = target
+        elif gate is not None:
+            outcome = gate.status  # 이미 해소됨
+
+    return {"outcome": outcome, "approved": approved, "rejected": rejected, "total_blocking": total}

--- a/backend/tests/test_edg_s9_parallel_quorum.py
+++ b/backend/tests/test_edg_s9_parallel_quorum.py
@@ -1,0 +1,265 @@
+"""E-DG S9: parallel/quorum approval MVP 테스트.
+
+핵심: 대표 Gate 1개 + approver row N개(orphan 0)·quorum all/any/count·any_reject_blocks·
+consult/non-blocking quorum 제외·SoD self-approval guard(생성 시 + 해소 시)·transition_gate 단일 rail.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    import app.models.participation  # noqa: F401 — gate_resolver FK(participation_role) 등록
+    import app.models.gate  # noqa: F401
+    import app.models.hitl_config  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_step_run(s, org):
+    from app.models.project import Project
+    from app.models.workflow_line import WorkflowLineStepRun
+    proj = uuid.uuid4()
+    s.add(Project(id=proj, org_id=org, name="p"))
+    sr = WorkflowLineStepRun(
+        org_id=org, project_id=proj, entity_type="story", entity_id=uuid.uuid4(),
+        from_status="in-review", to_status="done", status="gate_pending", mode="gate_pending",
+        correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex)
+    s.add(sr); await s.flush()
+    return sr
+
+
+def _approver(member_id=None, kind="approver", blocking=None, **kw):
+    return {"member_id": member_id or uuid.uuid4(), "member_type": "human", "kind": kind,
+            **({"blocking": blocking} if blocking is not None else {}), **kw}
+
+
+# ── 생성: orphan 0 ──────────────────────────────────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_create_parallel_gate_single_gate_n_rows_orphan_zero():
+    from app.services.workflow_parallel_approval import create_parallel_gate
+    from app.models.workflow_line import WorkflowLineStepApproval
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr = await _seed_step_run(s, org)
+        a1, a2 = _approver(), _approver()
+        gate, group = await create_parallel_gate(
+            s, sr, approvers=[a1, a2], quorum={"type": "all"},
+            member_id=uuid.uuid4(), role_id=uuid.uuid4())
+        assert gate.status == "pending"  # 대표 Gate 1개·pending
+        rows = (await s.execute(select(WorkflowLineStepApproval).where(
+            WorkflowLineStepApproval.approval_group_id == group))).scalars().all()
+        assert len(rows) == 2
+        # ⭐orphan 0: 전 row 가 대표 Gate 와 step_run 에 정합·step_run.gate_id 연결
+        assert all(r.gate_id == gate.id and r.step_run_id == sr.id for r in rows)
+        assert sr.gate_id == gate.id and sr.approval_group_id == group
+    await engine.dispose()
+
+
+# ── quorum all/any/count ────────────────────────────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_quorum_all_requires_every_blocking_approval():
+    from app.services.workflow_parallel_approval import create_parallel_gate, record_parallel_decision
+    from app.models.gate import Gate
+    from sqlalchemy import select
+    from app.models.workflow_line import WorkflowLineStepApproval
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr = await _seed_step_run(s, org)
+        a1, a2 = _approver(), _approver()
+        gate, group = await create_parallel_gate(
+            s, sr, approvers=[a1, a2], quorum={"type": "all"},
+            member_id=uuid.uuid4(), role_id=uuid.uuid4())
+        ids = {r.approver_member_id: r.id for r in (await s.execute(select(WorkflowLineStepApproval).where(
+            WorkflowLineStepApproval.approval_group_id == group))).scalars().all()}
+        # 1명만 approve → 아직 pending
+        r1 = await record_parallel_decision(s, ids[a1["member_id"]], "approved", a1["member_id"])
+        assert r1["outcome"] == "pending"
+        g = (await s.execute(select(Gate).where(Gate.id == gate.id))).scalar_one()
+        assert g.status == "pending"
+        # 나머지 approve → quorum all 충족 → approved
+        r2 = await record_parallel_decision(s, ids[a2["member_id"]], "approved", a2["member_id"])
+        assert r2["outcome"] == "approved" and r2["approved"] == 2
+        g = (await s.execute(select(Gate).where(Gate.id == gate.id))).scalar_one()
+        assert g.status == "approved"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_quorum_any_one_approval_suffices():
+    from app.services.workflow_parallel_approval import create_parallel_gate, record_parallel_decision
+    from app.models.gate import Gate
+    from sqlalchemy import select
+    from app.models.workflow_line import WorkflowLineStepApproval
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr = await _seed_step_run(s, org)
+        a1, a2 = _approver(), _approver()
+        gate, group = await create_parallel_gate(
+            s, sr, approvers=[a1, a2], quorum={"type": "any"},
+            member_id=uuid.uuid4(), role_id=uuid.uuid4())
+        rid = (await s.execute(select(WorkflowLineStepApproval.id).where(
+            WorkflowLineStepApproval.approver_member_id == a1["member_id"]))).scalar_one()
+        r = await record_parallel_decision(s, rid, "approved", a1["member_id"])
+        assert r["outcome"] == "approved"
+        g = (await s.execute(select(Gate).where(Gate.id == gate.id))).scalar_one()
+        assert g.status == "approved"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_quorum_count_threshold():
+    from app.services.workflow_parallel_approval import create_parallel_gate, record_parallel_decision
+    from app.models.gate import Gate
+    from sqlalchemy import select
+    from app.models.workflow_line import WorkflowLineStepApproval
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr = await _seed_step_run(s, org)
+        a1, a2, a3 = _approver(), _approver(), _approver()
+        gate, group = await create_parallel_gate(
+            s, sr, approvers=[a1, a2, a3], quorum={"type": "count", "count": 2},
+            member_id=uuid.uuid4(), role_id=uuid.uuid4())
+        ids = {r.approver_member_id: r.id for r in (await s.execute(select(WorkflowLineStepApproval).where(
+            WorkflowLineStepApproval.approval_group_id == group))).scalars().all()}
+        assert (await record_parallel_decision(s, ids[a1["member_id"]], "approved", a1["member_id"]))["outcome"] == "pending"
+        r = await record_parallel_decision(s, ids[a2["member_id"]], "approved", a2["member_id"])
+        assert r["outcome"] == "approved" and r["approved"] == 2  # count=2 도달
+        g = (await s.execute(select(Gate).where(Gate.id == gate.id))).scalar_one()
+        assert g.status == "approved"
+    await engine.dispose()
+
+
+# ── any_reject_blocks ───────────────────────────────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_any_reject_blocks_rejects_gate():
+    from app.services.workflow_parallel_approval import create_parallel_gate, record_parallel_decision
+    from app.models.gate import Gate
+    from sqlalchemy import select
+    from app.models.workflow_line import WorkflowLineStepApproval
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr = await _seed_step_run(s, org)
+        a1, a2 = _approver(), _approver()
+        gate, group = await create_parallel_gate(
+            s, sr, approvers=[a1, a2], quorum={"type": "all"},
+            member_id=uuid.uuid4(), role_id=uuid.uuid4())
+        rid = (await s.execute(select(WorkflowLineStepApproval.id).where(
+            WorkflowLineStepApproval.approver_member_id == a1["member_id"]))).scalar_one()
+        # 1명 reject → any_reject_blocks → 즉시 rejected(나머지 대기 안 함)
+        r = await record_parallel_decision(s, rid, "rejected", a1["member_id"])
+        assert r["outcome"] == "rejected" and r["rejected"] == 1
+        g = (await s.execute(select(Gate).where(Gate.id == gate.id))).scalar_one()
+        assert g.status == "rejected"
+    await engine.dispose()
+
+
+# ── consult/non-blocking quorum 제외 ────────────────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_consult_excluded_from_quorum():
+    from app.services.workflow_parallel_approval import create_parallel_gate, record_parallel_decision
+    from app.models.gate import Gate
+    from sqlalchemy import select
+    from app.models.workflow_line import WorkflowLineStepApproval
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr = await _seed_step_run(s, org)
+        a_block = _approver(kind="approver")
+        a_consult = _approver(kind="consult")  # non-blocking·quorum 제외
+        gate, group = await create_parallel_gate(
+            s, sr, approvers=[a_block, a_consult], quorum={"type": "all"},
+            member_id=uuid.uuid4(), role_id=uuid.uuid4())
+        rid = (await s.execute(select(WorkflowLineStepApproval.id).where(
+            WorkflowLineStepApproval.approver_member_id == a_block["member_id"]))).scalar_one()
+        # blocking approver 1명만 approve → consult 무관하게 quorum all 충족(blocking 총 1)
+        r = await record_parallel_decision(s, rid, "approved", a_block["member_id"])
+        assert r["outcome"] == "approved" and r["total_blocking"] == 1  # consult 미집계
+        g = (await s.execute(select(Gate).where(Gate.id == gate.id))).scalar_one()
+        assert g.status == "approved"
+        # consult row 는 여전히 pending(audit 에 남음)
+        consult = (await s.execute(select(WorkflowLineStepApproval).where(
+            WorkflowLineStepApproval.approver_member_id == a_consult["member_id"]))).scalar_one()
+        assert consult.status == "pending" and consult.kind == "consult"
+    await engine.dispose()
+
+
+# ── SoD self-approval guard ─────────────────────────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_sod_guard_at_creation_blocks_self_approver():
+    from app.services.workflow_parallel_approval import create_parallel_gate, SelfApprovalError
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr = await _seed_step_run(s, org)
+        requester = uuid.uuid4()
+        # blocking approver == requested_by → SoD 위반(생성 시 거부)
+        with pytest.raises(SelfApprovalError):
+            await create_parallel_gate(
+                s, sr, approvers=[_approver(member_id=requester)], quorum={"type": "all"},
+                member_id=uuid.uuid4(), role_id=uuid.uuid4(), requested_by_member_id=requester)
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_sod_guard_at_resolution_and_foreign_resolver():
+    from app.services.workflow_parallel_approval import record_parallel_decision, SelfApprovalError
+    from app.models.workflow_line import WorkflowLineStepApproval
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr = await _seed_step_run(s, org)
+        requester = uuid.uuid4()
+        # 직접 삽입: approver==requested_by 인 row(생성 가드 우회·해소 가드 검증용)
+        appr = WorkflowLineStepApproval(
+            org_id=org, project_id=sr.project_id, step_run_id=sr.id, gate_id=uuid.uuid4(),
+            approval_group_id=uuid.uuid4(), approver_member_id=requester, approver_member_type="human",
+            requested_by_member_id=requester, kind="approver", blocking=True, status="pending")
+        s.add(appr); await s.flush()
+        # ⭐해소 시 SoD: resolver(=approver=requester) == requested_by → 거부
+        with pytest.raises(SelfApprovalError):
+            await record_parallel_decision(s, appr.id, "approved", requester)
+        # 남의 row 해소 시도(resolver != approver) → 거부
+        appr2 = WorkflowLineStepApproval(
+            org_id=org, project_id=sr.project_id, step_run_id=sr.id, gate_id=uuid.uuid4(),
+            approval_group_id=uuid.uuid4(), approver_member_id=uuid.uuid4(), approver_member_type="human",
+            kind="approver", blocking=True, status="pending")
+        s.add(appr2); await s.flush()
+        with pytest.raises(SelfApprovalError):
+            await record_parallel_decision(s, appr2.id, "approved", uuid.uuid4())
+    await engine.dispose()


### PR DESCRIPTION
## E-DECISION-GATE S9 — Parallel/quorum approval MVP

스토리 `0441f63c` · 5pt · 의존 S1(스키마·merged)·S5(merge-gate·merged). **마이그 없음**(0126 에서 `workflow_step_approvals` 생성 완료). 비-lane → 디디 + 까심 QA.

multi-approver gate 를 **대표 `Gate` 1개 + `workflow_step_approvals` approver row N개**로 표면화한다(Gate 단일 row UX 유지).

### 변경
- `app/models/workflow_line.py` — `WorkflowLineStepApproval` ORM(0126 SSOT 미러) + `APPROVAL_KINDS/STATUSES/QUORUM_TYPES`.
- `app/services/workflow_parallel_approval.py` (신규):
  - **`create_parallel_gate`** — 대표 Gate 1개(`create_gate` 재사용) + `step_run.gate_id` 연결(⭐S6 hook `find_active_step_run_for_gate`→라인 전이 자동) + approver row N개(공유 `approval_group_id`). orphan 0(전 row `gate_id==gate.id`·동일 group·AC⑦).
  - **`record_parallel_decision`** — row 결정 기록 → **blocking approver-kind** row 로 quorum 재계산(consult/non-blocking 제외·AC④) → any reject(`any_reject_blocks`)→`transition_gate(rejected)` / quorum(`all`/`any`/`count`) 충족→`transition_gate(approved)` / else pending(AC②⑤). gate terminal 시 멱등 skip.

### 설계 보장
- ⭐**SoD self-approval guard 2중**(AC⑥): row 생성 시(blocking approver) + 해소 시(resolver). approver/resolver 가 `requested_by`/`implementation`/`original_approver` 와 동일 불가. resolver 는 본인 row 만 해소.
- **transition_gate 단일 rail** — 신규 EventType/승인경로 0. quorum 충족이 기존 게이트 해소 경로(S6 hook)를 그대로 탄다.
- `percent` quorum = Phase3 defer(AC②).

### 테스트 (8/8 PASS · 실 PG)
- 대표 Gate 1개 + N row · **orphan=0**
- quorum `all`(전원)·`any`(1명)·`count`(임계)
- `any_reject_blocks`(1 reject→즉시 rejected)
- **consult 제외**(blocking 총량 미집계·consult row 는 pending 유지)
- SoD guard 생성 시(approver==requested_by 거부)·해소 시(resolver==requested_by 거부)·foreign resolver(남의 row) 거부

🤖 Generated with [Claude Code](https://claude.com/claude-code)