### PR TITLE
[SID:e9bd1908] 설정 '연동'을 결제 섹션에서 분리 — 자체 섹션 헤더

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -897,7 +897,8 @@ export default function SettingsPage() {
               </>
             ) : null}
 
-            {/* E-GHAPP: 연동 — 서브라우트(`/settings/integrations`·install-callback 타깃)로 네비게이션(탭 아닌 발견성 진입점) */}
+            {/* E-GHAPP: 연동 — 자체 섹션(결제와 분리·향후 slack/jira 등 통합 표준 위치)·서브라우트 `/settings/integrations`(install-callback 타깃·탭 아닌 발견성 진입점) */}
+            <span className="px-2 pb-1 pt-4 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{t('tabIntegrations')}</span>
             <Link
               href="/settings/integrations"
               className="flex w-full items-center gap-2 px-3 py-2 text-sm text-muted-foreground transition hover:text-foreground"


### PR DESCRIPTION
## 배경
선생님 적출: 설정 nav에서 '연동'이 결제(billing) 섹션 항목 바로 아래에 자체 헤더 없이 위치 → 시각적으로 결제에 묶여 보임(어색한 그룹핑).

## 변경
- 결제와 위험 구역 사이에 독립 '연동' 섹션 헤더 추가(기존 섹션 라벨 패턴 재사용·`t('tabIntegrations')`).
- 향후 slack/jira 등 통합이 들어올 표준 위치.

## 범위
섹션 헤더 1줄 + 주석. 링크/페이지/카드/가시성 불변. 신규 i18n 키 0. canonical 유지.

## 검증
배포 후 1008px에서 '연동'이 결제와 분리된 자체 섹션으로 표시 + visible 유지 + 실 클릭 → `/settings/integrations` 도달 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)