### PR TITLE
[d4c486a4] E-DG S16 — dogfood default story line seed

### DIFF
--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -189,6 +189,26 @@ async def workflow_grandfather_backfill(
         return _err("INTERNAL_ERROR", "Internal server error", 500)
 
 
+# ─── GET /api/v2/internal/cron/seed-default-story-line ────────────────────────
+# E-DG S16: 뭉클랩(기본) org 의 default story line 을 published(shadow)로 시드(idempotent). PO 트리거.
+# ?org_id= 로 다른 org 시드. default-off·shadow 라 라이브 무영향.
+
+@router.get("/seed-default-story-line")
+async def seed_default_story_line_cron(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID | None = Query(default=None),
+) -> JSONResponse:
+    verify_cron(request)
+    try:
+        from app.services.workflow_line_seed import seed_default_story_line
+        result = await seed_default_story_line(session, org_id)
+        return _ok(result)
+    except Exception as exc:
+        logger.exception("cron error: %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)
+
+
 # ─── GET /api/v2/internal/cron/inbox-outbox ────────────────────────────────────
 
 @router.get("/inbox-outbox")

--- a/backend/app/services/workflow_line_seed.py
+++ b/backend/app/services/workflow_line_seed.py
@@ -1,0 +1,104 @@
+"""E-DECISION-GATE S16: dogfood default story line seed.
+
+뭉클랩 org 의 기본 story 라인(published ``workflow_line_definition`` + version)을 시드해 라인이
+shadow 로 dogfood 관측을 시작하게 한다. S2 config 구조(lint/config_hash/모델) 재사용.
+
+- ③ 기본 ``rollout_mode='shadow'``(enforcing 아님·S18 runtime mode 와 정합·라이브 무영향).
+- ② idempotent — 동일 (org, entity_type='story', source='system_default') 의 published version 이
+  같은 config_hash 로 이미 있으면 재생성 0(재실행·fresh-DB 안전).
+- ④ S2 ``lint_config`` 통과하는 valid config(no catch-all·approver/ fallback 정의·allowlist event).
+"""
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.workflow_line import WorkflowLineDefinition, WorkflowLineDefinitionVersion
+from app.services.workflow_line_config import compute_config_hash, lint_config
+
+# 뭉클랩(dogfood) org. 다른 org 시드는 명시 org_id 로.
+MOONKLABS_ORG_ID = uuid.UUID("54bac162-5c0d-49fa-8e49-85977063a091")
+# system seed 작성자 sentinel(거버넌스 작성자 부재·FK-free).
+_SEED_AUTHOR = uuid.UUID("00000000-0000-0000-0000-000000000000")
+_SOURCE = "system_default"
+_ENTITY = "story"
+
+# lean default story line(AC①): dev relay → QA observe → PO merge-gate. 기본 shadow.
+DEFAULT_STORY_LINE_CONFIG: dict[str, Any] = {
+    "rollout_mode": "shadow",
+    "steps": [
+        {
+            "step_key": "dev_relay",
+            "from_status": "backlog", "to_status": "ready-for-dev",
+            "step_type": "agent-handoff",
+            "assignee_policy": {"role": "developer"},  # dev relay 대상
+            "event_type": "dispatched",                # connector allow-list
+        },
+        {
+            "step_key": "qa_observe",
+            "from_status": "in-progress", "to_status": "in-review",
+            "step_type": "advisory",                   # QA 단계·관측(human step 아님)
+        },
+        {
+            "step_key": "po_merge_gate",
+            "from_status": "in-review", "to_status": "done",
+            "step_type": "merge-gate", "gate_type": "merge",  # H1 merge-gate wrapper
+            "approval_policy": {"approver_role": "product_owner"},          # AC②: approver
+            "assignee_policy": {"role": "product_owner", "fallback_role": "admin"},  # AC④: fallback
+        },
+    ],
+}
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+async def seed_default_story_line(
+    session: AsyncSession, org_id: uuid.UUID | None = None,
+    config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """org 의 기본 story 라인을 published 로 시드(idempotent). 반환: 결과 요약."""
+    org_id = org_id or MOONKLABS_ORG_ID
+    config = config or DEFAULT_STORY_LINE_CONFIG
+
+    # ④ lint — invalid seed 차단(approver/fallback/allowlist/catch-all).
+    errors = lint_config(config)
+    if errors:
+        return {"status": "lint_failed", "errors": errors}
+    config_hash = compute_config_hash(config)
+
+    # ② idempotent — 같은 hash 의 published version 이 이미 있으면 skip.
+    existing = (await session.execute(
+        select(WorkflowLineDefinitionVersion.id).where(
+            WorkflowLineDefinitionVersion.org_id == org_id,
+            WorkflowLineDefinitionVersion.project_id.is_(None),
+            WorkflowLineDefinitionVersion.entity_type == _ENTITY,
+            WorkflowLineDefinitionVersion.status == "published",
+            WorkflowLineDefinitionVersion.config_hash == config_hash,
+        ).limit(1)
+    )).scalar_one_or_none()
+    if existing is not None:
+        return {"status": "already_seeded", "config_hash": config_hash, "org_id": str(org_id)}
+
+    now = _now()
+    defn = WorkflowLineDefinition(
+        org_id=org_id, project_id=None, entity_type=_ENTITY, name="Default Story Line",
+        version=1, is_active=True, source=_SOURCE, config_hash=config_hash, published_at=now,
+        created_by_member_id=_SEED_AUTHOR,
+    )
+    session.add(defn)
+    await session.flush()
+    session.add(WorkflowLineDefinitionVersion(
+        line_definition_id=defn.id, org_id=org_id, project_id=None, entity_type=_ENTITY, version=1,
+        status="published", config=config, config_hash=config_hash, lint_status="passed",
+        created_by_member_id=_SEED_AUTHOR, published_at=now,
+    ))
+    await session.flush()
+    await session.commit()
+    return {
+        "status": "seeded", "config_hash": config_hash, "org_id": str(org_id),
+        "definition_id": str(defn.id), "rollout_mode": config.get("rollout_mode"),
+    }

--- a/backend/tests/test_edg_s16_seed.py
+++ b/backend/tests/test_edg_s16_seed.py
@@ -1,0 +1,97 @@
+"""E-DG S16: dogfood default story line seed 테스트.
+
+핵심: published definition+version 시드·기본 shadow·lint 통과·idempotent(재실행 0·config_hash).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def test_default_config_passes_lint_and_is_shadow():
+    from app.services.workflow_line_seed import DEFAULT_STORY_LINE_CONFIG
+    from app.services.workflow_line_config import lint_config
+    assert lint_config(DEFAULT_STORY_LINE_CONFIG) == []  # ④ valid config
+    assert DEFAULT_STORY_LINE_CONFIG["rollout_mode"] == "shadow"  # ③ 기본 shadow
+    # AC①: 3 transitions(dev relay·QA observe·merge-gate)
+    steps = {(s["from_status"], s["to_status"]): s for s in DEFAULT_STORY_LINE_CONFIG["steps"]}
+    assert steps[("backlog", "ready-for-dev")]["step_type"] == "agent-handoff"
+    assert steps[("in-review", "done")]["step_type"] == "merge-gate"
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_seed_creates_published_definition_and_version():
+    from app.services.workflow_line_seed import seed_default_story_line
+    from app.models.workflow_line import WorkflowLineDefinition, WorkflowLineDefinitionVersion
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        r = await seed_default_story_line(s, org)
+        assert r["status"] == "seeded" and r["rollout_mode"] == "shadow"
+        defn = (await s.execute(select(WorkflowLineDefinition).where(
+            WorkflowLineDefinition.org_id == org))).scalar_one()
+        assert defn.is_active and defn.source == "system_default" and defn.entity_type == "story"
+        ver = (await s.execute(select(WorkflowLineDefinitionVersion).where(
+            WorkflowLineDefinitionVersion.org_id == org))).scalar_one()
+        assert ver.status == "published" and ver.config_hash == r["config_hash"]
+        assert ver.config["rollout_mode"] == "shadow"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_seed_idempotent():
+    from app.services.workflow_line_seed import seed_default_story_line
+    from app.models.workflow_line import WorkflowLineDefinition
+    from sqlalchemy import select, func
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        r1 = await seed_default_story_line(s, org)
+        r2 = await seed_default_story_line(s, org)  # 재실행
+        assert r1["status"] == "seeded" and r2["status"] == "already_seeded"
+        n = (await s.execute(select(func.count()).select_from(WorkflowLineDefinition).where(
+            WorkflowLineDefinition.org_id == org))).scalar()
+        assert n == 1  # 중복 0
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_seed_rejects_invalid_config():
+    from app.services.workflow_line_seed import seed_default_story_line
+    engine, Session = await _session()
+    async with Session() as s:
+        # merge-gate 인데 approver 없음 → lint no_approver → seed 거부
+        bad = {"rollout_mode": "shadow", "steps": [
+            {"from_status": "in-review", "to_status": "done", "step_type": "merge-gate"}]}
+        r = await seed_default_story_line(s, uuid.uuid4(), config=bad)
+        assert r["status"] == "lint_failed" and r["errors"]
+    await engine.dispose()


### PR DESCRIPTION
## E-DECISION-GATE S16 — Dogfood default story line seed

스토리 `d4c486a4` · 3pt · 의존 S2(config)·S3(엔진)·S5(merge-gate)·S18(runtime)·전부 merged · 비-lane · **마이그 없음·shadow(라이브 무영향)**.

뭉클랩(`54bac162`) org 의 기본 story 라인을 published(shadow)로 시드해 라인이 dogfood 관측을 시작하게 한다. S2 config 구조(lint/config_hash/모델) 재사용.

### 변경
- `app/services/workflow_line_seed.py` (신규) — `seed_default_story_line`:
  - lean default config(AC①): **dev relay**(backlog→ready-for-dev·agent-handoff·role=developer)·**QA observe**(in-progress→in-review·advisory)·**PO merge-gate**(in-review→done·gate_type=merge·H1 wrapper).
  - ③ 기본 `rollout_mode='shadow'`(enforcing 아님·S18 정합·라이브 무영향).
  - ④ `lint_config` 통과 valid config(merge-gate `approver_role`/`fallback_role`·allowlist event·catch-all 0). invalid → `lint_failed`(시드 안 함).
  - ② **idempotent**: 동일 (org·story·system_default) published version 이 같은 `config_hash` 로 있으면 `already_seeded`(중복 0·재실행/fresh-DB 안전).
- `app/routers/cron.py` — `GET /api/v2/internal/cron/seed-default-story-line`(?org_id=)·PO 트리거.

### 테스트 (4/4 PASS · 실 PG)
- default config **lint pass + shadow** + 3 transitions 정합
- published definition/version 생성(source=system_default·status=published)
- **idempotent**(재실행 already_seeded·중복 0)
- invalid config(merge-gate no approver) 거부

### 비고
- 시드는 **shadow** + S18 runtime default-off 라 enable 전까지 완전 dormant(라이브 0 영향). enforcing enable 은 seed+E2E 후 PO/선생님 GO.
- `cron.py` 기존 F401/E402 는 develop 선재·S16 무관(additive endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)