### PR TITLE
[d4c486a4-followup] S16 — seed config enforcing + 재시드 retire-then-activate (rollout unblock)

### DIFF
--- a/backend/app/services/workflow_line_seed.py
+++ b/backend/app/services/workflow_line_seed.py
@@ -3,7 +3,9 @@
 뭉클랩 org 의 기본 story 라인(published ``workflow_line_definition`` + version)을 시드해 라인이
 shadow 로 dogfood 관측을 시작하게 한다. S2 config 구조(lint/config_hash/모델) 재사용.
 
-- ③ 기본 ``rollout_mode='shadow'``(enforcing 아님·S18 runtime mode 와 정합·라이브 무영향).
+- ③ config ``rollout_mode='enforcing'``(라인 *의도*=최종 enforcing). 실제 staged rollout(shadow→
+  advisory→enforcing)은 S18 runtime mode(env)가 담당하고 effective=min(runtime, config) 라
+  runtime 이 stager 가 된다. "기본 shadow"는 runtime default(DECISION_GATE_LINE_MODE=shadow)로 달성.
 - ② idempotent — 동일 (org, entity_type='story', source='system_default') 의 published version 이
   같은 config_hash 로 이미 있으면 재생성 0(재실행·fresh-DB 안전).
 - ④ S2 ``lint_config`` 통과하는 valid config(no catch-all·approver/ fallback 정의·allowlist event).
@@ -12,7 +14,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.workflow_line import WorkflowLineDefinition, WorkflowLineDefinitionVersion
@@ -25,9 +27,10 @@ _SEED_AUTHOR = uuid.UUID("00000000-0000-0000-0000-000000000000")
 _SOURCE = "system_default"
 _ENTITY = "story"
 
-# lean default story line(AC①): dev relay → QA observe → PO merge-gate. 기본 shadow.
+# lean default story line(AC①): dev relay → QA observe → PO merge-gate. config 의도=enforcing
+# (실제 단계는 runtime env 가 staging·min(runtime, config)).
 DEFAULT_STORY_LINE_CONFIG: dict[str, Any] = {
-    "rollout_mode": "shadow",
+    "rollout_mode": "enforcing",
     "steps": [
         {
             "step_key": "dev_relay",
@@ -69,30 +72,58 @@ async def seed_default_story_line(
     if errors:
         return {"status": "lint_failed", "errors": errors}
     config_hash = compute_config_hash(config)
+    now = _now()
 
-    # ② idempotent — 같은 hash 의 published version 이 이미 있으면 skip.
-    existing = (await session.execute(
-        select(WorkflowLineDefinitionVersion.id).where(
+    # 현재 org-default active definition 들(idempotency 판단 + retire 대상). active 유일성(S1 partial
+    # unique)이라 보통 0~1개.
+    actives = (await session.execute(
+        select(WorkflowLineDefinition).where(
+            WorkflowLineDefinition.org_id == org_id,
+            WorkflowLineDefinition.project_id.is_(None),
+            WorkflowLineDefinition.entity_type == _ENTITY,
+            WorkflowLineDefinition.source == _SOURCE,
+            WorkflowLineDefinition.is_active.is_(True),
+        )
+    )).scalars().all()
+    # ② idempotent — 같은 config_hash 의 active 가 이미 있으면 skip.
+    if any(d.config_hash == config_hash for d in actives):
+        return {"status": "already_seeded", "config_hash": config_hash, "org_id": str(org_id)}
+
+    # ⭐재시드 안전성(retire-then-activate): 기존 active(다른 config_hash·예: 구 shadow)를 retire
+    # (is_active=False + retired_at·published version→retired) 후 새 버전을 activate. active 유일성
+    # (partial unique) 위반 0·2개 active 방지.
+    retired = 0
+    for d in actives:
+        d.is_active = False
+        d.retired_at = now
+        await session.execute(
+            update(WorkflowLineDefinitionVersion).where(
+                WorkflowLineDefinitionVersion.line_definition_id == d.id,
+                WorkflowLineDefinitionVersion.status == "published",
+            ).values(status="retired")
+        )
+        retired += 1
+    if retired:
+        await session.flush()
+
+    # version uniqueness 회피 — 다음 버전 번호.
+    next_v = ((await session.execute(
+        select(func.coalesce(func.max(WorkflowLineDefinitionVersion.version), 0)).where(
             WorkflowLineDefinitionVersion.org_id == org_id,
             WorkflowLineDefinitionVersion.project_id.is_(None),
             WorkflowLineDefinitionVersion.entity_type == _ENTITY,
-            WorkflowLineDefinitionVersion.status == "published",
-            WorkflowLineDefinitionVersion.config_hash == config_hash,
-        ).limit(1)
-    )).scalar_one_or_none()
-    if existing is not None:
-        return {"status": "already_seeded", "config_hash": config_hash, "org_id": str(org_id)}
+        )
+    )).scalar() or 0) + 1
 
-    now = _now()
     defn = WorkflowLineDefinition(
         org_id=org_id, project_id=None, entity_type=_ENTITY, name="Default Story Line",
-        version=1, is_active=True, source=_SOURCE, config_hash=config_hash, published_at=now,
+        version=next_v, is_active=True, source=_SOURCE, config_hash=config_hash, published_at=now,
         created_by_member_id=_SEED_AUTHOR,
     )
     session.add(defn)
     await session.flush()
     session.add(WorkflowLineDefinitionVersion(
-        line_definition_id=defn.id, org_id=org_id, project_id=None, entity_type=_ENTITY, version=1,
+        line_definition_id=defn.id, org_id=org_id, project_id=None, entity_type=_ENTITY, version=next_v,
         status="published", config=config, config_hash=config_hash, lint_status="passed",
         created_by_member_id=_SEED_AUTHOR, published_at=now,
     ))
@@ -100,5 +131,6 @@ async def seed_default_story_line(
     await session.commit()
     return {
         "status": "seeded", "config_hash": config_hash, "org_id": str(org_id),
-        "definition_id": str(defn.id), "rollout_mode": config.get("rollout_mode"),
+        "definition_id": str(defn.id), "version": next_v, "retired_previous": retired,
+        "rollout_mode": config.get("rollout_mode"),
     }

--- a/backend/tests/test_edg_s16_seed.py
+++ b/backend/tests/test_edg_s16_seed.py
@@ -33,11 +33,12 @@ async def _session():
     return engine, async_sessionmaker(engine, expire_on_commit=False)
 
 
-def test_default_config_passes_lint_and_is_shadow():
+def test_default_config_passes_lint_and_is_enforcing():
     from app.services.workflow_line_seed import DEFAULT_STORY_LINE_CONFIG
     from app.services.workflow_line_config import lint_config
     assert lint_config(DEFAULT_STORY_LINE_CONFIG) == []  # ④ valid config
-    assert DEFAULT_STORY_LINE_CONFIG["rollout_mode"] == "shadow"  # ③ 기본 shadow
+    # ③ config 의도=enforcing(실제 단계는 runtime env 가 staging·effective=min(runtime, config)).
+    assert DEFAULT_STORY_LINE_CONFIG["rollout_mode"] == "enforcing"
     # AC①: 3 transitions(dev relay·QA observe·merge-gate)
     steps = {(s["from_status"], s["to_status"]): s for s in DEFAULT_STORY_LINE_CONFIG["steps"]}
     assert steps[("backlog", "ready-for-dev")]["step_type"] == "agent-handoff"
@@ -54,14 +55,49 @@ async def test_seed_creates_published_definition_and_version():
     async with Session() as s:
         org = uuid.uuid4()
         r = await seed_default_story_line(s, org)
-        assert r["status"] == "seeded" and r["rollout_mode"] == "shadow"
+        assert r["status"] == "seeded" and r["rollout_mode"] == "enforcing"
         defn = (await s.execute(select(WorkflowLineDefinition).where(
             WorkflowLineDefinition.org_id == org))).scalar_one()
         assert defn.is_active and defn.source == "system_default" and defn.entity_type == "story"
         ver = (await s.execute(select(WorkflowLineDefinitionVersion).where(
             WorkflowLineDefinitionVersion.org_id == org))).scalar_one()
         assert ver.status == "published" and ver.config_hash == r["config_hash"]
-        assert ver.config["rollout_mode"] == "shadow"
+        assert ver.config["rollout_mode"] == "enforcing"  # config 의도=enforcing
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_reseed_retires_old_active_and_activates_new():
+    """⭐재시드 안전성(PO 후속): 구 shadow config active → enforcing 재시드 시 구버전 retire
+    (is_active=False·version retired)·새 enforcing 단일 active. active 유일성 보존."""
+    from app.services.workflow_line_seed import seed_default_story_line
+    from app.models.workflow_line import WorkflowLineDefinition, WorkflowLineDefinitionVersion
+    from sqlalchemy import select, func
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        # 구 shadow config 선시드
+        shadow_cfg = {"rollout_mode": "shadow", "steps": [
+            {"from_status": "in-review", "to_status": "done", "step_type": "merge-gate",
+             "gate_type": "merge", "approval_policy": {"approver_role": "product_owner"},
+             "assignee_policy": {"role": "product_owner", "fallback_role": "admin"}}]}
+        r0 = await seed_default_story_line(s, org, config=shadow_cfg)
+        assert r0["status"] == "seeded"
+        # enforcing 기본 config 재시드 → 구 retire·신 active
+        r1 = await seed_default_story_line(s, org)
+        assert r1["status"] == "seeded" and r1["retired_previous"] == 1 and r1["version"] == 2
+        # active 정확히 1개·enforcing
+        actives = (await s.execute(select(WorkflowLineDefinition).where(
+            WorkflowLineDefinition.org_id == org, WorkflowLineDefinition.is_active.is_(True)))).scalars().all()
+        assert len(actives) == 1 and actives[0].config_hash == r1["config_hash"]
+        # 구 published version → retired
+        retired_n = (await s.execute(select(func.count()).select_from(WorkflowLineDefinitionVersion).where(
+            WorkflowLineDefinitionVersion.org_id == org,
+            WorkflowLineDefinitionVersion.status == "retired"))).scalar()
+        assert retired_n == 1
+        # 재재시드(enforcing 동일) → already_seeded(idempotent)
+        assert (await seed_default_story_line(s, org))["status"] == "already_seeded"
     await engine.dispose()
 
 


### PR DESCRIPTION
## S16 follow-up — seed config rollout_mode→enforcing + re-seed safety

라이브 advisory E2E 진단(PO GO): S18 effective = min(runtime, config) 인데 S16 seed config rollout_mode='shadow' 라 runtime 을 advisory/enforcing 으로 플립해도 min(advisory|enforcing, shadow)=shadow 로 캡 → 의도된 staged rollout(shadow→advisory→enforcing via runtime env)이 막힘. shadow는 완벽 작동했으나 그 위 단계 불가. 마이그 없음.

### 변경 (fix · model A)
- DEFAULT_STORY_LINE_CONFIG rollout_mode 'shadow'→'enforcing'(라인 의도=최종 enforcing). 실제 단계는 S18 runtime mode(env)가 stager → effective=min(runtime, enforcing)=runtime. "기본 shadow"는 runtime default(DECISION_GATE_LINE_MODE=shadow)로 달성.
- ⭐재시드 안전성(retire-then-activate): 기존 active org-default definition(구 shadow 등 다른 config_hash)을 is_active=False+retired_at·published version→retired 후 새 enforcing 버전 activate. active 유일성(S1 partial unique) 위반 0·2개 active 방지. next_version 으로 version uniqueness 회피. idempotent(같은 config_hash active 시 already_seeded).

### 테스트 (5/5 PASS · 실 PG)
- default config lint + enforcing · published def/version · idempotent · invalid 거부
- ⭐retire-then-activate(구 shadow→enforcing 재시드: 구 retired·신 단일 active·version 2·재재시드 idempotent)

### 머지 후
PO 재시드(seed cron) → 구 shadow def retire·신 enforcing def active → runtime env 플립(shadow→advisory→enforcing)이 실효 → advisory/enforcing 재E2E 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
