### PR TITLE
[SID:4ab04747] storage RC — 삭제 다이얼로그 파일명 누락 fix (t.rich 태그형)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -106,7 +106,7 @@
     "delete": "Delete",
     "cancel": "Cancel",
     "deleteTitle": "Delete this asset?",
-    "deleteBody": "Deleting {name} can't be undone.",
+    "deleteBody": "Deleting <b>{name}</b> can't be undone.",
     "deleteImpact": "This asset is currently used in {count} place(s) — deleting it will break the links below.",
     "selectPrompt": "Select an asset to see its details.",
     "emptyTitle": "No assets yet",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -106,7 +106,7 @@
     "delete": "삭제",
     "cancel": "취소",
     "deleteTitle": "자산을 삭제할까요?",
-    "deleteBody": "{name}을(를) 삭제하면 되돌릴 수 없습니다.",
+    "deleteBody": "<b>{name}</b>을(를) 삭제하면 되돌릴 수 없습니다.",
     "deleteImpact": "이 자산은 현재 {count}곳에서 사용 중입니다 — 삭제하면 아래 항목의 링크가 끊어집니다.",
     "selectPrompt": "자산을 선택하면 상세 정보가 표시됩니다.",
     "emptyTitle": "아직 자산이 없습니다",

--- a/apps/web/src/components/storage/storage-delete-dialog.tsx
+++ b/apps/web/src/components/storage/storage-delete-dialog.tsx
@@ -62,7 +62,8 @@ export function StorageDeleteDialog({ asset, open, onOpenChange, onDeleted }: St
               {/* Body */}
               <div className="px-[18px] pb-[14px] pt-[4px] text-[13px] leading-[1.55] text-muted-foreground">
                 {t.rich('deleteBody', {
-                  name: () => <b className="font-semibold text-foreground">{asset.name}</b>,
+                  name: asset.name,
+                  b: (chunks) => <b className="font-semibold text-foreground">{chunks}</b>,
                 })}
 
                 {usageCount > 0 ? (


### PR DESCRIPTION
## 배경
S5 Storage UI(#1752) 머지 後 **dev 라이브 픽셀 스모크에서 적출**한 런타임 i18n 버그 핫픽스. 정적 가디언·까심 QA·`pnpm build`가 못 잡은 클래스(런타임 next-intl 렌더).

## 버그
삭제 다이얼로그 본문이 `"을(를) 삭제하면 되돌릴 수 없습니다."`로 **파일명 누락** — DOM 실측: `<b>` 노드 0개·`image.png` 부재.
원인: `t.rich('deleteBody', { name: () => <b>… })` — next-intl `{name}` **값 placeholder**에 **함수**(=태그 핸들러용)를 넘겨 미렌더(빈 출력).

## 수정 (next-intl 정규 태그 패턴)
- 메시지(en·ko): `{name}` → `<b>{name}</b>`
  - ko: `"<b>{name}</b>을(를) 삭제하면 되돌릴 수 없습니다."`
  - en: `"Deleting <b>{name}</b> can't be undone."`
- 호출: `t.rich('deleteBody', { name: asset.name, b: (chunks) => <b className="font-semibold text-foreground">{chunks}</b> })`

## 범위
3파일·4+/3- (delete-dialog.tsx + en/ko deleteBody). 레이아웃/토큰/위계 무변경 — 유나 정적 PASS 유효. 나머지 스모크 항목(3존·아바타3·source 4타입·양테마·정렬·summary·사용처)은 라이브 PASS 확인.

## 검증
- `pnpm build` 그린.
- 머지+재배포 後 dev 픽셀 라이브 재검(파일명 렌더 확인) 예정 — 이전 버그가 build-green이었던 만큼 끝단 라이브 확인까지 done 판정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)