### PR TITLE
feat(e-loop-ledger): P1-S3 — embed-backlog cron 파이프라인

### DIFF
--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -467,6 +467,33 @@ async def score_hypotheses_cron(
         return _err("INTERNAL_ERROR", "Internal server error", 500)
 
 
+# ─── POST /api/v2/internal/cron/embed-backlog ──────────────────────────────────
+
+@router.post("/embed-backlog")
+async def embed_backlog_cron(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """E-LOOP-LEDGER P1-S3: embeddings 백로그(status pending/failed) 배치 임베딩(블루프린트 §P1).
+
+    embed_client(P1-S2, gemini-embedding-001@768) 호출 — 성공 시 ready(벡터 저장), 실패(인증불가/
+    API오류/응답이상)는 원인 구분 불가라 pending 유지(false-hit 0 설계 계승, 다음 tick 재시도).
+    FOR UPDATE SKIP LOCKED로 중첩 invocation 간 disjoint 배치 보장(workflow_handoff_watchdog 동형).
+    tick당 상한 있음(폭주 방지). 신규 write-path(P1-S4)가 쌓은 pending row를 이 cron이 drain.
+    """
+    verify_cron(request)
+
+    from app.services.embedding_backlog import process_embedding_backlog
+
+    try:
+        summary = await process_embedding_backlog(session)
+        await session.commit()
+        return _ok(summary)
+    except Exception as exc:
+        logger.exception("embed-backlog cron error: %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)
+
+
 # ─── S8: storage capacity lifecycle crons ─────────────────────────────────────
 
 _ASSET_GRACE_DAYS = 7

--- a/backend/app/services/embedding_backlog.py
+++ b/backend/app/services/embedding_backlog.py
@@ -1,0 +1,81 @@
+"""E-LOOP-LEDGER P1-S3: embeddings 백로그 cron 배치 임베딩(Context Pack 파운데이션).
+
+score_hypotheses(hypothesis_scorer.py) cron 패턴을 구조적으로 미러(라우터는 verify_cron+위임+
+commit만, 실 로직은 이 서비스 모듈) — 단 배치 selection은 workflow_handoff_watchdog.py/
+workflow_sla_processor.py의 FOR UPDATE SKIP LOCKED를 따른다(중첩 cron invocation이 같은
+pending row를 동시에 집어 Vertex AI를 중복 호출하는 것을 방지 — score_hypotheses엔 이 보호가
+없지만 그건 외부 API 중복호출 비용이 없는 GA4/internal_ops 판정이라 무관하고, 이쪽은 유료 API라
+직접 미러하지 않는다).
+
+status='pending'뿐 아니라 'failed'도 재시도 대상(app/models/embedding.py 문서화된 FSM —
+"재시도는 cron이 pending으로 되돌림"을 이 cron이 매 tick 재선정으로 구현. 별도 retry_count
+컬럼/마이그 없음 — PO 지시로 이 스토리는 마이그 0).
+
+embed_text(P1-S2)가 인증불가/API오류/응답이상 전부 예외없이 None으로 수렴시키므로(S8 "false-hit 0"
+설계 계승) cron 레벨에서 원인 구분이 불가하다 — None은 'failed'로 전환하지 않고 pending 그대로
+둔다(다음 tick 자연 재시도, 무한 루프 아님 — tick당 _BATCH_SIZE 상한이 유일한 방어선).
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.embedding import Embedding
+
+logger = logging.getLogger(__name__)
+
+_BATCH_SIZE = 50  # tick당 상한(폭주 방지 — assets-grace-hard-delete의 500-limit과 동형 패턴,
+# 유료 임베딩 API 호출이라 더 보수적으로 설정).
+
+
+async def process_embedding_backlog(session: AsyncSession, limit: int = _BATCH_SIZE) -> dict[str, Any]:
+    """embeddings status='pending'|'failed' 배치를 집어 embed_text(P1-S2) 호출·결과 반영.
+
+    반환: scanned/embedded/pending_retry/failed 카운트(score_hypotheses 응답 스키마 미러).
+    """
+    from app.core.config import EMBEDDING_DIMENSION
+    from app.services.embedding_client import MODEL_VERSION, embed_text
+
+    rows = (await session.execute(
+        select(Embedding)
+        .where(Embedding.status.in_(("pending", "failed")))
+        .order_by(Embedding.created_at.asc())
+        .limit(limit)
+        .with_for_update(skip_locked=True)
+    )).scalars().all()
+
+    embedded: list[uuid.UUID] = []
+    pending_retry: list[uuid.UUID] = []
+    failed: list[dict[str, str]] = []
+
+    for row in rows:
+        try:
+            vector = embed_text(row.embedding_text)
+            if vector is None:
+                # 인증불가/API오류/응답이상 원인 구분 불가(embed_text가 전부 None으로 수렴) →
+                # pending 유지(false-hit 0). 이미 'failed'였던 row도 여기서 pending으로 재정착.
+                row.status = "pending"
+                pending_retry.append(row.id)
+                continue
+            row.embedding = vector
+            row.model_version = MODEL_VERSION
+            row.dimension = EMBEDDING_DIMENSION
+            row.status = "ready"
+            row.error_message = None
+            embedded.append(row.id)
+        except Exception as exc:  # embed_text 자체는 raise 안 하지만 방어적 격리(한 row 실패가 배치 전체를 막지 않음).
+            logger.exception("embed-backlog: row %s 처리 실패: %s", row.id, exc)
+            row.status = "failed"
+            row.error_message = str(exc)[:500]
+            failed.append({"id": str(row.id), "error": str(exc)})
+
+    return {
+        "scanned": len(rows),
+        "embedded": [str(i) for i in embedded],
+        "pending_retry": [str(i) for i in pending_retry],
+        "failed": failed,
+    }

--- a/backend/tests/test_e_loop_ledger_p1_s3_embed_backlog.py
+++ b/backend/tests/test_e_loop_ledger_p1_s3_embed_backlog.py
@@ -1,0 +1,119 @@
+"""E-LOOP-LEDGER P1-S3: embed-backlog cron 단위 테스트(mock session, 블루프린트 §P1).
+
+핵심 불변식: embed_text 성공→ready(벡터+model_version+dimension 저장)·None(인증불가/API오류
+원인 불문)→pending 유지(false-hit 0, 원인 구분 없이 재시도)·예외 발생 row만 격리적으로 failed.
+한 row의 예외가 배치 전체를 막지 않는다(개별 try/except).
+"""
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import embedding_backlog as backlog
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _row(status="pending", embedding_text="loop: 신규 온보딩 개선"):
+    return SimpleNamespace(
+        id=uuid.uuid4(), status=status, embedding_text=embedding_text,
+        embedding=None, model_version=None, dimension=None, error_message=None,
+    )
+
+
+def _result(items):
+    r = MagicMock()
+    r.scalars.return_value.all.return_value = items
+    return r
+
+
+def _session(rows):
+    s = AsyncMock()
+    s.execute = AsyncMock(return_value=_result(rows))
+    return s
+
+
+async def test_embed_success_marks_ready_and_stores_vector():
+    row = _row()
+    session = _session([row])
+    vector = [0.1] * 768
+    with patch("app.services.embedding_client.embed_text", return_value=vector):
+        summary = await backlog.process_embedding_backlog(session)
+    assert row.status == "ready"
+    assert row.embedding == vector
+    assert row.model_version == "gemini-embedding-001"
+    assert row.dimension == 768
+    assert row.error_message is None
+    assert summary["embedded"] == [str(row.id)]
+    assert summary["pending_retry"] == []
+    assert summary["failed"] == []
+
+
+async def test_embed_none_keeps_pending_no_failure_signal():
+    """인증불가/API오류 등 embed_text가 None을 반환하는 모든 경우 — 원인 구분 없이 pending 유지."""
+    row = _row(status="pending")
+    session = _session([row])
+    with patch("app.services.embedding_client.embed_text", return_value=None):
+        summary = await backlog.process_embedding_backlog(session)
+    assert row.status == "pending"
+    assert summary["embedded"] == []
+    assert summary["pending_retry"] == [str(row.id)]
+    assert summary["failed"] == []
+
+
+async def test_failed_row_reselected_resets_to_pending_on_none():
+    """기존 status='failed' row도 이 cron이 재선정 — embed_text가 다시 None이면 pending으로 되돌림
+    (app/models/embedding.py 문서화된 FSM: '재시도는 cron이 pending으로 되돌림')."""
+    row = _row(status="failed")
+    row.error_message = "이전 실패"
+    session = _session([row])
+    with patch("app.services.embedding_client.embed_text", return_value=None):
+        await backlog.process_embedding_backlog(session)
+    assert row.status == "pending"
+
+
+async def test_one_row_exception_does_not_block_batch():
+    good = _row()
+    bad = _row()
+    session = _session([bad, good])
+    vector = [0.2] * 768
+
+    calls = {"n": 0}
+
+    def _embed(text):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("unexpected SDK crash")
+        return vector
+
+    with patch("app.services.embedding_client.embed_text", side_effect=_embed):
+        summary = await backlog.process_embedding_backlog(session)
+
+    assert bad.status == "failed"
+    assert "unexpected SDK crash" in bad.error_message
+    assert good.status == "ready"
+    assert summary["embedded"] == [str(good.id)]
+    assert len(summary["failed"]) == 1
+    assert summary["failed"][0]["id"] == str(bad.id)
+
+
+async def test_empty_backlog_returns_zero_counts():
+    session = _session([])
+    summary = await backlog.process_embedding_backlog(session)
+    assert summary == {"scanned": 0, "embedded": [], "pending_retry": [], "failed": []}
+
+
+async def test_batch_limit_passed_through_to_query():
+    from sqlalchemy.dialects import postgresql
+
+    session = _session([])
+    await backlog.process_embedding_backlog(session, limit=5)
+    executed_query = session.execute.call_args[0][0]
+    compiled = str(executed_query.compile(
+        dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+    ))
+    assert "LIMIT 5" in compiled

--- a/backend/tests/test_e_loop_ledger_p1_s3_embed_backlog_realdb.py
+++ b/backend/tests/test_e_loop_ledger_p1_s3_embed_backlog_realdb.py
@@ -1,0 +1,162 @@
+"""E-LOOP-LEDGER P1-S3: embed-backlog cron 실 Postgres 검증(블루프린트 §P1).
+
+핵심: pgvector round-trip(embedding 컬럼 실 저장/조회)·SKIP LOCKED 동시성(중첩 cron invocation이
+같은 row를 중복 처리 안 함)·failed row 재선정→pending 리셋. embed_client는 라이브 Vertex AI 호출
+없이 patch(P1-S2 자체 검증은 test_e_loop_ledger_p1_s2_embedding_client.py 스코프).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _embedding(**ov):
+    from app.models.embedding import Embedding
+    base = dict(
+        id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(),
+        entity_type="loop", entity_id=uuid.uuid4(),
+        embedding_text="loop: 신규 온보딩 개선", content_hash="deadbeef",
+        status="pending",
+    )
+    base.update(ov)
+    return Embedding(**base)
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_embed_success_persists_vector_real_db():
+    from sqlalchemy import text as _text, select
+    from app.core.database import Base
+    from app.models.embedding import Embedding
+    from app.services.embedding_backlog import process_embedding_backlog
+
+    engine, Session = await _session()
+    row = _embedding()
+    vector = [0.5] * 768
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add(row)
+            await s.commit()
+
+        async with Session() as s:
+            with patch("app.services.embedding_client.embed_text", return_value=vector):
+                summary = await process_embedding_backlog(s)
+            await s.commit()
+        assert summary["embedded"] == [str(row.id)]
+
+        async with Session() as s:
+            persisted = (await s.execute(
+                select(Embedding).where(Embedding.id == row.id)
+            )).scalar_one()
+            assert persisted.status == "ready"
+            assert persisted.model_version == "gemini-embedding-001"
+            assert persisted.dimension == 768
+            assert list(persisted.embedding) == pytest.approx(vector)
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_embed_none_and_failed_reselect_stay_or_reset_pending_real_db():
+    from sqlalchemy import text as _text, select
+    from app.core.database import Base
+    from app.models.embedding import Embedding
+    from app.services.embedding_backlog import process_embedding_backlog
+
+    engine, Session = await _session()
+    still_pending = _embedding(status="pending")
+    was_failed = _embedding(status="failed", error_message="이전 실패")
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add_all([still_pending, was_failed])
+            await s.commit()
+
+        async with Session() as s:
+            with patch("app.services.embedding_client.embed_text", return_value=None):
+                summary = await process_embedding_backlog(s)
+            await s.commit()
+        assert set(summary["pending_retry"]) == {str(still_pending.id), str(was_failed.id)}
+
+        async with Session() as s:
+            rows = dict((await s.execute(
+                select(Embedding.id, Embedding.status)
+            )).all())
+            assert rows[still_pending.id] == "pending"
+            assert rows[was_failed.id] == "pending"  # failed → cron이 재선정→pending 리셋
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_concurrent_invocations_skip_locked_disjoint_real_db():
+    """⭐중첩 cron invocation이 같은 pending row를 동시에 집으면 유료 Vertex AI API가 중복 호출된다.
+    FOR UPDATE SKIP LOCKED로 잠긴 row는 건너뛰어 정확히 한쪽만 처리."""
+    from sqlalchemy import select
+    from app.core.database import Base
+    from app.models.embedding import Embedding
+    from app.services.embedding_backlog import process_embedding_backlog
+    from sqlalchemy import text as _text
+
+    engine, Session = await _session()
+    row = _embedding()
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add(row)
+            await s.commit()
+
+        async with Session() as s_lock, Session() as s_work:
+            held = (await s_lock.execute(
+                select(Embedding).where(Embedding.id == row.id).with_for_update(skip_locked=True)
+            )).scalar_one_or_none()
+            assert held is not None  # s_lock이 row 잠금 보유
+
+            with patch("app.services.embedding_client.embed_text", return_value=[0.1] * 768) as embed_mock:
+                summary = await process_embedding_backlog(s_work)
+            assert summary["scanned"] == 0  # ⭐잠긴 row는 건너뜀
+            embed_mock.assert_not_called()
+            await s_lock.rollback()
+
+        async with Session() as s2:
+            with patch("app.services.embedding_client.embed_text", return_value=[0.2] * 768) as embed_mock2:
+                summary2 = await process_embedding_backlog(s2)
+            await s2.commit()
+        assert summary2["embedded"] == [str(row.id)]
+        assert embed_mock2.call_count == 1
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- E-LOOP-LEDGER P1-S3(story `350a99f0`) — `POST /api/v2/internal/cron/embed-backlog`. embeddings `status='pending'|'failed'` 배치를 `embed_client`(P1-S2, gemini-embedding-001@768)로 임베딩 → 성공 시 `ready`(벡터/model_version/dimension 저장), 실패는 원인 구분 불가라 `pending` 유지(false-hit 0 설계 계승).
- 배치 selection에 `FOR UPDATE SKIP LOCKED` 적용(`workflow_handoff_watchdog.py`/`workflow_sla_processor.py` 미러) — 중첩 cron invocation이 같은 row를 동시에 집어 유료 Vertex AI API를 중복호출하는 것을 방지.
- 라우터 구조는 `score_hypotheses` cron 미러(verify_cron+위임+commit만, 로직은 `app/services/embedding_backlog.py`).
- 별도 retry_count 컬럼/마이그 없이, 기존 `failed` row를 매 tick 재선정해 `pending`으로 리셋 — `app/models/embedding.py`에 문서화된 FSM("재시도는 cron이 pending으로 되돌림")을 구현.
- 마이그 없음.

## Test plan
- [x] mock-session 단위 테스트 6건(성공/None 유지/failed 재선정/예외 격리/빈 배치/limit 배선) — `tests/test_e_loop_ledger_p1_s3_embed_backlog.py`
- [x] realdb 테스트 3건(pgvector round-trip·None 유지+failed→pending 리셋·SKIP LOCKED 동시성 disjoint) — `tests/test_e_loop_ledger_p1_s3_embed_backlog_realdb.py`
- [x] `alembic upgrade head`(throwaway pgvector/pgvector:pg16) — 0151에서 무변경 도달(신규 마이그 없음 확인)
- [x] `create_all`/`drop_all` fresh-runnable round-trip(별도 컨테이너)
- [x] 전체 pytest suite — baseline(93건) 대비 diff 확인. 신규 3건 실패는 내 코드 로직 무관 — 격리 실행 시 9/9 pass 확인, 원인은 이미 baseline에 존재하는 사전-존재 이슈(`DependentObjectsStillExistError: team_members view depends on agent_project_profiles table`, `test_claim_participation.py::test_ensure_implementation_participation_idempotent`에서도 동일 시그니처 확인 — 여러 realdb 테스트가 한 컨테이너를 공유하는 풀스위트 특유의 cross-test DB 정리 순서 문제, 이 브랜치가 만든 회귀 아님)

🤖 Generated with [Claude Code](https://claude.com/claude-code)