### PR TITLE
[E-DG][S27] Dispatch anchor expansion (hypothesis, sprint)

### DIFF
--- a/backend/app/services/agent_dispatch.py
+++ b/backend/app/services/agent_dispatch.py
@@ -18,7 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.doc import Doc
 from app.models.event import Event, EventType
 from app.models.hypothesis import Hypothesis
-from app.models.pm import Epic, Story
+from app.models.pm import Epic, Sprint, Story
 from app.routers.agent_gateway import wake_agent
 from app.routers.events import _event_to_payload, _push_to_agent
 from app.services.activity_stream import extract_activities_best_effort
@@ -27,10 +27,24 @@ from app.services.member_resolver import resolve_member_identity
 from app.services.notification_dispatch import dispatch_notification
 from app.services.workflow_readiness_matrix import READINESS_MATRIX
 
-# S21: dispatch 가능 엔티티는 readiness matrix 의 dispatch_capable SSOT 에서 도출(현 epic/story/doc).
-# hypothesis/sprint fetch 추가(S23/S26) 시 matrix descriptor 만 바꾸면 자동 확장. _fetch_entity 분기는
-# 그때 함께 확장(현 byte-동일).
+# S21/S27: dispatch 가능 엔티티는 readiness matrix 의 dispatch_capable SSOT 에서 도출.
 _ENTITY_TYPES = {e for e, d in READINESS_MATRIX.items() if d.dispatch_capable}
+
+
+async def _resolve_sprint_dispatch_owner(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID,
+) -> uuid.UUID | None:
+    """Sprint 은 assignee 컬럼이 없어 전이 wake 를 프로젝트 relay-owner 로 보낸다(S27).
+
+    owner 해소는 member-SSOT(project_auth.resolve_project_relay_owner) 단일 경로 — ad-hoc
+    TeamMember.role 리졸버 금지(grant/admin 403 드리프트 회피). 부재 시 None(no_assignee 가시화·
+    가짜 fallback 금지). 반환 canonical member id 는 resolve_member_identity 의 human/agent 분기에 위임.
+    """
+    from app.services.project_auth import resolve_project_relay_owner
+
+    return await resolve_project_relay_owner(db, project_id, org_id)
 
 
 class DispatchResponse(BaseModel):
@@ -82,6 +96,18 @@ async def _fetch_entity(
         )
         r0 = row.one_or_none()
         r = (r0[0], r0[1], None, r0[2]) if r0 is not None else None
+    elif entity_type == "sprint":
+        row = await db.execute(
+            select(Sprint.title, Sprint.status, Sprint.project_id).where(
+                Sprint.id == entity_id, Sprint.org_id == org_id
+            )
+        )
+        r0 = row.one_or_none()
+        if r0 is None:
+            r = None
+        else:
+            assignee_id = await _resolve_sprint_dispatch_owner(db, org_id, r0.project_id)
+            r = (assignee_id, r0.title, f"status={r0.status}", r0.project_id)
     else:
         return None, None, None, None
 

--- a/backend/app/services/l2_trigger_worker.py
+++ b/backend/app/services/l2_trigger_worker.py
@@ -37,12 +37,17 @@ from app.services.l2_heuristics import (
     HeuristicThresholds,
     TriggerDecision,
 )
+from app.services.workflow_readiness_matrix import READINESS_MATRIX
 
 logger = logging.getLogger(__name__)
 
-# dispatch service(S1)가 처리 가능한 anchor entity. 이 외(sprint/hypothesis 등)는 firing만 기록하고
-# wake는 skip한다(해당 타입 dispatch 경로는 후속 확장).
-_DISPATCHABLE_ANCHORS = frozenset({"epic", "story", "doc"})
+# S27: dispatch 가능한 anchor entity = readiness matrix dispatch_capable SSOT 파생(agent_dispatch
+# ._ENTITY_TYPES 와 동일 노선). 하드코딩 2-소스 드리프트 박멸 — matrix 가 단일 진실(엔티티 dispatch
+# 승격은 matrix dispatch_capable 한 곳만 토글하면 두 경로 동시 반영). hypothesis(owner_member_id)·
+# sprint(project owner relay) wake 타깃은 agent_dispatch._fetch_entity 가 해소.
+_DISPATCHABLE_ANCHORS = frozenset(
+    e for e, d in READINESS_MATRIX.items() if d.dispatch_capable
+)
 
 # Phase 1 활동-구동 트리거 대상 verb(status_changed→담당자 wake). 확장 시 여기에 추가.
 _ACTIVITY_TRIGGER_VERBS = frozenset({"status_changed"})
@@ -78,6 +83,7 @@ class L2TriggerWorker:
     # 데드라인 nudge 불필요한 종결 상태(타입별).
     _HYPOTHESIS_TERMINAL = ("verified", "falsified", "killed", "archived")
     _EPIC_TERMINAL = ("completed", "done", "closed", "archived", "cancelled", "canceled")
+    _SPRINT_TERMINAL = ("closed", "archived", "cancelled", "canceled")
 
     def __init__(
         self,
@@ -303,13 +309,13 @@ class L2TriggerWorker:
 
         deadline은 활동이 발생하지 않으므로 cursor poll로는 못 잡는다 — 별도 주기 스캔.
         · Epic.target_date — assignee_id를 target으로 dispatch service가 wake(dispatchable).
-        · Hypothesis.measure_after — drafted_by/created_by(agent-가능)를 target으로 firing 기록
-          (현 dispatch 서비스는 hypothesis 미지원이라 wake는 skip·후속 확장).
-        Sprint.end_date 스캔은 sprint dispatch 경로 확정과 함께 후속 확장.
+        · Hypothesis.measure_after — owner_member_id를 target으로 dispatch service가 wake(dispatchable).
+        · Sprint.end_date — project owner/admin lane을 target으로 dispatch service가 wake(dispatchable).
         """
         now = _utcnow()
         firings = await self._collect_epic_deadlines(db, now)
         firings += await self._collect_hypothesis_deadlines(db, now)
+        firings += await self._collect_sprint_deadlines(db, now)
         await self._dispatch_decisions(db, firings)
         return firings
 
@@ -347,21 +353,52 @@ class L2TriggerWorker:
         rows = (
             await db.execute(
                 text(
-                    "SELECT id, org_id, measure_after, status, drafted_by_member_id, "
-                    "created_by_member_id FROM hypotheses "
-                    "WHERE status NOT IN :terminal AND measure_after <= :horizon"
+                    "SELECT id, org_id, measure_after, status, owner_member_id FROM hypotheses "
+                    "WHERE owner_member_id IS NOT NULL AND status NOT IN :terminal "
+                    "AND measure_after <= :horizon"
                 ).bindparams(bindparam("terminal", expanding=True)),
                 {"terminal": list(self._HYPOTHESIS_TERMINAL), "horizon": horizon},
             )
         ).mappings().all()
         out: list[tuple[TriggerDecision, uuid.UUID]] = []
         for r in rows:
-            target = r["drafted_by_member_id"] or r["created_by_member_id"]
             for d in self.evaluator.evaluate_deadline(
                 DeadlineTarget(
                     entity_type="hypothesis",
                     entity_id=r["id"],
                     deadline=r["measure_after"],
+                    status=r["status"],
+                    target_agent_id=r["owner_member_id"],
+                ),
+                now,
+            ):
+                out.append((d, r["org_id"]))
+        return out
+
+    async def _collect_sprint_deadlines(self, db, now) -> list[tuple[TriggerDecision, uuid.UUID]]:
+        horizon_date = (now + timedelta(hours=self.evaluator.t.deadline_epic_target_h)).date()
+        rows = (
+            await db.execute(
+                text(
+                    "SELECT id, org_id, end_date, status FROM sprints "
+                    "WHERE end_date IS NOT NULL AND status NOT IN :terminal AND end_date <= :horizon"
+                ).bindparams(bindparam("terminal", expanding=True)),
+                {"terminal": list(self._SPRINT_TERMINAL), "horizon": horizon_date},
+            )
+        ).mappings().all()
+        from app.services.agent_dispatch import _fetch_entity
+
+        out: list[tuple[TriggerDecision, uuid.UUID]] = []
+        for r in rows:
+            target, _title, _desc, _proj = await _fetch_entity(db, "sprint", r["id"], r["org_id"])
+            if not target:
+                continue
+            deadline = datetime.combine(r["end_date"], dt_time(23, 59, 59), tzinfo=timezone.utc)
+            for d in self.evaluator.evaluate_deadline(
+                DeadlineTarget(
+                    entity_type="sprint",
+                    entity_id=r["id"],
+                    deadline=deadline,
                     status=r["status"],
                     target_agent_id=target,
                 ),

--- a/backend/app/services/project_auth.py
+++ b/backend/app/services/project_auth.py
@@ -72,6 +72,62 @@ async def get_project_role(
     return max(candidates, key=lambda r: PROJECT_ROLE_RANK[r])
 
 
+async def resolve_project_relay_owner(
+    session: AsyncSession,
+    project_id: uuid.UUID,
+    org_id: uuid.UUID,
+) -> uuid.UUID | None:
+    """프로젝트의 단일 relay-owner canonical member id 해소(E-DG S27 sprint dispatch anchor).
+
+    sprint 은 assignee 컬럼이 없어, 전이 wake 대상을 프로젝트 책임자로 relay 한다. owner 해소는
+    member-SSOT(project_access granted ∪ org owner/admin floor)를 따르며 — ad-hoc TeamMember.role
+    리졸버 금지(event_notifications/docs 가 자체 team_member 리졸버를 굴려 grant/admin 403 드리프트를
+    낸 그 함정 회피). 반환은 **canonical member id 1개**(team_members.id | org_members.id)라
+    `resolve_member_identity()`의 human notification / agent wake 분기에 그대로 물린다.
+
+    우선순위(deterministic 단일 픽):
+      1. project_access(permission='granted', role='owner') — pa.member_id(team_member) ∪
+         pa.org_member_id(grant-only 휴먼). human/agent 무관(agent-PO 도 relay 대상).
+      2. org_members.role='owner' (org-wide floor).
+      3. org_members.role='admin'.
+    동순위 tie-break = created_at ASC, id ASC. 없으면 None(no_assignee 가시화 — 가짜 fallback 금지).
+    asyncpg text 함정 회피: uuid 직접 바인딩·COALESCE 는 컬럼에만(파라미터 IS NULL/::uuid 미사용).
+    """
+    row = (
+        await session.execute(
+            text(
+                """
+                SELECT cid FROM (
+                    SELECT COALESCE(pa.member_id, pa.org_member_id) AS cid,
+                           1 AS src_rank, pa.created_at AS created_at
+                      FROM project_access pa
+                      JOIN projects p ON p.id = pa.project_id
+                     WHERE pa.project_id = :pid AND p.org_id = :oid
+                       AND pa.permission = 'granted' AND pa.role = 'owner'
+                       AND COALESCE(pa.member_id, pa.org_member_id) IS NOT NULL
+                    UNION ALL
+                    SELECT om.id AS cid, 2 AS src_rank, om.created_at AS created_at
+                      FROM org_members om
+                      JOIN projects p ON p.org_id = om.org_id
+                     WHERE p.id = :pid AND om.org_id = :oid
+                       AND om.role = 'owner' AND om.deleted_at IS NULL
+                    UNION ALL
+                    SELECT om.id AS cid, 3 AS src_rank, om.created_at AS created_at
+                      FROM org_members om
+                      JOIN projects p ON p.org_id = om.org_id
+                     WHERE p.id = :pid AND om.org_id = :oid
+                       AND om.role = 'admin' AND om.deleted_at IS NULL
+                ) cands
+                ORDER BY src_rank ASC, created_at ASC, cid ASC
+                LIMIT 1
+                """
+            ),
+            {"pid": project_id, "oid": org_id},
+        )
+    ).one_or_none()
+    return row[0] if row is not None else None
+
+
 async def has_project_role(
     session: AsyncSession,
     user_id: uuid.UUID,

--- a/backend/app/services/project_auth.py
+++ b/backend/app/services/project_auth.py
@@ -85,15 +85,23 @@ async def resolve_project_relay_owner(
     낸 그 함정 회피). 반환은 **canonical member id 1개**(team_members.id | org_members.id)라
     `resolve_member_identity()`의 human notification / agent wake 분기에 그대로 물린다.
 
-    우선순위(deterministic 단일 픽):
+    우선순위(deterministic):
       1. project_access(permission='granted', role='owner') — pa.member_id(team_member) ∪
          pa.org_member_id(grant-only 휴먼). human/agent 무관(agent-PO 도 relay 대상).
       2. org_members.role='owner' (org-wide floor).
       3. org_members.role='admin'.
-    동순위 tie-break = created_at ASC, id ASC. 없으면 None(no_assignee 가시화 — 가짜 fallback 금지).
-    asyncpg text 함정 회피: uuid 직접 바인딩·COALESCE 는 컬럼에만(파라미터 IS NULL/::uuid 미사용).
+    동순위 tie-break = created_at ASC, id ASC.
+
+    ⚠️S27 QA(산티아고 SME) 블로커 fix: 후보를 우선순위로 정렬해 **org 에서 실제 resolve 가능한 첫
+    후보**를 반환한다. stale/cross-org/orphan project_access(role='owner') row 가 있어도 그 id 가
+    org 에서 resolve 안 되면 skip 하고 다음 우선순위(org owner/admin floor)로 fallthrough — 데이터
+    드리프트가 floor 가드를 무력화하지 못하게. resolve 가능성 판정은 `resolve_member_identity`(SSOT
+    oracle)에 위임 — SQL 로 멤버 존재 술어를 재구현하면 그게 또 드리프트 소스가 되므로 금지.
+    없으면 None(no_assignee 가시화 — 가짜 fallback 금지). asyncpg text 함정 회피: uuid 직접 바인딩.
     """
-    row = (
+    from app.services.member_resolver import resolve_member_identity  # lazy(순환 import 회피)
+
+    rows = (
         await session.execute(
             text(
                 """
@@ -119,13 +127,20 @@ async def resolve_project_relay_owner(
                        AND om.role = 'admin' AND om.deleted_at IS NULL
                 ) cands
                 ORDER BY src_rank ASC, created_at ASC, cid ASC
-                LIMIT 1
                 """
             ),
             {"pid": project_id, "oid": org_id},
         )
-    ).one_or_none()
-    return row[0] if row is not None else None
+    ).all()
+    seen: set[uuid.UUID] = set()
+    for row in rows:
+        cid = row[0]
+        if cid in seen:  # 한 멤버가 여러 tier 에 걸릴 수 있음(이미 시도한 건 skip)
+            continue
+        seen.add(cid)
+        if await resolve_member_identity(cid, org_id, session) is not None:
+            return cid  # 우선순위 순 최초 resolve 가능 후보
+    return None
 
 
 async def has_project_role(

--- a/backend/app/services/workflow_readiness_matrix.py
+++ b/backend/app/services/workflow_readiness_matrix.py
@@ -41,7 +41,7 @@ class EntityReadiness:
     valid_transitions: frozenset[tuple[str, str]] | None
     # S21 시점 routing/resolution 게이트 실가동 여부(현재 story 만 True).
     gating_eligible: bool
-    # agent_dispatch._fetch_entity 가 이 엔티티를 로드할 수 있는지(현 epic/story/doc).
+    # agent_dispatch._fetch_entity 가 이 엔티티를 로드할 수 있는지(현 epic/story/doc/hypothesis/sprint).
     dispatch_capable: bool
     # gating_eligible=False 인 이유(observability/후속 스토리 라우팅). eligible 이면 None.
     blocking_reason: str | None
@@ -88,8 +88,8 @@ READINESS_MATRIX: dict[str, EntityReadiness] = {
         # ⭐S26: overlay-gated = 시작(planning→active)·마감(active→closed·review→closed). full FSM 은
         # sprint.py _SPRINT_VALID_TRANSITIONS SSOT. archive(closed→archived)는 native 직행.
         valid_transitions=frozenset({("planning", "active"), ("active", "closed"), ("review", "closed")}),
-        gating_eligible=True,                    # S26: sprint contract gate(advisory·dispatch는 S27)
-        dispatch_capable=False,                  # ⚠️agent-handoff S27까지 금지(AC)·sprint dispatch 미지원
+        gating_eligible=True,                    # S26: sprint contract gate(advisory)
+        dispatch_capable=True,                   # S27: sprint dispatch anchor enabled(project owner/admin relay)
         blocking_reason=None,
     ),
     "doc": EntityReadiness(

--- a/backend/tests/test_edg_s21_readiness_matrix.py
+++ b/backend/tests/test_edg_s21_readiness_matrix.py
@@ -38,10 +38,10 @@ def test_matrix_covers_five_entities_with_verified_contracts():
     # S23: valid_transitions = overlay-gated subset(proposed→active 만)·full FSM 은 hypothesis.py SSOT.
     assert hyp.valid_transitions == frozenset({("proposed", "active")})
     assert get_readiness("epic").status_enum == frozenset({"draft", "active", "done", "archived"})
-    # S22 doc=native status 컬럼(0128)·draft→confirmed. S26 sprint=enum(planning..archived)·dispatch False.
+    # S22 doc=native status 컬럼(0128)·draft→confirmed. S27 sprint=enum(planning..archived)·dispatch True.
     assert get_readiness("doc").has_native_status is True
     assert get_readiness("doc").valid_transitions == frozenset({("draft", "confirmed")})
-    assert get_readiness("sprint").status_enum is not None and get_readiness("sprint").dispatch_capable is False
+    assert get_readiness("sprint").status_enum is not None and get_readiness("sprint").dispatch_capable is True
     # story=config-driven(모델 enum 상수 없음).
     assert get_readiness("story").status_enum is None and get_readiness("story").valid_transitions is None
 

--- a/backend/tests/test_edg_s26_sprint_overlay.py
+++ b/backend/tests/test_edg_s26_sprint_overlay.py
@@ -36,7 +36,7 @@ def test_matrix_sprint_eligible_dispatch_off():
     from app.services.workflow_readiness_matrix import get_readiness, is_transition_supported
     s = get_readiness("sprint")
     assert s.gating_eligible is True
-    assert s.dispatch_capable is False  # ⭐agent-handoff S27까지 금지
+    assert s.dispatch_capable is True  # S27: sprint dispatch anchor enabled
     assert s.valid_transitions == frozenset({("planning", "active"), ("active", "closed"), ("review", "closed")})
     assert is_transition_supported("sprint", "planning", "active") is True
     assert is_transition_supported("sprint", "review", "closed") is True

--- a/backend/tests/test_l2_trigger_worker.py
+++ b/backend/tests/test_l2_trigger_worker.py
@@ -162,13 +162,13 @@ async def test_collect_hypothesis_deadlines_pairs_org():
     agent, org, hyp_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
     now = datetime.now(timezone.utc)
     rows = [
-        {  # 임박 + drafted_by → 발사.
+        {  # S27: 임박 + owner_member_id → 발사(wake 타깃=owner·dispatchable 정합).
             "id": hyp_id, "org_id": org, "measure_after": now + timedelta(hours=5),
-            "status": "measuring", "drafted_by_member_id": agent, "created_by_member_id": None,
+            "status": "measuring", "owner_member_id": agent,
         },
-        {  # target 없음 → evaluator skip.
+        {  # target 없음 → evaluator skip(쿼리 WHERE owner IS NOT NULL 가 실DB선 제외).
             "id": uuid.uuid4(), "org_id": org, "measure_after": now + timedelta(hours=2),
-            "status": "active", "drafted_by_member_id": None, "created_by_member_id": None,
+            "status": "active", "owner_member_id": None,
         },
     ]
     db = AsyncMock()
@@ -262,7 +262,9 @@ async def test_fire_one_conflict_loser_skips_dispatch():
 @pytest.mark.anyio
 async def test_fire_one_non_dispatchable_records_firing_no_wake():
     w = L2TriggerWorker(use_advisory_lock=False)
-    d = _decision("hypothesis")  # 비-dispatchable anchor.
+    # S27: matrix 5종(story/hyp/doc/epic/sprint) 전부 dispatch_capable=True 가 됐으므로 비-dispatchable
+    # 검사는 matrix 미등록 타입으로(firing 기록되나 _DISPATCHABLE_ANCHORS 밖이라 wake skip).
+    d = _decision("task")  # 비-matrix anchor.
     db = AsyncMock()
     with patch.object(w, "_claim_firing", AsyncMock(return_value=True)), \
          patch("app.services.agent_dispatch.dispatch_entity_to_assignee", AsyncMock()) as disp:

--- a/backend/tests/test_project_relay_owner.py
+++ b/backend/tests/test_project_relay_owner.py
@@ -189,6 +189,28 @@ async def test_orphan_pa_owner_falls_through_to_org_floor():
 
 
 @pytest.mark.anyio
+async def test_crossorg_pa_owner_falls_through_to_org_floor():
+    """⚠️S27 QA(산티아고): cross-org project_access owner(다른 org 멤버)는 this-org resolve 실패 →
+    skip → org owner floor 승계. resolve_member_identity 가 org_id 스코프라 cross-org id 는 None."""
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    engine, Session = await _session()
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    async with Session() as s:
+        org, other_org = uuid.uuid4(), uuid.uuid4()
+        pid = await _seed_project(s, org)
+        cross = uuid.uuid4()    # 다른 org 의 멤버 — this-org 에선 resolve 불가
+        org_owner = uuid.uuid4()
+        s.add(OrgMember(id=cross, org_id=other_org, user_id=uuid.uuid4(), role="owner", created_at=base))
+        s.add(OrgMember(id=org_owner, org_id=org, user_id=uuid.uuid4(), role="owner", created_at=base))
+        s.add(ProjectAccess(id=uuid.uuid4(), project_id=pid, permission="granted", role="owner",
+                            member_id=cross, created_at=base))
+        await s.commit()
+        assert await resolve_project_relay_owner(s, pid, org) == org_owner  # cross ① skip → ② floor
+    await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_org_scoped_other_org_ignored():
     """다른 org 의 owner 는 무시(org 가드)."""
     from app.models.project import OrgMember

--- a/backend/tests/test_project_relay_owner.py
+++ b/backend/tests/test_project_relay_owner.py
@@ -1,0 +1,175 @@
+"""E-DG S27: project_auth.resolve_project_relay_owner — sprint dispatch relay-owner SSOT.
+
+우선순위(deterministic 단일 픽): ①project_access granted owner ②org_members owner ③org_members admin
+④tie-break created_at ASC. 반환=canonical member id(team_members.id | org_members.id)·없으면 None.
+member-SSOT(ad-hoc TeamMember.role 금지·agent-PO 도 relay)·가짜 fallback 금지.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.services.project_auth import resolve_project_relay_owner
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(raw SQL UNION/COALESCE)")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_project(s, org):
+    from app.models.project import Project
+    pid = uuid.uuid4()
+    s.add(Project(id=pid, org_id=org, name="p"))
+    await s.flush()
+    return pid
+
+
+def _t(base, mins):
+    return base + timedelta(minutes=mins)
+
+
+@pytest.mark.anyio
+async def test_priority1_project_access_owner_wins():
+    """project_access granted owner(member_id) > org owner. canonical=member_id 반환."""
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    engine, Session = await _session()
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    async with Session() as s:
+        org = uuid.uuid4()
+        pid = await _seed_project(s, org)
+        pa_member = uuid.uuid4()
+        org_owner = uuid.uuid4()
+        s.add(OrgMember(id=org_owner, org_id=org, user_id=uuid.uuid4(), role="owner", created_at=base))
+        s.add(ProjectAccess(id=uuid.uuid4(), project_id=pid, permission="granted", role="owner",
+                            member_id=pa_member, created_at=base))
+        await s.commit()
+        got = await resolve_project_relay_owner(s, pid, org)
+        assert got == pa_member  # ①가 ②를 이김
+    await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_priority1_org_member_id_fallback_when_no_member_id():
+    """pa.member_id 없고 org_member_id 있으면 org_member_id 반환(grant-only 휴먼)."""
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    engine, Session = await _session()
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    async with Session() as s:
+        org = uuid.uuid4()
+        pid = await _seed_project(s, org)
+        om_id = uuid.uuid4()
+        # project_access.org_member_id FK → org_members 선 시드(grant-only 휴먼·role=member).
+        s.add(OrgMember(id=om_id, org_id=org, user_id=uuid.uuid4(), role="member", created_at=base))
+        await s.flush()
+        s.add(ProjectAccess(id=uuid.uuid4(), project_id=pid, permission="granted", role="owner",
+                            org_member_id=om_id, created_at=base))
+        await s.commit()
+        assert await resolve_project_relay_owner(s, pid, org) == om_id
+    await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_priority2_org_owner_when_no_project_access():
+    from app.models.project import OrgMember
+    engine, Session = await _session()
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    async with Session() as s:
+        org = uuid.uuid4()
+        pid = await _seed_project(s, org)
+        owner, admin = uuid.uuid4(), uuid.uuid4()
+        s.add(OrgMember(id=admin, org_id=org, user_id=uuid.uuid4(), role="admin", created_at=base))
+        s.add(OrgMember(id=owner, org_id=org, user_id=uuid.uuid4(), role="owner", created_at=_t(base, 5)))
+        await s.commit()
+        assert await resolve_project_relay_owner(s, pid, org) == owner  # ②owner > ③admin
+    await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_priority3_org_admin_when_no_owner():
+    from app.models.project import OrgMember
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        pid = await _seed_project(s, org)
+        admin = uuid.uuid4()
+        s.add(OrgMember(id=admin, org_id=org, user_id=uuid.uuid4(), role="admin",
+                        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc)))
+        s.add(OrgMember(id=uuid.uuid4(), org_id=org, user_id=uuid.uuid4(), role="member",
+                        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc)))  # member=무자격
+        await s.commit()
+        assert await resolve_project_relay_owner(s, pid, org) == admin
+    await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_none_when_no_owner_or_admin():
+    """가짜 fallback 금지 — owner/admin 없으면 None(no_assignee 가시화)."""
+    from app.models.project import OrgMember
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        pid = await _seed_project(s, org)
+        s.add(OrgMember(id=uuid.uuid4(), org_id=org, user_id=uuid.uuid4(), role="member",
+                        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc)))
+        await s.commit()
+        assert await resolve_project_relay_owner(s, pid, org) is None
+    await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_tiebreak_earliest_created_at():
+    """동순위(pa owner 2명) → created_at ASC 결정적 단일 픽."""
+    from app.models.project_access import ProjectAccess
+    engine, Session = await _session()
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    async with Session() as s:
+        org = uuid.uuid4()
+        pid = await _seed_project(s, org)
+        early, late = uuid.uuid4(), uuid.uuid4()
+        s.add(ProjectAccess(id=uuid.uuid4(), project_id=pid, permission="granted", role="owner",
+                            member_id=late, created_at=_t(base, 10)))
+        s.add(ProjectAccess(id=uuid.uuid4(), project_id=pid, permission="granted", role="owner",
+                            member_id=early, created_at=base))
+        await s.commit()
+        assert await resolve_project_relay_owner(s, pid, org) == early
+    await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_scoped_other_org_ignored():
+    """다른 org 의 owner 는 무시(org 가드)."""
+    from app.models.project import OrgMember
+    engine, Session = await _session()
+    async with Session() as s:
+        org, other = uuid.uuid4(), uuid.uuid4()
+        pid = await _seed_project(s, org)
+        s.add(OrgMember(id=uuid.uuid4(), org_id=other, user_id=uuid.uuid4(), role="owner",
+                        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc)))
+        await s.commit()
+        assert await resolve_project_relay_owner(s, pid, org) is None
+    await engine.dispose()

--- a/backend/tests/test_project_relay_owner.py
+++ b/backend/tests/test_project_relay_owner.py
@@ -63,6 +63,8 @@ async def test_priority1_project_access_owner_wins():
         pid = await _seed_project(s, org)
         pa_member = uuid.uuid4()
         org_owner = uuid.uuid4()
+        # pa_member 가 org 에서 resolve 가능해야 ①가 유효(resolve_member_identity oracle).
+        s.add(OrgMember(id=pa_member, org_id=org, user_id=uuid.uuid4(), role="member", created_at=base))
         s.add(OrgMember(id=org_owner, org_id=org, user_id=uuid.uuid4(), role="owner", created_at=base))
         s.add(ProjectAccess(id=uuid.uuid4(), project_id=pid, permission="granted", role="owner",
                             member_id=pa_member, created_at=base))
@@ -144,6 +146,7 @@ async def test_none_when_no_owner_or_admin():
 @pytest.mark.anyio
 async def test_tiebreak_earliest_created_at():
     """동순위(pa owner 2명) → created_at ASC 결정적 단일 픽."""
+    from app.models.project import OrgMember
     from app.models.project_access import ProjectAccess
     engine, Session = await _session()
     base = datetime(2026, 1, 1, tzinfo=timezone.utc)
@@ -151,12 +154,37 @@ async def test_tiebreak_earliest_created_at():
         org = uuid.uuid4()
         pid = await _seed_project(s, org)
         early, late = uuid.uuid4(), uuid.uuid4()
+        # 둘 다 resolve 가능해야 tie-break 가 의미(아니면 unresolvable skip).
+        s.add(OrgMember(id=early, org_id=org, user_id=uuid.uuid4(), role="member", created_at=base))
+        s.add(OrgMember(id=late, org_id=org, user_id=uuid.uuid4(), role="member", created_at=base))
         s.add(ProjectAccess(id=uuid.uuid4(), project_id=pid, permission="granted", role="owner",
                             member_id=late, created_at=_t(base, 10)))
         s.add(ProjectAccess(id=uuid.uuid4(), project_id=pid, permission="granted", role="owner",
                             member_id=early, created_at=base))
         await s.commit()
         assert await resolve_project_relay_owner(s, pid, org) == early
+    await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_orphan_pa_owner_falls_through_to_org_floor():
+    """⚠️S27 QA 블로커: stale/orphan project_access owner(org resolve 불가)는 skip 하고 org owner
+    floor 로 fallthrough — 데이터 드리프트가 floor 가드를 무력화 못 함."""
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    engine, Session = await _session()
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    async with Session() as s:
+        org = uuid.uuid4()
+        pid = await _seed_project(s, org)
+        orphan = uuid.uuid4()   # project_access owner 지만 org 에 member 행 없음(stale/cross-org)
+        org_owner = uuid.uuid4()
+        s.add(OrgMember(id=org_owner, org_id=org, user_id=uuid.uuid4(), role="owner", created_at=base))
+        s.add(ProjectAccess(id=uuid.uuid4(), project_id=pid, permission="granted", role="owner",
+                            member_id=orphan, created_at=base))
+        await s.commit()
+        got = await resolve_project_relay_owner(s, pid, org)
+        assert got == org_owner  # orphan ① skip → ② org owner 로 fallthrough
     await engine.dispose()
 
 


### PR DESCRIPTION
## [E-DG][P2·S27][게이트웨이/BE] Dispatch anchor expansion (hypothesis, sprint)

L2 dispatch anchor를 **hypothesis·sprint로 확장** — 현재 epic/story/doc만 owner-relay wake되고 hypothesis·sprint는 firing-only(wake skip)였던 갭 봉합. **PO + 산티아고(게이트웨이 SME) 컨설트 LOCK** 반영. default 거동 보존(트리거 flag off).

### 발견: dispatch 게이트 2-소스 드리프트 (latent)
`agent_dispatch._ENTITY_TYPES`는 matrix `dispatch_capable` 파생인데 `l2_trigger_worker._DISPATCHABLE_ANCHORS`는 하드코딩 `{epic,story,doc}` → **hypothesis가 dispatch_capable=True인데도 L2 트리거선 firing-only**인 latent 갭. 두 게이트를 matrix SSOT로 통일해 박멸.

### 변경 (PO/SME LOCK 4건)
| 영역 | 내용 |
|------|------|
| matrix | sprint `dispatch_capable` False→**True**(S26서 막아둔 AC 해제)·hypothesis는 S23서 이미 True |
| `l2_trigger_worker` | `_DISPATCHABLE_ANCHORS` 하드코딩 제거 → **`READINESS_MATRIX.dispatch_capable` 파생**(드리프트 박멸·`_ENTITY_TYPES`와 동일 노선) |
| hypothesis wake | **`owner_member_id`**(status_changed + deadline scan 둘 다·기존 drafted/created→owner 통일) |
| sprint wake | **`project_auth.resolve_project_relay_owner(project_id, org_id)`** 신규 헬퍼(member-SSOT) |

### ⭐ sprint relay-owner = member-SSOT (핵심)
Sprint은 assignee 컬럼이 없어 전이 wake를 프로젝트 책임자로 relay. **ad-hoc `TeamMember.role` 리졸버 금지** — event_notifications/docs가 자체 team_member 리졸버를 굴려 grant/admin 403 낸 드리프트의 그 함정 회피(산티아고 SME catch).
- 우선순위(deterministic 단일 픽): ①`project_access` granted owner(`member_id`∪`org_member_id`·human/agent 무관) ②`org_members` owner ③`org_members` admin · tie-break `created_at`.
- 반환 = **canonical 단일 member id**(team_members.id | org_members.id) → `resolve_member_identity`의 human notify / agent wake 분기에 위임. 없으면 None(`no_assignee` 가시화·가짜 fallback 금지).
- **agent-PO도 relay 대상**(human-only 필터 미적용 — 이 시스템선 PO가 에이전트인 게 정상).

### 무회귀
relay-owner 7 테스트(priority 1>2>3·tie-break·org 가드·None)·hypothesis dispatch anchor·L2 worker 16(owner_member_id/비-matrix 정합 갱신)·matrix S21 5-전부-eligible. **60 passed**. 잔여 3 = **baseline create_all blindspot**(s4 engine-shadow×2=plain_transition/NoResultFound·l2 concurrent_dedup=`l2_trigger_firings` 미생성·시그니처 dispatch/relay 무관 — QA fresh-DB 교차확認 대상). 소스 ruff-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
