### PR TITLE
[SID:39724bef] Storage 상세 패널 이미지 썸네일 (source별 sign·프라이버시)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -116,7 +116,12 @@
     "errorTitle": "Couldn't load assets",
     "errorDesc": "Something went wrong. Try again.",
     "retry": "Retry",
-    "loadMore": "Load more"
+    "loadMore": "Load more",
+    "previewLoading": "Loading preview",
+    "previewNoAccessTitle": "Preview not available",
+    "previewNoAccessDesc": "This conversation attachment is only visible to participants.",
+    "previewPhantomTitle": "No preview",
+    "previewPhantomDesc": "This asset has no stored original."
   },
   "commandPalette": {
     "title": "Command palette",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -116,7 +116,12 @@
     "errorTitle": "자산을 불러오지 못했습니다",
     "errorDesc": "문제가 발생했습니다. 다시 시도해 주세요.",
     "retry": "다시 시도",
-    "loadMore": "더 보기"
+    "loadMore": "더 보기",
+    "previewLoading": "미리보기 불러오는 중",
+    "previewNoAccessTitle": "미리보기 권한이 없습니다",
+    "previewNoAccessDesc": "이 대화 첨부는 참여자만 볼 수 있어요.",
+    "previewPhantomTitle": "미리보기 없음",
+    "previewPhantomDesc": "저장된 원본이 없는 자산입니다."
   },
   "commandPalette": {
     "title": "커맨드 팔레트",

--- a/apps/web/src/components/storage/storage-detail-panel.tsx
+++ b/apps/web/src/components/storage/storage-detail-panel.tsx
@@ -12,6 +12,7 @@ import { EmptyState } from '@/components/ui/empty-state';
 import { StorageUploaderAvatar } from './storage-uploader-avatar';
 import { StorageSourceUsageList } from './storage-source-usage-list';
 import { StorageFileGlyph } from './storage-file-glyph';
+import { StorageThumbnail } from './storage-thumbnail';
 import type { Asset } from '@/lib/storage/types';
 
 interface StorageDetailPanelProps {
@@ -46,30 +47,35 @@ export function StorageDetailPanel({ asset, folderLabel, onDownload, onRequestDe
 
   const ext = fileExtLabel(asset.content_type, asset.name);
   const usageCount = asset.source_links.length;
+  const isImage = asset.content_type.startsWith('image/');
 
   return (
     <section className="flex h-full min-h-0 flex-col border-l border-border bg-card">
       {/* preview */}
-      <div className="relative grid h-[168px] shrink-0 place-items-center border-b border-border bg-gradient-to-br from-info/10 to-brand/[0.06]">
+      <div className="relative grid h-[168px] shrink-0 place-items-center overflow-hidden border-b border-border bg-gradient-to-br from-info/10 to-brand/[0.06]">
+        {isImage ? (
+          <StorageThumbnail key={asset.id} asset={asset} />
+        ) : (
+          <div
+            className="grid size-[96px] w-[128px] place-items-center rounded-[0.5rem] text-info shadow-lg"
+            style={{
+              backgroundImage:
+                'repeating-linear-gradient(45deg, var(--info-tint), var(--info-tint) 9px, transparent 9px, transparent 18px)',
+            }}
+          >
+            <StorageFileGlyph icon={getFileIcon(asset.content_type)} className="size-[30px]" />
+          </div>
+        )}
         {onClose ? (
           <button
             type="button"
             onClick={onClose}
             aria-label={t('cancel')}
-            className="absolute right-2 top-2 grid size-7 place-items-center rounded-md text-muted-foreground hover:bg-muted"
+            className="absolute right-2 top-2 z-10 grid size-7 place-items-center rounded-md bg-card/70 text-muted-foreground backdrop-blur-sm hover:bg-muted"
           >
             <X className="size-4" />
           </button>
         ) : null}
-        <div
-          className="grid size-[96px] w-[128px] place-items-center rounded-[0.5rem] text-info shadow-lg"
-          style={{
-            backgroundImage:
-              'repeating-linear-gradient(45deg, var(--info-tint), var(--info-tint) 9px, transparent 9px, transparent 18px)',
-          }}
-        >
-          <StorageFileGlyph icon={getFileIcon(asset.content_type)} className="size-[30px]" />
-        </div>
       </div>
 
       {/* dhead */}

--- a/apps/web/src/components/storage/storage-thumbnail.privacy.test.ts
+++ b/apps/web/src/components/storage/storage-thumbnail.privacy.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { selectSignPlan } from './storage-thumbnail';
+import type { Asset, AssetSourceLink } from '@/lib/storage/types';
+
+// #1769 codex 프라이버시 crux: selectSignPlan 우선순위 모순(story→doc→conv) → doc+conv mixed 자산이
+// doc step 에서 project-scoped asset_id 로 즉시 매칭 → conv 우회. fix=conv 최우선 재정렬.
+// 이 테스트가 INVARIANT("conv-sourced 자산은 절대 asset_id 로 서명 안 됨")를 잠근다.
+
+function asset(links: AssetSourceLink[], objectPath = 'org/o/project/p/x/u-f.png'): Asset {
+  return {
+    id: 'ASSET-1',
+    org_id: 'o',
+    project_id: 'p',
+    folder_id: null,
+    container: 'c',
+    object_path: objectPath,
+    name: 'f.png',
+    content_type: 'image/png',
+    size_bytes: 10,
+    created_at: '',
+    updated_at: '',
+    created_by: null,
+    source_links: links,
+  };
+}
+const conv = (id = 'CONV-1'): AssetSourceLink => ({ type: 'conversation_message', id, deeplink: { conversation_id: id } } as AssetSourceLink);
+const story = (id = 'STORY-1'): AssetSourceLink => ({ type: 'story', id, deeplink: { story_id: id } } as AssetSourceLink);
+const doc = (): AssetSourceLink => ({ type: 'doc', id: 'DOC-1', deeplink: { doc_slug: 'd' } } as AssetSourceLink);
+const manual = (): AssetSourceLink => ({ type: 'manual', id: 'M-1', deeplink: null } as AssetSourceLink);
+
+describe('selectSignPlan · 프라이버시 우선순위 (S4 #1769)', () => {
+  it('conv only → conv sign (path + conversation_id)', () => {
+    expect(selectSignPlan(asset([conv()]))).toEqual({ kind: 'path', param: 'conversation_id', id: 'CONV-1' });
+  });
+
+  it('🔒 doc+conv → conv sign (절대 asset_id 아님) — codex crux', () => {
+    expect(selectSignPlan(asset([doc(), conv()]))).toEqual({ kind: 'path', param: 'conversation_id', id: 'CONV-1' });
+    // 순서 무관하게 conv 최우선
+    expect(selectSignPlan(asset([conv(), doc()]))).toEqual({ kind: 'path', param: 'conversation_id', id: 'CONV-1' });
+  });
+
+  it('🔒 story+conv → conv sign (story path 가능해도 conv 우선)', () => {
+    expect(selectSignPlan(asset([story(), conv()]))).toEqual({ kind: 'path', param: 'conversation_id', id: 'CONV-1' });
+  });
+
+  it('🔒 conv 인데 conversation_id 없음 → phantom(null), 절대 asset_id 폴백 안 함', () => {
+    const noConvId = { type: 'conversation_message', id: 'c', deeplink: {} } as AssetSourceLink;
+    expect(selectSignPlan(asset([noConvId, manual()]))).toBeNull();
+    // object_path 없는 conv 도 phantom(asset_id 폴백 금지)
+    expect(selectSignPlan(asset([conv()], ''))).toBeNull();
+  });
+
+  it('story only → story sign (path + story_id)', () => {
+    expect(selectSignPlan(asset([story()]))).toEqual({ kind: 'path', param: 'story_id', id: 'STORY-1' });
+  });
+
+  it('doc only → asset_id', () => {
+    expect(selectSignPlan(asset([doc()]))).toEqual({ kind: 'asset' });
+  });
+
+  it('manual only → asset_id', () => {
+    expect(selectSignPlan(asset([manual()]))).toEqual({ kind: 'asset' });
+  });
+
+  it('source 없음 → phantom(null)', () => {
+    expect(selectSignPlan(asset([]))).toBeNull();
+  });
+});

--- a/apps/web/src/components/storage/storage-thumbnail.tsx
+++ b/apps/web/src/components/storage/storage-thumbnail.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { ImageOff, Loader2, Lock } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { Skeleton } from '@/components/ui/skeleton';
+import type { Asset, AssetDeeplink } from '@/lib/storage/types';
+
+/**
+ * 39724bef — Storage 상세 패널 미리보기 썸네일.
+ * 글리프만 그리던 preview header를 이미지 자산에 한해 실 썸네일(signed read)로 렌더한다.
+ *
+ * 프라이버시 crux: source_links 별로 sign 파라미터를 정확히 골라(=메시지뷰서 못 보면 썸네일도
+ * 못 본다) 대화(DM) 첨부가 프로젝트-스코프 asset_id 경로로 노출되지 않게 한다.
+ * - 단일 sign 시도만. 403/실패 시 다른 sign 파라미터로 fallback 금지(누출 0).
+ * - sign 403 = no-access placeholder · sign ok + img onError = phantom(GCS 객체 부재).
+ *
+ * 상태:
+ * - loading: skeleton shimmer + spinner
+ * - ok: <img> object-cover 채움
+ * - no-access: Lock placeholder (403 / network / non-ok — 콘텐츠 누출 0)
+ * - phantom: ImageOff placeholder (usable source 없음 / sign ok 했지만 원본 부재)
+ *
+ * 마운트는 부모가 key={asset.id} 로 강제 → 인스턴스 내 asset 은 불변(effect 단순화).
+ */
+
+type State = 'loading' | 'ok' | 'no-access' | 'phantom';
+
+/**
+ * 단일 source-appropriate sign 계획.
+ * - path: path={object_path} + (story_id|conversation_id) (리소스 authorize)
+ * - asset: asset_id (project-scoped: doc·manual)
+ * - null: 사용 가능한 source 없음 → phantom (sign 시도 자체 안 함)
+ */
+type SignPlan =
+  | { kind: 'path'; param: 'story_id' | 'conversation_id'; id: string }
+  | { kind: 'asset' }
+  | null;
+
+/** deeplink 객체에서 키 추출(string 값일 때만). 형상이 string|object|null 다양 → 보수적. */
+function deeplinkValue(deeplink: AssetDeeplink, key: string): string | null {
+  if (deeplink && typeof deeplink === 'object' && key in deeplink) {
+    const v = (deeplink as Record<string, unknown>)[key];
+    return typeof v === 'string' && v.length > 0 ? v : null;
+  }
+  return null;
+}
+
+/**
+ * source 선택 — "accessible 우선 + privacy-safe" 우선순위(정확히 하나):
+ *   1. story  → path + story_id        (project authorize)
+ *   2. doc    → asset_id               (project-scoped; doc 는 참여자 모델 없음)
+ *   3. conversation_message → path + conversation_id (참여자 authorize) ← manual BEFORE
+ *   4. manual → asset_id               (project-scoped)
+ *   5. 없음   → null (phantom)
+ *
+ * conv 가 manual(asset_id) 보다 먼저 검사된다 → conv-sourced 자산은 절대 project-scoped
+ * asset_id 로 서명되지 않는다(DM 누출 차단). conv source 인데 path 인자를 못 만들면 manual 로
+ * 내려가지 않고 phantom 반환(asset_id fallback 금지).
+ */
+function selectSignPlan(asset: Asset): SignPlan {
+  const links = asset.source_links;
+  const hasPath = typeof asset.object_path === 'string' && asset.object_path.length > 0;
+
+  // 1. story (path-based)
+  const story = links.find((l) => l.type === 'story');
+  if (story) {
+    const storyId = deeplinkValue(story.deeplink, 'story_id');
+    if (hasPath && storyId) return { kind: 'path', param: 'story_id', id: storyId };
+  }
+
+  // 2. doc (project-scoped asset_id)
+  if (links.some((l) => l.type === 'doc')) return { kind: 'asset' };
+
+  // 3. conversation_message (path-based) — manual 보다 먼저
+  const conv = links.find((l) => l.type === 'conversation_message');
+  if (conv) {
+    const conversationId = deeplinkValue(conv.deeplink, 'conversation_id');
+    if (hasPath && conversationId) return { kind: 'path', param: 'conversation_id', id: conversationId };
+    // conv source 지만 path 인자 못 만듦 → asset_id 로 절대 내려가지 않는다(누출 차단). phantom.
+    return null;
+  }
+
+  // 4. manual (project-scoped asset_id)
+  if (links.some((l) => l.type === 'manual')) return { kind: 'asset' };
+
+  // 5. 사용 가능한 source 없음
+  return null;
+}
+
+interface StorageThumbnailProps {
+  asset: Asset;
+}
+
+export function StorageThumbnail({ asset }: StorageThumbnailProps) {
+  const t = useTranslations('storage');
+  const plan = useMemo(() => selectSignPlan(asset), [asset]);
+  const [state, setState] = useState<State>(() => (plan ? 'loading' : 'phantom'));
+  const [signedUrl, setSignedUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!plan) return; // phantom — sign 시도 없음(초기 state 가 이미 phantom).
+    let cancelled = false;
+
+    // 외부 시스템(서명 라우트) 단일 fetch. 모든 setState 는 await 이후 → 동기 cascade 아님.
+    void (async () => {
+      try {
+        const params = new URLSearchParams();
+        if (plan.kind === 'asset') {
+          params.set('asset_id', asset.id);
+        } else {
+          // URLSearchParams.toString() 이 path 를 인코딩(=encodeURIComponent 등가).
+          params.set('path', asset.object_path);
+          params.set(plan.param, plan.id);
+        }
+        const res = await fetch(`/api/attachments/sign?${params.toString()}`);
+        if (cancelled) return;
+        // 403 = 권한 거부 → no-access. 다른 sign 인자로 fallback 절대 금지(단일 시도).
+        if (res.status === 403) {
+          setState('no-access');
+          return;
+        }
+        // network/other non-ok = graceful no-access(콘텐츠 누출 0).
+        if (!res.ok) {
+          setState('no-access');
+          return;
+        }
+        const json = (await res.json()) as { data?: { url?: string } };
+        if (cancelled) return;
+        const url = json.data?.url;
+        if (!url) {
+          setState('no-access');
+          return;
+        }
+        setSignedUrl(url);
+        setState('ok');
+      } catch {
+        if (!cancelled) setState('no-access');
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [plan, asset.id, asset.object_path]);
+
+  if (state === 'loading') {
+    return (
+      <div className="absolute inset-0">
+        <Skeleton className="absolute inset-0 rounded-none" />
+        <div className="absolute inset-0 grid place-items-center">
+          <Loader2 className="size-5 animate-spin text-info" aria-label={t('previewLoading')} />
+        </div>
+      </div>
+    );
+  }
+
+  if (state === 'no-access') {
+    return (
+      <div className="absolute inset-0 flex flex-col items-center justify-center gap-1.5 bg-muted px-4 text-center text-muted-foreground">
+        <Lock className="size-6" aria-hidden />
+        <span className="text-[11px] font-medium">{t('previewNoAccessTitle')}</span>
+        <span className="text-[10px]">{t('previewNoAccessDesc')}</span>
+      </div>
+    );
+  }
+
+  if (state === 'phantom' || !signedUrl) {
+    return (
+      <div className="absolute inset-0 flex flex-col items-center justify-center gap-1.5 bg-muted px-4 text-center text-muted-foreground">
+        <ImageOff className="size-6" aria-hidden />
+        <span className="text-[11px] font-medium">{t('previewPhantomTitle')}</span>
+        <span className="text-[10px]">{t('previewPhantomDesc')}</span>
+      </div>
+    );
+  }
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={signedUrl}
+      alt={asset.name}
+      // sign ok 했지만 GCS 객체 부재 → onError = phantom(403 no-access 와 구분).
+      onError={() => setState('phantom')}
+      className="absolute inset-0 h-full w-full object-cover"
+    />
+  );
+}

--- a/apps/web/src/components/storage/storage-thumbnail.tsx
+++ b/apps/web/src/components/storage/storage-thumbnail.tsx
@@ -47,32 +47,24 @@ function deeplinkValue(deeplink: AssetDeeplink, key: string): string | null {
 }
 
 /**
- * source 선택 — "accessible 우선 + privacy-safe" 우선순위(정확히 하나):
- *   1. story  → path + story_id        (project authorize)
- *   2. doc    → asset_id               (project-scoped; doc 는 참여자 모델 없음)
- *   3. conversation_message → path + conversation_id (참여자 authorize) ← manual BEFORE
+ * source 선택 — privacy-invariant 우선 우선순위(정확히 하나):
+ *   1. conversation_message → path + conversation_id (참여자 authorize) · 못 만들면 phantom ← 최우선
+ *   2. story  → path + story_id        (project authorize)
+ *   3. doc    → asset_id               (project-scoped)
  *   4. manual → asset_id               (project-scoped)
  *   5. 없음   → null (phantom)
  *
- * conv 가 manual(asset_id) 보다 먼저 검사된다 → conv-sourced 자산은 절대 project-scoped
- * asset_id 로 서명되지 않는다(DM 누출 차단). conv source 인데 path 인자를 못 만들면 manual 로
- * 내려가지 않고 phantom 반환(asset_id fallback 금지).
+ * 🔒 INVARIANT: conv-sourced 자산은 절대 project-scoped asset_id 로 서명되지 않는다(DM 누출 차단).
+ * conv 를 **최우선** 검사 — doc/story/manual 이 함께 있어도 conv 가 있으면 conv sign(참여자 authorize).
+ * doc asset_id 는 path 체크가 없어(project-scoped) doc+conv mixed 자산이 doc 먼저 매칭되면 우회됨
+ * → conv 를 step1 로 둬 차단(#1769 codex crux). conv 인데 path 인자를 못 만들면 phantom 반환
+ * (asset_id fallback 절대 금지).
  */
-function selectSignPlan(asset: Asset): SignPlan {
+export function selectSignPlan(asset: Asset): SignPlan {
   const links = asset.source_links;
   const hasPath = typeof asset.object_path === 'string' && asset.object_path.length > 0;
 
-  // 1. story (path-based)
-  const story = links.find((l) => l.type === 'story');
-  if (story) {
-    const storyId = deeplinkValue(story.deeplink, 'story_id');
-    if (hasPath && storyId) return { kind: 'path', param: 'story_id', id: storyId };
-  }
-
-  // 2. doc (project-scoped asset_id)
-  if (links.some((l) => l.type === 'doc')) return { kind: 'asset' };
-
-  // 3. conversation_message (path-based) — manual 보다 먼저
+  // 1. conversation_message (path-based) — 최우선. conv 있으면 무조건 conv sign 또는 phantom.
   const conv = links.find((l) => l.type === 'conversation_message');
   if (conv) {
     const conversationId = deeplinkValue(conv.deeplink, 'conversation_id');
@@ -80,6 +72,16 @@ function selectSignPlan(asset: Asset): SignPlan {
     // conv source 지만 path 인자 못 만듦 → asset_id 로 절대 내려가지 않는다(누출 차단). phantom.
     return null;
   }
+
+  // 2. story (path-based)
+  const story = links.find((l) => l.type === 'story');
+  if (story) {
+    const storyId = deeplinkValue(story.deeplink, 'story_id');
+    if (hasPath && storyId) return { kind: 'path', param: 'story_id', id: storyId };
+  }
+
+  // 3. doc (project-scoped asset_id)
+  if (links.some((l) => l.type === 'doc')) return { kind: 'asset' };
 
   // 4. manual (project-scoped asset_id)
   if (links.some((l) => l.type === 'manual')) return { kind: 'asset' };


### PR DESCRIPTION
## 개요
아버님 "사진 엑박" 후속 — 스토리지 상세 패널 preview가 이미지도 글리프만 그리던 걸 **실 이미지 썸네일(signed read)**로. FE-only(sign 분기=기존 BE route·디디 의존0). story `39724bef`. 핸드오프 `storage-thumbnail-handoff`·시각 SSOT `storage-thumbnail-mockup-html`.

## 🔒 프라이버시 (까심 cross-model 게이트·우회 0)
"메시지뷰서 못 보는 첨부는 썸네일도 안 보인다." source_links 별로 sign 파라미터를 **정확히 하나** 골라 대화(DM) 첨부가 프로젝트-스코프 `asset_id`로 노출되지 않게.
- **selectSignPlan 우선순위**: ①story=`path+story_id` ②doc=`asset_id` ③conversation_message=`path+conv_id` ④manual=`asset_id` ⑤없음=phantom.
- **conv를 manual보다 먼저 검사** → conv-sourced 자산은 절대 project-scoped `asset_id`로 서명 안 됨. conv source인데 path 인자 못 만들면 **phantom 반환(asset_id fallback 금지)** = DM 누출 차단.
- **단일 sign 시도** — 403/non-ok = `no-access` placeholder(콘텐츠 누출0)·**다른 param fallback 절대 금지**.
- sign ok + `<img onError>` = `phantom`(GCS 객체 부재·403과 구분).

## 5상태 (mockup SSOT)
①로딩(skeleton shimmer+spinner) ②성공(`<img>` object-cover) ③no-access(Lock·"미리보기 권한이 없습니다·대화 참여자만") ④phantom(ImageOff·"미리보기 없음") ⑤비이미지(기존 글리프 유지).

## 범위
- 상세 패널(zoneC) preview 헤더만. **list/grid 행=글리프 유지**(행별 source-sign N요청·프라이버시 per-row 회피·grid 썸네일=후속 옵션). 클릭 원본/lightbox=후속.
- 토큰 canonical(하드코딩 0)·lucide·양테마. GET /api/assets/{id} 별도 fetch 불요(list가 Asset 전량: object_path+source_links).

## 검증
- `pnpm build` 그린. **dev 픽셀(머지 後)**: 실 image.png 썸네일 렌더 + 비참여 대화첨부=placeholder(content 0)·양테마.

유나 가디언 정적(mockup 1:1·토큰) → 까심 cross-model(프라이버시 우회0·403→placeholder·fallback sign 0) → 머지 → dev 픽셀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)