### PR TITLE
[E-DG-REAL][P0] fix: Dockerfile COPY scripts/ 통째 — backfill 스크립트 이미지 포함

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,11 +19,11 @@ COPY sprintable_mcp/ sprintable_mcp/
 COPY alembic.ini .
 COPY alembic/ alembic/
 COPY bootstrap.py .
-COPY scripts/migrate.sh scripts/migrate.sh
-# E-MEMBER-SSOT 검증/감사 스크립트 — migrate-dev 잡 클론(command 오버라이드)으로 in-VPC 실행
-# (scripts는 namespace 패키지 — `python -m scripts.<name>`로 /app 기준 실행)
-COPY scripts/verify_grant_only_story_assign.py scripts/verify_grant_only_story_assign.py
-COPY scripts/audit_apikey_member_anchor.py scripts/audit_apikey_member_anchor.py
+# scripts/ 통째 동봉 — migrate-dev 잡 클론(command override)으로 in-VPC 실행하는 운영/백필 스크립트.
+# (scripts는 namespace/regular 패키지 — `python -m scripts.<name>`로 /app 기준 실행.) 개별 COPY는
+# 신규 스크립트가 이미지에서 누락되는 함정이 있어(E-DG-REAL P0 backfill 사건: 파일 존재≠이미지 포함)
+# 통째 COPY로 future-proof.
+COPY scripts/ scripts/
 
 # non-root 사용자 생성 + /app 소유권 변경 (uv .venv 포함)
 RUN useradd --create-home --shell /bin/bash appuser \


### PR DESCRIPTION
## Summary
Fixes the backfill VPC job failure `No module named scripts.backfill_void_empty_merge_gates`. #1662 added the backfill script, but the Dockerfile copied `scripts/` file-by-file, so the new script never made it into the image.

## Story
[SID:1ff89d23-a443-479e-9771-fc86d9b33424]

## Root cause (single)
`backend/Dockerfile` copied scripts individually (`migrate.sh`, `verify_grant_only_story_assign.py`, `audit_apikey_member_anchor.py`). A new script in the repo is therefore absent from the image — file existence ≠ image inclusion. The sibling scripts already run via `python -m scripts.<name>` as a **namespace package** (no `__init__.py`), so that pattern is fine; the only gap was the missing COPY.

## Change
- `COPY scripts/migrate.sh …` + the two per-file script COPYs → **`COPY scripts/ scripts/`** (wholesale, future-proof). New ops/backfill scripts are picked up automatically. No `__init__.py` added — keeps the established namespace-package pattern that the sibling scripts already rely on.

## Scope
- The P0 substance guard (`merge_verdict_gate.py`, under `app/`) is **already live** — new empty shells are already eradicated. This change only unblocks running the backfill VPC job for the accumulated 78 shells.
- After merge → CB rebuild → re-run `sprintable-backfill-empty-gates` (dry-run → expect `no-PR shells: 78` → `--apply`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
