### PR TITLE
[SID:09ebeb5f] 문서 상세 수정이력 패널 본문 잠식 fix (접기-기본 + 바운드 scroll)

### DIFF
--- a/apps/web/src/components/docs/doc-gate-section.tsx
+++ b/apps/web/src/components/docs/doc-gate-section.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { Shield, ShieldCheck, ShieldX, RotateCcw, Pencil, History, User } from 'lucide-react';
+import { Shield, ShieldCheck, ShieldX, RotateCcw, Pencil, History, User, ChevronDown } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import type { GateItem } from '@/components/kanban/types';
@@ -47,6 +47,7 @@ export function DocGateSection({
   const [revisions, setRevisions] = useState<DocRevision[]>([]);
   const [memberNames, setMemberNames] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState(false);
+  const [revOpen, setRevOpen] = useState(false); // 기본 접힘(본문 우선·이력 secondary — 개수가 레이아웃 못 밀어냄)
 
   const load = useCallback(async () => {
     const [gates, revsJson, membersJson] = await Promise.all([
@@ -90,7 +91,7 @@ export function DocGateSection({
   if (!state && !hasHistory) return null;
 
   return (
-    <section aria-label={t('docGateLabel')} className="mb-4 space-y-2 rounded-xl border border-border bg-muted/20 p-3">
+    <section aria-label={t('docGateLabel')} className="mb-4 max-h-[40vh] space-y-2 overflow-y-auto rounded-xl border border-border bg-muted/20 p-3">
       <div className="flex flex-wrap items-center gap-2">
         {meta && MetaIcon ? (
           <Badge variant={meta.variant} className="shrink-0 gap-1">
@@ -135,22 +136,31 @@ export function DocGateSection({
         </div>
       ) : null}
 
-      {/* revision 타임라인(v1→vN·created_at 오름차) */}
+      {/* revision 타임라인(v1→vN·created_at 오름차). 접기-기본 + 바운드 scroll → 이력 개수가 본문 못 밀어냄. */}
       {revisions.length > 0 ? (
         <div className="space-y-1">
-          <p className="inline-flex items-center gap-1 text-[11px] font-medium text-muted-foreground">
-            <History className="size-3" />
+          <button
+            type="button"
+            onClick={() => setRevOpen((o) => !o)}
+            aria-expanded={revOpen}
+            className="inline-flex items-center gap-1 text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <History className="size-3 shrink-0" />
             {t('docGateRevisions')}
-          </p>
-          <ul className="space-y-0.5">
-            {revisions.map((rev, i) => (
-              <li key={rev.id} className="flex items-center gap-2 text-[11px] text-muted-foreground">
-                <span className="shrink-0 font-mono text-foreground">v{i + 1}</span>
-                <span className="shrink-0">{resolveName(rev.created_by)}</span>
-                <span className="truncate">{fmtDate(rev.created_at)}</span>
-              </li>
-            ))}
-          </ul>
+            <span className="text-muted-foreground/70">({revisions.length})</span>
+            <ChevronDown className={`size-3 shrink-0 transition-transform ${revOpen ? 'rotate-180' : ''}`} />
+          </button>
+          {revOpen ? (
+            <ul className="max-h-32 space-y-0.5 overflow-y-auto pr-1">
+              {revisions.map((rev, i) => (
+                <li key={rev.id} className="flex items-center gap-2 text-[11px] text-muted-foreground">
+                  <span className="shrink-0 font-mono text-foreground">v{i + 1}</span>
+                  <span className="shrink-0">{resolveName(rev.created_by)}</span>
+                  <span className="truncate">{fmtDate(rev.created_at)}</span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
         </div>
       ) : null}
     </section>

--- a/apps/web/src/components/docs/doc-gate-section.tsx
+++ b/apps/web/src/components/docs/doc-gate-section.tsx
@@ -156,7 +156,7 @@ export function DocGateSection({
                 <li key={rev.id} className="flex items-center gap-2 text-[11px] text-muted-foreground">
                   <span className="shrink-0 font-mono text-foreground">v{i + 1}</span>
                   <span className="shrink-0">{resolveName(rev.created_by)}</span>
-                  <span className="truncate">{fmtDate(rev.created_at)}</span>
+                  <span className="min-w-0 truncate">{fmtDate(rev.created_at)}</span>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
## 한 줄
문서 상세에서 수정이력(revision) 패널이 본문을 세로로 잠식 — 이력 많을수록 본문이 하단 좁은 띠로 밀리고 저해상도/작은창선 본문 한 줄도 안 보임. **근본 = `DocGateSection`의 revision `<ul>`이 max-h·접기 없이 무제한 + 페이지 래퍼 `flex-shrink-0`.**

> story `09ebeb5f` · 핸드오프 doc `docs-ux-revision-panel-body-encroach-handoff`(PRIMARY) · 디자인/가디언: 유나 홀름 · 오르테가군 nod 완료 · 아버님 직접 적출(이미지 2장)

## 변경 (FE 전용 · 단일 파일 자족 · apps/web/src/components/docs/doc-gate-section.tsx)
- **`revOpen` state 신설(기본 접힘)** — 접힌 상태는 헤더 1줄(`수정이력 (N)`)뿐 → **이력 개수가 기본 레이아웃에 0 영향**(못 밀어냄).
- revision 블록 → **접기-기본 disclosure**: 토글 버튼(`History` + 라벨 + `({revisions.length})` + `ChevronDown` 회전 · `aria-expanded`) / 펼침 시 `<ul max-h-32 overflow-y-auto pr-1>` **바운드 scroll**. `<li>` 내용·정렬 기존 동일(`truncate` 유지).
- **`<section>` 안전캡** `max-h-[40vh] overflow-y-auto` — 반려사유 + 펼친 이력 동시 극한도 본문 ≥60% 보존(최후 안전망).
- **`docs/[slug]/page.tsx:389 flex-shrink-0` 유지** — 섹션이 자기-바운드되므로 페이지 레이아웃 변경 불요(결정 #3 · 최소 변경).

## 가드
- **신규 i18n 키 0** — `docGateRevisions`(수정이력 / Revision history)는 기존. count `({N})`는 숫자(언어 중립).
- **신규 토큰 0 · 매직 hex 0** — 기존 토큰만.
- a11y: 토글 `aria-expanded` + `ChevronDown` 시각 affordance.

## 검증
- `tsc --noEmit` **0**
- `eslint` (doc-gate-section) **0**
- `next build` **✓**

⚠️ **라이브 픽셀**: 아버님 이미지2 해상도(저해상도/작은창) BEFORE(본문 ≈1줄) → AFTER(다수 줄) 재현은 머지→dev 배포 후 가디언 동석(이력 다수 문서 상세 · 양테마 · 390px). PR 단계 = 가디언 코드리뷰 → 오르테가군 LGTM → 까심군 QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)