### PR TITLE
feat(e-loop-ledger): P1-S1 — polymorphic embeddings table (Context Pack foundation)

### DIFF
--- a/backend/alembic/versions/0151_embeddings.py
+++ b/backend/alembic/versions/0151_embeddings.py
@@ -1,0 +1,104 @@
+"""E-LOOP-LEDGER P1-S1(story 2b9c8b06): 폴리모픽 embeddings 테이블(Context Pack 파운데이션).
+
+Revision ID: 0151
+Revises: 0150
+Create Date: 2026-07-02
+
+블루프린트 §P1. Gate(work_item_type/id)·AssetLink(source_type/id) 폴리모픽 참조 패턴 미러 —
+entity_type/entity_id로 hypothesis/loop/loop_artifact를 가리킨다(DB FK 불가 — 폴리모픽).
+
+모델/차원: gemini-embedding-001 @ outputDimensionality=768(PO 확정, 2026-07-01) — vector(768).
+인덱스는 HNSW(agent_long_term_memories의 죽은 ivfflat 안 미러 — 신규 org가 거의 0 데이터로
+시작하는 멀티테넌트엔 HNSW가 적합, training step 불요·빈 테이블에도 구축 가능).
+
+이 스토리는 순수 스키마만 — embed client/cron은 P1-S2/S3.
+
+idempotent: 테이블 단위 inspect 가드(0113/0149/0150 선례와 동일 클래스).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0151"
+down_revision = "0150"
+branch_labels = None
+depends_on = None
+
+_EMBEDDING_DIM = 768
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    existing = set(insp.get_table_names())
+
+    if "embeddings" in existing:
+        return
+
+    op.create_table(
+        "embeddings",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "project_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("entity_type", sa.Text(), nullable=False),
+        sa.Column("entity_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("embedding_text", sa.Text(), nullable=False),
+        sa.Column("content_hash", sa.Text(), nullable=False),
+        # embedding vector(768) — pgvector 컬럼은 raw DDL로 추가(SQLAlchemy Column 타입이 아닌
+        # Postgres 고유 타입이라 op.create_table의 sa.Column으로 표현 불가).
+        sa.Column("model_version", sa.Text(), nullable=True),
+        sa.Column("dimension", sa.Integer(), nullable=True),
+        sa.Column("status", sa.String(16), nullable=False, server_default="pending"),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("created_by_member_id", UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "entity_type IN ('hypothesis','loop','loop_artifact')",
+            name="ck_embeddings_entity_type",
+        ),
+        sa.CheckConstraint(
+            "status IN ('pending','processing','ready','failed')",
+            name="ck_embeddings_status",
+        ),
+        sa.UniqueConstraint("entity_type", "entity_id", name="uq_embeddings_entity"),
+    )
+    # pgvector 컬럼(raw DDL — op.create_table의 sa.Column enum엔 vector 타입이 없음).
+    op.execute(f"ALTER TABLE embeddings ADD COLUMN embedding vector({_EMBEDDING_DIM})")
+
+    op.create_index("ix_embeddings_org_id", "embeddings", ["org_id"])
+    op.create_index(
+        "ix_embeddings_org_project_entity_type", "embeddings", ["org_id", "project_id", "entity_type"]
+    )
+    # cron backlog 조회(P1-S3): status='pending' 배치 스캔.
+    op.create_index(
+        "ix_embeddings_status_pending", "embeddings", ["status"],
+        postgresql_where=sa.text("status = 'pending'"),
+    )
+    # HNSW cosine — m/ef_construction은 pgvector 기본 권장값(16/64).
+    op.execute(
+        "CREATE INDEX ix_embeddings_embedding_hnsw ON embeddings "
+        "USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64)"
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    if "embeddings" in set(insp.get_table_names()):
+        op.drop_table("embeddings")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -5,6 +5,7 @@ from app.models.agent_routing_rule import AgentRoutingRule
 from app.models.agent_run import AgentRun
 from app.models.agent_session import AgentSession
 from app.models.bridge import BridgeChannelMapping, BridgeUserMapping
+from app.models.embedding import Embedding
 from app.models.gate import Gate
 from app.models.hitl import HitlPolicy, HitlRequest
 from app.models.mockup import MockupComponent, MockupPage, MockupScenario, MockupVersion, UsageMeter
@@ -60,6 +61,7 @@ __all__ = [
     "AgentSession",
     "BridgeChannelMapping",
     "BridgeUserMapping",
+    "Embedding",
     "Gate",
     "HitlPolicy",
     "HitlRequest",

--- a/backend/app/models/embedding.py
+++ b/backend/app/models/embedding.py
@@ -1,0 +1,100 @@
+"""E-LOOP-LEDGER P1-S1: 폴리모픽 embeddings 테이블(Context Pack 파운데이션, 블루프린트 §P1).
+
+Gate(work_item_type/work_item_id)·AssetLink(source_type/source_id) 폴리모픽 참조 패턴을
+미러 — entity_type/entity_id로 hypothesis/loop/loop_artifact를 가리킨다(DB FK 불가·참조
+무결성은 앱 레벨. orphan 정리는 write-path 스토리(P1-S4) 스코프).
+
+모델/차원: 초기값 gemini-embedding-001 @ outputDimensionality=768(오르테가 PO 확정, 2026-07-01).
+model_version/dimension 컬럼을 별도로 둬서 향후 모델 업그레이드(예: 3072/halfvec)가 기존 행과
+공존 가능하게 한다 — re-embed(cron)로 점진 이관, 빅뱅 마이그 불필요.
+
+status 라이프사이클: pending(생성 직후, embedding NULL) → processing(cron이 집음) →
+ready(embedding 채워짐) 또는 failed(error_message 채움, 재시도는 cron이 pending으로 되돌림 —
+P1-S3 스코프). 이 스토리(S1)는 순수 스키마만 — client/cron 없음.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pgvector.sqlalchemy import Vector
+from sqlalchemy import (
+    CheckConstraint,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    event,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, OrgScopedMixin, TimestampMixin
+
+# fresh-runnable(Base.metadata.create_all) 경로는 baseline.sql을 안 거치므로 pgvector
+# extension이 없다 — vector 컬럼이 있는 테이블 생성 시 "type vector does not exist"로 실패한다
+# (alembic upgrade head 경로는 baseline의 CREATE EXTENSION IF NOT EXISTS vector를 거쳐 무관).
+# create_all() 호출 직전 자동으로 extension을 보장해 모든 기존 create_all 기반 테스트가
+# 이 테이블 추가만으로 깨지지 않게 한다.
+@event.listens_for(Base.metadata, "before_create")
+def _ensure_vector_extension(target, connection, **kw):
+    connection.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+
+EMBEDDING_ENTITY_TYPES = frozenset({"hypothesis", "loop", "loop_artifact"})
+EMBEDDING_STATUSES = frozenset({"pending", "processing", "ready", "failed"})
+EMBEDDING_DIMENSION = 768
+
+
+class Embedding(Base, OrgScopedMixin, TimestampMixin):
+    __tablename__ = "embeddings"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False
+    )
+    entity_type: Mapped[str] = mapped_column(Text, nullable=False)
+    entity_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+
+    # embedding_text: 임베딩 생성에 쓴 원문(재현/디버그/재임베딩 판단용). content_hash로 staleness 감지
+    # (원본 엔티티 텍스트가 바뀌었는데 아직 재임베딩 안 된 상태를 write-path 스토리가 식별).
+    embedding_text: Mapped[str] = mapped_column(Text, nullable=False)
+    content_hash: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # NULL until status='ready'(cron이 채움, P1-S3 스코프).
+    embedding: Mapped[list[float] | None] = mapped_column(Vector(EMBEDDING_DIMENSION), nullable=True)
+    model_version: Mapped[str | None] = mapped_column(Text, nullable=True)
+    dimension: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    status: Mapped[str] = mapped_column(String(16), nullable=False, server_default="pending")
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_by_member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+
+    __table_args__ = (
+        CheckConstraint(
+            "entity_type IN ('hypothesis','loop','loop_artifact')",
+            name="ck_embeddings_entity_type",
+        ),
+        CheckConstraint(
+            "status IN ('pending','processing','ready','failed')",
+            name="ck_embeddings_status",
+        ),
+        # 엔티티당 embedding row 1개(재임베딩=UPDATE, 새 row 아님 — 이력 보관 불요·현재값만 유의미).
+        UniqueConstraint("entity_type", "entity_id", name="uq_embeddings_entity"),
+        # cron backlog 조회(P1-S3): status='pending' 배치 스캔.
+        Index("ix_embeddings_status_pending", "status", postgresql_where=text("status = 'pending'")),
+        # 테넌트 스코프 pre-filter(까심/codex 지적 — org_id+ANN 조합 recall 저하 완화 보조 인덱스).
+        Index("ix_embeddings_org_project_entity_type", "org_id", "project_id", "entity_type"),
+        # HNSW — cosine distance(agent_long_term_memories의 죽은 ivfflat 안 미러. 신규 org가
+        # 거의 0 데이터로 시작하는 멀티테넌트엔 HNSW가 적합 — training step 불요, 빈 테이블에도 구축).
+        Index(
+            "ix_embeddings_embedding_hnsw",
+            "embedding",
+            postgresql_using="hnsw",
+            postgresql_with={"m": 16, "ef_construction": 64},
+            postgresql_ops={"embedding": "vector_cosine_ops"},
+        ),
+    )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
     "boto3>=1.34.0",
     "pypdf>=5.0.0",
     "python-docx>=1.1.0",
+    # E-LOOP-LEDGER P1-S1: pgvector SQLAlchemy Vector 타입(embeddings 테이블). extension은 baseline에 이미 활성화됨.
+    "pgvector>=0.3.0",
 ]
 
 [dependency-groups]

--- a/backend/tests/test_e_loop_ledger_p1_s1_embeddings_schema.py
+++ b/backend/tests/test_e_loop_ledger_p1_s1_embeddings_schema.py
@@ -1,0 +1,215 @@
+"""E-LOOP-LEDGER P1-S1(story 2b9c8b06): 폴리모픽 embeddings 테이블 스키마 검증.
+
+순수 스키마 스토리 — client/cron 없음(P1-S2/S3 스코프). 여기서는 제약(CHECK/UNIQUE)이
+실제로 발동하는지, HNSW 인덱스가 실재하는지, 기본값이 맞는지를 실 DB로 검증한다.
+
+DB env(ALEMBIC_DATABASE_URL) 없으면 skip.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import uuid
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("24000000-0000-0000-0000-000000000001")
+PROJ = uuid.UUID("24000000-0000-0000-0000-000000000002")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _seed_org_project(s):
+    for sql in [
+        f"DELETE FROM embeddings WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','C24','c24org','free')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ}','{ORG}','P')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+def _hash(t: str) -> str:
+    return hashlib.sha256(t.encode()).hexdigest()
+
+
+async def test_default_status_pending_embedding_null():
+    from app.models.embedding import Embedding
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            entity_id = uuid.uuid4()
+            row = Embedding(
+                id=uuid.uuid4(), org_id=ORG, project_id=PROJ, entity_type="hypothesis",
+                entity_id=entity_id, embedding_text="x", content_hash=_hash("x"),
+            )
+            s.add(row)
+            await s.commit()
+            await s.refresh(row)
+            assert row.status == "pending"
+            assert row.embedding is None
+            assert row.model_version is None
+            assert row.dimension is None
+    finally:
+        await eng.dispose()
+
+
+async def test_entity_type_check_constraint_rejects_invalid_value():
+    from app.models.embedding import Embedding
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            s.add(Embedding(
+                id=uuid.uuid4(), org_id=ORG, project_id=PROJ, entity_type="story",
+                entity_id=uuid.uuid4(), embedding_text="x", content_hash=_hash("x"),
+            ))
+            with pytest.raises(IntegrityError):
+                await s.flush()
+            await s.rollback()
+    finally:
+        await eng.dispose()
+
+
+async def test_status_check_constraint_rejects_invalid_value():
+    from app.models.embedding import Embedding
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            s.add(Embedding(
+                id=uuid.uuid4(), org_id=ORG, project_id=PROJ, entity_type="hypothesis",
+                entity_id=uuid.uuid4(), embedding_text="x", content_hash=_hash("x"),
+                status="done",
+            ))
+            with pytest.raises(IntegrityError):
+                await s.flush()
+            await s.rollback()
+    finally:
+        await eng.dispose()
+
+
+async def test_unique_entity_type_and_entity_id_rejects_duplicate_row():
+    """비-tautological — 같은 (entity_type, entity_id)로 2번째 row 삽입 시도가 실제로
+    IntegrityError를 내는지(엔티티당 embedding row 1개 보장)."""
+    from app.models.embedding import Embedding
+
+    eng, Session = await _engine()
+    try:
+        entity_id = uuid.uuid4()
+        async with Session() as s:
+            await _seed_org_project(s)
+            s.add(Embedding(
+                id=uuid.uuid4(), org_id=ORG, project_id=PROJ, entity_type="loop",
+                entity_id=entity_id, embedding_text="first", content_hash=_hash("first"),
+            ))
+            await s.commit()
+
+        async with Session() as s:
+            s.add(Embedding(
+                id=uuid.uuid4(), org_id=ORG, project_id=PROJ, entity_type="loop",
+                entity_id=entity_id, embedding_text="second", content_hash=_hash("second"),
+            ))
+            with pytest.raises(IntegrityError):
+                await s.flush()
+            await s.rollback()
+    finally:
+        await eng.dispose()
+
+
+async def test_same_entity_id_different_entity_type_allowed():
+    """entity_id가 우연히 같아도 entity_type이 다르면 별개 row(복합 UNIQUE 확인)."""
+    from app.models.embedding import Embedding
+
+    eng, Session = await _engine()
+    try:
+        shared_id = uuid.uuid4()
+        async with Session() as s:
+            await _seed_org_project(s)
+            s.add(Embedding(
+                id=uuid.uuid4(), org_id=ORG, project_id=PROJ, entity_type="hypothesis",
+                entity_id=shared_id, embedding_text="h", content_hash=_hash("h"),
+            ))
+            s.add(Embedding(
+                id=uuid.uuid4(), org_id=ORG, project_id=PROJ, entity_type="loop",
+                entity_id=shared_id, embedding_text="l", content_hash=_hash("l"),
+            ))
+            await s.commit()  # 예외 없이 통과해야 함.
+    finally:
+        await eng.dispose()
+
+
+async def test_project_delete_cascades_embeddings():
+    from app.models.embedding import Embedding
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            row_id = uuid.uuid4()
+            s.add(Embedding(
+                id=row_id, org_id=ORG, project_id=PROJ, entity_type="loop_artifact",
+                entity_id=uuid.uuid4(), embedding_text="x", content_hash=_hash("x"),
+            ))
+            await s.commit()
+
+        async with Session() as s:
+            await s.execute(text(f"DELETE FROM projects WHERE id='{PROJ}'"))
+            await s.commit()
+
+        async with Session() as s:
+            fetched = (await s.execute(select(Embedding).where(Embedding.id == row_id))).scalar_one_or_none()
+            assert fetched is None, "project 삭제 시 embeddings row도 CASCADE로 사라져야 함"
+    finally:
+        await eng.dispose()
+
+
+async def test_hnsw_index_exists_with_cosine_ops():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            row = (await s.execute(text(
+                "SELECT indexdef FROM pg_indexes WHERE indexname = 'ix_embeddings_embedding_hnsw'"
+            ))).scalar_one_or_none()
+            assert row is not None, "HNSW 인덱스가 실재해야 함"
+            assert "hnsw" in row.lower()
+            assert "vector_cosine_ops" in row
+    finally:
+        await eng.dispose()
+
+
+async def test_status_pending_partial_index_exists():
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            row = (await s.execute(text(
+                "SELECT indexdef FROM pg_indexes WHERE indexname = 'ix_embeddings_status_pending'"
+            ))).scalar_one_or_none()
+            assert row is not None
+            assert "pending" in row
+    finally:
+        await eng.dispose()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1045,6 +1045,57 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/05/3d27272d30698dc0ecb7fdfaa41ad70303b444f81722bb99bce1d818638a/numpy-2.5.0.tar.gz", hash = "sha256:5a129578019311b6e56bdd714250f19b518f7dceeeb8d1af5490f4942d3f891c", size = 20652461, upload-time = "2026-06-21T20:57:51.95Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/0a/11486d02add7b1384dff7374d124b1cfbb0ee864dcc9f6a2c0380638cf84/numpy-2.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:489780423903667933b4ed6197b6ec3b75ea5dd17d1d8f0f38d798feb6921561", size = 16789987, upload-time = "2026-06-21T20:56:16.657Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b2/285f48640a181947b4587a3766d21ec1eaa7fea833d4b49957e09da467a2/numpy-2.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ece55976ced6bca95a03ae2839e2e5ccffe8eb6a3e7022415645eb154a81e4e6", size = 11760322, upload-time = "2026-06-21T20:56:19.813Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/67/b032db1eb03ca30d16eda3b0c22aaa615338b9263c2fd559d0f29451aca4/numpy-2.5.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:c83b664b0e6eee9594fa920cf0639d8af796606d3fad6cc70180c87e4b97c7be", size = 5319605, upload-time = "2026-06-21T20:56:22.173Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/83/03fc7300c7c6b6c84c487b1dc80d322817b95fbd1f4dd57a85e23b7198de/numpy-2.5.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:bf80333980bf37f523341ddd72c783f39d6829ec7736b9eb99086388a2d52cc2", size = 6653628, upload-time = "2026-06-21T20:56:23.914Z" },
+    { url = "https://files.pythonhosted.org/packages/82/49/2ec21730bc63ccfda829323f7040a8ed4715b3852ce658689cf74ee96a8c/numpy-2.5.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1a4874217b36d5ac8fc876f52e39df56f8182c88463e9e2dceabf7ca8b7efb8", size = 15153691, upload-time = "2026-06-21T20:56:25.631Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/6b/f4a3d0637692c49da8ef99d72d52526f92e0a8d6ac4f0ca9f31441b9d9ea/numpy-2.5.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aaa760137137e8d3c920d27927748215b56014f92667dc9b6c27dfc61249255a", size = 16660066, upload-time = "2026-06-21T20:56:28.009Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/2f/c354ec86d1f3f5c19649463b0d39652e160736e5b0a4cd18dff0576715c4/numpy-2.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7174ce8265fc7f7417d171c9ea8fe905220748893ea67a2a7abe726ec331c4b0", size = 16514638, upload-time = "2026-06-21T20:56:30.26Z" },
+    { url = "https://files.pythonhosted.org/packages/06/34/43efdcb319988648580f93c11f1ae82cf7e2faa74925e98e454ae3aa95f8/numpy-2.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b8c3daaf99de52415d20b42f8e8155c78642cb04207d02f9d317a0dcf1b3fb54", size = 18419647, upload-time = "2026-06-21T20:56:32.41Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e2/f5d1676b1d7fb682eb5e9a1641e7ebd2414b3216c370661d1029778908b4/numpy-2.5.0-cp312-cp312-win32.whl", hash = "sha256:6206db0af545d73d068add6d992279145f158428d1da6cc49adc4b630c5d6ee5", size = 6056688, upload-time = "2026-06-21T20:56:34.657Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7c/48f115d1c58a34032facebcd51fdf2d02df2c51d4a46a81dd1197bb2ea6b/numpy-2.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:6f2d6873e2940c860a309d21e25b1e69af6aaffdd80aa056b04c16380db1c4f2", size = 12419237, upload-time = "2026-06-21T20:56:36.24Z" },
+    { url = "https://files.pythonhosted.org/packages/86/26/2e0882f4044d1b1a1b63e875151fb2393389032022a8b7f5657a7996d3b2/numpy-2.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:a55e1eb2bca2cfd17a16b213c99dfc8502d47b0d494224d2122277d0400935ca", size = 10339912, upload-time = "2026-06-21T20:56:38.733Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/33/07675aaad7f26ea013d5e884d9a0d784b79c6bd7566c333f5a52fa3c610b/numpy-2.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:520e6b8be0a4b65840ac8090d4f51cef4bed66e2b0894d5a520f099adc24a9b2", size = 16784890, upload-time = "2026-06-21T20:56:40.799Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4b/953118a730ee3b35e28645e0eb4cf9beec5bdbb954e1ac2f5fcefba6bbc3/numpy-2.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:146b81cdd3967fdb6beca8ba25f00c58741d8f3cbd797f55af0fbe0bfec3469c", size = 11754584, upload-time = "2026-06-21T20:56:43.094Z" },
+    { url = "https://files.pythonhosted.org/packages/44/9b/56dd530c367c74ae17411027cea4135ca57e1e0583bf5594cee18bd83217/numpy-2.5.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:126b88d95e8ff9b00c9e717aa540469f21d6180162f84c0caec51b16215d49cd", size = 5313904, upload-time = "2026-06-21T20:56:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/b0/bcd672edad27ecca7da1f7bb0ce72cd1706a4f2d79ae94990afc97c13e1c/numpy-2.5.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d4313cef1594c5ce46c31b6e54e918338f63f16ee9322304e8c9114d6d81c8bd", size = 6648504, upload-time = "2026-06-21T20:56:47.567Z" },
+    { url = "https://files.pythonhosted.org/packages/80/9e/15cdfcbd30a1544a46c9e487a00df331c4672450216538705a9e51fa6710/numpy-2.5.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:750fb097caf26fa878746d9d119f6f9da12dedcbff1eea966c3e3447647c4a9e", size = 15150086, upload-time = "2026-06-21T20:56:49.352Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4e/8d7656ccaab3e81e97258b8a9bc5f0c8502513a92fb4ceb0a2cbfebc17bf/numpy-2.5.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3893adc2dc7c0412ba76777db55a049215d99c9aa3113003be8f49f4f1290ab9", size = 16647250, upload-time = "2026-06-21T20:56:51.542Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/81/97060281b602ed07f21b12f4ec409eac1f75a2f91fbc829ed8b2becf3ad4/numpy-2.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:835e454dd99b238cdc5a3f63bce2371296f5ebc53ca1e0f8e6ddbb6d92a29aab", size = 16512864, upload-time = "2026-06-21T20:56:55.401Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ab/4496208146911f8d8ddb54f68a972aafa6c8d44babcb2ea03b0e5cc87c9d/numpy-2.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f9836778081a0a3c02a6a21493f3e9f5b311f8d2541934f31f05583dc999ea4", size = 18408407, upload-time = "2026-06-21T20:56:57.75Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/9f/a4df67c181e4ee8b467aa3332dc2db10fd5c515136831302f3ca48bc0a01/numpy-2.5.0-cp313-cp313-win32.whl", hash = "sha256:0b525be4744b60bb0557ac872d53ef07d085b5f39622bc579c98d3809d05b988", size = 6054431, upload-time = "2026-06-21T20:57:00.016Z" },
+    { url = "https://files.pythonhosted.org/packages/30/53/491e1c47c55b62ccc6a63c1c5b8635c73fc2258dddeb9bda27cae4a0ae96/numpy-2.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:44353e2878930039db472b99dc353d749826e4010bd4d2a7f835e94a97a5c748", size = 12414420, upload-time = "2026-06-21T20:57:01.815Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/4a/25c2906f541e9d9f4c5769764db732e6627be91a13f4724fa10634d77db4/numpy-2.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:48f54b00711f83a5f796b70c518e8c2b3c5848dda03a54911f23eb68519b9b60", size = 10339533, upload-time = "2026-06-21T20:57:03.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ad/abc44aaceaf7b17ee1edde2bbb4458da591bc79574cffff50c4bb35f00d1/numpy-2.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f27582c55ba4c750b7c58c8faf021d2cd9324a662b466229db8a417b41368af9", size = 16783807, upload-time = "2026-06-21T20:57:06.253Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/39/b72e168daf9c00fb20c9fc996d00437ccecdef3102387775d29d7a62576d/numpy-2.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:28e7137057d551e4a83c4ae414e3451f50568409db7569aacc7f9811ee06a446", size = 11765215, upload-time = "2026-06-21T20:57:08.547Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a0/8400a9c0e3625182347593f5e1f57da9a617a534794805c8df5518154ddc/numpy-2.5.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e1da54b53e75cd9fcfc23efcc7edab2c6aecf97b6037566d8a0fe804af8ec57c", size = 5324493, upload-time = "2026-06-21T20:57:11.012Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/8c/0d104deaa0401c93395a629ec902891618a2eff76d19229139cb5a887bfc/numpy-2.5.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:694d8f74e156f7fd01179f1aa8faa2f648ab6ae0f70b6c3fe57a03249aea2303", size = 6645211, upload-time = "2026-06-21T20:57:12.919Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d9/4a4a628c812750363786afc3d33492709a5cd64b215469c16b0f6c7bb811/numpy-2.5.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a7569a7b53c77716f036bb28cb1c91f166a26ec7d9502cd1e4bdfe502fdec22", size = 15166004, upload-time = "2026-06-21T20:57:14.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5e/2a902317d7fc4aa93236e80c932662dadfc459b323d758329e01775125e1/numpy-2.5.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39a0433bd4086ebd462960cf375e19195bb07b53dc1d87dd5fcf47ad78576f03", size = 16650797, upload-time = "2026-06-21T20:57:16.906Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a0/a0090e6329f4ca5992c07847bb579c5259a19953dc57255bb08793142ffb/numpy-2.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:929f0c79ac38bcbd7154fe631dc907abfeddbcc5027a896bd1f7767323271e7a", size = 16524647, upload-time = "2026-06-21T20:57:19.165Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7d/6caf27734c42b65837e7461ed0dbbd6b6fc835060c9714ec59d673bb383a/numpy-2.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cc4f247a47bbf070bfd70be53ccdcf47b800af563535e7bbe172322197c30e21", size = 18411841, upload-time = "2026-06-21T20:57:21.638Z" },
+    { url = "https://files.pythonhosted.org/packages/13/dc/26edadbd812536769a82c2e9e002234e33feb5da43061d47a044f6d309b7/numpy-2.5.0-cp314-cp314-win32.whl", hash = "sha256:5dc71423499fab3f46f7a7201155ade1669ea101f2f429d332df9e72f8161731", size = 6106361, upload-time = "2026-06-21T20:57:23.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9e/4dd1459282229a72d92dece2ae9138e5cac94a72263a7ceb48f37434c925/numpy-2.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:ebb81d9d5443e0309d6c54894c3fbed74ad7da0714352a67b6d773cd189eae73", size = 12551749, upload-time = "2026-06-21T20:57:25.945Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a7/6bc6384c080b86c7f6c85c5bc5b540b24f4f679cd144791d99574e90d462/numpy-2.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:3b94d0d0deceebfad3e67ae5c0e5eb87371e8f7a0581cd04a779928c2450cf1e", size = 10617072, upload-time = "2026-06-21T20:57:28.175Z" },
+    { url = "https://files.pythonhosted.org/packages/86/6b/4a2b71d66ada5608ae02b63f150dfad520f6940721cb7f029ad270befc0e/numpy-2.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:22f3d43e362d650bc39db1f17851302874a148ca95ba6981c1dfb5fa6862f35b", size = 11881067, upload-time = "2026-06-21T20:57:30.104Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b2/d365eb40a20efb49d67e9feb90494ed8511282ee1f5fa16006675c65397d/numpy-2.5.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:243563efb4cd7528a264567e9fd206c87826457322521d06206a00bfa316c927", size = 5440290, upload-time = "2026-06-21T20:57:32.193Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5e/e9c03188de5f9b767e46a8fe988bcfd3efad066a4a3fda8b9cb11a93f895/numpy-2.5.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:84881d825ca75249b189bbee875fcfe3238aa5c479e6100893cda566e8e86826", size = 6748371, upload-time = "2026-06-21T20:57:33.933Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1d/68c186a38a5027bae2c4ddd5ea681fdaf8b4d30fb7301def6d8ad270390f/numpy-2.5.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cda12aa4779d42b8771180aba759c96f527d43446d8f380ab59e2b35e8489efd", size = 15214643, upload-time = "2026-06-21T20:57:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/67/73f67b7c7e20635baae9c4c3ead4ae7326a005900297a6110971abd62eb5/numpy-2.5.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c0121101093d2bd74981b10f8837d78e794a8ff57834eb27179f49e1ba11ac6", size = 16690128, upload-time = "2026-06-21T20:57:38.159Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/05/d4c1fb0c46d02a27d6b2b8b319a78c90937acec8631c1641874670b31e6f/numpy-2.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d371c92cfa09da00022f501ab67fafaea813d752eb30ac44336d45b1e5b0268a", size = 16577902, upload-time = "2026-06-21T20:57:40.447Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1d/771c797d50fa26e4888989cccf1d50ee51f530d4e455ad2692dcb64fa711/numpy-2.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9990713e9c38154c6861e7547f1e3fc7a87e75ff09bab24ef1cc81d81c2835e9", size = 18452814, upload-time = "2026-06-21T20:57:42.875Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/46/52fc0d2a68d7643f0f149eeea5a5d8ea2a3507056ac8afa83c9212606e8b/numpy-2.5.0-cp314-cp314t-win32.whl", hash = "sha256:edadfbd4794b1086c0d822f81863e8a68fc129d132fd0bb9e31e955d7fbbbdb7", size = 6253168, upload-time = "2026-06-21T20:57:45.101Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/be/6c8d1118b5f13b2881dc095d5b345de19c6638b8959c17409b6eff84c8aa/numpy-2.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f7e5fa4382967ae6548bd2f174219afb908e294b0d5f625af01166edd5f7d9aa", size = 12736286, upload-time = "2026-06-21T20:57:46.935Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6a/d3a169aaf8536cf228d56a09e04bcb713a2fe4410d4e2105b9419b5a9c89/numpy-2.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:016623417bb330d719d579daf2d6b9a01ddc52e41a9ed61a47f39fde46dcd865", size = 10686451, upload-time = "2026-06-21T20:57:49.313Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1068,6 +1119,18 @@ argon2 = [
 ]
 bcrypt = [
     { name = "bcrypt" },
+]
+
+[[package]]
+name = "pgvector"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/6c/6d8b4b03b958c02fa8687ec6063c49d952a189f8c91ebbe51e877dfab8f7/pgvector-0.4.2.tar.gz", hash = "sha256:322cac0c1dc5d41c9ecf782bd9991b7966685dee3a00bc873631391ed949513a", size = 31354, upload-time = "2025-12-05T01:07:17.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/26/6cee8a1ce8c43625ec561aff19df07f9776b7525d9002c86bceb3e0ac970/pgvector-0.4.2-py3-none-any.whl", hash = "sha256:549d45f7a18593783d5eec609ea1684a724ba8405c4cb182a0b2b08aeff04e08", size = 27441, upload-time = "2025-12-05T01:07:16.536Z" },
 ]
 
 [[package]]
@@ -1682,6 +1745,7 @@ dependencies = [
     { name = "httpx" },
     { name = "mcp" },
     { name = "passlib", extra = ["argon2", "bcrypt"] },
+    { name = "pgvector" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -1718,6 +1782,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcp", specifier = ">=1.8.0" },
     { name = "passlib", extras = ["argon2", "bcrypt"], specifier = ">=1.7.4" },
+    { name = "pgvector", specifier = ">=0.3.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary
- E-LOOP-LEDGER P1-S1(story `2b9c8b06`) — critical-path first story of the Context Pack (P1) embedding infrastructure. **Pure schema + migration** — embed client/cron are follow-up stories (P1-S2/S3).
- Mirrors the existing `Gate` (`work_item_type`/`work_item_id`) and `AssetLink` (`source_type`/`source_id`) polymorphic-reference patterns: `entity_type`/`entity_id` point at `hypothesis`/`loop`/`loop_artifact` rows (no DB FK possible — polymorphic; orphan cleanup on entity delete is P1-S4's write-path scope).
- Columns: `embedding vector(768)`, `embedding_text` (source text), `content_hash` (staleness detection), `model_version`/`dimension` (so a future model upgrade can coexist with old rows via incremental re-embed, no big-bang migration), `status` (`pending`/`processing`/`ready`/`failed`), `org_id`/`project_id` (tenant scope, `project_id` is a real FK with `ON DELETE CASCADE`).
- **Model/dimension** (PO-confirmed in the foundation crux): `gemini-embedding-001` @ `outputDimensionality=768` — keeps Google's current flagship model while staying compatible with pgvector's plain `vector` type (max 2000 dims) instead of needing `halfvec`.
- **Index = HNSW** (not `ivfflat`, deliberately *not* mirroring the dead `agent_long_term_memories.embedding` index) — verified via codex web search against current pgvector docs: HNSW needs no training step and builds fine on an empty table, which fits a multi-tenant product where every new org starts near-zero rows; `ivfflat` needs pre-existing data distribution for `lists` tuning. Also added a `status='pending'` partial index (for the future cron backlog scan) and a `(org_id, project_id, entity_type)` composite index (tenant pre-filter, mitigating the recall degradation that can occur when combining a tenant `WHERE` filter with ANN search).

## Regression found and fixed
`Base.metadata.create_all()` (the fresh-runnable path many existing tests use) never goes through `baseline.sql`, so it has no pgvector extension — creating a table with a `vector` column failed with `type vector does not exist` (the `alembic upgrade head` path is unaffected since baseline already has `CREATE EXTENSION IF NOT EXISTS vector`). Fixed with a `before_create` event listener on `Base.metadata` that transparently ensures the extension exists before any `create_all()` call — this is a global fix, not per-test-file, so no existing test needed touching.

## Test plan
- [x] `alembic upgrade head` reaches `0151` cleanly on a fresh `pgvector/pgvector:pg16` container; table/constraints/HNSW index verified via `\d embeddings`.
- [x] `Base.metadata.create_all()` + `drop_all()` fresh-runnable clean (confirms the extension-bootstrap fix works, and that the ORM-declared HNSW index produces identical DDL to the migration's raw SQL).
- [x] New `tests/test_e_loop_ledger_p1_s1_embeddings_schema.py` (8 tests, non-tautological):
  - Default `status='pending'`, `embedding`/`model_version`/`dimension` all `NULL` on minimal insert.
  - `entity_type`/`status` CHECK constraints actually reject invalid values (`IntegrityError`, not just documentation).
  - `UNIQUE(entity_type, entity_id)` actually rejects a second row for the same pair; a shared `entity_id` across *different* `entity_type`s is allowed (proves the composite key, not a false single-column read).
  - `project_id` `ON DELETE CASCADE` actually removes the `embeddings` row when the parent project is deleted (real DB round-trip, not just a schema read).
  - HNSW index and the `status='pending'` partial index verified present via `pg_indexes`.
- [x] **Full suite diffed against the pre-existing baseline (87 failures, established across S3–S8/P0 runs)** — byte-identical failure set, confirming the global `before_create` fix introduces zero regressions across every existing `create_all()`-based test file in the suite.

Added `pgvector` (Python) as a new dependency (`pyproject.toml`/`uv.lock`) for the SQLAlchemy `Vector` column type. dev/prod Cloud SQL already support pgvector (confirmed via existing CI comment).

⚠️ gcloud re-auth is pending PO-side — dev/QA can proceed fully (throwaway PG, unaffected), but per PO's note the actual merge + `sprintable-migrate-dev` job execution should wait for gcloud to come back.