### PR TITLE
[SID:f69fcd91] doc mutation cross-project IDOR — delete/cancel/update project-access 강제

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
           JWT_SECRET: ci-test-secret-at-least-32-chars-long
           SECRET_KEY: ci-test-secret-at-least-32-chars-long
-        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py tests/test_release_notes_realdb.py tests/test_audit_apikey_parity_realdb.py tests/test_doc_gate_cascade_scope_realdb.py -q
+        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py tests/test_release_notes_realdb.py tests/test_audit_apikey_parity_realdb.py tests/test_doc_gate_cascade_scope_realdb.py tests/test_doc_mutation_project_scope_idor_realdb.py -q
 
       - name: Verify fresh DB reached head (baseline + incremental)
         working-directory: backend

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user, get_project_scoped_org_id, get_verified_org_id
 from app.dependencies.database import get_db
-from app.models.doc import DocComment, DocRevision
+from app.models.doc import Doc, DocComment, DocRevision
 from app.models.member import Member
 from app.models.team import TeamMember
 from app.repositories.doc import DocRepository
@@ -296,7 +296,10 @@ async def update_doc(
     body: DocUpdate,
     repo: DocRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
 ) -> DocResponse:
+    # f69fcd91: 대상 doc 의 project 접근 강제(cross-project IDOR — patch 도 id+org 로만 잡아 mutate 하던 갭).
+    await _require_doc_project_access(session, id, uuid.UUID(auth.user_id), repo.org_id)
     data = body.model_dump(exclude_unset=True)
     # 4dd399c6: slug/slug_locked 는 유일성·alias 처리가 필요해 일반 필드와 분리.
     slug_in = data.pop("slug", None)
@@ -421,6 +424,9 @@ async def delete_doc(
     repo: DocRepository = Depends(_get_repo),
     auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    # f69fcd91: 대상 doc 의 project 접근 강제(cross-project IDOR 차단·get_project_scoped_org_id 의 org-only
+    # fallback 으로 同org 비-project caller 가 타 project doc 삭제 가능하던 갭). 없으면 404·무권한 403.
+    await _require_doc_project_access(repo.session, id, uuid.UUID(auth.user_id), repo.org_id)
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Doc not found")
@@ -454,6 +460,25 @@ async def _resolve_doc_member_id(auth: AuthContext, org_id: uuid.UUID, db: Async
     # member id(org_member.id)로 폴백. 비-멤버는 resolve_member가 400.
     from app.services.member_resolver import resolve_member
     return (await resolve_member(auth, org_id, db)).id
+
+
+async def _require_doc_project_access(
+    session: AsyncSession, doc_id: uuid.UUID, user_id: uuid.UUID, org_id: uuid.UUID
+) -> Doc:
+    """f69fcd91: doc mutation 의 canonical project-scope authz. 대상 doc 을 org-scope 로 로드하고 caller 의
+    그 doc project 접근(has_project_access SSOT=team_member∪grant∪owner/admin)을 강제 — doc 없으면 404·
+    무권한 403. delete/cancel/update 가 **id+org 로만** doc 잡아 mutate 하던 cross-project IDOR(同org
+    비-project caller 가 타 project doc 삭제/취소/수정) 차단. register_doc_asset 의 project 가드와 동일 SSOT.
+    반환=로드된 doc(caller 재사용 가능)."""
+    from app.services.project_auth import has_project_access
+    doc = (await session.execute(
+        select(Doc).where(Doc.id == doc_id, Doc.org_id == org_id, Doc.deleted_at.is_(None))
+    )).scalar_one_or_none()
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Doc not found")
+    if not await has_project_access(session, user_id, doc.project_id, org_id):
+        raise HTTPException(status_code=403, detail="해당 문서의 프로젝트 접근 권한이 없습니다")
+    return doc
 
 
 # ─── Share (Part B b1574f5a) ──────────────────────────────────────────────────
@@ -624,6 +649,9 @@ async def transition_doc_endpoint(
     from app.services.member_resolver import resolve_member
 
     caller = await resolve_member(auth, org_id, session)
+    # f69fcd91: 대상 doc 의 project 접근 강제(cross-project IDOR — cancel/transition 도 id+org 로만 doc
+    # 잡던 갭). via_gate 시스템 경로(gate 해소)는 transition_doc 직호출이라 무영향(이 엔드포인트만 user authz).
+    await _require_doc_project_access(session, id, uuid.UUID(auth.user_id), org_id)
     try:
         doc = await transition_doc(session, org_id, caller, id, body.status)
         await session.commit()

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -514,9 +514,9 @@ async def enable_doc_share(
     auth: AuthContext = Depends(get_current_user),
 ) -> ShareStatusResponse:
     """opt-in 공개 활성 — active 토큰 발급(멱등)."""
-    doc = await repo.get(id)
-    if doc is None:
-        raise HTTPException(status_code=404, detail="Doc not found")
+    # f69fcd91: 대상 doc project access 강제(cross-project IDOR — share enable/rotate/revoke 도 id+org
+    # 로만 doc 잡던 갭). 없으면 404·무권한 403. agent 도 has_project_access agent 분기로 차단.
+    doc = await _require_doc_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
     actor_id = await _resolve_doc_member_id(auth, repo.org_id, db)
     from app.services import doc_share
     tok = await doc_share.enable(db, repo.org_id, doc.project_id, id, actor_id)
@@ -531,9 +531,9 @@ async def regenerate_doc_share(
     auth: AuthContext = Depends(get_current_user),
 ) -> ShareStatusResponse:
     """구 토큰 즉시 폐기 + 신규 발급(유출 방어)."""
-    doc = await repo.get(id)
-    if doc is None:
-        raise HTTPException(status_code=404, detail="Doc not found")
+    # f69fcd91: 대상 doc project access 강제(cross-project IDOR — share enable/rotate/revoke 도 id+org
+    # 로만 doc 잡던 갭). 없으면 404·무권한 403. agent 도 has_project_access agent 분기로 차단.
+    doc = await _require_doc_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
     actor_id = await _resolve_doc_member_id(auth, repo.org_id, db)
     from app.services import doc_share
     tok = await doc_share.regenerate(db, repo.org_id, doc.project_id, id, actor_id)
@@ -548,9 +548,9 @@ async def disable_doc_share(
     auth: AuthContext = Depends(get_current_user),
 ) -> ShareStatusResponse:
     """공개 중단 — active 토큰 revoke(이후 공개 read 410)."""
-    doc = await repo.get(id)
-    if doc is None:
-        raise HTTPException(status_code=404, detail="Doc not found")
+    # f69fcd91: 대상 doc project access 강제(cross-project IDOR — share enable/rotate/revoke 도 id+org
+    # 로만 doc 잡던 갭). 없으면 404·무권한 403. agent 도 has_project_access agent 분기로 차단.
+    await _require_doc_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
     actor_id = await _resolve_doc_member_id(auth, repo.org_id, db)
     from app.services import doc_share
     await doc_share.revoke(db, repo.org_id, id, actor_id)
@@ -588,11 +588,8 @@ async def add_doc_comment(
     repo: DocRepository = Depends(_get_repo),
     auth: AuthContext = Depends(get_current_user),
 ) -> DocCommentResponse:
-    from app.models.doc import Doc
-    doc_result = await db.execute(select(Doc).where(Doc.id == id, Doc.org_id == repo.org_id))
-    doc = doc_result.scalar_one_or_none()
-    if not doc:
-        raise HTTPException(status_code=404, detail="Doc not found")
+    # f69fcd91: 대상 doc project access 강제(cross-project IDOR — 코멘트 주입도 id+org 로만 잡던 갭).
+    doc = await _require_doc_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
     created_by = await _resolve_doc_member_id(auth, repo.org_id, db)
     created_by = await canonicalize_member_id(created_by, db)  # AC3-2d(2): canonical 정규화
     comment = DocComment(

--- a/backend/tests/test_doc_concurrency_151e05f1.py
+++ b/backend/tests/test_doc_concurrency_151e05f1.py
@@ -8,10 +8,12 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.dependencies.auth import AuthContext
+from app.routers import docs as docs_mod
 from app.routers.docs import update_doc
 from app.schemas.doc import DocUpdate
 
@@ -42,7 +44,11 @@ async def _call(body_kwargs, doc_updated_at=T1):
     session.execute = AsyncMock()
     session.flush = AsyncMock()
     session.refresh = AsyncMock()
-    resp = await update_doc(d.id, DocUpdate(**body_kwargs), repo, session)
+    auth = AuthContext(user_id=str(uuid.uuid4()), email=None, claims={}, org_id=str(repo.org_id))
+    # f69fcd91: update_doc 가 project authz(_require_doc_project_access) 선행 — 이 테스트는 409 동시성
+    # 로직 검증이라 authz 게이트는 통과(doc 반환)로 패치.
+    with patch.object(docs_mod, "_require_doc_project_access", AsyncMock(return_value=d)):
+        resp = await update_doc(d.id, DocUpdate(**body_kwargs), repo, session, auth=auth)
     return resp, d
 
 

--- a/backend/tests/test_doc_mutation_project_scope_idor_realdb.py
+++ b/backend/tests/test_doc_mutation_project_scope_idor_realdb.py
@@ -1,0 +1,159 @@
+"""f69fcd91: doc mutation(delete/cancel/update) cross-project IDOR — realdb repro + lock.
+
+갭(codex #1792 QA 적출·PO confirm): delete_doc/transition_doc_endpoint/update_doc 가 대상 doc 을 **id+org**
+로만 잡아 mutate(get_project_scoped_org_id 의 project_id 는 caller query param·생략 시 org-only) → 同org
+**비-owner/admin·대상 doc project grant 없는** 멤버가 타 project doc 을 삭제/취소/수정 가능(수평 IDOR).
+
+fix = 3경로 다 대상 doc 의 `has_project_access(doc.project_id)` 강제. 본 테스트는 **fix 후 거동**(cross-project
+=403·same-project=통과)을 assert — fix 前엔 RED(mutation 성공/authz 부재)로 exploitability 실증, fix 後 GREEN.
+realdb 필수(has_project_access SSOT=team_member∪grant∪owner/admin·grant row 실측).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("c9000000-0000-0000-0000-000000000001")
+USER = uuid.UUID("c9000000-0000-0000-0000-0000000000a1")
+OM = uuid.UUID("c9000000-0000-0000-0000-0000000000b1")
+PROJ_A = uuid.UUID("c9000000-0000-0000-0000-0000000000c1")  # USER grant(접근 O)
+PROJ_B = uuid.UUID("c9000000-0000-0000-0000-0000000000c2")  # USER 접근 X(IDOR 축)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+
+
+async def _seed(s):
+    """ORG·USER(member·非owner/admin)·PROJ_A(grant)·PROJ_B(no grant) 시드 + 양 project 에 doc."""
+    from app.models.doc import Doc
+    for sql in [
+        f"DELETE FROM docs WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id IN ('{PROJ_A}','{PROJ_B}')",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','C9','c9org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@c9.test','x','U',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_A}','{ORG}','A')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_B}','{ORG}','B')",
+        # USER 는 PROJ_A 에만 grant(PROJ_B 접근 없음 — IDOR 테스트축).
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ_A}','{OM}','granted')",
+    ]:
+        await s.execute(text(sql))
+    docs = {}
+    for key, pid, status in [
+        ("b_del", PROJ_B, "draft"), ("b_cancel", PROJ_B, "pending"), ("b_upd", PROJ_B, "draft"),
+        ("a_del", PROJ_A, "draft"), ("a_cancel", PROJ_A, "pending"), ("a_upd", PROJ_A, "draft"),
+    ]:
+        d = Doc(id=uuid.uuid4(), org_id=ORG, project_id=pid, title="t",
+                slug=f"s-{uuid.uuid4().hex[:10]}", status=status, content="")
+        s.add(d)
+        docs[key] = d.id
+    await s.commit()
+    return docs
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+# ───────────────────────── delete ─────────────────────────
+
+@pytest.mark.anyio
+async def test_delete_cross_project_forbidden_same_project_ok():
+    from app.repositories.doc import DocRepository
+    from app.routers.docs import delete_doc
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            docs = await _seed(s)
+        # cross-project(PROJ_B·USER 무접근) → 403
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await delete_doc(id=docs["b_del"], repo=DocRepository(s, ORG), auth=_auth())
+            assert ei.value.status_code == 403
+        # same-project(PROJ_A·USER grant) → 통과
+        async with Session() as s:
+            out = await delete_doc(id=docs["a_del"], repo=DocRepository(s, ORG), auth=_auth())
+            await s.commit()
+            assert out == {"ok": True}
+    finally:
+        await eng.dispose()
+
+
+# ───────────────────────── cancel(transition pending→draft) ─────────────────────────
+
+@pytest.mark.anyio
+async def test_cancel_cross_project_forbidden_same_project_ok():
+    from app.routers.docs import DocTransitionRequest, transition_doc_endpoint
+    eng, Session = await _engine()
+    try:
+        docs = None
+        async with Session() as s:
+            docs = await _seed(s)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await transition_doc_endpoint(
+                    id=docs["b_cancel"], body=DocTransitionRequest(status="draft"),
+                    session=s, org_id=ORG, auth=_auth(),
+                )
+            assert ei.value.status_code == 403
+        async with Session() as s:
+            out = await transition_doc_endpoint(
+                id=docs["a_cancel"], body=DocTransitionRequest(status="draft"),
+                session=s, org_id=ORG, auth=_auth(),
+            )
+            assert out.status == "draft"
+    finally:
+        await eng.dispose()
+
+
+# ───────────────────────── update(patch) ─────────────────────────
+
+@pytest.mark.anyio
+async def test_update_cross_project_forbidden_same_project_ok():
+    from app.repositories.doc import DocRepository
+    from app.routers.docs import DocUpdate, update_doc
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            docs = await _seed(s)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await update_doc(
+                    id=docs["b_upd"], body=DocUpdate(title="hacked"),
+                    repo=DocRepository(s, ORG), session=s, auth=_auth(),
+                )
+            assert ei.value.status_code == 403
+        async with Session() as s:
+            out = await update_doc(
+                id=docs["a_upd"], body=DocUpdate(title="ok-edit"),
+                repo=DocRepository(s, ORG), session=s, auth=_auth(),
+            )
+            assert out.title == "ok-edit"
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_doc_mutation_project_scope_idor_realdb.py
+++ b/backend/tests/test_doc_mutation_project_scope_idor_realdb.py
@@ -30,6 +30,7 @@ USER = uuid.UUID("c9000000-0000-0000-0000-0000000000a1")
 OM = uuid.UUID("c9000000-0000-0000-0000-0000000000b1")
 PROJ_A = uuid.UUID("c9000000-0000-0000-0000-0000000000c1")  # USER grant(접근 O)
 PROJ_B = uuid.UUID("c9000000-0000-0000-0000-0000000000c2")  # USER 접근 X(IDOR 축)
+AGENT = uuid.UUID("c9000000-0000-0000-0000-0000000000e1")  # agent member·grant 0(agent IDOR 축)
 
 
 @pytest.fixture
@@ -42,6 +43,13 @@ def _auth():
     return AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
 
 
+def _agent_auth():
+    # 에이전트 키: auth.user_id=str(members.id)(_resolve_api_key). grant 없으면 has_project_access
+    # agent 분기서 차단돼야(cross-project mutate 불가).
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(AGENT), email=None, claims={}, org_id=str(ORG))
+
+
 async def _seed(s):
     """ORG·USER(member·非owner/admin)·PROJ_A(grant)·PROJ_B(no grant) 시드 + 양 project 에 doc."""
     from app.models.doc import Doc
@@ -49,6 +57,7 @@ async def _seed(s):
         f"DELETE FROM docs WHERE org_id='{ORG}'",
         f"DELETE FROM project_access WHERE project_id IN ('{PROJ_A}','{PROJ_B}')",
         f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
         f"DELETE FROM projects WHERE org_id='{ORG}'",
         f"DELETE FROM users WHERE id='{USER}'",
         f"DELETE FROM organizations WHERE id='{ORG}'",
@@ -56,6 +65,8 @@ async def _seed(s):
         "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
         f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@c9.test','x','U',true,true,0,false,0)",
         f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
+        # agent member(grant 0 — agent cross-project IDOR 축).
+        f"INSERT INTO members (id,org_id,type,name,is_active) VALUES ('{AGENT}','{ORG}','agent','Ag',true)",
         f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_A}','{ORG}','A')",
         f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_B}','{ORG}','B')",
         # USER 는 PROJ_A 에만 grant(PROJ_B 접근 없음 — IDOR 테스트축).
@@ -67,6 +78,9 @@ async def _seed(s):
     for key, pid, status in [
         ("b_del", PROJ_B, "draft"), ("b_cancel", PROJ_B, "pending"), ("b_upd", PROJ_B, "draft"),
         ("a_del", PROJ_A, "draft"), ("a_cancel", PROJ_A, "pending"), ("a_upd", PROJ_A, "draft"),
+        ("b_share", PROJ_B, "draft"), ("a_share", PROJ_A, "draft"),
+        ("b_comment", PROJ_B, "draft"), ("a_comment", PROJ_A, "draft"),
+        ("b_agent", PROJ_B, "draft"),
     ]:
         d = Doc(id=uuid.uuid4(), org_id=ORG, project_id=pid, title="t",
                 slug=f"s-{uuid.uuid4().hex[:10]}", status=status, content="")
@@ -155,5 +169,74 @@ async def test_update_cross_project_forbidden_same_project_ok():
                 repo=DocRepository(s, ORG), session=s, auth=_auth(),
             )
             assert out.title == "ok-edit"
+    finally:
+        await eng.dispose()
+
+
+# ───────────────────────── share (enable/regenerate/disable) ─────────────────────────
+
+@pytest.mark.anyio
+async def test_share_cross_project_forbidden_same_project_ok():
+    from app.repositories.doc import DocRepository
+    from app.routers.docs import disable_doc_share, enable_doc_share, regenerate_doc_share
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            docs = await _seed(s)
+        # cross-project(PROJ_B·USER 무접근) — enable/rotate/revoke 3 op 다 403
+        for op in (enable_doc_share, regenerate_doc_share, disable_doc_share):
+            async with Session() as s:
+                with pytest.raises(HTTPException) as ei:
+                    await op(id=docs["b_share"], repo=DocRepository(s, ORG), db=s, auth=_auth())
+                assert ei.value.status_code == 403, op.__name__
+        # same-project(PROJ_A) — enable 통과
+        async with Session() as s:
+            out = await enable_doc_share(id=docs["a_share"], repo=DocRepository(s, ORG), db=s, auth=_auth())
+            assert out.enabled is True
+    finally:
+        await eng.dispose()
+
+
+# ───────────────────────── comment ─────────────────────────
+
+@pytest.mark.anyio
+async def test_comment_cross_project_forbidden_same_project_ok():
+    from app.repositories.doc import DocRepository
+    from app.routers.docs import add_doc_comment
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            docs = await _seed(s)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await add_doc_comment(
+                    id=docs["b_comment"], content="x", db=s, repo=DocRepository(s, ORG), auth=_auth()
+                )
+            assert ei.value.status_code == 403
+        async with Session() as s:
+            out = await add_doc_comment(
+                id=docs["a_comment"], content="ok", db=s, repo=DocRepository(s, ORG), auth=_auth()
+            )
+            assert out.content == "ok"
+    finally:
+        await eng.dispose()
+
+
+# ───────────────────────── agent (grant 0 → 차단) ─────────────────────────
+
+@pytest.mark.anyio
+async def test_agent_without_grant_cross_project_forbidden():
+    """agent 키(grant 0)도 cross-project mutate 차단 — auth.user_id=str(members.id)(유효 UUID·throw 안 함)·
+    has_project_access agent 분기(project_access.member_id)가 grant 없으면 False → 403(fail-open 아님)."""
+    from app.repositories.doc import DocRepository
+    from app.routers.docs import delete_doc
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            docs = await _seed(s)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await delete_doc(id=docs["b_agent"], repo=DocRepository(s, ORG), auth=_agent_auth())
+            assert ei.value.status_code == 403
     finally:
         await eng.dispose()


### PR DESCRIPTION
## 갭 (codex #1792 QA 적출 · PO confirm · realdb repro 실증)
`delete_doc` / `transition_doc_endpoint`(cancel) / `update_doc`(patch) 가 대상 doc 을 **id+org 로만** 잡아
mutate. `get_project_scoped_org_id` 의 `project_id` 는 **caller query param**(대상 doc 의 project 아님)·생략 시
org-only fallback → 同org **비-owner/admin·대상 doc project grant 없는** 멤버가 타 project doc 삭제/취소/수정
가능(수평 **cross-project IDOR**). `register_doc_asset`·GET cross-org fallback 은 project access 검증 = 비일관.

## exploitability 실증 (realdb repro)
project A grant 만 가진 멤버가 project B doc **delete/cancel 성공**(`DID NOT RAISE`)·update 는 authz infra
부재. → fix 後 셋 다 403.

## fix
canonical 가드 **`_require_doc_project_access(session, doc_id, user_id, org_id)`** — 대상 doc org-scope 로드 +
`has_project_access(doc.project_id)` SSOT 강제(doc 없으면 404·무권한 403). **3 mutation 경로 다 적용**(한쪽만
닫으면 hole 잔존). `update_doc` 에 `auth=get_current_user` 추가. via_gate 시스템 경로(gate 해소→`transition_doc`
직호출)는 무영향(엔드포인트만 user authz).

## 검증
- realdb repro **3 RED→GREEN**(현재 mutation 성공 → fix 後 cross-project 403·same-project 통과)
- concurrency 테스트 auth 배선 · doc 스위트 **141 pass** · ruff · full no-DB **2638 pass**(잔여 8 = MCP-env DoD·무관) · 마이그 0
- IDOR realdb 테스트 CI PG-backed 잡 등록

⚠️ destructive + cross-project IDOR (#1791/#1794급) — codex cross-model QA(authz·IDOR·3경로 우회 불가) 요망.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
