### PR TITLE
[SID:41fca453] verify 레일 active 액센트 primary→info (fast-follow)

### DIFF
--- a/apps/web/src/app/onboarding/verify-rail.tsx
+++ b/apps/web/src/app/onboarding/verify-rail.tsx
@@ -40,8 +40,9 @@ function StepIcon({ status }: { status: RailStatus }) {
     );
   }
   if (status === 'active') {
+    // active = status 토큰 `info`(진행중)로 spectrum 완성: muted(대기)→info(진행중)→success(완료)/destructive(실패).
     return (
-      <span className="flex h-[22px] w-[22px] items-center justify-center rounded-full border-2 border-primary text-primary">
+      <span className="flex h-[22px] w-[22px] items-center justify-center rounded-full border-2 border-info text-info">
         <Loader2 className="h-3 w-3 animate-spin" aria-hidden />
       </span>
     );


### PR DESCRIPTION
## 배경
OB-3 라이브 픽셀 note#1 fast-follow (비-블로커). 유나 디자인 콜.

## 변경
verify 레일 active 단계 링/spinner: `border-primary text-primary` → `border-info text-info` (1토큰).

**근거(유나 디자인 lane):** verify 레일은 status 표시 → 색이 전부 status 토큰(done=`success`·failed=`destructive`·pending=`muted-foreground`). active도 status 토큰이어야 언어 일관 → `info`(진행중)가 spectrum 완성: `muted(대기) → info(진행중) → success(완료)/destructive(실패)`. `brand`는 제품 정체성 액센트지 status 토큰 아님. 시안의 brand=blue pop 의도는 `info`(같은 blue 계열·oklch 0.55 0.18 250)가 status-일관까지 챙기며 충족. 라이트서 primary≈검정 무겁게 읽히던 것도 해소.

## 검증
type-check 0 · build ✓. 신규 토큰 0(info 기존). 나머지 무변경.

## Base
`develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)