### PR TITLE
fix(retros): same-org cross-project IDOR — 전 라우트 has_project_access 강제 (#1801 HIGH)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
           JWT_SECRET: ci-test-secret-at-least-32-chars-long
           SECRET_KEY: ci-test-secret-at-least-32-chars-long
-        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py tests/test_release_notes_realdb.py tests/test_audit_apikey_parity_realdb.py tests/test_doc_gate_cascade_scope_realdb.py tests/test_doc_mutation_project_scope_idor_realdb.py -q
+        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py tests/test_release_notes_realdb.py tests/test_audit_apikey_parity_realdb.py tests/test_doc_gate_cascade_scope_realdb.py tests/test_doc_mutation_project_scope_idor_realdb.py tests/test_retro_mutation_project_scope_idor_realdb.py -q
 
       - name: Verify fresh DB reached head (baseline + incremental)
         working-directory: backend

--- a/backend/app/repositories/retro.py
+++ b/backend/app/repositories/retro.py
@@ -65,6 +65,19 @@ class RetroItemRepository:
         await self.session.flush()
         return True
 
+    async def delete_from_session(self, session_id: uuid.UUID, item_id: uuid.UUID) -> bool:
+        """item_id가 session_id 소속인지 원자적으로 확인 후 삭제(session IDOR 2차 방어 — item_id를
+        타 session 것으로 조작해 부모 session project-access 체크만 우회하는 것 차단)."""
+        result = await self.session.execute(
+            select(RetroItem).where(RetroItem.id == item_id, RetroItem.session_id == session_id)
+        )
+        item = result.scalar_one_or_none()
+        if item is None:
+            return False
+        await self.session.delete(item)
+        await self.session.flush()
+        return True
+
 
 class RetroVoteRepository:
     def __init__(self, session: AsyncSession) -> None:
@@ -110,3 +123,23 @@ class RetroActionRepository:
             update(RetroAction).where(RetroAction.id == action_id).values(**data)
         )
         return await self.get(action_id)
+
+    async def update_in_session(
+        self, session_id: uuid.UUID, action_id: uuid.UUID, **data: Any
+    ) -> RetroAction | None:
+        """action_id가 session_id 소속인지 원자적으로 확인 후 갱신(session IDOR 2차 방어 —
+        action_id를 타 session 것으로 조작해 부모 session project-access 체크만 우회하는 것 차단)."""
+        action = (
+            await self.session.execute(
+                select(RetroAction).where(
+                    RetroAction.id == action_id, RetroAction.session_id == session_id
+                )
+            )
+        ).scalar_one_or_none()
+        if action is None:
+            return None
+        for key, value in data.items():
+            setattr(action, key, value)
+        await self.session.flush()
+        await self.session.refresh(action)
+        return action

--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -1,11 +1,14 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.models.retro import RetroItem, RetroSession
 from app.services.member_resolver import canonicalize_member_id
+from app.services.project_auth import has_project_access
 from app.repositories.retro import (
     RetroActionRepository,
     RetroItemRepository,
@@ -35,18 +38,65 @@ def _get_session_repo(
     return RetroSessionRepository(db, org_id)
 
 
+async def _require_retro_project_access(
+    session: AsyncSession, session_id: uuid.UUID, user_id: uuid.UUID, org_id: uuid.UUID
+) -> RetroSession:
+    """대상 retro session의 canonical project-scope authz(doc-gate #1796 `_require_doc_project_access`
+    와 동일 패턴). session을 org-scope로 로드하고 caller의 그 session project 접근(has_project_access
+    SSOT=team_member∪grant∪owner/admin)을 강제 — 없으면 404·무권한 403. 기존 `_get_session_repo`가
+    org-level만 검증해 same-org cross-project IDOR가 있었음(#1801 까심 QA HIGH). 반환=로드된
+    session(caller 재사용 가능)."""
+    retro = (
+        await session.execute(
+            select(RetroSession).where(RetroSession.id == session_id, RetroSession.org_id == org_id)
+        )
+    ).scalar_one_or_none()
+    if retro is None:
+        raise HTTPException(status_code=404, detail="Retro session not found")
+    if not await has_project_access(session, user_id, retro.project_id, org_id):
+        raise HTTPException(status_code=403, detail="해당 회고의 프로젝트 접근 권한이 없습니다")
+    return retro
+
+
+async def _require_item_in_session(
+    session: AsyncSession, session_id: uuid.UUID, item_id: uuid.UUID
+) -> RetroItem:
+    """item_id가 session_id 소속인지 확인(2차 IDOR 방어 — item_id를 타 session 것으로 조작해
+    부모 session project-access 체크만 우회하는 것 차단)."""
+    item = (
+        await session.execute(
+            select(RetroItem).where(RetroItem.id == item_id, RetroItem.session_id == session_id)
+        )
+    ).scalar_one_or_none()
+    if item is None:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return item
+
+
 @router.get("", response_model=list[SessionListResponse])
 async def list_sessions(
     project_id: uuid.UUID | None = Query(default=None),
     sprint_id: uuid.UUID | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     repo: RetroSessionRepository = Depends(_get_session_repo),
 ) -> list[SessionListResponse]:
+    user_id = uuid.UUID(auth.user_id)
+    if project_id is not None:
+        # 명시 필터 시 그 프로젝트 접근권 선검증(무권한 project_id로 org 존재 여부 탐색 차단).
+        if not await has_project_access(db, user_id, project_id, repo.org_id):
+            raise HTTPException(status_code=403, detail="해당 프로젝트 접근 권한이 없습니다")
     filters: dict = {}
     if project_id:
         filters["project_id"] = project_id
     if sprint_id:
         filters["sprint_id"] = sprint_id
     sessions = await repo.list(**filters)
+    if project_id is None:
+        # project_id 생략 시 org 전체 세션이 나오던 갭 — 각 세션의 실제 project 접근권으로 필터.
+        sessions = [
+            s for s in sessions if await has_project_access(db, user_id, s.project_id, repo.org_id)
+        ]
     return [SessionListResponse.model_validate(s) for s in sessions]
 
 
@@ -54,9 +104,12 @@ async def list_sessions(
 async def create_session(
     body: CreateSession,
     db: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> SessionListResponse:
+    # body.project_id 를 검증 없이 신뢰하면 무권한 project 에 session 을 심는 mutation IDOR.
+    if not await has_project_access(db, uuid.UUID(auth.user_id), body.project_id, org_id):
+        raise HTTPException(status_code=403, detail="해당 프로젝트 접근 권한이 없습니다")
     repo = RetroSessionRepository(db, org_id)
     session = await repo.create(
         project_id=body.project_id,
@@ -72,11 +125,10 @@ async def create_session(
 async def get_session(
     id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     repo: RetroSessionRepository = Depends(_get_session_repo),
 ) -> SessionResponse:
-    session = await repo.get(id)
-    if session is None:
-        raise HTTPException(status_code=404, detail="Retro session not found")
+    session = await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
 
     item_repo = RetroItemRepository(db)
     action_repo = RetroActionRepository(db)
@@ -102,8 +154,11 @@ async def get_session(
 async def advance_phase(
     id: uuid.UUID,
     body: PhaseTransition,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     repo: RetroSessionRepository = Depends(_get_session_repo),
 ) -> SessionListResponse:
+    await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
     try:
         session = await repo.set_phase(id, body.phase)
     except (ValueError, Exception) as exc:
@@ -116,11 +171,10 @@ async def add_item(
     id: uuid.UUID,
     body: CreateItem,
     db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     repo: RetroSessionRepository = Depends(_get_session_repo),
 ) -> ItemResponse:
-    session = await repo.get(id)
-    if session is None:
-        raise HTTPException(status_code=404, detail="Retro session not found")
+    await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
     item_repo = RetroItemRepository(db)
     author_id = (await canonicalize_member_id(body.author_id, db)) if body.author_id else None
     item = await item_repo.create(
@@ -134,13 +188,12 @@ async def delete_item(
     id: uuid.UUID,
     item_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     repo: RetroSessionRepository = Depends(_get_session_repo),
 ) -> dict:
-    session = await repo.get(id)
-    if session is None:
-        raise HTTPException(status_code=404, detail="Retro session not found")
+    await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
     item_repo = RetroItemRepository(db)
-    ok = await item_repo.delete(item_id)
+    ok = await item_repo.delete_from_session(id, item_id)
     if not ok:
         raise HTTPException(status_code=404, detail="Item not found")
     return {"ok": True}
@@ -152,11 +205,11 @@ async def vote_item(
     item_id: uuid.UUID,
     voter_id: uuid.UUID = Query(...),
     db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     repo: RetroSessionRepository = Depends(_get_session_repo),
 ) -> VoteResponse:
-    session = await repo.get(id)
-    if session is None:
-        raise HTTPException(status_code=404, detail="Retro session not found")
+    await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
+    await _require_item_in_session(db, id, item_id)
     voter_id = await canonicalize_member_id(voter_id, db)  # AC3-2d(1b): canonical 정규화
     vote_repo = RetroVoteRepository(db)
     try:
@@ -172,11 +225,10 @@ async def vote_item(
 async def list_actions(
     id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     repo: RetroSessionRepository = Depends(_get_session_repo),
 ) -> list[ActionResponse]:
-    session = await repo.get(id)
-    if session is None:
-        raise HTTPException(status_code=404, detail="Retro session not found")
+    await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
     action_repo = RetroActionRepository(db)
     actions = await action_repo.list_by_session(id)
     return [ActionResponse.model_validate(a) for a in actions]
@@ -187,11 +239,10 @@ async def create_action(
     id: uuid.UUID,
     body: CreateAction,
     db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     repo: RetroSessionRepository = Depends(_get_session_repo),
 ) -> ActionResponse:
-    session = await repo.get(id)
-    if session is None:
-        raise HTTPException(status_code=404, detail="Retro session not found")
+    await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
     action_repo = RetroActionRepository(db)
     assignee_id = (await canonicalize_member_id(body.assignee_id, db)) if body.assignee_id else None
     action = await action_repo.create(
@@ -206,14 +257,14 @@ async def update_action(
     action_id: uuid.UUID,
     body: UpdateAction,
     db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     repo: RetroSessionRepository = Depends(_get_session_repo),
 ) -> ActionResponse:
-    session = await repo.get(id)
-    if session is None:
-        raise HTTPException(status_code=404, detail="Retro session not found")
+    # #1801 까심 QA HIGH — 이 라우트가 org-only 게이트였던 원 적출 지점.
+    await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
     action_repo = RetroActionRepository(db)
     data = body.model_dump(exclude_unset=True)
-    action = await action_repo.update(action_id, **data)
+    action = await action_repo.update_in_session(id, action_id, **data)
     if action is None:
         raise HTTPException(status_code=404, detail="Action not found")
     return ActionResponse.model_validate(action)
@@ -223,11 +274,10 @@ async def update_action(
 async def export_session(
     id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     repo: RetroSessionRepository = Depends(_get_session_repo),
 ) -> Response:
-    session = await repo.get(id)
-    if session is None:
-        raise HTTPException(status_code=404, detail="Retro session not found")
+    session = await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
 
     item_repo = RetroItemRepository(db)
     action_repo = RetroActionRepository(db)

--- a/backend/tests/test_retro_mutation_project_scope_idor_realdb.py
+++ b/backend/tests/test_retro_mutation_project_scope_idor_realdb.py
@@ -1,0 +1,241 @@
+"""#1801 까심 QA HIGH: 회고(retros) same-org cross-project IDOR — realdb repro + lock.
+
+갭: `retros.py`의 `_get_session_repo`가 org-level(`get_verified_org_id`)만 검증해 同org
+**해당 project 접근권 없는** 멤버가 타 project retro session/item/action을 read/mutate 가능했음
+(update_action이 원 적출 지점 — B3 완료토글 사용처). doc-gate #1796과 동일 패턴 fix:
+대상 session을 org-scope로 로드 후 caller의 `has_project_access(session.project_id)` 강제.
+
+본 테스트는 **fix 후 거동**(cross-project=403·same-project=통과·2차 item/action-session 불일치=404)을
+assert. realdb 필수(has_project_access SSOT=team_member∪grant∪owner/admin·grant row 실측)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("ca000000-0000-0000-0000-000000000001")
+USER = uuid.UUID("ca000000-0000-0000-0000-0000000000a1")
+OM = uuid.UUID("ca000000-0000-0000-0000-0000000000b1")
+PROJ_A = uuid.UUID("ca000000-0000-0000-0000-0000000000c1")  # USER grant(접근 O)
+PROJ_B = uuid.UUID("ca000000-0000-0000-0000-0000000000c2")  # USER 접근 X(IDOR 축)
+AGENT = uuid.UUID("ca000000-0000-0000-0000-0000000000e1")  # agent member·grant 0
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+
+
+def _agent_auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(AGENT), email=None, claims={}, org_id=str(ORG))
+
+
+async def _seed(s):
+    """ORG·USER(member·PROJ_A grant만)·PROJ_A/PROJ_B + 각 project에 retro session
+    (session_a 는 PROJ_A에 2개 — 2차 IDOR 테스트용: session_a1과 session_a2가 서로 다름)."""
+    for sql in [
+        f"DELETE FROM retro_actions WHERE session_id IN "
+        f"(SELECT id FROM retro_sessions WHERE org_id='{ORG}')",
+        f"DELETE FROM retro_items WHERE session_id IN "
+        f"(SELECT id FROM retro_sessions WHERE org_id='{ORG}')",
+        f"DELETE FROM retro_sessions WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id IN ('{PROJ_A}','{PROJ_B}')",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','CA','ca-org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@ca.test','x','U',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
+        f"INSERT INTO members (id,org_id,type,name,is_active) VALUES ('{AGENT}','{ORG}','agent','Ag',true)",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_A}','{ORG}','A')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_B}','{ORG}','B')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ_A}','{OM}','granted')",
+    ]:
+        await s.execute(text(sql))
+
+    from app.models.retro import RetroAction, RetroItem, RetroSession
+
+    ids: dict = {}
+    for key, pid in [("a1", PROJ_A), ("a2", PROJ_A), ("b", PROJ_B)]:
+        sess = RetroSession(id=uuid.uuid4(), org_id=ORG, project_id=pid, title=f"retro-{key}", phase="collect")
+        s.add(sess)
+        ids[f"session_{key}"] = sess.id
+    await s.flush()
+
+    item_a2 = RetroItem(id=uuid.uuid4(), session_id=ids["session_a2"], category="good", text="x")
+    action_a2 = RetroAction(id=uuid.uuid4(), session_id=ids["session_a2"], title="t")
+    s.add_all([item_a2, action_a2])
+    await s.flush()
+    ids["item_a2"] = item_a2.id
+    ids["action_a2"] = action_a2.id
+
+    await s.commit()
+    return ids
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+# ───────────────────────── update_action (#1801 원 적출 지점) ─────────────────────────
+
+@pytest.mark.anyio
+async def test_update_action_cross_project_forbidden_same_project_ok():
+    from app.repositories.retro import RetroActionRepository, RetroSessionRepository
+    from app.routers.retros import update_action
+    from app.schemas.retro import UpdateAction
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            ids = await _seed(s)
+            action_repo = RetroActionRepository(s)
+            action_b = await action_repo.create(session_id=ids["session_b"], title="hack target")
+            await s.commit()
+
+        # cross-project(PROJ_B·USER 무접근) → 403
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await update_action(
+                    id=ids["session_b"], action_id=action_b.id, body=UpdateAction(status="done"),
+                    db=s, auth=_auth(), repo=RetroSessionRepository(s, ORG),
+                )
+            assert ei.value.status_code == 403
+
+        # same-project(PROJ_A·grant) → 통과
+        async with Session() as s:
+            out = await update_action(
+                id=ids["session_a2"], action_id=ids["action_a2"], body=UpdateAction(status="done"),
+                db=s, auth=_auth(), repo=RetroSessionRepository(s, ORG),
+            )
+            assert out.status == "done"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_action_wrong_session_forbidden():
+    """action이 실존 + parent project 접근권 있어도, 선언한 session_id 소속이 아니면 404(2차 IDOR)."""
+    from app.repositories.retro import RetroSessionRepository
+    from app.routers.retros import update_action
+    from app.schemas.retro import UpdateAction
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            ids = await _seed(s)
+
+        # action_a2 는 session_a2 소속인데 session_a1(같은 PROJ_A·접근 O)로 호출 — 404 여야.
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await update_action(
+                    id=ids["session_a1"], action_id=ids["action_a2"], body=UpdateAction(status="done"),
+                    db=s, auth=_auth(), repo=RetroSessionRepository(s, ORG),
+                )
+            assert ei.value.status_code == 404
+    finally:
+        await eng.dispose()
+
+
+# ───────────────────────── get_session (read) ─────────────────────────
+
+@pytest.mark.anyio
+async def test_get_session_cross_project_forbidden_same_project_ok():
+    from app.repositories.retro import RetroSessionRepository
+    from app.routers.retros import get_session
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            ids = await _seed(s)
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await get_session(
+                    id=ids["session_b"], db=s, auth=_auth(), repo=RetroSessionRepository(s, ORG)
+                )
+            assert ei.value.status_code == 403
+
+        async with Session() as s:
+            out = await get_session(
+                id=ids["session_a1"], db=s, auth=_auth(), repo=RetroSessionRepository(s, ORG)
+            )
+            assert out.id == ids["session_a1"]
+    finally:
+        await eng.dispose()
+
+
+# ───────────────────────── create_session(body.project_id 신뢰 mutation) ─────────────────────────
+
+@pytest.mark.anyio
+async def test_create_session_untrusted_project_id_forbidden():
+    from app.routers.retros import create_session
+    from app.schemas.retro import CreateSession
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await create_session(
+                    body=CreateSession(project_id=PROJ_B, org_id=ORG, title="무단 생성"),
+                    db=s, auth=_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 403
+
+        async with Session() as s:
+            out = await create_session(
+                body=CreateSession(project_id=PROJ_A, org_id=ORG, title="정상 생성"),
+                db=s, auth=_auth(), org_id=ORG,
+            )
+            assert out.project_id == PROJ_A
+    finally:
+        await eng.dispose()
+
+
+# ───────────────────────── agent(grant 0 → 차단) ─────────────────────────
+
+@pytest.mark.anyio
+async def test_agent_without_grant_cross_project_forbidden():
+    """agent 키(grant 0)도 cross-project read/mutate 차단 — has_project_access agent 분기가
+    grant 없으면 False → 403(fail-open 아님)."""
+    from app.repositories.retro import RetroSessionRepository
+    from app.routers.retros import get_session
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            ids = await _seed(s)
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await get_session(
+                    id=ids["session_a1"], db=s, auth=_agent_auth(), repo=RetroSessionRepository(s, ORG)
+                )
+            assert ei.value.status_code == 403
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_retros.py
+++ b/backend/tests/test_retros.py
@@ -1,4 +1,9 @@
-"""S24 AC: Retro router + repository 단위 테스트 (7건 이상)."""
+"""S24 AC: Retro router + repository 단위 테스트 (7건 이상).
+
+#1801 까심 QA HIGH(same-org cross-project IDOR) fix 후: `_require_retro_project_access`가 모든
+session-scoped 라우트에서 `has_project_access`를 호출하므로, 기존 테스트는 그 호출을 명시
+patch해야 한다(패치 안 하면 진짜 session.execute가 한 번 더 끼어들어 call-count 기반 mock
+순번이 밀림 — 광역 mock 공유 함정. [[feedback_shared_flow_query_breaks_broad_mock]])."""
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -8,16 +13,17 @@ from httpx import ASGITransport, AsyncClient
 
 ORG_ID = uuid.uuid4()
 PROJECT_ID = uuid.uuid4()
+OTHER_PROJECT_ID = uuid.uuid4()
 SESSION_ID = uuid.uuid4()
 ITEM_ID = uuid.uuid4()
 VOTER_ID = uuid.uuid4()
 
 
-def _mock_session(phase: str = "collect") -> MagicMock:
+def _mock_session(phase: str = "collect", project_id: uuid.UUID = PROJECT_ID) -> MagicMock:
     s = MagicMock()
     s.id = SESSION_ID
     s.org_id = ORG_ID
-    s.project_id = PROJECT_ID
+    s.project_id = project_id
     s.sprint_id = None
     s.created_by = None
     s.title = "Sprint 3 Retro"
@@ -61,6 +67,15 @@ def _mock_vote() -> MagicMock:
     return v
 
 
+def _allow_project_access():
+    """has_project_access를 True로 patch(router-local import 경로) — session-scope pre-check용."""
+    return patch("app.routers.retros.has_project_access", new=AsyncMock(return_value=True))
+
+
+def _deny_project_access():
+    return patch("app.routers.retros.has_project_access", new=AsyncMock(return_value=False))
+
+
 @pytest.fixture
 def anyio_backend():
     return "asyncio"
@@ -99,8 +114,9 @@ async def test_list_retro_sessions_200():
         mock_result.scalars.return_value.all.return_value = [_mock_session()]
         session.execute = AsyncMock(return_value=mock_result)
 
-        async with client as c:
-            resp = await c.get(f"/api/v2/retros?project_id={PROJECT_ID}")
+        with _allow_project_access():
+            async with client as c:
+                resp = await c.get(f"/api/v2/retros?project_id={PROJECT_ID}")
 
         assert resp.status_code == 200
         assert len(resp.json()) == 1
@@ -110,10 +126,52 @@ async def test_list_retro_sessions_200():
 
 
 @pytest.mark.anyio
+async def test_list_retro_sessions_no_project_id_filters_by_access():
+    """project_id 생략 시 org 전체가 아니라 has_project_access 통과분만 반환(#1801 스윕)."""
+    client, session, app = await _client()
+    try:
+        accessible = _mock_session(project_id=PROJECT_ID)
+        inaccessible = _mock_session(project_id=OTHER_PROJECT_ID)
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [accessible, inaccessible]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async def fake_access(_db, _user_id, project_id, _org_id):
+            return project_id == PROJECT_ID
+
+        with patch("app.routers.retros.has_project_access", new=AsyncMock(side_effect=fake_access)):
+            async with client as c:
+                resp = await c.get("/api/v2/retros")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body) == 1
+        assert body[0]["project_id"] == str(PROJECT_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_retro_sessions_cross_project_403():
+    client, session, app = await _client()
+    try:
+        with _deny_project_access():
+            async with client as c:
+                resp = await c.get(f"/api/v2/retros?project_id={OTHER_PROJECT_ID}")
+
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_create_retro_session_201():
     client, session, app = await _client()
     try:
-        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+        with (
+            _allow_project_access(),
+            patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create,
+        ):
             mock_create.return_value = _mock_session()
 
             async with client as c:
@@ -130,6 +188,24 @@ async def test_create_retro_session_201():
 
 
 @pytest.mark.anyio
+async def test_create_retro_session_cross_project_403():
+    """body.project_id를 검증 없이 신뢰하면 무권한 project에 session을 심을 수 있던 mutation IDOR."""
+    client, session, app = await _client()
+    try:
+        with _deny_project_access():
+            async with client as c:
+                resp = await c.post("/api/v2/retros", json={
+                    "project_id": str(OTHER_PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "무단 생성 시도",
+                })
+
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_get_retro_session_with_items_200():
     """GET /{id} → items + actions nested."""
     client, session, app = await _client()
@@ -139,8 +215,9 @@ async def test_get_retro_session_with_items_200():
         mock_result.scalars.return_value.all.return_value = []
         session.execute = AsyncMock(return_value=mock_result)
 
-        async with client as c:
-            resp = await c.get(f"/api/v2/retros/{SESSION_ID}")
+        with _allow_project_access():
+            async with client as c:
+                resp = await c.get(f"/api/v2/retros/{SESSION_ID}")
 
         assert resp.status_code == 200
         body = resp.json()
@@ -168,6 +245,24 @@ async def test_get_retro_session_404():
 
 
 @pytest.mark.anyio
+async def test_get_retro_session_cross_project_403():
+    """#1801 계열 — session은 org 내에 존재하나 caller가 그 project에 접근권 없음 → 403(404 아님)."""
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session(project_id=OTHER_PROJECT_ID)
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with _deny_project_access():
+            async with client as c:
+                resp = await c.get(f"/api/v2/retros/{SESSION_ID}")
+
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_advance_phase_200():
     """collect → group 순차 전이."""
     client, session, app = await _client()
@@ -181,7 +276,9 @@ async def test_advance_phase_200():
             nonlocal call_count
             call_count += 1
             result = MagicMock()
-            if call_count == 1:
+            # call 1 = _require_retro_project_access pre-check, call 2 = set_phase() 내부 get()
+            # (둘 다 현재 phase="collect" 세션이어야 current_idx 계산이 맞음) — call 3+ = update() 내부 get().
+            if call_count <= 2:
                 result.scalar_one_or_none.return_value = collect_session
             else:
                 result.scalar_one_or_none.return_value = group_session
@@ -189,8 +286,9 @@ async def test_advance_phase_200():
 
         session.execute = mock_execute
 
-        async with client as c:
-            resp = await c.patch(f"/api/v2/retros/{SESSION_ID}/phase", json={"phase": "group"})
+        with _allow_project_access():
+            async with client as c:
+                resp = await c.patch(f"/api/v2/retros/{SESSION_ID}/phase", json={"phase": "group"})
 
         assert resp.status_code == 200
         assert resp.json()["phase"] == "group"
@@ -216,7 +314,10 @@ async def test_add_item_201():
         session.refresh = AsyncMock()
         session.add = MagicMock()
 
-        with patch("app.repositories.retro.RetroItemRepository.create", new_callable=AsyncMock) as mock_create:
+        with (
+            _allow_project_access(),
+            patch("app.repositories.retro.RetroItemRepository.create", new_callable=AsyncMock) as mock_create,
+        ):
             mock_create.return_value = _mock_item()
 
             async with client as c:
@@ -232,8 +333,93 @@ async def test_add_item_201():
 
 
 @pytest.mark.anyio
+async def test_delete_item_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with (
+            _allow_project_access(),
+            patch(
+                "app.repositories.retro.RetroItemRepository.delete_from_session",
+                new_callable=AsyncMock,
+            ) as mock_delete,
+        ):
+            mock_delete.return_value = True
+
+            async with client as c:
+                resp = await c.delete(f"/api/v2/retros/{SESSION_ID}/items/{ITEM_ID}")
+
+        assert resp.status_code == 200
+        mock_delete.assert_awaited_once_with(SESSION_ID, ITEM_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_item_wrong_session_404():
+    """item_id가 실존해도 session_id 소속이 아니면 404(2차 IDOR 방어 — parent session 접근권만으론 불충분)."""
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with (
+            _allow_project_access(),
+            patch(
+                "app.repositories.retro.RetroItemRepository.delete_from_session",
+                new_callable=AsyncMock,
+            ) as mock_delete,
+        ):
+            mock_delete.return_value = False  # 타 session 소속 item
+
+            async with client as c:
+                resp = await c.delete(f"/api/v2/retros/{SESSION_ID}/items/{ITEM_ID}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_vote_duplicate_409():
     """중복 투표 → 409."""
+    client, session, app = await _client()
+    try:
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            # call1 = _require_retro_project_access, call2 = _require_item_in_session, call3+ = 중복투표 체크
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = _mock_session()
+            elif call_count == 2:
+                result.scalar_one_or_none.return_value = _mock_item()
+            else:
+                result.scalar_one_or_none.return_value = _mock_vote()  # 이미 존재
+            return result
+
+        session.execute = mock_execute
+
+        with _allow_project_access():
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/retros/{SESSION_ID}/items/{ITEM_ID}/vote?voter_id={VOTER_ID}"
+                )
+
+        assert resp.status_code == 409
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_vote_item_wrong_session_404():
+    """item_id가 session 소속이 아니면 투표도 404(2차 IDOR 방어)."""
     client, session, app = await _client()
     try:
         call_count = 0
@@ -245,17 +431,101 @@ async def test_vote_duplicate_409():
             if call_count == 1:
                 result.scalar_one_or_none.return_value = _mock_session()
             else:
-                result.scalar_one_or_none.return_value = _mock_vote()  # 이미 존재
+                result.scalar_one_or_none.return_value = None  # item이 이 session 소속 아님
             return result
 
         session.execute = mock_execute
 
-        async with client as c:
-            resp = await c.post(
-                f"/api/v2/retros/{SESSION_ID}/items/{ITEM_ID}/vote?voter_id={VOTER_ID}"
-            )
+        with _allow_project_access():
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/retros/{SESSION_ID}/items/{ITEM_ID}/vote?voter_id={VOTER_ID}"
+                )
 
-        assert resp.status_code == 409
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_action_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        updated_action = _mock_action()
+        updated_action.status = "done"
+
+        with (
+            _allow_project_access(),
+            patch(
+                "app.repositories.retro.RetroActionRepository.update_in_session",
+                new_callable=AsyncMock,
+            ) as mock_update,
+        ):
+            mock_update.return_value = updated_action
+
+            async with client as c:
+                resp = await c.patch(
+                    f"/api/v2/retros/{SESSION_ID}/actions/{updated_action.id}",
+                    json={"status": "done"},
+                )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "done"
+        mock_update.assert_awaited_once()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_action_cross_project_403():
+    """#1801 원 적출 지점 — parent session이 caller 무권한 project 소속이면 403."""
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session(project_id=OTHER_PROJECT_ID)
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with _deny_project_access():
+            async with client as c:
+                resp = await c.patch(
+                    f"/api/v2/retros/{SESSION_ID}/actions/{uuid.uuid4()}",
+                    json={"status": "done"},
+                )
+
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_action_wrong_session_404():
+    """action_id가 실존해도 session_id 소속이 아니면 404(2차 IDOR 방어)."""
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with (
+            _allow_project_access(),
+            patch(
+                "app.repositories.retro.RetroActionRepository.update_in_session",
+                new_callable=AsyncMock,
+            ) as mock_update,
+        ):
+            mock_update.return_value = None  # 타 session 소속 action
+
+            async with client as c:
+                resp = await c.patch(
+                    f"/api/v2/retros/{SESSION_ID}/actions/{uuid.uuid4()}",
+                    json={"status": "done"},
+                )
+
+        assert resp.status_code == 404
     finally:
         app.dependency_overrides.clear()
 
@@ -279,8 +549,9 @@ async def test_export_markdown_200():
 
         session.execute = mock_execute
 
-        async with client as c:
-            resp = await c.get(f"/api/v2/retros/{SESSION_ID}/export")
+        with _allow_project_access():
+            async with client as c:
+                resp = await c.get(f"/api/v2/retros/{SESSION_ID}/export")
 
         assert resp.status_code == 200
         assert "Sprint 3 Retro" in resp.text


### PR DESCRIPTION
## Summary
- 까심 QA #1801 HIGH 적출(story `9f27af8f`): `retros.py` `update_action`이 org-level만 검증(`_get_session_repo`→`get_verified_org_id`)해, 같은 org의 **다른 project** retro session의 `action_id`만 알면 FE `project_id` 무시하고 PATCH 성공(same-org cross-project IDOR). B3 완료토글이 이 엔드포인트 사용.
- PO(오르테가) 지시로 codex(gpt-5.5) 설계 확정 → 전수 스윕 — doc-gate #1796 `_require_doc_project_access`와 동일 canonical 패턴.

## Fix
- **`_require_retro_project_access` 헬퍼 신설**: session을 org-scope로 로드 후 caller의 `has_project_access(session.project_id)` 강제(없으면 404·무권한 403).
- **9개 라우트 전부 적용**: `get_session`·`advance_phase`·`add_item`·`delete_item`·`vote_item`·`list_actions`·`create_action`·`update_action`·`export_session` — `update_action`만이 아니라 read info-disclosure까지 동일 갭이었음.
- `list_sessions`: `project_id` 필터 시 선검증, 생략 시 org 전체 대신 `has_project_access` 통과분만 반환.
- `create_session`: `body.project_id`를 검증 없이 신뢰해 무권한 project에 session을 심을 수 있던 mutation IDOR도 동일 계열로 봉합.
- **2차 IDOR 방어**: `item_id`/`action_id`가 실존해도 선언한 `session_id` 소속이 아니면 404 — `RetroItemRepository.delete_from_session`/`RetroActionRepository.update_in_session`(원자적 session_id 매칭) 신설, `vote_item`은 `_require_item_in_session` pre-check.

## Test plan
- [x] `test_retros.py` 18건(mock) — `has_project_access` 명시 patch로 광역 mock 공유 함정 회피, cross-project 403 3건 + 2차 IDOR 404 3건 신규.
- [x] `test_retro_mutation_project_scope_idor_realdb.py` 5건(realdb) — cross-project=403·same-project=통과·2차 IDOR=404·agent grant-0 차단.
- [x] **소스 1줄 뮤테이션(access check 항상-허용)으로 realdb 3건 RED 확인 후 복원** — tautology 아님을 실증(mutation-kill 검증).
- [x] 전체 backend 스위트(2770+ pass) 회귀 0 확인 — 무관 93건 실패는 retro 코드 참조 0(다른 subsystem의 사전 존재 seed/제약 drift, 예: `ck_project_access_role` CHECK).
- [x] CI: 신규 realdb 테스트를 asset-registry 잡의 명시 pytest 파일 목록에 추가(안 하면 CI가 미실행).

## Gate 상태
codex 설계 → 이 PR(디디 구현) → 까심 재-QA(spoofing/authz 매트릭스) → 머지 대기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)