### PR TITLE
[SID:6580c655] planning 스프린트 종료/취소 버튼 노출 (web 종료 경로 fix)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2421,6 +2421,8 @@
     "activateError": "Failed to start sprint.",
     "closeError": "Failed to close sprint.",
     "closeConfirm": "Close this sprint? Incomplete stories will move to backlog.",
+    "cancelSprint": "Cancel Sprint",
+    "cancelConfirm": "Cancel this sprint that hasn't started? Stories return to the backlog.",
     "sprintStories": "Sprint Stories",
     "noSprintStories": "No stories assigned to this sprint.",
     "backlog": "Backlog",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2421,6 +2421,8 @@
     "activateError": "스프린트 시작에 실패했습니다.",
     "closeError": "스프린트 종료에 실패했습니다.",
     "closeConfirm": "스프린트를 종료하시겠습니까? 미완료 스토리는 백로그로 이동됩니다.",
+    "cancelSprint": "스프린트 취소",
+    "cancelConfirm": "시작하지 않은 스프린트를 취소하시겠습니까? 스토리는 백로그로 돌아갑니다.",
     "sprintStories": "스프린트 스토리",
     "noSprintStories": "배정된 스토리가 없습니다.",
     "backlog": "백로그",

--- a/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
+++ b/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { Plus, X, Play, StopCircle, ChevronRight, Trash2, AlertTriangle, Target, Clock, Users, Calendar } from 'lucide-react';
+import { Plus, X, Play, StopCircle, ChevronRight, Trash2, AlertTriangle, Target, Clock, Users, Calendar, Ban } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
@@ -423,7 +423,9 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
 
   const handleClose = async () => {
     if (!selected) return;
-    if (!confirm(t('closeConfirm'))) return;
+    // 6580c655: planning(미시작) 종료=취소/discard 의미라 confirm 카피 분기. 엔드포인트는 동일
+    // POST /close(디디 BE #1698이 planning→closed=velocity 0 취소로 처리).
+    if (!confirm(selected.status === 'planning' ? t('cancelConfirm') : t('closeConfirm'))) return;
     setClosing(true);
     setActionError(null);
     try {
@@ -608,10 +610,18 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
 
       {/* Action buttons */}
       {selected.status === 'planning' ? (
-        <Button size="sm" className="mb-4 w-full" onClick={() => void handleActivate()} disabled={activating}>
-          <Play className="size-4" />
-          {activating ? '...' : t('activate')}
-        </Button>
+        // 6580c655: planning=활성화 + 취소(discard). 이전엔 활성화만이라 미시작 스프린트를 web서
+        // 종료 못 함(선생님 제보 Sprint 13 overdue) — BE #1698 planning→closed 경로에 취소 버튼 노출.
+        <div className="mb-4 flex flex-col gap-2">
+          <Button size="sm" className="w-full" onClick={() => void handleActivate()} disabled={activating}>
+            <Play className="size-4" />
+            {activating ? '...' : t('activate')}
+          </Button>
+          <Button size="sm" variant="outline" className="w-full" onClick={() => void handleClose()} disabled={closing}>
+            <Ban className="size-4" />
+            {closing ? '...' : t('cancelSprint')}
+          </Button>
+        </div>
       ) : null}
       {selected.status === 'active' ? (
         <Button size="sm" variant="outline" className="mb-4 w-full" onClick={() => void handleClose()} disabled={closing}>


### PR DESCRIPTION
## 한 줄
선생님 제보(Sprint 13 overdue를 web서 못 닫음) — FE 종료 버튼이 `status==='active'` 전용이라 **planning 스프린트는 종료 경로 0**. 디디 BE #1698(planning→closed·취소/discard·velocity 0)에 맞춰 planning에 취소 버튼 노출.

> story `6580c655` · 디디 BE #1698(`82a31396`·develop 머지·dev 배포) · `sprints-client.tsx`

## 변경
- **planning 상세에 활성화 + 취소(`Ban`·discard) 2버튼**(`flex-col gap-2`). 취소=`handleClose` 재사용(POST `/api/sprints/{id}/close`·BE #1698이 planning을 취소로 처리).
- `handleClose` confirm 카피 **status 분기**: planning=`cancelConfirm`(미시작 취소·스토리 백로그 복귀)·active=`closeConfirm`(종료·미완료 백로그). i18n `sprints.cancelSprint`/`cancelConfirm` ko+en.
- **active 종료 버튼 무변경**.

## 검증
- `tsc` 0 · `eslint` 0 · `next build` ✓ · i18n parity.
- 기능 동결: 활성화·종료 핸들러/엔드포인트 무변경(취소는 동일 `/close` 재사용·confirm 카피만 분기).

⚠️ **E2E(SME 디디/산티아고)**: planning 스프린트 상세 → 취소 → BE planning→closed(velocity 0)·스토리 백로그 복귀·목록서 closed 반영. active 종료 회귀. 선생님 제보 Sprint 13 취소 가능 확認.

🤖 Generated with [Claude Code](https://claude.com/claude-code)