### PR TITLE
[E-GHAPP][Bot-M.2] feat: 웹훅 통합 ingress (dual-secret·dedup·per-install routing)

### DIFF
--- a/backend/alembic/versions/0134_github_webhook_delivery.py
+++ b/backend/alembic/versions/0134_github_webhook_delivery.py
@@ -1,0 +1,50 @@
+"""E-GHAPP Bot-M.2: github_webhook_delivery (웹훅 멱등 dedup store).
+
+App/legacy 웹훅 통합 ingress의 멱등 — uq(source, delivery_id). HMAC 검증 後 insert + business
+side-effect + status 갱신을 동일 트랜잭션으로(실패=rollback→GitHub retry 보존). 중복=2xx no-op.
+additive·신규 테이블·백필 불요(과거 delivery 추적 불요).
+
+⚠️baseline schema.sql 미변경(의도): post-0096 신규 테이블(0130~0133 동형). fresh-DB CI(baseline +
+alembic upgrade head)가 0134 적용. create_all 금지 — 모델↔마이그 매칭은 migrated-DB 로 검증.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+
+revision = "0134"
+down_revision = "0133"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if "github_webhook_delivery" in insp.get_table_names():
+        return
+    op.create_table(
+        "github_webhook_delivery",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("source", sa.String(length=16), nullable=False),       # legacy | app
+        sa.Column("delivery_id", sa.String(length=128), nullable=False),  # X-GitHub-Delivery
+        sa.Column("event", sa.String(length=64), nullable=True),
+        sa.Column("installation_id", sa.BigInteger(), nullable=True),
+        sa.Column("org_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="received"),
+        sa.Column("error_code", sa.String(length=64), nullable=True),
+        sa.Column("error_message", sa.String(length=512), nullable=True),
+        sa.Column("received_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("processed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    # 멱등 핵심: 같은 (source, delivery_id) 중복 → 2xx no-op. source 다르면 별도(spoof 방지).
+    op.create_unique_constraint(
+        "uq_github_webhook_delivery_src_delivery", "github_webhook_delivery", ["source", "delivery_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "uq_github_webhook_delivery_src_delivery", "github_webhook_delivery", type_="unique"
+    )
+    op.drop_table("github_webhook_delivery")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -122,6 +122,9 @@ class Settings(BaseSettings):
     github_app_private_key: str = ""         # PEM. dev/local fallback only — prod 는 Secret Manager
     github_app_private_key_secret: str = ""  # Secret Manager resource name (prod 우선 소스)
     github_app_state_secret: str = ""        # 설치 callback state(CSRF+org+nonce+TTL) 서명 키
+    # Bot-M.2: App 웹훅 HMAC 시크릿(legacy github_webhook_secret 과 분리). 미설정=app-source inert.
+    # github_webhook_secret 과 동일값(misconfig)이면 app inert + startup warning(legacy 무회귀 보존).
+    github_app_webhook_secret: str = ""
 
     # S-COMM-07: 에이전트 inbox webhook HMAC 검증 시크릿
     agent_inbox_webhook_secret: str = ""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,7 +19,10 @@ _logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     from app.core.database import engine
+    from app.routers.verdict_capture import warn_if_webhook_secret_misconfigured
     from app.services.pg_pubsub import listen_loop
+
+    warn_if_webhook_secret_misconfigured()  # Bot-M.2 P3: 웹훅 secret misconfig 를 트래픽 前 경고.
     task = asyncio.create_task(listen_loop())
     # E-L2 S5: 휴리스틱 트리거 워커는 default-off — 명시 활성화 시에만 task 생성(AC①).
     l2_task = None

--- a/backend/app/models/github_installation.py
+++ b/backend/app/models/github_installation.py
@@ -9,7 +9,7 @@ per-org 격리: 모든 read 는 org_id 스코프(anti-IDOR). 한 org 당 한 ins
 import uuid
 from datetime import datetime
 
-from sqlalchemy import BigInteger, DateTime, ForeignKey, String, func
+from sqlalchemy import BigInteger, DateTime, ForeignKey, String, UniqueConstraint, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -54,3 +54,29 @@ class GithubInstallNonce(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
+
+
+class GithubWebhookDelivery(Base):
+    """Bot-M.2: 웹훅 delivery 멱등 store — **uq(source, delivery_id)**. HMAC 검증 後 dedup insert +
+    business side-effect + status 갱신을 **동일 트랜잭션**으로 묶는다 — 실패=rollback→GitHub retry 보존
+    (delivery row 도 함께 rollback돼 retry 안 막음). 중복충돌=savepoint rollback + 2xx no-op.
+    status: received | processed | ignored | failed | duplicate. (retention/cleanup 은 후속 hygiene.)
+    """
+    __tablename__ = "github_webhook_delivery"
+    __table_args__ = (
+        UniqueConstraint("source", "delivery_id", name="uq_github_webhook_delivery_src_delivery"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    source: Mapped[str] = mapped_column(String(16), nullable=False)        # legacy | app (검증된 secret서 결정)
+    delivery_id: Mapped[str] = mapped_column(String(128), nullable=False)  # X-GitHub-Delivery
+    event: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    installation_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    org_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="received")
+    error_code: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    error_message: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    received_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    processed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -195,6 +195,19 @@ def _resolve_webhook_source(raw_body: bytes, signature_header: str | None) -> st
     return None
 
 
+def warn_if_webhook_secret_misconfigured() -> None:
+    """Startup config 검증(P3): app webhook secret 이 legacy 와 동일(misconfig)이면 **트래픽 前** 경고.
+    app inert 로 동작해 보안 위험은 없으나 운영자가 secret 을 분리하도록 알린다. ⚠️secret 정보 미노출.
+    """
+    legacy = settings.github_webhook_secret
+    app_s = settings.github_app_webhook_secret
+    if app_s and legacy and app_s == legacy:
+        logger.warning(
+            "[startup] github_app_webhook_secret 가 github_webhook_secret 와 동일(misconfig) → "
+            "App webhook inert(legacy 만 동작). 별도 App webhook secret 설정 필요."
+        )
+
+
 def _normalize_ci(conclusion: str | None) -> str | None:
     """CI provider 결론 → success|failure|cancelled. 미완료(in_progress/queued 등)면 None(skip)."""
     if not conclusion:
@@ -267,37 +280,44 @@ async def _process_webhook_event(
     if story_id is None:
         return {"skipped_reason": "no_sid_tag", "recorded": []}, "ignored"
 
-    # AC③: story 없으면 skip.
-    story = (
-        await session.execute(
-            select(Story).where(Story.id == story_id, Story.deleted_at.is_(None))
-        )
-    ).scalar_one_or_none()
-    if story is None:
-        return {"skipped_reason": "story_not_found", "recorded": []}, "ignored"
-
     installation: GithubInstallation | None = None
     if source == "app":
-        # app: org 는 **installation DB resolve 로만**(payload 추론 금지). suspended → side-effect 금지.
+        # ⭐app: **installation→org resolve 를 story 조회보다 먼저**(org context 확립 前 전역 story 조회 금지
+        # — 미등록 installation 으로 story 존재 oracle 차단). org 는 installation DB 로만(payload 추론 금지).
         if installation_id is None:
             return {"skipped_reason": "no_installation_id", "recorded": []}, "ignored"
         installation = (
             await session.execute(
                 select(GithubInstallation).where(
                     GithubInstallation.installation_id == installation_id,
-                    GithubInstallation.suspended_at.is_(None),
+                    GithubInstallation.suspended_at.is_(None),  # suspended → side-effect 금지.
                 )
             )
         ).scalar_one_or_none()
         if installation is None:
-            # 미등록/suspended installation → graceful ignore(business side-effect 0·delivery status만).
+            # 미등록/suspended installation → story 조회 없이 graceful ignore(side-effect 0·oracle 0).
             return {"skipped_reason": "installation_not_registered_or_suspended", "recorded": []}, "ignored"
         org_id = installation.org_id
         delivery.org_id = org_id
-        if story.org_id != org_id:
-            # SID story 가 resolved org 소속이 아님 → cross-org spoof 차단(anti-IDOR).
-            return {"skipped_reason": "story_org_mismatch", "recorded": []}, "ignored"
+        # story 를 **resolved org 로 스코프** 조회 — cross-org 차단 + 존재 oracle 차단(타 org story 는 not_found).
+        story = (
+            await session.execute(
+                select(Story).where(
+                    Story.id == story_id, Story.org_id == org_id, Story.deleted_at.is_(None)
+                )
+            )
+        ).scalar_one_or_none()
+        if story is None:
+            return {"skipped_reason": "story_not_found", "recorded": []}, "ignored"
     else:
+        # legacy: 기존 동작 — Story.id 전역 조회 → org = story.org_id.
+        story = (
+            await session.execute(
+                select(Story).where(Story.id == story_id, Story.deleted_at.is_(None))
+            )
+        ).scalar_one_or_none()
+        if story is None:
+            return {"skipped_reason": "story_not_found", "recorded": []}, "ignored"
         org_id = story.org_id
         delivery.org_id = org_id
 

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -9,17 +9,20 @@ import hashlib
 import hmac
 import json
 import logging
+import re
 import uuid
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Header, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.dependencies.database import get_db
-from app.models.github_installation import GithubInstallation
+from app.models.github_installation import GithubInstallation, GithubWebhookDelivery
 from app.models.pm import Story
 from app.routers.cron import CRON_SECRET, _err, _ok, verify_cron
 from app.services.github_app import get_installation_token
@@ -153,13 +156,43 @@ _CI_FAILURE = frozenset({"failure", "timed_out", "action_required", "stale", "st
 _CI_CANCELLED = frozenset({"cancelled", "canceled", "skipped", "neutral"})
 
 
-def _verify_github_signature(raw_body: bytes, signature_header: str | None) -> bool:
-    """X-Hub-Signature-256 HMAC-SHA256 검증. 시크릿 미설정/서명 불일치면 False."""
-    secret = settings.github_webhook_secret
-    if not secret or not signature_header:
+_SIG_RE = re.compile(r"^sha256=[0-9a-f]{64}$")  # X-Hub-Signature-256 = 'sha256=<hex64>' 형식만 허용.
+_app_inert_warned = False  # equal-secret misconfig warning 1회만(로그 스팸 방지).
+
+
+def _hmac_match(raw_body: bytes, signature_header: str | None, secret: str) -> bool:
+    """X-Hub-Signature-256 HMAC-SHA256 full-string constant-time 비교. secret 빈값/header 없음/형식
+    오류(bare hex·wrong prefix)면 False. ⚠️secret/signature 원문은 로그에 남기지 않는다."""
+    if not secret or not signature_header or not _SIG_RE.match(signature_header):
         return False
-    expected = hmac.new(secret.encode(), raw_body, hashlib.sha256).hexdigest()
-    return hmac.compare_digest(expected, signature_header.removeprefix("sha256="))
+    expected = "sha256=" + hmac.new(secret.encode(), raw_body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature_header)
+
+
+def _resolve_webhook_source(raw_body: bytes, signature_header: str | None) -> str | None:
+    """source 를 **검증된 secret match 로만** 결정(untrusted payload 금지). 'app'|'legacy'|None.
+
+    - app secret(`github_app_webhook_secret`) 미설정 → app inert(app 검증 skip)·legacy 만.
+    - app secret == legacy secret(둘 다 non-empty·misconfig) → **app inert + startup warning**(legacy
+      무회귀 보존·silent app-우선 금지).
+    - 그 외 → app 먼저 검증(match=app)·아니면 legacy(match=legacy)·둘 다 실패=None.
+    """
+    global _app_inert_warned
+    legacy_secret = settings.github_webhook_secret
+    app_secret = settings.github_app_webhook_secret
+    equal_misconfig = bool(app_secret) and bool(legacy_secret) and app_secret == legacy_secret
+    if equal_misconfig and not _app_inert_warned:
+        logger.warning(
+            "github_app_webhook_secret 가 github_webhook_secret 와 동일(misconfig) → app webhook inert; "
+            "legacy 경로만 동작. 별도 App webhook secret 설정 필요."  # ⚠️secret 값/길이/해시 미노출.
+        )
+        _app_inert_warned = True
+    app_inert = (not app_secret) or equal_misconfig
+    if not app_inert and _hmac_match(raw_body, signature_header, app_secret):
+        return "app"
+    if _hmac_match(raw_body, signature_header, legacy_secret):
+        return "legacy"
+    return None
 
 
 def _normalize_ci(conclusion: str | None) -> str | None:
@@ -219,31 +252,20 @@ def _extract_pr_ci(event: str, payload: dict) -> tuple[int, bool, str | None, st
     return pr_number, merged, ci_conclusion, head_sha
 
 
-@router.post("/github-webhook")
-async def github_webhook(
-    request: Request,
-    session: AsyncSession = Depends(get_db),
-    x_github_event: str | None = Header(default=None),
-    x_hub_signature_256: str | None = Header(default=None),
-) -> JSONResponse:
-    """GitHub PR/CI webhook → [SID:uuid] 파싱 → capture_pr_ci_verdict (H1-S6 실 runtime 경로).
+async def _process_webhook_event(
+    session: AsyncSession, source: str, event: str, payload: dict, installation_id: int | None,
+    delivery: GithubWebhookDelivery,
+) -> tuple[dict, str]:
+    """검증·dedup 통과한 이벤트 처리(legacy/app 라우팅). (result, status) 반환. status∈processed|ignored.
 
-    HMAC 검증 후 PR merge(=pr verdict)·CI 완료(=ci verdict)를 기록한다. SID 없거나(AC②) story
-    없으면(AC③) skip. duplicate webhook은 uq(participation,source) upsert로 멱등(AC⑤).
+    org resolve: **legacy**=story.org_id(기존). **app**=installation.id→github_installation(suspended 제외)
+    →그 org_id만(anti-IDOR·payload/repo-owner 추론 금지)·story 가 그 org 소속 아니면 거부(cross-org spoof).
+    native CI(Bot-M.1)=installation 토큰. **caller 가 동일 트랜잭션으로 commit/rollback**(여기선 commit 안 함).
     """
-    raw = await request.body()
-    if not _verify_github_signature(raw, x_hub_signature_256):
-        return _err("INVALID_SIGNATURE", "GitHub webhook 서명 검증 실패", 401)
-
-    try:
-        payload = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
-        return _err("INVALID_PAYLOAD", "JSON 파싱 실패", 400)
-
     # AC②: [SID:] 태그 없으면 skip(거짓기록 금지).
     story_id = next((sid for t in _candidate_texts(payload) if (sid := parse_story_id(t))), None)
     if story_id is None:
-        return _ok({"skipped_reason": "no_sid_tag", "recorded": []})
+        return {"skipped_reason": "no_sid_tag", "recorded": []}, "ignored"
 
     # AC③: story 없으면 skip.
     story = (
@@ -252,58 +274,147 @@ async def github_webhook(
         )
     ).scalar_one_or_none()
     if story is None:
-        return _ok({"skipped_reason": "story_not_found", "recorded": []})
+        return {"skipped_reason": "story_not_found", "recorded": []}, "ignored"
+
+    installation: GithubInstallation | None = None
+    if source == "app":
+        # app: org 는 **installation DB resolve 로만**(payload 추론 금지). suspended → side-effect 금지.
+        if installation_id is None:
+            return {"skipped_reason": "no_installation_id", "recorded": []}, "ignored"
+        installation = (
+            await session.execute(
+                select(GithubInstallation).where(
+                    GithubInstallation.installation_id == installation_id,
+                    GithubInstallation.suspended_at.is_(None),
+                )
+            )
+        ).scalar_one_or_none()
+        if installation is None:
+            # 미등록/suspended installation → graceful ignore(business side-effect 0·delivery status만).
+            return {"skipped_reason": "installation_not_registered_or_suspended", "recorded": []}, "ignored"
+        org_id = installation.org_id
+        delivery.org_id = org_id
+        if story.org_id != org_id:
+            # SID story 가 resolved org 소속이 아님 → cross-org spoof 차단(anti-IDOR).
+            return {"skipped_reason": "story_org_mismatch", "recorded": []}, "ignored"
+    else:
+        org_id = story.org_id
+        delivery.org_id = org_id
 
     repo = (payload.get("repository") or {}).get("full_name") or ""
-    pr_number, merged, ci_conclusion, head_sha = _extract_pr_ci(x_github_event or "", payload)
+    pr_number, merged, ci_conclusion, head_sha = _extract_pr_ci(event, payload)
 
     # 행동 가능한 신호(머지 또는 CI 완료)가 없으면 skip(in_progress 등).
     if not merged and ci_conclusion is None:
-        return _ok({"skipped_reason": "no_actionable_signal", "recorded": []})
+        return {"skipped_reason": "no_actionable_signal", "recorded": []}, "ignored"
 
-    # Bot-M.1: native CI 채움 — **installation 토큰**(per-org)으로 statusCheckRollup pull(⚠️PAT fallback 없음).
-    # story SID confident-resolve 後 이벤트에 CI 결론이 없으면(머지 이벤트), org→github_installation→
-    # get_installation_token 해소(org-scope·토큰 mint는 org resolve 後만) → rollup으로 ci_result 주입.
-    # App 미설치 org/토큰 없음/실패/미완료 → ci_conclusion None 유지(graceful unknown·success 승격 금지).
-    # native_ci unknown(reason) 계약(산티아고 lock): native CI 시도 시 응답에 {state, reason} 노출.
-    native_ci_state: str | None = None  # 'success'|'failure'|'unknown' (시도했을 때만 set)
+    # Bot-M.1: native CI 채움 — **installation 토큰**(org-scope)으로 statusCheckRollup pull(⚠️PAT fallback 없음).
+    # app source 는 위서 resolve된 installation(suspended 제외) 직접 사용·legacy 는 org→installation resolve.
+    # 토큰 없음/미설치/실패/미완료 → ci unknown 유지(graceful·success 승격 금지). unknown(reason) 계약.
+    native_ci_state: str | None = None
     native_ci_reason: str | None = None
     if ci_conclusion is None and head_sha and repo:
-        inst = (
-            await session.execute(
-                select(GithubInstallation).where(GithubInstallation.org_id == story.org_id)
-            )
-        ).scalar_one_or_none()
-        if inst is None:
-            native_ci_state, native_ci_reason = "unknown", "no_installation"        # org 미연결.
+        inst_for_ci = installation
+        if inst_for_ci is None:  # legacy: org→installation resolve(suspended 제외).
+            inst_for_ci = (
+                await session.execute(
+                    select(GithubInstallation).where(
+                        GithubInstallation.org_id == org_id,
+                        GithubInstallation.suspended_at.is_(None),
+                    )
+                )
+            ).scalar_one_or_none()
+        if inst_for_ci is None:
+            native_ci_state, native_ci_reason = "unknown", "no_installation"
         else:
-            inst_token = await get_installation_token(inst.installation_id)
+            inst_token = await get_installation_token(inst_for_ci.installation_id)
             if not inst_token:
-                native_ci_state, native_ci_reason = "unknown", "no_installation_token"  # 토큰 mint 실패.
+                native_ci_state, native_ci_reason = "unknown", "no_installation_token"
             else:
                 ci, reason = await fetch_status_check_rollup(repo, head_sha, inst_token)
                 if ci is not None:
                     ci_conclusion = ci
-                    native_ci_state, native_ci_reason = ci, None                    # resolved.
+                    native_ci_state, native_ci_reason = ci, None
                 else:
-                    native_ci_state, native_ci_reason = "unknown", reason           # pending/api_error/not_found.
-        logger.info("native CI story=%s state=%s reason=%s", story_id, native_ci_state, native_ci_reason)
-
-    try:
-        result = await capture_pr_ci_verdict(
-            session=session,
-            org_id=story.org_id,
-            story_id=story_id,
-            pr_number=pr_number,
-            repo=repo,
-            merged=merged,
-            ci_result=ci_conclusion,  # AC④: failure→capture가 fail로 채점.
+                    native_ci_state, native_ci_reason = "unknown", reason
+        logger.info(
+            "native CI story=%s source=%s state=%s reason=%s",
+            story_id, source, native_ci_state, native_ci_reason,
         )
+
+    result = await capture_pr_ci_verdict(
+        session=session,
+        org_id=org_id,
+        story_id=story_id,
+        pr_number=pr_number,
+        repo=repo,
+        merged=merged,
+        ci_result=ci_conclusion,  # AC④: failure→capture가 fail로 채점.
+    )
+    if native_ci_state is not None:
+        result = {**result, "native_ci": {"state": native_ci_state, "reason": native_ci_reason}}
+    return result, "processed"
+
+
+@router.post("/github-webhook")
+async def github_webhook(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+    x_github_event: str | None = Header(default=None),
+    x_hub_signature_256: str | None = Header(default=None),
+    x_github_delivery: str | None = Header(default=None),
+) -> JSONResponse:
+    """GitHub 웹훅 통합 ingress(Bot-M.2) → [SID:uuid]/installation 라우팅 → capture_pr_ci_verdict.
+
+    보안(산티아고 lock): ⭐**HMAC-before-parse**(검증 前 parse/DB/dedup/capture 0)·source 는 **검증된
+    secret 으로만**(payload 금지)·dedup `(source, delivery_id)` insert+side-effect+status **동일 트랜잭션**
+    (실패=rollback→GitHub retry 보존·중복=2xx no-op)·app=installation resolve 後 org-scope(anti-IDOR).
+    """
+    raw = await request.body()
+
+    # 1) source 결정 = 검증된 secret(app/legacy). 실패면 401 — parse/DB/dedup 전부 0.
+    source = _resolve_webhook_source(raw, x_hub_signature_256)
+    if source is None:
+        return _err("INVALID_SIGNATURE", "GitHub webhook 서명 검증 실패", 401)
+
+    # 2) no-delivery-id → reject(sig 검증 後·DB insert 前). 멱등 불가하므로 감사가능하게 거부.
+    if not x_github_delivery:
+        return _err("MISSING_DELIVERY_ID", "X-GitHub-Delivery 헤더 없음", 400)
+
+    # 3) parse(검증 後에만).
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return _err("INVALID_PAYLOAD", "JSON 파싱 실패", 400)
+    if not isinstance(payload, dict):
+        return _err("INVALID_PAYLOAD", "JSON object 아님", 400)
+
+    event = x_github_event or ""
+    inst_raw = (payload.get("installation") or {}).get("id")
+    installation_id = inst_raw if isinstance(inst_raw, int) else None
+
+    # 4) dedup insert — uq(source, delivery_id) 중복이면 2xx no-op(side-effect 0·세션 clean).
+    delivery = GithubWebhookDelivery(
+        source=source, delivery_id=x_github_delivery, event=event,
+        installation_id=installation_id, status="received",
+    )
+    session.add(delivery)
+    try:
+        await session.flush()
+    except IntegrityError:
+        await session.rollback()  # 중복 → 세션 clean + no-op(capture 0).
+        return _ok({"skipped_reason": "duplicate_delivery", "recorded": []})
+
+    # 5) 처리 + status 갱신 + commit 을 **동일 트랜잭션**으로. 실패=rollback(delivery row 도 함께 → retry 보존).
+    try:
+        result, status_label = await _process_webhook_event(
+            session, source, event, payload, installation_id, delivery
+        )
+        delivery.status = status_label
+        delivery.processed_at = datetime.now(timezone.utc)
         await session.commit()
-        if native_ci_state is not None:
-            # native CI 결과/사유를 응답에 노출(라이브 진단·'unknown 0' 검증·관측). DB schema 무변경.
-            result = {**result, "native_ci": {"state": native_ci_state, "reason": native_ci_reason}}
         return _ok(result)
     except Exception as exc:
-        logger.exception("github webhook verdict capture failed: %s", exc)
-        return _err("INTERNAL_ERROR", "verdict capture failed", 500)
+        await session.rollback()  # delivery insert 포함 전부 rollback → GitHub retry 가 재처리(영구 no-op 금지).
+        logger.exception("github webhook 처리 실패 delivery=%s event=%s: %s", x_github_delivery, event, exc)
+        return _err("WEBHOOK_PROCESSING_FAILED", "처리 중 오류(재시도 가능)", 500)

--- a/backend/tests/test_bot_m2_webhook_integration.py
+++ b/backend/tests/test_bot_m2_webhook_integration.py
@@ -2,8 +2,9 @@
 
 커버: HMAC-before-parse(invalid sig→parse/DB/capture 0) · dual-secret source(검증된 secret로만·payload
 금지) · app sig로 legacy spoof 불가 · equal-secret misconfig→app inert+legacy 보존 · no-delivery-id reject
-· dedup (source,delivery_id) 중복→2xx no-op + 세션 clean · 처리 실패→rollback(retry 보존) · app
-installation→org resolve 後 org-scope(anti-IDOR) · 미등록/suspended→graceful ignore · cross-org story 거부.
+· dedup (source,delivery_id) 중복→2xx no-op + 세션 clean · 처리 실패→rollback(retry 보존) · **app=
+installation→org resolve 先 → story org-scoped 조회**(anti-IDOR 순서·타 org SID 미매치·존재 oracle 0) ·
+미등록/suspended→graceful ignore.
 """
 from __future__ import annotations
 
@@ -41,18 +42,21 @@ def _sign(body: bytes, secret: str) -> str:
     return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
 
 
-def _mk_session(*, story=..., installation=..., flush_error=False):
-    """execute side_effect=[story, installation, ...]·add sync·flush(옵션 IntegrityError)."""
+def _result(val):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = val
+    return r
+
+
+def _mk_session(execute_results=(), *, flush_error=False):
+    """execute 는 호출 순서대로 execute_results 의 scalar 값 반환(여분은 None). add sync·flush 옵션 IntegrityError."""
     session = AsyncMock()
     session.add = MagicMock()
-    story_res = MagicMock()
-    story_res.scalar_one_or_none.return_value = (
-        MagicMock(org_id=ORG_A) if story is ... else story
+    seq = [_result(v) for v in execute_results] + [_result(None) for _ in range(4)]
+    session.execute = AsyncMock(side_effect=seq)
+    session.flush = AsyncMock(
+        side_effect=IntegrityError("dup", {}, Exception()) if flush_error else None
     )
-    inst_res = MagicMock()
-    inst_res.scalar_one_or_none.return_value = (None if installation is ... else installation)
-    session.execute = AsyncMock(side_effect=[story_res, inst_res, inst_res, inst_res])
-    session.flush = AsyncMock(side_effect=IntegrityError("dup", {}, Exception()) if flush_error else None)
     session.commit = AsyncMock()
     session.rollback = AsyncMock()
     return session
@@ -89,6 +93,7 @@ async def _post(payload, *, event="workflow_run", delivery="dlv-1", sign_secret=
 
 
 def _wf(sid=STORY_ID, installation_id=555):
+    """workflow_run failure(ci=failure → actionable·native CI 블록 skip → capture 직행)."""
     return {
         "installation": {"id": installation_id},
         "repository": {"full_name": "moonklabs/sprintable"},
@@ -97,10 +102,18 @@ def _wf(sid=STORY_ID, installation_id=555):
     }
 
 
+def _story(org_id=ORG_A):
+    return MagicMock(org_id=org_id)
+
+
+def _inst(org_id=ORG_A, installation_id=555):
+    return MagicMock(org_id=org_id, installation_id=installation_id, suspended_at=None)
+
+
 # ── HMAC-before-parse ───────────────────────────────────────────────────────────
 @pytest.mark.anyio
 async def test_invalid_sig_401_no_side_effect():
-    session = _mk_session()
+    session = _mk_session([_story()])
     resp, session, cap = await _post(_wf(), bad_sig=True, session=session)
     assert resp.status_code == 401
     session.add.assert_not_called()       # DB insert 0.
@@ -136,9 +149,8 @@ async def test_malformed_json_with_invalid_sig_401_not_parse_error():
 # ── dual-secret source 결정 ──────────────────────────────────────────────────────
 @pytest.mark.anyio
 async def test_app_source_routed_by_app_secret():
-    """app secret로 서명 → source=app → installation resolve(org_a) → capture(org_a)."""
-    inst = MagicMock(org_id=ORG_A, installation_id=555, suspended_at=None)
-    session = _mk_session(story=MagicMock(org_id=ORG_A), installation=inst)
+    """app secret 서명 → source=app → installation resolve(org_a) 先 → org-scoped story → capture(org_a)."""
+    session = _mk_session([_inst(ORG_A), _story(ORG_A)])  # execute: installation→story 순.
     resp, session, cap = await _post(_wf(), sign_secret=APP_SECRET, session=session)
     assert resp.status_code == 200
     cap.assert_awaited_once()
@@ -147,8 +159,8 @@ async def test_app_source_routed_by_app_secret():
 
 @pytest.mark.anyio
 async def test_legacy_source_routed_by_legacy_secret():
-    """legacy secret로 서명 → source=legacy → story.org_id로 capture(installation 불요)."""
-    session = _mk_session(story=MagicMock(org_id=ORG_A))
+    """legacy secret 서명 → source=legacy → story.org_id로 capture(installation 불요)."""
+    session = _mk_session([_story(ORG_A)])
     resp, session, cap = await _post(_wf(), sign_secret=LEGACY_SECRET, session=session)
     assert resp.status_code == 200
     cap.assert_awaited_once()
@@ -157,12 +169,13 @@ async def test_legacy_source_routed_by_legacy_secret():
 
 @pytest.mark.anyio
 async def test_app_sig_cannot_spoof_legacy():
-    """app secret 서명 payload는 legacy로 분류 안 됨(source=app) → installation 없으면 ignore(legacy SID capture 0)."""
+    """app secret 서명 payload는 source=app으로 분류 → installation.id 없으면 ignore(legacy SID capture 0)."""
     payload = _wf()
     payload.pop("installation")  # app source인데 installation.id 없음.
-    session = _mk_session(story=MagicMock(org_id=ORG_A))
+    session = _mk_session([_story(ORG_A)])
     resp, session, cap = await _post(payload, sign_secret=APP_SECRET, session=session)
     assert resp.status_code == 200
+    assert "no_installation_id" in resp.text
     cap.assert_not_awaited()  # legacy로 spoof되어 capture 되지 않음.
 
 
@@ -170,21 +183,19 @@ async def test_app_sig_cannot_spoof_legacy():
 async def test_equal_secret_app_inert_legacy_preserved():
     """app secret == legacy secret(misconfig) → app inert. 그 secret 서명은 source=legacy로 처리(보존)."""
     shared = "shared-secret"
-    inst = MagicMock(org_id=ORG_A, installation_id=555, suspended_at=None)
-    session = _mk_session(story=MagicMock(org_id=ORG_A), installation=inst)
+    session = _mk_session([_story(ORG_A)])  # legacy 경로 → story 1회.
     resp, session, cap = await _post(
         _wf(), sign_secret=shared, legacy=shared, app=shared, session=session
     )
     assert resp.status_code == 200
     cap.assert_awaited_once()
-    # legacy 경로(story.org_id) — installation resolve 안 탐(app inert).
-    assert cap.await_args.kwargs["org_id"] == ORG_A
+    assert cap.await_args.kwargs["org_id"] == ORG_A  # legacy 경로(story.org_id)·installation resolve 안 탐.
 
 
 # ── no-delivery-id ──────────────────────────────────────────────────────────────
 @pytest.mark.anyio
 async def test_missing_delivery_id_rejected_after_sig():
-    session = _mk_session()
+    session = _mk_session([_story(ORG_A)])
     resp, session, cap = await _post(_wf(), delivery=None, sign_secret=LEGACY_SECRET, session=session)
     assert resp.status_code == 400
     session.add.assert_not_called()  # DB insert 0(sig 검증은 통과·delivery 없음만 reject).
@@ -195,7 +206,7 @@ async def test_missing_delivery_id_rejected_after_sig():
 @pytest.mark.anyio
 async def test_duplicate_delivery_2xx_noop():
     """uq(source, delivery_id) 충돌(flush IntegrityError) → rollback + 2xx no-op + capture 0."""
-    session = _mk_session(story=MagicMock(org_id=ORG_A), flush_error=True)
+    session = _mk_session([_story(ORG_A)], flush_error=True)
     resp, session, cap = await _post(_wf(), sign_secret=LEGACY_SECRET, session=session)
     assert resp.status_code == 200
     assert "duplicate_delivery" in resp.text
@@ -207,7 +218,7 @@ async def test_duplicate_delivery_2xx_noop():
 @pytest.mark.anyio
 async def test_processing_failure_rolls_back_for_retry():
     """처리(capture) 실패 → rollback(delivery row 포함) → 500(GitHub retry 재처리·영구 no-op 금지)."""
-    session = _mk_session(story=MagicMock(org_id=ORG_A))
+    session = _mk_session([_story(ORG_A)])
     cap = AsyncMock(side_effect=RuntimeError("boom"))
     resp, session, cap = await _post(_wf(), sign_secret=LEGACY_SECRET, session=session, cap=cap)
     assert resp.status_code == 500
@@ -215,23 +226,24 @@ async def test_processing_failure_rolls_back_for_retry():
     session.commit.assert_not_awaited()
 
 
-# ── per-install routing / anti-IDOR ──────────────────────────────────────────────
+# ── per-install routing / anti-IDOR (P1: resolve 先 → org-scoped story) ───────────
 @pytest.mark.anyio
 async def test_app_unregistered_or_suspended_installation_ignored():
-    """app source·installation 미등록(or suspended_at 필터로 제외) → resolve None → 2xx graceful ignore·capture 0."""
-    session = _mk_session(story=MagicMock(org_id=ORG_A), installation=None)
+    """app source·installation 미등록(or suspended_at 필터 제외) → resolve None → story 조회 없이 2xx ignore·capture 0."""
+    session = _mk_session([None])  # 1st execute=installation resolve → None.
     resp, session, cap = await _post(_wf(), sign_secret=APP_SECRET, session=session)
     assert resp.status_code == 200
     assert "installation_not_registered_or_suspended" in resp.text
-    cap.assert_not_awaited()  # org side-effect 0.
+    cap.assert_not_awaited()                  # org side-effect 0.
+    assert session.execute.await_count == 1   # ⭐installation resolve 만 — story 전역 조회 안 함(oracle 0).
 
 
 @pytest.mark.anyio
-async def test_app_cross_org_story_mismatch_ignored():
-    """app installation=org_a로 resolve인데 SID story가 org_b 소속 → cross-org spoof 거부(capture 0)."""
-    inst = MagicMock(org_id=ORG_A, installation_id=555, suspended_at=None)
-    session = _mk_session(story=MagicMock(org_id=ORG_B), installation=inst)  # story=org_b ≠ installation org_a.
+async def test_app_cross_org_sid_not_found_via_scoped_query():
+    """app installation=org_a resolve인데 SID story가 타 org → org-scoped 조회서 미매치(not_found)·capture 0."""
+    # execute: installation(org_a) → story scoped query(org_a) 미매치 → None.
+    session = _mk_session([_inst(ORG_A), None])
     resp, session, cap = await _post(_wf(), sign_secret=APP_SECRET, session=session)
     assert resp.status_code == 200
-    assert "story_org_mismatch" in resp.text
+    assert "story_not_found" in resp.text  # 전역 lookup 아닌 org-scoped 미매치.
     cap.assert_not_awaited()

--- a/backend/tests/test_bot_m2_webhook_integration.py
+++ b/backend/tests/test_bot_m2_webhook_integration.py
@@ -1,0 +1,237 @@
+"""E-GHAPP Bot-M.2: 웹훅 통합 ingress 보안 단위(산티아고 lock 게이트 기준).
+
+커버: HMAC-before-parse(invalid sig→parse/DB/capture 0) · dual-secret source(검증된 secret로만·payload
+금지) · app sig로 legacy spoof 불가 · equal-secret misconfig→app inert+legacy 보존 · no-delivery-id reject
+· dedup (source,delivery_id) 중복→2xx no-op + 세션 clean · 처리 실패→rollback(retry 보존) · app
+installation→org resolve 後 org-scope(anti-IDOR) · 미등록/suspended→graceful ignore · cross-org story 거부.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.exc import IntegrityError
+
+from app.routers import verdict_capture as mod
+
+LEGACY_SECRET = "legacy-secret"
+APP_SECRET = "app-secret"
+STORY_ID = uuid.uuid4()
+ORG_A = uuid.uuid4()
+ORG_B = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _reset_warn():
+    mod._app_inert_warned = False
+    yield
+
+
+def _sign(body: bytes, secret: str) -> str:
+    return "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def _mk_session(*, story=..., installation=..., flush_error=False):
+    """execute side_effect=[story, installation, ...]·add sync·flush(옵션 IntegrityError)."""
+    session = AsyncMock()
+    session.add = MagicMock()
+    story_res = MagicMock()
+    story_res.scalar_one_or_none.return_value = (
+        MagicMock(org_id=ORG_A) if story is ... else story
+    )
+    inst_res = MagicMock()
+    inst_res.scalar_one_or_none.return_value = (None if installation is ... else installation)
+    session.execute = AsyncMock(side_effect=[story_res, inst_res, inst_res, inst_res])
+    session.flush = AsyncMock(side_effect=IntegrityError("dup", {}, Exception()) if flush_error else None)
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    return session
+
+
+async def _post(payload, *, event="workflow_run", delivery="dlv-1", sign_secret=LEGACY_SECRET,
+                bad_sig=False, legacy=LEGACY_SECRET, app=APP_SECRET, session=None, cap=None):
+    from app.dependencies.database import get_db
+    from app.main import app as fastapi_app
+
+    if session is None:
+        session = _mk_session()
+    if cap is None:
+        cap = AsyncMock(return_value={"recorded": ["ci"], "skipped_reason": None})
+
+    async def override_db():
+        yield session
+
+    fastapi_app.dependency_overrides[get_db] = override_db
+    body = json.dumps(payload).encode()
+    headers = {"X-GitHub-Event": event}
+    if delivery is not None:
+        headers["X-GitHub-Delivery"] = delivery
+    headers["X-Hub-Signature-256"] = "sha256=" + "f" * 64 if bad_sig else _sign(body, sign_secret)
+    try:
+        async with AsyncClient(transport=ASGITransport(app=fastapi_app), base_url="http://test") as c:
+            with patch.object(mod.settings, "github_webhook_secret", legacy), \
+                 patch.object(mod.settings, "github_app_webhook_secret", app), \
+                 patch.object(mod, "capture_pr_ci_verdict", new=cap):
+                resp = await c.post("/api/v2/internal/verdict/github-webhook", content=body, headers=headers)
+        return resp, session, cap
+    finally:
+        fastapi_app.dependency_overrides.clear()
+
+
+def _wf(sid=STORY_ID, installation_id=555):
+    return {
+        "installation": {"id": installation_id},
+        "repository": {"full_name": "moonklabs/sprintable"},
+        "workflow_run": {"conclusion": "failure", "head_sha": "sha1",
+                         "head_branch": f"feat-[SID:{sid}]", "pull_requests": [{"number": 7}]},
+    }
+
+
+# ── HMAC-before-parse ───────────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_invalid_sig_401_no_side_effect():
+    session = _mk_session()
+    resp, session, cap = await _post(_wf(), bad_sig=True, session=session)
+    assert resp.status_code == 401
+    session.add.assert_not_called()       # DB insert 0.
+    cap.assert_not_awaited()              # capture 0.
+    session.execute.assert_not_awaited()  # parse/DB 0.
+
+
+@pytest.mark.anyio
+async def test_malformed_json_with_invalid_sig_401_not_parse_error():
+    """invalid sig면 json.loads 전에 401 — malformed body여도 parse error(400) 안 남."""
+    from app.dependencies.database import get_db
+    from app.main import app as fastapi_app
+    session = _mk_session()
+
+    async def override_db():
+        yield session
+    fastapi_app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=fastapi_app), base_url="http://test") as c:
+            with patch.object(mod.settings, "github_webhook_secret", LEGACY_SECRET), \
+                 patch.object(mod.settings, "github_app_webhook_secret", APP_SECRET):
+                resp = await c.post(
+                    "/api/v2/internal/verdict/github-webhook",
+                    content=b"not-json{{{", headers={"X-GitHub-Event": "push",
+                    "X-GitHub-Delivery": "d", "X-Hub-Signature-256": "sha256=" + "a" * 64},
+                )
+        assert resp.status_code == 401   # parse error(400)가 아니라 sig 거부(401).
+        session.add.assert_not_called()
+    finally:
+        fastapi_app.dependency_overrides.clear()
+
+
+# ── dual-secret source 결정 ──────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_app_source_routed_by_app_secret():
+    """app secret로 서명 → source=app → installation resolve(org_a) → capture(org_a)."""
+    inst = MagicMock(org_id=ORG_A, installation_id=555, suspended_at=None)
+    session = _mk_session(story=MagicMock(org_id=ORG_A), installation=inst)
+    resp, session, cap = await _post(_wf(), sign_secret=APP_SECRET, session=session)
+    assert resp.status_code == 200
+    cap.assert_awaited_once()
+    assert cap.await_args.kwargs["org_id"] == ORG_A   # resolved installation org_id로만 capture.
+
+
+@pytest.mark.anyio
+async def test_legacy_source_routed_by_legacy_secret():
+    """legacy secret로 서명 → source=legacy → story.org_id로 capture(installation 불요)."""
+    session = _mk_session(story=MagicMock(org_id=ORG_A))
+    resp, session, cap = await _post(_wf(), sign_secret=LEGACY_SECRET, session=session)
+    assert resp.status_code == 200
+    cap.assert_awaited_once()
+    assert cap.await_args.kwargs["org_id"] == ORG_A
+
+
+@pytest.mark.anyio
+async def test_app_sig_cannot_spoof_legacy():
+    """app secret 서명 payload는 legacy로 분류 안 됨(source=app) → installation 없으면 ignore(legacy SID capture 0)."""
+    payload = _wf()
+    payload.pop("installation")  # app source인데 installation.id 없음.
+    session = _mk_session(story=MagicMock(org_id=ORG_A))
+    resp, session, cap = await _post(payload, sign_secret=APP_SECRET, session=session)
+    assert resp.status_code == 200
+    cap.assert_not_awaited()  # legacy로 spoof되어 capture 되지 않음.
+
+
+@pytest.mark.anyio
+async def test_equal_secret_app_inert_legacy_preserved():
+    """app secret == legacy secret(misconfig) → app inert. 그 secret 서명은 source=legacy로 처리(보존)."""
+    shared = "shared-secret"
+    inst = MagicMock(org_id=ORG_A, installation_id=555, suspended_at=None)
+    session = _mk_session(story=MagicMock(org_id=ORG_A), installation=inst)
+    resp, session, cap = await _post(
+        _wf(), sign_secret=shared, legacy=shared, app=shared, session=session
+    )
+    assert resp.status_code == 200
+    cap.assert_awaited_once()
+    # legacy 경로(story.org_id) — installation resolve 안 탐(app inert).
+    assert cap.await_args.kwargs["org_id"] == ORG_A
+
+
+# ── no-delivery-id ──────────────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_missing_delivery_id_rejected_after_sig():
+    session = _mk_session()
+    resp, session, cap = await _post(_wf(), delivery=None, sign_secret=LEGACY_SECRET, session=session)
+    assert resp.status_code == 400
+    session.add.assert_not_called()  # DB insert 0(sig 검증은 통과·delivery 없음만 reject).
+    cap.assert_not_awaited()
+
+
+# ── dedup ───────────────────────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_duplicate_delivery_2xx_noop():
+    """uq(source, delivery_id) 충돌(flush IntegrityError) → rollback + 2xx no-op + capture 0."""
+    session = _mk_session(story=MagicMock(org_id=ORG_A), flush_error=True)
+    resp, session, cap = await _post(_wf(), sign_secret=LEGACY_SECRET, session=session)
+    assert resp.status_code == 200
+    assert "duplicate_delivery" in resp.text
+    session.rollback.assert_awaited()  # 세션 clean.
+    cap.assert_not_awaited()           # capture 0.
+    session.commit.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_processing_failure_rolls_back_for_retry():
+    """처리(capture) 실패 → rollback(delivery row 포함) → 500(GitHub retry 재처리·영구 no-op 금지)."""
+    session = _mk_session(story=MagicMock(org_id=ORG_A))
+    cap = AsyncMock(side_effect=RuntimeError("boom"))
+    resp, session, cap = await _post(_wf(), sign_secret=LEGACY_SECRET, session=session, cap=cap)
+    assert resp.status_code == 500
+    session.rollback.assert_awaited()    # delivery insert 도 함께 rollback → retry 보존.
+    session.commit.assert_not_awaited()
+
+
+# ── per-install routing / anti-IDOR ──────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_app_unregistered_or_suspended_installation_ignored():
+    """app source·installation 미등록(or suspended_at 필터로 제외) → resolve None → 2xx graceful ignore·capture 0."""
+    session = _mk_session(story=MagicMock(org_id=ORG_A), installation=None)
+    resp, session, cap = await _post(_wf(), sign_secret=APP_SECRET, session=session)
+    assert resp.status_code == 200
+    assert "installation_not_registered_or_suspended" in resp.text
+    cap.assert_not_awaited()  # org side-effect 0.
+
+
+@pytest.mark.anyio
+async def test_app_cross_org_story_mismatch_ignored():
+    """app installation=org_a로 resolve인데 SID story가 org_b 소속 → cross-org spoof 거부(capture 0)."""
+    inst = MagicMock(org_id=ORG_A, installation_id=555, suspended_at=None)
+    session = _mk_session(story=MagicMock(org_id=ORG_B), installation=inst)  # story=org_b ≠ installation org_a.
+    resp, session, cap = await _post(_wf(), sign_secret=APP_SECRET, session=session)
+    assert resp.status_code == 200
+    assert "story_org_mismatch" in resp.text
+    cap.assert_not_awaited()

--- a/backend/tests/test_h1_s6_github_webhook.py
+++ b/backend/tests/test_h1_s6_github_webhook.py
@@ -15,7 +15,13 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app.routers import verdict_capture as mod
-from app.routers.verdict_capture import _candidate_texts, _extract_pr_ci, _normalize_ci, _verify_github_signature
+from app.routers.verdict_capture import (
+    _candidate_texts,
+    _extract_pr_ci,
+    _hmac_match,
+    _normalize_ci,
+    _resolve_webhook_source,
+)
 
 _SECRET = "testsecret"
 STORY_ID = uuid.uuid4()
@@ -58,14 +64,24 @@ def test_extract_pr_ci_workflow_run_failure():
     assert head_sha == "def456"
 
 
-def test_verify_signature():
+def test_hmac_match_format_and_compare():
     body = b'{"a":1}'
     sig = "sha256=" + hmac.new(_SECRET.encode(), body, hashlib.sha256).hexdigest()
-    with patch.object(mod.settings, "github_webhook_secret", _SECRET):
-        assert _verify_github_signature(body, sig) is True
-        assert _verify_github_signature(body, "sha256=bad") is False
-    with patch.object(mod.settings, "github_webhook_secret", ""):
-        assert _verify_github_signature(body, sig) is False  # 시크릿 미설정 → 거부.
+    assert _hmac_match(body, sig, _SECRET) is True
+    assert _hmac_match(body, "sha256=bad", _SECRET) is False          # 형식오류(hex64 아님).
+    assert _hmac_match(body, sig.removeprefix("sha256="), _SECRET) is False  # bare hex(prefix 없음) 거부.
+    assert _hmac_match(body, sig, "") is False                        # secret 미설정 거부.
+    assert _hmac_match(body, None, _SECRET) is False                  # header 없음 거부.
+
+
+def test_resolve_webhook_source_legacy_only_by_default():
+    body = b'{"a":1}'
+    legacy_sig = "sha256=" + hmac.new(_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    # app secret 미설정 → app inert·legacy 만.
+    with patch.object(mod.settings, "github_webhook_secret", _SECRET), \
+         patch.object(mod.settings, "github_app_webhook_secret", ""):
+        assert _resolve_webhook_source(body, legacy_sig) == "legacy"
+        assert _resolve_webhook_source(body, "sha256=" + "0" * 64) is None  # 둘다 실패.
 
 
 # ── 엔드포인트(실 runtime 경로) ────────────────────────────────────────────────
@@ -79,6 +95,7 @@ async def _post(payload: dict, *, event: str, story=..., sign=True, installation
     from app.main import app
 
     session = AsyncMock()
+    session.add = MagicMock()  # add 는 sync(AsyncMock 경고 방지).
     result = MagicMock()
     result.scalar_one_or_none.return_value = (
         MagicMock(org_id=ORG_ID) if story is ... else story
@@ -96,11 +113,13 @@ async def _post(payload: dict, *, event: str, story=..., sign=True, installation
 
     app.dependency_overrides[get_db] = override_db
     body = json.dumps(payload).encode()
-    headers = {"X-GitHub-Event": event}
+    headers = {"X-GitHub-Event": event, "X-GitHub-Delivery": "test-delivery-legacy"}  # Bot-M.2: delivery 필수.
     headers["X-Hub-Signature-256"] = _sign(body) if sign else "sha256=bad"
     try:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-            with patch.object(mod.settings, "github_webhook_secret", _SECRET):
+            # legacy source(app secret 미설정 → app inert): 기존 무회귀 검증.
+            with patch.object(mod.settings, "github_webhook_secret", _SECRET), \
+                 patch.object(mod.settings, "github_app_webhook_secret", ""):
                 resp = await c.post("/api/v2/internal/verdict/github-webhook", content=body, headers=headers)
         return resp
     finally:


### PR DESCRIPTION
## Summary
E-GHAPP **Bot-M.2** (webhook integration): unify the legacy repo webhook (hook#640488969) and App per-install events into a single ingress, with **source determined only by verified secret** (never payload), idempotent dedup, and per-install org resolution (anti-IDOR). Santiago's 10-point security model mapped 1:1.

## Story
[SID:38a0c220-5b11-45a2-a52e-06b76feb4243]

## Santiago security-checklist mapping
- **HMAC-before-parse**: `sha256=<hex64>` format only, full-string constant-time compare; invalid/missing sig → 401 with **0 parse / DB / dedup / capture**. ✅
- **source from verified secret (not payload)**: dual-secret-try (app `github_app_webhook_secret` → app; legacy `github_webhook_secret` → legacy; neither → 401). ✅
- **equal-secret misconfig**: app secret unset OR == legacy → **app inert + one-time startup warning** (legacy preserved; silent app-priority discarded). Warning logs no secret value/length/hash. ✅
- **no-delivery-id**: reject 4xx **after sig verify, before DB insert**. ✅
- **dedup**: new `github_webhook_delivery(source, delivery_id uq, event, installation_id, org_id, status, error_*, received_at, processed_at)` (migration 0134, additive). insert + side-effect + status update in **one transaction** → failure rolls back (GitHub retry preserved, no permanent no-op); duplicate-conflict → rollback + 2xx no-op + capture 0. ✅
- **per-install / anti-IDOR**: app → `installation.id` → `github_installation` (suspended_at IS NULL) → **that org_id only** (no repo-owner/payload inference); story must belong to resolved org or → cross-org reject. unregistered/suspended → 2xx graceful ignore. ✅
- **legacy no-regression**: legacy source keeps existing secret/SID/skip-reasons/response. ✅
- **logs**: no secret/signature/raw payload; structured delivery/event/installation only. ✅

## Files
- `models/github_installation.py` (`GithubWebhookDelivery`) · `alembic/0134_github_webhook_delivery.py` · `core/config.py` (`github_app_webhook_secret`) · `routers/verdict_capture.py` (`_hmac_match`, `_resolve_webhook_source`, `_process_webhook_event`, restructured `github_webhook`) · `tests/test_bot_m2_webhook_integration.py` (11) + `tests/test_h1_s6_github_webhook.py` (delivery header + dual-secret unit).

## Verification
- `CI=1` verdict/gate/github suite: **74 passed, 2 skipped**. alembic head = 0134. app loads.
- Fresh-DB CI (baseline + alembic upgrade head) applies 0134.
- Live (post-App-registration): App webhook → app-source → installation→org resolve → capture; duplicate delivery → no-op; legacy hook unchanged.

## Out of scope
delivery retention/cleanup = follow-up hygiene (non-blocking). Live App webhook verification bundled with Bot-S/M.1 after App registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
