### PR TITLE
[SID:ee7794eb] ③-A develop — prod PgBouncer 배포 env 배선 + v1.5 용량경고

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -51,6 +51,11 @@ jobs:
             # (PgBouncer 가 Cloud SQL 연결 decouple → app pool×instance 무관). ③ 前 prod 승격 금지(승격 rollout 자체가 초과).
             echo "backend_max_instances=10" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=G-RYHFE7XM3X" >> "$GITHUB_OUTPUT"
+            # ③ 중앙 PgBouncer(ee7794eb): prod on. DATABASE_URL→PgBouncer 서비스·DATABASE_URL_DIRECT→Cloud SQL
+            # 시크릿 주입(값은 PO·이름만 참조). 이게 켜져야 maxScale 10 이 rollout-safe(연결 decouple).
+            echo "db_pgbouncer=true" >> "$GITHUB_OUTPUT"
+            echo "database_url_secret=DATABASE_URL_PROD_PGB" >> "$GITHUB_OUTPUT"
+            echo "database_url_direct_secret=DATABASE_URL_DIRECT_PROD" >> "$GITHUB_OUTPUT"
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
@@ -60,6 +65,10 @@ jobs:
             # (이전 10 = rollout 2×10×5+5=105≫25 → 매 배포 TooManyConnections. steady 80<100 주석은 rollout 누락이었음.)
             echo "backend_max_instances=1" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=" >> "$GITHUB_OUTPUT"
+            # dev: PgBouncer off(maxScale 1+pool 4 이미 안전·prod-only ③). DATABASE_URL out-of-band 유지.
+            echo "db_pgbouncer=false" >> "$GITHUB_OUTPUT"
+            echo "database_url_secret=" >> "$GITHUB_OUTPUT"
+            echo "database_url_direct_secret=" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Submit Cloud Build
@@ -67,6 +76,6 @@ jobs:
           gcloud builds submit \
             --config=cloudbuild.yaml \
             --project="${{ secrets.GCP_PROJECT_ID }}" \
-            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}",_BACKEND_MIN_INSTANCES="${{ steps.env.outputs.backend_min_instances }}",_BACKEND_MAX_INSTANCES="${{ steps.env.outputs.backend_max_instances }}",_GA4_MEASUREMENT_ID="${{ steps.env.outputs.ga4_measurement_id }}" \
+            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}",_BACKEND_MIN_INSTANCES="${{ steps.env.outputs.backend_min_instances }}",_BACKEND_MAX_INSTANCES="${{ steps.env.outputs.backend_max_instances }}",_GA4_MEASUREMENT_ID="${{ steps.env.outputs.ga4_measurement_id }}",_DB_PGBOUNCER="${{ steps.env.outputs.db_pgbouncer }}",_DATABASE_URL_SECRET="${{ steps.env.outputs.database_url_secret }}",_DATABASE_URL_DIRECT_SECRET="${{ steps.env.outputs.database_url_direct_secret }}" \
             --suppress-logs \
             .

--- a/backend/alembic/versions/0143_release_notes_v15_capacity_item.py
+++ b/backend/alembic/versions/0143_release_notes_v15_capacity_item.py
@@ -1,0 +1,36 @@
+"""E-INFRA ③ B: v1.5 릴노트에 스토리지 용량경고 항목 추가 (de-hardcode 데이터·dev+prod 일관).
+
+선생님 결정: 1.6 아님·v1.5 에 += . S8 용량경고(실 라이브 기능)를 v1.5 items 에 append. 데이터주도지만
+prod 일관·baseline 재현 위해 migration(0142 seed 위 idempotent UPDATE).
+
+idempotent: 이미 그 항목이 있으면(items @> ) skip. v1.5 행 없으면(미시드) no-op.
+"""
+from __future__ import annotations
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0143"
+down_revision = "0142"
+branch_labels = None
+depends_on = None
+
+_NOTE_KEY = "2026-06-v1-5"
+_ITEM = [{"text": "저장공간이 한도에 가까워지면 미리 알려드려요."}]
+
+
+def upgrade() -> None:
+    item_json = json.dumps(_ITEM, ensure_ascii=False)
+    op.execute(
+        sa.text(
+            "UPDATE release_notes SET items = items || CAST(:item AS jsonb) "
+            "WHERE note_key = :k AND NOT (items @> CAST(:item AS jsonb))"
+        ).bindparams(item=item_json, k=_NOTE_KEY)
+    )
+
+
+def downgrade() -> None:
+    # 항목 제거(best-effort·jsonb - 는 객체 배열 직접 미지원이라 재구성). 무손실 롤백 위해 no-op 허용.
+    pass

--- a/backend/tests/test_release_notes_realdb.py
+++ b/backend/tests/test_release_notes_realdb.py
@@ -49,6 +49,8 @@ async def test_list_returns_seeded_newest_first():
             v15 = next(r for r in out if r.id == "2026-06-v1-5")
             assert v15.version == "v1.5" and v15.publishedAt == "2026년 6월"  # display_period→publishedAt
             assert v15.items and v15.items[0].text  # JSONB items 매핑
+            # 0143(③ B): v1.5 에 스토리지 용량경고 항목 append(idempotent).
+            assert any("저장공간" in i.text for i in v15.items), "v1.5 용량경고 항목 누락(0143)"
     finally:
         await engine.dispose()
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,6 +18,11 @@ substitutions:
   #    decouple) 또는 tier↑ 전제**. dev(f1-micro 25)는 maxScale 1(2×1×5+5=15≤25)로 cloud-build.yml 에서 강제.
   _BACKEND_MAX_INSTANCES: '10'
   _GA4_MEASUREMENT_ID: ""  # dev 기본값 빈 문자열 — prod 트리거에서 G-RYHFE7XM3X 주입
+  # ③ 중앙 PgBouncer(ee7794eb): prod 만 on. cloud-build.yml(GHA)이 per-env override(prod=true+시크릿名·dev=false).
+  # on 時 deploy 가 DATABASE_URL→PgBouncer 서비스·DATABASE_URL_DIRECT→Cloud SQL 시크릿 주입(시크릿 값은 PO·이름만 참조).
+  _DB_PGBOUNCER: 'false'
+  _DATABASE_URL_SECRET: ''          # prod: DATABASE_URL_PROD_PGB (→PgBouncer:6432)
+  _DATABASE_URL_DIRECT_SECRET: ''   # prod: DATABASE_URL_DIRECT_PROD (→Cloud SQL 직결·pg_pubsub LISTEN)
 
 steps:
   # ─── Frontend (Next.js standalone) ────────────────────────────────────────
@@ -93,24 +98,32 @@ steps:
 
   - id: deploy-backend
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    entrypoint: gcloud
+    # ③ PgBouncer: prod 만 DATABASE_URL→PgBouncer·DATABASE_URL_DIRECT→Cloud SQL 시크릿을 조건부 주입해야 해
+    # bash 분기로 전환(dev 는 base·DATABASE_URL out-of-band 보존). 기존 플래그/주의는 그대로 유지.
+    entrypoint: bash
     args:
-      - run
-      - deploy
-      - sprintable-backend-${_DEPLOY_ENV}
-      - --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA}
-      - --region=${_AR_REGION}
-      - --min-instances=${_BACKEND_MIN_INSTANCES}
-      - --max-instances=${_BACKEND_MAX_INSTANCES}
-      # ⭐frontend 가 NEXT_PUBLIC_FASTAPI_URL 로 backend 를 직접 호출(public 필수). 플래그 없으면
-      # gcloud run deploy 가 기존 IAM 을 preserve(non-deterministic) → 신규/리셋 시 allUsers invoker
-      # 유실로 403(2026-06-21 prod promotion 사건). 명시적·멱등 설정으로 매 배포 public 보장(dev/prod 공통).
-      - --allow-unauthenticated
-      # OB-1: 에이전트 onboarding generator 가 읽는 backend-direct URL 을 런타임 env 로 주입.
-      # ⚠️ 반드시 --update-env-vars(additive·기존 backend env[DATABASE_URL 등] 보존). --set-env-vars 금지
-      # (전체 wipe). _FASTAPI_URL 은 dev/prod 각 backend-direct run.app(프론트 NEXT_PUBLIC_FASTAPI_URL 과 동일 값).
-      - --update-env-vars=FASTAPI_URL=${_FASTAPI_URL}
-      - --quiet
+      - -c
+      - |
+        set -euo pipefail
+        DEPLOY_ARGS=(
+          run deploy "sprintable-backend-${_DEPLOY_ENV}"
+          "--image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA}"
+          "--region=${_AR_REGION}"
+          "--min-instances=${_BACKEND_MIN_INSTANCES}"
+          "--max-instances=${_BACKEND_MAX_INSTANCES}"
+          # ⭐public 필수(2026-06-21 prod 403 사건)·멱등 보장(dev/prod 공통).
+          --allow-unauthenticated
+          # ⚠️ --update-env-vars(additive·기존 DATABASE_URL 등 보존). --set-env-vars 금지(전체 wipe).
+          # FASTAPI_URL=backend-direct run.app · DB_PGBOUNCER=prod만 true(③·cloud-build.yml per-env).
+          "--update-env-vars=FASTAPI_URL=${_FASTAPI_URL},DB_PGBOUNCER=${_DB_PGBOUNCER}"
+          --quiet
+        )
+        # ③ prod-only: DATABASE_URL→PgBouncer 시크릿·DATABASE_URL_DIRECT→Cloud SQL 시크릿 주입(값은 PO·이름 참조).
+        # dev(_DB_PGBOUNCER=false)는 미주입 → DATABASE_URL out-of-band 보존(현 동작 무변경).
+        if [ "${_DB_PGBOUNCER}" = "true" ]; then
+          DEPLOY_ARGS+=( "--update-secrets=DATABASE_URL=${_DATABASE_URL_SECRET}:latest,DATABASE_URL_DIRECT=${_DATABASE_URL_DIRECT_SECRET}:latest" )
+        fi
+        gcloud "${DEPLOY_ARGS[@]}"
     waitFor: [push-backend]
 
 options:


### PR DESCRIPTION
## ③-A develop pieces — prod PgBouncer 배포 env 배선 + v1.5 용량경고 (ee7794eb)

PO 요청 2 piece(develop·승격 前 준비). 블루프린트 `einfra3-prod-central-pgbouncer-blueprint` 실행. PgBouncer 중앙 서비스·시크릿 값·§4 순서는 PO+gcloud.

### piece 1 — prod DB_PGBOUNCER 배포 배선
- `cloud-build.yml` per-env: **prod** `db_pgbouncer=true` + `database_url_secret=DATABASE_URL_PROD_PGB` + `database_url_direct_secret=DATABASE_URL_DIRECT_PROD`(시크릿 **값은 PO**·이름만 참조). **dev=false**(off·무영향).
- `cloudbuild.yaml` deploy-backend → **bash 분기**: `--update-env-vars=...,DB_PGBOUNCER=${_DB_PGBOUNCER}`(additive) + **prod-only** `--update-secrets=DATABASE_URL=…PGB:latest,DATABASE_URL_DIRECT=…DIRECT:latest`. dev 는 미주입 → DATABASE_URL **out-of-band 보존**(현 동작 무변경). 기존 플래그(`--allow-unauthenticated`·additive 주의)·waitFor 유지.
- DATABASE_URL→PgBouncer:6432·DATABASE_URL_DIRECT→Cloud SQL(pg_pubsub LISTEN direct·#1776 BE 와 짝).

### piece 2 — B: v1.5 += 용량경고 (migration 0143·idempotent)
release_notes v1.5 items 에 `저장공간이 한도에 가까워지면 미리 알려드려요.` append(`items @>` 가드·중복 0·v1.5 행 없으면 no-op). dev+prod 일관(de-hardcode 데이터지만 baseline 재현 위해 migration).

### 검증
- 양 YAML valid · deploy args **dry-run**(prod=`--update-secrets` 포함·DB_PGBOUNCER=true·dev=미포함·false) · 0143 적용 後 v1.5 4항목 · release_notes realdb 3 pass(용량경고 assert) · ruff clean.

### 순서 (PO 조율)
이 PR 머지 → PO PgBouncer 2-instance 서비스+시크릿 stand-up → §4(maxScale 4 캡 → 서비스 → develop→main 승격[이 env 운반] → 복원) → §6 실측.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
