### PR TITLE
[E-MCP-HTTP][S1] Streamable HTTP transport + per-connection bearer auth

### DIFF
--- a/backend/sprintable_mcp/__main__.py
+++ b/backend/sprintable_mcp/__main__.py
@@ -28,6 +28,14 @@ def main() -> None:
     if not settings.sprintable_api_url:
         print("Error: SPRINTABLE_API_URL environment variable required", file=sys.stderr)
         sys.exit(1)
+
+    # E-MCP-HTTP S1: transport 분기. http=외부/Poke(per-request bearer·startup env-key auth/filter 없음·
+    # SSE bridge 미구동=내부 이벤트 분리). stdio=내부 에이전트(현행·env 단일키·툴+이벤트). 기본 stdio(무회귀).
+    transport = (settings.mcp_transport or "stdio").strip().lower()
+    if transport == "http":
+        _run_http()
+        return
+
     if not settings.agent_api_key:
         print("Error: AGENT_API_KEY environment variable required", file=sys.stderr)
         sys.exit(1)
@@ -68,6 +76,25 @@ async def _run() -> None:
         sse_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await sse_task
+
+
+def _run_http() -> None:
+    """E-MCP-HTTP S1: Streamable HTTP(외부/Poke) — 툴 전용. per-request bearer auth(http_auth ASGI
+    미들웨어가 요청별 키 contextvar set)·startup env-key auth/filter 없음(scope 는 per-key·call-time).
+    ⭐SSE bridge 미구동 = 내부 에이전트 실시간 이벤트는 stdio 경로 분리 유지(§7·격하 0)."""
+    import uvicorn
+
+    from .http_auth import bearer_auth_asgi
+
+    # env fallback 키(미설정 허용·실제 키는 per-request override). stateless_http=True 는 mcp 구성에서.
+    client.configure(settings.sprintable_api_url, settings.agent_api_key or "")
+    app = bearer_auth_asgi(mcp.streamable_http_app())
+    print(
+        f"Sprintable MCP — Streamable HTTP on {settings.mcp_http_host}:{settings.mcp_http_port}/mcp "
+        "(per-request bearer auth·tools-only)",
+        file=sys.stderr,
+    )
+    uvicorn.run(app, host=settings.mcp_http_host, port=settings.mcp_http_port, log_level="info")
 
 
 if __name__ == "__main__":

--- a/backend/sprintable_mcp/__main__.py
+++ b/backend/sprintable_mcp/__main__.py
@@ -86,8 +86,13 @@ def _run_http() -> None:
 
     from .http_auth import bearer_auth_asgi
 
-    # env fallback 키(미설정 허용·실제 키는 per-request override). stateless_http=True 는 mcp 구성에서.
-    client.configure(settings.sprintable_api_url, settings.agent_api_key or "")
+    # env fallback 키. ⭐http 모드 실제 인증은 per-request bearer override(미들웨어)라 이 fallback 은
+    # never-hit(미들웨어가 bearer 없으면 401). agent_api_key 미설정 시 placeholder(configure 계약 유지·
+    # 백엔드는 override 키로 호출되며 placeholder 가 새면 401 로 거름·fail-safe). stateless_http=True 는 mcp 구성.
+    client.configure(
+        settings.sprintable_api_url,
+        settings.agent_api_key or "_http_per_request_bearer_only_",
+    )
     app = bearer_auth_asgi(mcp.streamable_http_app())
     print(
         f"Sprintable MCP — Streamable HTTP on {settings.mcp_http_host}:{settings.mcp_http_port}/mcp "

--- a/backend/sprintable_mcp/api_client.py
+++ b/backend/sprintable_mcp/api_client.py
@@ -24,6 +24,23 @@ def set_project_override(project_id: str | None):
 def reset_project_override(token) -> None:
     _project_override.reset(token)
 
+
+# E-MCP-HTTP S1: per-request API 키 override(http 모드 멀티테넌트). http 미들웨어가 요청경계서
+# Authorization: Bearer <key> 를 set → request() 가 그 키로 백엔드 호출. 미설정(stdio)이면 env
+# 단일키(self._api_key) 사용(무회귀). contextvar 라 async 동시요청별 격리.
+_api_key_override: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "mcp_api_key_override", default=None
+)
+
+
+def set_api_key_override(api_key: str | None):
+    """per-request API 키 override 설정 — 반환 token 으로 reset(http 미들웨어가 요청 스코프로 사용)."""
+    return _api_key_override.set(api_key or None)
+
+
+def reset_api_key_override(token) -> None:
+    _api_key_override.reset(token)
+
 # 백엔드 에러 본문을 MCP 에러 문자열에 노출할 때, 비정상적으로 큰 body가
 # 에이전트 컨텍스트를 잠식하지 않도록 자르는 상한.
 _ERROR_BODY_MAX = 1500
@@ -137,11 +154,12 @@ class SprintableClient:
         self._org_id: str = ""
         self._project_id: str = ""
 
-    def configure(self, api_url: str, api_key: str) -> None:
+    def configure(self, api_url: str, api_key: str = "") -> None:
         if not api_url:
             raise ValueError("api_url is required")
-        if not api_key:
-            raise ValueError("api_key is required")
+        # E-MCP-HTTP S1: http 모드는 per-request bearer override 가 키를 공급하므로 env fallback 키가
+        # 비어도 허용(stdio 모드는 main() 이 사전에 agent_api_key 필수 검사). 빈 키 + override 없으면
+        # 백엔드가 401 로 거른다(fail-safe).
         self._base_url = api_url.rstrip("/")
         self._api_key = api_key
 
@@ -183,9 +201,11 @@ class SprintableClient:
         params: dict | None = None,
     ) -> Any:
         url = f"{self._base_url}{path}"
+        # E-MCP-HTTP S1: effective 키 = per-request override(http 멀티테넌트) ∨ env 단일키(stdio·무회귀).
+        _key = _api_key_override.get() or self._api_key
         headers = {
-            "Authorization": f"Bearer {self._api_key}",
-            "x-agent-api-key": self._api_key,
+            "Authorization": f"Bearer {_key}",
+            "x-agent-api-key": _key,
             "Content-Type": "application/json",
         }
         # 85429ee0: per-call override 시 X-Project-Id 헤더 전송 — 백엔드 get_verified_org_id 가

--- a/backend/sprintable_mcp/api_client.py
+++ b/backend/sprintable_mcp/api_client.py
@@ -154,12 +154,11 @@ class SprintableClient:
         self._org_id: str = ""
         self._project_id: str = ""
 
-    def configure(self, api_url: str, api_key: str = "") -> None:
+    def configure(self, api_url: str, api_key: str) -> None:
         if not api_url:
             raise ValueError("api_url is required")
-        # E-MCP-HTTP S1: http 모드는 per-request bearer override 가 키를 공급하므로 env fallback 키가
-        # 비어도 허용(stdio 모드는 main() 이 사전에 agent_api_key 필수 검사). 빈 키 + override 없으면
-        # 백엔드가 401 로 거른다(fail-safe).
+        if not api_key:
+            raise ValueError("api_key is required")
         self._base_url = api_url.rstrip("/")
         self._api_key = api_key
 

--- a/backend/sprintable_mcp/config.py
+++ b/backend/sprintable_mcp/config.py
@@ -12,6 +12,13 @@ class McpSettings(BaseSettings):
     agent_api_key: str = ""
     sse_seen_ids_max_size: int = 10000
     sse_seen_ids_ttl_seconds: int = 3600
+    # E-MCP-HTTP S1: transport 선택(기본 stdio=로컬 에이전트 무회귀·http=외부/Poke Streamable HTTP).
+    mcp_transport: str = "stdio"            # "stdio" | "http"
+    mcp_http_host: str = "0.0.0.0"          # http 모드 bind host
+    mcp_http_port: int = 8080               # http 모드 bind port(Cloud Run $PORT 주입 가능)
+    # per-key scope 캐시 bound(멀티테넌트 多키 무한증식 방지·SeenIdsCache 패턴).
+    mcp_scope_cache_max_size: int = 1000
+    mcp_scope_cache_ttl_seconds: int = 300
 
 
 settings = McpSettings()

--- a/backend/sprintable_mcp/http_auth.py
+++ b/backend/sprintable_mcp/http_auth.py
@@ -1,0 +1,65 @@
+"""E-MCP-HTTP S1: per-connection bearer auth — Streamable HTTP(외부/Poke) 전용 ASGI 미들웨어.
+
+매 요청 경계서 ``Authorization: Bearer <key>`` 를 추출해 api_client 의 per-request 키 contextvar 에 set
+(멀티테넌트·키마다 scope/백엔드 호출 분리). ``X-Project-Id`` 는 기존 project override 에 매핑. 키 없으면
+401(MCP /mcp 경로 한정·health 류 비-MCP 경로는 통과해 S2 Cloud Run 헬스체크 호환). contextvar 는
+요청 async-context 별 격리되며 finally 에서 reset(누수 0).
+"""
+from __future__ import annotations
+
+from .api_client import (
+    reset_api_key_override,
+    reset_project_override,
+    set_api_key_override,
+    set_project_override,
+)
+
+_UNAUTHORIZED_BODY = (
+    b'{"error":{"code":"unauthorized",'
+    b'"message":"Authorization: Bearer <api_key> required"}}'
+)
+
+
+async def _send_401(send) -> None:
+    await send({
+        "type": "http.response.start",
+        "status": 401,
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"www-authenticate", b"Bearer"),
+        ],
+    })
+    await send({"type": "http.response.body", "body": _UNAUTHORIZED_BODY})
+
+
+def bearer_auth_asgi(app):
+    """app(streamable_http_app) 을 per-request bearer auth 로 감싸는 순수 ASGI 미들웨어."""
+
+    async def middleware(scope, receive, send):
+        if scope.get("type") != "http":
+            await app(scope, receive, send)
+            return
+        path = scope.get("path", "")
+        # 비-MCP 경로(health 등)는 인증 없이 통과 — S2 Cloud Run liveness/readiness 호환.
+        if not path.startswith("/mcp"):
+            await app(scope, receive, send)
+            return
+
+        headers = {k.decode("latin-1").lower(): v.decode("latin-1")
+                   for k, v in scope.get("headers", [])}
+        auth = headers.get("authorization", "")
+        if not auth[:7].lower() == "bearer " or not auth[7:].strip():
+            await _send_401(send)
+            return
+
+        key = auth[7:].strip()
+        project_id = headers.get("x-project-id") or None
+        ktok = set_api_key_override(key)
+        ptok = set_project_override(project_id)
+        try:
+            await app(scope, receive, send)
+        finally:
+            reset_api_key_override(ktok)
+            reset_project_override(ptok)
+
+    return middleware

--- a/backend/sprintable_mcp/pyproject.toml
+++ b/backend/sprintable_mcp/pyproject.toml
@@ -12,10 +12,13 @@ license = { text = "Proprietary" }
 authors = [{ name = "Sprintable" }]
 keywords = ["mcp", "sprintable", "agent", "model-context-protocol"]
 dependencies = [
-    "mcp>=1.0.0",
+    # E-MCP-HTTP S1: streamable-http floor(mcp 1.8+·run_streamable_http_async/transport='streamable-http')
+    # — fresh 빌드가 구버전 받아 http 미지원되는 footgun 방지(S2 Cloud Run 빌드 보증). 설치본 1.27.1 검증완.
+    "mcp>=1.8.0",
     "httpx>=0.27",
     "pydantic>=2.0",
     "pydantic-settings>=2.0",
+    "uvicorn>=0.30",   # http 모드 ASGI 서버(streamable_http_app + bearer auth 미들웨어 구동). stdio 무관.
 ]
 
 # E-MCP S4: 외부(레포 없음) 한 줄 구동 — `uvx sprintable-mcp`.

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -5,6 +5,8 @@ import asyncio
 import inspect
 import json
 import logging
+import time
+from collections import OrderedDict
 from typing import get_type_hints
 
 logger = logging.getLogger(__name__)
@@ -14,7 +16,7 @@ from mcp.types import TextContent
 from pydantic import BaseModel
 from pydantic.fields import PydanticUndefined
 
-from .api_client import client, reset_project_override, set_project_override
+from .api_client import _api_key_override, client, reset_project_override, set_project_override
 from .config import settings
 from .response import ok
 from .schemas import SprintableInput
@@ -120,24 +122,57 @@ async def _heartbeat_fire_forget() -> None:
 
 
 # ── E-MCP S2: call-time toolset enforcement ──────────────────────────────────
-# 키의 허용 toolset(scope)을 /api/v2/mcp/manifest에서 1회 로드(캐시) 후, 매 도구 호출 시
+# 키의 허용 toolset(scope)을 /api/v2/mcp/manifest에서 로드(per-key 캐시) 후, 매 도구 호출 시
 # is_tool_allowed로 차단(403-shape). 백엔드 ApiKey.scope가 진짜 SSOT, 여기선 defense-in-depth.
-_key_scope: list[str] | None = None
-_scope_loaded: bool = False
+# E-MCP-HTTP S1: env 단일키 글로벌 캐시 → **per-key bounded 캐시**(http 멀티테넌트·多키 무한증식 방지·
+# LRU+TTL·SeenIdsCache 패턴). 미해소(manifest 실패) sentinel=_SCOPE_FAILOPEN(None=전체 허용 fail-open).
+_SCOPE_MISS = object()
+_SCOPE_FAILOPEN: object = None  # None = legacy 전체 허용(백엔드 최종 SSOT)
 
 
-async def _load_scope() -> None:
-    global _key_scope, _scope_loaded
-    if _scope_loaded:
-        return
-    _scope_loaded = True
+class _ScopeCache:
+    """per-key scope LRU+TTL 캐시(bound)·SeenIdsCache 패턴. value=list[str]|None(fail-open)."""
+
+    def __init__(self, max_size: int, ttl_seconds: float) -> None:
+        self._max = max_size
+        self._ttl = ttl_seconds
+        self._store: "OrderedDict[str, tuple[float, list[str] | None]]" = OrderedDict()
+
+    def get(self, key: str):
+        item = self._store.get(key)
+        if item is None:
+            return _SCOPE_MISS
+        added_at, scope = item
+        if (time.monotonic() - added_at) > self._ttl:
+            del self._store[key]
+            return _SCOPE_MISS
+        self._store.move_to_end(key)  # LRU touch
+        return scope
+
+    def put(self, key: str, scope: list[str] | None) -> None:
+        self._store[key] = (time.monotonic(), scope)
+        self._store.move_to_end(key)
+        while len(self._store) > self._max:
+            self._store.popitem(last=False)  # LRU evict
+
+
+_scope_cache = _ScopeCache(settings.mcp_scope_cache_max_size, settings.mcp_scope_cache_ttl_seconds)
+
+
+async def _load_scope_for(key: str) -> list[str] | None:
+    """effective 키의 scope 해소(per-key 캐시). manifest 는 api_client 가 per-request 키(contextvar)로
+    호출하므로 그 키의 scope 가 온다. 실패 시 fail-open(None·백엔드 최종 SSOT)."""
+    cached = _scope_cache.get(key)
+    if cached is not _SCOPE_MISS:
+        return cached  # type: ignore[return-value]
     try:
         manifest = await client.get("/api/v2/mcp/manifest")
-        _key_scope = manifest.get("scope") or []
+        scope: list[str] | None = manifest.get("scope") or []
     except Exception:
-        # 매니페스트 미가용 시 레거시 기본(비파괴 전체)로 fail-open — 백엔드가 최종 SSOT.
-        _key_scope = None
+        scope = _SCOPE_FAILOPEN  # 매니페스트 미가용 → fail-open(백엔드가 최종 SSOT)
         logger.warning("MCP toolset manifest load failed — falling back to legacy scope")
+    _scope_cache.put(key, scope)
+    return scope
 
 
 def _denied(name: str) -> list[TextContent]:
@@ -179,8 +214,11 @@ def _flat(name: str, doc: str, input_cls: type[BaseModel], fn):
 
     async def wrapper(**kwargs):
         # E-MCP S2: call-time enforcement — 키 허용 밖 도구는 호출 차단(403-shape).
-        await _load_scope()
-        if not is_tool_allowed(name, _key_scope):
+        # E-MCP-HTTP S1: effective 키(http=per-request bearer override·stdio=env 단일키)별 scope 로드
+        # (per-key bounded 캐시). 멀티테넌트서 키마다 다른 scope 정확 적용.
+        _eff_key = _api_key_override.get() or settings.agent_api_key
+        _scope = await _load_scope_for(_eff_key)
+        if not is_tool_allowed(name, _scope):
             return _denied(name)
         # 85429ee0: per-call project_id override → contextvar(tool 호출 스코프). client.project_id +
         # X-Project-Id 헤더에 반영(org-agent 멀티프로젝트 grant). 미지정이면 키 default(무회귀).
@@ -207,6 +245,9 @@ mcp = FastMCP(
         "Sprintable Python MCP server. "
         f"Backend: {settings.sprintable_api_url}"
     ),
+    # E-MCP-HTTP S1: stateless HTTP(요청간 세션 미보존)=무상태 툴서버(서버리스/멀티인스턴스 안전·Cloud
+    # Run S2). stdio 모드는 이 설정 무시(영향 0).
+    stateless_http=True,
 )
 
 

--- a/backend/tests/test_e_mcp_http_s1.py
+++ b/backend/tests/test_e_mcp_http_s1.py
@@ -1,0 +1,170 @@
+"""E-MCP-HTTP S1: Streamable HTTP transport + per-connection bearer auth.
+
+핵심: ①transport 공존(기본 stdio 무회귀·http 선택) ②per-request 키 contextvar→api_client 헤더(멀티테넌트)
+③per-key bounded scope 캐시(LRU+TTL) ④bearer auth 미들웨어(401·contextvar set·X-Project-Id·health 통과)
+⑤이벤트 채널 분리(http=SSE 미구동·구조적). 전부 CI-runnable(실서버 X·ASGI mock).
+"""
+from __future__ import annotations
+
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── ① transport / config ──────────────────────────────────────────────────────
+def test_transport_default_stdio():
+    from sprintable_mcp.config import McpSettings
+    s = McpSettings()
+    assert s.mcp_transport == "stdio"            # 기본 stdio = 로컬 무회귀
+    assert s.mcp_scope_cache_max_size > 0
+    assert s.mcp_scope_cache_ttl_seconds > 0
+
+
+# ── ② per-request 키 contextvar ───────────────────────────────────────────────
+def test_api_key_override_contextvar():
+    from sprintable_mcp.api_client import (
+        _api_key_override, set_api_key_override, reset_api_key_override,
+    )
+    assert _api_key_override.get() is None        # 기본 미설정(stdio)
+    tok = set_api_key_override("reqkey")
+    assert _api_key_override.get() == "reqkey"
+    reset_api_key_override(tok)
+    assert _api_key_override.get() is None
+    tok2 = set_api_key_override("")               # 빈 키 → None(falsy 정규화)
+    assert _api_key_override.get() is None
+    reset_api_key_override(tok2)
+
+
+@pytest.mark.anyio
+async def test_request_uses_override_key_then_env_fallback():
+    """request 헤더 키 = per-request override ∨ env 단일키(무회귀)."""
+    from unittest.mock import AsyncMock, patch
+    from sprintable_mcp.api_client import SprintableClient, set_api_key_override, reset_api_key_override
+    c = SprintableClient()
+    c.configure("https://x", "envkey")
+    captured = {}
+
+    async def _fake_request(method, url, **kw):
+        captured["headers"] = kw.get("headers", {})
+        class R:
+            status_code = 200
+            is_success = True
+            headers = {"content-type": "application/json"}
+            def json(self): return {}
+            @property
+            def text(self): return "{}"
+        return R()
+
+    with patch("httpx.AsyncClient.request", new=AsyncMock(side_effect=_fake_request)):
+        # override 없음 → env 키
+        await c.get("/x")
+        assert captured["headers"]["Authorization"] == "Bearer envkey"
+        # override 설정 → 그 키
+        tok = set_api_key_override("reqkey")
+        try:
+            await c.get("/x")
+            assert captured["headers"]["Authorization"] == "Bearer reqkey"
+            assert captured["headers"]["x-agent-api-key"] == "reqkey"
+        finally:
+            reset_api_key_override(tok)
+
+
+# ── ③ per-key bounded scope 캐시 ──────────────────────────────────────────────
+def test_scope_cache_lru_and_ttl():
+    from sprintable_mcp.server import _ScopeCache, _SCOPE_MISS
+    c = _ScopeCache(max_size=2, ttl_seconds=100)
+    assert c.get("k1") is _SCOPE_MISS
+    c.put("k1", ["a"])
+    c.put("k2", ["b"])
+    assert c.get("k1") == ["a"]
+    c.put("k3", ["c"])                             # max2 초과 → LRU(k2가 최근접근 아니라면) evict
+    # k1을 위에서 get해 touch했으니 k2가 LRU → evict 대상
+    assert c.get("k2") is _SCOPE_MISS
+    assert c.get("k3") == ["c"]
+    # TTL 만료
+    c2 = _ScopeCache(max_size=10, ttl_seconds=-1)  # 즉시 만료
+    c2.put("z", ["x"])
+    assert c2.get("z") is _SCOPE_MISS
+
+
+@pytest.mark.anyio
+async def test_load_scope_for_per_key():
+    """키마다 다른 manifest scope 캐시(per-key)."""
+    from unittest.mock import AsyncMock, patch
+    from sprintable_mcp import server as srv
+    srv._scope_cache = srv._ScopeCache(10, 100)  # 격리
+    calls = {"n": 0}
+
+    async def _fake_get(path):
+        calls["n"] += 1
+        return {"scope": ["tool_a"]}
+
+    with patch.object(srv.client, "get", new=AsyncMock(side_effect=_fake_get)):
+        s1 = await srv._load_scope_for("keyA")
+        s1b = await srv._load_scope_for("keyA")  # 캐시 히트(추가 호출 X)
+        assert s1 == ["tool_a"] and s1b == ["tool_a"]
+        assert calls["n"] == 1                    # keyA 1회만 fetch(캐시)
+        await srv._load_scope_for("keyB")         # 다른 키 → 새 fetch
+        assert calls["n"] == 2
+
+
+# ── ④ bearer auth ASGI 미들웨어 ───────────────────────────────────────────────
+async def _run_asgi(mw, path, headers):
+    """미들웨어를 mock app으로 구동. 반환 (status, app_called, captured_key)."""
+    state = {"app_called": False, "key": "__none__", "project": "__none__", "status": None, "body": b""}
+    from sprintable_mcp.api_client import _api_key_override, _project_override
+
+    async def _app(scope, receive, send):
+        state["app_called"] = True
+        state["key"] = _api_key_override.get()
+        state["project"] = _project_override.get()
+
+    async def _recv(): return {"type": "http.request", "body": b"", "more_body": False}
+    async def _send(msg):
+        if msg["type"] == "http.response.start":
+            state["status"] = msg["status"]
+        elif msg["type"] == "http.response.body":
+            state["body"] += msg.get("body", b"")
+
+    scope = {"type": "http", "path": path,
+             "headers": [(k.encode(), v.encode()) for k, v in headers.items()]}
+    await mw(_app)(scope, _recv, _send)
+    return state
+
+
+@pytest.mark.anyio
+async def test_bearer_middleware_401_without_bearer():
+    from sprintable_mcp.http_auth import bearer_auth_asgi
+    st = await _run_asgi(bearer_auth_asgi, "/mcp", {})           # bearer 없음
+    assert st["status"] == 401 and not st["app_called"]
+    st2 = await _run_asgi(bearer_auth_asgi, "/mcp", {"authorization": "Bearer "})  # 빈 키
+    assert st2["status"] == 401
+
+
+@pytest.mark.anyio
+async def test_bearer_middleware_sets_contextvar():
+    from sprintable_mcp.http_auth import bearer_auth_asgi
+    st = await _run_asgi(bearer_auth_asgi, "/mcp",
+                         {"authorization": "Bearer sk_abc", "x-project-id": "proj-1"})
+    assert st["app_called"] and st["key"] == "sk_abc" and st["project"] == "proj-1"
+
+
+@pytest.mark.anyio
+async def test_bearer_middleware_health_path_passes_without_auth():
+    """비-/mcp 경로(health 등)는 인증 없이 통과(S2 Cloud Run 헬스체크 호환)."""
+    from sprintable_mcp.http_auth import bearer_auth_asgi
+    st = await _run_asgi(bearer_auth_asgi, "/health", {})        # bearer 없어도
+    assert st["app_called"] and st["status"] is None            # 401 아님·app 통과
+
+
+@pytest.mark.anyio
+async def test_bearer_middleware_resets_contextvar_after_request():
+    """요청 後 contextvar 누수 0(finally reset)."""
+    from sprintable_mcp.http_auth import bearer_auth_asgi
+    from sprintable_mcp.api_client import _api_key_override
+    await _run_asgi(bearer_auth_asgi, "/mcp", {"authorization": "Bearer k1"})
+    assert _api_key_override.get() is None                       # 누수 없음


### PR DESCRIPTION
## [E-MCP-HTTP][S1] Streamable HTTP transport + per-connection bearer auth

선생님 GO·`E-MCP-HTTP` epic. `sprintable_mcp` 에 **Streamable HTTP** transport 추가(외부/Poke)·**기존 stdio 무회귀** 유지. PO 4축 sign-off + 보강2(bound per-key scope·per-request contextvar) + 스코프(S1=http 외부 + stdio 내부 유지·내부 이벤트 0손댐). **마이그0·dev-only**.

### 3축 + 보강
| 축 | 구현 |
|----|------|
| ① **transport 공존** | `config.mcp_transport`(env·기본 **stdio**). http → `_run_http()` uvicorn 으로 `mcp.streamable_http_app()`(**stateless_http=True**·`/mcp`). stdio 는 현행(`run_stdio_async`+SSE·env 단일키) 그대로 |
| ② **per-conn bearer auth** | `http_auth.bearer_auth_asgi` ASGI 미들웨어: 요청별 `Authorization: Bearer`→`_api_key_override` contextvar(멀티테넌트·키마다 백엔드 호출/scope 분리)·`X-Project-Id`→기존 project override·bearer 없으면 **401**(`/mcp` 한정·health 통과). `request` 헤더가 effective 키(override∨env) |
| ③ **per-key scope** | 글로벌 `_key_scope` → `_ScopeCache`(**LRU+TTL·bound**·SeenIdsCache 패턴) + `_load_scope_for(key)`. tool wrapper 가 effective 키별 scope 로 `is_tool_allowed` |
| ④ **이벤트 채널 분리(§7)** | http=**툴 전용**·`sse_bridge` 미구동(미변경)·내부 에이전트 실시간 이벤트는 stdio 경로 유지(격하 0) |
| ⑤ deps | `mcp>=1.8.0`(streamable-http floor·설치본 1.27.1 검증완) + `uvicorn>=0.30` |

### 무회귀
S1 **9 테스트**(transport 기본 stdio·키 override→헤더·scope LRU/TTL/per-key·bearer 401/contextvar/health 통과/누수0)·기존 MCP **28**(per-call project·s2 toolset·s3 boot·byoa scope) 통과·ruff(신규파일) clean·마이그0.

### S2 예고
dev Cloud Run 호스팅 + smoke. health 경로 미들웨어 통과 처리 완(liveness 호환). prod 승격은 별도 선생님 승인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
