### PR TITLE
[SID:0a6487c6] fix: config 필터 제거 — BE user-scope 신뢰 (라이브 RC)

### DIFF
--- a/apps/web/src/components/settings/my-notification-channel-section.tsx
+++ b/apps/web/src/components/settings/my-notification-channel-section.tsx
@@ -69,12 +69,14 @@ export function MyNotificationChannelSection({ projectId, projectName }: MyNotif
     if (deleteConfirmId) cancelRef.current?.focus();
   }, [deleteConfirmId]);
 
-  // AC2 집계 — 그 멤버의 글로벌(null)+전 프로젝트 config 전부(5c1258e2서 좁힌 필터 제거).
-  const fetchWebhookConfigs = useCallback(async (mid: string) => {
+  // AC2 집계 — BE GET이 이미 caller user-scope(IDOR fix #1726=내 것만 반환). 클라 member_id 필터는
+  // 중복+유해(BE가 member_id를 user_id로 저장/반환하는데 /api/me.id는 org-member-id라 0 매치→전 config 숨김 회귀).
+  // → 필터 제거하고 BE 스코프 그대로 신뢰. (member_id 시맨틱은 디디 BE #1726 확인 항목)
+  const fetchWebhookConfigs = useCallback(async () => {
     const res = await fetch('/api/webhooks/config');
     if (!res.ok) return;
     const json = await res.json() as { data: WebhookConfig[] };
-    setWebhookConfigs((json.data ?? []).filter((c) => c.member_id === mid));
+    setWebhookConfigs(json.data ?? []);
   }, []);
 
   useEffect(() => {
@@ -95,7 +97,7 @@ export function MyNotificationChannelSection({ projectId, projectName }: MyNotif
         const mid = json.data?.id ?? null;
         if (!mid) return;
         setMemberId(mid);
-        await fetchWebhookConfigs(mid);
+        await fetchWebhookConfigs();
       } finally {
         setLoading(false);
       }
@@ -132,7 +134,7 @@ export function MyNotificationChannelSection({ projectId, projectName }: MyNotif
         const json = await res.json().catch(() => null) as { error?: { message?: string } } | null;
         addToast({ type: 'error', title: json?.error?.message ?? tc('error') });
       }
-      await fetchWebhookConfigs(memberId);
+      await fetchWebhookConfigs();
     } finally {
       setBusyId(null);
     }
@@ -150,7 +152,7 @@ export function MyNotificationChannelSection({ projectId, projectName }: MyNotif
         return;
       }
       setDeleteConfirmId(null);
-      await fetchWebhookConfigs(memberId);
+      await fetchWebhookConfigs();
     } finally {
       setBusyId(null);
     }
@@ -208,7 +210,7 @@ export function MyNotificationChannelSection({ projectId, projectName }: MyNotif
         return;
       }
       addToast({ type: 'success', title: 'Webhook URL saved' });
-      await fetchWebhookConfigs(memberId);
+      await fetchWebhookConfigs();
     } finally {
       setSavingNew(false);
     }


### PR DESCRIPTION
## RC (라이브 픽셀·dev·#1725 머지 後 적출)
설정 알림 목적지가 **config 실존인데 목록 empty**.
- `/api/me` `id` = org-member-id (예 `2fd14616`).
- `GET /api/webhooks/config` 반환 config `member_id` = **user_id** (예 `d3ed4ed8`) — BE #1726(IDOR fix)가 user 스코프로 저장/반환.
- 컴포넌트 `fetchWebhookConfigs`의 `c.member_id === mid`(org-member-id) → **0 매치 → 전 config 숨김.** 5c1258e2 리스트도 같은 회귀.

## Fix (1줄·깨끗)
BE GET이 이미 **caller user-scope**(IDOR fix=내 것만 반환·sellerking이 전체 아닌 본인 3개만 받음) → 클라 `member_id` 필터는 **중복+유해** → 제거. `fetchWebhookConfigs()` 인자 없이 `setWebhookConfigs(json.data ?? [])`. `memberId`는 PUT body/guard용 유지.

## follow-up (디디 BE #1726)
`member_id` 시맨틱(IDOR fix가 user_id로 의도한 건지) 교차확인 — PUT upsert body member_id는 BE가 auth서 derive(무시) 가정(toggle/save 정상). validate-reject면 별도 정렬.

## 검증
type-check 0 · lint 0 · build ✓.

## Base
`develop` (단일 fix 커밋 `4c6d9fbb`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)