### PR TITLE
[E-DG] workflow-line status 배치 read 엔드포인트 (S11 FE unblock)

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -28,7 +28,12 @@ from app.services.verdict_capture import resolve_implementation_participation
 from app.services.notification_dispatch import dispatch_notification
 from app.services.story_status_events import emit_story_status_changed
 from app.services.webhook_dispatch import fire_webhooks
-from app.services.workflow_line_status import WorkflowLineStatusResponse, build_workflow_line_status
+from app.services.workflow_line_status import (
+    LineStatusSummary,
+    WorkflowLineStatusResponse,
+    build_workflow_line_status,
+    build_workflow_line_status_batch,
+)
 from app.services.workflow_pipeline import process_event
 from app.services.rule_evaluator import EventContext
 from app.services.workflow_violation import build_violation_event, check_transition
@@ -248,6 +253,25 @@ async def create_story(
         title=story.title,
     )
     return StoryResponse.model_validate(story)
+
+
+# E-DG S11 FE unblock: 보드 카드 badge 용 배치 read — per-story fetch N+1 회피(gates 배치 패턴
+# 미러·1 fetch+map). ⚠️ /{id} 보다 **먼저** 선언(specific-before-parameterized). active-only 요약
+# (mode/status + engine_degraded/grandfathered/handoff_stuck + delivery_status)·org-scoped·N+1 0.
+@router.get("/workflow-line/status", response_model=list[LineStatusSummary])
+async def get_workflow_line_status_batch(
+    ids: str = Query(..., description="comma-separated story ids"),
+    repo: StoryRepository = Depends(_get_repo),
+) -> list[LineStatusSummary]:
+    try:
+        story_ids = [uuid.UUID(x) for x in ids.split(",") if x.strip()]
+    except ValueError:
+        raise HTTPException(status_code=422, detail="invalid story id in ids")
+    if not story_ids:
+        return []
+    if len(story_ids) > 200:  # 보드 페이지 단위 방어(과대 IN 금지)
+        raise HTTPException(status_code=422, detail="too many ids (max 200)")
+    return await build_workflow_line_status_batch(repo.session, repo.org_id, story_ids)
 
 
 @router.get("/{id}", response_model=StoryResponse)

--- a/backend/app/services/workflow_line_status.py
+++ b/backend/app/services/workflow_line_status.py
@@ -85,6 +85,18 @@ class WorkflowLineStatusResponse(BaseModel):
     history: list[HistoryItem] = []
 
 
+class LineStatusSummary(BaseModel):
+    """보드 카드 badge 용 경량 요약(배치). full StepRunView/history 없이 flag 만."""
+    story_id: uuid.UUID
+    has_active: bool
+    mode: str | None = None
+    status: str | None = None
+    engine_degraded: bool = False
+    grandfathered: bool = False
+    handoff_stuck: bool = False
+    delivery_status: str | None = None
+
+
 def _degraded_flags(run: WorkflowLineStepRun) -> tuple[bool, bool, str | None]:
     """(engine_degraded, grandfathered, note) 도출."""
     engine_degraded = bool(run.degraded_to_plain) or (run.failure_class in _DEGRADED_FAILURE_CLASSES)
@@ -196,3 +208,42 @@ async def build_workflow_line_status(
         h1_evidence=h1_evidence, approvers=approvers, last_event=last_event,
     )
     return WorkflowLineStatusResponse(story_id=story_id, has_active=True, active=view)
+
+
+async def build_workflow_line_status_batch(
+    session: AsyncSession, org_id: uuid.UUID, story_ids: list[uuid.UUID],
+) -> list[LineStatusSummary]:
+    """여러 story 의 line-status 경량 요약(보드 badge 용). 단일 쿼리·N+1 0.
+
+    ⭐active-only(open status) + entity_id IN (ids) 1쿼리(unbounded .all() 금지·ids 가 bound·S10 교훈).
+    story 당 가장 최근 active run 1건으로 요약하고, run 없는 story 는 has_active=False 로 반환한다.
+    handoff_stuck = delivery_status=='timed_out'(S8 watchdog 가 stuck 을 timed_out 으로 기록).
+    """
+    if not story_ids:
+        return []
+    rows = (await session.execute(
+        select(WorkflowLineStepRun).where(
+            WorkflowLineStepRun.org_id == org_id,
+            WorkflowLineStepRun.entity_type == "story",
+            WorkflowLineStepRun.entity_id.in_(story_ids),
+            WorkflowLineStepRun.status.in_(_OPEN_STEP_RUN_STATUSES),
+        ).order_by(WorkflowLineStepRun.started_at.desc())
+    )).scalars().all()
+
+    latest: dict[uuid.UUID, WorkflowLineStepRun] = {}
+    for r in rows:  # started_at desc → story 당 첫 등장이 최신
+        latest.setdefault(r.entity_id, r)
+
+    out: list[LineStatusSummary] = []
+    for sid in story_ids:
+        r = latest.get(sid)
+        if r is None:
+            out.append(LineStatusSummary(story_id=sid, has_active=False))
+            continue
+        engine_degraded, grandfathered, _ = _degraded_flags(r)
+        out.append(LineStatusSummary(
+            story_id=sid, has_active=True, mode=r.mode, status=r.status,
+            engine_degraded=engine_degraded, grandfathered=grandfathered,
+            handoff_stuck=(r.delivery_status == "timed_out"), delivery_status=r.delivery_status,
+        ))
+    return out

--- a/backend/tests/test_edg_batch_line_status.py
+++ b/backend/tests/test_edg_batch_line_status.py
@@ -1,0 +1,114 @@
+"""E-DG S11-unblock: workflow-line status 배치 read 테스트.
+
+핵심: 여러 story 의 active 요약(mode/status+flags+delivery_status)·run 없거나 terminal-only 면
+has_active=False·handoff_stuck(timed_out)·engine_degraded/grandfathered·story_ids 순서 보존·N+1 0.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _run(s, org, story_id, *, status="gate_pending", mode="advisory_only", **kw):
+    from app.models.workflow_line import WorkflowLineStepRun
+    sr = WorkflowLineStepRun(
+        org_id=org, project_id=uuid.uuid4(), entity_type="story", entity_id=story_id,
+        from_status="in-review", to_status="done", status=status, mode=mode,
+        correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex, **kw)
+    s.add(sr)
+    await s.flush()
+    return sr
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_batch_summary_active_and_missing():
+    from app.services.workflow_line_status import build_workflow_line_status_batch
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        s1, s2, s3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        await _run(s, org, s1, status="gate_pending", delivery_status="not_required")
+        await _run(s, org, s2, status="applied")  # terminal-only → has_active=False
+        # s3: run 없음
+        res = await build_workflow_line_status_batch(s, org, [s1, s2, s3])
+        by_id = {r.story_id: r for r in res}
+        assert by_id[s1].has_active is True and by_id[s1].status == "gate_pending"
+        assert by_id[s2].has_active is False  # terminal-only(active 아님)
+        assert by_id[s3].has_active is False  # run 없음
+        # ⭐순서 보존(story_ids 순)
+        assert [r.story_id for r in res] == [s1, s2, s3]
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_batch_handoff_stuck_and_degraded_flags():
+    from app.services.workflow_line_status import build_workflow_line_status_batch
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        stuck, degraded, grand = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        await _run(s, org, stuck, status="dispatched", delivery_status="timed_out")  # handoff_stuck
+        await _run(s, org, degraded, status="gate_pending", degraded_to_plain=True)
+        await _run(s, org, grand, status="gate_pending", mode="plain_transition")
+        res = {r.story_id: r for r in
+               await build_workflow_line_status_batch(s, org, [stuck, degraded, grand])}
+        assert res[stuck].handoff_stuck is True and res[stuck].delivery_status == "timed_out"
+        assert res[degraded].engine_degraded is True
+        assert res[grand].grandfathered is True
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_batch_latest_active_per_story_and_org_scope():
+    from app.services.workflow_line_status import build_workflow_line_status_batch
+    from datetime import datetime, timedelta, timezone
+    engine, Session = await _session()
+    async with Session() as s:
+        org, other_org = uuid.uuid4(), uuid.uuid4()
+        sid = uuid.uuid4()
+        now = datetime(2026, 6, 19, tzinfo=timezone.utc)
+        await _run(s, org, sid, status="gate_pending", started_at=now - timedelta(hours=5))
+        await _run(s, org, sid, status="waiting_gate", started_at=now - timedelta(hours=1))  # 최신
+        # 다른 org 의 동일 story id run → org-scope 로 제외돼야
+        await _run(s, other_org, sid, status="escalated")
+        res = await build_workflow_line_status_batch(s, org, [sid])
+        assert len(res) == 1 and res[0].status == "waiting_gate"  # 최신 active·타 org 미혼입
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_batch_empty_ids():
+    from app.services.workflow_line_status import build_workflow_line_status_batch
+    engine, Session = await _session()
+    async with Session() as s:
+        assert await build_workflow_line_status_batch(s, uuid.uuid4(), []) == []
+    await engine.dispose()


### PR DESCRIPTION
## E-DG — Workflow-line status 배치 read (S11 FE 카드 badge unblock)

PO 요청(비-lane interleave) · **마이그 없음·read-only** · 기존 `workflow_line_status` 서비스 재사용.

보드 카드 badge 가 per-story `/{id}/workflow-line/status` fetch 시 N+1(20~50카드, BE no-N+1 원칙 역행). gates 배치 패턴 미러로 1 fetch+map.

### 변경
- `GET /api/v2/stories/workflow-line/status?ids=a,b,c` (comma-sep) — `/{id}` 보다 **먼저 선언**(specific-before-parameterized). 기존 `_get_repo` org-scoped auth 재사용·max 200 ids·422 on invalid.
- `workflow_line_status.build_workflow_line_status_batch` — **active-only(open status) + `entity_id IN (ids)` 단일 쿼리**(unbounded `.all()` 금지·ids bound·S10 교훈)·**N+1 0**. story 당 최신 active 1건 요약: `mode`/`status` + `engine_degraded`/`grandfathered`/`handoff_stuck` flag + `delivery_status`(full StepRunView/history 불요). run 없거나 terminal-only → `has_active=False`.
- `handoff_stuck = delivery_status=='timed_out'`(S8 watchdog).
- `LineStatusSummary` 경량 응답 모델.

### 테스트 (4/4 PASS · 실 PG)
- active/missing/terminal-only(has_active 분기·순서 보존)
- handoff_stuck/engine_degraded/grandfathered flag
- 최신 active per story + **org-scope**(타 org 동일 story id run 미혼입)
- empty ids → []

FE(유나/미르코) ① 카드 badge 가 소비. 까심 QA 부탁하는.

🤖 Generated with [Claude Code](https://claude.com/claude-code)