### PR TITLE
[SID:53bc0945] v1.5 릴노트 += 스토리지 용량경고 (migration 0143)

### DIFF
--- a/backend/alembic/versions/0143_release_notes_v15_capacity_item.py
+++ b/backend/alembic/versions/0143_release_notes_v15_capacity_item.py
@@ -1,0 +1,36 @@
+"""E-INFRA ③ B: v1.5 릴노트에 스토리지 용량경고 항목 추가 (de-hardcode 데이터·dev+prod 일관).
+
+선생님 결정: 1.6 아님·v1.5 에 += . S8 용량경고(실 라이브 기능)를 v1.5 items 에 append. 데이터주도지만
+prod 일관·baseline 재현 위해 migration(0142 seed 위 idempotent UPDATE).
+
+idempotent: 이미 그 항목이 있으면(items @> ) skip. v1.5 행 없으면(미시드) no-op.
+"""
+from __future__ import annotations
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0143"
+down_revision = "0142"
+branch_labels = None
+depends_on = None
+
+_NOTE_KEY = "2026-06-v1-5"
+_ITEM = [{"text": "저장공간이 한도에 가까워지면 미리 알려드려요."}]
+
+
+def upgrade() -> None:
+    item_json = json.dumps(_ITEM, ensure_ascii=False)
+    op.execute(
+        sa.text(
+            "UPDATE release_notes SET items = items || CAST(:item AS jsonb) "
+            "WHERE note_key = :k AND NOT (items @> CAST(:item AS jsonb))"
+        ).bindparams(item=item_json, k=_NOTE_KEY)
+    )
+
+
+def downgrade() -> None:
+    # 항목 제거(best-effort·jsonb - 는 객체 배열 직접 미지원이라 재구성). 무손실 롤백 위해 no-op 허용.
+    pass

--- a/backend/tests/test_release_notes_realdb.py
+++ b/backend/tests/test_release_notes_realdb.py
@@ -49,6 +49,8 @@ async def test_list_returns_seeded_newest_first():
             v15 = next(r for r in out if r.id == "2026-06-v1-5")
             assert v15.version == "v1.5" and v15.publishedAt == "2026년 6월"  # display_period→publishedAt
             assert v15.items and v15.items[0].text  # JSONB items 매핑
+            # 0143(v1.5 += 용량경고·de-hardcode 데이터): 스토리지 용량경고 항목 append(idempotent).
+            assert any("저장공간" in i.text for i in v15.items), "v1.5 용량경고 항목 누락(0143)"
     finally:
         await engine.dispose()
 


### PR DESCRIPTION
## v1.5 릴노트 += 스토리지 용량경고 항목 (de-hardcode 데이터)

선생님 결정: 1.6 아님·v1.5 에 += . S8 용량경고(실 라이브 기능)를 v1.5 items 에 append.

⚠️ 원래 #1777(③ PgBouncer 배포 배선 + 이 항목)에 함께 있었으나, **③ PgBouncer Cloud Run 토폴로지가 불가**(Cloud Run raw TCP 미지원·PO deploy-time 적발)로 piece1 보류 → **토폴로지 무관한 이 항목만 별 PR로 분리**(방향 무관하게 머지 가능·PO 콜).

### 변경
- migration **0143**(idempotent): release_notes v1.5(`note_key=2026-06-v1-5`) items 에 `저장공간이 한도에 가까워지면 미리 알려드려요.` append(`items @>` 가드·중복 0·v1.5 행 없으면 no-op). dev+prod 일관.

### 검증
0143 적용+v1.5 4항목·release_notes realdb 3 pass(용량경고 assert)·ruff clean. 머지 後 migrate-dev(PO lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)