### PR TITLE
[S6-BE] GET /api/v2/assets/{id} — single asset for embed-card

### DIFF
--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -331,3 +331,30 @@ def _build_source_link(stype, sid, asset_name, story_t, doc_t, msg_t) -> SourceL
         return SourceLink(type=stype, id=sid, title=title, deeplink=deeplink)
     # manual: 파일명 title·deeplink 없음(source 조회 불요·항상 생성)
     return SourceLink(type=stype, id=sid, title=asset_name, deeplink=None)
+
+
+@router.get("/assets/{asset_id}", response_model=AssetResponse)
+async def get_asset(
+    asset_id: str,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> AssetResponse:
+    """GET /api/v2/assets/{id} — 단건 asset(enriched·S6 embed-card 리치카드 소스).
+
+    _scope_filter 와 동일 org/project 접근권(IDOR·S3 authorize 일관). malformed UUID / 스코프 밖 /
+    삭제됨 = **graceful 404**(존재여부 비노출). 라우트는 /assets/storage-usage·/folders 後 선언이라
+    리터럴 경로 미shadow(파라미터 라우트 최후).
+    """
+    try:
+        aid = uuid.UUID(asset_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Asset not found") from None
+    clauses, accessible = await _scope_filter(db, auth, org_id, None)
+    asset = (await db.execute(
+        select(Asset).where(Asset.id == aid, and_(*clauses))
+    )).scalar_one_or_none()
+    if asset is None:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    enriched = await _enrich(db, org_id, accessible, [asset])
+    return enriched[asset.id]

--- a/backend/tests/test_asset_registry_realdb.py
+++ b/backend/tests/test_asset_registry_realdb.py
@@ -712,7 +712,8 @@ async def test_storage_usage_sums_committed_excludes_softdeleted():
             ), {"org": ORG, "proj": PROJ_A, "c": BUCKET, "p": "su/c", "n": "c", "sz": 999})
             await s.commit()
 
-            auth = MagicMock(); auth.user_id = str(USER)
+            auth = MagicMock()
+            auth.user_id = str(USER)
             resp = await storage_usage(db=s, auth=auth, org_id=ORG)
             assert resp.org_id == ORG
             assert resp.used_bytes == 350  # 100+250 (soft-deleted 999 제외)
@@ -792,7 +793,8 @@ async def test_storage_usage_limit_ee_gated(monkeypatch):
                 " VALUES (gen_random_uuid(),:o,:p,:c,'u/a','a',:sz,NULL)"
             ), {"o": ORG, "p": PROJ_A, "c": BUCKET, "sz": 512 * MB})
             await s.commit()
-            auth = MagicMock(); auth.user_id = str(USER)
+            auth = MagicMock()
+            auth.user_id = str(USER)
 
             # OSS(is_ee_enabled False) → limit null·percentage 0
             monkeypatch.setattr(settings, "license_consent", "")
@@ -804,5 +806,49 @@ async def test_storage_usage_limit_ee_gated(monkeypatch):
             ee = await storage_usage(db=s, auth=auth, org_id=ORG)
             assert ee.limit_bytes == 5120 * MB
             assert ee.percentage == round(512 / 5120 * 100, 1)  # =10.0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_single_asset_scoped():
+    """S6 BE: GET /assets/{id} — accessible project asset 반환·cross-project/malformed/없음/삭제=404(graceful)."""
+    from unittest.mock import MagicMock
+
+    from fastapi import HTTPException
+
+    from app.routers.assets import get_asset
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            ins = ("INSERT INTO assets (id,org_id,project_id,container,object_path,name,size_bytes)"
+                   " VALUES (:id,:o,:p,:c,:path,:n,10)")
+            aid_a = uuid.uuid4()  # PROJ_A: USER granted
+            await s.execute(text(ins), {"id": aid_a, "o": ORG, "p": PROJ_A, "c": BUCKET, "path": "ga/a", "n": "a.png"})
+            aid_b = uuid.uuid4()  # PROJ_B: USER 미접근
+            await s.execute(text(ins), {"id": aid_b, "o": ORG, "p": PROJ_B, "c": BUCKET, "path": "ga/b", "n": "b.png"})
+            aid_del = uuid.uuid4()  # soft-deleted
+            await s.execute(text(
+                "INSERT INTO assets (id,org_id,project_id,container,object_path,name,size_bytes,deleted_at)"
+                " VALUES (:id,:o,:p,:c,'ga/d','d.png',10, now())"
+            ), {"id": aid_del, "o": ORG, "p": PROJ_A, "c": BUCKET})
+            await s.commit()
+
+            auth = MagicMock()
+            auth.user_id = str(USER)
+
+            r = await get_asset(str(aid_a), db=s, auth=auth, org_id=ORG)
+            assert r.id == aid_a and r.name == "a.png"
+
+            for bad, why in [(str(aid_b), "cross-project"), (str(aid_del), "soft-deleted"),
+                             (str(uuid.uuid4()), "nonexistent"), ("not-a-uuid", "malformed")]:
+                try:
+                    await get_asset(bad, db=s, auth=auth, org_id=ORG)
+                    assert False, f"expected 404 for {why}"
+                except HTTPException as e:
+                    assert e.status_code == 404, why
     finally:
         await engine.dispose()


### PR DESCRIPTION
## S6 BE — `GET /api/v2/assets/{id}` 단건 asset (embed-card 리치카드 소스)

S6 #1760 재QA **BLOCKER**(까심 verdict는 머지가능이었으나 PO 병행 codex 적출): 단건 asset 엔드포인트 부재 → assets.py=list·storage-usage·folders만. FE embed-card 가 `/api/assets/{id}` fetch → BE **404** → 리치카드 **항상 fallback**(S6 핵심 표현 깨짐).

### 변경
- `GET /api/v2/assets/{id}` 추가. `_scope_filter` 동일 org/project 접근권(IDOR·list/S3 authorize 일관)·`_enrich` 재사용(created_by + source_links).
- **graceful 404**: malformed UUID / 스코프 밖(cross-project) / soft-deleted / 없음 = 404(존재여부 비노출).
- 라우트는 `/assets/storage-usage`·`/folders` 後(파라미터 라우트 최후) 선언 → 리터럴 경로 미shadow.

### 테스트 (CI alembic-fresh)
- accessible project asset 반환 · cross-project/malformed/없음/soft-deleted → 404.
- 기존 #1759 E702(auth=MagicMock 세미콜론) 정리. ruff clean · **마이그 없음**.

S6 #1760(미르코 FE)과 co-merge — BE-first 권장(FE embed-card fetch 대상 준비).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
