### PR TITLE
fix(e-loop-ledger): P1-S3g — score_hypotheses 배치 SAVEPOINT 격리

### DIFF
--- a/backend/app/services/hypothesis_scorer.py
+++ b/backend/app/services/hypothesis_scorer.py
@@ -13,6 +13,18 @@ measure_after가 도래한 가설을 채점한다. legacy outcome_scorer(sprint/
     source='ga4'          → score_ga4_outcome (GA4 Data API)
     source='internal_ops' (metric=completion_pct) → 링크된 스토리 완료율 → score_epic_outcome
     그 외(manual 등)       → 자동 채점 안 함(§10.4), measuring 유지.
+
+🔴P1-S3g fix(2026-07-02, story 7ca1c953): internal_ops 브랜치의 _linked_story_completion_pct가
+실 DB 쿼리(Story JOIN)를 한다 — 이 쿼리가 실 Postgres 에러(UndefinedTable/타임아웃 등)로
+트랜잭션을 server-level aborted 시키면, 종전엔 except가 Python 예외만 잡고 같은 세션으로
+루프를 continue해 이후 batch의 모든 쿼리(다른 hypothesis의 record_outcome_verdicts/
+attribute_loop_outcome 포함)가 연쇄 실패하고 cron route의 session.commit()이 조용히
+ROLLBACK되어 이미 처리된 다른 hypothesis들의 진행(active→measuring 등)까지 통째 유실될 수
+있었다(P1-S7 까심 QA CRITICAL에서 발견된 것과 동일 클래스 — [[feedback_savepoint_failopen_
+session_poison]] 참고). score_ga4_outcome/score_epic_outcome(+_linked_story_completion_pct)를
+session.begin_nested()(SAVEPOINT)로 격리해, 한 hypothesis의 DB abort가 그 SAVEPOINT만
+롤백시키고 batch 내 다른 hypothesis 진행과 outer commit은 오염시키지 않게 한다. GA4 브랜치는
+순수 HTTP(fetch_ga4_metric)라 애초에 이 위험이 없음(무관).
 """
 from __future__ import annotations
 
@@ -88,15 +100,18 @@ async def score_hypotheses(session: AsyncSession) -> dict[str, Any]:
         md = hyp.metric_definition or {}
         source = md.get("source")
         try:
-            if source == "ga4":
-                scoring = score_ga4_outcome(md)
-            elif source == "internal_ops":
-                pct = await _linked_story_completion_pct(session, hyp.id)
-                result = score_epic_outcome(md, pct)
-                scoring = result if result is not None else {"outcome_status": "pending", "outcome_result": None}
-            else:
-                # manual·미지원 source → 자동 채점 금지(거짓 신호 차단). measuring 유지.
-                scoring = {"outcome_status": "pending", "outcome_result": None}
+            async with session.begin_nested():  # SAVEPOINT — internal_ops의 실 DB 쿼리가 실
+                # Postgres 에러를 내도 이 hypothesis 처리만 롤백되고 batch 나머지(이미 flush된
+                # active→measuring 등)는 오염되지 않는다. except는 이 async with 밖에서 잡는다.
+                if source == "ga4":
+                    scoring = score_ga4_outcome(md)
+                elif source == "internal_ops":
+                    pct = await _linked_story_completion_pct(session, hyp.id)
+                    result = score_epic_outcome(md, pct)
+                    scoring = result if result is not None else {"outcome_status": "pending", "outcome_result": None}
+                else:
+                    # manual·미지원 source → 자동 채점 금지(거짓 신호 차단). measuring 유지.
+                    scoring = {"outcome_status": "pending", "outcome_result": None}
         except Exception as exc:  # GA4 회수 등 실패 → measuring 유지(위장 금지)
             logger.warning("hypothesis scoring failed id=%s: %s", hyp.id, exc)
             failed.append({"id": str(hyp.id), "error": str(exc)})

--- a/backend/tests/test_e_loop_ledger_p1_s3g_score_hypotheses_savepoint_realdb.py
+++ b/backend/tests/test_e_loop_ledger_p1_s3g_score_hypotheses_savepoint_realdb.py
@@ -1,0 +1,94 @@
+"""E-LOOP-LEDGER P1-S3g: score_hypotheses 배치 SAVEPOINT 격리 실 Postgres 검증(story 7ca1c953).
+
+핵심: internal_ops 브랜치(_linked_story_completion_pct)가 실 Postgres 에러(UndefinedTable)로
+트랜잭션을 server-level aborted 시켜도, SAVEPOINT 격리 덕에 같은 batch의 다른 hypothesis(GA4
+브랜치, DB 무관) 진행이 실제로 persist되는지 비-tautological로 검증한다(P1-S7 까심 QA CRITICAL과
+동일 클래스 landmine — mock RuntimeError는 이 시나리오를 재현 못 함).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _real_db_error_completion_pct(session, hypothesis_id):
+    from sqlalchemy import text as _text
+    await session.execute(_text("SELECT * FROM this_table_definitely_does_not_exist_xyz"))
+    return 0.0  # 위에서 반드시 예외 — 도달 안 함.
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_real_db_error_in_one_hypothesis_does_not_lose_batch_mates_progress_real_db():
+    """🔴P1-S7과 동일 클래스 landmine 회귀 — h_bad(internal_ops)의 실 DB abort가 h_good(ga4)의
+    verified 전이 persist를 절대 막지 않아야 한다(SAVEPOINT 없었다면 session.commit()이 조용히
+    ROLLBACK되어 h_good 진행까지 함께 유실됐을 시나리오)."""
+    from sqlalchemy import text as _text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    from app.models.hypothesis import Hypothesis
+    from app.services.hypothesis_scorer import score_hypotheses
+
+    url = _REAL_DB_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+        "postgresql://", "postgresql+asyncpg://"
+    )
+    engine = create_async_engine(url)
+    org, project, owner = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    due = datetime.now(timezone.utc) - timedelta(hours=1)
+    h_good, h_bad = uuid.uuid4(), uuid.uuid4()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+
+    def _hyp(hid, source):
+        return Hypothesis(
+            id=hid, org_id=org, project_id=project, owner_member_id=owner,
+            statement="가설", metric_definition={"metric": "x", "source": source, "target": 10, "direction": "up"},
+            measure_after=due, status="active",
+        )
+
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add_all([_hyp(h_good, "ga4"), _hyp(h_bad, "internal_ops")])
+            await s.commit()
+
+        async with Session() as s:
+            with patch(
+                "app.services.hypothesis_scorer.score_ga4_outcome",
+                return_value={"outcome_status": "hit", "outcome_result": {"actual": 1}},
+            ):
+                with patch(
+                    "app.services.hypothesis_scorer._linked_story_completion_pct",
+                    new=_real_db_error_completion_pct,
+                ):
+                    summary = await score_hypotheses(s)
+            await s.commit()  # ⭐SAVEPOINT 없었다면 이 commit이 조용히 ROLLBACK됐을 지점.
+
+        assert str(h_bad) in [f["id"] for f in summary["failed"]]
+        assert str(h_good) in summary["verified"]
+
+        async with Session() as s:
+            statuses = dict((await s.execute(
+                _text("SELECT id::text, status FROM hypotheses WHERE org_id=:o"), {"o": org}
+            )).all())
+        # ⭐핵심 단정: h_bad의 DB abort에도 h_good의 verified 전이가 실제 DB에 persist돼야 한다.
+        assert statuses[str(h_good)] == "verified"
+        assert statuses[str(h_bad)] == "measuring"  # active→measuring까지는 성공(scoring만 실패).
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()

--- a/backend/tests/test_ho_s4_scorer_verdict_wiring.py
+++ b/backend/tests/test_ho_s4_scorer_verdict_wiring.py
@@ -30,6 +30,17 @@ def _hyp(status="active", source="ga4"):
     )
 
 
+def _mock_session():
+    """P1-S3g: session.begin_nested()가 진짜 async context manager처럼 동작해야(SAVEPOINT 구조
+    재현) — plain AsyncMock()은 __aenter__/__aexit__을 자동 지원하지 않는다."""
+    session = AsyncMock()
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=None)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    session.begin_nested = MagicMock(return_value=cm)
+    return session
+
+
 # ── AC①②④: 해소 시 배선 호출·response 노출·manual 미호출 ─────────────────────
 
 @pytest.mark.anyio
@@ -37,7 +48,7 @@ async def test_resolved_calls_wiring_manual_does_not():
     verified_hyp = _hyp("active", "ga4")     # ga4 hit → verified → 배선 호출.
     manual_hyp = _hyp("measuring", "manual")  # manual → pending → 배선 미호출(AC④).
 
-    session = AsyncMock()
+    session = _mock_session()
     res = MagicMock()
     res.scalars.return_value.all.return_value = [verified_hyp, manual_hyp]
     session.execute = AsyncMock(return_value=res)
@@ -63,7 +74,7 @@ async def test_resolved_calls_wiring_manual_does_not():
 @pytest.mark.anyio
 async def test_skipped_wiring_goes_to_verdicts_skipped():
     h = _hyp("active", "ga4")
-    session = AsyncMock()
+    session = _mock_session()
     res = MagicMock()
     res.scalars.return_value.all.return_value = [h]
     session.execute = AsyncMock(return_value=res)

--- a/backend/tests/test_hypothesis_scorer.py
+++ b/backend/tests/test_hypothesis_scorer.py
@@ -60,6 +60,12 @@ def _session(execute_results):
     s = AsyncMock()
     s.execute = AsyncMock(side_effect=execute_results)
     s.commit = AsyncMock()
+    # P1-S3g: session.begin_nested()가 진짜 async context manager처럼 동작해야(SAVEPOINT 구조
+    # 재현) — plain AsyncMock()은 __aenter__/__aexit__을 자동 지원하지 않는다.
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=None)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    s.begin_nested = MagicMock(return_value=cm)
     return s
 
 


### PR DESCRIPTION
## Summary
- E-LOOP-LEDGER P1-S3g(story `7ca1c953`, high priority bugfix) — P1-S7 까심 QA CRITICAL 감사 중 발견된 동일 클래스 pre-existing landmine 회수.
- `score_hypotheses`의 `internal_ops` 브랜치(`_linked_story_completion_pct`)가 try/except 안에서 실 DB 쿼리(Story JOIN)를 하고, 실패 시 같은 세션으로 batch loop을 continue한다 — 그 쿼리가 실 Postgres 레벨 abort를 일으키면 이후 세션의 모든 쿼리가 연쇄 실패하고 cron route의 `session.commit()`이 조용히 ROLLBACK되어 이미 처리된 다른 hypothesis들의 진행까지 통째 유실될 수 있었다(hourly cron이라 방치 시 언젠가 터지는 landmine). GA4 브랜치(순수 HTTP)는 애초에 무관.
- fix: `score_ga4_outcome`/`score_epic_outcome`(+`_linked_story_completion_pct`)를 `session.begin_nested()`(SAVEPOINT)로 격리 — P1-S7 fix와 동일 패턴 이식.
- 비-tautological 검증: 실 DB-레벨 에러(UndefinedTable)를 internal_ops hypothesis에 재현하면서 같은 batch의 GA4 hypothesis가 verified로 실제 persist되는지 직접 확인. fix 적용 전 이 신규 테스트가 실제로 (더 심하게) FAIL함을 확인한 후 fix 적용해 GREEN 전환.
- 기존 mock 테스트 2개 파일의 bare `AsyncMock()` 세션도 `session.begin_nested()`를 진짜 async context manager로 mock하도록 수정.
- 마이그 없음.

## Test plan
- [x] 신규 realdb 테스트(비-tautological, 배치 중 한 건 실 DB abort→나머지 persist 확인) — `tests/test_e_loop_ledger_p1_s3g_score_hypotheses_savepoint_realdb.py`
- [x] fix 적용 전 신규 테스트가 실제로 FAIL함을 직접 확인(non-tautological 증명) 후 fix 적용
- [x] 기존 `test_hypothesis_scorer.py`(8건)·`test_ho_s4_scorer_verdict_wiring.py`(2+1건) 전부 통과
- [x] `alembic upgrade head`(throwaway pgvector/pgvector:pg16) — 0151에서 무변경 도달(신규 마이그 없음 확인)
- [x] `create_all`/`drop_all` fresh-runnable round-trip(별도 컨테이너)
- [x] 전체 pytest suite — baseline 대비 diff 확인. 이 브랜치 신규 테스트는 0건 신규실패(전부 clean, 최종 확인 라운드). rotation된 기존 1건은 이미 확인된 pre-existing 사전이슈(`DependentObjectsStillExistError`)와 동일 시그니처

🤖 Generated with [Claude Code](https://claude.com/claude-code)