### PR TITLE
[SID:e9bd1908] 설정 LNB '연동' 발견성 fix — nav 기본 노출(breakpoint lg→md)

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -812,8 +812,8 @@ export default function SettingsPage() {
   return (
     <>
       <Tabs value={activeTab} onValueChange={handleTabChange} orientation="vertical" className="flex-1 min-h-0 gap-0">
-        {/* Left nav: desktop=always visible, mobile=toggle via lnbOpen */}
-        <div className={`shrink-0 border-r overflow-y-auto p-4 flex-col w-52 ${lnbOpen ? 'flex' : 'hidden'} lg:flex`}>
+        {/* Left nav: desktop/tablet(≥md)=always visible, mobile(<md)=toggle via lnbOpen */}
+        <div className={`shrink-0 border-r overflow-y-auto p-4 flex-col w-52 ${lnbOpen ? 'flex' : 'hidden'} md:flex`}>
           <h1 className="mb-4 px-2 text-sm font-semibold">{t('title')}</h1>
           <TabsList variant="line" className="w-full flex-col items-stretch">
             <span className="px-2 pb-1 pt-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{t('myAccount')}</span>
@@ -925,7 +925,7 @@ export default function SettingsPage() {
             <button
               type="button"
               onClick={() => setLnbOpen((v) => !v)}
-              className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+              className="md:hidden rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
               aria-label="Toggle navigation"
             >
               {lnbOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}


### PR DESCRIPTION
## 배경
선생님 라이브 실측: \`/settings/integrations\` 페이지는 라이브이나, '연동' nav 링크가 1008px(리뷰 뷰포트)에서 **visible:false** (getBoundingClientRect w/h 전부 0). 설정 좌측 nav가 \`lg:flex\`(≥1024)에서만 기본 노출되어 1024px 미만 데스크탑에서 통째 display:none → URL 직접 입력 없이는 '연동' 도달 불가.

## 변경
- \`settings/page.tsx\` nav 사이드바: \`lg:flex\` → \`md:flex\` (≥768 기본 노출, 1008px/데스크탑 커버)
- 모바일 LNB 토글 버튼: \`md:hidden\` 추가 (md+ 에서 nav 상시 노출 → 중복 토글 제거, SidebarTrigger 유지)

## 범위
className 2곳 + 주석. 토큰/구조/기능 변경 0. canonical 유지.

## 검증
배포 후 1008px에서 설정 nav + '연동' visible(w/h>0) + 실 클릭 → \`/settings/integrations\` 도달 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)