### PR TITLE
feat(e-loop-ledger): S15 — hypothesis 자동초안 gen-LLM(S25) 근본 구현

### DIFF
--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -379,11 +379,55 @@ def _build_source_snapshot(context: dict | None) -> dict:
 
 
 def _template_statement(context: dict | None) -> str:
-    """deterministic 템플릿 초안(§3.9.5). LLM draft service는 미확인이라 후속 story로 미룬다."""
+    """deterministic 템플릿 초안(§3.9.5) — gen-LLM(S25) 미가용/실패 시 fallback."""
     title = (context or {}).get("title")
     if isinstance(title, str) and title.strip():
         return f"{title.strip()[:120]} — 이 실행 묶음이 목표 지표를 개선한다"
     return "이 실행 묶음이 목표 지표를 개선한다"
+
+
+_DRAFT_INSTRUCTION = (
+    "다음은 새 가설(hypothesis)의 소재가 될 작업 맥락이다. 이 맥락에 명시된 내용만 근거로, "
+    '"실행하면 목표 지표가 개선될 것이다" 형태의 검증 가능한 가설 문장을 한국어 1문장으로 '
+    "작성하라. 맥락에 없는 지표/숫자/사실을 추정하거나 새로 만들어내지 마라. 사람이 검토·수정할 "
+    "초안이니 간결하고 구체적으로 작성하라."
+)
+
+
+def _build_draft_prompt(context: dict | None) -> str | None:
+    """S15: 맥락(title/description/summary) 전무면 None — 근거 없이 LLM에 지어내라고
+    시키지 않는다(S26/S27과 동형 원칙: 없는 사실을 만들 근거 자체를 안 준다)."""
+    if not context:
+        return None
+    title, description, summary = context.get("title"), context.get("description"), context.get("summary")
+    if not any(isinstance(v, str) and v.strip() for v in (title, description, summary)):
+        return None
+    lines = [_DRAFT_INSTRUCTION, ""]
+    if title:
+        lines.append(f"제목: {title}")
+    if description:
+        lines.append(f"설명: {description}")
+    if summary:
+        lines.append(f"요약: {summary}")
+    lines.extend(["", "가설 문장(1문장):"])
+    return "\n".join(lines)
+
+
+def _draft_statement(context: dict | None) -> tuple[str, bool]:
+    """S15 근본 구현: gen-LLM(S25)으로 맥락 기반 초안 시도 → 맥락 부족/LLM 미가용/실패 시
+    기존 deterministic 템플릿으로 graceful fallback(무손상, S25/S26/S27과 동일 격리 철학).
+    반환 = (statement, llm_generated 여부 — draft_metadata에 기록해 추후 추적 가능)."""
+    prompt = _build_draft_prompt(context)
+    if prompt is not None:
+        try:
+            from app.services.llm_client import generate_text
+
+            generated = generate_text(prompt)
+            if generated and generated.strip():
+                return generated.strip(), True
+        except Exception as exc:
+            logger.warning("hypothesis draft: LLM 초안 실패(템플릿 fallback): %s", exc)
+    return _template_statement(context), False
 
 
 async def draft_hypothesis(
@@ -392,12 +436,16 @@ async def draft_hypothesis(
     caller: ResolvedMember,
     payload: HypothesisDraftRequest,
 ) -> HypothesisDraftResponse:
-    """§3.9 — 흐름 부산물에서 AI 초안 생성. DB에 active를 만들지 않는다.
+    """§3.9 — 흐름 부산물에서 AI 초안 생성. DB에 active를 만들지 않는다(호출부는 항상
+    create_hypothesis를 통해서만 persist하고, status='proposed' 강제는 그 함수의 기존 정책
+    그대로 — agent caller는 절대 active를 만들 수 없다. "돕되 대체 안 함": 자동초안은 제안일
+    뿐, 인간이 검토·수정·confirm(별도 human-only transition)해야 active가 된다).
 
     persist=true이면 status='proposed' row만 생성(create 경로 재사용 — owner/agent 규칙 동일).
-    초기에는 deterministic 템플릿(LLM 미연결). 사람이 statement/metric을 다듬고 확정한다.
+    S15: gen-LLM(S25)으로 statement 초안 시도 → 미가용/실패 시 기존 deterministic 템플릿으로
+    graceful fallback. metric_definition/measure_after는 여전히 고정값(사람이 다듬는 전제).
     """
-    statement = _template_statement(payload.context)
+    statement, llm_generated = _draft_statement(payload.context)
     metric_definition = {"metric": "outcome", "source": "manual", "target": 1, "direction": "up"}
     measure_after = datetime.now(timezone.utc) + timedelta(days=_DEFAULT_MEASURE_DAYS)
     snapshot = _build_source_snapshot(payload.context)
@@ -421,7 +469,10 @@ async def draft_hypothesis(
                 story_ids=story_ids,
                 source_type=payload.source_type,
                 source_id=payload.source_id,
-                draft_metadata={"template": True, "source_snapshot": snapshot},
+                draft_metadata={
+                    "generation_method": "llm" if llm_generated else "template",
+                    "source_snapshot": snapshot,
+                },
             ),
         )
     return HypothesisDraftResponse(

--- a/backend/tests/test_e_loop_ledger_s15_hypothesis_llm_draft.py
+++ b/backend/tests/test_e_loop_ledger_s15_hypothesis_llm_draft.py
@@ -1,0 +1,209 @@
+"""E-LOOP-LEDGER S15(story 2d1e02c0·P2): hypothesis 자동초안 — gen-LLM(S25) 근본 구현.
+
+핵심(비-tautological, S26/S27과 동형 원칙 재사용):
+ⓐ 맥락(title/description/summary) 전무면 LLM 호출 자체를 안 함(spy) — 근거 없이 지어내지 않음.
+ⓑ 프롬프트가 맥락 필드만 사용(밖 사실 주입 0)·no-fabrication 지시 포함.
+ⓒ graceful fallback — LLM 미가용/예외/빈 응답 시 기존 deterministic 템플릿으로 무손상 대체
+   (fallback이 "우연"이 아니라 실제 경로임을 각 실패모드별로 직접 검증).
+ⓓ "돕되 대체 안 함" — draft_hypothesis는 항상 status='proposed'만 생성(active 자동생성 없음,
+   create_hypothesis의 기존 human-only active 정책을 그대로 통과·우회 없음).
+ⓔ draft_metadata.generation_method가 실제 사용된 경로(llm/template)를 정확히 기록.
+
+DB 불요(mock 세션) — test_hypothesis_service.py와 동형 하네스, 이 파일은 S15 신규 로직만
+독립 검증한다(cross-project 등 create_hypothesis 공통 가드는 기존 파일이 커버).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.schemas.hypothesis import HypothesisDraftRequest
+from app.services import hypothesis as svc
+from app.services.hypothesis import _build_draft_prompt, _draft_statement, _template_statement
+from app.services.member_resolver import ResolvedMember
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+CALLER_ID = uuid.uuid4()
+HYP_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _mock_embedding_enqueue():
+    with patch("app.services.embedding_enqueue.enqueue_embedding", new=AsyncMock(return_value=None)):
+        yield
+
+
+# ── ⓑ 프롬프트 — 맥락 필드만 사용 ────────────────────────────────────────────
+
+def test_build_draft_prompt_none_context_returns_none():
+    assert _build_draft_prompt(None) is None
+
+
+def test_build_draft_prompt_empty_context_returns_none():
+    assert _build_draft_prompt({}) is None
+    assert _build_draft_prompt({"title": "", "description": None}) is None
+
+
+def test_build_draft_prompt_title_only_omits_other_sections():
+    prompt = _build_draft_prompt({"title": "온보딩 개선 에픽"})
+    assert "온보딩 개선 에픽" in prompt
+    assert "설명:" not in prompt and "요약:" not in prompt
+
+
+def test_build_draft_prompt_all_fields_included():
+    prompt = _build_draft_prompt({"title": "T", "description": "D", "summary": "S"})
+    assert "제목: T" in prompt and "설명: D" in prompt and "요약: S" in prompt
+
+
+def test_build_draft_prompt_instructs_no_fabrication_and_single_sentence():
+    prompt = _build_draft_prompt({"title": "T"})
+    assert "추정하거나" in prompt and "만들어내지" in prompt
+    assert "1문장" in prompt
+
+
+# ── ⓐⓒ _draft_statement — LLM 시도/graceful fallback ───────────────────────────
+
+def test_no_context_falls_back_to_template_without_calling_llm():
+    with patch("app.services.llm_client.generate_text") as mock_gen:
+        statement, llm_generated = _draft_statement(None)
+    mock_gen.assert_not_called()
+    assert llm_generated is False
+    assert statement == _template_statement(None)
+
+
+def test_llm_success_returns_generated_statement():
+    with patch("app.services.llm_client.generate_text", return_value="실행하면 활성화율이 오를 것이다.") as mock_gen:
+        statement, llm_generated = _draft_statement({"title": "온보딩 개선"})
+    mock_gen.assert_called_once()
+    assert statement == "실행하면 활성화율이 오를 것이다."
+    assert llm_generated is True
+    passed_prompt = mock_gen.call_args.args[0]
+    assert "온보딩 개선" in passed_prompt
+
+
+def test_llm_unavailable_falls_back_to_template():
+    with patch("app.services.llm_client.generate_text", return_value=None):
+        statement, llm_generated = _draft_statement({"title": "온보딩 개선"})
+    assert llm_generated is False
+    assert statement == _template_statement({"title": "온보딩 개선"})
+
+
+def test_llm_exception_falls_back_to_template_not_raised():
+    with patch("app.services.llm_client.generate_text", side_effect=RuntimeError("boom")):
+        statement, llm_generated = _draft_statement({"title": "온보딩 개선"})
+    assert llm_generated is False
+    assert statement == _template_statement({"title": "온보딩 개선"})
+
+
+def test_llm_blank_response_falls_back_to_template():
+    """빈/공백 응답을 그대로 statement로 쓰지 않고 템플릿으로 대체(안전 필터 차단 등 대비)."""
+    with patch("app.services.llm_client.generate_text", return_value="   "):
+        statement, llm_generated = _draft_statement({"title": "온보딩 개선"})
+    assert llm_generated is False
+    assert statement == _template_statement({"title": "온보딩 개선"})
+
+
+# ── ⓓⓔ draft_hypothesis 전체 경로(mock 세션) — generation_method 기록 + proposed 고정 ──
+
+def _hyp_stub(**overrides) -> SimpleNamespace:
+    base = dict(
+        id=HYP_ID, org_id=ORG_ID, project_id=PROJECT_ID, owner_member_id=CALLER_ID,
+        created_by_member_id=CALLER_ID, confirmed_by_member_id=None,
+        statement="s", metric_definition={"metric": "outcome", "source": "manual", "target": 1, "direction": "up"},
+        measure_after=datetime(2026, 7, 1, tzinfo=timezone.utc), status="proposed",
+        outcome_result=None, confidence=None, source_type=None, source_id=None,
+        drafted_by_member_id=None, draft_metadata=None,
+        human_accounting={}, gate_contract={},
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _repo_mock(hyp: SimpleNamespace) -> AsyncMock:
+    repo = AsyncMock()
+    repo.create = AsyncMock(return_value=hyp)
+    repo.get_epic_ids = AsyncMock(return_value=[])
+    repo.get_story_ids = AsyncMock(return_value=[])
+    repo.add_epic_links = AsyncMock()
+    repo.add_story_links = AsyncMock()
+    return repo
+
+
+def _caller() -> ResolvedMember:
+    return ResolvedMember(id=CALLER_ID, user_id=uuid.uuid4(), name="u", type="human", role="member", org_id=ORG_ID)
+
+
+def _members_lookup() -> dict:
+    """human caller가 owner 기본값(self)이 되므로 _verify_human_owner가 이 id를 human으로
+    조회할 수 있어야 한다(HUMAN_OWNER_REQUIRED로 새지 않게)."""
+    return {CALLER_ID: _caller()}
+
+
+def _empty_session() -> MagicMock:
+    session = MagicMock()
+    res = MagicMock()
+    res.all = MagicMock(return_value=[])
+    session.execute = AsyncMock(return_value=res)
+    return session
+
+
+@pytest.mark.anyio
+async def test_draft_persist_llm_success_records_llm_generation_method():
+    repo = _repo_mock(_hyp_stub())
+    payload = HypothesisDraftRequest(
+        project_id=PROJECT_ID, source_type="conversation", source_id=uuid.uuid4(),
+        persist=True, context={"title": "온보딩 개선"},
+    )
+    with patch.object(svc, "HypothesisRepository", return_value=repo), \
+         patch.object(svc, "lookup_members_by_ids", AsyncMock(return_value=_members_lookup())), \
+         patch("app.services.llm_client.generate_text", return_value="실행하면 활성화율이 오를 것이다."):
+        out = await svc.draft_hypothesis(_empty_session(), ORG_ID, _caller(), payload)
+
+    assert out.statement == "실행하면 활성화율이 오를 것이다."
+    create_kwargs = repo.create.call_args.kwargs
+    assert create_kwargs["status"] == "proposed"  # ⭐돕되 대체 안 함 — 자동 active 절대 없음.
+    assert create_kwargs["draft_metadata"]["generation_method"] == "llm"
+
+
+@pytest.mark.anyio
+async def test_draft_persist_llm_unavailable_records_template_generation_method():
+    repo = _repo_mock(_hyp_stub())
+    payload = HypothesisDraftRequest(
+        project_id=PROJECT_ID, source_type="conversation", source_id=uuid.uuid4(),
+        persist=True, context={"title": "온보딩 개선"},
+    )
+    with patch.object(svc, "HypothesisRepository", return_value=repo), \
+         patch.object(svc, "lookup_members_by_ids", AsyncMock(return_value=_members_lookup())), \
+         patch("app.services.llm_client.generate_text", return_value=None):
+        out = await svc.draft_hypothesis(_empty_session(), ORG_ID, _caller(), payload)
+
+    assert out.statement == _template_statement({"title": "온보딩 개선"})
+    create_kwargs = repo.create.call_args.kwargs
+    assert create_kwargs["status"] == "proposed"
+    assert create_kwargs["draft_metadata"]["generation_method"] == "template"
+
+
+@pytest.mark.anyio
+async def test_draft_no_persist_still_drafts_statement_without_creating_row():
+    payload = HypothesisDraftRequest(
+        project_id=PROJECT_ID, source_type="epic", source_id=uuid.uuid4(),
+        persist=False, context={"title": "온보딩 개선"},
+    )
+    with patch("app.services.llm_client.generate_text", return_value="실행하면 활성화율이 오를 것이다.") as mock_gen:
+        out = await svc.draft_hypothesis(_empty_session(), ORG_ID, _caller(), payload)
+    mock_gen.assert_called_once()
+    assert out.statement == "실행하면 활성화율이 오를 것이다."
+    assert out.hypothesis is None
+    assert out.requires_confirmation is True


### PR DESCRIPTION
## Summary
- story `2d1e02c0`(P2). 의존: S14. S25(gen-LLM 파운데이션) 위.
- ⚠️ 저장된 AC 원문은 gen-LLM 도입 이전에 쓰여 "신 drafting 인프라 0"으로 명시돼있으나, S25/S26/S27이 그 사이 머지되며 Ortega 킥오프에서 명시적으로 "이제 gen-LLM 있으니 근본 구현" 방향으로 업데이트됨 — 이 PR은 채팅 킥오프(최신 지시)를 따름. 스토리 AC 문서 갱신은 PO 몫으로 남겨둠.
- `draft_hypothesis`의 statement 생성을 deterministic 템플릿 단독에서 S25 `generate_text()` 우선 시도로 전환(`_template_statement`의 "LLM draft service는 미확인이라 후속 story로 미룬다" 주석 해소).

## 구현
- 맥락(title/description/summary) 전무면 LLM 호출 자체를 생략(근거 없이 지어내지 않음, S26/S27과 동형 원칙).
- 맥락 있으면 그 필드만 사용한 프롬프트로 `generate_text()` 시도(no-fabrication 명시 지시).
- LLM 미가용/예외/빈 응답 시 기존 deterministic 템플릿으로 graceful fallback(무손상).
- `draft_metadata.generation_method`(llm|template)로 실사용 경로 기록.
- **"돕되 대체 안 함" 유지**: `draft_hypothesis`는 여전히 항상 `status='proposed'`만 생성(agent caller는 active 자동생성 불가 — `create_hypothesis`의 기존 human-only active 전이 정책을 그대로 통과·우회 없음). `metric_definition`/`measure_after`는 여전히 고정값(LLM 자유생성 대상 아님 — JSON 스키마 신뢰성 문제로 이번 스코프 제외).

## Test plan
- [x] 신규 13 테스트: 프롬프트가 맥락 필드만 사용(밖 사실 주입 0)·맥락 없으면 LLM 미호출(spy)·LLM 성공/미가용/예외/빈응답 각각의 fallback 개별 검증·draft_hypothesis 전체 경로(mock 세션)에서 status=proposed 고정+generation_method 정확 기록·persist=false 미리보기 경로.
- [x] 기존 `test_hypothesis_service.py`+`test_hypotheses_router.py` 64건 전부 회귀 0.
- [x] ruff 클린(pre-existing E402 3건은 이 diff와 무관, origin/develop에도 존재).

🤖 Generated with [Claude Code](https://claude.com/claude-code)