### PR TITLE
feat(e-loop-ledger): S2 — loop_artifacts(variant) 테이블(story 9731403a)

### DIFF
--- a/backend/alembic/versions/0150_loop_artifacts.py
+++ b/backend/alembic/versions/0150_loop_artifacts.py
@@ -1,0 +1,142 @@
+"""E-LOOP-LEDGER S2(story 9731403a): loop_artifacts(variant) 테이블 + S1 지연 FK 마무리.
+
+Revision ID: 0150
+Revises: 0149
+Create Date: 2026-07-01
+
+블루프린트 §1/§2. variant 후보 + per-variant 결정/이유(choose/rejection reason=moat 신호원).
+
+- `loop_runs.chosen_artifact_id`의 FK를 여기서 잠근다(S1이 컬럼만 만들어둔 것 — 이 테이블이
+  이제 존재하므로 ALTER TABLE ADD CONSTRAINT, 컬럼 재생성 없음).
+- partial UNIQUE(loop_id, variant_group) WHERE decision='chosen' — 슬롯당 승자 ≤1.
+- asset_links.source_type CHECK를 넓혀 'loop_artifact' 추가(DROP+CREATE — Postgres는 CHECK
+  in-place ALTER 불가, 0145 phase CHECK 확장과 동일 패턴).
+
+idempotent: 테이블 단위 inspect 가드(0113/0149 선례와 동일 클래스).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision = "0150"
+down_revision = "0149"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    existing = set(insp.get_table_names())
+
+    if "loop_artifacts" not in existing:
+        op.create_table(
+            "loop_artifacts",
+            sa.Column("id", UUID(as_uuid=True), primary_key=True),
+            sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+            sa.Column(
+                "loop_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("loop_runs.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "asset_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("assets.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("variant_group", sa.Text(), nullable=False),
+            sa.Column("variant_label", sa.Text(), nullable=False),
+            sa.Column("decision", sa.String(16), nullable=False, server_default="pending"),
+            sa.Column("choose_reason", sa.Text(), nullable=True),
+            # ⭐moat 신호원 — 왜 반려했나. 필수화(게이트 강제)는 S5 스코프, 스키마는 nullable.
+            sa.Column("rejection_reason", sa.Text(), nullable=True),
+            sa.Column(
+                "generation_metadata",
+                JSONB,
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+            ),
+            sa.Column("sort_order", sa.Integer(), nullable=False, server_default="0"),
+            # FK 비강제(hypotheses.owner_member_id 동형 컨벤션) — resolve_member 서비스 해소.
+            sa.Column("created_by_member_id", UUID(as_uuid=True), nullable=False),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                onupdate=sa.func.now(),
+                nullable=False,
+            ),
+            sa.CheckConstraint(
+                "decision IN ('pending','chosen','rejected')",
+                name="ck_loop_artifacts_decision",
+            ),
+        )
+        op.create_index("ix_loop_artifacts_org_id", "loop_artifacts", ["org_id"])
+        op.create_index(
+            "ix_loop_artifacts_loop_variant_group",
+            "loop_artifacts",
+            ["loop_id", "variant_group", "sort_order"],
+        )
+        op.create_index("ix_loop_artifacts_asset_id", "loop_artifacts", ["asset_id"])
+        # 슬롯(variant_group)당 승자 ≤1 — chosen 행만 대상인 partial unique(0108 doc_share_tokens
+        # active 1개 보장과 동일 패턴).
+        op.create_index(
+            "uq_loop_artifacts_chosen_per_group",
+            "loop_artifacts",
+            ["loop_id", "variant_group"],
+            unique=True,
+            postgresql_where=sa.text("decision = 'chosen'"),
+        )
+
+    # S1 지연 FK 마무리 — loop_runs.chosen_artifact_id는 컬럼만 있었다.
+    existing_fks = {fk["name"] for fk in insp.get_foreign_keys("loop_runs")}
+    if "fk_loop_runs_chosen_artifact_id" not in existing_fks:
+        op.create_foreign_key(
+            "fk_loop_runs_chosen_artifact_id",
+            "loop_runs",
+            "loop_artifacts",
+            ["chosen_artifact_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+    # asset_links.source_type CHECK 확장 — Postgres는 CHECK in-place ALTER 불가라 DROP+CREATE
+    # (0145 retro_sessions.phase CHECK 확장과 동일 패턴).
+    op.drop_constraint("ck_asset_links_source_type", "asset_links", type_="check")
+    op.create_check_constraint(
+        "ck_asset_links_source_type",
+        "asset_links",
+        "source_type IN ('conversation_message','story','doc','manual','loop_artifact')",
+    )
+
+
+def downgrade() -> None:
+    # 주의: asset_links에 source_type='loop_artifact' 행이 이미 있으면 아래 CHECK 재축소가
+    # 위반으로 실패한다(0145 phase CHECK 축소와 동일 한계 — best-effort, 데이터 역매핑 없음).
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+
+    op.drop_constraint("ck_asset_links_source_type", "asset_links", type_="check")
+    op.create_check_constraint(
+        "ck_asset_links_source_type",
+        "asset_links",
+        "source_type IN ('conversation_message','story','doc','manual')",
+    )
+
+    existing_fks = {fk["name"] for fk in insp.get_foreign_keys("loop_runs")}
+    if "fk_loop_runs_chosen_artifact_id" in existing_fks:
+        op.drop_constraint("fk_loop_runs_chosen_artifact_id", "loop_runs", type_="foreignkey")
+
+    existing = set(insp.get_table_names())
+    if "loop_artifacts" in existing:
+        op.drop_table("loop_artifacts")

--- a/backend/app/models/asset.py
+++ b/backend/app/models/asset.py
@@ -24,7 +24,8 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.models.base import Base, OrgScopedMixin, SoftDeleteMixin, TimestampMixin
 
 # asset_links.source_type 허용값(catch: AC6 다형). CHECK + 서비스 가드 양쪽에서 강제.
-ASSET_LINK_SOURCE_TYPES = ("conversation_message", "story", "doc", "manual")
+# 'loop_artifact': E-LOOP-LEDGER S2(0150) — CHECK 제약도 그 마이그에서 동일하게 확장됨.
+ASSET_LINK_SOURCE_TYPES = ("conversation_message", "story", "doc", "manual", "loop_artifact")
 
 
 class AssetFolder(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
@@ -111,7 +112,7 @@ class AssetLink(Base, OrgScopedMixin, TimestampMixin):
             "asset_id", "source_type", "source_id", name="uq_asset_links_asset_source"
         ),
         CheckConstraint(
-            "source_type IN ('conversation_message','story','doc','manual')",
+            "source_type IN ('conversation_message','story','doc','manual','loop_artifact')",
             name="ck_asset_links_source_type",
         ),
         Index("ix_asset_links_source", "source_type", "source_id"),

--- a/backend/app/models/loop.py
+++ b/backend/app/models/loop.py
@@ -85,8 +85,18 @@ class LoopRun(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     decision_gate_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("gate.id", ondelete="SET NULL"), nullable=True
     )
+    # name+use_alter=True 필수 — loop_artifacts.loop_id→loop_runs.id 와 함께 진짜 2-테이블
+    # FK 순환을 이룬다(parent_loop_id self-FK와 다른 클래스). 무명이면 SQLAlchemy
+    # Base.metadata.drop_all()이 DROP 순서를 못 풀어 CircularDependencyError(까심 QA 발견,
+    # fresh-schema 라운드트립 쓰는 테스트 다수가 회귀). 마이그 0150의
+    # op.create_foreign_key("fk_loop_runs_chosen_artifact_id", ...)와 이름 일치 필수.
     chosen_artifact_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("loop_artifacts.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True),
+        ForeignKey(
+            "loop_artifacts.id", ondelete="SET NULL",
+            name="fk_loop_runs_chosen_artifact_id", use_alter=True,
+        ),
+        nullable=True
     )
     recipe_slug: Mapped[str | None] = mapped_column(Text, nullable=True)
     title: Mapped[str] = mapped_column(Text, nullable=False)

--- a/backend/app/models/loop.py
+++ b/backend/app/models/loop.py
@@ -1,8 +1,8 @@
-"""E-LOOP-LEDGER S1: loop_runs 척추 엔티티(append-only spine).
+"""E-LOOP-LEDGER S1+S2: loop_runs 척추 + loop_artifacts(variant) 엔티티.
 
-블루프린트 `e-loop-ledger-blueprint` §1 구현. 반복(loop) — goal→brief→variants→
-decision→execute→measure→outcome — 의 spine만 신설하고, 나머지(hypotheses/docs/
-assets/gate)는 기존 엔티티를 EXTEND(FK로 연결)한다.
+블루프린트 `e-loop-ledger-blueprint` §1/§2 구현. 반복(loop) — goal→brief→variants→
+decision→execute→measure→outcome — 의 spine + variant 후보를 신설하고, 나머지
+(hypotheses/docs/assets/gate)는 기존 엔티티를 EXTEND(FK로 연결)한다.
 
 status FSM (§1):
     draft → briefing → generating → deciding → executing → measuring → closed
@@ -10,8 +10,10 @@ status FSM (§1):
     (closed | abandoned → 어디로도 역전이 금지 — terminal. app/models/hypothesis.py의
     is_valid_transition 패턴과 동형.)
 
-chosen_artifact_id: loop_artifacts(S2, 후속 스토리)를 가리키나 이 마이그 시점엔 그
-테이블이 없어 FK 제약이 없다(컬럼만). S2 마이그가 ALTER TABLE ADD CONSTRAINT로 잠근다.
+chosen_artifact_id: S1 마이그(0149) 시점엔 loop_artifacts가 없어 컬럼만 있었으나, S2
+마이그(0150)가 ALTER TABLE ADD CONSTRAINT로 FK를 잠갔다 — 이 모델(ORM 레벨)도 동일하게
+FK를 선언해야 fresh-runnable(create_all) 스키마가 마이그 스키마와 일치한다(선언 안 하면
+model↔migration drift — Gate 미등록 사건과 동일 클래스).
 """
 from __future__ import annotations
 
@@ -24,6 +26,7 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Index,
+    Integer,
     String,
     Text,
     text,
@@ -32,7 +35,10 @@ from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
-from app.models.base import OrgScopedMixin, SoftDeleteMixin, TimestampMixin
+from app.models.base import OrgScopedMixin, TimestampMixin, SoftDeleteMixin
+
+# §2 decision 3종
+LOOP_ARTIFACT_DECISIONS = frozenset({"pending", "chosen", "rejected"})
 
 # §1 상태 8종 (DB CHECK와 동기)
 LOOP_RUN_STATUSES = frozenset(
@@ -79,8 +85,9 @@ class LoopRun(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     decision_gate_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("gate.id", ondelete="SET NULL"), nullable=True
     )
-    # loop_artifacts(S2) 생성 전이라 FK 없음 — 컬럼만.
-    chosen_artifact_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    chosen_artifact_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("loop_artifacts.id", ondelete="SET NULL"), nullable=True
+    )
     recipe_slug: Mapped[str | None] = mapped_column(Text, nullable=True)
     title: Mapped[str] = mapped_column(Text, nullable=False)
     goal_tags: Mapped[list[str]] = mapped_column(
@@ -111,4 +118,52 @@ class LoopRun(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
         ),
         Index("ix_loop_runs_parent_loop_id", "parent_loop_id"),
         Index("ix_loop_runs_goal_tags_gin", "goal_tags", postgresql_using="gin"),
+    )
+
+
+class LoopArtifact(Base, OrgScopedMixin, TimestampMixin):
+    """§2: loop당 variant 후보 + per-variant 결정/이유. rejection_reason=moat 신호원."""
+
+    __tablename__ = "loop_artifacts"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    loop_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("loop_runs.id", ondelete="CASCADE"), nullable=False
+    )
+    asset_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("assets.id", ondelete="CASCADE"), nullable=False
+    )
+    variant_group: Mapped[str] = mapped_column(Text, nullable=False)
+    variant_label: Mapped[str] = mapped_column(Text, nullable=False)
+    decision: Mapped[str] = mapped_column(String(16), nullable=False, server_default="pending")
+    choose_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # ⭐moat 신호원 — 왜 반려했나. 필수화(게이트 강제)는 S5 스코프, 스키마는 nullable.
+    rejection_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    generation_metadata: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb"), default=dict
+    )
+    sort_order: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    # FK 비강제(hypotheses.owner_member_id 동형 컨벤션) — resolve_member 서비스 해소.
+    created_by_member_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+
+    __table_args__ = (
+        CheckConstraint(
+            "decision IN ('pending','chosen','rejected')",
+            name="ck_loop_artifacts_decision",
+        ),
+        Index(
+            "ix_loop_artifacts_loop_variant_group",
+            "loop_id",
+            "variant_group",
+            "sort_order",
+        ),
+        Index("ix_loop_artifacts_asset_id", "asset_id"),
+        # 슬롯(variant_group)당 승자 ≤1 — chosen 행만 대상인 partial unique.
+        Index(
+            "uq_loop_artifacts_chosen_per_group",
+            "loop_id",
+            "variant_group",
+            unique=True,
+            postgresql_where=text("decision = 'chosen'"),
+        ),
     )

--- a/backend/tests/test_e_loop_ledger_s2_loop_artifacts.py
+++ b/backend/tests/test_e_loop_ledger_s2_loop_artifacts.py
@@ -1,0 +1,322 @@
+"""E-LOOP-LEDGER S2(story 9731403a): loop_artifacts(variant) 테이블 검증.
+
+DB env(ALEMBIC_DATABASE_URL) 없으면 skip. 특히 까심 QA 사전 요구사항 — partial UNIQUE
+(chosen 슬롯당 1개) + CHECK + chosen_artifact_id FK 순환 정합을 비-tautological(실제
+위반이 거부되는지 직접 재현)로 검증한다."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _seed_org_project(session) -> tuple[uuid.UUID, uuid.UUID]:
+    org_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    await session.execute(
+        text(
+            "INSERT INTO organizations (id, name, slug) VALUES (:org_id, 'S2 Org', :slug) "
+            "ON CONFLICT (id) DO NOTHING"
+        ),
+        {"org_id": org_id, "slug": f"s2-org-{org_id}"},
+    )
+    await session.execute(
+        text("INSERT INTO projects (id, org_id, name) VALUES (:pid, :org_id, 'S2 Project')"),
+        {"pid": project_id, "org_id": org_id},
+    )
+    await session.commit()
+    return org_id, project_id
+
+
+async def _seed_loop(session, org_id, project_id) -> uuid.UUID:
+    from app.models.loop import LoopRun
+
+    loop_id = uuid.uuid4()
+    session.add(LoopRun(
+        id=loop_id, org_id=org_id, project_id=project_id,
+        title="loop for artifacts", created_by_member_id=uuid.uuid4(),
+    ))
+    await session.commit()
+    return loop_id
+
+
+async def _seed_asset(session, org_id, project_id) -> uuid.UUID:
+    asset_id = uuid.uuid4()
+    await session.execute(
+        text(
+            "INSERT INTO assets (id, org_id, project_id, container, object_path, name, content_type, "
+            "size_bytes, created_by) VALUES (:id, :org_id, :project_id, 'sprintable-memo-attachments', "
+            ":path, :name, 'image/png', 100, :created_by)"
+        ),
+        {"id": asset_id, "org_id": org_id, "project_id": project_id, "path": f"loop/{asset_id}.png",
+         "name": f"variant-{asset_id}.png", "created_by": uuid.uuid4()},
+    )
+    await session.commit()
+    return asset_id
+
+
+@pytest.mark.anyio
+async def test_create_artifact_defaults():
+    from app.models.loop import LoopArtifact
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id, project_id = await _seed_org_project(session)
+            loop_id = await _seed_loop(session, org_id, project_id)
+            asset_id = await _seed_asset(session, org_id, project_id)
+
+            artifact_id = uuid.uuid4()
+            session.add(LoopArtifact(
+                id=artifact_id, org_id=org_id, loop_id=loop_id, asset_id=asset_id,
+                variant_group="headline", variant_label="A", created_by_member_id=uuid.uuid4(),
+            ))
+            await session.commit()
+
+            fetched = (
+                await session.execute(select(LoopArtifact).where(LoopArtifact.id == artifact_id))
+            ).scalar_one()
+            assert fetched.decision == "pending"
+            assert fetched.generation_metadata == {}
+            assert fetched.sort_order == 0
+            assert fetched.choose_reason is None
+            assert fetched.rejection_reason is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_decision_check_constraint_rejects_invalid_value():
+    from app.models.loop import LoopArtifact
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id, project_id = await _seed_org_project(session)
+            loop_id = await _seed_loop(session, org_id, project_id)
+            asset_id = await _seed_asset(session, org_id, project_id)
+
+            session.add(LoopArtifact(
+                id=uuid.uuid4(), org_id=org_id, loop_id=loop_id, asset_id=asset_id,
+                variant_group="headline", variant_label="A", decision="maybe",
+                created_by_member_id=uuid.uuid4(),
+            ))
+            with pytest.raises(IntegrityError):
+                await session.flush()
+            await session.rollback()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_second_chosen_in_same_variant_group_rejected():
+    """까심 QA 사전 요구 — partial UNIQUE(loop_id, variant_group) WHERE chosen을 실제
+    두 번째 chosen INSERT로 재현(happy-path 1건만으로는 tautological)."""
+    from app.models.loop import LoopArtifact
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id, project_id = await _seed_org_project(session)
+            loop_id = await _seed_loop(session, org_id, project_id)
+            asset_a = await _seed_asset(session, org_id, project_id)
+            asset_b = await _seed_asset(session, org_id, project_id)
+
+            session.add(LoopArtifact(
+                id=uuid.uuid4(), org_id=org_id, loop_id=loop_id, asset_id=asset_a,
+                variant_group="headline", variant_label="A", decision="chosen",
+                created_by_member_id=uuid.uuid4(),
+            ))
+            await session.commit()
+
+            session.add(LoopArtifact(
+                id=uuid.uuid4(), org_id=org_id, loop_id=loop_id, asset_id=asset_b,
+                variant_group="headline", variant_label="B", decision="chosen",
+                created_by_member_id=uuid.uuid4(),
+            ))
+            with pytest.raises(IntegrityError):
+                await session.flush()
+            await session.rollback()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_two_chosen_in_different_variant_groups_allowed():
+    """다중 슬롯(헤드라인셋+이미지셋 각 승자) — 서로 다른 variant_group이면 각각 chosen 가능."""
+    from app.models.loop import LoopArtifact
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id, project_id = await _seed_org_project(session)
+            loop_id = await _seed_loop(session, org_id, project_id)
+            asset_a = await _seed_asset(session, org_id, project_id)
+            asset_b = await _seed_asset(session, org_id, project_id)
+
+            session.add(LoopArtifact(
+                id=uuid.uuid4(), org_id=org_id, loop_id=loop_id, asset_id=asset_a,
+                variant_group="headline", variant_label="A", decision="chosen",
+                created_by_member_id=uuid.uuid4(),
+            ))
+            session.add(LoopArtifact(
+                id=uuid.uuid4(), org_id=org_id, loop_id=loop_id, asset_id=asset_b,
+                variant_group="image", variant_label="A", decision="chosen",
+                created_by_member_id=uuid.uuid4(),
+            ))
+            await session.commit()  # 서로 다른 슬롯 — 위반 없어야
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_rejected_does_not_conflict_with_chosen_in_same_group():
+    """partial index가 decision='chosen'에만 걸리므로 rejected 다건은 무제한이어야."""
+    from app.models.loop import LoopArtifact
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id, project_id = await _seed_org_project(session)
+            loop_id = await _seed_loop(session, org_id, project_id)
+            asset_chosen = await _seed_asset(session, org_id, project_id)
+            asset_r1 = await _seed_asset(session, org_id, project_id)
+            asset_r2 = await _seed_asset(session, org_id, project_id)
+
+            session.add(LoopArtifact(
+                id=uuid.uuid4(), org_id=org_id, loop_id=loop_id, asset_id=asset_chosen,
+                variant_group="headline", variant_label="A", decision="chosen",
+                created_by_member_id=uuid.uuid4(),
+            ))
+            session.add(LoopArtifact(
+                id=uuid.uuid4(), org_id=org_id, loop_id=loop_id, asset_id=asset_r1,
+                variant_group="headline", variant_label="B", decision="rejected",
+                rejection_reason="too generic", created_by_member_id=uuid.uuid4(),
+            ))
+            session.add(LoopArtifact(
+                id=uuid.uuid4(), org_id=org_id, loop_id=loop_id, asset_id=asset_r2,
+                variant_group="headline", variant_label="C", decision="rejected",
+                rejection_reason="off-brand tone", created_by_member_id=uuid.uuid4(),
+            ))
+            await session.commit()  # 위반 없어야
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_loop_run_chosen_artifact_id_fk_now_enforced():
+    """S1의 지연 FK(chosen_artifact_id)가 S2 마이그로 잠겼는지 — 존재 안 하는 artifact id
+    참조는 FK 위반이어야(S1 시점엔 컬럼만 있어 이 위반이 안 걸렸을 것)."""
+    from app.models.loop import LoopRun
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id, project_id = await _seed_org_project(session)
+            session.add(LoopRun(
+                id=uuid.uuid4(), org_id=org_id, project_id=project_id,
+                title="bad chosen_artifact_id", created_by_member_id=uuid.uuid4(),
+                chosen_artifact_id=uuid.uuid4(),  # 존재하지 않는 artifact
+            ))
+            with pytest.raises(IntegrityError):
+                await session.flush()
+            await session.rollback()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_loop_run_chosen_artifact_id_set_null_on_artifact_delete():
+    from app.models.loop import LoopArtifact, LoopRun
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id, project_id = await _seed_org_project(session)
+            loop_id = await _seed_loop(session, org_id, project_id)
+            asset_id = await _seed_asset(session, org_id, project_id)
+            artifact_id = uuid.uuid4()
+            session.add(LoopArtifact(
+                id=artifact_id, org_id=org_id, loop_id=loop_id, asset_id=asset_id,
+                variant_group="headline", variant_label="A", decision="chosen",
+                created_by_member_id=uuid.uuid4(),
+            ))
+            await session.commit()
+
+            await session.execute(
+                text("UPDATE loop_runs SET chosen_artifact_id = :aid WHERE id = :lid"),
+                {"aid": artifact_id, "lid": loop_id},
+            )
+            await session.commit()
+
+            await session.execute(text("DELETE FROM loop_artifacts WHERE id = :id"), {"id": artifact_id})
+            await session.commit()
+
+            run = (await session.execute(select(LoopRun).where(LoopRun.id == loop_id))).scalar_one()
+            assert run.chosen_artifact_id is None  # SET NULL, 부모 loop_run 생존
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_asset_link_source_type_accepts_loop_artifact():
+    """asset_links CHECK가 실제로 넓어졌는지 — 'loop_artifact' INSERT가 성공해야."""
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id, project_id = await _seed_org_project(session)
+            asset_id = await _seed_asset(session, org_id, project_id)
+            await session.execute(
+                text(
+                    "INSERT INTO asset_links (id, org_id, asset_id, source_type, source_id) "
+                    "VALUES (:id, :org_id, :asset_id, 'loop_artifact', :source_id)"
+                ),
+                {"id": uuid.uuid4(), "org_id": org_id, "asset_id": asset_id, "source_id": uuid.uuid4()},
+            )
+            await session.commit()  # 위반 없어야
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_asset_link_source_type_still_rejects_unknown_value():
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as session:
+            org_id, project_id = await _seed_org_project(session)
+            asset_id = await _seed_asset(session, org_id, project_id)
+            with pytest.raises(IntegrityError):
+                await session.execute(
+                    text(
+                        "INSERT INTO asset_links (id, org_id, asset_id, source_type, source_id) "
+                        "VALUES (:id, :org_id, :asset_id, 'not_a_real_source', :source_id)"
+                    ),
+                    {"id": uuid.uuid4(), "org_id": org_id, "asset_id": asset_id, "source_id": uuid.uuid4()},
+                )
+                await session.commit()
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- 블루프린트 §1/§2 — variant 후보 + per-variant 결정/이유(choose/rejection reason=복리의 moat 신호원). 마이그 **0150**(`alembic heads` 재확인, 0149 다음).
- **decision** CHECK 3값(`pending|chosen|rejected`). `rejection_reason`=왜 반려했나(필수화는 S5 게이트 스코프, 스키마는 nullable).
- **partial UNIQUE(loop_id, variant_group) WHERE decision='chosen'** — 슬롯당 승자 ≤1. 서로 다른 `variant_group`(다중 슬롯 — 헤드라인셋/이미지셋 각각)은 각자 chosen 허용.
- **S1의 지연 FK 마무리**: `loop_runs.chosen_artifact_id`에 `ALTER TABLE ADD CONSTRAINT` FK→`loop_artifacts.id`(SET NULL) — 컬럼 재생성 없음. ORM 모델도 동일하게 FK 선언(안 하면 fresh-runnable `create_all()`과 마이그 스키마가 드리프트 — S1의 Gate 미등록 사건과 동일 클래스, 미리 방지).
- **`asset_links.source_type` CHECK 확장**(DROP+CREATE — Postgres는 CHECK in-place ALTER 불가, 0145 phase CHECK 확장과 동일 패턴) + `ASSET_LINK_SOURCE_TYPES` 튜플에 `'loop_artifact'` 추가.

## Test plan
- [x] 신규 9개(happy-path만 아닌 비-tautological, 까심 QA 사전 요구 반영): partial UNIQUE를 **실제 2번째 chosen INSERT로 위반 재현**·다른 `variant_group`은 chosen 허용·`rejected` 다건 무제한(같은 슬롯)·`decision` CHECK·`chosen_artifact_id` FK가 **이제 실제로 걸리는지**(존재하지 않는 artifact 참조 시 위반)·`SET NULL` 실증(artifact 삭제 시 부모 loop_run 생존)·`asset_links` CHECK 확장 양방향(loop_artifact 허용/미지값 여전히 거부).
- [x] 실 PG(0096 baseline→0150) upgrade/downgrade 양방향 검증.
- [x] `Base.metadata.create_all()` fresh-runnable 확인(마이그 스키마와 일치).
- [x] 전체 스위트 2615 pass — pre-existing 12건 실패만(이 변경과 무관).
- [x] 컨테이너 정리 완료(공유 컨테이너 미사용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)