### PR TITLE
[9ef6ac8c] E-DG S13 — SLA processor for human-gate

### DIFF
--- a/backend/app/models/workflow_line.py
+++ b/backend/app/models/workflow_line.py
@@ -182,3 +182,26 @@ class WorkflowLineStepApproval(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
     )
+
+
+# S13 SLA processor 가 기록하는 append-only audit event type.
+STEP_RUN_EVENT_TYPES = frozenset({
+    "status_apply", "dispatch_create", "wake", "reminded", "escalated", "sla_timeout", "auto_approved",
+})
+
+
+class WorkflowLineStepRunEvent(Base):
+    """step_run 의 append-only audit event(0126 미러). S13 reminder/escalation/timeout 기록."""
+
+    __tablename__ = "workflow_step_run_events"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    step_run_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    event_type: Mapped[str] = mapped_column(Text, nullable=False)
+    actor_member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    target_member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    payload: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default="{}")
+    correlation_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -149,6 +149,25 @@ async def workflow_handoff_watchdog(
         return _err("INTERNAL_ERROR", "Internal server error", 500)
 
 
+# ─── GET /api/v2/internal/cron/workflow-sla ───────────────────────────────────
+# E-DG S13(P1-3): human-gate SLA processor — pending gate 가 방치되지 않게 reminder→escalation→
+# timeout(keep_pending 기본·auto_approve 금지조건) 으로 제품이 독촉. hitl-timeouts 와 별도 endpoint.
+
+@router.get("/workflow-sla")
+async def workflow_sla(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    verify_cron(request)
+    try:
+        from app.services.workflow_sla_processor import process_sla
+        counts = await process_sla(session)
+        return _ok(counts)
+    except Exception as exc:
+        logger.exception("cron error: %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)
+
+
 # ─── GET /api/v2/internal/cron/inbox-outbox ────────────────────────────────────
 
 @router.get("/inbox-outbox")

--- a/backend/app/services/workflow_sla_processor.py
+++ b/backend/app/services/workflow_sla_processor.py
@@ -1,0 +1,182 @@
+"""E-DECISION-GATE S13: SLA processor for human-gate (P1-3).
+
+pending human-gate 가 방치되지 않게 **reminder → escalation → timeout** 정책으로 제품이 독촉한다
+(오너 수동 "쳐노는지?" 패턴 제품화). HITL-timeout cron 레일 재사용·별도 endpoint.
+
+보수적 기본: on_timeout 기본 ``keep_pending`` · ⭐auto_approve default off + high-risk/prod-touch/
+story_points>=8/trust-unresolved 에서 금지 · ⭐system timeout transition 은 ``resolver_id=None``
+(사람 결정이 아니므로 trust 환류 차단). SKIP LOCKED 로 cron 겹침 시 중복 reminder/escalation 방지.
+"""
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.gate import Gate
+from app.models.workflow_line import (
+    WorkflowLineDefinitionVersion,
+    WorkflowLineStepRun,
+    WorkflowLineStepRunEvent,
+)
+
+# SLA 가 독촉하는 미해소 human-gate 대기 상태.
+_SLA_GATE_STATUSES = ("gate_pending", "waiting_gate", "waiting_parallel", "reminded", "escalated", "held")
+_TERMINAL_GATE = frozenset({"approved", "rejected"})
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+async def _resolve_sla_policy(session: AsyncSession, sr: WorkflowLineStepRun) -> dict[str, Any]:
+    """step_run 이 가리키는 published config step 의 sla_policy(없으면 {})."""
+    if sr.line_definition_id is None:
+        return {}
+    version = (await session.execute(
+        select(WorkflowLineDefinitionVersion).where(
+            WorkflowLineDefinitionVersion.line_definition_id == sr.line_definition_id,
+            WorkflowLineDefinitionVersion.status == "published",
+        ).order_by(WorkflowLineDefinitionVersion.version.desc()).limit(1)
+    )).scalar_one_or_none()
+    config = dict(version.config) if version and isinstance(version.config, dict) else {}
+    for step in config.get("steps") or []:
+        if (isinstance(step, dict) and step.get("to_status") == sr.to_status
+                and step.get("from_status") in (sr.from_status, None)):
+            pol = step.get("sla_policy")
+            return pol if isinstance(pol, dict) else {}
+    return {}
+
+
+def _auto_approve_allowed(sr: WorkflowLineStepRun, story_points: int | None) -> bool:
+    """⭐auto_approve 금지조건(AC④): high-risk/prod-touch/sp>=8/trust-unresolved 면 False."""
+    risk = sr.risk_snapshot or {}
+    if risk.get("prod_touch") is True or risk.get("high_risk") is True:
+        return False
+    if story_points is not None and story_points >= 8:
+        return False
+    trust = sr.trust_snapshot or {}
+    # cold_start / 미해소 trust(hit_rate None) 면 자동승인 금지(보수적).
+    if trust.get("cold_start") is True or trust.get("unresolved") is True:
+        return False
+    if "hit_rate" in trust and trust.get("hit_rate") is None:
+        return False
+    return True
+
+
+def _record_event(session: AsyncSession, sr: WorkflowLineStepRun, event_type: str,
+                  *, target_id: uuid.UUID | None = None, payload: dict | None = None) -> None:
+    session.add(WorkflowLineStepRunEvent(
+        org_id=sr.org_id, project_id=sr.project_id, step_run_id=sr.id, event_type=event_type,
+        target_member_id=target_id, payload=payload or {}, correlation_id=sr.correlation_id,
+    ))
+
+
+async def _notify(session: AsyncSession, sr: WorkflowLineStepRun, target_id: uuid.UUID | None,
+                  event_type: str, title: str) -> None:
+    """best-effort notification(실패는 SLA processor 비중단)."""
+    if target_id is None:
+        return
+    try:
+        from app.services.notification_dispatch import dispatch_notification
+        await dispatch_notification(
+            session, org_id=sr.org_id, event_type=event_type, target_member_ids=[target_id],
+            title=title, body=f"{sr.entity_type} {sr.entity_id} {sr.from_status}→{sr.to_status}",
+            reference_type=sr.entity_type, reference_id=sr.entity_id,
+        )
+    except Exception:  # noqa: BLE001 — notification 실패는 비중단(best-effort).
+        pass
+
+
+async def _maybe_auto_approve(session: AsyncSession, sr: WorkflowLineStepRun) -> bool:
+    """on_timeout=auto_approve + 허용조건 충족 시 system transition(resolver_id=None). 성공 시 True."""
+    if sr.gate_id is None:
+        return False
+    gate = (await session.execute(
+        select(Gate).where(Gate.id == sr.gate_id, Gate.org_id == sr.org_id)
+    )).scalar_one_or_none()
+    if gate is None or gate.status in _TERMINAL_GATE:
+        return False
+    story_points = None
+    from app.models.pm import Story  # 순환 회피 lazy import.
+    story = await session.get(Story, sr.entity_id)
+    if story is not None:
+        story_points = getattr(story, "story_points", None)
+    if not _auto_approve_allowed(sr, story_points):
+        return False
+    from app.services.gate_service import transition_gate
+    # ⭐resolver_id=None: system 자동승인은 사람 결정이 아니므로 trust 환류 차단(AC⑤).
+    await transition_gate(session, sr.org_id, sr.gate_id, "approved", resolver_id=None)
+    _record_event(session, sr, "auto_approved", payload={"reason": "sla_timeout_auto_approve"})
+    return True
+
+
+async def process_sla(session: AsyncSession, now: datetime | None = None) -> dict[str, int]:
+    """미해소 human-gate step_run 을 SLA 정책대로 reminder/escalation/timeout 처리한다."""
+    now = now or _now()
+    rows = (await session.execute(
+        select(WorkflowLineStepRun).where(
+            WorkflowLineStepRun.status.in_(_SLA_GATE_STATUSES),
+        ).order_by(WorkflowLineStepRun.started_at.asc()).with_for_update(skip_locked=True)
+    )).scalars().all()
+
+    counts = {"reminded": 0, "escalated": 0, "auto_approved": 0, "kept_pending": 0, "skipped": 0}
+    for sr in rows:
+        policy = await _resolve_sla_policy(session, sr)
+        timeout_h = policy.get("timeout_hours")
+        if not timeout_h:
+            counts["skipped"] += 1
+            continue
+        elapsed_h = (now - sr.started_at).total_seconds() / 3600.0
+
+        # ── 1) timeout ───────────────────────────────────────────────────────
+        if elapsed_h >= timeout_h:
+            on_timeout = policy.get("on_timeout", "keep_pending")
+            if on_timeout == "auto_approve" and await _maybe_auto_approve(session, sr):
+                counts["auto_approved"] += 1
+                continue
+            # keep_pending(기본) 또는 auto_approve 금지 → 보수적: escalate 1회 후 pending 유지.
+            escalate_to = policy.get("escalate_to")
+            if escalate_to and sr.escalated_to_member_id is None:
+                target = _resolve_escalation_target(escalate_to)
+                if target is not None:
+                    sr.escalated_to_member_id = target
+                    sr.status = "escalated"
+                    _record_event(session, sr, "escalated", target_id=target,
+                                  payload={"reason": "sla_timeout"})
+                    await _notify(session, sr, target, "gate_escalated", "Gate escalated — SLA timeout")
+                    counts["escalated"] += 1
+                    continue
+            counts["kept_pending"] += 1  # ⭐방치 아님·gate 유지(이미 escalate or escalate_to 없음)
+            continue
+
+        # ── 2) reminder ──────────────────────────────────────────────────────
+        reminder_after = policy.get("reminder_after_hours")
+        max_reminders = policy.get("max_reminders", 0)
+        if (reminder_after is not None and elapsed_h >= reminder_after
+                and sr.reminder_count < max_reminders
+                and (sr.next_reminder_at is None or now >= sr.next_reminder_at)):
+            _record_event(session, sr, "reminded", payload={"reminder_count": sr.reminder_count + 1})
+            await _notify(session, sr, sr.resolved_member_id, "gate_reminder", "Gate reminder — still pending")
+            sr.reminder_count += 1
+            every = policy.get("reminder_every_hours") or reminder_after
+            sr.next_reminder_at = now + timedelta(hours=every)
+            if sr.status != "escalated":
+                sr.status = "reminded"
+            counts["reminded"] += 1
+
+    await session.commit()
+    return counts
+
+
+def _resolve_escalation_target(escalate_to: Any) -> uuid.UUID | None:
+    """escalate_to 를 member_id 로 해소. MVP: member uuid 직접 지정. role_key 해소는 후속 defer."""
+    if isinstance(escalate_to, uuid.UUID):
+        return escalate_to
+    if isinstance(escalate_to, str):
+        try:
+            return uuid.UUID(escalate_to)
+        except ValueError:
+            return None  # role_key 등 비-uuid → 후속 Phase(deputy/role resolver)
+    return None

--- a/backend/tests/test_edg_s13_sla_processor.py
+++ b/backend/tests/test_edg_s13_sla_processor.py
@@ -1,0 +1,217 @@
+"""E-DG S13: SLA processor for human-gate 테스트.
+
+핵심: reminder(step_run_events.reminded+notify·idempotent·cap)·timeout keep_pending 기본·
+escalation(escalated_to_member_id)·auto_approve(허용 시 resolver_id=None / high-risk·sp>=8·
+trust-unresolved 금지).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+_NOW = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+_NOTIFY = "app.services.notification_dispatch.dispatch_notification"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    import app.models.participation  # noqa: F401 — gate_resolver FK 등록
+    import app.models.gate  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    import sqlalchemy as sa
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        # process_sla 는 cron 시맨틱상 org 필터 없이 전 org 스캔 → 공유 DB 의 이전 테스트 row 가
+        # 카운트를 오염시킨다. 테스트 격리: 워크플로/게이트 테이블을 매 셋업서 비운다.
+        await conn.execute(sa.text(
+            "TRUNCATE workflow_line_step_runs, workflow_step_run_events, workflow_step_approvals, "
+            "gate, workflow_line_definitions, workflow_line_definition_versions CASCADE"))
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_line(s, org, sla_policy, *, from_status="in-review", to_status="done"):
+    from app.models.workflow_line import WorkflowLineDefinition, WorkflowLineDefinitionVersion
+    defn = WorkflowLineDefinition(org_id=org, project_id=None, entity_type="story", name="L",
+                                  is_active=True, version=1)
+    s.add(defn)
+    await s.flush()
+    s.add(WorkflowLineDefinitionVersion(
+        line_definition_id=defn.id, org_id=org, project_id=None, entity_type="story", version=1,
+        status="published", config_hash="h", created_by_member_id=uuid.uuid4(),
+        config={"steps": [{"from_status": from_status, "to_status": to_status,
+                           "step_type": "human-gate", "sla_policy": sla_policy}]}))
+    await s.flush()
+    return defn.id
+
+
+async def _seed_run(s, org, defn_id, *, age_h, status="gate_pending", from_status="in-review",
+                    to_status="done", entity_id=None, **kw):
+    from app.models.workflow_line import WorkflowLineStepRun
+    sr = WorkflowLineStepRun(
+        org_id=org, project_id=uuid.uuid4(), line_definition_id=defn_id, entity_type="story",
+        entity_id=entity_id or uuid.uuid4(), from_status=from_status, to_status=to_status,
+        status=status, mode="gate_pending", correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex,
+        started_at=_NOW - timedelta(hours=age_h), **kw)
+    s.add(sr)
+    await s.flush()
+    return sr
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_reminder_fires_records_event_and_idempotent():
+    from app.services.workflow_sla_processor import process_sla
+    from app.models.workflow_line import WorkflowLineStepRun, WorkflowLineStepRunEvent
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        defn = await _seed_line(s, org, {"timeout_hours": 24, "reminder_after_hours": 2,
+                                         "reminder_every_hours": 2, "max_reminders": 3})
+        sr = await _seed_run(s, org, defn, age_h=3, resolved_member_id=uuid.uuid4())
+        with patch(_NOTIFY, new=AsyncMock()) as notify:
+            c1 = await process_sla(s, now=_NOW)
+        assert c1["reminded"] == 1 and notify.await_count == 1
+        row = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id))).scalar_one()
+        assert row.reminder_count == 1 and row.status == "reminded" and row.next_reminder_at is not None
+        evs = (await s.execute(select(WorkflowLineStepRunEvent).where(
+            WorkflowLineStepRunEvent.step_run_id == sr.id,
+            WorkflowLineStepRunEvent.event_type == "reminded"))).scalars().all()
+        assert len(evs) == 1
+        # 같은 now 재실행 → next_reminder_at 미도래 → 재reminder 0(idempotent)
+        with patch(_NOTIFY, new=AsyncMock()) as notify2:
+            c2 = await process_sla(s, now=_NOW)
+        assert c2["reminded"] == 0 and notify2.await_count == 0
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_reminder_cap_respected():
+    from app.services.workflow_sla_processor import process_sla
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        defn = await _seed_line(s, org, {"timeout_hours": 24, "reminder_after_hours": 2,
+                                         "reminder_every_hours": 2, "max_reminders": 1})
+        await _seed_run(s, org, defn, age_h=10, reminder_count=1)  # 이미 cap 도달
+        with patch(_NOTIFY, new=AsyncMock()) as notify:
+            c = await process_sla(s, now=_NOW)
+        assert c["reminded"] == 0 and notify.await_count == 0
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_timeout_keep_pending_default_no_transition():
+    from app.services.workflow_sla_processor import process_sla
+    from app.models.workflow_line import WorkflowLineStepRun
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        defn = await _seed_line(s, org, {"timeout_hours": 4})  # on_timeout 미지정 → keep_pending
+        sr = await _seed_run(s, org, defn, age_h=10)
+        with patch(_NOTIFY, new=AsyncMock()):
+            c = await process_sla(s, now=_NOW)
+        assert c["kept_pending"] == 1 and c["auto_approved"] == 0
+        row = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id))).scalar_one()
+        assert row.status == "gate_pending"  # 전이 없음(보수적)
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_timeout_escalates_and_idempotent():
+    from app.services.workflow_sla_processor import process_sla
+    from app.models.workflow_line import WorkflowLineStepRun
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org, deputy = uuid.uuid4(), uuid.uuid4()
+        defn = await _seed_line(s, org, {"timeout_hours": 4, "escalate_to": str(deputy)})
+        sr = await _seed_run(s, org, defn, age_h=10)
+        with patch(_NOTIFY, new=AsyncMock()) as notify:
+            c = await process_sla(s, now=_NOW)
+        assert c["escalated"] == 1 and notify.await_count == 1
+        row = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id))).scalar_one()
+        assert row.escalated_to_member_id == deputy and row.status == "escalated"
+        # 재실행 → 이미 escalated_to 세팅 → 재escalate 0(idempotent)
+        with patch(_NOTIFY, new=AsyncMock()):
+            c2 = await process_sla(s, now=_NOW)
+        assert c2["escalated"] == 0 and c2["kept_pending"] == 1
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_timeout_auto_approve_when_allowed_resolver_none():
+    from app.services.workflow_sla_processor import process_sla
+    from app.models.gate import Gate
+    from app.models.project import Project
+    from app.models.pm import Story
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org, story_id = uuid.uuid4(), uuid.uuid4()
+        proj = uuid.uuid4()
+        s.add(Project(id=proj, org_id=org, name="p"))
+        await s.flush()  # Project 선확정(Story FK 순서 보장)
+        s.add(Story(id=story_id, org_id=org, project_id=proj, title="t", status="in-review",
+                    story_points=3))
+        gate = Gate(id=uuid.uuid4(), org_id=org, work_item_id=story_id, work_item_type="story",
+                    gate_type="merge", status="pending")
+        s.add(gate)
+        await s.flush()
+        defn = await _seed_line(s, org, {"timeout_hours": 4, "on_timeout": "auto_approve"})
+        await _seed_run(s, org, defn, age_h=10, entity_id=story_id, gate_id=gate.id,
+                        risk_snapshot={}, trust_snapshot={})
+        with patch(_NOTIFY, new=AsyncMock()):
+            c = await process_sla(s, now=_NOW)
+        assert c["auto_approved"] == 1
+        g = (await s.execute(select(Gate).where(Gate.id == gate.id))).scalar_one()
+        assert g.status == "approved" and g.resolver_id is None  # ⭐system transition·trust 환류 차단
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_auto_approve_forbidden_high_risk_falls_back():
+    from app.services.workflow_sla_processor import process_sla
+    from app.models.gate import Gate
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org, story_id = uuid.uuid4(), uuid.uuid4()
+        gate = Gate(id=uuid.uuid4(), org_id=org, work_item_id=story_id, work_item_type="story",
+                    gate_type="merge", status="pending")
+        s.add(gate)
+        await s.flush()
+        defn = await _seed_line(s, org, {"timeout_hours": 4, "on_timeout": "auto_approve"})
+        # ⭐prod_touch high-risk → auto_approve 금지 → keep_pending fallback
+        await _seed_run(s, org, defn, age_h=10, entity_id=story_id, gate_id=gate.id,
+                        risk_snapshot={"prod_touch": True}, trust_snapshot={})
+        with patch(_NOTIFY, new=AsyncMock()):
+            c = await process_sla(s, now=_NOW)
+        assert c["auto_approved"] == 0 and c["kept_pending"] == 1
+        g = (await s.execute(select(Gate).where(Gate.id == gate.id))).scalar_one()
+        assert g.status == "pending"  # 자동승인 안 됨(금지조건)
+    await engine.dispose()


### PR DESCRIPTION
## E-DECISION-GATE S13 — SLA processor for human-gate (P1-3)

스토리 `9ef6ac8c` · 5pt · 의존 S9(merged) · 비-lane(디디 + 까심 QA + PO). **마이그 없음**(0126 `workflow_step_run_events` 재사용).

pending human-gate 가 방치되지 않게 **reminder → escalation → timeout** 정책으로 제품이 독촉(오너 수동 "쳐노는지?" 패턴 제품화). HITL-timeout cron 레일 재사용·별도 endpoint.

### 변경
- `app/models/workflow_line.py` — **`WorkflowLineStepRunEvent` ORM**(0126 `workflow_step_run_events` 미러·append-only audit·모델 신설).
- `app/services/workflow_sla_processor.py` (신규) — `process_sla`:
  - `sla_policy`(timeout_hours/reminder_after_hours/reminder_every_hours/max_reminders/escalate_to/deputy_allowed/on_timeout)를 **published config step 에서 해소**(AC①).
  - **reminder** = `step_run_events.reminded` 기록 + `dispatch_notification` + reminder_count/next_reminder_at 갱신(AC②·max cap·next_reminder_at gate 로 **idempotent**).
  - **escalation** = `escalate_to` 해소 + `escalated_to_member_id` 기록·1회만(AC③·idempotent).
  - **timeout 기본 `keep_pending`**. ⭐`auto_approve` default off + **high-risk/prod-touch/story_points>=8/trust-unresolved 금지**(AC④). ⭐**system transition 은 `resolver_id=None`**(사람 결정 아님·trust 환류 차단·AC⑤).
  - **SKIP LOCKED** 로 cron 겹침 시 중복 처리 방지(AC⑥).
- `app/routers/cron.py` — `GET /api/v2/internal/cron/workflow-sla`(verify_cron·hitl-timeouts 와 별도·AC⑥).

### 테스트 (6/6 PASS · 실 PG)
- reminder 발화 + event 기록 + **idempotent**(next_reminder_at 미도래 재실행 0)
- reminder cap(max_reminders)
- timeout **keep_pending** 기본(전이 0)
- timeout **escalate** + idempotent(escalated_to set)
- timeout **auto_approve(허용)** → gate approved + **resolver_id=None**
- auto_approve **금지(high-risk prod_touch)** → keep_pending fallback(gate pending 유지)

### 비고
- 변경 신규 파일(service/model/test) ruff clean. `cron.py` 의 기존 F401/E402(uuid/Header/update unused·E402)는 develop 선재(S8 도 동일 상태로 머지)·S13 무관(additive endpoint 만 추가)·CI Lint=`pnpm lint`(FE)라 백엔드 ruff 비강제. 별도 cleanup 스토리 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)