### PR TITLE
[SID:b13352c2] doc 삭제 cascade — pending doc_approval gate system void (orphan 방지)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
           JWT_SECRET: ci-test-secret-at-least-32-chars-long
           SECRET_KEY: ci-test-secret-at-least-32-chars-long
-        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py tests/test_release_notes_realdb.py tests/test_audit_apikey_parity_realdb.py -q
+        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py tests/test_release_notes_realdb.py tests/test_audit_apikey_parity_realdb.py tests/test_doc_gate_cascade_scope_realdb.py -q
 
       - name: Verify fresh DB reached head (baseline + incremental)
         working-directory: backend

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -419,10 +419,18 @@ async def update_doc(
 async def delete_doc(
     id: uuid.UUID,
     repo: DocRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Doc not found")
+    # b13352c2: doc 삭제 시 그 doc 의 pending doc_approval 게이트를 cascade void(orphan Gate inbox 항목 방지).
+    # 삭제 권한자(인증 caller) 트리거 system cascade — human-gate authz 우회 정당(별도 결재 아님). void 는
+    # begin_nested 격리 best-effort라 삭제 비중단. pending 아니면 no-op(멱등)·doc_approval 만 스코핑.
+    from app.services.gate_service import void_pending_doc_gate
+    from app.services.member_resolver import resolve_member
+    deleter = await resolve_member(auth, repo.org_id, repo.session)
+    await void_pending_doc_gate(repo.session, repo.org_id, id, deleter.id)
     return {"ok": True}
 
 

--- a/backend/app/services/doc.py
+++ b/backend/app/services/doc.py
@@ -168,6 +168,14 @@ async def transition_doc(
             content=doc.content, created_by=caller.id,
         ))
 
+    # b13352c2: 상신취소(pending→draft) 시 연결 pending doc_approval 게이트 cascade void(orphan Gate inbox
+    # 방지·PO 실측 cancel-orphan). doc 가 pending 을 떠나면 그 결재 사이클 종료 → gate void. 재상신(draft→pending)
+    # 시 create_gate 멱등이 voided(=terminal) 게이트를 re-open(L102)하므로 멱등 reuse 의도와 충돌 0. 삭제
+    # cascade(docs.py delete_doc)와 동일 void_pending_doc_gate·system cascade(취소자 트리거·human-gate authz 우회 정당).
+    if doc.status == "pending" and to_status == "draft":
+        from app.services.gate_service import void_pending_doc_gate
+        await void_pending_doc_gate(session, org_id, doc.id, caller.id)
+
     doc.status = to_status
     await session.flush()
     return doc

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -211,6 +211,42 @@ async def void_gate(
     return gate
 
 
+async def void_pending_doc_gate(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    doc_id: uuid.UUID,
+    voider_id: uuid.UUID,
+) -> bool:
+    """b13352c2: doc 삭제 cascade — 그 doc 의 pending doc_approval 게이트를 system void(orphan Gate inbox
+    항목 방지). 삭제 권한자가 트리거하는 **system cascade**라 human-gate authz(can_approve·human-only) 우회
+    정당(별도 결재 아님·actor=삭제자·자기승인 아님·산티아고 검토). 스코핑=`doc_approval` 만(타 gate_type 무접촉)·
+    멱등(pending 아니면 no-op)·begin_nested 격리 best-effort(void 실패가 doc 삭제 비중단). 반환=void 수행 여부."""
+    from app.services.doc import DOC_GATE_TYPE, DOC_GATE_WORK_ITEM_TYPE
+    gate = (await session.execute(
+        select(Gate).where(
+            Gate.org_id == org_id,
+            Gate.work_item_id == doc_id,
+            Gate.work_item_type == DOC_GATE_WORK_ITEM_TYPE,
+            Gate.gate_type == DOC_GATE_TYPE,
+            Gate.status == "pending",
+        )
+    )).scalar_one_or_none()
+    if gate is None:
+        return False  # pending doc-gate 없음(terminal/held/부재) → no-op(멱등).
+    try:
+        async with session.begin_nested():
+            await void_gate(
+                session, org_id, gate.id, voider_id,
+                "doc 삭제 cascade — pending 결재 게이트 자동 무효화",
+            )
+        return True
+    except Exception:
+        logger.warning(
+            "doc 삭제 cascade void 실패(비중단) doc=%s gate=%s", doc_id, gate.id, exc_info=True
+        )
+        return False
+
+
 async def _set_linked_step_run(session, org_id, gate_id, *, status, held_until, reason):
     """gate 에 묶인 미해소 step_run 의 status/held_until 갱신(없으면 no-op·legacy/비-라인 gate)."""
     from app.services.workflow_line_resolution import find_active_step_run_for_gate

--- a/backend/tests/test_doc_gate_cascade_b13352c2.py
+++ b/backend/tests/test_doc_gate_cascade_b13352c2.py
@@ -71,3 +71,27 @@ async def test_best_effort_swallows_void_failure():
                new=AsyncMock(side_effect=ValueError("boom"))):
         r = await void_pending_doc_gate(s, uuid.uuid4(), uuid.uuid4(), uuid.uuid4())
     assert r is False
+
+
+# ── 상신취소(pending→draft)도 gate void(cancel-orphan 방지·PO 실측 ⓑ 케이스) ──
+@pytest.mark.anyio
+async def test_cancel_pending_to_draft_voids_gate():
+    from app.services.doc import transition_doc
+    from app.services.member_resolver import ResolvedMember
+    org = uuid.uuid4()
+    doc = MagicMock(status="pending", id=uuid.uuid4(), title="t", project_id=uuid.uuid4(), content="c")
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = doc
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=result)
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    caller = ResolvedMember(id=uuid.uuid4(), user_id=uuid.uuid4(), name="u", type="human",
+                            role="member", org_id=org)
+    with patch("app.services.gate_service.void_pending_doc_gate",
+               new=AsyncMock(return_value=True)) as vpg:
+        await transition_doc(session, org, caller, doc.id, "draft")
+    vpg.assert_awaited_once()
+    assert vpg.await_args.args[2] == doc.id          # 그 doc 의 게이트
+    assert vpg.await_args.args[3] == caller.id        # voider=취소자
+    assert doc.status == "draft"

--- a/backend/tests/test_doc_gate_cascade_b13352c2.py
+++ b/backend/tests/test_doc_gate_cascade_b13352c2.py
@@ -1,0 +1,73 @@
+"""b13352c2: doc 삭제 cascade — pending doc_approval 게이트 system void(orphan Gate inbox 방지).
+
+void_pending_doc_gate: pending doc_approval gate 만 void(멱등·doc_approval 스코핑)·begin_nested 격리
+best-effort(void 실패가 삭제 비중단). 삭제 권한자 트리거 system cascade라 human-gate authz 우회 정당.
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.gate_service import void_pending_doc_gate
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class _NestedCM:
+    """real savepoint 동형: 예외 미억제(__aexit__ False) — AsyncMock 의 CM/coroutine 혼동 회피."""
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _session(gate):
+    s = AsyncMock()
+    gr = MagicMock()
+    gr.scalar_one_or_none.return_value = gate
+    s.execute = AsyncMock(return_value=gr)
+    s.begin_nested = MagicMock(return_value=_NestedCM())
+    return s
+
+
+# ── pending doc_approval gate → void(True·사유 비어있지 않음) ──
+@pytest.mark.anyio
+async def test_voids_pending_doc_gate():
+    gate = SimpleNamespace(id=uuid.uuid4())
+    s = _session(gate)
+    voider = uuid.uuid4()
+    with patch("app.services.gate_service.void_gate", new=AsyncMock()) as vg:
+        r = await void_pending_doc_gate(s, uuid.uuid4(), uuid.uuid4(), voider)
+    assert r is True
+    vg.assert_awaited_once()
+    # void_gate(session, org_id, gate_id, voider_id, reason) — voider 강제·reason 비어있지 않음.
+    assert vg.await_args.args[3] == voider
+    assert vg.await_args.args[4].strip()
+
+
+# ── pending doc-gate 없음(terminal/held/부재) → no-op(False·void 미호출·멱등) ──
+@pytest.mark.anyio
+async def test_noop_when_no_pending_gate():
+    s = _session(None)
+    with patch("app.services.gate_service.void_gate", new=AsyncMock()) as vg:
+        r = await void_pending_doc_gate(s, uuid.uuid4(), uuid.uuid4(), uuid.uuid4())
+    assert r is False
+    vg.assert_not_awaited()
+
+
+# ── best-effort: void 실패 swallow(False·예외 비전파=삭제 비중단) ──
+@pytest.mark.anyio
+async def test_best_effort_swallows_void_failure():
+    gate = SimpleNamespace(id=uuid.uuid4())
+    s = _session(gate)
+    with patch("app.services.gate_service.void_gate",
+               new=AsyncMock(side_effect=ValueError("boom"))):
+        r = await void_pending_doc_gate(s, uuid.uuid4(), uuid.uuid4(), uuid.uuid4())
+    assert r is False

--- a/backend/tests/test_doc_gate_cascade_scope_realdb.py
+++ b/backend/tests/test_doc_gate_cascade_scope_realdb.py
@@ -53,17 +53,18 @@ async def test_void_pending_doc_gate_scoping_locked():
     from app.services.gate_service import void_pending_doc_gate
 
     orgA, orgB = uuid.uuid4(), uuid.uuid4()
-    d1, d2, d3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    d1, d2 = uuid.uuid4(), uuid.uuid4()
     engine, Session = await _session()
     try:
         async with Session() as s:
+            # 각 negative 는 match 와 **정확히 1 차원만** 다르게(변수 분리) → 스코핑 차원별 독립 잠금.
             cases = {
                 "match": _gate(orgA, d1, wit="doc", gt="doc_approval", status="pending"),     # → VOID
-                "merge": _gate(orgA, d1, wit="doc", gt="merge", status="pending"),            # gate_type≠
-                "wrongtype": _gate(orgA, d1, wit="story", gt="doc_approval", status="pending"),  # work_item_type≠
-                "terminal": _gate(orgA, d2, wit="doc", gt="doc_approval", status="approved"),  # status≠pending
-                "otherdoc": _gate(orgA, d3, wit="doc", gt="doc_approval", status="pending"),   # work_item_id≠
-                "crossorg": _gate(orgB, d1, wit="doc", gt="doc_approval", status="pending"),   # org≠
+                "merge": _gate(orgA, d1, wit="doc", gt="merge", status="pending"),            # gate_type만 다름
+                "wrongtype": _gate(orgA, d1, wit="story", gt="doc_approval", status="pending"),  # work_item_type만
+                "terminal": _gate(orgA, d1, wit="doc", gt="doc_approval", status="approved"),  # status만(같은 d1!)
+                "otherdoc": _gate(orgA, d2, wit="doc", gt="doc_approval", status="pending"),   # work_item_id만
+                "crossorg": _gate(orgB, d1, wit="doc", gt="doc_approval", status="pending"),   # org만
             }
             for g in cases.values():
                 s.add(g)

--- a/backend/tests/test_doc_gate_cascade_scope_realdb.py
+++ b/backend/tests/test_doc_gate_cascade_scope_realdb.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import uuid
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -53,19 +54,19 @@ async def test_void_pending_doc_gate_scoping_locked():
     from app.services.gate_service import void_pending_doc_gate
 
     orgA, orgB = uuid.uuid4(), uuid.uuid4()
-    d1, d2, d3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()  # uq(org,work_item,type,gate_type)=1 → 차원별 別 doc
+    d1, d2 = uuid.uuid4(), uuid.uuid4()
     engine, Session = await _session()
     try:
         async with Session() as s:
-            # 비-status 차원: match 와 정확히 1 차원만 다른 negative(같은 d1). uq 때문에 status 차원은
-            # 같은 키에 2행 불가 → terminal 은 자기 doc(d3)에 두고 그 doc 을 void 시도해 status 필터 격리(아래).
+            # 비-status 차원: match 와 정확히 1 차원만 다른 negative(같은 d1). outcome(잘못 void됨) 으로 격리.
+            # ⚠️status 차원은 outcome 으론 격리 불가(void_gate FSM 이 approved→voided 거부 + best-effort
+            # swallow 가 이중방어 → 필터 유무 무관 terminal 무접촉) → 별 call-spy 테스트로 잠근다(아래).
             cases = {
                 "match": _gate(orgA, d1, wit="doc", gt="doc_approval", status="pending"),     # → VOID
                 "merge": _gate(orgA, d1, wit="doc", gt="merge", status="pending"),            # gate_type만 다름
                 "wrongtype": _gate(orgA, d1, wit="story", gt="doc_approval", status="pending"),  # work_item_type만
                 "otherdoc": _gate(orgA, d2, wit="doc", gt="doc_approval", status="pending"),   # work_item_id만
                 "crossorg": _gate(orgB, d1, wit="doc", gt="doc_approval", status="pending"),   # org만
-                "terminal": _gate(orgA, d3, wit="doc", gt="doc_approval", status="approved"),  # status만(자기 doc d3)
             }
             for g in cases.values():
                 s.add(g)
@@ -74,16 +75,46 @@ async def test_void_pending_doc_gate_scoping_locked():
 
             voided = await void_pending_doc_gate(s, orgA, d1, uuid.uuid4())
             assert voided is True  # 매칭(orgA·d1·doc·doc_approval·pending) void 수행
-            # status 차원 격리: terminal 의 자기 doc(d3) 을 void 시도 → status='pending' 필터로 no-op(False)·
-            # terminal 무접촉. status 필터 제거 시 이 호출이 terminal 을 void → 아래 assert 가 잡음.
-            voided_terminal = await void_pending_doc_gate(s, orgA, d3, uuid.uuid4())
-            assert voided_terminal is False  # terminal(approved)은 pending 아님 → no-op
 
             statuses = {r.id: r.status for r in (await s.execute(select(Gate))).scalars().all()}
         # 매칭만 voided.
         assert statuses[ids["match"]] == "voided", "매칭 doc_approval pending gate 미void"
         # 나머지 전부 무접촉(스코핑 누수 시 잘못 void) — 각 스코핑 차원 1개씩 잠금.
-        for k in ("merge", "wrongtype", "otherdoc", "crossorg", "terminal"):
+        for k in ("merge", "wrongtype", "otherdoc", "crossorg"):
             assert statuses[ids[k]] != "voided", f"{k} 가 잘못 void됨(스코핑 누수·authz 우회)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_void_pending_doc_gate_status_filter_call_spy():
+    """status 차원 격리(call-spy). codex 3R: terminal gate 의 outcome(무접촉)은 void_gate 의 FSM 거부
+    (approved→voided invalid) + begin_nested best-effort swallow 가 이중방어라, query 의 status='pending'
+    필터 유무와 무관하게 항상 통과 → outcome 으론 status 격리 불가. → void_gate **호출 여부**로 직접 검증:
+    terminal-doc 은 status 필터가 걸러 void_gate **미호출**·pending-doc 은 **호출**. 필터 제거 시 terminal 도
+    호출돼 spy 가 적발([[feedback_failure_triage_by_signature]] 변수 분리·call-spy)."""
+    from app.services import gate_service as gs
+
+    orgA = uuid.uuid4()
+    d_pending, d_terminal = uuid.uuid4(), uuid.uuid4()
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            s.add(_gate(orgA, d_pending, wit="doc", gt="doc_approval", status="pending"))
+            s.add(_gate(orgA, d_terminal, wit="doc", gt="doc_approval", status="approved"))
+            await s.flush()
+
+            # terminal: status 필터가 걸러 void_gate 미호출(필터 제거 시 호출 → assert_not_awaited 적발).
+            with patch.object(gs, "void_gate", new=AsyncMock()) as spy_terminal:
+                r_t = await gs.void_pending_doc_gate(s, orgA, d_terminal, uuid.uuid4())
+            spy_terminal.assert_not_awaited()
+            assert r_t is False  # terminal=pending 아님 → 매칭 0 → no-op
+
+            # pending: void_gate 호출(spy 동작 + 양성 경로 확認).
+            with patch.object(gs, "void_gate", new=AsyncMock()) as spy_pending:
+                r_p = await gs.void_pending_doc_gate(s, orgA, d_pending, uuid.uuid4())
+            spy_pending.assert_awaited_once()
+            assert r_p is True
     finally:
         await engine.dispose()

--- a/backend/tests/test_doc_gate_cascade_scope_realdb.py
+++ b/backend/tests/test_doc_gate_cascade_scope_realdb.py
@@ -1,0 +1,83 @@
+"""b13352c2 codex finding②: cascade void 스코핑 realdb lock(mock 무의미 보완).
+
+`void_pending_doc_gate` 의 WHERE(org_id·work_item_id·work_item_type='doc'·gate_type='doc_approval'·
+status='pending')를 **negative 케이스**로 잠근다 — authz-critical(우회 cascade)이라 스코핑 1개라도 빠지면
+타 gate 를 잘못 void(권한 우회). 매칭 게이트만 void·나머지(타 gate_type·타 work_item_type·terminal·타 doc·
+cross-org)는 무접촉. DB env 없으면 skip(CI alembic-fresh).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.participation  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _gate(org, wi, *, wit, gt, status):
+    from app.models.gate import Gate
+    return Gate(id=uuid.uuid4(), org_id=org, work_item_id=wi, work_item_type=wit,
+                gate_type=gt, status=status)
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_void_pending_doc_gate_scoping_locked():
+    from sqlalchemy import select
+
+    from app.models.gate import Gate
+    from app.services.gate_service import void_pending_doc_gate
+
+    orgA, orgB = uuid.uuid4(), uuid.uuid4()
+    d1, d2, d3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            cases = {
+                "match": _gate(orgA, d1, wit="doc", gt="doc_approval", status="pending"),     # → VOID
+                "merge": _gate(orgA, d1, wit="doc", gt="merge", status="pending"),            # gate_type≠
+                "wrongtype": _gate(orgA, d1, wit="story", gt="doc_approval", status="pending"),  # work_item_type≠
+                "terminal": _gate(orgA, d2, wit="doc", gt="doc_approval", status="approved"),  # status≠pending
+                "otherdoc": _gate(orgA, d3, wit="doc", gt="doc_approval", status="pending"),   # work_item_id≠
+                "crossorg": _gate(orgB, d1, wit="doc", gt="doc_approval", status="pending"),   # org≠
+            }
+            for g in cases.values():
+                s.add(g)
+            await s.flush()
+            ids = {k: g.id for k, g in cases.items()}
+
+            voided = await void_pending_doc_gate(s, orgA, d1, uuid.uuid4())
+            assert voided is True  # 매칭 gate 존재 → void 수행
+
+            statuses = {r.id: r.status for r in (await s.execute(select(Gate))).scalars().all()}
+        # 매칭만 voided.
+        assert statuses[ids["match"]] == "voided", "매칭 doc_approval pending gate 미void"
+        # 나머지 전부 무접촉(스코핑 누수 시 잘못 void) — 각 스코핑 차원 1개씩 잠금.
+        for k in ("merge", "wrongtype", "terminal", "otherdoc", "crossorg"):
+            assert statuses[ids[k]] != "voided", f"{k} 가 잘못 void됨(스코핑 누수·authz 우회)"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_doc_gate_cascade_scope_realdb.py
+++ b/backend/tests/test_doc_gate_cascade_scope_realdb.py
@@ -53,18 +53,19 @@ async def test_void_pending_doc_gate_scoping_locked():
     from app.services.gate_service import void_pending_doc_gate
 
     orgA, orgB = uuid.uuid4(), uuid.uuid4()
-    d1, d2 = uuid.uuid4(), uuid.uuid4()
+    d1, d2, d3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()  # uq(org,work_item,type,gate_type)=1 → 차원별 別 doc
     engine, Session = await _session()
     try:
         async with Session() as s:
-            # 각 negative 는 match 와 **정확히 1 차원만** 다르게(변수 분리) → 스코핑 차원별 독립 잠금.
+            # 비-status 차원: match 와 정확히 1 차원만 다른 negative(같은 d1). uq 때문에 status 차원은
+            # 같은 키에 2행 불가 → terminal 은 자기 doc(d3)에 두고 그 doc 을 void 시도해 status 필터 격리(아래).
             cases = {
                 "match": _gate(orgA, d1, wit="doc", gt="doc_approval", status="pending"),     # → VOID
                 "merge": _gate(orgA, d1, wit="doc", gt="merge", status="pending"),            # gate_type만 다름
                 "wrongtype": _gate(orgA, d1, wit="story", gt="doc_approval", status="pending"),  # work_item_type만
-                "terminal": _gate(orgA, d1, wit="doc", gt="doc_approval", status="approved"),  # status만(같은 d1!)
                 "otherdoc": _gate(orgA, d2, wit="doc", gt="doc_approval", status="pending"),   # work_item_id만
                 "crossorg": _gate(orgB, d1, wit="doc", gt="doc_approval", status="pending"),   # org만
+                "terminal": _gate(orgA, d3, wit="doc", gt="doc_approval", status="approved"),  # status만(자기 doc d3)
             }
             for g in cases.values():
                 s.add(g)
@@ -72,13 +73,17 @@ async def test_void_pending_doc_gate_scoping_locked():
             ids = {k: g.id for k, g in cases.items()}
 
             voided = await void_pending_doc_gate(s, orgA, d1, uuid.uuid4())
-            assert voided is True  # 매칭 gate 존재 → void 수행
+            assert voided is True  # 매칭(orgA·d1·doc·doc_approval·pending) void 수행
+            # status 차원 격리: terminal 의 자기 doc(d3) 을 void 시도 → status='pending' 필터로 no-op(False)·
+            # terminal 무접촉. status 필터 제거 시 이 호출이 terminal 을 void → 아래 assert 가 잡음.
+            voided_terminal = await void_pending_doc_gate(s, orgA, d3, uuid.uuid4())
+            assert voided_terminal is False  # terminal(approved)은 pending 아님 → no-op
 
             statuses = {r.id: r.status for r in (await s.execute(select(Gate))).scalars().all()}
         # 매칭만 voided.
         assert statuses[ids["match"]] == "voided", "매칭 doc_approval pending gate 미void"
         # 나머지 전부 무접촉(스코핑 누수 시 잘못 void) — 각 스코핑 차원 1개씩 잠금.
-        for k in ("merge", "wrongtype", "terminal", "otherdoc", "crossorg"):
+        for k in ("merge", "wrongtype", "otherdoc", "crossorg", "terminal"):
             assert statuses[ids[k]] != "voided", f"{k} 가 잘못 void됨(스코핑 누수·authz 우회)"
     finally:
         await engine.dispose()

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -182,8 +182,13 @@ async def test_delete_doc_200():
         session.delete = AsyncMock()
         session.flush = AsyncMock()
 
-        async with client as c:
-            resp = await c.delete(f"/api/v2/docs/{DOC_ID}")
+        # b13352c2: delete_doc 가 cascade(resolve_member + void_pending_doc_gate) 호출 → 패치(이 테스트는 삭제만 검증·cascade는 별도).
+        from unittest.mock import patch as _patch
+        with _patch("app.services.member_resolver.resolve_member",
+                    new=AsyncMock(return_value=MagicMock(id=uuid.uuid4()))), \
+             _patch("app.services.gate_service.void_pending_doc_gate", new=AsyncMock(return_value=False)):
+            async with client as c:
+                resp = await c.delete(f"/api/v2/docs/{DOC_ID}")
 
         assert resp.status_code == 200
         assert resp.json()["ok"] is True


### PR DESCRIPTION
## doc 삭제 시 pending doc_approval gate cascade void (orphan Gate inbox 방지)

근본 갭(선생님 실 Web 발견·gate `1486915b`/`72559ae3`): doc DELETE 가 연결된 pending doc_approval gate 를 정리 안 함 → orphan gate 가 Gate inbox 잔존·enrich null(deleted_at/부재 가드) → FE `#id` 폴백 → 결재자가 "무슨 doc인지 모름".

### fix
- **`gate_service.void_pending_doc_gate(session, org_id, doc_id, voider_id)`**: 그 doc 의 pending doc_approval gate 조회 → `void_gate`(system). **doc_approval 스코핑**(work_item_type='doc' ∧ gate_type='doc_approval'·타 gate_type 무접촉)·**멱등**(pending 아니면 no-op·terminal/held 무변경)·**begin_nested 격리 best-effort**(void 실패가 삭제 비중단).
- **`docs.py delete_doc`**: 삭제 후 cascade 호출·voider=인증 삭제자(`resolve_member`).
- 삭제 권한자 트리거 **system cascade**라 human-gate authz(can_approve·human-only) 우회 정당(별도 결재 아님·자기승인 아님·산티아고 보안검토). `void_gate` 는 서비스 직호출(authz는 endpoint 전용)이라 system 호출 적합.

### ⚠️ 노트 (PO 판단)
스토리는 "soft-delete(deleted_at)" 전제이나, 실제 `delete_doc` 은 `BaseRepository.delete`=**HARD delete** (Doc 가 SoftDeleteMixin 보유하나 deleted_at set 경로가 코드에 없음). cascade-void 는 hard/soft 무관하게 orphan 해소(hard=doc row 소멸→enrich None·soft=deleted_at 가드 제외→둘 다 pending gate orphan). **soft-delete 전환은 별건 큰 변경(전 쿼리 deleted_at 가드 등)이라 미포함**(스코프 밖) — 필요 시 후속 스토리.

### 검증
신규 3(voids-pending[voider/사유 강제]·no-gate no-op·best-effort swallow)·delete_doc 기존 테스트 cascade 패치. full no-DB 2620 pass(잔여 8 기존)·ruff·마이그 0.

### smoke (PO/선생님)
pending doc-gate 있는 doc DELETE → Gate inbox(`?status=pending`)서 그 항목 사라짐(AC④).

PR 열면 PO crux + codex cross-model QA(우회 스코핑 정확·doc_approval 외 무접촉) + CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)