### PR TITLE
[SID:ee7794eb] dev maxScale durable=1 (cloud-build.yml per-env) — 배포 리셋 제거

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -46,16 +46,19 @@ jobs:
             echo "target=prod" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-prod-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
             echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
-            # maxScale 10: 429 포화(2026-06-09)·6은 sat 유발. #1330 가속→연결 회전→10×8=80<DB 100 viable. PgBouncer 後 30+.
+            # ⚠️ maxScale 10: rollout(2×) 時 per-instance 5(pool 4 + raw 1) → 2×10×5+20=120 > prod g1-small
+            # max_conn 100. 즉 10 은 **③ 연결안전(PgBouncer transaction-mode·DB_PGBOUNCER) 또는 tier↑ 전제**
+            # (PgBouncer 가 Cloud SQL 연결 decouple → app pool×instance 무관). ③ 前 prod 승격 금지(승격 rollout 자체가 초과).
             echo "backend_max_instances=10" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=G-RYHFE7XM3X" >> "$GITHUB_OUTPUT"
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
             echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
-            # maxScale 10: 429 포화(2026-06-09)·6은 sat 유발. #1330 statement_cache 가속→연결 회전→
-            # 10×8=80<DB 100 viable. prod(L49)·cloudbuild.yaml default와 합치. PgBouncer 랜딩 後 30+.
-            echo "backend_max_instances=10" >> "$GITHUB_OUTPUT"
+            # ⚠️ maxScale 1 (ee7794eb·durable): dev Cloud SQL f1-micro max_conn~25. rollout(old+new 2×)·
+            # per-instance = pool(3/1=4·#1773) + pg_pubsub raw 1 = 5. 2×1×5+5(admin)=15 ≤ 25 ✓.
+            # (이전 10 = rollout 2×10×5+5=105≫25 → 매 배포 TooManyConnections. steady 80<100 주석은 rollout 누락이었음.)
+            echo "backend_max_instances=1" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=" >> "$GITHUB_OUTPUT"
           fi
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,11 +11,11 @@ substitutions:
   _DEPLOY_ENV: dev
   _FASTAPI_URL: https://sprintable-backend-dev-787818285179.asia-northeast3.run.app
   _BACKEND_MIN_INSTANCES: '1'
-  # ⚠️ maxScale 10 = 429 포화 인시던트(2026-06-09) 後. 6(#1325)은 부하에 인스턴스 포화→429 유발.
-  #    #1330 statement_cache revert로 쿼리 가속→연결 빠른 회전→10×8=80 < DB 100 viable(peak 여유).
-  #    수렴 history: 3(#1319前·sat)→10(#1319·churn)→6(#1325·429 sat)→10(#1330 가속·viable).
-  #    durable fix는 2c4dcae7 PgBouncer(연결 decouple·maxScale 30+)·랜딩 後 상향. 그 前까지 10.
-  #    (GHA develop→dev·main→prod 자동배포가 이 default 주입 → 6이면 머지마다 429 재발 latent → 10.)
+  # ⚠️ 이 값은 **GHA cloud-build.yml 이 per-env override**(dev=1·prod=10) — 이 default 는 수동 빌드 fallback.
+  #    maxScale 10 history: 429 포화(2026-06-09)→#1330 가속→steady 10×8=80<100 "viable" 판단이었으나
+  #    **rollout(old+new 2×) 누락**이었음(ee7794eb·dev TooManyConnections). rollout per-instance = pool(4)
+  #    + pg_pubsub raw(1) = 5 → 2×10×5+20=120 > 100. 즉 maxScale 10 은 **PgBouncer(DB_PGBOUNCER·연결
+  #    decouple) 또는 tier↑ 전제**. dev(f1-micro 25)는 maxScale 1(2×1×5+5=15≤25)로 cloud-build.yml 에서 강제.
   _BACKEND_MAX_INSTANCES: '10'
   _GA4_MEASUREMENT_ID: ""  # dev 기본값 빈 문자열 — prod 트리거에서 G-RYHFE7XM3X 주입
 


### PR DESCRIPTION
## dev maxScale durable=1 (cloud-build.yml per-env) — 배포 리셋 band-aid 제거 (ee7794eb)

post-deploy 실측(PO): #1773 dev 배포가 maxScale 를 **cloudbuild default 10 으로 리셋**(rev 01243)·수동 maxScale 1 을 덮음 → 매 dev 배포마다 재발. 근본 = GHA `cloud-build.yml` 이 dev/prod 모두 `backend_max_instances=10` 주입, 그 주석이 **rollout 2× 누락**(steady 10×8=80<100 "viable" = #1773 가 잡은 동일 blind spot 이 maxScale 디폴트에도 박혀 있었음).

### durable fix
- **dev `backend_max_instances` 10→1**: rollout per-instance = pool(4·#1773) + pg_pubsub raw(1) = 5. **2×1×5+5(admin)=15 ≤ 25**(f1-micro) ✓. (10 이면 2×10×5+5=105≫25 → 매 배포 TooManyConnections.)
- **prod 10 유지** — 단 rollout 2×10×5+20=**120>100** 이라 **③ PgBouncer(`DB_PGBOUNCER`·연결 decouple) 또는 tier↑ 전제**. ③ 前 prod 승격 금지(승격 rollout 자체가 초과) — 주석 명시.
- `cloudbuild.yaml` default 주석도 rollout 2× 반영(GHA per-env override·default 는 수동 fallback).

### 검증
- YAML syntax 검증 통과. dev(develop)=1·prod(main)=10 확인.
- test 무변경 — `test_e_infra_s2_pool` 의 `DEV_MAX_SCALE=1` + prod@10-needs-pooler 게이트가 이 값들을 이미 락(#1773).
- 이게 ② DB pool 하드닝의 **deploy-config 절반**(maxScale durable). 머지→dev 배포 시 maxScale 1 영속(더 이상 리셋 안 됨).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
