### PR TITLE
[E-DG-REAL][S1] feat: PR↔story 게이트 CI 링킹 컨벤션 (SID 태깅)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,12 @@
 ## Summary
 Brief description of changes.
 
+## Story
+<!-- Links this PR to its story's approval gate (CI/merge verdict). Use the FULL 36-char
+     story UUID. Also put `sid-<uuid>` in the branch name — required for CI evidence
+     (CI webhooks carry only the branch). See CONTRIBUTING.md "Linking PRs to Stories". -->
+[SID:00000000-0000-0000-0000-000000000000]
+
 ## Related Issue
 Fixes #(issue number)
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,9 +2,9 @@
 Brief description of changes.
 
 ## Story
-<!-- Links this PR to its story's approval gate (CI/merge verdict). Use the FULL 36-char
-     story UUID. Also put `sid-<uuid>` in the branch name — required for CI evidence
-     (CI webhooks carry only the branch). See CONTRIBUTING.md "Linking PRs to Stories". -->
+<!-- Optional. Links this PR to its story's approval gate (CI/merge verdict). Use the
+     FULL 36-char story UUID, and ideally a `sid-<uuid>` segment in the branch name too
+     (CI webhooks carry only the branch). Internal convention — see AGENTS.md. -->
 [SID:00000000-0000-0000-0000-000000000000]
 
 ## Related Issue

--- a/.github/workflows/sid-link-check.yml
+++ b/.github/workflows/sid-link-check.yml
@@ -27,5 +27,5 @@ jobs:
              || printf '%s' "$PR_BODY" | grep -qiE "\[SID:$UUID\]"; then
             echo "Story SID tag found — the approval gate will link the CI/merge verdict."
           else
-            echo "::warning title=No story SID tag::This PR has no [SID:<full-uuid>] in its body or sid-<full-uuid> in its branch name. Its approval gate will stay 'unknown (self-report only)'. See CONTRIBUTING.md 'Linking PRs to Stories'. (advisory — does not block merge)"
+            echo "::warning title=No story SID tag::This PR has no [SID:<full-uuid>] in its body or sid-<full-uuid> in its branch name, so its approval gate keeps 'CI unknown (self-report only)'. Tagging is optional — see AGENTS.md 'Linking PRs to story gates'. (advisory — does not block merge)"
           fi

--- a/.github/workflows/sid-link-check.yml
+++ b/.github/workflows/sid-link-check.yml
@@ -1,0 +1,31 @@
+name: SID Link Check
+
+# E-DG-REAL S1: advisory check that a PR is linked to its story (gate CI evidence).
+# NON-BLOCKING by design — every path exits 0; it only emits a ::warning:: annotation.
+# It must never be added to required status checks. The real linking is done by the
+# GitHub webhook (app/routers/verdict_capture.py); this just nudges contributors to tag.
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  sid-link-check:
+    name: Story link (SID) — advisory
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Check for story SID tag (branch or PR body)
+        env:
+          BRANCH: ${{ github.head_ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Mirrors _SID_RE in app/services/verdict_capture.py:
+          #   [SID:<uuid>] in PR body  |  sid-<uuid> / sid/<uuid> in branch
+          UUID='[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
+          if printf '%s' "$BRANCH" | grep -qiE "sid[-_/]$UUID" \
+             || printf '%s' "$PR_BODY" | grep -qiE "\[SID:$UUID\]"; then
+            echo "Story SID tag found — the approval gate will link the CI/merge verdict."
+          else
+            echo "::warning title=No story SID tag::This PR has no [SID:<full-uuid>] in its body or sid-<full-uuid> in its branch name. Its approval gate will stay 'unknown (self-report only)'. See CONTRIBUTING.md 'Linking PRs to Stories'. (advisory — does not block merge)"
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md — repo-internal conventions for Sprintable's own agents
+
+This file documents conventions used by **this repository's own agent contributors**.
+It is an internal convenience, **not** a requirement for customers using Sprintable.
+(Customer-facing contribution notes live in [`CONTRIBUTING.md`](CONTRIBUTING.md).)
+
+## Linking PRs to story gates (gate CI evidence)
+
+Sprintable's approval gates record the **real** CI/merge outcome of a story instead of
+self-report. A live GitHub webhook (`app/routers/verdict_capture.py`) parses a story id
+from PR/CI events and feeds the verdict into that story's gate via
+`capture_pr_ci_verdict` → `resolve_gate_from_verdict`. If no story id is found, the
+verdict is skipped and the gate stays `CI unknown (self-report only)`.
+
+The id is matched by `_SID_RE` in `app/services/verdict_capture.py` as a **fallback
+chain** — any one of these, when present, links the gate:
+
+1. **Explicit link** (planned, convention-free — product surface; tracked separately).
+2. **Branch name** — a `sid-<full-uuid>` / `sid/<full-uuid>` segment.
+3. **PR body** — a `[SID:<full-uuid>]` tag.
+
+None is mandatory; untagged PRs are handled gracefully (skipped).
+
+### Convention for our agents (fast internal unblock)
+
+When an agent opens a story-backed PR in this repo, tag it so its gate gets real CI
+evidence:
+
+- **Branch** — include a `sid-<full-story-uuid>` segment, e.g.
+  `feat/sid-14744174-35d3-452c-9594-386fc2c3b0ef-gate-ci-linking`.
+  This is the **primary carrier for CI evidence**: CI webhook events (`workflow_run`,
+  `check_suite`, `status`) carry only `head_branch` — not the PR title/body — so the
+  branch is the only reliable carrier for the *CI* verdict.
+- **PR body** — include `[SID:<full-story-uuid>]` (the PR template has a placeholder).
+  This covers the *merge* verdict and shows the link to reviewers.
+
+Notes:
+- Use the **full 36-character story UUID**, not the short 8-char id — `_SID_RE` requires
+  the full UUID. Resolve it from the story in Sprintable.
+- A non-blocking advisory check (`.github/workflows/sid-link-check.yml`) emits a warning
+  when a PR has neither carrier. It never blocks merge.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,30 +33,17 @@ pnpm build         # Production build
    - Screenshots for UI changes
 4. **Review**: At least one approval required before merge
 
-## Linking PRs to Stories (gate CI evidence)
+## Linking PRs to Stories
 
-Sprintable's approval gates record **real** CI/merge outcomes (not self-report) by
-auto-linking each PR to its story. A GitHub webhook parses a **story id tag** from the
-PR and feeds the CI/merge verdict into that story's gate. **Without the tag the gate
-stays `unknown (self-report only)`** — the verdict is silently skipped.
+Sprintable's approval gates can auto-link a PR to its story so a gate reflects the real
+CI/merge outcome. Contributors in this repository may opt to tag a PR by including a
+`sid-<story-uuid>` segment in the branch name (or `[SID:<story-uuid>]` in the PR body) —
+this is **optional**, and untagged PRs are handled gracefully. The detailed tagging
+conventions used by this repo's own agents live in [`AGENTS.md`](AGENTS.md).
 
-Tag every story-backed PR in **both** places:
-
-1. **Branch name** — include a `sid-<full-story-uuid>` segment, e.g.
-   `feat/sid-14744174-35d3-452c-9594-386fc2c3b0ef-gate-ci-linking`.
-   This is **required for CI evidence**: CI webhook events (`workflow_run`,
-   `check_suite`, `status`) carry only the branch name — not the PR title/body — so the
-   branch is the only reliable carrier for the *CI* verdict.
-2. **PR body** — include `[SID:<full-story-uuid>]` (the PR template has a placeholder).
-   This covers the *merge* verdict and makes the link visible to reviewers.
-
-Notes:
-- Use the **full 36-character story UUID**, not the short 8-char id (the parser requires
-  the full UUID). Resolve it from the story in Sprintable.
-- The tag is matched by `app/services/verdict_capture.py` (`_SID_RE`):
-  `[SID:<uuid>]` (title/body) or `sid-<uuid>` / `sid/<uuid>` (branch).
-- **Non-blocking**: a missing tag does not block merge — CI emits a warning and the
-  gate simply stays `unknown`. Untagged PRs are handled gracefully (skipped).
+Convention-free linking for product use (in-app, no branch/PR naming rules) is planned
+and provided separately — the tagging above is an internal convenience, not a
+requirement for using Sprintable.
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,31 @@ pnpm build         # Production build
    - Screenshots for UI changes
 4. **Review**: At least one approval required before merge
 
+## Linking PRs to Stories (gate CI evidence)
+
+Sprintable's approval gates record **real** CI/merge outcomes (not self-report) by
+auto-linking each PR to its story. A GitHub webhook parses a **story id tag** from the
+PR and feeds the CI/merge verdict into that story's gate. **Without the tag the gate
+stays `unknown (self-report only)`** — the verdict is silently skipped.
+
+Tag every story-backed PR in **both** places:
+
+1. **Branch name** — include a `sid-<full-story-uuid>` segment, e.g.
+   `feat/sid-14744174-35d3-452c-9594-386fc2c3b0ef-gate-ci-linking`.
+   This is **required for CI evidence**: CI webhook events (`workflow_run`,
+   `check_suite`, `status`) carry only the branch name — not the PR title/body — so the
+   branch is the only reliable carrier for the *CI* verdict.
+2. **PR body** — include `[SID:<full-story-uuid>]` (the PR template has a placeholder).
+   This covers the *merge* verdict and makes the link visible to reviewers.
+
+Notes:
+- Use the **full 36-character story UUID**, not the short 8-char id (the parser requires
+  the full UUID). Resolve it from the story in Sprintable.
+- The tag is matched by `app/services/verdict_capture.py` (`_SID_RE`):
+  `[SID:<uuid>]` (title/body) or `sid-<uuid>` / `sid/<uuid>` (branch).
+- **Non-blocking**: a missing tag does not block merge — CI emits a warning and the
+  gate simply stays `unknown`. Untagged PRs are handled gracefully (skipped).
+
 ## Code Style
 
 - **TypeScript strict mode** — no `any` unless absolutely necessary


### PR DESCRIPTION
## Summary
Makes story approval gates record the **real** CI/merge outcome (not self-report) by linking PRs to stories. The linking machine and GitHub webhook are already live and correct — the gap was purely **input** (no parseable story id reached the PR/branch). This PR is **scoped to our internal dogfood**: it does not impose any convention on customers.

## Story
[SID:14744174-35d3-452c-9594-386fc2c3b0ef]

## Root cause
`github-webhook` → `_SID_RE` → `capture_pr_ci_verdict` → `resolve_gate_from_verdict` is complete, and the GitHub webhook is active (hook #640488969). The gap: `_SID_RE` needs a full 36-char UUID (`[SID:<uuid>]` in PR body, or `sid-<uuid>` in branch), but our PRs used short ids → 0 matches → skip → gate stays `CI unknown (self-report only)`. Measured: 84 story gates, **78 pending with `decision_basis="CI unknown (self-report only)"`**.

**Why branch (not just PR body):** CI webhook events (`workflow_run`/`check_suite`/`status`) carry only `head_branch` — not the PR title/body. So the branch is the only reliable carrier for the *CI* verdict; PR-body covers the *merge* verdict.

## Changes (no backend code — the machine is already correct)
- **`AGENTS.md`** (new, repo-internal): detailed tagging convention for **our agents** — fallback chain `explicit link > branch sid > PR body`, full UUID, why CI needs the branch.
- **`CONTRIBUTING.md`**: short, neutral note — gates auto-link; `sid-<uuid>` branch tagging is **optional** (untagged OK); convention-free product linking (in-app) is provided separately. No customer mandate.
- **PR template**: optional `[SID:<uuid>]` placeholder.
- **`.github/workflows/sid-link-check.yml`**: non-blocking advisory (warns if untagged; never blocks, never a required check).

## Scope / no-regression
- Internal dogfood only — branch `sid-<uuid>` unblocks **our** 78 gates; no convention forced on customers. Convention-free product linking (explicit PR↔story API/UI) is an elevated follow-up story (S5).
- Untagged PRs handled gracefully (parser → None → skip). Verified with the real backend `parse_story_id` (dogfood branch/body → story uuid; short id / unfilled placeholder → None).
- This PR **dogfoods** the convention (branch `sid-14744174-…` + body `[SID:…]`).

## Verification
- Real `parse_story_id` confirmed across linked / short-id / placeholder cases.
- Advisory workflow logic simulated (linked / unlinked / short-id / placeholder).
- E2E note: dogfood story `14744174` has participation (implementation) but **no gate yet**, so this PR exercises verdict *recording*; demonstrating a gate flip (`unknown → pass`) needs a story that has a gate (one of the 78, or S2 backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
