### PR TITLE
[SID:1732-cleanup] revert: OSS StandupService plan_stories enrich (dead code 회수)

### DIFF
--- a/apps/web/src/services/standup.test.ts
+++ b/apps/web/src/services/standup.test.ts
@@ -57,61 +57,6 @@ describe('StandupService.save', () => {
   });
 });
 
-describe('StandupService.getEntries plan_stories enrich (b47f9b05)', () => {
-  it('resolves plan_story_ids to plan_stories org-scoped, incl. cross-board backlog (no sprint/status filter)', async () => {
-    const storiesFilters: string[] = [];
-    const db = {
-      from(table: string) {
-        if (table === 'standup_entries') {
-          return {
-            select() { return this; },
-            eq() { return this; },
-            order: async () => ({
-              data: [{
-                id: 'e1', org_id: 'org-1', project_id: 'p1', author_id: 'm1', date: '2026-04-10',
-                plan_story_ids: ['s-sprint', 's-backlog'],
-              }],
-              error: null,
-            }),
-          };
-        }
-        if (table === 'stories') {
-          return {
-            select() { return this; },
-            in() { return this; },
-            is(col: string) { storiesFilters.push(`is:${col}`); return this; },
-            eq(col: string) { storiesFilters.push(`eq:${col}`); return this; },
-            then: (resolve: (v: { data: unknown; error: null }) => void) => Promise.resolve({
-              data: [
-                { id: 's-sprint', title: 'In sprint', status: 'in-progress', priority: 'high', project_id: 'p1', sprint_id: 'sp1' },
-                { id: 's-backlog', title: 'Backlog other board', status: 'backlog', priority: 'low', project_id: 'p2', sprint_id: null },
-              ],
-              error: null,
-            }).then(resolve),
-          };
-        }
-        return { select() { return this; }, eq() { return this; }, single: async () => ({ data: null, error: null }) };
-      },
-    } as any;
-
-    const service = new StandupService(db);
-    const entries = await service.getEntries('p1', '2026-04-10');
-
-    expect(entries).toHaveLength(1);
-    // cross-board 백로그(sprint_id null·타 project)도 탈락 없이 포함
-    expect(entries[0].plan_stories).toEqual([
-      { id: 's-sprint', title: 'In sprint', status: 'in-progress', priority: 'high', project_id: 'p1', sprint_id: 'sp1' },
-      { id: 's-backlog', title: 'Backlog other board', status: 'backlog', priority: 'low', project_id: 'p2', sprint_id: null },
-    ]);
-    // 불변식: org_id + deleted_at만, sprint/project/status 필터 없음
-    expect(storiesFilters).toContain('is:deleted_at');
-    expect(storiesFilters).toContain('eq:org_id');
-    expect(storiesFilters).not.toContain('eq:sprint_id');
-    expect(storiesFilters).not.toContain('eq:status');
-    expect(storiesFilters).not.toContain('eq:project_id');
-  });
-});
-
 describe('StandupFeedbackService', () => {
   it('loads feedback by standup date', async () => {
     const db = {

--- a/apps/web/src/services/standup.ts
+++ b/apps/web/src/services/standup.ts
@@ -15,20 +15,6 @@ export interface SaveStandupInput {
   plan_story_ids?: string[];
 }
 
-/**
- * b47f9b05: ee standup GET이 Supabase-direct라 raw plan_story_ids만 내려 FE가 active-sprint scoped
- * stories fallback→백로그(sprint 밖) 탈락. plan_story_ids를 stories org-scope 조회로 resolve해
- * plan_stories(BE #1731 enrich 동형)로 채워 내린다. cross-board(타 프로젝트 백로그) 노출 보장.
- */
-export interface PlanStorySummary {
-  id: string;
-  title: string;
-  status: string;
-  priority: string;
-  project_id: string;
-  sprint_id: string | null;
-}
-
 export interface CreateStandupFeedbackInput {
   project_id: string;
   org_id: string;
@@ -67,9 +53,7 @@ export class StandupService {
       .eq('date', date)
       .order('created_at');
     if (error) throw error;
-    const entries = (data ?? []) as Array<Record<string, unknown>>;
-    const map = await this.resolvePlanStories(entries);
-    return entries.map((e) => this.attachPlanStories(e, map));
+    return data;
   }
 
   async getEntryForUser(projectId: string, authorId: string, date: string) {
@@ -81,53 +65,7 @@ export class StandupService {
       .eq('date', date)
       .single();
     if (error && error.code !== 'PGRST116') throw error;
-    if (!data) return data;
-    const map = await this.resolvePlanStories([data]);
-    return this.attachPlanStories(data, map);
-  }
-
-  /** plan_story_ids → stories org-scope 조회(cross-board)로 PlanStorySummary 맵. admin client에도 org_id 가드. */
-  private async resolvePlanStories(
-    entries: Array<Record<string, unknown>>,
-  ): Promise<Map<string, PlanStorySummary>> {
-    const map = new Map<string, PlanStorySummary>();
-    const ids = [...new Set(entries.flatMap((e) => (e.plan_story_ids as string[] | null) ?? []))];
-    if (ids.length === 0) return map;
-    const orgId = (entries.find((e) => e.org_id)?.org_id as string | undefined) ?? null;
-    // ⭐ 불변식(디디): org_id 스코프 ONLY + deleted_at is null. sprint/project/board/status 필터 금지
-    // — 좁히면 백로그(sprint 밖·타 보드) 다시 탈락(BE _entries_with_plan_stories 동형).
-    let query = this.db
-      .from('stories')
-      .select('id, title, status, priority, project_id, sprint_id')
-      .in('id', ids)
-      .is('deleted_at', null);
-    if (orgId) query = query.eq('org_id', orgId);
-    const { data, error } = await query;
-    if (error) throw error;
-    for (const s of (data ?? []) as Array<Record<string, unknown>>) {
-      map.set(s.id as string, {
-        id: s.id as string,
-        title: s.title as string,
-        status: s.status as string,
-        priority: s.priority as string,
-        project_id: s.project_id as string,
-        sprint_id: (s.sprint_id as string | null) ?? null,
-      });
-    }
-    return map;
-  }
-
-  private attachPlanStories<T extends Record<string, unknown>>(
-    entry: T,
-    map: Map<string, PlanStorySummary>,
-  ): T & { plan_stories: PlanStorySummary[] } {
-    const ids = (entry.plan_story_ids as string[] | null) ?? [];
-    return {
-      ...entry,
-      plan_stories: ids
-        .map((id) => map.get(id))
-        .filter((s): s is PlanStorySummary => Boolean(s)),
-    };
+    return data;
   }
 
   async save(input: SaveStandupInput) {
@@ -187,14 +125,12 @@ export class StandupService {
   async getHistory(projectId: string, limit = 50) {
     const { data, error } = await this.db
       .from('standup_entries')
-      .select('author_id, date, done, plan, blockers, plan_story_ids, org_id')
+      .select('author_id, date, done, plan, blockers')
       .eq('project_id', projectId)
       .order('date', { ascending: false })
       .limit(limit);
     if (error) throw error;
-    const entries = (data ?? []) as Array<Record<string, unknown>>;
-    const map = await this.resolvePlanStories(entries);
-    return entries.map((e) => this.attachPlanStories(e, map));
+    return data;
   }
 }
 


### PR DESCRIPTION
## 배경 (PO 52ab9267 · low · cleanup)
#1732(`5e239693`)에서 `apps/web/src/services/StandupService`에 추가한 `plan_stories` enrich를 **회수**(revert). 멀티계정 빌드 사이 끼우는 trivial cleanup.

## 근거 — dead code 확인
- `StandupService` consumer = `ee/apps/web` 라우트(**unbuilt dead** — ee 빌드 모델 정정으로 확인) + 단위 테스트뿐.
- **라이브 OSS standup = `/api` proxy → FastAPI #1731 enrich**가 실 동작. 즉 이 service-레이어 enrich는 **라이브 미사용**(앞선 #1732 dev 픽셀의 백로그 칩 노출도 실제로는 #1731이 처리).
- → OSS service 레이어의 dead 잔재 제거.

## ⚠️ 불가침
- **#1731(BE FastAPI enrich)은 무변경** — 그게 실 동작 fix. 이 PR은 OSS service dead 잔재만 제거(BE 무영향).

## 변경
`git revert 5e239693` — `PlanStorySummary` interface · `resolvePlanStories`/`attachPlanStories` · getEntries/getEntryForUser/getHistory의 enrich 호출 + getHistory select 추가분(plan_story_ids/org_id)을 **#1732 前(raw plan_story_ids) 상태로 복원**. `standup.test.ts`의 #1732 테스트 제거. (2파일·-123/+4)

## 검증
- type-check 0 · lint 0 · build ✓ · vitest 4/4(원복).
- ⚠️ dev 픽셀(유나): #1731 경로로 plan_stories 백로그 칩 **여전 노출**(이미 라이브 PASS 경로·무회귀 확인).

## Base
`develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)