### PR TITLE
[E-DG][S29] Admin policy simulator BE — dry-run resolve-preview API

### DIFF
--- a/backend/app/routers/workflow_line_config.py
+++ b/backend/app/routers/workflow_line_config.py
@@ -302,8 +302,10 @@ def _project_preview(decision, from_status, to_status, routing_context) -> "Reso
     )
     gates = []
     if decision.mode in _MODE_TO_GATE_TYPE:
+        # ⭐QA Nit2: merge-gate dry-run 은 mode=gate_pending 이지만 effective_gate_type="merge" 로
+        # 정확 라벨(human 오라벨 방지·FE 가 merge_verdict 배지 렌더). effective_gate_type 우선.
         gates.append(PreviewGate(
-            gate_type=_MODE_TO_GATE_TYPE[decision.mode],
+            gate_type=decision.effective_gate_type or _MODE_TO_GATE_TYPE[decision.mode],
             target=decision.blocking_reason, gate_id=decision.gate_id,
         ))
     return ResolvePreviewResponse(
@@ -330,7 +332,9 @@ async def resolve_preview(
     결정 로직(preview≠real 드리프트 회피)·resolve_routing_context(side-effect-free)로 표시용 routing/
     trust. candidate-config diff/what-if 는 S29-followup(PO Q1 published-only)."""
     actor = uuid.UUID(auth.user_id)
-    # Q4: canonical project_auth admin gate(ad-hoc role 쿼리 금지·S27 교훈) — 라인 config 편집권과 동일.
+    # Q4: admin-only 게이트. ⚠️네이밍 주의(QA Nit1)=`_require_draft_author` 는 이름과 달리 **admin 강제**
+    # (project owner/admin ∪ org owner/admin·project_auth canonical·ad-hoc role 금지·S27 교훈). 공유
+    # 헬퍼라 rename 안 하고 호출부 노트로 의도 명시 — 라인 config 편집권과 동일 레벨이 policy 미리보기 권한.
     await _require_draft_author(session, actor, org_id, body.project_id)
 
     decision = await evaluate_line_for_transition(

--- a/backend/app/routers/workflow_line_config.py
+++ b/backend/app/routers/workflow_line_config.py
@@ -28,6 +28,8 @@ from app.services.workflow_line_config import (
     request_publish,
     transition_version,
 )
+from app.services.workflow_line_engine import evaluate_line_for_transition
+from app.services.workflow_line_resolver import resolve_routing_context
 
 router = APIRouter(prefix="/api/v2/workflow-line-config", tags=["workflow-line-config"])
 
@@ -230,3 +232,118 @@ async def retire_version(
     version = await transition_version(session, version, "retired")
     await session.commit()
     return VersionResponse.model_validate(version)
+
+
+class ResolvePreviewRequest(BaseModel):
+    entity_type: str
+    entity_id: uuid.UUID
+    from_status: str | None = None
+    to_status: str
+    actor_id: uuid.UUID | None = None
+    actor_type: str | None = None
+    project_id: uuid.UUID | None = None
+
+    @field_validator("entity_type")
+    @classmethod
+    def _valid_entity(cls, v: str) -> str:
+        if v not in ENTITY_TYPES:
+            raise ValueError(f"entity_type must be one of {sorted(ENTITY_TYPES)}")
+        return v
+
+
+# ⭐FE(유나) 3축 계약(cross-layer 사전정합): routing_path·gates·trust_branch.
+class PreviewStep(BaseModel):
+    from_status: str | None = None
+    to_status: str
+    route: str | None = None  # 이 전이가 거치는 라우팅 결정 라벨
+
+
+class PreviewGate(BaseModel):
+    gate_type: str | None = None      # human | policy | merge
+    target: str | None = None         # 게이트 대상 설명(blocking_reason)
+    gate_id: uuid.UUID | None = None
+
+
+class PreviewTrustBranch(BaseModel):
+    # ⚠️ null="데이터 없음(cold-start)" ≠ 0(실값) — FE 가 다르게 렌더하므로 null 보존(hypothesis_hit_rate).
+    trust: float | None = None
+    decision: str | None = None       # auto_merge | ask_human | block
+    cold_start: bool = False          # trust=null 사유(FE null≠0 렌더 보조)
+
+
+class ResolvePreviewResponse(BaseModel):
+    mode: str
+    proceeds: bool
+    blocking_reason: str | None = None
+    http_status: int | None = None
+    matched: bool  # 이 전이를 거버닝하는 published 라인 step 존재(mode != plain_transition)
+    routing_path: list[PreviewStep] = []   # ① 거치는 step 시퀀스(Phase-1=단일 전이)
+    gates: list[PreviewGate] = []          # ② 걸리는 게이트
+    trust_branch: PreviewTrustBranch       # ③ trust + decision
+    routing_context: dict[str, Any] = {}   # raw(디버그·완전성·additive)
+
+
+_MODE_TO_DECISION = {
+    "plain_transition": "auto_merge", "advisory_only": "auto_merge",
+    "engine_failed": "auto_merge", "gate_pending": "ask_human", "blocked_by_policy": "block",
+}
+_MODE_TO_GATE_TYPE = {"gate_pending": "human", "blocked_by_policy": "policy"}
+
+
+def _project_preview(decision, from_status, to_status, routing_context) -> "ResolvePreviewResponse":
+    """LineDecision + routing_context 를 FE 3축으로 투영(documented mapping·PO 요청)."""
+    trust = routing_context.get("trust") if isinstance(routing_context, dict) else {}
+    trust = trust if isinstance(trust, dict) else {}
+    matched = decision.mode != "plain_transition"
+    decision_label = _MODE_TO_DECISION.get(decision.mode)
+    routing_path = (
+        [PreviewStep(from_status=from_status, to_status=to_status, route=decision_label)]
+        if matched else []
+    )
+    gates = []
+    if decision.mode in _MODE_TO_GATE_TYPE:
+        gates.append(PreviewGate(
+            gate_type=_MODE_TO_GATE_TYPE[decision.mode],
+            target=decision.blocking_reason, gate_id=decision.gate_id,
+        ))
+    return ResolvePreviewResponse(
+        mode=decision.mode, proceeds=decision.proceeds,
+        blocking_reason=decision.blocking_reason, http_status=decision.http_status,
+        matched=matched, routing_path=routing_path, gates=gates,
+        trust_branch=PreviewTrustBranch(
+            trust=trust.get("hypothesis_hit_rate"),   # ⭐None=cold-start 보존(0점 금지)
+            decision=decision_label, cold_start=bool(trust.get("cold_start", False)),
+        ),
+        routing_context=routing_context if isinstance(routing_context, dict) else {},
+    )
+
+
+@router.post("/resolve-preview", response_model=ResolvePreviewResponse)
+async def resolve_preview(
+    body: ResolvePreviewRequest,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> ResolvePreviewResponse:
+    """⭐S29 Phase-1: dry-run resolve-preview — 현 published 라인이 이 전이를 어떻게 라우팅/게이팅하는지
+    **실제 전이/write 없이** 미리보기(admin-only). evaluate_line_for_transition(dry_run=True)로 동일
+    결정 로직(preview≠real 드리프트 회피)·resolve_routing_context(side-effect-free)로 표시용 routing/
+    trust. candidate-config diff/what-if 는 S29-followup(PO Q1 published-only)."""
+    actor = uuid.UUID(auth.user_id)
+    # Q4: canonical project_auth admin gate(ad-hoc role 쿼리 금지·S27 교훈) — 라인 config 편집권과 동일.
+    await _require_draft_author(session, actor, org_id, body.project_id)
+
+    decision = await evaluate_line_for_transition(
+        session, org_id=org_id, project_id=body.project_id,
+        entity_type=body.entity_type, entity_id=body.entity_id,
+        from_status=body.from_status, to_status=body.to_status,
+        actor_id=body.actor_id, actor_type=body.actor_type, dry_run=True,
+    )
+    # 표시용 routing/trust: 엔진이 쓰는 동일 함수(side-effect-free) 재사용 → preview 와 real 일치.
+    routing_context = await resolve_routing_context(
+        session, org_id, entity_type=body.entity_type, entity_id=body.entity_id,
+        actor_member_id=body.actor_id, actor_type=body.actor_type,
+    )
+    # ⭐dry-run write-0 보장(QA 집중 항목): 평가 경로는 write 0 이지만 잔여 0 을 명시적으로 rollback.
+    await session.rollback()
+    return _project_preview(decision, body.from_status, body.to_status, routing_context)

--- a/backend/app/services/workflow_line_engine.py
+++ b/backend/app/services/workflow_line_engine.py
@@ -148,8 +148,13 @@ async def evaluate_line_for_transition(
     actor_id: uuid.UUID | None = None,
     actor_type: str | None = None,
     transition_id: str | None = None,
+    dry_run: bool = False,
 ) -> LineDecision:
-    """전이 직전 라인 평가. ⭐절대 예외를 raise하지 않는다(P0-1 fail-open)."""
+    """전이 직전 라인 평가. ⭐절대 예외를 raise하지 않는다(P0-1 fail-open).
+
+    ⭐S29 dry_run=True: resolve-preview 모드 — 동일 결정 로직을 돌되 **side-effect 0**(step_run insert·
+    grandfather consume·merge-gate write·commit 전부 스킵). preview≠real 드리프트 회피 위해 별 함수
+    복제 대신 같은 경로에 dry_run 을 스레딩한다. 반환 LineDecision 의 step_run_id 는 None(미persist)."""
     transition_id = transition_id or uuid.uuid4().hex
     correlation_id = uuid.uuid4()
     try:
@@ -174,8 +179,19 @@ async def evaluate_line_for_transition(
 
         # S19(P0-5): grandfather — enable 전 in-flight story 의 첫 transition 은 새 gate 에 안 갇히게
         # 비차단 통과(marker 소비·다음 transition 부터 거버닝). board freeze 0(AC①④).
-        from app.services.workflow_grandfather import consume_grandfather
-        if await consume_grandfather(session, org_id, entity_type, entity_id, from_status, to_status):
+        # ⭐S29 dry-run: peek(consume 금지·write 0) — preview 가 grandfather 적용여부를 거짓 없이
+        # 반영(PO Q3·preview 는 거짓말 안 함). real 경로는 consume(marker 소비).
+        from app.services.workflow_grandfather import _has_open_grandfather, consume_grandfather
+        if dry_run:
+            _grandfathered = (
+                await _has_open_grandfather(session, org_id, entity_id)
+                if entity_type == "story" else False
+            )
+        else:
+            _grandfathered = await consume_grandfather(
+                session, org_id, entity_type, entity_id, from_status, to_status
+            )
+        if _grandfathered:
             return _plain()
 
         step = _match_step(config, from_status, to_status)
@@ -199,7 +215,7 @@ async def evaluate_line_for_transition(
                 to_status=to_status, status="blocked_by_policy", run_mode="blocked_by_policy",
                 routing_decision="block", routing_reason="static policy block",
                 routing_context=routing_context, trust_snapshot=trust_snapshot,
-                transition_id=transition_id, correlation_id=correlation_id,
+                transition_id=transition_id, correlation_id=correlation_id, dry_run=dry_run,
             )
             return LineDecision(
                 mode="blocked_by_policy", status_to_apply=None,
@@ -213,7 +229,7 @@ async def evaluate_line_for_transition(
                 session, org_id=org_id, project_id=project_id, definition=definition, step=step,
                 entity_type=entity_type, entity_id=entity_id, from_status=from_status,
                 to_status=to_status, routing_context=routing_context, trust_snapshot=trust_snapshot,
-                transition_id=transition_id, correlation_id=correlation_id,
+                transition_id=transition_id, correlation_id=correlation_id, dry_run=dry_run,
             )
 
         # shadow/advisory(+ S3 dormant enforcing) → step_run 기록 후 비차단.
@@ -224,7 +240,7 @@ async def evaluate_line_for_transition(
             routing_decision="would_" + str(step.get("step_type") or "advisory"),
             routing_reason=f"shadow/advisory record (mode={mode})",
             routing_context=routing_context, trust_snapshot=trust_snapshot,
-            transition_id=transition_id, correlation_id=correlation_id,
+            transition_id=transition_id, correlation_id=correlation_id, dry_run=dry_run,
         )
         # S7: enforcing agent-handoff step 은 status 적용 후 라우터가 relay(다음 actor dispatch).
         # shadow/advisory 모드는 관측만(relay 안 함). step_run 기록 실패(None)면 relay 대상 없음.
@@ -247,6 +263,7 @@ async def evaluate_line_for_transition(
                 to_status=to_status, status="engine_failed", run_mode="engine_failed",
                 failure_class=type(exc).__name__, failure_message=str(exc)[:500],
                 degraded_to_plain=True, transition_id=transition_id, correlation_id=correlation_id,
+                dry_run=dry_run,
             )
             step_run_id = sr.id if sr else None
         except Exception:  # noqa: BLE001 — 기록 실패도 무시(전이 우선).
@@ -262,9 +279,14 @@ async def _record_step_run(
     from_status, to_status, status, run_mode, transition_id, correlation_id,
     routing_decision=None, routing_reason=None, failure_class=None, failure_message=None,
     degraded_to_plain=False, routing_context=None, trust_snapshot=None,
-    gate_id=None, h1_gate_id=None, effective_gate_type=None,
+    gate_id=None, h1_gate_id=None, effective_gate_type=None, dry_run=False,
 ) -> WorkflowLineStepRun | None:
-    """step_run 기록. 호출자가 best-effort 로 감싼다(기록 실패도 전이 비차단)."""
+    """step_run 기록. 호출자가 best-effort 로 감싼다(기록 실패도 전이 비차단).
+
+    ⭐S29 dry_run=True 면 insert 0(write 스킵)·None 반환 — 호출부는 이미 None 을 step_run_id=None 로
+    처리(decision 의 mode/routing 은 sr 와 무관하게 호출부서 계산되므로 preview 정확성 유지)."""
+    if dry_run:
+        return None
     sr = WorkflowLineStepRun(
         org_id=org_id, project_id=project_id or org_id,  # project_id NN — org-level 라인은 org_id로 대체 표기
         line_definition_id=definition.id if definition is not None else None,
@@ -298,6 +320,7 @@ async def _record_step_run(
 async def _merge_gate_wrapper(
     session: AsyncSession, *, org_id, project_id, definition, step, entity_type, entity_id,
     from_status, to_status, routing_context, trust_snapshot, transition_id, correlation_id,
+    dry_run=False,
 ) -> LineDecision:
     """S5(P0-2): in-review→done merge-gate step = H1 merge gate 단일 통합.
 
@@ -306,6 +329,16 @@ async def _merge_gate_wrapper(
     로 재사용해 별도 line human-gate Gate 를 만들지 않는다(이중 pending 방지). H1 evidence metadata 는
     evaluate_merge_gate 가 gate row 에 write-back(유지). 예외는 바깥 try/except 가 engine_failed→plain.
     """
+    # ⭐S29 dry-run: evaluate_merge_gate 는 gate row 에 evidence write-back(side-effect)이라 preview 서
+    # 호출 금지. Phase-1 은 "이 전이가 merge-gate 에 걸린다"(gate 대상)까지만 미리보고, 정확 verdict
+    # (auto/block/human)는 미계산(CI/PR 동적 상태 의존). preview 는 거짓말 안 하므로 verdict 미상 명시.
+    if dry_run:
+        return LineDecision(
+            mode="gate_pending", status_to_apply=None,
+            blocking_reason="merge-gate (dry-run preview · 정확 verdict 미계산: CI/PR 동적 상태 의존)",
+            http_status=202,
+        )
+
     from app.services.merge_verdict_gate import AUTO_MERGE, BLOCK, evaluate_merge_gate
 
     decision = await evaluate_merge_gate(

--- a/backend/app/services/workflow_line_engine.py
+++ b/backend/app/services/workflow_line_engine.py
@@ -46,6 +46,9 @@ class LineDecision:
     degraded_to_plain: bool = False
     # S7: enforcing agent-handoff step 의 step_run id — 라우터가 status 적용 후 relay 한다(set 시에만).
     relay_step_run_id: uuid.UUID | None = None
+    # S29: dry-run preview 가 gate 종류(merge|human|policy)를 FE 에 정확 라벨하기 위한 힌트. real 경로는
+    # step_run 에만 기록하므로 None(decision 미사용)·dry-run merge-gate preview 만 "merge" 로 set.
+    effective_gate_type: str | None = None
 
     @property
     def proceeds(self) -> bool:
@@ -337,6 +340,7 @@ async def _merge_gate_wrapper(
             mode="gate_pending", status_to_apply=None,
             blocking_reason="merge-gate (dry-run preview · 정확 verdict 미계산: CI/PR 동적 상태 의존)",
             http_status=202,
+            effective_gate_type="merge",  # ⭐FE 가 merge_verdict 배지로 정확 렌더(human 오라벨 방지·QA Nit2)
         )
 
     from app.services.merge_verdict_gate import AUTO_MERGE, BLOCK, evaluate_merge_gate

--- a/backend/tests/test_edg_s29_dryrun_preview.py
+++ b/backend/tests/test_edg_s29_dryrun_preview.py
@@ -182,3 +182,13 @@ async def test_dry_run_peek_does_not_consume_grandfather(monkeypatch):
         )).scalar()
         assert st == "grandfathered"
     await engine.dispose()
+
+
+def test_project_merge_gate_type():
+    """⭐QA Nit2: merge-gate dry-run(mode=gate_pending·effective_gate_type='merge') → gate_type='merge'
+    (human 오라벨 방지·FE merge_verdict 배지). effective_gate_type 우선."""
+    d = LineDecision(mode="gate_pending", status_to_apply=None,
+                     blocking_reason="merge-gate (dry-run preview)", effective_gate_type="merge")
+    r = _project_preview(d, "in-review", "done", {"trust": {"hypothesis_hit_rate": None, "cold_start": True}})
+    assert r.gates[0].gate_type == "merge"  # human 아님
+    assert r.trust_branch.decision == "ask_human"  # gate_pending → ask_human 분기는 유지

--- a/backend/tests/test_edg_s29_dryrun_preview.py
+++ b/backend/tests/test_edg_s29_dryrun_preview.py
@@ -1,0 +1,184 @@
+"""E-DG S29: dry-run resolve-preview API + engine dry_run 모드.
+
+핵심: ①evaluate_line(dry_run=True)=side-effect 0(step_run insert·grandfather consume·gate write 스킵·
+commit 0) ②grandfather는 peek(consume 금지·preview 거짓말 안 함) ③LineDecision→FE 3축 투영(routing_
+path·gates·trust_branch·⭐trust null≠0 보존). admin-gated·published-only(Phase-1).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from app.routers.workflow_line_config import _project_preview
+from app.services.workflow_line_engine import LineDecision
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── 3축 투영(unit·CI-runnable·FE 계약) ────────────────────────────────────────
+def test_project_plain_empty_axes():
+    """default-off/라인없음(plain) → matched=False·routing_path/gates 빈배열·trust null(cold-start)."""
+    d = LineDecision(mode="plain_transition", status_to_apply=None)
+    r = _project_preview(d, "draft", "confirmed", {"trust": {"hypothesis_hit_rate": None, "cold_start": True}})
+    assert r.matched is False and r.routing_path == [] and r.gates == []
+    assert r.trust_branch.trust is None and r.trust_branch.cold_start is True
+    assert r.trust_branch.decision == "auto_merge" and r.proceeds is True
+
+
+def test_project_gate_pending_human():
+    """gate_pending → gate_type=human·decision=ask_human·proceeds=False."""
+    d = LineDecision(mode="gate_pending", status_to_apply=None, blocking_reason="human review")
+    r = _project_preview(d, "draft", "confirmed", {"trust": {"hypothesis_hit_rate": 0.0, "cold_start": False}})
+    assert r.matched is True and r.proceeds is False
+    assert r.routing_path[0].from_status == "draft" and r.routing_path[0].to_status == "confirmed"
+    assert r.gates[0].gate_type == "human" and r.gates[0].target == "human review"
+    assert r.trust_branch.decision == "ask_human"
+    # ⭐null≠0: 0.0 은 실값으로 보존(None 으로 강등 금지).
+    assert r.trust_branch.trust == 0.0 and r.trust_branch.cold_start is False
+
+
+def test_project_blocked_policy():
+    d = LineDecision(mode="blocked_by_policy", status_to_apply=None, blocking_reason="policy blocks")
+    r = _project_preview(d, "active", "done", {"trust": {"hypothesis_hit_rate": 0.7, "cold_start": False}})
+    assert r.gates[0].gate_type == "policy" and r.trust_branch.decision == "block"
+    assert r.proceeds is False and r.trust_branch.trust == 0.7
+
+
+# ── engine dry_run = write 0 (real-PG) ────────────────────────────────────────
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _enable_shadow(mp, mode="shadow"):
+    from app.core.config import settings
+    mp.setattr(settings, "decision_gate_line_enabled", True)
+    mp.setattr(settings, "decision_gate_line_org_allowlist", "")
+    mp.setattr(settings, "decision_gate_line_mode", mode)
+
+
+async def _seed_line(s, org, *, rollout="shadow", from_status="draft", to_status="confirmed"):
+    from app.models.project import Project
+    from app.models.doc import Doc
+    from app.models.workflow_line import WorkflowLineDefinition, WorkflowLineDefinitionVersion
+    proj = uuid.uuid4()
+    s.add(Project(id=proj, org_id=org, name="p"))
+    await s.flush()
+    defn = WorkflowLineDefinition(org_id=org, project_id=None, entity_type="doc",
+                                  name="L", is_active=True, version=1)
+    s.add(defn)
+    await s.flush()
+    s.add(WorkflowLineDefinitionVersion(
+        line_definition_id=defn.id, org_id=org, project_id=None, entity_type="doc", version=1,
+        status="published", config_hash="h", created_by_member_id=uuid.uuid4(),
+        config={"rollout_mode": rollout, "steps": [{
+            "from_status": from_status, "to_status": to_status, "step_type": "human-gate"}]}))
+    doc = Doc(org_id=org, project_id=proj, title="d", slug=f"d-{uuid.uuid4().hex[:8]}",
+              content="x", status=from_status)
+    s.add(doc)
+    await s.flush()
+    return proj, doc
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_dry_run_records_no_step_run(monkeypatch):
+    """⭐dry_run=True 는 step_run insert 0(real 은 1) — write-0 증명(QA 집중)."""
+    from app.services.workflow_line_engine import evaluate_line_for_transition
+    from app.models.workflow_line import WorkflowLineStepRun
+    from sqlalchemy import select, func
+    _enable_shadow(monkeypatch)
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        proj, doc = await _seed_line(s, org)
+        await s.commit()
+
+        async def _count():
+            return (await s.execute(
+                select(func.count()).select_from(WorkflowLineStepRun)
+                .where(WorkflowLineStepRun.entity_id == doc.id)
+            )).scalar()
+
+        dec_dry = await evaluate_line_for_transition(
+            s, org_id=org, project_id=proj, entity_type="doc", entity_id=doc.id,
+            from_status="draft", to_status="confirmed", dry_run=True)
+        await s.commit()
+        assert await _count() == 0  # ⭐write 0
+
+        dec_real = await evaluate_line_for_transition(
+            s, org_id=org, project_id=proj, entity_type="doc", entity_id=doc.id,
+            from_status="draft", to_status="confirmed", dry_run=False)
+        await s.commit()
+        assert await _count() == 1  # real 은 step_run 기록 → 라인 active 입증
+        # 결정 parity: dry 와 real 의 mode 동일(같은 로직·드리프트 0).
+        assert dec_dry.mode == dec_real.mode == "advisory_only"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_dry_run_peek_does_not_consume_grandfather(monkeypatch):
+    """⭐grandfather peek: dry_run 은 marker 를 consume 하지 않는다(preview 가 거짓말 안 함·PO Q3)."""
+    from app.services.workflow_line_engine import evaluate_line_for_transition
+    from app.models.project import Project
+    from app.models.pm import Story
+    from app.models.workflow_line import (
+        WorkflowLineDefinition, WorkflowLineDefinitionVersion, WorkflowLineStepRun,
+    )
+    from sqlalchemy import select
+    _enable_shadow(monkeypatch, mode="enforcing")
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        proj = uuid.uuid4()
+        s.add(Project(id=proj, org_id=org, name="p"))
+        await s.flush()
+        defn = WorkflowLineDefinition(org_id=org, project_id=None, entity_type="story",
+                                      name="L", is_active=True, version=1)
+        s.add(defn)
+        await s.flush()
+        s.add(WorkflowLineDefinitionVersion(
+            line_definition_id=defn.id, org_id=org, project_id=None, entity_type="story", version=1,
+            status="published", config_hash="h", created_by_member_id=uuid.uuid4(),
+            config={"rollout_mode": "enforcing", "steps": [{
+                "from_status": "in-review", "to_status": "done", "step_type": "human-gate"}]}))
+        story = Story(org_id=org, project_id=proj, title="t", status="in-review", priority="high")
+        s.add(story)
+        await s.flush()
+        marker = WorkflowLineStepRun(
+            org_id=org, project_id=proj, entity_type="story", entity_id=story.id,
+            from_status="in-review", to_status="in-review", status="grandfathered",
+            mode="advisory_only", correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex)
+        s.add(marker)
+        await s.flush()
+        await s.commit()
+
+        await evaluate_line_for_transition(
+            s, org_id=org, project_id=proj, entity_type="story", entity_id=story.id,
+            from_status="in-review", to_status="done", dry_run=True)
+        await s.commit()
+        # ⭐marker 여전히 open(consume 안 됨) — dry_run peek.
+        st = (await s.execute(
+            select(WorkflowLineStepRun.status).where(WorkflowLineStepRun.id == marker.id)
+        )).scalar()
+        assert st == "grandfathered"
+    await engine.dispose()


### PR DESCRIPTION
## [E-DG][P3·S29][BE] Admin policy simulator — dry-run resolve-preview API

라인 config publish 전 "이 전이가 현 published 라인에서 어떻게 라우팅/게이팅되나"를 **실제 전이/write 없이** 미리보기. PO 4결정 sign-off 반영. **마이그 0**(코드만).

### dry_run 스레딩(복제 금지=preview≠real 드리프트 회피)
`evaluate_line_for_transition(dry_run=True)` = 동일 결정 로직·**side-effect 0**:
| write | dry_run 처리 |
|-------|-------------|
| `_record_step_run` insert ×3 | early `return None`(decision 의 mode/routing 은 sr 무관) |
| `consume_grandfather`(marker UPDATE) | ⭐**peek**(`_has_open_grandfather` SELECT·미소비·PO Q3) |
| `_merge_gate_wrapper`→`evaluate_merge_gate`(gate write-back) | 미호출·gate-대상까지만 preview(정확 verdict=CI/PR 동적 의존이라 미계산 명시) |

`dry_run=False` 는 param 비활성 = **기존 거동 byte-equivalent**(무회귀).

### 엔드포인트
`POST /api/v2/workflow-line-config/resolve-preview` — **admin-only**(`_require_draft_author` = project_auth canonical·ad-hoc role 금지·S27 교훈)·published-only(candidate diff/what-if = S29-followup·PO Q1).

### ⭐FE(유나) 3축 계약 사전정합(cross-layer)
`LineDecision` → `{routing_path, gates, trust_branch}` 투영(documented mapping):
- `trust_branch.trust` = `hypothesis_hit_rate` **null 보존**(cold-start "데이터 없음" ≠ 0 실값)·`cold_start` 플래그.
- `decision` enum = `auto_merge|ask_human|block`.

### 검증
S29 5 테스트: 투영 unit 3(**CI-runnable**·FE 계약·⭐trust null≠0) + write-0·peek 2(real-PG·QA 집중). 엔진 회귀 6 failed=**baseline create_all blindspot**(stash 대조 동일·dry_run 무관). ruff-clean.

### FE 핸드오프(미르코군)
3축 shape `{routing_path,gates,trust_branch}`·실 payload 1발 E2E(가정 shape false-green 금지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
