### PR TITLE
[SID:9e6fd116] Release Note 인앱 / What's new (auto-open + top-bar 버튼)

### DIFF
--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -18,6 +18,7 @@ import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
 import { ContextualPanelLayout, useContextualPanelState } from '@/components/ui/contextual-panel-layout';
 import { TeamPresencePanel } from '@/components/presence/team-presence-panel';
 import { useTeamPresence } from '@/components/presence/use-team-presence';
+import { ReleaseNotesProvider } from '@/components/release-notes/release-notes-gate';
 import { RefreshProvider } from '@/contexts/refresh-context';
 import { TeamPresenceToggleProvider } from '@/components/presence/team-presence-toggle';
 import type { OrgSwitcherItem } from '@/components/nav/unified-switcher';
@@ -62,6 +63,7 @@ function ScrollShell({ showTopBar, children }: { showTopBar: boolean; children: 
   const workingCount = items.filter((i) => i.working).length;
 
   return (
+    <ReleaseNotesProvider userId={currentTeamMemberId}>
     <TeamPresenceToggleProvider value={{ toggle: panel.togglePanel, workingCount, open: panel.inlinePanelOpen || panel.drawerOpen }}>
     <SidebarInset className="relative flex flex-col overflow-hidden">
       <div ref={setRef} className="flex flex-1 min-h-0 flex-col overflow-y-auto">
@@ -91,6 +93,7 @@ function ScrollShell({ showTopBar, children }: { showTopBar: boolean; children: 
       </div>
     </SidebarInset>
     </TeamPresenceToggleProvider>
+    </ReleaseNotesProvider>
   );
 }
 

--- a/apps/web/src/components/nav/top-bar.tsx
+++ b/apps/web/src/components/nav/top-bar.tsx
@@ -3,6 +3,7 @@
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { cn } from '@/lib/utils';
 import { NotificationBell } from './notification-bell';
+import { WhatsNewButton } from '@/components/release-notes/whats-new-button';
 import { PresenceToggleButton } from '@/components/presence/team-presence-toggle';
 import { useTopBar } from './top-bar-context';
 
@@ -31,6 +32,7 @@ export function TopBar({ className }: TopBarProps) {
         {actions}
         {/* 2505d27d: presence 패널 토글(선생님 결정·FAB 대체) — Bell 옆·working-count 배지 */}
         <PresenceToggleButton />
+        <WhatsNewButton />
         <NotificationBell />
       </div>
     </div>

--- a/apps/web/src/components/release-notes/release-notes-dialog.tsx
+++ b/apps/web/src/components/release-notes/release-notes-dialog.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useState } from 'react';
+import { Sparkles, ChevronRight, ChevronLeft, ArrowRight } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { RELEASE_NOTES, type ReleaseNote } from '@/lib/release-notes';
+
+interface ReleaseNotesDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function ReleaseNotesDialog({ open, onClose }: ReleaseNotesDialogProps) {
+  const [view, setView] = useState<'latest' | 'list'>('latest');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const note: ReleaseNote | undefined = selectedId
+    ? RELEASE_NOTES.find((n) => n.id === selectedId)
+    : RELEASE_NOTES[0];
+
+  const reset = () => {
+    setView('latest');
+    setSelectedId(null);
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      onClose();
+      reset();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md rounded-xl">
+        {view === 'latest' && note ? (
+          <>
+            <DialogHeader className="space-y-2">
+              <span className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-info">
+                <Sparkles className="h-3.5 w-3.5" aria-hidden />
+                What&apos;s new
+              </span>
+              <DialogTitle className="flex flex-wrap items-center gap-2 text-lg">
+                {note.title}
+                <Badge variant="outline" className="text-xs">{note.version}</Badge>
+              </DialogTitle>
+              <p className="text-xs text-muted-foreground">{note.publishedAt}</p>
+              <DialogDescription className="text-sm text-muted-foreground">
+                {note.summary}
+              </DialogDescription>
+            </DialogHeader>
+            <ul className="space-y-2">
+              {note.items.map((item, i) => (
+                <li key={i} className="flex items-start gap-2 text-sm">
+                  <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-info" aria-hidden />
+                  <span className="min-w-0">
+                    {item.text}
+                    {item.href && (
+                      <a
+                        href={item.href}
+                        className="ml-1.5 inline-flex items-center gap-0.5 text-info hover:underline"
+                      >
+                        자세히 보기
+                        <ArrowRight className="h-3 w-3" aria-hidden />
+                      </a>
+                    )}
+                  </span>
+                </li>
+              ))}
+            </ul>
+            <DialogFooter className="flex-row items-center justify-between border-t border-border pt-4 sm:justify-between">
+              <Button variant="ghost" size="sm" onClick={() => setView('list')}>
+                이전 노트
+              </Button>
+              <Button variant="hero" size="sm" onClick={() => handleOpenChange(false)}>
+                확인
+              </Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader className="space-y-2">
+              <button
+                type="button"
+                onClick={reset}
+                className="inline-flex w-fit items-center gap-1 text-xs text-muted-foreground transition hover:text-foreground"
+              >
+                <ChevronLeft className="h-3.5 w-3.5" aria-hidden />
+                이전 노트
+              </button>
+              <DialogTitle className="text-base">릴리즈 노트</DialogTitle>
+              <DialogDescription className="sr-only">이전 릴리즈 노트 목록</DialogDescription>
+            </DialogHeader>
+            <ul className="divide-y divide-border overflow-hidden rounded-md border border-border">
+              {RELEASE_NOTES.map((n) => (
+                <li key={n.id}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setSelectedId(n.id);
+                      setView('latest');
+                    }}
+                    className="flex w-full items-center gap-2 px-3 py-2.5 text-left transition hover:bg-accent"
+                  >
+                    <Badge variant="outline" className="shrink-0 text-xs">{n.version}</Badge>
+                    <span className="min-w-0 flex-1 truncate text-sm">{n.title}</span>
+                    <span className="shrink-0 text-xs text-muted-foreground">{n.publishedAt}</span>
+                    <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/release-notes/release-notes-gate.tsx
+++ b/apps/web/src/components/release-notes/release-notes-gate.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import { LATEST_RELEASE_NOTE_ID } from '@/lib/release-notes';
+import { ReleaseNotesDialog } from './release-notes-dialog';
+
+interface ReleaseNotesContextValue {
+  open: () => void;
+  hasUnseen: boolean;
+}
+
+const ReleaseNotesContext = createContext<ReleaseNotesContextValue | null>(null);
+
+/** top-bar 버튼 등 consumer. provider 밖이면 null → 버튼은 렌더 안 함. */
+export function useReleaseNotes(): ReleaseNotesContextValue | null {
+  return useContext(ReleaseNotesContext);
+}
+
+function seenKey(userId: string): string {
+  return `sprintable.releaseNotes.seen.${userId}`;
+}
+
+interface ReleaseNotesProviderProps {
+  userId?: string;
+  children: React.ReactNode;
+}
+
+export function ReleaseNotesProvider({ userId, children }: ReleaseNotesProviderProps) {
+  const [open, setOpen] = useState(false);
+  const [seenId, setSeenId] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
+
+  // mount 後 localStorage 읽기 (SSR hydration 불일치 방지). 미열람 최신 노트면 auto-open.
+  useEffect(() => {
+    if (!userId) return;
+    try {
+      const seen = localStorage.getItem(seenKey(userId));
+      setSeenId(seen);
+      if (LATEST_RELEASE_NOTE_ID && seen !== LATEST_RELEASE_NOTE_ID) setOpen(true);
+    } catch {
+      // localStorage 차단 환경 — gate 무동작
+    } finally {
+      setReady(true);
+    }
+  }, [userId]);
+
+  const markSeen = useCallback(() => {
+    if (!userId || !LATEST_RELEASE_NOTE_ID) return;
+    try {
+      localStorage.setItem(seenKey(userId), LATEST_RELEASE_NOTE_ID);
+    } catch {
+      // ignore
+    }
+    setSeenId(LATEST_RELEASE_NOTE_ID);
+  }, [userId]);
+
+  const handleOpen = useCallback(() => setOpen(true), []);
+  const handleClose = useCallback(() => {
+    markSeen();
+    setOpen(false);
+  }, [markSeen]);
+
+  const hasUnseen = ready && LATEST_RELEASE_NOTE_ID != null && seenId !== LATEST_RELEASE_NOTE_ID;
+
+  // userId 없으면 gate skip (셸은 인증 後라 보통 존재)
+  if (!userId) return <>{children}</>;
+
+  return (
+    <ReleaseNotesContext.Provider value={{ open: handleOpen, hasUnseen }}>
+      {children}
+      <ReleaseNotesDialog open={open} onClose={handleClose} />
+    </ReleaseNotesContext.Provider>
+  );
+}

--- a/apps/web/src/components/release-notes/whats-new-button.tsx
+++ b/apps/web/src/components/release-notes/whats-new-button.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { Sparkles } from 'lucide-react';
+import { useReleaseNotes } from './release-notes-gate';
+
+/** top-bar What's-new 버튼. provider 밖(컨텍스트 null)이면 렌더 안 함. */
+export function WhatsNewButton() {
+  const ctx = useReleaseNotes();
+  if (!ctx) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={ctx.open}
+      aria-label="What's new"
+      className="relative flex size-8 items-center justify-center rounded-md text-foreground/70 transition hover:bg-accent hover:text-foreground"
+    >
+      <Sparkles className="size-4" />
+      {ctx.hasUnseen && (
+        <span
+          className="absolute -right-0.5 -top-0.5 size-2 rounded-full bg-info ring-2 ring-background"
+          aria-hidden
+        />
+      )}
+    </button>
+  );
+}

--- a/apps/web/src/lib/release-notes.ts
+++ b/apps/web/src/lib/release-notes.ts
@@ -1,0 +1,57 @@
+export interface ReleaseNoteItem {
+  text: string;
+  href?: string;
+}
+
+export interface ReleaseNote {
+  id: string;
+  version: string;
+  /** 표시용 문자열 (정렬/비교는 배열 순서·id로) */
+  publishedAt: string;
+  title: string;
+  summary: string;
+  items: ReleaseNoteItem[];
+}
+
+/**
+ * newest-first. ⚠️ 어느 릴리즈를 어떤 문구로 알릴지는 PO/product 콜 — 아래는 대표 시드(구조 검증용).
+ * id = 가시성 비교 키(localStorage seen 과 대조). 실제 노트 추가/문구는 PO가 갱신.
+ */
+export const RELEASE_NOTES: ReleaseNote[] = [
+  {
+    id: '2026-06-v1-4',
+    version: 'v1.4',
+    publishedAt: '2026년 6월',
+    title: '번다운 차트와 채팅이 새로워졌어요',
+    summary: '스프린트 진행 상황을 한눈에, 팀 대화는 더 빠르게.',
+    items: [
+      { text: '스프린트 번다운 차트로 남은 작업량을 실시간으로 추적합니다.' },
+      { text: '채팅 응답 속도를 개선하고 대화 목록을 정리했습니다.' },
+      { text: '알림 목적지를 한 화면에서 보고·끄고·실제 도달을 테스트합니다.' },
+    ],
+  },
+  {
+    id: '2026-06-v1-3',
+    version: 'v1.3',
+    publishedAt: '2026년 6월',
+    title: '온보딩이 2분이면 끝나요',
+    summary: '설정 하나를 붙여넣고, 실제로 작동하는지 바로 확인합니다.',
+    items: [
+      { text: '에이전트 연결 설정을 한 번에 복사합니다.' },
+      { text: '연결 확인 레일로 실제 동작을 직접 검증합니다.' },
+    ],
+  },
+  {
+    id: '2026-05-v1-2',
+    version: 'v1.2',
+    publishedAt: '2026년 5월',
+    title: '보드가 더 부드러워졌어요',
+    summary: '칸반 보드 드래그와 모바일 사용성을 개선했습니다.',
+    items: [
+      { text: '카드 드래그·드롭 정확도를 높였습니다.' },
+      { text: '모바일에서 보드 스크롤이 매끄러워졌습니다.' },
+    ],
+  },
+];
+
+export const LATEST_RELEASE_NOTE_ID = RELEASE_NOTES[0]?.id ?? null;


### PR DESCRIPTION
## 배경
인앱 릴리즈 노트 / What's new — 미열람 최신 노트 **auto-open** + top-bar **Sparkles 버튼**(미열람 dot)으로 언제든 재오픈. 시안 nod 완(PO fba3e14e). FE = OSS apps/web 단일(ee 무관).

스토리 `9e6fd116` · 유나 핸드오프.

## 구현 (4 신규 + 2 통합)
- **`lib/release-notes.ts`**: `ReleaseNote`/`ReleaseNoteItem` 타입 + `RELEASE_NOTES`(newest-first·대표 시드 v1.4/1.3/1.2) + `LATEST_RELEASE_NOTE_ID`. ⚠️ 실제 알릴 릴리즈/문구는 **PO/product 콜**(구조 검증용 시드).
- **`release-notes-dialog.tsx`**: 공유 `Dialog`(max-w-md·rounded-xl)·`view: latest|list`.
  - latest: eyebrow `WHAT'S NEW`(Sparkles+`text-info`)·title+version `Badge`+date·summary·items(info dot 불릿·`href`면 "자세히 보기"+arrow)·footer border-t 좌'이전 노트'/우'확인'. close X(primitive).
  - list: '← 이전 노트' + version Badge+title+date 행 → 선택 시 latest. a11y(DialogTitle/Description·Esc·focus-trap).
- **`release-notes-gate.tsx`** (provider): seen-key `sprintable.releaseNotes.seen.${userId}` · mount `useEffect`(SSR hydration 방지) · `seen !== LATEST`면 auto-open · `onClose=markSeen` · Context `{open(), hasUnseen}` 노출 · userId 없으면 skip.
- **`whats-new-button.tsx`**: top-bar Sparkles 버튼(`ctx.open`·`hasUnseen` dot `ring-background` cut-out·`aria-label`). provider 밖이면 null.
- **통합**: `dashboard-shell.tsx` ScrollShell → `<ReleaseNotesProvider userId={currentTeamMemberId}>` wrap · `top-bar.tsx` NotificationBell 옆 `<WhatsNewButton/>`.

## 토큰 / 테마 / 스코프
신규 토큰 0(`text-info`/`Sparkles`/Skeleton 기존) · 양테마 자동 · **FE=OSS apps/web 단일**(ee 무관).

## 검증
- type-check 0 · lint 0 · build ✓.
- ⚠️ dev 픽셀(유나): auto-open · top-bar 버튼 · 미열람 dot · **dismiss 後 재로드 미열람 안 뜸(seen 영속)** · 이전 노트 전환 · 양테마.

## Base
`develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)