### PR TITLE
[E-DG][S29-followup] GET /workflow-line-config/active (좌-pane 데이터소스)

### DIFF
--- a/backend/app/routers/workflow_line_config.py
+++ b/backend/app/routers/workflow_line_config.py
@@ -7,7 +7,7 @@ RBAC: draft 관리 = project admin+(또는 org owner/admin) / publish(요청·�
 import uuid
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict, field_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -351,3 +351,39 @@ async def resolve_preview(
     # ⭐dry-run write-0 보장(QA 집중 항목): 평가 경로는 write 0 이지만 잔여 0 을 명시적으로 rollback.
     await session.rollback()
     return _project_preview(decision, body.from_status, body.to_status, routing_context)
+
+
+class ActiveLineResponse(BaseModel):
+    entity_type: str
+    project_id: uuid.UUID | None = None
+    has_active: bool                       # 활성 published 라인 존재(default-off/미발행→false)
+    definition_id: uuid.UUID | None = None
+    config: dict[str, Any] = {}            # 현 published config(steps/gates 시퀀스). 없으면 {}
+
+
+@router.get("/active", response_model=ActiveLineResponse)
+async def get_active_line(
+    entity_type: str = Query(...),
+    project_id: uuid.UUID | None = Query(default=None),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> ActiveLineResponse:
+    """⭐S29 좌-pane 데이터소스: (entity_type, project)의 현 active published 라인 config(steps/gates).
+
+    admin-only(project_auth canonical·S29 패턴 재사용)·read-only·마이그0. SSOT=WorkflowLineDefinition
+    (is_active=True·project override>org-default) + 최신 published version config. 엔진 헬퍼 재사용
+    (preview≠real 드리프트 회피). 활성 라인 없으면 has_active=false·config={}(default-off 정상)."""
+    if entity_type not in ENTITY_TYPES:
+        raise HTTPException(status_code=422, detail=f"entity_type must be one of {sorted(ENTITY_TYPES)}")
+    actor = uuid.UUID(auth.user_id)
+    await _require_draft_author(session, actor, org_id, project_id)  # admin 게이팅(이름≠동작·admin 강제)
+    from app.services.workflow_line_engine import _active_definition, _published_config
+    definition = await _active_definition(session, org_id, project_id, entity_type)
+    if definition is None:
+        return ActiveLineResponse(entity_type=entity_type, project_id=project_id, has_active=False)
+    config = await _published_config(session, definition)
+    return ActiveLineResponse(
+        entity_type=entity_type, project_id=project_id, has_active=True,
+        definition_id=definition.id, config=config,
+    )

--- a/backend/tests/test_s29_active_line_get.py
+++ b/backend/tests/test_s29_active_line_get.py
@@ -1,0 +1,74 @@
+"""E-DG S29 followup: GET /workflow-line-config/active — 좌-pane 데이터소스(현 published 라인 config)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_invalid_entity_type_422_unit():
+    """entity_type 검증은 DB 전 — 미등록 타입 422(ENTITY_TYPES 가드)."""
+    from app.models.workflow_line import ENTITY_TYPES
+    assert "widget" not in ENTITY_TYPES
+    assert "story" in ENTITY_TYPES
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.participation  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_active_line_returns_published_config():
+    """활성 published 라인의 config(steps) 반환(엔진 헬퍼 재사용)."""
+    from app.services.workflow_line_engine import _active_definition, _published_config
+    from app.models.workflow_line import WorkflowLineDefinition, WorkflowLineDefinitionVersion
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        defn = WorkflowLineDefinition(org_id=org, project_id=None, entity_type="story",
+                                      name="L", is_active=True, version=1)
+        s.add(defn)
+        await s.flush()
+        s.add(WorkflowLineDefinitionVersion(
+            line_definition_id=defn.id, org_id=org, project_id=None, entity_type="story", version=1,
+            status="published", config_hash="h", created_by_member_id=uuid.uuid4(),
+            config={"rollout_mode": "shadow", "steps": [{"from_status": "a", "to_status": "b"}]}))
+        await s.commit()
+        d = await _active_definition(s, org, None, "story")
+        assert d is not None
+        cfg = await _published_config(s, d)
+        assert cfg.get("steps") == [{"from_status": "a", "to_status": "b"}]
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_no_active_line_returns_none():
+    """활성 라인 없으면 None(엔드포인트는 has_active=false)."""
+    from app.services.workflow_line_engine import _active_definition
+    engine, Session = await _session()
+    async with Session() as s:
+        assert await _active_definition(s, uuid.uuid4(), None, "story") is None
+    await engine.dispose()


### PR DESCRIPTION
미르코 S29 좌 pane 언블록. (entity_type,project)의 현 active published 라인 config(steps/gates) 반환·admin-only·read-only·마이그0. 엔진 헬퍼(_active_definition/_published_config) 재사용. 활성 라인 없으면 has_active=false. 테스트 3·ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)