### PR TITLE
[E-DG][S21] Entity readiness matrix + generic transition adapter

### DIFF
--- a/backend/app/services/agent_dispatch.py
+++ b/backend/app/services/agent_dispatch.py
@@ -24,8 +24,12 @@ from app.services.activity_stream import extract_activities_best_effort
 from app.services.event_seq import assign_recipient_seq
 from app.services.member_resolver import resolve_member_identity
 from app.services.notification_dispatch import dispatch_notification
+from app.services.workflow_readiness_matrix import READINESS_MATRIX
 
-_ENTITY_TYPES = {"epic", "story", "doc"}
+# S21: dispatch 가능 엔티티는 readiness matrix 의 dispatch_capable SSOT 에서 도출(현 epic/story/doc).
+# hypothesis/sprint fetch 추가(S23/S26) 시 matrix descriptor 만 바꾸면 자동 확장. _fetch_entity 분기는
+# 그때 함께 확장(현 byte-동일).
+_ENTITY_TYPES = {e for e, d in READINESS_MATRIX.items() if d.dispatch_capable}
 
 
 class DispatchResponse(BaseModel):

--- a/backend/app/services/workflow_line_resolution.py
+++ b/backend/app/services/workflow_line_resolution.py
@@ -15,10 +15,10 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.workflow_line import (
-    WorkflowLineDefinition,
     WorkflowLineDefinitionVersion,
     WorkflowLineStepRun,
 )
+from app.services.workflow_readiness_matrix import get_readiness, record_unsupported_entity_attempt
 
 # 이 gate 에 묶인 step_run 이 아직 미해소(승인/반려 대기) 상태로 볼 수 있는 집합.
 _OPEN_STEP_RUN_STATUSES = frozenset({
@@ -73,7 +73,12 @@ async def apply_workflow_line_resolution(
     sr = (await session.execute(
         select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == step_run_id).with_for_update()
     )).scalar_one_or_none()
-    if sr is None or sr.entity_type != "story":  # Phase1 = story-only
+    if sr is None:
+        return
+    # S21: story 외 엔티티는 readiness matrix gating_eligible 로 판정(현 story 만)·미지원은 로그+no-op.
+    _desc = get_readiness(sr.entity_type)
+    if _desc is None or not _desc.gating_eligible:
+        record_unsupported_entity_attempt(sr.entity_type, sr.from_status, sr.to_status, sr.entity_id)
         return
     step = await _step_config(session, sr)
 
@@ -153,7 +158,12 @@ async def relay_agent_handoff(
     sr = (await session.execute(
         select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == step_run_id).with_for_update()
     )).scalar_one_or_none()
-    if sr is None or sr.entity_type != "story":  # Phase1 = story-only
+    if sr is None:
+        return None
+    # S21: gating_eligible 엔티티(현 story)만 handoff relay·미지원은 로그+no-op(fail-open).
+    _desc = get_readiness(sr.entity_type)
+    if _desc is None or not _desc.gating_eligible:
+        record_unsupported_entity_attempt(sr.entity_type, sr.from_status, sr.to_status, sr.entity_id)
         return None
 
     trigger_metadata = {

--- a/backend/app/services/workflow_line_resolver.py
+++ b/backend/app/services/workflow_line_resolver.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.pm import Story
 from app.services.trust_score import compute_member_trust_scores
+from app.services.workflow_readiness_matrix import get_readiness, record_unsupported_entity_attempt
 
 # story_points 가 이 이상이면 high-effort 신호(휴리스틱·S5 에서 정교화).
 _HIGH_EFFORT_POINTS = 8
@@ -85,12 +86,17 @@ async def resolve_routing_context(
 ) -> dict[str, Any]:
     """라우팅 컨텍스트 = entity · story predicate · actor · risk_flags · trust.
 
-    비-story entity 는 Phase1 범위 밖 → unsupported context 로 안전하게 내려보낸다(무리 확장 X).
+    S21: gating_eligible 엔티티(현 story)만 full context 생산. 비-eligible(doc/hyp/epic/sprint)은
+    readiness matrix 의 blocking_reason 으로 unsupported context 를 내려보내고 시도를 로그로 남긴다
+    (no-op 이 silent 아닐 것·fail-open). story 경로는 거동 불변.
     """
-    if entity_type != "story":
+    desc = get_readiness(entity_type)
+    if desc is None or not desc.gating_eligible:
+        record_unsupported_entity_attempt(entity_type, entity_id=entity_id)
         return {
             "entity_type": entity_type, "entity_id": str(entity_id),
-            "supported": False, "reason": "unsupported_entity_type",
+            "supported": False,
+            "reason": desc.blocking_reason if desc else "unknown_entity_type",
             "risk_flags": {"prod_touch": None, "uncertain": True},
             "trust": {"cold_start": True, "captured_before_verdict": True},
             "suggested_default": "ask_human",

--- a/backend/app/services/workflow_line_status.py
+++ b/backend/app/services/workflow_line_status.py
@@ -130,16 +130,17 @@ def _blocking_reason(run: WorkflowLineStepRun) -> str | None:
 
 
 async def build_workflow_line_status(
-    session: AsyncSession, org_id: uuid.UUID, story_id: uuid.UUID,
+    session: AsyncSession, org_id: uuid.UUID, story_id: uuid.UUID, entity_type: str = "story",
 ) -> WorkflowLineStatusResponse:
-    """story 의 workflow-line 상태 read model 을 조립한다(active 또는 terminal history).
+    """엔티티의 workflow-line 상태 read model 을 조립한다(active 또는 terminal history).
 
     ⭐bounded query(SME): runs 전체를 .all() 로 읽지 않고 active 는 LIMIT 1, history 는 LIMIT 5
-    로 DB-level 제한한다(스토리당 run 누적이 커도 상수 비용).
+    로 DB-level 제한한다(엔티티당 run 누적이 커도 상수 비용).
+    S21: entity_type 파라미터화(기본 "story"=back-compat). story_id 인자명은 호환 위해 유지.
     """
     _story_runs = select(WorkflowLineStepRun).where(
         WorkflowLineStepRun.org_id == org_id,
-        WorkflowLineStepRun.entity_type == "story",
+        WorkflowLineStepRun.entity_type == entity_type,
         WorkflowLineStepRun.entity_id == story_id,
     )
     # active = 미해소(open) run 중 가장 최근 1건(LIMIT 1).
@@ -236,7 +237,7 @@ async def _resolve_recipient_agent(
 
 
 async def build_workflow_line_status_batch(
-    session: AsyncSession, org_id: uuid.UUID, story_ids: list[uuid.UUID],
+    session: AsyncSession, org_id: uuid.UUID, story_ids: list[uuid.UUID], entity_type: str = "story",
 ) -> list[LineStatusSummary]:
     """여러 story 의 line-status 경량 요약(보드 badge 용). 단일 쿼리·N+1 0.
 
@@ -249,7 +250,7 @@ async def build_workflow_line_status_batch(
     rows = (await session.execute(
         select(WorkflowLineStepRun).where(
             WorkflowLineStepRun.org_id == org_id,
-            WorkflowLineStepRun.entity_type == "story",
+            WorkflowLineStepRun.entity_type == entity_type,  # S21: 파라미터화(기본 story=back-compat)
             WorkflowLineStepRun.entity_id.in_(story_ids),
             WorkflowLineStepRun.status.in_(_OPEN_STEP_RUN_STATUSES),
         ).order_by(WorkflowLineStepRun.started_at.desc())

--- a/backend/app/services/workflow_readiness_matrix.py
+++ b/backend/app/services/workflow_readiness_matrix.py
@@ -1,0 +1,141 @@
+"""E-DECISION-GATE S21: Entity readiness matrix (Phase 2 foundation).
+
+Phase 1 라인 엔진은 story 에 하드코딩돼 있다(routing/resolution/status-read). Phase 2 는 이를
+doc/hypothesis/epic/sprint 로 확장하되, **엔티티별 readiness 이질성을 무시한 generic code 를 막는** 것이
+핵심(success_hypothesis). 이 모듈은 그 이질성을 **명시적 descriptor 행렬**로 인코딩한다.
+
+⭐설계 원칙:
+- **순수 데이터**(callable/엔진 import 0) → 순환 의존 없음. 엔티티별 실제 로직(predicate/status setter/
+  fetch)은 각 서비스에 inline 유지하고, 이 모듈은 "지원 여부 + 사유 + enum 계약"만 SSOT 로 보유한다.
+- **gating_eligible**: S21 시점 routing/resolution 게이트가 실가동하는 엔티티(= story 만). 나머지는
+  False + blocking_reason 으로 "왜 아직 아닌지"를 명시(S22~S26 에서 승격).
+- **미지원 = 명시 no-op**(silent 아님): ``record_unsupported_entity_attempt`` 로 구조화 로그를 남겨
+  observability 를 보장한다(§6: engine 실패 ≠ silent skip).
+- **fail-open 정합**: matrix miss/미지원은 transition 을 막지 않는다(409 아님). gate 미생성일 뿐.
+
+⚠️ enum/전이 값은 각 모델/스키마의 SSOT 를 import 해 재사용한다(중복 정의 금지 → S22+ 오염 방지).
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+
+from app.models.hypothesis import HYPOTHESIS_STATUSES, _VALID_TRANSITIONS as _HYP_TRANSITIONS
+from app.schemas.epic import EPIC_STATUSES
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class EntityReadiness:
+    """엔티티 1종의 line-readiness 계약(이질성 인코딩)."""
+
+    entity_type: str
+    has_native_status: bool
+    # status 유효값 집합. None = enum 계약 없음(story=config-driven · sprint=free-string · doc=status無).
+    status_enum: frozenset[str] | None
+    # 합법 (from,to) 전이. None = 모델 레벨 전이규칙 없음(story=config · epic/sprint 미정의).
+    valid_transitions: frozenset[tuple[str, str]] | None
+    # S21 시점 routing/resolution 게이트 실가동 여부(현재 story 만 True).
+    gating_eligible: bool
+    # agent_dispatch._fetch_entity 가 이 엔티티를 로드할 수 있는지(현 epic/story/doc).
+    dispatch_capable: bool
+    # gating_eligible=False 인 이유(observability/후속 스토리 라우팅). eligible 이면 None.
+    blocking_reason: str | None
+
+
+# ⭐ Entity Readiness Matrix — 이질성 gradient(Story FULL → Hyp READY → Epic PARTIAL → Sprint WEAK → Doc NONE).
+# enum/전이 값은 SSOT import(hypothesis.py:39/44 · schemas/epic.py:7). story status 는 config-driven
+# (workflow_line_seed.py:37-49)이라 모델 상수 없음 → enum/transitions=None.
+READINESS_MATRIX: dict[str, EntityReadiness] = {
+    "story": EntityReadiness(
+        entity_type="story",
+        has_native_status=True,                 # pm.py:101 String(30)
+        status_enum=None,                        # config-driven(seed) → 모델 enum 상수 없음
+        valid_transitions=None,                  # config 라인이 전이 정의(엔진 Phase1)
+        gating_eligible=True,                    # Phase1 = story 라인 dogfood
+        dispatch_capable=True,
+        blocking_reason=None,
+    ),
+    "hypothesis": EntityReadiness(
+        entity_type="hypothesis",
+        has_native_status=True,                  # hypothesis.py:81 String(24)
+        status_enum=frozenset(HYPOTHESIS_STATUSES),       # hypothesis.py:39
+        valid_transitions=frozenset(_HYP_TRANSITIONS),    # hypothesis.py:44 (native FSM·계약 最강)
+        gating_eligible=False,
+        dispatch_capable=False,                  # _fetch_entity 미지원 → S23서 추가
+        blocking_reason="dispatch_fetch_and_gate_wiring_pending_s23",
+    ),
+    "epic": EntityReadiness(
+        entity_type="epic",
+        has_native_status=True,                  # pm.py:59 String(20)
+        status_enum=frozenset(EPIC_STATUSES),    # schemas/epic.py:7 (draft|active|done|archived)
+        valid_transitions=None,                  # 전이규칙 미정의
+        gating_eligible=False,
+        dispatch_capable=True,
+        blocking_reason="transition_rules_undefined_pending_s25",
+    ),
+    "sprint": EntityReadiness(
+        entity_type="sprint",
+        has_native_status=True,                  # pm.py:23 String(20) default planning
+        status_enum=None,                        # free-string(enum 계약 弱)
+        valid_transitions=None,
+        gating_eligible=False,
+        dispatch_capable=False,
+        blocking_reason="status_enum_undefined_pending_s26",
+    ),
+    "doc": EntityReadiness(
+        entity_type="doc",
+        has_native_status=False,                 # doc.py: status 컬럼 부재
+        status_enum=None,
+        valid_transitions=None,
+        gating_eligible=False,
+        dispatch_capable=True,
+        # 잠정권고(S21 lock 금지·S22 design 이연): docs.status native 컬럼 vs virtual overlay.
+        # doc lifecycle(콘텐츠 승인)이 work status 와 의미가 달라 동형성만으로 결정 안 함.
+        blocking_reason="docs_status_undefined_pending_s22",
+    ),
+}
+
+
+def get_readiness(entity_type: str) -> EntityReadiness | None:
+    """엔티티 readiness descriptor. 미등록 → None(예외 아님·호출자가 fail-open 처리)."""
+    return READINESS_MATRIX.get(entity_type)
+
+
+def is_transition_supported(entity_type: str, from_status: str, to_status: str) -> bool:
+    """이 엔티티+전이가 라인 게이트 실가동 대상인가. 미등록/비-eligible → False(no-op).
+
+    valid_transitions 가 정의된 엔티티(hypothesis)는 전이 합법성까지 검사하나, story 처럼 config-driven
+    (valid_transitions=None)이면 eligible 여부만으로 판정(전이 합법성은 config lint/엔진 책임).
+    """
+    desc = READINESS_MATRIX.get(entity_type)
+    if desc is None or not desc.gating_eligible:
+        return False
+    if desc.valid_transitions is not None:
+        return (from_status, to_status) in desc.valid_transitions
+    return True
+
+
+def record_unsupported_entity_attempt(
+    entity_type: str, from_status: str | None = None, to_status: str | None = None,
+    entity_id: uuid.UUID | None = None,
+) -> None:
+    """미지원 엔티티 라인 시도를 구조화 로그로 남긴다(§6: no-op 이 silent 아닐 것).
+
+    metric `unsupported_entity_gate_attempt_count` 의 로그-기반 소스. 실패가 아니라 "아직 미지원"
+    관측치이므로 warning 이 아닌 info 레벨(fail-open 정합).
+    """
+    desc = READINESS_MATRIX.get(entity_type)
+    logger.info(
+        "unsupported_entity_gate_attempt entity_type=%s reason=%s from=%s to=%s entity_id=%s",
+        entity_type,
+        desc.blocking_reason if desc else "unknown_entity_type",
+        from_status, to_status, entity_id,
+        extra={
+            "metric": "unsupported_entity_gate_attempt_count",
+            "entity_type": entity_type,
+            "blocking_reason": desc.blocking_reason if desc else "unknown_entity_type",
+        },
+    )

--- a/backend/tests/test_edg_s21_readiness_matrix.py
+++ b/backend/tests/test_edg_s21_readiness_matrix.py
@@ -1,0 +1,94 @@
+"""E-DG S21: Entity readiness matrix + generic transition adapter.
+
+핵심: matrix descriptor 정확성(검증된 enum·이질성 gradient)·is_transition_supported·미지원 no-op이
+silent 아님(로그)·routing context 가 entity-specific reason 반환·status 함수 entity_type 파라미터화.
+story 거동 byte-동일은 기존 edg_s3/s4/s5/s7 테스트가 커버(무회귀).
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.workflow_readiness_matrix import (
+    READINESS_MATRIX,
+    get_readiness,
+    is_transition_supported,
+    record_unsupported_entity_attempt,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── matrix descriptor 정확성(② 검증된 enum·gradient) ──────────────────────────
+def test_matrix_covers_five_entities_with_verified_contracts():
+    assert set(READINESS_MATRIX) == {"story", "hypothesis", "epic", "sprint", "doc"}
+    # gradient: story 만 gating_eligible(S21).
+    assert get_readiness("story").gating_eligible is True
+    for e in ("hypothesis", "epic", "sprint", "doc"):
+        assert get_readiness(e).gating_eligible is False
+        assert get_readiness(e).blocking_reason  # 사유 명시(silent 금지)
+    # 검증된 enum(SSOT import) — hypothesis/epic.
+    hyp = get_readiness("hypothesis")
+    assert hyp.status_enum is not None and "measuring" in hyp.status_enum
+    assert ("proposed", "active") in hyp.valid_transitions  # native FSM
+    assert get_readiness("epic").status_enum == frozenset({"draft", "active", "done", "archived"})
+    # doc=native status 없음·sprint=enum 없음(free-string).
+    assert get_readiness("doc").has_native_status is False
+    assert get_readiness("sprint").status_enum is None and get_readiness("sprint").has_native_status is True
+    # story=config-driven(모델 enum 상수 없음).
+    assert get_readiness("story").status_enum is None and get_readiness("story").valid_transitions is None
+
+
+def test_is_transition_supported_only_eligible():
+    assert is_transition_supported("story", "backlog", "ready-for-dev") is True
+    # 비-eligible 은 valid transition 이라도 False(S21 미가동).
+    assert is_transition_supported("hypothesis", "proposed", "active") is False
+    assert is_transition_supported("doc", "a", "b") is False
+    assert is_transition_supported("unknown", "a", "b") is False  # 미등록=no-op
+
+
+def test_get_readiness_unknown_returns_none():
+    assert get_readiness("nonexistent") is None
+
+
+# ── 미지원 no-op 이 silent 아닐 것(④ observability) ──────────────────────────
+def test_unsupported_attempt_emits_structured_log(caplog):
+    with caplog.at_level(logging.INFO, logger="app.services.workflow_readiness_matrix"):
+        record_unsupported_entity_attempt("doc", "draft", "published", uuid.uuid4())
+    rec = [r for r in caplog.records if "unsupported_entity_gate_attempt" in r.getMessage()]
+    assert rec, "미지원 시도가 로그로 남아야 한다(silent 금지)"
+    assert getattr(rec[0], "metric", None) == "unsupported_entity_gate_attempt_count"
+    assert getattr(rec[0], "blocking_reason", None) == "docs_status_undefined_pending_s22"
+
+
+def test_unsupported_attempt_unknown_entity_logs_reason(caplog):
+    with caplog.at_level(logging.INFO, logger="app.services.workflow_readiness_matrix"):
+        record_unsupported_entity_attempt("widget")
+    rec = [r for r in caplog.records if "unsupported_entity_gate_attempt" in r.getMessage()]
+    assert rec and getattr(rec[0], "blocking_reason", None) == "unknown_entity_type"
+
+
+# ── routing context: 비-eligible 은 descriptor reason·unknown 은 unknown_entity_type ──
+@pytest.mark.anyio
+async def test_routing_context_non_eligible_returns_descriptor_reason():
+    from app.services.workflow_line_resolver import resolve_routing_context
+    session = AsyncMock()  # 비-eligible 은 session.get 전에 반환 → DB 불필요
+    for entity, reason in [
+        ("hypothesis", "dispatch_fetch_and_gate_wiring_pending_s23"),
+        ("epic", "transition_rules_undefined_pending_s25"),
+        ("sprint", "status_enum_undefined_pending_s26"),
+        ("doc", "docs_status_undefined_pending_s22"),
+    ]:
+        ctx = await resolve_routing_context(session, uuid.uuid4(), entity_type=entity, entity_id=uuid.uuid4())
+        assert ctx["supported"] is False and ctx["reason"] == reason
+        assert ctx["suggested_default"] == "ask_human"
+    # 미등록 entity → unknown_entity_type(fail-open·예외 아님)
+    ctx = await resolve_routing_context(session, uuid.uuid4(), entity_type="widget", entity_id=uuid.uuid4())
+    assert ctx["supported"] is False and ctx["reason"] == "unknown_entity_type"
+    session.get.assert_not_called()  # 비-eligible 은 DB 안 침

--- a/backend/tests/test_edg_s4_resolver.py
+++ b/backend/tests/test_edg_s4_resolver.py
@@ -133,7 +133,10 @@ async def test_routing_context_non_story_unsupported():
     async with Session() as s:
         ctx = await resolve_routing_context(
             s, uuid.uuid4(), entity_type="epic", entity_id=uuid.uuid4())
-        assert ctx["supported"] is False and ctx["reason"] == "unsupported_entity_type"
+        # S21: 미지원 사유가 generic "unsupported_entity_type" → readiness matrix descriptor 의
+        # entity-specific blocking_reason 으로 정밀화(observability). epic = 전이규칙 미정의(S25).
+        assert ctx["supported"] is False
+        assert ctx["reason"] == "transition_rules_undefined_pending_s25"
         assert ctx["suggested_default"] == "ask_human"  # 불명=safe default
     await engine.dispose()
 


### PR DESCRIPTION
## [E-DG][S21] Entity readiness matrix + generic transition adapter

E-DG **Phase 2 foundation** (design-review 게이트 PASS분). Phase 1 story 라인 엔진을 generic transition adapter로 일반화 + 엔티티별 status readiness 이질성을 명시 행렬로 인코딩. **마이그 없음 · default-off · story 거동 byte-동일.**

설계 doc: `design-edg-s21-readiness-matrix-adapter` (PO design-review PASS).

### 핵심 산출 — `workflow_readiness_matrix.py` (신설)
- `EntityReadiness` descriptor: `has_native_status·status_enum·valid_transitions·gating_eligible·dispatch_capable·blocking_reason`. **순수 데이터**(callable/엔진 import 0 → 순환 의존 없음).
- 이질성 gradient(success_hypothesis "이질성 무시 generic 방지"): **Story FULL(eligible)** → Hyp READY(native FSM) → Epic PARTIAL(enum만) → Sprint WEAK(free-string) → **Doc NONE(status無)**. S21 = **story만 gating_eligible**·나머지 blocking_reason 명시.
- enum은 **SSOT import**(검증됨): `HYPOTHESIS_STATUSES`/`_VALID_TRANSITIONS`(hypothesis.py:39/44)·`EPIC_STATUSES`(schemas/epic.py:7). story=config-driven(enum 상수 없음).
- `get_readiness`·`is_transition_supported`·`record_unsupported_entity_attempt`(구조화 로그·**no-op silent 금지**).

### 5 핫스팟 matrix-lookup 일반화 (story byte-동일·타 entity는 eligible=False라 no-op)
| 파일 | 변경 |
|------|------|
| `workflow_line_resolver.py` | `if != "story"` → `gating_eligible` + descriptor reason + 로그 |
| `workflow_line_resolution.py` | `entity_type != "story"` 가드 2곳 → matrix gating_eligible |
| `workflow_line_status.py` | `entity_type` 파라미터화(기본 "story"=back-compat) |
| `agent_dispatch.py` | `_ENTITY_TYPES`을 matrix `dispatch_capable` SSOT에서 도출(동일 집합 {epic,story,doc}) |

### §6 가드 (build-guide)
- 미지원 entity = **명시 no-op + 구조화 로그**(observability·`unsupported_entity_gate_attempt_count`)·`entity_line_supported_transition_count`는 step_run 영속 집계.
- dispatch 트랜잭션 내 commit 0 · 새 event type 0 · matrix miss = **fail-open**(transition 통과·409 아님).
- Doc (A)native-status vs (B)overlay **lock 안 함**(blocking_reason만·**S22 design 이연**·doc lifecycle≠work status).

### 테스트 / 무회귀 (조건③ = 생명선)
- **S21 신규 6 PASS**(matrix descriptor·is_transition_supported·미지원 로그·routing reason·unknown entity).
- s4 reason 테스트 갱신(generic "unsupported_entity_type" → entity-specific descriptor reason).
- ⭐**story byte-동일 입증**: 엔진 회귀 12 failed가 **baseline(엔진 unchanged·reporter 브랜치)과 동일 노드**(create_all blindspot 기존분·CI=alembic fresh-DB라 미해당). **내 신규 회귀 0**(시그니처 전수 검증). 변경 소스 전 파일 ruff-clean.

### 이연(미터치) — Phase 2 후속
Doc 컬럼/마이그=S22 · Sprint enum+API=S26 · Epic 전이규칙=S25 · hyp dispatch fetch=S23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
