### PR TITLE
feat(e-loop-ledger): S24 BE — LoopArtifact text_content 계약 + 전문 lazy endpoint

### DIFF
--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -358,3 +358,43 @@ async def get_asset(
         raise HTTPException(status_code=404, detail="Asset not found")
     enriched = await _enrich(db, org_id, accessible, [asset])
     return enriched[asset.id]
+
+
+class AssetTextResponse(BaseModel):
+    asset_id: uuid.UUID
+    content_type: str
+    text_content: str
+
+
+@router.get("/assets/{asset_id}/text", response_model=AssetTextResponse)
+async def get_asset_text(
+    asset_id: str,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> AssetTextResponse:
+    """GET /api/v2/assets/{id}/text — S24(doc 8e8725da §3④) 전문 on-demand refetch.
+
+    결정 UX 카드는 LoopArtifactResponse.text_content(4KB cap)만 inline 받는다(N+1 최소화).
+    4KB 초과(text_truncated=true)일 때 "더보기" 클릭 시에만 이 endpoint로 전문을 lazy fetch —
+    list 응답은 가볍게 유지. authz/404 규칙은 get_asset과 동일(_scope_filter 재사용).
+    """
+    try:
+        aid = uuid.UUID(asset_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Asset not found") from None
+    clauses, _accessible = await _scope_filter(db, auth, org_id, None)
+    asset = (await db.execute(
+        select(Asset).where(Asset.id == aid, and_(*clauses))
+    )).scalar_one_or_none()
+    if asset is None:
+        raise HTTPException(status_code=404, detail="Asset not found")
+    if not asset.content_type or not asset.content_type.startswith("text/"):
+        raise HTTPException(status_code=400, detail="Not a text asset")
+
+    from app.services.storage import get_storage_provider
+
+    data = await get_storage_provider().download_object(asset.container, asset.object_path)
+    return AssetTextResponse(
+        asset_id=asset.id, content_type=asset.content_type, text_content=data.decode("utf-8", errors="ignore")
+    )

--- a/backend/app/routers/assets.py
+++ b/backend/app/routers/assets.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
 import uuid
 from datetime import datetime
 from typing import Any, Literal
@@ -28,6 +29,8 @@ from app.models.doc import Doc
 from app.models.pm import Story
 from app.models.team import TeamMember
 from app.services.project_auth import accessible_project_ids_in_org, has_project_access
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v2", tags=["assets"])
 
@@ -394,7 +397,14 @@ async def get_asset_text(
 
     from app.services.storage import get_storage_provider
 
-    data = await get_storage_provider().download_object(asset.container, asset.object_path)
+    # 까심 RC: blob 부재/삭제/일시장애가 여기서 그대로 터지면 FastAPI 500(graceful 위반) —
+    # _resolve_artifact_text(inline 경로)와 동일 정책으로 503+명확 메시지(context_pack.py의
+    # EMBED_UNAVAILABLE 503 관용구와 동형 — storage도 외부 의존성 장애는 503).
+    try:
+        data = await get_storage_provider().download_object(asset.container, asset.object_path)
+    except Exception:
+        logger.warning("asset text 조회 실패 asset=%s", asset.id, exc_info=True)
+        raise HTTPException(status_code=503, detail="자산 내용을 불러올 수 없습니다. 잠시 후 다시 시도하세요.") from None
     return AssetTextResponse(
         asset_id=asset.id, content_type=asset.content_type, text_content=data.decode("utf-8", errors="ignore")
     )

--- a/backend/app/schemas/loop.py
+++ b/backend/app/schemas/loop.py
@@ -71,6 +71,13 @@ class LoopArtifactResponse(BaseModel):
     created_at: datetime
     updated_at: datetime
 
+    # S24: 결정 UX copy 변형 표시(doc 8e8725da §3). asset 파생값 — LoopArtifact ORM에는 없는
+    # 필드라 model_validate(artifact) 後 서비스가 채운다(asset_id로 join). content_type=카드 렌더
+    # 분기 키(image/* 는 기존 경로 불변·text_content=null). text_content 는 text/* 에만 4KB cap.
+    content_type: str | None = None
+    text_content: str | None = None
+    text_truncated: bool = False
+
 
 class LoopArtifactVariantGroup(BaseModel):
     variant_group: str

--- a/backend/app/services/loop.py
+++ b/backend/app/services/loop.py
@@ -33,6 +33,39 @@ from app.services.project_auth import has_project_access
 
 logger = logging.getLogger(__name__)
 
+# S24: 결정 UX copy 변형 inline 계약(doc 8e8725da §3 crux) — 4KB cap. asset은 DB에 text를
+# 들고 있지 않음(GCS blob만·app/models/asset.py에 content 컬럼 없음) → N+1 판단: 결정 UX는
+# variant 수가 작아(few·context-pack ~5) inline GCS read N회가 허용 범위(crux 확정, 큰 N이면
+# GET /assets/{id}/text 같은 lazy 경로로 전환).
+_TEXT_CONTENT_CAP_BYTES = 4096
+
+
+async def _resolve_artifact_text(asset: Asset | None) -> tuple[str | None, bool]:
+    """asset이 text/* 면 (capped 내용, truncated 여부) — 아니면/실패하면 (None, False).
+
+    best-effort: storage 장애가 카드 렌더 전체를 죽이면 안 된다(image 경로와 동일한 관용).
+    utf-8 문자 경계에서 안 잘릴 수 있어 errors='ignore'로 trailing 불완전 바이트만 버림(프리뷰용
+    발췌라 완전성보다 안정성 우선 — 전문은 S24 §3④ on-demand refetch로 별도 확보)."""
+    if asset is None or not asset.content_type or not asset.content_type.startswith("text/"):
+        return None, False
+    try:
+        from app.services.storage import get_storage_provider
+
+        data = await get_storage_provider().download_object(asset.container, asset.object_path)
+    except Exception:
+        logger.warning("artifact text 조회 실패 asset=%s", asset.id, exc_info=True)
+        return None, False
+    truncated = len(data) > _TEXT_CONTENT_CAP_BYTES
+    text = data[:_TEXT_CONTENT_CAP_BYTES].decode("utf-8", errors="ignore")
+    return text, truncated
+
+
+async def _to_artifact_response(artifact: LoopArtifact, asset: Asset | None) -> LoopArtifactResponse:
+    resp = LoopArtifactResponse.model_validate(artifact)
+    resp.content_type = asset.content_type if asset is not None else None
+    resp.text_content, resp.text_truncated = await _resolve_artifact_text(asset)
+    return resp
+
 
 class LoopServiceError(Exception):
     """도메인 오류 — 라우터가 code/message를 HTTPException dict-detail로 매핑한다."""
@@ -193,7 +226,7 @@ async def create_loop_artifact(
         created_by_member_id=caller.id,
     )
 
-    return LoopArtifactResponse.model_validate(artifact)
+    return await _to_artifact_response(artifact, asset)
 
 
 async def list_loop_artifacts(
@@ -201,12 +234,20 @@ async def list_loop_artifacts(
 ) -> list[LoopArtifactVariantGroup]:
     repo = LoopArtifactRepository(session, org_id)
     rows = await repo.list_by_loop(loop_id)
+    asset_ids = {a.asset_id for a in rows}
+    assets_by_id: dict[uuid.UUID, Asset] = {}
+    if asset_ids:
+        assets = (await session.execute(
+            select(Asset).where(Asset.id.in_(asset_ids), Asset.org_id == org_id)
+        )).scalars().all()
+        assets_by_id = {a.id: a for a in assets}
+
     groups: list[LoopArtifactVariantGroup] = []
     for variant_group, items in itertools.groupby(rows, key=lambda a: a.variant_group):
-        groups.append(LoopArtifactVariantGroup(
-            variant_group=variant_group,
-            artifacts=[LoopArtifactResponse.model_validate(a) for a in items],
-        ))
+        artifacts = [
+            await _to_artifact_response(a, assets_by_id.get(a.asset_id)) for a in items
+        ]
+        groups.append(LoopArtifactVariantGroup(variant_group=variant_group, artifacts=artifacts))
     return groups
 
 

--- a/backend/tests/test_e_loop_ledger_s24_artifact_text_content.py
+++ b/backend/tests/test_e_loop_ledger_s24_artifact_text_content.py
@@ -62,9 +62,16 @@ async def test_resolve_artifact_text_none_asset():
 
 @pytest.mark.anyio
 async def test_resolve_artifact_text_image_content_type_skips_storage_read():
-    # content_type=image/* → storage read 자체를 안 함(container/object_path가 가짜라도 에러 안 남).
-    asset = _FakeAsset(uuid.uuid4(), "image/png", "nope", "nope/nope.png")
-    text_content, truncated = await _resolve_artifact_text(asset)
+    """까심 RC(선택·권장) — fake path가 "가드 없어도 우연히 같은 결과"일 수 있어 tautological
+    위험([[feedback_test_isolate_bug_variable]]). spy로 download_object 호출 0회를 직접 assert해
+    가드가 실제로 storage read 자체를 막는지(에러를 삼킨 게 아니라) 비-tautological하게 증명."""
+    from unittest.mock import AsyncMock, patch
+
+    asset = _FakeAsset(uuid.uuid4(), "image/png", "uploads", "some/real/path.png")
+    with patch("app.services.storage.get_storage_provider") as mock_provider:
+        mock_provider.return_value.download_object = AsyncMock(side_effect=AssertionError("should not be called"))
+        text_content, truncated = await _resolve_artifact_text(asset)
+    mock_provider.return_value.download_object.assert_not_called()
     assert text_content is None and truncated is False
 
 
@@ -290,6 +297,30 @@ async def test_get_asset_text_endpoint_success():
             out = await get_asset_text(asset_id=str(asset_id), db=s, auth=_auth(), org_id=ORG)
             assert out.text_content == full
             assert out.content_type == "text/plain"
+    finally:
+        await eng.dispose()
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_get_asset_text_endpoint_missing_blob_graceful_503_not_500():
+    """까심 RC(필수) — DB row는 존재하지만 GCS blob이 없음(head_object 등록 후 blob 삭제/일시장애
+    시나리오). fix 前엔 download_object의 FileNotFoundError가 그대로 터져 FastAPI 500 — fix 後엔
+    503+명확 메시지(크래시 아님). object_path를 write 없이 등록해 실제 부재를 재현(mock 아님)."""
+    from app.routers.assets import get_asset_text
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            asset_id = await _seed_asset(
+                s, PROJ_A, "text/plain", object_path=f"org/{ORG}/never-uploaded-{uuid.uuid4().hex[:8]}.txt"
+            )
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await get_asset_text(asset_id=str(asset_id), db=s, auth=_auth(), org_id=ORG)
+            assert ei.value.status_code == 503
     finally:
         await eng.dispose()
 

--- a/backend/tests/test_e_loop_ledger_s24_artifact_text_content.py
+++ b/backend/tests/test_e_loop_ledger_s24_artifact_text_content.py
@@ -1,0 +1,331 @@
+"""E-LOOP-LEDGER S24(story bf9f6e25·P0-UX·prod-blocking): LoopArtifactResponse.text_content 계약
+(doc 8e8725da §3) — content_type 분기 키 + text/* 4KB-cap inline + image 회귀0 + 전문 lazy endpoint.
+
+비-tautological 핵심:
+ⓐ text/* asset → content_type + text_content(원문 그대로, cap 이내) + text_truncated=False.
+ⓑ 4KB 초과 text → text_content가 정확히 4096바이트로 잘리고 text_truncated=True(진짜 storage
+   read+cap 로직 실행 — mock RuntimeError가 아니라 LocalStorageProvider로 실 파일 write/read).
+ⓒ image/* asset → text_content=None·text_truncated=False·기존 필드(asset_id 등) 불변(회귀0 실증 —
+   S4 기존 테스트의 image asset 시드가 그대로 통과하는 것과 별개로 여기서 명시 검증).
+ⓓ storage read 실패(파일 미존재) → 크래시 없이 (None, False)로 graceful degrade(best-effort).
+ⓔ GET /assets/{id}/text — text 성공/이미지 400/미존재 404.
+
+DB env(ALEMBIC_DATABASE_URL) 없으면 realdb 파트 skip. STORAGE_PROVIDER는 미설정(local 기본) —
+LocalStorageProvider가 STORAGE_LOCAL_ROOT 하위에 실제로 write/read한다(GCS 크레덴셜 불요).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.routers import loops as r
+from app.schemas.loop import LoopArtifactCreate
+from app.services.loop import _resolve_artifact_text
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _local_storage_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path / "storage"))
+    monkeypatch.delenv("STORAGE_PROVIDER", raising=False)  # 명시적으로 local 강제(dev/prod=gcs 오염 방지)
+
+
+# ── 유닛: _resolve_artifact_text (DB 불요) ─────────────────────────────────────
+
+class _FakeAsset:
+    def __init__(self, id, content_type, container, object_path):
+        self.id = id
+        self.content_type = content_type
+        self.container = container
+        self.object_path = object_path
+
+
+@pytest.mark.anyio
+async def test_resolve_artifact_text_none_asset():
+    text_content, truncated = await _resolve_artifact_text(None)
+    assert text_content is None and truncated is False
+
+
+@pytest.mark.anyio
+async def test_resolve_artifact_text_image_content_type_skips_storage_read():
+    # content_type=image/* → storage read 자체를 안 함(container/object_path가 가짜라도 에러 안 남).
+    asset = _FakeAsset(uuid.uuid4(), "image/png", "nope", "nope/nope.png")
+    text_content, truncated = await _resolve_artifact_text(asset)
+    assert text_content is None and truncated is False
+
+
+@pytest.mark.anyio
+async def test_resolve_artifact_text_missing_object_graceful_degrade():
+    # content_type=text/* 지만 실제 파일이 없음 → FileNotFoundError를 삼키고 (None, False).
+    asset = _FakeAsset(uuid.uuid4(), "text/plain", "uploads", "does/not/exist.txt")
+    text_content, truncated = await _resolve_artifact_text(asset)
+    assert text_content is None and truncated is False
+
+
+@pytest.mark.anyio
+async def test_resolve_artifact_text_short_text_full_no_truncation():
+    from app.services.storage import get_storage_provider
+
+    asset = _FakeAsset(uuid.uuid4(), "text/plain", "uploads", f"t-{uuid.uuid4().hex}.txt")
+    body = "짧은 카피 문구".encode("utf-8")
+    ok = await get_storage_provider().put_object("uploads", asset.object_path, body, content_type="text/plain")
+    assert ok
+    text_content, truncated = await _resolve_artifact_text(asset)
+    assert text_content == body.decode("utf-8")
+    assert truncated is False
+
+
+@pytest.mark.anyio
+async def test_resolve_artifact_text_over_4kb_truncated_exactly():
+    from app.services.storage import get_storage_provider
+
+    asset = _FakeAsset(uuid.uuid4(), "text/plain", "uploads", f"t-{uuid.uuid4().hex}.txt")
+    body = ("a" * 5000).encode("ascii")  # 4096바이트 cap보다 명확히 큼(경계 모호성 없는 ascii)
+    await get_storage_provider().put_object("uploads", asset.object_path, body, content_type="text/plain")
+    text_content, truncated = await _resolve_artifact_text(asset)
+    assert truncated is True
+    assert len(text_content.encode("utf-8")) == 4096
+    assert text_content == "a" * 4096
+
+
+# ── realdb: create_loop_artifact / list_loop_artifacts 응답 필드 실증 ─────────────
+
+pytestmark_db = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("24000000-0000-0000-0000-000000000001")
+USER = uuid.UUID("24000000-0000-0000-0000-0000000000a1")
+OM = uuid.UUID("24000000-0000-0000-0000-0000000000b1")
+PROJ_A = uuid.UUID("24000000-0000-0000-0000-000000000002")
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+
+
+async def _seed(s):
+    for sql in [
+        f"DELETE FROM asset_links WHERE org_id='{ORG}'",
+        f"DELETE FROM loop_artifacts WHERE org_id='{ORG}'",
+        f"DELETE FROM loop_runs WHERE org_id='{ORG}'",
+        f"DELETE FROM assets WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ_A}'",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','S24','s24org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@s24.test','x','U',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_A}','{ORG}','A')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ_A}','{OM}','granted')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _seed_loop(s, project_id) -> uuid.UUID:
+    from app.repositories.loop import LoopRunRepository
+    repo = LoopRunRepository(s, ORG)
+    loop = await repo.create(
+        project_id=project_id, title="L", goal_tags=[], status="draft",
+        created_by_member_id=uuid.uuid4(),
+    )
+    await s.commit()
+    return loop.id
+
+
+async def _seed_asset(s, project_id, content_type, container="uploads", object_path=None) -> uuid.UUID:
+    from app.models.asset import Asset
+    a = Asset(
+        id=uuid.uuid4(), org_id=ORG, project_id=project_id, container=container,
+        object_path=object_path or f"org/{ORG}/asset-{uuid.uuid4().hex[:8]}",
+        name="a", content_type=content_type, size_bytes=100,
+    )
+    s.add(a)
+    await s.commit()
+    return a.id
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_create_artifact_text_asset_returns_inline_text_content():
+    from app.services.storage import get_storage_provider
+
+    eng, Session = await _engine()
+    try:
+        object_path = f"org/{ORG}/text-{uuid.uuid4().hex[:8]}.txt"
+        await get_storage_provider().put_object(
+            "uploads", object_path, "무료로 시작하기".encode("utf-8"), content_type="text/plain"
+        )
+        async with Session() as s:
+            await _seed(s)
+            loop_id = await _seed_loop(s, PROJ_A)
+            asset_id = await _seed_asset(s, PROJ_A, "text/plain", object_path=object_path)
+
+        async with Session() as s:
+            out = await r.create_loop_artifact(
+                loop_id=loop_id,
+                body=LoopArtifactCreate(variant_group="cta", variant_label="A", asset_id=asset_id),
+                session=s, auth=_auth(), org_id=ORG,
+            )
+            assert out.content_type == "text/plain"
+            assert out.text_content == "무료로 시작하기"
+            assert out.text_truncated is False
+    finally:
+        await eng.dispose()
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_create_artifact_image_asset_text_content_null_zero_regression():
+    """⭐image 회귀0: content_type만 새로 채워지고 text_content/text_truncated는 조용히 null/False —
+    기존 필드(asset_id/variant_label/decision 등)는 S4 테스트와 동일하게 그대로."""
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            loop_id = await _seed_loop(s, PROJ_A)
+            asset_id = await _seed_asset(s, PROJ_A, "image/png")
+
+        async with Session() as s:
+            out = await r.create_loop_artifact(
+                loop_id=loop_id,
+                body=LoopArtifactCreate(variant_group="hero", variant_label="A", asset_id=asset_id),
+                session=s, auth=_auth(), org_id=ORG,
+            )
+            assert out.content_type == "image/png"
+            assert out.text_content is None
+            assert out.text_truncated is False
+            assert out.asset_id == asset_id
+            assert out.decision == "pending"
+    finally:
+        await eng.dispose()
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_list_loop_artifacts_mixed_text_and_image_batch():
+    """N개 variant(텍스트+이미지 혼합) list — 각 아이템이 자기 asset의 content_type/text에 맞게
+    독립적으로 채워지는지(batch asset 조회가 asset_id로 올바르게 매핑되는지) 실증."""
+    from app.services.storage import get_storage_provider
+
+    eng, Session = await _engine()
+    try:
+        object_path = f"org/{ORG}/text-{uuid.uuid4().hex[:8]}.txt"
+        await get_storage_provider().put_object(
+            "uploads", object_path, "지금 업그레이드".encode("utf-8"), content_type="text/plain"
+        )
+        async with Session() as s:
+            await _seed(s)
+            loop_id = await _seed_loop(s, PROJ_A)
+            text_asset = await _seed_asset(s, PROJ_A, "text/plain", object_path=object_path)
+            image_asset = await _seed_asset(s, PROJ_A, "image/png")
+
+        async with Session() as s:
+            await r.create_loop_artifact(
+                loop_id=loop_id,
+                body=LoopArtifactCreate(variant_group="pricing-cta", variant_label="A", asset_id=text_asset),
+                session=s, auth=_auth(), org_id=ORG,
+            )
+            await r.create_loop_artifact(
+                loop_id=loop_id,
+                body=LoopArtifactCreate(variant_group="pricing-cta", variant_label="B", asset_id=image_asset),
+                session=s, auth=_auth(), org_id=ORG,
+            )
+            await s.commit()
+
+        async with Session() as s:
+            groups = await r.list_loop_artifacts(loop_id=loop_id, session=s, auth=_auth(), org_id=ORG)
+            assert len(groups) == 1
+            by_label = {a.variant_label: a for a in groups[0].artifacts}
+            assert by_label["A"].content_type == "text/plain"
+            assert by_label["A"].text_content == "지금 업그레이드"
+            assert by_label["B"].content_type == "image/png"
+            assert by_label["B"].text_content is None
+    finally:
+        await eng.dispose()
+
+
+# ── realdb: GET /assets/{id}/text ──────────────────────────────────────────────
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_get_asset_text_endpoint_success():
+    from app.routers.assets import get_asset_text
+    from app.services.storage import get_storage_provider
+
+    eng, Session = await _engine()
+    try:
+        object_path = f"org/{ORG}/full-{uuid.uuid4().hex[:8]}.txt"
+        full = "긴 이메일 본문 " * 100
+        await get_storage_provider().put_object("uploads", object_path, full.encode("utf-8"), content_type="text/plain")
+        async with Session() as s:
+            await _seed(s)
+            asset_id = await _seed_asset(s, PROJ_A, "text/plain", object_path=object_path)
+
+        async with Session() as s:
+            out = await get_asset_text(asset_id=str(asset_id), db=s, auth=_auth(), org_id=ORG)
+            assert out.text_content == full
+            assert out.content_type == "text/plain"
+    finally:
+        await eng.dispose()
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_get_asset_text_endpoint_image_asset_400():
+    from app.routers.assets import get_asset_text
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            asset_id = await _seed_asset(s, PROJ_A, "image/png")
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await get_asset_text(asset_id=str(asset_id), db=s, auth=_auth(), org_id=ORG)
+            assert ei.value.status_code == 400
+    finally:
+        await eng.dispose()
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_get_asset_text_endpoint_not_found_404():
+    from app.routers.assets import get_asset_text
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await get_asset_text(asset_id=str(uuid.uuid4()), db=s, auth=_auth(), org_id=ORG)
+            assert ei.value.status_code == 404
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## Summary
- story `bf9f6e25`(P0-UX·prod-blocking) BE 절반. contract doc `e-loop-ledger-s24-copy-variant-handoff`(8e8725da) §3 구현.
- `LoopArtifactResponse`에 `content_type`/`text_content`(text/*만·4KB cap)/`text_truncated` 추가. `image/*`는 `text_content=null`로 기존 경로 완전 불변(회귀0).
- N+1 판단(디디 담당 항목): `Asset`은 DB에 텍스트 본문을 들고 있지 않고 GCS blob만(container/object_path) — 결정 UX는 variant 수가 작아(few·context-pack ~5) inline read로 시작(crux 확정대로). 큰 N이 되면 이 판단을 재검토.
- "더보기" 전문 확보용 `GET /api/v2/assets/{id}/text` lazy endpoint 신규(text/* 전용·400/404 가드).
- 스키마/마이그레이션 변경 없음 — 응답 shape만 확장(`Asset.content_type`은 기존 컬럼).

## Test plan
- [x] 신규 유닛 테스트: `_resolve_artifact_text` — None asset/image asset(storage read 스킵)/파일 미존재(graceful degrade)/4KB 정확 경계 truncation(진짜 LocalStorageProvider write+read, mock 아님).
- [x] realdb: `create_loop_artifact`/`list_loop_artifacts` text asset·image asset·혼합 배치 — content_type/text_content/text_truncated 필드 실증.
- [x] realdb: `GET /assets/{id}/text` 성공/이미지 400/미존재 404.
- [x] 기존 S4/S2 artifact 테스트(`test_e_loop_ledger_s4_artifact_registration.py`, `test_e_loop_ledger_s2_loop_artifacts.py`) 동일 컨테이너 재실행 — 전부 통과(image 경로 회귀0).
- [x] 풀스위트 실행 후 98건 실패 확인 → 대표 3건을 `git stash`로 내 diff 제거 후 동일 컨테이너에서 재실행, clean `origin/develop`에서도 동일하게 실패함을 확인(project_access CHECK/`.mcp.json` 로컬 경로 등 pre-existing 환경 노이즈, 내 diff와 무관).

🤖 Generated with [Claude Code](https://claude.com/claude-code)