### PR TITLE
[E-DG][S22] Doc decision overlay (docs.status)

### DIFF
--- a/backend/alembic/versions/0128_docs_status.py
+++ b/backend/alembic/versions/0128_docs_status.py
@@ -1,0 +1,32 @@
+"""E-DG S22: docs.status (doc decision lifecycle·doc-specific 값).
+
+doc 은 native status 가 없었다(콘텐츠만). S22 결정(A): work status 재사용 없이 doc-전용 lifecycle
+값(draft|confirmed|denied|superseded|deprecated)을 native 컬럼으로 추가 → 콘텐츠 승인≠작업 진행
+의미 분리 + FE 뱃지/쿼리/readiness. additive·default 'draft'·기존 doc 전부 draft 백필(승인이력 없음·
+보수적)·default-off 라 동작영향 0.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0128"
+down_revision = "0127"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    cols = {c["name"] for c in insp.get_columns("docs")}
+    if "status" not in cols:
+        # NN + server_default 'draft' → 기존 행 자동 백필(보수적·승인이력 없음).
+        op.add_column(
+            "docs",
+            sa.Column("status", sa.Text(), nullable=False, server_default="draft"),
+        )
+        op.create_index("ix_docs_status", "docs", ["status"])
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_docs_status")
+    op.drop_column("docs", "status")

--- a/backend/app/models/doc.py
+++ b/backend/app/models/doc.py
@@ -9,6 +9,21 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.core.database import Base
 from app.models.base import OrgScopedMixin, SoftDeleteMixin, TimestampMixin
 
+# E-DG S22: doc decision lifecycle(doc-specific·work status 아님). hypothesis _VALID_TRANSITIONS 패턴 미러.
+DOC_STATUSES = frozenset({"draft", "confirmed", "denied", "superseded", "deprecated"})
+# 합법 (from, to) 전이. confirmed/denied→draft 외 역전이 금지. ⭐draft→confirmed 만 line overlay-gated.
+_DOC_VALID_TRANSITIONS: set[tuple[str, str]] = {
+    ("draft", "confirmed"),       # 승인(human-gate overlay 대상)
+    ("draft", "denied"),          # 반려
+    ("denied", "draft"),          # 재작성(revise·S28 토대)
+    ("confirmed", "superseded"),  # 신버전 대체
+    ("confirmed", "deprecated"),  # 폐기
+}
+
+
+def is_valid_doc_transition(from_status: str, to_status: str) -> bool:
+    return (from_status, to_status) in _DOC_VALID_TRANSITIONS
+
 
 class Doc(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     __tablename__ = "docs"
@@ -26,6 +41,9 @@ class Doc(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True
     )
+    # E-DG S22: doc decision lifecycle(doc-specific 값·work status 아님). draft→confirmed 만 line
+    # overlay-gated(나머지 native 직행). 0128 마이그·default draft.
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default="draft")
     title: Mapped[str] = mapped_column(Text, nullable=False)
     slug: Mapped[str] = mapped_column(Text, nullable=False)
     # 4dd399c6: False=자동관리(제목 파생·untitled-* 교정 대상), True=사용자 고정(자동 교정 금지).

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -520,3 +520,35 @@ async def list_doc_revisions(
     ).order_by(DocRevision.created_at.desc()).limit(limit)
     result = await db.execute(q)
     return [DocRevisionResponse.model_validate(r) for r in result.scalars()]
+
+
+class DocTransitionRequest(BaseModel):
+    status: str
+
+
+@router.post("/{id}/transition", response_model=DocResponse)
+async def transition_doc_endpoint(
+    id: uuid.UUID,
+    body: DocTransitionRequest,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> DocResponse:
+    """E-DG S22: doc decision lifecycle 전이(create/update 와 분리). draft→confirmed 는 human-only
+    (+enforcing 시 line human-gate overlay). caller 는 인증 컨텍스트에서 도출(RC① 패턴·body 신뢰 X)."""
+    from app.services.doc import DocTransitionError, transition_doc
+    from app.services.member_resolver import resolve_member
+
+    caller = await resolve_member(auth, org_id, session)
+    try:
+        doc = await transition_doc(session, org_id, caller, id, body.status)
+        await session.commit()
+        return DocResponse.model_validate(doc)
+    except DocTransitionError as e:
+        _codes = {
+            "DOC_NOT_FOUND": 404, "HUMAN_CONFIRM_REQUIRED": 403,
+            "INVALID_STATUS": 422, "INVALID_DOC_TRANSITION": 422,
+        }
+        raise HTTPException(
+            status_code=_codes.get(e.code, 400), detail={"code": e.code, "message": e.message}
+        )

--- a/backend/app/schemas/doc.py
+++ b/backend/app/schemas/doc.py
@@ -68,6 +68,8 @@ class DocResponse(BaseModel):
     parent_id: uuid.UUID | None = None
     created_by: uuid.UUID | None = None
     assignee_id: uuid.UUID | None = None
+    # E-DG S22: doc decision status(doc-specific lifecycle·work status 아님). 기본 draft.
+    status: str = "draft"
     title: str
     slug: str
     canonical_slug: str

--- a/backend/app/services/agent_dispatch.py
+++ b/backend/app/services/agent_dispatch.py
@@ -214,3 +214,69 @@ async def dispatch_entity_to_assignee(
         "hypothesis_anchor": hypothesis_anchor,
     }
     return response, delivery
+
+
+async def dispatch_payload_to_member(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    member_id: uuid.UUID,
+    *,
+    title: str,
+    content: str,
+    source_entity_type: str,
+    source_entity_id: uuid.UUID,
+    project_id: uuid.UUID | None = None,
+    message: str | None = None,
+    trigger_metadata: dict[str, Any] | None = None,
+    sender_id: uuid.UUID | None = None,
+    commit: bool = True,
+) -> DispatchResponse:
+    """S22: entity assignee 와 무관하게 **특정 member**(예: doc author=created_by)에게 dispatched
+    이벤트 생성 + (agent) wake. ``dispatch_entity_to_assignee`` 의 member-dispatch core 를 author-wake
+    용으로 분리한 lower-level helper(assignee 고정 우회). 순서/불변식 동일(flush→seq→commit 후 wake).
+    ⚠️ commit=False 면 호출자 트랜잭션 합류(여기서 commit/wake 안 함·P1-2)."""
+    member = await resolve_member_identity(member_id, org_id, db)
+    if member is None:
+        return DispatchResponse(dispatched=False, assignee_id=member_id, reason="unresolved_member")
+    member_type = member.type
+
+    payload: dict[str, Any] = {
+        "entity_type": source_entity_type,
+        "entity_id": str(source_entity_id),
+        "title": title,
+        "message": message,
+        "content": content,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    if trigger_metadata is not None:
+        payload["trigger_metadata"] = trigger_metadata  # 새 event type 금지·trigger_metadata additive
+
+    event = Event(
+        project_id=project_id,
+        org_id=org_id,
+        event_type=EventType.dispatched.value,
+        source_entity_type=source_entity_type,
+        source_entity_id=source_entity_id,
+        sender_id=sender_id,
+        recipient_id=member_id,
+        recipient_type=member_type,
+        payload=payload,
+        status="pending",
+    )
+    db.add(event)
+    await db.flush()
+    if member_type == "agent":
+        await assign_recipient_seq(db, event)
+    await extract_activities_best_effort(db, [event.id])
+
+    if commit:
+        await db.commit()
+        if member_type == "agent":
+            if event.recipient_seq is not None:
+                wake_agent(str(member_id), event.recipient_seq)
+            else:
+                _push_to_agent(str(member_id), _event_to_payload(event))
+    return DispatchResponse(
+        dispatched=True, event_id=event.id, assignee_id=member_id,
+        assignee_type=member_type, recipient_seq=event.recipient_seq, reason="ok",
+    )

--- a/backend/app/services/doc.py
+++ b/backend/app/services/doc.py
@@ -1,0 +1,76 @@
+"""E-DG S22: doc decision lifecycle 전이 서비스.
+
+doc 의 native status(0128·doc-specific 값)를 hypothesis 와 동형 패턴으로 전이한다. ⭐draft→confirmed
+만 line overlay-gated(enforcing→human-gate·default-off→inline human confirm). 나머지 전이는 native
+직행. ``via_gate=True`` = Decision Gate 승인이 적용하는 경로(overlay 재진입 차단).
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.doc import Doc, DOC_STATUSES, is_valid_doc_transition
+from app.services.member_resolver import ResolvedMember
+
+
+class DocTransitionError(Exception):
+    """도메인 오류 — 라우터가 code/message 를 HTTPException 으로 매핑."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+async def transition_doc(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    caller: ResolvedMember,
+    doc_id: uuid.UUID,
+    to_status: str,
+    via_gate: bool = False,
+) -> Doc:
+    """doc status 전이. draft→confirmed 는 human-only(+enforcing 시 line overlay). via_gate=True 면
+    overlay 재진입(re-gate 루프) 없이 native 직행(caller=gate approver·human)."""
+    doc = (await session.execute(
+        select(Doc).where(Doc.id == doc_id, Doc.org_id == org_id, Doc.deleted_at.is_(None))
+    )).scalar_one_or_none()
+    if doc is None:
+        raise DocTransitionError("DOC_NOT_FOUND", "문서를 찾을 수 없습니다.")
+
+    if to_status not in DOC_STATUSES:
+        raise DocTransitionError("INVALID_STATUS", f"알 수 없는 doc status: {to_status}")
+    if not is_valid_doc_transition(doc.status, to_status):
+        raise DocTransitionError(
+            "INVALID_DOC_TRANSITION", f"불법 전이: {doc.status} → {to_status}"
+        )
+
+    # ⭐E-DG S22: draft→confirmed line overlay. enforcing 라인이면 human-gate 생성·draft 유지(가시
+    # confirm 대기). default-off/plain/엔진실패 → 아래 inline human-only 폴백(byte-동일·agent 차단 유지·
+    # ⚠️fail-open=confirmed 통과 아님). via_gate(gate 승인 적용)면 overlay skip.
+    if to_status == "confirmed" and doc.status == "draft" and not via_gate:
+        _decision = None
+        try:
+            from app.services.workflow_line_engine import evaluate_line_for_transition
+            _decision = await evaluate_line_for_transition(
+                session, org_id=org_id, project_id=doc.project_id,
+                entity_type="doc", entity_id=doc.id,
+                from_status="draft", to_status="confirmed",
+                actor_id=caller.id, actor_type=caller.type,
+            )
+        except Exception:  # noqa: BLE001 — fail-open: 엔진 실패는 inline human-only 폴백(agent 차단 유지).
+            _decision = None
+        if _decision is not None and not _decision.proceeds:
+            # enforcing: human-gate pending. doc draft 유지·gate 가 confirm 대기 가시화(에러 아님).
+            await session.commit()  # gate/step_run 보존(stories.py:736 패턴).
+            return doc
+
+    # confirm 확정은 휴먼만(콘텐츠 승인=human-validated). agent 직접 confirm 차단.
+    if to_status == "confirmed" and caller.type != "human":
+        raise DocTransitionError("HUMAN_CONFIRM_REQUIRED", "confirmed 전이는 휴먼만 가능합니다.")
+
+    doc.status = to_status
+    await session.flush()
+    return doc

--- a/backend/app/services/workflow_line_resolution.py
+++ b/backend/app/services/workflow_line_resolution.py
@@ -142,8 +142,9 @@ async def _apply_doc_confirmed(
         sr.resolved_at = _now()
         await session.flush()
         return
-    # ⭐SoD: approver 미상이거나 author(created_by) 자신이면 차단(자기 doc 자기 confirm).
-    if resolver_id is None or resolver_id == doc.created_by:
+    # ⭐SoD(RC②): approver 미상 OR author 불명(created_by None) OR author 자신이면 차단. ⚠️created_by
+    # None 을 fail-closed 로 막지 않으면 created_by=null doc 생성 후 self-confirm 으로 SoD 우회([[feedback_actor_type_failclosed]]).
+    if resolver_id is None or doc.created_by is None or resolver_id == doc.created_by:
         sr.status = "skipped"
         sr.resolved_at = _now()
         await session.flush()

--- a/backend/app/services/workflow_line_resolution.py
+++ b/backend/app/services/workflow_line_resolution.py
@@ -114,6 +114,63 @@ async def _apply_hypothesis_active(
     await session.flush()
 
 
+async def _apply_doc_confirmed(
+    session: AsyncSession, sr: WorkflowLineStepRun, resolver_id: uuid.UUID | None
+) -> None:
+    """S22: doc draft→confirmed gate 승인 적용. native ``transition_doc`` 재사용(parallel 0). ⭐SoD:
+    approver ≠ doc.created_by(author·자기 doc 자기 confirm 차단). 승인 후 author(created_by) 자동재개
+    wake(commit=False·gate 트랜잭션 합류·§6 dispatch tx commit 0)."""
+    from app.models.doc import Doc
+    from app.services.doc import transition_doc
+    from app.services.member_resolver import ResolvedMember
+
+    doc = (await session.execute(
+        select(Doc).where(Doc.id == sr.entity_id).with_for_update()
+    )).scalar_one_or_none()
+    if doc is None:
+        sr.status = "approved"
+        sr.resolved_at = _now()
+        await session.flush()
+        return
+    if doc.status == "confirmed":  # 멱등: 이미 confirmed → no-op.
+        sr.status = "applied"
+        sr.resolved_at = _now()
+        await session.flush()
+        return
+    if doc.status != "draft":  # stale: draft 아니면 미적용.
+        sr.status = "skipped"
+        sr.resolved_at = _now()
+        await session.flush()
+        return
+    # ⭐SoD: approver 미상이거나 author(created_by) 자신이면 차단(자기 doc 자기 confirm).
+    if resolver_id is None or resolver_id == doc.created_by:
+        sr.status = "skipped"
+        sr.resolved_at = _now()
+        await session.flush()
+        logger.warning(
+            "doc_confirm_sod_block sr=%s approver=%s author=%s", sr.id, resolver_id, doc.created_by,
+        )
+        return
+    approver = ResolvedMember(
+        id=resolver_id, user_id=None, name="gate_approver", type="human", role="member",
+        org_id=sr.org_id,
+    )
+    await transition_doc(session, sr.org_id, approver, doc.id, "confirmed", via_gate=True)
+    # author 자동재개(success_hypothesis): created_by 에게 dispatched 이벤트(commit=False → gate
+    # 트랜잭션 합류·gates.py:137 commit 후 agent 가 consume·새 event type 0·trigger_metadata만).
+    if doc.created_by is not None:
+        from app.services.agent_dispatch import dispatch_payload_to_member
+        await dispatch_payload_to_member(
+            session, sr.org_id, doc.created_by,
+            title=doc.title or "doc", content=f"[doc confirmed] {doc.title or ''}".strip(),
+            source_entity_type="doc", source_entity_id=doc.id, project_id=doc.project_id,
+            trigger_metadata={"source": "workflow_line", "reason": "doc_confirmed"}, commit=False,
+        )
+    sr.status = "applied"
+    sr.resolved_at = _now()
+    await session.flush()
+
+
 async def apply_workflow_line_resolution(
     session: AsyncSession, step_run_id: uuid.UUID, new_status: str,
     resolver_id: uuid.UUID | None = None,
@@ -153,9 +210,12 @@ async def apply_workflow_line_resolution(
         await session.flush()
         return
 
-    # S23: hypothesis 는 native FSM 재사용(transition_hypothesis·parallel 0). story 는 기존 inline.
+    # S23/S22: hypothesis/doc 는 native FSM 재사용(transition_*·parallel 0). story 는 기존 inline.
     if sr.entity_type == "hypothesis":
         await _apply_hypothesis_active(session, sr, resolver_id)
+        return
+    if sr.entity_type == "doc":
+        await _apply_doc_confirmed(session, sr, resolver_id)
         return
 
     from app.models.pm import Story  # 순환 회피 lazy import.

--- a/backend/app/services/workflow_readiness_matrix.py
+++ b/backend/app/services/workflow_readiness_matrix.py
@@ -21,6 +21,7 @@ import logging
 import uuid
 from dataclasses import dataclass
 
+from app.models.doc import DOC_STATUSES
 from app.models.hypothesis import HYPOTHESIS_STATUSES
 from app.schemas.epic import EPIC_STATUSES
 
@@ -89,14 +90,13 @@ READINESS_MATRIX: dict[str, EntityReadiness] = {
     ),
     "doc": EntityReadiness(
         entity_type="doc",
-        has_native_status=False,                 # doc.py: status 컬럼 부재
-        status_enum=None,
-        valid_transitions=None,
-        gating_eligible=False,
+        has_native_status=True,                  # S22(A): docs.status native 컬럼(0128·doc-specific 값)
+        status_enum=frozenset(DOC_STATUSES),      # doc.py DOC_STATUSES(draft|confirmed|denied|superseded|deprecated)
+        # ⭐S22: overlay-gated subset = draft→confirmed 만(full FSM 은 doc.py _DOC_VALID_TRANSITIONS SSOT).
+        valid_transitions=frozenset({("draft", "confirmed")}),
+        gating_eligible=True,                     # S22: draft→confirmed overlay 가동
         dispatch_capable=True,
-        # 잠정권고(S21 lock 금지·S22 design 이연): docs.status native 컬럼 vs virtual overlay.
-        # doc lifecycle(콘텐츠 승인)이 work status 와 의미가 달라 동형성만으로 결정 안 함.
-        blocking_reason="docs_status_undefined_pending_s22",
+        blocking_reason=None,
     ),
 }
 

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -19,6 +19,7 @@ def _mock_doc() -> MagicMock:
     d.parent_id = None
     d.created_by = None
     d.assignee_id = None
+    d.status = "draft"  # E-DG S22: 신규 status 필드(MagicMock→DocResponse 검증 실패 방지)
     d.title = "Getting Started"
     d.slug = "getting-started"
     d.canonical_slug = "getting-started"  # 4dd399c6: property on real Doc; mock 명시 필수

--- a/backend/tests/test_edg_s21_readiness_matrix.py
+++ b/backend/tests/test_edg_s21_readiness_matrix.py
@@ -28,10 +28,11 @@ def anyio_backend():
 # ── matrix descriptor 정확성(② 검증된 enum·gradient) ──────────────────────────
 def test_matrix_covers_five_entities_with_verified_contracts():
     assert set(READINESS_MATRIX) == {"story", "hypothesis", "epic", "sprint", "doc"}
-    # gradient: story + hypothesis(S23) gating_eligible. epic/sprint/doc 아직 미가동.
+    # gradient: story + hypothesis(S23) + doc(S22) gating_eligible. epic/sprint 아직 미가동.
     assert get_readiness("story").gating_eligible is True
     assert get_readiness("hypothesis").gating_eligible is True  # S23 flip
-    for e in ("epic", "sprint", "doc"):
+    assert get_readiness("doc").gating_eligible is True         # S22 flip
+    for e in ("epic", "sprint"):
         assert get_readiness(e).gating_eligible is False
         assert get_readiness(e).blocking_reason  # 사유 명시(silent 금지)
     # 검증된 enum(SSOT import) — hypothesis/epic.
@@ -40,8 +41,9 @@ def test_matrix_covers_five_entities_with_verified_contracts():
     # S23: valid_transitions = overlay-gated subset(proposed→active 만)·full FSM 은 hypothesis.py SSOT.
     assert hyp.valid_transitions == frozenset({("proposed", "active")})
     assert get_readiness("epic").status_enum == frozenset({"draft", "active", "done", "archived"})
-    # doc=native status 없음·sprint=enum 없음(free-string).
-    assert get_readiness("doc").has_native_status is False
+    # S22: doc=native status 컬럼(0128)·draft→confirmed overlay·sprint=enum 없음(free-string).
+    assert get_readiness("doc").has_native_status is True
+    assert get_readiness("doc").valid_transitions == frozenset({("draft", "confirmed")})
     assert get_readiness("sprint").status_enum is None and get_readiness("sprint").has_native_status is True
     # story=config-driven(모델 enum 상수 없음).
     assert get_readiness("story").status_enum is None and get_readiness("story").valid_transitions is None
@@ -52,8 +54,11 @@ def test_is_transition_supported_only_eligible():
     # S23: hypothesis proposed→active 는 overlay-gated(True)·그 외 hyp 전이는 scope 밖(False·native 직행).
     assert is_transition_supported("hypothesis", "proposed", "active") is True
     assert is_transition_supported("hypothesis", "active", "measuring") is False
-    # 비-eligible(doc) + 미등록은 False.
-    assert is_transition_supported("doc", "a", "b") is False
+    # S22: doc draft→confirmed overlay-gated(True)·그 외 doc 전이는 scope 밖.
+    assert is_transition_supported("doc", "draft", "confirmed") is True
+    assert is_transition_supported("doc", "confirmed", "superseded") is False
+    # 비-eligible(epic) + 미등록은 False.
+    assert is_transition_supported("epic", "draft", "active") is False
     assert is_transition_supported("unknown", "a", "b") is False  # 미등록=no-op
 
 
@@ -64,11 +69,11 @@ def test_get_readiness_unknown_returns_none():
 # ── 미지원 no-op 이 silent 아닐 것(④ observability) ──────────────────────────
 def test_unsupported_attempt_emits_structured_log(caplog):
     with caplog.at_level(logging.INFO, logger="app.services.workflow_readiness_matrix"):
-        record_unsupported_entity_attempt("doc", "draft", "published", uuid.uuid4())
+        record_unsupported_entity_attempt("sprint", "planning", "active", uuid.uuid4())
     rec = [r for r in caplog.records if "unsupported_entity_gate_attempt" in r.getMessage()]
     assert rec, "미지원 시도가 로그로 남아야 한다(silent 금지)"
     assert getattr(rec[0], "metric", None) == "unsupported_entity_gate_attempt_count"
-    assert getattr(rec[0], "blocking_reason", None) == "docs_status_undefined_pending_s22"
+    assert getattr(rec[0], "blocking_reason", None) == "status_enum_undefined_pending_s26"
 
 
 def test_unsupported_attempt_unknown_entity_logs_reason(caplog):
@@ -83,11 +88,10 @@ def test_unsupported_attempt_unknown_entity_logs_reason(caplog):
 async def test_routing_context_non_eligible_returns_descriptor_reason():
     from app.services.workflow_line_resolver import resolve_routing_context
     session = AsyncMock()  # 비-eligible 은 session.get 전에 반환 → DB 불필요
-    # S23: hypothesis 는 eligible 승격(session.get 경로) → 여기선 비-eligible 만 검사.
+    # S23 hypothesis·S22 doc 는 eligible 승격(session.get 경로) → 여기선 비-eligible(epic/sprint)만 검사.
     for entity, reason in [
         ("epic", "transition_rules_undefined_pending_s25"),
         ("sprint", "status_enum_undefined_pending_s26"),
-        ("doc", "docs_status_undefined_pending_s22"),
     ]:
         ctx = await resolve_routing_context(session, uuid.uuid4(), entity_type=entity, entity_id=uuid.uuid4())
         assert ctx["supported"] is False and ctx["reason"] == reason

--- a/backend/tests/test_edg_s22_doc_overlay.py
+++ b/backend/tests/test_edg_s22_doc_overlay.py
@@ -38,6 +38,23 @@ def test_matrix_doc_eligible_draft_to_confirmed_only():
     assert is_transition_supported("doc", "confirmed", "superseded") is False  # scope 밖
 
 
+@pytest.mark.anyio
+async def test_apply_sod_blocks_author_null_doc():
+    """⭐RC②(SoD fail-closed·CI-runnable·skipif 없음): created_by=None(저자 불명) doc → confirm 차단.
+    없으면 created_by=null 생성 후 self-confirm 으로 SoD 우회(UUID==None=False 빈틈)."""
+    from unittest.mock import AsyncMock, MagicMock
+    from app.services.workflow_line_resolution import _apply_doc_confirmed
+    doc = MagicMock(status="draft", created_by=None, id=uuid.uuid4(),
+                    title="x", project_id=uuid.uuid4())
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = doc
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=result)
+    sr = MagicMock(entity_type="doc", entity_id=doc.id, org_id=uuid.uuid4())
+    await _apply_doc_confirmed(session, sr, resolver_id=uuid.uuid4())  # 임의 approver
+    assert sr.status == "skipped"  # author 불명 → fail-closed 차단(transition_doc 미도달)
+
+
 async def _session():
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
     from app.core.database import Base

--- a/backend/tests/test_edg_s22_doc_overlay.py
+++ b/backend/tests/test_edg_s22_doc_overlay.py
@@ -1,0 +1,172 @@
+"""E-DG S22: doc decision overlay (docs.status·draft→confirmed line overlay).
+
+핵심: doc FSM·gate 승인 applier 가 native transition_doc(via_gate) 재사용·⭐SoD(approver≠created_by
+author)·author 자동재개 wake(commit=False)·default-off byte-동일(agent confirm 차단). 마이그 백필 draft.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── doc FSM(unit·DB 없이) ─────────────────────────────────────────────────────
+def test_doc_fsm_valid_transitions():
+    from app.models.doc import DOC_STATUSES, is_valid_doc_transition
+    assert DOC_STATUSES == {"draft", "confirmed", "denied", "superseded", "deprecated"}
+    assert is_valid_doc_transition("draft", "confirmed")
+    assert is_valid_doc_transition("denied", "draft")          # revise
+    assert is_valid_doc_transition("confirmed", "superseded")
+    assert not is_valid_doc_transition("confirmed", "draft")   # 역전이 금지
+    assert not is_valid_doc_transition("draft", "deprecated")  # 비합법
+
+
+def test_matrix_doc_eligible_draft_to_confirmed_only():
+    from app.services.workflow_readiness_matrix import get_readiness, is_transition_supported
+    d = get_readiness("doc")
+    assert d.gating_eligible is True and d.has_native_status is True
+    assert d.valid_transitions == frozenset({("draft", "confirmed")})
+    assert is_transition_supported("doc", "draft", "confirmed") is True
+    assert is_transition_supported("doc", "confirmed", "superseded") is False  # scope 밖
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.participation  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    import app.models.event  # noqa: F401 — author wake dispatched 이벤트(events 테이블)
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_doc(s, org, proj, author, status="draft"):
+    from app.models.doc import Doc
+    d = Doc(org_id=org, project_id=proj, created_by=author, title="문서", slug="doc-x",
+            content="", status=status)
+    s.add(d)
+    await s.flush()
+    return d
+
+
+async def _seed_sr(s, org, proj, doc_id):
+    from app.models.workflow_line import WorkflowLineStepRun
+    sr = WorkflowLineStepRun(
+        org_id=org, project_id=proj, entity_type="doc", entity_id=doc_id,
+        from_status="draft", to_status="confirmed", status="gate_pending", mode="enforcing",
+        correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex,
+    )
+    s.add(sr)
+    await s.flush()
+    return sr
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_apply_sod_blocks_author_self_confirm():
+    """⭐SoD: approver == created_by(author) → 차단(skipped)·doc draft 유지."""
+    from app.services.workflow_line_resolution import _apply_doc_confirmed
+    from app.models.project import Project
+    from sqlalchemy import text as sa_text
+    engine, Session = await _session()
+    async with Session() as s:
+        org, proj, author = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        s.add(Project(id=proj, org_id=org, name="p"))
+        await s.flush()
+        doc = await _seed_doc(s, org, proj, author)
+        sr = await _seed_sr(s, org, proj, doc.id)
+        await _apply_doc_confirmed(s, sr, resolver_id=author)  # author 자기 confirm
+        await s.commit()
+        st = (await s.execute(sa_text("SELECT status FROM docs WHERE id=:i"), {"i": doc.id})).scalar()
+        assert st == "draft" and sr.status == "skipped"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_apply_different_approver_confirms_and_wakes_author(monkeypatch):
+    """approver ≠ author → confirmed + author(created_by) 자동재개 wake 호출(member_id=author)."""
+    from app.services.workflow_line_resolution import _apply_doc_confirmed
+    from app.models.project import Project
+    from sqlalchemy import text as sa_text
+    import app.services.agent_dispatch as ad
+    captured = {}
+
+    async def _fake_wake(db, org_id, member_id, **kw):
+        captured["member_id"] = member_id
+        captured["commit"] = kw.get("commit")
+        from app.services.agent_dispatch import DispatchResponse
+        return DispatchResponse(dispatched=True, reason="ok")
+
+    monkeypatch.setattr(ad, "dispatch_payload_to_member", _fake_wake)
+    engine, Session = await _session()
+    async with Session() as s:
+        org, proj, author, approver = uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        s.add(Project(id=proj, org_id=org, name="p"))
+        await s.flush()
+        doc = await _seed_doc(s, org, proj, author)
+        sr = await _seed_sr(s, org, proj, doc.id)
+        await _apply_doc_confirmed(s, sr, resolver_id=approver)
+        await s.commit()
+        st = (await s.execute(sa_text("SELECT status FROM docs WHERE id=:i"), {"i": doc.id})).scalar()
+        assert st == "confirmed" and sr.status == "applied"
+        # ⭐author 자동재개: created_by 대상 wake·commit=False(gate 트랜잭션 합류·§6).
+        assert captured["member_id"] == author and captured["commit"] is False
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_apply_idempotent_already_confirmed():
+    from app.services.workflow_line_resolution import _apply_doc_confirmed
+    from app.models.project import Project
+    engine, Session = await _session()
+    async with Session() as s:
+        org, proj, author, approver = uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        s.add(Project(id=proj, org_id=org, name="p"))
+        await s.flush()
+        doc = await _seed_doc(s, org, proj, author, status="confirmed")
+        sr = await _seed_sr(s, org, proj, doc.id)
+        await _apply_doc_confirmed(s, sr, resolver_id=approver)
+        await s.commit()
+        assert sr.status == "applied"  # no-op·예외 0
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_default_off_agent_confirm_blocked():
+    """default-off(라인 없음): agent confirm 시도 → overlay decision=plain → inline HUMAN_CONFIRM_REQUIRED
+    유지(byte-동일·fail-open=통과 아님)."""
+    from app.services.doc import transition_doc, DocTransitionError
+    from app.services.member_resolver import ResolvedMember
+    from app.models.project import Project
+    engine, Session = await _session()
+    async with Session() as s:
+        org, proj, author = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        s.add(Project(id=proj, org_id=org, name="p"))
+        await s.flush()
+        doc = await _seed_doc(s, org, proj, author)
+        await s.commit()
+        agent = ResolvedMember(id=uuid.uuid4(), user_id=None, name="a", type="agent",
+                               role="member", org_id=org)
+        with pytest.raises(DocTransitionError) as ei:
+            await transition_doc(s, org, agent, doc.id, "confirmed")
+        assert ei.value.code == "HUMAN_CONFIRM_REQUIRED"
+    await engine.dispose()


### PR DESCRIPTION
## [E-DG][S22] Doc decision overlay (docs.status·draft→confirmed line overlay)

E-DG Phase 2. design-review **(A) 승인분**. doc 은 native status 없어 **doc-specific lifecycle 값**(`draft|confirmed|denied|superseded|deprecated`)을 native 컬럼으로 추가 — work status 재사용 0(콘텐츠 승인≠작업 진행 의미 분리). **목적: 문서 승인 후 채팅 GO 없이 author agent 자동 재개.** additive 마이그·default-off·기존 doc byte-동일.

설계 doc: `design-edg-s22-doc-decision-overlay` (PO (A) 승인·5조건).

### 변경
| 영역 | 내용 |
|------|------|
| 마이그 **0128** | `docs.status` Text NN server_default `draft`·기존 doc 백필 draft(보수적)·index. additive |
| 모델/FSM `doc.py` | status + `DOC_STATUSES` + `_DOC_VALID_TRANSITIONS` + `is_valid_doc_transition`. ⭐draft→confirmed만 overlay-gated |
| 서비스 `services/doc.py` | `transition_doc` + overlay(enforcing→human-gate·default-off→inline human-only·fail-open=inline 폴백·via_gate) |
| 엔드포인트 | `POST /docs/{id}/transition`(create/update와 분리·caller 인증컨텍스트·RC① 패턴) |
| matrix | doc `gating_eligible` F→T·`has_native_status` T·`valid_transitions={(draft,confirmed)}` |
| applier `_apply_doc_confirmed` | native transition_doc(via_gate) 재사용·⭐SoD(approver≠created_by author)·멱등·author wake |
| helper | `dispatch_payload_to_member`: assignee 무관 특정 member(author) dispatched+wake(author≠assignee 분리) |

### PO 5조건 충족
1. **author 컬럼 확정**: doc author=`created_by`(doc.py:23·drafted_by 없음)·assignee_id=리뷰어 별개.
2. **SoD = approver≠`created_by`**(자기 doc 자기 confirm 차단)·resolver None도 차단·S23 RC① gates.py resolver_id 강제 위.
3. **마이그 default draft 백필**(기존 doc 전부 draft·보수적·default-off 동작영향0). 기존분 draft 뱃지 UX=유나 FE 표시정책.
4. **draft→confirmed만 overlay**·§7 S23 동형(parallel 0·engine실패=inline fail-open·새 event 0·dispatch tx commit 0).
5. **`dispatch_payload_to_member` helper**(commit=False·§6). ⚠️산티아고군 SME consult 대상(dispatch 영역).

### 테스트 / 무회귀
- S22 5종 PASS(doc FSM·matrix flip·SoD self-confirm 차단·confirm+author-wake[member_id=author·commit=False]·멱등·default-off agent 차단) + S21 matrix doc flip 갱신.
- ⭐story byte-동일: 엔진 회귀 **12 failed=baseline 동일**(create_all blindspot·내 시그니처 0). DocResponse mock 10파일 **95 passed**(status 회귀 0·시그니처 triage). 변경 소스 ruff-clean.

### 안전 / 이연
additive 마이그·default-off. **머지+migrate-dev 0128 원자**(migrate-dev=PO gcloud). FE(doc 뱃지·transition UI·status≠work status 시각 구분)=유나/미르코 경유(나중). S28(resubmit) 본 S22 위.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
