### PR TITLE
[SID:ade2d6d5] 딥링크 scroll-race fix — center-scroll이 target 안 띄우던 RC

### DIFF
--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -93,6 +93,10 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   const lastScrolledIdRef = useRef<string | null>(null);
   const scrollTargetRef = useRef<string | undefined>(undefined);
   const scrollLoadAttemptsRef = useRef(0);
+  // scroll race fix: rAF(post-paint 측정)·settle 디바운스(prepend/이미지로드로 target 밀림 재보정)·done(유저 스크롤 존중).
+  const scrollRafRef = useRef<number | null>(null);
+  const scrollSettleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scrollDoneRef = useRef(false);
   // CB-S8: render 후 스크롤 트리거용 ref (setTimeout 패턴 대체)
   const shouldScrollToBottomRef = useRef(false);
   // CB-S8: pull-to-refresh 터치 추적
@@ -149,9 +153,11 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
     }
   }, [loading, scrollToBottom, scrollToMessageId]);
 
-  // Deeplink (ade2d6d5): 언마운트 시 하이라이트 타이머 정리(메모리·setState-after-unmount 방지).
+  // Deeplink (ade2d6d5): 언마운트 시 타이머/rAF 정리(메모리·setState-after-unmount 방지).
   useEffect(() => () => {
     if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current);
+    if (scrollSettleTimerRef.current) clearTimeout(scrollSettleTimerRef.current);
+    if (scrollRafRef.current != null) cancelAnimationFrame(scrollRafRef.current);
   }, []);
 
   // 1aeecdde P2: 에이전트 typing 즉시 해제(답장 메시지 도착 시·다음 폴링 전 갭 제거).
@@ -370,24 +376,36 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   // 로드 후 다시 탐색한다. 대상 미발견·페이지 소진 시 no-op(graceful).
   useEffect(() => {
     if (!scrollToMessageId || loading) return;
-    // 대상이 바뀌면 시도 카운터 리셋(이전 대상의 잔여 시도 영향 제거).
+    // 대상이 바뀌면 시도/상태 리셋.
     if (scrollTargetRef.current !== scrollToMessageId) {
       scrollTargetRef.current = scrollToMessageId;
       scrollLoadAttemptsRef.current = 0;
+      scrollDoneRef.current = false;
     }
-    // 같은 대상으로 이미 스크롤했다면 재스크롤 금지.
-    if (lastScrolledIdRef.current === scrollToMessageId) return;
+    // settle 완료(추가 레이아웃 변화 없음) → 재보정 중단(유저 스크롤 존중).
+    if (scrollDoneRef.current) return;
 
     const container = scrollRef.current;
     if (!container) return;
     const el = container.querySelector<HTMLElement>(`#msg-${CSS.escape(scrollToMessageId)}`);
     if (el) {
-      lastScrolledIdRef.current = scrollToMessageId;
       scrollLoadAttemptsRef.current = 0;
-      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current);
-      setHighlightId(scrollToMessageId);
-      highlightTimerRef.current = setTimeout(() => setHighlightId(null), 2200);
+      // race fix: 동기 scrollIntoView 는 prepend 페이지 paint/이미지로드 前 측정→target 이 이후
+      // 성장으로 밀려 off-screen(top≈15022). rAF 로 paint 後 측정 + messages 변경마다(prepend·이미지) center 재보정.
+      if (scrollRafRef.current != null) cancelAnimationFrame(scrollRafRef.current);
+      scrollRafRef.current = requestAnimationFrame(() => {
+        container.querySelector<HTMLElement>(`#msg-${CSS.escape(scrollToMessageId)}`)?.scrollIntoView({ block: 'center' });
+      });
+      // 첫 발견 시에만 하이라이트(2.2s).
+      if (lastScrolledIdRef.current !== scrollToMessageId) {
+        lastScrolledIdRef.current = scrollToMessageId;
+        if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current);
+        setHighlightId(scrollToMessageId);
+        highlightTimerRef.current = setTimeout(() => setHighlightId(null), 2200);
+      }
+      // settle 디바운스: 추가 messages 변경 없이 안정되면 done(재보정 정지).
+      if (scrollSettleTimerRef.current) clearTimeout(scrollSettleTimerRef.current);
+      scrollSettleTimerRef.current = setTimeout(() => { scrollDoneRef.current = true; }, 600);
       return;
     }
     // 미발견 + 이전 페이지 존재 → 바운드 내에서 이전 페이지 로드 후 재시도(messages 변경→effect 재실행).


### PR DESCRIPTION
## 개요
딥링크 enrich(#1795) 라이브 픽셀 **INCONCLUSIVE** 후속 RC. 유나 라이브: highlight ring은 붙는데 **center-scroll이 target을 뷰로 안 데려옴**(target top≈15022 off-screen·long conv 4런 일관).

## 근본
scroll effect가 el found 시 **동기적으로 `scrollIntoView({behavior:'smooth'})` 즉발** + `lastScrolledIdRef` **영구 가드**. `load-until-found`가 prepend한 older 페이지가 React commit돼도 **paint/이미지로드 前에 scroll 측정**→target 위치 오산·이후 콘텐츠 성장으로 target이 아래로 밀려 off-screen. 영구 가드가 corrective 재스크롤을 차단. `smooth`는 중간 레이아웃 변경에 취약. (짧은 conv=타겟 첫페이지·prepend 없음→무영향 = **long-conv 한정 race**.)

## fix
- **`requestAnimationFrame`로 paint 後 측정** 후 `scrollIntoView({block:'center'})` instant(`smooth` 제거).
- **영구 가드 제거** → `messages` 변경(prepend·이미지로드 성장)마다 center **재보정**.
- **settle 디바운스**(600ms 추가 변경 없으면 `scrollDoneRef=true`→재보정 정지·**유저 스크롤 존중**).
- 하이라이트는 첫 발견 1회만(2.2s). 언마운트 cleanup에 rAF+settle timer 추가(메모리·setState-after-unmount 방지).

## 안전
- `messageId` 부재 = 기존 거동(하단 스크롤) **불변**. 미발견=graceful no-op(불변).
- settle 後 재보정 정지 → 유저가 스크롤 이동 시 방해 0.

## 검증
- `pnpm build` EXIT0·tsc/lint clean.
- **유나 재캡처**: long conv(796b6d2e) center-scroll이 target 띄우는지(off-screen 해소) + short conv 회귀·양테마.

게이트(가볍게): PO crux + 유나 픽셀(codex 불요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)