### PR TITLE
[SID:c1947a32] S4 핫픽스 — register asset_id(snake_case) 추출 (dev 픽셀 적출)

### DIFF
--- a/apps/web/src/components/docs/extensions/image-upload.test.ts
+++ b/apps/web/src/components/docs/extensions/image-upload.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { pickRegisteredAssetId } from './image-upload';
+
+// S4 핫픽스(#1768) 계약 잠금: doc-attach register(`POST /api/docs/{id}/assets`) 응답에서
+// asset id 추출. dev 끝단서 적출 — BE 실응답은 snake `data.asset_id`인데 FE가 camel `data.assetId`만
+// 봐서 HTTP 200인데도 assetId=null → sign 미호출 → 이미지/파일 error state로 조용히 degrade했었다.
+describe('pickRegisteredAssetId · register 응답 계약 (S4 #1768)', () => {
+  it('BE 실응답 snake `{data:{asset_id}}` 를 추출한다 (계약의 1순위·회귀 잠금)', () => {
+    // dev 라이브서 실측한 정확한 형상.
+    const real = { data: { asset_id: '63b752eb-700c-4aa4-b437-ca8e6ae4d7e0', filename: 's4.png', size: 92, mime: 'image/png' }, error: null, meta: null };
+    expect(pickRegisteredAssetId(real)).toBe('63b752eb-700c-4aa4-b437-ca8e6ae4d7e0');
+  });
+
+  it('camelCase `{data:{assetId}}` 폴백', () => {
+    expect(pickRegisteredAssetId({ data: { assetId: 'a-1' } })).toBe('a-1');
+  });
+
+  it('`{data:{id}}` 폴백', () => {
+    expect(pickRegisteredAssetId({ data: { id: 'a-2' } })).toBe('a-2');
+  });
+
+  it('평면 `{asset_id}` / `{assetId}` / `{id}` 폴백', () => {
+    expect(pickRegisteredAssetId({ asset_id: 'a-3' })).toBe('a-3');
+    expect(pickRegisteredAssetId({ assetId: 'a-4' })).toBe('a-4');
+    expect(pickRegisteredAssetId({ id: 'a-5' })).toBe('a-5');
+  });
+
+  it('snake 가 camel/평면보다 우선 (실 BE 계약)', () => {
+    expect(pickRegisteredAssetId({ data: { asset_id: 'snake', assetId: 'camel', id: 'plain' } })).toBe('snake');
+  });
+
+  it('없거나 비정상 응답은 null (→ 호출부가 error state graceful 처리)', () => {
+    expect(pickRegisteredAssetId(null)).toBeNull();
+    expect(pickRegisteredAssetId(undefined)).toBeNull();
+    expect(pickRegisteredAssetId({})).toBeNull();
+    expect(pickRegisteredAssetId({ data: null })).toBeNull();
+    expect(pickRegisteredAssetId({ data: { filename: 'x.png' } })).toBeNull();
+  });
+});

--- a/apps/web/src/components/docs/extensions/image-upload.ts
+++ b/apps/web/src/components/docs/extensions/image-upload.ts
@@ -86,11 +86,23 @@ async function uploadAndRegister(docId: string, file: File): Promise<AssetRef> {
     }),
   });
   if (!reg.ok) throw new Error('register failed');
+  // BE register 응답은 snake_case(`data.asset_id`) — camelCase/평면 폴백도 같이 수용(계약 견고화).
   const json = (await reg.json().catch(() => null)) as
-    | { data?: { assetId?: string; id?: string } | null; assetId?: string; id?: string }
+    | {
+        data?: { asset_id?: string; assetId?: string; id?: string } | null;
+        asset_id?: string;
+        assetId?: string;
+        id?: string;
+      }
     | null;
   const assetId =
-    json?.data?.assetId ?? json?.data?.id ?? json?.assetId ?? json?.id ?? null;
+    json?.data?.asset_id ??
+    json?.data?.assetId ??
+    json?.data?.id ??
+    json?.asset_id ??
+    json?.assetId ??
+    json?.id ??
+    null;
   if (!assetId) throw new Error('no assetId in register response');
   return { assetId, filename: meta.name, size: meta.size, mime: meta.content_type };
 }

--- a/apps/web/src/components/docs/extensions/image-upload.ts
+++ b/apps/web/src/components/docs/extensions/image-upload.ts
@@ -67,6 +67,33 @@ export interface AssetRef {
  *     (2) register → { data: { assetId } } (또는 {id}). assetId(ref) 반환.
  * register 엔드포인트는 design-first(디디) — 미존재 시 non-2xx 로 throw 되어 호출부가 error 상태 처리.
  */
+/**
+ * register(`POST /api/docs/{id}/assets`) 응답에서 asset id 추출.
+ * BE 실응답은 snake_case `data.asset_id`(apiSuccess `{data}` envelope) — camelCase/평면 폴백도 수용(계약 견고화).
+ * dev 끝단 적출(#1768): HTTP 200인데 키 형상(snake↔camel) 불일치로 sign 미호출·이미지 미렌더로
+ * 조용히 degrade했던 클래스. 이 추출이 그 계약을 잠근다(테스트로 영구 고정).
+ */
+export function pickRegisteredAssetId(json: unknown): string | null {
+  const j = json as
+    | {
+        data?: { asset_id?: string; assetId?: string; id?: string } | null;
+        asset_id?: string;
+        assetId?: string;
+        id?: string;
+      }
+    | null
+    | undefined;
+  return (
+    j?.data?.asset_id ??
+    j?.data?.assetId ??
+    j?.data?.id ??
+    j?.asset_id ??
+    j?.assetId ??
+    j?.id ??
+    null
+  );
+}
+
 async function uploadAndRegister(docId: string, file: File): Promise<AssetRef> {
   const fd = new FormData();
   fd.append('file', file);
@@ -86,23 +113,8 @@ async function uploadAndRegister(docId: string, file: File): Promise<AssetRef> {
     }),
   });
   if (!reg.ok) throw new Error('register failed');
-  // BE register 응답은 snake_case(`data.asset_id`) — camelCase/평면 폴백도 같이 수용(계약 견고화).
-  const json = (await reg.json().catch(() => null)) as
-    | {
-        data?: { asset_id?: string; assetId?: string; id?: string } | null;
-        asset_id?: string;
-        assetId?: string;
-        id?: string;
-      }
-    | null;
-  const assetId =
-    json?.data?.asset_id ??
-    json?.data?.assetId ??
-    json?.data?.id ??
-    json?.asset_id ??
-    json?.assetId ??
-    json?.id ??
-    null;
+  const json = await reg.json().catch(() => null);
+  const assetId = pickRegisteredAssetId(json);
   if (!assetId) throw new Error('no assetId in register response');
   return { assetId, filename: meta.name, size: meta.size, mime: meta.content_type };
 }


### PR DESCRIPTION
## 개요
S4 doc-attach **dev 픽셀 끝단 검증서 적출한 버그** 핫픽스. 첨부 업로드가 `attachments` 200 + `register` 200인데도 이미지/파일이 **error state**로 빠지던 근본 원인.

## 근본
BE register(`POST /api/v2/docs/{id}/assets`) 응답 = `{"data":{"asset_id":"…","filename":…,"size":…,"mime":…}}` (**snake_case `asset_id`**).
FE `uploadAndRegister` 추출이 `data.assetId ?? data.id ?? assetId ?? id`(**camelCase**)만 봐서 → `assetId=null` → `throw 'no assetId'` → 노드 error state → **sign 미호출 → 이미지 미렌더**. HTTP는 200/200이라 **build-green·정적분석 못잡고 조용히 degrade**.

## fix
```ts
const assetId =
  json?.data?.asset_id ??   // ← BE 실제 응답(snake) 우선
  json?.data?.assetId ?? json?.data?.id ??
  json?.asset_id ?? json?.assetId ?? json?.id ?? null;
```
- `image-upload.ts uploadAndRegister`는 **이미지·파일 공유 단일 추출점** → 양 경로 동시 수정.
- 핸드오프 §0 계약도 `asset_id`(snake)였음 — FE가 camelCase로 잘못 가정한 계약-읽기 버그.

## 검증
- dev 라이브(sellerking·#1767): drop→`attachments` 200(FE→GCS 실 object_path)→`register` 200 응답 `data.asset_id` 실측 포착 → camel 추출 실패 확認.
- `pnpm build` 그린.
- **머지→재배포 後 재픽셀**(이미지 실 렌더·signed·read-only 뷰)로 끝단 박제 예정.

dev 끝단 검증(아버님 "실제 보이게")이 200/200 뒤의 형상 불일치를 적출 — pre-merge 추론·build-green이 못잡던 클래스.

🤖 Generated with [Claude Code](https://claude.com/claude-code)