### PR TITLE
[E-GHAPP][Bot-L.1] feat: PR↔story 링크 모델·resolver 체인·auto-match·close-on-merge

### DIFF
--- a/backend/alembic/versions/0135_pull_request_story_link.py
+++ b/backend/alembic/versions/0135_pull_request_story_link.py
@@ -1,0 +1,59 @@
+"""E-GHAPP Bot-L.1: pull_request_story_link (PR↔story canonical 링크).
+
+컨벤션-free 링킹 store — explicit/auto_match/sid/text link_source + confidence + evidence. close-on-merge 는
+confident link 에만. additive·신규 테이블·백필 불요(과거 PR 링크 추적 불요).
+
+⚠️baseline schema.sql 미변경(의도): post-0096 신규 테이블(0130~0134 동형). fresh-DB CI 가 0135 적용.
+create_all 금지 — 모델↔마이그 매칭은 migrated-DB 로 검증.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+
+revision = "0135"
+down_revision = "0134"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if "pull_request_story_link" in insp.get_table_names():
+        return
+    op.create_table(
+        "pull_request_story_link",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("story_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("repo_full_name", sa.String(length=255), nullable=False),
+        sa.Column("pr_number", sa.Integer(), nullable=False),
+        sa.Column("link_source", sa.String(length=16), nullable=False),
+        sa.Column("confidence", sa.String(length=8), nullable=False),
+        sa.Column("created_by", UUID(as_uuid=True), nullable=True),
+        sa.Column("evidence", JSONB(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_unique_constraint(
+        "uq_pr_story_link_org_repo_pr", "pull_request_story_link", ["org_id", "repo_full_name", "pr_number"]
+    )
+    op.create_index("ix_pull_request_story_link_org_id", "pull_request_story_link", ["org_id"])
+    op.create_index("ix_pull_request_story_link_story_id", "pull_request_story_link", ["story_id"])
+    op.create_foreign_key(
+        "fk_pr_story_link_org", "pull_request_story_link", "organizations",
+        ["org_id"], ["id"], ondelete="CASCADE",
+    )
+    op.create_foreign_key(
+        "fk_pr_story_link_story", "pull_request_story_link", "stories",
+        ["story_id"], ["id"], ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_pr_story_link_story", "pull_request_story_link", type_="foreignkey")
+    op.drop_constraint("fk_pr_story_link_org", "pull_request_story_link", type_="foreignkey")
+    op.drop_constraint("uq_pr_story_link_org_repo_pr", "pull_request_story_link", type_="unique")
+    op.drop_table("pull_request_story_link")

--- a/backend/app/models/pull_request_story_link.py
+++ b/backend/app/models/pull_request_story_link.py
@@ -1,0 +1,47 @@
+"""E-GHAPP Bot-L.1: PR ↔ story 링크(컨벤션-free 링킹의 canonical store).
+
+유저가 PR 제목에 `[SID:uuid]` 를 박는 대신, 봇이 PR↔story 링크를 관리한다. link_source 로 어떻게 링크됐는지
+(explicit 명시연결 / auto_match 휴리스틱 / sid 텍스트태그 / text fallback)와 confidence(high|medium|low)를
+보존한다. **close-on-merge 는 confident link(explicit·auto high·sid exact)에만** 적용된다(오매치 done 방지).
+
+per-org 격리: 모든 read/write 는 org_id 스코프(anti-IDOR). PR 당 canonical 단일 링크 — uq(org_id,
+repo_full_name, pr_number). 재링크는 우선순위에 따라 upsert. evidence 는 auto-match 근거(matched tokens·
+field·후보 수)를 담아 오매치 사후 조사를 가능케 한다.
+"""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class PullRequestStoryLink(Base):
+    __tablename__ = "pull_request_story_link"
+    __table_args__ = (
+        UniqueConstraint("org_id", "repo_full_name", "pr_number", name="uq_pr_story_link_org_repo_pr"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    # per-org 격리 — org 삭제 시 cascade. story 도 같은 org(앱 레벨서 항상 재검증).
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    story_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("stories.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    repo_full_name: Mapped[str] = mapped_column(String(255), nullable=False)  # lowercase 정규화 저장.
+    pr_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    link_source: Mapped[str] = mapped_column(String(16), nullable=False)  # explicit | auto_match | sid | text
+    confidence: Mapped[str] = mapped_column(String(8), nullable=False)     # high | medium | low
+    created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)  # explicit=member
+    evidence: Mapped[dict | None] = mapped_column(JSONB, nullable=True)     # matched tokens/field/후보수/reason
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routers/github_integration.py
+++ b/backend/app/routers/github_integration.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse, RedirectResponse
 from jose import jwt
+from pydantic import BaseModel
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -21,12 +22,14 @@ from app.core.config import settings
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id, require_admin
 from app.dependencies.database import get_db
 from app.models.github_installation import GithubInstallation, GithubInstallNonce
+from app.models.pm import Story
 from app.services.github_app import (
     fetch_installation_metadata,
     sign_install_state,
     verify_install_state,
     verify_installation_owned,
 )
+from app.services.pr_story_link import upsert_link
 
 router = APIRouter(prefix="/api/v2/integrations/github", tags=["github-integration"])
 
@@ -147,5 +150,56 @@ async def github_status(
             "account_type": inst.account_type,
             "repository_selection": inst.repository_selection,
             "suspended": inst.suspended_at is not None,
+        }
+    )
+
+
+class _ExplicitLinkBody(BaseModel):
+    story_id: uuid.UUID
+    repo_full_name: str
+    pr_number: int
+
+
+@router.post("/links")
+async def create_explicit_link(
+    body: _ExplicitLinkBody,
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """PR↔story **명시연결**(explicit·confidence high·Bot-L.2 UI 의 BE). resolver 체인 최우선·close-on-merge
+    가능. ⭐anti-IDOR: story 가 **caller org 소속**이어야(미소속/부재 = generic 404·타 org 존재 oracle 0).
+    per-org 격리·upsert(uq org,repo,pr)·created_by=caller member.
+    """
+    if not body.repo_full_name.strip() or body.pr_number <= 0:
+        return JSONResponse(status_code=422, content={"error": "invalid_pr_identity"})
+    # story org-scope 검증(타 org story_id 차단·존재 여부 노출 금지).
+    story = (
+        await session.execute(
+            select(Story).where(
+                Story.id == body.story_id, Story.org_id == org_id, Story.deleted_at.is_(None)
+            )
+        )
+    ).scalar_one_or_none()
+    if story is None:
+        return JSONResponse(status_code=404, content={"error": "story_not_found"})
+    try:
+        created_by: uuid.UUID | None = uuid.UUID(auth.user_id)
+    except (ValueError, TypeError):
+        created_by = None
+    link = await upsert_link(
+        session, org_id, body.story_id, body.repo_full_name, body.pr_number,
+        link_source="explicit", confidence="high", created_by=created_by,
+        evidence={"by": "explicit_api"},
+    )
+    await session.commit()
+    return JSONResponse(
+        content={
+            "id": str(link.id),
+            "story_id": str(body.story_id),
+            "repo_full_name": link.repo_full_name,
+            "pr_number": link.pr_number,
+            "link_source": "explicit",
+            "confidence": "high",
         }
     )

--- a/backend/app/routers/github_integration.py
+++ b/backend/app/routers/github_integration.py
@@ -168,12 +168,12 @@ async def create_explicit_link(
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """PR↔story **명시연결**(explicit·confidence high·Bot-L.2 UI 의 BE). resolver 체인 최우선·close-on-merge
-    가능. ⭐anti-IDOR: story 가 **caller org 소속**이어야(미소속/부재 = generic 404·타 org 존재 oracle 0).
-    per-org 격리·upsert(uq org,repo,pr)·created_by=caller member.
+    가능. ⭐anti-IDOR **2층**: ①story 가 caller org 소속 ②**repo 가 org 의 설치 context**(installation account)에
+    속함. 둘 다 미충족 = generic 404(타 org/repo 존재 oracle 0). per-org 격리·upsert·created_by=caller member.
     """
-    if not body.repo_full_name.strip() or body.pr_number <= 0:
+    if not body.repo_full_name.strip() or "/" not in body.repo_full_name or body.pr_number <= 0:
         return JSONResponse(status_code=422, content={"error": "invalid_pr_identity"})
-    # story org-scope 검증(타 org story_id 차단·존재 여부 노출 금지).
+    # ①story org-scope 검증(타 org story_id 차단·존재 여부 노출 금지).
     story = (
         await session.execute(
             select(Story).where(
@@ -183,6 +183,18 @@ async def create_explicit_link(
     ).scalar_one_or_none()
     if story is None:
         return JSONResponse(status_code=404, content={"error": "story_not_found"})
+    # ②repo 가 org 의 설치 context 에 속하는지(anti-IDOR·임의 repo high link 차단). org 의 active installation
+    # account_login 과 repo owner 일치 요구. 미설치/owner 불일치 = generic 404(repo 존재 oracle 0).
+    inst = (
+        await session.execute(
+            select(GithubInstallation).where(
+                GithubInstallation.org_id == org_id, GithubInstallation.suspended_at.is_(None)
+            )
+        )
+    ).scalar_one_or_none()
+    repo_owner = body.repo_full_name.strip().split("/", 1)[0].lower()
+    if inst is None or not inst.account_login or repo_owner != inst.account_login.lower():
+        return JSONResponse(status_code=404, content={"error": "repo_not_in_org_context"})
     try:
         created_by: uuid.UUID | None = uuid.UUID(auth.user_id)
     except (ValueError, TypeError):

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -26,6 +26,8 @@ from app.models.github_installation import GithubInstallation, GithubWebhookDeli
 from app.models.pm import Story
 from app.routers.cron import CRON_SECRET, _err, _ok, verify_cron
 from app.services.github_app import get_installation_token
+from app.services.pr_story_link import resolve_story_for_pr
+from app.services.story_status_events import advance_story_to_done
 from app.services.verdict_capture import (
     capture_pr_ci_verdict,
     capture_review_verdict,
@@ -269,21 +271,21 @@ async def _process_webhook_event(
     session: AsyncSession, source: str, event: str, payload: dict, installation_id: int | None,
     delivery: GithubWebhookDelivery,
 ) -> tuple[dict, str]:
-    """검증·dedup 통과한 이벤트 처리(legacy/app 라우팅). (result, status) 반환. status∈processed|ignored.
+    """검증·dedup 통과한 이벤트 처리(legacy/app 라우팅·Bot-L.1 resolver 체인). (result, status) 반환.
 
-    org resolve: **legacy**=story.org_id(기존). **app**=installation.id→github_installation(suspended 제외)
-    →그 org_id만(anti-IDOR·payload/repo-owner 추론 금지)·story 가 그 org 소속 아니면 거부(cross-org spoof).
-    native CI(Bot-M.1)=installation 토큰. **caller 가 동일 트랜잭션으로 commit/rollback**(여기선 commit 안 함).
+    org resolve: **app**=installation.id→github_installation(suspended 제외)→그 org_id만(anti-IDOR·payload
+    추론 금지·resolve 先). **legacy**=resolver 가 SID 전역→story.org_id(무회귀). story 해소=resolver 체인
+    (explicit>auto high>SID>text). **close-on-merge**=should_auto_close(confident)+merge → advance_story_to_done
+    (단일 idempotent 헬퍼). native CI(Bot-M.1)=installation 토큰. caller 가 동일 트랜잭션으로 commit/rollback.
     """
-    # AC②: [SID:] 태그 없으면 skip(거짓기록 금지).
-    story_id = next((sid for t in _candidate_texts(payload) if (sid := parse_story_id(t))), None)
-    if story_id is None:
-        return {"skipped_reason": "no_sid_tag", "recorded": []}, "ignored"
+    texts = _candidate_texts(payload)
+    repo = (payload.get("repository") or {}).get("full_name") or ""
+    pr_number, merged, ci_conclusion, head_sha = _extract_pr_ci(event, payload)
 
     installation: GithubInstallation | None = None
+    org_id: uuid.UUID | None = None
     if source == "app":
-        # ⭐app: **installation→org resolve 를 story 조회보다 먼저**(org context 확립 前 전역 story 조회 금지
-        # — 미등록 installation 으로 story 존재 oracle 차단). org 는 installation DB 로만(payload 추론 금지).
+        # ⭐app: installation→org resolve 先(미등록 installation 으로 story 존재 oracle 차단·payload 추론 금지).
         if installation_id is None:
             return {"skipped_reason": "no_installation_id", "recorded": []}, "ignored"
         installation = (
@@ -295,38 +297,21 @@ async def _process_webhook_event(
             )
         ).scalar_one_or_none()
         if installation is None:
-            # 미등록/suspended installation → story 조회 없이 graceful ignore(side-effect 0·oracle 0).
             return {"skipped_reason": "installation_not_registered_or_suspended", "recorded": []}, "ignored"
         org_id = installation.org_id
         delivery.org_id = org_id
-        # story 를 **resolved org 로 스코프** 조회 — cross-org 차단 + 존재 oracle 차단(타 org story 는 not_found).
-        story = (
-            await session.execute(
-                select(Story).where(
-                    Story.id == story_id, Story.org_id == org_id, Story.deleted_at.is_(None)
-                )
-            )
-        ).scalar_one_or_none()
-        if story is None:
-            return {"skipped_reason": "story_not_found", "recorded": []}, "ignored"
-    else:
-        # legacy: 기존 동작 — Story.id 전역 조회 → org = story.org_id.
-        story = (
-            await session.execute(
-                select(Story).where(Story.id == story_id, Story.deleted_at.is_(None))
-            )
-        ).scalar_one_or_none()
-        if story is None:
-            return {"skipped_reason": "story_not_found", "recorded": []}, "ignored"
-        org_id = story.org_id
-        delivery.org_id = org_id
 
-    repo = (payload.get("repository") or {}).get("full_name") or ""
-    pr_number, merged, ci_conclusion, head_sha = _extract_pr_ci(event, payload)
-
-    # 행동 가능한 신호(머지 또는 CI 완료)가 없으면 skip(in_progress 등).
+    # 행동 가능한 신호(머지 또는 CI 완료)가 없으면 skip(in_progress 등) — resolve/side-effect 前.
     if not merged and ci_conclusion is None:
         return {"skipped_reason": "no_actionable_signal", "recorded": []}, "ignored"
+
+    # Bot-L.1 resolver 체인: explicit>auto high>SID>text. app=org-scoped(org 알려짐)·legacy=SID 전역→story.org_id.
+    rl = await resolve_story_for_pr(session, org_id, repo, pr_number, texts)
+    if rl.story_id is None:
+        return {"skipped_reason": rl.reason, "recorded": []}, "ignored"  # no_match/auto suggestion 등.
+    story_id = rl.story_id
+    org_id = rl.org_id  # app=입력 org·legacy=story.org_id(resolver 검증). 단일 진실원.
+    delivery.org_id = org_id
 
     # Bot-M.1: native CI 채움 — **installation 토큰**(org-scope)으로 statusCheckRollup pull(⚠️PAT fallback 없음).
     # app source 는 위서 resolve된 installation(suspended 제외) 직접 사용·legacy 는 org→installation resolve.
@@ -373,6 +358,19 @@ async def _process_webhook_event(
     )
     if native_ci_state is not None:
         result = {**result, "native_ci": {"state": native_ci_state, "reason": native_ci_reason}}
+
+    # Bot-L.1 close-on-merge: **confident link**(explicit·auto high·sid)+merge → story done(idempotent).
+    # med/low/text suggestion 은 should_auto_close=False → close 안 함(오매치 done 방지). gate-approve 와
+    # 동일 advance_story_to_done 헬퍼(단일 정책·중복 advance 0). actor=system(자동). already-done=no-op.
+    if merged and rl.should_auto_close:
+        story_obj = await session.get(Story, story_id)
+        closed = False
+        if story_obj is not None and story_obj.org_id == org_id:  # org-scope 재확인(anti-IDOR).
+            closed = await advance_story_to_done(session, org_id, story_obj, actor_type="system")
+        result = {
+            **result,
+            "auto_close": {"closed": closed, "source": rl.source, "confidence": rl.confidence},
+        }
     return result, "processed"
 
 

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -304,21 +304,16 @@ async def _advance_story_on_merge_approve(session: AsyncSession, gate: Gate, new
         return
     from app.models.pm import Story  # 순환 회피 lazy import.
 
-    story = await session.get(Story, gate.work_item_id)
-    if story is not None and story.status != "done":
-        old_status = story.status
-        story.status = "done"
-        await session.flush()
-        # 41a6e294: gate-driven done도 정상 status-change side-effects를 발화 — events(→L1
-        # activity_events 캡처=verdict 증거원)·webhook·L2 trigger·notification·activity. status만
-        # 직접 set하면 활동그래프 누락(게이트가 만든 done이 게이트 증거에 안 잡히는 자기모순).
-        # actor=resolver(승인 휴먼·#1504로 휴먼 보장). 정상 board 경로와 공유 helper(parity).
-        from app.services.story_status_events import emit_story_status_changed
+    # Bot-L.1: gate-approve 와 PR-merge close-on-merge 가 **단일 idempotent 헬퍼**(advance_story_to_done)를
+    # 공유한다 — 상태전이 정책을 1곳에 둬 중복 advance/drift 0. 헬퍼가 done side-effects(events→L1 verdict
+    # 증거·webhook·L2·notification·activity)를 발화(board parity). actor=resolver(승인 휴먼·#1504). 이미
+    # done/부재면 no-op(멱등).
+    from app.services.story_status_events import advance_story_to_done
 
-        await emit_story_status_changed(
-            session, gate.org_id, story, old_status,
-            actor_id=gate.resolver_id, actor_type="human",
-        )
+    story = await session.get(Story, gate.work_item_id)
+    await advance_story_to_done(
+        session, gate.org_id, story, actor_id=gate.resolver_id, actor_type="human",
+    )
 
 
 # gate_type → verdict source (qa→qa·merge→merge·deploy→design·pr_review→pr).

--- a/backend/app/services/pr_story_link.py
+++ b/backend/app/services/pr_story_link.py
@@ -104,7 +104,9 @@ async def _auto_match(
     scored: list[tuple[int, Story]] = []
     for s in stories:
         title_slug = _slugify(s.title)
-        if title_slug and (title_slug in pr_slugs or any(title_slug in sl for sl in pr_slugs if sl)):
+        # ⭐high 는 **exact slug equality** 만(story title slug == PR 텍스트(title/branch) 전체 slug).
+        # substring/contains 는 high 아님 — partial token overlap(medium/low)로 내려 오매치 auto-close 차단.
+        if title_slug and title_slug in pr_slugs:
             exact.append(s)
             continue
         overlap = len(_tokens(s.title) & pr_tokens)

--- a/backend/app/services/pr_story_link.py
+++ b/backend/app/services/pr_story_link.py
@@ -1,0 +1,239 @@
+"""E-GHAPP Bot-L.1: PR ↔ story resolver 체인 + auto-match 휴리스틱 + explicit link upsert.
+
+**컨벤션-free 링킹의 심장.** 유저가 `[SID:uuid]` 를 박지 않아도 봇이 PR↔story 를 해소한다.
+
+resolver 우선순위(deterministic): **explicit > auto_match(high only) > SID(_SID_RE) > auto_match(med/low
+suggestion) > none**. `should_auto_close` 는 confident link(explicit·auto high·sid exact)에만 True —
+close-on-merge 가 **오매치 done 을 못 내게** 한다(med/low/text 는 suggestion·done 금지).
+
+per-org 격리(anti-IDOR): org 가 알려진 경우(app webhook) 전 조회를 org-scope. org 미상(legacy webhook)이면
+SID 전역 조회로 story→org 를 도출(기존 무회귀). story 는 항상 `org_id AND deleted_at IS NULL` 재검증.
+"""
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.pm import Story
+from app.models.pull_request_story_link import PullRequestStoryLink
+from app.services.verdict_capture import parse_story_id  # _SID_RE 흡수(legacy 무회귀).
+
+_VALID_SOURCES = ("explicit", "auto_match", "sid", "text")
+_VALID_CONFIDENCE = ("high", "medium", "low")
+# auto-match 후보 본문 토큰화(소문자 영숫자). story title/slug 와 PR title/branch/body 비교용.
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+# 잡음 토큰(매칭 신호 약화 방지) — 흔한 PR/branch 접두.
+_STOP = {"feat", "fix", "chore", "refactor", "test", "docs", "the", "and", "for", "wip", "pr", "sid"}
+
+
+@dataclass
+class ResolvedLink:
+    story_id: uuid.UUID | None
+    org_id: uuid.UUID | None
+    source: str | None           # explicit | auto_match | sid | text | None
+    confidence: str | None       # high | medium | low | None
+    should_auto_close: bool      # confident(explicit·auto high·sid)만 True — 오매치 done 방지.
+    reason: str
+    evidence: dict | None = None
+
+
+def normalize_repo(repo: str | None) -> str:
+    """repo_full_name 정규화(lowercase·strip). 저장/조회 일관성(대소문자 우회 차단)."""
+    return (repo or "").strip().lower()
+
+
+def _tokens(text: str) -> set[str]:
+    return {t for t in _TOKEN_RE.findall((text or "").lower()) if t not in _STOP and len(t) >= 3}
+
+
+def _slugify(text: str) -> str:
+    return "-".join(_TOKEN_RE.findall((text or "").lower()))
+
+
+async def _scoped_story(session: AsyncSession, story_id: uuid.UUID, org_id: uuid.UUID) -> Story | None:
+    """org-scoped story 조회(anti-IDOR·타 org 미노출)."""
+    return (
+        await session.execute(
+            select(Story).where(
+                Story.id == story_id, Story.org_id == org_id, Story.deleted_at.is_(None)
+            )
+        )
+    ).scalar_one_or_none()
+
+
+async def _global_story(session: AsyncSession, story_id: uuid.UUID) -> Story | None:
+    """org 미상(legacy)일 때 전역 story 조회 → org 도출(기존 SID 흐름 무회귀)."""
+    return (
+        await session.execute(
+            select(Story).where(Story.id == story_id, Story.deleted_at.is_(None))
+        )
+    ).scalar_one_or_none()
+
+
+async def _auto_match(
+    session: AsyncSession, org_id: uuid.UUID, texts: list[str]
+) -> ResolvedLink | None:
+    """org 내 active story 들과 PR title/branch/body 토큰을 비교해 후보 추론(per-org).
+
+    high: title/slug exact match **& 후보 정확히 1개**. medium: partial token 다수 중복(후보 1). low/복수:
+    ambiguous. ⭐**high 만 canonical link/close** — med/low 는 suggestion(영속·done 금지)으로 오매치 방지.
+    """
+    pr_tokens: set[str] = set()
+    pr_slugs: set[str] = set()
+    for t in texts:
+        pr_tokens |= _tokens(t)
+        pr_slugs.add(_slugify(t))
+    if not pr_tokens:
+        return None
+    # 후보 풀: org 의 비-done active story(과도 스캔 방지 위해 done/삭제 제외).
+    stories = (
+        await session.execute(
+            select(Story).where(
+                Story.org_id == org_id,
+                Story.deleted_at.is_(None),
+                Story.status != "done",
+            )
+        )
+    ).scalars().all()
+
+    exact: list[Story] = []
+    scored: list[tuple[int, Story]] = []
+    for s in stories:
+        title_slug = _slugify(s.title)
+        if title_slug and (title_slug in pr_slugs or any(title_slug in sl for sl in pr_slugs if sl)):
+            exact.append(s)
+            continue
+        overlap = len(_tokens(s.title) & pr_tokens)
+        if overlap > 0:
+            scored.append((overlap, s))
+
+    if len(exact) == 1:
+        s = exact[0]
+        return ResolvedLink(
+            s.id, org_id, "auto_match", "high", True, "auto_title_slug_exact",
+            {"matched": "title_slug", "candidate_count": 1, "story_title": s.title},
+        )
+    if len(exact) > 1:
+        return ResolvedLink(
+            None, org_id, "auto_match", "low", False, "auto_ambiguous_exact",
+            {"matched": "title_slug", "candidate_count": len(exact)},
+        )
+    if scored:
+        scored.sort(key=lambda x: x[0], reverse=True)
+        top, story = scored[0]
+        # 단일 우세 후보(2위와 차이 있고 신호 충분) → medium suggestion(close 금지).
+        ambiguous = len(scored) > 1 and scored[1][0] == top
+        conf = "low" if (ambiguous or top < 2) else "medium"
+        return ResolvedLink(
+            None, org_id, "auto_match", conf, False, "auto_partial_token",
+            {"matched": "token_overlap", "overlap": top, "candidate_count": len(scored)},
+        )
+    return None
+
+
+async def resolve_story_for_pr(
+    session: AsyncSession,
+    org_id: uuid.UUID | None,
+    repo_full_name: str,
+    pr_number: int,
+    texts: list[str],
+) -> ResolvedLink:
+    """PR → story 해소(우선순위 체인). org_id None=legacy(SID 전역). 반환 should_auto_close 가 close-on-merge
+    가능 여부를 명시(구현 실수 방지)."""
+    repo = normalize_repo(repo_full_name)
+
+    # 1) explicit/저장된 canonical link(org-scoped). 명시연결이 최우선.
+    if org_id is not None and repo and pr_number:
+        link = (
+            await session.execute(
+                select(PullRequestStoryLink).where(
+                    PullRequestStoryLink.org_id == org_id,
+                    PullRequestStoryLink.repo_full_name == repo,
+                    PullRequestStoryLink.pr_number == pr_number,
+                    PullRequestStoryLink.deleted_at.is_(None),
+                )
+            )
+        ).scalar_one_or_none()
+        if link is not None:
+            story = await _scoped_story(session, link.story_id, org_id)
+            if story is not None:
+                close = link.link_source == "explicit" or (
+                    link.link_source in ("auto_match", "sid") and link.confidence == "high"
+                )
+                return ResolvedLink(
+                    story.id, org_id, link.link_source, link.confidence, close,
+                    "stored_explicit" if link.link_source == "explicit" else "stored_link",
+                    link.evidence,
+                )
+
+    # 2) auto_match high(org 알 때만) — high 만 SID 위로.
+    auto_suggestion: ResolvedLink | None = None
+    if org_id is not None:
+        am = await _auto_match(session, org_id, texts)
+        if am is not None and am.story_id is not None and am.confidence == "high":
+            return am
+        auto_suggestion = am  # med/low/ambiguous → SID 아래로 보류(close 금지).
+
+    # 3) SID(텍스트 태그·_SID_RE exact). org 알면 scoped·모르면 전역(legacy 무회귀).
+    sid = next((s for t in texts if (s := parse_story_id(t))), None)
+    if sid is not None:
+        story = (
+            await _scoped_story(session, sid, org_id) if org_id is not None
+            else await _global_story(session, sid)
+        )
+        if story is not None:
+            return ResolvedLink(
+                story.id, story.org_id, "sid", "high", True, "sid_exact", {"sid": str(sid)}
+            )
+
+    # 4) auto_match med/low → suggestion(영속·done 금지). 아니면 legacy 호환 skip reason.
+    if auto_suggestion is not None:
+        return auto_suggestion
+    # SID 있으나 story 미해소(org-scope 미매치 포함)=story_not_found·SID 없음=no_sid_tag(legacy 무회귀).
+    reason = "story_not_found" if sid is not None else "no_sid_tag"
+    return ResolvedLink(None, org_id, None, None, False, reason)
+
+
+async def upsert_link(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    story_id: uuid.UUID,
+    repo_full_name: str,
+    pr_number: int,
+    *,
+    link_source: str,
+    confidence: str,
+    created_by: uuid.UUID | None = None,
+    evidence: dict | None = None,
+) -> PullRequestStoryLink:
+    """canonical 단일 링크 upsert(uq org,repo,pr). 재링크=우선순위/소스 갱신. 호출자는 org-scope 검증 후 호출."""
+    repo = normalize_repo(repo_full_name)
+    existing = (
+        await session.execute(
+            select(PullRequestStoryLink).where(
+                PullRequestStoryLink.org_id == org_id,
+                PullRequestStoryLink.repo_full_name == repo,
+                PullRequestStoryLink.pr_number == pr_number,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        existing.story_id = story_id
+        existing.link_source = link_source
+        existing.confidence = confidence
+        existing.created_by = created_by
+        existing.evidence = evidence
+        existing.deleted_at = None
+        await session.flush()
+        return existing
+    link = PullRequestStoryLink(
+        org_id=org_id, story_id=story_id, repo_full_name=repo, pr_number=pr_number,
+        link_source=link_source, confidence=confidence, created_by=created_by, evidence=evidence,
+    )
+    session.add(link)
+    await session.flush()
+    return link

--- a/backend/app/services/story_status_events.py
+++ b/backend/app/services/story_status_events.py
@@ -137,3 +137,31 @@ async def emit_story_status_changed(
             await db.flush()
         except Exception:
             pass
+
+
+async def advance_story_to_done(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    story,
+    *,
+    actor_id: uuid.UUID | None = None,
+    actor_type: str | None = None,
+    actor_name: str | None = None,
+) -> bool:
+    """story 를 done 으로 전이하는 **단일 idempotent 헬퍼**(E-GHAPP Bot-L.1).
+
+    gate-approve(`_advance_story_on_merge_approve`)와 PR-merge close-on-merge 가 **공유**한다 — 상태전이
+    정책을 한 곳에 둬 중복 advance/drift 를 막는다. story None/이미 done 이면 **no-op(False)**. 전이 시
+    emit_story_status_changed 로 status_changed side-effects(events·webhook·L2·notification·activity)를
+    동일하게 발화(board 경로와 parity). 호출자는 org-scope 로 story 를 조회해 넘긴다(anti-IDOR).
+    """
+    if story is None or story.status == "done":
+        return False  # 멱등: 이미 done/부재 → no-op.
+    old_status = story.status
+    story.status = "done"
+    await db.flush()
+    await emit_story_status_changed(
+        db, org_id, story, old_status,
+        actor_id=actor_id, actor_type=actor_type, actor_name=actor_name,
+    )
+    return True

--- a/backend/tests/test_bot_l1_pr_story_link.py
+++ b/backend/tests/test_bot_l1_pr_story_link.py
@@ -111,6 +111,21 @@ async def test_resolver_auto_high_single_exact():
 
 
 @pytest.mark.anyio
+async def test_resolver_auto_substring_not_high_no_close():
+    """⭐substring/contains 는 high 아님(오매치 방지): story 'Login' + PR 'fix login bug' → high/close 금지.
+
+    exact slug equality 만 high. 'login' 은 'fix-login-bug' 의 부분문자열이지만 != 전체 slug → token overlap
+    (medium/low) → canonical link/auto-close 안 됨(story_id None·should_auto_close False).
+    """
+    story = _story(id=uuid.uuid4(), title="Login")
+    # explicit(None) → auto_stories([story]) → SID(None). auto 가 high 면 안 됨.
+    session = _session([_scalar(None), _scalars([story]), _scalar(None)])
+    rl = await resolve_story_for_pr(session, ORG_A, "org/repo", 9, ["fix login bug"])
+    assert rl.confidence != "high"
+    assert rl.story_id is None and rl.should_auto_close is False  # auto-close 안 됨.
+
+
+@pytest.mark.anyio
 async def test_resolver_auto_ambiguous_multiple_exact_no_close():
     """동일 slug 후보 복수 → ambiguous low·link 없음·close 금지(오매치 방지)."""
     s1, s2 = _story(id=uuid.uuid4(), title="Add SSO login"), _story(id=uuid.uuid4(), title="Add SSO login")
@@ -146,7 +161,11 @@ def test_normalize_repo_lowercase():
 
 
 # ── explicit-link endpoint (anti-IDOR) ───────────────────────────────────────────
-async def _post_link(body, *, org_id=ORG_A, story_result, member_id=None):
+def _inst(account_login="org"):
+    return MagicMock(account_login=account_login, suspended_at=None)
+
+
+async def _post_link(body, *, org_id=ORG_A, story_result, installation_result=None, member_id=None):
     from app.dependencies.auth import get_current_user, get_verified_org_id
     from app.dependencies.database import get_db
     from app.main import app as fastapi_app
@@ -154,9 +173,12 @@ async def _post_link(body, *, org_id=ORG_A, story_result, member_id=None):
 
     session = AsyncMock()
     session.add = MagicMock()
-    res = MagicMock()
-    res.scalar_one_or_none.return_value = story_result
-    session.execute = AsyncMock(return_value=res)
+    story_res = MagicMock()
+    story_res.scalar_one_or_none.return_value = story_result
+    inst_res = MagicMock()
+    inst_res.scalar_one_or_none.return_value = installation_result
+    # 쿼리 순서: ①story org-scope ②installation(repo-context). story None 이면 installation 미도달.
+    session.execute = AsyncMock(side_effect=[story_res, inst_res, inst_res])
     session.commit = AsyncMock()
     session.flush = AsyncMock()
 
@@ -181,10 +203,11 @@ async def _post_link(body, *, org_id=ORG_A, story_result, member_id=None):
 
 @pytest.mark.anyio
 async def test_explicit_link_same_org_success():
+    """story org-scope 통과 + repo owner == installation account_login → upsert."""
     body = {"story_id": str(STORY_ID), "repo_full_name": "org/repo", "pr_number": 7}
-    resp, up = await _post_link(body, story_result=_story(org_id=ORG_A))
+    resp, up = await _post_link(body, story_result=_story(org_id=ORG_A), installation_result=_inst("org"))
     assert resp.status_code == 200
-    up.assert_awaited_once()  # org-scope story 통과 → upsert.
+    up.assert_awaited_once()
 
 
 @pytest.mark.anyio
@@ -197,9 +220,23 @@ async def test_explicit_link_cross_org_404_no_oracle():
 
 
 @pytest.mark.anyio
+async def test_explicit_link_repo_not_in_org_context_404():
+    """story 는 org 소속이나 repo owner != installation account(or 미설치) → generic 404·upsert 0(repo oracle 0)."""
+    body = {"story_id": str(STORY_ID), "repo_full_name": "evil/repo", "pr_number": 7}
+    # owner 'evil' != installation account 'org' → repo_not_in_org_context.
+    resp, up = await _post_link(body, story_result=_story(org_id=ORG_A), installation_result=_inst("org"))
+    assert resp.status_code == 404
+    up.assert_not_awaited()
+    # 미설치(installation None)도 동일 404.
+    resp2, up2 = await _post_link(body, story_result=_story(org_id=ORG_A), installation_result=None)
+    assert resp2.status_code == 404
+    up2.assert_not_awaited()
+
+
+@pytest.mark.anyio
 async def test_explicit_link_invalid_pr_identity_422():
     body = {"story_id": str(STORY_ID), "repo_full_name": "  ", "pr_number": 0}
-    resp, up = await _post_link(body, story_result=_story(org_id=ORG_A))
+    resp, up = await _post_link(body, story_result=_story(org_id=ORG_A), installation_result=_inst("org"))
     assert resp.status_code == 422
     up.assert_not_awaited()
 

--- a/backend/tests/test_bot_l1_pr_story_link.py
+++ b/backend/tests/test_bot_l1_pr_story_link.py
@@ -1,0 +1,269 @@
+"""E-GHAPP Bot-L.1: PR↔story 링크 모델·resolver 체인·auto-match·close-on-merge 단위(산티아고 게이트).
+
+커버: advance_story_to_done idempotent · resolver priority(explicit>auto high>SID) · auto high single-exact
+만 link/close · auto medium/low/ambiguous suggestion(close 0) · SID legacy(org None) 무회귀 · explicit-link
+endpoint anti-IDOR(same-org success·cross-org 404 oracle 0) · upsert · close-on-merge confident-only.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.services import pr_story_link as prl
+from app.services.pr_story_link import ResolvedLink, normalize_repo, resolve_story_for_pr
+
+ORG_A = uuid.uuid4()
+ORG_B = uuid.uuid4()
+STORY_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _scalar(val):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = val
+    return r
+
+
+def _scalars(rows):
+    r = MagicMock()
+    r.scalars.return_value.all.return_value = list(rows)
+    return r
+
+
+def _session(execute_seq):
+    s = AsyncMock()
+    s.execute = AsyncMock(side_effect=list(execute_seq))
+    return s
+
+
+def _story(id=STORY_ID, org_id=ORG_A, title="Add SSO login", status="in_progress"):
+    return MagicMock(id=id, org_id=org_id, title=title, status=status)
+
+
+def _link(story_id=STORY_ID, source="explicit", confidence="high"):
+    return MagicMock(story_id=story_id, link_source=source, confidence=confidence, evidence=None)
+
+
+# ── advance_story_to_done (단일 idempotent 헬퍼) ──────────────────────────────────
+@pytest.mark.anyio
+async def test_advance_story_to_done_transitions_and_emits():
+    from app.services.story_status_events import advance_story_to_done
+    story = _story(status="in_review")
+    session = AsyncMock()
+    with patch("app.services.story_status_events.emit_story_status_changed", new=AsyncMock()) as emit:
+        changed = await advance_story_to_done(session, ORG_A, story, actor_type="system")
+    assert changed is True and story.status == "done"
+    emit.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_advance_story_to_done_idempotent_when_already_done():
+    from app.services.story_status_events import advance_story_to_done
+    story = _story(status="done")
+    session = AsyncMock()
+    with patch("app.services.story_status_events.emit_story_status_changed", new=AsyncMock()) as emit:
+        changed = await advance_story_to_done(session, ORG_A, story, actor_type="system")
+    assert changed is False                 # 이미 done → no-op.
+    emit.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_advance_story_to_done_noop_when_none():
+    from app.services.story_status_events import advance_story_to_done
+    assert await advance_story_to_done(AsyncMock(), ORG_A, None, actor_type="system") is False
+
+
+# ── resolver 우선순위 ─────────────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_resolver_explicit_wins():
+    """explicit link 존재 → 최우선·should_auto_close=True. SID/auto 미조회."""
+    story = _story()
+    session = _session([_scalar(_link(source="explicit")), _scalar(story)])  # explicit → scoped story.
+    rl = await resolve_story_for_pr(session, ORG_A, "Org/Repo", 7, ["feat [SID:%s]" % uuid.uuid4()])
+    assert rl.story_id == STORY_ID and rl.source == "explicit" and rl.should_auto_close is True
+
+
+@pytest.mark.anyio
+async def test_resolver_sid_legacy_no_org():
+    """legacy(org None): explicit/auto skip → SID 전역 → high·close=True(무회귀)."""
+    story = _story()
+    session = _session([_scalar(story)])  # SID 전역 1쿼리.
+    rl = await resolve_story_for_pr(session, None, "Org/Repo", 7, ["feat [SID:%s]" % STORY_ID])
+    assert rl.story_id == STORY_ID and rl.source == "sid" and rl.confidence == "high" and rl.should_auto_close
+
+
+@pytest.mark.anyio
+async def test_resolver_auto_high_single_exact():
+    """auto-match: title slug exact & 후보 1개 → high·link/close 가능."""
+    story = _story(title="Add SSO login")
+    # explicit(None) → auto_stories([story]) (SID 미도달·auto high 즉시 반환).
+    session = _session([_scalar(None), _scalars([story])])
+    rl = await resolve_story_for_pr(session, ORG_A, "org/repo", 9, ["Add SSO login"])
+    assert rl.story_id == STORY_ID and rl.source == "auto_match" and rl.confidence == "high"
+    assert rl.should_auto_close is True
+
+
+@pytest.mark.anyio
+async def test_resolver_auto_ambiguous_multiple_exact_no_close():
+    """동일 slug 후보 복수 → ambiguous low·link 없음·close 금지(오매치 방지)."""
+    s1, s2 = _story(id=uuid.uuid4(), title="Add SSO login"), _story(id=uuid.uuid4(), title="Add SSO login")
+    session = _session([_scalar(None), _scalars([s1, s2]), _scalar(None)])  # explicit·auto(복수)·SID(None).
+    rl = await resolve_story_for_pr(session, ORG_A, "org/repo", 9, ["Add SSO login"])
+    assert rl.story_id is None and rl.should_auto_close is False  # canonical link/close 금지.
+
+
+@pytest.mark.anyio
+async def test_resolver_auto_partial_medium_no_close_falls_below_sid():
+    """partial token 후보(medium) + SID 있으면 SID(high)가 우선. SID 없으면 medium suggestion(close 0)."""
+    partial = _story(id=uuid.uuid4(), title="Refactor SSO token cache layer")
+    sid_story = _story(id=STORY_ID, title="Whatever")
+    # SID 존재 케이스: explicit(None)·auto([partial]→medium)·SID(sid_story) → SID high 우선.
+    session = _session([_scalar(None), _scalars([partial]), _scalar(sid_story)])
+    rl = await resolve_story_for_pr(session, ORG_A, "org/repo", 9, ["feat sso token [SID:%s]" % STORY_ID])
+    assert rl.source == "sid" and rl.should_auto_close is True  # auto medium 이 SID 아래.
+
+
+@pytest.mark.anyio
+async def test_resolver_no_match_reason_legacy():
+    """SID 없음(legacy) → no_sid_tag. SID 있으나 story 없음 → story_not_found."""
+    s1 = _session([_scalar(None)])  # legacy SID 전역 미스(SID 없음 → SID 쿼리 자체 없음).
+    rl1 = await resolve_story_for_pr(s1, None, "o/r", 1, ["no tag here"])
+    assert rl1.story_id is None and rl1.reason == "no_sid_tag"
+    s2 = _session([_scalar(None)])  # SID 있으나 전역 story None.
+    rl2 = await resolve_story_for_pr(s2, None, "o/r", 1, ["feat [SID:%s]" % uuid.uuid4()])
+    assert rl2.story_id is None and rl2.reason == "story_not_found"
+
+
+def test_normalize_repo_lowercase():
+    assert normalize_repo("  MoonkLabs/Sprintable ") == "moonklabs/sprintable"
+
+
+# ── explicit-link endpoint (anti-IDOR) ───────────────────────────────────────────
+async def _post_link(body, *, org_id=ORG_A, story_result, member_id=None):
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+    from app.main import app as fastapi_app
+    from app.routers import github_integration as gi
+
+    session = AsyncMock()
+    session.add = MagicMock()
+    res = MagicMock()
+    res.scalar_one_or_none.return_value = story_result
+    session.execute = AsyncMock(return_value=res)
+    session.commit = AsyncMock()
+    session.flush = AsyncMock()
+
+    async def override_db():
+        yield session
+
+    fastapi_app.dependency_overrides[get_db] = override_db
+    fastapi_app.dependency_overrides[get_verified_org_id] = lambda: org_id
+    # 엔드포인트는 auth.user_id(=member id)만 사용 → 경량 stub(AuthContext 전체 생성자 회피).
+    fastapi_app.dependency_overrides[get_current_user] = lambda: MagicMock(
+        user_id=str(member_id or uuid.uuid4())
+    )
+    try:
+        async with AsyncClient(transport=ASGITransport(app=fastapi_app), base_url="http://test") as c:
+            with patch.object(gi, "upsert_link", new=AsyncMock(return_value=MagicMock(
+                id=uuid.uuid4(), repo_full_name="org/repo", pr_number=body["pr_number"]))) as up:
+                resp = await c.post("/api/v2/integrations/github/links", json=body)
+        return resp, up
+    finally:
+        fastapi_app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_explicit_link_same_org_success():
+    body = {"story_id": str(STORY_ID), "repo_full_name": "org/repo", "pr_number": 7}
+    resp, up = await _post_link(body, story_result=_story(org_id=ORG_A))
+    assert resp.status_code == 200
+    up.assert_awaited_once()  # org-scope story 통과 → upsert.
+
+
+@pytest.mark.anyio
+async def test_explicit_link_cross_org_404_no_oracle():
+    """타 org story_id → org-scope 조회 미스 → generic 404·upsert 0(존재 oracle 0)."""
+    body = {"story_id": str(STORY_ID), "repo_full_name": "org/repo", "pr_number": 7}
+    resp, up = await _post_link(body, story_result=None)  # 타 org/부재 → scoped 미스.
+    assert resp.status_code == 404
+    up.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_explicit_link_invalid_pr_identity_422():
+    body = {"story_id": str(STORY_ID), "repo_full_name": "  ", "pr_number": 0}
+    resp, up = await _post_link(body, story_result=_story(org_id=ORG_A))
+    assert resp.status_code == 422
+    up.assert_not_awaited()
+
+
+# ── close-on-merge (웹훅 통합·confident-only) ─────────────────────────────────────
+import hashlib  # noqa: E402
+import hmac  # noqa: E402
+import json  # noqa: E402
+
+_WH_SECRET = "legacy-wh-secret"
+
+
+async def _merge_webhook(*, should_close: bool):
+    """legacy merge PR(SID·head.sha 없음→native CI skip) → close-on-merge 경로 검증."""
+    from app.dependencies.database import get_db
+    from app.main import app as fastapi_app
+    from app.routers import verdict_capture as vmod
+
+    story = _story(id=STORY_ID, org_id=ORG_A, status="in_review")
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.rollback = AsyncMock()
+    session.execute = AsyncMock(return_value=_scalar(story))  # SID 전역 story.
+    session.get = AsyncMock(return_value=story)
+
+    async def override_db():
+        yield session
+
+    fastapi_app.dependency_overrides[get_db] = override_db
+    payload = {"action": "closed", "repository": {"full_name": "o/r"},
+               "pull_request": {"number": 5, "merged": True, "title": f"feat [SID:{STORY_ID}]"}}
+    body = json.dumps(payload).encode()
+    sig = "sha256=" + hmac.new(_WH_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    headers = {"X-GitHub-Event": "pull_request", "X-GitHub-Delivery": "m1", "X-Hub-Signature-256": sig}
+    # resolver 가 반환할 should_auto_close 를 강제(SID=True / 비confident=False) — close 분기만 격리 검증.
+    rl = ResolvedLink(STORY_ID, ORG_A, "sid", "high", should_close, "sid_exact")
+    try:
+        async with AsyncClient(transport=ASGITransport(app=fastapi_app), base_url="http://test") as c:
+            with patch.object(vmod.settings, "github_webhook_secret", _WH_SECRET), \
+                 patch.object(vmod.settings, "github_app_webhook_secret", ""), \
+                 patch.object(vmod, "resolve_story_for_pr", new=AsyncMock(return_value=rl)), \
+                 patch.object(vmod, "capture_pr_ci_verdict",
+                              new=AsyncMock(return_value={"recorded": ["pr"], "skipped_reason": None})), \
+                 patch.object(vmod, "advance_story_to_done", new=AsyncMock(return_value=True)) as adv:
+                resp = await c.post("/api/v2/internal/verdict/github-webhook", content=body, headers=headers)
+        return resp, adv, session
+    finally:
+        fastapi_app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_close_on_merge_confident_advances_story():
+    """merge + confident link(should_auto_close) → advance_story_to_done 호출(done)."""
+    resp, adv, session = await _merge_webhook(should_close=True)
+    assert resp.status_code == 200
+    adv.assert_awaited_once()  # 단일 헬퍼로 done 진행.
+    assert "auto_close" in resp.text
+
+
+@pytest.mark.anyio
+async def test_close_on_merge_skips_when_not_confident():
+    """merge 라도 should_auto_close=False(med/low/text) → advance 미호출(오매치 done 0)."""
+    resp, adv, session = await _merge_webhook(should_close=False)
+    assert resp.status_code == 200
+    adv.assert_not_awaited()

--- a/backend/tests/test_bot_m2_webhook_integration.py
+++ b/backend/tests/test_bot_m2_webhook_integration.py
@@ -43,16 +43,26 @@ def _sign(body: bytes, secret: str) -> str:
 
 
 def _result(val):
+    """val 이 list 면 scalars().all()=val(스캔 쿼리)·아니면 scalar_one_or_none=val(단건 쿼리)."""
     r = MagicMock()
-    r.scalar_one_or_none.return_value = val
+    if isinstance(val, list):
+        r.scalar_one_or_none.return_value = None
+        r.scalars.return_value.all.return_value = val
+    else:
+        r.scalar_one_or_none.return_value = val
+        r.scalars.return_value.all.return_value = []
     return r
 
 
 def _mk_session(execute_results=(), *, flush_error=False):
-    """execute 는 호출 순서대로 execute_results 의 scalar 값 반환(여분은 None). add sync·flush 옵션 IntegrityError."""
+    """execute 는 호출 순서대로 execute_results 반환(여분 빈 결과). add sync·flush 옵션 IntegrityError.
+
+    Bot-L.1 resolver 쿼리 순서 — app: [installation, explicit_link, auto_stories(list), sid_story],
+    legacy: [sid_story(전역)]. native CI skip(ci=failure)·close-on-merge skip(merged=False) 가정.
+    """
     session = AsyncMock()
     session.add = MagicMock()
-    seq = [_result(v) for v in execute_results] + [_result(None) for _ in range(4)]
+    seq = [_result(v) for v in execute_results] + [_result(None) for _ in range(6)]
     session.execute = AsyncMock(side_effect=seq)
     session.flush = AsyncMock(
         side_effect=IntegrityError("dup", {}, Exception()) if flush_error else None
@@ -149,8 +159,9 @@ async def test_malformed_json_with_invalid_sig_401_not_parse_error():
 # ── dual-secret source 결정 ──────────────────────────────────────────────────────
 @pytest.mark.anyio
 async def test_app_source_routed_by_app_secret():
-    """app secret 서명 → source=app → installation resolve(org_a) 先 → org-scoped story → capture(org_a)."""
-    session = _mk_session([_inst(ORG_A), _story(ORG_A)])  # execute: installation→story 순.
+    """app secret 서명 → source=app → installation resolve(org_a) 先 → resolver(explicit∅·auto∅·SID) → capture(org_a)."""
+    # 쿼리 순서: installation → explicit_link(None) → auto_stories([]) → sid_story(org_a).
+    session = _mk_session([_inst(ORG_A), None, [], _story(ORG_A)])
     resp, session, cap = await _post(_wf(), sign_secret=APP_SECRET, session=session)
     assert resp.status_code == 200
     cap.assert_awaited_once()
@@ -241,8 +252,8 @@ async def test_app_unregistered_or_suspended_installation_ignored():
 @pytest.mark.anyio
 async def test_app_cross_org_sid_not_found_via_scoped_query():
     """app installation=org_a resolve인데 SID story가 타 org → org-scoped 조회서 미매치(not_found)·capture 0."""
-    # execute: installation(org_a) → story scoped query(org_a) 미매치 → None.
-    session = _mk_session([_inst(ORG_A), None])
+    # execute: installation(org_a) → explicit_link(None) → auto_stories([]) → sid scoped(org_a) 미매치(None).
+    session = _mk_session([_inst(ORG_A), None, [], None])
     resp, session, cap = await _post(_wf(), sign_secret=APP_SECRET, session=session)
     assert resp.status_code == 200
     assert "story_not_found" in resp.text  # 전역 lookup 아닌 org-scoped 미매치.

--- a/backend/tests/test_h1_s6_github_webhook.py
+++ b/backend/tests/test_h1_s6_github_webhook.py
@@ -97,9 +97,11 @@ async def _post(payload: dict, *, event: str, story=..., sign=True, installation
     session = AsyncMock()
     session.add = MagicMock()  # add 는 sync(AsyncMock 경고 방지).
     result = MagicMock()
-    result.scalar_one_or_none.return_value = (
-        MagicMock(org_id=ORG_ID) if story is ... else story
-    )
+    # resolver 가 story.id 를 반환 → SID-source capture story_id 검증 위해 mock story.id=STORY_ID.
+    # auto_match `.scalars().all()` 는 빈 리스트(legacy=org None 이라 애초 미실행이나 방어).
+    story_mock = MagicMock(id=STORY_ID, org_id=ORG_ID) if story is ... else story
+    result.scalar_one_or_none.return_value = story_mock
+    result.scalars.return_value.all.return_value = []
     if installation is ...:
         session.execute = AsyncMock(return_value=result)  # 모든 query 동일(기존 동작).
     else:


### PR DESCRIPTION
## Summary
E-GHAPP **Bot-L.1** (BE) — convention-free PR↔story linking: a new link model + deterministic resolver chain + auto-match heuristic + close-on-merge, so users no longer need to embed `[SID:uuid]`. Santiago's security findings mapped 1:1.

## Story
[SID:fd6a5215-c66c-48ba-a9b1-c8afd3d15d54]

## What
- **Model** `pull_request_story_link` (migration 0135, additive): per-org (`org_id` FK), `story_id` FK, `repo_full_name` (lowercase-normalized), `pr_number`, `link_source` (explicit|auto_match|sid|text), `confidence` (high|medium|low), `created_by`, `evidence` JSONB, soft-delete. **`uq(org_id, repo_full_name, pr_number)`** — canonical single link per PR (relink = upsert).
- **Resolver** `resolve_story_for_pr` → `ResolvedLink(story_id, org_id, source, confidence, should_auto_close, reason, evidence)`: **explicit > auto_match(high) > SID(`_SID_RE` absorbed) > auto med/low suggestion > none**. app = org-scoped (org known); legacy = global SID → `story.org_id` (no-regression). Every story read re-validated `org_id AND deleted_at`.
- **Auto-match** (per-org candidates): title-slug exact & single candidate = high (link/close); partial = medium; multiple/weak = low. **Only high creates a canonical link / auto-closes**; med/low/ambiguous = suggestion (not persisted, no close) — mismatch guard.
- **Close-on-merge**: Bot-M.2 unified webhook merge + `should_auto_close` (confident) → story done, via a **single idempotent helper `advance_story_to_done`** shared by gate-approve + PR-merge (one state-transition policy, no double-advance, already-done no-op).
- **Explicit-link endpoint** `POST /api/v2/integrations/github/links`: org-member auth, **anti-IDOR** (story must belong to caller org; non-member/absent → generic 404, no existence oracle), org-scoped upsert.

## Santiago security-checklist mapping
per-org isolation ✅ · explicit-link authz anti-IDOR (caller org + `Story.id AND org_id AND deleted_at`) ✅ · resolver priority no-regression ✅ · med/low/ambiguous no auto-link/no auto-close ✅ · close-on-merge confident-only ✅ · single `advance_story_to_done` idempotent helper (gate-approve + PR-merge) ✅ · `_SID_RE` legacy no-regression ✅.

## Files
`models/pull_request_story_link.py` · `alembic/0135_pull_request_story_link.py` · `services/pr_story_link.py` (resolver/auto-match/upsert) · `services/story_status_events.py` (`advance_story_to_done`) · `services/gate_service.py` (`_advance_story_on_merge_approve` → shared helper) · `routers/verdict_capture.py` (`_process_webhook_event` resolver + close-on-merge) · `routers/github_integration.py` (explicit-link endpoint) · `tests/test_bot_l1_pr_story_link.py` (15) + webhook/h1_s6 regression updates.

## Verification
- `CI=1` suite: **89 passed, 2 skipped** (incl. gate-approve no-regression via test_merge_verdict_gate, Bot-M.2 webhook). alembic head = 0135. app loads.
- Fresh-DB CI applies 0135. Close-on-merge live-verifiable via our-repo legacy webhook (App not required); App-source explicit/auto verified after App registration.

## Out of scope
Bot-L.2 = FE explicit-link UI (Yuna design → Mirko, after this BE API). Repo-ownership deeper model = future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
