### PR TITLE
feat(e-loop-ledger): S11b — Context Pack dispatch story/epic 간접 entity 커버리지

### DIFF
--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -574,9 +574,25 @@ async def resolve_dispatch_context_pack(
     if entity_type == "hypothesis":
         hypothesis_id = entity_id
     elif entity_type in ("story", "epic"):
-        repo = HypothesisRepository(session, org_id)
-        anchor_hyp = await repo.resolve_primary_anchor(entity_type, entity_id)
-        if anchor_hyp is None:
+        # 까심 QA RC(2026-07-02): Context Pack은 dispatch(critical path)의 optional 보강이라
+        # 이 해소가 실패/예상외 타입을 내도 dispatch 자체를 절대 깨면 안 된다(resolve_dispatch_anchor
+        # 의 isinstance 방어와 동일 원칙 + 쿼리 자체의 예외까지 try/except로 추가 방어 — anchor
+        # 쪽은 쿼리 예외 방어가 없어 이번에 같은 취약점이 있었음이 드러남).
+        try:
+            repo = HypothesisRepository(session, org_id)
+            anchor_hyp = await repo.resolve_primary_anchor(entity_type, entity_id)
+        except Exception as exc:
+            logger.warning(
+                "resolve_dispatch_context_pack: anchor 해소 실패(생략 처리) %s %s: %s",
+                entity_type, entity_id, exc,
+            )
+            return None
+        if not isinstance(anchor_hyp, Hypothesis):
+            if anchor_hyp is not None:
+                logger.warning(
+                    "resolve_dispatch_context_pack: non-Hypothesis anchor %r for %s %s — 생략",
+                    type(anchor_hyp).__name__, entity_type, entity_id,
+                )
             return None
         hypothesis_id = anchor_hyp.id
     else:

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -554,20 +554,32 @@ async def resolve_dispatch_context_pack(
     entity_type: str,
     entity_id: uuid.UUID,
 ) -> str | None:
-    """E-LOOP-LEDGER P1-S11: dispatch 대상의 Context Pack(S7이 조립한 markdown brief) — 복리
-    조직기억이 에이전트에게 실제로 전달되는 지점(crux GO 2026-07-02).
+    """E-LOOP-LEDGER P1-S11(+S11b): dispatch 대상의 Context Pack(S7이 조립한 markdown brief) —
+    복리 조직기억이 에이전트에게 실제로 전달되는 지점(crux GO 2026-07-02).
 
-    entity_type=='hypothesis'만 스코프(hypothesis→loop만 결정론적 직접 경로 — loop은 dispatch
-    entity가 아니고, story/epic은 간접 해소가 필요해 후속 스토리로 분리). 그 hypothesis에 연결된
-    loop 중 최신(created_at desc)·abandoned 제외 1개를 선택 — 여러 loop이 있을 수 있어(1:0..N)
-    결정론적 단일 선택이 필요하다.
+    entity_type=='hypothesis'는 직접 경로. story/epic은 resolve_primary_anchor(hypothesis_anchor
+    와 동일 SSOT — story link primary 우선→없으면 story의 epic primary로 fallback·epic은 epic
+    link primary)로 대표 hypothesis 1건을 먼저 해소한 뒤 동일 loop 조회로 합류한다(S11b, 간접
+    entity 커버리지). sprint/doc 등 그 외는 anchor 메커니즘 자체가 커버하지 않는 범위라 동형으로
+    스코프 밖(None, 쿼리 0).
+
+    해소된 hypothesis에 연결된 loop 중 최신(created_at desc)·abandoned 제외 1개를 선택 — 여러
+    loop이 있을 수 있어(1:0..N) 결정론적 단일 선택이 필요하다.
 
     데이터 소스는 선택된 loop의 brief_doc_id(S7이 draft→briefing 전이 시 조립한 Doc)를 그대로
     재사용한다 — 재검색(embed_client 호출) 안 함. dispatch는 사용자가 응답을 기다리는 요청이
     아니라(S6 검색과 대비) latency/비용을 새로 들일 이유가 없다. brief_doc_id가 없으면(loop이
     아직 briefing 전이 전) None(hypothesis_anchor의 null-fallback과 동형 — 재검색으로 억지로
     채우지 않는다)."""
-    if entity_type != "hypothesis":
+    if entity_type == "hypothesis":
+        hypothesis_id = entity_id
+    elif entity_type in ("story", "epic"):
+        repo = HypothesisRepository(session, org_id)
+        anchor_hyp = await repo.resolve_primary_anchor(entity_type, entity_id)
+        if anchor_hyp is None:
+            return None
+        hypothesis_id = anchor_hyp.id
+    else:
         return None
 
     from app.models.doc import Doc
@@ -577,7 +589,7 @@ async def resolve_dispatch_context_pack(
         select(LoopRun)
         .where(
             LoopRun.org_id == org_id,
-            LoopRun.hypothesis_id == entity_id,
+            LoopRun.hypothesis_id == hypothesis_id,
             LoopRun.status != "abandoned",
             LoopRun.deleted_at.is_(None),
         )

--- a/backend/tests/test_e_loop_ledger_p1_s11_dispatch_context_pack.py
+++ b/backend/tests/test_e_loop_ledger_p1_s11_dispatch_context_pack.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.models.hypothesis import Hypothesis
 from app.services import agent_dispatch as svc
 from app.services import hypothesis as hyp_svc
 
@@ -65,8 +66,12 @@ async def test_story_with_no_primary_hypothesis_returns_none():
 
 
 async def test_story_resolves_via_primary_hypothesis_anchor_then_loop_and_doc():
-    """S11b: story→primary hypothesis anchor→그 hypothesis의 loop→brief doc 경로가 전부 합류."""
-    anchor_hyp = SimpleNamespace(id=uuid.uuid4())
+    """S11b: story→primary hypothesis anchor→그 hypothesis의 loop→brief doc 경로가 전부 합류.
+
+    anchor_hyp은 실제 Hypothesis 인스턴스여야 한다 — 까심 QA RC(2026-07-02) 이후
+    resolve_dispatch_context_pack이 isinstance(anchor_hyp, Hypothesis) 방어를 갖췄으므로,
+    SimpleNamespace를 쓰면 그 방어에 걸려 masking(잘못된 이유로 테스트가 통과/실패)된다."""
+    anchor_hyp = Hypothesis(id=uuid.uuid4())
     doc_id = uuid.uuid4()
     loop = _loop(brief_doc_id=doc_id)
     doc = SimpleNamespace(content="## Context Pack\n\nstory 간접 해소 브리핑.")
@@ -86,7 +91,9 @@ async def test_story_resolves_via_primary_hypothesis_anchor_then_loop_and_doc():
 
 
 async def test_epic_resolves_via_primary_hypothesis_anchor():
-    anchor_hyp = SimpleNamespace(id=uuid.uuid4())
+    """anchor_hyp은 실제 Hypothesis 인스턴스여야 isinstance 방어를 통과해 loop 쿼리까지
+    genuinely 도달한다(SimpleNamespace면 방어에서 조기 반환돼 masking)."""
+    anchor_hyp = Hypothesis(id=uuid.uuid4())
     session = _scalar_one_or_none_session(None)  # anchor는 있지만 연결 loop이 없음.
     with patch.object(
         hyp_svc.HypothesisRepository, "resolve_primary_anchor", AsyncMock(return_value=anchor_hyp),

--- a/backend/tests/test_e_loop_ledger_p1_s11_dispatch_context_pack.py
+++ b/backend/tests/test_e_loop_ledger_p1_s11_dispatch_context_pack.py
@@ -1,9 +1,11 @@
-"""E-LOOP-LEDGER P1-S11: Context Pack agent dispatch 주입 단위 테스트(mock, 블루프린트 §2).
+"""E-LOOP-LEDGER P1-S11(+S11b): Context Pack agent dispatch 주입 단위 테스트(mock, 블루프린트 §2).
 
 3개 델리버리 경로(BYO=event.payload passthrough·CC payload dict·CC delivery dict+
 deliver_injected_event_webhook)가 전부 context_pack을 실제로 받는지, brief 없으면 null로
 graceful하게 생략되는지, 기존 dispatch(trigger_metadata 등) 무회귀를 검증한다.
-hypothesis-only 스코프(story/epic/sprint/doc은 즉시 None, DB 쿼리 0)도 확인.
+S11b(2026-07-02): story/epic도 resolve_primary_anchor로 간접 해소(hypothesis_anchor와 동일
+SSOT)·sprint/doc은 그 anchor 메커니즘 자체가 커버 안 하는 범위라 동형으로 스코프 밖(즉시
+None, DB 쿼리 0).
 """
 from __future__ import annotations
 
@@ -41,12 +43,58 @@ def _scalar_one_or_none_session(value):
     return s
 
 
-async def test_non_hypothesis_entity_returns_none_without_query():
+async def test_out_of_scope_entity_returns_none_without_query():
+    """sprint/doc은 hypothesis_anchor 메커니즘 자체가 커버 안 하는 범위 — 동형으로 스코프 밖."""
     session = AsyncMock()
     session.execute = AsyncMock()
-    out = await hyp_svc.resolve_dispatch_context_pack(session, uuid.uuid4(), "story", uuid.uuid4())
+    out = await hyp_svc.resolve_dispatch_context_pack(session, uuid.uuid4(), "sprint", uuid.uuid4())
     assert out is None
     session.execute.assert_not_called()
+
+
+async def test_story_with_no_primary_hypothesis_returns_none():
+    """S11b: story/epic 모두 primary anchor가 없으면(hypothesis_story_links 미해소) None."""
+    with patch.object(
+        hyp_svc.HypothesisRepository, "resolve_primary_anchor", AsyncMock(return_value=None),
+    ):
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        out = await hyp_svc.resolve_dispatch_context_pack(session, uuid.uuid4(), "story", uuid.uuid4())
+    assert out is None
+    session.execute.assert_not_called()  # anchor 자체가 없으면 loop/doc 쿼리 자체를 안 함.
+
+
+async def test_story_resolves_via_primary_hypothesis_anchor_then_loop_and_doc():
+    """S11b: story→primary hypothesis anchor→그 hypothesis의 loop→brief doc 경로가 전부 합류."""
+    anchor_hyp = SimpleNamespace(id=uuid.uuid4())
+    doc_id = uuid.uuid4()
+    loop = _loop(brief_doc_id=doc_id)
+    doc = SimpleNamespace(content="## Context Pack\n\nstory 간접 해소 브리핑.")
+
+    session = AsyncMock()
+    loop_result = MagicMock()
+    loop_result.scalar_one_or_none.return_value = loop
+    doc_result = MagicMock()
+    doc_result.scalar_one_or_none.return_value = doc
+    session.execute = AsyncMock(side_effect=[loop_result, doc_result])
+
+    with patch.object(
+        hyp_svc.HypothesisRepository, "resolve_primary_anchor", AsyncMock(return_value=anchor_hyp),
+    ):
+        out = await hyp_svc.resolve_dispatch_context_pack(session, uuid.uuid4(), "story", uuid.uuid4())
+    assert out == doc.content
+
+
+async def test_epic_resolves_via_primary_hypothesis_anchor():
+    anchor_hyp = SimpleNamespace(id=uuid.uuid4())
+    session = _scalar_one_or_none_session(None)  # anchor는 있지만 연결 loop이 없음.
+    with patch.object(
+        hyp_svc.HypothesisRepository, "resolve_primary_anchor", AsyncMock(return_value=anchor_hyp),
+    ) as mock_resolve:
+        out = await hyp_svc.resolve_dispatch_context_pack(session, uuid.uuid4(), "epic", uuid.uuid4())
+    assert out is None
+    mock_resolve.assert_called_once()
+    assert mock_resolve.call_args.args[0] == "epic"
 
 
 async def test_no_linked_loop_returns_none():

--- a/backend/tests/test_e_loop_ledger_p1_s11_dispatch_context_pack.py
+++ b/backend/tests/test_e_loop_ledger_p1_s11_dispatch_context_pack.py
@@ -92,7 +92,12 @@ async def test_story_resolves_via_primary_hypothesis_anchor_then_loop_and_doc():
 
 async def test_epic_resolves_via_primary_hypothesis_anchor():
     """anchor_hyp은 실제 Hypothesis 인스턴스여야 isinstance 방어를 통과해 loop 쿼리까지
-    genuinely 도달한다(SimpleNamespace면 방어에서 조기 반환돼 masking)."""
+    genuinely 도달한다(SimpleNamespace면 방어에서 조기 반환돼 masking).
+
+    까심/codex QA RC(2026-07-02): out is None 단독으로는 "가드가 조기 거부"와 "가드 통과 후
+    loop 쿼리 결과가 없어 None"을 구분 못 한다(둘 다 out is None) — isinstance 가드를 통째로
+    제거해도 이 테스트는 통과해 회귀탐지력이 0이었다. session.execute(loop 쿼리) 실제 호출
+    여부를 직접 검증해 "가드를 genuinely 통과했다"는 것을 관찰 가능하게 만든다."""
     anchor_hyp = Hypothesis(id=uuid.uuid4())
     session = _scalar_one_or_none_session(None)  # anchor는 있지만 연결 loop이 없음.
     with patch.object(
@@ -102,6 +107,9 @@ async def test_epic_resolves_via_primary_hypothesis_anchor():
     assert out is None
     mock_resolve.assert_called_once()
     assert mock_resolve.call_args.args[0] == "epic"
+    # 가드 통과 증명 — 가드가 anchor_hyp을 거부했다면 loop 쿼리(session.execute)는 호출되지
+    # 않았을 것이다. 이 assertion이 있어야 isinstance 가드 제거 시 이 테스트가 genuinely 실패한다.
+    session.execute.assert_called_once()
 
 
 async def test_no_linked_loop_returns_none():

--- a/backend/tests/test_e_loop_ledger_p1_s11_dispatch_context_pack_realdb.py
+++ b/backend/tests/test_e_loop_ledger_p1_s11_dispatch_context_pack_realdb.py
@@ -1,10 +1,13 @@
-"""E-LOOP-LEDGER P1-S11: resolve_dispatch_context_pack 실 Postgres 검증(블루프린트 §2).
+"""E-LOOP-LEDGER P1-S11(+S11b): resolve_dispatch_context_pack 실 Postgres 검증(블루프린트 §2).
 
 핵심: hypothesis→loop 1:0..N 관계에서 최신(created_at desc)·non-abandoned 1개만 선택되는지·
 brief_doc_id 없는 loop은 None인지를 실 DB round-trip으로 직접 검증. 순수 wiring(payload/delivery
 dict 조립)은 mock 테스트(test_e_loop_ledger_p1_s11_dispatch_context_pack.py)가 이미 커버 —
 여기선 신규 SQL 쿼리 로직(정렬·필터)만 실 DB로 검증한다(resolve_dispatch_anchor의 실DB 검증이
 별도 스모크로 분리된 것과 동형 관례).
+
+S11b: story dispatch가 hypothesis_story_links(link_type='primary')를 거쳐 그 hypothesis의
+loop→brief doc까지 실 DB round-trip으로 합류하는지도 검증.
 """
 from __future__ import annotations
 
@@ -127,6 +130,107 @@ async def test_loop_without_brief_doc_id_returns_none_real_db():
         async with Session() as s:
             out = await resolve_dispatch_context_pack(s, org, "hypothesis", hyp_id)
         assert out is None
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_story_dispatch_resolves_via_primary_hypothesis_link_to_loop_brief_real_db():
+    """S11b: story dispatch → hypothesis_story_links(primary) → 그 hypothesis의 최신 non-abandoned
+    loop → brief doc까지 실 DB round-trip 전부 합류."""
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.models.doc import Doc
+    from app.models.hypothesis import Hypothesis, HypothesisStoryLink
+    from app.models.loop import LoopRun
+    from app.models.pm import Story
+    from app.services.hypothesis import resolve_dispatch_context_pack
+
+    engine, Session = await _session()
+    org, project = uuid.uuid4(), uuid.uuid4()
+    hyp_id, story_id, loop_id, doc_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    now = datetime.now(timezone.utc)
+
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add_all([
+                Story(id=story_id, org_id=org, project_id=project, title="story"),
+                Hypothesis(
+                    id=hyp_id, org_id=org, project_id=project, owner_member_id=uuid.uuid4(),
+                    statement="가설", metric_definition={"metric": "x", "source": "manual", "target": 1, "direction": "up"},
+                    measure_after=now, status="active",
+                ),
+                Doc(id=doc_id, org_id=org, project_id=project, title="brief", slug="brief",
+                    content="## Context Pack\n\nstory 간접 해소 브리핑."),
+            ])
+            await s.flush()
+            s.add_all([
+                HypothesisStoryLink(id=uuid.uuid4(), hypothesis_id=hyp_id, story_id=story_id, link_type="primary"),
+                LoopRun(id=loop_id, org_id=org, project_id=project, hypothesis_id=hyp_id,
+                        title="loop", created_by_member_id=uuid.uuid4(),
+                        status="briefing", brief_doc_id=doc_id),
+            ])
+            await s.commit()
+
+        async with Session() as s:
+            out = await resolve_dispatch_context_pack(s, org, "story", story_id)
+        assert out == "## Context Pack\n\nstory 간접 해소 브리핑."
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_story_without_primary_link_falls_back_to_epic_primary_real_db():
+    """S11b AC①: story에 primary link가 없으면 그 story의 epic의 primary hypothesis로 fallback
+    (resolve_primary_anchor의 기존 story→epic fallback을 그대로 재사용함을 실 DB로 확인)."""
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.models.doc import Doc
+    from app.models.hypothesis import Hypothesis, HypothesisEpicLink
+    from app.models.loop import LoopRun
+    from app.models.pm import Epic, Story
+    from app.services.hypothesis import resolve_dispatch_context_pack
+
+    engine, Session = await _session()
+    org, project = uuid.uuid4(), uuid.uuid4()
+    epic_id, hyp_id, story_id, loop_id, doc_id = (
+        uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), uuid.uuid4(),
+    )
+    now = datetime.now(timezone.utc)
+
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add_all([
+                Epic(id=epic_id, org_id=org, project_id=project, title="epic"),
+                Hypothesis(
+                    id=hyp_id, org_id=org, project_id=project, owner_member_id=uuid.uuid4(),
+                    statement="가설", metric_definition={"metric": "x", "source": "manual", "target": 1, "direction": "up"},
+                    measure_after=now, status="active",
+                ),
+                Doc(id=doc_id, org_id=org, project_id=project, title="brief", slug="brief",
+                    content="## Context Pack\n\nepic fallback 브리핑."),
+            ])
+            await s.flush()
+            s.add_all([
+                Story(id=story_id, org_id=org, project_id=project, epic_id=epic_id, title="story"),
+                HypothesisEpicLink(id=uuid.uuid4(), hypothesis_id=hyp_id, epic_id=epic_id, link_type="primary"),
+                LoopRun(id=loop_id, org_id=org, project_id=project, hypothesis_id=hyp_id,
+                        title="loop", created_by_member_id=uuid.uuid4(),
+                        status="briefing", brief_doc_id=doc_id),
+            ])
+            await s.commit()
+
+        async with Session() as s:
+            out = await resolve_dispatch_context_pack(s, org, "story", story_id)
+        assert out == "## Context Pack\n\nepic fallback 브리핑."
     finally:
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)


### PR DESCRIPTION
## Summary
S11(Context Pack dispatch 주입)은 `entity_type=='hypothesis'`만 스코프라, story/epic 배정으로 dispatch되는 에이전트는 Context Pack을 못 받았다. `hypothesis_anchor`는 이미 story/epic을 지원하는데 `context_pack`만 뒤처진 gap([[gap-as-story]], S11 크럭스서 명시 deferred).

`resolve_dispatch_context_pack`이 story/epic도 처리하도록 확장 — `HypothesisRepository.resolve_primary_anchor`(hypothesis_anchor와 완전히 동일한 SSOT)로 대표 hypothesis를 먼저 해소한 뒤, 기존 hypothesis→loop→brief doc 조회 로직에 그대로 합류한다(신규 SQL 쿼리 로직 없음 — 기존 결정론적 heuristic 재사용).
- story: story-link `primary` 우선 → 없으면 그 story의 epic-link `primary`로 fallback(hypothesis_anchor와 동형).
- epic: epic-link `primary` 직접.
- sprint/doc: anchor 메커니즘 자체가 커버 안 하는 범위라 그대로 스코프 밖 유지(스코프 확장 안 함 — AC의 "필요 시 커버" 판단).

## Test plan
- [x] mock 단위(12개): out-of-scope(sprint) 쿼리 0회 확인, primary anchor 없으면 loop/doc 쿼리 자체를 안 함, story/epic 각각 `resolve_primary_anchor` 경유 확인.
- [x] realdb round-trip 신규 2건: story→primary link→loop→brief doc / story→(link 없음)→epic primary fallback→loop→brief doc.
- [x] **비-동어반복 검증**: story/epic 분기를 제거하고 hypothesis-only로 되돌림 → 신규 realdb 테스트 2건이 genuinely 실패(`assert None == 브리핑 텍스트`) → 원복 → 재확인 GREEN.
- [x] S11 기존 hypothesis 직접경로 회귀(4개) 무영향.
- [x] 같은 alembic 0153 위 S14/S19/S1/S22/S24/S2/S3/S4/S5/S7/S8(124개) 무회귀.
- [x] `uvx ruff check` 신규 위반 0(baseline E402 pre-existing 확인).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>