### PR TITLE
[SID:bf305fa0] 멀티계정 PR2 — 계정 switcher UI + add-account 플로우

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -34,6 +34,16 @@
     "add": "Add",
     "confirm": "Confirm"
   },
+  "accountSwitcher": {
+    "title": "Accounts",
+    "addAccount": "Add account",
+    "signOutThis": "Sign out this account",
+    "signOutAll": "Sign out all accounts",
+    "switching": "Switching…",
+    "switchFailed": "Failed to switch account. Please try again.",
+    "reloginRequired": "Re-login required",
+    "capReached": "Account limit reached"
+  },
   "nav": {
     "dashboard": "Dashboard",
     "sprintManagement": "Sprint Management",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -34,6 +34,16 @@
     "add": "추가",
     "confirm": "확인"
   },
+  "accountSwitcher": {
+    "title": "계정",
+    "addAccount": "계정 추가",
+    "signOutThis": "이 계정 로그아웃",
+    "signOutAll": "모든 계정 로그아웃",
+    "switching": "전환 중…",
+    "switchFailed": "계정 전환에 실패했습니다. 다시 시도해 주세요.",
+    "reloginRequired": "재로그인 필요",
+    "capReached": "계정 한도에 도달했습니다"
+  },
   "nav": {
     "dashboard": "대시보드",
     "sprintManagement": "스프린트 관리",

--- a/apps/web/src/app/api/auth/add-account/route.ts
+++ b/apps/web/src/app/api/auth/add-account/route.ts
@@ -1,11 +1,15 @@
 import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { verifyCsrfOrigin } from '@/lib/auth/csrf';
-import { SP_RT_COOKIE } from '@/lib/db/server';
+import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { cookieBase } from '@/lib/auth/cookies';
 import { handleApiError } from '@/lib/api-error';
+import { ACCOUNT_CAP } from '@/lib/auth/account-limits';
 import {
   ACTIVE_ACCOUNT_COOKIE,
+  auditVault,
+  discardActiveSession,
+  discardCookies,
   getVerifiedActiveAccountId,
   setVaultEntry,
 } from '@/lib/auth/account-vault';
@@ -22,15 +26,41 @@ export async function POST(request: Request) {
     if (csrf) return csrf;
 
     const store = await cookies();
-    const res = NextResponse.json({ data: { ok: true, redirect: '/login' } });
-
-    const currentId = await getVerifiedActiveAccountId();
+    const at = store.get(SP_AT_COOKIE)?.value;
     const currentRt = store.get(SP_RT_COOKIE)?.value;
+    const currentId = await getVerifiedActiveAccountId();
+    const { valid: vault, staleNames } = await auditVault();
+
+    // RC1: active 세션이 corrupt(sp_at.sub != sp_rt.sub / 포인터 mismatch)면 폐기 + 401 거부
+    // (corrupt RT를 vault에 넣지 않음·PR1 accounts/switch 동일 배선).
+    if (at && currentRt && !currentId) {
+      const corrupt = NextResponse.json(
+        { error: { code: 'ACTIVE_SESSION_CORRUPT', message: 'active session integrity check failed' } },
+        { status: 401 },
+      );
+      discardActiveSession(corrupt.cookies);
+      discardCookies(corrupt.cookies, staleNames);
+      return corrupt;
+    }
+
+    // 5-cap server guard — UI 비활성만으로는 클라 우회 POST 가능. 서버서 한도 enforce.
+    const total = vault.length + (currentId ? 1 : 0);
+    if (total >= ACCOUNT_CAP) {
+      const capped = NextResponse.json(
+        { error: { code: 'ACCOUNT_LIMIT_REACHED', message: 'account limit reached' } },
+        { status: 409 },
+      );
+      discardCookies(capped.cookies, staleNames);
+      return capped;
+    }
+
+    const res = NextResponse.json({ data: { ok: true, redirect: '/login' } });
     if (currentId && currentRt) {
       setVaultEntry(res.cookies, currentId, currentRt);
       // active 포인터 제거 — 로그인 後 새 sp_at.sub 가 active(stale 포인터 mismatch 방지).
       res.cookies.set(ACTIVE_ACCOUNT_COOKIE, '', { ...cookieBase(), maxAge: 0 });
     }
+    discardCookies(res.cookies, staleNames); // RC1: stale vault 폐기
     return res;
   } catch (err: unknown) {
     return handleApiError(err);

--- a/apps/web/src/app/api/auth/add-account/route.ts
+++ b/apps/web/src/app/api/auth/add-account/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { verifyCsrfOrigin } from '@/lib/auth/csrf';
+import { SP_RT_COOKIE } from '@/lib/db/server';
+import { cookieBase } from '@/lib/auth/cookies';
+import { handleApiError } from '@/lib/api-error';
+import {
+  ACTIVE_ACCOUNT_COOKIE,
+  getVerifiedActiveAccountId,
+  setVaultEntry,
+} from '@/lib/auth/account-vault';
+
+/**
+ * POST /api/auth/add-account (ⓒ) — 계정 추가 진입.
+ * 현 active 계정 RT를 vault에 보존하고 active 포인터를 비운 뒤 클라가 로그인 플로우로 진입한다.
+ * 로그인 완료 시 새 계정이 active(sp_at/sp_rt)·이전 계정은 vault에 남아 switcher에 노출.
+ * (active 포인터 제거 → 로그인 後 sp_at.sub 로 active 도출·stale 포인터 mismatch 방지.)
+ */
+export async function POST(request: Request) {
+  try {
+    const csrf = verifyCsrfOrigin(request);
+    if (csrf) return csrf;
+
+    const store = await cookies();
+    const res = NextResponse.json({ data: { ok: true, redirect: '/login' } });
+
+    const currentId = await getVerifiedActiveAccountId();
+    const currentRt = store.get(SP_RT_COOKIE)?.value;
+    if (currentId && currentRt) {
+      setVaultEntry(res.cookies, currentId, currentRt);
+      // active 포인터 제거 — 로그인 後 새 sp_at.sub 가 active(stale 포인터 mismatch 방지).
+      res.cookies.set(ACTIVE_ACCOUNT_COOKIE, '', { ...cookieBase(), maxAge: 0 });
+    }
+    return res;
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/components/nav/profile-menu.tsx
+++ b/apps/web/src/components/nav/profile-menu.tsx
@@ -1,10 +1,11 @@
 'use client';
 
+import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { ChevronsUpDown, Settings, LogOut } from 'lucide-react';
-import { logoutUser } from '@/lib/db/client';
+import { useCallback, useState } from 'react';
+import { ChevronsUpDown, Settings, LogOut, Plus, Check, Loader2 } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -14,6 +15,16 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
+
+interface Account {
+  account_id: string;
+  name: string | null;
+  email: string | null;
+  org_name: string | null;
+  avatar_url: string | null;
+  status: 'active' | 'inactive' | 'expired';
+}
 
 interface ProfileMenuProps {
   name: string;
@@ -21,52 +32,196 @@ interface ProfileMenuProps {
   avatarUrl?: string | null;
 }
 
-function getInitial(name: string): string {
-  if (!name) return '?';
-  return name[0]?.toUpperCase() ?? '?';
+// tier 한도(Free 2 / Paid 5·PO 검토 中) — 한도 도달 시 계정 추가 비활성. 기본 5.
+const ACCOUNT_CAP = 5;
+
+function initialOf(label: string | null | undefined): string {
+  const s = (label ?? '').trim();
+  return s ? s[0]!.toUpperCase() : '?';
 }
 
-export function ProfileMenu({ name, email }: ProfileMenuProps) {
-  const router = useRouter();
-  const t = useTranslations('common');
-  const displayLabel = email ?? name;
+function Avatar({ url, label, className }: { url?: string | null; label: string; className?: string }) {
+  if (url) {
+    return (
+      <Image
+        src={url}
+        alt=""
+        width={28}
+        height={28}
+        unoptimized
+        className={cn('shrink-0 rounded-md object-cover', className)}
+      />
+    );
+  }
+  return (
+    <span
+      className={cn(
+        'flex shrink-0 items-center justify-center rounded-md bg-sidebar-accent text-xs font-semibold text-sidebar-accent-foreground',
+        className,
+      )}
+    >
+      {initialOf(label)}
+    </span>
+  );
+}
 
-  const handleLogout = async () => {
-    await logoutUser();
-    router.push('/login');
-    router.refresh();
+export function ProfileMenu({ name, avatarUrl }: ProfileMenuProps) {
+  const router = useRouter();
+  const t = useTranslations('accountSwitcher');
+  const tc = useTranslations('common');
+  const tn = useTranslations('nav');
+
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [busy, setBusy] = useState<string | null>(null); // account_id | 'add' | 'signout'
+  const [error, setError] = useState<string | null>(null);
+
+  // 드롭다운 열 때 fetch(이벤트 기반 — effect 내 setState 회피·불필요한 상시 호출 방지).
+  const load = useCallback(async () => {
+    try {
+      const r = await fetch('/api/accounts');
+      if (!r.ok) return;
+      const j = (await r.json()) as { data?: { accounts?: Account[] }; accounts?: Account[] };
+      setAccounts(j.data?.accounts ?? j.accounts ?? []);
+    } catch {
+      /* prop fallback 유지 */
+    }
+  }, []);
+
+  const active = accounts.find((a) => a.status === 'active');
+  const others = accounts.filter((a) => a.status !== 'active');
+  const ordered = active ? [active, ...others] : others;
+  const triggerName = active?.name ?? active?.email ?? name;
+  const triggerAvatar = active?.avatar_url ?? avatarUrl ?? null;
+  const atCap = accounts.length >= ACCOUNT_CAP;
+
+  const handleSwitch = async (acc: Account) => {
+    if (busy || acc.status === 'active') return;
+    if (acc.status === 'expired') {
+      window.location.assign('/login'); // 만료 = switch 불가 → 로그인 재진입
+      return;
+    }
+    setBusy(acc.account_id);
+    setError(null);
+    try {
+      const r = await fetch('/api/auth/switch-account', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ account_id: acc.account_id }),
+      });
+      if (!r.ok) {
+        // 409(전환 중/실패) 포함 graceful — 낙관 전환 안 함·spinner 복구.
+        setError(t('switchFailed'));
+        setBusy(null);
+        return;
+      }
+      window.location.assign('/inbox'); // active 전환 → 풀 리로드로 전 컨텍스트 리셋
+    } catch {
+      setError(t('switchFailed'));
+      setBusy(null);
+    }
+  };
+
+  const handleAdd = async () => {
+    if (atCap || busy) return;
+    setBusy('add');
+    try {
+      const r = await fetch('/api/auth/add-account', { method: 'POST', headers: { 'Content-Type': 'application/json' } });
+      const j = (await r.json().catch(() => null)) as { data?: { redirect?: string } } | null;
+      window.location.assign(j?.data?.redirect ?? '/login');
+    } catch {
+      setBusy(null);
+    }
+  };
+
+  const handleSignOut = async (scope: 'this' | 'all') => {
+    if (busy) return;
+    setBusy('signout');
+    try {
+      const r = await fetch('/api/auth/signout-account', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ scope }),
+      });
+      const j = (await r.json().catch(() => null)) as { data?: { next?: string | null } } | null;
+      window.location.assign(scope === 'this' && j?.data?.next ? '/inbox' : '/login');
+    } catch {
+      router.push('/login');
+    }
   };
 
   return (
-    <DropdownMenu>
+    <DropdownMenu onOpenChange={(open) => { if (open) void load(); }}>
       <DropdownMenuTrigger className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition hover:bg-sidebar-accent">
-        <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-sidebar-accent text-xs font-semibold text-sidebar-accent-foreground">
-          {getInitial(name)}
-        </span>
-        <span className="min-w-0 flex-1 truncate text-sm font-medium text-sidebar-foreground">
-          {name}
-        </span>
+        <Avatar url={triggerAvatar} label={triggerName} className="size-7" />
+        <span className="min-w-0 flex-1 truncate text-sm font-medium text-sidebar-foreground">{triggerName}</span>
         <ChevronsUpDown className="size-3.5 shrink-0 text-sidebar-foreground/60" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent side="top" align="start" className="w-56">
+      <DropdownMenuContent side="top" align="start" className="w-64">
+        <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">{t('title')}</DropdownMenuLabel>
         <DropdownMenuGroup>
-          <DropdownMenuLabel className="flex flex-col gap-0.5">
-            <span className="text-sm font-medium">{name}</span>
-            {displayLabel !== name && (
-              <span className="text-xs font-normal text-muted-foreground">{displayLabel}</span>
-            )}
-          </DropdownMenuLabel>
+          {ordered.map((acc) => {
+            const isActive = acc.status === 'active';
+            const isExpired = acc.status === 'expired';
+            const label = acc.name ?? acc.email ?? tc('unknown');
+            return (
+              <DropdownMenuItem
+                key={acc.account_id}
+                disabled={busy !== null || isActive}
+                onClick={() => void handleSwitch(acc)}
+                className={cn('flex items-center gap-2', isActive && 'bg-info/10')}
+              >
+                <Avatar url={acc.avatar_url} label={label} className="size-6" />
+                <span className="flex min-w-0 flex-1 flex-col">
+                  <span className="truncate text-sm">{label}</span>
+                  {isExpired ? (
+                    <span className="truncate text-xs text-muted-foreground">{t('reloginRequired')}</span>
+                  ) : (
+                    acc.email && acc.email !== label && (
+                      <span className="truncate text-xs text-muted-foreground">{acc.email}</span>
+                    )
+                  )}
+                </span>
+                {isActive && <Check className="size-4 shrink-0 text-info" />}
+                {busy === acc.account_id && <Loader2 className="size-4 shrink-0 animate-spin text-muted-foreground" />}
+              </DropdownMenuItem>
+            );
+          })}
         </DropdownMenuGroup>
+        {error && <p className="px-2 py-1 text-xs text-destructive">{error}</p>}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          disabled={atCap || busy !== null}
+          onClick={() => void handleAdd()}
+          className="flex items-center gap-2"
+        >
+          {busy === 'add' ? <Loader2 className="size-4 animate-spin" /> : <Plus className="size-4" />}
+          <span className="flex-1">{t('addAccount')}</span>
+          {atCap && <span className="text-xs text-muted-foreground">{t('capReached')}</span>}
+        </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem render={<Link href="/settings" />}>
           <Settings className="size-4" />
-          설정
+          {tn('settings')}
         </DropdownMenuItem>
         <DropdownMenuSeparator />
-        <DropdownMenuItem onClick={() => void handleLogout()} className="flex items-center gap-2 text-destructive focus:bg-destructive/10 focus:text-destructive">
+        <DropdownMenuItem
+          disabled={busy !== null}
+          onClick={() => void handleSignOut('this')}
+          className="flex items-center gap-2 text-destructive focus:bg-destructive/10 focus:text-destructive"
+        >
           <LogOut className="size-4" />
-          {t('logout')}
+          {others.length > 0 ? t('signOutThis') : tc('logout')}
         </DropdownMenuItem>
+        {others.length > 0 && (
+          <DropdownMenuItem
+            disabled={busy !== null}
+            onClick={() => void handleSignOut('all')}
+            className="flex items-center gap-2 text-destructive focus:bg-destructive/10 focus:text-destructive"
+          >
+            <LogOut className="size-4" />
+            {t('signOutAll')}
+          </DropdownMenuItem>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/web/src/components/nav/profile-menu.tsx
+++ b/apps/web/src/components/nav/profile-menu.tsx
@@ -16,6 +16,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
+import { ACCOUNT_CAP } from '@/lib/auth/account-limits';
 
 interface Account {
   account_id: string;
@@ -31,9 +32,6 @@ interface ProfileMenuProps {
   email?: string | null;
   avatarUrl?: string | null;
 }
-
-// tier 한도(Free 2 / Paid 5·PO 검토 中) — 한도 도달 시 계정 추가 비활성. 기본 5.
-const ACCOUNT_CAP = 5;
 
 function initialOf(label: string | null | undefined): string {
   const s = (label ?? '').trim();
@@ -124,8 +122,18 @@ export function ProfileMenu({ name, avatarUrl }: ProfileMenuProps) {
   const handleAdd = async () => {
     if (atCap || busy) return;
     setBusy('add');
+    setError(null);
     try {
       const r = await fetch('/api/auth/add-account', { method: 'POST', headers: { 'Content-Type': 'application/json' } });
+      if (!r.ok) {
+        if (r.status === 401) {
+          window.location.assign('/login'); // corrupt active → 폐기됨·로그인 재진입
+          return;
+        }
+        setError(t('capReached')); // 409 cap(서버 guard·UI 우회 방어) 등
+        setBusy(null);
+        return;
+      }
       const j = (await r.json().catch(() => null)) as { data?: { redirect?: string } } | null;
       window.location.assign(j?.data?.redirect ?? '/login');
     } catch {

--- a/apps/web/src/lib/auth/account-limits.ts
+++ b/apps/web/src/lib/auth/account-limits.ts
@@ -1,0 +1,5 @@
+/**
+ * 멀티계정 한도(tier) — Free 2 / Paid 5 (PO 검토 中). 현재 단일 상수 = 5.
+ * 클라(switcher 추가 비활성 UX) + 서버(add-account cap guard) 공유 — 서버 전용 import 없음(클라 安全).
+ */
+export const ACCOUNT_CAP = 5;


### PR DESCRIPTION
## 배경
멀티계정 스위칭 `bf305fa0` — **PR2 = switcher UI**(PR1 #1739 머지된 vault/proxy mechanism 위). 유나 banked 4상태 스펙(②내 빌드·핸드오프 doc 대신 스펙 직빌드).

## 변경
- **`profile-menu.tsx` → 계정 switcher 확장**(SidebarFooter 앵커). 드롭다운 **open 시** `/api/accounts` fetch(이벤트 기반·effect 내 setState 회피).
  - **4상태**: `active`(info-tint+✓·현재계정·트리거) / `inactive`(클릭=switch) / `expired`(muted·"재로그인 필요"·클릭=로그인 재진입).
  - **switch**: `POST /api/auth/switch-account {account_id}` → 200 시 `/inbox` 풀 리로드(전 컨텍스트 리셋) · **409 graceful**(에러 문구·낙관 전환 X·spinner 복구).
  - **계정 추가**: `POST /api/auth/add-account` → 로그인 진입 · **5-cap muted**(한도 시 비활성·tier Free2/Paid5 PO 검토).
  - **sign-out**: `this`(다음 계정 승격) / `all`(others 있을 때만). 단일계정은 일반 로그아웃.
  - **avatar**: avatar_url → next/image(unoptimized) · 없으면 이니셜 폴백.
- **`api/auth/add-account/route.ts`** (ⓒ): 현 RT vault 보존 + active 포인터 클리어 → `/login` redirect(stale 포인터 mismatch 방지·CSRF).
- **i18n**: `accountSwitcher` ns 신규(en/ko parity).

## 검증
- type-check 0 · lint 0 · build ✓.
- design-first: BE `switch-account`/`accounts/resolve` 랜딩 後 실 e2e. 미머지 시 graceful(switch 409·resolve decode 최소 리스트).

## 게이트
가디언 정적(switcher spec·a11y·info 액센트·3분기·양테마) + 까심 cross-model + 산티아고 보안 + 유나 dev 픽셀(양테마·4상태+switch 실패+5-cap).

## 관련
- PR1 #1739(mechanism·MERGED) · pre-prod RC(multi-instance epoch·prod 승격 前) · doc `bf305fa0-multi-account-auth-mechanism`.

## Base
`develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)