### PR TITLE
feat(e-loop-ledger): P1-S4 — write-path embedding enqueue

### DIFF
--- a/backend/app/services/embedding_enqueue.py
+++ b/backend/app/services/embedding_enqueue.py
@@ -1,0 +1,94 @@
+"""E-LOOP-LEDGER P1-S4: write-path embedding 큐잉 — hypothesis/loop/loop_artifact create(+content
+변경 update) 시 embeddings row를 status='pending'으로 동기 INSERT/UPSERT만 한다(네트워크 I/O 0
+— 실제 임베딩 생성은 P1-S3 cron이 다음 tick에 처리). score_hypotheses/attribute_loop_outcome이
+서비스 함수 안에 직접 배선된 것과 동형 패턴(신규 엔드포인트 0).
+
+content_hash로 staleness를 판단 — 같은 텍스트면 no-op(재큐잉 방지, cron 낭비 방지). 텍스트가
+바뀌면 기존 벡터/model_version/dimension을 지우고 pending으로 되돌린다(과거 벡터가 새 텍스트를
+대표한다고 오인되는 것을 방지 — 재임베딩 전까지는 검색 결과에서 자연히 빠진다, embedding IS NULL).
+"""
+from __future__ import annotations
+
+import hashlib
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.embedding import Embedding
+
+
+def _content_hash(text: str) -> str:
+    return hashlib.sha256(text.encode()).hexdigest()
+
+
+async def enqueue_embedding(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID,
+    entity_type: str,
+    entity_id: uuid.UUID,
+    embedding_text: str,
+    created_by_member_id: uuid.UUID | None = None,
+) -> None:
+    """entity_type+entity_id의 embeddings row를 pending으로 큐잉(신규 또는 재큐잉).
+
+    embedding_text가 비어있으면 아무것도 하지 않는다(예: choose_reason 미기입 상태의 artifact —
+    호출부가 조건부로 호출하거나, 빈 텍스트를 그냥 넘겨도 안전하게 no-op).
+    """
+    if not embedding_text or not embedding_text.strip():
+        return
+
+    new_hash = _content_hash(embedding_text)
+    existing = (await session.execute(
+        select(Embedding).where(
+            Embedding.entity_type == entity_type, Embedding.entity_id == entity_id
+        )
+    )).scalar_one_or_none()
+
+    if existing is not None:
+        if existing.content_hash == new_hash:
+            return  # 변경 없음 — no-op(재큐잉/cron 낭비 방지)
+        existing.embedding_text = embedding_text
+        existing.content_hash = new_hash
+        existing.status = "pending"
+        existing.embedding = None
+        existing.model_version = None
+        existing.dimension = None
+        existing.error_message = None
+        await session.flush()
+        return
+
+    session.add(Embedding(
+        id=uuid.uuid4(),
+        org_id=org_id,
+        project_id=project_id,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        embedding_text=embedding_text,
+        content_hash=new_hash,
+        status="pending",
+        created_by_member_id=created_by_member_id,
+    ))
+    await session.flush()
+
+
+def build_hypothesis_embedding_text(statement: str) -> str:
+    return statement
+
+
+def build_loop_embedding_text(title: str, goal_tags: list[str]) -> str:
+    if not goal_tags:
+        return title
+    return f"{title}\n{' '.join(goal_tags)}"
+
+
+def build_loop_artifact_embedding_text(
+    variant_label: str, choose_reason: str | None, rejection_reason: str | None
+) -> str:
+    parts = [variant_label]
+    if choose_reason:
+        parts.append(choose_reason)
+    if rejection_reason:
+        parts.append(rejection_reason)
+    return "\n".join(parts)

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -160,6 +160,15 @@ async def create_hypothesis(
     )
     await repo.add_epic_links(hyp.id, payload.epic_ids, "primary")
     await repo.add_story_links(hyp.id, payload.story_ids, "supports")
+
+    # E-LOOP-LEDGER P1-S4: statement를 embeddings 큐에 pending으로 등록(네트워크 I/O 0 —
+    # 실제 임베딩은 P1-S3 cron이 처리). score_hypotheses/attribute_loop_outcome과 동형 배선.
+    from app.services.embedding_enqueue import build_hypothesis_embedding_text, enqueue_embedding
+    await enqueue_embedding(
+        session, org_id, hyp.project_id, "hypothesis", hyp.id,
+        build_hypothesis_embedding_text(hyp.statement), created_by_member_id=caller.id,
+    )
+
     return await _to_response(repo, hyp)
 
 
@@ -219,6 +228,15 @@ async def update_hypothesis(
         await _verify_human_owner(session, new_owner)
 
     updated = await repo.update(hypothesis_id, **fields)
+
+    # P1-S4: statement가 바뀌면 재임베딩 큐잉(content_hash가 변경 없는 재저장은 no-op으로 걸러줌).
+    if "statement" in fields:
+        from app.services.embedding_enqueue import build_hypothesis_embedding_text, enqueue_embedding
+        await enqueue_embedding(
+            session, org_id, updated.project_id, "hypothesis", updated.id,
+            build_hypothesis_embedding_text(updated.statement), created_by_member_id=caller.id,
+        )
+
     return await _to_response(repo, updated)
 
 

--- a/backend/app/services/loop.py
+++ b/backend/app/services/loop.py
@@ -91,6 +91,14 @@ async def create_loop(
         status="draft",
         created_by_member_id=caller.id,
     )
+
+    # P1-S4: title+goal_tags를 embeddings 큐에 pending으로 등록(네트워크 I/O 0).
+    from app.services.embedding_enqueue import build_loop_embedding_text, enqueue_embedding
+    await enqueue_embedding(
+        session, org_id, loop.project_id, "loop", loop.id,
+        build_loop_embedding_text(loop.title, loop.goal_tags), created_by_member_id=caller.id,
+    )
+
     return LoopResponse.model_validate(loop)
 
 
@@ -169,6 +177,16 @@ async def create_loop_artifact(
         )
         .on_conflict_do_nothing(constraint="uq_asset_links_asset_source")
     )
+
+    # P1-S4: variant_label만으로 우선 큐잉(choose/rejection_reason은 S5 decide 시점에
+    # 재큐잉 — "moat" 텍스트[왜 골랐나/반려했나]가 실제로 완성되는 순간이 그때이기 때문).
+    from app.services.embedding_enqueue import build_loop_artifact_embedding_text, enqueue_embedding
+    await enqueue_embedding(
+        session, org_id, loop.project_id, "loop_artifact", artifact.id,
+        build_loop_artifact_embedding_text(artifact.variant_label, None, None),
+        created_by_member_id=caller.id,
+    )
+
     return LoopArtifactResponse.model_validate(artifact)
 
 
@@ -234,14 +252,33 @@ async def decide_loop_artifacts(
                 f"variant_group '{group_decision.variant_group}'의 chosen+rejections가 "
                 "pending 아티팩트 집합과 정확히 일치해야 합니다.",
             )
-        await artifact_repo.update(
+        # P1-S4: chosen/rejected 아티팩트를 여기서 재큐잉한다 — choose_reason/rejection_reason
+        # ("moat" 신호)이 실제로 채워지는 순간이 바로 지금이라, create 시점(variant_label만)의
+        # 얇은 임베딩을 이유까지 포함한 온전한 텍스트로 갱신(content_hash가 달라 재큐잉됨).
+        from app.services.embedding_enqueue import build_loop_artifact_embedding_text, enqueue_embedding
+
+        chosen_artifact = await artifact_repo.update(
             group_decision.chosen_artifact_id,
             decision="chosen", choose_reason=group_decision.choose_reason,
         )
+        await enqueue_embedding(
+            session, org_id, loop.project_id, "loop_artifact", chosen_artifact.id,
+            build_loop_artifact_embedding_text(
+                chosen_artifact.variant_label, chosen_artifact.choose_reason, None
+            ),
+            created_by_member_id=caller.id,
+        )
         for rejection in group_decision.rejections:
-            await artifact_repo.update(
+            rejected_artifact = await artifact_repo.update(
                 rejection.artifact_id,
                 decision="rejected", rejection_reason=rejection.rejection_reason,
+            )
+            await enqueue_embedding(
+                session, org_id, loop.project_id, "loop_artifact", rejected_artifact.id,
+                build_loop_artifact_embedding_text(
+                    rejected_artifact.variant_label, None, rejected_artifact.rejection_reason
+                ),
+                created_by_member_id=caller.id,
             )
 
     # decision_gate_id는 매 콜(gate 생성 시점부터) stamp — FE가 진행중 게이트를 참조할 수 있게.

--- a/backend/tests/test_e_loop_ledger_p1_s4_write_path.py
+++ b/backend/tests/test_e_loop_ledger_p1_s4_write_path.py
@@ -1,0 +1,264 @@
+"""E-LOOP-LEDGER P1-S4(story dadd1857): write-path embedding 큐잉 검증.
+
+4개 write-path 지점(hypothesis create/update·loop create·loop_artifact create·S5 decide)이
+실제로 embeddings row를 pending으로 큐잉하는지, content_hash 무변경 시 no-op(재큐잉 방지)인지,
+S5 decide 시 choose/rejection_reason 포함 텍스트로 재큐잉되는지를 실 DB로 검증한다.
+
+DB env(ALEMBIC_DATABASE_URL) 없으면 skip.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("25000000-0000-0000-0000-000000000001")
+USER = uuid.UUID("25000000-0000-0000-0000-0000000000a1")
+OM = uuid.UUID("25000000-0000-0000-0000-0000000000b1")
+PROJ = uuid.UUID("25000000-0000-0000-0000-000000000002")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _seed(s):
+    for sql in [
+        f"DELETE FROM embeddings WHERE org_id='{ORG}'",
+        f"DELETE FROM loop_artifacts WHERE org_id='{ORG}'",
+        f"DELETE FROM loop_runs WHERE org_id='{ORG}'",
+        f"DELETE FROM hypotheses WHERE org_id='{ORG}'",
+        f"DELETE FROM assets WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','C25','c25org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@c25.test','x','U',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ}','{ORG}','P')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ}','{OM}','granted')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _fetch_embedding(s, entity_type, entity_id):
+    from app.models.embedding import Embedding
+    return (await s.execute(
+        select(Embedding).where(Embedding.entity_type == entity_type, Embedding.entity_id == entity_id)
+    )).scalar_one_or_none()
+
+
+# ── hypothesis create/update ──────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_hypothesis_enqueues_pending_embedding():
+    from app.schemas.hypothesis import HypothesisCreate
+    from app.services.hypothesis import create_hypothesis
+    from app.services.member_resolver import resolve_member
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            caller = await resolve_member(_auth(), ORG, s, project_id=PROJ)
+            out = await create_hypothesis(s, ORG, caller, HypothesisCreate(
+                project_id=PROJ, statement="loops should improve retention",
+                metric_definition={"metric": "m", "source": "manual", "target": 1, "direction": "up"},
+                measure_after=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ))
+            await s.commit()
+
+            emb = await _fetch_embedding(s, "hypothesis", out.id)
+            assert emb is not None
+            assert emb.status == "pending"
+            assert emb.embedding_text == "loops should improve retention"
+            assert emb.embedding is None
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_hypothesis_statement_reenqueues_only_when_changed():
+    from app.schemas.hypothesis import HypothesisCreate, HypothesisUpdate
+    from app.services.hypothesis import create_hypothesis, update_hypothesis
+    from app.services.member_resolver import resolve_member
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            caller = await resolve_member(_auth(), ORG, s, project_id=PROJ)
+            out = await create_hypothesis(s, ORG, caller, HypothesisCreate(
+                project_id=PROJ, statement="v1",
+                metric_definition={"metric": "m", "source": "manual", "target": 1, "direction": "up"},
+                measure_after=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ))
+            await s.commit()
+            emb_v1 = await _fetch_embedding(s, "hypothesis", out.id)
+            hash_v1 = emb_v1.content_hash
+
+        # 무변경 필드(confidence)만 업데이트 — content_hash 그대로여야(no-op).
+        async with Session() as s:
+            await update_hypothesis(s, ORG, caller, out.id, HypothesisUpdate(confidence=0.5))
+            await s.commit()
+            emb_after_noop = await _fetch_embedding(s, "hypothesis", out.id)
+            assert emb_after_noop.content_hash == hash_v1
+
+        # statement 변경 — content_hash 갱신+status pending 재큐잉.
+        async with Session() as s:
+            await update_hypothesis(s, ORG, caller, out.id, HypothesisUpdate(statement="v2 changed"))
+            await s.commit()
+            emb_v2 = await _fetch_embedding(s, "hypothesis", out.id)
+            assert emb_v2.content_hash != hash_v1
+            assert emb_v2.embedding_text == "v2 changed"
+            assert emb_v2.status == "pending"
+    finally:
+        await eng.dispose()
+
+
+# ── loop create ──────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_loop_enqueues_title_and_goal_tags():
+    from app.schemas.loop import LoopCreate
+    from app.services.loop import create_loop
+    from app.services.member_resolver import resolve_member
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            caller = await resolve_member(_auth(), ORG, s, project_id=PROJ)
+            out = await create_loop(s, ORG, caller, LoopCreate(
+                project_id=PROJ, title="Improve onboarding", goal_tags=["retention", "activation"],
+            ))
+            await s.commit()
+
+            emb = await _fetch_embedding(s, "loop", out.id)
+            assert emb is not None
+            assert emb.status == "pending"
+            assert emb.embedding_text == "Improve onboarding\nretention activation"
+    finally:
+        await eng.dispose()
+
+
+# ── loop_artifact create + S5 decide 재큐잉 ─────────────────────────────────
+
+async def _seed_asset(s):
+    from app.models.asset import Asset
+    a = Asset(
+        id=uuid.uuid4(), org_id=ORG, project_id=PROJ, container="uploads",
+        object_path=f"org/{ORG}/asset-{uuid.uuid4().hex[:8]}.png", name="a.png", size_bytes=1,
+    )
+    s.add(a)
+    await s.commit()
+    return a.id
+
+
+@pytest.mark.anyio
+async def test_create_loop_artifact_enqueues_variant_label_only():
+    from app.repositories.loop import LoopRunRepository
+    from app.schemas.loop import LoopArtifactCreate
+    from app.services.loop import create_loop_artifact
+    from app.services.member_resolver import resolve_member
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            asset_id = await _seed_asset(s)
+            loop = await LoopRunRepository(s, ORG).create(
+                project_id=PROJ, title="L", goal_tags=[], status="deciding",
+                created_by_member_id=uuid.uuid4(),
+            )
+            await s.commit()
+            caller = await resolve_member(_auth(), ORG, s, project_id=PROJ)
+            out = await create_loop_artifact(s, ORG, caller, loop, LoopArtifactCreate(
+                variant_group="headline", variant_label="Variant A: bold CTA", asset_id=asset_id,
+            ))
+            await s.commit()
+
+            emb = await _fetch_embedding(s, "loop_artifact", out.id)
+            assert emb is not None
+            assert emb.embedding_text == "Variant A: bold CTA"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_decide_reenqueues_artifact_with_reason_included():
+    """S5 decide 시 choose_reason/rejection_reason이 포함된 온전한 텍스트로 재큐잉되는지 —
+    create 시점(variant_label만)과 다른 content_hash로 갱신되는지까지 실증."""
+    from app.repositories.loop import LoopArtifactRepository, LoopRunRepository
+    from app.schemas.loop import LoopArtifactCreate, LoopArtifactRejection, LoopDecisionRequest, VariantGroupDecision
+    from app.services.loop import create_loop_artifact, decide_loop_artifacts
+    from app.services.member_resolver import resolve_member
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            asset1 = await _seed_asset(s)
+            asset2 = await _seed_asset(s)
+            loop = await LoopRunRepository(s, ORG).create(
+                project_id=PROJ, title="L", goal_tags=[], status="deciding",
+                created_by_member_id=uuid.uuid4(),
+            )
+            await s.commit()
+            caller = await resolve_member(_auth(), ORG, s, project_id=PROJ)
+            a1 = await create_loop_artifact(s, ORG, caller, loop, LoopArtifactCreate(
+                variant_group="headline", variant_label="A", asset_id=asset1,
+            ))
+            a2 = await create_loop_artifact(s, ORG, caller, loop, LoopArtifactCreate(
+                variant_group="headline", variant_label="B", asset_id=asset2,
+            ))
+            await s.commit()
+            emb_a1_before = await _fetch_embedding(s, "loop_artifact", a1.id)
+            hash_before = emb_a1_before.content_hash
+
+        async with Session() as s:
+            await decide_loop_artifacts(s, ORG, caller, loop, LoopDecisionRequest(decisions=[
+                VariantGroupDecision(
+                    variant_group="headline", chosen_artifact_id=a1.id,
+                    choose_reason="Higher click-through in A/B test",
+                    rejections=[LoopArtifactRejection(artifact_id=a2.id, rejection_reason="Confusing copy")],
+                ),
+            ]))
+            await s.commit()
+
+            emb_a1_after = await _fetch_embedding(s, "loop_artifact", a1.id)
+            assert emb_a1_after.content_hash != hash_before
+            assert emb_a1_after.embedding_text == "A\nHigher click-through in A/B test"
+            assert emb_a1_after.status == "pending"
+
+            emb_a2_after = await _fetch_embedding(s, "loop_artifact", a2.id)
+            assert emb_a2_after.embedding_text == "B\nConfusing copy"
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_hypothesis_service.py
+++ b/backend/tests/test_hypothesis_service.py
@@ -41,6 +41,15 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+def _mock_embedding_enqueue():
+    """E-LOOP-LEDGER P1-S4: create/update_hypothesis가 해소 직후 enqueue_embedding을 호출
+    하므로(추가 session.execute+flush), 전이 로직만 검증하는 기존 mock-session 테스트에서는
+    배선 호출을 격리한다(_mock_outcome_verdicts/_mock_loop_attribution과 동일 이유)."""
+    with patch("app.services.embedding_enqueue.enqueue_embedding", new=AsyncMock(return_value=None)):
+        yield
+
+
 def _caller(member_type: str) -> ResolvedMember:
     cid = CALLER_HUMAN_ID if member_type == "human" else CALLER_AGENT_ID
     return ResolvedMember(


### PR DESCRIPTION
## Summary
- E-LOOP-LEDGER P1-S4(story `dadd1857`) — was developed stacked on P1-S1's branch while S1 was pending QA/gcloud-reauth; **S1 merged to `develop` (#1825) while this was in progress**, so this branch has been rebased cleanly onto current `develop` (single commit, no duplicate S1 history).
- `app/services/embedding_enqueue.py::enqueue_embedding` — on `hypothesis`/`loop`/`loop_artifact` create (and content-changing update), synchronously INSERT/UPSERT an `embeddings` row with `status='pending'` (zero network I/O — actual embedding generation is P1-S3's cron, separate story). Same wiring pattern as `score_hypotheses`/`attribute_loop_outcome` (directly inside the existing service functions, no new endpoint).
- `content_hash` (sha256) drives staleness detection — re-saving unchanged text is a no-op (avoids needless re-queuing / cron churn). When text actually changes, the stale `embedding`/`model_version`/`dimension` are cleared and `status` reset to `pending` — a stale vector never silently represents new text (until re-embedded, `embedding IS NULL` naturally excludes the row from similarity search).

### Four write-path touch points
- `create_hypothesis` / `update_hypothesis` (only when `statement` is in the update payload) — `build_hypothesis_embedding_text(statement)`.
- `create_loop` — `build_loop_embedding_text(title, goal_tags)`.
- `create_loop_artifact` — `build_loop_artifact_embedding_text(variant_label, None, None)` (thin initial embedding — no reason yet).
- **`decide_loop_artifacts` (S5, on chosen/rejected finalization)** — re-enqueues with `choose_reason`/`rejection_reason` included. Per PO's judgment: the "moat" signal (*why* a variant was chosen/rejected) is the actual compounding-learning payload, so the ideal re-embed moment is exactly when that reason gets filled in (S5's decision), not at artifact creation.

### Regression fixed
Existing mock-session `test_hypothesis_service.py` tests broke because the new `enqueue_embedding` call does a real `session.execute`/`flush` that a bare `MagicMock` session can't satisfy. Added an isolation patch (`_mock_embedding_enqueue` autouse fixture) — same convention already established for `_mock_outcome_verdicts`/`_mock_loop_attribution` in the S7 scorer tests, not a functional change.

## Test plan
- [x] `Base.metadata.create_all()` + `drop_all()` fresh-runnable clean.
- [x] New `tests/test_e_loop_ledger_p1_s4_write_path.py` (5 tests, non-tautological, real DB):
  - `create_hypothesis` produces an actual `pending` `embeddings` row with the correct `embedding_text`.
  - `update_hypothesis` with only unrelated fields changed (`confidence`) leaves `content_hash` identical (no-op proven, not just "no error"); changing `statement` actually updates `content_hash`/`embedding_text` and resets to `pending`.
  - `create_loop` enqueues the title+goal_tags-joined text.
  - `create_loop_artifact` enqueues `variant_label` only.
  - `decide_loop_artifacts` re-enqueues **both** the chosen and rejected artifacts with reason-included text, and the `content_hash` is asserted to differ from the pre-decision hash (proves actual re-embed, not just "still has *a* value").
- [x] Full loop/hypothesis/embeddings-schema test suites (43 tests) pass, including the isolation-fixed mock tests.
- [x] **Full suite diffed against the pre-existing baseline** (87 failures) — byte-identical failure set, zero new regressions, re-confirmed on the rebased branch. Given this touches core `hypothesis`/`loop` write paths broadly used across the codebase, this was checked with extra care both pre- and post-rebase.

Depends on P1-S1 (merged, #1825). No migration of its own.