### PR TITLE
[SID:f5d69782] 설정 UI 갈아엎기 — canonical sweep 전건 + de-boxy profile (목업 타겟·HARD 픽셀 게이트)

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -816,7 +816,7 @@ export default function SettingsPage() {
         <div className={`shrink-0 border-r overflow-y-auto p-4 flex-col w-52 ${lnbOpen ? 'flex' : 'hidden'} md:flex`}>
           <h1 className="mb-4 px-2 text-sm font-semibold">{t('title')}</h1>
           <TabsList variant="line" className="w-full flex-col items-stretch">
-            <span className="px-2 pb-1 pt-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{t('myAccount')}</span>
+            <span className="px-2 pb-1 pt-1 text-[10px] font-medium text-muted-foreground/70">{t('myAccount')}</span>
             <TabsTrigger value="profile">
               <User className="h-4 w-4" />
               {t('tabProfile')}
@@ -830,7 +830,7 @@ export default function SettingsPage() {
               {t('tabNotifications')}
             </TabsTrigger>
 
-            <span className="px-2 pb-1 pt-4 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{t('projectSettings')}</span>
+            <span className="px-2 pb-1 pt-4 text-[10px] font-medium text-muted-foreground/70">{t('projectSettings')}</span>
             {currentProjectId && !HIDDEN_SETTINGS_TABS.has('ai') ? (
               <TabsTrigger value="ai">
                 <Bot className="h-4 w-4" />
@@ -858,7 +858,7 @@ export default function SettingsPage() {
 
             {adminChecked ? (
               <>
-                <span className="truncate px-2 pb-1 pt-4 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{t('organizationSettings')}</span>
+                <span className="truncate px-2 pb-1 pt-4 text-[10px] font-medium text-muted-foreground/70">{t('organizationSettings')}</span>
                 <TabsTrigger value="organization">
                   <FolderKanban className="h-4 w-4" />
                   {t('tabOrganization')}
@@ -877,7 +877,7 @@ export default function SettingsPage() {
 
             {adminChecked && isAdmin ? (
               <>
-                <span className="truncate px-2 pb-1 pt-4 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{t('billing')}</span>
+                <span className="truncate px-2 pb-1 pt-4 text-[10px] font-medium text-muted-foreground/70">{t('billing')}</span>
                 {isEEEnabled() && (
                   <TabsTrigger value="subscription">
                     <CreditCard className="h-4 w-4" />
@@ -898,7 +898,7 @@ export default function SettingsPage() {
             ) : null}
 
             {/* E-GHAPP: 연동 — 자체 섹션(결제와 분리·향후 slack/jira 등 통합 표준 위치)·서브라우트 `/settings/integrations`(install-callback 타깃·탭 아닌 발견성 진입점) */}
-            <span className="px-2 pb-1 pt-4 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{t('tabIntegrations')}</span>
+            <span className="px-2 pb-1 pt-4 text-[10px] font-medium text-muted-foreground/70">{t('tabIntegrations')}</span>
             <Link
               href="/settings/integrations"
               className="flex w-full items-center gap-2 px-3 py-2 text-sm text-muted-foreground transition hover:text-foreground"
@@ -907,7 +907,7 @@ export default function SettingsPage() {
               {t('tabIntegrations')}
             </Link>
 
-            <span className="px-2 pb-1 pt-4 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{t('dangerZone')}</span>
+            <span className="px-2 pb-1 pt-4 text-[10px] font-medium text-muted-foreground/70">{t('dangerZone')}</span>
             <TabsTrigger
               value="danger"
               className="text-destructive hover:text-destructive data-active:text-destructive data-active:bg-destructive/10"
@@ -1005,7 +1005,7 @@ export default function SettingsPage() {
                             <div key={category.key}>
                               {/* 카테고리 헤더 */}
                               <div className="mb-1 flex items-center justify-between">
-                                <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                <span className="text-xs font-semibold text-muted-foreground">
                                   {t(`notification_category_${category.key}`)}
                                 </span>
                                 <button

--- a/apps/web/src/components/settings/agent-api-keys-section.tsx
+++ b/apps/web/src/components/settings/agent-api-keys-section.tsx
@@ -254,11 +254,11 @@ export function AgentApiKeysSection({ projectId }: { projectId: string }) {
                 </div>
 
                 {freshKey ? (
-                  <div className="mb-3 rounded-md border border-yellow-300 bg-yellow-50 p-3 dark:border-yellow-700 dark:bg-yellow-950">
-                    <p className="mb-1 text-xs font-semibold text-yellow-800 dark:text-yellow-200">
+                  <div className="mb-3 rounded-md border border-warning/30 bg-warning/8 p-3">
+                    <p className="mb-1 text-xs font-semibold text-warning">
                       새 API Key — 지금만 표시됩니다. 복사해 두세요.
                     </p>
-                    <code className="block break-all text-xs text-yellow-900 dark:text-yellow-100">
+                    <code className="block break-all text-xs text-warning">
                       {freshKey.api_key}
                     </code>
                   </div>

--- a/apps/web/src/components/settings/ai-settings.tsx
+++ b/apps/web/src/components/settings/ai-settings.tsx
@@ -203,7 +203,7 @@ export function AiSettingsSection({ projectId }: { projectId: string }) {
             className="w-full rounded border px-3 py-2 text-sm"
           />
           {requiresNewApiKey && (
-            <p className="mt-1 text-xs text-amber-600">{t('aiApiKeyProviderChangeRequired')}</p>
+            <p className="mt-1 text-xs text-warning">{t('aiApiKeyProviderChangeRequired')}</p>
           )}
         </div>
 
@@ -244,7 +244,7 @@ export function AiSettingsSection({ projectId }: { projectId: string }) {
         </div>
 
         {error && <p className="text-xs text-destructive">{error}</p>}
-        {saved && <p className="text-xs text-green-500">{t('aiSettingsSaved')}</p>}
+        {saved && <p className="text-xs text-success">{t('aiSettingsSaved')}</p>}
 
         <button
           onClick={handleSave}

--- a/apps/web/src/components/settings/byom-key-management.tsx
+++ b/apps/web/src/components/settings/byom-key-management.tsx
@@ -234,7 +234,7 @@ export function ByomKeyManagement({ projectId }: { projectId: string }) {
           {/* Key input form */}
           <div className="space-y-3">
             <div>
-              <label className="mb-1.5 block text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
                 {t('providerLabel')}
               </label>
               <OperatorDropdownSelect
@@ -250,7 +250,7 @@ export function ByomKeyManagement({ projectId }: { projectId: string }) {
             </div>
 
             <div>
-              <label className="mb-1.5 block text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+              <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
                 {t('apiKeyLabel')}
               </label>
               <div className="flex gap-2">
@@ -280,7 +280,7 @@ export function ByomKeyManagement({ projectId }: { projectId: string }) {
 
             {requiresBaseUrl ? (
               <div>
-                <label className="mb-1.5 block text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
+                <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
                   {t('baseUrlLabel')}
                 </label>
                 <OperatorInput
@@ -343,8 +343,8 @@ export function ByomKeyManagement({ projectId }: { projectId: string }) {
       {/* Delete confirmation dialog */}
       {showDeleteConfirm ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
-          <div className="w-full max-w-sm rounded-3xl border border-white/10 bg-muted p-6 shadow-xl backdrop-blur-xl">
-            <h3 className="text-lg font-semibold text-rose-100">{t('deleteConfirmTitle')}</h3>
+          <div className="w-full max-w-sm rounded-2xl border border-white/10 bg-muted p-6 shadow-xl backdrop-blur-xl">
+            <h3 className="text-lg font-semibold text-destructive">{t('deleteConfirmTitle')}</h3>
             <p className="mt-2 text-sm text-muted-foreground">{t('deleteConfirmDesc')}</p>
             <div className="mt-6 flex gap-3">
               <Button variant="glass" className="flex-1" onClick={() => setShowDeleteConfirm(false)}>

--- a/apps/web/src/components/settings/mcp-connection-settings.tsx
+++ b/apps/web/src/components/settings/mcp-connection-settings.tsx
@@ -200,7 +200,7 @@ export function McpConnectionSettings({ projectId }: { projectId: string }) {
               const isOAuth = connection.authStrategy === 'oauth';
               const canSave = !isOAuth && Boolean(secretDrafts[connection.serverKey]?.trim());
               return (
-                <div key={connection.serverKey} className="rounded-3xl border border-white/10 bg-muted/45 p-4">
+                <div key={connection.serverKey} className="rounded-xl border border-white/10 bg-muted/45 p-4">
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="space-y-2">
                       <div className="flex items-center gap-2">
@@ -274,7 +274,7 @@ export function McpConnectionSettings({ projectId }: { projectId: string }) {
           </div>
         )}
 
-        <div className="rounded-3xl border border-dashed border-white/10 p-4">
+        <div className="rounded-xl border border-dashed border-white/10 p-4">
           <div className="space-y-1">
             <h3 className="text-sm font-semibold text-foreground">{t('customRequestTitle')}</h3>
             <p className="text-sm text-muted-foreground">{t('customRequestDescription')}</p>

--- a/apps/web/src/components/settings/my-profile-section.tsx
+++ b/apps/web/src/components/settings/my-profile-section.tsx
@@ -67,8 +67,8 @@ export function MyProfileSection() {
         </div>
       </SectionCardHeader>
       <SectionCardBody className="space-y-4">
-        <div className="grid gap-3 text-sm">
-          <div className="flex items-center gap-4">
+        <div className="divide-y divide-border text-sm">
+          <div className="flex items-center gap-4 py-2.5">
             <span className="w-20 shrink-0 text-muted-foreground">{t('profileName')}</span>
             {editing ? (
               <div className="flex items-center gap-2">
@@ -95,11 +95,11 @@ export function MyProfileSection() {
             )}
           </div>
           {error && <p className="text-xs text-destructive">{error}</p>}
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-4 py-2.5">
             <span className="w-20 shrink-0 text-muted-foreground">{t('profileEmail')}</span>
             <span className="text-muted-foreground">{profile.email ?? '—'}</span>
           </div>
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-4 py-2.5">
             <span className="w-20 shrink-0 text-muted-foreground">{t('profileRole')}</span>
             <span>{profile.role}</span>
           </div>

--- a/apps/web/src/components/settings/set-password-section.tsx
+++ b/apps/web/src/components/settings/set-password-section.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { Check, Circle } from 'lucide-react';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 
 function checkPasswordRules(pw: string) {
@@ -90,7 +91,7 @@ export function SetPasswordSection() {
             placeholder="New password"
             autoComplete="new-password"
             className={`w-full rounded-lg border px-4 py-2 text-sm text-foreground bg-background focus:outline-none focus:ring-2 focus:ring-primary ${
-              showRules && !isPasswordValid ? 'border-rose-400' : 'border-border'
+              showRules && !isPasswordValid ? 'border-destructive' : 'border-border'
             }`}
             value={password}
             onChange={(e) => { setPassword(e.target.value); setTouched(true); }}
@@ -101,7 +102,7 @@ export function SetPasswordSection() {
             placeholder="Confirm new password"
             autoComplete="new-password"
             className={`w-full rounded-lg border px-4 py-2 text-sm text-foreground bg-background focus:outline-none focus:ring-2 focus:ring-primary ${
-              touched && confirm && !isConfirmValid ? 'border-rose-400' : 'border-border'
+              touched && confirm && !isConfirmValid ? 'border-destructive' : 'border-border'
             }`}
             value={confirm}
             onChange={(e) => setConfirm(e.target.value)}
@@ -112,7 +113,7 @@ export function SetPasswordSection() {
             <ul className="space-y-1 text-xs">
               <PasswordRuleItem met={rules.length} label="At least 8 characters" />
               <li className={`flex items-center gap-1.5 ${categoriesMet >= 3 ? 'text-success' : 'text-muted-foreground'}`}>
-                <span>{categoriesMet >= 3 ? '✓' : '○'}</span>
+                {categoriesMet >= 3 ? <Check className="size-3.5 shrink-0" /> : <Circle className="size-3.5 shrink-0" />}
                 <span>At least 3 of: uppercase, lowercase, digit, special character ({categoriesMet}/3)</span>
               </li>
             </ul>
@@ -138,7 +139,7 @@ export function SetPasswordSection() {
 function PasswordRuleItem({ met, label }: { met: boolean; label: string }) {
   return (
     <li className={`flex items-center gap-1.5 ${met ? 'text-success' : 'text-muted-foreground'}`}>
-      <span>{met ? '✓' : '○'}</span>
+      {met ? <Check className="size-3.5 shrink-0" /> : <Circle className="size-3.5 shrink-0" />}
       <span>{label}</span>
     </li>
   );

--- a/apps/web/src/components/settings/set-password-section.tsx
+++ b/apps/web/src/components/settings/set-password-section.tsx
@@ -110,9 +110,9 @@ export function SetPasswordSection() {
           />
 
           {showRules && (
-            <ul className="space-y-1 text-xs">
+            <ul className="divide-y divide-border text-xs">
               <PasswordRuleItem met={rules.length} label="At least 8 characters" />
-              <li className={`flex items-center gap-1.5 ${categoriesMet >= 3 ? 'text-success' : 'text-muted-foreground'}`}>
+              <li className={`flex items-center gap-1.5 py-1.5 ${categoriesMet >= 3 ? 'text-success' : 'text-muted-foreground'}`}>
                 {categoriesMet >= 3 ? <Check className="size-3.5 shrink-0" /> : <Circle className="size-3.5 shrink-0" />}
                 <span>At least 3 of: uppercase, lowercase, digit, special character ({categoriesMet}/3)</span>
               </li>
@@ -138,7 +138,7 @@ export function SetPasswordSection() {
 
 function PasswordRuleItem({ met, label }: { met: boolean; label: string }) {
   return (
-    <li className={`flex items-center gap-1.5 ${met ? 'text-success' : 'text-muted-foreground'}`}>
+    <li className={`flex items-center gap-1.5 py-1.5 ${met ? 'text-success' : 'text-muted-foreground'}`}>
       {met ? <Check className="size-3.5 shrink-0" /> : <Circle className="size-3.5 shrink-0" />}
       <span>{label}</span>
     </li>

--- a/apps/web/src/components/settings/slack-integration-settings.tsx
+++ b/apps/web/src/components/settings/slack-integration-settings.tsx
@@ -250,7 +250,7 @@ export function SlackIntegrationSettingsSection() {
               <div className="border-b border-white/8 px-5 py-4">
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div className="space-y-1">
-                    <p className="text-xs uppercase tracking-[0.24em] text-muted-foreground">{t('workspaceLabel')}</p>
+                    <p className="text-xs text-muted-foreground">{t('workspaceLabel')}</p>
                     <h3 className="text-lg font-semibold text-foreground">
                       {data.workspace?.team_name ?? t('workspaceDisconnected')}
                     </h3>
@@ -273,15 +273,15 @@ export function SlackIntegrationSettingsSection() {
               </div>
               <div className="grid gap-3 px-5 py-4 sm:grid-cols-3">
                 <div className="rounded-2xl border border-white/8 bg-black/10 px-4 py-3">
-                  <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">{t('metricChannels')}</p>
+                  <p className="text-xs text-muted-foreground">{t('metricChannels')}</p>
                   <p className="mt-2 text-2xl font-semibold text-foreground">{data.channels.length}</p>
                 </div>
                 <div className="rounded-2xl border border-white/8 bg-black/10 px-4 py-3">
-                  <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">{t('metricMapped')}</p>
+                  <p className="text-xs text-muted-foreground">{t('metricMapped')}</p>
                   <p className="mt-2 text-2xl font-semibold text-foreground">{data.mappings.length}</p>
                 </div>
                 <div className="rounded-2xl border border-white/8 bg-black/10 px-4 py-3">
-                  <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">{t('metricDirty')}</p>
+                  <p className="text-xs text-muted-foreground">{t('metricDirty')}</p>
                   <p className="mt-2 text-2xl font-semibold text-foreground">{allDirtyChannels.length}</p>
                 </div>
               </div>
@@ -290,7 +290,7 @@ export function SlackIntegrationSettingsSection() {
             <GlassPanel className="border-white/8 bg-muted/40 p-5">
               <div className="space-y-3">
                 <div className="flex items-center gap-2 text-sm font-medium text-foreground">
-                  <CheckCircle2 className="size-4 text-emerald-300" />
+                  <CheckCircle2 className="size-4 text-success" />
                   {t('actionPanelTitle')}
                 </div>
                 <p className="text-sm text-muted-foreground">{t('actionPanelDescription')}</p>
@@ -328,7 +328,7 @@ export function SlackIntegrationSettingsSection() {
           {loading ? (
             <div className="grid gap-3">
               {[1, 2, 3].map((item) => (
-                <div key={item} className="h-28 animate-pulse rounded-3xl border border-white/8 bg-muted/45" />
+                <div key={item} className="h-28 animate-pulse rounded-xl border border-white/8 bg-muted/45" />
               ))}
             </div>
           ) : data.status === 'disconnected' ? (
@@ -384,7 +384,7 @@ export function SlackIntegrationSettingsSection() {
 
                       <div className="grid flex-1 gap-3 xl:max-w-xl xl:grid-cols-[minmax(0,1fr)_auto]">
                         <div className="space-y-2">
-                          <label className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{t('selectProjectLabel')}</label>
+                          <label className="text-xs text-muted-foreground">{t('selectProjectLabel')}</label>
                           <OperatorDropdownSelect
                             value={selectedProjectId}
                             onValueChange={(v) => setSelectedProjects((prev) => ({ ...prev, [channel.id]: v }))}
@@ -461,7 +461,7 @@ export function SlackIntegrationSettingsSection() {
       ) : null}
 
       <Dialog open={Boolean(remapConflict)} onOpenChange={(open) => { if (!open) setRemapConflict(null); }}>
-        <DialogContent className="max-w-lg rounded-3xl border border-white/10 bg-muted text-foreground shadow-[0_30px_80px_rgba(0,0,0,0.42)]">
+        <DialogContent className="max-w-lg rounded-xl border border-white/10 bg-muted text-foreground shadow-[0_30px_80px_rgba(0,0,0,0.42)]">
           <DialogHeader>
             <DialogTitle>{t('remapDialogTitle')}</DialogTitle>
             <DialogDescription className="text-muted-foreground">

--- a/apps/web/src/components/settings/standup-deadline-section.tsx
+++ b/apps/web/src/components/settings/standup-deadline-section.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { Check } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 
@@ -50,7 +51,7 @@ export function StandupDeadlineSection({ projectId }: Props) {
         <SectionCardBody>
           <div className="flex items-center gap-4">
             <div className="flex flex-col gap-1">
-              <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">{t('standupDeadline')}</label>
+              <label className="text-xs font-medium text-muted-foreground">{t('standupDeadline')}</label>
               <input
                 type="time"
                 value={deadline}
@@ -59,7 +60,7 @@ export function StandupDeadlineSection({ projectId }: Props) {
               />
             </div>
             <Button size="sm" className="mt-4" onClick={handleSave} disabled={saving || !projectId}>
-              {saved ? '✓ 저장됨' : saving ? '저장 중...' : t('save')}
+              {saved ? <><Check className="size-4" />저장됨</> : saving ? '저장 중...' : t('save')}
             </Button>
           </div>
         </SectionCardBody>

--- a/apps/web/src/components/settings/theme-settings.tsx
+++ b/apps/web/src/components/settings/theme-settings.tsx
@@ -2,6 +2,7 @@
 
 import { useTheme } from 'next-themes';
 import { useEffect, useState, startTransition } from 'react';
+import { Palette } from 'lucide-react';
 import { OperatorDropdownSelect } from '@/components/ui/operator-dropdown-select';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 
@@ -24,7 +25,7 @@ export function ThemeSettings() {
     <SectionCard>
       <SectionCardHeader>
         <div className="space-y-1">
-          <h2 className="text-base font-semibold text-foreground">🎨 테마 설정</h2>
+          <h2 className="flex items-center gap-1.5 text-base font-semibold text-foreground"><Palette className="size-4" />테마 설정</h2>
           <p className="text-sm text-muted-foreground">라이트 모드, 다크 모드 또는 시스템 설정을 따를 수 있습니다.</p>
         </div>
       </SectionCardHeader>

--- a/apps/web/src/components/settings/two-factor-section.tsx
+++ b/apps/web/src/components/settings/two-factor-section.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { ShieldCheck } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 
@@ -96,7 +97,7 @@ export function TwoFactorSection() {
     <SectionCard>
       <SectionCardHeader>
         <div className="space-y-1">
-          <h2 className="text-base font-semibold text-foreground">🔐 {t('twoFactorTitle')}</h2>
+          <h2 className="flex items-center gap-1.5 text-base font-semibold text-foreground"><ShieldCheck className="size-4" />{t('twoFactorTitle')}</h2>
           <p className="text-sm text-muted-foreground">
             {state === 'enabled' ? t('twoFactorActive') : t('twoFactorDescription')}
           </p>
@@ -104,7 +105,7 @@ export function TwoFactorSection() {
       </SectionCardHeader>
       <SectionCardBody className="space-y-4">
         {message && (
-          <p className={`text-sm ${message.type === 'success' ? 'text-emerald-400' : 'text-rose-400'}`}>{message.text}</p>
+          <p className={`text-sm ${message.type === 'success' ? 'text-success' : 'text-destructive'}`}>{message.text}</p>
         )}
 
         {state === 'disabled' && (
@@ -157,14 +158,14 @@ export function TwoFactorSection() {
               inputMode="numeric"
               maxLength={6}
               placeholder="000000"
-              className="w-full rounded-lg border border-border bg-background px-4 py-2 text-center font-mono tracking-widest text-foreground focus:outline-none focus:ring-2 focus:ring-rose-500"
+              className="w-full rounded-lg border border-border bg-background px-4 py-2 text-center font-mono tracking-widest text-foreground focus:outline-none focus:ring-2 focus:ring-destructive"
               value={otpCode}
               onChange={(e) => setOtpCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
             />
             <button
               onClick={handleDisable}
               disabled={busy || otpCode.length !== 6}
-              className="rounded-lg border border-rose-500/40 px-4 py-2 text-sm font-medium text-rose-400 hover:border-rose-400 hover:text-rose-300 disabled:opacity-50"
+              className="rounded-lg border border-destructive px-4 py-2 text-sm font-medium text-destructive hover:border-destructive hover:text-destructive disabled:opacity-50"
             >
               {busy ? '...' : t('twoFactorDisable')}
             </button>

--- a/apps/web/src/components/settings/workflow-active-line-view.tsx
+++ b/apps/web/src/components/settings/workflow-active-line-view.tsx
@@ -47,7 +47,7 @@ export function WorkflowActiveLineView({ projectId }: { projectId?: string | nul
     <div className="space-y-3 rounded-xl border border-border bg-muted/10 p-3">
       <div className="flex items-center gap-2">
         <GitBranch className="size-4 shrink-0 text-muted-foreground" />
-        <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{t('simActiveLine')}</p>
+        <p className="text-[11px] font-medium text-muted-foreground">{t('simActiveLine')}</p>
         <select
           value={entityType}
           onChange={(e) => setEntityType(e.target.value)}

--- a/apps/web/src/components/settings/workflow-policy-simulator-section.tsx
+++ b/apps/web/src/components/settings/workflow-policy-simulator-section.tsx
@@ -127,7 +127,7 @@ export function WorkflowPolicySimulatorSection() {
           </div>
 
           <div className="space-y-1">
-            <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{t('simAxisRouting')}</p>
+            <p className="text-[11px] font-medium text-muted-foreground">{t('simAxisRouting')}</p>
             {result.routing_path.length ? (
               <ul className="space-y-0.5">
                 {result.routing_path.map((s, i) => (
@@ -143,7 +143,7 @@ export function WorkflowPolicySimulatorSection() {
           </div>
 
           <div className="space-y-1">
-            <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{t('simAxisGates')}</p>
+            <p className="text-[11px] font-medium text-muted-foreground">{t('simAxisGates')}</p>
             {result.gates.length ? (
               <div className="flex flex-wrap gap-1.5">
                 {result.gates.map((g, i) => {
@@ -161,7 +161,7 @@ export function WorkflowPolicySimulatorSection() {
           </div>
 
           <div className="space-y-1">
-            <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{t('simAxisTrust')}</p>
+            <p className="text-[11px] font-medium text-muted-foreground">{t('simAxisTrust')}</p>
             <div className="flex flex-wrap items-center gap-2">
               {decisionMeta ? <Badge variant={decisionMeta.variant}>{t(decisionMeta.labelKey)}</Badge> : null}
               <span className="text-xs text-muted-foreground">

--- a/apps/web/src/components/settings/workflow-template-gallery-section.tsx
+++ b/apps/web/src/components/settings/workflow-template-gallery-section.tsx
@@ -254,7 +254,7 @@ export function WorkflowTemplateGallerySection({
             })}
 
             {applyResult && (
-              <p className={`text-xs ${applyResult.ok ? 'text-green-600 dark:text-green-400' : 'text-destructive'}`}>
+              <p className={`text-xs ${applyResult.ok ? 'text-success' : 'text-destructive'}`}>
                 {applyResult.message}
               </p>
             )}


### PR DESCRIPTION
## 한 줄
E-MODERN Track I(10번째·마지막) — 선생님 **"목업↔구현 딴판" 강한 불만 → HARD 픽셀 done-gate**. HYBRID(canonical-primary + moderate de-boxy). **기능 100% 동결**·14파일.

> story `f5d69782` · 핸드오프 `e-modern-settings-redesign-fe-handoff` · 목업 `settings-redesign-mockup.png`(SSOT)

## §1 canonical sweep (전 화면·전건 0)
- **글리프 4→lucide**: theme 🎨→`Palette`·two-factor 🔐→`ShieldCheck`·set-password ✓/○→`Check`/`Circle`·standup ✓→`Check`.
- **UPPERCASE tracking 20건→calm**(사이드바 header 6+notif+standup+slack/byom/workflow).
- **하드코딩색 11건→신호 토큰**(다크 안전): emerald/green→`success`·rose→`destructive`·amber/yellow→`warning`. ⚠️ agent-api-keys callout `bg-yellow-50`이 sed로 solid `bg-warning`된 것 → `bg-warning/8` 틴트 교정·redundant `dark:` 토큰 정리.
- **rounded-3xl→모달 2패턴**: byom 모달 셸(hand-rolled 오버레이)→`rounded-2xl`·slack `DialogContent`+skeleton→`rounded-xl`·mcp 카드→`rounded-xl`.

## §2 de-boxy moderate (목업 핵심)
- **profile**(my-profile-section): 정보 필드 grid → **divider 행**(`divide-y`·`py-2.5`·목업①).
- ⚠️ **org-members/notif/webhook de-boxy**: `MemberRow`=**공유 컴포넌트**(타 surface 영향)라 신중 — HARD 픽셀 게이트서 PO+유나 목업 1:1 대조 後 구체 density 갭 tune(shared 컴포넌트 break 회피).

## 검증
- `tsc` 0 · `eslint` **내 diff error 0** · `next build` ✓ · canonical 위반 0 · 신규 토큰 0 · 기능 동결(핸들러/fetch/state 제거 0).
- ⚠️ `lint` 경고 22 = **pre-existing**(page.tsx 미사용 핸들러 handleRevokeInvite 등·내 sed는 className만·내 diff 무관).

## ⛔ HARD 픽셀 done-gate (이번 핵심)
머지→dev 배포→**PO+유나 둘 다 목업 이미지 vs dev 라이브 1:1 실 렌더 픽셀**(눈으로·canonical-pass≠layout-pass·DOM 측정 0). **매치 전 done/prod 금지·딴판이면 즉시 재작업(post-hoc 아님)·딴판 0 목표.** de-boxy density 갭 콜 주면 즉시 재작업(org-members/notif/webhook 포함·shared 컴포넌트는 신중 parametrize).

🤖 Generated with [Claude Code](https://claude.com/claude-code)