### PR TITLE
[E-DG-REAL][P0] fix: 게이트 빈-껍데기 박멸 — evidence-driven materialization + 80 backfill

### DIFF
--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.models.participation import ParticipationRole
+from app.services.gate_resolver import resolve_disposition
 from app.services.gate_service import create_gate
 from app.services.trust_score import compute_member_trust_scores
 from app.services.verdict_capture import (
@@ -250,6 +251,30 @@ async def evaluate_merge_gate(
     member_id = participation.member_id
     role_id = participation.role_id
     role_key = await _role_key(session, role_id)
+
+    # P0(E-DG-REAL 1ff89d23): evidence-driven materialization — 빈 'CI unknown' shell 양산 박멸.
+    # 게이트는 **실 신호(CI 결과 · 연결 PR · 명시 deny 정책)**가 있을 때만 만든다. CI/PR 증거가
+    # 둘 다 없을 때만 정책을 확인하고, deny가 아니면(ask=시스템 기본이라 그 자체론 신호 아님) 사람이
+    # 판단할 게 없는 빈 shell이 되므로 **게이트를 만들지 않는다**(no-gate·row 0·done 통과). 실 CI
+    # 증거는 GitHub 앱(S5)이 native 당김. 3 트리거(board preflight·report-done·line-engine) 모두
+    # 이 단일 chokepoint를 거쳐 일관 적용. (증거 있으면 resolve_disposition 호출조차 생략.)
+    if ci is None and pr_number <= 0:
+        disposition = await resolve_disposition(session, org_id, member_id, role_id, MERGE_GATE_TYPE)
+        if disposition != "deny":
+            logger.info(
+                "merge gate: no substance (ci=None pr_number=0 disposition=%s) story=%s "
+                "— gate not materialized (no-gate)",
+                disposition, story_id,
+            )
+            return MergeGateDecision(
+                decision=AUTO_MERGE,
+                reason="no-substance: no CI/PR evidence and policy is not deny — gate not materialized",
+                gate_id=None,
+                gate_status=None,
+                disposition=disposition,
+                trust=None,
+                ci_result=ci,
+            )
 
     # 1. trust(Cage) — implementation 역할 clean_pass_rate. **capture보다 먼저** 계산한다.
     #    ⚠️ capture_pr_ci_verdict는 현재 PR/CI verdict를 session에 add한다. SQLAlchemy autoflush=True

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -260,6 +260,12 @@ async def evaluate_merge_gate(
     # 이 단일 chokepoint를 거쳐 일관 적용. (증거 있으면 resolve_disposition 호출조차 생략.)
     if ci is None and pr_number <= 0:
         disposition = await resolve_disposition(session, org_id, member_id, role_id, MERGE_GATE_TYPE)
+        # follow-up(enforcing 롤아웃·GitHub앱 S5 때 재고): substance로 인정하는 정책은 현재 'deny'만.
+        # 'ask'는 SYSTEM_DEFAULT(=ask)라 그 자체론 신호가 아니므로 증거 0이면 no-gate. 다만 resolve_disposition
+        # 은 disposition 문자열만 돌려주고 **출처(시스템 기본 vs 명시 override/posture)를 구분하지 않는다** →
+        # 어떤 org가 '증거 무관 전-머지 휴먼 사인오프' 의도로 ask를 명시 설정해도 지금은 bypass된다. 그 의도를
+        # 살리려면 resolve_disposition이 explicit-ask를 default-ask와 구분(출처 노출)해야 한다. P0(즉시 sloppy
+        # 탈출)에선 빈 shell 박멸이 우선이라 deny-only로 둔다.
         if disposition != "deny":
             logger.info(
                 "merge gate: no substance (ci=None pr_number=0 disposition=%s) story=%s "

--- a/backend/scripts/backfill_void_empty_merge_gates.py
+++ b/backend/scripts/backfill_void_empty_merge_gates.py
@@ -1,0 +1,91 @@
+"""E-DG-REAL P0 (1ff89d23): 누적 빈-껍데기 merge 게이트 void backfill (idempotent).
+
+배경: P0 前에는 모든 story→done이 `evaluate_merge_gate(ci_result=None, pr_number=0)`를 거쳐
+무조건 'CI unknown (self-report only)' 게이트 shell을 만들었다(증거 0·사람이 판단 불가). P0 코드가
+이를 막지만(evidence-driven materialization), 이미 누적된 shell은 인박스에 남는다. 이 job이 그것을
+**void**(audit 보존·인박스서 제거·delete 아님) 처리한다.
+
+대상(보수적·무PR shell만): gate_type='merge' · status='pending' · decision_basis='CI unknown
+(self-report only)' · neutral_facts.pr_number 가 없음/0. 실 PR 있는 게이트·approved/auto_passed·
+held 등은 건드리지 않는다. 재실행 멱등(이미 voided면 status가 pending이 아니라 재대상 아님).
+
+env: DATABASE_URL (백엔드 동일·cloud-sql-proxy/in-VPC). 쓰기 작업.
+실행:
+  cd backend && DATABASE_URL=... python -m scripts.backfill_void_empty_merge_gates            # dry-run
+  cd backend && DATABASE_URL=... python -m scripts.backfill_void_empty_merge_gates --apply     # 실제 void
+옵션: --org <uuid> 로 특정 org만.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+
+from app.core.database import async_session_factory
+from app.models.gate import Gate
+
+MERGE_GATE_TYPE = "merge"
+_SHELL_BASIS = "CI unknown (self-report only)"
+_VOID_NOTE = "no-substance shell · replaced by evidence-driven gating (E-DG-REAL P0 1ff89d23)"
+
+
+def _is_no_pr(neutral_facts: dict | None) -> bool:
+    """실 PR 컨텍스트가 없는 shell인지 — pr_number 없음/0/falsy."""
+    if not neutral_facts:
+        return True
+    return not neutral_facts.get("pr_number")
+
+
+async def main() -> int:
+    if not os.environ.get("DATABASE_URL"):
+        print("DATABASE_URL 미설정", file=sys.stderr)
+        return 2
+
+    parser = argparse.ArgumentParser(description="void empty 'CI unknown' merge gate shells (idempotent)")
+    parser.add_argument("--apply", action="store_true", help="실제 void 커밋 (미지정 시 dry-run)")
+    parser.add_argument("--org", type=str, default=None, help="특정 org_id 만 (기본 전체)")
+    args = parser.parse_args()
+
+    q = select(Gate).where(
+        Gate.gate_type == MERGE_GATE_TYPE,
+        Gate.status == "pending",
+        Gate.decision_basis == _SHELL_BASIS,
+    )
+    if args.org:
+        q = q.where(Gate.org_id == uuid.UUID(args.org))
+
+    async with async_session_factory() as db:
+        rows = (await db.execute(q)).scalars().all()
+        targets = [g for g in rows if _is_no_pr(g.neutral_facts)]
+        skipped_has_pr = len(rows) - len(targets)
+
+        print(
+            f"matched pending 'CI unknown' merge gates: {len(rows)} "
+            f"(no-PR shells: {len(targets)}, has-PR skipped: {skipped_has_pr})"
+        )
+
+        if not args.apply:
+            for g in targets[:20]:
+                print(f"  [dry-run void] gate={g.id} org={g.org_id} story={g.work_item_id}")
+            if len(targets) > 20:
+                print(f"  … +{len(targets) - 20} more")
+            print("dry-run — no changes. 실제 적용은 --apply.")
+            return 0
+
+        now = datetime.now(timezone.utc)
+        for g in targets:
+            g.status = "voided"
+            g.resolved_at = now
+            g.resolution_note = _VOID_NOTE
+        await db.commit()
+        print(f"voided {len(targets)} no-substance shell gates.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/backend/tests/test_merge_verdict_gate.py
+++ b/backend/tests/test_merge_verdict_gate.py
@@ -442,3 +442,73 @@ async def test_strong_outcome_track_record_auto_merges_real_db():
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)
         await engine.dispose()
+
+
+# ── P0 (E-DG-REAL 1ff89d23): evidence-driven materialization (빈 shell 박멸) ──────
+import contextlib  # noqa: E402
+
+
+async def _run_substance(*, ci_result, pr_number, disposition):
+    """substance 가드 경로 — participation 있음, disposition 주입, create_gate spy 반환."""
+    part = SimpleNamespace(member_id=uuid.uuid4(), role_id=uuid.uuid4())
+    gate = SimpleNamespace(id=uuid.uuid4(), status="pending")
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch.object(mod, "resolve_implementation_participation",
+                                         AsyncMock(return_value=part)))
+        stack.enter_context(patch.object(mod, "_role_key", AsyncMock(return_value="implementation")))
+        stack.enter_context(patch.object(mod, "resolve_disposition",
+                                         AsyncMock(return_value=disposition)))
+        stack.enter_context(patch.object(mod, "capture_pr_ci_verdict",
+                                         AsyncMock(return_value={"recorded": [], "skipped_reason": "no_sid_tag"})))
+        stack.enter_context(patch.object(mod, "compute_member_trust_scores",
+                                         AsyncMock(return_value={"scores": []})))
+        create_spy = stack.enter_context(patch.object(mod, "create_gate", AsyncMock(return_value=gate)))
+        res = await evaluate_merge_gate(
+            AsyncMock(), uuid.uuid4(), uuid.uuid4(),
+            pr_number=pr_number, repo=("o/r" if pr_number else ""),
+            ci_result=ci_result, pr_result=None,
+        )
+    return res, create_spy
+
+
+@pytest.mark.anyio
+async def test_no_substance_no_gate_materialized():
+    """무증거(ci None·pr 0·정책 ask) → 게이트 미생성·no-gate(AUTO_MERGE)·row 0."""
+    res, create_spy = await _run_substance(ci_result=None, pr_number=0, disposition="ask")
+    assert res.decision == AUTO_MERGE
+    assert res.gate_id is None
+    assert "no-substance" in res.reason
+    create_spy.assert_not_awaited()  # 빈 shell 안 만든다.
+
+
+@pytest.mark.anyio
+async def test_no_substance_allow_auto_also_no_gate():
+    """무증거 + 정책 allow_auto → 동일하게 no-gate(done 통과·row 0)."""
+    res, create_spy = await _run_substance(ci_result=None, pr_number=0, disposition="allow_auto")
+    assert res.decision == AUTO_MERGE and res.gate_id is None
+    create_spy.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_ci_result_present_materializes_gate():
+    """CI 결과 있음(green/red) → substance → 게이트 생성(기존 동작 보존)."""
+    res, create_spy = await _run_substance(ci_result="fail", pr_number=0, disposition="ask")
+    assert res.gate_id is not None
+    assert res.decision == BLOCK  # red CI 하드블록(무회귀).
+    create_spy.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_connected_pr_materializes_gate():
+    """연결 PR(pr_number>0) → substance → 게이트 생성(증거 평가 대상)."""
+    res, create_spy = await _run_substance(ci_result=None, pr_number=7, disposition="ask")
+    assert res.gate_id is not None
+    create_spy.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_deny_policy_materializes_even_without_evidence():
+    """명시 deny 정책 → 증거 없어도 게이트 생성(하드블록 honor)."""
+    res, create_spy = await _run_substance(ci_result=None, pr_number=0, disposition="deny")
+    assert res.gate_id is not None
+    create_spy.assert_awaited_once()


### PR DESCRIPTION
## Summary
Stops approval gates from manufacturing empty `CI unknown (self-report only)` shells, and voids the 80 already accumulated. The gate machine now **materializes only on real substance** (CI result, connected PR, or explicit `deny` policy).

## Story
[SID:1ff89d23-a443-479e-9771-fc86d9b33424]

## Root cause
Every story→done routes through `evaluate_merge_gate(...)`, which **unconditionally** called `create_gate`. With no PR/CI context (`ci_result=None, pr_number=0`) `_decide` returns `ASK_HUMAN "CI unknown (self-report only)"`, so each transition created an evidence-less shell. Three triggers hit this: board PATCH preflight (`stories.py`), report-done (`workflow_report.py`), and the line engine (`workflow_line_engine.py`). Measured live: **84 story gates, 80 with `evidence_status=insufficient` / `decision_basis="CI unknown (self-report only)"`**.

## Changes (single chokepoint — `evaluate_merge_gate`)
- **Substance guard**: when there is no CI and no connected PR, resolve the policy disposition; if it is not `deny` (note `ask` is the *system default*, not a per-story signal), **do not create a gate** — return a no-gate decision (`AUTO_MERGE`, `gate_id=None`) so the transition proceeds. If CI/PR evidence is present, disposition isn't even resolved. All 3 triggers inherit this via the one chokepoint.
- **No-regression**: red CI → BLOCK; connected PR → gate; explicit `deny` → gate; advisory mode unchanged. Gates still materialize whenever there's a real signal.
- **Backfill** (`scripts/backfill_void_empty_merge_gates.py`): voids the accumulated no-PR shells (`status=pending`, `decision_basis="CI unknown (self-report only)"`, no `pr_number`) — audit-preserving (`status=voided` + reason note), idempotent, **dry-run by default** (`--apply` to commit).

## Behavior change (PO-approved)
A no-substance →done is no longer blocked/shelled — with zero evidence there is nothing for a human to evaluate. Real CI evidence will be pulled natively by the GitHub App (S5). Current advisory mode keeps the risk low; enforcing is a separate call.

## Verification
- Unit: 5 new tests (no-substance→no-gate, allow_auto→no-gate, CI present→materialize, connected PR→materialize, deny→materialize) + existing `_decide`/orchestration matrix unchanged. `CI=1` gate suite green (78 passed).
- Live (to run on dev): backfill `--dry-run` count vs the 80; board→done with no PR → 0 new shells; gate inbox count before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
