### PR TITLE
[SID:a126704c] fix(S34): lint 뱃지 lint_status 오독 수정 (.status→.lint_status)

### DIFF
--- a/apps/web/src/components/settings/workflow-line-editor-section.tsx
+++ b/apps/web/src/components/settings/workflow-line-editor-section.tsx
@@ -76,7 +76,7 @@ export function WorkflowLineEditorSection({ projectId }: { projectId?: string | 
   const [versions, setVersions] = useState<VersionItem[]>([]);
   const [draftId, setDraftId] = useState<string | null>(null);
   const [configText, setConfigText] = useState('');
-  const [lint, setLint] = useState<{ status: string; errors: { message?: string }[] } | null>(null);
+  const [lint, setLint] = useState<{ lint_status: string; errors: { message?: string }[] } | null>(null);
   const [activeSteps, setActiveSteps] = useState<Step[]>([]);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -151,7 +151,7 @@ export function WorkflowLineEditorSection({ projectId }: { projectId?: string | 
     setBusy(true);
     try {
       const r = await fetch(`/api/workflow-line-config/versions/${draftId}/lint`, { method: 'POST' });
-      setLint(r.ok ? ((await r.json()) as { status: string; errors: { message?: string }[] }) : null);
+      setLint(r.ok ? ((await r.json()) as { lint_status: string; errors: { message?: string }[] }) : null);
     } finally { setBusy(false); }
   };
 
@@ -232,8 +232,8 @@ export function WorkflowLineEditorSection({ projectId }: { projectId?: string | 
               />
               {lint ? (
                 <div className="space-y-1">
-                  <Badge variant={lint.status === 'passed' ? 'success' : 'destructive'}>
-                    {lint.status === 'passed' ? t('lineEditorLintPass') : t('lineEditorLintFail')}
+                  <Badge variant={lint.lint_status === 'passed' ? 'success' : 'destructive'}>
+                    {lint.lint_status === 'passed' ? t('lineEditorLintPass') : t('lineEditorLintFail')}
                   </Badge>
                   {lint.errors?.length ? (
                     <ul className="space-y-0.5">


### PR DESCRIPTION
## S34 lint UI 버그 수정 — lint 뱃지가 항상 "검사 실패"

PO 라이브 픽셀 적출: editor에서 **검사(Lint)** 누르면 BE가 `200 {lint_status:"passed", errors:[]}`(valid config)를 반환하는데도 UI는 **"검사 실패"**.

### 원인
`LintResponse` top-level 키는 **`lint_status`**(+`errors`)인데, `workflow-line-editor-section.tsx`가 `lint.status`(undefined)를 읽음 → `undefined === 'passed'` = false → **항상 fail 표시**. (History 모드의 `v.lint_status`는 이미 맞게 읽어 같은 config가 "passed"로 뜸 → 버그 corroborate.)

### 수정 (`workflow-line-editor-section.tsx`·3곳)
- lint state 타입 `{ status }` → `{ lint_status }`
- fetch 캐스트 `as { status }` → `as { lint_status }`
- 뱃지 조건 `lint.status === 'passed'` → `lint.lint_status === 'passed'`(variant + 라벨)

신규 i18n/토큰 0. 응답 top-level 키 실측 원칙(계약은 그라운딩했으나 필드명 오타 — 즉시 정정).

### 검증
`tsc` 0 · `eslint` 0 · `next build` ✓. PO 재-픽셀(검사 통과 뜨는지)로 S34 = E-DG 마지막 닫음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)