### PR TITLE
feat(e-sprint-loop): a4acc4d0 — HypothesisSprintLink (sprint↔가설 링크, N:1)

### DIFF
--- a/backend/alembic/versions/0154_hypothesis_sprint_links.py
+++ b/backend/alembic/versions/0154_hypothesis_sprint_links.py
@@ -1,0 +1,67 @@
+"""E-SPRINT-LOOP a4acc4d0: hypothesis_sprint_links 조인 테이블 (N:1).
+
+Revision ID: 0154
+Revises: 0153
+Create Date: 2026-07-03
+
+hypothesis_epic_links/hypothesis_story_links(0113) 패턴 미러. epic/story와 달리
+(hypothesis_id, target_id) 쌍이 아니라 hypothesis_id 단독 unique — 가설은 정확히
+1개 sprint에만 링크된다(PO crux 2026-07-03: sprint=시간상자, cross-sprint 복리는
+회수로 성립하므로 멀티링크 불요). idempotent: 테이블 단위 inspect 가드(0113 선례).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0154"
+down_revision = "0153"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    existing = set(insp.get_table_names())
+
+    if "hypothesis_sprint_links" not in existing:
+        op.create_table(
+            "hypothesis_sprint_links",
+            sa.Column("id", UUID(as_uuid=True), primary_key=True),
+            sa.Column(
+                "hypothesis_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("hypotheses.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "sprint_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("sprints.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("link_type", sa.String(24), nullable=False, server_default="declared"),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.UniqueConstraint("hypothesis_id", name="uq_hypothesis_sprint_links_hypothesis"),
+        )
+        op.create_index(
+            "ix_hypothesis_sprint_links_sprint",
+            "hypothesis_sprint_links",
+            ["sprint_id"],
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    existing = set(insp.get_table_names())
+
+    if "hypothesis_sprint_links" in existing:
+        op.drop_table("hypothesis_sprint_links")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -26,7 +26,12 @@ from app.models.notification import InboxItem, Notification, NotificationSetting
 from app.models.notification_preference import NotificationPreference
 from app.models.organization import Organization
 from app.models.pm import Epic, Sprint, Story, Task
-from app.models.hypothesis import Hypothesis, HypothesisEpicLink, HypothesisStoryLink
+from app.models.hypothesis import (
+    Hypothesis,
+    HypothesisEpicLink,
+    HypothesisSprintLink,
+    HypothesisStoryLink,
+)
 from app.models.loop import LoopRun
 from app.models.story_assignee import StoryAssignee
 from app.models.project import OrgMember, Project
@@ -81,6 +86,7 @@ __all__ = [
     "Epic",
     "Hypothesis",
     "HypothesisEpicLink",
+    "HypothesisSprintLink",
     "HypothesisStoryLink",
     "InboxItem",
     "LoopRun",

--- a/backend/app/models/hypothesis.py
+++ b/backend/app/models/hypothesis.py
@@ -189,3 +189,38 @@ class HypothesisStoryLink(Base):
         UniqueConstraint("hypothesis_id", "story_id", name="uq_hypothesis_story_links"),
         Index("ix_hypothesis_story_links_story", "story_id"),
     )
+
+
+class HypothesisSprintLink(Base):
+    """E-SPRINT-LOOP a4acc4d0: 가설↔스프린트 연결. epic/story 링크와 달리 **N:1**(PO 결·
+    2026-07-03) — sprint는 시간상자, 가설은 그 안의 실험이라 한 가설은 정확히 1개 sprint에
+    속한다(epic/story의 N:M 지지 관계와 의미론이 다름). cross-sprint 복리는 링크가 아니라
+    회수(context_pack_search·project 전역)로 성립하므로 멀티링크 불필요 — §6 비협상은
+    context_pack_search.py에 sprint_id 필터를 추가하지 않는 것으로 준수(이 테이블 신설과
+    무관하게 그 파일은 org_id+project_id 스코프 그대로).
+
+    link_type: 'declared'(sprint 열기 시 직접 선언, 기본) | 'seeded'(이전 sprint의 L3
+    다음가설 추천을 채택해 생긴 링크 — story 3). seed된 가설의 home도 여전히 1개(seed
+    대상 sprint) — 측정이 걸쳐도 선언 sprint에 잔류(§ PO 결).
+    """
+
+    __tablename__ = "hypothesis_sprint_links"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    hypothesis_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("hypotheses.id", ondelete="CASCADE"), nullable=False
+    )
+    sprint_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("sprints.id", ondelete="CASCADE"), nullable=False
+    )
+    link_type: Mapped[str] = mapped_column(String(24), nullable=False, server_default="declared")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        # N:1 강제(PO 결) — epic/story의 (hypothesis_id, target_id) 쌍 unique와 달리
+        # hypothesis_id 단독 unique. 재배정은 서비스가 upsert(기존 링크 delete→insert)로 처리.
+        UniqueConstraint("hypothesis_id", name="uq_hypothesis_sprint_links_hypothesis"),
+        Index("ix_hypothesis_sprint_links_sprint", "sprint_id"),
+    )

--- a/backend/app/models/hypothesis.py
+++ b/backend/app/models/hypothesis.py
@@ -220,7 +220,8 @@ class HypothesisSprintLink(Base):
 
     __table_args__ = (
         # N:1 강제(PO 결) — epic/story의 (hypothesis_id, target_id) 쌍 unique와 달리
-        # hypothesis_id 단독 unique. 재배정은 서비스가 upsert(기존 링크 delete→insert)로 처리.
+        # hypothesis_id 단독 unique. 재배정은 repo.set_sprint_link의 원자적 ON CONFLICT
+        # upsert로 처리(select→delete→insert 레이스 제거, a4acc4d0 까심 RC②).
         UniqueConstraint("hypothesis_id", name="uq_hypothesis_sprint_links_hypothesis"),
         Index("ix_hypothesis_sprint_links_sprint", "sprint_id"),
     )

--- a/backend/app/repositories/hypothesis.py
+++ b/backend/app/repositories/hypothesis.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import uuid
 
 from sqlalchemy import desc, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.hypothesis import (
@@ -203,24 +204,18 @@ class HypothesisRepository(BaseRepository[Hypothesis]):
     async def set_sprint_link(
         self, hypothesis_id: uuid.UUID, sprint_id: uuid.UUID, link_type: str = "declared"
     ) -> None:
-        """N:1 upsert — 같은 sprint면 no-op, 다른 sprint면 기존 링크 delete 후 재생성
-        (uq_hypothesis_sprint_links_hypothesis 단독 unique라 pair-idempotent add로는 불가:
-        재배정은 명시적 교체여야 함)."""
-        existing = (await self.session.execute(
-            select(HypothesisSprintLink).where(
-                HypothesisSprintLink.hypothesis_id == hypothesis_id
-            )
-        )).scalar_one_or_none()
-        if existing is not None:
-            if existing.sprint_id == sprint_id:
-                return
-            await self.session.delete(existing)
-            await self.session.flush()
-        self.session.add(
-            HypothesisSprintLink(
-                hypothesis_id=hypothesis_id, sprint_id=sprint_id, link_type=link_type
-            )
+        """N:1 원자적 upsert(a4acc4d0 까심 RC②) — `INSERT ... ON CONFLICT (hypothesis_id)
+        DO UPDATE`로 재배정(교체)한다. 이전의 select→delete→insert 3단계는 동시 재링크 시
+        둘 다 no-row를 관측한 뒤 각자 insert해 uq_hypothesis_sprint_links_hypothesis
+        위반(500)이 날 수 있는 레이스였다 — ON CONFLICT는 DB 레벨 원자성이라 그 창이 없다."""
+        stmt = pg_insert(HypothesisSprintLink).values(
+            id=uuid.uuid4(), hypothesis_id=hypothesis_id, sprint_id=sprint_id, link_type=link_type,
         )
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["hypothesis_id"],
+            set_={"sprint_id": stmt.excluded.sprint_id, "link_type": stmt.excluded.link_type},
+        )
+        await self.session.execute(stmt)
         await self.session.flush()
 
     async def remove_sprint_link(self, hypothesis_id: uuid.UUID) -> None:

--- a/backend/app/repositories/hypothesis.py
+++ b/backend/app/repositories/hypothesis.py
@@ -11,7 +11,12 @@ import uuid
 from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.hypothesis import Hypothesis, HypothesisEpicLink, HypothesisStoryLink
+from app.models.hypothesis import (
+    Hypothesis,
+    HypothesisEpicLink,
+    HypothesisSprintLink,
+    HypothesisStoryLink,
+)
 from app.models.pm import Story
 from app.repositories.base import BaseRepository
 
@@ -28,6 +33,7 @@ class HypothesisRepository(BaseRepository[Hypothesis]):
         owner_member_id: uuid.UUID | None = None,
         epic_id: uuid.UUID | None = None,
         story_id: uuid.UUID | None = None,
+        sprint_id: uuid.UUID | None = None,
         limit: int = 100,
     ) -> list[Hypothesis]:
         q = select(Hypothesis).where(
@@ -51,6 +57,14 @@ class HypothesisRepository(BaseRepository[Hypothesis]):
                 Hypothesis.id.in_(
                     select(HypothesisStoryLink.hypothesis_id).where(
                         HypothesisStoryLink.story_id == story_id
+                    )
+                )
+            )
+        if sprint_id is not None:
+            q = q.where(
+                Hypothesis.id.in_(
+                    select(HypothesisSprintLink.hypothesis_id).where(
+                        HypothesisSprintLink.sprint_id == sprint_id
                     )
                 )
             )
@@ -102,6 +116,29 @@ class HypothesisRepository(BaseRepository[Hypothesis]):
         )).all()
         for hid, sid in rows:
             result[hid].append(sid)
+        return result
+
+    async def get_sprint_id(self, hypothesis_id: uuid.UUID) -> uuid.UUID | None:
+        """N:1 — 가설당 sprint 링크는 최대 1개(uq_hypothesis_sprint_links_hypothesis)."""
+        return await self.session.scalar(
+            select(HypothesisSprintLink.sprint_id).where(
+                HypothesisSprintLink.hypothesis_id == hypothesis_id
+            )
+        )
+
+    async def get_sprint_ids_map(
+        self, hypothesis_ids: list[uuid.UUID]
+    ) -> dict[uuid.UUID, uuid.UUID | None]:
+        result: dict[uuid.UUID, uuid.UUID | None] = {hid: None for hid in hypothesis_ids}
+        if not hypothesis_ids:
+            return result
+        rows = (await self.session.execute(
+            select(HypothesisSprintLink.hypothesis_id, HypothesisSprintLink.sprint_id).where(
+                HypothesisSprintLink.hypothesis_id.in_(hypothesis_ids)
+            )
+        )).all()
+        for hid, sid in rows:
+            result[hid] = sid
         return result
 
     # ── 링크 추가/제거 (멱등: 기존 (hypothesis, target) 쌍은 건너뜀) ──────────────
@@ -162,6 +199,39 @@ class HypothesisRepository(BaseRepository[Hypothesis]):
         for link in links:
             await self.session.delete(link)
         await self.session.flush()
+
+    async def set_sprint_link(
+        self, hypothesis_id: uuid.UUID, sprint_id: uuid.UUID, link_type: str = "declared"
+    ) -> None:
+        """N:1 upsert — 같은 sprint면 no-op, 다른 sprint면 기존 링크 delete 후 재생성
+        (uq_hypothesis_sprint_links_hypothesis 단독 unique라 pair-idempotent add로는 불가:
+        재배정은 명시적 교체여야 함)."""
+        existing = (await self.session.execute(
+            select(HypothesisSprintLink).where(
+                HypothesisSprintLink.hypothesis_id == hypothesis_id
+            )
+        )).scalar_one_or_none()
+        if existing is not None:
+            if existing.sprint_id == sprint_id:
+                return
+            await self.session.delete(existing)
+            await self.session.flush()
+        self.session.add(
+            HypothesisSprintLink(
+                hypothesis_id=hypothesis_id, sprint_id=sprint_id, link_type=link_type
+            )
+        )
+        await self.session.flush()
+
+    async def remove_sprint_link(self, hypothesis_id: uuid.UUID) -> None:
+        existing = (await self.session.execute(
+            select(HypothesisSprintLink).where(
+                HypothesisSprintLink.hypothesis_id == hypothesis_id
+            )
+        )).scalar_one_or_none()
+        if existing is not None:
+            await self.session.delete(existing)
+            await self.session.flush()
 
     # ── dispatch anchor 해소 (S6 §5.2) ──────────────────────────────────────────
     async def _primary_via_epic(self, epic_id: uuid.UUID) -> Hypothesis | None:

--- a/backend/app/routers/hypotheses.py
+++ b/backend/app/routers/hypotheses.py
@@ -95,6 +95,7 @@ async def list_hypotheses(
     project_id: uuid.UUID = Query(...),
     epic_id: uuid.UUID | None = Query(default=None),
     story_id: uuid.UUID | None = Query(default=None),
+    sprint_id: uuid.UUID | None = Query(default=None),
     status_filter: str | None = Query(default=None, alias="status"),
     owner_member_id: uuid.UUID | None = Query(default=None),
     limit: int = Query(default=100, ge=1, le=2000),
@@ -104,7 +105,7 @@ async def list_hypotheses(
     items = await svc.list_hypotheses(
         session, org_id, project_id,
         status=status_filter, owner_member_id=owner_member_id,
-        epic_id=epic_id, story_id=story_id, limit=limit,
+        epic_id=epic_id, story_id=story_id, sprint_id=sprint_id, limit=limit,
     )
     response.headers["X-Total-Count"] = str(len(items))
     return items

--- a/backend/app/schemas/hypothesis.py
+++ b/backend/app/schemas/hypothesis.py
@@ -66,12 +66,16 @@ class HypothesisTransition(BaseModel):
 class HypothesisLinkRequest(BaseModel):
     epic_ids: list[uuid.UUID] = []
     story_ids: list[uuid.UUID] = []
+    # N:1(PO 결 2026-07-03) — epic_ids/story_ids와 달리 리스트가 아니라 단일 값.
+    # 이미 다른 sprint에 링크돼 있으면 교체(재배정) — HypothesisRepository.set_sprint_link 참고.
+    sprint_id: uuid.UUID | None = None
     link_type: str | None = None
 
 
 class HypothesisUnlinkRequest(BaseModel):
     epic_ids: list[uuid.UUID] = []
     story_ids: list[uuid.UUID] = []
+    unlink_sprint: bool = False
 
 
 class HypothesisResponse(BaseModel):
@@ -99,6 +103,8 @@ class HypothesisResponse(BaseModel):
     gate_contract: dict[str, Any]
     epic_ids: list[uuid.UUID] = []
     story_ids: list[uuid.UUID] = []
+    # N:1(PO 결) — sprint 링크는 최대 1개라 리스트가 아니라 nullable 단일 값.
+    sprint_id: uuid.UUID | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -108,11 +114,13 @@ class HypothesisResponse(BaseModel):
         obj: Any,
         epic_ids: list[uuid.UUID] | None = None,
         story_ids: list[uuid.UUID] | None = None,
+        sprint_id: uuid.UUID | None = None,
     ) -> "HypothesisResponse":
-        # epic_ids/story_ids는 모델 컬럼이 아니라 링크 테이블 집계 — 서비스가 주입한다.
+        # epic_ids/story_ids/sprint_id는 모델 컬럼이 아니라 링크 테이블 집계 — 서비스가 주입한다.
         resp = cls.model_validate(obj)
         resp.epic_ids = epic_ids or []
         resp.story_ids = story_ids or []
+        resp.sprint_id = sprint_id
         return resp
 
 

--- a/backend/app/schemas/hypothesis.py
+++ b/backend/app/schemas/hypothesis.py
@@ -30,6 +30,9 @@ class HypothesisCreate(BaseModel):
     status: str = "proposed"
     epic_ids: list[uuid.UUID] = []
     story_ids: list[uuid.UUID] = []
+    # N:1(PO 결) — epic_ids/story_ids와 대칭으로 create-time 링크(a4acc4d0 까심 RC① fix:
+    # 이전엔 /links 전용이라 create 시 sprint_id를 줘도 silent drop됐다).
+    sprint_id: uuid.UUID | None = None
     source_type: str | None = None
     source_id: uuid.UUID | None = None
     draft_metadata: dict[str, Any] | None = None
@@ -50,6 +53,9 @@ class HypothesisUpdate(BaseModel):
     confidence: float | None = None
     draft_metadata: dict[str, Any] | None = None
     human_accounting: dict[str, Any] | None = None
+    # N:1(PO 결) — hypotheses 컬럼이 아니라 링크 테이블 행이라 서비스가 별도 경로로 처리
+    # (repo.update()에 그대로 넘기면 존재하지 않는 컬럼이라 silent no-op). None = 링크 해제.
+    sprint_id: uuid.UUID | None = None
 
     @field_validator("metric_definition")
     @classmethod

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -149,8 +149,13 @@ async def create_hypothesis(
             "INVALID_CREATE_STATUS", "생성 시 status는 proposed|active만 허용됩니다."
         )
 
-    # cross-project epic/story 링크 차단(§3.7.2) — repo.create 전이라 거부 시 orphan 가설 0.
-    await _assert_targets_same_project(session, payload.project_id, payload.epic_ids, payload.story_ids)
+    # cross-project epic/story/sprint 링크 차단(§3.7.2·a4acc4d0 까심 RC①) — repo.create 전이라
+    # 거부 시 orphan 가설 0. sprint_id도 epic_ids/story_ids와 대칭으로 create-time 링크 지원
+    # (sprint-open 선언 흐름 + story 3 seed가 create-time 링크를 요구 — 이전엔 /links 전용이라
+    # create 시 sprint_id를 줘도 silent drop됐다).
+    await _assert_targets_same_project(
+        session, payload.project_id, payload.epic_ids, payload.story_ids, payload.sprint_id
+    )
 
     repo = HypothesisRepository(session, org_id)
     hyp = await repo.create(
@@ -172,6 +177,8 @@ async def create_hypothesis(
     )
     await repo.add_epic_links(hyp.id, payload.epic_ids, "primary")
     await repo.add_story_links(hyp.id, payload.story_ids, "supports")
+    if payload.sprint_id is not None:
+        await repo.set_sprint_link(hyp.id, payload.sprint_id, "declared")
 
     # E-LOOP-LEDGER P1-S4: statement를 embeddings 큐에 pending으로 등록(네트워크 I/O 0 —
     # 실제 임베딩은 P1-S3 cron이 처리). score_hypotheses/attribute_loop_outcome과 동형 배선.
@@ -238,11 +245,27 @@ async def update_hypothesis(
     fields = payload.model_dump(exclude_unset=True)
     if not fields:
         raise HypothesisServiceError("NO_VALID_FIELDS", "수정할 필드가 없습니다.")
+    # sprint_id는 hypotheses 컬럼이 아니라 링크 테이블 행(a4acc4d0 까심 RC①) — repo.update()에
+    # 그대로 넘기면 존재하지 않는 컬럼이라 silent no-op이 된다. 별도 경로(set/remove_sprint_link)로
+    # 분리하고, sprint_id만 patch돼도(exclude_unset 시맨틱) NO_VALID_FIELDS에 걸리지 않게
+    # 위 dict 생성 이후에 pop한다.
+    sprint_id_provided = "sprint_id" in fields
+    sprint_id = fields.pop("sprint_id", None)
     new_owner = fields.get("owner_member_id")
     if new_owner is not None:
         await _verify_human_owner(session, new_owner)
+    # cross-project 가드는 어떤 컬럼 mutation보다 먼저 — 거부 시 부분 update 0(create 경로와 동형).
+    if sprint_id_provided and sprint_id is not None:
+        await _assert_targets_same_project(session, hyp.project_id, [], [], sprint_id)
 
-    updated = await repo.update(hypothesis_id, **fields)
+    updated = hyp
+    if fields:
+        updated = await repo.update(hypothesis_id, **fields)
+    if sprint_id_provided:
+        if sprint_id is not None:
+            await repo.set_sprint_link(hypothesis_id, sprint_id, "declared")
+        else:
+            await repo.remove_sprint_link(hypothesis_id)
 
     # P1-S4: statement가 바뀌면 재임베딩 큐잉(content_hash가 변경 없는 재저장은 no-op으로 걸러줌).
     if "statement" in fields:

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -18,7 +18,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.hypothesis import HYPOTHESIS_STATUSES, Hypothesis, is_valid_transition
-from app.models.pm import Epic, Story
+from app.models.pm import Epic, Sprint, Story
 
 logger = logging.getLogger(__name__)
 from app.repositories.hypothesis import HypothesisRepository
@@ -79,7 +79,8 @@ async def _to_response(
 ) -> HypothesisResponse:
     epic_ids = await repo.get_epic_ids(hyp.id)
     story_ids = await repo.get_story_ids(hyp.id)
-    return HypothesisResponse.from_model(hyp, epic_ids, story_ids)
+    sprint_id = await repo.get_sprint_id(hyp.id)
+    return HypothesisResponse.from_model(hyp, epic_ids, story_ids, sprint_id)
 
 
 async def _assert_targets_same_project(
@@ -87,12 +88,15 @@ async def _assert_targets_same_project(
     project_id: uuid.UUID,
     epic_ids: list[uuid.UUID],
     story_ids: list[uuid.UUID],
+    sprint_id: uuid.UUID | None = None,
 ) -> None:
-    """§3.7.2 — 링크 대상 epic/story가 hypothesis와 다른 project면 거부.
+    """§3.7.2 — 링크 대상 epic/story/sprint가 hypothesis와 다른 project면 거부.
 
     create/draft/link 공통 service 가드. 이전엔 라우터(link 라우트)에만 있어 create·draft
     경로의 add_epic_links/add_story_links가 same-org cross-project blind INSERT로 우회됐다.
-    존재하지 않는 대상도 same-project 검증 불가라 거부한다(rowcount 대조).
+    존재하지 않는 대상도 same-project 검증 불가라 거부한다(rowcount 대조). sprint_id는
+    a4acc4d0(N:1)이 동일 원칙으로 확장 — org 스코프도 여기서 겸함(project는 org 1:1이라
+    다른 org의 sprint_id를 넣어도 project_id 불일치로 걸림, anti-IDOR).
     """
     if epic_ids:
         rows = (await session.execute(
@@ -109,6 +113,14 @@ async def _assert_targets_same_project(
         if len(rows) != len(set(story_ids)) or any(pid != project_id for _id, pid in rows):
             raise HypothesisServiceError(
                 "CROSS_PROJECT_LINK_FORBIDDEN", "다른 프로젝트의 스토리에는 연결할 수 없습니다."
+            )
+    if sprint_id is not None:
+        sprint_project_id = await session.scalar(
+            select(Sprint.project_id).where(Sprint.id == sprint_id)
+        )
+        if sprint_project_id != project_id:
+            raise HypothesisServiceError(
+                "CROSS_PROJECT_LINK_FORBIDDEN", "다른 프로젝트의 스프린트에는 연결할 수 없습니다."
             )
 
 
@@ -191,6 +203,7 @@ async def list_hypotheses(
     owner_member_id: uuid.UUID | None = None,
     epic_id: uuid.UUID | None = None,
     story_id: uuid.UUID | None = None,
+    sprint_id: uuid.UUID | None = None,
     limit: int = 100,
 ) -> list[HypothesisResponse]:
     repo = HypothesisRepository(session, org_id)
@@ -200,12 +213,14 @@ async def list_hypotheses(
         owner_member_id=owner_member_id,
         epic_id=epic_id,
         story_id=story_id,
+        sprint_id=sprint_id,
         limit=limit,
     )
     ids = [r.id for r in rows]
     emap = await repo.get_epic_ids_map(ids)
     smap = await repo.get_story_ids_map(ids)
-    return [HypothesisResponse.from_model(r, emap[r.id], smap[r.id]) for r in rows]
+    spmap = await repo.get_sprint_ids_map(ids)
+    return [HypothesisResponse.from_model(r, emap[r.id], smap[r.id], spmap[r.id]) for r in rows]
 
 
 async def update_hypothesis(
@@ -326,10 +341,14 @@ async def link_hypothesis(
     hyp = await repo.get(hypothesis_id)
     if hyp is None:
         raise HypothesisServiceError("HYPOTHESIS_NOT_FOUND", "가설을 찾을 수 없습니다.")
-    # cross-project epic/story 링크 차단(§3.7.2) — service 공통 가드(라우터 위임 제거).
-    await _assert_targets_same_project(session, hyp.project_id, payload.epic_ids, payload.story_ids)
+    # cross-project epic/story/sprint 링크 차단(§3.7.2·a4acc4d0) — service 공통 가드(라우터 위임 제거).
+    await _assert_targets_same_project(
+        session, hyp.project_id, payload.epic_ids, payload.story_ids, payload.sprint_id
+    )
     await repo.add_epic_links(hypothesis_id, payload.epic_ids, payload.link_type or "primary")
     await repo.add_story_links(hypothesis_id, payload.story_ids, payload.link_type or "supports")
+    if payload.sprint_id is not None:
+        await repo.set_sprint_link(hypothesis_id, payload.sprint_id, payload.link_type or "declared")
     return await _to_response(repo, hyp)
 
 
@@ -345,6 +364,8 @@ async def unlink_hypothesis(
         raise HypothesisServiceError("HYPOTHESIS_NOT_FOUND", "가설을 찾을 수 없습니다.")
     await repo.remove_epic_links(hypothesis_id, payload.epic_ids)
     await repo.remove_story_links(hypothesis_id, payload.story_ids)
+    if payload.unlink_sprint:
+        await repo.remove_sprint_link(hypothesis_id)
     return await _to_response(repo, hyp)
 
 

--- a/backend/tests/test_e_loop_ledger_s15_hypothesis_llm_draft.py
+++ b/backend/tests/test_e_loop_ledger_s15_hypothesis_llm_draft.py
@@ -136,6 +136,7 @@ def _repo_mock(hyp: SimpleNamespace) -> AsyncMock:
     repo.create = AsyncMock(return_value=hyp)
     repo.get_epic_ids = AsyncMock(return_value=[])
     repo.get_story_ids = AsyncMock(return_value=[])
+    repo.get_sprint_id = AsyncMock(return_value=None)
     repo.add_epic_links = AsyncMock()
     repo.add_story_links = AsyncMock()
     return repo

--- a/backend/tests/test_e_loop_ledger_s16_hypothesis_draft_loop_goal.py
+++ b/backend/tests/test_e_loop_ledger_s16_hypothesis_draft_loop_goal.py
@@ -87,6 +87,7 @@ def _repo_mock(hyp: SimpleNamespace) -> AsyncMock:
     repo.create = AsyncMock(return_value=hyp)
     repo.get_epic_ids = AsyncMock(return_value=[])
     repo.get_story_ids = AsyncMock(return_value=[])
+    repo.get_sprint_id = AsyncMock(return_value=None)
     repo.add_epic_links = AsyncMock()
     repo.add_story_links = AsyncMock()
     return repo

--- a/backend/tests/test_e_sprint_loop_a4acc4d0_sprint_link_realdb.py
+++ b/backend/tests/test_e_sprint_loop_a4acc4d0_sprint_link_realdb.py
@@ -1,0 +1,143 @@
+"""E-SPRINT-LOOP a4acc4d0: HypothesisSprintLink 재배정 — realdb 원자성 실증(까심 RC②).
+
+select→delete→insert 3단계(구 구현)는 동시 재링크 시 둘 다 no-row를 관측한 뒤 각자
+insert해 uq_hypothesis_sprint_links_hypothesis 위반(500)이 날 수 있는 TOCTOU 레이스였다.
+`INSERT ... ON CONFLICT (hypothesis_id) DO UPDATE`(HypothesisRepository.set_sprint_link)로
+교체한 뒤, **실제 동시 두 세션이 같은 hypothesis를 서로 다른 sprint로 동시 재배정**해도
+예외 없이 정확히 1행만 남는지 실 Postgres로 검증한다(mock 세션으로는 DB 레벨 락/원자성을
+관측할 수 없어 이 파일이 필요 — codex 지적).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("da000000-0000-0000-0000-000000000001")
+PROJ = uuid.UUID("da000000-0000-0000-0000-0000000000c1")
+OWNER = uuid.UUID("da000000-0000-0000-0000-0000000000b1")
+HYP = uuid.UUID("da000000-0000-0000-0000-0000000000d1")
+SPRINT_A = uuid.UUID("da000000-0000-0000-0000-0000000000e1")
+SPRINT_B = uuid.UUID("da000000-0000-0000-0000-0000000000e2")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _seed(s):
+    for sql in [
+        f"DELETE FROM hypothesis_sprint_links WHERE hypothesis_id='{HYP}'",
+        f"DELETE FROM hypotheses WHERE id='{HYP}'",
+        f"DELETE FROM sprints WHERE id IN ('{SPRINT_A}','{SPRINT_B}')",
+        f"DELETE FROM projects WHERE id='{PROJ}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','DA','da-org','free')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES "
+        f"('{PROJ}','{ORG}','P','none')",
+        f"INSERT INTO sprints (id,org_id,project_id,title,status,duration) VALUES "
+        f"('{SPRINT_A}','{ORG}','{PROJ}','sprint-a','planning',14)",
+        f"INSERT INTO sprints (id,org_id,project_id,title,status,duration) VALUES "
+        f"('{SPRINT_B}','{ORG}','{PROJ}','sprint-b','planning',14)",
+    ]:
+        await s.execute(text(sql))
+    # metric_definition JSON 리터럴의 콜론(`"target":1`)이 text()의 `:bindparam` 파서와
+    # 충돌해(asyncpg text() 함정) 별도 bound parameter로 분리(feedback_asyncpg_text_traps 동형).
+    await s.execute(
+        text(
+            "INSERT INTO hypotheses (id,org_id,project_id,owner_member_id,statement,"
+            "metric_definition,measure_after,status,human_accounting,gate_contract) VALUES "
+            "(:id,:org_id,:project_id,:owner_id,:statement,"
+            "CAST(:metric AS jsonb),:measure_after,'proposed','{}','{}')"
+        ),
+        {
+            "id": HYP, "org_id": ORG, "project_id": PROJ, "owner_id": OWNER,
+            "statement": "stmt",
+            "metric": '{"metric":"x","source":"manual","target":1,"direction":"up"}',
+            "measure_after": datetime(2026, 8, 1, tzinfo=timezone.utc),
+        },
+    )
+    await s.commit()
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+@pytest.mark.anyio
+async def test_sequential_reassign_replaces_no_violation():
+    """A→B 순차 재배정 — 정확히 1행, 최신 sprint_id만 남음(구현 §2 카디널리티 실증)."""
+    from app.models.hypothesis import HypothesisSprintLink
+    from app.repositories.hypothesis import HypothesisRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            repo = HypothesisRepository(s, ORG)
+            await repo.set_sprint_link(HYP, SPRINT_A, "declared")
+            await repo.set_sprint_link(HYP, SPRINT_B, "declared")  # 재배정
+            await s.commit()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(HypothesisSprintLink).where(HypothesisSprintLink.hypothesis_id == HYP)
+            )).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].sprint_id == SPRINT_B
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_concurrent_reassign_atomic_no_unique_violation():
+    """두 세션이 동시에 같은 hypothesis를 다른 sprint로 재배정 — 예외 없이 정확히 1행
+    (구 select→delete→insert였다면 둘 다 no-row 관측→unique_violation 위험이 있던 지점)."""
+    from app.models.hypothesis import HypothesisSprintLink
+    from app.repositories.hypothesis import HypothesisRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            repo = HypothesisRepository(s, ORG)
+            await repo.set_sprint_link(HYP, SPRINT_A, "declared")  # 최초 링크
+            await s.commit()
+
+        async def _reassign(sprint_id):
+            async with Session() as s:
+                repo = HypothesisRepository(s, ORG)
+                await repo.set_sprint_link(HYP, sprint_id, "declared")
+                await s.commit()
+
+        # 동시 재배정 — 둘 다 예외 없이 완료돼야(ON CONFLICT 원자성).
+        results = await asyncio.gather(
+            _reassign(SPRINT_A), _reassign(SPRINT_B), return_exceptions=True
+        )
+        exceptions = [r for r in results if isinstance(r, Exception)]
+        assert exceptions == [], f"동시 재배정이 예외를 냄(원자성 깨짐): {exceptions}"
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(HypothesisSprintLink).where(HypothesisSprintLink.hypothesis_id == HYP)
+            )).scalars().all()
+            assert len(rows) == 1  # 어느 한쪽이 이기든 정확히 1행만 생존
+            assert rows[0].sprint_id in (SPRINT_A, SPRINT_B)
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_hypothesis_service.py
+++ b/backend/tests/test_hypothesis_service.py
@@ -21,6 +21,7 @@ from app.schemas.hypothesis import (
     HypothesisLinkRequest,
     HypothesisResponse,
     HypothesisTransition,
+    HypothesisUnlinkRequest,
     HypothesisUpdate,
 )
 from app.services import hypothesis as svc
@@ -81,10 +82,13 @@ def _repo_mock(hyp: SimpleNamespace | None) -> AsyncMock:
     repo.update = AsyncMock(side_effect=lambda _id, **f: _hyp_stub(**f) if hyp is None else _hyp_stub(**{**hyp.__dict__, **f}))
     repo.get_epic_ids = AsyncMock(return_value=[])
     repo.get_story_ids = AsyncMock(return_value=[])
+    repo.get_sprint_id = AsyncMock(return_value=None)
     repo.add_epic_links = AsyncMock()
     repo.add_story_links = AsyncMock()
     repo.remove_epic_links = AsyncMock()
     repo.remove_story_links = AsyncMock()
+    repo.set_sprint_link = AsyncMock()
+    repo.remove_sprint_link = AsyncMock()
     return repo
 
 
@@ -364,6 +368,81 @@ async def test_link_adds_epic_and_story():
         )
     repo.add_epic_links.assert_awaited_once_with(HYP_ID, [eid], "primary")
     repo.add_story_links.assert_awaited_once_with(HYP_ID, [sid], "supports")
+
+
+# ── a4acc4d0: HypothesisSprintLink (N:1) ────────────────────────────────────────
+
+def _session_scalar(value):
+    """sprint 가드(`session.scalar`)용 mock 세션 — epic/story 가드(`session.execute().all()`)와
+    호출 형태가 다르다(Sprint.project_id는 단일 스칼라 조회)."""
+    session = MagicMock()
+    session.scalar = AsyncMock(return_value=value)
+    return session
+
+
+async def test_link_sets_sprint():
+    repo = _repo_mock(_hyp_stub())
+    p_repo, p_lookup = _patch(repo, "human")
+    sprint_id = uuid.uuid4()
+    session = _session_scalar(PROJECT_ID)  # 동일 project sprint
+    with p_repo, p_lookup:
+        await svc.link_hypothesis(
+            session, ORG_ID, HYP_ID,
+            HypothesisLinkRequest(sprint_id=sprint_id),
+        )
+    repo.set_sprint_link.assert_awaited_once_with(HYP_ID, sprint_id, "declared")
+
+
+async def test_link_sprint_cross_project_forbidden():
+    repo = _repo_mock(_hyp_stub())
+    p_repo, p_lookup = _patch(repo, "human")
+    sprint_id = uuid.uuid4()
+    session = _session_scalar(uuid.uuid4())  # 다른 project sprint
+    with p_repo, p_lookup, pytest.raises(svc.HypothesisServiceError) as ei:
+        await svc.link_hypothesis(
+            session, ORG_ID, HYP_ID,
+            HypothesisLinkRequest(sprint_id=sprint_id),
+        )
+    assert ei.value.code == "CROSS_PROJECT_LINK_FORBIDDEN"
+    repo.set_sprint_link.assert_not_awaited()
+
+
+async def test_link_sprint_nonexistent_forbidden():
+    """존재하지 않는 sprint_id — Sprint.project_id 조회가 None(스칼라 no-row)이라
+    project_id와 불일치로 동일하게 거부된다(epic/story의 rowcount 대조와 동형 원칙)."""
+    repo = _repo_mock(_hyp_stub())
+    p_repo, p_lookup = _patch(repo, "human")
+    session = _session_scalar(None)
+    with p_repo, p_lookup, pytest.raises(svc.HypothesisServiceError) as ei:
+        await svc.link_hypothesis(
+            session, ORG_ID, HYP_ID,
+            HypothesisLinkRequest(sprint_id=uuid.uuid4()),
+        )
+    assert ei.value.code == "CROSS_PROJECT_LINK_FORBIDDEN"
+
+
+async def test_unlink_sprint_only_when_flagged():
+    repo = _repo_mock(_hyp_stub())
+    p_repo, p_lookup = _patch(repo, "human")
+    with p_repo, p_lookup:
+        await svc.unlink_hypothesis(
+            MagicMock(), ORG_ID, HYP_ID, HypothesisUnlinkRequest(),
+        )
+    repo.remove_sprint_link.assert_not_awaited()
+
+    with p_repo, p_lookup:
+        await svc.unlink_hypothesis(
+            MagicMock(), ORG_ID, HYP_ID, HypothesisUnlinkRequest(unlink_sprint=True),
+        )
+    repo.remove_sprint_link.assert_awaited_once_with(HYP_ID)
+
+
+def test_response_exposes_sprint_id():
+    resp = HypothesisResponse.from_model(_hyp_stub(), [], [], None)
+    assert resp.sprint_id is None
+    sprint_id = uuid.uuid4()
+    resp2 = HypothesisResponse.from_model(_hyp_stub(), [], [], sprint_id)
+    assert resp2.sprint_id == sprint_id
 
 
 # ── 54a8bd8a: cross-project 가드 service 레벨 — create/draft 경로 패리티 ─────────

--- a/backend/tests/test_hypothesis_service.py
+++ b/backend/tests/test_hypothesis_service.py
@@ -445,6 +445,93 @@ def test_response_exposes_sprint_id():
     assert resp2.sprint_id == sprint_id
 
 
+# ── a4acc4d0 까심 RC①: create/update sprint_id 대칭(epic_ids/story_ids와 동형) ──────
+
+async def test_create_sets_sprint():
+    repo = _repo_mock(_hyp_stub())
+    p_repo, p_lookup = _patch(repo, "human")
+    sprint_id = uuid.uuid4()
+    session = _session_scalar(PROJECT_ID)
+    payload = HypothesisCreate(
+        project_id=PROJECT_ID, statement="s", metric_definition=VALID_METRIC,
+        measure_after=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        owner_member_id=OWNER_ID, sprint_id=sprint_id,
+    )
+    with p_repo, p_lookup:
+        await svc.create_hypothesis(session, ORG_ID, _caller("human"), payload)
+    repo.set_sprint_link.assert_awaited_once_with(HYP_ID, sprint_id, "declared")
+
+
+async def test_create_sprint_cross_project_forbidden():
+    """create 경로도 cross-project sprint 링크 거부 — repo.create 전 차단(orphan 0)."""
+    repo = _repo_mock(_hyp_stub())
+    p_repo, p_lookup = _patch(repo, "human")
+    session = _session_scalar(uuid.uuid4())  # 다른 project sprint
+    payload = HypothesisCreate(
+        project_id=PROJECT_ID, statement="s", metric_definition=VALID_METRIC,
+        measure_after=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        owner_member_id=OWNER_ID, sprint_id=uuid.uuid4(),
+    )
+    with p_repo, p_lookup, pytest.raises(svc.HypothesisServiceError) as ei:
+        await svc.create_hypothesis(session, ORG_ID, _caller("human"), payload)
+    assert ei.value.code == "CROSS_PROJECT_LINK_FORBIDDEN"
+    repo.create.assert_not_awaited()
+
+
+async def test_update_sprint_id_only_does_not_raise_no_valid_fields():
+    """patch body가 sprint_id 단독이어도 NO_VALID_FIELDS에 걸리지 않는다(fix 전 회귀 재현 대상)."""
+    repo = _repo_mock(_hyp_stub())
+    p_repo, p_lookup = _patch(repo, "human")
+    sprint_id = uuid.uuid4()
+    session = _session_scalar(PROJECT_ID)
+    with p_repo, p_lookup:
+        await svc.update_hypothesis(
+            session, ORG_ID, _caller("human"), HYP_ID,
+            HypothesisUpdate(sprint_id=sprint_id),
+        )
+    repo.set_sprint_link.assert_awaited_once_with(HYP_ID, sprint_id, "declared")
+    repo.update.assert_not_awaited()  # sprint_id만 있으면 컬럼 update 호출 자체가 없어야 함
+
+
+async def test_update_sprint_id_null_unlinks():
+    repo = _repo_mock(_hyp_stub())
+    p_repo, p_lookup = _patch(repo, "human")
+    with p_repo, p_lookup:
+        await svc.update_hypothesis(
+            MagicMock(), ORG_ID, _caller("human"), HYP_ID,
+            HypothesisUpdate(sprint_id=None),
+        )
+    repo.remove_sprint_link.assert_awaited_once_with(HYP_ID)
+
+
+async def test_update_sprint_cross_project_forbidden():
+    repo = _repo_mock(_hyp_stub())
+    p_repo, p_lookup = _patch(repo, "human")
+    session = _session_scalar(uuid.uuid4())  # 다른 project sprint
+    with p_repo, p_lookup, pytest.raises(svc.HypothesisServiceError) as ei:
+        await svc.update_hypothesis(
+            session, ORG_ID, _caller("human"), HYP_ID,
+            HypothesisUpdate(sprint_id=uuid.uuid4()),
+        )
+    assert ei.value.code == "CROSS_PROJECT_LINK_FORBIDDEN"
+    repo.set_sprint_link.assert_not_awaited()
+
+
+async def test_update_statement_and_sprint_together():
+    """컬럼 필드 + sprint_id 동시 patch — 둘 다 적용(repo.update는 sprint_id 없이 호출)."""
+    repo = _repo_mock(_hyp_stub())
+    p_repo, p_lookup = _patch(repo, "human")
+    sprint_id = uuid.uuid4()
+    session = _session_scalar(PROJECT_ID)
+    with p_repo, p_lookup:
+        await svc.update_hypothesis(
+            session, ORG_ID, _caller("human"), HYP_ID,
+            HypothesisUpdate(statement="new", sprint_id=sprint_id),
+        )
+    repo.update.assert_awaited_once_with(HYP_ID, statement="new")
+    repo.set_sprint_link.assert_awaited_once_with(HYP_ID, sprint_id, "declared")
+
+
 # ── 54a8bd8a: cross-project 가드 service 레벨 — create/draft 경로 패리티 ─────────
 
 def _session_one_result(rows):


### PR DESCRIPTION
## Summary
- E-SPRINT-LOOP BE 첫 스토리(`a4acc4d0`, foundation) — epic/story 링크 패턴(`hypothesis.py:148-191`) 미러해 `hypothesis_sprint_links` 조인 테이블 신설
- **N:1 카디널리티 강제**(`unique(hypothesis_id)`, PO crux 결 2026-07-03) — sprint는 시간상자·가설은 그 안의 실험이라 epic/story의 N:M 지지 관계와 의미론이 다름
- 신규 라우터 없이 기존 `/api/v2/hypotheses` 확장: `sprint_id` 필터(list) + `sprint_id`/`unlink_sprint`(link/unlink) — cross-project 가드(`_assert_targets_same_project`)도 sprint까지 동형 확장(54a8bd8a 교훈 재사용)
- 마이그 `0154_hypothesis_sprint_links.py`(0113 미러·idempotent inspect 가드)
- `context_pack_search.py` 무접촉(§6 비협상 — cross-sprint 복리는 링크가 아니라 회수로 성립)

## Design
설계 문서: sprintable docs `design-a4acc4d0-hypothesis-sprint-link`(PO crux 통과 2026-07-03). 나머지 스토리(retro §5 계약·채택→시드)도 함께 승인됨 — 후속 PR.

## Test plan
- [x] `pytest tests/ -k "hypothesis or sprint or context_pack or dispatch"` — 272 passed, 0 regressions
- [x] `pytest tests/` 전체 — 2847 passed, 8 xfailed, 8 failed(전부 MCP/DoD 환경설정 테스트·develop baseline에서도 동일하게 실패 확인, 이 변경과 무관)
- [x] 실 로컬 Postgres(`Base.metadata.create_all`)로 스키마 실측: 컬럼/FK/unique 인덱스 정확 대조
- [x] unique 제약 실증: 같은 hypothesis를 다른 sprint에 재링크 시도 → `unique_violation`
- [x] CASCADE 실증: hypothesis 삭제·sprint 삭제 양방향 모두 링크 row 정리 확인
- [x] `context_pack_search.py` 변경 없음 grep 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)