### PR TITLE
[SID:81066cc8] S7 LOW cleanup — segment-parser robustness + authorize wrong-org 테스트

### DIFF
--- a/backend/app/services/asset_registry.py
+++ b/backend/app/services/asset_registry.py
@@ -34,6 +34,17 @@ def canonical_object_path(stored_url: str, container: str = DEFAULT_CONTAINER) -
     return stored_url
 
 
+def _prefix_segments_match(object_path: str, segments: list[str]) -> bool:
+    """object_path 의 앞 segment 들이 `segments` 와 **정확히 일치** + 그 뒤에 비어있지 않은 file segment.
+
+    까심 LOW(robustness): `startswith(문자열)` 대신 segment 단위 정확 비교 — 빈 trailing(`.../chat/<conv>/`
+    파일 없음)·prefix 혼동·UUID 형식 변형을 견고하게 거부한다. 모든 비교값은 str(UUID) canonical 형식.
+    """
+    parts = object_path.split("/")
+    n = len(segments)
+    return len(parts) > n and parts[:n] == segments and parts[n] != ""
+
+
 def path_in_source_scope(
     object_path: str,
     source_type: str,
@@ -43,25 +54,25 @@ def path_in_source_scope(
 ) -> bool:
     """object_path 가 이 source(=메시지/스토리)에 귀속된 경로인지 검증(IDOR·registry 오염 차단).
 
-    S1 `_is_scoped_to_conversation` 와 동형: 업로드 경로가 resource 에 스코프돼야 등록(유저가 타
-    project/conv 경로 심어 오염 차단·까심). 두 namespace 인식(S7·AC3 무회귀):
-    - legacy: `chat/<project>/<conversation>/...` · `story/<project>/<story>/...`
-    - S7 신: `org/<org>/project/<project>/chat/<conversation>/...` · `.../story/<story>/...`
-    manual/doc 은 경로 제약 없음(신뢰 등록·doc=S4).
+    registry(sync)·agent-context(attachment_context)·authorize 가 **공유하는 단일 SSOT**(까심: 규칙
+    단일화). 업로드 경로가 resource 에 스코프돼야 통과(유저가 타 org/project/conv 경로 심어 오염/IDOR
+    차단). 두 namespace 인식(S7·AC3 무회귀)·**org/project/source 전 tenancy segment exact 바인딩**:
+    - legacy: `chat/<project>/<conversation>/<file>` · `story/<project>/<story>/<file>`
+    - S7 신: `org/<org>/project/<project>/chat/<conversation>/<file>` · `.../story/<story>/<file>`
+    신 namespace 의 org segment 도 반드시 일치(미검증 시 cross-org IDOR·CRITICAL). manual/doc 은 경로
+    제약 없음(신뢰 등록·doc=S4). segment 단위 정확 비교(_prefix_segments_match)로 변형/우회 견고.
     """
-    if source_type == "conversation_message":
-        if object_path.startswith(f"chat/{project_id}/{source_id}/"):
-            return True
-        return org_id is not None and object_path.startswith(
-            f"org/{org_id}/project/{project_id}/chat/{source_id}/"
-        )
-    if source_type == "story":
-        if object_path.startswith(f"story/{project_id}/{source_id}/"):
-            return True
-        return org_id is not None and object_path.startswith(
-            f"org/{org_id}/project/{project_id}/story/{source_id}/"
-        )
-    return True
+    pid, sid = str(project_id), str(source_id)
+    kind = {"conversation_message": "chat", "story": "story"}.get(source_type)
+    if kind is None:
+        return True  # manual/doc 등 경로 제약 없는 source
+    # legacy: <kind>/<project>/<source>/<file>
+    if _prefix_segments_match(object_path, [kind, pid, sid]):
+        return True
+    # S7 신: org/<org>/project/<project>/<kind>/<source>/<file> — org 까지 exact 바인딩.
+    return org_id is not None and _prefix_segments_match(
+        object_path, ["org", str(org_id), "project", pid, kind, sid]
+    )
 
 
 async def sync_attachment_assets(

--- a/backend/tests/test_asset_canonical.py
+++ b/backend/tests/test_asset_canonical.py
@@ -75,3 +75,29 @@ def test_scope_rejects_wrong_source_or_org():
 
 def test_scope_manual_unconstrained():
     assert path_in_source_scope("anything/x.png", "manual", _PROJ, _uuid.uuid4(), _ORG)
+
+
+def test_scope_segment_robustness():
+    """까심 LOW: segment 단위 정확 비교 견고성 — 빈 trailing·prefix 혼동 거부·subdir 허용."""
+    # 빈 trailing(파일 segment 없음) → 거부
+    assert not path_in_source_scope(f"chat/{_PROJ}/{_CONV}/", "conversation_message", _PROJ, _CONV, _ORG)
+    assert not path_in_source_scope(
+        f"org/{_ORG}/project/{_PROJ}/chat/{_CONV}/", "conversation_message", _PROJ, _CONV, _ORG)
+    # conv segment prefix 혼동(예: <conv>extra) → 정확 segment 불일치로 거부
+    assert not path_in_source_scope(
+        f"chat/{_PROJ}/{_CONV}extra/u.png", "conversation_message", _PROJ, _CONV, _ORG)
+    # 중간 삽입(parts[4]!='chat') → 거부
+    assert not path_in_source_scope(
+        f"org/{_ORG}/project/{_PROJ}/evil/chat/{_CONV}/u.png", "conversation_message", _PROJ, _CONV, _ORG)
+    # 정당한 subdir 깊은 경로는 허용(file segment 비어있지 않음)
+    assert path_in_source_scope(
+        f"chat/{_PROJ}/{_CONV}/sub/u.png", "conversation_message", _PROJ, _CONV, _ORG)
+
+
+def test_scope_cross_org_with_correct_proj_conv_rejected():
+    """까심 CRITICAL 고정: org segment만 틀려도(proj+conv 정확) 거부 — cross-org IDOR 차단."""
+    other_org = _uuid.uuid4()
+    assert not path_in_source_scope(
+        f"org/{other_org}/project/{_PROJ}/chat/{_CONV}/u.png", "conversation_message", _PROJ, _CONV, _ORG)
+    assert not path_in_source_scope(
+        f"org/{other_org}/project/{_PROJ}/story/{_STORY}/u.png", "story", _PROJ, _STORY, _ORG)

--- a/backend/tests/test_attachment_authorize_a54ddc16.py
+++ b/backend/tests/test_attachment_authorize_a54ddc16.py
@@ -268,3 +268,20 @@ async def test_authorize_conversation_s7_same_org_cross_project_idor_403():
         assert r.status_code == 403  # 타 project 경로 서명 차단(IDOR)
     finally:
         app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_authorize_conversation_s7_clean_wrong_org_403():
+    """까심 LOW: 구조는 정상(타 segment 삽입 없음)·org segment만 틀린 신 namespace → 403.
+    org 검증을 단독 격리(`org/<타org>/project/<proj>/chat/<conv>/file`·proj+conv 정확)."""
+    import uuid as _u
+    bad = f"org/{_u.uuid4()}/project/{PROJECT_ID}/chat/{CONV_ID}/u1-abc.png"  # 깔끔한 구조·org만 틀림
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_scalar(PROJECT_ID)])  # conv project=PROJECT_ID 조회
+    client, app = await _client(session)
+    try:
+        with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()):
+            r = await _get(client, f"path={bad}&conversation_id={CONV_ID}")
+        assert r.status_code == 403  # org segment 불일치 → cross-org 서명 차단
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## S7 LOW cleanup — segment-parser robustness + authorize wrong-org 음성테스트

까심 재QA LOW 4건(non-blocker·CRITICAL org-IDOR 표면 방어 강화). #1757(CRITICAL fix) 후속.

- **segment parser robustness**: `path_in_source_scope` 가 `startswith(문자열)` → `_prefix_segments_match`(segment 단위 정확 비교). 빈 trailing(`.../chat/<conv>/` 파일 없음)·prefix 혼동(`<conv>extra`)·중간 삽입 견고 거부·정당 subdir 허용. **registry/context/authorize 공유 SSOT** 단일 경로 유지(행위 동치).
- **authorize wrong-org 음성테스트**: 구조 정상·org segment만 틀린 신 namespace → 403(org 검증 단독 격리).
- **UUID 형식**: 비교값 str(UUID) canonical 일관(docstring 명시).
- **doc**: `path_in_source_scope` docstring 갱신(SSOT·org 바인딩·CRITICAL 근거·robustness).

### 테스트
- `path_in_source_scope` segment robustness(빈 trailing/prefix 혼동/중간삽입/subdir) · cross-org(proj+conv 정확·org 틀림) 거부 · authorize clean wrong-org 403.
- canonical+authorize+context 46 · realdb 12 · asset/attachment/webhook sweep 88 pass · refactor 행위 동치 · ruff clean(신규) · **마이그 없음**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
