### PR TITLE
[E-GHAPP][Bot-M.1] feat: native CI = installation 토큰 statusCheckRollup (PAT fallback 제거)

### DIFF
--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -19,8 +19,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.dependencies.database import get_db
+from app.models.github_installation import GithubInstallation
 from app.models.pm import Story
 from app.routers.cron import CRON_SECRET, _err, _ok, verify_cron
+from app.services.github_app import get_installation_token
 from app.services.verdict_capture import (
     capture_pr_ci_verdict,
     capture_review_verdict,
@@ -259,14 +261,22 @@ async def github_webhook(
     if not merged and ci_conclusion is None:
         return _ok({"skipped_reason": "no_actionable_signal", "recorded": []})
 
-    # S5 Phase S: native CI 채움. story가 SID로 confident-resolve된(위 AC②/③ 통과) 상태에서, 이벤트에
-    # CI 결론이 없으면(대표적으로 머지 이벤트) PR head SHA의 statusCheckRollup을 1콜 pull해 게이트에 실 CI를
-    # 주입한다(CI unknown 박멸). 이벤트가 이미 CI 결론을 실었으면 그 값을 유지. 토큰 없음/미완료/실패는
-    # None=무영향(미링크 CI unknown 유지). confident-link(exact PK)에서만 동작(여긴 SID resolve 後라 충족).
+    # Bot-M.1: native CI 채움 — **installation 토큰**(per-org)으로 statusCheckRollup pull(⚠️PAT fallback 없음).
+    # story SID confident-resolve 後 이벤트에 CI 결론이 없으면(머지 이벤트), org→github_installation→
+    # get_installation_token 해소(org-scope·토큰 mint는 org resolve 後만) → rollup으로 ci_result 주입.
+    # App 미설치 org/토큰 없음/실패/미완료 → ci_conclusion None 유지(graceful unknown·success 승격 금지).
     if ci_conclusion is None and head_sha and repo:
-        native_ci = await fetch_status_check_rollup(repo, head_sha)
-        if native_ci is not None:
-            ci_conclusion = native_ci
+        inst = (
+            await session.execute(
+                select(GithubInstallation).where(GithubInstallation.org_id == story.org_id)
+            )
+        ).scalar_one_or_none()
+        if inst is not None:
+            inst_token = await get_installation_token(inst.installation_id)
+            if inst_token:
+                native_ci = await fetch_status_check_rollup(repo, head_sha, inst_token)
+                if native_ci is not None:
+                    ci_conclusion = native_ci
 
     try:
         result = await capture_pr_ci_verdict(

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -265,18 +265,29 @@ async def github_webhook(
     # story SID confident-resolve 後 이벤트에 CI 결론이 없으면(머지 이벤트), org→github_installation→
     # get_installation_token 해소(org-scope·토큰 mint는 org resolve 後만) → rollup으로 ci_result 주입.
     # App 미설치 org/토큰 없음/실패/미완료 → ci_conclusion None 유지(graceful unknown·success 승격 금지).
+    # native_ci unknown(reason) 계약(산티아고 lock): native CI 시도 시 응답에 {state, reason} 노출.
+    native_ci_state: str | None = None  # 'success'|'failure'|'unknown' (시도했을 때만 set)
+    native_ci_reason: str | None = None
     if ci_conclusion is None and head_sha and repo:
         inst = (
             await session.execute(
                 select(GithubInstallation).where(GithubInstallation.org_id == story.org_id)
             )
         ).scalar_one_or_none()
-        if inst is not None:
+        if inst is None:
+            native_ci_state, native_ci_reason = "unknown", "no_installation"        # org 미연결.
+        else:
             inst_token = await get_installation_token(inst.installation_id)
-            if inst_token:
-                native_ci = await fetch_status_check_rollup(repo, head_sha, inst_token)
-                if native_ci is not None:
-                    ci_conclusion = native_ci
+            if not inst_token:
+                native_ci_state, native_ci_reason = "unknown", "no_installation_token"  # 토큰 mint 실패.
+            else:
+                ci, reason = await fetch_status_check_rollup(repo, head_sha, inst_token)
+                if ci is not None:
+                    ci_conclusion = ci
+                    native_ci_state, native_ci_reason = ci, None                    # resolved.
+                else:
+                    native_ci_state, native_ci_reason = "unknown", reason           # pending/api_error/not_found.
+        logger.info("native CI story=%s state=%s reason=%s", story_id, native_ci_state, native_ci_reason)
 
     try:
         result = await capture_pr_ci_verdict(
@@ -289,6 +300,9 @@ async def github_webhook(
             ci_result=ci_conclusion,  # AC④: failure→capture가 fail로 채점.
         )
         await session.commit()
+        if native_ci_state is not None:
+            # native CI 결과/사유를 응답에 노출(라이브 진단·'unknown 0' 검증·관측). DB schema 무변경.
+            result = {**result, "native_ci": {"state": native_ci_state, "reason": native_ci_reason}}
         return _ok(result)
     except Exception as exc:
         logger.exception("github webhook verdict capture failed: %s", exc)

--- a/backend/app/services/verdict_capture.py
+++ b/backend/app/services/verdict_capture.py
@@ -99,16 +99,19 @@ async def fetch_pr_review_rounds(repo: str, pr_number: int) -> int:
         return 0
 
 
-async def fetch_status_check_rollup(repo: str, head_sha: str, token: str) -> str | None:
+async def fetch_status_check_rollup(repo: str, head_sha: str, token: str) -> tuple[str | None, str]:
     """E-GHAPP Bot-M.1: PR head commit의 집계 CI 상태를 GitHub GraphQL statusCheckRollup으로 조회.
 
-    반환 'success'|'failure'|None. **token(installation access token)**으로 호출 — token 없음/형식오류/
-    실패/미완료(PENDING 등)면 None(무영향·CI unknown 유지). ⚠️**PAT(GITHUB_TOKEN) fallback 없음**(Bot-M.1
-    게이트): 토큰은 호출자가 org→installation→get_installation_token 으로 해소해 전달한다(org-scope 보장).
-    capture_pr_ci_verdict가 success→pass·그 외→fail로 채점하므로 success/failure만 의미한다.
+    반환 **(ci, reason)** — ci ∈ 'success'|'failure'|None, reason은 unknown(ci=None) 사유 진단용:
+      ('success', 'resolved') · ('failure', 'resolved') · (None, 'pending') · (None, 'api_error') ·
+      (None, 'not_found') · (None, 'no_token'/'bad_input').
+    **token(installation access token)**으로 호출. ⚠️**PAT fallback 없음**(Bot-M.1 게이트). reason은 라이브
+    App/권한 진단 + 'unknown 0' 검증용(success 승격 절대 금지). 토큰은 호출자가 org→installation 해소해 전달.
     """
-    if not token or not repo or "/" not in repo or not head_sha:
-        return None
+    if not token:
+        return None, "no_token"
+    if not repo or "/" not in repo or not head_sha:
+        return None, "bad_input"
     owner, name = repo.split("/", 1)
     query = (
         "query($owner:String!,$name:String!,$oid:GitObjectID!){"
@@ -127,18 +130,21 @@ async def fetch_status_check_rollup(repo: str, head_sha: str, token: str) -> str
                 json={"query": query, "variables": {"owner": owner, "name": name, "oid": head_sha}},
             )
         if resp.status_code != 200:
-            return None
+            return None, "api_error"
         data = resp.json()
         obj = (((data.get("data") or {}).get("repository") or {}).get("object")) or {}
-        state = (obj.get("statusCheckRollup") or {}).get("state") if isinstance(obj, dict) else None
+        rollup = (obj.get("statusCheckRollup") if isinstance(obj, dict) else None) or {}
+        state = rollup.get("state")
         if state == "SUCCESS":
-            return "success"
+            return "success", "resolved"
         if state in ("FAILURE", "ERROR"):
-            return "failure"
-        return None  # PENDING/EXPECTED/None → 미완료, 채우지 않음(CI unknown 유지).
+            return "failure", "resolved"
+        if state in ("PENDING", "EXPECTED"):
+            return None, "pending"          # 미완료 — 채우지 않음(success 승격 금지).
+        return None, "not_found"            # rollup 없음(체크 미설정/SHA 불일치 등).
     except Exception as exc:  # noqa: BLE001
         logger.warning("statusCheckRollup fetch failed repo=%s sha=%s: %s", repo, head_sha, exc)
-        return None
+        return None, "api_error"
 
 
 async def capture_pr_ci_verdict(

--- a/backend/app/services/verdict_capture.py
+++ b/backend/app/services/verdict_capture.py
@@ -99,14 +99,15 @@ async def fetch_pr_review_rounds(repo: str, pr_number: int) -> int:
         return 0
 
 
-async def fetch_status_check_rollup(repo: str, head_sha: str) -> str | None:
-    """E-DG-REAL S5 Phase S: PR head commit의 집계 CI 상태를 GitHub GraphQL statusCheckRollup으로 조회.
+async def fetch_status_check_rollup(repo: str, head_sha: str, token: str) -> str | None:
+    """E-GHAPP Bot-M.1: PR head commit의 집계 CI 상태를 GitHub GraphQL statusCheckRollup으로 조회.
 
-    반환 'success'|'failure'|None. GITHUB_TOKEN 없거나 실패/미완료(PENDING 등)면 None(무영향·CI unknown 유지).
-    capture_pr_ci_verdict가 success→pass·그 외→fail로 채점하므로 success/failure만 의미한다. 한 콜로 PR의
-    모든 체크 집계 상태를 얻어, CI 이벤트가 없는 머지 이벤트에서도 게이트에 실 CI를 채운다.
+    반환 'success'|'failure'|None. **token(installation access token)**으로 호출 — token 없음/형식오류/
+    실패/미완료(PENDING 등)면 None(무영향·CI unknown 유지). ⚠️**PAT(GITHUB_TOKEN) fallback 없음**(Bot-M.1
+    게이트): 토큰은 호출자가 org→installation→get_installation_token 으로 해소해 전달한다(org-scope 보장).
+    capture_pr_ci_verdict가 success→pass·그 외→fail로 채점하므로 success/failure만 의미한다.
     """
-    if not GITHUB_TOKEN or not repo or "/" not in repo or not head_sha:
+    if not token or not repo or "/" not in repo or not head_sha:
         return None
     owner, name = repo.split("/", 1)
     query = (
@@ -120,7 +121,7 @@ async def fetch_status_check_rollup(repo: str, head_sha: str) -> str | None:
             resp = await client.post(
                 "https://api.github.com/graphql",
                 headers={
-                    "Authorization": f"Bearer {GITHUB_TOKEN}",
+                    "Authorization": f"Bearer {token}",
                     "Accept": "application/vnd.github+json",
                 },
                 json={"query": query, "variables": {"owner": owner, "name": name, "oid": head_sha}},

--- a/backend/tests/test_h1_s6_github_webhook.py
+++ b/backend/tests/test_h1_s6_github_webhook.py
@@ -74,7 +74,7 @@ def _sign(body: bytes) -> str:
     return "sha256=" + hmac.new(_SECRET.encode(), body, hashlib.sha256).hexdigest()
 
 
-async def _post(payload: dict, *, event: str, story=..., sign=True):
+async def _post(payload: dict, *, event: str, story=..., sign=True, installation=...):
     from app.dependencies.database import get_db
     from app.main import app
 
@@ -83,7 +83,13 @@ async def _post(payload: dict, *, event: str, story=..., sign=True):
     result.scalar_one_or_none.return_value = (
         MagicMock(org_id=ORG_ID) if story is ... else story
     )
-    session.execute = AsyncMock(return_value=result)
+    if installation is ...:
+        session.execute = AsyncMock(return_value=result)  # 모든 query 동일(기존 동작).
+    else:
+        # 1st execute=story select, 2nd=installation select(native CI 블록), 이후 installation 반복.
+        inst_result = MagicMock()
+        inst_result.scalar_one_or_none.return_value = installation
+        session.execute = AsyncMock(side_effect=[result, inst_result, inst_result, inst_result])
 
     async def override_db():
         yield session
@@ -210,69 +216,112 @@ async def test_workflow_run_branch_sid_links_capture():
 from app.services import verdict_capture as _svc  # noqa: E402
 
 
+def _native_ci(resp):
+    """응답 envelope-tolerant native_ci 추출({state, reason} or None)."""
+    body = resp.json()
+    data = body.get("data", body) if isinstance(body, dict) else {}
+    return (data or {}).get("native_ci")
+
+
+_MERGE_PAYLOAD = {"action": "closed", "repository": {"full_name": "moonklabs/sprintable"},
+                  "pull_request": {"number": 12, "merged": True, "title": f"feat [SID:{STORY_ID}]",
+                                   "head": {"sha": "deadbeef"}}}
+
+
 @pytest.mark.anyio
 async def test_native_ci_fills_on_merge_when_no_conclusion():
-    """머지 이벤트(ci 결론 없음)+confident SID → statusCheckRollup pull로 ci_result 채움."""
-    payload = {"action": "closed", "repository": {"full_name": "moonklabs/sprintable"},
-               "pull_request": {"number": 12, "merged": True, "title": f"feat [SID:{STORY_ID}]",
-                                "head": {"sha": "deadbeef"}}}
+    """머지 이벤트(ci 결론 없음)+confident SID → installation 토큰 rollup으로 ci 채움·native_ci.state=success."""
     with patch.object(mod, "get_installation_token", new=AsyncMock(return_value="inst-tok")), \
          patch.object(mod, "fetch_status_check_rollup",
-                      new=AsyncMock(return_value="success")) as roll, \
+                      new=AsyncMock(return_value=("success", "resolved"))) as roll, \
          patch.object(mod, "capture_pr_ci_verdict",
                       new=AsyncMock(return_value={"recorded": ["pr", "ci"], "skipped_reason": None})) as cap:
-        resp = await _post(payload, event="pull_request")
+        resp = await _post(_MERGE_PAYLOAD, event="pull_request")
     assert resp.status_code == 200
-    # Bot-M.1: installation 토큰으로 호출(PAT 아님). _post 의 mock session 이 installation 행도 반환.
-    roll.assert_awaited_once_with("moonklabs/sprintable", "deadbeef", "inst-tok")
-    assert cap.await_args.kwargs["ci_result"] == "success"  # native CI가 채움.
+    roll.assert_awaited_once_with("moonklabs/sprintable", "deadbeef", "inst-tok")  # installation 토큰(PAT 아님).
+    assert cap.await_args.kwargs["ci_result"] == "success"
+    assert _native_ci(resp) == {"state": "success", "reason": None}
 
 
 @pytest.mark.anyio
-async def test_native_ci_graceful_when_no_installation_token():
-    """Bot-M.1: installation 토큰 없음(미설치/실패) → rollup 미호출·ci unknown 유지(graceful·PAT 승격 0)."""
-    payload = {"action": "closed", "repository": {"full_name": "moonklabs/sprintable"},
-               "pull_request": {"number": 12, "merged": True, "title": f"feat [SID:{STORY_ID}]",
-                                "head": {"sha": "deadbeef"}}}
-    with patch.object(mod, "get_installation_token", new=AsyncMock(return_value=None)), \
-         patch.object(mod, "fetch_status_check_rollup", new=AsyncMock(return_value="success")) as roll, \
+async def test_native_ci_unknown_reason_no_installation():
+    """unknown(reason): org 미연결(installation 행 없음) → native_ci.reason=no_installation·토큰 mint 안 함."""
+    with patch.object(mod, "get_installation_token", new=AsyncMock()) as tok, \
+         patch.object(mod, "fetch_status_check_rollup", new=AsyncMock()) as roll, \
          patch.object(mod, "capture_pr_ci_verdict",
                       new=AsyncMock(return_value={"recorded": ["pr"], "skipped_reason": None})) as cap:
-        resp = await _post(payload, event="pull_request")
+        resp = await _post(_MERGE_PAYLOAD, event="pull_request", installation=None)
     assert resp.status_code == 200
-    roll.assert_not_awaited()                          # 토큰 없으면 rollup 안 함.
-    assert cap.await_args.kwargs["ci_result"] is None  # ci unknown 유지(success 승격 금지).
+    tok.assert_not_called(); roll.assert_not_called()          # 미연결 → 토큰/rollup 안 함.
+    assert cap.await_args.kwargs["ci_result"] is None
+    assert _native_ci(resp) == {"state": "unknown", "reason": "no_installation"}
+
+
+@pytest.mark.anyio
+async def test_native_ci_unknown_reason_no_token():
+    """unknown(reason): installation 있으나 토큰 mint 실패 → reason=no_installation_token·rollup 안 함."""
+    with patch.object(mod, "get_installation_token", new=AsyncMock(return_value=None)), \
+         patch.object(mod, "fetch_status_check_rollup", new=AsyncMock()) as roll, \
+         patch.object(mod, "capture_pr_ci_verdict",
+                      new=AsyncMock(return_value={"recorded": ["pr"], "skipped_reason": None})) as cap:
+        resp = await _post(_MERGE_PAYLOAD, event="pull_request")
+    assert resp.status_code == 200
+    roll.assert_not_called()
+    assert cap.await_args.kwargs["ci_result"] is None
+    assert _native_ci(resp) == {"state": "unknown", "reason": "no_installation_token"}
+
+
+@pytest.mark.anyio
+async def test_native_ci_unknown_reason_pending():
+    """unknown(reason): rollup 미완료(pending) → reason=pending·ci unknown 유지(success 승격 0)."""
+    with patch.object(mod, "get_installation_token", new=AsyncMock(return_value="inst-tok")), \
+         patch.object(mod, "fetch_status_check_rollup", new=AsyncMock(return_value=(None, "pending"))), \
+         patch.object(mod, "capture_pr_ci_verdict",
+                      new=AsyncMock(return_value={"recorded": ["pr"], "skipped_reason": None})) as cap:
+        resp = await _post(_MERGE_PAYLOAD, event="pull_request")
+    assert resp.status_code == 200
+    assert cap.await_args.kwargs["ci_result"] is None
+    assert _native_ci(resp) == {"state": "unknown", "reason": "pending"}
 
 
 @pytest.mark.anyio
 async def test_native_ci_not_pulled_when_event_has_conclusion():
-    """이벤트가 이미 CI 결론을 실으면 native pull 안 함(그 결론 유지)."""
+    """이벤트가 이미 CI 결론을 실으면 native pull 안 함(그 결론 유지·native_ci 미노출)."""
     payload = {"repository": {"full_name": "o/r"},
                "workflow_run": {"conclusion": "failure", "head_sha": "sha1",
                                 "head_branch": f"feat-[SID:{STORY_ID}]", "pull_requests": [{"number": 7}]}}
-    with patch.object(mod, "fetch_status_check_rollup", new=AsyncMock(return_value="success")) as roll, \
+    with patch.object(mod, "fetch_status_check_rollup", new=AsyncMock(return_value=("success", "resolved"))) as roll, \
          patch.object(mod, "capture_pr_ci_verdict",
                       new=AsyncMock(return_value={"recorded": ["ci"], "skipped_reason": None})) as cap:
         resp = await _post(payload, event="workflow_run")
     assert resp.status_code == 200
     roll.assert_not_awaited()  # 이벤트 결론 있으면 native 미호출.
-    assert cap.await_args.kwargs["ci_result"] == "failure"  # 이벤트 결론 유지.
+    assert cap.await_args.kwargs["ci_result"] == "failure"
+    assert _native_ci(resp) is None  # native 시도 안 함 → 미노출.
 
 
 @pytest.mark.anyio
-async def test_fetch_status_check_rollup_normalizes():
-    """statusCheckRollup.state → success|failure|None 정규화. **token 인자**(PAT 아님)·token 없으면 None."""
-    # token 없음 → 즉시 None(콜 안 함·Bot-M.1 PAT fallback 제거).
-    assert await _svc.fetch_status_check_rollup("o/r", "sha", "") is None
+async def test_fetch_status_check_rollup_returns_ci_and_reason():
+    """statusCheckRollup → (ci, reason). token 없음=(None,no_token)·state별 매핑·PAT 인자 없음."""
+    assert await _svc.fetch_status_check_rollup("o/r", "sha", "") == (None, "no_token")
+    assert await _svc.fetch_status_check_rollup("badrepo", "sha", "tok") == (None, "bad_input")
 
-    def _resp(state):
+    def _resp(status, state):
         r = MagicMock()
-        r.status_code = 200
-        r.json.return_value = {"data": {"repository": {"object": {"statusCheckRollup": {"state": state}}}}}
+        r.status_code = status
+        r.json.return_value = {"data": {"repository": {"object": {"statusCheckRollup": ({"state": state} if state else None)}}}}
         return r
 
     import httpx
-    for state, expected in [("SUCCESS", "success"), ("FAILURE", "failure"),
-                            ("ERROR", "failure"), ("PENDING", None), ("EXPECTED", None)]:
-        with patch.object(httpx.AsyncClient, "post", new=AsyncMock(return_value=_resp(state))):
+    cases = [
+        (200, "SUCCESS", ("success", "resolved")),
+        (200, "FAILURE", ("failure", "resolved")),
+        (200, "ERROR", ("failure", "resolved")),
+        (200, "PENDING", (None, "pending")),
+        (200, "EXPECTED", (None, "pending")),
+        (200, None, (None, "not_found")),
+        (500, "SUCCESS", (None, "api_error")),
+    ]
+    for status, state, expected in cases:
+        with patch.object(httpx.AsyncClient, "post", new=AsyncMock(return_value=_resp(status, state))):
             assert await _svc.fetch_status_check_rollup("moonklabs/sprintable", "abc", "inst-tok") == expected

--- a/backend/tests/test_h1_s6_github_webhook.py
+++ b/backend/tests/test_h1_s6_github_webhook.py
@@ -216,14 +216,32 @@ async def test_native_ci_fills_on_merge_when_no_conclusion():
     payload = {"action": "closed", "repository": {"full_name": "moonklabs/sprintable"},
                "pull_request": {"number": 12, "merged": True, "title": f"feat [SID:{STORY_ID}]",
                                 "head": {"sha": "deadbeef"}}}
-    with patch.object(mod, "fetch_status_check_rollup",
+    with patch.object(mod, "get_installation_token", new=AsyncMock(return_value="inst-tok")), \
+         patch.object(mod, "fetch_status_check_rollup",
                       new=AsyncMock(return_value="success")) as roll, \
          patch.object(mod, "capture_pr_ci_verdict",
                       new=AsyncMock(return_value={"recorded": ["pr", "ci"], "skipped_reason": None})) as cap:
         resp = await _post(payload, event="pull_request")
     assert resp.status_code == 200
-    roll.assert_awaited_once_with("moonklabs/sprintable", "deadbeef")  # head SHA로 1콜.
+    # Bot-M.1: installation 토큰으로 호출(PAT 아님). _post 의 mock session 이 installation 행도 반환.
+    roll.assert_awaited_once_with("moonklabs/sprintable", "deadbeef", "inst-tok")
     assert cap.await_args.kwargs["ci_result"] == "success"  # native CI가 채움.
+
+
+@pytest.mark.anyio
+async def test_native_ci_graceful_when_no_installation_token():
+    """Bot-M.1: installation 토큰 없음(미설치/실패) → rollup 미호출·ci unknown 유지(graceful·PAT 승격 0)."""
+    payload = {"action": "closed", "repository": {"full_name": "moonklabs/sprintable"},
+               "pull_request": {"number": 12, "merged": True, "title": f"feat [SID:{STORY_ID}]",
+                                "head": {"sha": "deadbeef"}}}
+    with patch.object(mod, "get_installation_token", new=AsyncMock(return_value=None)), \
+         patch.object(mod, "fetch_status_check_rollup", new=AsyncMock(return_value="success")) as roll, \
+         patch.object(mod, "capture_pr_ci_verdict",
+                      new=AsyncMock(return_value={"recorded": ["pr"], "skipped_reason": None})) as cap:
+        resp = await _post(payload, event="pull_request")
+    assert resp.status_code == 200
+    roll.assert_not_awaited()                          # 토큰 없으면 rollup 안 함.
+    assert cap.await_args.kwargs["ci_result"] is None  # ci unknown 유지(success 승격 금지).
 
 
 @pytest.mark.anyio
@@ -243,10 +261,9 @@ async def test_native_ci_not_pulled_when_event_has_conclusion():
 
 @pytest.mark.anyio
 async def test_fetch_status_check_rollup_normalizes():
-    """statusCheckRollup.state → success|failure|None 정규화. 토큰 없으면 None(무영향)."""
-    # 토큰 없음 → 즉시 None(콜 안 함).
-    with patch.object(_svc, "GITHUB_TOKEN", ""):
-        assert await _svc.fetch_status_check_rollup("o/r", "sha") is None
+    """statusCheckRollup.state → success|failure|None 정규화. **token 인자**(PAT 아님)·token 없으면 None."""
+    # token 없음 → 즉시 None(콜 안 함·Bot-M.1 PAT fallback 제거).
+    assert await _svc.fetch_status_check_rollup("o/r", "sha", "") is None
 
     def _resp(state):
         r = MagicMock()
@@ -257,6 +274,5 @@ async def test_fetch_status_check_rollup_normalizes():
     import httpx
     for state, expected in [("SUCCESS", "success"), ("FAILURE", "failure"),
                             ("ERROR", "failure"), ("PENDING", None), ("EXPECTED", None)]:
-        with patch.object(_svc, "GITHUB_TOKEN", "tok"), \
-             patch.object(httpx.AsyncClient, "post", new=AsyncMock(return_value=_resp(state))):
-            assert await _svc.fetch_status_check_rollup("moonklabs/sprintable", "abc") == expected
+        with patch.object(httpx.AsyncClient, "post", new=AsyncMock(return_value=_resp(state))):
+            assert await _svc.fetch_status_check_rollup("moonklabs/sprintable", "abc", "inst-tok") == expected


### PR DESCRIPTION
## Summary
E-GHAPP **Bot-M.1** (native CI first): fill gate verdicts with real CI via `statusCheckRollup` using the **per-org installation token** from Bot-S — no PAT. Connected orgs' PR/CI flow real evidence into gates (`CI unknown` → resolved).

## Story
[SID:38a0c220-5b11-45a2-a52e-06b76feb4243]

## Santiago gate-criteria mapping
- **`fetch_status_check_rollup(..., token)` tokenized**: takes a `token` param; returns None if no token. ✅
- **PAT / `GITHUB_TOKEN` fallback completely removed** from this path. ✅ (legacy `fetch_pr_review_rounds` PAT usage untouched/unrelated.)
- **`org_id → github_installation.installation_id → get_installation_token()` path**: handler resolves the org's installation, mints the token, calls rollup. ✅
- **token mint only after org resolve**: `get_installation_token` is called only inside the `org_id`-scoped installation lookup. ✅
- **installation token DB-persist 0**: Bot-S principle (in-memory cache, per-installation). ✅
- **CI verdict success/failure/pending/unknown; no success-promotion**: rollup → success/failure; pending/error/no-token/no-install → `ci_conclusion` stays None (`unknown`, never promoted to success). ✅
- **Phase S verdict-inject path no-regression**: same injection point; only the token source changed. ✅
- **App-unregistered org graceful**: no installation row → token mint skipped → `ci` stays unknown. ✅

## Files
- `services/verdict_capture.py` (`fetch_status_check_rollup` tokenized) · `routers/verdict_capture.py` (resolve installation token in the native-CI block; imports `GithubInstallation` + `get_installation_token`) · `tests/test_h1_s6_github_webhook.py` (native-fill via installation token, no-token graceful, rollup tokenize, event-conclusion no-regression).

## Verification
- `CI=1` verdict/gate suite green (60 passed, 2 skipped). app loads.
- Live (post-App-registration): a connected org's sid-tagged PR merge → gate gets real `ci=pass` via the installation token (not PAT); unregistered org → unknown (graceful).

## Out of scope (Bot-M.2)
Per-install App webhook + integrate hook#640488969 + dedup + separate `github_app_webhook_secret` (HMAC-before-parse, org-scope-after-resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
