### PR TITLE
[SID:f5ee8387] H2 audit (b) anchor==legacy parity — member-SSOT cut 전제 (read-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
           JWT_SECRET: ci-test-secret-at-least-32-chars-long
           SECRET_KEY: ci-test-secret-at-least-32-chars-long
-        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py tests/test_release_notes_realdb.py -q
+        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py tests/test_release_notes_realdb.py tests/test_audit_apikey_parity_realdb.py -q
 
       - name: Verify fresh DB reached head (baseline + incremental)
         working-directory: backend

--- a/backend/scripts/jobs/audit_apikey_member_anchor.py
+++ b/backend/scripts/jobs/audit_apikey_member_anchor.py
@@ -5,9 +5,11 @@ is_active, not deleted)`를 요구한다. 0076은 agent_api_keys 전 row에 memb
 dual-write 했고 0075는 type='agent' team_member만 members에 넣었으므로, **active key 중**
 (a) tm.type != 'agent' 이거나 (b) members(agent) 행이 부재이면 cut-on 시 401(생명선 차단)이 된다.
 
-이 스크립트는 그런 **위반 active key**를 나열한다.
-- 0건  → flag-on 안전 + 0080 FK VALIDATE 통과.
-- 1건+ → 처리 필요: 정당 agent면 members 보정(또는 agent_anchor_sync 재실행), human/오용 key면 무효화.
+이 스크립트는 cut-on 위반 active key 를 **두 축**으로 나열한다(H2 = (a) ∩ (b) 둘 다 0 이어야 cut 안전):
+- **(a) 앵커 부재** — members(agent,active) 부재/NULL/wrong-type → cut-on 401(생명선 차단).
+- **(b) 해소 드리프트** — 유효 앵커가 있어도 anchor 해소(members.id + agent_project_profiles ORDER BY created_at)
+  가 legacy(team_members.id + ORDER BY project_id)와 다른 신원/프로젝트/org 면 cut 후 권한 드리프트.
+- 0건(a∩b∩FK) → flag-on 안전. 1건+ → 처리(앵커부재: members 보정/key 무효화 · 드리프트: 정렬 정합).
 
 env: DATABASE_URL (백엔드 동일, cloud-sql-proxy/in-VPC 경유). 읽기 전용(조회만).
 실행: cd backend && DATABASE_URL=... python -m scripts.jobs.audit_apikey_member_anchor
@@ -47,6 +49,37 @@ WHERE ak.member_id IS NOT NULL
   AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = ak.member_id)
 """
 
+# (b) anchor==legacy 해소 일치(H2 두 번째 축): **유효 앵커가 있어도** cut-on 이 legacy 와 다른 신원/
+# 프로젝트로 해소되면 cut 후 권한 드리프트. legacy(auth.py:136)=team_members ORDER BY project_id LIMIT 1,
+# anchor(auth.py:119)=agent_project_profiles ORDER BY created_at LIMIT 1 → 멀티프로젝트 agent 는 기본
+# 프로젝트가 갈릴 수 있다. member_id≠team_member_id=0075 invariant 파손. org 불일치도 점검.
+PARITY_SQL = """
+SELECT ak.id AS api_key_id, ak.team_member_id, ak.member_id,
+       leg.project_id AS legacy_proj, anc.project_id AS anchor_proj,
+       leg.org_id AS legacy_org, m.org_id AS anchor_org,
+       (ak.member_id IS DISTINCT FROM ak.team_member_id) AS id_mismatch,
+       (anc.project_id IS DISTINCT FROM leg.project_id)  AS proj_mismatch,
+       (m.org_id IS DISTINCT FROM leg.org_id)            AS org_mismatch
+FROM agent_api_keys ak
+JOIN members m ON m.id = ak.member_id
+             AND m.type = 'agent' AND m.is_active AND m.deleted_at IS NULL
+LEFT JOIN LATERAL (
+    SELECT tm.project_id, tm.org_id FROM team_members tm
+    WHERE tm.id = ak.team_member_id AND tm.is_active
+    ORDER BY tm.project_id LIMIT 1
+) leg ON TRUE
+LEFT JOIN LATERAL (
+    SELECT app.project_id FROM agent_project_profiles app
+    WHERE app.member_id = ak.member_id
+    ORDER BY app.created_at ASC LIMIT 1
+) anc ON TRUE
+WHERE ak.revoked_at IS NULL AND (ak.expires_at IS NULL OR ak.expires_at > now())
+  AND ( ak.member_id IS DISTINCT FROM ak.team_member_id
+     OR anc.project_id IS DISTINCT FROM leg.project_id
+     OR m.org_id IS DISTINCT FROM leg.org_id )
+ORDER BY ak.created_at
+"""
+
 
 async def main() -> int:
     if not os.environ.get("DATABASE_URL"):
@@ -55,19 +88,29 @@ async def main() -> int:
     async with async_session_factory() as s:
         rows = (await s.execute(text(AUDIT_SQL))).mappings().all()
         fk_bad = (await s.execute(text(FK_VIOLATION_SQL))).scalar_one()
+        parity = (await s.execute(text(PARITY_SQL))).mappings().all()
 
-    print(f"=== AC2 H2 감사: cut-on 위반 active key {len(rows)}건 ===")
+    print(f"=== (a) cut-on 앵커 부재 위반 active key {len(rows)}건 ===")
     for r in rows:
         print(
             f"  api_key={r['api_key_id']} tm={r['team_member_id']}({r['tm_type']},active={r['tm_active']}) "
             f"member_id={r['member_id']} member_exists={r['member_exists']} cut_ok={r['member_cut_ok']}"
         )
     print(f"=== 0080 FK VALIDATE 위반(members 부재 referent, 전 row) {fk_bad}건 ===")
+    print(f"=== (b) anchor≠legacy 해소 드리프트 active key {len(parity)}건 ===")
+    for r in parity:
+        diverge = ",".join(
+            d for d, on in (("id", r["id_mismatch"]), ("proj", r["proj_mismatch"]), ("org", r["org_mismatch"])) if on
+        )
+        print(
+            f"  api_key={r['api_key_id']} tm={r['team_member_id']} member_id={r['member_id']} diverge=[{diverge}] "
+            f"legacy_proj={r['legacy_proj']} anchor_proj={r['anchor_proj']} legacy_org={r['legacy_org']} anchor_org={r['anchor_org']}"
+        )
 
-    if len(rows) == 0 and fk_bad == 0:
-        print("[PASS] 위반 0건 — flag-on 안전 + 0080 FK VALIDATE 통과 예상")
+    if len(rows) == 0 and fk_bad == 0 and len(parity) == 0:
+        print("[PASS] (a)앵커존재 + (b)해소일치 + FK 모두 0 — flag-on 안전(cut 절대전제 충족)")
         return 0
-    print("[WARN] 위반 존재 — flag-on 전 처리 필요(정당 agent: members 보정 / human·오용: key 무효화)")
+    print("[WARN] 위반 존재 — flag-on 前 처리 필요(앵커부재: members 보정/key 무효화 · 해소드리프트: 기본프로젝트 정렬 정합)")
     return 1
 
 

--- a/backend/tests/test_audit_apikey_parity_realdb.py
+++ b/backend/tests/test_audit_apikey_parity_realdb.py
@@ -1,0 +1,80 @@
+"""f5ee8387 H2 audit (b) parity — anchor≠legacy 해소 드리프트 적출 검증. DB env 없으면 skip(CI alembic-fresh).
+
+핵심 리스크: 멀티프로젝트 agent 의 cut-on 기본 프로젝트가 legacy(team_members ORDER BY project_id)와
+anchor(agent_project_profiles ORDER BY created_at)서 갈릴 수 있다. PARITY_SQL 이 그 드리프트를 잡는지 락.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from scripts.jobs.audit_apikey_member_anchor import PARITY_SQL
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("a5000000-0000-0000-0000-000000000001")
+# P1 < P2 (legacy ORDER BY project_id → P1 선택)
+P1 = uuid.UUID("a5000000-0000-0000-0000-0000000000a1")
+P2 = uuid.UUID("a5000000-0000-0000-0000-0000000000b2")
+M_DIVERGE = uuid.UUID("a5000000-0000-0000-0000-0000000000d1")  # 멀티프로젝트·드리프트
+M_OK = uuid.UUID("a5000000-0000-0000-0000-0000000000e1")       # 단일프로젝트·일치
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _seed(s):
+    for sql in [
+        f"DELETE FROM agent_api_keys WHERE member_id IN ('{M_DIVERGE}','{M_OK}')",
+        f"DELETE FROM agent_project_profiles WHERE member_id IN ('{M_DIVERGE}','{M_OK}')",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','A5','a5org','free')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{P1}','{ORG}','P1'),('{P2}','{ORG}','P2')",
+        "INSERT INTO members (id,org_id,type,name,is_active) VALUES "
+        f"('{M_DIVERGE}','{ORG}','agent','Diverge',true),('{M_OK}','{ORG}','agent','Ok',true)",
+        # M_DIVERGE: P2 프로파일이 더 일찍 생성(anchor=created_at ASC → P2)·legacy=ORDER BY project_id → P1 → 드리프트.
+        "INSERT INTO agent_project_profiles (id,member_id,project_id,agent_role,fakechat_port,created_at) VALUES "
+        f"(gen_random_uuid(),'{M_DIVERGE}','{P2}','dev',9801,'2026-01-01T00:00:00+00'),"
+        f"(gen_random_uuid(),'{M_DIVERGE}','{P1}','dev',9802,'2026-02-01T00:00:00+00')",
+        # M_OK: 단일 프로젝트 → legacy=anchor=P1.
+        "INSERT INTO agent_project_profiles (id,member_id,project_id,agent_role,fakechat_port,created_at) VALUES "
+        f"(gen_random_uuid(),'{M_OK}','{P1}','dev',9803,'2026-01-01T00:00:00+00')",
+        # agent_api_keys: member_id=team_member_id(0075 정합)·active.
+        "INSERT INTO agent_api_keys (id,team_member_id,member_id,key_prefix,key_hash,created_at) VALUES "
+        f"(gen_random_uuid(),'{M_DIVERGE}','{M_DIVERGE}','sk_d','hash_d',now()),"
+        f"(gen_random_uuid(),'{M_OK}','{M_OK}','sk_o','hash_o',now())",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+@pytest.mark.anyio
+async def test_parity_catches_project_default_drift():
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+            rows = (await s.execute(text(PARITY_SQL))).mappings().all()
+            flagged = {r["member_id"]: r for r in rows}
+            # 드리프트 agent 는 잡히고(proj_mismatch·legacy P1·anchor P2)·일치 agent 는 미적출.
+            assert M_DIVERGE in flagged, f"드리프트 미적출: {list(flagged)}"
+            d = flagged[M_DIVERGE]
+            assert d["proj_mismatch"] is True
+            assert str(d["legacy_proj"]) == str(P1) and str(d["anchor_proj"]) == str(P2)
+            assert not d["id_mismatch"] and not d["org_mismatch"]  # id/org 는 일치(proj 만 드리프트)
+            assert M_OK not in flagged, "단일프로젝트 일치 agent 가 false-positive"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## H2 audit — (b) anchor==legacy 해소 parity 추가 (Stage 1 cut 전제)

member-SSOT API-key 컷오버(`member_ssot_apikey_cut` on·auth.py:103) 前 H2 감사. 기존 `audit_apikey_member_anchor.py` 는 **(a) 앵커 존재**만 검사 — **(b) anchor==legacy 해소 일치 누락**이라 유효 앵커여도 cut-on 이 legacy 와 다른 신원/프로젝트로 해소되면 권한 드리프트.

### 핵심 리스크 (b)
- **project-default 갈림**: legacy(auth.py:136)=`team_members ORDER BY project_id LIMIT 1` vs anchor(auth.py:119)=`agent_project_profiles ORDER BY created_at LIMIT 1` → 멀티프로젝트 agent 기본 프로젝트가 cut 전후로 달라질 수 있음.
- `member_id≠team_member_id`(0075 invariant 파손)·org 불일치도 점검.

### 변경 (read-only·코드 무변경)
- `PARITY_SQL`(LATERAL legacy/anchor 비교) 추가. `main` 이 **(a)앵커 + (b)parity + FK 모두 0** 일 때만 PASS(cut 절대전제).
- realdb 테스트: project-default 드리프트 agent 적출 + 단일프로젝트 일치 agent false-positive 0. CI alembic-fresh 등록.

### 검증
parity realdb 1 pass·ruff clean.

### Stage 1 운용 (dev only)
이 감사를 dev DB 에 실행 → **0건 確認**(= flag-on 안전) → dev `member_ssot_apikey_cut` ON → shadow 라이브검증(agent키 HTTP anchor 해소·/me 200·shadow-compare). **prod cut 은 별도 선생님 명시 GO 게이트**(maxScale급 prod-민감). 위반 1건+ 면 flag-on 前 처리(앵커부재: members 보정/key 무효화 · 드리프트: 정렬 정합).

🤖 Generated with [Claude Code](https://claude.com/claude-code)