### PR TITLE
[SID:3f1f2408] release-notes 공개 API write route 제거 — 멀티테넌시 침해 봉인

### DIFF
--- a/backend/app/routers/release_notes.py
+++ b/backend/app/routers/release_notes.py
@@ -1,23 +1,23 @@
-"""릴리즈 노트 API(E-POLISH 53bc0945) — 하드코딩 RELEASE_NOTES de-hardcode.
+"""릴리즈 노트 **공개 API** — GET(published·전역·authed user)만 노출.
 
-GET = published 노트(newest-first·전 org 공통·authed user). CRUD = org owner/admin(platform-admin 롤
-부재·v1). response 는 FE `ReleaseNote` shape 그대로(`note_key→id`·`display_period→publishedAt`) 매핑해
-dialog 무회귀. id(=note_key)는 FE localStorage seen-key 와 동일.
+write(생성/수정/삭제)는 3f1f2408 에서 공개 API 에서 **제거**: 릴노트는 sprintable 플랫폼 전역 changelog
+(전 고객 공유)인데, write 가 `is_org_owner_or_admin(호출자 자기 org)` 게이트라 **아무 고객 org owner 가
+전역 릴노트 편집/삭제 가능 = 멀티테넌시 침해**였다(실행 실증·EXPLOITABLE). 공개 API 에서 write route 자체를
+빼서 고객 write 경로를 0 으로 만든다. 릴노트 **관리(write)는 별도 비공개 운영자 어드민 경로**로만 제공(별 설계).
+모델/서비스(`release_note.py`)는 GET + 향후 어드민이 재사용하므로 **보존**.
+
+GET response 는 FE `ReleaseNote` shape(`note_key→id`·`display_period→publishedAt`) 그대로 매핑(dialog 무회귀).
 """
 from __future__ import annotations
 
-import uuid
-from datetime import datetime
-
-from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import get_current_user, get_verified_org_id
+from app.dependencies.auth import get_current_user
 from app.dependencies.database import get_db
 from app.models.release_note import ReleaseNote
-from app.services.project_auth import is_org_owner_or_admin
 
 router = APIRouter(prefix="/api/v2/release-notes", tags=["release-notes"])
 
@@ -36,27 +36,6 @@ class ReleaseNoteResponse(BaseModel):
     items: list[ReleaseNoteItemModel]
 
 
-class ReleaseNoteCreate(BaseModel):
-    note_key: str = Field(min_length=1)
-    version: str = Field(min_length=1)
-    published_at: datetime
-    display_period: str = Field(min_length=1)
-    title: str = Field(min_length=1)
-    summary: str = ""
-    items: list[ReleaseNoteItemModel] = Field(default_factory=list)
-    is_published: bool = True
-
-
-class ReleaseNoteUpdate(BaseModel):
-    version: str | None = None
-    published_at: datetime | None = None
-    display_period: str | None = None
-    title: str | None = None
-    summary: str | None = None
-    items: list[ReleaseNoteItemModel] | None = None
-    is_published: bool | None = None
-
-
 def _to_response(row: ReleaseNote) -> ReleaseNoteResponse:
     return ReleaseNoteResponse(
         id=row.note_key,
@@ -68,18 +47,13 @@ def _to_response(row: ReleaseNote) -> ReleaseNoteResponse:
     )
 
 
-async def _require_admin(session: AsyncSession, auth, org_id: uuid.UUID) -> None:
-    """CRUD = org owner/admin(canonical project_auth·ad-hoc role 금지). platform-admin 롤 부재로 유일 옵션."""
-    if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
-        raise HTTPException(status_code=403, detail="릴리즈 노트 관리는 org owner/admin 만 가능합니다.")
-
-
 @router.get("", response_model=list[ReleaseNoteResponse])
 async def list_release_notes(
     session: AsyncSession = Depends(get_db),
     _auth=Depends(get_current_user),
 ) -> list[ReleaseNoteResponse]:
-    """published 릴노트 newest-first(published_at desc). 전역(org 무관)·authed user."""
+    """published 릴노트 newest-first(published_at desc). 전역(org 무관)·authed user. write 는 공개 API
+    미노출(비공개 운영자 어드민 전용·3f1f2408)."""
     rows = (
         await session.execute(
             select(ReleaseNote)
@@ -88,74 +62,3 @@ async def list_release_notes(
         )
     ).scalars().all()
     return [_to_response(r) for r in rows]
-
-
-@router.post("", response_model=ReleaseNoteResponse, status_code=201)
-async def create_release_note(
-    body: ReleaseNoteCreate,
-    session: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(get_verified_org_id),
-    auth=Depends(get_current_user),
-) -> ReleaseNoteResponse:
-    await _require_admin(session, auth, org_id)
-    dup = (await session.execute(
-        select(ReleaseNote.id).where(ReleaseNote.note_key == body.note_key)
-    )).scalar_one_or_none()
-    if dup is not None:
-        raise HTTPException(status_code=409, detail="같은 note_key 의 릴노트가 이미 있습니다.")
-    row = ReleaseNote(
-        note_key=body.note_key,
-        version=body.version,
-        published_at=body.published_at,
-        display_period=body.display_period,
-        title=body.title,
-        summary=body.summary,
-        items=[i.model_dump(exclude_none=True) for i in body.items],
-        is_published=body.is_published,
-    )
-    session.add(row)
-    await session.commit()
-    await session.refresh(row)
-    return _to_response(row)
-
-
-@router.patch("/{note_key}", response_model=ReleaseNoteResponse)
-async def update_release_note(
-    note_key: str,
-    body: ReleaseNoteUpdate,
-    session: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(get_verified_org_id),
-    auth=Depends(get_current_user),
-) -> ReleaseNoteResponse:
-    await _require_admin(session, auth, org_id)
-    row = (await session.execute(
-        select(ReleaseNote).where(ReleaseNote.note_key == note_key)
-    )).scalar_one_or_none()
-    if row is None:
-        raise HTTPException(status_code=404, detail="릴노트를 찾을 수 없습니다.")
-    data = body.model_dump(exclude_unset=True)
-    if "items" in data and data["items"] is not None:
-        data["items"] = [i.model_dump(exclude_none=True) if hasattr(i, "model_dump")
-                         else i for i in body.items]
-    for k, v in data.items():
-        setattr(row, k, v)
-    await session.commit()
-    await session.refresh(row)
-    return _to_response(row)
-
-
-@router.delete("/{note_key}", status_code=204)
-async def delete_release_note(
-    note_key: str,
-    session: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(get_verified_org_id),
-    auth=Depends(get_current_user),
-) -> None:
-    await _require_admin(session, auth, org_id)
-    row = (await session.execute(
-        select(ReleaseNote).where(ReleaseNote.note_key == note_key)
-    )).scalar_one_or_none()
-    if row is None:
-        raise HTTPException(status_code=404, detail="릴노트를 찾을 수 없습니다.")
-    await session.delete(row)
-    await session.commit()

--- a/backend/tests/test_release_notes_no_write_routes.py
+++ b/backend/tests/test_release_notes_no_write_routes.py
@@ -1,0 +1,16 @@
+"""3f1f2408: release-notes 공개 API write route 부재 — 멀티테넌시 침해 회귀 가드(no-DB).
+
+릴노트=전역 changelog. write(POST/PATCH/PUT/DELETE)가 공개 라우터에 있으면 호출자 자기-org owner 가
+전역 노트 편집/삭제 가능(EXPLOITABLE 실증). 공개 API 에서 write route 자체를 제거 → 고객 write 경로 0.
+write 가 재추가되면 이 테스트가 잡는다. GET(published) 만 유지. (관리 write 는 별도 비공개 운영자 어드민.)
+"""
+from app.routers.release_notes import router
+
+
+def test_public_router_exposes_only_get():
+    methods: set[str] = set()
+    for r in router.routes:
+        methods |= (getattr(r, "methods", None) or set())
+    assert "GET" in methods, "published GET 은 유지돼야"
+    for m in ("POST", "PATCH", "PUT", "DELETE"):
+        assert m not in methods, f"공개 release-notes 에 {m} write route 잔존 — 멀티테넌시 침해 재발"

--- a/backend/tests/test_release_notes_realdb.py
+++ b/backend/tests/test_release_notes_realdb.py
@@ -1,16 +1,18 @@
-"""E-POLISH 53bc0945: release_notes API + 시드 realdb. DB env 없으면 skip(CI alembic-fresh).
+"""E-POLISH 53bc0945 + 3f1f2408: release_notes **GET** API realdb. DB env 없으면 skip(CI alembic-fresh).
 
-마이그 0142 가 테이블+시드(v1.2~v1.5) 생성 → list 가 4개 published newest-first·shape(id=note_key·
-publishedAt=display_period) 반환. CRUD 는 owner/admin(is_org_owner_or_admin) 게이트.
+마이그 0142 가 테이블+시드(v1.2~v1.5) → list 가 published newest-first·shape(id=note_key·
+publishedAt=display_period) 반환. write route 는 3f1f2408 에서 공개 API 제거(멀티테넌시 침해 봉인) — write
+테스트는 부재 가드(test_release_notes_no_write_routes.py·no-DB)로 이전. 여기선 GET 거동만.
 """
 from __future__ import annotations
 
 import os
 import uuid
-from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
 
 import pytest
-from fastapi import HTTPException
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 _RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
@@ -18,8 +20,6 @@ _ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace
     "postgresql://", "postgresql+asyncpg://"
 )
 pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
-
-ORG = uuid.uuid4()
 
 
 @pytest.fixture
@@ -56,62 +56,29 @@ async def test_list_returns_seeded_newest_first():
 
 
 @pytest.mark.anyio
-async def test_create_requires_owner_admin():
-    from app.routers.release_notes import ReleaseNoteCreate, create_release_note
-    engine = create_async_engine(_ASYNC)
-    Session = async_sessionmaker(engine, expire_on_commit=False)
-    key = f"test-{uuid.uuid4()}"
-    body = ReleaseNoteCreate(
-        note_key=key, version="vT", published_at="2026-07-01T00:00:00+00:00",
-        display_period="2026년 7월", title="T", summary="s", items=[{"text": "x"}],
-    )
-    try:
-        async with Session() as s:
-            # 비-admin → 403
-            with patch("app.routers.release_notes.is_org_owner_or_admin",
-                       new_callable=AsyncMock, return_value=False):
-                with pytest.raises(HTTPException) as e:
-                    await create_release_note(body=body, session=s, org_id=ORG, auth=_auth())
-                assert e.value.status_code == 403
-            # admin → 201 생성
-            with patch("app.routers.release_notes.is_org_owner_or_admin",
-                       new_callable=AsyncMock, return_value=True):
-                created = await create_release_note(body=body, session=s, org_id=ORG, auth=_auth())
-                assert created.id == key and created.version == "vT"
-    finally:
-        await engine.dispose()
-
-
-@pytest.mark.anyio
-async def test_unpublished_excluded_and_patch_delete():
-    from app.routers.release_notes import (
-        ReleaseNoteCreate,
-        ReleaseNoteUpdate,
-        create_release_note,
-        delete_release_note,
-        list_release_notes,
-        update_release_note,
-    )
+async def test_unpublished_excluded_from_list():
+    """is_published=False 노트는 GET 제외·True 면 포함(published 필터 검증). write 엔드포인트 없이 ORM 직시드."""
+    from app.models.release_note import ReleaseNote
+    from app.routers.release_notes import list_release_notes
     engine = create_async_engine(_ASYNC)
     Session = async_sessionmaker(engine, expire_on_commit=False)
     key = f"unpub-{uuid.uuid4()}"
     try:
-        with patch("app.routers.release_notes.is_org_owner_or_admin",
-                   new_callable=AsyncMock, return_value=True):
-            async with Session() as s:
-                # 미발행 생성 → list 제외.
-                await create_release_note(
-                    body=ReleaseNoteCreate(
-                        note_key=key, version="vU", published_at="2026-08-01T00:00:00+00:00",
-                        display_period="2026년 8월", title="U", summary="", items=[], is_published=False),
-                    session=s, org_id=ORG, auth=_auth())
-                assert key not in [r.id for r in await list_release_notes(session=s, _auth=_auth())]
-                # patch 발행 → list 포함.
-                await update_release_note(note_key=key, body=ReleaseNoteUpdate(is_published=True),
-                                          session=s, org_id=ORG, auth=_auth())
-                assert key in [r.id for r in await list_release_notes(session=s, _auth=_auth())]
-                # delete.
-                await delete_release_note(note_key=key, session=s, org_id=ORG, auth=_auth())
-                assert key not in [r.id for r in await list_release_notes(session=s, _auth=_auth())]
+        async with Session() as s:
+            s.add(ReleaseNote(
+                note_key=key, version="vU",
+                published_at=datetime(2026, 8, 1, tzinfo=timezone.utc),
+                display_period="2026년 8월", title="U", summary="", items=[], is_published=False,
+            ))
+            await s.commit()
+            assert key not in [r.id for r in await list_release_notes(session=s, _auth=_auth())]
+            row = (await s.execute(
+                select(ReleaseNote).where(ReleaseNote.note_key == key)
+            )).scalar_one()
+            row.is_published = True
+            await s.commit()
+            assert key in [r.id for r in await list_release_notes(session=s, _auth=_auth())]
+            await s.delete(row)
+            await s.commit()
     finally:
         await engine.dispose()


### PR DESCRIPTION
## 갭 (PO prod 발견 · realdb EXPLOITABLE 실증)
`release_notes.py` write(POST/PATCH/DELETE)가 `_require_admin`→`is_org_owner_or_admin(호출자 **자기 org**)`
게이트. 릴노트=sprintable 전역 changelog(전 고객 공유)인데 호출자가 자기 org owner 면 통과 → **아무 고객
org owner 가 전역 릴노트 편집/삭제**(수평 멀티테넌시 침해). **실증**: 고객 org owner→`create_release_note`→
전역 노트 생성 성공(`RESULT=EXPLOITABLE`).

## fix (선생님 최종)
릴노트 관리 = **완전 비공개 운영자 어드민** 영역(별 설계·PO 주도) → **공개 API 에서 write route 자체 제거**
(시크릿-게이트조차 불요·게이트할 공개 대상 0).
- 제거: create/update/delete 3 route + `_require_admin` + write 전용 모델(`ReleaseNoteCreate`/`Update`) +
  미사용 import(`is_org_owner_or_admin`·`get_verified_org_id`·`uuid`·`datetime`·`HTTPException`·`Field`).
- **유지**: GET(전역 published·authed user) · 모델/서비스(`release_note.py`·GET + 향후 어드민 재사용).

## 회귀 가드
- `test_release_notes_no_write_routes`(no-DB): 공개 라우터에 POST/PATCH/PUT/DELETE **부재**·GET 존재 assert
  (write 재추가 시 적발). EXPLOITABLE repro 는 이제 write 함수/route 부재로 **ImportError = NOT exploitable**.
- `test_release_notes_realdb`: write 테스트 제거·GET(list newest-first + unpublished 제외)만(ORM 직시드).

## 검증
- ruff · no-write-route 가드 1 · realdb GET 2 pass · full no-DB **2639 pass**(잔여 8=MCP-env DoD·무관)
- 제거 심볼 잔존 importer 0(`org_members._require_admin` 은 별개) · 마이그 0

⚠️ 멀티테넌시 침해 봉인 — codex 멀티테넌시 QA(PO 주도). 릴노트 **관리 어드민**은 별 스토리(비공개·후속).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
