### PR TITLE
[SID:1703a148] OB-2-align — 신규 에이전트 V2 게이트웨이 통일 (verify mcp_reachable 정렬)

### DIFF
--- a/backend/app/services/agent_onboarding_config.py
+++ b/backend/app/services/agent_onboarding_config.py
@@ -47,8 +47,21 @@ def build_agent_mcp_config(
 
     runtime 은 현재 ``claude-code`` 단일(향후 cursor 등 분기 여지). 미지원 값은 호출부(엔드포인트)가
     400 으로 거른다 — generator 는 항상 canonical stdio 아티팩트를 만든다.
+
+    **OB-2-align — 두 SSE 시스템 통일(AC④)**: sse_bridge 는 ``AGENT_GATEWAY_V2`` env 로 수신 경로를
+    가른다(sse_bridge.py). 두 경로 공존:
+      - V2 ``/api/v2/agent/stream`` — ``AgentGatewaySession`` 생성·recipient_seq/acked_seq 커서.
+        verify(OB-2)·단일경로 fix(5a99842b/c60dd33c)·presence 가 모두 이 경로를 가정. **canonical.**
+      - 구 ``/api/v2/events/stream`` — in-memory ``_agent_connections``·세션/presence 미생성(legacy).
+    flag 미설정이면 sse_bridge 가 **구 경로 default** → 신규 에이전트가 ``AgentGatewaySession`` 을
+    안 만들어 verify ``mcp_reachable`` 가 false-negative(통합 dogfood 적출). 따라서 아티팩트에
+    ``AGENT_GATEWAY_V2="1"`` 을 박아 신규 에이전트를 **V2 로 통일** — mcp_reachable+acked_seq 정렬로
+    verified-green 이 성립한다(서버 무변경·기존 에이전트 무영향).
     """
-    env: dict[str, str] = {"SPRINTABLE_API_URL": resolve_backend_direct_url()}
+    env: dict[str, str] = {
+        "SPRINTABLE_API_URL": resolve_backend_direct_url(),
+        "AGENT_GATEWAY_V2": "1",  # OB-2-align: 신규 에이전트를 V2 게이트웨이(/agent/stream)로 통일.
+    }
     if api_key_plaintext:
         env["AGENT_API_KEY"] = api_key_plaintext
     return {

--- a/backend/tests/test_ob2align_v2_transport.py
+++ b/backend/tests/test_ob2align_v2_transport.py
@@ -1,0 +1,28 @@
+"""OB-2-align: 신규 에이전트를 V2 게이트웨이(/agent/stream)로 통일 가드.
+
+통합 dogfood 적출: generator가 AGENT_GATEWAY_V2를 안 박아 신규 에이전트가 구 /events/stream
+default → AgentGatewaySession 미생성 → verify mcp_reachable false-negative. fix=아티팩트 env에
+AGENT_GATEWAY_V2="1" → V2 통일(서버 무변경·verify 코드 무변경·verified-green 정렬).
+"""
+from __future__ import annotations
+
+from app.services.agent_onboarding_config import build_agent_mcp_config
+
+
+def test_artifact_pins_agent_gateway_v2():
+    """신규 아티팩트 env에 AGENT_GATEWAY_V2='1' — 신규 에이전트 V2(/agent/stream) 통일."""
+    env = build_agent_mcp_config(api_key_plaintext="k")["mcpServers"]["sprintable"]["env"]
+    assert env["AGENT_GATEWAY_V2"] == "1"
+
+
+def test_v2_flag_present_even_without_key():
+    """키 미발급(connection-artifact placeholder 경로)에도 V2 flag는 항상 — 전 신규 에이전트 V2."""
+    env = build_agent_mcp_config(api_key_plaintext=None)["mcpServers"]["sprintable"]["env"]
+    assert env["AGENT_GATEWAY_V2"] == "1"
+    assert env["SPRINTABLE_API_URL"]  # backend-direct 도 항상
+
+
+def test_v2_flag_value_is_truthy_for_sse_bridge():
+    """sse_bridge `_use_v2`(os.getenv not in ('0','false',''))가 truthy로 보는 값이어야 V2 발효."""
+    env = build_agent_mcp_config(api_key_plaintext="k")["mcpServers"]["sprintable"]["env"]
+    assert env["AGENT_GATEWAY_V2"] not in ("0", "false", "")


### PR DESCRIPTION
## 요약 (E-ONBOARDING-DX OB-2-align · 통합 dogfood 발견)
OB-2 verify가 `/agent/stream`(V2·AgentGatewaySession·acked_seq)을 가정하는데, 실 stdio 에이전트(sse_bridge)는 `AGENT_GATEWAY_V2` env 미설정 시 **구 `/events/stream`**(legacy·in-memory·세션 미생성)로 붙어 → `mcp_reachable` false-negative(에이전트 붙어있는데 pending).

## 근본 (코드 실측)
- sse_bridge 경로 분기 = `AGENT_GATEWAY_V2` env (sse_bridge.py:184). set→V2 /agent/stream, unset→구 /events/stream.
- **OB-1 generator가 flag 미주입** → 신규 에이전트 구경로 default → AgentGatewaySession 미생성.

## fix (1줄·저위험)
generator 아티팩트 env에 **`AGENT_GATEWAY_V2: "1"`** → 신규 에이전트 V2 통일 → AgentGatewaySession 생성 → **mcp_reachable 작동 + acked_seq 정렬 → verified-green end-to-end**(verify 코드 무변경).
- 서버 V2 이미 라이브·하든(5a99842b/c60dd33c·main.py:147)·클라 sse_bridge V2-ready → flag만.
- **서버 무변경·기존 에이전트(webhook 경로) 무영향·핫패스 무변경.**
- 담롱 계약 v1.3의 `stream_connected`(event6)↔`mcp_reachable` 단일신호 정합도 연쇄 해결(OB-4b).

## AC
- AC① 패키지 /agent/stream 통일 ✅ · AC④ 두 SSE 시스템(V2 canonical vs 구 legacy) docstring 문서화 ✅
- **AC② 실 Claude Code 클라 verified-true 1발 = 라이브 dogfood**(유나 wizard 픽셀 플로우와 합산·실 wizard→실 V2 에이전트→verify green). 머지+배포 후 확정.
- AC③ 무회귀: 로컬 전체 pytest **2495 passed**(실패 8=CI-skip 환경 DoD)·기존 에이전트 무영향.

## 비고
산티아고(transport cutover·무회귀) 리뷰 권장. 구 /events/stream deprecation은 OB-2-align 밖(eventual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)