### PR TITLE
[SID:c60dd33c] story/activity 이벤트 Discord 400 + 과다 fan-out 박멸

### DIFF
--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -20,40 +20,15 @@ import httpx
 
 from app.models.conversation_webhook_delivery import ConversationWebhookDelivery
 from app.models.webhook_config import WebhookConfig
+# c60dd33c: Discord payload 변환은 공용 헬퍼(discord_webhook)로 단일화 — fire_webhooks 와 공유.
+from app.services.discord_webhook import is_discord_url as _is_discord_url
+from app.services.discord_webhook import to_discord_message_payload as _to_discord_payload
 
 logger = logging.getLogger(__name__)
 
 _EVENT_TYPE = "conversation.message_created"
 _MAX_RETRIES = 3
 _BACKOFF_BASE = 1.0  # seconds
-
-
-_DISCORD_URL_PATTERNS = ("discord.com/api/webhooks", "discordapp.com/api/webhooks")
-
-
-def _is_discord_url(url: str) -> bool:
-    return any(pat in url for pat in _DISCORD_URL_PATTERNS)
-
-
-def _to_discord_payload(payload: dict) -> dict:
-    """Sprintable webhook payload → Discord content 포맷 변환 (_fire_webhook 스타일)."""
-    content_text = (payload.get("content") or "")[:500]
-    conversation_id = payload.get("conversation_id", "")
-    thread_id = payload.get("thread_id") or ""
-
-    discord_content = f"📩 **새 메시지**"
-    if content_text:
-        discord_content += f"\n{content_text}"
-    if conversation_id:
-        discord_content += f"\n\nconversation_id: {conversation_id}"
-    if thread_id:
-        discord_content += f"\nmessage_id: {thread_id}"
-
-    result: dict = {"content": discord_content}
-    app_url = __import__("os").environ.get("NEXT_PUBLIC_APP_URL", "")
-    if app_url and conversation_id:
-        result["embeds"] = [{"title": "대화 보기", "url": f"{app_url}/conversations/{conversation_id}"}]
-    return result
 
 
 def _sign_payload(secret: str, body: bytes) -> str:

--- a/backend/app/services/discord_webhook.py
+++ b/backend/app/services/discord_webhook.py
@@ -1,0 +1,83 @@
+"""Discord webhook 페이로드 변환 공용 헬퍼 (c60dd33c).
+
+Discord incoming webhook 은 ``{content|embeds}`` 형식이 필수다. Sprintable raw envelope
+(``{event, data}`` 또는 conversation payload)를 그대로 POST 하면 **400 Bad Request** 로 거절된다.
+채팅 경로(conversation_webhook)와 generic 이벤트 경로(webhook_dispatch.fire_webhooks)가 같은
+변환 로직을 쓰도록 단일 진실원으로 추출 — 중복 0.
+
+라우팅/retry/status 는 이 모듈의 책임이 아니다(payload normalize 전용).
+"""
+from __future__ import annotations
+
+import os
+
+_DISCORD_URL_PATTERNS = ("discord.com/api/webhooks", "discordapp.com/api/webhooks")
+
+
+def is_discord_url(url: str) -> bool:
+    return any(pat in url for pat in _DISCORD_URL_PATTERNS)
+
+
+def to_discord_message_payload(payload: dict) -> dict:
+    """conversation.message_created payload → Discord content 포맷.
+
+    (conversation_webhook._to_discord_payload 에서 이전 — 채팅 전달 거동 byte-동형 유지.)
+    """
+    content_text = (payload.get("content") or "")[:500]
+    conversation_id = payload.get("conversation_id", "")
+    thread_id = payload.get("thread_id") or ""
+
+    discord_content = "📩 **새 메시지**"
+    if content_text:
+        discord_content += f"\n{content_text}"
+    if conversation_id:
+        discord_content += f"\n\nconversation_id: {conversation_id}"
+    if thread_id:
+        discord_content += f"\nmessage_id: {thread_id}"
+
+    result: dict = {"content": discord_content}
+    app_url = os.environ.get("NEXT_PUBLIC_APP_URL", "")
+    if app_url and conversation_id:
+        result["embeds"] = [{"title": "대화 보기", "url": f"{app_url}/conversations/{conversation_id}"}]
+    return result
+
+
+def to_discord_event_payload(event: str, data: dict) -> dict:
+    """generic 이벤트 envelope(``{event, data}``) → Discord content 포맷.
+
+    fire_webhooks 가 story/activity·file_conflict 등 모든 이벤트를 Discord 로 보낼 때 사용.
+    핵심 필드(제목·상태전이·actor)가 있으면 사람-친화 렌더, 없으면 event 명만으로도 유효
+    payload(=204). 항상 최소 ``{content}`` 를 보장해 400 을 차단한다.
+    """
+    content = f"🔔 **{event}**"
+
+    title = data.get("story_title") or data.get("title")
+    if title:
+        content += f"\n{title}"
+
+    old_status = data.get("old_status")
+    new_status = data.get("new_status") or data.get("status")
+    if old_status and new_status:
+        content += f"\n{old_status} → {new_status}"
+    elif new_status:
+        content += f"\n상태: {new_status}"
+
+    actor_name = data.get("actor_name")
+    if actor_name:
+        content += f"\nby {actor_name}"
+
+    reason = data.get("reason")
+    if reason:
+        content += f"\n{reason}"
+
+    result: dict = {"content": content[:2000]}  # Discord content 한도 2000자
+
+    app_url = os.environ.get("NEXT_PUBLIC_APP_URL", "")
+    story_id = data.get("story_id")
+    project_id = data.get("project_id")
+    if app_url and story_id and project_id:
+        result["embeds"] = [{
+            "title": "스토리 보기",
+            "url": f"{app_url}/projects/{project_id}/stories/{story_id}",
+        }]
+    return result

--- a/backend/app/services/story_status_events.py
+++ b/backend/app/services/story_status_events.py
@@ -77,9 +77,22 @@ async def emit_story_status_changed(
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
+    # c60dd33c: webhook 게이팅 기준 = 알림 대상(assignee/actor)과 동일 notify_ids. dispatch_notification
+    # 과 공유하므로 fire_webhooks 호출 전에 먼저 산출한다.
+    notify_ids: set[uuid.UUID] = set()
+    if story.assignee_id:
+        notify_ids.add(story.assignee_id)
+    if actor_id and actor_id != story.assignee_id:
+        notify_ids.add(actor_id)
+
     publish_event(str(org_id), "story.status_changed", event_data)
     try:
-        await fire_webhooks(db, org_id, "story.status_changed", event_data)
+        # AC2: story.status_changed 의 member-bound webhook 은 관련자(notify_ids)만 수신 → org-wide
+        # 과다 fan-out 차단. member_id=null 진짜 activity-feed 브로드캐스트는 보존(preserve_broadcast).
+        await fire_webhooks(
+            db, org_id, "story.status_changed", event_data,
+            recipient_member_ids=notify_ids,
+        )
     except Exception:
         pass
     try:
@@ -97,11 +110,6 @@ async def emit_story_status_changed(
     except Exception:
         pass
 
-    notify_ids: set[uuid.UUID] = set()
-    if story.assignee_id:
-        notify_ids.add(story.assignee_id)
-    if actor_id and actor_id != story.assignee_id:
-        notify_ids.add(actor_id)
     if notify_ids:
         # notif도 best-effort 격리 — gate 경로는 flush後 commit前 emit이라 notif 실패가 story done을
         # 롤백할 수 있다. 나머지 4 side-effect와 동일하게 isolation.

--- a/backend/app/services/webhook_dispatch.py
+++ b/backend/app/services/webhook_dispatch.py
@@ -14,6 +14,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.ssrf import validate_webhook_url_async
 from app.models.webhook_config import WebhookConfig
+# c60dd33c: Discord 페이로드 정규화 공용 헬퍼(채팅 경로와 단일화).
+from app.services.discord_webhook import is_discord_url, to_discord_event_payload
 
 
 def _build_signature_headers(secret: str | None, body: str) -> dict[str, str]:
@@ -27,29 +29,65 @@ def _build_signature_headers(secret: str | None, body: str) -> dict[str, str]:
     }
 
 
-async def fire_webhooks(session: AsyncSession, org_id: uuid.UUID, event: str, data: dict[str, Any]) -> None:
+async def fire_webhooks(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    event: str,
+    data: dict[str, Any],
+    *,
+    recipient_member_ids: set[uuid.UUID] | None = None,
+    preserve_broadcast: bool = True,
+) -> None:
+    """org webhook 발화 (c60dd33c).
+
+    **Discord 정규화(AC1)**: discord URL 에는 raw envelope 대신 ``{content|embeds}`` 변환
+    (``to_discord_event_payload``)을 보낸다 — 기존엔 raw envelope POST 라 discord 전원 400.
+    채팅 경로(conversation_webhook)와 동일 헬퍼·동형 거동. routing/retry/status 는 불변.
+
+    **타겟 게이팅(AC2·opt-in)**: ``recipient_member_ids`` 가 주어지면 member-bound webhook
+    (``member_id`` != null)은 그 집합의 멤버만 수신해 story/activity 의 org-wide 과다 fan-out 을
+    차단한다. ``member_id IS NULL`` 진짜 activity-feed 브로드캐스트는 ``preserve_broadcast`` 시
+    보존. **``recipient_member_ids`` 가 None(기본)이면 게이팅 없음 = 기존 fan-out 동작**이라 타
+    호출부(file_conflict·assignee_changed·workflow_violation)는 무회귀.
+    """
     result = await session.execute(
-        select(WebhookConfig.url, WebhookConfig.secret, WebhookConfig.events)
-        .where(WebhookConfig.org_id == org_id, WebhookConfig.is_active.is_(True))
+        select(
+            WebhookConfig.url,
+            WebhookConfig.secret,
+            WebhookConfig.events,
+            WebhookConfig.member_id,
+        ).where(WebhookConfig.org_id == org_id, WebhookConfig.is_active.is_(True))
     )
     configs = result.all()
     if not configs:
         return
 
-    payload_obj = {"event": event, "data": data}
-    body = json.dumps(payload_obj)
+    envelope_body = json.dumps({"event": event, "data": data})
+    discord_body = json.dumps(to_discord_event_payload(event, data))
 
     async with httpx.AsyncClient(timeout=10.0, follow_redirects=False) as client:
-        for row in configs:
-            url, secret, events = row
+        for url, secret, events, member_id in configs:
             if events and event not in events:
                 continue
+            # AC2 게이팅(opt-in): recipient_member_ids 주어진 경우만 적용. None=기존 동작.
+            if recipient_member_ids is not None:
+                if member_id is None:
+                    if not preserve_broadcast:
+                        continue  # broadcast 인데 보존 끄면 drop
+                elif member_id not in recipient_member_ids:
+                    continue  # member-bound 인데 관련자 아님 → drop(과다 fan-out 차단)
             # dispatch 시 IP 재검증 (DNS rebinding 방지)
             try:
                 await validate_webhook_url_async(url)
             except ValueError:
                 continue
-            headers = {"Content-Type": "application/json", **_build_signature_headers(secret, body)}
+            if is_discord_url(url):
+                # AC1: Discord 는 {content|embeds} 필수 + 서명 헤더 없음(채팅 경로와 동형).
+                body = discord_body
+                headers = {"Content-Type": "application/json"}
+            else:
+                body = envelope_body
+                headers = {"Content-Type": "application/json", **_build_signature_headers(secret, body)}
             try:
                 await client.post(url, content=body, headers=headers)
             except Exception:

--- a/backend/tests/test_c60dd33c_webhook_payload_gating.py
+++ b/backend/tests/test_c60dd33c_webhook_payload_gating.py
@@ -1,0 +1,181 @@
+"""c60dd33c: fire_webhooks Discord 페이로드 정규화(AC1) + 타겟 게이팅(AC2) 가드.
+
+BUG: fire_webhooks 가 ① raw envelope 를 Discord 에 그대로 POST(400) ② org 전 활성 webhook 에
+무차별 fan-out. fix: discord URL 은 {content} 변환, recipient_member_ids 주어지면 member-bound
+게이팅(broadcast 보존). None 이면 기존 동작(타 호출부 무회귀).
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import app.services.webhook_dispatch as wd
+from app.services.discord_webhook import (
+    is_discord_url,
+    to_discord_event_payload,
+    to_discord_message_payload,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ─── AC1: discord payload 정규화 ──────────────────────────────────────────────
+
+def test_to_discord_event_payload_has_content_not_envelope():
+    """이벤트 envelope 가 아니라 Discord {content} 형식이어야 400 안 난다."""
+    out = to_discord_event_payload("story.status_changed", {
+        "story_title": "[BE] 단일경로 전달", "old_status": "in-review", "new_status": "done",
+        "actor_name": "오르테가",
+    })
+    assert "content" in out and "event" not in out and "data" not in out
+    assert "story.status_changed" in out["content"]
+    assert "in-review → done" in out["content"]
+    assert len(out["content"]) <= 2000
+
+
+def test_to_discord_event_payload_minimal_still_valid():
+    """핵심 필드 없어도 최소 {content}(event명) 보장 — file_conflict 류도 204."""
+    out = to_discord_event_payload("file_conflict", {"severity": "warn"})
+    assert out["content"].strip() and "file_conflict" in out["content"]
+
+
+def test_is_discord_url():
+    assert is_discord_url("https://discord.com/api/webhooks/1/abc")
+    assert is_discord_url("https://discordapp.com/api/webhooks/1/abc")
+    assert not is_discord_url("https://hooks.example.com/x")
+
+
+def test_conversation_message_payload_unchanged_regression():
+    """AC3: 채팅 경로 discord payload 동형 유지(📩 새 메시지)."""
+    out = to_discord_message_payload({"content": "안녕", "conversation_id": "c1", "thread_id": "t1"})
+    assert out["content"].startswith("📩 **새 메시지**")
+    assert "안녕" in out["content"] and "conversation_id: c1" in out["content"]
+
+
+# ─── fire_webhooks 통합: discord 변환 + 게이팅 ────────────────────────────────
+
+def _session(configs):
+    """session.execute(...).all() → configs(list of (url, secret, events, member_id))."""
+    res = MagicMock()
+    res.all.return_value = configs
+    s = MagicMock()
+    s.execute = AsyncMock(return_value=res)
+    return s
+
+
+class _MockClient:
+    def __init__(self, sink):
+        self._sink = sink
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def post(self, url, content=None, headers=None):
+        self._sink.append({"url": url, "body": content, "headers": headers or {}})
+        return MagicMock()
+
+
+def _patches(sink):
+    return [
+        patch.object(wd.httpx, "AsyncClient", lambda *a, **k: _MockClient(sink)),
+        patch.object(wd, "validate_webhook_url_async", new=AsyncMock()),
+    ]
+
+
+DISCORD = "https://discord.com/api/webhooks/1/tok"
+GENERIC = "https://hook.example.com/x"
+
+
+@pytest.mark.anyio
+async def test_discord_gets_content_generic_gets_envelope():
+    """AC1: discord URL→{content}(서명 없음), generic→envelope(+서명)."""
+    import contextlib
+    sink: list = []
+    member = uuid.uuid4()
+    configs = [
+        (DISCORD, None, [], member),
+        (GENERIC, "sec", [], member),
+    ]
+    with contextlib.ExitStack() as st:
+        for p in _patches(sink):
+            st.enter_context(p)
+        await wd.fire_webhooks(_session(configs), uuid.uuid4(), "story.status_changed",
+                               {"story_title": "T"}, recipient_member_ids={member})
+
+    by_url = {p["url"]: p for p in sink}
+    dc = json.loads(by_url[DISCORD]["body"])
+    assert "content" in dc and "event" not in dc
+    assert "X-Sprintable-Signature" not in by_url[DISCORD]["headers"]  # discord 서명 없음
+    gen = json.loads(by_url[GENERIC]["body"])
+    assert gen["event"] == "story.status_changed" and "data" in gen
+    assert "X-Sprintable-Signature" in by_url[GENERIC]["headers"]
+
+
+@pytest.mark.anyio
+async def test_gating_member_bound_only_relevant_broadcast_preserved():
+    """AC2: recipient_member_ids 주어지면 member-bound는 관련자만·broadcast(null) 보존·무관 drop."""
+    import contextlib
+    sink: list = []
+    relevant = uuid.uuid4()
+    other = uuid.uuid4()
+    configs = [
+        ("https://discord.com/api/webhooks/relevant", None, [], relevant),  # 포함
+        ("https://discord.com/api/webhooks/other", None, [], other),        # drop
+        ("https://discord.com/api/webhooks/broadcast", None, [], None),     # 보존
+    ]
+    with contextlib.ExitStack() as st:
+        for p in _patches(sink):
+            st.enter_context(p)
+        await wd.fire_webhooks(_session(configs), uuid.uuid4(), "story.status_changed",
+                               {"story_title": "T"}, recipient_member_ids={relevant})
+
+    urls = {p["url"] for p in sink}
+    assert urls == {
+        "https://discord.com/api/webhooks/relevant",
+        "https://discord.com/api/webhooks/broadcast",
+    }, "관련자 member-bound + broadcast만, 무관 member-bound drop"
+
+
+@pytest.mark.anyio
+async def test_none_recipient_keeps_existing_fanout():
+    """AC3 무회귀: recipient_member_ids=None → 게이팅 0(전 활성 webhook 발송) = 기존 동작."""
+    import contextlib
+    sink: list = []
+    configs = [
+        ("https://discord.com/api/webhooks/a", None, [], uuid.uuid4()),
+        ("https://discord.com/api/webhooks/b", None, [], uuid.uuid4()),
+        ("https://discord.com/api/webhooks/c", None, [], None),
+    ]
+    with contextlib.ExitStack() as st:
+        for p in _patches(sink):
+            st.enter_context(p)
+        await wd.fire_webhooks(_session(configs), uuid.uuid4(), "file_conflict",
+                               {"severity": "warn"})  # recipient_member_ids 미전달
+
+    assert len(sink) == 3, "None이면 전원 발송(기존 fan-out 유지)"
+
+
+@pytest.mark.anyio
+async def test_events_filter_still_applies():
+    """이벤트 구독 필터(events) 회귀 가드 — 미구독 이벤트는 skip."""
+    import contextlib
+    sink: list = []
+    member = uuid.uuid4()
+    configs = [
+        (DISCORD, None, ["other.event"], member),  # story.status_changed 미구독 → skip
+    ]
+    with contextlib.ExitStack() as st:
+        for p in _patches(sink):
+            st.enter_context(p)
+        await wd.fire_webhooks(_session(configs), uuid.uuid4(), "story.status_changed",
+                               {"story_title": "T"}, recipient_member_ids={member})
+    assert sink == []


### PR DESCRIPTION
## 요약 (story c60dd33c · E-EVENT-1CONFIG)

내가 c2dfb823/5a99842b 검증 중 dev 로그로 포착한 후속 결함. `fire_webhooks`가 story/activity 이벤트를 ① **raw envelope로 Discord에 POST → 전원 400 Bad Request**(전달 0) ② **org 전 활성 webhook에 무차별 fan-out**(전 에이전트 글로벌 member-bound 포함). 채팅(conversation.message_created)은 `_to_discord_payload` 변환이 있어 204 정상 — 정확한 대조로 근본 확정.

산티아고 보안 컨설트 SSOT 채택: `member_id IS NULL`만 broadcast, member-bound는 명시 관련자만, 공용 util에 무조건 게이팅 금지(opt-in).

## AC1 — Discord 400 (payload 정규화)
- **`app/services/discord_webhook.py`** 공용 헬퍼 신설: `is_discord_url` · `to_discord_message_payload`(채팅) · `to_discord_event_payload`(generic 이벤트). 항상 최소 `{content}` 보장 → 400 차단.
- `conversation_webhook`의 로컬 `_is_discord_url`/`_to_discord_payload`를 이 헬퍼로 **단일화**(채팅 discord payload byte-동형 유지·중복 0).
- `fire_webhooks`: discord URL → `{content|embeds}` 변환(서명 헤더 없음·채팅 경로와 동형), generic → envelope+서명. **routing/retry/status 불변**.

## AC2 — 과다 fan-out (opt-in 타겟 게이팅)
- `fire_webhooks(..., recipient_member_ids: set|None=None, preserve_broadcast=True)`.
  - `recipient_member_ids` 주어지면: member-bound webhook(member_id != null)은 그 집합(관련자)만 수신, `member_id IS NULL` 진짜 activity-feed 브로드캐스트는 보존.
  - **`None`(기본) = 게이팅 0 = 기존 fan-out 동작** → 타 호출부(`file_conflict`·`story.assignee_changed`·`workflow_violation`) 무회귀.
- `emit_story_status_changed`만 `recipient_member_ids=notify_ids`(assignee+actor) 전달.

## AC 충족
- **AC1**: `test_to_discord_event_payload_*`(content 형식·최소 보장)·`test_discord_gets_content_generic_gets_envelope`(fire_webhooks 변환)
- **AC2**: `test_gating_member_bound_only_relevant_broadcast_preserved`(관련자만·broadcast 보존·무관 drop)·`test_none_recipient_keeps_existing_fanout`(None 무회귀)
- **AC3 회귀**: `test_conversation_message_payload_unchanged_regression`(채팅 📩 동형)·`test_events_filter_still_applies` + 기존 `test_emit_story_status_changed_isolation`·`test_s4_1_file_conflict`·`test_s3_2_violation_warn` 그린 유지
- **AC4**: 머지+dev 배포 후 story status 변경 1회 → webhook 400 0건 라이브 재확인(로그 첨부) 예정

## 테스트
로컬 전체 pytest **2464 passed**(실패 8건은 모두 `skipif(CI)` 환경 DoD 테스트 — 변경 모듈 무참조). 신규 8 케이스.

## 비고
- `deployment_lifecycle._fire_webhooks`는 별개 함수(공유 util 아님) — 범위 밖.
- 산티아고 review 포인트(project 과소필터 0·null broadcast 보존·타 호출부 fan-out 유지·chat payload 동형) 전부 충족.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
