### PR TITLE
feat(e-loop-ledger): S28 — Claude(claude-sonnet-5) Vertex 경로 + reasoning 실험

### DIFF
--- a/backend/app/services/llm_client.py
+++ b/backend/app/services/llm_client.py
@@ -1,4 +1,4 @@
-"""E-LOOP-LEDGER S25(story 0fb72183): Vertex AI(gemini-2.5-flash) 생성형 텍스트 클라이언트.
+"""E-LOOP-LEDGER S25/S28: Vertex AI 생성형 텍스트 클라이언트 — Gemini(기본)+Claude(실험) 경로.
 
 embedding_client.py와 동일한 genai.Client(vertexai=True) 재사용 — 신규 크리덴셜/배선 0(같은
 ADC/aiplatform SA, embed와 동일 project/location). L2 종합(S26)·S15 자동초안·미팅 AI요약(현재
@@ -6,6 +6,10 @@ ADC/aiplatform SA, embed와 동일 project/location). L2 종합(S26)·S15 자동
 
 인증 불가/빈 입력/API 오류는 예외 전파 없이 None 반환(embed_text와 동일 격리 철학 — 생성 실패가
 호출부를 크래시시키거나 잘못된 결과로 오인되게 하지 않는다. 절대 실패를 성공으로 위장하지 않음).
+
+S28(story 116e6fe8, 선생님 dogfood 지적): L2/L3 출력 품질이 순환적·비-actionable — 모델
+업그레이드 실험의 첫 축으로 Claude(claude-sonnet-5, Vertex Model Garden)를 별도 경로로
+추가(`generate_text_claude`). google-genai(Gemini)와 완전 독립 — `generate_text()`는 무변경.
 """
 from __future__ import annotations
 
@@ -124,3 +128,92 @@ def _log_generation_instrumentation(latency_ms: float, response) -> None:
         )
     except Exception as exc:
         logger.warning("llm_client instrumentation 실패(응답엔 무영향): %s", exc)
+
+
+# ── S28: Claude(claude-sonnet-5, Vertex Model Garden) — 실험 경로 ─────────────────
+
+CLAUDE_MODEL_VERSION = "claude-sonnet-5"
+# PO 실측(2026-07-02): 리전 엔드포인트(asia-northeast3 등)는 429 quota — global 로케이션이
+# 유일하게 동작(rawPredict 200 확인). google-genai(Gemini)의 vertex_ai_location과는 무관.
+_CLAUDE_REGION = "global"
+_CLAUDE_REASONING_LEVELS = frozenset({"disabled", "low", "medium", "high", "xhigh", "max"})
+
+
+def generate_text_claude(
+    prompt: str, *, max_output_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS, reasoning: str = "disabled",
+) -> str | None:
+    """Claude(claude-sonnet-5) 생성 — S28 모델/reasoning 레벨 실험용 별도 경로.
+
+    reasoning: "disabled"(thinking 끔) | "low"/"medium"/"high"/"xhigh"/"max"(adaptive thinking
+    +output_config.effort). ⚠️실측(2026-07-02): claude-sonnet-5는 구형
+    thinking.type="enabled"+budget_tokens를 지원 안 함(invalid_request_error 확인) —
+    thinking.type="adaptive"+output_config.effort로만 강도 제어 가능.
+
+    graceful 계약은 generate_text()와 동일: 인증 불가/빈 입력/API 오류/빈 응답 시 None(예외
+    전파 없음 — 호출부는 이를 "아직 못 만듦"으로 처리하고 graceful degrade해야 한다).
+    """
+    if not prompt or not prompt.strip():
+        return None
+    if reasoning not in _CLAUDE_REASONING_LEVELS:
+        reasoning = "disabled"
+
+    creds_file = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if not creds_file and not _has_adc():
+        logger.warning("llm_client(claude): 인증 정보 없음 → None 처리")
+        return None
+
+    start = time.monotonic()
+    try:
+        from anthropic import AnthropicVertex
+
+        client = AnthropicVertex(region=_CLAUDE_REGION, project_id=settings.gcp_project_id)
+        kwargs: dict = {
+            "model": CLAUDE_MODEL_VERSION,
+            "max_tokens": max_output_tokens,
+            "messages": [{"role": "user", "content": prompt}],
+        }
+        if reasoning == "disabled":
+            kwargs["thinking"] = {"type": "disabled"}
+        else:
+            kwargs["thinking"] = {"type": "adaptive"}
+            kwargs["output_config"] = {"effort": reasoning}
+
+        response = client.messages.create(**kwargs)
+        latency_ms = round((time.monotonic() - start) * 1000, 2)
+        _log_claude_generation_instrumentation(latency_ms, response, reasoning)
+
+        text = "".join(
+            block.text for block in response.content if getattr(block, "type", None) == "text"
+        ).strip()
+        if not text:
+            logger.warning(
+                "llm_client(claude): 빈 응답 → None 처리 (stop_reason=%s)",
+                getattr(response, "stop_reason", None),
+            )
+            return None
+        return text
+    except Exception as exc:  # invalid_request_error(4xx)·auth/quota·기타 SDK 오류 포괄
+        logger.warning("llm_client(claude): 생성 실패: %s", exc)
+        return None
+
+
+def _log_claude_generation_instrumentation(latency_ms: float, response, reasoning: str) -> None:
+    """S28: Claude 경로 latency+token 구조화 로깅 — 모델/reasoning 레벨 비교 실험 데이터
+    (선생님 요청 latency 표의 소스). non-fatal: 계측 실패가 응답을 막지 않는다."""
+    try:
+        usage = getattr(response, "usage", None)
+        details = getattr(usage, "output_tokens_details", None) if usage else None
+        logger.info(
+            "llm generation (claude)",
+            extra={"structured": {
+                "model": CLAUDE_MODEL_VERSION,
+                "reasoning": reasoning,
+                "latency_ms": latency_ms,
+                "input_tokens": getattr(usage, "input_tokens", None) if usage else None,
+                "output_tokens": getattr(usage, "output_tokens", None) if usage else None,
+                "thinking_tokens": getattr(details, "thinking_tokens", None) if details else None,
+                "stop_reason": getattr(response, "stop_reason", None),
+            }},
+        )
+    except Exception as exc:
+        logger.warning("llm_client(claude) instrumentation 실패(응답엔 무영향): %s", exc)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -32,6 +32,9 @@ dependencies = [
     "pgvector>=0.3.0",
     # E-LOOP-LEDGER P1-S2: Vertex AI(gemini-embedding-001) 임베딩 클라이언트. ADC 인증(신규 크리덴셜 0).
     "google-genai>=1.0.0",
+    # E-LOOP-LEDGER S28: Vertex AI Model Garden의 Anthropic(claude-sonnet-5) 생성형 경로. ADC 인증
+    # (신규 크리덴셜 0, google-genai와 동일 철학) — Gemini(google-genai)와 별도 SDK/클라이언트.
+    "anthropic[vertex]>=0.40.0",
 ]
 
 [dependency-groups]

--- a/backend/tests/test_e_loop_ledger_s28_llm_client_claude.py
+++ b/backend/tests/test_e_loop_ledger_s28_llm_client_claude.py
@@ -1,0 +1,178 @@
+"""E-LOOP-LEDGER S28(story 116e6fe8): llm_client.py::generate_text_claude(Claude 실험 경로) 검증.
+
+핵심 격리(비-tautological, generate_text/embed_text와 동형): 인증 정보 없음/SDK 예외/빈 응답
+→ 전부 None(예외 전파 없음). 실 Vertex 호출은 하지 않는다(SDK 호출부 mock).
+
+⭐reasoning 파라미터 계약(2026-07-02 실측 반영): "disabled"→thinking.type=disabled만·
+"low"~"max"→thinking.type=adaptive+output_config.effort(구형 enabled/budget_tokens 아님 —
+claude-sonnet-5가 그 구형 스킴을 invalid_request_error로 거부함을 실측 확인했고, 이 계약이
+그 실측을 그대로 코드화한 것임을 테스트로 고정).
+"""
+from __future__ import annotations
+
+import logging
+import os
+from unittest.mock import MagicMock, patch
+
+from app.services.llm_client import CLAUDE_MODEL_VERSION, generate_text_claude
+
+
+def _fake_response(text="synthesis", stop_reason="end_turn", input_tokens=100, output_tokens=50, thinking_tokens=0):
+    block = MagicMock()
+    block.type = "text"
+    block.text = text
+    response = MagicMock()
+    response.content = [block]
+    response.stop_reason = stop_reason
+    response.usage = MagicMock(
+        input_tokens=input_tokens, output_tokens=output_tokens,
+        output_tokens_details=MagicMock(thinking_tokens=thinking_tokens),
+    )
+    return response
+
+
+# ── 빈 입력/무인증 ────────────────────────────────────────────────────────────
+
+def test_empty_prompt_returns_none_without_auth_check():
+    assert generate_text_claude("") is None
+    assert generate_text_claude("   ") is None
+
+
+def test_no_credentials_returns_none_no_exception():
+    with patch("app.services.llm_client._has_adc", return_value=False), \
+         patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        result = generate_text_claude("summarize these precedents")
+    assert result is None
+
+
+# ── ⭐reasoning 파라미터 계약(2026-07-02 실측 고정) ────────────────────────────
+
+def test_disabled_reasoning_sends_thinking_disabled_only():
+    fake = _fake_response()
+    with patch("app.services.llm_client._has_adc", return_value=True), \
+         patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with patch("anthropic.AnthropicVertex") as mock_client_cls:
+            mock_client_cls.return_value.messages.create.return_value = fake
+            generate_text_claude("x", reasoning="disabled")
+    call_kwargs = mock_client_cls.return_value.messages.create.call_args.kwargs
+    assert call_kwargs["thinking"] == {"type": "disabled"}
+    assert "output_config" not in call_kwargs
+    assert call_kwargs["model"] == CLAUDE_MODEL_VERSION
+
+
+def test_low_reasoning_sends_adaptive_thinking_with_effort_not_legacy_budget():
+    """⭐claude-sonnet-5는 thinking.type=enabled+budget_tokens(구형)를 거부한다고 실측
+    확인됐음 — adaptive+output_config.effort만 실려나가야 한다(구형 스킴 회귀 방지)."""
+    fake = _fake_response()
+    with patch("app.services.llm_client._has_adc", return_value=True), \
+         patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with patch("anthropic.AnthropicVertex") as mock_client_cls:
+            mock_client_cls.return_value.messages.create.return_value = fake
+            generate_text_claude("x", reasoning="low")
+    call_kwargs = mock_client_cls.return_value.messages.create.call_args.kwargs
+    assert call_kwargs["thinking"] == {"type": "adaptive"}
+    assert call_kwargs["output_config"] == {"effort": "low"}
+    assert "budget_tokens" not in str(call_kwargs["thinking"])
+
+
+def test_invalid_reasoning_value_falls_back_to_disabled():
+    fake = _fake_response()
+    with patch("app.services.llm_client._has_adc", return_value=True), \
+         patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with patch("anthropic.AnthropicVertex") as mock_client_cls:
+            mock_client_cls.return_value.messages.create.return_value = fake
+            generate_text_claude("x", reasoning="nonsense")
+    call_kwargs = mock_client_cls.return_value.messages.create.call_args.kwargs
+    assert call_kwargs["thinking"] == {"type": "disabled"}
+
+
+# ── 성공 경로 ────────────────────────────────────────────────────────────────
+
+def test_successful_generation_returns_text_and_uses_global_region():
+    fake = _fake_response(text="과거 2건 기준 저부담 문구 권장.")
+    with patch("app.services.llm_client._has_adc", return_value=True), \
+         patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with patch("anthropic.AnthropicVertex") as mock_client_cls:
+            mock_client_cls.return_value.messages.create.return_value = fake
+            result = generate_text_claude("x")
+    assert result == "과거 2건 기준 저부담 문구 권장."
+    init_kwargs = mock_client_cls.call_args.kwargs
+    assert init_kwargs["region"] == "global"
+
+
+def test_multiple_text_blocks_concatenated():
+    b1, b2 = MagicMock(type="text", text="첫 문장. "), MagicMock(type="text", text="둘째 문장.")
+    fake = _fake_response()
+    fake.content = [b1, b2]
+    with patch("app.services.llm_client._has_adc", return_value=True), \
+         patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with patch("anthropic.AnthropicVertex") as mock_client_cls:
+            mock_client_cls.return_value.messages.create.return_value = fake
+            result = generate_text_claude("x")
+    assert result == "첫 문장. 둘째 문장."
+
+
+# ── ⭐실패 재현(비-tautological) ───────────────────────────────────────────────
+
+def test_empty_response_text_returns_none():
+    fake = _fake_response(text="   ")
+    with patch("app.services.llm_client._has_adc", return_value=True), \
+         patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with patch("anthropic.AnthropicVertex") as mock_client_cls:
+            mock_client_cls.return_value.messages.create.return_value = fake
+            result = generate_text_claude("x")
+    assert result is None
+
+
+def test_sdk_exception_returns_none_not_raised():
+    """실측한 invalid_request_error 포함 — SDK가 예외를 던져도 예외 전파 없이 None."""
+    with patch("app.services.llm_client._has_adc", return_value=True), \
+         patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with patch("anthropic.AnthropicVertex") as mock_client_cls:
+            mock_client_cls.return_value.messages.create.side_effect = RuntimeError(
+                '"thinking.type.enabled" is not supported for this model'
+            )
+            result = generate_text_claude("x", reasoning="low")
+    assert result is None
+
+
+# ── 구조화 로깅(latency+token 실험 데이터) ───────────────────────────────────────
+
+def test_generation_logs_structured_latency_and_thinking_tokens(caplog):
+    fake = _fake_response(input_tokens=332, output_tokens=180, thinking_tokens=42)
+    with patch("app.services.llm_client._has_adc", return_value=True), \
+         patch.dict(os.environ, {}, clear=False), \
+         caplog.at_level(logging.INFO, logger="app.services.llm_client"):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with patch("anthropic.AnthropicVertex") as mock_client_cls:
+            mock_client_cls.return_value.messages.create.return_value = fake
+            generate_text_claude("x", reasoning="low")
+
+    records = [r for r in caplog.records if r.message == "llm generation (claude)"]
+    assert len(records) == 1
+    structured = records[0].structured
+    assert structured["model"] == CLAUDE_MODEL_VERSION
+    assert structured["reasoning"] == "low"
+    assert structured["input_tokens"] == 332
+    assert structured["output_tokens"] == 180
+    assert structured["thinking_tokens"] == 42
+    assert isinstance(structured["latency_ms"], float)
+
+
+# ── AC④ 임베딩/Gemini 경로 회귀0 — 독립 함수임을 구조적으로 증명 ───────────────────
+
+def test_claude_path_does_not_touch_gemini_generate_text():
+    """generate_text(Gemini)는 무변경 — Claude 함수 추가가 별도 함수/코드경로임을 증명."""
+    import app.services.llm_client as lc
+
+    assert lc.generate_text is not lc.generate_text_claude
+    assert lc.MODEL_VERSION == "gemini-2.5-flash"
+    assert lc.CLAUDE_MODEL_VERSION == "claude-sonnet-5"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -40,6 +40,30 @@ wheels = [
 ]
 
 [[package]]
+name = "anthropic"
+version = "0.115.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/e2/e27b1e70b1ddcda72362d6a26c9c699a46173d48a6c7ba966e8cc97a6c4d/anthropic-0.115.1.tar.gz", hash = "sha256:040287319abb909acf1cc49d83c0405dc0b1121ef257034b02c2b54151cf2446", size = 949185, upload-time = "2026-07-01T21:54:19.05Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/3c/501c58a8f8c68811079e218a25d8672fe4fb9a650a4655e499e24d9375e9/anthropic-0.115.1-py3-none-any.whl", hash = "sha256:685fa94964c1b9428f6a76e42d0dbae49aa2016f5ad386a96becac04c5e80ef9", size = 957006, upload-time = "2026-07-01T21:54:17.392Z" },
+]
+
+[package.optional-dependencies]
+vertex = [
+    { name = "google-auth", extra = ["requests"] },
+]
+
+[[package]]
 name = "anyio"
 version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -473,6 +497,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -847,6 +880,74 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a", size = 306943, upload-time = "2026-06-29T13:03:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9", size = 307779, upload-time = "2026-06-29T13:03:15.418Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/59bd309cab4460c54cf1079f3eb7fe7af6a4c895c5c957a53378693bad2b/jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72", size = 335826, upload-time = "2026-06-29T13:03:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/f5ef7b65f0df47afa16596969defb281ebb86e96df346d62be6fd853d620/jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e", size = 362573, upload-time = "2026-06-29T13:03:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0b/ace4354da061ee38844a0c27dc2c21eecd27aea119e8da324bea987522d0/jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290", size = 457979, upload-time = "2026-06-29T13:03:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/55/40/c0253d3772eb9dcd8e6606ee9b2d53ec8e5b814589c47f140aa585f21eaa/jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01", size = 372302, upload-time = "2026-06-29T13:03:21.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48", size = 343805, upload-time = "2026-06-29T13:03:23.384Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/e196888a05befdda7dbe299b722d56f2f6eec65402bc34c0a3306d595feb/jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9", size = 351107, upload-time = "2026-06-29T13:03:24.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/74/4cd9e0fca65232136400354b630fbfcd2de634e22ccbb96567725981b548/jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5", size = 388441, upload-time = "2026-06-29T13:03:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8c/554691e48bc711299c0a293dd8a6179e24b2d66a54dc295421fcf64569c0/jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730", size = 516354, upload-time = "2026-06-29T13:03:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cb/01e9d69dc2cc6759d4f91e230b34489c4fdb2518992650633f9e20bece89/jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f", size = 547880, upload-time = "2026-06-29T13:03:29.534Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/2953195f1c6ad00f49fa67e13df7e60acb3dd4f387101bc15abccddd905e/jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274", size = 203473, upload-time = "2026-06-29T13:03:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/05/2909a8b10699a4d560f8c502b6b2c5f3991b682b1922c1eedda242b225bd/jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7", size = 196905, upload-time = "2026-06-29T13:03:32.472Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a9/6b82bb1c8d7790d602489b967b982a909e5d092875a6c2ade96444c8dfc5/jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331", size = 190618, upload-time = "2026-06-29T13:03:34.672Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ab/664fd8c4be028b2bedd3d2ff08769c4ede23d0dbc87a77c62384a0515b5d/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127", size = 303106, upload-time = "2026-06-29T13:05:07.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
 ]
 
 [[package]]
@@ -1781,6 +1882,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "anthropic", extra = ["vertex"] },
     { name = "asyncpg" },
     { name = "boto3" },
     { name = "fastapi" },
@@ -1819,6 +1921,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.13.0" },
+    { name = "anthropic", extras = ["vertex"], specifier = ">=0.40.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "boto3", specifier = ">=1.34.0" },
     { name = "fastapi", specifier = ">=0.115.0" },


### PR DESCRIPTION
## Summary
- story `116e6fe8`(P1·선생님 dogfood 지적). AC①(모델 업그레이드) 착수분 — Claude(`claude-sonnet-5`, Vertex AI Model Garden)를 `llm_client.py::generate_text_claude()`로 신규 추가. `google-genai`(Gemini) 경로는 **완전 무변경**(별도 SDK `anthropic[vertex]`, ADC 인증 재사용 — 신규 크리덴셜 0).

## ⭐실측 확정 사항(2026-07-02)
- 로케이션은 반드시 `global`(리전 엔드포인트 429 quota — PO가 먼저 확인, 저도 rawPredict로 재확인).
- `claude-sonnet-5`는 구형 `thinking.type="enabled"+budget_tokens`를 지원 안 함(`invalid_request_error` 실측) — `thinking.type="adaptive"+output_config.effort`로만 reasoning 강도 제어 가능(`low`/`medium`/`high`/`xhigh`/`max`). `reasoning="disabled"`는 그대로 지원.

## 선생님 실험(reasoning=disabled vs low) — 라이브 결과
실 production 데이터(project `f3e6ed64` loop `5afaa3f7`의 context-pack, items=2)로 재구성한 **실제 synthesis/recommendation 프롬프트**를 rawPredict로 각 2회씩 호출:

| 케이스 | disabled(ms) | low/adaptive(ms) |
|---|---|---|
| synthesis | 3321.3, 3007.5 | 2987.5, 3220.4 |
| recommendation | 4819.9, 3421.0 | 3004.0, 3137.8 |

- **레이턴시**: 두 레벨이 거의 동일(3000~3400ms대) — low가 딱히 느리지 않음.
- ⭐**thinking_tokens=0**(4회 전부) — `low` effort에서도 이 프롬프트/데이터 규모(item 2건)엔 adaptive가 reasoning을 전혀 안 씀. disabled와 low가 이 워크로드에서 비용·속도 차이 사실상 0.
- **품질**: 두 레벨 출력이 거의 동일 톤 — 여전히 "C가 채택되고 B가 기각됐다는 공통 패턴...주관적 판단" 류로 결정 자체의 재진술에 가까움. **AC②가 지적한 순환성은 reasoning 레벨 문제가 아니라 프롬프트 설계 문제**라는 실측 근거 확보(AC②가 진짜 레버).

캐싱(AC④)·프롬프트 재설계(AC②)는 모델·레벨 확정 후 이어감(AC 명시 순서).

## Test plan
- [x] 신규 11 테스트: reasoning 파라미터 계약 고정(disabled/adaptive+effort 정확 매핑, 구형 budget_tokens 스킴 미전송 명시 확인)·성공/실패(빈응답·SDK예외) 경로·구조화 로깅(latency/token)·Gemini 경로 독립성 구조적 증명.
- [x] 기존 S25(20)·embedding_client 전부 회귀 0.
- [x] ruff 클린.

🤖 Generated with [Claude Code](https://claude.com/claude-code)