### PR TITLE
[9f25e74a] stories.reporter_id(=creator) + created_by 노출 + reporter 서버필터 + 백필

### DIFF
--- a/backend/alembic/versions/0128_stories_reporter_id.py
+++ b/backend/alembic/versions/0128_stories_reporter_id.py
@@ -1,0 +1,42 @@
+"""9f25e74a: stories.reporter_id(=creator) 추가 + audit 백필(no-guess).
+
+보드 '내가 등록한'(reporter) 필터 지원. additive nullable 컬럼 — prod 코드(미인지) 무영향.
+백필은 story_activities(activity_type='story_created')의 실 created_by(actor)로만 — ⚠️추측 일괄
+백필 금지: create activity 없는 historical story 는 NULL 유지(실값 없으면 NULL). 신규 story 는
+create 경로가 reporter_id 를 채운다.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0128"
+down_revision = "0127"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    cols = {c["name"] for c in insp.get_columns("stories")}
+    if "reporter_id" not in cols:
+        op.add_column("stories", sa.Column("reporter_id", UUID(as_uuid=True), nullable=True))
+        op.create_index("ix_stories_reporter_id", "stories", ["reporter_id"])
+    # 백필(no-guess): story_created activity 의 실 created_by 만. 다중이면 가장 이른 것(DISTINCT ON).
+    op.execute(
+        """
+        UPDATE stories s SET reporter_id = sub.actor
+        FROM (
+            SELECT DISTINCT ON (story_id) story_id, created_by AS actor
+            FROM story_activities
+            WHERE activity_type = 'story_created'
+            ORDER BY story_id, created_at ASC
+        ) sub
+        WHERE sub.story_id = s.id AND s.reporter_id IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_stories_reporter_id")
+    op.drop_column("stories", "reporter_id")

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -94,6 +94,9 @@ class Story(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True
     )
+    # 9f25e74a: reporter(=creator·canonical member). create 경로가 채우고, historical 은 0128 백필
+    # (story_created activity 실값·no-guess). 보드 '내가 등록한' 필터·응답 created_by 키로 노출.
+    reporter_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
     meeting_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("meetings.id", ondelete="SET NULL"), nullable=True
     )

--- a/backend/app/repositories/story.py
+++ b/backend/app/repositories/story.py
@@ -31,6 +31,7 @@ class StoryRepository(BaseRepository[Story]):
         cursor: datetime | None = None,
         sprint_id: uuid.UUID | None = None,
         assignee_id: uuid.UUID | None = None,
+        reporter_id: uuid.UUID | None = None,
     ) -> tuple[list[Story], int]:
         """CB-S4: 보드 상태별 쿼리 — created_at DESC + priority 보조 정렬 + cursor 페이징.
 
@@ -46,6 +47,8 @@ class StoryRepository(BaseRepository[Story]):
             q = q.where(Story.sprint_id == sprint_id)
         if assignee_id:
             q = q.where(Story.assignee_id == assignee_id)
+        if reporter_id:  # 9f25e74a: '내가 등록한'(reporter) 서버필터 — 보드 done cursor 집합 기준.
+            q = q.where(Story.reporter_id == reporter_id)
 
         # done: 최근 7일 제한
         if status == "done":

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -77,6 +77,7 @@ async def list_stories(
     epic_id: uuid.UUID | None = Query(default=None),
     sprint_id: uuid.UUID | None = Query(default=None),
     assignee_id: uuid.UUID | None = Query(default=None),
+    reporter_id: uuid.UUID | None = Query(default=None, description="reporter(=creator) 서버필터·'내가 등록한'"),
     status_filter: str | None = Query(default=None, alias="status"),
     no_sprint: bool = Query(default=False, description="sprint 미배정 스토리만 반환"),
     limit: int = Query(default=1000, ge=1, le=2000),
@@ -101,6 +102,7 @@ async def list_stories(
             cursor=cursor_dt,
             sprint_id=sprint_id,
             assignee_id=assignee_id,
+            reporter_id=reporter_id,
         )
         if response is not None:
             response.headers["X-Total-Count"] = str(total)
@@ -118,6 +120,8 @@ async def list_stories(
         filters["sprint_id"] = sprint_id
     if assignee_id:
         filters["assignee_id"] = assignee_id
+    if reporter_id:
+        filters["reporter_id"] = reporter_id
     if status_filter:
         filters["status"] = status_filter
     stories = await repo.list(limit=limit, **filters)
@@ -211,6 +215,13 @@ async def create_story(
         user_id=uuid.UUID(auth.user_id),
     )
     repo = StoryRepository(session, org_id)
+    # 9f25e74a: reporter(=creator) — canonical member 로 해소(best-effort·실패 시 None·no-guess).
+    reporter_id: uuid.UUID | None = None
+    try:
+        from app.services.member_resolver import resolve_member
+        reporter_id = (await resolve_member(auth, org_id, session)).id
+    except Exception:  # noqa: BLE001 — reporter 해소 실패가 story 생성 막지 않음.
+        reporter_id = None
     # E-BOARD S5: assignee_ids 제공 시 단일 assignee_id(주담당)는 첫 요소로 동기화(미지정 시).
     effective_ids = (
         body.assignee_ids if body.assignee_ids is not None
@@ -226,6 +237,7 @@ async def create_story(
         epic_id=body.epic_id,
         sprint_id=body.sprint_id,
         assignee_id=primary_assignee,
+        reporter_id=reporter_id,
         meeting_id=body.meeting_id,
         status=body.status,
         priority=body.priority,

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 _METRIC_SOURCES = frozenset({"internal_ops", "ga4", "manual"})
 _METRIC_DIRECTIONS = frozenset({"up", "down"})
@@ -171,6 +171,9 @@ class StoryResponse(BaseModel):
     epic_id: uuid.UUID | None = None
     sprint_id: uuid.UUID | None = None
     assignee_id: uuid.UUID | None = None
+    # 9f25e74a: reporter(=creator) 노출 — 응답 키 'created_by'·모델 attr reporter_id 에서 읽음
+    # (validation_alias). FE '내가 등록한' 토글이 소비. historical NULL 가능(0128 백필 미스).
+    created_by: uuid.UUID | None = Field(default=None, validation_alias="reporter_id")
     # E-BOARD S5: 복수 assignee. join 테이블 멤버. 레거시 행은 [assignee_id] 폴백.
     assignee_ids: list[uuid.UUID] = []
     # E-FILE S4: 보드 스토리 첨부 (column 값). list 아니면 [](레거시 None/mock 안전).

--- a/backend/tests/test_9f25e74a_reporter.py
+++ b/backend/tests/test_9f25e74a_reporter.py
@@ -1,0 +1,124 @@
+"""9f25e74a: stories.reporter_id(=creator) + created_by 노출 + 서버필터 + 백필(no-guess).
+
+핵심: StoryResponse created_by(=reporter_id alias)·list_board reporter_id 필터·0128 백필(story_activities
+실값만·no-guess NULL).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── StoryResponse created_by 매핑(unit) ──────────────────────────────────────
+def test_story_response_exposes_created_by_from_reporter_id():
+    from app.schemas.story import StoryResponse
+    rid = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+    obj = MagicMock(
+        id=uuid.uuid4(), project_id=uuid.uuid4(), org_id=uuid.uuid4(),
+        epic_id=None, sprint_id=None, assignee_id=None, assignee_ids=[],
+        attachments=[], meeting_id=None, reporter_id=rid,
+        title="t", status="backlog", priority="medium", story_points=None,
+        description=None, acceptance_criteria=None, position=None,
+        is_excluded=False, success_hypothesis=None, measure_after=None,
+        outcome_status="n_a", outcome_result=None, metric_definition=None,
+        created_at=now, updated_at=now,
+    )
+    resp = StoryResponse.model_validate(obj)
+    assert resp.created_by == rid  # ⭐reporter_id → created_by
+    # NULL(백필 미스) 케이스
+    obj.reporter_id = None
+    assert StoryResponse.model_validate(obj).created_by is None
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _story(s, org, proj, *, status="done", reporter=None):
+    from app.models.pm import Story
+    st = Story(org_id=org, project_id=proj, title="t", status=status, reporter_id=reporter)
+    s.add(st)
+    await s.flush()
+    return st
+
+
+# ── list_board reporter 필터(repo·real PG) ───────────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_list_board_reporter_filter():
+    from app.repositories.story import StoryRepository
+    from app.models.project import Project
+    engine, Session = await _session()
+    async with Session() as s:
+        org, proj, me = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        s.add(Project(id=proj, org_id=org, name="p"))
+        await s.flush()
+        await _story(s, org, proj, reporter=me)        # 내가 등록
+        await _story(s, org, proj, reporter=uuid.uuid4())  # 타인
+        await _story(s, org, proj, reporter=None)      # 미상(백필 미스)
+        await s.commit()
+        repo = StoryRepository(s, org)
+        rows, total = await repo.list_board(project_id=proj, status="done", reporter_id=me)
+        assert total == 1 and all(r.reporter_id == me for r in rows)  # '내가 등록한'만
+        rows_all, total_all = await repo.list_board(project_id=proj, status="done")
+        assert total_all == 3  # 필터 없으면 전부
+    await engine.dispose()
+
+
+# ── 0128 백필 no-guess(real PG) ──────────────────────────────────────────────
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_0128_backfill_from_activity_no_guess():
+    import sqlalchemy as sa
+    from app.models.project import Project
+    from app.models.pm import StoryActivity
+    engine, Session = await _session()
+    async with Session() as s:
+        org, proj, creator = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        s.add(Project(id=proj, org_id=org, name="p"))
+        await s.flush()
+        st_with = await _story(s, org, proj, status="backlog", reporter=None)
+        st_without = await _story(s, org, proj, status="backlog", reporter=None)
+        # st_with 에만 story_created activity(실 생성자)
+        s.add(StoryActivity(org_id=org, story_id=st_with.id, project_id=proj,
+                            activity_type="story_created", created_by=creator,
+                            created_at=datetime.now(timezone.utc)))
+        await s.commit()
+        # 0128 백필 SQL 실행
+        await s.execute(sa.text(
+            "UPDATE stories s SET reporter_id = sub.actor FROM ("
+            " SELECT DISTINCT ON (story_id) story_id, created_by AS actor FROM story_activities"
+            " WHERE activity_type='story_created' ORDER BY story_id, created_at ASC) sub"
+            " WHERE sub.story_id = s.id AND s.reporter_id IS NULL"))
+        await s.commit()
+        # raw SQL scalar 직조회(identity-map 캐시·ORM lazy-load 우회·expire_on_commit=False)
+        r1 = (await s.execute(sa.text("SELECT reporter_id FROM stories WHERE id=:i"),
+                              {"i": st_with.id})).scalar()
+        r2 = (await s.execute(sa.text("SELECT reporter_id FROM stories WHERE id=:i"),
+                              {"i": st_without.id})).scalar()
+        assert r1 == creator   # activity 실값 백필
+        assert r2 is None      # ⭐no-guess: activity 없으면 NULL 유지
+    await engine.dispose()

--- a/backend/tests/test_e_cage_referee_p1_exclusion.py
+++ b/backend/tests/test_e_cage_referee_p1_exclusion.py
@@ -95,6 +95,7 @@ async def test_patch_story_is_excluded_true():
     marked_story.sprint_id = None
     marked_story.assignee_id = None
     marked_story.assignee_ids = []
+    marked_story.reporter_id = None  # 9f25e74a: created_by(alias) 검증 위해 명시
     marked_story.meeting_id = None
     # E-BOARD S5: update_story가 _attach_assignee_ids로 story_assignees 조회 → 빈 결과 모킹
     _empty = MagicMock()

--- a/backend/tests/test_e_cage_referee_p1_participation_api.py
+++ b/backend/tests/test_e_cage_referee_p1_participation_api.py
@@ -26,6 +26,7 @@ def _mock_story_obj(assignee_id=None):
     s.sprint_id = None
     s.assignee_id = assignee_id
     s.assignee_ids = [assignee_id] if assignee_id else []  # E-BOARD S5
+    s.reporter_id = None  # 9f25e74a: created_by(alias) 검증 위해 명시
     s.meeting_id = None
     s.title = "Story 1"
     s.status = "backlog"

--- a/backend/tests/test_e_event_inject_s3_assignment_wake.py
+++ b/backend/tests/test_e_event_inject_s3_assignment_wake.py
@@ -30,6 +30,7 @@ def _story(assignee_id):
     s.sprint_id = None
     s.assignee_id = assignee_id
     s.assignee_ids = [assignee_id] if assignee_id else []
+    s.reporter_id = None  # 9f25e74a: created_by(alias) 검증 위해 명시
     s.meeting_id = None
     s.title = "Build login"
     s.description = "OAuth + password"

--- a/backend/tests/test_stories.py
+++ b/backend/tests/test_stories.py
@@ -19,6 +19,8 @@ def _mock_story(status: str = "backlog") -> MagicMock:
     s.epic_id = None
     s.sprint_id = None
     s.assignee_id = None
+    # 9f25e74a: reporter_id 신규 컬럼 — 미지정 시 MagicMock이 created_by(alias) 검증 실패하므로 명시
+    s.reporter_id = None
     s.meeting_id = None
     s.title = "Story 1"
     s.status = status


### PR DESCRIPTION
## 9f25e74a — stories.reporter_id(=creator) BE: created_by 노출 + reporter 서버필터 + 백필

보드 '내가 등록한'(reporter) 필터의 BE lane. assignee 서버필터는 이미 기지원(#1621)이라 **reporter만** 추가하는 additive 변경.

### FE 계약(유나/미르코 토글칩 소비)
- **응답 키 = `created_by`** (= reporter_id·creator). FE '내가 등록한' 토글이 이 키로 본인 등록 여부 판별.
- **필터 = `GET /api/v2/stories?reporter_id={member_id}`** — 본인 member_id 전달 시 본인 등록 스토리만.

### 변경
| 영역 | 내용 |
|------|------|
| 모델 | `Story.reporter_id`(UUID nullable·index) |
| create | `create_story` → reporter = canonical member(`resolve_member`·best-effort·실패 시 None·no-guess) |
| 응답 | `StoryResponse.created_by`(validation_alias=`reporter_id`·NULL 허용) |
| 필터 | `?reporter_id=` → `list_board`(보드 done cursor 집합) + generic `list` **양 경로** |
| 마이그 | **0128**(additive): 컬럼+index, 백필=`story_activities`(`activity_type='story_created'`)의 실 `created_by`만(DISTINCT ON 최이른) |

### ⚠️ 백필 no-guess([[feedback_data_gap_fix_root_not_guess_backfill]])
create activity 없는 historical story 는 **NULL 유지**(추측 일괄백필 금지). 신규 story 는 create 경로가 채움. → 일부 구형 스토리 created_by=NULL 가능(FE 토글은 NULL=비-본인으로 자연 처리).

### 안전성
- **additive nullable** — prod 코드(미인지) 무영향. dev/prod 공유 DB라도 breaking 0.
- migrate-dev 적용은 **PO(gcloud)** — 머지+migrate 원자.

### 테스트 (3/3 PASS + 회귀 0)
- `created_by`(reporter_id alias·NULL 포함) 매핑·`list_board` reporter 필터·**0128 백필 no-guess**(activity 실값만·없으면 NULL).
- 신규 컬럼으로 기존 `_mock_story` fixture 2곳 `reporter_id=None` 명시([[feedback_pytest_mock_fixture]]). story-touching 70개 + 전체 스위프 회귀 0(잔여 실패 55는 create_all≠alembic blindspot 기존분·story 무관).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
