### PR TITLE
fix(billing): PLAN_PRICES 구가 → 신확정가 정정

### DIFF
--- a/apps/web/src/ee/components/billing/billing-tab.tsx
+++ b/apps/web/src/ee/components/billing/billing-tab.tsx
@@ -39,9 +39,11 @@ const STATUS_BADGE: Record<string, string> = {
   cancelled: 'bg-destructive-tint text-destructive',
 };
 
+// E-ADMIN B1(doc e-admin-b1-polar-live-price-ids) — Polar live 확정가와 일치.
+// yearly = 연간 결제 시 월 환산가($490/12·$1490/12 반올림, ~17% 할인).
 const PLAN_PRICES: Record<string, { monthly: number; yearly: number }> = {
-  team: { monthly: 29, yearly: 23 },
-  pro: { monthly: 79, yearly: 63 },
+  team: { monthly: 49, yearly: 41 },
+  pro: { monthly: 149, yearly: 124 },
 };
 
 export function BillingTab({ orgId }: { orgId: string }) {
@@ -137,7 +139,7 @@ export function BillingTab({ orgId }: { orgId: string }) {
                 className={`px-3 py-1 rounded text-sm font-medium border transition-colors ${selectedCycle === cycle ? 'bg-primary text-primary-foreground border-primary' : 'border-border text-muted-foreground hover:border-primary/50'}`}
               >
                 {cycle === 'monthly' ? '월간' : '연간'}
-                {cycle === 'yearly' && <span className="ml-1 text-xs text-green-600">(20% 할인)</span>}
+                {cycle === 'yearly' && <span className="ml-1 text-xs text-green-600">(17% 할인)</span>}
               </button>
             ))}
           </div>


### PR DESCRIPTION
## Summary
E-ADMIN B1 배선 중 디디가 적출한 FE 버그(내 스코프, `apps/web`). 백엔드 pricing 카탈로그는 Team $49/mo·Pro $149/mo로 이미 정정됐는데, `apps/web/src/ee/components/billing/billing-tab.tsx`의 `PLAN_PRICES`가 독립 하드코딩(구가 $29/$79)이라 연간 토글 등에서 여전히 틀린 가격이 보이던 버그.

- `PLAN_PRICES`: team `{monthly:29, yearly:23}` → `{monthly:49, yearly:41}`(490/12 반올림), pro `{monthly:79, yearly:63}` → `{monthly:149, yearly:124}`(1490/12 반올림). doc `e-admin-b1-polar-live-price-ids`(Polar live 확정가) 값과 일치.
- 같은 근본이라 "(20% 할인)" 라벨도 "(17% 할인)"로 동시 정정(실제 할인율 ~16.67%).
- `ee-stubs/components/billing/billing-tab.tsx`는 no-op 스텁이라 변경 불요(확인함).

**SSOT 근본 리팩터는 범위 밖**: 이 값을 BE `_PLAN_CATALOG`/pricing API에서 받아오게 하는 것이 근본이지만, 디디의 B1 `pricing_versions` API가 SSOT로 확정되면 그때 소비하는 게 맞음(현재 계약 미확정) — 이번 PR은 회귀 차단용 값 정정만.

## Test plan
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm lint` — 0 errors(기존 무관 warning 27건 그대로)
- [x] `pnpm build` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)