### PR TITLE
feat(e-loop-ledger): P1-S5 — 기존 데이터 embeddings 1회 backfill

### DIFF
--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -494,6 +494,31 @@ async def embed_backlog_cron(
         return _err("INTERNAL_ERROR", "Internal server error", 500)
 
 
+# ─── POST /api/v2/internal/cron/embed-backfill ─────────────────────────────────
+
+@router.post("/embed-backfill")
+async def embed_backfill_cron(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """E-LOOP-LEDGER P1-S5: 기존 hypothesis/loop/loop_artifact 전체를 embeddings status='pending'으로
+    1회 backfill(블루프린트 §P1). 네트워크 I/O 0(enqueue_embedding=INSERT/UPSERT만) — 실제 임베딩은
+    P1-S3(embed-backlog) cron이 후속 처리. content_hash 멱등이라 재실행해도 안전(순수 1회성 아님,
+    안전하게 재트리거 가능). 신규 마이그 0 — 순수 스크립트로 gcloud/migrate 잡과 무관.
+    """
+    verify_cron(request)
+
+    from app.services.embedding_backfill import backfill_embeddings
+
+    try:
+        counts = await backfill_embeddings(session)
+        await session.commit()
+        return _ok(counts)
+    except Exception as exc:
+        logger.exception("embed-backfill cron error: %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)
+
+
 # ─── S8: storage capacity lifecycle crons ─────────────────────────────────────
 
 _ASSET_GRACE_DAYS = 7

--- a/backend/app/services/embedding_backfill.py
+++ b/backend/app/services/embedding_backfill.py
@@ -1,0 +1,71 @@
+"""E-LOOP-LEDGER P1-S5: 기존 hypothesis/loop/loop_artifact 전체 1회 backfill(블루프린트 §P1).
+
+P1-S4의 enqueue_embedding(content_hash 멱등)을 그대로 재사용 — 신규 로직은 "전체 스캔" 뿐이다.
+재실행해도 안전(같은 텍스트는 no-op) — 순수 1회성이 아니라 언제든 다시 돌려도 되는 멱등 연산.
+
+archived hypothesis/soft-deleted loop 및 그 소속 artifact는 스캔 대상에서 제외한다 — S6(검색)가
+어차피 orphan 필터링으로 이들을 결과에서 드롭하므로, backfill 시점에 임베딩해봤자 검색에 노출될
+일이 없는 유료 API 비용 낭비다(cron이 나중에 이 pending row를 embed할 때 비용 발생 — 애초에
+큐잉을 안 하는 게 맞다).
+
+loop_artifact는 project_id 컬럼이 없어(loop_runs를 통해서만 project 소속) JOIN으로 해소한다.
+"""
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.hypothesis import Hypothesis
+from app.models.loop import LoopArtifact, LoopRun
+
+
+async def backfill_embeddings(session: AsyncSession) -> dict[str, int]:
+    from app.services.embedding_enqueue import (
+        build_hypothesis_embedding_text,
+        build_loop_artifact_embedding_text,
+        build_loop_embedding_text,
+        enqueue_embedding,
+    )
+
+    counts = {"hypothesis": 0, "loop": 0, "loop_artifact": 0}
+
+    hyps = (await session.execute(
+        select(Hypothesis).where(Hypothesis.status != "archived")
+    )).scalars().all()
+    for h in hyps:
+        await enqueue_embedding(
+            session, h.org_id, h.project_id, "hypothesis", h.id,
+            build_hypothesis_embedding_text(h.statement),
+            created_by_member_id=h.owner_member_id,
+        )
+        counts["hypothesis"] += 1
+
+    loops = (await session.execute(
+        select(LoopRun).where(LoopRun.deleted_at.is_(None))
+    )).scalars().all()
+    for lp in loops:
+        await enqueue_embedding(
+            session, lp.org_id, lp.project_id, "loop", lp.id,
+            build_loop_embedding_text(lp.title, lp.goal_tags),
+            created_by_member_id=lp.created_by_member_id,
+        )
+        counts["loop"] += 1
+
+    artifacts = (await session.execute(
+        select(LoopArtifact, LoopRun.project_id)
+        .join(LoopRun, LoopArtifact.loop_id == LoopRun.id)
+        .where(LoopRun.deleted_at.is_(None))
+    )).all()
+    for artifact, project_id in artifacts:
+        # 배선(P1-S4)과 동일 규칙: 결정 상태에 맞는 이유만 텍스트에 포함(chosen→choose_reason,
+        # rejected→rejection_reason, pending→둘 다 None).
+        choose_reason = artifact.choose_reason if artifact.decision == "chosen" else None
+        rejection_reason = artifact.rejection_reason if artifact.decision == "rejected" else None
+        await enqueue_embedding(
+            session, artifact.org_id, project_id, "loop_artifact", artifact.id,
+            build_loop_artifact_embedding_text(artifact.variant_label, choose_reason, rejection_reason),
+            created_by_member_id=artifact.created_by_member_id,
+        )
+        counts["loop_artifact"] += 1
+
+    return counts

--- a/backend/tests/test_e_loop_ledger_p1_s5_embedding_backfill.py
+++ b/backend/tests/test_e_loop_ledger_p1_s5_embedding_backfill.py
@@ -1,0 +1,115 @@
+"""E-LOOP-LEDGER P1-S5: embedding backfill 서비스 단위 테스트(mock session, 블루프린트 §P1).
+
+핵심 불변식: archived hypothesis/soft-deleted loop/그 소속 artifact는 스캔 대상에서 제외(orphan
+낭비 방지) — enqueue_embedding은 P1-S4에서 이미 검증됐으므로 여기선 patch해 "무엇을 몇 번 어떤
+인자로 호출했는지"만 검증한다. loop_artifact는 decision 상태에 맞는 이유만 텍스트에 반영.
+"""
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import embedding_backfill as backfill
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _hyp(status="active"):
+    return SimpleNamespace(
+        id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(),
+        owner_member_id=uuid.uuid4(), statement="가설 문장", status=status,
+    )
+
+
+def _loop():
+    return SimpleNamespace(
+        id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(),
+        created_by_member_id=uuid.uuid4(), title="루프 제목", goal_tags=["tag1"],
+    )
+
+
+def _artifact(decision="pending", choose_reason=None, rejection_reason=None):
+    return SimpleNamespace(
+        id=uuid.uuid4(), org_id=uuid.uuid4(), created_by_member_id=uuid.uuid4(),
+        variant_label="variant A", decision=decision,
+        choose_reason=choose_reason, rejection_reason=rejection_reason,
+    )
+
+
+def _scalars_result(items):
+    r = MagicMock()
+    r.scalars.return_value.all.return_value = items
+    return r
+
+
+def _rows_result(pairs):
+    r = MagicMock()
+    r.all.return_value = pairs
+    return r
+
+
+async def test_only_rows_returned_by_query_are_enqueued():
+    """세션이 반환한 항목만 enqueue 대상(카운트/인자 매핑 검증) — archived/soft-deleted가 실제로
+    SELECT WHERE에서 걸러지는지는 mock으론 증명 불가(쿼리를 실행 안 함) → realdb 테스트 스코프."""
+    hyp = _hyp(status="active")
+    lp = _loop()
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[
+        _scalars_result([hyp]), _scalars_result([lp]), _rows_result([]),
+    ])
+    with patch("app.services.embedding_enqueue.enqueue_embedding", new=AsyncMock()) as mock_enqueue:
+        counts = await backfill.backfill_embeddings(session)
+    assert counts == {"hypothesis": 1, "loop": 1, "loop_artifact": 0}
+    assert mock_enqueue.await_count == 2
+    hyp_call = mock_enqueue.await_args_list[0]
+    assert hyp_call.args[3] == "hypothesis" and hyp_call.args[4] == hyp.id
+
+
+async def test_loop_artifact_project_id_resolved_via_loop_join():
+    artifact = _artifact(decision="chosen", choose_reason="가장 좋은 이유")
+    project_id = uuid.uuid4()
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[
+        _scalars_result([]), _scalars_result([]), _rows_result([(artifact, project_id)]),
+    ])
+    with patch("app.services.embedding_enqueue.enqueue_embedding", new=AsyncMock()) as mock_enqueue:
+        counts = await backfill.backfill_embeddings(session)
+    assert counts["loop_artifact"] == 1
+    call = mock_enqueue.await_args_list[0]
+    assert call.args[1] == artifact.org_id
+    assert call.args[2] == project_id  # loop_runs JOIN으로 해소된 project_id.
+
+
+async def test_artifact_decision_state_gates_which_reason_included():
+    chosen = _artifact(decision="chosen", choose_reason="chosen text", rejection_reason="stale")
+    rejected = _artifact(decision="rejected", choose_reason="stale", rejection_reason="rejected text")
+    pending = _artifact(decision="pending", choose_reason="stale", rejection_reason="stale")
+    pid = uuid.uuid4()
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[
+        _scalars_result([]), _scalars_result([]),
+        _rows_result([(chosen, pid), (rejected, pid), (pending, pid)]),
+    ])
+    captured_texts = []
+    with patch(
+        "app.services.embedding_enqueue.build_loop_artifact_embedding_text",
+        side_effect=lambda label, cr, rr: captured_texts.append((cr, rr)) or "t",
+    ):
+        with patch("app.services.embedding_enqueue.enqueue_embedding", new=AsyncMock()):
+            await backfill.backfill_embeddings(session)
+    assert captured_texts[0] == ("chosen text", None)   # chosen: choose_reason만.
+    assert captured_texts[1] == (None, "rejected text")  # rejected: rejection_reason만.
+    assert captured_texts[2] == (None, None)             # pending: 둘 다 None.
+
+
+async def test_empty_scan_returns_zero_counts():
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[
+        _scalars_result([]), _scalars_result([]), _rows_result([]),
+    ])
+    counts = await backfill.backfill_embeddings(session)
+    assert counts == {"hypothesis": 0, "loop": 0, "loop_artifact": 0}

--- a/backend/tests/test_e_loop_ledger_p1_s5_embedding_backfill_realdb.py
+++ b/backend/tests/test_e_loop_ledger_p1_s5_embedding_backfill_realdb.py
@@ -1,0 +1,115 @@
+"""E-LOOP-LEDGER P1-S5: embedding backfill 실 Postgres 검증(블루프린트 §P1).
+
+핵심: archived hypothesis/soft-deleted loop/그 소속 artifact가 실제 SQL WHERE로 걸러지는지·
+loop_artifact의 project_id가 loop_runs JOIN으로 정확히 해소되는지·재실행이 멱등(content_hash
+불변 시 no-op, 중복 row 0)한지를 실 DB round-trip으로 직접 검증.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_backfill_excludes_archived_and_deleted_resolves_project_id_real_db():
+    from sqlalchemy import text as _text, select
+    from app.core.database import Base
+    from app.models.embedding import Embedding
+    from app.models.hypothesis import Hypothesis
+    from app.models.loop import LoopArtifact, LoopRun
+    from app.services.embedding_backfill import backfill_embeddings
+
+    engine, Session = await _session()
+    org, project = uuid.uuid4(), uuid.uuid4()
+    hyp_active, hyp_archived = uuid.uuid4(), uuid.uuid4()
+    loop_alive, loop_deleted = uuid.uuid4(), uuid.uuid4()
+    asset_alive, asset_deleted_parent = uuid.uuid4(), uuid.uuid4()
+    artifact_alive, artifact_orphaned = uuid.uuid4(), uuid.uuid4()
+
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add_all([
+                Hypothesis(
+                    id=hyp_active, org_id=org, project_id=project, owner_member_id=uuid.uuid4(),
+                    statement="살아있는 가설",
+                    metric_definition={"metric": "x", "source": "manual", "target": 1, "direction": "up"},
+                    measure_after=datetime.now(timezone.utc), status="active",
+                ),
+                Hypothesis(
+                    id=hyp_archived, org_id=org, project_id=project, owner_member_id=uuid.uuid4(),
+                    statement="보관된 가설",
+                    metric_definition={"metric": "x", "source": "manual", "target": 1, "direction": "up"},
+                    measure_after=datetime.now(timezone.utc), status="archived",
+                ),
+                LoopRun(id=loop_alive, org_id=org, project_id=project, title="살아있는 loop",
+                        created_by_member_id=uuid.uuid4()),
+                LoopRun(id=loop_deleted, org_id=org, project_id=project, title="삭제된 loop",
+                        created_by_member_id=uuid.uuid4(), deleted_at=datetime.now(timezone.utc)),
+                LoopArtifact(id=artifact_alive, org_id=org, loop_id=loop_alive, asset_id=asset_alive,
+                             variant_group="g1", variant_label="A", created_by_member_id=uuid.uuid4()),
+                LoopArtifact(id=artifact_orphaned, org_id=org, loop_id=loop_deleted, asset_id=asset_deleted_parent,
+                             variant_group="g1", variant_label="B", created_by_member_id=uuid.uuid4()),
+            ])
+            await s.commit()
+
+        async with Session() as s:
+            counts = await backfill_embeddings(s)
+            await s.commit()
+        assert counts == {"hypothesis": 1, "loop": 1, "loop_artifact": 1}
+
+        async with Session() as s:
+            embedded_entity_ids = set((await s.execute(select(Embedding.entity_id))).scalars().all())
+
+        assert hyp_active in embedded_entity_ids
+        assert hyp_archived not in embedded_entity_ids
+        assert loop_alive in embedded_entity_ids
+        assert loop_deleted not in embedded_entity_ids
+        assert artifact_alive in embedded_entity_ids
+        assert artifact_orphaned not in embedded_entity_ids  # soft-deleted loop 소속 → 스킵.
+
+        async with Session() as s:
+            artifact_emb = (await s.execute(
+                select(Embedding).where(Embedding.entity_id == artifact_alive)
+            )).scalar_one()
+            assert artifact_emb.project_id == project  # loop_runs JOIN으로 해소.
+            assert artifact_emb.status == "pending"
+
+        # 멱등 재실행: 동일 entity에 대해 row 중복 생성 안 됨(uq_embeddings_entity 위반 없이 no-op).
+        async with Session() as s:
+            counts2 = await backfill_embeddings(s)
+            await s.commit()
+        assert counts2 == {"hypothesis": 1, "loop": 1, "loop_artifact": 1}  # 스캔 대상 수는 동일.
+        async with Session() as s:
+            total = (await s.execute(select(Embedding))).scalars().all()
+            assert len(total) == 3  # 재실행해도 row 수는 그대로(UPSERT, 중복 INSERT 0).
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- E-LOOP-LEDGER P1-S5(story `1b7bc09b`) — `POST /api/v2/internal/cron/embed-backfill`. 기존 hypothesis/loop/loop_artifact 전체를 `embeddings status='pending'`으로 일괄 큐잉(cron이 후속 처리).
- P1-S4의 `enqueue_embedding`(content_hash 멱등)을 그대로 재사용 — 신규 로직은 "전체 스캔"뿐. 재실행해도 안전(같은 텍스트는 no-op) — 순수 1회성이 아니라 언제든 재트리거 가능한 멱등 연산.
- internal cron 인프라(`verify_cron`)만 재사용해 신규 인증/마이그 0 — "마이그면 gcloud 코디/스크립트면 무관" 선택지 중 스크립트 경로.
- archived hypothesis/soft-deleted loop 및 그 소속 artifact는 스캔 대상에서 제외 — S6(검색)가 orphan 필터링으로 이들을 어차피 결과에서 드롭하므로, backfill 시점에 임베딩해봤자 검색에 노출될 일 없는 유료 API 비용 낭비.
- `loop_artifact`는 `project_id` 컬럼이 없어(`loop_runs`를 통해서만 project 소속) JOIN으로 해소. artifact 텍스트는 `decision` 상태에 맞는 이유만 포함(chosen→choose_reason, rejected→rejection_reason, pending→둘 다 None) — P1-S4 write-path 배선과 동일 규칙.
- 마이그 없음.

## Test plan
- [x] mock-session 단위 테스트 4건(스캔 결과 매핑·project_id JOIN 해소·decision별 텍스트·빈 스캔) — `tests/test_e_loop_ledger_p1_s5_embedding_backfill.py`
- [x] realdb 테스트 1건(archived/soft-deleted 실 WHERE 배제·project_id JOIN round-trip·재실행 멱등 검증) — `tests/test_e_loop_ledger_p1_s5_embedding_backfill_realdb.py`
- [x] `alembic upgrade head`(throwaway pgvector/pgvector:pg16) — 0151에서 무변경 도달(신규 마이그 없음 확인)
- [x] `create_all`/`drop_all` fresh-runnable round-trip(별도 컨테이너)
- [x] 전체 pytest suite — baseline 대비 diff 확인. 신규 4건(P1-S3 realdb 3건 + 내 신규 realdb 1건)은 이미 확인된 pre-existing 사전이슈(`DependentObjectsStillExistError: team_members view↔agent_project_profiles table`)와 동일 시그니처 — 격리 실행 시 5/5 pass, 이 브랜치의 회귀 아님(P1-S2/S3/S6 PR에서도 동일 클래스 확인·문서화됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)