### PR TITLE
[E-DG][S33] Owner explicit override / force-resolve BE

### DIFF
--- a/backend/app/models/workflow_line.py
+++ b/backend/app/models/workflow_line.py
@@ -146,7 +146,9 @@ class WorkflowLineStepRun(Base):
 
 # ── S9 parallel/quorum approval (0126 SSOT·text+app validator) ────────────────
 APPROVAL_KINDS = frozenset({"approver", "consult", "deputy"})
-APPROVAL_STATUSES = frozenset({"pending", "approved", "rejected", "abstained", "withdrawn"})
+APPROVAL_STATUSES = frozenset(
+    {"pending", "approved", "rejected", "abstained", "withdrawn", "overridden"}
+)  # "overridden"=S33 owner override 강제 닫힘(승인 아님). column 은 free-text(DB CHECK 무)·상수 완전성용.
 QUORUM_TYPES = frozenset({"all", "any", "count"})  # percent = Phase3 defer
 
 

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -19,7 +19,7 @@ from app.services.gate_service import (
     void_gate,
 )
 from app.services.member_resolver import resolve_member
-from app.services.project_auth import is_org_owner_or_admin
+from app.services.project_auth import is_org_owner, is_org_owner_or_admin
 
 # 사람 검증 행위(approve/reject) — "human-validated" 웨지 integrity상 휴먼 member만 허용.
 _HUMAN_REVIEW_STATUSES = frozenset({"approved", "rejected"})
@@ -310,5 +310,39 @@ async def reassign_gate_approver_endpoint(
         result = await _enrich_approvers(session, org_id, rows)  # reassigned_by/at enrich(이벤트서)
         await session.commit()
         return result
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+
+class GateOverrideRequest(BaseModel):
+    decision: str  # "approved" | "rejected" (owner 강제 결정)
+    reason: str    # 필수 — 가장 민감한 액션이라 사유 의무
+
+
+async def _require_gate_owner(session, auth, org_id):
+    """⭐S33 owner-only 게이팅 — override 는 SoD 우회=가장 강력이라 admin(void/hold/reassign)보다 좁게
+    owner 만. is_org_owner(role='owner') canonical. 반환 resolved(owner_id=인증 caller 강제·body 신뢰 0)."""
+    resolved = await resolve_member(auth, org_id, session)
+    if not await is_org_owner(session, uuid.UUID(auth.user_id), org_id):
+        raise HTTPException(status_code=403, detail="이 액션은 org owner 만 가능합니다.")
+    return resolved
+
+
+@router.post("/{id}/override", response_model=GateResponse)
+async def override_gate_endpoint(
+    id: uuid.UUID,
+    body: GateOverrideRequest,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> GateResponse:
+    """⭐S33 owner force-resolve: owner 가 막힌/긴급 gate 를 강제 결정(approved|rejected). owner-only·
+    reason 필수·owner_id=인증 caller 강제(S23 RC①)·정상 결재(quorum/SoD) 우회. 가장 민감한 액션."""
+    from app.services.gate_service import override_gate
+    resolved = await _require_gate_owner(session, auth, org_id)
+    try:
+        gate = await override_gate(session, org_id, id, resolved.id, body.decision, body.reason)
+        await session.commit()
+        return GateResponse.model_validate(gate)
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -24,7 +24,11 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.gate import Gate, is_valid_transition
-from app.models.workflow_line import WorkflowLineStepRun
+from app.models.workflow_line import (
+    WorkflowLineStepApproval,
+    WorkflowLineStepRun,
+    WorkflowLineStepRunEvent,
+)
 from app.services.gate_resolver import resolve_disposition
 
 logger = logging.getLogger(__name__)
@@ -410,6 +414,117 @@ async def resolve_gate_from_verdict(
     gate.status = new_status
     gate.resolver_id = resolver_id
     gate.resolved_at = datetime.now(timezone.utc)
+    await session.flush()
+    await session.refresh(gate)
+    return gate
+
+
+async def override_gate(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    gate_id: uuid.UUID,
+    owner_id: uuid.UUID,
+    decision: str,
+    reason: str,
+) -> Gate:
+    """⭐E-DG S33 owner force-resolve: owner(최종권한자)가 막힌/긴급 gate 를 **강제 결정**한다.
+
+    ⚠️void(종료)/hold(정지)/reassign(교체)와 달리 **gate 결정 자체를 강제**(approved|rejected)·정상 결재
+    경로(quorum·SoD)를 **우회**한다 → 가장 강력·민감한 액션. 권한=owner-only(라우터 `is_org_owner`·admin
+    제외)·reason 필수·owner_id 는 인증 caller 강제(body 신뢰 0·S23 RC①).
+
+    메커니즘: ``transition_gate`` 재사용(FSM pending→approved|rejected·S6 hook 가 라인전이 자동 적용).
+    parallel gate 면 남은 pending approver row 를 ``status="overridden"`` 로 닫는다(approved 와 distinct·
+    강제 닫힘이지 승인 아님·dangling/SLA 방지). audit(최중) = ``WorkflowLineStepRunEvent(gate_overridden·
+    bypassed_sod=True·decision·reason)`` + ``logger.warning`` + 영향받은 requester·bypass된 approver 재-notify
+    (자기 gate 가 강제결정된 걸 알아야·안 하면 깜깜).
+    """
+    if decision not in ("approved", "rejected"):
+        raise ValueError("decision 은 approved|rejected 만 가능합니다.")
+    if not (reason and reason.strip()):
+        raise ValueError("override 는 reason(사유)이 필수입니다.")
+    gate = (await session.execute(
+        select(Gate).where(Gate.id == gate_id, Gate.org_id == org_id)
+    )).scalar_one_or_none()
+    if gate is None:
+        raise ValueError(f"Gate {gate_id} not found")
+    if gate.status != "pending":
+        raise ValueError(f"override 는 pending gate 만 가능합니다 (현재 {gate.status}).")
+
+    # 영향받은 pending approver row(parallel) — overridden 마킹 + notify 대상. 단일 gate 면 빈 리스트.
+    appr_rows = (await session.execute(
+        select(WorkflowLineStepApproval).where(
+            WorkflowLineStepApproval.gate_id == gate_id,
+            WorkflowLineStepApproval.org_id == org_id,
+            WorkflowLineStepApproval.status == "pending",
+        )
+    )).scalars().all()
+    bypassed = [a.approver_member_id for a in appr_rows]
+    requester_id = appr_rows[0].requested_by_member_id if appr_rows else None
+
+    # 라인 step_run(audit anchor·project_id) — transition_gate 가 _OPEN 밖으로 보내기 전에 캡처.
+    from app.services.workflow_line_resolution import find_active_step_run_for_gate
+    sr_id = await find_active_step_run_for_gate(session, org_id, gate_id)
+    sr = None
+    if sr_id is not None:
+        sr = (await session.execute(
+            select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == sr_id)
+        )).scalar_one_or_none()
+
+    # ⭐force-resolve: quorum/SoD 우회·S6 hook 라인전이 자동 적용.
+    await transition_gate(session, org_id, gate_id, decision, resolver_id=owner_id, note=reason)
+
+    # parallel approver row 닫기(overridden·강제 닫힘이지 승인 아님·dangling/SLA 방지).
+    now = datetime.now(timezone.utc)
+    for a in appr_rows:
+        a.status = "overridden"
+        a.resolved_at = now
+
+    # ⭐gate 행에 override 마커(FE cheap 신호·event fetch 없이 "강제 결정됨" 배지). transition_gate 는
+    # resolution_note 를 rejected 에만 세팅하므로 approved override 사유가 누락 → neutral_facts 로 보존.
+    # 전체 audit/메타(owner·시각·bypassed_sod)는 gate_overridden 이벤트가 SSOT(S32 reassign 동형).
+    gate.neutral_facts = {
+        **(gate.neutral_facts or {}),
+        "overridden": True,
+        "override_decision": decision,
+        "override_reason": reason,
+        "overridden_by_member_id": str(owner_id),
+    }
+
+    # audit(최중): bypassed_sod 플래그가 감사 추적 핵심. 라인 step_run 있을 때만 이벤트(없으면 gate행+log).
+    if sr is not None:
+        session.add(WorkflowLineStepRunEvent(
+            org_id=org_id, project_id=sr.project_id, step_run_id=sr.id,
+            event_type="gate_overridden", actor_member_id=owner_id,
+            payload={
+                "decision": decision, "reason": reason, "bypassed_sod": True,
+                "bypassed_approver_ids": [str(x) for x in bypassed],
+            },
+            correlation_id=sr.correlation_id,
+        ))
+    logger.warning(
+        "gate_overridden org=%s gate=%s decision=%s owner=%s bypassed_approvers=%d reason=%s",
+        org_id, gate_id, decision, owner_id, len(bypassed), reason,
+    )
+
+    # notify requester + bypass된 approver들(Q4·자기 gate 강제결정 통보). best-effort·중복 제거.
+    targets: dict[str, uuid.UUID] = {}
+    for t in [requester_id, *bypassed]:
+        if t is not None:
+            targets[str(t)] = t
+    if targets:
+        try:
+            from app.services.notification_dispatch import dispatch_notification
+            await dispatch_notification(
+                session, org_id=org_id, event_type="gate_overridden",
+                target_member_ids=list(targets.values()),
+                title="게이트가 강제 결정되었습니다",
+                body=f"owner 가 게이트를 {decision} 로 강제 결정했습니다: {reason}",
+                reference_type="gate", reference_id=gate_id,
+            )
+        except Exception:  # noqa: BLE001 — notification 실패는 비중단(override 자체는 성공).
+            pass
+
     await session.flush()
     await session.refresh(gate)
     return gate

--- a/backend/app/services/project_auth.py
+++ b/backend/app/services/project_auth.py
@@ -255,6 +255,30 @@ async def is_org_owner_or_admin(
     return row.scalar_one_or_none() is not None
 
 
+async def is_org_owner(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    org_id: uuid.UUID,
+) -> bool:
+    """user 가 해당 org 의 **owner** 인지(admin 제외). ⭐E-DG S33 gate override 전용 — override 는
+    SoD 우회=가장 강력한 액션이라 admin(void/hold/reassign)보다 좁게 owner-only 로 게이트한다.
+    is_org_owner_or_admin 과 동일 구조·role='owner' 만."""
+    row = await session.execute(
+        text(
+            """
+            SELECT 1 FROM org_members
+            WHERE user_id = :user_id
+              AND org_id = :org_id
+              AND deleted_at IS NULL
+              AND role = 'owner'
+            LIMIT 1
+            """
+        ),
+        {"user_id": user_id, "org_id": org_id},
+    )
+    return row.scalar_one_or_none() is not None
+
+
 async def first_accessible_project_id(
     session: AsyncSession,
     user_id: uuid.UUID,

--- a/backend/tests/test_edg_s33_override.py
+++ b/backend/tests/test_edg_s33_override.py
@@ -1,0 +1,186 @@
+"""E-DG S33: owner explicit override / force-resolve.
+
+핵심: ①owner 가 pending gate 를 강제 결정(approved|rejected·정상 quorum/SoD 우회) ②parallel approver row
+→ status="overridden"(distinct·dangling 방지) ③audit=gate_overridden 이벤트(bypassed_sod=True)+neutral_facts
+마커 ④reason 필수·decision 검증·non-pending 거부 ⑤owner-only(엔드포인트)·owner_id=인증 caller 강제.
+
+entity_type="task"(non-gating-eligible)로 시드해 라인-advance(story 전용)는 graceful no-op·override 로직만 격리.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.participation  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_gate(s, org, *, n_approvers=1, status="pending"):
+    from app.models.gate import Gate
+    from app.models.project import Project
+    from app.models.workflow_line import WorkflowLineStepApproval, WorkflowLineStepRun
+    proj = uuid.uuid4()
+    s.add(Project(id=proj, org_id=org, name="p"))
+    await s.flush()
+    wi = uuid.uuid4()
+    gate = Gate(id=uuid.uuid4(), org_id=org, work_item_id=wi, work_item_type="task",
+                gate_type="merge", status=status)
+    s.add(gate)
+    await s.flush()
+    sr = None
+    approvers = []
+    if n_approvers > 0:
+        sr = WorkflowLineStepRun(
+            org_id=org, project_id=proj, entity_type="task", entity_id=wi,
+            from_status="in-review", to_status="done", status="gate_pending", mode="gate_pending",
+            gate_id=gate.id, correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex)
+        s.add(sr)
+        await s.flush()
+        grp = uuid.uuid4()
+        for _ in range(n_approvers):
+            aid = uuid.uuid4()
+            appr = WorkflowLineStepApproval(
+                org_id=org, project_id=proj, step_run_id=sr.id, gate_id=gate.id, approval_group_id=grp,
+                approver_member_id=aid, approver_member_type="human", kind="approver", blocking=True,
+                status="pending", requested_by_member_id=uuid.uuid4())
+            s.add(appr)
+            approvers.append(aid)
+        await s.flush()
+    return gate, proj, approvers
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_override_approved_parallel_closes_approvers_and_audits():
+    """⭐override(approved): gate.status=approved·approver row overridden·gate_overridden 이벤트
+    (bypassed_sod=True)·neutral_facts 마커."""
+    from app.services.gate_service import override_gate
+    from app.models.workflow_line import WorkflowLineStepApproval, WorkflowLineStepRunEvent
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        gate, proj, approvers = await _seed_gate(s, org, n_approvers=2)
+        owner = uuid.uuid4()
+        await s.commit()
+        result = await override_gate(s, org, gate.id, owner, "approved", "긴급 배포·결재자 부재")
+        await s.commit()
+        assert result.status == "approved"
+        assert result.neutral_facts["overridden"] is True
+        assert result.neutral_facts["override_decision"] == "approved"
+        assert result.neutral_facts["overridden_by_member_id"] == str(owner)
+        rows = (await s.execute(select(WorkflowLineStepApproval).where(
+            WorkflowLineStepApproval.gate_id == gate.id))).scalars().all()
+        assert all(r.status == "overridden" for r in rows)   # 강제 닫힘(승인 아님)
+        ev = (await s.execute(select(WorkflowLineStepRunEvent).where(
+            WorkflowLineStepRunEvent.event_type == "gate_overridden"))).scalars().all()
+        assert len(ev) == 1
+        assert ev[0].actor_member_id == owner
+        assert ev[0].payload["bypassed_sod"] is True
+        assert ev[0].payload["decision"] == "approved"
+        assert len(ev[0].payload["bypassed_approver_ids"]) == 2
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_override_rejected():
+    """override(rejected): gate.status=rejected·force reject."""
+    from app.services.gate_service import override_gate
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        gate, _, _ = await _seed_gate(s, org, n_approvers=1)
+        await s.commit()
+        result = await override_gate(s, org, gate.id, uuid.uuid4(), "rejected", "정책 위반·강제 반려")
+        await s.commit()
+        assert result.status == "rejected"
+        assert result.neutral_facts["override_decision"] == "rejected"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_override_single_gate_no_approvers():
+    """단일 gate(approver row 없음)도 override 가능(force-resolve)·닫을 approver 0."""
+    from app.services.gate_service import override_gate
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        gate, _, _ = await _seed_gate(s, org, n_approvers=0)
+        await s.commit()
+        result = await override_gate(s, org, gate.id, uuid.uuid4(), "approved", "단일 gate 강제 통과")
+        await s.commit()
+        assert result.status == "approved"
+        assert result.neutral_facts["overridden"] is True
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_override_invalid_decision_and_reason():
+    """decision은 approved|rejected만·reason 필수·non-pending 거부."""
+    from app.services.gate_service import override_gate
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        gate, _, _ = await _seed_gate(s, org, n_approvers=1)
+        await s.commit()
+        with pytest.raises(ValueError, match="approved|rejected"):
+            await override_gate(s, org, gate.id, uuid.uuid4(), "voided", "x")
+        with pytest.raises(ValueError, match="reason"):
+            await override_gate(s, org, gate.id, uuid.uuid4(), "approved", "  ")
+        # non-pending: 먼저 approve 후 재-override 시도
+        await override_gate(s, org, gate.id, uuid.uuid4(), "approved", "first")
+        await s.commit()
+        with pytest.raises(ValueError, match="pending"):
+            await override_gate(s, org, gate.id, uuid.uuid4(), "approved", "again")
+    await engine.dispose()
+
+
+# ── 엔드포인트 owner-only(CI-runnable) ────────────────────────────────────────
+def _resolved_owner():
+    from app.services.member_resolver import ResolvedMember
+    return ResolvedMember(id=uuid.uuid4(), user_id=uuid.uuid4(), name="o", type="human",
+                          role="owner", org_id=uuid.uuid4())
+
+
+@pytest.mark.anyio
+async def test_override_endpoint_non_owner_403():
+    """admin이어도 owner 아니면 403(override는 owner-only·admin보다 좁음)."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, patch
+    from fastapi import HTTPException
+    from app.routers import gates as gates_mod
+    from app.routers.gates import GateOverrideRequest, override_gate_endpoint
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=_resolved_owner())), \
+         patch.object(gates_mod, "is_org_owner", AsyncMock(return_value=False)):  # admin이지만 owner 아님
+        with pytest.raises(HTTPException) as ei:
+            await override_gate_endpoint(
+                id=uuid.uuid4(), body=GateOverrideRequest(decision="approved", reason="x"),
+                session=AsyncMock(), org_id=uuid.uuid4(),
+                auth=SimpleNamespace(user_id=str(uuid.uuid4())))
+    assert ei.value.status_code == 403


### PR DESCRIPTION
## [E-DG][P3·S33][BE] Owner explicit override / force-resolve

owner(최종권한자)가 막힌/긴급 gate 를 **강제 결정**(approved|rejected). void(종료)/hold(정지)/reassign(교체)와 달리 **gate 결정 자체를 강제**·정상 결재(quorum/SoD)를 **우회** → 가장 강력·민감한 액션. PO 5결정 sign-off. ⭐**마이그0**(transition_gate FSM+S6 hook 재사용·approver status free-string·신규 컬럼0).

### 변경
| 영역 | 내용 |
|------|------|
| `project_auth.is_org_owner` | role='owner' only 게이트(override 전용·admin=void/hold/reassign·**결정 강제는 owner 만**) |
| `gate_service.override_gate` | transition_gate 로 force-resolve(quorum/SoD bypass·S6 hook 라인전이 자동) |
| parallel approver | pending row → `status="overridden"`(approved 와 distinct·강제 닫힘이지 승인 아님·dangling/SLA 방지) |
| audit(최중) | `WorkflowLineStepRunEvent(gate_overridden·**bypassed_sod=True**·decision·reason·bypassed_approver_ids)` + `logger.warning` + gate.neutral_facts 마커 |
| notify | 영향 requester + bypass된 approver 재-notify(자기 gate 강제결정 통보) |
| `POST /gates/{id}/override` | owner-only·`{decision, reason}`·owner_id=인증 caller 강제(S23 RC①)·reason 필수 |

### override-ness 표식 (유나 design·S32 이벤트-소스 동형)
gate.status=**표준**(approved/rejected) + `gate_overridden` 이벤트(bypassed_sod)가 override-ness SSOT. `gate.neutral_facts.overridden`(decision·reason·owner)는 FE cheap 배지 신호.

### 무회귀
S33 5(override approved+approvers overridden+event·rejected·단일 gate·invalid decision/reason/non-pending·endpoint non-owner 403)·기존 gate transition/parallel/void/hold/reassign **48 passed**·ruff-clean·마이그0.

### FE 계약(미르코)
`POST /api/v2/gates/{id}/override {decision: approved|rejected, reason}`. **owner-only**(admin 미노출·typed-confirm). override-ness = gate_overridden 이벤트 + `neutral_facts.overridden`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
