### PR TITLE
[E-DG][S31] Hold full UX BE — gate hold/unhold + SLA pause + held_until

### DIFF
--- a/backend/alembic/versions/0132_gate_held_until.py
+++ b/backend/alembic/versions/0132_gate_held_until.py
@@ -1,0 +1,29 @@
+"""E-DG S31: gate.held_until (admin hold 만료·시한부 보류).
+
+S31 hold full UX — admin 이 pending gate 를 일시 보류(held). gate.status='held' + held_until(시한부면
+만료 시각·무기한이면 None). FE 가 gate 직독으로 held_until 배지 렌더(step_run.held_until 경유 leaky
+회피). additive·nullable·백필 불요(기존 행 NULL=held 아님). default-off 동작영향 0.
+
+⚠️baseline schema.sql 미변경(의도): held_until 은 post-0096 추가(0132)·baseline/REVISION=0096 스냅샷엔
+원래 없음(superseded_by(0130)·doc org_id(0131)와 동형). fresh-DB CI(baseline + alembic upgrade head)가
+0132 적용. ⭐P0 교훈: 모델(gate.held_until) ↔ 마이그 매칭을 migrated-DB 로 검증(create_all 가림 방지).
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0132"
+down_revision = "0131"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    cols = {c["name"] for c in insp.get_columns("gate")}
+    if "held_until" not in cols:
+        op.add_column("gate", sa.Column("held_until", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("gate", "held_until")

--- a/backend/app/models/gate.py
+++ b/backend/app/models/gate.py
@@ -16,14 +16,17 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
 
-GATE_STATUSES = frozenset({"pending", "approved", "rejected", "auto_passed", "voided"})
+GATE_STATUSES = frozenset({"pending", "approved", "rejected", "auto_passed", "voided", "held"})
 
-# 합법 전이: (from, to). ⭐S30: pending→voided(admin recovery·오발행/막힌 gate 무효화). voided≠approval —
-# 묶인 step_run 은 skipped 로 해소돼 엔티티가 unblock(re-route 가능)되되 "승인됨"으로 전진하지 않는다.
+# 합법 전이: (from, to). ⭐S30: pending→voided(admin recovery·voided≠approval·step_run skipped 해소).
+# ⭐S31: pending↔held(admin hold/unhold·일시정지/재개·가역). held→approved/rejected 직접 금지 —
+# 재개(held→pending) 후 정상 pending 서 결정(hold와 결정 혼동 방지·4종 모델 clean).
 _VALID_TRANSITIONS: set[tuple[str, str]] = {
     ("pending", "approved"),
     ("pending", "rejected"),
     ("pending", "voided"),
+    ("pending", "held"),       # S31 hold(일시정지·SLA pause)
+    ("held", "pending"),       # S31 unhold(재개·SLA resume)
 }
 
 
@@ -43,6 +46,9 @@ class Gate(Base):
     resolver_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     resolution_note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # ⭐S31: hold 만료(시한부 보류). status='held' 일 때만 의미·무기한 hold 면 None. 0132 마이그(post-0096).
+    # FE 가 gate 직독으로 held_until 배지 렌더(step_run 경유 leaky 회피)·step_run.held_until 도 SLA 동기화.
+    held_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     neutral_facts: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     # H1-S3: merge verdict gate evidence metadata (0118).
     requires_human: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -11,7 +11,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.gate import Gate
-from app.services.gate_service import create_gate, transition_gate, void_gate
+from app.services.gate_service import (
+    create_gate,
+    hold_gate,
+    transition_gate,
+    unhold_gate,
+    void_gate,
+)
 from app.services.member_resolver import resolve_member
 from app.services.project_auth import is_org_owner_or_admin
 
@@ -64,6 +70,7 @@ class GateResponse(BaseModel):
     resolver_id: uuid.UUID | None = None
     resolved_at: datetime | None = None
     resolution_note: str | None = None
+    held_until: datetime | None = None  # S31: status='held' 시 시한부 만료(무기한이면 None)·additive
     neutral_facts: dict[str, Any] | None = None
     # H1-S3: merge verdict gate evidence metadata (0118)·additive·하위호환 default.
     requires_human: bool = False
@@ -167,6 +174,55 @@ async def void_gate_endpoint(
         raise HTTPException(status_code=403, detail="게이트 무효화는 org owner/admin 만 가능합니다.")
     try:
         gate = await void_gate(session, org_id, id, resolved.id, body.reason)
+        await session.commit()
+        return GateResponse.model_validate(gate)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+
+class GateHoldRequest(BaseModel):
+    reason: str | None = None       # S31: 보류 사유(선택·가역적 일시정지라 마찰↓)
+    held_until: datetime | None = None  # 시한부 만료(무기한이면 None)
+
+
+async def _require_gate_admin(session, auth, org_id):
+    """⭐S31/S30 공통: gate 파괴적/관리 액션 admin 게이팅(canonical project_auth·ad-hoc role 금지).
+    반환 resolved member(holder/voider=인증 caller 강제용·body 신뢰 0)."""
+    resolved = await resolve_member(auth, org_id, session)
+    if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
+        raise HTTPException(status_code=403, detail="이 액션은 org owner/admin 만 가능합니다.")
+    return resolved
+
+
+@router.post("/{id}/hold", response_model=GateResponse)
+async def hold_gate_endpoint(
+    id: uuid.UUID,
+    body: GateHoldRequest,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> GateResponse:
+    """⭐S31 admin hold: pending gate 일시 보류(held·SLA pause). admin-only·holder=인증 caller 강제."""
+    resolved = await _require_gate_admin(session, auth, org_id)
+    try:
+        gate = await hold_gate(session, org_id, id, resolved.id, body.reason, body.held_until)
+        await session.commit()
+        return GateResponse.model_validate(gate)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+
+@router.post("/{id}/unhold", response_model=GateResponse)
+async def unhold_gate_endpoint(
+    id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> GateResponse:
+    """⭐S31 admin unhold: held gate 재개(→pending·SLA resume). admin-only·actor=인증 caller."""
+    resolved = await _require_gate_admin(session, auth, org_id)
+    try:
+        gate = await unhold_gate(session, org_id, id, resolved.id)
         await session.commit()
         return GateResponse.model_validate(gate)
     except ValueError as e:

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -197,6 +197,99 @@ async def void_gate(
     return gate
 
 
+async def _set_linked_step_run(session, org_id, gate_id, *, status, held_until, reason):
+    """gate 에 묶인 미해소 step_run 의 status/held_until 갱신(없으면 no-op·legacy/비-라인 gate)."""
+    from app.services.workflow_line_resolution import find_active_step_run_for_gate
+    sr_id = await find_active_step_run_for_gate(session, org_id, gate_id)
+    if sr_id is None:
+        return None
+    sr = (await session.execute(
+        select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr_id)
+    )).scalar_one_or_none()
+    if sr is not None:
+        sr.status = status
+        sr.held_until = held_until
+        if reason is not None:
+            sr.routing_reason = reason[:500]
+    return sr_id
+
+
+async def hold_gate(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    gate_id: uuid.UUID,
+    holder_id: uuid.UUID,
+    reason: str | None = None,
+    held_until: datetime | None = None,
+) -> Gate:
+    """⭐S31 admin hold: pending gate 를 일시 보류(held). void(종료)와 달리 **가역**(unhold 재개).
+
+    묶인 step_run.status='held'+held_until 세팅 → SLA processor 가 reminder/escalation 일시정지(pause).
+    holder=인증 caller(라우터 강제·body 신뢰 0·S23 RC①). audit=gate 행(status='held'·resolver_id=holder·
+    resolution_note=reason·held_until)이 현 상태(status='held' 가 disambiguate·unhold 시 clear)+app-log
+    `gate_held`(durable 이력·S30 void 패턴). 사유는 선택(가역적 일시정지라 마찰↓).
+    """
+    gate = (await session.execute(
+        select(Gate).where(Gate.id == gate_id, Gate.org_id == org_id)
+    )).scalar_one_or_none()
+    if gate is None:
+        raise ValueError(f"Gate {gate_id} not found")
+    if not is_valid_transition(gate.status, "held"):
+        raise ValueError(f"불법 전이: {gate.status} → held. pending 게이트만 보류 가능.")
+
+    gate.status = "held"
+    gate.resolver_id = holder_id          # status='held' 가 holder 로 해석(approve/reject 아님)
+    gate.resolution_note = reason          # 선택
+    gate.held_until = held_until           # 무기한이면 None
+    sr_id = await _set_linked_step_run(
+        session, org_id, gate_id, status="held", held_until=held_until,
+        reason=f"gate held by admin{(': ' + reason) if reason else ''}",
+    )
+    logger.info(
+        "gate_held org=%s gate=%s holder=%s work=%s/%s step_run=%s until=%s reason=%s",
+        org_id, gate_id, holder_id, gate.work_item_type, gate.work_item_id, sr_id, held_until, reason,
+    )
+    await session.flush()
+    await session.refresh(gate)
+    return gate
+
+
+async def unhold_gate(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    gate_id: uuid.UUID,
+    actor_id: uuid.UUID,
+) -> Gate:
+    """⭐S31 admin unhold: held gate 를 재개(→pending). SLA 재개(step_run→gate_pending·다음 스캔서 처리).
+
+    held 상태 audit 필드(resolver_id/resolution_note/held_until)를 **clear**(재개된 pending 깨끗)·이력은
+    app-log `gate_unheld`. holder/actor=인증 caller(라우터 강제).
+    """
+    gate = (await session.execute(
+        select(Gate).where(Gate.id == gate_id, Gate.org_id == org_id)
+    )).scalar_one_or_none()
+    if gate is None:
+        raise ValueError(f"Gate {gate_id} not found")
+    if not is_valid_transition(gate.status, "pending"):
+        raise ValueError(f"불법 전이: {gate.status} → pending. 보류(held) 게이트만 재개 가능.")
+
+    gate.status = "pending"
+    gate.resolver_id = None
+    gate.resolution_note = None
+    gate.held_until = None
+    sr_id = await _set_linked_step_run(
+        session, org_id, gate_id, status="gate_pending", held_until=None,
+        reason="gate unheld by admin (resumed)",
+    )
+    logger.info(
+        "gate_unheld org=%s gate=%s actor=%s work=%s/%s step_run=%s",
+        org_id, gate_id, actor_id, gate.work_item_type, gate.work_item_id, sr_id,
+    )
+    await session.flush()
+    await session.refresh(gate)
+    return gate
+
+
 async def _advance_story_on_merge_approve(session: AsyncSession, gate: Gate, new_status: str) -> None:
     """merge 게이트 approve 시 work_item 스토리를 done으로 진행(H1-FIX-2).
 

--- a/backend/app/services/workflow_sla_processor.py
+++ b/backend/app/services/workflow_sla_processor.py
@@ -124,6 +124,13 @@ async def process_sla(session: AsyncSession, now: datetime | None = None) -> dic
     counts = {"reminded": 0, "escalated": 0, "auto_approved": 0, "kept_pending": 0,
               "unresolved": 0, "skipped": 0}
     for sr in rows:
+        # ⭐S31 hold = SLA pause: held step_run 은 reminder/escalation/timeout 일시정지(skip). admin 이
+        # 수동 unhold(→gate_pending) 하면 다음 스캔서 정상 처리 재개. ⚠️held 가 이미 _SLA_GATE_STATUSES
+        # 라 스캔엔 들어오므로 여기서 per-step skip. (held_until 만료 자동 재개는 S13 통합 followup —
+        # 그때 여기서 now>=held_until 이면 gate_pending 복귀시켜 처리.)
+        if sr.status == "held":
+            counts["skipped"] += 1
+            continue
         policy = await _resolve_sla_policy(session, sr)
         timeout_h = policy.get("timeout_hours")
         if not timeout_h:

--- a/backend/tests/test_edg_s31_hold.py
+++ b/backend/tests/test_edg_s31_hold.py
@@ -1,0 +1,213 @@
+"""E-DG S31: admin hold full UX — pending gate 일시 보류(held)·재개(unhold).
+
+핵심: ①pending↔held(held→pending만·held→approve/reject 직접 금지) ②hold→step_run held+held_until→
+SLA pause(processor skip) ③unhold→gate_pending 복귀+held_until/resolver/note clear(재개된 pending 깨끗)
+④사유 선택·holder=인증 caller·admin-only. gate.held_until(0132 마이그)·step_run.held_until(0126 기존).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.models.gate import GATE_STATUSES, is_valid_transition
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── FSM(unit·CI-runnable) ─────────────────────────────────────────────────────
+def test_hold_fsm():
+    assert "held" in GATE_STATUSES
+    assert is_valid_transition("pending", "held") is True
+    assert is_valid_transition("held", "pending") is True       # unhold(재개)
+    assert is_valid_transition("held", "approved") is False     # 직접 결정 금지(재개 후 pending서)
+    assert is_valid_transition("held", "rejected") is False
+    assert is_valid_transition("held", "voided") is False
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.participation  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_gate(s, org, *, status="pending"):
+    from app.models.gate import Gate
+    from app.models.workflow_line import WorkflowLineStepRun
+    proj = uuid.uuid4()
+    wi = uuid.uuid4()
+    gate = Gate(id=uuid.uuid4(), org_id=org, work_item_id=wi, work_item_type="story",
+                gate_type="merge", status=status)
+    s.add(gate)
+    await s.flush()
+    sr = WorkflowLineStepRun(
+        org_id=org, project_id=proj, entity_type="story", entity_id=wi,
+        from_status="in-review", to_status="done", status="gate_pending", mode="gate_pending",
+        gate_id=gate.id, h1_gate_id=gate.id, correlation_id=uuid.uuid4(),
+        transition_id=uuid.uuid4().hex)
+    s.add(sr)
+    await s.flush()
+    return gate, sr
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_hold_then_unhold_roundtrip():
+    """⭐hold: gate=held+held_until·step_run=held. unhold: gate=pending+clear·step_run=gate_pending."""
+    from app.services.gate_service import hold_gate, unhold_gate
+    from app.models.workflow_line import WorkflowLineStepRun
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        holder = uuid.uuid4()
+        until = datetime(2026, 6, 25, tzinfo=timezone.utc)
+        gate, sr = await _seed_gate(s, org)
+        await s.commit()
+        # hold
+        g = await hold_gate(s, org, gate.id, holder, "추가 정보 대기", until)
+        await s.commit()
+        assert g.status == "held" and g.resolver_id == holder
+        assert g.resolution_note == "추가 정보 대기" and g.held_until == until
+        sr2 = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id))).scalar_one()
+        assert sr2.status == "held" and sr2.held_until == until
+        # unhold(재개)
+        g2 = await unhold_gate(s, org, gate.id, holder)
+        await s.commit()
+        assert g2.status == "pending"
+        assert g2.resolver_id is None and g2.resolution_note is None and g2.held_until is None  # clear
+        sr3 = (await s.execute(select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr.id))).scalar_one()
+        assert sr3.status == "gate_pending" and sr3.held_until is None
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_hold_indefinite_no_until():
+    """무기한 hold(held_until 미지정)도 정상(사유도 선택)."""
+    from app.services.gate_service import hold_gate
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        gate, _ = await _seed_gate(s, org)
+        await s.commit()
+        g = await hold_gate(s, org, gate.id, uuid.uuid4())  # reason·until 둘 다 None
+        await s.commit()
+        assert g.status == "held" and g.held_until is None
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_hold_non_pending_and_unhold_non_held_rejected():
+    from app.services.gate_service import hold_gate, unhold_gate
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        approved, _ = await _seed_gate(s, org, status="approved")
+        pending, _ = await _seed_gate(s, org, status="pending")
+        await s.commit()
+        with pytest.raises(ValueError, match="pending 게이트만"):
+            await hold_gate(s, org, approved.id, uuid.uuid4())   # approved 는 hold 불가
+        with pytest.raises(ValueError, match="보류"):
+            await unhold_gate(s, org, pending.id, uuid.uuid4())  # pending 은 unhold 불가
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_sla_skips_held_step_run():
+    """⭐SLA pause: held step_run 은 processor 가 skip(reminder/escalation 일시정지)."""
+    from app.services.workflow_sla_processor import process_sla  # noqa: F401
+    from app.models.project import Project
+    from app.models.pm import Story
+    from app.models.workflow_line import WorkflowLineStepRun
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        proj = uuid.uuid4()
+        s.add(Project(id=proj, org_id=org, name="p"))
+        await s.flush()
+        story = Story(org_id=org, project_id=proj, title="t", status="in-review", priority="high")
+        s.add(story)
+        await s.flush()
+        # held step_run(started 한참 전 — timeout 넘겨도 held 라 skip 돼야)
+        s.add(WorkflowLineStepRun(
+            org_id=org, project_id=proj, entity_type="story", entity_id=story.id,
+            from_status="in-review", to_status="done", status="held", mode="gate_pending",
+            started_at=datetime.now(timezone.utc) - timedelta(days=10),
+            correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex))
+        await s.commit()
+        counts = await process_sla(s)
+        # held 는 skip(reminded/escalated 0)
+        assert counts.get("reminded", 0) == 0 and counts.get("escalated", 0) == 0
+        assert counts.get("skipped", 0) >= 1
+    await engine.dispose()
+
+
+# ── 엔드포인트 auth 회귀(CI-runnable) ──────────────────────────────────────────
+def _resolved_human():
+    from app.services.member_resolver import ResolvedMember
+    return ResolvedMember(id=uuid.uuid4(), user_id=uuid.uuid4(), name="a", type="human",
+                          role="admin", org_id=uuid.uuid4())
+
+
+@pytest.mark.anyio
+async def test_hold_unhold_endpoints_non_admin_403():
+    """hold/unhold 둘 다 non-admin → 403·서비스 호출 0."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, patch
+    from fastapi import HTTPException
+    from app.routers import gates as gates_mod
+    from app.routers.gates import GateHoldRequest, hold_gate_endpoint, unhold_gate_endpoint
+    holdfn, unholdfn = AsyncMock(), AsyncMock()
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=_resolved_human())), \
+         patch.object(gates_mod, "is_org_owner_or_admin", AsyncMock(return_value=False)), \
+         patch.object(gates_mod, "hold_gate", holdfn), \
+         patch.object(gates_mod, "unhold_gate", unholdfn):
+        with pytest.raises(HTTPException) as ei1:
+            await hold_gate_endpoint(id=uuid.uuid4(), body=GateHoldRequest(), session=AsyncMock(),
+                                     org_id=uuid.uuid4(), auth=SimpleNamespace(user_id=str(uuid.uuid4())))
+        with pytest.raises(HTTPException) as ei2:
+            await unhold_gate_endpoint(id=uuid.uuid4(), session=AsyncMock(),
+                                       org_id=uuid.uuid4(), auth=SimpleNamespace(user_id=str(uuid.uuid4())))
+    assert ei1.value.status_code == 403 and ei2.value.status_code == 403
+    holdfn.assert_not_awaited()
+    unholdfn.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_hold_endpoint_forces_holder_from_auth():
+    """⭐holder=인증 caller 강제(body엔 holder 필드 부재·spoof 0·S23 RC①)."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, patch
+    from app.routers import gates as gates_mod
+    from app.routers.gates import GateHoldRequest, hold_gate_endpoint
+    caller = _resolved_human()
+    holdfn = AsyncMock(return_value=SimpleNamespace())
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=caller)), \
+         patch.object(gates_mod, "is_org_owner_or_admin", AsyncMock(return_value=True)), \
+         patch.object(gates_mod, "hold_gate", holdfn), \
+         patch.object(gates_mod.GateResponse, "model_validate", lambda g: "OK"):
+        await hold_gate_endpoint(id=uuid.uuid4(), body=GateHoldRequest(reason="대기"), session=AsyncMock(),
+                                 org_id=uuid.uuid4(), auth=SimpleNamespace(user_id=str(uuid.uuid4())))
+    # hold_gate(session, org_id, gate_id, holder_id, reason, held_until) — holder=caller.id
+    assert holdfn.call_args.args[3] == caller.id


### PR DESCRIPTION
## [E-DG][P3·S31][BE] Hold full UX — gate hold/unhold + SLA pause

admin 이 pending 결재(gate)를 일시 보류(held·SLA pause)·재개(unhold). void(종료·불가역)와 달리 **가역**. PO 5결정 sign-off.

### ⭐ 기존 자산 발견·완성 (read-existing-first)
`step_run.held_until`(0126 S13-era) + `"held"` status 가 scaffold 됐으나 **SLA pause 로직이 미배선**이었다. S31 이 그걸 완성(중복 안 만들고).

### 변경
| 영역 | 내용 |
|------|------|
| `gate.py` | `GATE_STATUSES += held`·`pending↔held`(held→approve/reject 직접 금지·재개 후 결정) |
| 마이그 0132 | `gate.held_until`(post-0096·baseline 무변경). ⭐**migrated-DB 검증**(P0 drift 가드) |
| `hold_gate/unhold_gate` | hold=pending→held+step_run held+held_until→SLA pause·unhold=held→pending+**clear**+step_run→gate_pending |
| `workflow_sla_processor` | ⭐per-step **held skip**(일시정지)=scaffold 완성 |
| `POST /gates/{id}/hold {reason?,held_until?}`·`/unhold` | admin-only(canonical)·holder=인증 caller 강제(S23 RC①) |

### 결정(PO sign-off)
Q1 pending↔held(held→pending만)·Q2 gate.held_until 0132·Q3 SLA pause(held skip)·Q4 사유 선택+resolution_note/resolver_id 재사용(status=held disambiguate·unhold시 clear·logger gate_held/unheld)·Q5 auto-unhold=S13 followup(Phase-1 수동 unhold).

### 무회귀
S31 7 테스트(FSM+auth 2 **CI-runnable** + hold/unhold roundtrip·무기한·non-pending·**SLA pause** real-PG)·기존 gate+SLA **40 passed**·ruff-clean·migrated-DB 0132 검증.

### ⚠️ 머지 순서 (P0 doc-detail 교훈)
이 BE(hold/unhold + 0132 마이그) **머지 + migrate-dev 0132 後** FE #1640 머지(미머지 시 hold→404·held_until 컬럼 부재).

### FE 계약(미르코·#1640)
`POST /api/v2/gates/{id}/hold {reason?, held_until?}`·`/unhold`·admin·`GateResponse{held_until}`. held≠approval(가역·SLA pause·재개).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
