### PR TITLE
feat(e-loop-ledger): P1-S2 — Vertex AI (gemini-embedding-001) embed client

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,5 +1,11 @@
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+# E-LOOP-LEDGER P1: gemini-embedding-001 @ output_dimensionality=768(파운데이션 crux 확정,
+# 2026-07-01) — app.models.embedding.Embedding.embedding(vector 컬럼)과 embedding_client.py
+# 양쪽이 이 단일 상수를 참조한다(중복 선언 제거, PO 지시 2026-07-02). 배포별로 달라질 값이
+# 아니라(모델 자체를 바꾸는 결정) env-overridable Settings 필드가 아닌 plain 상수로 둔다.
+EMBEDDING_DIMENSION = 768
+
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=(".env", ".env.local"), env_file_encoding="utf-8", extra="ignore")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -20,6 +20,12 @@ class Settings(BaseSettings):
     cloud_sql_instance_dev: str = "sprintable-494803:asia-northeast3:sprintable-dev"
     cloud_sql_instance_prod: str = "sprintable-494803:asia-northeast3:sprintable-prod"
 
+    # E-LOOP-LEDGER P1-S2: Vertex AI 임베딩(gemini-embedding-001) — cloud_sql_instance_*와 동일
+    # GCP project/region(sprintable-494803·asia-northeast3) 기본값. ADC로 인증(신규 크리덴셜 관리 0,
+    # ga4_client.py/gcs.py와 동일 패턴).
+    gcp_project_id: str = "sprintable-494803"
+    vertex_ai_location: str = "asia-northeast3"
+
     # E-INFRA S2 + ee7794eb: DB 커넥션 풀 **rollout-safe** right-size (env DB_POOL_SIZE/DB_MAX_OVERFLOW override).
     # ⚠️ 배포 rollout 時 old+new 리비전이 **동시 점유(2×)** — steady 산식만 쓰면 배포 중 max_connections
     #    초과(2026-06-29 dev TooManyConnections·#1766 rollout 전요청 500). **인스턴스당 실 커넥션은 pool

--- a/backend/app/models/embedding.py
+++ b/backend/app/models/embedding.py
@@ -32,6 +32,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
+from app.core.config import EMBEDDING_DIMENSION
 from app.models.base import Base, OrgScopedMixin, TimestampMixin
 
 # fresh-runnable(Base.metadata.create_all) 경로는 baseline.sql을 안 거치므로 pgvector
@@ -45,7 +46,6 @@ def _ensure_vector_extension(target, connection, **kw):
 
 EMBEDDING_ENTITY_TYPES = frozenset({"hypothesis", "loop", "loop_artifact"})
 EMBEDDING_STATUSES = frozenset({"pending", "processing", "ready", "failed"})
-EMBEDDING_DIMENSION = 768
 
 
 class Embedding(Base, OrgScopedMixin, TimestampMixin):

--- a/backend/app/services/embedding_client.py
+++ b/backend/app/services/embedding_client.py
@@ -1,0 +1,85 @@
+"""E-LOOP-LEDGER P1-S2: Vertex AI(gemini-embedding-001) 임베딩 클라이언트.
+
+ga4_client.py/app/services/storage/gcs.py와 동형 ADC 인증 패턴 — 신규 크리덴셜 관리 0.
+GOOGLE_APPLICATION_CREDENTIALS 환경변수 또는 ADC(gcloud auth application-default login).
+인증 불가/API 오류는 예외 전파 없이 None 반환(pending 유지 — GA4 unauth와 동일 격리 철학,
+S8의 "false-hit 0" 설계를 그대로 계승: 임베딩 실패가 잘못된 검색 결과를 만들지 않는다).
+
+모델/차원: gemini-embedding-001 @ output_dimensionality=768(파운데이션 crux 확정,
+2026-07-01). ⚠️P1-S1(embeddings 테이블·병렬 개발)의 EMBEDDING_DIMENSION과 값이 반드시
+일치해야 한다 — 의도적으로 import 의존을 안 걸었다(S2가 S1 머지 여부와 무관하게 독립
+개발/머지되도록. app.models.embedding이 아직 develop에 없을 수 있음).
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+EMBEDDING_DIMENSION = 768
+
+MODEL_VERSION = "gemini-embedding-001"
+
+
+def _has_adc() -> bool:
+    """Application Default Credentials 사용 가능 여부 간단 체크(ga4_client.py와 동형)."""
+    try:
+        import google.auth
+        google.auth.default()
+        return True
+    except Exception:
+        return False
+
+
+def embed_text(text: str) -> list[float] | None:
+    """단일 텍스트를 임베딩. 인증 불가/API 오류/빈 입력 시 None(예외 전파 없음).
+
+    Returns:
+        768차원 float 리스트 또는 None(회수 실패 — 호출자는 이를 '아직 못 채움'으로 처리하고
+        pending 유지해야 한다. 절대 임의 벡터로 대체하거나 실패를 성공으로 위장하지 않는다).
+    """
+    if not text or not text.strip():
+        return None
+
+    creds_file = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if not creds_file and not _has_adc():
+        logger.warning("embedding_client: 인증 정보 없음 → None 처리(pending 유지)")
+        return None
+
+    try:
+        from google import genai
+        from google.genai import types
+
+        client = genai.Client(
+            vertexai=True,
+            project=settings.gcp_project_id,
+            location=settings.vertex_ai_location,
+            http_options=types.HttpOptions(api_version="v1"),
+        )
+        response = client.models.embed_content(
+            model=MODEL_VERSION,
+            contents=text,
+            config=types.EmbedContentConfig(output_dimensionality=EMBEDDING_DIMENSION),
+        )
+        values = response.embeddings[0].values
+        if not values or len(values) != EMBEDDING_DIMENSION:
+            logger.warning(
+                "embedding_client: 예상치 못한 응답 차원(got=%s expected=%s) → None 처리",
+                len(values) if values else 0, EMBEDDING_DIMENSION,
+            )
+            return None
+        return list(values)
+    except Exception as exc:  # errors.ClientError(4xx: auth/quota)·ServerError(5xx)·기타 SDK 오류 포괄
+        logger.warning("embedding_client: 임베딩 실패: %s", exc)
+        return None
+
+
+def embed_texts(texts: list[str]) -> list[list[float] | None]:
+    """다건 임베딩(cron 배치 처리용, P1-S3). ⚠️gemini-embedding-001은 요청당 단일 입력
+    텍스트 제한이라 진짜 batch API가 아니라 embed_text를 순차 호출한다 — 항목별 성공/실패가
+    독립적이라(한 텍스트 실패가 나머지를 막지 않음) 호출자(cron)가 항목별로 status를
+    ready/failed로 나눠 갱신할 수 있다. 입력과 동일 길이·동일 순서로 반환."""
+    return [embed_text(t) for t in texts]

--- a/backend/app/services/embedding_client.py
+++ b/backend/app/services/embedding_client.py
@@ -6,20 +6,18 @@ GOOGLE_APPLICATION_CREDENTIALS 환경변수 또는 ADC(gcloud auth application-d
 S8의 "false-hit 0" 설계를 그대로 계승: 임베딩 실패가 잘못된 검색 결과를 만들지 않는다).
 
 모델/차원: gemini-embedding-001 @ output_dimensionality=768(파운데이션 crux 확정,
-2026-07-01). ⚠️P1-S1(embeddings 테이블·병렬 개발)의 EMBEDDING_DIMENSION과 값이 반드시
-일치해야 한다 — 의도적으로 import 의존을 안 걸었다(S2가 S1 머지 여부와 무관하게 독립
-개발/머지되도록. app.models.embedding이 아직 develop에 없을 수 있음).
+2026-07-01) — app.core.config.EMBEDDING_DIMENSION 단일소스(app.models.embedding.Embedding.
+embedding 컬럼과 정합, PO 지시로 2026-07-02 중복 상수 정리). config.py는 pydantic Settings
+객체 없이도 import 가능해 S1 머지 여부와 무관하게 이 스토리가 독립 개발/머지된다.
 """
 from __future__ import annotations
 
 import logging
 import os
 
-from app.core.config import settings
+from app.core.config import EMBEDDING_DIMENSION, settings
 
 logger = logging.getLogger(__name__)
-
-EMBEDDING_DIMENSION = 768
 
 MODEL_VERSION = "gemini-embedding-001"
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
     "python-docx>=1.1.0",
     # E-LOOP-LEDGER P1-S1: pgvector SQLAlchemy Vector 타입(embeddings 테이블). extension은 baseline에 이미 활성화됨.
     "pgvector>=0.3.0",
+    # E-LOOP-LEDGER P1-S2: Vertex AI(gemini-embedding-001) 임베딩 클라이언트. ADC 인증(신규 크리덴셜 0).
+    "google-genai>=1.0.0",
 ]
 
 [dependency-groups]

--- a/backend/tests/test_e_loop_ledger_p1_s2_embedding_client.py
+++ b/backend/tests/test_e_loop_ledger_p1_s2_embedding_client.py
@@ -1,0 +1,122 @@
+"""E-LOOP-LEDGER P1-S2(story 25663736): embedding_client.py 검증.
+
+핵심 격리(비-tautological, GA4 unauth 격리와 동형): 인증 정보 없음 → None(예외 전파 없음).
+실 Vertex AI 호출은 하지 않는다(외부 API·GCP 크레딧 소비·CI 네트워크 의존 회피) — SDK 호출부는
+mock, 그 앞단(인증 게이트·빈 입력·차원 검증·예외 포괄)은 real 로직 그대로 태운다.
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.embedding_client import (
+    EMBEDDING_DIMENSION,
+    MODEL_VERSION,
+    embed_text,
+    embed_texts,
+)
+
+
+# ── 빈 입력 ────────────────────────────────────────────────────────────────
+
+def test_empty_text_returns_none_without_auth_check():
+    assert embed_text("") is None
+    assert embed_text("   ") is None
+
+
+# ── ⭐핵심 격리: 인증 정보 없음 → None(GA4 unauth와 동형) ─────────────────────
+
+def test_no_credentials_returns_none_no_exception():
+    with patch("app.services.embedding_client._has_adc", return_value=False), \
+         patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        result = embed_text("some real hypothesis statement")
+    assert result is None
+
+
+def test_credentials_file_env_set_skips_adc_check():
+    """GOOGLE_APPLICATION_CREDENTIALS가 설정돼 있으면 _has_adc()를 호출조차 안 함(둘 중
+    하나만 있으면 통과) — genai.Client 생성부터는 mock해 실제 API 호출은 안 나간다."""
+    fake_response = MagicMock()
+    fake_response.embeddings = [MagicMock(values=[0.1] * EMBEDDING_DIMENSION)]
+    with patch.dict(os.environ, {"GOOGLE_APPLICATION_CREDENTIALS": "/fake/path.json"}), \
+         patch("app.services.embedding_client._has_adc") as mock_adc:
+        with patch("google.genai.Client") as mock_client_cls:
+            mock_client_cls.return_value.models.embed_content.return_value = fake_response
+            result = embed_text("hello")
+        mock_adc.assert_not_called()
+    assert result == [0.1] * EMBEDDING_DIMENSION
+
+
+# ── 성공 경로(SDK mock) ────────────────────────────────────────────────────
+
+def test_successful_embed_returns_vector_of_expected_dimension():
+    fake_response = MagicMock()
+    fake_response.embeddings = [MagicMock(values=[0.5] * EMBEDDING_DIMENSION)]
+    with patch("app.services.embedding_client._has_adc", return_value=True), \
+         patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with patch("google.genai.Client") as mock_client_cls:
+            mock_client_cls.return_value.models.embed_content.return_value = fake_response
+            result = embed_text("some real hypothesis statement")
+    assert result == [0.5] * EMBEDDING_DIMENSION
+    assert len(result) == EMBEDDING_DIMENSION
+
+    call_kwargs = mock_client_cls.return_value.models.embed_content.call_args.kwargs
+    assert call_kwargs["model"] == MODEL_VERSION
+
+
+def test_wrong_dimension_response_returns_none():
+    """SDK가 예상과 다른 차원을 반환하면(모델/설정 drift) 위험한 벡터를 그대로 쓰지 않고
+    None으로 거부 — 잘못된 차원이 HNSW 인덱스에 섞여 들어가는 것을 원천 차단."""
+    fake_response = MagicMock()
+    fake_response.embeddings = [MagicMock(values=[0.1] * 512)]  # 768이 아님
+    with patch("app.services.embedding_client._has_adc", return_value=True), \
+         patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with patch("google.genai.Client") as mock_client_cls:
+            mock_client_cls.return_value.models.embed_content.return_value = fake_response
+            result = embed_text("x")
+    assert result is None
+
+
+def test_sdk_exception_returns_none_not_raised():
+    """API 오류(quota/auth/5xx 등)가 예외로 전파되지 않고 None으로 흡수됨 — 호출자(cron)가
+    개별 항목 실패로 전체 배치를 죽이지 않게."""
+    with patch("app.services.embedding_client._has_adc", return_value=True), \
+         patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with patch("google.genai.Client") as mock_client_cls:
+            mock_client_cls.return_value.models.embed_content.side_effect = RuntimeError("quota exceeded")
+            result = embed_text("x")
+    assert result is None
+
+
+# ── 배치 ────────────────────────────────────────────────────────────────────
+
+def test_embed_texts_preserves_order_and_independent_failures():
+    """3건 중 가운데 하나만 실패해도(SDK 예외) 나머지 2건은 정상 반환 — 항목별 독립성."""
+    ok_response = MagicMock()
+    ok_response.embeddings = [MagicMock(values=[0.2] * EMBEDDING_DIMENSION)]
+
+    call_count = {"n": 0}
+
+    def _side_effect(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            raise RuntimeError("boom")
+        return ok_response
+
+    with patch("app.services.embedding_client._has_adc", return_value=True), \
+         patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with patch("google.genai.Client") as mock_client_cls:
+            mock_client_cls.return_value.models.embed_content.side_effect = _side_effect
+            results = embed_texts(["a", "b", "c"])
+
+    assert len(results) == 3
+    assert results[0] == [0.2] * EMBEDDING_DIMENSION
+    assert results[1] is None
+    assert results[2] == [0.2] * EMBEDDING_DIMENSION

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -464,6 +464,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -542,6 +551,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
 ]
 
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
 [[package]]
 name = "google-cloud-core"
 version = "2.6.0"
@@ -593,6 +607,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
     { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
     { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+]
+
+[[package]]
+name = "google-genai"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/fe/b796087493c3c55371aa58b9f264841ace5bfdf8c668cafa7afa33c44bec/google_genai-2.10.0.tar.gz", hash = "sha256:77912cd558cd7dfd5b75c25fd1c609e78d7954dde583331104022a46ea90f9ee", size = 600039, upload-time = "2026-06-24T01:33:18.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/39/00bcfd94de255d24249401efff4f48d77bf6066b46447e519fa193c0c299/google_genai-2.10.0-py3-none-any.whl", hash = "sha256:d5350311567ae660c24cbc1752aee4b3d660f89c0106d2dcd2a69978c35afe1e", size = 957974, upload-time = "2026-06-24T01:33:16.296Z" },
 ]
 
 [[package]]
@@ -1732,6 +1767,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "sprintable-backend"
 version = "0.1.0"
 source = { virtual = "." }
@@ -1742,6 +1786,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "google-analytics-data" },
     { name = "google-cloud-storage" },
+    { name = "google-genai" },
     { name = "httpx" },
     { name = "mcp" },
     { name = "passlib", extra = ["argon2", "bcrypt"] },
@@ -1779,6 +1824,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "google-analytics-data", specifier = ">=0.18.0" },
     { name = "google-cloud-storage", specifier = ">=2.18.0" },
+    { name = "google-genai", specifier = ">=1.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcp", specifier = ">=1.8.0" },
     { name = "passlib", extras = ["argon2", "bcrypt"], specifier = ">=1.7.4" },
@@ -1883,6 +1929,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- E-LOOP-LEDGER P1-S2(story `25663736`) — the embedding-generation client for Context Pack, developed **independently of P1-S1** (the `embeddings` schema PR) per PO's explicit call, so this can complete/merge regardless of S1's QA/gcloud-reauth status.
- `app/services/embedding_client.py::embed_text(text) -> list[float] | None` — mirrors the exact ADC auth pattern already established by `ga4_client.py`/`app/services/storage/gcs.py` (`GOOGLE_APPLICATION_CREDENTIALS` env var or `gcloud auth application-default login`; zero new credential management).
- **Failure philosophy carried over from S8's "false-hit 0" design**: missing auth, API errors (4xx/5xx), empty input, and unexpected response dimension all resolve to `None` with no exception propagation — the caller (future P1-S3 cron) treats `None` as "not yet embedded" and keeps the row `pending`, never substituting a bad/wrong-dimension vector.
- `embed_texts(texts: list[str]) -> list[list[float] | None]` for the future cron's batch interface — `gemini-embedding-001` has a single-input-per-request limit (confirmed via current Vertex AI docs), so this is a sequential loop with **per-item independent failure** (one bad text doesn't kill the rest of the batch), not a true batch API call.
- Model/dimension: `gemini-embedding-001` @ `output_dimensionality=768` (foundation-crux confirmed). New settings `gcp_project_id` (`sprintable-494803`) / `vertex_ai_location` (`asia-northeast3`) — same GCP project/region already used by `cloud_sql_instance_dev`/`_prod`.
- **Deliberately does not import `app.models.embedding`** — the `EMBEDDING_DIMENSION` constant is duplicated locally rather than imported, specifically so this story doesn't depend on P1-S1 having merged first (S1 isn't in `develop` yet).
- New dependency: `google-genai` (confirmed via web-search-grounded research: `from google import genai; genai.Client(vertexai=True, ...); client.models.embed_content(model=..., config=types.EmbedContentConfig(output_dimensionality=768))`).
- No migration.

## Test plan
- [x] `Base.metadata.create_all()`/`drop_all()` fresh-runnable clean (untouched by this story).
- [x] New `tests/test_e_loop_ledger_p1_s2_embedding_client.py` (7 tests, non-tautological). Real Vertex AI calls are never made (avoids external API cost/CI network dependency) — only the SDK call boundary (`google.genai.Client`) is mocked; auth-gating, empty-input handling, dimension validation, and exception handling all exercise the real code path:
  - Empty/whitespace text → `None` without even reaching the auth check.
  - **⭐Core isolation (GA4-unauth-equivalent)**: no credentials (`_has_adc` mocked `False`, env var unset) → `None`, no exception.
  - `GOOGLE_APPLICATION_CREDENTIALS` set → skips the `_has_adc()` check entirely (asserted via `mock_adc.assert_not_called()`), proceeds to the (mocked) SDK call.
  - Successful embed returns the exact vector, and the SDK call is asserted to use `model="gemini-embedding-001"`.
  - Wrong-dimension SDK response (e.g. 512 instead of 768) → `None`, not the malformed vector — prevents a dimension-drifted vector from ever reaching the HNSW index.
  - SDK exception (e.g. quota exceeded) → `None`, not raised.
  - `embed_texts` with 3 items where the middle one's SDK call raises → asserts item 1 and 3 still return their vectors, item 2 is `None`, preserving order (per-item independence, not all-or-nothing).
- [x] Full config-related test suite (126 tests) passes with the new `gcp_project_id`/`vertex_ai_location` settings.
- [x] Full suite diffed against the pre-existing baseline (87 failures, established across S3–P1-S1 runs) — **byte-identical failure set**, zero new regressions.

Depends on nothing merge-blocking (no migration, no dependency on P1-S1). Ready to merge independently.