### PR TITLE
feat(e-loop-ledger): S13 — Context Pack UI 패널

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2641,7 +2641,8 @@
     "contextPackViewHypothesis": "View this hypothesis",
     "entityTypeLoop": "loop",
     "entityTypeHypothesis": "hypothesis",
-    "entityTypeDecision": "decision"
+    "entityTypeDecision": "decision",
+    "contextPackDecisionPending": "Not yet decided"
   },
   "sprints": {
     "title": "Sprints",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2626,7 +2626,22 @@
     "outcomeHit": "Hit",
     "outcomeMiss": "Miss",
     "outcomeNoResult": "No measurement result.",
-    "outcomeMetricLine": "{metric}: actual {actual} {dir} target {target}"
+    "outcomeMetricLine": "{metric}: actual {actual} {dir} target {target}",
+    "contextPackTitle": "Learn from past loops",
+    "contextPackSubtitle": "Semantically similar past decisions and outcomes — the past helping the present",
+    "contextPackCount": "{count} similar items",
+    "contextPackEmpty": "No related past loops",
+    "contextPackEmbedUnavailable": "History lookup temporarily unavailable",
+    "contextPackLoading": "Loading related history...",
+    "contextPackSimilarity": "similarity {value}",
+    "contextPackChosenLabel": "Chosen",
+    "contextPackRejectedLabel": "Rejected",
+    "contextPackOutcomeLine": "Outcome: {metric} {actual} {arrow} (target {target})",
+    "contextPackViewLoop": "View this loop",
+    "contextPackViewHypothesis": "View this hypothesis",
+    "entityTypeLoop": "loop",
+    "entityTypeHypothesis": "hypothesis",
+    "entityTypeDecision": "decision"
   },
   "sprints": {
     "title": "Sprints",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2641,7 +2641,8 @@
     "contextPackViewHypothesis": "이 가설 보기",
     "entityTypeLoop": "loop",
     "entityTypeHypothesis": "hypothesis",
-    "entityTypeDecision": "decision"
+    "entityTypeDecision": "decision",
+    "contextPackDecisionPending": "아직 결정 전입니다"
   },
   "sprints": {
     "title": "스프린트",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2626,7 +2626,22 @@
     "outcomeHit": "Hit",
     "outcomeMiss": "Miss",
     "outcomeNoResult": "측정 결과가 없습니다.",
-    "outcomeMetricLine": "{metric}: 실제 {actual} {dir} 목표 {target}"
+    "outcomeMetricLine": "{metric}: 실제 {actual} {dir} 목표 {target}",
+    "contextPackTitle": "과거 loop에서 학습",
+    "contextPackSubtitle": "의미 유사한 지난 실험의 결정과 성과 — 과거가 현재 브리핑을 돕습니다",
+    "contextPackCount": "유사 항목 {count}건",
+    "contextPackEmpty": "관련된 과거 loop가 없습니다",
+    "contextPackEmbedUnavailable": "이력 조회를 일시 생략했습니다",
+    "contextPackLoading": "관련 이력 불러오는 중...",
+    "contextPackSimilarity": "유사도 {value}",
+    "contextPackChosenLabel": "선택",
+    "contextPackRejectedLabel": "반려",
+    "contextPackOutcomeLine": "성과: {metric} {actual} {arrow} (목표 {target})",
+    "contextPackViewLoop": "이 loop 보기",
+    "contextPackViewHypothesis": "이 가설 보기",
+    "entityTypeLoop": "loop",
+    "entityTypeHypothesis": "hypothesis",
+    "entityTypeDecision": "decision"
   },
   "sprints": {
     "title": "스프린트",

--- a/apps/web/src/app/(authenticated)/loops/[id]/loop-detail-client.tsx
+++ b/apps/web/src/app/(authenticated)/loops/[id]/loop-detail-client.tsx
@@ -10,6 +10,7 @@ import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { LoopStatusBadge, type LoopStatus } from '@/components/loops/loop-status-badge';
 import { OutcomeBadge } from '@/components/loops/outcome-badge';
 import { VariantGallery, type VariantGroup } from '@/components/loops/variant-gallery';
+import { ContextPackPanel } from '@/components/loops/context-pack-panel';
 
 /** E-LOOP-LEDGER S7 loop_outcome_attribution.py::attribute_loop_outcome 산출 shape 그대로. */
 interface OutcomeSnapshot {
@@ -244,6 +245,9 @@ export function LoopDetailClient({ loopId }: { loopId: string }) {
           onDecided={() => void fetchAll()}
           outcome={loop.status === 'closed' ? loop.outcome_snapshot : null}
         />
+
+        {/* Context pack — E-LOOP-LEDGER S13: "과거 loop에서 학습" (S12 계약, 브리핑 맥락 부속 섹션) */}
+        <ContextPackPanel loopId={loop.id} />
       </div>
     </>
   );

--- a/apps/web/src/app/api/loops/[id]/context-pack/route.ts
+++ b/apps/web/src/app/api/loops/[id]/context-pack/route.ts
@@ -1,0 +1,10 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// GET /api/loops/[id]/context-pack → FastAPI GET /api/v2/loops/{id}/context-pack (E-LOOP-LEDGER S12).
+// ⚠️ S13 착수 시점(handoff e-loop-ledger-s13-context-pack-handoff §3) 기준 BE 엔드포인트 미착지 —
+// PO-locked 계약 shape(디디 S12 착수용, 목업이 정의)에 맞춰 UI+프록시만 먼저 준비. S12 머지되면
+// 라이브 연결(이 파일은 변경 불필요 — 순수 passthrough).
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await params;
+  return proxyToFastapi(request, `/api/v2/loops/${id}/context-pack`);
+}

--- a/apps/web/src/components/loops/context-pack-panel.tsx
+++ b/apps/web/src/components/loops/context-pack-panel.tsx
@@ -27,7 +27,8 @@ interface ContextPackItem {
   goal: string;
   decision: ContextPackDecision | null;
   outcome: ContextPackOutcome | null;
-  href: string;
+  /** hypothesis entity는 FE에 독립 라우트가 없어 BE가 null 반환(방어) — 링크 생략, broken 링크 대신 정직 null. */
+  href: string | null;
 }
 interface ContextPackResponse {
   items: ContextPackItem[];
@@ -49,9 +50,14 @@ function ContextPackCard({ item }: { item: ContextPackItem }) {
           </div>
           <p className="text-sm font-semibold text-foreground">{item.goal}</p>
         </div>
-        <span className="shrink-0 whitespace-nowrap text-[11px] font-medium text-muted-foreground">
-          {t('contextPackSimilarity', { value: item.similarity.toFixed(2) })}
-        </span>
+        <div className="flex shrink-0 flex-col items-end gap-1">
+          <span className="whitespace-nowrap text-[11px] font-medium text-muted-foreground">
+            {t('contextPackSimilarity', { value: item.similarity.toFixed(2) })}
+          </span>
+          <div className="h-1 w-16 overflow-hidden rounded-full bg-info-tint" aria-hidden>
+            <div className="h-full rounded-full bg-info" style={{ width: `${Math.round(item.similarity * 100)}%` }} />
+          </div>
+        </div>
       </div>
 
       {item.decision ? (
@@ -82,9 +88,11 @@ function ContextPackCard({ item }: { item: ContextPackItem }) {
             })}
           </span>
         ) : <span />}
-        <Link href={item.href} className="shrink-0 font-semibold text-primary hover:underline">
-          {viewLabel} →
-        </Link>
+        {item.href ? (
+          <Link href={item.href} className="shrink-0 font-semibold text-primary hover:underline">
+            {viewLabel} →
+          </Link>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/web/src/components/loops/context-pack-panel.tsx
+++ b/apps/web/src/components/loops/context-pack-panel.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { Brain } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { OutcomeBadge } from '@/components/loops/outcome-badge';
+
+/** E-LOOP-LEDGER S13 — GET /loops/{id}/context-pack 응답 shape(handoff §3, PO-locked). */
+interface ContextPackDecision {
+  chosen: { label: string; reason: string };
+  rejected: { label: string; reason: string }[];
+}
+interface ContextPackOutcome {
+  hypothesis_status: 'verified' | 'falsified';
+  metric: string;
+  actual: number;
+  target: number;
+  direction: 'up' | 'down';
+}
+interface ContextPackItem {
+  entity_type: 'loop' | 'hypothesis' | 'decision';
+  entity_id: string;
+  similarity: number;
+  goal: string;
+  decision: ContextPackDecision | null;
+  outcome: ContextPackOutcome | null;
+  href: string;
+}
+interface ContextPackResponse {
+  items: ContextPackItem[];
+  embed_available: boolean;
+}
+
+function ContextPackCard({ item }: { item: ContextPackItem }) {
+  const t = useTranslations('loops');
+  const entityLabel = t(`entityType${item.entity_type.charAt(0).toUpperCase()}${item.entity_type.slice(1)}` as 'entityTypeLoop');
+  const viewLabel = item.entity_type === 'hypothesis' ? t('contextPackViewHypothesis') : t('contextPackViewLoop');
+
+  return (
+    <div className="space-y-2.5 rounded-xl border border-border bg-card p-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="space-y-1">
+          <div className="flex items-center gap-1.5">
+            <Badge variant="chip" className="text-[9px] uppercase">{entityLabel}</Badge>
+            {item.outcome ? <OutcomeBadge hypothesisStatus={item.outcome.hypothesis_status} className="text-[9px]" /> : null}
+          </div>
+          <p className="text-sm font-semibold text-foreground">{item.goal}</p>
+        </div>
+        <span className="shrink-0 whitespace-nowrap text-[11px] font-medium text-muted-foreground">
+          {t('contextPackSimilarity', { value: item.similarity.toFixed(2) })}
+        </span>
+      </div>
+
+      {item.decision ? (
+        <div className="space-y-1 rounded-lg border border-border bg-muted/30 p-2.5 text-[11.5px]">
+          <div>
+            <Badge variant="success" className="mr-1.5 text-[9px]">{t('contextPackChosenLabel')}</Badge>
+            <span className="font-medium text-foreground">{item.decision.chosen.label}</span>
+            <span className="text-muted-foreground"> — {item.decision.chosen.reason}</span>
+          </div>
+          {item.decision.rejected.map((r, i) => (
+            <div key={i}>
+              <Badge variant="chip" className="mr-1.5 text-[9px]">{t('contextPackRejectedLabel')}</Badge>
+              <span className="font-medium text-foreground">{r.label}</span>
+              <span className="text-muted-foreground"> — {r.reason}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="flex items-center justify-between gap-2 border-t border-border pt-2 text-[11px] text-muted-foreground">
+        {item.outcome ? (
+          <span>
+            {t('contextPackOutcomeLine', {
+              metric: item.outcome.metric,
+              actual: item.outcome.actual,
+              arrow: item.outcome.direction === 'up' ? '↑' : '↓',
+              target: item.outcome.target,
+            })}
+          </span>
+        ) : <span />}
+        <Link href={item.href} className="shrink-0 font-semibold text-primary hover:underline">
+          {viewLabel} →
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * S13 — "과거 loop에서 학습" 패널. loop 상세/brief 뷰 부속 섹션(handoff §1).
+ * S12(GET /loops/{id}/context-pack) 착지 전이라도 계약 shape은 PO-locked(목업이 정의) —
+ * BFF는 이미 준비돼 있어 S12 머지되면 이 컴포넌트는 변경 없이 라이브 연결된다.
+ */
+export function ContextPackPanel({ loopId }: { loopId: string }) {
+  const t = useTranslations('loops');
+  const [data, setData] = useState<ContextPackResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [unavailable, setUnavailable] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setUnavailable(false);
+    void (async () => {
+      try {
+        const res = await fetch(`/api/loops/${loopId}/context-pack`);
+        if (cancelled) return;
+        if (!res.ok) { setUnavailable(true); return; }
+        const json = (await res.json()) as ContextPackResponse;
+        setData(json);
+      } catch {
+        if (!cancelled) setUnavailable(true);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [loopId]);
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-border bg-card">
+      <div className="border-b border-border bg-info-tint/40 px-4 py-3">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-1.5">
+            <Brain className="size-4 text-info" aria-hidden />
+            <span className="text-sm font-bold text-foreground">{t('contextPackTitle')}</span>
+          </div>
+          {!loading && !unavailable && data && data.items.length > 0 ? (
+            <Badge variant="outline">{t('contextPackCount', { count: data.items.length })}</Badge>
+          ) : null}
+        </div>
+        <p className="mt-0.5 text-xs text-muted-foreground">{t('contextPackSubtitle')}</p>
+      </div>
+
+      <div className="space-y-2.5 p-3">
+        {loading ? (
+          <>
+            <Skeleton className="h-20 rounded-xl" />
+            <Skeleton className="h-20 rounded-xl" />
+          </>
+        ) : unavailable || (data && !data.embed_available) ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">{t('contextPackEmbedUnavailable')}</p>
+        ) : !data || data.items.length === 0 ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">{t('contextPackEmpty')}</p>
+        ) : (
+          data.items.map((item) => <ContextPackCard key={`${item.entity_type}-${item.entity_id}`} item={item} />)
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/loops/context-pack-panel.tsx
+++ b/apps/web/src/components/loops/context-pack-panel.tsx
@@ -10,7 +10,9 @@ import { OutcomeBadge } from '@/components/loops/outcome-badge';
 
 /** E-LOOP-LEDGER S13 — GET /loops/{id}/context-pack 응답 shape(handoff §3, PO-locked). */
 interface ContextPackDecision {
-  chosen: { label: string; reason: string };
+  /** S12 Pydantic 실스키마 확인(까심 QA): loop에 chosen 아티팩트가 아직 없으면(결정 진행 중)
+   * decision 객체는 non-null이지만 chosen만 null일 수 있다 — rejected만 있거나 둘 다 빈 경우도 유효. */
+  chosen: { label: string; reason: string } | null;
   rejected: { label: string; reason: string }[];
 }
 interface ContextPackOutcome {
@@ -62,11 +64,15 @@ function ContextPackCard({ item }: { item: ContextPackItem }) {
 
       {item.decision ? (
         <div className="space-y-1 rounded-lg border border-border bg-muted/30 p-2.5 text-[11.5px]">
-          <div>
-            <Badge variant="success" className="mr-1.5 text-[9px]">{t('contextPackChosenLabel')}</Badge>
-            <span className="font-medium text-foreground">{item.decision.chosen.label}</span>
-            <span className="text-muted-foreground"> — {item.decision.chosen.reason}</span>
-          </div>
+          {item.decision.chosen ? (
+            <div>
+              <Badge variant="success" className="mr-1.5 text-[9px]">{t('contextPackChosenLabel')}</Badge>
+              <span className="font-medium text-foreground">{item.decision.chosen.label}</span>
+              <span className="text-muted-foreground"> — {item.decision.chosen.reason}</span>
+            </div>
+          ) : (
+            <p className="italic text-muted-foreground">{t('contextPackDecisionPending')}</p>
+          )}
           {item.decision.rejected.map((r, i) => (
             <div key={i}>
               <Badge variant="chip" className="mr-1.5 text-[9px]">{t('contextPackRejectedLabel')}</Badge>


### PR DESCRIPTION
## Summary
- E-LOOP-LEDGER S13(story `b1f37f82`) — loop 상세에 "과거 loop에서 학습" 부속 섹션. 의미 유사한 과거 loop/hypothesis/decision을 회수해 결정+성과를 보여준다(handoff `e-loop-ledger-s13-context-pack-handoff` §1~§3, 시안 `eloop-s13-context-pack-mockup.png`).
- **⚠️ S12(`GET /loops/{id}/context-pack`) BE 미착지 상태에서 착수** — PO가 목업 §3 shape을 계약으로 confirm(디디 S12가 이 shape에 맞춤)했으므로, UI+BFF 프록시를 계약 shape대로 먼저 완성. S12 머지되면 코드 변경 없이 라이브 연결(순수 passthrough).
- `ContextPackPanel` 신규: entity 타입칩(loop/hypothesis/decision) + `OutcomeBadge`(S9 재사용, soul-lock: miss=info) + goal + 유사도(0~1) + decision recap(선택+이유 / top rejected+이유, loop entity에만·nullable) + 성과 라인(metric/actual/target/방향 화살표) + 원본 링크(entity_type별 라벨 분기).
- 4상태: populated(BE similarity-desc 정렬 신뢰) · 빈 · 임베딩불가(`embed_available:false` 또는 BE 비2xx 응답 실패 — 둘 다 동일 폴백으로 흡수) · 로딩(skeleton).

## Test plan
- [x] `pnpm type-check` — 0 errors
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — 성공(EXIT 0)
- [x] 로컬 isolated docker(pgvector db)에서 실제 BE 검증:
  - [x] S12 엔드포인트 미착지 상태 그대로(현재 프로덕션과 동일) 접속 → "이력 조회를 일시 생략했습니다" 폴백 자연 발생 확인
  - [x] `window.fetch` mock으로 populated 케이스(loop×2[hit/miss]+hypothesis×1, decision recap 있음/없음 혼합) 렌더 확인
  - [x] 빈 상태(`items: []`) — 임베딩불가와 문구 구분 확인
  - [x] 로딩 skeleton 코드 확인(Skeleton 컴포넌트 재사용)
  - [x] 다크모드(populated+empty) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)