### PR TITLE
[SID:81066cc8] E-STORAGE-SSOT S7 — board/chat upload → org/project namespace + asset_id denorm

### DIFF
--- a/apps/web/src/app/api/conversations/[conversation_id]/attachments/route.ts
+++ b/apps/web/src/app/api/conversations/[conversation_id]/attachments/route.ts
@@ -38,13 +38,15 @@ export async function POST(
   if (!convRes.ok) {
     return NextResponse.json({ error: { message: 'conversation not found or no access' } }, { status: convRes.status === 403 ? 403 : 404 });
   }
-  const conv = (await convRes.json().catch(() => null)) as { project_id?: string | null } | null;
+  const conv = (await convRes.json().catch(() => null)) as { project_id?: string | null; org_id?: string | null } | null;
   const projectId = conv?.project_id;
-  if (!projectId) {
-    return NextResponse.json({ error: { message: 'conversation project could not be resolved' } }, { status: 422 });
+  const orgId = conv?.org_id;
+  if (!projectId || !orgId) {
+    return NextResponse.json({ error: { message: 'conversation org/project could not be resolved' } }, { status: 422 });
   }
   const safeName = (file.name || 'file').replace(/[^\w.\-]+/g, '_').slice(-128) || 'file';
-  const objectPath = `chat/${projectId}/${conversation_id}/${randomUUID()}-${safeName}`;
+  // E-STORAGE-SSOT S7: org/project namespace(Storage UI 노출)·source segment(conv) 유지(IDOR scope).
+  const objectPath = `org/${orgId}/project/${projectId}/chat/${conversation_id}/${randomUUID()}-${safeName}`;
 
   try {
     const storage = await createStorageService();

--- a/apps/web/src/app/api/stories/[id]/attachments/route.ts
+++ b/apps/web/src/app/api/stories/[id]/attachments/route.ts
@@ -38,13 +38,15 @@ export async function POST(
   if (!storyRes.ok) {
     return NextResponse.json({ error: { message: 'story not found or no access' } }, { status: storyRes.status === 403 ? 403 : 404 });
   }
-  const story = (await storyRes.json().catch(() => null)) as { project_id?: string | null } | null;
+  const story = (await storyRes.json().catch(() => null)) as { project_id?: string | null; org_id?: string | null } | null;
   const projectId = story?.project_id;
-  if (!projectId) {
-    return NextResponse.json({ error: { message: 'story project could not be resolved' } }, { status: 422 });
+  const orgId = story?.org_id;
+  if (!projectId || !orgId) {
+    return NextResponse.json({ error: { message: 'story org/project could not be resolved' } }, { status: 422 });
   }
   const safeName = (file.name || 'file').replace(/[^\w.\-]+/g, '_').slice(-128) || 'file';
-  const objectPath = `story/${projectId}/${id}/${randomUUID()}-${safeName}`;
+  // E-STORAGE-SSOT S7: org/project namespace(Storage UI 노출)·source segment(story) 유지(IDOR scope).
+  const objectPath = `org/${orgId}/project/${projectId}/story/${id}/${randomUUID()}-${safeName}`;
 
   try {
     const storage = await createStorageService();

--- a/backend/app/routers/attachments.py
+++ b/backend/app/routers/attachments.py
@@ -98,8 +98,12 @@ async def authorize_attachment(
     legacy_url = _PUBLIC_PREFIX + path  # legacy stored 형태
 
     if conversation_id is not None:
-        # ① 구조적 스코프: chat/<proj>/<conv_id>/<file> — conv id 가 path segment 여야
-        if not (path.startswith("chat/") and str(conversation_id) in segments):
+        # ① 구조적 스코프: conv id 가 path segment + 우리 namespace(legacy `chat/...` OR S7
+        #    `org/<org>/project/.../chat/...`). 정확 belongs 검사(②)가 실 게이트·이건 defense-in-depth.
+        ns_ok = path.startswith("chat/") or (
+            path.startswith(f"org/{org_id}/project/") and "/chat/" in path
+        )
+        if not (ns_ok and str(conversation_id) in segments):
             raise HTTPException(status_code=403, detail="Attachment path not scoped to this conversation")
         # 권한: conversation 참가자(canonical member). team_member 봐주기 없음.
         member = await resolve_member(auth, org_id, db, project_id=None)
@@ -124,8 +128,11 @@ async def authorize_attachment(
         if not belongs:
             raise HTTPException(status_code=403, detail="Attachment does not belong to this conversation")
     else:
-        # ① 구조적 스코프: story/<proj>/<story_id>/<file>
-        if not (path.startswith("story/") and str(story_id) in segments):
+        # ① 구조적 스코프: story id segment + 우리 namespace(legacy `story/...` OR S7 `org/.../story/...`).
+        ns_ok = path.startswith("story/") or (
+            path.startswith(f"org/{org_id}/project/") and "/story/" in path
+        )
+        if not (ns_ok and str(story_id) in segments):
             raise HTTPException(status_code=403, detail="Attachment path not scoped to this story")
         row = (await db.execute(
             select(Story.project_id, Story.attachments).where(

--- a/backend/app/routers/attachments.py
+++ b/backend/app/routers/attachments.py
@@ -21,8 +21,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.asset import Asset
-from app.models.conversation import ConversationParticipant
+from app.models.conversation import Conversation, ConversationParticipant
 from app.models.pm import Story
+from app.services.asset_registry import path_in_source_scope
 from app.services.member_resolver import resolve_member
 from app.services.project_auth import has_project_access
 
@@ -94,16 +95,20 @@ async def authorize_attachment(
     if not path or "://" in path:
         raise HTTPException(status_code=400, detail="path must be a bare object path")
 
-    segments = path.split("/")
-    legacy_url = _PUBLIC_PREFIX + path  # legacy stored 형태
+    legacy_url = _PUBLIC_PREFIX + path  # legacy stored 형태(belongs 정확매치용)
 
     if conversation_id is not None:
-        # ① 구조적 스코프: conv id 가 path segment + 우리 namespace(legacy `chat/...` OR S7
-        #    `org/<org>/project/.../chat/...`). 정확 belongs 검사(②)가 실 게이트·이건 defense-in-depth.
-        ns_ok = path.startswith("chat/") or (
-            path.startswith(f"org/{org_id}/project/") and "/chat/" in path
-        )
-        if not (ns_ok and str(conversation_id) in segments):
+        # ① 구조적 스코프 — 등록(sync)과 **동일 함수** path_in_source_scope 로 통일(까심 IDOR).
+        #    conv 의 실 project_id 를 DB 조회해 `chat/{proj}/{conv}/`(legacy) 또는
+        #    `org/{org}/project/{proj}/chat/{conv}/`(S7) **exact prefix**만 허용(중간 `/chat/` 우회 차단).
+        conv_proj = (await db.execute(
+            select(Conversation.project_id).where(
+                Conversation.id == conversation_id, Conversation.org_id == org_id
+            )
+        )).scalar_one_or_none()
+        if conv_proj is None:
+            raise HTTPException(status_code=404, detail="Conversation not found")
+        if not path_in_source_scope(path, "conversation_message", conv_proj, conversation_id, org_id):
             raise HTTPException(status_code=403, detail="Attachment path not scoped to this conversation")
         # 권한: conversation 참가자(canonical member). team_member 봐주기 없음.
         member = await resolve_member(auth, org_id, db, project_id=None)
@@ -128,12 +133,8 @@ async def authorize_attachment(
         if not belongs:
             raise HTTPException(status_code=403, detail="Attachment does not belong to this conversation")
     else:
-        # ① 구조적 스코프: story id segment + 우리 namespace(legacy `story/...` OR S7 `org/.../story/...`).
-        ns_ok = path.startswith("story/") or (
-            path.startswith(f"org/{org_id}/project/") and "/story/" in path
-        )
-        if not (ns_ok and str(story_id) in segments):
-            raise HTTPException(status_code=403, detail="Attachment path not scoped to this story")
+        # story 의 실 project_id 를 먼저 조회 — 구조 스코프를 등록과 동일 함수로 통일(까심 IDOR·project
+        # segment 도 story.project_id 와 정확 매치). `story/{proj}/{story}/` + `org/{org}/project/{proj}/story/{story}/`.
         row = (await db.execute(
             select(Story.project_id, Story.attachments).where(
                 Story.id == story_id,
@@ -144,6 +145,8 @@ async def authorize_attachment(
         if row is None:
             raise HTTPException(status_code=404, detail="Story not found")
         project_id, attachments = row
+        if not path_in_source_scope(path, "story", project_id, story_id, org_id):
+            raise HTTPException(status_code=403, detail="Attachment path not scoped to this story")
         if not await has_project_access(db, uuid.UUID(auth.user_id), project_id, org_id):
             raise HTTPException(status_code=403, detail="No access to this project")
         # ② 정확 매치: canonical object path == 요청 path

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -587,6 +587,9 @@ class MessageAttachment(BaseModel):
     name: str          # 원본 파일명
     content_type: str  # MIME
     size: int          # 바이트
+    # E-STORAGE-SSOT S7: asset registry row id(denorm·catch#4). asset_links=SSOT·이 필드=denorm.
+    # optional(legacy 첨부·미등록 호환). save 시 이 값으로 asset_link 파생(drift 0).
+    asset_id: uuid.UUID | None = None
 
     @field_validator("url")
     @classmethod
@@ -1226,8 +1229,9 @@ async def send_message(
     await db.flush()
 
     # E-STORAGE-SSOT S2: 첨부를 asset registry로 동기화(SAVE-time·같은 트랜잭션·orphan 0).
+    # S7: 반환 url→asset_id 로 JSONB asset_id 역기입(denorm·catch#4: asset_links=SSOT·JSONB=denorm).
     if body.attachments:
-        await sync_attachment_assets(
+        url_map = await sync_attachment_assets(
             db,
             org_id=org_id,
             project_id=conv.project_id,
@@ -1236,6 +1240,12 @@ async def send_message(
             attachments=[a.model_dump() for a in body.attachments],
             created_by=sender.id,
         )
+        if url_map:
+            msg.attachments = [
+                {**a, "asset_id": str(url_map[a["url"]])} if a.get("url") in url_map else a
+                for a in (msg.attachments or [])
+            ]
+            await db.flush()
 
     # AC10: Discord 수신자 파악 → SSE dispatch에서 제외 (동일 db 세션, flush 완료 상태)
     discord_exclude_ids: set[uuid.UUID] = set()

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -1210,8 +1210,9 @@ async def send_message(
         content=body.content,
         mentioned_ids=valid_mentioned_ids,
         thread_id=body.thread_id,
-        # E-FILE S1: 첨부 메타(URL+name+content_type+size)를 0093 attachments JSONB에 저장
-        attachments=[a.model_dump() for a in body.attachments],
+        # E-FILE S1: 첨부 메타(URL+name+content_type+size)를 0093 attachments JSONB에 저장.
+        # S7: client 제공 asset_id 는 strip(서버 권위·drift 방지·까심)·아래 sync url_map 으로만 역기입.
+        attachments=[{**a.model_dump(), "asset_id": None} for a in body.attachments],
     )
     db.add(msg)
 

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -247,7 +247,7 @@ async def create_story(
             _cb = await _resolve_team_member_id(auth, org_id, session)
         except Exception:
             _cb = None
-        await sync_attachment_assets(
+        url_map = await sync_attachment_assets(
             session,
             org_id=org_id,
             project_id=story.project_id,
@@ -256,6 +256,12 @@ async def create_story(
             attachments=[a.model_dump() for a in body.attachments],
             created_by=_cb,
         )
+        if url_map:  # S7: JSONB asset_id 역기입(denorm·catch#4)
+            story.attachments = [
+                {**a, "asset_id": str(url_map[a["url"]])} if a.get("url") in url_map else a
+                for a in (story.attachments or [])
+            ]
+            await session.flush()
     # E-BOARD S5: 복수 assignee join 기록 (단일 assignee_id와 공존)
     saved_ids = await StoryAssigneeRepository(session, org_id).set_for_story(story.id, effective_ids)
     # E-CAGE-REFEREE: assignee 설정 시 implementation 역할 participation 자동 생성
@@ -485,7 +491,7 @@ async def update_story(
             _cb = await _resolve_team_member_id(auth, repo.org_id, db)
         except Exception:
             _cb = None
-        await sync_attachment_assets(
+        url_map = await sync_attachment_assets(
             db,
             org_id=repo.org_id,
             project_id=story.project_id,
@@ -494,6 +500,12 @@ async def update_story(
             attachments=data.get("attachments") or [],
             created_by=_cb,
         )
+        if url_map:  # S7: JSONB asset_id 역기입(denorm·catch#4·attachments 교체 반영)
+            story.attachments = [
+                {**a, "asset_id": str(url_map[a["url"]])} if a.get("url") in url_map else a
+                for a in (story.attachments or [])
+            ]
+            await db.flush()
 
     # E-BOARD S5: 복수 assignee join 동기화 (단일 assignee_id와 정합 유지)
     if assignee_ids_in is not None:

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -237,8 +237,8 @@ async def create_story(
         success_hypothesis=body.success_hypothesis,
         metric_definition=body.metric_definition,
         measure_after=body.measure_after,
-        # E-FILE S4: 보드 스토리 첨부 (FE-proxy URL+메타) 저장
-        attachments=[a.model_dump() for a in body.attachments],
+        # E-FILE S4: 보드 스토리 첨부 (FE-proxy URL+메타) 저장. S7: client asset_id strip(서버 권위·drift 방지).
+        attachments=[{**a.model_dump(), "asset_id": None} for a in body.attachments],
     )
     # E-STORAGE-SSOT S2: 첨부를 asset registry로 동기화(SAVE-time·같은 트랜잭션·orphan 0).
     if body.attachments:
@@ -447,6 +447,9 @@ async def update_story(
     auth: AuthContext = Depends(get_current_user),
 ) -> StoryResponse:
     data = body.model_dump(exclude_unset=True)
+    # S7: client 제공 asset_id strip(서버 권위·drift 방지·까심)·아래 sync url_map 으로만 역기입.
+    if data.get("attachments"):
+        data["attachments"] = [{**a, "asset_id": None} for a in data["attachments"]]
     # E-BOARD S5: assignee_ids는 stories 컬럼이 아니므로 repo.update 전에 분리.
     assignee_ids_in = data.pop("assignee_ids", None)
     # assignee_ids만 제공되면 단일 assignee_id(주담당)를 첫 요소로 동기화 → 기존 event/notify 로직 재사용.

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -59,6 +59,8 @@ class StoryAttachment(BaseModel):
     name: str          # 원본 파일명
     content_type: str  # MIME
     size: int          # 바이트
+    # E-STORAGE-SSOT S7: asset registry row id(denorm·catch#4). asset_links=SSOT·이 필드=denorm.
+    asset_id: uuid.UUID | None = None
 
     @field_validator("url")
     @classmethod

--- a/backend/app/services/asset_registry.py
+++ b/backend/app/services/asset_registry.py
@@ -39,18 +39,28 @@ def path_in_source_scope(
     source_type: str,
     project_id: uuid.UUID | None,
     source_id: uuid.UUID,
+    org_id: uuid.UUID | None = None,
 ) -> bool:
     """object_path 가 이 source(=메시지/스토리)에 귀속된 경로인지 검증(IDOR·registry 오염 차단).
 
-    S1 `_is_scoped_to_conversation` 와 동형: 업로드 경로가 resource 에 스코프되므로
-    (`chat/<project>/<conversation>/...`·`story/<project>/<story>/...`) path 가 정확히 이 source 를
-    가리킬 때만 등록한다. 유저가 자기 메시지에 타 project/conv 객체 경로를 심어 registry 를
-    오염시키는 것 방지(까심 적출). manual/doc 은 경로 제약 없음(신뢰 등록·doc=S4).
+    S1 `_is_scoped_to_conversation` 와 동형: 업로드 경로가 resource 에 스코프돼야 등록(유저가 타
+    project/conv 경로 심어 오염 차단·까심). 두 namespace 인식(S7·AC3 무회귀):
+    - legacy: `chat/<project>/<conversation>/...` · `story/<project>/<story>/...`
+    - S7 신: `org/<org>/project/<project>/chat/<conversation>/...` · `.../story/<story>/...`
+    manual/doc 은 경로 제약 없음(신뢰 등록·doc=S4).
     """
     if source_type == "conversation_message":
-        return object_path.startswith(f"chat/{project_id}/{source_id}/")
+        if object_path.startswith(f"chat/{project_id}/{source_id}/"):
+            return True
+        return org_id is not None and object_path.startswith(
+            f"org/{org_id}/project/{project_id}/chat/{source_id}/"
+        )
     if source_type == "story":
-        return object_path.startswith(f"story/{project_id}/{source_id}/")
+        if object_path.startswith(f"story/{project_id}/{source_id}/"):
+            return True
+        return org_id is not None and object_path.startswith(
+            f"org/{org_id}/project/{project_id}/story/{source_id}/"
+        )
     return True
 
 
@@ -64,25 +74,27 @@ async def sync_attachment_assets(
     attachments: list[dict] | None,
     created_by: uuid.UUID | None = None,
     container: str = DEFAULT_CONTAINER,
-) -> list[uuid.UUID]:
+) -> dict[str, uuid.UUID]:
     """첨부 목록을 asset registry 로 동기화(upsert) + asset_link 재조정(reconcile).
 
     - 각 첨부 → asset upsert(멱등 키 container/object_path) → asset_link upsert.
     - source 의 현재 첨부 집합에 없는 기존 link 는 삭제(update 의 attachments 교체 의미 반영·SSOT 정확).
     - 외부 URL/타 버킷 첨부는 우리 객체가 아니므로 스킵.
-    반환: 현재 첨부에 대응하는 asset_id 목록.
+    반환: {원본 첨부 url → asset_id} (S7: 호출부가 JSONB 에 asset_id 역기입·denorm·catch#4).
     """
     if source_type not in ASSET_LINK_SOURCE_TYPES:
         raise ValueError(f"invalid asset link source_type: {source_type}")
 
     asset_ids: list[uuid.UUID] = []
+    url_map: dict[str, uuid.UUID] = {}
     for att in attachments or []:
         if not isinstance(att, dict):
             continue
-        obj = canonical_object_path(att.get("url") or "", container)
+        raw_url = att.get("url") or ""
+        obj = canonical_object_path(raw_url, container)
         if obj is None:
             continue  # 외부/비정상 — 우리 객체 아님
-        if not path_in_source_scope(obj, source_type, project_id, source_id):
+        if not path_in_source_scope(obj, source_type, project_id, source_id, org_id):
             continue  # 이 source 귀속 경로 아님 — registry 오염/IDOR 차단(까심)
         name = (att.get("name") or "").strip() or obj.rsplit("/", 1)[-1] or "file"
         content_type = (att.get("content_type") or "").strip() or None
@@ -122,6 +134,7 @@ async def sync_attachment_assets(
                 else sel.where(Asset.project_id.is_(None))
             asset_id = (await session.execute(sel)).scalar_one()
         asset_ids.append(asset_id)
+        url_map[raw_url] = asset_id  # JSONB asset_id 역기입용(denorm)
 
         await session.execute(
             pg_insert(AssetLink)
@@ -144,4 +157,4 @@ async def sync_attachment_assets(
         stale = stale.where(AssetLink.asset_id.not_in(asset_ids))
     await session.execute(stale)
 
-    return asset_ids
+    return url_map

--- a/backend/tests/test_asset_canonical.py
+++ b/backend/tests/test_asset_canonical.py
@@ -36,3 +36,42 @@ def test_external_or_other_bucket_is_none(external):
 def test_empty_is_none():
     assert canonical_object_path("", _BUCKET) is None
     assert canonical_object_path(_PREFIX, _BUCKET) is None  # prefix-only → 빈 path
+
+
+# E-STORAGE-SSOT S7 — path_in_source_scope: legacy + 신 org/project namespace 인식(DB 무관).
+import uuid as _uuid  # noqa: E402
+from app.services.asset_registry import path_in_source_scope  # noqa: E402
+
+_ORG = _uuid.UUID("11111111-1111-1111-1111-111111111111")
+_PROJ = _uuid.UUID("22222222-2222-2222-2222-222222222222")
+_CONV = _uuid.UUID("33333333-3333-3333-3333-333333333333")
+_STORY = _uuid.UUID("44444444-4444-4444-4444-444444444444")
+
+
+def test_scope_legacy_namespace():
+    assert path_in_source_scope(f"chat/{_PROJ}/{_CONV}/u.png", "conversation_message", _PROJ, _CONV, _ORG)
+    assert path_in_source_scope(f"story/{_PROJ}/{_STORY}/u.png", "story", _PROJ, _STORY, _ORG)
+
+
+def test_scope_s7_org_namespace():
+    assert path_in_source_scope(
+        f"org/{_ORG}/project/{_PROJ}/chat/{_CONV}/u.png", "conversation_message", _PROJ, _CONV, _ORG)
+    assert path_in_source_scope(
+        f"org/{_ORG}/project/{_PROJ}/story/{_STORY}/u.png", "story", _PROJ, _STORY, _ORG)
+
+
+def test_scope_rejects_wrong_source_or_org():
+    other = _uuid.uuid4()
+    # 타 conv
+    assert not path_in_source_scope(
+        f"org/{_ORG}/project/{_PROJ}/chat/{other}/u.png", "conversation_message", _PROJ, _CONV, _ORG)
+    # 타 org(신 namespace인데 org 불일치)
+    assert not path_in_source_scope(
+        f"org/{other}/project/{_PROJ}/chat/{_CONV}/u.png", "conversation_message", _PROJ, _CONV, _ORG)
+    # org_id 없이 신 namespace → 거부(legacy만 허용)
+    assert not path_in_source_scope(
+        f"org/{_ORG}/project/{_PROJ}/chat/{_CONV}/u.png", "conversation_message", _PROJ, _CONV, None)
+
+
+def test_scope_manual_unconstrained():
+    assert path_in_source_scope("anything/x.png", "manual", _PROJ, _uuid.uuid4(), _ORG)

--- a/backend/tests/test_asset_registry_realdb.py
+++ b/backend/tests/test_asset_registry_realdb.py
@@ -592,3 +592,41 @@ async def test_s7_new_namespace_sync_and_asset_id_map():
             assert new_path in url_map2 and bad not in url_map2
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_jsonb_asset_id_no_drift_with_strip():
+    """까심 drift: client 제공 asset_id 를 strip + 서버 url_map 만 역기입 → skip된 첨부에 asset_id 미잔존·
+    asset_links(SSOT)와 정합(handler 로직 동형: strip→sync→writeback)."""
+    from app.services.asset_registry import sync_attachment_assets
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            src = uuid.uuid4()
+            scoped = f"story/{PROJ_A}/{src}/u-a.png"
+            external = "https://evil.example/x.png"  # 우리 객체 아님 → sync skip
+            client_atts = [
+                {**_att(scoped), "asset_id": str(uuid.uuid4())},    # bogus client asset_id
+                {**_att(external), "asset_id": str(uuid.uuid4())},  # bogus + skip 대상
+            ]
+            stripped = [{**a, "asset_id": None} for a in client_atts]  # handler strip
+            url_map = await sync_attachment_assets(
+                s, org_id=ORG, project_id=PROJ_A, source_type="story", source_id=src, attachments=stripped,
+            )
+            await s.commit()
+            final = [
+                {**a, "asset_id": str(url_map[a["url"]])} if a["url"] in url_map else a
+                for a in stripped
+            ]
+            by_url = {a["url"]: a["asset_id"] for a in final}
+            assert by_url[scoped] == str(url_map[scoped])  # 서버 asset_id
+            assert by_url[external] is None  # skip된 첨부=asset_id None(client bogus 미잔존·drift 0)
+            n = (await s.execute(text(
+                f"SELECT count(*) FROM asset_links WHERE source_id='{src}' AND source_type='story'"
+            ))).scalar_one()
+            assert n == 1  # asset_links SSOT=등록된 1건만
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_asset_registry_realdb.py
+++ b/backend/tests/test_asset_registry_realdb.py
@@ -553,3 +553,42 @@ async def test_enrich_negative_doc_message_member_s3_fold():
             await s.commit()
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_s7_new_namespace_sync_and_asset_id_map():
+    """S7: 신 org/project namespace 업로드가 registry 등록·url→asset_id 맵 반환(JSONB denorm용)·
+    legacy 무회귀·타 org namespace 스코프 거부."""
+    from app.services.asset_registry import sync_attachment_assets
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            src = uuid.uuid4()
+            new_path = f"org/{ORG}/project/{PROJ_A}/story/{src}/u-a.png"
+            legacy_path = f"story/{PROJ_A}/{src}/u-b.png"
+            url_map = await sync_attachment_assets(
+                s, org_id=ORG, project_id=PROJ_A, source_type="story", source_id=src,
+                attachments=[_att(new_path), _att(legacy_path)],
+            )
+            await s.commit()
+            # 신 namespace + legacy 둘 다 등록(AC1/AC3)·url→asset_id 맵 반환(AC2 denorm)
+            assert new_path in url_map and legacy_path in url_map
+            n = (await s.execute(text(
+                f"SELECT count(*) FROM assets WHERE org_id='{ORG}' AND project_id='{PROJ_A}' "
+                f"AND object_path IN ('{new_path}','{legacy_path}')"
+            ))).scalar_one()
+            assert n == 2
+
+            # 타 org namespace(org 불일치)는 스코프 거부→미등록(IDOR)
+            bad = f"org/{uuid.uuid4()}/project/{PROJ_A}/story/{src}/x.png"
+            url_map2 = await sync_attachment_assets(
+                s, org_id=ORG, project_id=PROJ_A, source_type="story", source_id=src,
+                attachments=[_att(new_path), _att(bad)],
+            )
+            await s.commit()
+            assert new_path in url_map2 and bad not in url_map2
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_attachment_authorize_a54ddc16.py
+++ b/backend/tests/test_attachment_authorize_a54ddc16.py
@@ -94,7 +94,8 @@ async def test_authorize_400_path_with_scheme():
 @pytest.mark.anyio
 async def test_authorize_conversation_participant_and_belongs_200():
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[_scalar(uuid.uuid4()), _scalar(True)])  # participant, belongs
+    # S7: conv project_id 조회(스코프 통일) → participant → belongs
+    session.execute = AsyncMock(side_effect=[_scalar(PROJECT_ID), _scalar(uuid.uuid4()), _scalar(True)])
     client, app = await _client(session)
     try:
         with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()):
@@ -106,16 +107,15 @@ async def test_authorize_conversation_participant_and_belongs_200():
 
 @pytest.mark.anyio
 async def test_authorize_conversation_path_not_scoped_403():
-    """구조적 스코프 위반(다른 conv id 의 path)은 권한쿼리 전에 403 — cross-resource 차단."""
+    """구조적 스코프 위반(다른 conv id 의 path)은 conv project 조회 직후 스코프 게이트서 403."""
     session = AsyncMock()
-    session.execute = AsyncMock()  # 호출되면 안 됨
+    session.execute = AsyncMock(side_effect=[_scalar(PROJECT_ID)])  # conv project 조회만(스코프서 차단)
     other_conv = uuid.uuid4()
     client, app = await _client(session)
     try:
         with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()):
             r = await _get(client, f"path=chat/{PROJECT_ID}/{other_conv}/u-victim.png&conversation_id={CONV_ID}")
-        assert r.status_code == 403
-        session.execute.assert_not_awaited()  # 스코프 게이트서 차단
+        assert r.status_code == 403  # participant/belongs 쿼리 전 스코프 차단
     finally:
         app.dependency_overrides.clear()
 
@@ -123,7 +123,7 @@ async def test_authorize_conversation_path_not_scoped_403():
 @pytest.mark.anyio
 async def test_authorize_conversation_not_participant_403():
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[_scalar(None)])  # 비참가
+    session.execute = AsyncMock(side_effect=[_scalar(PROJECT_ID), _scalar(None)])  # conv project, 비참가
     client, app = await _client(session)
     try:
         with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()):
@@ -137,7 +137,7 @@ async def test_authorize_conversation_not_participant_403():
 async def test_authorize_conversation_belong_exact_miss_403():
     """구조 스코프 통과·참가자지만 stored 와 정확 일치 안 하면 403(substring 아님)."""
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[_scalar(uuid.uuid4()), _scalar(False)])
+    session.execute = AsyncMock(side_effect=[_scalar(PROJECT_ID), _scalar(uuid.uuid4()), _scalar(False)])
     client, app = await _client(session)
     try:
         with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()):
@@ -211,7 +211,8 @@ STORY_PATH_S7 = f"org/{ORG_ID}/project/{PROJECT_ID}/story/{STORY_ID}/u1-abc.png"
 @pytest.mark.anyio
 async def test_authorize_conversation_s7_namespace_200():
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[_scalar(uuid.uuid4()), _scalar(True)])
+    # conv project=PROJECT_ID → path_in_source_scope 통과(신 namespace) → participant → belongs
+    session.execute = AsyncMock(side_effect=[_scalar(PROJECT_ID), _scalar(uuid.uuid4()), _scalar(True)])
     client, app = await _client(session)
     try:
         with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()):
@@ -236,15 +237,34 @@ async def test_authorize_story_s7_namespace_200():
 
 @pytest.mark.anyio
 async def test_authorize_conversation_s7_wrong_org_403():
-    """신 namespace인데 org 불일치(타 org path) → 구조 스코프 거부(403)."""
+    """신 namespace 우회 시도(타 org/타 project/중간 /chat/) → exact-prefix 스코프 거부(403·까심 IDOR)."""
     import uuid as _u
-    bad = f"org/{_u.uuid4()}/project/{PROJECT_ID}/chat/{CONV_ID}/u.png"
+    # 타 org + 중간 /chat/ 삽입(`org/<타org>/project/<proj>/evil/chat/<conv>/`)
+    bad = f"org/{_u.uuid4()}/project/{PROJECT_ID}/evil/chat/{CONV_ID}/u.png"
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[_scalar(uuid.uuid4()), _scalar(True)])
+    session.execute = AsyncMock(side_effect=[_scalar(PROJECT_ID)])  # conv project 조회 후 스코프서 차단
     client, app = await _client(session)
     try:
         with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()):
             r = await _get(client, f"path={bad}&conversation_id={CONV_ID}")
         assert r.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_authorize_conversation_s7_same_org_cross_project_idor_403():
+    """까심 IDOR: 같은 org·타 project namespace + 중간 /chat/ 삽입 → exact-prefix 스코프 거부(403).
+    conv 실 project=PROJECT_ID 인데 path 는 타 project → path_in_source_scope 불일치."""
+    import uuid as _u
+    victim_proj = _u.uuid4()
+    bad = f"org/{ORG_ID}/project/{victim_proj}/evil/chat/{CONV_ID}/secret.png"
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_scalar(PROJECT_ID)])  # conv project=PROJECT_ID
+    client, app = await _client(session)
+    try:
+        with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()):
+            r = await _get(client, f"path={bad}&conversation_id={CONV_ID}")
+        assert r.status_code == 403  # 타 project 경로 서명 차단(IDOR)
     finally:
         app.dependency_overrides.clear()

--- a/backend/tests/test_attachment_authorize_a54ddc16.py
+++ b/backend/tests/test_attachment_authorize_a54ddc16.py
@@ -201,3 +201,50 @@ async def test_authorize_story_no_access_403():
         assert r.status_code == 403
     finally:
         app.dependency_overrides.clear()
+
+
+# E-STORAGE-SSOT S7 — authorize 가 신 org/project namespace 도 인식(legacy 무회귀·신 upload 렌더).
+CONV_PATH_S7 = f"org/{ORG_ID}/project/{PROJECT_ID}/chat/{CONV_ID}/u1-abc.png"
+STORY_PATH_S7 = f"org/{ORG_ID}/project/{PROJECT_ID}/story/{STORY_ID}/u1-abc.png"
+
+
+@pytest.mark.anyio
+async def test_authorize_conversation_s7_namespace_200():
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_scalar(uuid.uuid4()), _scalar(True)])
+    client, app = await _client(session)
+    try:
+        with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()):
+            r = await _get(client, f"path={CONV_PATH_S7}&conversation_id={CONV_ID}")
+        assert r.status_code == 200 and r.json()["authorized"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_authorize_story_s7_namespace_200():
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_story_row([{"url": STORY_PATH_S7}]))
+    client, app = await _client(session)
+    try:
+        with patch("app.routers.attachments.has_project_access", new_callable=AsyncMock, return_value=True):
+            r = await _get(client, f"path={STORY_PATH_S7}&story_id={STORY_ID}")
+        assert r.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_authorize_conversation_s7_wrong_org_403():
+    """신 namespace인데 org 불일치(타 org path) → 구조 스코프 거부(403)."""
+    import uuid as _u
+    bad = f"org/{_u.uuid4()}/project/{PROJECT_ID}/chat/{CONV_ID}/u.png"
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_scalar(uuid.uuid4()), _scalar(True)])
+    client, app = await _client(session)
+    try:
+        with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()):
+            r = await _get(client, f"path={bad}&conversation_id={CONV_ID}")
+        assert r.status_code == 403
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## E-STORAGE-SSOT S7 — board/chat upload → org/project namespace + asset_id denorm

epic `508adc04` · phasing 4. chat/story 업로드를 org/project namespace로 전환 + JSONB `asset_id` denorm(catch#4).

### 설계 (PO crux)
- **#1 save-time 생성(B·orphan 0·S2-D1 일관)**: 업로드는 신 namespace `{url}`만 반환, SAVE sync가 asset 생성 + `asset_id`를 JSONB 역기입. Storage UI는 전송된 asset만 노출(미전송=transient).
- **#2 namespace** = `org/<org>/project/<proj>/{chat|story}/<source>/...` (IDOR scope segment 유지).
- **#3 산티아고 stand-down**.

### 변경
- FE 업로드 route(conv/story): namespace 전환(`org_id`는 conversation/story GET 응답서 도출).
- `path_in_source_scope`: 신 org/project namespace + legacy 둘 다 인식(`org_id` 인자·AC3 무회귀·타 org/source 거부).
- `sync_attachment_assets`: 반환 `{url→asset_id}` 맵(JSONB 역기입용)·scope에 org_id 전달.
- `MessageAttachment`/`StoryAttachment`에 `asset_id` optional 필드(AC2 denorm·asset_links=SSOT).
- send_message / story create·update: sync 후 JSONB attachments에 `asset_id` 역기입(drift 0).
- **AC3 catch(자가 포착)**: 신 namespace 업로드를 기존 path-기반 sign 으로 렌더 시 `authorize_attachment` 구조 스코프가 `chat/`/`story/` prefix만 봐서 403 → 신 upload 렌더 깨짐. conv/story 구조 스코프를 legacy + 신 namespace 둘 다 인식하도록 확장(belongs 정확검사=실 게이트 무변경·타 org 거부).

### AC
- AC1 신 upload이 Storage UI org/project 노출(asset row project_id) ✅ / AC2 JSONB asset_id+url denorm ✅ / AC3 기존+신 렌더 무회귀(authorize 양 namespace) ✅ / AC4 까심 cross-model(산티아고 stand-down) — 대기.

### 테스트 (CI alembic-fresh PG)
- `path_in_source_scope` 신/legacy/거부 unit 4 · 신 namespace sync + asset_id 맵 + legacy 무회귀 + 타 org 거부 realdb · authorize 신 namespace 200 + 타 org 403.
- BE 33 + authorize 13 green · 풀스위트 2572 pass(잔여 7=기존 MCP env) · FE tsc + storage 15 · 마이그 없음(asset_id=JSONB 내부) · ruff/eslint clean(신규파일).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
