### PR TITLE
[doc-gate v2] 항상 manual(auto_pass 제외) + 상신 결재자 알림 (선생님 실 Web AC5 갭 2건)

### DIFF
--- a/backend/app/services/doc.py
+++ b/backend/app/services/doc.py
@@ -34,6 +34,7 @@ async def _notify_doc_approval_requested(
             select(OrgMember.id).where(
                 OrgMember.org_id == org_id,
                 OrgMember.role.in_(("owner", "admin")),
+                OrgMember.deleted_at.is_(None),  # 산티아고 RC: 삭제/탈퇴 owner/admin 제외(정보노출·실결재권자만)
                 OrgMember.id != requester_id,
             )
         )).scalars().all()

--- a/backend/app/services/doc.py
+++ b/backend/app/services/doc.py
@@ -6,6 +6,7 @@ doc 의 native status(0128·doc-specific 값)를 hypothesis 와 동형 패턴으
 """
 from __future__ import annotations
 
+import logging
 import uuid
 
 from sqlalchemy import select
@@ -14,9 +15,39 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.doc import Doc, DOC_STATUSES, DocRevision, is_valid_doc_transition
 from app.services.member_resolver import ResolvedMember
 
+logger = logging.getLogger(__name__)
+
 # E-DG doc-gate(48f064e5): doc 결재 인앱 게이트. work_item_type='doc'·gate_type='doc_approval'.
 DOC_GATE_WORK_ITEM_TYPE = "doc"
 DOC_GATE_TYPE = "doc_approval"
+
+
+async def _notify_doc_approval_requested(
+    session: AsyncSession, org_id: uuid.UUID, doc: Doc, gate_id: uuid.UUID, *, requester_id: uuid.UUID
+) -> None:
+    """doc-gate v2 갭2: doc 상신 → org owner/admin 휴먼 결재자에게 in-app 알림(상신자 본인 제외).
+    best-effort·비중단(알림 실패가 상신을 막지 않음). transition_gate 해소 알림과 대칭."""
+    try:
+        from app.models.project import OrgMember
+        from app.services.notification_dispatch import dispatch_notification
+        approver_ids = (await session.execute(
+            select(OrgMember.id).where(
+                OrgMember.org_id == org_id,
+                OrgMember.role.in_(("owner", "admin")),
+                OrgMember.id != requester_id,
+            )
+        )).scalars().all()
+        if approver_ids:
+            await dispatch_notification(
+                session, org_id=org_id, event_type="doc_approval_requested",
+                target_member_ids=list(approver_ids),
+                title="문서 결재 요청",
+                body=f"'{doc.title}' 문서가 결재 대기 중입니다.",
+                reference_type="gate", reference_id=gate_id,
+                source_project_id=doc.project_id,
+            )
+    except Exception:  # noqa: BLE001 — 알림 실패는 상신 비중단.
+        logger.warning("doc 상신 결재자 알림 실패 doc=%s", doc.id, exc_info=True)
 
 
 class DocTransitionError(Exception):
@@ -86,6 +117,11 @@ async def transition_doc(
             gate.resolution_note = None
         doc.status = "pending"
         await session.flush()
+        # doc-gate v2 갭2(선생님 실 Web): 상신 시 **결재자(org owner/admin 휴먼)에게 알림** — create_gate/
+        # doc transition 은 event/notification 0이라 상신해도 결재자가 모름(transition_gate 해소엔
+        # dispatch_notification 있는데 상신엔 없던 비대칭). best-effort(알림 실패는 상신 비중단·SoD상
+        # 상신자 본인 제외).
+        await _notify_doc_approval_requested(session, org_id, doc, gate.id, requester_id=caller.id)
         return doc
 
     # 결재 대기(pending) 문서의 승인/반려는 **gate 해소(via_gate)로만** — 직접 API self-confirm 차단.

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -47,6 +47,10 @@ _DISPOSITION_TO_STATUS: dict[str, str] = {
     "deny": "rejected",
 }
 
+# doc-gate v2 갭1: deliberate 인간 결재 gate — org allow_auto/deny posture 무관하게 항상 manual(pending).
+# disposition auto-pass/auto-deny 제외(인간 deliberation 이 정책 자동결정보다 우선).
+_ALWAYS_MANUAL_GATE_TYPES: frozenset[str] = frozenset({"doc_approval"})
+
 
 async def create_gate(
     session: AsyncSession,
@@ -74,6 +78,10 @@ async def create_gate(
 
     disposition = await resolve_disposition(session, org_id, member_id, role_id, gate_type)
     status = _DISPOSITION_TO_STATUS.get(disposition, "pending")
+    # doc-gate v2 갭1(선생님 실 Web): doc_approval 류 deliberate gate 는 disposition auto-pass 무관하게
+    # 항상 pending. auto_passed 면 수동 결재가 Gate inbox 에 안 떠 결재 불능(인간 결재 의도 우선).
+    if gate_type in _ALWAYS_MANUAL_GATE_TYPES:
+        status = "pending"
 
     gate = Gate(
         id=uuid.uuid4(),

--- a/backend/tests/test_edg_doc_gate_inbox.py
+++ b/backend/tests/test_edg_doc_gate_inbox.py
@@ -162,3 +162,64 @@ def test_transition_endpoint_refreshes_before_serialize():
     i_refresh = src.index("await session.refresh(doc)")
     i_validate = src.rindex("DocResponse.model_validate(doc)")
     assert i_commit < i_refresh < i_validate  # 순서 정합
+
+
+# ─── doc-gate v2: 갭1 항상 manual(auto_pass 제외) + 갭2 상신 알림 ──────────────
+
+@pytest.mark.anyio
+async def test_doc_approval_always_pending_despite_allow_auto():
+    """갭1: org posture→allow_auto 여도 doc_approval 은 항상 pending(deliberate 인간 결재)."""
+    from app.services.gate_service import create_gate
+    captured = {}
+    session = AsyncMock()
+    session.add = MagicMock(side_effect=lambda g: captured.__setitem__("gate", g))
+    session.flush = AsyncMock(); session.refresh = AsyncMock()
+    no_existing = MagicMock(); no_existing.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=no_existing)
+    with patch("app.services.gate_service.resolve_disposition", new=AsyncMock(return_value="allow_auto")):
+        await create_gate(session, uuid.uuid4(), uuid.uuid4(), "doc", "doc_approval",
+                          uuid.uuid4(), uuid.uuid4())
+    assert captured["gate"].status == "pending"  # allow_auto → 그래도 pending(force)
+
+
+@pytest.mark.anyio
+async def test_non_doc_gate_still_auto_passes():
+    """비-doc 게이트(merge 등)는 기존대로 allow_auto→auto_passed(force 미적용·무회귀)."""
+    from app.services.gate_service import create_gate
+    captured = {}
+    session = AsyncMock()
+    session.add = MagicMock(side_effect=lambda g: captured.__setitem__("gate", g))
+    session.flush = AsyncMock(); session.refresh = AsyncMock()
+    no_existing = MagicMock(); no_existing.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=no_existing)
+    with patch("app.services.gate_service.resolve_disposition", new=AsyncMock(return_value="allow_auto")):
+        await create_gate(session, uuid.uuid4(), uuid.uuid4(), "story", "merge",
+                          uuid.uuid4(), uuid.uuid4())
+    assert captured["gate"].status == "auto_passed"
+
+
+@pytest.mark.anyio
+async def test_submit_notifies_org_approvers():
+    """갭2: 상신 → org owner/admin 휴먼 결재자에게 dispatch_notification(상신자 제외·gate 참조)."""
+    from app.services.doc import _notify_doc_approval_requested
+    org, requester, gate_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    doc = MagicMock(id=uuid.uuid4(), title="설계 문서", project_id=uuid.uuid4())
+    owners = [uuid.uuid4(), uuid.uuid4()]
+    res = MagicMock(); res.scalars.return_value.all.return_value = owners
+    session = AsyncMock(); session.execute = AsyncMock(return_value=res)
+    with patch("app.services.notification_dispatch.dispatch_notification", new=AsyncMock()) as dn:
+        await _notify_doc_approval_requested(session, org, doc, gate_id, requester_id=requester)
+    dn.assert_awaited_once()
+    kw = dn.await_args.kwargs
+    assert kw["target_member_ids"] == owners
+    assert kw["event_type"] == "doc_approval_requested"
+    assert kw["reference_type"] == "gate" and kw["reference_id"] == gate_id
+
+
+@pytest.mark.anyio
+async def test_submit_notify_fail_silent():
+    """알림 실패는 상신 비중단(예외 전파 0)."""
+    from app.services.doc import _notify_doc_approval_requested
+    session = AsyncMock(); session.execute = AsyncMock(side_effect=RuntimeError("boom"))
+    await _notify_doc_approval_requested(session, uuid.uuid4(), MagicMock(id=uuid.uuid4()),
+                                         uuid.uuid4(), requester_id=uuid.uuid4())

--- a/backend/tests/test_edg_doc_gate_inbox.py
+++ b/backend/tests/test_edg_doc_gate_inbox.py
@@ -214,6 +214,8 @@ async def test_submit_notifies_org_approvers():
     assert kw["target_member_ids"] == owners
     assert kw["event_type"] == "doc_approval_requested"
     assert kw["reference_type"] == "gate" and kw["reference_id"] == gate_id
+    # 산티아고 RC: approver 쿼리에 deleted_at 필터(삭제 owner/admin 제외).
+    assert "deleted_at" in str(session.execute.await_args.args[0])
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## 배경 (선생님 실 Web doc 결재 테스트 — AC5 본체 2갭)
plumbing(상신→inbox·#1736/#1738)은 닫혔으나, **선생님 실 Web 결재서 본체 2갭** 발견:

## 갭1 — doc_approval auto_pass (수동 결재 불가)
`create_gate`가 `resolve_disposition`으로 org posture(**allow_auto**)를 doc_approval에도 적용 → gate가 `auto_passed`로 생성 → **수동 결재가 Gate inbox에 안 뜸**(선생님 결재 자체 불능).
- ⚠️ **검증 갭 자인**: 내 plumbing 검증은 agent+placeholder role이라 SYSTEM_DEFAULT(ask)→pending이었고, 선생님 **실 role은 org allow_auto** → auto_pass. **agent-context 검증이 real-human-context를 못 잡았음**(API-only verify 한계).
- **fix**: `_ALWAYS_MANUAL_GATE_TYPES={doc_approval}` — deliberate 인간 결재 gate는 disposition auto-pass **무관하게 항상 pending**(인간 결재 의도 > 정책 자동결정). 비-doc 게이트(merge 등) 무회귀.

## 갭2 — 상신 알림 0 (결재자 모름)
`create_gate`/doc transition이 event/notification **0** → 상신해도 **결재자가 모름**. (`transition_gate` 해소엔 `dispatch_notification` 있는데 **상신엔 비대칭**.)
- **fix**: 상신(draft→pending) 시 **org owner/admin 휴먼 결재자에게 `dispatch_notification`**(event=`doc_approval_requested`·gate 참조·상신자 본인 제외·best-effort 비중단·해소 알림과 대칭).

## 테스트
doc_approval allow_auto→pending · 비-doc auto_passed 무회귀 · 상신 알림 수신자/fail-silent 신규 4. 전체 pytest **2531 passed**(실패 8=환경 DoD).

## 비고
머지+재배포 後 내가 상신 재검(gate **pending** 확정·auto_pass 사라짐) + 선생님 Web 결재 알림 수신 확인 = AC5 완. 알림 수신자(현 owner/admin)는 의도 시 결재선/role 지정으로 확장 가능(PO 콜). 까심+산티아고 게이트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)