### PR TITLE
[SID:9ed96921] E-STORAGE-SSOT S2 — asset + folder registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,10 @@ jobs:
           # baseline REVISION invariant — the snapshot was captured at 0096; changing this without
           # regenerating baseline/schema.sql would mis-stamp fresh DBs. Lock it.
           test "$(cat backend/alembic/baseline/REVISION)" = "0096"
-          echo "baseline parity OK: team_members=VIEW, org_member_id nullable, seed present, 0097 applied, REVISION=0096"
+          # E-STORAGE-SSOT S2 (0139): asset registry 3 테이블 + asset_links source_type CHECK 적용 확인.
+          test "$(P "SELECT count(*) FROM information_schema.tables WHERE table_name IN ('assets','asset_folders','asset_links')")" = "3"
+          test "$(P "SELECT count(*) FROM pg_constraint WHERE conname='ck_asset_links_source_type'")" = "1"
+          echo "baseline parity OK: team_members=VIEW, org_member_id nullable, seed present, 0097 applied, asset registry present, REVISION=0096"
 
       - name: Verify fresh DB reached head (baseline + incremental)
         working-directory: backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,17 @@ jobs:
           test "$(P "SELECT count(*) FROM pg_constraint WHERE conname='ck_asset_links_source_type'")" = "1"
           echo "baseline parity OK: team_members=VIEW, org_member_id nullable, seed present, 0097 applied, asset registry present, REVISION=0096"
 
+      # E-STORAGE-SSOT: asset registry IDOR/정합 게이트는 real-DB 가 필수(backend-test 잡엔 PG 없음).
+      # 이 PG 백드 잡에서 실행해 S2~S8 IDOR/멀티테넌시 회귀를 CI 가 잡도록 박는다(까심#4).
+      - name: asset registry real-DB tests (IDOR / sync / backfill)
+        working-directory: backend
+        env:
+          ALEMBIC_DATABASE_URL: postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test
+          DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
+          JWT_SECRET: ci-test-secret-at-least-32-chars-long
+          SECRET_KEY: ci-test-secret-at-least-32-chars-long
+        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py -q
+
       - name: Verify fresh DB reached head (baseline + incremental)
         working-directory: backend
         env:

--- a/backend/alembic/versions/0139_add_asset_registry.py
+++ b/backend/alembic/versions/0139_add_asset_registry.py
@@ -81,8 +81,11 @@ def upgrade() -> None:
             sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
             sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
             sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
-            # org_id 포함 필수(멀티테넌시·cross-org dangling link 차단·까심). project_id 는 object_path 가 내포.
-            sa.UniqueConstraint("org_id", "container", "object_path", name="uq_assets_org_container_object_path"),
+            # (org_id, project_id) 포함 필수(멀티테넌시·까심): cross-org + same-org cross-project 누수 차단.
+            sa.UniqueConstraint(
+                "org_id", "project_id", "container", "object_path",
+                name="uq_assets_org_project_container_object_path",
+            ),
         )
         op.create_index("ix_assets_org_id", "assets", ["org_id"])
         op.create_index("ix_assets_project_id", "assets", ["project_id"])
@@ -160,7 +163,7 @@ def _backfill_source(conn, *, table, join, org_expr, project_expr, scope_like, s
         FROM {table} m {join}
         CROSS JOIN LATERAL jsonb_array_elements(m.attachments) AS att
         WHERE {where}
-        ON CONFLICT (org_id, container, object_path) DO NOTHING
+        ON CONFLICT (org_id, project_id, container, object_path) DO NOTHING
         """
     ).bindparams(bindparam("ids", expanding=True))
     insert_links = text(
@@ -169,7 +172,8 @@ def _backfill_source(conn, *, table, join, org_expr, project_expr, scope_like, s
         SELECT {org_expr}, a.id, :source_type, m.id
         FROM {table} m {join}
         CROSS JOIN LATERAL jsonb_array_elements(m.attachments) AS att
-        JOIN assets a ON a.org_id = {org_expr} AND a.container = :bucket AND a.object_path = {_CANON}
+        JOIN assets a ON a.org_id = {org_expr} AND a.project_id = {project_expr}
+                     AND a.container = :bucket AND a.object_path = {_CANON}
         WHERE {where}
         ON CONFLICT (asset_id, source_type, source_id) DO NOTHING
         """

--- a/backend/alembic/versions/0139_add_asset_registry.py
+++ b/backend/alembic/versions/0139_add_asset_registry.py
@@ -37,6 +37,8 @@ _CANON = (
 )
 # 우리 객체만(GCS prefix 또는 bare). 외부 https/gs/file 등은 제외.
 _OURS = "(att->>'url' LIKE :prefix || '%' OR position('://' in att->>'url') = 0)"
+# size 안전 캐스팅(까심#3): 비숫자(`""`·`"12 bytes"`) 오염에도 마이그 실패 금지.
+_SIZE = "CASE WHEN att->>'size' ~ '^[0-9]+$' THEN (att->>'size')::bigint ELSE 0 END"
 
 
 def upgrade() -> None:
@@ -79,7 +81,8 @@ def upgrade() -> None:
             sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
             sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
             sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
-            sa.UniqueConstraint("container", "object_path", name="uq_assets_container_object_path"),
+            # org_id 포함 필수(멀티테넌시·cross-org dangling link 차단·까심). project_id 는 object_path 가 내포.
+            sa.UniqueConstraint("org_id", "container", "object_path", name="uq_assets_org_container_object_path"),
         )
         op.create_index("ix_assets_org_id", "assets", ["org_id"])
         op.create_index("ix_assets_project_id", "assets", ["project_id"])
@@ -122,6 +125,8 @@ def _backfill(conn) -> None:
         join="JOIN conversations c ON c.id = m.conversation_id",
         org_expr="c.org_id",
         project_expr="c.project_id",
+        # 경로가 이 메시지에 귀속됐는지(IDOR·오염 차단·까심#2): chat/<project>/<conversation>/...
+        scope_like="'chat/' || c.project_id || '/' || m.conversation_id || '/%'",
         source_type="conversation_message",
     )
     _backfill_source(
@@ -130,16 +135,19 @@ def _backfill(conn) -> None:
         join="",
         org_expr="m.org_id",
         project_expr="m.project_id",
+        scope_like="'story/' || m.project_id || '/' || m.id || '/%'",
         source_type="story",
     )
 
 
-def _backfill_source(conn, *, table, join, org_expr, project_expr, source_type) -> None:
+def _backfill_source(conn, *, table, join, org_expr, project_expr, scope_like, source_type) -> None:
     params = {"prefix": _PREFIX, "bucket": _BUCKET}
+    # 우리 객체 + 이 source 귀속 경로만(까심#2). jsonb_typeof 가드(까심#3)는 ids_sql 에서 선행.
+    where = f"m.id IN :ids AND att->>'url' IS NOT NULL AND {_OURS} AND ({_CANON}) LIKE {scope_like}"
 
     ids_sql = text(
         f"SELECT m.id FROM {table} m "
-        f"WHERE m.id > :last AND m.attachments IS NOT NULL "
+        f"WHERE m.id > :last AND jsonb_typeof(m.attachments) = 'array' "
         f"AND jsonb_array_length(m.attachments) > 0 ORDER BY m.id LIMIT :lim"
     )
     insert_assets = text(
@@ -148,11 +156,11 @@ def _backfill_source(conn, *, table, join, org_expr, project_expr, source_type) 
         SELECT {org_expr}, {project_expr}, :bucket, {_CANON},
                COALESCE(NULLIF(att->>'name', ''), 'file'),
                NULLIF(att->>'content_type', ''),
-               COALESCE((att->>'size')::bigint, 0)
+               {_SIZE}
         FROM {table} m {join}
         CROSS JOIN LATERAL jsonb_array_elements(m.attachments) AS att
-        WHERE m.id IN :ids AND att->>'url' IS NOT NULL AND {_OURS}
-        ON CONFLICT (container, object_path) DO NOTHING
+        WHERE {where}
+        ON CONFLICT (org_id, container, object_path) DO NOTHING
         """
     ).bindparams(bindparam("ids", expanding=True))
     insert_links = text(
@@ -161,8 +169,8 @@ def _backfill_source(conn, *, table, join, org_expr, project_expr, source_type) 
         SELECT {org_expr}, a.id, :source_type, m.id
         FROM {table} m {join}
         CROSS JOIN LATERAL jsonb_array_elements(m.attachments) AS att
-        JOIN assets a ON a.container = :bucket AND a.object_path = {_CANON}
-        WHERE m.id IN :ids AND att->>'url' IS NOT NULL AND {_OURS}
+        JOIN assets a ON a.org_id = {org_expr} AND a.container = :bucket AND a.object_path = {_CANON}
+        WHERE {where}
         ON CONFLICT (asset_id, source_type, source_id) DO NOTHING
         """
     ).bindparams(bindparam("ids", expanding=True))

--- a/backend/alembic/versions/0139_add_asset_registry.py
+++ b/backend/alembic/versions/0139_add_asset_registry.py
@@ -1,0 +1,184 @@
+"""E-STORAGE-SSOT S2: asset registry — assets / asset_folders / asset_links.
+
+Revision ID: 0139
+Revises: 0138
+Create Date: 2026-06-26
+
+S1 IStorageService 위에 빌드. 모든 업로드를 queryable한 asset row로 편입. asset_links =
+참조원(message/story/doc/manual) SSOT(catch#4).
+
+idempotent: 테이블 단위 inspect 가드(0113 선례). 기존 chat/story 첨부(JSONB) → asset/asset_link
+**멱등 백필**(ON CONFLICT DO NOTHING·keyset 배치). 외부 URL/타 버킷은 우리 객체 아니므로 스킵.
+downgrade는 links → assets → asset_folders 역순 drop.
+"""
+from __future__ import annotations
+
+import os
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import bindparam, text
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0139"
+down_revision = "0138"
+branch_labels = None
+depends_on = None
+
+_BACKFILL_BATCH = 500
+# S1 GCS_MEMO_ATTACHMENTS_BUCKET 기본과 정합. legacy 첨부 컨테이너.
+_BUCKET = os.environ.get("GCS_MEMO_ATTACHMENTS_BUCKET", "sprintable-memo-attachments")
+_PREFIX = f"https://storage.googleapis.com/{_BUCKET}/"
+
+# legacy url → canonical object_path: GCS public prefix 제거 / bare 그대로 / 외부 스킴 스킵(NULL).
+_CANON = (
+    "CASE WHEN att->>'url' LIKE :prefix || '%' "
+    "THEN substr(att->>'url', length(:prefix) + 1) ELSE att->>'url' END"
+)
+# 우리 객체만(GCS prefix 또는 bare). 외부 https/gs/file 등은 제외.
+_OURS = "(att->>'url' LIKE :prefix || '%' OR position('://' in att->>'url') = 0)"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    existing = set(insp.get_table_names())
+
+    if "asset_folders" not in existing:
+        op.create_table(
+            "asset_folders",
+            sa.Column("id", UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+            sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("project_id", UUID(as_uuid=True), sa.ForeignKey("projects.id", ondelete="CASCADE"), nullable=True),
+            sa.Column("parent_id", UUID(as_uuid=True), sa.ForeignKey("asset_folders.id", ondelete="CASCADE"), nullable=True),
+            sa.Column("name", sa.Text(), nullable=False),
+            sa.Column("created_by", UUID(as_uuid=True), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+            sa.UniqueConstraint("org_id", "project_id", "parent_id", "name", name="uq_asset_folders_parent_name"),
+        )
+        op.create_index("ix_asset_folders_org_id", "asset_folders", ["org_id"])
+        op.create_index("ix_asset_folders_project_id", "asset_folders", ["project_id"])
+        op.create_index("ix_asset_folders_parent_id", "asset_folders", ["parent_id"])
+        op.create_index("ix_asset_folders_project_parent", "asset_folders", ["org_id", "project_id", "parent_id"])
+
+    if "assets" not in existing:
+        op.create_table(
+            "assets",
+            sa.Column("id", UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+            sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("project_id", UUID(as_uuid=True), sa.ForeignKey("projects.id", ondelete="CASCADE"), nullable=True),
+            sa.Column("folder_id", UUID(as_uuid=True), sa.ForeignKey("asset_folders.id", ondelete="SET NULL"), nullable=True),
+            sa.Column("container", sa.Text(), nullable=False),
+            sa.Column("object_path", sa.Text(), nullable=False),
+            sa.Column("name", sa.Text(), nullable=False),
+            sa.Column("content_type", sa.Text(), nullable=True),
+            sa.Column("size_bytes", sa.BigInteger(), nullable=False, server_default="0"),
+            sa.Column("created_by", UUID(as_uuid=True), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+            sa.UniqueConstraint("container", "object_path", name="uq_assets_container_object_path"),
+        )
+        op.create_index("ix_assets_org_id", "assets", ["org_id"])
+        op.create_index("ix_assets_project_id", "assets", ["project_id"])
+        op.create_index("ix_assets_folder_id", "assets", ["folder_id"])
+        op.create_index(
+            "ix_assets_org_project_ctype_created",
+            "assets",
+            ["org_id", "project_id", "content_type", sa.text("created_at DESC")],
+        )
+
+    if "asset_links" not in existing:
+        op.create_table(
+            "asset_links",
+            sa.Column("id", UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+            sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("asset_id", UUID(as_uuid=True), sa.ForeignKey("assets.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("source_type", sa.Text(), nullable=False),
+            sa.Column("source_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("created_by", UUID(as_uuid=True), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.UniqueConstraint("asset_id", "source_type", "source_id", name="uq_asset_links_asset_source"),
+            sa.CheckConstraint(
+                "source_type IN ('conversation_message','story','doc','manual')",
+                name="ck_asset_links_source_type",
+            ),
+        )
+        op.create_index("ix_asset_links_org_id", "asset_links", ["org_id"])
+        op.create_index("ix_asset_links_asset_id", "asset_links", ["asset_id"])
+        op.create_index("ix_asset_links_source", "asset_links", ["source_type", "source_id"])
+
+    _backfill(conn)
+
+
+def _backfill(conn) -> None:
+    """기존 chat/story 첨부(JSONB) → asset/asset_link 멱등 편입. keyset 배치(prod 락/시간 안전)."""
+    _backfill_source(
+        conn,
+        table="conversation_messages",
+        join="JOIN conversations c ON c.id = m.conversation_id",
+        org_expr="c.org_id",
+        project_expr="c.project_id",
+        source_type="conversation_message",
+    )
+    _backfill_source(
+        conn,
+        table="stories",
+        join="",
+        org_expr="m.org_id",
+        project_expr="m.project_id",
+        source_type="story",
+    )
+
+
+def _backfill_source(conn, *, table, join, org_expr, project_expr, source_type) -> None:
+    params = {"prefix": _PREFIX, "bucket": _BUCKET}
+
+    ids_sql = text(
+        f"SELECT m.id FROM {table} m "
+        f"WHERE m.id > :last AND m.attachments IS NOT NULL "
+        f"AND jsonb_array_length(m.attachments) > 0 ORDER BY m.id LIMIT :lim"
+    )
+    insert_assets = text(
+        f"""
+        INSERT INTO assets (org_id, project_id, container, object_path, name, content_type, size_bytes)
+        SELECT {org_expr}, {project_expr}, :bucket, {_CANON},
+               COALESCE(NULLIF(att->>'name', ''), 'file'),
+               NULLIF(att->>'content_type', ''),
+               COALESCE((att->>'size')::bigint, 0)
+        FROM {table} m {join}
+        CROSS JOIN LATERAL jsonb_array_elements(m.attachments) AS att
+        WHERE m.id IN :ids AND att->>'url' IS NOT NULL AND {_OURS}
+        ON CONFLICT (container, object_path) DO NOTHING
+        """
+    ).bindparams(bindparam("ids", expanding=True))
+    insert_links = text(
+        f"""
+        INSERT INTO asset_links (org_id, asset_id, source_type, source_id)
+        SELECT {org_expr}, a.id, :source_type, m.id
+        FROM {table} m {join}
+        CROSS JOIN LATERAL jsonb_array_elements(m.attachments) AS att
+        JOIN assets a ON a.container = :bucket AND a.object_path = {_CANON}
+        WHERE m.id IN :ids AND att->>'url' IS NOT NULL AND {_OURS}
+        ON CONFLICT (asset_id, source_type, source_id) DO NOTHING
+        """
+    ).bindparams(bindparam("ids", expanding=True))
+
+    last = "00000000-0000-0000-0000-000000000000"
+    while True:
+        rows = conn.execute(ids_sql, {"last": last, "lim": _BACKFILL_BATCH}).fetchall()
+        if not rows:
+            break
+        ids = [r[0] for r in rows]
+        conn.execute(insert_assets, {**params, "ids": ids})
+        conn.execute(insert_links, {**params, "ids": ids, "source_type": source_type})
+        last = str(ids[-1])
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS asset_links")
+    op.execute("DROP TABLE IF EXISTS assets")
+    op.execute("DROP TABLE IF EXISTS asset_folders")

--- a/backend/alembic/versions/0139_add_asset_registry.py
+++ b/backend/alembic/versions/0139_add_asset_registry.py
@@ -81,11 +81,16 @@ def upgrade() -> None:
             sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
             sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
             sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
-            # (org_id, project_id) 포함 필수(멀티테넌시·까심): cross-org + same-org cross-project 누수 차단.
-            sa.UniqueConstraint(
-                "org_id", "project_id", "container", "object_path",
-                name="uq_assets_org_project_container_object_path",
-            ),
+        )
+        # 멀티테넌시 멱등 키(까심 R1~R3): org_id+project_id 포함. project_id NULL(org-level)은
+        # NULL-distinct라 별도 partial unique 로 멱등 보장(2-index 정공).
+        op.create_index(
+            "uq_assets_proj_nonnull", "assets", ["org_id", "project_id", "container", "object_path"],
+            unique=True, postgresql_where=sa.text("project_id IS NOT NULL"),
+        )
+        op.create_index(
+            "uq_assets_proj_null", "assets", ["org_id", "container", "object_path"],
+            unique=True, postgresql_where=sa.text("project_id IS NULL"),
         )
         op.create_index("ix_assets_org_id", "assets", ["org_id"])
         op.create_index("ix_assets_project_id", "assets", ["project_id"])
@@ -163,7 +168,8 @@ def _backfill_source(conn, *, table, join, org_expr, project_expr, scope_like, s
         FROM {table} m {join}
         CROSS JOIN LATERAL jsonb_array_elements(m.attachments) AS att
         WHERE {where}
-        ON CONFLICT (org_id, project_id, container, object_path) DO NOTHING
+        ON CONFLICT (org_id, project_id, container, object_path)
+            WHERE project_id IS NOT NULL DO NOTHING
         """
     ).bindparams(bindparam("ids", expanding=True))
     insert_links = text(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -56,7 +56,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -146,6 +146,7 @@ app.include_router(activity_stream.router)
 app.include_router(events.router)
 app.include_router(agent_gateway.router)
 app.include_router(dispatch.router)
+app.include_router(assets.router)
 app.include_router(conversations.router)
 app.include_router(presence.router)
 app.include_router(sprints.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -36,9 +36,13 @@ from app.models.org_invite import OrgInvite
 from app.models.project_access import ProjectAccess
 from app.models.member import AgentProjectProfile, Member, MemberIdentityAlias
 from app.models.activity_event import ActivityEvent
+from app.models.asset import Asset, AssetFolder, AssetLink
 
 __all__ = [
     "ActivityEvent",
+    "Asset",
+    "AssetFolder",
+    "AssetLink",
     "AgentProjectProfile",
     "Member",
     "MemberIdentityAlias",

--- a/backend/app/models/asset.py
+++ b/backend/app/models/asset.py
@@ -1,0 +1,118 @@
+"""E-STORAGE-SSOT S2: asset registry — assets / asset_folders / asset_links.
+
+S1 IStorageService 위에 빌드. 모든 업로드를 queryable한 asset row로 편입(org/project namespace +
+legacy chat/story path 호환). asset_links = 자산이 어디서 참조되는지의 SSOT(catch#4·JSONB=denorm).
+
+⚠️ created_by 는 FK 없음 — `team_members` 가 뷰라 FK 불가. resolver member id 를 보관(검증은 서비스 계층).
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    ForeignKey,
+    Index,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, OrgScopedMixin, SoftDeleteMixin, TimestampMixin
+
+# asset_links.source_type 허용값(catch: AC6 다형). CHECK + 서비스 가드 양쪽에서 강제.
+ASSET_LINK_SOURCE_TYPES = ("conversation_message", "story", "doc", "manual")
+
+
+class AssetFolder(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
+    """org/project 스코프 폴더 트리. parent_id NULL = 루트."""
+
+    __tablename__ = "asset_folders"
+    __table_args__ = (
+        UniqueConstraint(
+            "org_id", "project_id", "parent_id", "name", name="uq_asset_folders_parent_name"
+        ),
+        Index("ix_asset_folders_project_parent", "org_id", "project_id", "parent_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=True, index=True
+    )
+    parent_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("asset_folders.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+
+
+class Asset(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
+    """blob 1건 = asset row. container+object_path 가 storage 좌표(S1 putObject 반환)."""
+
+    __tablename__ = "assets"
+    __table_args__ = (
+        # 멱등 upsert 키 — 같은 blob(=경로)은 단일 row(backfill/재업로드 중복 방지).
+        UniqueConstraint("container", "object_path", name="uq_assets_container_object_path"),
+        Index(
+            "ix_assets_org_project_ctype_created",
+            "org_id",
+            "project_id",
+            "content_type",
+            text("created_at DESC"),
+        ),
+        Index("ix_assets_folder_id", "folder_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=True, index=True
+    )
+    folder_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("asset_folders.id", ondelete="SET NULL"), nullable=True
+    )
+    # storage 좌표(S1 IStorageService container + objectPath). signRead/read 시 그대로 사용.
+    container: Mapped[str] = mapped_column(Text, nullable=False)
+    object_path: Mapped[str] = mapped_column(Text, nullable=False)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    content_type: Mapped[str | None] = mapped_column(Text, nullable=True)
+    size_bytes: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, server_default=text("0"), default=0
+    )
+    created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+
+    links: Mapped[list["AssetLink"]] = relationship(
+        "AssetLink", back_populates="asset", cascade="all, delete-orphan", lazy="select"
+    )
+
+
+class AssetLink(Base, OrgScopedMixin, TimestampMixin):
+    """asset ↔ 참조원(message/story/doc/manual) 링크. catch#4 SSOT(JSONB=denorm)."""
+
+    __tablename__ = "asset_links"
+    __table_args__ = (
+        UniqueConstraint(
+            "asset_id", "source_type", "source_id", name="uq_asset_links_asset_source"
+        ),
+        CheckConstraint(
+            "source_type IN ('conversation_message','story','doc','manual')",
+            name="ck_asset_links_source_type",
+        ),
+        Index("ix_asset_links_source", "source_type", "source_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    asset_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("assets.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    source_type: Mapped[str] = mapped_column(Text, nullable=False)
+    # manual 링크는 source_id NULL. 그 외는 message/story/doc id.
+    source_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+
+    asset: Mapped["Asset"] = relationship("Asset", back_populates="links")

--- a/backend/app/models/asset.py
+++ b/backend/app/models/asset.py
@@ -57,11 +57,15 @@ class Asset(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
 
     __tablename__ = "assets"
     __table_args__ = (
-        # 멱등 upsert 키 — 같은 blob(=경로)은 org 내 단일 row(backfill/재업로드 중복 방지).
-        # ⚠️ org_id 포함 필수(멀티테넌시): 전역 키면 타 org가 같은 object_path 재사용 시 conflict가
-        # 타 org asset_id로 매핑돼 cross-org dangling link/IDOR 발생(까심 적출). project_id 는
-        # object_path 가 이미 내포하므로 키 제외(nullable NULL-distinct로 org-level 멱등 깨짐 회피).
-        UniqueConstraint("org_id", "container", "object_path", name="uq_assets_org_container_object_path"),
+        # 멱등 upsert 키 — (org_id, project_id) 포함 필수(멀티테넌시·까심 R2/R3).
+        # org_id: cross-org dangling link 차단. project_id: same-org 두 project 가 같은 object_path
+        # (manual/doc 등 path 가 project 미내포 시) 쓸 때 cross-project 누수 차단. chat/story 는
+        # path 가 project 내포라 안전했으나 manual/doc 대비 키에 명시. project_id NULL(org-level)은
+        # NULL-distinct(dedup 안 됨)이나 S2 에 org-level writer 없음·cross-project 누수는 없음(허용).
+        UniqueConstraint(
+            "org_id", "project_id", "container", "object_path",
+            name="uq_assets_org_project_container_object_path",
+        ),
         Index(
             "ix_assets_org_project_ctype_created",
             "org_id",

--- a/backend/app/models/asset.py
+++ b/backend/app/models/asset.py
@@ -57,14 +57,18 @@ class Asset(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
 
     __tablename__ = "assets"
     __table_args__ = (
-        # 멱등 upsert 키 — (org_id, project_id) 포함 필수(멀티테넌시·까심 R2/R3).
-        # org_id: cross-org dangling link 차단. project_id: same-org 두 project 가 같은 object_path
-        # (manual/doc 등 path 가 project 미내포 시) 쓸 때 cross-project 누수 차단. chat/story 는
-        # path 가 project 내포라 안전했으나 manual/doc 대비 키에 명시. project_id NULL(org-level)은
-        # NULL-distinct(dedup 안 됨)이나 S2 에 org-level writer 없음·cross-project 누수는 없음(허용).
-        UniqueConstraint(
-            "org_id", "project_id", "container", "object_path",
-            name="uq_assets_org_project_container_object_path",
+        # 멱등 upsert 키(멀티테넌시·까심 R1~R3). org_id+project_id 둘 다 포함 — cross-org·same-org
+        # cross-project 누수 차단. project_id NULL(org-level capability·nullable=org레벨 허용)은
+        # PG UNIQUE 가 NULL-distinct라 별도 partial unique 로 멱등 보장(2-index 정공):
+        #   - non-null: (org_id, project_id, container, object_path) WHERE project_id IS NOT NULL
+        #   - null:     (org_id, container, object_path)            WHERE project_id IS NULL
+        Index(
+            "uq_assets_proj_nonnull", "org_id", "project_id", "container", "object_path",
+            unique=True, postgresql_where=text("project_id IS NOT NULL"),
+        ),
+        Index(
+            "uq_assets_proj_null", "org_id", "container", "object_path",
+            unique=True, postgresql_where=text("project_id IS NULL"),
         ),
         Index(
             "ix_assets_org_project_ctype_created",

--- a/backend/app/models/asset.py
+++ b/backend/app/models/asset.py
@@ -57,8 +57,11 @@ class Asset(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
 
     __tablename__ = "assets"
     __table_args__ = (
-        # 멱등 upsert 키 — 같은 blob(=경로)은 단일 row(backfill/재업로드 중복 방지).
-        UniqueConstraint("container", "object_path", name="uq_assets_container_object_path"),
+        # 멱등 upsert 키 — 같은 blob(=경로)은 org 내 단일 row(backfill/재업로드 중복 방지).
+        # ⚠️ org_id 포함 필수(멀티테넌시): 전역 키면 타 org가 같은 object_path 재사용 시 conflict가
+        # 타 org asset_id로 매핑돼 cross-org dangling link/IDOR 발생(까심 적출). project_id 는
+        # object_path 가 이미 내포하므로 키 제외(nullable NULL-distinct로 org-level 멱등 깨짐 회피).
+        UniqueConstraint("org_id", "container", "object_path", name="uq_assets_org_container_object_path"),
         Index(
             "ix_assets_org_project_ctype_created",
             "org_id",

--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -1,0 +1,77 @@
+"""E-STORAGE-SSOT S2: asset registry read API (AC2 queryable·list/search).
+
+scope-guard = HARD AC(D3·산티아고 stand-down 대신): 모든 응답이 요청자 org + 접근 가능 project 로
+필터(타 org/project asset 0 노출). project_id 지정 시 has_project_access 검증(IDOR 차단).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.models.asset import Asset
+from app.services.project_auth import accessible_project_ids_in_org, has_project_access
+
+router = APIRouter(prefix="/api/v2/assets", tags=["assets"])
+
+
+class AssetResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    project_id: uuid.UUID | None
+    folder_id: uuid.UUID | None
+    container: str
+    object_path: str
+    name: str
+    content_type: str | None
+    size_bytes: int
+    created_by: uuid.UUID | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@router.get("", response_model=list[AssetResponse])
+async def list_assets(
+    project_id: uuid.UUID | None = Query(None),
+    folder_id: uuid.UUID | None = Query(None),
+    mime: str | None = Query(None, description="content_type prefix (e.g. 'image/')"),
+    q: str | None = Query(None, description="name 부분검색(ILIKE)"),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> list[AssetResponse]:
+    user_id = uuid.UUID(auth.user_id)
+    stmt = select(Asset).where(Asset.org_id == org_id, Asset.deleted_at.is_(None))
+
+    if project_id is not None:
+        # HARD scope: 요청자가 이 project 접근권 보유해야(IDOR 차단·까심 적대 프로빙 대상).
+        if not await has_project_access(db, user_id, project_id, org_id):
+            raise HTTPException(status_code=403, detail="No access to this project")
+        stmt = stmt.where(Asset.project_id == project_id)
+    else:
+        # project 미지정 → 접근 가능 project + org-level(NULL)만(타 project asset 0 노출).
+        accessible = await accessible_project_ids_in_org(db, user_id, org_id)
+        stmt = stmt.where(
+            or_(Asset.project_id.is_(None), Asset.project_id.in_(accessible))
+        )
+
+    if folder_id is not None:
+        stmt = stmt.where(Asset.folder_id == folder_id)
+    if mime:
+        stmt = stmt.where(Asset.content_type.ilike(f"{mime}%"))
+    if q:
+        stmt = stmt.where(Asset.name.ilike(f"%{q}%"))
+
+    stmt = stmt.order_by(Asset.created_at.desc()).limit(limit).offset(offset)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [AssetResponse.model_validate(r) for r in rows]

--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -100,17 +100,21 @@ def _decode_cursor(cursor: str, sort: str) -> tuple[Any, uuid.UUID]:
 
 
 async def _scope_filter(db, auth, org_id, project_id):
-    """org + project 접근권으로 쿼리 스코프(IDOR 차단). 반환=WHERE clause 리스트."""
+    """org + project 접근권으로 쿼리 스코프(IDOR 차단). 반환=(WHERE clauses, accessible project set).
+
+    accessible set 은 enrich source 스코프(타 project source 누수 차단·까심 R3)에도 재사용한다.
+    """
     user_id = uuid.UUID(auth.user_id)
     clauses = [Asset.org_id == org_id, Asset.deleted_at.is_(None)]
     if project_id is not None:
         if not await has_project_access(db, user_id, project_id, org_id):
             raise HTTPException(status_code=403, detail="No access to this project")
         clauses.append(Asset.project_id == project_id)
+        accessible = {project_id}
     else:
-        accessible = await accessible_project_ids_in_org(db, user_id, org_id)
+        accessible = set(await accessible_project_ids_in_org(db, user_id, org_id))
         clauses.append(or_(Asset.project_id.is_(None), Asset.project_id.in_(accessible)))
-    return clauses
+    return clauses, accessible
 
 
 @router.get("/assets", response_model=AssetPage)
@@ -127,7 +131,7 @@ async def list_assets(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> AssetPage:
-    clauses = await _scope_filter(db, auth, org_id, project_id)
+    clauses, accessible = await _scope_filter(db, auth, org_id, project_id)
     if folder_id is not None:
         clauses.append(Asset.folder_id == folder_id)
     if mime:
@@ -152,7 +156,7 @@ async def list_assets(
     )
     assets = list((await db.execute(stmt)).scalars().all())
 
-    enriched = await _enrich(db, org_id, assets)
+    enriched = await _enrich(db, org_id, accessible, assets)
     items = [enriched[a.id] for a in assets]
     next_cursor = None
     if len(assets) == limit:
@@ -181,8 +185,18 @@ async def list_folders(
     return [FolderResponse.model_validate(r) for r in rows]
 
 
-async def _enrich(db: AsyncSession, org_id: uuid.UUID, assets: list[Asset]) -> dict[uuid.UUID, AssetResponse]:
-    """페이지 단위 batch enrich(N+1 회피): created_by(name/avatar) + source_links(title/deeplink)."""
+async def _enrich(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    accessible: set[uuid.UUID],
+    assets: list[Asset],
+) -> dict[uuid.UUID, AssetResponse]:
+    """페이지 단위 batch enrich(N+1 회피): created_by(name/avatar) + source_links(title/deeplink).
+
+    ⚠️ 다형 link 는 FK 없어 오염 row 가능 → enrich 조회를 **org + accessible-project scoped**
+    (타 org·접근불가 project 의 title/content/slug 누수 차단·까심 R2/R3). 스코프 lookup 서 못 찾은
+    source 는 **SourceLink 자체 미생성**(title=None 노출 말고 제거). member 는 org 레벨(project 무관).
+    """
     base = {a.id: AssetResponse.model_validate(a, from_attributes=True) for a in assets}
     if not assets:
         return base
@@ -198,29 +212,32 @@ async def _enrich(db: AsyncSession, org_id: uuid.UUID, assets: list[Asset]) -> d
         if sid is not None:
             by_type.setdefault(stype, set()).add(sid)
 
-    # type별 title/deeplink 소스 batch fetch.
-    # ⚠️ 다형 link 는 FK 없어 오염 row 가능 → 모든 enrich 조회를 **org-scoped**(타 org title/content/
-    # name 누수 차단·까심#7). ConversationMessage 는 자체 org_id 없어 conversations JOIN 으로 스코프.
+    # org + accessible-project 스코프 batch fetch. accessible 빈 set이면 in_([]) → 0건(누수 0).
     story_t = dict((await db.execute(
         select(Story.id, Story.title).where(
-            Story.id.in_(by_type["story"]), Story.org_id == org_id, Story.deleted_at.is_(None)
+            Story.id.in_(by_type["story"]), Story.org_id == org_id,
+            Story.project_id.in_(accessible), Story.deleted_at.is_(None),
         )
-    )).all()) if by_type.get("story") else {}
+    )).all()) if by_type.get("story") and accessible else {}
     doc_rows = (await db.execute(
         select(Doc.id, Doc.title, Doc.slug).where(
-            Doc.id.in_(by_type["doc"]), Doc.org_id == org_id, Doc.deleted_at.is_(None)
+            Doc.id.in_(by_type["doc"]), Doc.org_id == org_id,
+            Doc.project_id.in_(accessible), Doc.deleted_at.is_(None),
         )
-    )).all() if by_type.get("doc") else []
+    )).all() if by_type.get("doc") and accessible else []
     doc_t = {r[0]: (r[1], r[2]) for r in doc_rows}
     msg_rows = (await db.execute(
         select(ConversationMessage.id, ConversationMessage.conversation_id, ConversationMessage.content)
         .join(Conversation, Conversation.id == ConversationMessage.conversation_id)
-        .where(ConversationMessage.id.in_(by_type["conversation_message"]), Conversation.org_id == org_id)
-    )).all() if by_type.get("conversation_message") else []
+        .where(
+            ConversationMessage.id.in_(by_type["conversation_message"]),
+            Conversation.org_id == org_id, Conversation.project_id.in_(accessible),
+        )
+    )).all() if by_type.get("conversation_message") and accessible else []
     msg_t = {r[0]: (r[1], r[2]) for r in msg_rows}
 
-    # created_by enrich — team_members 뷰(name NOT NULL·avatar nullable). org-scoped(타 org member 누수
-    # 차단·까심#7). 멀티프로젝트 agent=뷰 N행 → id로 dedup.
+    # created_by enrich — team_members 뷰(name NOT NULL·avatar nullable)·org-scoped(member=org 레벨).
+    # 멀티프로젝트 agent=뷰 N행 → id로 dedup.
     cb_ids = {a.created_by for a in assets if a.created_by is not None}
     cb_map: dict[uuid.UUID, CreatedBy] = {}
     if cb_ids:
@@ -234,7 +251,8 @@ async def _enrich(db: AsyncSession, org_id: uuid.UUID, assets: list[Asset]) -> d
     links_by_asset: dict[uuid.UUID, list[SourceLink]] = {}
     for aid, stype, sid in links:
         sl = _build_source_link(stype, sid, base[aid].name, story_t, doc_t, msg_t)
-        links_by_asset.setdefault(aid, []).append(sl)
+        if sl is not None:  # 스코프 밖 source → link 미생성(누수 0)
+            links_by_asset.setdefault(aid, []).append(sl)
 
     for a in assets:
         resp = base[a.id]
@@ -243,18 +261,24 @@ async def _enrich(db: AsyncSession, org_id: uuid.UUID, assets: list[Asset]) -> d
     return base
 
 
-def _build_source_link(stype, sid, asset_name, story_t, doc_t, msg_t) -> SourceLink:
+def _build_source_link(stype, sid, asset_name, story_t, doc_t, msg_t) -> SourceLink | None:
+    """스코프된 source 맵에 없으면 None(link 미생성). manual 은 source 없이 파일명으로 항상 생성."""
     if stype == "story":
-        return SourceLink(type=stype, id=sid, title=story_t.get(sid),
-                          deeplink={"story_id": str(sid)} if sid else None)
+        if sid not in story_t:
+            return None
+        return SourceLink(type=stype, id=sid, title=story_t[sid], deeplink={"story_id": str(sid)})
     if stype == "doc":
-        title, slug = doc_t.get(sid, (None, None))
+        if sid not in doc_t:
+            return None
+        title, slug = doc_t[sid]
         return SourceLink(type=stype, id=sid, title=title,
                           deeplink={"doc_slug": slug} if slug else None)
     if stype == "conversation_message":
-        conv_id, content = msg_t.get(sid, (None, None))
+        if sid not in msg_t:
+            return None
+        conv_id, content = msg_t[sid]
         title = (content or "").strip()[:_SNIPPET] or "메시지"
-        deeplink = {"conversation_id": str(conv_id), "message_id": str(sid)} if conv_id and sid else None
+        deeplink = {"conversation_id": str(conv_id), "message_id": str(sid)} if conv_id else None
         return SourceLink(type=stype, id=sid, title=title, deeplink=deeplink)
-    # manual: 파일명 title·deeplink 없음
+    # manual: 파일명 title·deeplink 없음(source 조회 불요·항상 생성)
     return SourceLink(type=stype, id=sid, title=asset_name, deeplink=None)

--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -22,7 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.asset import Asset, AssetFolder, AssetLink
-from app.models.conversation import ConversationMessage
+from app.models.conversation import Conversation, ConversationMessage
 from app.models.doc import Doc
 from app.models.pm import Story
 from app.models.team import TeamMember
@@ -198,26 +198,35 @@ async def _enrich(db: AsyncSession, org_id: uuid.UUID, assets: list[Asset]) -> d
         if sid is not None:
             by_type.setdefault(stype, set()).add(sid)
 
-    # type별 title/deeplink 소스 batch fetch
+    # type별 title/deeplink 소스 batch fetch.
+    # ⚠️ 다형 link 는 FK 없어 오염 row 가능 → 모든 enrich 조회를 **org-scoped**(타 org title/content/
+    # name 누수 차단·까심#7). ConversationMessage 는 자체 org_id 없어 conversations JOIN 으로 스코프.
     story_t = dict((await db.execute(
-        select(Story.id, Story.title).where(Story.id.in_(by_type["story"]))
+        select(Story.id, Story.title).where(
+            Story.id.in_(by_type["story"]), Story.org_id == org_id, Story.deleted_at.is_(None)
+        )
     )).all()) if by_type.get("story") else {}
     doc_rows = (await db.execute(
-        select(Doc.id, Doc.title, Doc.slug).where(Doc.id.in_(by_type["doc"]))
+        select(Doc.id, Doc.title, Doc.slug).where(
+            Doc.id.in_(by_type["doc"]), Doc.org_id == org_id, Doc.deleted_at.is_(None)
+        )
     )).all() if by_type.get("doc") else []
     doc_t = {r[0]: (r[1], r[2]) for r in doc_rows}
     msg_rows = (await db.execute(
         select(ConversationMessage.id, ConversationMessage.conversation_id, ConversationMessage.content)
-        .where(ConversationMessage.id.in_(by_type["conversation_message"]))
+        .join(Conversation, Conversation.id == ConversationMessage.conversation_id)
+        .where(ConversationMessage.id.in_(by_type["conversation_message"]), Conversation.org_id == org_id)
     )).all() if by_type.get("conversation_message") else []
     msg_t = {r[0]: (r[1], r[2]) for r in msg_rows}
 
-    # created_by enrich — team_members 뷰(name NOT NULL·avatar nullable). 멀티프로젝트 agent=뷰 N행 → id로 dedup.
+    # created_by enrich — team_members 뷰(name NOT NULL·avatar nullable). org-scoped(타 org member 누수
+    # 차단·까심#7). 멀티프로젝트 agent=뷰 N행 → id로 dedup.
     cb_ids = {a.created_by for a in assets if a.created_by is not None}
     cb_map: dict[uuid.UUID, CreatedBy] = {}
     if cb_ids:
         for tid, name, avatar in (await db.execute(
-            select(TeamMember.id, TeamMember.name, TeamMember.avatar_url).where(TeamMember.id.in_(cb_ids))
+            select(TeamMember.id, TeamMember.name, TeamMember.avatar_url)
+            .where(TeamMember.id.in_(cb_ids), TeamMember.org_id == org_id)
         )).all():
             if tid not in cb_map:
                 cb_map[tid] = CreatedBy(id=tid, name=name, avatar_url=avatar)

--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -1,24 +1,49 @@
-"""E-STORAGE-SSOT S2: asset registry read API (AC2 queryable·list/search).
+"""E-STORAGE-SSOT S2: asset registry read API (AC2 queryable + S5 FE 계약).
 
-scope-guard = HARD AC(D3·산티아고 stand-down 대신): 모든 응답이 요청자 org + 접근 가능 project 로
-필터(타 org/project asset 0 노출). project_id 지정 시 has_project_access 검증(IDOR 차단).
+scope-guard = HARD AC(D3): 모든 응답이 요청자 org + 접근 가능 project 로 필터(타 org/project asset
+0 노출). project_id 지정 시 has_project_access 검증(IDOR 차단).
+
+S5 FE 계약(0046c9fc): created_by enrich·source_links(title+deeplink)·server-sort(date/name/size)+
+cursor pagination·folder tree endpoint. enrich 는 페이지 단위 batch(N+1 회피).
 """
 from __future__ import annotations
 
+import base64
+import json
 import uuid
 from datetime import datetime
+from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import or_, select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
-from app.models.asset import Asset
+from app.models.asset import Asset, AssetFolder, AssetLink
+from app.models.conversation import ConversationMessage
+from app.models.doc import Doc
+from app.models.pm import Story
+from app.models.team import TeamMember
 from app.services.project_auth import accessible_project_ids_in_org, has_project_access
 
-router = APIRouter(prefix="/api/v2/assets", tags=["assets"])
+router = APIRouter(prefix="/api/v2", tags=["assets"])
+
+_SNIPPET = 80
+
+
+class CreatedBy(BaseModel):
+    id: uuid.UUID
+    name: str
+    avatar_url: str | None = None
+
+
+class SourceLink(BaseModel):
+    type: str
+    id: uuid.UUID | None = None
+    title: str | None = None
+    deeplink: dict[str, str] | None = None
 
 
 class AssetResponse(BaseModel):
@@ -33,45 +58,194 @@ class AssetResponse(BaseModel):
     name: str
     content_type: str | None
     size_bytes: int
-    created_by: uuid.UUID | None
     created_at: datetime
     updated_at: datetime
+    created_by: CreatedBy | None = None
+    source_links: list[SourceLink] = []
 
 
-@router.get("", response_model=list[AssetResponse])
+class AssetPage(BaseModel):
+    items: list[AssetResponse]
+    next_cursor: str | None = None
+
+
+class FolderResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    parent_id: uuid.UUID | None
+    project_id: uuid.UUID | None
+
+
+_SORT_COLS = {"date": Asset.updated_at, "name": Asset.name, "size": Asset.size_bytes}
+
+
+def _encode_cursor(sort_value: Any, last_id: uuid.UUID) -> str:
+    raw = {"v": sort_value.isoformat() if isinstance(sort_value, datetime) else sort_value, "id": str(last_id)}
+    return base64.urlsafe_b64encode(json.dumps(raw).encode()).decode()
+
+
+def _decode_cursor(cursor: str, sort: str) -> tuple[Any, uuid.UUID]:
+    try:
+        raw = json.loads(base64.urlsafe_b64decode(cursor.encode()).decode())
+        v = raw["v"]
+        if sort == "date":
+            v = datetime.fromisoformat(v)
+        elif sort == "size":
+            v = int(v)
+        return v, uuid.UUID(raw["id"])
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="invalid cursor") from exc
+
+
+async def _scope_filter(db, auth, org_id, project_id):
+    """org + project 접근권으로 쿼리 스코프(IDOR 차단). 반환=WHERE clause 리스트."""
+    user_id = uuid.UUID(auth.user_id)
+    clauses = [Asset.org_id == org_id, Asset.deleted_at.is_(None)]
+    if project_id is not None:
+        if not await has_project_access(db, user_id, project_id, org_id):
+            raise HTTPException(status_code=403, detail="No access to this project")
+        clauses.append(Asset.project_id == project_id)
+    else:
+        accessible = await accessible_project_ids_in_org(db, user_id, org_id)
+        clauses.append(or_(Asset.project_id.is_(None), Asset.project_id.in_(accessible)))
+    return clauses
+
+
+@router.get("/assets", response_model=AssetPage)
 async def list_assets(
     project_id: uuid.UUID | None = Query(None),
     folder_id: uuid.UUID | None = Query(None),
     mime: str | None = Query(None, description="content_type prefix (e.g. 'image/')"),
     q: str | None = Query(None, description="name 부분검색(ILIKE)"),
+    sort: Literal["date", "name", "size"] = Query("date"),
+    order: Literal["asc", "desc"] = Query("desc"),
+    cursor: str | None = Query(None),
     limit: int = Query(50, ge=1, le=200),
-    offset: int = Query(0, ge=0),
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-) -> list[AssetResponse]:
-    user_id = uuid.UUID(auth.user_id)
-    stmt = select(Asset).where(Asset.org_id == org_id, Asset.deleted_at.is_(None))
+) -> AssetPage:
+    clauses = await _scope_filter(db, auth, org_id, project_id)
+    if folder_id is not None:
+        clauses.append(Asset.folder_id == folder_id)
+    if mime:
+        clauses.append(Asset.content_type.ilike(f"{mime}%"))
+    if q:
+        clauses.append(Asset.name.ilike(f"%{q}%"))
 
+    sort_col = _SORT_COLS[sort]
+    if cursor:
+        cv, cid = _decode_cursor(cursor, sort)
+        if order == "asc":
+            clauses.append(or_(sort_col > cv, and_(sort_col == cv, Asset.id > cid)))
+        else:
+            clauses.append(or_(sort_col < cv, and_(sort_col == cv, Asset.id < cid)))
+
+    direction = (lambda c: c.asc()) if order == "asc" else (lambda c: c.desc())
+    stmt = (
+        select(Asset)
+        .where(and_(*clauses))
+        .order_by(direction(sort_col), direction(Asset.id))
+        .limit(limit)
+    )
+    assets = list((await db.execute(stmt)).scalars().all())
+
+    enriched = await _enrich(db, org_id, assets)
+    items = [enriched[a.id] for a in assets]
+    next_cursor = None
+    if len(assets) == limit:
+        last = assets[-1]
+        next_cursor = _encode_cursor(getattr(last, {"date": "updated_at", "name": "name", "size": "size_bytes"}[sort]), last.id)
+    return AssetPage(items=items, next_cursor=next_cursor)
+
+
+@router.get("/folders", response_model=list[FolderResponse])
+async def list_folders(
+    project_id: uuid.UUID | None = Query(None),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> list[FolderResponse]:
+    user_id = uuid.UUID(auth.user_id)
+    clauses = [AssetFolder.org_id == org_id, AssetFolder.deleted_at.is_(None)]
     if project_id is not None:
-        # HARD scope: 요청자가 이 project 접근권 보유해야(IDOR 차단·까심 적대 프로빙 대상).
         if not await has_project_access(db, user_id, project_id, org_id):
             raise HTTPException(status_code=403, detail="No access to this project")
-        stmt = stmt.where(Asset.project_id == project_id)
+        clauses.append(AssetFolder.project_id == project_id)
     else:
-        # project 미지정 → 접근 가능 project + org-level(NULL)만(타 project asset 0 노출).
         accessible = await accessible_project_ids_in_org(db, user_id, org_id)
-        stmt = stmt.where(
-            or_(Asset.project_id.is_(None), Asset.project_id.in_(accessible))
-        )
+        clauses.append(or_(AssetFolder.project_id.is_(None), AssetFolder.project_id.in_(accessible)))
+    rows = (await db.execute(select(AssetFolder).where(and_(*clauses)).order_by(AssetFolder.name))).scalars().all()
+    return [FolderResponse.model_validate(r) for r in rows]
 
-    if folder_id is not None:
-        stmt = stmt.where(Asset.folder_id == folder_id)
-    if mime:
-        stmt = stmt.where(Asset.content_type.ilike(f"{mime}%"))
-    if q:
-        stmt = stmt.where(Asset.name.ilike(f"%{q}%"))
 
-    stmt = stmt.order_by(Asset.created_at.desc()).limit(limit).offset(offset)
-    rows = (await db.execute(stmt)).scalars().all()
-    return [AssetResponse.model_validate(r) for r in rows]
+async def _enrich(db: AsyncSession, org_id: uuid.UUID, assets: list[Asset]) -> dict[uuid.UUID, AssetResponse]:
+    """페이지 단위 batch enrich(N+1 회피): created_by(name/avatar) + source_links(title/deeplink)."""
+    base = {a.id: AssetResponse.model_validate(a, from_attributes=True) for a in assets}
+    if not assets:
+        return base
+
+    asset_ids = [a.id for a in assets]
+    links = (await db.execute(
+        select(AssetLink.asset_id, AssetLink.source_type, AssetLink.source_id)
+        .where(AssetLink.asset_id.in_(asset_ids), AssetLink.org_id == org_id)
+    )).all()
+
+    by_type: dict[str, set[uuid.UUID]] = {}
+    for _aid, stype, sid in links:
+        if sid is not None:
+            by_type.setdefault(stype, set()).add(sid)
+
+    # type별 title/deeplink 소스 batch fetch
+    story_t = dict((await db.execute(
+        select(Story.id, Story.title).where(Story.id.in_(by_type["story"]))
+    )).all()) if by_type.get("story") else {}
+    doc_rows = (await db.execute(
+        select(Doc.id, Doc.title, Doc.slug).where(Doc.id.in_(by_type["doc"]))
+    )).all() if by_type.get("doc") else []
+    doc_t = {r[0]: (r[1], r[2]) for r in doc_rows}
+    msg_rows = (await db.execute(
+        select(ConversationMessage.id, ConversationMessage.conversation_id, ConversationMessage.content)
+        .where(ConversationMessage.id.in_(by_type["conversation_message"]))
+    )).all() if by_type.get("conversation_message") else []
+    msg_t = {r[0]: (r[1], r[2]) for r in msg_rows}
+
+    # created_by enrich — team_members 뷰(name NOT NULL·avatar nullable). 멀티프로젝트 agent=뷰 N행 → id로 dedup.
+    cb_ids = {a.created_by for a in assets if a.created_by is not None}
+    cb_map: dict[uuid.UUID, CreatedBy] = {}
+    if cb_ids:
+        for tid, name, avatar in (await db.execute(
+            select(TeamMember.id, TeamMember.name, TeamMember.avatar_url).where(TeamMember.id.in_(cb_ids))
+        )).all():
+            if tid not in cb_map:
+                cb_map[tid] = CreatedBy(id=tid, name=name, avatar_url=avatar)
+
+    links_by_asset: dict[uuid.UUID, list[SourceLink]] = {}
+    for aid, stype, sid in links:
+        sl = _build_source_link(stype, sid, base[aid].name, story_t, doc_t, msg_t)
+        links_by_asset.setdefault(aid, []).append(sl)
+
+    for a in assets:
+        resp = base[a.id]
+        resp.created_by = cb_map.get(a.created_by) if a.created_by else None
+        resp.source_links = links_by_asset.get(a.id, [])
+    return base
+
+
+def _build_source_link(stype, sid, asset_name, story_t, doc_t, msg_t) -> SourceLink:
+    if stype == "story":
+        return SourceLink(type=stype, id=sid, title=story_t.get(sid),
+                          deeplink={"story_id": str(sid)} if sid else None)
+    if stype == "doc":
+        title, slug = doc_t.get(sid, (None, None))
+        return SourceLink(type=stype, id=sid, title=title,
+                          deeplink={"doc_slug": slug} if slug else None)
+    if stype == "conversation_message":
+        conv_id, content = msg_t.get(sid, (None, None))
+        title = (content or "").strip()[:_SNIPPET] or "메시지"
+        deeplink = {"conversation_id": str(conv_id), "message_id": str(sid)} if conv_id and sid else None
+        return SourceLink(type=stype, id=sid, title=title, deeplink=deeplink)
+    # manual: 파일명 title·deeplink 없음
+    return SourceLink(type=stype, id=sid, title=asset_name, deeplink=None)

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -25,6 +25,7 @@ from app.routers.events import _push_to_agent, publish_event
 from app.schemas.attachment import validate_attachment_url
 from app.services import chat_presence
 from app.services.agent_runtime import supports_deterministic_command
+from app.services.asset_registry import sync_attachment_assets
 from app.services.command_classifier import classify_command
 from app.services.event_seq import assign_recipient_seq
 from app.services.member_resolver import (
@@ -1223,6 +1224,18 @@ async def send_message(
         )
 
     await db.flush()
+
+    # E-STORAGE-SSOT S2: 첨부를 asset registry로 동기화(SAVE-time·같은 트랜잭션·orphan 0).
+    if body.attachments:
+        await sync_attachment_assets(
+            db,
+            org_id=org_id,
+            project_id=conv.project_id,
+            source_type="conversation_message",
+            source_id=msg.id,
+            attachments=[a.model_dump() for a in body.attachments],
+            created_by=sender.id,
+        )
 
     # AC10: Discord 수신자 파악 → SSE dispatch에서 제외 (동일 db 세션, flush 완료 상태)
     discord_exclude_ids: set[uuid.UUID] = set()

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -16,6 +16,7 @@ from app.repositories.story_assignee import StoryAssigneeRepository
 from app.routers.agent_gateway import wake_agent
 from app.routers.events import publish_event
 from app.services.event_seq import assign_recipient_seq
+from app.services.asset_registry import sync_attachment_assets
 from app.schemas.story import StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
 from app.services.member_resolver import canonicalize_member_id
 from app.services.merge_verdict_gate import (
@@ -239,6 +240,16 @@ async def create_story(
         # E-FILE S4: 보드 스토리 첨부 (FE-proxy URL+메타) 저장
         attachments=[a.model_dump() for a in body.attachments],
     )
+    # E-STORAGE-SSOT S2: 첨부를 asset registry로 동기화(SAVE-time·같은 트랜잭션·orphan 0).
+    if body.attachments:
+        await sync_attachment_assets(
+            session,
+            org_id=org_id,
+            project_id=story.project_id,
+            source_type="story",
+            source_id=story.id,
+            attachments=[a.model_dump() for a in body.attachments],
+        )
     # E-BOARD S5: 복수 assignee join 기록 (단일 assignee_id와 공존)
     saved_ids = await StoryAssigneeRepository(session, org_id).set_for_story(story.id, effective_ids)
     # E-CAGE-REFEREE: assignee 설정 시 implementation 역할 participation 자동 생성
@@ -460,6 +471,17 @@ async def update_story(
     story = await repo.update(id, **data)
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")
+
+    # E-STORAGE-SSOT S2: 첨부 교체(attachments 제공) 시 asset registry 재동기화(reconcile·SSOT 정확).
+    if "attachments" in data:
+        await sync_attachment_assets(
+            db,
+            org_id=repo.org_id,
+            project_id=story.project_id,
+            source_type="story",
+            source_id=story.id,
+            attachments=data.get("attachments") or [],
+        )
 
     # E-BOARD S5: 복수 assignee join 동기화 (단일 assignee_id와 정합 유지)
     if assignee_ids_in is not None:

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -242,6 +242,11 @@ async def create_story(
     )
     # E-STORAGE-SSOT S2: 첨부를 asset registry로 동기화(SAVE-time·같은 트랜잭션·orphan 0).
     if body.attachments:
+        _cb: uuid.UUID | None = None
+        try:  # created_by enrich용 업로더 member id(비보안·best-effort).
+            _cb = await _resolve_team_member_id(auth, org_id, session)
+        except Exception:
+            _cb = None
         await sync_attachment_assets(
             session,
             org_id=org_id,
@@ -249,6 +254,7 @@ async def create_story(
             source_type="story",
             source_id=story.id,
             attachments=[a.model_dump() for a in body.attachments],
+            created_by=_cb,
         )
     # E-BOARD S5: 복수 assignee join 기록 (단일 assignee_id와 공존)
     saved_ids = await StoryAssigneeRepository(session, org_id).set_for_story(story.id, effective_ids)
@@ -474,6 +480,11 @@ async def update_story(
 
     # E-STORAGE-SSOT S2: 첨부 교체(attachments 제공) 시 asset registry 재동기화(reconcile·SSOT 정확).
     if "attachments" in data:
+        _cb: uuid.UUID | None = None
+        try:
+            _cb = await _resolve_team_member_id(auth, repo.org_id, db)
+        except Exception:
+            _cb = None
         await sync_attachment_assets(
             db,
             org_id=repo.org_id,
@@ -481,6 +492,7 @@ async def update_story(
             source_type="story",
             source_id=story.id,
             attachments=data.get("attachments") or [],
+            created_by=_cb,
         )
 
     # E-BOARD S5: 복수 assignee join 동기화 (단일 assignee_id와 정합 유지)

--- a/backend/app/services/asset_registry.py
+++ b/backend/app/services/asset_registry.py
@@ -1,0 +1,120 @@
+"""E-STORAGE-SSOT S2: asset registry 서비스 — 첨부 persist 시 asset/asset_link 동기화(SAVE-time).
+
+D1 결정: upload 엔드포인트가 아니라 메시지/스토리 SAVE 트랜잭션 안에서 asset + asset_link 를
+원자 생성(orphan 0). attachments(JSONB) 와 같은 세션·같은 커밋에 묶인다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.asset import ASSET_LINK_SOURCE_TYPES, Asset, AssetLink
+
+# S1 GCS_MEMO_ATTACHMENTS_BUCKET 기본과 정합. 현재 단일 컨테이너(첨부 버킷).
+DEFAULT_CONTAINER = os.environ.get("GCS_MEMO_ATTACHMENTS_BUCKET", "sprintable-memo-attachments")
+_PUBLIC_PREFIX = f"https://storage.googleapis.com/{DEFAULT_CONTAINER}/"
+
+
+def canonical_object_path(stored_url: str, container: str = DEFAULT_CONTAINER) -> str | None:
+    """저장 url → canonical object_path. 우리 객체가 아니면 None.
+
+    S1 `_canonical_object_path` 규칙과 정합: GCS public prefix 제거 / bare 그대로 / 외부 스킴 None.
+    """
+    if not stored_url:
+        return None
+    prefix = f"https://storage.googleapis.com/{container}/"
+    if stored_url.startswith(prefix):
+        return stored_url[len(prefix):] or None
+    if "://" in stored_url:
+        return None
+    return stored_url
+
+
+async def sync_attachment_assets(
+    session: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID | None,
+    source_type: str,
+    source_id: uuid.UUID,
+    attachments: list[dict] | None,
+    created_by: uuid.UUID | None = None,
+    container: str = DEFAULT_CONTAINER,
+) -> list[uuid.UUID]:
+    """첨부 목록을 asset registry 로 동기화(upsert) + asset_link 재조정(reconcile).
+
+    - 각 첨부 → asset upsert(멱등 키 container/object_path) → asset_link upsert.
+    - source 의 현재 첨부 집합에 없는 기존 link 는 삭제(update 의 attachments 교체 의미 반영·SSOT 정확).
+    - 외부 URL/타 버킷 첨부는 우리 객체가 아니므로 스킵.
+    반환: 현재 첨부에 대응하는 asset_id 목록.
+    """
+    if source_type not in ASSET_LINK_SOURCE_TYPES:
+        raise ValueError(f"invalid asset link source_type: {source_type}")
+
+    asset_ids: list[uuid.UUID] = []
+    for att in attachments or []:
+        if not isinstance(att, dict):
+            continue
+        obj = canonical_object_path(att.get("url") or "", container)
+        if obj is None:
+            continue  # 외부/비정상 — 우리 객체 아님
+        name = (att.get("name") or "").strip() or obj.rsplit("/", 1)[-1] or "file"
+        content_type = (att.get("content_type") or "").strip() or None
+        try:
+            size_bytes = int(att.get("size") or 0)
+        except (TypeError, ValueError):
+            size_bytes = 0
+
+        # asset upsert — 멱등(container/object_path). 충돌 시 RETURNING 없음 → 후속 SELECT.
+        ins = (
+            pg_insert(Asset)
+            .values(
+                org_id=org_id,
+                project_id=project_id,
+                container=container,
+                object_path=obj,
+                name=name,
+                content_type=content_type,
+                size_bytes=size_bytes,
+                created_by=created_by,
+            )
+            .on_conflict_do_nothing(constraint="uq_assets_container_object_path")
+            .returning(Asset.id)
+        )
+        asset_id = (await session.execute(ins)).scalar_one_or_none()
+        if asset_id is None:
+            asset_id = (
+                await session.execute(
+                    select(Asset.id).where(
+                        Asset.container == container, Asset.object_path == obj
+                    )
+                )
+            ).scalar_one()
+        asset_ids.append(asset_id)
+
+        await session.execute(
+            pg_insert(AssetLink)
+            .values(
+                org_id=org_id,
+                asset_id=asset_id,
+                source_type=source_type,
+                source_id=source_id,
+                created_by=created_by,
+            )
+            .on_conflict_do_nothing(constraint="uq_asset_links_asset_source")
+        )
+
+    # reconcile: 이 source 의 현재 집합에 없는 link 제거(update 의 attachments 교체 의미).
+    stale = delete(AssetLink).where(
+        AssetLink.source_type == source_type,
+        AssetLink.source_id == source_id,
+    )
+    if asset_ids:
+        stale = stale.where(AssetLink.asset_id.not_in(asset_ids))
+    await session.execute(stale)
+
+    return asset_ids

--- a/backend/app/services/asset_registry.py
+++ b/backend/app/services/asset_registry.py
@@ -34,6 +34,26 @@ def canonical_object_path(stored_url: str, container: str = DEFAULT_CONTAINER) -
     return stored_url
 
 
+def path_in_source_scope(
+    object_path: str,
+    source_type: str,
+    project_id: uuid.UUID | None,
+    source_id: uuid.UUID,
+) -> bool:
+    """object_path 가 이 source(=메시지/스토리)에 귀속된 경로인지 검증(IDOR·registry 오염 차단).
+
+    S1 `_is_scoped_to_conversation` 와 동형: 업로드 경로가 resource 에 스코프되므로
+    (`chat/<project>/<conversation>/...`·`story/<project>/<story>/...`) path 가 정확히 이 source 를
+    가리킬 때만 등록한다. 유저가 자기 메시지에 타 project/conv 객체 경로를 심어 registry 를
+    오염시키는 것 방지(까심 적출). manual/doc 은 경로 제약 없음(신뢰 등록·doc=S4).
+    """
+    if source_type == "conversation_message":
+        return object_path.startswith(f"chat/{project_id}/{source_id}/")
+    if source_type == "story":
+        return object_path.startswith(f"story/{project_id}/{source_id}/")
+    return True
+
+
 async def sync_attachment_assets(
     session: AsyncSession,
     *,
@@ -62,6 +82,8 @@ async def sync_attachment_assets(
         obj = canonical_object_path(att.get("url") or "", container)
         if obj is None:
             continue  # 외부/비정상 — 우리 객체 아님
+        if not path_in_source_scope(obj, source_type, project_id, source_id):
+            continue  # 이 source 귀속 경로 아님 — registry 오염/IDOR 차단(까심)
         name = (att.get("name") or "").strip() or obj.rsplit("/", 1)[-1] or "file"
         content_type = (att.get("content_type") or "").strip() or None
         try:
@@ -82,15 +104,18 @@ async def sync_attachment_assets(
                 size_bytes=size_bytes,
                 created_by=created_by,
             )
-            .on_conflict_do_nothing(constraint="uq_assets_container_object_path")
+            .on_conflict_do_nothing(constraint="uq_assets_org_container_object_path")
             .returning(Asset.id)
         )
         asset_id = (await session.execute(ins)).scalar_one_or_none()
         if asset_id is None:
+            # conflict(이미 존재) → **org-scoped** 재조회(타 org row 매핑 금지·cross-org link 차단).
             asset_id = (
                 await session.execute(
                     select(Asset.id).where(
-                        Asset.container == container, Asset.object_path == obj
+                        Asset.org_id == org_id,
+                        Asset.container == container,
+                        Asset.object_path == obj,
                     )
                 )
             ).scalar_one()

--- a/backend/app/services/asset_registry.py
+++ b/backend/app/services/asset_registry.py
@@ -91,35 +91,36 @@ async def sync_attachment_assets(
         except (TypeError, ValueError):
             size_bytes = 0
 
-        # asset upsert — 멱등(container/object_path). 충돌 시 RETURNING 없음 → 후속 SELECT.
-        ins = (
-            pg_insert(Asset)
-            .values(
-                org_id=org_id,
-                project_id=project_id,
-                container=container,
-                object_path=obj,
-                name=name,
-                content_type=content_type,
-                size_bytes=size_bytes,
-                created_by=created_by,
-            )
-            .on_conflict_do_nothing(constraint="uq_assets_org_project_container_object_path")
-            .returning(Asset.id)
+        # asset upsert — 멱등. project_id null/non-null 별 partial unique 로 ON CONFLICT 분기(까심 R3).
+        base_ins = pg_insert(Asset).values(
+            org_id=org_id,
+            project_id=project_id,
+            container=container,
+            object_path=obj,
+            name=name,
+            content_type=content_type,
+            size_bytes=size_bytes,
+            created_by=created_by,
         )
+        if project_id is not None:
+            ins = base_ins.on_conflict_do_nothing(
+                index_elements=[Asset.org_id, Asset.project_id, Asset.container, Asset.object_path],
+                index_where=Asset.project_id.isnot(None),
+            ).returning(Asset.id)
+        else:
+            ins = base_ins.on_conflict_do_nothing(
+                index_elements=[Asset.org_id, Asset.container, Asset.object_path],
+                index_where=Asset.project_id.is_(None),
+            ).returning(Asset.id)
         asset_id = (await session.execute(ins)).scalar_one_or_none()
         if asset_id is None:
-            # conflict(이미 존재) → **org+project-scoped** 재조회(타 org/project row 매핑 금지·누수 차단).
-            asset_id = (
-                await session.execute(
-                    select(Asset.id).where(
-                        Asset.org_id == org_id,
-                        Asset.project_id == project_id,
-                        Asset.container == container,
-                        Asset.object_path == obj,
-                    )
-                )
-            ).scalar_one()
+            # conflict(이미 존재) → org+project-scoped 재조회(타 org/project row 매핑 금지·누수 차단).
+            sel = select(Asset.id).where(
+                Asset.org_id == org_id, Asset.container == container, Asset.object_path == obj
+            )
+            sel = sel.where(Asset.project_id == project_id) if project_id is not None \
+                else sel.where(Asset.project_id.is_(None))
+            asset_id = (await session.execute(sel)).scalar_one()
         asset_ids.append(asset_id)
 
         await session.execute(

--- a/backend/app/services/asset_registry.py
+++ b/backend/app/services/asset_registry.py
@@ -104,16 +104,17 @@ async def sync_attachment_assets(
                 size_bytes=size_bytes,
                 created_by=created_by,
             )
-            .on_conflict_do_nothing(constraint="uq_assets_org_container_object_path")
+            .on_conflict_do_nothing(constraint="uq_assets_org_project_container_object_path")
             .returning(Asset.id)
         )
         asset_id = (await session.execute(ins)).scalar_one_or_none()
         if asset_id is None:
-            # conflict(이미 존재) → **org-scoped** 재조회(타 org row 매핑 금지·cross-org link 차단).
+            # conflict(이미 존재) → **org+project-scoped** 재조회(타 org/project row 매핑 금지·누수 차단).
             asset_id = (
                 await session.execute(
                     select(Asset.id).where(
                         Asset.org_id == org_id,
+                        Asset.project_id == project_id,
                         Asset.container == container,
                         Asset.object_path == obj,
                     )

--- a/backend/tests/test_asset_canonical.py
+++ b/backend/tests/test_asset_canonical.py
@@ -1,0 +1,38 @@
+"""E-STORAGE-SSOT S2 — canonical_object_path 단위(DB 무관·CI backend-test 실행).
+
+S1 _canonical_object_path 규칙 정합: GCS public prefix 제거 / bare 그대로 / 외부 스킴 None.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.asset_registry import canonical_object_path
+
+_BUCKET = "sprintable-memo-attachments"
+_PREFIX = f"https://storage.googleapis.com/{_BUCKET}/"
+
+
+def test_strips_gcs_public_prefix():
+    assert canonical_object_path(_PREFIX + "chat/p/c/u-a.png", _BUCKET) == "chat/p/c/u-a.png"
+
+
+def test_bare_path_passthrough():
+    assert canonical_object_path("story/p/s/u-a.png", _BUCKET) == "story/p/s/u-a.png"
+
+
+@pytest.mark.parametrize(
+    "external",
+    [
+        "http://evil/a.png",
+        "gs://other-bucket/a.png",
+        "file:///etc/passwd",
+        "https://storage.googleapis.com/other-bucket/a.png",  # 타 버킷
+    ],
+)
+def test_external_or_other_bucket_is_none(external):
+    assert canonical_object_path(external, _BUCKET) is None
+
+
+def test_empty_is_none():
+    assert canonical_object_path("", _BUCKET) is None
+    assert canonical_object_path(_PREFIX, _BUCKET) is None  # prefix-only → 빈 path

--- a/backend/tests/test_asset_registry_realdb.py
+++ b/backend/tests/test_asset_registry_realdb.py
@@ -31,6 +31,8 @@ USER = uuid.UUID("a2000000-0000-0000-0000-0000000000a1")
 OM = uuid.UUID("a2000000-0000-0000-0000-0000000000b1")
 PROJ_A = uuid.UUID("a2000000-0000-0000-0000-0000000000c1")
 PROJ_B = uuid.UUID("a2000000-0000-0000-0000-0000000000c2")
+ORG2 = uuid.UUID("a2000000-0000-0000-0000-000000000002")
+PROJ_OTHER = uuid.UUID("a2000000-0000-0000-0000-0000000000d1")  # ORG2 소속
 BUCKET = "sprintable-memo-attachments"
 
 
@@ -284,6 +286,94 @@ async def test_cross_org_same_path_isolated_no_dangling_link():
             await s.execute(text(f"DELETE FROM asset_links WHERE org_id='{ORG2}'"))
             await s.execute(text(f"DELETE FROM assets WHERE org_id='{ORG2}'"))
             await s.execute(text(f"DELETE FROM organizations WHERE id='{ORG2}'"))
+            await s.commit()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_same_org_cross_project_no_collision():
+    """같은 org 두 project 가 동일 object_path(project 미내포) 등록 → project별 별도 asset·
+    cross-project link 누수 0(까심 R2#1·4-col unique 키)."""
+    from app.services.asset_registry import sync_attachment_assets
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            src_a, src_b = uuid.uuid4(), uuid.uuid4()
+            shared = "manual/shared/x.png"  # project 미내포 경로
+            await sync_attachment_assets(s, org_id=ORG, project_id=PROJ_A, source_type="manual",
+                                         source_id=src_a, attachments=[_att(shared)])
+            await sync_attachment_assets(s, org_id=ORG, project_id=PROJ_B, source_type="manual",
+                                         source_id=src_b, attachments=[_att(shared)])
+            await s.commit()
+            n = (await s.execute(text(
+                f"SELECT count(*) FROM assets WHERE org_id='{ORG}' AND object_path='{shared}'"
+            ))).scalar_one()
+            assert n == 2  # project별 별도 row(충돌 없음)
+            leak = (await s.execute(text(
+                f"SELECT count(*) FROM asset_links al JOIN assets a ON a.id=al.asset_id "
+                f"WHERE al.source_id='{src_b}' AND a.project_id <> '{PROJ_B}'"
+            ))).scalar_one()
+            assert leak == 0  # B link 가 타 project asset 에 안 붙음
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_enrich_no_cross_org_leak():
+    """오염 asset_link(타 org source id)가 있어도 enrich 가 타 org title/content/name 미누출(까심 R2#7)."""
+    from app.dependencies.auth import AuthContext
+    from app.routers.assets import list_assets
+    from app.services.asset_registry import sync_attachment_assets
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            other_story = uuid.uuid4()
+            for sql in [
+                f"DELETE FROM stories WHERE id='{other_story}'",
+                f"DELETE FROM projects WHERE id='{PROJ_OTHER}'",
+                f"DELETE FROM organizations WHERE id='{ORG2}'",
+                f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG2}','A2b','a2borg','free')",
+                f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_OTHER}','{ORG2}','OtherP')",
+                f"INSERT INTO stories (id,org_id,project_id,title,status,priority) "
+                f"VALUES ('{other_story}','{ORG2}','{PROJ_OTHER}','SECRET TITLE','backlog','medium')",
+            ]:
+                await s.execute(text(sql))
+            src = uuid.uuid4()
+            base = f"story/{PROJ_A}/{src}"
+            await sync_attachment_assets(s, org_id=ORG, project_id=PROJ_A, source_type="story",
+                                         source_id=src, attachments=[_att(f"{base}/u-a.png")])
+            await s.commit()
+            asset_id = (await s.execute(text(
+                f"SELECT id FROM assets WHERE org_id='{ORG}' AND object_path='{base}/u-a.png'"
+            ))).scalar_one()
+            # pollute: ORG asset_link → ORG2 story id(다형 link·FK 없음)
+            await s.execute(text(
+                "INSERT INTO asset_links (org_id, asset_id, source_type, source_id) "
+                f"VALUES ('{ORG}','{asset_id}','story','{other_story}') ON CONFLICT DO NOTHING"
+            ))
+            await s.commit()
+
+            auth = AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+            page = await list_assets(project_id=PROJ_A, folder_id=None, mime=None, q=None,
+                                     sort="date", order="desc", cursor=None, limit=50,
+                                     db=s, auth=auth, org_id=ORG)
+            leaked = [sl.title for it in page.items for sl in it.source_links
+                      if str(sl.id) == str(other_story)]
+            assert leaked and all(t is None for t in leaked)  # 타 org story title 미누출
+
+            for sql in [
+                f"DELETE FROM stories WHERE id='{other_story}'",
+                f"DELETE FROM projects WHERE id='{PROJ_OTHER}'",
+                f"DELETE FROM organizations WHERE id='{ORG2}'",
+            ]:
+                await s.execute(text(sql))
             await s.commit()
     finally:
         await engine.dispose()

--- a/backend/tests/test_asset_registry_realdb.py
+++ b/backend/tests/test_asset_registry_realdb.py
@@ -1,0 +1,239 @@
+"""E-STORAGE-SSOT S2 — asset registry real-DB(0139 적용 DB 전제).
+
+DB env(ALEMBIC_DATABASE_URL) 없으면 skip — CI alembic-fresh-db 잡 env에서 실행/로컬 PG.
+커버: SAVE-time sync(AC1)·idempotent·reconcile·external skip·source_type 다형(AC6)·
+list scope IDOR(AC2/D3 HARD)·legacy backfill(AC3).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+_SYNC = _RAW.replace("postgresql+asyncpg://", "postgresql+psycopg2://").replace(
+    "postgresql://", "postgresql+psycopg2://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("a2000000-0000-0000-0000-000000000001")
+USER = uuid.UUID("a2000000-0000-0000-0000-0000000000a1")
+OM = uuid.UUID("a2000000-0000-0000-0000-0000000000b1")
+PROJ_A = uuid.UUID("a2000000-0000-0000-0000-0000000000c1")
+PROJ_B = uuid.UUID("a2000000-0000-0000-0000-0000000000c2")
+BUCKET = "sprintable-memo-attachments"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _reset_and_seed(session):
+    # 멱등 클린업 후 org/projects/user/grant 시드. assets/asset_links 는 본 org 범위만 정리.
+    for sql in [
+        f"DELETE FROM asset_links WHERE org_id='{ORG}'",
+        f"DELETE FROM assets WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id IN ('{PROJ_A}','{PROJ_B}')",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','A2','a2org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,login_fail_count,totp_enabled,totp_fail_count) "
+        f"VALUES ('{USER}','u@a2.test','x','U',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_A}','{ORG}','A')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_B}','{ORG}','B')",
+        # USER 는 PROJ_A 에만 grant(PROJ_B 접근 없음 — IDOR 테스트축).
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ_A}','{OM}','granted')",
+    ]:
+        await session.execute(text(sql))
+    await session.commit()
+
+
+def _att(path, name="a.png", ctype="image/png", size=10):
+    return {"url": path, "name": name, "content_type": ctype, "size": size}
+
+
+@pytest.mark.anyio
+async def test_sync_creates_asset_and_link_idempotent_reconcile():
+    from app.services.asset_registry import sync_attachment_assets
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            src = uuid.uuid4()
+            # 1) create: bare + GCS-prefixed + 외부(skip) 혼합
+            ids = await sync_attachment_assets(
+                s, org_id=ORG, project_id=PROJ_A, source_type="story", source_id=src,
+                attachments=[
+                    _att("story/p/s/u-a.png"),
+                    _att(f"https://storage.googleapis.com/{BUCKET}/story/p/s/u-b.png", name="b.png"),
+                    _att("https://evil.example/x.png", name="ext.png"),  # 외부 → skip
+                ],
+            )
+            await s.commit()
+            assert len(ids) == 2  # 외부 1건 제외
+            cnt = (await s.execute(text(
+                f"SELECT count(*) FROM asset_links WHERE source_type='story' AND source_id='{src}'"
+            ))).scalar_one()
+            assert cnt == 2
+            # source_type 다형 CHECK 유효(AC6)
+            st = (await s.execute(text(
+                f"SELECT DISTINCT source_type FROM asset_links WHERE source_id='{src}'"
+            ))).scalar_one()
+            assert st == "story"
+
+            # 2) idempotent: 같은 첨부 재동기화 → row 증가 0
+            await sync_attachment_assets(
+                s, org_id=ORG, project_id=PROJ_A, source_type="story", source_id=src,
+                attachments=[_att("story/p/s/u-a.png"), _att(f"https://storage.googleapis.com/{BUCKET}/story/p/s/u-b.png", name="b.png")],
+            )
+            await s.commit()
+            cnt2 = (await s.execute(text(
+                f"SELECT count(*) FROM asset_links WHERE source_id='{src}'"
+            ))).scalar_one()
+            assert cnt2 == 2
+
+            # 3) reconcile: 첨부 하나로 교체 → 나머지 link 제거(SSOT 정확)
+            await sync_attachment_assets(
+                s, org_id=ORG, project_id=PROJ_A, source_type="story", source_id=src,
+                attachments=[_att("story/p/s/u-a.png")],
+            )
+            await s.commit()
+            cnt3 = (await s.execute(text(
+                f"SELECT count(*) FROM asset_links WHERE source_id='{src}'"
+            ))).scalar_one()
+            assert cnt3 == 1
+
+            # 4) 전체 제거 → link 0
+            await sync_attachment_assets(
+                s, org_id=ORG, project_id=PROJ_A, source_type="story", source_id=src, attachments=[],
+            )
+            await s.commit()
+            cnt4 = (await s.execute(text(
+                f"SELECT count(*) FROM asset_links WHERE source_id='{src}'"
+            ))).scalar_one()
+            assert cnt4 == 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_assets_scope_idor():
+    from app.dependencies.auth import AuthContext
+    from app.routers.assets import list_assets
+    from app.services.asset_registry import sync_attachment_assets
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            # A 프로젝트 asset, B 프로젝트 asset, org-level(NULL) asset
+            await sync_attachment_assets(s, org_id=ORG, project_id=PROJ_A, source_type="manual",
+                                         source_id=uuid.uuid4(), attachments=[_att("a/x.png")])
+            await sync_attachment_assets(s, org_id=ORG, project_id=PROJ_B, source_type="manual",
+                                         source_id=uuid.uuid4(), attachments=[_att("b/x.png")])
+            await sync_attachment_assets(s, org_id=ORG, project_id=None, source_type="manual",
+                                         source_id=uuid.uuid4(), attachments=[_att("org/x.png")])
+            await s.commit()
+
+            auth = AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+
+            # project 미지정 → 접근 가능(A) + org-level만. B 미노출(IDOR 차단).
+            rows = await list_assets(project_id=None, folder_id=None, mime=None, q=None,
+                                     limit=200, offset=0, db=s, auth=auth, org_id=ORG)
+            paths = {r.object_path for r in rows}
+            assert "a/x.png" in paths
+            assert "org/x.png" in paths
+            assert "b/x.png" not in paths  # 접근권 없는 project asset 0 노출
+
+            # project_id=A → 접근 OK, A asset만
+            rows_a = await list_assets(project_id=PROJ_A, folder_id=None, mime=None, q=None,
+                                       limit=200, offset=0, db=s, auth=auth, org_id=ORG)
+            assert {r.object_path for r in rows_a} == {"a/x.png"}
+
+            # project_id=B → 접근권 없음 → 403(IDOR)
+            from fastapi import HTTPException
+            with pytest.raises(HTTPException) as ei:
+                await list_assets(project_id=PROJ_B, folder_id=None, mime=None, q=None,
+                                  limit=200, offset=0, db=s, auth=auth, org_id=ORG)
+            assert ei.value.status_code == 403
+    finally:
+        await engine.dispose()
+
+
+def test_backfill_legacy_attachments_idempotent():
+    """legacy conversation_messages 첨부 → migration _backfill 멱등 편입(AC3). sync 엔진."""
+    # 0139 마이그 모듈 로드(_backfill).
+    mig_path = Path(__file__).resolve().parents[1] / "alembic" / "versions" / "0139_add_asset_registry.py"
+    spec = importlib.util.spec_from_file_location("mig_0139", mig_path)
+    mig = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mig)
+
+    conv = uuid.uuid4()
+    msg = uuid.uuid4()
+    engine = create_engine(_SYNC)
+    try:
+        with engine.begin() as conn:
+            # 멱등 클린업 + org/project/conversation/message(첨부) 시드
+            conn.execute(text(f"DELETE FROM asset_links WHERE org_id='{ORG}'"))
+            conn.execute(text(f"DELETE FROM assets WHERE org_id='{ORG}'"))
+            conn.execute(text(f"DELETE FROM conversation_messages WHERE id='{msg}'"))
+            conn.execute(text(f"DELETE FROM conversations WHERE id='{conv}'"))
+            conn.execute(text(f"DELETE FROM projects WHERE id='{PROJ_A}'"))
+            conn.execute(text(f"DELETE FROM organizations WHERE id='{ORG}'"))
+            conn.execute(text(f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','A2','a2org','free')"))
+            conn.execute(text(f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_A}','{ORG}','A')"))
+            conn.execute(text(
+                f"INSERT INTO conversations (id,org_id,project_id,type,status) "
+                f"VALUES ('{conv}','{ORG}','{PROJ_A}','group','open')"
+            ))
+            att_json = json.dumps([
+                {"url": "chat/p/c/u-a.png", "name": "a.png", "content_type": "image/png", "size": 3},
+                {"url": "https://evil.example/x.png", "name": "ext", "content_type": "image/png", "size": 1},
+            ])
+            # ⚠️ JSON 리터럴의 `:3` 등이 text() bind 로 오인되므로 반드시 bound param + CAST(jsonb).
+            conn.execute(
+                text(
+                    "INSERT INTO conversation_messages "
+                    "(id,conversation_id,content,mentioned_ids,reply_count,attachments) "
+                    "VALUES (:id,:conv,'hi','{}',0, CAST(:att AS jsonb))"
+                ),
+                {"id": str(msg), "conv": str(conv), "att": att_json},
+            )
+
+        with engine.begin() as conn:
+            mig._backfill(conn)
+        with engine.begin() as conn:
+            assets = conn.execute(text(f"SELECT count(*) FROM assets WHERE org_id='{ORG}'")).scalar_one()
+            links = conn.execute(text(
+                f"SELECT count(*) FROM asset_links WHERE source_type='conversation_message' AND source_id='{msg}'"
+            )).scalar_one()
+        assert assets == 1  # 외부 url 1건 제외
+        assert links == 1
+
+        # 멱등: 재실행 → 증가 0
+        with engine.begin() as conn:
+            mig._backfill(conn)
+        with engine.begin() as conn:
+            assets2 = conn.execute(text(f"SELECT count(*) FROM assets WHERE org_id='{ORG}'")).scalar_one()
+            links2 = conn.execute(text(f"SELECT count(*) FROM asset_links WHERE source_id='{msg}'")).scalar_one()
+        assert assets2 == 1 and links2 == 1
+    finally:
+        engine.dispose()

--- a/backend/tests/test_asset_registry_realdb.py
+++ b/backend/tests/test_asset_registry_realdb.py
@@ -77,17 +77,19 @@ async def test_sync_creates_asset_and_link_idempotent_reconcile():
         async with Session() as s:
             await _reset_and_seed(s)
             src = uuid.uuid4()
-            # 1) create: bare + GCS-prefixed + 외부(skip) 혼합
+            base = f"story/{PROJ_A}/{src}"  # 이 story 귀속 스코프(까심#2)
+            # 1) create: bare + GCS-prefixed + 외부(skip) + 타-source 경로(skip) 혼합
             ids = await sync_attachment_assets(
                 s, org_id=ORG, project_id=PROJ_A, source_type="story", source_id=src,
                 attachments=[
-                    _att("story/p/s/u-a.png"),
-                    _att(f"https://storage.googleapis.com/{BUCKET}/story/p/s/u-b.png", name="b.png"),
+                    _att(f"{base}/u-a.png"),
+                    _att(f"https://storage.googleapis.com/{BUCKET}/{base}/u-b.png", name="b.png"),
                     _att("https://evil.example/x.png", name="ext.png"),  # 외부 → skip
+                    _att(f"story/{PROJ_B}/{uuid.uuid4()}/u-c.png", name="c.png"),  # 타 story/project → skip(#2)
                 ],
             )
             await s.commit()
-            assert len(ids) == 2  # 외부 1건 제외
+            assert len(ids) == 2  # 외부 1 + 타-source 1 제외
             cnt = (await s.execute(text(
                 f"SELECT count(*) FROM asset_links WHERE source_type='story' AND source_id='{src}'"
             ))).scalar_one()
@@ -101,7 +103,7 @@ async def test_sync_creates_asset_and_link_idempotent_reconcile():
             # 2) idempotent: 같은 첨부 재동기화 → row 증가 0
             await sync_attachment_assets(
                 s, org_id=ORG, project_id=PROJ_A, source_type="story", source_id=src,
-                attachments=[_att("story/p/s/u-a.png"), _att(f"https://storage.googleapis.com/{BUCKET}/story/p/s/u-b.png", name="b.png")],
+                attachments=[_att(f"{base}/u-a.png"), _att(f"https://storage.googleapis.com/{BUCKET}/{base}/u-b.png", name="b.png")],
             )
             await s.commit()
             cnt2 = (await s.execute(text(
@@ -112,7 +114,7 @@ async def test_sync_creates_asset_and_link_idempotent_reconcile():
             # 3) reconcile: 첨부 하나로 교체 → 나머지 link 제거(SSOT 정확)
             await sync_attachment_assets(
                 s, org_id=ORG, project_id=PROJ_A, source_type="story", source_id=src,
-                attachments=[_att("story/p/s/u-a.png")],
+                attachments=[_att(f"{base}/u-a.png")],
             )
             await s.commit()
             cnt3 = (await s.execute(text(
@@ -155,25 +157,134 @@ async def test_list_assets_scope_idor():
 
             auth = AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
 
+            async def _paths(**kw):
+                page = await list_assets(project_id=kw.get("project_id"), folder_id=None, mime=None,
+                                         q=None, sort="date", order="desc", cursor=None, limit=200,
+                                         db=s, auth=auth, org_id=ORG)
+                return {r.object_path for r in page.items}
+
             # project 미지정 → 접근 가능(A) + org-level만. B 미노출(IDOR 차단).
-            rows = await list_assets(project_id=None, folder_id=None, mime=None, q=None,
-                                     limit=200, offset=0, db=s, auth=auth, org_id=ORG)
-            paths = {r.object_path for r in rows}
+            paths = await _paths(project_id=None)
             assert "a/x.png" in paths
             assert "org/x.png" in paths
             assert "b/x.png" not in paths  # 접근권 없는 project asset 0 노출
 
             # project_id=A → 접근 OK, A asset만
-            rows_a = await list_assets(project_id=PROJ_A, folder_id=None, mime=None, q=None,
-                                       limit=200, offset=0, db=s, auth=auth, org_id=ORG)
-            assert {r.object_path for r in rows_a} == {"a/x.png"}
+            assert await _paths(project_id=PROJ_A) == {"a/x.png"}
 
             # project_id=B → 접근권 없음 → 403(IDOR)
             from fastapi import HTTPException
             with pytest.raises(HTTPException) as ei:
-                await list_assets(project_id=PROJ_B, folder_id=None, mime=None, q=None,
-                                  limit=200, offset=0, db=s, auth=auth, org_id=ORG)
+                await _paths(project_id=PROJ_B)
             assert ei.value.status_code == 403
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_assets_enrich_and_cursor():
+    """S5 계약: source_links(story title+deeplink)·created_by enrich·cursor 페이지네이션."""
+    from app.dependencies.auth import AuthContext
+    from app.routers.assets import list_assets, list_folders
+    from app.services.asset_registry import sync_attachment_assets
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            story_id = uuid.uuid4()
+            await s.execute(text(
+                f"INSERT INTO stories (id,org_id,project_id,title,status,priority) "
+                f"VALUES ('{story_id}','{ORG}','{PROJ_A}','My Story','backlog','medium')"
+            ))
+            await s.commit()
+            base = f"story/{PROJ_A}/{story_id}"
+            await sync_attachment_assets(s, org_id=ORG, project_id=PROJ_A, source_type="story",
+                                         source_id=story_id, attachments=[_att(f"{base}/u-a.png")])
+            await s.commit()
+
+            auth = AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+            page = await list_assets(project_id=PROJ_A, folder_id=None, mime=None, q=None,
+                                     sort="date", order="desc", cursor=None, limit=50,
+                                     db=s, auth=auth, org_id=ORG)
+            assert len(page.items) == 1
+            sl = page.items[0].source_links
+            assert len(sl) == 1
+            assert sl[0].type == "story" and sl[0].title == "My Story"
+            assert sl[0].deeplink == {"story_id": str(story_id)}
+
+            # cursor: limit=1 두 자산서 페이지 경계 동작
+            await sync_attachment_assets(s, org_id=ORG, project_id=PROJ_A, source_type="story",
+                                         source_id=story_id, attachments=[_att(f"{base}/u-a.png"), _att(f"{base}/u-b.png")])
+            await s.commit()
+            p1 = await list_assets(project_id=PROJ_A, folder_id=None, mime=None, q=None,
+                                   sort="name", order="asc", cursor=None, limit=1,
+                                   db=s, auth=auth, org_id=ORG)
+            assert len(p1.items) == 1 and p1.next_cursor
+            p2 = await list_assets(project_id=PROJ_A, folder_id=None, mime=None, q=None,
+                                   sort="name", order="asc", cursor=p1.next_cursor, limit=1,
+                                   db=s, auth=auth, org_id=ORG)
+            assert len(p2.items) == 1
+            assert p1.items[0].id != p2.items[0].id  # 커서가 다음 페이지로 진행
+
+            # folders endpoint scope(빈 결과여도 200·접근권 가드)
+            folders = await list_folders(project_id=PROJ_A, db=s, auth=auth, org_id=ORG)
+            assert isinstance(folders, list)
+            from fastapi import HTTPException
+            with pytest.raises(HTTPException) as ei:
+                await list_folders(project_id=PROJ_B, db=s, auth=auth, org_id=ORG)
+            assert ei.value.status_code == 403
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cross_org_same_path_isolated_no_dangling_link():
+    """같은 object_path 를 두 org 에서 등록 → org 별 별도 asset row + org-정합 link(까심#1 blocker).
+
+    전역 UNIQUE 였다면 2번째 org save 가 1번째 org asset_id 에 conflict→매핑되어 cross-org
+    dangling link(al.org_id <> a.org_id) 발생. org-scoped 키로 0 임을 실증.
+    """
+    from app.services.asset_registry import sync_attachment_assets
+
+    ORG2 = uuid.UUID("a2000000-0000-0000-0000-000000000002")
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            for sql in [
+                f"DELETE FROM asset_links WHERE org_id='{ORG2}'",
+                f"DELETE FROM assets WHERE org_id='{ORG2}'",
+                f"DELETE FROM organizations WHERE id='{ORG2}'",
+                f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG2}','A2b','a2borg','free')",
+            ]:
+                await s.execute(text(sql))
+            await s.commit()
+
+            shared = "manual/shared/same-path.png"  # manual=경로 제약 없음(#2). 양 org 동일 경로.
+            await sync_attachment_assets(s, org_id=ORG, project_id=None, source_type="manual",
+                                         source_id=uuid.uuid4(), attachments=[_att(shared)])
+            await sync_attachment_assets(s, org_id=ORG2, project_id=None, source_type="manual",
+                                         source_id=uuid.uuid4(), attachments=[_att(shared)])
+            await s.commit()
+
+            n_assets = (await s.execute(text(
+                f"SELECT count(*) FROM assets WHERE object_path='{shared}' AND org_id IN ('{ORG}','{ORG2}')"
+            ))).scalar_one()
+            assert n_assets == 2  # org 별 별도 row
+
+            dangling = (await s.execute(text(
+                "SELECT count(*) FROM asset_links al JOIN assets a ON a.id=al.asset_id "
+                "WHERE al.org_id <> a.org_id"
+            ))).scalar_one()
+            assert dangling == 0  # cross-org dangling link 0(SSOT 정합)
+
+            await s.execute(text(f"DELETE FROM asset_links WHERE org_id='{ORG2}'"))
+            await s.execute(text(f"DELETE FROM assets WHERE org_id='{ORG2}'"))
+            await s.execute(text(f"DELETE FROM organizations WHERE id='{ORG2}'"))
+            await s.commit()
     finally:
         await engine.dispose()
 
@@ -205,8 +316,10 @@ def test_backfill_legacy_attachments_idempotent():
                 f"VALUES ('{conv}','{ORG}','{PROJ_A}','group','open')"
             ))
             att_json = json.dumps([
-                {"url": "chat/p/c/u-a.png", "name": "a.png", "content_type": "image/png", "size": 3},
+                # 이 conversation 귀속 경로(까심#2 scope) + size 비숫자 오염(까심#3 안전캐스팅)
+                {"url": f"chat/{PROJ_A}/{conv}/u-a.png", "name": "a.png", "content_type": "image/png", "size": "12 bytes"},
                 {"url": "https://evil.example/x.png", "name": "ext", "content_type": "image/png", "size": 1},
+                {"url": f"chat/{PROJ_A}/{uuid.uuid4()}/u-z.png", "name": "z", "content_type": "image/png", "size": 1},
             ])
             # ⚠️ JSON 리터럴의 `:3` 등이 text() bind 로 오인되므로 반드시 bound param + CAST(jsonb).
             conn.execute(

--- a/backend/tests/test_asset_registry_realdb.py
+++ b/backend/tests/test_asset_registry_realdb.py
@@ -323,29 +323,36 @@ async def test_same_org_cross_project_no_collision():
 
 
 @pytest.mark.anyio
-async def test_enrich_no_cross_org_leak():
-    """오염 asset_link(타 org source id)가 있어도 enrich 가 타 org title/content/name 미누출(까심 R2#7)."""
+async def test_enrich_no_cross_org_or_cross_project_leak():
+    """오염 asset_link(타 org OR same-org 접근불가 project source)는 enrich 에서 **link 자체 미생성**
+    (title/content/slug/deeplink/id 응답 0·까심 R3). 정상 source(접근 project)는 정상 enrich."""
     from app.dependencies.auth import AuthContext
     from app.routers.assets import list_assets
     from app.services.asset_registry import sync_attachment_assets
 
+    cross_org_story = uuid.uuid4()    # ORG2(타 org)
+    cross_proj_story = uuid.uuid4()   # ORG/PROJ_B(same org·USER 접근불가)
+    src = uuid.uuid4()                # 정상 story(ORG/PROJ_A·USER 접근가능)
     engine = create_async_engine(_ASYNC)
     Session = async_sessionmaker(engine, expire_on_commit=False)
     try:
         async with Session() as s:
             await _reset_and_seed(s)
-            other_story = uuid.uuid4()
             for sql in [
-                f"DELETE FROM stories WHERE id='{other_story}'",
                 f"DELETE FROM projects WHERE id='{PROJ_OTHER}'",
                 f"DELETE FROM organizations WHERE id='{ORG2}'",
                 f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG2}','A2b','a2borg','free')",
                 f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_OTHER}','{ORG2}','OtherP')",
+                # 정상 story(접근 가능 PROJ_A) — enrich 정상 노출돼야.
                 f"INSERT INTO stories (id,org_id,project_id,title,status,priority) "
-                f"VALUES ('{other_story}','{ORG2}','{PROJ_OTHER}','SECRET TITLE','backlog','medium')",
+                f"VALUES ('{src}','{ORG}','{PROJ_A}','OK STORY','backlog','medium')",
+                f"INSERT INTO stories (id,org_id,project_id,title,status,priority) "
+                f"VALUES ('{cross_org_story}','{ORG2}','{PROJ_OTHER}','SECRET ORG','backlog','medium')",
+                # same-org·접근불가 project(PROJ_B) story — USER 는 PROJ_A 만 grant.
+                f"INSERT INTO stories (id,org_id,project_id,title,status,priority) "
+                f"VALUES ('{cross_proj_story}','{ORG}','{PROJ_B}','SECRET PROJ','backlog','medium')",
             ]:
                 await s.execute(text(sql))
-            src = uuid.uuid4()
             base = f"story/{PROJ_A}/{src}"
             await sync_attachment_assets(s, org_id=ORG, project_id=PROJ_A, source_type="story",
                                          source_id=src, attachments=[_att(f"{base}/u-a.png")])
@@ -353,28 +360,57 @@ async def test_enrich_no_cross_org_leak():
             asset_id = (await s.execute(text(
                 f"SELECT id FROM assets WHERE org_id='{ORG}' AND object_path='{base}/u-a.png'"
             ))).scalar_one()
-            # pollute: ORG asset_link → ORG2 story id(다형 link·FK 없음)
-            await s.execute(text(
-                "INSERT INTO asset_links (org_id, asset_id, source_type, source_id) "
-                f"VALUES ('{ORG}','{asset_id}','story','{other_story}') ON CONFLICT DO NOTHING"
-            ))
+            # pollute: ORG asset_link → 타 org story + same-org 접근불가 project story(다형·FK 없음)
+            for poll in (cross_org_story, cross_proj_story):
+                await s.execute(text(
+                    "INSERT INTO asset_links (org_id, asset_id, source_type, source_id) "
+                    f"VALUES ('{ORG}','{asset_id}','story','{poll}') ON CONFLICT DO NOTHING"
+                ))
             await s.commit()
 
             auth = AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
             page = await list_assets(project_id=PROJ_A, folder_id=None, mime=None, q=None,
                                      sort="date", order="desc", cursor=None, limit=50,
                                      db=s, auth=auth, org_id=ORG)
-            leaked = [sl.title for it in page.items for sl in it.source_links
-                      if str(sl.id) == str(other_story)]
-            assert leaked and all(t is None for t in leaked)  # 타 org story title 미누출
+            all_links = [sl for it in page.items for sl in it.source_links]
+            # 정상 link(이 story·PROJ_A) 1건만·오염 2건은 미생성(id/title/deeplink 0 노출)
+            ids = {str(sl.id) for sl in all_links}
+            assert str(src) in ids
+            assert str(cross_org_story) not in ids
+            assert str(cross_proj_story) not in ids
+            titles = {sl.title for sl in all_links}
+            assert "SECRET ORG" not in titles and "SECRET PROJ" not in titles
 
             for sql in [
-                f"DELETE FROM stories WHERE id='{other_story}'",
+                f"DELETE FROM stories WHERE id IN ('{cross_org_story}','{cross_proj_story}')",
                 f"DELETE FROM projects WHERE id='{PROJ_OTHER}'",
                 f"DELETE FROM organizations WHERE id='{ORG2}'",
             ]:
                 await s.execute(text(sql))
             await s.commit()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_level_null_project_idempotent():
+    """org-level(project NULL) manual asset 재동기화 멱등 — partial-null unique 로 단일 row(까심 R3#2)."""
+    from app.services.asset_registry import sync_attachment_assets
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            path = "manual/orglevel/x.png"
+            for _ in range(3):
+                await sync_attachment_assets(s, org_id=ORG, project_id=None, source_type="manual",
+                                             source_id=uuid.uuid4(), attachments=[_att(path)])
+                await s.commit()
+            n = (await s.execute(text(
+                f"SELECT count(*) FROM assets WHERE org_id='{ORG}' AND project_id IS NULL AND object_path='{path}'"
+            ))).scalar_one()
+            assert n == 1  # 재동기화에도 단일 row(NULL-distinct 회귀 봉합)
     finally:
         await engine.dispose()
 


### PR DESCRIPTION
## E-STORAGE-SSOT S2 — asset + folder registry

epic `508adc04` · phasing 2. S1 `IStorageService` 위에 빌드 — 모든 첨부를 queryable한 asset registry로 편입.

### 변경 요약
**마이그레이션 (AC4 — 첫 배치)**
- `0139_add_asset_registry`: `assets` / `asset_folders` / `asset_links` 신설. idempotent inspect 가드 · fresh-runnable · reversible(downgrade 검증). 멱등 upsert 키 `UNIQUE(container, object_path)` · `asset_links.source_type` CHECK(다형·AC6) · org/project/folder 인덱스. baseline REVISION=0096 불변(incremental). CI `alembic-fresh-db` 가드에 3테이블 + CHECK 존재 검증 추가.
- **legacy 백필**: 기존 `conversation_messages`/`stories` 첨부(JSONB) → asset/asset_link **멱등 백필**(keyset 배치 · prod 락/시간 안전 · 외부 URL skip).

**모델/서비스**
- `models/asset.py`: `Asset`/`AssetFolder`/`AssetLink` (OrgScoped+Timestamp+SoftDelete[S8 선반영]). `created_by` no-FK(`team_members`=뷰).
- `services/asset_registry.py`: `canonical_object_path`(S1 `_canonical_object_path` 규칙 정합) + `sync_attachment_assets`(SAVE-time·같은 트랜잭션·upsert + reconcile + 외부 객체 skip).

**SAVE-time 배선 (D1 · AC1 · orphan 0)**
- `send_message` · `stories.create` · `stories.update`(첨부 교체→reconcile) persist 경로에서 asset + asset_link 원자 생성(같은 커밋).

**read API (AC2)**
- `GET /api/v2/assets` — list/search by org/project/folder/MIME/name. **scope-guard HARD(D3)**: `project_id` 지정→`has_project_access`(403) · 미지정→`accessible_project_ids_in_org`만(타 org/project asset 0 노출).

### AC 대응
- **AC1** upload(=첨부 persist)→asset row(같은 op). ✅ (real-DB sync 테스트)
- **AC2** list/search by org/project/folder/MIME/name. ✅
- **AC3** legacy chat/story 객체 읽힘·백필 편입(무회귀). ✅ (백필 멱등 테스트)
- **AC4** alembic 마이그 fresh-runnable + CI alembic-fresh 가드. ✅ (로컬 pg16 fresh→head·idempotent·reversible)
- **AC5** 까심 cross-model(IDOR 적대 프로빙) — 대기. 산티아고 stand-down(novel surface 없음).
- **AC6** asset_links source_type 다형(CHECK). ✅

### 보안 (D3 — scope guard = HARD AC)
모든 asset 엔드포인트가 요청자 org + 접근 가능 project로 필터(IDOR 차단). real-DB 테스트로 검증: 미지정 list가 접근권 없는 project asset 0 노출, `project_id`=타프로젝트→403. **까심 QA에 IDOR 적대 프로빙 요청**(list 타 org/project 반환?·POST scope).

### 테스트
- `test_asset_canonical.py` 7종(canonical_object_path·CI backend-test 실행).
- `test_asset_registry_realdb.py` 3종(SAVE-time sync/idempotent/reconcile/external-skip·list IDOR scope·legacy 백필 멱등) — `skipif(ALEMBIC_DATABASE_URL)`·로컬 pg16에서 전량 검증.
- 풀스위트 2568 pass(잔여 7 실패 = 기존 MCP tool-count/running-instance/.mcp.json subprocess env-의존·스토리지 무관·미변경).

### 머지 후 (PO lane)
dev `sprintable-migrate-dev` job으로 0139 적용 + schema parity 확인. prod 승격도 동일. 백필은 prod 데이터량 크면 batch 분리 가능(keyset 구조).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
