### PR TITLE
[fix] 스탠드업 plan_stories org-scope enrich — 백로그→데일리 할일 미노출 (a9e67531)

### DIFF
--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -7,17 +7,58 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.models.pm import Story
 from app.models.standup import StandupEntry, StandupEntryProject, StandupFeedback
 from app.repositories.standup import StandupEntryRepository, StandupFeedbackRepository
 from app.schemas.standup import (
     FeedbackCreate,
     FeedbackResponse,
+    PlanStorySummary,
     StandupEntryResponse,
     StandupSelfUpdate,
     StandupUpsert,
 )
 from app.services.member_resolver import canonicalize_member_id, resolve_member
 from app.services.project_auth import accessible_project_ids_in_org
+
+
+async def _entries_with_plan_stories(
+    entries: list[StandupEntry], session: AsyncSession, org_id: uuid.UUID
+) -> list[StandupEntryResponse]:
+    """a9e67531: 엔트리들의 plan_story_ids 를 **org-scope batch resolve**(N+1 회피) → plan_stories 주입.
+
+    엔트리=org-level planning artifact 라 plan_story 가 active-sprint/board 밖일 수 있어, FE 의 scoped
+    stories 배열로는 미해소(미노출 버그). 여기서 org-scope 로 id+title+status(+priority/project/sprint) 해소해
+    내려준다. ⭐org-scope 강제(`Story.org_id==org_id`)·삭제 제외·타org/미존재 id 는 **조용히 제외**(노출 0)·
+    plan_story_ids **입력 순서 보존**. plan_story_ids 는 하위호환 유지(FE id-only fallback).
+    """
+    all_ids = {sid for e in entries for sid in (e.plan_story_ids or [])}
+    summaries: dict[uuid.UUID, PlanStorySummary] = {}
+    if all_ids:
+        rows = (
+            await session.execute(
+                select(
+                    Story.id, Story.title, Story.status, Story.priority,
+                    Story.project_id, Story.sprint_id,
+                ).where(
+                    Story.id.in_(all_ids),
+                    Story.org_id == org_id,         # ⭐org-scope(anti-IDOR·타org 해소 0).
+                    Story.deleted_at.is_(None),
+                )
+            )
+        ).all()
+        for sid, title, status, priority, pid, spid in rows:
+            summaries[sid] = PlanStorySummary(
+                id=sid, title=title, status=status, priority=priority,
+                project_id=pid, sprint_id=spid,
+            )
+    out: list[StandupEntryResponse] = []
+    for e in entries:
+        resp = StandupEntryResponse.model_validate(e)
+        # 순서 보존 + 미발견(타org/삭제/미존재) 조용히 제외.
+        resp.plan_stories = [summaries[sid] for sid in (e.plan_story_ids or []) if sid in summaries]
+        out.append(resp)
+    return out
 
 router = APIRouter(prefix="/api/v2/standups", tags=["standups"])
 
@@ -67,7 +108,7 @@ async def list_standups(
     if date_filter:
         filters["date"] = date_filter
     entries = await repo.list(**filters)
-    return [StandupEntryResponse.model_validate(e) for e in entries]
+    return await _entries_with_plan_stories(entries, repo.session, repo.org_id)
 
 
 @router.post("", response_model=StandupEntryResponse, status_code=201)
@@ -93,7 +134,7 @@ async def upsert_standup(
     )
     # 1c2be9db: org-level write(project_id 없음) → author 접근 프로젝트로 링크 full overwrite.
     await _sync_org_level_links(repo, session, entry, body.project_id, auth.user_id, org_id)
-    return StandupEntryResponse.model_validate(entry)
+    return (await _entries_with_plan_stories([entry], session, org_id))[0]
 
 
 @router.put("", response_model=StandupEntryResponse)
@@ -127,7 +168,7 @@ async def update_standup(
     )
     # 1c2be9db: org-level self-save(project_id 없음) → author 접근 프로젝트로 링크 full overwrite.
     await _sync_org_level_links(repo, session, entry, body.project_id, auth.user_id, org_id)
-    return StandupEntryResponse.model_validate(entry)
+    return (await _entries_with_plan_stories([entry], session, org_id))[0]
 
 
 @router.get("/history", response_model=list[StandupEntryResponse])

--- a/backend/app/schemas/standup.py
+++ b/backend/app/schemas/standup.py
@@ -48,8 +48,20 @@ class StandupEntryResponse(BaseModel):
     plan: str | None = None
     blockers: str | None = None
     plan_story_ids: list[uuid.UUID]
+    # a9e67531: plan_story_ids 의 org-scope resolve 요약(id+title+status). FE 가 active-sprint stories 배열에
+    # 의존하지 않고 cross-board plan story 도 렌더(미노출 버그 근본 fix). plan_story_ids 는 하위호환 유지.
+    plan_stories: list["PlanStorySummary"] = []
     created_at: datetime
     updated_at: datetime
+
+
+class PlanStorySummary(BaseModel):
+    id: uuid.UUID
+    title: str
+    status: str
+    priority: str | None = None
+    project_id: uuid.UUID | None = None
+    sprint_id: uuid.UUID | None = None
 
 
 class FeedbackCreate(BaseModel):

--- a/backend/tests/test_standup_plan_stories_enrich.py
+++ b/backend/tests/test_standup_plan_stories_enrich.py
@@ -1,0 +1,78 @@
+"""a9e67531: 스탠드업 plan_stories org-scope enrich — 백로그→데일리 할일 미노출 버그 근본 fix.
+
+BE 가 plan_story_ids 를 org-scope resolve 해 plan_stories[{id,title,status,...}] 로 내려줌(FE 가 active-sprint
+stories 배열 의존 제거). 검증: 입력 순서 보존·타org/삭제/미존재 조용히 제외·plan_story_ids 하위호환 유지.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date as _date, datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.routers.standups import _entries_with_plan_stories
+
+ORG = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _entry(plan_story_ids):
+    now = datetime(2026, 6, 23, tzinfo=timezone.utc)
+    return SimpleNamespace(
+        id=uuid.uuid4(), project_id=None, org_id=ORG, sprint_id=None, author_id=uuid.uuid4(),
+        date=_date(2026, 6, 23), done="d", plan="p", blockers=None,
+        plan_story_ids=plan_story_ids, created_at=now, updated_at=now,
+    )
+
+
+def _row(sid, title="S", status="in-progress"):
+    return (sid, title, status, "medium", None, None)
+
+
+@pytest.mark.anyio
+async def test_plan_stories_resolve_order_preserved_and_missing_excluded():
+    s1, s2, s_missing = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    entry = _entry([s2, s_missing, s1])  # 입력 순서 [s2, missing, s1].
+    session = AsyncMock()
+    result = MagicMock()
+    # s_missing 은 타org/삭제라 쿼리 결과서 빠짐(s1,s2만 반환·순서 무관).
+    result.all.return_value = [_row(s1, "One"), _row(s2, "Two")]
+    session.execute = AsyncMock(return_value=result)
+
+    out = await _entries_with_plan_stories([entry], session, ORG)
+    resp = out[0]
+    # ⭐입력 순서 보존(s2→s1)·missing 조용히 제외.
+    assert [ps.id for ps in resp.plan_stories] == [s2, s1]
+    assert [ps.title for ps in resp.plan_stories] == ["Two", "One"]
+    # plan_story_ids 하위호환 유지(원본 3개 그대로).
+    assert resp.plan_story_ids == [s2, s_missing, s1]
+
+
+@pytest.mark.anyio
+async def test_no_plan_story_ids_no_query():
+    entry = _entry([])
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    out = await _entries_with_plan_stories([entry], session, ORG)
+    assert out[0].plan_stories == []
+    session.execute.assert_not_awaited()  # 빈 id → 쿼리 0.
+
+
+@pytest.mark.anyio
+async def test_org_scope_in_query():
+    """resolve 쿼리가 org_id 로 스코프되는지(anti-IDOR·타org 해소 0) — 컴파일 SQL 확인."""
+    s1 = uuid.uuid4()
+    entry = _entry([s1])
+    session = AsyncMock()
+    result = MagicMock()
+    result.all.return_value = [_row(s1)]
+    session.execute = AsyncMock(return_value=result)
+    await _entries_with_plan_stories([entry], session, ORG)
+    stmt = str(session.execute.await_args.args[0])
+    assert "org_id" in stmt and "deleted_at" in stmt  # org-scope + soft-delete 필터.


### PR DESCRIPTION
## Summary
Prod bug (선생님 direct, story a9e67531): standup 작성 중 backlog→daily-todo 추가 항목 미노출. **Diagnosis-first → root fix.**

## Diagnosis (FE/BE localize)
- **BE sound**: `plan_story_ids` is a `StandupEntry` ARRAY column — upsert persists `body.plan_story_ids` verbatim, GET returns it verbatim. No scope filter / id-mapping / dedup. (① mutation success ✓; ②③④⑤ no BE cause.)
- **Root = FE**: the standup page loads `stories` only **project+sprint-scoped** (`/api/stories?project_id&sprint_id`, gated on `projectId`). The plan-story picker + render (`planStoryIds.map → stories.find`) resolve against this scoped array → backlog / other-board / org-no-project stories aren't resolvable → not rendered. (= 유나's "broken pipe": entry org-level ↔ stories project-scoped.)

## Fix (PO decision: FE + BE-enrich; Santiago-recommended)
standup entry is an org-level planning artifact, so BE resolves `plan_story_ids` **org-scoped** and ships summaries (avoids FE per-board N-fetch / perm edges; stops cross-board recurrence).
- `StandupEntryResponse += plan_stories: [{id, title, status, priority?, project_id?, sprint_id?}]`. `plan_story_ids` kept (backward-compat; FE id-only fallback).
- `_entries_with_plan_stories`: union all entries' `plan_story_ids` → **one batched query** (no N+1): `Story.id IN ids AND org_id == caller org AND deleted_at IS NULL`. **org-scoped (anti-IDOR; 0 cross-org resolution)**, deleted/cross-org/missing ids **silently excluded** (no leak), **`plan_story_ids` input order preserved**. No raw content/description exposed.
- Applied to list / upsert / update (all 3 return paths).

## Santiago criteria
plan_stories added · plan_story_ids backward-compat · resolve org-scoped + deleted-excluded · cross-org/deleted/missing silently dropped · input order preserved · minimal fields (id/title/status + optional priority/project/sprint) · no raw content / cross-org leak · FE renders plan_stories first with id-only fallback. ✅

## Verification
`CI=1` standup suite **22 passed**; enrich unit tests (order preserved + missing excluded, empty-ids → 0 query, org-scope SQL assertion). compile; app loads; schema rebuild OK.

## FE / scope
FE (Mirko) renders from `plan_stories`, id-only fallback retained. The bridge modal (board → story → link) is a separate v3 (Track E). This PR is the immediate prod fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
