### PR TITLE
[24f5ae18] Gate inbox doc gate enrich — work_item_summary{title,slug} (doc 결재 UX·BE)

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -64,6 +64,13 @@ class GateTransitionRequest(BaseModel):
         return v
 
 
+class WorkItemSummary(BaseModel):
+    """doc-side 결재 UX(24f5ae18): 인박스 gate 가 work_item 을 렌더/링크하도록 title/slug 동봉.
+    현재 doc gate 에 채움(향후 타 work_item_type 확장 여지)."""
+    title: str
+    slug: str | None = None
+
+
 class GateResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -71,6 +78,9 @@ class GateResponse(BaseModel):
     org_id: uuid.UUID
     work_item_id: uuid.UUID
     work_item_type: str
+    # doc-side 결재 UX(24f5ae18): gate row 는 work_item_id 만이라 인박스가 doc 를 못 그림 → enrich.
+    # additive·nullable(비-doc/미존재 시 None·하위호환). FE 는 별도 doc fetch 제거.
+    work_item_summary: "WorkItemSummary | None" = None
     gate_type: str
     status: str
     resolver_id: uuid.UUID | None = None
@@ -125,7 +135,25 @@ async def list_gates(
     if status:
         q = q.where(Gate.status == status)
     result = await session.execute(q)
-    return [GateResponse.model_validate(g) for g in result.scalars().all()]
+    gates = list(result.scalars().all())
+    responses = [GateResponse.model_validate(g) for g in gates]
+
+    # doc-side 결재 UX(24f5ae18): doc gate 는 work_item_id(doc id)만이라 인박스가 doc 를 못 그림 →
+    # doc title/slug batch enrich(org-scope·soft-delete 가드·N+1 0). FE 가 "결재: <title>" 렌더 + /docs/<slug>
+    # 링크. 비-doc/삭제 doc 은 None(하위호환).
+    doc_ids = {g.work_item_id for g in gates if g.work_item_type == "doc"}
+    if doc_ids:
+        from app.models.doc import Doc
+        rows = (await session.execute(
+            select(Doc.id, Doc.title, Doc.slug).where(
+                Doc.id.in_(doc_ids), Doc.org_id == org_id, Doc.deleted_at.is_(None),
+            )
+        )).all()
+        summaries = {did: WorkItemSummary(title=title, slug=slug) for did, title, slug in rows}
+        for resp in responses:
+            if resp.work_item_type == "doc":
+                resp.work_item_summary = summaries.get(resp.work_item_id)
+    return responses
 
 
 @router.post("/{id}/transition", response_model=GateResponse)

--- a/backend/tests/test_gate_inbox_doc_enrich.py
+++ b/backend/tests/test_gate_inbox_doc_enrich.py
@@ -1,0 +1,53 @@
+"""24f5ae18: Gate inbox 가 doc gate 를 doc title/slug 로 enrich(인박스 렌더+링크)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.routers.gates import list_gates
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _gate(org, work_item_id, wtype):
+    return SimpleNamespace(
+        id=uuid.uuid4(), org_id=org, work_item_id=work_item_id, work_item_type=wtype,
+        gate_type="doc_approval" if wtype == "doc" else "merge", status="pending",
+        resolver_id=None, resolved_at=None, resolution_note=None, held_until=None,
+        neutral_facts=None, requires_human=False, evidence_status=None,
+        decision_basis=None, auto_decision_reason=None, work_item_summary=None,
+        created_at=datetime(2026, 6, 26, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 6, 26, tzinfo=timezone.utc),
+    )
+
+
+@pytest.mark.anyio
+async def test_doc_gate_enriched_with_title_slug():
+    org, doc_id = uuid.uuid4(), uuid.uuid4()
+    gates_res = MagicMock(); gates_res.scalars.return_value.all.return_value = [_gate(org, doc_id, "doc")]
+    docs_res = MagicMock(); docs_res.all.return_value = [(doc_id, "설계 문서", "design-doc")]
+    session = AsyncMock(); session.execute = AsyncMock(side_effect=[gates_res, docs_res])
+    out = await list_gates(work_item_id=None, work_item_type="doc", status="pending",
+                           session=session, org_id=org, _auth=None)
+    assert out[0].work_item_summary is not None
+    assert out[0].work_item_summary.title == "설계 문서"
+    assert out[0].work_item_summary.slug == "design-doc"
+
+
+@pytest.mark.anyio
+async def test_non_doc_gate_no_enrich_no_extra_query():
+    """비-doc gate 는 enrich 0(work_item_summary None)·doc 쿼리 미발생(N+1 0)."""
+    org = uuid.uuid4()
+    gates_res = MagicMock(); gates_res.scalars.return_value.all.return_value = [_gate(org, uuid.uuid4(), "story")]
+    session = AsyncMock(); session.execute = AsyncMock(side_effect=[gates_res])
+    out = await list_gates(work_item_id=None, work_item_type=None, status=None,
+                           session=session, org_id=org, _auth=None)
+    assert out[0].work_item_summary is None
+    assert session.execute.await_count == 1  # gates 쿼리만(doc enrich 쿼리 0)


### PR DESCRIPTION
## 배경 (선생님 실 Web 결재 블로커·essential)
doc-gate mechanism은 작동(#1740·fresh 상신→pending gate·auto_passed 0)하나 **gate row가 work_item_id(doc id)만** 가져 **Gate inbox가 doc를 렌더/링크 못 함** → 아버님 결재 UI 불가.

## fix — BE 계약 ⓐ (gate→doc enrich)
- `GateResponse.work_item_summary{title, slug}`(additive·nullable) 추가.
- `list_gates`가 doc gate를 **batch enrich**(work_item_id→Doc title/slug·**org-scope·deleted_at 가드·N+1 0**).
- FE(유나)는 인박스 gate row에 "결재: <title>" 렌더 + `/docs/<slug>` 링크·별도 doc fetch 제거. 비-doc/삭제 doc은 None(하위호환).

## FE 계약 ⓑ/ⓒ (기존 지원·신규 BE 0)
- **ⓑ resolve(승인/반려)** = 기존 `POST /api/v2/gates/{id}/transition {status: approved|rejected, note?}` (human-only authz·_resolve_doc_gate가 doc→confirmed/denied). ⚠️override(owner force-bypass·SoD)와 구분 — 일반 결재는 transition.
- **ⓒ doc-detail gate fetch** = 기존 `GET /api/v2/gates?work_item_id=<doc_id>&work_item_type=doc&status=pending`.

## 테스트
doc gate enrich(title/slug)·비-doc no-enrich+추가쿼리 0(N+1 가드) 신규 2. 전체 **2533 passed**(실패 8=환경 DoD).

머지+재배포 後 dev의 현 pending doc gate 3건(7ef33491·3e3fbd0a·0e0a2441) enrich 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)