### PR TITLE
[fix] planning 스프린트 종료 허용 (cancel/discard·velocity 0) — web 종료 경로 0 prod 버그

### DIFF
--- a/backend/app/schemas/sprint.py
+++ b/backend/app/schemas/sprint.py
@@ -10,6 +10,7 @@ from app.schemas.story import _validate_metric_definition
 SPRINT_STATUSES = ("planning", "active", "review", "closed", "archived")
 _SPRINT_VALID_TRANSITIONS: set[tuple[str, str]] = {
     ("planning", "active"),     # 시작(activate·1-active 제약·overlay-gated)
+    ("planning", "closed"),     # 시작 전 폐기(cancel/discard·한번도 안 뛴 스프린트·velocity 0·non-gated)
     ("active", "review"),        # review 단계(선택)
     ("active", "closed"),        # 마감 직행(review 생략·overlay-gated). close-state=closed(de-facto·decision① B)
     ("review", "closed"),        # 마감(review 경유·overlay-gated)

--- a/backend/app/services/sprint.py
+++ b/backend/app/services/sprint.py
@@ -74,6 +74,11 @@ async def transition_sprint(
     if to_status == "active":
         return await repo.activate(sprint_id)   # planning→active·1-active 제약
     if to_status == "closed":
+        # planning→closed = cancel/discard(한번도 안 뛴 스프린트). repo.close 는 active|review 만 수용하고
+        # velocity 집계 + outcome 채점(E-OUTCOME-LOOP)을 하는데, 실행 안 된 스프린트를 가설 채점하면
+        # 오측정 → discard 경로로 velocity 0 만 세팅(채점 skip). active|review 는 기존 repo.close 보존.
+        if sprint.status == "planning":
+            return await repo.update(sprint_id, status="closed", velocity=0)
         return await repo.close(sprint_id)      # active|review→closed·velocity 집계(repo.close=closed set)
     # review·archived: 특수 로직 없음 → inline.
     updated = await repo.update(sprint_id, status=to_status)

--- a/backend/tests/test_edg_s26_sprint_overlay.py
+++ b/backend/tests/test_edg_s26_sprint_overlay.py
@@ -28,7 +28,7 @@ def test_sprint_fsm_valid_transitions():
     assert is_valid_sprint_transition("active", "review")
     assert is_valid_sprint_transition("review", "closed")
     assert is_valid_sprint_transition("closed", "archived")  # native
-    assert not is_valid_sprint_transition("planning", "closed")  # 직행 금지
+    assert is_valid_sprint_transition("planning", "closed")  # 시작 전 폐기(cancel/discard·velocity 0·non-gated)
     assert not is_valid_sprint_transition("closed", "active")    # 역전이 금지
 
 
@@ -143,4 +143,33 @@ async def test_default_off_activate_any_caller():
         agent = ResolvedMember(id=uuid.uuid4(), user_id=None, name="a", type="agent", role="member", org_id=org)
         result = await transition_sprint(s, org, agent, sprint.id, "active")  # agent·default-off→활성
         assert result.status == "active"  # human-only inline 없음(enforcing gate가 담당)
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_planning_close_discard_velocity_zero():
+    """prod fix: planning→closed = cancel/discard. repo.close(active|review 전용·velocity 집계) 우회 →
+    discard 경로로 status=closed·velocity 0(한번도 안 뛴 스프린트 outcome 채점 skip). non-gated."""
+    from app.services.sprint import transition_sprint
+    from app.services.member_resolver import ResolvedMember
+    from app.models.pm import Sprint
+    from app.models.project import Project
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org, proj = uuid.uuid4(), uuid.uuid4()
+        s.add(Project(id=proj, org_id=org, name="p"))
+        await s.flush()
+        sprint = Sprint(org_id=org, project_id=proj, title="sp", status="planning")
+        s.add(sprint)
+        await s.commit()
+        caller = ResolvedMember(id=uuid.uuid4(), user_id=None, name="h", type="human", role="member", org_id=org)
+        result = await transition_sprint(s, org, caller, sprint.id, "closed")  # planning→closed discard
+        await s.commit()
+        st, vel = (await s.execute(
+            select(Sprint.status, Sprint.velocity).where(Sprint.id == sprint.id)
+        )).one()
+        assert result.status == "closed" and st == "closed"
+        assert vel == 0  # 안 뛴 스프린트 → velocity 0(채점 skip)
     await engine.dispose()


### PR DESCRIPTION
## Summary
**prod 버그(선생님 직접 제보·high)**: planning 상태 스프린트(Sprint 13·overdue 6/8)를 web서 종료할 방법이 없음. BE층 근본: sprint 상태머신이 `planning→closed` 전이를 불법으로 막음.

## 진단 (상태머신 SSOT)
- `_SPRINT_VALID_TRANSITIONS` 에 `(planning, closed)` 부재 → `transition_sprint` 가 `INVALID_SPRINT_TRANSITION`.
- 통과해도 `repo.close` 는 `active|review` 만 수용(velocity 집계 + E-OUTCOME-LOOP 채점) → planning 거부(`Cannot close sprint with status: planning`).

## Fix (BE · additive · migration 불요 · `closed` 기존 status)
- `_SPRINT_VALID_TRANSITIONS += (planning, closed)` — 시작 전 폐기(cancel/discard · 한번도 안 뛴 스프린트).
- `transition_sprint` apply: `planning→closed` 는 **discard 경로**(`repo.update(status=closed, velocity=0)`)로 `repo.close` 우회 — velocity 집계/outcome 채점 skip(실행 안 된 스프린트를 가설 채점하면 오측정). `active|review` 는 기존 `repo.close`(velocity 집계) 보존.
- **non-gated**: `planning→closed` 는 `_OVERLAY_TRANSITIONS` 미포함 → 승인 게이트 없이 즉시(unstarted 폐기는 검토 대상 없음). `active→closed`/`review→closed` overlay-gating 그대로.

## Verification
`CI=1` — FSM 전이 단언 갱신(`planning→closed` 합법·CI 커버) + `planning→closed` discard real-PG 테스트(status=closed·velocity 0). sprint 스위트 **90 passed**·compile·app 로드. readiness matrix(gated 전이)는 non-gated 라 미변경.

## FE (Mirko)
planning 상태에도 종료/취소 버튼 노출(현 active 전용 `sprints-client.tsx:617`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
