### PR TITLE
[SID:cd82925b] 문서 상단 여백 과다 fix (surgical padding·기능 동결)

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -403,13 +403,13 @@ export default function DocSlugPage() {
 
       {/* S28: doc decision gate(검토 상태·반려 사유·재상신 CTA·revision 이력). 비-gated/이력없음은 self-hide. */}
       {selectedDoc.doc_type !== 'sprint_report' ? (
-        <div className="flex-shrink-0 px-4 pt-3 lg:px-6">
+        <div className="flex-shrink-0 px-4 pt-2 lg:px-6">
           <DocGateSection docId={selectedDoc.id} status={selectedDoc.status} onTransitioned={fetchDoc} />
         </div>
       ) : null}
 
       {/* Editor */}
-      <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-4 py-4 lg:px-6 lg:py-6">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-4 pt-2 pb-4 lg:px-6 lg:pt-3 lg:pb-6">
         <DocEditor
           value={content}
           contentFormat={contentFormat}

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -288,13 +288,13 @@ export function DocEditor({
     <div className="flex h-full flex-col overflow-hidden rounded-xl border border-border bg-card max-md:h-[100dvh]">
       {/* Breadcrumb (위치: title 위) */}
       {breadcrumb && (
-        <div className="flex-shrink-0 px-6 pt-4">
+        <div className="flex-shrink-0 px-6 pt-3">
           {breadcrumb}
         </div>
       )}
       {/* Inline title (Notion style) */}
       {title !== undefined && (
-        <div className={`flex flex-shrink-0 items-center justify-between gap-2 px-6 pb-2 ${breadcrumb ? 'pt-2' : 'pt-3'}`}>
+        <div className="flex flex-shrink-0 items-center justify-between gap-2 px-6 pb-2 pt-2">
           {/* §3-2: 본문 hero 타이틀(36px) → 슬림 헤더 타이틀(18px·font-bold). 이중 헤더 해소·콘텐츠 공간 확보. */}
           <textarea
             ref={titleRef}


### PR DESCRIPTION
## 한 줄
선생님 적출(**문서 상단 여백 과다**) — #1683(머지됨) 위 누적 갭을 **pure padding 4건**으로 타이트. canonical 4px·**기능 동결**·top만 줄이고 하단 콘텐츠 호흡 유지.

> story `cd82925b` (E-MODERN Track C 문서 리디자인 follow-up) · 유나 spacing 스펙(develop 머지본 실측) · #1683 머지 후 별도 PR

## 진단 (상단 적층)
TopBar → (모바일 칩 밴드) → Dispatch바 → Gate(gated만) → **에디터 영역 `py-4/lg:py-6`** → doc-card[breadcrumb `pt-4`/타이틀 `pt`] → 제목. 갭 누적 → 콘텐츠 밀림.

## fix 4건 (surgical · apps/web · 2파일)
| # | 위치 | → 후 |
|---|---|---|
| 1 | `[slug]/page.tsx` 에디터 영역 | `py-4 lg:py-6` → `pt-2 pb-4 lg:pt-3 lg:pb-6` (doc-card 위 갭 −8/−12·하단 호흡 보존) |
| 2 | `doc-editor.tsx` 타이틀 블록 | ternary(`pt-2`/`pt-3`) → 항상 `pt-2` (no-breadcrumb −4px) |
| 3 | `doc-editor.tsx` breadcrumb | `pt-4` → `pt-3` (−4px) |
| 4 | `[slug]/page.tsx` Gate 래퍼 | `pt-3` → `pt-2` (gated −4px) |

**유지(손 안 댐)**: Dispatch바 `py-2`·모바일 칩 밴드 `py-2`(44px 터치)·metaSlot `pb-1`·탭 `py-2`. 순효과 상단 **−12~16px**. `pt-2`/`pt-3`(8/12px)이 권장 바닥 — 0 짜부 X(과잉만 제거).

## 검증
- `tsc` 0 · `eslint` 추가분 0(`63/65` unused eslint-disable는 #1683 전부터 pre-existing·내 diff 무관) · padding-only(기능 동결·핸들러/prop/state 무변경·canonical 4px).

⚠️ 라이브 = 머지 後 가디언 양테마 픽셀(상단 갭 실측·데스크탑 1008+·모바일 390·다크). PR 단계 = 가디언 코드리뷰 → PO LGTM → 까심 QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)