### PR TITLE
feat(mcp): E-LOOP-LEDGER P1-S12 — sprintable_get_loop_context 도구

### DIFF
--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -44,6 +44,8 @@ _CORE = "core"  # ping/notifications-check 등 기본 — 항상 허용
 _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     "ping", "sprintable_ping", "sprintable_my_dashboard", "sprintable_check_notifications",
     "sprintable_get_workflow_guide", "sprintable_list_team_members", "sprintable_poll_events",
+    # P1-S12: get_workflow_guide 동형(read-only·에이전트 on-demand pull) — 항상 허용.
+    "sprintable_get_loop_context",
 })
 
 # scope 토큰: 그룹명 외에 read/write(레거시·전체 비파괴 의미), admin/destructive(파괴적 허용)
@@ -250,6 +252,8 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     # hypotheses (E1-S5)
     "sprintable_list_hypotheses", "sprintable_get_hypothesis", "sprintable_create_hypothesis",
     "sprintable_update_hypothesis", "sprintable_link_hypothesis", "sprintable_confirm_hypothesis",
+    # loops (E-LOOP-LEDGER P1-S12)
+    "sprintable_get_loop_context",
 )
 
 # picker 표시 순서(비파괴 먼저). order 필드 힌트 + 배열 순서 둘 다 이 순서.

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -59,6 +59,7 @@ from .tools.hypotheses import (
     confirm_hypothesis, create_hypothesis, get_hypothesis,
     link_hypothesis, list_hypotheses, update_hypothesis,
 )
+from .tools.loops import GetLoopContextInput, get_loop_context
 from .tools.meetings import (
     CreateMeetingInput, ListMeetingsInput, MeetingIdInput, UpdateMeetingInput,
     create_meeting, delete_meeting, get_meeting, list_meetings,
@@ -458,6 +459,9 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_get_workflow_guide",
      "현재 프로젝트 워크플로우 가이드 텍스트 반환 — 에이전트 system prompt 주입용.",
      SprintableInput, get_workflow_guide),
+    ("sprintable_get_loop_context",
+     "loop의 Context Pack(의미 유사한 과거 loop/결정/성과) 조회 — 에이전트 on-demand pull, read-only.",
+     GetLoopContextInput, get_loop_context),
     ("sprintable_lock_files",
      "파일 작업 시작 선언 — 동시 수정 충돌 경고 반환. 작업 완료 후 반드시 unlock_files 호출.",
      LockFilesInput, lock_files),

--- a/backend/sprintable_mcp/tools/loops.py
+++ b/backend/sprintable_mcp/tools/loops.py
@@ -1,0 +1,26 @@
+"""Loop Context Pack MCP 도구 — E-LOOP-LEDGER P1-S12(블루프린트 §2/§P1).
+
+GET /api/v2/loops/{id}/context-pack의 얇은 HTTP 래퍼. read-only·always-allowed(get_workflow_guide
+동형) — 에이전트가 loop 작업 중 "의미 유사한 과거 loop/결정/성과"를 on-demand로 직접 pull하는
+경로(dispatch 시점 주입[P1-S11]과 별개 — 그건 push, 이건 필요할 때 agent가 스스로 조회하는 pull).
+"""
+from __future__ import annotations
+
+from mcp.types import TextContent
+
+from ..api_client import client
+from ..response import err, ok
+from ..schemas import SprintableInput
+
+
+class GetLoopContextInput(SprintableInput):
+    loop_id: str
+
+
+async def get_loop_context(args: GetLoopContextInput) -> list[TextContent]:
+    """loop의 Context Pack(items[]+embed_available) 조회 — structured JSON 그대로 반환."""
+    try:
+        result = await client.get(f"/api/v2/loops/{args.loop_id}/context-pack")
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))

--- a/backend/sprintable_mcp/toolset.py
+++ b/backend/sprintable_mcp/toolset.py
@@ -36,6 +36,12 @@ _CORE = "core"
 
 _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     "ping", "sprintable_ping", "sprintable_my_dashboard", "sprintable_check_notifications",
+    # P1-S12: 백엔드 SSOT(app/services/mcp_toolset.py)와 대조해 기존 드리프트 발견 후 동기화
+    # (get_workflow_guide/list_team_members/poll_events가 vendored 사본에 빠져있었음 — 발견 즉시
+    # 수정, 모두 비파괴 read라 always-allow 안전). sprintable_get_loop_context(P1-S12, 이 스토리
+    # 신규)도 read-only·get_workflow_guide 동형으로 여기 추가.
+    "sprintable_get_workflow_guide", "sprintable_list_team_members", "sprintable_poll_events",
+    "sprintable_get_loop_context",
 })
 
 _LEGACY_SCOPES: frozenset[str] = frozenset({"read", "write"})

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -1,4 +1,4 @@
-"""S3-6: 시스템 콜 계약 검증 — 95개 도구 등록 + 스키마 무결성 (Phase 3 완료)."""
+"""S3-6: 시스템 콜 계약 검증 — 96개 도구 등록 + 스키마 무결성 (Phase 3 완료)."""
 from __future__ import annotations
 
 import os
@@ -73,6 +73,8 @@ EXPECTED_TOOLS = {
     "sprintable_list_webhook_configs", "sprintable_upsert_webhook_config", "sprintable_delete_webhook_config",
     # workflow (1)
     "sprintable_get_workflow_guide",
+    # loops (1) — E-LOOP-LEDGER P1-S12
+    "sprintable_get_loop_context",
     # file locks (2)
     "sprintable_lock_files", "sprintable_unlock_files",
     # smoke
@@ -81,7 +83,7 @@ EXPECTED_TOOLS = {
 
 
 def test_total_tool_count():
-    assert len(_TOOLS) == 95
+    assert len(_TOOLS) == 96
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_mcp_loop_context_e_loop_ledger_p1_s12.py
+++ b/backend/tests/test_mcp_loop_context_e_loop_ledger_p1_s12.py
@@ -1,0 +1,76 @@
+"""E-LOOP-LEDGER P1-S12: sprintable_get_loop_context MCP 도구 테스트(블루프린트 §2/§P1).
+
+GET /loops/{id}/context-pack의 얇은 HTTP 래퍼(get_hypothesis와 동형 패턴) + always-allowed
+등록(get_workflow_guide 동형, SSOT↔vendored 양쪽 일치) 검증.
+"""
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sprintable_mcp.tools import loops as l
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _client(**methods):
+    c = MagicMock()
+    c.project_id = "proj-1"
+    for name, ret in methods.items():
+        setattr(c, name, AsyncMock(return_value=ret))
+    return c
+
+
+async def test_get_loop_context_calls_correct_path_and_returns_data():
+    payload = {"items": [{"entity_type": "loop", "similarity": 0.9}], "embed_available": True}
+    client = _client(get=payload)
+    with patch.object(l, "client", client):
+        out = await l.get_loop_context(l.GetLoopContextInput(loop_id="loop-1"))
+    assert client.get.call_args.args[0] == "/api/v2/loops/loop-1/context-pack"
+    data = json.loads(out[0].text)
+    assert data == payload
+
+
+async def test_get_loop_context_wraps_exception_as_err():
+    client = _client()
+    client.get = AsyncMock(side_effect=RuntimeError("boom"))
+    with patch.object(l, "client", client):
+        out = await l.get_loop_context(l.GetLoopContextInput(loop_id="loop-1"))
+    assert out[0].text == "Error: boom"
+
+
+# ── always-allowed 등록(SSOT+vendored 양쪽) ─────────────────────────────────────
+
+def test_get_loop_context_always_allowed_ssot_and_vendored():
+    from app.services.mcp_toolset import _ALWAYS_ALLOWED as ssot_always
+    from sprintable_mcp.toolset import _ALWAYS_ALLOWED as vendored_always
+    assert "sprintable_get_loop_context" in ssot_always
+    assert "sprintable_get_loop_context" in vendored_always
+
+
+def test_get_loop_context_is_tool_allowed_regardless_of_scope():
+    from app.services.mcp_toolset import is_tool_allowed as ssot_allowed
+    from sprintable_mcp.toolset import is_tool_allowed as vendored_allowed
+    # 어떤 scope를 줘도(심지어 무관한 그룹만) 항상 허용돼야 한다.
+    assert ssot_allowed("sprintable_get_loop_context", ["stories"])
+    assert vendored_allowed("sprintable_get_loop_context", ["stories"])
+    assert ssot_allowed("sprintable_get_loop_context", [])
+    assert vendored_allowed("sprintable_get_loop_context", [])
+
+
+def test_get_loop_context_registered_in_all_tool_names():
+    from app.services.mcp_toolset import ALL_TOOL_NAMES
+    assert "sprintable_get_loop_context" in ALL_TOOL_NAMES
+
+
+def test_vendored_drift_fixed_workflow_guide_team_members_poll_events_also_always_allowed():
+    """P1-S12 발견 즉시 수정 — vendored _ALWAYS_ALLOWED가 SSOT 대비 3건 누락돼있던 드리프트.
+    두 파일이 이 3건+신규 get_loop_context까지 동일해야 한다."""
+    from app.services.mcp_toolset import _ALWAYS_ALLOWED as ssot_always
+    from sprintable_mcp.toolset import _ALWAYS_ALLOWED as vendored_always
+    for tool in ("sprintable_get_workflow_guide", "sprintable_list_team_members", "sprintable_poll_events"):
+        assert tool in ssot_always
+        assert tool in vendored_always


### PR DESCRIPTION
## Summary
- E-LOOP-LEDGER P1-S12 MCP 툴 — `GET /api/v2/loops/{id}/context-pack`의 얇은 HTTP 래퍼(`get_hypothesis`와 동형 패턴). read-only·always-allowed(`get_workflow_guide` 동형) — 에이전트가 loop 작업 중 Context Pack을 on-demand로 직접 pull하는 경로(P1-S11의 dispatch 시점 push 주입과 별개).
- SSOT(`app/services/mcp_toolset.py`)+vendored(`sprintable_mcp/toolset.py`) 양쪽 `_ALWAYS_ALLOWED`에 등록. `ALL_TOOL_NAMES`(카탈로그)에도 추가. 도구 등록 총 95→96(`tests/mcp/test_contract.py` 갱신).
- **발견 즉시 수정**: SSOT↔vendored 대조 중 기존 드리프트 발견 — vendored `_ALWAYS_ALLOWED`에 `get_workflow_guide`/`list_team_members`/`poll_events` 3건이 누락돼있었다(SSOT엔 있음, "드리프트 금지" 명시 의도와 불일치). 독립 MCP 패키지(sprintable-mcp) 사용자에겐 이 3개 도구가 잘못 그룹-스코프 게이팅 당하고 있었을 것 — 모두 비파괴 read라 always-allow 안전, 이번에 동기화.

## Test plan
- [x] mock 테스트 2건(경로/에러 래핑)+양쪽 always-allowed 등록 확인 2건+`ALL_TOOL_NAMES` 등록 확인+드리프트 fix 회귀 1건 — `tests/test_mcp_loop_context_e_loop_ledger_p1_s12.py`
- [x] 기존 MCP 스위트(mcp_phase1/mcp_get_doc/mcp_list_backlog/e_mcp_http_s1/e_mcp_s3_boot_filter/e_mcp_s2_toolset/e_mcp_s4_standalone/mcp_hypotheses/mcp_per_call_project) 전부 무회귀 확인
- [x] `alembic upgrade head`(throwaway pgvector/pgvector:pg16) — 0151에서 무변경 도달(신규 마이그 없음)
- [x] 전체 pytest suite — baseline과 **byte-identical diff**(신규 실패 0건)

🤖 Generated with [Claude Code](https://claude.com/claude-code)