### PR TITLE
feat(retros): B2 아이템 그룹핑(parent_item_id) + vote_count 근본수정

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
           JWT_SECRET: ci-test-secret-at-least-32-chars-long
           SECRET_KEY: ci-test-secret-at-least-32-chars-long
-        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py tests/test_release_notes_realdb.py tests/test_audit_apikey_parity_realdb.py tests/test_doc_gate_cascade_scope_realdb.py tests/test_doc_mutation_project_scope_idor_realdb.py tests/test_retro_mutation_project_scope_idor_realdb.py tests/test_retro_voted_by_me_realdb.py -q
+        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py tests/test_release_notes_realdb.py tests/test_audit_apikey_parity_realdb.py tests/test_doc_gate_cascade_scope_realdb.py tests/test_doc_mutation_project_scope_idor_realdb.py tests/test_retro_mutation_project_scope_idor_realdb.py tests/test_retro_voted_by_me_realdb.py tests/test_retro_grouping_vote_count_realdb.py -q
 
       - name: Verify fresh DB reached head (baseline + incremental)
         working-directory: backend

--- a/backend/alembic/versions/0144_retro_item_grouping_vote_count.py
+++ b/backend/alembic/versions/0144_retro_item_grouping_vote_count.py
@@ -1,0 +1,89 @@
+"""B2(9f27af8f): retro_items 그룹핑(parent_item_id self-FK) + vote_count 근본수정.
+
+배경: `retro_items.vote_count`가 baseline 이래 어디서도 증가되지 않던 버그(B4 작업 중 발견) —
+`RetroVoteRepository.vote()`가 RetroVote row만 insert. 이 마이그가 (a) 기존 데이터를
+`retro_votes` 실측 COUNT로 재계산(backfill = 추측 아닌 source-of-truth 재집계) (b) 앞으로는
+`vote()`가 원자적 +1을 유지하도록 app 코드가 짝을 맞춤(별도 커밋, 이 마이그는 스키마만).
+
+`retro_votes(item_id, voter_id)` unique 제약도 신설 — 기존은 app-level pre-check(SELECT 후
+INSERT)뿐이라 동시 요청 레이스에서 중복 투표가 가능했음(TOCTOU). 제약 추가 전 기존 중복이
+있으면 위반이라 먼저 dedupe(오래된 것 유지 — created_at·id 순 1건만 남김)한다.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0144"
+down_revision = "0143"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "retro_items",
+        sa.Column("parent_item_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_retro_items_parent_item_id",
+        "retro_items",
+        "retro_items",
+        ["parent_item_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_check_constraint(
+        "retro_items_parent_not_self_check",
+        "retro_items",
+        "parent_item_id IS NULL OR parent_item_id <> id",
+    )
+    op.create_index("idx_retro_items_parent_item_id", "retro_items", ["parent_item_id"])
+    op.create_index("idx_retro_items_session_parent", "retro_items", ["session_id", "parent_item_id"])
+
+    # 기존 중복 투표 dedupe(가장 오래된 1건만 유지) — unique 제약 추가 전 선행 필수.
+    op.execute(
+        """
+        WITH ranked AS (
+          SELECT id,
+                 row_number() OVER (
+                   PARTITION BY item_id, voter_id
+                   ORDER BY created_at, id
+                 ) AS rn
+          FROM retro_votes
+        )
+        DELETE FROM retro_votes rv
+        USING ranked r
+        WHERE rv.id = r.id AND r.rn > 1
+        """
+    )
+    op.create_unique_constraint(
+        "uq_retro_votes_item_voter",
+        "retro_votes",
+        ["item_id", "voter_id"],
+    )
+
+    # vote_count 실측 재계산(추측 backfill 아님 — retro_votes 가 source of truth).
+    op.execute(
+        """
+        UPDATE retro_items ri
+        SET vote_count = COALESCE(v.cnt, 0)
+        FROM (
+          SELECT ri2.id, COUNT(rv.id)::integer AS cnt
+          FROM retro_items ri2
+          LEFT JOIN retro_votes rv ON rv.item_id = ri2.id
+          GROUP BY ri2.id
+        ) v
+        WHERE ri.id = v.id
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_retro_votes_item_voter", "retro_votes", type_="unique")
+    op.drop_index("idx_retro_items_session_parent", table_name="retro_items")
+    op.drop_index("idx_retro_items_parent_item_id", table_name="retro_items")
+    op.drop_constraint("retro_items_parent_not_self_check", "retro_items", type_="check")
+    op.drop_constraint("fk_retro_items_parent_item_id", "retro_items", type_="foreignkey")
+    op.drop_column("retro_items", "parent_item_id")

--- a/backend/app/models/retro.py
+++ b/backend/app/models/retro.py
@@ -45,12 +45,24 @@ class RetroItem(Base):
     category: Mapped[str] = mapped_column(Text, nullable=False)
     text: Mapped[str] = mapped_column(Text, nullable=False)
     vote_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # B2(9f27af8f): 'group' phase 병합 — child가 가리키는 값. parent는 반드시 top-level
+    # (parent_item_id IS NULL)이어야 함(체인/사이클 방지, app-level 검증 — 같은 테이블 참조라
+    # CHECK 제약으로 표현 불가). child는 vote 불가·투표는 parent로 이관.
+    parent_item_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("retro_items.id", ondelete="SET NULL"), nullable=True, index=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
 
     session: Mapped[RetroSession] = relationship("RetroSession", back_populates="items")
     votes: Mapped[list["RetroVote"]] = relationship("RetroVote", back_populates="item", lazy="select")
+    parent: Mapped["RetroItem | None"] = relationship(
+        "RetroItem", remote_side=[id], back_populates="children"
+    )
+    children: Mapped[list["RetroItem"]] = relationship(
+        "RetroItem", back_populates="parent", lazy="select"
+    )
 
 
 class RetroVote(Base):

--- a/backend/app/repositories/retro.py
+++ b/backend/app/repositories/retro.py
@@ -1,7 +1,8 @@
 import uuid
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, select, text, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.retro import PHASE_TRANSITIONS, RetroAction, RetroItem, RetroSession, RetroVote
@@ -78,20 +79,109 @@ class RetroItemRepository:
         await self.session.flush()
         return True
 
+    async def _refresh_vote_count(self, item_id: uuid.UUID) -> None:
+        """vote_count를 retro_votes 실측 COUNT로 재계산(그룹핑 시 vote 이관 후 정합 보정용)."""
+        count_subq = select(func.count(RetroVote.id)).where(RetroVote.item_id == item_id).scalar_subquery()
+        await self.session.execute(
+            update(RetroItem).where(RetroItem.id == item_id).values(vote_count=count_subq)
+        )
+
+    async def group_under_parent(
+        self, session_id: uuid.UUID, item_id: uuid.UUID, parent_item_id: uuid.UUID
+    ) -> RetroItem:
+        """B2: child를 parent 아래 병합 — child의 기존 투표는 parent로 이관(같은 voter 중복은
+        dedupe), child.vote_count=0, parent.vote_count는 이관 후 실측 재계산.
+
+        체인 방지: parent는 반드시 top-level(parent_item_id IS NULL)이어야 함 — 같은 테이블 자기
+        참조라 DB CHECK로 표현 불가, 여기서 app-level 검증."""
+        if item_id == parent_item_id:
+            raise ValueError("ITEM_CANNOT_GROUP_UNDER_SELF")
+
+        child = (
+            await self.session.execute(
+                select(RetroItem).where(RetroItem.id == item_id, RetroItem.session_id == session_id)
+            )
+        ).scalar_one_or_none()
+        parent = (
+            await self.session.execute(
+                select(RetroItem).where(
+                    RetroItem.id == parent_item_id, RetroItem.session_id == session_id
+                )
+            )
+        ).scalar_one_or_none()
+        if child is None or parent is None:
+            raise ValueError("ITEM_NOT_FOUND")
+        if child.parent_item_id is not None:
+            raise ValueError("ITEM_ALREADY_GROUPED")
+        if parent.parent_item_id is not None:
+            raise ValueError("PARENT_MUST_BE_TOP_LEVEL")
+        if child.category != parent.category:
+            raise ValueError("CATEGORY_MISMATCH")
+
+        # 같은 voter가 child·parent 양쪽에 투표했으면 parent에 남은 1표만 유지(dedupe).
+        await self.session.execute(
+            text(
+                """
+                DELETE FROM retro_votes child_votes
+                USING retro_votes parent_votes
+                WHERE child_votes.item_id = :item_id
+                  AND parent_votes.item_id = :parent_item_id
+                  AND parent_votes.voter_id = child_votes.voter_id
+                """
+            ),
+            {"item_id": item_id, "parent_item_id": parent_item_id},
+        )
+        await self.session.execute(
+            update(RetroVote).where(RetroVote.item_id == item_id).values(item_id=parent_item_id)
+        )
+
+        child.parent_item_id = parent_item_id
+        child.vote_count = 0
+        await self._refresh_vote_count(parent_item_id)
+        await self.session.flush()
+        await self.session.refresh(child)
+        return child
+
+    async def ungroup(self, session_id: uuid.UUID, item_id: uuid.UUID) -> RetroItem | None:
+        """child를 parent에서 분리 — 투표는 이관하지 않음(그룹핑 상태의 vote_count만 정합 유지가
+        목표. child는 병합 시점에 vote_count=0으로 리셋됐고 이후 투표 불가였으므로 분리 후에도 0)."""
+        item = (
+            await self.session.execute(
+                select(RetroItem).where(RetroItem.id == item_id, RetroItem.session_id == session_id)
+            )
+        ).scalar_one_or_none()
+        if item is None:
+            return None
+        item.parent_item_id = None
+        await self.session.flush()
+        await self.session.refresh(item)
+        return item
+
 
 class RetroVoteRepository:
     def __init__(self, session: AsyncSession) -> None:
         self.session = session
 
     async def vote(self, item_id: uuid.UUID, voter_id: uuid.UUID) -> RetroVote:
+        """중복투표 app-level pre-check(빠른 경로) + DB unique(item_id,voter_id) 제약(레이스
+        방지 — 동시 투표 시 둘 다 pre-check 통과 가능). IntegrityError는 반드시 SAVEPOINT
+        (begin_nested) 안에서만 catch — 아니면 async 세션이 poison돼 후속 write가
+        PendingRollbackError(이 레포 기존 교훈: E-DG S3 P0-1)."""
         existing = await self.session.execute(
             select(RetroVote).where(RetroVote.item_id == item_id, RetroVote.voter_id == voter_id)
         )
         if existing.scalar_one_or_none() is not None:
             raise ValueError("DUPLICATE_VOTE")
         vote = RetroVote(item_id=item_id, voter_id=voter_id)
-        self.session.add(vote)
-        await self.session.flush()
+        try:
+            async with self.session.begin_nested():
+                self.session.add(vote)
+                await self.session.flush()
+        except IntegrityError as exc:
+            raise ValueError("DUPLICATE_VOTE") from exc
+        await self.session.execute(
+            update(RetroItem).where(RetroItem.id == item_id).values(vote_count=RetroItem.vote_count + 1)
+        )
         await self.session.refresh(vote)
         return vote
 

--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -111,13 +111,16 @@ async def create_session(
     # body.project_id 를 검증 없이 신뢰하면 무권한 project 에 session 을 심는 mutation IDOR.
     if not await has_project_access(db, uuid.UUID(auth.user_id), body.project_id, org_id):
         raise HTTPException(status_code=403, detail="해당 프로젝트 접근 권한이 없습니다")
+    # P0(9f27af8f): created_by는 "누가 이 session을 만들었나"라는 행위자(actor) attribution —
+    # body.created_by(client 지정)를 신뢰하면 타인 명의 spoofing 벡터. auth로 canonical
+    # requester id를 직접 해소(B4/vote_item과 동일 SSOT 패턴), body.created_by는 무시.
+    creator = await resolve_member(auth, org_id, db, project_id=body.project_id)
     repo = RetroSessionRepository(db, org_id)
     session = await repo.create(
         project_id=body.project_id,
         title=body.title,
         sprint_id=body.sprint_id,
-        # AC3-2d(1b): 작성자 식별자 canonical 정규화(레거시 휴먼 tm.id→members.id). (A) write.
-        created_by=(await canonicalize_member_id(body.created_by, db)) if body.created_by else None,
+        created_by=creator.id,
     )
     return SessionListResponse.model_validate(session)
 
@@ -146,9 +149,9 @@ async def get_session(
             grouped_by_parent.setdefault(i.parent_item_id, []).append(i.id)
 
     # B4: voted_by_me — client 지정 voter_id 무신뢰. auth 로 canonical requester id 를 직접 해소
-    # (RetroVote.voter_id 는 vote 시 canonicalize_member_id 를 거친 members.id 공간이고, 휴먼은
-    # members.id=org_members.id 로 ID-preserving 백필돼 resolve_member(레거시 경로).id 와 동일
-    # 공간 — 별도 매핑 불요).
+    # (P0(9f27af8f) 이후 RetroVote.voter_id 는 vote_item 이 resolve_member 로 직접 써넣은
+    # members.id 공간이고, 휴먼은 members.id=org_members.id 로 ID-preserving 백필돼 여기
+    # resolve_member(레거시 경로).id 와 동일 공간 — 별도 매핑 불요).
     resolved = await resolve_member(auth, session.org_id, db, project_id=session.project_id)
     voted_item_ids: set[uuid.UUID] = set()
     if visible_items:
@@ -213,9 +216,11 @@ async def add_item(
     auth: AuthContext = Depends(get_current_user),
     repo: RetroSessionRepository = Depends(_get_session_repo),
 ) -> ItemResponse:
-    await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
+    session = await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
     item_repo = RetroItemRepository(db)
-    author_id = (await canonicalize_member_id(body.author_id, db)) if body.author_id else None
+    # P0(9f27af8f): author_id도 행위자(actor) attribution — body.author_id(client 지정) 무시,
+    # auth로 canonical requester id를 직접 해소(vote_item/create_session과 동일 SSOT 패턴).
+    author_id = (await resolve_member(auth, session.org_id, db, project_id=session.project_id)).id
     item = await item_repo.create(
         session_id=id, category=body.category, text=body.text, author_id=author_id
     )
@@ -279,17 +284,20 @@ async def delete_item(
 async def vote_item(
     id: uuid.UUID,
     item_id: uuid.UUID,
-    voter_id: uuid.UUID = Query(...),
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     repo: RetroSessionRepository = Depends(_get_session_repo),
 ) -> VoteResponse:
-    await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
+    # P0(9f27af8f): 원래 client-supplied `voter_id: Query(...)` — 타인 대신 투표하는
+    # spoofing 벡터였고, FE(#1801 리라이트)는 애초에 이 파라미터를 보내지 않아 전 투표가
+    # 422로 깨져 있었다(유나 라이브 E2E 적출). 근본수정: voter는 auth에서 canonical
+    # requester id로 서버사이드 해소(client 입력 전혀 신뢰하지 않음).
+    session = await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
     item = await _require_item_in_session(db, id, item_id)
     if item.parent_item_id is not None:
         # B2: 그룹핑된 child는 투표 불가 — 투표는 parent로 이관/집계.
         raise HTTPException(status_code=400, detail="Grouped child items cannot be voted directly")
-    voter_id = await canonicalize_member_id(voter_id, db)  # AC3-2d(1b): canonical 정규화
+    voter_id = (await resolve_member(auth, session.org_id, db, project_id=session.project_id)).id
     vote_repo = RetroVoteRepository(db)
     try:
         vote = await vote_repo.vote(item_id, voter_id)

--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -20,6 +20,7 @@ from app.schemas.retro import (
     CreateAction,
     CreateItem,
     CreateSession,
+    GroupItem,
     ItemResponse,
     PhaseTransition,
     SessionListResponse,
@@ -135,17 +136,26 @@ async def get_session(
     items = await item_repo.list_by_session(id)
     actions = await action_repo.list_by_session(id)
 
+    # B2: 그룹핑된 child는 응답에서 숨김(부모만 top-level로 노출) — parent id → child id 목록.
+    grouped_by_parent: dict[uuid.UUID, list[uuid.UUID]] = {}
+    visible_items = []
+    for i in items:
+        if i.parent_item_id is None:
+            visible_items.append(i)
+        else:
+            grouped_by_parent.setdefault(i.parent_item_id, []).append(i.id)
+
     # B4: voted_by_me — client 지정 voter_id 무신뢰. auth 로 canonical requester id 를 직접 해소
     # (RetroVote.voter_id 는 vote 시 canonicalize_member_id 를 거친 members.id 공간이고, 휴먼은
     # members.id=org_members.id 로 ID-preserving 백필돼 resolve_member(레거시 경로).id 와 동일
     # 공간 — 별도 매핑 불요).
     resolved = await resolve_member(auth, session.org_id, db, project_id=session.project_id)
     voted_item_ids: set[uuid.UUID] = set()
-    if items:
+    if visible_items:
         voted_rows = await db.execute(
             select(RetroVote.item_id).where(
                 RetroVote.voter_id == resolved.id,
-                RetroVote.item_id.in_([i.id for i in items]),
+                RetroVote.item_id.in_([i.id for i in visible_items]),
             )
         )
         voted_item_ids = set(voted_rows.scalars().all())
@@ -170,8 +180,10 @@ async def get_session(
                 vote_count=i.vote_count,
                 created_at=i.created_at,
                 voted_by_me=i.id in voted_item_ids,
+                parent_item_id=i.parent_item_id,
+                grouped_item_ids=grouped_by_parent.get(i.id, []),
             )
-            for i in items
+            for i in visible_items
         ],
         actions=[ActionResponse.model_validate(a) for a in actions],
     )
@@ -210,6 +222,43 @@ async def add_item(
     return ItemResponse.model_validate(item)
 
 
+@router.post("/{id}/items/{item_id}/group", response_model=ItemResponse)
+async def group_item(
+    id: uuid.UUID,
+    item_id: uuid.UUID,
+    body: GroupItem,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    repo: RetroSessionRepository = Depends(_get_session_repo),
+) -> ItemResponse:
+    """B2: item_id를 body.parent_item_id 아래 병합('group' phase 중복 정리)."""
+    await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
+    item_repo = RetroItemRepository(db)
+    try:
+        item = await item_repo.group_under_parent(id, item_id, body.parent_item_id)
+    except ValueError as exc:
+        if "ITEM_NOT_FOUND" in str(exc):
+            raise HTTPException(status_code=404, detail="Item not found") from exc
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return ItemResponse.model_validate(item)
+
+
+@router.post("/{id}/items/{item_id}/ungroup", response_model=ItemResponse)
+async def ungroup_item(
+    id: uuid.UUID,
+    item_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    repo: RetroSessionRepository = Depends(_get_session_repo),
+) -> ItemResponse:
+    await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
+    item_repo = RetroItemRepository(db)
+    item = await item_repo.ungroup(id, item_id)
+    if item is None:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return ItemResponse.model_validate(item)
+
+
 @router.delete("/{id}/items/{item_id}", status_code=200)
 async def delete_item(
     id: uuid.UUID,
@@ -236,7 +285,10 @@ async def vote_item(
     repo: RetroSessionRepository = Depends(_get_session_repo),
 ) -> VoteResponse:
     await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
-    await _require_item_in_session(db, id, item_id)
+    item = await _require_item_in_session(db, id, item_id)
+    if item.parent_item_id is not None:
+        # B2: 그룹핑된 child는 투표 불가 — 투표는 parent로 이관/집계.
+        raise HTTPException(status_code=400, detail="Grouped child items cannot be voted directly")
     voter_id = await canonicalize_member_id(voter_id, db)  # AC3-2d(1b): canonical 정규화
     vote_repo = RetroVoteRepository(db)
     try:
@@ -308,7 +360,8 @@ async def export_session(
 
     item_repo = RetroItemRepository(db)
     action_repo = RetroActionRepository(db)
-    items = await item_repo.list_by_session(id)
+    # B2: 그룹핑된 child는 export에서도 제외(parent에 집계된 vote_count로만 노출).
+    items = [i for i in await item_repo.list_by_session(id) if i.parent_item_id is None]
     actions = await action_repo.list_by_session(id)
 
     lines = [

--- a/backend/app/schemas/retro.py
+++ b/backend/app/schemas/retro.py
@@ -25,6 +25,11 @@ class ItemResponse(BaseModel):
     # B4: 요청자(canonical member id)가 이 item에 투표했는지 — get_session에서만 명시 계산
     # (계산 필드라 ORM에서 자동 채워지지 않음). 다른 생성/응답 경로는 default False.
     voted_by_me: bool = False
+    # B2: 'group' phase 병합. parent_item_id는 이 item이 병합돼 들어간 대상(child일 때만 non-null
+    # — 단, child는 get_session/export 응답에서 top-level만 노출하는 정책상 실제론 잘 안 보임).
+    parent_item_id: uuid.UUID | None = None
+    # parent item일 때 그 아래 병합된 child item id 목록(get_session에서만 명시 계산).
+    grouped_item_ids: list[uuid.UUID] = []
 
 
 class ActionResponse(BaseModel):
@@ -75,6 +80,10 @@ class CreateItem(BaseModel):
     category: str  # good | bad | improve
     text: str
     author_id: uuid.UUID | None = None
+
+
+class GroupItem(BaseModel):
+    parent_item_id: uuid.UUID
 
 
 class CreateAction(BaseModel):

--- a/backend/tests/test_member_ssot_ac3_2d.py
+++ b/backend/tests/test_member_ssot_ac3_2d.py
@@ -52,9 +52,13 @@ def test_batch1b_write_routers_canonicalize():
     for mod, name in [(retros, "retros"), (meetings, "meetings"), (stories, "stories")]:
         src = inspect.getsource(mod)
         assert "canonicalize_member_id" in src, f"{name} write canonicalize 누락"
-    # retro 4 식별 컬럼 전부 canonicalize(created_by/author_id/voter_id/assignee_id)
+    # P0(9f27af8f, vote-spoofing 봉쇄): created_by/author_id/voter_id는 "누가 행위하는가"
+    # attribution이라 client 입력을 신뢰하면 타인 명의 spoofing 벡터 — resolve_member(auth
+    # 기반 서버사이드 해소)로 전환. assignee_id만 "누구에게 할당하는가"(target-reference)라
+    # client가 타인을 정당하게 지정할 수 있어 canonicalize_member_id 유지.
     rsrc = inspect.getsource(retros)
-    assert rsrc.count("canonicalize_member_id(") >= 4, "retro 4컬럼 canonicalize 미흡"
+    assert rsrc.count("resolve_member(") >= 3, "retro 행위자(actor) 3필드(created_by/author_id/voter_id) resolve_member 미흡"
+    assert "canonicalize_member_id(" in rsrc, "retro assignee_id canonicalize 누락"
 
 
 def test_batch1b_activity_log_uses_lookup_members():

--- a/backend/tests/test_retro_grouping_vote_count_realdb.py
+++ b/backend/tests/test_retro_grouping_vote_count_realdb.py
@@ -304,7 +304,7 @@ async def test_get_session_hides_grouped_children_and_blocks_child_vote():
         async with Session() as s:
             with pytest.raises(HTTPException) as ei:
                 await vote_item(
-                    id=session_id, item_id=child_id, voter_id=uuid.uuid4(),
+                    id=session_id, item_id=child_id,
                     db=s, auth=_auth(), repo=RetroSessionRepository(s, ORG),
                 )
             assert ei.value.status_code == 400

--- a/backend/tests/test_retro_grouping_vote_count_realdb.py
+++ b/backend/tests/test_retro_grouping_vote_count_realdb.py
@@ -1,0 +1,312 @@
+"""B2(9f27af8f): retro 아이템 그룹핑(parent_item_id) + vote_count 근본수정 — realdb 실증.
+
+핵심 3가지는 mock으로 증명 불가:
+1. vote() 원자 +1이 실제로 vote_count를 정확히 유지하는지.
+2. 그룹핑 시 vote 이관·dedupe·parent vote_count 재계산이 실 트랜잭션에서 맞는지.
+3. **SAVEPOINT(begin_nested) 없이 IntegrityError를 catch하면 async 세션이 poison** 된다는
+   이 레포의 기존 교훈(E-DG S3 P0-1)을 재현하지 않는지 — 실제 DB unique 제약 위반을
+   결정론적으로 강제(이미 커밋된 투표에 pre-check 없이 직접 재-INSERT)해 vote()와 동일한
+   begin_nested 패턴이 세션을 poison시키지 않는지 실증한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("cc000000-0000-0000-0000-000000000001")
+USER = uuid.UUID("cc000000-0000-0000-0000-0000000000a1")
+OM = uuid.UUID("cc000000-0000-0000-0000-0000000000b1")
+PROJ = uuid.UUID("cc000000-0000-0000-0000-0000000000c1")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+
+
+async def _seed_org_project(s):
+    for sql in [
+        f"DELETE FROM retro_votes WHERE item_id IN "
+        f"(SELECT id FROM retro_items WHERE session_id IN "
+        f"(SELECT id FROM retro_sessions WHERE org_id='{ORG}'))",
+        f"DELETE FROM retro_items WHERE session_id IN (SELECT id FROM retro_sessions WHERE org_id='{ORG}')",
+        f"DELETE FROM retro_sessions WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','CC','cc-org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@cc.test','x','U',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ}','{ORG}','P')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ}','{OM}','granted')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _seed_session_with_items(s, *, n_items: int = 1, category: str = "good"):
+    from app.models.retro import RetroItem, RetroSession
+
+    sess = RetroSession(id=uuid.uuid4(), org_id=ORG, project_id=PROJ, title="r", phase="vote")
+    s.add(sess)
+    await s.flush()
+    items = []
+    for i in range(n_items):
+        item = RetroItem(id=uuid.uuid4(), session_id=sess.id, category=category, text=f"i{i}")
+        s.add(item)
+        items.append(item)
+    await s.flush()
+    await s.commit()
+    return sess.id, [i.id for i in items]
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+@pytest.mark.anyio
+async def test_vote_increments_vote_count_atomically():
+    from app.repositories.retro import RetroVoteRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            session_id, [item_id] = await _seed_session_with_items(s)
+
+        async with Session() as s:
+            await RetroVoteRepository(s).vote(item_id, uuid.uuid4())
+            await RetroVoteRepository(s).vote(item_id, uuid.uuid4())
+            await s.commit()
+
+        async with Session() as s:
+            from app.models.retro import RetroItem
+            item = (await s.execute(select(RetroItem).where(RetroItem.id == item_id))).scalar_one()
+            assert item.vote_count == 2
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_duplicate_vote_rejected_and_count_unaffected():
+    from app.repositories.retro import RetroVoteRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            session_id, [item_id] = await _seed_session_with_items(s)
+
+        voter = uuid.uuid4()
+        async with Session() as s:
+            await RetroVoteRepository(s).vote(item_id, voter)
+            await s.commit()
+
+        async with Session() as s:
+            with pytest.raises(ValueError, match="DUPLICATE_VOTE"):
+                await RetroVoteRepository(s).vote(item_id, voter)
+
+        async with Session() as s:
+            from app.models.retro import RetroItem
+            item = (await s.execute(select(RetroItem).where(RetroItem.id == item_id))).scalar_one()
+            assert item.vote_count == 1
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_savepoint_prevents_session_poisoning_on_integrity_error():
+    """SAVEPOINT(begin_nested) 없이 IntegrityError를 catch하면 async 세션이 poison되고 후속
+    write가 PendingRollbackError로 죽는다는 이 레포 기존 교훈(E-DG S3 P0-1)을 정확히 재현하지
+    않는지 직접 실증.
+
+    asyncio.gather로 진짜 두 커넥션을 동시 INSERT시키면 Postgres가 두 번째 요청을 (에러가
+    아니라) 첫 트랜잭션 커밋까지 **행(row-lock wait)**시켜 non-deterministic pytest 타임아웃
+    위험이 있다 — 그래서 여기선 app-level pre-check를 의도적으로 우회해 실제 DB unique 제약
+    위반을 **결정론적으로** 강제한다(이미 커밋된 투표에 대해 pre-check 없이 바로 INSERT를
+    시도 → 실제 IntegrityError). `vote()` 안의 정확히 같은 begin_nested 패턴을 그대로 재사용해
+    검증하므로 프로덕션 코드 경로와 동형이다."""
+    from app.models.retro import RetroVote
+    from app.repositories.retro import RetroVoteRepository
+    from sqlalchemy.exc import IntegrityError
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            session_id, [item_id] = await _seed_session_with_items(s)
+
+        voter = uuid.uuid4()
+        async with Session() as s:
+            # 정상 경로로 1표 커밋(이미 존재하는 투표를 실제로 만든다).
+            await RetroVoteRepository(s).vote(item_id, voter)
+            await s.commit()
+
+        async with Session() as s:
+            # app-level pre-check를 건너뛰고 vote()와 동일한 begin_nested 패턴만 직접 재현 —
+            # 이미 커밋된 (item_id, voter) 쌍이라 unique 제약이 반드시 위반된다(결정론적).
+            duplicate = RetroVote(item_id=item_id, voter_id=voter)
+            with pytest.raises(IntegrityError):
+                async with s.begin_nested():
+                    s.add(duplicate)
+                    await s.flush()
+
+            # 핵심 실증: SAVEPOINT 덕에 세션이 poison 안 됐으면 이 커밋+후속 쿼리가 정상 동작.
+            # (SAVEPOINT 없이 바깥 트랜잭션에서 바로 flush했다면 여기서 PendingRollbackError.)
+            await s.commit()
+            probe = await s.execute(text("SELECT 1"))
+            assert probe.scalar() == 1
+
+        async with Session() as s:
+            from app.models.retro import RetroItem
+            item = (await s.execute(select(RetroItem).where(RetroItem.id == item_id))).scalar_one()
+            assert item.vote_count == 1  # 실패한 중복 삽입은 vote_count에 반영 안 됨
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_group_moves_votes_dedupes_and_recomputes_parent_count():
+    from app.repositories.retro import RetroItemRepository, RetroVoteRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            session_id, item_ids = await _seed_session_with_items(s, n_items=2)
+        parent_id, child_id = item_ids[0], item_ids[1]
+
+        shared_voter = uuid.uuid4()
+        only_parent_voter = uuid.uuid4()
+        only_child_voter = uuid.uuid4()
+
+        async with Session() as s:
+            vr = RetroVoteRepository(s)
+            await vr.vote(parent_id, shared_voter)
+            await vr.vote(parent_id, only_parent_voter)
+            await vr.vote(child_id, shared_voter)  # 중복(양쪽 투표) — dedupe 대상
+            await vr.vote(child_id, only_child_voter)
+            await s.commit()
+
+        async with Session() as s:
+            item_repo = RetroItemRepository(s)
+            merged = await item_repo.group_under_parent(session_id, child_id, parent_id)
+            await s.commit()
+            assert merged.parent_item_id == parent_id
+            assert merged.vote_count == 0
+
+        async with Session() as s:
+            from app.models.retro import RetroItem, RetroVote
+            parent = (await s.execute(select(RetroItem).where(RetroItem.id == parent_id))).scalar_one()
+            # parent 원 2표 + child only_child_voter 1표 이관 = 3(shared_voter 중복은 dedupe).
+            assert parent.vote_count == 3
+            votes = (
+                await s.execute(select(RetroVote.voter_id).where(RetroVote.item_id == parent_id))
+            ).scalars().all()
+            assert set(votes) == {shared_voter, only_parent_voter, only_child_voter}
+            child_votes = (
+                await s.execute(select(RetroVote).where(RetroVote.item_id == child_id))
+            ).scalars().all()
+            assert child_votes == []  # child에는 vote row가 하나도 안 남아야
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_group_rejects_chain_and_self_and_category_mismatch():
+    from app.repositories.retro import RetroItemRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            session_id, item_ids = await _seed_session_with_items(s, n_items=3, category="good")
+        a, b, c = item_ids
+
+        async with Session() as s:
+            item_repo = RetroItemRepository(s)
+            # a→self 금지.
+            with pytest.raises(ValueError, match="ITEM_CANNOT_GROUP_UNDER_SELF"):
+                await item_repo.group_under_parent(session_id, a, a)
+
+            # b를 a 아래로 병합.
+            await item_repo.group_under_parent(session_id, b, a)
+            await s.commit()
+
+        async with Session() as s:
+            item_repo = RetroItemRepository(s)
+            # c를 이미 child인 b 아래로 병합 시도 — b가 top-level 아니므로 거부(체인 방지).
+            with pytest.raises(ValueError, match="PARENT_MUST_BE_TOP_LEVEL"):
+                await item_repo.group_under_parent(session_id, c, b)
+
+        # category 다른 item으로 체크.
+        async with Session() as s:
+            from app.models.retro import RetroItem
+            other_cat = RetroItem(id=uuid.uuid4(), session_id=session_id, category="bad", text="x")
+            s.add(other_cat)
+            await s.flush()
+            await s.commit()
+            other_cat_id = other_cat.id
+
+        async with Session() as s:
+            item_repo = RetroItemRepository(s)
+            with pytest.raises(ValueError, match="CATEGORY_MISMATCH"):
+                await item_repo.group_under_parent(session_id, other_cat_id, a)
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_session_hides_grouped_children_and_blocks_child_vote():
+    from app.repositories.retro import RetroItemRepository, RetroSessionRepository
+    from app.routers.retros import get_session, vote_item
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            session_id, item_ids = await _seed_session_with_items(s, n_items=2)
+        parent_id, child_id = item_ids
+
+        async with Session() as s:
+            await RetroItemRepository(s).group_under_parent(session_id, child_id, parent_id)
+            await s.commit()
+
+        async with Session() as s:
+            out = await get_session(
+                id=session_id, db=s, auth=_auth(), repo=RetroSessionRepository(s, ORG)
+            )
+            assert [i.id for i in out.items] == [parent_id]
+            assert out.items[0].grouped_item_ids == [child_id]
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await vote_item(
+                    id=session_id, item_id=child_id, voter_id=uuid.uuid4(),
+                    db=s, auth=_auth(), repo=RetroSessionRepository(s, ORG),
+                )
+            assert ei.value.status_code == 400
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_retro_voted_by_me_realdb.py
+++ b/backend/tests/test_retro_voted_by_me_realdb.py
@@ -117,3 +117,37 @@ async def test_voted_by_me_id_space_matches_real_resolve_member():
             assert by_id[ids["item2_id"]].voted_by_me is False
     finally:
         await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_vote_item_uses_resolved_caller_member_realdb():
+    """P0(9f27af8f) — vote_item에 client-supplied voter_id 파라미터 자체가 없다(함수 시그니처에
+    없음 — 스푸핑 벡터 원천 제거). 실 PG에서 caller(USER_A/USER_B)마다 정확히 자기 자신의
+    canonical member id로만 투표가 기록되는지(타인 명의 투표 불가) 실증."""
+    from app.repositories.retro import RetroSessionRepository
+    from app.routers.retros import vote_item
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            ids = await _seed(s)
+
+        async with Session() as s:
+            out = await vote_item(
+                id=ids["session_id"], item_id=ids["item2_id"],
+                db=s, auth=_auth(USER_A), repo=RetroSessionRepository(s, ORG),
+            )
+            await s.commit()
+            assert out.voter_id == OM_A
+            assert out.voter_id != OM_B
+
+        async with Session() as s:
+            out = await vote_item(
+                id=ids["session_id"], item_id=ids["item1_id"],
+                db=s, auth=_auth(USER_B), repo=RetroSessionRepository(s, ORG),
+            )
+            await s.commit()
+            assert out.voter_id == OM_B
+            assert out.voter_id != OM_A
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_retros.py
+++ b/backend/tests/test_retros.py
@@ -47,6 +47,10 @@ def _mock_item() -> MagicMock:
     # RetroItem 실 모델엔 없는 계산 필드 — MagicMock은 미설정 속성도 truthy를 자동생성하므로
     # (실 ORM 객체라면 getattr 이 없어 pydantic 기본값 False로 떨어짐) 명시적으로 맞춰준다.
     i.voted_by_me = False
+    # B2: 실 컬럼(parent_item_id)이지만 미설정 시 MagicMock이 truthy 자동생성 → 잘못
+    # "그룹핑됨"으로 오판(vote_item의 `is not None` 체크·get_session의 visible_items 필터
+    # 둘 다 영향). 기본은 top-level(None).
+    i.parent_item_id = None
     return i
 
 
@@ -569,6 +573,189 @@ async def test_vote_item_wrong_session_404():
                 )
 
         assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_vote_grouped_child_forbidden_400():
+    """B2 — parent_item_id가 있는(그룹핑된) child는 직접 투표 불가."""
+    client, session, app = await _client()
+    try:
+        grouped_item = _mock_item()
+        grouped_item.parent_item_id = uuid.uuid4()
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = _mock_session() if call_count == 1 else grouped_item
+            return result
+
+        session.execute = mock_execute
+
+        with _allow_project_access():
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/retros/{SESSION_ID}/items/{ITEM_ID}/vote?voter_id={VOTER_ID}"
+                )
+
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_group_item_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        parent_id = uuid.uuid4()
+        grouped = _mock_item()
+        grouped.parent_item_id = parent_id
+
+        with (
+            _allow_project_access(),
+            patch(
+                "app.repositories.retro.RetroItemRepository.group_under_parent",
+                new_callable=AsyncMock,
+            ) as mock_group,
+        ):
+            mock_group.return_value = grouped
+
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/retros/{SESSION_ID}/items/{ITEM_ID}/group",
+                    json={"parent_item_id": str(parent_id)},
+                )
+
+        assert resp.status_code == 200
+        assert resp.json()["parent_item_id"] == str(parent_id)
+        mock_group.assert_awaited_once_with(SESSION_ID, ITEM_ID, parent_id)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_group_item_invalid_400():
+    """category 불일치·이미 그룹핑됨·parent가 top-level 아님 등 — ValueError를 400으로 매핑."""
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with (
+            _allow_project_access(),
+            patch(
+                "app.repositories.retro.RetroItemRepository.group_under_parent",
+                new_callable=AsyncMock,
+            ) as mock_group,
+        ):
+            mock_group.side_effect = ValueError("CATEGORY_MISMATCH")
+
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/retros/{SESSION_ID}/items/{ITEM_ID}/group",
+                    json={"parent_item_id": str(uuid.uuid4())},
+                )
+
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_ungroup_item_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        ungrouped = _mock_item()
+        ungrouped.parent_item_id = None
+
+        with (
+            _allow_project_access(),
+            patch("app.repositories.retro.RetroItemRepository.ungroup", new_callable=AsyncMock) as mock_ungroup,
+        ):
+            mock_ungroup.return_value = ungrouped
+
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/items/{ITEM_ID}/ungroup")
+
+        assert resp.status_code == 200
+        assert resp.json()["parent_item_id"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_ungroup_item_not_found_404():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with (
+            _allow_project_access(),
+            patch("app.repositories.retro.RetroItemRepository.ungroup", new_callable=AsyncMock) as mock_ungroup,
+        ):
+            mock_ungroup.return_value = None
+
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/items/{ITEM_ID}/ungroup")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_session_hides_grouped_children():
+    """B2 — get_session은 top-level item만 노출·parent에 grouped_item_ids 반영."""
+    client, session, app = await _client()
+    try:
+        parent = _mock_item()
+        parent.id = uuid.uuid4()
+        parent.parent_item_id = None
+        child = _mock_item()
+        child.id = uuid.uuid4()
+        child.parent_item_id = parent.id
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = _mock_session()
+            elif call_count == 2:
+                result.scalars.return_value.all.return_value = [parent, child]
+            elif call_count == 3:
+                result.scalars.return_value.all.return_value = []  # actions
+            else:
+                result.scalars.return_value.all.return_value = []  # votes
+            return result
+
+        session.execute = mock_execute
+
+        with _allow_project_access(), _mock_resolve_member():
+            async with client as c:
+                resp = await c.get(f"/api/v2/retros/{SESSION_ID}")
+
+        items = resp.json()["items"]
+        assert len(items) == 1
+        assert items[0]["id"] == str(parent.id)
+        assert items[0]["grouped_item_ids"] == [str(child.id)]
     finally:
         app.dependency_overrides.clear()
 

--- a/backend/tests/test_retros.py
+++ b/backend/tests/test_retros.py
@@ -84,7 +84,7 @@ def _deny_project_access():
 
 
 def _mock_resolve_member(member_id: uuid.UUID | None = None):
-    """B4: get_session이 호출하는 resolve_member SSOT를 patch — DB member 해소 우회."""
+    """B4/P0: 라우터가 호출하는 resolve_member SSOT를 patch — DB member 해소 우회."""
     resolved = MagicMock()
     resolved.id = member_id or uuid.uuid4()
     return patch("app.routers.retros.resolve_member", new=AsyncMock(return_value=resolved))
@@ -182,8 +182,10 @@ async def test_list_retro_sessions_cross_project_403():
 async def test_create_retro_session_201():
     client, session, app = await _client()
     try:
+        resolved_id = uuid.uuid4()
         with (
             _allow_project_access(),
+            _mock_resolve_member(resolved_id),
             patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create,
         ):
             mock_create.return_value = _mock_session()
@@ -193,10 +195,15 @@ async def test_create_retro_session_201():
                     "project_id": str(PROJECT_ID),
                     "org_id": str(ORG_ID),
                     "title": "Sprint 3 Retro",
+                    "created_by": str(uuid.uuid4()),  # P0: client 지정값은 무시돼야 함
                 })
 
         assert resp.status_code == 201
         assert resp.json()["title"] == "Sprint 3 Retro"
+        # 핵심: created_by는 client body가 아니라 resolve_member 해소값으로 create 호출됨.
+        mock_create.assert_awaited_once_with(
+            project_id=PROJECT_ID, title="Sprint 3 Retro", sprint_id=None, created_by=resolved_id
+        )
     finally:
         app.dependency_overrides.clear()
 
@@ -342,6 +349,7 @@ async def test_add_item_default_not_voted():
 
         with (
             _allow_project_access(),
+            _mock_resolve_member(),
             patch("app.repositories.retro.RetroItemRepository.create", new_callable=AsyncMock) as mock_create,
         ):
             mock_create.return_value = _mock_item()
@@ -444,8 +452,10 @@ async def test_add_item_201():
         session.refresh = AsyncMock()
         session.add = MagicMock()
 
+        resolved_id = uuid.uuid4()
         with (
             _allow_project_access(),
+            _mock_resolve_member(resolved_id),
             patch("app.repositories.retro.RetroItemRepository.create", new_callable=AsyncMock) as mock_create,
         ):
             mock_create.return_value = _mock_item()
@@ -454,10 +464,15 @@ async def test_add_item_201():
                 resp = await c.post(f"/api/v2/retros/{SESSION_ID}/items", json={
                     "category": "good",
                     "text": "팀워크 좋았는",
+                    "author_id": str(uuid.uuid4()),  # P0: client 지정값은 무시돼야 함
                 })
 
         assert resp.status_code == 201
         assert resp.json()["category"] == "good"
+        # 핵심: author_id는 client body가 아니라 resolve_member 해소값으로 create 호출됨.
+        mock_create.assert_awaited_once_with(
+            session_id=SESSION_ID, category="good", text="팀워크 좋았는", author_id=resolved_id
+        )
     finally:
         app.dependency_overrides.clear()
 
@@ -536,11 +551,9 @@ async def test_vote_duplicate_409():
 
         session.execute = mock_execute
 
-        with _allow_project_access():
+        with _allow_project_access(), _mock_resolve_member(VOTER_ID):
             async with client as c:
-                resp = await c.post(
-                    f"/api/v2/retros/{SESSION_ID}/items/{ITEM_ID}/vote?voter_id={VOTER_ID}"
-                )
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/items/{ITEM_ID}/vote")
 
         assert resp.status_code == 409
     finally:
@@ -568,9 +581,7 @@ async def test_vote_item_wrong_session_404():
 
         with _allow_project_access():
             async with client as c:
-                resp = await c.post(
-                    f"/api/v2/retros/{SESSION_ID}/items/{ITEM_ID}/vote?voter_id={VOTER_ID}"
-                )
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/items/{ITEM_ID}/vote")
 
         assert resp.status_code == 404
     finally:
@@ -598,11 +609,50 @@ async def test_vote_grouped_child_forbidden_400():
 
         with _allow_project_access():
             async with client as c:
-                resp = await c.post(
-                    f"/api/v2/retros/{SESSION_ID}/items/{ITEM_ID}/vote?voter_id={VOTER_ID}"
-                )
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/items/{ITEM_ID}/vote")
 
         assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_vote_item_uses_resolved_caller_not_client_input():
+    """P0(9f27af8f) — voter_id는 client 입력에서 완전히 배제, resolve_member 해소값만 사용
+    (vote-spoofing 봉쇄). RetroVoteRepository.vote 가 resolve_member 해소값으로 호출되는지
+    직접 검증(호출 인자 assert — DB 생성 필드 mocking 없이 라우팅 로직만 격리)."""
+    client, session, app = await _client()
+    try:
+        resolved_id = uuid.uuid4()
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            # call1 = _require_retro_project_access, call2 = _require_item_in_session
+            result.scalar_one_or_none.return_value = _mock_session() if call_count == 1 else _mock_item()
+            return result
+
+        session.execute = mock_execute
+
+        with (
+            _allow_project_access(),
+            _mock_resolve_member(resolved_id),
+            patch("app.repositories.retro.RetroVoteRepository.vote", new_callable=AsyncMock) as mock_vote,
+        ):
+            v = _mock_vote()
+            v.voter_id = resolved_id
+            mock_vote.return_value = v
+
+            # POST body/query 어디에도 voter_id를 전혀 안 보냄 — 파라미터 자체가 없다.
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/items/{ITEM_ID}/vote")
+
+        assert resp.status_code == 201
+        assert resp.json()["voter_id"] == str(resolved_id)
+        # 핵심: vote()가 resolve_member 해소값으로만 호출됐는지(client 입력 경로 자체가 없음).
+        mock_vote.assert_awaited_once_with(ITEM_ID, resolved_id)
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary
- story `9f27af8f` 큐의 B2 — `retro_items` 그룹핑 모델('group' phase에서 유사/중복 아이템 병합, 미르코 FE가 시도했다가 BE 지원 없어 skip). B4 작업 중 발견한 `retro_items.vote_count` 항상-0 버그도 근본 수정(같은 PO 지시로 합류).
- codex(gpt-5.5) 설계 → PO(오르테가) crux 승인.

## Design
- `retro_items.parent_item_id` self-FK(join 테이블 아님 — 단순 계층, 필요해지면 그때 승격).
- 체인 방지: parent는 반드시 top-level이어야 함(app-level 검증, DB CHECK 불가 — 같은 테이블 자기참조).
- 투표 UX: 그룹핑 시 child는 응답에서 숨김(top-level만 노출), 기존 투표는 parent로 이관(같은 voter 중복 dedupe), child는 이후 투표 불가(400).
- `vote_count`: `vote()`가 insert 성공 후 같은 트랜잭션에서 원자적 `+1`. 마이그레이션 0144에서 `retro_votes` 실측 COUNT로 기존 데이터 재계산(추측 backfill 아님). `retro_votes(item_id,voter_id)` unique 제약도 신설(기존 app-level pre-check만으론 TOCTOU 레이스 있었음).

## Review correction (institutional memory catch)
codex 산출물의 `vote()` diff는 `IntegrityError`를 **SAVEPOINT(`begin_nested`) 없이** catch하는 구조였음 — 이 레포에 이미 기록된 함정(E-DG S3 P0-1, `[[feedback_savepoint_failopen_session_poison]]`)과 동일 패턴: SAVEPOINT 없이 flush 실패를 catch하면 async 세션이 poison돼 후속 write가 `PendingRollbackError`.

**직접 실증**: 소스에서 `begin_nested` 제거 → 실제로 `PendingRollbackError` 재현 확인 → 복원 → `begin_nested`로 GREEN 재확인. codex 산출을 그대로 신뢰하지 않고 기존 기관 지식으로 검증했음.

## API
- `POST /{id}/items/{item_id}/group`(body `{parent_item_id}`) / `POST /{id}/items/{item_id}/ungroup` 신설.
- `GET /{id}`·export는 top-level item만 노출 + `grouped_item_ids` 반영.

## Test plan
- [x] `test_retros.py` +9건(mock): group/ungroup 라우트(200/400/404), grouped child 투표 차단(400), get_session 그룹 숨김+`grouped_item_ids`.
- [x] `test_retro_grouping_vote_count_realdb.py` 6건(realdb):
  - vote() 원자 `+1` 정확성, 중복투표 거부+count 불변
  - **SAVEPOINT 세션-poison 방지 직접 실증**(결정론적 재현 — 이미 커밋된 투표에 pre-check 우회 후 재-INSERT)
  - 그룹핑 시 vote 이관/dedupe/parent count 재계산, child에 vote row 0건 확인
  - 체인 방지(자기그룹·이미 그룹핑된 parent 아래 재그룹·category 불일치 거부)
  - get_session 통합(그룹 숨김 + child 투표 차단 라우트 레벨)
- [x] `uv run pytest tests/test_retros.py tests/test_retro_mutation_project_scope_idor_realdb.py tests/test_retro_voted_by_me_realdb.py tests/test_retro_grouping_vote_count_realdb.py -q` — 39/39 pass.
- [x] 전체 backend 스위트(2787 pass) 회귀 0 — 무관 92건은 retro 코드 참조 0(기존 seed/제약 drift 재확인, 이전 IDOR/B4 PR과 동일 신호).
- [x] CI: 신규 realdb 테스트를 asset-registry 잡 명시 리스트에 추가.

## Scope note
B1(phase 전이 3단계+비차단+양방향 재설계)은 별 큐 — 이 PR은 phase 전이 로직 자체를 건드리지 않음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)