### PR TITLE
[SID:e-loop-ledger-s28] E-LOOP-LEDGER S28 — 브랜딩 + AI voice UI(attribution·확신도 배지)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2676,7 +2676,14 @@
     "createLoopDrafting": "Drafting...",
     "createLoopDraftNoteTitle": "This is an AI draft — review and edit before confirming.",
     "createLoopDraftNoteBody": "It won't be submitted as-is; you need to confirm it.",
-    "createLoopDraftRetry": "Suggest again"
+    "createLoopDraftRetry": "Suggest again",
+    "aiAttributionLabel": "Sprintable AI",
+    "aiConfidenceLabel": "{count} refs · {level}",
+    "aiConfidenceLowLabel": "Limited evidence · draft quality",
+    "aiConfidenceLevel_high": "High",
+    "aiConfidenceLevel_medium": "Medium",
+    "aiConfidenceLevel_low": "Low",
+    "aiTransparencyLine": "AI-assisted reference — the judgment is yours."
   },
   "sprints": {
     "title": "Sprints",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2676,7 +2676,14 @@
     "createLoopDrafting": "제안 중...",
     "createLoopDraftNoteTitle": "AI 초안입니다 — 검토·수정 후 확정하세요.",
     "createLoopDraftNoteBody": "이 문구는 그대로 제출되지 않으며, 당신이 확인해야 반영됩니다.",
-    "createLoopDraftRetry": "다시 제안"
+    "createLoopDraftRetry": "다시 제안",
+    "aiAttributionLabel": "Sprintable AI",
+    "aiConfidenceLabel": "근거 {count}건 · {level}",
+    "aiConfidenceLowLabel": "근거 부족 · 초안 수준",
+    "aiConfidenceLevel_high": "높음",
+    "aiConfidenceLevel_medium": "보통",
+    "aiConfidenceLevel_low": "낮음",
+    "aiTransparencyLine": "AI가 도운 참고 자료입니다 · 판단은 당신이 합니다."
   },
   "sprints": {
     "title": "스프린트",

--- a/apps/web/src/components/loops/ai-attribution.tsx
+++ b/apps/web/src/components/loops/ai-attribution.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Sparkle } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+
+export type AiConfidence = 'high' | 'medium' | 'low';
+
+const CONFIDENCE_VARIANT: Record<AiConfidence, 'success' | 'info' | 'warning'> = {
+  high: 'success',
+  medium: 'info',
+  low: 'warning',
+};
+
+/**
+ * E-LOOP-LEDGER S28 — "Powered by Sprintable" attribution + 확신도 배지(핸드오프 §2, render
+ * doc 86a6f061). L2(학습 요약)/L3(참고 제안)/draft(AI 초안) 3종 AI 조력 블록이 공유하는 "한 인격"
+ * 컴포넌트 — voice/attribution을 여기 한 곳에서만 관리해 3곳이 갈라지지 않게 한다.
+ *
+ * confidence/evidenceCount는 optional·null-safe: BE 계약(디디 S28) 미착지 과도기에는 attribution
+ * 칩만 뜨고 확신도 배지는 생략(퇴화 없음, S26/S27/S16과 동일 원칙).
+ */
+export function AiAttributionRow({
+  confidence,
+  evidenceCount,
+}: {
+  confidence?: AiConfidence | null;
+  evidenceCount?: number | null;
+}) {
+  const t = useTranslations('loops');
+  const label =
+    confidence === 'low'
+      ? t('aiConfidenceLowLabel')
+      : confidence && evidenceCount != null
+        ? t('aiConfidenceLabel', { count: evidenceCount, level: t(`aiConfidenceLevel_${confidence}` as 'aiConfidenceLevel_high') })
+        : null;
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <span className="inline-flex items-center gap-1 rounded-full border border-primary/30 bg-primary/10 px-2 py-0.5 text-[9.5px] font-bold text-primary">
+        <Sparkle className="size-2.5" aria-hidden />
+        {t('aiAttributionLabel')}
+      </span>
+      {confidence && label ? (
+        <Badge variant={CONFIDENCE_VARIANT[confidence]} className="text-[9px]">{label}</Badge>
+      ) : null}
+    </div>
+  );
+}
+
+/** 하단 투명성 라인 — dashed 상단 보더로 attribution 블록과 시각 구분(핸드오프 §2). */
+export function AiTransparencyLine({ className }: { className?: string }) {
+  const t = useTranslations('loops');
+  return (
+    <p className={`mt-1.5 border-t border-dashed border-border/70 pt-1.5 text-[9px] text-muted-foreground ${className ?? ''}`}>
+      {t('aiTransparencyLine')}
+    </p>
+  );
+}

--- a/apps/web/src/components/loops/context-pack-panel.tsx
+++ b/apps/web/src/components/loops/context-pack-panel.tsx
@@ -7,6 +7,7 @@ import { Brain, Lightbulb, Sparkles } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { OutcomeBadge } from '@/components/loops/outcome-badge';
+import { AiAttributionRow, AiTransparencyLine, type AiConfidence } from '@/components/loops/ai-attribution';
 
 /** E-LOOP-LEDGER S13 — GET /loops/{id}/context-pack 응답 shape(handoff §3, PO-locked). */
 interface ContextPackDecision {
@@ -46,6 +47,15 @@ interface ContextPackResponse {
    * ⭐유나 LOCK: 제안형 톤(복리 엔진은 결정을 돕지 대체 안 함)·시각 위계는 결정 UI보다 항상 낮게(subtle).
    */
   recommendation?: string | null;
+  /**
+   * E-LOOP-LEDGER S28 — voice/attribution 계약(#1854, 핸드오프 §5). synthesis/recommendation은
+   * 별도 gen-LLM 호출이라 confidence/evidence_count도 각각 독립(오르테가 확인, 2026-07-02) — 공유
+   * 단일 필드 아님. optional·null-safe: BE 미착지/신호 부족 시 attribution 칩만 뜨고 배지는 생략.
+   */
+  synthesis_confidence?: AiConfidence | null;
+  synthesis_evidence_count?: number | null;
+  recommendation_confidence?: AiConfidence | null;
+  recommendation_evidence_count?: number | null;
 }
 
 function ContextPackCard({ item }: { item: ContextPackItem }) {
@@ -175,21 +185,33 @@ export function ContextPackPanel({ loopId }: { loopId: string }) {
           <>
             {/* L2 요약(위) → L3 제안(중간) → L1 근거 items(아래) — 유나 LOCK: 위계는 항상 결정 UI보다 낮게. */}
             {data.synthesis ? (
-              <div className="flex items-start gap-2 rounded-lg border border-info-border bg-info-tint p-2.5 text-xs text-info">
-                <Sparkles className="mt-0.5 size-3.5 shrink-0" aria-hidden />
-                <div className="space-y-0.5">
-                  <p className="font-semibold">{t('contextPackSynthesisTitle')}</p>
-                  <p className="text-info/90">{data.synthesis}</p>
+              <div className="rounded-lg border border-info-border bg-info-tint p-2.5 text-xs text-info">
+                <div className="flex items-start gap-2">
+                  <Sparkles className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <div className="flex flex-wrap items-center justify-between gap-1.5">
+                      <p className="font-semibold">{t('contextPackSynthesisTitle')}</p>
+                      <AiAttributionRow confidence={data.synthesis_confidence} evidenceCount={data.synthesis_evidence_count} />
+                    </div>
+                    <p className="text-info/90">{data.synthesis}</p>
+                  </div>
                 </div>
+                <AiTransparencyLine className="border-info-border/60" />
               </div>
             ) : null}
             {data.recommendation ? (
-              <div className="flex items-start gap-2 rounded-lg border border-dashed border-border bg-muted/20 p-2.5 text-xs text-muted-foreground">
-                <Lightbulb className="mt-0.5 size-3.5 shrink-0" aria-hidden />
-                <div className="space-y-0.5">
-                  <p className="font-medium text-foreground/80">{t('contextPackRecommendationTitle')}</p>
-                  <p>{data.recommendation}</p>
+              <div className="rounded-lg border border-dashed border-border bg-muted/20 p-2.5 text-xs text-muted-foreground">
+                <div className="flex items-start gap-2">
+                  <Lightbulb className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <div className="flex flex-wrap items-center justify-between gap-1.5">
+                      <p className="font-medium text-foreground/80">{t('contextPackRecommendationTitle')}</p>
+                      <AiAttributionRow confidence={data.recommendation_confidence} evidenceCount={data.recommendation_evidence_count} />
+                    </div>
+                    <p>{data.recommendation}</p>
+                  </div>
                 </div>
+                <AiTransparencyLine />
               </div>
             ) : null}
             {data.items.map((item) => <ContextPackCard key={`${item.entity_type}-${item.entity_id}`} item={item} />)}

--- a/apps/web/src/components/loops/context-pack-panel.tsx
+++ b/apps/web/src/components/loops/context-pack-panel.tsx
@@ -48,14 +48,15 @@ interface ContextPackResponse {
    */
   recommendation?: string | null;
   /**
-   * E-LOOP-LEDGER S28 — voice/attribution 계약(#1854, 핸드오프 §5). synthesis/recommendation은
-   * 별도 gen-LLM 호출이라 confidence/evidence_count도 각각 독립(오르테가 확인, 2026-07-02) — 공유
-   * 단일 필드 아님. optional·null-safe: BE 미착지/신호 부족 시 attribution 칩만 뜨고 배지는 생략.
+   * E-LOOP-LEDGER S28 — voice/attribution 계약(실 BE #1854, `schemas/context_pack.py` 확인).
+   * *_confidence(LLM 산출·gen-LLM 호출별 독립)는 synthesis/recommendation 각각 분리 필드가 맞지만,
+   * evidence_count는 LLM 산출물이 아니라 **items 수로 결정론적 산출되는 단일 공유 필드**(까심 RC —
+   * FE가 초기에 synthesis_evidence_count/recommendation_evidence_count로 분리 가정했던 것을 실 BE
+   * shape로 수정, 크로스모델 계약 불일치 교정). optional·null-safe: BE 미착지 시 칩만 뜨고 배지 생략.
    */
   synthesis_confidence?: AiConfidence | null;
-  synthesis_evidence_count?: number | null;
   recommendation_confidence?: AiConfidence | null;
-  recommendation_evidence_count?: number | null;
+  evidence_count?: number | null;
 }
 
 function ContextPackCard({ item }: { item: ContextPackItem }) {
@@ -191,7 +192,7 @@ export function ContextPackPanel({ loopId }: { loopId: string }) {
                   <div className="min-w-0 flex-1 space-y-1">
                     <div className="flex flex-wrap items-center justify-between gap-1.5">
                       <p className="font-semibold">{t('contextPackSynthesisTitle')}</p>
-                      <AiAttributionRow confidence={data.synthesis_confidence} evidenceCount={data.synthesis_evidence_count} />
+                      <AiAttributionRow confidence={data.synthesis_confidence} evidenceCount={data.evidence_count} />
                     </div>
                     <p className="text-info/90">{data.synthesis}</p>
                   </div>
@@ -206,7 +207,7 @@ export function ContextPackPanel({ loopId }: { loopId: string }) {
                   <div className="min-w-0 flex-1 space-y-1">
                     <div className="flex flex-wrap items-center justify-between gap-1.5">
                       <p className="font-medium text-foreground/80">{t('contextPackRecommendationTitle')}</p>
-                      <AiAttributionRow confidence={data.recommendation_confidence} evidenceCount={data.recommendation_evidence_count} />
+                      <AiAttributionRow confidence={data.recommendation_confidence} evidenceCount={data.evidence_count} />
                     </div>
                     <p>{data.recommendation}</p>
                   </div>


### PR DESCRIPTION
## Summary
- "Powered by Sprintable" = voice 계약(핸드오프 `e-loop-ledger-s28-voice-branding-handoff`, render doc `86a6f061`) — L2 학습 요약/L3 참고 제안 블록에 attribution 계층 추가
- **✦ Sprintable AI** 칩(subtle, brand-tint) + **확신도 배지**(`confidence: high→success / medium→info / low→warning`, "근거 N건 · 수준" 라벨, low는 "근거 부족 · 초안 수준") + 하단 **투명성 라인**("AI가 도운 참고 자료입니다 · 판단은 당신이 합니다.")
- L2/L3가 공유하는 `ai-attribution.tsx` 컴포넌트로 분리 — "한 인격"(voice 통일) 원칙 실구현
- `synthesis_confidence`/`synthesis_evidence_count`/`recommendation_confidence`/`recommendation_evidence_count` optional 필드 추가 — synthesis/recommendation은 별도 gen-LLM 호출이라 confidence도 독립(오르테가 확인). BE #1854 미착지 과도기엔 attribution 칩만 뜨고 배지는 null-safe 생략(퇴화 없음)
- **S16 draft confidence 배지는 이번 스코프 제외** — 기존 `HypothesisDraftResponse.confidence`(float, hypothesis lifecycle 범용)를 high/medium/low로 재해석하면 다른 소비처와 충돌해 디디 확인 후 보류(별도 스토리). "AI 초안" 라벨만으로 voice 통일은 이미 충족
- 겸손한 위계(결정 UI > AI 인사이트) 불변, 신규 색 토큰 0, 양테마

## Test plan
- [x] `tsc --noEmit` / `eslint` / `next build` 전부 EXIT 0
- [x] `vitest run` 전체 스위트 167 files / 1038 tests 전부 통과, 회귀 0
- [x] 격리 docker + Service Worker로 context-pack 응답 목킹 — high(근거5·높음 success)/low(근거부족·초안수준 warning, recommendation=null 섹션 생략)/필드 부재(attribution 칩만, 배지 생략) 3케이스 전부 크래시 0
- [x] 다크모드 확인(배지 대비·가독성)

🤖 Generated with [Claude Code](https://claude.com/claude-code)