### PR TITLE
[SID:009fd681] S4 Phase2 — doc base64 첨부 → GCS backfill (멱등 배치)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
           JWT_SECRET: ci-test-secret-at-least-32-chars-long
           SECRET_KEY: ci-test-secret-at-least-32-chars-long
-        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py -q
+        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py -q
 
       - name: Verify fresh DB reached head (baseline + incremental)
         working-directory: backend

--- a/backend/app/services/asset_registry.py
+++ b/backend/app/services/asset_registry.py
@@ -87,6 +87,7 @@ async def sync_attachment_assets(
     created_by: uuid.UUID | None = None,
     container: str = DEFAULT_CONTAINER,
     path_scope_id: uuid.UUID | None = None,
+    reconcile: bool = True,
 ) -> dict[str, uuid.UUID]:
     """첨부 목록을 asset registry 로 동기화(upsert) + asset_link 재조정(reconcile).
 
@@ -173,12 +174,15 @@ async def sync_attachment_assets(
         )
 
     # reconcile: 이 source 의 현재 집합에 없는 link 제거(update 의 attachments 교체 의미).
-    stale = delete(AssetLink).where(
-        AssetLink.source_type == source_type,
-        AssetLink.source_id == source_id,
-    )
-    if asset_ids:
-        stale = stale.where(AssetLink.asset_id.not_in(asset_ids))
-    await session.execute(stale)
+    # ⚠️ S4 backfill 은 reconcile=False(additive) — base64-derived 만 넘기는데 reconcile 하면 같은 doc 의
+    # 기존 FE-업로드 asset_link 까지 삭제(clobber)된다. backfill 은 추가만·삭제 금지.
+    if reconcile:
+        stale = delete(AssetLink).where(
+            AssetLink.source_type == source_type,
+            AssetLink.source_id == source_id,
+        )
+        if asset_ids:
+            stale = stale.where(AssetLink.asset_id.not_in(asset_ids))
+        await session.execute(stale)
 
     return url_map

--- a/backend/app/services/doc_asset_backfill.py
+++ b/backend/app/services/doc_asset_backfill.py
@@ -99,20 +99,24 @@ def to_asset_ref_image_node(
     asset_id: uuid.UUID, filename: str, size: int, mime: str, *, width: int | None = None,
     alt: str | None = None,
 ) -> str:
-    """이미지 노드 asset-ref 직렬화(미르코 §1 LOCK byte-exact·CustomImageNode).
-
-    `<img data-asset-id data-filename data-size data-mime-type [width] [alt]>` — **src attr 없음**
-    (PO 크럭스 option ②: signed URL ephemeral·persist 금지·렌더 시 data-asset-id→sign?asset_id 해소).
-    width/alt 는 legacy 에 있을 때만(회귀0·resize/대체텍스트 보존).
+    """이미지 노드 asset-ref 직렬화 — **FE content-converter `imageWithAsset` 룰(실 round-trip 코드)
+    byte-exact**. ⚠️ §1.1 doc(`width="{px}"`·width-before-alt)은 부정확 — 실 코드는:
+    - escape = **quote-only**(`"`→&quot;·`&`/`<`/`>` 미escape·FE `a()` 동형).
+    - order = data-asset-id, data-filename, data-size, data-mime-type, **alt, then width**.
+    - width = **`style="width:{px}px;max-width:100%;height:auto"`** (width attr 아님).
+    - src 미출력(option ②·signed URL ephemeral·렌더 시 data-asset-id→sign?asset_id 해소).
     """
+    def _q(s: str) -> str:  # FE image a(): 따옴표만 escape(파일 노드 safeAttr 와 다름)
+        return s.replace('"', "&quot;")
+
     s = (
-        f'<img data-asset-id="{asset_id}" data-filename="{_esc(filename)}" '
-        f'data-size="{size}" data-mime-type="{_esc(mime)}"'
+        f'<img data-asset-id="{asset_id}" data-filename="{_q(filename)}" '
+        f'data-size="{size}" data-mime-type="{_q(mime)}"'
     )
-    if width:
-        s += f' width="{width}"'
     if alt:
-        s += f' alt="{_esc(alt)}"'
+        s += f' alt="{_q(alt)}"'
+    if width:
+        s += f' style="width:{width}px;max-width:100%;height:auto"'
     return s + ">"
 
 

--- a/backend/app/services/doc_asset_backfill.py
+++ b/backend/app/services/doc_asset_backfill.py
@@ -1,0 +1,269 @@
+"""E-STORAGE-SSOT S4 Phase2 (009fd681): doc 본문 base64 첨부 → GCS 자산 이관 + 본문 rewrite.
+
+핸드오프 §1 LOCK 계약: 노드 attrs `{assetId, filename, size, mime}`(`data-asset-id` ref). 렌더러는
+`data:`/base64 면 base64 렌더, `data-asset-id` 면 `sign?asset_id` 렌더(legacy 호환). 이 배치가 legacy
+base64 노드를 asset-ref 노드로 치환하면 자동으로 sign 경로로 전환된다.
+
+설계:
+- **멱등**: 변환된 노드는 `data:`/`data-file-data` 가 없으므로 재스캔 대상 아님 → 2회차 0.
+- **dry-run 기본**(apply=False): 변환 대상만 count, 쓰기 0. apply=True 만 put/register/content update.
+- **부분실패 graceful**: 노드별 put 실패 → 그 노드는 base64 유지(continue), 나머지 진행.
+- **additive register**: `sync_attachment_assets(reconcile=False)` — 같은 doc 의 기존 FE-업로드 link clobber 금지.
+- **per-doc 원자**: 한 doc 의 성공 노드들을 모아 content 1회 update(트랜잭션).
+
+⚠️ 이미지 ref 노드 정확 markup(img 태그 vs custom node·attr 이름)은 미르코 렌더러 contract(핸드오프 §1
+byte-exact). `to_asset_ref_image_node` 한 곳만 §1 확정 후 맞추면 된다(PO 크럭스: option ② = src persist
+금지·data-asset-id 만·렌더 시 sign 해소).
+"""
+from __future__ import annotations
+
+import base64
+import logging
+import mimetypes
+import re
+import uuid
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.doc import Doc
+from app.services.asset_registry import DEFAULT_CONTAINER, sync_attachment_assets
+
+logger = logging.getLogger(__name__)
+
+# legacy 파일 노드: <div data-type="fileAttachment" ... data-file-data="data:..."></div>
+_FILE_NODE_RE = re.compile(
+    r'<div\b[^>]*\bdata-type="fileAttachment"[^>]*\bdata-file-data="(?P<data>data:[^"]*)"[^>]*>\s*</div>',
+    re.IGNORECASE,
+)
+# legacy 이미지(markdown): ![alt](data:image/...;base64,...)
+_IMG_MD_RE = re.compile(r'!\[(?P<alt>[^\]]*)\]\((?P<data>data:image/[^)\s]+)\)')
+# legacy 이미지(raw HTML·width 보존형): <img ... src="data:image/..." ...>
+_IMG_HTML_RE = re.compile(r'<img\b[^>]*\bsrc="(?P<data>data:image/[^"]*)"[^>]*>', re.IGNORECASE)
+
+_ATTR_RE_CACHE: dict[str, re.Pattern] = {}
+
+
+def _attr(tag: str, name: str) -> str:
+    """tag 문자열에서 data-* attr 값 추출(순서 무관·없으면 '')."""
+    pat = _ATTR_RE_CACHE.get(name)
+    if pat is None:
+        pat = re.compile(rf'\b{re.escape(name)}="([^"]*)"', re.IGNORECASE)
+        _ATTR_RE_CACHE[name] = pat
+    m = pat.search(tag)
+    return m.group(1) if m else ""
+
+
+def _esc(s: str) -> str:
+    """attr 값 HTML escape(FE turndown safeAttr 와 동형: & " < > )."""
+    return (
+        s.replace("&", "&amp;").replace('"', "&quot;").replace("<", "&lt;").replace(">", "&gt;")
+    )
+
+
+def _decode_data_url(data_url: str) -> tuple[bytes, str] | None:
+    """`data:{mime};base64,{b64}` → (bytes, mime). 비-base64/파싱 실패 시 None."""
+    m = re.match(r"data:(?P<mime>[^;,]*);base64,(?P<b64>.*)", data_url, re.DOTALL)
+    if not m:
+        return None
+    try:
+        raw = base64.b64decode(m.group("b64"), validate=False)
+    except Exception:
+        return None
+    if not raw:
+        return None
+    return raw, (m.group("mime") or "application/octet-stream")
+
+
+def _safe_filename(name: str, mime: str) -> str:
+    """파일명 정규화(경로/공백 제거)·없으면 mime 기반 생성."""
+    base = re.sub(r"[^A-Za-z0-9._-]", "_", (name or "").strip()).strip("._") or ""
+    if not base:
+        ext = mimetypes.guess_extension(mime) or ".bin"
+        base = f"attachment{ext}"
+    return base[:120]
+
+
+def to_asset_ref_file_node(asset_id: uuid.UUID, filename: str, size: int, mime: str) -> str:
+    """파일 노드 asset-ref 직렬화(미르코 §1 LOCK byte-exact: data-asset-id **LAST**·data-file-data 없음).
+
+    `<div data-type="fileAttachment" data-filename data-size data-mime-type data-asset-id></div>`
+    """
+    return (
+        f'<div data-type="fileAttachment" data-filename="{_esc(filename)}" data-size="{size}" '
+        f'data-mime-type="{_esc(mime)}" data-asset-id="{asset_id}"></div>'
+    )
+
+
+def to_asset_ref_image_node(
+    asset_id: uuid.UUID, filename: str, size: int, mime: str, *, width: int | None = None,
+    alt: str | None = None,
+) -> str:
+    """이미지 노드 asset-ref 직렬화(미르코 §1 LOCK byte-exact·CustomImageNode).
+
+    `<img data-asset-id data-filename data-size data-mime-type [width] [alt]>` — **src attr 없음**
+    (PO 크럭스 option ②: signed URL ephemeral·persist 금지·렌더 시 data-asset-id→sign?asset_id 해소).
+    width/alt 는 legacy 에 있을 때만(회귀0·resize/대체텍스트 보존).
+    """
+    s = (
+        f'<img data-asset-id="{asset_id}" data-filename="{_esc(filename)}" '
+        f'data-size="{size}" data-mime-type="{_esc(mime)}"'
+    )
+    if width:
+        s += f' width="{width}"'
+    if alt:
+        s += f' alt="{_esc(alt)}"'
+    return s + ">"
+
+
+_WIDTH_STYLE_RE = re.compile(r"width:\s*(\d+)\s*px", re.IGNORECASE)
+_WIDTH_ATTR_RE = re.compile(r'\bwidth="(\d+)"', re.IGNORECASE)
+
+
+def _extract_width(tag: str) -> int | None:
+    """legacy <img> width 추출 — style="width:Xpx" 또는 width="X" attr. 회귀0(resize 보존)."""
+    style = _attr(tag, "style")
+    m = _WIDTH_STYLE_RE.search(style) or _WIDTH_ATTR_RE.search(tag)
+    return int(m.group(1)) if m else None
+
+
+class _Node:
+    __slots__ = ("start", "end", "kind", "data_url", "alt", "filename", "width", "asset_ref")
+
+    def __init__(self, start, end, kind, data_url, alt, filename, width=None):
+        self.start = start
+        self.end = end
+        self.kind = kind  # 'file' | 'image'
+        self.data_url = data_url
+        self.alt = alt
+        self.filename = filename
+        self.width = width
+        self.asset_ref: str | None = None
+
+
+def _scan_nodes(content: str) -> list[_Node]:
+    """본문에서 base64 노드(파일+이미지) 추출(span·kind·data-url·메타). 멱등: data-asset-id 노드는 미매치."""
+    nodes: list[_Node] = []
+    for m in _FILE_NODE_RE.finditer(content):
+        tag = m.group(0)
+        nodes.append(_Node(m.start(), m.end(), "file", m.group("data"),
+                           _attr(tag, "data-filename"), _attr(tag, "data-filename")))
+    for m in _IMG_MD_RE.finditer(content):
+        nodes.append(_Node(m.start(), m.end(), "image", m.group("data"), m.group("alt"), m.group("alt")))
+    for m in _IMG_HTML_RE.finditer(content):
+        tag = m.group(0)
+        nodes.append(_Node(m.start(), m.end(), "image", m.group("data"),
+                           _attr(tag, "alt"), _attr(tag, "alt"), _extract_width(tag)))
+    return nodes
+
+
+async def backfill_doc(
+    session: AsyncSession,
+    *,
+    doc_id: uuid.UUID,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID,
+    content: str,
+    apply: bool,
+) -> dict:
+    """단일 doc backfill. dry-run(apply=False)=count만. 반환 counts + (apply 시) 새 content."""
+    nodes = _scan_nodes(content)
+    result = {"found": len(nodes), "converted": 0, "failed": 0}
+    if not nodes or not apply:
+        return result
+
+    from app.services.storage import get_storage_provider  # call-time(테스트 patch·sync 와 동일 경로)
+
+    provider = get_storage_provider()
+    attachments: list[dict] = []
+    for n in nodes:
+        decoded = _decode_data_url(n.data_url)
+        if decoded is None:
+            result["failed"] += 1
+            continue
+        raw, mime = decoded
+        fname = _safe_filename(n.filename, mime)
+        obj = f"org/{org_id}/project/{project_id}/doc/{doc_id}/{uuid.uuid4()}-{fname}"
+        ok = await provider.put_object(DEFAULT_CONTAINER, obj, raw, content_type=mime)
+        if not ok:
+            result["failed"] += 1
+            continue  # base64 유지(부분실패 graceful)
+        n.filename, n.alt = fname, (n.alt or fname)
+        attachments.append({"url": obj, "name": fname, "content_type": mime, "_node": n,
+                            "_size": len(raw), "_mime": mime})
+
+    if not attachments:
+        return result
+
+    # additive register(reconcile=False·같은 doc 기존 link clobber 금지). head_object authoritative size.
+    url_map = await sync_attachment_assets(
+        session, org_id=org_id, project_id=project_id, source_type="doc",
+        source_id=doc_id, attachments=[{"url": a["url"], "name": a["name"],
+                                        "content_type": a["content_type"]} for a in attachments],
+        reconcile=False,
+    )
+    for a in attachments:
+        asset_id = url_map.get(a["url"])
+        n = a["_node"]
+        if asset_id is None:
+            result["failed"] += 1
+            continue  # register 미성공(scope 거부 등) → base64 유지
+        if n.kind == "file":
+            n.asset_ref = to_asset_ref_file_node(asset_id, n.filename, a["_size"], a["_mime"])
+        else:
+            n.asset_ref = to_asset_ref_image_node(
+                asset_id, n.filename, a["_size"], a["_mime"], width=n.width, alt=n.alt
+            )
+
+    # 성공 노드만 역순 치환(position 보존). 실패 노드는 base64 그대로.
+    new_content = content
+    for n in sorted([x for x in nodes if x.asset_ref], key=lambda x: x.start, reverse=True):
+        new_content = new_content[:n.start] + n.asset_ref + new_content[n.end:]
+        result["converted"] += 1
+
+    if result["converted"] and new_content != content:
+        await session.execute(
+            update(Doc).where(Doc.id == doc_id).values(content=new_content)
+        )
+        result["content"] = new_content
+    return result
+
+
+async def backfill_docs(
+    session: AsyncSession,
+    *,
+    apply: bool,
+    org_id: uuid.UUID | None = None,
+    chunk: int = 100,
+) -> dict:
+    """전 doc(또는 org 한정) keyset chunk 순회 backfill. 반환 집계 counts."""
+    totals = {"docs_scanned": 0, "docs_converted": 0, "found": 0, "converted": 0, "failed": 0}
+    last_id: uuid.UUID | None = None
+    while True:
+        q = select(Doc.id, Doc.org_id, Doc.project_id, Doc.content).order_by(Doc.id).limit(chunk)
+        # base64 보유 doc만(인덱스 없는 LIKE·배치라 허용). data-file-data 또는 data:image.
+        q = q.where(Doc.content.like("%data:%"))
+        if org_id is not None:
+            q = q.where(Doc.org_id == org_id)
+        if last_id is not None:
+            q = q.where(Doc.id > last_id)
+        rows = (await session.execute(q)).all()
+        if not rows:
+            break
+        for did, oid, pid, content in rows:
+            last_id = did
+            if pid is None or not content:
+                continue
+            totals["docs_scanned"] += 1
+            r = await backfill_doc(session, doc_id=did, org_id=oid, project_id=pid,
+                                   content=content, apply=apply)
+            totals["found"] += r["found"]
+            totals["converted"] += r["converted"]
+            totals["failed"] += r["failed"]
+            if r["converted"]:
+                totals["docs_converted"] += 1
+        if apply:
+            await session.commit()  # chunk 단위 커밋(resumable·부분 진행 보존)
+        if len(rows) < chunk:
+            break
+    return totals

--- a/backend/app/services/doc_asset_backfill.py
+++ b/backend/app/services/doc_asset_backfill.py
@@ -172,7 +172,7 @@ async def backfill_doc(
 ) -> dict:
     """단일 doc backfill. dry-run(apply=False)=count만. 반환 counts + (apply 시) 새 content."""
     nodes = _scan_nodes(content)
-    result = {"found": len(nodes), "converted": 0, "failed": 0}
+    result = {"found": len(nodes), "converted": 0, "failed": 0, "skipped_modified": 0}
     if not nodes or not apply:
         return result
 
@@ -199,37 +199,55 @@ async def backfill_doc(
     if not attachments:
         return result
 
-    # additive register(reconcile=False·같은 doc 기존 link clobber 금지). head_object authoritative size.
-    url_map = await sync_attachment_assets(
-        session, org_id=org_id, project_id=project_id, source_type="doc",
-        source_id=doc_id, attachments=[{"url": a["url"], "name": a["name"],
-                                        "content_type": a["content_type"]} for a in attachments],
-        reconcile=False,
-    )
-    for a in attachments:
-        asset_id = url_map.get(a["url"])
-        n = a["_node"]
-        if asset_id is None:
-            result["failed"] += 1
-            continue  # register 미성공(scope 거부 등) → base64 유지
-        if n.kind == "file":
-            n.asset_ref = to_asset_ref_file_node(asset_id, n.filename, a["_size"], a["_mime"])
-        else:
-            n.asset_ref = to_asset_ref_image_node(
-                asset_id, n.filename, a["_size"], a["_mime"], width=n.width, alt=n.alt
-            )
-
-    # 성공 노드만 역순 치환(position 보존). 실패 노드는 base64 그대로.
-    new_content = content
-    for n in sorted([x for x in nodes if x.asset_ref], key=lambda x: x.start, reverse=True):
-        new_content = new_content[:n.start] + n.asset_ref + new_content[n.end:]
-        result["converted"] += 1
-
-    if result["converted"] and new_content != content:
-        await session.execute(
-            update(Doc).where(Doc.id == doc_id).values(content=new_content)
+    # 낙관적 동시성(PO codex: lost-update race) — 스캔 스냅샷(content)↔content write 사이 유저가 그 doc 을
+    # 편집하면 무조건 덮어쓰기가 유저 편집을 clobber(데이터유실). register(asset/link insert) + content CAS
+    # (`WHERE content == 스냅샷`)를 savepoint 로 묶어, CAS miss(doc 변경됨)면 통째 rollback → asset/link
+    # orphan 0(GCS blob 만 미참조로 잔류=무해)·base64 유지·다음 run 재변환. 정상은 savepoint→chunk commit persist.
+    sp = await session.begin_nested()
+    try:
+        url_map = await sync_attachment_assets(
+            session, org_id=org_id, project_id=project_id, source_type="doc",
+            source_id=doc_id, attachments=[{"url": a["url"], "name": a["name"],
+                                            "content_type": a["content_type"]} for a in attachments],
+            reconcile=False,
         )
-        result["content"] = new_content
+        for a in attachments:
+            asset_id = url_map.get(a["url"])
+            n = a["_node"]
+            if asset_id is None:
+                result["failed"] += 1
+                continue  # register 미성공(scope 거부 등) → base64 유지
+            if n.kind == "file":
+                n.asset_ref = to_asset_ref_file_node(asset_id, n.filename, a["_size"], a["_mime"])
+            else:
+                n.asset_ref = to_asset_ref_image_node(
+                    asset_id, n.filename, a["_size"], a["_mime"], width=n.width, alt=n.alt
+                )
+
+        # 성공 노드만 역순 치환(position 보존). 실패 노드는 base64 그대로.
+        new_content = content
+        applied = 0
+        for n in sorted([x for x in nodes if x.asset_ref], key=lambda x: x.start, reverse=True):
+            new_content = new_content[:n.start] + n.asset_ref + new_content[n.end:]
+            applied += 1
+
+        if applied and new_content != content:
+            res = await session.execute(
+                update(Doc)
+                .where(Doc.id == doc_id, Doc.content == content)  # CAS — 스냅샷과 동일할 때만
+                .values(content=new_content)
+            )
+            if not res.rowcount:
+                await sp.rollback()  # doc 변경됨 — clobber 방지·asset/link insert 통째 취소
+                result["skipped_modified"] = applied
+                logger.warning("backfill: doc %s 스캔 후 변경됨 — lost-update 방지 skip", doc_id)
+                return result
+            result["content"] = new_content
+        await sp.commit()
+        result["converted"] = applied
+    except Exception:
+        await sp.rollback()
+        raise
     return result
 
 
@@ -241,7 +259,8 @@ async def backfill_docs(
     chunk: int = 100,
 ) -> dict:
     """전 doc(또는 org 한정) keyset chunk 순회 backfill. 반환 집계 counts."""
-    totals = {"docs_scanned": 0, "docs_converted": 0, "found": 0, "converted": 0, "failed": 0}
+    totals = {"docs_scanned": 0, "docs_converted": 0, "found": 0, "converted": 0,
+              "failed": 0, "skipped_modified": 0}
     last_id: uuid.UUID | None = None
     while True:
         q = select(Doc.id, Doc.org_id, Doc.project_id, Doc.content).order_by(Doc.id).limit(chunk)
@@ -264,6 +283,7 @@ async def backfill_docs(
             totals["found"] += r["found"]
             totals["converted"] += r["converted"]
             totals["failed"] += r["failed"]
+            totals["skipped_modified"] += r["skipped_modified"]
             if r["converted"]:
                 totals["docs_converted"] += 1
         if apply:

--- a/backend/app/services/storage/base.py
+++ b/backend/app/services/storage/base.py
@@ -30,3 +30,10 @@ class StorageProvider(abc.ABC):
     async def head_object(self, container: str, object_path: str) -> int | None:
         """객체 실 크기(bytes) — 부재/실패 시 None. capacity/size_bytes **authoritative source**(까심 ①:
         client-제공 size 신뢰 금지·size:0 quota 우회+음수 size_bytes 오염 차단). None=객체 미존재=미등록."""
+
+    @abc.abstractmethod
+    async def put_object(
+        self, container: str, object_path: str, data: bytes, *, content_type: str | None = None
+    ) -> bool:
+        """객체 업로드(S4 Phase2 backfill: doc 본문 base64→GCS 이관). 성공 True·실패 False(best-effort·
+        호출부가 실패 노드 base64 유지). D3(put=FE)의 후속 확장 — BE backfill 만 사용(런타임 업로드는 FE)."""

--- a/backend/app/services/storage/gcs.py
+++ b/backend/app/services/storage/gcs.py
@@ -81,3 +81,19 @@ class GcsStorageProvider(StorageProvider):
         except Exception:
             logger.warning("gcs storage: head 실패 path=%s", object_path, exc_info=True)
             return None
+
+    async def put_object(
+        self, container: str, object_path: str, data: bytes, *, content_type: str | None = None
+    ) -> bool:
+        def _blocking() -> bool:
+            from google.cloud import storage
+
+            blob = storage.Client().bucket(container).blob(object_path)
+            blob.upload_from_string(data, content_type=content_type or "application/octet-stream")
+            return True
+
+        try:
+            return await asyncio.to_thread(_blocking)
+        except Exception:
+            logger.warning("gcs storage: put 실패 path=%s", object_path, exc_info=True)
+            return False

--- a/backend/app/services/storage/local.py
+++ b/backend/app/services/storage/local.py
@@ -104,3 +104,18 @@ class LocalStorageProvider(StorageProvider):
         except Exception:
             logger.warning("local storage: head 실패 path=%s", object_path, exc_info=True)
             return None
+
+    async def put_object(
+        self, container: str, object_path: str, data: bytes, *, content_type: str | None = None
+    ) -> bool:
+        def _blocking() -> bool:
+            p = _resolve_safe(container, object_path)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(data)
+            return True
+
+        try:
+            return await asyncio.to_thread(_blocking)
+        except Exception:
+            logger.warning("local storage: put 실패 path=%s", object_path, exc_info=True)
+            return False

--- a/backend/app/services/storage/s3.py
+++ b/backend/app/services/storage/s3.py
@@ -80,3 +80,19 @@ class S3StorageProvider(StorageProvider):
         except Exception:
             logger.warning("s3 storage: head 실패 path=%s", object_path, exc_info=True)
             return None
+
+    async def put_object(
+        self, container: str, object_path: str, data: bytes, *, content_type: str | None = None
+    ) -> bool:
+        def _blocking() -> bool:
+            kwargs: dict = {"Bucket": container, "Key": object_path, "Body": data}
+            if content_type:
+                kwargs["ContentType"] = content_type
+            _client().put_object(**kwargs)
+            return True
+
+        try:
+            return await asyncio.to_thread(_blocking)
+        except Exception:
+            logger.warning("s3 storage: put 실패 path=%s", object_path, exc_info=True)
+            return False

--- a/backend/scripts/jobs/backfill_doc_base64_assets.py
+++ b/backend/scripts/jobs/backfill_doc_base64_assets.py
@@ -1,0 +1,62 @@
+"""E-STORAGE-SSOT S4 Phase2 (009fd681): doc 본문 base64 첨부 → GCS 자산 이관 + 본문 rewrite (멱등 배치).
+
+배경: S4 前 doc 첨부는 base64 가 `Doc.content` 에 인라인 저장(행 bloat·재사용/캡 미연동). 이 job 이
+legacy base64 노드를 GCS 업로드 + asset registry 등록 + 본문을 `data-asset-id` ref 로 치환한다(핸드오프
+§1 LOCK 포맷). 렌더러가 ref→`sign?asset_id` 로 해소하므로 변환 즉시 정상 렌더(legacy 호환 규칙).
+
+멱등(변환된 노드는 재스캔 대상 아님·2회차 0)·chunked·resumable·**dry-run 기본**·부분실패 graceful.
+register 는 additive(reconcile=False·같은 doc 기존 FE-업로드 link clobber 금지). size 는 head_object
+authoritative.
+
+env: DATABASE_URL (백엔드 동일·cloud-sql-proxy/in-VPC)·STORAGE_PROVIDER/버킷 설정. apply 시 GCS 쓰기.
+실행:
+  cd backend && DATABASE_URL=... python -m scripts.jobs.backfill_doc_base64_assets            # dry-run
+  cd backend && DATABASE_URL=... python -m scripts.jobs.backfill_doc_base64_assets --apply     # 실제 이관
+옵션: --org <uuid> 특정 org만 · --chunk N keyset 청크 크기(기본 100).
+
+⚠️ run 전 미르코 FE 렌더러(data-asset-id 분기) 머지 + 이미지 노드 markup byte-exact(§1) 대조 필수.
+dev 먼저·prod 는 선생님 승인 시(PO 게이트).
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+import uuid
+
+from app.core.database import async_session_factory
+from app.services.doc_asset_backfill import backfill_docs
+
+
+async def main() -> int:
+    if not os.environ.get("DATABASE_URL"):
+        print("DATABASE_URL 미설정", file=sys.stderr)
+        return 2
+
+    parser = argparse.ArgumentParser(
+        description="doc 본문 base64 첨부 → GCS 자산 이관 + ref rewrite (멱등·dry-run 기본)"
+    )
+    parser.add_argument("--apply", action="store_true", help="실제 이관/쓰기 (미지정 시 dry-run)")
+    parser.add_argument("--org", type=str, default=None, help="특정 org_id 만 (기본 전체)")
+    parser.add_argument("--chunk", type=int, default=100, help="keyset 청크 크기 (기본 100)")
+    args = parser.parse_args()
+
+    org_id = uuid.UUID(args.org) if args.org else None
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    print(f"[{mode}] doc base64 backfill 시작 org={args.org or 'ALL'} chunk={args.chunk}", file=sys.stderr)
+
+    async with async_session_factory() as session:
+        totals = await backfill_docs(session, apply=args.apply, org_id=org_id, chunk=args.chunk)
+
+    print(
+        f"[{mode}] 완료 — docs_scanned={totals['docs_scanned']} docs_converted={totals['docs_converted']} "
+        f"nodes_found={totals['found']} converted={totals['converted']} failed={totals['failed']}"
+    )
+    if not args.apply:
+        print("(dry-run — 쓰기 없음. --apply 로 실제 이관)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/backend/scripts/jobs/backfill_doc_base64_assets.py
+++ b/backend/scripts/jobs/backfill_doc_base64_assets.py
@@ -51,7 +51,8 @@ async def main() -> int:
 
     print(
         f"[{mode}] 완료 — docs_scanned={totals['docs_scanned']} docs_converted={totals['docs_converted']} "
-        f"nodes_found={totals['found']} converted={totals['converted']} failed={totals['failed']}"
+        f"nodes_found={totals['found']} converted={totals['converted']} failed={totals['failed']} "
+        f"skipped_modified={totals['skipped_modified']}"
     )
     if not args.apply:
         print("(dry-run — 쓰기 없음. --apply 로 실제 이관)", file=sys.stderr)

--- a/backend/tests/test_doc_asset_backfill_realdb.py
+++ b/backend/tests/test_doc_asset_backfill_realdb.py
@@ -1,0 +1,127 @@
+"""S4 Phase2 backfill — 실DB 통합(scan→put(mock)→register→rewrite). DB env 없으면 skip(CI alembic-fresh).
+
+put_object/head_object 는 mock(합성 객체·실 GCS 없음). register(sync_attachment_assets reconcile=False)·
+content rewrite·멱등·부분실패는 실DB로 검증.
+"""
+from __future__ import annotations
+
+import base64
+import os
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("b4000000-0000-0000-0000-000000000001")
+PROJ = uuid.UUID("b4000000-0000-0000-0000-0000000000c1")
+B64 = base64.b64encode(b"hello-bytes").decode()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _mock_storage(monkeypatch):
+    prov = MagicMock()
+    prov.put_object = AsyncMock(return_value=True)
+    prov.head_object = AsyncMock(return_value=11)  # sync authoritative size(합성 객체)
+    monkeypatch.setattr("app.services.storage.get_storage_provider", lambda: prov)
+    return prov
+
+
+async def _seed(s, content):
+    doc_id = uuid.uuid4()
+    for sql in [
+        f"DELETE FROM asset_links WHERE org_id='{ORG}'",
+        f"DELETE FROM assets WHERE org_id='{ORG}'",
+        f"DELETE FROM docs WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','B4','b4org','free')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ}','{ORG}','P')",
+    ]:
+        await s.execute(text(sql))
+    await s.execute(text(
+        "INSERT INTO docs (id,org_id,project_id,title,slug,content,content_format) "
+        f"VALUES ('{doc_id}','{ORG}','{PROJ}','T','slug-{doc_id}',:c,'markdown')"
+    ), {"c": content})
+    await s.commit()
+    return doc_id
+
+
+def _file_node():
+    return (f'<div data-type="fileAttachment" data-filename="a.pdf" data-size="11" '
+            f'data-mime-type="application/pdf" data-file-data="data:application/pdf;base64,{B64}"></div>')
+
+
+@pytest.mark.anyio
+async def test_dry_run_counts_no_write():
+    from app.services.doc_asset_backfill import backfill_doc
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            content = _file_node() + f"\n![cat](data:image/png;base64,{B64})"
+            did = await _seed(s, content)
+            r = await backfill_doc(s, doc_id=did, org_id=ORG, project_id=PROJ, content=content, apply=False)
+            assert r["found"] == 2 and r["converted"] == 0
+            # 쓰기 없음 — content/asset 불변.
+            n_assets = (await s.execute(text(f"SELECT count(*) FROM assets WHERE org_id='{ORG}'"))).scalar_one()
+            assert n_assets == 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_apply_converts_registers_rewrites_idempotent():
+    from app.services.doc_asset_backfill import backfill_doc
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            content = _file_node() + f"\n![cat](data:image/png;base64,{B64})"
+            did = await _seed(s, content)
+            r = await backfill_doc(s, doc_id=did, org_id=ORG, project_id=PROJ, content=content, apply=True)
+            await s.commit()
+            assert r["found"] == 2 and r["converted"] == 2 and r["failed"] == 0
+            new = (await s.execute(text(f"SELECT content FROM docs WHERE id='{did}'"))).scalar_one()
+            assert "data:" not in new and "data-file-data" not in new  # base64 제거
+            assert new.count("data-asset-id=") == 2  # ref 2개
+            n_assets = (await s.execute(text(f"SELECT count(*) FROM assets WHERE org_id='{ORG}'"))).scalar_one()
+            n_links = (await s.execute(text(
+                f"SELECT count(*) FROM asset_links WHERE org_id='{ORG}' AND source_type='doc'"))).scalar_one()
+            assert n_assets == 2 and n_links == 2
+            # 멱등: 변환된 content 재처리 → 0.
+            r2 = await backfill_doc(s, doc_id=did, org_id=ORG, project_id=PROJ, content=new, apply=True)
+            assert r2["found"] == 0 and r2["converted"] == 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_partial_failure_keeps_base64(_mock_storage):
+    from app.services.doc_asset_backfill import backfill_doc
+    _mock_storage.put_object = AsyncMock(side_effect=[True, False])  # 2번째 노드 put 실패
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            content = f"![a](data:image/png;base64,{B64})\n![b](data:image/jpeg;base64,{B64})"
+            did = await _seed(s, content)
+            r = await backfill_doc(s, doc_id=did, org_id=ORG, project_id=PROJ, content=content, apply=True)
+            await s.commit()
+            assert r["converted"] == 1 and r["failed"] == 1
+            new = (await s.execute(text(f"SELECT content FROM docs WHERE id='{did}'"))).scalar_one()
+            assert new.count("data-asset-id=") == 1 and new.count("data:image") == 1  # 실패 노드 base64 유지
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_doc_asset_backfill_realdb.py
+++ b/backend/tests/test_doc_asset_backfill_realdb.py
@@ -109,6 +109,29 @@ async def test_apply_converts_registers_rewrites_idempotent():
 
 
 @pytest.mark.anyio
+async def test_lost_update_race_no_clobber():
+    """PO codex: 스캔↔write 사이 doc 편집(stale 스냅샷) → CAS miss → 유저 편집 clobber 0(skip)."""
+    from app.services.doc_asset_backfill import backfill_doc
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            edited = "USER EDITED — 보존돼야 함"
+            did = await _seed(s, edited)  # DB 현재 content = 유저 편집본
+            stale = f"![old](data:image/png;base64,{B64})"  # backfill 이 든 stale 스냅샷(편집 前)
+            r = await backfill_doc(s, doc_id=did, org_id=ORG, project_id=PROJ, content=stale, apply=True)
+            await s.commit()
+            assert r["converted"] == 0 and r["skipped_modified"] == 1  # CAS miss → skip
+            now = (await s.execute(text(f"SELECT content FROM docs WHERE id='{did}'"))).scalar_one()
+            assert now == edited  # 유저 편집 무손실
+            # savepoint rollback → orphan asset/link 0.
+            n_assets = (await s.execute(text(f"SELECT count(*) FROM assets WHERE org_id='{ORG}'"))).scalar_one()
+            assert n_assets == 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_partial_failure_keeps_base64(_mock_storage):
     from app.services.doc_asset_backfill import backfill_doc
     _mock_storage.put_object = AsyncMock(side_effect=[True, False])  # 2번째 노드 put 실패

--- a/backend/tests/test_doc_asset_backfill_unit.py
+++ b/backend/tests/test_doc_asset_backfill_unit.py
@@ -35,12 +35,15 @@ def test_image_node_byte_exact_minimal():
 
 
 def test_image_node_byte_exact_with_width_alt():
+    # FE content-converter imageWithAsset 와 byte-exact: alt-before-width·width=style·quote-only escape.
     assert to_asset_ref_image_node(ID, "img.png", 999, "image/png", width=320, alt="cat") == (
         '<img data-asset-id="11111111-2222-3333-4444-555555555555" data-filename="img.png" '
-        'data-size="999" data-mime-type="image/png" width="320" alt="cat">'
+        'data-size="999" data-mime-type="image/png" alt="cat" '
+        'style="width:320px;max-width:100%;height:auto">'
     )
-    # src 절대 미포함(ephemeral signed URL persist 금지).
-    assert "src=" not in to_asset_ref_image_node(ID, "i.png", 1, "image/png", width=10)
+    # src 절대 미포함(ephemeral signed URL persist 금지)·width 는 style(attr 아님).
+    out = to_asset_ref_image_node(ID, "i.png", 1, "image/png", width=10)
+    assert "src=" not in out and 'width="10"' not in out and "style=\"width:10px" in out
 
 
 def test_scan_finds_all_three_forms():

--- a/backend/tests/test_doc_asset_backfill_unit.py
+++ b/backend/tests/test_doc_asset_backfill_unit.py
@@ -1,0 +1,82 @@
+"""S4 Phase2 backfill — 직렬화 byte-exact 락(미르코 §1 contract) + 스캔/디코드 단위(no DB).
+
+⚠️ 이 직렬화는 미르코 렌더러 contract라 byte-exact. 형태 바뀌면 렌더 깨짐 → 이 테스트가 회귀 게이트.
+"""
+from __future__ import annotations
+
+import base64
+import uuid
+
+from app.services.doc_asset_backfill import (
+    _decode_data_url,
+    _extract_width,
+    _scan_nodes,
+    to_asset_ref_file_node,
+    to_asset_ref_image_node,
+)
+
+ID = uuid.UUID("11111111-2222-3333-4444-555555555555")
+
+
+def test_file_node_byte_exact():
+    # 미르코 §1: data-asset-id **LAST**·data-file-data 없음.
+    assert to_asset_ref_file_node(ID, "report.pdf", 1234, "application/pdf") == (
+        '<div data-type="fileAttachment" data-filename="report.pdf" data-size="1234" '
+        'data-mime-type="application/pdf" data-asset-id="11111111-2222-3333-4444-555555555555"></div>'
+    )
+
+
+def test_image_node_byte_exact_minimal():
+    # src attr 없음(option ②)·order=asset-id,filename,size,mime-type.
+    assert to_asset_ref_image_node(ID, "img.png", 999, "image/png") == (
+        '<img data-asset-id="11111111-2222-3333-4444-555555555555" data-filename="img.png" '
+        'data-size="999" data-mime-type="image/png">'
+    )
+
+
+def test_image_node_byte_exact_with_width_alt():
+    assert to_asset_ref_image_node(ID, "img.png", 999, "image/png", width=320, alt="cat") == (
+        '<img data-asset-id="11111111-2222-3333-4444-555555555555" data-filename="img.png" '
+        'data-size="999" data-mime-type="image/png" width="320" alt="cat">'
+    )
+    # src 절대 미포함(ephemeral signed URL persist 금지).
+    assert "src=" not in to_asset_ref_image_node(ID, "i.png", 1, "image/png", width=10)
+
+
+def test_scan_finds_all_three_forms():
+    b64 = base64.b64encode(b"hello").decode()
+    content = (
+        f'<div data-type="fileAttachment" data-filename="a.pdf" data-size="5" '
+        f'data-mime-type="application/pdf" data-file-data="data:application/pdf;base64,{b64}"></div>\n'
+        f'![cat](data:image/png;base64,{b64})\n'
+        f'<img src="data:image/jpeg;base64,{b64}" alt="x" style="width:200px;max-width:100%">'
+    )
+    nodes = _scan_nodes(content)
+    kinds = sorted(n.kind for n in nodes)
+    assert kinds == ["file", "image", "image"]
+    img_html = [n for n in nodes if n.kind == "image" and n.width][0]
+    assert img_html.width == 200  # style width 보존
+
+
+def test_scan_idempotent_skips_asset_ref():
+    # 이미 변환된(data-asset-id·data: 없음) 노드는 미매치 → 2회차 0.
+    converted = (
+        '<div data-type="fileAttachment" data-filename="a.pdf" data-size="5" '
+        'data-mime-type="application/pdf" data-asset-id="' + str(ID) + '"></div>\n'
+        '<img data-asset-id="' + str(ID) + '" data-filename="i.png" data-size="9" data-mime-type="image/png">'
+    )
+    assert _scan_nodes(converted) == []
+
+
+def test_decode_data_url():
+    b64 = base64.b64encode(b"abc123").decode()
+    raw, mime = _decode_data_url(f"data:image/png;base64,{b64}")
+    assert raw == b"abc123" and mime == "image/png"
+    assert _decode_data_url("https://x/y.png") is None  # 비 data-url
+    assert _decode_data_url("data:image/png;base64,") is None  # 빈 데이터
+
+
+def test_extract_width():
+    assert _extract_width('<img src="x" style="width:320px;max-width:100%">') == 320
+    assert _extract_width('<img src="x" width="150">') == 150
+    assert _extract_width('<img src="x">') is None


### PR DESCRIPTION
## S4 Phase2 — doc 본문 base64 첨부 → GCS 자산 backfill (멱등 배치)

doc 본문 base64 인라인 첨부(행 bloat·재사용/캡 미연동)를 GCS 자산 + asset registry 로 이관 + 본문을 핸드오프 §1 LOCK 포맷(`data-asset-id` ref)으로 rewrite. 렌더러가 ref→`sign?asset_id` 해소(legacy 호환·전환기 무파손).

### 구성
- **provider `put_object`**(base+gcs+s3+local) — D3(put=FE)의 backfill 확장(BE 만 사용).
- **`sync_attachment_assets(reconcile=False)`** — additive register(같은 doc 기존 FE-업로드 link clobber 금지). size=head_object authoritative(#1763).
- **`doc_asset_backfill.py`** core: 스캔→decode→put→register→byte-exact rewrite. **멱등**(변환노드 재스캔 0)·**dry-run 기본**·keyset chunk resumable·**부분실패 graceful**(실패 노드 base64 유지)·per-doc 원자.
- **`scripts/jobs/backfill_doc_base64_assets.py`**(--apply·--org·--chunk·dry-run 기본).

### byte-exact §1 (미르코 LOCK)
- 이미지: `<img data-asset-id data-filename data-size data-mime-type [width][alt]>` — **src 없음**(PO 크럭스 option ②·ephemeral signed URL persist 금지·렌더 시 sign 해소).
- 파일: `<div data-type="fileAttachment" data-filename data-size data-mime-type data-asset-id></div>`(data-asset-id LAST·data-file-data 제거).

### 테스트
- unit 7: 직렬화 **byte-exact 락**(렌더 contract 회귀 게이트)·scan(3형태+멱등)·decode·width 추출.
- realdb 3: dry-run count·apply(변환+register+rewrite+멱등 2회차 0)·부분실패 base64 유지.
- CI alembic-fresh 등록. asset_registry realdb 38·풀스위트(no-DB) 2595 pass·ruff clean·마이그 없음.

### ⚠️ 게이트
**dry-run/run/merge 는 미르코 FE(`data-asset-id` 렌더러) 머지 後**(PO 게이트·렌더러가 ref 처리해야 결과 즉시 렌더). 까심 cross-model 대기. dev 먼저·prod 는 선생님 승인 시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
