### PR TITLE
[SID:c1947a32] S4-core BE — doc asset register endpoint + doc-scope IDOR

### DIFF
--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -695,9 +695,17 @@ async def register_doc_asset(
     )
     asset_id = url_map.get(body.url)
     if asset_id is None:
-        # path_in_source_scope(doc) 거부 = 이 doc namespace 밖 path(IDOR) 또는 외부/타버킷 URL.
-        raise HTTPException(status_code=400, detail="object_path not scoped to this document")
+        # 미등록 사유: ① path_in_source_scope(doc) 거부=이 doc namespace 밖 path(IDOR)/외부URL,
+        # ② head_object None=GCS에 객체 부재(FE putObject 미완·optimistic FE는 error state 처리).
+        raise HTTPException(
+            status_code=400, detail="object not registered: out-of-scope path or not uploaded"
+        )
+    # size 는 authoritative(sync 가 head_object 로 저장한 실값·client size 무시·까심①).
+    from app.models.asset import Asset
+    real_size = int((await session.execute(
+        select(Asset.size_bytes).where(Asset.id == asset_id)
+    )).scalar_one())
     await session.commit()
     return DocAssetRegisterResponse(
-        asset_id=asset_id, filename=body.filename, size=body.size, mime=body.mime
+        asset_id=asset_id, filename=body.filename, size=real_size, mime=body.mime
     )

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -632,3 +632,72 @@ async def transition_doc_endpoint(
         raise HTTPException(
             status_code=_codes.get(e.code, 400), detail={"code": e.code, "message": e.message}
         )
+
+
+class DocAssetRegisterRequest(BaseModel):
+    url: str           # FE putObject 반환(GCS url 또는 canonical bare path)
+    filename: str
+    size: int
+    mime: str | None = None
+
+
+class DocAssetRegisterResponse(BaseModel):
+    asset_id: uuid.UUID
+    filename: str
+    size: int
+    mime: str | None = None
+
+
+@router.post("/{doc_id}/assets", response_model=DocAssetRegisterResponse, status_code=201)
+async def register_doc_asset(
+    doc_id: uuid.UUID,
+    body: DocAssetRegisterRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> DocAssetRegisterResponse:
+    """POST /api/v2/docs/{doc_id}/assets — S4: FE-putObject 後 doc asset register(optimistic).
+
+    FE 가 압축→putObject(`org/{org}/project/{proj}/doc/{doc_id}/...`) 後 이 endpoint 로 register.
+    ⚠️ object_path 를 path_in_source_scope(doc 분기)로 검증 = **IDOR 핵심**(FE 가 임의/타org/타doc path
+    register 못 함). capacity 게이트①(ee seam·OSS no-op·doc 우회 구멍 차단)·asset + asset_link
+    (source_type=doc·source_id=doc_id) 생성. signed read 는 S3 authorize asset_id 분기 재사용(신규 0).
+    """
+    from app.core.config import settings
+    from app.models.doc import Doc
+    from app.services.asset_registry import sync_attachment_assets
+    from app.services.member_resolver import resolve_member
+    from app.services.project_auth import has_project_access
+
+    doc = (await session.execute(
+        select(Doc).where(Doc.id == doc_id, Doc.org_id == org_id, Doc.deleted_at.is_(None))
+    )).scalar_one_or_none()
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Doc not found")
+    if not await has_project_access(session, uuid.UUID(auth.user_id), doc.project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
+    att = {"url": body.url, "name": body.filename, "content_type": body.mime, "size": body.size}
+    # capacity 게이트①(서버사이드·ee seam·OSS no-op) — doc 업로드도 commit 前 enforce(우회 구멍 차단·까심①).
+    if settings.is_ee_enabled:
+        from ee.plan_limits import check_storage_capacity  # type: ignore[import]
+        await check_storage_capacity(session, org_id, [att])
+
+    created_by: uuid.UUID | None = None
+    try:
+        created_by = (await resolve_member(auth, org_id, session)).id
+    except Exception:  # noqa: BLE001 — created_by 는 비필수(asset.created_by nullable).
+        created_by = None
+
+    url_map = await sync_attachment_assets(
+        session, org_id=org_id, project_id=doc.project_id, source_type="doc",
+        source_id=doc_id, attachments=[att], created_by=created_by,
+    )
+    asset_id = url_map.get(body.url)
+    if asset_id is None:
+        # path_in_source_scope(doc) 거부 = 이 doc namespace 밖 path(IDOR) 또는 외부/타버킷 URL.
+        raise HTTPException(status_code=400, detail="object_path not scoped to this document")
+    await session.commit()
+    return DocAssetRegisterResponse(
+        asset_id=asset_id, filename=body.filename, size=body.size, mime=body.mime
+    )

--- a/backend/app/services/asset_registry.py
+++ b/backend/app/services/asset_registry.py
@@ -118,10 +118,14 @@ async def sync_attachment_assets(
             continue  # 이 source 귀속 경로 아님 — registry 오염/IDOR 차단(까심)
         name = (att.get("name") or "").strip() or obj.rsplit("/", 1)[-1] or "file"
         content_type = (att.get("content_type") or "").strip() or None
-        try:
-            size_bytes = int(att.get("size") or 0)
-        except (TypeError, ValueError):
-            size_bytes = 0
+        # 까심 ①: size 는 client-trust 금지 — 실 object size(head_object) **authoritative**(size:0 quota
+        # 우회·음수 size_bytes 오염 차단). 객체 부재(head None)=FE putObject 안 함/오염 → 등록 안 함(skip·
+        # phantom asset 0). 전 경로(doc register·chat send_message·story) 동시 적용=client-trust 완전 제거.
+        from app.services.storage import get_storage_provider
+
+        size_bytes = await get_storage_provider().head_object(container, obj)
+        if size_bytes is None:
+            continue
 
         # asset upsert — 멱등. project_id null/non-null 별 partial unique 로 ON CONFLICT 분기(까심 R3).
         base_ins = pg_insert(Asset).values(

--- a/backend/app/services/asset_registry.py
+++ b/backend/app/services/asset_registry.py
@@ -59,13 +59,14 @@ def path_in_source_scope(
     차단). 두 namespace 인식(S7·AC3 무회귀)·**org/project/source 전 tenancy segment exact 바인딩**:
     - legacy: `chat/<project>/<conversation>/<file>` · `story/<project>/<story>/<file>`
     - S7 신: `org/<org>/project/<project>/chat/<conversation>/<file>` · `.../story/<story>/<file>`
-    신 namespace 의 org segment 도 반드시 일치(미검증 시 cross-org IDOR·CRITICAL). manual/doc 은 경로
-    제약 없음(신뢰 등록·doc=S4). segment 단위 정확 비교(_prefix_segments_match)로 변형/우회 견고.
+    신 namespace 의 org segment 도 반드시 일치(미검증 시 cross-org IDOR·CRITICAL). **doc(S4)**도 동일
+    스코프 강제(`org/<org>/project/<project>/doc/<doc_id>/`·register endpoint IDOR 핵심·FE 임의/타org path
+    register 차단). manual 만 경로 제약 없음(신뢰 등록). segment 단위 정확 비교(_prefix_segments_match)로 견고.
     """
     pid, sid = str(project_id), str(source_id)
-    kind = {"conversation_message": "chat", "story": "story"}.get(source_type)
+    kind = {"conversation_message": "chat", "story": "story", "doc": "doc"}.get(source_type)
     if kind is None:
-        return True  # manual/doc 등 경로 제약 없는 source
+        return True  # manual 등 경로 제약 없는 source(신뢰 등록)
     # legacy: <kind>/<project>/<source>/<file>
     if _prefix_segments_match(object_path, [kind, pid, sid]):
         return True

--- a/backend/app/services/storage/base.py
+++ b/backend/app/services/storage/base.py
@@ -25,3 +25,8 @@ class StorageProvider(abc.ABC):
     @abc.abstractmethod
     async def delete_object(self, container: str, object_path: str) -> bool:
         """객체 hard-delete(S8 grace cron). 이미 없으면 True(멱등)·실패 시 False(best-effort·호출부 계속)."""
+
+    @abc.abstractmethod
+    async def head_object(self, container: str, object_path: str) -> int | None:
+        """객체 실 크기(bytes) — 부재/실패 시 None. capacity/size_bytes **authoritative source**(까심 ①:
+        client-제공 size 신뢰 금지·size:0 quota 우회+음수 size_bytes 오염 차단). None=객체 미존재=미등록."""

--- a/backend/app/services/storage/gcs.py
+++ b/backend/app/services/storage/gcs.py
@@ -68,3 +68,16 @@ class GcsStorageProvider(StorageProvider):
         except Exception:
             logger.warning("gcs storage: delete 실패 path=%s", object_path, exc_info=True)
             return False
+
+    async def head_object(self, container: str, object_path: str) -> int | None:
+        def _blocking() -> int | None:
+            from google.cloud import storage
+
+            blob = storage.Client().bucket(container).get_blob(object_path)  # get_blob=None if absent
+            return int(blob.size) if blob is not None and blob.size is not None else None
+
+        try:
+            return await asyncio.to_thread(_blocking)
+        except Exception:
+            logger.warning("gcs storage: head 실패 path=%s", object_path, exc_info=True)
+            return None

--- a/backend/app/services/storage/local.py
+++ b/backend/app/services/storage/local.py
@@ -93,3 +93,14 @@ class LocalStorageProvider(StorageProvider):
         except Exception:
             logger.warning("local storage: delete 실패 path=%s", object_path, exc_info=True)
             return False
+
+    async def head_object(self, container: str, object_path: str) -> int | None:
+        def _blocking() -> int | None:
+            p = _resolve_safe(container, object_path)
+            return p.stat().st_size if p.exists() else None
+
+        try:
+            return await asyncio.to_thread(_blocking)
+        except Exception:
+            logger.warning("local storage: head 실패 path=%s", object_path, exc_info=True)
+            return None

--- a/backend/app/services/storage/s3.py
+++ b/backend/app/services/storage/s3.py
@@ -66,3 +66,17 @@ class S3StorageProvider(StorageProvider):
         except Exception:
             logger.warning("s3 storage: delete 실패 path=%s", object_path, exc_info=True)
             return False
+
+    async def head_object(self, container: str, object_path: str) -> int | None:
+        def _blocking() -> int | None:
+            try:
+                resp = _client().head_object(Bucket=container, Key=object_path)
+                return int(resp["ContentLength"])
+            except Exception:
+                return None  # 404/absent
+
+        try:
+            return await asyncio.to_thread(_blocking)
+        except Exception:
+            logger.warning("s3 storage: head 실패 path=%s", object_path, exc_info=True)
+            return None

--- a/backend/ee/plan_limits.py
+++ b/backend/ee/plan_limits.py
@@ -108,8 +108,9 @@ async def check_storage_capacity(session: AsyncSession, org_id, attachments: lis
     """S8: org storage 캡 enforce(서버 게이트·all tiers). per-file + 총량(committed+신규).
 
     tier(org_subscriptions)→plan_tier_limits[tier]→캡. 캡 미정의 tier=무제한(no-op). **우리 버킷 객체만**
-    카운트(canonical_object_path not None·외부 URL 제외). 보수적: 재전송 중복은 over-count(안전측·캡 초과
-    절대 불허). OSS 는 호출 안 됨(is_ee_enabled 게이트·라우터). 초과 시 402 PLAN_LIMIT_EXCEEDED.
+    카운트(canonical_object_path not None·외부 URL 제외). **size 는 head_object authoritative**(까심 ①:
+    client-size:0 quota 우회·음수 size 오염 차단·sync 와 동일 source). 객체 부재(head None)=미카운트(미등록될
+    것). OSS 는 호출 안 됨(is_ee_enabled 게이트·라우터). 초과 시 402 PLAN_LIMIT_EXCEEDED.
     """
     if not attachments:
         return
@@ -124,16 +125,20 @@ async def check_storage_capacity(session: AsyncSession, org_id, attachments: lis
     max_file_bytes = max_file_mb * 1024 * 1024
     max_storage_bytes = max_storage_mb * 1024 * 1024
 
-    from app.services.asset_registry import canonical_object_path
+    from app.services.asset_registry import DEFAULT_CONTAINER, canonical_object_path
+    from app.services.storage import get_storage_provider
 
+    provider = get_storage_provider()
     new_bytes = 0
     for att in attachments:
-        if not isinstance(att, dict) or canonical_object_path(att.get("url") or "") is None:
-            continue  # 우리 객체 아님(외부/타버킷) → 우리 storage 미카운트
-        try:
-            size = max(0, int(att.get("size") or 0))  # 음수 clamp(까심 ②·함수단독 raw 호출 방어·총량 우회 차단)
-        except (TypeError, ValueError):
-            size = 0
+        if not isinstance(att, dict):
+            continue
+        obj = canonical_object_path(att.get("url") or "", DEFAULT_CONTAINER)
+        if obj is None:
+            continue  # 우리 객체 아님(외부/타버킷) → 미카운트
+        size = await provider.head_object(DEFAULT_CONTAINER, obj)  # authoritative(client size 무시·까심①)
+        if size is None:
+            continue  # 객체 부재 = 미카운트(미등록될 것)
         if size > max_file_bytes:
             raise _storage_limit_error("file_size", max_file_mb, tier)
         new_bytes += size

--- a/backend/tests/test_asset_canonical.py
+++ b/backend/tests/test_asset_canonical.py
@@ -121,3 +121,17 @@ async def test_local_provider_delete_object(tmp_path, monkeypatch):
 @pytest.fixture
 def anyio_backend():
     return "asyncio"
+
+
+def test_scope_doc_namespace_s4():
+    """S4: doc 분기 — org/project/doc exact-prefix 강제(이전 unconstrained). cross-org/project/doc 거부·manual 무제약."""
+    doc = _uuid.uuid4()
+    assert path_in_source_scope(f"org/{_ORG}/project/{_PROJ}/doc/{doc}/u.png", "doc", _PROJ, doc, _ORG)
+    # cross-org / cross-doc / cross-project → 거부
+    assert not path_in_source_scope(f"org/{_uuid.uuid4()}/project/{_PROJ}/doc/{doc}/u.png", "doc", _PROJ, doc, _ORG)
+    assert not path_in_source_scope(f"org/{_ORG}/project/{_PROJ}/doc/{_uuid.uuid4()}/u.png", "doc", _PROJ, doc, _ORG)
+    assert not path_in_source_scope(f"org/{_ORG}/project/{_uuid.uuid4()}/doc/{doc}/u.png", "doc", _PROJ, doc, _ORG)
+    # 빈 trailing / 중간삽입 거부
+    assert not path_in_source_scope(f"org/{_ORG}/project/{_PROJ}/doc/{doc}/", "doc", _PROJ, doc, _ORG)
+    # manual 은 여전히 무제약(신뢰 등록)
+    assert path_in_source_scope("anything/x.png", "manual", _PROJ, _uuid.uuid4(), _ORG)

--- a/backend/tests/test_asset_registry_realdb.py
+++ b/backend/tests/test_asset_registry_realdb.py
@@ -947,3 +947,71 @@ async def test_storage_warn_cron_email_dedup_rearm(monkeypatch):
             assert m2 is None
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_register_doc_asset_s4():
+    """S4: doc asset register endpoint — valid=asset+asset_link(doc) 생성·out-of-scope path=400(IDOR)·
+    no project access=403·doc 없음=404."""
+    from unittest.mock import MagicMock
+
+    from fastapi import HTTPException
+
+    from app.models.doc import Doc
+    from app.routers.docs import DocAssetRegisterRequest, register_doc_asset
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _reset_and_seed(s)
+            doc = Doc(org_id=ORG, project_id=PROJ_A, title="t", slug=f"s4-{uuid.uuid4()}")
+            s.add(doc)
+            doc_b = Doc(org_id=ORG, project_id=PROJ_B, title="tb", slug=f"s4b-{uuid.uuid4()}")  # USER 미접근
+            s.add(doc_b)
+            await s.flush()
+            doc_id, doc_b_id = doc.id, doc_b.id
+            await s.commit()
+
+            auth = MagicMock()
+            auth.user_id = str(USER)
+
+            # ① valid register → asset + asset_link(source_type=doc)
+            good = f"org/{ORG}/project/{PROJ_A}/doc/{doc_id}/u-a.png"
+            resp = await register_doc_asset(
+                doc_id, DocAssetRegisterRequest(url=good, filename="a.png", size=123, mime="image/png"),
+                session=s, auth=auth, org_id=ORG,
+            )
+            assert resp.filename == "a.png" and resp.size == 123
+            link_n = (await s.execute(text(
+                f"SELECT count(*) FROM asset_links WHERE source_type='doc' AND source_id='{doc_id}'"
+            ))).scalar_one()
+            asset_n = (await s.execute(text(f"SELECT count(*) FROM assets WHERE id='{resp.asset_id}'"))).scalar_one()
+            assert link_n == 1 and asset_n == 1
+
+            # ② out-of-scope path(타 doc namespace) → 400 IDOR
+            bad = f"org/{ORG}/project/{PROJ_A}/doc/{uuid.uuid4()}/evil.png"
+            try:
+                await register_doc_asset(doc_id, DocAssetRegisterRequest(url=bad, filename="e", size=1), session=s, auth=auth, org_id=ORG)
+                assert False, "expected 400"
+            except HTTPException as e:
+                assert e.status_code == 400
+
+            # ③ no project access(PROJ_B doc) → 403
+            try:
+                await register_doc_asset(
+                    doc_b_id, DocAssetRegisterRequest(url=f"org/{ORG}/project/{PROJ_B}/doc/{doc_b_id}/x.png", filename="x", size=1),
+                    session=s, auth=auth, org_id=ORG,
+                )
+                assert False, "expected 403"
+            except HTTPException as e:
+                assert e.status_code == 403
+
+            # ④ doc 없음 → 404
+            try:
+                await register_doc_asset(uuid.uuid4(), DocAssetRegisterRequest(url="org/x/y/doc/z/f.png", filename="x", size=1), session=s, auth=auth, org_id=ORG)
+                assert False, "expected 404"
+            except HTTPException as e:
+                assert e.status_code == 404
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_asset_registry_realdb.py
+++ b/backend/tests/test_asset_registry_realdb.py
@@ -41,6 +41,32 @@ def anyio_backend():
     return "asyncio"
 
 
+# 까심①: sync/capacity 가 size 를 head_object(실 object size)로 가져온다(client-trust 제거). realdb 테스트는
+# 실 GCS 객체가 없으므로(합성 path) provider.head_object 를 mock — 기본 size + per-path override(_HEAD_SIZES).
+_HEAD_SIZE_DEFAULT = 10
+_HEAD_SIZES: dict[str, int] = {}
+
+
+@pytest.fixture(autouse=True)
+def _mock_storage_head(monkeypatch):
+    from unittest.mock import AsyncMock, MagicMock
+
+    import app.services.storage as _storage_mod
+
+    _HEAD_SIZES.clear()
+
+    async def _head(container, object_path):
+        return _HEAD_SIZES.get(object_path, _HEAD_SIZE_DEFAULT)
+
+    prov = MagicMock()
+    prov.head_object = AsyncMock(side_effect=_head)
+    # sync_attachment_assets·check_storage_capacity 는 call-time `from app.services.storage import
+    # get_storage_provider` → source 패치로 둘 다 mock 픽업. (cron grace 테스트는 cron.get_storage_provider
+    # 자체 패치라 독립.)
+    monkeypatch.setattr(_storage_mod, "get_storage_provider", lambda: prov)
+    yield
+
+
 async def _reset_and_seed(session):
     # 멱등 클린업 후 org/projects/user/grant 시드. assets/asset_links 는 본 org 범위만 정리.
     for sql in [
@@ -746,7 +772,9 @@ async def test_check_storage_capacity_enforce():
             await s.commit()
 
             def _att_sized(sz, path="cap/new.png"):
-                return {"url": f"org/{ORG}/project/{PROJ_A}/chat/{uuid.uuid4()}/{path}", "name": "n", "content_type": "image/png", "size": sz}
+                url = f"org/{ORG}/project/{PROJ_A}/chat/{uuid.uuid4()}/{path}"
+                _HEAD_SIZES[url] = sz  # head_object authoritative(까심①)·client size 무시 증명용 att size=0
+                return {"url": url, "name": "n", "content_type": "image/png", "size": 0}
 
             # 총량 초과: used(5GB-100)+200 > 5GB → 402
             try:
@@ -976,18 +1004,20 @@ async def test_register_doc_asset_s4():
             auth = MagicMock()
             auth.user_id = str(USER)
 
-            # ① valid register → asset + asset_link(source_type=doc)
+            # ① valid register → asset + asset_link(source_type=doc). size=head_object authoritative(까심①):
+            #    client size=999999(거짓)여도 무시되고 head 실값(777) 저장/반환.
             good = f"org/{ORG}/project/{PROJ_A}/doc/{doc_id}/u-a.png"
+            _HEAD_SIZES[good] = 777
             resp = await register_doc_asset(
-                doc_id, DocAssetRegisterRequest(url=good, filename="a.png", size=123, mime="image/png"),
+                doc_id, DocAssetRegisterRequest(url=good, filename="a.png", size=999999, mime="image/png"),
                 session=s, auth=auth, org_id=ORG,
             )
-            assert resp.filename == "a.png" and resp.size == 123
+            assert resp.filename == "a.png" and resp.size == 777  # client 999999 무시·head 777
             link_n = (await s.execute(text(
                 f"SELECT count(*) FROM asset_links WHERE source_type='doc' AND source_id='{doc_id}'"
             ))).scalar_one()
-            asset_n = (await s.execute(text(f"SELECT count(*) FROM assets WHERE id='{resp.asset_id}'"))).scalar_one()
-            assert link_n == 1 and asset_n == 1
+            size_row = (await s.execute(text(f"SELECT size_bytes FROM assets WHERE id='{resp.asset_id}'"))).scalar_one()
+            assert link_n == 1 and int(size_row) == 777  # DB 도 authoritative
 
             # ② out-of-scope path(타 doc namespace) → 400 IDOR
             bad = f"org/{ORG}/project/{PROJ_A}/doc/{uuid.uuid4()}/evil.png"


### PR DESCRIPTION
## S4-core BE — doc asset register endpoint + `path_in_source_scope` doc 분기 (IDOR)

E-STORAGE-SSOT S4 (storage 에픽 마지막 FE의 BE 슬라이스). docs 첨부 base64 data-url → Storage asset ref. PO crux 3답 반영(FE-putObject+BE-register · backfill 별 PR · signed read=S3 재사용).

### 변경
- **`path_in_source_scope` doc 분기**: doc 를 unconstrained(True) → `org/{org}/project/{proj}/doc/{doc_id}/` **exact-prefix 강제**(`_prefix_segments_match` SSOT). **register IDOR 핵심**(FE 가 임의/타org/타doc path register 차단). source_id=doc_id 가 path 와 일치 = 축 mismatch 0. **manual 만 무제약 유지**.
- **`POST /api/v2/docs/{doc_id}/assets`** (register·optimistic): doc 접근권(org-scoped + `has_project_access`) · **capacity 게이트①**(`check_storage_capacity`·ee seam·OSS no-op·doc 우회 구멍 차단=까심①) · `sync_attachment_assets`(source_type=doc·source_id=doc_id)로 asset+asset_link 생성. object_path scope 거부 시 **400**(IDOR). 반환 `{asset_id,filename,size,mime}` = FE asset ref 스키마.
- **signed read = 신규 0**: FE 가 asset_id 로 S3 authorize asset_id 분기 재사용.

### FE↔BE 계약 (미르코 S4 FE wire)
```
POST /api/v2/docs/{doc_id}/assets   req: {url, filename, size, mime}   resp: {asset_id, filename, size, mime}
```
FE: 압축 → putObject(`org/{org}/project/{proj}/doc/{doc_id}/{uuid}-{name}`) → 이 endpoint register → assetId 노드 attrs swap → signed render(authorize asset_id).

### 테스트 (CI alembic-fresh)
- doc namespace scope(cross-org/project/doc·빈 trailing 거부·manual 무제약) · register valid(asset+asset_link doc) · out-of-scope 400 · no-access 403 · doc 없음 404.
- asset realdb+canonical+authorize 49 · doc/asset no-DB 182 pass · ruff clean · **마이그 없음**(doc source_type 기존 정의).

### 후속
- **backfill 별 PR**(base64→GCS→content rewrite·content 변조 risk라 core 안정化 後·PO 동의). public placeholder = authorize 403/404 → FE 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
