### PR TITLE
[SID:5a99842b] 단일경로 전달 — 메시지 경로 SSE↔webhook 게이팅 통일 + backfill landmine 박멸

### DIFF
--- a/apps/web/src/app/api/cron/expire-stale-events/route.ts
+++ b/apps/web/src/app/api/cron/expire-stale-events/route.ts
@@ -1,0 +1,9 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function GET(request: Request) {
+  const _r = await proxyToFastapi(request, '/api/v2/internal/cron/expire-stale-events');
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess({ ok: true });
+  return apiSuccess(await _r.json());
+}

--- a/backend/alembic/versions/0136_event1config_backlog_drain.py
+++ b/backend/alembic/versions/0136_event1config_backlog_drain.py
@@ -1,0 +1,57 @@
+"""E-EVENT-1CONFIG: webhook-covered agent 의 backlog pending agent-event 1회 drain.
+
+배경(backfill landmine): 기존 ACK 는 acked_seq 만 전진시키고 Event.status 를 안 건드려,
+agent SSE 이벤트가 status='pending' 으로 영구 잔존해 왔다. 동반 코드 변경 이후 ACK 는 ACK 한
+이벤트를 delivered 마킹하지만, **이미 webhook 으로 전환한 agent**(활성 member-bound webhook
+보유)는 더 이상 SSE 로 접속·ACK 하지 않으므로 그들의 기존 pending 이벤트는 영영 retire 되지
+않는다 → restart backfill 폭주의 원천. 이 1회 drain 이 그 백로그를 새 ACK 거동과 **동형**으로
+delivered 마킹해 cleanup(expire-stale cron) 회수 대상으로 만든다.
+
+스코프(런타임 SSE-skip 판정과 동일 predicate):
+  status='pending' AND recipient_type='agent' AND recipient_seq IS NOT NULL(=agent SSE 이벤트)
+  AND 수신자가 활성 member-bound webhook 보유(org+member 일치·project 독립).
+비-webhook agent 는 SSE 로 정상 ACK 하므로 건드리지 않는다(그들 백로그는 ACK retire + 30일
+expire-stale 가 처리).
+
+멱등: status='pending' 행만 전이 → 재실행 시 대상 0(no-op). fresh DB: 매칭 0 → no-op.
+fresh-runnable: 순수 UPDATE·스키마 변경 없음.
+롤백: 데이터 전이(backlog drain)는 비가역 — no-op downgrade (0099 동일 정책).
+
+Revision ID: 0136
+Revises: 0135
+Create Date: 2026-06-25
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0136"
+down_revision = "0135"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE events e
+        SET status = 'delivered',
+            delivered_at = COALESCE(e.delivered_at, NOW())
+        WHERE e.status = 'pending'
+          AND e.recipient_type = 'agent'
+          AND e.recipient_seq IS NOT NULL
+          AND EXISTS (
+              SELECT 1
+              FROM webhook_configs w
+              WHERE w.member_id = e.recipient_id
+                AND w.org_id = e.org_id
+                AND w.is_active = true
+                AND w.member_id IS NOT NULL
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    # backlog drain(데이터 전이)은 비가역 — no-op (0099·0081 동일 정책).
+    pass

--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -486,5 +486,22 @@ async def ack_event(
         existing.acked_seq = body.seq
         existing.updated_at = datetime.now(timezone.utc)
 
+    # E-EVENT-1CONFIG(backfill landmine 박멸): ACK 가 acked_seq 만 전진시키고 Event.status 를
+    # 안 건드리면 agent SSE 이벤트가 status='pending' 으로 영구 잔존한다 — cleanup(events.py
+    # expire-stale)은 status='delivered' 만 삭제하므로 영영 회수 불가 + 미-ack 누적. ACK 한
+    # 이벤트(recipient_seq <= seq)를 같은 트랜잭션서 delivered 마킹해 cleanup 회수 대상이 되게
+    # 한다. recipient_seq IS NOT NULL = agent SSE 이벤트만(human 이벤트는 seq 없음). status=
+    # 'pending' 만 전이 → 이미 delivered/expired 는 무변경(idempotent·재-ack no-op).
+    await db.execute(
+        update(Event)
+        .where(
+            Event.recipient_id == agent_id,
+            Event.recipient_seq.isnot(None),
+            Event.recipient_seq <= body.seq,
+            Event.status == "pending",
+        )
+        .values(status="delivered", delivered_at=datetime.now(timezone.utc))
+    )
+
     await db.commit()
     return {"acked_seq": body.seq}

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -26,6 +26,7 @@ from app.services import chat_presence
 from app.services.agent_runtime import supports_deterministic_command
 from app.services.command_classifier import classify_command
 from app.services.event_seq import assign_recipient_seq
+from app.services.webhook_targeting import active_webhook_member_ids
 from app.services.member_resolver import (
     ResolvedMember,
     filter_org_member_ids,
@@ -292,10 +293,38 @@ async def _dispatch_conversation_event(
     )).all()
     member_type_map = {r[0]: r[1] for r in member_rows}
 
+    # E-EVENT-1CONFIG(이중수신 박멸): 활성 member-bound webhook 보유 agent recipient는 SSE
+    # enqueue 스킵 — webhook 경로(deliver_conversation_message_webhook)가 동일 메시지를 전달하므로
+    # (dispatch_notification 과 대칭). 판정 스코프는 그 전달 predicate 와 정확히 동일:
+    #   authorized = mentioned 우선·없으면 participants(sender 제외) / member-bound / **project 독립**.
+    # member_id=null 브로드캐스트는 멤버 세션 채널이 아니라 공유 엔드포인트 → skip 근거 제외
+    # (active_webhook_member_ids 가 member_id IS NOT NULL 만 본다). 비-mentioned participant 는
+    # webhook 미커버 → SSE 유지(silent loss 0).
+    mentioned_authorized = {m for m in (msg.mentioned_ids or []) if m is not None}
+    webhook_authorized = (
+        (mentioned_authorized & participant_ids) if mentioned_authorized else participant_ids
+    )
+    agent_webhook_candidates = {
+        pid for pid in participant_ids
+        if member_type_map.get(pid) == "agent" and pid in webhook_authorized
+    }
+    webhook_covered = await active_webhook_member_ids(db, org_id, agent_webhook_candidates)
+
     events_to_push: list[tuple[str, Event]] = []
     _set_working_any = False
     for pid in sorted(participant_ids):  # deadlock 방지: 일관 락 순서
         m_type = member_type_map.get(pid, "human")
+        is_agent = m_type == "agent"
+        # 1aeecdde P2: agent recipient 에게 메시지가 dispatch = 답장 생성 시작 → working emit.
+        # 그 agent 가 reply 를 보내면 send_message 에서 clear, 안 보내면 TTL 자동 소멸(ephemeral).
+        # webhook-covered agent 도 webhook 으로 받아 답장하므로 working 표시는 유지한다.
+        if is_agent:
+            chat_presence.set_working(str(conversation.id), str(pid))
+            _set_working_any = True
+        # webhook-covered agent → SSE Event/seq/push 스킵(이중수신 박멸). human Event 는 무변경
+        # (웹 UI SSE = events.py status 별경로·FORK2).
+        if is_agent and pid in webhook_covered:
+            continue
         event = Event(
             project_id=conversation.project_id,
             org_id=org_id,
@@ -310,11 +339,6 @@ async def _dispatch_conversation_event(
         )
         db.add(event)
         events_to_push.append((str(pid), event))
-        # 1aeecdde P2: agent recipient 에게 메시지가 dispatch = 답장 생성 시작 → working emit.
-        # 그 agent 가 reply 를 보내면 send_message 에서 clear, 안 보내면 TTL 자동 소멸(ephemeral).
-        if m_type == "agent":
-            chat_presence.set_working(str(conversation.id), str(pid))
-            _set_working_any = True
 
     # flush로 event.id 확보
     await db.flush()
@@ -356,9 +380,20 @@ async def _dispatch_mention_events(
     )).all()
     member_type_map = {r[0]: r[1] for r in member_rows}
 
+    # E-EVENT-1CONFIG(이중수신 박멸): 멘션 대상 = webhook authorized set 그 자체(mentioned 우선
+    # 규칙의 mentioned 측). 활성 member-bound webhook 보유 agent 는 SSE(conversation:mention)
+    # 스킵 — webhook 이 동일 메시지를 전달. member_id=null 브로드캐스트는 제외(SSOT 동일).
+    agent_webhook_candidates = {
+        pid for pid in mention_targets if member_type_map.get(pid) == "agent"
+    }
+    webhook_covered = await active_webhook_member_ids(db, org_id, agent_webhook_candidates)
+
     events_to_push: list[tuple[str, Event]] = []
     for pid in sorted(mention_targets):  # deadlock 방지: 일관 락 순서
         m_type = member_type_map.get(pid, "human")
+        # webhook-covered agent → SSE 스킵. human 은 무변경(FORK2).
+        if m_type == "agent" and pid in webhook_covered:
+            continue
         event = Event(
             project_id=conversation.project_id,
             org_id=org_id,

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -26,7 +26,6 @@ from app.services import chat_presence
 from app.services.agent_runtime import supports_deterministic_command
 from app.services.command_classifier import classify_command
 from app.services.event_seq import assign_recipient_seq
-from app.services.webhook_targeting import active_webhook_member_ids
 from app.services.member_resolver import (
     ResolvedMember,
     filter_org_member_ids,
@@ -267,10 +266,14 @@ async def _dispatch_conversation_event(
     org_id: uuid.UUID,
     sender: "ResolvedMember | TeamMember",
     exclude_ids: set[uuid.UUID] | None = None,
+    webhook_covered_ids: set[uuid.UUID] | None = None,
 ) -> list[tuple[str, dict]]:
     """conversation:message → Event INSERT + flush. push 페이로드 반환 (commit 후 호출).
 
     exclude_ids: SSE 발송에서 제외할 member_id 집합 (Discord 수신자 등).
+    webhook_covered_ids: E-EVENT-1CONFIG — webhook 으로 전달되는(=SSE enqueue 스킵할) agent
+        member 집합. send_message 요청 트랜잭션서 webhook 전달 대상과 **같은 snapshot** 으로
+        산출돼 넘어온다(resolve_conversation_webhook_targets) → skip↔deliver 동일 결정·TOCTOU 차단.
     반환값: [(pid_str, payload)] — db.commit() 완료 후 _push_to_agent() 호출용.
     """
     if not conversation.project_id:
@@ -293,22 +296,12 @@ async def _dispatch_conversation_event(
     )).all()
     member_type_map = {r[0]: r[1] for r in member_rows}
 
-    # E-EVENT-1CONFIG(이중수신 박멸): 활성 member-bound webhook 보유 agent recipient는 SSE
-    # enqueue 스킵 — webhook 경로(deliver_conversation_message_webhook)가 동일 메시지를 전달하므로
-    # (dispatch_notification 과 대칭). 판정 스코프는 그 전달 predicate 와 정확히 동일:
-    #   authorized = mentioned 우선·없으면 participants(sender 제외) / member-bound / **project 독립**.
-    # member_id=null 브로드캐스트는 멤버 세션 채널이 아니라 공유 엔드포인트 → skip 근거 제외
-    # (active_webhook_member_ids 가 member_id IS NOT NULL 만 본다). 비-mentioned participant 는
-    # webhook 미커버 → SSE 유지(silent loss 0).
-    mentioned_authorized = {m for m in (msg.mentioned_ids or []) if m is not None}
-    webhook_authorized = (
-        (mentioned_authorized & participant_ids) if mentioned_authorized else participant_ids
-    )
-    agent_webhook_candidates = {
-        pid for pid in participant_ids
-        if member_type_map.get(pid) == "agent" and pid in webhook_authorized
-    }
-    webhook_covered = await active_webhook_member_ids(db, org_id, agent_webhook_candidates)
+    # E-EVENT-1CONFIG(이중수신 박멸): webhook-covered agent recipient 는 SSE enqueue 스킵 —
+    # webhook 경로(deliver_conversation_message_webhook)가 동일 메시지를 전달하므로(대칭). covered
+    # 집합은 webhook 실 전달 대상과 같은 snapshot 으로 산출돼(authorized=mentioned 우선·sender 제외 /
+    # member-bound / project 독립 / member_id=null 브로드캐스트 제외) 넘어온다 → 비-mentioned
+    # participant·human·broadcast 는 covered 밖 → SSE 유지(silent loss 0). human Event 는 무변경(FORK2).
+    webhook_covered = webhook_covered_ids or set()
 
     events_to_push: list[tuple[str, Event]] = []
     _set_working_any = False
@@ -366,9 +359,13 @@ async def _dispatch_mention_events(
     org_id: uuid.UUID,
     sender: TeamMember,
     mention_targets: set[uuid.UUID],
+    webhook_covered_ids: set[uuid.UUID] | None = None,
 ) -> list[tuple[str, dict]]:
     """AC1: 멘션 대상에게 conversation:mention Event INSERT + flush. push 페이로드 반환 (commit 후 호출).
 
+    webhook_covered_ids: E-EVENT-1CONFIG — webhook 전달 대상과 같은 snapshot 으로 산출된
+        SSE-skip agent 집합(_dispatch_conversation_event 와 공유). 멘션 대상 ⊆ authorized 라
+        그대로 적용 가능.
     반환값: [(pid_str, payload)] — db.commit() 완료 후 _push_to_agent() 호출용.
     """
     if not conversation.project_id or not mention_targets:
@@ -380,13 +377,9 @@ async def _dispatch_mention_events(
     )).all()
     member_type_map = {r[0]: r[1] for r in member_rows}
 
-    # E-EVENT-1CONFIG(이중수신 박멸): 멘션 대상 = webhook authorized set 그 자체(mentioned 우선
-    # 규칙의 mentioned 측). 활성 member-bound webhook 보유 agent 는 SSE(conversation:mention)
-    # 스킵 — webhook 이 동일 메시지를 전달. member_id=null 브로드캐스트는 제외(SSOT 동일).
-    agent_webhook_candidates = {
-        pid for pid in mention_targets if member_type_map.get(pid) == "agent"
-    }
-    webhook_covered = await active_webhook_member_ids(db, org_id, agent_webhook_candidates)
+    # E-EVENT-1CONFIG(이중수신 박멸): webhook-covered agent 는 SSE(conversation:mention) 스킵 —
+    # webhook 이 동일 메시지를 전달. covered 집합은 webhook 실 전달과 같은 snapshot(TOCTOU 차단).
+    webhook_covered = webhook_covered_ids or set()
 
     events_to_push: list[tuple[str, Event]] = []
     for pid in sorted(mention_targets):  # deadlock 방지: 일관 락 순서
@@ -1245,10 +1238,37 @@ async def send_message(
     # 비-command 면 빈 결과 → 무영향. 차단 대상은 dispatch exclude 로 합쳐 주입 0.
     blocked_agent_ids, command_hints = await _command_capability_gate(db, conv, msg, sender, org_id)
 
+    # E-EVENT-1CONFIG: webhook 전달 대상을 요청 트랜잭션서 1회 산출(SSOT) — SSE-skip 결정과 실제
+    # webhook delivery 가 **같은 snapshot/결정**을 쓰게 해 TOCTOU silent loss 를 차단한다(산티아고
+    # Finding 1). 산출된 target 을 그대로 delivery task 로 넘기고(post-commit requery 0), 그로부터
+    # 도출한 covered member 집합을 SSE-skip 에 쓴다.
+    from app.services.conversation_webhook import resolve_conversation_webhook_targets
+    webhook_targets: list = []
+    if conv.project_id:
+        try:
+            webhook_targets = await resolve_conversation_webhook_targets(
+                db,
+                conversation_id=conversation_id,
+                org_id=org_id,
+                project_id=conv.project_id,
+                sender_id=sender.id,
+                mentioned_ids=list(msg.mentioned_ids) if msg.mentioned_ids else None,
+            )
+        except Exception:
+            logger.warning(
+                "webhook target resolve failed conversation_id=%s — SSE 유지(skip 0·fail-open)",
+                conversation_id, exc_info=True,
+            )
+    webhook_covered_ids = {t.member_id for t in webhook_targets if t.member_id is not None}
+
     pending_sse_pushes: list[tuple[str, dict]] = []
     try:
         async with db.begin_nested():
-            pending_sse_pushes += await _dispatch_conversation_event(db, conv, msg, org_id, sender, exclude_ids=discord_exclude_ids | blocked_agent_ids)
+            pending_sse_pushes += await _dispatch_conversation_event(
+                db, conv, msg, org_id, sender,
+                exclude_ids=discord_exclude_ids | blocked_agent_ids,
+                webhook_covered_ids=webhook_covered_ids,
+            )
     except Exception as _dispatch_err:
         # dispatch 실패를 삼키지 않고 surface — 게이트웨이 이벤트 미생성 무음 방지
         logger.error("conversation event dispatch failed conversation_id=%s", conversation_id, exc_info=True)
@@ -1260,7 +1280,10 @@ async def send_message(
         if mention_targets:
             try:
                 async with db.begin_nested():
-                    pending_sse_pushes += await _dispatch_mention_events(db, conv, msg, org_id, sender, mention_targets)
+                    pending_sse_pushes += await _dispatch_mention_events(
+                        db, conv, msg, org_id, sender, mention_targets,
+                        webhook_covered_ids=webhook_covered_ids,
+                    )
             except Exception:
                 logger.warning("mention event dispatch failed conversation_id=%s", conversation_id, exc_info=True)
 
@@ -1333,7 +1356,8 @@ async def send_message(
     except Exception:
         logger.warning("ws_chat broadcast failed message_id=%s", msg.id, exc_info=True)
 
-    # webhook delivery BackgroundTask (AC1~8)
+    # webhook delivery BackgroundTask (AC1~8) — E-EVENT-1CONFIG: targets 를 요청 트랜잭션서 산출한
+    # webhook_targets 로 고정 전달(post-commit requery 0·SSE-skip 과 동일 snapshot·TOCTOU 차단).
     from app.services.conversation_webhook import deliver_conversation_message_webhook
     background_tasks.add_task(
         deliver_conversation_message_webhook,
@@ -1346,6 +1370,7 @@ async def send_message(
         created_at=msg.created_at,
         mentioned_ids=list(msg.mentioned_ids) if msg.mentioned_ids else None,
         content=msg.content,
+        targets=webhook_targets,
     )
 
     # Discord 아웃바운드 (AC9~11)

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -130,6 +130,26 @@ async def hitl_timeouts(
         return _err("INTERNAL_ERROR", "Internal server error", 500)
 
 
+# ─── GET /api/v2/internal/cron/expire-stale-events ────────────────────────────
+# E-EVENT-1CONFIG: backfill landmine 박멸의 cleanup 짝. ACK retire 가 agent SSE 이벤트를
+# delivered 로 마킹해도, 이 cron 이 호출돼야 실제로 회수(삭제)된다. 기존 /events/expire-stale 은
+# org-scoped(헤더 의존)·호출자 0 이었다 → 전 org 일괄 cleanup 으로 cron 연결.
+@router.get("/expire-stale-events")
+async def expire_stale_events_cron(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    verify_cron(request)
+    try:
+        from app.routers.events import expire_stale_events_core
+
+        result = await expire_stale_events_core(session, org_id=None)  # 전 org
+        return _ok(result)
+    except Exception as exc:
+        logger.exception("cron error (expire-stale-events): %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)
+
+
 # ─── GET /api/v2/internal/cron/workflow-handoff-watchdog ──────────────────────
 # E-DG S8: handoff watchdog + ACK reconciliation(P0-3). silent handoff stall 을 observable
 # incident 로 전환 — ACK 대사 → acked / 10분 미ACK → timed_out(board badge) + fallback notification.

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -524,36 +524,36 @@ assert _EXPIRE_DAYS * 24 >= _EVENT_RETENTION_MIN_HOURS, "Event retention must be
 assert _CLEANUP_DAYS * 24 >= _EVENT_RETENTION_MIN_HOURS, "Event cleanup must be >= 24h"
 
 
+async def expire_stale_events_core(
+    db: AsyncSession, org_id: uuid.UUID | None
+) -> dict:
+    """30일 초과 pending → expired, 7일 초과 delivered 삭제.
+
+    ``org_id`` 가 주어지면 그 org 로 스코프(엔드포인트 경로), ``None`` 이면 전 org 일괄
+    회수(cron 경로). E-EVENT-1CONFIG: ACK retire 가 delivered 로 마킹한 agent SSE 이벤트를
+    이 cleanup 이 회수한다 — 둘이 짝이라 cron 미연결 시 retire 해도 영영 안 지워진다.
+    """
+    now = datetime.now(timezone.utc)
+    cutoff_expire = now - timedelta(days=_EXPIRE_DAYS)
+    cutoff_cleanup = now - timedelta(days=_CLEANUP_DAYS)
+
+    expire_where = [Event.status == "pending", Event.created_at < cutoff_expire]
+    cleanup_where = [Event.status == "delivered", Event.delivered_at < cutoff_cleanup]
+    if org_id is not None:
+        expire_where.append(Event.org_id == org_id)
+        cleanup_where.append(Event.org_id == org_id)
+
+    expired = await db.execute(update(Event).where(*expire_where).values(status="expired"))
+    cleaned = await db.execute(delete(Event).where(*cleanup_where))
+
+    await db.commit()
+    return {"expired": expired.rowcount, "cleaned": cleaned.rowcount}
+
+
 @router.post("/expire-stale", status_code=200)
 async def expire_stale_events(
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
     """POST /api/v2/events/expire-stale — 30일 초과 pending → expired, 7일 초과 delivered 삭제."""
-    now = datetime.now(timezone.utc)
-    cutoff_expire = now - timedelta(days=_EXPIRE_DAYS)
-    cutoff_cleanup = now - timedelta(days=_CLEANUP_DAYS)
-
-    expired = await db.execute(
-        update(Event)
-        .where(
-            Event.org_id == org_id,
-            Event.status == "pending",
-            Event.created_at < cutoff_expire,
-        )
-        .values(status="expired")
-    )
-
-    cleaned = await db.execute(
-        delete(Event).where(
-            Event.org_id == org_id,
-            Event.status == "delivered",
-            Event.delivered_at < cutoff_cleanup,
-        )
-    )
-
-    await db.commit()
-    return {
-        "expired": expired.rowcount,
-        "cleaned": cleaned.rowcount,
-    }
+    return await expire_stale_events_core(db, org_id)

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -14,6 +14,8 @@ import logging
 import uuid
 from datetime import datetime, timezone
 
+from typing import NamedTuple
+
 import httpx
 
 from app.models.conversation_webhook_delivery import ConversationWebhookDelivery
@@ -179,6 +181,93 @@ def _select_project_scope_targets(
     return targets
 
 
+class _WebhookTarget(NamedTuple):
+    """conversation.message_created 전달 대상 webhook의 직렬화 가능한 스냅샷.
+
+    E-EVENT-1CONFIG: 요청 트랜잭션서 산출해 (a) SSE-skip covered set 도출과 (b) post-commit
+    delivery 양쪽에 같은 결정을 흘려보내기 위해 ORM 대신 평면 값으로 고정(세션 분리/commit 경계
+    안전·BackgroundTask 전달 가능).
+    """
+    id: uuid.UUID
+    url: str
+    secret: str | None
+    member_id: uuid.UUID | None
+
+
+async def resolve_conversation_webhook_targets(
+    db,
+    *,
+    conversation_id: uuid.UUID,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID,
+    sender_id: uuid.UUID | None,
+    mentioned_ids: list[uuid.UUID] | None,
+) -> list[_WebhookTarget]:
+    """conversation.message_created 의 실 전달 대상 webhook 을 결정하는 SSOT.
+
+    이 결과가 ① 메시지 경로 SSE-skip 의 covered member 집합과 ② 실제 webhook 전달 대상 둘 다의
+    **단일 출처**다. send_message 요청 트랜잭션에서 1회 호출해 skip 결정과 delivery 가 같은
+    snapshot/결정을 쓰게 함으로써 TOCTOU(skip 됐는데 post-commit requery 시 target 0 →
+    silent loss)를 차단한다(산티아고 Finding 1).
+
+    authorized = mentioned 우선(**sender 제외**)·없으면 참가자 전원(sender 제외). member-bound
+    webhook 은 그 멤버가 authorized 일 때만, member_id=null 브로드캐스트는 무조건 포함(참가자
+    게이팅 c2dfb823). sender 제외로 자기 self-mention webhook 비대칭도 제거(Finding 2).
+    """
+    from sqlalchemy import select
+
+    from app.models.conversation import ConversationParticipant
+
+    if mentioned_ids:
+        # 멘션 있으면 멘션 대상만 — sender 제외(자기 메시지를 자기 webhook 으로 되받지 않도록·
+        # SSE mention 경로[conversations.py]와 authorized set 통일). 멘션이 sender 뿐이면 전달 0.
+        member_ids_for_webhook: list[uuid.UUID] = [m for m in mentioned_ids if m != sender_id]
+    else:
+        participant_member_ids = (await db.execute(
+            select(ConversationParticipant.member_id).where(
+                ConversationParticipant.conversation_id == conversation_id,
+                *([ConversationParticipant.member_id != sender_id] if sender_id else []),
+            )
+        )).scalars().all()
+        member_ids_for_webhook = list(participant_member_ids)
+
+    authorized_member_ids: set[uuid.UUID] = {
+        mid for mid in member_ids_for_webhook if mid is not None
+    }
+
+    # 프로젝트-스코프 활성 webhook + 참가자 게이팅(c2dfb823).
+    wh_rows = (await db.execute(
+        select(WebhookConfig).where(
+            WebhookConfig.org_id == org_id,
+            WebhookConfig.project_id == project_id,
+            WebhookConfig.is_active.is_(True),
+        )
+    )).scalars().all()
+    target_configs = _select_project_scope_targets(wh_rows, authorized_member_ids)
+
+    # member-bound webhook 은 글로벌·타 프로젝트에도 존재 가능 → member_id union(중복 id/url 차단).
+    if member_ids_for_webhook:
+        extra_wh_rows = (await db.execute(
+            select(WebhookConfig).where(
+                WebhookConfig.org_id == org_id,
+                WebhookConfig.member_id.in_(member_ids_for_webhook),
+                WebhookConfig.is_active.is_(True),
+            )
+        )).scalars().all()
+        existing_ids = {wh.id for wh in target_configs}
+        existing_urls = {wh.url for wh in target_configs}
+        for wh in extra_wh_rows:
+            if wh.id not in existing_ids and wh.url not in existing_urls:
+                target_configs.append(wh)
+                existing_ids.add(wh.id)
+                existing_urls.add(wh.url)
+
+    return [
+        _WebhookTarget(id=wh.id, url=wh.url, secret=wh.secret, member_id=wh.member_id)
+        for wh in target_configs
+    ]
+
+
 async def deliver_conversation_message_webhook(
     message_id: uuid.UUID,
     conversation_id: uuid.UUID,
@@ -189,80 +278,30 @@ async def deliver_conversation_message_webhook(
     created_at: datetime,
     mentioned_ids: list[uuid.UUID] | None = None,
     content: str | None = None,
+    targets: list[_WebhookTarget] | None = None,
 ) -> None:
     """BackgroundTask 진입점.
 
-    webhook_configs에서 conversation.message_created 이벤트 구독 중인
-    활성 webhook을 조회하고 delivery attempt 기록 후 발송.
+    전달 대상은 ``targets`` 로 받는다(send_message 요청 트랜잭션서 산출). 이는 SSE-skip 결정과
+    **같은 snapshot** 이라 TOCTOU silent loss 를 차단한다(산티아고 Finding 1). targets 미전달 시
+    (구 호출자/방어) 이 함수가 직접 resolve — 단 그 경로는 skip 과 다른 snapshot 일 수 있다.
     """
     from app.core.database import async_session_factory
     from sqlalchemy import select
 
     async with async_session_factory() as db:
         try:
-            # AC1/AC4: 인가 수신자 멤버 집합 먼저 도출 — mentioned_ids 우선,
-            # 없으면 대화 참가자 전원(sender 제외). 프로젝트-스코프 게이팅의 기준이 된다.
-            member_ids_for_webhook: list[uuid.UUID] = list(mentioned_ids) if mentioned_ids else []
-            if not member_ids_for_webhook:
-                from app.models.conversation import ConversationParticipant
-                participant_member_ids = (await db.execute(
-                    select(ConversationParticipant.member_id).where(
-                        ConversationParticipant.conversation_id == conversation_id,
-                        *(
-                            [ConversationParticipant.member_id != sender_id]
-                            if sender_id else []
-                        ),
-                    )
-                )).scalars().all()
-                member_ids_for_webhook = list(participant_member_ids)
-
-            authorized_member_ids: set[uuid.UUID] = {
-                mid for mid in member_ids_for_webhook if mid is not None
-            }
-
-            # 프로젝트-스코프 활성 webhook 조회 후 참가자 게이팅(BUG c2dfb823):
-            # member-bound webhook은 그 멤버가 인가 수신자일 때만, member_id=null
-            # 진짜 브로드캐스트만 무조건 포함. events 미구독은 제외(backwards compatible).
-            wh_rows = (await db.execute(
-                select(WebhookConfig).where(
-                    WebhookConfig.org_id == org_id,
-                    WebhookConfig.project_id == project_id,
-                    WebhookConfig.is_active.is_(True),
-                )
-            )).scalars().all()
-            target_webhooks = _select_project_scope_targets(wh_rows, authorized_member_ids)
-
-            # 참가자/mentioned 멤버에 묶인 webhook은 프로젝트 스코프 밖(글로벌·타 프로젝트)에도
-            # 존재할 수 있어 member_id로 한 번 더 union(중복은 id/url 로 차단).
-            if member_ids_for_webhook:
-                extra_wh_rows = (await db.execute(
-                    select(WebhookConfig).where(
-                        WebhookConfig.org_id == org_id,
-                        WebhookConfig.member_id.in_(member_ids_for_webhook),
-                        WebhookConfig.is_active.is_(True),
-                    )
-                )).scalars().all()
-                existing_ids = {wh.id for wh in target_webhooks}
-                existing_urls = {wh.url for wh in target_webhooks}
-                for wh in extra_wh_rows:
-                    if wh.id not in existing_ids and wh.url not in existing_urls:
-                        target_webhooks.append(wh)
-                        existing_ids.add(wh.id)
-                        existing_urls.add(wh.url)
-
-            # 웹훅 없는 멤버 → 내장 /chats 경로로 fallback (conversations router에서 처리)
-            webhook_covered_ids: set[uuid.UUID] = {
-                wh.member_id for wh in target_webhooks if wh.member_id is not None
-            }
-            fallback_ids = [mid for mid in member_ids_for_webhook if mid not in webhook_covered_ids]
-            if fallback_ids:
-                logger.debug(
-                    "conversation webhook: %d member(s) without webhook — in-app fallback applies message_id=%s",
-                    len(fallback_ids),
-                    message_id,
+            if targets is None:
+                targets = await resolve_conversation_webhook_targets(
+                    db,
+                    conversation_id=conversation_id,
+                    org_id=org_id,
+                    project_id=project_id,
+                    sender_id=sender_id,
+                    mentioned_ids=mentioned_ids,
                 )
 
-            if not target_webhooks:
+            if not targets:
                 return
 
             mentioned_id_strs = [str(m) for m in (mentioned_ids or [])]
@@ -330,7 +369,7 @@ async def deliver_conversation_message_webhook(
                 "images": attachment_images,
             }
 
-            for wh in target_webhooks:
+            for wh in targets:
                 delivery = ConversationWebhookDelivery(
                     id=uuid.uuid4(),
                     message_id=message_id,

--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -17,6 +17,7 @@ from app.models.event import Event
 from app.models.notification import Notification, NotificationSetting
 from app.models.team import TeamMember
 from app.models.webhook_config import WebhookConfig
+from app.services.webhook_targeting import active_webhook_member_ids
 
 logger = logging.getLogger(__name__)
 
@@ -142,19 +143,12 @@ async def dispatch_notification(
         if not enabled_member_ids:
             return
 
-        # 활성 webhook_configs가 있는 멤버 집합 — 웹훅 채널로 전달되므로 내장 알림 스킵
-        webhook_member_ids: set[uuid.UUID] = set()
-        try:
-            wh_rows = await db.execute(
-                select(WebhookConfig.member_id).where(
-                    WebhookConfig.member_id.in_(enabled_member_ids),
-                    WebhookConfig.is_active.is_(True),
-                    WebhookConfig.member_id.isnot(None),
-                )
-            )
-            webhook_member_ids = {row for row in wh_rows.scalars().all()}
-        except Exception:
-            logger.warning("dispatch_notification: webhook_configs lookup failed — no skip applied")
+        # 활성 webhook_configs가 있는 멤버 집합 — 웹훅 채널로 전달되므로 내장 알림 스킵.
+        # E-EVENT-1CONFIG: 메시지 경로 SSE-skip과 공용 SSOT(active_webhook_member_ids) —
+        # member-bound(project-독립) 활성 webhook 보유 멤버. fail-open(조회 실패=빈 집합).
+        webhook_member_ids = await active_webhook_member_ids(
+            db, org_id, enabled_member_ids
+        )
 
         # BUG-2 수정: user_id.isnot(None) 필터 제거 — agent는 user_id=NULL이므로 제외됐던 문제
         # type 및 project_id도 함께 조회

--- a/backend/app/services/webhook_targeting.py
+++ b/backend/app/services/webhook_targeting.py
@@ -1,0 +1,68 @@
+"""E-EVENT-1CONFIG: webhook 커버리지 판정 공용 진실원(SSOT).
+
+메시지 경로(`conversations.py`)·`notification_dispatch`가 공유하는 "webhook으로 전달되는
+멤버" 판정의 단일 진실원. 이 집합이 곧 내장 SSE enqueue(또는 in-app 알림)를 **스킵**할
+멤버 집합 — 같은 메시지를 webhook + SSE 양쪽으로 받는 이중수신을 박멸한다.
+
+## 판정 스코프 (c2dfb823 머지코드 = d21089f1 `deliver_conversation_message_webhook` SSOT)
+- **member-bound webhook(member_id != null)** 은 member-global union 쿼리가 ``project_id``
+  필터 없이 전달하므로 **project 독립**이다. 즉 멤버가 활성 member-bound webhook 을 가지면
+  그 멤버는 어느 프로젝트 대화든 webhook 으로 전달받는다 → webhook-covered.
+- **member_id=null 브로드캐스트** 는 특정 멤버의 세션 구동 채널이 아니라 공유 엔드포인트로
+  전달된다. 이를 멤버 커버리지로 치면 webhook 없는 agent 의 SSE 까지 꺼져 **silent loss**
+  가 발생하므로 이 판정에서 **제외**한다(``member_id`` 가 NULL 이 아닌 행만 본다).
+
+따라서 SSE-skip 판정 = "그 agent 가 활성 member-bound webhook 을 보유"(project 무관)이며,
+이는 webhook 실 전달과 정확히 대칭이라 ①이중수신 잔존(너무 좁음) ②silent loss(너무 넓음)
+둘 다 없다. notification_dispatch 의 기존 member-only 판정이 보안상 옳았음을 SSOT 로 확정한다.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Collection
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.webhook_config import WebhookConfig
+
+logger = logging.getLogger(__name__)
+
+
+async def active_webhook_member_ids(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    member_ids: Collection[uuid.UUID],
+) -> set[uuid.UUID]:
+    """``member_ids`` 중 활성 member-bound webhook 보유 멤버 집합(project 독립).
+
+    webhook 으로 전달되는(=내장 SSE/알림 스킵 대상) 멤버를 가린다.
+
+    fail-open: 조회 실패 시 빈 집합을 반환해 **아무도 스킵하지 않는다**. webhook 판정 실패가
+    전달 자체를 막으면 안 되므로(SSE 는 항상 살아남아 메시지 누락 0), 예외는 삼키고 경고만 남긴다.
+
+    Args:
+        db: async 세션.
+        org_id: webhook 을 org 로 스코프(실 전달 predicate 와 대칭·cross-org 격리).
+        member_ids: 후보 멤버(보통 인가 수신자=mentioned 우선·없으면 participants).
+    """
+    candidate_ids = [m for m in member_ids if m is not None]
+    if not candidate_ids:
+        return set()
+    try:
+        rows = await db.execute(
+            select(WebhookConfig.member_id).where(
+                WebhookConfig.org_id == org_id,
+                WebhookConfig.member_id.in_(candidate_ids),
+                WebhookConfig.is_active.is_(True),
+                WebhookConfig.member_id.isnot(None),
+            )
+        )
+        return {row for row in rows.scalars().all()}
+    except Exception:
+        logger.warning(
+            "active_webhook_member_ids lookup failed — no skip applied (fail-open SSE)",
+            exc_info=True,
+        )
+        return set()

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -537,12 +537,15 @@ async def test_send_message_filters_cross_org_mentions_group():
         session.refresh.side_effect = _refresh
 
         mention_calls = {}
-        async def _capture_mention(db, conversation, msg, org_id, sender, mention_targets):
+        async def _capture_mention(db, conversation, msg, org_id, sender, mention_targets,
+                                   webhook_covered_ids=None):
             mention_calls["targets"] = set(mention_targets)
             return []
 
         with patch("app.routers.conversations.filter_org_member_ids",
                    new=AsyncMock(return_value={valid_id})), \
+             patch("app.services.conversation_webhook.resolve_conversation_webhook_targets",
+                   new=AsyncMock(return_value=[])), \
              patch("app.routers.conversations._dispatch_conversation_event",
                    new=AsyncMock(return_value=[])), \
              patch("app.routers.conversations._dispatch_mention_events",

--- a/backend/tests/test_event1config_ack_retire.py
+++ b/backend/tests/test_event1config_ack_retire.py
@@ -1,0 +1,134 @@
+"""E-EVENT-1CONFIG Part B: ACK retire 가드 (backfill landmine 박멸).
+
+ack_event 가 acked_seq 전진뿐 아니라 recipient_seq <= seq 인 pending agent 이벤트를 같은
+트랜잭션서 delivered 마킹함을 가드한다. 이게 빠지면 cleanup(expire-stale)이 영영 회수 못 해
+pending 무한 적재 → restart backfill 폭주.
+
+- mock 가드(CI 상시): UPDATE(events) 가 발행되는지 — retire 제거 시 FAIL.
+- 실DB 가드(DATABASE_URL): <=seq delivered / >seq pending / idempotent 의미 검증.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.sql.dml import Update
+
+from app.routers.agent_gateway import AckRequest, ack_event
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _api_key_auth(agent_id: uuid.UUID) -> SimpleNamespace:
+    return SimpleNamespace(
+        claims={"app_metadata": {"api_key_id": "k1"}},
+        user_id=str(agent_id),
+    )
+
+
+@pytest.mark.anyio
+async def test_ack_issues_delivered_update_on_events():
+    """ACK 시 cursor UPSERT 외에 events 대상 UPDATE(delivered)가 반드시 발행된다."""
+    agent_id = uuid.uuid4()
+    cursor = SimpleNamespace(acked_seq=0, updated_at=None, agent_id=agent_id)
+    sel_result = MagicMock()
+    sel_result.scalar_one_or_none.return_value = cursor
+
+    executed: list = []
+
+    async def _execute(stmt, *a, **k):
+        executed.append(stmt)
+        return sel_result
+
+    db = SimpleNamespace(
+        execute=_execute,
+        add=MagicMock(),
+        commit=AsyncMock(),
+    )
+
+    out = await ack_event(AckRequest(seq=7), db=db, auth=_api_key_auth(agent_id))
+    assert out == {"acked_seq": 7}
+
+    updates = [s for s in executed if isinstance(s, Update)]
+    assert len(updates) == 1, "events delivered UPDATE 가 발행돼야 한다(retire)"
+    assert updates[0].table.name == "events"
+
+
+@pytest.mark.anyio
+async def test_ack_requires_api_key():
+    """비-API-key caller 는 403 (기존 거동 무회귀)."""
+    from fastapi import HTTPException
+
+    db = SimpleNamespace(execute=AsyncMock(), add=MagicMock(), commit=AsyncMock())
+    auth = SimpleNamespace(claims={"app_metadata": {}}, user_id=str(uuid.uuid4()))
+    with pytest.raises(HTTPException) as ei:
+        await ack_event(AckRequest(seq=1), db=db, auth=auth)
+    assert ei.value.status_code == 403
+
+
+# ─── 실DB 의미 가드 ───────────────────────────────────────────────────────────
+
+_ASYNCPG_URL = (
+    os.getenv("DATABASE_URL", "").replace("postgresql+asyncpg://", "postgresql://")
+    or None
+)
+_requires_db = pytest.mark.skipif(
+    not _ASYNCPG_URL, reason="DATABASE_URL not set — real DB test skipped"
+)
+
+
+@_requires_db
+@pytest.mark.anyio
+async def test_ack_retire_semantics_realdb():
+    """<=seq pending → delivered, >seq 유지, 재-ack idempotent."""
+    from app.core.database import async_session_factory
+
+    org, proj, agent = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    async with async_session_factory() as db:
+        await db.execute(
+            text("INSERT INTO organizations (id, name, slug) VALUES (:i, :n, :s)"),
+            {"i": org, "n": f"ack-org-{org}", "s": f"ack-{org}"},
+        )
+        await db.execute(
+            text("INSERT INTO projects (id, org_id, name) VALUES (:i, :o, :n)"),
+            {"i": proj, "o": org, "n": f"ack-proj-{proj}"},
+        )
+        for seq in (1, 2, 3):
+            await db.execute(
+                text(
+                    "INSERT INTO events "
+                    "(id, org_id, project_id, event_type, recipient_id, recipient_type, "
+                    " payload, status, recipient_seq) VALUES "
+                    "(gen_random_uuid(), :o, :p, 'conversation.message_created', :r, 'agent', "
+                    " '{}', 'pending', :seq)"
+                ),
+                {"o": org, "p": proj, "r": agent, "seq": seq},
+            )
+        await db.commit()
+        try:
+            await ack_event(AckRequest(seq=2), db=db, auth=_api_key_auth(agent))
+
+            rows = (await db.execute(
+                text("SELECT recipient_seq, status FROM events WHERE recipient_id = :r"),
+                {"r": agent},
+            )).all()
+            by_seq = {r[0]: r[1] for r in rows}
+            assert by_seq[1] == "delivered"
+            assert by_seq[2] == "delivered"
+            assert by_seq[3] == "pending", ">seq 이벤트는 유지(미-ack)"
+
+            # 재-ack: 동일 seq → no-op(idempotent), 에러 없음
+            await ack_event(AckRequest(seq=2), db=db, auth=_api_key_auth(agent))
+        finally:
+            await db.execute(text("DELETE FROM events WHERE recipient_id = :r"), {"r": agent})
+            await db.execute(text("DELETE FROM agent_event_cursors WHERE agent_id = :a"), {"a": agent})
+            await db.execute(text("DELETE FROM projects WHERE id = :i"), {"i": proj})
+            await db.execute(text("DELETE FROM organizations WHERE id = :i"), {"i": org})
+            await db.commit()

--- a/backend/tests/test_event1config_expire_cron.py
+++ b/backend/tests/test_event1config_expire_cron.py
@@ -1,0 +1,120 @@
+"""E-EVENT-1CONFIG Part B: expire-stale cron 배선 가드.
+
+expire_stale_events_core(org_id=None) 전 org 일괄 cleanup + cron 라우트 등록 + ACK retire 가
+delivered 마킹한 이벤트를 cleanup 이 회수함을 가드한다. cron 미연결이 원 landmine 이라 라우트
+존재 자체가 회귀 가드.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import text
+
+from app.routers.events import expire_stale_events_core
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _rowcount_result(rc: int) -> MagicMock:
+    r = MagicMock()
+    r.rowcount = rc
+    return r
+
+
+@pytest.mark.anyio
+async def test_core_global_issues_update_delete_and_commits():
+    db = SimpleNamespace(
+        execute=AsyncMock(side_effect=[_rowcount_result(3), _rowcount_result(2)]),
+        commit=AsyncMock(),
+    )
+    out = await expire_stale_events_core(db, org_id=None)
+    assert out == {"expired": 3, "cleaned": 2}
+    assert db.execute.await_count == 2  # update(expire) + delete(cleanup)
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_core_org_scoped_also_runs():
+    db = SimpleNamespace(
+        execute=AsyncMock(side_effect=[_rowcount_result(0), _rowcount_result(0)]),
+        commit=AsyncMock(),
+    )
+    out = await expire_stale_events_core(db, org_id=uuid.uuid4())
+    assert out == {"expired": 0, "cleaned": 0}
+
+
+def test_cron_route_registered():
+    """cron 미연결이 원 landmine — 라우트 등록 자체가 회귀 가드."""
+    from app.main import app
+
+    paths = {getattr(r, "path", None) for r in app.routes}
+    assert "/api/v2/internal/cron/expire-stale-events" in paths
+
+
+# ─── 실DB 의미 가드 (org 스코프·delivered 회수) ───────────────────────────────
+
+_ASYNCPG_URL = (
+    os.getenv("DATABASE_URL", "").replace("postgresql+asyncpg://", "postgresql://")
+    or None
+)
+_requires_db = pytest.mark.skipif(
+    not _ASYNCPG_URL, reason="DATABASE_URL not set — real DB test skipped"
+)
+
+
+@_requires_db
+@pytest.mark.anyio
+async def test_global_cleanup_recovers_delivered_across_orgs_realdb():
+    """전 org cleanup: 7일 초과 delivered 삭제(ACK retire 회수)·org 무관."""
+    from app.core.database import async_session_factory
+
+    org_a, org_b = uuid.uuid4(), uuid.uuid4()
+    proj_a, proj_b = uuid.uuid4(), uuid.uuid4()
+    agent = uuid.uuid4()
+    old = datetime.now(timezone.utc) - timedelta(days=10)
+
+    async with async_session_factory() as db:
+        for org, proj in ((org_a, proj_a), (org_b, proj_b)):
+            await db.execute(
+                text("INSERT INTO organizations (id, name, slug) VALUES (:i, :n, :s)"),
+                {"i": org, "n": f"exp-org-{org}", "s": f"exp-{org}"},
+            )
+            await db.execute(
+                text("INSERT INTO projects (id, org_id, name) VALUES (:i, :o, :n)"),
+                {"i": proj, "o": org, "n": f"exp-proj-{proj}"},
+            )
+            # 오래된 delivered(ACK retire 산출물) — cleanup 대상
+            await db.execute(
+                text(
+                    "INSERT INTO events (id, org_id, project_id, event_type, recipient_id, "
+                    " recipient_type, payload, status, recipient_seq, delivered_at) VALUES "
+                    "(gen_random_uuid(), :o, :p, 'conversation.message_created', :r, 'agent', "
+                    " '{}', 'delivered', 1, :d)"
+                ),
+                {"o": org, "p": proj, "r": agent, "d": old},
+            )
+        await db.commit()
+        try:
+            out = await expire_stale_events_core(db, org_id=None)
+            assert out["cleaned"] >= 2, "양 org 의 오래된 delivered 모두 회수"
+
+            remaining = (await db.execute(
+                text("SELECT count(*) FROM events WHERE recipient_id = :r AND status = 'delivered'"),
+                {"r": agent},
+            )).scalar()
+            assert remaining == 0
+        finally:
+            await db.execute(text("DELETE FROM events WHERE recipient_id = :r"), {"r": agent})
+            for proj in (proj_a, proj_b):
+                await db.execute(text("DELETE FROM projects WHERE id = :i"), {"i": proj})
+            for org in (org_a, org_b):
+                await db.execute(text("DELETE FROM organizations WHERE id = :i"), {"i": org})
+            await db.commit()

--- a/backend/tests/test_event1config_message_gating.py
+++ b/backend/tests/test_event1config_message_gating.py
@@ -1,9 +1,11 @@
 """E-EVENT-1CONFIG Part A: 메시지 경로 SSE 게이팅 가드 (이중수신 박멸).
 
-_dispatch_conversation_event / _dispatch_mention_events 가 webhook-covered agent recipient 의
-SSE Event 를 스킵하되, ①비-mentioned participant ②human ③비-covered agent 는 SSE 유지함을
-가드한다. active_webhook_member_ids(SSOT)는 별도 단위테스트(test_webhook_targeting)로 검증 —
-여기선 authorized-set 계산 + skip 결정만 격리 검증(헬퍼는 patch).
+_dispatch_conversation_event / _dispatch_mention_events 가 **넘어온** webhook_covered_ids 의
+agent recipient SSE Event 를 스킵하되 human·비-covered agent 는 유지함을 가드한다.
+
+covered 집합 산출(authorized=mentioned우선·sender제외·member-bound·project독립·broadcast제외)은
+resolve_conversation_webhook_targets 의 책임 → test_event1config_webhook_targets 에서 검증.
+여기선 "covered 받으면 정확히 그 agent 만 스킵" 결정만 격리 가드(TOCTOU: skip↔deliver 동일 snapshot).
 """
 from __future__ import annotations
 
@@ -51,7 +53,7 @@ async def _assign_seq(_db, event):
 
 
 class _DB:
-    """participant→member_type execute 2발 + add 캡처. webhook 헬퍼는 patch라 execute 미사용."""
+    """participant→member_type execute + add 캡처."""
 
     def __init__(self, exec_rows: list):
         self._exec_rows = list(exec_rows)
@@ -63,11 +65,10 @@ class _DB:
         return self._exec_rows.pop(0)
 
 
-def _patches(covered_fn):
+def _patches():
     return [
         patch.object(conv, "assign_recipient_seq", _assign_seq),
         patch("app.services.activity_stream.extract_activities_best_effort", AsyncMock()),
-        patch.object(conv, "active_webhook_member_ids", covered_fn),
         patch("app.services.presence_events.emit_conversation_working", lambda *_a, **_k: None),
         patch("app.services.presence_events.emit_presence", lambda *_a, **_k: None),
     ]
@@ -92,64 +93,22 @@ async def test_covered_agent_skipped_others_kept():
         _result_all([(agent_cov, "agent"), (agent_unc, "agent"), (human, "human")]),  # types
     ])
 
-    async def covered_fn(_db, _org, candidates):
-        assert set(candidates) == {agent_cov, agent_unc}  # human 은 후보 아님
-        return {agent_cov}
-
     with contextlib.ExitStack() as stack:
-        for p in _patches(covered_fn):
+        for p in _patches():
             stack.enter_context(p)
-        out = await conv._dispatch_conversation_event(db, conversation, msg, org_id, sender)
+        out = await conv._dispatch_conversation_event(
+            db, conversation, msg, org_id, sender, webhook_covered_ids={agent_cov},
+        )
 
     recipients = {ev.recipient_id for ev in db.added}
     assert recipients == {agent_unc, human}, "covered agent 만 SSE 스킵"
-    assert agent_cov not in recipients
-    # 반환 push 페이로드도 covered 제외
     assert {uuid.UUID(pid) for pid, _ in out} == {agent_unc, human}
 
 
-# ─── AC2/grant-only: mentioned 있으면 비-mentioned participant 는 후보 제외(skip 금지) ──
+# ─── FORK2: human 은 covered 에 들어 있어도 Event 무변경(agent 만 스킵) ──────────
 
 @pytest.mark.anyio
-async def test_non_mentioned_participant_not_skipped_even_with_webhook():
-    """멘션 있는 메시지: 멘션 안 된 participant agent 는 webhook 보유여도 SSE 유지(silent loss 0)."""
-    import contextlib
-
-    org_id = uuid.uuid4()
-    sender = _sender()
-    agent_mentioned = uuid.uuid4()
-    agent_not_mentioned = uuid.uuid4()  # webhook 보유하지만 멘션 안 됨
-    conversation = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
-    msg = _msg(mentioned=[agent_mentioned])
-
-    db = _DB([
-        _result_all([(agent_mentioned,), (agent_not_mentioned,)]),
-        _result_all([(agent_mentioned, "agent"), (agent_not_mentioned, "agent")]),
-    ])
-
-    seen_candidates = {}
-
-    async def covered_fn(_db, _org, candidates):
-        seen_candidates["set"] = set(candidates)
-        # 둘 다 webhook 보유라 가정해도, 후보에 든 멤버만 covered 가능
-        return set(candidates)
-
-    with contextlib.ExitStack() as stack:
-        for p in _patches(covered_fn):
-            stack.enter_context(p)
-        await conv._dispatch_conversation_event(db, conversation, msg, org_id, sender)
-
-    # 후보 = 멘션된 agent 만(authorized=mentioned 우선)
-    assert seen_candidates["set"] == {agent_mentioned}
-    recipients = {ev.recipient_id for ev in db.added}
-    # 멘션된 covered agent 는 스킵, 멘션 안 된 participant 는 유지
-    assert recipients == {agent_not_mentioned}
-
-
-# ─── FORK2: human 은 webhook 보유여도 Event 무변경 ────────────────────────────
-
-@pytest.mark.anyio
-async def test_human_never_skipped():
+async def test_human_never_skipped_even_if_in_covered():
     import contextlib
 
     org_id = uuid.uuid4()
@@ -163,16 +122,42 @@ async def test_human_never_skipped():
         _result_all([(human, "human")]),
     ])
 
-    async def covered_fn(_db, _org, candidates):
-        assert set(candidates) == set()  # human 은 후보 아님 — 헬퍼 호출돼도 빈 후보
-        return set()
-
     with contextlib.ExitStack() as stack:
-        for p in _patches(covered_fn):
+        for p in _patches():
             stack.enter_context(p)
-        await conv._dispatch_conversation_event(db, conversation, msg, org_id, sender)
+        # human id 를 covered 에 일부러 넣어도 human Event 는 생성돼야(is_agent 가드)
+        await conv._dispatch_conversation_event(
+            db, conversation, msg, org_id, sender, webhook_covered_ids={human},
+        )
 
     assert {ev.recipient_id for ev in db.added} == {human}
+
+
+# ─── covered 없으면(빈/None) 전원 SSE 유지 ─────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_no_covered_keeps_all_agents():
+    import contextlib
+
+    org_id = uuid.uuid4()
+    sender = _sender()
+    agent_a = uuid.uuid4()
+    conversation = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    msg = _msg()
+
+    db = _DB([
+        _result_all([(agent_a,)]),
+        _result_all([(agent_a, "agent")]),
+    ])
+
+    with contextlib.ExitStack() as stack:
+        for p in _patches():
+            stack.enter_context(p)
+        await conv._dispatch_conversation_event(
+            db, conversation, msg, org_id, sender, webhook_covered_ids=None,
+        )
+
+    assert {ev.recipient_id for ev in db.added} == {agent_a}
 
 
 # ─── mention 경로: covered mentioned agent 스킵, uncovered 유지 ────────────────
@@ -193,13 +178,12 @@ async def test_mention_path_gates_covered_agent():
         _result_all([(agent_cov, "agent"), (agent_unc, "agent")]),  # member_type
     ])
 
-    async def covered_fn(_db, _org, candidates):
-        assert set(candidates) == {agent_cov, agent_unc}
-        return {agent_cov}
-
     with contextlib.ExitStack() as stack:
-        for p in _patches(covered_fn):
+        for p in _patches():
             stack.enter_context(p)
-        await conv._dispatch_mention_events(db, conversation, msg, org_id, sender, targets)
+        await conv._dispatch_mention_events(
+            db, conversation, msg, org_id, sender, targets,
+            webhook_covered_ids={agent_cov},
+        )
 
     assert {ev.recipient_id for ev in db.added} == {agent_unc}

--- a/backend/tests/test_event1config_message_gating.py
+++ b/backend/tests/test_event1config_message_gating.py
@@ -1,0 +1,205 @@
+"""E-EVENT-1CONFIG Part A: 메시지 경로 SSE 게이팅 가드 (이중수신 박멸).
+
+_dispatch_conversation_event / _dispatch_mention_events 가 webhook-covered agent recipient 의
+SSE Event 를 스킵하되, ①비-mentioned participant ②human ③비-covered agent 는 SSE 유지함을
+가드한다. active_webhook_member_ids(SSOT)는 별도 단위테스트(test_webhook_targeting)로 검증 —
+여기선 authorized-set 계산 + skip 결정만 격리 검증(헬퍼는 patch).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import app.routers.conversations as conv
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _result_all(rows: list):
+    r = SimpleNamespace()
+    r.all = lambda: rows
+    return r
+
+
+def _msg(mentioned=None):
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        conversation_id=uuid.uuid4(),
+        thread_id=None,
+        reply_count=0,
+        last_reply_at=None,
+        content="hi",
+        mentioned_ids=list(mentioned or []),
+        attachments=[],
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def _sender():
+    return SimpleNamespace(id=uuid.uuid4(), name="송신자", type="human")
+
+
+async def _assign_seq(_db, event):
+    event.recipient_seq = 1
+
+
+class _DB:
+    """participant→member_type execute 2발 + add 캡처. webhook 헬퍼는 patch라 execute 미사용."""
+
+    def __init__(self, exec_rows: list):
+        self._exec_rows = list(exec_rows)
+        self.added: list = []
+        self.add = lambda ev: self.added.append(ev)
+        self.flush = AsyncMock()
+
+    async def execute(self, *_a, **_k):
+        return self._exec_rows.pop(0)
+
+
+def _patches(covered_fn):
+    return [
+        patch.object(conv, "assign_recipient_seq", _assign_seq),
+        patch("app.services.activity_stream.extract_activities_best_effort", AsyncMock()),
+        patch.object(conv, "active_webhook_member_ids", covered_fn),
+        patch("app.services.presence_events.emit_conversation_working", lambda *_a, **_k: None),
+        patch("app.services.presence_events.emit_presence", lambda *_a, **_k: None),
+    ]
+
+
+# ─── AC1: covered agent 는 스킵, uncovered agent·human 은 유지 ──────────────────
+
+@pytest.mark.anyio
+async def test_covered_agent_skipped_others_kept():
+    import contextlib
+
+    org_id = uuid.uuid4()
+    sender = _sender()
+    agent_cov = uuid.uuid4()
+    agent_unc = uuid.uuid4()
+    human = uuid.uuid4()
+    conversation = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    msg = _msg()
+
+    db = _DB([
+        _result_all([(agent_cov,), (agent_unc,), (human,), (sender.id,)]),  # participants
+        _result_all([(agent_cov, "agent"), (agent_unc, "agent"), (human, "human")]),  # types
+    ])
+
+    async def covered_fn(_db, _org, candidates):
+        assert set(candidates) == {agent_cov, agent_unc}  # human 은 후보 아님
+        return {agent_cov}
+
+    with contextlib.ExitStack() as stack:
+        for p in _patches(covered_fn):
+            stack.enter_context(p)
+        out = await conv._dispatch_conversation_event(db, conversation, msg, org_id, sender)
+
+    recipients = {ev.recipient_id for ev in db.added}
+    assert recipients == {agent_unc, human}, "covered agent 만 SSE 스킵"
+    assert agent_cov not in recipients
+    # 반환 push 페이로드도 covered 제외
+    assert {uuid.UUID(pid) for pid, _ in out} == {agent_unc, human}
+
+
+# ─── AC2/grant-only: mentioned 있으면 비-mentioned participant 는 후보 제외(skip 금지) ──
+
+@pytest.mark.anyio
+async def test_non_mentioned_participant_not_skipped_even_with_webhook():
+    """멘션 있는 메시지: 멘션 안 된 participant agent 는 webhook 보유여도 SSE 유지(silent loss 0)."""
+    import contextlib
+
+    org_id = uuid.uuid4()
+    sender = _sender()
+    agent_mentioned = uuid.uuid4()
+    agent_not_mentioned = uuid.uuid4()  # webhook 보유하지만 멘션 안 됨
+    conversation = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    msg = _msg(mentioned=[agent_mentioned])
+
+    db = _DB([
+        _result_all([(agent_mentioned,), (agent_not_mentioned,)]),
+        _result_all([(agent_mentioned, "agent"), (agent_not_mentioned, "agent")]),
+    ])
+
+    seen_candidates = {}
+
+    async def covered_fn(_db, _org, candidates):
+        seen_candidates["set"] = set(candidates)
+        # 둘 다 webhook 보유라 가정해도, 후보에 든 멤버만 covered 가능
+        return set(candidates)
+
+    with contextlib.ExitStack() as stack:
+        for p in _patches(covered_fn):
+            stack.enter_context(p)
+        await conv._dispatch_conversation_event(db, conversation, msg, org_id, sender)
+
+    # 후보 = 멘션된 agent 만(authorized=mentioned 우선)
+    assert seen_candidates["set"] == {agent_mentioned}
+    recipients = {ev.recipient_id for ev in db.added}
+    # 멘션된 covered agent 는 스킵, 멘션 안 된 participant 는 유지
+    assert recipients == {agent_not_mentioned}
+
+
+# ─── FORK2: human 은 webhook 보유여도 Event 무변경 ────────────────────────────
+
+@pytest.mark.anyio
+async def test_human_never_skipped():
+    import contextlib
+
+    org_id = uuid.uuid4()
+    sender = _sender()
+    human = uuid.uuid4()
+    conversation = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    msg = _msg()
+
+    db = _DB([
+        _result_all([(human,)]),
+        _result_all([(human, "human")]),
+    ])
+
+    async def covered_fn(_db, _org, candidates):
+        assert set(candidates) == set()  # human 은 후보 아님 — 헬퍼 호출돼도 빈 후보
+        return set()
+
+    with contextlib.ExitStack() as stack:
+        for p in _patches(covered_fn):
+            stack.enter_context(p)
+        await conv._dispatch_conversation_event(db, conversation, msg, org_id, sender)
+
+    assert {ev.recipient_id for ev in db.added} == {human}
+
+
+# ─── mention 경로: covered mentioned agent 스킵, uncovered 유지 ────────────────
+
+@pytest.mark.anyio
+async def test_mention_path_gates_covered_agent():
+    import contextlib
+
+    org_id = uuid.uuid4()
+    sender = _sender()
+    agent_cov = uuid.uuid4()
+    agent_unc = uuid.uuid4()
+    conversation = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    msg = _msg(mentioned=[agent_cov, agent_unc])
+    targets = {agent_cov, agent_unc}
+
+    db = _DB([
+        _result_all([(agent_cov, "agent"), (agent_unc, "agent")]),  # member_type
+    ])
+
+    async def covered_fn(_db, _org, candidates):
+        assert set(candidates) == {agent_cov, agent_unc}
+        return {agent_cov}
+
+    with contextlib.ExitStack() as stack:
+        for p in _patches(covered_fn):
+            stack.enter_context(p)
+        await conv._dispatch_mention_events(db, conversation, msg, org_id, sender, targets)
+
+    assert {ev.recipient_id for ev in db.added} == {agent_unc}

--- a/backend/tests/test_event1config_webhook_targets.py
+++ b/backend/tests/test_event1config_webhook_targets.py
@@ -1,0 +1,161 @@
+"""E-EVENT-1CONFIG: resolve_conversation_webhook_targets SSOT 가드.
+
+이 함수가 SSE-skip covered set 과 실제 webhook delivery 대상의 단일 출처다(TOCTOU 차단).
+가드: ①sender self-mention 제외(Finding 2) ②mentioned 우선·없으면 participants(sender 제외)
+③member-bound project-독립 union ④member_id=null 브로드캐스트 포함하되 covered 엔 미포함.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.conversation_webhook import (
+    _EVENT_TYPE,
+    resolve_conversation_webhook_targets,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _wh(member_id, events=None):
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        url=f"https://h/{uuid.uuid4()}",
+        secret=None,
+        events=events if events is not None else [_EVENT_TYPE],
+        member_id=member_id,
+    )
+
+
+def _scalars(rows: list) -> MagicMock:
+    r = MagicMock()
+    r.scalars.return_value.all.return_value = rows
+    return r
+
+
+@pytest.mark.anyio
+async def test_sender_excluded_from_mentioned_finding2():
+    """멘션에 sender 가 포함돼도 sender webhook 은 전달 대상 아님(skip authorized set 과 통일)."""
+    org, proj, sender, agent_a = (uuid.uuid4() for _ in range(4))
+    wh_sender = _wh(sender)
+    wh_a = _wh(agent_a)
+    wh_bcast = _wh(None)
+
+    db = SimpleNamespace(execute=AsyncMock(side_effect=[
+        _scalars([wh_sender, wh_a, wh_bcast]),  # project-scope
+        _scalars([wh_a]),                       # member-global union(member_id IN [agent_a])
+    ]))
+
+    targets = await resolve_conversation_webhook_targets(
+        db, conversation_id=uuid.uuid4(), org_id=org, project_id=proj,
+        sender_id=sender, mentioned_ids=[sender, agent_a],
+    )
+    member_ids = {t.member_id for t in targets}
+    assert sender not in member_ids, "sender self-mention 제외(Finding 2)"
+    assert agent_a in member_ids
+    assert None in member_ids, "member_id=null 브로드캐스트 포함"
+    covered = {t.member_id for t in targets if t.member_id is not None}
+    assert covered == {agent_a}, "covered 엔 broadcast 미포함·sender 미포함"
+
+
+@pytest.mark.anyio
+async def test_mention_only_sender_yields_no_member_target():
+    """sender 가 자기만 멘션 → authorized 0 → member-bound 대상 없음(broadcast 만 가능)."""
+    org, proj, sender = (uuid.uuid4() for _ in range(3))
+    wh_sender = _wh(sender)
+    wh_bcast = _wh(None)
+
+    db = SimpleNamespace(execute=AsyncMock(side_effect=[
+        _scalars([wh_sender, wh_bcast]),  # project-scope: sender 는 authorized 아님→제외, bcast 유지
+        # member-global union 은 member_ids_for_webhook=[] 이라 호출 안 됨
+    ]))
+
+    targets = await resolve_conversation_webhook_targets(
+        db, conversation_id=uuid.uuid4(), org_id=org, project_id=proj,
+        sender_id=sender, mentioned_ids=[sender],
+    )
+    assert {t.member_id for t in targets} == {None}, "broadcast 만 — sender member webhook 제외"
+
+
+@pytest.mark.anyio
+async def test_no_mention_uses_participants_minus_sender():
+    """멘션 없으면 참가자(sender 제외) authorized — participant 쿼리 1발 선행."""
+    org, proj, conv_id, sender, agent_a = (uuid.uuid4() for _ in range(5))
+    wh_a = _wh(agent_a)
+
+    db = SimpleNamespace(execute=AsyncMock(side_effect=[
+        _scalars([agent_a]),   # participant query (.scalars().all())
+        _scalars([wh_a]),      # project-scope
+        _scalars([wh_a]),      # member-global union
+    ]))
+
+    targets = await resolve_conversation_webhook_targets(
+        db, conversation_id=conv_id, org_id=org, project_id=proj,
+        sender_id=sender, mentioned_ids=None,
+    )
+    assert {t.member_id for t in targets} == {agent_a}
+
+
+# ─── 실DB 전체 predicate (project 독립·sender 제외·broadcast) ──────────────────
+
+_ASYNCPG_URL = (
+    os.getenv("DATABASE_URL", "").replace("postgresql+asyncpg://", "postgresql://")
+    or None
+)
+_requires_db = pytest.mark.skipif(
+    not _ASYNCPG_URL, reason="DATABASE_URL not set — real DB test skipped"
+)
+
+
+@_requires_db
+@pytest.mark.anyio
+async def test_resolve_predicate_realdb():
+    """실DB: member-bound project-독립 union·sender 제외·broadcast 포함."""
+    from app.core.database import async_session_factory
+    from app.models.webhook_config import WebhookConfig
+
+    org = uuid.uuid4()
+    proj_x, proj_y = uuid.uuid4(), uuid.uuid4()
+    sender, agent_a = uuid.uuid4(), uuid.uuid4()
+
+    async with async_session_factory() as db:
+        # agent_a webhook 은 proj_y 스코프(메시지는 proj_x) — project 독립 union 검증
+        db.add_all([
+            WebhookConfig(id=uuid.uuid4(), org_id=org, project_id=proj_y,
+                          member_id=agent_a, url="https://h/a", is_active=True,
+                          events=[_EVENT_TYPE]),
+            WebhookConfig(id=uuid.uuid4(), org_id=org, project_id=proj_x,
+                          member_id=sender, url="https://h/s", is_active=True,
+                          events=[_EVENT_TYPE]),
+            WebhookConfig(id=uuid.uuid4(), org_id=org, project_id=proj_x,
+                          member_id=None, url="https://h/b", is_active=True,
+                          events=[_EVENT_TYPE]),
+        ])
+        await db.commit()
+        try:
+            targets = await resolve_conversation_webhook_targets(
+                db, conversation_id=uuid.uuid4(), org_id=org, project_id=proj_x,
+                sender_id=sender, mentioned_ids=[sender, agent_a],
+            )
+            member_ids = {t.member_id for t in targets}
+            assert agent_a in member_ids, "타 프로젝트 member-bound 도 union 으로 covered(project 독립)"
+            assert sender not in member_ids, "sender 제외(Finding 2)"
+            assert None in member_ids, "broadcast 포함"
+        finally:
+            for mid in (agent_a, sender):
+                await db.execute(
+                    WebhookConfig.__table__.delete().where(WebhookConfig.member_id == mid)
+                )
+            await db.execute(
+                WebhookConfig.__table__.delete().where(
+                    WebhookConfig.org_id == org, WebhookConfig.member_id.is_(None)
+                )
+            )
+            await db.commit()

--- a/backend/tests/test_webhook_targeting.py
+++ b/backend/tests/test_webhook_targeting.py
@@ -1,0 +1,140 @@
+"""E-EVENT-1CONFIG: active_webhook_member_ids 공용 SSOT 가드.
+
+이중수신 박멸의 단일 진실원. member-bound(project-독립) 활성 webhook 보유 멤버만 반환하고,
+입력 None 필터·fail-open(조회 실패=빈 집합=스킵 0)을 결정적으로 가드한다.
+
+예측 semantics(project-독립·broadcast 제외·org 격리)는 실DB 가드(아래 _requires_db)에서 검증.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.webhook_targeting import active_webhook_member_ids
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _scalars_result(member_ids: list[uuid.UUID]) -> MagicMock:
+    """select(WebhookConfig.member_id) → scalars().all() 결과 mock."""
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = member_ids
+    return result
+
+
+@pytest.mark.anyio
+async def test_empty_member_ids_short_circuits_no_db():
+    """빈 입력 → DB 조회 없이 빈 집합."""
+    db = AsyncMock()
+    db.execute = AsyncMock()
+    out = await active_webhook_member_ids(db, uuid.uuid4(), [])
+    assert out == set()
+    db.execute.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_only_none_member_ids_short_circuits():
+    """None만 들어오면(예: 익명/미해소) DB 조회 없이 빈 집합 — None 필터."""
+    db = AsyncMock()
+    db.execute = AsyncMock()
+    out = await active_webhook_member_ids(db, uuid.uuid4(), [None, None])
+    assert out == set()
+    db.execute.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_returns_members_with_active_member_bound_webhook():
+    """member-bound 활성 webhook 보유 멤버만 반환."""
+    covered = uuid.uuid4()
+    uncovered = uuid.uuid4()
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalars_result([covered]))
+    out = await active_webhook_member_ids(db, uuid.uuid4(), [covered, uncovered])
+    assert out == {covered}
+
+
+@pytest.mark.anyio
+async def test_fail_open_on_db_error_returns_empty():
+    """조회 실패 → 빈 집합(아무도 스킵 안 함). webhook 판정 실패가 SSE 전달을 막지 않는다."""
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=RuntimeError("boom"))
+    out = await active_webhook_member_ids(db, uuid.uuid4(), [uuid.uuid4()])
+    assert out == set()
+
+
+@pytest.mark.anyio
+async def test_none_filtered_but_real_ids_still_queried():
+    """None 섞여 있어도 실 멤버는 정상 조회(None만 제거)."""
+    real = uuid.uuid4()
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalars_result([real]))
+    out = await active_webhook_member_ids(db, uuid.uuid4(), [None, real])
+    assert out == {real}
+    db.execute.assert_called_once()
+
+
+# ─── 실DB 예측 semantics 가드 (project-독립·broadcast 제외·org 격리) ──────────────
+
+_ASYNCPG_URL = (
+    os.getenv("DATABASE_URL", "").replace("postgresql+asyncpg://", "postgresql://")
+    or None
+)
+_requires_db = pytest.mark.skipif(
+    not _ASYNCPG_URL, reason="DATABASE_URL not set — real DB test skipped"
+)
+
+
+@_requires_db
+@pytest.mark.anyio
+async def test_predicate_semantics_realdb():
+    """실DB: member-bound는 project 독립으로 covered, broadcast(null)은 제외, 타 org 격리."""
+    from app.core.database import async_session_factory
+    from app.models.webhook_config import WebhookConfig
+
+    org_a, org_b = uuid.uuid4(), uuid.uuid4()
+    proj_x, proj_y = uuid.uuid4(), uuid.uuid4()
+    agent_member_proj = uuid.uuid4()   # webhook이 proj_x 스코프인 member-bound
+    agent_broadcast_only = uuid.uuid4()  # 자기 webhook 없음, broadcast만 존재
+    agent_cross_org = uuid.uuid4()     # 타 org webhook
+    agent_inactive = uuid.uuid4()      # is_active=False
+
+    async with async_session_factory() as db:
+        db.add_all([
+            WebhookConfig(id=uuid.uuid4(), org_id=org_a, project_id=proj_x,
+                          member_id=agent_member_proj, url="https://h/1", is_active=True),
+            WebhookConfig(id=uuid.uuid4(), org_id=org_a, project_id=proj_x,
+                          member_id=None, url="https://h/bcast", is_active=True),
+            WebhookConfig(id=uuid.uuid4(), org_id=org_b, project_id=proj_y,
+                          member_id=agent_cross_org, url="https://h/2", is_active=True),
+            WebhookConfig(id=uuid.uuid4(), org_id=org_a, project_id=proj_x,
+                          member_id=agent_inactive, url="https://h/3", is_active=False),
+        ])
+        await db.commit()
+        try:
+            # org_a 기준 조회: proj_y 대화여도 member-bound는 project 독립으로 covered.
+            out = await active_webhook_member_ids(
+                db, org_a,
+                [agent_member_proj, agent_broadcast_only, agent_cross_org, agent_inactive],
+            )
+            assert agent_member_proj in out, "member-bound는 project 독립으로 covered"
+            assert agent_broadcast_only not in out, "broadcast(null)은 멤버 커버 아님 — 제외"
+            assert agent_cross_org not in out, "타 org webhook 격리"
+            assert agent_inactive not in out, "비활성 webhook 제외"
+        finally:
+            for mid in (agent_member_proj, agent_cross_org, agent_inactive):
+                await db.execute(
+                    WebhookConfig.__table__.delete().where(WebhookConfig.member_id == mid)
+                )
+            await db.execute(
+                WebhookConfig.__table__.delete().where(
+                    WebhookConfig.org_id.in_([org_a, org_b]),
+                    WebhookConfig.member_id.is_(None),
+                )
+            )
+            await db.commit()


### PR DESCRIPTION
## 요약 (story 5a99842b · E-EVENT-1CONFIG · 정공법/백절불굴)

선생님 관측 2건의 근본을 단일경로 전달로 박멸한다: ① webhook ON인데 fakechat(SSE)으로도 같은 메시지가 오는 **이중수신**, ② restart 때 대량 **backfill**.

PO 초기 spec은 "project-scoped 게이팅"이었으나, 머지된 c2dfb823(d21089f1) 실 코드를 까보니 member-bound webhook 전달이 **project 독립**이라 판정 기준을 정정(FORK1). 산티아고군 보안 컨설트로 `notification_dispatch member-only predicate == deliver_conversation_message_webhook member-bound target predicate`를 SSOT로 확정.

## Part A — 메시지 경로 SSE 게이팅 (이중수신 박멸)

- **`active_webhook_member_ids` 공용 SSOT 신설** (`app/services/webhook_targeting.py`): member-bound(project-독립) 활성 webhook 보유 멤버 판정. `member_id=null` 브로드캐스트는 멤버 세션 채널이 아니므로 제외(silent loss 0). fail-open(조회 실패=빈 집합=skip 0).
- **`_dispatch_conversation_event` / `_dispatch_mention_events`** (`conversations.py`): webhook-covered agent recipient의 SSE Event/seq/`_push_to_agent` 스킵 — webhook 경로가 동일 메시지를 전달. **human Event는 무변경**(웹 UI SSE=events.py status 별경로·FORK2).
- 판정 스코프 = 실 전달 predicate와 대칭: `authorized = mentioned 우선·없으면 participants(sender 제외)` / `member_id == agent` / `is_active` / **project 필터 없음**. 비-mentioned participant는 webhook 미커버 → SSE 유지.
- **`notification_dispatch`의 inline webhook 판정을 공용 헬퍼로 통일**(인가 약화 0·기존 거동 무회귀).

## Part B — backfill landmine 박멸

- **`ack_event`** (`agent_gateway.py`): ACK한 이벤트(`recipient_seq <= seq`인 pending agent SSE 이벤트)를 같은 트랜잭션에서 `delivered` 마킹 → cleanup 회수 가능. 기존엔 `acked_seq`만 전진해 `status='pending'` 영구 잔존 → 무한 적재.
- **expire-stale를 cron 연결**: `events.py` expire 로직을 `expire_stale_events_core(db, org_id)`로 추출(endpoint·cron 공유). cron `GET /api/v2/internal/cron/expire-stale-events`(전 org 일괄) + FE 프록시 route 신설. (스케줄러 등록은 PO 인프라 담당.)
- **0136 마이그**: webhook-covered agent의 기존 pending agent-event 1회 drain(새 ACK 거동과 동형·idempotent·fresh-runnable·downgrade no-op).

## AC 충족

- **AC1** 이중수신 박멸: covered agent SSE 0·webhook만 → `test_event1config_message_gating`
- **AC2** 스코프 정합/grant-only: 비-mentioned participant·human은 skip 금지 → 동 테스트 + `test_webhook_targeting`(실DB project-독립·broadcast 제외·org 격리)
- **AC3** 게이팅 통일·무회귀: `test_notification_dispatch` 9건 그린 유지
- **AC4** backfill retire: ACK 후 delivered·cleanup 회수 → `test_event1config_ack_retire`·`test_event1config_expire_cron`(라우트 등록 가드 포함)
- **AC6** 무회귀: 채팅 204·c2dfb823 참가자 게이팅·mentioned 경로 무회귀(전체 스위트)

## 테스트

로컬 전체 pytest **2453 passed** (실패 8건은 모두 `skipif(CI)` DoD 환경 테스트 — 로컬 MCP 프로세스 수/.mcp.json 경로 의존, 변경 모듈 무참조). 실DB 가드는 `DATABASE_URL` 미설정 시 skip. FE route는 기존 cron route(inbox-outbox 등) 동형 미러 — CI Build/Type가 검증.

## 범위 밖 (합의)

- webhook 최종 실패 시 SSE 자동 fallback: dual-path 복잡도 재유입 위험 → 별도 하드닝 스토리. 현재 webhook 최종 실패는 `_retry_deliver`의 `logger.error` + `ConversationWebhookDelivery.status='failed'`로 관측 가능.
- 스케줄러(Cloud Scheduler 등) 등록: PO 인프라.
- c60dd33c(story/activity `fire_webhooks` 400)는 webhook 송신측 별건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
