### PR TITLE
[SID:4fbb10c1] E-STORAGE S8 — 스토리지 용량 경고 배너 (FE·에픽 마지막 조각)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -121,7 +121,19 @@
     "previewNoAccessTitle": "Preview not available",
     "previewNoAccessDesc": "This conversation attachment is only visible to participants.",
     "previewPhantomTitle": "No preview",
-    "previewPhantomDesc": "This asset has no stored original."
+    "previewPhantomDesc": "This asset has no stored original.",
+    "capacityWarnTitle": "Storage is almost full",
+    "capacityWarnDesc": "You've used {pct}% of your storage limit. Free up space or upgrade your plan.",
+    "capacityWarnDescNoManage": "You've used {pct}% of your storage limit. Please free up some space.",
+    "capacityBlockTitle": "Storage is full · uploads are paused",
+    "capacityBlockDesc": "To upload new files, free up space by removing existing files or upgrade your plan.",
+    "capacityUsage": "<b>{used}</b> / {limit} used · {pct}%",
+    "capacityManageFiles": "Manage files",
+    "capacityUpgrade": "Upgrade",
+    "capacityToastTitle": "Storage {pct}% full",
+    "capacityToastDesc": "Uploads may be restricted soon.",
+    "capacityToastDescBlock": "Uploads are paused. Please free up space.",
+    "capacityDismiss": "Hide for this session"
   },
   "commandPalette": {
     "title": "Command palette",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -121,7 +121,19 @@
     "previewNoAccessTitle": "미리보기 권한이 없습니다",
     "previewNoAccessDesc": "이 대화 첨부는 참여자만 볼 수 있어요.",
     "previewPhantomTitle": "미리보기 없음",
-    "previewPhantomDesc": "저장된 원본이 없는 자산입니다."
+    "previewPhantomDesc": "저장된 원본이 없는 자산입니다.",
+    "capacityWarnTitle": "스토리지 공간이 거의 찼습니다",
+    "capacityWarnDesc": "사용량이 한도의 {pct}%에 도달했습니다. 공간을 정리하거나 플랜을 업그레이드하세요.",
+    "capacityWarnDescNoManage": "사용량이 한도의 {pct}%에 도달했습니다. 공간을 정리해 주세요.",
+    "capacityBlockTitle": "스토리지가 가득 찼습니다 · 업로드가 중단되었습니다",
+    "capacityBlockDesc": "새 파일을 업로드하려면 기존 파일을 정리해 공간을 확보하거나 플랜을 업그레이드하세요.",
+    "capacityUsage": "<b>{used}</b> / {limit} 사용 중 · {pct}%",
+    "capacityManageFiles": "파일 관리",
+    "capacityUpgrade": "업그레이드",
+    "capacityToastTitle": "스토리지 {pct}% 사용 중",
+    "capacityToastDesc": "곧 업로드가 제한될 수 있습니다.",
+    "capacityToastDescBlock": "업로드가 중단되었습니다. 공간을 확보해 주세요.",
+    "capacityDismiss": "이번 세션 동안 숨기기"
   },
   "commandPalette": {
     "title": "커맨드 팔레트",

--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -3,6 +3,7 @@ import { headers } from 'next/headers';
 import { getServerSession } from '@/lib/db/server';
 import { buildLoginRedirect } from '@/lib/auth/session-redirect';
 import { DashboardShell } from '../dashboard/dashboard-shell';
+import { StorageCapacityToastProvider } from '@/components/storage/storage-capacity-toast-provider';
 
 interface MemberContext {
   id: string;
@@ -82,7 +83,7 @@ export default async function AuthenticatedLayout({
       projectMemberships={projectMemberships}
       orgMemberships={orgMemberships}
     >
-      {children}
+      <StorageCapacityToastProvider>{children}</StorageCapacityToastProvider>
     </DashboardShell>
   );
 }

--- a/apps/web/src/app/api/assets/storage-usage/route.ts
+++ b/apps/web/src/app/api/assets/storage-usage/route.ts
@@ -1,0 +1,13 @@
+import { apiSuccess } from '@/lib/api-response';
+
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// GET /api/assets/storage-usage
+// → FastAPI /api/v2/assets/storage-usage ({ org_id, used_bytes, limit_bytes, percentage })
+// BE derives the org from the JWT; proxyToFastapi forwards query params + auth verbatim.
+export async function GET(request: Request) {
+  const _r = await proxyToFastapi(request, '/api/v2/assets/storage-usage');
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess({ ok: true });
+  return apiSuccess(await _r.json());
+}

--- a/apps/web/src/components/storage/storage-capacity-banner.tsx
+++ b/apps/web/src/components/storage/storage-capacity-banner.tsx
@@ -57,7 +57,9 @@ export function StorageCapacityBanner() {
           data?: { used_bytes?: number; limit_bytes?: number; percentage?: number };
         };
         const d = json.data;
-        if (!d || typeof d.percentage !== 'number') return;
+        // percentage 가 유한수일 때만 채택 — limit_bytes 0/null(무제한·OSS) → BE 가 NaN/Infinity/null
+        // 줄 수 있고, NaN < 80 은 false 라 가드 없으면 깨진(NaN%) 배너가 렌더된다(div0 방어).
+        if (!d || !Number.isFinite(d.percentage)) return;
         if (cancelled) return;
         setUsage({
           used: d.used_bytes ?? 0,

--- a/apps/web/src/components/storage/storage-capacity-banner.tsx
+++ b/apps/web/src/components/storage/storage-capacity-banner.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { AlertOctagon, AlertTriangle, X } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+import { isEEEnabled } from '@/lib/ee';
+import { formatStorageSize } from '@/lib/storage/format';
+import { cn } from '@/lib/utils';
+
+/** 세션 한정 dismiss 키 — warning 배너만 사용. 다음 세션에도 ≥80%면 재노출(영구 숨김 금지). */
+const WARN_DISMISS_KEY = 'storage-capacity-warn-dismissed';
+
+interface StorageUsage {
+  used: number;
+  limit: number;
+  pct: number;
+}
+
+/**
+ * S8 — 스토리지 용량 경고 배너 (story 4fbb10c1).
+ * `/api/assets/storage-usage` 를 마운트 시 1회(no-polling) 조회해 2-심각도로 노출:
+ *   - 80–99% → warning(amber)·세션 dismiss 가능(sessionStorage)·다음 세션 재노출
+ *   - 100%+  → block(red)·non-dismissible(실 차단 상태 은폐 방지)
+ * <80% 또는 fetch 실패 → 아무것도 렌더하지 않음(graceful, 에러 표면 없음).
+ * 색상은 Alert variant + bg-warning/bg-destructive 토큰만 사용(하드코딩 금지·양 테마 대응).
+ */
+export function StorageCapacityBanner() {
+  const t = useTranslations('storage');
+  const router = useRouter();
+  const { orgId, orgMemberships } = useDashboardContext();
+
+  const [usage, setUsage] = useState<StorageUsage | null>(null);
+  // 세션 dismiss 플래그 복원(이번 세션 한정) — lazy initializer.
+  // 배너는 usage 로드(클라이언트) 전엔 null 렌더라 SSR/hydration 불일치 없음.
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    try {
+      return sessionStorage.getItem(WARN_DISMISS_KEY) === '1';
+    } catch {
+      // sessionStorage 접근 불가 환경 — dismiss 비활성(배너 노출 유지)
+      return false;
+    }
+  });
+
+  // 마운트 1회 조회(폴링 없음·취소 안전).
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch('/api/assets/storage-usage');
+        if (!res.ok) return;
+        const json = (await res.json()) as {
+          data?: { used_bytes?: number; limit_bytes?: number; percentage?: number };
+        };
+        const d = json.data;
+        if (!d || typeof d.percentage !== 'number') return;
+        if (cancelled) return;
+        setUsage({
+          used: d.used_bytes ?? 0,
+          limit: d.limit_bytes ?? 0,
+          pct: d.percentage,
+        });
+      } catch {
+        // 조회 실패는 치명적이지 않음 — 배너 미노출(에러 표면 없음)
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // <80% 또는 미조회 → 미노출.
+  if (!usage || usage.pct < 80) return null;
+
+  const isBlock = usage.pct >= 100;
+  // warning 만 세션 dismiss 적용·block 은 항상 노출(non-dismissible).
+  if (!isBlock && dismissed) return null;
+
+  const role = orgMemberships.find((o) => o.orgId === orgId)?.role;
+  const canManage = role === 'owner' || role === 'admin';
+  // 업그레이드 CTA = 권한(owner/admin) + billing 탭 EE 게이트 모두 충족 시에만.
+  const showUpgrade = canManage && isEEEnabled();
+
+  const roundedPct = Math.round(usage.pct);
+  const title = isBlock ? t('capacityBlockTitle') : t('capacityWarnTitle');
+  const desc = isBlock
+    ? t('capacityBlockDesc')
+    : canManage
+      ? t('capacityWarnDesc', { pct: roundedPct })
+      : t('capacityWarnDescNoManage', { pct: roundedPct });
+
+  const handleDismiss = () => {
+    try {
+      sessionStorage.setItem(WARN_DISMISS_KEY, '1');
+    } catch {
+      // 영속 실패해도 이번 렌더에선 숨김 처리
+    }
+    setDismissed(true);
+  };
+
+  return (
+    <Alert variant={isBlock ? 'destructive' : 'warning'}>
+      {isBlock ? <AlertOctagon className="size-4" /> : <AlertTriangle className="size-4" />}
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription>{desc}</AlertDescription>
+
+      {/* 사용량 바 */}
+      <div className="col-start-2 mt-2">
+        <div
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={roundedPct}
+          aria-label={`${formatStorageSize(usage.used)} / ${formatStorageSize(usage.limit)} · ${roundedPct}%`}
+          className="h-1.5 w-full overflow-hidden rounded-full bg-muted"
+        >
+          <div
+            className={cn('h-full rounded-full', isBlock ? 'bg-destructive' : 'bg-warning')}
+            style={{ width: `${Math.min(100, usage.pct)}%` }}
+          />
+        </div>
+        <p className="mt-1.5 text-xs text-muted-foreground">
+          {t.rich('capacityUsage', {
+            used: formatStorageSize(usage.used),
+            limit: formatStorageSize(usage.limit),
+            pct: roundedPct,
+            b: (chunks) => <b className="font-semibold text-foreground">{chunks}</b>,
+          })}
+        </p>
+      </div>
+
+      {/* CTA — 파일 관리는 block 상태에서도 primary(red-on-red 금지) */}
+      <div className="col-start-2 mt-2 flex flex-wrap gap-2">
+        <Button size="sm" variant="default" onClick={() => router.push('/storage')}>
+          {t('capacityManageFiles')}
+        </Button>
+        {showUpgrade && (
+          <Button size="sm" variant="outline" onClick={() => router.push('/settings?tab=billing')}>
+            {t('capacityUpgrade')}
+          </Button>
+        )}
+      </div>
+
+      {/* 세션 dismiss — warning 만. block 은 dismiss 없음. */}
+      {!isBlock && (
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="absolute right-2 top-2"
+          aria-label={t('capacityDismiss')}
+          onClick={handleDismiss}
+        >
+          <X className="size-4" />
+        </Button>
+      )}
+    </Alert>
+  );
+}

--- a/apps/web/src/components/storage/storage-capacity-banner.tsx
+++ b/apps/web/src/components/storage/storage-capacity-banner.tsx
@@ -57,14 +57,17 @@ export function StorageCapacityBanner() {
           data?: { used_bytes?: number; limit_bytes?: number; percentage?: number };
         };
         const d = json.data;
+        if (!d) return;
         // percentage 가 유한수일 때만 채택 — limit_bytes 0/null(무제한·OSS) → BE 가 NaN/Infinity/null
         // 줄 수 있고, NaN < 80 은 false 라 가드 없으면 깨진(NaN%) 배너가 렌더된다(div0 방어).
-        if (!d || !Number.isFinite(d.percentage)) return;
+        // (typeof 로 number 내로잉 + isFinite 로 NaN/Infinity 배제.)
+        const pct = d.percentage;
+        if (typeof pct !== 'number' || !Number.isFinite(pct)) return;
         if (cancelled) return;
         setUsage({
           used: d.used_bytes ?? 0,
           limit: d.limit_bytes ?? 0,
-          pct: d.percentage,
+          pct,
         });
       } catch {
         // 조회 실패는 치명적이지 않음 — 배너 미노출(에러 표면 없음)

--- a/apps/web/src/components/storage/storage-capacity-toast-provider.tsx
+++ b/apps/web/src/components/storage/storage-capacity-toast-provider.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useTranslations } from 'next-intl';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+import { ToastContainer, useToast } from '@/components/ui/toast';
+
+/** 세션 1회 가드 — 같은 세션 새로고침 시 토스트 재노출 방지. */
+const TOAST_SHOWN_KEY = 'storage-capacity-toast-shown';
+
+/**
+ * S8 — 글로벌 스토리지 용량 session-toast (story 4fbb10c1).
+ * /storage 밖에 있는 유저에게도 ≥80% 임박을 앱 로드 1회 알린다(폴링 없음·세션 1회).
+ * 토스트는 정보 전용(액션 링크 미지원 — addToast 는 {title, body?, type} 만) → CTA 는 배너가 담당.
+ * 100%+ 는 destructive 톤(type='error')으로 "업로드 중단" 고지.
+ */
+export function StorageCapacityToastProvider({ children }: { children: React.ReactNode }) {
+  const t = useTranslations('storage');
+  const { orgId } = useDashboardContext();
+  const { toasts, addToast, dismissToast } = useToast();
+  const ranRef = useRef(false);
+
+  useEffect(() => {
+    // 인증 컨텍스트 준비(orgId) + 세션 1회만.
+    if (!orgId || ranRef.current) return;
+    try {
+      if (sessionStorage.getItem(TOAST_SHOWN_KEY) === '1') {
+        ranRef.current = true;
+        return;
+      }
+    } catch {
+      // sessionStorage 불가 — 가드 없이 1회 진행
+    }
+    ranRef.current = true;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch('/api/assets/storage-usage');
+        if (!res.ok) return;
+        const json = (await res.json()) as { data?: { percentage?: number } };
+        const pct = json.data?.percentage;
+        if (cancelled || typeof pct !== 'number' || pct < 80) return;
+        const roundedPct = Math.round(pct);
+        const isBlock = pct >= 100;
+        addToast({
+          type: isBlock ? 'error' : 'warning',
+          title: t('capacityToastTitle', { pct: roundedPct }),
+          body: isBlock ? t('capacityToastDescBlock') : t('capacityToastDesc'),
+        });
+        try {
+          sessionStorage.setItem(TOAST_SHOWN_KEY, '1');
+        } catch {
+          // 영속 실패 무시
+        }
+      } catch {
+        // 조회 실패는 치명적이지 않음 — 토스트 미노출
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [orgId, addToast, t]);
+
+  return (
+    <>
+      {children}
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+    </>
+  );
+}

--- a/apps/web/src/components/storage/storage-capacity-toast-provider.tsx
+++ b/apps/web/src/components/storage/storage-capacity-toast-provider.tsx
@@ -41,7 +41,7 @@ export function StorageCapacityToastProvider({ children }: { children: React.Rea
         const json = (await res.json()) as { data?: { percentage?: number } };
         const pct = json.data?.percentage;
         // 유한수 가드 — limit_bytes 0/null(무제한) → NaN/Infinity 가능(div0 방어). NaN<80=false 회피.
-        if (cancelled || !Number.isFinite(pct) || (pct as number) < 80) return;
+        if (cancelled || typeof pct !== 'number' || !Number.isFinite(pct) || pct < 80) return;
         const roundedPct = Math.round(pct);
         const isBlock = pct >= 100;
         addToast({

--- a/apps/web/src/components/storage/storage-capacity-toast-provider.tsx
+++ b/apps/web/src/components/storage/storage-capacity-toast-provider.tsx
@@ -40,7 +40,8 @@ export function StorageCapacityToastProvider({ children }: { children: React.Rea
         if (!res.ok) return;
         const json = (await res.json()) as { data?: { percentage?: number } };
         const pct = json.data?.percentage;
-        if (cancelled || typeof pct !== 'number' || pct < 80) return;
+        // 유한수 가드 — limit_bytes 0/null(무제한) → NaN/Infinity 가능(div0 방어). NaN<80=false 회피.
+        if (cancelled || !Number.isFinite(pct) || (pct as number) < 80) return;
         const roundedPct = Math.round(pct);
         const isBlock = pct >= 100;
         addToast({

--- a/apps/web/src/components/storage/storage-view.tsx
+++ b/apps/web/src/components/storage/storage-view.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { useContextualPanelState } from '@/components/ui/contextual-panel-layout';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { formatTotalSize } from '@/lib/storage/format';
+import { StorageCapacityBanner } from './storage-capacity-banner';
 import { StorageFolderTree } from './storage-folder-tree';
 import { StorageAssetList } from './storage-asset-list';
 import { StorageDetailPanel } from './storage-detail-panel';
@@ -244,6 +245,10 @@ export function StorageView() {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <TopBarSlot title={topBarTitle} />
+
+      <div className="px-4 pt-3 empty:hidden">
+        <StorageCapacityBanner />
+      </div>
 
       <div
         className={cn(

--- a/apps/web/src/lib/storage/format.ts
+++ b/apps/web/src/lib/storage/format.ts
@@ -102,6 +102,23 @@ export function formatTotalSize(bytes: number): string {
   return `${(mb / 1024).toFixed(1)} GB`;
 }
 
+/**
+ * 스토리지 용량 포맷(S8 용량 경고 배너) — formatTotalSize 는 GB 상한이라 TB 한도(엔터프라이즈
+ * 플랜)에서 "5120.0 GB" 같이 깨진다. B/KB/MB/GB/TB 까지 커버하는 용량 전용 포맷터.
+ * 예: 5368709120 → "5.0 GB", 0 → "0 B".
+ */
+export function formatStorageSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return '0 B';
+  if (bytes < 1024) return `${Math.round(bytes)} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  const mb = kb / 1024;
+  if (mb < 1024) return `${mb.toFixed(1)} MB`;
+  const gb = mb / 1024;
+  if (gb < 1024) return `${gb.toFixed(1)} GB`;
+  return `${(gb / 1024).toFixed(1)} TB`;
+}
+
 /** ISO → YYYY-MM-DD (상세 메타 '생성' 행). */
 export function formatDate(iso: string): string {
   const t = new Date(iso).getTime();


### PR DESCRIPTION
## 개요
E-STORAGE S8 (마지막 FE 조각) — capacity 게이트(BE+prod 完·cron 80% 경고 메일 발송 中)의 **인앱 경고 surface**. 2-심각도 Alert 배너(`/storage` 상단) + 글로벌 session-toast. story `4fbb10c1`·핸드오프 `e-storage-s8-capacity-warning-handoff`·시각 SSOT `e-storage-s8-mockup-html`.

## 구현
- **데이터**: `GET /api/v2/assets/storage-usage` → `{used_bytes, limit_bytes, percentage}`. FE proxy 신설(`api/assets/storage-usage`·proxyToFastapi). 마운트 1회 fetch·no-polling·graceful(실패/<80%=미렌더).
- **2 심각도**: `<80%` 미렌더 · **80–99% warning**(`Alert variant=warning`·AlertTriangle·세션 dismiss `sessionStorage`·다음 세션 ≥80%면 재노출·영구숨김 금지) · **100%+ block**(`variant=destructive`·AlertOctagon·**non-dismissible**).
- **사용량 바**(progressbar·aria·`bg-warning`/`bg-destructive` fill) + **GB 텍스트**(`formatStorageSize` 신규·GB/TB-aware·기존 formatFileSize는 MB-max).
- **CTA**: 파일 관리(항상·`variant=default` primary·**block서도 red-on-red 금지**→`/storage`) + 업그레이드(**`canManage && isEEEnabled()`일 때만**·outline→`/settings?tab=billing`).
  - `canManage` = org role(owner/admin) via `useDashboardContext` orgMemberships(핸드오프대로·BE billing 필드 아님).
  - **billing 라우트 실확認**: 전용 `/settings/billing` 없음 → `/settings?tab=billing` 쿼리탭(EE-게이트)·PO 추론 정정(라이브 그라운딩 authoritative).
- **글로벌 session-toast**((authenticated) layout·DashboardShell 내부): ≥80%면 앱 로드 1회(sessionStorage 가드)·정보용(`{title,body,type}`·**toast 액션링크 미지원→CTA는 배너**·v1 결정)·100%=error 톤.
- **i18n** storage ns 13키(비즈니스 톤·`capacityUsage`=`<b>{used}</b>` 태그형 t.rich). 토큰 canonical·양테마.

## NOTE
- 토스트는 액션링크 없음(toast 시스템 제약·PO 결정 v1)·CTA는 /storage 배너가 담당. useToast 확장=backlog.
- 글로벌 ToastContainer가 페이지별 컨테이너와 공존(독립 state·용량토스트 1회/transient·저위험).

## 검증
- `pnpm build` 그린(EXIT0)·신규 라우트 `/api/assets/storage-usage` 등록·eslint 0(변경파일).
- **dev 픽셀(머지 後)**: 테스트 org ≥80% warning + 100% block 라이브 렌더·양테마 (⚠️테스트 org ≥80% 도달/강제 state 수단 필요 시 PO 핑).

유나 정적 가디언(mockup 1:1·warning/block 토큰·can_manage 게이팅·GB 포맷) → PO crux → 까심 cross-model → 머지 → dev 픽셀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)