### PR TITLE
[SID:5b7ae2b1] 메뉴 클릭 지연 fix — loading.tsx 7 라우트 신규

### DIFF
--- a/apps/web/src/app/(authenticated)/activity/loading.tsx
+++ b/apps/web/src/app/(authenticated)/activity/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from '@/components/ui/page-skeleton';
+
+export default function Loading() {
+  return <PageSkeleton showTitle rows={8} cards={0} />;
+}

--- a/apps/web/src/app/(authenticated)/agents/loading.tsx
+++ b/apps/web/src/app/(authenticated)/agents/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from '@/components/ui/page-skeleton';
+
+export default function Loading() {
+  return <PageSkeleton showTitle cards={3} rows={4} />;
+}

--- a/apps/web/src/app/(authenticated)/channel/loading.tsx
+++ b/apps/web/src/app/(authenticated)/channel/loading.tsx
@@ -1,0 +1,21 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function Loading() {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="border-b border-border px-4 py-3">
+        <Skeleton className="h-6 w-40" />
+      </div>
+      <div className="flex-1 space-y-4 overflow-hidden p-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className={i % 2 === 0 ? 'flex justify-start' : 'flex justify-end'}>
+            <Skeleton className={`h-16 rounded-xl ${i % 2 === 0 ? 'w-2/3' : 'w-1/2'}`} />
+          </div>
+        ))}
+      </div>
+      <div className="border-t border-border p-3">
+        <Skeleton className="h-12 w-full rounded-lg" />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/chats/loading.tsx
+++ b/apps/web/src/app/(authenticated)/chats/loading.tsx
@@ -1,0 +1,22 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function Loading() {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="border-b border-border px-4 py-3">
+        <Skeleton className="h-5 w-24" />
+      </div>
+      <div className="flex-1 space-y-1 overflow-hidden p-2">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 px-3 py-2.5">
+            <Skeleton className="h-10 w-10 rounded-full" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-3 w-48" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/docs/loading.tsx
+++ b/apps/web/src/app/(authenticated)/docs/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from '@/components/ui/page-skeleton';
+
+export default function Loading() {
+  return <PageSkeleton showTitle rows={8} cards={0} />;
+}

--- a/apps/web/src/app/(authenticated)/settings/loading.tsx
+++ b/apps/web/src/app/(authenticated)/settings/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from '@/components/ui/page-skeleton';
+
+export default function Loading() {
+  return <PageSkeleton showTitle cards={0} rows={6} />;
+}

--- a/apps/web/src/app/(authenticated)/sprints/loading.tsx
+++ b/apps/web/src/app/(authenticated)/sprints/loading.tsx
@@ -1,0 +1,5 @@
+import { PageSkeleton } from '@/components/ui/page-skeleton';
+
+export default function Loading() {
+  return <PageSkeleton showTitle cards={2} rows={4} />;
+}


### PR DESCRIPTION
## 배경 (measure-first)
메뉴 클릭 시 지연 체감의 근본 = **loading.tsx 없는 라우트는 클릭 後 nav pending 피드백 0** → old 페이지가 freeze된 것처럼 보임. (대조: board는 skeleton@25ms 있음 / agents는 null로 없음.)

스토리 `5b7ae2b1` · 유나 핸드오프 · PO nod (conv 2bd6cc38).

## Fix
Next.js App Router `loading.tsx` = 라우트 nav 시 즉시 렌더(<100ms skeleton). **7 라우트에 신규 추가**(저위험·회귀 0·기존 동작 무변경).

**A. `PageSkeleton` 재사용 (5·list형)**
| route | props |
|---|---|
| `docs` | `showTitle rows={8} cards={0}` |
| `activity` | `showTitle rows={8} cards={0}` |
| `settings` | `showTitle cards={0} rows={6}` |
| `agents` | `showTitle cards={3} rows={4}` |
| `sprints` | `showTitle cards={2} rows={4}` |

**B. 커스텀 `Skeleton` (2·셰이프 상이)**
- `chats`: 타이틀바 + conversation-row 6(아바타 circle `h-10 w-10` + 2줄 `h-4 w-32`/`h-3 w-48`) · `flex min-h-0 flex-1 flex-col` 래퍼(페이지 셰이프 일치).
- `channel`: 헤더 + 메시지 버블 row 4(좌/우 교차) + 하단 입력바.

## 토큰 / 테마
신규 토큰 0 · 양테마 자동(`Skeleton` `--skeleton-base/highlight` 토큰 기반) · 기존 loading.tsx 패턴 일관.

## ⚠️ agents ee/ 오버라이드 (디디 교차확인 요청)
`ee/apps/web/src/app/(authenticated)/agents/page.tsx` 존재(loading.tsx 부재). ee 오버레이 빌드에서 OSS `agents/loading.tsx`가 ee agents 라우트에도 적용되는지 확인 필요 — 적용 안 되면 ee/에도 동일 loading.tsx 추가(fast-follow). 나머지 6 = clean OSS·prod 반영.

## 검증
- type-check 0 · lint 0 · build ✓.
- ⚠️ dev 픽셀(유나): 라우트별 skeleton **실 렌더** 확인(파일존재≠렌더·각 <100ms·before/after ms 7개 기록). 게이트 까심+산티아고.

## scope 경계
board cold render 1203ms·`api/docs` 550ms는 **별개 후속**(PO 분리)·이 PR 범위 아님.

## Base
`develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)