### PR TITLE
[SID:b47f9b05] 스탠드업 history+get plan_stories enrich — 백로그 미노출 잔여 BE 갭

### DIFF
--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -177,9 +177,13 @@ async def list_standup_history(
     limit: int = Query(default=30, ge=1, le=200),
     repo: StandupEntryRepository = Depends(_get_repo),
 ) -> list[StandupEntryResponse]:
-    """GET /api/v2/standups/history — 최근 N개 스탠드업 히스토리 조회 (AC2 S-STANDUP-FIX)."""
+    """GET /api/v2/standups/history — 최근 N개 스탠드업 히스토리 조회 (AC2 S-STANDUP-FIX).
+
+    b47f9b05: list/upsert/update 와 동일하게 plan_stories org-scope enrich(a9e67531) 적용 — 미적용 시
+    백로그→데일리 할일(plan_story_ids)이 plan_stories 빈 채 내려가 cross-board 미노출(SaaS FE 프록시 포함).
+    """
     entries = await repo.list(project_id=project_id, limit=limit)
-    return [StandupEntryResponse.model_validate(e) for e in entries]
+    return await _entries_with_plan_stories(entries, repo.session, repo.org_id)
 
 
 @router.get("/missing", response_model=list[uuid.UUID])
@@ -224,7 +228,8 @@ async def get_standup(
     entry = await repo.get(id)
     if entry is None:
         raise HTTPException(status_code=404, detail="Standup entry not found")
-    return StandupEntryResponse.model_validate(entry)
+    # b47f9b05: 단건 조회도 plan_stories enrich(list/upsert/update 와 일관·cross-board 백로그 노출).
+    return (await _entries_with_plan_stories([entry], repo.session, repo.org_id))[0]
 
 
 @router.post("/{id}/feedback", response_model=FeedbackResponse, status_code=201)

--- a/backend/tests/test_standup_plan_stories_enrich.py
+++ b/backend/tests/test_standup_plan_stories_enrich.py
@@ -76,3 +76,40 @@ async def test_org_scope_in_query():
     await _entries_with_plan_stories([entry], session, ORG)
     stmt = str(session.execute.await_args.args[0])
     assert "org_id" in stmt and "deleted_at" in stmt  # org-scope + soft-delete 필터.
+
+
+# ─── b47f9b05: history + get_standup enrich 갭 회귀(원 시나리오) ──────────────
+
+def _repo(*, list_ret=None, get_ret=None, session=None):
+    return SimpleNamespace(
+        list=AsyncMock(return_value=list_ret),
+        get=AsyncMock(return_value=get_ret),
+        session=session, org_id=ORG,
+    )
+
+
+@pytest.mark.anyio
+async def test_history_endpoint_enriches_backlog_plan_story():
+    """history 가 백로그(cross-board) plan_story 를 enrich — 미적용 시 plan_stories 빈 채 미노출 회귀."""
+    from app.routers.standups import list_standup_history
+    backlog = uuid.uuid4()
+    session = AsyncMock()
+    result = MagicMock(); result.all.return_value = [_row(backlog, "Backlog", "backlog")]
+    session.execute = AsyncMock(return_value=result)
+    repo = _repo(list_ret=[_entry([backlog])], session=session)
+    out = await list_standup_history(project_id=uuid.uuid4(), limit=30, repo=repo)
+    assert [ps.id for ps in out[0].plan_stories] == [backlog]  # 백로그 노출(enrich)
+
+
+@pytest.mark.anyio
+async def test_get_standup_endpoint_enriches_backlog_plan_story():
+    """단건 조회도 백로그 plan_story enrich(list/upsert/update 와 일관)."""
+    from app.routers.standups import get_standup
+    backlog = uuid.uuid4()
+    entry = _entry([backlog])
+    session = AsyncMock()
+    result = MagicMock(); result.all.return_value = [_row(backlog, "Backlog", "backlog")]
+    session.execute = AsyncMock(return_value=result)
+    repo = _repo(get_ret=entry, session=session)
+    out = await get_standup(id=entry.id, repo=repo)
+    assert [ps.id for ps in out.plan_stories] == [backlog]


### PR DESCRIPTION
## 배경 (prod버그 b47f9b05 — root 판정)
스탠드업 생성 시 백로그→데일리 할일 추가해도 미노출(prod 실유저). **root 판정 결과**:

**root = SaaS FE(ee/apps/web)** — 서브에이전트+직접검증 확정: `ee/apps/web/src/app/api/standup/route.ts`가 메인 `apps/web`(backend 프록시)을 **override·Supabase-direct**로 읽어 `plan_stories` enrich 미수신 → FE `standup-review-card`가 plan_stories 없으면 `plan_story_ids`를 **active-sprint scoped `stories` 배열**서 resolve(fallback) → 백로그(sprint 밖) 탈락 → 미노출. **OSS `apps/web`엔 #1689 닿았으나 SaaS `ee/apps/web`엔 미적용**(prod=SaaS). → **FE 수정은 미르코/유나 lane**(PO 라우팅).

## 이 PR (BE 잔여 갭·내 lane)
근본은 FE지만 **BE에도 잔여 비일관**: a9e67531(#1688)이 `_entries_with_plan_stories` enrich를 list/upsert/update에만 적용·**GET /history·GET /{id}는 미적용**(`model_validate` 직결·plan_stories=[]). 그 경로로 읽으면 동일 미노출.
- fix: history + get_standup도 enrich 적용(전 read 엔드포인트 일관).
- **SaaS FE를 backend 프록시로 정합**시키는 방향(미르코 fix)의 토대 — 프록시가 enriched plan_stories 받게 됨.

## 테스트 (AC4 회귀)
history/get_standup가 백로그(cross-board) plan_story enrich 회귀 2(원 시나리오). 전체 2519 passed(실패 8=환경 DoD).

## AC 매핑
AC4 root(FE=ee/apps/web Supabase-direct·BE 잔여 갭) 명시+회귀 ✅. AC1/2/3(즉시표시·persist·실패)는 **FE fix(미르코)서 닫힘**(이 PR은 BE 일관 토대). AC5 까심+산티아고 게이트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)