### PR TITLE
release: ③ 출시노트 v1.5(+용량경고) + storage S8 배너 + 연결안전 maxScale 5 → prod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
           JWT_SECRET: ci-test-secret-at-least-32-chars-long
           SECRET_KEY: ci-test-secret-at-least-32-chars-long
-        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py -q
+        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py tests/test_release_notes_realdb.py -q
 
       - name: Verify fresh DB reached head (baseline + incremental)
         working-directory: backend

--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -46,10 +46,11 @@ jobs:
             echo "target=prod" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-prod-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
             echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
-            # ⚠️ maxScale 10: rollout(2×) 時 per-instance 5(pool 4 + raw 1) → 2×10×5+20=120 > prod g1-small
-            # max_conn 100. 즉 10 은 **③ 연결안전(PgBouncer transaction-mode·DB_PGBOUNCER) 또는 tier↑ 전제**
-            # (PgBouncer 가 Cloud SQL 연결 decouple → app pool×instance 무관). ③ 前 prod 승격 금지(승격 rollout 자체가 초과).
-            echo "backend_max_instances=10" >> "$GITHUB_OUTPUT"
+            # ⚠️ maxScale 5 (ee7794eb ③·선생님 right-size): prod g1-small max_conn 100. per-instance 5(pool
+            # 3/1=4 + pg_pubsub raw 1). rollout(old+new 2×): 2×5×5+20(admin)=70 ≤ 100 ✓ (여유 30).
+            # (PgBouncer 풀러 불필요 — Cloud Run raw TCP 미지원으로 중앙 PgBouncer 불가·관리형 풀링은 Enterprise Plus
+            # 전용. maxScale 10 은 2×10×5+20=120>100 이라 폐기. 향후 트래픽↑ 시 tier업 동반해야 maxScale 상향.)
+            echo "backend_max_instances=5" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=G-RYHFE7XM3X" >> "$GITHUB_OUTPUT"
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -46,16 +46,19 @@ jobs:
             echo "target=prod" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-prod-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
             echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
-            # maxScale 10: 429 포화(2026-06-09)·6은 sat 유발. #1330 가속→연결 회전→10×8=80<DB 100 viable. PgBouncer 後 30+.
+            # ⚠️ maxScale 10: rollout(2×) 時 per-instance 5(pool 4 + raw 1) → 2×10×5+20=120 > prod g1-small
+            # max_conn 100. 즉 10 은 **③ 연결안전(PgBouncer transaction-mode·DB_PGBOUNCER) 또는 tier↑ 전제**
+            # (PgBouncer 가 Cloud SQL 연결 decouple → app pool×instance 무관). ③ 前 prod 승격 금지(승격 rollout 자체가 초과).
             echo "backend_max_instances=10" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=G-RYHFE7XM3X" >> "$GITHUB_OUTPUT"
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
             echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
-            # maxScale 10: 429 포화(2026-06-09)·6은 sat 유발. #1330 statement_cache 가속→연결 회전→
-            # 10×8=80<DB 100 viable. prod(L49)·cloudbuild.yaml default와 합치. PgBouncer 랜딩 後 30+.
-            echo "backend_max_instances=10" >> "$GITHUB_OUTPUT"
+            # ⚠️ maxScale 1 (ee7794eb·durable): dev Cloud SQL f1-micro max_conn~25. rollout(old+new 2×)·
+            # per-instance = pool(3/1=4·#1773) + pg_pubsub raw 1 = 5. 2×1×5+5(admin)=15 ≤ 25 ✓.
+            # (이전 10 = rollout 2×10×5+5=105≫25 → 매 배포 TooManyConnections. steady 80<100 주석은 rollout 누락이었음.)
+            echo "backend_max_instances=1" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=" >> "$GITHUB_OUTPUT"
           fi
 

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -121,7 +121,19 @@
     "previewNoAccessTitle": "Preview not available",
     "previewNoAccessDesc": "This conversation attachment is only visible to participants.",
     "previewPhantomTitle": "No preview",
-    "previewPhantomDesc": "This asset has no stored original."
+    "previewPhantomDesc": "This asset has no stored original.",
+    "capacityWarnTitle": "Storage is almost full",
+    "capacityWarnDesc": "You've used {pct}% of your storage limit. Free up space or upgrade your plan.",
+    "capacityWarnDescNoManage": "You've used {pct}% of your storage limit. Please free up some space.",
+    "capacityBlockTitle": "Storage is full · uploads are paused",
+    "capacityBlockDesc": "To upload new files, free up space by removing existing files or upgrade your plan.",
+    "capacityUsage": "<b>{used}</b> / {limit} used · {pct}%",
+    "capacityManageFiles": "Manage files",
+    "capacityUpgrade": "Upgrade",
+    "capacityToastTitle": "Storage {pct}% full",
+    "capacityToastDesc": "Uploads may be restricted soon.",
+    "capacityToastDescBlock": "Uploads are paused. Please free up space.",
+    "capacityDismiss": "Hide for this session"
   },
   "commandPalette": {
     "title": "Command palette",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -121,7 +121,19 @@
     "previewNoAccessTitle": "미리보기 권한이 없습니다",
     "previewNoAccessDesc": "이 대화 첨부는 참여자만 볼 수 있어요.",
     "previewPhantomTitle": "미리보기 없음",
-    "previewPhantomDesc": "저장된 원본이 없는 자산입니다."
+    "previewPhantomDesc": "저장된 원본이 없는 자산입니다.",
+    "capacityWarnTitle": "스토리지 공간이 거의 찼습니다",
+    "capacityWarnDesc": "사용량이 한도의 {pct}%에 도달했습니다. 공간을 정리하거나 플랜을 업그레이드하세요.",
+    "capacityWarnDescNoManage": "사용량이 한도의 {pct}%에 도달했습니다. 공간을 정리해 주세요.",
+    "capacityBlockTitle": "스토리지가 가득 찼습니다 · 업로드가 중단되었습니다",
+    "capacityBlockDesc": "새 파일을 업로드하려면 기존 파일을 정리해 공간을 확보하거나 플랜을 업그레이드하세요.",
+    "capacityUsage": "<b>{used}</b> / {limit} 사용 중 · {pct}%",
+    "capacityManageFiles": "파일 관리",
+    "capacityUpgrade": "업그레이드",
+    "capacityToastTitle": "스토리지 {pct}% 사용 중",
+    "capacityToastDesc": "곧 업로드가 제한될 수 있습니다.",
+    "capacityToastDescBlock": "업로드가 중단되었습니다. 공간을 확보해 주세요.",
+    "capacityDismiss": "이번 세션 동안 숨기기"
   },
   "commandPalette": {
     "title": "커맨드 팔레트",

--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -3,6 +3,7 @@ import { headers } from 'next/headers';
 import { getServerSession } from '@/lib/db/server';
 import { buildLoginRedirect } from '@/lib/auth/session-redirect';
 import { DashboardShell } from '../dashboard/dashboard-shell';
+import { StorageCapacityToastProvider } from '@/components/storage/storage-capacity-toast-provider';
 
 interface MemberContext {
   id: string;
@@ -82,7 +83,7 @@ export default async function AuthenticatedLayout({
       projectMemberships={projectMemberships}
       orgMemberships={orgMemberships}
     >
-      {children}
+      <StorageCapacityToastProvider>{children}</StorageCapacityToastProvider>
     </DashboardShell>
   );
 }

--- a/apps/web/src/app/api/assets/storage-usage/route.ts
+++ b/apps/web/src/app/api/assets/storage-usage/route.ts
@@ -1,0 +1,13 @@
+import { apiSuccess } from '@/lib/api-response';
+
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// GET /api/assets/storage-usage
+// → FastAPI /api/v2/assets/storage-usage ({ org_id, used_bytes, limit_bytes, percentage })
+// BE derives the org from the JWT; proxyToFastapi forwards query params + auth verbatim.
+export async function GET(request: Request) {
+  const _r = await proxyToFastapi(request, '/api/v2/assets/storage-usage');
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess({ ok: true });
+  return apiSuccess(await _r.json());
+}

--- a/apps/web/src/app/api/release-notes/route.ts
+++ b/apps/web/src/app/api/release-notes/route.ts
@@ -1,0 +1,11 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// 릴리즈 노트 조회(de-hardcode·story 53bc0945) — BE `GET /api/v2/release-notes`(published·newest-first).
+// CRUD(owner/admin)는 v1 범위 밖(시드/관리 API 직접)·후속 admin UI 때 프록시 추가.
+export async function GET(request: Request) {
+  const _r = await proxyToFastapi(request, '/api/v2/release-notes');
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess([]);
+  return apiSuccess(await _r.json());
+}

--- a/apps/web/src/components/release-notes/release-notes-dialog.tsx
+++ b/apps/web/src/components/release-notes/release-notes-dialog.tsx
@@ -12,20 +12,21 @@ import {
 } from '@/components/ui/dialog';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { RELEASE_NOTES, type ReleaseNote } from '@/lib/release-notes';
+import { type ReleaseNote } from '@/lib/release-notes';
 
 interface ReleaseNotesDialogProps {
   open: boolean;
   onClose: () => void;
+  notes: ReleaseNote[];
 }
 
-export function ReleaseNotesDialog({ open, onClose }: ReleaseNotesDialogProps) {
+export function ReleaseNotesDialog({ open, onClose, notes }: ReleaseNotesDialogProps) {
   const [view, setView] = useState<'latest' | 'list'>('latest');
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
   const note: ReleaseNote | undefined = selectedId
-    ? RELEASE_NOTES.find((n) => n.id === selectedId)
-    : RELEASE_NOTES[0];
+    ? notes.find((n) => n.id === selectedId)
+    : notes[0];
 
   const reset = () => {
     setView('latest');
@@ -42,7 +43,25 @@ export function ReleaseNotesDialog({ open, onClose }: ReleaseNotesDialogProps) {
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-md rounded-xl">
-        {view === 'latest' && note ? (
+        {notes.length === 0 ? (
+          <>
+            <DialogHeader className="space-y-2">
+              <span className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-info">
+                <Sparkles className="h-3.5 w-3.5" aria-hidden />
+                What&apos;s new
+              </span>
+              <DialogTitle className="text-base">릴리즈 노트</DialogTitle>
+              <DialogDescription className="text-sm text-muted-foreground">
+                아직 새로운 소식이 없어요. 업데이트가 준비되면 여기에서 알려드릴게요.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button variant="hero" size="sm" onClick={() => handleOpenChange(false)}>
+                확인
+              </Button>
+            </DialogFooter>
+          </>
+        ) : view === 'latest' && note ? (
           <>
             <DialogHeader className="space-y-2">
               <span className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-info">
@@ -101,7 +120,7 @@ export function ReleaseNotesDialog({ open, onClose }: ReleaseNotesDialogProps) {
               <DialogDescription className="sr-only">이전 릴리즈 노트 목록</DialogDescription>
             </DialogHeader>
             <ul className="divide-y divide-border overflow-hidden rounded-md border border-border">
-              {RELEASE_NOTES.map((n) => (
+              {notes.map((n) => (
                 <li key={n.id}>
                   <button
                     type="button"

--- a/apps/web/src/components/release-notes/release-notes-gate.tsx
+++ b/apps/web/src/components/release-notes/release-notes-gate.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
-import { LATEST_RELEASE_NOTE_ID } from '@/lib/release-notes';
+import { fetchReleaseNotes, type ReleaseNote } from '@/lib/release-notes';
 import { ReleaseNotesDialog } from './release-notes-dialog';
 
 interface ReleaseNotesContextValue {
@@ -29,30 +29,44 @@ export function ReleaseNotesProvider({ userId, children }: ReleaseNotesProviderP
   const [open, setOpen] = useState(false);
   const [seenId, setSeenId] = useState<string | null>(null);
   const [ready, setReady] = useState(false);
+  const [notes, setNotes] = useState<ReleaseNote[]>([]);
 
-  // mount 後 localStorage 읽기 (SSR hydration 불일치 방지). 미열람 최신 노트면 auto-open.
+  // de-hardcode(53bc0945): 노트는 API 에서 로드. 최신 노트 id = notes[0]?.id (서버 newest-first).
+  const latestId = notes[0]?.id ?? null;
+
+  // mount 後 노트 fetch + localStorage 읽기(SSR hydration 불일치 방지). 미열람 최신 노트면 auto-open.
   useEffect(() => {
     if (!userId) return;
-    try {
-      const seen = localStorage.getItem(seenKey(userId));
-      setSeenId(seen);
-      if (LATEST_RELEASE_NOTE_ID && seen !== LATEST_RELEASE_NOTE_ID) setOpen(true);
-    } catch {
-      // localStorage 차단 환경 — gate 무동작
-    } finally {
-      setReady(true);
-    }
+    let cancelled = false;
+    void (async () => {
+      const fetched = await fetchReleaseNotes();
+      if (cancelled) return;
+      setNotes(fetched);
+      try {
+        const seen = localStorage.getItem(seenKey(userId));
+        setSeenId(seen);
+        const latest = fetched[0]?.id ?? null;
+        if (latest && seen !== latest) setOpen(true);
+      } catch {
+        // localStorage 차단 환경 — gate 무동작
+      } finally {
+        setReady(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, [userId]);
 
   const markSeen = useCallback(() => {
-    if (!userId || !LATEST_RELEASE_NOTE_ID) return;
+    if (!userId || !latestId) return;
     try {
-      localStorage.setItem(seenKey(userId), LATEST_RELEASE_NOTE_ID);
+      localStorage.setItem(seenKey(userId), latestId);
     } catch {
       // ignore
     }
-    setSeenId(LATEST_RELEASE_NOTE_ID);
-  }, [userId]);
+    setSeenId(latestId);
+  }, [userId, latestId]);
 
   const handleOpen = useCallback(() => setOpen(true), []);
   const handleClose = useCallback(() => {
@@ -60,7 +74,7 @@ export function ReleaseNotesProvider({ userId, children }: ReleaseNotesProviderP
     setOpen(false);
   }, [markSeen]);
 
-  const hasUnseen = ready && LATEST_RELEASE_NOTE_ID != null && seenId !== LATEST_RELEASE_NOTE_ID;
+  const hasUnseen = ready && latestId != null && seenId !== latestId;
 
   // userId 없으면 gate skip (셸은 인증 後라 보통 존재)
   if (!userId) return <>{children}</>;
@@ -68,7 +82,7 @@ export function ReleaseNotesProvider({ userId, children }: ReleaseNotesProviderP
   return (
     <ReleaseNotesContext.Provider value={{ open: handleOpen, hasUnseen }}>
       {children}
-      <ReleaseNotesDialog open={open} onClose={handleClose} />
+      <ReleaseNotesDialog open={open} onClose={handleClose} notes={notes} />
     </ReleaseNotesContext.Provider>
   );
 }

--- a/apps/web/src/components/storage/storage-capacity-banner.tsx
+++ b/apps/web/src/components/storage/storage-capacity-banner.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { AlertOctagon, AlertTriangle, X } from 'lucide-react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+import { isEEEnabled } from '@/lib/ee';
+import { formatStorageSize } from '@/lib/storage/format';
+import { cn } from '@/lib/utils';
+
+/** 세션 한정 dismiss 키 — warning 배너만 사용. 다음 세션에도 ≥80%면 재노출(영구 숨김 금지). */
+const WARN_DISMISS_KEY = 'storage-capacity-warn-dismissed';
+
+interface StorageUsage {
+  used: number;
+  limit: number;
+  pct: number;
+}
+
+/**
+ * S8 — 스토리지 용량 경고 배너 (story 4fbb10c1).
+ * `/api/assets/storage-usage` 를 마운트 시 1회(no-polling) 조회해 2-심각도로 노출:
+ *   - 80–99% → warning(amber)·세션 dismiss 가능(sessionStorage)·다음 세션 재노출
+ *   - 100%+  → block(red)·non-dismissible(실 차단 상태 은폐 방지)
+ * <80% 또는 fetch 실패 → 아무것도 렌더하지 않음(graceful, 에러 표면 없음).
+ * 색상은 Alert variant + bg-warning/bg-destructive 토큰만 사용(하드코딩 금지·양 테마 대응).
+ */
+export function StorageCapacityBanner() {
+  const t = useTranslations('storage');
+  const router = useRouter();
+  const { orgId, orgMemberships } = useDashboardContext();
+
+  const [usage, setUsage] = useState<StorageUsage | null>(null);
+  // 세션 dismiss 플래그 복원(이번 세션 한정) — lazy initializer.
+  // 배너는 usage 로드(클라이언트) 전엔 null 렌더라 SSR/hydration 불일치 없음.
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    try {
+      return sessionStorage.getItem(WARN_DISMISS_KEY) === '1';
+    } catch {
+      // sessionStorage 접근 불가 환경 — dismiss 비활성(배너 노출 유지)
+      return false;
+    }
+  });
+
+  // 마운트 1회 조회(폴링 없음·취소 안전).
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch('/api/assets/storage-usage');
+        if (!res.ok) return;
+        const json = (await res.json()) as {
+          data?: { used_bytes?: number; limit_bytes?: number; percentage?: number };
+        };
+        const d = json.data;
+        if (!d) return;
+        // percentage 가 유한수일 때만 채택 — limit_bytes 0/null(무제한·OSS) → BE 가 NaN/Infinity/null
+        // 줄 수 있고, NaN < 80 은 false 라 가드 없으면 깨진(NaN%) 배너가 렌더된다(div0 방어).
+        // (typeof 로 number 내로잉 + isFinite 로 NaN/Infinity 배제.)
+        const pct = d.percentage;
+        if (typeof pct !== 'number' || !Number.isFinite(pct)) return;
+        if (cancelled) return;
+        setUsage({
+          used: d.used_bytes ?? 0,
+          limit: d.limit_bytes ?? 0,
+          pct,
+        });
+      } catch {
+        // 조회 실패는 치명적이지 않음 — 배너 미노출(에러 표면 없음)
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // <80% 또는 미조회 → 미노출.
+  if (!usage || usage.pct < 80) return null;
+
+  const isBlock = usage.pct >= 100;
+  // warning 만 세션 dismiss 적용·block 은 항상 노출(non-dismissible).
+  if (!isBlock && dismissed) return null;
+
+  const role = orgMemberships.find((o) => o.orgId === orgId)?.role;
+  const canManage = role === 'owner' || role === 'admin';
+  // 업그레이드 CTA = 권한(owner/admin) + billing 탭 EE 게이트 모두 충족 시에만.
+  const showUpgrade = canManage && isEEEnabled();
+
+  const roundedPct = Math.round(usage.pct);
+  const title = isBlock ? t('capacityBlockTitle') : t('capacityWarnTitle');
+  const desc = isBlock
+    ? t('capacityBlockDesc')
+    : canManage
+      ? t('capacityWarnDesc', { pct: roundedPct })
+      : t('capacityWarnDescNoManage', { pct: roundedPct });
+
+  const handleDismiss = () => {
+    try {
+      sessionStorage.setItem(WARN_DISMISS_KEY, '1');
+    } catch {
+      // 영속 실패해도 이번 렌더에선 숨김 처리
+    }
+    setDismissed(true);
+  };
+
+  return (
+    <Alert variant={isBlock ? 'destructive' : 'warning'}>
+      {isBlock ? <AlertOctagon className="size-4" /> : <AlertTriangle className="size-4" />}
+      <AlertTitle>{title}</AlertTitle>
+      <AlertDescription>{desc}</AlertDescription>
+
+      {/* 사용량 바 */}
+      <div className="col-start-2 mt-2">
+        <div
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={roundedPct}
+          aria-label={`${formatStorageSize(usage.used)} / ${formatStorageSize(usage.limit)} · ${roundedPct}%`}
+          className="h-1.5 w-full overflow-hidden rounded-full bg-muted"
+        >
+          <div
+            className={cn('h-full rounded-full', isBlock ? 'bg-destructive' : 'bg-warning')}
+            style={{ width: `${Math.min(100, usage.pct)}%` }}
+          />
+        </div>
+        <p className="mt-1.5 text-xs text-muted-foreground">
+          {t.rich('capacityUsage', {
+            used: formatStorageSize(usage.used),
+            limit: formatStorageSize(usage.limit),
+            pct: roundedPct,
+            b: (chunks) => <b className="font-semibold text-foreground">{chunks}</b>,
+          })}
+        </p>
+      </div>
+
+      {/* CTA — 파일 관리는 block 상태에서도 primary(red-on-red 금지) */}
+      <div className="col-start-2 mt-2 flex flex-wrap gap-2">
+        <Button size="sm" variant="default" onClick={() => router.push('/storage')}>
+          {t('capacityManageFiles')}
+        </Button>
+        {showUpgrade && (
+          <Button size="sm" variant="outline" onClick={() => router.push('/settings?tab=billing')}>
+            {t('capacityUpgrade')}
+          </Button>
+        )}
+      </div>
+
+      {/* 세션 dismiss — warning 만. block 은 dismiss 없음. */}
+      {!isBlock && (
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="absolute right-2 top-2"
+          aria-label={t('capacityDismiss')}
+          onClick={handleDismiss}
+        >
+          <X className="size-4" />
+        </Button>
+      )}
+    </Alert>
+  );
+}

--- a/apps/web/src/components/storage/storage-capacity-toast-provider.tsx
+++ b/apps/web/src/components/storage/storage-capacity-toast-provider.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useTranslations } from 'next-intl';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+import { ToastContainer, useToast } from '@/components/ui/toast';
+
+/** 세션 1회 가드 — 같은 세션 새로고침 시 토스트 재노출 방지. */
+const TOAST_SHOWN_KEY = 'storage-capacity-toast-shown';
+
+/**
+ * S8 — 글로벌 스토리지 용량 session-toast (story 4fbb10c1).
+ * /storage 밖에 있는 유저에게도 ≥80% 임박을 앱 로드 1회 알린다(폴링 없음·세션 1회).
+ * 토스트는 정보 전용(액션 링크 미지원 — addToast 는 {title, body?, type} 만) → CTA 는 배너가 담당.
+ * 100%+ 는 destructive 톤(type='error')으로 "업로드 중단" 고지.
+ */
+export function StorageCapacityToastProvider({ children }: { children: React.ReactNode }) {
+  const t = useTranslations('storage');
+  const { orgId } = useDashboardContext();
+  const { toasts, addToast, dismissToast } = useToast();
+  const ranRef = useRef(false);
+
+  useEffect(() => {
+    // 인증 컨텍스트 준비(orgId) + 세션 1회만.
+    if (!orgId || ranRef.current) return;
+    try {
+      if (sessionStorage.getItem(TOAST_SHOWN_KEY) === '1') {
+        ranRef.current = true;
+        return;
+      }
+    } catch {
+      // sessionStorage 불가 — 가드 없이 1회 진행
+    }
+    ranRef.current = true;
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch('/api/assets/storage-usage');
+        if (!res.ok) return;
+        const json = (await res.json()) as { data?: { percentage?: number } };
+        const pct = json.data?.percentage;
+        // 유한수 가드 — limit_bytes 0/null(무제한) → NaN/Infinity 가능(div0 방어). NaN<80=false 회피.
+        if (cancelled || typeof pct !== 'number' || !Number.isFinite(pct) || pct < 80) return;
+        const roundedPct = Math.round(pct);
+        const isBlock = pct >= 100;
+        addToast({
+          type: isBlock ? 'error' : 'warning',
+          title: t('capacityToastTitle', { pct: roundedPct }),
+          body: isBlock ? t('capacityToastDescBlock') : t('capacityToastDesc'),
+        });
+        try {
+          sessionStorage.setItem(TOAST_SHOWN_KEY, '1');
+        } catch {
+          // 영속 실패 무시
+        }
+      } catch {
+        // 조회 실패는 치명적이지 않음 — 토스트 미노출
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [orgId, addToast, t]);
+
+  return (
+    <>
+      {children}
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+    </>
+  );
+}

--- a/apps/web/src/components/storage/storage-view.tsx
+++ b/apps/web/src/components/storage/storage-view.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { useContextualPanelState } from '@/components/ui/contextual-panel-layout';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { formatTotalSize } from '@/lib/storage/format';
+import { StorageCapacityBanner } from './storage-capacity-banner';
 import { StorageFolderTree } from './storage-folder-tree';
 import { StorageAssetList } from './storage-asset-list';
 import { StorageDetailPanel } from './storage-detail-panel';
@@ -244,6 +245,10 @@ export function StorageView() {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <TopBarSlot title={topBarTitle} />
+
+      <div className="px-4 pt-3 empty:hidden">
+        <StorageCapacityBanner />
+      </div>
 
       <div
         className={cn(

--- a/apps/web/src/lib/release-notes.ts
+++ b/apps/web/src/lib/release-notes.ts
@@ -6,7 +6,7 @@ export interface ReleaseNoteItem {
 export interface ReleaseNote {
   id: string;
   version: string;
-  /** 표시용 문자열 (정렬/비교는 배열 순서·id로) */
+  /** 표시용 문자열 (정렬/비교는 서버 published_at·id로) */
   publishedAt: string;
   title: string;
   summary: string;
@@ -14,44 +14,18 @@ export interface ReleaseNote {
 }
 
 /**
- * newest-first. ⚠️ 어느 릴리즈를 어떤 문구로 알릴지는 PO/product 콜 — 아래는 대표 시드(구조 검증용).
- * id = 가시성 비교 키(localStorage seen 과 대조). 실제 노트 추가/문구는 PO가 갱신.
+ * 릴리즈 노트는 BE(`release_notes` 테이블)에서 데이터주도로 제공된다(de-hardcode·story 53bc0945).
+ * `GET /api/release-notes` → newest-first published. id = 가시성 비교 키(localStorage seen 과 대조).
+ * 노트 추가/문구는 관리 CRUD(또는 시드)로 — 코드 편집/배포 불필요.
+ * 실패/빈 응답은 `[]` (호출부가 빈상태 graceful·gate auto-open 안 함).
  */
-export const RELEASE_NOTES: ReleaseNote[] = [
-  {
-    id: '2026-06-v1-4',
-    version: 'v1.4',
-    publishedAt: '2026년 6월',
-    title: '멀티계정 전환과 알림 도달 확인이 생겼어요',
-    summary: '로그아웃 없이 계정을 오가고, 알림이 실제로 도달했는지 한눈에 확인하세요.',
-    items: [
-      { text: '여러 계정을 추가해 로그아웃 없이 전환합니다.' },
-      { text: '알림 목적지를 한 화면에서 보고·끄고·실제 도달을 테스트합니다.' },
-      { text: '에이전트 추가를 모달 한 곳에서 끝냅니다.' },
-    ],
-  },
-  {
-    id: '2026-06-v1-3',
-    version: 'v1.3',
-    publishedAt: '2026년 6월',
-    title: '온보딩이 2분이면 끝나요',
-    summary: '설정 하나를 붙여넣고, 실제로 작동하는지 바로 확인합니다.',
-    items: [
-      { text: '에이전트 연결 설정을 한 번에 복사합니다.' },
-      { text: '연결 확인 레일로 실제 동작을 직접 검증합니다.' },
-    ],
-  },
-  {
-    id: '2026-05-v1-2',
-    version: 'v1.2',
-    publishedAt: '2026년 5월',
-    title: '보드가 더 부드러워졌어요',
-    summary: '칸반 보드 드래그와 모바일 사용성을 개선했습니다.',
-    items: [
-      { text: '카드 드래그·드롭 정확도를 높였습니다.' },
-      { text: '모바일에서 보드 스크롤이 매끄러워졌습니다.' },
-    ],
-  },
-];
-
-export const LATEST_RELEASE_NOTE_ID = RELEASE_NOTES[0]?.id ?? null;
+export async function fetchReleaseNotes(): Promise<ReleaseNote[]> {
+  try {
+    const res = await fetch('/api/release-notes', { credentials: 'same-origin' });
+    if (!res.ok) return [];
+    const body = (await res.json()) as { data?: ReleaseNote[] };
+    return Array.isArray(body?.data) ? body.data : [];
+  } catch {
+    return [];
+  }
+}

--- a/apps/web/src/lib/storage/format.ts
+++ b/apps/web/src/lib/storage/format.ts
@@ -102,6 +102,23 @@ export function formatTotalSize(bytes: number): string {
   return `${(mb / 1024).toFixed(1)} GB`;
 }
 
+/**
+ * 스토리지 용량 포맷(S8 용량 경고 배너) — formatTotalSize 는 GB 상한이라 TB 한도(엔터프라이즈
+ * 플랜)에서 "5120.0 GB" 같이 깨진다. B/KB/MB/GB/TB 까지 커버하는 용량 전용 포맷터.
+ * 예: 5368709120 → "5.0 GB", 0 → "0 B".
+ */
+export function formatStorageSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return '0 B';
+  if (bytes < 1024) return `${Math.round(bytes)} B`;
+  const kb = bytes / 1024;
+  if (kb < 1024) return `${kb.toFixed(1)} KB`;
+  const mb = kb / 1024;
+  if (mb < 1024) return `${mb.toFixed(1)} MB`;
+  const gb = mb / 1024;
+  if (gb < 1024) return `${gb.toFixed(1)} GB`;
+  return `${(gb / 1024).toFixed(1)} TB`;
+}
+
 /** ISO → YYYY-MM-DD (상세 메타 '생성' 행). */
 export function formatDate(iso: string): string {
   const t = new Date(iso).getTime();

--- a/backend/alembic/versions/0142_add_release_notes.py
+++ b/backend/alembic/versions/0142_add_release_notes.py
@@ -1,0 +1,109 @@
+"""E-POLISH 53bc0945: release_notes 테이블 — 하드코딩 RELEASE_NOTES de-hardcode + 시드.
+
+릴노트 제품 전역(org 무관) 글로벌 테이블. note_key = FE localStorage seen-key("2026-06-v1-4")·무회귀.
+시드 = 기존 v1.2~v1.4(release-notes.ts const 무손실 이관) + v1.5 스토리지 노트(파일첨부·썸네일) 추가.
+
+idempotent: 테이블 inspect 가드(시드는 create 직후만). downgrade = drop.
+"""
+from __future__ import annotations
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision = "0142"
+down_revision = "0141"
+branch_labels = None
+depends_on = None
+
+
+_SEED = [
+    {
+        "note_key": "2026-05-v1-2", "version": "v1.2",
+        "published_at": "2026-05-15 00:00:00+00", "display_period": "2026년 5월",
+        "title": "보드가 더 부드러워졌어요",
+        "summary": "칸반 보드 드래그와 모바일 사용성을 개선했습니다.",
+        "items": [
+            {"text": "카드 드래그·드롭 정확도를 높였습니다."},
+            {"text": "모바일에서 보드 스크롤이 매끄러워졌습니다."},
+        ],
+    },
+    {
+        "note_key": "2026-06-v1-3", "version": "v1.3",
+        "published_at": "2026-06-10 00:00:00+00", "display_period": "2026년 6월",
+        "title": "온보딩이 2분이면 끝나요",
+        "summary": "설정 하나를 붙여넣고, 실제로 작동하는지 바로 확인합니다.",
+        "items": [
+            {"text": "에이전트 연결 설정을 한 번에 복사합니다."},
+            {"text": "연결 확인 레일로 실제 동작을 직접 검증합니다."},
+        ],
+    },
+    {
+        "note_key": "2026-06-v1-4", "version": "v1.4",
+        "published_at": "2026-06-20 00:00:00+00", "display_period": "2026년 6월",
+        "title": "멀티계정 전환과 알림 도달 확인이 생겼어요",
+        "summary": "로그아웃 없이 계정을 오가고, 알림이 실제로 도달했는지 한눈에 확인하세요.",
+        "items": [
+            {"text": "여러 계정을 추가해 로그아웃 없이 전환합니다."},
+            {"text": "알림 목적지를 한 화면에서 보고·끄고·실제 도달을 테스트합니다."},
+            {"text": "에이전트 추가를 모달 한 곳에서 끝냅니다."},
+        ],
+    },
+    {
+        "note_key": "2026-06-v1-5", "version": "v1.5",
+        "published_at": "2026-06-26 00:00:00+00", "display_period": "2026년 6월",
+        "title": "파일 첨부와 미리보기가 생겼어요",
+        "summary": "문서에 파일과 이미지를 첨부하고, 스토리지에서 한곳에 모아 확인하세요.",
+        "items": [
+            {"text": "문서 본문에 파일과 이미지를 첨부합니다."},
+            {"text": "첨부한 파일을 스토리지에서 한눈에 관리합니다."},
+            {"text": "이미지 썸네일로 내용을 빠르게 확인합니다."},
+        ],
+    },
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    if "release_notes" in set(insp.get_table_names()):
+        return  # idempotent
+
+    op.create_table(
+        "release_notes",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text("gen_random_uuid()")),
+        sa.Column("note_key", sa.Text(), nullable=False),
+        sa.Column("version", sa.Text(), nullable=False),
+        sa.Column("published_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("display_period", sa.Text(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=False, server_default=""),
+        sa.Column("items", JSONB(), nullable=False, server_default=sa.text("'[]'::jsonb")),
+        sa.Column("is_published", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.text("now()")),
+    )
+    op.create_unique_constraint("uq_release_notes_note_key", "release_notes", ["note_key"])
+    op.create_index("ix_release_notes_published_at", "release_notes", ["published_at"])
+    op.create_index("ix_release_notes_is_published", "release_notes", ["is_published"])
+
+    # 시드(create 직후만·무손실 이관 + v1.5 추가). id/타임스탬프는 server_default.
+    ins = sa.text(
+        "INSERT INTO release_notes (note_key, version, published_at, display_period, title, summary, items) "
+        "VALUES (:note_key, :version, :published_at, :display_period, :title, :summary, CAST(:items AS jsonb))"
+    )
+    for n in _SEED:
+        op.execute(ins.bindparams(
+            note_key=n["note_key"], version=n["version"], published_at=n["published_at"],
+            display_period=n["display_period"], title=n["title"], summary=n["summary"],
+            items=json.dumps(n["items"], ensure_ascii=False),
+        ))
+
+
+def downgrade() -> None:
+    op.drop_table("release_notes")

--- a/backend/alembic/versions/0143_release_notes_v15_capacity_item.py
+++ b/backend/alembic/versions/0143_release_notes_v15_capacity_item.py
@@ -1,0 +1,36 @@
+"""E-INFRA ③ B: v1.5 릴노트에 스토리지 용량경고 항목 추가 (de-hardcode 데이터·dev+prod 일관).
+
+선생님 결정: 1.6 아님·v1.5 에 += . S8 용량경고(실 라이브 기능)를 v1.5 items 에 append. 데이터주도지만
+prod 일관·baseline 재현 위해 migration(0142 seed 위 idempotent UPDATE).
+
+idempotent: 이미 그 항목이 있으면(items @> ) skip. v1.5 행 없으면(미시드) no-op.
+"""
+from __future__ import annotations
+
+import json
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0143"
+down_revision = "0142"
+branch_labels = None
+depends_on = None
+
+_NOTE_KEY = "2026-06-v1-5"
+_ITEM = [{"text": "저장공간이 한도에 가까워지면 미리 알려드려요."}]
+
+
+def upgrade() -> None:
+    item_json = json.dumps(_ITEM, ensure_ascii=False)
+    op.execute(
+        sa.text(
+            "UPDATE release_notes SET items = items || CAST(:item AS jsonb) "
+            "WHERE note_key = :k AND NOT (items @> CAST(:item AS jsonb))"
+        ).bindparams(item=item_json, k=_NOTE_KEY)
+    )
+
+
+def downgrade() -> None:
+    # 항목 제거(best-effort·jsonb - 는 객체 배열 직접 미지원이라 재구성). 무손실 롤백 위해 no-op 허용.
+    pass

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -15,15 +15,21 @@ class Settings(BaseSettings):
     cloud_sql_instance_dev: str = "sprintable-494803:asia-northeast3:sprintable-dev"
     cloud_sql_instance_prod: str = "sprintable-494803:asia-northeast3:sprintable-prod"
 
-    # E-INFRA S2: DB 커넥션 풀 right-size (env DB_POOL_SIZE / DB_MAX_OVERFLOW로 override).
-    # 산식: (maxScale × (pool_size + max_overflow)) + admin/migration headroom ≤ max_connections.
-    #   prod(sprintable-prod db-g1-small, max_connections=100, maxScale=10):
-    #     10 × (5 + 3) = 80  + ~20 headroom(superuser_reserved 3 + migrate-prod 잡 + 수동 admin) = 100 ✓
-    #   dev(maxScale=3): 3 × (5+3)=24 로 여유 큼 — 필요 시 env로 상향(예 10/20) 독립 right-size.
-    # ⚠️ --concurrency=80(인스턴스당 동시 HTTP 요청)과 별개: 풀은 **DB op 점유 구간만** 커넥션을 잡고
-    #    즉시 반납하므로 80 동시요청 ≠ 80 커넥션. pool+overflow 초과분은 pool_timeout 대기(실패 아님).
-    db_pool_size: int = 5
-    db_max_overflow: int = 3
+    # E-INFRA S2 + ee7794eb: DB 커넥션 풀 **rollout-safe** right-size (env DB_POOL_SIZE/DB_MAX_OVERFLOW override).
+    # ⚠️ 배포 rollout 時 old+new 리비전이 **동시 점유(2×)** — steady 산식만 쓰면 배포 중 max_connections
+    #    초과(2026-06-29 dev TooManyConnections·#1766 rollout 전요청 500). **인스턴스당 실 커넥션은 pool
+    #    밖의 raw 연결까지** 포함해야 한다(까심 적출): pg_pubsub.listen_loop = raw asyncpg **상시 1개**(pool
+    #    미점유). (l2_worker 는 engine.connect→pool 내·추가 0.) → **per_instance = (pool+overflow) + RAW(1) = 5.**
+    #    rollout-aware 산식: **2 × maxScale × ((pool+overflow) + RAW) + admin/migration headroom ≤ max_connections.**
+    #   ① 앱 최소요구(실측): pool+overflow ≥ 4 (total 3 이면 send_message pool_timeout). ∴ pool 3/1=4 고정(밑으로 불가).
+    #   ② dev(f1-micro ~25·maxScale 실측 10→PO **1** 적용 rev 01240-hkc): 2×1×5+5 = 15 ≤ 25 (여유 10).
+    #      (maxScale 2 면 25/25 한계·1 로 여유 확보. 10 이면 2×10×5+5=105≫25 → pool 4 단독 불가·maxScale↓ 필수.)
+    #   ③ prod(g1-small 100·maxScale **실측 필수**): 2×10×5+20=120 > 100(가정 10이면 초과). 안전 상한 maxScale≤8
+    #      (2×8×5+20=100·여유 0). **prod 승격 前 PgBouncer(durable·연결 decouple) 또는 tier↑ 필수**(maxScale 캡만으론 0 headroom).
+    # ⚠️ 향후 always-on LISTEN/raw 연결 추가 시 RAW 카운트 ++ 동반(산식 누락 = 이번 false-PASS 재발).
+    # ⚠️ --concurrency=80 과 별개: 풀은 DB op 점유 구간만 잡고 즉시 반납·초과분 pool_timeout 대기(실패 아님).
+    db_pool_size: int = 3
+    db_max_overflow: int = 1
 
     # PgBouncer ④: 사이드카(localhost:6432·pool_mode=transaction) 경유 여부(env DB_PGBOUNCER).
     # off(기본): 직접 Cloud SQL — 현 동작 100% 유지(사이드카 없어도 다운 X).

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -10,6 +10,11 @@ class Settings(BaseSettings):
     # Cloud SQL Unix socket 연결 예시 (Cloud Run 등):
     #   postgresql+asyncpg://sprintable:PASSWORD@/sprintable?host=/cloudsql/sprintable:asia-northeast3:sprintable-dev
     database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:54322/postgres"
+    # ee7794eb ③: DB_PGBOUNCER on 時 DATABASE_URL 은 PgBouncer(transaction-mode) 를 가리키는데, pg_pubsub
+    # raw LISTEN/NOTIFY 는 transaction-mode 비호환(연결이 statement 마다 반납돼 LISTEN 상태 소실) → **direct
+    # Cloud SQL URL 별도**로 우회. 미설정 시 database_url 폴백(non-PgBouncer 환경). on+미설정 = startup
+    # fail-closed(pg_pubsub.check_listen_config·main lifespan).
+    database_url_direct: str = ""
 
     # Cloud SQL (D-S1: Phase D GCP 인프라)
     cloud_sql_instance_dev: str = "sprintable-494803:asia-northeast3:sprintable-dev"

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -5,12 +5,13 @@ from sqlalchemy.orm import DeclarativeBase
 
 from app.core.config import settings
 
-# S20/E-INFRA S2: DB 풀 right-size — SSE는 대기 구간에서 커넥션 미점유(개별 세션 패턴).
-# 인스턴스당 최대 커넥션 = pool_size + max_overflow. 클러스터 총합 = maxScale × (pool_size+overflow).
-# ⚠️ 산식: (maxScale × (pool_size+max_overflow)) + admin/migration headroom ≤ Cloud SQL max_connections.
-#   prod(db-g1-small max_connections=100, maxScale=10): 10×(5+3)=80 + ~20 headroom = 100 ✓
-#   (이전 10/20=30/instance × 10 = 300 > 100 → 고갈 위험이라 right-size)
-# env DB_POOL_SIZE / DB_MAX_OVERFLOW로 환경별 독립 조정(config.py 산식 주석 참조).
+# S20/E-INFRA S2 + ee7794eb: DB 풀 **rollout-safe** right-size — SSE는 대기 구간 커넥션 미점유(개별 세션).
+# ⚠️ 인스턴스당 실 커넥션 = (pool_size+max_overflow) + **pool 밖 raw 연결**(pg_pubsub.listen_loop 상시 1·
+#   l2_worker 는 pool 내). rollout(old+new 2×) 반영: 2×maxScale×((pool+overflow)+RAW)+headroom ≤ max_connections.
+#   per_instance = 4(pool 3/1) + RAW 1 = **5**. (pool 4 는 앱최소·밑으로 불가.)
+#   dev(~25·maxScale 10→PO 1): 2×1×5+5=15 ≤ 25(여유 10). prod(100·maxScale 실측필수): 2×10×5+20=120>100 →
+#   maxScale≤8(2×8×5+20=100·여유0) + ③ 승격 前 PgBouncer/tier↑ 필수. 향후 raw 추가 시 RAW++ (config.py 산식).
+# env DB_POOL_SIZE / DB_MAX_OVERFLOW로 조정하되 상향은 rollout 여유(tier↑/maxScale↓/PgBouncer) 동반.
 def _build_engine_kwargs() -> dict:
     """create_async_engine 인자를 DB_PGBOUNCER flag로 분기.
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -20,9 +20,10 @@ _logger = logging.getLogger(__name__)
 async def lifespan(app: FastAPI):
     from app.core.database import engine
     from app.routers.verdict_capture import warn_if_webhook_secret_misconfigured
-    from app.services.pg_pubsub import listen_loop
+    from app.services.pg_pubsub import check_listen_config, listen_loop
 
     warn_if_webhook_secret_misconfigured()  # Bot-M.2 P3: 웹훅 secret misconfig 를 트래픽 前 경고.
+    check_listen_config()  # ee7794eb ③ fail-closed: DB_PGBOUNCER on + DATABASE_URL_DIRECT 없으면 startup raise.
     task = asyncio.create_task(listen_loop())
     # E-L2 S5: 휴리스틱 트리거 워커는 default-off — 명시 활성화 시에만 task 생성(AC①).
     l2_task = None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -56,7 +56,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -147,6 +147,7 @@ app.include_router(events.router)
 app.include_router(agent_gateway.router)
 app.include_router(dispatch.router)
 app.include_router(assets.router)
+app.include_router(release_notes.router)
 app.include_router(conversations.router)
 app.include_router(presence.router)
 app.include_router(sprints.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -38,9 +38,11 @@ from app.models.project_access import ProjectAccess
 from app.models.member import AgentProjectProfile, Member, MemberIdentityAlias
 from app.models.activity_event import ActivityEvent
 from app.models.asset import Asset, AssetFolder, AssetLink
+from app.models.release_note import ReleaseNote
 
 __all__ = [
     "ActivityEvent",
+    "ReleaseNote",
     "Asset",
     "AssetFolder",
     "AssetLink",

--- a/backend/app/models/release_note.py
+++ b/backend/app/models/release_note.py
@@ -1,0 +1,44 @@
+"""릴리즈 노트 모델(E-POLISH 53bc0945·선생님 직접) — 하드코딩 RELEASE_NOTES 배열 de-hardcode.
+
+릴노트는 **제품 전역**(전 org 동일)이라 org_id 없는 글로벌 테이블. `note_key`(text unique)는 FE
+localStorage seen-key("2026-06-v1-4")와 동일 값 — 가시성 비교 무회귀 핵심. 정렬은 `published_at`
+(timestamp) desc = newest-first. `display_period`("2026년 6월")는 표시용. CRUD = org owner/admin
+(platform-admin 롤 부재·v1).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Text, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin
+
+
+class ReleaseNote(Base, TimestampMixin):
+    """릴리즈 노트 1건(제품 전역·org 무관)."""
+
+    __tablename__ = "release_notes"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    # FE localStorage seen-key 와 동일 문자열("2026-06-v1-4") — 가시성 비교 무회귀. unique.
+    note_key: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    version: Mapped[str] = mapped_column(Text, nullable=False)
+    # 정렬 기준(newest-first). display_period 는 표시 전용(정렬 불가 "2026년 6월").
+    published_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
+    display_period: Mapped[str] = mapped_column(Text, nullable=False)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    summary: Mapped[str] = mapped_column(Text, nullable=False, server_default="", default="")
+    # [{text: str, href?: str}, ...]
+    items: Mapped[list] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb"), default=list
+    )
+    is_published: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("true"), default=True, index=True
+    )

--- a/backend/app/routers/release_notes.py
+++ b/backend/app/routers/release_notes.py
@@ -1,0 +1,161 @@
+"""릴리즈 노트 API(E-POLISH 53bc0945) — 하드코딩 RELEASE_NOTES de-hardcode.
+
+GET = published 노트(newest-first·전 org 공통·authed user). CRUD = org owner/admin(platform-admin 롤
+부재·v1). response 는 FE `ReleaseNote` shape 그대로(`note_key→id`·`display_period→publishedAt`) 매핑해
+dialog 무회귀. id(=note_key)는 FE localStorage seen-key 와 동일.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.models.release_note import ReleaseNote
+from app.services.project_auth import is_org_owner_or_admin
+
+router = APIRouter(prefix="/api/v2/release-notes", tags=["release-notes"])
+
+
+class ReleaseNoteItemModel(BaseModel):
+    text: str
+    href: str | None = None
+
+
+class ReleaseNoteResponse(BaseModel):
+    id: str  # = note_key (FE seen-key·가시성 비교)
+    version: str
+    publishedAt: str  # = display_period(표시 문자열)
+    title: str
+    summary: str
+    items: list[ReleaseNoteItemModel]
+
+
+class ReleaseNoteCreate(BaseModel):
+    note_key: str = Field(min_length=1)
+    version: str = Field(min_length=1)
+    published_at: datetime
+    display_period: str = Field(min_length=1)
+    title: str = Field(min_length=1)
+    summary: str = ""
+    items: list[ReleaseNoteItemModel] = Field(default_factory=list)
+    is_published: bool = True
+
+
+class ReleaseNoteUpdate(BaseModel):
+    version: str | None = None
+    published_at: datetime | None = None
+    display_period: str | None = None
+    title: str | None = None
+    summary: str | None = None
+    items: list[ReleaseNoteItemModel] | None = None
+    is_published: bool | None = None
+
+
+def _to_response(row: ReleaseNote) -> ReleaseNoteResponse:
+    return ReleaseNoteResponse(
+        id=row.note_key,
+        version=row.version,
+        publishedAt=row.display_period,
+        title=row.title,
+        summary=row.summary,
+        items=[ReleaseNoteItemModel(**i) if isinstance(i, dict) else i for i in (row.items or [])],
+    )
+
+
+async def _require_admin(session: AsyncSession, auth, org_id: uuid.UUID) -> None:
+    """CRUD = org owner/admin(canonical project_auth·ad-hoc role 금지). platform-admin 롤 부재로 유일 옵션."""
+    if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
+        raise HTTPException(status_code=403, detail="릴리즈 노트 관리는 org owner/admin 만 가능합니다.")
+
+
+@router.get("", response_model=list[ReleaseNoteResponse])
+async def list_release_notes(
+    session: AsyncSession = Depends(get_db),
+    _auth=Depends(get_current_user),
+) -> list[ReleaseNoteResponse]:
+    """published 릴노트 newest-first(published_at desc). 전역(org 무관)·authed user."""
+    rows = (
+        await session.execute(
+            select(ReleaseNote)
+            .where(ReleaseNote.is_published.is_(True))
+            .order_by(ReleaseNote.published_at.desc())
+        )
+    ).scalars().all()
+    return [_to_response(r) for r in rows]
+
+
+@router.post("", response_model=ReleaseNoteResponse, status_code=201)
+async def create_release_note(
+    body: ReleaseNoteCreate,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> ReleaseNoteResponse:
+    await _require_admin(session, auth, org_id)
+    dup = (await session.execute(
+        select(ReleaseNote.id).where(ReleaseNote.note_key == body.note_key)
+    )).scalar_one_or_none()
+    if dup is not None:
+        raise HTTPException(status_code=409, detail="같은 note_key 의 릴노트가 이미 있습니다.")
+    row = ReleaseNote(
+        note_key=body.note_key,
+        version=body.version,
+        published_at=body.published_at,
+        display_period=body.display_period,
+        title=body.title,
+        summary=body.summary,
+        items=[i.model_dump(exclude_none=True) for i in body.items],
+        is_published=body.is_published,
+    )
+    session.add(row)
+    await session.commit()
+    await session.refresh(row)
+    return _to_response(row)
+
+
+@router.patch("/{note_key}", response_model=ReleaseNoteResponse)
+async def update_release_note(
+    note_key: str,
+    body: ReleaseNoteUpdate,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> ReleaseNoteResponse:
+    await _require_admin(session, auth, org_id)
+    row = (await session.execute(
+        select(ReleaseNote).where(ReleaseNote.note_key == note_key)
+    )).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="릴노트를 찾을 수 없습니다.")
+    data = body.model_dump(exclude_unset=True)
+    if "items" in data and data["items"] is not None:
+        data["items"] = [i.model_dump(exclude_none=True) if hasattr(i, "model_dump")
+                         else i for i in body.items]
+    for k, v in data.items():
+        setattr(row, k, v)
+    await session.commit()
+    await session.refresh(row)
+    return _to_response(row)
+
+
+@router.delete("/{note_key}", status_code=204)
+async def delete_release_note(
+    note_key: str,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth=Depends(get_current_user),
+) -> None:
+    await _require_admin(session, auth, org_id)
+    row = (await session.execute(
+        select(ReleaseNote).where(ReleaseNote.note_key == note_key)
+    )).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="릴노트를 찾을 수 없습니다.")
+    await session.delete(row)
+    await session.commit()

--- a/backend/app/services/pg_pubsub.py
+++ b/backend/app/services/pg_pubsub.py
@@ -101,17 +101,36 @@ async def _dispatch_received(payload_str: str) -> None:
         logger.warning("pg_listen dispatch failed target=%s: %s", target, exc)
 
 
+def _resolve_listen_url(s=None) -> str:
+    """LISTEN raw 연결 URL — ee7794eb ③: DB_PGBOUNCER on 時 transaction-mode PgBouncer 는 LISTEN/NOTIFY
+    미지원이라 **direct Cloud SQL**(database_url_direct)로 우회. 미설정 폴백=database_url(non-PgBouncer)."""
+    if s is None:
+        from app.core.config import settings as s
+    return (s.database_url_direct or s.database_url).replace("postgresql+asyncpg://", "postgresql://", 1)
+
+
+def check_listen_config(s=None) -> None:
+    """fail-closed: DB_PGBOUNCER on 인데 direct URL 없으면 raise — LISTEN 이 PgBouncer 경유로 깨지는
+    misconfig 를 startup서 차단(silent 이벤트 유실 방지). main lifespan 이 create_task 前 호출."""
+    if s is None:
+        from app.core.config import settings as s
+    if s.db_pgbouncer and not s.database_url_direct:
+        raise RuntimeError(
+            "DB_PGBOUNCER=on requires DATABASE_URL_DIRECT — pg_pubsub LISTEN 은 transaction-mode "
+            "PgBouncer 비호환이라 direct Cloud SQL URL 필수 (fail-closed·ee7794eb ③)."
+        )
+
+
 async def listen_loop() -> None:
     """PG LISTEN 수신 루프. lifespan startup에서 background task로 실행.
 
-    - raw asyncpg 전용 커넥션 1개 (SQLAlchemy pool 미점유)
+    - raw asyncpg 전용 커넥션 1개 (SQLAlchemy pool 미점유·DB_PGBOUNCER 시 direct Cloud SQL 우회)
     - 연결 실패 시 exponential backoff 1s→2s→4s→max 30s
     - CancelledError 수신 시 커넥션 정리 후 종료
     """
     import asyncpg
-    from app.core.config import settings
 
-    raw_url = settings.database_url.replace("postgresql+asyncpg://", "postgresql://", 1)
+    raw_url = _resolve_listen_url()
     delay = 1.0
 
     logger.info("pg_listen starting on channel=%s instance=%s", _CHANNEL, INSTANCE_ID)

--- a/backend/tests/test_e_infra_s2_pool.py
+++ b/backend/tests/test_e_infra_s2_pool.py
@@ -1,13 +1,28 @@
-"""E-INFRA S2: DB 풀 right-size — prod max_connections=100 고갈 방지.
+"""E-INFRA S2 + ee7794eb: DB 풀 **rollout-safe** right-size — max_connections 고갈 방지.
 
-산식: (maxScale × (pool_size + max_overflow)) + headroom ≤ max_connections.
-prod(db-g1-small): max_connections=100, maxScale=10 → pool+overflow ≤ 8/instance.
+⚠️ 인스턴스당 실 커넥션 = (pool+overflow) + **pool 밖 raw 연결**. pg_pubsub.listen_loop 가 raw asyncpg
+상시 1개(pool 미점유)를 잡는다(까심 적출 — 직전 산식이 이를 누락해 prod 테스트가 false-PASS). l2_worker 는
+engine.connect→pool 내(추가 0). → per_instance = (pool+overflow) + RAW.
+
+rollout(old+new 2×) 산식: **2 × maxScale × ((pool+overflow) + RAW) + headroom ≤ max_connections.**
+  per_instance = 4(pool 3/1·앱최소) + RAW 1 = 5.
+  dev(~25·maxScale 10→PO 1): 2×1×5+5 = 15 ≤ 25(여유 10). prod(100·maxScale 실측필수): 2×10×5+20=120>100
+  → maxScale≤8(2×8×5+20=100·여유0) + PgBouncer/tier↑(③ 승격 前). 향후 raw 추가 시 RAW++.
 """
 from app.core.config import Settings
 
+ROLLOUT = 2  # 배포 중 old+new 리비전 동시 점유
+RAW_PER_INSTANCE = 1  # pg_pubsub.listen_loop raw asyncpg(pool 밖·상시). ⚠️ always-on LISTEN 추가 시 ++.
+
 PROD_MAX_CONNECTIONS = 100
-PROD_MAX_SCALE = 10
-HEADROOM = 20  # superuser_reserved(3) + migrate-prod 잡 + 수동 admin
+PROD_MAX_SCALE_ASSUMED = 10  # ⚠️ 가정 — ③ prod 승격 前 gcloud 실측 필수
+PROD_HEADROOM = 20
+
+DEV_MAX_CONNECTIONS = 25  # sprintable-dev db-f1-micro
+DEV_MAX_SCALE = 1  # PO 적용(rev 01240-hkc): dev maxScale 10→1 (2×1×5+5=15≤25·여유 10)
+DEV_HEADROOM = 5
+
+APP_MIN_PER_INSTANCE = 4  # 실측: total 3 이면 send_message pool_timeout
 
 
 def _clear_pool_env(monkeypatch):
@@ -15,29 +30,61 @@ def _clear_pool_env(monkeypatch):
     monkeypatch.delenv("DB_MAX_OVERFLOW", raising=False)
 
 
-def test_default_pool_fits_prod_max_connections(monkeypatch):
+def _effective_per_instance(s) -> int:
+    """실 커넥션 = pool+overflow + pool 밖 raw(pg_pubsub). 산식은 반드시 raw 포함(false-PASS 방지)."""
+    return s.db_pool_size + s.db_max_overflow + RAW_PER_INSTANCE
+
+
+def test_default_pool_min_viable_for_app(monkeypatch):
+    """앱 최소요구(pool+overflow ≥ 4) — total 3 이면 send_message pool_timeout(실측)."""
     _clear_pool_env(monkeypatch)
     s = Settings()
-    per_instance = s.db_pool_size + s.db_max_overflow
-    cluster_total = PROD_MAX_SCALE * per_instance + HEADROOM
-    assert cluster_total <= PROD_MAX_CONNECTIONS, (
-        f"prod 풀 고갈 위험: {PROD_MAX_SCALE}×{per_instance}+{HEADROOM}={cluster_total} > {PROD_MAX_CONNECTIONS}"
+    assert s.db_pool_size + s.db_max_overflow >= APP_MIN_PER_INSTANCE
+
+
+def test_effective_per_instance_counts_raw_connection(monkeypatch):
+    """⚠️ 산식이 pool 밖 raw 연결(pg_pubsub +1)을 포함하는지 — 직전 false-PASS 회귀 게이트."""
+    _clear_pool_env(monkeypatch)
+    s = Settings()
+    assert _effective_per_instance(s) == s.db_pool_size + s.db_max_overflow + RAW_PER_INSTANCE
+    assert _effective_per_instance(s) == 5  # pool 4 + raw 1 (현 기본)
+
+
+def test_dev_rollout_within_limit_at_applied_maxscale(monkeypatch):
+    """dev(maxScale 1·PO 적용)가 rollout(raw 포함) 중 한도 내 — 인시던트 직접 회귀 게이트(2×1×5+5=15≤25)."""
+    _clear_pool_env(monkeypatch)
+    s = Settings()
+    eff = _effective_per_instance(s)
+    total = ROLLOUT * DEV_MAX_SCALE * eff + DEV_HEADROOM
+    assert total <= DEV_MAX_CONNECTIONS, (
+        f"dev rollout 고갈: 2×{DEV_MAX_SCALE}×{eff}+{DEV_HEADROOM}={total} > {DEV_MAX_CONNECTIONS}"
     )
-    assert per_instance <= 8, f"인스턴스당 {per_instance} > 8 (maxScale 10 기준 초과)"
+
+
+def test_prod_assumed_maxscale_exceeds_needs_cap_and_pooler(monkeypatch):
+    """⚠️ raw 포함 시 prod 가정 maxScale 10 은 한도 초과 — ③ 승격 前 maxScale≤8 + PgBouncer/tier 필수.
+
+    (이 테스트가 'prod@10 안전' false 가정을 차단·실 연결수 산식을 문서화.)
+    """
+    _clear_pool_env(monkeypatch)
+    s = Settings()
+    eff = _effective_per_instance(s)
+    at_assumed = ROLLOUT * PROD_MAX_SCALE_ASSUMED * eff + PROD_HEADROOM
+    assert at_assumed > PROD_MAX_CONNECTIONS  # 120 > 100 — prod@10 초과(블로커 문서화)
+    safe_max_scale = (PROD_MAX_CONNECTIONS - PROD_HEADROOM) // (ROLLOUT * eff)
+    assert safe_max_scale == 8  # 안전 상한(여유 0·PgBouncer/tier 권장)
 
 
 def test_pool_env_configurable(monkeypatch):
-    # dev는 maxScale 3이라 여유 큼 — env로 상향 가능
-    monkeypatch.setenv("DB_POOL_SIZE", "10")
-    monkeypatch.setenv("DB_MAX_OVERFLOW", "20")
+    monkeypatch.setenv("DB_POOL_SIZE", "6")
+    monkeypatch.setenv("DB_MAX_OVERFLOW", "2")
     s = Settings()
-    assert s.db_pool_size == 10
-    assert s.db_max_overflow == 20
+    assert s.db_pool_size == 6
+    assert s.db_max_overflow == 2
 
 
 def test_engine_uses_settings_pool():
     from app.core import database
     from app.core.config import settings
-    # 엔진 풀이 settings 값을 반영 (하드코딩 아님)
     assert database.engine.pool.size() == settings.db_pool_size
     assert database.engine.pool._max_overflow == settings.db_max_overflow

--- a/backend/tests/test_pg_pubsub_listen_url.py
+++ b/backend/tests/test_pg_pubsub_listen_url.py
@@ -1,0 +1,43 @@
+"""ee7794eb ③: pg_pubsub LISTEN raw URL — DB_PGBOUNCER 時 direct Cloud SQL 우회 + fail-closed 가드.
+
+transaction-mode PgBouncer 는 LISTEN/NOTIFY 미지원 → DB_PGBOUNCER on 이면 raw LISTEN 은 database_url_direct
+(direct Cloud SQL)로 가야 한다. on 인데 direct 미설정은 startup fail-closed(silent 이벤트 유실 차단).
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.pg_pubsub import _resolve_listen_url, check_listen_config
+
+
+def _s(database_url, database_url_direct="", db_pgbouncer=False):
+    return SimpleNamespace(
+        database_url=database_url, database_url_direct=database_url_direct, db_pgbouncer=db_pgbouncer
+    )
+
+
+def test_resolve_uses_direct_when_set():
+    # DB_PGBOUNCER on: DATABASE_URL=PgBouncer·LISTEN 은 direct 로.
+    s = _s("postgresql+asyncpg://pgb:6432/db", "postgresql+asyncpg://cloudsql/db", db_pgbouncer=True)
+    assert _resolve_listen_url(s) == "postgresql://cloudsql/db"  # direct·asyncpg 접두 제거
+
+
+def test_resolve_falls_back_to_database_url_when_no_direct():
+    # non-PgBouncer(off): direct 미설정 → database_url 폴백(현 동작 유지).
+    s = _s("postgresql+asyncpg://cloudsql/db")
+    assert _resolve_listen_url(s) == "postgresql://cloudsql/db"
+
+
+def test_check_raises_when_pgbouncer_on_without_direct():
+    # fail-closed: on + direct 없음 → raise(LISTEN 깨짐 차단).
+    s = _s("postgresql+asyncpg://pgb:6432/db", "", db_pgbouncer=True)
+    with pytest.raises(RuntimeError, match="DATABASE_URL_DIRECT"):
+        check_listen_config(s)
+
+
+def test_check_ok_when_pgbouncer_off():
+    check_listen_config(_s("postgresql+asyncpg://cloudsql/db"))  # off → no raise
+
+
+def test_check_ok_when_pgbouncer_on_with_direct():
+    check_listen_config(_s("pgb", "direct", db_pgbouncer=True))  # on + direct → no raise

--- a/backend/tests/test_pgbouncer_config.py
+++ b/backend/tests/test_pgbouncer_config.py
@@ -3,7 +3,7 @@
 engine은 import-time 단일 생성이라 flag별 재생성이 어렵다 → 분기 로직을
 database._build_engine_kwargs()로 추출해 settings 토글 → 인자 검증으로 커버한다.
 
-- off(기본): pool_size=5/overflow=3 + connect_args 비움(statement_cache_size 없음)
+- off(기본): pool_size=3/overflow=1(rollout-safe·앱최소 4·ee7794eb) + connect_args 비움(statement_cache_size 없음)
 - on:        pool_size=2/overflow=1 + connect_args={"statement_cache_size": 0}
 """
 from __future__ import annotations
@@ -18,8 +18,8 @@ def test_settings_defaults_flag_off():
     assert s.db_pgbouncer is False
     assert s.db_pgbouncer_pool_size == 2
     assert s.db_pgbouncer_max_overflow == 1
-    assert s.db_pool_size == 5
-    assert s.db_max_overflow == 3
+    assert s.db_pool_size == 3  # ee7794eb: rollout-safe·앱최소(≥4=3+1) default
+    assert s.db_max_overflow == 1
 
 
 def test_settings_flag_on_via_env(monkeypatch):

--- a/backend/tests/test_release_notes_realdb.py
+++ b/backend/tests/test_release_notes_realdb.py
@@ -49,6 +49,8 @@ async def test_list_returns_seeded_newest_first():
             v15 = next(r for r in out if r.id == "2026-06-v1-5")
             assert v15.version == "v1.5" and v15.publishedAt == "2026년 6월"  # display_period→publishedAt
             assert v15.items and v15.items[0].text  # JSONB items 매핑
+            # 0143(v1.5 += 용량경고·de-hardcode 데이터): 스토리지 용량경고 항목 append(idempotent).
+            assert any("저장공간" in i.text for i in v15.items), "v1.5 용량경고 항목 누락(0143)"
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_release_notes_realdb.py
+++ b/backend/tests/test_release_notes_realdb.py
@@ -1,0 +1,115 @@
+"""E-POLISH 53bc0945: release_notes API + 시드 realdb. DB env 없으면 skip(CI alembic-fresh).
+
+마이그 0142 가 테이블+시드(v1.2~v1.5) 생성 → list 가 4개 published newest-first·shape(id=note_key·
+publishedAt=display_period) 반환. CRUD 는 owner/admin(is_org_owner_or_admin) 게이트.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth():
+    a = MagicMock()
+    a.user_id = str(uuid.uuid4())
+    return a
+
+
+@pytest.mark.anyio
+async def test_list_returns_seeded_newest_first():
+    from app.routers.release_notes import list_release_notes
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            out = await list_release_notes(session=s, _auth=_auth())
+            keys = [r.id for r in out]
+            # 시드 4개가 newest-first(v1.5→v1.2)로 선두에(다른 테스트가 추가했을 수 있어 포함 검사).
+            assert "2026-06-v1-5" in keys and "2026-05-v1-2" in keys
+            idx = {k: i for i, k in enumerate(keys)}
+            assert idx["2026-06-v1-5"] < idx["2026-06-v1-4"] < idx["2026-06-v1-3"] < idx["2026-05-v1-2"]
+            v15 = next(r for r in out if r.id == "2026-06-v1-5")
+            assert v15.version == "v1.5" and v15.publishedAt == "2026년 6월"  # display_period→publishedAt
+            assert v15.items and v15.items[0].text  # JSONB items 매핑
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_requires_owner_admin():
+    from app.routers.release_notes import ReleaseNoteCreate, create_release_note
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    key = f"test-{uuid.uuid4()}"
+    body = ReleaseNoteCreate(
+        note_key=key, version="vT", published_at="2026-07-01T00:00:00+00:00",
+        display_period="2026년 7월", title="T", summary="s", items=[{"text": "x"}],
+    )
+    try:
+        async with Session() as s:
+            # 비-admin → 403
+            with patch("app.routers.release_notes.is_org_owner_or_admin",
+                       new_callable=AsyncMock, return_value=False):
+                with pytest.raises(HTTPException) as e:
+                    await create_release_note(body=body, session=s, org_id=ORG, auth=_auth())
+                assert e.value.status_code == 403
+            # admin → 201 생성
+            with patch("app.routers.release_notes.is_org_owner_or_admin",
+                       new_callable=AsyncMock, return_value=True):
+                created = await create_release_note(body=body, session=s, org_id=ORG, auth=_auth())
+                assert created.id == key and created.version == "vT"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unpublished_excluded_and_patch_delete():
+    from app.routers.release_notes import (
+        ReleaseNoteCreate,
+        ReleaseNoteUpdate,
+        create_release_note,
+        delete_release_note,
+        list_release_notes,
+        update_release_note,
+    )
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    key = f"unpub-{uuid.uuid4()}"
+    try:
+        with patch("app.routers.release_notes.is_org_owner_or_admin",
+                   new_callable=AsyncMock, return_value=True):
+            async with Session() as s:
+                # 미발행 생성 → list 제외.
+                await create_release_note(
+                    body=ReleaseNoteCreate(
+                        note_key=key, version="vU", published_at="2026-08-01T00:00:00+00:00",
+                        display_period="2026년 8월", title="U", summary="", items=[], is_published=False),
+                    session=s, org_id=ORG, auth=_auth())
+                assert key not in [r.id for r in await list_release_notes(session=s, _auth=_auth())]
+                # patch 발행 → list 포함.
+                await update_release_note(note_key=key, body=ReleaseNoteUpdate(is_published=True),
+                                          session=s, org_id=ORG, auth=_auth())
+                assert key in [r.id for r in await list_release_notes(session=s, _auth=_auth())]
+                # delete.
+                await delete_release_note(note_key=key, session=s, org_id=ORG, auth=_auth())
+                assert key not in [r.id for r in await list_release_notes(session=s, _auth=_auth())]
+    finally:
+        await engine.dispose()

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,11 +11,11 @@ substitutions:
   _DEPLOY_ENV: dev
   _FASTAPI_URL: https://sprintable-backend-dev-787818285179.asia-northeast3.run.app
   _BACKEND_MIN_INSTANCES: '1'
-  # ⚠️ maxScale 10 = 429 포화 인시던트(2026-06-09) 後. 6(#1325)은 부하에 인스턴스 포화→429 유발.
-  #    #1330 statement_cache revert로 쿼리 가속→연결 빠른 회전→10×8=80 < DB 100 viable(peak 여유).
-  #    수렴 history: 3(#1319前·sat)→10(#1319·churn)→6(#1325·429 sat)→10(#1330 가속·viable).
-  #    durable fix는 2c4dcae7 PgBouncer(연결 decouple·maxScale 30+)·랜딩 後 상향. 그 前까지 10.
-  #    (GHA develop→dev·main→prod 자동배포가 이 default 주입 → 6이면 머지마다 429 재발 latent → 10.)
+  # ⚠️ 이 값은 **GHA cloud-build.yml 이 per-env override**(dev=1·prod=10) — 이 default 는 수동 빌드 fallback.
+  #    maxScale 10 history: 429 포화(2026-06-09)→#1330 가속→steady 10×8=80<100 "viable" 판단이었으나
+  #    **rollout(old+new 2×) 누락**이었음(ee7794eb·dev TooManyConnections). rollout per-instance = pool(4)
+  #    + pg_pubsub raw(1) = 5 → 2×10×5+20=120 > 100. 즉 maxScale 10 은 **PgBouncer(DB_PGBOUNCER·연결
+  #    decouple) 또는 tier↑ 전제**. dev(f1-micro 25)는 maxScale 1(2×1×5+5=15≤25)로 cloud-build.yml 에서 강제.
   _BACKEND_MAX_INSTANCES: '10'
   _GA4_MEASUREMENT_ID: ""  # dev 기본값 빈 문자열 — prod 트리거에서 G-RYHFE7XM3X 주입
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,12 +11,14 @@ substitutions:
   _DEPLOY_ENV: dev
   _FASTAPI_URL: https://sprintable-backend-dev-787818285179.asia-northeast3.run.app
   _BACKEND_MIN_INSTANCES: '1'
-  # ⚠️ 이 값은 **GHA cloud-build.yml 이 per-env override**(dev=1·prod=10) — 이 default 는 수동 빌드 fallback.
-  #    maxScale 10 history: 429 포화(2026-06-09)→#1330 가속→steady 10×8=80<100 "viable" 판단이었으나
-  #    **rollout(old+new 2×) 누락**이었음(ee7794eb·dev TooManyConnections). rollout per-instance = pool(4)
-  #    + pg_pubsub raw(1) = 5 → 2×10×5+20=120 > 100. 즉 maxScale 10 은 **PgBouncer(DB_PGBOUNCER·연결
-  #    decouple) 또는 tier↑ 전제**. dev(f1-micro 25)는 maxScale 1(2×1×5+5=15≤25)로 cloud-build.yml 에서 강제.
-  _BACKEND_MAX_INSTANCES: '10'
+  # ⚠️ default '1'(아래) = _DEPLOY_ENV:dev default 와 정합한 **dev-safe fallback**(수동 `gcloud builds submit`
+  #    override 없을 때 maxScale 10 trap=2×10×5+5=105>25 재현 차단). GHA cloud-build.yml 이 per-env override(prod=5·dev=1).
+  #    rollout-safe 산식(ee7794eb·dev TooManyConnections 인시던트): **2 × maxScale × (pool+overflow + raw) +
+  #    headroom ≤ max_conn**. per-instance = pool(3/1=4) + pg_pubsub raw(1) = 5.
+  #    prod(g1-small 100): maxScale **5** → 2×5×5+20=70 ≤ 100 ✓(선생님 right-size·여유 30). 10 은 120>100 폐기.
+  #    dev(f1-micro 25): maxScale 1 → 2×1×5+5=15 ≤ 25 ✓. (PgBouncer 풀러: Cloud Run raw TCP 미지원으로 중앙
+  #    불가·관리형 풀링 Enterprise Plus 전용 → 채택 안 함. 트래픽↑ 時 tier업 동반해야 maxScale 상향.)
+  _BACKEND_MAX_INSTANCES: '1'
   _GA4_MEASUREMENT_ID: ""  # dev 기본값 빈 문자열 — prod 트리거에서 G-RYHFE7XM3X 주입
 
 steps:


### PR DESCRIPTION
## ③ prod 출시 (E-INFRA ③ 연결안전 + 출시노트 de-hardcode + storage S8)

선생님 결정: maxScale right-size (중앙 PgBouncer 폐기 — Cloud Run raw TCP 미지원·Cloud SQL 관리형풀링 Enterprise Plus 전용으로 둘 다 불가).

### 포함 (release 브랜치·develop→main)
- 출시노트 de-hardcode (#1772) + v1.5 += 용량경고 항목 (#1778·mig 0143)
- storage S8 용량경고 배너 (#1774)
- DB 풀 right-size 3/1 (#1773) + maxScale 5 (#1779·rollout 2×5×5+20=70≤100·여유30·cloudbuild default 1 trap 제거)
- pg_pubsub LISTEN direct URL + fail-closed 가드 (#1776·dormant)

### 연결안전 검증
- prod g1-small max_conn 100·maxScale 5 → rollout worst 81≤100
- prod DB preflight 0142+0143 선적용 完 (0141→0143)
- dry-run 머지 클린·충돌 0·doc-gate(prod-blocker·reverted) 재유입 0 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)