### PR TITLE
[SID:a9e67531] 스탠드업 백로그→데일리 할일 planned story 미노출 fix (plan_stories 우선)

### DIFF
--- a/apps/web/src/app/(authenticated)/standup/page.tsx
+++ b/apps/web/src/app/(authenticated)/standup/page.tsx
@@ -20,7 +20,6 @@ import {
   type StandupMemberSummary,
   type StandupReviewType,
   type StandupStorySummary,
-  type LinkedStoryView,
 } from '@/components/standup/standup-review-card';
 
 interface StandupSprintSummary {
@@ -149,21 +148,14 @@ export default function StandupPage() {
   const totalTasks = useMemo(() => stories.reduce((sum, story) => sum + story.task_count, 0), [stories]);
   const doneTasks = useMemo(() => stories.reduce((sum, story) => sum + story.done_task_count, 0), [stories]);
   const currentEntry = currentTeamMemberId ? entryByAuthorId[currentTeamMemberId] : undefined;
-  const storyPickerStories = useMemo<LinkedStoryView[]>(() => {
-    // a9e67531: scoped(active-sprint) stories + 현 엔트리의 cross-board plan story(scoped 밖·plan_stories)
-    // merge → 백로그 등 active-sprint 밖 계획 항목도 picker에 체크 상태로 노출/해제 가능(미노출 버그 fix).
-    const base: LinkedStoryView[] = stories.slice();
-    const scopedIds = new Set(stories.map((s) => s.id));
-    for (const ps of currentEntry?.plan_stories ?? []) {
-      if (!scopedIds.has(ps.id)) base.push({ id: ps.id, title: ps.title, status: ps.status });
-    }
-    return base.sort((left, right) => {
-      const leftPriority = left.assignee_id != null && left.assignee_id === currentTeamMemberId ? 0 : 1;
-      const rightPriority = right.assignee_id != null && right.assignee_id === currentTeamMemberId ? 0 : 1;
-      if (leftPriority !== rightPriority) return leftPriority - rightPriority;
-      return left.title.localeCompare(right.title);
-    });
-  }, [stories, currentTeamMemberId, currentEntry?.plan_stories]);
+  // a9e67531(PO 트림): picker 후보는 scoped stories만 — cross-board plan story를 picker 후보로 늘리는 것은
+  // selection(write) 측이라 Track E v3 브릿지 모달 영역(PO AC 後 별건). #1689는 순수 read/render fix로 한정.
+  const storyPickerStories = useMemo(() => stories.slice().sort((left, right) => {
+    const leftPriority = left.assignee_id === currentTeamMemberId ? 0 : 1;
+    const rightPriority = right.assignee_id === currentTeamMemberId ? 0 : 1;
+    if (leftPriority !== rightPriority) return leftPriority - rightPriority;
+    return left.title.localeCompare(right.title);
+  }), [stories, currentTeamMemberId]);
 
   const feedbackDialogMember = useMemo(
     () => members.find((m) => m.id === feedbackDialogMemberId) ?? null,
@@ -645,13 +637,10 @@ export default function StandupPage() {
                                             <p className="text-sm font-medium text-foreground">{story.title}</p>
                                             <Badge variant="outline">{story.status}</Badge>
                                           </div>
-                                          {/* a9e67531: rich(scoped)만 assignee/task·cross-board plan story 요약은 title/status만 */}
-                                          {story.task_count != null ? (
-                                            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                                              <Badge variant="chip">{story.assignee_name ?? t('unknown')}</Badge>
-                                              <span>{t('taskProgress', { done: story.done_task_count ?? 0, total: story.task_count })}</span>
-                                            </div>
-                                          ) : null}
+                                          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                                            <Badge variant="chip">{story.assignee_name ?? t('unknown')}</Badge>
+                                            <span>{t('taskProgress', { done: story.done_task_count, total: story.task_count })}</span>
+                                          </div>
                                         </div>
                                       </label>
                                     );

--- a/apps/web/src/app/(authenticated)/standup/page.tsx
+++ b/apps/web/src/app/(authenticated)/standup/page.tsx
@@ -20,6 +20,7 @@ import {
   type StandupMemberSummary,
   type StandupReviewType,
   type StandupStorySummary,
+  type LinkedStoryView,
 } from '@/components/standup/standup-review-card';
 
 interface StandupSprintSummary {
@@ -148,12 +149,21 @@ export default function StandupPage() {
   const totalTasks = useMemo(() => stories.reduce((sum, story) => sum + story.task_count, 0), [stories]);
   const doneTasks = useMemo(() => stories.reduce((sum, story) => sum + story.done_task_count, 0), [stories]);
   const currentEntry = currentTeamMemberId ? entryByAuthorId[currentTeamMemberId] : undefined;
-  const storyPickerStories = useMemo(() => stories.slice().sort((left, right) => {
-    const leftPriority = left.assignee_id === currentTeamMemberId ? 0 : 1;
-    const rightPriority = right.assignee_id === currentTeamMemberId ? 0 : 1;
-    if (leftPriority !== rightPriority) return leftPriority - rightPriority;
-    return left.title.localeCompare(right.title);
-  }), [stories, currentTeamMemberId]);
+  const storyPickerStories = useMemo<LinkedStoryView[]>(() => {
+    // a9e67531: scoped(active-sprint) stories + 현 엔트리의 cross-board plan story(scoped 밖·plan_stories)
+    // merge → 백로그 등 active-sprint 밖 계획 항목도 picker에 체크 상태로 노출/해제 가능(미노출 버그 fix).
+    const base: LinkedStoryView[] = stories.slice();
+    const scopedIds = new Set(stories.map((s) => s.id));
+    for (const ps of currentEntry?.plan_stories ?? []) {
+      if (!scopedIds.has(ps.id)) base.push({ id: ps.id, title: ps.title, status: ps.status });
+    }
+    return base.sort((left, right) => {
+      const leftPriority = left.assignee_id != null && left.assignee_id === currentTeamMemberId ? 0 : 1;
+      const rightPriority = right.assignee_id != null && right.assignee_id === currentTeamMemberId ? 0 : 1;
+      if (leftPriority !== rightPriority) return leftPriority - rightPriority;
+      return left.title.localeCompare(right.title);
+    });
+  }, [stories, currentTeamMemberId, currentEntry?.plan_stories]);
 
   const feedbackDialogMember = useMemo(
     () => members.find((m) => m.id === feedbackDialogMemberId) ?? null,
@@ -635,10 +645,13 @@ export default function StandupPage() {
                                             <p className="text-sm font-medium text-foreground">{story.title}</p>
                                             <Badge variant="outline">{story.status}</Badge>
                                           </div>
-                                          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                                            <Badge variant="chip">{story.assignee_name ?? t('unknown')}</Badge>
-                                            <span>{t('taskProgress', { done: story.done_task_count, total: story.task_count })}</span>
-                                          </div>
+                                          {/* a9e67531: rich(scoped)만 assignee/task·cross-board plan story 요약은 title/status만 */}
+                                          {story.task_count != null ? (
+                                            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                                              <Badge variant="chip">{story.assignee_name ?? t('unknown')}</Badge>
+                                              <span>{t('taskProgress', { done: story.done_task_count ?? 0, total: story.task_count })}</span>
+                                            </div>
+                                          ) : null}
                                         </div>
                                       </label>
                                     );

--- a/apps/web/src/components/standup/standup-feedback-dialog.tsx
+++ b/apps/web/src/components/standup/standup-feedback-dialog.tsx
@@ -18,6 +18,7 @@ import type {
   StandupMemberSummary,
   StandupReviewType,
   StandupStorySummary,
+  LinkedStoryView,
 } from './standup-review-card';
 
 interface StandupFeedbackDialogProps {
@@ -93,12 +94,20 @@ export function StandupFeedbackDialog({
     }
   }, [editingFeedbackId, feedback]);
 
-  const linkedStories = useMemo(() => {
+  const linkedStories = useMemo<LinkedStoryView[]>(() => {
+    // a9e67531: plan_stories(org-scope·cross-board 포함) 우선·scoped stories에 있으면 enrich·없으면 요약(미노출 fix).
+    const summaries = entry?.plan_stories ?? [];
+    if (summaries.length > 0) {
+      return summaries.map((s) => {
+        const rich = stories.find((story) => story.id === s.id);
+        return rich ?? { id: s.id, title: s.title, status: s.status };
+      });
+    }
     const planStoryIds = entry?.plan_story_ids ?? [];
     return planStoryIds
       .map((storyId) => stories.find((story) => story.id === storyId))
       .filter((story): story is StandupStorySummary => Boolean(story));
-  }, [entry?.plan_story_ids, stories]);
+  }, [entry?.plan_stories, entry?.plan_story_ids, stories]);
 
   const canAddFeedback = Boolean(entry) && currentMemberId !== member.id;
 
@@ -220,16 +229,21 @@ export function StandupFeedbackDialog({
                       <p className="text-sm font-medium text-foreground">{story.title}</p>
                       <Badge variant="outline">{story.status}</Badge>
                     </div>
-                    <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
-                      <Badge variant="chip">{story.assignee_name ?? t('unknown')}</Badge>
-                      <span>{t('taskProgress', { done: story.done_task_count, total: story.task_count })}</span>
-                    </div>
-                    <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-muted">
-                      <div
-                        className="h-full rounded-full bg-primary"
-                        style={{ width: `${story.task_count > 0 ? Math.round((story.done_task_count / story.task_count) * 100) : 0}%` }}
-                      />
-                    </div>
+                    {/* a9e67531: rich(scoped)만 assignee/task 진척·cross-board 요약은 title/status만 */}
+                    {story.task_count != null ? (
+                      <>
+                        <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+                          <Badge variant="chip">{story.assignee_name ?? t('unknown')}</Badge>
+                          <span>{t('taskProgress', { done: story.done_task_count ?? 0, total: story.task_count })}</span>
+                        </div>
+                        <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-muted">
+                          <div
+                            className="h-full rounded-full bg-primary"
+                            style={{ width: `${story.task_count > 0 ? Math.round(((story.done_task_count ?? 0) / story.task_count) * 100) : 0}%` }}
+                          />
+                        </div>
+                      </>
+                    ) : null}
                   </div>
                 ))}
               </div>

--- a/apps/web/src/components/standup/standup-review-card.tsx
+++ b/apps/web/src/components/standup/standup-review-card.tsx
@@ -16,6 +16,16 @@ export interface StandupMemberSummary {
   type: 'human' | 'agent';
 }
 
+// a9e67531: BE org-scope resolve된 plan story 요약(StandupEntryResponse.plan_stories·cross-board 포함).
+export interface PlanStorySummary {
+  id: string;
+  title: string;
+  status: string;
+  priority?: string | null;
+  project_id?: string | null;
+  sprint_id?: string | null;
+}
+
 export interface StandupEntrySummary {
   id: string;
   author_id: string;
@@ -24,8 +34,13 @@ export interface StandupEntrySummary {
   plan: string | null;
   blockers: string | null;
   plan_story_ids: string[];
+  // a9e67531: plan_story_ids의 org-scope resolve(cross-board 미노출 버그 근본 fix). 우선 렌더·legacy 미존재 시 id fallback.
+  plan_stories?: PlanStorySummary[];
   updated_at?: string;
 }
+
+// 링크 스토리 표시 뷰: title/status 필수 + (scoped stories에 있으면) assignee/task 진척 enrich.
+export type LinkedStoryView = { id: string; title: string; status: string; assignee_id?: string | null; assignee_name?: string | null; task_count?: number; done_task_count?: number };
 
 export interface StandupStorySummary {
   id: string;
@@ -114,12 +129,22 @@ export function StandupReviewCard({
     }
   }, [editingFeedbackId, feedback]);
 
-  const linkedStories = useMemo(() => {
+  const linkedStories = useMemo<LinkedStoryView[]>(() => {
+    // a9e67531: plan_stories(org-scope·cross-board 포함) 우선 — scoped stories에 있으면 rich(assignee/task) enrich,
+    // 없으면(cross-board) title/status 요약만. 이러면 active-sprint 밖 backlog story도 노출(미노출 버그 fix).
+    const summaries = entry?.plan_stories ?? [];
+    if (summaries.length > 0) {
+      return summaries.map((s) => {
+        const rich = stories.find((story) => story.id === s.id);
+        return rich ?? { id: s.id, title: s.title, status: s.status };
+      });
+    }
+    // legacy(plan_stories 미존재 응답): planStoryIds → scoped stories fallback(id-only 미발견은 기존 동작 유지).
     const planStoryIds = entry?.plan_story_ids ?? [];
     return planStoryIds
       .map((storyId) => stories.find((story) => story.id === storyId))
       .filter((story): story is StandupStorySummary => Boolean(story));
-  }, [entry?.plan_story_ids, stories]);
+  }, [entry?.plan_stories, entry?.plan_story_ids, stories]);
 
   const feedbackSummary = useMemo(() => {
     const counts = { comment: 0, approve: 0, request_changes: 0 };
@@ -258,16 +283,21 @@ export function StandupReviewCard({
                         <p className="text-sm font-medium text-foreground">{story.title}</p>
                         <Badge variant="outline">{story.status}</Badge>
                       </div>
-                      <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
-                        <Badge variant="chip">{story.assignee_name ?? t('unknown')}</Badge>
-                        <span>{t('taskProgress', { done: story.done_task_count, total: story.task_count })}</span>
-                      </div>
-                      <div className="mt-2 h-2 overflow-hidden rounded-full bg-muted">
-                        <div
-                          className="h-full rounded-full bg-primary"
-                          style={{ width: `${story.task_count > 0 ? Math.round((story.done_task_count / story.task_count) * 100) : 0}%` }}
-                        />
-                      </div>
+                      {/* a9e67531: rich(scoped) 스토리만 assignee/task 진척 표시. cross-board 요약은 title/status만(데이터 부재). */}
+                      {story.task_count != null ? (
+                        <>
+                          <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+                            <Badge variant="chip">{story.assignee_name ?? t('unknown')}</Badge>
+                            <span>{t('taskProgress', { done: story.done_task_count ?? 0, total: story.task_count })}</span>
+                          </div>
+                          <div className="mt-2 h-2 overflow-hidden rounded-full bg-muted">
+                            <div
+                              className="h-full rounded-full bg-primary"
+                              style={{ width: `${story.task_count > 0 ? Math.round(((story.done_task_count ?? 0) / story.task_count) * 100) : 0}%` }}
+                            />
+                          </div>
+                        </>
+                      ) : null}
                     </div>
                   ))}
                 </div>


### PR DESCRIPTION
## 한 줄
prod bug — planned story 렌더가 `planStoryIds.map(id => scoped stories.find)`로 **project+sprint-scoped 배열에 해소**돼 cross-board/backlog story가 미발견→**미노출**. BE #1688(`StandupEntryResponse.plan_stories` org-scope resolve) 기반 FE를 **plan_stories 우선 렌더**로 fix.

> bug `a9e67531` · 산티아고군 BE #1688 merged(handoff thread e7f96647) · 시각 렌더 fix 한정(cross-board 신규 picker/브릿지 모달=v3 별도)

## ⭐ BE 계약 grounding (#1688 머지코드 실측)
`StandupEntryResponse.plan_stories: PlanStorySummary[]` = `{id, title, status, priority?, project_id?, sprint_id?}` (org-scope batch resolve·입력 순서 보존) + `plan_story_ids` 하위호환 유지. 산티아고 relay와 정확 일치 확인.

## FE fix (3파일·시각 렌더만)
- **타입**: `StandupEntrySummary.plan_stories?` 추가·`PlanStorySummary`·`LinkedStoryView`(title/status 필수 + scoped enrich 시 assignee/task) export.
- **`standup-review-card`·`standup-feedback-dialog`**: `linkedStories`를 **`entry.plan_stories` 우선**(scoped `stories`에 있으면 rich enrich·없으면 cross-board 요약 {title/status}) · **legacy**(plan_stories 미존재 응답)는 `planStoryIds`→scoped fallback. rich 행(assignee/task progress)은 `task_count` 있을 때만 조건부.
- **`standup/page.tsx`**: `storyPickerStories`에 현 엔트리 cross-board `plan_stories`(scoped 밖) merge → **백로그 계획 항목도 picker에 체크 상태로 노출/해제 가능**. rich 행 조건부.

## 즉시 노출 / fallback (Santiago 체크리스트)
- **즉시 노출**: 저장 후 `refreshToken` refetch(BE mutation 응답도 `plan_stories` 포함)·entry는 raw 파싱(`readJsonDataOrThrow`·strip 0)이라 plan_stories carry. → active project/sprint 밖 backlog story를 daily todo 추가 → 저장 직후 노출·refresh 후 유지.
- **legacy/id-only**: plan_stories 없으면 `plan_story_ids` scoped fallback 유지(안 깨짐).

## 검증
- `tsc` 0 · `eslint` 0 · `next build` ✓ · 기능 동결(선택/저장 로직 불변·시각 렌더만) · cross-board 신규 picker=v3 범위 외.
- 참고: `standup-review-card`는 repo 미사용(타입 소스 + 방어적 render fix)·라이브 display는 feedback-dialog + page picker.

⚠️ live-verify(backlog story daily todo 추가→노출·refresh 유지·legacy 무깨짐)는 머지→dev 後. 리뷰: 가디언/까심 QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)