### PR TITLE
[SID:e6f25e53] 대화 첨부 authorize — owner/admin 우회 (선생님 제보)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
           JWT_SECRET: ci-test-secret-at-least-32-chars-long
           SECRET_KEY: ci-test-secret-at-least-32-chars-long
-        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py -q
+        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py -q
 
       - name: Verify fresh DB reached head (baseline + incremental)
         working-directory: backend

--- a/backend/app/routers/attachments.py
+++ b/backend/app/routers/attachments.py
@@ -119,7 +119,20 @@ async def authorize_attachment(
             )
         )).scalar_one_or_none()
         if is_participant is None:
-            raise HTTPException(status_code=403, detail="Not a participant of this conversation")
+            # owner/admin 우회 — conversations.py get_conversation/list 와 **동일 SSOT**(e6f25e53·선생님 제보):
+            # agent-only 대화는 org owner/admin 열람 허용(메시지 LIST/get_conversation 은 보이는데 첨부 sign 만
+            # 403 이던 불일치 해소). 휴먼 참가 대화(사적 DM)는 참가자-only 유지(프라이버시). belongs(②)는
+            # 그대로 — 우회는 참가자 요건만 면제·임의 path 허용 아님. story 브랜치(has_project_access)는 무변경.
+            from app.routers.conversations import (
+                _conversation_has_human_participant,
+                _effective_org_role,
+            )
+            role = await _effective_org_role(auth, org_id, db, member)
+            if not (
+                role in ("owner", "admin")
+                and not await _conversation_has_human_participant(conversation_id, db)
+            ):
+                raise HTTPException(status_code=403, detail="Not a participant of this conversation")
         # ② 정확 매치: stored url == bare path(신규) OR == legacy 전체 URL. substring 금지.
         belongs = (await db.execute(
             text(

--- a/backend/tests/test_attachment_authorize_a54ddc16.py
+++ b/backend/tests/test_attachment_authorize_a54ddc16.py
@@ -122,11 +122,45 @@ async def test_authorize_conversation_path_not_scoped_403():
 
 @pytest.mark.anyio
 async def test_authorize_conversation_not_participant_403():
+    """비참가 + 非owner/admin(member) → 403(우회 없음)."""
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[_scalar(PROJECT_ID), _scalar(None)])  # conv project, 비참가
     client, app = await _client(session)
     try:
-        with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()):
+        with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()), \
+             patch("app.routers.conversations._effective_org_role", new_callable=AsyncMock, return_value="member"):
+            r = await _get(client, f"path={CONV_PATH}&conversation_id={CONV_ID}")
+        assert r.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_authorize_conversation_owner_agentonly_bypass_200():
+    """e6f25e53: 비참가 owner/admin + agent-only 대화 → 우회 허용(메시지 LIST 와 일관·선생님 제보)."""
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_scalar(PROJECT_ID), _scalar(None), _scalar(True)])  # conv proj·비참가·belongs
+    client, app = await _client(session)
+    try:
+        with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()), \
+             patch("app.routers.conversations._effective_org_role", new_callable=AsyncMock, return_value="owner"), \
+             patch("app.routers.conversations._conversation_has_human_participant", new_callable=AsyncMock, return_value=False):
+            r = await _get(client, f"path={CONV_PATH}&conversation_id={CONV_ID}")
+        assert r.status_code == 200 and r.json()["authorized"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_authorize_conversation_owner_humandm_403():
+    """비참가 owner/admin 라도 휴먼 참가 대화(사적 DM)면 → 403(프라이버시·우회 금지)."""
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_scalar(PROJECT_ID), _scalar(None)])  # conv proj·비참가(belongs 도달 전 403)
+    client, app = await _client(session)
+    try:
+        with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()), \
+             patch("app.routers.conversations._effective_org_role", new_callable=AsyncMock, return_value="owner"), \
+             patch("app.routers.conversations._conversation_has_human_participant", new_callable=AsyncMock, return_value=True):
             r = await _get(client, f"path={CONV_PATH}&conversation_id={CONV_ID}")
         assert r.status_code == 403
     finally:

--- a/backend/tests/test_conv_human_participant_realdb.py
+++ b/backend/tests/test_conv_human_participant_realdb.py
@@ -1,0 +1,85 @@
+"""e6f25e53 (산티아고 SME 권고): `_conversation_has_human_participant` 보수성 **실 view** 락.
+
+cp2(test_chat_visibility_admin_bypass)는 team_members 쿼리를 mock 해 helper set-logic 만 검증한다.
+이건 실 team_members VIEW(members⋈agent_project_profiles)로 락: agent(뷰 출현) + grant-only/미앵커 휴먼
+(team_members agent 미확정) 섞이면 human=True(보수적), agent-only 면 False. DB env 없으면 skip(CI alembic-fresh).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("e6000000-0000-0000-0000-000000000001")
+PROJ = uuid.UUID("e6000000-0000-0000-0000-0000000000c1")
+AGENT = uuid.UUID("e6000000-0000-0000-0000-0000000000a1")
+AGENT2 = uuid.UUID("e6000000-0000-0000-0000-0000000000a2")
+HUMAN_UNANCHORED = uuid.UUID("e6000000-0000-0000-0000-0000000000b9")  # team_members agent 미확정(grant-only/미앵커)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _seed(s):
+    for sql in [
+        f"DELETE FROM conversation_participants WHERE member_id IN ('{AGENT}','{AGENT2}','{HUMAN_UNANCHORED}')",
+        f"DELETE FROM conversations WHERE org_id='{ORG}'",
+        f"DELETE FROM agent_project_profiles WHERE member_id IN ('{AGENT}','{AGENT2}')",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','E6','e6org','free')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ}','{ORG}','P')",
+        "INSERT INTO members (id,org_id,type,name,is_active) VALUES "
+        f"('{AGENT}','{ORG}','agent','Bot1',true),('{AGENT2}','{ORG}','agent','Bot2',true)",
+        # 에이전트 team_members 뷰 출현(agent_project_profiles join).
+        "INSERT INTO agent_project_profiles (id,member_id,project_id,agent_role,fakechat_port) VALUES "
+        f"(gen_random_uuid(),'{AGENT}','{PROJ}','dev',9701),(gen_random_uuid(),'{AGENT2}','{PROJ}','dev',9702)",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _conv_with(s, conv_id, member_ids):
+    await s.execute(text(
+        f"INSERT INTO conversations (id,project_id,org_id,type,created_by) "
+        f"VALUES ('{conv_id}','{PROJ}','{ORG}','group','{AGENT}')"
+    ))
+    for m in member_ids:
+        await s.execute(text(
+            "INSERT INTO conversation_participants (id,conversation_id,member_id) "
+            f"VALUES (gen_random_uuid(),'{conv_id}','{m}')"
+        ))
+    await s.commit()
+
+
+@pytest.mark.anyio
+async def test_helper_conservatism_real_view():
+    from app.routers.conversations import _conversation_has_human_participant
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+            # ① agent(뷰 출현) + 미앵커 휴먼(agent 미확정) → 보수적 human=True (산티아고 케이스).
+            mixed = uuid.uuid4()
+            await _conv_with(s, mixed, [AGENT, HUMAN_UNANCHORED])
+            assert await _conversation_has_human_participant(mixed, s) is True
+            # ② agent-only(둘 다 뷰 agent) → False.
+            agent_only = uuid.uuid4()
+            await _conv_with(s, agent_only, [AGENT, AGENT2])
+            assert await _conversation_has_human_participant(agent_only, s) is False
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 대화 첨부 authorize — owner/admin 우회 추가 (선생님 제보·critical e6f25e53)

선생님(sellerking·org owner) dev 스토리지 상세서 대화 첨부 이미지 403(`/api/attachments/sign` → BE authorize → 403).

### 근본 (실측 정정)
- **킥오프 ①(네임스페이스 staleness) = 이미 해소됨**: authorize 는 `path_in_source_scope`(attachments.py:111/148·S7-aware·#1751), `attachment_context._is_scoped_to_conversation` 도 `path_in_source_scope`(#1757). `startswith("chat/")` 부재. 라이브 probe(참가자·S7 path)=200. → 참가자는 S7 첨부 정상.
- **실 근본 = ②**: authorize conv 분기가 **참가자-only**. org owner/admin 은 메시지 LIST/get_conversation 은 보는데(owner/admin 우회 보유) **첨부 sign 만 403**(불일치). 선생님=비참가 owner.

### fix
- authorize conv 분기에 conversations.py **동일 SSOT 우회** mirror: 참가자 실패 시 `_effective_org_role` owner/admin **AND** agent-only(`not _conversation_has_human_participant`)면 허용. 휴먼 DM 은 참가자-only(프라이버시). `belongs`(정확매치) 무변경 = 우회는 참가자 요건만 면제·임의 path 불가. story/asset_id 분기 무변경.
- 정공법 #1(path-scope SSOT 1함수)은 이미 충족(`path_in_source_scope` 공유)이라 신규 작업 없음.

### 테스트 (masking-off·dispatch 레벨)
- 참가자 200 · **owner+agent대화 200(우회)** · **owner+휴먼DM 403(프라이버시)** · 非owner 비참가 403 · 타org/타대화/빈trailing 403 · legacy 200.
- authorize 17 + attachment/conversation cluster 110 pass · ruff clean · 순환 import 0 · 마이그 없음.

### 게이트
보안 인가 변경 → 까심 cross-model + 산티아고 SME(PO 소환). 격리 worktree 작업.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
