### PR TITLE
[SID:cd82925b] 문서 수직 밀도 박스1 — Dispatch 아바타+popover·모바일 칩 띠 제거

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1197,6 +1197,8 @@
     "docGateEdit": "Revise",
     "docGateRevisions": "Revision history",
     "docMetaRevisions": "{count} revisions",
+    "assignee": "Assignee",
+    "assigneeUnassigned": "Assign owner",
     "noProject": "No project selected",
     "selectDoc": "Select a document",
     "lastUpdated": "Last updated",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1197,6 +1197,8 @@
     "docGateEdit": "수정",
     "docGateRevisions": "수정 이력",
     "docMetaRevisions": "수정 이력 {count}",
+    "assignee": "담당자",
+    "assigneeUnassigned": "담당자 배정",
     "noProject": "프로젝트가 선택되지 않았습니다",
     "selectDoc": "문서를 선택하세요",
     "lastUpdated": "최종 수정",

--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -22,7 +22,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useDocsLayout } from '../docs-context';
-import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
+import { DocAssigneeControl } from '@/components/docs/doc-assignee-control';
 import { DocBreadcrumb } from '@/components/docs/doc-breadcrumb';
 
 interface DocDetail {
@@ -122,7 +122,7 @@ export default function DocSlugPage() {
   const isNewRef = useRef(typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('new') === '1');
   const isNew = isNewRef.current;
 
-  const { projectId, tree, setTree, pendingDocUpdate, clearPendingDocUpdate, expandFolder } = useDocsLayout();
+  const { projectId, tree, setTree, pendingDocUpdate, clearPendingDocUpdate, expandFolder, openTreeDrawer } = useDocsLayout();
 
   const [selectedDoc, setSelectedDoc] = useState<DocDetail | null>(null);
   const [docLoading, setDocLoading] = useState(true);
@@ -387,19 +387,7 @@ export default function DocSlugPage() {
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      {/* Dispatch */}
-      {projectId && (
-        <div className="flex-shrink-0 border-b border-border px-4 py-2 lg:px-6">
-          <EntityDispatchPanel
-            entityType="doc"
-            entityId={selectedDoc.id}
-            projectId={projectId}
-            currentAssigneeId={selectedDoc.assignee_id}
-            onAssigneePatched={(aid) => setSelectedDoc((prev) => prev ? { ...prev, assignee_id: aid } : prev)}
-            mobileMode="assignee-only"
-          />
-        </div>
-      )}
+      {/* 박스1: Dispatch(담당자) 밴드 제거 → 슬림 헤더 담당자 아바타+popover로 이동(content-dominant·기능 보존). */}
 
       {/* S28: doc decision gate(검토 상태·반려 사유·재상신 CTA·revision 이력). 비-gated/이력없음은 self-hide. */}
       {selectedDoc.doc_type !== 'sprint_report' ? (
@@ -426,6 +414,15 @@ export default function DocSlugPage() {
           onTitleChange={handleTitleChange}
           titlePlaceholder={t('titlePlaceholder')}
           titleAutoFocus={isNew || !title}
+          onOpenTree={openTreeDrawer}
+          dispatchSlot={projectId ? (
+            <DocAssigneeControl
+              docId={selectedDoc.id}
+              projectId={projectId}
+              currentAssigneeId={selectedDoc.assignee_id ?? null}
+              onAssigneePatched={(aid) => setSelectedDoc((prev) => prev ? { ...prev, assignee_id: aid } : prev)}
+            />
+          ) : undefined}
           metaSlot={
             <>
               {revisionCount != null ? (

--- a/apps/web/src/app/(authenticated)/docs/docs-client-layout.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-client-layout.tsx
@@ -263,7 +263,7 @@ export function DocsClientLayout({ children }: { children: React.ReactNode }) {
 
 
   return (
-    <DocsLayoutContext.Provider value={{ projectId, tree, setTree, handleNewDoc, fetchTree, pendingDocUpdate, clearPendingDocUpdate, expandFolder }}>
+    <DocsLayoutContext.Provider value={{ projectId, tree, setTree, handleNewDoc, fetchTree, pendingDocUpdate, clearPendingDocUpdate, expandFolder, openTreeDrawer: openDrawer }}>
       <TopBarSlot
         title={topBarTitle}
         actions={topBarActions}
@@ -286,7 +286,9 @@ export function DocsClientLayout({ children }: { children: React.ReactNode }) {
           </aside>
         )}
         <section className="relative flex min-w-0 flex-1 flex-col overflow-hidden bg-background">
-          {/* Mobile drawer trigger bar */}
+          {/* 박스1: 모바일 칩 띠는 리스트뷰(문서 미선택)서만 노출 — doc 상세는 슬림 헤더 트리 아이콘이
+              트리 트리거 대체(중복 빈 띠 제거·문서명은 헤더 제목이 흡수). 리스트뷰는 칩이 유일 트리 접근이라 보존. */}
+          {!currentSlug && (
           <div
             className={cn(
               'flex-shrink-0 flex items-center gap-2 border-b border-border/80 bg-background px-4 py-2 lg:hidden',
@@ -296,13 +298,13 @@ export function DocsClientLayout({ children }: { children: React.ReactNode }) {
               gnbHidden && '-translate-y-[calc(100%+var(--gnb-mobile-height))]',
             )}
           >
-            {/* §4-1: ☰(Menu) 제거 → 칩(문서아이콘+현재 문서명+▾). GNB ☰와 시각 구분·breadcrumb 겸 트리거. */}
             <button type="button" onClick={() => setTreeDrawerOpen(true)} className="flex min-h-[44px] min-w-0 max-w-full items-center gap-2 rounded-lg border border-border px-3 text-sm text-foreground transition-colors hover:bg-accent" aria-label="문서 트리 열기">
               <FileText className="size-4 shrink-0 text-muted-foreground" />
               <span className="min-w-0 truncate font-medium">{currentDocTitle ?? t('title')}</span>
               <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
             </button>
           </div>
+          )}
           {/* Desktop collapsed sidebar open button */}
           {sidebarCollapsed && (
             <button

--- a/apps/web/src/app/(authenticated)/docs/docs-context.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-context.tsx
@@ -27,6 +27,8 @@ interface DocsLayoutContextType {
   pendingDocUpdate: DocUpdate | null;
   clearPendingDocUpdate: () => void;
   expandFolder: (id: string) => void;
+  /** 박스1: 모바일 트리 드로어 열기(슬림 헤더 트리 아이콘이 consume·칩 띠 트리거 대체) */
+  openTreeDrawer?: () => void;
 }
 
 export const DocsLayoutContext = createContext<DocsLayoutContextType | null>(null);

--- a/apps/web/src/components/docs/doc-assignee-control.tsx
+++ b/apps/web/src/components/docs/doc-assignee-control.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { User, UserPlus } from 'lucide-react';
+import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
+
+/**
+ * 박스1: 담당자 아바타 + popover. 슬림 헤더 액션 클러스터에 glanceable owner 신호(누가 owner인지 보여야 함).
+ * Dispatch 밴드 대체 — content-dominant 유지 + 기능 보존(기존 EntityDispatchPanel picker 그대로 popover 안).
+ * shadcn Popover 부재 → 코드베이스 click-outside 패턴(버튼 anchor + 조건부 패널). 신규 토큰 0.
+ */
+export function DocAssigneeControl({
+  docId,
+  projectId,
+  currentAssigneeId,
+  onAssigneePatched,
+}: {
+  docId: string;
+  projectId: string;
+  currentAssigneeId: string | null;
+  onAssigneePatched: (assigneeId: string) => void;
+}) {
+  const t = useTranslations('docs');
+  const [open, setOpen] = useState(false);
+  const [memberName, setMemberName] = useState<string | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // 현 담당자 이름 resolve(아바타 이니셜용). EntityDispatchPanel도 멤버를 fetch하나 트리거 라벨용 경량 조회.
+  // null 케이스는 동기 setState 대신 render서 파생(currentAssigneeId 가드)해 set-state-in-effect 회피.
+  useEffect(() => {
+    if (!currentAssigneeId) return;
+    let alive = true;
+    void fetch(`/api/members?project_id=${projectId}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .catch(() => null)
+      .then((json) => {
+        if (!alive) return;
+        const rows = ((json?.data ?? json) as { id: string; name: string }[] | null) ?? [];
+        const m = Array.isArray(rows) ? rows.find((x) => x.id === currentAssigneeId) : null;
+        setMemberName(m?.name ?? null);
+      });
+    return () => { alive = false; };
+  }, [currentAssigneeId, projectId]);
+
+  // click-outside 닫기
+  useEffect(() => {
+    if (!open) return;
+    const h = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', h);
+    return () => document.removeEventListener('mousedown', h);
+  }, [open]);
+
+  const assigned = !!currentAssigneeId;
+  // currentAssigneeId 가드: 담당자 해제/변경 시 stale memberName 무시(render 파생).
+  const initials = assigned && memberName ? memberName.slice(0, 2).toUpperCase() : null;
+  const label = assigned ? `${t('assignee')}: ${memberName ?? ''}`.trim() : t('assigneeUnassigned');
+
+  return (
+    <div ref={ref} className="relative shrink-0">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        title={label}
+        aria-label={label}
+        className={
+          assigned
+            ? 'flex size-7 items-center justify-center rounded-full border border-border bg-muted text-[10px] font-medium text-foreground'
+            : 'flex size-7 items-center justify-center rounded-full border border-dashed border-muted-foreground/50 text-muted-foreground transition-colors hover:text-foreground'
+        }
+      >
+        {assigned ? (initials ?? <User className="size-3.5" />) : <UserPlus className="size-3.5" />}
+      </button>
+      {open ? (
+        <div className="absolute right-0 top-full z-50 mt-1 w-72 rounded-lg border border-border bg-popover p-2 shadow-md">
+          <EntityDispatchPanel
+            entityType="doc"
+            entityId={docId}
+            projectId={projectId}
+            currentAssigneeId={currentAssigneeId}
+            onAssigneePatched={onAssigneePatched}
+            mobileMode="assignee-only"
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -16,7 +16,7 @@ import TableRow from '@tiptap/extension-table-row';
 import TableCell from '@tiptap/extension-table-cell';
 import TableHeader from '@tiptap/extension-table-header';
 import Placeholder from '@tiptap/extension-placeholder';
-import { Bold, Italic, Strikethrough, Code, Link2, Highlighter, Undo2, Redo2 } from 'lucide-react';
+import { Bold, Italic, Strikethrough, Code, Link2, Highlighter, Undo2, Redo2, PanelLeft } from 'lucide-react';
 import { CalloutNode } from './extensions/callout-node';
 import { SlashCommandExtension } from './extensions/slash-command';
 import { PageEmbedExtension } from './extensions/page-embed-node';
@@ -56,6 +56,8 @@ export function DocEditor({
   urlSlot,
   actions,
   metaSlot,
+  dispatchSlot,
+  onOpenTree,
   syncBanner,
   labels,
 }: {
@@ -82,6 +84,10 @@ export function DocEditor({
   actions?: React.ReactNode;
   /** §3-2 단일 슬림 헤더: 제목 아래 muted 메타 서브라인(수정 이력 N · 시각). 배지는 DocGateSection SSOT. */
   metaSlot?: React.ReactNode;
+  /** 박스1: 담당자 아바타+popover(헤더 액션 클러스터·glanceable owner). */
+  dispatchSlot?: React.ReactNode;
+  /** 박스1: 모바일 트리 드로어 열기(헤더 좌측 트리 아이콘·lg:hidden·칩 띠 대체). */
+  onOpenTree?: () => void;
   /** Sync-state off-ramp banner (conflict / remote-changed), rendered below the toolbar. */
   syncBanner?: React.ReactNode;
   labels: {
@@ -281,7 +287,18 @@ export function DocEditor({
           자동저장·저장). 영구 툴바·별도 저장바·중복 헤더 밴드 제거(기능 위치만 이동·제거 0). content dominant(~74%).
           포맷=BubbleMenu(선택)·slash(/)·단축키·모바일 하단 툴바로 도달. */}
       <header className="sticky top-0 z-10 flex flex-shrink-0 flex-wrap items-center gap-x-2 gap-y-1 border-b border-border bg-card px-3 py-1.5">
-        {breadcrumb ? <div className="flex shrink-0 items-center">{breadcrumb}</div> : null}
+        {/* 박스1: 모바일 트리 아이콘(칩 띠 대체·lg:hidden·드로어 트리거·데스크는 사이드바 트리) */}
+        {onOpenTree ? (
+          <button
+            type="button"
+            onClick={onOpenTree}
+            aria-label="문서 트리 열기"
+            className="flex size-7 shrink-0 items-center justify-center rounded-md border border-border text-muted-foreground transition-colors hover:bg-accent hover:text-foreground lg:hidden"
+          >
+            <PanelLeft className="size-4" />
+          </button>
+        ) : null}
+        {breadcrumb ? <div className="hidden shrink-0 items-center lg:flex">{breadcrumb}</div> : null}
         {title !== undefined ? (
           /* 인라인 제목 1줄(editable textarea·whitespace-nowrap·flex-1 min-w-0·편집 기능 보존) */
           <textarea
@@ -354,6 +371,8 @@ export function DocEditor({
               {labels.save}
             </button>
           ) : null}
+          {/* 박스1: 담당자 아바타+popover(glanceable owner·Dispatch 밴드 대체) */}
+          {dispatchSlot}
           {actions ? <div className="flex items-center gap-1">{actions}</div> : null}
         </div>
       </header>


### PR DESCRIPTION
## 한 줄
박스1(수직 밀도 재설계 마무리) — **Dispatch(담당자) 밴드 → 슬림 헤더 아바타+popover** + **모바일 칩 빈 띠 제거 → 헤더 트리 아이콘**. 유나 디자인 콜 반영·**기능 100% 동결**·신규 토큰 0. (#1685 박스2 머지본 위·diff=박스1만.)

> story `cd82925b` · 핸드오프 박스1 · 유나 콜(①(A) 아바타+popover·②칩 띠 제거+헤더 트리아이콘·③TopBar 무변경)

## 변경
**① Dispatch → 담당자 아바타+popover** (콜 (A)·glanceable owner):
- 신규 `doc-assignee-control.tsx`: ~28px 원형(`border rounded-full`)·assigned=이니셜·**unassigned=dashed + `UserPlus` muted**(배정 유도). click → **커스텀 popover**(⚠️shadcn Popover 부재→코드베이스 click-outside)에 **기존 `EntityDispatchPanel` picker 그대로**(불변·배선만). 멤버명 resolve는 async setState만(`set-state-in-effect` 회피·null render 파생).
- `DocEditor` `dispatchSlot` prop → 헤더. page **Dispatch 밴드 제거**.

**② 모바일 칩 띠 → 헤더 트리 아이콘** (콜 권장):
- `DocEditor` `onOpenTree`(`PanelLeft`·`lg:hidden`). **드로어 기계장치 불변**. `DocsLayoutContext.openTreeDrawer` 노출→page consume.
- 칩 띠 = **`!currentSlug`(리스트뷰)서만** — doc 상세는 헤더 트리아이콘 대체(빈 띠 제거·문서명 헤더 흡수). 리스트뷰는 칩이 유일 트리 접근이라 보존(grounding: `docs-empty-view` 자체 트리거 없음). breadcrumb 데스크 전용.

**③ TopBar 무변경**(슬림 헤더가 문서명 노출·app-shell 리스크 회피).

i18n `docs.assignee`/`assigneeUnassigned` ko/en(parity 128/128).

## 검증
- `tsc` 0 · `eslint` 0(박스1 파일 clean·`[slug]/page.tsx` 63/65 unused-disable pre-existing) · `next build` ✓ · canonical 위반 0 · 신규 토큰 0.
- **기능 동결**: picker·드로어·dispatch 로직 불변(위치만 이동)·담당자 배정·트리 접근 보존.

## ⚠️ 시각 confirm 대상
담당자 아바타 **2상태(assigned 이니셜 / unassigned dashed+UserPlus)** + popover + 모바일 헤더 트리 아이콘 = 신규 UI. 유나 가디언 시각 confirm 부탁. 픽셀 = 머지 後 양 테마(데스크 1008+·모바일 390·content height>50%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)