### PR TITLE
[SID:5844a011] 보드 A "정갈한 밀도" 재설계 (부품 한 벌·순수 시각·기능 동결)

### DIFF
--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -129,7 +129,7 @@ export function KanbanColumn({
         ? 'bg-success/5'
         : isInvalidTarget
           ? 'bg-muted/20 opacity-45'
-          : statusColor.tint;
+          : 'bg-transparent'; // E-MODERN A: status 색 tint 배경 전면 제거(색=신호만·헤더 dot이 유일 상태색)
 
   return (
     <div
@@ -137,7 +137,7 @@ export function KanbanColumn({
       className={`flex h-full flex-col rounded-xl p-3 transition ${collapsed ? 'w-[52px] min-w-[52px]' : 'w-[280px] min-w-[240px]'} ${colClass}`}
     >
       {isDragging && isValidTarget && (
-        <div className="mb-3 rounded-xl border border-success-border/30 bg-success-tint px-2 py-1 text-center text-[10px] font-medium uppercase tracking-widest text-success/70">
+        <div className="mb-3 rounded-md border border-success-border/30 bg-success-tint px-2 py-1 text-center text-[10px] font-medium text-success/70">
           {t('validDrop')}
         </div>
       )}
@@ -155,39 +155,33 @@ export function KanbanColumn({
               >
                 <ChevronDown className="h-3.5 w-3.5" />
               </button>
-              <Badge
-                variant="secondary"
-                className={`rounded-full px-2 font-mono text-[11px] shadow-sm ${wipExceeded ? 'bg-destructive/15 text-destructive' : ''}`}
-              >
+              <span className={`text-[11px] tabular-nums ${wipExceeded ? 'text-destructive' : 'text-muted-foreground'}`}>
                 {totalCount !== undefined ? (hasMore ? `${totalCount}+` : totalCount) : stories.length}
-              </Badge>
+              </span>
             </>
           ) : (
             <>
-              <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                <span className={`h-2 w-2 rounded-full ${statusColor.dot}`} aria-hidden="true" />
+              <h3 className="flex items-center gap-2 text-xs font-semibold text-foreground">
+                <span className={`size-1.5 shrink-0 rounded-full ${statusColor.dot}`} aria-hidden="true" />
                 {label}
               </h3>
               <div className="flex items-center gap-1.5">
                 {/* AC1: WIP 초과 배지 */}
                 {wipExceeded && (
-                  <Badge variant="destructive" className="rounded-full px-2 font-mono text-[10px]">
+                  <Badge variant="destructive" className="text-[10px]">
                     {t('wipLimitExceeded')}
                   </Badge>
                 )}
                 {/* AC1: WIP limit 배지 (설정된 경우) */}
                 {wipLimit !== null && wipLimit !== undefined && !wipExceeded && (
-                  <Badge variant="secondary" className="rounded-full px-2 font-mono text-[10px] text-muted-foreground">
+                  <Badge variant="outline" className="text-[10px] text-muted-foreground">
                     {t('wipLimitLabel')}: {wipLimit}
                   </Badge>
                 )}
-                {/* 카드 수 배지 */}
-                <Badge
-                  variant="secondary"
-                  className={`rounded-full px-2.5 font-mono text-[11px] shadow-sm ${wipExceeded ? 'bg-destructive/15 text-destructive' : ''}`}
-                >
+                {/* 카드 수 — pill/shadow/mono 제거·tabular(정렬 유지·결 정갈) */}
+                <span className={`text-xs tabular-nums ${wipExceeded ? 'text-destructive' : 'text-muted-foreground'}`}>
                   {totalCount !== undefined ? (hasMore ? `${totalCount}+` : totalCount) : stories.length}
-                </Badge>
+                </span>
                 {/* AC5: WIP limit 편집 버튼 */}
                 <button
                   type="button"

--- a/apps/web/src/components/kanban/kanban-filters.tsx
+++ b/apps/web/src/components/kanban/kanban-filters.tsx
@@ -31,19 +31,19 @@ export function KanbanFilters({
 
   return (
     <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
-      <OperatorSelect value={selectedSprintId} onChange={(e) => onSprintChange(e.target.value)} className="w-full rounded-xl bg-background sm:w-auto sm:min-w-[190px]">
+      <OperatorSelect value={selectedSprintId} onChange={(e) => onSprintChange(e.target.value)} className="w-full rounded-lg bg-background text-xs sm:w-auto sm:min-w-[190px]">
         <option value="">{t('allSprints')}</option>
         {sprints.map((sprint) => (
           <option key={sprint.id} value={sprint.id}>{sprint.title}</option>
         ))}
       </OperatorSelect>
-      <OperatorSelect value={selectedEpicId} onChange={(e) => onEpicChange(e.target.value)} className="w-full rounded-xl bg-background sm:w-auto sm:min-w-[190px]">
+      <OperatorSelect value={selectedEpicId} onChange={(e) => onEpicChange(e.target.value)} className="w-full rounded-lg bg-background text-xs sm:w-auto sm:min-w-[190px]">
         <option value="">{t('allEpics')}</option>
         {epics.map((epic) => (
           <option key={epic.id} value={epic.id}>{epic.title}</option>
         ))}
       </OperatorSelect>
-      <OperatorSelect value={selectedAssigneeId} onChange={(e) => onAssigneeChange(e.target.value)} className="w-full rounded-xl bg-background sm:w-auto sm:min-w-[190px]">
+      <OperatorSelect value={selectedAssigneeId} onChange={(e) => onAssigneeChange(e.target.value)} className="w-full rounded-lg bg-background text-xs sm:w-auto sm:min-w-[190px]">
         <option value="">{t('allAssignees')}</option>
         {members.map((member) => (
           <option key={member.id} value={member.id}>{member.name}</option>

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -248,7 +248,9 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
               <span>{pendingGateType ? `${pendingGateType} ${tCage('gatePending')}` : tCage('gatePending')}</span>
             </Badge>
           ) : lineBadgeMeta ? (
-            <Badge variant="outline" className="gap-1">
+            // 가디언 fold-in: 실 alert(handoff_stuck=destructive·waiting_human=warning)는 색=신호 유지,
+            // 정보성(engine_degraded·grandfathered)만 outline. LINE_BADGE_META가 이미 그 위계라 variant 원복.
+            <Badge variant={lineBadgeMeta.variant} className="gap-1">
               <lineBadgeMeta.Icon className="size-3 shrink-0" />
               <span>{tCage(lineBadgeMeta.labelKey)}</span>
             </Badge>

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -9,17 +9,13 @@ import { Badge } from '@/components/ui/badge';
 import { AlertTriangle, ChevronRight, EyeOff, History, Pause, Rocket, Zap, ZapOff, type LucideIcon } from 'lucide-react';
 import { LabelChip } from '@/components/ui/label-chip';
 
-const EPIC_COLORS = [
-  'info',
-  'success',
-  'secondary',
-  'outline',
-  'info',
-] as const;
+// E-MODERN A: 에픽 식별 dot — 기존 시맨틱 토큰만(신규 토큰/raw 팔레트 0). 신호색(warning=blocked·
+// accent-claim=agent·destructive) 회피해 의미 충돌 0. 랜덤 5색 채움 배지(loud)는 퇴출.
+const EPIC_DOT_CLASSES = ['bg-info', 'bg-success', 'bg-secondary', 'bg-muted-foreground'] as const;
 
-function getEpicColor(epicId: string): 'info' | 'success' | 'secondary' | 'outline' {
+function getEpicDotClass(epicId: string): string {
   const hash = epicId.split('').reduce((a, c) => a + c.charCodeAt(0), 0);
-  return EPIC_COLORS[hash % EPIC_COLORS.length]!;
+  return EPIC_DOT_CLASSES[hash % EPIC_DOT_CLASSES.length]!;
 }
 
 function getInitials(name: string): string {
@@ -224,47 +220,43 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
       {...listeners}
       onClick={onClick}
       onContextMenu={handleContextMenu}
-      className={`group relative cursor-pointer overflow-hidden rounded-lg p-3 transition ${
-        hasAgent
-          ? 'bg-gradient-to-br from-accent-claim/8 to-purple-500/4 ring-1 ring-accent-claim/30 hover:ring-accent-claim/60'
-          : 'bg-background shadow-sm hover:shadow-md hover:bg-background'
-      }`}
+      title={`#${story.id.slice(0, 6)}`}
+      className="group relative cursor-pointer rounded-lg border border-border bg-card p-3 transition hover:border-muted-foreground/30"
     >
-      {hasAgent && (
-        <div className="absolute inset-0 pointer-events-none rounded-lg border border-transparent bg-gradient-to-r from-accent-claim/10 to-purple-500/10 opacity-50" />
-      )}
+      {/* E-MODERN A: 에픽 = 작은 색 dot + muted 라벨(일관 식별·랜덤 채움배지 퇴출) */}
       {epicName && story.epic_id ? (
-        <Badge variant={getEpicColor(story.epic_id)} className="mb-2 max-w-full">
-          <span className="min-w-0 truncate leading-none">{epicName}</span>
-        </Badge>
+        <div className="mb-1.5 flex items-center gap-1.5 text-[11px] text-muted-foreground">
+          <span className={`size-1.5 shrink-0 rounded-sm ${getEpicDotClass(story.epic_id)}`} aria-hidden="true" />
+          <span className="min-w-0 truncate">{epicName}</span>
+        </div>
       ) : null}
-      {/* Zone A meta row — dep 뱃지 + label 칩 + workflow-line badge(boy-scout 1배지) */}
+      {/* E-MODERN A meta row — blocked=신호(text-warning+dot)·label 칩·line/gate=boy-scout 1배지(muted) */}
       {(blockedBy.length > 0 && story.status !== 'done') || labels.length > 0 || lineBadge ? (
-        <div className="mb-2 flex flex-wrap gap-1">
+        <div className="mb-2 flex flex-wrap items-center gap-1.5">
           {blockedBy.length > 0 && story.status !== 'done' ? (
-            <Badge variant="warning" className="gap-1">
-              <AlertTriangle className="size-3 shrink-0" />
-              <span>{t('blockedBy', { count: blockedBy.length })}</span>
-            </Badge>
+            <span className="inline-flex items-center gap-1 text-[10px] text-warning">
+              <span className="size-1.5 shrink-0 rounded-full bg-warning" aria-hidden="true" />
+              {t('blockedBy', { count: blockedBy.length })}
+            </span>
           ) : null}
           {labels.map((label) => (
             <LabelChip key={label.id} label={label} />
           ))}
           {lineBadge === 'pending_gate' ? (
-            <Badge variant="info" className="gap-1">
+            <Badge variant="outline" className="gap-1">
               <Pause className="size-3 shrink-0" />
               <span>{pendingGateType ? `${pendingGateType} ${tCage('gatePending')}` : tCage('gatePending')}</span>
             </Badge>
           ) : lineBadgeMeta ? (
-            <Badge variant={lineBadgeMeta.variant} className="gap-1">
+            <Badge variant="outline" className="gap-1">
               <lineBadgeMeta.Icon className="size-3 shrink-0" />
               <span>{tCage(lineBadgeMeta.labelKey)}</span>
             </Badge>
           ) : null}
         </div>
       ) : null}
-      <p className="relative z-10 line-clamp-2 text-sm font-medium leading-5 text-foreground">{story.title}</p>
-      <div className="relative z-10 mt-3 flex items-center justify-between gap-2">
+      <p className="line-clamp-2 text-sm font-medium leading-snug text-foreground">{story.title}</p>
+      <div className="mt-2.5 flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           {assigneeList.length > 0 ? (
             <div className="flex -space-x-1.5">
@@ -294,50 +286,49 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
             <div />
           )}
           {hasAgent && (
-            <div className="flex items-center gap-1.5 text-[10px] font-mono text-accent-claim">
-              <span className="relative flex h-1.5 w-1.5">
-                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent-claim opacity-75"></span>
-                <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-accent-claim"></span>
-              </span>
-              <span>&gt; Agent active</span>
-            </div>
+            <span className="inline-flex items-center gap-1 text-[10px] text-accent-claim">
+              <span className="size-1.5 shrink-0 rounded-full bg-accent-claim" aria-hidden="true" />
+              {t('filterAgents')}
+            </span>
           )}
         </div>
         <div className="flex items-center gap-2">
-          <span className="font-mono text-[10px] text-muted-foreground/50">#{story.id.slice(0, 6)}</span>
           {story.story_points != null ? (
-            <Badge variant="secondary" className="font-mono text-[10px] px-1.5 py-0">{story.story_points}</Badge>
+            <span className="text-[11px] tabular-nums text-muted-foreground">{t('storyPointsBadge', { count: story.story_points })}</span>
           ) : null}
-          {lastExecution ? (
-            <span
-              title={[
-                lastExecution.rule_name ?? '워크플로우 실행됨',
-                lastExecution.completed_at ? new Date(lastExecution.completed_at).toLocaleString() : '',
-                lastExecution.status === 'matched' ? '✅ 규칙 매칭' : '⊘ 규칙 없음',
-              ].filter(Boolean).join(' · ')}
-              className="flex h-5 w-5 items-center justify-center"
-            >
-              {lastExecution.status === 'matched' ? (
-                <Zap className="h-3 w-3 text-warning" />
-              ) : (
-                <ZapOff className="h-3 w-3 text-muted-foreground/40" />
-              )}
-            </span>
-          ) : null}
-          {projectId ? (
-            <button
-              onClick={(e) => void handleKickoff(e)}
-              disabled={triggering}
-              title={t('kickoff')}
-              className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground/60 hover:text-primary hover:bg-primary/10 disabled:opacity-40 transition"
-            >
-              {triggering ? (
-                <span className="h-3 w-3 animate-spin rounded-full border border-current border-t-transparent" />
-              ) : (
-                <Rocket className="h-3 w-3" />
-              )}
-            </button>
-          ) : null}
+          {/* E-MODERN A: 액션 점진 공개 — 데스크탑 hover 노출·모바일(hover 없음)은 상시(kickoff 도달성=기능 동결 보존) */}
+          <span className="flex items-center gap-1.5 opacity-100 transition focus-within:opacity-100 sm:opacity-0 sm:group-hover:opacity-100">
+            {lastExecution ? (
+              <span
+                title={[
+                  lastExecution.rule_name ?? '워크플로우 실행됨',
+                  lastExecution.completed_at ? new Date(lastExecution.completed_at).toLocaleString() : '',
+                  lastExecution.status === 'matched' ? '✅ 규칙 매칭' : '⊘ 규칙 없음',
+                ].filter(Boolean).join(' · ')}
+                className="flex h-5 w-5 items-center justify-center"
+              >
+                {lastExecution.status === 'matched' ? (
+                  <Zap className="h-3 w-3 text-warning" />
+                ) : (
+                  <ZapOff className="h-3 w-3 text-muted-foreground/40" />
+                )}
+              </span>
+            ) : null}
+            {projectId ? (
+              <button
+                onClick={(e) => void handleKickoff(e)}
+                disabled={triggering}
+                title={t('kickoff')}
+                className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground/60 hover:text-primary hover:bg-primary/10 disabled:opacity-40 transition"
+              >
+                {triggering ? (
+                  <span className="h-3 w-3 animate-spin rounded-full border border-current border-t-transparent" />
+                ) : (
+                  <Rocket className="h-3 w-3" />
+                )}
+              </button>
+            ) : null}
+          </span>
         </div>
       </div>
 


### PR DESCRIPTION
## 한 줄
현 보드(최고밀도 화면)를 결 **"정갈·미니멀하되 다 품되 안 시끄러운"**으로. **순수 시각만 — 기능 100% 동결**(핸들러/props/상태 0 변경). 시안 = `board-redesign-mockup.png` Take A(선생님 승인).

> story `5844a011` · 핸드오프 doc `e-modern-board-a-parts-set-handoff`(PRIMARY) · 결 A 확정 · 디자인/가디언: 유나 홀름 · 오르테가군 승인

## 부품 한 벌 (기준 못박기 · 기존 OKLCH 토큰+radius 스케일 위 규율)
- **타입 4단**: title `text-sm` · body `text-xs` · meta `text-[11px]` · micro `text-[10px]`. **보드 `font-mono` 전면 퇴출 → `tabular-nums`**.
- **모서리 기존 스케일만**: 카드 `rounded-lg` · 컬럼 `rounded-xl` · dot `rounded-sm/full`.
- **간격 4px**: `p-3` · `gap-2.5` · `space-y-2`.
- **색 = 신호만**: status dot · blocked(`text-warning`+dot) · agent(`accent-claim` 1개) · WIP ring · 에픽 색 dot. 그 외 중립.

## 변경 (FE 전용 · apps/web · 3파일)
**`story-card.tsx`** (핵심):
- 카드 = `rounded-lg border border-border bg-card p-3`(agent도 **동일 표면** — 글로우/그래디언트/ring-glow/overflow-hidden 제거).
- 에픽 = 작은 색 dot + muted 라벨(랜덤 5색 채움 배지 퇴출 · 기존 시맨틱 토큰만 · 신호색 회피).
- 제목 위계 또렷(`text-sm font-medium leading-snug`).
- agent 인디케이터 = accent dot + 라벨(`ping`/`> Agent active` 모노 **제거**).
- SP = `text-[11px] tabular-nums`(badge/mono 제거 · 기존 `storyPointsBadge` 키 재사용).
- `#id` 카드면 제거 → `title` 속성으로 이동.
- 액션(zap/rocket) = `group-hover` 점진 공개. **단 모바일(hover 없음)은 상시 노출** → kickoff 도달성 보존(기능 동결).
- line/gate badge = muted(`outline`) boy-scout 1배지.

**`kanban-column.tsx`**:
- 컬럼 `bg-transparent`(status 색 tint 배경 **전면 제거** · WIP 초과 ring·드롭 하이라이트 신호만 보존).
- 헤더 = dot + 이름(`uppercase tracking` 제거 · muted→foreground).
- 카운트 = `tabular-nums` span(pill/shadow/mono 제거). WIP 배지 pill/mono 제거.

**`kanban-filters.tsx`**: 필터 select `rounded-xl` → `rounded-lg text-xs`(일관).

**`kanban-board.tsx`**: 툴바에 부품 한 벌 위반 0 → **무변경**(불필요 리스크 회피 · 시각 win은 위 3파일에 담김).

## 게이트 대비 자기검수
- **기능 동결**: diff 검수 — 핸들러/훅/props/상태 무변경(kickoff `onClick`은 hover wrapper 들여쓰기만·바이트 동일). DnD/컴포저/컨텍스트메뉴/킥오프/WIP/collapse/load more/optimistic 로직 불변.
- **신규 토큰 0 · 신규 i18n 0**(messages diff 없음 · `storyPointsBadge`/`filterAgents` 기존 키 재사용) · **arbitrary `text-[Npx]`/`rounded-[Npx]` 0**(4단 내 `text-[10px]`/`text-[11px]`만 · `text-[10.5px]` 자기적출→`text-[10px]` 정정).
- `tsc` 0 · `eslint` 0 · `next build` ✓.

## 리뷰 노트
- **액션 hover 모바일 폴백**: doc §2.1④는 `opacity-0`(기본 숨김)이나, 순수 hover-숨김은 터치(hover 없음)서 kickoff 도달 불가 = 기능 동결 위반 우려 → `sm:opacity-0 sm:group-hover:opacity-100`(데스크탑 hover-공개·모바일 상시)로 양립. 모바일도 숨김 원하면 콜 주세요.
- **에픽 dot 색**: `style=epicColor`(pseudocode)를 기존 시맨틱 토큰 4종 해시 회전(info/success/secondary/muted-foreground)으로 구현(raw 팔레트 0·신호색 회피). 시안 색셋과 다르면 조정.

⚠️ **라이브 픽셀 = 머지 후**(1008×970 라이트/다크·모바일·**기능 회귀 0**). PR 단계 = PO grep + 까심 코드정합 + 가디언 코드리뷰. 가디언 픽셀은 머지 후 동석.

🤖 Generated with [Claude Code](https://claude.com/claude-code)