### PR TITLE
[e2c60c92] E-DG S17 — recall/withdraw pending gate action

### DIFF
--- a/backend/app/models/workflow_line.py
+++ b/backend/app/models/workflow_line.py
@@ -188,6 +188,7 @@ class WorkflowLineStepApproval(Base):
 STEP_RUN_EVENT_TYPES = frozenset({
     "status_apply", "dispatch_create", "wake", "reminded", "escalated", "sla_timeout", "auto_approved",
     "fallback_notified",  # S12 Gap2: stuck handoff fallback human notification(idempotent marker)
+    "withdrawn",          # S17: author recall/withdraw pending gate run
 })
 
 

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -322,6 +322,37 @@ async def workflow_line_fallback_notify(
     return result
 
 
+class WithdrawRequest(BaseModel):
+    step_run_id: uuid.UUID
+    reason: str | None = None
+
+
+# E-DG S17: author/owner pending gate run 철회(withdraw). requester/owner/admin 만·idempotent·
+# Gate enum 미확장(run/approval status 로만)·entity 미전이.
+@router.post("/{id}/workflow-line/withdraw")
+async def workflow_line_withdraw(
+    id: uuid.UUID,
+    body: WithdrawRequest,
+    repo: StoryRepository = Depends(_get_repo),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    story = await repo.get(id)
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+    actor_id = await _resolve_team_member_id(auth, repo.org_id, db)
+    from app.services.workflow_recall import withdraw_pending_run
+    result = await withdraw_pending_run(repo.session, repo.org_id, id, body.step_run_id, actor_id, body.reason)
+    status = result.get("status")
+    if status == "not_found":
+        raise HTTPException(status_code=404, detail="step_run not found for this story")
+    if status == "forbidden":
+        raise HTTPException(status_code=403, detail="only requester/owner/admin can withdraw")
+    if status == "not_active":
+        raise HTTPException(status_code=409, detail=f"run not in active pending state ({result.get('run_status')})")
+    return result
+
+
 class BulkUpdateItem(BaseModel):
     id: uuid.UUID
     status: str | None = None

--- a/backend/app/services/workflow_recall.py
+++ b/backend/app/services/workflow_recall.py
@@ -13,6 +13,7 @@ from datetime import datetime, timezone
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.gate import Gate
 from app.models.team import TeamMember
 from app.models.workflow_line import (
     WorkflowLineStepApproval,
@@ -82,6 +83,17 @@ async def withdraw_pending_run(
                 WorkflowLineStepApproval.approval_group_id == sr.approval_group_id,
                 WorkflowLineStepApproval.status == "pending",
             ).values(status="withdrawn", resolved_at=_now())
+        )
+    # ⭐B1(까심): Gate instance 도 닫는다. 안 닫으면 다른 approver 가 POST /gates/{id}/transition→approved
+    # 시 find_active_step_run_for_gate 가 withdrawn run 을 못 찾아 legacy _advance_story_on_merge_approve
+    # 로 story=done 우회. Gate enum 미확장 유지 — 기존 'rejected'(withdraw 시맨틱)로 pending gate 닫음.
+    gate_ids = [g for g in (sr.gate_id, sr.h1_gate_id) if g is not None]
+    if gate_ids:
+        await session.execute(
+            update(Gate).where(
+                Gate.id.in_(gate_ids), Gate.org_id == org_id, Gate.status == "pending",
+            ).values(status="rejected", resolver_id=actor_id, resolved_at=_now(),
+                     resolution_note="withdrawn by author")
         )
     # ⑥ withdrawn event.
     session.add(WorkflowLineStepRunEvent(

--- a/backend/app/services/workflow_recall.py
+++ b/backend/app/services/workflow_recall.py
@@ -1,0 +1,94 @@
+"""E-DECISION-GATE S17: recall/withdraw pending gate action.
+
+author/owner 가 승인 前 pending gate run 을 철회한다(reject 안 거치고). Gate enum 확장 없이(Phase1)
+``workflow_line_step_runs.status='withdrawn'`` + approval rows ``withdrawn`` 으로 표현한다.
+
+- ② ⭐기존 ``Gate`` enum 미확장 — withdraw 는 run/approval status 로만. ③ entity status 미전이
+  (from_status 유지). ④ requester/owner/admin 만(SoD). ⑤ idempotent(terminal 시도→not_active·FOR
+  UPDATE 직렬화). ⑥ withdrawn step_run_event 기록.
+"""
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.team import TeamMember
+from app.models.workflow_line import (
+    WorkflowLineStepApproval,
+    WorkflowLineStepRun,
+    WorkflowLineStepRunEvent,
+)
+
+# withdraw 가능한 active pending 상태(AC①).
+_ACTIVE_PENDING = ("waiting_gate", "waiting_parallel", "gate_pending")
+_PRIVILEGED_ROLES = frozenset({"admin", "owner", "product_owner"})
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+async def _is_requester(session: AsyncSession, sr: WorkflowLineStepRun, actor_id: uuid.UUID) -> bool:
+    """run 의 author(requested_by) 인가 — approval rows 의 requested_by_member_id 로 해소."""
+    if sr.approval_group_id is None:
+        return False
+    rb = (await session.execute(
+        select(WorkflowLineStepApproval.requested_by_member_id).where(
+            WorkflowLineStepApproval.approval_group_id == sr.approval_group_id,
+            WorkflowLineStepApproval.requested_by_member_id.is_not(None),
+        ).limit(1)
+    )).scalar_one_or_none()
+    return rb is not None and str(rb) == str(actor_id)
+
+
+async def _is_privileged(session: AsyncSession, org_id: uuid.UUID, actor_id: uuid.UUID) -> bool:
+    m = await session.get(TeamMember, actor_id)
+    return m is not None and m.org_id == org_id and (m.role in _PRIVILEGED_ROLES)
+
+
+async def withdraw_pending_run(
+    session: AsyncSession, org_id: uuid.UUID, story_id: uuid.UUID, step_run_id: uuid.UUID,
+    actor_id: uuid.UUID, reason: str | None = None,
+) -> dict:
+    """pending run 철회. 반환 status: withdrawn|not_found|not_active|forbidden."""
+    # ⑤ FOR UPDATE 로 직렬화(동시 withdraw·fresh status).
+    sr = (await session.execute(
+        select(WorkflowLineStepRun).where(
+            WorkflowLineStepRun.id == step_run_id,
+            WorkflowLineStepRun.org_id == org_id,
+            WorkflowLineStepRun.entity_type == "story",
+            WorkflowLineStepRun.entity_id == story_id,
+        ).with_for_update()
+    )).scalar_one_or_none()
+    if sr is None:
+        return {"status": "not_found"}
+    # ⑤ idempotent: active pending 아니면 no-op(terminal/withdrawn 재시도).
+    if sr.status not in _ACTIVE_PENDING:
+        return {"status": "not_active", "run_status": sr.status}
+    # ④ authz: requester(author) 또는 owner/admin.
+    if not (await _is_requester(session, sr, actor_id)
+            or await _is_privileged(session, org_id, actor_id)):
+        return {"status": "forbidden"}
+
+    sr.status = "withdrawn"  # ② run status 로만(Gate enum 미확장)·③ entity 미전이(from_status 유지)
+    sr.withdrawn_by_member_id = actor_id
+    sr.withdrawn_at = _now()
+    sr.withdraw_reason = reason
+    # gate 해소(③): pending approval rows 를 withdrawn 으로 닫음(approval enum 내·Gate enum 불변).
+    if sr.approval_group_id is not None:
+        await session.execute(
+            update(WorkflowLineStepApproval).where(
+                WorkflowLineStepApproval.approval_group_id == sr.approval_group_id,
+                WorkflowLineStepApproval.status == "pending",
+            ).values(status="withdrawn", resolved_at=_now())
+        )
+    # ⑥ withdrawn event.
+    session.add(WorkflowLineStepRunEvent(
+        org_id=org_id, project_id=sr.project_id, step_run_id=step_run_id, event_type="withdrawn",
+        actor_member_id=actor_id, payload={"reason": reason} if reason else {},
+        correlation_id=sr.correlation_id,
+    ))
+    await session.flush()
+    await session.commit()
+    return {"status": "withdrawn", "step_run_id": str(step_run_id)}

--- a/backend/tests/test_edg_s17_recall.py
+++ b/backend/tests/test_edg_s17_recall.py
@@ -92,6 +92,30 @@ async def test_requester_withdraws_and_closes_approvals():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
+async def test_withdraw_closes_linked_gate_blocks_bypass():
+    """⭐B1(까심): withdraw 가 linked Gate 를 'rejected'로 닫아 legacy merge approve 우회 차단."""
+    from app.services.workflow_recall import withdraw_pending_run
+    from app.models.gate import Gate
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        admin = await _member(s, org, role="admin")
+        sr = await _run(s, org)
+        gate = Gate(id=uuid.uuid4(), org_id=org, work_item_id=sr.entity_id, work_item_type="story",
+                    gate_type="merge", status="pending")
+        s.add(gate)
+        sr.gate_id = gate.id
+        await s.commit()
+        r = await withdraw_pending_run(s, org, sr.entity_id, sr.id, admin)
+        assert r["status"] == "withdrawn"
+        g = (await s.execute(select(Gate).where(Gate.id == gate.id))).scalar_one()
+        assert g.status == "rejected" and g.resolver_id == admin  # Gate 닫힘(우회 봉합·enum 미확장)
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
 async def test_admin_can_withdraw_and_stranger_forbidden():
     from app.services.workflow_recall import withdraw_pending_run
     engine, Session = await _session()

--- a/backend/tests/test_edg_s17_recall.py
+++ b/backend/tests/test_edg_s17_recall.py
@@ -1,0 +1,132 @@
+"""E-DG S17: recall/withdraw pending gate 테스트.
+
+핵심: requester/privileged withdraw→status='withdrawn'+approval withdrawn+event·forbidden(타인)·
+idempotent(terminal→not_active)·not_found·entity 미전이·Gate enum 미확장.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _member(s, org, *, role="member"):
+    from app.models.project import Project
+    from app.models.team import TeamMember
+    mid, proj = uuid.uuid4(), uuid.uuid4()
+    s.add(Project(id=proj, org_id=org, name="p"))
+    await s.flush()
+    s.add(TeamMember(id=mid, org_id=org, project_id=proj, type="human", name="m", role=role))
+    await s.flush()
+    return mid
+
+
+async def _run(s, org, *, status="gate_pending", group=None, requested_by=None):
+    from app.models.workflow_line import WorkflowLineStepRun, WorkflowLineStepApproval
+    sr = WorkflowLineStepRun(
+        org_id=org, project_id=uuid.uuid4(), entity_type="story", entity_id=uuid.uuid4(),
+        from_status="in-review", to_status="done", status=status, mode="gate_pending",
+        approval_group_id=group, correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex)
+    s.add(sr)
+    await s.flush()
+    if group is not None:
+        s.add(WorkflowLineStepApproval(
+            org_id=org, project_id=sr.project_id, step_run_id=sr.id, approval_group_id=group,
+            approver_member_id=uuid.uuid4(), approver_member_type="human",
+            requested_by_member_id=requested_by, kind="approver", blocking=True, status="pending"))
+        await s.flush()
+    return sr
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_requester_withdraws_and_closes_approvals():
+    from app.services.workflow_recall import withdraw_pending_run
+    from app.models.workflow_line import WorkflowLineStepRun, WorkflowLineStepApproval, WorkflowLineStepRunEvent
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        author = await _member(s, org)
+        group = uuid.uuid4()
+        sr = await _run(s, org, group=group, requested_by=author)
+        await s.commit()
+        r = await withdraw_pending_run(s, org, sr.entity_id, sr.id, author, reason="mistake")
+        assert r["status"] == "withdrawn"
+        row = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id))).scalar_one()
+        assert row.status == "withdrawn" and row.withdrawn_by_member_id == author
+        assert row.withdraw_reason == "mistake" and row.from_status == "in-review"  # ③ 미전이
+        appr = (await s.execute(select(WorkflowLineStepApproval).where(
+            WorkflowLineStepApproval.approval_group_id == group))).scalars().all()
+        assert all(a.status == "withdrawn" for a in appr)  # gate 해소(approval withdrawn)
+        evs = (await s.execute(select(WorkflowLineStepRunEvent).where(
+            WorkflowLineStepRunEvent.step_run_id == sr.id,
+            WorkflowLineStepRunEvent.event_type == "withdrawn"))).scalars().all()
+        assert len(evs) == 1  # ⑥ event
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_admin_can_withdraw_and_stranger_forbidden():
+    from app.services.workflow_recall import withdraw_pending_run
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        admin = await _member(s, org, role="admin")
+        stranger = await _member(s, org, role="member")
+        sr1 = await _run(s, org)   # approval 없음(requester 불명)
+        sr2 = await _run(s, org)
+        await s.commit()
+        # ④ admin → 허용
+        assert (await withdraw_pending_run(s, org, sr1.entity_id, sr1.id, admin))["status"] == "withdrawn"
+        # ④ 타인(non-requester·non-privileged) → forbidden
+        assert (await withdraw_pending_run(s, org, sr2.entity_id, sr2.id, stranger))["status"] == "forbidden"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_idempotent_not_active_and_not_found():
+    from app.services.workflow_recall import withdraw_pending_run
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        admin = await _member(s, org, role="admin")
+        sr = await _run(s, org)
+        await s.commit()
+        assert (await withdraw_pending_run(s, org, sr.entity_id, sr.id, admin))["status"] == "withdrawn"
+        # ⑤ 재시도 → not_active(이미 withdrawn)
+        r2 = await withdraw_pending_run(s, org, sr.entity_id, sr.id, admin)
+        assert r2["status"] == "not_active" and r2["run_status"] == "withdrawn"
+        # 없는 run → not_found
+        assert (await withdraw_pending_run(s, org, sr.entity_id, uuid.uuid4(), admin))["status"] == "not_found"
+        # active pending 아닌 run(applied) → not_active
+        applied = await _run(s, org, status="applied")
+        await s.flush()
+        assert (await withdraw_pending_run(s, org, applied.entity_id, applied.id, admin))["status"] == "not_active"
+    await engine.dispose()


### PR DESCRIPTION
## E-DECISION-GATE S17 — Recall/withdraw pending gate action

스토리 `e2c60c92` · 3pt · 의존 S1·S9·merged · 비-lane · **마이그 없음**.

author/owner 가 승인 前 pending gate run 을 철회(reject 안 거치고). **Gate enum 확장 없이** run/approval status 로만 표현.

### 변경
- `app/services/workflow_recall.py` (신규) — `withdraw_pending_run`:
  - ① active pending(waiting_gate/waiting_parallel/gate_pending) → `status='withdrawn'` + `withdrawn_by_member_id`/`withdrawn_at`/`withdraw_reason`.
  - ② ⭐**Gate enum 미확장** — run status + approval rows `'withdrawn'`(approval enum 내)로만.
  - ③ entity status **미전이**(from_status 유지)·gate 해소 = pending approval rows withdrawn.
  - ④ authz: **requester**(approval requested_by) 또는 **owner/admin**(TeamMember.role)만·타인 forbidden.
  - ⑤ **idempotent**: `FOR UPDATE` 직렬화 + active pending 아니면 `not_active`(terminal 재시도 no-op).
  - ⑥ `withdrawn` step_run_event.
- `app/routers/stories.py` — `POST /api/v2/stories/{id}/workflow-line/withdraw` {step_run_id, reason?}·org-scoped·actor 해소·404/403/409 매핑.

### 테스트 (3/3 PASS · 실 PG)
- requester withdraw + approval withdrawn + event + **미전이**
- admin 허용 / 타인(non-requester·non-privileged) **forbidden**
- **idempotent** not_active(withdrawn/applied 재시도)·not_found

### 비고
- requester 해소는 approval rows requested_by 기반(S9 parallel). approval 없는 run 은 owner/admin 만 withdraw(안전 기본).

🤖 Generated with [Claude Code](https://claude.com/claude-code)