### PR TITLE
[SID:4fbb10c1] S8 Phase 2 — grace cron + 80% storage email

### DIFF
--- a/backend/alembic/versions/0141_add_storage_warn_notified_at.py
+++ b/backend/alembic/versions/0141_add_storage_warn_notified_at.py
@@ -1,0 +1,33 @@
+"""E-STORAGE-SSOT S8 Phase 2: org_subscriptions.storage_warn_notified_at — 80% 경고 메일 dedup.
+
+Revision ID: 0141
+Revises: 0140
+Create Date: 2026-06-28
+
+80% storage 경고 메일을 매 cron tick 마다 재발송하지 않도록 org 단위 last-notified 마커. cron 이
+보내기 前 (NULL 또는 cooldown 경과) 확인·발송 後 갱신. nullable(미발송=NULL). idempotent·fresh-runnable.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import inspect
+
+revision = "0141"
+down_revision = "0140"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    cols = {c["name"] for c in inspect(bind).get_columns("org_subscriptions")}
+    if "storage_warn_notified_at" not in cols:
+        op.add_column(
+            "org_subscriptions",
+            sa.Column("storage_warn_notified_at", sa.DateTime(timezone=True), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    op.drop_column("org_subscriptions", "storage_warn_notified_at")

--- a/backend/app/models/org_subscription.py
+++ b/backend/app/models/org_subscription.py
@@ -22,6 +22,8 @@ class OrgSubscription(Base):
     status: Mapped[str] = mapped_column(Text, nullable=False, default="active")
     current_period_start: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     current_period_end: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # S8 Phase 2: 80% storage 경고 메일 dedup 마커(마지막 발송 시각·NULL=미발송).
+    storage_warn_notified_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -9,9 +9,7 @@ import os
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
-
-logger = logging.getLogger(__name__)
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -19,7 +17,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.database import get_db
 from app.models.agent_run import AgentRun
 from app.models.agent_session import AgentSession
+from app.models.asset import Asset
 from app.models.hitl import HitlRequest
+from app.models.org_subscription import OrgSubscription
+from app.models.plan_tier_limit import PlanTierLimit
+from app.models.project import OrgMember
+from app.models.user import User
+from app.services.email import send_email
+from app.services.storage import get_storage_provider
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v2/internal/cron", tags=["cron"])
 
@@ -457,4 +464,126 @@ async def score_hypotheses_cron(
         return _ok(summary)
     except Exception as exc:
         logger.exception("score-hypotheses cron error: %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)
+
+
+# ─── S8: storage capacity lifecycle crons ─────────────────────────────────────
+
+_ASSET_GRACE_DAYS = 7
+_STORAGE_WARN_THRESHOLD = 0.8
+_STORAGE_WARN_COOLDOWN = timedelta(days=7)
+
+
+@router.get("/assets-grace-hard-delete")
+async def assets_grace_hard_delete(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """S8: soft-delete(deleted_at) 7일 경과 asset hard-delete — blob(provider)+row(asset_links FK CASCADE).
+
+    best-effort: blob delete 성공(또는 이미 없음=멱등) 시에만 row 삭제. blob delete 실패 시 row 보존
+    →다음 tick 재시도(orphan 0). tick당 최대 500건(폭주 방지).
+    """
+    verify_cron(request)
+    try:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=_ASSET_GRACE_DAYS)
+        rows = list((await session.execute(
+            select(Asset)
+            .where(Asset.deleted_at.is_not(None), Asset.deleted_at < cutoff)
+            .limit(500)
+        )).scalars().all())
+        provider = get_storage_provider()
+        deleted = 0
+        failed = 0
+        for a in rows:
+            if await provider.delete_object(a.container, a.object_path):
+                await session.delete(a)  # asset_links 는 FK ondelete=CASCADE 로 자동 삭제
+                deleted += 1
+            else:
+                failed += 1  # blob delete 실패 → row 보존(다음 tick 재시도)
+        await session.commit()
+        return _ok({"hard_deleted": deleted, "blob_delete_failed": failed})
+    except Exception as exc:
+        logger.exception("assets-grace-hard-delete cron error: %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)
+
+
+@router.get("/storage-usage-warn")
+async def storage_usage_warn(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """S8: SaaS org storage 사용량이 캡의 80%+ 면 owner/admin 경고 메일(dedup·cooldown 7일).
+
+    org_subscription(active) 대상. 캡 미정의 tier=무제한(skip). 80% 미만 복귀 시 마커 re-arm(재크로싱 시
+    즉시 재경고). 메일 실패는 best-effort(개별 흡수). cooldown 내 재발송 금지(storage_warn_notified_at).
+    """
+    verify_cron(request)
+    try:
+        now = datetime.now(timezone.utc)
+        subs = list((await session.execute(
+            select(OrgSubscription).where(OrgSubscription.status == "active")
+        )).scalars().all())
+        caps = {
+            t: mb for t, mb in (await session.execute(
+                select(PlanTierLimit.tier, PlanTierLimit.max_storage_mb)
+            )).all()
+        }
+        notified = 0
+        for sub in subs:
+            cap_mb = caps.get(sub.tier)
+            if not cap_mb:
+                continue  # 캡 미정의 tier = 무제한
+            cap_bytes = int(cap_mb) * 1024 * 1024
+            used = int((await session.execute(
+                select(func.coalesce(func.sum(Asset.size_bytes), 0)).where(
+                    Asset.org_id == sub.org_id, Asset.deleted_at.is_(None)
+                )
+            )).scalar_one())
+            if used < cap_bytes * _STORAGE_WARN_THRESHOLD:
+                if sub.storage_warn_notified_at is not None:  # 80% 미만 복귀 → re-arm
+                    await session.execute(
+                        update(OrgSubscription)
+                        .where(OrgSubscription.id == sub.id)
+                        .values(storage_warn_notified_at=None)
+                    )
+                continue
+            if (
+                sub.storage_warn_notified_at is not None
+                and (now - sub.storage_warn_notified_at) < _STORAGE_WARN_COOLDOWN
+            ):
+                continue  # cooldown 내 — 재발송 금지(dedup)
+            emails = [
+                r[0] for r in (await session.execute(
+                    select(User.email)
+                    .join(OrgMember, User.id == OrgMember.user_id)
+                    .where(
+                        OrgMember.org_id == sub.org_id,
+                        OrgMember.role.in_(["owner", "admin"]),
+                        OrgMember.deleted_at.is_(None),
+                    )
+                )).all()
+            ]
+            pct = round(used / cap_bytes * 100, 1)
+            subject = f"[Sprintable] Storage usage at {pct}%"
+            html = (
+                f"<p>Your organization's storage usage has reached <b>{pct}%</b> "
+                f"({used // (1024 * 1024)}MB / {cap_mb}MB).</p>"
+                f"<p>Free up space (delete unused files) or upgrade your plan to avoid upload limits.</p>"
+            )
+            for em in emails:
+                try:
+                    send_email(em, subject, html)
+                except Exception:
+                    logger.warning("storage-usage-warn email 실패 org=%s", sub.org_id, exc_info=True)
+            await session.execute(
+                update(OrgSubscription)
+                .where(OrgSubscription.id == sub.id)
+                .values(storage_warn_notified_at=now)
+            )
+            notified += 1
+        await session.commit()
+        return _ok({"notified_orgs": notified})
+    except Exception as exc:
+        logger.exception("storage-usage-warn cron error: %s", exc)
         return _err("INTERNAL_ERROR", "Internal server error", 500)

--- a/backend/app/services/storage/base.py
+++ b/backend/app/services/storage/base.py
@@ -21,3 +21,7 @@ class StorageProvider(abc.ABC):
         self, container: str, object_path: str, *, ttl: timedelta
     ) -> str | None:
         """단기 만료 read 서명 URL. 실패 시 None(best-effort)."""
+
+    @abc.abstractmethod
+    async def delete_object(self, container: str, object_path: str) -> bool:
+        """객체 hard-delete(S8 grace cron). 이미 없으면 True(멱등)·실패 시 False(best-effort·호출부 계속)."""

--- a/backend/app/services/storage/gcs.py
+++ b/backend/app/services/storage/gcs.py
@@ -51,3 +51,20 @@ class GcsStorageProvider(StorageProvider):
         except Exception:
             logger.warning("gcs storage: signed url 생성 실패 path=%s", object_path, exc_info=True)
             return None
+
+    async def delete_object(self, container: str, object_path: str) -> bool:
+        def _blocking() -> bool:
+            from google.cloud import storage
+            from google.cloud.exceptions import NotFound
+
+            try:
+                storage.Client().bucket(container).blob(object_path).delete()
+            except NotFound:
+                return True  # 이미 없음 = 멱등
+            return True
+
+        try:
+            return await asyncio.to_thread(_blocking)
+        except Exception:
+            logger.warning("gcs storage: delete 실패 path=%s", object_path, exc_info=True)
+            return False

--- a/backend/app/services/storage/local.py
+++ b/backend/app/services/storage/local.py
@@ -82,3 +82,14 @@ class LocalStorageProvider(StorageProvider):
         except Exception:
             logger.warning("local storage: signed url 생성 실패 path=%s", object_path, exc_info=True)
             return None
+
+    async def delete_object(self, container: str, object_path: str) -> bool:
+        def _blocking() -> bool:
+            _resolve_safe(container, object_path).unlink(missing_ok=True)  # 없어도 OK = 멱등
+            return True
+
+        try:
+            return await asyncio.to_thread(_blocking)
+        except Exception:
+            logger.warning("local storage: delete 실패 path=%s", object_path, exc_info=True)
+            return False

--- a/backend/app/services/storage/s3.py
+++ b/backend/app/services/storage/s3.py
@@ -55,3 +55,14 @@ class S3StorageProvider(StorageProvider):
         except Exception:
             logger.warning("s3 storage: signed url 생성 실패 path=%s", object_path, exc_info=True)
             return None
+
+    async def delete_object(self, container: str, object_path: str) -> bool:
+        def _blocking() -> bool:
+            _client().delete_object(Bucket=container, Key=object_path)  # S3 delete=멱등(없어도 성공)
+            return True
+
+        try:
+            return await asyncio.to_thread(_blocking)
+        except Exception:
+            logger.warning("s3 storage: delete 실패 path=%s", object_path, exc_info=True)
+            return False

--- a/backend/ee/plan_limits.py
+++ b/backend/ee/plan_limits.py
@@ -131,7 +131,7 @@ async def check_storage_capacity(session: AsyncSession, org_id, attachments: lis
         if not isinstance(att, dict) or canonical_object_path(att.get("url") or "") is None:
             continue  # 우리 객체 아님(외부/타버킷) → 우리 storage 미카운트
         try:
-            size = int(att.get("size") or 0)
+            size = max(0, int(att.get("size") or 0))  # 음수 clamp(까심 ②·함수단독 raw 호출 방어·총량 우회 차단)
         except (TypeError, ValueError):
             size = 0
         if size > max_file_bytes:

--- a/backend/tests/test_asset_canonical.py
+++ b/backend/tests/test_asset_canonical.py
@@ -101,3 +101,23 @@ def test_scope_cross_org_with_correct_proj_conv_rejected():
         f"org/{other_org}/project/{_PROJ}/chat/{_CONV}/u.png", "conversation_message", _PROJ, _CONV, _ORG)
     assert not path_in_source_scope(
         f"org/{other_org}/project/{_PROJ}/story/{_STORY}/u.png", "story", _PROJ, _STORY, _ORG)
+@pytest.mark.anyio
+async def test_local_provider_delete_object(tmp_path, monkeypatch):
+    """S8 Phase 2: local provider delete_object — 파일 삭제 + 이미 없으면 멱등(True)."""
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.services.storage.local import LocalStorageProvider
+
+    p = LocalStorageProvider()
+    target = tmp_path / "bucket" / "a" / "f.png"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(b"x")
+    assert target.exists()
+    assert await p.delete_object("bucket", "a/f.png") is True
+    assert not target.exists()
+    # 이미 없음 → 멱등 True
+    assert await p.delete_object("bucket", "a/f.png") is True
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"

--- a/backend/tests/test_asset_registry_realdb.py
+++ b/backend/tests/test_asset_registry_realdb.py
@@ -852,3 +852,98 @@ async def test_get_single_asset_scoped():
                     assert e.status_code == 404, why
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_grace_cron_hard_deletes_expired_softdeleted(monkeypatch):
+    """S8 Phase 2: grace cron — soft-delete 7일 경과만 hard-delete(row+link CASCADE). 최근/live 보존.
+    blob delete 성공 시에만 row 삭제(mock provider)."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from app.routers import cron
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            aid = uuid.uuid4()
+            await s.execute(text(
+                "INSERT INTO assets (id,org_id,project_id,container,object_path,name,size_bytes,deleted_at)"
+                " VALUES (:id,:o,:p,:c,'grace/a','a',10, now() - interval '8 days')"
+            ), {"id": aid, "o": ORG, "p": PROJ_A, "c": BUCKET})
+            await s.execute(text(
+                "INSERT INTO asset_links (id,org_id,asset_id,source_type,source_id)"
+                " VALUES (gen_random_uuid(),:o,:aid,'manual',gen_random_uuid())"
+            ), {"o": ORG, "aid": aid})
+            await s.execute(text(
+                "INSERT INTO assets (id,org_id,project_id,container,object_path,name,size_bytes,deleted_at)"
+                " VALUES (gen_random_uuid(),:o,:p,:c,'grace/b','b',10, now() - interval '1 day')"
+            ), {"o": ORG, "p": PROJ_A, "c": BUCKET})
+            await s.execute(text(
+                "INSERT INTO assets (id,org_id,project_id,container,object_path,name,size_bytes,deleted_at)"
+                " VALUES (gen_random_uuid(),:o,:p,:c,'grace/c','c',10, NULL)"
+            ), {"o": ORG, "p": PROJ_A, "c": BUCKET})
+            await s.commit()
+
+            prov = MagicMock()
+            prov.delete_object = AsyncMock(return_value=True)
+            monkeypatch.setattr(cron, "get_storage_provider", lambda: prov)
+
+            await cron.assets_grace_hard_delete(MagicMock(), session=s)
+
+            gone = (await s.execute(text(f"SELECT count(*) FROM assets WHERE id='{aid}'"))).scalar_one()
+            link_gone = (await s.execute(text(f"SELECT count(*) FROM asset_links WHERE asset_id='{aid}'"))).scalar_one()
+            kept = (await s.execute(text(
+                f"SELECT count(*) FROM assets WHERE org_id='{ORG}' AND object_path IN ('grace/b','grace/c')"
+            ))).scalar_one()
+            assert gone == 0 and link_gone == 0 and kept == 2
+            prov.delete_object.assert_awaited()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_storage_warn_cron_email_dedup_rearm(monkeypatch):
+    """S8 Phase 2: 80% 경고 cron — over-80%→owner 메일+마커, cooldown→재발송 X, under-80%→마커 re-arm."""
+    from unittest.mock import MagicMock
+
+    from app.routers import cron
+
+    GB = 1024 ** 3
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            await s.execute(text(f"UPDATE org_members SET role='owner' WHERE org_id='{ORG}'"))
+            await s.execute(text(f"DELETE FROM org_subscriptions WHERE org_id='{ORG}'"))
+            await s.execute(text(
+                "INSERT INTO org_subscriptions (id,org_id,polar_customer_id,tier,status)"
+                " VALUES (gen_random_uuid(),:o,'cust_test','free','active')"
+            ), {"o": ORG})
+            await s.execute(text(
+                "INSERT INTO assets (id,org_id,project_id,container,object_path,name,size_bytes,deleted_at)"
+                " VALUES (gen_random_uuid(),:o,:p,:c,'warn/big','big',:sz,NULL)"
+            ), {"o": ORG, "p": PROJ_A, "c": BUCKET, "sz": int(4.5 * GB)})
+            await s.commit()
+
+            sent: list = []
+            monkeypatch.setattr(cron, "send_email", lambda to, subject, html: sent.append(to) or True)
+
+            await cron.storage_usage_warn(MagicMock(), session=s)
+            assert "u@a2.test" in sent
+            m1 = (await s.execute(text(f"SELECT storage_warn_notified_at FROM org_subscriptions WHERE org_id='{ORG}'"))).scalar_one()
+            assert m1 is not None
+
+            sent.clear()
+            await cron.storage_usage_warn(MagicMock(), session=s)
+            assert sent == []
+
+            await s.execute(text(f"UPDATE assets SET deleted_at=now() WHERE org_id='{ORG}' AND object_path='warn/big'"))
+            await s.commit()
+            await cron.storage_usage_warn(MagicMock(), session=s)
+            m2 = (await s.execute(text(f"SELECT storage_warn_notified_at FROM org_subscriptions WHERE org_id='{ORG}'"))).scalar_one()
+            assert m2 is None
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## S8 Phase 2 — soft-delete 7일 grace cron + 80% storage 경고 email (+ size clamp ②)

S8 `4fbb10c1` Phase 2 (비차단 fast-follow). Phase 1(#1759·server-side enforce) 위 lifecycle. base=develop(Phase 1 머지 後 rebase·Phase 2 단독 커밋).

### 변경
- **provider `delete_object`** 추가(base+gcs+s3+local·멱등·best-effort). S1 D3 "read+sign만"을 S8 BE-side blob hard-delete 실사용으로 해소.
- **grace cron** `GET /internal/cron/assets-grace-hard-delete`: soft-delete 7일 경과 asset hard-delete(blob+row·asset_links FK CASCADE). **blob delete 성공 시에만 row 삭제**(실패=다음 tick 재시도·orphan 0)·tick당 500.
- **80% 경고 cron** `GET /internal/cron/storage-usage-warn`: SaaS org(org_subscriptions active) 사용량 캡의 80%+ → owner/admin 경고 email. **dedup**=`org_subscriptions.storage_warn_notified_at`(마이그 0141)+cooldown 7일·80% 미만 복귀 시 re-arm.
- **size clamp ②**(까심): `check_storage_capacity` size 음수 clamp(`max(0,int)`)·함수단독 raw 호출 총량 우회 방어.
- cron.py 구조 정리(misplaced logger→imports 下·unused Header 제거).

### 테스트 (CI alembic-fresh)
- grace cron(7일 경과만 hard-delete·link CASCADE·최근/live 보존·blob mock) · 80% 경고(owner 메일+마커·cooldown 재발송X·under-80% re-arm) · local provider delete(멱등).
- 마이그 0139→0141 clean+0141 컬럼 검증 · 풀스위트(no-DB) **2580 pass**·잔여 8=기존 MCP-env · ruff clean.

### 후속/운영
- **migrate=PO lane**(0141·머지 後 sprintable-migrate-dev). cron 스케줄 배선(Next.js /api/cron/* → 두 endpoint)=infra/PO.
- follow-up①(doc/직접attach 게이트)=S4 BE 회수. Phase 2 **FE UX(80% 표시·Supabase 캡 제거)**=미르코 트랙.
- 노트: 80% 경고는 org_subscription 보유 org 대상(無subscription free=FE UX+enforce 로 커버).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
