### PR TITLE
[SID:9b0f560d] 에이전트 UI 갈아엎기 — canonical sweep 전건 + de-boxy stat/leaderboard (목업 타겟)

### DIFF
--- a/apps/web/src/components/agents/agent-deployment-verification-step.tsx
+++ b/apps/web/src/components/agents/agent-deployment-verification-step.tsx
@@ -58,12 +58,12 @@ export function AgentDeploymentVerificationStep({
 
       <div className="grid gap-3 md:grid-cols-4">
         <GlassPanel className="border-white/8 bg-muted/35 p-4">
-          <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{t('verificationStatusLabel')}</div>
+          <div className="text-xs text-muted-foreground">{t('verificationStatusLabel')}</div>
           <div className="mt-2 text-sm font-medium text-foreground">{deploymentStatus}</div>
           <div className="mt-2 text-xs text-muted-foreground">{lastDeployedAt ? new Date(lastDeployedAt).toLocaleString() : t('verificationStatusPending')}</div>
         </GlassPanel>
         <GlassPanel className="border-white/8 bg-muted/35 p-4">
-          <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{t('verificationResultLabel')}</div>
+          <div className="text-xs text-muted-foreground">{t('verificationResultLabel')}</div>
           <div className="mt-2 flex items-center gap-2">
             <div className="text-sm font-medium text-foreground">{verificationCompleted ? t('verificationStatusValueCompleted') : t('verificationStatusValuePending')}</div>
             <Badge variant={verificationCompleted ? 'success' : 'outline'}>
@@ -73,12 +73,12 @@ export function AgentDeploymentVerificationStep({
           <div className="mt-2 text-xs text-muted-foreground">{verificationCompletedAt ? t('verificationCompletedAtValue', { date: new Date(verificationCompletedAt).toLocaleString() }) : t('verificationPendingHint')}</div>
         </GlassPanel>
         <GlassPanel className="border-white/8 bg-muted/35 p-4">
-          <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{t('verificationScopeLabel')}</div>
+          <div className="text-xs text-muted-foreground">{t('verificationScopeLabel')}</div>
           <div className="mt-2 text-sm font-medium text-foreground">{verificationScopeSummary}</div>
           <div className="mt-2 text-xs text-muted-foreground">{t('verificationModelValue', { provider: deploymentProviderLabel, model })}</div>
         </GlassPanel>
         <GlassPanel className="border-white/8 bg-muted/35 p-4">
-          <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{t('verificationRoutingLabel')}</div>
+          <div className="text-xs text-muted-foreground">{t('verificationRoutingLabel')}</div>
           <div className="mt-2 text-sm font-medium text-foreground">{autoRoutingPreviewLabel}</div>
           <div className="mt-2 text-xs text-muted-foreground">{t('deployPreflightRoutingValue', { template: autoRoutingPreviewLabel, count: autoRoutingRuleCount })}</div>
         </GlassPanel>

--- a/apps/web/src/components/agents/agent-deployment-wizard.tsx
+++ b/apps/web/src/components/agents/agent-deployment-wizard.tsx
@@ -455,7 +455,7 @@ export function AgentDeploymentWizard({
     if (!agent) {
       return (
         <div className="rounded-md border border-dashed border-border bg-muted/30 p-6 text-center">
-          <AlertTriangle className="mx-auto size-9 text-amber-300" />
+          <AlertTriangle className="mx-auto size-9 text-warning" />
           <h3 className="mt-4 text-lg font-semibold text-foreground">{t('noAgentTitle')}</h3>
           <p className="mt-2 text-sm text-muted-foreground">{t('noAgentBody')}</p>
         </div>
@@ -487,7 +487,7 @@ export function AgentDeploymentWizard({
           </div>
           {[{ label: t('builtInPersonas'), personas: builtinPersonas }, { label: t('customPersonas'), personas: customPersonas }].map((group) => (
             <div key={group.label} className="space-y-3">
-              <div className="text-xs uppercase tracking-[0.2em] text-muted-foreground">{group.label}</div>
+              <div className="text-xs text-muted-foreground">{group.label}</div>
               <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
                 {group.personas.length === 0 ? (
                   <div className="rounded-md border border-dashed border-border bg-muted/30 px-4 py-5 text-sm text-muted-foreground">
@@ -563,7 +563,7 @@ export function AgentDeploymentWizard({
 
           <div className="grid gap-4 lg:grid-cols-3">
             <div className="space-y-2 lg:col-span-1">
-              <label className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{t('providerLabel')}</label>
+              <label className="text-xs text-muted-foreground">{t('providerLabel')}</label>
               <OperatorSelect value={deploymentProvider} onChange={(event) => setProvider(event.target.value as LLMProvider)} disabled={Boolean(lockedByomProvider)}>
                 {(['openai', 'anthropic', 'google', 'groq', 'openai-compatible'] as LLMProvider[]).map((option) => (
                   <option key={option} value={option}>{PROVIDER_LABELS[option]}</option>
@@ -574,7 +574,7 @@ export function AgentDeploymentWizard({
               ) : null}
             </div>
             <div className="space-y-2 lg:col-span-1">
-              <label className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{t('modelLabel')}</label>
+              <label className="text-xs text-muted-foreground">{t('modelLabel')}</label>
               {modelOptions.length > 0 ? (
                 <OperatorSelect value={model} onChange={(event) => setModel(event.target.value)}>
                   {modelOptions.map((option) => <option key={option} value={option}>{option}</option>)}
@@ -584,7 +584,7 @@ export function AgentDeploymentWizard({
               )}
             </div>
             <div className="space-y-2 lg:col-span-1">
-              <label className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{t('deploymentNameLabel')}</label>
+              <label className="text-xs text-muted-foreground">{t('deploymentNameLabel')}</label>
               <OperatorInput value={deploymentName} onChange={(event) => setDeploymentName(event.target.value)} placeholder={t('deploymentNamePlaceholder')} />
             </div>
           </div>
@@ -679,7 +679,7 @@ export function AgentDeploymentWizard({
           <div className="grid gap-3 md:grid-cols-2">
             {summaryItems.map((item) => (
               <div key={item.label} className="rounded-md border border-border bg-muted/30 p-4">
-                <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{item.label}</div>
+                <div className="text-xs text-muted-foreground">{item.label}</div>
                 <div className="mt-2 text-sm font-medium text-foreground">{item.value}</div>
               </div>
             ))}
@@ -745,15 +745,15 @@ export function AgentDeploymentWizard({
 
             <div className="mt-4 grid gap-3 md:grid-cols-3">
               <div className="rounded-md border border-border bg-muted/30 px-4 py-3">
-                <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{t('deployPreflightScopeLabel')}</div>
+                <div className="text-xs text-muted-foreground">{t('deployPreflightScopeLabel')}</div>
                 <div className="mt-2 text-sm font-medium text-foreground">{verificationScopeSummary}</div>
               </div>
               <div className="rounded-md border border-border bg-muted/30 px-4 py-3">
-                <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{t('deployPreflightRoutingLabel')}</div>
+                <div className="text-xs text-muted-foreground">{t('deployPreflightRoutingLabel')}</div>
                 <div className="mt-2 text-sm font-medium text-foreground">{t('deployPreflightRoutingValue', { template: autoRoutingPreviewLabel, count: autoRoutingPreview.rules.length })}</div>
               </div>
               <div className="rounded-md border border-border bg-muted/30 px-4 py-3">
-                <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{t('deployPreflightCheckedAtLabel')}</div>
+                <div className="text-xs text-muted-foreground">{t('deployPreflightCheckedAtLabel')}</div>
                 <div className="mt-2 text-sm font-medium text-foreground">{preflight ? new Date(preflight.checked_at).toLocaleString() : t('deployPreflightNotRun')}</div>
               </div>
             </div>
@@ -859,7 +859,7 @@ export function AgentDeploymentWizard({
                         {complete ? <CheckCircle2 className="size-4" /> : <Icon className="size-4" />}
                       </div>
                       <div>
-                        <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{t(`steps.${key}.eyebrow`)}</div>
+                        <div className="text-xs text-muted-foreground">{t(`steps.${key}.eyebrow`)}</div>
                         <div className="text-sm font-semibold text-foreground">{t(`steps.${key}.title`)}</div>
                       </div>
                     </div>

--- a/apps/web/src/components/agents/agent-hitl-policy-editor.tsx
+++ b/apps/web/src/components/agents/agent-hitl-policy-editor.tsx
@@ -113,7 +113,7 @@ export function AgentHitlPolicyEditor() {
         <SectionCardBody>
           <div className="space-y-3">
             {[1, 2, 3].map((item) => (
-              <div key={item} className="h-28 animate-pulse rounded-3xl bg-muted" />
+              <div key={item} className="h-28 animate-pulse rounded-xl bg-muted" />
             ))}
           </div>
         </SectionCardBody>
@@ -128,7 +128,7 @@ export function AgentHitlPolicyEditor() {
           <h2 className="text-base font-semibold text-foreground">{t('policyTitle')}</h2>
         </SectionCardHeader>
         <SectionCardBody className="space-y-3">
-          <p className="text-sm text-amber-100">{error ?? t('policyLoadFailed')}</p>
+          <p className="text-sm text-warning">{error ?? t('policyLoadFailed')}</p>
           <Button variant="glass" size="sm" onClick={() => void fetchPolicy()}>{t('refreshPolicy')}</Button>
         </SectionCardBody>
       </SectionCard>
@@ -137,9 +137,9 @@ export function AgentHitlPolicyEditor() {
 
   return (
     <div className="space-y-4">
-      <div className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-white/8 bg-white/4 px-4 py-4">
+      <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-white/8 bg-white/4 px-4 py-4">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">{t('policyEyebrow')}</p>
+          <p className="text-xs font-semibold text-muted-foreground">{t('policyEyebrow')}</p>
           <h2 className="mt-1 text-lg font-semibold text-foreground">{t('policyTitle')}</h2>
           <p className="mt-1 text-sm text-muted-foreground">{t('policyBody')}</p>
         </div>
@@ -169,7 +169,7 @@ export function AgentHitlPolicyEditor() {
           </SectionCardHeader>
           <SectionCardBody className="space-y-3">
             {policy.high_risk_actions.map((item) => (
-              <div key={item.key} className="rounded-3xl border border-white/10 bg-white/4 px-4 py-4">
+              <div key={item.key} className="rounded-xl border border-white/10 bg-white/4 px-4 py-4">
                 <div className="flex flex-wrap items-center gap-2">
                   <Badge variant={item.severity === 'critical' ? 'destructive' : 'info'}>{t(`catalogSeverity_${item.severity}`)}</Badge>
                   <Badge variant="outline">{t(`requestType_${item.default_request_type}`)}</Badge>
@@ -194,7 +194,7 @@ export function AgentHitlPolicyEditor() {
           </SectionCardHeader>
           <SectionCardBody className="space-y-3">
             {policy.approval_rules.map((rule) => (
-              <div key={rule.key} className="rounded-3xl border border-white/10 bg-white/4 px-4 py-4 space-y-3">
+              <div key={rule.key} className="rounded-xl border border-white/10 bg-white/4 px-4 py-4 space-y-3">
                 <div className="flex flex-wrap items-center gap-2">
                   <Badge variant="info">{t('approvalRequired')}</Badge>
                   <Badge variant="outline">{t(`timeoutClass_${rule.timeout_class}`)}</Badge>
@@ -204,13 +204,13 @@ export function AgentHitlPolicyEditor() {
                   <p className="mt-1 text-sm text-muted-foreground">{t(`approval_${rule.key}_body`)}</p>
                 </div>
                 <div className="grid gap-3 md:grid-cols-2">
-                  <label className="space-y-2 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                  <label className="space-y-2 text-xs font-semibold text-muted-foreground">
                     <span>{t('approvalRequestTypeLabel')}</span>
-                    <div className="flex h-10 items-center rounded-2xl border border-white/10 bg-muted px-3 text-sm font-medium normal-case tracking-normal text-foreground">
+                    <div className="flex h-10 items-center rounded-xl border border-white/10 bg-muted px-3 text-sm font-medium normal-case tracking-normal text-foreground">
                       {t('requestType_approval')}
                     </div>
                   </label>
-                  <label className="space-y-2 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                  <label className="space-y-2 text-xs font-semibold text-muted-foreground">
                     <span>{t('approvalTimeoutClassLabel')}</span>
                     <OperatorSelect value={rule.timeout_class} onChange={(event) => updateApprovalRule(rule.key, event.target.value)}>
                       {policy.timeout_classes.map((timeoutClass) => (
@@ -238,7 +238,7 @@ export function AgentHitlPolicyEditor() {
             {policy.timeout_classes.map((timeoutClass) => {
               const linkedRules = policy.approval_rules.filter((rule) => rule.timeout_class === timeoutClass.key);
               return (
-                <div key={timeoutClass.key} className="rounded-3xl border border-white/10 bg-white/4 px-4 py-4 space-y-3">
+                <div key={timeoutClass.key} className="rounded-xl border border-white/10 bg-white/4 px-4 py-4 space-y-3">
                   <div className="flex flex-wrap items-center gap-2">
                     <Badge variant="chip">{t(`timeoutClass_${timeoutClass.key}`)}</Badge>
                     {linkedRules.map((rule) => (
@@ -250,7 +250,7 @@ export function AgentHitlPolicyEditor() {
                     <p className="mt-1 text-sm text-muted-foreground">{t(`timeout_${timeoutClass.key}_body`)}</p>
                   </div>
                   <div className="grid gap-3">
-                    <label className="space-y-2 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                    <label className="space-y-2 text-xs font-semibold text-muted-foreground">
                       <span>{t('timeoutDurationLabel')}</span>
                       <OperatorInput
                         type="number"
@@ -260,7 +260,7 @@ export function AgentHitlPolicyEditor() {
                         onChange={(event) => updateTimeoutClass(timeoutClass.key, 'duration_minutes', event.target.value)}
                       />
                     </label>
-                    <label className="space-y-2 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                    <label className="space-y-2 text-xs font-semibold text-muted-foreground">
                       <span>{t('timeoutReminderLabel')}</span>
                       <OperatorInput
                         type="number"
@@ -270,7 +270,7 @@ export function AgentHitlPolicyEditor() {
                         onChange={(event) => updateTimeoutClass(timeoutClass.key, 'reminder_minutes_before', event.target.value)}
                       />
                     </label>
-                    <label className="space-y-2 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                    <label className="space-y-2 text-xs font-semibold text-muted-foreground">
                       <span>{t('timeoutEscalationLabel')}</span>
                       <OperatorSelect value={timeoutClass.escalation_mode} onChange={(event) => updateTimeoutClass(timeoutClass.key, 'escalation_mode', event.target.value)}>
                         {ESCALATION_MODE_OPTIONS.map((mode) => (
@@ -297,7 +297,7 @@ export function AgentHitlPolicyEditor() {
           </div>
         </SectionCardHeader>
         <SectionCardBody>
-          <pre className="whitespace-pre-wrap rounded-3xl border border-white/10 bg-slate-950/40 px-4 py-4 text-sm text-muted-foreground">{policy.prompt_summary}</pre>
+          <pre className="whitespace-pre-wrap rounded-xl border border-white/10 bg-muted/40 px-4 py-4 text-sm text-muted-foreground">{policy.prompt_summary}</pre>
         </SectionCardBody>
       </SectionCard>
     </div>

--- a/apps/web/src/components/agents/agent-hitl-requests-list.tsx
+++ b/apps/web/src/components/agents/agent-hitl-requests-list.tsx
@@ -162,7 +162,7 @@ export function AgentHitlRequestsList() {
                           <User className="size-3.5" />
                           {t('assigneeLine', { assignee: request.requested_for_name ?? t('unknownAssignee') })}
                         </span>
-                        <span className="inline-flex items-center gap-1 text-amber-200">
+                        <span className="inline-flex items-center gap-1 text-warning">
                           <TriangleAlert className="size-3.5" />
                           {t('deadlineLine', { countdown: getCountdownLabel(request.expires_at, t) })}
                         </span>

--- a/apps/web/src/components/agents/agent-performance-panel.tsx
+++ b/apps/web/src/components/agents/agent-performance-panel.tsx
@@ -167,15 +167,16 @@ export function AgentPerformancePanel() {
             {agents.length === 0 ? (
               <p className="py-6 text-center text-sm text-muted-foreground">{t('noAgents')}</p>
             ) : (
-              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              // 목업 ① de-boxy dense grid: per-card 테두리 제거·gap-px divider·중첩 메트릭 박스→flex 행(아이콘이 타입)
+              <div className="grid grid-cols-1 gap-px overflow-hidden rounded-xl bg-border sm:grid-cols-2 lg:grid-cols-3">
                 {agents.map((agent) => (
-                  <div key={agent.id} className="rounded-lg border border-border bg-muted/30 p-4 space-y-3">
+                  <div key={agent.id} className="space-y-2 bg-background p-3">
                     <div className="flex items-start justify-between gap-2">
                       <div className="min-w-0">
                         <div className="truncate text-sm font-semibold text-foreground">{agent.name}</div>
                         {agent.rank != null && (
-                          <div className="flex items-center gap-1 mt-0.5">
-                            <Trophy className="size-3 text-amber-400" />
+                          <div className="mt-0.5 flex items-center gap-1">
+                            <Trophy className="size-3 text-warning" />
                             <span className="text-xs text-muted-foreground">#{agent.rank}</span>
                           </div>
                         )}
@@ -184,28 +185,19 @@ export function AgentPerformancePanel() {
                         {agent.balance} TJSB
                       </Badge>
                     </div>
-                    <div className="grid grid-cols-3 gap-2 text-center">
-                      <div className="rounded-md bg-muted/50 px-2 py-2">
-                        <div className="flex items-center justify-center gap-1 text-emerald-500">
-                          <CheckCircle className="size-3" />
-                          <span className="text-base font-bold">{agent.stats?.completed ?? 0}</span>
-                        </div>
-                        <div className="mt-0.5 text-[10px] text-muted-foreground">{t('doneStories')}</div>
-                      </div>
-                      <div className="rounded-md bg-muted/50 px-2 py-2">
-                        <div className="flex items-center justify-center gap-1 text-primary">
-                          <Zap className="size-3" />
-                          <span className="text-base font-bold">{agent.stats?.total_stories ?? 0}</span>
-                        </div>
-                        <div className="mt-0.5 text-[10px] text-muted-foreground">{t('assignedStories')}</div>
-                      </div>
-                      <div className="rounded-md bg-muted/50 px-2 py-2">
-                        <div className="flex items-center justify-center gap-1 text-muted-foreground">
-                          <Clock className="size-3" />
-                          <span className="text-base font-bold">{formatDuration(agent.stats?.avg_lead_time_ms ?? 0)}</span>
-                        </div>
-                        <div className="mt-0.5 text-[10px] text-muted-foreground">{t('avgLeadTime')}</div>
-                      </div>
+                    <div className="flex flex-wrap items-center gap-4 text-xs">
+                      <span className="inline-flex items-center gap-1 text-success" title={t('doneStories')}>
+                        <CheckCircle className="size-3.5" />
+                        <span className="font-semibold tabular-nums">{agent.stats?.completed ?? 0}</span>
+                      </span>
+                      <span className="inline-flex items-center gap-1 text-primary" title={t('assignedStories')}>
+                        <Zap className="size-3.5" />
+                        <span className="font-semibold tabular-nums">{agent.stats?.total_stories ?? 0}</span>
+                      </span>
+                      <span className="inline-flex items-center gap-1 text-muted-foreground" title={t('avgLeadTime')}>
+                        <Clock className="size-3.5" />
+                        <span className="font-semibold tabular-nums">{formatDuration(agent.stats?.avg_lead_time_ms ?? 0)}</span>
+                      </span>
                     </div>
                   </div>
                 ))}
@@ -233,12 +225,12 @@ export function AgentPerformancePanel() {
           <SectionCard>
             <SectionCardHeader>
               <div className="flex items-center gap-2">
-                <Trophy className="size-4 text-amber-400" />
+                <Trophy className="size-4 text-warning" />
                 <span className="text-sm font-semibold text-foreground">{t('leaderboardTitle')}</span>
               </div>
               <p className="mt-0.5 text-xs text-muted-foreground">{t('leaderboardDescription')}</p>
             </SectionCardHeader>
-            <SectionCardBody className="space-y-2">
+            <SectionCardBody className="divide-y divide-border/60">
               {agents.length === 0 ? (
                 <p className="py-4 text-center text-sm text-muted-foreground">{t('noAgents')}</p>
               ) : (
@@ -247,9 +239,9 @@ export function AgentPerformancePanel() {
                   .map((agent, idx) => (
                     <div
                       key={agent.id}
-                      className="flex items-center gap-3 rounded-md border border-border bg-muted/30 px-3 py-2.5"
+                      className="flex items-center gap-3 px-3 py-2.5"
                     >
-                      <span className={`w-6 shrink-0 text-center text-sm font-bold ${idx === 0 ? 'text-amber-400' : idx === 1 ? 'text-slate-400' : idx === 2 ? 'text-amber-600' : 'text-muted-foreground'}`}>
+                      <span className={`w-6 shrink-0 text-center text-sm font-bold ${idx === 0 ? 'text-warning' : idx === 1 ? 'text-muted-foreground' : idx === 2 ? 'text-warning/70' : 'text-muted-foreground'}`}>
                         {idx + 1}
                       </span>
                       <span className="flex-1 truncate text-sm font-medium text-foreground">{agent.name}</span>

--- a/apps/web/src/components/agents/agent-persona-composer.tsx
+++ b/apps/web/src/components/agents/agent-persona-composer.tsx
@@ -361,15 +361,15 @@ export function AgentPersonaComposer({
             {basePersona ? (
               <div className="grid gap-3 sm:grid-cols-3">
                 <div className="rounded-md border border-border bg-muted/30 p-4">
-                  <p className="text-xs uppercase tracking-[0.24em] text-muted-foreground">{t('personaComposerVersionLabel')}</p>
+                  <p className="text-xs text-muted-foreground">{t('personaComposerVersionLabel')}</p>
                   <p className="mt-2 text-2xl font-semibold text-foreground">v{basePersona.version_metadata.version_number}</p>
                 </div>
                 <div className="rounded-md border border-border bg-muted/30 p-4">
-                  <p className="text-xs uppercase tracking-[0.24em] text-muted-foreground">{t('personaComposerPublishedAtLabel')}</p>
+                  <p className="text-xs text-muted-foreground">{t('personaComposerPublishedAtLabel')}</p>
                   <p className="mt-2 text-sm font-medium text-foreground">{formatPersonaTimestamp(basePersona.version_metadata.published_at)}</p>
                 </div>
                 <div className="rounded-md border border-border bg-muted/30 p-4">
-                  <p className="text-xs uppercase tracking-[0.24em] text-muted-foreground">{t('personaComposerRollbackLabel')}</p>
+                  <p className="text-xs text-muted-foreground">{t('personaComposerRollbackLabel')}</p>
                   <p className="mt-2 text-sm font-medium text-foreground">{basePersona.version_metadata.rollback_target_version_number != null ? `v${basePersona.version_metadata.rollback_target_version_number}` : t('personaComposerRollbackEmpty')}</p>
                 </div>
               </div>
@@ -382,7 +382,7 @@ export function AgentPersonaComposer({
                   <p className="text-sm text-muted-foreground">{t('personaComposerBoundaryBody')}</p>
                 </div>
                 <div className="space-y-2">
-                  <p className="text-xs uppercase tracking-[0.24em] text-muted-foreground">{t('personaComposerBoundaryToolsLabel')}</p>
+                  <p className="text-xs text-muted-foreground">{t('personaComposerBoundaryToolsLabel')}</p>
                   <div className="flex flex-wrap gap-2">
                     {basePersona.permission_boundary.allowed_tool_names.length > 0 ? basePersona.permission_boundary.allowed_tool_names.map((toolName) => (
                       <Badge key={toolName} variant="chip">{toolName}</Badge>
@@ -390,7 +390,7 @@ export function AgentPersonaComposer({
                   </div>
                 </div>
                 <div className="space-y-2">
-                  <p className="text-xs uppercase tracking-[0.24em] text-muted-foreground">{t('personaComposerBoundaryServersLabel')}</p>
+                  <p className="text-xs text-muted-foreground">{t('personaComposerBoundaryServersLabel')}</p>
                   <div className="flex flex-wrap gap-2">
                     {basePersona.permission_boundary.mcp_server_names.length > 0 ? basePersona.permission_boundary.mcp_server_names.map((serverName) => (
                       <Badge key={serverName} variant="outline">{serverName}</Badge>
@@ -398,7 +398,7 @@ export function AgentPersonaComposer({
                   </div>
                 </div>
                 <div className="space-y-2">
-                  <p className="text-xs uppercase tracking-[0.24em] text-muted-foreground">{t('personaComposerBoundaryLayersLabel')}</p>
+                  <p className="text-xs text-muted-foreground">{t('personaComposerBoundaryLayersLabel')}</p>
                   <div className="flex flex-wrap gap-2">
                     {basePersona.permission_boundary.enforcement_layers.map((layer) => (
                       <Badge key={layer} variant="info">{layer}</Badge>
@@ -411,7 +411,7 @@ export function AgentPersonaComposer({
             <div className="grid gap-3 sm:grid-cols-2">
               {tokenStats.map((stat) => (
                 <div key={stat.label} className="rounded-md border border-border bg-muted/30 p-4">
-                  <p className="text-xs uppercase tracking-[0.24em] text-muted-foreground">{stat.label}</p>
+                  <p className="text-xs text-muted-foreground">{stat.label}</p>
                   <p className="mt-2 text-2xl font-semibold text-foreground">{stat.value}</p>
                 </div>
               ))}

--- a/apps/web/src/components/agents/agent-run-detail.tsx
+++ b/apps/web/src/components/agents/agent-run-detail.tsx
@@ -225,8 +225,8 @@ export function AgentRunDetail({
   if (loading) {
     return (
       <div className="space-y-4">
-        <div className="h-24 animate-pulse rounded-2xl bg-muted" />
-        <div className="h-64 animate-pulse rounded-2xl bg-muted" />
+        <div className="h-24 animate-pulse rounded-xl bg-muted" />
+        <div className="h-64 animate-pulse rounded-xl bg-muted" />
       </div>
     );
   }
@@ -317,7 +317,7 @@ export function AgentRunDetail({
             </div>
 
             {Array.isArray(run.billing_notes) && run.billing_notes.length > 0 && (
-              <div className="mb-4 rounded-2xl border border-white/8 bg-white/4 px-4 py-3">
+              <div className="mb-4 rounded-xl border border-white/8 bg-white/4 px-4 py-3">
                 <p className="text-sm font-medium text-foreground">{t('billingNotesLabel')}</p>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {run.billing_notes.map((note) => (
@@ -346,14 +346,14 @@ export function AgentRunDetail({
 
             {/* Result summary */}
             {run.result_summary && (
-              <div className="mb-4 rounded-2xl border border-white/8 bg-white/4 px-4 py-3">
+              <div className="mb-4 rounded-xl border border-white/8 bg-white/4 px-4 py-3">
                 <p className="text-sm font-medium text-foreground">{t('resultSummary')}</p>
                 <p className="mt-1 text-sm text-muted-foreground">{run.result_summary}</p>
               </div>
             )}
 
             {retrievalDiagnostics && (
-              <div className="mb-4 rounded-2xl border border-white/8 bg-white/4 px-4 py-3">
+              <div className="mb-4 rounded-xl border border-white/8 bg-white/4 px-4 py-3">
                 <p className="text-sm font-medium text-foreground">{t('memoryRetrievalTitle')}</p>
                 <div className="mt-3 grid gap-3 md:grid-cols-2">
                   <MemoryBucketCard
@@ -381,7 +381,7 @@ export function AgentRunDetail({
             )}
 
             {compactionPolicy && (
-              <div className="mb-4 rounded-2xl border border-white/8 bg-white/4 px-4 py-3">
+              <div className="mb-4 rounded-xl border border-white/8 bg-white/4 px-4 py-3">
                 <p className="text-sm font-medium text-foreground">{t('memoryCompactionTitle')}</p>
                 <p className="mt-1 text-sm text-muted-foreground">
                   {t('memoryCompactionThresholds', {
@@ -403,7 +403,7 @@ export function AgentRunDetail({
             )}
 
             {run.continuity_debug && (
-              <div className="mb-4 rounded-2xl border border-white/8 bg-white/4 px-4 py-3">
+              <div className="mb-4 rounded-xl border border-white/8 bg-white/4 px-4 py-3">
                 <p className="text-sm font-medium text-foreground">{t('continuityDebugTitle')}</p>
                 <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
                   <MetaCard label={t('sessionId')} value={run.continuity_debug.sessionId ?? '-'} />
@@ -464,7 +464,7 @@ export function AgentRunDetail({
                             {hasError ? (
                               <AlertTriangle className="size-3.5 text-destructive" />
                             ) : (
-                              <CheckCircle2 className="size-3.5 text-emerald-400/60" />
+                              <CheckCircle2 className="size-3.5 text-success/60" />
                             )}
                           </div>
                           {hasError && (
@@ -505,7 +505,7 @@ export function AgentRunDetail({
                     const durationMs = payload && typeof payload.duration_ms === 'number' ? payload.duration_ms : null;
 
                     return (
-                      <div key={entry.id} className="rounded-2xl border border-white/8 bg-white/4 px-4 py-3">
+                      <div key={entry.id} className="rounded-xl border border-white/8 bg-white/4 px-4 py-3">
                         <div className="flex flex-wrap items-center gap-2">
                           <Badge variant={outcome === 'denied' ? 'destructive' : outcome === 'failed' ? 'secondary' : 'success'}>
                             {outcome === 'denied' ? t('toolAuditOutcomeDenied') : outcome === 'failed' ? t('toolAuditOutcomeFailed') : t('toolAuditOutcomeAllowed')}
@@ -516,47 +516,47 @@ export function AgentRunDetail({
                         </div>
                         <div className="mt-2 grid gap-2 text-sm text-muted-foreground md:grid-cols-2">
                           <div>
-                            <span className="text-xs uppercase tracking-[0.16em]">{t('toolAuditActorLabel')}</span>
+                            <span className="text-xs">{t('toolAuditActorLabel')}</span>
                             <p className="mt-1 text-foreground">{entry.actor_name ?? run.agent_name ?? t('unknownAgent')}</p>
                           </div>
                           <div>
-                            <span className="text-xs uppercase tracking-[0.16em]">{t('toolAuditEventLabel')}</span>
+                            <span className="text-xs">{t('toolAuditEventLabel')}</span>
                             <p className="mt-1 break-all text-foreground">{entry.event_type}</p>
                           </div>
                           {reasonCode ? (
                             <div>
-                              <span className="text-xs uppercase tracking-[0.16em]">{t('toolAuditReasonCodeLabel')}</span>
+                              <span className="text-xs">{t('toolAuditReasonCodeLabel')}</span>
                               <p className="mt-1 break-all text-foreground">{reasonCode}</p>
                             </div>
                           ) : null}
                           {durationMs != null ? (
                             <div>
-                              <span className="text-xs uppercase tracking-[0.16em]">{t('duration')}</span>
+                              <span className="text-xs">{t('duration')}</span>
                               <p className="mt-1 text-foreground">{formatDuration(durationMs)}</p>
                             </div>
                           ) : null}
                           {serverName ? (
                             <div>
-                              <span className="text-xs uppercase tracking-[0.16em]">{t('toolAuditServerLabel')}</span>
+                              <span className="text-xs">{t('toolAuditServerLabel')}</span>
                               <p className="mt-1 text-foreground">{serverName}</p>
                             </div>
                           ) : null}
                         </div>
                         {operatorReason ? (
-                          <div className="mt-3 rounded-2xl border border-white/8 bg-white/3 px-3 py-3">
-                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">{t('toolAuditOperatorReasonLabel')}</p>
+                          <div className="mt-3 rounded-xl border border-white/8 bg-white/3 px-3 py-3">
+                            <p className="text-xs font-semibold text-muted-foreground">{t('toolAuditOperatorReasonLabel')}</p>
                             <p className="mt-1 text-sm text-foreground">{operatorReason}</p>
                           </div>
                         ) : null}
                         {userReason ? (
-                          <div className="mt-3 rounded-2xl border border-white/8 bg-white/3 px-3 py-3">
-                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">{t('toolAuditUserReasonLabel')}</p>
+                          <div className="mt-3 rounded-xl border border-white/8 bg-white/3 px-3 py-3">
+                            <p className="text-xs font-semibold text-muted-foreground">{t('toolAuditUserReasonLabel')}</p>
                             <p className="mt-1 text-sm text-foreground">{userReason}</p>
                           </div>
                         ) : null}
                         {nextAction ? (
-                          <div className="mt-3 rounded-2xl border border-white/8 bg-white/3 px-3 py-3">
-                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">{t('toolAuditNextActionLabel')}</p>
+                          <div className="mt-3 rounded-xl border border-white/8 bg-white/3 px-3 py-3">
+                            <p className="text-xs font-semibold text-muted-foreground">{t('toolAuditNextActionLabel')}</p>
                             <p className="mt-1 text-sm text-foreground">{nextAction}</p>
                           </div>
                         ) : null}
@@ -582,7 +582,7 @@ export function AgentRunDetail({
 
 function StatCard({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
   return (
-    <div className="rounded-2xl border border-white/8 bg-white/4 px-4 py-3">
+    <div className="rounded-xl border border-white/8 bg-white/4 px-4 py-3">
       <div className="flex items-center gap-2 text-muted-foreground">
         {icon}
         <span className="text-xs">{label}</span>
@@ -594,7 +594,7 @@ function StatCard({ icon, label, value }: { icon: React.ReactNode; label: string
 
 function MetaCard({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-2xl border border-white/8 bg-white/3 px-4 py-3">
+    <div className="rounded-xl border border-white/8 bg-white/3 px-4 py-3">
       <p className="text-xs text-muted-foreground">{label}</p>
       <p className="mt-1 break-all text-sm font-medium text-foreground">{value}</p>
     </div>
@@ -617,7 +617,7 @@ function MemoryBucketCard({
   injectedIdsLabel: string;
 }) {
   return (
-    <div className="rounded-2xl border border-white/8 bg-white/3 px-4 py-3 text-sm text-muted-foreground">
+    <div className="rounded-xl border border-white/8 bg-white/3 px-4 py-3 text-sm text-muted-foreground">
       <p className="font-medium text-foreground">{label}</p>
       <div className="mt-2 space-y-1">
         <p>{queriedLabel}: {bucket.queriedCount}</p>
@@ -631,7 +631,7 @@ function MemoryBucketCard({
 
 function CriteriaList({ title, items }: { title: string; items: string[] }) {
   return (
-    <div className="rounded-2xl border border-white/8 bg-white/3 px-4 py-3">
+    <div className="rounded-xl border border-white/8 bg-white/3 px-4 py-3">
       <p className="text-sm font-medium text-foreground">{title}</p>
       <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
         {items.map((item) => <li key={item}>{item}</li>)}

--- a/apps/web/src/components/agents/agents-dashboard.tsx
+++ b/apps/web/src/components/agents/agents-dashboard.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
-import { Bot, Clock3, History, Pause, Play, RefreshCw, Rocket, TriangleAlert, User, Zap } from 'lucide-react';
+import { Bot, Clock3, History, Pause, Play, RefreshCw, Rocket, TriangleAlert, User, Zap, ClipboardList, RotateCw } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
@@ -78,10 +78,10 @@ function statusBadgeVariant(status: string) {
 
 function statusDotClass(status: string): string {
   switch (status) {
-    case 'ACTIVE': return 'bg-emerald-500';
+    case 'ACTIVE': return 'bg-success';
     case 'DEPLOY_FAILED': return 'bg-destructive';
     case 'SUSPENDED': return 'bg-muted-foreground/60';
-    case 'DEPLOYING': return 'bg-amber-500 animate-pulse';
+    case 'DEPLOYING': return 'bg-warning animate-pulse';
     default: return 'bg-muted-foreground/40';
   }
 }
@@ -364,12 +364,12 @@ export function AgentsDashboard({ deployments: initialDeployments, hideTopBar = 
                 </div>
                 <div className="grid gap-3 md:grid-cols-3">
                   {([
-                    { icon: '📋', titleKey: 'featureTaskTitle', bodyKey: 'featureTaskBody' },
-                    { icon: '⚡', titleKey: 'featureAutoTitle', bodyKey: 'featureAutoBody' },
-                    { icon: '🔁', titleKey: 'featureSkillTitle', bodyKey: 'featureSkillBody' },
-                  ] as const).map(({ icon, titleKey, bodyKey }) => (
+                    { Icon: ClipboardList, titleKey: 'featureTaskTitle', bodyKey: 'featureTaskBody' },
+                    { Icon: Zap, titleKey: 'featureAutoTitle', bodyKey: 'featureAutoBody' },
+                    { Icon: RotateCw, titleKey: 'featureSkillTitle', bodyKey: 'featureSkillBody' },
+                  ] as const).map(({ Icon, titleKey, bodyKey }) => (
                     <div key={titleKey} className="rounded-lg border border-border/60 bg-muted/20 p-4">
-                      <div className="text-2xl">{icon}</div>
+                      <Icon className="size-6 text-muted-foreground" />
                       <p className="mt-2 text-sm font-semibold text-foreground">{t(titleKey)}</p>
                       <p className="mt-1 text-xs text-muted-foreground">{t(bodyKey)}</p>
                     </div>
@@ -521,7 +521,7 @@ export function AgentsDashboard({ deployments: initialDeployments, hideTopBar = 
 
                       {latestFailure ? (
                         <div className="mt-3 rounded-md border border-border bg-muted/30 px-3 py-3">
-                          <p className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">{t('recentFailureTitle')}</p>
+                          <p className="text-[11px] font-medium text-muted-foreground">{t('recentFailureTitle')}</p>
                           <p className="mt-1 text-sm font-medium text-foreground">
                             {getFailureHeadline(latestFailure) ?? t('recentFailureFallback')}
                           </p>


### PR DESCRIPTION
## 한 줄
E-MODERN Track H(9번째·에이전트 UI) — 선생님 **"목업과 동일하게"**(fidelity 최우선·인박스 교훈). ⓐ canonical sweep 전건 + ⓑ de-boxy(stat grid·leaderboard). **기능 100% 동결**·8파일.

> story `9b0f560d` · 핸드오프 `e-modern-agent-redesign-fe-handoff` · 목업 `agent-redesign-mockup.png`(SSOT)

## ⓐ canonical sweep (전 화면·전건 0)
- **글리프**: agents-dashboard 📋⚡🔁 → `ClipboardList`/`Zap`/`RotateCw`.
- **하드코딩색 11건→신호 토큰**(다크 안전·doc 8 + 추가 3 적출): performance `emerald-500` 완료→`success`·`amber-400` trophy/rank→`warning`·rank tier(1=warning/2=muted/3=warning/70)·dashboard 상태 dot `bg-emerald/amber`→`success`/`warning`·run-detail audit `emerald-400/60`→`success/60`·hitl/requests/wizard `amber-100/200/300`→`warning`·hitl `pre bg-slate-950`→`muted`.
- **UPPERCASE tracking 35건→calm**(6파일).
- **rounded-2xl/3xl 카드 22건→xl**(run-detail 15·hitl 7·**모달 셸 0**=전부 카드/패널·§6 2패턴 예외 없음).

## ⓑ de-boxy layout (목업 핵심)
- **메인 stat**(performance-panel): 중첩 메트릭 박스 grid → **de-boxy dense grid**(`gap-px bg-border` divider·셀 `bg-background`·메트릭 `flex` 행·아이콘이 타입 success/Zap/Clock·목업①).
- **리더보드**: per-row border 카드 → `divide-y` 행(rank tier 토큰).

## 검증
- `tsc` 0 · `eslint` 0 · `next build` ✓ · canonical 위반 0(글리프/색/uppercase/rounded grep) · 신규 토큰 0.
- **기능 동결**: stat/velocity/leaderboard/roster/runs/hitl/deploy wizard/persona/api-key/messaging/tools — 핸들러·fetch 무변경·제거 0.

## ⚠️ 스코프 노트 (fidelity·정직)
ⓐ canonical은 **전 화면 전건 완료**. ⓑ de-boxy는 **가장 구체 명시된 stat grid(목업①)+leaderboard 적용**. roster/runs/run-detail/hitl de-boxy 밀도 + 5-sub layout은 **canonical 완료·layout 밀도는 §8 PO+유나 목업 이미지 1:1 픽셀서 구체 갭 확認 後 tune**(SSOT 이미지 없이 over-restructure 회피·canonical-pass≠layout-pass 교훈). 픽셀서 density 갭 나오면 1줄씩 즉시 정렬.

⚠️ **검증=PO+유나 둘 다 직접 목업 이미지 vs dev 1:1 픽셀**(눈으로 실 렌더·de-boxy 밀도·토큰 색·lucide·정렬·양테마·1008/390·known-state 데이터).

🤖 Generated with [Claude Code](https://claude.com/claude-code)