### PR TITLE
[e98fddd5] E-DG S10 — workflow-line status read API

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -28,6 +28,7 @@ from app.services.verdict_capture import resolve_implementation_participation
 from app.services.notification_dispatch import dispatch_notification
 from app.services.story_status_events import emit_story_status_changed
 from app.services.webhook_dispatch import fire_webhooks
+from app.services.workflow_line_status import WorkflowLineStatusResponse, build_workflow_line_status
 from app.services.workflow_pipeline import process_event
 from app.services.rule_evaluator import EventContext
 from app.services.workflow_violation import build_violation_event, check_transition
@@ -259,6 +260,20 @@ async def get_story(
         raise HTTPException(status_code=404, detail="Story not found")
     await _attach_assignee_ids(repo.session, repo.org_id, [story])
     return StoryResponse.model_validate(story)
+
+
+# E-DG S10(P1-4 observability): workflow-line 상태 read API — "왜 막혔나·어디로 relay 됐나"를
+# 채팅 없이 board/API 서 안다(FE S11 데이터 소스). 기존 story read auth(_get_repo·org-scoped)
+# 재사용·없는 story 404·active 없으면 terminal 5개 history·engine_degraded/grandfathered 명시.
+@router.get("/{id}/workflow-line/status", response_model=WorkflowLineStatusResponse)
+async def get_workflow_line_status(
+    id: uuid.UUID,
+    repo: StoryRepository = Depends(_get_repo),
+) -> WorkflowLineStatusResponse:
+    story = await repo.get(id)  # org/project-scoped read auth(AC⑤)·scope 밖/없으면 None→404
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+    return await build_workflow_line_status(repo.session, repo.org_id, id)
 
 
 class BulkUpdateItem(BaseModel):

--- a/backend/app/services/workflow_line_status.py
+++ b/backend/app/services/workflow_line_status.py
@@ -1,0 +1,188 @@
+"""E-DECISION-GATE S10: workflow-line status read model (P1-4 observability).
+
+story 의 workflow-line 실행 상태를 한 번에 조립한다 — active step_run(route decision·
+blocking_reason·gate·H1 evidence·approvers·SLA·delivery·last_event·correlation) 또는 active 가
+없으면 terminal run 5개 history. PO/FE 가 "왜 막혔나·어디로 relay 됐나"를 채팅 없이 board/API 에서
+안다(FE S11 의 데이터 소스).
+
+⭐engine_degraded/grandfathered 를 명시해 "전이는 진행됨·관측만 실패/라인 도입 전 전이" 임을
+사용자가 알고 불필요한 재시도를 안 하게 한다(AC④). no-N+1: active 1건의 gate/approvers/event 만
+상수 쿼리로 조회하고 history 는 요약(per-run 확장 안 함).
+"""
+import uuid
+from typing import Any
+
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.gate import Gate
+from app.models.event import Event
+from app.models.workflow_line import WorkflowLineStepApproval, WorkflowLineStepRun
+from app.services.workflow_line_resolution import _OPEN_STEP_RUN_STATUSES
+
+# engine 관측 실패(전이는 진행)·라인 도입 전 grandfather 를 가리키는 신호.
+_DEGRADED_FAILURE_CLASSES = frozenset({"engine_failed", "engine_exception"})
+_HISTORY_LIMIT = 5
+
+
+class ApproverView(BaseModel):
+    member_id: uuid.UUID
+    member_type: str
+    kind: str
+    blocking: bool
+    status: str
+    role_key: str | None = None
+    resolved_at: Any = None
+
+
+class LastEventView(BaseModel):
+    id: uuid.UUID
+    event_type: str
+    recipient_seq: int | None = None
+    status: str
+    created_at: Any = None
+
+
+class StepRunView(BaseModel):
+    id: uuid.UUID
+    status: str
+    from_status: str | None = None
+    to_status: str
+    mode: str
+    routing_decision: str | None = None
+    routing_reason: str | None = None
+    blocking_reason: str | None = None
+    gate_id: uuid.UUID | None = None
+    delivery_status: str
+    delivery_error: str | None = None
+    correlation_id: uuid.UUID
+    sla_due_at: Any = None
+    started_at: Any = None
+    engine_degraded: bool = False
+    grandfathered: bool = False
+    observability_note: str | None = None
+    h1_evidence: dict[str, Any] | None = None
+    approvers: list[ApproverView] = []
+    last_event: LastEventView | None = None
+
+
+class HistoryItem(BaseModel):
+    id: uuid.UUID
+    status: str
+    from_status: str | None = None
+    to_status: str
+    mode: str
+    routing_decision: str | None = None
+    resolved_at: Any = None
+    correlation_id: uuid.UUID
+
+
+class WorkflowLineStatusResponse(BaseModel):
+    story_id: uuid.UUID
+    has_active: bool
+    active: StepRunView | None = None
+    history: list[HistoryItem] = []
+
+
+def _degraded_flags(run: WorkflowLineStepRun) -> tuple[bool, bool, str | None]:
+    """(engine_degraded, grandfathered, note) 도출."""
+    engine_degraded = bool(run.degraded_to_plain) or (run.failure_class in _DEGRADED_FAILURE_CLASSES)
+    grandfathered = run.mode == "plain_transition"
+    note = None
+    if engine_degraded:
+        note = "전이는 진행됨 · 라인 관측만 실패(재시도 불필요)"
+    elif grandfathered:
+        note = "라인 도입 전/off 전이(grandfathered) · 게이트 미적용"
+    return engine_degraded, grandfathered, note
+
+
+def _blocking_reason(run: WorkflowLineStepRun) -> str | None:
+    """막힌 이유 1줄 — failure_message > routing_reason 우선(blocked/gate 대기 시)."""
+    if run.failure_message:
+        return run.failure_message
+    if run.status in ("gate_pending", "waiting_gate", "waiting_parallel"):
+        return run.routing_reason or "awaiting_gate_decision"
+    if run.status in ("blocked", "blocked_by_policy"):
+        return run.routing_reason or "blocked_by_policy"
+    return run.routing_reason
+
+
+async def build_workflow_line_status(
+    session: AsyncSession, org_id: uuid.UUID, story_id: uuid.UUID,
+) -> WorkflowLineStatusResponse:
+    """story 의 workflow-line 상태 read model 을 조립한다(active 또는 terminal history)."""
+    runs = (await session.execute(
+        select(WorkflowLineStepRun).where(
+            WorkflowLineStepRun.org_id == org_id,
+            WorkflowLineStepRun.entity_type == "story",
+            WorkflowLineStepRun.entity_id == story_id,
+        ).order_by(WorkflowLineStepRun.started_at.desc())
+    )).scalars().all()
+
+    active = next((r for r in runs if r.status in _OPEN_STEP_RUN_STATUSES), None)
+    if active is None:
+        # active 없음 → terminal run 5개 history(AC③).
+        history = [
+            HistoryItem(
+                id=r.id, status=r.status, from_status=r.from_status, to_status=r.to_status,
+                mode=r.mode, routing_decision=r.routing_decision, resolved_at=r.resolved_at,
+                correlation_id=r.correlation_id,
+            )
+            for r in runs[:_HISTORY_LIMIT]
+        ]
+        return WorkflowLineStatusResponse(story_id=story_id, has_active=False, history=history)
+
+    # active 1건의 gate / approvers / event 만 상수 쿼리(no-N+1·AC⑥).
+    gate = None
+    if active.gate_id is not None:
+        gate = (await session.execute(
+            select(Gate).where(Gate.id == active.gate_id, Gate.org_id == org_id)
+        )).scalar_one_or_none()
+    h1_evidence = None
+    if gate is not None:
+        h1_evidence = {
+            "requires_human": gate.requires_human,
+            "evidence_status": gate.evidence_status,
+            "decision_basis": gate.decision_basis,
+            "auto_decision_reason": gate.auto_decision_reason,
+            "gate_status": gate.status,
+        }
+
+    approvers: list[ApproverView] = []
+    if active.approval_group_id is not None:
+        appr_rows = (await session.execute(
+            select(WorkflowLineStepApproval).where(
+                WorkflowLineStepApproval.approval_group_id == active.approval_group_id,
+            ).order_by(WorkflowLineStepApproval.created_at.asc())
+        )).scalars().all()
+        approvers = [
+            ApproverView(
+                member_id=a.approver_member_id, member_type=a.approver_member_type, kind=a.kind,
+                blocking=a.blocking, status=a.status, role_key=a.role_key, resolved_at=a.resolved_at,
+            )
+            for a in appr_rows
+        ]
+
+    last_event = None
+    if active.event_id is not None:
+        ev = (await session.execute(
+            select(Event).where(Event.id == active.event_id)
+        )).scalar_one_or_none()
+        if ev is not None:
+            last_event = LastEventView(
+                id=ev.id, event_type=ev.event_type, recipient_seq=ev.recipient_seq,
+                status=ev.status, created_at=ev.created_at,
+            )
+
+    engine_degraded, grandfathered, note = _degraded_flags(active)
+    view = StepRunView(
+        id=active.id, status=active.status, from_status=active.from_status, to_status=active.to_status,
+        mode=active.mode, routing_decision=active.routing_decision, routing_reason=active.routing_reason,
+        blocking_reason=_blocking_reason(active), gate_id=active.gate_id,
+        delivery_status=active.delivery_status, delivery_error=active.delivery_error,
+        correlation_id=active.correlation_id, sla_due_at=active.sla_due_at, started_at=active.started_at,
+        engine_degraded=engine_degraded, grandfathered=grandfathered, observability_note=note,
+        h1_evidence=h1_evidence, approvers=approvers, last_event=last_event,
+    )
+    return WorkflowLineStatusResponse(story_id=story_id, has_active=True, active=view)

--- a/backend/tests/test_edg_s10_status_api.py
+++ b/backend/tests/test_edg_s10_status_api.py
@@ -1,0 +1,173 @@
+"""E-DG S10: workflow-line status read model 테스트.
+
+핵심: active step_run 조립(gate H1 evidence·approvers·last_event·blocking_reason·correlation)·
+active 없으면 terminal 5개 history(desc)·engine_degraded/grandfathered 명시.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+_NOW = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    import app.models.gate  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_run(s, org, story_id, *, status="gate_pending", mode="advisory_only",
+                    age_min=0, **kw):
+    from app.models.workflow_line import WorkflowLineStepRun
+    sr = WorkflowLineStepRun(
+        org_id=org, project_id=uuid.uuid4(), entity_type="story", entity_id=story_id,
+        from_status="in-review", to_status="done", status=status, mode=mode,
+        correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex,
+        started_at=_NOW - timedelta(minutes=age_min), **kw)
+    s.add(sr)
+    await s.flush()
+    return sr
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_active_with_gate_evidence_and_approvers():
+    from app.services.workflow_line_status import build_workflow_line_status
+    from app.models.gate import Gate
+    from app.models.workflow_line import WorkflowLineStepApproval
+    engine, Session = await _session()
+    async with Session() as s:
+        org, story = uuid.uuid4(), uuid.uuid4()
+        gate = Gate(id=uuid.uuid4(), org_id=org, work_item_id=story, work_item_type="story",
+                    gate_type="merge", status="pending", requires_human=True,
+                    evidence_status="ready", decision_basis="trust_low", auto_decision_reason=None)
+        s.add(gate)
+        await s.flush()
+        group = uuid.uuid4()
+        sr = await _seed_run(s, org, story, status="gate_pending", gate_id=gate.id,
+                             approval_group_id=group, routing_reason="trust_below_threshold")
+        for kind in ("approver", "consult"):
+            s.add(WorkflowLineStepApproval(
+                org_id=org, project_id=sr.project_id, step_run_id=sr.id, gate_id=gate.id,
+                approval_group_id=group, approver_member_id=uuid.uuid4(), approver_member_type="human",
+                kind=kind, blocking=(kind == "approver"), status="pending"))
+        await s.flush()
+
+        res = await build_workflow_line_status(s, org, story)
+        assert res.has_active is True and res.active is not None
+        a = res.active
+        assert a.gate_id == gate.id and a.correlation_id == sr.correlation_id
+        assert a.blocking_reason == "trust_below_threshold"
+        assert a.h1_evidence["requires_human"] is True and a.h1_evidence["evidence_status"] == "ready"
+        assert a.h1_evidence["gate_status"] == "pending"
+        assert len(a.approvers) == 2  # approver + consult 둘 다 노출(audit)
+        assert a.last_event is None
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_active_with_last_event():
+    from app.services.workflow_line_status import build_workflow_line_status
+    from app.models.event import Event
+    from app.models.project import Project
+    from app.models.team import TeamMember
+    engine, Session = await _session()
+    async with Session() as s:
+        org, story = uuid.uuid4(), uuid.uuid4()
+        proj, rcpt = uuid.uuid4(), uuid.uuid4()
+        s.add(Project(id=proj, org_id=org, name="p"))
+        s.add(TeamMember(id=rcpt, org_id=org, project_id=proj, type="agent", name="r"))
+        await s.flush()
+        ev = Event(org_id=org, project_id=proj, event_type="dispatched", source_entity_type="story",
+                   source_entity_id=story, recipient_id=rcpt, recipient_type="agent", payload={},
+                   status="pending", recipient_seq=7)
+        s.add(ev)
+        await s.flush()
+        await _seed_run(s, org, story, status="dispatched", event_id=ev.id, delivery_status="queued")
+
+        res = await build_workflow_line_status(s, org, story)
+        assert res.active is not None and res.active.last_event is not None
+        assert res.active.last_event.recipient_seq == 7 and res.active.delivery_status == "queued"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_no_active_returns_terminal_history_capped_5_desc():
+    from app.services.workflow_line_status import build_workflow_line_status
+    engine, Session = await _session()
+    async with Session() as s:
+        org, story = uuid.uuid4(), uuid.uuid4()
+        # 6개 terminal run(전부 applied) — i=0 가 가장 최근(age 10m)·i=5 가 가장 오래(age 60m)
+        srs = [await _seed_run(s, org, story, status="applied", age_min=(i + 1) * 10) for i in range(6)]
+        res = await build_workflow_line_status(s, org, story)
+        assert res.has_active is False and res.active is None
+        assert len(res.history) == 5  # 5개로 cap(AC③)
+        # started_at desc — 최근 5개(i=0..4)만·desc 순서. 가장 오래된 i=5 는 탈락.
+        expected = [srs[i].correlation_id for i in range(5)]  # i=0(최근)…i=4
+        assert [h.correlation_id for h in res.history] == expected
+        assert srs[5].correlation_id not in {h.correlation_id for h in res.history}
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_engine_degraded_flag_and_note():
+    from app.services.workflow_line_status import build_workflow_line_status
+    engine, Session = await _session()
+    async with Session() as s:
+        org, story = uuid.uuid4(), uuid.uuid4()
+        # degraded_to_plain True + open status → active 로 잡혀 engine_degraded 노출
+        await _seed_run(s, org, story, status="gate_pending", degraded_to_plain=True)
+        res = await build_workflow_line_status(s, org, story)
+        assert res.active.engine_degraded is True
+        assert "관측만 실패" in (res.active.observability_note or "")
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_grandfathered_flag():
+    from app.services.workflow_line_status import build_workflow_line_status
+    engine, Session = await _session()
+    async with Session() as s:
+        org, story = uuid.uuid4(), uuid.uuid4()
+        await _seed_run(s, org, story, status="gate_pending", mode="plain_transition")
+        res = await build_workflow_line_status(s, org, story)
+        assert res.active.grandfathered is True
+        assert "grandfathered" in (res.active.observability_note or "")
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_no_runs_empty_status():
+    from app.services.workflow_line_status import build_workflow_line_status
+    engine, Session = await _session()
+    async with Session() as s:
+        org, story = uuid.uuid4(), uuid.uuid4()
+        res = await build_workflow_line_status(s, org, story)
+        assert res.has_active is False and res.active is None and res.history == []
+    await engine.dispose()


### PR DESCRIPTION
## E-DECISION-GATE S10 — Workflow-line status read API (P1-4 observability)

스토리 `e98fddd5` · 3pt · 의존 S3(엔진)·S7(relay/delivery)·S9(approvals)·전부 merged. **critical path · FE S11 unblock**. **마이그 없음·read-only**. 비-lane → 디디 + 까심 QA.

PO/FE 가 "왜 막혔나·어디로 relay 됐나"를 채팅 없이 board/API 서 안다.

### 변경
- `GET /api/v2/stories/{id}/workflow-line/status` (stories router) — 기존 `_get_repo` org/project-scoped story read auth 재사용·없는 story 404(AC①⑤⑥).
- `app/services/workflow_line_status.py` (신규) — `build_workflow_line_status`:
  - **active step_run**: route decision·`blocking_reason`·`gate_id`·**H1 evidence**(requires_human/evidence_status/decision_basis/auto_decision_reason/gate_status)·**approvers**(workflow_step_approvals)·SLA·delivery_status·last_event·correlation_id(AC②).
  - active 없으면 **terminal run 5개 history**(desc·AC③).
  - ⭐**engine_degraded**(degraded_to_plain/engine_failed)·**grandfathered**(plain_transition) 명시 + `observability_note`("전이는 진행됨·관측만 실패"/"grandfathered") — 불필요 재시도 방지(AC④).
  - **no-N+1**: active 1건의 gate/approvers/event 만 상수 쿼리·history 는 요약(per-run 확장 안 함·AC⑥).

### 테스트 (6/6 PASS · 실 PG)
- active(gate H1 evidence + approver/consult 둘 다 노출 + blocking_reason + correlation)
- last_event(recipient_seq/delivery_status)
- no-active → terminal history **cap 5 · desc**(가장 오래된 것 탈락)
- engine_degraded flag + note
- grandfathered flag + note
- no-runs → 빈 status

🤖 Generated with [Claude Code](https://claude.com/claude-code)