### PR TITLE
[SID:c8842b40] E-LOOP-LEDGER S28c — L2/L3 본문 줄바꿈 렌더(구조 flatten fix)

### DIFF
--- a/apps/web/src/components/loops/context-pack-panel.tsx
+++ b/apps/web/src/components/loops/context-pack-panel.tsx
@@ -194,7 +194,7 @@ export function ContextPackPanel({ loopId }: { loopId: string }) {
                       <p className="font-semibold">{t('contextPackSynthesisTitle')}</p>
                       <AiAttributionRow confidence={data.synthesis_confidence} evidenceCount={data.evidence_count} />
                     </div>
-                    <p className="text-info/90">{data.synthesis}</p>
+                    <p className="whitespace-pre-line text-info/90">{data.synthesis}</p>
                   </div>
                 </div>
                 <AiTransparencyLine className="border-info-border/60" />
@@ -209,7 +209,7 @@ export function ContextPackPanel({ loopId }: { loopId: string }) {
                       <p className="font-medium text-foreground/80">{t('contextPackRecommendationTitle')}</p>
                       <AiAttributionRow confidence={data.recommendation_confidence} evidenceCount={data.evidence_count} />
                     </div>
-                    <p>{data.recommendation}</p>
+                    <p className="whitespace-pre-line">{data.recommendation}</p>
                   </div>
                 </div>
                 <AiTransparencyLine />


### PR DESCRIPTION
## Summary
- 선생님 dev 점검 적출: LLM이 "- 패턴 / - 다음 행동 / - 회피할 것 / - 리스크" 구조로 synthesis(L2)/recommendation(L3)를 출력하는데, FE가 `<p>{text}</p>` 그대로 렌더해 CSS 기본 `white-space: normal`이 개행을 다 삼켜 한 문단으로 뭉쳐 보이던 문제
- 두 `<p>` 모두 `whitespace-pre-line` 클래스 추가 — `\n`은 줄바꿈으로 보존하고 여분 공백/탭만 접어서 불릿 구조가 그대로 드러남
- 소량 fix(2줄 diff), 신규 로직/토큰 없음

## Test plan
- [x] `tsc --noEmit` / `eslint` / `next build` 전부 EXIT 0
- [x] `vitest run` 전체 스위트 167 files / 1038 tests 전부 통과, 회귀 0
- [x] 격리 docker + Service Worker로 실제 "- " 불릿 다중행 텍스트 mock → 라이트/다크 둘 다 줄바꿈이 시각적으로 보존되는 것 확인, 크래시 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)