### PR TITLE
feat(e-loop-ledger): P1-S11 — Context Pack agent dispatch payload 주입

### DIFF
--- a/backend/app/services/agent_dispatch.py
+++ b/backend/app/services/agent_dispatch.py
@@ -155,14 +155,22 @@ async def dispatch_entity_to_assignee(
     member_type = assignee_member.type
 
     # E1-S6 L4: 대표 가설 anchor 주입 (epic/story) — additive.
-    from app.services.hypothesis import format_anchor_line, resolve_dispatch_anchor
+    from app.services.hypothesis import (
+        format_anchor_line,
+        resolve_dispatch_anchor,
+        resolve_dispatch_context_pack,
+    )
     hypothesis_anchor = await resolve_dispatch_anchor(db, org_id, entity_type, entity_id)
+    # E-LOOP-LEDGER P1-S11: Context Pack(S7 markdown brief) 주입 — additive, hypothesis-only 스코프.
+    context_pack = await resolve_dispatch_context_pack(db, org_id, entity_type, entity_id)
 
     # E-EVENT-INJECT S1: connector가 content 없는 이벤트를 드롭하므로 top-level content 부여.
     _detail = (message or description or "").strip()
     content = f"[{entity_type}] {title}" + (f" — {_detail}" if _detail else "")
     if hypothesis_anchor is not None:
         content += "\n" + format_anchor_line(hypothesis_anchor)
+    if context_pack is not None:
+        content += "\n\n" + context_pack
     payload: dict[str, Any] = {
         "entity_type": entity_type,
         "entity_id": str(entity_id),
@@ -171,6 +179,7 @@ async def dispatch_entity_to_assignee(
         "message": message,
         "content": content,
         "hypothesis_anchor": hypothesis_anchor,
+        "context_pack": context_pack,
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
     if trigger_metadata is not None:
@@ -238,6 +247,7 @@ async def dispatch_entity_to_assignee(
         "source_entity_type": entity_type,
         "source_entity_id": entity_id,
         "hypothesis_anchor": hypothesis_anchor,
+        "context_pack": context_pack,
     }
     return response, delivery
 

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -60,6 +60,7 @@ async def deliver_injected_event_webhook(
     source_entity_type: str | None = None,
     source_entity_id: uuid.UUID | None = None,
     hypothesis_anchor: dict | None = None,
+    context_pack: str | None = None,
 ) -> None:
     """1f01c1ad: INJECTABLE 이벤트(dispatched/story_assigned 등)를 수신자 member webhook으로 전달.
 
@@ -111,6 +112,8 @@ async def deliver_injected_event_webhook(
         "source_entity_id": str(source_entity_id) if source_entity_id else None,
         # E1-S6 L4: 대표 가설 anchor(additive·null default — 구 소비자 호환).
         "hypothesis_anchor": hypothesis_anchor,
+        # E-LOOP-LEDGER P1-S11: Context Pack(additive·null default — 구 소비자 호환).
+        "context_pack": context_pack,
     }
 
     seen_urls: set[str] = set()

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -492,3 +492,48 @@ async def resolve_dispatch_anchor(
             )
         return None
     return build_anchor_dict(hyp)
+
+
+async def resolve_dispatch_context_pack(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    entity_type: str,
+    entity_id: uuid.UUID,
+) -> str | None:
+    """E-LOOP-LEDGER P1-S11: dispatch 대상의 Context Pack(S7이 조립한 markdown brief) — 복리
+    조직기억이 에이전트에게 실제로 전달되는 지점(crux GO 2026-07-02).
+
+    entity_type=='hypothesis'만 스코프(hypothesis→loop만 결정론적 직접 경로 — loop은 dispatch
+    entity가 아니고, story/epic은 간접 해소가 필요해 후속 스토리로 분리). 그 hypothesis에 연결된
+    loop 중 최신(created_at desc)·abandoned 제외 1개를 선택 — 여러 loop이 있을 수 있어(1:0..N)
+    결정론적 단일 선택이 필요하다.
+
+    데이터 소스는 선택된 loop의 brief_doc_id(S7이 draft→briefing 전이 시 조립한 Doc)를 그대로
+    재사용한다 — 재검색(embed_client 호출) 안 함. dispatch는 사용자가 응답을 기다리는 요청이
+    아니라(S6 검색과 대비) latency/비용을 새로 들일 이유가 없다. brief_doc_id가 없으면(loop이
+    아직 briefing 전이 전) None(hypothesis_anchor의 null-fallback과 동형 — 재검색으로 억지로
+    채우지 않는다)."""
+    if entity_type != "hypothesis":
+        return None
+
+    from app.models.doc import Doc
+    from app.models.loop import LoopRun
+
+    loop = (await session.execute(
+        select(LoopRun)
+        .where(
+            LoopRun.org_id == org_id,
+            LoopRun.hypothesis_id == entity_id,
+            LoopRun.status != "abandoned",
+            LoopRun.deleted_at.is_(None),
+        )
+        .order_by(LoopRun.created_at.desc())
+        .limit(1)
+    )).scalar_one_or_none()
+    if loop is None or loop.brief_doc_id is None:
+        return None
+
+    doc = (await session.execute(
+        select(Doc).where(Doc.id == loop.brief_doc_id, Doc.org_id == org_id, Doc.deleted_at.is_(None))
+    )).scalar_one_or_none()
+    return doc.content if doc is not None else None

--- a/backend/tests/test_agent_dispatch.py
+++ b/backend/tests/test_agent_dispatch.py
@@ -37,6 +37,7 @@ def _patches():
         patch.object(svc, "dispatch_notification", AsyncMock()),
         patch.object(svc, "wake_agent", MagicMock()),
         patch("app.services.hypothesis.resolve_dispatch_anchor", AsyncMock(return_value=None)),
+        patch("app.services.hypothesis.resolve_dispatch_context_pack", AsyncMock(return_value=None)),
     ]
 
 

--- a/backend/tests/test_e_loop_ledger_p1_s11_dispatch_context_pack.py
+++ b/backend/tests/test_e_loop_ledger_p1_s11_dispatch_context_pack.py
@@ -1,0 +1,223 @@
+"""E-LOOP-LEDGER P1-S11: Context Pack agent dispatch 주입 단위 테스트(mock, 블루프린트 §2).
+
+3개 델리버리 경로(BYO=event.payload passthrough·CC payload dict·CC delivery dict+
+deliver_injected_event_webhook)가 전부 context_pack을 실제로 받는지, brief 없으면 null로
+graceful하게 생략되는지, 기존 dispatch(trigger_metadata 등) 무회귀를 검증한다.
+hypothesis-only 스코프(story/epic/sprint/doc은 즉시 None, DB 쿼리 0)도 확인.
+"""
+from __future__ import annotations
+
+import contextlib
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import agent_dispatch as svc
+from app.services import hypothesis as hyp_svc
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── resolve_dispatch_context_pack: 단위 ────────────────────────────────────
+
+def _loop(status="briefing", brief_doc_id=None, created_at=None):
+    return SimpleNamespace(
+        id=uuid.uuid4(), status=status, brief_doc_id=brief_doc_id,
+        created_at=created_at or datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def _scalar_one_or_none_session(value):
+    s = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = value
+    s.execute = AsyncMock(return_value=result)
+    return s
+
+
+async def test_non_hypothesis_entity_returns_none_without_query():
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    out = await hyp_svc.resolve_dispatch_context_pack(session, uuid.uuid4(), "story", uuid.uuid4())
+    assert out is None
+    session.execute.assert_not_called()
+
+
+async def test_no_linked_loop_returns_none():
+    session = _scalar_one_or_none_session(None)
+    out = await hyp_svc.resolve_dispatch_context_pack(session, uuid.uuid4(), "hypothesis", uuid.uuid4())
+    assert out is None
+
+
+async def test_loop_without_brief_doc_returns_none():
+    loop = _loop(brief_doc_id=None)
+    session = _scalar_one_or_none_session(loop)
+    out = await hyp_svc.resolve_dispatch_context_pack(session, uuid.uuid4(), "hypothesis", uuid.uuid4())
+    assert out is None
+
+
+async def test_loop_with_brief_doc_returns_doc_content():
+    doc_id = uuid.uuid4()
+    loop = _loop(brief_doc_id=doc_id)
+    doc = SimpleNamespace(content="## Context Pack\n\n과거 유사 항목 1건 발견.")
+
+    session = AsyncMock()
+    loop_result = MagicMock()
+    loop_result.scalar_one_or_none.return_value = loop
+    doc_result = MagicMock()
+    doc_result.scalar_one_or_none.return_value = doc
+    session.execute = AsyncMock(side_effect=[loop_result, doc_result])
+
+    out = await hyp_svc.resolve_dispatch_context_pack(session, uuid.uuid4(), "hypothesis", uuid.uuid4())
+    assert out == doc.content
+
+
+# ── dispatch_entity_to_assignee: context_pack payload/delivery/content 주입 ──
+
+def _agent_member():
+    return SimpleNamespace(id=uuid.uuid4(), type="agent")
+
+
+async def _assign_seq(_db, event):
+    event.recipient_seq = 1
+
+
+def _patches(context_pack_value):
+    proj = uuid.uuid4()
+    return [
+        patch.object(svc, "_fetch_entity", AsyncMock(return_value=(uuid.uuid4(), "H", "desc", proj))),
+        patch.object(svc, "resolve_member_identity", AsyncMock(return_value=_agent_member())),
+        patch.object(svc, "assign_recipient_seq", _assign_seq),
+        patch.object(svc, "extract_activities_best_effort", AsyncMock()),
+        patch.object(svc, "dispatch_notification", AsyncMock()),
+        patch.object(svc, "wake_agent", MagicMock()),
+        patch("app.services.hypothesis.resolve_dispatch_anchor", AsyncMock(return_value=None)),
+        patch("app.services.hypothesis.resolve_dispatch_context_pack", AsyncMock(return_value=context_pack_value)),
+    ]
+
+
+def _db_capturing(captured):
+    db = AsyncMock()
+    db.add = lambda ev: captured.__setitem__("event", ev)
+    return db
+
+
+async def test_context_pack_present_appears_in_payload_delivery_and_content():
+    captured: dict = {}
+    db = _db_capturing(captured)
+    cp = "## Context Pack\n\n과거 유사 항목 1건 발견."
+    with contextlib.ExitStack() as stack:
+        for p in _patches(cp):
+            stack.enter_context(p)
+        resp, delivery = await svc.dispatch_entity_to_assignee(
+            db, uuid.uuid4(), "hypothesis", uuid.uuid4(), "msg",
+        )
+    assert captured["event"].payload["context_pack"] == cp
+    assert delivery["context_pack"] == cp
+    assert cp in captured["event"].payload["content"]  # 에이전트가 실제로 읽는 content에도 반영.
+
+
+async def test_context_pack_absent_is_null_not_omitted():
+    captured: dict = {}
+    db = _db_capturing(captured)
+    with contextlib.ExitStack() as stack:
+        for p in _patches(None):
+            stack.enter_context(p)
+        resp, delivery = await svc.dispatch_entity_to_assignee(
+            db, uuid.uuid4(), "hypothesis", uuid.uuid4(), "msg",
+        )
+    # hypothesis_anchor와 동형 — always-present/nullable(생략 아님).
+    assert captured["event"].payload["context_pack"] is None
+    assert delivery["context_pack"] is None
+
+
+async def test_existing_dispatch_behavior_unaffected():
+    """기존 trigger_metadata additive 계약이 context_pack 추가로 안 깨지는지(무회귀)."""
+    captured: dict = {}
+    db = _db_capturing(captured)
+    with contextlib.ExitStack() as stack:
+        for p in _patches(None):
+            stack.enter_context(p)
+        resp, delivery = await svc.dispatch_entity_to_assignee(
+            db, uuid.uuid4(), "hypothesis", uuid.uuid4(), "msg",
+            trigger_metadata={"trigger": "deadline"},
+        )
+    assert resp.dispatched is True
+    assert captured["event"].payload["trigger_metadata"] == {"trigger": "deadline"}
+
+
+# ── deliver_injected_event_webhook: context_pack passthrough ───────────────
+
+async def test_webhook_delivery_passes_through_context_pack():
+    from app.services.conversation_webhook import deliver_injected_event_webhook
+
+    wh = SimpleNamespace(
+        id=uuid.uuid4(), url="https://discord.com/api/webhooks/1/a", secret=None,
+        events=None, member_id=uuid.uuid4(), is_active=True,
+    )
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = [wh]
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=result)
+
+    def _factory():
+        @contextlib.asynccontextmanager
+        async def _cm():
+            yield db
+        return _cm()
+
+    calls = []
+
+    async def _capture(url, secret, payload):
+        calls.append(payload)
+
+    cp = "## Context Pack\n\n과거 유사 항목 1건 발견."
+    with patch("app.core.database.async_session_factory", _factory), \
+         patch("app.services.conversation_webhook._attempt_delivery", new=AsyncMock(side_effect=_capture)):
+        await deliver_injected_event_webhook(
+            org_id=uuid.uuid4(), recipient_id=wh.member_id,
+            content="[hypothesis] H", event_type="dispatched",
+            source_entity_type="hypothesis", source_entity_id=uuid.uuid4(),
+            hypothesis_anchor=None, context_pack=cp,
+        )
+    assert len(calls) == 1
+    assert calls[0]["context_pack"] == cp
+
+
+async def test_webhook_delivery_defaults_context_pack_none_backward_compat():
+    """기존 호출부(context_pack 인자 없이 호출)도 여전히 동작 — 기본값 None."""
+    from app.services.conversation_webhook import deliver_injected_event_webhook
+
+    wh = SimpleNamespace(
+        id=uuid.uuid4(), url="https://discord.com/api/webhooks/1/a", secret=None,
+        events=None, member_id=uuid.uuid4(), is_active=True,
+    )
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = [wh]
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=result)
+
+    def _factory():
+        @contextlib.asynccontextmanager
+        async def _cm():
+            yield db
+        return _cm()
+
+    calls = []
+
+    async def _capture(url, secret, payload):
+        calls.append(payload)
+
+    with patch("app.core.database.async_session_factory", _factory), \
+         patch("app.services.conversation_webhook._attempt_delivery", new=AsyncMock(side_effect=_capture)):
+        await deliver_injected_event_webhook(
+            org_id=uuid.uuid4(), recipient_id=wh.member_id,
+            content="[story] S", event_type="dispatched",
+        )
+    assert calls[0]["context_pack"] is None

--- a/backend/tests/test_e_loop_ledger_p1_s11_dispatch_context_pack_realdb.py
+++ b/backend/tests/test_e_loop_ledger_p1_s11_dispatch_context_pack_realdb.py
@@ -1,0 +1,133 @@
+"""E-LOOP-LEDGER P1-S11: resolve_dispatch_context_pack 실 Postgres 검증(블루프린트 §2).
+
+핵심: hypothesis→loop 1:0..N 관계에서 최신(created_at desc)·non-abandoned 1개만 선택되는지·
+brief_doc_id 없는 loop은 None인지를 실 DB round-trip으로 직접 검증. 순수 wiring(payload/delivery
+dict 조립)은 mock 테스트(test_e_loop_ledger_p1_s11_dispatch_context_pack.py)가 이미 커버 —
+여기선 신규 SQL 쿼리 로직(정렬·필터)만 실 DB로 검증한다(resolve_dispatch_anchor의 실DB 검증이
+별도 스모크로 분리된 것과 동형 관례).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_selects_most_recent_non_abandoned_loop_with_brief_doc_real_db():
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.models.doc import Doc
+    from app.models.hypothesis import Hypothesis
+    from app.models.loop import LoopRun
+    from app.services.hypothesis import resolve_dispatch_context_pack
+
+    engine, Session = await _session()
+    org, project = uuid.uuid4(), uuid.uuid4()
+    hyp_id = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+
+    older_loop_id, newer_loop_id, abandoned_loop_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    older_doc_id, newer_doc_id = uuid.uuid4(), uuid.uuid4()
+
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add_all([
+                Hypothesis(
+                    id=hyp_id, org_id=org, project_id=project, owner_member_id=uuid.uuid4(),
+                    statement="가설", metric_definition={"metric": "x", "source": "manual", "target": 1, "direction": "up"},
+                    measure_after=now, status="active",
+                ),
+                Doc(id=older_doc_id, org_id=org, project_id=project, title="older brief", slug="older-brief",
+                    content="## Context Pack\n\n오래된 브리핑."),
+                Doc(id=newer_doc_id, org_id=org, project_id=project, title="newer brief", slug="newer-brief",
+                    content="## Context Pack\n\n최신 브리핑."),
+            ])
+            await s.flush()
+            s.add_all([
+                LoopRun(id=older_loop_id, org_id=org, project_id=project, hypothesis_id=hyp_id,
+                        title="older loop", created_by_member_id=uuid.uuid4(),
+                        status="briefing", brief_doc_id=older_doc_id,
+                        created_at=now - timedelta(days=2)),
+                LoopRun(id=newer_loop_id, org_id=org, project_id=project, hypothesis_id=hyp_id,
+                        title="newer loop", created_by_member_id=uuid.uuid4(),
+                        status="briefing", brief_doc_id=newer_doc_id,
+                        created_at=now - timedelta(days=1)),
+                # 가장 최신이지만 abandoned → 제외돼야(older brief보다도 늦은데도 안 뽑힘).
+                LoopRun(id=abandoned_loop_id, org_id=org, project_id=project, hypothesis_id=hyp_id,
+                        title="abandoned loop", created_by_member_id=uuid.uuid4(),
+                        status="abandoned", brief_doc_id=older_doc_id, created_at=now),
+            ])
+            await s.commit()
+
+        async with Session() as s:
+            out = await resolve_dispatch_context_pack(s, org, "hypothesis", hyp_id)
+        assert out == "## Context Pack\n\n최신 브리핑."  # newer_loop(non-abandoned 중 최신) 선택.
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_loop_without_brief_doc_id_returns_none_real_db():
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.models.hypothesis import Hypothesis
+    from app.models.loop import LoopRun
+    from app.services.hypothesis import resolve_dispatch_context_pack
+
+    engine, Session = await _session()
+    org, project = uuid.uuid4(), uuid.uuid4()
+    hyp_id = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add_all([
+                Hypothesis(
+                    id=hyp_id, org_id=org, project_id=project, owner_member_id=uuid.uuid4(),
+                    statement="가설", metric_definition={"metric": "x", "source": "manual", "target": 1, "direction": "up"},
+                    measure_after=now, status="active",
+                ),
+                LoopRun(id=uuid.uuid4(), org_id=org, project_id=project, hypothesis_id=hyp_id,
+                        title="draft loop", created_by_member_id=uuid.uuid4(),
+                        status="draft", brief_doc_id=None),
+            ])
+            await s.commit()
+
+        async with Session() as s:
+            out = await resolve_dispatch_context_pack(s, org, "hypothesis", hyp_id)
+        assert out is None
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- E-LOOP-LEDGER P1-S11(블루프린트 §2, crux GO) — hypothesis 담당자에게 dispatch될 때 P1-S7이 조립한 Context Pack(과거 유사 loop/결정/성과 markdown brief)을 payload에 additive로 주입. 복리 조직기억이 에이전트에게 실제로 전달되는 지점.
- `app.services.hypothesis::resolve_dispatch_context_pack` — 기존 `resolve_dispatch_anchor`(hypothesis_anchor) 패턴을 그대로 미러. hypothesis-only 스코프(loop은 dispatch entity가 아니고, hypothesis→loop만 결정론적 직접 경로 — story/epic 간접 해소는 후속 스토리로 분리, PO가 별도 생성).
- 여러 loop이 있을 수 있어(1:0..N) 최신(`created_at desc`)·abandoned 제외 1개만 선택. 선택된 loop의 `brief_doc_id`(S7이 조립한 Doc)를 그대로 재사용(재검색 안 함 — dispatch는 latency/비용 최소화가 맞음). `brief_doc_id` 없으면 None(hypothesis_anchor의 null-fallback과 동형).
- ⭐3개 델리버리 경로 전부 수정: ① `agent_dispatch.py`의 `payload` dict(BYO/SSE는 `event.payload` 그대로 통과돼 자동 커버) ② `delivery` dict(CC 릴레이 파라미터) ③ `conversation_webhook.py::deliver_injected_event_webhook`의 keyword-only 시그니처+내부 payload dict — ②만 고치고 ③을 안 고치면 `TypeError`로 크래시한다. `content` 문자열에도 반영.
- 마이그 없음.

## Test plan
- [x] mock-session 단위 테스트 9건(resolve_dispatch_context_pack 4·dispatch payload/delivery/content 3·webhook passthrough 2) — `tests/test_e_loop_ledger_p1_s11_dispatch_context_pack.py`
- [x] realdb 테스트 2건(최신·non-abandoned 선택+brief_doc_id 없음→None) — `tests/test_e_loop_ledger_p1_s11_dispatch_context_pack_realdb.py`
- [x] 기존 `test_agent_dispatch.py`/`test_hypothesis_dispatch_anchor.py`/`test_event_inject_webhook_1f01c1ad.py`/`test_edg_s7_handoff_relay.py`/`test_l2_trigger_worker.py`/`test_l2_config_observability.py`/`test_l2_e2e_status_changed.py` 등 dispatch 관련 기존 스위트 전부 무회귀 확인(3경로 다 커버)
- [x] `alembic upgrade head`(throwaway pgvector/pgvector:pg16) — 0151에서 무변경 도달(신규 마이그 없음 확인)
- [x] `create_all`/`drop_all` fresh-runnable round-trip(별도 컨테이너)
- [x] 전체 pytest suite — baseline 대비 diff 확인. 이 브랜치 신규 realdb 테스트 2건이 풀스위트에서만 rotation(격리는 clean, 2회 확인) — 이미 여러 PR에서 확인된 pre-existing 사전이슈(`DependentObjectsStillExistError`)와 동일 시그니처, 회귀 아님

🤖 Generated with [Claude Code](https://claude.com/claude-code)