### PR TITLE
feat(e-sprint-loop): dc861e44 — retro §5 계약(hypotheses[] + L2 종합 + L3 다음가설)

### DIFF
--- a/backend/alembic/versions/0155_retro_synthesis_next_hypotheses.py
+++ b/backend/alembic/versions/0155_retro_synthesis_next_hypotheses.py
@@ -1,0 +1,41 @@
+"""E-SPRINT-LOOP dc861e44: retro_sessions에 synthesis/next_hypotheses nullable JSONB.
+
+Revision ID: 0155
+Revises: 0154
+Create Date: 2026-07-03
+
+L2 종합(synthesis)·L3 다음가설 추천(next_hypotheses) 캐시 컬럼. overwrite 저장
+(PO 결 2026-07-03: 이력 보존 YAGNI). idempotent: 컬럼 단위 inspect 가드.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "0155"
+down_revision = "0154"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    cols = {c["name"] for c in insp.get_columns("retro_sessions")}
+
+    if "synthesis" not in cols:
+        op.add_column("retro_sessions", sa.Column("synthesis", JSONB, nullable=True))
+    if "next_hypotheses" not in cols:
+        op.add_column("retro_sessions", sa.Column("next_hypotheses", JSONB, nullable=True))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    cols = {c["name"] for c in insp.get_columns("retro_sessions")}
+
+    if "next_hypotheses" in cols:
+        op.drop_column("retro_sessions", "next_hypotheses")
+    if "synthesis" in cols:
+        op.drop_column("retro_sessions", "synthesis")

--- a/backend/app/models/retro.py
+++ b/backend/app/models/retro.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime
 
 from sqlalchemy import DateTime, ForeignKey, Integer, Text, func
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.database import Base
@@ -40,6 +40,15 @@ class RetroSession(Base, OrgScopedMixin, TimestampMixin):
     )
     title: Mapped[str] = mapped_column(Text, nullable=False)
     phase: Mapped[str] = mapped_column(Text, nullable=False, default="collect")
+    # dc861e44 §5 — L2 종합(on-demand). null=미생성→FE "종합 생성" CTA. overwrite 저장
+    # (PO 결 2026-07-03: 1세션=1 최신·이력 보존 YAGNI — 진짜 결정은 story 3서 proposed
+    # 가설로 별도 영속). shape: {learned:[{text,source}], generated_at, source:'ai_draft'}.
+    synthesis: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    # dc861e44 §5 — L3 다음가설 추천(on-demand). synthesis 선행 필수(recommend-next가
+    # 409 SYNTHESIS_REQUIRED로 fail-closed 가드). overwrite 저장(synthesis와 동일 정책).
+    # shape: [{id,statement,metric_definition,measure_after,confidence,rationale,
+    #          requires_confirmation:true}]
+    next_hypotheses: Mapped[list | None] = mapped_column(JSONB, nullable=True)
 
     items: Mapped[list["RetroItem"]] = relationship("RetroItem", back_populates="session", lazy="select")
     actions: Mapped[list["RetroAction"]] = relationship("RetroAction", back_populates="session", lazy="select")

--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -41,14 +41,20 @@ def _get_session_repo(
 
 
 def _has_valid_synthesis(synthesis: object) -> bool:
-    """recommend-next 게이팅(까심 RC②, 2026-07-03) — `synthesis is None`만 보면 `{}`·`[]`·
-    `{"learned": []}` 같은 malformed/empty 값이 게이트를 통과한다. `synthesis=[]`는
+    """recommend-next 게이팅(까심 codex RC①·②, 2026-07-03) — `synthesis is None`만 보면
+    `{}`·`[]`·`{"learned": []}` 같은 malformed/empty 값이 게이트를 통과한다. `synthesis=[]`는
     `_build_next_hypotheses_prompt`의 `.get("learned")` 호출에서 AttributeError(500)까지
-    난다. dict이고 `learned`이 비어있지 않은 리스트일 때만 "종합이 실제로 존재"로 인정."""
-    return (
-        isinstance(synthesis, dict)
-        and isinstance(synthesis.get("learned"), list)
-        and len(synthesis["learned"]) > 0
+    난다. **1차 라운드에서 "learned가 비어있지 않은 list"까지만 봤는데 codex가 아이템 shape
+    미검증을 다시 잡음**(`{"learned":[123]}`·`{"learned":[{}]}` 통과해 recommend-next가 사실상
+    빈 종합으로 LLM 호출/persist) — ≥1개 dict 아이템이 non-blank `text`를 가져야 유효."""
+    if not isinstance(synthesis, dict):
+        return False
+    learned = synthesis.get("learned")
+    if not isinstance(learned, list) or not learned:
+        return False
+    return any(
+        isinstance(item, dict) and isinstance(item.get("text"), str) and item["text"].strip()
+        for item in learned
     )
 
 

--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.retro import RetroItem, RetroSession, RetroVote
+from app.services import retro_synthesis as synth_svc
 from app.services.member_resolver import canonicalize_member_id, resolve_member
 from app.services.project_auth import has_project_access
 from app.repositories.retro import (
@@ -125,19 +126,13 @@ async def create_session(
     return SessionListResponse.model_validate(session)
 
 
-@router.get("/{id}", response_model=SessionResponse)
-async def get_session(
-    id: uuid.UUID,
-    db: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    repo: RetroSessionRepository = Depends(_get_session_repo),
+async def _build_session_response(
+    db: AsyncSession, session: RetroSession, auth: AuthContext
 ) -> SessionResponse:
-    session = await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
-
     item_repo = RetroItemRepository(db)
     action_repo = RetroActionRepository(db)
-    items = await item_repo.list_by_session(id)
-    actions = await action_repo.list_by_session(id)
+    items = await item_repo.list_by_session(session.id)
+    actions = await action_repo.list_by_session(session.id)
 
     # P1(9f27af8f, 유나 real-payload 재현): grouped child를 items에서 제외하면 FE가 클러스터를
     # 그릴 데이터 자체가 없어짐(FE는 items를 top-level/child로 필터링해 렌더 — child 객체가
@@ -162,6 +157,11 @@ async def get_session(
             )
         )
         voted_item_ids = set(voted_rows.scalars().all())
+
+    # dc861e44 §5 — sprint 링크 가설(story 1 sprint_id 필터 재사용). sprint 미연결 회고는 [].
+    hypotheses = await synth_svc.build_hypotheses_items(
+        db, session.org_id, session.project_id, session.sprint_id
+    )
 
     return SessionResponse(
         id=session.id,
@@ -189,7 +189,57 @@ async def get_session(
             for i in items
         ],
         actions=[ActionResponse.model_validate(a) for a in actions],
+        hypotheses=hypotheses,
+        synthesis=session.synthesis,
+        next_hypotheses=session.next_hypotheses,
     )
+
+
+@router.get("/{id}", response_model=SessionResponse)
+async def get_session(
+    id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    repo: RetroSessionRepository = Depends(_get_session_repo),
+) -> SessionResponse:
+    session = await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
+    return await _build_session_response(db, session, auth)
+
+
+@router.post("/{id}/synthesize", response_model=SessionResponse)
+async def synthesize_session(
+    id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    repo: RetroSessionRepository = Depends(_get_session_repo),
+) -> SessionResponse:
+    """dc861e44 §3 — L2 종합(on-demand·버튼 트리거). overwrite 저장(PO 결)."""
+    session = await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
+    result = await synth_svc.synthesize(db, session)
+    updated = await repo.update(id, synthesis=result)
+    assert updated is not None
+    return await _build_session_response(db, updated, auth)
+
+
+@router.post("/{id}/recommend-next", response_model=SessionResponse)
+async def recommend_next_session(
+    id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    repo: RetroSessionRepository = Depends(_get_session_repo),
+) -> SessionResponse:
+    """dc861e44 §3 — L3 다음가설 추천(on-demand). synthesis 선행 필수 — PO 결(2026-07-03):
+    fail-closed(409), 자동 선행 생성 안 함(HITL 순서 — 팀이 종합을 보고/편집한 뒤 추천)."""
+    session = await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
+    if session.synthesis is None:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "SYNTHESIS_REQUIRED", "message": "종합을 먼저 생성해야 합니다."},
+        )
+    result = await synth_svc.recommend_next(session.synthesis)
+    updated = await repo.update(id, next_hypotheses=result)
+    assert updated is not None
+    return await _build_session_response(db, updated, auth)
 
 
 @router.patch("/{id}/phase", response_model=SessionListResponse)

--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -40,6 +40,18 @@ def _get_session_repo(
     return RetroSessionRepository(db, org_id)
 
 
+def _has_valid_synthesis(synthesis: object) -> bool:
+    """recommend-next 게이팅(까심 RC②, 2026-07-03) — `synthesis is None`만 보면 `{}`·`[]`·
+    `{"learned": []}` 같은 malformed/empty 값이 게이트를 통과한다. `synthesis=[]`는
+    `_build_next_hypotheses_prompt`의 `.get("learned")` 호출에서 AttributeError(500)까지
+    난다. dict이고 `learned`이 비어있지 않은 리스트일 때만 "종합이 실제로 존재"로 인정."""
+    return (
+        isinstance(synthesis, dict)
+        and isinstance(synthesis.get("learned"), list)
+        and len(synthesis["learned"]) > 0
+    )
+
+
 async def _require_retro_project_access(
     session: AsyncSession, session_id: uuid.UUID, user_id: uuid.UUID, org_id: uuid.UUID
 ) -> RetroSession:
@@ -213,9 +225,18 @@ async def synthesize_session(
     auth: AuthContext = Depends(get_current_user),
     repo: RetroSessionRepository = Depends(_get_session_repo),
 ) -> SessionResponse:
-    """dc861e44 §3 — L2 종합(on-demand·버튼 트리거). overwrite 저장(PO 결)."""
+    """dc861e44 §3 — L2 종합(on-demand·버튼 트리거). overwrite 저장(PO 결).
+
+    ⚠️ result가 None(LLM 생성 실패)이면 **저장하지 않는다** — 기존 good synthesis 캐시를
+    빈 결과로 덮어써 잃는 data-loss(오르테가 지적 2026-07-03·S28 캐시게이트 버그와 동형)를
+    막는다. 502로 실패를 명시하고 재시도를 유도(자동 backfill 없음)."""
     session = await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
     result = await synth_svc.synthesize(db, session)
+    if result is None:
+        raise HTTPException(
+            status_code=502,
+            detail={"code": "SYNTHESIS_GENERATION_FAILED", "message": "AI 종합 생성에 실패했습니다. 잠시 후 다시 시도해주세요."},
+        )
     updated = await repo.update(id, synthesis=result)
     assert updated is not None
     return await _build_session_response(db, updated, auth)
@@ -231,12 +252,19 @@ async def recommend_next_session(
     """dc861e44 §3 — L3 다음가설 추천(on-demand). synthesis 선행 필수 — PO 결(2026-07-03):
     fail-closed(409), 자동 선행 생성 안 함(HITL 순서 — 팀이 종합을 보고/편집한 뒤 추천)."""
     session = await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
-    if session.synthesis is None:
+    if not _has_valid_synthesis(session.synthesis):
         raise HTTPException(
             status_code=409,
             detail={"code": "SYNTHESIS_REQUIRED", "message": "종합을 먼저 생성해야 합니다."},
         )
     result = await synth_svc.recommend_next(session.synthesis)
+    if result is None:
+        # synthesize_session과 동일 원칙 — 실패를 빈 배열로 조용히 저장해 기존 good
+        # next_hypotheses 캐시를 지우지 않는다(오르테가 지적 2026-07-03).
+        raise HTTPException(
+            status_code=502,
+            detail={"code": "RECOMMENDATION_GENERATION_FAILED", "message": "다음가설 추천 생성에 실패했습니다. 잠시 후 다시 시도해주세요."},
+        )
     updated = await repo.update(id, next_hypotheses=result)
     assert updated is not None
     return await _build_session_response(db, updated, auth)

--- a/backend/app/schemas/retro.py
+++ b/backend/app/schemas/retro.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
@@ -43,6 +44,46 @@ class ActionResponse(BaseModel):
     created_at: datetime
 
 
+class RetroHypothesisItem(BaseModel):
+    """dc861e44 §5 — sprint 링크 가설(story 1 `hypothesis_sprint_links.sprint_id`) 평탄화.
+    N>=0 동일 렌더 — 0개/측정중만이어도 graceful(FE "아직 측정 중")."""
+
+    id: uuid.UUID
+    statement: str
+    status: str  # verified|falsified|measuring|killed|... (색/라벨은 FE·SOUL-LOCK)
+    metric: str | None = None
+    target: float | None = None
+    direction: str | None = None
+    actual: float | None = None  # outcome_result.actual, 미확정이면 None(측정중)
+    href: str
+
+
+class SynthesisLearnedItem(BaseModel):
+    text: str
+    source: str
+
+
+class Synthesis(BaseModel):
+    """L2 종합 — on-demand·overwrite 저장(PO 결). null이면 미생성(FE CTA)."""
+
+    learned: list[SynthesisLearnedItem]
+    generated_at: datetime
+    source: str = "ai_draft"
+
+
+class NextHypothesisCandidate(BaseModel):
+    """L3 다음가설 추천 — `HypothesisDraftResponse` 형 재사용(§5 계약). id는 story 3
+    "채택" 액션이 참조할 안정 키(이 story 스코프에선 순수 데이터 형상만)."""
+
+    id: uuid.UUID
+    statement: str
+    metric_definition: dict[str, Any]
+    measure_after: datetime
+    confidence: float | None = None
+    rationale: str
+    requires_confirmation: bool = True
+
+
 class SessionResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -57,6 +98,10 @@ class SessionResponse(BaseModel):
     updated_at: datetime
     items: list[ItemResponse] = []
     actions: list[ActionResponse] = []
+    # dc861e44 §5 — additive+nullable. hypotheses는 sprint_id 없으면 항상 []·회귀 0.
+    hypotheses: list[RetroHypothesisItem] = []
+    synthesis: Synthesis | None = None
+    next_hypotheses: list[NextHypothesisCandidate] | None = None
 
 
 class SessionListResponse(BaseModel):

--- a/backend/app/services/retro_synthesis.py
+++ b/backend/app/services/retro_synthesis.py
@@ -1,0 +1,206 @@
+"""E-SPRINT-LOOP dc861e44: retro §5 계약 — hypotheses[] 평탄화 + L2 종합 + L3 다음가설.
+
+design-first crux 반영(2026-07-03): synthesis/next_hypotheses는 on-demand·overwrite
+저장(retro_sessions nullable JSONB — repository.update()가 그대로 처리, 이 모듈은
+호출부가 저장할 dict/list를 만들어주기만 한다). LLM은 `llm_client.generate_text_claude`
+(graceful: 인증불가/오류 시 None) + JSON 출력 지시 + 파싱 실패 시 graceful fallback —
+S15(`hypothesis._draft_statement`)의 "LLM 실패해도 완전 실패 없음" 철학을 미러한다.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.retro import RetroItem, RetroSession
+
+logger = logging.getLogger(__name__)
+
+_TOP_ITEMS_LIMIT = 8
+_DEFAULT_MEASURE_DAYS = 14
+_MAX_NEXT_HYPOTHESES = 3
+
+_SOUL_LOCK_INSTRUCTION = (
+    "반증된(falsified) 가설이나 부정적 회고 항목은 실패로 서술하지 마라 — "
+    '"~을 확인했다", "~이 아님을 배웠다"처럼 학습 데이터로 서술하라. '
+    '"실패했다"·"안 됐다" 같은 표현은 금지한다.'
+)
+
+_SYNTHESIS_INSTRUCTION = (
+    "다음은 한 스프린트의 가설 검증 결과와 팀 회고 상위 의견이다. 이 정보만 근거로 "
+    '"이번 스프린트에서 배운 것"을 2~4개의 불릿으로 한국어로 종합하라. 각 불릿은 반드시 '
+    "근거(가설 statement 또는 회고 아이템 내용)를 함께 명시하라. " + _SOUL_LOCK_INSTRUCTION +
+    " 맥락에 없는 사실/숫자를 지어내지 마라. 출력은 반드시 아래 JSON 배열 형식만 — "
+    '다른 텍스트 절대 추가하지 마라:\n[{"text": "...", "source": "..."}]'
+)
+
+_NEXT_HYPOTHESES_INSTRUCTION = (
+    "다음은 한 스프린트 회고의 종합(무엇을 배웠는지)이다. 이 종합만 근거로 다음 스프린트에서 "
+    f"검증할 만한 가설 후보를 최대 {_MAX_NEXT_HYPOTHESES}개, 각각 " '"~할 것이다" 형태의 '
+    "제안형 한국어 문장으로 작성하라. 각 후보에는 반드시 근거(종합의 어느 부분에서 나왔는지)를 "
+    "rationale로 함께 제시하고, confidence(0.0~1.0, 확신도를 정직하게)를 매겨라. " +
+    _SOUL_LOCK_INSTRUCTION + " 맥락에 없는 사실을 지어내지 마라. 출력은 반드시 아래 JSON "
+    '배열 형식만 — 다른 텍스트 절대 추가하지 마라:\n'
+    '[{"statement": "...", "rationale": "...", "confidence": 0.0}]'
+)
+
+
+def _extract_json(raw: str) -> Any | None:
+    """LLM 출력이 ```json 코드펜스로 감싸져 오는 경우가 흔해 벗겨내고 파싱 시도."""
+    text = raw.strip()
+    if text.startswith("```"):
+        text = text.strip("`")
+        if text[:4].lower() == "json":
+            text = text[4:]
+        text = text.strip()
+    try:
+        return json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+async def build_hypotheses_items(
+    session: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID, sprint_id: uuid.UUID | None
+) -> list[dict[str, Any]]:
+    """§5 hypotheses[] — story 1의 sprint_id 필터 재사용(신규 쿼리 로직 없음). sprint 미연결
+    회고는 빈 배열(N=0 graceful)."""
+    if sprint_id is None:
+        return []
+    from app.services import hypothesis as hyp_svc
+
+    hyps = await hyp_svc.list_hypotheses(session, org_id, project_id, sprint_id=sprint_id, limit=200)
+    items: list[dict[str, Any]] = []
+    for h in hyps:
+        md = h.metric_definition or {}
+        actual = (h.outcome_result or {}).get("actual") if h.outcome_result else None
+        items.append({
+            "id": h.id,
+            "statement": h.statement,
+            "status": h.status,
+            "metric": md.get("metric"),
+            "target": md.get("target"),
+            "direction": md.get("direction"),
+            "actual": actual,
+            "href": f"/hypotheses/{h.id}",
+        })
+    return items
+
+
+async def _top_voted_item_texts(session: AsyncSession, session_id: uuid.UUID) -> list[str]:
+    from sqlalchemy import select
+
+    rows = (await session.execute(
+        select(RetroItem)
+        .where(RetroItem.session_id == session_id, RetroItem.parent_item_id.is_(None))
+        .order_by(RetroItem.vote_count.desc(), RetroItem.created_at.desc())
+        .limit(_TOP_ITEMS_LIMIT)
+    )).scalars().all()
+    return [f"[{i.category}] {i.text} ({i.vote_count}표)" for i in rows]
+
+
+def _build_synthesis_prompt(
+    hypotheses_items: list[dict[str, Any]], item_texts: list[str]
+) -> str | None:
+    """S15와 동형 원칙 — 근거(가설·투표 아이템) 전무면 None(지어내라고 시키지 않음)."""
+    if not hypotheses_items and not item_texts:
+        return None
+    lines = [_SYNTHESIS_INSTRUCTION, ""]
+    if hypotheses_items:
+        lines.append("가설 결과:")
+        for h in hypotheses_items:
+            actual_part = f" (실측 {h['actual']})" if h.get("actual") is not None else ""
+            lines.append(f"- {h['statement']} — {h['status']}{actual_part}")
+    if item_texts:
+        lines.append("")
+        lines.append("회고 상위 의견:")
+        lines.extend(f"- {t}" for t in item_texts)
+    return "\n".join(lines)
+
+
+async def synthesize(session: AsyncSession, retro: RetroSession) -> dict[str, Any]:
+    """L2 종합 생성 — 저장은 호출부(router)가 repo.update()로 overwrite."""
+    from app.services.llm_client import generate_text_claude
+
+    hypotheses_items = await build_hypotheses_items(
+        session, retro.org_id, retro.project_id, retro.sprint_id
+    )
+    item_texts = await _top_voted_item_texts(session, retro.id)
+    prompt = _build_synthesis_prompt(hypotheses_items, item_texts)
+    now = datetime.now(timezone.utc)
+
+    if prompt is None:
+        return {"learned": [], "generated_at": now.isoformat(), "source": "ai_draft"}
+
+    raw = None
+    try:
+        raw = generate_text_claude(prompt, reasoning="disabled")
+    except Exception as exc:  # noqa: BLE001 — LLM 실패는 graceful fallback, dispatch 안 깨짐.
+        logger.warning("retro synthesize: LLM 호출 실패(fallback): %s", exc)
+
+    learned: list[dict[str, str]] = []
+    if raw:
+        parsed = _extract_json(raw)
+        if isinstance(parsed, list):
+            learned = [
+                {"text": str(x["text"]), "source": str(x.get("source", ""))}
+                for x in parsed
+                if isinstance(x, dict) and isinstance(x.get("text"), str) and x["text"].strip()
+            ]
+        if not learned:
+            # 파싱 실패/빈 배열 — 원문을 단일 bullet로 래핑(완전 실패 없음, S15 fallback 철학).
+            learned = [{"text": raw.strip()[:500], "source": "generated"}]
+
+    return {"learned": learned, "generated_at": now.isoformat(), "source": "ai_draft"}
+
+
+def _build_next_hypotheses_prompt(synthesis: dict[str, Any]) -> str | None:
+    learned = synthesis.get("learned") or []
+    if not learned:
+        return None
+    lines = [_NEXT_HYPOTHESES_INSTRUCTION, "", "종합:"]
+    lines.extend(f"- {item.get('text', '')}" for item in learned if isinstance(item, dict))
+    return "\n".join(lines)
+
+
+async def recommend_next(synthesis: dict[str, Any]) -> list[dict[str, Any]]:
+    """L3 다음가설 추천 — synthesis(§5 계약 dict, 이미 non-null임을 라우터가 보장) 기반.
+    metric_definition/measure_after는 S15 draft_hypothesis와 동형으로 고정 템플릿(LLM이
+    구조화 수치를 지어내지 않게) — statement/rationale/confidence만 LLM 생성."""
+    from app.services.llm_client import generate_text_claude
+
+    prompt = _build_next_hypotheses_prompt(synthesis)
+    if prompt is None:
+        return []
+
+    raw = None
+    try:
+        raw = generate_text_claude(prompt, reasoning="disabled")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("retro recommend_next: LLM 호출 실패(fallback): %s", exc)
+    if not raw:
+        return []
+
+    parsed = _extract_json(raw)
+    if not isinstance(parsed, list):
+        return []
+
+    measure_after = datetime.now(timezone.utc) + timedelta(days=_DEFAULT_MEASURE_DAYS)
+    candidates: list[dict[str, Any]] = []
+    for x in parsed[:_MAX_NEXT_HYPOTHESES]:
+        if not isinstance(x, dict) or not isinstance(x.get("statement"), str) or not x["statement"].strip():
+            continue
+        confidence = x.get("confidence")
+        candidates.append({
+            "id": str(uuid.uuid4()),
+            "statement": x["statement"].strip(),
+            "metric_definition": {"metric": "outcome", "source": "manual", "target": 1, "direction": "up"},
+            "measure_after": measure_after.isoformat(),
+            "confidence": float(confidence) if isinstance(confidence, (int, float)) else None,
+            "rationale": str(x.get("rationale", "")),
+            "requires_confirmation": True,
+        })
+    return candidates

--- a/backend/app/services/retro_synthesis.py
+++ b/backend/app/services/retro_synthesis.py
@@ -127,8 +127,13 @@ async def synthesize(session: AsyncSession, retro: RetroSession) -> dict[str, An
     반환 None = **생성 실패**(호출부는 절대 저장하면 안 됨 — 기존 good 캐시가 있다면 그대로
     보존해야 함, PO 지적 2026-07-02 S28 캐시게이트 버그와 동형: "일시장애≠영구 no-result").
     구분: 근거(가설·투표 아이템) 전무는 **정당한 빈 결과**(learned=[])이지 실패가 아니다 —
-    LLM을 아예 호출 안 하고 그대로 반환. 반면 호출까지 갔는데 응답이 없으면(None/빈 문자열/
-    예외) 진짜 실패로 취급해 None 반환 — 조용히 learned=[]를 반환해 기존 캐시를 지우지 않는다."""
+    LLM을 아예 호출 안 하고 그대로 반환. 반면 호출까지 갔는데 응답이 없거나(None/빈 문자열/
+    예외) **JSON 파싱 실패/스키마 불일치**면 진짜 실패로 수렴(None) — 까심 codex RC(2026-07-03):
+    raw 텍스트를 단일 bullet로 "구제"하던 이전 fallback(S15 draft_hypothesis의 템플릿-fallback
+    철학을 그대로 미러한 것)이 실은 **캐시-overwrite 맥락에서 garbage-persist**였다. S15는
+    fallback 결과를 그 자리서 즉시 응답할 뿐 아무것도 지우지 않지만, 여기서는 라우터가
+    non-None 반환값을 곧장 `repo.update()`로 **기존 good synthesis 위에 덮어쓴다** — 같은
+    "완전 실패 없음" 철학이 정반대 결과(데이터 보존 vs 파괴)를 낳는 컨텍스트라 미러가 틀렸다."""
     from app.services.llm_client import generate_text_claude
 
     hypotheses_items = await build_hypotheses_items(
@@ -150,8 +155,8 @@ async def synthesize(session: AsyncSession, retro: RetroSession) -> dict[str, An
     if not raw:
         return None  # 근거는 있었는데 LLM이 실패 — 기존 캐시 보존(호출부 502·미저장).
 
-    learned: list[dict[str, str]] = []
     parsed = _extract_json(raw)
+    learned: list[dict[str, str]] = []
     if isinstance(parsed, list):
         learned = [
             {"text": str(x["text"]), "source": str(x.get("source", ""))}
@@ -159,9 +164,10 @@ async def synthesize(session: AsyncSession, retro: RetroSession) -> dict[str, An
             if isinstance(x, dict) and isinstance(x.get("text"), str) and x["text"].strip()
         ]
     if not learned:
-        # JSON 파싱 실패/스키마 불일치 — raw 자체는 실 LLM 응답(완전 실패 아님)이라 원문을
-        # 단일 bullet로 래핑해 구제(S15 fallback 철학). "raw가 아예 없음"과는 다른 케이스.
-        learned = [{"text": raw.strip()[:500], "source": "generated"}]
+        # JSON 파싱 실패/스키마 불일치/전부 malformed — raw-wrap 구제 없이 명시 실패(None).
+        # raw는 실 LLM 응답이었지만, 형식을 안 지킨 응답을 캐시에 넣는 것 자체가 이전 good
+        # synthesis를 저품질 1-bullet로 강등시키는 data-loss(까심 codex RC②).
+        return None
 
     return {"learned": learned, "generated_at": now.isoformat(), "source": "ai_draft"}
 

--- a/backend/app/services/retro_synthesis.py
+++ b/backend/app/services/retro_synthesis.py
@@ -121,8 +121,14 @@ def _build_synthesis_prompt(
     return "\n".join(lines)
 
 
-async def synthesize(session: AsyncSession, retro: RetroSession) -> dict[str, Any]:
-    """L2 종합 생성 — 저장은 호출부(router)가 repo.update()로 overwrite."""
+async def synthesize(session: AsyncSession, retro: RetroSession) -> dict[str, Any] | None:
+    """L2 종합 생성 — 저장은 호출부(router)가 repo.update()로 overwrite.
+
+    반환 None = **생성 실패**(호출부는 절대 저장하면 안 됨 — 기존 good 캐시가 있다면 그대로
+    보존해야 함, PO 지적 2026-07-02 S28 캐시게이트 버그와 동형: "일시장애≠영구 no-result").
+    구분: 근거(가설·투표 아이템) 전무는 **정당한 빈 결과**(learned=[])이지 실패가 아니다 —
+    LLM을 아예 호출 안 하고 그대로 반환. 반면 호출까지 갔는데 응답이 없으면(None/빈 문자열/
+    예외) 진짜 실패로 취급해 None 반환 — 조용히 learned=[]를 반환해 기존 캐시를 지우지 않는다."""
     from app.services.llm_client import generate_text_claude
 
     hypotheses_items = await build_hypotheses_items(
@@ -138,21 +144,24 @@ async def synthesize(session: AsyncSession, retro: RetroSession) -> dict[str, An
     raw = None
     try:
         raw = generate_text_claude(prompt, reasoning="disabled")
-    except Exception as exc:  # noqa: BLE001 — LLM 실패는 graceful fallback, dispatch 안 깨짐.
-        logger.warning("retro synthesize: LLM 호출 실패(fallback): %s", exc)
+    except Exception as exc:  # noqa: BLE001 — 예외도 "실패"로 수렴(None), 여기서 삼키지 않음.
+        logger.warning("retro synthesize: LLM 호출 실패: %s", exc)
+
+    if not raw:
+        return None  # 근거는 있었는데 LLM이 실패 — 기존 캐시 보존(호출부 502·미저장).
 
     learned: list[dict[str, str]] = []
-    if raw:
-        parsed = _extract_json(raw)
-        if isinstance(parsed, list):
-            learned = [
-                {"text": str(x["text"]), "source": str(x.get("source", ""))}
-                for x in parsed
-                if isinstance(x, dict) and isinstance(x.get("text"), str) and x["text"].strip()
-            ]
-        if not learned:
-            # 파싱 실패/빈 배열 — 원문을 단일 bullet로 래핑(완전 실패 없음, S15 fallback 철학).
-            learned = [{"text": raw.strip()[:500], "source": "generated"}]
+    parsed = _extract_json(raw)
+    if isinstance(parsed, list):
+        learned = [
+            {"text": str(x["text"]), "source": str(x.get("source", ""))}
+            for x in parsed
+            if isinstance(x, dict) and isinstance(x.get("text"), str) and x["text"].strip()
+        ]
+    if not learned:
+        # JSON 파싱 실패/스키마 불일치 — raw 자체는 실 LLM 응답(완전 실패 아님)이라 원문을
+        # 단일 bullet로 래핑해 구제(S15 fallback 철학). "raw가 아예 없음"과는 다른 케이스.
+        learned = [{"text": raw.strip()[:500], "source": "generated"}]
 
     return {"learned": learned, "generated_at": now.isoformat(), "source": "ai_draft"}
 
@@ -166,10 +175,14 @@ def _build_next_hypotheses_prompt(synthesis: dict[str, Any]) -> str | None:
     return "\n".join(lines)
 
 
-async def recommend_next(synthesis: dict[str, Any]) -> list[dict[str, Any]]:
+async def recommend_next(synthesis: dict[str, Any]) -> list[dict[str, Any]] | None:
     """L3 다음가설 추천 — synthesis(§5 계약 dict, 이미 non-null임을 라우터가 보장) 기반.
     metric_definition/measure_after는 S15 draft_hypothesis와 동형으로 고정 템플릿(LLM이
-    구조화 수치를 지어내지 않게) — statement/rationale/confidence만 LLM 생성."""
+    구조화 수치를 지어내지 않게) — statement/rationale/confidence만 LLM 생성.
+
+    반환 None = **생성 실패**(호출부 미저장 — synthesize와 동일 원칙, 기존 good
+    next_hypotheses 캐시를 빈 배열/garbage로 덮어쓰지 않는다). synthesis.learned가 애초에
+    비어 있어 프롬프트 자체를 안 만든 경우만 정당한 빈 배열(LLM 미호출)."""
     from app.services.llm_client import generate_text_claude
 
     prompt = _build_next_hypotheses_prompt(synthesis)
@@ -180,13 +193,14 @@ async def recommend_next(synthesis: dict[str, Any]) -> list[dict[str, Any]]:
     try:
         raw = generate_text_claude(prompt, reasoning="disabled")
     except Exception as exc:  # noqa: BLE001
-        logger.warning("retro recommend_next: LLM 호출 실패(fallback): %s", exc)
+        logger.warning("retro recommend_next: LLM 호출 실패: %s", exc)
     if not raw:
-        return []
+        return None  # LLM 실패 — 기존 캐시 보존.
 
     parsed = _extract_json(raw)
     if not isinstance(parsed, list):
-        return []
+        return None  # 파싱 자체가 완전 실패(리스트가 아님) — synthesis처럼 원문 래핑 구제가
+        # 불가(스키마상 statement 필수 필드라 텍스트 1줄로 대체 불가) → 명시 실패로 처리.
 
     measure_after = datetime.now(timezone.utc) + timedelta(days=_DEFAULT_MEASURE_DAYS)
     candidates: list[dict[str, Any]] = []
@@ -203,4 +217,8 @@ async def recommend_next(synthesis: dict[str, Any]) -> list[dict[str, Any]]:
             "rationale": str(x.get("rationale", "")),
             "requires_confirmation": True,
         })
+    if not candidates:
+        # 응답은 JSON 배열이었지만 항목이 전부 스키마 불일치 — 사실상 생성 실패와 동급이라
+        # 빈 배열을 "정답"으로 저장하지 않는다(기존 캐시 보존).
+        return None
     return candidates

--- a/backend/tests/test_e_sprint_loop_dc861e44_retro_synthesis_realdb.py
+++ b/backend/tests/test_e_sprint_loop_dc861e44_retro_synthesis_realdb.py
@@ -206,6 +206,66 @@ async def test_synthesize_cross_project_403():
         await eng.dispose()
 
 
+@pytest.mark.anyio
+async def test_llm_failure_does_not_destroy_existing_good_synthesis():
+    """까심 RC①(2026-07-03) — good synthesis가 이미 저장된 상태에서 [다시 생성]이 LLM 장애로
+    실패하면 502를 반환하고 **DB의 기존 값은 그대로**여야 한다(재조회로 실증 — 세션 로컬 파이썬
+    객체 비교가 아니라 진짜 커밋된 DB 상태 확인)."""
+    from app.routers.retros import get_session, synthesize_session
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        good_raw = '[{"text": "가설이 반증됐다 — 학습 데이터", "source": "가설 1"}]'
+        async with Session() as s:
+            with patch("app.services.llm_client.generate_text_claude", return_value=good_raw):
+                await synthesize_session(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
+            await s.commit()
+
+        # [다시 생성] 중 LLM 장애(Anthropic outage 재현) — 예외로 실패.
+        async with Session() as s:
+            with patch("app.services.llm_client.generate_text_claude", side_effect=RuntimeError("outage")):
+                with pytest.raises(HTTPException) as ei:
+                    await synthesize_session(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
+                assert ei.value.status_code == 502
+                assert ei.value.detail["code"] == "SYNTHESIS_GENERATION_FAILED"
+            await s.rollback()  # 실패 응답이면 어차피 아무것도 flush 안 됨 — 명시적으로 확인
+
+        # 재조회 — DB에 남은 값은 여전히 "good"(빈 배열/garbage로 덮이지 않음).
+        async with Session() as s:
+            resp = await get_session(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
+        assert resp.synthesis is not None
+        assert resp.synthesis.learned[0].text == "가설이 반증됐다 — 학습 데이터"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_recommend_next_malformed_synthesis_in_db_returns_409_not_500():
+    """까심 RC②(2026-07-03) — DB에 malformed synthesis(list)가 들어있어도 크래시 없이 409."""
+    from app.routers.retros import recommend_next_session
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            await s.execute(
+                text("UPDATE retro_sessions SET synthesis = '[]'::jsonb WHERE id = :id"),
+                {"id": SESSION_A},
+            )
+            await s.commit()
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await recommend_next_session(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
+            assert ei.value.status_code == 409
+            assert ei.value.detail["code"] == "SYNTHESIS_REQUIRED"
+    finally:
+        await eng.dispose()
+
+
 def _repo(session):
     from app.repositories.retro import RetroSessionRepository
     return RetroSessionRepository(session, ORG)

--- a/backend/tests/test_e_sprint_loop_dc861e44_retro_synthesis_realdb.py
+++ b/backend/tests/test_e_sprint_loop_dc861e44_retro_synthesis_realdb.py
@@ -1,0 +1,211 @@
+"""E-SPRINT-LOOP dc861e44: retro §5 계약 — realdb E2E(IDOR 상속·409 게이팅·hypotheses[] embed).
+
+router 함수를 직접 호출해(context_pack_search_idor_realdb.py·retro_mutation_project_scope_idor_
+realdb.py와 동형) 실 Postgres로 검증: ① sprint 링크 가설이 hypotheses[]로 정확히 평탄화되는지
+(story 1 HypothesisSprintLink 재사용) ② synthesize/recommend-next가 IDOR 가드(#1801)를
+상속하는지 ③ recommend-next가 synthesis 없으면 fail-closed 409인지. LLM은 patch(실 API 미호출).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from unittest.mock import patch
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("db000000-0000-0000-0000-000000000001")
+USER = uuid.UUID("db000000-0000-0000-0000-0000000000a1")
+OM = uuid.UUID("db000000-0000-0000-0000-0000000000b1")
+PROJ_A = uuid.UUID("db000000-0000-0000-0000-0000000000c1")  # USER grant(접근 O)
+PROJ_B = uuid.UUID("db000000-0000-0000-0000-0000000000c2")  # USER 접근 X(IDOR 축)
+SPRINT = uuid.UUID("db000000-0000-0000-0000-0000000000d1")
+HYP = uuid.UUID("db000000-0000-0000-0000-0000000000d2")
+SESSION_A = uuid.UUID("db000000-0000-0000-0000-0000000000e1")
+SESSION_B = uuid.UUID("db000000-0000-0000-0000-0000000000e2")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+
+
+async def _seed(s):
+    for sql in [
+        f"DELETE FROM retro_sessions WHERE org_id='{ORG}'",
+        f"DELETE FROM hypothesis_sprint_links WHERE hypothesis_id='{HYP}'",
+        f"DELETE FROM hypotheses WHERE id='{HYP}'",
+        f"DELETE FROM sprints WHERE id='{SPRINT}'",
+        f"DELETE FROM project_access WHERE project_id IN ('{PROJ_A}','{PROJ_B}')",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','DB','db-org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@db.test','x','U',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ_A}','{ORG}','A','none')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ_B}','{ORG}','B','none')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ_A}','{OM}','granted')",
+        f"INSERT INTO sprints (id,org_id,project_id,title,status,duration) VALUES "
+        f"('{SPRINT}','{ORG}','{PROJ_A}','sprint-a','planning',14)",
+    ]:
+        await s.execute(text(sql))
+    # hypothesis(§5 metric/target/direction/actual 평탄화 실증용 — falsified+actual 채점됨)
+    await s.execute(
+        text(
+            "INSERT INTO hypotheses (id,org_id,project_id,owner_member_id,statement,"
+            "metric_definition,measure_after,status,outcome_result,human_accounting,gate_contract) VALUES "
+            "(:id,:org_id,:project_id,:owner_id,:statement,CAST(:metric AS jsonb),:measure_after,"
+            "'falsified',CAST(:outcome AS jsonb),'{}','{}')"
+        ),
+        {
+            "id": HYP, "org_id": ORG, "project_id": PROJ_A, "owner_id": OM,
+            "statement": "온보딩 개선으로 이탈이 줄 것이다",
+            "metric": '{"metric":"retention","source":"manual","target":50,"direction":"up"}',
+            "measure_after": datetime(2026, 8, 1, tzinfo=timezone.utc),
+            "outcome": '{"actual": 42}',
+        },
+    )
+    await s.execute(
+        text(
+            "INSERT INTO hypothesis_sprint_links (id,hypothesis_id,sprint_id,link_type) "
+            "VALUES (:id,:hyp,:sprint,'declared')"
+        ),
+        {"id": uuid.uuid4(), "hyp": HYP, "sprint": SPRINT},
+    )
+    # retro session — PROJ_A(sprint 링크)·PROJ_B(IDOR 대상)
+    from app.models.retro import RetroSession
+    s.add(RetroSession(
+        id=SESSION_A, org_id=ORG, project_id=PROJ_A, sprint_id=SPRINT,
+        title="retro-a", phase="closed",
+    ))
+    s.add(RetroSession(
+        id=SESSION_B, org_id=ORG, project_id=PROJ_B, title="retro-b", phase="collect",
+    ))
+    await s.commit()
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+@pytest.mark.anyio
+async def test_hypotheses_embed_flattens_sprint_linked_hypothesis():
+    from app.routers.retros import get_session
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            resp = await get_session(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
+        assert len(resp.hypotheses) == 1
+        h = resp.hypotheses[0]
+        assert h.id == HYP
+        assert h.status == "falsified"
+        assert h.metric == "retention"
+        assert h.target == 50
+        assert h.direction == "up"
+        assert h.actual == 42
+        assert h.href == f"/hypotheses/{HYP}"
+        assert resp.synthesis is None
+        assert resp.next_hypotheses is None
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_synthesize_then_recommend_next_full_flow():
+    from app.routers.retros import recommend_next_session, synthesize_session
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        # get_db 의존성은 요청 끝에서 커밋한다(프로덕션 경로) — 라우터 함수를 직접 호출하는
+        # 이 테스트는 그 래핑을 우회하므로 명시 commit 필요(repo.update()는 flush만 함).
+        synth_raw = '[{"text": "가설이 반증됐다(온보딩 42% vs 목표 50%) — 학습 데이터", "source": "가설 1"}]'
+        async with Session() as s:
+            with patch("app.services.llm_client.generate_text_claude", return_value=synth_raw):
+                resp = await synthesize_session(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
+            await s.commit()
+        assert resp.synthesis is not None
+        assert len(resp.synthesis.learned) == 1
+        assert "학습" in resp.synthesis.learned[0].text or resp.synthesis.learned[0].text
+
+        next_raw = '[{"statement": "온보딩 UX를 단순화하면 이탈이 줄 것이다.", "rationale": "가설 1 반증", "confidence": 0.55}]'
+        async with Session() as s:
+            with patch("app.services.llm_client.generate_text_claude", return_value=next_raw):
+                resp2 = await recommend_next_session(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
+            await s.commit()
+        assert resp2.next_hypotheses is not None
+        assert len(resp2.next_hypotheses) == 1
+        assert resp2.next_hypotheses[0].requires_confirmation is True
+
+        # 재조회해도 overwrite 캐시가 그대로 남아있는지(PO 결 — 매 GET 재생성 안 함).
+        from app.routers.retros import get_session
+        async with Session() as s:
+            resp3 = await get_session(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
+        assert resp3.synthesis is not None
+        assert resp3.next_hypotheses is not None
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_recommend_next_without_synthesis_409():
+    from app.routers.retros import recommend_next_session
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await recommend_next_session(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
+            assert ei.value.status_code == 409
+            assert ei.value.detail["code"] == "SYNTHESIS_REQUIRED"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_synthesize_cross_project_403():
+    """IDOR 가드 상속(#1801) — USER는 PROJ_B(SESSION_B) grant 없음."""
+    from app.routers.retros import synthesize_session
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await synthesize_session(SESSION_B, db=s, auth=_auth(), repo=_repo(s))
+            assert ei.value.status_code == 403
+    finally:
+        await eng.dispose()
+
+
+def _repo(session):
+    from app.repositories.retro import RetroSessionRepository
+    return RetroSessionRepository(session, ORG)

--- a/backend/tests/test_e_sprint_loop_dc861e44_retro_synthesis_realdb.py
+++ b/backend/tests/test_e_sprint_loop_dc861e44_retro_synthesis_realdb.py
@@ -243,6 +243,41 @@ async def test_llm_failure_does_not_destroy_existing_good_synthesis():
 
 
 @pytest.mark.anyio
+async def test_malformed_llm_response_does_not_destroy_existing_good_synthesis():
+    """까심 codex RC①(2026-07-03) — [다시 생성]에서 LLM이 예외/None이 아니라 **JSON 형식을
+    안 지킨 텍스트**를 반환해도(raw는 존재) 기존 good synthesis가 살아남아야 한다. 1차 fix는
+    raw가 None/예외인 경우만 잡았고, "raw는 있지만 malformed"는 여전히 1-bullet로 래핑해
+    캐시를 덮어썼다(codex가 잡은 잔여 구멍) — 이제 이 경로도 502·캐시 보존."""
+    from app.routers.retros import get_session, synthesize_session
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        good_raw = '[{"text": "가설이 반증됐다 — 학습 데이터", "source": "가설 1"}]'
+        async with Session() as s:
+            with patch("app.services.llm_client.generate_text_claude", return_value=good_raw):
+                await synthesize_session(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
+            await s.commit()
+
+        # [다시 생성] — LLM이 응답은 하지만 JSON 형식을 안 지킴(raw-wrap 구제 제거 검증).
+        async with Session() as s:
+            with patch("app.services.llm_client.generate_text_claude", return_value="이건 JSON이 아님"):
+                with pytest.raises(HTTPException) as ei:
+                    await synthesize_session(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
+                assert ei.value.status_code == 502
+            await s.rollback()
+
+        async with Session() as s:
+            resp = await get_session(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
+        assert resp.synthesis is not None
+        assert resp.synthesis.learned[0].text == "가설이 반증됐다 — 학습 데이터"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
 async def test_recommend_next_malformed_synthesis_in_db_returns_409_not_500():
     """까심 RC②(2026-07-03) — DB에 malformed synthesis(list)가 들어있어도 크래시 없이 409."""
     from app.routers.retros import recommend_next_session
@@ -255,6 +290,31 @@ async def test_recommend_next_malformed_synthesis_in_db_returns_409_not_500():
             await s.execute(
                 text("UPDATE retro_sessions SET synthesis = '[]'::jsonb WHERE id = :id"),
                 {"id": SESSION_A},
+            )
+            await s.commit()
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await recommend_next_session(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
+            assert ei.value.status_code == 409
+            assert ei.value.detail["code"] == "SYNTHESIS_REQUIRED"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_recommend_next_item_shape_malformed_synthesis_in_db_returns_409():
+    """까심 codex RC②(2026-07-03) — learned는 비어있지 않은 list지만 아이템이 스키마 불일치
+    (text 부재)면 여전히 409여야 한다(item-shape 미검증 시 통과하던 구멍)."""
+    from app.routers.retros import recommend_next_session
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            await s.execute(
+                text("UPDATE retro_sessions SET synthesis = :syn WHERE id = :id"),
+                {"syn": '{"learned": [{}], "generated_at": "t", "source": "ai_draft"}', "id": SESSION_A},
             )
             await s.commit()
         async with Session() as s:

--- a/backend/tests/test_retro_synthesis_service.py
+++ b/backend/tests/test_retro_synthesis_service.py
@@ -129,7 +129,10 @@ async def test_synthesize_malformed_json_falls_back_to_raw_wrap():
     assert result["learned"][0]["source"] == "generated"
 
 
-async def test_synthesize_llm_none_falls_back_to_empty_learned():
+async def test_synthesize_llm_none_returns_none_not_empty_success():
+    """data-loss 방지(오르테가 지적 2026-07-03) — LLM이 근거는 받고도 실패하면 '정당한 빈
+    결과'가 아니라 명시 실패(None)여야 한다. 호출부가 이 None을 기존 캐시 덮어쓰기 신호로
+    오인하면 안 되므로 dict가 아니라 None을 반환한다."""
     session = _empty_execute_session()
     retro = _retro(sprint_id=SPRINT_ID)
     hyp = SimpleNamespace(
@@ -139,10 +142,10 @@ async def test_synthesize_llm_none_falls_back_to_empty_learned():
     with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
          patch("app.services.llm_client.generate_text_claude", return_value=None):
         result = await svc.synthesize(session, retro)
-    assert result["learned"] == []
+    assert result is None
 
 
-async def test_synthesize_llm_exception_graceful():
+async def test_synthesize_llm_exception_returns_none():
     session = _empty_execute_session()
     retro = _retro(sprint_id=SPRINT_ID)
     hyp = SimpleNamespace(
@@ -151,8 +154,8 @@ async def test_synthesize_llm_exception_graceful():
     )
     with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
          patch("app.services.llm_client.generate_text_claude", side_effect=RuntimeError("boom")):
-        result = await svc.synthesize(session, retro)  # 예외 전파 없이 graceful
-    assert result["learned"] == []
+        result = await svc.synthesize(session, retro)  # 예외 전파는 없음(None으로 수렴)
+    assert result is None
 
 
 # ── recommend_next ────────────────────────────────────────────────────────────
@@ -191,8 +194,26 @@ async def test_recommend_next_caps_at_max_and_drops_malformed():
     assert len(result) == 3  # _MAX_NEXT_HYPOTHESES=3 캡
 
 
-async def test_recommend_next_invalid_json_returns_empty():
+async def test_recommend_next_invalid_json_returns_none():
+    """data-loss 방지 — 파싱 완전 실패는 빈 배열(성공으로 오인 가능)이 아니라 None(실패)."""
     synthesis = {"learned": [{"text": "x", "source": "s"}], "generated_at": "x", "source": "ai_draft"}
     with patch("app.services.llm_client.generate_text_claude", return_value="not json"):
         result = await svc.recommend_next(synthesis)
-    assert result == []
+    assert result is None
+
+
+async def test_recommend_next_llm_none_returns_none():
+    synthesis = {"learned": [{"text": "x", "source": "s"}], "generated_at": "x", "source": "ai_draft"}
+    with patch("app.services.llm_client.generate_text_claude", return_value=None):
+        result = await svc.recommend_next(synthesis)
+    assert result is None
+
+
+async def test_recommend_next_all_items_malformed_returns_none():
+    """JSON 배열 형식은 맞지만 항목 전부 스키마 불일치(statement 부재) — 빈 배열을 '정답'으로
+    저장하면 안 되므로 None(실패)."""
+    synthesis = {"learned": [{"text": "x", "source": "s"}], "generated_at": "x", "source": "ai_draft"}
+    raw = '[{"no_statement": true}, {"also_wrong": 1}]'
+    with patch("app.services.llm_client.generate_text_claude", return_value=raw):
+        result = await svc.recommend_next(synthesis)
+    assert result is None

--- a/backend/tests/test_retro_synthesis_service.py
+++ b/backend/tests/test_retro_synthesis_service.py
@@ -1,0 +1,198 @@
+"""E-SPRINT-LOOP dc861e44: retro_synthesis 서비스 단위 테스트.
+
+핵심 불변식: 근거 전무(가설·투표 아이템 0건)면 LLM 호출 자체를 안 함(S15 동형·지어내기
+금지)·LLM 실패/파싱 실패는 항상 graceful fallback(완전 실패 없음)·synthesis 없으면
+recommend_next이 빈 배열(라우터의 409 게이팅과 별개로 서비스 레벨도 안전)."""
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import retro_synthesis as svc
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+SPRINT_ID = uuid.uuid4()
+SESSION_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _retro(sprint_id=None):
+    return SimpleNamespace(
+        id=SESSION_ID, org_id=ORG_ID, project_id=PROJECT_ID, sprint_id=sprint_id,
+    )
+
+
+def _empty_execute_session():
+    """RetroItem 상위 투표 쿼리가 빈 리스트를 반환하는 mock 세션."""
+    session = MagicMock()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = []
+    session.execute = AsyncMock(return_value=result)
+    return session
+
+
+# ── build_hypotheses_items ───────────────────────────────────────────────────
+
+async def test_build_hypotheses_items_no_sprint_returns_empty():
+    result = await svc.build_hypotheses_items(MagicMock(), ORG_ID, PROJECT_ID, None)
+    assert result == []
+
+
+async def test_build_hypotheses_items_flattens_metric_and_actual():
+    hyp = SimpleNamespace(
+        id=uuid.uuid4(), statement="stmt", status="falsified",
+        metric_definition={"metric": "signup_rate", "target": 10, "direction": "up"},
+        outcome_result={"actual": 7.5},
+    )
+    with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])):
+        result = await svc.build_hypotheses_items(MagicMock(), ORG_ID, PROJECT_ID, SPRINT_ID)
+    assert result == [{
+        "id": hyp.id, "statement": "stmt", "status": "falsified",
+        "metric": "signup_rate", "target": 10, "direction": "up", "actual": 7.5,
+        "href": f"/hypotheses/{hyp.id}",
+    }]
+
+
+async def test_build_hypotheses_items_measuring_actual_none():
+    hyp = SimpleNamespace(
+        id=uuid.uuid4(), statement="stmt", status="measuring",
+        metric_definition={"metric": "x", "target": 1, "direction": "up"},
+        outcome_result=None,
+    )
+    with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])):
+        result = await svc.build_hypotheses_items(MagicMock(), ORG_ID, PROJECT_ID, SPRINT_ID)
+    assert result[0]["actual"] is None
+
+
+# ── synthesize ────────────────────────────────────────────────────────────────
+
+async def test_synthesize_no_context_skips_llm_call():
+    """가설도 투표 아이템도 0건 — LLM 호출 자체를 안 함(S15 동형: 지어낼 근거가 없으면 안 시킴)."""
+    session = _empty_execute_session()
+    retro = _retro(sprint_id=None)
+    with patch("app.services.llm_client.generate_text_claude") as mock_gen:
+        result = await svc.synthesize(session, retro)
+    mock_gen.assert_not_called()
+    assert result["learned"] == []
+    assert result["source"] == "ai_draft"
+
+
+async def test_synthesize_parses_valid_json():
+    session = _empty_execute_session()
+    retro = _retro(sprint_id=SPRINT_ID)
+    hyp = SimpleNamespace(
+        id=uuid.uuid4(), statement="stmt", status="verified",
+        metric_definition={"metric": "x", "target": 1, "direction": "up"},
+        outcome_result={"actual": 2},
+    )
+    raw = '[{"text": "가설이 검증됐다", "source": "가설 1"}]'
+    with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
+         patch("app.services.llm_client.generate_text_claude", return_value=raw):
+        result = await svc.synthesize(session, retro)
+    assert result["learned"] == [{"text": "가설이 검증됐다", "source": "가설 1"}]
+
+
+async def test_synthesize_strips_markdown_fence():
+    session = _empty_execute_session()
+    retro = _retro(sprint_id=SPRINT_ID)
+    hyp = SimpleNamespace(
+        id=uuid.uuid4(), statement="stmt", status="verified",
+        metric_definition={}, outcome_result=None,
+    )
+    raw = '```json\n[{"text": "배운 것", "source": "s"}]\n```'
+    with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
+         patch("app.services.llm_client.generate_text_claude", return_value=raw):
+        result = await svc.synthesize(session, retro)
+    assert result["learned"] == [{"text": "배운 것", "source": "s"}]
+
+
+async def test_synthesize_malformed_json_falls_back_to_raw_wrap():
+    session = _empty_execute_session()
+    retro = _retro(sprint_id=SPRINT_ID)
+    hyp = SimpleNamespace(
+        id=uuid.uuid4(), statement="stmt", status="verified",
+        metric_definition={}, outcome_result=None,
+    )
+    raw = "이건 JSON이 아니라 그냥 텍스트임"
+    with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
+         patch("app.services.llm_client.generate_text_claude", return_value=raw):
+        result = await svc.synthesize(session, retro)
+    assert len(result["learned"]) == 1
+    assert result["learned"][0]["text"] == raw
+    assert result["learned"][0]["source"] == "generated"
+
+
+async def test_synthesize_llm_none_falls_back_to_empty_learned():
+    session = _empty_execute_session()
+    retro = _retro(sprint_id=SPRINT_ID)
+    hyp = SimpleNamespace(
+        id=uuid.uuid4(), statement="stmt", status="verified",
+        metric_definition={}, outcome_result=None,
+    )
+    with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
+         patch("app.services.llm_client.generate_text_claude", return_value=None):
+        result = await svc.synthesize(session, retro)
+    assert result["learned"] == []
+
+
+async def test_synthesize_llm_exception_graceful():
+    session = _empty_execute_session()
+    retro = _retro(sprint_id=SPRINT_ID)
+    hyp = SimpleNamespace(
+        id=uuid.uuid4(), statement="stmt", status="verified",
+        metric_definition={}, outcome_result=None,
+    )
+    with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
+         patch("app.services.llm_client.generate_text_claude", side_effect=RuntimeError("boom")):
+        result = await svc.synthesize(session, retro)  # 예외 전파 없이 graceful
+    assert result["learned"] == []
+
+
+# ── recommend_next ────────────────────────────────────────────────────────────
+
+async def test_recommend_next_empty_synthesis_skips_llm():
+    with patch("app.services.llm_client.generate_text_claude") as mock_gen:
+        result = await svc.recommend_next({"learned": [], "generated_at": "x", "source": "ai_draft"})
+    mock_gen.assert_not_called()
+    assert result == []
+
+
+async def test_recommend_next_parses_candidates():
+    synthesis = {"learned": [{"text": "배운 것", "source": "s"}], "generated_at": "x", "source": "ai_draft"}
+    raw = '[{"statement": "다음엔 온보딩을 개선하면 이탈이 줄 것이다.", "rationale": "가설 2 반증에서", "confidence": 0.6}]'
+    with patch("app.services.llm_client.generate_text_claude", return_value=raw):
+        result = await svc.recommend_next(synthesis)
+    assert len(result) == 1
+    c = result[0]
+    assert c["statement"] == "다음엔 온보딩을 개선하면 이탈이 줄 것이다."
+    assert c["rationale"] == "가설 2 반증에서"
+    assert c["confidence"] == 0.6
+    assert c["requires_confirmation"] is True
+    assert c["metric_definition"] == {"metric": "outcome", "source": "manual", "target": 1, "direction": "up"}
+    uuid.UUID(c["id"])  # 안정 참조 키 — 파싱 가능한 uuid여야 함
+    datetime.fromisoformat(c["measure_after"])  # ISO datetime
+
+
+async def test_recommend_next_caps_at_max_and_drops_malformed():
+    synthesis = {"learned": [{"text": "x", "source": "s"}], "generated_at": "x", "source": "ai_draft"}
+    raw = (
+        '[{"statement": "a"}, {"statement": "b"}, {"statement": "c"}, '
+        '{"statement": "d"}, {"no_statement": true}]'
+    )
+    with patch("app.services.llm_client.generate_text_claude", return_value=raw):
+        result = await svc.recommend_next(synthesis)
+    assert len(result) == 3  # _MAX_NEXT_HYPOTHESES=3 캡
+
+
+async def test_recommend_next_invalid_json_returns_empty():
+    synthesis = {"learned": [{"text": "x", "source": "s"}], "generated_at": "x", "source": "ai_draft"}
+    with patch("app.services.llm_client.generate_text_claude", return_value="not json"):
+        result = await svc.recommend_next(synthesis)
+    assert result == []

--- a/backend/tests/test_retro_synthesis_service.py
+++ b/backend/tests/test_retro_synthesis_service.py
@@ -113,7 +113,10 @@ async def test_synthesize_strips_markdown_fence():
     assert result["learned"] == [{"text": "배운 것", "source": "s"}]
 
 
-async def test_synthesize_malformed_json_falls_back_to_raw_wrap():
+async def test_synthesize_malformed_json_returns_none_no_raw_wrap():
+    """까심 codex RC①(2026-07-03) — 파싱 실패한 raw를 단일 bullet로 "구제"하던 이전 fallback은
+    캐시-overwrite 맥락에서 garbage-persist였다(S15 템플릿-fallback 철학이 여기선 오적용).
+    이제 malformed/wrong-shape는 명시 실패(None) — 호출부가 기존 캐시를 지키게 한다."""
     session = _empty_execute_session()
     retro = _retro(sprint_id=SPRINT_ID)
     hyp = SimpleNamespace(
@@ -124,9 +127,22 @@ async def test_synthesize_malformed_json_falls_back_to_raw_wrap():
     with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
          patch("app.services.llm_client.generate_text_claude", return_value=raw):
         result = await svc.synthesize(session, retro)
-    assert len(result["learned"]) == 1
-    assert result["learned"][0]["text"] == raw
-    assert result["learned"][0]["source"] == "generated"
+    assert result is None
+
+
+async def test_synthesize_valid_json_wrong_item_shape_returns_none():
+    """JSON 배열이지만 항목이 스키마 불일치(text 부재/blank) — 전부 None(실패)."""
+    session = _empty_execute_session()
+    retro = _retro(sprint_id=SPRINT_ID)
+    hyp = SimpleNamespace(
+        id=uuid.uuid4(), statement="stmt", status="verified",
+        metric_definition={}, outcome_result=None,
+    )
+    raw = '[{"no_text": 1}, {"text": "   "}]'
+    with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
+         patch("app.services.llm_client.generate_text_claude", return_value=raw):
+        result = await svc.synthesize(session, retro)
+    assert result is None
 
 
 async def test_synthesize_llm_none_returns_none_not_empty_success():

--- a/backend/tests/test_retros.py
+++ b/backend/tests/test_retros.py
@@ -1073,6 +1073,56 @@ async def test_synthesize_session_200_persists_via_repo_update():
 
 
 @pytest.mark.anyio
+async def test_synthesize_llm_failure_does_not_overwrite_existing_cache():
+    """data-loss 방지(오르테가 지적 2026-07-03) — LLM 생성 실패(svc가 None 반환) 시 502를
+    반환하고 repo.update()를 절대 호출하지 않는다(기존 good synthesis 캐시 보존)."""
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with (
+            _allow_project_access(),
+            patch("app.routers.retros.synth_svc.synthesize", new=AsyncMock(return_value=None)),
+            patch("app.repositories.base.BaseRepository.update", new=AsyncMock()) as mock_update,
+        ):
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/synthesize")
+
+        assert resp.status_code == 502
+        assert resp.json()["error"]["code"] == "SYNTHESIS_GENERATION_FAILED"
+        mock_update.assert_not_awaited()  # 핵심 — 실패 시 캐시 절대 건드리지 않음
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_recommend_next_llm_failure_does_not_overwrite_existing_cache():
+    client, session, app = await _client()
+    try:
+        s = _mock_session()
+        s.synthesis = {"learned": [{"text": "x", "source": "s"}], "generated_at": "t", "source": "ai_draft"}
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = s
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with (
+            _allow_project_access(),
+            patch("app.routers.retros.synth_svc.recommend_next", new=AsyncMock(return_value=None)),
+            patch("app.repositories.base.BaseRepository.update", new=AsyncMock()) as mock_update,
+        ):
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/recommend-next")
+
+        assert resp.status_code == 502
+        assert resp.json()["error"]["code"] == "RECOMMENDATION_GENERATION_FAILED"
+        mock_update.assert_not_awaited()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_recommend_next_without_synthesis_409():
     """PO 결(2026-07-03) — synthesis 미생성 시 fail-closed 409(자동 선행 생성 안 함)."""
     client, session, app = await _client()
@@ -1089,6 +1139,40 @@ async def test_recommend_next_without_synthesis_409():
 
         assert resp.status_code == 409
         assert resp.json()["error"]["code"] == "SYNTHESIS_REQUIRED"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.parametrize("malformed_synthesis", [
+    {},                    # dict이지만 learned 키 부재
+    [],                    # dict조차 아님 — .get() 호출 시 AttributeError 크래시 지점
+    {"learned": []},       # 형태는 맞지만 실제론 빈 종합(근거 없음으로 생성된 케이스)
+    {"learned": "x"},      # learned가 list가 아님
+    "not a dict",          # 완전 이형
+])
+@pytest.mark.anyio
+async def test_recommend_next_malformed_synthesis_409_not_crash(malformed_synthesis):
+    """까심 RC②(2026-07-03) — `is None`만 보던 구 게이트는 `[]`를 통과시켜
+    `_build_next_hypotheses_prompt`의 `.get()` 호출에서 500 크래시가 났다. `_has_valid_synthesis`
+    는 이 전부를 409로 fail-closed(크래시 없음·LLM 호출 없음·persist 없음)."""
+    client, session, app = await _client()
+    try:
+        s = _mock_session()
+        s.synthesis = malformed_synthesis
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = s
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with (
+            _allow_project_access(),
+            patch("app.routers.retros.synth_svc.recommend_next") as mock_recommend,
+        ):
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/recommend-next")
+
+        assert resp.status_code == 409
+        assert resp.json()["error"]["code"] == "SYNTHESIS_REQUIRED"
+        mock_recommend.assert_not_called()  # 게이트에서 막혀 LLM 경로 진입 자체를 안 함
     finally:
         app.dependency_overrides.clear()
 

--- a/backend/tests/test_retros.py
+++ b/backend/tests/test_retros.py
@@ -1144,11 +1144,14 @@ async def test_recommend_next_without_synthesis_409():
 
 
 @pytest.mark.parametrize("malformed_synthesis", [
-    {},                    # dict이지만 learned 키 부재
-    [],                    # dict조차 아님 — .get() 호출 시 AttributeError 크래시 지점
-    {"learned": []},       # 형태는 맞지만 실제론 빈 종합(근거 없음으로 생성된 케이스)
-    {"learned": "x"},      # learned가 list가 아님
-    "not a dict",          # 완전 이형
+    {},                          # dict이지만 learned 키 부재
+    [],                          # dict조차 아님 — .get() 호출 시 AttributeError 크래시 지점
+    {"learned": []},             # 형태는 맞지만 실제론 빈 종합(근거 없음으로 생성된 케이스)
+    {"learned": "x"},            # learned가 list가 아님
+    "not a dict",                # 완전 이형
+    {"learned": [123]},          # 까심 codex RC②: 아이템이 dict가 아님(shape 미검증 시 통과)
+    {"learned": [{}]},           # 아이템이 dict지만 text 키 부재
+    {"learned": [{"text": "  "}]},  # text가 공백뿐
 ])
 @pytest.mark.anyio
 async def test_recommend_next_malformed_synthesis_409_not_crash(malformed_synthesis):

--- a/backend/tests/test_retros.py
+++ b/backend/tests/test_retros.py
@@ -6,6 +6,7 @@ patch해야 한다(패치 안 하면 진짜 session.execute가 한 번 더 끼�
 순번이 밀림 — 광역 mock 공유 함정. [[feedback_shared_flow_query_breaks_broad_mock]])."""
 import uuid
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -32,6 +33,11 @@ def _mock_session(phase: str = "collect", project_id: uuid.UUID = PROJECT_ID) ->
     s.actions = []
     s.created_at = datetime(2026, 4, 29, tzinfo=timezone.utc)
     s.updated_at = datetime(2026, 4, 29, tzinfo=timezone.utc)
+    # dc861e44: MagicMock은 미설정 속성을 truthy 자동생성하므로(parent_item_id와 동일 함정)
+    # 명시 None — 실 ORM 컬럼 기본값(미생성)과 정합, SessionResponse(synthesis: Synthesis|None)
+    # Pydantic 검증 통과에 필수.
+    s.synthesis = None
+    s.next_hypotheses = None
     return s
 
 
@@ -1002,5 +1008,196 @@ async def test_export_markdown_200():
         assert resp.status_code == 200
         assert "Sprint 3 Retro" in resp.text
         assert "# " in resp.text
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── dc861e44: synthesize / recommend-next ────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_synthesize_session_cross_project_403():
+    """IDOR 가드 상속(#1801) — synthesize도 _require_retro_project_access를 탐."""
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session(project_id=OTHER_PROJECT_ID)
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with _deny_project_access():
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/synthesize")
+
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_synthesize_session_200_persists_via_repo_update():
+    client, session, app = await _client()
+    try:
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = _mock_session()
+            else:
+                result.scalars.return_value.all.return_value = []  # items/actions 빈 리스트
+            return result
+
+        session.execute = mock_execute
+
+        synthesis_result = {
+            "learned": [{"text": "배운 것", "source": "s"}],
+            "generated_at": "2026-07-03T00:00:00+00:00", "source": "ai_draft",
+        }
+        updated = _mock_session()
+        updated.synthesis = synthesis_result
+
+        with (
+            _allow_project_access(), _mock_resolve_member(),
+            patch("app.routers.retros.synth_svc.synthesize", new=AsyncMock(return_value=synthesis_result)),
+            patch("app.repositories.base.BaseRepository.update", new=AsyncMock(return_value=updated)) as mock_update,
+        ):
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/synthesize")
+
+        assert resp.status_code == 200
+        assert resp.json()["synthesis"]["learned"][0]["text"] == "배운 것"
+        mock_update.assert_awaited_once_with(SESSION_ID, synthesis=synthesis_result)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_recommend_next_without_synthesis_409():
+    """PO 결(2026-07-03) — synthesis 미생성 시 fail-closed 409(자동 선행 생성 안 함)."""
+    client, session, app = await _client()
+    try:
+        s = _mock_session()
+        s.synthesis = None
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = s
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with _allow_project_access():
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/recommend-next")
+
+        assert resp.status_code == 409
+        assert resp.json()["error"]["code"] == "SYNTHESIS_REQUIRED"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_recommend_next_cross_project_403():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session(project_id=OTHER_PROJECT_ID)
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with _deny_project_access():
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/recommend-next")
+
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_recommend_next_200_when_synthesis_present():
+    client, session, app = await _client()
+    try:
+        s = _mock_session()
+        s.synthesis = {
+            "learned": [{"text": "x", "source": "s"}],
+            "generated_at": "2026-07-03T00:00:00+00:00", "source": "ai_draft",
+        }
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = s
+            else:
+                result.scalars.return_value.all.return_value = []
+            return result
+
+        session.execute = mock_execute
+
+        candidates = [{
+            "id": str(uuid.uuid4()), "statement": "다음엔 X를 검증할 것이다.",
+            "metric_definition": {"metric": "outcome", "source": "manual", "target": 1, "direction": "up"},
+            "measure_after": "2026-08-01T00:00:00+00:00", "confidence": 0.5,
+            "rationale": "r", "requires_confirmation": True,
+        }]
+        updated = _mock_session()
+        updated.synthesis = s.synthesis
+        updated.next_hypotheses = candidates
+
+        with (
+            _allow_project_access(), _mock_resolve_member(),
+            patch("app.routers.retros.synth_svc.recommend_next", new=AsyncMock(return_value=candidates)),
+            patch("app.repositories.base.BaseRepository.update", new=AsyncMock(return_value=updated)) as mock_update,
+        ):
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/recommend-next")
+
+        assert resp.status_code == 200
+        assert resp.json()["next_hypotheses"][0]["statement"] == "다음엔 X를 검증할 것이다."
+        mock_update.assert_awaited_once_with(SESSION_ID, next_hypotheses=candidates)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_session_embeds_hypotheses_when_sprint_linked():
+    """§5 hypotheses[] — sprint_id 있으면 story 1 필터 재사용해 채움."""
+    client, session, app = await _client()
+    try:
+        s = _mock_session()
+        s.sprint_id = uuid.uuid4()
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = s
+            else:
+                result.scalars.return_value.all.return_value = []
+            return result
+
+        session.execute = mock_execute
+
+        hyp = SimpleNamespace(
+            id=uuid.uuid4(), statement="stmt", status="verified",
+            metric_definition={"metric": "x", "target": 1, "direction": "up"},
+            outcome_result={"actual": 2},
+        )
+
+        with (
+            _allow_project_access(), _mock_resolve_member(),
+            patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])),
+        ):
+            async with client as c:
+                resp = await c.get(f"/api/v2/retros/{SESSION_ID}")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["hypotheses"]) == 1
+        assert body["hypotheses"][0]["statement"] == "stmt"
+        assert body["hypotheses"][0]["actual"] == 2
+        assert body["synthesis"] is None
+        assert body["next_hypotheses"] is None
     finally:
         app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- E-SPRINT-LOOP BE story 2(`dc861e44`) — story 1(`a4acc4d0` HypothesisSprintLink, 머지됨 `7f0ec8b6`)의 `sprint_id` 필터를 재사용해 retro `SessionResponse`에 3개 신규 표면 추가
- **`hypotheses[]`** — sprint 링크 가설 평탄화(id/statement/status/metric/target/direction/actual/href). sprint 미연결 회고는 `[]`(graceful)
- **`synthesis`(L2·on-demand)** — `POST /{id}/synthesize`. `generate_text_claude` + JSON 출력 지시 + 파싱, 실패/빈 컨텍스트는 graceful fallback(S15 철학 미러). SOUL-LOCK 프롬프트 지시(반증=학습 서술)
- **`next_hypotheses`(L3·on-demand)** — `POST /{id}/recommend-next`. **synthesis 없으면 409 SYNTHESIS_REQUIRED**(fail-closed, PO 결 2026-07-03 — 자동 선행 생성 안 함)
- 저장: `retro_sessions` nullable JSONB 2컬럼(overwrite 캐시, 마이그 `0155`) — PO 결: 이력 보존 YAGNI
- 신규 엔드포인트는 기존 `_require_retro_project_access` IDOR 가드(#1801 교훈) 그대로 상속
- `context_pack_search.py` 무접촉(§6 비협상)

## Design
설계 문서: sprintable docs `design-dc861e44-retro-s5-contract`(PO crux 통과 2026-07-03).

## Test plan
- [x] `pytest tests/ -k "retro or hypothesis or sprint"` — 250 passed, 0 regressions
- [x] `pytest tests/` 전체 — 2872 passed(story 1 대비 +19)·기존 8건 실패는 develop baseline과 동일(MCP/DoD 환경설정, 무관)
- [x] 신규 서비스 단위 테스트(`test_retro_synthesis_service.py`, 13건): 근거 0건→LLM 미호출·JSON 파싱 성공/마크다운 펜스 벗기기/파싱 실패 fallback/LLM None·예외 graceful·recommend_next 캡(N≤3)·malformed 드롭
- [x] 라우터 테스트(`test_retros.py` +8건): synthesize/recommend-next cross-project 403(IDOR 상속)·409 게이팅·200 happy path·hypotheses[] embed
- [x] **실 Postgres E2E**(`test_e_sprint_loop_dc861e44_retro_synthesis_realdb.py`, 4건): sprint 링크 가설 평탄화(falsified+actual 42/target 50 실측)·synthesize→recommend-next 전체 흐름(overwrite 캐시 재조회 확인)·409 게이팅·cross-project 403
- [x] `context_pack_search.py` 변경 없음 grep 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)