### PR TITLE
[SID:48f064e5] doc 결재 → 인앱 Gate inbox 와이어 (E-DG·HIGH·선생님-facing)

### DIFF
--- a/backend/app/models/doc.py
+++ b/backend/app/models/doc.py
@@ -10,10 +10,16 @@ from app.core.database import Base
 from app.models.base import OrgScopedMixin, SoftDeleteMixin, TimestampMixin
 
 # E-DG S22: doc decision lifecycle(doc-specific·work status 아님). hypothesis _VALID_TRANSITIONS 패턴 미러.
-DOC_STATUSES = frozenset({"draft", "confirmed", "denied", "superseded", "deprecated"})
-# 합법 (from, to) 전이. confirmed/denied→draft 외 역전이 금지. ⭐draft→confirmed 만 line overlay-gated.
+# E-DG doc-gate(48f064e5): draft→pending(상신·Gate inbox 노출)→confirmed/denied(gate 해소). pending=
+# 결재 대기(인앱 Gate). FE 계약(doc decision lifecycle: draft|pending|confirmed|denied)과 정합.
+DOC_STATUSES = frozenset({"draft", "pending", "confirmed", "denied", "superseded", "deprecated"})
+# 합법 (from, to) 전이. confirmed/denied→draft 외 역전이 금지.
 _DOC_VALID_TRANSITIONS: set[tuple[str, str]] = {
-    ("draft", "confirmed"),       # 승인(human-gate overlay 대상)
+    ("draft", "pending"),         # 상신(결재 요청·doc-gate 생성·Gate inbox 노출)
+    ("pending", "confirmed"),     # 승인(gate approve·human·via_gate)
+    ("pending", "denied"),        # 반려(gate reject·via_gate)
+    ("pending", "draft"),         # 상신 취소(작성자 회수)
+    ("draft", "confirmed"),       # 레거시 직접 승인(non-gated·line overlay 대상)
     ("draft", "denied"),          # 반려
     ("denied", "draft"),          # 재작성(revise·S28 토대)
     ("confirmed", "superseded"),  # 신버전 대체

--- a/backend/app/services/doc.py
+++ b/backend/app/services/doc.py
@@ -14,6 +14,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.doc import Doc, DOC_STATUSES, DocRevision, is_valid_doc_transition
 from app.services.member_resolver import ResolvedMember
 
+# E-DG doc-gate(48f064e5): doc 결재 인앱 게이트. work_item_type='doc'·gate_type='doc_approval'.
+DOC_GATE_WORK_ITEM_TYPE = "doc"
+DOC_GATE_TYPE = "doc_approval"
+
 
 class DocTransitionError(Exception):
     """도메인 오류 — 라우터가 code/message 를 HTTPException 으로 매핑."""
@@ -46,6 +50,26 @@ async def transition_doc(
         raise DocTransitionError(
             "INVALID_DOC_TRANSITION", f"불법 전이: {doc.status} → {to_status}"
         )
+
+    # E-DG doc-gate(48f064e5): 상신 draft→pending → 인앱 doc-gate 생성(work_item_type='doc'·pending)
+    # → Gate inbox(/api/gates?status=pending) 노출. doc.status='pending'(결재 대기). create_gate 멱등
+    # (재상신=기존 gate 반환·중복 0). 결재(승인/반려)는 gate 해소가 _resolve_doc_gate 로 수행.
+    if to_status == "pending" and doc.status == "draft":
+        from app.services.gate_service import create_gate
+        from app.services.workflow_line_config import _default_role_id
+        role_id = await _default_role_id(session, org_id) or doc.id  # 기본 결재 role(부재 시 placeholder)
+        await create_gate(
+            session, org_id, doc.id, DOC_GATE_WORK_ITEM_TYPE, DOC_GATE_TYPE,
+            caller.id, role_id,
+            neutral_facts={"requested_by_member_id": str(caller.id), "doc_title": doc.title},
+        )
+        doc.status = "pending"
+        await session.flush()
+        return doc
+
+    # 결재 대기(pending) 문서의 승인/반려는 **gate 해소(via_gate)로만** — 직접 API self-confirm 차단.
+    if doc.status == "pending" and to_status in ("confirmed", "denied") and not via_gate:
+        raise DocTransitionError("GATE_REQUIRED", "결재 대기 문서는 Gate 승인/반려로만 전이됩니다.")
 
     # ⭐E-DG S22: draft→confirmed line overlay. enforcing 라인이면 human-gate 생성·draft 유지(가시
     # confirm 대기). default-off/plain/엔진실패 → 아래 inline human-only 폴백(byte-동일·agent 차단 유지·

--- a/backend/app/services/doc.py
+++ b/backend/app/services/doc.py
@@ -58,11 +58,20 @@ async def transition_doc(
         from app.services.gate_service import create_gate
         from app.services.workflow_line_config import _default_role_id
         role_id = await _default_role_id(session, org_id) or doc.id  # 기본 결재 role(부재 시 placeholder)
-        await create_gate(
+        gate = await create_gate(
             session, org_id, doc.id, DOC_GATE_WORK_ITEM_TYPE, DOC_GATE_TYPE,
             caller.id, role_id,
             neutral_facts={"requested_by_member_id": str(caller.id), "doc_title": doc.title},
         )
+        # ⚠️재상신 RC(산티아고): uq(work_item_id,gate_type)=1 gate·terminal(approved/rejected)=immutable →
+        # create_gate 멱등이 기존 **terminal gate 를 반환**해(상태필터 없음) 재상신 시 새 pending gate 0 →
+        # Gate inbox 미노출+결재 불능. 재상신=새 결재 사이클이므로 terminal gate 를 pending 으로 **re-open**
+        # (직접 reset — FSM 전이 아님·해소 메타 clear). pending/held(admin hold)면 그대로 둔다.
+        if gate.status in ("approved", "rejected", "auto_passed", "voided"):
+            gate.status = "pending"
+            gate.resolver_id = None
+            gate.resolved_at = None
+            gate.resolution_note = None
         doc.status = "pending"
         await session.flush()
         return doc

--- a/backend/app/services/doc.py
+++ b/backend/app/services/doc.py
@@ -68,6 +68,18 @@ async def transition_doc(
         # Gate inbox 미노출+결재 불능. 재상신=새 결재 사이클이므로 terminal gate 를 pending 으로 **re-open**
         # (직접 reset — FSM 전이 아님·해소 메타 clear). pending/held(admin hold)면 그대로 둔다.
         if gate.status in ("approved", "rejected", "auto_passed", "voided"):
+            # 감사추적 보존(산티아고 audit): clear 전에 이전 결재(누가/언제/왜)를 neutral_facts.
+            # decision_history 에 append(append-only·재상신 사이클별 1건) → 반려 이력 손실 0. 그 후 current
+            # 해소필드 clear(새 결재 사이클). JSONB 는 in-place mutation 미감지라 새 dict 재할당.
+            _prior = {
+                "status": gate.status,
+                "resolver_id": str(gate.resolver_id) if gate.resolver_id else None,
+                "resolved_at": gate.resolved_at.isoformat() if gate.resolved_at else None,
+                "resolution_note": gate.resolution_note,
+            }
+            _facts = dict(gate.neutral_facts or {})
+            _facts["decision_history"] = [*_facts.get("decision_history", []), _prior]
+            gate.neutral_facts = _facts
             gate.status = "pending"
             gate.resolver_id = None
             gate.resolved_at = None

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -309,7 +309,14 @@ async def _resolve_doc_gate(session: AsyncSession, gate: Gate, new_status: str) 
         return
     from app.models.doc import Doc
 
-    doc = await session.get(Doc, gate.work_item_id)
+    # 방어심층(산티아고): PK get 대신 org_id + soft-delete 가드(타org/삭제 doc 무영향).
+    doc = (await session.execute(
+        select(Doc).where(
+            Doc.id == gate.work_item_id,
+            Doc.org_id == gate.org_id,
+            Doc.deleted_at.is_(None),
+        )
+    )).scalar_one_or_none()
     if doc is None or doc.status != "pending":
         return  # 멱등·pending 아니면 no-op(double-resolve/취소 방어).
     doc.status = "confirmed" if new_status == "approved" else "denied"

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -142,6 +142,8 @@ async def transition_gate(
     else:
         # H1-FIX-2: merge 게이트 approve → work item 스토리를 done으로 진행(_preflight 재평가 우회).
         await _advance_story_on_merge_approve(session, gate, new_status)
+        # E-DG doc-gate(48f064e5): doc 결재 게이트 approve→confirmed·reject→denied.
+        await _resolve_doc_gate(session, gate, new_status)
 
     await session.flush()
     await session.refresh(gate)
@@ -292,6 +294,26 @@ async def unhold_gate(
     await session.flush()
     await session.refresh(gate)
     return gate
+
+
+async def _resolve_doc_gate(session: AsyncSession, gate: Gate, new_status: str) -> None:
+    """E-DG doc-gate(48f064e5): doc 결재 게이트 해소 → doc status 전이(merge-approve 의 doc 아날로그).
+
+    approve→confirmed · reject→denied. **pending doc 만**(멱등·非pending no-op·이미 결정/취소면 무시).
+    human-only 결재(AC4)는 게이트 전이 엔드포인트 authz 에서 강제 — 여기는 status 반영만.
+    """
+    from app.services.doc import DOC_GATE_TYPE, DOC_GATE_WORK_ITEM_TYPE
+    if gate.work_item_type != DOC_GATE_WORK_ITEM_TYPE or gate.gate_type != DOC_GATE_TYPE:
+        return
+    if new_status not in ("approved", "rejected"):
+        return
+    from app.models.doc import Doc
+
+    doc = await session.get(Doc, gate.work_item_id)
+    if doc is None or doc.status != "pending":
+        return  # 멱등·pending 아니면 no-op(double-resolve/취소 방어).
+    doc.status = "confirmed" if new_status == "approved" else "denied"
+    await session.flush()
 
 
 async def _advance_story_on_merge_approve(session: AsyncSession, gate: Gate, new_status: str) -> None:

--- a/backend/tests/test_edg_doc_gate_inbox.py
+++ b/backend/tests/test_edg_doc_gate_inbox.py
@@ -48,7 +48,8 @@ async def test_submit_creates_doc_gate_and_pending_status():
     doc = MagicMock(status="draft", id=uuid.uuid4(), title="설계 문서", project_id=uuid.uuid4())
     session = _doc_session(doc)
     role_id = uuid.uuid4()
-    with patch("app.services.gate_service.create_gate", new=AsyncMock()) as mock_cg, \
+    with patch("app.services.gate_service.create_gate",
+               new=AsyncMock(return_value=MagicMock(status="pending"))) as mock_cg, \
          patch("app.services.workflow_line_config._default_role_id",
                new=AsyncMock(return_value=role_id)):
         caller = _human(org)
@@ -64,22 +65,30 @@ async def test_submit_creates_doc_gate_and_pending_status():
 
 def _doc_gate(work_item_id):
     return MagicMock(work_item_type=DOC_GATE_WORK_ITEM_TYPE, gate_type=DOC_GATE_TYPE,
-                     work_item_id=work_item_id)
+                     work_item_id=work_item_id, org_id=uuid.uuid4())
+
+
+def _gate_session(doc):
+    """_resolve_doc_gate 는 select(Doc)(org_id+deleted_at 가드)로 조회 — execute 모킹."""
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = doc
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=result)
+    session.flush = AsyncMock()
+    return session
 
 
 @pytest.mark.anyio
 async def test_gate_approve_confirms_doc():
     doc = MagicMock(status="pending")
-    session = AsyncMock(); session.get = AsyncMock(return_value=doc); session.flush = AsyncMock()
-    await _resolve_doc_gate(session, _doc_gate(uuid.uuid4()), "approved")
+    await _resolve_doc_gate(_gate_session(doc), _doc_gate(uuid.uuid4()), "approved")
     assert doc.status == "confirmed"
 
 
 @pytest.mark.anyio
 async def test_gate_reject_denies_doc():
     doc = MagicMock(status="pending")
-    session = AsyncMock(); session.get = AsyncMock(return_value=doc); session.flush = AsyncMock()
-    await _resolve_doc_gate(session, _doc_gate(uuid.uuid4()), "rejected")
+    await _resolve_doc_gate(_gate_session(doc), _doc_gate(uuid.uuid4()), "rejected")
     assert doc.status == "denied"
 
 
@@ -87,18 +96,38 @@ async def test_gate_reject_denies_doc():
 async def test_gate_resolve_noop_when_not_pending():
     """이미 결정/취소(non-pending) doc → no-op(멱등·double-resolve 방어)."""
     doc = MagicMock(status="confirmed")
-    session = AsyncMock(); session.get = AsyncMock(return_value=doc); session.flush = AsyncMock()
-    await _resolve_doc_gate(session, _doc_gate(uuid.uuid4()), "approved")
+    await _resolve_doc_gate(_gate_session(doc), _doc_gate(uuid.uuid4()), "approved")
     assert doc.status == "confirmed"  # 불변
 
 
 @pytest.mark.anyio
 async def test_gate_resolve_ignores_non_doc_gate():
-    """story/merge 게이트엔 무영향(work_item_type/gate_type 가드)."""
-    session = AsyncMock(); session.get = AsyncMock()
+    """story/merge 게이트엔 무영향(work_item_type/gate_type 가드·doc 조회 0)."""
+    session = AsyncMock(); session.execute = AsyncMock()
     gate = MagicMock(work_item_type="story", gate_type="merge", work_item_id=uuid.uuid4())
     await _resolve_doc_gate(session, gate, "approved")
-    session.get.assert_not_called()
+    session.execute.assert_not_called()
+
+
+# ─── RC(산티아고): 재상신 시 terminal gate re-open(결재 재가능) ──────────────
+
+@pytest.mark.anyio
+async def test_resubmit_reopens_terminal_gate():
+    """draft→pending→reject→denied→draft→재상신: create_gate 멱등이 기존 rejected gate 반환 →
+    pending 으로 re-open(resolver/해소메타 clear) → 결재 재가능(Gate inbox 재노출)."""
+    org = uuid.uuid4()
+    doc = MagicMock(status="draft", id=uuid.uuid4(), title="t", project_id=uuid.uuid4())
+    session = _doc_session(doc)
+    rejected = MagicMock(status="rejected", resolver_id=uuid.uuid4(),
+                         resolved_at=object(), resolution_note="반려사유")
+    with patch("app.services.gate_service.create_gate", new=AsyncMock(return_value=rejected)), \
+         patch("app.services.workflow_line_config._default_role_id",
+               new=AsyncMock(return_value=uuid.uuid4())):
+        await transition_doc(session, org, _human(org), doc.id, "pending")
+    assert rejected.status == "pending"          # re-open
+    assert rejected.resolver_id is None and rejected.resolved_at is None
+    assert rejected.resolution_note is None
+    assert doc.status == "pending"
 
 
 # ─── AC3: pending 직접 self-confirm 차단(gate 해소로만) ───────────────────────

--- a/backend/tests/test_edg_doc_gate_inbox.py
+++ b/backend/tests/test_edg_doc_gate_inbox.py
@@ -6,6 +6,7 @@ confirmed/reject→denied(AC2)·pending status 추가로 422 해소(AC3)·human-
 from __future__ import annotations
 
 import uuid
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -118,8 +119,10 @@ async def test_resubmit_reopens_terminal_gate():
     org = uuid.uuid4()
     doc = MagicMock(status="draft", id=uuid.uuid4(), title="t", project_id=uuid.uuid4())
     session = _doc_session(doc)
-    rejected = MagicMock(status="rejected", resolver_id=uuid.uuid4(),
-                         resolved_at=object(), resolution_note="반려사유")
+    prior_resolver = uuid.uuid4()
+    rejected = MagicMock(status="rejected", resolver_id=prior_resolver,
+                         resolved_at=datetime(2026, 6, 26, tzinfo=timezone.utc),
+                         resolution_note="반려사유", neutral_facts=None)
     with patch("app.services.gate_service.create_gate", new=AsyncMock(return_value=rejected)), \
          patch("app.services.workflow_line_config._default_role_id",
                new=AsyncMock(return_value=uuid.uuid4())):
@@ -128,6 +131,10 @@ async def test_resubmit_reopens_terminal_gate():
     assert rejected.resolver_id is None and rejected.resolved_at is None
     assert rejected.resolution_note is None
     assert doc.status == "pending"
+    # 감사추적 보존(산티아고): 이전 반려(누가/왜)가 decision_history 에 append.
+    hist = rejected.neutral_facts["decision_history"]
+    assert hist[-1]["status"] == "rejected" and hist[-1]["resolution_note"] == "반려사유"
+    assert hist[-1]["resolver_id"] == str(prior_resolver)
 
 
 # ─── AC3: pending 직접 self-confirm 차단(gate 해소로만) ───────────────────────

--- a/backend/tests/test_edg_doc_gate_inbox.py
+++ b/backend/tests/test_edg_doc_gate_inbox.py
@@ -1,0 +1,113 @@
+"""48f064e5: doc 결재 → 인앱 Gate inbox 와이어.
+
+상신(draft→pending)=doc-gate(work_item_type='doc'·pending) 생성→Gate inbox 노출(AC1)·gate approve→
+confirmed/reject→denied(AC2)·pending status 추가로 422 해소(AC3)·human-only 결재=게이트 엔드포인트 authz(AC4).
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.doc import (
+    DOC_GATE_TYPE,
+    DOC_GATE_WORK_ITEM_TYPE,
+    DocTransitionError,
+    transition_doc,
+)
+from app.services.gate_service import _resolve_doc_gate
+from app.services.member_resolver import ResolvedMember
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _human(org):
+    return ResolvedMember(id=uuid.uuid4(), user_id=uuid.uuid4(), name="u", type="human",
+                          role="member", org_id=org)
+
+
+def _doc_session(doc):
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = doc
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=result)
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    return session
+
+
+# ─── AC1: 상신 → doc-gate 생성·Gate inbox ────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_submit_creates_doc_gate_and_pending_status():
+    org = uuid.uuid4()
+    doc = MagicMock(status="draft", id=uuid.uuid4(), title="설계 문서", project_id=uuid.uuid4())
+    session = _doc_session(doc)
+    role_id = uuid.uuid4()
+    with patch("app.services.gate_service.create_gate", new=AsyncMock()) as mock_cg, \
+         patch("app.services.workflow_line_config._default_role_id",
+               new=AsyncMock(return_value=role_id)):
+        caller = _human(org)
+        out = await transition_doc(session, org, caller, doc.id, "pending")
+    assert out.status == "pending"  # 결재 대기
+    # doc-gate(work_item_type='doc'·gate_type='doc_approval') 생성 → /api/gates?status=pending 노출
+    args = mock_cg.await_args.args
+    assert args[2] == doc.id and args[3] == DOC_GATE_WORK_ITEM_TYPE and args[4] == DOC_GATE_TYPE
+    assert args[5] == caller.id  # 상신자 = member_id
+
+
+# ─── AC2: gate 해소 → doc status ─────────────────────────────────────────────
+
+def _doc_gate(work_item_id):
+    return MagicMock(work_item_type=DOC_GATE_WORK_ITEM_TYPE, gate_type=DOC_GATE_TYPE,
+                     work_item_id=work_item_id)
+
+
+@pytest.mark.anyio
+async def test_gate_approve_confirms_doc():
+    doc = MagicMock(status="pending")
+    session = AsyncMock(); session.get = AsyncMock(return_value=doc); session.flush = AsyncMock()
+    await _resolve_doc_gate(session, _doc_gate(uuid.uuid4()), "approved")
+    assert doc.status == "confirmed"
+
+
+@pytest.mark.anyio
+async def test_gate_reject_denies_doc():
+    doc = MagicMock(status="pending")
+    session = AsyncMock(); session.get = AsyncMock(return_value=doc); session.flush = AsyncMock()
+    await _resolve_doc_gate(session, _doc_gate(uuid.uuid4()), "rejected")
+    assert doc.status == "denied"
+
+
+@pytest.mark.anyio
+async def test_gate_resolve_noop_when_not_pending():
+    """이미 결정/취소(non-pending) doc → no-op(멱등·double-resolve 방어)."""
+    doc = MagicMock(status="confirmed")
+    session = AsyncMock(); session.get = AsyncMock(return_value=doc); session.flush = AsyncMock()
+    await _resolve_doc_gate(session, _doc_gate(uuid.uuid4()), "approved")
+    assert doc.status == "confirmed"  # 불변
+
+
+@pytest.mark.anyio
+async def test_gate_resolve_ignores_non_doc_gate():
+    """story/merge 게이트엔 무영향(work_item_type/gate_type 가드)."""
+    session = AsyncMock(); session.get = AsyncMock()
+    gate = MagicMock(work_item_type="story", gate_type="merge", work_item_id=uuid.uuid4())
+    await _resolve_doc_gate(session, gate, "approved")
+    session.get.assert_not_called()
+
+
+# ─── AC3: pending 직접 self-confirm 차단(gate 해소로만) ───────────────────────
+
+@pytest.mark.anyio
+async def test_pending_direct_confirm_blocked_without_gate():
+    org = uuid.uuid4()
+    doc = MagicMock(status="pending", id=uuid.uuid4(), title="t", project_id=uuid.uuid4())
+    session = _doc_session(doc)
+    with pytest.raises(DocTransitionError) as ei:
+        await transition_doc(session, org, _human(org), doc.id, "confirmed")  # via_gate=False
+    assert ei.value.code == "GATE_REQUIRED"

--- a/backend/tests/test_edg_s22_doc_overlay.py
+++ b/backend/tests/test_edg_s22_doc_overlay.py
@@ -21,12 +21,18 @@ def anyio_backend():
 # ── doc FSM(unit·DB 없이) ─────────────────────────────────────────────────────
 def test_doc_fsm_valid_transitions():
     from app.models.doc import DOC_STATUSES, is_valid_doc_transition
-    assert DOC_STATUSES == {"draft", "confirmed", "denied", "superseded", "deprecated"}
+    # 48f064e5: pending(결재 대기·인앱 Gate) 추가.
+    assert DOC_STATUSES == {"draft", "pending", "confirmed", "denied", "superseded", "deprecated"}
     assert is_valid_doc_transition("draft", "confirmed")
+    assert is_valid_doc_transition("draft", "pending")          # 상신(doc-gate)
+    assert is_valid_doc_transition("pending", "confirmed")      # 승인(gate)
+    assert is_valid_doc_transition("pending", "denied")         # 반려(gate)
+    assert is_valid_doc_transition("pending", "draft")          # 상신 취소
     assert is_valid_doc_transition("denied", "draft")          # revise
     assert is_valid_doc_transition("confirmed", "superseded")
     assert not is_valid_doc_transition("confirmed", "draft")   # 역전이 금지
     assert not is_valid_doc_transition("draft", "deprecated")  # 비합법
+    assert not is_valid_doc_transition("pending", "superseded")  # 비합법
 
 
 def test_matrix_doc_eligible_draft_to_confirmed_only():


### PR DESCRIPTION
## 배경 (E-DG 마지막 클로저·선생님-facing)
doc 결재가 인앱 Gate inbox에 미노출(선생님이 Web서 doc 결재 원했으나 이번 실제 못 함). `create_gate` 호출=merge/merge_verdict/parallel-approval/line-config **4곳뿐·doc transition 미와이어**·`DOC_STATUSES`에 `pending` 부재로 FE 상신(draft→pending) **422**.

## fix (FE 계약 정합·doc decision lifecycle: draft|pending|confirmed|denied)
- **AC1·AC3**: `DOC_STATUSES`에 **`pending`** + 전이(draft→pending 상신·pending→confirmed/denied·pending→draft 취소). `transition_doc` draft→pending → **`create_gate(work_item_type='doc'·gate_type='doc_approval'·pending)`** → `/api/gates?status=pending`(Gate inbox·`list_gates` generic) 노출·doc.status='pending'. 멱등(재상신=기존 gate). **422 해소.**
- **AC2**: `_resolve_doc_gate`(merge-approve의 doc 아날로그) — gate **approve→confirmed·reject→denied**. pending doc만(멱등·非pending no-op). `transition_gate` else-분기 배선(line step_run 없는 doc gate).
- **AC4**: human-only 결재 = 게이트 전이 엔드포인트 **기존 authz**(`gates.py:144` `resolved.type != 'human'` → 403).
- pending doc **직접 self-confirm 차단**(via_gate 해소로만·`GATE_REQUIRED`).

## 비고
- **마이그 불요**: docs.status=free Text(0128·CHECK 없음) → 'pending' DB 위반 0(baseline CHECK 점검 완).
- **FE 무변경 예상**: FE는 이미 pending lifecycle + doc-gate read 코딩됨(`doc-gate-section.tsx`·route.ts 재상신=draft→pending). BE 422가 block이었고 BE fix로 unblock.
- 데이터층 generic이라 doc gate 지원·기존 doc/gate 플로우 무회귀.

## 테스트 (TDD)
상신→gate·approve/reject→status·non-pending no-op·non-doc 무영향·self-confirm 차단·FSM 신규 6 + 기존 doc 테스트 갱신. 전체 pytest **2525 passed**(실패 8=환경 DoD).

**AC5(선생님 Web doc 결재 실동작)=머지+배포 후 라이브 확인**(핵심 가치). 까심+산티아고 게이트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)