### PR TITLE
[SID:ee7794eb] prod maxScale 10→5 right-size (③·PgBouncer 폐기)

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -46,10 +46,11 @@ jobs:
             echo "target=prod" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-prod-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
             echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
-            # ⚠️ maxScale 10: rollout(2×) 時 per-instance 5(pool 4 + raw 1) → 2×10×5+20=120 > prod g1-small
-            # max_conn 100. 즉 10 은 **③ 연결안전(PgBouncer transaction-mode·DB_PGBOUNCER) 또는 tier↑ 전제**
-            # (PgBouncer 가 Cloud SQL 연결 decouple → app pool×instance 무관). ③ 前 prod 승격 금지(승격 rollout 자체가 초과).
-            echo "backend_max_instances=10" >> "$GITHUB_OUTPUT"
+            # ⚠️ maxScale 5 (ee7794eb ③·선생님 right-size): prod g1-small max_conn 100. per-instance 5(pool
+            # 3/1=4 + pg_pubsub raw 1). rollout(old+new 2×): 2×5×5+20(admin)=70 ≤ 100 ✓ (여유 30).
+            # (PgBouncer 풀러 불필요 — Cloud Run raw TCP 미지원으로 중앙 PgBouncer 불가·관리형 풀링은 Enterprise Plus
+            # 전용. maxScale 10 은 2×10×5+20=120>100 이라 폐기. 향후 트래픽↑ 시 tier업 동반해야 maxScale 상향.)
+            echo "backend_max_instances=5" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=G-RYHFE7XM3X" >> "$GITHUB_OUTPUT"
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,13 +11,14 @@ substitutions:
   _DEPLOY_ENV: dev
   _FASTAPI_URL: https://sprintable-backend-dev-787818285179.asia-northeast3.run.app
   _BACKEND_MIN_INSTANCES: '1'
-  # ⚠️ 이 값은 **GHA cloud-build.yml 이 per-env override**(prod=5·dev=1) — 이 default 는 수동 빌드 fallback.
+  # ⚠️ default '1'(아래) = _DEPLOY_ENV:dev default 와 정합한 **dev-safe fallback**(수동 `gcloud builds submit`
+  #    override 없을 때 maxScale 10 trap=2×10×5+5=105>25 재현 차단). GHA cloud-build.yml 이 per-env override(prod=5·dev=1).
   #    rollout-safe 산식(ee7794eb·dev TooManyConnections 인시던트): **2 × maxScale × (pool+overflow + raw) +
   #    headroom ≤ max_conn**. per-instance = pool(3/1=4) + pg_pubsub raw(1) = 5.
   #    prod(g1-small 100): maxScale **5** → 2×5×5+20=70 ≤ 100 ✓(선생님 right-size·여유 30). 10 은 120>100 폐기.
   #    dev(f1-micro 25): maxScale 1 → 2×1×5+5=15 ≤ 25 ✓. (PgBouncer 풀러: Cloud Run raw TCP 미지원으로 중앙
   #    불가·관리형 풀링 Enterprise Plus 전용 → 채택 안 함. 트래픽↑ 時 tier업 동반해야 maxScale 상향.)
-  _BACKEND_MAX_INSTANCES: '10'
+  _BACKEND_MAX_INSTANCES: '1'
   _GA4_MEASUREMENT_ID: ""  # dev 기본값 빈 문자열 — prod 트리거에서 G-RYHFE7XM3X 주입
 
 steps:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,11 +11,12 @@ substitutions:
   _DEPLOY_ENV: dev
   _FASTAPI_URL: https://sprintable-backend-dev-787818285179.asia-northeast3.run.app
   _BACKEND_MIN_INSTANCES: '1'
-  # ⚠️ 이 값은 **GHA cloud-build.yml 이 per-env override**(dev=1·prod=10) — 이 default 는 수동 빌드 fallback.
-  #    maxScale 10 history: 429 포화(2026-06-09)→#1330 가속→steady 10×8=80<100 "viable" 판단이었으나
-  #    **rollout(old+new 2×) 누락**이었음(ee7794eb·dev TooManyConnections). rollout per-instance = pool(4)
-  #    + pg_pubsub raw(1) = 5 → 2×10×5+20=120 > 100. 즉 maxScale 10 은 **PgBouncer(DB_PGBOUNCER·연결
-  #    decouple) 또는 tier↑ 전제**. dev(f1-micro 25)는 maxScale 1(2×1×5+5=15≤25)로 cloud-build.yml 에서 강제.
+  # ⚠️ 이 값은 **GHA cloud-build.yml 이 per-env override**(prod=5·dev=1) — 이 default 는 수동 빌드 fallback.
+  #    rollout-safe 산식(ee7794eb·dev TooManyConnections 인시던트): **2 × maxScale × (pool+overflow + raw) +
+  #    headroom ≤ max_conn**. per-instance = pool(3/1=4) + pg_pubsub raw(1) = 5.
+  #    prod(g1-small 100): maxScale **5** → 2×5×5+20=70 ≤ 100 ✓(선생님 right-size·여유 30). 10 은 120>100 폐기.
+  #    dev(f1-micro 25): maxScale 1 → 2×1×5+5=15 ≤ 25 ✓. (PgBouncer 풀러: Cloud Run raw TCP 미지원으로 중앙
+  #    불가·관리형 풀링 Enterprise Plus 전용 → 채택 안 함. 트래픽↑ 時 tier업 동반해야 maxScale 상향.)
   _BACKEND_MAX_INSTANCES: '10'
   _GA4_MEASUREMENT_ID: ""  # dev 기본값 빈 문자열 — prod 트리거에서 G-RYHFE7XM3X 주입
 


### PR DESCRIPTION
## prod maxScale 10→5 right-size (③ 연결안전·선생님 결정)

③ 연결안전 결정: 중앙 PgBouncer 토폴로지 불가(**Cloud Run raw TCP 미지원**·관리형 풀링 Enterprise Plus 전용·PO deploy-time 적발) → **정공법 maxScale right-size**(선생님 콜). PgBouncer 없이 prod 를 rollout-safe.

### 변경
- `cloud-build.yml` prod `backend_max_instances` **10→5**: per-instance 5(pool 3/1=4 + pg_pubsub raw 1)·rollout(2×) `2×5×5+20=70 ≤ 100`(g1-small·여유 30). **dev=1 유지**(`2×1×5+5=15≤25`). 주석 'PgBouncer/tier 전제' → 'right-size·풀러 불필요'.
- `cloudbuild.yaml` default 주석도 prod 5 산식 반영(default 10 은 수동 fallback·GHA per-env override).

### context
- PgBouncer 경로 폐기(#1777 닫힘). #1776(direct URL)은 미래 풀러용 dormant 보존(무해·DB_PGBOUNCER off no-op).
- PO interim prod maxScale 4 캡(rev 00183) → 이 PR 승격 배포로 settle 5.
- 코드로직 무변경·마이그 없음. 양 YAML valid·prod=5/dev=1 확認.

🤖 Generated with [Claude Code](https://claude.com/claude-code)