### PR TITLE
feat(e-loop-ledger): S27 — Context Pack L3 능동 추천(synthesis+goal→새 loop 처방)

### DIFF
--- a/backend/app/schemas/context_pack.py
+++ b/backend/app/schemas/context_pack.py
@@ -51,7 +51,12 @@ class ContextPackResponse(BaseModel):
     """P1-S12: 최상위 응답 — items(similarity-desc)+embed_available(임베딩 불가 상태 구분).
 
     S26: synthesis(L2 학습 종합, str|None) 추가 — items 회수 근거로만 gen-LLM(S25)이 증류.
-    items 0건이거나 gen-LLM 미가용이면 null(퇴화 없음 — items(L1)는 그대로 표시)."""
+    items 0건이거나 gen-LLM 미가용이면 null(퇴화 없음 — items(L1)는 그대로 표시).
+
+    S27: recommendation(L3 능동 추천, str|None) 추가 — synthesis(L2)+새 loop의 goal/hypothesis를
+    gen-LLM으로 처방. synthesis가 null이면(근거 자체가 없음) recommendation도 항상 null(L1/L2
+    무손상 — 과잉 처방 금지)."""
     items: list[ContextPackItem]
     embed_available: bool
     synthesis: str | None = None
+    recommendation: str | None = None

--- a/backend/app/services/context_pack_items.py
+++ b/backend/app/services/context_pack_items.py
@@ -78,7 +78,10 @@ async def build_loop_context_pack(
     # search_similar_embeddings는 cosine 거리 ASC(=similarity DESC)로 이미 정렬 — crux ①과 정합.
     items = await _build_items(session, org_id, results)
     synthesis = _synthesize_learnings(items)
-    return ContextPackResponse(items=items, embed_available=True, synthesis=synthesis)
+    recommendation = await _recommend_next_step(session, org_id, loop, synthesis, len(items))
+    return ContextPackResponse(
+        items=items, embed_available=True, synthesis=synthesis, recommendation=recommendation,
+    )
 
 
 async def _build_items(session: AsyncSession, org_id: uuid.UUID, results: list) -> list[ContextPackItem]:
@@ -242,4 +245,57 @@ def _synthesize_learnings(items: list[ContextPackItem]) -> str | None:
         return generate_text(_build_synthesis_prompt(items))
     except Exception as exc:
         logger.warning("context-pack synthesis 실패(생략 처리): %s", exc)
+        return None
+
+
+# ── S27: L3 능동 추천(synthesis+새 loop goal/hypothesis→처방) ────────────────────
+
+_RECOMMENDATION_INSTRUCTION = (
+    "다음은 새로 시작하는 loop의 목표와, 과거 유사 실행들에서 이미 종합된 학습 요약이다. 이 "
+    "학습 요약이 새 loop에 실질적으로 도움이 되는 구체적 제안을 한국어 1~2문장으로 하라. 요약 "
+    "밖의 사실을 추정하거나 새로 만들어내지 마라. 근거(과거 사례 수)가 적거나 애매하면 "
+    "단정적으로 처방하지 말고 '과거 N건 기준' 같은 정직한 hedge를 반드시 포함해 신중하게 "
+    "제안하라."
+)
+
+
+def _build_recommendation_prompt(
+    new_goal: str, new_hypothesis: str | None, synthesis: str, item_count: int,
+) -> str:
+    """⭐과신 방지(S27 AC②): 근거는 synthesis(이미 items 근거로만 만들어진 종합)뿐 — 새 loop의
+    goal/hypothesis는 처방 "대상"을 명시할 뿐 학습 근거로 주입되지 않는다(items 밖 사실 0)."""
+    lines = [_RECOMMENDATION_INSTRUCTION, "", f"[새 loop] 목표: {new_goal}"]
+    if new_hypothesis:
+        lines.append(f"           가설: {new_hypothesis}")
+    lines.extend([
+        "",
+        f"[과거 학습 종합 — 근거 {item_count}건]",
+        synthesis,
+        "",
+        "제안(1~2문장, hedge 포함):",
+    ])
+    return "\n".join(lines)
+
+
+async def _recommend_next_step(
+    session: AsyncSession, org_id: uuid.UUID, loop: LoopRun, synthesis: str | None, item_count: int,
+) -> str | None:
+    """S27 AC①③: synthesis가 없으면(L2 자체가 근거 부족으로 실패/생략) 추천을 아예 시도하지
+    않는다 — 종합도 없이 처방하는 것은 과잉(과신) 처방이라 원천 차단."""
+    if synthesis is None:
+        return None
+    hyp_statement: str | None = None
+    if loop.hypothesis_id is not None:
+        hyp_statement = (await session.execute(
+            select(Hypothesis.statement).where(
+                Hypothesis.id == loop.hypothesis_id, Hypothesis.org_id == org_id
+            )
+        )).scalar_one_or_none()
+    try:
+        from app.services.llm_client import generate_text
+
+        prompt = _build_recommendation_prompt(loop.title, hyp_statement, synthesis, item_count)
+        return generate_text(prompt)
+    except Exception as exc:
+        logger.warning("context-pack recommendation 실패(생략 처리): %s", exc)
         return None

--- a/backend/app/services/context_pack_items.py
+++ b/backend/app/services/context_pack_items.py
@@ -260,17 +260,23 @@ _RECOMMENDATION_INSTRUCTION = (
 
 
 def _build_recommendation_prompt(
-    new_goal: str, new_hypothesis: str | None, synthesis: str, item_count: int,
+    new_goal: str, new_hypothesis: str | None, synthesis: str | None, item_count: int,
 ) -> str:
     """⭐과신 방지(S27 AC②): 근거는 synthesis(이미 items 근거로만 만들어진 종합)뿐 — 새 loop의
-    goal/hypothesis는 처방 "대상"을 명시할 뿐 학습 근거로 주입되지 않는다(items 밖 사실 0)."""
+    goal/hypothesis는 처방 "대상"을 명시할 뿐 학습 근거로 주입되지 않는다(items 밖 사실 0).
+
+    까심 RC: synthesis=None을 None-safe로 처리(TypeError로 크래시하지 않음) — 이래야
+    _recommend_next_step의 `if synthesis is None: return None` 가드가 "유일한" 과잉처방
+    방지 게이트가 된다(가드 없이 이 함수만으로는 크래시가 우연히 generate_text 미호출을
+    만드는 masking을 방지 — 실제 프롬프트 조립이 어떤 입력에도 안전해야 가드의 존재 여부가
+    테스트에서 정직하게 드러난다)."""
     lines = [_RECOMMENDATION_INSTRUCTION, "", f"[새 loop] 목표: {new_goal}"]
     if new_hypothesis:
         lines.append(f"           가설: {new_hypothesis}")
     lines.extend([
         "",
         f"[과거 학습 종합 — 근거 {item_count}건]",
-        synthesis,
+        synthesis if synthesis else "(종합 없음)",
         "",
         "제안(1~2문장, hedge 포함):",
     ])

--- a/backend/tests/test_e_loop_ledger_s27_context_pack_recommendation.py
+++ b/backend/tests/test_e_loop_ledger_s27_context_pack_recommendation.py
@@ -50,10 +50,22 @@ def test_recommendation_prompt_instructs_hedge_and_no_fabrication():
     assert "hedge" in prompt
 
 
+def test_recommendation_prompt_synthesis_none_is_safe_not_a_crash():
+    """까심 RC — synthesis=None으로 프롬프트 조립 자체가 크래시하지 않아야 한다. 이래야
+    _recommend_next_step의 `if synthesis is None: return None` 가드가 과잉처방을 막는
+    "유일한" 게이트가 되고(우연한 TypeError 흡수로 masking되지 않고), 가드를 실수로
+    지우면 generate_text가 실제로 불려 테스트가 정직하게 실패한다(아래 spy 테스트 참고)."""
+    prompt = _build_recommendation_prompt("g", None, None, 0)
+    assert "(종합 없음)" in prompt
+
+
 # ── ⓐ synthesis=None → 추천 자제(generate_text 미호출, spy) ────────────────────
 
 @pytest.mark.anyio
 async def test_synthesis_none_skips_recommendation_without_calling_llm():
+    """⭐까심 RC 검증됨(비-tautological): 프롬프트 빌더가 None-safe이므로(위 테스트) 이
+    assert_not_called()는 가드가 실제로 작동해야만 통과한다 — 가드를 지워보면 generate_text가
+    호출돼 이 테스트가 정확히 그 지점서 실패함을 로컬 검증(fix 임시 제거→재현→복원)."""
     from app.models.loop import LoopRun
 
     loop = LoopRun(id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(), title="L", status="briefing")

--- a/backend/tests/test_e_loop_ledger_s27_context_pack_recommendation.py
+++ b/backend/tests/test_e_loop_ledger_s27_context_pack_recommendation.py
@@ -1,11 +1,12 @@
-"""E-LOOP-LEDGER S26(story df8dca69·P2·L2): Context Pack 학습 종합(회수 items→증류) 검증.
+"""E-LOOP-LEDGER S27(story 840939c7·P2·L3): Context Pack 능동 추천(synthesis+새 loop→처방) 검증.
 
 핵심(비-tautological):
-ⓐ ⭐환각 방지 — 프롬프트가 items 필드만 나열(items 밖 지식 주입 0)함을 프롬프트 텍스트로 직접
-   확인·items=0건이면 generate_text 자체를 호출 안 함(spy로 call_count==0 직접 증명 — 까심
-   S24 RC에서 지적한 "fake path 우연일치" tautological 위험을 피해 처음부터 spy로 작성).
-ⓑ graceful degrade — gen-LLM(S25) None/예외 시 synthesis=None이지만 items(L1)는 그대로.
-ⓒ realdb round-trip — build_loop_context_pack이 synthesis를 실제로 채워 반환.
+ⓐ ⭐과신 방지 — synthesis가 None이면(L2 자체가 근거 부족) 추천 생성(generate_text) 자체를
+   시도하지 않음(spy로 call_count==0 직접 증명 — S24/S26에서 확립한 spy 관용구 재사용, fake
+   path 우연일치 tautological 위험 회피).
+ⓑ 프롬프트가 synthesis+새 loop goal/hypothesis만 사용(items 밖 사실 주입 0)함을 텍스트로 직접 확인.
+ⓒ graceful degrade — recommendation 생성 실패해도 items(L1)/synthesis(L2)는 무손상.
+ⓓ realdb round-trip — full pipeline(synthesis→recommendation) 정합 및 각 단계 독립 실패 격리.
 
 DB env(PARITY_TEST_DATABASE_URL/ALEMBIC_DATABASE_URL) 없으면 realdb 파트 skip.
 """
@@ -18,13 +19,7 @@ from unittest.mock import patch
 
 import pytest
 
-from app.schemas.context_pack import (
-    ContextPackDecision,
-    ContextPackDecisionSide,
-    ContextPackItem,
-    ContextPackOutcome,
-)
-from app.services.context_pack_items import _build_synthesis_prompt, _synthesize_learnings
+from app.services.context_pack_items import _build_recommendation_prompt, _recommend_next_step
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
@@ -34,74 +29,82 @@ def anyio_backend():
     return "asyncio"
 
 
-def _sample_item(**overrides) -> ContextPackItem:
-    defaults = dict(
-        entity_type="loop", entity_id=uuid.uuid4(), similarity=0.9, goal="CTA 문구 실험",
-        decision=ContextPackDecision(
-            chosen=ContextPackDecisionSide(label="A안", reason="저부담 문구가 클릭률을 높인다"),
-            rejected=[ContextPackDecisionSide(label="B안", reason="가격 언급이 부담을 줌")],
-        ),
-        outcome=ContextPackOutcome(hypothesis_status="verified", metric="cvr", actual=12.4, target=10, direction="up"),
-        href="/loops/x",
-    )
-    defaults.update(overrides)
-    return ContextPackItem(**defaults)
+# ── ⓑ 프롬프트 — synthesis+새 loop 필드만 사용 ─────────────────────────────────
+
+def test_recommendation_prompt_contains_goal_synthesis_and_item_count():
+    prompt = _build_recommendation_prompt("가격 페이지 CTA 실험", None, "과거 CTA 실험 3건이 저부담 문구를 채택.", 3)
+    assert "가격 페이지 CTA 실험" in prompt
+    assert "과거 CTA 실험 3건이 저부담 문구를 채택." in prompt
+    assert "근거 3건" in prompt
+    assert "가설:" not in prompt  # hypothesis 없으면 그 줄 자체가 없어야(밖 사실 주입 0).
 
 
-# ── ⓐ 환각 방지 — 프롬프트가 items 필드만 나열 ─────────────────────────────────
+def test_recommendation_prompt_includes_hypothesis_when_present():
+    prompt = _build_recommendation_prompt("가격 실험", "저부담 문구가 전환율을 높인다", "종합", 1)
+    assert "가설: 저부담 문구가 전환율을 높인다" in prompt
 
-def test_synthesis_prompt_contains_only_item_fields_no_external_facts():
-    item = _sample_item()
-    prompt = _build_synthesis_prompt([item])
-    assert "CTA 문구 실험" in prompt
-    assert "A안" in prompt and "저부담 문구가 클릭률을 높인다" in prompt
-    assert "B안" in prompt and "가격 언급이 부담을 줌" in prompt
-    assert "verified" in prompt
-    # 명시적 환각 금지 지시가 프롬프트에 실제로 포함돼있는지.
+
+def test_recommendation_prompt_instructs_hedge_and_no_fabrication():
+    prompt = _build_recommendation_prompt("g", None, "s", 1)
     assert "추정하거나" in prompt and "만들어내지" in prompt
+    assert "hedge" in prompt
 
 
-def test_synthesis_prompt_handles_missing_reason_gracefully():
-    item = _sample_item(decision=ContextPackDecision(
-        chosen=ContextPackDecisionSide(label="A안", reason=None), rejected=[],
-    ))
-    prompt = _build_synthesis_prompt([item])
-    assert "(이유 미기록)" in prompt
+# ── ⓐ synthesis=None → 추천 자제(generate_text 미호출, spy) ────────────────────
 
+@pytest.mark.anyio
+async def test_synthesis_none_skips_recommendation_without_calling_llm():
+    from app.models.loop import LoopRun
 
-# ── ⓐ items=0건 → generate_text 자체 미호출(spy) ────────────────────────────
-
-def test_empty_items_returns_none_without_calling_llm():
+    loop = LoopRun(id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(), title="L", status="briefing")
     with patch("app.services.llm_client.generate_text") as mock_gen:
-        result = _synthesize_learnings([])
+        result = await _recommend_next_step(session=None, org_id=loop.org_id, loop=loop, synthesis=None, item_count=0)
     mock_gen.assert_not_called()
     assert result is None
 
 
-# ── ⓑ graceful degrade ──────────────────────────────────────────────────────
+# ── ⓒ graceful degrade — generate_text 실패/미가용 ──────────────────────────────
 
-def test_llm_unavailable_returns_none():
-    item = _sample_item()
+@pytest.mark.anyio
+async def test_llm_unavailable_returns_none_when_no_hypothesis():
+    from app.models.loop import LoopRun
+
+    loop = LoopRun(id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(), title="L", status="briefing")
     with patch("app.services.llm_client.generate_text", return_value=None) as mock_gen:
-        result = _synthesize_learnings([item])
+        result = await _recommend_next_step(
+            session=None, org_id=loop.org_id, loop=loop, synthesis="과거 종합", item_count=2,
+        )
     mock_gen.assert_called_once()
     assert result is None
 
 
-def test_llm_exception_returns_none_not_raised():
-    item = _sample_item()
+@pytest.mark.anyio
+async def test_llm_exception_returns_none_not_raised():
+    from app.models.loop import LoopRun
+
+    loop = LoopRun(id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(), title="L", status="briefing")
     with patch("app.services.llm_client.generate_text", side_effect=RuntimeError("boom")):
-        result = _synthesize_learnings([item])
+        result = await _recommend_next_step(
+            session=None, org_id=loop.org_id, loop=loop, synthesis="과거 종합", item_count=2,
+        )
     assert result is None
 
 
-def test_llm_success_returns_synthesis_text():
-    item = _sample_item()
-    with patch("app.services.llm_client.generate_text", return_value="과거 CTA 실험 1건 — 저부담 문구 채택.") as mock_gen:
-        result = _synthesize_learnings([item])
-    assert result == "과거 CTA 실험 1건 — 저부담 문구 채택."
+@pytest.mark.anyio
+async def test_llm_success_returns_recommendation_and_passes_grounded_prompt():
+    from app.models.loop import LoopRun
+
+    loop = LoopRun(id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(), title="가격 실험", status="briefing")
+    with patch(
+        "app.services.llm_client.generate_text",
+        return_value="과거 3건 기준 저부담 문구 우선 권장.",
+    ) as mock_gen:
+        result = await _recommend_next_step(
+            session=None, org_id=loop.org_id, loop=loop, synthesis="과거 종합 텍스트", item_count=3,
+        )
+    assert result == "과거 3건 기준 저부담 문구 우선 권장."
     passed_prompt = mock_gen.call_args.args[0]
-    assert "CTA 문구 실험" in passed_prompt
+    assert "가격 실험" in passed_prompt and "과거 종합 텍스트" in passed_prompt
 
 
 # ── realdb ───────────────────────────────────────────────────────────────────
@@ -133,7 +136,7 @@ def _unit(i: int, dim: int = 768) -> list[float]:
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 @pytest.mark.anyio
-async def test_build_loop_context_pack_populates_synthesis_real_db():
+async def test_full_pipeline_populates_recommendation_with_target_loop_hypothesis_real_db():
     from sqlalchemy import text as _text
     from app.core.database import Base
     from app.models.embedding import Embedding
@@ -144,14 +147,22 @@ async def test_build_loop_context_pack_populates_synthesis_real_db():
     engine, Session = await _session()
     query_vec = _unit(0)
     past_hyp_id = uuid.uuid4()
+    target_hyp_id = uuid.uuid4()
 
     try:
         async with Session() as s:
             await s.execute(_text("SET session_replication_role = replica"))
+            s.add(Hypothesis(
+                id=target_hyp_id, org_id=ORG, project_id=PROJECT, owner_member_id=uuid.uuid4(),
+                statement="저부담 문구가 전환율을 높인다",
+                metric_definition={"metric": "x", "source": "manual", "target": 1, "direction": "up"},
+                measure_after=datetime.now(timezone.utc), status="proposed",
+            ))
+            await s.flush()
             repo = LoopRunRepository(s, ORG)
             target_loop = await repo.create(
-                project_id=PROJECT, title="타깃 loop", goal_tags=[],
-                status="draft", created_by_member_id=uuid.uuid4(),
+                project_id=PROJECT, title="가격 페이지 CTA 실험", goal_tags=[],
+                status="draft", hypothesis_id=target_hyp_id, created_by_member_id=uuid.uuid4(),
             )
             s.add(Hypothesis(
                 id=past_hyp_id, org_id=ORG, project_id=PROJECT, owner_member_id=uuid.uuid4(),
@@ -171,16 +182,18 @@ async def test_build_loop_context_pack_populates_synthesis_real_db():
         async with Session() as s:
             loop_obj = await LoopRunRepository(s, ORG).get(target_loop.id)
             with patch("app.services.embedding_client.embed_text", return_value=query_vec), \
-                 patch("app.services.llm_client.generate_text", return_value="과거 실험 1건이 목표 지표를 달성.") as mock_gen:
+                 patch(
+                     "app.services.llm_client.generate_text",
+                     side_effect=["과거 실험 1건이 목표 지표를 달성.", "과거 1건 기준 저부담 문구 권장."],
+                 ) as mock_gen:
                 out = await build_loop_context_pack(s, ORG, loop_obj)
 
         assert out.synthesis == "과거 실험 1건이 목표 지표를 달성."
-        # S27: synthesis 성공 시 recommendation도 시도되므로(같은 mock 반환값을 재사용) 2회 호출.
-        # 이 테스트의 관심사(synthesis 필드)는 첫 호출 인자로 확인 — call count 자체는 S27 몫.
-        assert mock_gen.call_count >= 1
-        first_prompt = mock_gen.call_args_list[0].args[0]
-        assert "과거 실험" in first_prompt
-        assert len(out.items) == 1
+        assert out.recommendation == "과거 1건 기준 저부담 문구 권장."
+        assert mock_gen.call_count == 2
+        recommendation_prompt = mock_gen.call_args_list[1].args[0]
+        assert "가격 페이지 CTA 실험" in recommendation_prompt
+        assert "저부담 문구가 전환율을 높인다" in recommendation_prompt
     finally:
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)
@@ -189,9 +202,7 @@ async def test_build_loop_context_pack_populates_synthesis_real_db():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 @pytest.mark.anyio
-async def test_build_loop_context_pack_no_learnable_items_synthesis_none_no_llm_call_real_db():
-    """학습된 선례가 0건(S12 필터로 전부 걸러짐)이면 synthesis=None이고 gen-LLM 호출 자체가
-    없어야 한다(spy) — 빈 프롬프트로라도 LLM을 부르는 낭비/오동작을 실 파이프라인으로 실증."""
+async def test_no_learnable_items_recommendation_none_no_llm_call_real_db():
     from sqlalchemy import text as _text
     from app.core.database import Base
     from app.repositories.loop import LoopRunRepository
@@ -216,6 +227,7 @@ async def test_build_loop_context_pack_no_learnable_items_synthesis_none_no_llm_
 
         assert out.items == []
         assert out.synthesis is None
+        assert out.recommendation is None
         mock_gen.assert_not_called()
     finally:
         async with engine.begin() as conn:
@@ -225,8 +237,9 @@ async def test_build_loop_context_pack_no_learnable_items_synthesis_none_no_llm_
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 @pytest.mark.anyio
-async def test_build_loop_context_pack_llm_unavailable_items_still_returned_real_db():
-    """⭐AC③ graceful — gen-LLM 미가용이어도 items(L1)는 퇴화 없이 그대로 반환."""
+async def test_synthesis_fails_recommendation_also_none_only_one_llm_attempt_real_db():
+    """⭐AC①③ 파이프라인 레벨 실증 — synthesis 자체가 실패(L2 gen-LLM 미가용)하면 recommendation은
+    시도조차 안 한다(과잉 처방 방지) — generate_text가 정확히 1회(synthesis 시도)만 불림."""
     from sqlalchemy import text as _text
     from app.core.database import Base
     from app.models.embedding import Embedding
@@ -264,12 +277,13 @@ async def test_build_loop_context_pack_llm_unavailable_items_still_returned_real
         async with Session() as s:
             loop_obj = await LoopRunRepository(s, ORG).get(target_loop.id)
             with patch("app.services.embedding_client.embed_text", return_value=query_vec), \
-                 patch("app.services.llm_client.generate_text", return_value=None):
+                 patch("app.services.llm_client.generate_text", return_value=None) as mock_gen:
                 out = await build_loop_context_pack(s, ORG, loop_obj)
 
         assert out.synthesis is None
-        assert len(out.items) == 1
-        assert out.items[0].goal == "과거 실험"
+        assert out.recommendation is None
+        assert len(out.items) == 1  # items(L1)는 무손상.
+        assert mock_gen.call_count == 1  # synthesis 시도만(recommendation은 시도조차 안 함).
     finally:
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)


### PR DESCRIPTION
## Summary
- story `840939c7`(P2·L3·S25+S26 의존).
- L2 synthesis + 새 loop 자신의 goal/hypothesis(연결돼있으면)를 S25 `generate_text()`로 처방 → `ContextPackResponse.recommendation: str|None` 신규 필드.
- **과신 방지(AC②)**: synthesis가 없으면(L2 자체가 근거 부족으로 생략/실패) recommendation 생성을 아예 시도하지 않음(과잉 처방 원천 차단). 프롬프트에 "정직한 hedge 필수" 명시 지시 포함. 새 loop의 goal/hypothesis는 처방 "대상" 명시일 뿐 학습 근거로 주입되지 않음(근거는 synthesis뿐).
- **graceful(AC③)**: recommendation 실패해도 items(L1)/synthesis(L2) 무손상.
- FE 계약: `recommendation: str | null` — Mirco가 S13 패널에 추천 섹션(synthesis 아래·"제안" 라벨) 붙일 수 있음.
- 캐싱·토큰 cap은 S25/S26과 동일(fresh-per-GET·512 cap) — S26에서 이미 합의된 판단 유지.

## Test plan
- [x] 신규 10 테스트: 프롬프트가 synthesis+새 loop 필드만 포함(hypothesis 없으면 그 줄 자체 없음)·hedge/no-fabrication 지시 포함·synthesis=None 시 LLM 미호출(spy)·LLM 미가용/예외 시 None·성공 시 반환·realdb full pipeline(hypothesis 로드 포함)·학습 선례 0건 시 recommendation도 None(LLM 미호출)·synthesis 실패 시 recommendation도 시도조차 안 함(generate_text 정확히 1회).
- [x] 기존 S26/P1-S12 realdb 테스트 재실행 — 회귀 0(S26의 `populates_synthesis` 테스트 1건은 mock 재사용으로 이제 2회 호출되는 게 정상이라 관심사 위주로 단언 완화·갱신).
- [x] 풀스위트 대비 8건은 이 세션서 반복 확인된 pre-existing 노이즈 시그니처 그대로.
- [x] ruff 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)