### PR TITLE
[SID:f5ee8387] anchor resolver 기본프로젝트 정렬 정합 — behavior-preserving cut (auth-critical)

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -116,7 +116,11 @@ async def _resolve_api_key(raw_key: str, db: AsyncSession) -> AuthContext:
         proj = (await db.execute(
             select(AgentProjectProfile.project_id)
             .where(AgentProjectProfile.member_id == m.id)
-            .order_by(AgentProjectProfile.created_at.asc())
+            # behavior-preserving: legacy(team_members ORDER BY project_id)와 동일 정렬 → 멀티프로젝트
+            # 에이전트 기본 프로젝트가 cut 전후 동일(드리프트 0). created_at 정렬은 silent 기본프로젝트
+            # 변경 = 컷오버 무중단 원칙 위반(prod 산티아고 c7a8dd0e 케이스). team_members 뷰가
+            # agent_project_profiles 서 파생되므로 project_id ASC 로 두 경로 default 동치.
+            .order_by(AgentProjectProfile.project_id.asc())
             .limit(1)
         )).scalar_one_or_none()
         member_id = m.id

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -127,9 +127,14 @@ async def _resolve_api_key(raw_key: str, db: AsyncSession) -> AuthContext:
         proj = (await db.execute(
             select(_proj_union.c.project_id).order_by(_proj_union.c.project_id.asc()).limit(1)
         )).scalar_one_or_none()
+        # legacy 는 team_members 행이 없으면(=접근 프로젝트 0) 401(아래 else 분기). cut-on 도 동치로 401 —
+        # union 이 비면(profile·grant 모두 없음) 인증 거부(무프로젝트 키를 project_id=None 으로 통과시키면
+        # legacy 대비 인증 widening). 까심 finding①.
+        if proj is None:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="API key member not found")
         member_id = m.id
         org_id = str(m.org_id)
-        project_id = str(proj) if proj else None
+        project_id = str(proj)
     else:
         # 레거시: team_members 경로.
         # team_members 는 0088 이후 projection VIEW라 멀티프로젝트 에이전트(org-level grant)는

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -8,7 +8,7 @@ from typing import Literal
 
 from fastapi import Depends, Header, HTTPException, Query, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from sqlalchemy import func, select
+from sqlalchemy import func, select, union
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import async_session_factory
@@ -101,8 +101,9 @@ async def _resolve_api_key(raw_key: str, db: AsyncSession) -> AuthContext:
     # user_id 동일 = 무중단. 기본 off(레거시), 실 에이전트 무중단 실증 후 단계 on.
     from app.core.config import settings as _settings
     if _settings.member_ssot_apikey_cut:
-        # anchor cut: members.id 기반. project_id는 agent_project_profiles 경유(ORDER BY 결정성).
+        # anchor cut: members.id 기반.
         from app.models.member import AgentProjectProfile, Member
+        from app.models.project_access import ProjectAccess
         m = (await db.execute(
             select(Member).where(
                 Member.id == api_key.member_id,
@@ -113,15 +114,18 @@ async def _resolve_api_key(raw_key: str, db: AsyncSession) -> AuthContext:
         )).scalar_one_or_none()
         if not m:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="API key member not found")
+        # 기본 project = legacy(team_members ORDER BY project_id LIMIT 1)와 동치 해소. team_members 뷰(0110)의
+        # 에이전트 set = agent_project_profiles(profile) ∪ project_access(permission='granted', grant-only).
+        # profile 만 보면 grant-only 최소 project_id 누락 → cut 후 기본프로젝트 드리프트(까심 BLOCKER). 두 anchor
+        # 소스 UNION 후 project_id ASC 로 legacy 와 동일 set·정렬 → 전 agent 드리프트 0(behavior-preserving).
+        _proj_union = union(
+            select(AgentProjectProfile.project_id).where(AgentProjectProfile.member_id == m.id),
+            select(ProjectAccess.project_id).where(
+                ProjectAccess.member_id == m.id, ProjectAccess.permission == "granted"
+            ),
+        ).subquery()
         proj = (await db.execute(
-            select(AgentProjectProfile.project_id)
-            .where(AgentProjectProfile.member_id == m.id)
-            # behavior-preserving: legacy(team_members ORDER BY project_id)와 동일 정렬 → 멀티프로젝트
-            # 에이전트 기본 프로젝트가 cut 전후 동일(드리프트 0). created_at 정렬은 silent 기본프로젝트
-            # 변경 = 컷오버 무중단 원칙 위반(prod 산티아고 c7a8dd0e 케이스). team_members 뷰가
-            # agent_project_profiles 서 파생되므로 project_id ASC 로 두 경로 default 동치.
-            .order_by(AgentProjectProfile.project_id.asc())
-            .limit(1)
+            select(_proj_union.c.project_id).order_by(_proj_union.c.project_id.asc()).limit(1)
         )).scalar_one_or_none()
         member_id = m.id
         org_id = str(m.org_id)

--- a/backend/scripts/jobs/audit_apikey_member_anchor.py
+++ b/backend/scripts/jobs/audit_apikey_member_anchor.py
@@ -9,9 +9,10 @@ dual-write 했고 0075는 type='agent' team_member만 members에 넣었으므로
 - **(a) cut regression** — legacy 는 200(active team_members 존재)인데 anchor 는 401(members(agent,active)
   부재) = flip 으로 실제 깨지는 working 키. legacy 도 이미 401 인 dead 키(inactive tm)는 flip 무관이므로
   regression 에서 제외하고 INFO(revoke 후보)로만 집계 — '깨지는 키'와 '이미 죽은 키'를 분리.
-- **(b) 해소 드리프트** — 유효 앵커가 있어도 anchor 해소(members.id + agent_project_profiles ORDER BY project_id)
-  가 legacy(team_members.id + ORDER BY project_id)와 다른 신원/프로젝트/org 면 cut 후 권한 드리프트.
-  (anchor 정렬을 legacy 와 동일 project_id ASC 로 정합한 後 — 정상이면 proj 축 0, 깨지면 정렬회귀/0075 파손 감지.)
+- **(b) 해소 드리프트** — 유효 앵커가 있어도 anchor 해소가 legacy 와 다른 신원/프로젝트/org 면 cut 후 권한
+  드리프트. anchor 기본프로젝트 = resolver 와 동일 union(agent_project_profiles ∪ project_access granted)
+  ORDER BY project_id LIMIT 1 = legacy team_members(0110 뷰) set 과 동치. 정상이면 proj 축 0, 깨지면
+  grant-only 누락/union 복제 회귀/0075 파손 감지.
 - 0건(a∩b∩FK) → flag-on 안전(dead 키 INFO 는 비차단). 1건+ → 처리(regression: 0075 정합/members 보정 · 드리프트: 정렬 정합).
 
 env: DATABASE_URL (백엔드 동일, cloud-sql-proxy/in-VPC 경유). 읽기 전용(조회만).
@@ -65,10 +66,10 @@ WHERE ak.member_id IS NOT NULL
 """
 
 # (b) anchor==legacy 해소 일치(H2 두 번째 축): **유효 앵커가 있어도** cut-on 이 legacy 와 다른 신원/
-# 프로젝트로 해소되면 cut 후 권한 드리프트. legacy=team_members ORDER BY project_id LIMIT 1, anchor=
-# agent_project_profiles ORDER BY **project_id** LIMIT 1(auth.py 가 behavior-preserving 정렬 정합 후).
-# 두 경로가 project_id ASC 동일 정렬이라 정상 데이터면 proj_mismatch 0(정합 깨지면=정렬 회귀/0075 파손
-# 감지). member_id≠team_member_id=0075 invariant 파손. org 불일치도 점검.
+# 프로젝트로 해소되면 cut 후 권한 드리프트. legacy=team_members(0110 뷰) ORDER BY project_id LIMIT 1,
+# anchor=resolver 와 동일 union(agent_project_profiles ∪ project_access granted) ORDER BY project_id LIMIT 1.
+# team_members 뷰 agent set = 그 union 이므로 정상이면 proj_mismatch 0 — 어긋나면 union 복제 회귀/0075
+# 파손/grant-only 누락 감지. member_id≠team_member_id=0075 invariant 파손. org 불일치도 점검.
 PARITY_SQL = """
 SELECT ak.id AS api_key_id, ak.team_member_id, ak.member_id,
        leg.project_id AS legacy_proj, anc.project_id AS anchor_proj,
@@ -85,9 +86,14 @@ LEFT JOIN LATERAL (
     ORDER BY tm.project_id LIMIT 1
 ) leg ON TRUE
 LEFT JOIN LATERAL (
-    SELECT app.project_id FROM agent_project_profiles app
-    WHERE app.member_id = ak.member_id
-    ORDER BY app.project_id ASC LIMIT 1
+    -- resolver(auth.py)와 동일 set: agent_project_profiles ∪ project_access(granted). legacy(team_members
+    -- 뷰=동일 union)와 비교 → union 이 뷰 set 과 어긋나면(복제 회귀) proj_mismatch 로 적출(self-check).
+    SELECT u.project_id FROM (
+        SELECT project_id FROM agent_project_profiles WHERE member_id = ak.member_id
+        UNION
+        SELECT project_id FROM project_access WHERE member_id = ak.member_id AND permission = 'granted'
+    ) u
+    ORDER BY u.project_id ASC LIMIT 1
 ) anc ON TRUE
 WHERE ak.revoked_at IS NULL AND (ak.expires_at IS NULL OR ak.expires_at > now())
   -- legacy 가 실제 해소되는 키만(dead 키의 legacy NULL 을 anchor 와 비교해 가짜 드리프트로 잡지 않도록).

--- a/backend/scripts/jobs/audit_apikey_member_anchor.py
+++ b/backend/scripts/jobs/audit_apikey_member_anchor.py
@@ -5,10 +5,13 @@ is_active, not deleted)`를 요구한다. 0076은 agent_api_keys 전 row에 memb
 dual-write 했고 0075는 type='agent' team_member만 members에 넣었으므로, **active key 중**
 (a) tm.type != 'agent' 이거나 (b) members(agent) 행이 부재이면 cut-on 시 401(생명선 차단)이 된다.
 
-이 스크립트는 cut **regression** 을 두 축으로 나열한다(H2 = (a) ∩ (b) ∩ FK 모두 0 이어야 cut 안전):
+이 스크립트는 cut 안전을 세 축으로 검사한다(H2 = (a) ∩ (b) ∩ (c) ∩ FK 모두 0 이어야 cut 안전):
 - **(a) cut regression** — legacy 는 200(active team_members 존재)인데 anchor 는 401(members(agent,active)
   부재) = flip 으로 실제 깨지는 working 키. legacy 도 이미 401 인 dead 키(inactive tm)는 flip 무관이므로
   regression 에서 제외하고 INFO(revoke 후보)로만 집계 — '깨지는 키'와 '이미 죽은 키'를 분리.
+- **(c) widening** — legacy 는 401(접근 프로젝트 0)인데 cut-on 이 통과 = 인증 확대(반대 방향). member valid
+  인데 active team_members 없는 무프로젝트 키. auth.py ①(proj None→401)이 런타임 차단하나 audit 가 게이트로
+  surface(있으면 flip 前 placement/revoke).
 - **(b) 해소 드리프트** — 유효 앵커가 있어도 anchor 해소가 legacy 와 다른 신원/프로젝트/org 면 cut 후 권한
   드리프트. anchor 기본프로젝트 = resolver 와 동일 union(agent_project_profiles ∪ project_access granted)
   ORDER BY project_id LIMIT 1 = legacy team_members(0110 뷰) set 과 동치. 정상이면 proj 축 0, 깨지면
@@ -104,6 +107,21 @@ WHERE ak.revoked_at IS NULL AND (ak.expires_at IS NULL OR ak.expires_at > now())
 ORDER BY ak.created_at
 """
 
+# (c) widening(까심 finding②): legacy 는 active team_members 0(=접근 프로젝트 0)이면 401 인데, cut-on 이
+# 통과하면 인증 확대. member valid(agent,active,not-deleted)인데 active team_members 가 없는 active 키 —
+# auth.py ①(proj None→401)이 런타임 차단하지만, audit 가 그 키 존재 자체를 게이트로 surface(있으면 flip 前
+# placement/revoke). union==team_members(뷰) 이므로 이 키 = 무프로젝트 키. regression 의 EXISTS(active tm)
+# 필터가 못 보는 반대 방향.
+WIDENING_SQL = """
+SELECT ak.id AS api_key_id, ak.team_member_id, ak.member_id
+FROM agent_api_keys ak
+JOIN members m ON m.id = ak.member_id
+             AND m.type = 'agent' AND m.is_active AND m.deleted_at IS NULL
+WHERE ak.revoked_at IS NULL AND (ak.expires_at IS NULL OR ak.expires_at > now())
+  AND NOT EXISTS (SELECT 1 FROM team_members tm WHERE tm.id = ak.team_member_id AND tm.is_active)
+ORDER BY ak.created_at
+"""
+
 
 async def main() -> int:
     if not os.environ.get("DATABASE_URL"):
@@ -114,6 +132,7 @@ async def main() -> int:
         fk_bad = (await s.execute(text(FK_VIOLATION_SQL))).scalar_one()
         parity = (await s.execute(text(PARITY_SQL))).mappings().all()
         dead = (await s.execute(text(DEAD_KEYS_SQL))).scalar_one()
+        widen = (await s.execute(text(WIDENING_SQL))).mappings().all()
 
     print(f"=== (a) cut REGRESSION (legacy 200·anchor 401) active key {len(rows)}건 ===")
     for r in rows:
@@ -131,12 +150,15 @@ async def main() -> int:
             f"  api_key={r['api_key_id']} tm={r['team_member_id']} member_id={r['member_id']} diverge=[{diverge}] "
             f"legacy_proj={r['legacy_proj']} anchor_proj={r['anchor_proj']} legacy_org={r['legacy_org']} anchor_org={r['anchor_org']}"
         )
+    print(f"=== (c) widening (legacy 401·무프로젝트인데 member valid) active key {len(widen)}건 ===")
+    for r in widen:
+        print(f"  api_key={r['api_key_id']} tm={r['team_member_id']} member_id={r['member_id']} (무프로젝트·auth.py ① 401 처리)")
     print(f"--- INFO: dead 키(legacy·anchor 둘 다 이미 401·flip 무관·revoke 후보) {dead}건 ---")
 
-    if len(rows) == 0 and fk_bad == 0 and len(parity) == 0:
-        print(f"[PASS] (a)regression + (b)드리프트 + FK 모두 0 — flag-on 안전(cut 절대전제 충족). dead 키 {dead}건은 flip 무관(별도 revoke 후보)")
+    if len(rows) == 0 and fk_bad == 0 and len(parity) == 0 and len(widen) == 0:
+        print(f"[PASS] (a)regression + (b)드리프트 + (c)widening + FK 모두 0 — flag-on 안전. dead 키 {dead}건은 flip 무관(별도 revoke)")
         return 0
-    print("[WARN] 위반 존재 — flag-on 前 처리 필요(regression: 0075 정합/members 보정 · 해소드리프트: 기본프로젝트 정렬 정합)")
+    print("[WARN] 위반 존재 — flag-on 前 처리(regression: 0075/members 보정 · 드리프트: union 정합 · widening: 무프로젝트 키 placement/revoke)")
     return 1
 
 

--- a/backend/scripts/jobs/audit_apikey_member_anchor.py
+++ b/backend/scripts/jobs/audit_apikey_member_anchor.py
@@ -9,8 +9,9 @@ dual-write 했고 0075는 type='agent' team_member만 members에 넣었으므로
 - **(a) cut regression** — legacy 는 200(active team_members 존재)인데 anchor 는 401(members(agent,active)
   부재) = flip 으로 실제 깨지는 working 키. legacy 도 이미 401 인 dead 키(inactive tm)는 flip 무관이므로
   regression 에서 제외하고 INFO(revoke 후보)로만 집계 — '깨지는 키'와 '이미 죽은 키'를 분리.
-- **(b) 해소 드리프트** — 유효 앵커가 있어도 anchor 해소(members.id + agent_project_profiles ORDER BY created_at)
+- **(b) 해소 드리프트** — 유효 앵커가 있어도 anchor 해소(members.id + agent_project_profiles ORDER BY project_id)
   가 legacy(team_members.id + ORDER BY project_id)와 다른 신원/프로젝트/org 면 cut 후 권한 드리프트.
+  (anchor 정렬을 legacy 와 동일 project_id ASC 로 정합한 後 — 정상이면 proj 축 0, 깨지면 정렬회귀/0075 파손 감지.)
 - 0건(a∩b∩FK) → flag-on 안전(dead 키 INFO 는 비차단). 1건+ → 처리(regression: 0075 정합/members 보정 · 드리프트: 정렬 정합).
 
 env: DATABASE_URL (백엔드 동일, cloud-sql-proxy/in-VPC 경유). 읽기 전용(조회만).
@@ -64,9 +65,10 @@ WHERE ak.member_id IS NOT NULL
 """
 
 # (b) anchor==legacy 해소 일치(H2 두 번째 축): **유효 앵커가 있어도** cut-on 이 legacy 와 다른 신원/
-# 프로젝트로 해소되면 cut 후 권한 드리프트. legacy(auth.py:136)=team_members ORDER BY project_id LIMIT 1,
-# anchor(auth.py:119)=agent_project_profiles ORDER BY created_at LIMIT 1 → 멀티프로젝트 agent 는 기본
-# 프로젝트가 갈릴 수 있다. member_id≠team_member_id=0075 invariant 파손. org 불일치도 점검.
+# 프로젝트로 해소되면 cut 후 권한 드리프트. legacy=team_members ORDER BY project_id LIMIT 1, anchor=
+# agent_project_profiles ORDER BY **project_id** LIMIT 1(auth.py 가 behavior-preserving 정렬 정합 후).
+# 두 경로가 project_id ASC 동일 정렬이라 정상 데이터면 proj_mismatch 0(정합 깨지면=정렬 회귀/0075 파손
+# 감지). member_id≠team_member_id=0075 invariant 파손. org 불일치도 점검.
 PARITY_SQL = """
 SELECT ak.id AS api_key_id, ak.team_member_id, ak.member_id,
        leg.project_id AS legacy_proj, anc.project_id AS anchor_proj,
@@ -85,7 +87,7 @@ LEFT JOIN LATERAL (
 LEFT JOIN LATERAL (
     SELECT app.project_id FROM agent_project_profiles app
     WHERE app.member_id = ak.member_id
-    ORDER BY app.created_at ASC LIMIT 1
+    ORDER BY app.project_id ASC LIMIT 1
 ) anc ON TRUE
 WHERE ak.revoked_at IS NULL AND (ak.expires_at IS NULL OR ak.expires_at > now())
   -- legacy 가 실제 해소되는 키만(dead 키의 legacy NULL 을 anchor 와 비교해 가짜 드리프트로 잡지 않도록).

--- a/backend/tests/test_audit_apikey_parity_realdb.py
+++ b/backend/tests/test_audit_apikey_parity_realdb.py
@@ -1,8 +1,9 @@
-"""f5ee8387 H2 audit 정밀화 검증 — cut REGRESSION 게이트가 '깨지는 키'만 잡고 'dead 키'는 INFO 로 분리,
-(b) parity 가 project-default 드리프트를 잡는지 락. DB env 없으면 skip(CI alembic-fresh).
+"""f5ee8387 H2 audit 검증 — cut REGRESSION 게이트('깨지는 키'만·dead 는 INFO) + parity(정렬 정합 後
+멀티프로젝트 무드리프트 + id_mismatch 적출). DB env 없으면 skip(CI alembic-fresh).
 
-PO dev audit 적발: 기존 (a)가 legacy 도 이미 401 인 dead 키(inactive tm)까지 위반으로 inflation(team_members
-projection VIEW dup 포함). 정밀화 = (a) regression(legacy 200·anchor 401)만 게이트·dead 는 count(DISTINCT) INFO.
+prod audit가 (b)서 산티아고 멀티프로젝트 agent 기본프로젝트 드리프트(legacy project_id ASC vs anchor
+created_at ASC) 적발 → anchor 정렬을 legacy 와 동일 project_id ASC 로 정합(auth.py + PARITY_SQL).
+정합 後엔 정상 데이터면 proj 드리프트 0(M_DIVERGE 미적출)·id_mismatch 만 parity 가 잡는다.
 """
 from __future__ import annotations
 
@@ -22,17 +23,20 @@ _ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace
 pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
 
 ORG = uuid.UUID("a5000000-0000-0000-0000-000000000001")
-P1 = uuid.UUID("a5000000-0000-0000-0000-0000000000a1")  # P1 < P2 (legacy ORDER BY project_id → P1)
+P1 = uuid.UUID("a5000000-0000-0000-0000-0000000000a1")  # P1 < P2 (project_id ASC → P1)
 P2 = uuid.UUID("a5000000-0000-0000-0000-0000000000b2")
-M_OK = uuid.UUID("a5000000-0000-0000-0000-0000000000e1")        # 단일프로젝트·일치
-M_DIVERGE = uuid.UUID("a5000000-0000-0000-0000-0000000000d1")   # 멀티프로젝트·드리프트
+M_OK = uuid.UUID("a5000000-0000-0000-0000-0000000000e1")        # 단일프로젝트
+M_DIVERGE = uuid.UUID("a5000000-0000-0000-0000-0000000000d1")   # 멀티프로젝트(정렬 정합 後 무드리프트)
 M_REG = uuid.UUID("a5000000-0000-0000-0000-0000000000c1")       # active(legacy 200)
 M_INACTIVE = uuid.UUID("a5000000-0000-0000-0000-0000000000c2")  # inactive anchor(K_REG 가 가리킴 → anchor 401)
 M_DEAD = uuid.UUID("a5000000-0000-0000-0000-0000000000f1")      # inactive(legacy·anchor 둘 다 401)
+M_TMSIDE = uuid.UUID("a5000000-0000-0000-0000-0000000000aa")    # K_IDD legacy 측(active)
+M_ANCHORSIDE = uuid.UUID("a5000000-0000-0000-0000-0000000000bb")  # K_IDD anchor 측(active·다른 id)
 K_OK = uuid.UUID("a5000000-0000-0000-0000-00000000ba01")
 K_DIV = uuid.UUID("a5000000-0000-0000-0000-00000000ba02")
 K_REG = uuid.UUID("a5000000-0000-0000-0000-00000000ba03")
 K_DEAD = uuid.UUID("a5000000-0000-0000-0000-00000000ba04")
+K_IDD = uuid.UUID("a5000000-0000-0000-0000-00000000ba05")       # member_id≠team_member_id(id_mismatch)
 
 
 @pytest.fixture
@@ -41,10 +45,11 @@ def anyio_backend():
 
 
 async def _seed(s):
+    keys = f"'{K_OK}','{K_DIV}','{K_REG}','{K_DEAD}','{K_IDD}'"
     for sql in [
-        f"DELETE FROM agent_api_keys WHERE id IN ('{K_OK}','{K_DIV}','{K_REG}','{K_DEAD}')",
+        f"DELETE FROM agent_api_keys WHERE id IN ({keys})",
         f"DELETE FROM agent_project_profiles WHERE member_id IN "
-        f"('{M_OK}','{M_DIVERGE}','{M_REG}','{M_DEAD}')",
+        f"('{M_OK}','{M_DIVERGE}','{M_REG}','{M_DEAD}','{M_TMSIDE}','{M_ANCHORSIDE}')",
         f"DELETE FROM members WHERE org_id='{ORG}'",
         f"DELETE FROM projects WHERE org_id='{ORG}'",
         f"DELETE FROM organizations WHERE id='{ORG}'",
@@ -53,28 +58,32 @@ async def _seed(s):
         "INSERT INTO members (id,org_id,type,name,is_active) VALUES "
         f"('{M_OK}','{ORG}','agent','Ok',true),('{M_DIVERGE}','{ORG}','agent','Div',true),"
         f"('{M_REG}','{ORG}','agent','Reg',true),('{M_INACTIVE}','{ORG}','agent','Inact',false),"
-        f"('{M_DEAD}','{ORG}','agent','Dead',false)",
-        # agent_project_profiles → team_members(view) 행. M_DIVERGE: P2 가 더 일찍 생성(anchor=created_at→P2)·legacy=P1.
+        f"('{M_DEAD}','{ORG}','agent','Dead',false),('{M_TMSIDE}','{ORG}','agent','TmSide',true),"
+        f"('{M_ANCHORSIDE}','{ORG}','agent','AnchorSide',true)",
+        # M_DIVERGE: P2 프로파일이 더 일찍 생성 — created_at 정렬이면 P2(legacy P1과 드리프트)였으나,
+        # project_id 정렬 정합 後엔 anchor 도 P1(최소 project_id) → 드리프트 0.
         "INSERT INTO agent_project_profiles (id,member_id,project_id,agent_role,fakechat_port,created_at) VALUES "
         f"(gen_random_uuid(),'{M_OK}','{P1}','dev',9803,'2026-01-01T00:00:00+00'),"
         f"(gen_random_uuid(),'{M_DIVERGE}','{P2}','dev',9801,'2026-01-01T00:00:00+00'),"
         f"(gen_random_uuid(),'{M_DIVERGE}','{P1}','dev',9802,'2026-02-01T00:00:00+00'),"
         f"(gen_random_uuid(),'{M_REG}','{P1}','dev',9804,'2026-01-01T00:00:00+00'),"
-        f"(gen_random_uuid(),'{M_DEAD}','{P1}','dev',9805,'2026-01-01T00:00:00+00')",
-        # 키: K_REG = legacy(M_REG active) 200 · anchor(M_INACTIVE) 401 → regression.
-        #     K_DEAD = legacy(M_DEAD inactive)·anchor 둘 다 401 → dead(INFO).
+        f"(gen_random_uuid(),'{M_DEAD}','{P1}','dev',9805,'2026-01-01T00:00:00+00'),"
+        f"(gen_random_uuid(),'{M_TMSIDE}','{P1}','dev',9806,'2026-01-01T00:00:00+00'),"
+        f"(gen_random_uuid(),'{M_ANCHORSIDE}','{P1}','dev',9807,'2026-01-01T00:00:00+00')",
+        # K_REG=regression(legacy 200·anchor 401) · K_DEAD=dead(INFO) · K_IDD=id_mismatch(member≠tm).
         "INSERT INTO agent_api_keys (id,team_member_id,member_id,key_prefix,key_hash,created_at) VALUES "
         f"('{K_OK}','{M_OK}','{M_OK}','sk_o','h_o',now()),"
         f"('{K_DIV}','{M_DIVERGE}','{M_DIVERGE}','sk_d','h_d',now()),"
         f"('{K_REG}','{M_REG}','{M_INACTIVE}','sk_r','h_r',now()),"
-        f"('{K_DEAD}','{M_DEAD}','{M_DEAD}','sk_x','h_x',now())",
+        f"('{K_DEAD}','{M_DEAD}','{M_DEAD}','sk_x','h_x',now()),"
+        f"('{K_IDD}','{M_TMSIDE}','{M_ANCHORSIDE}','sk_i','h_i',now())",
     ]:
         await s.execute(text(sql))
     await s.commit()
 
 
 @pytest.mark.anyio
-async def test_audit_regression_gate_and_parity():
+async def test_audit_regression_gate_and_aligned_parity():
     engine = create_async_engine(_ASYNC)
     Session = async_sessionmaker(engine, expire_on_commit=False)
     try:
@@ -82,16 +91,19 @@ async def test_audit_regression_gate_and_parity():
             await _seed(s)
             reg = {r["api_key_id"] for r in (await s.execute(text(AUDIT_SQL))).mappings().all()}
             dead = (await s.execute(text(DEAD_KEYS_SQL))).scalar_one()
-            parity = {r["member_id"]: r for r in (await s.execute(text(PARITY_SQL))).mappings().all()}
+            parity = {r["api_key_id"]: r for r in (await s.execute(text(PARITY_SQL))).mappings().all()}
 
             # (a) regression: legacy 200·anchor 401 인 K_REG 만. dead/ok/valid 는 제외.
             assert K_REG in reg, f"regression 미적출: {reg}"
-            assert K_DEAD not in reg, "dead 키가 regression 으로 오분류(flip 무관인데)"
+            assert K_DEAD not in reg, "dead 키가 regression 으로 오분류"
             assert K_OK not in reg and K_DIV not in reg, "정상 키 false-positive"
-            # dead 키(K_DEAD)는 INFO count 로만(≥1·DISTINCT 라 dup inflation 없음).
             assert dead >= 1, f"dead 키 INFO 미집계: {dead}"
-            # (b) parity: 멀티프로젝트 드리프트 M_DIVERGE 만(proj_mismatch).
-            assert M_DIVERGE in parity and parity[M_DIVERGE]["proj_mismatch"] is True
-            assert M_OK not in parity, "단일프로젝트 일치 agent false-positive"
+
+            # (b) 정렬 정합 後: 멀티프로젝트 M_DIVERGE 는 anchor 도 project_id ASC → P1 = legacy → 무드리프트.
+            assert K_DIV not in parity, "정렬 정합 後에도 멀티프로젝트 드리프트(정합 미적용?)"
+            assert K_OK not in parity, "단일프로젝트 false-positive"
+            # parity 는 여전히 id_mismatch(0075 파손) 를 잡는다 — K_IDD(member≠tm).
+            assert K_IDD in parity and parity[K_IDD]["id_mismatch"] is True
+            assert parity[K_IDD]["proj_mismatch"] is False  # 둘 다 P1 → proj 는 정합
     finally:
         await engine.dispose()

--- a/backend/tests/test_audit_apikey_parity_realdb.py
+++ b/backend/tests/test_audit_apikey_parity_realdb.py
@@ -138,3 +138,37 @@ async def test_audit_regression_gate_and_aligned_parity():
             assert parity[K_IDD]["proj_mismatch"] is False  # 둘 다 P1 → proj 는 정합
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_resolver_cut_on_no_project_raises_401():
+    """auth.py finding①(까심 v3): cut-on flag-on 에서 member valid·접근 프로젝트 0(M_NOPROJ: profile·grant
+    둘 다 없음 → union 빈)인 agent 키는 `_resolve_api_key` 가 **401** — legacy(team_members 0행=401)와 동치.
+    audit (c) widening 게이트의 **resolver 측 짝**: `if proj is None: raise 401` 코드 경로 직접 락(제거 시 fail)."""
+    from fastapi import HTTPException
+
+    from app.core import config as _cfg
+    from app.core.security import hash_token
+    from app.dependencies.auth import _resolve_api_key
+
+    raw = "sk_live_noproj" + "9" * 50
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    prev = _cfg.settings.member_ssot_apikey_cut
+    try:
+        async with Session() as s:
+            await _seed(s)
+            # K_NOPROJ(member=M_NOPROJ·profile·grant 0)의 key_hash 를 실 해시로 → _resolve_api_key 가 조회 가능.
+            await s.execute(
+                text("UPDATE agent_api_keys SET key_hash = :h WHERE id = :k"),
+                {"h": hash_token(raw), "k": str(K_NOPROJ)},
+            )
+            await s.commit()
+        _cfg.settings.member_ssot_apikey_cut = True
+        async with Session() as s:
+            with pytest.raises(HTTPException) as e:
+                await _resolve_api_key(raw, s)
+            assert e.value.status_code == 401, f"무프로젝트 cut-on 이 401 아님(widening): {e.value.status_code}"
+    finally:
+        _cfg.settings.member_ssot_apikey_cut = prev
+        await engine.dispose()

--- a/backend/tests/test_audit_apikey_parity_realdb.py
+++ b/backend/tests/test_audit_apikey_parity_realdb.py
@@ -14,7 +14,12 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from scripts.jobs.audit_apikey_member_anchor import AUDIT_SQL, DEAD_KEYS_SQL, PARITY_SQL
+from scripts.jobs.audit_apikey_member_anchor import (
+    AUDIT_SQL,
+    DEAD_KEYS_SQL,
+    PARITY_SQL,
+    WIDENING_SQL,
+)
 
 _RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
 _ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
@@ -33,12 +38,14 @@ M_DEAD = uuid.UUID("a5000000-0000-0000-0000-0000000000f1")      # inactive(legac
 M_TMSIDE = uuid.UUID("a5000000-0000-0000-0000-0000000000aa")    # K_IDD legacy 측(active)
 M_ANCHORSIDE = uuid.UUID("a5000000-0000-0000-0000-0000000000bb")  # K_IDD anchor 측(active·다른 id)
 M_GRANT = uuid.UUID("a5000000-0000-0000-0000-0000000000cc")     # grant-only(profile P2 + grant P1)
+M_NOPROJ = uuid.UUID("a5000000-0000-0000-0000-0000000000dd")    # member valid·무프로젝트(widening 케이스)
 K_OK = uuid.UUID("a5000000-0000-0000-0000-00000000ba01")
 K_DIV = uuid.UUID("a5000000-0000-0000-0000-00000000ba02")
 K_REG = uuid.UUID("a5000000-0000-0000-0000-00000000ba03")
 K_DEAD = uuid.UUID("a5000000-0000-0000-0000-00000000ba04")
 K_IDD = uuid.UUID("a5000000-0000-0000-0000-00000000ba05")       # member_id≠team_member_id(id_mismatch)
 K_GRANT = uuid.UUID("a5000000-0000-0000-0000-00000000ba06")     # grant-only 최소 project_id(까심 BLOCKER 케이스)
+K_NOPROJ = uuid.UUID("a5000000-0000-0000-0000-00000000ba07")    # 무프로젝트 member-valid(widening·까심 finding②)
 
 
 @pytest.fixture
@@ -47,9 +54,9 @@ def anyio_backend():
 
 
 async def _seed(s):
-    keys = f"'{K_OK}','{K_DIV}','{K_REG}','{K_DEAD}','{K_IDD}','{K_GRANT}'"
+    keys = f"'{K_OK}','{K_DIV}','{K_REG}','{K_DEAD}','{K_IDD}','{K_GRANT}','{K_NOPROJ}'"
     members = (
-        f"'{M_OK}','{M_DIVERGE}','{M_REG}','{M_DEAD}','{M_TMSIDE}','{M_ANCHORSIDE}','{M_GRANT}'"
+        f"'{M_OK}','{M_DIVERGE}','{M_REG}','{M_DEAD}','{M_TMSIDE}','{M_ANCHORSIDE}','{M_GRANT}','{M_NOPROJ}'"
     )
     for sql in [
         f"DELETE FROM agent_api_keys WHERE id IN ({keys})",
@@ -64,7 +71,8 @@ async def _seed(s):
         f"('{M_OK}','{ORG}','agent','Ok',true),('{M_DIVERGE}','{ORG}','agent','Div',true),"
         f"('{M_REG}','{ORG}','agent','Reg',true),('{M_INACTIVE}','{ORG}','agent','Inact',false),"
         f"('{M_DEAD}','{ORG}','agent','Dead',false),('{M_TMSIDE}','{ORG}','agent','TmSide',true),"
-        f"('{M_ANCHORSIDE}','{ORG}','agent','AnchorSide',true),('{M_GRANT}','{ORG}','agent','Grant',true)",
+        f"('{M_ANCHORSIDE}','{ORG}','agent','AnchorSide',true),('{M_GRANT}','{ORG}','agent','Grant',true),"
+        f"('{M_NOPROJ}','{ORG}','agent','NoProj',true)",
         # M_DIVERGE: P2 프로파일이 더 일찍 생성 — created_at 정렬이면 P2(legacy P1과 드리프트)였으나,
         # project_id 정렬 정합 後엔 anchor 도 P1(최소 project_id) → 드리프트 0.
         "INSERT INTO agent_project_profiles (id,member_id,project_id,agent_role,fakechat_port,created_at) VALUES "
@@ -88,7 +96,9 @@ async def _seed(s):
         f"('{K_REG}','{M_REG}','{M_INACTIVE}','sk_r','h_r',now()),"
         f"('{K_DEAD}','{M_DEAD}','{M_DEAD}','sk_x','h_x',now()),"
         f"('{K_IDD}','{M_TMSIDE}','{M_ANCHORSIDE}','sk_i','h_i',now()),"
-        f"('{K_GRANT}','{M_GRANT}','{M_GRANT}','sk_g','h_g',now())",
+        f"('{K_GRANT}','{M_GRANT}','{M_GRANT}','sk_g','h_g',now()),"
+        # K_NOPROJ: member valid 인데 profile·grant 0 → active team_members 0 → legacy 401·widening 케이스.
+        f"('{K_NOPROJ}','{M_NOPROJ}','{M_NOPROJ}','sk_n','h_n',now())",
     ]:
         await s.execute(text(sql))
     await s.commit()
@@ -104,6 +114,7 @@ async def test_audit_regression_gate_and_aligned_parity():
             reg = {r["api_key_id"] for r in (await s.execute(text(AUDIT_SQL))).mappings().all()}
             dead = (await s.execute(text(DEAD_KEYS_SQL))).scalar_one()
             parity = {r["api_key_id"]: r for r in (await s.execute(text(PARITY_SQL))).mappings().all()}
+            widen = {r["api_key_id"] for r in (await s.execute(text(WIDENING_SQL))).mappings().all()}
 
             # (a) regression: legacy 200·anchor 401 인 K_REG 만. dead/ok/valid 는 제외.
             assert K_REG in reg, f"regression 미적출: {reg}"
@@ -117,6 +128,11 @@ async def test_audit_regression_gate_and_aligned_parity():
             # 까심 BLOCKER: grant-only 최소 project_id(P1)도 union(agent_project_profiles ∪ project_access granted)
             # 에 포함 → anchor MIN=P1=legacy team_members(branch3) → 무드리프트. profile-only resolver 면 P2 드리프트.
             assert K_GRANT not in parity, "grant-only 최소 project 미union(profile-only resolver 잔여 드리프트)"
+
+            # (c) widening(까심 finding②): 무프로젝트 member-valid(K_NOPROJ)는 legacy 401인데 cut-on 통과 위험
+            # → audit 가 게이트로 적출. 프로젝트 있는 키(OK/DIV/GRANT)는 active tm 존재라 미적출.
+            assert K_NOPROJ in widen, f"무프로젝트 widening 미적출: {widen}"
+            assert K_OK not in widen and K_DIV not in widen and K_GRANT not in widen, "프로젝트 보유 키 widening false-positive"
             # parity 는 여전히 id_mismatch(0075 파손) 를 잡는다 — K_IDD(member≠tm).
             assert K_IDD in parity and parity[K_IDD]["id_mismatch"] is True
             assert parity[K_IDD]["proj_mismatch"] is False  # 둘 다 P1 → proj 는 정합

--- a/backend/tests/test_audit_apikey_parity_realdb.py
+++ b/backend/tests/test_audit_apikey_parity_realdb.py
@@ -32,11 +32,13 @@ M_INACTIVE = uuid.UUID("a5000000-0000-0000-0000-0000000000c2")  # inactive ancho
 M_DEAD = uuid.UUID("a5000000-0000-0000-0000-0000000000f1")      # inactive(legacy·anchor 둘 다 401)
 M_TMSIDE = uuid.UUID("a5000000-0000-0000-0000-0000000000aa")    # K_IDD legacy 측(active)
 M_ANCHORSIDE = uuid.UUID("a5000000-0000-0000-0000-0000000000bb")  # K_IDD anchor 측(active·다른 id)
+M_GRANT = uuid.UUID("a5000000-0000-0000-0000-0000000000cc")     # grant-only(profile P2 + grant P1)
 K_OK = uuid.UUID("a5000000-0000-0000-0000-00000000ba01")
 K_DIV = uuid.UUID("a5000000-0000-0000-0000-00000000ba02")
 K_REG = uuid.UUID("a5000000-0000-0000-0000-00000000ba03")
 K_DEAD = uuid.UUID("a5000000-0000-0000-0000-00000000ba04")
 K_IDD = uuid.UUID("a5000000-0000-0000-0000-00000000ba05")       # member_id≠team_member_id(id_mismatch)
+K_GRANT = uuid.UUID("a5000000-0000-0000-0000-00000000ba06")     # grant-only 최소 project_id(까심 BLOCKER 케이스)
 
 
 @pytest.fixture
@@ -45,11 +47,14 @@ def anyio_backend():
 
 
 async def _seed(s):
-    keys = f"'{K_OK}','{K_DIV}','{K_REG}','{K_DEAD}','{K_IDD}'"
+    keys = f"'{K_OK}','{K_DIV}','{K_REG}','{K_DEAD}','{K_IDD}','{K_GRANT}'"
+    members = (
+        f"'{M_OK}','{M_DIVERGE}','{M_REG}','{M_DEAD}','{M_TMSIDE}','{M_ANCHORSIDE}','{M_GRANT}'"
+    )
     for sql in [
         f"DELETE FROM agent_api_keys WHERE id IN ({keys})",
-        f"DELETE FROM agent_project_profiles WHERE member_id IN "
-        f"('{M_OK}','{M_DIVERGE}','{M_REG}','{M_DEAD}','{M_TMSIDE}','{M_ANCHORSIDE}')",
+        f"DELETE FROM project_access WHERE member_id IN ({members})",
+        f"DELETE FROM agent_project_profiles WHERE member_id IN ({members})",
         f"DELETE FROM members WHERE org_id='{ORG}'",
         f"DELETE FROM projects WHERE org_id='{ORG}'",
         f"DELETE FROM organizations WHERE id='{ORG}'",
@@ -59,7 +64,7 @@ async def _seed(s):
         f"('{M_OK}','{ORG}','agent','Ok',true),('{M_DIVERGE}','{ORG}','agent','Div',true),"
         f"('{M_REG}','{ORG}','agent','Reg',true),('{M_INACTIVE}','{ORG}','agent','Inact',false),"
         f"('{M_DEAD}','{ORG}','agent','Dead',false),('{M_TMSIDE}','{ORG}','agent','TmSide',true),"
-        f"('{M_ANCHORSIDE}','{ORG}','agent','AnchorSide',true)",
+        f"('{M_ANCHORSIDE}','{ORG}','agent','AnchorSide',true),('{M_GRANT}','{ORG}','agent','Grant',true)",
         # M_DIVERGE: P2 프로파일이 더 일찍 생성 — created_at 정렬이면 P2(legacy P1과 드리프트)였으나,
         # project_id 정렬 정합 後엔 anchor 도 P1(최소 project_id) → 드리프트 0.
         "INSERT INTO agent_project_profiles (id,member_id,project_id,agent_role,fakechat_port,created_at) VALUES "
@@ -69,14 +74,21 @@ async def _seed(s):
         f"(gen_random_uuid(),'{M_REG}','{P1}','dev',9804,'2026-01-01T00:00:00+00'),"
         f"(gen_random_uuid(),'{M_DEAD}','{P1}','dev',9805,'2026-01-01T00:00:00+00'),"
         f"(gen_random_uuid(),'{M_TMSIDE}','{P1}','dev',9806,'2026-01-01T00:00:00+00'),"
-        f"(gen_random_uuid(),'{M_ANCHORSIDE}','{P1}','dev',9807,'2026-01-01T00:00:00+00')",
-        # K_REG=regression(legacy 200·anchor 401) · K_DEAD=dead(INFO) · K_IDD=id_mismatch(member≠tm).
+        f"(gen_random_uuid(),'{M_ANCHORSIDE}','{P1}','dev',9807,'2026-01-01T00:00:00+00'),"
+        # M_GRANT: profile 은 P2(높은 project_id)에만·P1 은 grant-only(profile 無·project_access granted).
+        f"(gen_random_uuid(),'{M_GRANT}','{P2}','dev',9808,'2026-01-01T00:00:00+00')",
+        # M_GRANT grant-only: P1(최소 project_id) 에 profile 없이 granted → team_members 뷰 branch3.
+        # 까심 BLOCKER: profile-only resolver 면 P2(드리프트), union resolver 면 P1(=legacy·무드리프트).
+        f"INSERT INTO project_access (id,project_id,member_id,permission) VALUES "
+        f"(gen_random_uuid(),'{P1}','{M_GRANT}','granted')",
+        # K_REG=regression · K_DEAD=dead(INFO) · K_IDD=id_mismatch · K_GRANT=grant-only-lowest.
         "INSERT INTO agent_api_keys (id,team_member_id,member_id,key_prefix,key_hash,created_at) VALUES "
         f"('{K_OK}','{M_OK}','{M_OK}','sk_o','h_o',now()),"
         f"('{K_DIV}','{M_DIVERGE}','{M_DIVERGE}','sk_d','h_d',now()),"
         f"('{K_REG}','{M_REG}','{M_INACTIVE}','sk_r','h_r',now()),"
         f"('{K_DEAD}','{M_DEAD}','{M_DEAD}','sk_x','h_x',now()),"
-        f"('{K_IDD}','{M_TMSIDE}','{M_ANCHORSIDE}','sk_i','h_i',now())",
+        f"('{K_IDD}','{M_TMSIDE}','{M_ANCHORSIDE}','sk_i','h_i',now()),"
+        f"('{K_GRANT}','{M_GRANT}','{M_GRANT}','sk_g','h_g',now())",
     ]:
         await s.execute(text(sql))
     await s.commit()
@@ -99,9 +111,12 @@ async def test_audit_regression_gate_and_aligned_parity():
             assert K_OK not in reg and K_DIV not in reg, "정상 키 false-positive"
             assert dead >= 1, f"dead 키 INFO 미집계: {dead}"
 
-            # (b) 정렬 정합 後: 멀티프로젝트 M_DIVERGE 는 anchor 도 project_id ASC → P1 = legacy → 무드리프트.
+            # (b) union 해소 後: 멀티프로젝트 M_DIVERGE 는 anchor 도 project_id ASC → P1 = legacy → 무드리프트.
             assert K_DIV not in parity, "정렬 정합 後에도 멀티프로젝트 드리프트(정합 미적용?)"
             assert K_OK not in parity, "단일프로젝트 false-positive"
+            # 까심 BLOCKER: grant-only 최소 project_id(P1)도 union(agent_project_profiles ∪ project_access granted)
+            # 에 포함 → anchor MIN=P1=legacy team_members(branch3) → 무드리프트. profile-only resolver 면 P2 드리프트.
+            assert K_GRANT not in parity, "grant-only 최소 project 미union(profile-only resolver 잔여 드리프트)"
             # parity 는 여전히 id_mismatch(0075 파손) 를 잡는다 — K_IDD(member≠tm).
             assert K_IDD in parity and parity[K_IDD]["id_mismatch"] is True
             assert parity[K_IDD]["proj_mismatch"] is False  # 둘 다 P1 → proj 는 정합


### PR DESCRIPTION
## anchor resolver 기본프로젝트 정렬을 legacy 와 정합 — prod 드리프트 0 (auth-critical)

prod H2 audit (b)가 드리프트 1건 적발(설계 의도대로): **산티아고 멀티프로젝트 agent**(`c7a8dd0e`)의 cut 전후 기본 프로젝트가 갈림.
- legacy 기본 = `team_members ORDER BY project_id ASC` → `07a710ef`
- anchor 기본 = `agent_project_profiles ORDER BY created_at ASC` → `857cc336`
- org 동일·`id_mismatch 0` = **순수 정렬 divergence**. flip 시 그 키의 `auth.project_id` claim 이 바뀌어, 명시 project_id 없는 호출이 다른 프로젝트를 타격 = 권한 드리프트.

### fix (behavior-preserving)
anchor resolver(`auth.py _resolve_api_key`)의 기본프로젝트 정렬을 **legacy 와 동일** `agent_project_profiles ORDER BY project_id ASC` 로 변경. `team_members` 뷰가 `agent_project_profiles` 서 파생되므로 두 경로 default 가 동치 → **전 agent 드리프트 0**(deterministic). 컷오버 원칙(identity anchor 만 바뀌고 resolution 동작 불변=무중단) 준수. `created_at` 정렬은 cut 이 **silent 하게 기본프로젝트를 바꾸는** 무중단 위반이라 채택 안 함. (per-agent 데이터 패치 = hacky, 미채택.)

### 변경
- `auth.py`: anchor proj `created_at.asc()` → `project_id.asc()`.
- `audit_apikey_member_anchor.py` PARITY anchor LATERAL 도 `project_id ASC` 정합(감사가 새 resolver 반영).
- realdb 테스트: 정합 後 멀티프로젝트 무드리프트(M_DIVERGE 미적출) + `id_mismatch`(K_IDD) parity 적출 + regression 게이트 유지.

### 검증
parity realdb 1 pass(aligned)·ruff·full no-DB 2608 pass(잔여 8=기존 MCP-env·auth 무회귀). **flag-gated** 변경(member_ssot_apikey_cut anchor 분기). dev 이미 flip-ON 이나 dev 드리프트 0(정렬 일치 agent뿐)이라 무영향.

⚠️ **auth-critical** — 까심 cross-model QA 필수. 머지 → dev 재검(드리프트 0) → prod 재audit(드리프트 0) → prod flip(선생님 GO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)