### PR TITLE
fix(cloudbuild): deploy-backend --allow-unauthenticated — prod 403 재발 차단

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -102,6 +102,10 @@ steps:
       - --region=${_AR_REGION}
       - --min-instances=${_BACKEND_MIN_INSTANCES}
       - --max-instances=${_BACKEND_MAX_INSTANCES}
+      # ⭐frontend 가 NEXT_PUBLIC_FASTAPI_URL 로 backend 를 직접 호출(public 필수). 플래그 없으면
+      # gcloud run deploy 가 기존 IAM 을 preserve(non-deterministic) → 신규/리셋 시 allUsers invoker
+      # 유실로 403(2026-06-21 prod promotion 사건). 명시적·멱등 설정으로 매 배포 public 보장(dev/prod 공통).
+      - --allow-unauthenticated
       - --quiet
     waitFor: [push-backend]
 


### PR DESCRIPTION
## prod 403 항구 fix

**배경**: 2026-06-21 prod promotion서 main CB backend 재배포 시 **allUsers invoker 유실 → prod backend 403**(앱 미도달). 즉시 해소는 수동 `add-iam-policy-binding allUsers run.invoker`.

**근본**: `cloudbuild.yaml` deploy-backend 에 `--allow-unauthenticated` 미설정. `gcloud run deploy` 는 auth 플래그 없으면 **기존 IAM preserve**(non-deterministic) → 신규/리셋 revision서 public 유실 가능. dev 는 과거 수동바인딩이 우연히 살아남았고 prod 는 유실.

**fix**: deploy-backend args 에 `--allow-unauthenticated` 추가(명시적·멱등). frontend 가 `NEXT_PUBLIC_FASTAPI_URL` 로 backend 직접 호출하므로 public 필수(dev/prod 공통·`_DEPLOY_ENV` 공유 스텝). **다음 prod 배포부터 403 재발 0**.

⚠️ ready-for-dev·중요도 높음(다음 prod 배포 전 머지 권장). yaml 파싱 검증 완.

🤖 Generated with [Claude Code](https://claude.com/claude-code)