### PR TITLE
[SID:89484c8c] doc-gate in-doc decider can_approve(rule A) — 헬퍼 추출 + list_gates per-caller enrich

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -194,16 +194,21 @@ async def list_gates(
     gates = list(result.scalars().all())
     responses = [GateResponse.model_validate(g) for g in gates]
 
-    # doc-side 결재 UX(24f5ae18): doc gate 는 work_item_id(doc id)만이라 인박스가 doc 를 못 그림 →
-    # doc title/slug batch enrich(org-scope·soft-delete 가드·N+1 0). FE 가 "결재: <title>" 렌더 + /docs/<slug>
-    # 링크. 비-doc/삭제 doc 은 None(하위호환). project_id 도 같이 조회해 can_approve enrich 에 재사용.
-    doc_ids = {g.work_item_id for g in gates if g.work_item_type == "doc"}
+    # doc-side enrich 2종 Doc 조회를 **한 배치**로(org-scope·soft-delete 가드·N+1 0):
+    #  ⓐ work_item_summary(24f5ae18): work_item_type=='doc' gate → title/slug.
+    #  ⓑ can_approve(89484c8c): gate_type=='doc_approval' gate → project_id.
+    # ⚠️project_id 소스 predicate 는 transition(gate_type=='doc_approval'·work_item_id→Doc)와 **동일**해야
+    # DRY 정합 — work_item_type 으로 키잉하면 doc_approval 인데 work_item_type≠doc 인 이상 게이트에서 enrich
+    # (can_approve)와 transition 강제가 갈림. 두 predicate 의 work_item_id 합집합으로 조회.
+    summary_doc_ids = {g.work_item_id for g in gates if g.work_item_type == "doc"}
+    approval_doc_ids = {g.work_item_id for g in gates if g.gate_type == "doc_approval"}
     doc_proj: dict[uuid.UUID, uuid.UUID] = {}
-    if doc_ids:
+    fetch_ids = summary_doc_ids | approval_doc_ids
+    if fetch_ids:
         from app.models.doc import Doc
         rows = (await session.execute(
             select(Doc.id, Doc.title, Doc.slug, Doc.project_id).where(
-                Doc.id.in_(doc_ids), Doc.org_id == org_id, Doc.deleted_at.is_(None),
+                Doc.id.in_(fetch_ids), Doc.org_id == org_id, Doc.deleted_at.is_(None),
             )
         )).all()
         summaries = {did: WorkItemSummary(title=title, slug=slug) for did, title, slug, _ in rows}

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.doc import Doc
-from app.models.gate import Gate
+from app.models.gate import Gate, is_valid_transition
 from app.services.gate_service import (
     create_gate,
     hold_gate,
@@ -231,7 +231,11 @@ async def list_gates(
                     session, g, resolved, _uid, org_id,
                     doc_project_id=doc_proj.get(g.work_item_id),
                 )
-                resp.can_approve = _reason is None
+                # 완전 DRY(codex): "지금 승인 가능" = authz(rule A·helper) **AND** FSM 으로 resolvable
+                # (pending). transition 도 authz(helper) + transition_gate FSM(is_valid_transition) 이중이므로
+                # enrich 도 동일 is_valid_transition 으로 FSM 반영 — terminal/held gate 는 can_approve=False(승인/
+                # 반려 둘 다 pending 전제라 "approved" 한 방향 검사로 충분). authz-only 의미 갈림 제거.
+                resp.can_approve = _reason is None and is_valid_transition(g.status, "approved")
         except Exception:  # noqa: BLE001 — can_approve 가시성 enrich 실패는 목록 비중단(fail-closed=False 유지).
             logger.warning("list_gates can_approve enrich 실패(비중단) org=%s", org_id, exc_info=True)
     return responses

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -1,4 +1,5 @@
 """E-CAGE-REFEREE P3: HITL Gate CRUD + 전이 엔드포인트."""
+import logging
 import uuid
 from datetime import datetime
 from typing import Any
@@ -21,6 +22,8 @@ from app.services.gate_service import (
 )
 from app.services.member_resolver import resolve_member
 from app.services.project_auth import has_project_access, is_org_owner, is_org_owner_or_admin
+
+logger = logging.getLogger(__name__)
 
 # 사람 검증 행위(approve/reject) — "human-validated" 웨지 integrity상 휴먼 member만 허용.
 _HUMAN_REVIEW_STATUSES = frozenset({"approved", "rejected"})
@@ -82,6 +85,10 @@ class GateResponse(BaseModel):
     # doc-side 결재 UX(24f5ae18): gate row 는 work_item_id 만이라 인박스가 doc 를 못 그림 → enrich.
     # additive·nullable(비-doc/미존재 시 None·하위호환). FE 는 별도 doc fetch 제거.
     work_item_summary: "WorkItemSummary | None" = None
+    # decider 가시성(89484c8c): doc_approval 게이트에 **per-caller** can_approve(rule A) — FE in-doc
+    # decider 버튼 게이팅 소스(parallel-approver 목록 아님). 비-doc/무자격/비-휴먼은 False(fail-closed·
+    # additive 하위호환). ⚠️실 authz 는 BE transition 강제(이 필드는 가시성뿐). [[can_approve_doc_gate_reason]]
+    can_approve: bool = False
     gate_type: str
     status: str
     resolver_id: uuid.UUID | None = None
@@ -96,6 +103,45 @@ class GateResponse(BaseModel):
     auto_decision_reason: str | None = None
     created_at: datetime
     updated_at: datetime
+
+
+# rule-A can_approve 단일 규칙(48f064e5 transition 인라인 → 89484c8c 추출·DRY). transition 강제(403
+# 분기)와 list_gates decider 가시성(can_approve bool) 이 공용 — 거동 분기 0.
+_DOC_UNSET: Any = object()
+
+
+async def can_approve_doc_gate_reason(
+    session: AsyncSession,
+    gate: Gate,
+    resolved: Any,
+    user_id: uuid.UUID,
+    org_id: uuid.UUID,
+    *,
+    doc_project_id: Any = _DOC_UNSET,
+) -> str | None:
+    """doc_approval 게이트 rule A(PO) 판정. None=승인 가능·else 거부사유 코드("not_human"/"self_or_unverified"/
+    "no_project_access"). rule A = human + 대상 doc project has_project_access + not-author(resolver≠
+    requester·미기록=fail-closed). ⚠️single source: transition self-approval/can_approve 강제와 list_gates
+    per-caller can_approve enrich 가 공용(분기 일치 보장). ``doc_project_id`` 미지정 시 대상 doc 직접 조회
+    (transition 단건)·list_gates 는 배치 조회한 project_id 주입(N+1 0)·None 주입=삭제/미존재 doc."""
+    if resolved.type != "human":
+        return "not_human"
+    requester = (gate.neutral_facts or {}).get("requested_by_member_id")
+    # SoD: 상신자 본인 금지 + 미기록(forged/이상 게이트)=fail-closed.
+    if requester is None or str(resolved.id) == str(requester):
+        return "self_or_unverified"
+    if doc_project_id is _DOC_UNSET:
+        _doc = (await session.execute(
+            select(Doc).where(
+                Doc.id == gate.work_item_id, Doc.org_id == org_id, Doc.deleted_at.is_(None)
+            )
+        )).scalar_one_or_none()
+        doc_project_id = _doc.project_id if _doc is not None else None
+    if doc_project_id is None or not await has_project_access(
+        session, user_id, doc_project_id, org_id
+    ):
+        return "no_project_access"
+    return None
 
 
 @router.post("", response_model=GateResponse, status_code=201)
@@ -135,7 +181,7 @@ async def list_gates(
     status: str | None = Query(default=None),
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth=Depends(get_current_user),
 ) -> list[GateResponse]:
     q = select(Gate).where(Gate.org_id == org_id)
     if work_item_id:
@@ -150,19 +196,39 @@ async def list_gates(
 
     # doc-side 결재 UX(24f5ae18): doc gate 는 work_item_id(doc id)만이라 인박스가 doc 를 못 그림 →
     # doc title/slug batch enrich(org-scope·soft-delete 가드·N+1 0). FE 가 "결재: <title>" 렌더 + /docs/<slug>
-    # 링크. 비-doc/삭제 doc 은 None(하위호환).
+    # 링크. 비-doc/삭제 doc 은 None(하위호환). project_id 도 같이 조회해 can_approve enrich 에 재사용.
     doc_ids = {g.work_item_id for g in gates if g.work_item_type == "doc"}
+    doc_proj: dict[uuid.UUID, uuid.UUID] = {}
     if doc_ids:
         from app.models.doc import Doc
         rows = (await session.execute(
-            select(Doc.id, Doc.title, Doc.slug).where(
+            select(Doc.id, Doc.title, Doc.slug, Doc.project_id).where(
                 Doc.id.in_(doc_ids), Doc.org_id == org_id, Doc.deleted_at.is_(None),
             )
         )).all()
-        summaries = {did: WorkItemSummary(title=title, slug=slug) for did, title, slug in rows}
+        summaries = {did: WorkItemSummary(title=title, slug=slug) for did, title, slug, _ in rows}
+        doc_proj = {did: pid for did, _, _, pid in rows}
         for resp in responses:
             if resp.work_item_type == "doc":
                 resp.work_item_summary = summaries.get(resp.work_item_id)
+
+    # decider 가시성(89484c8c): doc_approval 게이트에 **per-caller** can_approve(rule A) enrich — FE in-doc
+    # decider 버튼 게이팅 소스(parallel /approvers 아님·그건 admin-only·plain doc-gate 빈목록=dead-path).
+    # transition 강제와 can_approve_doc_gate_reason 단일 규칙 공용(DRY). 배치 project_id 주입(N+1 0)·비-휴먼/
+    # 무자격/삭제 doc = False(default·fail-closed). additive — 실 authz 는 transition BE 가 강제(이 필드=가시성뿐).
+    doc_gates = [(resp, g) for resp, g in zip(responses, gates) if g.gate_type == "doc_approval"]
+    if doc_gates:
+        try:
+            resolved = await resolve_member(auth, org_id, session)
+            _uid = uuid.UUID(auth.user_id)
+            for resp, g in doc_gates:
+                _reason = await can_approve_doc_gate_reason(
+                    session, g, resolved, _uid, org_id,
+                    doc_project_id=doc_proj.get(g.work_item_id),
+                )
+                resp.can_approve = _reason is None
+        except Exception:  # noqa: BLE001 — can_approve 가시성 enrich 실패는 목록 비중단(fail-closed=False 유지).
+            logger.warning("list_gates can_approve enrich 실패(비중단) org=%s", org_id, exc_info=True)
     return responses
 
 
@@ -186,31 +252,24 @@ async def transition_gate_endpoint(
         )
     # E-DG 48f064e5: doc 결재 게이트 BE-level can_approve 강제(FE 게이팅은 가시성뿐·실 authz는 BE).
     # 룰(A·PO 결정): human(위) + 대상 doc project has_project_access + not-author(resolver≠requester).
-    # 비-human/no-project-access/self → 403 fail-closed. 비-doc 게이트(merge 등)는 기존 경로 무변경.
+    # 89484c8c: rule 을 can_approve_doc_gate_reason 단일 규칙으로 추출 — list_gates per-caller can_approve
+    # 가시성과 **공용**(거동 분기 0·DRY). 거부사유별 403 메시지는 여기서 보존(self vs 권한). 휴먼 체크는
+    # 위에서 선행되므로 여기 not_human 미도달(방어적으로 권한 403 매핑). 비-doc 게이트는 기존 경로 무변경.
     _gate = (await session.execute(
         select(Gate).where(Gate.id == id, Gate.org_id == org_id)
     )).scalar_one_or_none()
     if _gate is not None and _gate.gate_type == "doc_approval":  # doc.py DOC_GATE_TYPE
-        _facts = _gate.neutral_facts or {}
-        _requester = _facts.get("requested_by_member_id")
-        # ① self-approval(SoD): 상신자 본인 승인/거부 금지. SoD 가드가 parallel 경로에만 있어 plain
-        # doc-gate 는 미적용이던 갭 — 여기서 닫음. requester=현 사이클 상신자(재오픈 시 갱신).
-        # ⚠️fail-closed(산티아고/PO 플래그): 상신자 미기록(None)이면 SoD 검증 불가 → 거부(silent self-approval
-        # 우회 방지). 정상 doc-gate 는 doc.py 생성·재상신서 항상 persist — None=이상 게이트.
-        if _requester is None or str(resolved.id) == str(_requester):
+        _reason = await can_approve_doc_gate_reason(
+            session, _gate, resolved, uuid.UUID(auth.user_id), org_id
+        )
+        # ① self-approval(SoD)·상신자 미기록(forged/이상 게이트) fail-closed.
+        if _reason == "self_or_unverified":
             raise HTTPException(
                 status_code=403,
                 detail="본인이 상신한 doc 결재는 본인이 승인/거부할 수 없습니다 (self-approval 금지·상신자 미검증 차단).",
             )
-        # ② can_approve 자격: 대상 doc 의 project 접근 보유 human 만(project-scope·random org-member 차단).
-        _doc = (await session.execute(
-            select(Doc).where(
-                Doc.id == _gate.work_item_id, Doc.org_id == org_id, Doc.deleted_at.is_(None)
-            )
-        )).scalar_one_or_none()
-        if _doc is None or not await has_project_access(
-            session, uuid.UUID(auth.user_id), _doc.project_id, org_id
-        ):
+        # ② can_approve 자격(no_project_access·삭제 doc·방어적 not_human): project-scope·random org-member 차단.
+        if _reason is not None:
             raise HTTPException(
                 status_code=403,
                 detail="doc 결재 권한이 없습니다 (대상 프로젝트 접근 필요).",

--- a/backend/tests/test_gate_decider_can_approve_89484c8c.py
+++ b/backend/tests/test_gate_decider_can_approve_89484c8c.py
@@ -1,0 +1,226 @@
+"""89484c8c: doc-gate in-doc decider can_approve(rule A) — 헬퍼 + list_gates per-caller enrich.
+
+`can_approve_doc_gate_reason` 단일 규칙(transition 강제와 공용·DRY)을 list_gates 가 doc_approval 게이트에
+per-caller `can_approve` 로 채워 FE in-doc decider 버튼 게이팅 소스를 제공한다(admin-only·parallel-approver
+전용인 `/approvers` dead-path 대체). 실 authz 는 transition BE 가 강제(이 필드=가시성뿐).
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.routers import gates as gates_mod
+from app.routers.gates import can_approve_doc_gate_reason, list_gates
+from app.services.member_resolver import ResolvedMember
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _human(mid: uuid.UUID) -> ResolvedMember:
+    return ResolvedMember(
+        id=mid, user_id=uuid.uuid4(), name="h", type="human", role="member", org_id=uuid.uuid4()
+    )
+
+
+def _agent(mid: uuid.UUID) -> ResolvedMember:
+    return ResolvedMember(
+        id=mid, user_id=uuid.uuid4(), name="a", type="agent", role="member", org_id=uuid.uuid4()
+    )
+
+
+def _gate(requester_id, *, work_item_id=None):
+    return SimpleNamespace(
+        gate_type="doc_approval",
+        neutral_facts={"requested_by_member_id": str(requester_id)} if requester_id else {},
+        work_item_id=work_item_id or uuid.uuid4(),
+        work_item_type="doc",
+    )
+
+
+def _doc_result(project_id):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = (
+        SimpleNamespace(project_id=project_id) if project_id is not None else None
+    )
+    return r
+
+
+# ────────────────────────────── 헬퍼: rule A 분기 ──────────────────────────────
+
+@pytest.mark.anyio
+async def test_reason_not_human():
+    session = AsyncMock()
+    reason = await can_approve_doc_gate_reason(
+        session, _gate(uuid.uuid4()), _agent(uuid.uuid4()), uuid.uuid4(), uuid.uuid4(),
+        doc_project_id=uuid.uuid4(),
+    )
+    assert reason == "not_human"
+    session.execute.assert_not_awaited()  # 비-휴먼 즉시 차단(쿼리 0)
+
+
+@pytest.mark.anyio
+async def test_reason_self_approval():
+    mid = uuid.uuid4()
+    reason = await can_approve_doc_gate_reason(
+        AsyncMock(), _gate(mid), _human(mid), uuid.uuid4(), uuid.uuid4(), doc_project_id=uuid.uuid4()
+    )
+    assert reason == "self_or_unverified"  # requester == resolver
+
+
+@pytest.mark.anyio
+async def test_reason_unverified_requester_fail_closed():
+    reason = await can_approve_doc_gate_reason(
+        AsyncMock(), _gate(None), _human(uuid.uuid4()), uuid.uuid4(), uuid.uuid4(),
+        doc_project_id=uuid.uuid4(),
+    )
+    assert reason == "self_or_unverified"  # requester 미기록 → fail-closed
+
+
+@pytest.mark.anyio
+async def test_reason_no_project_access_injected():
+    with patch.object(gates_mod, "has_project_access", AsyncMock(return_value=False)):
+        reason = await can_approve_doc_gate_reason(
+            AsyncMock(), _gate(uuid.uuid4()), _human(uuid.uuid4()), uuid.uuid4(), uuid.uuid4(),
+            doc_project_id=uuid.uuid4(),
+        )
+    assert reason == "no_project_access"
+
+
+@pytest.mark.anyio
+async def test_reason_deleted_doc_injected_none():
+    spy = AsyncMock(return_value=True)
+    with patch.object(gates_mod, "has_project_access", spy):
+        reason = await can_approve_doc_gate_reason(
+            AsyncMock(), _gate(uuid.uuid4()), _human(uuid.uuid4()), uuid.uuid4(), uuid.uuid4(),
+            doc_project_id=None,  # 삭제/미존재 doc
+        )
+    assert reason == "no_project_access"
+    spy.assert_not_awaited()  # project_id None → 접근체크 전 차단
+
+
+@pytest.mark.anyio
+async def test_reason_ok_injected():
+    with patch.object(gates_mod, "has_project_access", AsyncMock(return_value=True)):
+        reason = await can_approve_doc_gate_reason(
+            AsyncMock(), _gate(uuid.uuid4()), _human(uuid.uuid4()), uuid.uuid4(), uuid.uuid4(),
+            doc_project_id=uuid.uuid4(),
+        )
+    assert reason is None  # 승인 가능(not-author + 접근 보유 + human)
+
+
+@pytest.mark.anyio
+async def test_reason_fetches_doc_when_project_id_unset():
+    """doc_project_id 미지정(transition 단건 경로) → 대상 doc 직접 조회."""
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_doc_result(uuid.uuid4()))
+    with patch.object(gates_mod, "has_project_access", AsyncMock(return_value=True)):
+        reason = await can_approve_doc_gate_reason(
+            session, _gate(uuid.uuid4()), _human(uuid.uuid4()), uuid.uuid4(), uuid.uuid4()
+        )
+    assert reason is None
+    session.execute.assert_awaited_once()  # _UNSET → fetch 경로
+
+
+@pytest.mark.anyio
+async def test_reason_fetch_deleted_doc():
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_doc_result(None))  # 조회 결과 없음(삭제)
+    spy = AsyncMock(return_value=True)
+    with patch.object(gates_mod, "has_project_access", spy):
+        reason = await can_approve_doc_gate_reason(
+            session, _gate(uuid.uuid4()), _human(uuid.uuid4()), uuid.uuid4(), uuid.uuid4()
+        )
+    assert reason == "no_project_access"
+    spy.assert_not_awaited()
+
+
+# ──────────────────── list_gates: per-caller can_approve enrich ────────────────────
+
+def _resp(g):
+    return SimpleNamespace(
+        work_item_type=g.work_item_type, work_item_id=g.work_item_id,
+        work_item_summary=None, can_approve=False,
+    )
+
+
+async def _list_gates(gate, *, has_access, resolved=None, resolve_raises=False):
+    org, pid = uuid.uuid4(), uuid.uuid4()
+    gates_result = MagicMock()
+    gates_result.scalars.return_value.all.return_value = [gate]
+    doc_batch = MagicMock()
+    doc_batch.all.return_value = [(gate.work_item_id, "T", "slug", pid)]
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[gates_result, doc_batch])
+    auth = SimpleNamespace(user_id=str(uuid.uuid4()))
+    rm = (
+        AsyncMock(side_effect=Exception("boom")) if resolve_raises
+        else AsyncMock(return_value=resolved or _human(uuid.uuid4()))
+    )
+    with patch.object(gates_mod.GateResponse, "model_validate", _resp), \
+         patch.object(gates_mod, "resolve_member", rm), \
+         patch.object(gates_mod, "has_project_access", AsyncMock(return_value=has_access)):
+        return await list_gates(
+            work_item_id=None, work_item_type=None, status=None,
+            session=session, org_id=org, auth=auth,
+        )
+
+
+@pytest.mark.anyio
+async def test_list_gates_can_approve_true_for_qualified():
+    out = await _list_gates(_gate(uuid.uuid4()), has_access=True)  # not-author
+    assert out[0].can_approve is True
+
+
+@pytest.mark.anyio
+async def test_list_gates_can_approve_false_no_access():
+    out = await _list_gates(_gate(uuid.uuid4()), has_access=False)
+    assert out[0].can_approve is False
+
+
+@pytest.mark.anyio
+async def test_list_gates_can_approve_false_for_author():
+    mid = uuid.uuid4()
+    out = await _list_gates(_gate(mid), has_access=True, resolved=_human(mid))  # author=caller
+    assert out[0].can_approve is False  # self-approval 금지
+
+
+@pytest.mark.anyio
+async def test_list_gates_can_approve_false_for_agent():
+    out = await _list_gates(_gate(uuid.uuid4()), has_access=True, resolved=_agent(uuid.uuid4()))
+    assert out[0].can_approve is False  # 비-휴먼
+
+
+@pytest.mark.anyio
+async def test_list_gates_non_doc_gate_untouched():
+    merge = SimpleNamespace(
+        gate_type="merge", work_item_type="story", work_item_id=uuid.uuid4(), neutral_facts={}
+    )
+    org = uuid.uuid4()
+    gates_result = MagicMock()
+    gates_result.scalars.return_value.all.return_value = [merge]
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[gates_result])  # doc_ids 비어 doc batch 미실행
+    auth = SimpleNamespace(user_id=str(uuid.uuid4()))
+    rm = AsyncMock(return_value=_human(uuid.uuid4()))
+    with patch.object(gates_mod.GateResponse, "model_validate", _resp), \
+         patch.object(gates_mod, "resolve_member", rm), \
+         patch.object(gates_mod, "has_project_access", AsyncMock(return_value=True)):
+        out = await list_gates(
+            work_item_id=None, work_item_type=None, status=None,
+            session=session, org_id=org, auth=auth,
+        )
+    assert out[0].can_approve is False
+    rm.assert_not_awaited()  # 비-doc 게이트만이면 resolve_member 미호출(불필요 작업 0)
+
+
+@pytest.mark.anyio
+async def test_list_gates_can_approve_enrich_nonfatal():
+    """resolve_member 실패해도 목록은 반환(can_approve=False fail-closed·비중단)."""
+    out = await _list_gates(_gate(uuid.uuid4()), has_access=True, resolve_raises=True)
+    assert out[0].can_approve is False

--- a/backend/tests/test_gate_decider_can_approve_89484c8c.py
+++ b/backend/tests/test_gate_decider_can_approve_89484c8c.py
@@ -34,12 +34,13 @@ def _agent(mid: uuid.UUID) -> ResolvedMember:
     )
 
 
-def _gate(requester_id, *, work_item_id=None):
+def _gate(requester_id, *, work_item_id=None, status="pending"):
     return SimpleNamespace(
         gate_type="doc_approval",
         neutral_facts={"requested_by_member_id": str(requester_id)} if requester_id else {},
         work_item_id=work_item_id or uuid.uuid4(),
         work_item_type="doc",
+        status=status,
     )
 
 
@@ -199,7 +200,8 @@ async def test_list_gates_can_approve_false_for_agent():
 @pytest.mark.anyio
 async def test_list_gates_non_doc_gate_untouched():
     merge = SimpleNamespace(
-        gate_type="merge", work_item_type="story", work_item_id=uuid.uuid4(), neutral_facts={}
+        gate_type="merge", work_item_type="story", work_item_id=uuid.uuid4(),
+        neutral_facts={}, status="pending",
     )
     org = uuid.uuid4()
     gates_result = MagicMock()
@@ -234,7 +236,7 @@ async def test_list_gates_can_approve_uses_doc_approval_predicate_not_work_item_
     org, doc_id, pid = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
     g = SimpleNamespace(  # 이상: gate_type=doc_approval 이나 work_item_type≠doc
         gate_type="doc_approval", work_item_type="story", work_item_id=doc_id,
-        neutral_facts={"requested_by_member_id": str(uuid.uuid4())},
+        neutral_facts={"requested_by_member_id": str(uuid.uuid4())}, status="pending",
     )
     gates_result = MagicMock()
     gates_result.scalars.return_value.all.return_value = [g]
@@ -251,3 +253,17 @@ async def test_list_gates_can_approve_uses_doc_approval_predicate_not_work_item_
             session=session, org_id=org, auth=auth,
         )
     assert out[0].can_approve is True  # project_id 가 doc_approval predicate 로 조회됨(work_item_type 무관)
+
+
+@pytest.mark.anyio
+async def test_list_gates_can_approve_false_for_terminal_status():
+    """status-DRY(codex): authz 통과해도 terminal(approved/rejected) gate 는 can_approve False — transition
+    FSM(is_valid_transition·pending 외 거부)과 동일. can_approve='지금 승인 가능'(authz + pending) 의미 정합."""
+    out = await _list_gates(_gate(uuid.uuid4(), status="approved"), has_access=True)
+    assert out[0].can_approve is False  # 자격 OK 지만 pending 아님 → FSM 으로 차단
+
+
+@pytest.mark.anyio
+async def test_list_gates_can_approve_false_for_held_status():
+    out = await _list_gates(_gate(uuid.uuid4(), status="held"), has_access=True)
+    assert out[0].can_approve is False  # held 도 pending→approved FSM 아님

--- a/backend/tests/test_gate_decider_can_approve_89484c8c.py
+++ b/backend/tests/test_gate_decider_can_approve_89484c8c.py
@@ -224,3 +224,30 @@ async def test_list_gates_can_approve_enrich_nonfatal():
     """resolve_member 실패해도 목록은 반환(can_approve=False fail-closed·비중단)."""
     out = await _list_gates(_gate(uuid.uuid4()), has_access=True, resolve_raises=True)
     assert out[0].can_approve is False
+
+
+@pytest.mark.anyio
+async def test_list_gates_can_approve_uses_doc_approval_predicate_not_work_item_type():
+    """② DRY: doc_approval 인데 work_item_type≠doc 인 이상 게이트도 project_id 를 doc_approval predicate
+    (work_item_id→Doc·transition 과 동일)로 조회 → can_approve 가 transition 강제와 정합. work_item_type 으로
+    키잉하면 project_id=None→can_approve False 로 갈림(이 테스트가 그 회귀를 잠금)."""
+    org, doc_id, pid = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    g = SimpleNamespace(  # 이상: gate_type=doc_approval 이나 work_item_type≠doc
+        gate_type="doc_approval", work_item_type="story", work_item_id=doc_id,
+        neutral_facts={"requested_by_member_id": str(uuid.uuid4())},
+    )
+    gates_result = MagicMock()
+    gates_result.scalars.return_value.all.return_value = [g]
+    doc_batch = MagicMock()
+    doc_batch.all.return_value = [(doc_id, "T", "slug", pid)]  # approval predicate 로 조회돼야 채워짐
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[gates_result, doc_batch])
+    auth = SimpleNamespace(user_id=str(uuid.uuid4()))
+    with patch.object(gates_mod.GateResponse, "model_validate", _resp), \
+         patch.object(gates_mod, "resolve_member", AsyncMock(return_value=_human(uuid.uuid4()))), \
+         patch.object(gates_mod, "has_project_access", AsyncMock(return_value=True)):
+        out = await list_gates(
+            work_item_id=None, work_item_type=None, status=None,
+            session=session, org_id=org, auth=auth,
+        )
+    assert out[0].can_approve is True  # project_id 가 doc_approval predicate 로 조회됨(work_item_type 무관)

--- a/backend/tests/test_gate_inbox_doc_enrich.py
+++ b/backend/tests/test_gate_inbox_doc_enrich.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.routers import gates as gates_mod
 from app.routers.gates import list_gates
+from app.services.member_resolver import ResolvedMember
 
 
 @pytest.fixture
@@ -30,12 +32,23 @@ def _gate(org, work_item_id, wtype):
 
 @pytest.mark.anyio
 async def test_doc_gate_enriched_with_title_slug():
-    org, doc_id = uuid.uuid4(), uuid.uuid4()
-    gates_res = MagicMock(); gates_res.scalars.return_value.all.return_value = [_gate(org, doc_id, "doc")]
-    docs_res = MagicMock(); docs_res.all.return_value = [(doc_id, "설계 문서", "design-doc")]
-    session = AsyncMock(); session.execute = AsyncMock(side_effect=[gates_res, docs_res])
-    out = await list_gates(work_item_id=None, work_item_type="doc", status="pending",
-                           session=session, org_id=org, _auth=None)
+    org, doc_id, pid = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    gates_res = MagicMock()
+    gates_res.scalars.return_value.all.return_value = [_gate(org, doc_id, "doc")]
+    # 89484c8c: 배치가 project_id 도 조회(4-tuple) — can_approve enrich 재사용.
+    docs_res = MagicMock()
+    docs_res.all.return_value = [(doc_id, "설계 문서", "design-doc", pid)]
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[gates_res, docs_res])
+    auth = SimpleNamespace(user_id=str(uuid.uuid4()))
+    resolved = ResolvedMember(
+        id=uuid.uuid4(), user_id=uuid.uuid4(), name="h", type="human", role="member", org_id=org
+    )
+    # doc_approval gate → can_approve enrich 가 resolve_member 호출(여기선 summary 만 검증·patch 로 무crash).
+    with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=resolved)), \
+         patch.object(gates_mod, "has_project_access", AsyncMock(return_value=True)):
+        out = await list_gates(work_item_id=None, work_item_type="doc", status="pending",
+                               session=session, org_id=org, auth=auth)
     assert out[0].work_item_summary is not None
     assert out[0].work_item_summary.title == "설계 문서"
     assert out[0].work_item_summary.slug == "design-doc"
@@ -43,11 +56,13 @@ async def test_doc_gate_enriched_with_title_slug():
 
 @pytest.mark.anyio
 async def test_non_doc_gate_no_enrich_no_extra_query():
-    """비-doc gate 는 enrich 0(work_item_summary None)·doc 쿼리 미발생(N+1 0)."""
+    """비-doc gate 는 enrich 0(work_item_summary None)·doc 쿼리 미발생(N+1 0)·can_approve enrich skip."""
     org = uuid.uuid4()
-    gates_res = MagicMock(); gates_res.scalars.return_value.all.return_value = [_gate(org, uuid.uuid4(), "story")]
-    session = AsyncMock(); session.execute = AsyncMock(side_effect=[gates_res])
+    gates_res = MagicMock()
+    gates_res.scalars.return_value.all.return_value = [_gate(org, uuid.uuid4(), "story")]
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[gates_res])
     out = await list_gates(work_item_id=None, work_item_type=None, status=None,
-                           session=session, org_id=org, _auth=None)
+                           session=session, org_id=org, auth=None)
     assert out[0].work_item_summary is None
-    assert session.execute.await_count == 1  # gates 쿼리만(doc enrich 쿼리 0)
+    assert session.execute.await_count == 1  # gates 쿼리만(doc/can_approve enrich 쿼리 0)


### PR DESCRIPTION
## 문제 — ① decider DEAD-PATH (PO 실측)
FE in-doc 승인/반려 버튼이 **영영 안 뜬다**. FE(`doc-gate-section.tsx`)가 게이팅 소스로 쓰던
`GET /api/gates/{id}/approvers`(`list_gate_approvers`)는 **admin-only + parallel/quorum gate 의 approver
row 전용** → plain `doc_approval` 게이트는 approver row 0 (+ 非admin 403) → `isApprover` 항상 false →
in-doc decider 사망. 인박스 quick 결재만 can_approve(rule A)로 작동.

## fix — ⓑ (PO 승인)
decider 자격 소스를 **rule A(can_approve)**로 전환. `/approvers` 는 **무변경**(S32 reassign/quorum 회귀 방지).

- rule A 를 transition 인라인(48f064e5)에서 **`can_approve_doc_gate_reason` 단일 규칙으로 추출**:
  human + 대상 doc project `has_project_access` + not-author(resolver≠requester·미기록 fail-closed).
  → transition 강제(403 분기 메시지 보존)와 list_gates 가시성이 **공용(DRY·거동 분기 0)**.
- `GateResponse.can_approve: bool` 추가(additive·**per-caller**·default False fail-closed).
- `list_gates`: doc_approval 게이트에 per-caller can_approve enrich. doc batch 에 `project_id` 합류(**N+1 0**)·
  비-휴먼/무자격/삭제 doc=False·`resolve_member` 실패는 **비중단**(가시성 enrich 가 목록 안 막음).
- `transition_gate_endpoint`: 인라인 rule → 헬퍼 호출 치환(self vs 권한 403 메시지 동일).

## FE 계약 (미르코 #1793 페어)
`gate.can_approve` 로 in-doc decider 게이팅 · `/approvers` fetch 삭제 · reviewerName 재배치/드롭.
실 authz 는 BE transition 강제(이 필드 = **가시성뿐**).

## 검증
- 신규 **14 pass**(헬퍼 8 rule-A 분기 + list_gates enrich 6: 자격/무접근/author/agent/비-doc 무접촉/비중단)
- 기존 gate 스위트 **19 pass**(transition 회귀 0·`/approvers`·parallel 무변경)
- ruff · full no-DB **2629 pass**(잔여 10 = MCP-env DoD·무관) · 마이그 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
