### PR TITLE
feat(retros): B4 voted_by_me — 요청자 투표 여부 반영

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
           JWT_SECRET: ci-test-secret-at-least-32-chars-long
           SECRET_KEY: ci-test-secret-at-least-32-chars-long
-        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py tests/test_release_notes_realdb.py tests/test_audit_apikey_parity_realdb.py tests/test_doc_gate_cascade_scope_realdb.py tests/test_doc_mutation_project_scope_idor_realdb.py tests/test_retro_mutation_project_scope_idor_realdb.py -q
+        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py tests/test_release_notes_realdb.py tests/test_audit_apikey_parity_realdb.py tests/test_doc_gate_cascade_scope_realdb.py tests/test_doc_mutation_project_scope_idor_realdb.py tests/test_retro_mutation_project_scope_idor_realdb.py tests/test_retro_voted_by_me_realdb.py -q
 
       - name: Verify fresh DB reached head (baseline + incremental)
         working-directory: backend

--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -6,8 +6,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
-from app.models.retro import RetroItem, RetroSession
-from app.services.member_resolver import canonicalize_member_id
+from app.models.retro import RetroItem, RetroSession, RetroVote
+from app.services.member_resolver import canonicalize_member_id, resolve_member
 from app.services.project_auth import has_project_access
 from app.repositories.retro import (
     RetroActionRepository,
@@ -135,6 +135,21 @@ async def get_session(
     items = await item_repo.list_by_session(id)
     actions = await action_repo.list_by_session(id)
 
+    # B4: voted_by_me — client 지정 voter_id 무신뢰. auth 로 canonical requester id 를 직접 해소
+    # (RetroVote.voter_id 는 vote 시 canonicalize_member_id 를 거친 members.id 공간이고, 휴먼은
+    # members.id=org_members.id 로 ID-preserving 백필돼 resolve_member(레거시 경로).id 와 동일
+    # 공간 — 별도 매핑 불요).
+    resolved = await resolve_member(auth, session.org_id, db, project_id=session.project_id)
+    voted_item_ids: set[uuid.UUID] = set()
+    if items:
+        voted_rows = await db.execute(
+            select(RetroVote.item_id).where(
+                RetroVote.voter_id == resolved.id,
+                RetroVote.item_id.in_([i.id for i in items]),
+            )
+        )
+        voted_item_ids = set(voted_rows.scalars().all())
+
     return SessionResponse(
         id=session.id,
         project_id=session.project_id,
@@ -145,7 +160,19 @@ async def get_session(
         phase=session.phase,
         created_at=session.created_at,
         updated_at=session.updated_at,
-        items=[ItemResponse.model_validate(i) for i in items],
+        items=[
+            ItemResponse(
+                id=i.id,
+                session_id=i.session_id,
+                author_id=i.author_id,
+                category=i.category,
+                text=i.text,
+                vote_count=i.vote_count,
+                created_at=i.created_at,
+                voted_by_me=i.id in voted_item_ids,
+            )
+            for i in items
+        ],
         actions=[ActionResponse.model_validate(a) for a in actions],
     )
 

--- a/backend/app/schemas/retro.py
+++ b/backend/app/schemas/retro.py
@@ -22,6 +22,9 @@ class ItemResponse(BaseModel):
     text: str
     vote_count: int
     created_at: datetime
+    # B4: 요청자(canonical member id)가 이 item에 투표했는지 — get_session에서만 명시 계산
+    # (계산 필드라 ORM에서 자동 채워지지 않음). 다른 생성/응답 경로는 default False.
+    voted_by_me: bool = False
 
 
 class ActionResponse(BaseModel):

--- a/backend/tests/test_retro_voted_by_me_realdb.py
+++ b/backend/tests/test_retro_voted_by_me_realdb.py
@@ -1,0 +1,119 @@
+"""B4: `voted_by_me` — realdb ID-space 정합 실증.
+
+설계 claim: `RetroVote.voter_id`는 vote 시 `canonicalize_member_id`를 거친 members.id 공간이고,
+휴먼은 members.id=org_members.id로 ID-preserving 백필돼 `resolve_member`(레거시 경로).id와
+정확히 같은 공간 — 별도 매핑 불요. mock으로는 이 claim 자체를 검증할 수 없다(양쪽 다 patch로
+가짜값을 주입하면 우연히 맞아떨어짐) — 실 PG에서 canonicalize_member_id로 저장된 voter_id와
+resolve_member로 해소한 requester id가 **진짜로 같은 값**인지 실증 필요.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("cb000000-0000-0000-0000-000000000001")
+USER_A = uuid.UUID("cb000000-0000-0000-0000-0000000000a1")  # item1에 투표
+USER_B = uuid.UUID("cb000000-0000-0000-0000-0000000000a2")  # 미투표(cross-member 노출 0 검증)
+OM_A = uuid.UUID("cb000000-0000-0000-0000-0000000000b1")
+OM_B = uuid.UUID("cb000000-0000-0000-0000-0000000000b2")
+PROJ = uuid.UUID("cb000000-0000-0000-0000-0000000000c1")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth(user_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(user_id), email=None, claims={}, org_id=str(ORG))
+
+
+async def _seed(s):
+    from app.models.retro import RetroItem, RetroSession, RetroVote
+    from app.services.member_resolver import canonicalize_member_id
+
+    for sql in [
+        f"DELETE FROM retro_votes WHERE item_id IN "
+        f"(SELECT id FROM retro_items WHERE session_id IN "
+        f"(SELECT id FROM retro_sessions WHERE org_id='{ORG}'))",
+        f"DELETE FROM retro_items WHERE session_id IN (SELECT id FROM retro_sessions WHERE org_id='{ORG}')",
+        f"DELETE FROM retro_sessions WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id IN ('{USER_A}','{USER_B}')",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','CB','cb-org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{USER_A}','a@cb.test','x','A',true,true,0,false,0),"
+        f"('{USER_B}','b@cb.test','x','B',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES "
+        f"('{OM_A}','{ORG}','{USER_A}','member'),('{OM_B}','{ORG}','{USER_B}','member')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ}','{ORG}','P')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) VALUES "
+        f"(gen_random_uuid(),'{PROJ}','{OM_A}','granted'),"
+        f"(gen_random_uuid(),'{PROJ}','{OM_B}','granted')",
+    ]:
+        await s.execute(text(sql))
+
+    sess = RetroSession(id=uuid.uuid4(), org_id=ORG, project_id=PROJ, title="r", phase="vote")
+    s.add(sess)
+    await s.flush()
+
+    item1 = RetroItem(id=uuid.uuid4(), session_id=sess.id, category="good", text="i1")
+    item2 = RetroItem(id=uuid.uuid4(), session_id=sess.id, category="good", text="i2")
+    s.add_all([item1, item2])
+    await s.flush()
+
+    # 실제 vote_item 라우트와 동일 경로 — canonicalize_member_id를 거쳐 voter_id 저장.
+    voter_id = await canonicalize_member_id(OM_A, s)
+    s.add(RetroVote(id=uuid.uuid4(), item_id=item1.id, voter_id=voter_id))
+    await s.flush()
+    await s.commit()
+
+    return {"session_id": sess.id, "item1_id": item1.id, "item2_id": item2.id}
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+@pytest.mark.anyio
+async def test_voted_by_me_id_space_matches_real_resolve_member():
+    from app.repositories.retro import RetroSessionRepository
+    from app.routers.retros import get_session
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            ids = await _seed(s)
+
+        # USER_A(투표자 본인) — item1만 voted_by_me=True.
+        async with Session() as s:
+            out = await get_session(id=ids["session_id"], db=s, auth=_auth(USER_A), repo=RetroSessionRepository(s, ORG))
+            by_id = {i.id: i for i in out.items}
+            assert by_id[ids["item1_id"]].voted_by_me is True
+            assert by_id[ids["item2_id"]].voted_by_me is False
+
+        # USER_B(미투표) — item1도 voted_by_me=False(cross-member 노출 0).
+        async with Session() as s:
+            out = await get_session(id=ids["session_id"], db=s, auth=_auth(USER_B), repo=RetroSessionRepository(s, ORG))
+            by_id = {i.id: i for i in out.items}
+            assert by_id[ids["item1_id"]].voted_by_me is False
+            assert by_id[ids["item2_id"]].voted_by_me is False
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_retros.py
+++ b/backend/tests/test_retros.py
@@ -44,6 +44,9 @@ def _mock_item() -> MagicMock:
     i.text = "팀워크 좋았는"
     i.vote_count = 2
     i.created_at = datetime(2026, 4, 29, tzinfo=timezone.utc)
+    # RetroItem 실 모델엔 없는 계산 필드 — MagicMock은 미설정 속성도 truthy를 자동생성하므로
+    # (실 ORM 객체라면 getattr 이 없어 pydantic 기본값 False로 떨어짐) 명시적으로 맞춰준다.
+    i.voted_by_me = False
     return i
 
 
@@ -74,6 +77,13 @@ def _allow_project_access():
 
 def _deny_project_access():
     return patch("app.routers.retros.has_project_access", new=AsyncMock(return_value=False))
+
+
+def _mock_resolve_member(member_id: uuid.UUID | None = None):
+    """B4: get_session이 호출하는 resolve_member SSOT를 patch — DB member 해소 우회."""
+    resolved = MagicMock()
+    resolved.id = member_id or uuid.uuid4()
+    return patch("app.routers.retros.resolve_member", new=AsyncMock(return_value=resolved))
 
 
 @pytest.fixture
@@ -215,7 +225,7 @@ async def test_get_retro_session_with_items_200():
         mock_result.scalars.return_value.all.return_value = []
         session.execute = AsyncMock(return_value=mock_result)
 
-        with _allow_project_access():
+        with _allow_project_access(), _mock_resolve_member():
             async with client as c:
                 resp = await c.get(f"/api/v2/retros/{SESSION_ID}")
 
@@ -224,6 +234,122 @@ async def test_get_retro_session_with_items_200():
         assert body["id"] == str(SESSION_ID)
         assert "items" in body
         assert "actions" in body
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_retro_session_voted_by_me_reflects_only_requester():
+    """B4 — voted_by_me는 요청자 본인 투표만 반영(타인 투표는 노출 안 함)."""
+    client, session, app = await _client()
+    try:
+        my_id = uuid.uuid4()
+        other_id = uuid.uuid4()
+        item_i_voted = _mock_item()
+        item_i_voted.id = uuid.uuid4()
+        item_other_voted = _mock_item()
+        item_other_voted.id = uuid.uuid4()
+        item_nobody_voted = _mock_item()
+        item_nobody_voted.id = uuid.uuid4()
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = _mock_session()
+            elif call_count == 2:
+                result.scalars.return_value.all.return_value = [
+                    item_i_voted, item_other_voted, item_nobody_voted,
+                ]
+            elif call_count == 3:
+                result.scalars.return_value.all.return_value = []  # actions
+            else:
+                # votes query — voter_id=my_id 로 필터되므로 my_id가 실제 투표한 item만 반환
+                result.scalars.return_value.all.return_value = [item_i_voted.id]
+            return result
+
+        session.execute = mock_execute
+
+        with _allow_project_access(), _mock_resolve_member(my_id):
+            async with client as c:
+                resp = await c.get(f"/api/v2/retros/{SESSION_ID}")
+
+        assert resp.status_code == 200
+        items_by_id = {i["id"]: i for i in resp.json()["items"]}
+        assert items_by_id[str(item_i_voted.id)]["voted_by_me"] is True
+        assert items_by_id[str(item_other_voted.id)]["voted_by_me"] is False
+        assert items_by_id[str(item_nobody_voted.id)]["voted_by_me"] is False
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_retro_session_no_items_skips_votes_query():
+    """items가 비어있으면 votes 쿼리 자체를 스킵(불필요 왕복 0)."""
+    client, session, app = await _client()
+    try:
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = _mock_session()
+            else:
+                result.scalars.return_value.all.return_value = []
+            return result
+
+        session.execute = mock_execute
+
+        with _allow_project_access(), _mock_resolve_member():
+            async with client as c:
+                resp = await c.get(f"/api/v2/retros/{SESSION_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["items"] == []
+        # call1=session, call2=items(빈), call3=actions(빈) — votes 쿼리(4번째) 없음.
+        assert call_count == 3
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_add_item_default_not_voted():
+    """add_item(신규 생성)은 voted_by_me 계산 없이 기본 False."""
+    client, session, app = await _client()
+    try:
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = _mock_session() if call_count == 1 else _mock_item()
+            return result
+
+        session.execute = mock_execute
+        session.flush = AsyncMock()
+        session.refresh = AsyncMock()
+        session.add = MagicMock()
+
+        with (
+            _allow_project_access(),
+            patch("app.repositories.retro.RetroItemRepository.create", new_callable=AsyncMock) as mock_create,
+        ):
+            mock_create.return_value = _mock_item()
+
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/items", json={
+                    "category": "good",
+                    "text": "새 아이템",
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["voted_by_me"] is False
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary
- story `9f27af8f` 큐의 첫 항목(B4) — `GET /{id}`(get_session) 응답 `ItemResponse`에 `voted_by_me: bool` 추가. 요청자가 해당 item에 투표했는지 반영(미르코 FE는 이미 graceful degrade, 필드만 추가하면 라이브).
- PO(오르테가) crux 승인 완료(#1801/#1802 후속 스레드).

## Design
- client 지정 `voter_id`(기존 `vote_item`의 client-supplied 방식) 대신 **auth로 canonical requester id를 직접 해소** — `resolve_member(auth, org_id, db, project_id=session.project_id)` SSOT 재사용(docs.py 등 기존 canonical 패턴).
- **ID-space 정합**: `RetroVote.voter_id`는 vote 시 `canonicalize_member_id`를 거친 `members.id` 공간. 휴먼은 `members.id=org_members.id`로 ID-preserving 백필돼 `resolve_member`(레거시 경로).id와 동일 공간 — 별도 매핑 불요. **mock으로는 이 claim 자체를 증명 못 해** realdb 테스트로 실 PG에서 실증.
- N+1 0: items 조회 후 단일 `IN` 쿼리로 voted set 획득, items 비면 쿼리 자체 스킵.
- backward-compat: `voted_by_me` default `False`, `add_item`의 기존 `model_validate` 경로는 무변경(신규 item=투표 0이 맞음).

## Adjacent finding (별건, B2 스코프로 flag만)
`retro_items.vote_count`가 `RetroVoteRepository.vote()`에서 전혀 증가 안 됨(row insert만) — prod에서 계속 0일 것. B2("vote 합산" 스코프)에서 함께 처리하는 게 맞다고 판단, 지금은 손 안 댐(큐 안 섞으려고).

## Test plan
- [x] `test_retros.py` +4건: cross-member 미노출(내 투표만 반영, 타인 투표 안 보임)·no-items 시 votes 쿼리 스킵·`add_item` 기본 `False`(+ `_mock_item()` 픽스처의 MagicMock 자동-truthy 함정도 수정).
- [x] `test_retro_voted_by_me_realdb.py` 1건 — **ID-space 실증**: 실 PG에서 `canonicalize_member_id`로 저장된 `voter_id`와 `resolve_member`로 해소한 requester id가 진짜 같은 값인지 확인(투표자 본인=True·타인=False).
- [x] `uv run pytest tests/test_retros.py tests/test_retro_mutation_project_scope_idor_realdb.py tests/test_retro_voted_by_me_realdb.py -q` — 27 passed(throwaway PG, 공유 컨테이너 미사용).
- [x] CI: 신규 realdb 테스트를 asset-registry 잡 명시 리스트에 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)