### PR TITLE
[E-GHAPP] fix: install_callback redirect 를 프론트 절대주소로 (백엔드 host 404 회귀)

### DIFF
--- a/backend/app/routers/github_integration.py
+++ b/backend/app/routers/github_integration.py
@@ -71,8 +71,12 @@ async def install_callback(
 ) -> RedirectResponse:
     """GitHub 설치 후 리다이렉트. state(CSRF+org+nonce+TTL) 검증 → nonce one-time consume → installation
     소속 검증(anti-IDOR) → github_installation upsert. 위조/만료/replay/소속불일치 전부 거부.
+
+    ⚠️redirect 는 **프론트 절대주소**(`settings.app_url`)로 — 콜백이 백엔드 host 라 상대경로면 GitHub 가 백엔드
+    host 로 해소해 404(연결 저장은 성공·redirect 타겟만 버그였음). github=<value> 외 installation_id/state 등
+    민감 param 미포함(FE 가 value→neutral copy).
     """
-    settings_url = "/settings/integrations"
+    settings_url = f"{settings.app_url.rstrip('/')}/settings/integrations"
 
     verified = verify_install_state(state)
     if verified is None:

--- a/backend/tests/test_github_app_bot_s.py
+++ b/backend/tests/test_github_app_bot_s.py
@@ -240,4 +240,7 @@ async def test_callback_replay_rejected_when_nonce_already_consumed():
         with patch("app.routers.github_integration.verify_installation_owned", new=AsyncMock(return_value=True)) as owned:
             resp = await install_callback(installation_id=1, state=state, code="x", setup_action="install", session=session)
     assert resp.status_code == 302 and "replay_or_expired" in resp.headers["location"]
+    # ⭐redirect 는 **프론트 절대주소**여야(상대경로면 GitHub 가 백엔드 host 로 해소→404 회귀). app_url 기준.
+    loc = resp.headers["location"]
+    assert loc.startswith(ga.settings.app_url.rstrip("/") + "/settings/integrations"), loc
     owned.assert_not_awaited()  # consume 실패 시 ownership 검증조차 안 감.


### PR DESCRIPTION
## Summary
Fix the GitHub App connect-callback 404 (선생님 live finding): `install_callback` redirected to a **relative** path, which GitHub resolved against the **backend** host (the callback runs on backend) → backend has no such frontend route → 404. The connection itself succeeded (github_installation saved); only the redirect target was wrong.

## Fix
`settings_url` → **frontend absolute URL** `f"{settings.app_url.rstrip('/')}/settings/integrations"`. All 5 RedirectResponse (success `connected` + failures `invalid_state`/`replay_or_expired`/`not_owned`/`conflict`) inherit it. No installation_id/state in the redirect URL — only `github=<value>` (FE maps value → neutral copy). `app_url` = dev-app env.

## Test
Existing replay test strengthened with an **absolute-URL assertion** (`location.startswith(app_url + "/settings/integrations")`) — regression guard against relative paths. 16 passed; app loads.

## Verification
Post-deploy: connect → callback → redirects to `dev-app.sprintable.ai/settings/integrations?github=connected` (no 404), card shows connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
