### PR TITLE
feat(retros): B1 phase 3게이트+비차단+양방향 재설계

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
           JWT_SECRET: ci-test-secret-at-least-32-chars-long
           SECRET_KEY: ci-test-secret-at-least-32-chars-long
-        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py tests/test_release_notes_realdb.py tests/test_audit_apikey_parity_realdb.py tests/test_doc_gate_cascade_scope_realdb.py tests/test_doc_mutation_project_scope_idor_realdb.py tests/test_retro_mutation_project_scope_idor_realdb.py tests/test_retro_voted_by_me_realdb.py tests/test_retro_grouping_vote_count_realdb.py -q
+        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py tests/test_release_notes_realdb.py tests/test_audit_apikey_parity_realdb.py tests/test_doc_gate_cascade_scope_realdb.py tests/test_doc_mutation_project_scope_idor_realdb.py tests/test_retro_mutation_project_scope_idor_realdb.py tests/test_retro_voted_by_me_realdb.py tests/test_retro_grouping_vote_count_realdb.py tests/test_retro_phase_transitions_realdb.py -q
 
       - name: Verify fresh DB reached head (baseline + incremental)
         working-directory: backend

--- a/backend/alembic/versions/0145_retro_phase_three_gate.py
+++ b/backend/alembic/versions/0145_retro_phase_three_gate.py
@@ -1,0 +1,52 @@
+"""B1(9f27af8f): retro_sessions.phase 6게이트 → 3능동게이트+terminal de-gate.
+
+유나 locked mockup §B1 — group/discuss는 강제 통과 게이트였던 게 문제라 phase 자체에서 제거
+(rename 아님). 기존 라이브 세션은 PO 권고 매핑으로 일괄 이관(전보존 — items/votes/actions/
+grouping은 phase와 무관한 별도 테이블이라 이 마이그가 손대지 않음):
+  collect→collect, group→vote, vote→vote, discuss→action, action→action, closed→closed
+
+순서: (a) UPDATE phase 매핑 적용 → (b) CHECK 제약을 4값 세트로 교체(순서 반대면 기존 group/
+discuss 세션이 남아있는 동안 CHECK 위반).
+
+downgrade()는 phase 값 자체는 복원 안 함(group→vote/discuss→action은 손실 매핑이라 역산
+불가 — 어느 vote 세션이 원래 group이었는지 정보가 없음) — CHECK 제약만 6값으로 되돌려
+downgrade 직후 앱이 계속 4값으로만 쓰면 기능상 문제 없음(6값 CHECK가 4값의 상위집합).
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0145"
+down_revision = "0144"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE retro_sessions
+        SET phase = CASE phase
+            WHEN 'group' THEN 'vote'
+            WHEN 'discuss' THEN 'action'
+            ELSE phase
+        END
+        WHERE phase IN ('group', 'discuss')
+        """
+    )
+    op.drop_constraint("retro_sessions_phase_check", "retro_sessions", type_="check")
+    op.create_check_constraint(
+        "retro_sessions_phase_check",
+        "retro_sessions",
+        "phase = ANY (ARRAY['collect'::text, 'vote'::text, 'action'::text, 'closed'::text])",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("retro_sessions_phase_check", "retro_sessions", type_="check")
+    op.create_check_constraint(
+        "retro_sessions_phase_check",
+        "retro_sessions",
+        "phase = ANY (ARRAY['collect'::text, 'group'::text, 'vote'::text, 'discuss'::text, "
+        "'action'::text, 'closed'::text])",
+    )

--- a/backend/app/models/retro.py
+++ b/backend/app/models/retro.py
@@ -8,8 +8,21 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.core.database import Base
 from app.models.base import OrgScopedMixin, TimestampMixin
 
-RETRO_PHASES = ("collect", "group", "vote", "discuss", "action", "closed")
-PHASE_TRANSITIONS: dict[str, str] = {p: RETRO_PHASES[i + 1] for i, p in enumerate(RETRO_PHASES[:-1])}
+# B1(9f27af8f): 6게이트(collect/group/vote/discuss/action/closed) → 3능동게이트+terminal 로
+# de-gate(rename 아님) — 유나 locked mockup §B1. group/discuss는 강제 통과 게이트였던 게 문제라
+# 비차단 선택 액션으로 강등(group=B2 그룹핑 툴, discuss=선택 노트 — 둘 다 전용 phase 불요, 언제든
+# 가능). 기존 세션은 마이그 0145에서 {group→vote, discuss→action}로 일괄 이관(공존 아님).
+RETRO_PHASES = ("collect", "vote", "action", "closed")
+
+# 3 능동단계(collect/vote/action)는 인접 양방향(뒤로가기 포함, 데이터 PRESERVE) + action→closed
+# 편도. closed는 terminal 고정(되돌리면 투표/액션 수정 가능성과 감사 의미가 섞임 — 유나 스펙
+# "terminal 유지"). 비인접 점프(예: collect→action, collect→closed)는 여전히 거부.
+ALLOWED_PHASE_TRANSITIONS: dict[str, frozenset[str]] = {
+    "collect": frozenset({"vote"}),
+    "vote": frozenset({"collect", "action"}),
+    "action": frozenset({"vote", "closed"}),
+    "closed": frozenset(),
+}
 
 
 class RetroSession(Base, OrgScopedMixin, TimestampMixin):

--- a/backend/app/repositories/retro.py
+++ b/backend/app/repositories/retro.py
@@ -5,7 +5,14 @@ from sqlalchemy import func, select, text, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.retro import PHASE_TRANSITIONS, RetroAction, RetroItem, RetroSession, RetroVote
+from app.models.retro import (
+    ALLOWED_PHASE_TRANSITIONS,
+    RETRO_PHASES,
+    RetroAction,
+    RetroItem,
+    RetroSession,
+    RetroVote,
+)
 from app.repositories.base import BaseRepository
 
 
@@ -13,28 +20,20 @@ class RetroSessionRepository(BaseRepository[RetroSession]):
     def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
         super().__init__(RetroSession, session, org_id)
 
-    async def advance_phase(self, id: uuid.UUID) -> RetroSession:
-        retro = await self.get(id)
-        if retro is None:
-            raise ValueError(f"RetroSession {id} not found")
-        next_phase = PHASE_TRANSITIONS.get(retro.phase)
-        if next_phase is None:
-            raise ValueError(f"Session is already in final phase: {retro.phase}")
-        updated = await self.update(id, phase=next_phase)
-        assert updated is not None
-        return updated
-
     async def set_phase(self, id: uuid.UUID, new_phase: str) -> RetroSession:
-        from app.models.retro import RETRO_PHASES
+        """B1: 인접 양방향(collect↔vote↔action) + action→closed 편도만 허용. closed는
+        terminal(전이 0건). 같은 phase 재지정은 no-op(멱등 — FE advance 확인 다이얼로그가
+        중복 클릭해도 안전)."""
         retro = await self.get(id)
         if retro is None:
             raise ValueError(f"RetroSession {id} not found")
-        current_idx = list(RETRO_PHASES).index(retro.phase)
-        new_idx = list(RETRO_PHASES).index(new_phase) if new_phase in RETRO_PHASES else -1
-        if new_idx < 0:
+        if new_phase not in RETRO_PHASES:
             raise ValueError(f"Invalid phase: {new_phase}")
-        if new_idx != current_idx + 1:
-            raise ValueError(f"Non-sequential transition: {retro.phase} → {new_phase}")
+        if new_phase == retro.phase:
+            return retro
+        allowed = ALLOWED_PHASE_TRANSITIONS.get(retro.phase, frozenset())
+        if new_phase not in allowed:
+            raise ValueError(f"Invalid phase transition: {retro.phase} → {new_phase}")
         updated = await self.update(id, phase=new_phase)
         assert updated is not None
         return updated

--- a/backend/tests/test_retro_phase_transitions_realdb.py
+++ b/backend/tests/test_retro_phase_transitions_realdb.py
@@ -1,0 +1,184 @@
+"""B1(9f27af8f): retro phase 3게이트+비차단+양방향 — realdb 전이 매트릭스 실증.
+
+`set_phase`의 인접 양방향(collect↔vote↔action) + action→closed 편도 + closed terminal을
+실 PG에서 라우터 함수(`advance_phase`)를 직접 호출해 실증한다. 특히 **양방향 데이터 보존**
+(뒤로가기해도 기존 투표/그룹핑/액션이 안 사라짐)을 확인 — phase 컬럼만 바뀌고 나머지 테이블은
+전혀 손대지 않는다는 설계 전제를 실측.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("cd000000-0000-0000-0000-000000000001")
+USER = uuid.UUID("cd000000-0000-0000-0000-0000000000a1")
+OM = uuid.UUID("cd000000-0000-0000-0000-0000000000b1")
+PROJ = uuid.UUID("cd000000-0000-0000-0000-0000000000c1")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+
+
+async def _seed_session(s, phase: str):
+    from app.models.retro import RetroAction, RetroItem, RetroSession, RetroVote
+
+    for sql in [
+        f"DELETE FROM retro_actions WHERE session_id IN "
+        f"(SELECT id FROM retro_sessions WHERE org_id='{ORG}')",
+        f"DELETE FROM retro_votes WHERE item_id IN "
+        f"(SELECT id FROM retro_items WHERE session_id IN "
+        f"(SELECT id FROM retro_sessions WHERE org_id='{ORG}'))",
+        f"DELETE FROM retro_items WHERE session_id IN (SELECT id FROM retro_sessions WHERE org_id='{ORG}')",
+        f"DELETE FROM retro_sessions WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','CD','cd-org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@cd.test','x','U',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ}','{ORG}','P')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ}','{OM}','granted')",
+    ]:
+        await s.execute(text(sql))
+
+    sess = RetroSession(id=uuid.uuid4(), org_id=ORG, project_id=PROJ, title="r", phase=phase)
+    s.add(sess)
+    await s.flush()
+
+    item = RetroItem(id=uuid.uuid4(), session_id=sess.id, category="good", text="i")
+    s.add(item)
+    await s.flush()
+    vote = RetroVote(id=uuid.uuid4(), item_id=item.id, voter_id=OM)
+    s.add(vote)
+    action = RetroAction(id=uuid.uuid4(), session_id=sess.id, title="a")
+    s.add(action)
+    await s.flush()
+    await s.commit()
+
+    return {"session_id": sess.id, "item_id": item.id, "vote_id": vote.id, "action_id": action.id}
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+@pytest.mark.parametrize(
+    "start,target",
+    [
+        ("collect", "vote"),
+        ("vote", "collect"),
+        ("vote", "action"),
+        ("action", "vote"),
+        ("action", "closed"),
+    ],
+)
+@pytest.mark.anyio
+async def test_allowed_transitions(start, target):
+    from app.repositories.retro import RetroSessionRepository
+    from app.routers.retros import advance_phase
+    from app.schemas.retro import PhaseTransition
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            ids = await _seed_session(s, start)
+
+        async with Session() as s:
+            out = await advance_phase(
+                id=ids["session_id"], body=PhaseTransition(phase=target),
+                db=s, auth=_auth(), repo=RetroSessionRepository(s, ORG),
+            )
+            assert out.phase == target
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.parametrize(
+    "start,target",
+    [
+        ("collect", "action"),
+        ("collect", "closed"),
+        ("vote", "closed"),
+        ("closed", "action"),
+        ("closed", "vote"),
+        ("closed", "collect"),
+    ],
+)
+@pytest.mark.anyio
+async def test_rejected_non_adjacent_transitions(start, target):
+    from app.repositories.retro import RetroSessionRepository
+    from app.routers.retros import advance_phase
+    from app.schemas.retro import PhaseTransition
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            ids = await _seed_session(s, start)
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await advance_phase(
+                    id=ids["session_id"], body=PhaseTransition(phase=target),
+                    db=s, auth=_auth(), repo=RetroSessionRepository(s, ORG),
+                )
+            assert ei.value.status_code == 400
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_backward_transition_preserves_all_data():
+    """B1 핵심 — vote→collect 뒤로가기해도 item/vote/action 전부 그대로(phase 컬럼만 변경)."""
+    from app.models.retro import RetroAction, RetroItem, RetroSession, RetroVote
+    from app.repositories.retro import RetroSessionRepository
+    from app.routers.retros import advance_phase
+    from app.schemas.retro import PhaseTransition
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            ids = await _seed_session(s, "vote")
+
+        async with Session() as s:
+            out = await advance_phase(
+                id=ids["session_id"], body=PhaseTransition(phase="collect"),
+                db=s, auth=_auth(), repo=RetroSessionRepository(s, ORG),
+            )
+            await s.commit()
+            assert out.phase == "collect"
+
+        async with Session() as s:
+            sess = (await s.execute(select(RetroSession).where(RetroSession.id == ids["session_id"]))).scalar_one()
+            item = (await s.execute(select(RetroItem).where(RetroItem.id == ids["item_id"]))).scalar_one_or_none()
+            vote = (await s.execute(select(RetroVote).where(RetroVote.id == ids["vote_id"]))).scalar_one_or_none()
+            action = (await s.execute(select(RetroAction).where(RetroAction.id == ids["action_id"]))).scalar_one_or_none()
+            assert sess.phase == "collect"
+            assert item is not None
+            assert vote is not None
+            assert action is not None
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_retros.py
+++ b/backend/tests/test_retros.py
@@ -402,11 +402,11 @@ async def test_get_retro_session_cross_project_403():
 
 @pytest.mark.anyio
 async def test_advance_phase_200():
-    """collect → group 순차 전이."""
+    """B1 — collect → vote 인접 전이."""
     client, session, app = await _client()
     try:
         collect_session = _mock_session("collect")
-        group_session = _mock_session("group")
+        vote_session = _mock_session("vote")
 
         call_count = 0
 
@@ -415,21 +415,100 @@ async def test_advance_phase_200():
             call_count += 1
             result = MagicMock()
             # call 1 = _require_retro_project_access pre-check, call 2 = set_phase() 내부 get()
-            # (둘 다 현재 phase="collect" 세션이어야 current_idx 계산이 맞음) — call 3+ = update() 내부 get().
+            # (둘 다 현재 phase="collect" 세션이어야 전이 허용판정이 맞음) — call 3+ = update() 내부 get().
             if call_count <= 2:
                 result.scalar_one_or_none.return_value = collect_session
             else:
-                result.scalar_one_or_none.return_value = group_session
+                result.scalar_one_or_none.return_value = vote_session
             return result
 
         session.execute = mock_execute
 
         with _allow_project_access():
             async with client as c:
-                resp = await c.patch(f"/api/v2/retros/{SESSION_ID}/phase", json={"phase": "group"})
+                resp = await c.patch(f"/api/v2/retros/{SESSION_ID}/phase", json={"phase": "vote"})
 
         assert resp.status_code == 200
-        assert resp.json()["phase"] == "group"
+        assert resp.json()["phase"] == "vote"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_advance_phase_backward_vote_to_collect_200():
+    """B1 — 양방향: vote → collect 뒤로가기 허용(데이터는 손대지 않음, phase만 변경)."""
+    client, session, app = await _client()
+    try:
+        vote_session = _mock_session("vote")
+        collect_session = _mock_session("collect")
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = vote_session if call_count <= 2 else collect_session
+            return result
+
+        session.execute = mock_execute
+
+        with _allow_project_access():
+            async with client as c:
+                resp = await c.patch(f"/api/v2/retros/{SESSION_ID}/phase", json={"phase": "collect"})
+
+        assert resp.status_code == 200
+        assert resp.json()["phase"] == "collect"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.parametrize(
+    "current_phase,target_phase",
+    [
+        ("collect", "action"),  # 비인접 점프
+        ("collect", "closed"),  # 비인접 점프
+        ("vote", "closed"),  # 비인접 점프
+        ("closed", "action"),  # terminal에서 전이 시도
+        ("closed", "vote"),  # terminal에서 전이 시도
+        ("closed", "collect"),  # terminal에서 전이 시도
+    ],
+)
+@pytest.mark.anyio
+async def test_advance_phase_non_adjacent_rejected_400(current_phase, target_phase):
+    """B1 — 비인접 전이는 여전히 거부(closed는 terminal이라 전이 0건)."""
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session(current_phase)
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with _allow_project_access():
+            async with client as c:
+                resp = await c.patch(
+                    f"/api/v2/retros/{SESSION_ID}/phase", json={"phase": target_phase}
+                )
+
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_advance_phase_same_phase_noop_200():
+    """B1 — 같은 phase 재지정은 no-op(멱등 — FE 중복클릭 방어)."""
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session("vote")
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with _allow_project_access():
+            async with client as c:
+                resp = await c.patch(f"/api/v2/retros/{SESSION_ID}/phase", json={"phase": "vote"})
+
+        assert resp.status_code == 200
+        assert resp.json()["phase"] == "vote"
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary
- story `9f27af8f` 큐의 마지막 항목 B1 — 유나 locked mockup §B1 기준. 6게이트(collect/group/vote/discuss/action/closed)가 강제 빈 게이트(group/discuss)를 포함해 UX 문제 → **de-gate**(rename 아님)로 3능동게이트+terminal 재설계.
- codex(gpt-5.5) 설계 → PO(오르테가) crux 승인.

## Design
- `RETRO_PHASES`를 4값(`collect`/`vote`/`action`/`closed`)으로 좁힘.
- 전이 = `collect↔vote↔action` **인접 양방향**(뒤로가기 포함, 데이터 **PRESERVE**) + `action→closed` **편도**. `closed`는 **terminal 고정**(감사 의미 보존 — 스펙 명시).
- `group`(B2 그룹핑 툴)·`discuss`(선택 노트)는 전용 phase 없이 vote/action 단계 중 자유 사용으로 강등 — `group_item`/`ungroup_item`은 이미 phase 게이팅이 없어 무변경.
- 죽은 코드 제거: `RetroSessionRepository.advance_phase()` + 구 `PHASE_TRANSITIONS`(순방향-전용 dict) — grep으로 사용처 0건 확인 후 제거. `set_phase()`가 `ALLOWED_PHASE_TRANSITIONS`(인접 양방향 매핑)로 재작성, 같은 phase 재지정은 no-op(FE 중복클릭 방어).
- **API 계약 무변경**: `PATCH /{id}/phase {phase: <target>}` 그대로(direction 방식보다 FE 변경 최소·목표 상태가 명시적).

## Migration (0145)
기존 라이브 세션 phase를 PO 권고 매핑으로 일괄 이관(`group→vote`, `discuss→action`, 나머지 동일) 후 CHECK 제약을 4값으로 교체. UPDATE→CHECK 순서 필수. `downgrade()`는 CHECK만 6값 원복(phase 값 자체는 손실 매핑이라 복원 불가 — 정직하게 문서화).

## Test plan (B1은 회귀 위험 최고 항목 — 특히 꼼꼼히)
- [x] **마이그 실제 적용 실증**: throwaway PG를 0144에 세워두고 6-phase 세션 전부(items/votes/actions/`parent_item_id` 그룹핑 포함) seed → `upgrade head` → 매핑 정확성 + 데이터 1건도 안 밀렸음을 직접 psql로 확인. `downgrade→재upgrade` 라운드트립도 검증.
- [x] `test_retros.py`(mock): 인접 양방향 200(`collect→vote`·`vote→collect`) + 비인접 거부 400(6종, `closed`에서 전이 3종 포함) + 같은-phase no-op 200.
- [x] `test_retro_phase_transitions_realdb.py`(신규, realdb): 전이 매트릭스(허용 5·거부 6) + 뒤로가기 시 item/vote/action 전부 보존 실증.
- [x] `uv run pytest tests/test_retros.py ... tests/test_retro_phase_transitions_realdb.py -q` — 75/75 pass.
- [x] 전체 backend 스위트(2809 pass) 회귀 0 — 무관 92건 재확인(이전 3개 PR과 동일 신호).
- [x] CI: 신규 realdb 테스트를 asset-registry 잡 명시 리스트에 추가.

## FE 스코프
미르코 페어(스테퍼 3단계화+비차단 오버레이, 유나 phase-options mockup B열이 SSOT). 이 PR은 BE 계약만 — API shape 무변경이라 FE 착수 블로킹 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)