### PR TITLE
[SID:00a75ea6] 알림 story 아이콘 Bookmark→FileText (cross-surface 일관·픽셀 nit)

### DIFF
--- a/apps/web/src/services/notification-display.ts
+++ b/apps/web/src/services/notification-display.ts
@@ -1,13 +1,13 @@
 import { NOTIFICATION_TYPES } from '@/lib/notification-types';
 import {
-  Bookmark, ClipboardList, Trophy, Info, AlertTriangle, Wrench,
+  FileText, ClipboardList, Trophy, Info, AlertTriangle, Wrench,
   CheckCircle2, Flag, User, Mail, Bot, type LucideIcon,
 } from 'lucide-react';
 
 // 알림 type 아이콘 — 장식 emoji(📌📋🏆ℹ️…)를 lucide로 충실 변환(글리프 0·다크 안전).
-// ⚠️ 아이콘 선택은 emoji 의미 1:1 매핑(가디언 픽셀서 정합 확認).
+// story=FileText: 채팅 ENTITY_ICONS와 cross-surface 부품 언어 일관(같은 story=같은 아이콘·유나 픽셀 콜).
 export const NOTIFICATION_TYPE_ICONS: Record<string, LucideIcon> = {
-  story: Bookmark,
+  story: FileText,
   task: ClipboardList,
   reward: Trophy,
   info: Info,
@@ -17,7 +17,7 @@ export const NOTIFICATION_TYPE_ICONS: Record<string, LucideIcon> = {
   task_completed: CheckCircle2,
   sprint_closed: Flag,
   standup_reminder: User,
-  story_assigned: Bookmark,
+  story_assigned: FileText,
   invitation: Mail,
   agent_joined: Bot,
 };


### PR DESCRIPTION
## 한 줄
#1695(인박스) 머지 後 유나 dev 양테마 픽셀 **formal 콜**: 알림 `story`·`story_assigned` 아이콘 `Bookmark`→`FileText`. 상수 1줄.

## 근거 (cross-surface 부품 언어 일관)
채팅 `ENTITY_ICONS`가 `story=FileText`로 엔티티 아이콘 언어를 이미 확립 → 사용자가 **채팅 embed든 인박스 알림이든 같은 story를 같은 아이콘으로 인식**(canonical 한 벌 핵심). 폐지될 글리프(📌·Bookmark 충실)보다 cross-surface 일관 우선(유나 디자인 콜·근거: ①폐지될 글리프 앵커 약함 ②채팅 story=FileText 기 확립 ③일관>미학).

## 변경
`notification-display.ts` NOTIFICATION_TYPE_ICONS: `story: Bookmark`→`FileText`·`story_assigned: Bookmark`→`FileText`. `Bookmark` import→`FileText` 교체(unused 0).

## 검증
`tsc` 0 · `eslint` 0 · 상수 1줄(렌더/로직 무변경·NotifIcon 헬퍼 그대로). #1695 LGTM 가디언이 픽셀서 FileText 방향 確定.

🤖 Generated with [Claude Code](https://claude.com/claude-code)