### PR TITLE
[E-MCP-HTTP][ee2f4e58] fix: HTTP 경로 default project_id 키-컨텍스트 해소 (stdio parity)

### DIFF
--- a/backend/sprintable_mcp/api_client.py
+++ b/backend/sprintable_mcp/api_client.py
@@ -41,6 +41,12 @@ def set_api_key_override(api_key: str | None):
 def reset_api_key_override(token) -> None:
     _api_key_override.reset(token)
 
+
+# E-MCP-HTTP ee2f4e58: per-key 해소 컨텍스트 캐시(http 멀티테넌트). 키 → {member_id,org_id,project_id}.
+# http 미들웨어가 요청경계서 ensure_auth_context(key) 로 1회 해소·캐시 → 명시 project_id 없는 툴도 그 키의
+# default 로 해소(stdio startup resolve_auth_context 와 parity). 싱글톤 self._* 에 쓰지 않아 테넌트 격리(무블리드).
+_auth_ctx_cache: dict[str, dict[str, str]] = {}
+
 # 백엔드 에러 본문을 MCP 에러 문자열에 노출할 때, 비정상적으로 큰 body가
 # 에이전트 컨텍스트를 잠식하지 않도록 자르는 상한.
 _ERROR_BODY_MAX = 1500
@@ -163,7 +169,7 @@ class SprintableClient:
         self._api_key = api_key
 
     async def resolve_auth_context(self) -> dict[str, str]:
-        """GET /api/v2/auth/me → org_id/project_id/member_id 캐시."""
+        """GET /api/v2/auth/me → org_id/project_id/member_id 캐시(stdio 부팅 시 1회)."""
         data = await self.get("/api/v2/auth/me")
         self._member_id = data.get("member_id") or ""
         self._org_id = data.get("org_id") or ""
@@ -178,18 +184,58 @@ class SprintableClient:
             "project_id": self._project_id,
         }
 
+    async def ensure_auth_context(self, api_key: str) -> dict[str, str]:
+        """E-MCP-HTTP ee2f4e58: per-request bearer 키의 default 컨텍스트(member/org/project)를 키별
+        1회 해소·캐시. http 미들웨어가 요청경계서 호출 → 명시 project_id 없는 툴 호출도 그 키의 default 로
+        해소(stdio resolve_auth_context 와 parity·422 제거). 싱글톤 self._* 는 건드리지 않아 테넌트 격리.
+
+        멀티프로젝트 키: /api/v2/auth/me 가 주는 server-canonical default project_id 를 그대로 사용
+        (클라 임의선택 0). default 가 비면 빈 채로 둬 호출자가 project_id 를 명시하게 한다(추측 금지).
+
+        캐시 수명 = 프로세스. 키의 default project 가 런타임 중 바뀌면 stale 할 수 있으나(재기동 시 해소),
+        parity 가 목표라 TTL 은 의도적으로 두지 않는다(over-engineer 회피).
+        """
+        if not api_key:
+            return {}
+        cached = _auth_ctx_cache.get(api_key)
+        if cached is not None:
+            return cached
+        data = await self.get("/api/v2/auth/me")
+        ctx = {
+            "member_id": data.get("member_id") or "",
+            "org_id": data.get("org_id") or "",
+            "project_id": data.get("project_id") or "",
+        }
+        _auth_ctx_cache[api_key] = ctx
+        return ctx
+
+    def _effective_ctx(self) -> dict[str, str]:
+        """현 요청의 effective 키(per-request override ∨ env 단일키)에 해소된 컨텍스트.
+
+        stdio: override 미설정이라 env 키 기준이고 캐시는 비어 있어 {} → 프로퍼티는 self._* 로 폴백(무회귀).
+        http: 미들웨어가 그 요청 키로 ensure_auth_context 해둬 default 컨텍스트를 돌려준다.
+        """
+        key = _api_key_override.get() or self._api_key
+        return _auth_ctx_cache.get(key, {})
+
     @property
     def member_id(self) -> str:
-        return self._member_id
+        # stdio env-key 해소값 우선 → 없으면(http) per-key 해소 캐시.
+        return self._member_id or self._effective_ctx().get("member_id", "")
 
     @property
     def org_id(self) -> str:
-        return self._org_id
+        return self._org_id or self._effective_ctx().get("org_id", "")
 
     @property
     def project_id(self) -> str:
-        # per-call override(85429ee0) 우선 — 없으면 키 default(무회귀).
-        return _project_override.get() or self._project_id
+        # per-call override(85429ee0) 우선. override=None(=미설정·arg 부재)은 falsy 라 skip →
+        # stdio env-key default → http per-key 해소 default(ee2f4e58). 이 fall-through 가 422 제거 핵심.
+        return (
+            _project_override.get()
+            or self._project_id
+            or self._effective_ctx().get("project_id", "")
+        )
 
     async def request(
         self,
@@ -214,14 +260,15 @@ class SprintableClient:
         if _override:
             headers["X-Project-Id"] = _override
 
-        # POST/PUT/PATCH body에 context 필드 자동 주입(project_id 는 override 반영된 effective).
+        # POST/PUT/PATCH body에 context 필드 자동 주입. ee2f4e58: 프로퍼티 경유로 읽어 http per-key
+        # 해소 default 까지 반영(stdio 는 self._* 우선이라 무회귀).
         if method.upper() in ("POST", "PUT", "PATCH") and json is not None:
             if not json.get("project_id") and self.project_id:
                 json = {**json, "project_id": self.project_id}
-            if not json.get("org_id") and self._org_id:
-                json = {**json, "org_id": self._org_id}
-            if not json.get("created_by") and self._member_id:
-                json = {**json, "created_by": self._member_id}
+            if not json.get("org_id") and self.org_id:
+                json = {**json, "org_id": self.org_id}
+            if not json.get("created_by") and self.member_id:
+                json = {**json, "created_by": self.member_id}
 
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.request(method, url, json=json, params=params, headers=headers)

--- a/backend/sprintable_mcp/http_auth.py
+++ b/backend/sprintable_mcp/http_auth.py
@@ -7,12 +7,17 @@
 """
 from __future__ import annotations
 
+import logging
+
 from .api_client import (
+    client,
     reset_api_key_override,
     reset_project_override,
     set_api_key_override,
     set_project_override,
 )
+
+logger = logging.getLogger(__name__)
 
 _UNAUTHORIZED_BODY = (
     b'{"error":{"code":"unauthorized",'
@@ -72,6 +77,13 @@ def bearer_auth_asgi(app):
         ktok = set_api_key_override(key)
         ptok = set_project_override(project_id)
         try:
+            # ee2f4e58: 이 키의 default 컨텍스트(member/org/project)를 1회 해소·캐시 →
+            # 명시 project_id 없는 툴 호출도 키 default 로 해소(stdio parity·422 제거).
+            # additive·non-fatal: 해소 실패해도 인증 흐름은 진행(백엔드가 401/422 로 자연 처리).
+            try:
+                await client.ensure_auth_context(key)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("ensure_auth_context 실패(non-fatal): %s", exc)
             await app(scope, receive, send)
         finally:
             reset_api_key_override(ktok)

--- a/backend/tests/test_e_mcp_http_project_default_ee2f4e58.py
+++ b/backend/tests/test_e_mcp_http_project_default_ee2f4e58.py
@@ -1,0 +1,186 @@
+"""E-MCP-HTTP ee2f4e58: HTTP 경로 default project_id 해소(키 컨텍스트·stdio parity).
+
+근본(두 겹): _run_http 가 resolve_auth_context 미호출(싱글톤 _project_id 빈값) + 툴 래퍼
+server.py 가 _project_override 를 None arg 로 clobber → client.project_id="" → 백엔드 422.
+fix: 미들웨어가 요청경계서 키별 ensure_auth_context 해소·캐시, 프로퍼티 폴백체인을
+override → stdio self._* → http per-key 해소 로. 명시 project_id(override)는 최우선(Poke 무회귀).
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    """per-key 캐시는 모듈 전역 → 테스트 간 격리(누수 0)."""
+    import sprintable_mcp.api_client as ac
+    ac._auth_ctx_cache.clear()
+    yield
+    ac._auth_ctx_cache.clear()
+
+
+def _fresh_client(api_url="https://be", api_key="envkey"):
+    from sprintable_mcp.api_client import SprintableClient
+    c = SprintableClient()
+    c.configure(api_url, api_key)
+    return c
+
+
+@pytest.mark.anyio
+async def test_ensure_auth_context_resolves_and_caches_per_key():
+    """키별 /auth/me 1회 해소·캐시(같은 키 재호출은 캐시 히트·다른 키는 새 fetch). 빈 키는 no-op."""
+    c = _fresh_client()
+    calls = {"n": 0}
+
+    async def _fake_get(path, **kw):
+        calls["n"] += 1
+        return {"member_id": "m1", "org_id": "o1", "project_id": "p1"}
+
+    with patch.object(c, "get", new=AsyncMock(side_effect=_fake_get)):
+        ctx = await c.ensure_auth_context("keyA")
+        assert ctx == {"member_id": "m1", "org_id": "o1", "project_id": "p1"}
+        await c.ensure_auth_context("keyA")            # 캐시 히트(추가 fetch X)
+        assert calls["n"] == 1
+        await c.ensure_auth_context("keyB")            # 다른 키 → 새 fetch
+        assert calls["n"] == 2
+        assert await c.ensure_auth_context("") == {}   # 빈 키 → no-op
+        assert calls["n"] == 2
+
+
+@pytest.mark.anyio
+async def test_http_default_resolved_when_no_explicit_project():
+    """http: override=None(arg 부재)·self._* 빈값 → per-key 해소 default 사용(422 제거 핵심)."""
+    from sprintable_mcp.api_client import set_api_key_override, reset_api_key_override
+    c = _fresh_client(api_key="_http_per_request_bearer_only_")  # http placeholder
+    c._project_id = c._org_id = c._member_id = ""                # http 싱글톤 미해소 상태
+
+    async def _fake_get(path, **kw):
+        return {"member_id": "mh", "org_id": "oh", "project_id": "ph"}
+
+    with patch.object(c, "get", new=AsyncMock(side_effect=_fake_get)):
+        ktok = set_api_key_override("reqkeyA")
+        try:
+            await c.ensure_auth_context("reqkeyA")
+            assert c.project_id == "ph"     # 폴백 → 해소 default
+            assert c.org_id == "oh"
+            assert c.member_id == "mh"
+        finally:
+            reset_api_key_override(ktok)
+
+
+@pytest.mark.anyio
+async def test_explicit_project_override_wins_poke_no_regression():
+    """명시 project_id → override 최우선(외부/Poke 호출자 무회귀). 해소 default 는 무시된다."""
+    from sprintable_mcp.api_client import (
+        reset_api_key_override,
+        reset_project_override,
+        set_api_key_override,
+        set_project_override,
+    )
+    c = _fresh_client(api_key="_http_per_request_bearer_only_")
+    c._project_id = ""
+
+    async def _fake_get(path, **kw):
+        return {"member_id": "mh", "org_id": "oh", "project_id": "ph"}
+
+    with patch.object(c, "get", new=AsyncMock(side_effect=_fake_get)):
+        ktok = set_api_key_override("reqkeyA")
+        await c.ensure_auth_context("reqkeyA")
+        ptok = set_project_override("explicit-P")   # 툴 arg 로 들어온 명시 project
+        try:
+            assert c.project_id == "explicit-P"     # override 최우선(해소 ph 무시)
+        finally:
+            reset_project_override(ptok)
+            reset_api_key_override(ktok)
+
+
+def test_stdio_no_regression_uses_singleton_attr():
+    """stdio: self._*(startup resolve) 우선·캐시 미사용 → 무회귀."""
+    c = _fresh_client(api_key="envkey")
+    c._project_id, c._org_id, c._member_id = "stdio-P", "stdio-O", "stdio-M"
+    assert c.project_id == "stdio-P"   # 캐시 비어도 싱글톤 값
+    assert c.org_id == "stdio-O"
+    assert c.member_id == "stdio-M"
+
+
+@pytest.mark.anyio
+async def test_override_none_falls_through_not_explicit_empty():
+    """override=None(미설정)은 falsy → skip 하고 다음 단계로 fall-through(오르테가 ①)."""
+    from sprintable_mcp.api_client import (
+        reset_api_key_override,
+        set_api_key_override,
+    )
+    c = _fresh_client(api_key="_http_per_request_bearer_only_")
+    c._project_id = ""
+
+    async def _fake_get(path, **kw):
+        return {"member_id": "", "org_id": "", "project_id": "ph"}
+
+    with patch.object(c, "get", new=AsyncMock(side_effect=_fake_get)):
+        ktok = set_api_key_override("reqkeyA")
+        try:
+            await c.ensure_auth_context("reqkeyA")
+            # _project_override 미설정(None) → skip → self._project_id("") skip → 해소 "ph"
+            assert c.project_id == "ph"
+        finally:
+            reset_api_key_override(ktok)
+
+
+@pytest.mark.anyio
+async def test_middleware_triggers_ensure_auth_context():
+    """미들웨어가 요청경계서 ensure_auth_context(요청 키) 호출(no-arg 툴 default 해소 트리거)."""
+    from sprintable_mcp import api_client as ac
+    from sprintable_mcp.http_auth import bearer_auth_asgi
+    seen: dict = {}
+
+    async def _fake_ensure(key):
+        seen["key"] = key
+        return {}
+
+    async def _app(scope, receive, send):
+        seen["app"] = True
+
+    async def _recv():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def _send(msg):
+        pass
+
+    with patch.object(ac.client, "ensure_auth_context", new=AsyncMock(side_effect=_fake_ensure)):
+        scope = {"type": "http", "path": "/mcp",
+                 "headers": [(b"authorization", b"Bearer sk_req")]}
+        await bearer_auth_asgi(_app)(scope, _recv, _send)
+    assert seen.get("key") == "sk_req" and seen.get("app") is True
+
+
+@pytest.mark.anyio
+async def test_middleware_ensure_failure_non_fatal():
+    """ensure_auth_context 실패해도 app 통과(auth additive·non-fatal)."""
+    from sprintable_mcp import api_client as ac
+    from sprintable_mcp.http_auth import bearer_auth_asgi
+    state = {"app": False}
+
+    async def _boom(key):
+        raise RuntimeError("auth/me down")
+
+    async def _app(scope, receive, send):
+        state["app"] = True
+
+    async def _recv():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def _send(msg):
+        pass
+
+    with patch.object(ac.client, "ensure_auth_context", new=AsyncMock(side_effect=_boom)):
+        scope = {"type": "http", "path": "/mcp",
+                 "headers": [(b"authorization", b"Bearer sk_x")]}
+        await bearer_auth_asgi(_app)(scope, _recv, _send)
+    assert state["app"] is True   # 해소 실패해도 인증 흐름 진행


### PR DESCRIPTION
## E-MCP-HTTP ee2f4e58 — HTTP 경로 default project_id 키-컨텍스트 해소 (stdio parity)

### 근본 (두 겹)
1. `_run_http`가 placeholder 키로 `configure`만 하고 `resolve_auth_context` 미호출 → 싱글톤 `client._project_id` 빈값.
2. 툴 래퍼 `server.py` `set_project_override(kwargs.get("project_id"))`가 매 호출 override를 `None`(arg 부재)로 clobber.

⇒ `client.project_id = override(None) or _project_id("")` = `""` → 백엔드 422 `project_id: Input should be a valid UUID`. 명시 project_id 없는 외부/HTTP 호출이 전부 실패(로컬 stdio는 startup resolve로 정상이라 발생 안 함).

### 변경 (3 파일)
- **`api_client.py`**: per-key 해소 컨텍스트 캐시 `_auth_ctx_cache` + `ensure_auth_context(key)` 추가. `member_id`/`org_id`/`project_id` 프로퍼티 폴백체인 = `override → stdio self._* → http per-key 해소`. POST body context 주입(org_id/created_by)도 프로퍼티 경유로 전환(http parity). `override=None`은 falsy → skip 후 fall-through(미설정과 명시 빈값 구분).
- **`http_auth.py`**: bearer auth 미들웨어가 요청 경계서 `ensure_auth_context(bearer key)` 호출(try/except·non-fatal — 해소 실패해도 인증 흐름 진행).
- **`tests/test_e_mcp_http_project_default_ee2f4e58.py`**: 신규 7 케이스.

### 멀티프로젝트 키 규칙
`/api/v2/auth/me`가 반환하는 server-canonical default project_id 사용(클라이언트 임의선택 없음). default가 비면 빈 채로 두어 호출자가 project_id 명시(추측 금지). 캐시 수명 = 프로세스(키 default 변경 시 재기동으로 해소·TTL 미도입).

### 검증
- 단위/계약: `CI=1` 전체 그린 — 98 passed · 2 skipped(2는 env+CI 게이트 dev-E2E·본 변경면 무관). 신규 7 전부 pass.
- 라이브(로컬 fixed 서버 · dev 백엔드 · 실 키):
  - `get_project_overview` (project_id 미지정) **422 → 200**.
  - `list_stories` / `my_dashboard` / `list_epics` (project_id 미지정) 200.
  - 명시 project_id 호출 **무회귀 200**.
  - invalid 키 → `UNAUTHORIZED`(per-key auth 유지).
- stdio 무회귀: `self._*`(startup resolve) 우선·캐시 미사용.

### Out-of-scope
`list_backlog`는 project_id 에러는 해소되나 `id: invalid UUID` 잔여 — backend route shadow(`/api/v2/stories/backlog` vs `/api/v2/stories/{id}`) **가설(미확정)**. MCP 레이어 아닌 백엔드 이슈로 보이며 본 PR 범위 밖 · 별도 티켓 권고.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
