### PR TITLE
[SID:5f724d96] E-LOOP-LEDGER S24b — >4KB copy 전문 lazy-refetch 배선

### DIFF
--- a/apps/web/src/app/api/assets/[id]/text/route.ts
+++ b/apps/web/src/app/api/assets/[id]/text/route.ts
@@ -1,0 +1,15 @@
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// GET /api/assets/[id]/text → FastAPI GET /api/v2/assets/{id}/text ({ data: AssetTextResponse })
+// E-LOOP-LEDGER S24b — text_truncated(>4KB) 아티팩트의 "더보기" lazy refetch. 400(not-text)/
+// 404/503(storage 일시장애, BE가 명시 graceful) 전부 비-2xx passthrough → 클라이언트가 처리.
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await params;
+  if (!UUID_RE.test(id)) return ApiErrors.badRequest('invalid asset id');
+  const _r = await proxyToFastapi(request, `/api/v2/assets/${id}/text`);
+  if (!_r.ok) return _r;
+  return apiSuccess(await _r.json());
+}

--- a/apps/web/src/components/loops/artifact-preview.tsx
+++ b/apps/web/src/components/loops/artifact-preview.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { ImageOff, Loader2, Lock } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -78,11 +78,51 @@ function ImagePreview({ assetId, fallbackLabel }: { assetId: string; fallbackLab
   );
 }
 
-/** text/* 프리뷰 — text_content가 LoopArtifactResponse에 이미 실려오므로 fetch 없이 동기 렌더. */
-function TextPreview({ textContent, textTruncated }: { textContent: string; textTruncated: boolean }) {
+/**
+ * text/* 프리뷰 — text_content(≤4KB)가 LoopArtifactResponse에 이미 실려오므로 fetch 없이
+ * 동기 렌더이 기본. textTruncated(원본 >4KB)일 때만 "더보기"가 GET /api/assets/{id}/text로
+ * 전문을 lazy refetch(S24b fast-follow, 디디 endpoint) — <4KB(대다수)는 순수 클라이언트
+ * line-clamp 토글 그대로(회귀0). 실패(503 등)는 캡된 textContent를 유지한 채 재시도 affordance.
+ */
+function TextPreview({
+  assetId,
+  textContent,
+  textTruncated,
+}: {
+  assetId: string;
+  textContent: string;
+  textTruncated: boolean;
+}) {
   const t = useTranslations('storage');
   const [expanded, setExpanded] = useState(false);
+  const [fullText, setFullText] = useState<string | null>(null);
+  const [loadingFull, setLoadingFull] = useState(false);
+  const [fullTextError, setFullTextError] = useState(false);
   const isLong = textContent.length > SHORT_COPY_THRESHOLD;
+  const displayText = fullText ?? textContent;
+
+  const fetchFullText = useCallback(async () => {
+    setLoadingFull(true);
+    setFullTextError(false);
+    try {
+      const res = await fetch(`/api/assets/${assetId}/text`);
+      if (!res.ok) { setFullTextError(true); return; }
+      const { data } = (await res.json()) as { data?: { text_content?: string } };
+      if (!data?.text_content) { setFullTextError(true); return; }
+      setFullText(data.text_content);
+      setExpanded(true);
+    } catch {
+      setFullTextError(true);
+    } finally {
+      setLoadingFull(false);
+    }
+  }, [assetId]);
+
+  const handleToggle = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (textTruncated && fullText === null) { void fetchFullText(); return; }
+    setExpanded((v) => !v);
+  };
 
   return (
     <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 overflow-y-auto bg-muted/30 px-3 py-2 text-center">
@@ -92,18 +132,25 @@ function TextPreview({ textContent, textTruncated }: { textContent: string; text
           isLong && !expanded && 'line-clamp-3 text-[11.5px] font-normal',
         )}
       >
-        {textContent}
+        {displayText}
       </p>
       {isLong ? (
         <button
           type="button"
-          onClick={(e) => { e.stopPropagation(); setExpanded((v) => !v); }}
-          className="text-[10px] font-semibold text-primary hover:underline"
+          onClick={handleToggle}
+          disabled={loadingFull}
+          className="text-[10px] font-semibold text-primary hover:underline disabled:opacity-50"
         >
-          {expanded ? t('previewCollapse') : t('previewExpand')}
+          {loadingFull ? t('previewLoading') : expanded ? t('previewCollapse') : t('previewExpand')}
         </button>
       ) : null}
-      {textTruncated ? <span className="text-[9px] text-muted-foreground">{t('previewTruncatedNote')}</span> : null}
+      {fullTextError ? (
+        <button type="button" onClick={handleToggle} className="text-[9px] font-medium text-destructive hover:underline">
+          {t('errorDesc')} · {t('retry')}
+        </button>
+      ) : textTruncated && fullText === null ? (
+        <span className="text-[9px] text-muted-foreground">{t('previewTruncatedNote')}</span>
+      ) : null}
     </div>
   );
 }
@@ -131,7 +178,7 @@ function renderByContentType(
     return <ImagePreview assetId={assetId} fallbackLabel={fallbackLabel} />;
   }
   if (contentType.startsWith('text/') && textContent) {
-    return <TextPreview textContent={textContent} textTruncated={textTruncated} />;
+    return <TextPreview assetId={assetId} textContent={textContent} textTruncated={textTruncated} />;
   }
   // 기타 type(video 등) 또는 text/*인데 text_content 없음(null-safe 폴백) — label+chip.
   return <TypeChipFallback contentType={contentType} fallbackLabel={fallbackLabel} />;


### PR DESCRIPTION
## Summary
- S24에서 미룬 fast-follow: `text_truncated=true`(원본 >4KB)인 결정 UX 카드의 "더보기"가 `GET /api/assets/{id}/text`(디디 S24 BE endpoint, 이미 존재·503 graceful 처리됨)로 전문을 lazy refetch
- `<4KB`(대다수)는 기존 순수 클라이언트 line-clamp 토글 그대로 — 원본이 4KB를 넘을 때만 fetch 경로를 탐(회귀 0)
- 로딩 상태("불러오는 중...", 버튼 disabled) / 에러 상태(capped 미리보기 유지, 재시도 affordance) 추가
- BFF `/api/assets/[id]/text` 라우트 신설(기존 `/api/assets/[id]/route.ts`와 동일한 raw-passthrough+`{data}` wrap 패턴)

## Test plan
- [x] `tsc --noEmit` / `eslint` / `next build` 전부 EXIT 0
- [x] `vitest run` 전체 스위트 167 files / 1038 tests 전부 통과, 회귀 0
- [x] 격리 docker 스택(local storage provider) + 실 11.25KB 텍스트 파일 시딩 → 카드가 4KB 캡+line-clamp+"더보기"로 정상 렌더 → 클릭 시 실제 `GET /api/v2/assets/{id}/text` 라운드트립으로 전문(11.25KB) 정상 로드·표시
- [x] Service Worker로 `/api/assets/*/text`만 503 목킹 → 에러 상태(캡된 미리보기 유지+재시도 링크) 확인 → SW 해제 후 재시도 → 실제 성공 확인(idempotent)
- [x] 다크모드(성공/에러 상태 둘 다) 확인, 크래시 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)