### PR TITLE
[908075db] 단계3 — switch override 밴드에이드 가드 flag-off gate (de-fallback SSOT)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1236,10 +1236,13 @@ async def switch_project(
     )
 
     # 908075db 단계1: target을 명시 의도로 전달 — flag on이면 _build_app_metadata가 추측 없이 그대로 존중.
-    # flag off면 아래 override가 기존처럼 보정(밴드에이드는 단계3서 제거). 둘 다 결과 동일(target 고정).
     app_metadata = await _build_app_metadata(user, session, project_id=target_project_id)
-    app_metadata["project_id"] = str(target_project_id)
-    user.last_project_id = target_project_id  # _build_app_metadata가 덮어쓴 경우 재설정
+    # 908075db 단계3: flag-on이면 de-fallback이 명시 target 을 존중(_resolve_explicit→project_id=target)·
+    # last_project_id 는 위 1229 kept + 단계2 무mutation 으로 target 유지 → 아래 override 밴드에이드가
+    # redundant. flag-off(prod)만 보정(전면 삭제는 prod flag-on 後 단계4·dev 한정).
+    if not settings.build_app_metadata_defallback:
+        app_metadata["project_id"] = str(target_project_id)
+        user.last_project_id = target_project_id  # _build_app_metadata가 덮어쓴 경우 재설정
 
     tokens = create_tokens(str(user.id), email=user.email, app_metadata=app_metadata)
     _, refresh_exp = create_refresh_token(str(user.id), expires_delta=timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS))
@@ -1300,14 +1303,17 @@ async def switch_organization(
     # (내부가 target org로 스코프해 project_id/last_project_id를 그 org의 것 또는 null로 해소.)
     app_metadata = await _build_app_metadata(user, session, org_id=body.org_id)
     app_metadata["org_id"] = str(body.org_id)
-    # belt-and-suspenders: 캡처한 target project_id로 재확정(스코프 결과와 일치)
-    if target_project_id:
-        app_metadata["project_id"] = str(target_project_id)
-    else:
-        app_metadata.pop("project_id", None)
-    # ⚠️0746: _build_app_metadata(org_id 스코프)가 last_project_id를 in-org/null로 설정하므로 추가
-    # 재설정 불필요하나, 캡처값과 동기 보장(refresh가 cross-org로 재누수하지 않도록).
-    user.last_project_id = target_project_id
+    # 908075db 단계3: flag-on이면 org-scope de-fallback이 explicit_pid(=1283서 set한 last_project_id=
+    # first_accessible)를 has_project_access로 검증해 in-org project 또는 null 로 해소(1297 capture==
+    # last_project_id) → 아래 belt-and-suspenders 가 redundant. flag-off(prod)만 캡처값으로 재확정
+    # (전면 삭제는 prod flag-on 後 단계4·dev 한정).
+    if not settings.build_app_metadata_defallback:
+        if target_project_id:
+            app_metadata["project_id"] = str(target_project_id)
+        else:
+            app_metadata.pop("project_id", None)
+        # ⚠️0746: 캡처값과 동기 보장(refresh가 cross-org로 재누수하지 않도록).
+        user.last_project_id = target_project_id
 
     tokens = create_tokens(str(user.id), email=user.email, app_metadata=app_metadata)
     _, refresh_exp = create_refresh_token(str(user.id), expires_delta=timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS))

--- a/backend/tests/test_908075db_stage3_switch_guards.py
+++ b/backend/tests/test_908075db_stage3_switch_guards.py
@@ -1,0 +1,126 @@
+"""908075db 단계3: switch_project/switch_org override 밴드에이드 가드 gate(flag-off-only).
+
+flag-on(de-fallback SSOT): 가드 skip → kept 코드(capture/last_project_id) + de-fallback이 project_id·
+last_project_id 를 ⭐**둘 다** target 으로 커버(가드 없이도 정합). flag-off(prod): 가드 유지 → wrong
+de-fallback 결과를 target 으로 보정(무회귀). 둘 다 결과 동일(target) = parity.
+"""
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.routers.auth import SwitchProjectRequest, SwitchOrganizationRequest, switch_project, switch_organization
+
+ORG = uuid.uuid4()
+USER = uuid.uuid4()
+TARGET = uuid.uuid4()
+WRONG = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _user():
+    u = MagicMock()
+    u.id = USER
+    u.email = "e@test.com"
+    u.last_project_id = None
+    u.last_org_id = ORG
+    return u
+
+
+def _auth():
+    a = MagicMock()
+    a.user_id = str(USER)
+    return a
+
+
+async def _run_switch_project(flag: bool, defallback_pid):
+    """switch_project 호출 → (token app_metadata, user.last_project_id) 반환."""
+    user = _user()
+    session = AsyncMock()
+    captured = {}
+
+    def _ct(uid, email=None, app_metadata=None):
+        captured["md"] = dict(app_metadata or {})
+        return {"access_token": "a", "refresh_token": "r"}
+
+    md = {"org_id": str(ORG), "project_id": (str(defallback_pid) if defallback_pid else None),
+          "role": "member", "projects": []}
+    with patch("app.routers.auth.settings.build_app_metadata_defallback", flag), \
+         patch("app.routers.auth._get_user_by_id", new=AsyncMock(return_value=user)), \
+         patch("app.routers.auth.has_project_access", new=AsyncMock(return_value=True)), \
+         patch("app.routers.auth._build_app_metadata", new=AsyncMock(return_value=md)), \
+         patch("app.routers.auth.create_tokens", _ct), \
+         patch("app.routers.auth.create_refresh_token", return_value=("rt", None)), \
+         patch("app.routers.auth._store_refresh_token", new=AsyncMock()):
+        await switch_project(SwitchProjectRequest(project_id=TARGET), session, _auth())
+    return captured["md"], user.last_project_id
+
+
+@pytest.mark.anyio
+async def test_switch_project_flag_on_covers_both_without_guard():
+    """⭐flag-on: 가드 skip 이어도 project_id + last_project_id 둘 다 target(de-fallback=target)."""
+    md, last_pid = await _run_switch_project(flag=True, defallback_pid=TARGET)
+    assert md["project_id"] == str(TARGET)   # ⓐ de-fallback 이 target 존중
+    assert last_pid == TARGET                # ⓑ kept 1229 last_project_id=target
+
+
+@pytest.mark.anyio
+async def test_switch_project_flag_off_guard_corrects_wrong():
+    """flag-off(prod): de-fallback 이 wrong 줘도 가드가 target 으로 보정(무회귀)."""
+    md, last_pid = await _run_switch_project(flag=False, defallback_pid=WRONG)
+    assert md["project_id"] == str(TARGET)   # 가드 override → target
+    assert last_pid == TARGET                # 가드 재설정 → target
+
+
+async def _run_switch_org(flag: bool, first_accessible, defallback_pid):
+    """switch_organization 호출 → (token app_metadata, user.last_project_id)."""
+    user = _user()
+    session = AsyncMock()
+    # org_members membership = exists, first_accessible_project_id = first_accessible
+    mem = MagicMock()
+    mem.scalar_one_or_none.return_value = 1
+    session.execute = AsyncMock(return_value=mem)
+    captured = {}
+
+    def _ct(uid, email=None, app_metadata=None):
+        captured["md"] = dict(app_metadata or {})
+        return {"access_token": "a", "refresh_token": "r"}
+
+    md = {"org_id": str(ORG), "role": "member", "projects": []}
+    if defallback_pid:
+        md["project_id"] = str(defallback_pid)
+    with patch("app.routers.auth.settings.build_app_metadata_defallback", flag), \
+         patch("app.routers.auth._get_user_by_id", new=AsyncMock(return_value=user)), \
+         patch("app.routers.auth.first_accessible_project_id", new=AsyncMock(return_value=first_accessible)), \
+         patch("app.routers.auth._build_app_metadata", new=AsyncMock(return_value=md)), \
+         patch("app.routers.auth.create_tokens", _ct), \
+         patch("app.routers.auth.create_refresh_token", return_value=("rt", None)), \
+         patch("app.routers.auth._store_refresh_token", new=AsyncMock()):
+        await switch_organization(SwitchOrganizationRequest(org_id=ORG), session, _auth())
+    return captured["md"], user.last_project_id
+
+
+@pytest.mark.anyio
+async def test_switch_org_flag_on_covers_target_without_guard():
+    """⭐flag-on: 가드 skip 이어도 project_id(first_accessible) + last_project_id 둘 다 정합."""
+    md, last_pid = await _run_switch_org(flag=True, first_accessible=TARGET, defallback_pid=TARGET)
+    assert md["project_id"] == str(TARGET) and last_pid == TARGET
+
+
+@pytest.mark.anyio
+async def test_switch_org_flag_on_zero_project_org_null():
+    """⭐flag-on 0-project org(first_accessible None): de-fallback 도 project 없음 → md project 없음·
+    last_project_id None(가드 pop/null 없이도 정합)."""
+    md, last_pid = await _run_switch_org(flag=True, first_accessible=None, defallback_pid=None)
+    assert md.get("project_id") in (None, "") and last_pid is None
+
+
+@pytest.mark.anyio
+async def test_switch_org_flag_off_guard_corrects():
+    """flag-off(prod): de-fallback wrong → 가드가 캡처 target 으로 재확정(무회귀)."""
+    md, last_pid = await _run_switch_org(flag=False, first_accessible=TARGET, defallback_pid=WRONG)
+    assert md["project_id"] == str(TARGET) and last_pid == TARGET


### PR DESCRIPTION
## 908075db 단계3 — switch override 밴드에이드 가드 flag-off gate

de-fallback 단계2 dev soak 3일 green(PO 실측·rev 01096-nsd·회귀 0). 단계3: switch_project/switch_org 의 중복 override 밴드에이드를 flag-off 전용으로 gate. **dev 한정·prod 미적용·마이그 없음.**

### 설계(PO 승인·gate-not-delete)
⚠️ flag=dev-only·prod off. 가드 전면삭제 시 prod(flag off)서 _build_app_metadata 추측 fallback이 last_project_id 덮어쓰고 wrong project_id 반환 → switch P0 인증회귀. ∴ 가드를 `if not settings.build_app_metadata_defallback:` 로 gate(기존 de-fallback 패턴 385/404/483 동형). flag-on(dev)→가드 skip(de-fallback SSOT)·flag-off(prod)→가드 유지(무회귀). 전면 삭제는 prod flag-on 後 단계4.

### 변경
- switch_project(auth.py): `app_metadata['project_id']=target` + `last_project_id=target` 재설정 → flag-off gate. (유지: 1229 last_project_id=target=명시의도·project_id 전달.)
- switch_org(auth.py): belt-and-suspenders(target 재확정 + last_project_id 재설정) → flag-off gate. (유지: first_accessible·last_org_id·capture.)

### 테스트 (5/5 PASS + 기존 switch 25개 무회귀)
- ⭐PO 핵심 단정(flag on/off parity): switch_project flag-on → `project_id` + `last_project_id` **둘 다 target**(가드 없이 de-fallback+kept 코드가 커버)·flag-off → 가드 보정.
- switch_org flag-on(target·0-project org null)·flag-off 보정.
- 기존 switch_project/switch_org/de-fallback/0746 테스트 25개 전량 PASS = flag-off(prod) 경로 불변(무회귀).

### 비고
- (a)switch_project + (b)switch_org 동일 패턴·parity 테스트로 함께 검증 → 1 PR(단계적 요청이었으나 동형이라 합침·분리 원하면 split 가능).
- auth.py 기존 ruff(대형 파일·develop baseline 23)는 단계3 무관(내 변경 줄 신규 에러 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
