### PR TITLE
[SID:c1947a32] S4 핫픽스 — file-node asset-ref 직렬화 fix (파일 첨부 유실·dev 픽셀 적출)

### DIFF
--- a/apps/web/src/components/docs/extensions/attachment-upload.roundtrip.test.ts
+++ b/apps/web/src/components/docs/extensions/attachment-upload.roundtrip.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Editor } from '@tiptap/core';
+import Document from '@tiptap/extension-document';
+import Paragraph from '@tiptap/extension-paragraph';
+import Text from '@tiptap/extension-text';
+import { FileAttachmentNode } from './file-node';
+import { CustomImageNode } from './image-node';
+import { ImageUploadExtension, registerDocIdProvider, startAttachmentUpload } from './image-upload';
+
+// S4 끝단 적출(dev 픽셀): 파일 첨부가 upload200+register200(asset_id 반환)인데도 노드가
+// data-asset-id 없이(data-file-data="") 직렬화 → read-only/reload 서 inert·라운드트립 유실.
+// 근본: file-node 의 assetId attr 에 attr-level renderHTML 이 있어 HTMLAttributes.assetId 가
+// data-asset-id 로 미리 매핑됨 → 노드 renderHTML 의 assetId=undefined → 항상 data-file-data.
+// 이 테스트가 "노드 assetId → getHTML data-asset-id" 계약을 잠근다(이미지 control 포함).
+beforeEach(() => {
+  global.fetch = vi.fn(async (url: string) => {
+    const u = String(url);
+    if (u.includes('/attachments')) {
+      return { ok: true, status: 200, json: async () => ({ url: 'https://gcs/doc/f.bin', name: 'f.bin', content_type: 'application/octet-stream', size: 12 }) } as Response;
+    }
+    if (u.includes('/assets')) {
+      // BE 실 응답 형상 — snake `data.asset_id`.
+      return { ok: true, status: 200, json: async () => ({ data: { asset_id: 'AID-1', filename: 'f.bin', size: 12, mime: 'application/octet-stream' }, error: null, meta: null }) } as Response;
+    }
+    return { ok: false, status: 404, json: async () => ({}) } as Response;
+  }) as unknown as typeof fetch;
+});
+
+function makeEditor() {
+  return new Editor({
+    extensions: [Document, Paragraph, Text, CustomImageNode, FileAttachmentNode, ImageUploadExtension],
+    content: '<p></p>',
+  });
+}
+
+async function flush() {
+  await Promise.resolve(); await Promise.resolve(); await Promise.resolve();
+}
+
+describe('attachment upload → asset-ref 직렬화 라운드트립 (S4)', () => {
+  it('파일 업로드: 노드 assetId 설정 + getHTML 이 data-asset-id 직렬화(data-file-data 아님)', async () => {
+    const editor = makeEditor();
+    registerDocIdProvider(editor, () => 'DOC-1');
+    await startAttachmentUpload(editor, new File(['hello world!'], 'f.bin', { type: 'application/octet-stream' }));
+    await flush();
+
+    const html = editor.getHTML();
+    expect(html).toContain('data-type="fileAttachment"');
+    expect(html).toContain('data-asset-id="AID-1"');
+    expect(html).not.toContain('data-file-data'); // ref 면 legacy attr 부재(상호배타).
+    editor.destroy();
+  });
+
+  it('이미지 업로드(control): getHTML 이 data-asset-id 직렬화(src 부재)', async () => {
+    const editor = makeEditor();
+    registerDocIdProvider(editor, () => 'DOC-1');
+    // 1x1 PNG (압축 분기 회피 위해 <1MB)
+    const png = Uint8Array.from(atob('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='), (c) => c.charCodeAt(0));
+    await startAttachmentUpload(editor, new File([png], 'a.png', { type: 'image/png' }));
+    await flush();
+
+    const html = editor.getHTML();
+    expect(html).toContain('data-asset-id="AID-1"');
+    expect(html).not.toMatch(/<img[^>]*\ssrc=/); // ref 이미지는 src 미직렬화.
+    editor.destroy();
+  });
+});

--- a/apps/web/src/components/docs/extensions/file-node.tsx
+++ b/apps/web/src/components/docs/extensions/file-node.tsx
@@ -201,11 +201,13 @@ export const FileAttachmentNode = Node.create({
         parseHTML: (el) => (el as HTMLElement).getAttribute('data-file-data') ?? '',
       },
       // ref(assetId) — data-asset-id 라운드트립.
+      // ⚠️ attr-level renderHTML 두지 않는다: 노드 renderHTML 이 HTMLAttributes.assetId 를 읽어
+      // data-asset-id ↔ data-file-data 상호배타로 직렬화하기 때문. attr renderHTML 을 두면 assetId 가
+      // HTMLAttributes 에서 data-asset-id 로 미리 매핑돼 노드 renderHTML 의 assetId 가 undefined →
+      // 항상 data-file-data 로 직렬화되는 버그(파일 asset-ref 유실·dev 끝단 적출).
       assetId: {
         default: null,
         parseHTML: (el) => (el as HTMLElement).getAttribute('data-asset-id'),
-        renderHTML: (attributes: Record<string, unknown>) =>
-          attributes['assetId'] ? { 'data-asset-id': String(attributes['assetId']) } : {},
       },
       // transient(직렬화 X).
       uploadId: { default: null, rendered: false },


### PR DESCRIPTION
## 개요
S4 doc-attach **dev 재픽셀 끝단서 적출**. 파일 첨부가 `attachments` 200 + `register` 200(`asset_id` 반환)이고 노드 attrs에 `assetId`도 정상 설정되는데, **`getHTML`이 `data-file-data=""`(data-asset-id 아님)로 직렬화** → read-only 뷰/에디터 reload서 파일 카드가 **inert**(다운로드 no-op)·마크다운 라운드트립서 유실. (이미지 asset-ref는 정상 작동이라 더 은밀.)

## 근본
`file-node.tsx` 의 `assetId` attr 에 **attr-level `renderHTML`**(`assetId → data-asset-id`)이 있어, 노드 `renderHTML({ HTMLAttributes })` 시점엔 `HTMLAttributes` 가 이미 `data-asset-id` 로 매핑돼 있고 **`HTMLAttributes.assetId` 는 undefined**. 노드 renderHTML 의 구조분해 `assetId` 가 undefined → `assetId ? data-asset-id : data-file-data` 삼항이 **항상 else(data-file-data)** → asset-ref 유실. `image-node` 는 `node.attrs.assetId` 를 직접 읽어 무영향(그래서 이미지만 정상이었음).

## fix
`assetId` attr 의 attr-level `renderHTML` 제거(`parseHTML` 유지). → `HTMLAttributes.assetId` 가 raw 값으로 도달 → 노드 renderHTML 의 `data-asset-id ↔ data-file-data` 상호배타 직렬화 정상화. (raw `assetId` 는 노드 renderHTML 이 explicit 객체를 빌드하며 spread 안 하므로 DOM 누출 0.)

## 검증
- **회귀테스트**(`attachment-upload.roundtrip.test.ts`): 실 tiptap Editor + mock fetch(register snake `{data:{asset_id}}`) → `startAttachmentUpload`(파일) → `getHTML` 에 `data-asset-id` 잠금 + `data-file-data` 부재 assert(+이미지 control: src 미직렬화). **2/2**.
- `pnpm build` 그린.
- **머지→재배포 後 재픽셀**: 파일 카드 다운로드(sign `asset_id`→새탭)·read-only 뷰 라운드트립 보존 박제 예정.

dev 끝단 검증이 attrs-set 뒤의 renderHTML 매핑 충돌을 적출 — 노드 attrs만 보면 정상이라 단위/정적분석 사각.

🤖 Generated with [Claude Code](https://claude.com/claude-code)