### PR TITLE
[S12-BE] recipient_agent (Gap1) + fallback-notify endpoint (Gap2)

### DIFF
--- a/backend/app/models/workflow_line.py
+++ b/backend/app/models/workflow_line.py
@@ -187,6 +187,7 @@ class WorkflowLineStepApproval(Base):
 # S13 SLA processor 가 기록하는 append-only audit event type.
 STEP_RUN_EVENT_TYPES = frozenset({
     "status_apply", "dispatch_create", "wake", "reminded", "escalated", "sla_timeout", "auto_approved",
+    "fallback_notified",  # S12 Gap2: stuck handoff fallback human notification(idempotent marker)
 })
 
 

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -300,6 +300,28 @@ async def get_workflow_line_status(
     return await build_workflow_line_status(repo.session, repo.org_id, id)
 
 
+class FallbackNotifyRequest(BaseModel):
+    step_run_id: uuid.UUID
+
+
+# E-DG S12 Gap2: stuck handoff fallback human notification. 기존 _get_repo org-scoped auth·없는
+# story 404·dispatch_notification 재사용·idempotent(run당 1회·already_notified)·status rollback 0.
+@router.post("/{id}/workflow-line/fallback-notify")
+async def workflow_line_fallback_notify(
+    id: uuid.UUID,
+    body: FallbackNotifyRequest,
+    repo: StoryRepository = Depends(_get_repo),
+) -> dict:
+    story = await repo.get(id)
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+    from app.services.workflow_fallback_notify import fallback_notify
+    result = await fallback_notify(repo.session, repo.org_id, id, body.step_run_id)
+    if result.get("status") == "not_found":
+        raise HTTPException(status_code=404, detail="step_run not found for this story")
+    return result
+
+
 class BulkUpdateItem(BaseModel):
     id: uuid.UUID
     status: str | None = None

--- a/backend/app/services/workflow_fallback_notify.py
+++ b/backend/app/services/workflow_fallback_notify.py
@@ -1,0 +1,80 @@
+"""E-DECISION-GATE S12 Gap2: stuck handoff fallback human notification.
+
+stuck(timed_out) agent handoff 을 휴먼이 개입하도록 fallback 통지한다. 기존 ``dispatch_notification``
+재사용·human owner(= project active human member)에게 발송.
+
+⭐idempotent(run당 1회): step_run 단위 advisory lock + ``fallback_notified`` step_run_event marker
+로 동시/재호출 시 ``already_notified``(check-then-insert TOCTOU 회피·[[feedback_check_then_insert_toctou]]).
+⭐status 안 되돌림 — step_run/story status 미변경(통지 audit marker 만).
+"""
+import uuid
+
+import sqlalchemy as sa
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.team import TeamMember
+from app.models.workflow_line import WorkflowLineStepRun, WorkflowLineStepRunEvent
+
+_FALLBACK_EVENT = "fallback_notified"
+
+
+async def fallback_notify(
+    session: AsyncSession, org_id: uuid.UUID, story_id: uuid.UUID, step_run_id: uuid.UUID,
+) -> dict:
+    """stuck handoff 의 fallback human 통지(idempotent·status rollback 0). 반환 status: notified|
+    already_notified|not_found."""
+    sr = (await session.execute(
+        select(WorkflowLineStepRun).where(
+            WorkflowLineStepRun.id == step_run_id,
+            WorkflowLineStepRun.org_id == org_id,
+            WorkflowLineStepRun.entity_type == "story",
+            WorkflowLineStepRun.entity_id == story_id,
+        )
+    )).scalar_one_or_none()
+    if sr is None:
+        return {"status": "not_found", "notified": False}
+
+    # ⭐step_run 단위 advisory lock(tx-scoped) — 동시 호출 직렬화로 중복 통지 0(TOCTOU 회피).
+    await session.execute(
+        sa.text("SELECT pg_advisory_xact_lock(hashtext(:k))"),
+        {"k": f"wf_fallback_notify:{step_run_id}"},
+    )
+    existing = (await session.execute(
+        select(WorkflowLineStepRunEvent.id).where(
+            WorkflowLineStepRunEvent.step_run_id == step_run_id,
+            WorkflowLineStepRunEvent.event_type == _FALLBACK_EVENT,
+        ).limit(1)
+    )).scalar_one_or_none()
+    if existing is not None:
+        return {"status": "already_notified", "notified": False}
+
+    # human owner = project active human member(들). Story/Project 에 owner 컬럼이 없어 휴먼 멤버로 해소.
+    targets = (await session.execute(
+        select(TeamMember.id).where(
+            TeamMember.org_id == org_id,
+            TeamMember.project_id == sr.project_id,
+            TeamMember.type == "human",
+            TeamMember.is_active.is_(True),
+        )
+    )).scalars().all()
+
+    if targets:
+        from app.services.notification_dispatch import dispatch_notification
+        await dispatch_notification(
+            session, org_id=org_id, event_type="handoff_fallback",
+            target_member_ids=list(targets),
+            title="Stuck handoff — fallback to human",
+            body=f"{sr.entity_type} {story_id} agent handoff stalled — human intervention requested",
+            reference_type="story", reference_id=story_id,
+        )
+
+    # idempotent marker(통지 0명이어도 기록 — 재통지 방지). ⭐status 변경 없음(rollback 0).
+    session.add(WorkflowLineStepRunEvent(
+        org_id=org_id, project_id=sr.project_id, step_run_id=step_run_id,
+        event_type=_FALLBACK_EVENT, payload={"target_count": len(targets)},
+        correlation_id=sr.correlation_id,
+    ))
+    await session.flush()
+    await session.commit()
+    return {"status": "notified", "notified": True, "target_count": len(targets)}

--- a/backend/app/services/workflow_line_status.py
+++ b/backend/app/services/workflow_line_status.py
@@ -44,6 +44,13 @@ class LastEventView(BaseModel):
     created_at: Any = None
 
 
+class RecipientAgentView(BaseModel):
+    """S12 Gap1: stuck handoff 의 막힌 recipient(dispatch event recipient 기반·assignee 파생 아님)."""
+    id: uuid.UUID
+    name: str | None = None
+    type: str | None = None
+
+
 class StepRunView(BaseModel):
     id: uuid.UUID
     status: str
@@ -65,6 +72,7 @@ class StepRunView(BaseModel):
     h1_evidence: dict[str, Any] | None = None
     approvers: list[ApproverView] = []
     last_event: LastEventView | None = None
+    recipient_agent: RecipientAgentView | None = None  # S12 Gap1: 막힌 agent(event recipient)
 
 
 class HistoryItem(BaseModel):
@@ -95,6 +103,7 @@ class LineStatusSummary(BaseModel):
     grandfathered: bool = False
     handoff_stuck: bool = False
     delivery_status: str | None = None
+    recipient_agent: RecipientAgentView | None = None  # S12 Gap1: 막힌 agent(event recipient)
 
 
 def _degraded_flags(run: WorkflowLineStepRun) -> tuple[bool, bool, str | None]:
@@ -187,6 +196,7 @@ async def build_workflow_line_status(
         ]
 
     last_event = None
+    recipient_agent = None
     if active.event_id is not None:
         ev = (await session.execute(
             select(Event).where(Event.id == active.event_id)
@@ -196,6 +206,8 @@ async def build_workflow_line_status(
                 id=ev.id, event_type=ev.event_type, recipient_seq=ev.recipient_seq,
                 status=ev.status, created_at=ev.created_at,
             )
+            # S12 Gap1: 막힌 recipient agent(event recipient 기반·assignee 파생 X).
+            recipient_agent = await _resolve_recipient_agent(session, ev.recipient_id)
 
     engine_degraded, grandfathered, note = _degraded_flags(active)
     view = StepRunView(
@@ -205,9 +217,22 @@ async def build_workflow_line_status(
         delivery_status=active.delivery_status, delivery_error=active.delivery_error,
         correlation_id=active.correlation_id, sla_due_at=active.sla_due_at, started_at=active.started_at,
         engine_degraded=engine_degraded, grandfathered=grandfathered, observability_note=note,
-        h1_evidence=h1_evidence, approvers=approvers, last_event=last_event,
+        h1_evidence=h1_evidence, approvers=approvers, last_event=last_event, recipient_agent=recipient_agent,
     )
     return WorkflowLineStatusResponse(story_id=story_id, has_active=True, active=view)
+
+
+async def _resolve_recipient_agent(
+    session: AsyncSession, recipient_id: uuid.UUID | None,
+) -> RecipientAgentView | None:
+    """event recipient_id → TeamMember(id/name/type). 없으면 id만(FE 폴백 '에이전트')."""
+    if recipient_id is None:
+        return None
+    from app.models.team import TeamMember
+    m = await session.get(TeamMember, recipient_id)
+    if m is None:
+        return RecipientAgentView(id=recipient_id)
+    return RecipientAgentView(id=recipient_id, name=m.name, type=m.type)
 
 
 async def build_workflow_line_status_batch(
@@ -234,6 +259,30 @@ async def build_workflow_line_status_batch(
     for r in rows:  # started_at desc → story 당 첫 등장이 최신
         latest.setdefault(r.entity_id, r)
 
+    # S12 Gap1: recipient_agent 배치 해소(N+1 0) — event_ids→Event.recipient_id, recipient_ids→
+    # TeamMember 를 각 1쿼리(IN). per-run 추가 fetch 없음.
+    agent_by_run: dict[uuid.UUID, RecipientAgentView] = {}
+    event_ids = [r.event_id for r in latest.values() if r.event_id is not None]
+    if event_ids:
+        from app.models.team import TeamMember
+        evs = (await session.execute(
+            select(Event.id, Event.recipient_id).where(Event.id.in_(event_ids))
+        )).all()
+        ev_recipient = {eid: rid for eid, rid in evs}
+        rids = [rid for rid in ev_recipient.values() if rid is not None]
+        members = {}
+        if rids:
+            members = {m.id: m for m in (await session.execute(
+                select(TeamMember).where(TeamMember.id.in_(rids))
+            )).scalars().all()}
+        for r in latest.values():
+            rid = ev_recipient.get(r.event_id) if r.event_id is not None else None
+            if rid is None:
+                continue
+            m = members.get(rid)
+            agent_by_run[r.id] = (RecipientAgentView(id=rid, name=m.name, type=m.type)
+                                  if m is not None else RecipientAgentView(id=rid))
+
     out: list[LineStatusSummary] = []
     for sid in story_ids:
         r = latest.get(sid)
@@ -245,5 +294,6 @@ async def build_workflow_line_status_batch(
             story_id=sid, has_active=True, mode=r.mode, status=r.status,
             engine_degraded=engine_degraded, grandfathered=grandfathered,
             handoff_stuck=(r.delivery_status == "timed_out"), delivery_status=r.delivery_status,
+            recipient_agent=agent_by_run.get(r.id),
         ))
     return out

--- a/backend/tests/test_edg_s12be_recipient_fallback.py
+++ b/backend/tests/test_edg_s12be_recipient_fallback.py
@@ -1,0 +1,174 @@
+"""E-DG S12 BE: recipient_agent 노출(Gap1) + fallback-notify(Gap2) 테스트.
+
+Gap1: 단건/배치 status 에 recipient_agent(event recipient 기반·member 없으면 id-only).
+Gap2: fallback_notify(project human 통지 + marker)·idempotent(already_notified)·not_found·status rollback 0.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+_NOTIFY = "app.services.notification_dispatch.dispatch_notification"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _member(s, org, proj, *, mtype="agent", name="rcpt", is_active=True):
+    from app.models.team import TeamMember
+    mid = uuid.uuid4()
+    s.add(TeamMember(id=mid, org_id=org, project_id=proj, type=mtype, name=name, is_active=is_active))
+    await s.flush()
+    return mid
+
+
+async def _run_with_event(s, org, proj, *, recipient_id=None, with_member=True, status="dispatched"):
+    from app.models.event import Event
+    from app.models.workflow_line import WorkflowLineStepRun
+    if recipient_id is None:
+        recipient_id = (await _member(s, org, proj, mtype="agent", name="에이전트A")) if with_member else uuid.uuid4()
+    ev = Event(org_id=org, project_id=proj, event_type="dispatched", source_entity_type="story",
+               source_entity_id=uuid.uuid4(), recipient_id=recipient_id, recipient_type="agent",
+               payload={}, status="pending", recipient_seq=7)
+    s.add(ev)
+    await s.flush()
+    story_id = uuid.uuid4()
+    sr = WorkflowLineStepRun(
+        org_id=org, project_id=proj, entity_type="story", entity_id=story_id,
+        from_status="in-review", to_status="done", status=status, mode="advisory_only",
+        delivery_status="timed_out", event_id=ev.id, recipient_seq=7,
+        correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex)
+    s.add(sr)
+    await s.flush()
+    return sr, story_id, recipient_id
+
+
+async def _project(s, org):
+    from app.models.project import Project
+    proj = uuid.uuid4()
+    s.add(Project(id=proj, org_id=org, name="p"))
+    await s.flush()
+    return proj
+
+
+# ── Gap1: recipient_agent ────────────────────────────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_single_status_exposes_recipient_agent():
+    from app.services.workflow_line_status import build_workflow_line_status
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        proj = await _project(s, org)
+        sr, story_id, rid = await _run_with_event(s, org, proj, status="dispatched")
+        res = await build_workflow_line_status(s, org, story_id)
+        assert res.active is not None and res.active.recipient_agent is not None
+        assert res.active.recipient_agent.id == rid
+        assert res.active.recipient_agent.name == "에이전트A" and res.active.recipient_agent.type == "agent"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_recipient_agent_id_only_when_member_missing():
+    # events.recipient_id 는 team_members FK 라 'member 없는 recipient' 는 단위로 검증한다
+    # (_resolve_recipient_agent 가 session.get None → id-only 반환·FE '에이전트' 폴백).
+    from app.services.workflow_line_status import _resolve_recipient_agent
+    engine, Session = await _session()
+    async with Session() as s:
+        orphan = uuid.uuid4()
+        ra = await _resolve_recipient_agent(s, orphan)
+        assert ra is not None and ra.id == orphan and ra.name is None  # id-only(FE '에이전트' 폴백)
+        assert await _resolve_recipient_agent(s, None) is None
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_batch_status_exposes_recipient_agent_no_nplus1():
+    from app.services.workflow_line_status import build_workflow_line_status_batch
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        proj = await _project(s, org)
+        sr, story_id, rid = await _run_with_event(s, org, proj, status="dispatched")
+        res = await build_workflow_line_status_batch(s, org, [story_id])
+        assert len(res) == 1 and res[0].has_active
+        assert res[0].recipient_agent is not None and res[0].recipient_agent.id == rid
+        assert res[0].recipient_agent.name == "에이전트A" and res[0].handoff_stuck is True
+    await engine.dispose()
+
+
+# ── Gap2: fallback-notify ─────────────────────────────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_fallback_notify_notifies_humans_and_idempotent():
+    from app.services.workflow_fallback_notify import fallback_notify
+    from app.models.workflow_line import WorkflowLineStepRunEvent
+    from sqlalchemy import select, func
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        proj = await _project(s, org)
+        sr, story_id, _ = await _run_with_event(s, org, proj)
+        await _member(s, org, proj, mtype="human", name="owner")   # human owner
+        await _member(s, org, proj, mtype="agent", name="bot")     # agent(제외)
+        await s.commit()
+        with patch(_NOTIFY, new=AsyncMock()) as notify:
+            r1 = await fallback_notify(s, org, story_id, sr.id)
+        assert r1["status"] == "notified" and r1["target_count"] == 1  # human 1명만
+        assert notify.await_count == 1
+        # idempotent: 2nd 호출 → already_notified·재통지 0·marker 1개
+        with patch(_NOTIFY, new=AsyncMock()) as notify2:
+            r2 = await fallback_notify(s, org, story_id, sr.id)
+        assert r2["status"] == "already_notified" and notify2.await_count == 0
+        n = (await s.execute(select(func.count()).select_from(WorkflowLineStepRunEvent).where(
+            WorkflowLineStepRunEvent.step_run_id == sr.id,
+            WorkflowLineStepRunEvent.event_type == "fallback_notified"))).scalar()
+        assert n == 1  # marker 정확히 1개
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_fallback_notify_not_found_and_no_status_rollback():
+    from app.services.workflow_fallback_notify import fallback_notify
+    from app.models.workflow_line import WorkflowLineStepRun
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        proj = await _project(s, org)
+        sr, story_id, _ = await _run_with_event(s, org, proj, status="dispatched")
+        await s.commit()
+        # not_found: 엉뚱한 step_run_id
+        r = await fallback_notify(s, org, story_id, uuid.uuid4())
+        assert r["status"] == "not_found"
+        # ⭐status rollback 0: 통지해도 step_run.status 불변
+        with patch(_NOTIFY, new=AsyncMock()):
+            await fallback_notify(s, org, story_id, sr.id)
+        row = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id))).scalar_one()
+        assert row.status == "dispatched"  # 미변경(rollback/전이 없음)
+    await engine.dispose()


### PR DESCRIPTION
## E-DG S12 BE — recipient_agent 노출(Gap1) + fallback-notify(Gap2)

FE S12(#1613·handoff stuck UX)의 BE 의존 2건. FE 가 forward-compat(`recipient_agent?`·fallback 프록시 404 graceful)로 대기 중 — 이 BE 로 액션 완성. 산티아고 gateway SME 동석. **마이그 없음**.

### Gap1 — recipient_agent(막힌 agent) 노출
- `StepRunView`(단건) + `LineStatusSummary`(배치)에 `recipient_agent{id/name/type}` 추가.
- ⭐**event recipient_id → TeamMember 해소**(assignee 파생 X·실 막힌 recipient 정확). member 없으면 id-only(FE '에이전트' 폴백). 배치는 `event_ids`/`recipient_ids` IN 2쿼리로 **N+1 0**.

### Gap2 — fallback-notify endpoint
- `POST /api/v2/stories/{id}/workflow-line/fallback-notify` `{step_run_id}` — 기존 `_get_repo` org-scoped auth·없는 story/step_run 404.
- `workflow_fallback_notify.fallback_notify`: **human owner(project active human member)**에게 `dispatch_notification` 재사용 통지. ⭐**idempotent** — step_run 단위 `pg_advisory_xact_lock` + `fallback_notified` step_run_event marker(run당 1회·재호출 `already_notified`·TOCTOU 회피). ⭐**status rollback 0**(step_run/story status 미변경).

### 테스트 (5/5 PASS · 실 PG)
- 단건/배치 recipient_agent(name/type)·member 없을 때 id-only
- fallback notify(human 1명·agent 제외) + marker·**idempotent already_notified**(재통지 0·marker 1)·not_found·**status 불변**

### ⚠️ SME 확認 포인트
- **human owner 타겟**: Story/Project 에 owner 컬럼이 없어 **project active human member** 로 해소(다수 가능). 단일 canonical owner 가 있어야 하면 PO/SME 지정 바람.

🤖 Generated with [Claude Code](https://claude.com/claude-code)