### PR TITLE
[SID:0c1a81b6] 에이전트 추가 경로 통일 — 모달 단일진입 v2

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -5,7 +5,7 @@ import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { BarChart2, Bell, Bot, Check, CheckCircle2, CreditCard, FolderKanban, GitBranch, Menu, Palette, Plus, ShieldCheck, Trash2, User, Users, Webhook, X } from 'lucide-react';
+import { BarChart2, Bell, Bot, CreditCard, FolderKanban, GitBranch, Menu, Palette, Plus, ShieldCheck, Trash2, User, Users, Webhook, X } from 'lucide-react';
 import { UsageDashboard } from '@/components/settings/usage-dashboard';
 import { OrgMembersSection } from '@/components/settings/org-members-section';
 import { AddMemberModal } from '@/components/settings/add-member-modal';
@@ -30,7 +30,6 @@ import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { OperatorInput } from '@/components/ui/operator-control';
-import { OperatorDropdownSelect } from '@/components/ui/operator-dropdown-select';
 import { MemberRow } from '@/components/ui/member-row';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
@@ -90,13 +89,6 @@ interface ProjectMember {
   webhook_url?: string | null;
   created_by?: string | null;
   fakechat_port?: number | null;
-}
-
-interface NewAgentResult {
-  name: string;
-  fakechat_port: number | null;
-  mcp_config: Record<string, unknown> | null;
-  api_key: string | null;
 }
 
 const NOTIFICATION_CATEGORIES = [
@@ -200,16 +192,9 @@ export default function SettingsPage() {
   const [membersSubTab, setMembersSubTab] = useState<'people' | 'agents'>('people');
   const [addMemberOpen, setAddMemberOpen] = useState(false); // 7363ec8a: 통합 "+멤버 추가" 모달
   const [orgAgents, setOrgAgents] = useState<ProjectMember[]>([]);
-  const [newAgentName, setNewAgentName] = useState('');
-  // org-agent S5: 단일 project_id → scope 인지(전체/특정) 멀티프로젝트 생성으로 업그레이드.
-  const [newAgentRole, setNewAgentRole] = useState<'member' | 'admin'>('member');
-  const [newAgentScopeMode, setNewAgentScopeMode] = useState<'org' | 'projects'>('projects');
-  const [newAgentProjectIds, setNewAgentProjectIds] = useState<string[]>([]);
-  const [addingAgent, setAddingAgent] = useState(false);
+  // 에이전트 추가 v2(name·role·scope·결과)는 AddMemberModal 임베드 <AddAgentForm>가 호스팅(0c1a81b6 경로 통일).
   const [deactivatingAgentId, setDeactivatingAgentId] = useState<string | null>(null);
   const [agentActionMessage, setAgentActionMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
-  const [newAgentResult, setNewAgentResult] = useState<NewAgentResult | null>(null);
-  const [newAgentMcpCopied, setNewAgentMcpCopied] = useState(false);
   const [webhookEditing, setWebhookEditing] = useState<Record<string, string>>({});
   const [webhookSaving, setWebhookSaving] = useState<string | null>(null);
   const [webhookErrors, setWebhookErrors] = useState<Record<string, string>>({});
@@ -337,57 +322,6 @@ export default function SettingsPage() {
     if (!res.ok) return;
     const json = await res.json();
     setOrgAgents((json.data ?? []) as ProjectMember[]);
-  };
-
-  const toggleNewAgentProject = (id: string) => {
-    setNewAgentProjectIds((prev) => prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id]);
-  };
-
-  const handleAddAgent = async () => {
-    if (!newAgentName.trim()) return;
-    if (newAgentScopeMode === 'projects' && newAgentProjectIds.length === 0) return;
-    setAddingAgent(true);
-    setAgentActionMessage(null);
-    setNewAgentResult(null);
-    // org-agent S5: v1 단일프로젝트(/api/team-members) → v2 org-level scope(/api/agents).
-    // org_id·인가는 BE 가 verified context 로 해소 → body 미포함. scope_mode='org'면 project_ids 무시.
-    const res = await fetch('/api/agents', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        name: newAgentName.trim(),
-        role: newAgentRole,
-        scope_mode: newAgentScopeMode,
-        project_ids: newAgentScopeMode === 'projects' ? newAgentProjectIds : [],
-      }),
-    });
-    if (res.ok) {
-      const json = await res.json() as { data?: { fakechat_port?: number | null; mcp_config?: Record<string, unknown> | null; api_key?: string | null } };
-      setNewAgentResult({
-        name: newAgentName.trim(),
-        fakechat_port: json.data?.fakechat_port ?? null,
-        mcp_config: json.data?.mcp_config ?? null,
-        api_key: json.data?.api_key ?? null,
-      });
-      setNewAgentName('');
-      setNewAgentRole('member');
-      setNewAgentScopeMode('projects');
-      setNewAgentProjectIds([]);
-      await refreshOrgAgents();
-    } else {
-      const json = await res.json().catch(() => null) as { error?: { message?: string } } | null;
-      setAgentActionMessage({ type: 'error', text: json?.error?.message ?? t('agentActionFailed') });
-    }
-    setAddingAgent(false);
-  };
-
-  const handleCopyNewAgentMcp = async () => {
-    if (!newAgentResult?.mcp_config) return;
-    try {
-      await navigator.clipboard.writeText(JSON.stringify(newAgentResult.mcp_config, null, 2));
-      setNewAgentMcpCopied(true);
-      setTimeout(() => setNewAgentMcpCopied(false), 2000);
-    } catch { /* noop */ }
   };
 
   const handleToggleAgentActive = async (agent: ProjectMember) => {
@@ -1371,47 +1305,6 @@ export default function SettingsPage() {
                         </Alert>
                       ) : null}
 
-                      {newAgentResult ? (
-                        <div className="rounded-md border border-success-border bg-success-tint p-4 space-y-3">
-                          <div className="flex items-center justify-between">
-                            <p className="text-sm font-semibold text-success">
-                              {newAgentResult.name} 생성 완료
-                            </p>
-                            <button type="button" onClick={() => setNewAgentResult(null)} className="text-muted-foreground hover:text-foreground">
-                              <X className="size-3.5" />
-                            </button>
-                          </div>
-                          {newAgentResult.fakechat_port ? (
-                            <div className="flex items-center gap-2 text-xs">
-                              <Badge variant="info">SSE</Badge>
-                              <span className="font-mono text-foreground">Port: {newAgentResult.fakechat_port}</span>
-                              <span className="text-muted-foreground">— fakechat http://localhost:{newAgentResult.fakechat_port}/sse</span>
-                            </div>
-                          ) : null}
-                          {newAgentResult.api_key ? (
-                            <div className="space-y-1">
-                              <p className="text-xs font-medium text-foreground">API Key — 지금만 표시됩니다.</p>
-                              <code className="block break-all rounded bg-background border border-border p-2 text-xs font-mono text-foreground/80">
-                                {newAgentResult.api_key}
-                              </code>
-                            </div>
-                          ) : null}
-                          {newAgentResult.mcp_config ? (
-                            <div className="space-y-1">
-                              <div className="flex items-center justify-between">
-                                <p className="text-xs font-medium text-foreground">MCP Config (SSE)</p>
-                                <Button variant="glass" size="sm" onClick={() => void handleCopyNewAgentMcp()}>
-                                  {newAgentMcpCopied ? <Check className="size-3" /> : 'Copy'}
-                                </Button>
-                              </div>
-                              <pre className="overflow-x-auto rounded-md border border-border bg-muted/30 p-3 text-xs text-foreground/80">
-                                {JSON.stringify(newAgentResult.mcp_config, null, 2)}
-                              </pre>
-                            </div>
-                          ) : null}
-                        </div>
-                      ) : null}
-
                       {orgAgents.length > 0 ? (
                         <div className="space-y-2">
                           {orgAgents.map((agent) => {
@@ -1460,92 +1353,6 @@ export default function SettingsPage() {
                         </div>
                       )}
 
-                      {/* org-agent S5: scope 인지 생성 폼 — agent-deployment-wizard scope 패턴 미러(신규 토큰 0). */}
-                      <div className="space-y-4">
-                        <div className="space-y-1.5">
-                          <label className="text-xs font-medium text-muted-foreground">{t('agentNameLabel')}</label>
-                          <OperatorInput
-                            value={newAgentName}
-                            onChange={(e) => setNewAgentName(e.target.value)}
-                            placeholder={t('agentNamePlaceholder')}
-                          />
-                        </div>
-
-                        <div className="space-y-1.5">
-                          <label className="text-xs font-medium text-muted-foreground">{t('agentRoleLabel')}</label>
-                          <OperatorDropdownSelect
-                            value={newAgentRole}
-                            onValueChange={(v) => setNewAgentRole(v as 'member' | 'admin')}
-                            options={[
-                              { value: 'member', label: t('agentRoleMember') },
-                              { value: 'admin', label: t('agentRoleAdmin') },
-                            ]}
-                          />
-                        </div>
-
-                        <div className="space-y-2">
-                          <label className="text-xs font-medium text-muted-foreground">{t('agentScopeLabel')}</label>
-                          <div className="grid gap-3 md:grid-cols-2">
-                            {(['org', 'projects'] as const).map((mode) => {
-                              const selected = newAgentScopeMode === mode;
-                              return (
-                                <button
-                                  key={mode}
-                                  type="button"
-                                  onClick={() => setNewAgentScopeMode(mode)}
-                                  className={`rounded-md border px-4 py-4 text-left transition ${selected ? 'border-primary/40 bg-primary/10' : 'border-border bg-muted/30 hover:bg-muted'}`}
-                                >
-                                  <div className="flex items-center justify-between gap-3">
-                                    <div>
-                                      <p className="text-sm font-semibold text-foreground">{mode === 'org' ? t('agentScopeAllProjects') : t('agentScopeSpecificProjects')}</p>
-                                      <p className="mt-1 text-sm text-muted-foreground">{mode === 'org' ? t('agentScopeAllProjectsBody') : t('agentScopeSpecificProjectsBody')}</p>
-                                    </div>
-                                    {selected ? <CheckCircle2 className="size-5 shrink-0 text-primary" /> : null}
-                                  </div>
-                                </button>
-                              );
-                            })}
-                          </div>
-
-                          {newAgentScopeMode === 'projects' ? (
-                            <div className="grid max-h-72 gap-3 overflow-y-auto md:grid-cols-2 xl:grid-cols-3">
-                              {projects.map((project) => {
-                                const selected = newAgentProjectIds.includes(project.id);
-                                return (
-                                  <button
-                                    key={project.id}
-                                    type="button"
-                                    onClick={() => toggleNewAgentProject(project.id)}
-                                    className={`rounded-md border px-4 py-4 text-left transition ${selected ? 'border-primary/40 bg-primary/10' : 'border-border bg-muted/30 hover:bg-muted'}`}
-                                  >
-                                    <div className="flex items-center justify-between gap-3">
-                                      <p className="truncate text-sm font-semibold text-foreground">{project.name}</p>
-                                      {selected ? <CheckCircle2 className="size-5 shrink-0 text-primary" /> : null}
-                                    </div>
-                                  </button>
-                                );
-                              })}
-                            </div>
-                          ) : (
-                            <div className="rounded-md border border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
-                              {t('agentScopeAllProjectsHint', { count: projects.length })}
-                            </div>
-                          )}
-                        </div>
-
-                        <p className="text-xs text-muted-foreground">{t('agentSeatCaption')}</p>
-
-                        <div className="flex justify-end">
-                          <Button
-                            variant="hero"
-                            size="lg"
-                            onClick={() => void handleAddAgent()}
-                            disabled={!newAgentName.trim() || (newAgentScopeMode === 'projects' && newAgentProjectIds.length === 0) || addingAgent}
-                          >
-                            {addingAgent ? '...' : t('addAgent')}
-                          </Button>
-                        </div>
-                      </div>
                     </SectionCardBody>
                   </SectionCard>
                 </div>

--- a/apps/web/src/components/settings/add-agent-form.tsx
+++ b/apps/web/src/components/settings/add-agent-form.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Check, CheckCircle2 } from 'lucide-react';
+import { OperatorInput } from '@/components/ui/operator-control';
+import { OperatorDropdownSelect } from '@/components/ui/operator-dropdown-select';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+interface NewAgentResult {
+  name: string;
+  fakechat_port: number | null;
+  mcp_config: Record<string, unknown> | null;
+  api_key: string | null;
+}
+
+interface AddAgentFormProps {
+  projects: { id: string; name: string }[];
+  /** 생성 성공 시 — 부모 agents 목록 갱신/토스트. */
+  onCreated?: () => void;
+  /** 결과 phase '완료' — 모달 닫기 등. */
+  onDone?: () => void;
+}
+
+/**
+ * 0c1a81b6 — 에이전트 추가 v2 단일 진입(모달 임베드). 2-phase: 입력(name·role·scope) → 결과(API 키·MCP).
+ * org-agent S5 scope 인지 생성(`/api/agents`). settings 인라인 폼서 추출(경로 통일).
+ */
+export function AddAgentForm({ projects, onCreated, onDone }: AddAgentFormProps) {
+  const t = useTranslations('settings');
+  const [name, setName] = useState('');
+  const [role, setRole] = useState<'member' | 'admin'>('member');
+  const [scopeMode, setScopeMode] = useState<'org' | 'projects'>('projects');
+  const [projectIds, setProjectIds] = useState<string[]>([]);
+  const [adding, setAdding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<NewAgentResult | null>(null);
+  const [mcpCopied, setMcpCopied] = useState(false);
+
+  const toggleProject = (id: string) =>
+    setProjectIds((prev) => (prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id]));
+
+  const handleAdd = async () => {
+    if (!name.trim()) return;
+    if (scopeMode === 'projects' && projectIds.length === 0) return;
+    setAdding(true);
+    setError(null);
+    try {
+      // org-agent S5: org-level scope 생성(/api/agents). org_id·인가는 BE verified context.
+      // scope_mode='org'면 project_ids 무시.
+      const res = await fetch('/api/agents', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: name.trim(),
+          role,
+          scope_mode: scopeMode,
+          project_ids: scopeMode === 'projects' ? projectIds : [],
+        }),
+      });
+      if (res.ok) {
+        const json = await res.json() as { data?: { fakechat_port?: number | null; mcp_config?: Record<string, unknown> | null; api_key?: string | null } };
+        setResult({
+          name: name.trim(),
+          fakechat_port: json.data?.fakechat_port ?? null,
+          mcp_config: json.data?.mcp_config ?? null,
+          api_key: json.data?.api_key ?? null,
+        });
+        setName('');
+        setRole('member');
+        setScopeMode('projects');
+        setProjectIds([]);
+        onCreated?.();
+      } else {
+        const json = await res.json().catch(() => null) as { error?: { message?: string } } | null;
+        setError(json?.error?.message ?? t('agentActionFailed'));
+      }
+    } catch {
+      setError(t('agentActionFailed'));
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const handleCopyMcp = async () => {
+    if (!result?.mcp_config) return;
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(result.mcp_config, null, 2));
+      setMcpCopied(true);
+      setTimeout(() => setMcpCopied(false), 2000);
+    } catch {
+      /* noop */
+    }
+  };
+
+  // ── 결과 phase ──
+  if (result) {
+    return (
+      <div className="space-y-4">
+        <div className="space-y-3 rounded-md border border-success-border bg-success-tint p-4">
+          <p className="text-sm font-semibold text-success">{result.name} 생성 완료</p>
+          {result.fakechat_port ? (
+            <div className="flex flex-wrap items-center gap-2 text-xs">
+              <Badge variant="info">SSE</Badge>
+              <span className="font-mono text-foreground">Port: {result.fakechat_port}</span>
+              <span className="text-muted-foreground">— fakechat http://localhost:{result.fakechat_port}/sse</span>
+            </div>
+          ) : null}
+          {result.api_key ? (
+            <div className="space-y-1">
+              <p className="text-xs font-medium text-foreground">API Key — 지금만 표시됩니다.</p>
+              <code className="block break-all rounded border border-border bg-background p-2 font-mono text-xs text-foreground/80">
+                {result.api_key}
+              </code>
+            </div>
+          ) : null}
+          {result.mcp_config ? (
+            <div className="space-y-1">
+              <div className="flex items-center justify-between">
+                <p className="text-xs font-medium text-foreground">MCP Config (SSE)</p>
+                <Button variant="glass" size="sm" onClick={() => void handleCopyMcp()}>
+                  {mcpCopied ? <Check className="size-3" /> : 'Copy'}
+                </Button>
+              </div>
+              <pre className="overflow-x-auto rounded-md border border-border bg-muted/30 p-3 text-xs text-foreground/80">
+                {JSON.stringify(result.mcp_config, null, 2)}
+              </pre>
+            </div>
+          ) : null}
+        </div>
+        <div className="flex justify-end">
+          <Button variant="hero" onClick={() => { setResult(null); onDone?.(); }}>
+            완료
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── 입력 phase ──
+  return (
+    <div className="space-y-4">
+      {error ? (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className="space-y-1.5">
+        <label className="text-xs font-medium text-muted-foreground">{t('agentNameLabel')}</label>
+        <OperatorInput value={name} onChange={(e) => setName(e.target.value)} placeholder={t('agentNamePlaceholder')} />
+      </div>
+
+      <div className="space-y-1.5">
+        <label className="text-xs font-medium text-muted-foreground">{t('agentRoleLabel')}</label>
+        <OperatorDropdownSelect
+          value={role}
+          onValueChange={(v) => setRole(v as 'member' | 'admin')}
+          options={[
+            { value: 'member', label: t('agentRoleMember') },
+            { value: 'admin', label: t('agentRoleAdmin') },
+          ]}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-xs font-medium text-muted-foreground">{t('agentScopeLabel')}</label>
+        <div className="grid gap-3 md:grid-cols-2">
+          {(['org', 'projects'] as const).map((mode) => {
+            const selected = scopeMode === mode;
+            return (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => setScopeMode(mode)}
+                className={`rounded-md border px-4 py-4 text-left transition ${selected ? 'border-primary/40 bg-primary/10' : 'border-border bg-muted/30 hover:bg-muted'}`}
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-foreground">{mode === 'org' ? t('agentScopeAllProjects') : t('agentScopeSpecificProjects')}</p>
+                    <p className="mt-1 text-sm text-muted-foreground">{mode === 'org' ? t('agentScopeAllProjectsBody') : t('agentScopeSpecificProjectsBody')}</p>
+                  </div>
+                  {selected ? <CheckCircle2 className="size-5 shrink-0 text-primary" /> : null}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        {scopeMode === 'projects' ? (
+          <div className="grid max-h-72 gap-3 overflow-y-auto md:grid-cols-2 xl:grid-cols-3">
+            {projects.map((project) => {
+              const selected = projectIds.includes(project.id);
+              return (
+                <button
+                  key={project.id}
+                  type="button"
+                  onClick={() => toggleProject(project.id)}
+                  className={`rounded-md border px-4 py-4 text-left transition ${selected ? 'border-primary/40 bg-primary/10' : 'border-border bg-muted/30 hover:bg-muted'}`}
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="truncate text-sm font-semibold text-foreground">{project.name}</p>
+                    {selected ? <CheckCircle2 className="size-5 shrink-0 text-primary" /> : null}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="rounded-md border border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
+            {t('agentScopeAllProjectsHint', { count: projects.length })}
+          </div>
+        )}
+      </div>
+
+      <p className="text-xs text-muted-foreground">{t('agentSeatCaption')}</p>
+
+      <div className="flex justify-end">
+        <Button
+          variant="hero"
+          size="lg"
+          onClick={() => void handleAdd()}
+          disabled={!name.trim() || (scopeMode === 'projects' && projectIds.length === 0) || adding}
+        >
+          {adding ? '...' : t('addAgent')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/add-member-modal.tsx
+++ b/apps/web/src/components/settings/add-member-modal.tsx
@@ -6,6 +6,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '
 import { OperatorInput } from '@/components/ui/operator-control';
 import { OperatorDropdownSelect } from '@/components/ui/operator-dropdown-select';
 import { Button } from '@/components/ui/button';
+import { AddAgentForm } from './add-agent-form';
 import { cn } from '@/lib/utils';
 
 type MemberType = 'human' | 'agent';
@@ -34,14 +35,12 @@ export function AddMemberModal({ open, onClose, orgId, projects, defaultType = '
   const [email, setEmail] = useState('');
   const [role, setRole] = useState<'admin' | 'member'>('member');
   const [projectIds, setProjectIds] = useState<string[]>([]);
-  // 에이전트(team-members)
-  const [agentName, setAgentName] = useState('');
-  const [agentProjectId, setAgentProjectId] = useState('');
+  // 에이전트(v2)는 <AddAgentForm>가 자체 state/submit/결과 phase 호스팅 — 모달은 human invite만 다룬다.
 
   const reset = () => {
     setType(defaultType);
     setEmail(''); setRole('member'); setProjectIds([]);
-    setAgentName(''); setAgentProjectId(''); setError(null);
+    setError(null);
   };
   const close = () => { reset(); onClose(); };
 
@@ -51,41 +50,30 @@ export function AddMemberModal({ open, onClose, orgId, projects, defaultType = '
     if (!open) return;
     setType(defaultType);
     setEmail(''); setRole('member'); setProjectIds([]);
-    setAgentName(''); setAgentProjectId(''); setError(null);
+    setError(null);
   }, [open, defaultType]);
   const toggleProject = (id: string) =>
     setProjectIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
 
-  const submit = async () => {
+  // human invite 전용(agent는 AddAgentForm가 처리). orgId null 가드 — /organizations/null/invites 차단.
+  const submitHuman = async () => {
     if (submitting) return;
+    if (!orgId) { setError(t('addMemberInviteError')); return; }
+    if (!email.trim()) { setError(t('inviteEmailRequired')); return; }
     setSubmitting(true);
     setError(null);
     try {
-      if (type === 'human') {
-        if (!email.trim()) { setError(t('inviteEmailRequired')); return; }
-        const res = await fetch(`/api/organizations/${orgId}/invites`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ email: email.trim(), role, project_ids: projectIds }),
-        });
-        const json = (await res.json().catch(() => ({}))) as { error?: { message?: string } };
-        if (!res.ok) { setError(json.error?.message ?? t('addMemberInviteError')); return; }
-        onAdded('human', t('addMemberInviteSuccess'));
-        close();
-      } else {
-        if (!agentName.trim() || !agentProjectId) { setError(t('addMemberAgentRequired')); return; }
-        const res = await fetch('/api/team-members', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ org_id: orgId, project_id: agentProjectId, name: agentName.trim(), type: 'agent', role: 'member' }),
-        });
-        const json = (await res.json().catch(() => ({}))) as { error?: { message?: string } };
-        if (!res.ok) { setError(json.error?.message ?? t('addMemberAgentError')); return; }
-        onAdded('agent', t('addMemberAgentSuccess'));
-        close();
-      }
+      const res = await fetch(`/api/organizations/${orgId}/invites`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: email.trim(), role, project_ids: projectIds }),
+      });
+      const json = (await res.json().catch(() => ({}))) as { error?: { message?: string } };
+      if (!res.ok) { setError(json.error?.message ?? t('addMemberInviteError')); return; }
+      onAdded('human', t('addMemberInviteSuccess'));
+      close();
     } catch {
-      setError(t(type === 'human' ? 'addMemberInviteError' : 'addMemberAgentError'));
+      setError(t('addMemberInviteError'));
     } finally {
       setSubmitting(false);
     }
@@ -172,31 +160,23 @@ export function AddMemberModal({ open, onClose, orgId, projects, defaultType = '
             </div>
           </div>
         ) : (
-          <div className="space-y-3">
-            <OperatorInput
-              value={agentName}
-              onChange={(e) => setAgentName(e.target.value)}
-              placeholder={t('agentNamePlaceholder')}
-            />
-            <OperatorDropdownSelect
-              value={agentProjectId}
-              onValueChange={(v) => setAgentProjectId(v)}
-              options={[
-                { value: '', label: t('selectProject') },
-                ...projects.map((p) => ({ value: p.id, label: p.name })),
-              ]}
-            />
-          </div>
+          <AddAgentForm
+            projects={projects}
+            onCreated={() => onAdded('agent', t('addMemberAgentSuccess'))}
+            onDone={close}
+          />
         )}
 
-        {error ? <p className="text-xs text-destructive">{error}</p> : null}
+        {type === 'human' && error ? <p className="text-xs text-destructive">{error}</p> : null}
 
-        <DialogFooter>
-          <Button variant="ghost" onClick={close} disabled={submitting}>{tc('cancel')}</Button>
-          <Button variant="hero" onClick={() => void submit()} disabled={submitting}>
-            {submitting ? '...' : t('addMember')}
-          </Button>
-        </DialogFooter>
+        {type === 'human' ? (
+          <DialogFooter>
+            <Button variant="ghost" onClick={close} disabled={submitting}>{tc('cancel')}</Button>
+            <Button variant="hero" onClick={() => void submitHuman()} disabled={submitting || !orgId}>
+              {submitting ? '...' : t('addMember')}
+            </Button>
+          </DialogFooter>
+        ) : null}
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## 배경
에이전트 추가가 **2경로**로 갈려 있었다: ① settings 인라인 폼(v2·scope 인지·`/api/agents`) ② "+멤버 추가" 모달 agent 분기(v1·`/api/team-members`·role 강제 member). 7363ec8a 의도(단일 진입)를 완성 — **모달 단일 진입**으로 통일. FE-only · BE 무변경.

스토리 `0c1a81b6` · 유나 핸드오프 · PO nod (conv 1b97a627).

## 변경
- **신규 `add-agent-form.tsx`**: settings 인라인 v2 플로우 추출 — **2-phase**(입력 `name`·`role[member/admin]`·`scope[org/projects + 프로젝트 picker]` → 결과 `API 키`·`MCP config`·copy). props `{ projects, onCreated?, onDone? }`. `POST /api/agents`(org-level scope·BE verified context).
- **`add-member-modal.tsx`**: v1 agent 분기(`POST /api/team-members`·role 강제) **폐기** → `<AddAgentForm>` 임베드(모달이 2-step 호스팅·결과 phase서 키/MCP). human 분기 유지. footer/error = **human-only**(agent는 AddAgentForm 자체 버튼). ⭐ **orgId null 가드**(human submit 비활성 + early-return → `/organizations/null/invites` 차단).
- **`settings/page.tsx`**: 인라인 폼 + result 블록 + `handleAddAgent`/`handleCopyNewAgentMcp`/`toggleNewAgentProject` + `newAgent*` 상태 + `NewAgentResult` 타입 + 미사용 import(`Check`/`CheckCircle2`/`OperatorDropdownSelect`) 제거. **agent LIST·toggle·`agentActionMessage` 유지**. agents subtab 갱신 = 모달 `onAdded`(기존·단일 진입).

## 안전
- ⚠️ `agent-api-keys-section.tsx`의 동명 `handleAddAgent`는 **별개·무변경**.
- 신규 토큰 0 · 양테마 자동.

## 검증
- type-check 0 · lint 0(내 신규 warning·잔여는 pre-existing invite\*/MemberRow) · build ✓.
- ⚠️ dev 픽셀(유나): 모달 agent 추가서 scope/role 선택 + 키/MCP 결과 노출 · 인라인 폼 사라짐 · orgId null 가드 · human|agent 토글 동일 진입.

## Base
`develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)