### PR TITLE
[46102a42] E-DG S14 — deputy/availability/SoD role resolver

### DIFF
--- a/backend/app/models/workflow_line.py
+++ b/backend/app/models/workflow_line.py
@@ -205,3 +205,36 @@ class WorkflowLineStepRunEvent(Base):
     payload: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default="{}")
     correlation_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+
+# S14 deputy/availability/SoD resolver 의 candidate source.
+AVAILABILITY_STATUSES = frozenset({"available", "ooo", "unavailable", "busy"})
+
+
+class WorkflowRoleAssignment(Base):
+    """role_key → member 후보(0126 미러). S14 resolver 가 active/effective/availability 필터 + deputy
+    대체 + SoD 로 candidate 를 해소한다. ``metadata`` 컬럼은 SQLAlchemy 예약어라 attr 명을 우회한다.
+    """
+
+    __tablename__ = "workflow_role_assignments"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    project_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    role_key: Mapped[str] = mapped_column(Text, nullable=False)
+    member_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    member_type: Mapped[str] = mapped_column(Text, nullable=False)
+    priority: Mapped[int] = mapped_column(Integer, nullable=False, server_default="100")
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
+    deputy_member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    deputy_member_type: Mapped[str | None] = mapped_column(Text, nullable=True)
+    availability_status: Mapped[str] = mapped_column(Text, nullable=False, server_default="available")
+    effective_from: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    effective_to: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    delegation_policy: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default="{}")
+    # ``metadata`` 는 Declarative 예약어 → attr 명 분리·DB 컬럼명은 그대로 "metadata".
+    assignment_metadata: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, server_default="{}")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/services/workflow_role_resolver.py
+++ b/backend/app/services/workflow_role_resolver.py
@@ -1,0 +1,133 @@
+"""E-DECISION-GATE S14: deputy / availability / SoD role resolver.
+
+``workflow_role_assignments`` 에서 role_key → member 후보를 해소한다:
+- ① active / effective-period / availability 필터.
+- ② availability='ooo'(불가) & deputy_allowed → deputy 대체 + original_approver_member_id 보존.
+- ③ inactive/terminated member 제외(TeamMember.is_active).
+- ④ human-gate 는 prefer=human(agent approver 불허).
+- ⑤ ⭐SoD: requested_by/current assignee/implementation actor 와 동일 approver 는 self-approval
+  forbidden → 다음 후보로 fallback(없으면 unresolved → escalate).
+- ⑥ 후보 없으면 None → 호출부가 unresolved_assignee + board badge(silent prison 아님).
+
+OOO/inactive approver 가 pending prison 을 만들지 않게 한다.
+"""
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.team import TeamMember
+from app.models.workflow_line import WorkflowLineStepRun, WorkflowRoleAssignment
+
+# availability 가 후보 불가(=deputy 필요) 인 상태.
+_UNAVAILABLE = frozenset({"ooo", "unavailable"})
+
+
+@dataclass
+class ResolvedCandidate:
+    member_id: uuid.UUID
+    member_type: str
+    original_approver_member_id: uuid.UUID | None  # deputy 대체 시 원 approver 보존(②)
+    via_deputy: bool
+    role_assignment_id: uuid.UUID
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+async def _member_active(session: AsyncSession, member_id: uuid.UUID) -> bool:
+    """③ inactive/terminated 제외 — TeamMember.is_active."""
+    m = await session.get(TeamMember, member_id)
+    return m is not None and bool(m.is_active)
+
+
+def _deputy_allowed(assignment: WorkflowRoleAssignment) -> bool:
+    pol = assignment.delegation_policy
+    return bool(pol.get("deputy_allowed")) if isinstance(pol, dict) else False
+
+
+async def resolve_role_candidate(
+    session: AsyncSession, org_id: uuid.UUID, role_key: str, *,
+    project_id: uuid.UUID | None = None, prefer_human: bool = True,
+    sod_exclude: set[uuid.UUID] | None = None, now: datetime | None = None,
+) -> ResolvedCandidate | None:
+    """role_key 의 유효 후보 1명을 priority 순으로 해소(없으면 None)."""
+    now = now or _now()
+    sod_norm = {str(x) for x in (sod_exclude or set()) if x is not None}
+
+    rows = (await session.execute(
+        select(WorkflowRoleAssignment).where(
+            WorkflowRoleAssignment.org_id == org_id,
+            WorkflowRoleAssignment.role_key == role_key,
+            WorkflowRoleAssignment.is_active.is_(True),
+        )
+    )).scalars().all()
+
+    # project 우선(요청 project 매칭 0 → org-level NULL 1 → 타 project 2=제외), 그 다음 priority.
+    def _proj_rank(a: WorkflowRoleAssignment) -> int:
+        if project_id is not None and a.project_id == project_id:
+            return 0
+        if a.project_id is None:
+            return 1
+        return 2
+
+    for a in sorted(rows, key=lambda a: (_proj_rank(a), a.priority)):
+        if _proj_rank(a) == 2:
+            continue  # 다른 project scope → 후보 아님
+        # ① effective period
+        if a.effective_from is not None and now < a.effective_from:
+            continue
+        if a.effective_to is not None and now > a.effective_to:
+            continue
+
+        # availability + deputy 대체(②)
+        eff_member, eff_type, original, via_deputy = a.member_id, a.member_type, None, False
+        if a.availability_status in _UNAVAILABLE:
+            if _deputy_allowed(a) and a.deputy_member_id is not None:
+                eff_member = a.deputy_member_id
+                eff_type = a.deputy_member_type or "human"
+                original = a.member_id  # 원 approver 보존
+                via_deputy = True
+            else:
+                continue  # OOO·deputy 불가 → 후보 아님
+
+        # ④ human-gate prefer=human → agent approver 불허
+        if prefer_human and eff_type == "agent":
+            continue
+        # ③ inactive/terminated 제외
+        if not await _member_active(session, eff_member):
+            continue
+        # ⑤ SoD: self-approval forbidden → 다음 후보로 fallback
+        if str(eff_member) in sod_norm:
+            continue
+
+        return ResolvedCandidate(eff_member, eff_type, original, via_deputy, a.id)
+
+    return None  # ⑥ 후보 없음
+
+
+async def resolve_or_mark_unresolved(
+    session: AsyncSession, step_run: WorkflowLineStepRun, role_key: str, *,
+    prefer_human: bool = True, sod_exclude: set[uuid.UUID] | None = None,
+    now: datetime | None = None,
+) -> ResolvedCandidate | None:
+    """resolve_role_candidate + 후보 없으면 step_run 을 unresolved_assignee 로 가시화(⑥·silent prison X).
+
+    후보 해소 시 step_run.resolved_member_id/type 세팅(deputy 면 escalated_to_member_id 에 원 approver
+    보존하지 않고 resolved 에 effective member 기록). 반환: 후보 또는 None.
+    """
+    cand = await resolve_role_candidate(
+        session, step_run.org_id, role_key, project_id=step_run.project_id,
+        prefer_human=prefer_human, sod_exclude=sod_exclude, now=now,
+    )
+    if cand is None:
+        step_run.delivery_status = "unresolved_assignee"  # board badge 소스(silent prison 아님)
+        await session.flush()
+        return None
+    step_run.resolved_member_id = cand.member_id
+    step_run.resolved_member_type = cand.member_type
+    await session.flush()
+    return cand

--- a/backend/app/services/workflow_sla_processor.py
+++ b/backend/app/services/workflow_sla_processor.py
@@ -121,7 +121,8 @@ async def process_sla(session: AsyncSession, now: datetime | None = None) -> dic
         ).order_by(WorkflowLineStepRun.started_at.asc()).with_for_update(skip_locked=True)
     )).scalars().all()
 
-    counts = {"reminded": 0, "escalated": 0, "auto_approved": 0, "kept_pending": 0, "skipped": 0}
+    counts = {"reminded": 0, "escalated": 0, "auto_approved": 0, "kept_pending": 0,
+              "unresolved": 0, "skipped": 0}
     for sr in rows:
         policy = await _resolve_sla_policy(session, sr)
         timeout_h = policy.get("timeout_hours")
@@ -139,7 +140,7 @@ async def process_sla(session: AsyncSession, now: datetime | None = None) -> dic
             # keep_pending(기본) 또는 auto_approve 금지 → 보수적: escalate 1회 후 pending 유지.
             escalate_to = policy.get("escalate_to")
             if escalate_to and sr.escalated_to_member_id is None:
-                target = _resolve_escalation_target(escalate_to)
+                target = await _resolve_escalation(session, sr, escalate_to, now)
                 if target is not None:
                     sr.escalated_to_member_id = target
                     sr.status = "escalated"
@@ -148,6 +149,13 @@ async def process_sla(session: AsyncSession, now: datetime | None = None) -> dic
                     await _notify(session, sr, target, "gate_escalated", "Gate escalated — SLA timeout")
                     counts["escalated"] += 1
                     continue
+                # ⭐S14 fold-in: escalate_to(role/deputy)가 해소 안 되면 silent keep_pending 금지 →
+                # unresolved_assignee 로 가시화(board badge·silent prison 아님·S14 AC⑥).
+                sr.delivery_status = "unresolved_assignee"
+                _record_event(session, sr, "escalated",
+                              payload={"reason": "sla_timeout", "unresolved": True})
+                counts["unresolved"] += 1
+                continue
             counts["kept_pending"] += 1  # ⭐방치 아님·gate 유지(이미 escalate or escalate_to 없음)
             continue
 
@@ -170,13 +178,27 @@ async def process_sla(session: AsyncSession, now: datetime | None = None) -> dic
     return counts
 
 
-def _resolve_escalation_target(escalate_to: Any) -> uuid.UUID | None:
-    """escalate_to 를 member_id 로 해소. MVP: member uuid 직접 지정. role_key 해소는 후속 defer."""
+async def _resolve_escalation(
+    session: AsyncSession, sr: WorkflowLineStepRun, escalate_to: Any, now: datetime,
+) -> uuid.UUID | None:
+    """escalate_to 를 member_id 로 해소.
+
+    UUID(직지정)는 그대로, 비-UUID 는 role_key 로 보고 S14 ``resolve_role_candidate`` 로 deputy/
+    availability/SoD 해소(prefer_human·현 assignee 는 SoD 제외). 미해소면 None → 호출부가
+    unresolved_assignee 로 가시화(silent keep_pending 금지).
+    """
     if isinstance(escalate_to, uuid.UUID):
         return escalate_to
     if isinstance(escalate_to, str):
         try:
-            return uuid.UUID(escalate_to)
+            return uuid.UUID(escalate_to)  # UUID 직지정
         except ValueError:
-            return None  # role_key 등 비-uuid → 후속 Phase(deputy/role resolver)
+            pass  # role_key → resolver
+        from app.services.workflow_role_resolver import resolve_role_candidate
+        sod = {sr.resolved_member_id} if sr.resolved_member_id else set()
+        cand = await resolve_role_candidate(
+            session, sr.org_id, escalate_to, project_id=sr.project_id,
+            prefer_human=True, sod_exclude=sod, now=now,
+        )
+        return cand.member_id if cand is not None else None
     return None

--- a/backend/app/services/workflow_sla_processor.py
+++ b/backend/app/services/workflow_sla_processor.py
@@ -151,10 +151,15 @@ async def process_sla(session: AsyncSession, now: datetime | None = None) -> dic
                     continue
                 # ⭐S14 fold-in: escalate_to(role/deputy)가 해소 안 되면 silent keep_pending 금지 →
                 # unresolved_assignee 로 가시화(board badge·silent prison 아님·S14 AC⑥).
-                sr.delivery_status = "unresolved_assignee"
-                _record_event(session, sr, "escalated",
-                              payload={"reason": "sla_timeout", "unresolved": True})
-                counts["unresolved"] += 1
+                # ⭐멱등(산티아고 SME·S8 동류): cron 재실행마다 append-only escalated(unresolved) event
+                # 중복 기록 방지 — 이미 unresolved 표시됐으면 재기록/재카운트 skip.
+                if sr.delivery_status != "unresolved_assignee":
+                    sr.delivery_status = "unresolved_assignee"
+                    _record_event(session, sr, "escalated",
+                                  payload={"reason": "sla_timeout", "unresolved": True})
+                    counts["unresolved"] += 1
+                else:
+                    counts["kept_pending"] += 1  # 이미 가시화됨·중복 event 0
                 continue
             counts["kept_pending"] += 1  # ⭐방치 아님·gate 유지(이미 escalate or escalate_to 없음)
             continue

--- a/backend/tests/test_edg_s14_role_resolver.py
+++ b/backend/tests/test_edg_s14_role_resolver.py
@@ -256,4 +256,13 @@ async def test_s13_escalation_unresolved_role_visible_not_silent():
         assert c["unresolved"] == 1 and c["escalated"] == 0 and c["kept_pending"] == 0
         row = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id))).scalar_one()
         assert row.delivery_status == "unresolved_assignee"  # silent prison 아님
+
+        # ⭐멱등(산티아고 SME): cron 재실행해도 escalated(unresolved) event 중복 기록 안 함.
+        from app.models.workflow_line import WorkflowLineStepRunEvent
+        c2 = await process_sla(s, now=_NOW)
+        assert c2["unresolved"] == 0 and c2["kept_pending"] == 1  # 재기록 skip
+        evs = (await s.execute(select(WorkflowLineStepRunEvent).where(
+            WorkflowLineStepRunEvent.step_run_id == sr.id,
+            WorkflowLineStepRunEvent.event_type == "escalated"))).scalars().all()
+        assert len(evs) == 1  # append-only event 1개만(중복 0)
     await engine.dispose()

--- a/backend/tests/test_edg_s14_role_resolver.py
+++ b/backend/tests/test_edg_s14_role_resolver.py
@@ -1,0 +1,259 @@
+"""E-DG S14: deputy/availability/SoD role resolver 테스트.
+
+핵심: active/effective-period/availability 필터·OOO+deputy 대체(original 보존)·inactive 제외·
+human-gate agent 불허·SoD self-approval fallback·후보 없음→unresolved_assignee·priority/project 우선.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+_NOW = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _member(s, org, *, is_active=True, mtype="human", proj=None):
+    from app.models.project import Project
+    from app.models.team import TeamMember
+    mid = uuid.uuid4()
+    proj = proj or uuid.uuid4()
+    s.add(Project(id=proj, org_id=org, name="p"))
+    await s.flush()
+    s.add(TeamMember(id=mid, org_id=org, project_id=proj, type=mtype, name="m", is_active=is_active))
+    await s.flush()
+    return mid
+
+
+async def _assign(s, org, role_key, member_id, mtype="human", **kw):
+    from app.models.workflow_line import WorkflowRoleAssignment
+    a = WorkflowRoleAssignment(org_id=org, role_key=role_key, member_id=member_id,
+                               member_type=mtype, **kw)
+    s.add(a)
+    await s.flush()
+    return a
+
+
+async def _seed_sla_run(s, org, sla_policy, *, age_h, from_status="in-review", to_status="done"):
+    """S13 SLA escalation × S14 resolver 통합용: published line + timed-out gate step_run."""
+    from app.models.workflow_line import (
+        WorkflowLineDefinition, WorkflowLineDefinitionVersion, WorkflowLineStepRun)
+    defn = WorkflowLineDefinition(org_id=org, project_id=None, entity_type="story", name="L",
+                                  is_active=True, version=1)
+    s.add(defn)
+    await s.flush()
+    s.add(WorkflowLineDefinitionVersion(
+        line_definition_id=defn.id, org_id=org, project_id=None, entity_type="story", version=1,
+        status="published", config_hash="h", created_by_member_id=uuid.uuid4(),
+        config={"steps": [{"from_status": from_status, "to_status": to_status,
+                           "step_type": "human-gate", "sla_policy": sla_policy}]}))
+    sr = WorkflowLineStepRun(
+        org_id=org, project_id=uuid.uuid4(), line_definition_id=defn.id, entity_type="story",
+        entity_id=uuid.uuid4(), from_status=from_status, to_status=to_status, status="gate_pending",
+        mode="gate_pending", correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex,
+        started_at=_NOW - timedelta(hours=age_h))
+    s.add(sr)
+    await s.flush()
+    return sr
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_basic_active_available_resolves():
+    from app.services.workflow_role_resolver import resolve_role_candidate
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        m = await _member(s, org)
+        await _assign(s, org, "reviewer", m)
+        cand = await resolve_role_candidate(s, org, "reviewer", now=_NOW)
+        assert cand is not None and cand.member_id == m and not cand.via_deputy
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_effective_period_filters_out():
+    from app.services.workflow_role_resolver import resolve_role_candidate
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        m = await _member(s, org)
+        await _assign(s, org, "reviewer", m, effective_from=_NOW + timedelta(days=1))  # 미래
+        assert await resolve_role_candidate(s, org, "reviewer", now=_NOW) is None
+        m2 = await _member(s, org)
+        await _assign(s, org, "rev2", m2, effective_to=_NOW - timedelta(days=1))  # 만료
+        assert await resolve_role_candidate(s, org, "rev2", now=_NOW) is None
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_ooo_with_deputy_substitutes_and_preserves_original():
+    from app.services.workflow_role_resolver import resolve_role_candidate
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        owner = await _member(s, org)
+        deputy = await _member(s, org)
+        await _assign(s, org, "reviewer", owner, availability_status="ooo",
+                      deputy_member_id=deputy, deputy_member_type="human",
+                      delegation_policy={"deputy_allowed": True})
+        cand = await resolve_role_candidate(s, org, "reviewer", now=_NOW)
+        assert cand.member_id == deputy and cand.via_deputy is True
+        assert cand.original_approver_member_id == owner  # ② 원 approver 보존
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_ooo_without_deputy_excluded():
+    from app.services.workflow_role_resolver import resolve_role_candidate
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        owner = await _member(s, org)
+        await _assign(s, org, "reviewer", owner, availability_status="ooo",
+                      delegation_policy={"deputy_allowed": False})
+        assert await resolve_role_candidate(s, org, "reviewer", now=_NOW) is None
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_inactive_member_excluded():
+    from app.services.workflow_role_resolver import resolve_role_candidate
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        m = await _member(s, org, is_active=False)  # terminated/inactive
+        await _assign(s, org, "reviewer", m)
+        assert await resolve_role_candidate(s, org, "reviewer", now=_NOW) is None
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_agent_approver_blocked_for_human_gate():
+    from app.services.workflow_role_resolver import resolve_role_candidate
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        agent = await _member(s, org, mtype="agent")
+        await _assign(s, org, "reviewer", agent, mtype="agent")
+        assert await resolve_role_candidate(s, org, "reviewer", prefer_human=True, now=_NOW) is None
+        # prefer_human=False 면 허용
+        c = await resolve_role_candidate(s, org, "reviewer", prefer_human=False, now=_NOW)
+        assert c is not None and c.member_id == agent
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_sod_self_approval_falls_back_to_next():
+    from app.services.workflow_role_resolver import resolve_role_candidate
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        author = await _member(s, org)
+        other = await _member(s, org)
+        await _assign(s, org, "reviewer", author, priority=10)   # 1순위지만 SoD 제외
+        await _assign(s, org, "reviewer", other, priority=20)    # fallback
+        cand = await resolve_role_candidate(s, org, "reviewer", sod_exclude={author}, now=_NOW)
+        assert cand is not None and cand.member_id == other  # ⑤ self-approval fallback
+        # author 만 있으면 후보 없음
+        cand2 = await resolve_role_candidate(s, org, "rev_solo", sod_exclude={author}, now=_NOW)
+        assert cand2 is None
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_priority_order_and_unresolved_marks_step_run():
+    from app.services.workflow_role_resolver import resolve_role_candidate, resolve_or_mark_unresolved
+    from app.models.workflow_line import WorkflowLineStepRun
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        lo = await _member(s, org)
+        hi = await _member(s, org)
+        await _assign(s, org, "reviewer", hi, priority=50)
+        await _assign(s, org, "reviewer", lo, priority=5)  # 더 낮은 숫자=우선
+        cand = await resolve_role_candidate(s, org, "reviewer", now=_NOW)
+        assert cand.member_id == lo  # priority 5 우선
+        # 후보 없는 role → resolve_or_mark_unresolved 가 step_run 가시화(⑥)
+        sr = WorkflowLineStepRun(
+            org_id=org, project_id=uuid.uuid4(), entity_type="story", entity_id=uuid.uuid4(),
+            from_status="in-review", to_status="done", status="gate_pending", mode="gate_pending",
+            correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex)
+        s.add(sr)
+        await s.flush()
+        out = await resolve_or_mark_unresolved(s, sr, "no_such_role", now=_NOW)
+        assert out is None and sr.delivery_status == "unresolved_assignee"
+    await engine.dispose()
+
+
+# ── S13 SLA escalation × S14 resolver 통합(fold-in) ──────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_s13_escalation_resolves_role_key_via_s14_resolver():
+    """⭐fold-in: S13 SLA escalate_to=role_key → S14 resolver 로 해소(silent keep_pending 금지)."""
+    import sqlalchemy as sa
+    from app.services.workflow_sla_processor import process_sla
+    from app.models.workflow_line import WorkflowLineStepRun
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        await s.execute(sa.text("TRUNCATE workflow_line_step_runs CASCADE"))  # process_sla 전역 스캔 격리
+        org = uuid.uuid4()
+        deputy = await _member(s, org)
+        await _assign(s, org, "manager", deputy)  # role_key='manager' → deputy
+        sr = await _seed_sla_run(s, org, {"timeout_hours": 4, "escalate_to": "manager"}, age_h=10)
+        c = await process_sla(s, now=_NOW)
+        assert c["escalated"] == 1 and c["unresolved"] == 0
+        row = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id))).scalar_one()
+        assert row.escalated_to_member_id == deputy and row.status == "escalated"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_s13_escalation_unresolved_role_visible_not_silent():
+    """⭐fold-in: role_key 후보 없으면 silent keep_pending 금지 → unresolved_assignee 가시화."""
+    import sqlalchemy as sa
+    from app.services.workflow_sla_processor import process_sla
+    from app.models.workflow_line import WorkflowLineStepRun
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        await s.execute(sa.text("TRUNCATE workflow_line_step_runs CASCADE"))
+        org = uuid.uuid4()
+        sr = await _seed_sla_run(s, org, {"timeout_hours": 4, "escalate_to": "no_role"}, age_h=10)
+        c = await process_sla(s, now=_NOW)
+        assert c["unresolved"] == 1 and c["escalated"] == 0 and c["kept_pending"] == 0
+        row = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id))).scalar_one()
+        assert row.delivery_status == "unresolved_assignee"  # silent prison 아님
+    await engine.dispose()


### PR DESCRIPTION
## E-DECISION-GATE S14 — Deputy / availability / SoD role resolver (P1-3)

스토리 `46102a42` · 5pt · 의존 S1·S9(merged) · 비-lane(디디 + 까심 QA + PO). **마이그 없음**(0126 `workflow_role_assignments` 재사용).

OOO/inactive approver 가 pending prison 을 만들지 않게 + self-approval(SoD) 차단.

### 변경
- `app/models/workflow_line.py` — **`WorkflowRoleAssignment` ORM**(0126 미러·신설·`metadata` 예약어 attr 우회).
- `app/services/workflow_role_resolver.py` (신규) — `resolve_role_candidate`:
  - ① active/effective-period/availability 필터.
  - ② `availability=ooo` & `deputy_allowed` → **deputy 대체 + `original_approver_member_id` 보존**.
  - ③ inactive/terminated(TeamMember.is_active) 제외.
  - ④ human-gate `prefer=human` → **agent approver 불허**.
  - ⑤ ⭐**SoD**: requested_by/assignee/implementation 동일 approver → 다음 후보 fallback.
  - priority asc · project 우선(project match→org-level NULL→타 project 제외).
  - `resolve_or_mark_unresolved`: 후보 없으면 `delivery_status='unresolved_assignee'` 가시화(⑥·silent prison 아님).
- ⭐**S13 fold-in**(산티아고 SME·PO 재분류) — `workflow_sla_processor` escalation 을 resolver 에 배선: `escalate_to` UUID-direct 유지 + **role_key → `resolve_role_candidate`**(deputy/availability/SoD). role 미해소 시 **silent keep_pending 금지 → `unresolved_assignee` 가시화**.

### 테스트 (16/16 PASS · 실 PG)
- S14(10): basic·effective-period·ooo+deputy(original 보존)·ooo-no-deputy·inactive·agent-block(prefer_human)·SoD-fallback·priority+unresolved.
- ⭐**S13×S14 통합 회귀(2)**: escalate_to role_key→resolver 해소(escalated)·role 미해소→unresolved_assignee(silent 아님).
- S13 회귀(6): SLA processor 무회귀(배선 후에도 reminder/escalate/timeout 정상).

### 비고 (⑦ governance)
deputy/delegation 변경의 effective-period 는 resolver 가 honor(①). owner-approval governance(write-path)는 별도 config 경로 — 본 PR 은 read resolver + S13 fold-in 범위.

🤖 Generated with [Claude Code](https://claude.com/claude-code)