### PR TITLE
[SID:9b1f0216] S24 follow-up — LOW① + LOW② + story-chip gate indicator

### DIFF
--- a/apps/web/src/components/hypotheses/hypotheses-section.tsx
+++ b/apps/web/src/components/hypotheses/hypotheses-section.tsx
@@ -105,21 +105,17 @@ export function HypothesesSection({ epicId, projectId }: { epicId: string; proje
       const json = await res.json();
       const arr = (json?.data ?? []) as Hypothesis[];
       setItems(arr);
-      // S24: hyp별 gate(bounded N·storyGatesMap 미러) + team-members 이름맵.
-      const [gateResults, membersJson] = await Promise.all([
-        Promise.all(arr.map((h) =>
-          fetch(`/api/gates?work_item_id=${h.id}&work_item_type=hypothesis`)
-            .then((r) => (r.ok ? (r.json() as Promise<GateItem[]>) : []))
-            .catch(() => []),
-        )),
+      // S24 QA LOW② fix: per-hyp N fetch → status-batch(GateInbox식·pending+rejected status-only 2 fetch→클라 work_item_type='hypothesis' 필터·map). confirmed는 hyp payload(confirmed_by) 파생이라 gate 조회 불요.
+      const [pendingGates, rejectedGates, membersJson] = await Promise.all([
+        fetch('/api/gates?status=pending').then((r) => (r.ok ? (r.json() as Promise<GateItem[]>) : [])).catch(() => []),
+        fetch('/api/gates?status=rejected').then((r) => (r.ok ? (r.json() as Promise<GateItem[]>) : [])).catch(() => []),
         fetch('/api/team-members').then((r) => (r.ok ? r.json() : { data: [] })).catch(() => ({ data: [] })),
       ]);
       const gmap: Record<string, GateItem> = {};
-      arr.forEach((h, i) => {
-        const gs = gateResults[i] ?? [];
-        const g = gs.find((x) => x.status === 'pending' || x.status === 'rejected') ?? gs[0];
-        if (g) gmap[h.id] = g;
-      });
+      // pending 우선·rejected는 pending 없을 때만(한 hyp에 둘 다면 진행중 pending이 우세).
+      for (const g of [...rejectedGates, ...pendingGates]) {
+        if (g.work_item_type === 'hypothesis') gmap[g.work_item_id] = g;
+      }
       setHypGatesMap(gmap);
       const names: Record<string, string> = {};
       for (const m of (membersJson as { data?: { id: string; name: string }[] }).data ?? []) names[m.id] = m.name;

--- a/apps/web/src/components/hypotheses/hypothesis-gate-badge.tsx
+++ b/apps/web/src/components/hypotheses/hypothesis-gate-badge.tsx
@@ -35,12 +35,14 @@ function deriveGateState(hypothesis: Hypothesis, gate: GateItem | undefined): Ga
 interface HypothesisGateBadgeProps {
   hypothesis: Hypothesis;
   gate: GateItem | undefined;
-  resolveName: (memberId: string) => string;
-  resolverId: string;
-  onResolved: () => void;
+  resolveName?: (memberId: string) => string;
+  resolverId?: string;
+  onResolved?: () => void;
+  // S24 follow-up: story-칩 연결 surface용 compact 모드 — 작은 Shield indicator(pending/rejected만·title 툴팁·라벨/evidence/action 생략).
+  compact?: boolean;
 }
 
-export function HypothesisGateBadge({ hypothesis, gate, resolveName, resolverId, onResolved }: HypothesisGateBadgeProps) {
+export function HypothesisGateBadge({ hypothesis, gate, resolveName = (id) => id, resolverId = '', onResolved = () => {}, compact = false }: HypothesisGateBadgeProps) {
   const t = useTranslations('hypotheses');
   const [resolving, setResolving] = useState(false);
   const [rejectNote, setRejectNote] = useState<string | null>(null); // null=닫힘·string=반려 입력 中
@@ -50,6 +52,17 @@ export function HypothesisGateBadge({ hypothesis, gate, resolveName, resolverId,
 
   const meta = META[state];
   const MetaIcon = meta.Icon;
+
+  // compact(story-칩 연결 surface): 작은 Shield indicator — pending/rejected만(주의 필요·confirmed 생략 boy-scout)·title 툴팁·라벨/evidence/action 생략.
+  if (compact) {
+    if (state === 'confirmed') return null;
+    return (
+      <span title={t(meta.labelKey)} aria-label={t(meta.labelKey)} className="inline-flex shrink-0 items-center">
+        <MetaIcon className={`size-3.5 ${state === 'rejected' ? 'text-destructive' : 'text-warning'}`} />
+      </span>
+    );
+  }
+
   const canAct = state === 'pending' && gate != null && gateNeedsAction(gate);
 
   const transition = async (status: 'approved' | 'rejected', note?: string) => {
@@ -68,9 +81,9 @@ export function HypothesisGateBadge({ hypothesis, gate, resolveName, resolverId,
     }
   };
 
-  // 결재자/초안자 evidence 미니(띠 우측).
+  // 결재자/초안자 evidence 미니(띠 우측). 확인=confirmed_by / 반려=gate.resolver_id(반려 경로엔 confirmed_by 미설정·QA LOW① fix·doc §3 "반려 시 {사람명}").
   const draftedBy = hypothesis.drafted_by_member_id;
-  const confirmedBy = hypothesis.confirmed_by_member_id;
+  const actorId = state === 'rejected' ? (gate?.resolver_id ?? null) : hypothesis.confirmed_by_member_id;
 
   return (
     <div className="space-y-1.5 rounded-xl border border-border bg-muted/20 px-3 py-2">
@@ -86,10 +99,10 @@ export function HypothesisGateBadge({ hypothesis, gate, resolveName, resolverId,
             {t('gateDraftedBy', { name: resolveName(draftedBy) })}
           </span>
         ) : null}
-        {confirmedBy && (state === 'confirmed' || state === 'rejected') ? (
+        {actorId && (state === 'confirmed' || state === 'rejected') ? (
           <span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground">
             <User className="size-3 shrink-0" />
-            {t(state === 'rejected' ? 'gateRejectedBy' : 'gateConfirmedBy', { name: resolveName(confirmedBy) })}
+            {t(state === 'rejected' ? 'gateRejectedBy' : 'gateConfirmedBy', { name: resolveName(actorId) })}
           </span>
         ) : null}
         {/* approve/reject = GateInbox action 재사용(requires_human·pending 시만) */}

--- a/apps/web/src/components/hypotheses/story-hypotheses-section.tsx
+++ b/apps/web/src/components/hypotheses/story-hypotheses-section.tsx
@@ -5,6 +5,8 @@ import { useTranslations } from 'next-intl';
 import { AlertTriangle, Link2, Plus, Search, X } from 'lucide-react';
 import type { Hypothesis } from '@sprintable/core-storage';
 import { HypothesisStatusBadge } from './hypothesis-status-badge';
+import { HypothesisGateBadge } from './hypothesis-gate-badge';
+import type { GateItem } from '@/components/kanban/types';
 
 /**
  * Story-detail panel "linked hypotheses" surface (E1-S8c / S9 fold · blueprint §6.5).
@@ -33,6 +35,8 @@ export function StoryHypothesesSection({
   const [candidates, setCandidates] = useState<Hypothesis[] | null>(null);
   const [query, setQuery] = useState('');
   const [busyId, setBusyId] = useState<string | null>(null);
+  // S24 follow-up: 연결 칩 compact gate indicator용 hypGatesMap(status-batch·pending/rejected).
+  const [hypGatesMap, setHypGatesMap] = useState<Record<string, GateItem>>({});
 
   // story.epic_id에 속하지 않은 가설 = 다른 에픽 소속(AC③ 경고 대상). epic 미지정 story는 판정 보류.
   const isCrossEpic = useCallback(
@@ -49,6 +53,14 @@ export function StoryHypothesesSection({
       if (!res.ok) { setLinked([]); return; }
       const json = await res.json();
       setLinked((json?.data ?? []) as Hypothesis[]);
+      // S24 follow-up: gate status-batch(pending+rejected→hypothesis 필터→map)·confirmed는 칩서 생략이라 불요.
+      const [pg, rg] = await Promise.all([
+        fetch('/api/gates?status=pending').then((r) => (r.ok ? (r.json() as Promise<GateItem[]>) : [])).catch(() => []),
+        fetch('/api/gates?status=rejected').then((r) => (r.ok ? (r.json() as Promise<GateItem[]>) : [])).catch(() => []),
+      ]);
+      const gmap: Record<string, GateItem> = {};
+      for (const g of [...rg, ...pg]) if (g.work_item_type === 'hypothesis') gmap[g.work_item_id] = g;
+      setHypGatesMap(gmap);
     } catch {
       setLinked([]);
     }
@@ -152,6 +164,8 @@ export function StoryHypothesesSection({
                   {t('crossEpic')}
                 </span>
               ) : null}
+              {/* S24 follow-up: gate approval compact indicator(pending/rejected만·title 툴팁) */}
+              <HypothesisGateBadge hypothesis={h} gate={hypGatesMap[h.id]} compact />
               <HypothesisStatusBadge status={h.status} className="shrink-0" />
               <button
                 type="button"


### PR DESCRIPTION
## S24 follow-up — QA LOW 2건 + story-chip (S24 #1626 머지 후속)

S24 `#1626`(epic primary surface) 머지 후속. 까심 cross-model QA LOW 2건 + 유나 가디언 story-칩 디자인 콜을 한 PR로 develop 위에 번들. **신규 토큰 0 · 신규 i18n 0**(기존 `hypotheses.gate*` 재사용).

### 변경 (`hypothesis-gate-badge.tsx` · `hypotheses-section.tsx` · `story-hypotheses-section.tsx`)
- **LOW① (rejected 결재자명)** — 반려 경로엔 `confirmed_by_member_id`가 미설정 → 이름 미표시였음. `gate.resolver_id`(실 반려 transition 실행자)로 정정. doc §3 "반려 시 {사람명}" 정합 · 유나 가디언 검증.
- **LOW② (N+1 최적화)** — `hypotheses-section`의 per-hyp gate fetch(N) → **status-batch**(`?status=pending`+`?status=rejected` status-only 2 fetch → 클라 `work_item_type='hypothesis'` 필터 → map). confirmed는 hyp payload(`confirmed_by`) 파생이라 gate 조회 불요. GateInbox 패턴(status-only fetch)·확인된 계약.
- **story-칩 compact indicator** — `hypothesis-gate-badge`에 `compact` 모드(작은 Shield·**pending/rejected만**·confirmed 생략 boy-scout·`title` 툴팁·라벨/evidence/action 생략). `story-hypotheses-section` 연결-칩에 마운트 + gate status-batch.

### 검증
`tsc` 0 · `eslint` 0 · `next build` ✓ Compiled successfully · 신규 토큰/i18n 0.
PR → **가디언 시각 리뷰**(story-칩 compact Shield·LOW① rejected 결재자명·다크) → 까심 QA(LOW② status-batch) → 머지 → dev 픽셀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)