### PR TITLE
fix(deploy): CI 배포에 FASTAPI_URL 런타임 env 주입 (OB-1 fast-follow)

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -106,6 +106,10 @@ steps:
       # gcloud run deploy 가 기존 IAM 을 preserve(non-deterministic) → 신규/리셋 시 allUsers invoker
       # 유실로 403(2026-06-21 prod promotion 사건). 명시적·멱등 설정으로 매 배포 public 보장(dev/prod 공통).
       - --allow-unauthenticated
+      # OB-1: 에이전트 onboarding generator 가 읽는 backend-direct URL 을 런타임 env 로 주입.
+      # ⚠️ 반드시 --update-env-vars(additive·기존 backend env[DATABASE_URL 등] 보존). --set-env-vars 금지
+      # (전체 wipe). _FASTAPI_URL 은 dev/prod 각 backend-direct run.app(프론트 NEXT_PUBLIC_FASTAPI_URL 과 동일 값).
+      - --update-env-vars=FASTAPI_URL=${_FASTAPI_URL}
       - --quiet
     waitFor: [push-backend]
 


### PR DESCRIPTION
## 갭 (OB-1 dev-verify 적출·PO)
CI 배포는 `cloudbuild.yaml` deploy-backend 스텝으로 도는데 image+instances+allow-unauth만 설정하고 **backend 런타임 env를 안 건드림**. `_FASTAPI_URL`은 프론트(`NEXT_PUBLIC_FASTAPI_URL`)에만 먹임. `deploy_backend.sh`(OB-1서 FASTAPI_URL 추가)는 **수동 전용·CI 경로 아님** → dev backend에 FASTAPI_URL 부재 → OB-1 generator가 `localhost:8000` fallback → **dev 아티팩트 깨짐**.

## fix
deploy-backend 스텝에 `--update-env-vars=FASTAPI_URL=${_FASTAPI_URL}` 한 줄.
- ⚠️ **`--update-env-vars`(additive·기존 env 보존)** — `--set-env-vars`는 전체 wipe(DATABASE_URL 등 유실)라 **금지**.
- `_FASTAPI_URL`은 dev/prod 각 backend-direct run.app(프론트와 동일 substitution·gh-action이 env별 주입). 매 CI 배포가 멱등 주입(서비스 재생성에도 안전).
- `deploy_backend.sh` 라인은 수동 배포용으로 유지.

## 검증
YAML valid. dev 배포 후 `GET /api/v2/agents/{id}/connection-artifact` content의 SPRINTABLE_API_URL이 backend-direct run.app(localhost 아님) 확인 = OB-1 done 봉인 조건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)