### PR TITLE
[SID:b47f9b05] 스탠드업 plan_stories enrich (ee 백로그→데일리 미노출 prod fix)

### DIFF
--- a/apps/web/src/services/standup.test.ts
+++ b/apps/web/src/services/standup.test.ts
@@ -57,6 +57,61 @@ describe('StandupService.save', () => {
   });
 });
 
+describe('StandupService.getEntries plan_stories enrich (b47f9b05)', () => {
+  it('resolves plan_story_ids to plan_stories org-scoped, incl. cross-board backlog (no sprint/status filter)', async () => {
+    const storiesFilters: string[] = [];
+    const db = {
+      from(table: string) {
+        if (table === 'standup_entries') {
+          return {
+            select() { return this; },
+            eq() { return this; },
+            order: async () => ({
+              data: [{
+                id: 'e1', org_id: 'org-1', project_id: 'p1', author_id: 'm1', date: '2026-04-10',
+                plan_story_ids: ['s-sprint', 's-backlog'],
+              }],
+              error: null,
+            }),
+          };
+        }
+        if (table === 'stories') {
+          return {
+            select() { return this; },
+            in() { return this; },
+            is(col: string) { storiesFilters.push(`is:${col}`); return this; },
+            eq(col: string) { storiesFilters.push(`eq:${col}`); return this; },
+            then: (resolve: (v: { data: unknown; error: null }) => void) => Promise.resolve({
+              data: [
+                { id: 's-sprint', title: 'In sprint', status: 'in-progress', priority: 'high', project_id: 'p1', sprint_id: 'sp1' },
+                { id: 's-backlog', title: 'Backlog other board', status: 'backlog', priority: 'low', project_id: 'p2', sprint_id: null },
+              ],
+              error: null,
+            }).then(resolve),
+          };
+        }
+        return { select() { return this; }, eq() { return this; }, single: async () => ({ data: null, error: null }) };
+      },
+    } as any;
+
+    const service = new StandupService(db);
+    const entries = await service.getEntries('p1', '2026-04-10');
+
+    expect(entries).toHaveLength(1);
+    // cross-board 백로그(sprint_id null·타 project)도 탈락 없이 포함
+    expect(entries[0].plan_stories).toEqual([
+      { id: 's-sprint', title: 'In sprint', status: 'in-progress', priority: 'high', project_id: 'p1', sprint_id: 'sp1' },
+      { id: 's-backlog', title: 'Backlog other board', status: 'backlog', priority: 'low', project_id: 'p2', sprint_id: null },
+    ]);
+    // 불변식: org_id + deleted_at만, sprint/project/status 필터 없음
+    expect(storiesFilters).toContain('is:deleted_at');
+    expect(storiesFilters).toContain('eq:org_id');
+    expect(storiesFilters).not.toContain('eq:sprint_id');
+    expect(storiesFilters).not.toContain('eq:status');
+    expect(storiesFilters).not.toContain('eq:project_id');
+  });
+});
+
 describe('StandupFeedbackService', () => {
   it('loads feedback by standup date', async () => {
     const db = {

--- a/apps/web/src/services/standup.ts
+++ b/apps/web/src/services/standup.ts
@@ -15,6 +15,20 @@ export interface SaveStandupInput {
   plan_story_ids?: string[];
 }
 
+/**
+ * b47f9b05: ee standup GET이 Supabase-direct라 raw plan_story_ids만 내려 FE가 active-sprint scoped
+ * stories fallback→백로그(sprint 밖) 탈락. plan_story_ids를 stories org-scope 조회로 resolve해
+ * plan_stories(BE #1731 enrich 동형)로 채워 내린다. cross-board(타 프로젝트 백로그) 노출 보장.
+ */
+export interface PlanStorySummary {
+  id: string;
+  title: string;
+  status: string;
+  priority: string;
+  project_id: string;
+  sprint_id: string | null;
+}
+
 export interface CreateStandupFeedbackInput {
   project_id: string;
   org_id: string;
@@ -53,7 +67,9 @@ export class StandupService {
       .eq('date', date)
       .order('created_at');
     if (error) throw error;
-    return data;
+    const entries = (data ?? []) as Array<Record<string, unknown>>;
+    const map = await this.resolvePlanStories(entries);
+    return entries.map((e) => this.attachPlanStories(e, map));
   }
 
   async getEntryForUser(projectId: string, authorId: string, date: string) {
@@ -65,7 +81,53 @@ export class StandupService {
       .eq('date', date)
       .single();
     if (error && error.code !== 'PGRST116') throw error;
-    return data;
+    if (!data) return data;
+    const map = await this.resolvePlanStories([data]);
+    return this.attachPlanStories(data, map);
+  }
+
+  /** plan_story_ids → stories org-scope 조회(cross-board)로 PlanStorySummary 맵. admin client에도 org_id 가드. */
+  private async resolvePlanStories(
+    entries: Array<Record<string, unknown>>,
+  ): Promise<Map<string, PlanStorySummary>> {
+    const map = new Map<string, PlanStorySummary>();
+    const ids = [...new Set(entries.flatMap((e) => (e.plan_story_ids as string[] | null) ?? []))];
+    if (ids.length === 0) return map;
+    const orgId = (entries.find((e) => e.org_id)?.org_id as string | undefined) ?? null;
+    // ⭐ 불변식(디디): org_id 스코프 ONLY + deleted_at is null. sprint/project/board/status 필터 금지
+    // — 좁히면 백로그(sprint 밖·타 보드) 다시 탈락(BE _entries_with_plan_stories 동형).
+    let query = this.db
+      .from('stories')
+      .select('id, title, status, priority, project_id, sprint_id')
+      .in('id', ids)
+      .is('deleted_at', null);
+    if (orgId) query = query.eq('org_id', orgId);
+    const { data, error } = await query;
+    if (error) throw error;
+    for (const s of (data ?? []) as Array<Record<string, unknown>>) {
+      map.set(s.id as string, {
+        id: s.id as string,
+        title: s.title as string,
+        status: s.status as string,
+        priority: s.priority as string,
+        project_id: s.project_id as string,
+        sprint_id: (s.sprint_id as string | null) ?? null,
+      });
+    }
+    return map;
+  }
+
+  private attachPlanStories<T extends Record<string, unknown>>(
+    entry: T,
+    map: Map<string, PlanStorySummary>,
+  ): T & { plan_stories: PlanStorySummary[] } {
+    const ids = (entry.plan_story_ids as string[] | null) ?? [];
+    return {
+      ...entry,
+      plan_stories: ids
+        .map((id) => map.get(id))
+        .filter((s): s is PlanStorySummary => Boolean(s)),
+    };
   }
 
   async save(input: SaveStandupInput) {
@@ -125,12 +187,14 @@ export class StandupService {
   async getHistory(projectId: string, limit = 50) {
     const { data, error } = await this.db
       .from('standup_entries')
-      .select('author_id, date, done, plan, blockers')
+      .select('author_id, date, done, plan, blockers, plan_story_ids, org_id')
       .eq('project_id', projectId)
       .order('date', { ascending: false })
       .limit(limit);
     if (error) throw error;
-    return data;
+    const entries = (data ?? []) as Array<Record<string, unknown>>;
+    const map = await this.resolvePlanStories(entries);
+    return entries.map((e) => this.attachPlanStories(e, map));
   }
 }
 


### PR DESCRIPTION
## 배경 (prod·실유저 `4fd33269`)
ee 스탠드업: 백로그 스토리를 데일리 plan에 넣어도 리뷰 카드에 **미노출**. write/persist는 정상.

스토리 `b47f9b05` · 유나 핸드오프 · 디디 BE verdict(conv fab25f72·②).

## 근본
prod=ee/apps/web(Supabase-direct 오버레이). `ee/.../api/standup/route.ts` GET이 `StandupService`(Supabase-direct)라 BE `plan_stories` enrich 미수신(raw `plan_story_ids`만) → FE `standup-review-card.tsx`가 plan_story_ids → **active-sprint scoped** `stories` fallback → 백로그(sprint 밖·타 보드) 탈락.

## Fix (②·디디 verdict — 저위험·BE 무변경·FastAPI 도달 무관)
`StandupService`(ee 라우트가 소비·OSS 라우트는 proxy라 미사용)에서 `plan_story_ids`를 **stories org-scope 조회**로 resolve → `PlanStorySummary` 6필드(id/title/status/priority/project_id/sprint_id)로 `plan_stories` enrich. BE `_entries_with_plan_stories`(#1731) **동형 shape**.
- `getEntries` / `getEntryForUser`(단건) / `getHistory` 전부 enrich.
- ⭐ **불변식(디디)**: stories 조회 = `org_id` 스코프 ONLY + `deleted_at is null`. **sprint/project/board/status 필터 금지** — 좁히면 백로그 재탈락(근본 재현).
- **ee 라우트 무변경**(서비스 enrich가 자동 적용) · **FE `standup-review-card` 무변경**(plan_stories 우선 소비). POST/write 유지.
- `getHistory` select에 `plan_story_ids`·`org_id` 추가(enrich용·additive).

## 검증
- vitest: getEntries enrich 신규 테스트 — cross-board 백로그(sprint_id null·타 project) 포함 + 불변식(org_id/deleted_at만·sprint/status/project 필터 없음) 검증.
- type-check 0 · lint 0 · build ✓ · vitest 5/5.
- ⚠️ dev 라이브 픽셀(유나·arbiter): 스탠드업 생성→백로그 할당→데일리 추가→**노출**·history/단건.

## Base
`develop` (prod 승격 전 dev 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)