### PR TITLE
[SID:f5ee8387] H2 audit 정밀화 — cut REGRESSION 게이트 + dead 키 INFO 분리 (follow-up #1784)

### DIFF
--- a/backend/scripts/jobs/audit_apikey_member_anchor.py
+++ b/backend/scripts/jobs/audit_apikey_member_anchor.py
@@ -5,11 +5,13 @@ is_active, not deleted)`를 요구한다. 0076은 agent_api_keys 전 row에 memb
 dual-write 했고 0075는 type='agent' team_member만 members에 넣었으므로, **active key 중**
 (a) tm.type != 'agent' 이거나 (b) members(agent) 행이 부재이면 cut-on 시 401(생명선 차단)이 된다.
 
-이 스크립트는 cut-on 위반 active key 를 **두 축**으로 나열한다(H2 = (a) ∩ (b) 둘 다 0 이어야 cut 안전):
-- **(a) 앵커 부재** — members(agent,active) 부재/NULL/wrong-type → cut-on 401(생명선 차단).
+이 스크립트는 cut **regression** 을 두 축으로 나열한다(H2 = (a) ∩ (b) ∩ FK 모두 0 이어야 cut 안전):
+- **(a) cut regression** — legacy 는 200(active team_members 존재)인데 anchor 는 401(members(agent,active)
+  부재) = flip 으로 실제 깨지는 working 키. legacy 도 이미 401 인 dead 키(inactive tm)는 flip 무관이므로
+  regression 에서 제외하고 INFO(revoke 후보)로만 집계 — '깨지는 키'와 '이미 죽은 키'를 분리.
 - **(b) 해소 드리프트** — 유효 앵커가 있어도 anchor 해소(members.id + agent_project_profiles ORDER BY created_at)
   가 legacy(team_members.id + ORDER BY project_id)와 다른 신원/프로젝트/org 면 cut 후 권한 드리프트.
-- 0건(a∩b∩FK) → flag-on 안전. 1건+ → 처리(앵커부재: members 보정/key 무효화 · 드리프트: 정렬 정합).
+- 0건(a∩b∩FK) → flag-on 안전(dead 키 INFO 는 비차단). 1건+ → 처리(regression: 0075 정합/members 보정 · 드리프트: 정렬 정합).
 
 env: DATABASE_URL (백엔드 동일, cloud-sql-proxy/in-VPC 경유). 읽기 전용(조회만).
 실행: cd backend && DATABASE_URL=... python -m scripts.jobs.audit_apikey_member_anchor
@@ -24,22 +26,34 @@ from sqlalchemy import text
 
 from app.core.database import async_session_factory
 
-# active(미revoke·미만료) key 중 cut-on이 깨질 row: members(agent,active) 부재
+# (a) cut REGRESSION: legacy 가 해소되는데(active team_members 존재) anchor 는 401(members(agent,active) 부재)
+# = flip 으로 **실제 깨지는 working 키**. legacy 도 이미 401 인 dead 키(inactive tm)는 flip 무관이라 제외(INFO).
+# 0075(member_id=team_member_id)면 legacy/anchor 가 동일 members row 라 정합 — regression 은 사실상 0075 파손
+# (id_mismatch)일 때만 발생. members=테이블(1:1)·legacy 판정은 EXISTS 로 → team_members projection VIEW dup 회피.
 AUDIT_SQL = """
 SELECT ak.id            AS api_key_id,
        ak.team_member_id,
        ak.member_id,
-       tm.type          AS tm_type,
-       tm.is_active     AS tm_active,
        (m.id IS NOT NULL) AS member_exists,
-       (m.type = 'agent' AND m.is_active AND m.deleted_at IS NULL) AS member_cut_ok
+       (m.id IS NOT NULL AND m.type = 'agent' AND m.is_active AND m.deleted_at IS NULL) AS member_cut_ok
 FROM agent_api_keys ak
-LEFT JOIN team_members tm ON tm.id = ak.team_member_id
-LEFT JOIN members m       ON m.id = ak.member_id
+LEFT JOIN members m ON m.id = ak.member_id
 WHERE ak.revoked_at IS NULL
   AND (ak.expires_at IS NULL OR ak.expires_at > now())
   AND NOT (m.id IS NOT NULL AND m.type = 'agent' AND m.is_active AND m.deleted_at IS NULL)
+  AND EXISTS (SELECT 1 FROM team_members tm WHERE tm.id = ak.team_member_id AND tm.is_active)
 ORDER BY ak.created_at
+"""
+
+# INFO(게이트 아님): anchor·legacy 둘 다 실패하는 dead 키(inactive tm) — flip 무관(이미 401)·revoke 정리 후보.
+# count(DISTINCT) 로 team_members VIEW dup inflation 제거.
+DEAD_KEYS_SQL = """
+SELECT count(DISTINCT ak.id) FROM agent_api_keys ak
+LEFT JOIN members m ON m.id = ak.member_id
+WHERE ak.revoked_at IS NULL
+  AND (ak.expires_at IS NULL OR ak.expires_at > now())
+  AND NOT (m.id IS NOT NULL AND m.type = 'agent' AND m.is_active AND m.deleted_at IS NULL)
+  AND NOT EXISTS (SELECT 1 FROM team_members tm WHERE tm.id = ak.team_member_id AND tm.is_active)
 """
 
 # 0080 FK VALIDATE 가드와 동일 기준: member_id referent 부재(active 무관 전 row)
@@ -74,6 +88,8 @@ LEFT JOIN LATERAL (
     ORDER BY app.created_at ASC LIMIT 1
 ) anc ON TRUE
 WHERE ak.revoked_at IS NULL AND (ak.expires_at IS NULL OR ak.expires_at > now())
+  -- legacy 가 실제 해소되는 키만(dead 키의 legacy NULL 을 anchor 와 비교해 가짜 드리프트로 잡지 않도록).
+  AND EXISTS (SELECT 1 FROM team_members tm WHERE tm.id = ak.team_member_id AND tm.is_active)
   AND ( ak.member_id IS DISTINCT FROM ak.team_member_id
      OR anc.project_id IS DISTINCT FROM leg.project_id
      OR m.org_id IS DISTINCT FROM leg.org_id )
@@ -89,12 +105,13 @@ async def main() -> int:
         rows = (await s.execute(text(AUDIT_SQL))).mappings().all()
         fk_bad = (await s.execute(text(FK_VIOLATION_SQL))).scalar_one()
         parity = (await s.execute(text(PARITY_SQL))).mappings().all()
+        dead = (await s.execute(text(DEAD_KEYS_SQL))).scalar_one()
 
-    print(f"=== (a) cut-on 앵커 부재 위반 active key {len(rows)}건 ===")
+    print(f"=== (a) cut REGRESSION (legacy 200·anchor 401) active key {len(rows)}건 ===")
     for r in rows:
         print(
-            f"  api_key={r['api_key_id']} tm={r['team_member_id']}({r['tm_type']},active={r['tm_active']}) "
-            f"member_id={r['member_id']} member_exists={r['member_exists']} cut_ok={r['member_cut_ok']}"
+            f"  api_key={r['api_key_id']} tm={r['team_member_id']} member_id={r['member_id']} "
+            f"member_exists={r['member_exists']} cut_ok={r['member_cut_ok']}"
         )
     print(f"=== 0080 FK VALIDATE 위반(members 부재 referent, 전 row) {fk_bad}건 ===")
     print(f"=== (b) anchor≠legacy 해소 드리프트 active key {len(parity)}건 ===")
@@ -106,11 +123,12 @@ async def main() -> int:
             f"  api_key={r['api_key_id']} tm={r['team_member_id']} member_id={r['member_id']} diverge=[{diverge}] "
             f"legacy_proj={r['legacy_proj']} anchor_proj={r['anchor_proj']} legacy_org={r['legacy_org']} anchor_org={r['anchor_org']}"
         )
+    print(f"--- INFO: dead 키(legacy·anchor 둘 다 이미 401·flip 무관·revoke 후보) {dead}건 ---")
 
     if len(rows) == 0 and fk_bad == 0 and len(parity) == 0:
-        print("[PASS] (a)앵커존재 + (b)해소일치 + FK 모두 0 — flag-on 안전(cut 절대전제 충족)")
+        print(f"[PASS] (a)regression + (b)드리프트 + FK 모두 0 — flag-on 안전(cut 절대전제 충족). dead 키 {dead}건은 flip 무관(별도 revoke 후보)")
         return 0
-    print("[WARN] 위반 존재 — flag-on 前 처리 필요(앵커부재: members 보정/key 무효화 · 해소드리프트: 기본프로젝트 정렬 정합)")
+    print("[WARN] 위반 존재 — flag-on 前 처리 필요(regression: 0075 정합/members 보정 · 해소드리프트: 기본프로젝트 정렬 정합)")
     return 1
 
 

--- a/backend/tests/test_audit_apikey_parity_realdb.py
+++ b/backend/tests/test_audit_apikey_parity_realdb.py
@@ -1,7 +1,8 @@
-"""f5ee8387 H2 audit (b) parity — anchor≠legacy 해소 드리프트 적출 검증. DB env 없으면 skip(CI alembic-fresh).
+"""f5ee8387 H2 audit 정밀화 검증 — cut REGRESSION 게이트가 '깨지는 키'만 잡고 'dead 키'는 INFO 로 분리,
+(b) parity 가 project-default 드리프트를 잡는지 락. DB env 없으면 skip(CI alembic-fresh).
 
-핵심 리스크: 멀티프로젝트 agent 의 cut-on 기본 프로젝트가 legacy(team_members ORDER BY project_id)와
-anchor(agent_project_profiles ORDER BY created_at)서 갈릴 수 있다. PARITY_SQL 이 그 드리프트를 잡는지 락.
+PO dev audit 적발: 기존 (a)가 legacy 도 이미 401 인 dead 키(inactive tm)까지 위반으로 inflation(team_members
+projection VIEW dup 포함). 정밀화 = (a) regression(legacy 200·anchor 401)만 게이트·dead 는 count(DISTINCT) INFO.
 """
 from __future__ import annotations
 
@@ -12,7 +13,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from scripts.jobs.audit_apikey_member_anchor import PARITY_SQL
+from scripts.jobs.audit_apikey_member_anchor import AUDIT_SQL, DEAD_KEYS_SQL, PARITY_SQL
 
 _RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
 _ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
@@ -21,11 +22,17 @@ _ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace
 pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
 
 ORG = uuid.UUID("a5000000-0000-0000-0000-000000000001")
-# P1 < P2 (legacy ORDER BY project_id → P1 선택)
-P1 = uuid.UUID("a5000000-0000-0000-0000-0000000000a1")
+P1 = uuid.UUID("a5000000-0000-0000-0000-0000000000a1")  # P1 < P2 (legacy ORDER BY project_id → P1)
 P2 = uuid.UUID("a5000000-0000-0000-0000-0000000000b2")
-M_DIVERGE = uuid.UUID("a5000000-0000-0000-0000-0000000000d1")  # 멀티프로젝트·드리프트
-M_OK = uuid.UUID("a5000000-0000-0000-0000-0000000000e1")       # 단일프로젝트·일치
+M_OK = uuid.UUID("a5000000-0000-0000-0000-0000000000e1")        # 단일프로젝트·일치
+M_DIVERGE = uuid.UUID("a5000000-0000-0000-0000-0000000000d1")   # 멀티프로젝트·드리프트
+M_REG = uuid.UUID("a5000000-0000-0000-0000-0000000000c1")       # active(legacy 200)
+M_INACTIVE = uuid.UUID("a5000000-0000-0000-0000-0000000000c2")  # inactive anchor(K_REG 가 가리킴 → anchor 401)
+M_DEAD = uuid.UUID("a5000000-0000-0000-0000-0000000000f1")      # inactive(legacy·anchor 둘 다 401)
+K_OK = uuid.UUID("a5000000-0000-0000-0000-00000000ba01")
+K_DIV = uuid.UUID("a5000000-0000-0000-0000-00000000ba02")
+K_REG = uuid.UUID("a5000000-0000-0000-0000-00000000ba03")
+K_DEAD = uuid.UUID("a5000000-0000-0000-0000-00000000ba04")
 
 
 @pytest.fixture
@@ -35,46 +42,56 @@ def anyio_backend():
 
 async def _seed(s):
     for sql in [
-        f"DELETE FROM agent_api_keys WHERE member_id IN ('{M_DIVERGE}','{M_OK}')",
-        f"DELETE FROM agent_project_profiles WHERE member_id IN ('{M_DIVERGE}','{M_OK}')",
+        f"DELETE FROM agent_api_keys WHERE id IN ('{K_OK}','{K_DIV}','{K_REG}','{K_DEAD}')",
+        f"DELETE FROM agent_project_profiles WHERE member_id IN "
+        f"('{M_OK}','{M_DIVERGE}','{M_REG}','{M_DEAD}')",
         f"DELETE FROM members WHERE org_id='{ORG}'",
         f"DELETE FROM projects WHERE org_id='{ORG}'",
         f"DELETE FROM organizations WHERE id='{ORG}'",
         f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','A5','a5org','free')",
         f"INSERT INTO projects (id,org_id,name) VALUES ('{P1}','{ORG}','P1'),('{P2}','{ORG}','P2')",
         "INSERT INTO members (id,org_id,type,name,is_active) VALUES "
-        f"('{M_DIVERGE}','{ORG}','agent','Diverge',true),('{M_OK}','{ORG}','agent','Ok',true)",
-        # M_DIVERGE: P2 프로파일이 더 일찍 생성(anchor=created_at ASC → P2)·legacy=ORDER BY project_id → P1 → 드리프트.
+        f"('{M_OK}','{ORG}','agent','Ok',true),('{M_DIVERGE}','{ORG}','agent','Div',true),"
+        f"('{M_REG}','{ORG}','agent','Reg',true),('{M_INACTIVE}','{ORG}','agent','Inact',false),"
+        f"('{M_DEAD}','{ORG}','agent','Dead',false)",
+        # agent_project_profiles → team_members(view) 행. M_DIVERGE: P2 가 더 일찍 생성(anchor=created_at→P2)·legacy=P1.
         "INSERT INTO agent_project_profiles (id,member_id,project_id,agent_role,fakechat_port,created_at) VALUES "
+        f"(gen_random_uuid(),'{M_OK}','{P1}','dev',9803,'2026-01-01T00:00:00+00'),"
         f"(gen_random_uuid(),'{M_DIVERGE}','{P2}','dev',9801,'2026-01-01T00:00:00+00'),"
-        f"(gen_random_uuid(),'{M_DIVERGE}','{P1}','dev',9802,'2026-02-01T00:00:00+00')",
-        # M_OK: 단일 프로젝트 → legacy=anchor=P1.
-        "INSERT INTO agent_project_profiles (id,member_id,project_id,agent_role,fakechat_port,created_at) VALUES "
-        f"(gen_random_uuid(),'{M_OK}','{P1}','dev',9803,'2026-01-01T00:00:00+00')",
-        # agent_api_keys: member_id=team_member_id(0075 정합)·active.
+        f"(gen_random_uuid(),'{M_DIVERGE}','{P1}','dev',9802,'2026-02-01T00:00:00+00'),"
+        f"(gen_random_uuid(),'{M_REG}','{P1}','dev',9804,'2026-01-01T00:00:00+00'),"
+        f"(gen_random_uuid(),'{M_DEAD}','{P1}','dev',9805,'2026-01-01T00:00:00+00')",
+        # 키: K_REG = legacy(M_REG active) 200 · anchor(M_INACTIVE) 401 → regression.
+        #     K_DEAD = legacy(M_DEAD inactive)·anchor 둘 다 401 → dead(INFO).
         "INSERT INTO agent_api_keys (id,team_member_id,member_id,key_prefix,key_hash,created_at) VALUES "
-        f"(gen_random_uuid(),'{M_DIVERGE}','{M_DIVERGE}','sk_d','hash_d',now()),"
-        f"(gen_random_uuid(),'{M_OK}','{M_OK}','sk_o','hash_o',now())",
+        f"('{K_OK}','{M_OK}','{M_OK}','sk_o','h_o',now()),"
+        f"('{K_DIV}','{M_DIVERGE}','{M_DIVERGE}','sk_d','h_d',now()),"
+        f"('{K_REG}','{M_REG}','{M_INACTIVE}','sk_r','h_r',now()),"
+        f"('{K_DEAD}','{M_DEAD}','{M_DEAD}','sk_x','h_x',now())",
     ]:
         await s.execute(text(sql))
     await s.commit()
 
 
 @pytest.mark.anyio
-async def test_parity_catches_project_default_drift():
+async def test_audit_regression_gate_and_parity():
     engine = create_async_engine(_ASYNC)
     Session = async_sessionmaker(engine, expire_on_commit=False)
     try:
         async with Session() as s:
             await _seed(s)
-            rows = (await s.execute(text(PARITY_SQL))).mappings().all()
-            flagged = {r["member_id"]: r for r in rows}
-            # 드리프트 agent 는 잡히고(proj_mismatch·legacy P1·anchor P2)·일치 agent 는 미적출.
-            assert M_DIVERGE in flagged, f"드리프트 미적출: {list(flagged)}"
-            d = flagged[M_DIVERGE]
-            assert d["proj_mismatch"] is True
-            assert str(d["legacy_proj"]) == str(P1) and str(d["anchor_proj"]) == str(P2)
-            assert not d["id_mismatch"] and not d["org_mismatch"]  # id/org 는 일치(proj 만 드리프트)
-            assert M_OK not in flagged, "단일프로젝트 일치 agent 가 false-positive"
+            reg = {r["api_key_id"] for r in (await s.execute(text(AUDIT_SQL))).mappings().all()}
+            dead = (await s.execute(text(DEAD_KEYS_SQL))).scalar_one()
+            parity = {r["member_id"]: r for r in (await s.execute(text(PARITY_SQL))).mappings().all()}
+
+            # (a) regression: legacy 200·anchor 401 인 K_REG 만. dead/ok/valid 는 제외.
+            assert K_REG in reg, f"regression 미적출: {reg}"
+            assert K_DEAD not in reg, "dead 키가 regression 으로 오분류(flip 무관인데)"
+            assert K_OK not in reg and K_DIV not in reg, "정상 키 false-positive"
+            # dead 키(K_DEAD)는 INFO count 로만(≥1·DISTINCT 라 dup inflation 없음).
+            assert dead >= 1, f"dead 키 INFO 미집계: {dead}"
+            # (b) parity: 멀티프로젝트 드리프트 M_DIVERGE 만(proj_mismatch).
+            assert M_DIVERGE in parity and parity[M_DIVERGE]["proj_mismatch"] is True
+            assert M_OK not in parity, "단일프로젝트 일치 agent false-positive"
     finally:
         await engine.dispose()


### PR DESCRIPTION
## H2 audit 정밀화 (follow-up to #1784·dev audit 적발 반영)

#1784 머지 後 PO dev audit 실행서 적발: (a)가 legacy 도 이미 401 인 **dead 키(inactive tm)**까지 위반 집계 + `team_members` projection VIEW JOIN 으로 **dup inflation**(98bec2ab ×7). 게이트가 "이미 죽은 키"와 "flip 으로 깨지는 키"를 혼동.

### 정밀화 (read-only)
- **(a) = cut REGRESSION** = legacy 200(`EXISTS active team_members`)인데 anchor 401(`members(agent,active)` 부재) = flip 으로 실제 깨지는 working 키. `members` 테이블 1:1 JOIN + legacy 는 **EXISTS** 판정 → VIEW dup inflation 원천 제거(DISTINCT 불요).
- **dead 키 = `DEAD_KEYS_SQL count(DISTINCT)` INFO** 분리(비차단·revoke 후보 노출).
- **(b) parity** 에 `EXISTS(active tm)` 스코프 — dead 키 legacy NULL 을 가짜 드리프트로 안 잡게.
- **[PASS] = (a)regression + (b)드리프트 + FK 모두 0**(dead INFO 무관).

### 핵심
0075(`member_id=team_member_id`) 정합이면 legacy/anchor 동일 row → regression 은 0075 파손 시만. dev `id_mismatch=0` 이라 **재audit [PASS] 예상**(flip 이 working 키 안 깸).

### 검증
realdb 테스트 확장: regression(K_REG) 적출·dead(K_DEAD) 제외·dead INFO 집계·드리프트(M_DIVERGE) + false-positive 0 전수 락. ruff clean·코드 무변경(스크립트+테스트).

→ 머지 後 dev 재audit → [PASS] → dev `member_ssot_apikey_cut` ON → shadow 라이브검증. prod cut 별도 선생님 GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)