### PR TITLE
[0441f63c] S9 fast-follow — terminal-idempotent + E702 lint

### DIFF
--- a/backend/app/services/workflow_parallel_approval.py
+++ b/backend/app/services/workflow_parallel_approval.py
@@ -101,6 +101,22 @@ async def create_parallel_gate(
     return gate, group_id
 
 
+async def _tally_blocking(session: AsyncSession, group_id: uuid.UUID) -> dict[str, int]:
+    """그룹의 blocking approver-kind row 집계(consult/non-blocking 제외·AC④)."""
+    rows = (await session.execute(
+        select(WorkflowLineStepApproval).where(
+            WorkflowLineStepApproval.approval_group_id == group_id,
+            WorkflowLineStepApproval.kind == "approver",
+            WorkflowLineStepApproval.blocking.is_(True),
+        )
+    )).scalars().all()
+    return {
+        "approved": sum(1 for r in rows if r.status == "approved"),
+        "rejected": sum(1 for r in rows if r.status == "rejected"),
+        "total_blocking": len(rows),
+    }
+
+
 def _quorum_met(approved: int, total_blocking: int, qtype: str, qcount: int | None) -> bool:
     if total_blocking == 0:
         return False
@@ -142,18 +158,24 @@ async def record_parallel_decision(
     ):
         raise SelfApprovalError(resolver_id)
 
+    # ⭐terminal 멱등 skip: gate 가 이미 해소(approved/rejected)됐으면 late decision 은 approval row
+    # 를 mutate 하지 않고 그대로 skip 한다(quorum 충족/any-reject 로 게이트가 닫힌 뒤 도착한 결정이
+    # row state·audit 를 오염시키지 않게·SME 적출). row mutate 보다 먼저 검사한다.
+    gate = None
+    if appr.gate_id is not None:
+        gate = (await session.execute(
+            select(Gate).where(Gate.id == appr.gate_id, Gate.org_id == appr.org_id)
+        )).scalar_one_or_none()
+        if gate is not None and gate.status in _TERMINAL_GATE:
+            tally = await _tally_blocking(session, appr.approval_group_id)
+            return {"outcome": gate.status, "skipped": True, **tally}
+
     appr.status = decision
     appr.resolved_at = _now()
     await session.flush()
 
     # 그룹의 blocking approver-kind row 로 quorum 재계산(consult/non-blocking 제외·AC④).
-    rows = (await session.execute(
-        select(WorkflowLineStepApproval).where(
-            WorkflowLineStepApproval.approval_group_id == appr.approval_group_id,
-            WorkflowLineStepApproval.kind == "approver",
-            WorkflowLineStepApproval.blocking.is_(True),
-        )
-    )).scalars().all()
+    tally = await _tally_blocking(session, appr.approval_group_id)
     sr = (await session.execute(
         select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == appr.step_run_id)
     )).scalar_one_or_none()
@@ -162,27 +184,17 @@ async def record_parallel_decision(
     qcount = policy.get("count")
     reject_policy = policy.get("reject_policy", "any_reject_blocks")
 
-    approved = sum(1 for r in rows if r.status == "approved")
-    rejected = sum(1 for r in rows if r.status == "rejected")
-    total = len(rows)
-
     outcome = "pending"
     target: str | None = None
-    if reject_policy == "any_reject_blocks" and rejected >= 1:
+    if reject_policy == "any_reject_blocks" and tally["rejected"] >= 1:
         target = "rejected"
-    elif _quorum_met(approved, total, qtype, qcount):
+    elif _quorum_met(tally["approved"], tally["total_blocking"], qtype, qcount):
         target = "approved"
 
-    if target is not None and appr.gate_id is not None:
-        # gate 가 이미 terminal 이면 멱등 skip(중복/경합 해소 무시·불법 전이 회피).
-        gate = (await session.execute(
-            select(Gate).where(Gate.id == appr.gate_id, Gate.org_id == appr.org_id)
-        )).scalar_one_or_none()
-        if gate is not None and gate.status not in _TERMINAL_GATE:
-            from app.services.gate_service import transition_gate
-            await transition_gate(session, appr.org_id, appr.gate_id, target, resolver_id=resolver_id)
-            outcome = target
-        elif gate is not None:
-            outcome = gate.status  # 이미 해소됨
+    # target 도달 시 transition_gate 단일 rail 로 해소(gate 는 위에서 non-terminal 확인됨).
+    if target is not None and gate is not None:
+        from app.services.gate_service import transition_gate
+        await transition_gate(session, appr.org_id, appr.gate_id, target, resolver_id=resolver_id)
+        outcome = target
 
-    return {"outcome": outcome, "approved": approved, "rejected": rejected, "total_blocking": total}
+    return {"outcome": outcome, "skipped": False, **tally}

--- a/backend/tests/test_edg_s9_parallel_quorum.py
+++ b/backend/tests/test_edg_s9_parallel_quorum.py
@@ -46,7 +46,8 @@ async def _seed_step_run(s, org):
         org_id=org, project_id=proj, entity_type="story", entity_id=uuid.uuid4(),
         from_status="in-review", to_status="done", status="gate_pending", mode="gate_pending",
         correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex)
-    s.add(sr); await s.flush()
+    s.add(sr)
+    await s.flush()
     return sr
 
 
@@ -160,6 +161,37 @@ async def test_quorum_count_threshold():
     await engine.dispose()
 
 
+# ── terminal 멱등: late decision skip(row 불변) ─────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_late_decision_after_terminal_skipped_row_unchanged():
+    from app.services.workflow_parallel_approval import create_parallel_gate, record_parallel_decision
+    from app.models.gate import Gate
+    from sqlalchemy import select
+    from app.models.workflow_line import WorkflowLineStepApproval
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr = await _seed_step_run(s, org)
+        a1, a2 = _approver(), _approver()
+        gate, group = await create_parallel_gate(
+            s, sr, approvers=[a1, a2], quorum={"type": "any"},
+            member_id=uuid.uuid4(), role_id=uuid.uuid4())
+        ids = {r.approver_member_id: r.id for r in (await s.execute(select(WorkflowLineStepApproval).where(
+            WorkflowLineStepApproval.approval_group_id == group))).scalars().all()}
+        # a1 approve → quorum any 충족 → gate approved
+        assert (await record_parallel_decision(s, ids[a1["member_id"]], "approved", a1["member_id"]))["outcome"] == "approved"
+        # ⭐a2 의 late reject → gate terminal 이라 skip·row 불변(rejected 로 안 바뀜)·gate 유지
+        late = await record_parallel_decision(s, ids[a2["member_id"]], "rejected", a2["member_id"])
+        assert late["skipped"] is True and late["outcome"] == "approved"
+        a2_row = (await s.execute(select(WorkflowLineStepApproval).where(
+            WorkflowLineStepApproval.id == ids[a2["member_id"]]))).scalar_one()
+        assert a2_row.status == "pending" and a2_row.resolved_at is None  # mutate 안 됨
+        g = (await s.execute(select(Gate).where(Gate.id == gate.id))).scalar_one()
+        assert g.status == "approved"  # 그대로
+    await engine.dispose()
+
+
 # ── any_reject_blocks ───────────────────────────────────────────────────────
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
@@ -250,7 +282,8 @@ async def test_sod_guard_at_resolution_and_foreign_resolver():
             org_id=org, project_id=sr.project_id, step_run_id=sr.id, gate_id=uuid.uuid4(),
             approval_group_id=uuid.uuid4(), approver_member_id=requester, approver_member_type="human",
             requested_by_member_id=requester, kind="approver", blocking=True, status="pending")
-        s.add(appr); await s.flush()
+        s.add(appr)
+        await s.flush()
         # ⭐해소 시 SoD: resolver(=approver=requester) == requested_by → 거부
         with pytest.raises(SelfApprovalError):
             await record_parallel_decision(s, appr.id, "approved", requester)
@@ -259,7 +292,8 @@ async def test_sod_guard_at_resolution_and_foreign_resolver():
             org_id=org, project_id=sr.project_id, step_run_id=sr.id, gate_id=uuid.uuid4(),
             approval_group_id=uuid.uuid4(), approver_member_id=uuid.uuid4(), approver_member_type="human",
             kind="approver", blocking=True, status="pending")
-        s.add(appr2); await s.flush()
+        s.add(appr2)
+        await s.flush()
         with pytest.raises(SelfApprovalError):
             await record_parallel_decision(s, appr2.id, "approved", uuid.uuid4())
     await engine.dispose()


### PR DESCRIPTION
## S9 fast-follow fix (gap story)

S9(#1603·`d8c82f84`) 머지 후 산티아고 SME cross-check 적출 2건을 fast-follow 회수한다(둘 다 **non-breaking·default-off** → revert 아닌 fix-forward). PO 지시.

### 변경
① **terminal-idempotent 불일치** — `record_parallel_decision()` 이 gate terminal 체크 **前** approval row 를 mutate 해, quorum 충족/any-reject 로 gate 가 닫힌 뒤 도착한 late decision 이 row(`status`/`resolved_at`)를 바꿔 gate 상태와 불일치했다. **fix**: gate terminal 체크를 row mutate **앞**으로 이동 — terminal 이면 row 불변으로 skip(`return skipped=True`). `_tally_blocking` 헬퍼로 집계 경로 단일화.
② **E702 lint** — test 세미콜론 3건(`s.add(...); await ...`) 분리.
③ **회귀 추가** — `test_late_decision_after_terminal_skipped_row_unchanged`: gate approved 후 late reject → `skipped`·row `pending` 유지·gate `approved` 유지.

### 테스트
- 9/9 PASS(실 PG·기존 8 + late-terminal 회귀 1)
- ruff clean(E702 0)
- 마이그 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)