### PR TITLE
[SID:840939c7] E-LOOP-LEDGER S27 — Context Pack 능동 추천(recommendation) 섹션

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2646,7 +2646,8 @@
     "entityTypeHypothesis": "hypothesis",
     "entityTypeDecision": "decision",
     "contextPackDecisionPending": "Not yet decided",
-    "contextPackSynthesisTitle": "Learning summary"
+    "contextPackSynthesisTitle": "Learning summary",
+    "contextPackRecommendationTitle": "For consideration"
   },
   "sprints": {
     "title": "Sprints",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2646,7 +2646,8 @@
     "entityTypeHypothesis": "hypothesis",
     "entityTypeDecision": "decision",
     "contextPackDecisionPending": "아직 결정 전입니다",
-    "contextPackSynthesisTitle": "학습 요약"
+    "contextPackSynthesisTitle": "학습 요약",
+    "contextPackRecommendationTitle": "참고 제안"
   },
   "sprints": {
     "title": "스프린트",

--- a/apps/web/src/components/loops/context-pack-panel.tsx
+++ b/apps/web/src/components/loops/context-pack-panel.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
-import { Brain, Sparkles } from 'lucide-react';
+import { Brain, Lightbulb, Sparkles } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { OutcomeBadge } from '@/components/loops/outcome-badge';
@@ -40,6 +40,12 @@ interface ContextPackResponse {
    * optional: 디디 BE 미착지 과도기·gen-LLM 미가용·items 0건 등은 null — 섹션 자체를 렌더 생략(null-safe).
    */
   synthesis?: string | null;
+  /**
+   * E-LOOP-LEDGER S27 — gen-LLM 능동 추천(L3, #1845, PO-locked 계약). optional·null-safe: BE 미착지/
+   * gen-LLM 미가용/근거 부족 등은 null — 섹션 생략(퇴화 없음, S26과 동일 원칙).
+   * ⭐유나 LOCK: 제안형 톤(복리 엔진은 결정을 돕지 대체 안 함)·시각 위계는 결정 UI보다 항상 낮게(subtle).
+   */
+  recommendation?: string | null;
 }
 
 function ContextPackCard({ item }: { item: ContextPackItem }) {
@@ -167,12 +173,22 @@ export function ContextPackPanel({ loopId }: { loopId: string }) {
           <p className="py-4 text-center text-sm text-muted-foreground">{t('contextPackEmpty')}</p>
         ) : (
           <>
+            {/* L2 요약(위) → L3 제안(중간) → L1 근거 items(아래) — 유나 LOCK: 위계는 항상 결정 UI보다 낮게. */}
             {data.synthesis ? (
               <div className="flex items-start gap-2 rounded-lg border border-info-border bg-info-tint p-2.5 text-xs text-info">
                 <Sparkles className="mt-0.5 size-3.5 shrink-0" aria-hidden />
                 <div className="space-y-0.5">
                   <p className="font-semibold">{t('contextPackSynthesisTitle')}</p>
                   <p className="text-info/90">{data.synthesis}</p>
+                </div>
+              </div>
+            ) : null}
+            {data.recommendation ? (
+              <div className="flex items-start gap-2 rounded-lg border border-dashed border-border bg-muted/20 p-2.5 text-xs text-muted-foreground">
+                <Lightbulb className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+                <div className="space-y-0.5">
+                  <p className="font-medium text-foreground/80">{t('contextPackRecommendationTitle')}</p>
+                  <p>{data.recommendation}</p>
                 </div>
               </div>
             ) : null}


### PR DESCRIPTION
## Summary
- 디디 BE #1845(`ContextPackResponse.recommendation: str|None`, L3 능동 추천) 계약에 맞춰 "과거 loop에서 학습" 패널에 제안 섹션 추가
- 순서: **L2 학습 요약 → L3 참고 제안 → L1 근거(item 카드)**
- 유나 LOCK 원칙 2개 반영:
  1. 제안형 톤 — 레이블 "참고 제안"(비명령형), BE 생성 텍스트를 그대로 렌더(강조/경고 색 없음)
  2. 시각 위계 — dashed border + `bg-muted/20` + `text-muted-foreground`로 synthesis(L2, `bg-info-tint` 강조) 및 결정 UI(variant gallery, 페이지 상단)보다 항상 subtle하게 하위 배치
- `recommendation`이 null이면 섹션 자체를 생략(BE 미착지·gen-LLM 미가용·근거 부족 등 전부) — raw items(L1)는 그대로, 퇴화 없음
- i18n 키(`contextPackRecommendationTitle`) 추가

## Test plan
- [x] `tsc --noEmit` / `eslint` / `next build` 전부 EXIT 0
- [x] 격리 docker 스택 + Service Worker로 `/api/loops/{id}/context-pack` 응답 목킹(recommendation 필드는 BE #1845 RC fix 중이라 계약대로 선빌드) → 채워진 케이스(순서·위계 육안 확인)와 null 케이스(섹션 생략, 나머지 그대로) 둘 다 크래시 0
- [x] 다크모드 재확인(가독성·위계 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)