### PR TITLE
[RC#2] fix(epics): epic 편집 PATCH서 status 제거 (prod 블로커·422)

### DIFF
--- a/apps/web/src/app/(authenticated)/epics/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/epics/[id]/page.tsx
@@ -146,7 +146,6 @@ function EpicEditInline({ epic, onSaved, onCancel }: { epic: Epic; onSaved: (e: 
   const [description, setDescription] = useState(epic.description ?? '');
   const [objective, setObjective] = useState(epic.objective ?? '');
   const [successCriteria, setSuccessCriteria] = useState(epic.success_criteria ?? '');
-  const [status, setStatus] = useState<EpicStatus>(epic.status);
   const [priority, setPriority] = useState<EpicPriority>(epic.priority);
   const [targetDate, setTargetDate] = useState(epic.target_date?.slice(0, 10) ?? '');
   const [targetSp, setTargetSp] = useState(epic.target_sp !== undefined && epic.target_sp !== null ? String(epic.target_sp) : '');
@@ -164,7 +163,6 @@ function EpicEditInline({ epic, onSaved, onCancel }: { epic: Epic; onSaved: (e: 
           description: description.trim() || undefined,
           objective: objective.trim() || undefined,
           success_criteria: successCriteria.trim() || undefined,
-          status,
           priority,
           ...(targetDate ? { target_date: targetDate } : {}),
           ...(targetSp ? { target_sp: Number(targetSp) } : {}),
@@ -176,7 +174,7 @@ function EpicEditInline({ epic, onSaved, onCancel }: { epic: Epic; onSaved: (e: 
     } finally {
       setSaving(false);
     }
-  }, [title, description, objective, successCriteria, status, priority, targetDate, targetSp, epic, onSaved]);
+  }, [title, description, objective, successCriteria, priority, targetDate, targetSp, epic, onSaved]);
 
   const inputCls = 'w-full rounded-lg border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/40';
 
@@ -186,13 +184,8 @@ function EpicEditInline({ epic, onSaved, onCancel }: { epic: Epic; onSaved: (e: 
       <textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={4} className={`${inputCls} resize-none`} placeholder="설명 (마크다운)" />
       <textarea value={objective} onChange={(e) => setObjective(e.target.value)} rows={3} className={`${inputCls} resize-none`} placeholder="목표 (Objective)" />
       <textarea value={successCriteria} onChange={(e) => setSuccessCriteria(e.target.value)} rows={3} className={`${inputCls} resize-none`} placeholder="성공 기준 (Success Criteria)" />
+      {/* RC#2: status select 제거 — 전용 transition(상세 헤더 컨트롤·⓶)·일반 PATCH 봉인(BE #1651). 편집=title/desc/objective/criteria/priority/target만. */}
       <div className="grid grid-cols-2 gap-3">
-        <select value={status} onChange={(e) => setStatus(e.target.value as EpicStatus)} className={inputCls}>
-          <option value="draft">Draft</option>
-          <option value="active">Active</option>
-          <option value="done">Done</option>
-          <option value="archived">Archived</option>
-        </select>
         <select value={priority} onChange={(e) => setPriority(e.target.value as EpicPriority)} className={inputCls}>
           <option value="critical">Critical</option>
           <option value="high">High</option>

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -271,7 +271,6 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
   const [title, setTitle] = useState(epic.title);
   const [description, setDescription] = useState(epic.description ?? '');
   const [priority, setPriority] = useState<EpicPriority>(epic.priority);
-  const [status, setStatus] = useState<EpicStatus>(epic.status);
   const [targetDate, setTargetDate] = useState(epic.target_date?.slice(0, 10) ?? '');
   const [targetSp, setTargetSp] = useState(epic.target_sp !== undefined ? String(epic.target_sp) : '');
   const [submitting, setSubmitting] = useState(false);
@@ -289,7 +288,7 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
         title: title.trim(),
         description: description.trim() || undefined,
         priority,
-        status,
+        // RC#2: status 제외 — generic PATCH서 봉인(BE #1651 422)·전용 transition endpoint 전용.
       };
       if (targetDate) body.target_date = targetDate;
       if (targetSp) body.target_sp = Number(targetSp);
@@ -309,7 +308,7 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
     } finally {
       setSubmitting(false);
     }
-  }, [title, description, priority, status, targetDate, targetSp, epic.id, epic.stories, onSaved]);
+  }, [title, description, priority, targetDate, targetSp, epic.id, epic.stories, onSaved]);
 
   return (
     <form onSubmit={(e) => { void handleSubmit(e); }} className="space-y-4">
@@ -334,34 +333,19 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
         />
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
-        <div className="space-y-1.5">
-          <label className="text-xs font-medium text-muted-foreground">{t('fieldStatus')}</label>
-          <select
-            value={status}
-            onChange={(e) => setStatus(e.target.value as EpicStatus)}
-            className="w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
-          >
-            <option value="draft">{t('statusDraft')}</option>
-            <option value="active">{t('statusActive')}</option>
-            <option value="done">{t('statusDone')}</option>
-            <option value="archived">{t('statusArchived')}</option>
-          </select>
-        </div>
-
-        <div className="space-y-1.5">
-          <label className="text-xs font-medium text-muted-foreground">{t('fieldPriority')}</label>
-          <select
-            value={priority}
-            onChange={(e) => setPriority(e.target.value as EpicPriority)}
-            className="w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
-          >
-            <option value="critical">{t('priorityCritical')}</option>
-            <option value="high">{t('priorityHigh')}</option>
-            <option value="medium">{t('priorityMedium')}</option>
-            <option value="low">{t('priorityLow')}</option>
-          </select>
-        </div>
+      {/* RC#2: status는 편집 폼서 제거 — 전용 POST /epics/{id}/transition(상세 헤더 transition 컨트롤·⓶)·일반 PATCH서 봉인(BE #1651·hypothesis/story 선례 동형). 편집=title/desc/priority/target만. */}
+      <div className="space-y-1.5">
+        <label className="text-xs font-medium text-muted-foreground">{t('fieldPriority')}</label>
+        <select
+          value={priority}
+          onChange={(e) => setPriority(e.target.value as EpicPriority)}
+          className="w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+        >
+          <option value="critical">{t('priorityCritical')}</option>
+          <option value="high">{t('priorityHigh')}</option>
+          <option value="medium">{t('priorityMedium')}</option>
+          <option value="low">{t('priorityLow')}</option>
+        </select>
       </div>
 
       <div className="grid grid-cols-2 gap-3">


### PR DESCRIPTION
## RC#2 prod 블로커 — epic 편집 전건 422

**근본**: BE #1651이 epic `status`를 generic `PATCH /epics/{id}`서 봉인(422)·status 변경은 전용 `POST /epics/{id}/transition`(FSM+SoD+gate)만. FE epic-edit **2폼이 PATCH body에 `status`를 항상 전송** → 봉인 後 **모든 epic 편집(제목·설명 포함)이 422**로 깨짐.

**선례 정합**: hypothesis(`updateHypothesisSchema` §3.5)·story 동형 — `status`는 transition endpoint 전용이라 update allowlist서 제외.

### 변경 (⓵ — prod fix·순수 FE)
- `epics-client.tsx`(편집 모달)·`epics/[id]/page.tsx`(상세 편집): **PATCH body서 `status` 제거** + **편집폼 status `<select>` 제거**(status는 ⓶ 상세헤더 transition 컨트롤로 이동) + 미사용 `status` state·useCallback dep 정리.
- 편집 = `title`/`description`/(`objective`/`success_criteria`)/`priority`/`target_*`만 PATCH.

### 검증
`tsc` 0 · `eslint` 0 · `next build` ✓.

### follow-up (⓶ — 별 PR)
status-transition 컨트롤: 상세 헤더 status badge + **유효 next-state만 dropdown**(FSM·"보이는=실행가능"·invalid 미노출) → `POST /epics/{id}/transition`. ⭐ **draft→active는 human-gate라 gate-pending("승인 대기") 반영**(낙관적 active X·PO impl note②)·S24 gate-badge 어휘 재사용. 유나 mockup PO PASS·impl GO.

PR → 유나 가디언 + 까심 QA(epic 편집 복구·status PATCH 제거·prod 경로).

🤖 Generated with [Claude Code](https://claude.com/claude-code)