### PR TITLE
[E-MODERN][CC-BE.1] feat: 커맨드 센터 집계 2 엔드포인트 (my-actions·overview)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -56,7 +56,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -185,6 +185,7 @@ app.include_router(notifications.router)
 app.include_router(attachments.router)
 app.include_router(notification_preferences.router)
 app.include_router(analytics.router)
+app.include_router(command_center.router)
 app.include_router(rewards.router)
 app.include_router(audit_logs.router)
 app.include_router(dashboard.router)

--- a/backend/app/routers/command_center.py
+++ b/backend/app/routers/command_center.py
@@ -25,6 +25,7 @@ from app.models.hypothesis import Hypothesis
 from app.models.member import Member
 from app.models.pm import Epic, Story
 from app.models.workflow_line import WorkflowLineStepApproval, WorkflowLineStepRun
+from app.services.member_resolver import resolve_member
 
 router = APIRouter(prefix="/api/v2/command-center", tags=["command-center"])
 
@@ -44,10 +45,10 @@ async def my_actions(
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """① 지금 내 할 일. `action_queue`=caller member-private·`attention`=org 자동 이상감지(scope 분리)."""
-    try:
-        member_id = uuid.UUID(auth.user_id)
-    except (ValueError, TypeError):
-        return JSONResponse(status_code=400, content={"error": "invalid_member"})
+    # ⭐caller member_id 는 **canonical resolver** 로 서버 resolve(API키=team_member·JWT human=org_member).
+    # auth.user_id 직사용 금지 — human JWT 는 users.id 라 approver_member_id/assignee_id(member계열)와 불일치.
+    member = await resolve_member(auth, org_id, session)
+    member_id = member.id
 
     queue: list[dict] = []
     # 게이트 승인 대기 = 내가 approver 인 pending blocking approval(member-private·서버 resolve member_id).
@@ -104,6 +105,9 @@ async def my_actions(
                 WorkflowLineStepRun.org_id == org_id,
                 WorkflowLineStepRun.status == "pending",
                 WorkflowLineStepRun.started_at < threshold,
+                # ⭐agent run 만(HIGH2): human approval/handoff 의 오래 pending 은 'agent_stuck' 아님 —
+                # 필터 없으면 타 멤버 대기가 org attention 으로 우회 노출(혼합-scope 경계 흐려짐).
+                WorkflowLineStepRun.resolved_member_type == "agent",
             )
             .order_by(WorkflowLineStepRun.started_at.asc())
             .limit(20)

--- a/backend/app/routers/command_center.py
+++ b/backend/app/routers/command_center.py
@@ -1,0 +1,232 @@
+"""E-MODERN Track C: 커맨드 센터 BE — CC-BE.1 (집계 2 엔드포인트).
+
+운영자 대시보드의 cross-cut 집계. **2 엔드포인트**(FE N+1 차단):
+- `GET /api/v2/command-center/my-actions` — ⭐**혼합 scope**: `action_queue`(=caller **member-private**·타 멤버 큐 노출 0)
+  + `attention`(=**org-scope** 자동 이상감지). 두 섹션 scope label·배열 분리(산티아고 lock).
+- `GET /api/v2/command-center/overview` — **org/team** scope: 헤더 함대 + 프로젝트 현황.
+
+**mock-0 금지선**: CC-BE.1 미구현(신규 집계)은 `{"status": "pending_data"}` 명시 — 가짜 수치 0(CC-BE.2서 실데이터).
+**민감 정보 비노출**(산티아고): 이상감지는 enum/summary·count 만(raw error/log/failure_message 0).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.models.activity_event import ActivityEvent
+from app.models.hypothesis import Hypothesis
+from app.models.member import Member
+from app.models.pm import Epic, Story
+from app.models.workflow_line import WorkflowLineStepApproval, WorkflowLineStepRun
+
+router = APIRouter(prefix="/api/v2/command-center", tags=["command-center"])
+
+# 자동 이상감지 임계(분). step_run 이 pending 으로 이 시간 넘게 정체 = 에이전트 멈춤(CC-BE.1 1종).
+_AGENT_STUCK_MINUTES = 30
+_PENDING = {"status": "pending_data"}  # mock-0: 신규 집계 미구현 — 가짜 수치 대신 명시(CC-BE.2서 실데이터).
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@router.get("/my-actions")
+async def my_actions(
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """① 지금 내 할 일. `action_queue`=caller member-private·`attention`=org 자동 이상감지(scope 분리)."""
+    try:
+        member_id = uuid.UUID(auth.user_id)
+    except (ValueError, TypeError):
+        return JSONResponse(status_code=400, content={"error": "invalid_member"})
+
+    queue: list[dict] = []
+    # 게이트 승인 대기 = 내가 approver 인 pending blocking approval(member-private·서버 resolve member_id).
+    approvals = (
+        await session.execute(
+            select(WorkflowLineStepApproval)
+            .where(
+                WorkflowLineStepApproval.org_id == org_id,
+                WorkflowLineStepApproval.approver_member_id == member_id,
+                WorkflowLineStepApproval.status == "pending",
+                WorkflowLineStepApproval.blocking.is_(True),
+            )
+            .order_by(WorkflowLineStepApproval.created_at.asc())
+            .limit(50)
+        )
+    ).scalars().all()
+    for a in approvals:
+        queue.append({
+            "type": "gate_approval",
+            "priority": "warn",
+            "context": {"gate_id": str(a.gate_id) if a.gate_id else None,
+                        "approval_group_id": str(a.approval_group_id), "kind": a.kind},
+            "created_at": a.created_at.isoformat() if a.created_at else None,
+        })
+    # 리뷰/머지 대기 = 내 배정 in-review 스토리(member-private).
+    reviews = (
+        await session.execute(
+            select(Story)
+            .where(
+                Story.org_id == org_id,
+                Story.assignee_id == member_id,
+                Story.status == "in-review",
+                Story.deleted_at.is_(None),
+            )
+            .order_by(Story.updated_at.desc())
+            .limit(50)
+        )
+    ).scalars().all()
+    for s in reviews:
+        queue.append({
+            "type": "review_merge",
+            "priority": "info",
+            "title": s.title,
+            "context": {"story_id": str(s.id), "status": s.status},
+            "created_at": s.updated_at.isoformat() if s.updated_at else None,
+        })
+
+    # 자동 이상감지(org-scope) — CC-BE.1 1종: 에이전트 멈춤(step_run pending 정체). raw error/log 비노출.
+    threshold = _now() - timedelta(minutes=_AGENT_STUCK_MINUTES)
+    stuck = (
+        await session.execute(
+            select(WorkflowLineStepRun)
+            .where(
+                WorkflowLineStepRun.org_id == org_id,
+                WorkflowLineStepRun.status == "pending",
+                WorkflowLineStepRun.started_at < threshold,
+            )
+            .order_by(WorkflowLineStepRun.started_at.asc())
+            .limit(20)
+        )
+    ).scalars().all()
+    attention_items = [
+        {
+            "type": "agent_stuck",
+            "severity": "warn",
+            "auto_detected": True,
+            # enum/summary·식별자만(민감 텍스트 0): entity·게이트타입·정체 분 수.
+            "entity_type": r.entity_type,
+            "entity_id": str(r.entity_id),
+            "gate_type": r.effective_gate_type,
+            "stuck_since": r.started_at.isoformat() if r.started_at else None,
+        }
+        for r in stuck
+    ]
+
+    return JSONResponse(content={
+        "action_queue": {  # scope: member(caller) — 타 멤버 큐 노출 0.
+            "scope": "member",
+            "items": sorted(queue, key=lambda x: {"danger": 0, "warn": 1, "info": 2}.get(x["priority"], 9)),
+        },
+        "attention": {  # scope: org — 자동 이상감지(운영자 visibility).
+            "scope": "org",
+            "items": attention_items,
+            "pending": ["story_stalled", "unanswered_blocker", "time_sensitive", "my_blockers"],  # CC-BE.2.
+        },
+        "is_clear": len(queue) == 0 and len(attention_items) == 0,
+    })
+
+
+@router.get("/overview")
+async def overview(
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """② 프로젝트 현황 + 헤더 함대. scope=org/team. 신규 집계는 pending_data(mock 0)."""
+    # 헤더 — 함대: 총 에이전트(실)·상태 breakdown 은 pending_data(CC-BE.2 fleet status).
+    total_agents = (
+        await session.execute(
+            select(func.count(Member.id)).where(
+                Member.org_id == org_id, Member.type == "agent",
+                Member.is_active.is_(True), Member.deleted_at.is_(None),
+            )
+        )
+    ).scalar_one()
+
+    # 에픽 진척(실): org 스토리 epic 별 done/total. is_excluded 제외(데이터 오염).
+    rows = (
+        await session.execute(
+            select(
+                Story.epic_id,
+                func.count(Story.id),
+                func.count(Story.id).filter(Story.status == "done"),
+            )
+            .where(
+                Story.org_id == org_id, Story.deleted_at.is_(None),
+                Story.epic_id.isnot(None), Story.is_excluded.is_(False),
+            )
+            .group_by(Story.epic_id)
+        )
+    ).all()
+    counts = {epic_id: (total, done) for epic_id, total, done in rows}
+    epics_q = (
+        await session.execute(select(Epic).where(Epic.org_id == org_id))
+    ).scalars().all()
+    epics = []
+    for e in epics_q:
+        total, done = counts.get(e.id, (0, 0))
+        if total == 0:
+            continue  # 스토리 0 에픽은 진척 표시 제외(노이즈).
+        epics.append({
+            "epic_id": str(e.id), "title": e.title, "status": e.status,
+            "total": total, "done": done,
+            "completion_pct": round(done * 100 / total) if total else 0,
+        })
+    epics.sort(key=lambda x: x["completion_pct"])  # 덜 된 것 위(주의).
+
+    # 성과(가설 적중·실): verified=hit / 전체.
+    h_total, h_hit = (
+        await session.execute(
+            select(
+                func.count(Hypothesis.id),
+                func.count(Hypothesis.id).filter(Hypothesis.status == "verified"),
+            ).where(Hypothesis.org_id == org_id)
+        )
+    ).one()
+
+    # 최근 중요 변화(실·org): 최근 활동 이벤트(verb/object/시각만·raw payload 비노출).
+    events = (
+        await session.execute(
+            select(ActivityEvent)
+            .where(ActivityEvent.org_id == org_id)
+            .order_by(ActivityEvent.occurred_at.desc())
+            .limit(10)
+        )
+    ).scalars().all()
+    recent_changes = [
+        {
+            "verb": ev.verb,
+            "object_type": ev.object_type,
+            "object_id": str(ev.object_id) if ev.object_id else None,
+            "occurred_at": ev.occurred_at.isoformat() if ev.occurred_at else None,
+        }
+        for ev in events
+    ]
+
+    return JSONResponse(content={
+        "scope": "org",
+        "fleet": {  # 헤더 함대 라이브 요약.
+            "total_agents": total_agents,
+            "status_breakdown": _PENDING,  # 작업중/막힘/유휴 = CC-BE.2(workflow-line status).
+        },
+        "project_status": {
+            "epics": epics,                                   # 실데이터.
+            "outcome": {"hit": h_hit, "total": h_total},      # 실데이터.
+            "recent_changes": recent_changes,                 # 실데이터.
+            "risk": _PENDING,        # 지연/막힘/실패 — CC-BE.2(due/dependency/failed-run).
+            "cycle_time": _PENDING,  # CC-BE.2.
+            "contribution": _PENDING,  # 에이전트:사람 — CC-BE.2.
+            "cost_trend": _PENDING,  # 토큰/비용 시계열 — CC-BE.2.
+        },
+    })

--- a/backend/tests/test_command_center.py
+++ b/backend/tests/test_command_center.py
@@ -1,0 +1,145 @@
+"""E-MODERN Track C: 커맨드 센터 CC-BE.1 단위(산티아고 혼합-scope checklist).
+
+커버: /my-actions action_queue(member-private·gate_approval+review_merge·caller member_id) / attention(org
+agent_stuck·enum/summary·raw 비노출) scope label 분리 · /overview org(fleet total 실·breakdown pending_data·
+epics/outcome/recent 실·risk/cycle/contribution/cost pending_data) · invalid member 400 · mock 0.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+ORG_A = uuid.uuid4()
+MEMBER = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _r_scalars(rows):
+    r = MagicMock()
+    r.scalars.return_value.all.return_value = list(rows)
+    return r
+
+
+def _r_scalar(val):
+    r = MagicMock()
+    r.scalar_one.return_value = val
+    return r
+
+
+def _r_all(rows):
+    r = MagicMock()
+    r.all.return_value = list(rows)
+    return r
+
+
+def _r_one(tup):
+    r = MagicMock()
+    r.one.return_value = tup
+    return r
+
+
+async def _get(path, *, execute_seq, member=MEMBER, org=ORG_A):
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+    from app.main import app as fastapi_app
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=list(execute_seq))
+
+    async def override_db():
+        yield session
+
+    fastapi_app.dependency_overrides[get_db] = override_db
+    fastapi_app.dependency_overrides[get_verified_org_id] = lambda: org
+    fastapi_app.dependency_overrides[get_current_user] = lambda: MagicMock(
+        user_id=str(member) if member else "not-a-uuid"
+    )
+    try:
+        async with AsyncClient(transport=ASGITransport(app=fastapi_app), base_url="http://test") as c:
+            resp = await c.get(path)
+        return resp, session
+    finally:
+        fastapi_app.dependency_overrides.clear()
+
+
+def _data(resp):
+    body = resp.json()
+    return body.get("data", body) if isinstance(body, dict) else {}
+
+
+# ── /my-actions ─────────────────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_my_actions_scope_separation_and_items():
+    approval = MagicMock(gate_id=uuid.uuid4(), approval_group_id=uuid.uuid4(), kind="approver",
+                         created_at=datetime(2026, 6, 23, tzinfo=timezone.utc))
+    review = MagicMock(id=uuid.uuid4(), title="Ship login", status="in-review",
+                       updated_at=datetime(2026, 6, 23, tzinfo=timezone.utc))
+    stuck = MagicMock(entity_type="story", entity_id=uuid.uuid4(), effective_gate_type="merge",
+                      started_at=datetime(2026, 6, 23, tzinfo=timezone.utc), failure_message="SECRET raw error")
+    # 쿼리 순서: approvals → reviews → stuck.
+    resp, _ = await _get("/api/v2/command-center/my-actions",
+                         execute_seq=[_r_scalars([approval]), _r_scalars([review]), _r_scalars([stuck])])
+    assert resp.status_code == 200
+    d = _data(resp)
+    assert d["action_queue"]["scope"] == "member"      # ⭐member-private.
+    assert d["attention"]["scope"] == "org"            # ⭐org.
+    types = {i["type"] for i in d["action_queue"]["items"]}
+    assert types == {"gate_approval", "review_merge"}
+    assert d["attention"]["items"][0]["type"] == "agent_stuck" and d["attention"]["items"][0]["auto_detected"]
+    # ⭐민감 텍스트 비노출: failure_message 가 응답 어디에도 없어야.
+    assert "SECRET raw error" not in resp.text
+    assert "my_blockers" in d["attention"]["pending"]  # CC-BE.2 명시.
+
+
+@pytest.mark.anyio
+async def test_my_actions_clear_state():
+    resp, _ = await _get("/api/v2/command-center/my-actions",
+                         execute_seq=[_r_scalars([]), _r_scalars([]), _r_scalars([])])
+    assert resp.status_code == 200
+    assert _data(resp)["is_clear"] is True
+
+
+@pytest.mark.anyio
+async def test_my_actions_invalid_member_400():
+    resp, session = await _get("/api/v2/command-center/my-actions", execute_seq=[], member=None)
+    assert resp.status_code == 400
+    session.execute.assert_not_awaited()  # member resolve 실패 → 쿼리 0.
+
+
+# ── /overview ─────────────────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_overview_real_and_pending_data():
+    epic_id = uuid.uuid4()
+    epic = MagicMock(id=epic_id, title="Auth epic", status="active")
+    # 순서: total_agents(scalar) → epic story group(all) → epics(scalars) → hypothesis(one) → events(scalars).
+    resp, _ = await _get(
+        "/api/v2/command-center/overview",
+        execute_seq=[
+            _r_scalar(4),                       # total_agents
+            _r_all([(epic_id, 5, 2)]),          # epic group: total 5, done 2
+            _r_scalars([epic]),                 # epics
+            _r_one((10, 3)),                    # hypothesis total 10, hit 3
+            _r_scalars([MagicMock(verb="story.status_changed", object_type="story",
+                                  object_id=uuid.uuid4(),
+                                  occurred_at=datetime(2026, 6, 23, tzinfo=timezone.utc))]),
+        ],
+    )
+    assert resp.status_code == 200
+    d = _data(resp)
+    assert d["scope"] == "org"
+    assert d["fleet"]["total_agents"] == 4
+    assert d["fleet"]["status_breakdown"] == {"status": "pending_data"}   # 신규=pending.
+    assert d["project_status"]["epics"][0]["completion_pct"] == 40        # 2/5.
+    assert d["project_status"]["outcome"] == {"hit": 3, "total": 10}      # 실데이터.
+    assert len(d["project_status"]["recent_changes"]) == 1
+    # mock-0: 신규 집계는 전부 pending_data(가짜 수치 0).
+    for k in ("risk", "cycle_time", "contribution", "cost_trend"):
+        assert d["project_status"][k] == {"status": "pending_data"}

--- a/backend/tests/test_command_center.py
+++ b/backend/tests/test_command_center.py
@@ -46,10 +46,11 @@ def _r_one(tup):
     return r
 
 
-async def _get(path, *, execute_seq, member=MEMBER, org=ORG_A):
+async def _get(path, *, execute_seq, member=MEMBER, org=ORG_A, resolve_raises=None):
     from app.dependencies.auth import get_current_user, get_verified_org_id
     from app.dependencies.database import get_db
     from app.main import app as fastapi_app
+    from app.routers import command_center as mod
 
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=list(execute_seq))
@@ -59,13 +60,18 @@ async def _get(path, *, execute_seq, member=MEMBER, org=ORG_A):
 
     fastapi_app.dependency_overrides[get_db] = override_db
     fastapi_app.dependency_overrides[get_verified_org_id] = lambda: org
-    fastapi_app.dependency_overrides[get_current_user] = lambda: MagicMock(
-        user_id=str(member) if member else "not-a-uuid"
-    )
+    # ⭐auth.user_id 를 일부러 member 와 다른 값(=users.id 모사)으로 둬, 엔드포인트가 raw user_id 가 아니라
+    # canonical resolve_member 로 member.id 를 쓰는지 증명(HIGH1). resolve_member 는 patch.
+    fastapi_app.dependency_overrides[get_current_user] = lambda: MagicMock(user_id=str(uuid.uuid4()))
+    if resolve_raises is not None:
+        resolver = AsyncMock(side_effect=resolve_raises)
+    else:
+        resolver = AsyncMock(return_value=MagicMock(id=member))
     try:
-        async with AsyncClient(transport=ASGITransport(app=fastapi_app), base_url="http://test") as c:
-            resp = await c.get(path)
-        return resp, session
+        with patch.object(mod, "resolve_member", new=resolver):
+            async with AsyncClient(transport=ASGITransport(app=fastapi_app), base_url="http://test") as c:
+                resp = await c.get(path)
+        return resp, session, resolver
     finally:
         fastapi_app.dependency_overrides.clear()
 
@@ -85,8 +91,9 @@ async def test_my_actions_scope_separation_and_items():
     stuck = MagicMock(entity_type="story", entity_id=uuid.uuid4(), effective_gate_type="merge",
                       started_at=datetime(2026, 6, 23, tzinfo=timezone.utc), failure_message="SECRET raw error")
     # 쿼리 순서: approvals → reviews → stuck.
-    resp, _ = await _get("/api/v2/command-center/my-actions",
-                         execute_seq=[_r_scalars([approval]), _r_scalars([review]), _r_scalars([stuck])])
+    resp, session, resolver = await _get(
+        "/api/v2/command-center/my-actions",
+        execute_seq=[_r_scalars([approval]), _r_scalars([review]), _r_scalars([stuck])])
     assert resp.status_code == 200
     d = _data(resp)
     assert d["action_queue"]["scope"] == "member"      # ⭐member-private.
@@ -100,18 +107,45 @@ async def test_my_actions_scope_separation_and_items():
 
 
 @pytest.mark.anyio
+async def test_my_actions_uses_canonical_member_resolver():
+    """HIGH1: auth.user_id(=users.id 모사·member 와 다름) 직사용 금지 → resolve_member 로 member.id 해소."""
+    resp, session, resolver = await _get(
+        "/api/v2/command-center/my-actions",
+        execute_seq=[_r_scalars([]), _r_scalars([]), _r_scalars([])])
+    assert resp.status_code == 200
+    resolver.assert_awaited_once()  # canonical resolver 사용(raw auth.user_id 아님).
+
+
+@pytest.mark.anyio
+async def test_my_actions_agent_stuck_filters_to_agent():
+    """HIGH2: agent_stuck 쿼리가 resolved_member_type=='agent' 로 필터(human run 미포함)."""
+    resp, session, resolver = await _get(
+        "/api/v2/command-center/my-actions",
+        execute_seq=[_r_scalars([]), _r_scalars([]), _r_scalars([])])
+    assert resp.status_code == 200
+    # 3번째 execute = agent_stuck 쿼리. 컴파일된 SQL 에 agent 필터(resolved_member_type)가 박혀야.
+    stuck_stmt = str(session.execute.await_args_list[2].args[0])
+    assert "resolved_member_type" in stuck_stmt
+
+
+@pytest.mark.anyio
 async def test_my_actions_clear_state():
-    resp, _ = await _get("/api/v2/command-center/my-actions",
-                         execute_seq=[_r_scalars([]), _r_scalars([]), _r_scalars([])])
+    resp, session, resolver = await _get(
+        "/api/v2/command-center/my-actions",
+        execute_seq=[_r_scalars([]), _r_scalars([]), _r_scalars([])])
     assert resp.status_code == 200
     assert _data(resp)["is_clear"] is True
 
 
 @pytest.mark.anyio
-async def test_my_actions_invalid_member_400():
-    resp, session = await _get("/api/v2/command-center/my-actions", execute_seq=[], member=None)
+async def test_my_actions_resolver_failure_propagates():
+    """member resolve 실패(미존재 등) → resolve_member 가 401/403/400 raise → 큐 쿼리 0."""
+    from fastapi import HTTPException
+    resp, session, resolver = await _get(
+        "/api/v2/command-center/my-actions", execute_seq=[],
+        resolve_raises=HTTPException(status_code=400, detail="member not found"))
     assert resp.status_code == 400
-    session.execute.assert_not_awaited()  # member resolve 실패 → 쿼리 0.
+    session.execute.assert_not_awaited()  # resolve 실패 → action_queue 쿼리 0.
 
 
 # ── /overview ─────────────────────────────────────────────────────────────────
@@ -120,7 +154,7 @@ async def test_overview_real_and_pending_data():
     epic_id = uuid.uuid4()
     epic = MagicMock(id=epic_id, title="Auth epic", status="active")
     # 순서: total_agents(scalar) → epic story group(all) → epics(scalars) → hypothesis(one) → events(scalars).
-    resp, _ = await _get(
+    resp, session, resolver = await _get(
         "/api/v2/command-center/overview",
         execute_seq=[
             _r_scalar(4),                       # total_agents


### PR DESCRIPTION
## Summary
E-MODERN Track C — Command Center BE **phase 1 (CC-BE.1)**: two cross-cut aggregation endpoints for the operator dashboard. Santiago's mixed-scope security checklist mapped 1:1. **mock-0**: unbuilt (new) aggregations return `{"status": "pending_data"}` — never fake numbers (real data lands in CC-BE.2).

## Story
[SID:f84b244c-c6e0-437b-9c57-b6ded8384529]

## Endpoints + response contract (FE sync)

### `GET /api/v2/command-center/my-actions`  — ⭐mixed scope, strongly separated
```jsonc
{
  "action_queue": {                 // scope: MEMBER (caller, server-resolved member_id; no other member's queue)
    "scope": "member",
    "items": [
      {"type": "gate_approval", "priority": "warn", "context": {"gate_id", "approval_group_id", "kind"}, "created_at"},
      {"type": "review_merge",  "priority": "info", "title": "<story>", "context": {"story_id", "status"}, "created_at"}
    ]                               // sorted danger > warn > info
  },
  "attention": {                    // scope: ORG (auto anomaly, operator visibility)
    "scope": "org",
    "items": [
      {"type": "agent_stuck", "severity": "warn", "auto_detected": true,
       "entity_type", "entity_id", "gate_type", "stuck_since"}   // enum/ids/time only — NO raw error/log
    ],
    "pending": ["story_stalled","unanswered_blocker","time_sensitive","my_blockers"]  // CC-BE.2
  },
  "is_clear": true|false
}
```

### `GET /api/v2/command-center/overview`  — scope: ORG/team
```jsonc
{
  "scope": "org",
  "fleet": { "total_agents": <int>, "status_breakdown": {"status":"pending_data"} },   // breakdown = CC-BE.2
  "project_status": {
    "epics": [ {"epic_id","title","status","total","done","completion_pct"} ],          // REAL (sorted least-complete first)
    "outcome": { "hit": <int>, "total": <int> },                                        // REAL (verified / all hypotheses)
    "recent_changes": [ {"verb","object_type","object_id","occurred_at"} ],             // REAL (no raw payload)
    "risk": {"status":"pending_data"}, "cycle_time": {"status":"pending_data"},
    "contribution": {"status":"pending_data"}, "cost_trend": {"status":"pending_data"}  // CC-BE.2
  }
}
```
> FE: `pending_data` items render "준비중" or omit (omit-not-placeholder) — never mock. Real items go live automatically when CC-BE.2 fills them.

## Santiago security checklist
- `action_queue` = caller member-private (member_id server-resolved; gate_approval via `approver_member_id == me`, review_merge via `assignee_id == me`; no other member's queue). ✅
- `attention` = org-scope anomaly; **enum/summary/ids/time only — failure_message/delivery_error/raw log NOT exposed** (test asserts a raw error string is absent from response). ✅
- two sections scope-labeled + array-separated; section-level sort (no single global sort). ✅
- `/overview` org-scope; real vs `pending_data` explicit; **mock 0**. ✅

## Files
`routers/command_center.py` (new) · `main.py` (register) · `tests/test_command_center.py` (4). No model/migration change.

## Verification
`CI=1` 4 passed. app loads; routes registered (`/my-actions`, `/overview`). Live-verifiable on dev (real org data).

## Out of scope (CC-BE.2)
remaining anomalies (story-stalled, unanswered-blocker, time-sensitive), fleet status breakdown, contribution (agent:human), cycle-time, cost-trend sparkline, blocker attribution ("내가 풀 블로커").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
