### PR TITLE
[fix] doc 전이 응답 500 (MissingGreenlet) — commit 後 refresh (48f064e5 fast-follow)

### DIFF
--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -619,6 +619,10 @@ async def transition_doc_endpoint(
     try:
         doc = await transition_doc(session, org_id, caller, id, body.status)
         await session.commit()
+        # 48f064e5 fix: UPDATE 후 commit 으로 server-onupdate 컬럼(updated_at)이 expired → model_validate
+        # 의 동기 컨텍스트서 lazy-load 시 MissingGreenlet(async IO) → 500. refresh 로 async 컨텍스트서
+        # eager 재로드(create_doc=INSERT라 무영향이었음). [[base_repository_refresh]] 패턴.
+        await session.refresh(doc)
         return DocResponse.model_validate(doc)
     except DocTransitionError as e:
         _codes = {

--- a/backend/tests/test_edg_doc_gate_inbox.py
+++ b/backend/tests/test_edg_doc_gate_inbox.py
@@ -147,3 +147,18 @@ async def test_pending_direct_confirm_blocked_without_gate():
     with pytest.raises(DocTransitionError) as ei:
         await transition_doc(session, org, _human(org), doc.id, "confirmed")  # via_gate=False
     assert ei.value.code == "GATE_REQUIRED"
+
+
+# ─── 500 fix: 전이 엔드포인트가 commit 後 refresh (MissingGreenlet 방지) ─────────
+
+def test_transition_endpoint_refreshes_before_serialize():
+    """UPDATE→commit으로 server-onupdate(updated_at) expired → model_validate lazy-load=MissingGreenlet
+    →500. commit→refresh→model_validate 순서로 async 컨텍스트 eager 재로드(라이브 dev 재현됨)."""
+    import inspect
+    from app.routers import docs
+    src = inspect.getsource(docs.transition_doc_endpoint)
+    assert "await session.refresh(doc)" in src
+    i_commit = src.index("await session.commit()")
+    i_refresh = src.index("await session.refresh(doc)")
+    i_validate = src.rindex("DocResponse.model_validate(doc)")
+    assert i_commit < i_refresh < i_validate  # 순서 정합


### PR DESCRIPTION
## 근본 (dev Cloud Run traceback)
`transition_doc` 은 doc 을 **UPDATE** → `session.commit()` 시 **server-onupdate 컬럼(`updated_at`)이 expired** → 엔드포인트 `DocResponse.model_validate(doc)`(동기 pydantic 컨텍스트)가 expired 속성 lazy-load → **async IO 시도 → MissingGreenlet → ValidationError → 500**. commit 은 끝나 **데이터는 영속**(doc-gate Gate inbox 노출이 증거)·응답만 터짐.

traceback: `updated_at / Error extracting attribute: MissingGreenlet ... [type=get_attribute_error, input_type=Doc]`

- create_doc=**INSERT**라 무영향이었음(내 "직접 model_validate 배제"는 오판정·traceback 으로 정정·정직 기록).
- doc-gate(48f064e5)의 **draft→pending 이 전이 성공경로를 처음 라이브 실행**하며 노출 — 기존 draft→confirmed 도 동일 잠재 버그(전이 응답 미사용이라 안 터졌을 뿐).

## fix (1줄급·근본)
commit 後 **`await session.refresh(doc)`**(async 컨텍스트서 updated_at+속성 eager 재로드) 後 model_validate. [[base_repository_refresh]] 패턴(PR #590 동형).

## 테스트
엔드포인트 commit→refresh→model_validate 순서 가드(실 MissingGreenlet 은 PG 필요·라이브 dev 재검으로 확정). 전체 pytest **2527 passed**(실패 8=환경 DoD).

머지→재배포→**plumbing 재검(상신 200 + gate inbox) + 선생님 Web 결재 = AC5 완**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)