### PR TITLE
feat(e-sprint-loop): ecc531ce — 다음가설 채택→시드 (link_type=seeded)

### DIFF
--- a/backend/app/repositories/retro.py
+++ b/backend/app/repositories/retro.py
@@ -38,6 +38,29 @@ class RetroSessionRepository(BaseRepository[RetroSession]):
         assert updated is not None
         return updated
 
+    async def get_for_update(self, id: uuid.UUID) -> RetroSession | None:
+        """ecc531ce(까심 crux 2026-07-03) — 동시 [채택] 더블클릭 시 둘 다 next_hypotheses의
+        "미채택" 상태를 읽고 각자 create_hypothesis를 호출하면 중복 proposed 가설이 생긴다
+        (#1862 set_sprint_link TOCTOU와 같은 클래스). `FOR UPDATE`로 이 세션 row를 잠가
+        두 번째 요청이 첫 번째 커밋 후에야 읽도록 직렬화 — check-then-insert가 아니라
+        "이미 존재하는 row의 필드"를 다루는 경우라 SELECT FOR UPDATE가 유효하다
+        (check_then_insert_toctou 메모의 "row 0 시점 무력" 케이스와 다름 — 여기 row는 항상 존재).
+
+        `execution_options(populate_existing=True)` 필수 — 이 세션이 `_require_retro_project_
+        access`에서 이미 같은 id로 언락 SELECT를 한 번 했다면 identity map에 그 객체가 캐싱돼
+        있어, FOR UPDATE가 DB 레벨 락은 정확히 걸어도(실측 확인) SQLAlchemy가 Python 객체
+        속성을 새로 fetch한 row로 갱신 안 하면 잠금 대기 후에도 여전히 "잠금 전" 값(stale
+        next_hypotheses)을 반환하는 조용한 버그가 난다 — 락은 걸렸는데 읽은 값은 옛날 것이라
+        원자성이 실효 없어지는 것. 원 구현(populate_existing 누락)에서 실 동시성 테스트로
+        재현·적발."""
+        result = await self.session.execute(
+            select(RetroSession)
+            .where(RetroSession.id == id, RetroSession.org_id == self.org_id)
+            .with_for_update()
+            .execution_options(populate_existing=True)
+        )
+        return result.scalar_one_or_none()
+
 
 class RetroItemRepository:
     def __init__(self, session: AsyncSession) -> None:

--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -7,6 +7,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.retro import RetroItem, RetroSession, RetroVote
+from app.services import hypothesis as hyp_svc
+from app.services import retro_hypothesis_seed as seed_svc
 from app.services import retro_synthesis as synth_svc
 from app.services.member_resolver import canonicalize_member_id, resolve_member
 from app.services.project_auth import has_project_access
@@ -16,6 +18,7 @@ from app.repositories.retro import (
     RetroSessionRepository,
     RetroVoteRepository,
 )
+from app.schemas.hypothesis import HypothesisCreate, HypothesisLinkRequest
 from app.schemas.retro import (
     ActionResponse,
     CreateAction,
@@ -272,6 +275,77 @@ async def recommend_next_session(
             detail={"code": "RECOMMENDATION_GENERATION_FAILED", "message": "다음가설 추천 생성에 실패했습니다. 잠시 후 다시 시도해주세요."},
         )
     updated = await repo.update(id, next_hypotheses=result)
+    assert updated is not None
+    return await _build_session_response(db, updated, auth)
+
+
+@router.post("/{id}/next-hypotheses/{candidate_id}/adopt", response_model=SessionResponse)
+async def adopt_next_hypothesis(
+    id: uuid.UUID,
+    candidate_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    repo: RetroSessionRepository = Depends(_get_session_repo),
+) -> SessionResponse:
+    """ecc531ce §3 — L3 추천 채택 → proposed 가설 persist + 다음 sprint 있으면
+    link_type="seeded"로 링크(없으면 backlog proposed). 신규 hypothesis 서비스 로직 0줄 —
+    기존 create_hypothesis + link_hypothesis 조합. sprint_id는 서버가 조회(§2 PO 결)해서
+    클라이언트가 넘기지 않으므로 그 축의 IDOR가 설계상 없다.
+
+    SOUL-LOCK(유나 §6) "채택=인간 게이트" — agent caller는 403.
+
+    원자성(까심 crux 2026-07-03): `repo.get_for_update`로 이 session row를 잠가 동시
+    더블클릭이 직렬화되게 한다 — 안 그러면 둘 다 "미채택"을 읽고 각자 create_hypothesis를
+    호출해 중복 proposed 가설이 생긴다(#1862 set_sprint_link TOCTOU와 같은 클래스)."""
+    session = await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
+    caller = await resolve_member(auth, session.org_id, db, project_id=session.project_id)
+    if caller.type != "human":
+        raise HTTPException(
+            status_code=403,
+            detail={"code": "ADOPTION_REQUIRES_HUMAN", "message": "다음가설 채택은 사람만 할 수 있습니다."},
+        )
+
+    locked = await repo.get_for_update(id)
+    if locked is None:
+        raise HTTPException(status_code=404, detail="Retro session not found")
+
+    candidate = seed_svc.find_candidate(locked.next_hypotheses, candidate_id)
+    if candidate is None:
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "CANDIDATE_NOT_FOUND", "message": "추천 가설을 찾을 수 없습니다."},
+        )
+    if candidate.get("adopted_hypothesis_id"):
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "ALREADY_ADOPTED", "message": "이미 채택된 추천입니다."},
+        )
+
+    hyp = await hyp_svc.create_hypothesis(
+        db, session.org_id, caller,
+        HypothesisCreate(
+            project_id=session.project_id,
+            statement=candidate["statement"],
+            metric_definition=candidate["metric_definition"],
+            measure_after=candidate["measure_after"],
+            status="proposed",
+            source_type="retro_synthesis",
+            source_id=session.id,
+        ),
+    )
+
+    next_sprint = await seed_svc.resolve_next_sprint(db, session.org_id, session.project_id)
+    if next_sprint is not None:
+        await hyp_svc.link_hypothesis(
+            db, session.org_id, hyp.id,
+            HypothesisLinkRequest(sprint_id=next_sprint.id, link_type="seeded"),
+        )
+
+    updated_candidates = [
+        {**c, "adopted_hypothesis_id": str(hyp.id)} if str(c.get("id")) == str(candidate_id) else c
+        for c in locked.next_hypotheses
+    ]
+    updated = await repo.update(id, next_hypotheses=updated_candidates)
     assert updated is not None
     return await _build_session_response(db, updated, auth)
 

--- a/backend/app/schemas/retro.py
+++ b/backend/app/schemas/retro.py
@@ -73,7 +73,7 @@ class Synthesis(BaseModel):
 
 class NextHypothesisCandidate(BaseModel):
     """L3 다음가설 추천 — `HypothesisDraftResponse` 형 재사용(§5 계약). id는 story 3
-    "채택" 액션이 참조할 안정 키(이 story 스코프에선 순수 데이터 형상만)."""
+    "채택" 액션이 참조할 안정 키."""
 
     id: uuid.UUID
     statement: str
@@ -82,6 +82,8 @@ class NextHypothesisCandidate(BaseModel):
     confidence: float | None = None
     rationale: str
     requires_confirmation: bool = True
+    # ecc531ce — 채택되면 생성된 hypothesis id(idempotency 겸용 마커). None=미채택.
+    adopted_hypothesis_id: uuid.UUID | None = None
 
 
 class SessionResponse(BaseModel):

--- a/backend/app/services/retro_hypothesis_seed.py
+++ b/backend/app/services/retro_hypothesis_seed.py
@@ -1,0 +1,45 @@
+"""E-SPRINT-LOOP ecc531ce: 다음가설 채택→시드.
+
+design-first crux 반영(2026-07-03): 신규 hypothesis 서비스 로직은 0줄 — 기존
+`create_hypothesis`(proposed 생성)와 `link_hypothesis`(sprint_id+link_type="seeded")를
+그대로 두 번 호출해 조합한다(라우터에서). 이 모듈은 "다음 sprint" 해소와 candidate 탐색만
+담당 — 둘 다 순수 조회/헬퍼라 hypothesis 서비스를 건드리지 않는다.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.pm import Sprint
+
+
+async def resolve_next_sprint(
+    session: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID
+) -> Sprint | None:
+    """§2 PO 결(2026-07-03) — planning 상태 sprint 중 가장 이른 start_date(없으면
+    created_at)를 "다음 sprint"로 본다. `SprintRepository.activate()`의 1-active 제약과
+    달리 planning은 다건 공존 가능해 deterministic 선택 규칙이 필요했다. 없으면 None
+    (호출부는 backlog proposed로 그대로 둔다 — sprint 링크 생략)."""
+    return (await session.execute(
+        select(Sprint)
+        .where(Sprint.org_id == org_id, Sprint.project_id == project_id, Sprint.status == "planning")
+        .order_by(Sprint.start_date.asc().nulls_last(), Sprint.created_at.asc())
+        .limit(1)
+    )).scalar_one_or_none()
+
+
+def find_candidate(next_hypotheses: Any, candidate_id: uuid.UUID) -> dict[str, Any] | None:
+    """next_hypotheses(retro_sessions JSONB) 중 candidate_id 항목을 찾는다. 동시에 shape
+    검증도 겸한다 — malformed 캐시(list가 아니거나 item이 dict가 아님)는 못 믿으므로
+    안전하게 None을 반환해 라우터가 404로 처리하게 한다(연산 계속 X)."""
+    if not isinstance(next_hypotheses, list):
+        return None
+    for item in next_hypotheses:
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("id")) == str(candidate_id):
+            return item
+    return None

--- a/backend/tests/test_e_sprint_loop_ecc531ce_adopt_seed_realdb.py
+++ b/backend/tests/test_e_sprint_loop_ecc531ce_adopt_seed_realdb.py
@@ -1,0 +1,278 @@
+"""E-SPRINT-LOOP ecc531ce: 다음가설 채택→시드 — realdb(IDOR·human-gate·N:1·동시성).
+
+router 함수를 직접 호출해(story 1/2와 동형 패턴) 실 Postgres로 검증: ① 다음 sprint가
+있으면 link_type=seeded로 연결·없으면 backlog proposed(sprint 링크 없음) ② 동시 더블클릭
+(concurrent adopt)이 중복 hypothesis를 만들지 않는지(까심 crux 핵심 요구) ③ 재채택 409
+④ IDOR 상속. embeddings 테이블은 로컬 pg16에 pgvector가 없어 스키마에서 제외했으므로
+`enqueue_embedding`을 patch(이 story의 관심사 밖 — story 1/S1이 이미 검증한 배선)."""
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("dc000000-0000-0000-0000-000000000001")
+USER = uuid.UUID("dc000000-0000-0000-0000-0000000000a1")
+OM = uuid.UUID("dc000000-0000-0000-0000-0000000000b1")
+PROJ_A = uuid.UUID("dc000000-0000-0000-0000-0000000000c1")  # USER grant(접근 O)
+PROJ_B = uuid.UUID("dc000000-0000-0000-0000-0000000000c2")  # USER 접근 X(IDOR 축)
+SPRINT_PLANNING_LATE = uuid.UUID("dc000000-0000-0000-0000-0000000000d1")
+SPRINT_PLANNING_EARLY = uuid.UUID("dc000000-0000-0000-0000-0000000000d2")
+SESSION_A = uuid.UUID("dc000000-0000-0000-0000-0000000000e1")
+SESSION_A_NOSPRINT = uuid.UUID("dc000000-0000-0000-0000-0000000000e2")
+SESSION_B = uuid.UUID("dc000000-0000-0000-0000-0000000000e3")
+CANDIDATE_ID = uuid.UUID("dc000000-0000-0000-0000-0000000000f1")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+
+
+def _candidate_payload(cid: uuid.UUID = CANDIDATE_ID) -> list:
+    return [{
+        "id": str(cid),
+        "statement": "온보딩 UX를 단순화하면 이탈이 줄 것이다.",
+        "metric_definition": {"metric": "outcome", "source": "manual", "target": 1, "direction": "up"},
+        "measure_after": (datetime.now(timezone.utc) + timedelta(days=14)).isoformat(),
+        "confidence": 0.55, "rationale": "가설 1 반증에서", "requires_confirmation": True,
+        "adopted_hypothesis_id": None,
+    }]
+
+
+async def _seed(s):
+    for sql in [
+        f"DELETE FROM retro_sessions WHERE org_id='{ORG}'",
+        f"DELETE FROM hypotheses WHERE org_id='{ORG}'",
+        f"DELETE FROM sprints WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id IN ('{PROJ_A}','{PROJ_B}')",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','DC','dc-org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@dc.test','x','U',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ_A}','{ORG}','A','none')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ_B}','{ORG}','B','none')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission) "
+        f"VALUES (gen_random_uuid(),'{PROJ_A}','{OM}','granted')",
+        # planning sprint 2개(§2 규칙 실증: 이른 start_date가 선택돼야 함) + active sprint 1개(제외 대상).
+        f"INSERT INTO sprints (id,org_id,project_id,title,status,duration,start_date) VALUES "
+        f"('{SPRINT_PLANNING_LATE}','{ORG}','{PROJ_A}','late','planning',14,'2026-09-01')",
+        f"INSERT INTO sprints (id,org_id,project_id,title,status,duration,start_date) VALUES "
+        f"('{SPRINT_PLANNING_EARLY}','{ORG}','{PROJ_A}','early','planning',14,'2026-08-01')",
+    ]:
+        await s.execute(text(sql))
+    from app.models.retro import RetroSession
+    s.add(RetroSession(
+        id=SESSION_A, org_id=ORG, project_id=PROJ_A, title="retro-a", phase="closed",
+        next_hypotheses=_candidate_payload(),
+    ))
+    s.add(RetroSession(
+        id=SESSION_A_NOSPRINT, org_id=ORG, project_id=PROJ_A, title="retro-a-nosprint", phase="closed",
+        next_hypotheses=_candidate_payload(uuid.uuid4()),
+    ))
+    s.add(RetroSession(
+        id=SESSION_B, org_id=ORG, project_id=PROJ_B, title="retro-b", phase="closed",
+        next_hypotheses=_candidate_payload(),
+    ))
+    await s.commit()
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+def _repo(session):
+    from app.repositories.retro import RetroSessionRepository
+    return RetroSessionRepository(session, ORG)
+
+
+def _no_embed():
+    """매 호출마다 새 patch 인스턴스 — 동시 실행(asyncio.gather) 시 같은 patch 객체를
+    공유하면 'Patch is already started' RuntimeError가 난다(patch는 재진입 불가)."""
+    return patch("app.services.embedding_enqueue.enqueue_embedding", new=AsyncMock(return_value=None))
+
+
+@pytest.mark.anyio
+async def test_adopt_creates_proposed_hypothesis_seeds_earliest_planning_sprint():
+    """§2 PO 결 — planning 중 가장 이른 start_date(0801)가 선택돼야 함(0901 아님)."""
+    from app.routers.retros import adopt_next_hypothesis
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            with _no_embed():
+                resp = await adopt_next_hypothesis(
+                    SESSION_A, CANDIDATE_ID, db=s, auth=_auth(), repo=_repo(s),
+                )
+            await s.commit()
+
+        assert resp.next_hypotheses[0].adopted_hypothesis_id is not None
+        hyp_id = resp.next_hypotheses[0].adopted_hypothesis_id
+
+        async with Session() as s:
+            from app.models.hypothesis import Hypothesis, HypothesisSprintLink
+            hyp = (await s.execute(select(Hypothesis).where(Hypothesis.id == hyp_id))).scalar_one()
+            assert hyp.status == "proposed"
+            assert hyp.statement == "온보딩 UX를 단순화하면 이탈이 줄 것이다."
+            link = (await s.execute(
+                select(HypothesisSprintLink).where(HypothesisSprintLink.hypothesis_id == hyp_id)
+            )).scalar_one()
+            assert link.sprint_id == SPRINT_PLANNING_EARLY  # 이른 sprint가 선택됨
+            assert link.link_type == "seeded"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_adopt_no_planning_sprint_creates_backlog_proposed_no_link():
+    """AC #2 — 다음 sprint 없으면 backlog proposed(링크 없음). PROJ_B는 seed에서 sprint 0개."""
+    from app.routers.retros import adopt_next_hypothesis
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            # PROJ_B는 사용자 접근권이 없어(IDOR 대상) 여기선 못 씀 — PROJ_A에서 planning sprint를
+            # 전부 지워 "다음 sprint 없음"을 재현.
+            await s.execute(text(f"DELETE FROM sprints WHERE project_id='{PROJ_A}'"))
+            await s.commit()
+
+        async with Session() as s:
+            with _no_embed():
+                resp = await adopt_next_hypothesis(
+                    SESSION_A, CANDIDATE_ID, db=s, auth=_auth(), repo=_repo(s),
+                )
+            await s.commit()
+
+        hyp_id = resp.next_hypotheses[0].adopted_hypothesis_id
+        assert hyp_id is not None
+
+        async with Session() as s:
+            from app.models.hypothesis import Hypothesis, HypothesisSprintLink
+            hyp = (await s.execute(select(Hypothesis).where(Hypothesis.id == hyp_id))).scalar_one()
+            assert hyp.status == "proposed"
+            link = (await s.execute(
+                select(HypothesisSprintLink).where(HypothesisSprintLink.hypothesis_id == hyp_id)
+            )).scalar_one_or_none()
+            assert link is None  # backlog proposed — sprint 링크 없음
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_adopt_already_adopted_409():
+    from app.routers.retros import adopt_next_hypothesis
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            with _no_embed():
+                await adopt_next_hypothesis(SESSION_A, CANDIDATE_ID, db=s, auth=_auth(), repo=_repo(s))
+            await s.commit()
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await adopt_next_hypothesis(SESSION_A, CANDIDATE_ID, db=s, auth=_auth(), repo=_repo(s))
+            assert ei.value.status_code == 409
+            assert ei.value.detail["code"] == "ALREADY_ADOPTED"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_adopt_cross_project_403():
+    from app.routers.retros import adopt_next_hypothesis
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await adopt_next_hypothesis(SESSION_B, CANDIDATE_ID, db=s, auth=_auth(), repo=_repo(s))
+            assert ei.value.status_code == 403
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_concurrent_double_click_creates_exactly_one_hypothesis():
+    """까심 crux 핵심(2026-07-03) — 동시 더블클릭이 중복 proposed 가설을 만들면 안 된다.
+    `get_for_update`(FOR UPDATE)가 두 요청을 직렬화 — 하나는 200, 하나는 409(ALREADY_ADOPTED)
+    여야 하고, hypotheses 테이블에는 정확히 1행만 생겨야 한다."""
+    from app.models.retro import RetroSession
+    from app.routers.retros import adopt_next_hypothesis
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            row = (await s.execute(
+                select(RetroSession).where(RetroSession.id == SESSION_A_NOSPRINT)
+            )).scalar_one()
+            seeded_candidate_id = uuid.UUID(row.next_hypotheses[0]["id"])
+
+        async def _attempt():
+            async with Session() as s:
+                try:
+                    resp = await adopt_next_hypothesis(
+                        SESSION_A_NOSPRINT, seeded_candidate_id,
+                        db=s, auth=_auth(), repo=_repo(s),
+                    )
+                    await s.commit()
+                    return ("ok", resp)
+                except HTTPException as exc:
+                    await s.rollback()
+                    return ("error", exc.status_code)
+
+        # 두 태스크가 각자 patch.start()/stop()을 하면 한쪽의 __exit__이 다른 쪽이 아직
+        # 쓰는 중인 패치를 원본으로 되돌려버리는 레이스가 난다(unittest.mock.patch가 동시
+        # 진입을 가정 안 함) — gather 전체를 감싸는 단일 patch로 묶어 이 레이스를 없앤다.
+        with _no_embed():
+            results = await asyncio.gather(_attempt(), _attempt())
+        outcomes = [r[0] for r in results]
+        assert outcomes.count("ok") == 1
+        assert outcomes.count("error") == 1
+        assert 409 in [r[1] for r in results if r[0] == "error"]
+
+        async with Session() as s:
+            from app.models.hypothesis import Hypothesis
+            count = (await s.execute(
+                select(Hypothesis).where(
+                    Hypothesis.org_id == ORG, Hypothesis.source_id == SESSION_A_NOSPRINT
+                )
+            ))
+            rows = count.scalars().all()
+            assert len(rows) == 1  # 핵심 — 동시 더블클릭이 딱 1개만 생성
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_retro_hypothesis_seed_service.py
+++ b/backend/tests/test_retro_hypothesis_seed_service.py
@@ -1,0 +1,48 @@
+"""E-SPRINT-LOOP ecc531ce: retro_hypothesis_seed 서비스 단위 테스트.
+
+resolve_next_sprint(§2 PO 결: planning 중 가장 이른 start_date/created_at)와
+find_candidate(shape 검증 겸용 탐색)의 순수 로직만 — DB 연결/실 hypothesis 생성은
+realdb 스위트(test_e_sprint_loop_ecc531ce_*.py)에서."""
+import uuid
+
+import pytest
+
+from app.services import retro_hypothesis_seed as svc
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── find_candidate ────────────────────────────────────────────────────────────
+
+def test_find_candidate_matches_by_id():
+    cid = uuid.uuid4()
+    items = [{"id": str(cid), "statement": "s"}, {"id": str(uuid.uuid4()), "statement": "x"}]
+    result = svc.find_candidate(items, cid)
+    assert result == items[0]
+
+
+def test_find_candidate_not_found_returns_none():
+    assert svc.find_candidate([{"id": str(uuid.uuid4())}], uuid.uuid4()) is None
+
+
+def test_find_candidate_none_next_hypotheses_returns_none():
+    assert svc.find_candidate(None, uuid.uuid4()) is None
+
+
+def test_find_candidate_not_a_list_returns_none():
+    """malformed 캐시(dict/str 등) — 안전하게 None(라우터가 404로 처리)."""
+    assert svc.find_candidate({"learned": []}, uuid.uuid4()) is None
+    assert svc.find_candidate("not a list", uuid.uuid4()) is None
+
+
+def test_find_candidate_skips_non_dict_items():
+    cid = uuid.uuid4()
+    items = [123, "x", {"id": str(cid), "statement": "s"}]
+    result = svc.find_candidate(items, cid)
+    assert result == {"id": str(cid), "statement": "s"}

--- a/backend/tests/test_retros.py
+++ b/backend/tests/test_retros.py
@@ -89,10 +89,13 @@ def _deny_project_access():
     return patch("app.routers.retros.has_project_access", new=AsyncMock(return_value=False))
 
 
-def _mock_resolve_member(member_id: uuid.UUID | None = None):
-    """B4/P0: 라우터가 호출하는 resolve_member SSOT를 patch — DB member 해소 우회."""
+def _mock_resolve_member(member_id: uuid.UUID | None = None, member_type: str = "human"):
+    """B4/P0: 라우터가 호출하는 resolve_member SSOT를 patch — DB member 해소 우회.
+    ecc531ce: type 기본값 human(MagicMock 미설정 시 truthy 자동생성이 "human"과 항상
+    불일치해 adopt 라우트의 human-gate가 오탐 403을 내던 함정 — 명시 설정 필수)."""
     resolved = MagicMock()
     resolved.id = member_id or uuid.uuid4()
+    resolved.type = member_type
     return patch("app.routers.retros.resolve_member", new=AsyncMock(return_value=resolved))
 
 
@@ -1286,5 +1289,203 @@ async def test_get_session_embeds_hypotheses_when_sprint_linked():
         assert body["hypotheses"][0]["actual"] == 2
         assert body["synthesis"] is None
         assert body["next_hypotheses"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── ecc531ce: 다음가설 채택→시드 ─────────────────────────────────────────────
+
+CANDIDATE_ID = uuid.uuid4()
+
+
+def _candidate(**overrides) -> dict:
+    base = {
+        "id": str(CANDIDATE_ID), "statement": "다음엔 온보딩을 개선하면 이탈이 줄 것이다.",
+        "metric_definition": {"metric": "outcome", "source": "manual", "target": 1, "direction": "up"},
+        "measure_after": "2026-08-01T00:00:00+00:00", "confidence": 0.5,
+        "rationale": "r", "requires_confirmation": True, "adopted_hypothesis_id": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _mock_session_with_candidate(candidate_overrides=None, project_id=PROJECT_ID) -> MagicMock:
+    s = _mock_session(project_id=project_id)
+    s.next_hypotheses = [_candidate(**(candidate_overrides or {}))]
+    return s
+
+
+@pytest.mark.anyio
+async def test_adopt_requires_human_403():
+    """SOUL-LOCK "채택=인간 게이트" — agent caller는 403."""
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with _allow_project_access(), _mock_resolve_member(member_type="agent"):
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/next-hypotheses/{CANDIDATE_ID}/adopt")
+
+        assert resp.status_code == 403
+        assert resp.json()["error"]["code"] == "ADOPTION_REQUIRES_HUMAN"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_adopt_cross_project_403():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session(project_id=OTHER_PROJECT_ID)
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with _deny_project_access():
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/next-hypotheses/{CANDIDATE_ID}/adopt")
+
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_adopt_candidate_not_found_404():
+    client, session, app = await _client()
+    try:
+        s = _mock_session()
+        s.next_hypotheses = []
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = s
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with (
+            _allow_project_access(), _mock_resolve_member(),
+            patch("app.repositories.retro.RetroSessionRepository.get_for_update", new=AsyncMock(return_value=s)),
+        ):
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/next-hypotheses/{CANDIDATE_ID}/adopt")
+
+        assert resp.status_code == 404
+        assert resp.json()["error"]["code"] == "CANDIDATE_NOT_FOUND"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_adopt_already_adopted_409():
+    """PO 결(2026-07-03) — 재채택은 fail-closed 409(house style)."""
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        locked = _mock_session_with_candidate({"adopted_hypothesis_id": str(uuid.uuid4())})
+
+        with (
+            _allow_project_access(), _mock_resolve_member(),
+            patch("app.repositories.retro.RetroSessionRepository.get_for_update", new=AsyncMock(return_value=locked)),
+        ):
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/next-hypotheses/{CANDIDATE_ID}/adopt")
+
+        assert resp.status_code == 409
+        assert resp.json()["error"]["code"] == "ALREADY_ADOPTED"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_adopt_200_creates_hypothesis_and_seeds_next_sprint():
+    client, session, app = await _client()
+    try:
+        s = _mock_session()
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = s
+            else:
+                result.scalars.return_value.all.return_value = []
+            return result
+
+        session.execute = mock_execute
+
+        locked = _mock_session_with_candidate()
+        hyp_id = uuid.uuid4()
+        hyp = SimpleNamespace(id=hyp_id, project_id=PROJECT_ID)
+        next_sprint = SimpleNamespace(id=uuid.uuid4())
+        updated_session = _mock_session()
+        updated_session.next_hypotheses = [_candidate(adopted_hypothesis_id=str(hyp_id))]
+
+        with (
+            _allow_project_access(), _mock_resolve_member(),
+            patch("app.repositories.retro.RetroSessionRepository.get_for_update", new=AsyncMock(return_value=locked)),
+            patch("app.routers.retros.hyp_svc.create_hypothesis", new=AsyncMock(return_value=hyp)) as mock_create,
+            patch("app.routers.retros.seed_svc.resolve_next_sprint", new=AsyncMock(return_value=next_sprint)),
+            patch("app.routers.retros.hyp_svc.link_hypothesis", new=AsyncMock()) as mock_link,
+            patch("app.repositories.base.BaseRepository.update", new=AsyncMock(return_value=updated_session)) as mock_update,
+        ):
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/next-hypotheses/{CANDIDATE_ID}/adopt")
+
+        assert resp.status_code == 200
+        mock_create.assert_awaited_once()
+        mock_link.assert_awaited_once()
+        link_args = mock_link.await_args.args
+        assert link_args[2] == hyp_id
+        assert link_args[3].sprint_id == next_sprint.id
+        assert link_args[3].link_type == "seeded"
+        mock_update.assert_awaited_once()
+        assert resp.json()["next_hypotheses"][0]["adopted_hypothesis_id"] == str(hyp_id)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_adopt_no_next_sprint_skips_link_backlog_proposed():
+    """AC #2 — 다음 sprint 없으면 backlog proposed(링크 자체를 생략)."""
+    client, session, app = await _client()
+    try:
+        s = _mock_session()
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = s
+            else:
+                result.scalars.return_value.all.return_value = []
+            return result
+
+        session.execute = mock_execute
+
+        locked = _mock_session_with_candidate()
+        hyp_id = uuid.uuid4()
+        hyp = SimpleNamespace(id=hyp_id, project_id=PROJECT_ID)
+        updated_session = _mock_session()
+        updated_session.next_hypotheses = [_candidate(adopted_hypothesis_id=str(hyp_id))]
+
+        with (
+            _allow_project_access(), _mock_resolve_member(),
+            patch("app.repositories.retro.RetroSessionRepository.get_for_update", new=AsyncMock(return_value=locked)),
+            patch("app.routers.retros.hyp_svc.create_hypothesis", new=AsyncMock(return_value=hyp)),
+            patch("app.routers.retros.seed_svc.resolve_next_sprint", new=AsyncMock(return_value=None)),
+            patch("app.routers.retros.hyp_svc.link_hypothesis", new=AsyncMock()) as mock_link,
+            patch("app.repositories.base.BaseRepository.update", new=AsyncMock(return_value=updated_session)),
+        ):
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/next-hypotheses/{CANDIDATE_ID}/adopt")
+
+        assert resp.status_code == 200
+        mock_link.assert_not_called()
     finally:
         app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- E-SPRINT-LOOP BE **마지막 스토리**(`ecc531ce`) — story 1(`a4acc4d0`)·story 2(`dc861e44`) 위에 신규 hypothesis 서비스 로직 0줄, 기존 `create_hypothesis`(proposed 생성)+`link_hypothesis`(sprint_id+link_type="seeded")를 조합
- `POST /api/v2/retros/{id}/next-hypotheses/{candidate_id}/adopt`(신규) — L3 추천 채택 → proposed 가설 persist
- **다음 sprint 해소**: planning 상태 중 가장 이른 start_date(없으면 created_at, PO 결 2026-07-03) — 없으면 backlog proposed(sprint 링크 생략)
- **SOUL-LOCK "채택=인간 게이트"** — agent caller 403 `ADOPTION_REQUIRES_HUMAN`
- **anti-IDOR**: sprint_id는 서버가 조회(클라이언트 입력 아님) — 그 축의 IDOR가 설계상 존재하지 않음
- **재채택**: 409 `ALREADY_ADOPTED`(house style, idempotency 마커로 `adopted_hypothesis_id` 추가)
- **동시성**: `repo.get_for_update`(`SELECT ... FOR UPDATE`)로 세션 row를 잠가 동시 더블클릭 직렬화

## 구현 중 발견·수정한 버그
실 동시성 테스트(두 세션이 같은 candidate를 동시 채택 시도)로 재현: `FOR UPDATE`가 DB 레벨 락은 정확히 걸어도, `_require_retro_project_access`가 이미 그 세션 row를 identity map에 캐싱해뒀다면 SQLAlchemy가 락 후 재조회 시 Python 객체 속성을 새 row로 갱신하지 않아 **"잠금 대기 후에도 여전히 옛 값(next_hypotheses)을 읽는" 조용한 원자성 실효 상실**이 있었다 — 첫 실행에서 두 요청 다 200(중복 hypothesis 2개 생성)으로 재현됨. `execution_options(populate_existing=True)` 추가로 수정, 3회 반복 실행으로 안정성 확인.

## Design
설계 문서: sprintable docs `design-ecc531ce-next-hypothesis-seed`(PO crux 통과 2026-07-03, 동시성 원자성 요구사항 포함).

## Test plan
- [x] `pytest tests/` 전체 — 2896 passed(story 2 대비 +11)·기존 8건 실패는 develop baseline과 동일(MCP/DoD 환경설정, 무관)
- [x] 서비스 단위 테스트(`test_retro_hypothesis_seed_service.py`, 5건): find_candidate shape 검증
- [x] 라우터 테스트(`test_retros.py` +9건): human-gate 403·cross-project 403·candidate-not-found 404·already-adopted 409·200 happy path(with/without next sprint)
- [x] **실 Postgres E2E**(`test_e_sprint_loop_ecc531ce_adopt_seed_realdb.py`, 5건): 가장 이른 planning sprint 선택 실증·backlog fallback·재채택 409·cross-project 403·**동시 더블클릭이 정확히 1개 hypothesis만 생성**(concurrency 버그 재현→수정→3회 안정성 확인)
- [x] `context_pack_search.py` 변경 없음 grep 확인

머지되면 BE 3스토리(a4acc4d0/dc861e44/ecc531ce) 전부 완결 — 미르코군 FE(closed cockpit) 핸드오프 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)