### PR TITLE
[E-MCP-HTTP][S3] docs: README Hosted HTTPS MCP (dev preview) 연결 섹션

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,39 @@ Add Sprintable as an MCP server in your agent's config. This gives the agent acc
 
 Replace `localhost:3108` with your Sprintable URL if deployed remotely.
 
+#### Hosted HTTPS MCP — dev preview
+
+> ⚠️ **dev preview.** This is a development-only deployment for testing remote connections. Not production-ready — endpoint and availability may change.
+
+Sprintable also runs a **hosted Streamable HTTP MCP** so external clients (e.g. [Poke](https://poke.com/integrations/new)) can connect without running a local server. Each connection authenticates with a **per-connection bearer token** (your agent's API key), and the key's scope decides which tools are exposed.
+
+- **Endpoint** (dev): `https://sprintable-mcp-dev-57iommnikq-du.a.run.app/mcp`
+- **Transport**: Streamable HTTP (stateless)
+- **Auth**: `Authorization: Bearer YOUR_AGENT_API_KEY` (per request)
+
+<!-- prod 승격 시: ① 위 endpoint URL 1줄을 prod 게이트웨이 URL로 flip ② prod 게이트웨이에 env
+     MCP_ALLOWED_HOSTS=<prod-host>(쉼표구분·exact host) 설정해 DNS-rebinding 보호 ON. 게이트웨이 배포 +
+     이 README flip + whitelist 를 한 묶음으로. dev 는 MCP_ALLOWED_HOSTS 비움(보호 OFF·bearer+TLS 가 보안). -->
+
+**Poke** ([poke.com/integrations/new](https://poke.com/integrations/new)): add an MCP integration pointing at the endpoint above, with your agent's API key as the bearer token.
+
+**Generic HTTP MCP client:**
+```json
+{
+  "mcpServers": {
+    "sprintable": {
+      "type": "http",
+      "url": "https://sprintable-mcp-dev-57iommnikq-du.a.run.app/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_AGENT_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Realtime event delivery (agent notifications) stays on the existing dedicated channel and is unaffected by the HTTP MCP — the hosted endpoint serves tools only.
+
 ### Step 3 — Set the webhook URL (optional)
 
 In Sprintable: **Settings → Agents → [Your Agent] → Webhook URL**


### PR DESCRIPTION
## 공개 문서 — HTTPS MCP 연결법 (선생님 지적)

연결법이 내부 Docs(`sprintable-https-mcp-dev-connection-20260622`)만이면 부족 → **공개 README**에도 반영. 메인레포 README Step 2(MCP server) 아래에 **Hosted HTTPS MCP — dev preview** 섹션 추가.

### 내용
- dev 엔드포인트 `https://sprintable-mcp-dev-57iommnikq-du.a.run.app/mcp`·Streamable HTTP(stateless)·**per-connection Bearer**(키 scope→툴 노출).
- **Poke**([poke.com/integrations/new](https://poke.com/integrations/new)) 연결법 + generic HTTP MCP client json 예시.
- ⭐**'dev preview' 라벨**(현 dev-only·prod-ready 아님 명시·endpoint 변동 가능).
- ⭐**prod-ready 구조**(선생님): endpoint 1줄 flip + `MCP_ALLOWED_HOSTS` whitelist 전환법을 **HTML 주석**으로 명시(외부 렌더 비노출·repo 소스/팀만). prod 승격 = 게이트웨이 배포 + README flip + whitelist 한 묶음.
- §7 이벤트 무영향(http=툴 전용) 명시.

### ⚠️ outward-facing
공개 README라 **PO 리뷰 머지 전 필수**(선생님/PO 게이트). 코드 변경 0·문서만·마이그0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)