### PR TITLE
[E-DG-REAL][hygiene] refactor: 런타임 잡 스크립트 scripts/jobs/ 격리 (recon-surface 축소)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,11 +19,11 @@ COPY sprintable_mcp/ sprintable_mcp/
 COPY alembic.ini .
 COPY alembic/ alembic/
 COPY bootstrap.py .
-# scripts/ 통째 동봉 — migrate-dev 잡 클론(command override)으로 in-VPC 실행하는 운영/백필 스크립트.
-# (scripts는 namespace/regular 패키지 — `python -m scripts.<name>`로 /app 기준 실행.) 개별 COPY는
-# 신규 스크립트가 이미지에서 누락되는 함정이 있어(E-DG-REAL P0 backfill 사건: 파일 존재≠이미지 포함)
-# 통째 COPY로 future-proof.
-COPY scripts/ scripts/
+# 런타임 잡 스크립트만 동봉(scripts/jobs/) — migrate-dev 잡 클론(command override)으로 in-VPC 실행:
+# `python -m scripts.jobs.<name>`(/app 기준·namespace 패키지). 디렉토리 통째 COPY라 신규 잡 스크립트는
+# 자동 포함(개별 COPY 누락 함정 회피·E-DG-REAL P0 backfill 사건). deploy/setup/provision .sh·RUNBOOK 등
+# 비-런타임 스크립트는 scripts/ 루트에 남겨 런타임 이미지서 제외(recon-surface 최소화).
+COPY scripts/jobs/ scripts/jobs/
 
 # non-root 사용자 생성 + /app 소유권 변경 (uv .venv 포함)
 RUN useradd --create-home --shell /bin/bash appuser \

--- a/backend/scripts/jobs/audit_apikey_member_anchor.py
+++ b/backend/scripts/jobs/audit_apikey_member_anchor.py
@@ -10,7 +10,7 @@ dual-write 했고 0075는 type='agent' team_member만 members에 넣었으므로
 - 1건+ → 처리 필요: 정당 agent면 members 보정(또는 agent_anchor_sync 재실행), human/오용 key면 무효화.
 
 env: DATABASE_URL (백엔드 동일, cloud-sql-proxy/in-VPC 경유). 읽기 전용(조회만).
-실행: cd backend && DATABASE_URL=... python -m scripts.audit_apikey_member_anchor
+실행: cd backend && DATABASE_URL=... python -m scripts.jobs.audit_apikey_member_anchor
 """
 from __future__ import annotations
 

--- a/backend/scripts/jobs/backfill_void_empty_merge_gates.py
+++ b/backend/scripts/jobs/backfill_void_empty_merge_gates.py
@@ -11,8 +11,8 @@ held 등은 건드리지 않는다. 재실행 멱등(이미 voided면 status가 
 
 env: DATABASE_URL (백엔드 동일·cloud-sql-proxy/in-VPC). 쓰기 작업.
 실행:
-  cd backend && DATABASE_URL=... python -m scripts.backfill_void_empty_merge_gates            # dry-run
-  cd backend && DATABASE_URL=... python -m scripts.backfill_void_empty_merge_gates --apply     # 실제 void
+  cd backend && DATABASE_URL=... python -m scripts.jobs.backfill_void_empty_merge_gates            # dry-run
+  cd backend && DATABASE_URL=... python -m scripts.jobs.backfill_void_empty_merge_gates --apply     # 실제 void
 옵션: --org <uuid> 로 특정 org만.
 """
 from __future__ import annotations

--- a/backend/scripts/jobs/verify_grant_only_story_assign.py
+++ b/backend/scripts/jobs/verify_grant_only_story_assign.py
@@ -18,7 +18,7 @@
 
 실행:
   cd backend && DATABASE_URL=... JWT_SECRET=... BACKEND_URL=... ORG_ID=... PROJECT_ID=... \
-      python -m scripts.verify_grant_only_story_assign
+      python -m scripts.jobs.verify_grant_only_story_assign
 
 ⚠️ 0079 migrate-dev 적용 후 실행할 것. (0078만 적용 시 의도적으로 500이 나며 FAIL로 표시된다.)
 """


### PR DESCRIPTION
## Summary
Hygiene follow-up to #1664. `COPY scripts/ scripts/` (added to fix the backfill-script image-omission) also shipped `deploy_*.sh` / `setup_*.sh` / `provision_*.sh` / `RUNBOOK_prod_db_split.md` into the runtime image (incl. prod) — a small recon-surface (no value leak). This scopes the image to **runtime job scripts only**.

## Story
[SID:1ff89d23-a443-479e-9771-fc86d9b33424]

## Changes
- Move the 3 runtime job scripts (`backfill_void_empty_merge_gates`, `verify_grant_only_story_assign`, `audit_apikey_member_anchor`) into `backend/scripts/jobs/` (git mv — rename preserved).
- `Dockerfile`: `COPY scripts/ scripts/` → **`COPY scripts/jobs/ scripts/jobs/`**. Only runtime job scripts land in the image; deploy/setup/provision `.sh` + runbooks stay in `scripts/` root, excluded from the image. Directory-wholesale COPY keeps the future-proofing (new job scripts auto-included) while dropping the non-runtime recon surface.
- Invocation path: `python -m scripts.<name>` → `python -m scripts.jobs.<name>` (docstrings). Namespace package — no `__init__.py` needed (`-m scripts.jobs.<name>` resolution verified). No code callers (run via gcloud job clones).

## Operational note
The migrate-dev clone job command must be updated to `python -m scripts.jobs.backfill_void_empty_merge_gates` (path moved).

## Verification
- `python -m scripts.jobs.backfill_void_empty_merge_gates` resolves and runs (exits with `DATABASE_URL 미설정` guard when unset).
- This PR is **sid-tagged** (branch + `[SID:...]`), so its CI/merge doubles as the Phase S native-CI e2e (signed webhook on the now-deployed code → story `1ff89d23` CI verdict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
