### PR TITLE
[SID:8f05409b] OB-4 onboarding funnel — events 테이블 + POST 엔드포인트 + BE emit seam (5/8)

### DIFF
--- a/backend/alembic/versions/0137_onboarding_events.py
+++ b/backend/alembic/versions/0137_onboarding_events.py
@@ -1,0 +1,54 @@
+"""OB-4: onboarding_events append-only funnel 계측 store.
+
+블루프린트 §6 · 측정계약 doc(`ob-4-onboarding-funnel-measurement-contract`). FE emit 4종 + BE
+emit 8종을 단일 append-only 테이블에 캡처. ``session_id``(FE 조인키)·``agent_id``(post-auth)·dims.
+**키 평문 미저장**(``key_prefix`` prefix-only·AC3).
+
+additive·신규 테이블·백필 불요. baseline schema.sql 미변경(post-0096 신규 테이블·0130~0136 동형 —
+fresh-DB CI[baseline + alembic upgrade head]가 0137 적용·create_all 금지). fresh-runnable·idempotent.
+
+Revision ID: 0137
+Revises: 0136
+Create Date: 2026-06-25
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0137"
+down_revision = "0136"
+branch_labels = None
+depends_on = None
+
+_INDEX_COLS = ("event", "session_id", "agent_id", "env", "runtime", "failure_reason", "server_ts")
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS onboarding_events (
+            id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            event         text NOT NULL,
+            session_id    uuid,
+            agent_id      uuid,
+            org_id        uuid,
+            project_id    uuid,
+            runtime       text,
+            env           text,
+            transport     text,
+            key_prefix    text,
+            failure_reason text,
+            client_ts     timestamptz,
+            meta          jsonb NOT NULL DEFAULT '{}'::jsonb,
+            server_ts     timestamptz NOT NULL DEFAULT now()
+        )
+        """
+    )
+    for col in _INDEX_COLS:
+        op.execute(
+            f"CREATE INDEX IF NOT EXISTS ix_onboarding_events_{col} ON onboarding_events ({col})"
+        )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS onboarding_events")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -56,7 +56,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -182,6 +182,7 @@ app.include_router(retros.router)
 app.include_router(entities.router)
 app.include_router(event_notifications.router)
 app.include_router(notifications.router)
+app.include_router(onboarding.router)
 app.include_router(attachments.router)
 app.include_router(notification_preferences.router)
 app.include_router(analytics.router)

--- a/backend/app/models/onboarding_event.py
+++ b/backend/app/models/onboarding_event.py
@@ -1,0 +1,36 @@
+"""OB-4: onboarding_events 모델 (append-only funnel 계측).
+
+측정계약 doc §2/§5. 키 평문 미저장(key_prefix prefix-only). server_ts=권위 시각(서버 스탬프).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class OnboardingEvent(Base):
+    __tablename__ = "onboarding_events"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    event: Mapped[str] = mapped_column(Text, nullable=False)
+    # session_id = FE wizard 조인 키(pre-auth↔post-auth 연결). agent_id = 발급 이후만.
+    session_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    agent_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    org_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    project_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    runtime: Mapped[str | None] = mapped_column(Text, nullable=True)
+    env: Mapped[str | None] = mapped_column(Text, nullable=True)
+    transport: Mapped[str | None] = mapped_column(Text, nullable=True)
+    key_prefix: Mapped[str | None] = mapped_column(Text, nullable=True)  # prefix-only(≤12)·평문키 금지
+    failure_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    client_ts: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    meta: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    server_ts: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -480,6 +480,8 @@ async def ack_event(
         select(AgentEventCursor).where(AgentEventCursor.agent_id == agent_id)
     )).scalar_one_or_none()
 
+    prior_acked = existing.acked_seq if existing else 0  # OB-4: verify 완료 감지 기준선
+
     if existing is None:
         db.add(AgentEventCursor(agent_id=agent_id, acked_seq=body.seq))
     elif body.seq > existing.acked_seq:
@@ -502,6 +504,24 @@ async def ack_event(
         )
         .values(status="delivered", delivered_at=datetime.now(timezone.utc))
     )
+
+    # OB-4 seam: 새로 ack된 범위(prior_acked < seq <= body.seq)에 verify connection_test 가 있으면
+    # ack_received + verified 발화(verify 라운드트립 완료·funnel·non-blocking·verify-ack에만 한정).
+    if body.seq > prior_acked:
+        from app.services.agent_verify import VERIFY_EVENT_TYPE
+        from app.services.onboarding_funnel import emit_onboarding_event
+        _verify_done = (await db.execute(
+            select(Event.id).where(
+                Event.recipient_id == agent_id,
+                Event.event_type == VERIFY_EVENT_TYPE,
+                Event.recipient_seq.isnot(None),
+                Event.recipient_seq > prior_acked,
+                Event.recipient_seq <= body.seq,
+            ).limit(1)
+        )).first()
+        if _verify_done:
+            await emit_onboarding_event(db, "ack_received", agent_id=agent_id)
+            await emit_onboarding_event(db, "verified", agent_id=agent_id)
 
     await db.commit()
     return {"acked_seq": body.seq}

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -25,6 +25,7 @@ from app.services.agent_onboarding_config import (
     build_agent_mcp_config,
 )
 from app.services.agent_verify import get_verification_state, start_verification
+from app.services.onboarding_funnel import emit_onboarding_event, safe_key_prefix
 from app.services.org_agent import create_org_level_agent
 
 router = APIRouter(prefix="/api/v2/agents", tags=["agents"])
@@ -121,6 +122,14 @@ async def create_org_agent(
     response["mcp_config"] = build_agent_mcp_config(api_key_plaintext=api_key_plaintext)
     if api_key_plaintext:
         response["api_key"] = api_key_plaintext
+
+    # OB-4 seam: agent_created (funnel·non-blocking·fail-silent). key_prefix=prefix-only(평문키 금지).
+    await emit_onboarding_event(
+        session, "agent_created", agent_id=member.id, org_id=org_id,
+        project_id=(project_ids[0] if project_ids else None),
+        runtime="claude-code", transport="stdio", key_prefix=safe_key_prefix(api_key_plaintext),
+    )
+    await session.commit()
     return response
 
 
@@ -153,6 +162,14 @@ async def get_agent_connection_artifact(
         raise HTTPException(status_code=404, detail="Agent not found")
 
     artifact = build_agent_mcp_config(api_key_plaintext=_API_KEY_PLACEHOLDER, runtime=runtime)
+
+    # OB-4 seam: config_generated (generator 아티팩트 반환·funnel·non-blocking).
+    await emit_onboarding_event(
+        session, "config_generated", agent_id=member.id, org_id=org_id,
+        runtime=runtime, transport="stdio",
+    )
+    await session.commit()
+
     # BE↔FE 계약 락(OB-3 wizard 1:1 렌더): content = paste-ready .mcp.json **문자열**(dict 아님).
     return {
         "filename": ".mcp.json",
@@ -194,6 +211,11 @@ async def verify_agent_connection(
 
     seq = await start_verification(
         session, agent_id=agent_id, org_id=org_id, project_id=member.project_id
+    )
+    # OB-4 seam: event_sent (합성 verify 이벤트 디스패치·funnel·non-blocking·verify tx 동승).
+    await emit_onboarding_event(
+        session, "event_sent", agent_id=agent_id, org_id=org_id,
+        project_id=member.project_id, runtime="claude-code", transport="stdio",
     )
     await session.commit()
 

--- a/backend/app/routers/onboarding.py
+++ b/backend/app/routers/onboarding.py
@@ -1,0 +1,102 @@
+"""OB-4: 온보딩 funnel 이벤트 수신 엔드포인트 (측정계약 doc §2).
+
+`POST /api/v2/onboarding/events` — OB-3 프록시가 보내는 FE emit 4종(+BE도 가능)의 끝단.
+**optional auth**: agent 키 있으면 서버가 agent_id/org_id/project_id/key_prefix 도출(서버-truth·클라
+신뢰 금지), 없으면 pre-auth(익명·session_id만). **PII 가드(AC3)**: 전체키 형태 발견 시 422 reject·
+key_prefix ≤12. 측정 끝단이라 fire-and-forget(202).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import _resolve_api_key, bearer_scheme
+from app.dependencies.database import get_db
+from app.services.onboarding_funnel import (
+    EVENT_CATALOG,
+    FAILURE_REASONS,
+    KEY_PREFIX_MAX,
+    contains_secret,
+    record_onboarding_event,
+    safe_key_prefix,
+)
+
+router = APIRouter(prefix="/api/v2/onboarding", tags=["onboarding"])
+
+
+class OnboardingEventBody(BaseModel):
+    event: str
+    session_id: uuid.UUID | None = None
+    agent_id: uuid.UUID | None = None
+    runtime: str | None = None
+    env: str | None = None
+    transport: str | None = None
+    key_prefix: str | None = None
+    failure_reason: str | None = None
+    client_ts: datetime | None = None
+    meta: dict = Field(default_factory=dict)
+
+
+@router.post("/events", status_code=202)
+async def post_onboarding_event(
+    body: OnboardingEventBody,
+    db: AsyncSession = Depends(get_db),
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+    x_agent_api_key: str | None = Header(default=None, alias="x-agent-api-key"),
+) -> dict:
+    # AC1: 이벤트 enum(11) 화이트리스트 — 그 외 422.
+    if body.event not in EVENT_CATALOG:
+        raise HTTPException(status_code=422, detail=f"unknown event: {body.event}")
+    if body.failure_reason and body.failure_reason not in FAILURE_REASONS:
+        raise HTTPException(status_code=422, detail=f"unknown failure_reason: {body.failure_reason}")
+
+    # AC3: PII/시크릿 가드 — 어느 필드(key_prefix·meta 등)든 전체키 형태면 reject(저장 금지).
+    if contains_secret(body.model_dump(mode="json")):
+        raise HTTPException(status_code=422, detail="plaintext secret detected — rejected")
+    if body.key_prefix and len(body.key_prefix) > KEY_PREFIX_MAX:
+        raise HTTPException(status_code=422, detail="key_prefix must be prefix-only (≤12)")
+
+    # optional auth: 키 있으면 서버-truth 우선(클라 agent_id/key_prefix 신뢰 금지·§5).
+    agent_id = body.agent_id
+    org_id: uuid.UUID | None = None
+    project_id: uuid.UUID | None = None
+    key_prefix = body.key_prefix
+    raw_key = (
+        x_agent_api_key
+        if (x_agent_api_key and x_agent_api_key.startswith("sk_"))
+        else (credentials.credentials if credentials else None)
+    )
+    if raw_key:
+        try:
+            ctx = await _resolve_api_key(raw_key, db)
+            app_meta = ctx.claims.get("app_metadata", {})
+            agent_id = uuid.UUID(ctx.user_id)
+            org_id = uuid.UUID(app_meta["org_id"]) if app_meta.get("org_id") else None
+            project_id = uuid.UUID(app_meta["project_id"]) if app_meta.get("project_id") else None
+            key_prefix = safe_key_prefix(raw_key)  # 서버측 prefix(클라 미신뢰)
+        except Exception:
+            # 키 무효 → pre-auth(익명) 취급. 측정 끝단은 reject보다 best-effort 캡처 우선.
+            pass
+
+    await record_onboarding_event(
+        db,
+        event=body.event,
+        session_id=body.session_id,
+        agent_id=agent_id,
+        org_id=org_id,
+        project_id=project_id,
+        runtime=body.runtime,
+        env=body.env,
+        transport=body.transport,
+        key_prefix=key_prefix,
+        failure_reason=body.failure_reason,
+        client_ts=body.client_ts,
+        meta=body.meta,
+    )
+    await db.commit()
+    return {"ok": True}

--- a/backend/app/routers/onboarding.py
+++ b/backend/app/routers/onboarding.py
@@ -61,11 +61,12 @@ async def post_onboarding_event(
     if body.key_prefix and len(body.key_prefix) > KEY_PREFIX_MAX:
         raise HTTPException(status_code=422, detail="key_prefix must be prefix-only (≤12)")
 
-    # optional auth: 키 있으면 서버-truth 우선(클라 agent_id/key_prefix 신뢰 금지·§5).
-    agent_id = body.agent_id
+    # RC-2(산티아고): client-supplied agent_id/org_id/project_id/key_prefix **전부 불신** — valid 키서만
+    # 서버가 도출(스푸핑 차단). 무효/무인증이면 None 유지(pre-auth=session_id만 신뢰). body.agent_id 무시.
+    agent_id: uuid.UUID | None = None
     org_id: uuid.UUID | None = None
     project_id: uuid.UUID | None = None
-    key_prefix = body.key_prefix
+    key_prefix: str | None = None
     raw_key = (
         x_agent_api_key
         if (x_agent_api_key and x_agent_api_key.startswith("sk_"))

--- a/backend/app/services/onboarding_funnel.py
+++ b/backend/app/services/onboarding_funnel.py
@@ -1,0 +1,128 @@
+"""OB-4: 온보딩 funnel 계측 — 이벤트 카탈로그·PII 가드·record/emit (측정계약 doc SSOT).
+
+측정계약 `ob-4-onboarding-funnel-measurement-contract` §1/§2/§4/§5. FE 4종은 프록시
+`POST /onboarding/events`로 들어오고, BE 8종은 OB-1~3 동선 seam에서 `emit_onboarding_event`로 박는다.
+**키 평문 미저장**(key_prefix prefix-only·전체키 패턴 reject·AC3).
+"""
+from __future__ import annotations
+
+import logging
+import re
+import uuid
+from datetime import datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.onboarding_event import OnboardingEvent
+
+logger = logging.getLogger(__name__)
+
+# §1 canonical 11종 = FE 4(사용자행동) + BE 7(서버관측) + verify_started(FE).
+EVENT_CATALOG = frozenset({
+    "onboarding_started", "agent_created", "config_generated", "config_copied",
+    "first_auth_seen", "stream_connected", "verify_started", "event_sent",
+    "ack_received", "verified", "abandoned",
+})
+# BE-emit 8종(seam map). FE 4종(onboarding_started/config_copied/verify_started/abandoned_explicit)은
+# OB-3 프록시로 들어온다.
+BE_EMIT_EVENTS = frozenset({
+    "agent_created", "config_generated", "first_auth_seen", "stream_connected",
+    "event_sent", "ack_received", "verified", "abandoned",
+})
+# §4 실패사유 taxonomy(8).
+FAILURE_REASONS = frozenset({
+    "config_error", "no_copy", "no_auth", "stream_unreachable",
+    "no_ack", "verify_timeout", "verify_error", "abandoned_explicit",
+})
+
+KEY_PREFIX_MAX = 12
+# 전체키 형태(sk_live_/sk_test_ + 20자+) — 어느 필드든 발견 시 저장 거부(AC3).
+_SECRET_RE = re.compile(r"sk_(live|test)_[A-Za-z0-9]{20,}")
+
+
+def contains_secret(value: object) -> bool:
+    """문자열/중첩 dict/list 어디든 전체키 패턴이 있으면 True(=저장 금지)."""
+    if isinstance(value, str):
+        return bool(_SECRET_RE.search(value))
+    if isinstance(value, dict):
+        return any(contains_secret(k) or contains_secret(v) for k, v in value.items())
+    if isinstance(value, (list, tuple)):
+        return any(contains_secret(v) for v in value)
+    return False
+
+
+def safe_key_prefix(api_key_plaintext: str | None) -> str | None:
+    """api_key → prefix-only(≤12자). 평문키 절대 미저장."""
+    if not api_key_plaintext:
+        return None
+    return api_key_plaintext[:KEY_PREFIX_MAX]
+
+
+async def record_onboarding_event(
+    db: AsyncSession,
+    *,
+    event: str,
+    session_id: uuid.UUID | None = None,
+    agent_id: uuid.UUID | None = None,
+    org_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    runtime: str | None = None,
+    env: str | None = None,
+    transport: str | None = None,
+    key_prefix: str | None = None,
+    failure_reason: str | None = None,
+    client_ts: datetime | None = None,
+    meta: dict | None = None,
+) -> OnboardingEvent:
+    """단일 onboarding_event INSERT(저장 SSOT). 검증/PII 가드는 호출부 책임. 호출자가 commit.
+
+    key_prefix 는 ≤12 절삭(평문키 방어 2중화).
+    """
+    row = OnboardingEvent(
+        event=event,
+        session_id=session_id,
+        agent_id=agent_id,
+        org_id=org_id,
+        project_id=project_id,
+        runtime=runtime,
+        env=env,
+        transport=transport,
+        key_prefix=(key_prefix[:KEY_PREFIX_MAX] if key_prefix else None),
+        failure_reason=failure_reason,
+        client_ts=client_ts,
+        meta=meta or {},
+    )
+    db.add(row)
+    await db.flush()
+    return row
+
+
+async def emit_onboarding_event(
+    db: AsyncSession,
+    event: str,
+    *,
+    agent_id: uuid.UUID | None = None,
+    session_id: uuid.UUID | None = None,
+    org_id: uuid.UUID | None = None,
+    project_id: uuid.UUID | None = None,
+    runtime: str | None = None,
+    env: str | None = None,
+    transport: str | None = None,
+    key_prefix: str | None = None,
+    failure_reason: str | None = None,
+    meta: dict | None = None,
+) -> None:
+    """BE seam emit — **non-blocking·fail-silent**(측정이 wizard/런타임 UX 절대 안 막음).
+
+    ``begin_nested``(SAVEPOINT)로 격리: emit flush 실패가 호출부 트랜잭션을 poison 하지 않게 한다
+    (보조 write 실패→PendingRollbackError 방지). 실패는 삼키고 경고만 — 단일경로 fix·핫패스 무회귀.
+    """
+    try:
+        async with db.begin_nested():
+            await record_onboarding_event(
+                db, event=event, agent_id=agent_id, session_id=session_id, org_id=org_id,
+                project_id=project_id, runtime=runtime, env=env, transport=transport,
+                key_prefix=key_prefix, failure_reason=failure_reason, meta=meta,
+            )
+    except Exception:
+        logger.warning("onboarding emit failed event=%s agent=%s", event, agent_id, exc_info=True)

--- a/backend/app/services/onboarding_funnel.py
+++ b/backend/app/services/onboarding_funnel.py
@@ -74,10 +74,17 @@ async def record_onboarding_event(
     client_ts: datetime | None = None,
     meta: dict | None = None,
 ) -> OnboardingEvent:
-    """단일 onboarding_event INSERT(저장 SSOT). 검증/PII 가드는 호출부 책임. 호출자가 commit.
+    """단일 onboarding_event INSERT(저장 SSOT). 호출자가 commit.
 
-    key_prefix 는 ≤12 절삭(평문키 방어 2중화).
+    **RC-1 choke-point PII 방어(산티아고)**: 어느 호출자(endpoint·BE emit·future caller)든 이 단일
+    저장 경로를 타므로, 여기서 secret-형태(전체키)를 한 번 더 막는다 — meta 등에 평문키가 섞이면
+    ValueError raise(endpoint=422로 전환·emit=fail-silent로 미저장). key_prefix 는 ≤12 절삭(2중화).
     """
+    if contains_secret({
+        "key_prefix": key_prefix, "failure_reason": failure_reason,
+        "runtime": runtime, "env": env, "transport": transport, "meta": meta,
+    }):
+        raise ValueError("onboarding event contains a secret-shaped value — refused")
     row = OnboardingEvent(
         event=event,
         session_id=session_id,

--- a/backend/tests/test_ob4_onboarding_funnel.py
+++ b/backend/tests/test_ob4_onboarding_funnel.py
@@ -1,0 +1,135 @@
+"""OB-4: 온보딩 funnel 계측 가드 (측정계약 doc §1/§2/§4).
+
+이벤트 카탈로그·PII 가드(전체키 reject)·emit begin_nested 격리(fail-silent)·POST 엔드포인트
+(enum 422·PII 422·optional auth 서버-truth·저장).
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.onboarding_event import OnboardingEvent
+from app.routers.onboarding import OnboardingEventBody, post_onboarding_event
+from app.services import onboarding_funnel as f
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ─── 카탈로그 / PII 가드 ──────────────────────────────────────────────────────
+
+def test_event_catalog_has_canonical_11():
+    assert len(f.EVENT_CATALOG) == 11
+    assert "config_generated" in f.EVENT_CATALOG and "verified" in f.EVENT_CATALOG
+    assert len(f.BE_EMIT_EVENTS) == 8
+    assert len(f.FAILURE_REASONS) == 8
+
+
+def test_contains_secret_detects_full_key_not_prefix():
+    assert f.contains_secret("sk_" + "live_" + "z" * 28) is True
+    assert f.contains_secret({"meta": {"k": "sk_test_" + "a" * 24}}) is True
+    assert f.contains_secret(["x", ["sk_live_" + "b" * 30]]) is True
+    assert f.contains_secret("sk_live_") is False  # prefix-only(짧음) 통과
+    assert f.contains_secret({"event": "verified", "key_prefix": "sk_live_"}) is False
+
+
+def test_safe_key_prefix_truncates():
+    assert f.safe_key_prefix("sk_" + "live_" + "z" * 21) == "sk_live_zzzz"  # 첫 12자
+    assert len(f.safe_key_prefix("sk_live_xxxxxxxxxxxxx")) <= f.KEY_PREFIX_MAX
+    assert f.safe_key_prefix(None) is None
+
+
+# ─── emit begin_nested 격리(fail-silent) ──────────────────────────────────────
+
+def _nested_cm():
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=None)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+@pytest.mark.anyio
+async def test_emit_uses_begin_nested_and_records():
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    db.begin_nested = MagicMock(return_value=_nested_cm())
+    await f.emit_onboarding_event(db, "config_generated", agent_id=uuid.uuid4())
+    db.begin_nested.assert_called_once()  # SAVEPOINT 격리
+    db.add.assert_called_once()
+    assert isinstance(db.add.call_args[0][0], OnboardingEvent)
+
+
+@pytest.mark.anyio
+async def test_emit_fail_silent_does_not_raise():
+    db = AsyncMock()
+    db.begin_nested = MagicMock(side_effect=RuntimeError("boom"))
+    # 실패해도 예외 전파 0(측정이 UX 안 막음)
+    await f.emit_onboarding_event(db, "verified", agent_id=uuid.uuid4())
+
+
+# ─── POST /onboarding/events ──────────────────────────────────────────────────
+
+def _db():
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+    return db
+
+
+@pytest.mark.anyio
+async def test_post_unknown_event_422():
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as ei:
+        await post_onboarding_event(
+            OnboardingEventBody(event="bogus_event"), db=_db(), credentials=None, x_agent_api_key=None
+        )
+    assert ei.value.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_post_secret_in_meta_rejected_422():
+    from fastapi import HTTPException
+    body = OnboardingEventBody(event="config_copied", meta={"leak": "sk_live_" + "a" * 30})
+    with pytest.raises(HTTPException) as ei:
+        await post_onboarding_event(body, db=_db(), credentials=None, x_agent_api_key=None)
+    assert ei.value.status_code == 422 and "secret" in ei.value.detail
+
+
+@pytest.mark.anyio
+async def test_post_anonymous_pre_auth_stores():
+    db = _db()
+    sess = uuid.uuid4()
+    body = OnboardingEventBody(event="onboarding_started", session_id=sess, runtime="claude-code")
+    out = await post_onboarding_event(body, db=db, credentials=None, x_agent_api_key=None)
+    assert out == {"ok": True}
+    row = db.add.call_args[0][0]
+    assert row.event == "onboarding_started" and row.session_id == sess and row.agent_id is None
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_post_authed_derives_server_truth():
+    """키 있으면 agent_id/org_id/key_prefix를 서버가 도출(클라 agent_id 무시)."""
+    db = _db()
+    real_agent = uuid.uuid4()
+    real_org = uuid.uuid4()
+    ctx = SimpleNamespace(
+        user_id=str(real_agent),
+        claims={"app_metadata": {"org_id": str(real_org), "project_id": None, "api_key_id": "k"}},
+    )
+    body = OnboardingEventBody(event="first_auth_seen", agent_id=uuid.uuid4())  # 클라가 보낸 가짜 agent_id
+    with patch("app.routers.onboarding._resolve_api_key", new=AsyncMock(return_value=ctx)):
+        await post_onboarding_event(
+            body, db=db, credentials=None, x_agent_api_key="sk_" + "live_" + "z" * 26
+        )
+    row = db.add.call_args[0][0]
+    assert row.agent_id == real_agent  # 서버-truth(클라 무시)
+    assert row.org_id == real_org
+    assert row.key_prefix == "sk_live_zzzz" and len(row.key_prefix) <= f.KEY_PREFIX_MAX

--- a/backend/tests/test_ob4_onboarding_funnel.py
+++ b/backend/tests/test_ob4_onboarding_funnel.py
@@ -114,6 +114,46 @@ async def test_post_anonymous_pre_auth_stores():
     db.commit.assert_awaited_once()
 
 
+# ─── RC-1: choke-point PII 방어(record 전 경로) ───────────────────────────────
+
+@pytest.mark.anyio
+async def test_record_rejects_secret_in_meta_choke_point():
+    """record_onboarding_event(전 경로 초크포인트)가 meta 속 전체키를 막는다(endpoint 우회 차단)."""
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    with pytest.raises(ValueError):
+        await f.record_onboarding_event(
+            db, event="config_copied", meta={"api_key": "sk_" + "live_" + "z" * 30}
+        )
+    db.add.assert_not_called()  # secret이면 저장 0
+
+
+@pytest.mark.anyio
+async def test_emit_swallows_secret_meta_not_stored():
+    """BE emit이 secret meta 받아도 record raise→fail-silent로 미저장(예외 전파 0)."""
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.begin_nested = MagicMock(return_value=_nested_cm())
+    await f.emit_onboarding_event(db, "config_generated", meta={"leak": "sk_" + "live_" + "z" * 30})
+    db.add.assert_not_called()
+
+
+# ─── RC-2: pre-auth client agent_id 스푸핑 차단 ───────────────────────────────
+
+@pytest.mark.anyio
+async def test_post_pre_auth_ignores_client_agent_id():
+    """무인증이면 client-supplied agent_id 무시(None)·session_id만 신뢰(스푸핑 차단)."""
+    db = _db()
+    spoofed = uuid.uuid4()
+    sess = uuid.uuid4()
+    body = OnboardingEventBody(event="config_copied", session_id=sess, agent_id=spoofed)
+    await post_onboarding_event(body, db=db, credentials=None, x_agent_api_key=None)
+    row = db.add.call_args[0][0]
+    assert row.agent_id is None and row.key_prefix is None  # 클라 불신
+    assert row.session_id == sess  # session_id만 신뢰
+
+
 @pytest.mark.anyio
 async def test_post_authed_derives_server_truth():
     """키 있으면 agent_id/org_id/key_prefix를 서버가 도출(클라 agent_id 무시)."""


### PR DESCRIPTION
## 요약 (E-ONBOARDING-DX OB-4 · 블루프린트 §6 · 측정계약 doc)
온보딩 funnel 계측. OB-3 FE emit 4종이 보내던(현재 404로 떨어지던) 끝단 + BE 서버-truth emit.

## 토대 (AC1·AC3 — 완)
- **0137 마이그**: `onboarding_events` append-only(인덱스 7종)·fresh-runnable·idempotent·baseline 미변경(post-0096 신규).
- **`onboarding_funnel.py`**: 이벤트 카탈로그(11)·실패사유(8)·**PII 가드**(전체키 `sk_(live|test)_…` 어디든 reject·key_prefix ≤12)·`record`/`emit`. emit = **begin_nested 격리·non-blocking·fail-silent**(측정이 UX 안 막음·보조write poison 방지).
- **`POST /api/v2/onboarding/events`**: enum 422·PII 422·**optional auth**(키 있으면 agent_id/org_id/key_prefix 서버-truth·클라 미신뢰, 없으면 pre-auth 익명·session_id 조인키).

## BE emit seam (AC4 — **5/8**)
- ✅ `agent_created`(org-agent create)·`config_generated`(connection-artifact)·`event_sent`(verify-connection 디스패치)·`ack_received`+`verified`(ack_event — verify connection_test가 새로 ack된 범위에 들 때만 한정).

## ⚠️ 잔여 seam 3종 (continuation·집중 작업 분리)
오늘 하든한 critical path라 fatigue 없이 집중 와이어 권장:
- `first_auth_seen`: auth.py `_resolve_api_key` 핫패스(`last_used_at` None = 첫인증 디덕 — 깔끔하나 auth 의존성 commit 의미 신중).
- `stream_connected`: agent_stream SSE 제너레이터 lifecycle(1회/연결).
- `abandoned`: cron 파생(config_generated→30분 미verified·failure_reason taxonomy 도출).

## 테스트
신규 9(PII 가드·emit 격리/fail-silent·엔드포인트 enum/PII/anon/서버-truth). 로컬 전체 pytest **2489 passed**(실패 8=CI-skip 환경 DoD). ⚠️self-PII: GitHub push protection이 테스트 fake-key 리터럴까지 잡아 런타임 concat으로 정리(full-key 리터럴 0).

## 비고
산티아고 보안(키 prefix 가드·PII·optional-auth) 리뷰 권장. FE emit/프록시는 OB-3(#1719 머지됨). 잔여 3 seam은 PO 콜로 이 PR 연장 또는 OB-4 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)