### PR TITLE
[SID:893b4cbe] E-STORAGE-SSOT S3 — authorize asset scope + signed-read disposition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,14 +79,14 @@ jobs:
 
       # E-STORAGE-SSOT: asset registry IDOR/정합 게이트는 real-DB 가 필수(backend-test 잡엔 PG 없음).
       # 이 PG 백드 잡에서 실행해 S2~S8 IDOR/멀티테넌시 회귀를 CI 가 잡도록 박는다(까심#4).
-      - name: asset registry real-DB tests (IDOR / sync / backfill)
+      - name: asset registry real-DB tests (IDOR / sync / backfill / authorize)
         working-directory: backend
         env:
           ALEMBIC_DATABASE_URL: postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test
           DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
           JWT_SECRET: ci-test-secret-at-least-32-chars-long
           SECRET_KEY: ci-test-secret-at-least-32-chars-long
-        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py -q
+        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py -q
 
       - name: Verify fresh DB reached head (baseline + incremental)
         working-directory: backend

--- a/apps/web/src/app/api/attachments/sign/route.ts
+++ b/apps/web/src/app/api/attachments/sign/route.ts
@@ -30,19 +30,39 @@ export async function GET(request: Request) {
     const rawPath = searchParams.get('path');
     const conversationId = searchParams.get('conversation_id');
     const storyId = searchParams.get('story_id');
+    const assetId = searchParams.get('asset_id');
+    // S5 계약: preview=inline / download=attachment.
+    const disposition = searchParams.get('disposition') === 'attachment' ? 'attachment' : 'inline';
 
-    if (!rawPath) return ApiErrors.badRequest('path is required');
-    // BE 계약: 정확히 하나의 리소스(conversation_id XOR story_id).
-    if ((conversationId === null) === (storyId === null)) {
-      return ApiErrors.badRequest('exactly one of conversation_id or story_id is required');
+    // BE 계약: 정확히 하나의 리소스(conversation_id | story_id | asset_id).
+    if ([conversationId, storyId, assetId].filter((x) => x !== null).length !== 1) {
+      return ApiErrors.badRequest('exactly one of conversation_id, story_id, asset_id is required');
     }
 
+    const storage = await createStorageService();
+
+    // S3: asset_id 경로 — BE 가 registry(SSOT)에서 {container, object_path} 권위 derive(FE 제공값 trust X).
+    if (assetId) {
+      const authUrl = new URL('/api/v2/attachments/authorize', FASTAPI_URL());
+      authUrl.searchParams.set('asset_id', assetId);
+      const authRes = await fetch(authUrl.toString(), {
+        headers: { Authorization: `Bearer ${session.access_token}` },
+        cache: 'no-store',
+      });
+      if (authRes.status === 403) return ApiErrors.forbidden('첨부 접근 권한이 없습니다');
+      if (authRes.status === 404) return ApiErrors.badRequest('asset not found');
+      if (!authRes.ok) return ApiErrors.badRequest('attachment authorization failed');
+      const a = (await authRes.json()) as { container?: string; object_path?: string };
+      if (!a.container || !a.object_path) return ApiErrors.badRequest('asset authorization incomplete');
+      const url = await storage.signRead(a.container, a.object_path, { disposition });
+      return apiSuccess({ url });
+    }
+
+    // conv/story 경로 — 기존 path 기반(구조 스코프 + canonical 정확 매치) 2겹 방어 무변경.
+    if (!rawPath) return ApiErrors.badRequest('path is required');
     const objectPath = canonicalObjectPath(rawPath);
-    // bare object path(스킴 없음)만 허용 — injection 차단(BE와 동일 가드).
     if (!objectPath || objectPath.includes('://')) return ApiErrors.badRequest('invalid attachment path');
 
-    // BE authorize — 요청자 접근권 + path 소속(구조 스코프 + canonical 정확 매치) 2겹 방어.
-    // 세션 access_token(sp_at)을 Bearer로 전달. org는 BE가 토큰서 도출.
     const authUrl = new URL('/api/v2/attachments/authorize', FASTAPI_URL());
     authUrl.searchParams.set('path', objectPath);
     if (conversationId) authUrl.searchParams.set('conversation_id', conversationId);
@@ -55,9 +75,7 @@ export async function GET(request: Request) {
     if (authRes.status === 403) return ApiErrors.forbidden('첨부 접근 권한이 없습니다');
     if (!authRes.ok) return ApiErrors.badRequest('attachment authorization failed');
 
-    // authorize 통과 — 단기 만료 서명 URL 발급(provider 추상 경유).
-    const storage = await createStorageService();
-    const url = await storage.signRead(GCS_MEMO_ATTACHMENTS_BUCKET, objectPath);
+    const url = await storage.signRead(GCS_MEMO_ATTACHMENTS_BUCKET, objectPath, { disposition });
     return apiSuccess({ url });
   } catch (err: unknown) {
     return handleApiError(err);

--- a/apps/web/src/app/api/storage/local/[...path]/route.ts
+++ b/apps/web/src/app/api/storage/local/[...path]/route.ts
@@ -47,11 +47,12 @@ export async function GET(
     return NextResponse.json({ error: { message: 'not found' } }, { status: 404 });
   }
 
-  return new NextResponse(new Uint8Array(body), {
-    status: 200,
-    headers: {
-      'content-type': 'application/octet-stream',
-      'cache-control': 'private, no-store',
-    },
-  });
+  // S3: disposition(inline|attachment) — GCS responseDisposition / S3 ResponseContentDisposition 와 동치.
+  const disposition = searchParams.get('disposition') === 'attachment' ? 'attachment' : 'inline';
+  const headers: Record<string, string> = {
+    'content-type': 'application/octet-stream',
+    'cache-control': 'private, no-store',
+    'content-disposition': disposition,
+  };
+  return new NextResponse(new Uint8Array(body), { status: 200, headers });
 }

--- a/apps/web/src/lib/storage/providers/gcs.ts
+++ b/apps/web/src/lib/storage/providers/gcs.ts
@@ -1,5 +1,5 @@
 import { Storage } from '@google-cloud/storage';
-import type { IStorageService, StorageObjectHead } from '@sprintable/core-storage';
+import type { IStorageService, SignReadOptions, StorageObjectHead } from '@sprintable/core-storage';
 
 // E-STORAGE-SSOT S1: GCS provider. `@google-cloud/storage` 직 import 는 이 파일에만 격리된다
 // (AC1: call-site 직 import 0). 로직은 기존 `lib/gcs.ts`(uploadToGcs/getSignedReadUrl)에서 이관.
@@ -42,8 +42,9 @@ export class GcsStorageService implements IStorageService {
   async signRead(
     container: string,
     objectPath: string,
-    expiresInMs = 5 * 60 * 1000,
+    opts?: SignReadOptions,
   ): Promise<string> {
+    const expiresInMs = opts?.expiresInMs ?? 5 * 60 * 1000;
     const [url] = await this.storage
       .bucket(container)
       .file(objectPath)
@@ -51,6 +52,7 @@ export class GcsStorageService implements IStorageService {
         version: 'v4',
         action: 'read',
         expires: Date.now() + expiresInMs,
+        ...(opts?.disposition ? { responseDisposition: opts.disposition } : {}),
       });
     return url;
   }

--- a/apps/web/src/lib/storage/providers/local.ts
+++ b/apps/web/src/lib/storage/providers/local.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, stat, unlink, writeFile } from 'node:fs/promises';
 import { dirname, resolve, sep } from 'node:path';
-import type { IStorageService, StorageObjectHead } from '@sprintable/core-storage';
+import type { IStorageService, SignReadOptions, StorageObjectHead } from '@sprintable/core-storage';
 import { localStorageConfig, resolveLocalSigningSecret } from '../config';
 import { signLocalObject } from '../local-sign';
 
@@ -41,12 +41,14 @@ export class LocalDiskStorageService implements IStorageService {
   async signRead(
     container: string,
     objectPath: string,
-    expiresInMs = 5 * 60 * 1000,
+    opts?: SignReadOptions,
   ): Promise<string> {
-    const exp = Date.now() + expiresInMs;
+    const exp = Date.now() + (opts?.expiresInMs ?? 5 * 60 * 1000);
     const sig = signLocalObject(this.signingSecret, container, objectPath, exp);
     // same-origin 상대 URL — 브라우저가 직접 fetch. serve 라우트가 HMAC 검증.
+    // disposition 은 HMAC 비포함(inline↔attachment 변조는 cosmetic·무해)·serve 가 헤더로 반영.
     const qs = new URLSearchParams({ exp: String(exp), sig });
+    if (opts?.disposition) qs.set('disposition', opts.disposition);
     return `/api/storage/local/${container}/${objectPath}?${qs.toString()}`;
   }
 

--- a/apps/web/src/lib/storage/providers/s3.ts
+++ b/apps/web/src/lib/storage/providers/s3.ts
@@ -6,7 +6,7 @@ import {
   S3Client,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import type { IStorageService, StorageObjectHead } from '@sprintable/core-storage';
+import type { IStorageService, SignReadOptions, StorageObjectHead } from '@sprintable/core-storage';
 import { s3StorageConfig } from '../config';
 
 // E-STORAGE-SSOT S1: S3(및 minio 호환) provider. @aws-sdk 는 팩토리에서 provider=s3 일 때만
@@ -57,11 +57,16 @@ export class S3StorageService implements IStorageService {
   async signRead(
     container: string,
     objectPath: string,
-    expiresInMs = 5 * 60 * 1000,
+    opts?: SignReadOptions,
   ): Promise<string> {
+    const expiresInMs = opts?.expiresInMs ?? 5 * 60 * 1000;
     return getSignedUrl(
       this.client,
-      new GetObjectCommand({ Bucket: container, Key: objectPath }),
+      new GetObjectCommand({
+        Bucket: container,
+        Key: objectPath,
+        ...(opts?.disposition ? { ResponseContentDisposition: opts.disposition } : {}),
+      }),
       { expiresIn: Math.ceil(expiresInMs / 1000) },
     );
   }

--- a/apps/web/src/lib/storage/storage.test.ts
+++ b/apps/web/src/lib/storage/storage.test.ts
@@ -64,7 +64,7 @@ describe('LocalDiskStorageService roundtrip', () => {
     const read = await svc.readObject(container, objectPath);
     expect(read?.toString('utf8')).toBe('hello storage');
 
-    const signed = await svc.signRead(container, objectPath, 60_000);
+    const signed = await svc.signRead(container, objectPath, { expiresInMs: 60_000 });
     expect(signed).toContain(`/api/storage/local/${container}/${objectPath}`);
     const u = new URL(signed, 'http://localhost');
     const exp = Number(u.searchParams.get('exp'));

--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -197,7 +197,17 @@ async def _enrich(
     (타 org·접근불가 project 의 title/content/slug 누수 차단·까심 R2/R3). 스코프 lookup 서 못 찾은
     source 는 **SourceLink 자체 미생성**(title=None 노출 말고 제거). member 는 org 레벨(project 무관).
     """
-    base = {a.id: AssetResponse.model_validate(a, from_attributes=True) for a in assets}
+    # ⚠️ created_by(ORM=UUID)를 model_validate 가 CreatedBy 로 coerce 시도→ValidationError(S2 잠복 버그·
+    # created_by 세팅된 실 asset 에서 list 500). created_by/source_links 는 ORM 매핑 제외하고 아래서 enrich.
+    base = {
+        a.id: AssetResponse(
+            id=a.id, org_id=a.org_id, project_id=a.project_id, folder_id=a.folder_id,
+            container=a.container, object_path=a.object_path, name=a.name,
+            content_type=a.content_type, size_bytes=a.size_bytes,
+            created_at=a.created_at, updated_at=a.updated_at,
+        )
+        for a in assets
+    }
     if not assets:
         return base
 

--- a/backend/app/routers/attachments.py
+++ b/backend/app/routers/attachments.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.models.asset import Asset
 from app.models.conversation import ConversationParticipant
 from app.models.pm import Story
 from app.services.member_resolver import resolve_member
@@ -48,19 +49,48 @@ def _canonical_object_path(stored_url: str) -> str | None:
 
 @router.get("/authorize")
 async def authorize_attachment(
-    path: str = Query(..., description="GCS object path (bare·스킴 없음)"),
+    path: str | None = Query(default=None, description="GCS object path (bare·스킴 없음·conv/story 전용)"),
     conversation_id: uuid.UUID | None = Query(default=None),
     story_id: uuid.UUID | None = Query(default=None),
+    asset_id: uuid.UUID | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
     """GET /api/v2/attachments/authorize — 첨부 접근 인가(200) / 거부(403).
 
-    정확히 하나의 리소스(conversation_id XOR story_id)·요청자 접근권·path 소속(구조+정확매치).
+    정확히 하나의 리소스(conversation_id | story_id | asset_id)·요청자 접근권.
+    S3: asset_id 분기(S2 registry·D1: BE가 registry에서 {container,object_path} 권위 derive·FE 제공값
+    trust X). conversation/story 엄격검사(path 구조+정확매치)는 무변경(IDOR 유지).
     """
-    if (conversation_id is None) == (story_id is None):
-        raise HTTPException(status_code=400, detail="exactly one of conversation_id or story_id required")
+    if sum(x is not None for x in (conversation_id, story_id, asset_id)) != 1:
+        raise HTTPException(
+            status_code=400,
+            detail="exactly one of conversation_id, story_id, asset_id required",
+        )
+
+    if asset_id is not None:
+        # S3·D1: asset_id 가 truth. registry(org-scoped)에서 좌표 derive→authz→{container,object_path}
+        # 반환(FE 제공 path/container 안 받음·attack surface↓). cross-org=org 필터 0행→404(AC4).
+        asset = (await db.execute(
+            select(Asset).where(
+                Asset.id == asset_id,
+                Asset.org_id == org_id,
+                Asset.deleted_at.is_(None),
+            )
+        )).scalar_one_or_none()
+        if asset is None:
+            raise HTTPException(status_code=404, detail="Asset not found")
+        # 인가(AC1·AC4): project asset=has_project_access·org-level(project_id NULL)=verified-org 멤버.
+        # org_id 는 get_verified_org_id 로 검증됨(asset.org_id==org_id 매치)→ org-level 통과.
+        if asset.project_id is not None and not await has_project_access(
+            db, uuid.UUID(auth.user_id), asset.project_id, org_id
+        ):
+            raise HTTPException(status_code=403, detail="No access to this project")
+        # BE 권위 좌표 반환 — FE 는 이걸로 signRead(외부URL/wrong-bucket 불가·AC3).
+        return {"authorized": True, "container": asset.container, "object_path": asset.object_path}
+
+    # conv/story 분기는 path(bare object) 필수.
     if not path or "://" in path:
         raise HTTPException(status_code=400, detail="path must be a bare object path")
 

--- a/backend/tests/test_asset_registry_realdb.py
+++ b/backend/tests/test_asset_registry_realdb.py
@@ -476,3 +476,80 @@ def test_backfill_legacy_attachments_idempotent():
         assert assets2 == 1 and links2 == 1
     finally:
         engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_enrich_negative_doc_message_member_s3_fold():
+    """AC6(S2 fold·S3): Doc/Message enrich + created_by(member) 도 cross-org 오염 시 미누출.
+
+    오염 asset_link(doc/conversation_message·타 org source)는 link 미생성·타 org created_by 는 null.
+    """
+    from app.dependencies.auth import AuthContext
+    from app.routers.assets import list_assets
+    from app.services.asset_registry import sync_attachment_assets
+
+    other_doc = uuid.uuid4()
+    other_conv = uuid.uuid4()
+    other_msg = uuid.uuid4()
+    foreign_member = uuid.uuid4()  # ORG 멤버 아님 → created_by enrich 시 null
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            for sql in [
+                # 잔여(이전 run) 정리는 project 스코프로(고정 slug 충돌 방지·id-only 정리 불충분).
+                f"DELETE FROM conversation_messages WHERE conversation_id IN "
+                f"(SELECT id FROM conversations WHERE project_id='{PROJ_OTHER}')",
+                f"DELETE FROM conversations WHERE project_id='{PROJ_OTHER}'",
+                f"DELETE FROM docs WHERE project_id='{PROJ_OTHER}'",
+                f"DELETE FROM projects WHERE id='{PROJ_OTHER}'",
+                f"DELETE FROM organizations WHERE id='{ORG2}'",
+                f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG2}','A2b','a2borg','free')",
+                f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_OTHER}','{ORG2}','OtherP')",
+                f"INSERT INTO docs (id,org_id,project_id,title,slug) "
+                f"VALUES ('{other_doc}','{ORG2}','{PROJ_OTHER}','SECRET DOC','secret-doc')",
+                f"INSERT INTO conversations (id,org_id,project_id,type,status) "
+                f"VALUES ('{other_conv}','{ORG2}','{PROJ_OTHER}','group','open')",
+                "INSERT INTO conversation_messages (id,conversation_id,content,mentioned_ids,reply_count) "
+                f"VALUES ('{other_msg}','{other_conv}','SECRET MSG','{{}}',0)",
+            ]:
+                await s.execute(text(sql))
+            # ORG/PROJ_A manual asset.
+            await sync_attachment_assets(s, org_id=ORG, project_id=PROJ_A, source_type="manual",
+                                         source_id=uuid.uuid4(), attachments=[_att("manual/a/x.png")])
+            await s.commit()
+            asset_id = (await s.execute(text(
+                f"SELECT id FROM assets WHERE org_id='{ORG}' AND object_path='manual/a/x.png'"
+            ))).scalar_one()
+            # 타 org doc/message link 주입 + 타 org created_by 설정(오염).
+            for stype, sid in (("doc", other_doc), ("conversation_message", other_msg)):
+                await s.execute(text(
+                    "INSERT INTO asset_links (org_id, asset_id, source_type, source_id) "
+                    f"VALUES ('{ORG}','{asset_id}','{stype}','{sid}') ON CONFLICT DO NOTHING"
+                ))
+            await s.execute(text(f"UPDATE assets SET created_by='{foreign_member}' WHERE id='{asset_id}'"))
+            await s.commit()
+
+            auth = AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+            page = await list_assets(project_id=PROJ_A, folder_id=None, mime=None, q=None,
+                                     sort="date", order="desc", cursor=None, limit=50,
+                                     db=s, auth=auth, org_id=ORG)
+            item = next(it for it in page.items if str(it.id) == str(asset_id))
+            ids = {str(sl.id) for sl in item.source_links}
+            titles = {sl.title for sl in item.source_links}
+            assert str(other_doc) not in ids and str(other_msg) not in ids  # 오염 link 미생성
+            assert "SECRET DOC" not in titles and "SECRET MSG" not in titles  # 타 org 내용 미누출
+            assert item.created_by is None  # 타 org member created_by 미해소(누수 0)
+
+            for sql in [
+                f"DELETE FROM conversation_messages WHERE id='{other_msg}'",
+                f"DELETE FROM conversations WHERE id='{other_conv}'",
+                f"DELETE FROM docs WHERE id='{other_doc}'",
+                f"DELETE FROM projects WHERE id='{PROJ_OTHER}'",
+                f"DELETE FROM organizations WHERE id='{ORG2}'",
+            ]:
+                await s.execute(text(sql))
+            await s.commit()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_attachment_authorize_asset_s3.py
+++ b/backend/tests/test_attachment_authorize_asset_s3.py
@@ -1,0 +1,125 @@
+"""E-STORAGE-SSOT S3 — authorize_attachment asset_id 분기(real-DB).
+
+AC1 project-access(or org-level) 유저만·AC3 외부/wrong-bucket(asset_id=truth라 BE derive)·AC4 cross-org
+project_id 403/404. asset_id=truth(D1)라 BE 가 registry 에서 {container,object_path} 권위 derive·반환.
+DB env 없으면 skip(CI alembic-fresh 잡서 실행).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("a3000000-0000-0000-0000-000000000001")
+ORG2 = uuid.UUID("a3000000-0000-0000-0000-000000000002")
+USER = uuid.UUID("a3000000-0000-0000-0000-0000000000a1")
+OM = uuid.UUID("a3000000-0000-0000-0000-0000000000b1")
+PROJ_A = uuid.UUID("a3000000-0000-0000-0000-0000000000c1")  # USER grant
+PROJ_B = uuid.UUID("a3000000-0000-0000-0000-0000000000c2")  # USER no-access
+PROJ_OTHER = uuid.UUID("a3000000-0000-0000-0000-0000000000d1")  # ORG2
+BUCKET = "sprintable-memo-attachments"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _seed(s):
+    for sql in [
+        f"DELETE FROM assets WHERE org_id IN ('{ORG}','{ORG2}')",
+        f"DELETE FROM project_access WHERE project_id IN ('{PROJ_A}','{PROJ_B}')",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id IN ('{ORG}','{ORG2}')",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id IN ('{ORG}','{ORG2}')",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','A3','a3','free')",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG2}','A3b','a3b','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@a3.test','x','U',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_A}','{ORG}','A')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_B}','{ORG}','B')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_OTHER}','{ORG2}','OtherP')",
+        # USER grant PROJ_A 만.
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ_A}','{OM}','granted')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _mk_asset(s, org, project) -> uuid.UUID:
+    aid = uuid.uuid4()
+    await s.execute(
+        text(
+            "INSERT INTO assets (id,org_id,project_id,container,object_path,name,size_bytes) "
+            "VALUES (:id, :org, :proj, :bucket, :path, 'x.png', 1)"
+        ),
+        {"id": str(aid), "org": str(org), "proj": (str(project) if project else None),
+         "bucket": BUCKET, "path": f"x/{aid}.png"},
+    )
+    await s.commit()
+    return aid
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(USER), email="u@a3.test", claims={}, org_id=str(ORG))
+
+
+@pytest.mark.anyio
+async def test_authorize_asset_branch():
+    from app.routers.attachments import authorize_attachment
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+            a_ok = await _mk_asset(s, ORG, PROJ_A)        # 접근 가능 project
+            a_noacc = await _mk_asset(s, ORG, PROJ_B)     # same org·접근불가 project
+            a_orglvl = await _mk_asset(s, ORG, None)      # org-level
+            a_xorg = await _mk_asset(s, ORG2, PROJ_OTHER) # 타 org
+            auth = _auth()
+
+            # AC1: project access → 200 + BE derive 좌표
+            res = await authorize_attachment(path=None, conversation_id=None, story_id=None,
+                                             asset_id=a_ok, db=s, auth=auth, org_id=ORG)
+            assert res["authorized"] is True
+            assert res["container"] == BUCKET and res["object_path"] == f"x/{a_ok}.png"
+
+            # AC1: org-level → org 멤버 통과
+            res2 = await authorize_attachment(path=None, conversation_id=None, story_id=None,
+                                              asset_id=a_orglvl, db=s, auth=auth, org_id=ORG)
+            assert res2["authorized"] is True
+
+            # 접근불가 project → 403
+            with pytest.raises(HTTPException) as e1:
+                await authorize_attachment(path=None, conversation_id=None, story_id=None,
+                                           asset_id=a_noacc, db=s, auth=auth, org_id=ORG)
+            assert e1.value.status_code == 403
+
+            # AC4: cross-org asset → 404(org 필터 0행)
+            with pytest.raises(HTTPException) as e2:
+                await authorize_attachment(path=None, conversation_id=None, story_id=None,
+                                           asset_id=a_xorg, db=s, auth=auth, org_id=ORG)
+            assert e2.value.status_code == 404
+
+            # XOR: 2개 동시 → 400
+            with pytest.raises(HTTPException) as e3:
+                await authorize_attachment(path="x", conversation_id=uuid.uuid4(), story_id=None,
+                                           asset_id=a_ok, db=s, auth=auth, org_id=ORG)
+            assert e3.value.status_code == 400
+    finally:
+        await engine.dispose()

--- a/packages/core-storage/src/index.ts
+++ b/packages/core-storage/src/index.ts
@@ -131,6 +131,7 @@ export type {
 export type {
   IStorageService,
   StorageObjectHead,
+  SignReadOptions,
 } from './interfaces/IStorageService';
 
 export { NullSubscriptionRepository } from './null/NullSubscriptionRepository';

--- a/packages/core-storage/src/interfaces/IStorageService.ts
+++ b/packages/core-storage/src/interfaces/IStorageService.ts
@@ -15,6 +15,12 @@ export interface StorageObjectHead {
   contentType: string | null;
 }
 
+/** signRead 옵션 — 만료·content-disposition(S3·S5 계약: preview=inline / download=attachment). */
+export interface SignReadOptions {
+  expiresInMs?: number;
+  disposition?: 'inline' | 'attachment';
+}
+
 export interface IStorageService {
   /**
    * 객체 업로드. 반환 `url` 은 첨부 메타에 저장되는 canonical 값으로, sign/authorize 경로의
@@ -29,8 +35,8 @@ export interface IStorageService {
     contentType?: string,
   ): Promise<{ url: string }>;
 
-  /** authorize 통과 후 호출되는 단기 만료 read 서명 URL. */
-  signRead(container: string, objectPath: string, expiresInMs?: number): Promise<string>;
+  /** authorize 통과 후 호출되는 단기 만료 read 서명 URL. opts.disposition 으로 inline/attachment 제어. */
+  signRead(container: string, objectPath: string, opts?: SignReadOptions): Promise<string>;
 
   /** 객체 삭제. 객체가 없으면 no-op. */
   deleteObject(container: string, objectPath: string): Promise<void>;


### PR DESCRIPTION
## E-STORAGE-SSOT S3 — authorize asset scope + signed-read disposition

epic `508adc04` · phasing 3. S2 asset registry 객체의 authz/서명 경로.

### 변경
**BE**
- `authorize_attachment`에 **asset_id 분기**(D1·PO: registry=SSOT·BE가 `{container, object_path}` 권위 derive·FE 제공값 trust X·attack surface↓). XOR을 `conversation_id | story_id | asset_id` 3-way로. conv/story 엄격검사 무변경(AC2 IDOR 유지).
  - 인가: project asset=`has_project_access`·org-level(project_id NULL)=verified-org 멤버(AC1). cross-org=org 필터 0행→404(AC4). asset_id가 truth라 외부URL/wrong-bucket 불가(AC3).
- ⚠️ **S2 잠복버그 fix**(이 PR서 포착): `list_assets` `_enrich` 가 `AssetResponse.model_validate(asset)`로 `created_by`(ORM=UUID)를 `CreatedBy` 로 coerce 시도 → **created_by 세팅된 실 asset(메시지/스토리 업로드는 created_by 세팅)에서 list 500**. S2 테스트가 created_by=None만 써서 미포착. base 를 명시 필드 구성으로 수정.

**FE**
- sign route `asset_id`(+ `disposition`) 분기 — asset_id면 BE authorize가 반환한 `{container, object_path}`로 signRead. conv/story 무변경.
- `IStorageService.signRead(container, path, opts?: {expiresInMs, disposition})` — GCS `responseDisposition`·S3 `ResponseContentDisposition`·local serve `Content-Disposition` 헤더. (S5 계약: preview=inline / download=attachment.)

### AC 대응
- AC1 project-access/org-level asset만 ✅ / AC2 conv/story IDOR 무변경 ✅ / AC3 외부·wrong-bucket reject(asset_id=truth) ✅ / AC4 cross-org 404 ✅ / AC5 까심 cross-model — 대기(산티아고 stand-down) / AC6 **S2 fold**: Doc/Message enrich + created_by(member) cross-org 오염 negative ✅

### 테스트 (CI alembic-fresh PG 게이트)
- `test_attachment_authorize_asset_s3.py`: project 200·org-level 200·no-access 403·cross-org 404·XOR 400.
- `test_asset_registry_realdb.py` AC6 fold: Doc/Message enrich + created_by cross-org 오염 → 응답 0(미생성/null).
- real-DB 38종 green · FE tsc + storage 15종 · 풀스위트 2568 pass(잔여 7=기존 MCP env-의존·무관) · 마이그 없음 · ruff/eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
