### PR TITLE
[SID:0d142311] 모바일 칸반 스와이프=드래그 prod 재발 근본 fix

### DIFF
--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -35,8 +35,9 @@ class MousePointerSensor extends PointerSensor {
   static activators = [
     {
       eventName: 'onPointerDown' as const,
+      // 좌클릭만 드래그(button===0) — 우/휠/보조 클릭은 dnd 게이트(산티아고 QA RC·dnd-kit 기본 PointerSensor 동등).
       handler: ({ nativeEvent }: { nativeEvent: PointerEvent }) =>
-        nativeEvent.isPrimary && nativeEvent.pointerType !== 'touch',
+        nativeEvent.isPrimary && nativeEvent.button === 0 && nativeEvent.pointerType !== 'touch',
     },
   ];
 }

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { Check, ChevronDown, LayoutGrid, LayoutList, Search } from 'lucide-react';
-import { DndContext, DragEndEvent, PointerSensor, TouchSensor, useSensor, useSensors, DragOverlay, closestCenter } from '@dnd-kit/core';
+import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors, DragOverlay, closestCenter } from '@dnd-kit/core';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -25,6 +25,21 @@ import { StoryDetailPanel } from './story-detail-panel';
 import { StoryCard } from './story-card';
 import { COLUMNS, VALID_TRANSITIONS, type KanbanStory, type KanbanSprint, type KanbanEpic, type KanbanMember, type ColumnId, type DependencyEdge, type GateItem, type LineStatusSummary } from './types';
 import type { LabelData } from '@/components/ui/label-chip';
+
+/**
+ * 터치는 드래그를 절대 시작하지 않게 — pointerType !== 'touch'만 드래그 활성(0d142311 prod 재발 근본 fix).
+ * 마우스/펜 = 8px 드래그 유지 / 터치 = 센서 무시 → 네이티브 스크롤(touch-action pan-x pan-y 보장).
+ * 타이밍 disambiguation(TouchSensor delay/tolerance) 포기·deterministic. 하이브리드(터치 노트북)도 마우스 드래그 유지.
+ */
+class MousePointerSensor extends PointerSensor {
+  static activators = [
+    {
+      eventName: 'onPointerDown' as const,
+      handler: ({ nativeEvent }: { nativeEvent: PointerEvent }) =>
+        nativeEvent.isPrimary && nativeEvent.pointerType !== 'touch',
+    },
+  ];
+}
 
 type DragOverlayCompatProps = {
   children?: React.ReactNode;
@@ -180,12 +195,11 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   const [storyTasks, setStoryTasks] = useState<Task[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
 
-  // Desktop: mouse drag begins after an 8px move. Touch: a 250ms press-and-hold is
-  // required before a drag starts, so vertical scrolling on mobile web isn't hijacked
-  // by the drag sensor — the root cause of "보드 dnd 안 됨" on touch (S6 AC1).
+  // 드래그는 non-touch pointer(마우스/펜)만 8px 이동으로 시작. 터치는 센서가 잡지 않아
+  // 네이티브 스크롤만 동작(0d142311: PointerSensor가 터치도 잡던 + TouchSensor 타이밍 fragile 근본 제거).
+  // 모바일 status 변경은 long-press 메뉴/드롭다운 경로 — touch-drag-reorder 상실은 product intent.
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
-    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } }),
+    useSensor(MousePointerSensor, { activationConstraint: { distance: 8 } }),
   );
 
   const epicMap: Record<string, string> = {};

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -129,13 +129,14 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,
-    // Touch dnd: pan-x pan-y lets a quick swipe scroll natively in BOTH axes (aborting the
-    // TouchSensor's 250ms delay) while a press-and-hold still starts a drag (dnd-kit
-    // preventDefaults once active). `none` would kill scroll-on-card.
+    // Touch dnd: pan-x pan-y lets a swipe scroll natively in BOTH axes. 0d142311: the drag
+    // sensor (MousePointerSensor) now ignores pointerType==='touch' entirely, so touch never
+    // starts a drag — pan-x pan-y just guarantees native scroll; press-and-hold drives the
+    // context menu, not a drag. `none` would kill scroll-on-card.
     // 0a36762d: pan-y alone (S6) preserved vertical column scroll but BLOCKED horizontal board
     // scroll — columns sit in an `overflow-x-auto` row (scrollW>clientW), so a horizontal swipe
-    // starting on a card had no native scroll and got captured. pan-x pan-y restores horizontal
-    // board scroll (superset of pan-y → no regression to vertical scroll or desktop drag).
+    // starting on a card had no native scroll. pan-x pan-y restores horizontal board scroll
+    // (superset of pan-y → no regression to vertical scroll or desktop drag).
     touchAction: 'pan-x pan-y' as const,
   };
 


### PR DESCRIPTION
## 배경 (prod·high)
모바일 칸반 swipe가 카드 드래그로 캡처되어 **의도치 않은 status/position PATCH** 발생 (prod 보드 `1d3bfded`·`469db8ca` 실유저 에스컬레이션). prior #1592(0a36762d·pan-y→pan-x pan-y) 타이밍 disambiguation fix의 **prod 재발** — 이번엔 근본·결정적 fix.

스토리 `0d142311` · 핸드오프 `0d142311-mobile-swipe-drag-handoff`(유나 접근 락·PO nod).

## 근본
- `kanban-board.tsx`: `PointerSensor({distance:8})` + `TouchSensor({delay:250,tolerance:5})`. **PointerSensor가 터치도 잡음**(Pointer Events = 마우스+터치 공통) → 8px 이동만으로 터치 드래그. TouchSensor delay/tolerance **타이밍 disambiguation 자체가 fragile**(slow swipe·hold-then-move가 임계 넘어 캡처).

## Fix 🅰 (deterministic·타이밍 포기)
센서를 **`MousePointerSensor`**(extends PointerSensor·`activators`가 `nativeEvent.pointerType !== 'touch'`만 활성)로 교체 + **TouchSensor 제거**.
- **마우스/펜** = 8px 드래그 그대로 (데스크탑 무회귀·하이브리드 터치 노트북도 마우스 드래그 유지).
- **터치** = 센서가 무시 → 네이티브 스크롤 (`touch-action: pan-x pan-y`[#1592] 유지·센서가 터치 안 잡으니 preventDefault 없음·충돌 0).
- 모바일 status 변경은 **long-press 메뉴 + 드롭다운** 경로 — touch-drag-reorder 상실 = **product intent**(swipe=scroll). 회귀 아님.

`story-card.tsx`: listeners 무변경 · touchAction 유지 · 주석만 갱신(stale TouchSensor 참조 → 새 모델).

## 검증 (⚠️ 라이브 픽셀이 arbiter)
- 모바일 터치 swipe(세로/가로) = 스크롤만 · status/position **PATCH 0**(네트워크 계측).
- 데스크탑 마우스 드래그 = 정상 PATCH(무회귀).
- 모바일 long-press → 메뉴 → status 변경 동작.
- type-check 0 · lint 0 · build ✓.
- ⚠️ prior fix가 prod 재발했던 버그 클래스 → **dev 라이브 픽셀(coarse 에뮬 + 실 터치)로 최종 판정**, 정적/CI는 보조.

## Base
`develop` (prod 승격 전 dev 검증 필수)

🤖 Generated with [Claude Code](https://claude.com/claude-code)