### PR TITLE
[SID:ee7794eb] ③ PgBouncer BE — pg_pubsub LISTEN direct URL + fail-closed 가드

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -10,6 +10,11 @@ class Settings(BaseSettings):
     # Cloud SQL Unix socket 연결 예시 (Cloud Run 등):
     #   postgresql+asyncpg://sprintable:PASSWORD@/sprintable?host=/cloudsql/sprintable:asia-northeast3:sprintable-dev
     database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:54322/postgres"
+    # ee7794eb ③: DB_PGBOUNCER on 時 DATABASE_URL 은 PgBouncer(transaction-mode) 를 가리키는데, pg_pubsub
+    # raw LISTEN/NOTIFY 는 transaction-mode 비호환(연결이 statement 마다 반납돼 LISTEN 상태 소실) → **direct
+    # Cloud SQL URL 별도**로 우회. 미설정 시 database_url 폴백(non-PgBouncer 환경). on+미설정 = startup
+    # fail-closed(pg_pubsub.check_listen_config·main lifespan).
+    database_url_direct: str = ""
 
     # Cloud SQL (D-S1: Phase D GCP 인프라)
     cloud_sql_instance_dev: str = "sprintable-494803:asia-northeast3:sprintable-dev"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,9 +20,10 @@ _logger = logging.getLogger(__name__)
 async def lifespan(app: FastAPI):
     from app.core.database import engine
     from app.routers.verdict_capture import warn_if_webhook_secret_misconfigured
-    from app.services.pg_pubsub import listen_loop
+    from app.services.pg_pubsub import check_listen_config, listen_loop
 
     warn_if_webhook_secret_misconfigured()  # Bot-M.2 P3: 웹훅 secret misconfig 를 트래픽 前 경고.
+    check_listen_config()  # ee7794eb ③ fail-closed: DB_PGBOUNCER on + DATABASE_URL_DIRECT 없으면 startup raise.
     task = asyncio.create_task(listen_loop())
     # E-L2 S5: 휴리스틱 트리거 워커는 default-off — 명시 활성화 시에만 task 생성(AC①).
     l2_task = None

--- a/backend/app/services/pg_pubsub.py
+++ b/backend/app/services/pg_pubsub.py
@@ -101,17 +101,36 @@ async def _dispatch_received(payload_str: str) -> None:
         logger.warning("pg_listen dispatch failed target=%s: %s", target, exc)
 
 
+def _resolve_listen_url(s=None) -> str:
+    """LISTEN raw 연결 URL — ee7794eb ③: DB_PGBOUNCER on 時 transaction-mode PgBouncer 는 LISTEN/NOTIFY
+    미지원이라 **direct Cloud SQL**(database_url_direct)로 우회. 미설정 폴백=database_url(non-PgBouncer)."""
+    if s is None:
+        from app.core.config import settings as s
+    return (s.database_url_direct or s.database_url).replace("postgresql+asyncpg://", "postgresql://", 1)
+
+
+def check_listen_config(s=None) -> None:
+    """fail-closed: DB_PGBOUNCER on 인데 direct URL 없으면 raise — LISTEN 이 PgBouncer 경유로 깨지는
+    misconfig 를 startup서 차단(silent 이벤트 유실 방지). main lifespan 이 create_task 前 호출."""
+    if s is None:
+        from app.core.config import settings as s
+    if s.db_pgbouncer and not s.database_url_direct:
+        raise RuntimeError(
+            "DB_PGBOUNCER=on requires DATABASE_URL_DIRECT — pg_pubsub LISTEN 은 transaction-mode "
+            "PgBouncer 비호환이라 direct Cloud SQL URL 필수 (fail-closed·ee7794eb ③)."
+        )
+
+
 async def listen_loop() -> None:
     """PG LISTEN 수신 루프. lifespan startup에서 background task로 실행.
 
-    - raw asyncpg 전용 커넥션 1개 (SQLAlchemy pool 미점유)
+    - raw asyncpg 전용 커넥션 1개 (SQLAlchemy pool 미점유·DB_PGBOUNCER 시 direct Cloud SQL 우회)
     - 연결 실패 시 exponential backoff 1s→2s→4s→max 30s
     - CancelledError 수신 시 커넥션 정리 후 종료
     """
     import asyncpg
-    from app.core.config import settings
 
-    raw_url = settings.database_url.replace("postgresql+asyncpg://", "postgresql://", 1)
+    raw_url = _resolve_listen_url()
     delay = 1.0
 
     logger.info("pg_listen starting on channel=%s instance=%s", _CHANNEL, INSTANCE_ID)

--- a/backend/tests/test_pg_pubsub_listen_url.py
+++ b/backend/tests/test_pg_pubsub_listen_url.py
@@ -1,0 +1,43 @@
+"""ee7794eb ③: pg_pubsub LISTEN raw URL — DB_PGBOUNCER 時 direct Cloud SQL 우회 + fail-closed 가드.
+
+transaction-mode PgBouncer 는 LISTEN/NOTIFY 미지원 → DB_PGBOUNCER on 이면 raw LISTEN 은 database_url_direct
+(direct Cloud SQL)로 가야 한다. on 인데 direct 미설정은 startup fail-closed(silent 이벤트 유실 차단).
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.pg_pubsub import _resolve_listen_url, check_listen_config
+
+
+def _s(database_url, database_url_direct="", db_pgbouncer=False):
+    return SimpleNamespace(
+        database_url=database_url, database_url_direct=database_url_direct, db_pgbouncer=db_pgbouncer
+    )
+
+
+def test_resolve_uses_direct_when_set():
+    # DB_PGBOUNCER on: DATABASE_URL=PgBouncer·LISTEN 은 direct 로.
+    s = _s("postgresql+asyncpg://pgb:6432/db", "postgresql+asyncpg://cloudsql/db", db_pgbouncer=True)
+    assert _resolve_listen_url(s) == "postgresql://cloudsql/db"  # direct·asyncpg 접두 제거
+
+
+def test_resolve_falls_back_to_database_url_when_no_direct():
+    # non-PgBouncer(off): direct 미설정 → database_url 폴백(현 동작 유지).
+    s = _s("postgresql+asyncpg://cloudsql/db")
+    assert _resolve_listen_url(s) == "postgresql://cloudsql/db"
+
+
+def test_check_raises_when_pgbouncer_on_without_direct():
+    # fail-closed: on + direct 없음 → raise(LISTEN 깨짐 차단).
+    s = _s("postgresql+asyncpg://pgb:6432/db", "", db_pgbouncer=True)
+    with pytest.raises(RuntimeError, match="DATABASE_URL_DIRECT"):
+        check_listen_config(s)
+
+
+def test_check_ok_when_pgbouncer_off():
+    check_listen_config(_s("postgresql+asyncpg://cloudsql/db"))  # off → no raise
+
+
+def test_check_ok_when_pgbouncer_on_with_direct():
+    check_listen_config(_s("pgb", "direct", db_pgbouncer=True))  # on + direct → no raise


### PR DESCRIPTION
## ③ PgBouncer BE: pg_pubsub LISTEN direct URL 우회 + fail-closed 가드 (ee7794eb)

중앙 PgBouncer 블루프린트(`einfra3-prod-central-pgbouncer-blueprint`·PO/선생님 nod)의 **BE 절반**.

DB_PGBOUNCER on 時 DATABASE_URL 은 PgBouncer(transaction-mode)를 가리키는데, pg_pubsub raw **LISTEN/NOTIFY 는 transaction-mode 비호환**(연결이 statement 마다 반납 → LISTEN 상태 소실) → **direct Cloud SQL URL 별도 우회** 필요.

### 변경
- `config.py`: `database_url_direct`(env `DATABASE_URL_DIRECT`·미설정 시 `database_url` 폴백 → non-PgBouncer 환경 무영향).
- `pg_pubsub._resolve_listen_url`: LISTEN raw 연결을 direct(or 폴백)로.
- `pg_pubsub.check_listen_config` + main lifespan 호출: **fail-closed** — DB_PGBOUNCER on 인데 `DATABASE_URL_DIRECT` 없으면 startup raise(LISTEN 깨짐·silent 이벤트 유실 차단·misconfig 배포 거부).
- app pool 2/1 분기·`statement_cache_size=0` 은 #1333서 이미 머지(이 PR 무변경).

### 검증
- 단위 5: `_resolve_listen_url`(direct/fallback)·`check_listen_config`(on+no-direct→raise·off→ok·on+direct→ok).
- full no-DB **2603 pass**(잔여 8=기존 MCP-env)·내 파일 ruff clean(main.py:60 E402 는 routers import 기존부·develop 동일·CI-tolerated)·마이그 없음.

### lane
인프라(중앙 PgBouncer Cloud Run 2-instance·시크릿 `DATABASE_URL_PGB`/`DATABASE_URL_DIRECT`·maxScale 캡/복원)는 PO+gcloud(블루프린트 §4·7). 머지 + 인프라 stand-up + §4 순서 → §6 실측 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
