### PR TITLE
[SID:c1cd484b] 칸반 상태전이 정공법 BE — allow + violation flag (FE #1755 동반)

### DIFF
--- a/backend/app/repositories/story.py
+++ b/backend/app/repositories/story.py
@@ -88,7 +88,7 @@ class StoryRepository(BaseRepository[Story]):
         return updated
 
     async def set_status(
-        self, id: uuid.UUID, new_status: str, violation_level: str = "block"
+        self, id: uuid.UUID, new_status: str, violation_level: str = "warn"
     ) -> Story:
         story = await self.get(id)
         if story is None:

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -37,7 +37,11 @@ from app.services.workflow_line_status import (
 )
 from app.services.workflow_pipeline import process_event
 from app.services.rule_evaluator import EventContext
-from app.services.workflow_violation import build_violation_event, check_transition
+from app.services.workflow_violation import (
+    build_violation_event,
+    build_violation_flag,
+    check_transition,
+)
 
 router = APIRouter(prefix="/api/v2/stories", tags=["stories"])
 
@@ -409,14 +413,28 @@ async def bulk_update_stories(
     payload: BulkUpdateRequest,
     db: AsyncSession = Depends(get_db),
     repo: StoryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[StoryResponse]:
+    # 정공법 A(c1cd484b): /bulk 도 /status 와 동일 — status 변경을 항상 allow 하되 비순차 전진 점프는
+    # violation flag(응답)+workflow_violation 이벤트로 가시화(차단 X). dnd 양경로(드래그·메뉴) 공통 SSOT.
+    # violation 웹훅 수신자 필터용 actor 1회 해소(org-wide fan-out 박멸·/status 와 동형).
+    actor_id: uuid.UUID | None = None
+    try:
+        actor_id = await _resolve_team_member_id(auth, repo.org_id, db)
+    except Exception:  # noqa: BLE001 — actor 해소 실패도 bulk 비차단.
+        actor_id = None
+
     updated: list[Story] = []
+    old_status_by_id: dict[uuid.UUID, str] = {}
     for item in payload.items:
         q = await db.execute(select(Story).where(Story.id == item.id))
         story = q.scalar_one_or_none()
         if not story:
             continue
         update_data = item.model_dump(exclude={"id"}, exclude_none=True)
+        # status 변경이면 전이 前 old_status 포착(violation 판정용·setattr 前).
+        if "status" in update_data and update_data["status"] != story.status:
+            old_status_by_id[story.id] = story.status
         for k, v in update_data.items():
             setattr(story, k, v)
         # E-BOARD S5: 단일 assignee_id 변경 시 join 미러(단일↔복수 공존 정합)
@@ -432,8 +450,40 @@ async def bulk_update_stories(
         await db.refresh(s)
     # refresh 後 transient assignee_ids 세팅(refresh 는 매핑 컬럼만 reload·transient 보존).
     await _attach_assignee_ids(db, repo.org_id, updated)
-    results = [StoryResponse.model_validate(s) for s in updated]
+
+    # 응답(violation flag 포함) + violation 이벤트 페이로드를 commit 前에 빌드(commit 시 attr expire→
+    # MissingGreenlet 방지·기존 results 빌드와 동일 시점). 이벤트 발화는 commit 後(/status 와 동일 순서).
+    results: list[StoryResponse] = []
+    violation_dispatch: list[tuple[dict, set[uuid.UUID]]] = []
+    for s in updated:
+        r = StoryResponse.model_validate(s)
+        old = old_status_by_id.get(s.id)
+        flag = build_violation_flag(old, s.status) if old is not None else None
+        r.violation = flag
+        results.append(r)
+        if flag is not None:
+            _ev = build_violation_event(
+                story_id=str(s.id), story_title=s.title, project_id=str(s.project_id),
+                org_id=str(repo.org_id), old_status=old, new_status=s.status,
+                reason=f"'{old}' → '{s.status}' 전이: {flag['skipped']}단계 건너뜀", severity="warn",
+            )
+            _notify = {m for m in (actor_id, s.assignee_id) if m is not None}
+            violation_dispatch.append((_ev, _notify))
+
     await db.commit()
+
+    # workflow_violation 발화(commit 後·기존 이벤트 타입이라 additive·기존 컨슈머 무영향). 실패는 비차단.
+    for _ev, _notify in violation_dispatch:
+        try:
+            publish_event(str(repo.org_id), "workflow_violation", _ev)
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            await fire_webhooks(
+                db, repo.org_id, "workflow_violation", _ev, recipient_member_ids=_notify,
+            )
+        except Exception:  # noqa: BLE001
+            pass
     return results
 
 
@@ -900,7 +950,10 @@ async def update_story_status(
         )
 
     await _attach_assignee_ids(db, repo.org_id, [story])
-    return StoryResponse.model_validate(story)
+    resp = StoryResponse.model_validate(story)
+    # 정공법 A: 비순차 점프면 응답에 violation flag(차단 없이 가시화·/bulk 와 동일 SSOT).
+    resp.violation = build_violation_flag(old_status, story.status)
+    return resp
 
 
 # ─── Schemas ──────────────────────────────────────────────────────────────────

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -761,17 +761,11 @@ async def update_story_status(
     story_before = await repo.get(id)
     old_status = story_before.status if story_before else None
 
-    # AC1/AC5/AC7: violation 체크 — block 모드면 전이 거부
-    from app.models.project import Project as ProjectModel
-    _proj_result = await db.execute(
-        select(ProjectModel).where(ProjectModel.id == story_before.project_id)
-    ) if story_before else None
-    _proj = _proj_result.scalar_one_or_none() if _proj_result else None
-    _violation_level = getattr(_proj, "violation_level", "warn") if _proj else "warn"
-
-    _violation = check_transition(old_status, body.status, _violation_level)
-    if _violation.violated and _violation_level == "block":
-        raise HTTPException(status_code=400, detail=_violation.reason or "워크플로우 위반으로 상태 전이가 거부되었습니다.")
+    # 정공법 A(c1cd484b·선생님 지시): 전이 순서 **하드블록 폐지** — 비순차 점프도 항상 allow,
+    # violation 은 warn 기록(이벤트)+응답 flag 로만 가시화. projects.violation_level=="block" 잔존이
+    # `/status`=block vs `/bulk`=pass SSOT 역설("정신병" 일부 경로 생존)을 만들던 걸 제거(까심 ②).
+    # → 전이-순서는 항상 warn. E-DG merge-gate/워크플로우 라인 엔진(아래)은 직교라 그대로 유지.
+    _violation = check_transition(old_status, body.status, "warn")
 
     # E-DG S5(P0-2): enforcing 라인의 merge-gate step이 이 전이를 거버닝하면, 아래 라인 엔진이
     # evaluate_merge_gate를 단일 평가한다 → 여기 _preflight_merge_gate/enforce_gate(done)는 skip해
@@ -849,7 +843,7 @@ async def update_story_status(
 
     try:
         # AC2: violation_level 전달 → warn 모드이면 set_status hard block 우회
-        story = await repo.set_status(id, body.status, violation_level=_violation_level)
+        story = await repo.set_status(id, body.status, violation_level="warn")
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -900,8 +894,8 @@ async def update_story_status(
 
     if old_status != story.status:
         org_id = repo.org_id
-        # AC2/3/4/6: warn 모드 위반 — 전이는 정상 진행, 이벤트+웹훅만 발행
-        if _violation.violated and _violation_level == "warn":
+        # AC2/3/4/6: 위반 — 전이는 항상 정상 진행(하드블록 폐지), 이벤트+웹훅만 발행(가시화).
+        if _violation.violated:
             _v_event = build_violation_event(
                 story_id=str(id),
                 story_title=story.title,

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -201,3 +201,13 @@ class StoryResponse(BaseModel):
     is_excluded: bool = False
     created_at: datetime
     updated_at: datetime
+    # 칸반 정공법(c1cd484b): 비순차 전진 점프 시 응답에 위반 flag(차단 X·FE 가시화). 정상/역방향=None.
+    # shape: {level:"warn", from, to, skipped}. /status·/bulk 동일. 라우터가 model_validate 後 직접 세팅.
+    violation: dict[str, Any] | None = None
+
+    @field_validator("violation", mode="before")
+    @classmethod
+    def _coerce_violation(cls, v):
+        # violation 은 ORM 컬럼이 아님 — from_attributes 시 비-dict(MagicMock auto-attr 등)는 None 처리
+        # (_coerce_attachments 와 동형). 실제 flag 는 라우터가 model_validate 後 dict 로 할당한다.
+        return v if isinstance(v, dict) else None

--- a/backend/app/services/workflow_violation.py
+++ b/backend/app/services/workflow_violation.py
@@ -60,6 +60,26 @@ def check_transition(
     return ViolationResult(violated=False)
 
 
+def build_violation_flag(old_status: str | None, new_status: str) -> dict | None:
+    """정공법 A(c1cd484b): 비순차 전진 점프를 응답용 violation flag 로 변환(차단 X·FE 가시화).
+
+    `/status`·`/bulk` **공통 SSOT** — 두 경로가 동일 판정·동일 shape 를 쓰도록 단일 함수로 둔다.
+    정상 인접 전이·역방향 reopen(정당한 rework) → None. 2단계+ 전진 점프 → flag.
+    shape: {level, from, to, skipped}. skipped = 건너뛴 중간 단계 수(new_rank-old_rank-1).
+    """
+    res = check_transition(old_status, new_status, "warn")
+    if not res.violated:
+        return None
+    old_rank = _STATUS_RANK.get(old_status or "", 0)
+    new_rank = _STATUS_RANK.get(new_status, 0)
+    return {
+        "level": "warn",
+        "from": old_status,
+        "to": new_status,
+        "skipped": max(1, new_rank - old_rank - 1),
+    }
+
+
 def build_violation_event(
     story_id: str,
     story_title: str,

--- a/backend/tests/test_stories.py
+++ b/backend/tests/test_stories.py
@@ -219,22 +219,30 @@ async def test_status_transition_200():
 
 
 @pytest.mark.anyio
-async def test_status_transition_invalid_400():
-    """backlog → done 비순차 전이 → 400."""
+async def test_status_nonsequential_jump_allowed_with_violation():
+    """정공법 A(c1cd484b): 비순차 전진 점프(backlog→in-review)는 하드블록 폐지 → 200(allow) + violation flag.
+    (이전엔 400 차단 — '정신병' 근원. /bulk 와 SSOT 동형.)"""
     client, session, app = await _client()
     try:
-        backlog_story = _mock_story("backlog")
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = backlog_story
-        session.execute = AsyncMock(return_value=mock_result)
+        story = _mock_story("backlog")
+
+        async def mock_execute(stmt, *args, **kwargs):
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = story
+            return result
+        session.execute = mock_execute
 
         async with client as c:
             resp = await c.patch(
                 f"/api/v2/stories/{STORY_ID}/status",
-                json={"status": "done"},
+                json={"status": "in-review"},
             )
 
-        assert resp.status_code == 400
+        assert resp.status_code == 200
+        v = resp.json()["violation"]
+        assert v is not None
+        assert v["level"] == "warn" and v["from"] == "backlog" and v["to"] == "in-review"
+        assert v["skipped"] == 2  # ready-for-dev, in-progress 건너뜀
     finally:
         app.dependency_overrides.clear()
 
@@ -326,14 +334,17 @@ async def test_status_same_status_idempotent_200(status: str):
     ("in-review", "in-progress"),
     ("ready-for-dev", "backlog"),
 ])
-async def test_status_backward_transition_400(from_status: str, to_status: str):
-    """역방향 전이 거부 → 400."""
+async def test_status_backward_transition_allowed(from_status: str, to_status: str):
+    """정공법 A: 역방향 전이(reopen)는 정당한 rework → 200(allow)·violation 없음(null). (이전엔 400.)"""
     client, session, app = await _client()
     try:
         story = _mock_story(from_status)
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = story
-        session.execute = AsyncMock(return_value=mock_result)
+
+        async def mock_execute(stmt, *args, **kwargs):
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = story
+            return result
+        session.execute = mock_execute
 
         async with client as c:
             resp = await c.patch(
@@ -341,7 +352,8 @@ async def test_status_backward_transition_400(from_status: str, to_status: str):
                 json={"status": to_status},
             )
 
-        assert resp.status_code == 400
+        assert resp.status_code == 200
+        assert resp.json()["violation"] is None
     finally:
         app.dependency_overrides.clear()
 

--- a/backend/tests/test_stories_bulk_body_contract.py
+++ b/backend/tests/test_stories_bulk_body_contract.py
@@ -64,13 +64,72 @@ async def test_bulk_handler_refreshes_and_serializes(monkeypatch):
     repo.org_id = uuid.uuid4()
 
     monkeypatch.setattr(stories_mod, "_attach_assignee_ids", AsyncMock())
+    monkeypatch.setattr(stories_mod, "_resolve_team_member_id", AsyncMock(return_value=None))
     # ⚠️ model_validate 는 모킹하지 않는다 — 실 직렬화를 태워야 P0 3차류를 잡는다.
 
     payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": "done"}])
-    result = await bulk_update_stories(payload, db, repo)
+    result = await bulk_update_stories(payload, db, repo, auth=MagicMock())
 
     assert story.status == "done"  # setattr 적용
     db.refresh.assert_awaited_once_with(story)  # MissingGreenlet fix 가드(refresh 누락 시 실패)
     assert len(result) == 1 and result[0].status == "done"  # 실 StoryResponse 직렬화 통과
     assert result[0].id == story.id
     db.commit.assert_awaited_once()
+    # status="todo"(미지 rank)→done = 위반 판정 불가 → violation None(allow·무플래그).
+    assert result[0].violation is None
+
+
+@pytest.mark.anyio
+async def test_bulk_nonsequential_jump_flags_violation_but_allows(monkeypatch):
+    """정공법 A: /bulk 2단계+ 전진 점프 → 차단 없이 violation flag 반환 + 이벤트 발행(가시화)."""
+    story = _full_story()
+    story.status = "backlog"  # backlog → in-progress = ready-for-dev 1단계 건너뜀
+    exec_result = MagicMock()
+    exec_result.scalar_one_or_none = MagicMock(return_value=story)
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=exec_result)
+    db.flush = AsyncMock(); db.refresh = AsyncMock(); db.commit = AsyncMock()
+    repo = MagicMock(); repo.org_id = uuid.uuid4()
+
+    monkeypatch.setattr(stories_mod, "_attach_assignee_ids", AsyncMock())
+    monkeypatch.setattr(stories_mod, "_resolve_team_member_id", AsyncMock(return_value=None))
+    _pub = MagicMock(); _fire = AsyncMock()
+    monkeypatch.setattr(stories_mod, "publish_event", _pub)
+    monkeypatch.setattr(stories_mod, "fire_webhooks", _fire)
+
+    payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": "in-progress"}])
+    result = await bulk_update_stories(payload, db, repo, auth=MagicMock())
+
+    assert story.status == "in-progress"  # allow(차단 X)
+    assert result[0].violation == {
+        "level": "warn", "from": "backlog", "to": "in-progress", "skipped": 1,
+    }
+    db.commit.assert_awaited_once()
+    # workflow_violation 가시화 — 기존 이벤트 타입(additive)·commit 後 발화.
+    _pub.assert_called_once()
+    assert _pub.call_args[0][1] == "workflow_violation"
+    _fire.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_bulk_adjacent_and_reopen_no_violation(monkeypatch):
+    """정공법 A: 인접 전진·역방향 reopen 은 정상 → violation None·이벤트 미발행."""
+    for old, new in [("ready-for-dev", "in-progress"), ("done", "in-progress")]:
+        story = _full_story(); story.status = old
+        exec_result = MagicMock()
+        exec_result.scalar_one_or_none = MagicMock(return_value=story)
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=exec_result)
+        db.flush = AsyncMock(); db.refresh = AsyncMock(); db.commit = AsyncMock()
+        repo = MagicMock(); repo.org_id = uuid.uuid4()
+        monkeypatch.setattr(stories_mod, "_attach_assignee_ids", AsyncMock())
+        monkeypatch.setattr(stories_mod, "_resolve_team_member_id", AsyncMock(return_value=None))
+        _fire = AsyncMock(); monkeypatch.setattr(stories_mod, "fire_webhooks", _fire)
+        monkeypatch.setattr(stories_mod, "publish_event", MagicMock())
+
+        payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": new}])
+        result = await bulk_update_stories(payload, db, repo, auth=MagicMock())
+
+        assert story.status == new  # allow
+        assert result[0].violation is None, f"{old}->{new} should be no-violation"
+        _fire.assert_not_awaited()  # 정상 전이=이벤트 미발행


### PR DESCRIPTION
## 칸반 상태전이 정공법 BE — allow + violation flag (차단 X·가시화)

prod 버그 `c1cd484b`(선생님 제보 "정신병"). 상태전이가 경로마다 규칙 상충: 드래그=한단계+`done:[]` 잠금 / 메뉴=무검증 / BE `/status`(엄격 인덱스) vs `/bulk`(무검증). **정공법 A(선생님 직접 지시)**: 자유 이동 + 비정상 점프는 위반(warn) 기록·**하드블록 X**.

**FE 동반 PR: #1755 (미르코)** — BE-first 머지 필수(FE 단독=BE abnormal reject→silent 롤백).

### BE 변경 (shared SSOT 통일)
- `workflow_violation.build_violation_flag(old,new)`: `/status`·`/bulk` **공통 SSOT**. 비순차 전진 2+점프 → `{level,from,to,skipped}`, 인접·역방향 reopen·None-old·미지 status → `None`.
- `set_status` 기본 `violation_level` `"block"`→`"warn"` (SSOT 기본=allow).
- `/bulk`: status 변경 item마다 violation 판정 → **응답 per-item `violation` flag** + `workflow_violation` 이벤트 발행(기존 타입·additive·기존 컨슈머 무영향)·**차단 X**. actor 1회 해소(웹훅 수신자 필터·org-wide fan-out 박멸). 페이로드/응답 commit 前 빌드(attr expire→MissingGreenlet 방지)·이벤트 commit 後 발화.
- `/status`: 응답에 `violation` flag 부착(shape 통일·이미 warn-default·이벤트 발행 중).
- `StoryResponse.violation` optional + before-validator(비-dict→None·`_coerce_attachments` 동형·MagicMock `from_attributes` 안전).

### 계약 (FE 합의)
```
violation: null | { level: "warn", from, to, skipped: <N> }
```
- 정상(인접 1단계·역방향 reopen) → `null`(애자일 정상 흐름).
- 전진 2+점프 → flag(allow+토스트). `skipped`=건너뛴 중간 단계 수.

### AC
- AC1 자유 이동(어느 칸→어느 칸) ✅ / AC2 done reopen ✅(역방향=무플래그) / AC3 차단 없이 위반 가시화 ✅ / shared SSOT `/status`=`/bulk` 동일 ✅.

### 테스트
- `build_violation_flag` 단위(2+점프 flag·인접/reopen/None/미지 → None) · `/bulk` 점프 flag+allow+이벤트 발행 · 인접/reopen 무플래그+이벤트 미발행 · 기존 bulk body 계약 회귀.
- 풀스위트 **2577 pass**(잔여=기존 MCP-env DoD)·ruff clean·마이그레이션 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
