### PR TITLE
feat(e-loop-ledger): S5 — POST /api/v2/loops/{id}/decision (variant slot decision gate)

### DIFF
--- a/backend/app/repositories/loop.py
+++ b/backend/app/repositories/loop.py
@@ -51,3 +51,28 @@ class LoopArtifactRepository(BaseRepository[LoopArtifact]):
             .order_by(LoopArtifact.variant_group.asc(), LoopArtifact.sort_order.asc())
         )
         return list((await self.session.execute(q)).scalars().all())
+
+    async def list_pending_by_group(self, loop_id: uuid.UUID, variant_group: str) -> list[LoopArtifact]:
+        q = select(LoopArtifact).where(
+            LoopArtifact.org_id == self.org_id,
+            LoopArtifact.loop_id == loop_id,
+            LoopArtifact.variant_group == variant_group,
+            LoopArtifact.decision == "pending",
+        )
+        return list((await self.session.execute(q)).scalars().all())
+
+    async def count_pending(self, loop_id: uuid.UUID) -> int:
+        q = select(LoopArtifact.id).where(
+            LoopArtifact.org_id == self.org_id,
+            LoopArtifact.loop_id == loop_id,
+            LoopArtifact.decision == "pending",
+        )
+        return len((await self.session.execute(q)).scalars().all())
+
+    async def distinct_variant_groups(self, loop_id: uuid.UUID) -> list[str]:
+        q = (
+            select(LoopArtifact.variant_group)
+            .where(LoopArtifact.org_id == self.org_id, LoopArtifact.loop_id == loop_id)
+            .distinct()
+        )
+        return list((await self.session.execute(q)).scalars().all())

--- a/backend/app/routers/loops.py
+++ b/backend/app/routers/loops.py
@@ -1,4 +1,5 @@
-"""E-LOOP-LEDGER S3/S4: /api/v2/loops 라우터 (POST/GET/LIST loops + POST/GET artifacts, 블루프린트 §3/§4).
+"""E-LOOP-LEDGER S3/S4/S5: /api/v2/loops 라우터 (POST/GET/LIST loops + POST/GET artifacts + POST decision,
+블루프린트 §3/§4/§5).
 
 계약: 성공은 raw model/list 반환, 오류는 HTTPException(dict detail {code,message}) —
 main.py 핸들러가 {data:null,error:{code,message,...},meta:null}로 감싼다(hypotheses.py 동형).
@@ -16,7 +17,13 @@ authz(artifacts, S4) — 2단계:
 ② asset_id가 그 loop과 같은 project 소유인지(서비스 레벨 ASSET_PROJECT_MISMATCH) — 신규
    크로스-리소스 IDOR 축(타 project asset을 이 loop에 link 못 하게).
 
-status FSM 전이는 이 스토리의 스코프 밖(S5 게이트/후속) — 생성 시 status='draft' 고정.
+authz(decision, S5) — loop project 접근(위와 동일) + **human-only 명시 체크**(gates.py
+transition_gate_endpoint와 동형: caller.type != 'human' → 403 — 결정 게이트는 순수 HITL,
+에이전트 API키는 자동 승인 불가). gate_type='loop_decision'은 gate_service._ALWAYS_MANUAL_GATE_TYPES에
+있어 org disposition posture와 무관하게 항상 human-pending.
+
+status FSM 전이(deciding→executing)는 loop의 전 variant_group이 결판났을 때만 발생(S5 §5).
+생성 시 status='draft' 고정 — draft→...→deciding 전이 자체는 이 스토리의 스코프 밖(추후 확장).
 """
 import uuid
 
@@ -31,6 +38,8 @@ from app.schemas.loop import (
     LoopArtifactResponse,
     LoopArtifactVariantGroup,
     LoopCreate,
+    LoopDecisionRequest,
+    LoopDecisionResponse,
     LoopResponse,
 )
 from app.services import loop as svc
@@ -44,6 +53,11 @@ _ERROR_STATUS: dict[str, int] = {
     "LOOP_PROJECT_ACCESS_DENIED": 403,
     "ASSET_NOT_FOUND": 404,
     "ASSET_PROJECT_MISMATCH": 403,
+    "LOOP_NOT_IN_DECIDING_STATE": 409,
+    "GATE_ALREADY_RESOLVED": 409,
+    "NO_PENDING_ARTIFACTS_IN_GROUP": 422,
+    "ARTIFACT_SET_MISMATCH": 422,
+    "INVALID_LOOP_TRANSITION": 409,
 }
 
 
@@ -134,3 +148,30 @@ async def list_loop_artifacts(
     except svc.LoopServiceError as err:
         _raise(err)
     return await svc.list_loop_artifacts(session, org_id, loop_id)
+
+
+@router.post("/{loop_id}/decision", response_model=LoopDecisionResponse)
+async def decide_loop(
+    loop_id: uuid.UUID,
+    body: LoopDecisionRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> LoopDecisionResponse:
+    loop = await LoopRunRepository(session, org_id).get(loop_id)
+    if loop is None:
+        raise HTTPException(
+            status_code=404, detail={"code": "LOOP_NOT_FOUND", "message": "루프를 찾을 수 없습니다."}
+        )
+    # ①loop project 접근 — resolve_member(project_id)가 검증(root-fix #1815로 agent도 보호).
+    caller = await resolve_member(auth, org_id, session, project_id=loop.project_id)
+    # ⭐human-only(gates.py transition_gate_endpoint와 동형) — 결정 게이트는 순수 HITL, agent 승인 불가.
+    if caller.type != "human":
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "DECISION_HUMAN_ONLY", "message": "루프 결정은 휴먼 멤버만 가능합니다 (에이전트 불가)."},
+        )
+    try:
+        return await svc.decide_loop_artifacts(session, org_id, caller, loop, body)
+    except svc.LoopServiceError as err:
+        _raise(err)

--- a/backend/app/schemas/loop.py
+++ b/backend/app/schemas/loop.py
@@ -8,7 +8,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class LoopCreate(BaseModel):
@@ -75,3 +75,29 @@ class LoopArtifactResponse(BaseModel):
 class LoopArtifactVariantGroup(BaseModel):
     variant_group: str
     artifacts: list[LoopArtifactResponse]
+
+
+class LoopArtifactRejection(BaseModel):
+    artifact_id: uuid.UUID
+    rejection_reason: str = Field(min_length=1)
+
+
+class VariantGroupDecision(BaseModel):
+    """S5: 슬롯(variant_group) 1개에 대한 결정 — 그 그룹 pending 집합과 chosen+rejections가
+    정확히 일치해야 한다(초과/누락 모두 거부, 서비스 레벨에서 검증)."""
+
+    variant_group: str
+    chosen_artifact_id: uuid.UUID
+    choose_reason: str = Field(min_length=1)
+    rejections: list[LoopArtifactRejection]
+
+
+class LoopDecisionRequest(BaseModel):
+    decisions: list[VariantGroupDecision] = Field(min_length=1)
+
+
+class LoopDecisionResponse(BaseModel):
+    loop: LoopResponse
+    gate_id: uuid.UUID
+    gate_status: str
+    all_groups_decided: bool

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -49,7 +49,9 @@ _DISPOSITION_TO_STATUS: dict[str, str] = {
 
 # doc-gate v2 갭1: deliberate 인간 결재 gate — org allow_auto/deny posture 무관하게 항상 manual(pending).
 # disposition auto-pass/auto-deny 제외(인간 deliberation 이 정책 자동결정보다 우선).
-_ALWAYS_MANUAL_GATE_TYPES: frozenset[str] = frozenset({"doc_approval"})
+# 'loop_decision'(E-LOOP-LEDGER S5): variant 선택도 동일 이유로 항상 human pending — GATE_TYPES에도
+# 미등록(doc_approval과 동일 선례. org gate override 설정 대상에서 제외=애초에 자동화 불가 명시).
+_ALWAYS_MANUAL_GATE_TYPES: frozenset[str] = frozenset({"doc_approval", "loop_decision"})
 
 
 async def create_gate(

--- a/backend/app/services/loop.py
+++ b/backend/app/services/loop.py
@@ -15,13 +15,15 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.asset import Asset, AssetLink
-from app.models.loop import LoopArtifact, LoopRun
+from app.models.loop import LoopArtifact, LoopRun, is_valid_transition
 from app.repositories.loop import LoopArtifactRepository, LoopRunRepository
 from app.schemas.loop import (
     LoopArtifactCreate,
     LoopArtifactResponse,
     LoopArtifactVariantGroup,
     LoopCreate,
+    LoopDecisionRequest,
+    LoopDecisionResponse,
     LoopResponse,
 )
 from app.services.member_resolver import ResolvedMember
@@ -164,3 +166,94 @@ async def list_loop_artifacts(
             artifacts=[LoopArtifactResponse.model_validate(a) for a in items],
         ))
     return groups
+
+
+async def decide_loop_artifacts(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    caller: ResolvedMember,
+    loop: LoopRun,
+    payload: LoopDecisionRequest,
+) -> LoopDecisionResponse:
+    """S5: variant 슬롯(variant_group)별 결정 — 1콜에 다중 그룹 동시 결정 허용. human-only는 호출부
+    (라우터)가 gates.py 동형 패턴(caller.type!='human'→403)으로 선행 검증한다.
+
+    chosen SSOT는 loop_artifacts.decision(그룹별) — loop_runs.chosen_artifact_id는 loop 전체가
+    단일 variant_group일 때만 편의상 stamp(다중슬롯이면 NULL 유지, 승자는 GET .../artifacts로).
+    status 전이(deciding→executing)는 loop의 **전 슬롯이 결판났을 때만**(pending 아티팩트 0)."""
+    if loop.status != "deciding":
+        raise LoopServiceError("LOOP_NOT_IN_DECIDING_STATE", "루프가 deciding 상태가 아닙니다.")
+
+    from app.services.gate_service import create_gate, transition_gate
+    from app.services.workflow_line_config import _default_role_id
+
+    role_id = await _default_role_id(session, org_id) or uuid.uuid4()
+    gate = await create_gate(
+        session, org_id, loop.id, "loop", "loop_decision",
+        caller.id, role_id,
+        neutral_facts={"requested_by_member_id": str(caller.id), "loop_title": loop.title},
+    )
+    # 재-결정 방지: 이 loop의 결정 프로세스가 이미 종결(approved/rejected)됐으면 side-effect 전 조기 차단.
+    if gate.status != "pending":
+        raise LoopServiceError("GATE_ALREADY_RESOLVED", "이 루프의 결정은 이미 종결되었습니다.")
+
+    artifact_repo = LoopArtifactRepository(session, org_id)
+    loop_repo = LoopRunRepository(session, org_id)
+
+    for group_decision in payload.decisions:
+        pending = await artifact_repo.list_pending_by_group(loop.id, group_decision.variant_group)
+        if not pending:
+            raise LoopServiceError(
+                "NO_PENDING_ARTIFACTS_IN_GROUP",
+                f"variant_group '{group_decision.variant_group}'에 결정할 pending 아티팩트가 없습니다.",
+            )
+        pending_ids = {a.id for a in pending}
+        rejection_ids = {r.artifact_id for r in group_decision.rejections}
+        expected = {group_decision.chosen_artifact_id} | rejection_ids
+        if expected != pending_ids or group_decision.chosen_artifact_id in rejection_ids:
+            raise LoopServiceError(
+                "ARTIFACT_SET_MISMATCH",
+                f"variant_group '{group_decision.variant_group}'의 chosen+rejections가 "
+                "pending 아티팩트 집합과 정확히 일치해야 합니다.",
+            )
+        await artifact_repo.update(
+            group_decision.chosen_artifact_id,
+            decision="chosen", choose_reason=group_decision.choose_reason,
+        )
+        for rejection in group_decision.rejections:
+            await artifact_repo.update(
+                rejection.artifact_id,
+                decision="rejected", rejection_reason=rejection.rejection_reason,
+            )
+
+    # decision_gate_id는 매 콜(gate 생성 시점부터) stamp — FE가 진행중 게이트를 참조할 수 있게.
+    if loop.decision_gate_id != gate.id:
+        loop = await loop_repo.update(loop.id, decision_gate_id=gate.id)
+
+    all_groups_decided = await artifact_repo.count_pending(loop.id) == 0
+    if all_groups_decided:
+        if not is_valid_transition(loop.status, "executing"):
+            raise LoopServiceError(
+                "INVALID_LOOP_TRANSITION", f"불법 전이: {loop.status} → executing"
+            )
+        gate = await transition_gate(session, org_id, gate.id, "approved", resolver_id=caller.id)
+        update_fields: dict = {"status": "executing", "decision_gate_id": gate.id}
+        groups = await artifact_repo.distinct_variant_groups(loop.id)
+        # 단일슬롯 편의 stamp — 다중슬롯이면 chosen_artifact_id는 NULL 유지(승자는 그룹별 GET로).
+        if len(groups) == 1:
+            chosen_id = (await session.execute(
+                select(LoopArtifact.id).where(
+                    LoopArtifact.org_id == org_id, LoopArtifact.loop_id == loop.id,
+                    LoopArtifact.decision == "chosen",
+                )
+            )).scalar_one_or_none()
+            if chosen_id is not None:
+                update_fields["chosen_artifact_id"] = chosen_id
+        loop = await loop_repo.update(loop.id, **update_fields)
+
+    return LoopDecisionResponse(
+        loop=LoopResponse.model_validate(loop),
+        gate_id=gate.id,
+        gate_status=gate.status,
+        all_groups_decided=all_groups_decided,
+    )

--- a/backend/tests/test_e_loop_ledger_s5_decision_gate.py
+++ b/backend/tests/test_e_loop_ledger_s5_decision_gate.py
@@ -8,6 +8,9 @@ S5 고유 가치(비-tautological):
 ⓓ 부분 결정: 일부 그룹만 결정 시 loop 'deciding' 유지(전 슬롯 결판나야 executing 전이).
 ⓔ 재-결정 방지(GATE_ALREADY_RESOLVED) + LOOP_NOT_IN_DECIDING_STATE.
 ⓕ 단일슬롯 chosen_artifact_id stamp vs 다중슬롯 NULL 유지.
+ⓖ 1콜 내 다중 그룹 중 하나가 실패하면(같은 트랜잭션) 앞서 처리된 그룹도 rollback 시 원복
+   (BaseRepository/create_gate/transition_gate 전부 flush만·commit 안 함을 실 DB로 실증 —
+   get_db 의존성의 except:rollback 패턴이 실제로 지킬 무결성 조건).
 
 DB env(ALEMBIC_DATABASE_URL) 없으면 realdb 파트 skip.
 """
@@ -212,6 +215,62 @@ async def test_decide_loop_not_deciding_state_409():
                 )
             assert ei.value.status_code == 409
             assert ei.value.detail["code"] == "LOOP_NOT_IN_DECIDING_STATE"
+    finally:
+        await eng.dispose()
+
+
+# ── ⓖ 1콜 내 부분실패 원자성(까심 QA 지적 지점) ──────────────────────────────
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_decide_partial_failure_within_one_call_rolls_back_earlier_group():
+    """decisions=[headline(유효), cta(mismatch)] 한 콜 — cta에서 실패하면 headline도
+    session.rollback() 후 pending으로 원복돼야 한다(BaseRepository/create_gate/transition_gate가
+    flush만 하고 commit하지 않는다는 설계를 실제 DB round-trip으로 실증 — get_db 의존성의
+    except:rollback 패턴이 프로덕션에서 지킬 원자성을 여기서는 명시적으로 재현·검증한다)."""
+    from app.repositories.loop import LoopRunRepository
+    from app.services.loop import LoopServiceError, decide_loop_artifacts
+    from app.services.member_resolver import resolve_member
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            loop_id = await _seed_loop(s)
+            h1 = await _seed_artifact(s, loop_id, "headline", "A")
+            h2 = await _seed_artifact(s, loop_id, "headline", "B")
+            c1 = await _seed_artifact(s, loop_id, "cta", "A")
+            await _seed_artifact(s, loop_id, "cta", "B")
+
+        async with Session() as s:
+            loop = await LoopRunRepository(s, ORG).get(loop_id)
+            caller = await resolve_member(_auth(), ORG, s, project_id=loop.project_id)
+            with pytest.raises(LoopServiceError) as ei:
+                await decide_loop_artifacts(
+                    s, ORG, caller, loop,
+                    LoopDecisionRequest(decisions=[
+                        VariantGroupDecision(
+                            variant_group="headline", chosen_artifact_id=h1, choose_reason="best",
+                            rejections=[LoopArtifactRejection(artifact_id=h2, rejection_reason="worse")],
+                        ),
+                        VariantGroupDecision(
+                            # cta: rejections 누락 — mismatch로 실패 유도(headline은 이미 flush됨).
+                            variant_group="cta", chosen_artifact_id=c1, choose_reason="best cta",
+                            rejections=[],
+                        ),
+                    ]),
+                )
+            assert ei.value.code == "ARTIFACT_SET_MISMATCH"
+            # get_db 의존성이 실제로 하는 것과 동일: 예외 시 rollback.
+            await s.rollback()
+
+        # 완전히 새 세션/커넥션으로 재조회 — 커밋되지 않았다면 headline도 여전히 pending.
+        async with Session() as s:
+            from app.models.loop import LoopArtifact
+            fetched_h1 = (await s.execute(select(LoopArtifact).where(LoopArtifact.id == h1))).scalar_one()
+            fetched_h2 = (await s.execute(select(LoopArtifact).where(LoopArtifact.id == h2))).scalar_one()
+            assert fetched_h1.decision == "pending", "headline chosen이 rollback 후에도 남아있으면 원자성 위반"
+            assert fetched_h2.decision == "pending", "headline rejected이 rollback 후에도 남아있으면 원자성 위반"
     finally:
         await eng.dispose()
 

--- a/backend/tests/test_e_loop_ledger_s5_decision_gate.py
+++ b/backend/tests/test_e_loop_ledger_s5_decision_gate.py
@@ -1,0 +1,464 @@
+"""E-LOOP-LEDGER S5(story f07b7a52): POST /api/v2/loops/{loop_id}/decision 검증.
+
+결정은 variant_group(슬롯) 단위(선생님 결정#2, 오르테가 크루 정정) — loop 전체 1개 아님.
+S5 고유 가치(비-tautological):
+ⓐ 이유 필수화(choose/rejection_reason min_length=1) — 스키마 레벨 구조적 거부.
+ⓑ human-only — gate_service._ALWAYS_MANUAL_GATE_TYPES + 라우터 명시 체크 이중.
+ⓒ 슬롯별 ARTIFACT_SET_MISMATCH(초과/누락) + NO_PENDING_ARTIFACTS_IN_GROUP.
+ⓓ 부분 결정: 일부 그룹만 결정 시 loop 'deciding' 유지(전 슬롯 결판나야 executing 전이).
+ⓔ 재-결정 방지(GATE_ALREADY_RESOLVED) + LOOP_NOT_IN_DECIDING_STATE.
+ⓕ 단일슬롯 chosen_artifact_id stamp vs 다중슬롯 NULL 유지.
+
+DB env(ALEMBIC_DATABASE_URL) 없으면 realdb 파트 skip.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.routers import loops as r
+from app.schemas.loop import LoopArtifactRejection, LoopDecisionRequest, VariantGroupDecision
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── ⓐⓑ 구조 검증(유닛, DB 불요) ─────────────────────────────────────────────
+
+def test_error_status_map_covers_decision_codes():
+    expected = {
+        "LOOP_NOT_IN_DECIDING_STATE", "GATE_ALREADY_RESOLVED",
+        "NO_PENDING_ARTIFACTS_IN_GROUP", "ARTIFACT_SET_MISMATCH", "INVALID_LOOP_TRANSITION",
+    }
+    assert expected <= set(r._ERROR_STATUS)
+
+
+def test_variant_group_decision_has_single_chosen_field_not_list():
+    # 구조상 그룹당 chosen은 정확히 1개 필드(list 아님) — API가 2 chosen을 애초에 표현 불가.
+    fields = VariantGroupDecision.model_fields
+    assert fields["chosen_artifact_id"].annotation is uuid.UUID
+
+
+def test_choose_reason_empty_raises_validation_error():
+    with pytest.raises(ValidationError):
+        VariantGroupDecision(
+            variant_group="headline", chosen_artifact_id=uuid.uuid4(), choose_reason="",
+            rejections=[],
+        )
+
+
+def test_rejection_reason_empty_raises_validation_error():
+    with pytest.raises(ValidationError):
+        LoopArtifactRejection(artifact_id=uuid.uuid4(), rejection_reason="")
+
+
+def test_decisions_list_requires_at_least_one_entry():
+    with pytest.raises(ValidationError):
+        LoopDecisionRequest(decisions=[])
+
+
+# ── realdb ───────────────────────────────────────────────────────────────────
+
+pytestmark_db = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("1f000000-0000-0000-0000-000000000001")
+USER = uuid.UUID("1f000000-0000-0000-0000-0000000000a1")
+OM = uuid.UUID("1f000000-0000-0000-0000-0000000000b1")
+AGENT = uuid.UUID("1f000000-0000-0000-0000-0000000000d1")
+PROJ_A = uuid.UUID("1f000000-0000-0000-0000-000000000002")
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+
+
+def _agent_auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(AGENT), email=None,
+        claims={"app_metadata": {"api_key_id": "ak_test", "org_id": str(ORG)}},
+        org_id=str(ORG),
+    )
+
+
+async def _seed(s):
+    for sql in [
+        f"DELETE FROM gate WHERE org_id='{ORG}'",
+        f"DELETE FROM asset_links WHERE org_id='{ORG}'",
+        f"DELETE FROM loop_artifacts WHERE org_id='{ORG}'",
+        f"DELETE FROM loop_runs WHERE org_id='{ORG}'",
+        f"DELETE FROM assets WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ_A}'",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','C1F','c1forg','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@c1f.test','x','U',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
+        f"INSERT INTO members (id,org_id,type,name,is_active) VALUES ('{AGENT}','{ORG}','agent','Ag',true)",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_A}','{ORG}','A')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ_A}','{OM}','granted')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ_A}',NULL,'{AGENT}','granted')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _seed_loop(s, status="deciding") -> uuid.UUID:
+    from app.repositories.loop import LoopRunRepository
+    repo = LoopRunRepository(s, ORG)
+    loop = await repo.create(
+        project_id=PROJ_A, title="L", goal_tags=[], status=status,
+        created_by_member_id=uuid.uuid4(),
+    )
+    await s.commit()
+    return loop.id
+
+
+async def _seed_artifact(s, loop_id, variant_group, variant_label) -> uuid.UUID:
+    from app.models.asset import Asset
+    from app.models.loop import LoopArtifact
+    asset = Asset(
+        id=uuid.uuid4(), org_id=ORG, project_id=PROJ_A, container="uploads",
+        object_path=f"org/{ORG}/asset-{uuid.uuid4().hex[:8]}.png", name="a.png", size_bytes=1,
+    )
+    s.add(asset)
+    await s.flush()
+    artifact = LoopArtifact(
+        id=uuid.uuid4(), org_id=ORG, loop_id=loop_id, asset_id=asset.id,
+        variant_group=variant_group, variant_label=variant_label, decision="pending",
+        created_by_member_id=uuid.uuid4(),
+    )
+    s.add(artifact)
+    await s.commit()
+    return artifact.id
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+# ── ⓑ human-only ─────────────────────────────────────────────────────────────
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_decide_agent_forbidden_403():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            loop_id = await _seed_loop(s)
+            a1 = await _seed_artifact(s, loop_id, "headline", "A")
+            a2 = await _seed_artifact(s, loop_id, "headline", "B")
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await r.decide_loop(
+                    loop_id=loop_id,
+                    body=LoopDecisionRequest(decisions=[VariantGroupDecision(
+                        variant_group="headline", chosen_artifact_id=a1, choose_reason="best",
+                        rejections=[LoopArtifactRejection(artifact_id=a2, rejection_reason="worse")],
+                    )]),
+                    session=s, auth=_agent_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 403
+            assert ei.value.detail["code"] == "DECISION_HUMAN_ONLY"
+    finally:
+        await eng.dispose()
+
+
+# ── ⓔ 전제 상태 ────────────────────────────────────────────────────────────
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_decide_loop_not_deciding_state_409():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            loop_id = await _seed_loop(s, status="draft")
+            a1 = await _seed_artifact(s, loop_id, "headline", "A")
+            a2 = await _seed_artifact(s, loop_id, "headline", "B")
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await r.decide_loop(
+                    loop_id=loop_id,
+                    body=LoopDecisionRequest(decisions=[VariantGroupDecision(
+                        variant_group="headline", chosen_artifact_id=a1, choose_reason="best",
+                        rejections=[LoopArtifactRejection(artifact_id=a2, rejection_reason="worse")],
+                    )]),
+                    session=s, auth=_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 409
+            assert ei.value.detail["code"] == "LOOP_NOT_IN_DECIDING_STATE"
+    finally:
+        await eng.dispose()
+
+
+# ── ⓒ 그룹별 mismatch ─────────────────────────────────────────────────────
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_decide_artifact_set_mismatch_missing_rejection():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            loop_id = await _seed_loop(s)
+            a1 = await _seed_artifact(s, loop_id, "headline", "A")
+            await _seed_artifact(s, loop_id, "headline", "B")  # 누락 — rejections에 안 넣음
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await r.decide_loop(
+                    loop_id=loop_id,
+                    body=LoopDecisionRequest(decisions=[VariantGroupDecision(
+                        variant_group="headline", chosen_artifact_id=a1, choose_reason="best",
+                        rejections=[],
+                    )]),
+                    session=s, auth=_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 422
+            assert ei.value.detail["code"] == "ARTIFACT_SET_MISMATCH"
+    finally:
+        await eng.dispose()
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_decide_artifact_set_mismatch_extra_unrelated_artifact():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            loop_id = await _seed_loop(s)
+            a1 = await _seed_artifact(s, loop_id, "headline", "A")
+            a2 = await _seed_artifact(s, loop_id, "headline", "B")
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await r.decide_loop(
+                    loop_id=loop_id,
+                    body=LoopDecisionRequest(decisions=[VariantGroupDecision(
+                        variant_group="headline", chosen_artifact_id=a1, choose_reason="best",
+                        rejections=[
+                            LoopArtifactRejection(artifact_id=a2, rejection_reason="worse"),
+                            LoopArtifactRejection(artifact_id=uuid.uuid4(), rejection_reason="ghost"),
+                        ],
+                    )]),
+                    session=s, auth=_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 422
+            assert ei.value.detail["code"] == "ARTIFACT_SET_MISMATCH"
+    finally:
+        await eng.dispose()
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_decide_no_pending_artifacts_in_group_422():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            loop_id = await _seed_loop(s)
+            # headline 아티팩트 아예 없음(오타/미존재 그룹).
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await r.decide_loop(
+                    loop_id=loop_id,
+                    body=LoopDecisionRequest(decisions=[VariantGroupDecision(
+                        variant_group="typo-group", chosen_artifact_id=uuid.uuid4(),
+                        choose_reason="best", rejections=[],
+                    )]),
+                    session=s, auth=_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 422
+            assert ei.value.detail["code"] == "NO_PENDING_ARTIFACTS_IN_GROUP"
+    finally:
+        await eng.dispose()
+
+
+# ── ⓔ gate가 loop.status와 별개로 이미 종결된 방어적 엣지케이스 ─────────────────
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_decide_gate_already_resolved_while_loop_still_deciding_409():
+    """loop.status='deciding'인데 그 loop의 gate가 (예: 외부/직접 경로로) 이미 approved인
+    비정상 상태 — decide_loop_artifacts는 LOOP_NOT_IN_DECIDING_STATE 이전에 이 gate 체크로
+    막혀야 한다(실제로는 loop.status가 deciding이라 그 체크는 통과하고 gate 체크가 잡음)."""
+    from app.services.gate_service import create_gate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            loop_id = await _seed_loop(s)
+            a1 = await _seed_artifact(s, loop_id, "headline", "A")
+            await _seed_artifact(s, loop_id, "headline", "B")
+            gate = await create_gate(
+                s, ORG, loop_id, "loop", "loop_decision", OM, uuid.uuid4(),
+                neutral_facts={"requested_by_member_id": str(OM)},
+            )
+            gate.status = "approved"
+            await s.commit()
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await r.decide_loop(
+                    loop_id=loop_id,
+                    body=LoopDecisionRequest(decisions=[VariantGroupDecision(
+                        variant_group="headline", chosen_artifact_id=a1, choose_reason="x",
+                        rejections=[],
+                    )]),
+                    session=s, auth=_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 409
+            assert ei.value.detail["code"] == "GATE_ALREADY_RESOLVED"
+    finally:
+        await eng.dispose()
+
+
+# ── ⓕ 성공: 단일슬롯 → executing + chosen_artifact_id stamp ────────────────────
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_decide_single_group_success_transitions_and_stamps_chosen():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            loop_id = await _seed_loop(s)
+            a1 = await _seed_artifact(s, loop_id, "headline", "A")
+            a2 = await _seed_artifact(s, loop_id, "headline", "B")
+
+        async with Session() as s:
+            out = await r.decide_loop(
+                loop_id=loop_id,
+                body=LoopDecisionRequest(decisions=[VariantGroupDecision(
+                    variant_group="headline", chosen_artifact_id=a1, choose_reason="best copy",
+                    rejections=[LoopArtifactRejection(artifact_id=a2, rejection_reason="weaker CTA")],
+                )]),
+                session=s, auth=_auth(), org_id=ORG,
+            )
+            await s.commit()
+            assert out.all_groups_decided is True
+            assert out.gate_status == "approved"
+            assert out.loop.status == "executing"
+            assert out.loop.chosen_artifact_id == a1
+
+        async with Session() as s:
+            from app.models.gate import Gate
+            from app.models.loop import LoopArtifact
+            chosen = (await s.execute(select(LoopArtifact).where(LoopArtifact.id == a1))).scalar_one()
+            rejected = (await s.execute(select(LoopArtifact).where(LoopArtifact.id == a2))).scalar_one()
+            assert chosen.decision == "chosen" and chosen.choose_reason == "best copy"
+            assert rejected.decision == "rejected" and rejected.rejection_reason == "weaker CTA"
+            gate = (await s.execute(
+                select(Gate).where(Gate.org_id == ORG, Gate.work_item_id == loop_id, Gate.gate_type == "loop_decision")
+            )).scalar_one()
+            assert gate.status == "approved"
+            assert gate.resolver_id == OM
+    finally:
+        await eng.dispose()
+
+
+# ── ⓓⓕ 부분 결정: 다중슬롯 → 전 슬롯 결판나야 executing, chosen_artifact_id NULL 유지 ──────
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_decide_multi_group_partial_then_complete():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            loop_id = await _seed_loop(s)
+            h1 = await _seed_artifact(s, loop_id, "headline", "A")
+            h2 = await _seed_artifact(s, loop_id, "headline", "B")
+            c1 = await _seed_artifact(s, loop_id, "cta", "A")
+            c2 = await _seed_artifact(s, loop_id, "cta", "B")
+
+        # 1단계: headline만 결정 — 전 슬롯 미결판(cta 남음).
+        async with Session() as s:
+            out1 = await r.decide_loop(
+                loop_id=loop_id,
+                body=LoopDecisionRequest(decisions=[VariantGroupDecision(
+                    variant_group="headline", chosen_artifact_id=h1, choose_reason="best",
+                    rejections=[LoopArtifactRejection(artifact_id=h2, rejection_reason="worse")],
+                )]),
+                session=s, auth=_auth(), org_id=ORG,
+            )
+            await s.commit()
+            assert out1.all_groups_decided is False
+            assert out1.loop.status == "deciding"
+            assert out1.loop.chosen_artifact_id is None
+
+        # 재-결정(headline) 시도는 이미 pending 0이라 NO_PENDING_ARTIFACTS_IN_GROUP.
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await r.decide_loop(
+                    loop_id=loop_id,
+                    body=LoopDecisionRequest(decisions=[VariantGroupDecision(
+                        variant_group="headline", chosen_artifact_id=h1, choose_reason="again",
+                        rejections=[],
+                    )]),
+                    session=s, auth=_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 422
+            assert ei.value.detail["code"] == "NO_PENDING_ARTIFACTS_IN_GROUP"
+
+        # 2단계: cta 결정 — 전 슬롯 결판(executing 전이). 2개 distinct group이라 chosen_artifact_id는 NULL 유지.
+        async with Session() as s:
+            out2 = await r.decide_loop(
+                loop_id=loop_id,
+                body=LoopDecisionRequest(decisions=[VariantGroupDecision(
+                    variant_group="cta", chosen_artifact_id=c1, choose_reason="best cta",
+                    rejections=[LoopArtifactRejection(artifact_id=c2, rejection_reason="weak cta")],
+                )]),
+                session=s, auth=_auth(), org_id=ORG,
+            )
+            await s.commit()
+            assert out2.all_groups_decided is True
+            assert out2.loop.status == "executing"
+            assert out2.loop.chosen_artifact_id is None  # 다중슬롯 — SSOT는 loop_artifacts.decision
+
+        # 재-결정 완전 종결 후 시도 → 409(loop이 이미 'executing'으로 떠나 LOOP_NOT_IN_DECIDING_STATE가
+        # GATE_ALREADY_RESOLVED보다 먼저 잡힌다 — loop.status가 deciding일 때만 gate 체크까지 도달하므로,
+        # 이 시나리오에서 더 정확한 신호. GATE_ALREADY_RESOLVED는 gate가 loop.status와 별개로 외부
+        # 경로(generic gates.py)로 먼저 종결되는 방어적 엣지케이스용 — 별도 유닛으로 커버).
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await r.decide_loop(
+                    loop_id=loop_id,
+                    body=LoopDecisionRequest(decisions=[VariantGroupDecision(
+                        variant_group="cta", chosen_artifact_id=c1, choose_reason="again",
+                        rejections=[],
+                    )]),
+                    session=s, auth=_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 409
+            assert ei.value.detail["code"] == "LOOP_NOT_IN_DECIDING_STATE"
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## Summary
- E-LOOP-LEDGER S5(story `f07b7a52`), the last spine BE story (5/6): the loop's variant-selection decision point — a human-only HITL gate.
- Decision is scoped **per variant_group (slot)**, not loop-wide (corrected during crux review per PO's directive — a loop can have multiple slots, e.g. headline/image/CTA, each with its own winner; loop-wide-1-chosen was the initial misreading of the blueprint's "exactly 1"). One call can decide multiple slots at once.
- Reuses the existing `gates.py`/`gate_service.py` infrastructure directly: `create_gate` (idempotent, `work_item_type='loop'`, `gate_type='loop_decision'`) and `transition_gate` (FSM + verdict-recording + workflow-line-resolution side-effects — all confirmed safe no-ops for this new gate/work-item type combo, since every side-effect branch in `gate_service.py` is `gate_type`/`work_item_type`-gated).
- `'loop_decision'` added to `gate_service._ALWAYS_MANUAL_GATE_TYPES` (same precedent as `doc_approval` — always human-pending regardless of org auto-approve posture; deliberately excluded from `GATE_TYPES` too, mirroring `doc_approval`'s exclusion, since org-admin gate-override config doesn't apply to a gate that's always manual).
- **authz**: loop project access via `resolve_member(project_id=loop.project_id)` (protected by the #1815 root-fix) + an explicit human-only check mirroring `gates.py`'s `transition_gate_endpoint` (`caller.type != "human"` → 403) — agents cannot approve this gate.
- `chosen` is SSOT'd in `loop_artifacts.decision` (per-group). `loop_runs.chosen_artifact_id` is a single-slot convenience column — stamped only when the loop has exactly one distinct `variant_group`; left `NULL` for multi-slot loops (per PO decision #2, consistent with S2's per-`variant_group` partial-unique constraint).
- `choose_reason`/`rejection_reason` are structurally required (`Field(min_length=1)`) — empty string is a 422 at the schema layer, not a runtime check.
- `deciding → executing` status transition (via `is_valid_transition`) only fires once **every** pending artifact across **all** slots of the loop has been decided — partial decisions leave the loop in `deciding` and the gate in `pending`.
- No migration — pure service layer.

## Test plan
- [x] `alembic upgrade head` stays at `0150`.
- [x] `Base.metadata.create_all()` + `drop_all()` fresh-runnable clean.
- [x] New `tests/test_e_loop_ledger_s5_decision_gate.py` (13 tests, non-tautological):
  - Empty `choose_reason`/`rejection_reason` → `pydantic.ValidationError` at construction (structural 422 proof).
  - `VariantGroupDecision.chosen_artifact_id` asserted to be a single `UUID` field (not a list) — API can't even represent "2 chosen" by construction.
  - Agent caller → 403 `DECISION_HUMAN_ONLY`.
  - Loop not in `deciding` state → 409.
  - Per-group `ARTIFACT_SET_MISMATCH`: missing rejection and extra/unrelated artifact_id, both asserted.
  - Nonexistent/already-decided group → 422 `NO_PENDING_ARTIFACTS_IN_GROUP`.
  - Single-slot success: asserts `all_groups_decided`, `gate_status == "approved"`, `loop.status == "executing"`, `loop.chosen_artifact_id == chosen`, the actual `LoopArtifact` rows' `decision`/`*_reason` fields, and the real `Gate` row's `status`/`resolver_id`.
  - Multi-slot: decide slot 1 → asserts loop stays `deciding`, `chosen_artifact_id` stays `None`; re-decide the same (now-empty) slot → 422; decide slot 2 → asserts `executing` transition fires and `chosen_artifact_id` stays `None` (multi-slot NULL); re-decide after full completion → 409 `LOOP_NOT_IN_DECIDING_STATE`.
  - Dedicated edge-case test for `GATE_ALREADY_RESOLVED` (gate externally resolved while loop is still `deciding`) — constructed directly via `gate_service.create_gate` to actually exercise that guard path.
- [x] S1–S4 loop tests (46 tests) + `resolve_member` IDOR regression + HITL/gate test files (102 tests total) pass unchanged.
- [x] Full suite diffed against the pre-existing baseline (87 failures, established across S3/#1815/S4/rebase runs) — **byte-identical failure set**, zero new regressions.

Depends on S2 (merged) + `gates.py`/`gate_service.py` (existing) + the resolve_member root-fix (#1815, merged). Next: S6 (board UI, FE).