### PR TITLE
fix(e-sprint-loop): synthesize 502 근본 — Sonnet5 프리앰블/트레일링 텍스트 파서 견고화

### DIFF
--- a/backend/app/services/llm_client.py
+++ b/backend/app/services/llm_client.py
@@ -141,6 +141,7 @@ _CLAUDE_REASONING_LEVELS = frozenset({"disabled", "low", "medium", "high", "xhig
 
 def generate_text_claude(
     prompt: str, *, max_output_tokens: int = DEFAULT_MAX_OUTPUT_TOKENS, reasoning: str = "disabled",
+    response_schema: dict | None = None,
 ) -> str | None:
     """Claude(claude-sonnet-5) 생성 — S28 모델/reasoning 레벨 실험용 별도 경로.
 
@@ -149,9 +150,22 @@ def generate_text_claude(
     thinking.type="enabled"+budget_tokens를 지원 안 함(invalid_request_error 확인) —
     thinking.type="adaptive"+output_config.effort로만 강도 제어 가능.
 
-    graceful 계약은 generate_text()와 동일: 인증 불가/빈 입력/API 오류/빈 응답 시 None(예외
-    전파 없음 — 호출부는 이를 "아직 못 만듦"으로 처리하고 graceful degrade해야 한다).
-    """
+    response_schema(E-SPRINT-LOOP dc861e44 2026-07-03, 선생님/PO 지적): JSON Schema를 주면
+    `output_config.format`으로 structured output을 강제한다(AnthropicVertex·claude-sonnet-5·
+    rawPredict가 GA로 지원 — 모델 교체 불요, 실측 SDK 0.115.1
+    `messages.create(output_config=...)` 확인). 프리앰블/트레일링 프로즈 문제(retro
+    synthesize 502 dev repro)의 근본 해법 — 프롬프트로 "JSON만 내라" 애원하는 밴드에이드
+    대신 스키마로 유효 JSON을 구조적으로 보장한다. top-level은 object 권장(배열 직접
+    top-level은 지양 — 호출부가 스키마의 wrapping key로 꺼낸다). effort(reasoning)와
+    format은 `output_config` 안에서 병합(SDK `.stream()` 구현의 병합 패턴과 동일 원칙).
+
+    stop_reason 명시 체크(max_tokens/refusal) — 스키마가 유효성을 보장해도 truncate/거부는
+    막지 못하므로, 텍스트가 비어있지 않아도 이 두 stop_reason이면 즉시 실패(None) 처리한다
+    (부분 JSON을 "성공"으로 오인하지 않기 위함).
+
+    graceful 계약은 generate_text()와 동일: 인증 불가/빈 입력/API 오류/빈 응답/truncate/거부
+    시 None(예외 전파 없음 — 호출부는 이를 "아직 못 만듦"으로 처리하고 graceful degrade해야
+    한다)."""
     if not prompt or not prompt.strip():
         return None
     if reasoning not in _CLAUDE_REASONING_LEVELS:
@@ -176,19 +190,32 @@ def generate_text_claude(
             kwargs["thinking"] = {"type": "disabled"}
         else:
             kwargs["thinking"] = {"type": "adaptive"}
-            kwargs["output_config"] = {"effort": reasoning}
+
+        output_config: dict = {}
+        if reasoning != "disabled":
+            output_config["effort"] = reasoning
+        if response_schema is not None:
+            output_config["format"] = {"type": "json_schema", "schema": response_schema}
+        if output_config:
+            kwargs["output_config"] = output_config
 
         response = client.messages.create(**kwargs)
         latency_ms = round((time.monotonic() - start) * 1000, 2)
         _log_claude_generation_instrumentation(latency_ms, response, reasoning)
+
+        stop_reason = getattr(response, "stop_reason", None)
+        if stop_reason in ("max_tokens", "refusal"):
+            logger.warning(
+                "llm_client(claude): stop_reason=%s(truncate/거부) → None 처리", stop_reason
+            )
+            return None
 
         text = "".join(
             block.text for block in response.content if getattr(block, "type", None) == "text"
         ).strip()
         if not text:
             logger.warning(
-                "llm_client(claude): 빈 응답 → None 처리 (stop_reason=%s)",
-                getattr(response, "stop_reason", None),
+                "llm_client(claude): 빈 응답 → None 처리 (stop_reason=%s)", stop_reason
             )
             return None
         return text

--- a/backend/app/services/retro_synthesis.py
+++ b/backend/app/services/retro_synthesis.py
@@ -199,10 +199,15 @@ async def synthesize(session: AsyncSession, retro: RetroSession) -> dict[str, An
     items = parsed.get("items") if parsed is not None else None
     learned: list[dict[str, str]] = []
     if isinstance(items, list):
+        # 까심 codex RC(2026-07-03) — text는 걸렀는데 source(근거)는 안 걸러 근거 없는
+        # 학습이 새어들 수 있었다. response_schema가 source를 required로 강제하니 빠진
+        # 응답 = 스키마 위반 → #1863 원칙대로 그 item을 드롭(text와 대칭 검증).
         learned = [
-            {"text": str(x["text"]), "source": str(x.get("source", ""))}
+            {"text": x["text"].strip(), "source": x["source"].strip()}
             for x in items
-            if isinstance(x, dict) and isinstance(x.get("text"), str) and x["text"].strip()
+            if isinstance(x, dict)
+            and isinstance(x.get("text"), str) and x["text"].strip()
+            and isinstance(x.get("source"), str) and x["source"].strip()
         ]
     if not learned:
         # response_schema가 유효 object를 보장해도(2026-07-03 구조화 전환) items가 빈
@@ -274,14 +279,24 @@ async def recommend_next(synthesis: dict[str, Any]) -> list[dict[str, Any]] | No
     for x in items[:_MAX_NEXT_HYPOTHESES]:
         if not isinstance(x, dict) or not isinstance(x.get("statement"), str) or not x["statement"].strip():
             continue
-        confidence = x.get("confidence")
+        # 까심 codex RC(2026-07-03) — response_schema가 rationale/confidence를 required로
+        # 강제하지만 JSON Schema "number"는 범위(min/max)를 강제 못 한다(PO 실측: Vertex
+        # structured output 제약). statement처럼 rationale도 non-blank 필수·confidence는
+        # [0.0,1.0] clamp(범위 밖/비숫자는 스키마 위반과 동급 → item 드롭, #1863 원칙).
+        rationale = x.get("rationale")
+        if not isinstance(rationale, str) or not rationale.strip():
+            continue
+        confidence_raw = x.get("confidence")
+        if not isinstance(confidence_raw, (int, float)) or isinstance(confidence_raw, bool):
+            continue
+        confidence = max(0.0, min(1.0, float(confidence_raw)))
         candidates.append({
             "id": str(uuid.uuid4()),
             "statement": x["statement"].strip(),
             "metric_definition": {"metric": "outcome", "source": "manual", "target": 1, "direction": "up"},
             "measure_after": measure_after.isoformat(),
-            "confidence": float(confidence) if isinstance(confidence, (int, float)) else None,
-            "rationale": str(x.get("rationale", "")),
+            "confidence": confidence,
+            "rationale": rationale.strip(),
             "requires_confirmation": True,
         })
     if not candidates:

--- a/backend/app/services/retro_synthesis.py
+++ b/backend/app/services/retro_synthesis.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -276,18 +277,28 @@ async def recommend_next(synthesis: dict[str, Any]) -> list[dict[str, Any]] | No
 
     measure_after = datetime.now(timezone.utc) + timedelta(days=_DEFAULT_MEASURE_DAYS)
     candidates: list[dict[str, Any]] = []
-    for x in items[:_MAX_NEXT_HYPOTHESES]:
+    # 까심 codex RC round2(2026-07-03) — 전체 items를 순회하며 "유효한" 후보 수가
+    # _MAX_NEXT_HYPOTHESES에 도달하면 멈춘다(raw 순서로 슬라이스 후 필터하면 앞쪽 malformed
+    # item이 뒤쪽 valid item을 밀어내는 over-drop이 났다 — filter-then-cap이 정답).
+    for x in items:
+        if len(candidates) >= _MAX_NEXT_HYPOTHESES:
+            break
         if not isinstance(x, dict) or not isinstance(x.get("statement"), str) or not x["statement"].strip():
             continue
-        # 까심 codex RC(2026-07-03) — response_schema가 rationale/confidence를 required로
-        # 강제하지만 JSON Schema "number"는 범위(min/max)를 강제 못 한다(PO 실측: Vertex
-        # structured output 제약). statement처럼 rationale도 non-blank 필수·confidence는
-        # [0.0,1.0] clamp(범위 밖/비숫자는 스키마 위반과 동급 → item 드롭, #1863 원칙).
+        # response_schema가 rationale/confidence를 required로 강제하지만 JSON Schema
+        # "number"는 범위(min/max)도, NaN/Infinity 배제도 못 한다(PO 실측: Vertex
+        # structured output 제약 — json.loads는 표준 확장으로 NaN/Infinity를 파싱한다).
+        # statement처럼 rationale은 non-blank 필수·confidence는 유한수만 [0.0,1.0] clamp
+        # (범위 밖/비숫자/비유한은 스키마 위반과 동급 → item 드롭, #1863 원칙).
         rationale = x.get("rationale")
         if not isinstance(rationale, str) or not rationale.strip():
             continue
         confidence_raw = x.get("confidence")
-        if not isinstance(confidence_raw, (int, float)) or isinstance(confidence_raw, bool):
+        if (
+            not isinstance(confidence_raw, (int, float))
+            or isinstance(confidence_raw, bool)
+            or not math.isfinite(confidence_raw)
+        ):
             continue
         confidence = max(0.0, min(1.0, float(confidence_raw)))
         candidates.append({

--- a/backend/app/services/retro_synthesis.py
+++ b/backend/app/services/retro_synthesis.py
@@ -2,10 +2,14 @@
 
 design-first crux 반영(2026-07-03): synthesis/next_hypotheses는 on-demand·overwrite
 저장(retro_sessions nullable JSONB — repository.update()가 그대로 처리, 이 모듈은
-호출부가 저장할 dict/list를 만들어주기만 한다). LLM은 `llm_client.generate_text_claude`
-(graceful: 인증불가/오류 시 None) + JSON 출력 지시 + 파싱 실패 시 graceful fallback —
-S15(`hypothesis._draft_statement`)의 "LLM 실패해도 완전 실패 없음" 철학을 미러한다.
-"""
+호출부가 저장할 dict/list를 만들어주기만 한다).
+
+structured output(2026-07-03, 선생님/PO 지적·dev repro `84d63d5c` 실측): LLM 출력 형식은
+프롬프트로 "JSON만 내라" 애원하는 밴드에이드가 아니라 `generate_text_claude`의
+`response_schema`(Anthropic Vertex structured output GA)로 구조적으로 강제한다 —
+Sonnet5가 프리앰블/트레일링 프로즈를 붙이는 문제 자체가 스키마 레벨에서 소멸한다.
+graceful 계약(data-loss 방지, #1863 RC)은 불변: 스키마가 유효 JSON을 보장해도
+refusal/max_tokens/SDK 오류는 여전히 None(호출부 미저장·502)."""
 from __future__ import annotations
 
 import json
@@ -30,12 +34,13 @@ _SOUL_LOCK_INSTRUCTION = (
     '"실패했다"·"안 됐다" 같은 표현은 금지한다.'
 )
 
+# 출력 형식 지시("JSON만 내라")는 response_schema가 구조적으로 강제하므로 프롬프트에서
+# 제거 — 프롬프트는 콘텐츠 규칙만 담당(관심사 분리, 밴드에이드 잔재 제거).
 _SYNTHESIS_INSTRUCTION = (
     "다음은 한 스프린트의 가설 검증 결과와 팀 회고 상위 의견이다. 이 정보만 근거로 "
-    '"이번 스프린트에서 배운 것"을 2~4개의 불릿으로 한국어로 종합하라. 각 불릿은 반드시 '
+    '"이번 스프린트에서 배운 것"을 2~4개 항목으로 한국어로 종합하라. 각 항목은 반드시 '
     "근거(가설 statement 또는 회고 아이템 내용)를 함께 명시하라. " + _SOUL_LOCK_INSTRUCTION +
-    " 맥락에 없는 사실/숫자를 지어내지 마라. 출력은 반드시 아래 JSON 배열 형식만 — "
-    '다른 텍스트 절대 추가하지 마라:\n[{"text": "...", "source": "..."}]'
+    " 맥락에 없는 사실/숫자를 지어내지 마라."
 )
 
 _NEXT_HYPOTHESES_INSTRUCTION = (
@@ -43,41 +48,58 @@ _NEXT_HYPOTHESES_INSTRUCTION = (
     f"검증할 만한 가설 후보를 최대 {_MAX_NEXT_HYPOTHESES}개, 각각 " '"~할 것이다" 형태의 '
     "제안형 한국어 문장으로 작성하라. 각 후보에는 반드시 근거(종합의 어느 부분에서 나왔는지)를 "
     "rationale로 함께 제시하고, confidence(0.0~1.0, 확신도를 정직하게)를 매겨라. " +
-    _SOUL_LOCK_INSTRUCTION + " 맥락에 없는 사실을 지어내지 마라. 출력은 반드시 아래 JSON "
-    '배열 형식만 — 다른 텍스트 절대 추가하지 마라:\n'
-    '[{"statement": "...", "rationale": "...", "confidence": 0.0}]'
+    _SOUL_LOCK_INSTRUCTION + " 맥락에 없는 사실을 지어내지 마라."
 )
 
+# top-level은 object 권장(배열 직접 top-level 지양, PO 지시) — items 키로 배열을 감싼다.
+_SYNTHESIS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "items": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {"text": {"type": "string"}, "source": {"type": "string"}},
+                "required": ["text", "source"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["items"],
+    "additionalProperties": False,
+}
 
-def _extract_json(raw: str) -> Any | None:
-    """LLM 출력 파싱 — 실측(2026-07-03, dev repro `84d63d5c`): "다른 텍스트 절대 추가하지
-    마라" 지시에도 Sonnet5(reasoning=disabled)가 프리앰블/트레일링 텍스트를 배열 앞뒤에
-    붙이는 사례를 실 Cloud Run 로그(httpx 200 OK 확인 후 파싱 단계 거부)로 확인 — 순수
-    JSON만 받아들이던 구 구현(1차 strip만)이 이 흔한 케이스를 못 잡았다.
+_NEXT_HYPOTHESES_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "items": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "statement": {"type": "string"},
+                    "rationale": {"type": "string"},
+                    "confidence": {"type": "number"},
+                },
+                "required": ["statement", "rationale", "confidence"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    "required": ["items"],
+    "additionalProperties": False,
+}
 
-    3단계로 견고화: ① 마크다운 코드펜스 벗기기(기존) ② 그대로 파싱 시도 ③ 실패하면 첫
-    '['~마지막 ']' 구간만 잘라 재시도(프리앰블/트레일링 프로즈 무시). ①②만으로 안 될 때만
-    ③을 타므로 엄격한 파싱이 여전히 우선이고, 정말 JSON 배열이 아예 없으면(대괄호 자체가
-    없거나 부분추출도 파싱 실패) 여전히 None(명시 실패 — data-loss 방지 원칙 불변)."""
-    text = raw.strip()
-    if text.startswith("```"):
-        text = text.strip("`")
-        if text[:4].lower() == "json":
-            text = text[4:]
-        text = text.strip()
+
+def _parse_json_object(raw: str) -> dict[str, Any] | None:
+    """response_schema가 유효 JSON object를 구조적으로 보장하므로 코드펜스 벗기기·bracket
+    매칭 같은 방어적 파싱은 더 이상 불요(2026-07-03 PO 지시 — 밴드에이드 제거). 그래도
+    SDK/스키마 컴파일 엣지케이스에 대비해 json.loads 실패는 흡수(None, 호출부가 실패 처리)."""
     try:
-        return json.loads(text)
-    except (json.JSONDecodeError, ValueError):
-        pass
-
-    start = text.find("[")
-    end = text.rfind("]")
-    if start == -1 or end == -1 or end <= start:
-        return None
-    try:
-        return json.loads(text[start:end + 1])
+        parsed = json.loads(raw.strip())
     except (json.JSONDecodeError, ValueError):
         return None
+    return parsed if isinstance(parsed, dict) else None
 
 
 async def build_hypotheses_items(
@@ -165,29 +187,30 @@ async def synthesize(session: AsyncSession, retro: RetroSession) -> dict[str, An
 
     raw = None
     try:
-        raw = generate_text_claude(prompt, reasoning="disabled")
+        raw = generate_text_claude(prompt, reasoning="disabled", response_schema=_SYNTHESIS_SCHEMA)
     except Exception as exc:  # noqa: BLE001 — 예외도 "실패"로 수렴(None), 여기서 삼키지 않음.
         logger.warning("retro synthesize: LLM 호출 실패: %s", exc)
 
     if not raw:
-        return None  # 근거는 있었는데 LLM이 실패 — 기존 캐시 보존(호출부 502·미저장).
+        return None  # 근거는 있었는데 LLM이 실패(또는 stop_reason=max_tokens/refusal —
+        # generate_text_claude가 이미 걸러 None으로 수렴) — 기존 캐시 보존(호출부 502·미저장).
 
-    parsed = _extract_json(raw)
+    parsed = _parse_json_object(raw)
+    items = parsed.get("items") if parsed is not None else None
     learned: list[dict[str, str]] = []
-    if isinstance(parsed, list):
+    if isinstance(items, list):
         learned = [
             {"text": str(x["text"]), "source": str(x.get("source", ""))}
-            for x in parsed
+            for x in items
             if isinstance(x, dict) and isinstance(x.get("text"), str) and x["text"].strip()
         ]
     if not learned:
-        # JSON 파싱 실패/스키마 불일치/전부 malformed — raw-wrap 구제 없이 명시 실패(None).
-        # raw는 실 LLM 응답이었지만, 형식을 안 지킨 응답을 캐시에 넣는 것 자체가 이전 good
-        # synthesis를 저품질 1-bullet로 강등시키는 data-loss(까심 codex RC②). raw 원문을
-        # 로그에 남겨(dev repro 2026-07-03 교훈 — 실패 원인을 추측 아닌 실측으로 파악하려면
-        # 최소한 흔적이 있어야 한다) 다음 파서 반례를 재현 없이 바로 확인할 수 있게 한다.
+        # response_schema가 유효 object를 보장해도(2026-07-03 구조화 전환) items가 빈
+        # 배열이거나 항목이 스키마 위반이면(방어적 케이스) 여전히 명시 실패(None) — raw-wrap
+        # 구제 없이(까심 codex RC②) 기존 good synthesis를 저품질로 덮어쓰지 않는다. raw 원문을
+        # 로그에 남겨(2026-07-03 dev repro 교훈) 다음 반례를 재현 없이 바로 확인 가능하게 한다.
         logger.warning(
-            "retro synthesize: JSON 파싱 실패(raw 원문 앞 500자) — %s", raw.strip()[:500]
+            "retro synthesize: 유효 items 없음(raw 원문 앞 500자) — %s", raw.strip()[:500]
         )
         return None
 
@@ -227,25 +250,28 @@ async def recommend_next(synthesis: dict[str, Any]) -> list[dict[str, Any]] | No
 
     raw = None
     try:
-        raw = generate_text_claude(prompt, reasoning="disabled")
+        raw = generate_text_claude(
+            prompt, reasoning="disabled", response_schema=_NEXT_HYPOTHESES_SCHEMA
+        )
     except Exception as exc:  # noqa: BLE001
         logger.warning("retro recommend_next: LLM 호출 실패: %s", exc)
     if not raw:
-        return None  # LLM 실패 — 기존 캐시 보존.
+        return None  # LLM 실패(또는 max_tokens/refusal) — 기존 캐시 보존.
 
-    parsed = _extract_json(raw)
-    if not isinstance(parsed, list):
-        # 파싱 자체가 완전 실패(리스트가 아님) — synthesis처럼 원문 래핑 구제가 불가(스키마상
-        # statement 필수 필드라 텍스트 1줄로 대체 불가) → 명시 실패로 처리. raw 원문을 로그에
-        # 남김(2026-07-03 dev repro 교훈 — synthesize와 동형).
+    parsed = _parse_json_object(raw)
+    items = parsed.get("items") if parsed is not None else None
+    if not isinstance(items, list):
+        # response_schema가 유효 object를 보장해도(2026-07-03 구조화 전환) items 키 자체가
+        # 방어적 케이스로 리스트가 아닐 수 있음 — synthesize처럼 원문 래핑 구제가 불가(스키마상
+        # statement 필수 필드라 텍스트 1줄로 대체 불가) → 명시 실패. raw 원문을 로그에 남김.
         logger.warning(
-            "retro recommend_next: JSON 파싱 실패(raw 원문 앞 500자) — %s", raw.strip()[:500]
+            "retro recommend_next: 유효 items 없음(raw 원문 앞 500자) — %s", raw.strip()[:500]
         )
         return None
 
     measure_after = datetime.now(timezone.utc) + timedelta(days=_DEFAULT_MEASURE_DAYS)
     candidates: list[dict[str, Any]] = []
-    for x in parsed[:_MAX_NEXT_HYPOTHESES]:
+    for x in items[:_MAX_NEXT_HYPOTHESES]:
         if not isinstance(x, dict) or not isinstance(x.get("statement"), str) or not x["statement"].strip():
             continue
         confidence = x.get("confidence")

--- a/backend/app/services/retro_synthesis.py
+++ b/backend/app/services/retro_synthesis.py
@@ -50,7 +50,15 @@ _NEXT_HYPOTHESES_INSTRUCTION = (
 
 
 def _extract_json(raw: str) -> Any | None:
-    """LLM 출력이 ```json 코드펜스로 감싸져 오는 경우가 흔해 벗겨내고 파싱 시도."""
+    """LLM 출력 파싱 — 실측(2026-07-03, dev repro `84d63d5c`): "다른 텍스트 절대 추가하지
+    마라" 지시에도 Sonnet5(reasoning=disabled)가 프리앰블/트레일링 텍스트를 배열 앞뒤에
+    붙이는 사례를 실 Cloud Run 로그(httpx 200 OK 확인 후 파싱 단계 거부)로 확인 — 순수
+    JSON만 받아들이던 구 구현(1차 strip만)이 이 흔한 케이스를 못 잡았다.
+
+    3단계로 견고화: ① 마크다운 코드펜스 벗기기(기존) ② 그대로 파싱 시도 ③ 실패하면 첫
+    '['~마지막 ']' 구간만 잘라 재시도(프리앰블/트레일링 프로즈 무시). ①②만으로 안 될 때만
+    ③을 타므로 엄격한 파싱이 여전히 우선이고, 정말 JSON 배열이 아예 없으면(대괄호 자체가
+    없거나 부분추출도 파싱 실패) 여전히 None(명시 실패 — data-loss 방지 원칙 불변)."""
     text = raw.strip()
     if text.startswith("```"):
         text = text.strip("`")
@@ -59,6 +67,15 @@ def _extract_json(raw: str) -> Any | None:
         text = text.strip()
     try:
         return json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    start = text.find("[")
+    end = text.rfind("]")
+    if start == -1 or end == -1 or end <= start:
+        return None
+    try:
+        return json.loads(text[start:end + 1])
     except (json.JSONDecodeError, ValueError):
         return None
 
@@ -166,7 +183,12 @@ async def synthesize(session: AsyncSession, retro: RetroSession) -> dict[str, An
     if not learned:
         # JSON 파싱 실패/스키마 불일치/전부 malformed — raw-wrap 구제 없이 명시 실패(None).
         # raw는 실 LLM 응답이었지만, 형식을 안 지킨 응답을 캐시에 넣는 것 자체가 이전 good
-        # synthesis를 저품질 1-bullet로 강등시키는 data-loss(까심 codex RC②).
+        # synthesis를 저품질 1-bullet로 강등시키는 data-loss(까심 codex RC②). raw 원문을
+        # 로그에 남겨(dev repro 2026-07-03 교훈 — 실패 원인을 추측 아닌 실측으로 파악하려면
+        # 최소한 흔적이 있어야 한다) 다음 파서 반례를 재현 없이 바로 확인할 수 있게 한다.
+        logger.warning(
+            "retro synthesize: JSON 파싱 실패(raw 원문 앞 500자) — %s", raw.strip()[:500]
+        )
         return None
 
     return {"learned": learned, "generated_at": now.isoformat(), "source": "ai_draft"}
@@ -213,8 +235,13 @@ async def recommend_next(synthesis: dict[str, Any]) -> list[dict[str, Any]] | No
 
     parsed = _extract_json(raw)
     if not isinstance(parsed, list):
-        return None  # 파싱 자체가 완전 실패(리스트가 아님) — synthesis처럼 원문 래핑 구제가
-        # 불가(스키마상 statement 필수 필드라 텍스트 1줄로 대체 불가) → 명시 실패로 처리.
+        # 파싱 자체가 완전 실패(리스트가 아님) — synthesis처럼 원문 래핑 구제가 불가(스키마상
+        # statement 필수 필드라 텍스트 1줄로 대체 불가) → 명시 실패로 처리. raw 원문을 로그에
+        # 남김(2026-07-03 dev repro 교훈 — synthesize와 동형).
+        logger.warning(
+            "retro recommend_next: JSON 파싱 실패(raw 원문 앞 500자) — %s", raw.strip()[:500]
+        )
+        return None
 
     measure_after = datetime.now(timezone.utc) + timedelta(days=_DEFAULT_MEASURE_DAYS)
     candidates: list[dict[str, Any]] = []

--- a/backend/tests/test_e_loop_ledger_s28_llm_client_claude.py
+++ b/backend/tests/test_e_loop_ledger_s28_llm_client_claude.py
@@ -90,6 +90,80 @@ def test_invalid_reasoning_value_falls_back_to_disabled():
     assert call_kwargs["thinking"] == {"type": "disabled"}
 
 
+# ── ⭐response_schema — structured output(2026-07-03, 선생님/PO 지적: 근본 해법) ──
+
+def test_response_schema_sends_output_config_format_json_schema():
+    """실측(SDK 0.115.1 messages.create) — output_config.format={"type":"json_schema",
+    "schema":...}가 정확한 전송 형태. reasoning=disabled(effort 없음)에서도 format만으로
+    output_config가 실려야 한다(이전엔 disabled면 output_config 자체를 안 보냈음)."""
+    schema = {"type": "object", "properties": {"items": {"type": "array"}}, "required": ["items"]}
+    fake = _fake_response(text='{"items": []}')
+    with patch("app.services.llm_client._has_adc", return_value=True), \
+         patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with patch("anthropic.AnthropicVertex") as mock_client_cls:
+            mock_client_cls.return_value.messages.create.return_value = fake
+            generate_text_claude("x", reasoning="disabled", response_schema=schema)
+    call_kwargs = mock_client_cls.return_value.messages.create.call_args.kwargs
+    assert call_kwargs["output_config"] == {"format": {"type": "json_schema", "schema": schema}}
+    assert call_kwargs["thinking"] == {"type": "disabled"}
+
+
+def test_response_schema_merges_with_effort():
+    """reasoning != disabled + response_schema 동시 지정 시 effort와 format이 같은
+    output_config dict 안에서 병합돼야 함(SDK .stream() 병합 패턴과 동일 원칙)."""
+    schema = {"type": "object", "properties": {"items": {"type": "array"}}, "required": ["items"]}
+    fake = _fake_response(text='{"items": []}')
+    with patch("app.services.llm_client._has_adc", return_value=True), \
+         patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with patch("anthropic.AnthropicVertex") as mock_client_cls:
+            mock_client_cls.return_value.messages.create.return_value = fake
+            generate_text_claude("x", reasoning="low", response_schema=schema)
+    call_kwargs = mock_client_cls.return_value.messages.create.call_args.kwargs
+    assert call_kwargs["output_config"] == {
+        "effort": "low", "format": {"type": "json_schema", "schema": schema},
+    }
+
+
+# ── ⭐stop_reason 명시 방어(max_tokens/refusal) ─────────────────────────────────
+
+def test_stop_reason_max_tokens_returns_none_even_with_partial_text():
+    """텍스트가 비어있지 않아도(truncated JSON일 수 있음) stop_reason=max_tokens면 명시
+    실패(None) — 부분 JSON을 성공으로 오인하지 않기 위함."""
+    fake = _fake_response(text='{"items": [{"text": "부분', stop_reason="max_tokens")
+    with patch("app.services.llm_client._has_adc", return_value=True), \
+         patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with patch("anthropic.AnthropicVertex") as mock_client_cls:
+            mock_client_cls.return_value.messages.create.return_value = fake
+            result = generate_text_claude("x")
+    assert result is None
+
+
+def test_stop_reason_refusal_returns_none():
+    fake = _fake_response(text="I cannot help with that.", stop_reason="refusal")
+    with patch("app.services.llm_client._has_adc", return_value=True), \
+         patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with patch("anthropic.AnthropicVertex") as mock_client_cls:
+            mock_client_cls.return_value.messages.create.return_value = fake
+            result = generate_text_claude("x")
+    assert result is None
+
+
+def test_stop_reason_end_turn_still_succeeds():
+    """회귀 방지 — 정상 종료(end_turn)는 여전히 텍스트를 반환해야 함."""
+    fake = _fake_response(text='{"items": []}', stop_reason="end_turn")
+    with patch("app.services.llm_client._has_adc", return_value=True), \
+         patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+        with patch("anthropic.AnthropicVertex") as mock_client_cls:
+            mock_client_cls.return_value.messages.create.return_value = fake
+            result = generate_text_claude("x")
+    assert result == '{"items": []}'
+
+
 # ── 성공 경로 ────────────────────────────────────────────────────────────────
 
 def test_successful_generation_returns_text_and_uses_global_region():

--- a/backend/tests/test_e_sprint_loop_dc861e44_retro_synthesis_realdb.py
+++ b/backend/tests/test_e_sprint_loop_dc861e44_retro_synthesis_realdb.py
@@ -144,7 +144,7 @@ async def test_synthesize_then_recommend_next_full_flow():
 
         # get_db 의존성은 요청 끝에서 커밋한다(프로덕션 경로) — 라우터 함수를 직접 호출하는
         # 이 테스트는 그 래핑을 우회하므로 명시 commit 필요(repo.update()는 flush만 함).
-        synth_raw = '[{"text": "가설이 반증됐다(온보딩 42% vs 목표 50%) — 학습 데이터", "source": "가설 1"}]'
+        synth_raw = '{"items": [{"text": "가설이 반증됐다(온보딩 42% vs 목표 50%) — 학습 데이터", "source": "가설 1"}]}'
         async with Session() as s:
             with patch("app.services.llm_client.generate_text_claude", return_value=synth_raw):
                 resp = await synthesize_session(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
@@ -153,7 +153,7 @@ async def test_synthesize_then_recommend_next_full_flow():
         assert len(resp.synthesis.learned) == 1
         assert "학습" in resp.synthesis.learned[0].text or resp.synthesis.learned[0].text
 
-        next_raw = '[{"statement": "온보딩 UX를 단순화하면 이탈이 줄 것이다.", "rationale": "가설 1 반증", "confidence": 0.55}]'
+        next_raw = '{"items": [{"statement": "온보딩 UX를 단순화하면 이탈이 줄 것이다.", "rationale": "가설 1 반증", "confidence": 0.55}]}'
         async with Session() as s:
             with patch("app.services.llm_client.generate_text_claude", return_value=next_raw):
                 resp2 = await recommend_next_session(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
@@ -218,7 +218,7 @@ async def test_llm_failure_does_not_destroy_existing_good_synthesis():
         async with Session() as s:
             await _seed(s)
 
-        good_raw = '[{"text": "가설이 반증됐다 — 학습 데이터", "source": "가설 1"}]'
+        good_raw = '{"items": [{"text": "가설이 반증됐다 — 학습 데이터", "source": "가설 1"}]}'
         async with Session() as s:
             with patch("app.services.llm_client.generate_text_claude", return_value=good_raw):
                 await synthesize_session(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
@@ -255,7 +255,7 @@ async def test_malformed_llm_response_does_not_destroy_existing_good_synthesis()
         async with Session() as s:
             await _seed(s)
 
-        good_raw = '[{"text": "가설이 반증됐다 — 학습 데이터", "source": "가설 1"}]'
+        good_raw = '{"items": [{"text": "가설이 반증됐다 — 학습 데이터", "source": "가설 1"}]}'
         async with Session() as s:
             with patch("app.services.llm_client.generate_text_claude", return_value=good_raw):
                 await synthesize_session(SESSION_A, db=s, auth=_auth(), repo=_repo(s))

--- a/backend/tests/test_retro_synthesis_service.py
+++ b/backend/tests/test_retro_synthesis_service.py
@@ -145,6 +145,22 @@ async def test_synthesize_valid_object_wrong_item_shape_returns_none():
     assert result is None
 
 
+async def test_synthesize_missing_source_drops_item():
+    """까심 codex RC③(2026-07-03) — text는 걸렀는데 source(근거)는 안 걸러 근거 없는 학습이
+    새어들 수 있었다. text/source 대칭 검증 — source 없는 항목은 드롭, 전부 드롭이면 None."""
+    session = _empty_execute_session()
+    retro = _retro(sprint_id=SPRINT_ID)
+    hyp = SimpleNamespace(
+        id=uuid.uuid4(), statement="stmt", status="verified",
+        metric_definition={}, outcome_result=None,
+    )
+    raw = '{"items": [{"text": "근거 없는 배운 것"}, {"text": "진짜", "source": "가설 1"}]}'
+    with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
+         patch("app.services.llm_client.generate_text_claude", return_value=raw):
+        result = await svc.synthesize(session, retro)
+    assert result["learned"] == [{"text": "진짜", "source": "가설 1"}]
+
+
 async def test_synthesize_llm_none_returns_none_not_empty_success():
     """data-loss 방지(오르테가 지적 2026-07-03) — LLM이 근거는 받고도 실패하면 '정당한 빈
     결과'가 아니라 명시 실패(None)여야 한다. 호출부가 이 None을 기존 캐시 덮어쓰기 신호로
@@ -221,14 +237,60 @@ async def test_recommend_next_mixed_learned_drops_garbage_items_from_prompt():
 
 
 async def test_recommend_next_caps_at_max_and_drops_malformed():
+    """까심 codex RC(2026-07-03): statement-only 항목은 rationale/confidence 미검증 시절엔
+    "성공"으로 통과해 버그가 살아있어도 그린이던 tautological 테스트였다 — 이제 rationale/
+    confidence까지 채운 valid 4개 + no_statement 1개(드롭)로 캡·드롭을 함께 비-tautology
+    실증한다."""
     synthesis = {"learned": [{"text": "x", "source": "s"}], "generated_at": "x", "source": "ai_draft"}
     raw = (
-        '{"items": [{"statement": "a"}, {"statement": "b"}, {"statement": "c"}, '
-        '{"statement": "d"}, {"no_statement": true}]}'
+        '{"items": ['
+        '{"statement": "a", "rationale": "r-a", "confidence": 0.5}, '
+        '{"statement": "b", "rationale": "r-b", "confidence": 0.5}, '
+        '{"statement": "c", "rationale": "r-c", "confidence": 0.5}, '
+        '{"statement": "d", "rationale": "r-d", "confidence": 0.5}, '
+        '{"no_statement": true}'
+        ']}'
     )
     with patch("app.services.llm_client.generate_text_claude", return_value=raw):
         result = await svc.recommend_next(synthesis)
-    assert len(result) == 3  # _MAX_NEXT_HYPOTHESES=3 캡
+    assert len(result) == 3  # _MAX_NEXT_HYPOTHESES=3 캡(전체 4개 유효 중 슬라이스)
+
+
+async def test_recommend_next_out_of_range_confidence_is_clamped_not_dropped():
+    """까심 codex RC①(2026-07-03) — JSON Schema "number"는 범위(min/max) 강제 불가(PO 실측:
+    Vertex structured output 제약). 9.0/-1.0처럼 범위 밖 숫자는 드롭이 아니라 [0.0,1.0]로
+    clamp(값 자체는 신뢰하되 안전 범위로 보정 — missing/비숫자와는 다른 처리)."""
+    synthesis = {"learned": [{"text": "x", "source": "s"}], "generated_at": "x", "source": "ai_draft"}
+    raw = (
+        '{"items": ['
+        '{"statement": "a", "rationale": "r", "confidence": 9.0}, '
+        '{"statement": "b", "rationale": "r", "confidence": -1.0}'
+        ']}'
+    )
+    with patch("app.services.llm_client.generate_text_claude", return_value=raw):
+        result = await svc.recommend_next(synthesis)
+    assert len(result) == 2
+    assert result[0]["confidence"] == 1.0
+    assert result[1]["confidence"] == 0.0
+
+
+async def test_recommend_next_missing_confidence_or_rationale_drops_item():
+    """까심 codex RC②(2026-07-03) — confidence가 missing/비숫자거나 rationale이 blank면
+    statement가 있어도 item 드롭(text/source와 대칭 검증, #1863 원칙). 캡(_MAX_NEXT_
+    HYPOTHESES=3)이 슬라이스 후 필터라 3개 이내로 구성(4번째는 아예 안 보임 — 별도
+    캡 테스트에서 이미 검증)."""
+    synthesis = {"learned": [{"text": "x", "source": "s"}], "generated_at": "x", "source": "ai_draft"}
+    raw = (
+        '{"items": ['
+        '{"statement": "a", "rationale": "r", "confidence": "not-a-number"}, '
+        '{"statement": "b", "confidence": 0.5}, '
+        '{"statement": "c", "rationale": "r", "confidence": 0.7}'
+        ']}'
+    )
+    with patch("app.services.llm_client.generate_text_claude", return_value=raw):
+        result = await svc.recommend_next(synthesis)
+    assert len(result) == 1
+    assert result[0]["statement"] == "c"
 
 
 async def test_recommend_next_invalid_json_returns_none():

--- a/backend/tests/test_retro_synthesis_service.py
+++ b/backend/tests/test_retro_synthesis_service.py
@@ -275,22 +275,62 @@ async def test_recommend_next_out_of_range_confidence_is_clamped_not_dropped():
 
 
 async def test_recommend_next_missing_confidence_or_rationale_drops_item():
-    """까심 codex RC②(2026-07-03) — confidence가 missing/비숫자거나 rationale이 blank면
-    statement가 있어도 item 드롭(text/source와 대칭 검증, #1863 원칙). 캡(_MAX_NEXT_
-    HYPOTHESES=3)이 슬라이스 후 필터라 3개 이내로 구성(4번째는 아예 안 보임 — 별도
-    캡 테스트에서 이미 검증)."""
+    """까심 codex RC②(round1, 2026-07-03) — confidence가 missing/비숫자거나 rationale이
+    blank면 statement가 있어도 item 드롭(text/source와 대칭 검증, #1863 원칙). filter-then-
+    cap(round2 fix) 덕에 앞쪽 malformed 3개를 지나 4번째 valid item("d")까지 정상 도달함을
+    함께 실증 — round1 당시엔 슬라이스-후-필터 버그로 이 케이스가 아예 안 보였다."""
     synthesis = {"learned": [{"text": "x", "source": "s"}], "generated_at": "x", "source": "ai_draft"}
     raw = (
         '{"items": ['
         '{"statement": "a", "rationale": "r", "confidence": "not-a-number"}, '
         '{"statement": "b", "confidence": 0.5}, '
-        '{"statement": "c", "rationale": "r", "confidence": 0.7}'
+        '{"statement": "c", "rationale": "   ", "confidence": 0.5}, '
+        '{"statement": "d", "rationale": "r", "confidence": 0.7}'
         ']}'
     )
     with patch("app.services.llm_client.generate_text_claude", return_value=raw):
         result = await svc.recommend_next(synthesis)
     assert len(result) == 1
-    assert result[0]["statement"] == "c"
+    assert result[0]["statement"] == "d"
+
+
+async def test_recommend_next_non_finite_confidence_drops_item():
+    """까심 codex RC round2(2026-07-03) — `json.loads`는 표준 확장으로 NaN/Infinity/
+    -Infinity를 파싱한다(Python json 모듈 특성). `isinstance(x,(int,float))` 가드는
+    NaN도 통과시켜 `max(0.0,min(1.0,nan))`이 1.0(최대 확신도)으로 둔갑 — #1863 fail-closed
+    위반이었다. math.isfinite로 NaN/Infinity/-Infinity 전부 드롭."""
+    synthesis = {"learned": [{"text": "x", "source": "s"}], "generated_at": "x", "source": "ai_draft"}
+    raw = (
+        '{"items": ['
+        '{"statement": "nan-item", "rationale": "r", "confidence": NaN}, '
+        '{"statement": "inf-item", "rationale": "r", "confidence": Infinity}, '
+        '{"statement": "neginf-item", "rationale": "r", "confidence": -Infinity}, '
+        '{"statement": "valid-item", "rationale": "r", "confidence": 0.5}'
+        ']}'
+    )
+    with patch("app.services.llm_client.generate_text_claude", return_value=raw):
+        result = await svc.recommend_next(synthesis)
+    assert len(result) == 1
+    assert result[0]["statement"] == "valid-item"
+    assert result[0]["confidence"] == 0.5
+
+
+async def test_recommend_next_filter_then_cap_not_slice_then_filter():
+    """까심 codex RC round2(2026-07-03) — 앞쪽 3개가 전부 malformed고 4~6번째가 valid면,
+    슬라이스-후-필터(구 버그)는 items[:3]만 보고 전부 드롭→None(유효 후보 유실 = over-drop).
+    filter-then-cap은 전체를 순회해 valid 3개(캡)를 정확히 찾아낸다."""
+    synthesis = {"learned": [{"text": "x", "source": "s"}], "generated_at": "x", "source": "ai_draft"}
+    raw = (
+        '{"items": ['
+        '{"statement": "bad1"}, {"statement": "bad2"}, {"statement": "bad3"}, '
+        '{"statement": "good1", "rationale": "r", "confidence": 0.1}, '
+        '{"statement": "good2", "rationale": "r", "confidence": 0.2}, '
+        '{"statement": "good3", "rationale": "r", "confidence": 0.3}'
+        ']}'
+    )
+    with patch("app.services.llm_client.generate_text_claude", return_value=raw):
+        result = await svc.recommend_next(synthesis)
+    assert [c["statement"] for c in result] == ["good1", "good2", "good3"]
 
 
 async def test_recommend_next_invalid_json_returns_none():

--- a/backend/tests/test_retro_synthesis_service.py
+++ b/backend/tests/test_retro_synthesis_service.py
@@ -1,8 +1,13 @@
 """E-SPRINT-LOOP dc861e44: retro_synthesis 서비스 단위 테스트.
 
 핵심 불변식: 근거 전무(가설·투표 아이템 0건)면 LLM 호출 자체를 안 함(S15 동형·지어내기
-금지)·LLM 실패/파싱 실패는 항상 graceful fallback(완전 실패 없음)·synthesis 없으면
-recommend_next이 빈 배열(라우터의 409 게이팅과 별개로 서비스 레벨도 안전)."""
+금지)·LLM 실패/파싱 실패는 항상 명시 실패(None, data-loss 방지·#1863 원칙)·synthesis
+없으면 recommend_next이 빈 배열(라우터의 409 게이팅과 별개로 서비스 레벨도 안전).
+
+structured output(2026-07-03, 선생님/PO 지적) 전환 후: LLM 응답은 response_schema가
+강제하는 object-wrapped 형(`{"items": [...]}`) — 프리앰블/트레일링 프로즈·코드펜스 문제
+자체가 스키마 레벨에서 소멸했으므로 그 방어 테스트(구 bracket-matching 파서용)는 제거,
+대신 "items가 방어적으로 malformed일 때도 여전히 명시 실패"만 남긴다."""
 import uuid
 from datetime import datetime, timezone
 from types import SimpleNamespace
@@ -92,60 +97,23 @@ async def test_synthesize_parses_valid_json():
         metric_definition={"metric": "x", "target": 1, "direction": "up"},
         outcome_result={"actual": 2},
     )
-    raw = '[{"text": "가설이 검증됐다", "source": "가설 1"}]'
+    raw = '{"items": [{"text": "가설이 검증됐다", "source": "가설 1"}]}'
     with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
          patch("app.services.llm_client.generate_text_claude", return_value=raw):
         result = await svc.synthesize(session, retro)
     assert result["learned"] == [{"text": "가설이 검증됐다", "source": "가설 1"}]
-
-
-async def test_synthesize_strips_markdown_fence():
-    session = _empty_execute_session()
-    retro = _retro(sprint_id=SPRINT_ID)
-    hyp = SimpleNamespace(
-        id=uuid.uuid4(), statement="stmt", status="verified",
-        metric_definition={}, outcome_result=None,
-    )
-    raw = '```json\n[{"text": "배운 것", "source": "s"}]\n```'
+    # response_schema가 실려 나갔는지도 확인 — 구조화 강제가 실제로 걸리는지.
+    call_kwargs = None
     with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
-         patch("app.services.llm_client.generate_text_claude", return_value=raw):
-        result = await svc.synthesize(session, retro)
-    assert result["learned"] == [{"text": "배운 것", "source": "s"}]
+         patch("app.services.llm_client.generate_text_claude", return_value=raw) as mock_gen:
+        await svc.synthesize(session, retro)
+        call_kwargs = mock_gen.call_args.kwargs
+    assert call_kwargs["response_schema"] == svc._SYNTHESIS_SCHEMA
 
 
-async def test_synthesize_strips_preamble_prose_before_json_array():
-    """dev repro 실측(2026-07-03, retro 84d63d5c) — Sonnet5가 "다른 텍스트 절대 추가하지
-    마라" 지시에도 프리앰블 프로즈를 배열 앞에 붙이는 사례를 실 Cloud Run 로그로 확인(httpx
-    200 OK 후 파싱 거부→502). 순수 JSON만 받던 구 파서가 이 흔한 케이스를 놓쳤다."""
-    session = _empty_execute_session()
-    retro = _retro(sprint_id=SPRINT_ID)
-    hyp = SimpleNamespace(
-        id=uuid.uuid4(), statement="stmt", status="verified",
-        metric_definition={}, outcome_result=None,
-    )
-    raw = '다음은 요청하신 종합입니다:\n\n[{"text": "배운 것", "source": "s"}]'
-    with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
-         patch("app.services.llm_client.generate_text_claude", return_value=raw):
-        result = await svc.synthesize(session, retro)
-    assert result["learned"] == [{"text": "배운 것", "source": "s"}]
-
-
-async def test_synthesize_strips_trailing_prose_after_json_array():
-    session = _empty_execute_session()
-    retro = _retro(sprint_id=SPRINT_ID)
-    hyp = SimpleNamespace(
-        id=uuid.uuid4(), statement="stmt", status="verified",
-        metric_definition={}, outcome_result=None,
-    )
-    raw = '[{"text": "배운 것", "source": "s"}]\n\n도움이 되셨길 바랍니다.'
-    with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
-         patch("app.services.llm_client.generate_text_claude", return_value=raw):
-        result = await svc.synthesize(session, retro)
-    assert result["learned"] == [{"text": "배운 것", "source": "s"}]
-
-
-async def test_synthesize_no_brackets_at_all_returns_none():
-    """대괄호 자체가 없으면(순수 프로즈 응답) 부분추출도 불가 — 여전히 명시 실패(None)."""
+async def test_synthesize_prose_only_response_returns_none():
+    """response_schema가 유효 JSON을 구조적으로 보장하지만(2026-07-03 전환), SDK/스키마
+    엣지케이스에 대비한 방어 파싱은 유지 — object가 아니면 여전히 명시 실패(None)."""
     session = _empty_execute_session()
     retro = _retro(sprint_id=SPRINT_ID)
     hyp = SimpleNamespace(
@@ -159,32 +127,18 @@ async def test_synthesize_no_brackets_at_all_returns_none():
     assert result is None
 
 
-async def test_synthesize_malformed_json_returns_none_no_raw_wrap():
+async def test_synthesize_valid_object_wrong_item_shape_returns_none():
     """까심 codex RC①(2026-07-03) — 파싱 실패한 raw를 단일 bullet로 "구제"하던 이전 fallback은
     캐시-overwrite 맥락에서 garbage-persist였다(S15 템플릿-fallback 철학이 여기선 오적용).
-    이제 malformed/wrong-shape는 명시 실패(None) — 호출부가 기존 캐시를 지키게 한다."""
+    구조화 전환 후에도 이 원칙은 불변 — items object는 유효해도 아이템이 스키마 불일치
+    (text 부재/blank)면 전부 None(실패), 호출부가 기존 캐시를 지키게 한다."""
     session = _empty_execute_session()
     retro = _retro(sprint_id=SPRINT_ID)
     hyp = SimpleNamespace(
         id=uuid.uuid4(), statement="stmt", status="verified",
         metric_definition={}, outcome_result=None,
     )
-    raw = "이건 JSON이 아니라 그냥 텍스트임"
-    with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
-         patch("app.services.llm_client.generate_text_claude", return_value=raw):
-        result = await svc.synthesize(session, retro)
-    assert result is None
-
-
-async def test_synthesize_valid_json_wrong_item_shape_returns_none():
-    """JSON 배열이지만 항목이 스키마 불일치(text 부재/blank) — 전부 None(실패)."""
-    session = _empty_execute_session()
-    retro = _retro(sprint_id=SPRINT_ID)
-    hyp = SimpleNamespace(
-        id=uuid.uuid4(), statement="stmt", status="verified",
-        metric_definition={}, outcome_result=None,
-    )
-    raw = '[{"no_text": 1}, {"text": "   "}]'
+    raw = '{"items": [{"no_text": 1}, {"text": "   "}]}'
     with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
          patch("app.services.llm_client.generate_text_claude", return_value=raw):
         result = await svc.synthesize(session, retro)
@@ -231,8 +185,8 @@ async def test_recommend_next_empty_synthesis_skips_llm():
 
 async def test_recommend_next_parses_candidates():
     synthesis = {"learned": [{"text": "배운 것", "source": "s"}], "generated_at": "x", "source": "ai_draft"}
-    raw = '[{"statement": "다음엔 온보딩을 개선하면 이탈이 줄 것이다.", "rationale": "가설 2 반증에서", "confidence": 0.6}]'
-    with patch("app.services.llm_client.generate_text_claude", return_value=raw):
+    raw = '{"items": [{"statement": "다음엔 온보딩을 개선하면 이탈이 줄 것이다.", "rationale": "가설 2 반증에서", "confidence": 0.6}]}'
+    with patch("app.services.llm_client.generate_text_claude", return_value=raw) as mock_gen:
         result = await svc.recommend_next(synthesis)
     assert len(result) == 1
     c = result[0]
@@ -243,6 +197,7 @@ async def test_recommend_next_parses_candidates():
     assert c["metric_definition"] == {"metric": "outcome", "source": "manual", "target": 1, "direction": "up"}
     uuid.UUID(c["id"])  # 안정 참조 키 — 파싱 가능한 uuid여야 함
     datetime.fromisoformat(c["measure_after"])  # ISO datetime
+    assert mock_gen.call_args.kwargs["response_schema"] == svc._NEXT_HYPOTHESES_SCHEMA
 
 
 async def test_recommend_next_mixed_learned_drops_garbage_items_from_prompt():
@@ -257,7 +212,7 @@ async def test_recommend_next_mixed_learned_drops_garbage_items_from_prompt():
         ],
         "generated_at": "x", "source": "ai_draft",
     }
-    raw = '[{"statement": "다음 검증", "rationale": "r", "confidence": 0.5}]'
+    raw = '{"items": [{"statement": "다음 검증", "rationale": "r", "confidence": 0.5}]}'
     with patch("app.services.llm_client.generate_text_claude", return_value=raw) as mock_gen:
         await svc.recommend_next(synthesis)
     prompt_sent = mock_gen.call_args.args[0]
@@ -268,8 +223,8 @@ async def test_recommend_next_mixed_learned_drops_garbage_items_from_prompt():
 async def test_recommend_next_caps_at_max_and_drops_malformed():
     synthesis = {"learned": [{"text": "x", "source": "s"}], "generated_at": "x", "source": "ai_draft"}
     raw = (
-        '[{"statement": "a"}, {"statement": "b"}, {"statement": "c"}, '
-        '{"statement": "d"}, {"no_statement": true}]'
+        '{"items": [{"statement": "a"}, {"statement": "b"}, {"statement": "c"}, '
+        '{"statement": "d"}, {"no_statement": true}]}'
     )
     with patch("app.services.llm_client.generate_text_claude", return_value=raw):
         result = await svc.recommend_next(synthesis)
@@ -292,10 +247,10 @@ async def test_recommend_next_llm_none_returns_none():
 
 
 async def test_recommend_next_all_items_malformed_returns_none():
-    """JSON 배열 형식은 맞지만 항목 전부 스키마 불일치(statement 부재) — 빈 배열을 '정답'으로
+    """items object는 유효해도 항목 전부 스키마 불일치(statement 부재) — 빈 배열을 '정답'으로
     저장하면 안 되므로 None(실패)."""
     synthesis = {"learned": [{"text": "x", "source": "s"}], "generated_at": "x", "source": "ai_draft"}
-    raw = '[{"no_statement": true}, {"also_wrong": 1}]'
+    raw = '{"items": [{"no_statement": true}, {"also_wrong": 1}]}'
     with patch("app.services.llm_client.generate_text_claude", return_value=raw):
         result = await svc.recommend_next(synthesis)
     assert result is None

--- a/backend/tests/test_retro_synthesis_service.py
+++ b/backend/tests/test_retro_synthesis_service.py
@@ -113,6 +113,52 @@ async def test_synthesize_strips_markdown_fence():
     assert result["learned"] == [{"text": "배운 것", "source": "s"}]
 
 
+async def test_synthesize_strips_preamble_prose_before_json_array():
+    """dev repro 실측(2026-07-03, retro 84d63d5c) — Sonnet5가 "다른 텍스트 절대 추가하지
+    마라" 지시에도 프리앰블 프로즈를 배열 앞에 붙이는 사례를 실 Cloud Run 로그로 확인(httpx
+    200 OK 후 파싱 거부→502). 순수 JSON만 받던 구 파서가 이 흔한 케이스를 놓쳤다."""
+    session = _empty_execute_session()
+    retro = _retro(sprint_id=SPRINT_ID)
+    hyp = SimpleNamespace(
+        id=uuid.uuid4(), statement="stmt", status="verified",
+        metric_definition={}, outcome_result=None,
+    )
+    raw = '다음은 요청하신 종합입니다:\n\n[{"text": "배운 것", "source": "s"}]'
+    with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
+         patch("app.services.llm_client.generate_text_claude", return_value=raw):
+        result = await svc.synthesize(session, retro)
+    assert result["learned"] == [{"text": "배운 것", "source": "s"}]
+
+
+async def test_synthesize_strips_trailing_prose_after_json_array():
+    session = _empty_execute_session()
+    retro = _retro(sprint_id=SPRINT_ID)
+    hyp = SimpleNamespace(
+        id=uuid.uuid4(), statement="stmt", status="verified",
+        metric_definition={}, outcome_result=None,
+    )
+    raw = '[{"text": "배운 것", "source": "s"}]\n\n도움이 되셨길 바랍니다.'
+    with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
+         patch("app.services.llm_client.generate_text_claude", return_value=raw):
+        result = await svc.synthesize(session, retro)
+    assert result["learned"] == [{"text": "배운 것", "source": "s"}]
+
+
+async def test_synthesize_no_brackets_at_all_returns_none():
+    """대괄호 자체가 없으면(순수 프로즈 응답) 부분추출도 불가 — 여전히 명시 실패(None)."""
+    session = _empty_execute_session()
+    retro = _retro(sprint_id=SPRINT_ID)
+    hyp = SimpleNamespace(
+        id=uuid.uuid4(), statement="stmt", status="verified",
+        metric_definition={}, outcome_result=None,
+    )
+    raw = "죄송하지만 데이터가 부족해 종합을 생성할 수 없습니다."
+    with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
+         patch("app.services.llm_client.generate_text_claude", return_value=raw):
+        result = await svc.synthesize(session, retro)
+    assert result is None
+
+
 async def test_synthesize_malformed_json_returns_none_no_raw_wrap():
     """까심 codex RC①(2026-07-03) — 파싱 실패한 raw를 단일 bullet로 "구제"하던 이전 fallback은
     캐시-overwrite 맥락에서 garbage-persist였다(S15 템플릿-fallback 철학이 여기선 오적용).


### PR DESCRIPTION
## Summary
dev 실측 진단(2026-07-03, 오르테가군 PO 진단·repro `84d63d5c`) → **선생님 근본 지적으로 밴드에이드(bracket 추출)를 structured output으로 업그레이드**.

**1차 진단(밴드에이드, 이후 폐기)**: `_extract_json`이 순수 JSON만 받아들여 Sonnet5의 프리앰블/트레일링 프로즈를 못 잡던 문제 — bracket-matching으로 임시 완화.

**근본 fix (선생님/PO 지시)**: Anthropic Vertex structured output(GA, 모델 교체 불요 — SDK 0.115.1 `messages.create(output_config=...)` 실측 확인)로 유효 JSON을 스키마 레벨에서 구조적으로 강제.

1. `llm_client.generate_text_claude`에 `response_schema` 파라미터 추가 — `output_config={"format":{"type":"json_schema","schema":...}}`(effort와 병합 가능). `stop_reason`(`max_tokens`/`refusal`) 명시 체크 추가 — 부분 JSON을 성공으로 오인하지 않게 즉시 None.
2. `retro_synthesis.py` — 프롬프트의 "JSON만 내라" 애원 제거(스키마가 보장), top-level object로 배열을 감싼 스키마(`_SYNTHESIS_SCHEMA`/`_NEXT_HYPOTHESES_SCHEMA`), bracket-matching 파서를 단순 `json.loads`(`_parse_json_object`)로 교체.
3. **#1863 RC data-loss 방지 원칙은 완전히 불변** — 방어적 파싱 실패 시에도 여전히 None(캐시 보존).

기존 bracket-matching 방어 테스트(프리앰블/트레일링 프로즈 스트립)는 구조화 전환으로 그 실패 클래스 자체가 소멸해 제거, object-wrapped 픽스처로 전체 갱신.

## Test plan
- [x] 단위 테스트(llm_client): `response_schema` 전송 형태·effort 병합·`stop_reason=max_tokens/refusal` 명시 방어·`end_turn` 회귀 방지 — 4건 신규
- [x] 단위 테스트(retro_synthesis): object-wrapped 파싱·response_schema 전달 확인·wrong-item-shape 방어 — 갱신
- [x] `pytest tests/` 전체 — 2901 passed(1차 밴드에이드 대비 +5)·기존 8건 실패는 develop baseline과 동일(무관)
- [x] **실 Postgres**(`test_e_sprint_loop_dc861e44_retro_synthesis_realdb.py` 8건) — object-wrapped mock raw로 전체 흐름·data-loss 방지·malformed 게이팅 재검증
- [ ] **머지 후 dev 재배포되면 repro 재실행**(`POST /api/v2/retros/84d63d5c-112f-475b-a439-9b021a05badc/synthesize`)으로 실제 200+종합 채워짐 확인 필요 — 로컬은 GCP ADC 재인증이 사람 전용이라 Sonnet5 실호출 불가, **PO(오르테가군)가 인프라 경로로 최종 확인**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)