### PR TITLE
[SID:21496392] story.assignee_changed + workflow_violation webhook 관련자 스코핑 (c60dd33c 갭)

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -511,9 +511,18 @@ async def update_story(
             "assignees": [str(story.assignee_id)] if story.assignee_id else [],
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
+        # AC1(c60dd33c 미러): assignee_changed webhook은 관련자만 — 담당자(신/구)+행위자. member-bound
+        # webhook이 무관 에이전트에 fan-out되던 갭 차단. member_id=null 브로드캐스트는 보존(preserve_broadcast).
+        _assignee_notify_ids = {
+            m for m in (story.assignee_id, old_assignee_id, actor_id) if m is not None
+        }
+        # publish_event는 org-level 브라우저 UI 활동피드(_subscribers·per-agent 미전파)라 org-wide 의도 유지(AC2).
         publish_event(str(org_id), "story.assignee_changed", event_data)
         try:
-            await fire_webhooks(db, org_id, "story.assignee_changed", event_data)
+            await fire_webhooks(
+                db, org_id, "story.assignee_changed", event_data,
+                recipient_member_ids=_assignee_notify_ids,
+            )
         except Exception:
             pass
         try:
@@ -804,12 +813,20 @@ async def update_story_status(
                 reason=_violation.reason or "워크플로우 위반 감지",
                 severity="warn",
             )
+            # AC4(동일 패턴): workflow_violation webhook도 관련자(행위자+담당자)만 — 동일 org-wide fan-out
+            # 박멸. publish_event(UI 활동피드)는 org-wide 유지.
+            _violation_notify_ids = {
+                m for m in (actor_id, story.assignee_id) if m is not None
+            }
             try:
                 publish_event(str(org_id), "workflow_violation", _v_event)
             except Exception:
                 pass
             try:
-                await fire_webhooks(db, org_id, "workflow_violation", _v_event)
+                await fire_webhooks(
+                    db, org_id, "workflow_violation", _v_event,
+                    recipient_member_ids=_violation_notify_ids,
+                )
             except Exception:
                 pass
         # 41a6e294: status_changed side-effects(events→L1·webhook·L2·notif·activity)는 공유 helper로

--- a/backend/tests/test_assignee_changed_fanout_21496392.py
+++ b/backend/tests/test_assignee_changed_fanout_21496392.py
@@ -1,0 +1,33 @@
+"""21496392: story.assignee_changed (+workflow_violation) webhook org-wide fan-out 박멸 가드.
+
+c60dd33c 미러 — fire_webhooks에 recipient_member_ids(관련자) 전달로 무관 에이전트 fan-out 차단.
+게이팅 메커니즘 자체는 test_c60dd33c_webhook_payload_gating이 검증(recipient_member_ids 게이팅·
+broadcast 보존). 여기선 stories.py 두 호출부가 그 게이팅을 **실제로 배선**했는지 회귀 가드.
+publish_event(UI 활동피드·_subscribers)는 org-wide 의도 유지(per-agent 미전파)라 미스코핑.
+"""
+from __future__ import annotations
+
+import inspect
+
+from app.routers import stories
+
+
+def test_assignee_changed_fire_webhooks_gated_to_relevant():
+    src = inspect.getsource(stories)
+    # assignee_changed: recipient_member_ids = 담당자(신/구)+행위자
+    assert "recipient_member_ids=_assignee_notify_ids" in src
+    assert "story.assignee_id, old_assignee_id, actor_id" in src
+
+
+def test_workflow_violation_fire_webhooks_gated():
+    src = inspect.getsource(stories)
+    # workflow_violation도 동일 패턴(행위자+담당자)
+    assert "recipient_member_ids=_violation_notify_ids" in src
+    assert "actor_id, story.assignee_id" in src
+
+
+def test_assignee_changed_fire_webhooks_not_bare_orgwide():
+    """무게이팅(bare 3-arg) org-wide 호출이 남아있지 않은지 — 회귀 차단."""
+    src = inspect.getsource(stories)
+    assert 'fire_webhooks(db, org_id, "story.assignee_changed", event_data)' not in src
+    assert 'fire_webhooks(db, org_id, "workflow_violation", _v_event)' not in src


### PR DESCRIPTION
## 요약 (event-delivery · 선생님 발견 2026-06-25)
`story.assignee_changed`가 org 모든 active webhook에 fan-out → **무관 에이전트 수신(노이즈)**. c60dd33c(#1715)가 `story.status_changed`만 notify_ids 스코핑하고 **assignee_changed 경로는 안 건드린 갭**(diff 확인).

## 근본 (stories.py:516)
`fire_webhooks(db, org_id, "story.assignee_changed", event_data)` — 수신자 스코핑 없이 발사 → member-bound webhook이 무관 에이전트에 전파.

## fix (c60dd33c 미러)
- **AC1**: assignee_changed fire_webhooks에 `recipient_member_ids={담당자(신/구)+행위자}` 전달. member_id=null 브로드캐스트는 보존(`preserve_broadcast`).
- **AC4**: `workflow_violation`(stories.py:821·동일 org-wide 패턴)도 `{행위자+담당자}` 스코핑.
- **AC2**: `publish_event`는 org-level **브라우저 UI 활동피드**(`_subscribers`·per-agent 미전파)라 org-wide 의도 유지 — 스코핑 시 활동피드 파손(실측: `_agent_connections` 아님·publish_event는 org 브로드캐스트 SSE).

## 테스트
두 호출부 게이팅 배선 회귀 가드 3(게이팅 **메커니즘** 자체는 `test_c60dd33c_webhook_payload_gating` 검증). 로컬 전체 pytest **2495 passed**(실패 8=CI-skip 환경 DoD).
**AC3**(무관 에이전트 수신 0건 dev 로그)는 머지+배포 후 라이브 실증 — c60dd33c AC4와 동형.

## 비고
까심+산티아고 게이트(AC5). publish_event 스코핑 제외 근거(UI 활동피드)는 산티아고 확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)