### PR TITLE
[E-DG][S25] Epic line overlay (draft→active + active→done)

### DIFF
--- a/backend/app/routers/epics.py
+++ b/backend/app/routers/epics.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user, get_verified_org_id
@@ -181,3 +182,35 @@ async def get_epic_progress(
     if epic is None:
         raise HTTPException(status_code=404, detail="Epic not found")
     return await repo.get_progress(id)
+
+
+class EpicTransitionRequest(BaseModel):
+    status: str
+
+
+@router.post("/{id}/transition", response_model=EpicResponse)
+async def transition_epic_endpoint(
+    id: uuid.UUID,
+    body: EpicTransitionRequest,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> EpicResponse:
+    """E-DG S25: epic decision lifecycle 전이(create/update 분리). draft→active(human-only)·active→done
+    line overlay. caller 는 인증 컨텍스트에서 도출(RC① 패턴·body 신뢰 X)."""
+    from app.services.epic import EpicTransitionError, transition_epic
+    from app.services.member_resolver import resolve_member
+
+    caller = await resolve_member(auth, org_id, session)
+    try:
+        epic = await transition_epic(session, org_id, caller, id, body.status)
+        await session.commit()
+        return EpicResponse.model_validate(epic)
+    except EpicTransitionError as e:
+        _codes = {
+            "EPIC_NOT_FOUND": 404, "HUMAN_CONFIRM_REQUIRED": 403,
+            "INVALID_STATUS": 422, "INVALID_EPIC_TRANSITION": 422,
+        }
+        raise HTTPException(
+            status_code=_codes.get(e.code, 400), detail={"code": e.code, "message": e.message}
+        )

--- a/backend/app/schemas/epic.py
+++ b/backend/app/schemas/epic.py
@@ -7,6 +7,20 @@ from pydantic import BaseModel, ConfigDict
 EPIC_STATUSES = ("draft", "active", "done", "archived")
 EPIC_PRIORITIES = ("critical", "high", "medium", "low")
 
+# E-DG S25: epic decision lifecycle 전이규칙. ⭐draft→active·active→done 만 line overlay-gated
+# (나머지 archive 류는 native 직행). hypothesis _VALID_TRANSITIONS 패턴 미러.
+_EPIC_VALID_TRANSITIONS: set[tuple[str, str]] = {
+    ("draft", "active"),       # activation(human-gate overlay)
+    ("active", "done"),        # completion(aggregate-gate overlay)
+    ("active", "archived"),    # native
+    ("done", "archived"),      # native
+    ("draft", "archived"),     # native
+}
+
+
+def is_valid_epic_transition(from_status: str, to_status: str) -> bool:
+    return (from_status, to_status) in _EPIC_VALID_TRANSITIONS
+
 
 class EpicCreate(BaseModel):
     project_id: uuid.UUID

--- a/backend/app/services/epic.py
+++ b/backend/app/services/epic.py
@@ -1,0 +1,80 @@
+"""E-DG S25: epic decision lifecycle 전이 서비스.
+
+epic native status(draft|active|done|archived)를 hypothesis/doc 동형 패턴으로 전이한다. ⭐**TWO
+overlay-gated 전이**: draft→active(activation·human-gate) + active→done(completion·aggregate-gate).
+나머지(archive 류)는 native 직행. ``via_gate=True`` = Decision Gate 승인 적용 경로(overlay 재진입 차단).
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.pm import Epic
+from app.schemas.epic import EPIC_STATUSES, is_valid_epic_transition
+from app.services.member_resolver import ResolvedMember
+
+# overlay-gated 전이(나머지는 native 직행). matrix valid_transitions 와 일치.
+_OVERLAY_TRANSITIONS = frozenset({("draft", "active"), ("active", "done")})
+
+
+class EpicTransitionError(Exception):
+    """도메인 오류 — 라우터가 code/message 를 HTTPException 으로 매핑."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+async def transition_epic(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    caller: ResolvedMember,
+    epic_id: uuid.UUID,
+    to_status: str,
+    via_gate: bool = False,
+) -> Epic:
+    """epic status 전이. draft→active·active→done 는 line overlay-gated(enforcing→gate·default-off→
+    inline). draft→active 는 human-only(activation=human decision). via_gate=True 면 overlay 재진입 없이
+    native 직행(caller=gate approver)."""
+    epic = (await session.execute(
+        select(Epic).where(Epic.id == epic_id, Epic.org_id == org_id)
+    )).scalar_one_or_none()
+    if epic is None:
+        raise EpicTransitionError("EPIC_NOT_FOUND", "에픽을 찾을 수 없습니다.")
+
+    if to_status not in EPIC_STATUSES:
+        raise EpicTransitionError("INVALID_STATUS", f"알 수 없는 epic status: {to_status}")
+    if not is_valid_epic_transition(epic.status, to_status):
+        raise EpicTransitionError(
+            "INVALID_EPIC_TRANSITION", f"불법 전이: {epic.status} → {to_status}"
+        )
+
+    # ⭐E-DG S25: draft→active / active→done line overlay. enforcing 라인이면 gate 생성·status 유지
+    # (가시 결재 대기). default-off/plain/엔진실패 → 아래 inline 폴백(byte-동일·⚠️fail-open=통과 아님).
+    # via_gate(gate 승인 적용)면 overlay skip. active→done 의 routing_context aggregate 는 resolver 가 산출.
+    if (epic.status, to_status) in _OVERLAY_TRANSITIONS and not via_gate:
+        _decision = None
+        try:
+            from app.services.workflow_line_engine import evaluate_line_for_transition
+            _decision = await evaluate_line_for_transition(
+                session, org_id=org_id, project_id=epic.project_id,
+                entity_type="epic", entity_id=epic.id,
+                from_status=epic.status, to_status=to_status,
+                actor_id=caller.id, actor_type=caller.type,
+            )
+        except Exception:  # noqa: BLE001 — fail-open: 엔진 실패는 inline 폴백(차단 유지).
+            _decision = None
+        if _decision is not None and not _decision.proceeds:
+            await session.commit()  # gate/step_run 보존(stories.py:736 패턴).
+            return epic
+
+    # activation(draft→active)은 휴먼만(PO/owner decision). active→done 은 inline 시 caller 권한(라우터 보강).
+    if to_status == "active" and caller.type != "human":
+        raise EpicTransitionError("HUMAN_CONFIRM_REQUIRED", "active(activation) 전이는 휴먼만 가능합니다.")
+
+    epic.status = to_status
+    await session.flush()
+    return epic

--- a/backend/app/services/workflow_line_resolution.py
+++ b/backend/app/services/workflow_line_resolution.py
@@ -172,6 +172,66 @@ async def _apply_doc_confirmed(
     await session.flush()
 
 
+async def _apply_epic_transition(
+    session: AsyncSession, sr: WorkflowLineStepRun, resolver_id: uuid.UUID | None
+) -> None:
+    """S25: epic draft→active / active→done gate 승인 적용. native ``transition_epic``(via_gate) 재사용
+    (parallel 0). ⭐SoD(draft→active activation 만): approver ≠ epic.assignee_id(owner proxy·fail-closed).
+    ⚠️epic assignee 흔히 null→enforcing 시 과차단 — enforcing 전 SoD 대상 project owner 로 정교화 필요
+    (enable-prep·default-off 무해). active→done(completion)은 SoD 무관."""
+    from app.models.pm import Epic
+    from app.services.epic import transition_epic
+    from app.services.member_resolver import ResolvedMember
+
+    epic = (await session.execute(
+        select(Epic).where(Epic.id == sr.entity_id).with_for_update()
+    )).scalar_one_or_none()
+    if epic is None:
+        sr.status = "approved"
+        sr.resolved_at = _now()
+        await session.flush()
+        return
+    if epic.status == sr.to_status:  # 멱등
+        sr.status = "applied"
+        sr.resolved_at = _now()
+        await session.flush()
+        return
+    if sr.from_status is not None and epic.status != sr.from_status:  # stale
+        sr.status = "skipped"
+        sr.resolved_at = _now()
+        await session.flush()
+        return
+    # ⭐SoD: activation(draft→active)만·approver 미상 ∨ assignee 불명 ∨ ==assignee → 차단(fail-closed).
+    if sr.to_status == "active" and (
+        resolver_id is None or epic.assignee_id is None or resolver_id == epic.assignee_id
+    ):
+        sr.status = "skipped"
+        sr.resolved_at = _now()
+        await session.flush()
+        logger.warning(
+            "epic_activation_sod_block sr=%s approver=%s assignee=%s",
+            sr.id, resolver_id, epic.assignee_id,
+        )
+        return
+    approver = ResolvedMember(
+        id=resolver_id, user_id=None, name="gate_approver", type="human", role="member",
+        org_id=sr.org_id,
+    )
+    await transition_epic(session, sr.org_id, approver, epic.id, sr.to_status, via_gate=True)
+    # assignee 자동재개: epic assignee 에게 dispatched(commit=False·gate 트랜잭션 합류·§6 tx commit 0).
+    if epic.assignee_id is not None:
+        from app.services.agent_dispatch import dispatch_payload_to_member
+        await dispatch_payload_to_member(
+            session, sr.org_id, epic.assignee_id,
+            title=epic.title or "epic", content=f"[epic {sr.to_status}] {epic.title or ''}".strip(),
+            source_entity_type="epic", source_entity_id=epic.id, project_id=epic.project_id,
+            trigger_metadata={"source": "workflow_line", "reason": f"epic_{sr.to_status}"}, commit=False,
+        )
+    sr.status = "applied"
+    sr.resolved_at = _now()
+    await session.flush()
+
+
 async def apply_workflow_line_resolution(
     session: AsyncSession, step_run_id: uuid.UUID, new_status: str,
     resolver_id: uuid.UUID | None = None,
@@ -217,6 +277,9 @@ async def apply_workflow_line_resolution(
         return
     if sr.entity_type == "doc":
         await _apply_doc_confirmed(session, sr, resolver_id)
+        return
+    if sr.entity_type == "epic":
+        await _apply_epic_transition(session, sr, resolver_id)
         return
 
     from app.models.pm import Story  # 순환 회피 lazy import.

--- a/backend/app/services/workflow_line_resolver.py
+++ b/backend/app/services/workflow_line_resolver.py
@@ -19,7 +19,7 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.pm import Story
+from app.models.pm import Epic, Story
 from app.services.trust_score import compute_member_trust_scores
 from app.services.workflow_readiness_matrix import get_readiness, record_unsupported_entity_attempt
 
@@ -108,7 +108,7 @@ async def resolve_routing_context(
     trust = await resolve_trust_snapshot(session, org_id, actor_member_id, role_key)
     # safe default: 위험 불확실 또는 cold-start → ask_human 제안(S4 는 표기만·비차단).
     suggested = "ask_human" if (risk_flags.get("uncertain") or trust.get("cold_start")) else None
-    return {
+    result = {
         "entity_type": entity_type, "entity_id": str(entity_id), "supported": True,
         "story": _story_predicate(story),
         "actor": {
@@ -119,3 +119,22 @@ async def resolve_routing_context(
         "trust": trust,
         "suggested_default": suggested,
     }
+    # ⭐S25: epic 은 산하 story aggregate(completion/open)를 routing material 로 포함(advisory·active→done
+    # 분기 근거·gate 정책 강제 아님·S4 shadow 정합). get_epic_progress 재사용(N+1 0).
+    if entity_type == "epic":
+        result["epic_aggregate"] = await _epic_aggregate(session, org_id, entity_id)
+    return result
+
+
+async def _epic_aggregate(
+    session: AsyncSession, org_id: uuid.UUID, epic_id: uuid.UUID
+) -> dict[str, Any]:
+    """epic 산하 story 완료/리스크 집계(active→done routing material·advisory). get_epic_progress 재사용."""
+    epic = await session.get(Epic, epic_id)
+    if epic is None:
+        return {"total_stories": 0, "done_stories": 0, "completion_pct": 0, "open_stories": 0}
+    from app.repositories.analytics import AnalyticsRepository
+    prog = await AnalyticsRepository(session, org_id).get_epic_progress(epic.project_id, epic_id)
+    total = int(prog.get("total_stories") or 0)
+    done = int(prog.get("done_stories") or 0)
+    return {**prog, "open_stories": total - done}  # open_stories = 미완(risk material)

--- a/backend/app/services/workflow_readiness_matrix.py
+++ b/backend/app/services/workflow_readiness_matrix.py
@@ -74,10 +74,11 @@ READINESS_MATRIX: dict[str, EntityReadiness] = {
         entity_type="epic",
         has_native_status=True,                  # pm.py:59 String(20)
         status_enum=frozenset(EPIC_STATUSES),    # schemas/epic.py:7 (draft|active|done|archived)
-        valid_transitions=None,                  # 전이규칙 미정의
-        gating_eligible=False,
+        # ⭐S25: overlay-gated subset = draft→active·active→done(full FSM 은 epic.py _EPIC_VALID_TRANSITIONS).
+        valid_transitions=frozenset({("draft", "active"), ("active", "done")}),
+        gating_eligible=True,                    # S25: epic activation/completion overlay 가동
         dispatch_capable=True,
-        blocking_reason="transition_rules_undefined_pending_s25",
+        blocking_reason=None,
     ),
     "sprint": EntityReadiness(
         entity_type="sprint",

--- a/backend/tests/test_edg_s21_readiness_matrix.py
+++ b/backend/tests/test_edg_s21_readiness_matrix.py
@@ -32,7 +32,8 @@ def test_matrix_covers_five_entities_with_verified_contracts():
     assert get_readiness("story").gating_eligible is True
     assert get_readiness("hypothesis").gating_eligible is True  # S23 flip
     assert get_readiness("doc").gating_eligible is True         # S22 flip
-    for e in ("epic", "sprint"):
+    assert get_readiness("epic").gating_eligible is True        # S25 flip
+    for e in ("sprint",):
         assert get_readiness(e).gating_eligible is False
         assert get_readiness(e).blocking_reason  # 사유 명시(silent 금지)
     # 검증된 enum(SSOT import) — hypothesis/epic.
@@ -57,8 +58,11 @@ def test_is_transition_supported_only_eligible():
     # S22: doc draft→confirmed overlay-gated(True)·그 외 doc 전이는 scope 밖.
     assert is_transition_supported("doc", "draft", "confirmed") is True
     assert is_transition_supported("doc", "confirmed", "superseded") is False
-    # 비-eligible(epic) + 미등록은 False.
-    assert is_transition_supported("epic", "draft", "active") is False
+    # S25: epic draft→active·active→done overlay-gated(True)·done→archived scope 밖.
+    assert is_transition_supported("epic", "draft", "active") is True
+    assert is_transition_supported("epic", "done", "archived") is False
+    # 비-eligible(sprint) + 미등록은 False.
+    assert is_transition_supported("sprint", "planning", "active") is False
     assert is_transition_supported("unknown", "a", "b") is False  # 미등록=no-op
 
 
@@ -90,7 +94,6 @@ async def test_routing_context_non_eligible_returns_descriptor_reason():
     session = AsyncMock()  # 비-eligible 은 session.get 전에 반환 → DB 불필요
     # S23 hypothesis·S22 doc 는 eligible 승격(session.get 경로) → 여기선 비-eligible(epic/sprint)만 검사.
     for entity, reason in [
-        ("epic", "transition_rules_undefined_pending_s25"),
         ("sprint", "status_enum_undefined_pending_s26"),
     ]:
         ctx = await resolve_routing_context(session, uuid.uuid4(), entity_type=entity, entity_id=uuid.uuid4())

--- a/backend/tests/test_edg_s25_epic_overlay.py
+++ b/backend/tests/test_edg_s25_epic_overlay.py
@@ -1,0 +1,143 @@
+"""E-DG S25: epic line overlay (draft→active + active→done).
+
+핵심: epic FSM·matrix flip·⭐SoD(approver≠assignee_id·activation만·assignee None fail-closed)·
+active→done(SoD 무관)·default-off agent activation 차단·resolver epic_aggregate(advisory).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── FSM·matrix (unit·CI-runnable) ─────────────────────────────────────────────
+def test_epic_fsm_valid_transitions():
+    from app.schemas.epic import is_valid_epic_transition
+    assert is_valid_epic_transition("draft", "active")
+    assert is_valid_epic_transition("active", "done")
+    assert is_valid_epic_transition("active", "archived")  # native
+    assert not is_valid_epic_transition("done", "active")  # 역전이 금지
+    assert not is_valid_epic_transition("draft", "done")   # 비합법(직행 금지)
+
+
+def test_matrix_epic_eligible_two_overlay_transitions():
+    from app.services.workflow_readiness_matrix import get_readiness, is_transition_supported
+    e = get_readiness("epic")
+    assert e.gating_eligible is True
+    assert e.valid_transitions == frozenset({("draft", "active"), ("active", "done")})
+    assert is_transition_supported("epic", "draft", "active") is True
+    assert is_transition_supported("epic", "active", "done") is True
+    assert is_transition_supported("epic", "done", "archived") is False  # scope 밖(native)
+
+
+# ── SoD applier (CI-runnable·mock·skipif 없음) ────────────────────────────────
+def _mock_sr(to_status):
+    from unittest.mock import MagicMock
+    return MagicMock(entity_type="epic", entity_id=uuid.uuid4(), org_id=uuid.uuid4(),
+                     from_status="draft", to_status=to_status)
+
+
+async def _run_apply(epic_mock, sr, resolver_id):
+    from unittest.mock import AsyncMock, MagicMock
+    from app.services.workflow_line_resolution import _apply_epic_transition
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = epic_mock
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=result)
+    await _apply_epic_transition(session, sr, resolver_id=resolver_id)
+
+
+@pytest.mark.anyio
+async def test_apply_sod_blocks_assignee_self_approve():
+    """⭐SoD(activation): approver == epic.assignee_id → 차단(skipped)."""
+    from unittest.mock import MagicMock
+    assignee = uuid.uuid4()
+    epic = MagicMock(status="draft", assignee_id=assignee, id=uuid.uuid4(), title="e", project_id=uuid.uuid4())
+    sr = _mock_sr("active")
+    await _run_apply(epic, sr, resolver_id=assignee)  # self
+    assert sr.status == "skipped"
+
+
+@pytest.mark.anyio
+async def test_apply_sod_assignee_null_fail_closed():
+    """⭐RC② 교훈 선제: assignee_id None(불명) → activation 차단(fail-closed)."""
+    from unittest.mock import MagicMock
+    epic = MagicMock(status="draft", assignee_id=None, id=uuid.uuid4(), title="e", project_id=uuid.uuid4())
+    sr = _mock_sr("active")
+    await _run_apply(epic, sr, resolver_id=uuid.uuid4())
+    assert sr.status == "skipped"  # assignee None → fail-closed
+
+
+# ── active→done(SoD 무관)·default-off·aggregate (real-PG) ─────────────────────
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.participation  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    import app.models.event  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_default_off_agent_activation_blocked():
+    """default-off: agent draft→active → overlay plain → inline HUMAN_CONFIRM_REQUIRED(byte-동일)."""
+    from app.services.epic import transition_epic, EpicTransitionError
+    from app.services.member_resolver import ResolvedMember
+    from app.models.pm import Epic
+    from app.models.project import Project
+    engine, Session = await _session()
+    async with Session() as s:
+        org, proj = uuid.uuid4(), uuid.uuid4()
+        s.add(Project(id=proj, org_id=org, name="p"))
+        await s.flush()
+        epic = Epic(org_id=org, project_id=proj, title="e", status="draft")
+        s.add(epic)
+        await s.commit()
+        agent = ResolvedMember(id=uuid.uuid4(), user_id=None, name="a", type="agent", role="member", org_id=org)
+        with pytest.raises(EpicTransitionError) as ei:
+            await transition_epic(s, org, agent, epic.id, "active")
+        assert ei.value.code == "HUMAN_CONFIRM_REQUIRED"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_resolver_epic_aggregate_included():
+    """⭐active→done routing material: resolver 가 epic 산하 story aggregate 포함(advisory)."""
+    from app.services.workflow_line_resolver import resolve_routing_context
+    from app.models.pm import Epic, Story
+    from app.models.project import Project
+    engine, Session = await _session()
+    async with Session() as s:
+        org, proj = uuid.uuid4(), uuid.uuid4()
+        s.add(Project(id=proj, org_id=org, name="p"))
+        await s.flush()
+        epic = Epic(org_id=org, project_id=proj, title="e", status="active")
+        s.add(epic)
+        await s.flush()
+        s.add(Story(org_id=org, project_id=proj, epic_id=epic.id, title="s1", status="done"))
+        s.add(Story(org_id=org, project_id=proj, epic_id=epic.id, title="s2", status="in-progress"))
+        await s.commit()
+        ctx = await resolve_routing_context(s, org, entity_type="epic", entity_id=epic.id)
+        assert ctx["supported"] is True and ctx["entity_type"] == "epic"
+        agg = ctx["epic_aggregate"]
+        assert agg["total_stories"] == 2 and agg["done_stories"] == 1 and agg["open_stories"] == 1
+    await engine.dispose()

--- a/backend/tests/test_edg_s4_resolver.py
+++ b/backend/tests/test_edg_s4_resolver.py
@@ -132,11 +132,11 @@ async def test_routing_context_non_story_unsupported():
     engine, Session = await _session()
     async with Session() as s:
         ctx = await resolve_routing_context(
-            s, uuid.uuid4(), entity_type="epic", entity_id=uuid.uuid4())
-        # S21: 미지원 사유가 generic "unsupported_entity_type" → readiness matrix descriptor 의
-        # entity-specific blocking_reason 으로 정밀화(observability). epic = 전이규칙 미정의(S25).
+            s, uuid.uuid4(), entity_type="sprint", entity_id=uuid.uuid4())
+        # 미지원 사유 = readiness matrix descriptor 의 entity-specific blocking_reason. ⚠️epic 은 S25서
+        # eligible 승격됐으므로 still-non-eligible 인 sprint 로 검사(sprint=enum 미정의·S26 대기).
         assert ctx["supported"] is False
-        assert ctx["reason"] == "transition_rules_undefined_pending_s25"
+        assert ctx["reason"] == "status_enum_undefined_pending_s26"
         assert ctx["suggested_default"] == "ask_human"  # 불명=safe default
     await engine.dispose()
 


### PR DESCRIPTION
## [E-DG][S25] Epic line overlay (draft→active + active→done)

E-DG Phase 2. design-review PASS분. epic native status(`draft|active|done|archived`)를 line overlay 로(S23/S22 패턴 미러·**마이그 없음**·default-off·byte-동일). ⭐**TWO overlay-gated 전이**(이전 단일과 다름): `draft→active`(activation·human-gate·SoD)·`active→done`(completion·routing_context에 story aggregate). 나머지(archive)는 native 직행.

설계 doc: `design-edg-s25-epic-line-overlay` (PO PASS·2확認).

### 변경
| 영역 | 내용 |
|------|------|
| FSM `schemas/epic.py` | `_EPIC_VALID_TRANSITIONS` + `is_valid_epic_transition` |
| matrix | epic `gating_eligible` F→T·`valid_transitions={(draft,active),(active,done)}` |
| `services/epic.py` | `transition_epic`: 2전이 overlay(enforcing→gate·default-off→inline·fail-open·via_gate)·draft→active human-only |
| ⭐resolver `_epic_aggregate` | epic 산하 story completion/open 을 routing_context에(get_epic_progress 재사용·advisory·gate 강제 아님·S4 shadow) |
| applier `_apply_epic_transition` | native transition_epic(via_gate) 재사용·SoD(activation만·approver≠assignee_id·assignee None fail-closed)·멱등·assignee dispatch(commit=False) |
| endpoint | `POST /epics/{id}/transition`(create/update 분리·caller 인증·RC① 패턴) |

### PO 2확認 반영
1. ⚠️ **epic SoD=assignee_id 한계(LOW)**: epic assignee 흔히 null→enforcing 시 과차단. **default-off 무해**. enforcing 전 SoD 대상 **project owner(f82eb154)로 정교화** = enable-prep(보완스토리 fbefba4f). 현 assignee proxy+fail-closed는 우회0이라 GO.
2. **aggregate=advisory 확認**: get_epic_progress는 routing material(S4 shadow)·gate 정책 강제(completion<100→block) 아님.

### 무회귀
S25 테스트(FSM·matrix·SoD self/assignee-null fail-closed[CI-runnable]·default-off agent 차단·resolver aggregate) + S21 matrix epic flip·s4 non_story(epic→sprint) 갱신. 기존 epic **16 passed**·엔진 잔여 2 failed=**baseline**(create_all blindspot·시그니처 epic 0). 소스 ruff-clean. **마이그0·default-off**.

S22(doc) 머지 후 rebase(post-S22 base·matrix/resolution adjacency 정리). FE(epic gate UI·S24 hypothesis-gate-badge 공유)는 유나 경유 나중.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
