### PR TITLE
[E-DG][S28] Resubmit/revision semantics (doc)

### DIFF
--- a/backend/alembic/versions/0130_docs_superseded_by.py
+++ b/backend/alembic/versions/0130_docs_superseded_by.py
@@ -3,8 +3,13 @@
 doc resubmit/revision(안A·같은-doc 재상신)은 doc.id/slug 를 stable 하게 유지하고 버전 이력은
 DocRevision 이 담당한다. superseded_by 는 **cross-doc 대체**(confirmed→superseded 시 이 doc 을 대체한
 별 doc) canonical 링크용 — 재상신 체인엔 안 쓴다. additive·nullable self-FK(ondelete SET NULL)·백필
-불요(기존 행 NULL). default-off 동작영향 0. ⚠️baseline schema.sql 동반 갱신(S26 CHECK·S27 l2_trigger
-처럼 baseline-parity 빠뜨리면 fresh-DB drift→RC).
+불요(기존 행 NULL). default-off 동작영향 0.
+
+⚠️baseline schema.sql 은 **건드리지 않는다**(의도): baseline/REVISION=0096 스냅샷 위에 이 마이그가
+컬럼을 얹는다. additive 신규 컬럼은 baseline 미변경이 선례 — 0128 status·0129 sprint enum·기존
+canonical_slug·slug_locked 전부 post-0096 마이그로만 추가됐고 baseline docs 테이블엔 없다. fresh-DB
+CI(baseline + `alembic upgrade head`)가 0130 을 적용하므로 drift 없음. (S26 는 0096 baseline 에
+*이미 있던* CHECK 를 넓힌 케이스라 baseline 동반이 필요했던 것 — 그와 구분.)
 """
 from alembic import op
 import sqlalchemy as sa

--- a/backend/alembic/versions/0130_docs_superseded_by.py
+++ b/backend/alembic/versions/0130_docs_superseded_by.py
@@ -1,0 +1,38 @@
+"""E-DG S28: docs.superseded_by (cross-doc 대체 포인터).
+
+doc resubmit/revision(안A·같은-doc 재상신)은 doc.id/slug 를 stable 하게 유지하고 버전 이력은
+DocRevision 이 담당한다. superseded_by 는 **cross-doc 대체**(confirmed→superseded 시 이 doc 을 대체한
+별 doc) canonical 링크용 — 재상신 체인엔 안 쓴다. additive·nullable self-FK(ondelete SET NULL)·백필
+불요(기존 행 NULL). default-off 동작영향 0. ⚠️baseline schema.sql 동반 갱신(S26 CHECK·S27 l2_trigger
+처럼 baseline-parity 빠뜨리면 fresh-DB drift→RC).
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0130"
+down_revision = "0129"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    cols = {c["name"] for c in insp.get_columns("docs")}
+    if "superseded_by" not in cols:
+        op.add_column(
+            "docs",
+            sa.Column("superseded_by", postgresql.UUID(as_uuid=True), nullable=True),
+        )
+        op.create_foreign_key(
+            "docs_superseded_by_fkey", "docs", "docs",
+            ["superseded_by"], ["id"], ondelete="SET NULL",
+        )
+        op.create_index("ix_docs_superseded_by", "docs", ["superseded_by"])
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_docs_superseded_by")
+    op.execute("ALTER TABLE docs DROP CONSTRAINT IF EXISTS docs_superseded_by_fkey")
+    op.drop_column("docs", "superseded_by")

--- a/backend/app/models/doc.py
+++ b/backend/app/models/doc.py
@@ -44,6 +44,12 @@ class Doc(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     # E-DG S22: doc decision lifecycle(doc-specific 값·work status 아님). draft→confirmed 만 line
     # overlay-gated(나머지 native 직행). 0128 마이그·default draft.
     status: Mapped[str] = mapped_column(Text, nullable=False, server_default="draft")
+    # E-DG S28: cross-doc 대체 포인터(이 doc 을 대체한 후속 doc). ⚠️같은-doc 재상신(안A)은 이걸 안 씀 —
+    # 버전 이력은 DocRevision 이 담당. confirmed→superseded(완전 신버전이 별 doc 으로 대체) 케이스의
+    # canonical 링크용. 0130 마이그·additive nullable self-FK(백필 불요).
+    superseded_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("docs.id", ondelete="SET NULL"), nullable=True, index=True
+    )
     title: Mapped[str] = mapped_column(Text, nullable=False)
     slug: Mapped[str] = mapped_column(Text, nullable=False)
     # 4dd399c6: False=자동관리(제목 파생·untitled-* 교정 대상), True=사용자 고정(자동 교정 금지).
@@ -63,8 +69,14 @@ class Doc(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
         nullable=True,
     )
 
-    children: Mapped[list["Doc"]] = relationship("Doc", back_populates="parent", lazy="select")
-    parent: Mapped["Doc | None"] = relationship("Doc", back_populates="children", remote_side=[id])
+    # ⚠️E-DG S28: superseded_by self-FK 추가로 docs↔docs FK 가 2개 → parent/children 는 parent_id FK 를
+    # 명시(foreign_keys)해 ambiguous join 회피.
+    children: Mapped[list["Doc"]] = relationship(
+        "Doc", back_populates="parent", lazy="select", foreign_keys=[parent_id]
+    )
+    parent: Mapped["Doc | None"] = relationship(
+        "Doc", back_populates="children", remote_side=[id], foreign_keys=[parent_id]
+    )
 
     @property
     def is_folder(self) -> bool:

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -513,10 +513,17 @@ async def list_doc_revisions(
     id: uuid.UUID,
     limit: int = Query(default=50, le=100),
     db: AsyncSession = Depends(get_db),
-    _repo: DocRepository = Depends(_get_repo),
+    repo: DocRepository = Depends(_get_repo),
 ) -> list[DocRevisionResponse]:
+    # ⚠️S28 보안(까심 RC·cross-org IDOR): doc 이 caller org 소속인지 org-scoped repo 로 먼저 검증.
+    # 안 하면 다른 org 가 doc UUID 추측만으로 revision content 를 읽는다(S28 전엔 revision 미배선이라
+    # 빈 응답 잠복·재상신 스냅샷 배선으로 활성화). revision 쿼리에도 org_id 가드(방어 심층).
+    doc = await repo.get(id)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Doc not found")
     q = select(DocRevision).where(
         DocRevision.doc_id == id,
+        DocRevision.org_id == repo.org_id,
     ).order_by(DocRevision.created_at.desc()).limit(limit)
     result = await db.execute(q)
     return [DocRevisionResponse.model_validate(r) for r in result.scalars()]

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -469,10 +469,17 @@ async def list_doc_comments(
     id: uuid.UUID,
     limit: int = Query(default=20, le=100),
     db: AsyncSession = Depends(get_db),
-    _repo: DocRepository = Depends(_get_repo),
+    repo: DocRepository = Depends(_get_repo),
 ) -> list[DocCommentResponse]:
+    # ⚠️S28 보안(까심 RC twin·revisions 동형 IDOR): doc 이 caller org 소속인지 org-scoped repo 로 검증.
+    # ⭐comments 는 revisions(S28 전 잠복)와 달리 이미 populated 라 active cross-org 노출이었다(pre-
+    # existing·revisions 고치며 surface sweep 서 적출·같이 봉인). org_id 가드(방어 심층).
+    doc = await repo.get(id)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Doc not found")
     q = select(DocComment).where(
         DocComment.doc_id == id,
+        DocComment.org_id == repo.org_id,
     ).order_by(DocComment.created_at.asc()).limit(limit)
     result = await db.execute(q)
     return [DocCommentResponse.model_validate(r) for r in result.scalars()]

--- a/backend/app/schemas/doc.py
+++ b/backend/app/schemas/doc.py
@@ -70,6 +70,9 @@ class DocResponse(BaseModel):
     assignee_id: uuid.UUID | None = None
     # E-DG S22: doc decision status(doc-specific lifecycle·work status 아님). 기본 draft.
     status: str = "draft"
+    # E-DG S28: cross-doc 대체 포인터(이 doc 을 대체한 후속 doc·없으면 None). additive read·재상신
+    # 체인엔 안 씀(버전 이력=DocRevision 타임라인). nullable 하위호환.
+    superseded_by: uuid.UUID | None = None
     title: str
     slug: str
     canonical_slug: str

--- a/backend/app/services/doc.py
+++ b/backend/app/services/doc.py
@@ -11,7 +11,7 @@ import uuid
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.doc import Doc, DOC_STATUSES, is_valid_doc_transition
+from app.models.doc import Doc, DOC_STATUSES, DocRevision, is_valid_doc_transition
 from app.services.member_resolver import ResolvedMember
 
 
@@ -70,6 +70,15 @@ async def transition_doc(
     # confirm 확정은 휴먼만(콘텐츠 승인=human-validated). agent 직접 confirm 차단.
     if to_status == "confirmed" and caller.type != "human":
         raise DocTransitionError("HUMAN_CONFIRM_REQUIRED", "confirmed 전이는 휴먼만 가능합니다.")
+
+    # ⭐E-DG S28: denied→draft(재상신 위한 revise) 시 직전(denied) 버전 content 를 DocRevision 에 스냅샷.
+    # 안A — doc.id/slug stable 유지하고 버전 이력은 DocRevision 타임라인(mockup v1→v2 데이터소스)으로.
+    # 저자가 이후 content 를 덮어쓰기 전에 반려본을 보존한다(재상신 사이클마다 1 revision).
+    if to_status == "draft" and doc.status == "denied":
+        session.add(DocRevision(
+            doc_id=doc.id, project_id=doc.project_id, org_id=org_id,
+            content=doc.content, created_by=caller.id,
+        ))
 
     doc.status = to_status
     await session.flush()

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -20,6 +20,7 @@ def _mock_doc() -> MagicMock:
     d.created_by = None
     d.assignee_id = None
     d.status = "draft"  # E-DG S22: 신규 status 필드(MagicMock→DocResponse 검증 실패 방지)
+    d.superseded_by = None  # E-DG S28: 신규 superseded_by(동일 패턴·MagicMock None 명시)
     d.title = "Getting Started"
     d.slug = "getting-started"
     d.canonical_slug = "getting-started"  # 4dd399c6: property on real Doc; mock 명시 필수

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -199,3 +199,43 @@ async def test_list_docs_with_parent_id_200():
         assert resp.status_code == 200
     finally:
         app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_doc_revisions_cross_org_404():
+    """⚠️S28 보안(까심 RC·cross-org IDOR): 다른 org doc 의 revisions 요청 → org-scoped repo.get None →
+    404. revision content 무노출(S28 스냅샷 배선으로 활성화된 누출 봉인)."""
+    client, session, app = await _client()
+    try:
+        # org-scoped repo.get 이 None(이 org 소속 아님) → 404·revision 쿼리 미실행.
+        with patch("app.repositories.base.BaseRepository.get", AsyncMock(return_value=None)):
+            async with client as c:
+                resp = await c.get(f"/api/v2/docs/{DOC_ID}/revisions")
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_doc_revisions_in_org_200():
+    """org 소속 doc 은 revisions 정상 반환(org_id 가드 통과)."""
+    client, session, app = await _client()
+    try:
+        rev = MagicMock()
+        rev.id = uuid.uuid4()
+        rev.doc_id = DOC_ID
+        rev.org_id = ORG_ID
+        rev.project_id = PROJECT_ID
+        rev.content = "v1 body"
+        rev.created_by = None
+        rev.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+        rev_result = MagicMock()
+        rev_result.scalars.return_value = [rev]
+        session.execute = AsyncMock(return_value=rev_result)
+        with patch("app.repositories.base.BaseRepository.get", AsyncMock(return_value=_mock_doc())):
+            async with client as c:
+                resp = await c.get(f"/api/v2/docs/{DOC_ID}/revisions")
+        assert resp.status_code == 200
+        assert resp.json()[0]["content"] == "v1 body"
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -239,3 +239,17 @@ async def test_list_doc_revisions_in_org_200():
         assert resp.json()[0]["content"] == "v1 body"
     finally:
         app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_doc_comments_cross_org_404():
+    """⚠️S28 보안(까심 RC twin): 다른 org doc 의 comments 요청 → org-scoped repo.get None → 404.
+    revisions 와 동형 IDOR(comments 는 이미 populated 라 active 노출이었음·같이 봉인)."""
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.base.BaseRepository.get", AsyncMock(return_value=None)):
+            async with client as c:
+                resp = await c.get(f"/api/v2/docs/{DOC_ID}/comments")
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_edg_s28_doc_resubmit.py
+++ b/backend/tests/test_edg_s28_doc_resubmit.py
@@ -1,0 +1,127 @@
+"""E-DG S28: doc resubmit/revision semantics (안A·같은-doc 재상신).
+
+반려(denied)→수정(denied→draft)→재상신(draft→confirmed re-gate) 흐름. ⭐안A: doc.id/slug stable
+유지하고 버전 이력은 DocRevision 타임라인(mockup v1→v2 데이터소스). denied→draft 시 직전(denied) content
+스냅샷. superseded_by 는 cross-doc 대체용(재상신 미사용·additive 컬럼). doc-only(hyp 라이프사이클 무관).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from app.services.doc import transition_doc
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _caller(org, type_="human"):
+    from app.services.member_resolver import ResolvedMember
+    return ResolvedMember(id=uuid.uuid4(), user_id=uuid.uuid4(), name="author",
+                          type=type_, role="member", org_id=org)
+
+
+async def _seed_doc(s, org, status, content="v1 content"):
+    from app.models.doc import Doc
+    from app.models.project import Project
+    proj = uuid.uuid4()
+    s.add(Project(id=proj, org_id=org, name="p"))
+    await s.flush()
+    doc = Doc(org_id=org, project_id=proj, title="d", slug=f"d-{uuid.uuid4().hex[:8]}",
+              content=content, status=status)
+    s.add(doc)
+    await s.flush()
+    return doc
+
+
+# ── DocRevision 스냅샷(denied→draft 재상신 사이클) ───────────────────────────────
+@pytest.mark.anyio
+async def test_denied_to_draft_snapshots_prior_content():
+    """⭐재상신 위한 revise(denied→draft) 시 직전 denied 버전 content 가 DocRevision 에 보존."""
+    from app.models.doc import DocRevision
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        doc = await _seed_doc(s, org, status="denied", content="rejected draft body")
+        await s.commit()
+        await transition_doc(s, org, _caller(org), doc.id, "draft")
+        await s.commit()
+        revs = (await s.execute(
+            select(DocRevision).where(DocRevision.doc_id == doc.id)
+        )).scalars().all()
+        assert len(revs) == 1
+        assert revs[0].content == "rejected draft body"  # denied 버전 보존
+        assert revs[0].doc_id == doc.id  # 같은-doc(안A·새 doc 안 만듦)
+        refreshed = doc
+        assert refreshed.status == "draft"  # 전이 적용됨
+    await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_non_revise_transition_no_snapshot():
+    """denied→draft 외 전이(draft→denied)는 스냅샷 안 함(사이클당 1 revision)."""
+    from app.models.doc import DocRevision
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        doc = await _seed_doc(s, org, status="draft")
+        await s.commit()
+        await transition_doc(s, org, _caller(org), doc.id, "denied")  # 반려(스냅샷 아님)
+        await s.commit()
+        revs = (await s.execute(
+            select(DocRevision).where(DocRevision.doc_id == doc.id)
+        )).scalars().all()
+        assert len(revs) == 0
+    await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_multi_cycle_builds_revision_timeline():
+    """재상신 2 사이클 → DocRevision 2개(mockup v1→v2 타임라인)."""
+    from app.models.doc import Doc, DocRevision
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        doc = await _seed_doc(s, org, status="denied", content="cycle1")
+        await s.commit()
+        # 사이클1: denied→draft(snap cycle1) → draft→denied(content 갱신 후 가정)
+        await transition_doc(s, org, _caller(org), doc.id, "draft")
+        d = (await s.execute(select(Doc).where(Doc.id == doc.id))).scalar_one()
+        d.content = "cycle2"
+        await s.flush()
+        await transition_doc(s, org, _caller(org), doc.id, "denied")
+        # 사이클2: denied→draft(snap cycle2)
+        await transition_doc(s, org, _caller(org), doc.id, "draft")
+        await s.commit()
+        revs = (await s.execute(
+            select(DocRevision).where(DocRevision.doc_id == doc.id)
+            .order_by(DocRevision.created_at)
+        )).scalars().all()
+        assert [r.content for r in revs] == ["cycle1", "cycle2"]  # 버전 타임라인
+    await engine.dispose()


### PR DESCRIPTION
## [E-DG][P2·S28][BE/FE] Resubmit/revision semantics (doc)

반려(denied)→수정(denied→draft)→재상신(draft→confirmed re-gate) 흐름. **PO design sign-off = 안A(같은-doc 재상신)**. 유나양 가디언-approved mockup 기준. 마이그 동반·**default-off**·**doc-only**(hyp는 supersede 라이프사이클 자체가 없음).

### 안A 채택 근거(PO)
⭐**stable identity 하드요건**: doc은 slug-autoderive로 고유 slug + 외부 링크/참조. 안B(재상신마다 새 doc v2)는 slug 충돌·canonical 해소 부담이 과함. 안A는 doc.id/slug 1개로 안정, **버전 이력은 DocRevision 타임라인**(mockup v1→v2 데이터소스).

### 변경
| 영역 | 내용 |
|------|------|
| 마이그 0130 | `docs.superseded_by`(nullable self-FK·SET NULL·index). 실-PG 전체 체인(0096→0130) 적용 검증 |
| DocRevision 배선 | `transition_doc` denied→draft(revise) 시 직전 denied content 스냅샷 → 재상신 사이클마다 1 revision. **그동안 INSERT 미배선이던 갭 봉합**(GET `/docs/{id}/revisions` 기존 엔드포인트가 타임라인 제공) |
| 모델 FK | superseded_by 추가로 docs↔docs FK 2개 → parent/children에 `foreign_keys=[parent_id]` 명시(ambiguous join 회피) |
| DocResponse | `superseded_by` additive read 노출(재상신 미사용·cross-doc 대체용) |

### baseline-parity(S26/S27 교훈)
⚠️`baseline/REVISION=0096` 스냅샷 위에 마이그(0128 status·0129 sprint·0130 superseded_by)가 컬럼 추가 → **baseline schema.sql 미변경이 정합**(S26는 0096 baseline에 기존 CHECK가 있어 갱신 필요했던 케이스라 구분). 실-PG 체인 적용으로 컬럼+FK+index 생성 확認.

### 단일경로 SSOT
DocUpdate에 `status` 필드 없음(S22가 이미 차단) → **PATCH status 옆문 0**. 전이는 `transition_doc`(`/transition` 엔드포인트·gate apply) 단일. '재상신=draft→pending'의 pending=**gate-pending**(라인엔진 step_run·per-attempt·재상신마다 fresh·`create_gate` 멱등/uq 무관).

### 무회귀
S28 3 테스트(denied→draft 스냅샷·非-revise 무스냅샷·멀티사이클 타임라인)·doc family **47+9 passed**. `_mock_doc` superseded_by=None 명시(MagicMock→DocResponse·S22 status 동일 패턴). ruff-clean. ⚠️마이그 동반=머지+migrate-dev 0130.

### FE 핸드오프(미르코군)
GET `/docs/{id}/revisions`(타임라인)·doc.status(denied/draft/confirmed badge)·전이 `POST /docs/{id}/transition`. 재상신 CTA="재검토 요청"→draft→confirmed(자기승인 금지·resolver 재결정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
