### PR TITLE
feat(e-loop-ledger): P1-S6 — context-pack 유사도 검색 엔드포인트

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,7 +57,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -155,6 +155,7 @@ app.include_router(sprints.router)
 app.include_router(epics.router)
 app.include_router(hypotheses.router)
 app.include_router(loops.router)
+app.include_router(context_pack.router)
 app.include_router(dependencies.router)
 app.include_router(labels.router)
 app.include_router(labels.item_label_router)

--- a/backend/app/routers/context_pack.py
+++ b/backend/app/routers/context_pack.py
@@ -1,0 +1,55 @@
+"""E-LOOP-LEDGER P1-S6: /api/v2/context-pack 라우터(유사도 검색, 블루프린트 §P1).
+
+계약: 성공은 raw list 반환, 오류는 HTTPException(dict detail {code,message}) — loops.py/docs.py
+동형(main.py 핸들러가 {data:null,error:{code,message},meta:null}로 감쌈).
+
+authz: project_id 필수(Query(...))+has_project_access 명시 호출(docs.py의
+_require_doc_project_access와 동형, IDOR-safe — 선생님 결정#6: search는 loops.py LIST의
+get_project_scoped_org_id 단독 의존보다 엄격한 project 멤버십을 요구한다. get_project_scoped_org_id는
+project의 org 소속만 확인하고 caller의 project 멤버십 자체는 검증하지 않음 — has_project_access를
+별도로 걸어야 실제 project-level IDOR을 막는다).
+
+query embed는 동기 embed_client(P1-S2) 직접 호출 — 검색은 사용자가 응답을 기다리는 요청이라 cron의
+None-tolerant(false-hit 0) 설계와 달리 embed 실패를 즉시 503으로 드러낸다(결과를 조용히 비워
+"검색 결과 없음"으로 오인시키지 않음).
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user, get_project_scoped_org_id
+from app.dependencies.database import get_db
+from app.schemas.context_pack import ContextPackSearchResult
+
+router = APIRouter(prefix="/api/v2/context-pack", tags=["context-pack"])
+
+
+@router.get("/search", response_model=list[ContextPackSearchResult])
+async def search_context_pack(
+    project_id: uuid.UUID = Query(...),
+    query: str = Query(..., min_length=1),
+    limit: int = Query(default=10, ge=1, le=50),
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_project_scoped_org_id),
+) -> list[ContextPackSearchResult]:
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "PROJECT_ACCESS_DENIED", "message": "해당 프로젝트 접근 권한이 없습니다"},
+        )
+
+    from app.services.embedding_client import embed_text
+    vector = embed_text(query)
+    if vector is None:
+        raise HTTPException(
+            status_code=503,
+            detail={"code": "EMBED_UNAVAILABLE", "message": "임베딩 서비스를 사용할 수 없습니다. 잠시 후 다시 시도하세요."},
+        )
+
+    from app.services.context_pack_search import search_similar_embeddings
+    return await search_similar_embeddings(session, org_id, project_id, vector, limit=limit)

--- a/backend/app/schemas/context_pack.py
+++ b/backend/app/schemas/context_pack.py
@@ -1,0 +1,12 @@
+import uuid
+
+from pydantic import BaseModel
+
+
+class ContextPackSearchResult(BaseModel):
+    """P1-S6: 유사도 검색 결과 1건. entity_type/entity_id는 embeddings의 폴리모픽 참조를 그대로 노출
+    (호출자가 S7 Context Pack 조립 시 해당 엔티티를 직접 로드)."""
+    entity_type: str
+    entity_id: uuid.UUID
+    embedding_text: str
+    similarity: float

--- a/backend/app/services/context_pack_search.py
+++ b/backend/app/services/context_pack_search.py
@@ -1,0 +1,83 @@
+"""E-LOOP-LEDGER P1-S6: Context Pack 유사도 검색(블루프린트 §P1).
+
+status='ready' 임베딩만 cosine 거리(pgvector `<=>`)로 ORDER BY — S1 이후 이 코드베이스에서
+embedding 컬럼에 대한 첫 실 쿼리(app/models/embedding.py의 HNSW 인덱스는 지금까지 미사용 상태였음).
+
+recall 트랩(까심/codex 지적, app/models/embedding.py에 문서화): HNSW는 WHERE 등식필터를 인덱스
+레벨에서 걷지 못한다 — pgvector가 그래프 순회 중 후보에 필터를 적용하므로 project_id/status 필터의
+선택도가 낮으면 recall이 저하될 수 있다(seq-scan은 아니지만 유효 결과가 LIMIT보다 적게 반환될 수
+있음). 완화책으로 SET LOCAL hnsw.ef_search를 기본값(40)보다 높여 후보 풀을 넓힌다 — 근본 해법(테넌트
+파티셔닝)은 후속 스토리 스코프.
+
+orphan 정리(assets.py의 AssetLink 패턴 미러): entity_type/entity_id는 DB FK 없는 폴리모픽 참조라
+soft-delete/archive된 부모의 stale embedding row가 남을 수 있다. 후보를 부모 타입별로 배치조회해
+"살아있음" 조건에 없으면 결과에서 드롭(백필 안 함 — limit개 요청해 그보다 적게 반환될 수 있음,
+AssetLink와 동일 트레이드오프).
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.embedding import Embedding
+from app.models.hypothesis import Hypothesis
+from app.models.loop import LoopRun
+from app.schemas.context_pack import ContextPackSearchResult
+
+_EF_SEARCH = 100  # pgvector 기본 40보다 높여 등식필터 결합 시 recall 완화(세션 GUC, SET LOCAL).
+
+
+async def search_similar_embeddings(
+    session: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID,
+    query_vector: list[float], limit: int = 10,
+) -> list[ContextPackSearchResult]:
+    # Postgres SET/SET LOCAL은 bind parameter를 받지 않는다(asyncpg PostgresSyntaxError) — _EF_SEARCH가
+    # 하드코딩 내부 상수(사용자 입력 아님)라 리터럴 인라인이 안전(SQL 인젝션 축 없음).
+    await session.execute(text(f"SET LOCAL hnsw.ef_search = {_EF_SEARCH}"))
+
+    distance = Embedding.embedding.cosine_distance(query_vector)
+    rows = (await session.execute(
+        select(Embedding, distance.label("distance"))
+        .where(
+            Embedding.org_id == org_id,
+            Embedding.project_id == project_id,
+            Embedding.status == "ready",
+        )
+        .order_by(distance)
+        .limit(limit)
+    )).all()
+    if not rows:
+        return []
+
+    hyp_ids = {r.Embedding.entity_id for r in rows if r.Embedding.entity_type == "hypothesis"}
+    loop_ids = {r.Embedding.entity_id for r in rows if r.Embedding.entity_type == "loop"}
+
+    alive_hyp_ids: set[uuid.UUID] = set()
+    if hyp_ids:
+        alive_hyp_ids = set((await session.execute(
+            select(Hypothesis.id).where(Hypothesis.id.in_(hyp_ids), Hypothesis.status != "archived")
+        )).scalars().all())
+
+    alive_loop_ids: set[uuid.UUID] = set()
+    if loop_ids:
+        alive_loop_ids = set((await session.execute(
+            select(LoopRun.id).where(LoopRun.id.in_(loop_ids), LoopRun.deleted_at.is_(None))
+        )).scalars().all())
+
+    results: list[ContextPackSearchResult] = []
+    for r in rows:
+        emb, distance_val = r.Embedding, r.distance
+        if emb.entity_type == "hypothesis" and emb.entity_id not in alive_hyp_ids:
+            continue
+        if emb.entity_type == "loop" and emb.entity_id not in alive_loop_ids:
+            continue
+        # loop_artifact: 삭제/보관 개념 없음(app/models/loop.py) — 항상 유지.
+        results.append(ContextPackSearchResult(
+            entity_type=emb.entity_type,
+            entity_id=emb.entity_id,
+            embedding_text=emb.embedding_text,
+            similarity=1.0 - distance_val,
+        ))
+    return results

--- a/backend/tests/test_e_loop_ledger_p1_s6_context_pack_search.py
+++ b/backend/tests/test_e_loop_ledger_p1_s6_context_pack_search.py
@@ -1,0 +1,83 @@
+"""E-LOOP-LEDGER P1-S6: context-pack 유사도 검색 서비스 단위 테스트(mock session, 블루프린트 §P1).
+
+핵심 불변식: status='ready'만 대상(서비스 함수 자체는 SQL WHERE로 위임하므로 여기선 orphan
+필터링만 직접 검증) — archived hypothesis/soft-deleted loop을 가리키는 stale embedding은 결과에서
+드롭. loop_artifact는 삭제 개념이 없어 항상 유지. 빈 배치는 조기 반환(추가 쿼리 0).
+"""
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services import context_pack_search as svc
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _emb_row(entity_type, entity_id, distance, embedding_text="text"):
+    emb = SimpleNamespace(entity_type=entity_type, entity_id=entity_id, embedding_text=embedding_text)
+    return SimpleNamespace(Embedding=emb, distance=distance)
+
+
+class _FakeSession:
+    def __init__(self, embed_rows, alive_hyp_ids, alive_loop_ids):
+        self._embed_rows = embed_rows
+        self._alive_hyp_ids = alive_hyp_ids
+        self._alive_loop_ids = alive_loop_ids
+        self.executed = []
+
+    async def execute(self, stmt, params=None):
+        self.executed.append(stmt)
+        text_str = str(stmt)
+        result = MagicMock()
+        if "SET LOCAL" in text_str or "hnsw" in text_str.lower():
+            return result
+        if "hypotheses" in text_str.lower():
+            result.scalars.return_value.all.return_value = list(self._alive_hyp_ids)
+            return result
+        if "loop_runs" in text_str.lower():
+            result.scalars.return_value.all.return_value = list(self._alive_loop_ids)
+            return result
+        # embeddings 메인 쿼리
+        result.all.return_value = self._embed_rows
+        return result
+
+
+async def test_orphaned_hypothesis_dropped_alive_kept():
+    alive_id = uuid.uuid4()
+    dead_id = uuid.uuid4()  # archived → alive set에서 제외
+    rows = [_emb_row("hypothesis", alive_id, 0.1), _emb_row("hypothesis", dead_id, 0.2)]
+    session = _FakeSession(rows, alive_hyp_ids={alive_id}, alive_loop_ids=set())
+    out = await svc.search_similar_embeddings(session, uuid.uuid4(), uuid.uuid4(), [0.0] * 768)
+    assert len(out) == 1
+    assert out[0].entity_id == alive_id
+    assert out[0].similarity == pytest.approx(0.9)
+
+
+async def test_orphaned_loop_dropped_alive_kept():
+    alive_id = uuid.uuid4()
+    dead_id = uuid.uuid4()  # soft-deleted → alive set에서 제외
+    rows = [_emb_row("loop", alive_id, 0.3), _emb_row("loop", dead_id, 0.4)]
+    session = _FakeSession(rows, alive_hyp_ids=set(), alive_loop_ids={alive_id})
+    out = await svc.search_similar_embeddings(session, uuid.uuid4(), uuid.uuid4(), [0.0] * 768)
+    assert [r.entity_id for r in out] == [alive_id]
+
+
+async def test_loop_artifact_never_filtered_no_deletion_concept():
+    aid = uuid.uuid4()
+    rows = [_emb_row("loop_artifact", aid, 0.15)]
+    session = _FakeSession(rows, alive_hyp_ids=set(), alive_loop_ids=set())
+    out = await svc.search_similar_embeddings(session, uuid.uuid4(), uuid.uuid4(), [0.0] * 768)
+    assert [r.entity_id for r in out] == [aid]
+
+
+async def test_empty_backlog_returns_empty_no_extra_queries():
+    session = _FakeSession([], alive_hyp_ids=set(), alive_loop_ids=set())
+    out = await svc.search_similar_embeddings(session, uuid.uuid4(), uuid.uuid4(), [0.0] * 768)
+    assert out == []
+    # SET LOCAL + 메인 embeddings 쿼리 2회만(orphan 배치조회는 후보 0이라 스킵).
+    assert len(session.executed) == 2

--- a/backend/tests/test_e_loop_ledger_p1_s6_context_pack_search_idor_realdb.py
+++ b/backend/tests/test_e_loop_ledger_p1_s6_context_pack_search_idor_realdb.py
@@ -1,0 +1,116 @@
+"""E-LOOP-LEDGER P1-S6: context-pack search cross-project IDOR — realdb(선생님 결정#6).
+
+get_project_scoped_org_id는 project의 org 소속만 확인하고 caller의 project 멤버십 자체는
+검증하지 않는다(app/dependencies/auth.py) — search_context_pack이 has_project_access를
+별도로 명시 호출하지 않으면 同org 비멤버가 타 project의 임베딩 검색 결과를 열람 가능(수평 IDOR).
+본 테스트는 라우터 함수를 직접 호출해(docs.py의 test_doc_mutation_project_scope_idor_realdb.py와
+동형) cross-project=403·same-project=통과(embed_text는 결정론적 결과를 위해 patch)를 검증한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("d9000000-0000-0000-0000-000000000001")
+USER = uuid.UUID("d9000000-0000-0000-0000-0000000000a1")
+OM = uuid.UUID("d9000000-0000-0000-0000-0000000000b1")
+PROJ_A = uuid.UUID("d9000000-0000-0000-0000-0000000000c1")  # USER grant(접근 O)
+PROJ_B = uuid.UUID("d9000000-0000-0000-0000-0000000000c2")  # USER 접근 X(IDOR 축)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+
+
+async def _seed(s):
+    for sql in [
+        f"DELETE FROM embeddings WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id IN ('{PROJ_A}','{PROJ_B}')",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','D9','d9org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@d9.test','x','U',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_A}','{ORG}','A')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_B}','{ORG}','B')",
+        # USER는 PROJ_A에만 grant(PROJ_B 접근 없음 — IDOR 테스트축).
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ_A}','{OM}','granted')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+@pytest.mark.anyio
+async def test_cross_project_forbidden_same_project_ok():
+    from app.routers.context_pack import search_context_pack
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        # cross-project(PROJ_B·USER 무접근) → 403
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await search_context_pack(
+                    project_id=PROJ_B, query="검색어", limit=10, session=s, auth=_auth(), org_id=ORG,
+                )
+            assert ei.value.status_code == 403
+            assert ei.value.detail["code"] == "PROJECT_ACCESS_DENIED"
+
+        # same-project(PROJ_A·USER grant) → 통과(embed_text patch로 결정론적 결과).
+        async with Session() as s:
+            with patch("app.services.embedding_client.embed_text", return_value=[0.1] * 768):
+                out = await search_context_pack(
+                    project_id=PROJ_A, query="검색어", limit=10, session=s, auth=_auth(), org_id=ORG,
+                )
+            assert out == []  # 시드된 embedding 없음 — 403이 아니라 정상 빈 결과라는 점이 핵심.
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_embed_unavailable_returns_503_not_leaked_as_empty_result():
+    """embed_text가 None(인증불가)이면 조용히 빈 결과가 아니라 503으로 드러나야(사용자 대기 요청)."""
+    from app.routers.context_pack import search_context_pack
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            with patch("app.services.embedding_client.embed_text", return_value=None):
+                with pytest.raises(HTTPException) as ei:
+                    await search_context_pack(
+                        project_id=PROJ_A, query="검색어", limit=10, session=s, auth=_auth(), org_id=ORG,
+                    )
+                assert ei.value.status_code == 503
+                assert ei.value.detail["code"] == "EMBED_UNAVAILABLE"
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_e_loop_ledger_p1_s6_context_pack_search_realdb.py
+++ b/backend/tests/test_e_loop_ledger_p1_s6_context_pack_search_realdb.py
@@ -1,0 +1,154 @@
+"""E-LOOP-LEDGER P1-S6: context-pack 유사도 검색 실 Postgres 검증(블루프린트 §P1).
+
+핵심: pgvector cosine 거리 실 ORDER BY(가까운 벡터가 먼저)·status='ready'만 대상·orphan
+정리(archived hypothesis/soft-deleted loop을 가리키는 stale embedding 드롭)를 실 DB round-trip으로
+직접 검증. HNSW 인덱스가 생긴 이후 embedding 컬럼에 대한 이 코드베이스 첫 실 쿼리.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _unit(i: int, dim: int = 768) -> list[float]:
+    """i번째 축만 1.0인 단위벡터 — cosine 거리로 서로 직교(거리 1.0), 자기자신과는 거리 0."""
+    v = [0.0] * dim
+    v[i] = 1.0
+    return v
+
+
+def _near(i: int, dim: int = 768) -> list[float]:
+    """i번째 축에 살짝 못 미치는 벡터 — _unit(i)와 방향이 거의 같아(코사인 거리 작음) '가까움' 표현."""
+    v = [0.01] * dim
+    v[i] = 0.99
+    return v
+
+
+def _opposite(i: int, dim: int = 768) -> list[float]:
+    """i번째 축의 반대 방향 단위벡터 — query(axis i)와 코사인 거리 2(유사도 -1), 가장 멀다."""
+    v = [0.0] * dim
+    v[i] = -1.0
+    return v
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_cosine_order_and_orphan_filtering_real_db():
+    from sqlalchemy import text as _text, select
+    from app.core.database import Base
+    from app.models.embedding import Embedding
+    from app.models.hypothesis import Hypothesis
+    from app.models.loop import LoopRun
+    from app.services.context_pack_search import search_similar_embeddings
+
+    engine, Session = await _session()
+    org, project = uuid.uuid4(), uuid.uuid4()
+    query_vec = _unit(0)  # query가 axis 0을 향함 → axis 0에 가까운 embedding이 먼저 나와야 함.
+
+    hyp_alive, hyp_archived = uuid.uuid4(), uuid.uuid4()
+    loop_alive, loop_deleted = uuid.uuid4(), uuid.uuid4()
+    artifact_id = uuid.uuid4()
+    other_org_embedding = uuid.uuid4()
+
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add_all([
+                Hypothesis(
+                    id=hyp_alive, org_id=org, project_id=project, owner_member_id=uuid.uuid4(),
+                    statement="살아있는 가설",
+                    metric_definition={"metric": "x", "source": "manual", "target": 1, "direction": "up"},
+                    measure_after=datetime.now(timezone.utc),
+                    status="active",
+                ),
+                Hypothesis(
+                    id=hyp_archived, org_id=org, project_id=project, owner_member_id=uuid.uuid4(),
+                    statement="보관된 가설",
+                    metric_definition={"metric": "x", "source": "manual", "target": 1, "direction": "up"},
+                    measure_after=datetime.now(timezone.utc),
+                    status="archived",
+                ),
+                LoopRun(id=loop_alive, org_id=org, project_id=project, title="살아있는 loop",
+                        created_by_member_id=uuid.uuid4()),
+                LoopRun(id=loop_deleted, org_id=org, project_id=project, title="삭제된 loop",
+                        created_by_member_id=uuid.uuid4(), deleted_at=datetime.now(timezone.utc)),
+            ])
+            await s.flush()
+            # 가장 query와 가까운(axis 0) — 살아있는 hypothesis, 최상위 노출 기대.
+            s.add_all([
+                Embedding(id=uuid.uuid4(), org_id=org, project_id=project,
+                          entity_type="hypothesis", entity_id=hyp_alive,
+                          embedding_text="alive hyp", content_hash="h1",
+                          embedding=_near(0), model_version="m", dimension=768, status="ready"),
+                Embedding(id=uuid.uuid4(), org_id=org, project_id=project,
+                          entity_type="hypothesis", entity_id=hyp_archived,
+                          embedding_text="archived hyp", content_hash="h2",
+                          embedding=_near(0), model_version="m", dimension=768, status="ready"),
+                Embedding(id=uuid.uuid4(), org_id=org, project_id=project,
+                          entity_type="loop", entity_id=loop_alive,
+                          embedding_text="alive loop", content_hash="h3",
+                          embedding=_unit(1), model_version="m", dimension=768, status="ready"),
+                Embedding(id=uuid.uuid4(), org_id=org, project_id=project,
+                          entity_type="loop", entity_id=loop_deleted,
+                          embedding_text="deleted loop", content_hash="h4",
+                          embedding=_unit(1), model_version="m", dimension=768, status="ready"),
+                Embedding(id=uuid.uuid4(), org_id=org, project_id=project,
+                          entity_type="loop_artifact", entity_id=artifact_id,
+                          embedding_text="artifact", content_hash="h5",
+                          embedding=_opposite(0), model_version="m", dimension=768, status="ready"),
+                # status='pending'(아직 미임베딩) → 검색 결과에서 제외돼야.
+                Embedding(id=uuid.uuid4(), org_id=org, project_id=project,
+                          entity_type="loop_artifact", entity_id=uuid.uuid4(),
+                          embedding_text="not yet embedded", content_hash="h6",
+                          status="pending"),
+                # 다른 project → 결과에서 제외돼야.
+                Embedding(id=other_org_embedding, org_id=org, project_id=uuid.uuid4(),
+                          entity_type="loop_artifact", entity_id=uuid.uuid4(),
+                          embedding_text="other project", content_hash="h7",
+                          embedding=_near(0), model_version="m", dimension=768, status="ready"),
+            ])
+            await s.commit()
+
+        async with Session() as s:
+            results = await search_similar_embeddings(s, org, project, query_vec, limit=10)
+
+        ids = [r.entity_id for r in results]
+        # orphan 정리: archived hypothesis·soft-deleted loop 제외.
+        assert hyp_archived not in ids
+        assert loop_deleted not in ids
+        # 다른 project·pending 상태는 애초 SQL WHERE로 제외.
+        assert other_org_embedding not in [r.entity_id for r in results]
+        # 살아있는 3건(hyp_alive, loop_alive, artifact_id)만 남음.
+        assert set(ids) == {hyp_alive, loop_alive, artifact_id}
+        # 코사인 순서: query(axis 0)에 가장 가까운 hyp_alive(_near(0))가 최상위.
+        assert ids[0] == hyp_alive
+        assert results[0].similarity > results[1].similarity > results[2].similarity
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- E-LOOP-LEDGER P1-S6(story `7b76392b`) — `GET /api/v2/context-pack/search?project_id=&query=`. query를 `embed_client`(P1-S2)로 동기 임베드 후 pgvector cosine 거리(`<=>`, `Vector.cosine_distance()`)로 `status='ready'` 임베딩만 정렬. S1 이후 embedding 컬럼(HNSW 인덱스)에 대한 이 코드베이스 첫 실 쿼리.
- authz: `project_id` 필수(`Query(...)`) + `has_project_access` 명시 호출(`docs.py`의 `_require_doc_project_access`와 동형 — 선생님 결정#6). `get_project_scoped_org_id`는 project의 org 소속만 확인하고 caller의 project 멤버십은 검증하지 않아 별도로 걸어야 실제 project-level IDOR을 막는다.
- orphan 정리(`assets.py`의 `AssetLink` 패턴 미러): 폴리모픽 `entity_type/entity_id`가 가리키는 부모가 archived hypothesis/soft-deleted loop이면 결과에서 드롭(백필 안 함). `loop_artifact`는 삭제 개념이 없어 항상 유지.
- recall 트랩: HNSW가 WHERE 등식필터를 인덱스 레벨에서 못 걷는 구조적 한계 — `SET LOCAL hnsw.ef_search`를 기본(40)보다 높여(100) 완화(테넌트 파티셔닝은 후속 스토리 스코프, `app/models/embedding.py`에 이미 문서화된 트레이드오프).
- embed 실패(인증불가 등)는 검색=사용자 대기 요청이라 cron과 달리 즉시 503으로 드러남(조용히 빈 결과로 오인시키지 않음).
- 마이그 없음.

## Test plan
- [x] mock-session 단위 테스트 4건(orphan hypothesis/loop 필터링·loop_artifact 항상 유지·빈 배치) — `tests/test_e_loop_ledger_p1_s6_context_pack_search.py`
- [x] realdb 테스트 3건(cosine 순서+orphan 정리 round-trip·IDOR cross-project 403/same-project 통과·embed 실패 503) — `tests/test_e_loop_ledger_p1_s6_context_pack_search_realdb.py`, `tests/test_e_loop_ledger_p1_s6_context_pack_search_idor_realdb.py`
- [x] `alembic upgrade head`(throwaway pgvector/pgvector:pg16) — 0151에서 무변경 도달(신규 마이그 없음 확인)
- [x] `create_all`/`drop_all` fresh-runnable round-trip(별도 컨테이너)
- [x] 전체 pytest suite — baseline 대비 diff 확인. 신규 2건(내 realdb 테스트 1건 + 무관 테스트 1건)은 이미 확인된 pre-existing 사전이슈 2종(`DependentObjectsStillExistError: team_members view↔agent_project_profiles table` / asyncpg "attached to a different loop")과 동일 시그니처 — 격리 실행 시 전부 pass, 이 브랜치의 회귀 아님(P1-S2/P1-S3 PR에서도 동일 클래스 확인·문서화됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)