### PR TITLE
[E-MODERN][CC-BE.2] feat: 커맨드 센터 pending_data 실데이터 채우기 + recent_changes verb allowlist

### DIFF
--- a/backend/app/routers/command_center.py
+++ b/backend/app/routers/command_center.py
@@ -1,12 +1,13 @@
-"""E-MODERN Track C: 커맨드 센터 BE — CC-BE.1 (집계 2 엔드포인트).
+"""E-MODERN Track C: 커맨드 센터 BE — CC-BE.1 + CC-BE.2 (집계 2 엔드포인트).
 
 운영자 대시보드의 cross-cut 집계. **2 엔드포인트**(FE N+1 차단):
 - `GET /api/v2/command-center/my-actions` — ⭐**혼합 scope**: `action_queue`(=caller **member-private**·타 멤버 큐 노출 0)
   + `attention`(=**org-scope** 자동 이상감지). 두 섹션 scope label·배열 분리(산티아고 lock).
 - `GET /api/v2/command-center/overview` — **org/team** scope: 헤더 함대 + 프로젝트 현황.
 
-**mock-0 금지선**: CC-BE.1 미구현(신규 집계)은 `{"status": "pending_data"}` 명시 — 가짜 수치 0(CC-BE.2서 실데이터).
-**민감 정보 비노출**(산티아고): 이상감지는 enum/summary·count 만(raw error/log/failure_message 0).
+**mock-0 금지선**: 미구현은 `{"status": "pending_data"}`·실데이터 없으면 empty(가짜 수치 0).
+**민감 정보 비노출**(산티아고): 이상감지·blocker 는 enum/ids/age 만(raw error/log/blocker text 0). 비용·기여는
+org **aggregate only**(개인별 비용/blame/랭킹 노출 0).
 """
 from __future__ import annotations
 
@@ -16,22 +17,30 @@ from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 from sqlalchemy import func, select
+from sqlalchemy.orm import aliased
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.activity_event import ActivityEvent
+from app.models.agent_run import AgentRun
+from app.models.dependency import ItemDependency
 from app.models.hypothesis import Hypothesis
-from app.models.member import Member
-from app.models.pm import Epic, Story
+from app.models.member import AgentProjectProfile, Member
+from app.models.pm import Epic, Story, StoryActivity
 from app.models.workflow_line import WorkflowLineStepApproval, WorkflowLineStepRun
 from app.services.member_resolver import resolve_member
 
 router = APIRouter(prefix="/api/v2/command-center", tags=["command-center"])
 
-# 자동 이상감지 임계(분). step_run 이 pending 으로 이 시간 넘게 정체 = 에이전트 멈춤(CC-BE.1 1종).
+# 자동 이상감지 임계. step_run pending 정체=에이전트 멈춤·story 무진행=정체·blocker 무응답.
 _AGENT_STUCK_MINUTES = 30
-_PENDING = {"status": "pending_data"}  # mock-0: 신규 집계 미구현 — 가짜 수치 대신 명시(CC-BE.2서 실데이터).
+_STORY_STALLED_DAYS = 3
+_BLOCKER_UNANSWERED_DAYS = 2
+_PENDING = {"status": "pending_data"}  # mock-0: 미구현 집계 — 가짜 수치 대신 명시.
+# recent_changes 의미 이벤트 allowlist(저신호 conversation.* 등 제외·unknown 기본 제외).
+_MEANINGFUL_VERB_PREFIXES = ("story.", "gate.", "pr.", "epic.", "sprint.", "dependency.", "merge")
+_OPEN_EXCLUDED_STATUSES = ("done",)  # blocked/stalled 판정의 "open" = non-done.
 
 
 def _now() -> datetime:
@@ -49,6 +58,7 @@ async def my_actions(
     # auth.user_id 직사용 금지 — human JWT 는 users.id 라 approver_member_id/assignee_id(member계열)와 불일치.
     member = await resolve_member(auth, org_id, session)
     member_id = member.id
+    now = _now()
 
     queue: list[dict] = []
     # 게이트 승인 대기 = 내가 approver 인 pending blocking approval(member-private·서버 resolve member_id).
@@ -95,37 +105,103 @@ async def my_actions(
             "context": {"story_id": str(s.id), "status": s.status},
             "created_at": s.updated_at.isoformat() if s.updated_at else None,
         })
+    # CC-BE.2 내가 풀 블로커(member-private): 내 담당(blocker) 스토리가 막은 open 스토리. caller-bound.
+    _Blocker = aliased(Story)
+    _Blocked = aliased(Story)
+    my_blockers = (
+        await session.execute(
+            select(ItemDependency.from_id, ItemDependency.to_id)
+            .select_from(ItemDependency)
+            .join(_Blocker, _Blocker.id == ItemDependency.from_id)
+            .join(_Blocked, _Blocked.id == ItemDependency.to_id)
+            .where(
+                ItemDependency.org_id == org_id,
+                ItemDependency.dep_type == "blocks",
+                ItemDependency.item_type == "story",
+                _Blocker.assignee_id == member_id,        # 막은 쪽이 내 담당.
+                _Blocker.deleted_at.is_(None),
+                _Blocked.status.not_in(_OPEN_EXCLUDED_STATUSES),  # 막힌 쪽이 아직 open.
+                _Blocked.deleted_at.is_(None),
+            )
+            .limit(50)
+        )
+    ).all()
+    for blocker_id, blocked_id in my_blockers:
+        queue.append({
+            "type": "my_blockers",
+            "priority": "danger",  # 내가 푸는 게 남을 막고 있음 — 최우선.
+            "context": {"blocker_story_id": str(blocker_id), "blocked_story_id": str(blocked_id)},
+        })
 
-    # 자동 이상감지(org-scope) — CC-BE.1 1종: 에이전트 멈춤(step_run pending 정체). raw error/log 비노출.
-    threshold = _now() - timedelta(minutes=_AGENT_STUCK_MINUTES)
+    # ── 자동 이상감지(org-scope) — enum/ids/age 만(민감 텍스트 0) ──────────────────────
+    attention_items: list[dict] = []
+    # 1) 에이전트 멈춤(step_run pending 정체·agent-only). raw error/log 비노출.
     stuck = (
         await session.execute(
             select(WorkflowLineStepRun)
             .where(
                 WorkflowLineStepRun.org_id == org_id,
                 WorkflowLineStepRun.status == "pending",
-                WorkflowLineStepRun.started_at < threshold,
-                # ⭐agent run 만(HIGH2): human approval/handoff 의 오래 pending 은 'agent_stuck' 아님 —
-                # 필터 없으면 타 멤버 대기가 org attention 으로 우회 노출(혼합-scope 경계 흐려짐).
-                WorkflowLineStepRun.resolved_member_type == "agent",
+                WorkflowLineStepRun.started_at < now - timedelta(minutes=_AGENT_STUCK_MINUTES),
+                WorkflowLineStepRun.resolved_member_type == "agent",  # HIGH2: agent run 만.
             )
             .order_by(WorkflowLineStepRun.started_at.asc())
             .limit(20)
         )
     ).scalars().all()
-    attention_items = [
-        {
-            "type": "agent_stuck",
-            "severity": "warn",
-            "auto_detected": True,
-            # enum/summary·식별자만(민감 텍스트 0): entity·게이트타입·정체 분 수.
-            "entity_type": r.entity_type,
-            "entity_id": str(r.entity_id),
+    for r in stuck:
+        attention_items.append({
+            "type": "agent_stuck", "severity": "warn", "auto_detected": True,
+            "entity_type": r.entity_type, "entity_id": str(r.entity_id),
             "gate_type": r.effective_gate_type,
             "stuck_since": r.started_at.isoformat() if r.started_at else None,
-        }
-        for r in stuck
-    ]
+        })
+    # 2) CC-BE.2 스토리 N일 정체(org-visible 필드만).
+    stalled = (
+        await session.execute(
+            select(Story.id, Story.updated_at)
+            .where(
+                Story.org_id == org_id,
+                Story.status.not_in(("done", "backlog")),
+                Story.deleted_at.is_(None),
+                Story.is_excluded.is_(False),
+                Story.updated_at < now - timedelta(days=_STORY_STALLED_DAYS),
+            )
+            .order_by(Story.updated_at.asc())
+            .limit(20)
+        )
+    ).all()
+    for sid, updated_at in stalled:
+        attention_items.append({
+            "type": "story_stalled", "severity": "warn", "auto_detected": True,
+            "story_id": str(sid),
+            "stalled_days": (now - updated_at).days if updated_at else None,
+        })
+    # 3) CC-BE.2 답없는 블로커(enum/ids/age — raw blocker text 0).
+    _BlockedU = aliased(Story)
+    unanswered = (
+        await session.execute(
+            select(ItemDependency.from_id, ItemDependency.to_id, ItemDependency.created_at)
+            .select_from(ItemDependency)
+            .join(_BlockedU, _BlockedU.id == ItemDependency.to_id)
+            .where(
+                ItemDependency.org_id == org_id,
+                ItemDependency.dep_type == "blocks",
+                ItemDependency.item_type == "story",
+                ItemDependency.created_at < now - timedelta(days=_BLOCKER_UNANSWERED_DAYS),
+                _BlockedU.status.not_in(_OPEN_EXCLUDED_STATUSES),
+                _BlockedU.deleted_at.is_(None),
+            )
+            .order_by(ItemDependency.created_at.asc())
+            .limit(20)
+        )
+    ).all()
+    for blocker_id, blocked_id, created_at in unanswered:
+        attention_items.append({
+            "type": "unanswered_blocker", "severity": "warn", "auto_detected": True,
+            "blocked_story_id": str(blocked_id), "blocker_id": str(blocker_id),
+            "age_days": (now - created_at).days if created_at else None,
+        })
 
     return JSONResponse(content={
         "action_queue": {  # scope: member(caller) — 타 멤버 큐 노출 0.
@@ -135,7 +211,7 @@ async def my_actions(
         "attention": {  # scope: org — 자동 이상감지(운영자 visibility).
             "scope": "org",
             "items": attention_items,
-            "pending": ["story_stalled", "unanswered_blocker", "time_sensitive", "my_blockers"],  # CC-BE.2.
+            "pending": ["time_sensitive"],  # 잔여 미구현(overdue/스프린트 D-N·due 소스 부재).
         },
         "is_clear": len(queue) == 0 and len(attention_items) == 0,
     })
@@ -147,8 +223,9 @@ async def overview(
     _auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """② 프로젝트 현황 + 헤더 함대. scope=org/team. 신규 집계는 pending_data(mock 0)."""
-    # 헤더 — 함대: 총 에이전트(실)·상태 breakdown 은 pending_data(CC-BE.2 fleet status).
+    """② 프로젝트 현황 + 헤더 함대. scope=org/team. 비용·기여는 org aggregate only(개인 노출 0)."""
+    now = _now()
+    # 헤더 — 함대: 총 에이전트(실).
     total_agents = (
         await session.execute(
             select(func.count(Member.id)).where(
@@ -158,7 +235,7 @@ async def overview(
         )
     ).scalar_one()
 
-    # 에픽 진척(실): org 스토리 epic 별 done/total. is_excluded 제외(데이터 오염).
+    # 에픽 진척(실): org 스토리 epic 별 done/total. is_excluded 제외.
     rows = (
         await session.execute(
             select(
@@ -181,13 +258,13 @@ async def overview(
     for e in epics_q:
         total, done = counts.get(e.id, (0, 0))
         if total == 0:
-            continue  # 스토리 0 에픽은 진척 표시 제외(노이즈).
+            continue
         epics.append({
             "epic_id": str(e.id), "title": e.title, "status": e.status,
             "total": total, "done": done,
             "completion_pct": round(done * 100 / total) if total else 0,
         })
-    epics.sort(key=lambda x: x["completion_pct"])  # 덜 된 것 위(주의).
+    epics.sort(key=lambda x: x["completion_pct"])
 
     # 성과(가설 적중·실): verified=hit / 전체.
     h_total, h_hit = (
@@ -199,13 +276,13 @@ async def overview(
         )
     ).one()
 
-    # 최근 중요 변화(실·org): 최근 활동 이벤트(verb/object/시각만·raw payload 비노출).
+    # 최근 중요 변화(실·org): 의미 이벤트만(저신호 conversation.* 등 제외·unknown 기본 제외).
     events = (
         await session.execute(
             select(ActivityEvent)
             .where(ActivityEvent.org_id == org_id)
             .order_by(ActivityEvent.occurred_at.desc())
-            .limit(10)
+            .limit(40)
         )
     ).scalars().all()
     recent_changes = [
@@ -216,21 +293,144 @@ async def overview(
             "occurred_at": ev.occurred_at.isoformat() if ev.occurred_at else None,
         }
         for ev in events
+        if ev.verb and ev.verb.startswith(_MEANINGFUL_VERB_PREFIXES)
+    ][:10]
+
+    # CC-BE.2 기여(에이전트 vs 사람·aggregate only·개인 blame/랭킹 0): done 스토리 assignee type 집계.
+    contrib_rows = (
+        await session.execute(
+            select(Member.type, func.count(Story.id))
+            .select_from(Story)
+            .join(Member, Member.id == Story.assignee_id, isouter=True)
+            .where(
+                Story.org_id == org_id, Story.status == "done",
+                Story.deleted_at.is_(None), Story.is_excluded.is_(False),
+            )
+            .group_by(Member.type)
+        )
+    ).all()
+    contribution = {"agent": 0, "human": 0, "unassigned": 0}
+    for mtype, cnt in contrib_rows:
+        if mtype == "agent":
+            contribution["agent"] = cnt
+        elif mtype == "human":
+            contribution["human"] = cnt
+        else:  # assignee 없음(None) 또는 미상 type → unassigned.
+            contribution["unassigned"] += cnt
+
+    # CC-BE.2 사이클타임(실·org): created→done 평균 일수(최근 30일 done·excluded/deleted 제외).
+    avg_secs, cycle_sample = (
+        await session.execute(
+            select(
+                func.avg(func.extract("epoch", StoryActivity.created_at - Story.created_at)),
+                func.count(StoryActivity.id),
+            )
+            .select_from(StoryActivity)
+            .join(Story, Story.id == StoryActivity.story_id)
+            .where(
+                StoryActivity.org_id == org_id,
+                StoryActivity.activity_type == "status_changed",
+                StoryActivity.new_value == "done",
+                StoryActivity.created_at > now - timedelta(days=30),
+                Story.deleted_at.is_(None), Story.is_excluded.is_(False),
+            )
+        )
+    ).one()
+    cycle_time = {
+        "avg_days": round(float(avg_secs) / 86400, 1) if avg_secs is not None else None,
+        "sample": int(cycle_sample or 0),
+    }
+
+    # CC-BE.2 비용 추세(실·org aggregate only·개인별 비용 노출 0): agent_runs 일별 합. 없으면 honest empty.
+    cost_rows = (
+        await session.execute(
+            select(
+                func.date(AgentRun.started_at),
+                func.sum(AgentRun.cost_usd),
+                func.sum(func.coalesce(AgentRun.input_tokens, 0) + func.coalesce(AgentRun.output_tokens, 0)),
+            )
+            .where(AgentRun.org_id == org_id, AgentRun.started_at > now - timedelta(days=14))
+            .group_by(func.date(AgentRun.started_at))
+            .order_by(func.date(AgentRun.started_at))
+        )
+    ).all()
+    points = [
+        {"date": str(d), "cost_usd": round(float(c or 0), 4), "tokens": int(t or 0)}
+        for d, c, t in cost_rows
     ]
+    cost_trend = {
+        "points": points,
+        "total_cost_usd": round(sum(p["cost_usd"] for p in points), 4),
+        "delta_pct": None,  # 직전 기간 대비 증감은 후속(현 14일 합만).
+    }
+
+    # CC-BE.2 위험(실): 막힌 open 스토리 수 + 실패 run 수. overdue 는 due 필드 부재 → pending_data.
+    _BlockedR = aliased(Story)
+    blocked_cnt = (
+        await session.execute(
+            select(func.count(func.distinct(ItemDependency.to_id)))
+            .select_from(ItemDependency)
+            .join(_BlockedR, _BlockedR.id == ItemDependency.to_id)
+            .where(
+                ItemDependency.org_id == org_id,
+                ItemDependency.dep_type == "blocks",
+                ItemDependency.item_type == "story",
+                _BlockedR.status.not_in(_OPEN_EXCLUDED_STATUSES),
+                _BlockedR.deleted_at.is_(None),
+            )
+        )
+    ).scalar_one()
+    failed_runs = (
+        await session.execute(
+            select(func.count(AgentRun.id)).where(
+                AgentRun.org_id == org_id, AgentRun.status == "failed",
+                AgentRun.started_at > now - timedelta(days=7),
+            )
+        )
+    ).scalar_one()
+    risk = {"blocked": int(blocked_cnt or 0), "failed_runs": int(failed_runs or 0), "overdue": _PENDING}
+
+    # CC-BE.2 함대 status breakdown(실·org agent profile). working=online+active_story.
+    fleet_rows = (
+        await session.execute(
+            select(
+                AgentProjectProfile.agent_status,
+                func.count(func.distinct(AgentProjectProfile.member_id)),
+                func.count(func.distinct(AgentProjectProfile.member_id)).filter(
+                    AgentProjectProfile.active_story_id.isnot(None)
+                ),
+            )
+            .select_from(AgentProjectProfile)
+            .join(Member, Member.id == AgentProjectProfile.member_id)
+            .where(
+                Member.org_id == org_id, Member.type == "agent",
+                Member.is_active.is_(True), Member.deleted_at.is_(None),
+            )
+            .group_by(AgentProjectProfile.agent_status)
+        )
+    ).all()
+    fleet_breakdown = {"online": 0, "offline": 0, "working": 0}
+    for status_val, cnt, working_cnt in fleet_rows:
+        if status_val == "online":
+            fleet_breakdown["online"] += cnt
+            fleet_breakdown["working"] += working_cnt
+        elif status_val == "offline":
+            fleet_breakdown["offline"] += cnt
+        # status NULL(미접속) 등은 online/offline 어디에도 안 셈(보수적).
 
     return JSONResponse(content={
         "scope": "org",
-        "fleet": {  # 헤더 함대 라이브 요약.
+        "fleet": {
             "total_agents": total_agents,
-            "status_breakdown": _PENDING,  # 작업중/막힘/유휴 = CC-BE.2(workflow-line status).
+            "status_breakdown": fleet_breakdown,  # CC-BE.2 실데이터.
         },
         "project_status": {
-            "epics": epics,                                   # 실데이터.
-            "outcome": {"hit": h_hit, "total": h_total},      # 실데이터.
-            "recent_changes": recent_changes,                 # 실데이터.
-            "risk": _PENDING,        # 지연/막힘/실패 — CC-BE.2(due/dependency/failed-run).
-            "cycle_time": _PENDING,  # CC-BE.2.
-            "contribution": _PENDING,  # 에이전트:사람 — CC-BE.2.
-            "cost_trend": _PENDING,  # 토큰/비용 시계열 — CC-BE.2.
+            "epics": epics,
+            "outcome": {"hit": h_hit, "total": h_total},
+            "recent_changes": recent_changes,
+            "risk": risk,                # CC-BE.2(overdue 만 pending).
+            "cycle_time": cycle_time,    # CC-BE.2.
+            "contribution": contribution,  # CC-BE.2 aggregate.
+            "cost_trend": cost_trend,    # CC-BE.2.
         },
     })

--- a/backend/app/routers/command_center.py
+++ b/backend/app/routers/command_center.py
@@ -118,6 +118,8 @@ async def my_actions(
                 ItemDependency.org_id == org_id,
                 ItemDependency.dep_type == "blocks",
                 ItemDependency.item_type == "story",
+                _Blocker.org_id == org_id,                # defense-in-depth: 조인 story 도 org-scope.
+                _Blocked.org_id == org_id,
                 _Blocker.assignee_id == member_id,        # 막은 쪽이 내 담당.
                 _Blocker.deleted_at.is_(None),
                 _Blocked.status.not_in(_OPEN_EXCLUDED_STATUSES),  # 막힌 쪽이 아직 open.
@@ -189,6 +191,7 @@ async def my_actions(
                 ItemDependency.dep_type == "blocks",
                 ItemDependency.item_type == "story",
                 ItemDependency.created_at < now - timedelta(days=_BLOCKER_UNANSWERED_DAYS),
+                _BlockedU.org_id == org_id,               # defense-in-depth: 조인 story 도 org-scope.
                 _BlockedU.status.not_in(_OPEN_EXCLUDED_STATUSES),
                 _BlockedU.deleted_at.is_(None),
             )
@@ -301,7 +304,8 @@ async def overview(
         await session.execute(
             select(Member.type, func.count(Story.id))
             .select_from(Story)
-            .join(Member, Member.id == Story.assignee_id, isouter=True)
+            # outer join + ON 에 org_id — 타 org member 매칭 차단(cross-org → unassigned 으로 떨어짐).
+            .join(Member, (Member.id == Story.assignee_id) & (Member.org_id == org_id), isouter=True)
             .where(
                 Story.org_id == org_id, Story.status == "done",
                 Story.deleted_at.is_(None), Story.is_excluded.is_(False),
@@ -375,6 +379,7 @@ async def overview(
                 ItemDependency.org_id == org_id,
                 ItemDependency.dep_type == "blocks",
                 ItemDependency.item_type == "story",
+                _BlockedR.org_id == org_id,               # defense-in-depth: 조인 story 도 org-scope.
                 _BlockedR.status.not_in(_OPEN_EXCLUDED_STATUSES),
                 _BlockedR.deleted_at.is_(None),
             )

--- a/backend/tests/test_command_center.py
+++ b/backend/tests/test_command_center.py
@@ -81,99 +81,162 @@ def _data(resp):
     return body.get("data", body) if isinstance(body, dict) else {}
 
 
+# my-actions 쿼리 순서: approvals → reviews → my_blockers(.all) → agent_stuck → stalled(.all) → unanswered(.all).
+def _ma_seq(approvals=(), reviews=(), my_blockers=(), stuck=(), stalled=(), unanswered=()):
+    return [_r_scalars(approvals), _r_scalars(reviews), _r_all(my_blockers),
+            _r_scalars(stuck), _r_all(stalled), _r_all(unanswered)]
+
+
+_DT = datetime(2026, 6, 23, tzinfo=timezone.utc)
+_OLD = datetime(2026, 6, 1, tzinfo=timezone.utc)  # 충분히 과거(정체/age 판정용).
+
+
 # ── /my-actions ─────────────────────────────────────────────────────────────────
 @pytest.mark.anyio
 async def test_my_actions_scope_separation_and_items():
-    approval = MagicMock(gate_id=uuid.uuid4(), approval_group_id=uuid.uuid4(), kind="approver",
-                         created_at=datetime(2026, 6, 23, tzinfo=timezone.utc))
-    review = MagicMock(id=uuid.uuid4(), title="Ship login", status="in-review",
-                       updated_at=datetime(2026, 6, 23, tzinfo=timezone.utc))
+    approval = MagicMock(gate_id=uuid.uuid4(), approval_group_id=uuid.uuid4(), kind="approver", created_at=_DT)
+    review = MagicMock(id=uuid.uuid4(), title="Ship login", status="in-review", updated_at=_DT)
     stuck = MagicMock(entity_type="story", entity_id=uuid.uuid4(), effective_gate_type="merge",
-                      started_at=datetime(2026, 6, 23, tzinfo=timezone.utc), failure_message="SECRET raw error")
-    # 쿼리 순서: approvals → reviews → stuck.
+                      started_at=_DT, failure_message="SECRET raw error")
     resp, session, resolver = await _get(
         "/api/v2/command-center/my-actions",
-        execute_seq=[_r_scalars([approval]), _r_scalars([review]), _r_scalars([stuck])])
+        execute_seq=_ma_seq(approvals=[approval], reviews=[review], stuck=[stuck]))
     assert resp.status_code == 200
     d = _data(resp)
     assert d["action_queue"]["scope"] == "member"      # ⭐member-private.
     assert d["attention"]["scope"] == "org"            # ⭐org.
-    types = {i["type"] for i in d["action_queue"]["items"]}
-    assert types == {"gate_approval", "review_merge"}
+    assert {i["type"] for i in d["action_queue"]["items"]} == {"gate_approval", "review_merge"}
     assert d["attention"]["items"][0]["type"] == "agent_stuck" and d["attention"]["items"][0]["auto_detected"]
-    # ⭐민감 텍스트 비노출: failure_message 가 응답 어디에도 없어야.
-    assert "SECRET raw error" not in resp.text
-    assert "my_blockers" in d["attention"]["pending"]  # CC-BE.2 명시.
+    assert "SECRET raw error" not in resp.text          # ⭐민감 텍스트 비노출.
+    assert d["attention"]["pending"] == ["time_sensitive"]  # CC-BE.2서 나머지 채움(my_blockers→큐로 이동).
+
+
+@pytest.mark.anyio
+async def test_my_actions_my_blockers_member_private():
+    """CC-BE.2: 내가 풀 블로커(내 담당이 막은 open 스토리)가 action_queue(member-private·danger)에."""
+    blocker_id, blocked_id = uuid.uuid4(), uuid.uuid4()
+    resp, session, resolver = await _get(
+        "/api/v2/command-center/my-actions",
+        execute_seq=_ma_seq(my_blockers=[(blocker_id, blocked_id)]))
+    assert resp.status_code == 200
+    items = _data(resp)["action_queue"]["items"]
+    mb = [i for i in items if i["type"] == "my_blockers"]
+    assert len(mb) == 1 and mb[0]["priority"] == "danger"
+    assert mb[0]["context"]["blocked_story_id"] == str(blocked_id)
+
+
+@pytest.mark.anyio
+async def test_my_actions_stalled_and_unanswered_blocker_enum_only():
+    """CC-BE.2 이상감지: story_stalled + unanswered_blocker(org attention·enum/ids/age·raw text 0)."""
+    sid, blocker_id, blocked_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    resp, session, resolver = await _get(
+        "/api/v2/command-center/my-actions",
+        execute_seq=_ma_seq(stalled=[(sid, _OLD)], unanswered=[(blocker_id, blocked_id, _OLD)]))
+    assert resp.status_code == 200
+    types = {i["type"] for i in _data(resp)["attention"]["items"]}
+    assert {"story_stalled", "unanswered_blocker"} <= types
+    items = _data(resp)["attention"]["items"]
+    stalled_item = next(i for i in items if i["type"] == "story_stalled")
+    assert stalled_item["story_id"] == str(sid) and isinstance(stalled_item["stalled_days"], int)
+    ub = next(i for i in items if i["type"] == "unanswered_blocker")
+    assert ub["blocked_story_id"] == str(blocked_id) and isinstance(ub["age_days"], int)
 
 
 @pytest.mark.anyio
 async def test_my_actions_uses_canonical_member_resolver():
     """HIGH1: auth.user_id(=users.id 모사·member 와 다름) 직사용 금지 → resolve_member 로 member.id 해소."""
-    resp, session, resolver = await _get(
-        "/api/v2/command-center/my-actions",
-        execute_seq=[_r_scalars([]), _r_scalars([]), _r_scalars([])])
+    resp, session, resolver = await _get("/api/v2/command-center/my-actions", execute_seq=_ma_seq())
     assert resp.status_code == 200
-    resolver.assert_awaited_once()  # canonical resolver 사용(raw auth.user_id 아님).
+    resolver.assert_awaited_once()
 
 
 @pytest.mark.anyio
 async def test_my_actions_agent_stuck_filters_to_agent():
-    """HIGH2: agent_stuck 쿼리가 resolved_member_type=='agent' 로 필터(human run 미포함)."""
-    resp, session, resolver = await _get(
-        "/api/v2/command-center/my-actions",
-        execute_seq=[_r_scalars([]), _r_scalars([]), _r_scalars([])])
+    """HIGH2: agent_stuck 쿼리(4번째 execute)가 resolved_member_type=='agent' 로 필터."""
+    resp, session, resolver = await _get("/api/v2/command-center/my-actions", execute_seq=_ma_seq())
     assert resp.status_code == 200
-    # 3번째 execute = agent_stuck 쿼리. 컴파일된 SQL 에 agent 필터(resolved_member_type)가 박혀야.
-    stuck_stmt = str(session.execute.await_args_list[2].args[0])
-    assert "resolved_member_type" in stuck_stmt
+    assert "resolved_member_type" in str(session.execute.await_args_list[3].args[0])
 
 
 @pytest.mark.anyio
 async def test_my_actions_clear_state():
-    resp, session, resolver = await _get(
-        "/api/v2/command-center/my-actions",
-        execute_seq=[_r_scalars([]), _r_scalars([]), _r_scalars([])])
+    resp, session, resolver = await _get("/api/v2/command-center/my-actions", execute_seq=_ma_seq())
     assert resp.status_code == 200
     assert _data(resp)["is_clear"] is True
 
 
 @pytest.mark.anyio
 async def test_my_actions_resolver_failure_propagates():
-    """member resolve 실패(미존재 등) → resolve_member 가 401/403/400 raise → 큐 쿼리 0."""
+    """member resolve 실패 → resolve_member 가 raise → 큐 쿼리 0."""
     from fastapi import HTTPException
     resp, session, resolver = await _get(
         "/api/v2/command-center/my-actions", execute_seq=[],
         resolve_raises=HTTPException(status_code=400, detail="member not found"))
     assert resp.status_code == 400
-    session.execute.assert_not_awaited()  # resolve 실패 → action_queue 쿼리 0.
+    session.execute.assert_not_awaited()
 
 
 # ── /overview ─────────────────────────────────────────────────────────────────
+# 쿼리 순서: total_agents→epic_rows→epics→hypothesis→events→contribution→cycle→cost→blocked→failed→fleet.
+def _ov_seq(*, total_agents=0, epic_rows=(), epics=(), hyp=(0, 0), events=(),
+            contrib=(), cycle=(None, 0), cost=(), blocked=0, failed=0, fleet=()):
+    return [
+        _r_scalar(total_agents), _r_all(epic_rows), _r_scalars(epics), _r_one(hyp),
+        _r_scalars(events), _r_all(contrib), _r_one(cycle), _r_all(cost),
+        _r_scalar(blocked), _r_scalar(failed), _r_all(fleet),
+    ]
+
+
 @pytest.mark.anyio
-async def test_overview_real_and_pending_data():
+async def test_overview_real_aggregations():
+    from datetime import date
     epic_id = uuid.uuid4()
     epic = MagicMock(id=epic_id, title="Auth epic", status="active")
-    # 순서: total_agents(scalar) → epic story group(all) → epics(scalars) → hypothesis(one) → events(scalars).
+    ev = MagicMock(verb="story.status_changed", object_type="story", object_id=uuid.uuid4(), occurred_at=_DT)
     resp, session, resolver = await _get(
         "/api/v2/command-center/overview",
-        execute_seq=[
-            _r_scalar(4),                       # total_agents
-            _r_all([(epic_id, 5, 2)]),          # epic group: total 5, done 2
-            _r_scalars([epic]),                 # epics
-            _r_one((10, 3)),                    # hypothesis total 10, hit 3
-            _r_scalars([MagicMock(verb="story.status_changed", object_type="story",
-                                  object_id=uuid.uuid4(),
-                                  occurred_at=datetime(2026, 6, 23, tzinfo=timezone.utc))]),
-        ],
+        execute_seq=_ov_seq(
+            total_agents=4, epic_rows=[(epic_id, 5, 2)], epics=[epic], hyp=(10, 3), events=[ev],
+            contrib=[("agent", 7), ("human", 3), (None, 2)],
+            cycle=(172800.0, 4),  # 2.0 days avg, sample 4
+            cost=[(date(2026, 6, 23), 1.5, 1000)],
+            blocked=2, failed=1, fleet=[("online", 3, 2), ("offline", 1, 0)],
+        ),
     )
     assert resp.status_code == 200
     d = _data(resp)
-    assert d["scope"] == "org"
+    ps = d["project_status"]
     assert d["fleet"]["total_agents"] == 4
-    assert d["fleet"]["status_breakdown"] == {"status": "pending_data"}   # 신규=pending.
-    assert d["project_status"]["epics"][0]["completion_pct"] == 40        # 2/5.
-    assert d["project_status"]["outcome"] == {"hit": 3, "total": 10}      # 실데이터.
-    assert len(d["project_status"]["recent_changes"]) == 1
-    # mock-0: 신규 집계는 전부 pending_data(가짜 수치 0).
-    for k in ("risk", "cycle_time", "contribution", "cost_trend"):
-        assert d["project_status"][k] == {"status": "pending_data"}
+    assert d["fleet"]["status_breakdown"] == {"online": 3, "offline": 1, "working": 2}  # CC-BE.2 실.
+    assert ps["epics"][0]["completion_pct"] == 40
+    assert ps["outcome"] == {"hit": 3, "total": 10}
+    assert ps["contribution"] == {"agent": 7, "human": 3, "unassigned": 2}  # aggregate(개인 0).
+    assert ps["cycle_time"] == {"avg_days": 2.0, "sample": 4}
+    assert ps["cost_trend"]["total_cost_usd"] == 1.5 and len(ps["cost_trend"]["points"]) == 1
+    assert ps["risk"] == {"blocked": 2, "failed_runs": 1, "overdue": {"status": "pending_data"}}
+
+
+@pytest.mark.anyio
+async def test_overview_recent_changes_excludes_conversation():
+    """recent_changes allowlist: conversation.* 등 저신호 제외·의미 verb 만(unknown 기본 제외)."""
+    convo = MagicMock(verb="conversation.message_created", object_type="conversation",
+                      object_id=uuid.uuid4(), occurred_at=_DT)
+    story = MagicMock(verb="story.status_changed", object_type="story", object_id=uuid.uuid4(), occurred_at=_DT)
+    unknown = MagicMock(verb="presence.tick", object_type=None, object_id=None, occurred_at=_DT)
+    resp, session, resolver = await _get(
+        "/api/v2/command-center/overview", execute_seq=_ov_seq(events=[convo, story, unknown]))
+    assert resp.status_code == 200
+    verbs = [r["verb"] for r in _data(resp)["project_status"]["recent_changes"]]
+    assert verbs == ["story.status_changed"]  # conversation.*·presence.* 제외.
+
+
+@pytest.mark.anyio
+async def test_overview_cost_trend_empty_honest_and_cycle_null():
+    """소스 없을 때: cost_trend=honest empty(가짜 0 아님)·cycle_time avg null·mock 0."""
+    resp, session, resolver = await _get(
+        "/api/v2/command-center/overview", execute_seq=_ov_seq(cost=[], cycle=(None, 0)))
+    assert resp.status_code == 200
+    ps = _data(resp)["project_status"]
+    assert ps["cost_trend"] == {"points": [], "total_cost_usd": 0, "delta_pct": None}
+    assert ps["cycle_time"] == {"avg_days": None, "sample": 0}
+    # 신규 집계가 mock 가짜 수치를 내지 않음(빈 소스=정직한 empty/null).


### PR DESCRIPTION
## Summary
E-MODERN Track C — Command Center BE **phase 2 (CC-BE.2)**: fill the CC-BE.1 `pending_data` placeholders with REAL aggregations + fix a live `recent_changes` noise finding. Santiago's perm/info-exposure criteria 1:1. **mock-0** absolute (real data, honest empty, or remaining `pending_data` — never fake numbers). FE is forward-compat → fields go live automatically.

## Story
[SID:f84b244c-c6e0-437b-9c57-b6ded8384529]

## `pending_data` → real (response shape)
- **`contribution`** = `{"agent": N, "human": M, "unassigned": K}` — done stories grouped by assignee `Member.type`. **Aggregate only** (no per-member ranking/blame); excludes is_excluded/deleted.
- **`cycle_time`** = `{"avg_days": float|null, "sample": int}` — `Story.created_at` → done (latest `StoryActivity` status_changed→done), last ~30d, excluded/deleted out, `sample 0 → null` (not fake).
- **`cost_trend`** = `{"points": [{"date","cost_usd","tokens"}], "total_cost_usd", "delta_pct": null}` — `AgentRun` daily GROUP BY (14d), **org-scope (no per-member cost)**. **No runs → honest empty** (`points: []`, total 0) — not fake, not pending.
- **`risk`** = `{"blocked": int, "failed_runs": int, "overdue": {"status":"pending_data"}}` — blocked open stories via `ItemDependency`, failed `AgentRun` (7d). overdue stays pending (no Story due-date field).
- **`fleet.status_breakdown`** = `{"online": N, "offline": M, "working": <online w/ active_story>}` — `AgentProjectProfile` × org agents.
- **`/my-actions` attention** += `story_stalled` `{story_id, stalled_days}` + `unanswered_blocker` `{blocked_story_id, blocker_id, age_days}` — org-scope, **enum/ids/age only (no raw blocker/error text)**. `attention.pending` now `["time_sensitive"]` only.
- **`/my-actions` action_queue** += `my_blockers` `{blocker_story_id, blocked_story_id}` priority danger — `ItemDependency` where the blocking story is **assigned to caller** (member-private, caller-bound via resolve_member.id).

## recent_changes live fix (PO/Santiago)
verb **allowlist** (`story.`/`gate.`/`pr.`/`epic.`/`sprint.`/`dependency.`/`merge`), excludes `conversation.*` + unknown verbs (default-exclude) — kills the low-signal chat noise seen live.

## Santiago criteria
org-scope every query ✓ · contribution aggregate-only (no blame) ✓ · cost org-scope (no per-member) ✓ · cycle excluded/deleted out + done-timestamp via StoryActivity ✓ · blocker/anomaly enum/ids/age only (no raw text) ✓ · my_blockers caller-bound member-private ✓ · mock-0 (cost honest-empty, cycle null, overdue pending) ✓ · CC-BE.1 mixed-scope separation intact.

## Files
`routers/command_center.py` (+282/-) · `tests/test_command_center.py` (10 passed: 6 updated for new query order + 4 new — my_blockers member-private, stalled/unanswered enum-only, recent_changes excludes conversation.*, cost_trend empty + cycle null). No model/migration change.

## Verification
`CI=1` 10 passed. router compiles, app loads. Live-verifiable on dev (fills the 5 "준비중" the live guardian observed).

## Remaining pending
`risk.overdue` (no due-date field) · `attention.time_sensitive` · cost_trend `delta_pct` (prior-period delta = follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
