### PR TITLE
[SID:b0efa076] 게이트 카드 빈/cold-start 상태 위계 재설계 (omit, not placeholder)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2672,6 +2672,7 @@
     "coldStartProvisional": "Provisional",
     "seedKeep": "Keep",
     "seedKill": "Kill",
-    "outcomeAccumulating": "Awaiting verdict data"
+    "outcomeAccumulating": "Awaiting verdict data",
+    "evidenceNonePrompt": "No evidence yet — review by content"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2672,6 +2672,7 @@
     "coldStartProvisional": "임시 예측",
     "seedKeep": "유지 예측",
     "seedKill": "중단 예측",
-    "outcomeAccumulating": "판정 데이터 누적 중"
+    "outcomeAccumulating": "판정 데이터 누적 중",
+    "evidenceNonePrompt": "근거 데이터 없음 — 내용으로 직접 판단"
   }
 }

--- a/apps/web/src/components/cage/gate-evidence.tsx
+++ b/apps/web/src/components/cage/gate-evidence.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { Fragment } from 'react';
+import { CheckCircle, XCircle } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Badge } from '@/components/ui/badge';
 import type { GateItem } from '@/components/kanban/types';
@@ -9,8 +11,14 @@ import type { GateItem } from '@/components/kanban/types';
  * approve/reject facts) 공용. 신규 화면 0 — decision 배지 + facts(CI·신뢰도) + 사유.
  *
  * 🔑 핵심 가드(AC③): 신뢰도 None=`null`은 "데이터 없음"으로만 표시한다. 0%/빨강/낮음으로
- * 절대 환원하지 않는다(null≠0 — 미측정과 0은 다르다). CI 미상도 동형(? 알 수 없음).
+ * 절대 환원하지 않는다(null≠0 — 미측정과 0은 다르다). CI 미상도 동형(미표시).
  * 플랫폼은 위험도 판단을 하지 않는다(neutral_facts = 관찰 사실).
+ *
+ * 🔑 S3 상태 위계(E-DG-REAL): "없으면 비운다(omit, not placeholder)". 데이터 없는 카드는
+ * 2열 그리드·"없음" 라벨을 렌더하지 않고 한 줄로 가라앉힌다(recede). 세 시각 결과 —
+ *   A 빈/증거-없음(`!gateHasEvidence`): decision 배지 + 한 줄 안내만.
+ *   B 부분증거: present-fact만 flowing 1줄(없는 건 빠짐·dangling `·` 금지) + 사유.
+ *   C 충실((ci||trust) && coldStartSeed): 납품|판단 2열 복귀(HO-S8 "통과≠옳음" 보존·S5 슬롯).
  *
  * decision 배지 3종(BE decision = auto_merge|ask_human|block). gate status=pending(미transition)은
  * ask_human "확인 필요"로 통합(정합 노트 — 별도 "대기" 배지 불필요). 리뷰 증거는 gate 응답에
@@ -50,80 +58,135 @@ function trustScore(gate: GateItem): number | null {
   return typeof v === 'number' ? v : null; // null≠0 — 미측정 보존(AC③)
 }
 
+/**
+ * 카드에 사람이 평가할 '실 증거'가 있는가. 빈/cold-start 구분의 단일 소스.
+ * self_report_only 단독은 증거 아님(trust 실값에 붙는 qualifier로만 — 빈카드 도배 원인 제거).
+ */
+export function gateHasEvidence(gate: GateItem): boolean {
+  const f = gate.neutral_facts;
+  const hasCi = f?.['ci_result'] === 'pass' || f?.['ci_result'] === 'fail';
+  const hasTrust = typeof f?.['trust'] === 'number'; // null≠0 — number만
+  const hasSeed = f?.['cold_start_seed'] === true;
+  const hasReason = Boolean(gate.decision_basis); // 실 human reason만
+  return hasCi || hasTrust || hasSeed || hasReason;
+}
+
+// CI 신호 — lucide CheckCircle/XCircle(gate-line-context 정합·boy-scout). null이면 호출 자체 안 함(omit).
+function CiSignal({ ci }: { ci: 'pass' | 'fail' }) {
+  const t = useTranslations('cage');
+  return ci === 'pass' ? (
+    <span className="inline-flex items-center gap-1 text-success">
+      <CheckCircle className="size-3 shrink-0" />
+      {t('ciLabel')} {t('ciPass')}
+    </span>
+  ) : (
+    <span className="inline-flex items-center gap-1 text-destructive">
+      <XCircle className="size-3 shrink-0" />
+      {t('ciLabel')} {t('ciFail')}
+    </span>
+  );
+}
+
+// 신뢰도 — 실값만. 자기보고 태그는 trust 실값에 '붙어서만'(단독 도배 금지).
+function TrustValue({ trust, selfReportOnly }: { trust: number; selfReportOnly: boolean }) {
+  const t = useTranslations('cage');
+  return (
+    <span className="inline-flex items-center gap-1">
+      {t('trustLabel')}{' '}
+      <span className="text-foreground">{t('trustScorePercent', { score: Math.round(trust * 100) })}</span>
+      {selfReportOnly ? (
+        <span className="rounded bg-muted px-1 py-px text-[10px] text-muted-foreground">{t('selfReportTag')}</span>
+      ) : null}
+    </span>
+  );
+}
+
 export function GateEvidence({ gate, className }: { gate: GateItem; className?: string }) {
   const t = useTranslations('cage');
   const decision = gateDecision(gate);
   const ci = ciResult(gate);
   const trust = trustScore(gate);
   const selfReportOnly = gate.neutral_facts?.['self_report_only'] === true;
-  const reason = gate.decision_basis ?? gate.auto_decision_reason ?? null;
+  const reason = gate.decision_basis ?? null; // 실 human reason만(auto_decision_reason echo 폴백 제거 — 배지가 이미 표시)
   // HO-S8 cold-start: 미확정 outcome은 "임시 예측"(keep/kill)으로만 — 판정/% 환원 절대 X.
   const coldStartSeed = gate.neutral_facts?.['cold_start_seed'] === true;
   const seedPrediction = gate.neutral_facts?.['seed_prediction'];
   const seedKey = seedPrediction === 'keep' ? 'seedKeep' : seedPrediction === 'kill' ? 'seedKill' : null;
 
+  const decisionBadge = decision ? (
+    <Badge variant={DECISION_META[decision].variant} className="shrink-0">
+      <span aria-hidden className="mr-0.5">{DECISION_META[decision].mark}</span>
+      {t(DECISION_META[decision].labelKey)}
+    </Badge>
+  ) : null;
+
+  // ── State A · 빈 / 증거-없음: 배지 + 한 줄만(2열·CI·신뢰도·outcome·자기보고 전부 미표시·recede)
+  if (!gateHasEvidence(gate)) {
+    return (
+      <div className={className}>
+        {decisionBadge}
+        <p className="mt-1.5 text-[11.5px] italic text-muted-foreground/60">{t('evidenceNonePrompt')}</p>
+      </div>
+    );
+  }
+
+  // ── State C · 실증거 충실: 납품 신호 AND 판단 신호 둘 다 → 납품|판단 2열 복귀(forward-compat·S5 슬롯)
+  const rich = (ci !== null || trust !== null) && coldStartSeed;
+  if (rich) {
+    return (
+      <div className={className}>
+        {decisionBadge}
+        {/* HO-S8 AC①: CI(납품·"통과했다") ↔ Outcome(판단·"옳았다") 2열 분리 — "통과≠옳음" 명시. */}
+        <div className="mt-1.5 grid grid-cols-1 gap-2 text-[11.5px] sm:grid-cols-2 sm:gap-3">
+          {/* 좌: 납품(delivery 신호 — 기계 검증). S5(GitHub앱) PR·AC·위험 슬롯 자리. */}
+          <div className="space-y-0.5">
+            <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">{t('deliveryColLabel')}</p>
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-muted-foreground">
+              {ci !== null ? <CiSignal ci={ci} /> : null}
+              {trust !== null ? <TrustValue trust={trust} selfReportOnly={selfReportOnly} /> : null}
+              {/* S5: PR·AC·위험 → 여기에 추가(데이터 도착 시·지금은 미렌더) */}
+            </div>
+          </div>
+          {/* 우: 판단("옳았다 판정"). gate엔 정밀 hit_rate 없음 → 임시 예측만(억지 % X). */}
+          <div className="space-y-0.5">
+            <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">{t('outcomeColLabel')}</p>
+            <div className="text-muted-foreground">
+              {seedKey ? (
+                <Badge variant="chip" className="shrink-0">{t(seedKey)}</Badge>
+              ) : (
+                <span className="italic text-muted-foreground/80">{t('coldStartProvisional')}</span>
+              )}
+            </div>
+          </div>
+        </div>
+        {reason ? (
+          <p className="mt-1.5 text-[11.5px] text-muted-foreground">{t('reasonLabel')} · {reason}</p>
+        ) : null}
+      </div>
+    );
+  }
+
+  // ── State B · 부분증거: present-fact만 flowing 1줄(없는 건 빠짐·구분자 `·`는 양옆 항목 있을 때만)
+  const facts: React.ReactNode[] = [];
+  if (ci !== null) facts.push(<CiSignal ci={ci} />);
+  if (trust !== null) facts.push(<TrustValue trust={trust} selfReportOnly={selfReportOnly} />);
+  if (coldStartSeed && seedKey) facts.push(<Badge variant="chip" className="shrink-0">{t(seedKey)}</Badge>);
+
   return (
     <div className={className}>
-      {decision ? (
-        <Badge variant={DECISION_META[decision].variant} className="shrink-0">
-          <span aria-hidden className="mr-0.5">{DECISION_META[decision].mark}</span>
-          {t(DECISION_META[decision].labelKey)}
-        </Badge>
+      {decisionBadge}
+      {facts.length > 0 ? (
+        <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11.5px] text-muted-foreground">
+          {facts.map((node, i) => (
+            <Fragment key={i}>
+              {i > 0 ? <span aria-hidden className="text-muted-foreground/50">·</span> : null}
+              {node}
+            </Fragment>
+          ))}
+        </div>
       ) : null}
-
-      {/* HO-S8 AC①: CI(납품·"통과했다") ↔ Outcome(판단·"옳았다") 2열 분리 — "통과≠옳음" 명시. */}
-      <div className="mt-1.5 grid grid-cols-1 gap-2 text-[11.5px] sm:grid-cols-2 sm:gap-3">
-        {/* 좌: CI · 납품(delivery 신호 — 기계 검증). 신뢰도=clean_pass(delivery)·리뷰는 gate 미노출이라 제외. */}
-        <div className="space-y-0.5">
-          <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">{t('deliveryColLabel')}</p>
-          <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-muted-foreground">
-            <span>
-              {t('ciLabel')}:{' '}
-              {ci === 'pass' ? (
-                <span className="text-success">✓ {t('ciPass')}</span>
-              ) : ci === 'fail' ? (
-                <span className="text-destructive">✗ {t('ciFail')}</span>
-              ) : (
-                <span>? {t('ciUnknown')}</span>
-              )}
-            </span>
-            <span aria-hidden>·</span>
-            <span className="inline-flex items-center gap-1">
-              {t('trustLabel')}:{' '}
-              {trust === null ? (
-                <span className="italic text-muted-foreground">{t('trustScoreNoData')}</span>
-              ) : (
-                <span className="text-foreground">{t('trustScorePercent', { score: Math.round(trust * 100) })}</span>
-              )}
-              {selfReportOnly ? (
-                <span className="rounded bg-muted px-1 py-px text-[10px] text-muted-foreground">{t('selfReportTag')}</span>
-              ) : null}
-            </span>
-          </div>
-        </div>
-        {/* 우: Outcome · 판단("옳았다 판정"). gate엔 정밀 hit_rate 없음 → 임시 예측 / 누적 중만(억지 % X·hit_rate %는 TrustScoreCard). */}
-        <div className="space-y-0.5">
-          <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground/70">{t('outcomeColLabel')}</p>
-          <div className="text-muted-foreground">
-            {coldStartSeed ? (
-              <span className="inline-flex items-center gap-1.5">
-                <span className="italic">{t('coldStartProvisional')}</span>
-                {seedKey ? (
-                  <Badge variant="chip" className="shrink-0">{t(seedKey)}</Badge>
-                ) : null}
-              </span>
-            ) : (
-              <span className="italic text-muted-foreground/80">{t('outcomeAccumulating')}</span>
-            )}
-          </div>
-        </div>
-      </div>
-
-      {/* 사유 1줄(decision_basis·AC①②) */}
       {reason ? (
-        <p className="mt-1.5 text-[11.5px] text-muted-foreground">
-          {t('reasonLabel')} · {reason}
-        </p>
+        <p className="mt-1.5 text-[11.5px] text-muted-foreground">{t('reasonLabel')} · {reason}</p>
       ) : null}
     </div>
   );

--- a/apps/web/src/components/cage/gate-inbox.tsx
+++ b/apps/web/src/components/cage/gate-inbox.tsx
@@ -6,7 +6,7 @@ import { CheckCircle, XCircle, Ban, MoreHorizontal, AlertTriangle, Pause, PlayCi
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
-import { GateEvidence, gateNeedsAction, gateDecision } from '@/components/cage/gate-evidence';
+import { GateEvidence, gateNeedsAction, gateDecision, gateHasEvidence } from '@/components/cage/gate-evidence';
 import { GateLineContext } from '@/components/cage/gate-line-context';
 import { GateReassignModal } from '@/components/cage/gate-reassign-modal';
 import { GateOverrideModal } from '@/components/cage/gate-override-modal';
@@ -221,12 +221,15 @@ export function GateInbox({ memberId }: GateInboxProps) {
                     resolveName={(id) => memberNames[id] ?? id.slice(0, 6)}
                     className="mt-1"
                   />
-                  <div className="flex items-center gap-2 pt-1.5">
-                    <span className="shrink-0 text-[9px] font-medium uppercase tracking-wide text-muted-foreground/70">
-                      {t('lineEvidenceDivider')}
-                    </span>
-                    <span className="h-px flex-1 bg-border" />
-                  </div>
+                  {/* S3: 증거 없는 카드(State A)는 구분선도 숨김 — 빈 블록 위 헤더 방지(omit) */}
+                  {gateHasEvidence(gate) ? (
+                    <div className="flex items-center gap-2 pt-1.5">
+                      <span className="shrink-0 text-[9px] font-medium uppercase tracking-wide text-muted-foreground/70">
+                        {t('lineEvidenceDivider')}
+                      </span>
+                      <span className="h-px flex-1 bg-border" />
+                    </div>
+                  ) : null}
                 </>
               ) : null}
               {/* H1-S8: decision 배지 + CI/신뢰도 facts + 사유(read-only evidence) */}


### PR DESCRIPTION
## 한 줄
`gate-evidence.tsx`가 데이터 유무와 무관하게 2열 그리드를 **항상** 렌더 → 인박스 78카드가 `알 수 없음·검수 데이터 없음·판정 데이터 누적 중·자기보고` **회색 4줄로 도배**되던 문제 해소. 원칙 = **"없으면 비운다(omit, not placeholder)"** — 없는 사실은 라벨이 아니라 미표시.

> story `b0efa076` · epic `61511c71` · 핸드오프 doc `edg-real-s3-gate-card-state-hierarchy-handoff`(PRIMARY) · 디자인/가디언: 유나 홀름 · 오르테가군 nod 완료

## 변경 (FE 전용 · apps/web)
**1. `cage/gate-evidence.tsx` (핵심)**
- `gateHasEvidence(gate)` export 신설 — `ci_result(pass/fail)` · `trust(number)` · `cold_start_seed` · `decision_basis` 중 하나라도 있으면 `true`. 빈/cold-start 구분의 단일 소스.
- **3상태 분기:**
  - **A · 빈**(`!gateHasEvidence`): decision 배지 + `evidenceNonePrompt` 한 줄만 (`italic text-muted-foreground/60` recede). 2열·CI·신뢰도·outcome·자기보고 **전부 미표시**.
  - **B · 부분증거**: present-fact만 flowing 1줄(없는 건 빠짐 · **dangling `·` 금지** = 양옆 항목 있을 때만 구분자) + 사유 줄.
  - **C · 충실**(`(ci!==null||trust!==null) && coldStartSeed`): 납품 | 판단 **2열 그리드 복귀**(HO-S8 "통과≠옳음" 의미분리 보존 · 납품 컬럼 = S5 GitHub앱 PR·AC·위험 forward-compat 슬롯).
- CI 신호 lucide `CheckCircle`/`XCircle` 전환(텍스트 `✓/✗/?` 폐기 · `gate-line-context` 정합 · null이면 호출 자체 안 함).
- `self_report_only` **단독은 증거 아님** — trust 실값에 붙는 qualifier로만(빈카드 `자기보고` 도배 원인 제거).
- `reason = decision_basis ?? null`(기존 `?? auto_decision_reason` echo 폴백 제거 — 배지가 이미 표시 · 중복 클러터 제거).

**2. `cage/gate-inbox.tsx` (cross-file 소폭)**
- `gateHasEvidence` import → "근거 · 왜" 구분선을 `lineMap && gateHasEvidence(gate)`일 때만 렌더(State A 빈 블록 위 헤더 방지 · DRY).

**3. i18n (`messages/ko.json` · `en.json`)**
- `cage.evidenceNonePrompt` 추가 — ko `근거 데이터 없음 — 내용으로 직접 판단` / en `No evidence yet — review by content`. **parity 109/109**.

## 가드 (AC3 grep 대비)
- **null≠0 유지·강화** — trust `null` = 미표시(0%/빨강/낮음 환원 절대 X). 본 변경은 가장 강한 null≠0 = 아무 주장도 안 함.
- **신규 토큰 0 · 매직 hex 0** — 기존 토큰만(`success`/`destructive`/`muted-foreground`/`muted`/`border`).
- `outcomeAccumulating`("판정 데이터 누적 중")은 더 이상 렌더 안 됨(키 잔존·무해).

## 검증
- `tsc --noEmit` **0**
- `eslint` (gate-evidence·gate-inbox) **0**
- i18n cage parity **109/109**
- `next build` **✓**

⚠️ **스크린샷 (before/after · 양테마 · 390px)**: 빈/cold-start State A는 **default-off**라 라이브 픽셀은 머지→dev 배포 후 가디언 동석으로 진행(유나 mockup = 오르테가군 채널 첨부). PR 단계는 가디언 **코드리뷰** → 오르테가군 LGTM → 까심군 QA 순.

🤖 Generated with [Claude Code](https://claude.com/claude-code)