### PR TITLE
fix(e-sprint-loop): defense-in-depth 2건 — garbage learned 드롭 + planning tie-break

### DIFF
--- a/backend/app/services/retro_hypothesis_seed.py
+++ b/backend/app/services/retro_hypothesis_seed.py
@@ -22,11 +22,16 @@ async def resolve_next_sprint(
     """§2 PO 결(2026-07-03) — planning 상태 sprint 중 가장 이른 start_date(없으면
     created_at)를 "다음 sprint"로 본다. `SprintRepository.activate()`의 1-active 제약과
     달리 planning은 다건 공존 가능해 deterministic 선택 규칙이 필요했다. 없으면 None
-    (호출부는 backlog proposed로 그대로 둔다 — sprint 링크 생략)."""
+    (호출부는 backlog proposed로 그대로 둔다 — sprint 링크 생략).
+
+    까심 QA MINOR(2026-07-03) — start_date와 created_at까지 완전히 동일한 sprint가
+    여럿이면(같은 배치로 생성된 케이스) 여전히 비결정적이었다. `Sprint.id.asc()`를 최종
+    tie-break로 추가 — id는 uuid4라 값 자체엔 의미 없지만, 같은 세션 안에서 매번 같은
+    행을 고른다는 순수 결정성만 보장하면 된다(어느 것이 뽑히든 product 의미는 동일)."""
     return (await session.execute(
         select(Sprint)
         .where(Sprint.org_id == org_id, Sprint.project_id == project_id, Sprint.status == "planning")
-        .order_by(Sprint.start_date.asc().nulls_last(), Sprint.created_at.asc())
+        .order_by(Sprint.start_date.asc().nulls_last(), Sprint.created_at.asc(), Sprint.id.asc())
         .limit(1)
     )).scalar_one_or_none()
 

--- a/backend/app/services/retro_synthesis.py
+++ b/backend/app/services/retro_synthesis.py
@@ -173,11 +173,19 @@ async def synthesize(session: AsyncSession, retro: RetroSession) -> dict[str, An
 
 
 def _build_next_hypotheses_prompt(synthesis: dict[str, Any]) -> str | None:
+    """까심 QA MINOR(2026-07-03) — `_has_valid_synthesis`는 "≥1개 유효 아이템"만 요구하므로
+    혼합 learned(예: [{"text":"진짜 내용"}, {"foo":"bar"}])가 게이트를 통과할 수 있다. 이전엔
+    dict이기만 하면 `item.get('text','')`로 빈 문자열 bullet("- ")까지 프롬프트에 흘려보냈다
+    — 게이트와 동일한 shape 검증(non-blank text)으로 garbage 아이템을 여기서도 드롭."""
     learned = synthesis.get("learned") or []
-    if not learned:
+    valid_texts = [
+        item["text"] for item in learned
+        if isinstance(item, dict) and isinstance(item.get("text"), str) and item["text"].strip()
+    ]
+    if not valid_texts:
         return None
     lines = [_NEXT_HYPOTHESES_INSTRUCTION, "", "종합:"]
-    lines.extend(f"- {item.get('text', '')}" for item in learned if isinstance(item, dict))
+    lines.extend(f"- {t}" for t in valid_texts)
     return "\n".join(lines)
 
 

--- a/backend/tests/test_e_sprint_loop_ecc531ce_adopt_seed_realdb.py
+++ b/backend/tests/test_e_sprint_loop_ecc531ce_adopt_seed_realdb.py
@@ -117,6 +117,42 @@ def _no_embed():
 
 
 @pytest.mark.anyio
+async def test_resolve_next_sprint_full_tie_breaks_deterministically_by_id():
+    """까심 QA MINOR(2026-07-03) — start_date·created_at까지 완전히 동일한 planning sprint가
+    여럿이면 `Sprint.id.asc()` tie-break 없이는 비결정적이었다. 두 sprint를 같은 start_date·
+    같은 explicit created_at으로 심고, 매번 같은(더 작은 id) sprint가 선택되는지 확인."""
+    from app.services.retro_hypothesis_seed import resolve_next_sprint
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+            await s.execute(text(f"DELETE FROM sprints WHERE project_id='{PROJ_A}'"))
+            same_ts = datetime(2026, 8, 15, tzinfo=timezone.utc)
+            tie_a = uuid.UUID("dc000000-0000-0000-0000-0000000000aa")
+            tie_b = uuid.UUID("dc000000-0000-0000-0000-0000000000bb")
+            for sid in (tie_b, tie_a):  # 삽입 순서를 id 순서와 반대로 — 삽입순 우연 일치 배제
+                await s.execute(
+                    text(
+                        "INSERT INTO sprints (id,org_id,project_id,title,status,duration,"
+                        "start_date,created_at) VALUES "
+                        "(:id,:org,:proj,'tie','planning',14,'2026-08-15',:ts)"
+                    ),
+                    {"id": sid, "org": ORG, "proj": PROJ_A, "ts": same_ts},
+                )
+            await s.commit()
+
+        picks = set()
+        for _ in range(3):
+            async with Session() as s:
+                sprint = await resolve_next_sprint(s, ORG, PROJ_A)
+                picks.add(sprint.id)
+        assert picks == {tie_a}  # 항상 더 작은 id(tie_a < tie_b)만 선택 — 결정적
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
 async def test_adopt_creates_proposed_hypothesis_seeds_earliest_planning_sprint():
     """§2 PO 결 — planning 중 가장 이른 start_date(0801)가 선택돼야 함(0901 아님)."""
     from app.routers.retros import adopt_next_hypothesis

--- a/backend/tests/test_retro_synthesis_service.py
+++ b/backend/tests/test_retro_synthesis_service.py
@@ -199,6 +199,26 @@ async def test_recommend_next_parses_candidates():
     datetime.fromisoformat(c["measure_after"])  # ISO datetime
 
 
+async def test_recommend_next_mixed_learned_drops_garbage_items_from_prompt():
+    """까심 QA MINOR(2026-07-03) — `_has_valid_synthesis`는 "≥1개 유효 아이템"만 요구해
+    혼합 learned가 게이트를 통과할 수 있다. garbage 아이템(text 없음)이 프롬프트에 빈
+    bullet("- ")로 새면 안 됨 — LLM 호출 프롬프트에 실제로 뭐가 전달됐는지 직접 검증."""
+    synthesis = {
+        "learned": [
+            {"text": "진짜 배운 것", "source": "s"},
+            {"foo": "bar"},  # text 키 자체가 없음
+            {"text": "   "},  # text가 공백뿐
+        ],
+        "generated_at": "x", "source": "ai_draft",
+    }
+    raw = '[{"statement": "다음 검증", "rationale": "r", "confidence": 0.5}]'
+    with patch("app.services.llm_client.generate_text_claude", return_value=raw) as mock_gen:
+        await svc.recommend_next(synthesis)
+    prompt_sent = mock_gen.call_args.args[0]
+    assert "진짜 배운 것" in prompt_sent
+    assert "- \n" not in prompt_sent and not prompt_sent.rstrip().endswith("- ")
+
+
 async def test_recommend_next_caps_at_max_and_drops_malformed():
     synthesis = {"learned": [{"text": "x", "source": "s"}], "generated_at": "x", "source": "ai_draft"}
     raw = (


### PR DESCRIPTION
## Summary
까심 QA MINOR 2건(#1863/#1864, non-blocking) — 오르테가군 제안대로 한 커밋으로 묶어서 처리.

1. **(#1863 MINOR)** `_build_next_hypotheses_prompt`가 혼합 `learned`(일부만 유효)에서 dict이기만 하면 그대로 프롬프트에 넣어 text 없는 항목이 빈 bullet(`"- "`)로 LLM에 새어갔다. 게이트(`_has_valid_synthesis`)와 동일한 shape 검증(non-blank text)으로 garbage 아이템 드롭.
2. **(#1864 MINOR)** `resolve_next_sprint`의 tie-break(start_date·created_at)가 완전히 동일한 sprint가 여럿이면 여전히 비결정적이었다. `Sprint.id.asc()`를 최종 tie-break로 추가.

## Test plan
- [x] 단위 테스트: 혼합 learned 프롬프트에 garbage bullet 미포함 직접 검증(실제 LLM 호출 프롬프트 문자열 assertion)
- [x] **실 Postgres**: 동일 start_date+동일 explicit created_at인 sprint 2개 심고 `resolve_next_sprint`가 3회 반복 모두 같은(더 작은 id) sprint를 선택함을 확인
- [x] `pytest tests/ -k "retro or hypothesis or sprint"` — 275 passed, 0 회귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)