### PR TITLE
[SID:84f57f97] dispatch core flow fix — story assignee 영속화 + re-sync (P0 prod)

### DIFF
--- a/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
+++ b/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
@@ -40,6 +40,12 @@ export function EntityDispatchPanel({
   // f5ae74e4: Dispatch(이벤트 전달)를 Kickoff(킥오프·워크플로우 규칙)와 라벨·툴팁으로 명확히 구분.
   const dispatchTitle = !assigneeId ? t('dispatchNeedsAssignee') : t('dispatchTooltip');
 
+  // 84f57f97 fix①: currentAssigneeId prop 변경(낙관 배정·재fetch) 시 local assigneeId 동기화.
+  // 미동기화 시 stale 상태로 dispatch→BE가 직전 배정 못 봐 core flow 막힘(prod 버그 근본 1).
+  useEffect(() => {
+    setAssigneeId(currentAssigneeId ?? '');
+  }, [currentAssigneeId]);
+
   useEffect(() => {
     if (!moreOpen) return;
     const handler = (e: MouseEvent | TouchEvent) => {
@@ -69,16 +75,21 @@ export function EntityDispatchPanel({
     if (!assigneeId || dispatching) return;
     setDispatching(true);
     try {
-      const patchPath = entityType === 'doc' ? `/api/docs/${entityId}` : `/api/epics/${entityId}`;
-      if (entityType !== 'story') {
-        const patchRes = await fetch(patchPath, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ assignee_id: assigneeId }),
-        });
-        if (!patchRes.ok) throw new Error('assignee patch failed');
-        onAssigneePatched?.(assigneeId);
-      }
+      // 84f57f97 fix②: dispatch 前 assignee를 전 entity type 영속화(이전엔 story만 스킵→미영속→
+      // BE dispatch가 담당자 못 봐 core flow 막힘). story=assignee_ids 배열·doc/epic=assignee_id.
+      const patchPath = entityType === 'doc' ? `/api/docs/${entityId}`
+        : entityType === 'epic' ? `/api/epics/${entityId}`
+        : `/api/stories/${entityId}`;
+      const patchBody = entityType === 'story'
+        ? { assignee_ids: [assigneeId] }
+        : { assignee_id: assigneeId };
+      const patchRes = await fetch(patchPath, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patchBody),
+      });
+      if (!patchRes.ok) throw new Error('assignee patch failed');
+      onAssigneePatched?.(assigneeId);
 
       const dispatchRes = await fetch('/api/dispatch', {
         method: 'POST',

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -801,7 +801,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   entityType="story"
                   entityId={story.id}
                   projectId={projectId}
-                  currentAssigneeId={localAssigneeIds.length > 1 ? undefined : story.assignee_id}
+                  currentAssigneeId={localAssigneeIds.length > 1 ? undefined : (localAssigneeIds[0] ?? story.assignee_id)}
                   onAssigneePatched={(aid) => onStoryUpdate?.({ ...story, assignee_id: aid })}
                 />
               </div>


### PR DESCRIPTION
## 🚨 P0 — prod 보드 dispatch core flow 막힘 (선생님 직접 제보)

**근본**: story dispatch가 배정 assignee를 **dispatch 前 영속화하지 않아** BE가 담당자를 못 봄(doc/epic은 PATCH·story만 스킵) + local 상태 stale.

## 3축 fix
1. **EntityDispatchPanel re-sync effect**: `currentAssigneeId` prop 변경(낙관 배정·재fetch) 시 local `assigneeId` 동기화. 미동기화 시 stale 상태로 dispatch → BE가 직전 배정 미인식.
2. **dispatch 前 assignee 전 entity type 영속화**: 이전 `entityType !== 'story'`로 story만 PATCH 스킵(=근본). story=`PATCH /api/stories/{id} {assignee_ids:[assigneeId]}`(검증된 계약·`story-detail-panel`의 `patchStory`가 동일 사용)·doc/epic=`assignee_id`. PATCH 성공 後 dispatch 순서 보장.
3. **caller fallback**(`story-detail-panel`): `currentAssigneeId={localAssigneeIds.length>1 ? undefined : (localAssigneeIds[0] ?? story.assignee_id)}` — 낙관 업데이트된 로컬 단일 배정 우선(stale `story.assignee_id` 폴백). 멀티배정(>1)은 단일 picker 미표현이라 undefined 유지.

## 검증
- `tsc` 0 · `eslint` 0(re-sync effect set-state 룰 무경고) · `next build` ✓.
- **기능 동결**: dispatch 실패 reason 매트릭스·toast·doc/epic PATCH 경로·멀티배정 케이스 전부 보존.
- 2파일(`entity-dispatch-panel.tsx` +22/-11 · `story-detail-panel.tsx` 1줄).

⚠️ **E2E 회귀(SME=산티아고)**: 보드서 story에 담당자 지정 → dispatch → BE가 assignee 인식·dispatched=true·도착 확認. doc/epic dispatch 회귀(영속 경로 통합)·멀티배정 dispatch. P0라 머지→develop→smoke→prod 프로모션 우선.

🤖 Generated with [Claude Code](https://claude.com/claude-code)