### PR TITLE
[SID:b5870c4c] fix: MCP list_backlog 422 shadow — 기존 stories+no_sprint 재사용

### DIFF
--- a/backend/sprintable_mcp/tools/stories.py
+++ b/backend/sprintable_mcp/tools/stories.py
@@ -79,8 +79,13 @@ async def list_stories(args: ListStoriesInput) -> list[TextContent]:
 
 async def list_backlog(args: SprintableInput) -> list[TextContent]:
     """백로그 스토리 목록 (스프린트 미배정)."""
+    # b5870c4c: 전용 `/stories/backlog` 라우트 부재 → `/{id}` 로 shadow 돼 422(id="backlog" 非-UUID).
+    # 기존 list 엔드포인트 + `no_sprint` 필터(server-side repo.list_backlog·sprint 미배정·docstring 정합) 재사용.
+    # ⚠️ no_sprint 는 project_id 와 함께여야 backlog 분기 동작(stories.py list_stories).
     try:
-        return ok(await client.get("/api/v2/stories/backlog", params={"project_id": client.project_id}))
+        return ok(await client.get(
+            "/api/v2/stories", params={"project_id": client.project_id, "no_sprint": "true"}
+        ))
     except Exception as exc:
         return err(str(exc))
 

--- a/backend/tests/test_mcp_list_backlog_b5870c4c.py
+++ b/backend/tests/test_mcp_list_backlog_b5870c4c.py
@@ -1,0 +1,32 @@
+"""b5870c4c: MCP list_backlog 이 존재하는 엔드포인트를 호출하는지 회귀 게이트.
+
+버그: `sprintable_list_backlog` 가 `GET /api/v2/stories/backlog`(부재 라우트) 호출 → `/{id}` 로 shadow 돼
+422(id="backlog" 非-UUID). fix(B): 기존 `GET /api/v2/stories` + `no_sprint`(server-side repo.list_backlog·
+sprint 미배정·tool docstring 정합) 재사용. 신규 라우트 0.
+"""
+import pytest
+
+from sprintable_mcp.tools import stories as st
+
+
+@pytest.mark.anyio
+async def test_list_backlog_targets_existing_endpoint_with_no_sprint(monkeypatch):
+    captured: dict = {}
+
+    class _FakeClient:
+        project_id = "proj-1"
+        org_id = None
+
+        async def get(self, path, params=None):
+            captured["path"] = path
+            captured["params"] = params or {}
+            return []
+
+    monkeypatch.setattr(st, "client", _FakeClient())
+    await st.list_backlog(None)
+
+    # 부재 라우트(/stories/backlog) 호출 금지 — /{id} shadow→422 의 근본.
+    assert captured["path"] == "/api/v2/stories", captured
+    # no_sprint(+project_id)로 server-side backlog(sprint 미배정) 분기.
+    assert captured["params"].get("no_sprint") == "true"
+    assert captured["params"].get("project_id") == "proj-1"


### PR DESCRIPTION
## MCP list_backlog 422 shadow 해소 (E-MCP-HTTP 6/6)

**버그**: `sprintable_list_backlog`(`sprintable_mcp/tools/stories.py`)가 `GET /api/v2/stories/backlog` 호출 → stories 라우터에 `/backlog` 부재라 **`GET /{id}` 로 shadow**(id="backlog") → `422`(non-UUID). transport 무관(stdio·http)·list_backlog latent broken.

**fix (옵션 B·표면 최소·신규 라우트 0)**: 기존 `GET /api/v2/stories` + `no_sprint=true`(+`project_id`) 재사용. 이 조합이 server-side `repo.list_backlog`(sprint 미배정·deleted 제외)를 반환 → tool docstring "스프린트 미배정" 의미와 정합. (옵션 A 전용 라우트는 `/{id}` 앞 정의 필요·surface↑라 미채택.)

**검증**: list_backlog 가 `/api/v2/stories`(부재 `/stories/backlog` 아님) + `no_sprint` 호출 회귀 게이트 1 pass·ruff clean·마이그 없음.

→ **E-MCP-HTTP 6/6** 닫힘.

🤖 Generated with [Claude Code](https://claude.com/claude-code)