### PR TITLE
[E-GHAPP][Bot-L.2-BE] feat: PR↔story 링크 GET(list) / DELETE(unlink) endpoint

### DIFF
--- a/backend/app/routers/github_integration.py
+++ b/backend/app/routers/github_integration.py
@@ -23,6 +23,7 @@ from app.dependencies.auth import AuthContext, get_current_user, get_verified_or
 from app.dependencies.database import get_db
 from app.models.github_installation import GithubInstallation, GithubInstallNonce
 from app.models.pm import Story
+from app.models.pull_request_story_link import PullRequestStoryLink
 from app.services.github_app import (
     fetch_installation_metadata,
     sign_install_state,
@@ -215,3 +216,72 @@ async def create_explicit_link(
             "confidence": "high",
         }
     )
+
+
+def _link_view(link: PullRequestStoryLink) -> dict:
+    return {
+        "id": str(link.id),
+        "repo_full_name": link.repo_full_name,
+        "pr_number": link.pr_number,
+        "link_source": link.link_source,
+        "confidence": link.confidence,
+        "evidence": link.evidence,
+        "created_at": link.created_at.isoformat() if link.created_at else None,
+    }
+
+
+@router.get("/links")
+async def list_links(
+    story_id: uuid.UUID = Query(...),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """story 의 PR↔story 링크 목록(Bot-L.2 UI '연결 PR 표시'). org-scope·story 선검증(anti-IDOR).
+    타 org/부재 story = generic 404(존재 oracle 0). 링크는 org+story+미삭제만 반환."""
+    story = (
+        await session.execute(
+            select(Story).where(
+                Story.id == story_id, Story.org_id == org_id, Story.deleted_at.is_(None)
+            )
+        )
+    ).scalar_one_or_none()
+    if story is None:
+        return JSONResponse(status_code=404, content={"error": "story_not_found"})
+    links = (
+        await session.execute(
+            select(PullRequestStoryLink)
+            .where(
+                PullRequestStoryLink.org_id == org_id,
+                PullRequestStoryLink.story_id == story_id,
+                PullRequestStoryLink.deleted_at.is_(None),
+            )
+            .order_by(PullRequestStoryLink.created_at.desc())
+        )
+    ).scalars().all()
+    return JSONResponse(content={"links": [_link_view(link) for link in links]})
+
+
+@router.delete("/links/{link_id}")
+async def delete_link(
+    link_id: uuid.UUID,
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """PR↔story 링크 해제(Bot-L.2 UI '해제'·soft-delete). ⭐anti-IDOR: `link.id AND org_id` — 타 org/부재/
+    이미 삭제는 generic 404(존재 oracle 0). soft-delete(deleted_at) 라 close-on-merge resolver 에서 즉시 제외."""
+    link = (
+        await session.execute(
+            select(PullRequestStoryLink).where(
+                PullRequestStoryLink.id == link_id,
+                PullRequestStoryLink.org_id == org_id,
+                PullRequestStoryLink.deleted_at.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    if link is None:
+        return JSONResponse(status_code=404, content={"error": "link_not_found"})
+    link.deleted_at = datetime.now(timezone.utc)
+    await session.commit()
+    return JSONResponse(content={"deleted": True, "id": str(link_id)})

--- a/backend/tests/test_bot_l2_be_links.py
+++ b/backend/tests/test_bot_l2_be_links.py
@@ -1,0 +1,116 @@
+"""E-GHAPP Bot-L.2-BE: PR↔story 링크 GET(list) / DELETE(unlink) endpoint 보안 단위(산티아고 게이트).
+
+커버: GET org-scope + story 선검증(타 org/부재=generic 404 oracle 0)·org+story+미삭제 링크만 반환 ·
+DELETE anti-IDOR(link.id AND org_id·타 org/부재/이미삭제=generic 404)·soft-delete(deleted_at).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+ORG_A = uuid.uuid4()
+STORY_ID = uuid.uuid4()
+LINK_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _story(org_id=ORG_A):
+    return MagicMock(id=STORY_ID, org_id=org_id)
+
+
+def _link(org_id=ORG_A):
+    return MagicMock(
+        id=LINK_ID, org_id=org_id, story_id=STORY_ID, repo_full_name="org/repo", pr_number=7,
+        link_source="explicit", confidence="high", evidence={"by": "explicit_api"},
+        created_at=datetime(2026, 6, 22, tzinfo=timezone.utc), deleted_at=None,
+    )
+
+
+def _client_session(*, execute_results):
+    """execute side_effect=execute_results(scalar 또는 list)·commit/flush mock."""
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.flush = AsyncMock()
+    seq = []
+    for v in execute_results:
+        r = MagicMock()
+        if isinstance(v, list):
+            r.scalars.return_value.all.return_value = v
+            r.scalar_one_or_none.return_value = None
+        else:
+            r.scalar_one_or_none.return_value = v
+        seq.append(r)
+    session.execute = AsyncMock(side_effect=seq + [MagicMock()])
+    return session
+
+
+async def _req(method, path, *, execute_results, org_id=ORG_A):
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+    from app.main import app as fastapi_app
+
+    session = _client_session(execute_results=execute_results)
+
+    async def override_db():
+        yield session
+
+    fastapi_app.dependency_overrides[get_db] = override_db
+    fastapi_app.dependency_overrides[get_verified_org_id] = lambda: org_id
+    fastapi_app.dependency_overrides[get_current_user] = lambda: MagicMock(user_id=str(uuid.uuid4()))
+    try:
+        async with AsyncClient(transport=ASGITransport(app=fastapi_app), base_url="http://test") as c:
+            resp = await c.request(method, path)
+        return resp, session
+    finally:
+        fastapi_app.dependency_overrides.clear()
+
+
+# ── GET list ──────────────────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_list_links_same_org_returns_links():
+    # execute: story(org_a) → links([link]).
+    resp, _ = await _req("GET", f"/api/v2/integrations/github/links?story_id={STORY_ID}",
+                         execute_results=[_story(ORG_A), [_link(ORG_A)]])
+    assert resp.status_code == 200
+    body = resp.json()
+    data = body.get("data", body)
+    assert len(data["links"]) == 1
+    assert data["links"][0]["repo_full_name"] == "org/repo" and data["links"][0]["confidence"] == "high"
+
+
+@pytest.mark.anyio
+async def test_list_links_cross_org_story_404_no_oracle():
+    """타 org/부재 story → story 선검증 미스 → generic 404·링크 조회 0(oracle 0)."""
+    resp, session = await _req("GET", f"/api/v2/integrations/github/links?story_id={STORY_ID}",
+                               execute_results=[None])  # story scoped 미스.
+    assert resp.status_code == 404
+    assert session.execute.await_count == 1  # story 검증만 — 링크 조회 안 함.
+
+
+# ── DELETE unlink ───────────────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_delete_link_same_org_soft_deletes():
+    link = _link(ORG_A)
+    resp, session = await _req("DELETE", f"/api/v2/integrations/github/links/{LINK_ID}",
+                               execute_results=[link])
+    assert resp.status_code == 200
+    assert link.deleted_at is not None      # soft-delete.
+    session.commit.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_delete_link_cross_org_404_no_oracle():
+    """타 org/부재/이미삭제 link → `id AND org_id AND deleted_at IS NULL` 미스 → generic 404·commit 0."""
+    resp, session = await _req("DELETE", f"/api/v2/integrations/github/links/{LINK_ID}",
+                               execute_results=[None])  # 타 org → org-scoped 미스.
+    assert resp.status_code == 404
+    session.commit.assert_not_awaited()  # side-effect 0.


### PR DESCRIPTION
## Summary
E-GHAPP **Bot-L.2-BE** — the BE slice for the Bot-L.2 FE explicit-link UI: adds **GET (list)** + **DELETE (unlink)** to the existing POST (create), so the UI can show connected PRs and unlink them. Santiago's contract 1:1.

## Story
[SID:2c44acd3-f7c5-4715-8e86-7e2887cbd6cf]

## Endpoints
- **GET `/api/v2/integrations/github/links?story_id=`** — org-scoped; story re-validated (`Story.id AND org_id AND deleted_at IS NULL`, cross-org/absent → generic 404, no oracle); returns links (`org_id AND story_id AND deleted_at IS NULL`, created_at desc) with repo/pr/source/confidence/evidence/created_at.
- **DELETE `/api/v2/integrations/github/links/{id}`** — **anti-IDOR** `id AND org_id AND deleted_at IS NULL` (cross-org/absent/already-deleted → generic 404, no oracle); **soft-delete** (`deleted_at`) so the resolver/close-on-merge drops it immediately.
- POST create (Bot-L.1) anti-IDOR (story org-scope + repo installation ownership) — no regression.

## Verification
- `CI=1`: **70 passed** (Bot-L.2-BE GET/DELETE + Bot-L.1 POST no-regression + Bot-M.2 + Bot-S). app loads. No model/migration change (reuses Bot-L.1's `pull_request_story_link` soft-delete + per-org).
- Tests: GET same-org returns links · cross-org/absent story → 404 (0 link query) · DELETE same-org soft-delete + commit · cross-org → 404 + commit 0.

## FE mapping (Bot-L.2 — Yuna/Mirko)
GET → show connected PRs · POST → add · DELETE → unlink. Santiago's UX findings (generic-404 neutral copy, high vs med/low visual split, installation-repo-only add) land in the FE design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
