### PR TITLE
[SID:3447782e] OB-2 verify-connection + verification-status (실 SSE 라운드트립)

### DIFF
--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -24,6 +24,7 @@ from app.services.agent_onboarding_config import (
     SUPPORTED_RUNTIMES,
     build_agent_mcp_config,
 )
+from app.services.agent_verify import get_verification_state, start_verification
 from app.services.org_agent import create_org_level_agent
 
 router = APIRouter(prefix="/api/v2/agents", tags=["agents"])
@@ -158,4 +159,76 @@ async def get_agent_connection_artifact(
         "content": json.dumps(artifact, indent=2, ensure_ascii=False),
         "agent_id": str(member.id),
         "runtime": runtime,
+    }
+
+
+async def _fetch_org_agent(session: AsyncSession, agent_id: uuid.UUID, org_id: uuid.UUID):
+    """org-scope agent 조회(anti-IDOR). team_members projection VIEW 멀티행 → .limit(1)."""
+    return (await session.execute(
+        select(TeamMember).where(
+            TeamMember.id == agent_id,
+            TeamMember.org_id == org_id,
+            TeamMember.type == "agent",
+        ).limit(1)
+    )).scalar_one_or_none()
+
+
+@router.post("/{agent_id}/verify-connection")
+async def verify_agent_connection(
+    agent_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """OB-2 AC1: 합성 connection_test Event 를 **실 SSE 경로**로 발사 → 라운드트립 verify 시작.
+
+    single-target(AC3): 해당 agent 1명에게만 — fire_webhooks/org 브로드캐스트 미사용. 이벤트는
+    실 /agent/stream 경로(우회 X)로 가고, 에이전트가 ack 하면(acked_seq>=seq) verified 가 된다.
+    응답은 verification-status 와 동일한 6단계 레일(초기 상태)을 같이 실어 FE 가 즉시 렌더하게 한다.
+    """
+    member = await _fetch_org_agent(session, agent_id, org_id)
+    if member is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    if not member.project_id:
+        raise HTTPException(status_code=400, detail="agent has no project scope to verify")
+
+    seq = await start_verification(
+        session, agent_id=agent_id, org_id=org_id, project_id=member.project_id
+    )
+    await session.commit()
+
+    # commit 후 SSE 스트림 nudge(단일 타겟). payload 미포함 — 스트림이 seq>acked_seq 재조회로 가져간다.
+    from app.routers.agent_gateway import wake_agent
+    wake_agent(str(agent_id), seq)
+
+    state = await get_verification_state(session, agent_id)
+    return {
+        "agent_id": str(agent_id),
+        "verification_seq": seq,
+        "verified": state["verified"],
+        "rail": state["rail"],
+    }
+
+
+@router.get("/{agent_id}/verification-status")
+async def agent_verification_status(
+    agent_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """OB-2 AC2: 6단계 레일 폴링/조회(BE↔FE 계약 락). SSE 우선·이 poll 은 fallback.
+
+    각 단계 ``{state, status: pending|active|done}``. ack/verified 는 acked_seq>=seq 권위 신호만.
+    """
+    member = await _fetch_org_agent(session, agent_id, org_id)
+    if member is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    state = await get_verification_state(session, agent_id)
+    return {
+        "agent_id": str(agent_id),
+        "verification_seq": state["verify_seq"],
+        "verified": state["verified"],
+        "rail": state["rail"],
     }

--- a/backend/app/services/agent_verify.py
+++ b/backend/app/services/agent_verify.py
@@ -1,0 +1,125 @@
+"""OB-2: 에이전트 connection verify — 합성 이벤트를 실 SSE 라운드트립으로 확증 (블루프린트 §4).
+
+`POST verify-connection` 이 ``onboarding.connection_test`` 합성 Event 를 만들어 **실 /agent/stream
+경로**(우회 X·``assign_recipient_seq`` + ``wake_agent`` · single-target)로 보내고, `GET
+verification-status` 가 ``acked_seq`` vs 그 seq + 세션 freshness 로 6단계 레일을 도출한다.
+
+신규 테이블 없음 — 합성 Event(=record) + ``AgentEventCursor.acked_seq`` + ``AgentGatewaySession``
+재사용. **ack/verified 는 ``acked_seq >= seq`` 권위 신호만**(낙관 0). ``event_delivered`` 는
+reachable~ack 사이 active 로 표현한다 — 게이트웨이 ack-커서 모델상 per-event delivered 를 ack 와
+별개로 durable 마킹하는 신호가 없고, /agent/stream 핫패스를 건드리지 않는다(AC4·PO 확정).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.agent_gateway import AgentEventCursor, AgentGatewaySession
+from app.models.event import Event
+from app.services.event_seq import assign_recipient_seq
+
+VERIFY_EVENT_TYPE = "onboarding.connection_test"
+# 6단계 canonical 레일(OB-3 1:1·OB-4 vocab 정합). config_copied 는 FE 권위(BE 는 waiting 부터 관측).
+RAIL_STATES = ("config_copied", "waiting", "mcp_reachable", "event_delivered", "ack", "verified")
+
+
+def build_verification_rail(
+    *,
+    verify_seq: int | None,
+    acked_seq: int | None,
+    has_fresh_session: bool,
+) -> list[dict]:
+    """6단계 레일 도출(순수). 각 ``{state, status: pending|active|done}``.
+
+    - ``verify_seq is None``(verify 미시작) → 전 단계 pending.
+    - ``acked_seq >= verify_seq``(권위) → waiting~verified 전부 done.
+    - fresh session·미-ack → waiting/mcp_reachable done·event_delivered **active**·ack/verified pending.
+    - 미-reachable·미-ack → waiting active·이후 pending.
+    """
+    if verify_seq is None:
+        return [{"state": s, "status": "pending"} for s in RAIL_STATES]
+
+    acked = acked_seq is not None and acked_seq >= verify_seq
+    rail: list[dict] = [{"state": "config_copied", "status": "done"}]  # verify 시작=copy 선행 간주
+    if acked:
+        tail = [
+            ("waiting", "done"), ("mcp_reachable", "done"),
+            ("event_delivered", "done"), ("ack", "done"), ("verified", "done"),
+        ]
+    elif has_fresh_session:
+        tail = [
+            ("waiting", "done"), ("mcp_reachable", "done"),
+            ("event_delivered", "active"), ("ack", "pending"), ("verified", "pending"),
+        ]
+    else:
+        tail = [
+            ("waiting", "active"), ("mcp_reachable", "pending"),
+            ("event_delivered", "pending"), ("ack", "pending"), ("verified", "pending"),
+        ]
+    rail += [{"state": s, "status": st} for s, st in tail]
+    return rail
+
+
+async def start_verification(
+    db: AsyncSession, *, agent_id: uuid.UUID, org_id: uuid.UUID, project_id: uuid.UUID
+) -> int:
+    """합성 connection_test Event INSERT + per-recipient seq 발급. 호출자가 commit + wake_agent.
+
+    single-target(AC3): recipient = 해당 agent 1명만. fire_webhooks / org 브로드캐스트 미사용.
+    """
+    event = Event(
+        project_id=project_id,
+        org_id=org_id,
+        event_type=VERIFY_EVENT_TYPE,
+        source_entity_type="agent",
+        source_entity_id=agent_id,
+        sender_id=None,
+        recipient_id=agent_id,
+        recipient_type="agent",
+        payload={"kind": "connection_test", "agent_id": str(agent_id)},
+        status="pending",
+    )
+    db.add(event)
+    await db.flush()
+    return await assign_recipient_seq(db, event)
+
+
+async def _has_fresh_session(db: AsyncSession, agent_id: uuid.UUID) -> bool:
+    """에이전트가 현재 /agent/stream 연결 중인지(= mcp_reachable). 게이트웨이의 동일 freshness TTL 사용."""
+    from app.routers.agent_gateway import _SESSION_FRESH_TTL  # lazy: 순환 import 회피
+
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=_SESSION_FRESH_TTL)
+    row = (await db.execute(
+        select(AgentGatewaySession.id).where(
+            AgentGatewaySession.agent_id == agent_id,
+            AgentGatewaySession.last_seen_at >= cutoff,
+        ).limit(1)
+    )).first()
+    return row is not None
+
+
+async def get_verification_state(db: AsyncSession, agent_id: uuid.UUID) -> dict:
+    """최신 verify Event seq + acked_seq + 세션 freshness → 레일/verified."""
+    verify_seq = (await db.execute(
+        select(Event.recipient_seq).where(
+            Event.recipient_id == agent_id,
+            Event.event_type == VERIFY_EVENT_TYPE,
+            Event.recipient_seq.isnot(None),
+        ).order_by(desc(Event.recipient_seq)).limit(1)
+    )).scalar_one_or_none()
+
+    acked_seq = (await db.execute(
+        select(AgentEventCursor.acked_seq).where(AgentEventCursor.agent_id == agent_id)
+    )).scalar_one_or_none()
+
+    fresh = await _has_fresh_session(db, agent_id) if verify_seq is not None else False
+    rail = build_verification_rail(
+        verify_seq=verify_seq, acked_seq=acked_seq, has_fresh_session=fresh
+    )
+    verified = (
+        verify_seq is not None and acked_seq is not None and acked_seq >= verify_seq
+    )
+    return {"verify_seq": verify_seq, "acked_seq": acked_seq, "verified": verified, "rail": rail}

--- a/backend/tests/test_ob2_verify_connection.py
+++ b/backend/tests/test_ob2_verify_connection.py
@@ -1,0 +1,147 @@
+"""OB-2: verify-connection + verification-status 가드 (블루프린트 §4).
+
+6단계 레일(config_copied→waiting→mcp_reachable→event_delivered→ack→verified) 도출 + 엔드포인트.
+ack/verified 는 acked_seq>=seq 권위 신호만(낙관 0).
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import app.routers.agents as ag
+from app.services.agent_verify import (
+    RAIL_STATES,
+    build_verification_rail,
+    get_verification_state,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _states(rail):
+    return {r["state"]: r["status"] for r in rail}
+
+
+# ─── rail builder (pure) ──────────────────────────────────────────────────────
+
+def test_rail_order_is_canonical_6():
+    rail = build_verification_rail(verify_seq=1, acked_seq=0, has_fresh_session=False)
+    assert [r["state"] for r in rail] == list(RAIL_STATES)
+    assert len(rail) == 6
+
+
+def test_rail_not_started_all_pending():
+    rail = build_verification_rail(verify_seq=None, acked_seq=None, has_fresh_session=False)
+    assert all(r["status"] == "pending" for r in rail)
+
+
+def test_rail_waiting_not_reachable():
+    s = _states(build_verification_rail(verify_seq=5, acked_seq=None, has_fresh_session=False))
+    assert s["config_copied"] == "done"
+    assert s["waiting"] == "active"
+    assert s["mcp_reachable"] == "pending" and s["verified"] == "pending"
+
+
+def test_rail_reachable_inflight_delivered_active():
+    s = _states(build_verification_rail(verify_seq=5, acked_seq=3, has_fresh_session=True))
+    assert s["waiting"] == "done" and s["mcp_reachable"] == "done"
+    assert s["event_delivered"] == "active"
+    assert s["ack"] == "pending" and s["verified"] == "pending"
+
+
+def test_rail_acked_all_done():
+    s = _states(build_verification_rail(verify_seq=5, acked_seq=5, has_fresh_session=True))
+    assert all(s[k] == "done" for k in RAIL_STATES)
+
+
+def test_rail_ack_is_authoritative_no_optimism():
+    """acked_seq>=seq면 session freshness 무관 verified(권위 신호만·낙관 0)."""
+    s = _states(build_verification_rail(verify_seq=5, acked_seq=9, has_fresh_session=False))
+    assert s["ack"] == "done" and s["verified"] == "done"
+
+
+# ─── get_verification_state (mock db) ─────────────────────────────────────────
+
+def _scalar(v):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = v
+    return r
+
+
+def _first(v):
+    r = MagicMock()
+    r.first.return_value = v
+    return r
+
+
+@pytest.mark.anyio
+async def test_get_state_acked_verified():
+    db = AsyncMock()
+    # execute 순서: verify_seq, acked_seq, session-fresh
+    db.execute = AsyncMock(side_effect=[_scalar(5), _scalar(7), _first(("sess",))])
+    out = await get_verification_state(db, uuid.uuid4())
+    assert out["verified"] is True
+    assert _states(out["rail"])["verified"] == "done"
+
+
+@pytest.mark.anyio
+async def test_get_state_no_verify_all_pending():
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_scalar(None), _scalar(None)])  # verify_seq None → session 미조회
+    out = await get_verification_state(db, uuid.uuid4())
+    assert out["verified"] is False
+    assert all(r["status"] == "pending" for r in out["rail"])
+
+
+# ─── endpoints (handler-direct) ───────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_verify_connection_404():
+    from fastapi import HTTPException
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar(None))
+    with pytest.raises(HTTPException) as ei:
+        await ag.verify_agent_connection(
+            uuid.uuid4(), session=db, auth=MagicMock(), org_id=uuid.uuid4()
+        )
+    assert ei.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_verify_connection_starts_single_target_and_returns_rail():
+    member = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar(member))
+    db.commit = AsyncMock()
+    rail = [{"state": s, "status": "pending"} for s in RAIL_STATES]
+    with patch.object(ag, "start_verification", new=AsyncMock(return_value=42)) as start, \
+         patch.object(ag, "get_verification_state",
+                      new=AsyncMock(return_value={"verified": False, "rail": rail, "verify_seq": 42})), \
+         patch("app.routers.agent_gateway.wake_agent", new=MagicMock()) as wake:
+        out = await ag.verify_agent_connection(
+            member.id, session=db, auth=MagicMock(), org_id=uuid.uuid4()
+        )
+    assert out["verification_seq"] == 42 and out["rail"] == rail
+    start.assert_awaited_once()  # single-target verify 시작
+    wake.assert_called_once()    # SSE nudge(단일 타겟·fire_webhooks 미사용)
+    db.commit.assert_awaited()
+
+
+@pytest.mark.anyio
+async def test_verification_status_returns_rail():
+    member = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar(member))
+    rail = [{"state": s, "status": "done"} for s in RAIL_STATES]
+    with patch.object(ag, "get_verification_state",
+                      new=AsyncMock(return_value={"verified": True, "rail": rail, "verify_seq": 9})):
+        out = await ag.agent_verification_status(
+            member.id, session=db, auth=MagicMock(), org_id=uuid.uuid4()
+        )
+    assert out["verified"] is True and out["rail"] == rail


### PR DESCRIPTION
## 요약 (E-ONBOARDING-DX OB-2 · 블루프린트 §4)
신규 유저가 .mcp.json 붙인 뒤 제품이 **실제 작동을 라운드트립으로 확증**(초록=진짜). OB-3 wizard verify 레일의 BE(critical path).

## AC1 — POST /api/v2/agents/{id}/verify-connection
합성 Event(recipient=agent·type=`onboarding.connection_test`)를 `assign_recipient_seq`로 seq 발급 → commit → `wake_agent`로 **실 /agent/stream 경로**(우회 X) nudge. 에이전트 ack(`acked_seq>=seq`)면 verified. **single-target(AC3)**: 해당 agent 1명만 — fire_webhooks/org 브로드캐스트 미사용.

## AC2 — GET /api/v2/agents/{id}/verification-status
BE↔FE 계약 락(OB-3 레일 1:1): 6단계 `{state, status: pending|active|done}` — config_copied→waiting→mcp_reachable→event_delivered→ack→verified. SSE 우선·이 poll fallback.
- 매핑(PO fork 확정·핫패스 무변경): waiting/mcp_reachable=fresh `AgentGatewaySession`·event_delivered=reachable~ack 사이 **active**·**ack/verified=`acked_seq>=seq` 권위 신호만**(낙관 0). `build_verification_rail` 순수함수로 결정적.

## AC3/AC4
fire_webhooks 미사용·단일 agent. **/agent/stream+ack 불변**(per-event delivered 마킹 안 함·PO 거부 수용)·단일경로 fix 불변·합성 event는 ack시 ack-retire→cleanup 회수(backlog 오염 0). **신규 테이블 0**(합성 Event + acked_seq + AgentGatewaySession 재사용).

## 테스트
rail 도출 전이 전수·get_state·엔드포인트(404·single-target·rail) **신규 11**. 로컬 전체 pytest **2480 passed**(실패 8=CI-skip 환경 DoD). 산티아고 보안(anti-IDOR·single-target) 리뷰 권장.

> 의존: OB-1(#1716 머지됨) 위. FASTAPI_URL 배포 갭은 #1717로 별도 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)