### PR TITLE
[SID:89484c8c] doc-gate in-doc decider dead-path fix — gate.can_approve 자격

### DIFF
--- a/apps/web/src/components/docs/doc-gate-section.tsx
+++ b/apps/web/src/components/docs/doc-gate-section.tsx
@@ -17,7 +17,8 @@ import type { GateItem } from '@/components/kanban/types';
  *   - doc.status = draft/pending/confirmed/denied → 배지(META map).
  *   - gate-row status = approved/rejected → decider 결재 transition body. 승인→BE가 doc→confirmed, 반려→doc→denied.
  * (34360c54) draft = "검토 요청" CTA 상시 노출(가시성 fix·draft→pending). (24f5ae18) pending+자격자 = in-doc 승인/반려.
- *   자격 = GET /api/gates/{id}/approvers 에 currentTeamMemberId 포함(저자 자기승인 금지·BE can_approve 강제·fail-closed).
+ *   자격 = gate.can_approve(BE per-caller·rule A: human+has_project_access+not-author·89484c8c). FE=가시성·실 authz=BE 403.
+ *   (구버전 /api/gates/{id}/approvers 는 S32 quorum/parallel 전용·plain doc-gate=빈목록이라 dead였음 → can_approve 로 교체.)
  * audit 타임라인 = revisions(요청/재요청) + 현재 gate resolution(승인/반려+사유) display 병합.
  *   ⚠️ 사이클별 풍부한 per-transition 이벤트 로그는 BE event-log 의존(디디 scope-TBD). v1 = 보유 데이터 병합.
  * 반려 사유 = doc gate(work_item_type='doc')의 resolution_note. revision = GET /docs/{id}/revisions(org-scoped IDOR fix).
@@ -59,26 +60,6 @@ function toState(status: string | undefined): DocGateState | null {
   return null; // draft 등은 배지 미표시
 }
 
-// approvers 응답 형상 방어 파싱: 배열 | {data:[]} | {approvers:[]}, 각 항목서 member id 추출. any 금지(strict).
-function extractApproverIds(raw: unknown): string[] {
-  const obj = raw as { data?: unknown; approvers?: unknown } | null;
-  const arr: unknown[] = Array.isArray(raw)
-    ? raw
-    : Array.isArray(obj?.data)
-      ? (obj!.data as unknown[])
-      : Array.isArray(obj?.approvers)
-        ? (obj!.approvers as unknown[])
-        : [];
-  const ids: string[] = [];
-  for (const item of arr) {
-    if (typeof item === 'string') { ids.push(item); continue; }
-    const r = item as Record<string, unknown>;
-    const id = r?.approver_member_id ?? r?.member_id ?? r?.team_member_id ?? r?.id;
-    if (typeof id === 'string') ids.push(id);
-  }
-  return ids;
-}
-
 export function DocGateSection({
   docId,
   status,
@@ -93,7 +74,6 @@ export function DocGateSection({
   const [gate, setGate] = useState<GateItem | null>(null);
   const [revisions, setRevisions] = useState<DocRevision[]>([]);
   const [memberNames, setMemberNames] = useState<Record<string, string>>({});
-  const [approverIds, setApproverIds] = useState<string[] | null>(null); // null = 미로드/실패 → fail-closed(버튼 숨김)
   const [busy, setBusy] = useState(false);
   const [auditOpen, setAuditOpen] = useState(false); // 기본 접힘(본문 우선·이력 secondary)
   const [rejectOpen, setRejectOpen] = useState(false);
@@ -115,17 +95,9 @@ export function DocGateSection({
     const names: Record<string, string> = {};
     for (const m of ((membersJson?.data ?? []) as { id: string; name: string }[])) names[m.id] = m.name;
     setMemberNames(names);
-    // (24f5ae18) decider 게이팅: pending + gate 있을 때만 자격자 목록 조회. 실패=null(fail-closed).
-    if (status === 'pending' && picked) {
-      const approversRaw = await fetch(`/api/gates/${picked.id}/approvers`)
-        .then((r) => (r.ok ? r.json() : null))
-        .catch(() => null);
-      if (signal?.aborted) return;
-      setApproverIds(approversRaw == null ? null : extractApproverIds(approversRaw));
-    } else {
-      setApproverIds(null);
-    }
-  }, [docId, status]);
+    // (89484c8c) decider 자격 = gate.can_approve(BE per-caller·rule A). 별도 approvers 조회 없음
+    // — /api/gates/{id}/approvers 는 S32 quorum/parallel 전용(plain doc-gate=빈목록)이라 dead였음.
+  }, [docId]);
 
   useEffect(() => {
     const ctrl = new AbortController();
@@ -137,10 +109,10 @@ export function DocGateSection({
   const meta = state ? META[state] : null;
   const MetaIcon = meta?.Icon;
   const isDraft = status === 'draft';
-  const isApprover = status === 'pending' && !!currentTeamMemberId && (approverIds?.includes(currentTeamMemberId) ?? false);
+  // 자격 = gate.can_approve(BE per-caller·rule A: human+has_project_access+not-author). FE=가시성·실 authz=BE 403.
+  const isApprover = status === 'pending' && gate?.can_approve === true;
   const resolveName = (id: string | null | undefined) => (id ? (memberNames[id] ?? id.slice(0, 6)) : '—');
   const fmtDate = (s: string | undefined) => (s ? new Date(s).toLocaleString() : '');
-  const reviewerName = approverIds && approverIds.length > 0 ? resolveName(approverIds[0]) : null;
 
   // doc.status transition(draft↔pending↔denied). gate-row transition과 별개.
   const docTransition = async (next: string) => {
@@ -263,7 +235,7 @@ export function DocGateSection({
           ) : state === 'pending' ? (
             /* ② pending + author/비자격자 = 검토자 응답 대기(액션 없음·self-approval 금지). */
             <span className="text-xs text-muted-foreground">
-              {reviewerName ? t('docGateAwaitingReviewer', { name: reviewerName }) : t('docGateAwaitingGeneric')}
+              {t('docGateAwaitingGeneric')}
             </span>
           ) : state === 'confirmed' && gate ? (
             /* ④ confirmed = 결재자 + 시각. */

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -44,6 +44,9 @@ export interface GateItem {
   // 대상 문서 요약을 동봉(디디 BE PR #1742·additive). non-doc/삭제된 문서 gate는 null → `?.` 가드 폴백.
   // slug는 향후 deep-link 후속용(MVP 미사용).
   work_item_summary?: { title: string; slug: string } | null;
+  // doc-gate in-doc 결재 자격(89484c8c): doc_approval gate 한정·per-caller·rule A(human+has_project_access+not-author).
+  // BE가 gates 리스트 응답 각 gate에 동봉(additive). undefined/false → in-doc 승인/반려 버튼 미노출(fail-closed). 실 authz=BE 403.
+  can_approve?: boolean;
   // H1-S3 머지 verdict 게이트 evidence(GateResponse·additive·하위호환 default). null≠0(AC③).
   requires_human?: boolean;
   evidence_status?: string | null; // sufficient | blocked | insufficient


### PR DESCRIPTION
## 개요
출하 後 적출(유나 라이브 smoke + PO 코드측정): doc-gate **in-doc 승인/반려 버튼이 dead**였음. 자격 소스 `GET /api/gates/{id}/approvers`가 **S32 quorum/parallel 전용**(plain doc-gate=빈목록·admin-only) → `isApprover` 영영 false → decider 버튼 미노출(인박스 quick 결재만 작동). #1790 머지본의 dead-path.

## fix (FE-BE 계약·디디 BE `89484c8c`와 페어)
- **BE**(디디): `GET /api/gates?work_item_id=<doc>&work_item_type=doc` 응답 **각 gate에 `can_approve: bool` 동봉**(doc_approval만·per-caller·rule A: human+has_project_access+not-author).
- **FE**(본 PR): `gate.can_approve`로 isApprover 게이팅:
  - `isApprover = status==='pending' && gate?.can_approve === true`
  - `/api/gates/{id}/approvers` fetch + `extractApproverIds` + `approverIds` state **삭제**(dead)
  - `reviewerName` 드롭 → "검토자 응답 대기 중" generic awaiting(approvers 목록 부재)
  - `GateItem.can_approve?: boolean` 추가(additive)

## 보안·계약
- **design-first**: `can_approve` undefined/false → 버튼 미노출(**fail-closed·회귀0**). BE 랜딩 前/後 모두 안전.
- **FE=가시성·실 authz=BE 403**(`can_approve` 강제). FE 우회(직접 transition 호출)는 BE가 차단(#1791 self-approval server-stamp).
- 신규 엔드포인트/라운드트립 0(기존 gates 리스트 응답 확장).

## 검증
- `pnpm build` EXIT0(tsc clean).
- **dev 픽셀(머지 後)**: pending doc에서 자격자(can_approve=true)에게 승인/반려 버튼 노출·실 결재→confirmed/denied·비자격자 미노출.

디디 BE PR 랜딩 시 응답 형상(top-level `gate.can_approve`) 정합 確認 → PO crux + codex + 유나 재캡처(b766cd08 pending 셋업) → BE+FE 같이 머지(BE authz 먼저).

🤖 Generated with [Claude Code](https://claude.com/claude-code)