### PR TITLE
[E-DG][S23] Hypothesis proposed→active line overlay

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -1,6 +1,6 @@
 """E-CAGE-REFEREE P3: HITL Gate CRUD + 전이 엔드포인트."""
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
-from app.models.gate import Gate, is_valid_transition
+from app.models.gate import Gate
 from app.services.gate_service import create_gate, transition_gate
 from app.services.member_resolver import resolve_member
 
@@ -125,6 +125,7 @@ async def transition_gate_endpoint(
     # authz(93fc7aeb): 게이트 approve/reject는 **휴먼 member만**. 에이전트(API key)가 사람 검증
     # 게이트를 승인하면 "agent-assisted·human-validated" 웨지 전제가 무너지므로 차단(403).
     # 시스템 auto-resolution(resolve_gate_from_verdict)은 transition_gate 서비스 직호출이라 무영향.
+    _resolver_id = body.resolver_id
     if body.status in _HUMAN_REVIEW_STATUSES:
         resolved = await resolve_member(auth, org_id, session)
         if resolved.type != "human":
@@ -132,8 +133,11 @@ async def transition_gate_endpoint(
                 status_code=403,
                 detail="게이트 승인/거부는 휴먼 멤버만 가능합니다 (에이전트 승인 불가).",
             )
+        # ⭐S23 RC①(SoD 위조 봉): resolver_id 를 인증 caller 로 강제 — body 조작(타인 UUID)으로
+        # SoD(approver≠owner) 우회·confirmed_by_member_id 위조하는 경로 차단(전 gate 타입 공통).
+        _resolver_id = resolved.id
     try:
-        gate = await transition_gate(session, org_id, id, body.status, body.resolver_id, body.note)
+        gate = await transition_gate(session, org_id, id, body.status, _resolver_id, body.note)
         await session.commit()
         return GateResponse.model_validate(gate)
     except ValueError as e:

--- a/backend/app/services/agent_dispatch.py
+++ b/backend/app/services/agent_dispatch.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.doc import Doc
 from app.models.event import Event, EventType
+from app.models.hypothesis import Hypothesis
 from app.models.pm import Epic, Story
 from app.routers.agent_gateway import wake_agent
 from app.routers.events import _event_to_payload, _push_to_agent
@@ -72,6 +73,15 @@ async def _fetch_entity(
             )
         )
         r = row.one_or_none()
+    elif entity_type == "hypothesis":
+        # S23: assignee=owner_member_id(책임 human)·title=statement·description 컬럼 없음(None).
+        row = await db.execute(
+            select(Hypothesis.owner_member_id, Hypothesis.statement, Hypothesis.project_id).where(
+                Hypothesis.id == entity_id, Hypothesis.org_id == org_id
+            )
+        )
+        r0 = row.one_or_none()
+        r = (r0[0], r0[1], None, r0[2]) if r0 is not None else None
     else:
         return None, None, None, None
 

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -228,7 +228,10 @@ async def transition_hypothesis(
     caller: ResolvedMember,
     hypothesis_id: uuid.UUID,
     payload: HypothesisTransition,
+    via_gate: bool = False,
 ) -> HypothesisResponse:
+    """hypothesis status 전이. ``via_gate=True`` = Decision Gate 승인이 적용하는 경로로, S23 overlay
+    재진입(re-gate 루프)을 막고 inline native 전이로 직행한다(caller=gate approver·human)."""
     repo = HypothesisRepository(session, org_id)
     hyp = await repo.get(hypothesis_id)
     if hyp is None:
@@ -241,6 +244,26 @@ async def transition_hypothesis(
         raise HypothesisServiceError(
             "INVALID_HYPOTHESIS_TRANSITION", f"불법 전이: {hyp.status} → {target}"
         )
+    # ⭐E-DG S23: proposed→active line overlay. enforcing 라인이면 human-gate 생성·proposed 유지
+    # (agent-drafted hyp 의 confirm 대기가 가시 gate 가 되고 승인 시 자동 재개). default-off/plain/
+    # 엔진실패 → 아래 inline human-only 로 폴백(byte-동일·agent 차단 유지·⚠️fail-open=active 통과 아님).
+    if target == "active" and hyp.status == "proposed" and not via_gate:
+        _decision = None
+        try:
+            from app.services.workflow_line_engine import evaluate_line_for_transition
+            _decision = await evaluate_line_for_transition(
+                session, org_id=org_id, project_id=hyp.project_id,
+                entity_type="hypothesis", entity_id=hyp.id,
+                from_status="proposed", to_status="active",
+                actor_id=caller.id, actor_type=caller.type,
+            )
+        except Exception:  # noqa: BLE001 — fail-open: 엔진 실패는 inline human-only 폴백(agent 차단 유지).
+            _decision = None
+        if _decision is not None and not _decision.proceeds:
+            # enforcing: human-gate pending. hyp proposed 유지·gate 가 confirm 대기 가시화(에러 아님).
+            await session.commit()  # gate/step_run 보존(stories.py:736 패턴·예외 시 rollback 방지).
+            return await _to_response(repo, hyp)
+
     # 'active' 확정은 휴먼만(§2.5.2). org admin/owner 검증은 라우터(S3)에서 보강.
     if target == "active" and caller.type != "human":
         raise HypothesisServiceError(

--- a/backend/app/services/workflow_line_resolution.py
+++ b/backend/app/services/workflow_line_resolution.py
@@ -8,6 +8,7 @@ legacy ``_advance_story_on_merge_approve`` 로 폴백한다(무회귀).
 P1-1 idempotency: story/run 을 row lock(SELECT FOR UPDATE)하고, stale ``from_status``(story 가 이미
 다른 status 로 이동)면 적용하지 않는다. 이미 목표 status 면 no-op.
 """
+import logging
 import uuid
 from typing import Any
 
@@ -19,6 +20,8 @@ from app.models.workflow_line import (
     WorkflowLineStepRun,
 )
 from app.services.workflow_readiness_matrix import get_readiness, record_unsupported_entity_attempt
+
+logger = logging.getLogger(__name__)
 
 # 이 gate 에 묶인 step_run 이 아직 미해소(승인/반려 대기) 상태로 볼 수 있는 집합.
 _OPEN_STEP_RUN_STATUSES = frozenset({
@@ -60,6 +63,57 @@ async def _step_config(session: AsyncSession, step_run: WorkflowLineStepRun) -> 
     return {}
 
 
+async def _apply_hypothesis_active(
+    session: AsyncSession, sr: WorkflowLineStepRun, resolver_id: uuid.UUID | None
+) -> None:
+    """S23: hypothesis proposed→active gate 승인 적용. native ``transition_hypothesis`` 재사용
+    (parallel FSM 0·AC3 동일결과+confirmed_by). ⭐SoD(AC5·trust-gaming): approver ≠ owner_member_id."""
+    from app.models.hypothesis import Hypothesis
+    from app.schemas.hypothesis import HypothesisTransition
+    from app.services.hypothesis import transition_hypothesis
+    from app.services.member_resolver import ResolvedMember
+
+    hyp = (await session.execute(
+        select(Hypothesis).where(Hypothesis.id == sr.entity_id).with_for_update()
+    )).scalar_one_or_none()
+    if hyp is None:
+        sr.status = "approved"
+        sr.resolved_at = _now()
+        await session.flush()
+        return
+    if hyp.status == "active":  # 멱등: 다른 경로로 이미 active → no-op.
+        sr.status = "applied"
+        sr.resolved_at = _now()
+        await session.flush()
+        return
+    if hyp.status != "proposed":  # stale: proposed 아니면 미적용(killed/archived 등).
+        sr.status = "skipped"
+        sr.resolved_at = _now()
+        await session.flush()
+        return
+    # ⭐SoD: approver 미상이거나 owner 자신이면 차단(자기 hyp 자기 confirm = trust-gaming).
+    if resolver_id is None or resolver_id == hyp.owner_member_id:
+        sr.status = "skipped"
+        sr.resolved_at = _now()
+        await session.flush()
+        logger.warning(
+            "hypothesis_activation_sod_block sr=%s approver=%s owner=%s",
+            sr.id, resolver_id, hyp.owner_member_id,
+        )
+        return
+    # 적용: native 전이 재사용(via_gate=True → overlay re-gate 루프 차단). confirmed_by=approver.
+    approver = ResolvedMember(
+        id=resolver_id, user_id=None, name="gate_approver", type="human", role="member",
+        org_id=sr.org_id,
+    )
+    await transition_hypothesis(
+        session, sr.org_id, approver, hyp.id, HypothesisTransition(status="active"), via_gate=True,
+    )
+    sr.status = "applied"
+    sr.resolved_at = _now()
+    await session.flush()
+
+
 async def apply_workflow_line_resolution(
     session: AsyncSession, step_run_id: uuid.UUID, new_status: str,
     resolver_id: uuid.UUID | None = None,
@@ -97,6 +151,11 @@ async def apply_workflow_line_resolution(
         sr.status = "approved"
         sr.resolved_at = _now()
         await session.flush()
+        return
+
+    # S23: hypothesis 는 native FSM 재사용(transition_hypothesis·parallel 0). story 는 기존 inline.
+    if sr.entity_type == "hypothesis":
+        await _apply_hypothesis_active(session, sr, resolver_id)
         return
 
     from app.models.pm import Story  # 순환 회피 lazy import.

--- a/backend/app/services/workflow_line_resolver.py
+++ b/backend/app/services/workflow_line_resolver.py
@@ -101,13 +101,15 @@ async def resolve_routing_context(
             "trust": {"cold_start": True, "captured_before_verdict": True},
             "suggested_default": "ask_human",
         }
-    story = await session.get(Story, entity_id)
+    # S23 LOW fix: story predicate 는 story 전용. 비-story eligible(hypothesis)은 Story 조회 안 함
+    # (entity_id 로 Story get → None → entity_type 오기록 방지·observability 정합).
+    story = await session.get(Story, entity_id) if entity_type == "story" else None
     risk_flags = _risk_flags(story)
     trust = await resolve_trust_snapshot(session, org_id, actor_member_id, role_key)
     # safe default: 위험 불확실 또는 cold-start → ask_human 제안(S4 는 표기만·비차단).
     suggested = "ask_human" if (risk_flags.get("uncertain") or trust.get("cold_start")) else None
     return {
-        "entity_type": "story", "entity_id": str(entity_id), "supported": True,
+        "entity_type": entity_type, "entity_id": str(entity_id), "supported": True,
         "story": _story_predicate(story),
         "actor": {
             "member_id": str(actor_member_id) if actor_member_id else None,

--- a/backend/app/services/workflow_readiness_matrix.py
+++ b/backend/app/services/workflow_readiness_matrix.py
@@ -21,7 +21,7 @@ import logging
 import uuid
 from dataclasses import dataclass
 
-from app.models.hypothesis import HYPOTHESIS_STATUSES, _VALID_TRANSITIONS as _HYP_TRANSITIONS
+from app.models.hypothesis import HYPOTHESIS_STATUSES
 from app.schemas.epic import EPIC_STATUSES
 
 logger = logging.getLogger(__name__)
@@ -62,10 +62,12 @@ READINESS_MATRIX: dict[str, EntityReadiness] = {
         entity_type="hypothesis",
         has_native_status=True,                  # hypothesis.py:81 String(24)
         status_enum=frozenset(HYPOTHESIS_STATUSES),       # hypothesis.py:39
-        valid_transitions=frozenset(_HYP_TRANSITIONS),    # hypothesis.py:44 (native FSM·계약 最강)
-        gating_eligible=False,
-        dispatch_capable=False,                  # _fetch_entity 미지원 → S23서 추가
-        blocking_reason="dispatch_fetch_and_gate_wiring_pending_s23",
+        # ⭐S23: overlay-gated subset = proposed→active 만(full native FSM 은 hypothesis.py:44 SSOT).
+        # measuring/verified 등 나머지 전이는 line overlay 안 검·native 직행(scope 명확).
+        valid_transitions=frozenset({("proposed", "active")}),
+        gating_eligible=True,                    # S23: proposed→active overlay 가동
+        dispatch_capable=True,                   # S23: _fetch_entity hypothesis 분기 추가
+        blocking_reason=None,
     ),
     "epic": EntityReadiness(
         entity_type="epic",

--- a/backend/tests/test_edg_s21_readiness_matrix.py
+++ b/backend/tests/test_edg_s21_readiness_matrix.py
@@ -28,15 +28,17 @@ def anyio_backend():
 # ── matrix descriptor 정확성(② 검증된 enum·gradient) ──────────────────────────
 def test_matrix_covers_five_entities_with_verified_contracts():
     assert set(READINESS_MATRIX) == {"story", "hypothesis", "epic", "sprint", "doc"}
-    # gradient: story 만 gating_eligible(S21).
+    # gradient: story + hypothesis(S23) gating_eligible. epic/sprint/doc 아직 미가동.
     assert get_readiness("story").gating_eligible is True
-    for e in ("hypothesis", "epic", "sprint", "doc"):
+    assert get_readiness("hypothesis").gating_eligible is True  # S23 flip
+    for e in ("epic", "sprint", "doc"):
         assert get_readiness(e).gating_eligible is False
         assert get_readiness(e).blocking_reason  # 사유 명시(silent 금지)
     # 검증된 enum(SSOT import) — hypothesis/epic.
     hyp = get_readiness("hypothesis")
     assert hyp.status_enum is not None and "measuring" in hyp.status_enum
-    assert ("proposed", "active") in hyp.valid_transitions  # native FSM
+    # S23: valid_transitions = overlay-gated subset(proposed→active 만)·full FSM 은 hypothesis.py SSOT.
+    assert hyp.valid_transitions == frozenset({("proposed", "active")})
     assert get_readiness("epic").status_enum == frozenset({"draft", "active", "done", "archived"})
     # doc=native status 없음·sprint=enum 없음(free-string).
     assert get_readiness("doc").has_native_status is False
@@ -47,8 +49,10 @@ def test_matrix_covers_five_entities_with_verified_contracts():
 
 def test_is_transition_supported_only_eligible():
     assert is_transition_supported("story", "backlog", "ready-for-dev") is True
-    # 비-eligible 은 valid transition 이라도 False(S21 미가동).
-    assert is_transition_supported("hypothesis", "proposed", "active") is False
+    # S23: hypothesis proposed→active 는 overlay-gated(True)·그 외 hyp 전이는 scope 밖(False·native 직행).
+    assert is_transition_supported("hypothesis", "proposed", "active") is True
+    assert is_transition_supported("hypothesis", "active", "measuring") is False
+    # 비-eligible(doc) + 미등록은 False.
     assert is_transition_supported("doc", "a", "b") is False
     assert is_transition_supported("unknown", "a", "b") is False  # 미등록=no-op
 
@@ -79,8 +83,8 @@ def test_unsupported_attempt_unknown_entity_logs_reason(caplog):
 async def test_routing_context_non_eligible_returns_descriptor_reason():
     from app.services.workflow_line_resolver import resolve_routing_context
     session = AsyncMock()  # 비-eligible 은 session.get 전에 반환 → DB 불필요
+    # S23: hypothesis 는 eligible 승격(session.get 경로) → 여기선 비-eligible 만 검사.
     for entity, reason in [
-        ("hypothesis", "dispatch_fetch_and_gate_wiring_pending_s23"),
         ("epic", "transition_rules_undefined_pending_s25"),
         ("sprint", "status_enum_undefined_pending_s26"),
         ("doc", "docs_status_undefined_pending_s22"),

--- a/backend/tests/test_edg_s23_hypothesis_overlay.py
+++ b/backend/tests/test_edg_s23_hypothesis_overlay.py
@@ -19,10 +19,38 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.mark.anyio
+async def test_gate_transition_forces_resolver_id_to_caller(monkeypatch):
+    """⭐RC①(SoD 위조 봉·CI-runnable): gate approve 시 body.resolver_id 조작 → 인증 caller.id 로 강제.
+    이게 없으면 owner 가 resolver_id=<타인 UUID> 제출해 SoD(approver≠owner)·confirmed_by 위조 가능."""
+    from unittest.mock import AsyncMock, MagicMock
+    from app.routers import gates as gm
+    from app.services.member_resolver import ResolvedMember
+    caller_id, spoofed = uuid.uuid4(), uuid.uuid4()
+    captured = {}
+
+    async def _fake_transition(session, org_id, gid, status, resolver_id, note):
+        captured["resolver_id"] = resolver_id
+        return MagicMock()
+
+    caller = ResolvedMember(
+        id=caller_id, user_id=None, name="h", type="human", role="member", org_id=uuid.uuid4())
+    monkeypatch.setattr(gm, "resolve_member", AsyncMock(return_value=caller))
+    monkeypatch.setattr(gm, "transition_gate", _fake_transition)
+    monkeypatch.setattr(gm.GateResponse, "model_validate", staticmethod(lambda g: g))
+    body = gm.GateTransitionRequest(status="approved", resolver_id=spoofed)
+    await gm.transition_gate_endpoint(
+        uuid.uuid4(), body, session=AsyncMock(), org_id=uuid.uuid4(), auth=MagicMock())
+    assert captured["resolver_id"] == caller_id  # ⭐조작된 spoofed 가 아니라 인증 caller
+    assert captured["resolver_id"] != spoofed
+
+
 async def _session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base
     import app.models  # noqa: F401
+    import app.models.participation  # noqa: F401 — org_gate_override FK 타깃(metadata 완전성·import 순서 무관)
+    import app.models.workflow_line  # noqa: F401
     url = _REAL_DB_URL
     for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
         if url.startswith(prefix):

--- a/backend/tests/test_edg_s23_hypothesis_overlay.py
+++ b/backend/tests/test_edg_s23_hypothesis_overlay.py
@@ -1,0 +1,170 @@
+"""E-DG S23: hypothesis proposed→active line overlay.
+
+핵심: gate 승인 applier 가 native ``transition_hypothesis``(via_gate) 재사용(parallel 0·confirmed_by
+=approver)·⭐SoD(approver≠owner_member_id) 차단·멱등·default-off byte-동일(overlay off→inline 폴백).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_hyp(s, org, proj, owner, status="proposed"):
+    from app.models.hypothesis import Hypothesis
+    h = Hypothesis(
+        org_id=org, project_id=proj, owner_member_id=owner, statement="가설",
+        metric_definition={"metric": "x"}, measure_after=datetime.now(timezone.utc), status=status,
+    )
+    s.add(h)
+    await s.flush()
+    return h
+
+
+async def _seed_sr(s, org, proj, hyp_id):
+    from app.models.workflow_line import WorkflowLineStepRun
+    sr = WorkflowLineStepRun(
+        org_id=org, project_id=proj, entity_type="hypothesis", entity_id=hyp_id,
+        from_status="proposed", to_status="active", status="gate_pending", mode="enforcing",
+        correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex,
+    )
+    s.add(sr)
+    await s.flush()
+    return sr
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_apply_sod_blocks_owner_self_approve():
+    """⭐SoD: approver == owner_member_id → 차단(skipped)·hyp proposed 유지(trust-gaming 봉)."""
+    from app.services.workflow_line_resolution import _apply_hypothesis_active
+    from sqlalchemy import text as sa_text
+    engine, Session = await _session()
+    async with Session() as s:
+        org, proj, owner = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        from app.models.project import Project
+        s.add(Project(id=proj, org_id=org, name="p"))
+        await s.flush()
+        hyp = await _seed_hyp(s, org, proj, owner)
+        sr = await _seed_sr(s, org, proj, hyp.id)
+        await _apply_hypothesis_active(s, sr, resolver_id=owner)  # approver=owner 자기 confirm
+        await s.commit()
+        st = (await s.execute(sa_text("SELECT status FROM hypotheses WHERE id=:i"), {"i": hyp.id})).scalar()
+        assert st == "proposed"  # 활성화 차단
+        assert sr.status == "skipped"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_apply_different_approver_activates_with_confirmed_by():
+    """approver ≠ owner → active + confirmed_by_member_id=approver(native transition_hypothesis 재사용)."""
+    from app.services.workflow_line_resolution import _apply_hypothesis_active
+    from sqlalchemy import text as sa_text
+    engine, Session = await _session()
+    async with Session() as s:
+        org, proj, owner, approver = uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        from app.models.project import Project
+        s.add(Project(id=proj, org_id=org, name="p"))
+        await s.flush()
+        hyp = await _seed_hyp(s, org, proj, owner)
+        sr = await _seed_sr(s, org, proj, hyp.id)
+        await _apply_hypothesis_active(s, sr, resolver_id=approver)
+        await s.commit()
+        row = (await s.execute(sa_text(
+            "SELECT status, confirmed_by_member_id FROM hypotheses WHERE id=:i"), {"i": hyp.id})).one()
+        assert row[0] == "active" and row[1] == approver  # AC3: 동일결과+confirmed_by
+        assert sr.status == "applied"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_apply_idempotent_already_active():
+    """이미 active(다른 경로 도달) → applied no-op(중복 활성화 0·에러 없음)."""
+    from app.services.workflow_line_resolution import _apply_hypothesis_active
+    engine, Session = await _session()
+    async with Session() as s:
+        org, proj, owner, approver = uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        from app.models.project import Project
+        s.add(Project(id=proj, org_id=org, name="p"))
+        await s.flush()
+        hyp = await _seed_hyp(s, org, proj, owner, status="active")
+        sr = await _seed_sr(s, org, proj, hyp.id)
+        await _apply_hypothesis_active(s, sr, resolver_id=approver)
+        await s.commit()
+        assert sr.status == "applied"  # no-op·예외 0
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_default_off_agent_active_still_blocked():
+    """default-off(라인 없음): agent active 시도 → overlay decision=plain → inline HUMAN_CONFIRM_REQUIRED
+    유지(byte-동일·fail-open=통과 아님)."""
+    from app.services.hypothesis import transition_hypothesis, HypothesisServiceError
+    from app.schemas.hypothesis import HypothesisTransition
+    from app.services.member_resolver import ResolvedMember
+    engine, Session = await _session()
+    async with Session() as s:
+        org, proj, owner = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        from app.models.project import Project
+        s.add(Project(id=proj, org_id=org, name="p"))
+        await s.flush()
+        hyp = await _seed_hyp(s, org, proj, owner)
+        await s.commit()
+        agent = ResolvedMember(id=uuid.uuid4(), user_id=None, name="a", type="agent", role="member", org_id=org)
+        with pytest.raises(HypothesisServiceError) as ei:
+            await transition_hypothesis(s, org, agent, hyp.id, HypothesisTransition(status="active"))
+        assert ei.value.code == "HUMAN_CONFIRM_REQUIRED"  # agent 차단 유지
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_via_gate_human_activates_without_regate():
+    """via_gate=True(gate 승인 적용 경로): human approver → active + confirmed_by·overlay 재진입 안 함."""
+    from app.services.hypothesis import transition_hypothesis
+    from app.schemas.hypothesis import HypothesisTransition
+    from app.services.member_resolver import ResolvedMember
+    from sqlalchemy import text as sa_text
+    engine, Session = await _session()
+    async with Session() as s:
+        org, proj, owner, approver = uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        from app.models.project import Project
+        s.add(Project(id=proj, org_id=org, name="p"))
+        await s.flush()
+        hyp = await _seed_hyp(s, org, proj, owner)
+        await s.commit()
+        human = ResolvedMember(id=approver, user_id=None, name="h", type="human", role="member", org_id=org)
+        await transition_hypothesis(
+            s, org, human, hyp.id, HypothesisTransition(status="active"), via_gate=True)
+        await s.commit()
+        row = (await s.execute(sa_text(
+            "SELECT status, confirmed_by_member_id FROM hypotheses WHERE id=:i"), {"i": hyp.id})).one()
+        assert row[0] == "active" and row[1] == approver
+    await engine.dispose()


### PR DESCRIPTION
## [E-DG][S23] Hypothesis proposed→active line overlay

E-DG Phase 2. hypothesis `proposed→active` 전이를 라인 overlay 로 — agent-drafted hyp 의 human confirm 대기가 제품 Decision Gate(GateInbox)로 보이고 승인 시 자동 재개. **⭐parallel FSM 0(native `transition_hypothesis` 재사용)·마이그 0(`confirmed_by_member_id` 기존)·default-off(기존 human 경로 byte-동일).**

설계 doc: `design-edg-s23-hypothesis-line-overlay` (PO design-review PASS·5조건).

### 변경 (5파일)
| 영역 | 내용 |
|------|------|
| `workflow_readiness_matrix.py` | hypothesis `gating_eligible` False→True·`dispatch_capable` True·`valid_transitions={(proposed,active)}` (overlay-gated subset·full FSM은 hypothesis.py SSOT·measuring 등 native 직행) |
| `hypothesis.py` (overlay 진입) | `transition_hypothesis` proposed→active 시 inline human-only **前에** `evaluate_line_for_transition` 호출. enforcing→gate·proposed 유지(에러 아님)·default-off/plain/engine실패→inline 폴백. `via_gate` 플래그로 적용경로 re-gate 루프 차단 |
| `workflow_line_resolution.py` (적용) | `_apply_hypothesis_active`: native `transition_hypothesis(via_gate=True, caller=approver)` 재사용 → AC3 동일결과+confirmed_by. SoD·멱등·stale |
| `agent_dispatch.py` | `_fetch_entity` hypothesis 분기(assignee=owner_member_id·title=statement) |

### PO 5조건 충족
1. **⭐SoD = approver ≠ `owner_member_id`** (코드 검증: owner=NN human 책임주체). 자기 hyp 자기 confirm 차단·`resolver_id` None 도 차단(trust-gaming 봉).
2. **default-off byte-동일 P0** — 기존 hypothesis 79 테스트 green·엔진 회귀 12 failed=baseline 동일(create_all blindspot·내 시그니처 0).
3. **overlay proposed→active만** — matrix `valid_transitions={(proposed,active)}`·entry `from==proposed`. measuring 등 native 직행.
4. **⚠️ fail-open = inline human-only 폴백**(agent=HUMAN_CONFIRM_REQUIRED 유지·active 통과 **아님**·story fail-open과 다른 의미).
5. **matrix flip** S21 머지분 위 clean.

### ⭐버그 fix (테스트가 적출)
`ResolvedMember` 는 `org_id` 필수 — applier 의 approver 생성에 `org_id=sr.org_id` 누락 시 **gate approve 마다 크래시**. 테스트 작성 중 발견·수정.

### 테스트 (5종 PASS + 무회귀)
SoD self-approve 차단·다른 approver 활성화+confirmed_by·멱등(active no-op)·default-off agent 차단·via_gate bypass. S21 matrix 테스트 hypothesis flip 갱신. 변경 소스 전부 ruff-clean.

### 이연
S24(hyp gate UI·FE 유나)·S27(dispatch anchor)·S28(resubmit)이 본 S23 위 빌드.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
