### PR TITLE
[ba596f6c] E-DG S15 — line metrics + baseline instrumentation

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -274,6 +274,16 @@ async def get_workflow_line_status_batch(
     return await build_workflow_line_status_batch(repo.session, repo.org_id, story_ids)
 
 
+# E-DG S15(P1-6): line metric 집계(org-scoped·read-only·default-off org=no-op). ⚠️ /{id} 보다 먼저.
+@router.get("/workflow-line/metrics")
+async def get_workflow_line_metrics(
+    window_days: int = Query(default=14, ge=1, le=90),
+    repo: StoryRepository = Depends(_get_repo),
+) -> dict:
+    from app.services.workflow_line_metrics import compute_line_metrics
+    return await compute_line_metrics(repo.session, repo.org_id, window_days=window_days)
+
+
 @router.get("/{id}", response_model=StoryResponse)
 async def get_story(
     id: uuid.UUID,

--- a/backend/app/services/workflow_line_metrics.py
+++ b/backend/app/services/workflow_line_metrics.py
@@ -1,0 +1,105 @@
+"""E-DECISION-GATE S15: line metrics + baseline instrumentation (P1-6).
+
+Phase1 성공 측정 metric 을 step_run / step_run_events 에서 **read-only 집계**한다(라이브 무영향).
+모든 집계는 aggregate SQL(func.count/case·group-by)로 — unbounded ``.all()`` 금지(S10 교훈)·org-
+scoped·시간창 bounded. default-off org(라인 step_run 0)는 total 0 → 0/no-op 반환(AC④).
+"""
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import case, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.workflow_line import WorkflowLineStepRun, WorkflowLineStepRunEvent
+
+_HANDOFF_DELIVERY = ("queued", "delivered", "acked", "timed_out", "dead_letter",
+                     "no_assignee", "unresolved_assignee")
+_PENDING_GATE_STATUSES = ("waiting_gate", "waiting_parallel", "gate_pending", "reminded", "escalated", "held")
+_BLOCKED_STATUSES = ("blocked", "blocked_by_policy")
+_GRANDFATHER_STATUSES = ("grandfathered", "grandfathered_applied")
+DEFAULT_WINDOW_DAYS = 14
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _rate(num: int, den: int) -> float | None:
+    return round(num / den, 4) if den else None
+
+
+async def compute_line_metrics(
+    session: AsyncSession, org_id: uuid.UUID, window_days: int = DEFAULT_WINDOW_DAYS,
+    now: datetime | None = None,
+) -> dict:
+    """org 의 line metric 집계(read-only·bounded·default-off org=0/no-op)."""
+    now = now or _now()
+    cutoff = now - timedelta(days=window_days)
+    base = (WorkflowLineStepRun.org_id == org_id, WorkflowLineStepRun.started_at >= cutoff)
+
+    def _c(cond):  # conditional count(단일 쿼리 내 case-sum)
+        return func.sum(case((cond, 1), else_=0))
+
+    row = (await session.execute(
+        select(
+            func.count().label("total"),
+            _c(WorkflowLineStepRun.delivery_status.in_(_HANDOFF_DELIVERY)).label("handoff_total"),
+            _c(WorkflowLineStepRun.delivery_status == "timed_out").label("stuck"),
+            _c(WorkflowLineStepRun.delivery_status == "unresolved_assignee").label("unresolved"),
+            _c(WorkflowLineStepRun.delivery_status == "acked").label("acked"),
+            _c((WorkflowLineStepRun.degraded_to_plain.is_(True))
+               | (WorkflowLineStepRun.status == "engine_failed")).label("degraded"),
+            _c(WorkflowLineStepRun.status.in_(_BLOCKED_STATUSES)).label("blocked"),
+            _c(WorkflowLineStepRun.status.in_(_GRANDFATHER_STATUSES)).label("grandfathered"),
+            _c(WorkflowLineStepRun.mode == "advisory_only").label("advisory"),
+        ).where(*base)
+    )).one()
+
+    total = int(row.total or 0)
+    if total == 0:
+        return {"org_id": str(org_id), "window_days": window_days, "total_step_runs": 0, "no_op": True}
+
+    handoff_total = int(row.handoff_total or 0)
+
+    # duplicate_pending_gate_count(=0 target): pending-gate 키 중복 그룹 수(uq 가 막지만 관측).
+    dup = (await session.execute(
+        select(func.count()).select_from(
+            select(WorkflowLineStepRun.entity_id).where(
+                *base, WorkflowLineStepRun.status.in_(_PENDING_GATE_STATUSES),
+            ).group_by(
+                WorkflowLineStepRun.entity_id, WorkflowLineStepRun.from_status,
+                WorkflowLineStepRun.to_status, WorkflowLineStepRun.effective_gate_type,
+            ).having(func.count() > 1).subquery()
+        )
+    )).scalar() or 0
+
+    # step_run_events 집계(reminder/escalation/fallback).
+    ev_rows = (await session.execute(
+        select(WorkflowLineStepRunEvent.event_type, func.count()).where(
+            WorkflowLineStepRunEvent.org_id == org_id,
+            WorkflowLineStepRunEvent.created_at >= cutoff,
+        ).group_by(WorkflowLineStepRunEvent.event_type)
+    )).all()
+    ev = {et: int(c) for et, c in ev_rows}
+
+    return {
+        "org_id": str(org_id),
+        "window_days": window_days,
+        "total_step_runs": total,
+        "no_op": False,
+        # ① Phase1 success metrics
+        "handoff_stuck_rate": _rate(int(row.stuck or 0), handoff_total),       # target <5%
+        "engine_degraded_transition_rate": _rate(int(row.degraded or 0), total),  # target <1%
+        "duplicate_pending_gate_count": int(dup),                              # target 0
+        "blocked_transition_count": int(row.blocked or 0),
+        "grandfathered_count": int(row.grandfathered or 0),
+        "advisory_observe_count": int(row.advisory or 0),                      # shadow/advisory 관측량
+        # ② baseline(enable 전)
+        "handoff_total": handoff_total,
+        "handoff_acked_count": int(row.acked or 0),
+        "dispatch_unresolved_assignee_rate": _rate(int(row.unresolved or 0), handoff_total),
+        # step_run_events
+        "reminder_count": ev.get("reminded", 0),
+        "escalation_count": ev.get("escalated", 0),
+        "fallback_notified_count": ev.get("fallback_notified", 0),
+    }

--- a/backend/tests/test_edg_s15_metrics.py
+++ b/backend/tests/test_edg_s15_metrics.py
@@ -1,0 +1,124 @@
+"""E-DG S15: line metrics + baseline instrumentation 테스트.
+
+핵심: default-off org no-op·handoff_stuck/degraded rate·duplicate_pending_gate·step_run_events
+집계·window bounded.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+_NOW = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _run(s, org, *, status="dispatched", mode="advisory_only", delivery="not_required",
+               degraded=False, age_days=1, from_status="in-review", to_status="done",
+               gate_type=None, entity_id=None):
+    from app.models.workflow_line import WorkflowLineStepRun
+    sr = WorkflowLineStepRun(
+        org_id=org, project_id=uuid.uuid4(), entity_type="story", entity_id=entity_id or uuid.uuid4(),
+        from_status=from_status, to_status=to_status, status=status, mode=mode,
+        delivery_status=delivery, degraded_to_plain=degraded, effective_gate_type=gate_type,
+        correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex,
+        started_at=_NOW - timedelta(days=age_days))
+    s.add(sr)
+    await s.flush()
+    return sr
+
+
+async def _event(s, org, sr, event_type):
+    from app.models.workflow_line import WorkflowLineStepRunEvent
+    s.add(WorkflowLineStepRunEvent(
+        org_id=org, project_id=sr.project_id, step_run_id=sr.id, event_type=event_type,
+        correlation_id=sr.correlation_id, created_at=_NOW - timedelta(days=1)))
+    await s.flush()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_default_off_org_no_op():
+    from app.services.workflow_line_metrics import compute_line_metrics
+    engine, Session = await _session()
+    async with Session() as s:
+        m = await compute_line_metrics(s, uuid.uuid4(), now=_NOW)
+        assert m["no_op"] is True and m["total_step_runs"] == 0
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_handoff_stuck_and_degraded_rates():
+    from app.services.workflow_line_metrics import compute_line_metrics
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        await _run(s, org, delivery="timed_out")   # stuck
+        await _run(s, org, delivery="acked")
+        await _run(s, org, delivery="queued")
+        await _run(s, org, status="engine_failed", mode="engine_failed", degraded=True)  # degraded
+        m = await compute_line_metrics(s, org, now=_NOW)
+        assert m["total_step_runs"] == 4 and m["handoff_total"] == 3
+        assert m["handoff_stuck_rate"] == round(1 / 3, 4)        # 1 timed_out / 3 handoff
+        assert m["engine_degraded_transition_rate"] == round(1 / 4, 4)  # 1 degraded / 4 total
+        assert m["handoff_acked_count"] == 1
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_duplicate_pending_gate_and_events():
+    from app.services.workflow_line_metrics import compute_line_metrics
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        # 같은 (entity, from, to, gate_type) pending-gate 2건 → duplicate 그룹 1
+        eid = uuid.uuid4()
+        await _run(s, org, status="gate_pending", gate_type="merge", entity_id=eid)
+        await _run(s, org, status="waiting_gate", gate_type="merge", entity_id=eid)
+        sr = await _run(s, org, status="gate_pending")
+        await _event(s, org, sr, "reminded")
+        await _event(s, org, sr, "reminded")
+        await _event(s, org, sr, "escalated")
+        m = await compute_line_metrics(s, org, now=_NOW)
+        assert m["duplicate_pending_gate_count"] == 1
+        assert m["reminder_count"] == 2 and m["escalation_count"] == 1
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_window_bounds_exclude_old():
+    from app.services.workflow_line_metrics import compute_line_metrics
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        await _run(s, org, delivery="timed_out", age_days=2)    # 창 내
+        await _run(s, org, delivery="timed_out", age_days=30)   # 창 밖(14d)
+        m = await compute_line_metrics(s, org, window_days=14, now=_NOW)
+        assert m["total_step_runs"] == 1  # old 제외
+    await engine.dispose()


### PR DESCRIPTION
## E-DECISION-GATE S15 — Line metrics + baseline instrumentation (P1-6)

스토리 `ba596f6c` · 3pt · 의존 S7·S8·S10·S13·전부 merged · 비-lane · **마이그 없음·read-only(라이브 무영향)**.

Phase1 성공 측정 metric 을 step_run/step_run_events 에서 read-only 집계.

### 변경
- `app/services/workflow_line_metrics.py` (신규) — `compute_line_metrics`(org-scoped·시간창 bounded):
  - **① success metrics**: `handoff_stuck_rate`(<5%)·`engine_degraded_transition_rate`(<1%)·`duplicate_pending_gate_count`(=0 target)·`blocked_transition_count`·`grandfathered_count`·`advisory_observe_count`.
  - **② baseline**: `handoff_total`/`acked`·`dispatch_unresolved_assignee_rate`.
  - step_run_events 집계: reminder/escalation/fallback_notified count.
  - ⭐**모든 집계 aggregate SQL**(func.count/case-sum·group-by)·**unbounded `.all()` 0**(S10 교훈). default-off org(step_run 0)는 `no_op` 반환(AC④).
- `app/routers/stories.py` — `GET /api/v2/stories/workflow-line/metrics?window_days=`(org-scoped·/{id} 앞 선언).

### 테스트 (4/4 PASS · 실 PG)
- default-off org **no_op**
- handoff_stuck_rate(1/3)·engine_degraded_rate(1/4)
- **duplicate_pending_gate_count**(중복 그룹 검출) + step_run_events(reminder/escalation) 집계
- window 경계(14d 밖 old 제외)

### 비고
- AC⑤(E-DG 스토리에 success_hypothesis/metric/measure_after 기록)는 MCP 데이터 업데이트로 별도 반영.
- chat-kick/activity-latency 계열(product_kick_adoption·manual_go_messages)은 chat/activity 도메인 instrumentation 필요 — 본 PR 은 step_run/events 파생 metric 범위(차기 확장 포인트).

🤖 Generated with [Claude Code](https://claude.com/claude-code)