### PR TITLE
feat(e-loop-ledger): S9 — outcome 표시 UI

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2621,7 +2621,12 @@
     "decisionError": "Failed to confirm the slot.",
     "noArtifacts": "This loop has no candidate artifacts yet.",
     "viewDetail": "View detail",
-    "notFound": "Loop not found."
+    "notFound": "Loop not found.",
+    "outcomeSectionLabel": "Outcome",
+    "outcomeHit": "Hit",
+    "outcomeMiss": "Miss",
+    "outcomeNoResult": "No measurement result.",
+    "outcomeMetricLine": "{metric}: actual {actual} {dir} target {target}"
   },
   "sprints": {
     "title": "Sprints",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2621,7 +2621,12 @@
     "decisionError": "슬롯 확정에 실패했습니다.",
     "noArtifacts": "이 loop에는 아직 후보 아티팩트가 없습니다.",
     "viewDetail": "상세 보기",
-    "notFound": "loop을 찾을 수 없습니다."
+    "notFound": "loop을 찾을 수 없습니다.",
+    "outcomeSectionLabel": "성과",
+    "outcomeHit": "Hit",
+    "outcomeMiss": "Miss",
+    "outcomeNoResult": "측정 결과가 없습니다.",
+    "outcomeMetricLine": "{metric}: 실제 {actual} {dir} 목표 {target}"
   },
   "sprints": {
     "title": "스프린트",

--- a/apps/web/src/app/(authenticated)/loops/[id]/loop-detail-client.tsx
+++ b/apps/web/src/app/(authenticated)/loops/[id]/loop-detail-client.tsx
@@ -8,7 +8,16 @@ import { ArrowLeft, FileText, GitBranch, ShieldAlert } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { LoopStatusBadge, type LoopStatus } from '@/components/loops/loop-status-badge';
+import { OutcomeBadge } from '@/components/loops/outcome-badge';
 import { VariantGallery, type VariantGroup } from '@/components/loops/variant-gallery';
+
+/** E-LOOP-LEDGER S7 loop_outcome_attribution.py::attribute_loop_outcome 산출 shape 그대로. */
+interface OutcomeSnapshot {
+  hypothesis_id: string;
+  hypothesis_status: 'verified' | 'falsified';
+  outcome_result: { metric: string; target: number; actual: number; direction: 'up' | 'down'; scored_at: string } | null;
+  attributed_at: string;
+}
 
 interface Loop {
   id: string;
@@ -20,6 +29,7 @@ interface Loop {
   title: string;
   goal_tags: string[];
   status: LoopStatus;
+  outcome_snapshot: OutcomeSnapshot | null;
 }
 
 interface Hypothesis {
@@ -41,6 +51,7 @@ interface DocSummary {
  */
 export function LoopDetailClient({ loopId }: { loopId: string }) {
   const t = useTranslations('loops');
+  const th = useTranslations('hypotheses');
   const router = useRouter();
 
   const [loop, setLoop] = useState<Loop | null>(null);
@@ -169,6 +180,26 @@ export function LoopDetailClient({ loopId }: { loopId: string }) {
             </div>
           ) : null}
 
+          {/* Outcome — E-LOOP-LEDGER S9: closed loop 성과(S7 outcome_snapshot 소비) */}
+          {loop.status === 'closed' && loop.outcome_snapshot ? (
+            <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/40 p-3">
+              <span className="text-xs font-medium text-muted-foreground">{t('outcomeSectionLabel')}</span>
+              <OutcomeBadge hypothesisStatus={loop.outcome_snapshot.hypothesis_status} />
+              {loop.outcome_snapshot.outcome_result ? (
+                <span className="text-sm text-foreground">
+                  {t('outcomeMetricLine', {
+                    metric: loop.outcome_snapshot.outcome_result.metric,
+                    actual: loop.outcome_snapshot.outcome_result.actual,
+                    dir: loop.outcome_snapshot.outcome_result.direction === 'up' ? th('dirUp') : th('dirDown'),
+                    target: loop.outcome_snapshot.outcome_result.target,
+                  })}
+                </span>
+              ) : (
+                <span className="text-sm italic text-muted-foreground">{t('outcomeNoResult')}</span>
+              )}
+            </div>
+          ) : null}
+
           {/* Goal / hypothesis */}
           <div className="rounded-lg border border-border bg-muted/40 p-3">
             <p className="mb-1 text-xs font-medium text-muted-foreground">{t('goalLabel')}</p>
@@ -206,7 +237,13 @@ export function LoopDetailClient({ loopId }: { loopId: string }) {
         </div>
 
         {/* Variant gallery */}
-        <VariantGallery loopId={loop.id} groups={groups} canDecide={canDecide} onDecided={() => void fetchAll()} />
+        <VariantGallery
+          loopId={loop.id}
+          groups={groups}
+          canDecide={canDecide}
+          onDecided={() => void fetchAll()}
+          outcome={loop.status === 'closed' ? loop.outcome_snapshot : null}
+        />
       </div>
     </>
   );

--- a/apps/web/src/app/(authenticated)/loops/loops-client.tsx
+++ b/apps/web/src/app/(authenticated)/loops/loops-client.tsx
@@ -8,6 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { EmptyState } from '@/components/ui/empty-state';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { LoopStatusBadge, type LoopStatus } from '@/components/loops/loop-status-badge';
+import { OutcomeBadge } from '@/components/loops/outcome-badge';
 
 interface Loop {
   id: string;
@@ -19,6 +20,7 @@ interface Loop {
   title: string;
   goal_tags: string[];
   status: LoopStatus;
+  outcome_snapshot: { hypothesis_status: 'verified' | 'falsified' } | null;
   created_at: string;
   updated_at: string;
 }
@@ -40,7 +42,12 @@ function LoopRow({ loop, onClick }: { loop: Loop; onClick: () => void }) {
       <div className="space-y-2">
         <div className="flex items-start justify-between gap-2">
           <p className="text-sm font-semibold leading-snug text-foreground">{loop.title}</p>
-          <LoopStatusBadge status={loop.status} />
+          <div className="flex shrink-0 items-center gap-1">
+            <LoopStatusBadge status={loop.status} />
+            {loop.status === 'closed' && loop.outcome_snapshot ? (
+              <OutcomeBadge hypothesisStatus={loop.outcome_snapshot.hypothesis_status} />
+            ) : null}
+          </div>
         </div>
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
           {loop.parent_loop_id ? (

--- a/apps/web/src/components/loops/outcome-badge.tsx
+++ b/apps/web/src/components/loops/outcome-badge.tsx
@@ -1,0 +1,22 @@
+import { useTranslations } from 'next-intl';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+/**
+ * E-LOOP-LEDGER S9 — closed loop 성과 배지. hypothesis-status-badge.tsx의 soul-lock과 동일 원칙:
+ * falsified(miss)에 destructive(빨강)를 쓰지 않는다 — 반증/미스에 빨강을 쓰면 사람이 정직한
+ * 라벨링(반려 이유 등)을 회피해 복리 학습 신호가 죽는다. hit=success(녹)·miss=info(청).
+ */
+export function OutcomeBadge({
+  hypothesisStatus,
+  className,
+}: {
+  hypothesisStatus: 'verified' | 'falsified';
+  className?: string;
+}) {
+  const t = useTranslations('loops');
+  if (hypothesisStatus === 'verified') {
+    return <Badge variant="success" className={cn('font-semibold', className)}>{t('outcomeHit')}</Badge>;
+  }
+  return <Badge variant="info" className={cn('font-semibold', className)}>{t('outcomeMiss')}</Badge>;
+}

--- a/apps/web/src/components/loops/variant-gallery.tsx
+++ b/apps/web/src/components/loops/variant-gallery.tsx
@@ -7,7 +7,13 @@ import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import { OperatorTextarea } from '@/components/ui/operator-control';
 import { ArtifactPreview } from '@/components/loops/artifact-preview';
+import { OutcomeBadge } from '@/components/loops/outcome-badge';
 import { Layers } from 'lucide-react';
+
+/** loop_outcome_attribution.py 산출 shape — closed loop에만 존재. */
+export interface OutcomeInfo {
+  hypothesis_status: 'verified' | 'falsified';
+}
 
 export interface LoopArtifact {
   id: string;
@@ -36,11 +42,13 @@ function VariantSlot({
   group,
   canDecide,
   onDecided,
+  outcome,
 }: {
   loopId: string;
   group: VariantGroup;
   canDecide: boolean;
   onDecided: () => void;
+  outcome: OutcomeInfo | null;
 }) {
   const t = useTranslations('loops');
   const sorted = [...group.artifacts].sort((a, b) => a.sort_order - b.sort_order);
@@ -135,7 +143,12 @@ function VariantSlot({
               <div className="space-y-1.5 p-2.5">
                 <div className="flex items-center justify-between gap-2">
                   <span className="truncate text-xs font-medium text-foreground">{artifact.variant_label}</span>
-                  {isChosen ? <Badge variant="success" className="text-[9px]">{t('chosenBadge')}</Badge> : null}
+                  <div className="flex shrink-0 items-center gap-1">
+                    {isChosen ? <Badge variant="success" className="text-[9px]">{t('chosenBadge')}</Badge> : null}
+                    {isChosen && outcome ? (
+                      <OutcomeBadge hypothesisStatus={outcome.hypothesis_status} className="text-[9px]" />
+                    ) : null}
+                  </div>
                 </div>
 
                 {isChosen && artifact.choose_reason ? (
@@ -197,11 +210,13 @@ export function VariantGallery({
   groups,
   canDecide,
   onDecided,
+  outcome = null,
 }: {
   loopId: string;
   groups: VariantGroup[];
   canDecide: boolean;
   onDecided: () => void;
+  outcome?: OutcomeInfo | null;
 }) {
   const t = useTranslations('loops');
 
@@ -218,6 +233,7 @@ export function VariantGallery({
           group={group}
           canDecide={canDecide}
           onDecided={onDecided}
+          outcome={outcome}
         />
       ))}
     </div>


### PR DESCRIPTION
## Summary
- E-LOOP-LEDGER S9(story `45c16c25`) — closed loop의 성과를 S6 Loop 보드에 얹는 작은 확장(2pt).
- **OutcomeBadge** 신규: hit=success(녹)·miss=info(청) — `hypothesis-status-badge.tsx`의 soul-lock 원칙 그대로 재사용(falsified/miss에 destructive 빨강 금지, 정직한 라벨링 회피 방지).
- **상세 헤더**: `status='closed'` + `outcome_snapshot` 존재 시 "성과" 섹션 — hit/miss 배지 + `"{metric}: 실제 {actual} {dir} 목표 {target}"`(dir는 기존 `hypotheses` 네임스페이스의 `dirUp(≥)`/`dirDown(≤)` 재사용). `outcome_result`가 null(manual/미지원 source)이면 폴백 문구.
- **variant 갤러리**: chosen 아티팩트 카드에 기존 "선택" 배지 옆 hit/miss 배지 추가(AC 그대로: "chosen variant에 hit/miss 배지").
- **loop 목록**: closed + outcome_snapshot 있는 행에 상태배지 옆 hit/miss 배지.

## 계약
`loop_outcome_attribution.py::attribute_loop_outcome`(S7, 머지됨) 산출 shape 그대로 소비:
```
{ hypothesis_id, hypothesis_status: 'verified'|'falsified',
  outcome_result: { metric, target, actual, direction: 'up'|'down', scored_at } | null,
  attributed_at }
```
`outcome_scorer.py::_build_result`/`_apply_direction` 코드로 direction 값('up'/'down') 실측 확인.

⚠️**참고**: S7 자체 주석대로 loop `executing→measuring` 전이 배선이 아직 없어(별도 갭 스토리, PO 회수 예정) `outcome_snapshot`이 실제로 채워지는 경로가 현재 시스템에는 없음 — 계약이 확정된 스키마를 소비하는 UI만 완성, 로컬 SQL 시드로 hit/miss/no-result 3케이스 라이브 검증.

## Test plan
- [x] `pnpm type-check` — 0 errors
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — 성공(EXIT 0)
- [x] 로컬 isolated docker(pgvector db)에서 SQL 시드(hit/miss/no-result 3가지 outcome_snapshot 케이스)로 라이브 검증:
  - [x] 목록: 종료 loop 3건 각각 Hit(녹)/Miss(청)/Hit+결과없음 배지 정상 표시
  - [x] 상세: 성과 섹션(hit/miss 배지 + "metric: 실제 X ≥/≤ 목표 Y" 또는 결과없음 폴백)
  - [x] variant 갤러리: chosen 카드에 선택 배지 + hit/miss 배지 동시 표시
  - [x] 다크모드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)