### PR TITLE
[fix] doc enrich slug-query 경로 보강 — FE 상세 실 경로 enrich (#1693 회귀 복구)

### DIFF
--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -25,10 +25,15 @@ from app.schemas.doc import (
 )
 
 
-async def _enrich_doc_response(doc, session: AsyncSession) -> DocResponse:
-    """doc 상세 응답에 담당자 member 요약 + 수정이력 요약 동봉(FE 이중 fetch 제거). doc.org_id 스코프(caller
-    가 이미 doc 접근 검증)·N+1 0(member 1쿼리 + revisions agg 1쿼리·단건 doc). additive·기존 필드 불변."""
-    resp = DocResponse.model_validate(doc)
+async def _resolve_doc_extras(
+    doc, session: AsyncSession
+) -> tuple[DocMemberSummary | None, DocRevisionsSummary]:
+    """단건 doc 의 담당자 member 요약 + 수정이력 요약 해소(FE 이중 fetch 제거 공용 코어).
+
+    doc.org_id 스코프(anti-IDOR·caller 는 이미 doc 접근 검증)·N+1 0(member 1쿼리 + revisions agg 1쿼리)·
+    assignee 없으면 member 쿼리 skip·member 미발견(타org/삭제/미존재)은 None(노출 0). detail(GET /{id})과
+    slug-query 단건 경로 양쪽에서 동일 코어 사용 — FE 실 소비 경로(slug-query)도 enrich되도록."""
+    assignee: DocMemberSummary | None = None
     if doc.assignee_id is not None:
         m = (
             await session.execute(
@@ -40,7 +45,7 @@ async def _enrich_doc_response(doc, session: AsyncSession) -> DocResponse:
             )
         ).first()
         if m is not None:
-            resp.assignee = DocMemberSummary(id=m[0], name=m[1], avatar_url=m[2])
+            assignee = DocMemberSummary(id=m[0], name=m[1], avatar_url=m[2])
     cnt, latest = (
         await session.execute(
             select(func.count(DocRevision.id), func.max(DocRevision.created_at)).where(
@@ -49,7 +54,21 @@ async def _enrich_doc_response(doc, session: AsyncSession) -> DocResponse:
             )
         )
     ).one()
-    resp.revisions = DocRevisionsSummary(count=cnt or 0, latest_at=latest)
+    return assignee, DocRevisionsSummary(count=cnt or 0, latest_at=latest)
+
+
+async def _enrich_doc_response(doc, session: AsyncSession) -> DocResponse:
+    """detail(GET /{id}) 응답에 담당자/수정이력 요약 동봉. additive·기존 필드 불변."""
+    resp = DocResponse.model_validate(doc)
+    resp.assignee, resp.revisions = await _resolve_doc_extras(doc, session)
+    return resp
+
+
+async def _enrich_doc_summary(doc, session: AsyncSession) -> DocSummaryResponse:
+    """slug-query 단건 경로 응답(DocSummaryResponse)에 담당자/수정이력 요약 동봉. FE 상세 fetchDoc 이
+    GET /api/docs?slug= 를 쓰므로 이 경로도 enrich 해야 #1693 payload 소비가 실제로 흐른다. additive."""
+    resp = DocSummaryResponse.model_validate(doc)
+    resp.assignee, resp.revisions = await _resolve_doc_extras(doc, session)
     return resp
 
 router = APIRouter(prefix="/api/v2/docs", tags=["docs"])
@@ -86,7 +105,9 @@ async def list_docs(
         if doc is None:
             # 4dd399c6 AC3: live 미스 → alias fallback. 응답 canonical_slug≠요청 slug면 FE가 router.replace.
             doc = await repo.get_by_alias(project_id, slug)
-        return [DocSummaryResponse.model_validate(doc)] if doc else []
+        # slug 단건 경로 = FE 문서 상세 fetchDoc 의 실 경로 → detail 과 동일하게 enrich(담당자/수정이력).
+        # 일반 list/tree/search 분기는 enrich 안 함(다건 N+1 회피·페이로드 과확장 금지).
+        return [await _enrich_doc_summary(doc, repo.session)] if doc else []
 
     if tags and project_id:
         tag_list = [t.strip() for t in tags.split(",") if t.strip()]

--- a/backend/app/schemas/doc.py
+++ b/backend/app/schemas/doc.py
@@ -57,6 +57,10 @@ class DocSummaryResponse(BaseModel):
     tags: list[str]
     updated_at: datetime
     snippet: str | None = None
+    # doc-payload enrich(slug-query 단건 경로): FE 상세 fetchDoc 이 GET /api/docs?slug= 를 쓰므로 이 응답에도
+    # 담당자/수정이력 요약 동봉(이중 fetch 제거). additive·nullable(다건 list/tree/search 엔 None). forward-ref.
+    assignee: "DocMemberSummary | None" = None
+    revisions: "DocRevisionsSummary | None" = None
 
 
 class DocMemberSummary(BaseModel):
@@ -116,3 +120,7 @@ class PublicDocResponse(BaseModel):
     title: str
     content: str
     content_format: str
+
+
+# DocSummaryResponse 는 뒤에 정의된 DocMemberSummary/DocRevisionsSummary 를 forward-ref 하므로 명시 rebuild.
+DocSummaryResponse.model_rebuild()

--- a/backend/tests/test_doc_slug_enrich.py
+++ b/backend/tests/test_doc_slug_enrich.py
@@ -1,0 +1,89 @@
+"""doc-payload enrich 후속: slug-query 단건 경로(FE 상세 fetchDoc 실 경로) enrich.
+
+#1691 은 GET /{id}(detail-by-id)만 enrich 했으나 FE 상세는 GET /api/docs?slug=(list_docs→
+DocSummaryResponse·비enrich)를 써서 #1693 payload 소비가 항상 null→fallback이었다(숨은 회귀). 이 패스가
+slug 단건 경로도 동일하게 담당자/수정이력을 채우는지 검증. org-scope·count/latest only·미발견 None.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.routers.docs import _enrich_doc_summary
+
+ORG = uuid.uuid4()
+T = datetime(2026, 6, 24, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _doc(assignee_id=None):
+    # DocSummaryResponse 가 읽는 필드 + enrich 가 읽는 org_id/assignee_id/id.
+    return SimpleNamespace(
+        id=uuid.uuid4(), project_id=uuid.uuid4(), org_id=ORG, parent_id=None,
+        title="t", slug="s", canonical_slug="s", slug_locked=False, icon=None,
+        sort_order=0, doc_type="page", is_folder=False, tags=[], updated_at=T,
+        snippet=None, assignee_id=assignee_id,
+    )
+
+
+@pytest.mark.anyio
+async def test_summary_enrich_assignee_and_revisions():
+    aid = uuid.uuid4()
+    doc = _doc(assignee_id=aid)
+    session = AsyncMock()
+    member_res = MagicMock(); member_res.first.return_value = (aid, "Didi", "https://av/d.png")
+    rev_res = MagicMock(); rev_res.one.return_value = (5, T)
+    session.execute = AsyncMock(side_effect=[member_res, rev_res])
+
+    resp = await _enrich_doc_summary(doc, session)
+    # ⭐FE 상세가 쓰는 DocSummaryResponse 에 payload 가 실제로 채워짐(이전 회귀 = 항상 None).
+    assert resp.assignee is not None and resp.assignee.name == "Didi"
+    assert resp.assignee.avatar_url == "https://av/d.png"
+    assert resp.revisions.count == 5 and resp.revisions.latest_at == T
+
+
+@pytest.mark.anyio
+async def test_summary_no_assignee_skips_member_query():
+    doc = _doc(assignee_id=None)
+    session = AsyncMock()
+    rev_res = MagicMock(); rev_res.one.return_value = (0, None)
+    session.execute = AsyncMock(return_value=rev_res)
+
+    resp = await _enrich_doc_summary(doc, session)
+    assert resp.assignee is None
+    assert resp.revisions.count == 0
+    assert session.execute.await_count == 1  # member skip → revisions 1쿼리만.
+
+
+@pytest.mark.anyio
+async def test_summary_assignee_not_found_none():
+    doc = _doc(assignee_id=uuid.uuid4())
+    session = AsyncMock()
+    member_res = MagicMock(); member_res.first.return_value = None  # 타org/삭제/미존재.
+    rev_res = MagicMock(); rev_res.one.return_value = (2, T)
+    session.execute = AsyncMock(side_effect=[member_res, rev_res])
+
+    resp = await _enrich_doc_summary(doc, session)
+    assert resp.assignee is None and resp.revisions.count == 2
+
+
+@pytest.mark.anyio
+async def test_summary_org_scoped():
+    doc = _doc(assignee_id=uuid.uuid4())
+    session = AsyncMock()
+    member_res = MagicMock(); member_res.first.return_value = None
+    rev_res = MagicMock(); rev_res.one.return_value = (0, None)
+    session.execute = AsyncMock(side_effect=[member_res, rev_res])
+    await _enrich_doc_summary(doc, session)
+    member_sql = str(session.execute.await_args_list[0].args[0])
+    rev_sql = str(session.execute.await_args_list[1].args[0])
+    assert "org_id" in member_sql and "deleted_at" in member_sql
+    assert "org_id" in rev_sql


### PR DESCRIPTION
## Summary
**dev 라이브 회귀 복구.** doc-payload enrich(#1691)는 `GET /{id}`(detail-by-id)에만 들어갔으나, **FE 문서 상세 `fetchDoc`은 `GET /api/docs?slug=`**(`list_docs`→`DocSummaryResponse`·**비enrich**)를 쓴다. #1693(이중 fetch 제거·payload 소비 전환)이 머지·배포되며 `selectedDoc.revisions.count`/`assignee.name` 이 항상 `undefined→null→fallback` = **상세 뷰 revision 메타/assignee 이름이 사라지는 숨은 회귀**(dev rev 01122). 픽셀 parity-accept 가 실데이터 미확인이라 가렸다.

## dev 실토큰 직접 호출 (ground truth)
- `GET /api/v2/docs/{id}` → `assignee`/`revisions` **有** (#1691 작동)
- `GET /api/v2/docs?slug=` → 둘 다 **無** (DocSummaryResponse item keys 에 없음)

## Fix (additive · FE 코드 변경 불요 · payload 만 채워지면 #1693 그대로 작동)
- `DocSummaryResponse += assignee/revisions` (nullable · 다건 list/tree/search 엔 `None`).
- `_resolve_doc_extras(doc, session)` 공유 코어 추출 (member 1쿼리 + revisions agg 1쿼리 · `doc.org_id` 스코프 · assignee 없으면 skip · 미발견 `None`) → detail(`_enrich_doc_response`) 과 slug(`_enrich_doc_summary`) 양쪽 동일 사용.
- `list_docs` 의 **slug 단건 경로만** enrich (alias fallback 후 canonical doc 기준). 일반 list/tree/search 다건 분기는 enrich 안 함 (N+1 · 페이로드 과확장 금지).

## Santiago 기준 1:1
DocSummaryResponse additive nullable · slug 단건 경로만 enrich · 다건 과확장 금지 (per-doc loop 없음) · alias fallback 후 canonical doc enrich · org-scope/soft-delete/member 미발견 None · revisions `count/latest_at` only · #1693 FE 변경 없이 response JSON 으로 payload 충족. ✅

## Verification
`CI=1` — slug-enrich 단위 4종 (member+revisions resolve · assignee 없으면 skip · 미발견 None · org-scope SQL) + doc 회귀 **78 passed**. compile · app 로드 · schema forward-ref rebuild. 배포 後 known-assigned doc 으로 `GET /api/docs?slug=` response JSON 재검증 예정.

## 교훈
FE 계약은 **실제 호출 endpoint 의 응답 스키마**로 끝단 검증 (detail-by-id 아니라 slug-query). parity-accept ≠ 실데이터 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
