### PR TITLE
[FE-fix] 채팅 입력창 밀림 — 메시지 min-h-0 + 입력창 flex-shrink-0 (presence ON 회귀)

### DIFF
--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -353,7 +353,7 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
 
   return (
     <div
-      className="border-t border-border/80 bg-background px-3 py-2"
+      className="flex-shrink-0 border-t border-border/80 bg-background px-3 py-2"
       onDragOver={(e) => e.preventDefault()}
       onDrop={handleDrop}
     >

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -403,7 +403,7 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
           {/* Messages */}
           <div
             ref={scrollRef}
-            className="relative flex-1 overflow-y-auto px-4 py-3"
+            className="relative min-h-0 flex-1 overflow-y-auto px-4 py-3"
             onTouchStart={handleTouchStart}
             onTouchMove={handleTouchMove}
             onTouchEnd={() => void handleTouchEnd()}


### PR DESCRIPTION
## 한 줄
선생님 제보 — **presence 패널 ON 시 입력창이 스크롤로 밀려 사라짐**(OFF 정상). flex-col 레이아웃 안정화로 fix(메시지만 스크롤·입력 고정).

> 채팅 입력창 회귀 fix · PO 직통(845a34c0) · 2파일

## 근본
- 메시지 스크롤 컨테이너 `flex-1 overflow-y-auto`에 **`min-h-0` 부재** → flex-1 자식이 콘텐츠 높이로 grow(컬럼 내 스크롤 안 되고 커짐) → 입력창을 viewport 밖으로 밀어냄.
- `ChatInput` root에 **`flex-shrink-0` 부재** → flex 자식 기본 축소.

## fix (PO 방향: 메시지만 스크롤·입력 고정)
- `chat-view` 메시지 컨테이너: `flex-1 overflow-y-auto` → **`min-h-0 flex-1 overflow-y-auto`**.
- `chat-input` root: **`flex-shrink-0`** 추가(composer는 어디서든 축소/밀림 금지).
- 결과: `[메시지 flex-1 min-h-0 스크롤][typing shrink-0][입력 shrink-0]` — 비-메시지 전부 고정·메시지만 스크롤·presence ON/OFF 무관 입력창 항상 보임.

## 검증
- `tsc` 0 · `eslint` 0 · `next build` ✓ · 시각/동작 무변경(레이아웃 안정화 className만·2줄).

⚠️ **라이브**(머지→dev): presence 패널 ON+긴 대화 스크롤 → 입력창 하단 고정 유지(밀림 0)·메시지만 스크롤·OFF 회귀 0·모바일/데스크탑.

🤖 Generated with [Claude Code](https://claude.com/claude-code)