### PR TITLE
[SID:24f5ea18] doc-side 결재 MVP — 인박스(GateInbox) doc gate 제목 + 승인/반려

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2728,6 +2728,7 @@
     "fallbackNotifyError": "Failed to notify",
     "gateApprove": "Approve",
     "gateReject": "Reject",
+    "docGateTitlePrefix": "Approval: ",
     "gateRejectTitle": "Reject gate",
     "gateRejectNotePlaceholder": "Reason (optional)",
     "gateRejectConfirm": "Confirm reject",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2728,6 +2728,7 @@
     "fallbackNotifyError": "통지에 실패했습니다",
     "gateApprove": "승인",
     "gateReject": "반려",
+    "docGateTitlePrefix": "결재: ",
     "gateRejectTitle": "게이트 반려",
     "gateRejectNotePlaceholder": "사유 (선택)",
     "gateRejectConfirm": "반려 확정",

--- a/apps/web/src/components/cage/gate-inbox.tsx
+++ b/apps/web/src/components/cage/gate-inbox.tsx
@@ -41,6 +41,10 @@ export function GateInbox({ memberId }: GateInboxProps) {
   // held 판정은 status==='held' OR held_until(디디 BE 표현 미확정·둘 다 커버·머지 후 정합).
   const [holdModal, setHoldModal] = useState<{ gateId: string; reason: string; indefinite: boolean; heldUntil: string } | null>(null);
   const isHeld = (g: GateItem) => g.status === 'held' || !!g.held_until;
+  // doc-side 결재(24f5ea18): doc 결재 gate 판정. work_item_type='doc' 또는 gate_type='doc_approval'(디디 BE PR #1742).
+  // doc gate는 머지 verdict의 requires_human/auto_decision 메타가 없어 gateNeedsAction이 false → 사람 결재 액션이
+  // 떠야 하므로 별도 분기로 승인/반려를 surface한다(human-only authz는 BE 강제).
+  const isDocGate = (g: GateItem) => g.work_item_type === 'doc' || g.gate_type === 'doc_approval';
   const resolveName = (id: string) => memberNames[id] ?? id.slice(0, 6);
   // S11 ②: 라인 컨텍스트(active step_run by story_id) + approver 이름맵.
   const [lineMap, setLineMap] = useState<Record<string, WorkflowLineStepRun>>({});
@@ -210,7 +214,14 @@ export function GateInbox({ memberId }: GateInboxProps) {
             <div className="min-w-0 flex-1 space-y-1">
               <div className="flex items-center gap-2">
                 <span className="shrink-0 text-xs font-medium text-foreground">{gate.gate_type}</span>
-                <span className="truncate text-xs text-muted-foreground">#{gate.work_item_id.slice(0, 6)}</span>
+                {/* doc gate: 원문서 제목 노출(work_item_summary·디디 BE PR #1742). 없으면(null/non-doc) 기존 raw id 폴백. */}
+                {gate.work_item_summary?.title ? (
+                  <span className="truncate text-xs text-muted-foreground" title={gate.work_item_summary.title}>
+                    {t('docGateTitlePrefix')}{gate.work_item_summary.title}
+                  </span>
+                ) : (
+                  <span className="truncate text-xs text-muted-foreground">#{gate.work_item_id.slice(0, 6)}</span>
+                )}
                 <span className="shrink-0 text-[10px] text-muted-foreground/70">{new Date(gate.created_at).toLocaleDateString()}</span>
               </div>
               {/* S11 ②: 라인 컨텍스트("어디·누가·언제") + ④ 구분선 → H1 GateEvidence("왜")와 분리 */}
@@ -279,7 +290,7 @@ export function GateInbox({ memberId }: GateInboxProps) {
                     {t('resumeAction')}
                   </Button>
                 </>
-              ) : gateNeedsAction(gate) ? (
+              ) : gateNeedsAction(gate) || isDocGate(gate) ? (
                 <>
                   <Button
                     size="sm"

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -40,6 +40,10 @@ export interface GateItem {
   overridden_at?: string | null;
   bypassed_sod?: boolean | null;
   neutral_facts: Record<string, unknown> | null;
+  // doc-side 결재(24f5ea18): doc gate(work_item_type='doc' / gate_type='doc_approval')일 때 BE가
+  // 대상 문서 요약을 동봉(디디 BE PR #1742·additive). non-doc/삭제된 문서 gate는 null → `?.` 가드 폴백.
+  // slug는 향후 deep-link 후속용(MVP 미사용).
+  work_item_summary?: { title: string; slug: string } | null;
   // H1-S3 머지 verdict 게이트 evidence(GateResponse·additive·하위호환 default). null≠0(AC③).
   requires_human?: boolean;
   evidence_status?: string | null; // sufficient | blocked | insufficient


### PR DESCRIPTION
## 개요 (MVP)

org owner가 인박스(GateInbox)에서 **문서 결재 게이트**를 승인/반려할 수 있도록 하는 최소 변경. 대상 컴포넌트는 `apps/web/src/components/cage/gate-inbox.tsx`(인박스 페이지가 `/api/gates?status=pending`로 읽는 실제 게이트 행). 기존 approve/reject transition 경로를 그대로 재사용하며 신규 BE 엔드포인트는 없다(디디 BE PR #1742의 enrich 필드 한 건만 의존).

## 변경 내용 (2가지)

1. **문서 제목 노출** — doc gate 행에서 raw `work_item_id` 대신 대상 문서 제목을 표시한다. BE가 동봉하는 `gate.work_item_summary.title`을 `결재: {title}` 형태로 렌더하고, 값이 없으면(`null`·non-doc·삭제된 문서) `?.` 가드로 기존 `#{id}` 렌더로 폴백한다(크래시 없음).
2. **승인/반려 액션 surface** — doc gate에서 기존 **승인/반려** 액션이 뜨도록 액션 조건을 `gateNeedsAction(gate) || isDocGate(gate)`로 확장. 머지 verdict 게이트와 달리 doc gate는 `requires_human`/`auto_decision_reason` 메타가 없어 `gateNeedsAction`이 false → 액션이 누락되던 블로커를 해소한다. 승인/반려는 **기존** `handleApprove`/`handleReject`를 그대로 재사용한다(`POST /api/gates/{id}/transition`, body `status: 'approved'` / `status: 'rejected', note`). human-only authz는 BE에서 강제(에이전트는 403).

## 파일별 변경

- `apps/web/src/components/cage/gate-inbox.tsx` — `isDocGate` 헬퍼 추가, doc 제목 렌더 분기, 액션 조건 확장.
- `apps/web/src/components/kanban/types.ts` — `GateItem.work_item_summary`(additive·nullable) 추가.
- `apps/web/messages/{en,ko}.json` — `cage` 네임스페이스에 `docGateTitlePrefix` 키 추가(en/ko parity).

## BE 계약 의존 (디디 — 확인 요망)

- **`gate.work_item_summary`**: doc gate(`work_item_type === 'doc'` / `gate_type === 'doc_approval'`)에서 `{ title: string; slug: string } | null`. non-doc·삭제 문서 gate는 `null`로 내려와야 함(FE는 `?.`로 graceful 폴백). slug는 MVP 미사용(deep-link 후속용).
- **doc gate 식별**: FE는 `work_item_type === 'doc'` OR `gate_type === 'doc_approval'` 둘 중 하나로 판정. BE 실제 값이 둘 중 어느 쪽인지 확인 요망(현재 두 표현 모두 커버).
- **resolve transition**: `POST /api/gates/{id}/transition` — 승인 `{ status: 'approved' }`, 반려 `{ status: 'rejected', note }`. 기존 코드가 `resolver_id`도 함께 보내는데(타 게이트 타입 동작 경로 유지), doc gate에서 무해/무시되는지 확인 요망(LOCKED 계약상 status만 필수).

## 후속(별도 스토리)

문서 상세 인컨텍스트 결재, "문서에서 검토" deep-link(slug 활용), decision_history 타임라인은 본 MVP에서 제외 — 별도 follow-up 스토리.

## 검증

- type-check ✓ (build로 `.next/types` 재생성 후 통과 — 직전 stale 아티팩트 오류 해소)
- lint ✓ (0 errors; 잔여 warning은 본 변경과 무관한 기존 파일)
- build ✓ (Compiled successfully, 177 페이지 생성 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)