### PR TITLE
[E-GHAPP][Bot-S] feat: per-org GitHub App 설치 foundation (OAuth+installation+토큰+status)

### DIFF
--- a/apps/web/src/app/api/integrations/github/connect/route.ts
+++ b/apps/web/src/app/api/integrations/github/connect/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import { fastapiCall } from '@/lib/fastapi-proxy';
+import { ApiErrors } from '@/lib/api-response';
+import { getServerSession } from '@/lib/db/server';
+
+// E-GHAPP Bot-S: GitHub App(봇) 설치 시작 — org admin이 여기로 오면 backend가 org-bound signed state로
+// GitHub App install URL을 발급하고, 그 URL로 302 리다이렉트한다(설치는 GitHub에서 진행). Route Handler
+// (Server Action 아님) — 외부 리다이렉트.
+export async function GET() {
+  const session = await getServerSession();
+  if (!session?.access_token) return ApiErrors.unauthorized();
+
+  try {
+    const result = await fastapiCall<{ install_url: string }>(
+      'GET',
+      '/api/v2/integrations/github/install/start',
+      session.access_token,
+    );
+    return NextResponse.redirect(result.install_url);
+  } catch (err: unknown) {
+    const status = err instanceof Error && err.message.includes('403') ? 403 : 400;
+    return NextResponse.json(
+      { data: null, error: { code: 'FAILED', message: String(err) }, meta: null },
+      { status },
+    );
+  }
+}

--- a/backend/alembic/versions/0133_github_installation.py
+++ b/backend/alembic/versions/0133_github_installation.py
@@ -39,10 +39,27 @@ def upgrade() -> None:
         "uq_github_installation_installation_id", "github_installation", ["installation_id"]
     )
     op.create_index("ix_github_installation_org_id", "github_installation", ["org_id"])
+    # RC fix: org_id → organizations FK(정합성·org 삭제 시 cascade).
+    op.create_foreign_key(
+        "fk_github_installation_org", "github_installation", "organizations",
+        ["org_id"], ["id"], ondelete="CASCADE",
+    )
+
+    # 설치 state nonce one-time consume store(replay 방어).
+    if "github_install_nonce" not in insp.get_table_names():
+        op.create_table(
+            "github_install_nonce",
+            sa.Column("jti", sa.String(length=64), primary_key=True),
+            sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        )
 
 
 def downgrade() -> None:
     bind = op.get_bind()
     insp = sa.inspect(bind)
+    if "github_install_nonce" in insp.get_table_names():
+        op.drop_table("github_install_nonce")
     if "github_installation" in insp.get_table_names():
         op.drop_table("github_installation")

--- a/backend/alembic/versions/0133_github_installation.py
+++ b/backend/alembic/versions/0133_github_installation.py
@@ -1,0 +1,48 @@
+"""E-GHAPP Bot-S: github_installation (per-org GitHub App 설치 매핑).
+
+org 가 GitHub App(봇) 설치 시 installation_id 매핑 저장. additive·신규 테이블·백필 불요(기존 org 는
+미설치=행 없음). installation access token 은 단명이라 저장 안 함(서비스가 app JWT 로 mint+캐시).
+
+⚠️baseline schema.sql 미변경(의도): post-0096 신규 테이블(0130~0132 동형). fresh-DB CI(baseline +
+alembic upgrade head)가 0133 적용. create_all 금지 — 모델↔마이그 매칭은 migrated-DB 로 검증.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+
+revision = "0133"
+down_revision = "0132"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if "github_installation" in insp.get_table_names():
+        return
+    op.create_table(
+        "github_installation",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("installation_id", sa.BigInteger(), nullable=False),
+        sa.Column("account_login", sa.String(length=255), nullable=True),
+        sa.Column("account_type", sa.String(length=32), nullable=True),
+        sa.Column("repository_selection", sa.String(length=16), nullable=True),
+        sa.Column("suspended_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_unique_constraint("uq_github_installation_org", "github_installation", ["org_id"])
+    op.create_unique_constraint(
+        "uq_github_installation_installation_id", "github_installation", ["installation_id"]
+    )
+    op.create_index("ix_github_installation_org_id", "github_installation", ["org_id"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if "github_installation" in insp.get_table_names():
+        op.drop_table("github_installation")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -113,6 +113,15 @@ class Settings(BaseSettings):
     # E-H1-S6: GitHub webhook(PR/CI verdict 캡처) HMAC 검증 시크릿. 미설정이면 webhook 거부(inert).
     github_webhook_secret: str = ""
 
+    # E-GHAPP Bot-S: GitHub App(봇) — per-org 설치/링킹. user-login OAuth(github_client_id/secret)와
+    # 별개 credential. private key 는 Secret Manager only(env 는 dev/local fallback·로그 노출 0).
+    github_app_id: str = ""                  # GitHub App numeric id (installation 토큰 API 경로용)
+    github_app_client_id: str = ""           # App client ID — JWT `iss`(현 권장)
+    github_app_slug: str = ""                # 설치 URL: github.com/apps/<slug>/installations/new
+    github_app_private_key: str = ""         # PEM. dev/local fallback only — prod 는 Secret Manager
+    github_app_private_key_secret: str = ""  # Secret Manager resource name (prod 우선 소스)
+    github_app_state_secret: str = ""        # 설치 callback state(CSRF+org+nonce+TTL) 서명 키
+
     # S-COMM-07: 에이전트 inbox webhook HMAC 검증 시크릿
     agent_inbox_webhook_secret: str = ""
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -117,6 +117,7 @@ class Settings(BaseSettings):
     # 별개 credential. private key 는 Secret Manager only(env 는 dev/local fallback·로그 노출 0).
     github_app_id: str = ""                  # GitHub App numeric id (installation 토큰 API 경로용)
     github_app_client_id: str = ""           # App client ID — JWT `iss`(현 권장)
+    github_app_client_secret: str = ""        # App OAuth client secret — install callback user-token 교환(소속 검증)
     github_app_slug: str = ""                # 설치 URL: github.com/apps/<slug>/installations/new
     github_app_private_key: str = ""         # PEM. dev/local fallback only — prod 는 Secret Manager
     github_app_private_key_secret: str = ""  # Secret Manager resource name (prod 우선 소스)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -53,7 +53,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -158,6 +158,7 @@ app.include_router(verdict_capture.router)
 app.include_router(trust_scores.router)
 app.include_router(hitl_config.router)
 app.include_router(gates.router)
+app.include_router(github_integration.router)
 app.include_router(gate_config.router)
 app.include_router(gate_config.org_router)
 app.include_router(gate_metrics.router)

--- a/backend/app/models/github_installation.py
+++ b/backend/app/models/github_installation.py
@@ -9,7 +9,7 @@ per-org 격리: 모든 read 는 org_id 스코프(anti-IDOR). 한 org 당 한 ins
 import uuid
 from datetime import datetime
 
-from sqlalchemy import BigInteger, DateTime, String, func
+from sqlalchemy import BigInteger, DateTime, ForeignKey, String, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -20,8 +20,14 @@ class GithubInstallation(Base):
     __tablename__ = "github_installation"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    # 한 org 당 한 설치(uq) — 재설치 시 같은 행 갱신(upsert by org_id).
-    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, unique=True, index=True)
+    # 한 org 당 한 설치(uq) — 재설치 시 같은 행 갱신(upsert by org_id). FK→organizations(RC: 정합성).
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
     # GitHub 가 발급하는 installation 식별자(토큰 mint API 경로 키). 전역 unique.
     installation_id: Mapped[int] = mapped_column(BigInteger, nullable=False, unique=True)
     account_login: Mapped[str | None] = mapped_column(String(255), nullable=True)
@@ -33,4 +39,18 @@ class GithubInstallation(Base):
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+
+class GithubInstallNonce(Base):
+    """설치 state nonce 서버측 store — **one-time consume**(replay 방어). install/start서 INSERT,
+    callback서 atomic DELETE(없으면 재사용/만료=거부). TTL 경과분은 주기/지연 정리(만료 체크로 거부됨).
+    """
+    __tablename__ = "github_install_nonce"
+
+    jti: Mapped[str] = mapped_column(String(64), primary_key=True)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
     )

--- a/backend/app/models/github_installation.py
+++ b/backend/app/models/github_installation.py
@@ -1,0 +1,36 @@
+"""E-GHAPP Bot-S: per-org GitHub App installation.
+
+org 가 GitHub App(봇)을 설치하면 GitHub 가 installation_id 를 발급한다. 이 행은 org_id ↔ installation
+매핑(설치 사실·account·repo 선택·suspend 상태)만 저장한다. **installation access token 은 단명(~1h)
+이라 여기 영속하지 않는다** — 서비스가 app JWT 로 그때그때 mint + 인메모리 캐시(보안모델 lock).
+
+per-org 격리: 모든 read 는 org_id 스코프(anti-IDOR). 한 org 당 한 installation(uq).
+"""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import BigInteger, DateTime, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class GithubInstallation(Base):
+    __tablename__ = "github_installation"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    # 한 org 당 한 설치(uq) — 재설치 시 같은 행 갱신(upsert by org_id).
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, unique=True, index=True)
+    # GitHub 가 발급하는 installation 식별자(토큰 mint API 경로 키). 전역 unique.
+    installation_id: Mapped[int] = mapped_column(BigInteger, nullable=False, unique=True)
+    account_login: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    account_type: Mapped[str | None] = mapped_column(String(32), nullable=True)  # Organization | User
+    repository_selection: Mapped[str | None] = mapped_column(String(16), nullable=True)  # all | selected
+    suspended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )

--- a/backend/app/routers/github_integration.py
+++ b/backend/app/routers/github_integration.py
@@ -1,0 +1,120 @@
+"""E-GHAPP Bot-S: GitHub App(봇) per-org 설치 — install start / callback / status.
+
+설치 flow: org admin이 FE "Connect GitHub" → (start) signed state로 GitHub App install URL → GitHub서
+설치 → (callback) state 검증 → github_installation 저장. 연결상태(status)는 org-scoped 조회.
+
+보안(lock): callback state=CSRF+org바인딩+nonce+TTL(verify_install_state)·전 read org_id 스코프
+(anti-IDOR)·installation access token은 여기 저장 안 함(서비스가 단명 mint+캐시).
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse, RedirectResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.models.github_installation import GithubInstallation
+from app.services.github_app import (
+    fetch_installation_metadata,
+    sign_install_state,
+    verify_install_state,
+)
+
+router = APIRouter(prefix="/api/v2/integrations/github", tags=["github-integration"])
+
+
+@router.get("/install/start")
+async def install_start(
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth: AuthContext = Depends(get_current_user),
+) -> JSONResponse:
+    """설치 URL 발급(org-bound signed state). FE Route Handler가 이 install_url로 302 리다이렉트."""
+    if not settings.github_app_slug:
+        return JSONResponse(status_code=503, content={"error": "github_app_not_configured"})
+    state = sign_install_state(org_id)
+    install_url = (
+        f"https://github.com/apps/{settings.github_app_slug}/installations/new?state={state}"
+    )
+    return JSONResponse(content={"install_url": install_url})
+
+
+@router.get("/install/callback")
+async def install_callback(
+    installation_id: int = Query(...),
+    state: str = Query(...),
+    setup_action: str | None = Query(default=None),
+    session: AsyncSession = Depends(get_db),
+) -> RedirectResponse:
+    """GitHub 설치 후 리다이렉트. state(CSRF+org+nonce+TTL) 검증 → github_installation upsert.
+
+    인증 credential = **signed state**(org 바인딩) — 위조/만료/replay면 거부. 성공/실패 모두 FE 설정으로 리다이렉트.
+    """
+    settings_url = f"{settings.frontend_url.rstrip('/')}/settings/integrations" if getattr(settings, "frontend_url", "") else "/settings/integrations"
+
+    org_id = verify_install_state(state)
+    if org_id is None:
+        return RedirectResponse(url=f"{settings_url}?github=invalid_state", status_code=302)
+
+    meta = await fetch_installation_metadata(installation_id) or {}
+
+    # org_id 기준 upsert(per-org 1설치·state가 org 바인딩이라 org A가 org B 행 못 씀=anti-IDOR).
+    existing = (
+        await session.execute(
+            select(GithubInstallation).where(GithubInstallation.org_id == org_id)
+        )
+    ).scalar_one_or_none()
+
+    if existing is not None:
+        existing.installation_id = installation_id
+        existing.account_login = meta.get("account_login")
+        existing.account_type = meta.get("account_type")
+        existing.repository_selection = meta.get("repository_selection")
+        existing.suspended_at = None
+    else:
+        session.add(
+            GithubInstallation(
+                org_id=org_id,
+                installation_id=installation_id,
+                account_login=meta.get("account_login"),
+                account_type=meta.get("account_type"),
+                repository_selection=meta.get("repository_selection"),
+            )
+        )
+    try:
+        await session.commit()
+    except Exception:
+        await session.rollback()
+        # installation_id가 다른 org에 이미 묶임(글로벌 uq) 등 → 충돌 거부(조용히 실패 리다이렉트).
+        return RedirectResponse(url=f"{settings_url}?github=conflict", status_code=302)
+
+    return RedirectResponse(url=f"{settings_url}?github=connected", status_code=302)
+
+
+@router.get("/status")
+async def github_status(
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """현 org의 GitHub App 연결상태(org_id 스코프·anti-IDOR). 미설치=graceful connected:false."""
+    inst = (
+        await session.execute(
+            select(GithubInstallation).where(GithubInstallation.org_id == org_id)
+        )
+    ).scalar_one_or_none()
+    if inst is None:
+        return JSONResponse(content={"connected": False})
+    return JSONResponse(
+        content={
+            "connected": True,
+            "account_login": inst.account_login,
+            "account_type": inst.account_type,
+            "repository_selection": inst.repository_selection,
+            "suspended": inst.suspended_at is not None,
+        }
+    )

--- a/backend/app/routers/github_integration.py
+++ b/backend/app/routers/github_integration.py
@@ -9,20 +9,23 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse, RedirectResponse
-from sqlalchemy import select
+from jose import jwt
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id, require_admin
 from app.dependencies.database import get_db
-from app.models.github_installation import GithubInstallation
+from app.models.github_installation import GithubInstallation, GithubInstallNonce
 from app.services.github_app import (
     fetch_installation_metadata,
     sign_install_state,
     verify_install_state,
+    verify_installation_owned,
 )
 
 router = APIRouter(prefix="/api/v2/integrations/github", tags=["github-integration"])
@@ -31,12 +34,23 @@ router = APIRouter(prefix="/api/v2/integrations/github", tags=["github-integrati
 @router.get("/install/start")
 async def install_start(
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth: AuthContext = Depends(get_current_user),
+    _auth: AuthContext = Depends(require_admin),  # ⭐org admin 전용(non-admin 거부).
+    session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """설치 URL 발급(org-bound signed state). FE Route Handler가 이 install_url로 302 리다이렉트."""
+    """설치 URL 발급(org-bound signed state + 서버측 nonce 등록). FE Route Handler가 install_url로 302."""
     if not settings.github_app_slug:
         return JSONResponse(status_code=503, content={"error": "github_app_not_configured"})
     state = sign_install_state(org_id)
+    # nonce 서버측 등록 — callback서 one-time consume(replay 방어).
+    claims = jwt.get_unverified_claims(state)
+    session.add(
+        GithubInstallNonce(
+            jti=claims["jti"],
+            org_id=org_id,
+            expires_at=datetime.fromtimestamp(int(claims["exp"]), tz=timezone.utc),
+        )
+    )
+    await session.commit()
     install_url = (
         f"https://github.com/apps/{settings.github_app_slug}/installations/new?state={state}"
     )
@@ -47,18 +61,35 @@ async def install_start(
 async def install_callback(
     installation_id: int = Query(...),
     state: str = Query(...),
+    code: str | None = Query(default=None),
     setup_action: str | None = Query(default=None),
     session: AsyncSession = Depends(get_db),
 ) -> RedirectResponse:
-    """GitHub 설치 후 리다이렉트. state(CSRF+org+nonce+TTL) 검증 → github_installation upsert.
-
-    인증 credential = **signed state**(org 바인딩) — 위조/만료/replay면 거부. 성공/실패 모두 FE 설정으로 리다이렉트.
+    """GitHub 설치 후 리다이렉트. state(CSRF+org+nonce+TTL) 검증 → nonce one-time consume → installation
+    소속 검증(anti-IDOR) → github_installation upsert. 위조/만료/replay/소속불일치 전부 거부.
     """
-    settings_url = f"{settings.frontend_url.rstrip('/')}/settings/integrations" if getattr(settings, "frontend_url", "") else "/settings/integrations"
+    settings_url = "/settings/integrations"
 
-    org_id = verify_install_state(state)
-    if org_id is None:
+    verified = verify_install_state(state)
+    if verified is None:
         return RedirectResponse(url=f"{settings_url}?github=invalid_state", status_code=302)
+    org_id, jti = verified
+
+    # one-time consume(replay 방어): atomic DELETE — 없으면(재사용/만료) 거부. consume은 즉시 커밋.
+    consumed = await session.execute(
+        delete(GithubInstallNonce).where(
+            GithubInstallNonce.jti == jti,
+            GithubInstallNonce.expires_at > datetime.now(timezone.utc),
+        )
+    )
+    await session.commit()
+    if consumed.rowcount == 0:
+        return RedirectResponse(url=f"{settings_url}?github=replay_or_expired", status_code=302)
+
+    # ⭐anti-IDOR: 콜백을 완료하는 user(org admin)가 이 installation 을 정당히 통제하는지 검증.
+    # 임의 installation_id 주입 차단. (code=user-authorization-during-install OAuth code·single-use.)
+    if not await verify_installation_owned(code or "", installation_id):
+        return RedirectResponse(url=f"{settings_url}?github=not_owned", status_code=302)
 
     meta = await fetch_installation_metadata(installation_id) or {}
 

--- a/backend/app/services/github_app.py
+++ b/backend/app/services/github_app.py
@@ -55,12 +55,15 @@ def _load_private_key() -> str | None:
             logger.error("Secret Manager private key fetch 실패: %s", exc)
             return None
 
-    if settings.github_app_private_key:
+    # env fallback 은 **dev/local 전용**. prod(app_env=production)는 Secret Manager strict — env 키 무시.
+    if settings.github_app_private_key and settings.app_env != "production":
         _private_key_cache = settings.github_app_private_key
         logger.info("github app private key loaded from env (dev/local fallback)")
         return _private_key_cache
+    if settings.github_app_private_key and settings.app_env == "production":
+        logger.error("prod 에서 env private key 무시 — Secret Manager(github_app_private_key_secret) 필요")
 
-    logger.warning("github app private key 미설정 — App 토큰 발급 불가(inert)")
+    logger.warning("github app private key 미설정/미해소 — App 토큰 발급 불가(inert)")
     return None
 
 
@@ -166,8 +169,11 @@ def sign_install_state(org_id: uuid.UUID) -> str:
     return jwt.encode(claims, settings.github_app_state_secret, algorithm="HS256")
 
 
-def verify_install_state(state: str) -> uuid.UUID | None:
-    """callback state 검증 → org_id. 서명불일치/만료/aud불일치/형식오류면 None(위조 거부)."""
+def verify_install_state(state: str) -> tuple[uuid.UUID, str] | None:
+    """callback state 검증 → (org_id, jti). 서명불일치/만료/aud불일치/jti없음/형식오류면 None(위조 거부).
+
+    jti(nonce)는 호출자가 서버측 one-time consume(재사용 거부)에 사용한다 — TTL(exp)은 여기서 거름.
+    """
     if not state or not settings.github_app_state_secret:
         return None
     try:
@@ -179,7 +185,46 @@ def verify_install_state(state: str) -> uuid.UUID | None:
         )
     except JWTError:
         return None
+    jti = claims.get("jti")
+    if not jti:
+        return None
     try:
-        return uuid.UUID(claims.get("org_id"))
+        return uuid.UUID(claims.get("org_id")), str(jti)
     except (ValueError, TypeError):
         return None
+
+
+async def verify_installation_owned(code: str, installation_id: int) -> bool:
+    """anti-IDOR 핵심: install callback OAuth `code`(user-authorization-during-install) → user token →
+    `GET /user/installations` 에 installation_id 포함 여부. = 콜백을 완료하는 user(org admin)가 그
+    installation 을 **정당히 통제**함을 증명. 임의 installation_id 주입(IDOR) 차단. 실패/불일치 → False.
+    """
+    if not code or not settings.github_app_client_id or not settings.github_app_client_secret:
+        return False
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            tok = await client.post(
+                "https://github.com/login/oauth/access_token",
+                headers={"Accept": "application/json"},
+                data={
+                    "client_id": settings.github_app_client_id,
+                    "client_secret": settings.github_app_client_secret,
+                    "code": code,
+                },
+            )
+            if tok.status_code != 200:
+                return False
+            user_token = tok.json().get("access_token")
+            if not user_token:
+                return False
+            insts = await client.get(
+                f"{_GITHUB_API}/user/installations",
+                headers={"Authorization": f"Bearer {user_token}", "Accept": "application/vnd.github+json"},
+            )
+            if insts.status_code != 200:
+                return False
+            ids = {i.get("id") for i in (insts.json().get("installations") or [])}
+            return installation_id in ids
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("installation ownership 검증 실패(installation=%s): %s", installation_id, exc)
+        return False

--- a/backend/app/services/github_app.py
+++ b/backend/app/services/github_app.py
@@ -1,0 +1,185 @@
+"""E-GHAPP Bot-S: GitHub App(봇) 토큰/state 보안 서비스 (산티아고 lock 보안모델).
+
+- App private key: **Secret Manager only**(prod) / env fallback(dev·local). 프로세스 메모리 캐시·로그 노출 0.
+- App JWT: RS256·`iss`=client ID·`iat`=now−60s·`exp`≤10분.
+- Installation token: `POST /app/installations/{id}/access_tokens`(App JWT Bearer)·~1h·**DB 영속 0**·
+  인메모리 캐시 + 만료 전 재mint.
+- 설치 callback state: CSRF nonce + org 바인딩 + TTL(서명·replay/위조 거부).
+
+⚠️ GitHub App API 시그니처(endpoint/claims)는 GitHub 공식 docs 기준(2026-06 PO 검증): iss=client ID·
+exp≤10m·POST access_tokens·token 1h. impl 변동 시 현행 docs 재확인.
+"""
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+
+import httpx
+from jose import JWTError, jwt
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_GITHUB_API = "https://api.github.com"
+_APP_JWT_TTL = 540  # 9분(<10분 상한·clock drift 여유)
+_TOKEN_REFRESH_SKEW = 300  # 만료 5분 전 재mint
+
+# private key 프로세스 캐시(로그/덤프 노출 회피 위해 모듈 전역·재fetch 최소화).
+_private_key_cache: str | None = None
+# installation token 인메모리 캐시: installation_id → (token, expiry_epoch). **DB 영속 안 함**.
+_token_cache: dict[int, tuple[str, float]] = {}
+
+
+def _load_private_key() -> str | None:
+    """App private key(PEM) 로드 — Secret Manager(prod) 우선, env(dev/local) fallback. 프로세스 캐시.
+
+    로그에 키를 절대 찍지 않는다(존재/소스만).
+    """
+    global _private_key_cache
+    if _private_key_cache:
+        return _private_key_cache
+
+    secret_name = settings.github_app_private_key_secret
+    if secret_name:
+        try:
+            from google.cloud import secretmanager  # lazy — prod 경로에서만.
+
+            client = secretmanager.SecretManagerServiceClient()
+            resp = client.access_secret_version(name=secret_name)
+            _private_key_cache = resp.payload.data.decode("utf-8")
+            logger.info("github app private key loaded from Secret Manager")
+            return _private_key_cache
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Secret Manager private key fetch 실패: %s", exc)
+            return None
+
+    if settings.github_app_private_key:
+        _private_key_cache = settings.github_app_private_key
+        logger.info("github app private key loaded from env (dev/local fallback)")
+        return _private_key_cache
+
+    logger.warning("github app private key 미설정 — App 토큰 발급 불가(inert)")
+    return None
+
+
+def build_app_jwt() -> str | None:
+    """App self-auth JWT(RS256·iss=client ID·exp≤10분). 키/클라이언트ID 없으면 None(inert)."""
+    key = _load_private_key()
+    if not key or not settings.github_app_client_id:
+        return None
+    now = int(time.time())
+    claims = {"iss": settings.github_app_client_id, "iat": now - 60, "exp": now + _APP_JWT_TTL}
+    try:
+        return jwt.encode(claims, key, algorithm="RS256")
+    except Exception as exc:  # noqa: BLE001
+        logger.error("app JWT 서명 실패: %s", exc)
+        return None
+
+
+async def get_installation_token(installation_id: int) -> str | None:
+    """installation access token(~1h) 발급/캐시. 만료 전이면 캐시 반환·아니면 재mint. **DB 영속 0**.
+
+    토큰/실패는 로그에 값 안 찍음. App JWT/키 없으면 None(inert·CI 이벤트 경로 무관).
+    """
+    cached = _token_cache.get(installation_id)
+    if cached and cached[1] - _TOKEN_REFRESH_SKEW > time.time():
+        return cached[0]
+
+    app_jwt = build_app_jwt()
+    if not app_jwt:
+        return None
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(
+                f"{_GITHUB_API}/app/installations/{installation_id}/access_tokens",
+                headers={
+                    "Authorization": f"Bearer {app_jwt}",
+                    "Accept": "application/vnd.github+json",
+                },
+            )
+        if resp.status_code not in (200, 201):
+            logger.warning("installation token mint HTTP %s (installation=%s)", resp.status_code, installation_id)
+            return None
+        data = resp.json()
+        token = data.get("token")
+        if not token:
+            return None
+        # expires_at ISO8601 → epoch. 파싱 실패 시 보수적 55분.
+        expiry = time.time() + 55 * 60
+        exp_str = data.get("expires_at")
+        if exp_str:
+            try:
+                from datetime import datetime
+
+                expiry = datetime.fromisoformat(exp_str.replace("Z", "+00:00")).timestamp()
+            except (ValueError, TypeError):
+                pass
+        _token_cache[installation_id] = (token, expiry)
+        return token
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("installation token mint 실패(installation=%s): %s", installation_id, exc)
+        return None
+
+
+async def fetch_installation_metadata(installation_id: int) -> dict | None:
+    """`GET /app/installations/{id}`(App JWT) — account login/type·repo selection. best-effort(None=graceful)."""
+    app_jwt = build_app_jwt()
+    if not app_jwt:
+        return None
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{_GITHUB_API}/app/installations/{installation_id}",
+                headers={"Authorization": f"Bearer {app_jwt}", "Accept": "application/vnd.github+json"},
+            )
+        if resp.status_code != 200:
+            return None
+        d = resp.json()
+        acct = d.get("account") or {}
+        return {
+            "account_login": acct.get("login"),
+            "account_type": acct.get("type"),
+            "repository_selection": d.get("repository_selection"),
+        }
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("installation metadata fetch 실패(installation=%s): %s", installation_id, exc)
+        return None
+
+
+# ── 설치 callback state (CSRF + org binding + nonce + TTL) ────────────────────────
+
+_STATE_TTL = 600  # 10분
+
+
+def sign_install_state(org_id: uuid.UUID) -> str:
+    """설치 시작 시 발급하는 state — org 바인딩 + nonce(jti·replay 방어) + TTL(exp). HS256 서명."""
+    now = int(time.time())
+    claims = {
+        "org_id": str(org_id),
+        "jti": uuid.uuid4().hex,  # nonce — replay 방어(callback 1회성 의미부여).
+        "iat": now,
+        "exp": now + _STATE_TTL,
+        "aud": "github-app-install",
+    }
+    return jwt.encode(claims, settings.github_app_state_secret, algorithm="HS256")
+
+
+def verify_install_state(state: str) -> uuid.UUID | None:
+    """callback state 검증 → org_id. 서명불일치/만료/aud불일치/형식오류면 None(위조 거부)."""
+    if not state or not settings.github_app_state_secret:
+        return None
+    try:
+        claims = jwt.decode(
+            state,
+            settings.github_app_state_secret,
+            algorithms=["HS256"],
+            audience="github-app-install",
+        )
+    except JWTError:
+        return None
+    try:
+        return uuid.UUID(claims.get("org_id"))
+    except (ValueError, TypeError):
+        return None

--- a/backend/tests/test_github_app_bot_s.py
+++ b/backend/tests/test_github_app_bot_s.py
@@ -1,0 +1,155 @@
+"""E-GHAPP Bot-S: GitHub App 보안모델 단위 (산티아고 lock 게이트 기준).
+
+커버: App JWT(iss=client ID·RS256·exp≤10m) · installation token(인메모리 캐시·재mint·DB영속0·미발급 graceful)
+· 설치 state(CSRF서명+org바인딩+nonce+TTL·위조/만료/replay 거부) · anti-IDOR(state→org 바인딩).
+GitHub App API 호출은 mock(실서버 0). 라이브(실 설치)는 App 등록 後 별도.
+"""
+from __future__ import annotations
+
+import time
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from jose import jwt
+
+from app.services import github_app as ga
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches():
+    ga._private_key_cache = None
+    ga._token_cache.clear()
+    yield
+    ga._private_key_cache = None
+    ga._token_cache.clear()
+
+
+# RS256 테스트용 키쌍(cryptography — python-jose[cryptography] 동봉).
+def _rsa_keypair():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    priv = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    pub = key.public_key().public_bytes(
+        serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+    ).decode()
+    return priv, pub
+
+
+# ── App JWT ───────────────────────────────────────────────────────────────────
+def test_app_jwt_claims_and_alg():
+    priv, pub = _rsa_keypair()
+    with patch.object(ga.settings, "github_app_private_key", priv), \
+         patch.object(ga.settings, "github_app_private_key_secret", ""), \
+         patch.object(ga.settings, "github_app_client_id", "Iv1.testclient"):
+        token = ga.build_app_jwt()
+    assert token
+    hdr = jwt.get_unverified_header(token)
+    assert hdr["alg"] == "RS256"                       # 게이트: RS256.
+    claims = jwt.decode(token, pub, algorithms=["RS256"], options={"verify_aud": False})
+    assert claims["iss"] == "Iv1.testclient"           # 게이트: iss=client ID.
+    assert claims["exp"] - claims["iat"] <= 600        # 게이트: exp≤10분.
+    assert claims["iat"] <= int(time.time())           # iat=now−60(clock drift).
+
+
+def test_app_jwt_none_without_key_or_clientid():
+    with patch.object(ga.settings, "github_app_private_key", ""), \
+         patch.object(ga.settings, "github_app_private_key_secret", ""):
+        assert ga.build_app_jwt() is None              # 키 없음 → inert.
+
+
+# ── installation token (캐시·미영속·graceful) ────────────────────────────────────
+@pytest.mark.anyio
+async def test_installation_token_cache_hit_no_mint():
+    ga._token_cache[123] = ("cached-tok", time.time() + 3600)  # 만료 여유.
+    with patch.object(ga, "build_app_jwt", return_value="appjwt") as bj, \
+         patch("httpx.AsyncClient.post", new=AsyncMock()) as post:
+        tok = await ga.get_installation_token(123)
+    assert tok == "cached-tok"
+    bj.assert_not_called(); post.assert_not_called()   # 캐시 히트 → mint 안 함.
+
+
+@pytest.mark.anyio
+async def test_installation_token_mint_and_cache():
+    resp = AsyncMock()
+    r = type("R", (), {"status_code": 201, "json": lambda self: {"token": "ghs_minted", "expires_at": "2099-01-01T00:00:00Z"}})()
+    with patch.object(ga, "build_app_jwt", return_value="appjwt"), \
+         patch("httpx.AsyncClient.post", new=AsyncMock(return_value=r)):
+        tok = await ga.get_installation_token(456)
+    assert tok == "ghs_minted"
+    assert 456 in ga._token_cache and ga._token_cache[456][0] == "ghs_minted"  # 인메모리 캐시(DB 아님).
+
+
+@pytest.mark.anyio
+async def test_installation_token_none_without_app_jwt():
+    with patch.object(ga, "build_app_jwt", return_value=None):
+        assert await ga.get_installation_token(789) is None   # App JWT 없음 → graceful None.
+
+
+# ── 설치 state (CSRF + org binding + nonce + TTL) ────────────────────────────────
+_SECRET = "test-state-secret-key"
+
+
+def test_state_roundtrip_org_binding():
+    org = uuid.uuid4()
+    with patch.object(ga.settings, "github_app_state_secret", _SECRET):
+        state = ga.sign_install_state(org)
+        assert ga.verify_install_state(state) == org      # org 바인딩 왕복.
+
+
+def test_state_tampered_rejected():
+    org = uuid.uuid4()
+    with patch.object(ga.settings, "github_app_state_secret", _SECRET):
+        state = ga.sign_install_state(org)
+        assert ga.verify_install_state(state[:-3] + "xxx") is None   # 변조 거부.
+        # 다른 시크릿 서명 → 거부.
+        forged = jwt.encode({"org_id": str(org), "aud": "github-app-install", "exp": int(time.time()) + 600}, "WRONG", algorithm="HS256")
+        assert ga.verify_install_state(forged) is None
+
+
+def test_state_expired_rejected():
+    org = uuid.uuid4()
+    with patch.object(ga.settings, "github_app_state_secret", _SECRET):
+        expired = jwt.encode(
+            {"org_id": str(org), "aud": "github-app-install", "iat": int(time.time()) - 1200, "exp": int(time.time()) - 600, "jti": uuid.uuid4().hex},
+            _SECRET, algorithm="HS256",
+        )
+        assert ga.verify_install_state(expired) is None     # TTL 만료 거부.
+
+
+def test_state_wrong_audience_rejected():
+    org = uuid.uuid4()
+    with patch.object(ga.settings, "github_app_state_secret", _SECRET):
+        wrong = jwt.encode(
+            {"org_id": str(org), "aud": "something-else", "exp": int(time.time()) + 600},
+            _SECRET, algorithm="HS256",
+        )
+        assert ga.verify_install_state(wrong) is None       # aud 불일치 거부.
+
+
+def test_state_unique_nonce_replay_marker():
+    org = uuid.uuid4()
+    with patch.object(ga.settings, "github_app_state_secret", _SECRET):
+        s1 = jwt.get_unverified_claims(ga.sign_install_state(org))
+        s2 = jwt.get_unverified_claims(ga.sign_install_state(org))
+    assert s1["jti"] != s2["jti"]                           # nonce 매 발급 고유(replay 방어 토대).
+
+
+def test_state_anti_idor_returns_bound_org_only():
+    """anti-IDOR 토대: state는 서명 시점 org에만 바인딩 — org A state 검증은 항상 A 반환(B로 위장 불가)."""
+    org_a, org_b = uuid.uuid4(), uuid.uuid4()
+    with patch.object(ga.settings, "github_app_state_secret", _SECRET):
+        state_a = ga.sign_install_state(org_a)
+        resolved = ga.verify_install_state(state_a)
+    assert resolved == org_a and resolved != org_b          # A의 state로 B 못 씀.

--- a/backend/tests/test_github_app_bot_s.py
+++ b/backend/tests/test_github_app_bot_s.py
@@ -105,7 +105,8 @@ def test_state_roundtrip_org_binding():
     org = uuid.uuid4()
     with patch.object(ga.settings, "github_app_state_secret", _SECRET):
         state = ga.sign_install_state(org)
-        assert ga.verify_install_state(state) == org      # org 바인딩 왕복.
+        result = ga.verify_install_state(state)
+        assert result is not None and result[0] == org and result[1]  # (org, jti) 왕복.
 
 
 def test_state_tampered_rejected():
@@ -152,4 +153,91 @@ def test_state_anti_idor_returns_bound_org_only():
     with patch.object(ga.settings, "github_app_state_secret", _SECRET):
         state_a = ga.sign_install_state(org_a)
         resolved = ga.verify_install_state(state_a)
-    assert resolved == org_a and resolved != org_b          # A의 state로 B 못 씀.
+    assert resolved is not None and resolved[0] == org_a and resolved[0] != org_b  # A의 state로 B 못 씀.
+
+
+# ── Santiago hold fixes: prod-env-refuse · no-jti · ownership · FK · replay ──────
+def test_prod_refuses_env_private_key():
+    """hold#2: prod(app_env=production)에선 env private key 무시(Secret Manager strict)."""
+    priv, _ = _rsa_keypair()
+    with patch.object(ga.settings, "app_env", "production"), \
+         patch.object(ga.settings, "github_app_private_key", priv), \
+         patch.object(ga.settings, "github_app_private_key_secret", ""):
+        assert ga._load_private_key() is None          # prod env fallback 차단.
+    # dev 는 env fallback 허용.
+    ga._private_key_cache = None
+    with patch.object(ga.settings, "app_env", "development"), \
+         patch.object(ga.settings, "github_app_private_key", priv), \
+         patch.object(ga.settings, "github_app_private_key_secret", ""):
+        assert ga._load_private_key() == priv
+
+
+def test_state_without_jti_rejected():
+    """hold#1: jti 없는 state 거부(서버측 consume 키 부재)."""
+    org = uuid.uuid4()
+    with patch.object(ga.settings, "github_app_state_secret", _SECRET):
+        no_jti = jwt.encode(
+            {"org_id": str(org), "aud": "github-app-install", "exp": int(time.time()) + 600},
+            _SECRET, algorithm="HS256",
+        )
+        assert ga.verify_install_state(no_jti) is None
+
+
+@pytest.mark.anyio
+async def test_installation_ownership_verify():
+    """hold#3: code→user token→/user/installations 에 installation_id 포함 시만 True(소속 검증)."""
+    class _Resp:
+        def __init__(self, status, payload):
+            self.status_code = status
+            self._p = payload
+        def json(self):
+            return self._p
+
+    async def _post_ok(url, **kw):
+        return _Resp(200, {"access_token": "user-tok"})
+
+    with patch.object(ga.settings, "github_app_client_id", "cid"), \
+         patch.object(ga.settings, "github_app_client_secret", "csec"):
+        # 포함 → True.
+        async def _get_match(url, **kw):
+            return _Resp(200, {"installations": [{"id": 555}, {"id": 999}]})
+        with patch("httpx.AsyncClient.post", new=AsyncMock(side_effect=_post_ok)), \
+             patch("httpx.AsyncClient.get", new=AsyncMock(side_effect=_get_match)):
+            assert await ga.verify_installation_owned("code", 555) is True
+        # 미포함 → False(IDOR 차단).
+        async def _get_nomatch(url, **kw):
+            return _Resp(200, {"installations": [{"id": 999}]})
+        with patch("httpx.AsyncClient.post", new=AsyncMock(side_effect=_post_ok)), \
+             patch("httpx.AsyncClient.get", new=AsyncMock(side_effect=_get_nomatch)):
+            assert await ga.verify_installation_owned("code", 555) is False
+    # code 없음 → False.
+    assert await ga.verify_installation_owned("", 555) is False
+
+
+def test_org_id_has_fk_to_organizations():
+    """hold#5: github_installation.org_id → organizations.id FK."""
+    from app.models.github_installation import GithubInstallation
+    targets = {str(fk.column) for fk in GithubInstallation.__table__.foreign_keys}
+    assert "organizations.id" in targets
+
+
+@pytest.mark.anyio
+async def test_callback_replay_rejected_when_nonce_already_consumed():
+    """hold#1(라우터): nonce 이미 소비(rowcount 0)면 callback 거부(replay_or_expired)."""
+    from unittest.mock import MagicMock
+    from app.routers.github_integration import install_callback
+
+    org = uuid.uuid4()
+    session = AsyncMock()
+    delete_result = MagicMock(); delete_result.rowcount = 0  # 이미 소비/만료.
+    session.execute = AsyncMock(return_value=delete_result)
+    session.commit = AsyncMock()
+
+    with patch.object(ga.settings, "github_app_state_secret", _SECRET), \
+         patch("app.services.github_app.settings.github_app_state_secret", _SECRET):
+        state = ga.sign_install_state(org)
+        # verify_installation_owned 는 호출 전에 거부돼야(consume 0).
+        with patch("app.routers.github_integration.verify_installation_owned", new=AsyncMock(return_value=True)) as owned:
+            resp = await install_callback(installation_id=1, state=state, code="x", setup_action="install", session=session)
+    assert resp.status_code == 302 and "replay_or_expired" in resp.headers["location"]
+    owned.assert_not_awaited()  # consume 실패 시 ownership 검증조차 안 감.


### PR DESCRIPTION
## Summary
E-GHAPP **Bot-S** (sub-phase 1, foundation): per-org GitHub App install OAuth flow + `github_installation` storage model + installation-token lifecycle + connection status. Implements Santiago's locked security model + PO-verified GitHub App API specs 1:1. Scope = install/model/token/status/anti-IDOR (Bot-M webhook/CI and Bot-L link model are out of scope).

## Story
[SID:e5c2bba6-6637-4702-9a2b-9720e087ca84]

## Gate-criteria mapping (Santiago hold + PO bar)
- **private key = Secret Manager only**: `_load_private_key()` — SM resource (prod) → process cache; env only as dev/local fallback; never logged (existence/source only). ✅ grep: no key in logs.
- **installation token DB-persist 0**: in-memory `_token_cache` (installation_id → token,expiry); re-mint before expiry; never stored in DB. ✅
- **JWT iss=client ID, RS256, exp≤10min**: `build_app_jwt()` — RS256, `iss=github_app_client_id`, `iat=now-60`, `exp=now+540s`. ✅ (test asserts).
- **state CSRF + org binding + nonce + TTL**: `sign/verify_install_state` — HS256 signed, `org_id` bound, `jti` nonce, `exp` TTL, `aud` check; tampered/expired/wrong-secret/wrong-aud → reject. ✅
- **anti-IDOR**: install upsert keyed by the state's signed `org_id` (org A's state can't write org B); `status` reads org_id-scoped only. ✅ (test: state resolves to bound org only).
- **`github_installation` additive migration, no create_all**: `0133` create_table with exists-guard; model↔migration column parity verified. ✅
- **no-regression**: user-login OAuth (`github_client_id/secret`) untouched (separate App credential); single webhook hook#640488969 untouched. ✅
- **status graceful**: uninstalled → `{connected:false}`; suspended flag exposed. ✅

## Files
- `config.py` (github_app_* fields) · `models/github_installation.py` · `alembic/0133` · `services/github_app.py` · `routers/github_integration.py` (+ main.py register) · FE `api/integrations/github/connect/route.ts` (slack-connect pattern) · `tests/test_github_app_bot_s.py` (11).

## Verification
- Unit: 11 pass (JWT claims/alg, token cache-hit-no-mint / mint+cache / graceful-none, state roundtrip/tamper/expired/aud/nonce/anti-IDOR). `CI=1` green.
- main app loads with routes registered; model↔migration column parity confirmed.
- **App registration + private key → Secret Manager = live-verification stage (선생님 lane)**. Code/tests built before, per plan.
- GitHub App API signatures per PO's 2026-06 GitHub-docs verification (iss=client ID, exp≤10m, POST access_tokens, 1h token); re-verify at any impl drift.

## Out of scope (later sub-phases)
Bot-M: per-install App webhook + integrate hook#640488969 + native CI via installation token (fills the Phase S native-pull slot). Bot-L: PR↔story link model + resolver chain + in-app link UI + close-on-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
