### PR TITLE
[SID:4fbb10c1] S8 Phase 1 — server-side capacity gate (plan_tier_limits + ee-seam enforce)

### DIFF
--- a/backend/alembic/versions/0140_add_plan_tier_limits.py
+++ b/backend/alembic/versions/0140_add_plan_tier_limits.py
@@ -1,0 +1,55 @@
+"""E-STORAGE-SSOT S8: plan_tier_limits — tier별 storage 캡(admin-configurable·server-trust SSOT).
+
+Revision ID: 0140
+Revises: 0139
+Create Date: 2026-06-28
+
+S8 capacity gate 의 캡 단일 소스(client-trust 0·하드코딩 X). BE enforce 가 org tier(org_subscriptions)→
+plan_tier_limits[tier]→캡으로 읽는다. FE 는 BE storage-usage 로 캡 read(Supabase 이원화 0). 결재값 seed:
+Free 5GB/100MB · Team 50GB/500MB · Pro 250GB/500MB (MB 단위 저장·admin 편집 가능).
+
+idempotent: 테이블 inspect 가드(0139 선례)·seed 는 ON CONFLICT DO NOTHING. fresh-runnable. downgrade=drop.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect, text
+
+revision = "0140"
+down_revision = "0139"
+branch_labels = None
+depends_on = None
+
+# 결재 확정값(MB). admin 이 이후 plan_tier_limits 를 직접 편집(하드코딩 아님·여긴 초기 seed).
+_SEED = [
+    ("free", 5 * 1024, 100),       # 5GB / 100MB
+    ("team", 50 * 1024, 500),      # 50GB / 500MB
+    ("pro", 250 * 1024, 500),      # 250GB / 500MB
+]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if "plan_tier_limits" not in inspect(bind).get_table_names():
+        op.create_table(
+            "plan_tier_limits",
+            sa.Column("tier", sa.Text(), primary_key=True),
+            sa.Column("max_storage_mb", sa.BigInteger(), nullable=False),
+            sa.Column("max_file_mb", sa.Integer(), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        )
+    # seed(멱등) — 이미 있으면 보존(admin 편집값 덮지 않음).
+    for tier, storage_mb, file_mb in _SEED:
+        bind.execute(
+            text(
+                "INSERT INTO plan_tier_limits (tier, max_storage_mb, max_file_mb) "
+                "VALUES (:t, :s, :f) ON CONFLICT (tier) DO NOTHING"
+            ),
+            {"t": tier, "s": storage_mb, "f": file_mb},
+        )
+
+
+def downgrade() -> None:
+    op.drop_table("plan_tier_limits")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -11,6 +11,7 @@ from app.models.user import RefreshToken, User
 from app.models.workflow_version import WorkflowVersion
 from app.models.api_key import ApiKey
 from app.models.org_subscription import OrgSubscription
+from app.models.plan_tier_limit import PlanTierLimit
 from app.models.policy_document import PolicyDocument
 from app.models.audit import AuditLog
 from app.models.webhook_config import WebhookConfig
@@ -63,6 +64,7 @@ __all__ = [
     "UsageMeter",
     "ApiKey",
     "OrgSubscription",
+    "PlanTierLimit",
     "PolicyDocument",
     "AuditLog",
     "WebhookConfig",

--- a/backend/app/models/plan_tier_limit.py
+++ b/backend/app/models/plan_tier_limit.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+
+from sqlalchemy import BigInteger, DateTime, Integer, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class PlanTierLimit(Base):
+    """tier별 storage 캡(S8·admin-configurable SSOT). enforce 가 org tier→이 행→캡으로 읽는다.
+
+    값은 MB 단위(admin 편집). client-trust 0(server 권위). seed=0140(결재값).
+    """
+
+    __tablename__ = "plan_tier_limits"
+
+    tier: Mapped[str] = mapped_column(Text, primary_key=True)
+    max_storage_mb: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    max_file_mb: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, ConfigDict
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.asset import Asset, AssetFolder, AssetLink
@@ -168,6 +169,8 @@ async def list_assets(
 class StorageUsageResponse(BaseModel):
     org_id: uuid.UUID
     used_bytes: int
+    limit_bytes: int | None = None
+    percentage: float = 0.0
 
 
 @router.get("/assets/storage-usage", response_model=StorageUsageResponse)
@@ -176,19 +179,29 @@ async def storage_usage(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> StorageUsageResponse:
-    """GET /api/v2/assets/storage-usage — org 의 committed(미삭제) asset bytes 합(S8 capacity usage).
+    """GET /api/v2/assets/storage-usage — org 의 committed(미삭제) asset bytes 합 + tier 캡 + percentage(S8).
 
     usage SSOT = asset registry **live SUM**(결재: committed asset bytes·org scope·drift 0). soft-delete
-    (deleted_at IS NOT NULL)는 합산서 제외 = 즉시 용량 회수(복구는 7일 grace·별도). 캡/enforce 는 별도
-    (enforce 위치 crux A/B)·이 엔드포인트는 usage 만 권위 제공(A/B 공통 필요). org-wide(프로젝트 무관).
+    (deleted_at IS NOT NULL)는 합산서 제외 = 즉시 용량 회수(복구는 7일 grace·별도). cap = **단일 BE SSOT**
+    (plan_tier_limits·server 권위·FE 가 이 응답으로 캡 read → Supabase 이원화 0). limit/percentage 는
+    **ee-gated**(is_ee_enabled): SaaS = org tier→plan_tier_limits 캡, OSS = null(무제한). org-wide.
     """
-    used = (await db.execute(
+    used = int((await db.execute(
         select(func.coalesce(func.sum(Asset.size_bytes), 0)).where(
             Asset.org_id == org_id,
             Asset.deleted_at.is_(None),
         )
-    )).scalar_one()
-    return StorageUsageResponse(org_id=org_id, used_bytes=int(used))
+    )).scalar_one())
+
+    limit_bytes: int | None = None
+    if settings.is_ee_enabled:
+        from ee.plan_limits import get_org_storage_limit_bytes  # type: ignore[import]
+        limit_bytes = await get_org_storage_limit_bytes(db, org_id)
+
+    pct = round(used / limit_bytes * 100, 1) if limit_bytes else 0.0
+    return StorageUsageResponse(
+        org_id=org_id, used_bytes=used, limit_bytes=limit_bytes, percentage=pct
+    )
 
 
 @router.get("/folders", response_model=list[FolderResponse])

--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -16,7 +16,7 @@ from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
@@ -163,6 +163,32 @@ async def list_assets(
         last = assets[-1]
         next_cursor = _encode_cursor(getattr(last, {"date": "updated_at", "name": "name", "size": "size_bytes"}[sort]), last.id)
     return AssetPage(items=items, next_cursor=next_cursor)
+
+
+class StorageUsageResponse(BaseModel):
+    org_id: uuid.UUID
+    used_bytes: int
+
+
+@router.get("/assets/storage-usage", response_model=StorageUsageResponse)
+async def storage_usage(
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> StorageUsageResponse:
+    """GET /api/v2/assets/storage-usage — org 의 committed(미삭제) asset bytes 합(S8 capacity usage).
+
+    usage SSOT = asset registry **live SUM**(결재: committed asset bytes·org scope·drift 0). soft-delete
+    (deleted_at IS NOT NULL)는 합산서 제외 = 즉시 용량 회수(복구는 7일 grace·별도). 캡/enforce 는 별도
+    (enforce 위치 crux A/B)·이 엔드포인트는 usage 만 권위 제공(A/B 공통 필요). org-wide(프로젝트 무관).
+    """
+    used = (await db.execute(
+        select(func.coalesce(func.sum(Asset.size_bytes), 0)).where(
+            Asset.org_id == org_id,
+            Asset.deleted_at.is_(None),
+        )
+    )).scalar_one()
+    return StorageUsageResponse(org_id=org_id, used_bytes=int(used))
 
 
 @router.get("/folders", response_model=list[FolderResponse])

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -13,6 +13,7 @@ from sqlalchemy import and_, func, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
@@ -1203,6 +1204,12 @@ async def send_message(
             raise HTTPException(status_code=400, detail="Thread root not found in this conversation")
         if root_msg.thread_id is not None:
             raise HTTPException(status_code=400, detail="Cannot reply to a reply (single-level thread only)")
+
+    # S8: 서버사이드 capacity 게이트(ee seam·SaaS only·OSS no-op) — asset commit 前 per-file+총량 enforce.
+    # 직접 API 우회 불가(commit-time gate). 초과 시 402 PLAN_LIMIT_EXCEEDED.
+    if settings.is_ee_enabled and body.attachments:
+        from ee.plan_limits import check_storage_capacity  # type: ignore[import]
+        await check_storage_capacity(db, org_id, [a.model_dump() for a in body.attachments])
 
     msg = ConversationMessage(
         conversation_id=conversation_id,

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user, get_project_scoped_org_id, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.event import Event
@@ -221,6 +222,10 @@ async def create_story(
         body.assignee_id if body.assignee_id is not None
         else (effective_ids[0] if effective_ids else None)
     )
+    # S8: 서버사이드 capacity 게이트(ee seam·SaaS only·OSS no-op) — asset commit 前 per-file+총량 enforce.
+    if settings.is_ee_enabled and body.attachments:
+        from ee.plan_limits import check_storage_capacity  # type: ignore[import]
+        await check_storage_capacity(session, org_id, [a.model_dump() for a in body.attachments])
     story = await repo.create(
         project_id=body.project_id,
         title=body.title,
@@ -450,6 +455,10 @@ async def update_story(
     # S7: client 제공 asset_id strip(서버 권위·drift 방지·까심)·아래 sync url_map 으로만 역기입.
     if data.get("attachments"):
         data["attachments"] = [{**a, "asset_id": None} for a in data["attachments"]]
+        # S8: 서버사이드 capacity 게이트(ee seam·SaaS only·OSS no-op) — 첨부 교체 commit 前 enforce.
+        if settings.is_ee_enabled:
+            from ee.plan_limits import check_storage_capacity  # type: ignore[import]
+            await check_storage_capacity(db, repo.org_id, data["attachments"])
     # E-BOARD S5: assignee_ids는 stories 컬럼이 아니므로 repo.update 전에 분리.
     assignee_ids_in = data.pop("assignee_ids", None)
     # assignee_ids만 제공되면 단일 assignee_id(주담당)를 첫 요소로 동기화 → 기존 event/notify 로직 재사용.

--- a/backend/ee/plan_limits.py
+++ b/backend/ee/plan_limits.py
@@ -76,6 +76,77 @@ async def check_project_create_limit(session: AsyncSession, org_id) -> None:
         raise _plan_limit_error("project", FREE_LIMITS["max_projects"])
 
 
+def _storage_limit_error(resource: str, limit_mb: int, tier: str) -> HTTPException:
+    upgrade = tier != "pro"
+    msg = (
+        f"{tier} plan {resource} limit ({limit_mb}MB) reached. Upgrade for more capacity."
+        if upgrade else f"{resource} limit ({limit_mb}MB) reached."
+    )
+    return HTTPException(
+        status_code=402,
+        detail={
+            "code": "PLAN_LIMIT_EXCEEDED",
+            "resource": resource,
+            "limit_mb": limit_mb,
+            "tier": tier,
+            "upgrade_required": upgrade,
+            "message": msg,
+        },
+    )
+
+
+async def get_org_storage_limit_bytes(session: AsyncSession, org_id) -> int | None:
+    """org tier 의 storage 캡(bytes). 캡 미정의 tier=None(무제한). storage-usage 표시 공용(server 권위 SSOT)."""
+    tier = await _get_org_tier(session, org_id)
+    row = (await session.execute(
+        text("SELECT max_storage_mb FROM plan_tier_limits WHERE tier = :t"), {"t": tier},
+    )).first()
+    return int(row[0]) * 1024 * 1024 if row else None
+
+
+async def check_storage_capacity(session: AsyncSession, org_id, attachments: list[dict] | None) -> None:
+    """S8: org storage 캡 enforce(서버 게이트·all tiers). per-file + 총량(committed+신규).
+
+    tier(org_subscriptions)→plan_tier_limits[tier]→캡. 캡 미정의 tier=무제한(no-op). **우리 버킷 객체만**
+    카운트(canonical_object_path not None·외부 URL 제외). 보수적: 재전송 중복은 over-count(안전측·캡 초과
+    절대 불허). OSS 는 호출 안 됨(is_ee_enabled 게이트·라우터). 초과 시 402 PLAN_LIMIT_EXCEEDED.
+    """
+    if not attachments:
+        return
+    tier = await _get_org_tier(session, org_id)
+    row = (await session.execute(
+        text("SELECT max_storage_mb, max_file_mb FROM plan_tier_limits WHERE tier = :t"),
+        {"t": tier},
+    )).first()
+    if row is None:
+        return  # 캡 미정의 tier → 무제한
+    max_storage_mb, max_file_mb = int(row[0]), int(row[1])
+    max_file_bytes = max_file_mb * 1024 * 1024
+    max_storage_bytes = max_storage_mb * 1024 * 1024
+
+    from app.services.asset_registry import canonical_object_path
+
+    new_bytes = 0
+    for att in attachments:
+        if not isinstance(att, dict) or canonical_object_path(att.get("url") or "") is None:
+            continue  # 우리 객체 아님(외부/타버킷) → 우리 storage 미카운트
+        try:
+            size = int(att.get("size") or 0)
+        except (TypeError, ValueError):
+            size = 0
+        if size > max_file_bytes:
+            raise _storage_limit_error("file_size", max_file_mb, tier)
+        new_bytes += size
+    if new_bytes == 0:
+        return
+    used = (await session.execute(
+        text("SELECT COALESCE(SUM(size_bytes),0) FROM assets WHERE org_id = :oid AND deleted_at IS NULL"),
+        {"oid": str(org_id)},
+    )).scalar() or 0
+    if int(used) + new_bytes > max_storage_bytes:
+        raise _storage_limit_error("storage", max_storage_mb, tier)
+
+
 async def check_member_invite_limit(session: AsyncSession, org_id) -> None:
     """Free: org당 member 5명 제한 (human + agent). Team/Pro는 스킵."""
     tier = await _get_org_tier(session, org_id)

--- a/backend/tests/test_asset_registry_realdb.py
+++ b/backend/tests/test_asset_registry_realdb.py
@@ -685,3 +685,40 @@ async def test_conversation_message_path_scope_id_vs_link_source_s7_ac1():
             assert url_map_idor == {}
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_storage_usage_sums_committed_excludes_softdeleted():
+    """S8: GET storage-usage = org committed asset bytes SUM. soft-deleted(deleted_at) 제외(용량 즉시 회수)."""
+    from unittest.mock import MagicMock
+
+    from app.routers.assets import storage_usage
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            ins = (
+                "INSERT INTO assets (id,org_id,project_id,container,object_path,name,size_bytes,deleted_at)"
+                " VALUES (gen_random_uuid(),:org,:proj,:c,:p,:n,:sz,:del)"
+            )
+            await s.execute(text(ins), {"org": ORG, "proj": PROJ_A, "c": BUCKET, "p": "su/a", "n": "a", "sz": 100, "del": None})
+            await s.execute(text(ins), {"org": ORG, "proj": PROJ_A, "c": BUCKET, "p": "su/b", "n": "b", "sz": 250, "del": None})
+            # soft-deleted → 합산 제외
+            await s.execute(text(
+                "INSERT INTO assets (id,org_id,project_id,container,object_path,name,size_bytes,deleted_at)"
+                " VALUES (gen_random_uuid(),:org,:proj,:c,:p,:n,:sz,now())"
+            ), {"org": ORG, "proj": PROJ_A, "c": BUCKET, "p": "su/c", "n": "c", "sz": 999})
+            await s.commit()
+
+            auth = MagicMock(); auth.user_id = str(USER)
+            resp = await storage_usage(db=s, auth=auth, org_id=ORG)
+            assert resp.org_id == ORG
+            assert resp.used_bytes == 350  # 100+250 (soft-deleted 999 제외)
+
+            # empty org(다른 org_id)면 0 — org-scope WHERE 검증(IDOR 라인은 list 테스트서 별도 커버)
+            empty = await storage_usage(db=s, auth=auth, org_id=ORG2)
+            assert empty.used_bytes == 0
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_asset_registry_realdb.py
+++ b/backend/tests/test_asset_registry_realdb.py
@@ -722,3 +722,87 @@ async def test_storage_usage_sums_committed_excludes_softdeleted():
             assert empty.used_bytes == 0
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_check_storage_capacity_enforce():
+    """S8 enforce: per-file + 총량 캡 초과 → 402. 미만/외부URL/빈 → 통과. (free tier=5GB/100MB·org_sub 없으면 free)."""
+    from ee.plan_limits import check_storage_capacity
+    from fastapi import HTTPException
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    GB = 1024 * 1024 * 1024
+    MB = 1024 * 1024
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            # plan_tier_limits seed(마이그)·org_subscription 없음→free. 기존 used 거의 5GB-100 으로 채움.
+            await s.execute(text(
+                "INSERT INTO assets (id,org_id,project_id,container,object_path,name,size_bytes,deleted_at)"
+                " VALUES (gen_random_uuid(),:o,:p,:c,'cap/big','big',:sz,NULL)"
+            ), {"o": ORG, "p": PROJ_A, "c": BUCKET, "sz": 5 * GB - 100})
+            await s.commit()
+
+            def _att_sized(sz, path="cap/new.png"):
+                return {"url": f"org/{ORG}/project/{PROJ_A}/chat/{uuid.uuid4()}/{path}", "name": "n", "content_type": "image/png", "size": sz}
+
+            # 총량 초과: used(5GB-100)+200 > 5GB → 402
+            try:
+                await check_storage_capacity(s, ORG, [_att_sized(200)])
+                assert False, "expected 402"
+            except HTTPException as e:
+                assert e.status_code == 402 and e.detail["code"] == "PLAN_LIMIT_EXCEEDED" and e.detail["resource"] == "storage"
+
+            # 미만: +50 < 100 여유 → 통과
+            await check_storage_capacity(s, ORG, [_att_sized(50)])
+
+            # per-file 초과: 200MB > free 100MB → 402(file_size)
+            try:
+                await check_storage_capacity(s, ORG, [_att_sized(200 * MB)])
+                assert False, "expected 402 per-file"
+            except HTTPException as e:
+                assert e.status_code == 402 and e.detail["resource"] == "file_size"
+
+            # 외부 URL(우리 객체 아님)=미카운트 → 통과
+            await check_storage_capacity(s, ORG, [{"url": "https://evil.example/x.png", "name": "x", "content_type": "image/png", "size": 999 * GB}])
+            # 빈 → no-op
+            await check_storage_capacity(s, ORG, [])
+            await check_storage_capacity(s, ORG, None)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_storage_usage_limit_ee_gated(monkeypatch):
+    """S8: storage-usage limit/percentage 는 ee-gated. SaaS=plan_tier_limits 캡, OSS=null."""
+    from unittest.mock import MagicMock
+
+    from app.core.config import settings
+    from app.routers.assets import storage_usage
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    MB = 1024 * 1024
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            await s.execute(text(
+                "INSERT INTO assets (id,org_id,project_id,container,object_path,name,size_bytes,deleted_at)"
+                " VALUES (gen_random_uuid(),:o,:p,:c,'u/a','a',:sz,NULL)"
+            ), {"o": ORG, "p": PROJ_A, "c": BUCKET, "sz": 512 * MB})
+            await s.commit()
+            auth = MagicMock(); auth.user_id = str(USER)
+
+            # OSS(is_ee_enabled False) → limit null·percentage 0
+            monkeypatch.setattr(settings, "license_consent", "")
+            oss = await storage_usage(db=s, auth=auth, org_id=ORG)
+            assert oss.used_bytes == 512 * MB and oss.limit_bytes is None and oss.percentage == 0.0
+
+            # SaaS(ee) → free 캡 5120MB·percentage 계산
+            monkeypatch.setattr(settings, "license_consent", "agreed")
+            ee = await storage_usage(db=s, auth=auth, org_id=ORG)
+            assert ee.limit_bytes == 5120 * MB
+            assert ee.percentage == round(512 / 5120 * 100, 1)  # =10.0
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## S8 Phase 1 — server-side capacity gate (plan_tier_limits SSOT + ee-seam enforce + storage-usage 캡)

S8 capacity metering+gate `4fbb10c1` Phase 1 (서버 게이트 완성). 결재: **server-side enforce·SaaS-only·OSS no-op·하드코딩 X**.

### 변경
- **마이그 0140** `plan_tier_limits(tier PK, max_storage_mb, max_file_mb)` + 결재값 seed(free 5120/100·team 51200/500·pro 256000/500 MB). 멱등(inspect 가드·ON CONFLICT)·fresh-runnable·**admin-editable 단일 SSOT**.
- **PlanTierLimit** model + `__init__` 등록.
- **`GET /api/v2/assets/storage-usage` 확장** → `{used_bytes, limit_bytes, percentage}`. used=committed live SUM(soft-delete 제외·org scope). limit/percentage=**ee-gated**(SaaS=org tier(`org_subscriptions`)→`plan_tier_limits` 캡·OSS=null). **FE 가 이 응답으로 캡 read=단일 BE SSOT**(Supabase 이원화 0·client-trust 0).
- **enforce** `ee.plan_limits.check_storage_capacity`(per-file>max_file_mb + 총량 used+신규>max_storage → 402 PLAN_LIMIT_EXCEEDED·우리버킷만 카운트·보수적). `is_ee_enabled` seam서 asset commit 前 호출(send_message·story create/update). **OSS no-op**(import 안 됨). **직접 API 우회 불가**(commit-time gate).

### 아키텍처 메모(crux 결정 반영)
- BE에 Supabase 데이터 클라 없음 → 캡을 BE-native SSOT(`plan_tier_limits`)로. tier는 `org_subscriptions`(Polar) BE-reachable.
- enforce=서버사이드(FE-only는 직접 API 우회→티어 무의미). FE는 UX(80% 경고·pre-flight)만=Phase 2.

### 테스트 (CI alembic-fresh서 실행)
- storage-usage: committed SUM·soft-delete 제외·org-scope·ee-gated limit(OSS null vs SaaS 5120MB·percentage).
- enforce: 총량 초과 402·미만 통과·per-file 402·external 미카운트·empty no-op.
- 풀스위트(no-DB) **2579 pass**·잔여 8=기존 MCP-env DoD. ruff clean(신규)·마이그 fresh-runnable(0138→0140 clean·seed 검증).

### 후속
- migrate=PO lane(머지 후 dev migrate·sprintable-migrate-dev). Phase 2(FE UX 80%+FE Supabase 캡 제거→BE 전환·미르코)·Phase 3(soft-delete 7일 grace cron + 80% email)=비차단 fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
