### PR TITLE
fix(retros): P1 — B2 그룹핑 렌더 회귀, session GET에 grouped child 포함

### DIFF
--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -139,13 +139,13 @@ async def get_session(
     items = await item_repo.list_by_session(id)
     actions = await action_repo.list_by_session(id)
 
-    # B2: 그룹핑된 child는 응답에서 숨김(부모만 top-level로 노출) — parent id → child id 목록.
+    # P1(9f27af8f, 유나 real-payload 재현): grouped child를 items에서 제외하면 FE가 클러스터를
+    # 그릴 데이터 자체가 없어짐(FE는 items를 top-level/child로 필터링해 렌더 — child 객체가
+    # 있어야 함). session GET은 **flat 배열로 전부 노출**(parent_item_id로 FE가 필터), export만
+    # top-level-only 유지(별도 필터, 아래). grouped_item_ids는 parent 조회 편의상 유지.
     grouped_by_parent: dict[uuid.UUID, list[uuid.UUID]] = {}
-    visible_items = []
     for i in items:
-        if i.parent_item_id is None:
-            visible_items.append(i)
-        else:
+        if i.parent_item_id is not None:
             grouped_by_parent.setdefault(i.parent_item_id, []).append(i.id)
 
     # B4: voted_by_me — client 지정 voter_id 무신뢰. auth 로 canonical requester id 를 직접 해소
@@ -154,11 +154,11 @@ async def get_session(
     # resolve_member(레거시 경로).id 와 동일 공간 — 별도 매핑 불요).
     resolved = await resolve_member(auth, session.org_id, db, project_id=session.project_id)
     voted_item_ids: set[uuid.UUID] = set()
-    if visible_items:
+    if items:
         voted_rows = await db.execute(
             select(RetroVote.item_id).where(
                 RetroVote.voter_id == resolved.id,
-                RetroVote.item_id.in_([i.id for i in visible_items]),
+                RetroVote.item_id.in_([i.id for i in items]),
             )
         )
         voted_item_ids = set(voted_rows.scalars().all())
@@ -186,7 +186,7 @@ async def get_session(
                 parent_item_id=i.parent_item_id,
                 grouped_item_ids=grouped_by_parent.get(i.id, []),
             )
-            for i in visible_items
+            for i in items
         ],
         actions=[ActionResponse.model_validate(a) for a in actions],
     )

--- a/backend/tests/test_retro_grouping_vote_count_realdb.py
+++ b/backend/tests/test_retro_grouping_vote_count_realdb.py
@@ -279,7 +279,9 @@ async def test_group_rejects_chain_and_self_and_category_mismatch():
 
 
 @pytest.mark.anyio
-async def test_get_session_hides_grouped_children_and_blocks_child_vote():
+async def test_get_session_includes_grouped_children_and_blocks_child_vote():
+    """P1(9f27af8f, 유나 real-payload 재현) — get_session은 grouped child도 items에 flat 포함
+    (FE가 top-level/child를 자체 필터링해 클러스터를 그리므로 child 객체 자체가 필요)."""
     from app.repositories.retro import RetroItemRepository, RetroSessionRepository
     from app.routers.retros import get_session, vote_item
 
@@ -298,8 +300,11 @@ async def test_get_session_hides_grouped_children_and_blocks_child_vote():
             out = await get_session(
                 id=session_id, db=s, auth=_auth(), repo=RetroSessionRepository(s, ORG)
             )
-            assert [i.id for i in out.items] == [parent_id]
-            assert out.items[0].grouped_item_ids == [child_id]
+            by_id = {i.id: i for i in out.items}
+            assert set(by_id.keys()) == {parent_id, child_id}
+            assert by_id[parent_id].parent_item_id is None
+            assert by_id[parent_id].grouped_item_ids == [child_id]
+            assert by_id[child_id].parent_item_id == parent_id
 
         async with Session() as s:
             with pytest.raises(HTTPException) as ei:
@@ -308,5 +313,33 @@ async def test_get_session_hides_grouped_children_and_blocks_child_vote():
                     db=s, auth=_auth(), repo=RetroSessionRepository(s, ORG),
                 )
             assert ei.value.status_code == 400
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_export_excludes_grouped_children():
+    """export는 P1 fix와 무관하게 top-level-only 유지(parent에 집계된 vote_count로만 노출)."""
+    from app.repositories.retro import RetroItemRepository, RetroSessionRepository
+    from app.routers.retros import export_session
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            session_id, item_ids = await _seed_session_with_items(s, n_items=2)
+        parent_id, child_id = item_ids
+
+        async with Session() as s:
+            await RetroItemRepository(s).group_under_parent(session_id, child_id, parent_id)
+            await s.commit()
+
+        async with Session() as s:
+            resp = await export_session(
+                id=session_id, db=s, auth=_auth(), repo=RetroSessionRepository(s, ORG)
+            )
+            body = resp.body.decode()
+            # child(session_with_items가 만든 'i1'/'i0' 텍스트)는 그룹핑된 쪽만 제외돼야.
+            assert body.count(" votes)") == 1  # parent 1건만(child 텍스트 라인 없음)
     finally:
         await eng.dispose()

--- a/backend/tests/test_retros.py
+++ b/backend/tests/test_retros.py
@@ -848,8 +848,10 @@ async def test_ungroup_item_not_found_404():
 
 
 @pytest.mark.anyio
-async def test_get_session_hides_grouped_children():
-    """B2 — get_session은 top-level item만 노출·parent에 grouped_item_ids 반영."""
+async def test_get_session_includes_grouped_children_flat():
+    """P1(9f27af8f, 유나 real-payload 재현) — get_session은 grouped child도 items에 그대로
+    포함(flat 배열, parent_item_id 세팅) — FE가 top-level/child를 자체 필터링해 클러스터를
+    그리므로 child 객체 자체가 응답에 있어야 함(id만으론 렌더 불가). export만 top-level-only 유지."""
     client, session, app = await _client()
     try:
         parent = _mock_item()
@@ -882,9 +884,11 @@ async def test_get_session_hides_grouped_children():
                 resp = await c.get(f"/api/v2/retros/{SESSION_ID}")
 
         items = resp.json()["items"]
-        assert len(items) == 1
-        assert items[0]["id"] == str(parent.id)
-        assert items[0]["grouped_item_ids"] == [str(child.id)]
+        by_id = {i["id"]: i for i in items}
+        assert len(items) == 2
+        assert by_id[str(parent.id)]["parent_item_id"] is None
+        assert by_id[str(parent.id)]["grouped_item_ids"] == [str(child.id)]
+        assert by_id[str(child.id)]["parent_item_id"] == str(parent.id)
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary
- 유나 통합 픽셀(real-payload) 재현: 드래그→`POST /group` 200·서버 vote 합산 정상인데 **화면엔 병합이 안 뜸**(배지 0·child row 미렌더·ungroup 0) — 유저 시점엔 아이템이 그냥 사라진 것처럼 보임.
- root cause: cross-layer contract gap — `GET /{id}`의 `items`가 grouped child를 완전히 제외하고 parent에 `grouped_item_ids`(id 배열)만 실었음(B2 원 설계 "top-level만 노출"). FE는 `items`를 top-level(`!parent_item_id`)/child(`parent_item_id` 필터)로 나눠 클러스터를 그리는데, child 객체 자체가 없어 필터 결과가 항상 빈 배열 → null 렌더.

## Fix (PO 결정 — 최소 옵션)
`session GET items`를 **flat 배열로 전부 노출**(child도 `parent_item_id` 세팅된 채 포함). FE는 이미 필터링 로직이 있어 데이터만 주면 그대로 렌더(**FE 변경 불요**). `grouped_item_ids`는 편의상 유지. **export는 top-level-only 그대로**(변경 없음).

## Test plan
- [x] `test_retros.py`(mock): `get_session`이 grouped child를 flat 포함(parent_item_id 세팅) 확인으로 교체.
- [x] `test_retro_grouping_vote_count_realdb.py`(realdb): 같은 확인 + **export는 top-level-only 유지**하는 신규 테스트 추가.
- [x] `uv run pytest tests/test_retros.py ... -q` — 76/76 pass.
- [x] 전체 backend 스위트(2809 pass) 회귀 0 — 무관 실패 세트 동일(flaky 2건 자리바꿈만, retro 코드 참조 0 확인).

🤖 Generated with [Claude Code](https://claude.com/claude-code)