### PR TITLE
feat(e-loop-ledger): S1 — loop_runs 척추 테이블(story e333e8b1)

### DIFF
--- a/backend/alembic/versions/0149_loop_runs.py
+++ b/backend/alembic/versions/0149_loop_runs.py
@@ -1,0 +1,131 @@
+"""E-LOOP-LEDGER S1(story e333e8b1): loop_runs 척추 테이블(append-only spine).
+
+Revision ID: 0149
+Revises: 0148
+Create Date: 2026-07-01
+
+블루프린트 `e-loop-ledger-blueprint` §1. loop(goal→brief→variants→decision→execute→
+measure→outcome) 반복의 spine 엔티티 — 나머지(hypotheses/docs/assets/gate)는 EXTEND,
+이 테이블만 신설. `chosen_artifact_id`는 컬럼만 만들고 FK 제약은 없다(S2가 loop_artifacts
+테이블 생성 후 ALTER TABLE ADD CONSTRAINT로 잠근다 — 순환 의존을 컬럼 재생성 없이 해소).
+
+status FSM: draft→briefing→generating→deciding→executing→measuring→closed 순차 진행.
+abandoned는 closed/measuring 이전 어느 상태에서든 진입 가능(조기 중단). closed/abandoned는
+terminal(역전이 없음) — app/models/hypothesis.py의 is_valid_transition 패턴과 동형.
+
+idempotent: 테이블 단위 inspect 가드(0113 hypotheses 선례와 동일 클래스).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+
+revision = "0149"
+down_revision = "0148"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    existing = set(insp.get_table_names())
+
+    if "loop_runs" not in existing:
+        op.create_table(
+            "loop_runs",
+            sa.Column("id", UUID(as_uuid=True), primary_key=True),
+            sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+            sa.Column(
+                "project_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("projects.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            # self-FK — lineage(N⇒N-1). SET NULL(CASCADE 아님): soft-delete 테이블이라 실
+            # DELETE 드물지만, 혹시 발생해도 lineage 전체 연쇄삭제보다 고아 허용이 안전.
+            sa.Column(
+                "parent_loop_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("loop_runs.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column(
+                "hypothesis_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("hypotheses.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column(
+                "brief_doc_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("docs.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column(
+                "decision_gate_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("gate.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            # loop_artifacts(S2)가 아직 없어 FK 없이 컬럼만.
+            sa.Column("chosen_artifact_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("recipe_slug", sa.Text(), nullable=True),
+            sa.Column("title", sa.Text(), nullable=False),
+            sa.Column(
+                "goal_tags",
+                ARRAY(sa.Text()),
+                nullable=False,
+                server_default=sa.text("'{}'::text[]"),
+            ),
+            sa.Column("status", sa.String(24), nullable=False, server_default="draft"),
+            sa.Column("outcome_snapshot", JSONB, nullable=True),
+            sa.Column("outcome_attributed_at", sa.DateTime(timezone=True), nullable=True),
+            # FK 비강제(hypotheses.owner_member_id/assignee_id 동형 컨벤션) — 서버 resolve_member 해소.
+            sa.Column("created_by_member_id", UUID(as_uuid=True), nullable=False),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+            sa.CheckConstraint(
+                "status IN ('draft','briefing','generating','deciding','executing',"
+                "'measuring','closed','abandoned')",
+                name="ck_loop_runs_status",
+            ),
+            sa.CheckConstraint(
+                "parent_loop_id IS NULL OR parent_loop_id <> id",
+                name="ck_loop_runs_parent_not_self",
+            ),
+        )
+        op.create_index("ix_loop_runs_org_id", "loop_runs", ["org_id"])
+        op.create_index(
+            "ix_loop_runs_org_project_status_created_at",
+            "loop_runs",
+            ["org_id", "project_id", "status", sa.text("created_at DESC")],
+        )
+        op.create_index("ix_loop_runs_parent_loop_id", "loop_runs", ["parent_loop_id"])
+        op.create_index(
+            "ix_loop_runs_goal_tags_gin",
+            "loop_runs",
+            ["goal_tags"],
+            postgresql_using="gin",
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    existing = set(insp.get_table_names())
+
+    if "loop_runs" in existing:
+        op.drop_table("loop_runs")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -5,6 +5,7 @@ from app.models.agent_routing_rule import AgentRoutingRule
 from app.models.agent_run import AgentRun
 from app.models.agent_session import AgentSession
 from app.models.bridge import BridgeChannelMapping, BridgeUserMapping
+from app.models.gate import Gate
 from app.models.hitl import HitlPolicy, HitlRequest
 from app.models.mockup import MockupComponent, MockupPage, MockupScenario, MockupVersion, UsageMeter
 from app.models.user import RefreshToken, User
@@ -25,6 +26,7 @@ from app.models.notification_preference import NotificationPreference
 from app.models.organization import Organization
 from app.models.pm import Epic, Sprint, Story, Task
 from app.models.hypothesis import Hypothesis, HypothesisEpicLink, HypothesisStoryLink
+from app.models.loop import LoopRun
 from app.models.story_assignee import StoryAssignee
 from app.models.project import OrgMember, Project
 from app.models.project_setting import ProjectSetting
@@ -58,6 +60,7 @@ __all__ = [
     "AgentSession",
     "BridgeChannelMapping",
     "BridgeUserMapping",
+    "Gate",
     "HitlPolicy",
     "HitlRequest",
     "MockupComponent",
@@ -78,6 +81,7 @@ __all__ = [
     "HypothesisEpicLink",
     "HypothesisStoryLink",
     "InboxItem",
+    "LoopRun",
     "Meeting",
     "Notification",
     "Conversation",

--- a/backend/app/models/loop.py
+++ b/backend/app/models/loop.py
@@ -1,0 +1,114 @@
+"""E-LOOP-LEDGER S1: loop_runs 척추 엔티티(append-only spine).
+
+블루프린트 `e-loop-ledger-blueprint` §1 구현. 반복(loop) — goal→brief→variants→
+decision→execute→measure→outcome — 의 spine만 신설하고, 나머지(hypotheses/docs/
+assets/gate)는 기존 엔티티를 EXTEND(FK로 연결)한다.
+
+status FSM (§1):
+    draft → briefing → generating → deciding → executing → measuring → closed
+    draft | briefing | generating | deciding | executing | measuring → abandoned
+    (closed | abandoned → 어디로도 역전이 금지 — terminal. app/models/hypothesis.py의
+    is_valid_transition 패턴과 동형.)
+
+chosen_artifact_id: loop_artifacts(S2, 후속 스토리)를 가리키나 이 마이그 시점엔 그
+테이블이 없어 FK 제약이 없다(컬럼만). S2 마이그가 ALTER TABLE ADD CONSTRAINT로 잠근다.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    ARRAY,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+from app.models.base import OrgScopedMixin, SoftDeleteMixin, TimestampMixin
+
+# §1 상태 8종 (DB CHECK와 동기)
+LOOP_RUN_STATUSES = frozenset(
+    {"draft", "briefing", "generating", "deciding", "executing", "measuring", "closed", "abandoned"}
+)
+
+_NON_TERMINAL_STATUSES = frozenset(
+    {"draft", "briefing", "generating", "deciding", "executing", "measuring"}
+)
+
+# 합법 전이: (from, to). closed/abandoned는 terminal(역전이 없음).
+_VALID_TRANSITIONS: set[tuple[str, str]] = {
+    ("draft", "briefing"),
+    ("briefing", "generating"),
+    ("generating", "deciding"),
+    ("deciding", "executing"),
+    ("executing", "measuring"),
+    ("measuring", "closed"),
+    # 조기 중단 — closed/abandoned 이전 어느 비-terminal 상태에서든 abandoned 진입 가능.
+    *{(s, "abandoned") for s in _NON_TERMINAL_STATUSES},
+}
+
+
+def is_valid_transition(from_status: str, to_status: str) -> bool:
+    return (from_status, to_status) in _VALID_TRANSITIONS
+
+
+class LoopRun(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
+    __tablename__ = "loop_runs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False
+    )
+    parent_loop_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("loop_runs.id", ondelete="SET NULL"), nullable=True
+    )
+    hypothesis_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("hypotheses.id", ondelete="SET NULL"), nullable=True
+    )
+    brief_doc_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("docs.id", ondelete="SET NULL"), nullable=True
+    )
+    decision_gate_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("gate.id", ondelete="SET NULL"), nullable=True
+    )
+    # loop_artifacts(S2) 생성 전이라 FK 없음 — 컬럼만.
+    chosen_artifact_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    recipe_slug: Mapped[str | None] = mapped_column(Text, nullable=True)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    goal_tags: Mapped[list[str]] = mapped_column(
+        ARRAY(Text), nullable=False, server_default=text("'{}'::text[]"), default=list
+    )
+    status: Mapped[str] = mapped_column(String(24), nullable=False, server_default="draft")
+    outcome_snapshot: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    outcome_attributed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # FK 비강제(hypotheses.owner_member_id/assignee_id 동형 컨벤션) — resolve_member 서비스 해소.
+    created_by_member_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('draft','briefing','generating','deciding','executing',"
+            "'measuring','closed','abandoned')",
+            name="ck_loop_runs_status",
+        ),
+        CheckConstraint(
+            "parent_loop_id IS NULL OR parent_loop_id <> id",
+            name="ck_loop_runs_parent_not_self",
+        ),
+        Index(
+            "ix_loop_runs_org_project_status_created_at",
+            "org_id",
+            "project_id",
+            "status",
+            text("created_at DESC"),
+        ),
+        Index("ix_loop_runs_parent_loop_id", "parent_loop_id"),
+        Index("ix_loop_runs_goal_tags_gin", "goal_tags", postgresql_using="gin"),
+    )

--- a/backend/tests/test_e_loop_ledger_s1_loop_runs.py
+++ b/backend/tests/test_e_loop_ledger_s1_loop_runs.py
@@ -1,0 +1,221 @@
+"""E-LOOP-LEDGER S1(story e333e8b1): loop_runs 척추 테이블 검증.
+
+DB env(ALEMBIC_DATABASE_URL) 없으면 realdb 파트 skip — status FSM 단위 테스트는 DB 불요."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.models.loop import LOOP_RUN_STATUSES, is_valid_transition
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── status FSM: legal + illegal 양방향(비-tautological — 까심 QA 사전 요구) ──────
+
+
+def test_transition_table_legal_sequential():
+    assert is_valid_transition("draft", "briefing")
+    assert is_valid_transition("briefing", "generating")
+    assert is_valid_transition("generating", "deciding")
+    assert is_valid_transition("deciding", "executing")
+    assert is_valid_transition("executing", "measuring")
+    assert is_valid_transition("measuring", "closed")
+
+
+def test_transition_table_legal_abandon_from_any_non_terminal():
+    for s in ("draft", "briefing", "generating", "deciding", "executing", "measuring"):
+        assert is_valid_transition(s, "abandoned"), f"{s}->abandoned should be legal"
+
+
+def test_transition_table_illegal_skips():
+    # 순차 스킵 — briefing 건너뛰고 generating으로 바로는 금지.
+    assert not is_valid_transition("draft", "generating")
+    assert not is_valid_transition("draft", "deciding")
+    assert not is_valid_transition("briefing", "executing")
+
+
+def test_transition_table_illegal_backward():
+    assert not is_valid_transition("briefing", "draft")
+    assert not is_valid_transition("measuring", "executing")
+    assert not is_valid_transition("closed", "measuring")
+
+
+def test_transition_table_illegal_from_terminal():
+    # closed/abandoned=terminal — 어디로도 전이 불가(자기 자신 포함).
+    for terminal in ("closed", "abandoned"):
+        for target in LOOP_RUN_STATUSES:
+            assert not is_valid_transition(terminal, target), f"{terminal}->{target} should be illegal"
+
+
+def test_transition_table_illegal_into_terminal_twice():
+    # closed/abandoned로의 재진입(이미 terminal인 상태에서)은 위 테스트로 커버됨 — 여기선
+    # terminal이 아닌 상태에서 abandoned/closed 외의 다른 terminal로 직행 금지 확인.
+    assert not is_valid_transition("draft", "closed")  # closed는 measuring에서만 도달
+    assert not is_valid_transition("briefing", "closed")
+
+
+def test_loop_run_statuses_matches_check_constraint_values():
+    assert LOOP_RUN_STATUSES == {
+        "draft", "briefing", "generating", "deciding", "executing", "measuring", "closed", "abandoned",
+    }
+
+
+# ── realdb: 모델 제약 실증 ────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+@pytest.mark.anyio
+async def test_status_check_constraint_rejects_invalid_value():
+    from app.models.loop import LoopRun
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = uuid.uuid4()
+            project_id = await _seed_project(session, org_id)
+            run = LoopRun(
+                id=uuid.uuid4(), org_id=org_id, project_id=project_id,
+                title="test loop", status="not_a_real_status",
+                created_by_member_id=uuid.uuid4(),
+            )
+            session.add(run)
+            with pytest.raises(IntegrityError):
+                await session.flush()
+            await session.rollback()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+@pytest.mark.anyio
+async def test_parent_loop_id_cannot_reference_self():
+    from app.models.loop import LoopRun
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = uuid.uuid4()
+            project_id = await _seed_project(session, org_id)
+            loop_id = uuid.uuid4()
+            run = LoopRun(
+                id=loop_id, org_id=org_id, project_id=project_id,
+                parent_loop_id=loop_id,  # 자기 자신 참조 — CHECK 위반이어야
+                title="self-parent loop", created_by_member_id=uuid.uuid4(),
+            )
+            session.add(run)
+            with pytest.raises(IntegrityError):
+                await session.flush()
+            await session.rollback()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+@pytest.mark.anyio
+async def test_create_and_read_loop_run_defaults():
+    from app.models.loop import LoopRun
+    from sqlalchemy import select
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = uuid.uuid4()
+            project_id = await _seed_project(session, org_id)
+            run_id = uuid.uuid4()
+            member_id = uuid.uuid4()
+            run = LoopRun(
+                id=run_id, org_id=org_id, project_id=project_id,
+                title="my first loop", created_by_member_id=member_id,
+            )
+            session.add(run)
+            await session.commit()
+
+            fetched = (
+                await session.execute(select(LoopRun).where(LoopRun.id == run_id))
+            ).scalar_one()
+            assert fetched.status == "draft"  # server_default
+            assert fetched.goal_tags == []  # server_default '{}'
+            assert fetched.outcome_snapshot is None
+            assert fetched.outcome_attributed_at is None
+            assert fetched.parent_loop_id is None
+            assert fetched.chosen_artifact_id is None
+            assert fetched.deleted_at is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+@pytest.mark.anyio
+async def test_parent_loop_lineage_and_set_null_on_parent_delete():
+    from app.models.loop import LoopRun
+    from sqlalchemy import select
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id = uuid.uuid4()
+            project_id = await _seed_project(session, org_id)
+            member_id = uuid.uuid4()
+            parent_id = uuid.uuid4()
+            child_id = uuid.uuid4()
+            session.add(LoopRun(
+                id=parent_id, org_id=org_id, project_id=project_id,
+                title="parent loop", created_by_member_id=member_id,
+            ))
+            await session.flush()
+            session.add(LoopRun(
+                id=child_id, org_id=org_id, project_id=project_id,
+                parent_loop_id=parent_id, title="child loop",
+                created_by_member_id=member_id,
+            ))
+            await session.commit()
+
+            # 하드 delete(정상 경로는 soft-delete지만, ON DELETE SET NULL 실증엔 실 DELETE 필요).
+            await session.execute(text("DELETE FROM loop_runs WHERE id = :id"), {"id": parent_id})
+            await session.commit()
+
+            child = (
+                await session.execute(select(LoopRun).where(LoopRun.id == child_id))
+            ).scalar_one()
+            assert child.parent_loop_id is None  # CASCADE 아닌 SET NULL — 자식 생존
+    finally:
+        await engine.dispose()
+
+
+async def _seed_project(session, org_id: uuid.UUID) -> uuid.UUID:
+    project_id = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+    await session.execute(
+        text(
+            "INSERT INTO organizations (id, name, slug, created_at) "
+            "VALUES (:org_id, 'Loop Test Org', :slug, :now) ON CONFLICT (id) DO NOTHING"
+        ),
+        {"org_id": org_id, "slug": f"loop-test-{org_id}", "now": now},
+    )
+    await session.execute(
+        text(
+            "INSERT INTO projects (id, org_id, name) VALUES (:pid, :org_id, 'Loop Test Project')"
+        ),
+        {"pid": project_id, "org_id": org_id},
+    )
+    await session.commit()
+    return project_id


### PR DESCRIPTION
## Summary
- 블루프린트 `e-loop-ledger-blueprint` §1 — 반복(loop) 관리의 append-only spine. 나머지(hypotheses/docs/assets/gate)는 EXTEND, `loop_runs`만 신설. `app/models/hypothesis.py`(E1, 최근 유사 규모 신엔티티)의 구조/전이 패턴을 그대로 미러.
- 마이그 **0149**(`alembic heads` 실측 확인 후 정정 — AC의 "0144"는 이미 retro/billing epic에 소비돼 무효, PO가 사전에 동일하게 예측함).
- **status FSM** 8값(`draft→briefing→generating→deciding→executing→measuring→closed` 순차 + `abandoned`는 비-terminal 어디서든 진입 가능, `closed`/`abandoned`는 terminal) + `is_valid_transition`.
- **`chosen_artifact_id`**: 컬럼만 생성(FK 없음) — `loop_artifacts`(S2, 후속 스토리)가 아직 없어 순환 의존을 컬럼 재생성 없이 해소. S2가 `ALTER TABLE ADD CONSTRAINT`로 잠근다.
- **`parent_loop_id`** self-FK는 `ON DELETE SET NULL`(CASCADE 아님 — lineage 전체 연쇄삭제 회피, soft-delete 테이블이라 실 DELETE 드물지만 안전 우선).
- **`goal_tags`** `ARRAY(Text)` + GIN 인덱스(Context Pack 태그검색 대비, `hypotheses.metric_definition` GIN 선례 미러).
- ⚠️ **부수 발견**: `Gate` 모델이 `app/models/__init__.py`에 아예 등록돼 있지 않았음 — `Base.metadata.create_all()`(fresh-runnable 테스트 경로)이 `loop_runs.decision_gate_id`의 FK 대상 테이블을 못 찾아 실패하는 것으로 발견. `Gate` import+`__all__` 등록 추가(마이그 불요, 기존 `gate` 테이블은 이미 존재).

## Test plan
- [x] 신규 11개: status 전이 legal(순차+abandon) + illegal(스킵/역행/terminal이탈) 양방향(비-tautological, 까심 QA 사전 요구사항 반영) · CHECK 제약 2종(잘못된 status·self-parent) realdb 실증 · 기본값(status=draft·goal_tags=[]·outcome_snapshot=None) · self-FK ON DELETE SET NULL(부모 삭제 시 자식 생존) 실증.
- [x] 실 PG(0096 baseline→0149) upgrade/downgrade 양방향 검증(throwaway `pgvector/pgvector:pg16`).
- [x] `Base.metadata.create_all()` fresh-runnable 확인(Gate 등록 후 정상 동작).
- [x] 전체 스위트 2615 pass(throwaway PG) — pre-existing 12건 실패만(이 변경과 무관, 세션 내내 관측된 동일 목록).
- [x] 컨테이너 정리 완료(공유 컨테이너 미사용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)