### PR TITLE
[SID:ed904b9d] L2 sprint deadline collect 테스트 — AC③ 잠금 (E-L2 verify-close)

### DIFF
--- a/backend/tests/test_l2_trigger_worker.py
+++ b/backend/tests/test_l2_trigger_worker.py
@@ -199,6 +199,33 @@ async def test_collect_epic_deadlines_dispatchable_anchor():
     assert pair_org == org and d.anchor_type in ("epic", "story", "doc")  # dispatchable.
 
 
+@pytest.mark.anyio
+async def test_collect_sprint_deadlines_dispatchable_anchor():
+    """ed904b9d AC③: sprint deadline → wake. sprint 은 assignee 컬럼 없음 → _fetch_entity 가 relay-owner 로
+    target 해소(S27). dispatchable anchor 라 L2 firing 이 wake skip 안 됨."""
+    w = L2TriggerWorker(use_advisory_lock=False)
+    owner, org, sprint_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    now = datetime.now(timezone.utc)
+    rows = [{
+        "id": sprint_id, "org_id": org,
+        # sprint 윈도우=deadline_sprint_end_h(24h). collect 가 end_date를 당일 23:59:59 로 combine 하므로
+        # 오늘 날짜면 remaining ≤ 24h → 임박 발사(어느 시각이든 안정·non-flaky).
+        "end_date": now.date(),
+        "status": "active",
+    }]
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_rows_result(rows))
+    with patch(
+        "app.services.agent_dispatch._fetch_entity", new_callable=AsyncMock,
+        return_value=(owner, "Sprint", "status=active", uuid.uuid4()),
+    ):
+        pairs = await w._collect_sprint_deadlines(db, now)
+    assert len(pairs) == 1
+    d, pair_org = pairs[0]
+    assert d.anchor_type == "sprint" and d.anchor_id == sprint_id and d.target_agent_id == owner
+    assert pair_org == org
+
+
 # ── S6: dedup 발사 ─────────────────────────────────────────────────────────────
 
 def _decision(anchor_type="epic", seq=None):


### PR DESCRIPTION
## E-L2 dispatch anchor (ed904b9d) — verify + AC③ 테스트 잠금

**실측**: hypothesis + sprint dispatch 는 **이미 구현됨**(E-DG S23 hypothesis·S27 sprint·`READINESS_MATRIX.dispatch_capable=True`·L2 `_fire_one` wake-skip 더는 적용 안 됨). 스토리 설명은 pre-S23/S27 상태 → **verify-close**(코드 0).

AC 커버리지 점검:
- ① hypothesis dispatch — `test_collect_hypothesis_deadlines_pairs_org` ✅(기존)
- ②④ hypothesis wake E2E / 정확 1-wake — `test_fire_one_winner_dispatches`·`test_concurrent_dedup_exactly_one_winner` ✅(기존)
- ③ **sprint wake — 직접 테스트 부재** → 이 PR이 추가.

`test_collect_sprint_deadlines_dispatchable_anchor`: sprint(assignee 컬럼 無)→`_fetch_entity` relay-owner 해소(S27)·`deadline_sprint_end_h`(24h) 윈도우 내 발사·`anchor_type='sprint'`·target=relay-owner. (작성 중 24h 윈도우 적발 — end_date 당일로 정합·non-flaky.)

### 검증
l2_worker 17 + dispatch 4 pass·ruff clean·**코드 무변경(테스트만)**.

### 노트
스토리는 sprint target="risk story agent"인데 실 구현은 **relay-owner**(sprint에 assignee 컬럼 부재). AC "sprint wake"는 충족. risk-story-agent 가 hard req면 별도 follow-up(현 relay-owner 가 합리적 landing).

→ 머지 시 ed904b9d done → **E-L2 9/9 auto-close**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)