### PR TITLE
[SID:9f7dde83] E-LOOP-LEDGER S18 — recipe→loop scaffold(recipe_slug 명시선택)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2683,7 +2683,9 @@
     "aiConfidenceLevel_high": "High",
     "aiConfidenceLevel_medium": "Medium",
     "aiConfidenceLevel_low": "Low",
-    "aiTransparencyLine": "AI-assisted reference — the judgment is yours."
+    "aiTransparencyLine": "AI-assisted reference — the judgment is yours.",
+    "createLoopRecipeLabel": "Workflow recipe (optional)",
+    "createLoopRecipeNone": "Go it alone"
   },
   "sprints": {
     "title": "Sprints",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2683,7 +2683,9 @@
     "aiConfidenceLevel_high": "높음",
     "aiConfidenceLevel_medium": "보통",
     "aiConfidenceLevel_low": "낮음",
-    "aiTransparencyLine": "AI가 도운 참고 자료입니다 · 판단은 당신이 합니다."
+    "aiTransparencyLine": "AI가 도운 참고 자료입니다 · 판단은 당신이 합니다.",
+    "createLoopRecipeLabel": "실행 방식 (선택)",
+    "createLoopRecipeNone": "직접 진행"
   },
   "sprints": {
     "title": "스프린트",

--- a/apps/web/src/app/api/workflow-recipes/route.ts
+++ b/apps/web/src/app/api/workflow-recipes/route.ts
@@ -1,0 +1,7 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// GET /api/workflow-recipes → FastAPI GET /api/v2/workflow-recipes (E-LOOP-LEDGER S18).
+// Raw passthrough (loops.ts convention) — BE returns a raw RecipeResponse[], no {data} envelope.
+export async function GET(request: Request): Promise<Response> {
+  return proxyToFastapi(request, '/api/v2/workflow-recipes');
+}

--- a/apps/web/src/components/loops/loop-create-dialog.tsx
+++ b/apps/web/src/components/loops/loop-create-dialog.tsx
@@ -70,6 +70,7 @@ export function LoopCreateDialog({
   const [linkedId, setLinkedId] = useState<string | null>(null);
 
   const [recipes, setRecipes] = useState<WorkflowRecipe[] | null>(null);
+  const [recipesFailed, setRecipesFailed] = useState(false);
   const [recipeSlug, setRecipeSlug] = useState('');
 
   const [submitting, setSubmitting] = useState(false);
@@ -90,6 +91,7 @@ export function LoopCreateDialog({
     setError(null);
     setDrafted(false);
     setRecipeSlug('');
+    setRecipesFailed(false);
   }, []);
 
   const handleDraft = useCallback(async () => {
@@ -135,19 +137,20 @@ export function LoopCreateDialog({
   }, [open, mode, hypotheses, projectId]);
 
   // E-LOOP-LEDGER S18 — recipe 목록은 선택 기능이라 fetch 실패해도 select 옵션만 없어질 뿐
-  // (null-safe, "직접 진행" 기본값으로 폼은 정상 동작).
+  // (null-safe, "직접 진행" 기본값으로 폼은 정상 동작). 실패는 recipesFailed로만 표시하고
+  // recipes는 null로 유지 — 닫힘/재오픈(reset)마다 recipesFailed가 풀려 재시도된다(영구 실종 방지).
   useEffect(() => {
-    if (!open || recipes !== null) return;
+    if (!open || recipes !== null || recipesFailed) return;
     void (async () => {
       try {
         const res = await fetch('/api/workflow-recipes');
-        if (!res.ok) { setRecipes([]); return; }
+        if (!res.ok) { setRecipesFailed(true); return; }
         setRecipes((await res.json()) as WorkflowRecipe[]);
       } catch {
-        setRecipes([]);
+        setRecipesFailed(true);
       }
     })();
-  }, [open, recipes]);
+  }, [open, recipes, recipesFailed]);
 
   const setMetricPatch = (patch: Partial<MetricDefinition>) => setMetric((m) => ({ ...m, ...patch }));
 
@@ -241,8 +244,9 @@ export function LoopCreateDialog({
 
           {recipes && recipes.length > 0 ? (
             <div className="space-y-1">
-              <label className="text-xs font-medium text-muted-foreground">{t('createLoopRecipeLabel')}</label>
+              <label htmlFor="loop-create-recipe" className="text-xs font-medium text-muted-foreground">{t('createLoopRecipeLabel')}</label>
               <select
+                id="loop-create-recipe"
                 value={recipeSlug}
                 onChange={(e) => setRecipeSlug(e.target.value)}
                 className="w-full rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"

--- a/apps/web/src/components/loops/loop-create-dialog.tsx
+++ b/apps/web/src/components/loops/loop-create-dialog.tsx
@@ -23,6 +23,16 @@ const EMPTY_METRIC: MetricDefinition = { metric: '', source: 'internal_ops', tar
 
 type Mode = 'new' | 'link';
 
+/** E-LOOP-LEDGER S18 — GET /api/workflow-recipes 응답 shape(블루프린트 §5, backend/app/routers/workflow_recipes.py 실측). */
+interface WorkflowRecipe {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  steps: { role: string; label: string; pattern: string; action: string }[];
+  builtin: boolean;
+}
+
 /**
  * E-LOOP-LEDGER S16 — net-new loop 생성 모달(핸드오프 §1/§2, render doc ec26cd28).
  * Goal(hypothesis) 필수 강제: trio(statement+metric_definition+measure_after) 또는
@@ -59,6 +69,9 @@ export function LoopCreateDialog({
   const [hypothesisSearch, setHypothesisSearch] = useState('');
   const [linkedId, setLinkedId] = useState<string | null>(null);
 
+  const [recipes, setRecipes] = useState<WorkflowRecipe[] | null>(null);
+  const [recipeSlug, setRecipeSlug] = useState('');
+
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -76,6 +89,7 @@ export function LoopCreateDialog({
     setHypothesisSearch('');
     setError(null);
     setDrafted(false);
+    setRecipeSlug('');
   }, []);
 
   const handleDraft = useCallback(async () => {
@@ -120,6 +134,21 @@ export function LoopCreateDialog({
     })();
   }, [open, mode, hypotheses, projectId]);
 
+  // E-LOOP-LEDGER S18 — recipe 목록은 선택 기능이라 fetch 실패해도 select 옵션만 없어질 뿐
+  // (null-safe, "직접 진행" 기본값으로 폼은 정상 동작).
+  useEffect(() => {
+    if (!open || recipes !== null) return;
+    void (async () => {
+      try {
+        const res = await fetch('/api/workflow-recipes');
+        if (!res.ok) { setRecipes([]); return; }
+        setRecipes((await res.json()) as WorkflowRecipe[]);
+      } catch {
+        setRecipes([]);
+      }
+    })();
+  }, [open, recipes]);
+
   const setMetricPatch = (patch: Partial<MetricDefinition>) => setMetric((m) => ({ ...m, ...patch }));
 
   const isGa4 = metric.source === 'ga4';
@@ -143,6 +172,7 @@ export function LoopCreateDialog({
         title: title.trim(),
         goal_tags: tags.split(',').map((s) => s.trim()).filter(Boolean),
       };
+      if (recipeSlug) body['recipe_slug'] = recipeSlug;
       if (mode === 'link') {
         body['hypothesis_id'] = linkedId;
       } else {
@@ -175,12 +205,13 @@ export function LoopCreateDialog({
     } finally {
       setSubmitting(false);
     }
-  }, [canSubmit, projectId, title, tags, mode, linkedId, statement, isGa4, metric, measureAfter, reset, onOpenChange, onCreated, t]);
+  }, [canSubmit, projectId, title, tags, mode, linkedId, statement, isGa4, metric, measureAfter, recipeSlug, reset, onOpenChange, onCreated, t]);
 
   const filteredHypotheses = (hypotheses ?? []).filter((h) =>
     h.statement.toLowerCase().includes(hypothesisSearch.trim().toLowerCase()),
   );
   const linkedHypothesis = hypotheses?.find((h) => h.id === linkedId) ?? null;
+  const selectedRecipe = recipes?.find((r) => r.slug === recipeSlug) ?? null;
 
   return (
     <Dialog
@@ -207,6 +238,32 @@ export function LoopCreateDialog({
               className="w-full rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
             />
           </div>
+
+          {recipes && recipes.length > 0 ? (
+            <div className="space-y-1">
+              <label className="text-xs font-medium text-muted-foreground">{t('createLoopRecipeLabel')}</label>
+              <select
+                value={recipeSlug}
+                onChange={(e) => setRecipeSlug(e.target.value)}
+                className="w-full rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+              >
+                <option value="">{t('createLoopRecipeNone')}</option>
+                {recipes.map((r) => (
+                  <option key={r.slug} value={r.slug}>{r.name}</option>
+                ))}
+              </select>
+              {selectedRecipe ? (
+                <div className="space-y-1 rounded-lg border border-dashed border-border bg-muted/30 p-2 text-[10.5px] text-muted-foreground">
+                  <p>{selectedRecipe.description}</p>
+                  <ol className="list-decimal space-y-0.5 pl-4">
+                    {selectedRecipe.steps.map((s, i) => (
+                      <li key={i}><span className="font-medium text-foreground">{s.label}</span> ({s.role})</li>
+                    ))}
+                  </ol>
+                </div>
+              ) : null}
+            </div>
+          ) : null}
 
           <div className="space-y-2.5 rounded-xl border border-border bg-muted/20 p-3">
             <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary
- 블루프린트 §5/§6 — S17이 지어둔 `loop-agency` builtin recipe(+ `GET /workflow-recipes`)를 S16 loop-create 다이얼로그의 Goal 단계에서 소비
- "실행 방식 (선택)" 드롭다운(제목 필드 바로 아래) — recipe 선택 시 `recipe_slug`를 `POST /api/loops` 페이로드에 실어 loop를 명시적으로 태그
- recipe 선택 시 `recipe.steps`(6단계 DAG: 목표·가설 정의→브리프 작성→실행안 생성→인간 선택→실행→추적 및 학습)를 그대로 렌더 — 커밋 전 워크플로우 구조 미리보기
- BFF `/api/workflow-recipes` 신설(raw passthrough, `/api/loops` 컨벤션과 동형)
- recipe 미선택("직접 진행" 기본값)은 기존 S16 폼과 완전 동일 동작 — `recipe_slug`는 optional이라 검증 로직(트리오/링크) 무변경, 회귀 0

## Test plan
- [x] `tsc --noEmit` / `eslint` / `next build` 전부 EXIT 0
- [x] `vitest run` 전체 스위트 167 files / 1038 tests 전부 통과, 회귀 0
- [x] 격리 docker(실 S17 BE, `loop-agency` 포함 3종 recipe) 라이브 검증 — recipe 드롭다운에서 "루프 에이전시" 선택 시 실 6단계가 정확히 렌더, 선택 후 loop 생성 성공 → 상세 페이지에 "레시피: loop-agency" 정상 반영(기존 S6 표시 로직 무변경 확인)
- [x] 다크모드 확인, 크래시 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)