### PR TITLE
[hotfix] webhook-config member_id 축 정합 — 휴먼 silent 미배달 회귀 (#1726 후속)

### DIFF
--- a/backend/alembic/versions/0138_webhook_config_member_axis_fix.py
+++ b/backend/alembic/versions/0138_webhook_config_member_axis_fix.py
@@ -2,14 +2,23 @@
 
 #1726 의 `_get_caller_member_id` 가 `canonicalize(auth.user_id)` = **users.id** 축으로 휴먼 webhook
 config 를 저장/스코프해, 디스패치(conversation_participants.member_id = org_member.id 축)와 불일치 →
-webhook silent 미배달. 코드는 `resolve_member().id`(휴먼=org_member.id·에이전트=team_member.id) 로 수정.
-이 마이그는 그 사이 users.id 축으로 저장된 휴먼 config 를 org_member.id 로 **1회 보정**한다.
+webhook silent 미배달. 코드는 `resolve_member().id`(휴먼=org_member.id) 로 수정. 이 마이그는 그 사이
+users.id 축으로 저장된 휴먼 config 를 org_member.id 로 **1회 보정**한다.
 
-- **idempotent**: 보정 후 member_id = org_member.id 라 `om.user_id = wc.member_id` 조인이 다시 안 잡힘.
-- **에이전트 무접촉**: agent config(member_id = team_member.id)는 org_members.user_id(=users.id)와 안
-  맞아 매칭 0 → 보정 대상 아님(무회귀).
-- **이미-정상 무접촉**: 기존 org_member.id 축 config 도 조인 0 → 무접촉.
-- org-scope 조인(`om.org_id = wc.org_id`)으로 cross-org 오매핑 차단.
+⚠️ unique 충돌 처리(산티아고 RC·prod-blocker): baseline partial unique 가 있다 —
+  - `idx_webhook_configs_default`: UNIQUE(org_id, member_id)              WHERE project_id IS NULL
+  - `idx_webhook_configs_unique` : UNIQUE(org_id, member_id, project_id) WHERE project_id IS NOT NULL
+같은 (org, user, scope) 에 ①과거 canonical(org_member.id) + ②#1726 後 회귀(users.id) 가 **공존**하면,
+②→org_member.id 단순 UPDATE 가 ①과 충돌해 alembic 실패(fresh-DB CI 미검출). 따라서:
+
+  1. **is_active OR-merge**: 충돌 시 ②(회귀)가 active 였으면 ①(canonical)도 active 로(배달 의도 보존).
+  2. **회귀 dup DELETE**: canonical 이 이미 있으면 ②(회귀·미배달이던 dup)를 삭제(canonical 유지가 안전).
+  3. **UPDATE 나머지**: canonical 이 없는 회귀만 org_member.id 로 보정(NOT EXISTS 가드로 충돌 0).
+
+scope 동일성은 `project_id IS NOT DISTINCT FROM`(NULL=NULL·default 인덱스, 정확일치·unique 인덱스 양립).
+- **idempotent**: 보정 후 member_id=org_member.id 라 `om.user_id=wc.member_id` 재매칭 0.
+- **에이전트 무접촉**: agent config(member_id=team_member.id)는 org_members.user_id(=users.id) 안 맞아 0행.
+- **prod 사실상 no-op**: 회귀는 develop-only·prod config 전부 canonical(배달中) → users.id row 0.
 
 Revision ID: 0138
 Revises: 0137
@@ -21,17 +30,54 @@ down_revision = "0137"
 branch_labels = None
 depends_on = None
 
+# ① is_active OR-merge: 충돌하는 active 회귀의 의도를 canonical 에 보존.
+_OR_MERGE_ACTIVE = """
+UPDATE webhook_configs canon
+SET is_active = TRUE
+FROM org_members om, webhook_configs reg
+WHERE om.id = canon.member_id
+  AND om.org_id = canon.org_id
+  AND om.user_id = reg.member_id            -- reg = 회귀(member_id = users.id)
+  AND reg.org_id = canon.org_id
+  AND reg.id <> canon.id
+  AND reg.project_id IS NOT DISTINCT FROM canon.project_id
+  AND reg.is_active
+  AND NOT canon.is_active
+"""
+
+# ② canonical 이 이미 있는 회귀 dup 삭제(미배달이던 회귀 제거·canonical 유지).
+_DELETE_COLLIDING_REGRESSED = """
+DELETE FROM webhook_configs reg
+USING org_members om, webhook_configs canon
+WHERE om.user_id = reg.member_id
+  AND om.org_id = reg.org_id
+  AND canon.org_id = reg.org_id
+  AND canon.member_id = om.id
+  AND canon.id <> reg.id
+  AND canon.project_id IS NOT DISTINCT FROM reg.project_id
+"""
+
+# ③ canonical 없는 회귀만 org_member.id 로 보정(NOT EXISTS 가드 = 충돌 0·방어).
+_UPDATE_REMAINING = """
+UPDATE webhook_configs reg
+SET member_id = om.id
+FROM org_members om
+WHERE om.user_id = reg.member_id
+  AND om.org_id = reg.org_id
+  AND NOT EXISTS (
+    SELECT 1 FROM webhook_configs c2
+    WHERE c2.org_id = reg.org_id
+      AND c2.member_id = om.id
+      AND c2.project_id IS NOT DISTINCT FROM reg.project_id
+      AND c2.id <> reg.id
+  )
+"""
+
 
 def upgrade() -> None:
-    op.execute(
-        """
-        UPDATE webhook_configs wc
-        SET member_id = om.id
-        FROM org_members om
-        WHERE om.user_id = wc.member_id
-          AND om.org_id = wc.org_id
-        """
-    )
+    op.execute(_OR_MERGE_ACTIVE)
+    op.execute(_DELETE_COLLIDING_REGRESSED)
+    op.execute(_UPDATE_REMAINING)
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/0138_webhook_config_member_axis_fix.py
+++ b/backend/alembic/versions/0138_webhook_config_member_axis_fix.py
@@ -1,0 +1,39 @@
+"""webhook_configs.member_id 축 보정: users.id → org_member.id (휴먼 config)
+
+#1726 의 `_get_caller_member_id` 가 `canonicalize(auth.user_id)` = **users.id** 축으로 휴먼 webhook
+config 를 저장/스코프해, 디스패치(conversation_participants.member_id = org_member.id 축)와 불일치 →
+webhook silent 미배달. 코드는 `resolve_member().id`(휴먼=org_member.id·에이전트=team_member.id) 로 수정.
+이 마이그는 그 사이 users.id 축으로 저장된 휴먼 config 를 org_member.id 로 **1회 보정**한다.
+
+- **idempotent**: 보정 후 member_id = org_member.id 라 `om.user_id = wc.member_id` 조인이 다시 안 잡힘.
+- **에이전트 무접촉**: agent config(member_id = team_member.id)는 org_members.user_id(=users.id)와 안
+  맞아 매칭 0 → 보정 대상 아님(무회귀).
+- **이미-정상 무접촉**: 기존 org_member.id 축 config 도 조인 0 → 무접촉.
+- org-scope 조인(`om.org_id = wc.org_id`)으로 cross-org 오매핑 차단.
+
+Revision ID: 0138
+Revises: 0137
+"""
+from alembic import op
+
+revision = "0138"
+down_revision = "0137"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE webhook_configs wc
+        SET member_id = om.id
+        FROM org_members om
+        WHERE om.user_id = wc.member_id
+          AND om.org_id = wc.org_id
+        """
+    )
+
+
+def downgrade() -> None:
+    # 데이터 보정 — 원 users.id 가 소실되어 역보정 불가. forward-only no-op.
+    pass

--- a/backend/app/routers/webhooks.py
+++ b/backend/app/routers/webhooks.py
@@ -36,12 +36,22 @@ def _get_repo(
 
 async def _get_caller_member_id(
     auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     session: AsyncSession = Depends(get_db),
 ) -> uuid.UUID:
-    """caller 의 canonical member_id — webhook-config 는 멤버 소유 리소스라 소유 스코프 강제(IDOR 차단).
-    레거시 휴먼 tm.id→members.id 정규화(저장된 member_id 와 동형 매칭)."""
-    from app.services.member_resolver import canonicalize_member_id
-    return await canonicalize_member_id(uuid.UUID(auth.user_id), session)
+    """caller 의 **canonical member_id**(멤버-ssot SSOT `resolve_member`) — webhook-config 소유 스코프.
+
+    휴먼 = org_member.id · 에이전트 = team_member.id. 이게 디스패치(conversation_participants.member_id,
+    0092 이후 동일 canonical 축)와 정합하는 축이다.
+
+    ⚠️ `canonicalize_member_id(auth.user_id)` 금지(축 버그): 휴먼은 `auth.user_id = users.id`(JWT sub,
+    OrgMember.user_id로 매칭)이고 alias 는 team_member.id→org_member.id 전용이라 users.id 는 no-op →
+    **users.id 축**으로 저장/스코프됨. 디스패치는 org_member.id 로 조회 → 0행 → webhook silent 미배달.
+    에이전트는 `auth.user_id = team_member.id` 라 두 방식 동일(무회귀). resolve_member 가 양쪽 정합 보장.
+    """
+    from app.services.member_resolver import resolve_member
+    resolved = await resolve_member(auth, org_id, session)
+    return resolved.id
 
 
 @router.get("/config", response_model=list[WebhookConfigResponse])

--- a/backend/tests/test_notif_trust_testsend.py
+++ b/backend/tests/test_notif_trust_testsend.py
@@ -178,3 +178,20 @@ async def test_upsert_uses_caller_member_ignoring_body():
     await upsert_webhook_config(body, repo=repo, caller_member_id=caller)
     # body.member_id(other) 가 아니라 caller 로 upsert — 타 멤버 설정 불가
     assert repo.upsert.await_args.kwargs["member_id"] == caller
+
+
+# ─── 멤버 축 정합: _get_caller_member_id = resolve_member().id (산티아고/PO hotfix) ──
+
+@pytest.mark.anyio
+async def test_caller_member_id_uses_resolve_member_not_user_id():
+    """_get_caller_member_id 는 resolve_member().id(휴먼=org_member.id·에이전트=team_member.id)를 쓴다.
+    canonicalize(auth.user_id) 금지 — 휴먼은 auth.user_id=users.id라 디스패치(org_member.id)와 불일치."""
+    from app.routers.webhooks import _get_caller_member_id
+    org_member_id = uuid.uuid4()
+    users_id = uuid.uuid4()
+    auth = SimpleNamespace(user_id=str(users_id))  # 휴먼 JWT sub = users.id
+    with patch("app.services.member_resolver.resolve_member",
+               new=AsyncMock(return_value=SimpleNamespace(id=org_member_id))):
+        out = await _get_caller_member_id(auth=auth, org_id=uuid.uuid4(), session=AsyncMock())
+    assert out == org_member_id        # canonical 축(디스패치 정합)
+    assert out != users_id             # users.id 축 아님(축 버그 회귀 차단)

--- a/backend/tests/test_s34.py
+++ b/backend/tests/test_s34.py
@@ -49,9 +49,12 @@ async def _client():
 
     from app.dependencies.auth import get_current_user
     from app.dependencies.database import get_db
+    from app.routers.webhooks import _get_caller_member_id
 
     app.dependency_overrides[get_db] = override_db
     app.dependency_overrides[get_current_user] = override_auth
+    # caller member 해소(resolve_member)는 인프라 — 단위테스트는 직접 오버라이드(멤버 소유 스코프=MEMBER_ID).
+    app.dependency_overrides[_get_caller_member_id] = lambda: MEMBER_ID
 
     from httpx import ASGITransport, AsyncClient
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app


### PR DESCRIPTION
## ⚠️ 배달 영향 회귀 hotfix (#1726 후속)
통합 trust-surface 라이브 픽셀서 발견(오르테가)·디디 추적·서브에이전트+직접 코드검증으로 확정.

## 근본
`_get_caller_member_id` 가 `canonicalize_member_id(auth.user_id)` 사용. 휴먼은 `auth.user_id = users.id`(JWT `sub`·`OrgMember.user_id`로 매칭)이고 alias 는 team_member.id→org_member.id 전용이라 **users.id 는 no-op** → webhook config 가 **users.id 축**으로 write/scope. 디스패치(`conversation_webhook.py` — `conversation_participants.member_id` = **org_member.id** 축, 0092 이후)와 불일치 → 휴먼 webhook **silent 미배달**.
- 예: sellerking config.member_id=`d3ed4ed8`(users.id)·/api/me=`2fd14616`(org_member.id) → 디스패치 0행.

## fix
`_get_caller_member_id` → **`resolve_member(auth, org_id, session).id`** (멤버-ssot canonical SSOT). 휴먼=org_member.id·에이전트=team_member.id → write/LIST/get_owned/delete 전부 디스패치 축 정합.

## 에이전트 무회귀 (PO 必須 #1·전수 확인)
agent 는 `auth.user_id = team_member.id`·`resolve_member(agent)=team_member.id`(legacy+anchor 양 분기·member_resolver.py)·alias 미적용 → **구 canonicalize 와 동일값(거동 불변)**. 디스패치도 agent participant=team_member.id 라 정합. **휴먼만 고치고 에이전트 안 깨짐.**

## 데이터 보정 (必須 #2)
**0138 마이그(idempotent)**: users.id 축 휴먼 config → org_member.id 1회 보정(`om.user_id=wc.member_id AND om.org_id=wc.org_id` org-scope 조인). 에이전트(team_member.id)·이미-정상(org_member.id) 무접촉. 재실행 시 조인 0(idempotent).

## 테스트
`_get_caller_member_id = resolve_member().id`(users.id 아님) 신규 1 · test_s34 인프라 오버라이드 정합. single head 0138 · 전체 2517 passed(실패 8=환경 DoD).

## 必須 #3 — 산티아고 consult
멤버-ssot 축·타 surface도 users.id 키잉 없나·fix 무회귀. #1727 FE 는 BE 반환 신뢰라 hotfix 後 자동 정합.
⚠️ **이 hotfix 머지+검증 전 prod 승격 보류**(배달 회귀).

🤖 Generated with [Claude Code](https://claude.com/claude-code)