### PR TITLE
release: member-SSOT 컷오버(union+widening) + maxScale durability + authz/L2/MCP — 선택승격(doc-gate 제외) → prod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
           JWT_SECRET: ci-test-secret-at-least-32-chars-long
           SECRET_KEY: ci-test-secret-at-least-32-chars-long
-        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py tests/test_release_notes_realdb.py -q
+        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py tests/test_release_notes_realdb.py tests/test_audit_apikey_parity_realdb.py -q
 
       - name: Verify fresh DB reached head (baseline + incremental)
         working-directory: backend

--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -56,10 +56,13 @@ jobs:
             echo "target=dev" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
             echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
-            # ⚠️ maxScale 1 (ee7794eb·durable): dev Cloud SQL f1-micro max_conn~25. rollout(old+new 2×)·
-            # per-instance = pool(3/1=4·#1773) + pg_pubsub raw 1 = 5. 2×1×5+5(admin)=15 ≤ 25 ✓.
-            # (이전 10 = rollout 2×10×5+5=105≫25 → 매 배포 TooManyConnections. steady 80<100 주석은 rollout 누락이었음.)
-            echo "backend_max_instances=1" >> "$GITHUB_OUTPUT"
+            # ⚠️ maxScale 8 (PO rev 01256-w9r right-size·durable): dev 429 근본 = Cloud Run "no available
+            # instance"(maxScale 1 이 fleet 폴링 압도·3h 1345건). per-instance = pool(3/1=4·#1773) +
+            # pg_pubsub raw 1 = 5. rollout(old+new 2×): 2×8×5=80 ≤ 100(PO 실측 dev DB max_conn). 이전
+            # maxScale 1 은 conn-safe였으나 인스턴스 기아로 429 → load+conn 양립값. DB_POOL_SIZE=3/
+            # DB_MAX_OVERFLOW=1 은 cloudbuild.yaml --update-env-vars 로 durable(lingering env 덮어씀).
+            # (⚠️ dev/prod 공유 DB라면 prod(2×5×5+admin)와 합산 점검 필요 — PO 토폴로지 확認.)
+            echo "backend_max_instances=8" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=" >> "$GITHUB_OUTPUT"
           fi
 

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -8,7 +8,7 @@ from typing import Literal
 
 from fastapi import Depends, Header, HTTPException, Query, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from sqlalchemy import func, select
+from sqlalchemy import func, select, union
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import async_session_factory
@@ -101,8 +101,9 @@ async def _resolve_api_key(raw_key: str, db: AsyncSession) -> AuthContext:
     # user_id 동일 = 무중단. 기본 off(레거시), 실 에이전트 무중단 실증 후 단계 on.
     from app.core.config import settings as _settings
     if _settings.member_ssot_apikey_cut:
-        # anchor cut: members.id 기반. project_id는 agent_project_profiles 경유(ORDER BY 결정성).
+        # anchor cut: members.id 기반.
         from app.models.member import AgentProjectProfile, Member
+        from app.models.project_access import ProjectAccess
         m = (await db.execute(
             select(Member).where(
                 Member.id == api_key.member_id,
@@ -113,15 +114,27 @@ async def _resolve_api_key(raw_key: str, db: AsyncSession) -> AuthContext:
         )).scalar_one_or_none()
         if not m:
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="API key member not found")
+        # 기본 project = legacy(team_members ORDER BY project_id LIMIT 1)와 동치 해소. team_members 뷰(0110)의
+        # 에이전트 set = agent_project_profiles(profile) ∪ project_access(permission='granted', grant-only).
+        # profile 만 보면 grant-only 최소 project_id 누락 → cut 후 기본프로젝트 드리프트(까심 BLOCKER). 두 anchor
+        # 소스 UNION 후 project_id ASC 로 legacy 와 동일 set·정렬 → 전 agent 드리프트 0(behavior-preserving).
+        _proj_union = union(
+            select(AgentProjectProfile.project_id).where(AgentProjectProfile.member_id == m.id),
+            select(ProjectAccess.project_id).where(
+                ProjectAccess.member_id == m.id, ProjectAccess.permission == "granted"
+            ),
+        ).subquery()
         proj = (await db.execute(
-            select(AgentProjectProfile.project_id)
-            .where(AgentProjectProfile.member_id == m.id)
-            .order_by(AgentProjectProfile.created_at.asc())
-            .limit(1)
+            select(_proj_union.c.project_id).order_by(_proj_union.c.project_id.asc()).limit(1)
         )).scalar_one_or_none()
+        # legacy 는 team_members 행이 없으면(=접근 프로젝트 0) 401(아래 else 분기). cut-on 도 동치로 401 —
+        # union 이 비면(profile·grant 모두 없음) 인증 거부(무프로젝트 키를 project_id=None 으로 통과시키면
+        # legacy 대비 인증 widening). 까심 finding①.
+        if proj is None:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="API key member not found")
         member_id = m.id
         org_id = str(m.org_id)
-        project_id = str(proj) if proj else None
+        project_id = str(proj)
     else:
         # 레거시: team_members 경로.
         # team_members 는 0088 이후 projection VIEW라 멀티프로젝트 에이전트(org-level grant)는

--- a/backend/app/routers/project_settings.py
+++ b/backend/app/routers/project_settings.py
@@ -1,14 +1,15 @@
 import uuid
 from datetime import time
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.project_setting import ProjectSetting
 from app.schemas.project_setting import ProjectSettingResponse, UpdateProjectSetting
+from app.services.project_auth import has_project_access, has_project_role
 
 router = APIRouter(prefix="/api/v2/project-settings", tags=["project-settings"])
 
@@ -19,8 +20,12 @@ _DEFAULT_DEADLINE = time(9, 0)
 async def get_project_settings(
     project_id: uuid.UUID = Query(...),
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> ProjectSettingResponse:
+    # E-MEMBER-POLICY(9b8d634b): 프로젝트 멤버만 열람 — cross-tenant read 차단(타 org 프로젝트 settings 노출 방지).
+    if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=403, detail="project access required")
     result = await session.execute(
         select(ProjectSetting).where(ProjectSetting.project_id == project_id)
     )
@@ -40,8 +45,14 @@ async def get_project_settings(
 async def upsert_project_settings(
     body: UpdateProjectSetting,
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> ProjectSettingResponse:
+    # E-MEMBER-POLICY(9b8d634b·정책 §2): 설정 변경 = project owner/admin(has_project_role 이 org owner/admin
+    # floor 포함). 기존 authz 0(누구나 타 프로젝트 standup_deadline 변경 가능)이던 보안 갭 차단.
+    if not await has_project_role(
+        session, uuid.UUID(auth.user_id), body.project_id, min_role="admin"
+    ):
+        raise HTTPException(status_code=403, detail="project owner/admin required")
     deadline = time.fromisoformat(body.standup_deadline)
     result = await session.execute(
         select(ProjectSetting).where(ProjectSetting.project_id == body.project_id)

--- a/backend/scripts/jobs/audit_apikey_member_anchor.py
+++ b/backend/scripts/jobs/audit_apikey_member_anchor.py
@@ -5,9 +5,11 @@ is_active, not deleted)`를 요구한다. 0076은 agent_api_keys 전 row에 memb
 dual-write 했고 0075는 type='agent' team_member만 members에 넣었으므로, **active key 중**
 (a) tm.type != 'agent' 이거나 (b) members(agent) 행이 부재이면 cut-on 시 401(생명선 차단)이 된다.
 
-이 스크립트는 그런 **위반 active key**를 나열한다.
-- 0건  → flag-on 안전 + 0080 FK VALIDATE 통과.
-- 1건+ → 처리 필요: 정당 agent면 members 보정(또는 agent_anchor_sync 재실행), human/오용 key면 무효화.
+이 스크립트는 cut-on 위반 active key 를 **두 축**으로 나열한다(H2 = (a) ∩ (b) 둘 다 0 이어야 cut 안전):
+- **(a) 앵커 부재** — members(agent,active) 부재/NULL/wrong-type → cut-on 401(생명선 차단).
+- **(b) 해소 드리프트** — 유효 앵커가 있어도 anchor 해소(members.id + agent_project_profiles ORDER BY created_at)
+  가 legacy(team_members.id + ORDER BY project_id)와 다른 신원/프로젝트/org 면 cut 후 권한 드리프트.
+- 0건(a∩b∩FK) → flag-on 안전. 1건+ → 처리(앵커부재: members 보정/key 무효화 · 드리프트: 정렬 정합).
 
 env: DATABASE_URL (백엔드 동일, cloud-sql-proxy/in-VPC 경유). 읽기 전용(조회만).
 실행: cd backend && DATABASE_URL=... python -m scripts.jobs.audit_apikey_member_anchor
@@ -47,6 +49,37 @@ WHERE ak.member_id IS NOT NULL
   AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = ak.member_id)
 """
 
+# (b) anchor==legacy 해소 일치(H2 두 번째 축): **유효 앵커가 있어도** cut-on 이 legacy 와 다른 신원/
+# 프로젝트로 해소되면 cut 후 권한 드리프트. legacy(auth.py:136)=team_members ORDER BY project_id LIMIT 1,
+# anchor(auth.py:119)=agent_project_profiles ORDER BY created_at LIMIT 1 → 멀티프로젝트 agent 는 기본
+# 프로젝트가 갈릴 수 있다. member_id≠team_member_id=0075 invariant 파손. org 불일치도 점검.
+PARITY_SQL = """
+SELECT ak.id AS api_key_id, ak.team_member_id, ak.member_id,
+       leg.project_id AS legacy_proj, anc.project_id AS anchor_proj,
+       leg.org_id AS legacy_org, m.org_id AS anchor_org,
+       (ak.member_id IS DISTINCT FROM ak.team_member_id) AS id_mismatch,
+       (anc.project_id IS DISTINCT FROM leg.project_id)  AS proj_mismatch,
+       (m.org_id IS DISTINCT FROM leg.org_id)            AS org_mismatch
+FROM agent_api_keys ak
+JOIN members m ON m.id = ak.member_id
+             AND m.type = 'agent' AND m.is_active AND m.deleted_at IS NULL
+LEFT JOIN LATERAL (
+    SELECT tm.project_id, tm.org_id FROM team_members tm
+    WHERE tm.id = ak.team_member_id AND tm.is_active
+    ORDER BY tm.project_id LIMIT 1
+) leg ON TRUE
+LEFT JOIN LATERAL (
+    SELECT app.project_id FROM agent_project_profiles app
+    WHERE app.member_id = ak.member_id
+    ORDER BY app.created_at ASC LIMIT 1
+) anc ON TRUE
+WHERE ak.revoked_at IS NULL AND (ak.expires_at IS NULL OR ak.expires_at > now())
+  AND ( ak.member_id IS DISTINCT FROM ak.team_member_id
+     OR anc.project_id IS DISTINCT FROM leg.project_id
+     OR m.org_id IS DISTINCT FROM leg.org_id )
+ORDER BY ak.created_at
+"""
+
 
 async def main() -> int:
     if not os.environ.get("DATABASE_URL"):
@@ -55,19 +88,29 @@ async def main() -> int:
     async with async_session_factory() as s:
         rows = (await s.execute(text(AUDIT_SQL))).mappings().all()
         fk_bad = (await s.execute(text(FK_VIOLATION_SQL))).scalar_one()
+        parity = (await s.execute(text(PARITY_SQL))).mappings().all()
 
-    print(f"=== AC2 H2 감사: cut-on 위반 active key {len(rows)}건 ===")
+    print(f"=== (a) cut-on 앵커 부재 위반 active key {len(rows)}건 ===")
     for r in rows:
         print(
             f"  api_key={r['api_key_id']} tm={r['team_member_id']}({r['tm_type']},active={r['tm_active']}) "
             f"member_id={r['member_id']} member_exists={r['member_exists']} cut_ok={r['member_cut_ok']}"
         )
     print(f"=== 0080 FK VALIDATE 위반(members 부재 referent, 전 row) {fk_bad}건 ===")
+    print(f"=== (b) anchor≠legacy 해소 드리프트 active key {len(parity)}건 ===")
+    for r in parity:
+        diverge = ",".join(
+            d for d, on in (("id", r["id_mismatch"]), ("proj", r["proj_mismatch"]), ("org", r["org_mismatch"])) if on
+        )
+        print(
+            f"  api_key={r['api_key_id']} tm={r['team_member_id']} member_id={r['member_id']} diverge=[{diverge}] "
+            f"legacy_proj={r['legacy_proj']} anchor_proj={r['anchor_proj']} legacy_org={r['legacy_org']} anchor_org={r['anchor_org']}"
+        )
 
-    if len(rows) == 0 and fk_bad == 0:
-        print("[PASS] 위반 0건 — flag-on 안전 + 0080 FK VALIDATE 통과 예상")
+    if len(rows) == 0 and fk_bad == 0 and len(parity) == 0:
+        print("[PASS] (a)앵커존재 + (b)해소일치 + FK 모두 0 — flag-on 안전(cut 절대전제 충족)")
         return 0
-    print("[WARN] 위반 존재 — flag-on 전 처리 필요(정당 agent: members 보정 / human·오용: key 무효화)")
+    print("[WARN] 위반 존재 — flag-on 前 처리 필요(앵커부재: members 보정/key 무효화 · 해소드리프트: 기본프로젝트 정렬 정합)")
     return 1
 
 

--- a/backend/scripts/jobs/audit_apikey_member_anchor.py
+++ b/backend/scripts/jobs/audit_apikey_member_anchor.py
@@ -5,11 +5,13 @@ is_active, not deleted)`를 요구한다. 0076은 agent_api_keys 전 row에 memb
 dual-write 했고 0075는 type='agent' team_member만 members에 넣었으므로, **active key 중**
 (a) tm.type != 'agent' 이거나 (b) members(agent) 행이 부재이면 cut-on 시 401(생명선 차단)이 된다.
 
-이 스크립트는 cut-on 위반 active key 를 **두 축**으로 나열한다(H2 = (a) ∩ (b) 둘 다 0 이어야 cut 안전):
-- **(a) 앵커 부재** — members(agent,active) 부재/NULL/wrong-type → cut-on 401(생명선 차단).
+이 스크립트는 cut **regression** 을 두 축으로 나열한다(H2 = (a) ∩ (b) ∩ FK 모두 0 이어야 cut 안전):
+- **(a) cut regression** — legacy 는 200(active team_members 존재)인데 anchor 는 401(members(agent,active)
+  부재) = flip 으로 실제 깨지는 working 키. legacy 도 이미 401 인 dead 키(inactive tm)는 flip 무관이므로
+  regression 에서 제외하고 INFO(revoke 후보)로만 집계 — '깨지는 키'와 '이미 죽은 키'를 분리.
 - **(b) 해소 드리프트** — 유효 앵커가 있어도 anchor 해소(members.id + agent_project_profiles ORDER BY created_at)
   가 legacy(team_members.id + ORDER BY project_id)와 다른 신원/프로젝트/org 면 cut 후 권한 드리프트.
-- 0건(a∩b∩FK) → flag-on 안전. 1건+ → 처리(앵커부재: members 보정/key 무효화 · 드리프트: 정렬 정합).
+- 0건(a∩b∩FK) → flag-on 안전(dead 키 INFO 는 비차단). 1건+ → 처리(regression: 0075 정합/members 보정 · 드리프트: 정렬 정합).
 
 env: DATABASE_URL (백엔드 동일, cloud-sql-proxy/in-VPC 경유). 읽기 전용(조회만).
 실행: cd backend && DATABASE_URL=... python -m scripts.jobs.audit_apikey_member_anchor
@@ -24,22 +26,34 @@ from sqlalchemy import text
 
 from app.core.database import async_session_factory
 
-# active(미revoke·미만료) key 중 cut-on이 깨질 row: members(agent,active) 부재
+# (a) cut REGRESSION: legacy 가 해소되는데(active team_members 존재) anchor 는 401(members(agent,active) 부재)
+# = flip 으로 **실제 깨지는 working 키**. legacy 도 이미 401 인 dead 키(inactive tm)는 flip 무관이라 제외(INFO).
+# 0075(member_id=team_member_id)면 legacy/anchor 가 동일 members row 라 정합 — regression 은 사실상 0075 파손
+# (id_mismatch)일 때만 발생. members=테이블(1:1)·legacy 판정은 EXISTS 로 → team_members projection VIEW dup 회피.
 AUDIT_SQL = """
 SELECT ak.id            AS api_key_id,
        ak.team_member_id,
        ak.member_id,
-       tm.type          AS tm_type,
-       tm.is_active     AS tm_active,
        (m.id IS NOT NULL) AS member_exists,
-       (m.type = 'agent' AND m.is_active AND m.deleted_at IS NULL) AS member_cut_ok
+       (m.id IS NOT NULL AND m.type = 'agent' AND m.is_active AND m.deleted_at IS NULL) AS member_cut_ok
 FROM agent_api_keys ak
-LEFT JOIN team_members tm ON tm.id = ak.team_member_id
-LEFT JOIN members m       ON m.id = ak.member_id
+LEFT JOIN members m ON m.id = ak.member_id
 WHERE ak.revoked_at IS NULL
   AND (ak.expires_at IS NULL OR ak.expires_at > now())
   AND NOT (m.id IS NOT NULL AND m.type = 'agent' AND m.is_active AND m.deleted_at IS NULL)
+  AND EXISTS (SELECT 1 FROM team_members tm WHERE tm.id = ak.team_member_id AND tm.is_active)
 ORDER BY ak.created_at
+"""
+
+# INFO(게이트 아님): anchor·legacy 둘 다 실패하는 dead 키(inactive tm) — flip 무관(이미 401)·revoke 정리 후보.
+# count(DISTINCT) 로 team_members VIEW dup inflation 제거.
+DEAD_KEYS_SQL = """
+SELECT count(DISTINCT ak.id) FROM agent_api_keys ak
+LEFT JOIN members m ON m.id = ak.member_id
+WHERE ak.revoked_at IS NULL
+  AND (ak.expires_at IS NULL OR ak.expires_at > now())
+  AND NOT (m.id IS NOT NULL AND m.type = 'agent' AND m.is_active AND m.deleted_at IS NULL)
+  AND NOT EXISTS (SELECT 1 FROM team_members tm WHERE tm.id = ak.team_member_id AND tm.is_active)
 """
 
 # 0080 FK VALIDATE 가드와 동일 기준: member_id referent 부재(active 무관 전 row)
@@ -74,6 +88,8 @@ LEFT JOIN LATERAL (
     ORDER BY app.created_at ASC LIMIT 1
 ) anc ON TRUE
 WHERE ak.revoked_at IS NULL AND (ak.expires_at IS NULL OR ak.expires_at > now())
+  -- legacy 가 실제 해소되는 키만(dead 키의 legacy NULL 을 anchor 와 비교해 가짜 드리프트로 잡지 않도록).
+  AND EXISTS (SELECT 1 FROM team_members tm WHERE tm.id = ak.team_member_id AND tm.is_active)
   AND ( ak.member_id IS DISTINCT FROM ak.team_member_id
      OR anc.project_id IS DISTINCT FROM leg.project_id
      OR m.org_id IS DISTINCT FROM leg.org_id )
@@ -89,12 +105,13 @@ async def main() -> int:
         rows = (await s.execute(text(AUDIT_SQL))).mappings().all()
         fk_bad = (await s.execute(text(FK_VIOLATION_SQL))).scalar_one()
         parity = (await s.execute(text(PARITY_SQL))).mappings().all()
+        dead = (await s.execute(text(DEAD_KEYS_SQL))).scalar_one()
 
-    print(f"=== (a) cut-on 앵커 부재 위반 active key {len(rows)}건 ===")
+    print(f"=== (a) cut REGRESSION (legacy 200·anchor 401) active key {len(rows)}건 ===")
     for r in rows:
         print(
-            f"  api_key={r['api_key_id']} tm={r['team_member_id']}({r['tm_type']},active={r['tm_active']}) "
-            f"member_id={r['member_id']} member_exists={r['member_exists']} cut_ok={r['member_cut_ok']}"
+            f"  api_key={r['api_key_id']} tm={r['team_member_id']} member_id={r['member_id']} "
+            f"member_exists={r['member_exists']} cut_ok={r['member_cut_ok']}"
         )
     print(f"=== 0080 FK VALIDATE 위반(members 부재 referent, 전 row) {fk_bad}건 ===")
     print(f"=== (b) anchor≠legacy 해소 드리프트 active key {len(parity)}건 ===")
@@ -106,11 +123,12 @@ async def main() -> int:
             f"  api_key={r['api_key_id']} tm={r['team_member_id']} member_id={r['member_id']} diverge=[{diverge}] "
             f"legacy_proj={r['legacy_proj']} anchor_proj={r['anchor_proj']} legacy_org={r['legacy_org']} anchor_org={r['anchor_org']}"
         )
+    print(f"--- INFO: dead 키(legacy·anchor 둘 다 이미 401·flip 무관·revoke 후보) {dead}건 ---")
 
     if len(rows) == 0 and fk_bad == 0 and len(parity) == 0:
-        print("[PASS] (a)앵커존재 + (b)해소일치 + FK 모두 0 — flag-on 안전(cut 절대전제 충족)")
+        print(f"[PASS] (a)regression + (b)드리프트 + FK 모두 0 — flag-on 안전(cut 절대전제 충족). dead 키 {dead}건은 flip 무관(별도 revoke 후보)")
         return 0
-    print("[WARN] 위반 존재 — flag-on 前 처리 필요(앵커부재: members 보정/key 무효화 · 해소드리프트: 기본프로젝트 정렬 정합)")
+    print("[WARN] 위반 존재 — flag-on 前 처리 필요(regression: 0075 정합/members 보정 · 해소드리프트: 기본프로젝트 정렬 정합)")
     return 1
 
 

--- a/backend/scripts/jobs/audit_apikey_member_anchor.py
+++ b/backend/scripts/jobs/audit_apikey_member_anchor.py
@@ -5,12 +5,17 @@ is_active, not deleted)`를 요구한다. 0076은 agent_api_keys 전 row에 memb
 dual-write 했고 0075는 type='agent' team_member만 members에 넣었으므로, **active key 중**
 (a) tm.type != 'agent' 이거나 (b) members(agent) 행이 부재이면 cut-on 시 401(생명선 차단)이 된다.
 
-이 스크립트는 cut **regression** 을 두 축으로 나열한다(H2 = (a) ∩ (b) ∩ FK 모두 0 이어야 cut 안전):
+이 스크립트는 cut 안전을 세 축으로 검사한다(H2 = (a) ∩ (b) ∩ (c) ∩ FK 모두 0 이어야 cut 안전):
 - **(a) cut regression** — legacy 는 200(active team_members 존재)인데 anchor 는 401(members(agent,active)
   부재) = flip 으로 실제 깨지는 working 키. legacy 도 이미 401 인 dead 키(inactive tm)는 flip 무관이므로
   regression 에서 제외하고 INFO(revoke 후보)로만 집계 — '깨지는 키'와 '이미 죽은 키'를 분리.
-- **(b) 해소 드리프트** — 유효 앵커가 있어도 anchor 해소(members.id + agent_project_profiles ORDER BY created_at)
-  가 legacy(team_members.id + ORDER BY project_id)와 다른 신원/프로젝트/org 면 cut 후 권한 드리프트.
+- **(c) widening** — legacy 는 401(접근 프로젝트 0)인데 cut-on 이 통과 = 인증 확대(반대 방향). member valid
+  인데 active team_members 없는 무프로젝트 키. auth.py ①(proj None→401)이 런타임 차단하나 audit 가 게이트로
+  surface(있으면 flip 前 placement/revoke).
+- **(b) 해소 드리프트** — 유효 앵커가 있어도 anchor 해소가 legacy 와 다른 신원/프로젝트/org 면 cut 후 권한
+  드리프트. anchor 기본프로젝트 = resolver 와 동일 union(agent_project_profiles ∪ project_access granted)
+  ORDER BY project_id LIMIT 1 = legacy team_members(0110 뷰) set 과 동치. 정상이면 proj 축 0, 깨지면
+  grant-only 누락/union 복제 회귀/0075 파손 감지.
 - 0건(a∩b∩FK) → flag-on 안전(dead 키 INFO 는 비차단). 1건+ → 처리(regression: 0075 정합/members 보정 · 드리프트: 정렬 정합).
 
 env: DATABASE_URL (백엔드 동일, cloud-sql-proxy/in-VPC 경유). 읽기 전용(조회만).
@@ -64,9 +69,10 @@ WHERE ak.member_id IS NOT NULL
 """
 
 # (b) anchor==legacy 해소 일치(H2 두 번째 축): **유효 앵커가 있어도** cut-on 이 legacy 와 다른 신원/
-# 프로젝트로 해소되면 cut 후 권한 드리프트. legacy(auth.py:136)=team_members ORDER BY project_id LIMIT 1,
-# anchor(auth.py:119)=agent_project_profiles ORDER BY created_at LIMIT 1 → 멀티프로젝트 agent 는 기본
-# 프로젝트가 갈릴 수 있다. member_id≠team_member_id=0075 invariant 파손. org 불일치도 점검.
+# 프로젝트로 해소되면 cut 후 권한 드리프트. legacy=team_members(0110 뷰) ORDER BY project_id LIMIT 1,
+# anchor=resolver 와 동일 union(agent_project_profiles ∪ project_access granted) ORDER BY project_id LIMIT 1.
+# team_members 뷰 agent set = 그 union 이므로 정상이면 proj_mismatch 0 — 어긋나면 union 복제 회귀/0075
+# 파손/grant-only 누락 감지. member_id≠team_member_id=0075 invariant 파손. org 불일치도 점검.
 PARITY_SQL = """
 SELECT ak.id AS api_key_id, ak.team_member_id, ak.member_id,
        leg.project_id AS legacy_proj, anc.project_id AS anchor_proj,
@@ -83,9 +89,14 @@ LEFT JOIN LATERAL (
     ORDER BY tm.project_id LIMIT 1
 ) leg ON TRUE
 LEFT JOIN LATERAL (
-    SELECT app.project_id FROM agent_project_profiles app
-    WHERE app.member_id = ak.member_id
-    ORDER BY app.created_at ASC LIMIT 1
+    -- resolver(auth.py)와 동일 set: agent_project_profiles ∪ project_access(granted). legacy(team_members
+    -- 뷰=동일 union)와 비교 → union 이 뷰 set 과 어긋나면(복제 회귀) proj_mismatch 로 적출(self-check).
+    SELECT u.project_id FROM (
+        SELECT project_id FROM agent_project_profiles WHERE member_id = ak.member_id
+        UNION
+        SELECT project_id FROM project_access WHERE member_id = ak.member_id AND permission = 'granted'
+    ) u
+    ORDER BY u.project_id ASC LIMIT 1
 ) anc ON TRUE
 WHERE ak.revoked_at IS NULL AND (ak.expires_at IS NULL OR ak.expires_at > now())
   -- legacy 가 실제 해소되는 키만(dead 키의 legacy NULL 을 anchor 와 비교해 가짜 드리프트로 잡지 않도록).
@@ -93,6 +104,21 @@ WHERE ak.revoked_at IS NULL AND (ak.expires_at IS NULL OR ak.expires_at > now())
   AND ( ak.member_id IS DISTINCT FROM ak.team_member_id
      OR anc.project_id IS DISTINCT FROM leg.project_id
      OR m.org_id IS DISTINCT FROM leg.org_id )
+ORDER BY ak.created_at
+"""
+
+# (c) widening(까심 finding②): legacy 는 active team_members 0(=접근 프로젝트 0)이면 401 인데, cut-on 이
+# 통과하면 인증 확대. member valid(agent,active,not-deleted)인데 active team_members 가 없는 active 키 —
+# auth.py ①(proj None→401)이 런타임 차단하지만, audit 가 그 키 존재 자체를 게이트로 surface(있으면 flip 前
+# placement/revoke). union==team_members(뷰) 이므로 이 키 = 무프로젝트 키. regression 의 EXISTS(active tm)
+# 필터가 못 보는 반대 방향.
+WIDENING_SQL = """
+SELECT ak.id AS api_key_id, ak.team_member_id, ak.member_id
+FROM agent_api_keys ak
+JOIN members m ON m.id = ak.member_id
+             AND m.type = 'agent' AND m.is_active AND m.deleted_at IS NULL
+WHERE ak.revoked_at IS NULL AND (ak.expires_at IS NULL OR ak.expires_at > now())
+  AND NOT EXISTS (SELECT 1 FROM team_members tm WHERE tm.id = ak.team_member_id AND tm.is_active)
 ORDER BY ak.created_at
 """
 
@@ -106,6 +132,7 @@ async def main() -> int:
         fk_bad = (await s.execute(text(FK_VIOLATION_SQL))).scalar_one()
         parity = (await s.execute(text(PARITY_SQL))).mappings().all()
         dead = (await s.execute(text(DEAD_KEYS_SQL))).scalar_one()
+        widen = (await s.execute(text(WIDENING_SQL))).mappings().all()
 
     print(f"=== (a) cut REGRESSION (legacy 200·anchor 401) active key {len(rows)}건 ===")
     for r in rows:
@@ -123,12 +150,15 @@ async def main() -> int:
             f"  api_key={r['api_key_id']} tm={r['team_member_id']} member_id={r['member_id']} diverge=[{diverge}] "
             f"legacy_proj={r['legacy_proj']} anchor_proj={r['anchor_proj']} legacy_org={r['legacy_org']} anchor_org={r['anchor_org']}"
         )
+    print(f"=== (c) widening (legacy 401·무프로젝트인데 member valid) active key {len(widen)}건 ===")
+    for r in widen:
+        print(f"  api_key={r['api_key_id']} tm={r['team_member_id']} member_id={r['member_id']} (무프로젝트·auth.py ① 401 처리)")
     print(f"--- INFO: dead 키(legacy·anchor 둘 다 이미 401·flip 무관·revoke 후보) {dead}건 ---")
 
-    if len(rows) == 0 and fk_bad == 0 and len(parity) == 0:
-        print(f"[PASS] (a)regression + (b)드리프트 + FK 모두 0 — flag-on 안전(cut 절대전제 충족). dead 키 {dead}건은 flip 무관(별도 revoke 후보)")
+    if len(rows) == 0 and fk_bad == 0 and len(parity) == 0 and len(widen) == 0:
+        print(f"[PASS] (a)regression + (b)드리프트 + (c)widening + FK 모두 0 — flag-on 안전. dead 키 {dead}건은 flip 무관(별도 revoke)")
         return 0
-    print("[WARN] 위반 존재 — flag-on 前 처리 필요(regression: 0075 정합/members 보정 · 해소드리프트: 기본프로젝트 정렬 정합)")
+    print("[WARN] 위반 존재 — flag-on 前 처리(regression: 0075/members 보정 · 드리프트: union 정합 · widening: 무프로젝트 키 placement/revoke)")
     return 1
 
 

--- a/backend/sprintable_mcp/tools/stories.py
+++ b/backend/sprintable_mcp/tools/stories.py
@@ -79,8 +79,13 @@ async def list_stories(args: ListStoriesInput) -> list[TextContent]:
 
 async def list_backlog(args: SprintableInput) -> list[TextContent]:
     """백로그 스토리 목록 (스프린트 미배정)."""
+    # b5870c4c: 전용 `/stories/backlog` 라우트 부재 → `/{id}` 로 shadow 돼 422(id="backlog" 非-UUID).
+    # 기존 list 엔드포인트 + `no_sprint` 필터(server-side repo.list_backlog·sprint 미배정·docstring 정합) 재사용.
+    # ⚠️ no_sprint 는 project_id 와 함께여야 backlog 분기 동작(stories.py list_stories).
     try:
-        return ok(await client.get("/api/v2/stories/backlog", params={"project_id": client.project_id}))
+        return ok(await client.get(
+            "/api/v2/stories", params={"project_id": client.project_id, "no_sprint": "true"}
+        ))
     except Exception as exc:
         return err(str(exc))
 

--- a/backend/tests/test_audit_apikey_parity_realdb.py
+++ b/backend/tests/test_audit_apikey_parity_realdb.py
@@ -1,8 +1,9 @@
-"""f5ee8387 H2 audit 정밀화 검증 — cut REGRESSION 게이트가 '깨지는 키'만 잡고 'dead 키'는 INFO 로 분리,
-(b) parity 가 project-default 드리프트를 잡는지 락. DB env 없으면 skip(CI alembic-fresh).
+"""f5ee8387 H2 audit 검증 — cut REGRESSION 게이트('깨지는 키'만·dead 는 INFO) + parity(정렬 정합 後
+멀티프로젝트 무드리프트 + id_mismatch 적출). DB env 없으면 skip(CI alembic-fresh).
 
-PO dev audit 적발: 기존 (a)가 legacy 도 이미 401 인 dead 키(inactive tm)까지 위반으로 inflation(team_members
-projection VIEW dup 포함). 정밀화 = (a) regression(legacy 200·anchor 401)만 게이트·dead 는 count(DISTINCT) INFO.
+prod audit가 (b)서 산티아고 멀티프로젝트 agent 기본프로젝트 드리프트(legacy project_id ASC vs anchor
+created_at ASC) 적발 → anchor 정렬을 legacy 와 동일 project_id ASC 로 정합(auth.py + PARITY_SQL).
+정합 後엔 정상 데이터면 proj 드리프트 0(M_DIVERGE 미적출)·id_mismatch 만 parity 가 잡는다.
 """
 from __future__ import annotations
 
@@ -13,7 +14,12 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from scripts.jobs.audit_apikey_member_anchor import AUDIT_SQL, DEAD_KEYS_SQL, PARITY_SQL
+from scripts.jobs.audit_apikey_member_anchor import (
+    AUDIT_SQL,
+    DEAD_KEYS_SQL,
+    PARITY_SQL,
+    WIDENING_SQL,
+)
 
 _RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
 _ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
@@ -22,17 +28,24 @@ _ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace
 pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
 
 ORG = uuid.UUID("a5000000-0000-0000-0000-000000000001")
-P1 = uuid.UUID("a5000000-0000-0000-0000-0000000000a1")  # P1 < P2 (legacy ORDER BY project_id → P1)
+P1 = uuid.UUID("a5000000-0000-0000-0000-0000000000a1")  # P1 < P2 (project_id ASC → P1)
 P2 = uuid.UUID("a5000000-0000-0000-0000-0000000000b2")
-M_OK = uuid.UUID("a5000000-0000-0000-0000-0000000000e1")        # 단일프로젝트·일치
-M_DIVERGE = uuid.UUID("a5000000-0000-0000-0000-0000000000d1")   # 멀티프로젝트·드리프트
+M_OK = uuid.UUID("a5000000-0000-0000-0000-0000000000e1")        # 단일프로젝트
+M_DIVERGE = uuid.UUID("a5000000-0000-0000-0000-0000000000d1")   # 멀티프로젝트(정렬 정합 後 무드리프트)
 M_REG = uuid.UUID("a5000000-0000-0000-0000-0000000000c1")       # active(legacy 200)
 M_INACTIVE = uuid.UUID("a5000000-0000-0000-0000-0000000000c2")  # inactive anchor(K_REG 가 가리킴 → anchor 401)
 M_DEAD = uuid.UUID("a5000000-0000-0000-0000-0000000000f1")      # inactive(legacy·anchor 둘 다 401)
+M_TMSIDE = uuid.UUID("a5000000-0000-0000-0000-0000000000aa")    # K_IDD legacy 측(active)
+M_ANCHORSIDE = uuid.UUID("a5000000-0000-0000-0000-0000000000bb")  # K_IDD anchor 측(active·다른 id)
+M_GRANT = uuid.UUID("a5000000-0000-0000-0000-0000000000cc")     # grant-only(profile P2 + grant P1)
+M_NOPROJ = uuid.UUID("a5000000-0000-0000-0000-0000000000dd")    # member valid·무프로젝트(widening 케이스)
 K_OK = uuid.UUID("a5000000-0000-0000-0000-00000000ba01")
 K_DIV = uuid.UUID("a5000000-0000-0000-0000-00000000ba02")
 K_REG = uuid.UUID("a5000000-0000-0000-0000-00000000ba03")
 K_DEAD = uuid.UUID("a5000000-0000-0000-0000-00000000ba04")
+K_IDD = uuid.UUID("a5000000-0000-0000-0000-00000000ba05")       # member_id≠team_member_id(id_mismatch)
+K_GRANT = uuid.UUID("a5000000-0000-0000-0000-00000000ba06")     # grant-only 최소 project_id(까심 BLOCKER 케이스)
+K_NOPROJ = uuid.UUID("a5000000-0000-0000-0000-00000000ba07")    # 무프로젝트 member-valid(widening·까심 finding②)
 
 
 @pytest.fixture
@@ -41,10 +54,14 @@ def anyio_backend():
 
 
 async def _seed(s):
+    keys = f"'{K_OK}','{K_DIV}','{K_REG}','{K_DEAD}','{K_IDD}','{K_GRANT}','{K_NOPROJ}'"
+    members = (
+        f"'{M_OK}','{M_DIVERGE}','{M_REG}','{M_DEAD}','{M_TMSIDE}','{M_ANCHORSIDE}','{M_GRANT}','{M_NOPROJ}'"
+    )
     for sql in [
-        f"DELETE FROM agent_api_keys WHERE id IN ('{K_OK}','{K_DIV}','{K_REG}','{K_DEAD}')",
-        f"DELETE FROM agent_project_profiles WHERE member_id IN "
-        f"('{M_OK}','{M_DIVERGE}','{M_REG}','{M_DEAD}')",
+        f"DELETE FROM agent_api_keys WHERE id IN ({keys})",
+        f"DELETE FROM project_access WHERE member_id IN ({members})",
+        f"DELETE FROM agent_project_profiles WHERE member_id IN ({members})",
         f"DELETE FROM members WHERE org_id='{ORG}'",
         f"DELETE FROM projects WHERE org_id='{ORG}'",
         f"DELETE FROM organizations WHERE id='{ORG}'",
@@ -53,28 +70,42 @@ async def _seed(s):
         "INSERT INTO members (id,org_id,type,name,is_active) VALUES "
         f"('{M_OK}','{ORG}','agent','Ok',true),('{M_DIVERGE}','{ORG}','agent','Div',true),"
         f"('{M_REG}','{ORG}','agent','Reg',true),('{M_INACTIVE}','{ORG}','agent','Inact',false),"
-        f"('{M_DEAD}','{ORG}','agent','Dead',false)",
-        # agent_project_profiles → team_members(view) 행. M_DIVERGE: P2 가 더 일찍 생성(anchor=created_at→P2)·legacy=P1.
+        f"('{M_DEAD}','{ORG}','agent','Dead',false),('{M_TMSIDE}','{ORG}','agent','TmSide',true),"
+        f"('{M_ANCHORSIDE}','{ORG}','agent','AnchorSide',true),('{M_GRANT}','{ORG}','agent','Grant',true),"
+        f"('{M_NOPROJ}','{ORG}','agent','NoProj',true)",
+        # M_DIVERGE: P2 프로파일이 더 일찍 생성 — created_at 정렬이면 P2(legacy P1과 드리프트)였으나,
+        # project_id 정렬 정합 後엔 anchor 도 P1(최소 project_id) → 드리프트 0.
         "INSERT INTO agent_project_profiles (id,member_id,project_id,agent_role,fakechat_port,created_at) VALUES "
         f"(gen_random_uuid(),'{M_OK}','{P1}','dev',9803,'2026-01-01T00:00:00+00'),"
         f"(gen_random_uuid(),'{M_DIVERGE}','{P2}','dev',9801,'2026-01-01T00:00:00+00'),"
         f"(gen_random_uuid(),'{M_DIVERGE}','{P1}','dev',9802,'2026-02-01T00:00:00+00'),"
         f"(gen_random_uuid(),'{M_REG}','{P1}','dev',9804,'2026-01-01T00:00:00+00'),"
-        f"(gen_random_uuid(),'{M_DEAD}','{P1}','dev',9805,'2026-01-01T00:00:00+00')",
-        # 키: K_REG = legacy(M_REG active) 200 · anchor(M_INACTIVE) 401 → regression.
-        #     K_DEAD = legacy(M_DEAD inactive)·anchor 둘 다 401 → dead(INFO).
+        f"(gen_random_uuid(),'{M_DEAD}','{P1}','dev',9805,'2026-01-01T00:00:00+00'),"
+        f"(gen_random_uuid(),'{M_TMSIDE}','{P1}','dev',9806,'2026-01-01T00:00:00+00'),"
+        f"(gen_random_uuid(),'{M_ANCHORSIDE}','{P1}','dev',9807,'2026-01-01T00:00:00+00'),"
+        # M_GRANT: profile 은 P2(높은 project_id)에만·P1 은 grant-only(profile 無·project_access granted).
+        f"(gen_random_uuid(),'{M_GRANT}','{P2}','dev',9808,'2026-01-01T00:00:00+00')",
+        # M_GRANT grant-only: P1(최소 project_id) 에 profile 없이 granted → team_members 뷰 branch3.
+        # 까심 BLOCKER: profile-only resolver 면 P2(드리프트), union resolver 면 P1(=legacy·무드리프트).
+        f"INSERT INTO project_access (id,project_id,member_id,permission) VALUES "
+        f"(gen_random_uuid(),'{P1}','{M_GRANT}','granted')",
+        # K_REG=regression · K_DEAD=dead(INFO) · K_IDD=id_mismatch · K_GRANT=grant-only-lowest.
         "INSERT INTO agent_api_keys (id,team_member_id,member_id,key_prefix,key_hash,created_at) VALUES "
         f"('{K_OK}','{M_OK}','{M_OK}','sk_o','h_o',now()),"
         f"('{K_DIV}','{M_DIVERGE}','{M_DIVERGE}','sk_d','h_d',now()),"
         f"('{K_REG}','{M_REG}','{M_INACTIVE}','sk_r','h_r',now()),"
-        f"('{K_DEAD}','{M_DEAD}','{M_DEAD}','sk_x','h_x',now())",
+        f"('{K_DEAD}','{M_DEAD}','{M_DEAD}','sk_x','h_x',now()),"
+        f"('{K_IDD}','{M_TMSIDE}','{M_ANCHORSIDE}','sk_i','h_i',now()),"
+        f"('{K_GRANT}','{M_GRANT}','{M_GRANT}','sk_g','h_g',now()),"
+        # K_NOPROJ: member valid 인데 profile·grant 0 → active team_members 0 → legacy 401·widening 케이스.
+        f"('{K_NOPROJ}','{M_NOPROJ}','{M_NOPROJ}','sk_n','h_n',now())",
     ]:
         await s.execute(text(sql))
     await s.commit()
 
 
 @pytest.mark.anyio
-async def test_audit_regression_gate_and_parity():
+async def test_audit_regression_gate_and_aligned_parity():
     engine = create_async_engine(_ASYNC)
     Session = async_sessionmaker(engine, expire_on_commit=False)
     try:
@@ -82,16 +113,62 @@ async def test_audit_regression_gate_and_parity():
             await _seed(s)
             reg = {r["api_key_id"] for r in (await s.execute(text(AUDIT_SQL))).mappings().all()}
             dead = (await s.execute(text(DEAD_KEYS_SQL))).scalar_one()
-            parity = {r["member_id"]: r for r in (await s.execute(text(PARITY_SQL))).mappings().all()}
+            parity = {r["api_key_id"]: r for r in (await s.execute(text(PARITY_SQL))).mappings().all()}
+            widen = {r["api_key_id"] for r in (await s.execute(text(WIDENING_SQL))).mappings().all()}
 
             # (a) regression: legacy 200·anchor 401 인 K_REG 만. dead/ok/valid 는 제외.
             assert K_REG in reg, f"regression 미적출: {reg}"
-            assert K_DEAD not in reg, "dead 키가 regression 으로 오분류(flip 무관인데)"
+            assert K_DEAD not in reg, "dead 키가 regression 으로 오분류"
             assert K_OK not in reg and K_DIV not in reg, "정상 키 false-positive"
-            # dead 키(K_DEAD)는 INFO count 로만(≥1·DISTINCT 라 dup inflation 없음).
             assert dead >= 1, f"dead 키 INFO 미집계: {dead}"
-            # (b) parity: 멀티프로젝트 드리프트 M_DIVERGE 만(proj_mismatch).
-            assert M_DIVERGE in parity and parity[M_DIVERGE]["proj_mismatch"] is True
-            assert M_OK not in parity, "단일프로젝트 일치 agent false-positive"
+
+            # (b) union 해소 後: 멀티프로젝트 M_DIVERGE 는 anchor 도 project_id ASC → P1 = legacy → 무드리프트.
+            assert K_DIV not in parity, "정렬 정합 後에도 멀티프로젝트 드리프트(정합 미적용?)"
+            assert K_OK not in parity, "단일프로젝트 false-positive"
+            # 까심 BLOCKER: grant-only 최소 project_id(P1)도 union(agent_project_profiles ∪ project_access granted)
+            # 에 포함 → anchor MIN=P1=legacy team_members(branch3) → 무드리프트. profile-only resolver 면 P2 드리프트.
+            assert K_GRANT not in parity, "grant-only 최소 project 미union(profile-only resolver 잔여 드리프트)"
+
+            # (c) widening(까심 finding②): 무프로젝트 member-valid(K_NOPROJ)는 legacy 401인데 cut-on 통과 위험
+            # → audit 가 게이트로 적출. 프로젝트 있는 키(OK/DIV/GRANT)는 active tm 존재라 미적출.
+            assert K_NOPROJ in widen, f"무프로젝트 widening 미적출: {widen}"
+            assert K_OK not in widen and K_DIV not in widen and K_GRANT not in widen, "프로젝트 보유 키 widening false-positive"
+            # parity 는 여전히 id_mismatch(0075 파손) 를 잡는다 — K_IDD(member≠tm).
+            assert K_IDD in parity and parity[K_IDD]["id_mismatch"] is True
+            assert parity[K_IDD]["proj_mismatch"] is False  # 둘 다 P1 → proj 는 정합
     finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_resolver_cut_on_no_project_raises_401():
+    """auth.py finding①(까심 v3): cut-on flag-on 에서 member valid·접근 프로젝트 0(M_NOPROJ: profile·grant
+    둘 다 없음 → union 빈)인 agent 키는 `_resolve_api_key` 가 **401** — legacy(team_members 0행=401)와 동치.
+    audit (c) widening 게이트의 **resolver 측 짝**: `if proj is None: raise 401` 코드 경로 직접 락(제거 시 fail)."""
+    from fastapi import HTTPException
+
+    from app.core import config as _cfg
+    from app.core.security import hash_token
+    from app.dependencies.auth import _resolve_api_key
+
+    raw = "sk_live_noproj" + "9" * 50
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    prev = _cfg.settings.member_ssot_apikey_cut
+    try:
+        async with Session() as s:
+            await _seed(s)
+            # K_NOPROJ(member=M_NOPROJ·profile·grant 0)의 key_hash 를 실 해시로 → _resolve_api_key 가 조회 가능.
+            await s.execute(
+                text("UPDATE agent_api_keys SET key_hash = :h WHERE id = :k"),
+                {"h": hash_token(raw), "k": str(K_NOPROJ)},
+            )
+            await s.commit()
+        _cfg.settings.member_ssot_apikey_cut = True
+        async with Session() as s:
+            with pytest.raises(HTTPException) as e:
+                await _resolve_api_key(raw, s)
+            assert e.value.status_code == 401, f"무프로젝트 cut-on 이 401 아님(widening): {e.value.status_code}"
+    finally:
+        _cfg.settings.member_ssot_apikey_cut = prev
         await engine.dispose()

--- a/backend/tests/test_audit_apikey_parity_realdb.py
+++ b/backend/tests/test_audit_apikey_parity_realdb.py
@@ -1,0 +1,80 @@
+"""f5ee8387 H2 audit (b) parity — anchor≠legacy 해소 드리프트 적출 검증. DB env 없으면 skip(CI alembic-fresh).
+
+핵심 리스크: 멀티프로젝트 agent 의 cut-on 기본 프로젝트가 legacy(team_members ORDER BY project_id)와
+anchor(agent_project_profiles ORDER BY created_at)서 갈릴 수 있다. PARITY_SQL 이 그 드리프트를 잡는지 락.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from scripts.jobs.audit_apikey_member_anchor import PARITY_SQL
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("a5000000-0000-0000-0000-000000000001")
+# P1 < P2 (legacy ORDER BY project_id → P1 선택)
+P1 = uuid.UUID("a5000000-0000-0000-0000-0000000000a1")
+P2 = uuid.UUID("a5000000-0000-0000-0000-0000000000b2")
+M_DIVERGE = uuid.UUID("a5000000-0000-0000-0000-0000000000d1")  # 멀티프로젝트·드리프트
+M_OK = uuid.UUID("a5000000-0000-0000-0000-0000000000e1")       # 단일프로젝트·일치
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _seed(s):
+    for sql in [
+        f"DELETE FROM agent_api_keys WHERE member_id IN ('{M_DIVERGE}','{M_OK}')",
+        f"DELETE FROM agent_project_profiles WHERE member_id IN ('{M_DIVERGE}','{M_OK}')",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','A5','a5org','free')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{P1}','{ORG}','P1'),('{P2}','{ORG}','P2')",
+        "INSERT INTO members (id,org_id,type,name,is_active) VALUES "
+        f"('{M_DIVERGE}','{ORG}','agent','Diverge',true),('{M_OK}','{ORG}','agent','Ok',true)",
+        # M_DIVERGE: P2 프로파일이 더 일찍 생성(anchor=created_at ASC → P2)·legacy=ORDER BY project_id → P1 → 드리프트.
+        "INSERT INTO agent_project_profiles (id,member_id,project_id,agent_role,fakechat_port,created_at) VALUES "
+        f"(gen_random_uuid(),'{M_DIVERGE}','{P2}','dev',9801,'2026-01-01T00:00:00+00'),"
+        f"(gen_random_uuid(),'{M_DIVERGE}','{P1}','dev',9802,'2026-02-01T00:00:00+00')",
+        # M_OK: 단일 프로젝트 → legacy=anchor=P1.
+        "INSERT INTO agent_project_profiles (id,member_id,project_id,agent_role,fakechat_port,created_at) VALUES "
+        f"(gen_random_uuid(),'{M_OK}','{P1}','dev',9803,'2026-01-01T00:00:00+00')",
+        # agent_api_keys: member_id=team_member_id(0075 정합)·active.
+        "INSERT INTO agent_api_keys (id,team_member_id,member_id,key_prefix,key_hash,created_at) VALUES "
+        f"(gen_random_uuid(),'{M_DIVERGE}','{M_DIVERGE}','sk_d','hash_d',now()),"
+        f"(gen_random_uuid(),'{M_OK}','{M_OK}','sk_o','hash_o',now())",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+@pytest.mark.anyio
+async def test_parity_catches_project_default_drift():
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+            rows = (await s.execute(text(PARITY_SQL))).mappings().all()
+            flagged = {r["member_id"]: r for r in rows}
+            # 드리프트 agent 는 잡히고(proj_mismatch·legacy P1·anchor P2)·일치 agent 는 미적출.
+            assert M_DIVERGE in flagged, f"드리프트 미적출: {list(flagged)}"
+            d = flagged[M_DIVERGE]
+            assert d["proj_mismatch"] is True
+            assert str(d["legacy_proj"]) == str(P1) and str(d["anchor_proj"]) == str(P2)
+            assert not d["id_mismatch"] and not d["org_mismatch"]  # id/org 는 일치(proj 만 드리프트)
+            assert M_OK not in flagged, "단일프로젝트 일치 agent 가 false-positive"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_audit_apikey_parity_realdb.py
+++ b/backend/tests/test_audit_apikey_parity_realdb.py
@@ -1,7 +1,8 @@
-"""f5ee8387 H2 audit (b) parity — anchor≠legacy 해소 드리프트 적출 검증. DB env 없으면 skip(CI alembic-fresh).
+"""f5ee8387 H2 audit 정밀화 검증 — cut REGRESSION 게이트가 '깨지는 키'만 잡고 'dead 키'는 INFO 로 분리,
+(b) parity 가 project-default 드리프트를 잡는지 락. DB env 없으면 skip(CI alembic-fresh).
 
-핵심 리스크: 멀티프로젝트 agent 의 cut-on 기본 프로젝트가 legacy(team_members ORDER BY project_id)와
-anchor(agent_project_profiles ORDER BY created_at)서 갈릴 수 있다. PARITY_SQL 이 그 드리프트를 잡는지 락.
+PO dev audit 적발: 기존 (a)가 legacy 도 이미 401 인 dead 키(inactive tm)까지 위반으로 inflation(team_members
+projection VIEW dup 포함). 정밀화 = (a) regression(legacy 200·anchor 401)만 게이트·dead 는 count(DISTINCT) INFO.
 """
 from __future__ import annotations
 
@@ -12,7 +13,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
-from scripts.jobs.audit_apikey_member_anchor import PARITY_SQL
+from scripts.jobs.audit_apikey_member_anchor import AUDIT_SQL, DEAD_KEYS_SQL, PARITY_SQL
 
 _RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
 _ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
@@ -21,11 +22,17 @@ _ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace
 pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
 
 ORG = uuid.UUID("a5000000-0000-0000-0000-000000000001")
-# P1 < P2 (legacy ORDER BY project_id → P1 선택)
-P1 = uuid.UUID("a5000000-0000-0000-0000-0000000000a1")
+P1 = uuid.UUID("a5000000-0000-0000-0000-0000000000a1")  # P1 < P2 (legacy ORDER BY project_id → P1)
 P2 = uuid.UUID("a5000000-0000-0000-0000-0000000000b2")
-M_DIVERGE = uuid.UUID("a5000000-0000-0000-0000-0000000000d1")  # 멀티프로젝트·드리프트
-M_OK = uuid.UUID("a5000000-0000-0000-0000-0000000000e1")       # 단일프로젝트·일치
+M_OK = uuid.UUID("a5000000-0000-0000-0000-0000000000e1")        # 단일프로젝트·일치
+M_DIVERGE = uuid.UUID("a5000000-0000-0000-0000-0000000000d1")   # 멀티프로젝트·드리프트
+M_REG = uuid.UUID("a5000000-0000-0000-0000-0000000000c1")       # active(legacy 200)
+M_INACTIVE = uuid.UUID("a5000000-0000-0000-0000-0000000000c2")  # inactive anchor(K_REG 가 가리킴 → anchor 401)
+M_DEAD = uuid.UUID("a5000000-0000-0000-0000-0000000000f1")      # inactive(legacy·anchor 둘 다 401)
+K_OK = uuid.UUID("a5000000-0000-0000-0000-00000000ba01")
+K_DIV = uuid.UUID("a5000000-0000-0000-0000-00000000ba02")
+K_REG = uuid.UUID("a5000000-0000-0000-0000-00000000ba03")
+K_DEAD = uuid.UUID("a5000000-0000-0000-0000-00000000ba04")
 
 
 @pytest.fixture
@@ -35,46 +42,56 @@ def anyio_backend():
 
 async def _seed(s):
     for sql in [
-        f"DELETE FROM agent_api_keys WHERE member_id IN ('{M_DIVERGE}','{M_OK}')",
-        f"DELETE FROM agent_project_profiles WHERE member_id IN ('{M_DIVERGE}','{M_OK}')",
+        f"DELETE FROM agent_api_keys WHERE id IN ('{K_OK}','{K_DIV}','{K_REG}','{K_DEAD}')",
+        f"DELETE FROM agent_project_profiles WHERE member_id IN "
+        f"('{M_OK}','{M_DIVERGE}','{M_REG}','{M_DEAD}')",
         f"DELETE FROM members WHERE org_id='{ORG}'",
         f"DELETE FROM projects WHERE org_id='{ORG}'",
         f"DELETE FROM organizations WHERE id='{ORG}'",
         f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','A5','a5org','free')",
         f"INSERT INTO projects (id,org_id,name) VALUES ('{P1}','{ORG}','P1'),('{P2}','{ORG}','P2')",
         "INSERT INTO members (id,org_id,type,name,is_active) VALUES "
-        f"('{M_DIVERGE}','{ORG}','agent','Diverge',true),('{M_OK}','{ORG}','agent','Ok',true)",
-        # M_DIVERGE: P2 프로파일이 더 일찍 생성(anchor=created_at ASC → P2)·legacy=ORDER BY project_id → P1 → 드리프트.
+        f"('{M_OK}','{ORG}','agent','Ok',true),('{M_DIVERGE}','{ORG}','agent','Div',true),"
+        f"('{M_REG}','{ORG}','agent','Reg',true),('{M_INACTIVE}','{ORG}','agent','Inact',false),"
+        f"('{M_DEAD}','{ORG}','agent','Dead',false)",
+        # agent_project_profiles → team_members(view) 행. M_DIVERGE: P2 가 더 일찍 생성(anchor=created_at→P2)·legacy=P1.
         "INSERT INTO agent_project_profiles (id,member_id,project_id,agent_role,fakechat_port,created_at) VALUES "
+        f"(gen_random_uuid(),'{M_OK}','{P1}','dev',9803,'2026-01-01T00:00:00+00'),"
         f"(gen_random_uuid(),'{M_DIVERGE}','{P2}','dev',9801,'2026-01-01T00:00:00+00'),"
-        f"(gen_random_uuid(),'{M_DIVERGE}','{P1}','dev',9802,'2026-02-01T00:00:00+00')",
-        # M_OK: 단일 프로젝트 → legacy=anchor=P1.
-        "INSERT INTO agent_project_profiles (id,member_id,project_id,agent_role,fakechat_port,created_at) VALUES "
-        f"(gen_random_uuid(),'{M_OK}','{P1}','dev',9803,'2026-01-01T00:00:00+00')",
-        # agent_api_keys: member_id=team_member_id(0075 정합)·active.
+        f"(gen_random_uuid(),'{M_DIVERGE}','{P1}','dev',9802,'2026-02-01T00:00:00+00'),"
+        f"(gen_random_uuid(),'{M_REG}','{P1}','dev',9804,'2026-01-01T00:00:00+00'),"
+        f"(gen_random_uuid(),'{M_DEAD}','{P1}','dev',9805,'2026-01-01T00:00:00+00')",
+        # 키: K_REG = legacy(M_REG active) 200 · anchor(M_INACTIVE) 401 → regression.
+        #     K_DEAD = legacy(M_DEAD inactive)·anchor 둘 다 401 → dead(INFO).
         "INSERT INTO agent_api_keys (id,team_member_id,member_id,key_prefix,key_hash,created_at) VALUES "
-        f"(gen_random_uuid(),'{M_DIVERGE}','{M_DIVERGE}','sk_d','hash_d',now()),"
-        f"(gen_random_uuid(),'{M_OK}','{M_OK}','sk_o','hash_o',now())",
+        f"('{K_OK}','{M_OK}','{M_OK}','sk_o','h_o',now()),"
+        f"('{K_DIV}','{M_DIVERGE}','{M_DIVERGE}','sk_d','h_d',now()),"
+        f"('{K_REG}','{M_REG}','{M_INACTIVE}','sk_r','h_r',now()),"
+        f"('{K_DEAD}','{M_DEAD}','{M_DEAD}','sk_x','h_x',now())",
     ]:
         await s.execute(text(sql))
     await s.commit()
 
 
 @pytest.mark.anyio
-async def test_parity_catches_project_default_drift():
+async def test_audit_regression_gate_and_parity():
     engine = create_async_engine(_ASYNC)
     Session = async_sessionmaker(engine, expire_on_commit=False)
     try:
         async with Session() as s:
             await _seed(s)
-            rows = (await s.execute(text(PARITY_SQL))).mappings().all()
-            flagged = {r["member_id"]: r for r in rows}
-            # 드리프트 agent 는 잡히고(proj_mismatch·legacy P1·anchor P2)·일치 agent 는 미적출.
-            assert M_DIVERGE in flagged, f"드리프트 미적출: {list(flagged)}"
-            d = flagged[M_DIVERGE]
-            assert d["proj_mismatch"] is True
-            assert str(d["legacy_proj"]) == str(P1) and str(d["anchor_proj"]) == str(P2)
-            assert not d["id_mismatch"] and not d["org_mismatch"]  # id/org 는 일치(proj 만 드리프트)
-            assert M_OK not in flagged, "단일프로젝트 일치 agent 가 false-positive"
+            reg = {r["api_key_id"] for r in (await s.execute(text(AUDIT_SQL))).mappings().all()}
+            dead = (await s.execute(text(DEAD_KEYS_SQL))).scalar_one()
+            parity = {r["member_id"]: r for r in (await s.execute(text(PARITY_SQL))).mappings().all()}
+
+            # (a) regression: legacy 200·anchor 401 인 K_REG 만. dead/ok/valid 는 제외.
+            assert K_REG in reg, f"regression 미적출: {reg}"
+            assert K_DEAD not in reg, "dead 키가 regression 으로 오분류(flip 무관인데)"
+            assert K_OK not in reg and K_DIV not in reg, "정상 키 false-positive"
+            # dead 키(K_DEAD)는 INFO count 로만(≥1·DISTINCT 라 dup inflation 없음).
+            assert dead >= 1, f"dead 키 INFO 미집계: {dead}"
+            # (b) parity: 멀티프로젝트 드리프트 M_DIVERGE 만(proj_mismatch).
+            assert M_DIVERGE in parity and parity[M_DIVERGE]["proj_mismatch"] is True
+            assert M_OK not in parity, "단일프로젝트 일치 agent false-positive"
     finally:
         await engine.dispose()

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -1,6 +1,5 @@
 """S18+S25+S32: conftest fixture 기반 통합 테스트 — Sprint 3+4+5 도메인 헬스 체크."""
 import uuid
-from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -238,7 +237,9 @@ async def test_project_settings_get_via_conftest(test_client, mock_session, proj
     mock_result.scalar_one_or_none.return_value = None
     mock_session.execute = AsyncMock(return_value=mock_result)
 
-    resp = await test_client.get(f"/api/v2/project-settings?project_id={project_id}")
+    from unittest.mock import patch as _patch
+    with _patch("app.routers.project_settings.has_project_access", new_callable=AsyncMock, return_value=True):
+        resp = await test_client.get(f"/api/v2/project-settings?project_id={project_id}")
     assert resp.status_code == 200
     assert resp.json()["standup_deadline"] == "09:00:00"
 

--- a/backend/tests/test_l2_trigger_worker.py
+++ b/backend/tests/test_l2_trigger_worker.py
@@ -199,6 +199,33 @@ async def test_collect_epic_deadlines_dispatchable_anchor():
     assert pair_org == org and d.anchor_type in ("epic", "story", "doc")  # dispatchable.
 
 
+@pytest.mark.anyio
+async def test_collect_sprint_deadlines_dispatchable_anchor():
+    """ed904b9d AC③: sprint deadline → wake. sprint 은 assignee 컬럼 없음 → _fetch_entity 가 relay-owner 로
+    target 해소(S27). dispatchable anchor 라 L2 firing 이 wake skip 안 됨."""
+    w = L2TriggerWorker(use_advisory_lock=False)
+    owner, org, sprint_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    now = datetime.now(timezone.utc)
+    rows = [{
+        "id": sprint_id, "org_id": org,
+        # sprint 윈도우=deadline_sprint_end_h(24h). collect 가 end_date를 당일 23:59:59 로 combine 하므로
+        # 오늘 날짜면 remaining ≤ 24h → 임박 발사(어느 시각이든 안정·non-flaky).
+        "end_date": now.date(),
+        "status": "active",
+    }]
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_rows_result(rows))
+    with patch(
+        "app.services.agent_dispatch._fetch_entity", new_callable=AsyncMock,
+        return_value=(owner, "Sprint", "status=active", uuid.uuid4()),
+    ):
+        pairs = await w._collect_sprint_deadlines(db, now)
+    assert len(pairs) == 1
+    d, pair_org = pairs[0]
+    assert d.anchor_type == "sprint" and d.anchor_id == sprint_id and d.target_agent_id == owner
+    assert pair_org == org
+
+
 # ── S6: dedup 발사 ─────────────────────────────────────────────────────────────
 
 def _decision(anchor_type="epic", seq=None):

--- a/backend/tests/test_mcp_list_backlog_b5870c4c.py
+++ b/backend/tests/test_mcp_list_backlog_b5870c4c.py
@@ -1,0 +1,32 @@
+"""b5870c4c: MCP list_backlog 이 존재하는 엔드포인트를 호출하는지 회귀 게이트.
+
+버그: `sprintable_list_backlog` 가 `GET /api/v2/stories/backlog`(부재 라우트) 호출 → `/{id}` 로 shadow 돼
+422(id="backlog" 非-UUID). fix(B): 기존 `GET /api/v2/stories` + `no_sprint`(server-side repo.list_backlog·
+sprint 미배정·tool docstring 정합) 재사용. 신규 라우트 0.
+"""
+import pytest
+
+from sprintable_mcp.tools import stories as st
+
+
+@pytest.mark.anyio
+async def test_list_backlog_targets_existing_endpoint_with_no_sprint(monkeypatch):
+    captured: dict = {}
+
+    class _FakeClient:
+        project_id = "proj-1"
+        org_id = None
+
+        async def get(self, path, params=None):
+            captured["path"] = path
+            captured["params"] = params or {}
+            return []
+
+    monkeypatch.setattr(st, "client", _FakeClient())
+    await st.list_backlog(None)
+
+    # 부재 라우트(/stories/backlog) 호출 금지 — /{id} shadow→422 의 근본.
+    assert captured["path"] == "/api/v2/stories", captured
+    # no_sprint(+project_id)로 server-side backlog(sprint 미배정) 분기.
+    assert captured["params"].get("no_sprint") == "true"
+    assert captured["params"].get("project_id") == "proj-1"

--- a/backend/tests/test_project_settings_authz.py
+++ b/backend/tests/test_project_settings_authz.py
@@ -1,0 +1,56 @@
+"""E-MEMBER-POLICY(9b8d634b): project_settings authz — 직전 authz 0(보안 갭) 차단.
+
+PATCH(설정 변경) = project owner/admin(has_project_role min='admin'·org floor 포함). GET(열람) = project
+member(has_project_access·테넌시). 둘 다 미통과 시 403. (모델/owner 1급은 S1~S4서 이미 구축·여기선 설정 authz 배선.)
+"""
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.routers import project_settings as ps
+
+
+def _auth():
+    a = MagicMock()
+    a.user_id = str(uuid.uuid4())
+    return a
+
+
+@pytest.mark.anyio
+async def test_patch_settings_requires_owner_admin():
+    body = MagicMock()
+    body.project_id = uuid.uuid4()
+    body.standup_deadline = "09:00"
+    # 비-owner/admin → 403 (직전엔 authz 0 으로 누구나 변경 가능했던 갭).
+    with patch.object(ps, "has_project_role", new_callable=AsyncMock, return_value=False):
+        with pytest.raises(HTTPException) as e:
+            await ps.upsert_project_settings(body=body, session=AsyncMock(), auth=_auth())
+        assert e.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_patch_settings_checks_admin_min_role():
+    body = MagicMock()
+    body.project_id = uuid.uuid4()
+    body.standup_deadline = "09:00"
+    # owner/admin 통과 시 authz 호출이 min_role='admin' 인지(레벨 정합). session 은 authz 後 차단해 호출인자만 확認.
+    mock_hpr = AsyncMock(return_value=True)
+    sess = AsyncMock()
+    sess.execute = AsyncMock(side_effect=RuntimeError("past-authz"))  # authz 통과 후 도달 증명
+    with patch.object(ps, "has_project_role", mock_hpr):
+        with pytest.raises(RuntimeError, match="past-authz"):
+            await ps.upsert_project_settings(body=body, session=sess, auth=_auth())
+    assert mock_hpr.await_args.kwargs.get("min_role") == "admin"
+
+
+@pytest.mark.anyio
+async def test_get_settings_requires_project_access():
+    # GET = project member(has_project_access·테넌시) — cross-tenant read(타 org settings 노출) 차단.
+    with patch.object(ps, "has_project_access", new_callable=AsyncMock, return_value=False):
+        with pytest.raises(HTTPException) as e:
+            await ps.get_project_settings(
+                project_id=uuid.uuid4(), session=AsyncMock(), auth=_auth(), org_id=uuid.uuid4()
+            )
+        assert e.value.status_code == 403

--- a/backend/tests/test_s31.py
+++ b/backend/tests/test_s31.py
@@ -333,8 +333,9 @@ async def test_get_project_settings_200():
         mock_result.scalar_one_or_none.return_value = _mock_setting()
         session.execute = AsyncMock(return_value=mock_result)
 
-        async with client as c:
-            resp = await c.get(f"/api/v2/project-settings?project_id={PROJECT_ID}")
+        with patch("app.routers.project_settings.has_project_access", new_callable=AsyncMock, return_value=True):
+            async with client as c:
+                resp = await c.get(f"/api/v2/project-settings?project_id={PROJECT_ID}")
 
         assert resp.status_code == 200
         assert resp.json()["standup_deadline"] == "09:00:00"
@@ -350,8 +351,9 @@ async def test_get_project_settings_default_200():
         mock_result.scalar_one_or_none.return_value = None
         session.execute = AsyncMock(return_value=mock_result)
 
-        async with client as c:
-            resp = await c.get(f"/api/v2/project-settings?project_id={PROJECT_ID}")
+        with patch("app.routers.project_settings.has_project_access", new_callable=AsyncMock, return_value=True):
+            async with client as c:
+                resp = await c.get(f"/api/v2/project-settings?project_id={PROJECT_ID}")
 
         assert resp.status_code == 200
         assert resp.json()["standup_deadline"] == "09:00:00"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -111,7 +111,11 @@ steps:
       # OB-1: 에이전트 onboarding generator 가 읽는 backend-direct URL 을 런타임 env 로 주입.
       # ⚠️ 반드시 --update-env-vars(additive·기존 backend env[DATABASE_URL 등] 보존). --set-env-vars 금지
       # (전체 wipe). _FASTAPI_URL 은 dev/prod 각 backend-direct run.app(프론트 NEXT_PUBLIC_FASTAPI_URL 과 동일 값).
-      - --update-env-vars=FASTAPI_URL=${_FASTAPI_URL}
+      # DB_POOL_SIZE=3/DB_MAX_OVERFLOW=1: config.py 기본과 동일하나 **명시 주입으로 durable**(과거 수동 설정·
+      # lingering env 가 config 기본을 덮는 것 방지). rollout 산식: 2×maxScale×(pool+overflow+pg_pubsub raw 1)
+      # ≤ DB max_conn (dev maxScale 8: 2×8×5=80 · prod maxScale 5: 2×5×5=50+admin). 변경 시 cloud-build.yml
+      # maxScale 와 짝으로 검토. (PO rev 01256 dev 429 right-size durable 화.)
+      - --update-env-vars=FASTAPI_URL=${_FASTAPI_URL},DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1
       - --quiet
     waitFor: [push-backend]
 


### PR DESCRIPTION
**선택 승격**: #1781-1787 7커밋만 cherry-pick(develop 통째 아님). doc-gate(E-DG doc-side·백로그 prod-blocker)+kanban/i18n divergence **제외**(재유입 방지).

포함: 컷오버 #1784-1786(union resolver+widening 401)·#1787 maxScale durability(prod-neutral)·#1781 MCP fix·#1782 project_settings authz·#1783 L2 verify. 마이그 0.

머지 後 prod CB 배포 → 재audit(a/b/c/FK 0) → flip(member_ssot_apikey_cut ON) → 디디 shadow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)