### PR TITLE
[E-DG][S32] Manual reassign / approver replacement BE

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -245,6 +245,33 @@ class GateApproverResponse(BaseModel):
     blocking: bool
     reassigned_from_member_id: uuid.UUID | None = None
     original_approver_member_id: uuid.UUID | None = None
+    # ⭐S32: "재지정됨 · {admin} · {시각}" 출처(마이그0·신규 컬럼 아님). reassign 이벤트
+    # (WorkflowLineStepRunEvent approver_reassigned)서 최신 actor/time enrich. 재지정 안 됐으면 None.
+    reassigned_by_member_id: uuid.UUID | None = None
+    reassigned_at: datetime | None = None
+
+
+async def _enrich_approvers(session, org_id, rows) -> list[GateApproverResponse]:
+    """approver row → response. 재지정된 row 는 최신 approver_reassigned 이벤트서 reassigned_by/at enrich
+    (FE "재지정됨 · admin · 시각" 렌더용·마이그0·이벤트가 메타 SSOT)."""
+    from app.models.workflow_line import WorkflowLineStepRunEvent
+    out = []
+    for r in rows:
+        resp = GateApproverResponse.model_validate(r)
+        if r.reassigned_from_member_id is not None:
+            ev = (await session.execute(
+                select(WorkflowLineStepRunEvent).where(
+                    WorkflowLineStepRunEvent.org_id == org_id,
+                    WorkflowLineStepRunEvent.step_run_id == r.step_run_id,
+                    WorkflowLineStepRunEvent.event_type == "approver_reassigned",
+                    WorkflowLineStepRunEvent.target_member_id == r.approver_member_id,
+                ).order_by(WorkflowLineStepRunEvent.created_at.desc()).limit(1)
+            )).scalar_one_or_none()
+            if ev is not None:
+                resp.reassigned_by_member_id = ev.actor_member_id
+                resp.reassigned_at = ev.created_at
+        out.append(resp)
+    return out
 
 
 @router.get("/{id}/approvers", response_model=list[GateApproverResponse])
@@ -255,11 +282,11 @@ async def list_gate_approvers_endpoint(
     auth=Depends(get_current_user),
 ) -> list[GateApproverResponse]:
     """⭐S32 FE conditional-display: gate approver row 목록(있으면 parallel gate→reassign 노출·없으면
-    단일/merge gate→reassign 미노출로 422 원천차단). admin-only."""
+    단일/merge gate→reassign 미노출로 422 원천차단). admin-only. 재지정 메타(누가/언제) enrich."""
     await _require_gate_admin(session, auth, org_id)
     from app.services.workflow_parallel_approval import list_gate_approvers
     rows = await list_gate_approvers(session, org_id, id)
-    return [GateApproverResponse.model_validate(r) for r in rows]
+    return await _enrich_approvers(session, org_id, rows)
 
 
 @router.post("/{id}/reassign", response_model=list[GateApproverResponse])
@@ -280,7 +307,8 @@ async def reassign_gate_approver_endpoint(
             old_approver_id=body.old_approver_id, reason=body.reason,
         )
         rows = await list_gate_approvers(session, org_id, id)  # 갱신된 approver 목록 반환
+        result = await _enrich_approvers(session, org_id, rows)  # reassigned_by/at enrich(이벤트서)
         await session.commit()
-        return [GateApproverResponse.model_validate(r) for r in rows]
+        return result
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -227,3 +227,60 @@ async def unhold_gate_endpoint(
         return GateResponse.model_validate(gate)
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))
+
+
+class GateReassignRequest(BaseModel):
+    new_approver_id: uuid.UUID
+    old_approver_id: uuid.UUID | None = None  # approver row 여러 개면 지정(1개면 생략)
+    reason: str | None = None
+
+
+class GateApproverResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    approver_member_id: uuid.UUID
+    approver_member_type: str
+    status: str
+    kind: str
+    blocking: bool
+    reassigned_from_member_id: uuid.UUID | None = None
+    original_approver_member_id: uuid.UUID | None = None
+
+
+@router.get("/{id}/approvers", response_model=list[GateApproverResponse])
+async def list_gate_approvers_endpoint(
+    id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> list[GateApproverResponse]:
+    """⭐S32 FE conditional-display: gate approver row 목록(있으면 parallel gate→reassign 노출·없으면
+    단일/merge gate→reassign 미노출로 422 원천차단). admin-only."""
+    await _require_gate_admin(session, auth, org_id)
+    from app.services.workflow_parallel_approval import list_gate_approvers
+    rows = await list_gate_approvers(session, org_id, id)
+    return [GateApproverResponse.model_validate(r) for r in rows]
+
+
+@router.post("/{id}/reassign", response_model=list[GateApproverResponse])
+async def reassign_gate_approver_endpoint(
+    id: uuid.UUID,
+    body: GateReassignRequest,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> list[GateApproverResponse]:
+    """⭐S32 admin reassign: parallel gate 의 pending 결재자 교체. admin-only·reassigner=인증 caller 강제
+    (body 신뢰 0·S23 RC①). gate.status 불변(pending 유지·재결정 대상). 단일 gate=422(parallel 전용)."""
+    resolved = await _require_gate_admin(session, auth, org_id)
+    from app.services.workflow_parallel_approval import list_gate_approvers, reassign_approver
+    try:
+        await reassign_approver(
+            session, org_id, id, body.new_approver_id, resolved.id,
+            old_approver_id=body.old_approver_id, reason=body.reason,
+        )
+        rows = await list_gate_approvers(session, org_id, id)  # 갱신된 approver 목록 반환
+        await session.commit()
+        return [GateApproverResponse.model_validate(r) for r in rows]
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))

--- a/backend/app/services/workflow_parallel_approval.py
+++ b/backend/app/services/workflow_parallel_approval.py
@@ -262,8 +262,13 @@ async def reassign_approver(
     member = await resolve_member_identity(new_approver_id, org_id, session)
     if member is None:
         raise ValueError("새 결재자가 이 org 의 멤버가 아닙니다.")
+    # ⚠️member-SSOT(까심 RC C4): has_project_access 2번째 인자는 human=user_id / agent=member_id 다
+    # (om.user_id==uid OR pa.member_id==uid). new_approver_id 는 member-id 공간이므로 그대로 넘기면
+    # member_id≠user_id 인 grant-only 휴먼이 false-reject(합법 재지정→422). resolved 의 user_id(휴먼)로
+    # 넘기고 agent(user_id 없음)는 member-id 유지. [[member_ssot_no_teammember_coercion]].
     from app.services.project_auth import has_project_access
-    if not await has_project_access(session, new_approver_id, target.project_id, org_id):
+    access_uid = member.user_id or new_approver_id
+    if not await has_project_access(session, access_uid, target.project_id, org_id):
         raise ValueError("새 결재자가 해당 프로젝트 접근권이 없습니다.")
     # ⭐SoD(AC⑥ 동형): 새 결재자가 요청자/구현자/최초결재자와 동일하면 거부(reassign 으로 자기승인 우회
     # 금지). record_parallel_decision 의 해소-시 SoD 와 동일 가드를 지정-시에도 선제 적용.

--- a/backend/app/services/workflow_parallel_approval.py
+++ b/backend/app/services/workflow_parallel_approval.py
@@ -8,6 +8,7 @@ audit/notification 엔 남지만 제외·AC④), quorum 충족/any-reject 면 ``
 ⭐SoD self-approval guard 는 **row 생성 시 + 해소 시 동시 검사**(AC⑥): approver/resolver 가
 requested_by / implementation / original_approver 와 동일하면 거부.
 """
+import logging
 import uuid
 from datetime import datetime, timezone
 from typing import Any
@@ -20,7 +21,10 @@ from app.models.workflow_line import (
     QUORUM_TYPES,
     WorkflowLineStepApproval,
     WorkflowLineStepRun,
+    WorkflowLineStepRunEvent,
 )
+
+logger = logging.getLogger(__name__)
 
 _TERMINAL_GATE = frozenset({"approved", "rejected"})
 _VALID_DECISIONS = frozenset({"approved", "rejected", "abstained"})
@@ -198,3 +202,106 @@ async def record_parallel_decision(
         outcome = target
 
     return {"outcome": outcome, "skipped": False, **tally}
+
+
+async def list_gate_approvers(
+    session: AsyncSession, org_id: uuid.UUID, gate_id: uuid.UUID
+) -> list[WorkflowLineStepApproval]:
+    """⭐S32 FE conditional-display: gate 의 approver row 목록(있으면 parallel gate → reassign 노출).
+    단일/merge gate 는 빈 리스트(approver row 없음 → FE reassign 미노출·422 원천차단)."""
+    r = await session.execute(
+        select(WorkflowLineStepApproval).where(
+            WorkflowLineStepApproval.gate_id == gate_id,
+            WorkflowLineStepApproval.org_id == org_id,
+        ).order_by(WorkflowLineStepApproval.created_at.asc())
+    )
+    return list(r.scalars().all())
+
+
+async def reassign_approver(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    gate_id: uuid.UUID,
+    new_approver_id: uuid.UUID,
+    reassigner_id: uuid.UUID,
+    old_approver_id: uuid.UUID | None = None,
+    reason: str | None = None,
+) -> WorkflowLineStepApproval:
+    """⭐S32: parallel gate 의 pending blocking approver 를 다른 멤버로 재지정(부재·오배정·휴가 복구).
+
+    void(종료)/hold(일시정지)와 달리 **gate.status 안 바꿈**(pending 유지·재결정 대상). approver row 의
+    approver_member_id 만 교체. scaffold 컬럼(reassigned_from_member_id·original_approver_member_id) 활용
+    → 마이그0. 단일/merge gate(approver row 없음)는 422("명시적 결재자 없음"·parallel 전용·Q1). 새 approver
+    유효성=org 멤버 실재+project_auth 접근권. reassigner=인증 caller(라우터 강제). audit=step_run_event
+    (approver_reassigned)+app-log. 새 approver 재-notify(dispatch·안 하면 gate stall).
+    """
+    rows = (await session.execute(
+        select(WorkflowLineStepApproval).where(
+            WorkflowLineStepApproval.gate_id == gate_id,
+            WorkflowLineStepApproval.org_id == org_id,
+            WorkflowLineStepApproval.status == "pending",
+            WorkflowLineStepApproval.blocking.is_(True),
+            WorkflowLineStepApproval.kind == "approver",
+        )
+    )).scalars().all()
+    if not rows:
+        raise ValueError("이 게이트엔 재지정할 명시적 결재자(approver)가 없습니다 (parallel gate 전용).")
+    if old_approver_id is not None:
+        target = next((a for a in rows if a.approver_member_id == old_approver_id), None)
+        if target is None:
+            raise ValueError("old_approver_id 에 해당하는 pending 결재자가 없습니다.")
+    elif len(rows) == 1:
+        target = rows[0]
+    else:
+        raise ValueError("결재자가 여러 명입니다 — old_approver_id 를 지정하세요.")
+
+    if new_approver_id == target.approver_member_id:
+        raise ValueError("이미 그 멤버가 결재자입니다.")
+    # 새 approver 유효성: org 멤버 실재 + 프로젝트 접근권(IDOR/유령 결재자 방지·Q5).
+    from app.services.member_resolver import resolve_member_identity
+    member = await resolve_member_identity(new_approver_id, org_id, session)
+    if member is None:
+        raise ValueError("새 결재자가 이 org 의 멤버가 아닙니다.")
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(session, new_approver_id, target.project_id, org_id):
+        raise ValueError("새 결재자가 해당 프로젝트 접근권이 없습니다.")
+    # ⭐SoD(AC⑥ 동형): 새 결재자가 요청자/구현자/최초결재자와 동일하면 거부(reassign 으로 자기승인 우회
+    # 금지). record_parallel_decision 의 해소-시 SoD 와 동일 가드를 지정-시에도 선제 적용.
+    if _sod_conflict(
+        new_approver_id, target.requested_by_member_id, target.implementation_member_id,
+        target.original_approver_member_id,
+    ):
+        raise ValueError("새 결재자가 SoD 당사자(요청자/구현자/최초결재자)와 동일 — 자기승인 우회 금지.")
+
+    old_id = target.approver_member_id
+    target.reassigned_from_member_id = old_id
+    if target.original_approver_member_id is None:
+        target.original_approver_member_id = old_id  # 최초 결재자만 보존(체인 누적 아님)
+    target.approver_member_id = new_approver_id
+    target.approver_member_type = member.type
+    # status 는 pending 유지(재결정 대상·gate status 도 불변).
+
+    session.add(WorkflowLineStepRunEvent(
+        org_id=org_id, project_id=target.project_id, step_run_id=target.step_run_id,
+        event_type="approver_reassigned", actor_member_id=reassigner_id,
+        target_member_id=new_approver_id,
+        payload={"old_approver_id": str(old_id), "gate_id": str(gate_id), "reason": reason},
+        correlation_id=uuid.uuid4(),
+    ))
+    logger.info(
+        "approver_reassigned org=%s gate=%s old=%s new=%s by=%s reason=%s",
+        org_id, gate_id, old_id, new_approver_id, reassigner_id, reason,
+    )
+    # 새 approver 재-notify(안 하면 새 결재자 모르고 gate stall·Q5). best-effort.
+    try:
+        from app.services.notification_dispatch import dispatch_notification
+        await dispatch_notification(
+            session, org_id=org_id, event_type="gate_reassigned",
+            target_member_ids=[new_approver_id], title="결재자로 재지정됨",
+            body="관리자가 당신을 이 결재의 새 결재자로 지정했습니다.",
+            reference_type="gate", reference_id=gate_id,
+        )
+    except Exception:  # noqa: BLE001 — notification 실패는 비중단(재지정 자체는 성공).
+        pass
+    await session.flush()
+    return target

--- a/backend/tests/test_edg_s32_reassign.py
+++ b/backend/tests/test_edg_s32_reassign.py
@@ -189,3 +189,27 @@ async def test_reassign_endpoint_non_admin_403():
                 session=AsyncMock(), org_id=uuid.uuid4(),
                 auth=SimpleNamespace(user_id=str(uuid.uuid4())))
     assert ei.value.status_code == 403
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_enrich_approvers_exposes_reassign_meta():
+    """⭐FE 데이터소스: reassign 후 GET /approvers enrich 가 reassigned_by/reassigned_at(이벤트서) 노출."""
+    from app.services.workflow_parallel_approval import list_gate_approvers, reassign_approver
+    from app.routers.gates import _enrich_approvers
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        gate, proj, approvers = await _seed_parallel_gate(s, org)
+        new_id = await _member_with_access(s, org, proj)
+        reassigner = uuid.uuid4()
+        await s.commit()
+        await reassign_approver(s, org, gate.id, new_id, reassigner)
+        await s.commit()
+        rows = await list_gate_approvers(s, org, gate.id)
+        enriched = await _enrich_approvers(s, org, rows)
+        r = enriched[0]
+        assert r.reassigned_by_member_id == reassigner   # {admin}
+        assert r.reassigned_at is not None                # {시각}
+        assert r.reassigned_from_member_id == approvers[0][0]  # 이전 결재자
+    await engine.dispose()

--- a/backend/tests/test_edg_s32_reassign.py
+++ b/backend/tests/test_edg_s32_reassign.py
@@ -1,0 +1,191 @@
+"""E-DG S32: manual reassign / ad-hoc approver replacement.
+
+핵심: ①parallel gate(approver row 보유)의 pending 결재자 교체(gate.status 불변·pending 유지) ②단일 gate
+(approver row 없음)=422(parallel 전용·Q1) ③새 approver 유효성(org 멤버+project_auth 접근·SoD) ④scaffold
+컬럼(reassigned_from·original 보존) 활용·마이그0 ⑤audit event+새 approver notify·admin·reassigner 강제.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.participation  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _member_with_access(s, org, proj=None):
+    """project 멤버(TeamMember active) — resolve_member_identity(TM.id) + has_project_access(team_member
+    active) 둘 다 통과. project 미지정이면 org-only(접근권 검사 실패 케이스용)."""
+    from app.models.team import TeamMember
+    mid = uuid.uuid4()
+    s.add(TeamMember(id=mid, org_id=org, project_id=proj, name="m", type="human",
+                     role="member", is_active=True))
+    await s.flush()
+    return mid
+
+
+async def _seed_parallel_gate(s, org, *, n_approvers=1):
+    from app.models.gate import Gate
+    from app.models.project import Project
+    from app.models.workflow_line import WorkflowLineStepApproval, WorkflowLineStepRun
+    proj = uuid.uuid4()
+    s.add(Project(id=proj, org_id=org, name="p"))
+    await s.flush()
+    wi = uuid.uuid4()
+    gate = Gate(id=uuid.uuid4(), org_id=org, work_item_id=wi, work_item_type="story",
+                gate_type="merge", status="pending")
+    s.add(gate)
+    await s.flush()
+    sr = WorkflowLineStepRun(
+        org_id=org, project_id=proj, entity_type="story", entity_id=wi,
+        from_status="in-review", to_status="done", status="gate_pending", mode="gate_pending",
+        gate_id=gate.id, correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex)
+    s.add(sr)
+    await s.flush()
+    approvers = []
+    grp = uuid.uuid4()
+    for _ in range(n_approvers):
+        aid = uuid.uuid4()
+        appr = WorkflowLineStepApproval(
+            org_id=org, project_id=proj, step_run_id=sr.id, gate_id=gate.id, approval_group_id=grp,
+            approver_member_id=aid, approver_member_type="human", kind="approver", blocking=True,
+            status="pending")
+        s.add(appr)
+        approvers.append((aid, appr))
+    await s.flush()
+    return gate, proj, approvers
+
+
+async def _seed_single_gate(s, org):
+    """approver row 없는 단일 gate(라인엔진 ASK_HUMAN 류)."""
+    from app.models.gate import Gate
+    gate = Gate(id=uuid.uuid4(), org_id=org, work_item_id=uuid.uuid4(), work_item_type="doc",
+                gate_type="merge", status="pending")
+    s.add(gate)
+    await s.flush()
+    return gate
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_reassign_updates_approver_row_and_event():
+    """⭐reassign: approver_member_id=new·reassigned_from=old·original 보존·status pending·event 기록."""
+    from app.services.workflow_parallel_approval import reassign_approver
+    from app.models.workflow_line import WorkflowLineStepRunEvent
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        gate, proj, approvers = await _seed_parallel_gate(s, org)
+        old_id = approvers[0][0]
+        new_id = await _member_with_access(s, org, proj)
+        reassigner = uuid.uuid4()
+        await s.commit()
+        target = await reassign_approver(s, org, gate.id, new_id, reassigner)
+        await s.commit()
+        assert target.approver_member_id == new_id
+        assert target.reassigned_from_member_id == old_id
+        assert target.original_approver_member_id == old_id   # 최초 보존
+        assert target.status == "pending"                     # gate 재결정 대상
+        ev = (await s.execute(select(WorkflowLineStepRunEvent).where(
+            WorkflowLineStepRunEvent.event_type == "approver_reassigned"))).scalars().all()
+        assert len(ev) == 1 and ev[0].target_member_id == new_id and ev[0].actor_member_id == reassigner
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_reassign_single_gate_422():
+    """단일 gate(approver row 없음)=명시 결재자 없음 → ValueError(Q1·parallel 전용)."""
+    from app.services.workflow_parallel_approval import reassign_approver
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        gate = await _seed_single_gate(s, org)
+        await s.commit()
+        # 단일 gate 는 approver row 자체가 없어 멤버 유효성 전에 실패(new_id 임의 가능).
+        with pytest.raises(ValueError, match="명시적 결재자"):
+            await reassign_approver(s, org, gate.id, uuid.uuid4(), uuid.uuid4())
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_reassign_invalid_new_approver_rejected():
+    """새 approver 가 org 멤버 아님 → 거부(유령 결재자 방지)."""
+    from app.services.workflow_parallel_approval import reassign_approver
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        gate, _, _ = await _seed_parallel_gate(s, org)
+        await s.commit()
+        with pytest.raises(ValueError, match="org 의 멤버"):
+            await reassign_approver(s, org, gate.id, uuid.uuid4(), uuid.uuid4())  # 미시드 멤버
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_reassign_multi_requires_old_approver_id():
+    """approver 여러 명이면 old_approver_id 필수."""
+    from app.services.workflow_parallel_approval import reassign_approver
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        gate, proj, approvers = await _seed_parallel_gate(s, org, n_approvers=2)
+        new_id = await _member_with_access(s, org, proj)
+        await s.commit()
+        with pytest.raises(ValueError, match="여러 명"):
+            await reassign_approver(s, org, gate.id, new_id, uuid.uuid4())  # old 미지정
+        # old 지정하면 성공
+        target = await reassign_approver(s, org, gate.id, new_id, uuid.uuid4(),
+                                         old_approver_id=approvers[1][0])
+        assert target.approver_member_id == new_id
+    await engine.dispose()
+
+
+# ── 엔드포인트 auth(CI-runnable) ─────────────────────────────────────────────
+def _resolved_human():
+    from app.services.member_resolver import ResolvedMember
+    return ResolvedMember(id=uuid.uuid4(), user_id=uuid.uuid4(), name="a", type="human",
+                          role="admin", org_id=uuid.uuid4())
+
+
+@pytest.mark.anyio
+async def test_reassign_endpoint_non_admin_403():
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, patch
+    from fastapi import HTTPException
+    from app.routers import gates as gates_mod
+    from app.routers.gates import GateReassignRequest, reassign_gate_approver_endpoint
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=_resolved_human())), \
+         patch.object(gates_mod, "is_org_owner_or_admin", AsyncMock(return_value=False)):
+        with pytest.raises(HTTPException) as ei:
+            await reassign_gate_approver_endpoint(
+                id=uuid.uuid4(), body=GateReassignRequest(new_approver_id=uuid.uuid4()),
+                session=AsyncMock(), org_id=uuid.uuid4(),
+                auth=SimpleNamespace(user_id=str(uuid.uuid4())))
+    assert ei.value.status_code == 403

--- a/backend/tests/test_edg_s32_reassign.py
+++ b/backend/tests/test_edg_s32_reassign.py
@@ -213,3 +213,29 @@ async def test_enrich_approvers_exposes_reassign_meta():
         assert r.reassigned_at is not None                # {시각}
         assert r.reassigned_from_member_id == approvers[0][0]  # 이전 결재자
     await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_reassign_grant_only_human_new_approver_ok():
+    """⭐까심 RC C4 회귀: member_id≠user_id 인 grant-only 휴먼(OrgMember+project_access grant)을 새
+    approver 로 재지정 — has_project_access 에 user_id 전달 안 하면 false-reject(422)됐던 버그."""
+    from app.services.workflow_parallel_approval import reassign_approver
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        gate, proj, _ = await _seed_parallel_gate(s, org)
+        # grant-only 휴먼: OrgMember(id≠user_id) + project_access granted(org_member_id 경유).
+        om_id = uuid.uuid4()
+        s.add(OrgMember(id=om_id, org_id=org, user_id=uuid.uuid4(), role="member"))
+        await s.flush()
+        s.add(ProjectAccess(id=uuid.uuid4(), project_id=proj, permission="granted", role="member",
+                            org_member_id=om_id))
+        await s.commit()
+        # new_approver_id = canonical member-id(om_id). fix 없으면 has_project_access(om_id) false→422.
+        target = await reassign_approver(s, org, gate.id, om_id, uuid.uuid4())
+        await s.commit()
+        assert target.approver_member_id == om_id   # grant-only 휴먼 재지정 성공
+    await engine.dispose()


### PR DESCRIPTION
## [E-DG][P3·S32][BE] Manual reassign / ad-hoc approver replacement

admin 이 parallel gate 의 pending 결재자(approver)를 다른 멤버로 재지정(부재·오배정·휴가 복구). void(종료)/hold(일시정지)와 달리 **gate.status 불변**(pending 유지·재결정 대상). PO 5결정 sign-off. ⭐**마이그0**.

### ⭐ 기존 자산 재사용 (read-existing-first)
`workflow_step_approvals`(S9·0126)의 reassign 컬럼(`reassigned_from_member_id`·`original_approver_member_id`)이 이미 scaffold → 재사용(S31 hold 동형). 마이그 불요.

### 변경
| 영역 | 내용 |
|------|------|
| `reassign_approver` | pending approver row 의 `approver_member_id` 교체·reassigned_from=old·original 보존·status pending 유지 |
| 유효성 | org 멤버 실재 + project_auth 접근권 + **SoD**(요청자/구현자/최초결재자 금지·자기승인 우회 차단) |
| 단일 gate | approver row 없음 → **422**("명시적 결재자 없음"·parallel 전용·Q1) |
| audit | `WorkflowLineStepRunEvent(approver_reassigned)` + logger + ⭐**새 approver 재-notify**(안 하면 gate stall·Q5) |
| `POST /gates/{id}/reassign`·`GET /gates/{id}/approvers` | admin-only(canonical)·reassigner=인증 caller 강제(S23 RC①) |

### FE conditional-display (유나 design)
`GET /gates/{id}/approvers` → approver row 있으면(parallel) reassign 노출·없으면(단일/merge) 미노출 → **422 UX 원천차단**.

### 무회귀
S32 5(reassign row+event·단일 422·invalid approver·multi old_id·endpoint non-admin 403)·기존 gate+parallel approval **63 passed**·ruff-clean·마이그0.

### FE 계약(미르코)
`POST /api/v2/gates/{id}/reassign {new_approver_id, old_approver_id?, reason?}` → approver 목록·`GET /gates/{id}/approvers`(conditional-display). gate.status 불변.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
