### PR TITLE
[SID:f9d41bae] 스프린트/에픽 UI 갈아엎기 (canonical·calm·진행바·기능 동결)

### DIFF
--- a/apps/web/src/app/(authenticated)/epics/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/epics/[id]/page.tsx
@@ -124,7 +124,7 @@ function MdBody({ content }: { content: string }) {
         ul: ({ children }) => <ul className="mb-2 ml-4 list-disc space-y-0.5">{children}</ul>,
         ol: ({ children }) => <ol className="mb-2 ml-4 list-decimal space-y-0.5">{children}</ol>,
         li: ({ children }) => <li className="text-sm leading-6">{children}</li>,
-        code: ({ children }) => <code className="rounded px-1 py-0.5 font-mono text-[13px] bg-muted">{children}</code>,
+        code: ({ children }) => <code className="rounded px-1 py-0.5 font-mono text-sm bg-muted">{children}</code>,
         strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
         em: ({ children }) => <em className="italic">{children}</em>,
       }}
@@ -312,7 +312,7 @@ export default function EpicDetailPage() {
         {/* Dispatch */}
         {epic.project_id && (
           <div className="rounded-xl border border-border bg-muted/20 p-4">
-            <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Dispatch</p>
+            <p className="mb-2 text-xs font-medium text-muted-foreground">Dispatch</p>
             <EntityDispatchPanel
               entityType="epic"
               entityId={epic.id}
@@ -342,7 +342,7 @@ export default function EpicDetailPage() {
 
             {/* Description */}
             <section className="space-y-2">
-              <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">설명</h2>
+              <h2 className="text-xs font-medium text-muted-foreground">설명</h2>
               {epic.description?.trim() ? (
                 <MdBody content={epic.description} />
               ) : (
@@ -353,7 +353,7 @@ export default function EpicDetailPage() {
             {/* Objective */}
             {epic.objective?.trim() && (
               <section className="space-y-2">
-                <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">목표 (Objective)</h2>
+                <h2 className="text-xs font-medium text-muted-foreground">목표 (Objective)</h2>
                 <MdBody content={epic.objective} />
               </section>
             )}
@@ -361,7 +361,7 @@ export default function EpicDetailPage() {
             {/* Success criteria */}
             {epic.success_criteria?.trim() && (
               <section className="space-y-2">
-                <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">성공 기준</h2>
+                <h2 className="text-xs font-medium text-muted-foreground">성공 기준</h2>
                 <MdBody content={epic.success_criteria} />
               </section>
             )}
@@ -370,7 +370,7 @@ export default function EpicDetailPage() {
 
         {/* Progress */}
         <section className="space-y-4">
-          <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">진행 상황</h2>
+          <h2 className="text-xs font-medium text-muted-foreground">진행 상황</h2>
           <div>
             <p className="mb-1 text-xs text-muted-foreground">스토리 완료</p>
             <ProgressBar done={done} total={stories.length} />
@@ -385,7 +385,7 @@ export default function EpicDetailPage() {
 
         {/* Stories — grouped by status */}
         <section className="space-y-4">
-          <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+          <h2 className="text-xs font-medium text-muted-foreground">
             스토리 ({stories.length})
           </h2>
           {stories.length === 0 ? (

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -463,7 +463,7 @@ function EpicRow({ epic, isSelected, onClick, onDeleteRequest }: EpicRowProps) {
           <span>{done}/{total} {t('stories')}</span>
           <HypothesesSummary count={epic.hypothesis_count ?? 0} riskyStatus={epic.risky_status ?? null} />
           {spExceeded ? (
-            <span className="rounded-full bg-destructive/10 px-1.5 py-0.5 text-[10px] font-semibold text-destructive">
+            <span className="rounded-full bg-destructive/10 px-1.5 py-0.5 text-xs font-semibold text-destructive">
               {t('spExceeded')}
             </span>
           ) : null}
@@ -584,7 +584,7 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
                 <div className="mt-1 flex items-center gap-1.5">
                   <p className="text-sm font-medium text-foreground">{epic.target_sp !== undefined ? epic.target_sp : '—'}</p>
                   {spExceeded ? (
-                    <span className="rounded-full bg-destructive/10 px-1.5 py-0.5 text-[10px] font-semibold text-destructive">{t('spExceeded')}</span>
+                    <span className="rounded-full bg-destructive/10 px-1.5 py-0.5 text-xs font-semibold text-destructive">{t('spExceeded')}</span>
                   ) : null}
                 </div>
               </div>
@@ -607,7 +607,7 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
                   <div className="flex items-center gap-2">
                     <p className="text-xs font-medium text-muted-foreground">{t('spProgress')}</p>
                     {spExceeded ? (
-                      <span className="rounded-full bg-destructive/10 px-1.5 py-0.5 text-[10px] font-semibold text-destructive">
+                      <span className="rounded-full bg-destructive/10 px-1.5 py-0.5 text-xs font-semibold text-destructive">
                         {t('spExceededDetail', { total: spProgress.total, target: epic.target_sp ?? 0 })}
                       </span>
                     ) : null}

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -423,7 +423,7 @@ function EpicRow({ epic, isSelected, onClick, onDeleteRequest }: EpicRowProps) {
 
   return (
     <div
-      className={`group relative w-full rounded-2xl border px-4 py-3.5 text-left transition-all duration-150 cursor-pointer ${
+      className={`group relative w-full rounded-xl border px-4 py-3.5 text-left transition-all duration-150 cursor-pointer ${
         isSelected
           ? 'border-primary/40 bg-primary/5'
           : 'border-border bg-card hover:border-primary/30 hover:bg-primary/5'
@@ -576,11 +576,11 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
             {/* Meta grid */}
             <div className="grid grid-cols-2 gap-3">
               <div className="rounded-xl bg-muted px-3 py-2.5">
-                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('targetDate')}</p>
+                <p className="text-xs font-medium text-muted-foreground">{t('targetDate')}</p>
                 <p className="mt-1 text-sm font-medium text-foreground">{formatDate(epic.target_date)}</p>
               </div>
               <div className="rounded-xl bg-muted px-3 py-2.5">
-                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('targetSp')}</p>
+                <p className="text-xs font-medium text-muted-foreground">{t('targetSp')}</p>
                 <div className="mt-1 flex items-center gap-1.5">
                   <p className="text-sm font-medium text-foreground">{epic.target_sp !== undefined ? epic.target_sp : '—'}</p>
                   {spExceeded ? (
@@ -592,7 +592,7 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
 
             {/* Description */}
             <div className="space-y-1.5">
-              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('description')}</p>
+              <p className="text-xs font-medium text-muted-foreground">{t('description')}</p>
               <p className="text-sm leading-relaxed text-foreground">
                 {epic.description?.trim() ? epic.description : <span className="italic text-muted-foreground">{t('noDescription')}</span>}
               </p>
@@ -600,12 +600,12 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
 
             {/* Progress */}
             <div className="space-y-3">
-              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('storiesProgress')}</p>
+              <p className="text-xs font-medium text-muted-foreground">{t('storiesProgress')}</p>
               <ProgressBar done={storyProgress.done} total={storyProgress.total} label={`${t('doneStories')} / ${t('totalStories')}`} />
               {spProgress.total > 0 ? (
                 <>
                   <div className="flex items-center gap-2">
-                    <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('spProgress')}</p>
+                    <p className="text-xs font-medium text-muted-foreground">{t('spProgress')}</p>
                     {spExceeded ? (
                       <span className="rounded-full bg-destructive/10 px-1.5 py-0.5 text-[10px] font-semibold text-destructive">
                         {t('spExceededDetail', { total: spProgress.total, target: epic.target_sp ?? 0 })}
@@ -619,7 +619,7 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
 
             {/* Story list */}
             <div className="space-y-2">
-              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('stories')}</p>
+              <p className="text-xs font-medium text-muted-foreground">{t('stories')}</p>
               {stories.length > 0 ? (
                 <div className="space-y-1.5">
                   {stories.map((story) => (

--- a/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
+++ b/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { Plus, X, Play, StopCircle, ChevronRight, Trash2, AlertTriangle } from 'lucide-react';
+import { Plus, X, Play, StopCircle, ChevronRight, Trash2, AlertTriangle, Target, Clock, Users, Calendar } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
@@ -167,9 +167,9 @@ function CreateDialog({ projectId, onCreated, onClose }: CreateDialogProps) {
               />
             </div>
           </div>
-          {/* ⎈ 실행 계획 */}
+          {/* 실행 계획(calm 라벨·Target lucide·장식 글리프 제거) */}
           <div className="space-y-2 rounded-xl border border-border bg-muted/20 p-3">
-            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">⎈ {t('planSection')}</p>
+            <p className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground"><Target className="size-3.5" />{t('planSection')}</p>
             <div className="space-y-1">
               <label className="text-xs font-medium text-muted-foreground">{t('goalLabel')}</label>
               <input
@@ -183,7 +183,7 @@ function CreateDialog({ projectId, onCreated, onClose }: CreateDialogProps) {
             <div className="grid grid-cols-2 gap-2">
               <div className="space-y-1">
                 <label className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
-                  <span>⏲</span>{t('capacityLabel')}
+                  <Clock className="size-3.5" />{t('capacityLabel')}
                 </label>
                 <div className="relative">
                   <input
@@ -199,7 +199,7 @@ function CreateDialog({ projectId, onCreated, onClose }: CreateDialogProps) {
               </div>
               <div className="space-y-1">
                 <label className="flex items-center gap-1 text-xs font-medium text-muted-foreground">
-                  <span>👤</span>{t('teamSizeLabel')}
+                  <Users className="size-3.5" />{t('teamSizeLabel')}
                 </label>
                 <div className="relative">
                   <input
@@ -216,9 +216,9 @@ function CreateDialog({ projectId, onCreated, onClose }: CreateDialogProps) {
             </div>
           </div>
 
-          {/* ◎ 효과 가설 */}
+          {/* 효과 가설(calm 라벨·Target lucide·장식 글리프 제거) */}
           <div className="space-y-1.5">
-            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">◎ {t('hypothesisSection')}</p>
+            <p className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground"><Target className="size-3.5" />{t('hypothesisSection')}</p>
             <OutcomeIntentFields value={intent} onChange={setIntent} />
           </div>
 
@@ -579,7 +579,7 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
       {/* Goal */}
       {selected.goal ? (
         <p className="mb-3 rounded-lg border border-border bg-muted/20 px-3 py-2 text-sm text-foreground">
-          <span className="mr-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">⎈ 목표</span>
+          <span className="mr-1.5 inline-flex items-center gap-1 align-middle text-xs font-medium text-muted-foreground"><Target className="size-3 shrink-0" />목표</span>
           {selected.goal}
         </p>
       ) : null}
@@ -589,18 +589,18 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
         <div className="mb-4 flex flex-wrap gap-2">
           {selected.capacity != null ? (
             <span className="flex items-center gap-1 rounded-md border border-border bg-muted/30 px-2.5 py-1 text-xs font-medium tabular-nums text-foreground">
-              <span className="text-muted-foreground">⏲</span>
+              <Clock className="size-3.5 text-muted-foreground" />
               {selected.capacity}<span className="ml-0.5 text-muted-foreground">SP</span>
             </span>
           ) : null}
           {selected.team_size != null ? (
             <span className="flex items-center gap-1 rounded-md border border-border bg-muted/30 px-2.5 py-1 text-xs font-medium tabular-nums text-foreground">
-              <span className="text-muted-foreground">👤</span>
+              <Users className="size-3.5 text-muted-foreground" />
               {selected.team_size}<span className="ml-0.5 text-muted-foreground">명</span>
             </span>
           ) : null}
           <span className="flex items-center gap-1 rounded-md border border-border bg-muted/30 px-2.5 py-1 text-xs font-medium tabular-nums text-foreground">
-            <span className="text-muted-foreground">📅</span>
+            <Calendar className="size-3.5 text-muted-foreground" />
             {sprintDurationDays(selected.start_date, selected.end_date)}{t('days')}
           </span>
         </div>
@@ -638,7 +638,11 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
         <p className="text-sm text-muted-foreground">{t('loading')}</p>
       ) : burndown ? (
         <div className="mb-6 space-y-3">
-          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('burndown')}</p>
+          <p className="text-xs font-medium text-muted-foreground">{t('burndown')}</p>
+          {/* 진행 바 — 기존 completion_pct 시각화(새 데이터 0·번다운 주인공) */}
+          <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+            <div className="h-full rounded-full bg-success transition-all" style={{ width: `${burndown.completion_pct}%` }} />
+          </div>
           <div className="grid grid-cols-3 gap-2">
             <div className="rounded-md border border-border bg-muted/30 p-2 text-center">
               <p className="text-xl font-bold text-foreground">{burndown.completion_pct}%</p>
@@ -655,10 +659,10 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
           </div>
           {burndown.ideal_line.length > 0 ? (
             <div className="rounded-md border border-border p-3">
-              <p className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">{t('burndown')}</p>
+              <p className="mb-1 text-xs font-medium text-muted-foreground">{t('burndown')}</p>
               <div className="flex gap-4 text-xs text-muted-foreground">
-                <span>📉 {t('idealLine')}: {burndown.ideal_line[0]?.points ?? 0} → 0</span>
-                <span>📊 {t('actualLine')}: {burndown.actual_line[0]?.points ?? 0} → {burndown.actual_line[burndown.actual_line.length - 1]?.points ?? 0}</span>
+                <span>{t('idealLine')}: {burndown.ideal_line[0]?.points ?? 0} → 0</span>
+                <span>{t('actualLine')}: {burndown.actual_line[0]?.points ?? 0} → {burndown.actual_line[burndown.actual_line.length - 1]?.points ?? 0}</span>
               </div>
             </div>
           ) : null}
@@ -675,7 +679,7 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
 
       {/* Sprint stories */}
       <div className="mb-4 space-y-2">
-        <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('sprintStories')}</p>
+        <p className="text-xs font-medium text-muted-foreground">{t('sprintStories')}</p>
         {loadingStories ? (
           <p className="text-xs text-muted-foreground">{t('loading')}</p>
         ) : sprintStories.length === 0 ? (
@@ -720,7 +724,7 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
       {/* Backlog assignment */}
       {selected.status !== 'closed' && backlogStories.length > 0 ? (
         <div className="space-y-2">
-          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('backlog')}</p>
+          <p className="text-xs font-medium text-muted-foreground">{t('backlog')}</p>
           <ul className="space-y-1.5">
             {backlogStories.map((story) => (
               <li key={story.id} className="flex items-center justify-between rounded-lg border border-dashed border-border px-3 py-2 hover:border-primary/40 hover:bg-primary/5 transition-colors">


### PR DESCRIPTION
## 한 줄
E-MODERN Track D — 스프린트/에픽 화면의 **장식 글리프 + UPPERCASE tracking 라벨 + 카드 rounded-2xl** 도배를 정갈·미니멀 canonical로. **순수 시각·위치만·새 기능 0**·신규 토큰 0·다크.

> story `f9d41bae` · 핸드오프 `e-modern-sprint-epic-redesign-fe-handoff`(PRIMARY) · 목업 양테마 · 3파일

## canonical transform (전역)
- **장식 글리프 → lucide**: ⎈→`Target`·⏲→`Clock`·👤→`Users`·📅→`Calendar`·◎→`Target`. 번다운 ideal/actual 라인 📉📊 제거. **장식 글리프 0**.
- **UPPERCASE tracking 라벨 → calm**: `text-[10px] uppercase tracking-[0.18em/wider/widest]` → `text-xs font-medium`(normal case·tracking 0). sprints-client·epics-client·epics/[id] 전 위치 일괄.
- **에픽 카드 `rounded-2xl` → `rounded-xl`** (epics-client L426). ⚠️ **모달 셸**(sprints L129/L253·epics L675) `rounded-2xl shadow-xl`은 **canonical 다이얼로그라 유지**(손 안 댐).
- **번다운 = 주인공**: **진행 바 추가**(`completion_pct` 시각화·**기존 데이터 재표현·새 엔드포인트 0**) + stat grid·ideal_line 보존.
- 임의 타이포 `text-[13px]`→`text-sm`(epics/[id] code). **색=신호만**(완료 success 등).

## 기능 100% 동결
번다운(`completion_pct`/done/total/ideal_line)·활성화/종료·체크인·배정/묶음·에픽 진행률·목표일/SP·상태 전이·SP 초과 경고·dispatch — **전부 보존**. diff = 글리프→아이콘·className만(핸들러/상태/데이터/API 무변경).

## 검증
- `tsc` 0 · `eslint` 0 · `next build` ✓ · **canonical 추가분 위반 0**(글리프·uppercase tracking·카드 rounded-2xl·text-[13px] grep self-check) · 신규 토큰 0 · 기능 동결 diff(핸들러/상태 제거 0).

## ⚠️ 리뷰 노트 — 모바일 nav 분리 clarification
핸드오프 §3-3/§6 "모바일 글로벌 ☰ ⊥ 섹션 탭(스프린트/에픽)" — grounding 결과 **/sprints·/epics는 별도 라우트**라 둘을 잇는 **기존 섹션 탭이 없음**. 글로벌 ☰는 app-sidebar(OUT OF SCOPE). → 섹션 탭이 **(a) 신규 구조 신설**(새 기능·"새 기능 0" 원칙과 충돌)인지 **(b) 기존 nav 요소 restyle**인지 콜 주시면 후속. 이 PR = canonical 시각 transform(§3 area 표 전건)에 집중·모바일 nav는 분리.

⚠️ **라이브 = 머지 後 가디언 양 테마 픽셀**(글리프 0·calm 라벨·카드 rounded-xl·번다운 진행 바·색=신호·다크·1008/390). PR 단계 = 가디언 코드리뷰 → PO LGTM → 까심 QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)