### PR TITLE
[perf] 문서 doc 상세 payload enrich — 담당자 아바타 + revisions 요약 (FE 이중 fetch 제거)

### DIFF
--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -4,16 +4,53 @@ from datetime import datetime
 
 from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Query
 from pydantic import BaseModel
-from sqlalchemy import delete, or_, select
+from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user, get_project_scoped_org_id, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.doc import DocComment, DocRevision
+from app.models.member import Member
 from app.models.team import TeamMember
 from app.repositories.doc import DocRepository
 from app.services.member_resolver import canonicalize_member_id
-from app.schemas.doc import DocCreate, DocResponse, DocSummaryResponse, DocUpdate, ShareStatusResponse
+from app.schemas.doc import (
+    DocCreate,
+    DocMemberSummary,
+    DocResponse,
+    DocRevisionsSummary,
+    DocSummaryResponse,
+    DocUpdate,
+    ShareStatusResponse,
+)
+
+
+async def _enrich_doc_response(doc, session: AsyncSession) -> DocResponse:
+    """doc 상세 응답에 담당자 member 요약 + 수정이력 요약 동봉(FE 이중 fetch 제거). doc.org_id 스코프(caller
+    가 이미 doc 접근 검증)·N+1 0(member 1쿼리 + revisions agg 1쿼리·단건 doc). additive·기존 필드 불변."""
+    resp = DocResponse.model_validate(doc)
+    if doc.assignee_id is not None:
+        m = (
+            await session.execute(
+                select(Member.id, Member.name, Member.avatar_url).where(
+                    Member.id == doc.assignee_id,
+                    Member.org_id == doc.org_id,        # org-scope(anti-IDOR).
+                    Member.deleted_at.is_(None),
+                )
+            )
+        ).first()
+        if m is not None:
+            resp.assignee = DocMemberSummary(id=m[0], name=m[1], avatar_url=m[2])
+    cnt, latest = (
+        await session.execute(
+            select(func.count(DocRevision.id), func.max(DocRevision.created_at)).where(
+                DocRevision.doc_id == doc.id,
+                DocRevision.org_id == doc.org_id,        # org-scope.
+            )
+        )
+    ).one()
+    resp.revisions = DocRevisionsSummary(count=cnt or 0, latest_at=latest)
+    return resp
 
 router = APIRouter(prefix="/api/v2/docs", tags=["docs"])
 
@@ -227,7 +264,9 @@ async def get_doc(
         )
         if member.scalar_one_or_none() is None:
             raise HTTPException(status_code=403, detail="해당 프로젝트의 멤버가 아닌")
-    return DocResponse.model_validate(doc)
+    # doc 상세(detail view)만 enrich: 담당자 member 요약 + 수정이력 요약 동봉(FE 이중 fetch 제거).
+    # create/update/transition 은 write-path 라 plain(추가 쿼리 0·기존 테스트 broad-mock 무파손).
+    return await _enrich_doc_response(doc, session)
 
 
 @router.patch("/{id}", response_model=DocResponse)

--- a/backend/app/schemas/doc.py
+++ b/backend/app/schemas/doc.py
@@ -59,6 +59,19 @@ class DocSummaryResponse(BaseModel):
     snippet: str | None = None
 
 
+class DocMemberSummary(BaseModel):
+    """담당자 member 최소 요약(아바타 렌더용·FE 별도 fetch 제거). org-scope resolve."""
+    id: uuid.UUID
+    name: str
+    avatar_url: str | None = None
+
+
+class DocRevisionsSummary(BaseModel):
+    """수정이력 요약(count/latest·FE 별도 fetch 제거). full history 는 /{id}/revisions 그대로 사용."""
+    count: int = 0
+    latest_at: datetime | None = None
+
+
 class DocResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -85,6 +98,10 @@ class DocResponse(BaseModel):
     tags: list[str]
     created_at: datetime
     updated_at: datetime
+    # doc-payload enrich(이중 fetch 제거): 담당자 member 요약 + 수정이력 요약을 doc 상세에 동봉.
+    # additive·nullable(하위호환·미enrich 응답/list 엔 None). FE 는 별도 member/revisions fetch 제거.
+    assignee: DocMemberSummary | None = None
+    revisions: DocRevisionsSummary | None = None
 
 
 class ShareStatusResponse(BaseModel):

--- a/backend/tests/test_doc_payload_enrich.py
+++ b/backend/tests/test_doc_payload_enrich.py
@@ -1,0 +1,95 @@
+"""doc-payload enrich: doc 상세에 담당자 member 요약 + 수정이력 요약 동봉(FE 이중 fetch 제거).
+
+검증: assignee_id → member(id/name/avatar_url) org-scope resolve · revisions count/latest agg ·
+타org/미존재 assignee 는 None(노출 0) · assignee 없으면 member 쿼리 skip · org-scope SQL.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.routers.docs import _enrich_doc_response
+
+ORG = uuid.uuid4()
+T = datetime(2026, 6, 24, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _doc(assignee_id=None):
+    return SimpleNamespace(
+        id=uuid.uuid4(), project_id=uuid.uuid4(), org_id=ORG, parent_id=None,
+        created_by=None, assignee_id=assignee_id, status="draft", superseded_by=None,
+        title="t", slug="s", canonical_slug="s", slug_locked=False, content="c",
+        icon=None, sort_order=0, doc_type="page", content_format="markdown", tags=[],
+        created_at=T, updated_at=T,
+    )
+
+
+@pytest.mark.anyio
+async def test_enrich_assignee_and_revisions():
+    aid = uuid.uuid4()
+    doc = _doc(assignee_id=aid)
+    session = AsyncMock()
+    member_res = MagicMock()
+    member_res.first.return_value = (aid, "Didi", "https://av/didi.png")
+    rev_res = MagicMock()
+    rev_res.one.return_value = (3, T)
+    session.execute = AsyncMock(side_effect=[member_res, rev_res])  # member → revisions 순.
+
+    resp = await _enrich_doc_response(doc, session)
+    assert resp.assignee is not None
+    assert resp.assignee.id == aid and resp.assignee.name == "Didi"
+    assert resp.assignee.avatar_url == "https://av/didi.png"
+    assert resp.revisions.count == 3 and resp.revisions.latest_at == T
+
+
+@pytest.mark.anyio
+async def test_enrich_no_assignee_skips_member_query():
+    doc = _doc(assignee_id=None)
+    session = AsyncMock()
+    rev_res = MagicMock()
+    rev_res.one.return_value = (0, None)
+    session.execute = AsyncMock(return_value=rev_res)
+
+    resp = await _enrich_doc_response(doc, session)
+    assert resp.assignee is None              # assignee 없으면 member 해소 skip.
+    assert resp.revisions.count == 0 and resp.revisions.latest_at is None
+    assert session.execute.await_count == 1  # revisions 쿼리 1건만(member skip).
+
+
+@pytest.mark.anyio
+async def test_enrich_assignee_not_found_is_none():
+    doc = _doc(assignee_id=uuid.uuid4())
+    session = AsyncMock()
+    member_res = MagicMock()
+    member_res.first.return_value = None       # 타org/삭제/미존재 → 미발견.
+    rev_res = MagicMock()
+    rev_res.one.return_value = (1, T)
+    session.execute = AsyncMock(side_effect=[member_res, rev_res])
+
+    resp = await _enrich_doc_response(doc, session)
+    assert resp.assignee is None               # 미발견 → 조용히 None(노출 0).
+    assert resp.revisions.count == 1
+
+
+@pytest.mark.anyio
+async def test_enrich_org_scoped_queries():
+    """member·revisions 쿼리가 doc.org_id 로 스코프되는지(anti-IDOR) — 컴파일 SQL 확인."""
+    doc = _doc(assignee_id=uuid.uuid4())
+    session = AsyncMock()
+    member_res = MagicMock(); member_res.first.return_value = None
+    rev_res = MagicMock(); rev_res.one.return_value = (0, None)
+    session.execute = AsyncMock(side_effect=[member_res, rev_res])
+    await _enrich_doc_response(doc, session)
+    member_sql = str(session.execute.await_args_list[0].args[0])
+    rev_sql = str(session.execute.await_args_list[1].args[0])
+    assert "org_id" in member_sql and "deleted_at" in member_sql  # member org-scope + soft-delete.
+    assert "org_id" in rev_sql                                    # revisions org-scope.

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -21,6 +21,8 @@ def _mock_doc() -> MagicMock:
     d.assignee_id = None
     d.status = "draft"  # E-DG S22: 신규 status 필드(MagicMock→DocResponse 검증 실패 방지)
     d.superseded_by = None  # E-DG S28: 신규 superseded_by(동일 패턴·MagicMock None 명시)
+    d.assignee = None  # doc-payload enrich: 신규 응답필드(MagicMock→DocResponse 검증 실패 방지·동일 패턴)
+    d.revisions = None  # doc-payload enrich: 신규 응답필드(동일 패턴)
     d.title = "Getting Started"
     d.slug = "getting-started"
     d.canonical_slug = "getting-started"  # 4dd399c6: property on real Doc; mock 명시 필수
@@ -123,6 +125,7 @@ async def test_get_doc_200():
     try:
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = _mock_doc()
+        mock_result.one.return_value = (0, None)  # doc-payload enrich: revisions count/latest agg.
         session.execute = AsyncMock(return_value=mock_result)
 
         async with client as c:


### PR DESCRIPTION
## Summary
FE 문서 상세 뷰의 **이중 fetch 제거**: 현재 doc 1건 볼 때 `doc` payload + 담당자 아바타(`member`) + 수정이력(`revisions`)을 각각 호출(3 fetch). doc 상세 응답에 두 요약을 동봉해 **단일 호출**로.

## Change (additive · 기존 `DocResponse` 계약 불변)
- `DocResponse += assignee: DocMemberSummary | None` (`id/name/avatar_url`) + `revisions: DocRevisionsSummary | None` (`count/latest_at`). nullable · default `None` → 하위호환 (list / 미enrich 응답엔 `None`, FE id-only fallback).
- `_enrich_doc_response(doc, session)`: 담당자 member 1쿼리 (`id/name/avatar_url`) + revisions agg 1쿼리 (`count(id)`, `max(created_at)`). **`doc.org_id` 스코프** (anti-IDOR · caller 는 이미 doc 접근 검증) · member 미발견(타org/삭제/미존재)은 **조용히 `None`** (노출 0) · `assignee_id` 없으면 member 쿼리 skip. **N+1 0** (단건 doc · 2쿼리).
- **GET `/{id}` (detail view) 만 enrich.** create/update/transition 은 write-path 라 plain 유지 — 추가 쿼리 0 · 기존 broad-mock 테스트 무파손 (공유흐름 쿼리추가→mock 파손 함정 회피).

## Santiago 기준 1:1
additive (DocResponse 필드 불변) · member 최소 (`id/name/avatar_url`) · revisions `count`/`latest` only (full history 는 `/{id}/revisions` 그대로) · org/doc scope 엄격 · FE 이중 fetch 제거 가능 · N+1 0 (selectin 불요·단건 2쿼리) · 기능 동결 (편집/리비전 UX 무변경). ✅

## Verification
`CI=1` — enrich 단위 4종(member+revisions resolve · assignee 없으면 member skip · 미발견 `None` · org-scope SQL) + doc 회귀 **74 passed**. 신규 응답필드라 `_mock_doc` 에 `assignee/revisions=None` 명시(from_attributes 검증, 기존 `status`/`superseded_by` 선례 동일).

## FE (Mirko)
doc 상세서 담당자 아바타·revisions 별도 fetch 제거하고 payload 의 `assignee`/`revisions` 직접 사용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
