### PR TITLE
[infra] fix: Dockerfile 에 scripts/migrate.sh 복원 — 마이그 잡 exec 실패 회귀(#1666 follow-up)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,11 +19,15 @@ COPY sprintable_mcp/ sprintable_mcp/
 COPY alembic.ini .
 COPY alembic/ alembic/
 COPY bootstrap.py .
-# 런타임 잡 스크립트만 동봉(scripts/jobs/) — migrate-dev 잡 클론(command override)으로 in-VPC 실행:
-# `python -m scripts.jobs.<name>`(/app 기준·namespace 패키지). 디렉토리 통째 COPY라 신규 잡 스크립트는
-# 자동 포함(개별 COPY 누락 함정 회피·E-DG-REAL P0 backfill 사건). deploy/setup/provision .sh·RUNBOOK 등
-# 비-런타임 스크립트는 scripts/ 루트에 남겨 런타임 이미지서 제외(recon-surface 최소화).
+# 런타임 잡 스크립트 동봉: scripts/jobs/(`python -m scripts.jobs.<name>`·namespace 패키지·신규 잡 자동 포함)
+# + scripts/migrate.sh(표준 sprintable-migrate{,-dev} 잡 command=`/app/scripts/migrate.sh`·env guard+CWD 보정+
+# `exec alembic upgrade head`). ⚠️migrate.sh 는 #1666서 `COPY scripts/`→`scripts/jobs/`로 좁히며 이미지서
+# 누락돼 마이그 잡 exec 실패했음(provision_migrate_job.sh 는 옛 경로 참조=계약 드리프트) — 명시 COPY 로 복원.
+# deploy/setup/provision .sh·RUNBOOK 등 비-런타임은 scripts/ 루트에 남겨 제외 유지(recon-surface 최소).
 COPY scripts/jobs/ scripts/jobs/
+COPY scripts/migrate.sh scripts/migrate.sh
+# git mode 100755 라 COPY 가 +x 보존하나, critical infra 라 명시(belt-and-suspenders·잡 직접 exec).
+RUN chmod +x scripts/migrate.sh
 
 # non-root 사용자 생성 + /app 소유권 변경 (uv .venv 포함)
 RUN useradd --create-home --shell /bin/bash appuser \


### PR DESCRIPTION
## Summary
Restore `scripts/migrate.sh` to the backend runtime image — fixes the migration-job exec failure introduced by #1666. **infra-critical** (migration jobs).

## Root cause
#1666 (hygiene) narrowed `backend/Dockerfile` from `COPY scripts/ scripts/` (#1664) to `COPY scripts/jobs/ scripts/jobs/`, to shrink recon surface. But `scripts/migrate.sh` lives in `scripts/` root (not `scripts/jobs/`), so it was **dropped from the image**. The standard `sprintable-migrate{,-dev}` jobs (and `provision_migrate_job.sh`) still invoke `command=/app/scripts/migrate.sh` → on the 06-23 `latest-dev` image the container fails to start (file absent — "echo doesn't even run"). 06-21 (pre-#1666) worked. ⚠️ **prod `sprintable-migrate` uses the same command** → same latent regression once prod runs a post-#1666 image.

## Fix (option A — minimal, contract preserved)
- `backend/Dockerfile`: `COPY scripts/migrate.sh scripts/migrate.sh` restored + `RUN chmod +x scripts/migrate.sh` (git mode is 100755 and COPY preserves it; chmod is belt-and-suspenders since the job execs it directly).
- Job command + `provision_migrate_job.sh` unchanged (`/app/scripts/migrate.sh` works again).
- `scripts/jobs/` COPY kept (Python job namespace). deploy/setup/provision .sh + RUNBOOK stay excluded (recon-surface hygiene intact — only `migrate.sh` re-added).
- `migrate.sh` keeps its value: ALEMBIC_DATABASE_URL guard + CWD fix + `exec alembic upgrade head`.

## Verification
- COPY source `backend/scripts/migrate.sh` exists (100755).
- Image build (incl. the COPY) validated by CI smoke-test (Docker Buildx).
- Post-deploy: PO reverts the dev migrate job's `sh -c` workaround back to standard `/app/scripts/migrate.sh`; prod `sprintable-migrate` confirmed on the same contract before next prod migration.

## Follow-up (separate)
A regression guard for "runtime script dropped from image" could be added later; for now the Dockerfile comment documents the #1666 trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
