### PR TITLE
[SID:0a553a95] 워크플로우 레시피 콘텐츠 i18n — 로케일별 name/description/step label

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3069,5 +3069,46 @@
     "seedKill": "Kill",
     "outcomeAccumulating": "Awaiting verdict data",
     "evidenceNonePrompt": "No evidence yet — review by content"
+  },
+  "workflowRecipes": {
+    "scrum-3step": {
+      "name": "3-Step Scrum",
+      "description": "Plan → Build → QA three-stage workflow. Fits small to mid-size sprints.",
+      "steps": {
+        "kickoff": { "label": "Define requirements" },
+        "implementation": { "label": "Build" },
+        "qa_review": { "label": "Verify" }
+      }
+    },
+    "kanban-simple": {
+      "name": "Simple Kanban",
+      "description": "To Do → In Progress → Done flow. Fits continuous delivery environments.",
+      "steps": {
+        "task_created": { "label": "Pick up task" },
+        "in_progress": { "label": "In progress" },
+        "done_check": { "label": "Confirm done" }
+      }
+    },
+    "solo": {
+      "name": "Solo Agent",
+      "description": "A single agent handles every stage. Fits simple automated tasks.",
+      "steps": {
+        "received": { "label": "Receive & analyze" },
+        "execute": { "label": "Execute" },
+        "report": { "label": "Report" }
+      }
+    },
+    "loop-agency": {
+      "name": "Loop Agency",
+      "description": "Compounding org-memory workflow — goal & hypothesis → brief → generate variants → human pick → execute → learn from outcomes. Fits recurring experiments (copy tests, campaign variants, etc.).",
+      "steps": {
+        "goal_hypothesis": { "label": "Define goal & hypothesis" },
+        "brief_doc_approval": { "label": "Write brief" },
+        "generate_variants": { "label": "Generate variants" },
+        "loop_decision": { "label": "Human decision" },
+        "execute": { "label": "Execute" },
+        "track_and_learn": { "label": "Track & learn" }
+      }
+    }
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3069,5 +3069,46 @@
     "seedKill": "중단 예측",
     "outcomeAccumulating": "판정 데이터 누적 중",
     "evidenceNonePrompt": "근거 데이터 없음 — 내용으로 직접 판단"
+  },
+  "workflowRecipes": {
+    "scrum-3step": {
+      "name": "3단계 스크럼",
+      "description": "기획 → 개발 → QA 3단계 워크플로우. 소규모~중규모 스프린트에 적합.",
+      "steps": {
+        "kickoff": { "label": "요구사항 정의" },
+        "implementation": { "label": "구현" },
+        "qa_review": { "label": "검증" }
+      }
+    },
+    "kanban-simple": {
+      "name": "칸반 심플",
+      "description": "할 일 → 진행 중 → 완료 단순 흐름. 지속적 딜리버리 환경에 적합.",
+      "steps": {
+        "task_created": { "label": "작업 접수" },
+        "in_progress": { "label": "진행" },
+        "done_check": { "label": "완료 확인" }
+      }
+    },
+    "solo": {
+      "name": "솔로 에이전트",
+      "description": "단일 에이전트가 전 단계를 처리. 간단한 자동화 태스크에 적합.",
+      "steps": {
+        "received": { "label": "수신 및 분석" },
+        "execute": { "label": "실행" },
+        "report": { "label": "보고" }
+      }
+    },
+    "loop-agency": {
+      "name": "루프 에이전시",
+      "description": "목표·가설 설정 → 브리프 → 실행안 생성 → 인간 선택 → 실행 → 성과 학습까지 이어지는 복리 조직기억 워크플로우. 반복되는 실험(카피·캠페인 variant 등)에 적합.",
+      "steps": {
+        "goal_hypothesis": { "label": "목표·가설 정의" },
+        "brief_doc_approval": { "label": "브리프 작성" },
+        "generate_variants": { "label": "실행안 생성" },
+        "loop_decision": { "label": "인간 선택" },
+        "execute": { "label": "실행" },
+        "track_and_learn": { "label": "추적 및 학습" }
+      }
+    }
   }
 }

--- a/apps/web/src/components/loops/loop-create-dialog.test.tsx
+++ b/apps/web/src/components/loops/loop-create-dialog.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { createTranslator } from 'next-intl';
+import enMessagesRaw from '../../../messages/en.json';
+import koMessagesRaw from '../../../messages/ko.json';
+import { localizeRecipe, type WorkflowRecipe } from './loop-create-dialog';
+
+// production `tr` (useTranslations()) resolves against the permissive default `IntlMessages`
+// generic (no global next-intl message-type augmentation in this repo) — cast here so the test
+// translator has the same loose type instead of the JSON import's inferred literal-key type.
+type LooseMessages = { [key: string]: string | LooseMessages };
+const enMessages = enMessagesRaw as unknown as LooseMessages;
+const koMessages = koMessagesRaw as unknown as LooseMessages;
+
+const BUILTIN_RECIPE: WorkflowRecipe = {
+  id: 'loop-agency',
+  slug: 'loop-agency',
+  name: '루프 에이전시',
+  description: '목표·가설 설정 → 브리프 → 실행안 생성 → 인간 선택 → 실행 → 성과 학습까지 이어지는 복리 조직기억 워크플로우. 반복되는 실험(카피·캠페인 variant 등)에 적합.',
+  steps: [
+    { role: 'Human', label: '목표·가설 정의', pattern: 'goal_hypothesis', action: 'define' },
+    { role: 'PO', label: '브리프 작성', pattern: 'brief_doc_approval', action: 'brief' },
+  ],
+  builtin: true,
+};
+
+const CUSTOM_RECIPE: WorkflowRecipe = {
+  id: 'a1b2c3',
+  slug: 'org-authored-flow',
+  name: '조직 자체 워크플로우',
+  description: '조직이 직접 작성한 커스텀 레시피 설명',
+  steps: [{ role: 'Custom', label: '커스텀 단계', pattern: 'unknown_pattern', action: 'do it' }],
+  builtin: false,
+};
+
+describe('localizeRecipe (E-LOOP-LEDGER S18-fu)', () => {
+  it('translates builtin recipe name/description/step labels for en locale', () => {
+    const tr = createTranslator({ locale: 'en', messages: enMessages, namespace: 'workflowRecipes' });
+    const localized = localizeRecipe(BUILTIN_RECIPE, tr);
+    expect(localized.name).toBe('Loop Agency');
+    expect(localized.description).toContain('Compounding org-memory workflow');
+    expect(localized.steps[0].label).toBe('Define goal & hypothesis');
+    expect(localized.steps[1].label).toBe('Write brief');
+  });
+
+  it('resolves builtin recipe through the ko table too (identity mapping, no visual change)', () => {
+    const tr = createTranslator({ locale: 'ko', messages: koMessages, namespace: 'workflowRecipes' });
+    const localized = localizeRecipe(BUILTIN_RECIPE, tr);
+    expect(localized.name).toBe(BUILTIN_RECIPE.name);
+    expect(localized.description).toBe(BUILTIN_RECIPE.description);
+    expect(localized.steps[0].label).toBe(BUILTIN_RECIPE.steps[0].label);
+  });
+
+  it('falls back to BE-original text for a non-builtin (custom/DB) recipe — no crash, no key miss', () => {
+    const tr = createTranslator({ locale: 'en', messages: enMessages, namespace: 'workflowRecipes' });
+    const localized = localizeRecipe(CUSTOM_RECIPE, tr);
+    expect(localized.name).toBe(CUSTOM_RECIPE.name);
+    expect(localized.description).toBe(CUSTOM_RECIPE.description);
+    expect(localized.steps[0].label).toBe(CUSTOM_RECIPE.steps[0].label);
+  });
+
+  it('covers all 4 builtin slugs with complete en translations', () => {
+    const recipes = enMessagesRaw.workflowRecipes as Record<string, { name: string; description: string }>;
+    for (const slug of ['scrum-3step', 'kanban-simple', 'solo', 'loop-agency']) {
+      expect(recipes[slug]?.name).toBeTruthy();
+      expect(recipes[slug]?.description).toBeTruthy();
+    }
+  });
+});

--- a/apps/web/src/components/loops/loop-create-dialog.tsx
+++ b/apps/web/src/components/loops/loop-create-dialog.tsx
@@ -24,13 +24,41 @@ const EMPTY_METRIC: MetricDefinition = { metric: '', source: 'internal_ops', tar
 type Mode = 'new' | 'link';
 
 /** E-LOOP-LEDGER S18 — GET /api/workflow-recipes 응답 shape(블루프린트 §5, backend/app/routers/workflow_recipes.py 실측). */
-interface WorkflowRecipe {
+export interface WorkflowRecipe {
   id: string;
   slug: string;
   name: string;
   description: string;
   steps: { role: string; label: string; pattern: string; action: string }[];
   builtin: boolean;
+}
+
+/** localizeRecipe가 실제로 쓰는 next-intl translator 표면만 뽑은 최소 구조 타입 —
+ * next-intl `Translator<Messages, Namespace>`의 깊은 제네릭에 결합하지 않아 테스트에서
+ * `createTranslator()`로 만든 translator도 그대로 넘길 수 있다. */
+type RecipeTranslator = {
+  (key: string): string;
+  has(key: string): boolean;
+};
+
+/**
+ * E-LOOP-LEDGER S18-fu — builtin 레시피는 BE `_BUILTIN_RECIPES`(Python 리터럴, 정적 콘텐츠)라
+ * `workflowRecipes` 메시지 네임스페이스로 FE-only 매핑한다(BE locale 필드 불요). `t.has()`로
+ * 키 존재를 직접 SSOT 삼아 커스텀(DB WorkflowTemplate) 레시피·미등록 slug는 자동으로 BE 원문
+ * fallback(별도 builtin-slug 화이트리스트 불필요, 크래시 0).
+ */
+export function localizeRecipe(recipe: WorkflowRecipe, tr: RecipeTranslator): WorkflowRecipe {
+  const nameKey = `${recipe.slug}.name`;
+  const descriptionKey = `${recipe.slug}.description`;
+  return {
+    ...recipe,
+    name: tr.has(nameKey) ? tr(nameKey) : recipe.name,
+    description: tr.has(descriptionKey) ? tr(descriptionKey) : recipe.description,
+    steps: recipe.steps.map((step) => {
+      const labelKey = `${recipe.slug}.steps.${step.pattern}.label`;
+      return tr.has(labelKey) ? { ...step, label: tr(labelKey) } : step;
+    }),
+  };
 }
 
 /**
@@ -57,6 +85,7 @@ export function LoopCreateDialog({
 }) {
   const t = useTranslations('loops');
   const th = useTranslations('hypotheses');
+  const tr = useTranslations('workflowRecipes');
 
   const [title, setTitle] = useState('');
   const [mode, setMode] = useState<Mode>('new');
@@ -214,7 +243,8 @@ export function LoopCreateDialog({
     h.statement.toLowerCase().includes(hypothesisSearch.trim().toLowerCase()),
   );
   const linkedHypothesis = hypotheses?.find((h) => h.id === linkedId) ?? null;
-  const selectedRecipe = recipes?.find((r) => r.slug === recipeSlug) ?? null;
+  const localizedRecipes = recipes?.map((r) => localizeRecipe(r, tr)) ?? null;
+  const selectedRecipe = localizedRecipes?.find((r) => r.slug === recipeSlug) ?? null;
 
   return (
     <Dialog
@@ -242,7 +272,7 @@ export function LoopCreateDialog({
             />
           </div>
 
-          {recipes && recipes.length > 0 ? (
+          {localizedRecipes && localizedRecipes.length > 0 ? (
             <div className="space-y-1">
               <label htmlFor="loop-create-recipe" className="text-xs font-medium text-muted-foreground">{t('createLoopRecipeLabel')}</label>
               <select
@@ -252,7 +282,7 @@ export function LoopCreateDialog({
                 className="w-full rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
               >
                 <option value="">{t('createLoopRecipeNone')}</option>
-                {recipes.map((r) => (
+                {localizedRecipes.map((r) => (
                   <option key={r.slug} value={r.slug}>{r.name}</option>
                 ))}
               </select>


### PR DESCRIPTION
## 요약
- S18(#1859) 까심 크로스모델 QA 적출(cross-cutting): loop-create 다이얼로그의 레시피 드롭다운/미리보기가 builtin recipe의 `name`/`description`/`steps[].label`을 BE 원문(한국어) 그대로 직렌더 → 영문 로케일 사용자가 한국어를 보던 갭.
- 접근안 (b) FE-only 매핑 채택(오르테가 PO 승인 완료, conv `a5ad8993`): builtin 레시피 4종(`scrum-3step`/`kanban-simple`/`solo`/`loop-agency`)은 `backend/app/routers/workflow_recipes.py`의 `_BUILTIN_RECIPES` Python 리터럴 상수(정적 콘텐츠) — `workflowRecipes` next-intl 네임스페이스로 매핑. `t.has(key)`로 키 존재 여부를 SSOT 삼아 커스텀(DB `WorkflowTemplate`) 레시피·미등록 slug는 자동으로 BE 원문 fallback(크래시 0, 별도 builtin-slug 화이트리스트 불필요).
- `loops-client.tsx`/`loop-detail-client.tsx`는 `recipe_slug`(기술적 슬러그, 로케일 무관)만 렌더 확인 — 실제 name/description i18n 갭은 loop-create 다이얼로그 1곳뿐이라 전 surface 적용 완료.

## 변경
- `apps/web/messages/{en,ko}.json`: `workflowRecipes` 네임스페이스 신설, key=`{slug}.name`/`{slug}.description`/`{slug}.steps.{pattern}.label`(pattern은 BE 응답의 안정적 machine key). ko는 BE 원문과 동일 텍스트로 identity mapping(시각 무변경).
- `loop-create-dialog.tsx`: `localizeRecipe()` 순수 함수 신설 — 드롭다운 옵션+선택 미리보기 둘 다 이 함수를 거친 `localizedRecipes`로 렌더.
- `loop-create-dialog.test.tsx`(신규): en 번역/ko identity/커스텀 레시피 fallback/4종 커버리지 4건.

## 스코프 밖
- role 필드(`PO`/`Dev`/`QA`/`Human`/`Agent`/`Any` 등)는 이미 로케일 무관 영문 약어라 번역 대상에서 제외.

## 검증
- [x] `tsc --noEmit` 0 errors
- [x] `eslint` 0 errors (신규/수정 파일 warning 0)
- [x] `vitest run` 1042 passed / 2 skipped (회귀 0, 신규 4건)
- [x] `next build` 성공

## 게이트
PO crux(오르테가, conv `a5ad8993`) 승인 완료 → 까심 QA → 유나 가디언(양테마) 대기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)