### PR TITLE
[SID:53bc0945] 출시노트 de-hardcode — release_notes 모델/API + FE 데이터주도

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
           JWT_SECRET: ci-test-secret-at-least-32-chars-long
           SECRET_KEY: ci-test-secret-at-least-32-chars-long
-        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py -q
+        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py tests/test_release_notes_realdb.py -q
 
       - name: Verify fresh DB reached head (baseline + incremental)
         working-directory: backend

--- a/apps/web/src/app/api/release-notes/route.ts
+++ b/apps/web/src/app/api/release-notes/route.ts
@@ -1,0 +1,11 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// 릴리즈 노트 조회(de-hardcode·story 53bc0945) — BE `GET /api/v2/release-notes`(published·newest-first).
+// CRUD(owner/admin)는 v1 범위 밖(시드/관리 API 직접)·후속 admin UI 때 프록시 추가.
+export async function GET(request: Request) {
+  const _r = await proxyToFastapi(request, '/api/v2/release-notes');
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess([]);
+  return apiSuccess(await _r.json());
+}

--- a/apps/web/src/components/release-notes/release-notes-dialog.tsx
+++ b/apps/web/src/components/release-notes/release-notes-dialog.tsx
@@ -12,20 +12,21 @@ import {
 } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { RELEASE_NOTES, type ReleaseNote } from '@/lib/release-notes';
+import { type ReleaseNote } from '@/lib/release-notes';
 
 interface ReleaseNotesDialogProps {
   open: boolean;
   onClose: () => void;
+  notes: ReleaseNote[];
 }
 
-export function ReleaseNotesDialog({ open, onClose }: ReleaseNotesDialogProps) {
+export function ReleaseNotesDialog({ open, onClose, notes }: ReleaseNotesDialogProps) {
   const [view, setView] = useState<'latest' | 'list'>('latest');
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
   const note: ReleaseNote | undefined = selectedId
-    ? RELEASE_NOTES.find((n) => n.id === selectedId)
-    : RELEASE_NOTES[0];
+    ? notes.find((n) => n.id === selectedId)
+    : notes[0];
 
   const reset = () => {
     setView('latest');
@@ -42,7 +43,25 @@ export function ReleaseNotesDialog({ open, onClose }: ReleaseNotesDialogProps) {
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-md rounded-xl">
-        {view === 'latest' && note ? (
+        {notes.length === 0 ? (
+          <>
+            <DialogHeader className="space-y-2">
+              <span className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-info">
+                <Sparkles className="h-3.5 w-3.5" aria-hidden />
+                What&apos;s new
+              </span>
+              <DialogTitle className="text-base">릴리즈 노트</DialogTitle>
+              <DialogDescription className="text-sm text-muted-foreground">
+                아직 새로운 소식이 없어요. 업데이트가 준비되면 여기에서 알려드릴게요.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button variant="hero" size="sm" onClick={() => handleOpenChange(false)}>
+                확인
+              </Button>
+            </DialogFooter>
+          </>
+        ) : view === 'latest' && note ? (
           <>
             <DialogHeader className="space-y-2">
               <span className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-info">
@@ -101,7 +120,7 @@ export function ReleaseNotesDialog({ open, onClose }: ReleaseNotesDialogProps) {
               <DialogDescription className="sr-only">이전 릴리즈 노트 목록</DialogDescription>
             </DialogHeader>
             <ul className="divide-y divide-border overflow-hidden rounded-md border border-border">
-              {RELEASE_NOTES.map((n) => (
+              {notes.map((n) => (
                 <li key={n.id}>
                   <button
                     type="button"

--- a/apps/web/src/components/release-notes/release-notes-gate.tsx
+++ b/apps/web/src/components/release-notes/release-notes-gate.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
-import { LATEST_RELEASE_NOTE_ID } from '@/lib/release-notes';
+import { fetchReleaseNotes, type ReleaseNote } from '@/lib/release-notes';
 import { ReleaseNotesDialog } from './release-notes-dialog';
 
 interface ReleaseNotesContextValue {
@@ -29,30 +29,44 @@ export function ReleaseNotesProvider({ userId, children }: ReleaseNotesProviderP
   const [open, setOpen] = useState(false);
   const [seenId, setSeenId] = useState<string | null>(null);
   const [ready, setReady] = useState(false);
+  const [notes, setNotes] = useState<ReleaseNote[]>([]);
 
-  // mount 後 localStorage 읽기 (SSR hydration 불일치 방지). 미열람 최신 노트면 auto-open.
+  // de-hardcode(53bc0945): 노트는 API 에서 로드. 최신 노트 id = notes[0]?.id (서버 newest-first).
+  const latestId = notes[0]?.id ?? null;
+
+  // mount 後 노트 fetch + localStorage 읽기(SSR hydration 불일치 방지). 미열람 최신 노트면 auto-open.
   useEffect(() => {
     if (!userId) return;
-    try {
-      const seen = localStorage.getItem(seenKey(userId));
-      setSeenId(seen);
-      if (LATEST_RELEASE_NOTE_ID && seen !== LATEST_RELEASE_NOTE_ID) setOpen(true);
-    } catch {
-      // localStorage 차단 환경 — gate 무동작
-    } finally {
-      setReady(true);
-    }
+    let cancelled = false;
+    void (async () => {
+      const fetched = await fetchReleaseNotes();
+      if (cancelled) return;
+      setNotes(fetched);
+      try {
+        const seen = localStorage.getItem(seenKey(userId));
+        setSeenId(seen);
+        const latest = fetched[0]?.id ?? null;
+        if (latest && seen !== latest) setOpen(true);
+      } catch {
+        // localStorage 차단 환경 — gate 무동작
+      } finally {
+        setReady(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, [userId]);
 
   const markSeen = useCallback(() => {
-    if (!userId || !LATEST_RELEASE_NOTE_ID) return;
+    if (!userId || !latestId) return;
     try {
-      localStorage.setItem(seenKey(userId), LATEST_RELEASE_NOTE_ID);
+      localStorage.setItem(seenKey(userId), latestId);
     } catch {
       // ignore
     }
-    setSeenId(LATEST_RELEASE_NOTE_ID);
-  }, [userId]);
+    setSeenId(latestId);
+  }, [userId, latestId]);
 
   const handleOpen = useCallback(() => setOpen(true), []);
   const handleClose = useCallback(() => {
@@ -60,7 +74,7 @@ export function ReleaseNotesProvider({ userId, children }: ReleaseNotesProviderP
     setOpen(false);
   }, [markSeen]);
 
-  const hasUnseen = ready && LATEST_RELEASE_NOTE_ID != null && seenId !== LATEST_RELEASE_NOTE_ID;
+  const hasUnseen = ready && latestId != null && seenId !== latestId;
 
   // userId 없으면 gate skip (셸은 인증 後라 보통 존재)
   if (!userId) return <>{children}</>;
@@ -68,7 +82,7 @@ export function ReleaseNotesProvider({ userId, children }: ReleaseNotesProviderP
   return (
     <ReleaseNotesContext.Provider value={{ open: handleOpen, hasUnseen }}>
       {children}
-      <ReleaseNotesDialog open={open} onClose={handleClose} />
+      <ReleaseNotesDialog open={open} onClose={handleClose} notes={notes} />
     </ReleaseNotesContext.Provider>
   );
 }

--- a/apps/web/src/lib/release-notes.ts
+++ b/apps/web/src/lib/release-notes.ts
@@ -6,7 +6,7 @@ export interface ReleaseNoteItem {
 export interface ReleaseNote {
   id: string;
   version: string;
-  /** 표시용 문자열 (정렬/비교는 배열 순서·id로) */
+  /** 표시용 문자열 (정렬/비교는 서버 published_at·id로) */
   publishedAt: string;
   title: string;
   summary: string;
@@ -14,44 +14,18 @@ export interface ReleaseNote {
 }
 
 /**
- * newest-first. ⚠️ 어느 릴리즈를 어떤 문구로 알릴지는 PO/product 콜 — 아래는 대표 시드(구조 검증용).
- * id = 가시성 비교 키(localStorage seen 과 대조). 실제 노트 추가/문구는 PO가 갱신.
+ * 릴리즈 노트는 BE(`release_notes` 테이블)에서 데이터주도로 제공된다(de-hardcode·story 53bc0945).
+ * `GET /api/release-notes` → newest-first published. id = 가시성 비교 키(localStorage seen 과 대조).
+ * 노트 추가/문구는 관리 CRUD(또는 시드)로 — 코드 편집/배포 불필요.
+ * 실패/빈 응답은 `[]` (호출부가 빈상태 graceful·gate auto-open 안 함).
  */
-export const RELEASE_NOTES: ReleaseNote[] = [
-  {
-    id: '2026-06-v1-4',
-    version: 'v1.4',
-    publishedAt: '2026년 6월',
-    title: '멀티계정 전환과 알림 도달 확인이 생겼어요',
-    summary: '로그아웃 없이 계정을 오가고, 알림이 실제로 도달했는지 한눈에 확인하세요.',
-    items: [
-      { text: '여러 계정을 추가해 로그아웃 없이 전환합니다.' },
-      { text: '알림 목적지를 한 화면에서 보고·끄고·실제 도달을 테스트합니다.' },
-      { text: '에이전트 추가를 모달 한 곳에서 끝냅니다.' },
-    ],
-  },
-  {
-    id: '2026-06-v1-3',
-    version: 'v1.3',
-    publishedAt: '2026년 6월',
-    title: '온보딩이 2분이면 끝나요',
-    summary: '설정 하나를 붙여넣고, 실제로 작동하는지 바로 확인합니다.',
-    items: [
-      { text: '에이전트 연결 설정을 한 번에 복사합니다.' },
-      { text: '연결 확인 레일로 실제 동작을 직접 검증합니다.' },
-    ],
-  },
-  {
-    id: '2026-05-v1-2',
-    version: 'v1.2',
-    publishedAt: '2026년 5월',
-    title: '보드가 더 부드러워졌어요',
-    summary: '칸반 보드 드래그와 모바일 사용성을 개선했습니다.',
-    items: [
-      { text: '카드 드래그·드롭 정확도를 높였습니다.' },
-      { text: '모바일에서 보드 스크롤이 매끄러워졌습니다.' },
-    ],
-  },
-];
-
-export const LATEST_RELEASE_NOTE_ID = RELEASE_NOTES[0]?.id ?? null;
+export async function fetchReleaseNotes(): Promise<ReleaseNote[]> {
+  try {
+    const res = await fetch('/api/release-notes', { credentials: 'same-origin' });
+    if (!res.ok) return [];
+    const body = (await res.json()) as { data?: ReleaseNote[] };
+    return Array.isArray(body?.data) ? body.data : [];
+  } catch {
+    return [];
+  }
+}

--- a/backend/alembic/versions/0142_add_release_notes.py
+++ b/backend/alembic/versions/0142_add_release_notes.py
@@ -1,0 +1,109 @@
+"""E-POLISH 53bc0945: release_notes 테이블 — 하드코딩 RELEASE_NOTES de-hardcode + 시드.
+
+릴노트 제품 전역(org 무관) 글로벌 테이블. note_key = FE localStorage seen-key("2026-06-v1-4")·무회귀.
+시드 = 기존 v1.2~v1.4(release-notes.ts const 무손실 이관) + v1.5 스토리지 노트(파일첨부·썸네일) 추가.
+
+idempotent: 테이블 inspect 가드(시드는 create 직후만). downgrade = drop.
+"""
+from __future__ import annotations
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision = "0142"
+down_revision = "0141"
+branch_labels = None
+depends_on = None
+
+
+_SEED = [
+    {
+        "note_key": "2026-05-v1-2", "version": "v1.2",
+        "published_at": "2026-05-15 00:00:00+00", "display_period": "2026년 5월",
+        "title": "보드가 더 부드러워졌어요",
+        "summary": "칸반 보드 드래그와 모바일 사용성을 개선했습니다.",
+        "items": [
+            {"text": "카드 드래그·드롭 정확도를 높였습니다."},
+            {"text": "모바일에서 보드 스크롤이 매끄러워졌습니다."},
+        ],
+    },
+    {
+        "note_key": "2026-06-v1-3", "version": "v1.3",
+        "published_at": "2026-06-10 00:00:00+00", "display_period": "2026년 6월",
+        "title": "온보딩이 2분이면 끝나요",
+        "summary": "설정 하나를 붙여넣고, 실제로 작동하는지 바로 확인합니다.",
+        "items": [
+            {"text": "에이전트 연결 설정을 한 번에 복사합니다."},
+            {"text": "연결 확인 레일로 실제 동작을 직접 검증합니다."},
+        ],
+    },
+    {
+        "note_key": "2026-06-v1-4", "version": "v1.4",
+        "published_at": "2026-06-20 00:00:00+00", "display_period": "2026년 6월",
+        "title": "멀티계정 전환과 알림 도달 확인이 생겼어요",
+        "summary": "로그아웃 없이 계정을 오가고, 알림이 실제로 도달했는지 한눈에 확인하세요.",
+        "items": [
+            {"text": "여러 계정을 추가해 로그아웃 없이 전환합니다."},
+            {"text": "알림 목적지를 한 화면에서 보고·끄고·실제 도달을 테스트합니다."},
+            {"text": "에이전트 추가를 모달 한 곳에서 끝냅니다."},
+        ],
+    },
+    {
+        "note_key": "2026-06-v1-5", "version": "v1.5",
+        "published_at": "2026-06-26 00:00:00+00", "display_period": "2026년 6월",
+        "title": "파일 첨부와 미리보기가 생겼어요",
+        "summary": "문서에 파일과 이미지를 첨부하고, 스토리지에서 한곳에 모아 확인하세요.",
+        "items": [
+            {"text": "문서 본문에 파일과 이미지를 첨부합니다."},
+            {"text": "첨부한 파일을 스토리지에서 한눈에 관리합니다."},
+            {"text": "이미지 썸네일로 내용을 빠르게 확인합니다."},
+        ],
+    },
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    if "release_notes" in set(insp.get_table_names()):
+        return  # idempotent
+
+    op.create_table(
+        "release_notes",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text("gen_random_uuid()")),
+        sa.Column("note_key", sa.Text(), nullable=False),
+        sa.Column("version", sa.Text(), nullable=False),
+        sa.Column("published_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("display_period", sa.Text(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=False, server_default=""),
+        sa.Column("items", JSONB(), nullable=False, server_default=sa.text("'[]'::jsonb")),
+        sa.Column("is_published", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("now()")),
+    )
+    op.create_unique_constraint("uq_release_notes_note_key", "release_notes", ["note_key"])
+    op.create_index("ix_release_notes_published_at", "release_notes", ["published_at"])
+    op.create_index("ix_release_notes_is_published", "release_notes", ["is_published"])
+
+    # 시드(create 직후만·무손실 이관 + v1.5 추가). id/타임스탬프는 server_default.
+    ins = sa.text(
+        "INSERT INTO release_notes (note_key, version, published_at, display_period, title, summary, items) "
+        "VALUES (:note_key, :version, :published_at, :display_period, :title, :summary, CAST(:items AS jsonb))"
+    )
+    for n in _SEED:
+        op.execute(ins.bindparams(
+            note_key=n["note_key"], version=n["version"], published_at=n["published_at"],
+            display_period=n["display_period"], title=n["title"], summary=n["summary"],
+            items=json.dumps(n["items"], ensure_ascii=False),
+        ))
+
+
+def downgrade() -> None:
+    op.drop_table("release_notes")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -56,7 +56,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -147,6 +147,7 @@ app.include_router(events.router)
 app.include_router(agent_gateway.router)
 app.include_router(dispatch.router)
 app.include_router(assets.router)
+app.include_router(release_notes.router)
 app.include_router(conversations.router)
 app.include_router(presence.router)
 app.include_router(sprints.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -38,9 +38,11 @@ from app.models.project_access import ProjectAccess
 from app.models.member import AgentProjectProfile, Member, MemberIdentityAlias
 from app.models.activity_event import ActivityEvent
 from app.models.asset import Asset, AssetFolder, AssetLink
+from app.models.release_note import ReleaseNote
 
 __all__ = [
     "ActivityEvent",
+    "ReleaseNote",
     "Asset",
     "AssetFolder",
     "AssetLink",

--- a/backend/app/models/release_note.py
+++ b/backend/app/models/release_note.py
@@ -1,0 +1,44 @@
+"""릴리즈 노트 모델(E-POLISH 53bc0945·선생님 직접) — 하드코딩 RELEASE_NOTES 배열 de-hardcode.
+
+릴노트는 **제품 전역**(전 org 동일)이라 org_id 없는 글로벌 테이블. `note_key`(text unique)는 FE
+localStorage seen-key("2026-06-v1-4")와 동일 값 — 가시성 비교 무회귀 핵심. 정렬은 `published_at`
+(timestamp) desc = newest-first. `display_period`("2026년 6월")는 표시용. CRUD = org owner/admin
+(platform-admin 롤 부재·v1).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Text, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class ReleaseNote(Base, TimestampMixin):
+    """릴리즈 노트 1건(제품 전역·org 무관)."""
+
+    __tablename__ = "release_notes"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    # FE localStorage seen-key 와 동일 문자열("2026-06-v1-4") — 가시성 비교 무회귀. unique.
+    note_key: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    version: Mapped[str] = mapped_column(Text, nullable=False)
+    # 정렬 기준(newest-first). display_period 는 표시 전용(정렬 불가 "2026년 6월").
+    published_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
+    display_period: Mapped[str] = mapped_column(Text, nullable=False)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    summary: Mapped[str] = mapped_column(Text, nullable=False, server_default="", default="")
+    # [{text: str, href?: str}, ...]
+    items: Mapped[list] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb"), default=list
+    )
+    is_published: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("true"), default=True, index=True
+    )

--- a/backend/app/routers/release_notes.py
+++ b/backend/app/routers/release_notes.py
@@ -1,0 +1,161 @@
+"""릴리즈 노트 API(E-POLISH 53bc0945) — 하드코딩 RELEASE_NOTES de-hardcode.
+
+GET = published 노트(newest-first·전 org 공통·authed user). CRUD = org owner/admin(platform-admin 롤
+부재·v1). response 는 FE `ReleaseNote` shape 그대로(`note_key→id`·`display_period→publishedAt`) 매핑해
+dialog 무회귀. id(=note_key)는 FE localStorage seen-key 와 동일.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.models.release_note import ReleaseNote
+from app.services.project_auth import is_org_owner_or_admin
+
+router = APIRouter(prefix="/api/v2/release-notes", tags=["release-notes"])
+
+
+class ReleaseNoteItemModel(BaseModel):
+    text: str
+    href: str | None = None
+
+
+class ReleaseNoteResponse(BaseModel):
+    id: str  # = note_key (FE seen-key·가시성 비교)
+    version: str
+    publishedAt: str  # = display_period(표시 문자열)
+    title: str
+    summary: str
+    items: list[ReleaseNoteItemModel]
+
+
+class ReleaseNoteCreate(BaseModel):
+    note_key: str = Field(min_length=1)
+    version: str = Field(min_length=1)
+    published_at: datetime
+    display_period: str = Field(min_length=1)
+    title: str = Field(min_length=1)
+    summary: str = ""
+    items: list[ReleaseNoteItemModel] = Field(default_factory=list)
+    is_published: bool = True
+
+
+class ReleaseNoteUpdate(BaseModel):
+    version: str | None = None
+    published_at: datetime | None = None
+    display_period: str | None = None
+    title: str | None = None
+    summary: str | None = None
+    items: list[ReleaseNoteItemModel] | None = None
+    is_published: bool | None = None
+
+
+def _to_response(row: ReleaseNote) -> ReleaseNoteResponse:
+    return ReleaseNoteResponse(
+        id=row.note_key,
+        version=row.version,
+        publishedAt=row.display_period,
+        title=row.title,
+        summary=row.summary,
+        items=[ReleaseNoteItemModel(**i) if isinstance(i, dict) else i for i in (row.items or [])],
+    )
+
+
+async def _require_admin(session: AsyncSession, auth, org_id: uuid.UUID) -> None:
+    """CRUD = org owner/admin(canonical project_auth·ad-hoc role 금지). platform-admin 롤 부재로 유일 옵션."""
+    if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
+        raise HTTPException(status_code=403, detail="릴리즈 노트 관리는 org owner/admin 만 가능합니다.")
+
+
+@router.get("", response_model=list[ReleaseNoteResponse])
+async def list_release_notes(
+    session: AsyncSession = Depends(get_db),
+    _auth=Depends(get_current_user),
+) -> list[ReleaseNoteResponse]:
+    """published 릴노트 newest-first(published_at desc). 전역(org 무관)·authed user."""
+    rows = (
+        await session.execute(
+            select(ReleaseNote)
+            .where(ReleaseNote.is_published.is_(True))
+            .order_by(ReleaseNote.published_at.desc())
+        )
+    ).scalars().all()
+    return [_to_response(r) for r in rows]
+
+
+@router.post("", response_model=ReleaseNoteResponse, status_code=201)
+async def create_release_note(
+    body: ReleaseNoteCreate,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> ReleaseNoteResponse:
+    await _require_admin(session, auth, org_id)
+    dup = (await session.execute(
+        select(ReleaseNote.id).where(ReleaseNote.note_key == body.note_key)
+    )).scalar_one_or_none()
+    if dup is not None:
+        raise HTTPException(status_code=409, detail="같은 note_key 의 릴노트가 이미 있습니다.")
+    row = ReleaseNote(
+        note_key=body.note_key,
+        version=body.version,
+        published_at=body.published_at,
+        display_period=body.display_period,
+        title=body.title,
+        summary=body.summary,
+        items=[i.model_dump(exclude_none=True) for i in body.items],
+        is_published=body.is_published,
+    )
+    session.add(row)
+    await session.commit()
+    await session.refresh(row)
+    return _to_response(row)
+
+
+@router.patch("/{note_key}", response_model=ReleaseNoteResponse)
+async def update_release_note(
+    note_key: str,
+    body: ReleaseNoteUpdate,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> ReleaseNoteResponse:
+    await _require_admin(session, auth, org_id)
+    row = (await session.execute(
+        select(ReleaseNote).where(ReleaseNote.note_key == note_key)
+    )).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="릴노트를 찾을 수 없습니다.")
+    data = body.model_dump(exclude_unset=True)
+    if "items" in data and data["items"] is not None:
+        data["items"] = [i.model_dump(exclude_none=True) if hasattr(i, "model_dump")
+                         else i for i in body.items]
+    for k, v in data.items():
+        setattr(row, k, v)
+    await session.commit()
+    await session.refresh(row)
+    return _to_response(row)
+
+
+@router.delete("/{note_key}", status_code=204)
+async def delete_release_note(
+    note_key: str,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> None:
+    await _require_admin(session, auth, org_id)
+    row = (await session.execute(
+        select(ReleaseNote).where(ReleaseNote.note_key == note_key)
+    )).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="릴노트를 찾을 수 없습니다.")
+    await session.delete(row)
+    await session.commit()

--- a/backend/tests/test_release_notes_realdb.py
+++ b/backend/tests/test_release_notes_realdb.py
@@ -1,0 +1,115 @@
+"""E-POLISH 53bc0945: release_notes API + 시드 realdb. DB env 없으면 skip(CI alembic-fresh).
+
+마이그 0142 가 테이블+시드(v1.2~v1.5) 생성 → list 가 4개 published newest-first·shape(id=note_key·
+publishedAt=display_period) 반환. CRUD 는 owner/admin(is_org_owner_or_admin) 게이트.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth():
+    a = MagicMock()
+    a.user_id = str(uuid.uuid4())
+    return a
+
+
+@pytest.mark.anyio
+async def test_list_returns_seeded_newest_first():
+    from app.routers.release_notes import list_release_notes
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            out = await list_release_notes(session=s, _auth=_auth())
+            keys = [r.id for r in out]
+            # 시드 4개가 newest-first(v1.5→v1.2)로 선두에(다른 테스트가 추가했을 수 있어 포함 검사).
+            assert "2026-06-v1-5" in keys and "2026-05-v1-2" in keys
+            idx = {k: i for i, k in enumerate(keys)}
+            assert idx["2026-06-v1-5"] < idx["2026-06-v1-4"] < idx["2026-06-v1-3"] < idx["2026-05-v1-2"]
+            v15 = next(r for r in out if r.id == "2026-06-v1-5")
+            assert v15.version == "v1.5" and v15.publishedAt == "2026년 6월"  # display_period→publishedAt
+            assert v15.items and v15.items[0].text  # JSONB items 매핑
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_requires_owner_admin():
+    from app.routers.release_notes import ReleaseNoteCreate, create_release_note
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    key = f"test-{uuid.uuid4()}"
+    body = ReleaseNoteCreate(
+        note_key=key, version="vT", published_at="2026-07-01T00:00:00+00:00",
+        display_period="2026년 7월", title="T", summary="s", items=[{"text": "x"}],
+    )
+    try:
+        async with Session() as s:
+            # 비-admin → 403
+            with patch("app.routers.release_notes.is_org_owner_or_admin",
+                       new_callable=AsyncMock, return_value=False):
+                with pytest.raises(HTTPException) as e:
+                    await create_release_note(body=body, session=s, org_id=ORG, auth=_auth())
+                assert e.value.status_code == 403
+            # admin → 201 생성
+            with patch("app.routers.release_notes.is_org_owner_or_admin",
+                       new_callable=AsyncMock, return_value=True):
+                created = await create_release_note(body=body, session=s, org_id=ORG, auth=_auth())
+                assert created.id == key and created.version == "vT"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unpublished_excluded_and_patch_delete():
+    from app.routers.release_notes import (
+        ReleaseNoteCreate,
+        ReleaseNoteUpdate,
+        create_release_note,
+        delete_release_note,
+        list_release_notes,
+        update_release_note,
+    )
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    key = f"unpub-{uuid.uuid4()}"
+    try:
+        with patch("app.routers.release_notes.is_org_owner_or_admin",
+                   new_callable=AsyncMock, return_value=True):
+            async with Session() as s:
+                # 미발행 생성 → list 제외.
+                await create_release_note(
+                    body=ReleaseNoteCreate(
+                        note_key=key, version="vU", published_at="2026-08-01T00:00:00+00:00",
+                        display_period="2026년 8월", title="U", summary="", items=[], is_published=False),
+                    session=s, org_id=ORG, auth=_auth())
+                assert key not in [r.id for r in await list_release_notes(session=s, _auth=_auth())]
+                # patch 발행 → list 포함.
+                await update_release_note(note_key=key, body=ReleaseNoteUpdate(is_published=True),
+                                          session=s, org_id=ORG, auth=_auth())
+                assert key in [r.id for r in await list_release_notes(session=s, _auth=_auth())]
+                # delete.
+                await delete_release_note(note_key=key, session=s, org_id=ORG, auth=_auth())
+                assert key not in [r.id for r in await list_release_notes(session=s, _auth=_auth())]
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 출시노트 de-hardcode — 데이터주도화 (선생님 직접·E-POLISH 53bc0945)

하드코딩 `RELEASE_NOTES` TS 배열(노트마다 코드편집+배포 필요) 제거 → BE 모델/API 데이터주도.

### BE
- **`release_notes` 글로벌 테이블**(org_id 없음·제품 전역). `note_key`(text unique)=FE localStorage seen-key(`"2026-06-v1-4"`)·**무회귀 핵심**. `published_at`(정렬·newest-first)+`display_period`(표시)+`items`(JSONB)+`is_published`+timestamps.
- `GET /api/v2/release-notes`(published·newest-first·authed)·response가 `note_key→id`·`display_period→publishedAt` 매핑해 **FE shape 그대로**. CRUD(POST/PATCH/DELETE)=**owner/admin**(`is_org_owner_or_admin`).
- 마이그 **0142**(idempotent inspect guard·post-0096 신규 테이블이라 baseline 미변경): 시드 **v1.2~v1.4 무손실 이관** + **v1.5 스토리지 노트**(파일첨부·문서첨부·썸네일=실 라이브 기능·비즈니스 톤) 추가.

### FE
- `lib/release-notes.ts`: 하드코딩 const 제거·types 유지·`fetchReleaseNotes()`(실패/빈=[] graceful). proxy `app/api/release-notes`.
- gate: API fetch→`notes[0].id`로 seen 비교(무회귀)·dialog에 notes 전달. dialog: notes prop+하드코딩 제거+**빈상태 graceful**.

### ⚠️ 설계 노트
릴노트는 전역인데 **platform-admin 롤이 코드에 부재** → CRUD 게이트는 `is_org_owner_or_admin`(아무 org owner/admin)가 v1 유일 옵션(현 단일 org=안전). "외부 org 유입 前 platform-admin tightening"은 PO follow-up 트랙.

### 검증
- 마이그 0142 + 시드 4개 newest-first(v1.5→v1.2) 실측·realdb 3(list shape·CRUD owner/admin 게이트·미발행 제외/patch/delete)·BE no-DB 2595 pass·FE type-check+eslint clean·ruff clean. CI alembic-fresh 등록. **마이그 dev 적용=PO lane**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
