### PR TITLE
fix(security): resolve_member agent cross-project IDOR prod hotfix (cherry-pick #1815)

### DIFF
--- a/backend/app/services/member_resolver.py
+++ b/backend/app/services/member_resolver.py
@@ -69,6 +69,13 @@ async def _resolve_member_legacy(
         )).scalars().first()
         if tm is None:
             raise HTTPException(status_code=400, detail="Team member not found")
+        # 까심 QA CRITICAL(#1814 S3 QA): 휴먼 분기만 project_id를 has_project_access로 검증했고
+        # agent(API키) 분기는 검증 없이 조기 return — agent가 접근권한 없는 project_id를 넘기면
+        # 그 project에 리소스가 생성됐다(cross-project IDOR). resolve_member(project_id=)를 쓰는
+        # 모든 라우터(loops/hypotheses/retros/standups/conversations 등)가 동일하게 뚫려 있었다.
+        if project_id is not None:
+            if not await has_project_access(session, tm.id, project_id, org_id):
+                raise HTTPException(status_code=403, detail="No access to this project")
         return ResolvedMember(
             id=tm.id,
             user_id=None,
@@ -144,6 +151,11 @@ async def _resolve_member_anchor(
             select(AgentProjectProfile.project_id).where(AgentProjectProfile.member_id == m.id)
             .order_by(AgentProjectProfile.created_at.asc()).limit(1)
         )).scalar_one_or_none()
+        # 까심 QA CRITICAL(#1814 S3 QA) — legacy 분기와 동일 갭(agent가 project_id 검증 없이 통과).
+        # anchor 경로도 동일하게 봉인(shadow 플래그로 어느 쪽이 active여도 안전).
+        if project_id is not None:
+            if not await has_project_access(session, m.id, project_id, org_id):
+                raise HTTPException(status_code=403, detail="No access to this project")
         return ResolvedMember(
             id=m.id,
             user_id=None,

--- a/backend/tests/test_resolve_member_agent_project_idor_realdb.py
+++ b/backend/tests/test_resolve_member_agent_project_idor_realdb.py
@@ -1,0 +1,173 @@
+"""까심 QA CRITICAL(#1814 S3 QA) — resolve_member의 is_api_key(agent) 분기가 project_id를
+검증 없이 통과시키던 cross-project IDOR의 realdb repro + root-fix 검증.
+
+갭: _resolve_member_legacy/_resolve_member_anchor 모두 JWT 휴먼 분기만 has_project_access로
+project_id를 검증했고, agent(API키) 분기는 조기 return — 접근권한 없는 project_id를 넘긴
+agent가 그 project에 리소스를 생성할 수 있었다(loops POST/hypotheses POST 등 resolve_member(...,
+project_id=)를 쓰는 전 라우터가 동일하게 뚫려 있었음). fix = 두 분기 모두에
+`has_project_access` 체크 추가.
+
+본 테스트는 까심 재현 시나리오 그대로: agent는 PROJ_A에만 grant, PROJ_B로 project_id를
+넘기면 fix 後 403이어야 한다(fix 前엔 통과했을 것 — RED→GREEN 실증). 라우터 레벨(loops.create_loop +
+hypotheses.create_hypothesis) 양쪽 다 커버해 root-fix가 실제로 두 엔드포인트를 동시에 막는 것을 증명한다.
+
+DB env(ALEMBIC_DATABASE_URL) 없으면 skip.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("1d000000-0000-0000-0000-000000000001")
+AGENT = uuid.UUID("1d000000-0000-0000-0000-0000000000a1")  # PROJ_A에만 grant
+HUMAN_OWNER = uuid.UUID("1d000000-0000-0000-0000-0000000000b1")  # hypothesis owner(human)
+OM_OWNER = uuid.UUID("1d000000-0000-0000-0000-0000000000c1")
+PROJ_A = uuid.UUID("1d000000-0000-0000-0000-000000000002")  # AGENT grant 있음
+PROJ_B = uuid.UUID("1d000000-0000-0000-0000-000000000003")  # AGENT grant 없음(IDOR 축)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _agent_auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(AGENT), email=None,
+        claims={"app_metadata": {"api_key_id": "ak_test", "org_id": str(ORG)}},
+        org_id=str(ORG),
+    )
+
+
+async def _seed(s, *, legacy_team_member: bool = False):
+    """ORG·AGENT(members type=agent, project_access grant=PROJ_A만)·PROJ_A/PROJ_B 시드.
+
+    legacy_team_member=True면 team_members(구·writable) 행도 추가 — _resolve_member_legacy가
+    `select(TeamMember)`로 읽는 대상이 이 저장소에서 실제로는 members⋈project_access VIEW이므로
+    members+project_access 시드만으로 이미 그 뷰에 투영된다(agent-grant-only 3번째 UNION 브랜치,
+    0110). 별도 INSERT INTO team_members는 불요(뷰는 read-only)."""
+    for sql in [
+        f"DELETE FROM project_access WHERE project_id IN ('{PROJ_A}','{PROJ_B}')",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{HUMAN_OWNER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','C1D','c1dorg','free')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_A}','{ORG}','A')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_B}','{ORG}','B')",
+        f"INSERT INTO members (id,org_id,type,name,is_active) VALUES ('{AGENT}','{ORG}','agent','Ag',true)",
+        # AGENT는 PROJ_A에만 grant(PROJ_B 접근 없음 — IDOR 테스트축).
+        f"INSERT INTO project_access (id,project_id,org_member_id,member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ_A}',NULL,'{AGENT}','granted')",
+        # hypotheses 경로용 human owner(agent caller는 owner 명시 필수).
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{HUMAN_OWNER}','o@c1d.test','x','O',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM_OWNER}','{ORG}','{HUMAN_OWNER}','member')",
+        f"INSERT INTO members (id,org_id,type,user_id,name,is_active) "
+        f"VALUES ('{OM_OWNER}','{ORG}','human','{HUMAN_OWNER}','O',true)",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+# ── resolve_member 유닛(레거시+앵커 양쪽) ─────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_resolve_member_legacy_agent_cross_project_forbidden_same_project_ok():
+    from app.services.member_resolver import _resolve_member_legacy
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        # cross-project(PROJ_B·grant 없음) → 까심 재현 시나리오: fix 前엔 통과했을 것.
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await _resolve_member_legacy(_agent_auth(), ORG, s, project_id=PROJ_B)
+            assert ei.value.status_code == 403
+
+        # same-project(PROJ_A·grant 있음) → 통과.
+        async with Session() as s:
+            resolved = await _resolve_member_legacy(_agent_auth(), ORG, s, project_id=PROJ_A)
+            assert resolved.id == AGENT
+            assert resolved.type == "agent"
+
+        # project_id 미지정(레거시 동작 보존 — 회귀 0).
+        async with Session() as s:
+            resolved = await _resolve_member_legacy(_agent_auth(), ORG, s, project_id=None)
+            assert resolved.id == AGENT
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_resolve_member_anchor_agent_cross_project_forbidden_same_project_ok():
+    from app.services.member_resolver import _resolve_member_anchor
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await _resolve_member_anchor(_agent_auth(), ORG, s, project_id=PROJ_B)
+            assert ei.value.status_code == 403
+
+        async with Session() as s:
+            resolved = await _resolve_member_anchor(_agent_auth(), ORG, s, project_id=PROJ_A)
+            assert resolved.id == AGENT
+            assert resolved.type == "agent"
+    finally:
+        await eng.dispose()
+
+
+# ── 라우터 레벨: hypotheses(develop에 이미 존재하는 resolve_member(project_id=) 호출부) ──
+# loops(S3, PR #1814)는 이 fix 브랜치 시점엔 develop에 없다 — S3가 이 fix 위로 rebase되면
+# 동일 시나리오(agent cross-project POST → 403)를 loops에도 추가한다(S3 PR에서 후속).
+
+@pytest.mark.anyio
+async def test_hypotheses_create_agent_cross_project_forbidden():
+    from app.routers.hypotheses import create_hypothesis
+    from app.schemas.hypothesis import HypothesisCreate
+
+    valid_metric = {"metric": "signups", "source": "manual", "target": 100, "direction": "up"}
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await create_hypothesis(
+                    body=HypothesisCreate(
+                        project_id=PROJ_B, statement="idor-attempt",
+                        metric_definition=valid_metric,
+                        measure_after=datetime(2026, 8, 1, tzinfo=timezone.utc),
+                        owner_member_id=OM_OWNER,
+                    ),
+                    session=s, auth=_agent_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 403
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## prod 핫픽스 — resolve_member agent 분기 cross-project IDOR (CRITICAL)

develop 검증 완료된 근본 fix `eb1eb21b`(PR #1815) prod 승격 cherry-pick. **순수 코드·마이그레이션 0.**

### 취약점
`_resolve_member_legacy`/`_resolve_member_anchor` 둘 다 JWT 휴먼 분기만 project_id를 `has_project_access`로 검증했고, agent(API키) 분기는 검증 없이 조기 return. 접근권한 없는 project_id를 넘긴 agent가 그 project에 리소스 생성 가능(POST /api/v2/hypotheses·loops·retros·standups·conversations 등 resolve_member(project_id=) 쓰는 모든 라우터). GET/LIST는 has_project_access 직접 호출로 무영향.

### fix
두 분기 모두 project_id is not None 시 has_project_access 체크 추가 → 실패 시 403.

### 검증
까심 realdb QA RED→GREEN(fix 전 롤백서 취약점 재현 → fix 후 403 차단). cherry-pick onto main 충돌 0.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>