### PR TITLE
[SID:f5d69782] HARD 픽셀 딴판 fix: 조직 구성원/초대 리스트 박시→de-boxy divide-y

### DIFF
--- a/apps/web/src/components/settings/org-members-section.tsx
+++ b/apps/web/src/components/settings/org-members-section.tsx
@@ -284,7 +284,10 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
         <SectionCardHeader>
           <h2 className="text-base font-semibold text-foreground">멤버 ({members.length})</h2>
         </SectionCardHeader>
-        <SectionCardBody className="space-y-2">
+        <SectionCardBody>
+          {/* HARD 픽셀 딴판 fix: 박시 per-member 카드 → project-access와 동일 de-boxy divide-y(공유 MemberRow flat·양 surface 정합) */}
+          {members.length > 0 ? (
+          <div className="divide-y divide-border overflow-hidden rounded-md border border-border">
           {members.map((member) => {
             const isThisOwner = member.role === 'owner';
             const canEdit = isOwner && !isThisOwner;
@@ -293,6 +296,7 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
                 key={member.id}
                 name={member.name}
                 email={member.email}
+                className="border-0 rounded-none bg-transparent"
                 meta={member.joined_at ? `${new Date(member.joined_at).toLocaleDateString('ko-KR')} 가입` : undefined}
                 actions={
                   <>
@@ -319,7 +323,8 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
               />
             );
           })}
-          {members.length === 0 && (
+          </div>
+          ) : (
             <p className="text-sm text-muted-foreground">멤버가 없습니다.</p>
           )}
         </SectionCardBody>
@@ -347,11 +352,13 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
           <SectionCardHeader>
             <h2 className="text-base font-semibold text-foreground">초대 대기 ({invites.length})</h2>
           </SectionCardHeader>
-          <SectionCardBody className="space-y-2">
+          <SectionCardBody>
+            <div className="divide-y divide-border overflow-hidden rounded-md border border-border">
             {invites.map((invite) => (
               <MemberRow
                 key={invite.id}
                 name={invite.email}
+                className="border-0 rounded-none bg-transparent"
                 meta={`${invite.role} · 만료: ${new Date(invite.expires_at).toLocaleDateString('ko-KR')}`}
                 emphasis="subtle"
                 actions={
@@ -383,6 +390,7 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
                 }
               />
             ))}
+            </div>
           </SectionCardBody>
         </SectionCard>
       )}


### PR DESCRIPTION
## 한 줄
#1704 머지 後 **PO+유나 HARD 픽셀 done-gate가 딴판 1건 적출**(done-gate 작동) — `org-members-section` 멤버/초대 리스트가 **박시**(per-member 카드)인데 목업+`project-access`는 **de-boxy divide-y 행**. 근본=org-members가 #1704 초기서 누락(핸드오프 §3 핵심).

> story `f5d69782` · #1704 후속(HARD 픽셀 딴판 재작업·post-hoc 아님) · 1파일

## fix (project-access 동일 패턴)
- 멤버 리스트 + 초대 대기 리스트 컨테이너 `space-y-2` → **`divide-y divide-border overflow-hidden rounded-md border border-border`**(단일 외곽선 + divider 행).
- `MemberRow` `className="border-0 rounded-none bg-transparent"`(기본 `rounded-md border bg-muted/30` flatten·`project-access`와 동형).
- ⭐ **공유 `MemberRow` 컴포넌트 자체 미변경** → `project-access` 무영향(org-members↔project-access 양 surface 정합·shared break 0). 빈 상태 조건부 보존.

## 검증
- `tsc` 0 · `eslint` 0 · `next build` ✓ · 기능 동결(역할 변경/제거/초대 핸들러 무변경·className만)·1파일 +11/-3.

⚠️ **HARD 픽셀 done-gate 재-픽셀**: 머지→dev→PO+유나 둘 다 조직 구성원/초대 리스트 목업 vs dev 1:1(de-boxy divider 행·project-access와 동일 밀도) + project-access 양 surface 무회귀 확認.

🤖 Generated with [Claude Code](https://claude.com/claude-code)