### PR TITLE
feat(e-loop-ledger): S3 — POST/GET/LIST /api/v2/loops CRUD API

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,7 +57,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -154,6 +154,7 @@ app.include_router(presence.router)
 app.include_router(sprints.router)
 app.include_router(epics.router)
 app.include_router(hypotheses.router)
+app.include_router(loops.router)
 app.include_router(dependencies.router)
 app.include_router(labels.router)
 app.include_router(labels.item_label_router)

--- a/backend/app/repositories/loop.py
+++ b/backend/app/repositories/loop.py
@@ -1,0 +1,38 @@
+"""E-LOOP-LEDGER S3: LoopRun repository — CRUD(BaseRepository) + 필터드 list."""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.loop import LoopRun
+from app.repositories.base import BaseRepository
+
+
+class LoopRunRepository(BaseRepository[LoopRun]):
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        super().__init__(LoopRun, session, org_id)
+
+    async def list_filtered(
+        self,
+        *,
+        project_id: uuid.UUID,
+        status: str | None = None,
+        parent_loop_id: uuid.UUID | None = None,
+        goal_tag: str | None = None,
+        limit: int = 100,
+    ) -> list[LoopRun]:
+        q = select(LoopRun).where(
+            LoopRun.org_id == self.org_id,
+            LoopRun.project_id == project_id,
+            LoopRun.deleted_at.is_(None),
+        )
+        if status is not None:
+            q = q.where(LoopRun.status == status)
+        if parent_loop_id is not None:
+            q = q.where(LoopRun.parent_loop_id == parent_loop_id)
+        if goal_tag is not None:
+            q = q.where(LoopRun.goal_tags.any(goal_tag))
+        q = q.order_by(LoopRun.created_at.desc(), LoopRun.id.desc()).limit(limit)
+        return list((await self.session.execute(q)).scalars().all())

--- a/backend/app/routers/loops.py
+++ b/backend/app/routers/loops.py
@@ -1,0 +1,83 @@
+"""E-LOOP-LEDGER S3: /api/v2/loops 라우터 (POST/GET/LIST, 블루프린트 §3).
+
+계약: 성공은 raw model/list 반환, 오류는 HTTPException(dict detail {code,message}) —
+main.py 핸들러가 {data:null,error:{code,message,...},meta:null}로 감싼다(hypotheses.py 동형).
+
+authz:
+- POST: resolve_member(auth, org_id, session, project_id=body.project_id)가 project 접근을
+  검증(무권한이면 400/403) + caller를 created_by_member_id로 서버 해소.
+- LIST: get_project_scoped_org_id 의존성(project_id 쿼리파람 기반, has_project_access SSOT).
+- GET(단건): _require_loop_project_access(service)가 org-scope 로드 후 has_project_access로
+  cross-project IDOR 차단(docs.py의 _require_doc_project_access와 동형).
+
+status FSM 전이는 이 스토리의 스코프 밖(S5 게이트/후속) — 생성 시 status='draft' 고정.
+"""
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user, get_project_scoped_org_id, get_verified_org_id
+from app.dependencies.database import get_db
+from app.schemas.loop import LoopCreate, LoopResponse
+from app.services import loop as svc
+from app.services.member_resolver import resolve_member
+
+router = APIRouter(prefix="/api/v2/loops", tags=["loops"])
+
+# 서비스 도메인 오류 code → HTTP status.
+_ERROR_STATUS: dict[str, int] = {
+    "LOOP_NOT_FOUND": 404,
+    "LOOP_PROJECT_ACCESS_DENIED": 403,
+}
+
+
+def _raise(err: svc.LoopServiceError) -> None:
+    raise HTTPException(
+        status_code=_ERROR_STATUS.get(err.code, 400),
+        detail={"code": err.code, "message": err.message},
+    )
+
+
+@router.get("", response_model=list[LoopResponse])
+async def list_loops(
+    response: Response,
+    project_id: uuid.UUID = Query(...),
+    status_filter: str | None = Query(default=None, alias="status"),
+    parent_loop_id: uuid.UUID | None = Query(default=None),
+    goal_tag: str | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=2000),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_project_scoped_org_id),
+) -> list[LoopResponse]:
+    items = await svc.list_loops(
+        session, org_id, project_id,
+        status=status_filter, parent_loop_id=parent_loop_id, goal_tag=goal_tag, limit=limit,
+    )
+    response.headers["X-Total-Count"] = str(len(items))
+    return items
+
+
+@router.post("", response_model=LoopResponse, status_code=201)
+async def create_loop(
+    body: LoopCreate,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> LoopResponse:
+    # resolve_member(project_id)가 프로젝트 접근을 검증한다(hypotheses.create_hypothesis와 동형).
+    caller = await resolve_member(auth, org_id, session, project_id=body.project_id)
+    return await svc.create_loop(session, org_id, caller, body)
+
+
+@router.get("/{loop_id}", response_model=LoopResponse)
+async def get_loop(
+    loop_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> LoopResponse:
+    try:
+        return await svc.get_loop(session, org_id, uuid.UUID(str(auth.user_id)), loop_id)
+    except svc.LoopServiceError as err:
+        _raise(err)

--- a/backend/app/schemas/loop.py
+++ b/backend/app/schemas/loop.py
@@ -1,0 +1,43 @@
+"""E-LOOP-LEDGER S3: /api/v2/loops DTO. 블루프린트 §3/§6.
+
+created_by_member_id는 절대 client 입력 필드가 아니다 — 서버가 resolve_member로 해소한다
+(hypotheses.created_by_member_id와 동일 컨벤션, identity 위조 방지)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class LoopCreate(BaseModel):
+    project_id: uuid.UUID
+    title: str
+    # S1 스키마는 nullable — API 레벨 필수화는 S14(P2) 스코프.
+    hypothesis_id: uuid.UUID | None = None
+    parent_loop_id: uuid.UUID | None = None
+    recipe_slug: str | None = None
+    goal_tags: list[str] = []
+
+
+class LoopResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    project_id: uuid.UUID
+    parent_loop_id: uuid.UUID | None = None
+    hypothesis_id: uuid.UUID | None = None
+    brief_doc_id: uuid.UUID | None = None
+    decision_gate_id: uuid.UUID | None = None
+    chosen_artifact_id: uuid.UUID | None = None
+    recipe_slug: str | None = None
+    title: str
+    goal_tags: list[str]
+    status: str
+    outcome_snapshot: dict[str, Any] | None = None
+    outcome_attributed_at: datetime | None = None
+    created_by_member_id: uuid.UUID
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/services/loop.py
+++ b/backend/app/services/loop.py
@@ -1,0 +1,92 @@
+"""E-LOOP-LEDGER S3: /api/v2/loops 서비스 — CRUD(create/get/list). 블루프린트 §3 참고.
+
+created_by_member_id는 client 입력이 아니라 caller(resolve_member)를 서버가 해소해 채운다
+(hypotheses.created_by_member_id와 동일 컨벤션 — services/hypothesis.py 참고).
+project 접근 인가는 project_auth.has_project_access(SSOT)를 단일 경로로 사용한다
+(docs.py의 _require_doc_project_access와 동형 — org-scope 로드 후 project 접근 검증).
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.loop import LoopRun
+from app.repositories.loop import LoopRunRepository
+from app.schemas.loop import LoopCreate, LoopResponse
+from app.services.member_resolver import ResolvedMember
+from app.services.project_auth import has_project_access
+
+
+class LoopServiceError(Exception):
+    """도메인 오류 — 라우터가 code/message를 HTTPException dict-detail로 매핑한다."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+async def _require_loop_project_access(
+    session: AsyncSession, loop_id: uuid.UUID, user_id: uuid.UUID, org_id: uuid.UUID
+) -> LoopRun:
+    """GET-by-id의 canonical project-scope authz. docs._require_doc_project_access와 동형:
+    org-scope로 대상을 로드(없으면 404) → has_project_access로 그 loop의 project 접근을
+    검증(무권한이면 403). id+org만으로 잡는 cross-project IDOR을 차단한다."""
+    repo = LoopRunRepository(session, org_id)
+    loop = await repo.get(loop_id)
+    if loop is None:
+        raise LoopServiceError("LOOP_NOT_FOUND", "루프를 찾을 수 없습니다.")
+    if not await has_project_access(session, user_id, loop.project_id, org_id):
+        raise LoopServiceError("LOOP_PROJECT_ACCESS_DENIED", "해당 루프의 프로젝트 접근 권한이 없습니다.")
+    return loop
+
+
+async def create_loop(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    caller: ResolvedMember,
+    payload: LoopCreate,
+) -> LoopResponse:
+    # resolve_member(project_id=...)가 이미 호출부(라우터)에서 caller의 project 접근을
+    # 검증했으므로 여기서는 재검증하지 않는다(hypotheses.create_hypothesis와 동형).
+    repo = LoopRunRepository(session, org_id)
+    loop = await repo.create(
+        project_id=payload.project_id,
+        title=payload.title,
+        hypothesis_id=payload.hypothesis_id,
+        parent_loop_id=payload.parent_loop_id,
+        recipe_slug=payload.recipe_slug,
+        goal_tags=payload.goal_tags,
+        status="draft",
+        created_by_member_id=caller.id,
+    )
+    return LoopResponse.model_validate(loop)
+
+
+async def get_loop(
+    session: AsyncSession, org_id: uuid.UUID, user_id: uuid.UUID, loop_id: uuid.UUID
+) -> LoopResponse:
+    loop = await _require_loop_project_access(session, loop_id, user_id, org_id)
+    return LoopResponse.model_validate(loop)
+
+
+async def list_loops(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID,
+    *,
+    status: str | None = None,
+    parent_loop_id: uuid.UUID | None = None,
+    goal_tag: str | None = None,
+    limit: int = 100,
+) -> list[LoopResponse]:
+    repo = LoopRunRepository(session, org_id)
+    rows = await repo.list_filtered(
+        project_id=project_id,
+        status=status,
+        parent_loop_id=parent_loop_id,
+        goal_tag=goal_tag,
+        limit=limit,
+    )
+    return [LoopResponse.model_validate(r) for r in rows]

--- a/backend/tests/test_e_loop_ledger_s3_loop_crud_api.py
+++ b/backend/tests/test_e_loop_ledger_s3_loop_crud_api.py
@@ -1,0 +1,254 @@
+"""E-LOOP-LEDGER S3(story fb70a775): /api/v2/loops CRUD API 검증.
+
+S3 고유 가치(비-tautological — 까심 QA 사전 요구 컨벤션):
+ⓐ cross-project GET 거부 실증(같은-org·타-project caller가 대상 loop project 접근 없이 GET
+   시도 → 403, has_project_access grant가 없는 세팅으로 실 재현. docs.py
+   test_doc_mutation_project_scope_idor_realdb.py와 동형 패턴).
+ⓑ 서버 actor 해소 — client가 created_by_member_id를 보낼 수 없는 스키마임을 증명하고, 실제
+   caller(resolve_member 해소 id)가 persisted row에 정확히 기록됨을 realdb로 검증.
+ⓒ v2 에러 엔벨로프 계약 — 서비스 도메인 오류 code→HTTP status 매핑 + dict-detail 계약(라우터
+   유닛, DB 불요).
+
+DB env(ALEMBIC_DATABASE_URL) 없으면 realdb 파트 skip.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.routers import loops as r
+from app.schemas.loop import LoopCreate
+from app.services.loop import LoopServiceError
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── ⓒ 오류 code→status 매핑(라우터 유닛, DB 불요) ────────────────────────────────
+
+def test_error_status_map_covers_service_codes():
+    expected = {"LOOP_NOT_FOUND", "LOOP_PROJECT_ACCESS_DENIED"}
+    assert expected <= set(r._ERROR_STATUS)
+
+
+@pytest.mark.parametrize("code,status", [
+    ("LOOP_NOT_FOUND", 404),
+    ("LOOP_PROJECT_ACCESS_DENIED", 403),
+])
+def test_raise_maps_code_to_status(code, status):
+    with pytest.raises(HTTPException) as ei:
+        r._raise(LoopServiceError(code, "msg"))
+    assert ei.value.status_code == status
+    assert ei.value.detail == {"code": code, "message": "msg"}
+
+
+def test_raise_unknown_code_defaults_400():
+    with pytest.raises(HTTPException) as ei:
+        r._raise(LoopServiceError("WHATEVER", "m"))
+    assert ei.value.status_code == 400
+
+
+def test_loop_create_schema_has_no_created_by_member_id_field():
+    # ⓑ client 입력 스키마에 actor 필드가 아예 없다 — 실수로 들어온 request body 값이 있어도
+    # LoopCreate가 그 필드를 정의하지 않으므로 Pydantic이 무시(extra 무시가 기본 ConfigDict).
+    assert "created_by_member_id" not in LoopCreate.model_fields
+
+
+# ── realdb ───────────────────────────────────────────────────────────────────
+
+pytestmark_db = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("1c000000-0000-0000-0000-000000000001")
+USER = uuid.UUID("1c000000-0000-0000-0000-0000000000a1")
+OM = uuid.UUID("1c000000-0000-0000-0000-0000000000b1")
+PROJ_A = uuid.UUID("1c000000-0000-0000-0000-0000000000c1")  # USER grant(접근 O)
+PROJ_B = uuid.UUID("1c000000-0000-0000-0000-0000000000c2")  # USER 접근 X(IDOR 축)
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+
+
+async def _seed(s):
+    """ORG·USER(member·非owner/admin)·PROJ_A(grant)·PROJ_B(no grant) 시드."""
+    for sql in [
+        f"DELETE FROM loop_runs WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id IN ('{PROJ_A}','{PROJ_B}')",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','C1C','c1corg','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@c1c.test','x','U',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_A}','{ORG}','A')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_B}','{ORG}','B')",
+        # USER는 PROJ_A에만 grant(PROJ_B 접근 없음 — IDOR 테스트축).
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ_A}','{OM}','granted')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+# ── ⓐ GET-by-id cross-project IDOR ────────────────────────────────────────────
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_get_loop_cross_project_forbidden_same_project_ok():
+    from app.repositories.loop import LoopRunRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            repo = LoopRunRepository(s, ORG)
+            loop_b = await repo.create(
+                project_id=PROJ_B, title="B loop", goal_tags=[], status="draft",
+                created_by_member_id=uuid.uuid4(),
+            )
+            loop_a = await repo.create(
+                project_id=PROJ_A, title="A loop", goal_tags=[], status="draft",
+                created_by_member_id=uuid.uuid4(),
+            )
+            await s.commit()
+            loop_b_id, loop_a_id = loop_b.id, loop_a.id
+
+        # cross-project(PROJ_B·USER 무접근) → 403
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await r.get_loop(loop_id=loop_b_id, session=s, auth=_auth(), org_id=ORG)
+            assert ei.value.status_code == 403
+            assert ei.value.detail["code"] == "LOOP_PROJECT_ACCESS_DENIED"
+
+        # same-project(PROJ_A·grant) → 통과
+        async with Session() as s:
+            out = await r.get_loop(loop_id=loop_a_id, session=s, auth=_auth(), org_id=ORG)
+            assert out.id == loop_a_id
+            assert out.project_id == PROJ_A
+    finally:
+        await eng.dispose()
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_get_loop_not_found_returns_404():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await r.get_loop(loop_id=uuid.uuid4(), session=s, auth=_auth(), org_id=ORG)
+            assert ei.value.status_code == 404
+            assert ei.value.detail["code"] == "LOOP_NOT_FOUND"
+    finally:
+        await eng.dispose()
+
+
+# ── ⓑ create — cross-project 생성 거부 + 서버 actor 해소 ─────────────────────────
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_create_loop_cross_project_forbidden_via_resolve_member():
+    """resolve_member(project_id=PROJ_B)가 USER의 PROJ_B 무접근을 검증해 거부한다 —
+    create_loop 서비스가 아니라 라우터의 resolve_member 호출이 이 가드를 선행한다."""
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await r.create_loop(
+                    body=LoopCreate(project_id=PROJ_B, title="hack"),
+                    session=s, auth=_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code in (400, 403)
+    finally:
+        await eng.dispose()
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_create_loop_persists_server_resolved_actor_not_arbitrary_value():
+    """생성된 row의 created_by_member_id는 resolve_member가 해소한 caller.id(=OM, USER의
+    org_member.id)와 정확히 일치한다 — LoopCreate에 그 필드가 없으므로 client가 다른 값을
+    주입할 방법이 애초에 없다는 것을 실 persist 값으로 증명."""
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            out = await r.create_loop(
+                body=LoopCreate(project_id=PROJ_A, title="A loop", goal_tags=["retention"]),
+                session=s, auth=_auth(), org_id=ORG,
+            )
+            await s.commit()
+            created_id = out.id
+
+        async with Session() as s:
+            from app.models.loop import LoopRun
+            row = (await s.execute(select(LoopRun).where(LoopRun.id == created_id))).scalar_one()
+            assert row.created_by_member_id == OM
+            assert row.status == "draft"
+            assert row.goal_tags == ["retention"]
+    finally:
+        await eng.dispose()
+
+
+# ── list ─────────────────────────────────────────────────────────────────────
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_list_loops_filters_by_status_and_project():
+    from app.repositories.loop import LoopRunRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            repo = LoopRunRepository(s, ORG)
+            await repo.create(
+                project_id=PROJ_A, title="draft-loop", goal_tags=[], status="draft",
+                created_by_member_id=uuid.uuid4(),
+            )
+            await repo.create(
+                project_id=PROJ_A, title="briefing-loop", goal_tags=[], status="briefing",
+                created_by_member_id=uuid.uuid4(),
+            )
+            await repo.create(
+                project_id=PROJ_B, title="other-project-loop", goal_tags=[], status="draft",
+                created_by_member_id=uuid.uuid4(),
+            )
+            await s.commit()
+
+        async with Session() as s:
+            from unittest.mock import MagicMock
+            items = await r.list_loops(
+                response=MagicMock(headers={}),
+                project_id=PROJ_A, status_filter="draft", parent_loop_id=None, goal_tag=None,
+                limit=100, session=s, org_id=ORG,
+            )
+            assert len(items) == 1
+            assert items[0].title == "draft-loop"
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_e_loop_ledger_s3_loop_crud_api.py
+++ b/backend/tests/test_e_loop_ledger_s3_loop_crud_api.py
@@ -73,8 +73,9 @@ pytestmark_db = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — s
 ORG = uuid.UUID("1c000000-0000-0000-0000-000000000001")
 USER = uuid.UUID("1c000000-0000-0000-0000-0000000000a1")
 OM = uuid.UUID("1c000000-0000-0000-0000-0000000000b1")
-PROJ_A = uuid.UUID("1c000000-0000-0000-0000-0000000000c1")  # USER grant(접근 O)
-PROJ_B = uuid.UUID("1c000000-0000-0000-0000-0000000000c2")  # USER 접근 X(IDOR 축)
+AGENT = uuid.UUID("1c000000-0000-0000-0000-0000000000d1")  # PROJ_A 스코프 agent(까심 재현 시나리오)
+PROJ_A = uuid.UUID("1c000000-0000-0000-0000-0000000000c1")  # USER/AGENT grant(접근 O)
+PROJ_B = uuid.UUID("1c000000-0000-0000-0000-0000000000c2")  # USER/AGENT 접근 X(IDOR 축)
 
 
 def _auth():
@@ -82,12 +83,27 @@ def _auth():
     return AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
 
 
+def _agent_auth():
+    """까심 QA CRITICAL(#1815) 재현 시나리오용 — API키 agent 호출자.
+
+    eb1eb21b(resolve_member root-fix)가 develop에 머지된 뒤 이 브랜치가 rebase되며 딸려온
+    보호(_resolve_member_legacy/_resolve_member_anchor 두 분기 모두 has_project_access 검증)를
+    loops 표면에서도 직접 실증한다 — S3 자체 코드 변경은 없음(루트 fix가 이미 막음)."""
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(AGENT), email=None,
+        claims={"app_metadata": {"api_key_id": "ak_test", "org_id": str(ORG)}},
+        org_id=str(ORG),
+    )
+
+
 async def _seed(s):
-    """ORG·USER(member·非owner/admin)·PROJ_A(grant)·PROJ_B(no grant) 시드."""
+    """ORG·USER(member·非owner/admin)·AGENT(PROJ_A만 grant)·PROJ_A(grant)·PROJ_B(no grant) 시드."""
     for sql in [
         f"DELETE FROM loop_runs WHERE org_id='{ORG}'",
         f"DELETE FROM project_access WHERE project_id IN ('{PROJ_A}','{PROJ_B}')",
         f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
         f"DELETE FROM projects WHERE org_id='{ORG}'",
         f"DELETE FROM users WHERE id='{USER}'",
         f"DELETE FROM organizations WHERE id='{ORG}'",
@@ -95,11 +111,14 @@ async def _seed(s):
         "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
         f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@c1c.test','x','U',true,true,0,false,0)",
         f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
+        f"INSERT INTO members (id,org_id,type,name,is_active) VALUES ('{AGENT}','{ORG}','agent','Ag',true)",
         f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_A}','{ORG}','A')",
         f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_B}','{ORG}','B')",
-        # USER는 PROJ_A에만 grant(PROJ_B 접근 없음 — IDOR 테스트축).
+        # USER/AGENT는 PROJ_A에만 grant(PROJ_B 접근 없음 — IDOR 테스트축).
         f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
         f"VALUES (gen_random_uuid(),'{PROJ_A}','{OM}','granted')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ_A}',NULL,'{AGENT}','granted')",
     ]:
         await s.execute(text(sql))
     await s.commit()
@@ -183,6 +202,38 @@ async def test_create_loop_cross_project_forbidden_via_resolve_member():
                     session=s, auth=_auth(), org_id=ORG,
                 )
             assert ei.value.status_code in (400, 403)
+    finally:
+        await eng.dispose()
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_create_loop_agent_cross_project_forbidden_403():
+    """까심 QA CRITICAL(#1814 S3 QA, root-fix #1815) 재현 시나리오 — agent가 PROJ_A에만 grant된
+    상태에서 body.project_id=PROJ_B로 POST하면 403이어야 한다. 이 방어는 eb1eb21b(develop 머지된
+    resolve_member root-fix)가 이미 제공 — loops.py 자체엔 변경 불요. same-project(PROJ_A) 성공까지
+    양방향 실증해 fix가 정당한 요청을 막지 않음도 확인."""
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        # cross-project(PROJ_B·agent grant 없음) → 403(취약점 있었다면 여기서 통과했을 것).
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await r.create_loop(
+                    body=LoopCreate(project_id=PROJ_B, title="agent-idor-attempt"),
+                    session=s, auth=_agent_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 403
+        # same-project(PROJ_A·agent grant 있음) → 통과 + created_by_member_id=agent id.
+        async with Session() as s:
+            out = await r.create_loop(
+                body=LoopCreate(project_id=PROJ_A, title="agent-legit"),
+                session=s, auth=_agent_auth(), org_id=ORG,
+            )
+            await s.commit()
+            assert out.project_id == PROJ_A
+            assert out.created_by_member_id == AGENT
     finally:
         await eng.dispose()
 


### PR DESCRIPTION
## Summary
- E-LOOP-LEDGER S3(story `fb70a775`): `POST/GET/LIST /api/v2/loops`, org+project scoped, mirroring `hypotheses.py`/`docs.py` router conventions.
- `POST`: `resolve_member(auth, org_id, session, project_id=body.project_id)` validates caller project access and server-resolves `created_by_member_id` (no client-supplied actor field exists in `LoopCreate`). Status is fixed to `draft` on create — FSM transitions are out of scope (S5 gate/follow-up).
- `LIST`: reuses the canonical `get_project_scoped_org_id` dependency; supports `status`/`parent_loop_id`/`goal_tag` filters + pagination limit.
- `GET /{loop_id}`: new `_require_loop_project_access` service helper, structurally identical to `docs._require_doc_project_access` — loads the loop org-scoped (404 if absent), then enforces `has_project_access` on the loop's `project_id` (403 if unauthorized). Blocks cross-project IDOR via id+org-only lookup.
- No schema change — pure API layer over S1/S2's `loop_runs` table (alembic head remains `0150`).

## Test plan
- [x] `alembic upgrade head` on a fresh throwaway `pgvector/pgvector:pg16` container reaches `0150` cleanly (no new migration needed).
- [x] `Base.metadata.create_all()` + `drop_all()` fresh-runnable round-trip clean.
- [x] New `tests/test_e_loop_ledger_s3_loop_crud_api.py` (10 tests, non-tautological):
  - Cross-project `GET` rejected 403 (`LOOP_PROJECT_ACCESS_DENIED`), same-project `GET` passes — real seeded org/project/grant data, not mocked.
  - `GET` on a nonexistent loop → 404 (`LOOP_NOT_FOUND`).
  - Cross-project `POST` rejected via `resolve_member`'s own project-access check.
  - Server-resolved actor: persisted `created_by_member_id` asserted to equal the resolved caller's `org_member.id`, proving no client-supplied value could have landed there (schema doesn't even expose the field).
  - `LIST` filtering by `status` + `project_id` isolation.
  - Error-code→HTTP-status mapping table coverage.
- [x] Full backend suite diffed pre/post (identical throwaway DB, migrations applied once each): failure **set** is byte-identical before and after this change (87 pre-existing/unrelated failures on plain `develop`, confirmed via direct diff) — zero regressions introduced. These 87 are not part of CI's `backend-test` job (which runs with no DB env, so realdb tests there skip) nor the curated realdb file lists in the other CI job.
- [x] `hypotheses.py` router tests (41 tests) + S1/S2 loop tests still pass unchanged.