### PR TITLE
fix(e-loop-ledger): gen-LLM 빈 응답 근본 원인 수정 — thinking budget 잠식

### DIFF
--- a/backend/app/services/llm_client.py
+++ b/backend/app/services/llm_client.py
@@ -61,14 +61,25 @@ def generate_text(prompt: str, *, max_output_tokens: int = DEFAULT_MAX_OUTPUT_TO
         response = client.models.generate_content(
             model=MODEL_VERSION,
             contents=prompt,
-            config=types.GenerateContentConfig(max_output_tokens=max_output_tokens),
+            config=types.GenerateContentConfig(
+                max_output_tokens=max_output_tokens,
+                # PO 실측(dev 로그, 2026-07-02): gemini-2.5-flash는 thinking 모델이라
+                # thinking_config 미지정 시 AUTOMATIC thinking budget이 max_output_tokens를
+                # 통째로 잠식해 200 OK+빈 text(finish_reason=MAX_TOKENS)로 끝나는 사례 실측.
+                # 이 용도(1~3문장 요약/처방)엔 deep reasoning 불요 — thinking_budget=0으로
+                # 명시 disable(SDK 문서: "0 is DISABLED"). 모델이 0을 거부하면(일부 모델은
+                # 완전 disable 불가) 아래 except가 흡수해 기존 graceful None으로 동일 안전.
+                thinking_config=types.ThinkingConfig(thinking_budget=0),
+            ),
         )
         latency_ms = round((time.monotonic() - start) * 1000, 2)
         _log_generation_instrumentation(latency_ms, response)
 
         text = response.text
         if not text or not text.strip():
-            logger.warning("llm_client: 빈 응답 → None 처리")
+            logger.warning(
+                "llm_client: 빈 응답 → None 처리 (finish_reason=%s)", _finish_reason(response)
+            )
             return None
         return text
     except Exception as exc:  # errors.ClientError(4xx: auth/quota/403)·ServerError(5xx)·기타 SDK 오류 포괄
@@ -76,8 +87,25 @@ def generate_text(prompt: str, *, max_output_tokens: int = DEFAULT_MAX_OUTPUT_TO
         return None
 
 
+def _finish_reason(response) -> str | None:
+    """candidates[0].finish_reason — MAX_TOKENS(thinking 잠식 등)/SAFETY/RECITATION 등 빈
+    응답의 근본 원인 진단용(PO 실측 요청, 2026-07-02). 실패해도 None(진단 보조일 뿐)."""
+    try:
+        candidates = getattr(response, "candidates", None)
+        if not candidates:
+            return None
+        reason = getattr(candidates[0], "finish_reason", None)
+        return reason.value if reason is not None and hasattr(reason, "value") else (
+            str(reason) if reason is not None else None
+        )
+    except Exception:
+        return None
+
+
 def _log_generation_instrumentation(latency_ms: float, response) -> None:
     """S25 AC③ 토큰 cap+구조화 로깅 — 크레딧 내 비용 추적(P1-S8 A2 계측 관용구 재사용).
+    2026-07-02 PO 실측 후 finish_reason/thoughts_token_count 추가(빈 응답 근본원인 진단 —
+    MAX_TOKENS면 thinking 잠식, SAFETY면 콘텐츠 차단 구분).
 
     non-fatal: 계측 실패가 이미 확보된 생성 응답을 막으면 안 된다(응답엔 무영향)."""
     try:
@@ -89,7 +117,9 @@ def _log_generation_instrumentation(latency_ms: float, response) -> None:
                 "latency_ms": latency_ms,
                 "prompt_token_count": getattr(usage, "prompt_token_count", None) if usage else None,
                 "candidates_token_count": getattr(usage, "candidates_token_count", None) if usage else None,
+                "thoughts_token_count": getattr(usage, "thoughts_token_count", None) if usage else None,
                 "total_token_count": getattr(usage, "total_token_count", None) if usage else None,
+                "finish_reason": _finish_reason(response),
             }},
         )
     except Exception as exc:

--- a/backend/tests/test_e_loop_ledger_s25_llm_client.py
+++ b/backend/tests/test_e_loop_ledger_s25_llm_client.py
@@ -102,6 +102,45 @@ def test_empty_response_text_returns_none():
     assert result is None
 
 
+def test_thinking_disabled_to_prevent_budget_exhausting_output():
+    """⭐PO 실측(dev 로그, 2026-07-02) — gemini-2.5-flash가 thinking_config 미지정 시
+    AUTOMATIC thinking budget이 max_output_tokens를 통째로 잠식해 200 OK+빈 text(사실상
+    기능 0)를 냄. thinking_budget=0(명시 disable)이 실제로 SDK config에 실려나가는지 실증."""
+    fake_response = MagicMock()
+    fake_response.text = "ok"
+    fake_response.usage_metadata = None
+    with patch("app.services.llm_client._has_adc", return_value=True), \
+         patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with patch("google.genai.Client") as mock_client_cls:
+            mock_client_cls.return_value.models.generate_content.return_value = fake_response
+            generate_text("x")
+    call_kwargs = mock_client_cls.return_value.models.generate_content.call_args.kwargs
+    assert call_kwargs["config"].thinking_config.thinking_budget == 0
+
+
+def test_empty_response_with_max_tokens_finish_reason_logged_for_diagnosis(caplog):
+    """⭐빈 응답의 근본 원인(MAX_TOKENS=thinking 잠식 vs SAFETY=차단 등)을 로그로 즉시 구분
+    가능해야 한다 — PO가 "finish_reason 추가해 원인 확정" 요청한 그 진단 능력을 직접 검증."""
+    from google.genai import types as genai_types
+
+    fake_candidate = MagicMock()
+    fake_candidate.finish_reason = genai_types.FinishReason.MAX_TOKENS
+    fake_response = MagicMock()
+    fake_response.text = ""
+    fake_response.usage_metadata = None
+    fake_response.candidates = [fake_candidate]
+    with patch("app.services.llm_client._has_adc", return_value=True), \
+         patch.dict(os.environ, {}, clear=False), \
+         caplog.at_level(logging.WARNING, logger="app.services.llm_client"):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with patch("google.genai.Client") as mock_client_cls:
+            mock_client_cls.return_value.models.generate_content.return_value = fake_response
+            result = generate_text("x")
+    assert result is None
+    assert any("MAX_TOKENS" in r.message for r in caplog.records)
+
+
 # ── ⭐AC⑤ 실패 재현(비-tautological) ────────────────────────────────────────
 
 def test_sdk_exception_returns_none_not_raised():


### PR DESCRIPTION
## Summary
- PO가 dev 라이브 로그로 실측: `/context-pack` GET → `generateContent` 200 OK인데 `response.text`가 빈 값 → `llm_client`가 정확히 graceful `None` 처리는 하지만 결과적으로 synthesis/recommendation/자동초안(S15·S26·S27 전부 동일 `generate_text()` 경유)이 전부 null — **graceful degrade는 정확했으나 기능 출력이 0**이었음.
- **근본 원인**: `gemini-2.5-flash`는 thinking 모델이라 `thinking_config` 미지정 시 AUTOMATIC thinking budget이 `max_output_tokens`를 통째로 잠식해 `finish_reason=MAX_TOKENS`+빈 text로 끝나는 known SDK gotcha.
- **fix**: `GenerateContentConfig`에 `thinking_config=ThinkingConfig(thinking_budget=0)` 명시(이 용도엔 deep reasoning 불요 — SDK 문서 "0 is DISABLED"). 모델이 0을 거부하는 케이스가 있어도 기존 `try/except`가 흡수해 동일 graceful `None`(회귀 없음, 최악의 경우도 지금과 동일).
- **진단성 개선**: 구조화 로깅에 `finish_reason`+`thoughts_token_count` 추가 — `MAX_TOKENS`(thinking 잠식) vs `SAFETY`(콘텐츠 차단) 등 빈 응답의 원인을 앞으로는 로그만으로 즉시 구분 가능. 빈 응답 WARNING 로그에도 `finish_reason` 포함.

## Impact
S15(hypothesis 자동초안)·S26(L2 synthesis)·S27(L3 recommendation) 전부 동일 `generate_text()`를 경유하므로 이 하나로 세 기능 모두의 실제 출력이 살아남.

## Test plan
- [x] 신규 2 테스트: `thinking_budget=0`이 실제로 SDK config에 실려나가는지·`MAX_TOKENS` finish_reason이 진단 로그에 정확히 찍히는지(caplog).
- [x] 기존 S25(신규 2건 포함 20)·embedding_client(7)·S15(13)·S26(8, mock)·S27(7, mock) = 47건 전부 회귀 0.
- [x] ruff 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)