### PR TITLE
feat(e-loop-ledger): S7 — hypothesis resolution → loop outcome attribution wiring

### DIFF
--- a/backend/app/routers/loops.py
+++ b/backend/app/routers/loops.py
@@ -53,6 +53,8 @@ _ERROR_STATUS: dict[str, int] = {
     "LOOP_PROJECT_ACCESS_DENIED": 403,
     "ASSET_NOT_FOUND": 404,
     "ASSET_PROJECT_MISMATCH": 403,
+    "HYPOTHESIS_NOT_FOUND": 404,
+    "HYPOTHESIS_PROJECT_MISMATCH": 403,
     "LOOP_NOT_IN_DECIDING_STATE": 409,
     "GATE_ALREADY_RESOLVED": 409,
     "NO_PENDING_ARTIFACTS_IN_GROUP": 422,
@@ -96,7 +98,10 @@ async def create_loop(
 ) -> LoopResponse:
     # resolve_member(project_id)가 프로젝트 접근을 검증한다(hypotheses.create_hypothesis와 동형).
     caller = await resolve_member(auth, org_id, session, project_id=body.project_id)
-    return await svc.create_loop(session, org_id, caller, body)
+    try:
+        return await svc.create_loop(session, org_id, caller, body)
+    except svc.LoopServiceError as err:
+        _raise(err)
 
 
 @router.get("/{loop_id}", response_model=LoopResponse)

--- a/backend/app/services/hypothesis_scorer.py
+++ b/backend/app/services/hypothesis_scorer.py
@@ -67,7 +67,10 @@ async def score_hypotheses(session: AsyncSession) -> dict[str, Any]:
     # HO-S4: 해소(verified/falsified) 직후 outcome verdict 배선 결과(가설 적중 이력→trust).
     verdicts_recorded: list[dict] = []
     verdicts_skipped: list[dict] = []
+    # E-LOOP-LEDGER S7: 해소 직후 loop outcome 귀속 배선 결과(복리 되먹임 고리).
+    loops_attributed: list[dict] = []
     from app.services.hypothesis_outcome_verdict import record_outcome_verdicts
+    from app.services.loop_outcome_attribution import attribute_loop_outcome
 
     hyps = (await session.execute(
         select(Hypothesis).where(
@@ -115,6 +118,11 @@ async def score_hypotheses(session: AsyncSession) -> dict[str, Any]:
                     "bet": vres.get("bet", []),
                     "execution": vres.get("execution", []),
                 })
+            # E-LOOP-LEDGER S7: 이 가설에 연결된 measuring 상태 loop 귀속(있으면). loop이 아직
+            # measuring에 도달하지 못했으면(전이 배선 갭·별도 스토리) no_measuring_loop로 skip.
+            lres = await attribute_loop_outcome(session, hyp)
+            if lres.get("attributed"):
+                loops_attributed.append({"hypothesis_id": str(hyp.id), "loop_ids": lres["attributed"]})
         else:
             pending.append(str(hyp.id))  # measuring 유지
 
@@ -127,5 +135,7 @@ async def score_hypotheses(session: AsyncSession) -> dict[str, Any]:
         "total": len(hyps),
         # HO-S4(AC②): outcome verdict 배선 결과를 cron response에 노출.
         "verdicts_recorded": verdicts_recorded,
+        # S7: loop outcome 귀속 결과를 cron response에 노출(관측 정직성).
+        "loops_attributed": loops_attributed,
         "verdicts_skipped": verdicts_skipped,
     }

--- a/backend/app/services/loop.py
+++ b/backend/app/services/loop.py
@@ -15,6 +15,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.asset import Asset, AssetLink
+from app.models.hypothesis import Hypothesis
 from app.models.loop import LoopArtifact, LoopRun, is_valid_transition
 from app.repositories.loop import LoopArtifactRepository, LoopRunRepository
 from app.schemas.loop import (
@@ -62,6 +63,23 @@ async def create_loop(
 ) -> LoopResponse:
     # resolve_member(project_id=...)가 이미 호출부(라우터)에서 caller의 project 접근을
     # 검증했으므로 여기서는 재검증하지 않는다(hypotheses.create_hypothesis와 동형).
+    #
+    # 까심 QA CRITICAL(#1818 S7 QA) — hypothesis_id는 FK만 있고 소유검증이 없었다(S4의
+    # ASSET_PROJECT_MISMATCH와 같은 크로스-리소스 IDOR 축이 빠짐). 타 org의 hypothesis_id를
+    # loop에 연결하면 그 hypothesis가 나중에 resolved될 때 attribute_loop_outcome이 그
+    # hypothesis의 기밀 outcome_result를 이 org의 loop에 stamp — cross-org 데이터 유출(까심
+    # 실재현). 여기서 원천 차단(S4 asset 패턴 그대로 미러).
+    if payload.hypothesis_id is not None:
+        hyp = (await session.execute(
+            select(Hypothesis).where(Hypothesis.id == payload.hypothesis_id, Hypothesis.org_id == org_id)
+        )).scalar_one_or_none()
+        if hyp is None:
+            raise LoopServiceError("HYPOTHESIS_NOT_FOUND", "가설을 찾을 수 없습니다.")
+        if hyp.project_id != payload.project_id:
+            raise LoopServiceError(
+                "HYPOTHESIS_PROJECT_MISMATCH", "가설이 이 루프와 같은 프로젝트에 속하지 않습니다."
+            )
+
     repo = LoopRunRepository(session, org_id)
     loop = await repo.create(
         project_id=payload.project_id,

--- a/backend/app/services/loop_outcome_attribution.py
+++ b/backend/app/services/loop_outcome_attribution.py
@@ -32,9 +32,14 @@ async def attribute_loop_outcome(session: AsyncSession, hypothesis) -> dict[str,
     if hypothesis.status not in _RESOLVED:
         return {"skipped_reason": "not_resolved", "attributed": []}
 
+    # 까심 QA CRITICAL(#1818 S7 QA) — org_id 스코프 없으면 cross-org 데이터 유출: 근본 fix는
+    # create_loop(app/services/loop.py)가 이제 hypothesis_id의 org/project 소속을 생성 시점에
+    # 검증하지만, 여기도 defense-in-depth로 org_id를 명시 필터한다(다른 loop 쿼리들과 일관 —
+    # 미래에 create_loop 가드가 우회/누락되는 경로가 생겨도 이 쿼리 자체가 타org 유출을 차단).
     loops = (await session.execute(
         select(LoopRun).where(
             LoopRun.hypothesis_id == hypothesis.id,
+            LoopRun.org_id == hypothesis.org_id,
             LoopRun.status == "measuring",
         )
     )).scalars().all()

--- a/backend/app/services/loop_outcome_attribution.py
+++ b/backend/app/services/loop_outcome_attribution.py
@@ -1,0 +1,66 @@
+"""E-LOOP-LEDGER S7: hypothesis 해소 → loop outcome 귀속 배선(블루프린트 §7).
+
+hypothesis_outcome_verdict.record_outcome_verdicts(HO-S4)와 완전히 동형 — 호출자
+(hypothesis_scorer.score_hypotheses)가 verified/falsified 전이 직후 호출하고 commit은
+호출자 책임. 신규 cron/엔드포인트 0(기존 outcome-loop 배선 재사용).
+
+⚠️scope: 이 배선은 loop.status=='measuring'인 loop만 대상 — draft→...→deciding·
+executing→measuring 같은 loop 자체의 상태전이 트리거는 별도 스토리(전이 배선 갭, 오르테가
+PO가 보완 스토리로 회수) 스코프다. 여기서는 "이미 measuring인 loop"을 전제로만 동작한다.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.loop import LoopRun, is_valid_transition
+
+_RESOLVED = frozenset({"verified", "falsified"})
+
+
+async def attribute_loop_outcome(session: AsyncSession, hypothesis) -> dict[str, Any]:
+    """resolved(verified/falsified) 가설에 연결된 measuring 상태 loop에 outcome을 귀속.
+
+    hypothesis.status not in (verified,falsified) → skip(not_resolved, HO-S4와 동일 게이팅).
+    loop.hypothesis_id로 연결된 loop 중 status=='measuring'인 것만 대상(measuring→closed만
+    합법 전이라 자연 필터) — 없으면 skip(no_measuring_loop). outcome_attributed_at이 이미
+    있으면 그 loop은 건너뛴다(불변 — 한번 스탬프된 snapshot은 재변경하지 않음).
+    """
+    if hypothesis.status not in _RESOLVED:
+        return {"skipped_reason": "not_resolved", "attributed": []}
+
+    loops = (await session.execute(
+        select(LoopRun).where(
+            LoopRun.hypothesis_id == hypothesis.id,
+            LoopRun.status == "measuring",
+        )
+    )).scalars().all()
+    if not loops:
+        return {"skipped_reason": "no_measuring_loop", "attributed": []}
+
+    now = datetime.now(timezone.utc)
+    attributed: list[str] = []
+    already_attributed: list[str] = []
+    for loop in loops:
+        if loop.outcome_attributed_at is not None:
+            already_attributed.append(str(loop.id))
+            continue
+        if not is_valid_transition(loop.status, "closed"):
+            continue  # 방어: measuring 필터로 이미 보장되지만 FSM SSOT 재확인.
+        loop.outcome_snapshot = {
+            "hypothesis_id": str(hypothesis.id),
+            "hypothesis_status": hypothesis.status,
+            "outcome_result": hypothesis.outcome_result,
+            "attributed_at": now.isoformat(),
+        }
+        loop.outcome_attributed_at = now
+        loop.status = "closed"
+        attributed.append(str(loop.id))
+
+    result: dict[str, Any] = {"attributed": attributed}
+    if already_attributed:
+        result["already_attributed"] = already_attributed
+    return result

--- a/backend/tests/test_e_loop_ledger_s3_loop_crud_api.py
+++ b/backend/tests/test_e_loop_ledger_s3_loop_crud_api.py
@@ -303,3 +303,96 @@ async def test_list_loops_filters_by_status_and_project():
             assert items[0].title == "draft-loop"
     finally:
         await eng.dispose()
+
+
+# ── 까심 QA CRITICAL(#1818 S7 QA) — hypothesis_id 소유검증(cross-org 데이터 유출 근본 차단) ──
+
+async def _seed_hypothesis(s, *, org_id, project_id) -> uuid.UUID:
+    from datetime import datetime, timezone
+    from app.models.hypothesis import Hypothesis
+    hyp = Hypothesis(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, owner_member_id=uuid.uuid4(),
+        statement="s", metric_definition={"metric": "m", "source": "manual", "target": 1, "direction": "up"},
+        measure_after=datetime(2026, 1, 1, tzinfo=timezone.utc), status="active",
+    )
+    s.add(hyp)
+    await s.commit()
+    return hyp.id
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_create_loop_cross_org_hypothesis_forbidden_404():
+    """까심 재현 시나리오 — 타 org의 hypothesis_id로 loop 생성 시도. FK만으론 존재 검증뿐이라
+    통과했을 것(fix 前) — org 스코프 조회로 404(같은 org 안에서 못 찾음, 존재 여부 오라클 최소화)."""
+    other_org = uuid.UUID("1c000000-0000-0000-0000-0000000000ee")
+    other_project = uuid.UUID("1c000000-0000-0000-0000-0000000000ef")
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            for sql in [
+                f"DELETE FROM projects WHERE org_id='{other_org}'",
+                f"DELETE FROM organizations WHERE id='{other_org}'",
+                f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{other_org}','OTH','othorg-1c','free')",
+                f"INSERT INTO projects (id,org_id,name) VALUES ('{other_project}','{other_org}','OTH-P')",
+            ]:
+                await s.execute(text(sql))
+            await s.commit()
+            other_org_hyp_id = await _seed_hypothesis(s, org_id=other_org, project_id=other_project)
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await r.create_loop(
+                    body=LoopCreate(
+                        project_id=PROJ_A, title="leak-attempt", hypothesis_id=other_org_hyp_id,
+                    ),
+                    session=s, auth=_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 404
+            assert ei.value.detail["code"] == "HYPOTHESIS_NOT_FOUND"
+    finally:
+        await eng.dispose()
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_create_loop_cross_project_same_org_hypothesis_forbidden_403():
+    """같은 org 내에서도 hypothesis가 loop과 다른 project 소속이면 403(S4 asset 패턴과 동일 축)."""
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            hyp_in_proj_b = await _seed_hypothesis(s, org_id=ORG, project_id=PROJ_B)
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await r.create_loop(
+                    body=LoopCreate(
+                        project_id=PROJ_A, title="mismatch-attempt", hypothesis_id=hyp_in_proj_b,
+                    ),
+                    session=s, auth=_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 403
+            assert ei.value.detail["code"] == "HYPOTHESIS_PROJECT_MISMATCH"
+    finally:
+        await eng.dispose()
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_create_loop_same_project_hypothesis_succeeds():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            hyp_id = await _seed_hypothesis(s, org_id=ORG, project_id=PROJ_A)
+
+        async with Session() as s:
+            out = await r.create_loop(
+                body=LoopCreate(project_id=PROJ_A, title="ok", hypothesis_id=hyp_id),
+                session=s, auth=_auth(), org_id=ORG,
+            )
+            assert out.hypothesis_id == hyp_id
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_e_loop_ledger_s7_outcome_attribution.py
+++ b/backend/tests/test_e_loop_ledger_s7_outcome_attribution.py
@@ -1,0 +1,363 @@
+"""E-LOOP-LEDGER S7(story acdd92eb): hypothesis 해소 → loop outcome 귀속 배선 검증.
+
+hypothesis_outcome_verdict.record_outcome_verdicts(HO-S4)와 동형 패턴 — 격리(비-tautological,
+happy-path만이 아님)·idempotent·immutable을 실 DB round-trip으로 검증한다.
+
+DB env(ALEMBIC_DATABASE_URL) 없으면 realdb 파트 skip.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.services.loop_outcome_attribution import attribute_loop_outcome
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── 유닛(DB 불요): not_resolved 게이팅 ────────────────────────────────────────
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("status", ["proposed", "active", "measuring", "killed", "archived"])
+async def test_unresolved_status_skips_without_touching_db(status):
+    """verified/falsified가 아닌 전 상태는 DB 조회조차 없이 즉시 skip — session.execute가
+    호출되면 이 mock은 AttributeError로 즉시 실패한다(happy-path만이 아닌 실 게이팅 증명)."""
+    hyp = SimpleNamespace(id=uuid.uuid4(), status=status, outcome_result=None)
+    session = object()  # execute 속성 자체가 없음 — 호출되면 즉시 AttributeError.
+    result = await attribute_loop_outcome(session, hyp)
+    assert result == {"skipped_reason": "not_resolved", "attributed": []}
+
+
+# ── realdb ───────────────────────────────────────────────────────────────────
+
+pytestmark_db = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("20000000-0000-0000-0000-000000000001")
+PROJ = uuid.UUID("20000000-0000-0000-0000-000000000002")
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _seed_org_project(s):
+    for sql in [
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','C2O','c2oorg','free')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ}','{ORG}','P')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _seed_hypothesis(s, status, outcome_result=None):
+    from app.models.hypothesis import Hypothesis
+    hyp = Hypothesis(
+        id=uuid.uuid4(), org_id=ORG, project_id=PROJ, owner_member_id=uuid.uuid4(),
+        statement="s", metric_definition={"metric": "m", "source": "manual", "target": 1, "direction": "up"},
+        measure_after=datetime(2026, 1, 1, tzinfo=timezone.utc), status=status,
+        outcome_result=outcome_result,
+    )
+    s.add(hyp)
+    await s.commit()
+    await s.refresh(hyp)
+    return hyp
+
+
+async def _seed_loop(s, hypothesis_id, status="measuring") -> uuid.UUID:
+    from app.repositories.loop import LoopRunRepository
+    repo = LoopRunRepository(s, ORG)
+    loop = await repo.create(
+        project_id=PROJ, title="L", goal_tags=[], status=status,
+        hypothesis_id=hypothesis_id, created_by_member_id=uuid.uuid4(),
+    )
+    await s.commit()
+    return loop.id
+
+
+async def _fetch_loop(s, loop_id):
+    from app.models.loop import LoopRun
+    return (await s.execute(select(LoopRun).where(LoopRun.id == loop_id))).scalar_one()
+
+
+async def _cleanup(s):
+    for sql in [
+        f"DELETE FROM loop_runs WHERE org_id='{ORG}'",
+        f"DELETE FROM hypotheses WHERE org_id='{ORG}'",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+# ── happy path: verified/falsified 양쪽 ───────────────────────────────────────
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_verified_hypothesis_attributes_measuring_loop_and_closes_it():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            await _cleanup(s)
+            hyp = await _seed_hypothesis(s, "verified", outcome_result={"actual": 120})
+            loop_id = await _seed_loop(s, hyp.id)
+
+            result = await attribute_loop_outcome(s, hyp)
+            await s.commit()
+            assert result["attributed"] == [str(loop_id)]
+
+            loop = await _fetch_loop(s, loop_id)
+            assert loop.status == "closed"
+            assert loop.outcome_attributed_at is not None
+            assert loop.outcome_snapshot == {
+                "hypothesis_id": str(hyp.id),
+                "hypothesis_status": "verified",
+                "outcome_result": {"actual": 120},
+                "attributed_at": loop.outcome_attributed_at.isoformat(),
+            }
+    finally:
+        await eng.dispose()
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_falsified_hypothesis_attributes_and_closes_loop():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            await _cleanup(s)
+            hyp = await _seed_hypothesis(s, "falsified", outcome_result={"actual": 5})
+            loop_id = await _seed_loop(s, hyp.id)
+
+            result = await attribute_loop_outcome(s, hyp)
+            await s.commit()
+            assert result["attributed"] == [str(loop_id)]
+
+            loop = await _fetch_loop(s, loop_id)
+            assert loop.status == "closed"
+            assert loop.outcome_snapshot["hypothesis_status"] == "falsified"
+    finally:
+        await eng.dispose()
+
+
+# ── 격리(비-tautological): 잘못된 상태서 outcome_snapshot 안 채워짐 ─────────────
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_active_hypothesis_does_not_attribute_measuring_loop():
+    """manual/active(미해소) 가설은 measuring loop이 있어도 귀속 0 — snapshot/attributed_at
+    둘 다 None으로 남는지, status도 measuring 그대로인지까지 확인(단순 return값만 X)."""
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            await _cleanup(s)
+            hyp = await _seed_hypothesis(s, "active")
+            loop_id = await _seed_loop(s, hyp.id)
+
+            result = await attribute_loop_outcome(s, hyp)
+            await s.commit()
+            assert result == {"skipped_reason": "not_resolved", "attributed": []}
+
+            loop = await _fetch_loop(s, loop_id)
+            assert loop.status == "measuring"
+            assert loop.outcome_attributed_at is None
+            assert loop.outcome_snapshot is None
+    finally:
+        await eng.dispose()
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_measuring_hypothesis_does_not_attribute():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            await _cleanup(s)
+            hyp = await _seed_hypothesis(s, "measuring")
+            loop_id = await _seed_loop(s, hyp.id)
+
+            result = await attribute_loop_outcome(s, hyp)
+            await s.commit()
+            assert result["skipped_reason"] == "not_resolved"
+
+            loop = await _fetch_loop(s, loop_id)
+            assert loop.outcome_snapshot is None
+    finally:
+        await eng.dispose()
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_verified_hypothesis_with_loop_not_in_measuring_skips():
+    """loop이 executing(measuring 아님)이면 hypothesis가 verified여도 귀속 0 — executing→measuring
+    전이 배선 갭(별도 스토리 스코프) 전제에서 안전하게 no-op함을 확인."""
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            await _cleanup(s)
+            hyp = await _seed_hypothesis(s, "verified", outcome_result={"actual": 1})
+            loop_id = await _seed_loop(s, hyp.id, status="executing")
+
+            result = await attribute_loop_outcome(s, hyp)
+            await s.commit()
+            assert result == {"skipped_reason": "no_measuring_loop", "attributed": []}
+
+            loop = await _fetch_loop(s, loop_id)
+            assert loop.status == "executing"
+            assert loop.outcome_snapshot is None
+    finally:
+        await eng.dispose()
+
+
+# ── idempotent + immutable ────────────────────────────────────────────────────
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_already_attributed_loop_stays_immutable_on_second_call():
+    """이미 attributed된 loop을 재호출해도 outcome_snapshot이 바뀌지 않는다(불변) — status가
+    이미 closed(measuring 아님)라 자연 필터로도 걸리지만, outcome_attributed_at 가드로 이중 방어."""
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            await _cleanup(s)
+            hyp = await _seed_hypothesis(s, "verified", outcome_result={"actual": 1})
+            loop_id = await _seed_loop(s, hyp.id)
+
+            await attribute_loop_outcome(s, hyp)
+            await s.commit()
+            loop_v1 = await _fetch_loop(s, loop_id)
+            snapshot_v1 = dict(loop_v1.outcome_snapshot)
+            attributed_at_v1 = loop_v1.outcome_attributed_at
+
+            # 재호출 — loop이 이미 closed(measuring 아님)라 no_measuring_loop로 skip.
+            result2 = await attribute_loop_outcome(s, hyp)
+            await s.commit()
+            assert result2 == {"skipped_reason": "no_measuring_loop", "attributed": []}
+
+            loop_v2 = await _fetch_loop(s, loop_id)
+            assert dict(loop_v2.outcome_snapshot) == snapshot_v1
+            assert loop_v2.outcome_attributed_at == attributed_at_v1
+    finally:
+        await eng.dispose()
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_manually_reopened_measuring_loop_with_prior_attribution_guarded_by_flag():
+    """outcome_attributed_at이 이미 세팅된 채로(방어적 시나리오) status만 measuring으로 되돌려도
+    attribute_loop_outcome은 그 loop을 재-스탬프하지 않는다(불변 가드가 status 필터와 독립적으로 동작)."""
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            await _cleanup(s)
+            hyp = await _seed_hypothesis(s, "verified", outcome_result={"actual": 1})
+            loop_id = await _seed_loop(s, hyp.id)
+            await attribute_loop_outcome(s, hyp)
+            await s.commit()
+            loop_v1 = await _fetch_loop(s, loop_id)
+            original_snapshot = dict(loop_v1.outcome_snapshot)
+
+            # 방어적 시나리오 시뮬레이션: status를 measuring으로 되돌림(outcome_attributed_at은 유지).
+            from app.repositories.loop import LoopRunRepository
+            await LoopRunRepository(s, ORG).update(loop_id, status="measuring")
+            await s.commit()
+
+            result = await attribute_loop_outcome(s, hyp)
+            await s.commit()
+            assert result["attributed"] == []
+            assert str(loop_id) in result.get("already_attributed", [])
+
+            loop_v2 = await _fetch_loop(s, loop_id)
+            assert dict(loop_v2.outcome_snapshot) == original_snapshot
+    finally:
+        await eng.dispose()
+
+
+# ── 다중 loop 동시 귀속 ────────────────────────────────────────────────────────
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_multiple_measuring_loops_linked_to_same_hypothesis_all_attributed():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            await _cleanup(s)
+            hyp = await _seed_hypothesis(s, "verified", outcome_result={"actual": 1})
+            loop1 = await _seed_loop(s, hyp.id)
+            loop2 = await _seed_loop(s, hyp.id)
+
+            result = await attribute_loop_outcome(s, hyp)
+            await s.commit()
+            assert set(result["attributed"]) == {str(loop1), str(loop2)}
+
+            for lid in (loop1, loop2):
+                loop = await _fetch_loop(s, lid)
+                assert loop.status == "closed"
+    finally:
+        await eng.dispose()
+
+
+# ── 통합: score_hypotheses 배선 경유 ──────────────────────────────────────────
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_score_hypotheses_wires_loop_attribution_end_to_end():
+    from unittest.mock import patch
+
+    from app.models.hypothesis import Hypothesis
+    from app.services import hypothesis_scorer as sc
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            await _cleanup(s)
+            hyp = Hypothesis(
+                id=uuid.uuid4(), org_id=ORG, project_id=PROJ, owner_member_id=uuid.uuid4(),
+                statement="s", metric_definition={"metric": "m", "source": "ga4", "target": 1, "direction": "up"},
+                measure_after=datetime(2020, 1, 1, tzinfo=timezone.utc), status="active",
+            )
+            s.add(hyp)
+            await s.commit()
+            loop_id = await _seed_loop(s, hyp.id)
+
+            with patch.object(
+                sc, "score_ga4_outcome",
+                return_value={"outcome_status": "hit", "outcome_result": {"actual": 5}},
+            ), patch(
+                "app.services.hypothesis_outcome_verdict.record_outcome_verdicts",
+                return_value={"skipped_reason": "no_linked_story", "bet": [], "execution": []},
+            ):
+                summary = await sc.score_hypotheses(s)
+            await s.commit()
+
+            assert str(hyp.id) in summary["verified"]
+            assert summary["loops_attributed"] == [{"hypothesis_id": str(hyp.id), "loop_ids": [str(loop_id)]}]
+
+            loop = await _fetch_loop(s, loop_id)
+            assert loop.status == "closed"
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_e_loop_ledger_s7_outcome_attribution.py
+++ b/backend/tests/test_e_loop_ledger_s7_outcome_attribution.py
@@ -320,6 +320,52 @@ async def test_multiple_measuring_loops_linked_to_same_hypothesis_all_attributed
         await eng.dispose()
 
 
+# ── 까심 QA CRITICAL(#1818) — org_id defense-in-depth(cross-org 유출 근본 2차 방어) ──
+
+OTHER_ORG = uuid.UUID("20000000-0000-0000-0000-0000000000ee")
+OTHER_PROJ = uuid.UUID("20000000-0000-0000-0000-0000000000ef")
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_cross_org_loop_not_attributed_org_scope_defense():
+    """근본 fix는 create_loop(S3)의 hypothesis 소유검증이지만, 여기서는 그 가드를 우회해
+    (레거시 데이터/미래 버그 가정) 타 org의 loop이 이 hypothesis_id를 참조하는 상황을 직접
+    구성해 attribute_loop_outcome 쿼리의 org_id 필터가 독립적으로 유출을 막는지 실증한다."""
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            await _cleanup(s)
+            for sql in [
+                f"DELETE FROM loop_runs WHERE org_id='{OTHER_ORG}'",
+                f"DELETE FROM projects WHERE org_id='{OTHER_ORG}'",
+                f"DELETE FROM organizations WHERE id='{OTHER_ORG}'",
+                f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{OTHER_ORG}','C2X','c2xorg','free')",
+                f"INSERT INTO projects (id,org_id,name) VALUES ('{OTHER_PROJ}','{OTHER_ORG}','OP')",
+            ]:
+                await s.execute(text(sql))
+            await s.commit()
+
+            hyp = await _seed_hypothesis(s, "verified", outcome_result={"secret": "org-A-revenue"})
+            from app.repositories.loop import LoopRunRepository
+            other_loop = await LoopRunRepository(s, OTHER_ORG).create(
+                project_id=OTHER_PROJ, title="leak-target", goal_tags=[], status="measuring",
+                hypothesis_id=hyp.id, created_by_member_id=uuid.uuid4(),
+            )
+            await s.commit()
+
+            result = await attribute_loop_outcome(s, hyp)
+            await s.commit()
+            assert result == {"skipped_reason": "no_measuring_loop", "attributed": []}
+
+            fetched = await _fetch_loop(s, other_loop.id)
+            assert fetched.status == "measuring"
+            assert fetched.outcome_snapshot is None
+    finally:
+        await eng.dispose()
+
+
 # ── 통합: score_hypotheses 배선 경유 ──────────────────────────────────────────
 
 @pytestmark_db

--- a/backend/tests/test_ho_s4_scorer_verdict_wiring.py
+++ b/backend/tests/test_ho_s4_scorer_verdict_wiring.py
@@ -44,7 +44,11 @@ async def test_resolved_calls_wiring_manual_does_not():
 
     spy = AsyncMock(return_value={"skipped_reason": None, "bet": ["b1"], "execution": ["e1"]})
     with patch.object(sc, "score_ga4_outcome", return_value={"outcome_status": "hit", "outcome_result": {"x": 1}}), \
-         patch("app.services.hypothesis_outcome_verdict.record_outcome_verdicts", new=spy):
+         patch("app.services.hypothesis_outcome_verdict.record_outcome_verdicts", new=spy), \
+         patch(
+             "app.services.loop_outcome_attribution.attribute_loop_outcome",
+             new=AsyncMock(return_value={"skipped_reason": "no_measuring_loop", "attributed": []}),
+         ):
         summary = await sc.score_hypotheses(session)
 
     # AC①: verified 가설에만 배선 호출(manual 미호출·AC④).
@@ -65,7 +69,11 @@ async def test_skipped_wiring_goes_to_verdicts_skipped():
     session.execute = AsyncMock(return_value=res)
     spy = AsyncMock(return_value={"skipped_reason": "no_linked_story", "bet": [], "execution": []})
     with patch.object(sc, "score_ga4_outcome", return_value={"outcome_status": "miss", "outcome_result": {}}), \
-         patch("app.services.hypothesis_outcome_verdict.record_outcome_verdicts", new=spy):
+         patch("app.services.hypothesis_outcome_verdict.record_outcome_verdicts", new=spy), \
+         patch(
+             "app.services.loop_outcome_attribution.attribute_loop_outcome",
+             new=AsyncMock(return_value={"skipped_reason": "no_measuring_loop", "attributed": []}),
+         ):
         summary = await sc.score_hypotheses(session)
     assert str(h.id) in summary["falsified"]
     assert summary["verdicts_skipped"] == [{"hypothesis_id": str(h.id), "reason": "no_linked_story"}]

--- a/backend/tests/test_hypothesis_scorer.py
+++ b/backend/tests/test_hypothesis_scorer.py
@@ -29,6 +29,17 @@ def _mock_outcome_verdicts():
         yield
 
 
+@pytest.fixture(autouse=True)
+def _mock_loop_attribution():
+    """E-LOOP-LEDGER S7: scorer가 해소 직후 attribute_loop_outcome도 호출하므로(추가 session.execute
+    1회), _mock_outcome_verdicts와 동일 이유로 전이 로직만 검증하는 기존 테스트에서 격리한다."""
+    with patch(
+        "app.services.loop_outcome_attribution.attribute_loop_outcome",
+        new=AsyncMock(return_value={"skipped_reason": "no_measuring_loop", "attributed": []}),
+    ):
+        yield
+
+
 def _hyp(status="active", source="ga4", **ov):
     md = {"metric": "signups", "source": source, "target": 100, "direction": "up"}
     base = dict(


### PR DESCRIPTION
## Summary
- E-LOOP-LEDGER S7(story `acdd92eb`), P0-b — the first wiring of the compounding feedback loop: when a hypothesis resolves (`verified`/`falsified`), stamp its `outcome_snapshot` onto any linked loop that's currently `measuring`, and close that loop.
- `app/services/loop_outcome_attribution.py::attribute_loop_outcome(session, hypothesis)` — a direct structural mirror of `hypothesis_outcome_verdict.record_outcome_verdicts` (HO-S4): same call convention (caller invokes right after a verified/falsified transition, caller commits), same skip-reason summary-dict return shape.
- **Zero new cron/endpoint** — wired directly alongside the existing `record_outcome_verdicts` call inside `hypothesis_scorer.py::score_hypotheses`, reusing the existing outcome-loop scoring cron entirely.
- Logic: `hypothesis.status not in (verified, falsified)` → skip (`not_resolved`). Linked `loop_runs` (`hypothesis_id=`) filtered to `status == 'measuring'` only (natural filter — `measuring → closed` is the only legal transition). `outcome_attributed_at` already set → skip that loop (immutable, never re-stamped). Otherwise stamps `outcome_snapshot` (`hypothesis_id`/`hypothesis_status`/`outcome_result`/`attributed_at`) + `outcome_attributed_at` + `status = 'closed'`.
- **Scope note** (flagged during crux, confirmed by PO): there is currently no code anywhere in the repo that transitions a loop `executing → measuring` (or `draft → ... → deciding`) — the loop lifecycle transition wiring itself is a gap across S1–S5, not something introduced here. PO is spinning up a separate follow-up story to close it. S7 is purely "hypothesis resolves → attribute to an *already-measuring* loop"; isolated tests seed loops directly in `measuring` state, matching this gap.

## Test plan
- [x] No migration.
- [x] `Base.metadata.create_all()` + `drop_all()` fresh-runnable clean.
- [x] New `tests/test_e_loop_ledger_s7_outcome_attribution.py` (14 tests, non-tautological):
  - Unresolved hypothesis statuses (`proposed`/`active`/`measuring`/`killed`/`archived`) skip *without even calling* `session.execute` — a plain `object()` is passed as the session, so any attempted DB call would raise `AttributeError` immediately.
  - `verified`/`falsified` happy paths: asserts the exact `outcome_snapshot` dict, `status == "closed"`, and `outcome_attributed_at` set.
  - **Isolation (not just happy-path)**: `active`/`measuring` hypothesis with a `measuring` loop attached → loop's `outcome_snapshot`/`outcome_attributed_at` stay `None` and `status` stays `measuring` — proves the wrong-state case doesn't silently fill in data.
  - `verified` hypothesis with the loop in `executing` (not `measuring`) → skipped, loop untouched — proves the "loop hasn't reached measuring yet" scope boundary holds.
  - Idempotent/immutable: attribute once, re-invoke → second call returns `no_measuring_loop` (loop already `closed`) and the original snapshot is asserted byte-identical; a second scenario manually resets `status` back to `measuring` while keeping `outcome_attributed_at` set, re-invokes, and asserts the `outcome_attributed_at` guard still blocks re-stamping (independent of the status filter).
  - Multiple loops linked to the same hypothesis, both `measuring` → both attributed in one call.
  - End-to-end: real `score_hypotheses(session)` call (GA4 scoring mocked to `hit`) drives an `active` hypothesis to `verified` and the linked `measuring` loop to `closed`, asserting the new `loops_attributed` key in the cron summary.
- [x] Fixed 2 pre-existing mock-based scorer test files (`test_hypothesis_scorer.py`, `test_ho_s4_scorer_verdict_wiring.py`) that broke because the new `attribute_loop_outcome` call consumes an additional `session.execute` — added isolation patches mirroring the existing `record_outcome_verdicts` isolation pattern (not a functional change, matches established test convention exactly).
- [x] Full suite diffed against the pre-existing baseline (87 failures, established across S3–S5/#1815 runs) — **byte-identical failure set**, zero new regressions. Confirmed the 5 failures seen in a targeted HO-suite run (`test_scorer_to_verdict_chain_real_db`, `test_score_hypotheses_transitions_due_active_real_db`, 3× `test_ho_s9_e2e_closed_loop`) are pre-existing baseline members, unrelated to this change.

Depends on S1 (merged). Mirrors the HO-S4 scorer-wiring pattern per PO's kickoff spec.