### PR TITLE
feat(e-loop-ledger): S17 — loop-agency builtin recipe

### DIFF
--- a/backend/app/routers/workflow_recipes.py
+++ b/backend/app/routers/workflow_recipes.py
@@ -57,6 +57,45 @@ _BUILTIN_RECIPES: list[dict[str, Any]] = [
         ],
         "builtin": True,
     },
+    # E-LOOP-LEDGER S17(블루프린트 §5): 복리 조직기억 loop — 목표·가설부터 실행·성과 학습까지
+    # 폐루프. 비개발 조직의 반복 실험(카피 테스트·캠페인 variant 등)에 적합. 6단계는 블루프린트
+    # §5가 명시한 DAG 그대로(Goal&Hypothesis→Brief→Generate Variants→Human Pick→Execute→
+    # Track&Learn) — loop_runs/loop_artifacts/gate(loop_decision) 실제 엔티티·게이트명과 정합.
+    {
+        "id": "loop-agency",
+        "slug": "loop-agency",
+        "name": "루프 에이전시",
+        "description": "목표·가설 설정 → 브리프 → 실행안 생성 → 인간 선택 → 실행 → 성과 학습까지 이어지는 "
+                        "복리 조직기억 워크플로우. 반복되는 실험(카피·캠페인 variant 등)에 적합.",
+        "steps": [
+            {
+                "role": "Human", "label": "목표·가설 정의", "pattern": "goal_hypothesis",
+                "action": "loop의 목표(goal)와 성과 가설(hypothesis)·측정 지표(metric)를 정의",
+            },
+            {
+                "role": "PO", "label": "브리프 작성", "pattern": "brief_doc_approval",
+                "action": "실행 계획을 브리프 문서로 작성하고 doc_approval 게이트를 통과",
+            },
+            {
+                "role": "Agent", "label": "실행안 생성", "pattern": "generate_variants",
+                "action": "brief를 바탕으로 복수의 실행안(variant)을 생성해 loop_artifacts로 등록",
+            },
+            {
+                "role": "Human", "label": "인간 선택", "pattern": "loop_decision",
+                "action": "실행안 중 하나를 선택(choose)하고 이유를 기록·나머지는 반려(reject) 이유를 기록",
+            },
+            {
+                "role": "Any", "label": "실행", "pattern": "execute",
+                "action": "선택된 실행안을 외부(캠페인 발행·배포 등)에서 실행",
+            },
+            {
+                "role": "Any", "label": "추적 및 학습", "pattern": "track_and_learn",
+                "action": "성과(GA4 등)를 측정해 outcome_snapshot으로 귀속하고, 다음 loop의 Context "
+                          "Pack에 이 loop의 선택·이유·성과가 학습 근거로 반영되게 한다",
+            },
+        ],
+        "builtin": True,
+    },
 ]
 
 _BUILTIN_BY_ID = {r["id"]: r for r in _BUILTIN_RECIPES}

--- a/backend/tests/test_s3_1_workflow_recipes.py
+++ b/backend/tests/test_s3_1_workflow_recipes.py
@@ -52,7 +52,7 @@ async def _client():
 
 @pytest.mark.anyio
 async def test_list_recipes_includes_builtins():
-    """AC1/6: GET /workflow-recipes — builtin 3종 포함."""
+    """AC1/6: GET /workflow-recipes — builtin 4종 포함(S17: loop-agency 추가)."""
     client, session, app = await _client()
     try:
         # DB에 템플릿 없는 경우
@@ -69,7 +69,8 @@ async def test_list_recipes_includes_builtins():
         assert "scrum-3step" in slugs
         assert "kanban-simple" in slugs
         assert "solo" in slugs
-        assert len(body) >= 3
+        assert "loop-agency" in slugs
+        assert len(body) >= 4
     finally:
         app.dependency_overrides.clear()
 
@@ -225,10 +226,10 @@ async def test_workflow_templates_endpoint_still_works():
 # ─── AC6: 3종 프리셋 단위 확인 ───────────────────────────────────────────────
 
 def test_builtin_recipes_slugs():
-    """AC6: 코드 내 3종 프리셋 slug 확인."""
+    """AC6(+S17): 코드 내 4종 프리셋 slug 확인(scrum-3step·kanban-simple·solo·loop-agency)."""
     from app.routers.workflow_recipes import _BUILTIN_RECIPES
     slugs = {r["slug"] for r in _BUILTIN_RECIPES}
-    assert slugs == {"scrum-3step", "kanban-simple", "solo"}
+    assert slugs == {"scrum-3step", "kanban-simple", "solo", "loop-agency"}
 
 
 def test_generate_guide_markdown_format():
@@ -240,3 +241,42 @@ def test_generate_guide_markdown_format():
     assert "###" in guide
     assert "**담당 역할**" in guide
     assert "**기대 행동**" in guide
+
+
+# ─── S17(블루프린트 §5): loop-agency 레시피 ─────────────────────────────────
+
+def test_loop_agency_recipe_has_blueprint_6_step_dag():
+    """블루프린트 §5 DAG 그대로: Goal&Hypothesis→Brief→Generate Variants→Human Pick→
+    Execute→Track&Learn — 6단계·pattern이 실제 엔티티/게이트명과 정합(S18이 이 pattern에
+    의존할 수 있게)."""
+    from app.routers.workflow_recipes import _BUILTIN_BY_ID
+    recipe = _BUILTIN_BY_ID["loop-agency"]
+    assert recipe["name"]
+    assert recipe["builtin"] is True
+    patterns = [s["pattern"] for s in recipe["steps"]]
+    assert patterns == [
+        "goal_hypothesis", "brief_doc_approval", "generate_variants",
+        "loop_decision", "execute", "track_and_learn",
+    ]
+
+
+@pytest.mark.anyio
+async def test_get_guide_builtin_loop_agency():
+    """AC2/3(S17): GET /workflow-recipes/loop-agency/guide — 마크다운+6단계 전부 서술."""
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get("/api/v2/workflow-recipes/loop-agency/guide")
+
+        assert resp.status_code == 200
+        guide = resp.json()["guide"]
+        for i in range(1, 7):
+            assert f"{i}단계" in guide
+        assert "가설" in guide
+        assert "loop_artifacts" in guide or "실행안" in guide
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
`_BUILTIN_RECIPES`에 `loop-agency` 추가 — 블루프린트 §5가 명시한 6단계 DAG 그대로: Goal&Hypothesis→Brief(doc_approval)→Generate Variants(loop_artifacts)→Human Pick(loop_decision gate)→Execute(외부)→Track&Learn(GA4→outcome_snapshot→다음 loop Context Pack). 각 step의 `pattern`은 실제 엔티티/게이트명과 정합(S18의 recipe→loop scaffold가 이 pattern에 안전하게 의존할 수 있게). 기존 3종(scrum-3step·kanban-simple·solo)과 동일 구조(role/label/pattern/action)로 additive — `get_recipe_guide`/`list_recipes` 기존 serving 경로를 그대로 재사용(신규 라우트 없음).

## ⚠️ 스코프 노트(PO 크럭스 확인 요청)
블루프린트 §5: "`get_workflow_guide`가 서빙(**loop 프로젝트 기본** recipe)" — 이 "기본"은 이 스토리에서 구현하지 않았습니다.

실측: `list_recipes`(`app/routers/workflow_recipes.py`)와 `get_workflow_guide`(`sprintable_mcp/tools/core.py`)는 **project_id 스코핑이 전혀 없습니다** — 라우터가 `project_id` 파라미터 자체를 선언하지 않아, MCP 클라이언트가 보내는 `project_id`가 조용히 무시됩니다. `get_workflow_guide`는 그냥 `GET /workflow-recipes`의 **첫 번째** 레시피를 서빙합니다(현재는 `scrum-3step`).

"프로젝트 기본"을 문자 그대로 구현하려면 project-type 인식 + 정렬/필터 로직이라는 훨씬 큰 아키텍처 변경이 필요해 "2pt·additive" 스코프를 벗어난다고 판단했습니다. `loop-agency`는 S18(Goal 폼)에서 `recipe_slug`로 명시 선택되는 경로로 노출되는 게 자연스러운 "기본" 실현이라 보는데, 확인 부탁드립니다.

## Test plan
- [x] `test_builtin_recipes_slugs`: 4종(scrum-3step/kanban-simple/solo/loop-agency).
- [x] `test_loop_agency_recipe_has_blueprint_6_step_dag`: pattern 6개가 블루프린트 순서·명칭과 정확히 일치.
- [x] `test_get_guide_builtin_loop_agency`: 마크다운 가이드에 6단계 전부 서술.
- [x] `test_list_recipes_includes_builtins` 갱신(4종 반영).
- [x] AC1-6 전체 회귀(43개, workflow_recipe/template/guide) GREEN·lint 클린.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>