### PR TITLE
feat(e-loop-ledger): S28 — Claude 배선 + 순환성 프롬프트 재설계 + 캐싱

### DIFF
--- a/backend/alembic/versions/0153_loop_runs_context_pack_cache.py
+++ b/backend/alembic/versions/0153_loop_runs_context_pack_cache.py
@@ -1,0 +1,40 @@
+"""E-LOOP-LEDGER S28(story 116e6fe8) AC④: loop_runs.context_pack_* — synthesis/recommendation 캐싱.
+
+additive·nullable(백필 불요 — 기존 loop은 캐시 미스로 시작, 다음 GET에서 자연 채워짐). gen-LLM
+(Claude, 비용 높음) 호출을 "같은 입력=1회만"으로 줄이기 위한 content-hash 캐시 — 회수 items
++loop 맥락+모델/프롬프트 버전이 전부 같을 때만 캐시 hit(app/services/context_pack_items.py 참고).
+
+*_confidence 컬럼(유나 BE↔FE 계약, 2026-07-02): LLM이 산출한 confidence 마커(high/medium/low)를
+캐시와 함께 보관 — 캐시 hit 시에도 confidence 배지가 그대로 재현되어야 하므로 텍스트와 동일
+생명주기로 저장.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0153"
+down_revision = "0152"
+branch_labels = None
+depends_on = None
+
+_COLUMNS = [
+    ("context_pack_cache_key", sa.String(length=64)),
+    ("context_pack_synthesis", sa.Text()),
+    ("context_pack_synthesis_confidence", sa.String(length=16)),
+    ("context_pack_recommendation", sa.Text()),
+    ("context_pack_recommendation_confidence", sa.String(length=16)),
+    ("context_pack_cached_at", sa.DateTime(timezone=True)),
+]
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    cols = {c["name"] for c in insp.get_columns("loop_runs")}
+    for name, col_type in _COLUMNS:
+        if name not in cols:
+            op.add_column("loop_runs", sa.Column(name, col_type, nullable=True))
+
+
+def downgrade() -> None:
+    for name, _ in reversed(_COLUMNS):
+        op.drop_column("loop_runs", name)

--- a/backend/app/models/loop.py
+++ b/backend/app/models/loop.py
@@ -109,6 +109,16 @@ class LoopRun(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     # FK 비강제(hypotheses.owner_member_id/assignee_id 동형 컨벤션) — resolve_member 서비스 해소.
     created_by_member_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
 
+    # S28(story 116e6fe8) AC④: Context Pack synthesis/recommendation content-hash 캐시(gen-LLM
+    # 재호출 방지 — "같은 입력=1회만"). cache_key가 최신 회수 items+loop 맥락+모델/프롬프트
+    # 버전 해시와 일치할 때만 재사용(app/services/context_pack_items.py::_compute_cache_key).
+    context_pack_cache_key: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    context_pack_synthesis: Mapped[str | None] = mapped_column(Text, nullable=True)
+    context_pack_synthesis_confidence: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    context_pack_recommendation: Mapped[str | None] = mapped_column(Text, nullable=True)
+    context_pack_recommendation_confidence: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    context_pack_cached_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
     __table_args__ = (
         CheckConstraint(
             "status IN ('draft','briefing','generating','deciding','executing',"

--- a/backend/app/schemas/context_pack.py
+++ b/backend/app/schemas/context_pack.py
@@ -55,8 +55,15 @@ class ContextPackResponse(BaseModel):
 
     S27: recommendation(L3 능동 추천, str|None) 추가 — synthesis(L2)+새 loop의 goal/hypothesis를
     gen-LLM으로 처방. synthesis가 null이면(근거 자체가 없음) recommendation도 항상 null(L1/L2
-    무손상 — 과잉 처방 금지)."""
+    무손상 — 과잉 처방 금지).
+
+    S28(유나 BE↔FE 계약, 2026-07-02): *_confidence("high"|"medium"|"low"|None)는 LLM이 산출한
+    확신도를 구조화 필드로 노출(텍스트 hedge와 별개 — FE 배지 렌더용). evidence_count는
+    items 수로 결정론적 산출(LLM 산출물 아님) — "과거 N건 기준" FE 표시 소스."""
     items: list[ContextPackItem]
     embed_available: bool
     synthesis: str | None = None
+    synthesis_confidence: str | None = None
     recommendation: str | None = None
+    recommendation_confidence: str | None = None
+    evidence_count: int = 0

--- a/backend/app/services/context_pack_items.py
+++ b/backend/app/services/context_pack_items.py
@@ -26,8 +26,12 @@ href(미르코 FE 라우트 실측 반영, 2026-07-02): loop→/loops/{id}·deci
 """
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
+import re
 import uuid
+from datetime import datetime, timezone
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -77,11 +81,85 @@ async def build_loop_context_pack(
 
     # search_similar_embeddings는 cosine 거리 ASC(=similarity DESC)로 이미 정렬 — crux ①과 정합.
     items = await _build_items(session, org_id, results)
-    synthesis = _synthesize_learnings(items)
-    recommendation = await _recommend_next_step(session, org_id, loop, synthesis, len(items))
+    if not items:
+        # 학습 근거 0건 — 종합/추천 시도 자체가 무의미(과잉 처방 방지, S26/S27 원칙). 캐시도 무관.
+        return ContextPackResponse(items=items, embed_available=True, evidence_count=0)
+
+    # evidence_count(유나 계약, 2026-07-02): items 수로 결정론적 산출 — LLM 산출물 아님.
+    evidence_count = len(items)
+    hyp_statement = await _load_loop_hypothesis_statement(session, org_id, loop)
+    cache_key = _compute_cache_key(items, loop, hyp_statement)
+
+    if loop.context_pack_cache_key == cache_key:
+        # S28 AC④ — 회수 items+새 loop 맥락+모델/프롬프트 버전이 전부 이전과 동일 → gen-LLM
+        # (Claude, 비용 높음) 재호출 없이 캐시 재사용("같은 입력=1회만 호출").
+        synthesis = loop.context_pack_synthesis
+        synthesis_confidence = loop.context_pack_synthesis_confidence
+        recommendation = loop.context_pack_recommendation
+        recommendation_confidence = loop.context_pack_recommendation_confidence
+    else:
+        synthesis, synthesis_confidence = _synthesize_learnings(items)
+        recommendation, recommendation_confidence = _recommend_next_step(
+            loop.title, hyp_statement, synthesis, evidence_count,
+        )
+        if synthesis is not None:
+            # gen-LLM 미가용/실패(synthesis=None)면 캐시에 기록하지 않는다 — 일시적 장애를
+            # 영구 캐시된 "결과 없음"으로 굳히면 안 됨(다음 요청이 다시 시도하게 둔다).
+            from app.repositories.loop import LoopRunRepository
+
+            await LoopRunRepository(session, org_id).update(
+                loop.id,
+                context_pack_cache_key=cache_key,
+                context_pack_synthesis=synthesis,
+                context_pack_synthesis_confidence=synthesis_confidence,
+                context_pack_recommendation=recommendation,
+                context_pack_recommendation_confidence=recommendation_confidence,
+                context_pack_cached_at=datetime.now(timezone.utc),
+            )
+
     return ContextPackResponse(
-        items=items, embed_available=True, synthesis=synthesis, recommendation=recommendation,
+        items=items, embed_available=True,
+        synthesis=synthesis, synthesis_confidence=synthesis_confidence,
+        recommendation=recommendation, recommendation_confidence=recommendation_confidence,
+        evidence_count=evidence_count,
     )
+
+
+async def _load_loop_hypothesis_statement(
+    session: AsyncSession, org_id: uuid.UUID, loop: LoopRun,
+) -> str | None:
+    if loop.hypothesis_id is None:
+        return None
+    return (await session.execute(
+        select(Hypothesis.statement).where(
+            Hypothesis.id == loop.hypothesis_id, Hypothesis.org_id == org_id
+        )
+    )).scalar_one_or_none()
+
+
+def _compute_cache_key(items: list[ContextPackItem], loop: LoopRun, hyp_statement: str | None) -> str:
+    """S28 AC④ — 회수 items(결정/성과)+새 loop 맥락+모델/프롬프트 버전이 전부 같을 때만 캐시
+    hit. 선례 결정/성과가 바뀌거나(예: pending→chosen, 새 outcome 확정) 모델/프롬프트를
+    바꾸면 입력 해시가 달라져 자동 무효화된다(별도 invalidation 로직 불요)."""
+    from app.services.llm_client import CLAUDE_MODEL_VERSION
+
+    payload = {
+        "items": [
+            {
+                "entity_type": it.entity_type, "entity_id": str(it.entity_id), "goal": it.goal,
+                "decision": it.decision.model_dump() if it.decision else None,
+                "outcome": it.outcome.model_dump() if it.outcome else None,
+            }
+            for it in items
+        ],
+        "loop_title": loop.title,
+        "hypothesis_statement": hyp_statement,
+        "model": CLAUDE_MODEL_VERSION,
+        "synthesis_prompt_version": _SYNTHESIS_PROMPT_VERSION,
+        "recommendation_prompt_version": _RECOMMENDATION_PROMPT_VERSION,
+    }
+    raw = json.dumps(payload, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
 async def _build_items(session: AsyncSession, org_id: uuid.UUID, results: list) -> list[ContextPackItem]:
@@ -200,12 +278,57 @@ def _build_outcome(hyp: Hypothesis | None) -> ContextPackOutcome | None:
     )
 
 
-# ── S26: L2 학습 종합(회수 items→증류) ────────────────────────────────────────
+# ── S28: confidence 마커 파싱(유나 BE↔FE 계약, 2026-07-02) ─────────────────────
 
+_CONFIDENCE_LEVELS = frozenset({"high", "medium", "low"})
+# 대소문자 무관·줄 앞뒤 공백 허용·행 전체가 이 마커여야(본문 문장 중간의 우연한 일치 방지).
+_CONFIDENCE_LINE_RE = re.compile(r"(?im)^\s*confidence:\s*(high|medium|low)\s*$")
+
+
+def _extract_confidence(text: str) -> tuple[str, str | None]:
+    """마지막 줄의 'confidence: high|medium|low' 마커를 본문에서 떼어내 구조화 필드로 뽑는다
+    (텍스트 hedge "패턴 불명확 N건 부족"과 별개로 FE가 배지 렌더용 구조화 신호를 갖게 함).
+    마커가 없거나 형식이 어긋나면 (원문 그대로, None) — 파싱 실패가 synthesis 자체를
+    깨면 안 된다(non-fatal, 텍스트 표시는 항상 보장)."""
+    match = _CONFIDENCE_LINE_RE.search(text)
+    if match is None:
+        return text.strip(), None
+    confidence = match.group(1).lower()
+    cleaned = _CONFIDENCE_LINE_RE.sub("", text, count=1).strip()
+    return cleaned, confidence
+
+
+# ── S26/S28: L2 학습 종합(회수 items→증류) ─────────────────────────────────────
+
+# S28: 프롬프트 텍스트를 바꿀 때마다 버전을 올린다 — 캐시 키에 들어가 구 버전 캐시를
+# 자동 무효화한다(_compute_cache_key).
+_SYNTHESIS_PROMPT_VERSION = "v2"
+
+# S28(선생님 dogfood 지적+PO crux): v1은 "요약해라"만 요구해 결정 재진술("C 채택, B 기각")에
+# 그쳐 순환적·비-actionable이었다(까심/유나가 실 라이브 출력으로 확인). v2 근본 재설계:
+# ①재진술 명시 금지 ②outcome(성과 FACT)을 결정-이유(주관적 서술)보다 우선 근거로 삼도록 강제
+# — 이게 순환성의 진짜 해독제(PO crux 핵심: outcome은 재진술이 아니라 사실) ③구조 강제(패턴·
+# 다음행동·회피·리스크)로 최소한 "무엇을 해야 하는지"까지 나오게 ④정직한 hedge("패턴
+# 불명확") 유지 ⑤환각 방지(items 밖 사실 금지)는 v1 그대로 유지.
 _SYNTHESIS_INSTRUCTION = (
-    "다음은 유사한 과거 실행(loop/가설)들의 실제 기록이다. 아래 데이터에 명시된 사실만 근거로 "
-    "공통 패턴이나 성공/실패 요인을 한국어 2~3문장으로 요약하라. 데이터에 없는 내용은 절대 "
-    "추정하거나 새로 만들어내지 마라 — 각 항목의 목표/채택·기각 이유/성과만 사용한다."
+    "다음은 유사한 과거 실행(loop/가설)들의 실제 기록이다. 이 데이터를 분석해 다음 실행에 "
+    "실질적으로 도움이 되는 통찰을 한국어로 작성하라.\n\n"
+    "금지: \"X가 채택되고 Y가 기각됐다\" 같은 단순 재진술은 절대 하지 마라 — 이미 알고 있는 "
+    "사실이다. 왜 그런 선택이 반복됐는지 한 단계 더 깊이 파고들어라.\n\n"
+    "성과(outcome) 우선 원칙: 성과 데이터(hit/miss·수치)가 있으면 그것을 최우선 근거로 삼아라 "
+    "— 무엇이 실제로 효과가 있었는지가 가장 강한 신호다. 성과가 없으면 결정 이유만으로 신중히 "
+    "판단하고 그 불확실성을 명시하라.\n\n"
+    "다음 구조로 답하라(각 항목 1문장, 데이터에 명시된 사실만 근거로):\n"
+    "- 패턴: 표면적 선택이 아니라 그 이면의 원리(비-obvious). 근거 부족하면 \"패턴 불명확(N건 "
+    "부족)\"이라고 정직하게 표시.\n"
+    "- 다음 행동: 다음 실행에서 시도해볼 만한 것 1가지(제안형으로 — 단정적 지시 아님).\n"
+    "- 회피: 반복하지 않는 게 좋아 보이는 것 1가지.\n"
+    "- 리스크: 이 결론의 불확실성/예외 가능성 1가지.\n\n"
+    "데이터에 없는 사실을 추정하거나 새로 만들어내지 마라.\n\n"
+    "마지막 줄에 정확히 다음 형식으로 확신도를 표시하라(그 외 텍스트 없이 이 형식 그대로):\n"
+    "confidence: high|medium|low\n"
+    "(성과 데이터가 있고 패턴이 명확하면 high, 결정 이유만 있고 사례가 적으면 low, 그 사이면 "
+    "medium — 데이터 근거 강도에 정직하게 맞춰라.)"
 )
 
 
@@ -233,29 +356,52 @@ def _build_synthesis_prompt(items: list[ContextPackItem]) -> str:
     return "\n".join(lines)
 
 
-def _synthesize_learnings(items: list[ContextPackItem]) -> str | None:
-    """S26 AC②③: items 0건이면 종합할 근거가 없으므로 즉시 None(LLM 호출 자체를 안 함).
-    gen-LLM(S25) 미가용/실패 시에도 None — build_loop_context_pack이 이미 조립한 items(L1)는
-    이 함수와 무관하게 그대로 반환되므로 패널은 퇴화 없이 raw 목록만 보여준다."""
-    if not items:
-        return None
-    try:
-        from app.services.llm_client import generate_text
+def _synthesize_learnings(items: list[ContextPackItem]) -> tuple[str | None, str | None]:
+    """S26 AC②③: items 0건이면 종합할 근거가 없으므로 즉시 (None, None)(LLM 호출 자체를 안
+    함). gen-LLM 미가용/실패 시에도 (None, None) — build_loop_context_pack이 이미 조립한
+    items(L1)는 이 함수와 무관하게 그대로 반환되므로 패널은 퇴화 없이 raw 목록만 보여준다.
 
-        return generate_text(_build_synthesis_prompt(items))
+    S28: Gemini(generate_text)→Claude(generate_text_claude, reasoning="disabled")로 전환.
+    실측(2026-07-02): 이 프롬프트 규모(item 수 적음)엔 disabled와 low(adaptive) 레이턴시/
+    thinking_tokens 차이가 사실상 0이라 비용 낮은 disabled 채택(선생님 결).
+
+    반환 = (synthesis 본문, confidence). confidence 마커 파싱 실패해도 본문은 항상 보존."""
+    if not items:
+        return None, None
+    try:
+        from app.services.llm_client import generate_text_claude
+
+        raw = generate_text_claude(_build_synthesis_prompt(items), reasoning="disabled")
+        if raw is None:
+            return None, None
+        return _extract_confidence(raw)
     except Exception as exc:
         logger.warning("context-pack synthesis 실패(생략 처리): %s", exc)
-        return None
+        return None, None
 
 
-# ── S27: L3 능동 추천(synthesis+새 loop goal/hypothesis→처방) ────────────────────
+# ── S27/S28: L3 능동 추천(synthesis+새 loop goal/hypothesis→처방) ─────────────────
 
+_RECOMMENDATION_PROMPT_VERSION = "v2"
+
+# S28(PO crux): v1은 순환성이 덜했지만(이미 "제안" 형태) outcome 우선 원칙+제안형 톤(유나
+# voice 계약 LOCK — "돕되 대체 안 함")을 명시로 강화. synthesis가 이미 v2 구조(패턴/다음행동/
+# 회피/리스크)라 이 프롬프트는 그걸 새 loop에 적용하는 역할.
 _RECOMMENDATION_INSTRUCTION = (
-    "다음은 새로 시작하는 loop의 목표와, 과거 유사 실행들에서 이미 종합된 학습 요약이다. 이 "
-    "학습 요약이 새 loop에 실질적으로 도움이 되는 구체적 제안을 한국어 1~2문장으로 하라. 요약 "
-    "밖의 사실을 추정하거나 새로 만들어내지 마라. 근거(과거 사례 수)가 적거나 애매하면 "
+    "다음은 새로 시작하는 loop의 목표와, 과거 유사 실행들에서 이미 종합된 학습(패턴·다음행동·"
+    "회피·리스크)이다. 이 학습을 이 새 loop에 구체적으로 적용할 제안을 한국어 1~2문장으로 "
+    "작성하라.\n\n"
+    "성과(outcome) 우선: 학습 요약에 성과 데이터가 반영돼 있으면 그것을 최우선 근거로 삼아라 "
+    "— 결과가 확인된 것이 가장 강한 신호다.\n\n"
+    "톤: 단정적 지시가 아니라 제안형으로(\"~해보는 게 좋아 보입니다\", \"~을 고려해볼 만합니다\" "
+    "등) — 최종 판단은 사람의 몫이다.\n\n"
+    "요약 밖의 사실을 추정하거나 새로 만들어내지 마라. 근거(과거 사례 수)가 적거나 애매하면 "
     "단정적으로 처방하지 말고 '과거 N건 기준' 같은 정직한 hedge를 반드시 포함해 신중하게 "
-    "제안하라."
+    "제안하라.\n\n"
+    "마지막 줄에 정확히 다음 형식으로 확신도를 표시하라(그 외 텍스트 없이 이 형식 그대로):\n"
+    "confidence: high|medium|low\n"
+    "(성과 기반 근거가 있고 사례가 여럿이면 high, 결정 이유만 있고 사례가 적으면 low, 그 "
+    "사이면 medium — 데이터 근거 강도에 정직하게 맞춰라.)"
 )
 
 
@@ -283,25 +429,25 @@ def _build_recommendation_prompt(
     return "\n".join(lines)
 
 
-async def _recommend_next_step(
-    session: AsyncSession, org_id: uuid.UUID, loop: LoopRun, synthesis: str | None, item_count: int,
-) -> str | None:
+def _recommend_next_step(
+    new_goal: str, new_hypothesis: str | None, synthesis: str | None, item_count: int,
+) -> tuple[str | None, str | None]:
     """S27 AC①③: synthesis가 없으면(L2 자체가 근거 부족으로 실패/생략) 추천을 아예 시도하지
-    않는다 — 종합도 없이 처방하는 것은 과잉(과신) 처방이라 원천 차단."""
-    if synthesis is None:
-        return None
-    hyp_statement: str | None = None
-    if loop.hypothesis_id is not None:
-        hyp_statement = (await session.execute(
-            select(Hypothesis.statement).where(
-                Hypothesis.id == loop.hypothesis_id, Hypothesis.org_id == org_id
-            )
-        )).scalar_one_or_none()
-    try:
-        from app.services.llm_client import generate_text
+    않는다 — 종합도 없이 처방하는 것은 과잉(과신) 처방이라 원천 차단.
 
-        prompt = _build_recommendation_prompt(loop.title, hyp_statement, synthesis, item_count)
-        return generate_text(prompt)
+    S28: hyp_statement를 build_loop_context_pack이 미리 로드해 넘겨주므로 session/org_id/
+    loop 의존 없는 순수 함수로 단순화(중복 조회 제거) + Claude(disabled) 전환 + confidence
+    파싱. 반환 = (recommendation 본문, confidence)."""
+    if synthesis is None:
+        return None, None
+    try:
+        from app.services.llm_client import generate_text_claude
+
+        prompt = _build_recommendation_prompt(new_goal, new_hypothesis, synthesis, item_count)
+        raw = generate_text_claude(prompt, reasoning="disabled")
+        if raw is None:
+            return None, None
+        return _extract_confidence(raw)
     except Exception as exc:
         logger.warning("context-pack recommendation 실패(생략 처리): %s", exc)
-        return None
+        return None, None

--- a/backend/app/services/context_pack_items.py
+++ b/backend/app/services/context_pack_items.py
@@ -102,9 +102,12 @@ async def build_loop_context_pack(
         recommendation, recommendation_confidence = _recommend_next_step(
             loop.title, hyp_statement, synthesis, evidence_count,
         )
-        if synthesis is not None:
-            # gen-LLM 미가용/실패(synthesis=None)면 캐시에 기록하지 않는다 — 일시적 장애를
-            # 영구 캐시된 "결과 없음"으로 굳히면 안 됨(다음 요청이 다시 시도하게 둔다).
+        if synthesis is not None and recommendation is not None:
+            # 까심 QA RC(2026-07-02): synthesis만 검사하면 recommendation의 일시적 장애(quota/
+            # timeout)가 recommendation=None으로 영구 캐시된다 — 입력이 안 바뀌는 한 gen-LLM이
+            # 복구돼도 캐시히트로 재시도 자체가 막힌다. 둘 다 성공했을 때만 캐시(둘 중 하나라도
+            # 실패하면 매 요청 재시도 — "일시적 장애를 영구 결과없음으로 굳히지 않는다" 원칙을
+            # synthesis/recommendation 양쪽에 동일 적용).
             from app.repositories.loop import LoopRunRepository
 
             await LoopRunRepository(session, org_id).update(

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -420,9 +420,12 @@ def _draft_statement(context: dict | None) -> tuple[str, bool]:
     prompt = _build_draft_prompt(context)
     if prompt is not None:
         try:
-            from app.services.llm_client import generate_text
+            # S28: Gemini(generate_text)→Claude(generate_text_claude, reasoning="disabled")로
+            # 전환(synthesis/recommendation과 동일 모델 배선). 단문 statement 생성이라 순환성
+            # 문제 자체가 없어 프롬프트 재설계는 대상 밖(PO 확인, 2026-07-02).
+            from app.services.llm_client import generate_text_claude
 
-            generated = generate_text(prompt)
+            generated = generate_text_claude(prompt, reasoning="disabled")
             if generated and generated.strip():
                 return generated.strip(), True
         except Exception as exc:

--- a/backend/tests/test_e_loop_ledger_p1_s12_context_pack_items.py
+++ b/backend/tests/test_e_loop_ledger_p1_s12_context_pack_items.py
@@ -22,6 +22,9 @@ def _loop_obj(loop_id=None, title="타깃 loop", goal_tags=None):
     return SimpleNamespace(
         id=loop_id or uuid.uuid4(), title=title, goal_tags=goal_tags or [],
         project_id=uuid.uuid4(), org_id=uuid.uuid4(),
+        # S28: hypothesis_id(캐시키/추천 컨텍스트)+context_pack_cache_key(캐시 히트 판정)를
+        # build_loop_context_pack이 무조건 읽는다 — None이면 캐시-미스 경로(정상)로 흐른다.
+        hypothesis_id=None, context_pack_cache_key=None,
     )
 
 
@@ -79,7 +82,8 @@ async def test_hypothesis_item_maps_goal_and_outcome_no_decision():
     hyp_result.scalars.return_value.all.return_value = [hyp]
     session.execute = AsyncMock(return_value=hyp_result)
 
-    with patch("app.services.embedding_client.embed_text", return_value=[0.1] * 768):
+    with patch("app.services.llm_client.generate_text_claude", return_value=None), \
+         patch("app.services.embedding_client.embed_text", return_value=[0.1] * 768):
         with patch(
             "app.services.context_pack_search.search_similar_embeddings",
             new=AsyncMock(return_value=[result]),
@@ -134,7 +138,8 @@ async def test_loop_item_gets_decision_and_indirect_outcome():
     artifact_res = MagicMock(); artifact_res.scalars.return_value.all.return_value = [chosen, rejected]
     session.execute = AsyncMock(side_effect=[loop_res, hyp_res, artifact_res])
 
-    with patch("app.services.embedding_client.embed_text", return_value=[0.1] * 768):
+    with patch("app.services.llm_client.generate_text_claude", return_value=None), \
+         patch("app.services.embedding_client.embed_text", return_value=[0.1] * 768):
         with patch(
             "app.services.context_pack_search.search_similar_embeddings",
             new=AsyncMock(return_value=[result]),
@@ -161,7 +166,8 @@ async def test_loop_artifact_item_maps_to_decision_entity_type_no_decision_block
     artifact_res = MagicMock(); artifact_res.scalars.return_value.all.return_value = [artifact]
     session.execute = AsyncMock(return_value=artifact_res)
 
-    with patch("app.services.embedding_client.embed_text", return_value=[0.1] * 768):
+    with patch("app.services.llm_client.generate_text_claude", return_value=None), \
+         patch("app.services.embedding_client.embed_text", return_value=[0.1] * 768):
         with patch(
             "app.services.context_pack_search.search_similar_embeddings",
             new=AsyncMock(return_value=[result]),
@@ -188,7 +194,8 @@ async def test_input_order_from_search_preserved_similarity_desc():
     artifact_res = MagicMock(); artifact_res.scalars.return_value.all.return_value = [a1, a2]
     session.execute = AsyncMock(return_value=artifact_res)
 
-    with patch("app.services.embedding_client.embed_text", return_value=[0.1] * 768):
+    with patch("app.services.llm_client.generate_text_claude", return_value=None), \
+         patch("app.services.embedding_client.embed_text", return_value=[0.1] * 768):
         with patch(
             "app.services.context_pack_search.search_similar_embeddings",
             new=AsyncMock(return_value=[r1, r2]),  # 이미 desc 정렬된 입력.
@@ -271,7 +278,8 @@ async def test_decided_loop_included_with_non_null_chosen():
     artifact_res = MagicMock(); artifact_res.scalars.return_value.all.return_value = [chosen]
     session.execute = AsyncMock(side_effect=[loop_res, artifact_res])
 
-    with patch("app.services.embedding_client.embed_text", return_value=[0.1] * 768):
+    with patch("app.services.llm_client.generate_text_claude", return_value=None), \
+         patch("app.services.embedding_client.embed_text", return_value=[0.1] * 768):
         with patch(
             "app.services.context_pack_search.search_similar_embeddings",
             new=AsyncMock(return_value=[result]),

--- a/backend/tests/test_e_loop_ledger_s15_hypothesis_llm_draft.py
+++ b/backend/tests/test_e_loop_ledger_s15_hypothesis_llm_draft.py
@@ -74,7 +74,7 @@ def test_build_draft_prompt_instructs_no_fabrication_and_single_sentence():
 # ── ⓐⓒ _draft_statement — LLM 시도/graceful fallback ───────────────────────────
 
 def test_no_context_falls_back_to_template_without_calling_llm():
-    with patch("app.services.llm_client.generate_text") as mock_gen:
+    with patch("app.services.llm_client.generate_text_claude") as mock_gen:
         statement, llm_generated = _draft_statement(None)
     mock_gen.assert_not_called()
     assert llm_generated is False
@@ -82,7 +82,7 @@ def test_no_context_falls_back_to_template_without_calling_llm():
 
 
 def test_llm_success_returns_generated_statement():
-    with patch("app.services.llm_client.generate_text", return_value="실행하면 활성화율이 오를 것이다.") as mock_gen:
+    with patch("app.services.llm_client.generate_text_claude", return_value="실행하면 활성화율이 오를 것이다.") as mock_gen:
         statement, llm_generated = _draft_statement({"title": "온보딩 개선"})
     mock_gen.assert_called_once()
     assert statement == "실행하면 활성화율이 오를 것이다."
@@ -92,14 +92,14 @@ def test_llm_success_returns_generated_statement():
 
 
 def test_llm_unavailable_falls_back_to_template():
-    with patch("app.services.llm_client.generate_text", return_value=None):
+    with patch("app.services.llm_client.generate_text_claude", return_value=None):
         statement, llm_generated = _draft_statement({"title": "온보딩 개선"})
     assert llm_generated is False
     assert statement == _template_statement({"title": "온보딩 개선"})
 
 
 def test_llm_exception_falls_back_to_template_not_raised():
-    with patch("app.services.llm_client.generate_text", side_effect=RuntimeError("boom")):
+    with patch("app.services.llm_client.generate_text_claude", side_effect=RuntimeError("boom")):
         statement, llm_generated = _draft_statement({"title": "온보딩 개선"})
     assert llm_generated is False
     assert statement == _template_statement({"title": "온보딩 개선"})
@@ -107,7 +107,7 @@ def test_llm_exception_falls_back_to_template_not_raised():
 
 def test_llm_blank_response_falls_back_to_template():
     """빈/공백 응답을 그대로 statement로 쓰지 않고 템플릿으로 대체(안전 필터 차단 등 대비)."""
-    with patch("app.services.llm_client.generate_text", return_value="   "):
+    with patch("app.services.llm_client.generate_text_claude", return_value="   "):
         statement, llm_generated = _draft_statement({"title": "온보딩 개선"})
     assert llm_generated is False
     assert statement == _template_statement({"title": "온보딩 개선"})
@@ -168,7 +168,7 @@ async def test_draft_persist_llm_success_records_llm_generation_method():
     )
     with patch.object(svc, "HypothesisRepository", return_value=repo), \
          patch.object(svc, "lookup_members_by_ids", AsyncMock(return_value=_members_lookup())), \
-         patch("app.services.llm_client.generate_text", return_value="실행하면 활성화율이 오를 것이다."):
+         patch("app.services.llm_client.generate_text_claude", return_value="실행하면 활성화율이 오를 것이다."):
         out = await svc.draft_hypothesis(_empty_session(), ORG_ID, _caller(), payload)
 
     assert out.statement == "실행하면 활성화율이 오를 것이다."
@@ -186,7 +186,7 @@ async def test_draft_persist_llm_unavailable_records_template_generation_method(
     )
     with patch.object(svc, "HypothesisRepository", return_value=repo), \
          patch.object(svc, "lookup_members_by_ids", AsyncMock(return_value=_members_lookup())), \
-         patch("app.services.llm_client.generate_text", return_value=None):
+         patch("app.services.llm_client.generate_text_claude", return_value=None):
         out = await svc.draft_hypothesis(_empty_session(), ORG_ID, _caller(), payload)
 
     assert out.statement == _template_statement({"title": "온보딩 개선"})
@@ -201,7 +201,7 @@ async def test_draft_no_persist_still_drafts_statement_without_creating_row():
         project_id=PROJECT_ID, source_type="epic", source_id=uuid.uuid4(),
         persist=False, context={"title": "온보딩 개선"},
     )
-    with patch("app.services.llm_client.generate_text", return_value="실행하면 활성화율이 오를 것이다.") as mock_gen:
+    with patch("app.services.llm_client.generate_text_claude", return_value="실행하면 활성화율이 오를 것이다.") as mock_gen:
         out = await svc.draft_hypothesis(_empty_session(), ORG_ID, _caller(), payload)
     mock_gen.assert_called_once()
     assert out.statement == "실행하면 활성화율이 오를 것이다."

--- a/backend/tests/test_e_loop_ledger_s16_hypothesis_draft_loop_goal.py
+++ b/backend/tests/test_e_loop_ledger_s16_hypothesis_draft_loop_goal.py
@@ -105,7 +105,7 @@ async def test_draft_persist_loop_goal_creates_row_with_null_source_id_and_empty
     )
     with patch.object(svc, "HypothesisRepository", return_value=repo), \
          patch.object(svc, "lookup_members_by_ids", AsyncMock(return_value={CALLER_ID: _caller()})), \
-         patch("app.services.llm_client.generate_text", return_value="가입 전환율을 개선하는 실험."):
+         patch("app.services.llm_client.generate_text_claude", return_value="가입 전환율을 개선하는 실험."):
         out = await svc.draft_hypothesis(None, ORG_ID, _caller(), payload)
 
     assert out.statement == "가입 전환율을 개선하는 실험."

--- a/backend/tests/test_e_loop_ledger_s26_context_pack_synthesis.py
+++ b/backend/tests/test_e_loop_ledger_s26_context_pack_synthesis.py
@@ -1,11 +1,14 @@
 """E-LOOP-LEDGER S26(story df8dca69·P2·L2): Context Pack 학습 종합(회수 items→증류) 검증.
 
+S28(선생님 dogfood 지적) 이후 갱신: Gemini→Claude(disabled) 전환·프롬프트 v2(순환 재진술
+금지+outcome 우선+구조화)·confidence 마커 파싱 추가. 이 파일은 그 갱신 반영판.
+
 핵심(비-tautological):
 ⓐ ⭐환각 방지 — 프롬프트가 items 필드만 나열(items 밖 지식 주입 0)함을 프롬프트 텍스트로 직접
-   확인·items=0건이면 generate_text 자체를 호출 안 함(spy로 call_count==0 직접 증명 — 까심
-   S24 RC에서 지적한 "fake path 우연일치" tautological 위험을 피해 처음부터 spy로 작성).
-ⓑ graceful degrade — gen-LLM(S25) None/예외 시 synthesis=None이지만 items(L1)는 그대로.
-ⓒ realdb round-trip — build_loop_context_pack이 synthesis를 실제로 채워 반환.
+   확인·items=0건이면 generate_text_claude 자체를 호출 안 함(spy로 call_count==0 직접 증명).
+ⓑ graceful degrade — gen-LLM None/예외 시 (None, None)이지만 items(L1)는 그대로.
+ⓒ realdb round-trip — build_loop_context_pack이 synthesis/confidence/evidence_count를
+   실제로 채워 반환.
 
 DB env(PARITY_TEST_DATABASE_URL/ALEMBIC_DATABASE_URL) 없으면 realdb 파트 skip.
 """
@@ -24,7 +27,11 @@ from app.schemas.context_pack import (
     ContextPackItem,
     ContextPackOutcome,
 )
-from app.services.context_pack_items import _build_synthesis_prompt, _synthesize_learnings
+from app.services.context_pack_items import (
+    _build_synthesis_prompt,
+    _extract_confidence,
+    _synthesize_learnings,
+)
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
@@ -57,7 +64,6 @@ def test_synthesis_prompt_contains_only_item_fields_no_external_facts():
     assert "A안" in prompt and "저부담 문구가 클릭률을 높인다" in prompt
     assert "B안" in prompt and "가격 언급이 부담을 줌" in prompt
     assert "verified" in prompt
-    # 명시적 환각 금지 지시가 프롬프트에 실제로 포함돼있는지.
     assert "추정하거나" in prompt and "만들어내지" in prompt
 
 
@@ -69,37 +75,97 @@ def test_synthesis_prompt_handles_missing_reason_gracefully():
     assert "(이유 미기록)" in prompt
 
 
-# ── ⓐ items=0건 → generate_text 자체 미호출(spy) ────────────────────────────
+# ── ⭐S28 v2: 순환 재진술 금지+outcome 우선+구조화+confidence 마커 지시 ──────────────
+
+def test_synthesis_prompt_v2_forbids_simple_restatement():
+    prompt = _build_synthesis_prompt([_sample_item()])
+    assert "재진술" in prompt and "금지" in prompt
+
+
+def test_synthesis_prompt_v2_prioritizes_outcome_as_fact():
+    prompt = _build_synthesis_prompt([_sample_item()])
+    assert "성과" in prompt and "최우선 근거" in prompt
+
+
+def test_synthesis_prompt_v2_requires_structured_sections():
+    prompt = _build_synthesis_prompt([_sample_item()])
+    for section in ("패턴:", "다음 행동:", "회피:", "리스크:"):
+        assert section in prompt
+
+
+def test_synthesis_prompt_v2_requests_confidence_marker():
+    prompt = _build_synthesis_prompt([_sample_item()])
+    assert "confidence: high|medium|low" in prompt
+
+
+# ── confidence 마커 파싱 ─────────────────────────────────────────────────────
+
+def test_extract_confidence_parses_marker_and_strips_it():
+    raw = "패턴: 저부담 문구가 이긴다.\n다음 행동: 참신한 문구 시도.\n\nconfidence: high"
+    text, confidence = _extract_confidence(raw)
+    assert confidence == "high"
+    assert "confidence" not in text.lower()
+    assert "패턴: 저부담 문구가 이긴다." in text
+
+
+def test_extract_confidence_case_insensitive_and_whitespace_tolerant():
+    raw = "본문 내용.\n  Confidence:   MEDIUM  "
+    text, confidence = _extract_confidence(raw)
+    assert confidence == "medium"
+    assert "confidence" not in text.lower()
+
+
+def test_extract_confidence_missing_marker_returns_none_but_preserves_text():
+    raw = "마커 없는 그냥 본문입니다."
+    text, confidence = _extract_confidence(raw)
+    assert confidence is None
+    assert text == "마커 없는 그냥 본문입니다."
+
+
+def test_extract_confidence_invalid_value_not_matched_preserves_original():
+    raw = "본문.\nconfidence: extreme"
+    text, confidence = _extract_confidence(raw)
+    assert confidence is None
+    assert "confidence: extreme" in text  # 매칭 실패 시 원문 그대로(본문 보존 우선).
+
+
+# ── ⓐ items=0건 → generate_text_claude 자체 미호출(spy) ────────────────────────
 
 def test_empty_items_returns_none_without_calling_llm():
-    with patch("app.services.llm_client.generate_text") as mock_gen:
-        result = _synthesize_learnings([])
+    with patch("app.services.llm_client.generate_text_claude") as mock_gen:
+        result, confidence = _synthesize_learnings([])
     mock_gen.assert_not_called()
-    assert result is None
+    assert result is None and confidence is None
 
 
 # ── ⓑ graceful degrade ──────────────────────────────────────────────────────
 
 def test_llm_unavailable_returns_none():
     item = _sample_item()
-    with patch("app.services.llm_client.generate_text", return_value=None) as mock_gen:
-        result = _synthesize_learnings([item])
+    with patch("app.services.llm_client.generate_text_claude", return_value=None) as mock_gen:
+        result, confidence = _synthesize_learnings([item])
     mock_gen.assert_called_once()
-    assert result is None
+    assert result is None and confidence is None
 
 
 def test_llm_exception_returns_none_not_raised():
     item = _sample_item()
-    with patch("app.services.llm_client.generate_text", side_effect=RuntimeError("boom")):
-        result = _synthesize_learnings([item])
-    assert result is None
+    with patch("app.services.llm_client.generate_text_claude", side_effect=RuntimeError("boom")):
+        result, confidence = _synthesize_learnings([item])
+    assert result is None and confidence is None
 
 
-def test_llm_success_returns_synthesis_text():
+def test_llm_success_returns_synthesis_text_and_uses_disabled_reasoning():
     item = _sample_item()
-    with patch("app.services.llm_client.generate_text", return_value="과거 CTA 실험 1건 — 저부담 문구 채택.") as mock_gen:
-        result = _synthesize_learnings([item])
+    with patch(
+        "app.services.llm_client.generate_text_claude",
+        return_value="과거 CTA 실험 1건 — 저부담 문구 채택.\nconfidence: low",
+    ) as mock_gen:
+        result, confidence = _synthesize_learnings([item])
     assert result == "과거 CTA 실험 1건 — 저부담 문구 채택."
+    assert confidence == "low"
+    call_kwargs = mock_gen.call_args.kwargs
+    assert call_kwargs["reasoning"] == "disabled"
     passed_prompt = mock_gen.call_args.args[0]
     assert "CTA 문구 실험" in passed_prompt
 
@@ -133,7 +199,7 @@ def _unit(i: int, dim: int = 768) -> list[float]:
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 @pytest.mark.anyio
-async def test_build_loop_context_pack_populates_synthesis_real_db():
+async def test_build_loop_context_pack_populates_synthesis_confidence_evidence_count_real_db():
     from sqlalchemy import text as _text
     from app.core.database import Base
     from app.models.embedding import Embedding
@@ -171,15 +237,19 @@ async def test_build_loop_context_pack_populates_synthesis_real_db():
         async with Session() as s:
             loop_obj = await LoopRunRepository(s, ORG).get(target_loop.id)
             with patch("app.services.embedding_client.embed_text", return_value=query_vec), \
-                 patch("app.services.llm_client.generate_text", return_value="과거 실험 1건이 목표 지표를 달성.") as mock_gen:
+                 patch(
+                     "app.services.llm_client.generate_text_claude",
+                     return_value="과거 실험 1건이 목표 지표를 달성.\nconfidence: high",
+                 ) as mock_gen:
                 out = await build_loop_context_pack(s, ORG, loop_obj)
 
         assert out.synthesis == "과거 실험 1건이 목표 지표를 달성."
-        # S27: synthesis 성공 시 recommendation도 시도되므로(같은 mock 반환값을 재사용) 2회 호출.
-        # 이 테스트의 관심사(synthesis 필드)는 첫 호출 인자로 확인 — call count 자체는 S27 몫.
+        assert out.synthesis_confidence == "high"
+        assert out.evidence_count == 1
         assert mock_gen.call_count >= 1
-        first_prompt = mock_gen.call_args_list[0].args[0]
-        assert "과거 실험" in first_prompt
+        first_call = mock_gen.call_args_list[0]
+        assert first_call.kwargs["reasoning"] == "disabled"
+        assert "과거 실험" in first_call.args[0]
         assert len(out.items) == 1
     finally:
         async with engine.begin() as conn:
@@ -190,8 +260,9 @@ async def test_build_loop_context_pack_populates_synthesis_real_db():
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 @pytest.mark.anyio
 async def test_build_loop_context_pack_no_learnable_items_synthesis_none_no_llm_call_real_db():
-    """학습된 선례가 0건(S12 필터로 전부 걸러짐)이면 synthesis=None이고 gen-LLM 호출 자체가
-    없어야 한다(spy) — 빈 프롬프트로라도 LLM을 부르는 낭비/오동작을 실 파이프라인으로 실증."""
+    """학습된 선례가 0건(S12 필터로 전부 걸러짐)이면 synthesis=None·evidence_count=0이고
+    gen-LLM 호출 자체가 없어야 한다(spy) — 빈 프롬프트로라도 LLM을 부르는 낭비/오동작을
+    실 파이프라인으로 실증."""
     from sqlalchemy import text as _text
     from app.core.database import Base
     from app.repositories.loop import LoopRunRepository
@@ -211,11 +282,12 @@ async def test_build_loop_context_pack_no_learnable_items_synthesis_none_no_llm_
         async with Session() as s:
             loop_obj = await LoopRunRepository(s, ORG).get(loop.id)
             with patch("app.services.embedding_client.embed_text", return_value=_unit(0)), \
-                 patch("app.services.llm_client.generate_text") as mock_gen:
+                 patch("app.services.llm_client.generate_text_claude") as mock_gen:
                 out = await build_loop_context_pack(s, ORG, loop_obj)
 
         assert out.items == []
         assert out.synthesis is None
+        assert out.evidence_count == 0
         mock_gen.assert_not_called()
     finally:
         async with engine.begin() as conn:
@@ -264,12 +336,156 @@ async def test_build_loop_context_pack_llm_unavailable_items_still_returned_real
         async with Session() as s:
             loop_obj = await LoopRunRepository(s, ORG).get(target_loop.id)
             with patch("app.services.embedding_client.embed_text", return_value=query_vec), \
-                 patch("app.services.llm_client.generate_text", return_value=None):
+                 patch("app.services.llm_client.generate_text_claude", return_value=None):
                 out = await build_loop_context_pack(s, ORG, loop_obj)
 
         assert out.synthesis is None
+        assert out.synthesis_confidence is None
+        assert out.evidence_count == 1  # ⭐evidence_count는 LLM 성패와 무관 — items 기반 결정론.
         assert len(out.items) == 1
         assert out.items[0].goal == "과거 실험"
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_build_loop_context_pack_cache_hit_skips_llm_call_real_db():
+    """⭐S28 AC④ 캐싱 — 같은 items/loop 맥락으로 두 번째 GET은 gen-LLM을 다시 호출하지 않고
+    캐시된 synthesis/recommendation을 그대로 반환한다("같은 입력=1회만 호출")."""
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.models.embedding import Embedding
+    from app.models.hypothesis import Hypothesis
+    from app.repositories.loop import LoopRunRepository
+    from app.services.context_pack_items import build_loop_context_pack
+
+    engine, Session = await _session()
+    query_vec = _unit(0)
+    past_hyp_id = uuid.uuid4()
+
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            repo = LoopRunRepository(s, ORG)
+            target_loop = await repo.create(
+                project_id=PROJECT, title="타깃 loop", goal_tags=[],
+                status="draft", created_by_member_id=uuid.uuid4(),
+            )
+            s.add(Hypothesis(
+                id=past_hyp_id, org_id=ORG, project_id=PROJECT, owner_member_id=uuid.uuid4(),
+                statement="과거 실험", metric_definition={"metric": "x", "source": "manual", "target": 1, "direction": "up"},
+                measure_after=datetime.now(timezone.utc), status="verified",
+                outcome_result={"metric": "cvr", "actual": 18.4, "target": 18, "direction": "up"},
+            ))
+            await s.flush()
+            s.add(Embedding(
+                id=uuid.uuid4(), org_id=ORG, project_id=PROJECT,
+                entity_type="hypothesis", entity_id=past_hyp_id,
+                embedding_text="과거 실험", content_hash="h1",
+                embedding=query_vec, model_version="m", dimension=768, status="ready",
+            ))
+            await s.commit()
+
+        # 1차 GET — 캐시 미스, LLM 호출.
+        async with Session() as s:
+            loop_obj = await LoopRunRepository(s, ORG).get(target_loop.id)
+            with patch("app.services.embedding_client.embed_text", return_value=query_vec), \
+                 patch(
+                     "app.services.llm_client.generate_text_claude",
+                     return_value="첫 응답.\nconfidence: medium",
+                 ) as mock_gen_1:
+                out1 = await build_loop_context_pack(s, ORG, loop_obj)
+            await s.commit()  # LoopRunRepository.update()의 flush를 실제로 커밋(다음 세션에서 캐시 보이게).
+        assert out1.synthesis == "첫 응답."
+        assert mock_gen_1.call_count >= 1
+
+        # 2차 GET(동일 items/loop) — 캐시 히트, LLM 미호출. 반환값도 mock2가 아니라 캐시값이어야.
+        async with Session() as s:
+            loop_obj2 = await LoopRunRepository(s, ORG).get(target_loop.id)
+            with patch("app.services.embedding_client.embed_text", return_value=query_vec), \
+                 patch(
+                     "app.services.llm_client.generate_text_claude",
+                     return_value="두번째 응답이면 버그.",
+                 ) as mock_gen_2:
+                out2 = await build_loop_context_pack(s, ORG, loop_obj2)
+
+        mock_gen_2.assert_not_called()
+        assert out2.synthesis == "첫 응답."  # 캐시된 값 그대로(두번째 mock 응답 아님).
+        assert out2.synthesis_confidence == "medium"
+        assert out2.evidence_count == 1
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_build_loop_context_pack_cache_invalidates_when_decision_changes_real_db():
+    """⭐캐시 무효화 — 선례 decision이 바뀌면(예: 새 chosen 확정) content-hash가 달라져 캐시가
+    자동 무효화되고 LLM이 다시 호출된다(stale 캐시 방지)."""
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.models.embedding import Embedding
+    from app.models.hypothesis import Hypothesis
+    from app.repositories.loop import LoopRunRepository
+    from app.services.context_pack_items import build_loop_context_pack
+
+    engine, Session = await _session()
+    query_vec = _unit(0)
+    past_hyp_id = uuid.uuid4()
+
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            repo = LoopRunRepository(s, ORG)
+            target_loop = await repo.create(
+                project_id=PROJECT, title="타깃 loop", goal_tags=[],
+                status="draft", created_by_member_id=uuid.uuid4(),
+            )
+            hyp = Hypothesis(
+                id=past_hyp_id, org_id=ORG, project_id=PROJECT, owner_member_id=uuid.uuid4(),
+                statement="과거 실험", metric_definition={"metric": "x", "source": "manual", "target": 1, "direction": "up"},
+                measure_after=datetime.now(timezone.utc), status="verified",
+                outcome_result={"metric": "cvr", "actual": 18.4, "target": 18, "direction": "up"},
+            )
+            s.add(hyp)
+            await s.flush()
+            s.add(Embedding(
+                id=uuid.uuid4(), org_id=ORG, project_id=PROJECT,
+                entity_type="hypothesis", entity_id=past_hyp_id,
+                embedding_text="과거 실험", content_hash="h1",
+                embedding=query_vec, model_version="m", dimension=768, status="ready",
+            ))
+            await s.commit()
+
+        async with Session() as s:
+            loop_obj = await LoopRunRepository(s, ORG).get(target_loop.id)
+            with patch("app.services.embedding_client.embed_text", return_value=query_vec), \
+                 patch("app.services.llm_client.generate_text_claude", return_value="첫 응답."):
+                await build_loop_context_pack(s, ORG, loop_obj)
+            await s.commit()  # 캐시 write를 실제로 커밋.
+
+        # outcome 변경(재측정 시나리오) — 캐시 키가 바뀌어야.
+        async with Session() as s:
+            hyp_row = await s.get(Hypothesis, past_hyp_id)
+            hyp_row.outcome_result = {"metric": "cvr", "actual": 25.0, "target": 18, "direction": "up"}
+            await s.commit()
+
+        async with Session() as s:
+            loop_obj2 = await LoopRunRepository(s, ORG).get(target_loop.id)
+            with patch("app.services.embedding_client.embed_text", return_value=query_vec), \
+                 patch(
+                     "app.services.llm_client.generate_text_claude", return_value="갱신된 응답.",
+                 ) as mock_gen_2:
+                out2 = await build_loop_context_pack(s, ORG, loop_obj2)
+
+        # 캐시 무효화 → synthesis+recommendation 둘 다 재호출(synthesis 성공 시 recommendation도 시도).
+        assert mock_gen_2.call_count == 2
+        assert out2.synthesis == "갱신된 응답."
     finally:
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)

--- a/backend/tests/test_e_loop_ledger_s26_context_pack_synthesis.py
+++ b/backend/tests/test_e_loop_ledger_s26_context_pack_synthesis.py
@@ -424,6 +424,80 @@ async def test_build_loop_context_pack_cache_hit_skips_llm_call_real_db():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 @pytest.mark.anyio
+async def test_build_loop_context_pack_recommendation_transient_failure_not_permanently_cached_real_db():
+    """⭐까심 QA RC(2026-07-02): synthesis는 성공·recommendation만 일시장애(quota/timeout)로
+    실패(None)해도 캐시에 기록되면 안 된다 — 기록되면 다음 요청이 캐시히트로 LLM을 다시
+    안 불러 recommendation=None이 영구 고착된다. 캐시 미기록 → 다음 GET이 둘 다 재시도해야."""
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.models.embedding import Embedding
+    from app.models.hypothesis import Hypothesis
+    from app.repositories.loop import LoopRunRepository
+    from app.services.context_pack_items import build_loop_context_pack
+
+    engine, Session = await _session()
+    query_vec = _unit(0)
+    past_hyp_id = uuid.uuid4()
+
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            repo = LoopRunRepository(s, ORG)
+            target_loop = await repo.create(
+                project_id=PROJECT, title="타깃 loop", goal_tags=[],
+                status="draft", created_by_member_id=uuid.uuid4(),
+            )
+            s.add(Hypothesis(
+                id=past_hyp_id, org_id=ORG, project_id=PROJECT, owner_member_id=uuid.uuid4(),
+                statement="과거 실험", metric_definition={"metric": "x", "source": "manual", "target": 1, "direction": "up"},
+                measure_after=datetime.now(timezone.utc), status="verified",
+                outcome_result={"metric": "cvr", "actual": 18.4, "target": 18, "direction": "up"},
+            ))
+            await s.flush()
+            s.add(Embedding(
+                id=uuid.uuid4(), org_id=ORG, project_id=PROJECT,
+                entity_type="hypothesis", entity_id=past_hyp_id,
+                embedding_text="과거 실험", content_hash="h1",
+                embedding=query_vec, model_version="m", dimension=768, status="ready",
+            ))
+            await s.commit()
+
+        # 1차 GET — synthesis 성공 + recommendation 일시장애(None). 호출 순서: synthesis→recommendation.
+        async with Session() as s:
+            loop_obj = await LoopRunRepository(s, ORG).get(target_loop.id)
+            with patch("app.services.embedding_client.embed_text", return_value=query_vec), \
+                 patch(
+                     "app.services.llm_client.generate_text_claude",
+                     side_effect=["synthesis 1.\nconfidence: high", None],
+                 ) as mock_gen_1:
+                out1 = await build_loop_context_pack(s, ORG, loop_obj)
+            await s.commit()
+        assert out1.synthesis == "synthesis 1."
+        assert out1.recommendation is None
+        assert mock_gen_1.call_count == 2
+
+        # 2차 GET(동일 items/loop) — 캐시가 기록되지 않았어야 하므로 synthesis+recommendation
+        # 둘 다 재시도(캐시히트였다면 mock_gen_2가 전혀 호출 안 됐을 것).
+        async with Session() as s:
+            loop_obj2 = await LoopRunRepository(s, ORG).get(target_loop.id)
+            with patch("app.services.embedding_client.embed_text", return_value=query_vec), \
+                 patch(
+                     "app.services.llm_client.generate_text_claude",
+                     side_effect=["synthesis 2.\nconfidence: high", "recommendation 2.\nconfidence: medium"],
+                 ) as mock_gen_2:
+                out2 = await build_loop_context_pack(s, ORG, loop_obj2)
+
+        assert mock_gen_2.call_count == 2  # 캐시 미기록 → 둘 다 재호출(복구 확인).
+        assert out2.synthesis == "synthesis 2."
+        assert out2.recommendation == "recommendation 2."
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
 async def test_build_loop_context_pack_cache_invalidates_when_decision_changes_real_db():
     """⭐캐시 무효화 — 선례 decision이 바뀌면(예: 새 chosen 확정) content-hash가 달라져 캐시가
     자동 무효화되고 LLM이 다시 호출된다(stale 캐시 방지)."""

--- a/backend/tests/test_e_loop_ledger_s27_context_pack_recommendation.py
+++ b/backend/tests/test_e_loop_ledger_s27_context_pack_recommendation.py
@@ -1,9 +1,12 @@
 """E-LOOP-LEDGER S27(story 840939c7·P2·L3): Context Pack 능동 추천(synthesis+새 loop→처방) 검증.
 
+S28(선생님 dogfood 지적) 이후 갱신: Gemini→Claude(disabled) 전환·프롬프트 v2(outcome 우선+
+제안형 톤 LOCK)·confidence 마커 파싱 추가·_recommend_next_step이 session/loop 의존 없는
+순수 함수로 단순화(build_loop_context_pack이 hyp_statement를 미리 로드해 넘김).
+
 핵심(비-tautological):
-ⓐ ⭐과신 방지 — synthesis가 None이면(L2 자체가 근거 부족) 추천 생성(generate_text) 자체를
-   시도하지 않음(spy로 call_count==0 직접 증명 — S24/S26에서 확립한 spy 관용구 재사용, fake
-   path 우연일치 tautological 위험 회피).
+ⓐ ⭐과신 방지 — synthesis가 None이면(L2 자체가 근거 부족) 추천 생성(generate_text_claude) 자체를
+   시도하지 않음(spy로 call_count==0 직접 증명).
 ⓑ 프롬프트가 synthesis+새 loop goal/hypothesis만 사용(items 밖 사실 주입 0)함을 텍스트로 직접 확인.
 ⓒ graceful degrade — recommendation 생성 실패해도 items(L1)/synthesis(L2)는 무손상.
 ⓓ realdb round-trip — full pipeline(synthesis→recommendation) 정합 및 각 단계 독립 실패 격리.
@@ -52,69 +55,68 @@ def test_recommendation_prompt_instructs_hedge_and_no_fabrication():
 
 def test_recommendation_prompt_synthesis_none_is_safe_not_a_crash():
     """까심 RC — synthesis=None으로 프롬프트 조립 자체가 크래시하지 않아야 한다. 이래야
-    _recommend_next_step의 `if synthesis is None: return None` 가드가 과잉처방을 막는
+    _recommend_next_step의 `if synthesis is None: return None, None` 가드가 과잉처방을 막는
     "유일한" 게이트가 되고(우연한 TypeError 흡수로 masking되지 않고), 가드를 실수로
-    지우면 generate_text가 실제로 불려 테스트가 정직하게 실패한다(아래 spy 테스트 참고)."""
+    지우면 generate_text_claude가 실제로 불려 테스트가 정직하게 실패한다(아래 spy 테스트 참고)."""
     prompt = _build_recommendation_prompt("g", None, None, 0)
     assert "(종합 없음)" in prompt
 
 
-# ── ⓐ synthesis=None → 추천 자제(generate_text 미호출, spy) ────────────────────
+# ── ⭐S28 v2: outcome 우선+제안형 톤(유나 voice 계약 LOCK)+confidence 마커 지시 ──────
 
-@pytest.mark.anyio
-async def test_synthesis_none_skips_recommendation_without_calling_llm():
+def test_recommendation_prompt_v2_prioritizes_outcome():
+    prompt = _build_recommendation_prompt("g", None, "s", 1)
+    assert "성과" in prompt and "최우선 근거" in prompt
+
+
+def test_recommendation_prompt_v2_suggestive_tone_not_command():
+    """유나 voice 계약 LOCK — "돕되 대체 안 함". 단정적 지시가 아니라 제안형 톤을 명시 요구."""
+    prompt = _build_recommendation_prompt("g", None, "s", 1)
+    assert "제안형" in prompt
+    assert "최종 판단은 사람의 몫" in prompt
+
+
+def test_recommendation_prompt_v2_requests_confidence_marker():
+    prompt = _build_recommendation_prompt("g", None, "s", 1)
+    assert "confidence: high|medium|low" in prompt
+
+
+# ── ⓐ synthesis=None → 추천 자제(generate_text_claude 미호출, spy) ────────────────
+
+def test_synthesis_none_skips_recommendation_without_calling_llm():
     """⭐까심 RC 검증됨(비-tautological): 프롬프트 빌더가 None-safe이므로(위 테스트) 이
-    assert_not_called()는 가드가 실제로 작동해야만 통과한다 — 가드를 지워보면 generate_text가
-    호출돼 이 테스트가 정확히 그 지점서 실패함을 로컬 검증(fix 임시 제거→재현→복원)."""
-    from app.models.loop import LoopRun
-
-    loop = LoopRun(id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(), title="L", status="briefing")
-    with patch("app.services.llm_client.generate_text") as mock_gen:
-        result = await _recommend_next_step(session=None, org_id=loop.org_id, loop=loop, synthesis=None, item_count=0)
+    assert_not_called()는 가드가 실제로 작동해야만 통과한다."""
+    with patch("app.services.llm_client.generate_text_claude") as mock_gen:
+        result, confidence = _recommend_next_step("L", None, None, 0)
     mock_gen.assert_not_called()
-    assert result is None
+    assert result is None and confidence is None
 
 
-# ── ⓒ graceful degrade — generate_text 실패/미가용 ──────────────────────────────
+# ── ⓒ graceful degrade — generate_text_claude 실패/미가용 ──────────────────────
 
-@pytest.mark.anyio
-async def test_llm_unavailable_returns_none_when_no_hypothesis():
-    from app.models.loop import LoopRun
-
-    loop = LoopRun(id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(), title="L", status="briefing")
-    with patch("app.services.llm_client.generate_text", return_value=None) as mock_gen:
-        result = await _recommend_next_step(
-            session=None, org_id=loop.org_id, loop=loop, synthesis="과거 종합", item_count=2,
-        )
+def test_llm_unavailable_returns_none_when_no_hypothesis():
+    with patch("app.services.llm_client.generate_text_claude", return_value=None) as mock_gen:
+        result, confidence = _recommend_next_step("L", None, "과거 종합", 2)
     mock_gen.assert_called_once()
-    assert result is None
+    assert result is None and confidence is None
 
 
-@pytest.mark.anyio
-async def test_llm_exception_returns_none_not_raised():
-    from app.models.loop import LoopRun
-
-    loop = LoopRun(id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(), title="L", status="briefing")
-    with patch("app.services.llm_client.generate_text", side_effect=RuntimeError("boom")):
-        result = await _recommend_next_step(
-            session=None, org_id=loop.org_id, loop=loop, synthesis="과거 종합", item_count=2,
-        )
-    assert result is None
+def test_llm_exception_returns_none_not_raised():
+    with patch("app.services.llm_client.generate_text_claude", side_effect=RuntimeError("boom")):
+        result, confidence = _recommend_next_step("L", None, "과거 종합", 2)
+    assert result is None and confidence is None
 
 
-@pytest.mark.anyio
-async def test_llm_success_returns_recommendation_and_passes_grounded_prompt():
-    from app.models.loop import LoopRun
-
-    loop = LoopRun(id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(), title="가격 실험", status="briefing")
+def test_llm_success_returns_recommendation_confidence_and_uses_disabled_reasoning():
     with patch(
-        "app.services.llm_client.generate_text",
-        return_value="과거 3건 기준 저부담 문구 우선 권장.",
+        "app.services.llm_client.generate_text_claude",
+        return_value="과거 3건 기준 저부담 문구 우선 권장.\nconfidence: medium",
     ) as mock_gen:
-        result = await _recommend_next_step(
-            session=None, org_id=loop.org_id, loop=loop, synthesis="과거 종합 텍스트", item_count=3,
-        )
+        result, confidence = _recommend_next_step("가격 실험", None, "과거 종합 텍스트", 3)
     assert result == "과거 3건 기준 저부담 문구 우선 권장."
+    assert confidence == "medium"
+    call_kwargs = mock_gen.call_args.kwargs
+    assert call_kwargs["reasoning"] == "disabled"
     passed_prompt = mock_gen.call_args.args[0]
     assert "가격 실험" in passed_prompt and "과거 종합 텍스트" in passed_prompt
 
@@ -195,14 +197,22 @@ async def test_full_pipeline_populates_recommendation_with_target_loop_hypothesi
             loop_obj = await LoopRunRepository(s, ORG).get(target_loop.id)
             with patch("app.services.embedding_client.embed_text", return_value=query_vec), \
                  patch(
-                     "app.services.llm_client.generate_text",
-                     side_effect=["과거 실험 1건이 목표 지표를 달성.", "과거 1건 기준 저부담 문구 권장."],
+                     "app.services.llm_client.generate_text_claude",
+                     side_effect=[
+                         "과거 실험 1건이 목표 지표를 달성.\nconfidence: high",
+                         "과거 1건 기준 저부담 문구 권장.\nconfidence: low",
+                     ],
                  ) as mock_gen:
                 out = await build_loop_context_pack(s, ORG, loop_obj)
 
         assert out.synthesis == "과거 실험 1건이 목표 지표를 달성."
+        assert out.synthesis_confidence == "high"
         assert out.recommendation == "과거 1건 기준 저부담 문구 권장."
+        assert out.recommendation_confidence == "low"
+        assert out.evidence_count == 1
         assert mock_gen.call_count == 2
+        for call in mock_gen.call_args_list:
+            assert call.kwargs["reasoning"] == "disabled"
         recommendation_prompt = mock_gen.call_args_list[1].args[0]
         assert "가격 페이지 CTA 실험" in recommendation_prompt
         assert "저부담 문구가 전환율을 높인다" in recommendation_prompt
@@ -234,12 +244,13 @@ async def test_no_learnable_items_recommendation_none_no_llm_call_real_db():
         async with Session() as s:
             loop_obj = await LoopRunRepository(s, ORG).get(loop.id)
             with patch("app.services.embedding_client.embed_text", return_value=_unit(0)), \
-                 patch("app.services.llm_client.generate_text") as mock_gen:
+                 patch("app.services.llm_client.generate_text_claude") as mock_gen:
                 out = await build_loop_context_pack(s, ORG, loop_obj)
 
         assert out.items == []
         assert out.synthesis is None
         assert out.recommendation is None
+        assert out.evidence_count == 0
         mock_gen.assert_not_called()
     finally:
         async with engine.begin() as conn:
@@ -251,7 +262,7 @@ async def test_no_learnable_items_recommendation_none_no_llm_call_real_db():
 @pytest.mark.anyio
 async def test_synthesis_fails_recommendation_also_none_only_one_llm_attempt_real_db():
     """⭐AC①③ 파이프라인 레벨 실증 — synthesis 자체가 실패(L2 gen-LLM 미가용)하면 recommendation은
-    시도조차 안 한다(과잉 처방 방지) — generate_text가 정확히 1회(synthesis 시도)만 불림."""
+    시도조차 안 한다(과잉 처방 방지) — generate_text_claude가 정확히 1회(synthesis 시도)만 불림."""
     from sqlalchemy import text as _text
     from app.core.database import Base
     from app.models.embedding import Embedding
@@ -289,12 +300,13 @@ async def test_synthesis_fails_recommendation_also_none_only_one_llm_attempt_rea
         async with Session() as s:
             loop_obj = await LoopRunRepository(s, ORG).get(target_loop.id)
             with patch("app.services.embedding_client.embed_text", return_value=query_vec), \
-                 patch("app.services.llm_client.generate_text", return_value=None) as mock_gen:
+                 patch("app.services.llm_client.generate_text_claude", return_value=None) as mock_gen:
                 out = await build_loop_context_pack(s, ORG, loop_obj)
 
         assert out.synthesis is None
         assert out.recommendation is None
         assert len(out.items) == 1  # items(L1)는 무손상.
+        assert out.evidence_count == 1  # ⭐evidence_count는 LLM 성패와 무관.
         assert mock_gen.call_count == 1  # synthesis 시도만(recommendation은 시도조차 안 함).
     finally:
         async with engine.begin() as conn:


### PR DESCRIPTION
## Summary
선생님 dogfood 지적("gemini 멍청" — L2/L3 출력이 순환 재진술뿐, 실행 불가능)에 대한 근본 대응. PO crux 확정 3점 반영:
- ①outcome-최우선-근거 프롬프트(순환성의 진짜 해독제 — 성과가 있으면 그것을 최우선 근거로, 없으면 결정 이유만으로 신중히 + 불확실성 명시)
- ②draft(hypothesis 단문 statement)는 순환성 문제 자체가 없어 재설계 대상 밖 — synthesis/recommendation만 프롬프트 재설계
- ③L3 추천은 제안형 톤(유나 voice-guide LOCK, "돕되 대체 안 함")

## Changes
- **Claude 배선**: synthesis(L2)/recommendation(L3)/hypothesis-draft 3곳 모두 Gemini→Claude(`claude-sonnet-5`, `reasoning="disabled"`)로 전환 — 선생님 실측 A/B 레이턴시+퀄리티 실험 결론(별도 PR #1852에서 확정).
- **프롬프트 v2**: 재진술 금지 + outcome-as-fact 최우선 근거 + 구조(비-obvious 패턴/구체적 다음 행동/회피할 것/리스크) + 정직 hedge("패턴 불명확 N건 부족") + 환각방지 + `confidence: high|medium|low` 마커.
- **캐싱**: `loop_runs`에 content-hash(SHA256) 키 컬럼 6개 추가(`0153` 마이그레이션). 회수 items(entity_type/goal/decision/outcome)+새 loop 맥락(title/hypothesis)+모델/프롬프트버전이 전부 동일할 때만 캐시 히트("같은 입력=1회만 호출"). LLM 실패 시엔 캐시에 기록하지 않음(일시 장애를 영구 "결과 없음"으로 굳히지 않기 위함) — 어떤 항목이 바뀌어도(선례 결정/성과 변경, 모델/프롬프트 버전 업) 해시가 달라져 자동 무효화.
- **유나 BE↔FE 계약(relay)**: `ContextPackResponse`에 `synthesis_confidence`/`recommendation_confidence`(LLM 마커 파싱)+`evidence_count`(items 수, 결정론적 — LLM 산출물 아님) 추가.

## 부수 발견 수정 (발견 즉시 수정)
내 캐시-키 로직이 `loop.hypothesis_id`/`loop.context_pack_cache_key`를 무조건 읽게 되면서 노출된 기존 갭:
- `test_e_loop_ledger_s16_hypothesis_draft_loop_goal.py`가 여전히 구 `generate_text`를 mock — `generate_text_claude`로 교체(S15와 동일 패턴, 이미 머지된 S25에서 S15는 반영됐으나 S16은 누락).
- `test_e_loop_ledger_p1_s12_context_pack_items.py`의 `_loop_obj` mock 스텁에 `hypothesis_id`/`context_pack_cache_key` 속성이 없어 새 캐시-키 로직에서 `AttributeError` — 속성 추가 + 해당 테스트들에 `generate_text_claude` mock 보강.

## Test plan
- [x] `test_e_loop_ledger_s28_llm_client_claude.py`(11) — Claude reasoning 계약(disabled/adaptive+effort, invalid→fallback, 구조화 로깅, Gemini 경로와 구조적 독립성).
- [x] `test_e_loop_ledger_s26_context_pack_synthesis.py`+`s27_context_pack_recommendation.py` — v2 프롬프트 구조(재진술 금지/outcome 최우선/confidence 마커/제안형 톤) + confidence 파싱 + evidence_count.
- [x] 캐싱 realdb 2종: cache-hit(2번째 GET, 다른 mock 리턴값에도 1번째 GET 캐시 재사용 확인)+cache-invalidate(선례 outcome 변경 시 재호출, 2회 call 확인).
- [x] **비-동어반복 검증**: 캐시-히트 가드를 `if False:`로 임시 무력화 → `generate_text_claude` 2회 호출로 genuinely 실패 확인(0회 기대 vs 실제 2회) → 원복 → 재확인 33/33 GREEN.
- [x] S15/S16 hypothesis-draft 회귀 — Claude mock으로 교체 후 GREEN.
- [x] P1-S12 mock 단위테스트(15) — 신규 loop 속성 보강 후 GREEN.
- [x] Alembic 체인 `0096→0153` 프레시 컨테이너 클린 적용 확인.
- [x] 같은 마이그레이션 위 alembic-convention 회귀 스위트(S2/S3/S4/S5/S7/S8/S22/S24, 97개) GREEN — 마이그레이션이 기존 기능 안 깸.
- [x] `uvx ruff check` 터치 파일 전수 — 신규 위반 0(기존 baseline 노이즈(E402/E702) origin/develop 대조로 pre-existing 확인).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>