### PR TITLE
[SID:bf305fa0] hotfix: switcher 드롭다운 크래시 — GroupLabel을 Group 내부로 (Base UI #31)

### DIFF
--- a/apps/web/src/components/nav/profile-menu.tsx
+++ b/apps/web/src/components/nav/profile-menu.tsx
@@ -165,8 +165,9 @@ export function ProfileMenu({ name, avatarUrl }: ProfileMenuProps) {
         <ChevronsUpDown className="size-3.5 shrink-0 text-sidebar-foreground/60" />
       </DropdownMenuTrigger>
       <DropdownMenuContent side="top" align="start" className="w-64">
-        <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">{t('title')}</DropdownMenuLabel>
         <DropdownMenuGroup>
+          {/* GroupLabel(base-ui)은 반드시 Group 내부 — Popup 직속이면 error #31 크래시. */}
+          <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">{t('title')}</DropdownMenuLabel>
           {ordered.map((acc) => {
             const isActive = acc.status === 'active';
             const isExpired = acc.status === 'expired';


### PR DESCRIPTION
## 🚨 블로커 hotfix
PR2 #1741(switcher·MERGED `b64a58ec`) dev 픽셀서 적출 — **ProfileMenu(계정 switcher) 드롭다운 열기 즉시 페이지 크래시**(Base UI error #31). develop 머지 상태라 **전 유저 프로필 메뉴(설정·로그아웃 진입까지) 블로킹**.

## 근본 원인
`DropdownMenuLabel` = `MenuPrimitive.GroupLabel`(base-ui). **GroupLabel은 반드시 `Menu.Group` 컨텍스트 내부**여야 하는데, PR2 rewrite서 계정 title 라벨을 `DropdownMenuGroup` **밖**(Popup 직속)에 배치 → on-render invariant throw(#31).
- 격리 일치: 워크스페이스/조직 스위처 등 타 DropdownMenu 정상(GroupLabel 외부 노출은 ProfileMenu만).
- 정적 검사(type/lint/build) 미적출 = 런타임 Base UI 불변식.

## fix
`<DropdownMenuLabel>`(계정 title)을 계정 리스트 `<DropdownMenuGroup>` **내부**로 이동(1-line 구조 수정). 빈 group(accounts=[] 첫 렌더) 가설도 label 상주로 동시 해소.

## 검증
- type-check 0 · lint 0 · build ✓.
- ⚠️ 렌더 크래시라 라이브가 arbiter — **유나 dev 재픽셀**(드롭다운 open·4상태·409·5-cap·양테마).

## Base
`develop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)