### PR TITLE
[SID:dab5d90c] 문서 상세 이중 fetch 제거 — doc payload(assignee·revisions) 직접 소비

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -43,6 +43,9 @@ interface DocDetail {
   // E-DG S22/S28: doc decision lifecycle status(draft|pending|confirmed|denied·기본 draft) + cross-doc 대체 포인터(S28·additive).
   status?: string;
   superseded_by?: string | null;
+  // #1691 payload enrich(이중 fetch 제거·additive·nullable): 담당자 요약 + 수정이력 요약 동봉.
+  assignee?: { id: string; name: string; avatar_url?: string | null } | null;
+  revisions?: { count: number; latest_at?: string | null } | null;
 }
 
 function InlineSaveIndicator({
@@ -134,23 +137,10 @@ export default function DocSlugPage() {
   const [slugLocked, setSlugLocked] = useState(false);
   const [urlDialogOpen, setUrlDialogOpen] = useState(false);
   const [shareDialogOpen, setShareDialogOpen] = useState(false);
-  // §3-2 슬림 헤더 메타: 수정 이력 N(작성자는 created_by/memberMap 부재로 드롭·PO 보수안). DocGateSection도
-  // revision을 fetch하나 헤더 메타용으로 경량 count만 별도 조회(공유 리프트는 S28 refactor라 follow-up).
-  const [revisionCount, setRevisionCount] = useState<number | null>(null);
-  const docId = selectedDoc?.id ?? null;
-  useEffect(() => {
-    if (!docId) { setRevisionCount(null); return; }
-    let alive = true;
-    void fetch(`/api/docs/${docId}/revisions`)
-      .then((r) => (r.ok ? r.json() : null))
-      .catch(() => null)
-      .then((json) => {
-        if (!alive) return;
-        const rows = (json?.data ?? json) as unknown[];
-        setRevisionCount(Array.isArray(rows) ? rows.length : null);
-      });
-    return () => { alive = false; };
-  }, [docId]);
+  // §3-2 슬림 헤더 메타: 수정 이력 N. #1691 payload enrich로 별도 /revisions fetch 제거 — doc payload의
+  // revisions.count 직접 소비(미enrich/legacy 응답엔 null → 메타 서브라인 숨김·기존 동작 동일).
+  // (DocGateSection의 revision 타임라인 fetch는 full history용이라 별개·유지.)
+  const revisionCount = selectedDoc?.revisions?.count ?? null;
 
   const handleDocSaved = useCallback((doc: DocDetail) => {
     setSelectedDoc(doc);
@@ -420,6 +410,7 @@ export default function DocSlugPage() {
               docId={selectedDoc.id}
               projectId={projectId}
               currentAssigneeId={selectedDoc.assignee_id ?? null}
+              assigneeName={selectedDoc.assignee?.name ?? null}
               onAssigneePatched={(aid) => setSelectedDoc((prev) => prev ? { ...prev, assignee_id: aid } : prev)}
             />
           ) : undefined}

--- a/apps/web/src/components/docs/doc-assignee-control.tsx
+++ b/apps/web/src/components/docs/doc-assignee-control.tsx
@@ -14,34 +14,21 @@ export function DocAssigneeControl({
   docId,
   projectId,
   currentAssigneeId,
+  assigneeName,
   onAssigneePatched,
 }: {
   docId: string;
   projectId: string;
   currentAssigneeId: string | null;
+  // #1691: doc payload(assignee.name) 직접 소비 — 이니셜용 별도 /api/members fetch 제거.
+  // payload 미동봉(legacy/미enrich)인데 assignee_id만 있으면 null → id-only(User 아이콘) fallback.
+  assigneeName: string | null;
   onAssigneePatched: (assigneeId: string) => void;
 }) {
   const t = useTranslations('docs');
   const [open, setOpen] = useState(false);
-  const [memberName, setMemberName] = useState<string | null>(null);
   const ref = useRef<HTMLDivElement>(null);
-
-  // 현 담당자 이름 resolve(아바타 이니셜용). EntityDispatchPanel도 멤버를 fetch하나 트리거 라벨용 경량 조회.
-  // null 케이스는 동기 setState 대신 render서 파생(currentAssigneeId 가드)해 set-state-in-effect 회피.
-  useEffect(() => {
-    if (!currentAssigneeId) return;
-    let alive = true;
-    void fetch(`/api/members?project_id=${projectId}`)
-      .then((r) => (r.ok ? r.json() : null))
-      .catch(() => null)
-      .then((json) => {
-        if (!alive) return;
-        const rows = ((json?.data ?? json) as { id: string; name: string }[] | null) ?? [];
-        const m = Array.isArray(rows) ? rows.find((x) => x.id === currentAssigneeId) : null;
-        setMemberName(m?.name ?? null);
-      });
-    return () => { alive = false; };
-  }, [currentAssigneeId, projectId]);
+  const memberName = assigneeName;
 
   // click-outside 닫기
   useEffect(() => {


### PR DESCRIPTION
## 한 줄
#1686 박스1 가디언서 flag한 **이중 fetch**(DocAssigneeControl `/api/members` + page `/revisions`)를 **BE #1691**(payload enrich)로 해소. **표시·동작 무변경·fetch만 단일화**.

> story `dab5d90c` · BE #1691(`DocResponse.assignee{id,name,avatar_url}` + `revisions{count,latest_at}`·additive·nullable) 머지코드 grounding · #1692와 독립 · 2파일

## 변경
- **DocAssigneeControl**: 이니셜용 `/api/members` fetch + memberName state/effect 제거 → **`assigneeName` prop(doc payload `assignee.name`) 직접 소비**(단일 호출). payload 미동봉(legacy/미enrich)인데 `assignee_id`만 있으면 `null` → **id-only(User 아이콘) fallback 보존**.
- **docs/[slug]/page.tsx**: `revisionCount` `/revisions` fetch+state+effect 제거 → **payload `revisions.count` 직접 파생**(`selectedDoc?.revisions?.count ?? null`). 메타 서브라인 "수정 이력 N" 무변경·`null`이면 숨김(기존 동작 동일). `DocDetail`에 `assignee`/`revisions` additive 타입.
- **DocGateSection revision 타임라인 fetch는 full history용이라 별개·유지**(이번 미터치).
- `avatar_url`은 **이번 스코프 밖**(이니셜 유지·아바타 이미지=별 시각 결정·후속).

## 검증
- `tsc` 0 · `next build` ✓ · **기능 동결 diff**(fetch 2개만 제거·`onAssigneePatched`/`docMetaRevisions`/`EntityDispatchPanel`/`initials`/`setSelectedDoc` 무변경).
- ⚠️ `lint` 경고 2(page.tsx InlineSaveIndicator unused eslint-disable)=**pre-existing·내 diff 무관**(InlineSaveIndicator 미터치). 내 변경분 자체 lint-clean.

⚠️ **라이브 검증**(머지→dev): 담당자 있는 doc 상세 → 아바타 이니셜·"수정 이력 N" 노출 + 네트워크 탭서 `/api/members`·`/revisions` 헤더용 호출 사라짐(단일 doc fetch) + assignee 해제 시 id-only fallback. 리뷰: 가디언 시각 회귀0(이니셜/popover·메타 서브라인 무변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)