### PR TITLE
[SID:df8dca69] E-LOOP-LEDGER S26 — Context Pack 학습 요약(synthesis) 섹션

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2645,7 +2645,8 @@
     "entityTypeLoop": "loop",
     "entityTypeHypothesis": "hypothesis",
     "entityTypeDecision": "decision",
-    "contextPackDecisionPending": "Not yet decided"
+    "contextPackDecisionPending": "Not yet decided",
+    "contextPackSynthesisTitle": "Learning summary"
   },
   "sprints": {
     "title": "Sprints",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2645,7 +2645,8 @@
     "entityTypeLoop": "loop",
     "entityTypeHypothesis": "hypothesis",
     "entityTypeDecision": "decision",
-    "contextPackDecisionPending": "아직 결정 전입니다"
+    "contextPackDecisionPending": "아직 결정 전입니다",
+    "contextPackSynthesisTitle": "학습 요약"
   },
   "sprints": {
     "title": "스프린트",

--- a/apps/web/src/components/loops/context-pack-panel.tsx
+++ b/apps/web/src/components/loops/context-pack-panel.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
-import { Brain } from 'lucide-react';
+import { Brain, Sparkles } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { OutcomeBadge } from '@/components/loops/outcome-badge';
@@ -35,6 +35,11 @@ interface ContextPackItem {
 interface ContextPackResponse {
   items: ContextPackItem[];
   embed_available: boolean;
+  /**
+   * E-LOOP-LEDGER S26 — gen-LLM이 회수 precedents를 증류한 학습 요약(#1843, PO-locked 계약).
+   * optional: 디디 BE 미착지 과도기·gen-LLM 미가용·items 0건 등은 null — 섹션 자체를 렌더 생략(null-safe).
+   */
+  synthesis?: string | null;
 }
 
 function ContextPackCard({ item }: { item: ContextPackItem }) {
@@ -161,7 +166,18 @@ export function ContextPackPanel({ loopId }: { loopId: string }) {
         ) : !data || data.items.length === 0 ? (
           <p className="py-4 text-center text-sm text-muted-foreground">{t('contextPackEmpty')}</p>
         ) : (
-          data.items.map((item) => <ContextPackCard key={`${item.entity_type}-${item.entity_id}`} item={item} />)
+          <>
+            {data.synthesis ? (
+              <div className="flex items-start gap-2 rounded-lg border border-info-border bg-info-tint p-2.5 text-xs text-info">
+                <Sparkles className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+                <div className="space-y-0.5">
+                  <p className="font-semibold">{t('contextPackSynthesisTitle')}</p>
+                  <p className="text-info/90">{data.synthesis}</p>
+                </div>
+              </div>
+            ) : null}
+            {data.items.map((item) => <ContextPackCard key={`${item.entity_type}-${item.entity_id}`} item={item} />)}
+          </>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- 디디 BE #1843(`ContextPackResponse.synthesis: str|None`, gen-LLM이 회수 precedents를 증류한 학습 요약) 계약에 맞춰 S13 "과거 loop에서 학습" 패널에 학습 요약 섹션 추가
- `synthesis`가 있으면 items 카드 위에 Sparkles 아이콘 + "학습 요약" 섹션 표시(기존 info-tint 톤 재사용)
- `synthesis`가 null이면 섹션 자체를 렌더 생략(gen-LLM 미가용·items 0건 등 BE가 null 반환하는 모든 케이스) — raw items 카드는 그대로, null-safe·크래시 0
- 양테마 확인, i18n 키(`contextPackSynthesisTitle`) 추가

## Test plan
- [x] `tsc --noEmit` / `eslint` / `next build` 전부 EXIT 0
- [x] 격리 docker 스택 + Service Worker로 `/api/loops/{id}/context-pack` 응답 목킹(synthesis 필드는 BE #1843 미착지라 계약대로 선빌드) → synthesis 채워진 케이스(학습 요약 섹션 + 기존 item 카드 정상 공존)와 synthesis=null 케이스(섹션 생략, item 카드만 그대로) 둘 다 크래시 0 확인
- [x] 다크모드 재확인(가독성/톤 일관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)