### PR TITLE
feat(e-loop-ledger): S4 — POST/GET /api/v2/loops/{id}/artifacts variant registration

### DIFF
--- a/backend/app/repositories/loop.py
+++ b/backend/app/repositories/loop.py
@@ -1,4 +1,4 @@
-"""E-LOOP-LEDGER S3: LoopRun repository — CRUD(BaseRepository) + 필터드 list."""
+"""E-LOOP-LEDGER S3/S4: LoopRun + LoopArtifact repository — CRUD(BaseRepository) + 필터드 list."""
 from __future__ import annotations
 
 import uuid
@@ -6,7 +6,7 @@ import uuid
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.loop import LoopRun
+from app.models.loop import LoopArtifact, LoopRun
 from app.repositories.base import BaseRepository
 
 
@@ -35,4 +35,19 @@ class LoopRunRepository(BaseRepository[LoopRun]):
         if goal_tag is not None:
             q = q.where(LoopRun.goal_tags.any(goal_tag))
         q = q.order_by(LoopRun.created_at.desc(), LoopRun.id.desc()).limit(limit)
+        return list((await self.session.execute(q)).scalars().all())
+
+
+class LoopArtifactRepository(BaseRepository[LoopArtifact]):
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        super().__init__(LoopArtifact, session, org_id)
+
+    async def list_by_loop(self, loop_id: uuid.UUID) -> list[LoopArtifact]:
+        # ix_loop_artifacts_loop_variant_group과 동일 순서(variant_group, sort_order) — GET
+        # 응답의 variant_group 그룹핑이 이미 정렬된 스캔 순서를 그대로 소비하도록.
+        q = (
+            select(LoopArtifact)
+            .where(LoopArtifact.org_id == self.org_id, LoopArtifact.loop_id == loop_id)
+            .order_by(LoopArtifact.variant_group.asc(), LoopArtifact.sort_order.asc())
+        )
         return list((await self.session.execute(q)).scalars().all())

--- a/backend/app/routers/loops.py
+++ b/backend/app/routers/loops.py
@@ -1,14 +1,20 @@
-"""E-LOOP-LEDGER S3: /api/v2/loops 라우터 (POST/GET/LIST, 블루프린트 §3).
+"""E-LOOP-LEDGER S3/S4: /api/v2/loops 라우터 (POST/GET/LIST loops + POST/GET artifacts, 블루프린트 §3/§4).
 
 계약: 성공은 raw model/list 반환, 오류는 HTTPException(dict detail {code,message}) —
 main.py 핸들러가 {data:null,error:{code,message,...},meta:null}로 감싼다(hypotheses.py 동형).
 
-authz:
+authz(loops):
 - POST: resolve_member(auth, org_id, session, project_id=body.project_id)가 project 접근을
   검증(무권한이면 400/403) + caller를 created_by_member_id로 서버 해소.
 - LIST: get_project_scoped_org_id 의존성(project_id 쿼리파람 기반, has_project_access SSOT).
 - GET(단건): _require_loop_project_access(service)가 org-scope 로드 후 has_project_access로
   cross-project IDOR 차단(docs.py의 _require_doc_project_access와 동형).
+
+authz(artifacts, S4) — 2단계:
+① loop_id로 loop을 먼저 org-scope 로드(404) → resolve_member(project_id=loop.project_id)로
+   caller의 그 project 접근 검증(agent 분기도 root-fix #1815로 보호) + actor 서버 해소.
+② asset_id가 그 loop과 같은 project 소유인지(서비스 레벨 ASSET_PROJECT_MISMATCH) — 신규
+   크로스-리소스 IDOR 축(타 project asset을 이 loop에 link 못 하게).
 
 status FSM 전이는 이 스토리의 스코프 밖(S5 게이트/후속) — 생성 시 status='draft' 고정.
 """
@@ -19,7 +25,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_project_scoped_org_id, get_verified_org_id
 from app.dependencies.database import get_db
-from app.schemas.loop import LoopCreate, LoopResponse
+from app.repositories.loop import LoopRunRepository
+from app.schemas.loop import (
+    LoopArtifactCreate,
+    LoopArtifactResponse,
+    LoopArtifactVariantGroup,
+    LoopCreate,
+    LoopResponse,
+)
 from app.services import loop as svc
 from app.services.member_resolver import resolve_member
 
@@ -29,6 +42,8 @@ router = APIRouter(prefix="/api/v2/loops", tags=["loops"])
 _ERROR_STATUS: dict[str, int] = {
     "LOOP_NOT_FOUND": 404,
     "LOOP_PROJECT_ACCESS_DENIED": 403,
+    "ASSET_NOT_FOUND": 404,
+    "ASSET_PROJECT_MISMATCH": 403,
 }
 
 
@@ -81,3 +96,41 @@ async def get_loop(
         return await svc.get_loop(session, org_id, uuid.UUID(str(auth.user_id)), loop_id)
     except svc.LoopServiceError as err:
         _raise(err)
+
+
+@router.post("/{loop_id}/artifacts", response_model=LoopArtifactResponse, status_code=201)
+async def create_loop_artifact(
+    loop_id: uuid.UUID,
+    body: LoopArtifactCreate,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> LoopArtifactResponse:
+    loop = await LoopRunRepository(session, org_id).get(loop_id)
+    if loop is None:
+        raise HTTPException(
+            status_code=404, detail={"code": "LOOP_NOT_FOUND", "message": "루프를 찾을 수 없습니다."}
+        )
+    # ①loop project 접근 — resolve_member(project_id)가 검증(root-fix #1815로 agent도 보호) +
+    # 서버 actor 해소(hypotheses/loops POST와 동일 anti-spoofing).
+    caller = await resolve_member(auth, org_id, session, project_id=loop.project_id)
+    try:
+        return await svc.create_loop_artifact(session, org_id, caller, loop, body)
+    except svc.LoopServiceError as err:
+        _raise(err)
+
+
+@router.get("/{loop_id}/artifacts", response_model=list[LoopArtifactVariantGroup])
+async def list_loop_artifacts(
+    loop_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> list[LoopArtifactVariantGroup]:
+    try:
+        # get_loop이 _require_loop_project_access(GET 단건과 동일 IDOR 방어)를 내부에서 수행 —
+        # 결과(LoopResponse)는 authz 게이트 통과 증거로만 쓰고 버린다.
+        await svc.get_loop(session, org_id, uuid.UUID(str(auth.user_id)), loop_id)
+    except svc.LoopServiceError as err:
+        _raise(err)
+    return await svc.list_loop_artifacts(session, org_id, loop_id)

--- a/backend/app/schemas/loop.py
+++ b/backend/app/schemas/loop.py
@@ -41,3 +41,37 @@ class LoopResponse(BaseModel):
     created_by_member_id: uuid.UUID
     created_at: datetime
     updated_at: datetime
+
+
+class LoopArtifactCreate(BaseModel):
+    """S4: variant 후보 등록. decision 필드는 의도적으로 없다 — 서버가 'pending' 고정
+    (chosen/rejected는 S5 게이트 전용 엔드포인트, client가 직접 전이 불가)."""
+
+    variant_group: str
+    variant_label: str
+    asset_id: uuid.UUID
+    generation_metadata: dict[str, Any] = {}
+
+
+class LoopArtifactResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    loop_id: uuid.UUID
+    asset_id: uuid.UUID
+    variant_group: str
+    variant_label: str
+    decision: str
+    choose_reason: str | None = None
+    rejection_reason: str | None = None
+    generation_metadata: dict[str, Any]
+    sort_order: int
+    created_by_member_id: uuid.UUID
+    created_at: datetime
+    updated_at: datetime
+
+
+class LoopArtifactVariantGroup(BaseModel):
+    variant_group: str
+    artifacts: list[LoopArtifactResponse]

--- a/backend/app/services/loop.py
+++ b/backend/app/services/loop.py
@@ -7,13 +7,23 @@ project 접근 인가는 project_auth.has_project_access(SSOT)를 단일 경로�
 """
 from __future__ import annotations
 
+import itertools
 import uuid
 
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.loop import LoopRun
-from app.repositories.loop import LoopRunRepository
-from app.schemas.loop import LoopCreate, LoopResponse
+from app.models.asset import Asset, AssetLink
+from app.models.loop import LoopArtifact, LoopRun
+from app.repositories.loop import LoopArtifactRepository, LoopRunRepository
+from app.schemas.loop import (
+    LoopArtifactCreate,
+    LoopArtifactResponse,
+    LoopArtifactVariantGroup,
+    LoopCreate,
+    LoopResponse,
+)
 from app.services.member_resolver import ResolvedMember
 from app.services.project_auth import has_project_access
 
@@ -90,3 +100,67 @@ async def list_loops(
         limit=limit,
     )
     return [LoopResponse.model_validate(r) for r in rows]
+
+
+async def create_loop_artifact(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    caller: ResolvedMember,
+    loop: LoopRun,
+    payload: LoopArtifactCreate,
+) -> LoopArtifactResponse:
+    """S4: 기존 asset을 loop의 variant 후보로 등록. loop project 접근은 호출부(라우터)의
+    resolve_member(project_id=loop.project_id)가 선행 검증(root-fix #1815로 agent 분기도 보호)
+    — 여기서는 두 번째 IDOR 축(asset 소유)만 검증한다.
+
+    decision은 payload에 필드가 없으므로 항상 'pending' — client가 chosen/rejected로 직접
+    생성할 방법이 스키마 레벨에서부터 없다(S5 게이트 전용 전이)."""
+    asset = (await session.execute(
+        select(Asset).where(Asset.id == payload.asset_id, Asset.org_id == org_id)
+    )).scalar_one_or_none()
+    if asset is None:
+        raise LoopServiceError("ASSET_NOT_FOUND", "자산을 찾을 수 없습니다.")
+    # ⭐크로스-리소스 IDOR: 타 프로젝트(또는 org-level=NULL) asset을 이 loop에 link 불가.
+    if asset.project_id != loop.project_id:
+        raise LoopServiceError(
+            "ASSET_PROJECT_MISMATCH", "자산이 이 루프와 같은 프로젝트에 속하지 않습니다."
+        )
+
+    repo = LoopArtifactRepository(session, org_id)
+    artifact = await repo.create(
+        loop_id=loop.id,
+        asset_id=payload.asset_id,
+        variant_group=payload.variant_group,
+        variant_label=payload.variant_label,
+        generation_metadata=payload.generation_metadata,
+        decision="pending",
+        created_by_member_id=caller.id,
+    )
+    # AssetLink SSOT 와이어링(catch#4) — asset_registry.sync_attachment_assets의 idempotent-insert
+    # 관용구 재사용. source_type='loop_artifact'는 0150에서 CHECK 확장됨.
+    await session.execute(
+        pg_insert(AssetLink)
+        .values(
+            org_id=org_id,
+            asset_id=payload.asset_id,
+            source_type="loop_artifact",
+            source_id=artifact.id,
+            created_by=caller.id,
+        )
+        .on_conflict_do_nothing(constraint="uq_asset_links_asset_source")
+    )
+    return LoopArtifactResponse.model_validate(artifact)
+
+
+async def list_loop_artifacts(
+    session: AsyncSession, org_id: uuid.UUID, loop_id: uuid.UUID
+) -> list[LoopArtifactVariantGroup]:
+    repo = LoopArtifactRepository(session, org_id)
+    rows = await repo.list_by_loop(loop_id)
+    groups: list[LoopArtifactVariantGroup] = []
+    for variant_group, items in itertools.groupby(rows, key=lambda a: a.variant_group):
+        groups.append(LoopArtifactVariantGroup(
+            variant_group=variant_group,
+            artifacts=[LoopArtifactResponse.model_validate(a) for a in items],
+        ))
+    return groups

--- a/backend/tests/test_e_loop_ledger_s4_artifact_registration.py
+++ b/backend/tests/test_e_loop_ledger_s4_artifact_registration.py
@@ -1,0 +1,350 @@
+"""E-LOOP-LEDGER S4(story e7b0e5cc): POST/GET /api/v2/loops/{loop_id}/artifacts 검증.
+
+S4 고유 가치(비-tautological):
+ⓐ 2단계 IDOR — ①loop project 접근(resolve_member root-fix #1815 재사용, agent 축까지)
+   ②⭐신규 크로스-리소스 축: asset이 loop과 다른 project(또는 org-level NULL) 소유면 403.
+ⓑ decision 서버 고정 — LoopArtifactCreate 스키마에 그 필드가 아예 없음을 구조적으로 증명.
+ⓒ AssetLink SSOT 와이어링 — 생성 시 asset_links(source_type='loop_artifact') 행이 실제로 생김.
+ⓓ GET variant_group 그룹핑 — 실 다중 그룹/다중 아이템으로 그룹핑 shape 실증.
+
+DB env(ALEMBIC_DATABASE_URL) 없으면 realdb 파트 skip.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.routers import loops as r
+from app.schemas.loop import LoopArtifactCreate
+from app.services.loop import LoopServiceError
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── ⓑ 오류 매핑 + decision 서버고정 구조 검증(유닛, DB 불요) ────────────────────
+
+def test_error_status_map_covers_asset_codes():
+    expected = {"ASSET_NOT_FOUND", "ASSET_PROJECT_MISMATCH"}
+    assert expected <= set(r._ERROR_STATUS)
+
+
+@pytest.mark.parametrize("code,status", [
+    ("ASSET_NOT_FOUND", 404),
+    ("ASSET_PROJECT_MISMATCH", 403),
+])
+def test_raise_maps_asset_code_to_status(code, status):
+    with pytest.raises(HTTPException) as ei:
+        r._raise(LoopServiceError(code, "msg"))
+    assert ei.value.status_code == status
+
+
+def test_loop_artifact_create_schema_has_no_decision_field():
+    # client가 생성 시 decision='chosen' 등을 실어보낼 방법이 스키마 레벨부터 없다.
+    assert "decision" not in LoopArtifactCreate.model_fields
+
+
+# ── realdb ───────────────────────────────────────────────────────────────────
+
+pytestmark_db = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("1e000000-0000-0000-0000-000000000001")
+USER = uuid.UUID("1e000000-0000-0000-0000-0000000000a1")
+OM = uuid.UUID("1e000000-0000-0000-0000-0000000000b1")
+AGENT = uuid.UUID("1e000000-0000-0000-0000-0000000000d1")  # PROJ_A에만 grant
+PROJ_A = uuid.UUID("1e000000-0000-0000-0000-000000000002")
+PROJ_B = uuid.UUID("1e000000-0000-0000-0000-000000000003")
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+
+
+def _agent_auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(AGENT), email=None,
+        claims={"app_metadata": {"api_key_id": "ak_test", "org_id": str(ORG)}},
+        org_id=str(ORG),
+    )
+
+
+async def _seed(s):
+    """ORG·USER(PROJ_A grant)·AGENT(PROJ_A grant)·PROJ_A/PROJ_B 시드."""
+    for sql in [
+        f"DELETE FROM asset_links WHERE org_id='{ORG}'",
+        f"DELETE FROM loop_artifacts WHERE org_id='{ORG}'",
+        f"DELETE FROM loop_runs WHERE org_id='{ORG}'",
+        f"DELETE FROM assets WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id IN ('{PROJ_A}','{PROJ_B}')",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','C1E','c1eorg','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@c1e.test','x','U',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
+        f"INSERT INTO members (id,org_id,type,name,is_active) VALUES ('{AGENT}','{ORG}','agent','Ag',true)",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_A}','{ORG}','A')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_B}','{ORG}','B')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ_A}','{OM}','granted')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ_A}',NULL,'{AGENT}','granted')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _seed_loop(s, project_id) -> uuid.UUID:
+    from app.repositories.loop import LoopRunRepository
+    repo = LoopRunRepository(s, ORG)
+    loop = await repo.create(
+        project_id=project_id, title="L", goal_tags=[], status="draft",
+        created_by_member_id=uuid.uuid4(),
+    )
+    await s.commit()
+    return loop.id
+
+
+async def _seed_asset(s, project_id) -> uuid.UUID:
+    from app.models.asset import Asset
+    a = Asset(
+        id=uuid.uuid4(), org_id=ORG, project_id=project_id, container="uploads",
+        object_path=f"org/{ORG}/asset-{uuid.uuid4().hex[:8]}.png", name="a.png",
+        content_type="image/png", size_bytes=100,
+    )
+    s.add(a)
+    await s.commit()
+    return a.id
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+# ── ⓐ① loop project 접근(resolve_member root-fix, agent 축) ───────────────────
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_create_artifact_agent_cross_project_loop_forbidden_403():
+    """agent는 PROJ_A만 grant. loop이 PROJ_B 소속이면 resolve_member(project_id=PROJ_B)가
+    403(까심 재현 시나리오와 동형 — root-fix #1815가 여기서도 막는지 loops artifact 표면서 실증)."""
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            loop_id = await _seed_loop(s, PROJ_B)
+            asset_id = await _seed_asset(s, PROJ_B)
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await r.create_loop_artifact(
+                    loop_id=loop_id,
+                    body=LoopArtifactCreate(variant_group="g", variant_label="A", asset_id=asset_id),
+                    session=s, auth=_agent_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 403
+    finally:
+        await eng.dispose()
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_create_artifact_loop_not_found_404():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            asset_id = await _seed_asset(s, PROJ_A)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await r.create_loop_artifact(
+                    loop_id=uuid.uuid4(),
+                    body=LoopArtifactCreate(variant_group="g", variant_label="A", asset_id=asset_id),
+                    session=s, auth=_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 404
+            assert ei.value.detail["code"] == "LOOP_NOT_FOUND"
+    finally:
+        await eng.dispose()
+
+
+# ── ⓐ② 크로스-리소스: asset이 loop과 다른 project 소유 ──────────────────────────
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_create_artifact_asset_cross_project_forbidden_403():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            loop_id = await _seed_loop(s, PROJ_A)
+            asset_id = await _seed_asset(s, PROJ_B)  # loop=A, asset=B — 불일치
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await r.create_loop_artifact(
+                    loop_id=loop_id,
+                    body=LoopArtifactCreate(variant_group="g", variant_label="A", asset_id=asset_id),
+                    session=s, auth=_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 403
+            assert ei.value.detail["code"] == "ASSET_PROJECT_MISMATCH"
+    finally:
+        await eng.dispose()
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_create_artifact_org_level_asset_forbidden_for_project_loop():
+    """asset.project_id=NULL(org-level)도 project-scoped loop엔 엄격 불허(설계 명시)."""
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            loop_id = await _seed_loop(s, PROJ_A)
+            asset_id = await _seed_asset(s, None)
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await r.create_loop_artifact(
+                    loop_id=loop_id,
+                    body=LoopArtifactCreate(variant_group="g", variant_label="A", asset_id=asset_id),
+                    session=s, auth=_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 403
+            assert ei.value.detail["code"] == "ASSET_PROJECT_MISMATCH"
+    finally:
+        await eng.dispose()
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_create_artifact_asset_not_found_404():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            loop_id = await _seed_loop(s, PROJ_A)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await r.create_loop_artifact(
+                    loop_id=loop_id,
+                    body=LoopArtifactCreate(variant_group="g", variant_label="A", asset_id=uuid.uuid4()),
+                    session=s, auth=_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 404
+            assert ei.value.detail["code"] == "ASSET_NOT_FOUND"
+    finally:
+        await eng.dispose()
+
+
+# ── ⓑⓒ 성공 경로: decision='pending' 고정 + AssetLink SSOT 생성 ─────────────────
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_create_artifact_success_pending_decision_and_asset_link_wired():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            loop_id = await _seed_loop(s, PROJ_A)
+            asset_id = await _seed_asset(s, PROJ_A)
+
+        async with Session() as s:
+            out = await r.create_loop_artifact(
+                loop_id=loop_id,
+                body=LoopArtifactCreate(
+                    variant_group="headline", variant_label="A",
+                    asset_id=asset_id, generation_metadata={"model": "x"},
+                ),
+                session=s, auth=_auth(), org_id=ORG,
+            )
+            await s.commit()
+            assert out.decision == "pending"
+            assert out.variant_group == "headline"
+            assert out.created_by_member_id == OM
+            artifact_id = out.id
+
+        async with Session() as s:
+            from app.models.asset import AssetLink
+            link = (await s.execute(
+                select(AssetLink).where(
+                    AssetLink.asset_id == asset_id,
+                    AssetLink.source_type == "loop_artifact",
+                    AssetLink.source_id == artifact_id,
+                )
+            )).scalar_one_or_none()
+            assert link is not None
+    finally:
+        await eng.dispose()
+
+
+# ── ⓓ GET variant_group 그룹핑 ──────────────────────────────────────────────
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_list_loop_artifacts_groups_by_variant_group():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            loop_id = await _seed_loop(s, PROJ_A)
+            asset1 = await _seed_asset(s, PROJ_A)
+            asset2 = await _seed_asset(s, PROJ_A)
+            asset3 = await _seed_asset(s, PROJ_A)
+
+        async with Session() as s:
+            for variant_group, variant_label, asset_id in [
+                ("headline", "B", asset2), ("headline", "A", asset1), ("cta", "A", asset3),
+            ]:
+                await r.create_loop_artifact(
+                    loop_id=loop_id,
+                    body=LoopArtifactCreate(variant_group=variant_group, variant_label=variant_label, asset_id=asset_id),
+                    session=s, auth=_auth(), org_id=ORG,
+                )
+            await s.commit()
+
+        async with Session() as s:
+            groups = await r.list_loop_artifacts(loop_id=loop_id, session=s, auth=_auth(), org_id=ORG)
+            assert [g.variant_group for g in groups] == ["cta", "headline"]
+            cta_group = next(g for g in groups if g.variant_group == "cta")
+            headline_group = next(g for g in groups if g.variant_group == "headline")
+            assert len(cta_group.artifacts) == 1
+            assert len(headline_group.artifacts) == 2
+    finally:
+        await eng.dispose()
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_list_loop_artifacts_cross_project_forbidden_403():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            loop_id = await _seed_loop(s, PROJ_B)
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await r.list_loop_artifacts(loop_id=loop_id, session=s, auth=_auth(), org_id=ORG)
+            assert ei.value.status_code == 403
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## Summary
- E-LOOP-LEDGER S4(story `e7b0e5cc`): links an existing `assets` row into a loop as a variant candidate via `loop_artifacts` (table already exists from S2, no migration).
- `decision` has no client-facing field at all in `LoopArtifactCreate` — server always creates rows as `pending`. `chosen`/`rejected` transitions are S5's (decision gate) scope, not this endpoint's.
- **Two-layer IDOR guard**:
  1. Loop project access — loads the loop org-scoped (404 if missing), then `resolve_member(auth, org_id, session, project_id=loop.project_id)` validates the caller's project access (agent branch protected by the `resolve_member` root-fix, #1815) and server-resolves `created_by_member_id`.
  2. **New cross-resource IDOR axis**: the referenced `asset_id` must belong to the *same project* as the loop — mismatched project (including an org-level asset with `project_id IS NULL`) → `403 ASSET_PROJECT_MISMATCH`. Nonexistent/wrong-org asset → `404 ASSET_NOT_FOUND`.
- On create, also wires an `AssetLink(source_type='loop_artifact', source_id=artifact.id)` row (asset_links catch#4 SSOT — `source_type` was already widened for this in S2's migration `0150`), reusing the idempotent-insert idiom from `asset_registry.sync_attachment_assets`.
- `GET /api/v2/loops/{id}/artifacts` returns variant-group-grouped results (`variant_group` ASC, `sort_order` ASC — matches the existing `ix_loop_artifacts_loop_variant_group` index order), authz via the existing S3 loop-GET IDOR guard.

## Test plan
- [x] `alembic upgrade head` stays at `0150` (no schema change).
- [x] `Base.metadata.create_all()` + `drop_all()` fresh-runnable clean.
- [x] New `tests/test_e_loop_ledger_s4_artifact_registration.py` (12 tests, non-tautological):
  - Agent scoped to project A, loop in project B → `POST .../artifacts` 403 (same root-fix repro pattern as S3).
  - Loop not found → 404.
  - Asset in a different project than the loop → 403 `ASSET_PROJECT_MISMATCH`; org-level asset (`project_id IS NULL`) against a project-scoped loop → also 403 (strict-by-design, asserted explicitly).
  - Nonexistent asset → 404 `ASSET_NOT_FOUND`.
  - Success path: `decision == "pending"`, server-resolved `created_by_member_id`, and a real `AssetLink` row is asserted present afterward (not just that create didn't error).
  - `LoopArtifactCreate.model_fields` asserted to not contain `"decision"` — structural proof client can't set it.
  - `GET` groups 3 seeded artifacts across 2 variant groups correctly (group count + per-group item count asserted, not just "response 200").
  - `GET` cross-project loop → 403.
- [x] S1/S2/S3 loop tests (34 tests) + the resolve_member IDOR regression tests still pass unchanged.
- [x] Full suite diffed against the pre-existing baseline (87 failures, established across S3/#1815/rebase runs) — **byte-identical failure set**, zero new regressions.

Depends on S2 (merged) + the resolve_member root-fix (#1815, merged). Mirrors the existing `assets`/`asset_links` and `docs.py` IDOR-guard patterns per Ortega's kickoff spec.