### PR TITLE
[infra] cloud-build durability — dev maxScale 8 (429 right-size) + 명시 DB_POOL 3/1

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -56,10 +56,13 @@ jobs:
             echo "target=dev" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
             echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
-            # ⚠️ maxScale 1 (ee7794eb·durable): dev Cloud SQL f1-micro max_conn~25. rollout(old+new 2×)·
-            # per-instance = pool(3/1=4·#1773) + pg_pubsub raw 1 = 5. 2×1×5+5(admin)=15 ≤ 25 ✓.
-            # (이전 10 = rollout 2×10×5+5=105≫25 → 매 배포 TooManyConnections. steady 80<100 주석은 rollout 누락이었음.)
-            echo "backend_max_instances=1" >> "$GITHUB_OUTPUT"
+            # ⚠️ maxScale 8 (PO rev 01256-w9r right-size·durable): dev 429 근본 = Cloud Run "no available
+            # instance"(maxScale 1 이 fleet 폴링 압도·3h 1345건). per-instance = pool(3/1=4·#1773) +
+            # pg_pubsub raw 1 = 5. rollout(old+new 2×): 2×8×5=80 ≤ 100(PO 실측 dev DB max_conn). 이전
+            # maxScale 1 은 conn-safe였으나 인스턴스 기아로 429 → load+conn 양립값. DB_POOL_SIZE=3/
+            # DB_MAX_OVERFLOW=1 은 cloudbuild.yaml --update-env-vars 로 durable(lingering env 덮어씀).
+            # (⚠️ dev/prod 공유 DB라면 prod(2×5×5+admin)와 합산 점검 필요 — PO 토폴로지 확認.)
+            echo "backend_max_instances=8" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=" >> "$GITHUB_OUTPUT"
           fi
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -111,7 +111,11 @@ steps:
       # OB-1: 에이전트 onboarding generator 가 읽는 backend-direct URL 을 런타임 env 로 주입.
       # ⚠️ 반드시 --update-env-vars(additive·기존 backend env[DATABASE_URL 등] 보존). --set-env-vars 금지
       # (전체 wipe). _FASTAPI_URL 은 dev/prod 각 backend-direct run.app(프론트 NEXT_PUBLIC_FASTAPI_URL 과 동일 값).
-      - --update-env-vars=FASTAPI_URL=${_FASTAPI_URL}
+      # DB_POOL_SIZE=3/DB_MAX_OVERFLOW=1: config.py 기본과 동일하나 **명시 주입으로 durable**(과거 수동 설정·
+      # lingering env 가 config 기본을 덮는 것 방지). rollout 산식: 2×maxScale×(pool+overflow+pg_pubsub raw 1)
+      # ≤ DB max_conn (dev maxScale 8: 2×8×5=80 · prod maxScale 5: 2×5×5=50+admin). 변경 시 cloud-build.yml
+      # maxScale 와 짝으로 검토. (PO rev 01256 dev 429 right-size durable 화.)
+      - --update-env-vars=FASTAPI_URL=${_FASTAPI_URL},DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1
       - --quiet
     waitFor: [push-backend]
 


### PR DESCRIPTION
## cloud-build durability — dev 429 right-size 영속화

dev 429 근본 = Cloud Run **"no available instance"**(maxScale 1 이 fleet 폴링 압도·3h 1345건). PO rev 01256-w9r 런타임 right-size(maxScale 1→8·pool 3/1)로 429 해소했으나, **다음 CB 배포가 파일값으로 덮어쓰면 재발** → durable 정정.

### 변경 (배포 설정만·코드 무변경)
- **`.github/workflows/cloud-build.yml` dev**: `backend_max_instances` 1 → **8**. 주석 정정: 기존 "f1-micro max_conn~25" 는 **stale** — PO 실측 dev DB max_conn=**100**(rev 01256 maxScale 8·`2×8×5=80≤100`·429 해소·TooManyConnections 0 으로 입증). 이전 maxScale 1 은 conn-safe였으나 인스턴스 기아로 429.
- **`cloudbuild.yaml`**: `--update-env-vars` 에 `DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1` **명시**(config.py 기본과 동일하나 durable — 과거 수동/lingering env 가 config 기본 덮는 것 방지). rollout 산식 `2×maxScale×(pool+overflow+pg_pubsub raw 1) ≤ max_conn` 주석 동봉.
- **prod 라인 점검**: maxScale 5·`2×5×5+20(admin)=70≤100` 이미 정확(blind spot 없음·#1779). pool 명시 env 로 dev/prod 일관.

### ⚠️ FLAG (PO 확認 요)
dev/prod 가 **Cloud SQL 공유**라면([[feedback_shared_dev_prod_db]]) dev(2×8×5=80) + prod(2×5×5=50)+admin 동시 rollout 합산이 100 초과 가능. PO 의 `2×8×5=80≤100` 은 dev standalone 가정 — DB 토폴로지(separate vs shared) 확認 부탁. 인프라값은 PO 실측 기준(나는 dev DB 직접 접근 0).

### 검증
YAML 양쪽 parse OK. (배포 설정이라 런타임 검증은 머지 후 dev CB 1회 — maxScale 8·pool env 반영 確認.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)