### PR TITLE
feat(e-sprint-loop): a353e88d — sprint-open 定(≥1 가설 강제 + L1 선례 enrichment)

### DIFF
--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -335,7 +335,9 @@ async def transition_sprint_endpoint(
         return SprintResponse.model_validate(sprint)
     except SprintTransitionError as e:
         _codes = {"SPRINT_NOT_FOUND": 404, "HUMAN_CONFIRM_REQUIRED": 403,
-                  "INVALID_STATUS": 422, "INVALID_SPRINT_TRANSITION": 422}
+                  "INVALID_STATUS": 422, "INVALID_SPRINT_TRANSITION": 422,
+                  # a353e88d — precondition-validation(형제 코드와 동급), PO 결 422.
+                  "HYPOTHESIS_REQUIRED_FOR_ACTIVATION": 422}
         raise HTTPException(status_code=_codes.get(e.code, 400), detail={"code": e.code, "message": e.message})
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -105,10 +105,18 @@ async def update_sprint(
             caller = await resolve_member(auth, org_id, session)
             try:
                 await transition_sprint(session, org_id, caller, id, _status_change)
-            except (SprintTransitionError, ValueError) as exc:
-                raise HTTPException(
-                    status_code=400, detail=getattr(exc, "message", str(exc))
-                ) from exc
+            except SprintTransitionError as exc:
+                # 까심 codex QA(2026-07-03, #1867): a353e88d 게이트가 구조화 code로
+                # raise하는데 이 경로가 400+string으로만 매핑해 FE graceful-404 계약
+                # (§5 handoff)이 깨졌다. 신규 code만 422+구조화 detail로 노출 — 기존
+                # 코드(INVALID_STATUS 등)는 status/shape 그대로(회귀 0, PO 결).
+                if exc.code == "HYPOTHESIS_REQUIRED_FOR_ACTIVATION":
+                    raise HTTPException(
+                        status_code=422, detail={"code": exc.code, "message": exc.message}
+                    ) from exc
+                raise HTTPException(status_code=400, detail=exc.message) from exc
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
     # 8a2bbda2: 날짜가 갱신되면 duration 을 (병합된) 날짜에서 재산출 저장(dates 단일진실).
     if "start_date" in data or "end_date" in data:
         existing = await repo.get(id)
@@ -157,8 +165,16 @@ async def activate_sprint(
     try:
         sprint = await transition_sprint(session, org_id, caller, id, "active")
         await session.commit()
-    except (SprintTransitionError, ValueError) as exc:
-        raise HTTPException(status_code=400, detail=getattr(exc, "message", str(exc))) from exc
+    except SprintTransitionError as exc:
+        # 까심 codex QA(2026-07-03, #1867): 위 update_sprint와 동일 갭 — 신규 code만
+        # 422+구조화 detail(FE §5 graceful 계약), 기존 코드는 backward-compat 유지.
+        if exc.code == "HYPOTHESIS_REQUIRED_FOR_ACTIVATION":
+            raise HTTPException(
+                status_code=422, detail={"code": exc.code, "message": exc.message}
+            ) from exc
+        raise HTTPException(status_code=400, detail=exc.message) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return SprintResponse.model_validate(sprint)
 
 

--- a/backend/app/schemas/context_pack.py
+++ b/backend/app/schemas/context_pack.py
@@ -3,13 +3,31 @@ import uuid
 from pydantic import BaseModel
 
 
+class ContextPackOutcome(BaseModel):
+    """P1-S12: hypothesis가 verified/falsified로 해소됐을 때만 populate(S9 OutcomeBadge 매핑)."""
+    hypothesis_status: str
+    metric: str | None = None
+    actual: float | None = None
+    target: float | None = None
+    direction: str | None = None
+
+
 class ContextPackSearchResult(BaseModel):
     """P1-S6: 유사도 검색 결과 1건. entity_type/entity_id는 embeddings의 폴리모픽 참조를 그대로 노출
-    (호출자가 S7 Context Pack 조립 시 해당 엔티티를 직접 로드)."""
+    (호출자가 S7 Context Pack 조립 시 해당 엔티티를 직접 로드).
+
+    a353e88d(PO 결 2026-07-03) — sprint-open L1 선례 UI가 "결과"까지 한 응답으로 보여주도록
+    additive+nullable 확장(서버 배치 enrich, N+1 금지 — §6 절대: 회수 스코프[WHERE 절] 무변경,
+    결과 shape에 필드만 얹음). entity_type=="hypothesis"일 때만 populate; loop 등 다른 엔티티는
+    항상 None. hypothesis_status는 outcome 유무와 무관하게 항상 노출(measuring/proposed 등
+    outcome 없는 상태도 표시), outcome은 실제 verified/falsified로 채점된 경우만(ContextPackOutcome
+    재사용 — P1-S12와 동일 형상)."""
     entity_type: str
     entity_id: uuid.UUID
     embedding_text: str
     similarity: float
+    hypothesis_status: str | None = None
+    outcome: ContextPackOutcome | None = None
 
 
 class ContextPackDecisionSide(BaseModel):
@@ -22,15 +40,6 @@ class ContextPackDecision(BaseModel):
     """P1-S12: entity_type=='loop'일 때만 populate — chosen 1건+top rejected(대표 1건)."""
     chosen: ContextPackDecisionSide | None = None
     rejected: list[ContextPackDecisionSide] = []
-
-
-class ContextPackOutcome(BaseModel):
-    """P1-S12: hypothesis가 verified/falsified로 해소됐을 때만 populate(S9 OutcomeBadge 매핑)."""
-    hypothesis_status: str
-    metric: str | None = None
-    actual: float | None = None
-    target: float | None = None
-    direction: str | None = None
 
 
 class ContextPackItem(BaseModel):

--- a/backend/app/services/context_pack_search.py
+++ b/backend/app/services/context_pack_search.py
@@ -24,9 +24,25 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.embedding import Embedding
 from app.models.hypothesis import Hypothesis
 from app.models.loop import LoopRun
-from app.schemas.context_pack import ContextPackSearchResult
+from app.schemas.context_pack import ContextPackOutcome, ContextPackSearchResult
 
 _EF_SEARCH = 100  # pgvector 기본 40보다 높여 등식필터 결합 시 recall 완화(세션 GUC, SET LOCAL).
+
+
+def _build_hypothesis_outcome(hyp: Hypothesis) -> ContextPackOutcome | None:
+    """a353e88d(PO 결 2026-07-03) — verified/falsified로 채점된 경우만 populate(outcome_scorer.py
+    _build_result의 {metric,target,actual,direction} 형상 그대로 매핑). 아직 안 채점됐으면
+    None(hypothesis_status는 결과와 무관하게 별도 필드로 항상 노출)."""
+    if hyp.outcome_result is None:
+        return None
+    md = hyp.metric_definition or {}
+    return ContextPackOutcome(
+        hypothesis_status=hyp.status,
+        metric=md.get("metric"),
+        actual=hyp.outcome_result.get("actual"),
+        target=md.get("target"),
+        direction=md.get("direction"),
+    )
 
 
 async def search_similar_embeddings(
@@ -54,11 +70,17 @@ async def search_similar_embeddings(
     hyp_ids = {r.Embedding.entity_id for r in rows if r.Embedding.entity_type == "hypothesis"}
     loop_ids = {r.Embedding.entity_id for r in rows if r.Embedding.entity_type == "loop"}
 
+    # a353e88d(PO 결 2026-07-03) — 기존엔 id만 뽑아 살아있음 체크만 했으나, L1 선례 UI가
+    # 결과(status/outcome)까지 한 응답으로 받도록 같은 배치 쿼리에서 전체 row를 싣는다
+    # (신규 왕복 0 — server-side batch enrich, N+1 금지 PO 요구 그대로).
     alive_hyp_ids: set[uuid.UUID] = set()
+    hyp_by_id: dict[uuid.UUID, Hypothesis] = {}
     if hyp_ids:
-        alive_hyp_ids = set((await session.execute(
-            select(Hypothesis.id).where(Hypothesis.id.in_(hyp_ids), Hypothesis.status != "archived")
-        )).scalars().all())
+        hyp_rows = (await session.execute(
+            select(Hypothesis).where(Hypothesis.id.in_(hyp_ids), Hypothesis.status != "archived")
+        )).scalars().all()
+        alive_hyp_ids = {h.id for h in hyp_rows}
+        hyp_by_id = {h.id: h for h in hyp_rows}
 
     alive_loop_ids: set[uuid.UUID] = set()
     if loop_ids:
@@ -74,10 +96,13 @@ async def search_similar_embeddings(
         if emb.entity_type == "loop" and emb.entity_id not in alive_loop_ids:
             continue
         # loop_artifact: 삭제/보관 개념 없음(app/models/loop.py) — 항상 유지.
+        hyp = hyp_by_id.get(emb.entity_id) if emb.entity_type == "hypothesis" else None
         results.append(ContextPackSearchResult(
             entity_type=emb.entity_type,
             entity_id=emb.entity_id,
             embedding_text=emb.embedding_text,
             similarity=1.0 - distance_val,
+            hypothesis_status=hyp.status if hyp is not None else None,
+            outcome=_build_hypothesis_outcome(hyp) if hyp is not None else None,
         ))
     return results

--- a/backend/app/services/sprint.py
+++ b/backend/app/services/sprint.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import uuid
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.repositories.sprint import SprintRepository
@@ -17,6 +18,12 @@ from app.services.member_resolver import ResolvedMember
 
 # overlay-gated 전이(나머지 archive 는 native). matrix valid_transitions 와 일치.
 _OVERLAY_TRANSITIONS = frozenset({("planning", "active"), ("active", "closed"), ("review", "closed")})
+
+# a353e88d PO 결(2026-07-03) — sprint-open 게이트가 인정하는 "선언"은 생존 가설만.
+# killed/archived만 링크된 채로 게이트를 통과하면 "검증 대상 0"인데 활성화가 되는
+# semantic 구멍(사고강제 무력화)이라 제외. verified/falsified는 재검증/재링크 가능성이
+# 있어 포함(HYPOTHESIS_STATUSES - 이 집합 = 인정 대상).
+_DEAD_HYPOTHESIS_STATUSES = frozenset({"killed", "archived"})
 
 
 class SprintTransitionError(Exception):
@@ -46,6 +53,27 @@ async def transition_sprint(
         raise SprintTransitionError(
             "INVALID_SPRINT_TRANSITION", f"불법 전이: {sprint.status} → {to_status}"
         )
+
+    # a353e88d — sprint-open 定: planning→active 게이트 = 생존 가설(HypothesisSprintLink)
+    # ≥1 필수. transition_sprint가 PATCH/activate/transition 3개 라우터 호출부의 단일
+    # SSOT라 여기 한 곳에 걸면 우회 축이 없다(S26 "PATCH 옆문 봉인"과 동일 전략).
+    if sprint.status == "planning" and to_status == "active":
+        from app.models.hypothesis import Hypothesis, HypothesisSprintLink
+
+        has_alive_hypothesis = await session.scalar(
+            select(HypothesisSprintLink.id)
+            .join(Hypothesis, Hypothesis.id == HypothesisSprintLink.hypothesis_id)
+            .where(
+                HypothesisSprintLink.sprint_id == sprint_id,
+                Hypothesis.status.notin_(_DEAD_HYPOTHESIS_STATUSES),
+            )
+            .limit(1)
+        )
+        if has_alive_hypothesis is None:
+            raise SprintTransitionError(
+                "HYPOTHESIS_REQUIRED_FOR_ACTIVATION",
+                "이 스프린트로 검증할 가설을 최소 1개 선언하세요.",
+            )
 
     gated = (sprint.status, to_status) in _OVERLAY_TRANSITIONS
     # ⭐S26: 시작/마감 line overlay(advisory). enforcing 라인이면 gate 생성·status 유지. default-off/

--- a/backend/tests/test_e_loop_ledger_p1_s6_context_pack_search.py
+++ b/backend/tests/test_e_loop_ledger_p1_s6_context_pack_search.py
@@ -24,10 +24,14 @@ def _emb_row(entity_type, entity_id, distance, embedding_text="text"):
 
 
 class _FakeSession:
-    def __init__(self, embed_rows, alive_hyp_ids, alive_loop_ids):
+    def __init__(self, embed_rows, alive_hyp_ids, alive_loop_ids, hyp_overrides=None):
         self._embed_rows = embed_rows
         self._alive_hyp_ids = alive_hyp_ids
         self._alive_loop_ids = alive_loop_ids
+        # a353e88d: alive-check 쿼리가 이제 id뿐 아니라 전체 row를 싣는다(L1 enrichment
+        # 배치 조회로 재사용) — hyp_overrides로 status/metric_definition/outcome_result를
+        # 테스트별로 지정, 없으면 무해한 기본값(orphan 필터링 테스트는 이 필드들 안 봄).
+        self._hyp_overrides = hyp_overrides or {}
         self.executed = []
 
     async def execute(self, stmt, params=None):
@@ -37,7 +41,13 @@ class _FakeSession:
         if "SET LOCAL" in text_str or "hnsw" in text_str.lower():
             return result
         if "hypotheses" in text_str.lower():
-            result.scalars.return_value.all.return_value = list(self._alive_hyp_ids)
+            hyps = [
+                self._hyp_overrides.get(hid) or SimpleNamespace(
+                    id=hid, status="proposed", metric_definition={}, outcome_result=None,
+                )
+                for hid in self._alive_hyp_ids
+            ]
+            result.scalars.return_value.all.return_value = hyps
             return result
         if "loop_runs" in text_str.lower():
             result.scalars.return_value.all.return_value = list(self._alive_loop_ids)
@@ -81,3 +91,45 @@ async def test_empty_backlog_returns_empty_no_extra_queries():
     assert out == []
     # SET LOCAL + 메인 embeddings 쿼리 2회만(orphan 배치조회는 후보 0이라 스킵).
     assert len(session.executed) == 2
+
+
+# ── a353e88d: L1 enrichment(hypothesis_status/outcome, server-side batch) ──────
+
+async def test_hypothesis_result_enriched_with_status_no_outcome_yet():
+    """outcome_result가 아직 없는(measuring 등) 가설 — hypothesis_status는 노출·outcome은 None."""
+    hid = uuid.uuid4()
+    rows = [_emb_row("hypothesis", hid, 0.2)]
+    hyp = SimpleNamespace(id=hid, status="measuring", metric_definition={}, outcome_result=None)
+    session = _FakeSession(rows, alive_hyp_ids={hid}, alive_loop_ids=set(), hyp_overrides={hid: hyp})
+    out = await svc.search_similar_embeddings(session, uuid.uuid4(), uuid.uuid4(), [0.0] * 768)
+    assert out[0].hypothesis_status == "measuring"
+    assert out[0].outcome is None
+
+
+async def test_hypothesis_result_enriched_with_outcome_when_scored():
+    """verified/falsified로 채점됐으면 outcome(metric/target/actual/direction)까지 populate."""
+    hid = uuid.uuid4()
+    rows = [_emb_row("hypothesis", hid, 0.2)]
+    hyp = SimpleNamespace(
+        id=hid, status="falsified",
+        metric_definition={"metric": "signup_rate", "target": 10, "direction": "up"},
+        outcome_result={"actual": 4.2},
+    )
+    session = _FakeSession(rows, alive_hyp_ids={hid}, alive_loop_ids=set(), hyp_overrides={hid: hyp})
+    out = await svc.search_similar_embeddings(session, uuid.uuid4(), uuid.uuid4(), [0.0] * 768)
+    assert out[0].hypothesis_status == "falsified"
+    assert out[0].outcome.metric == "signup_rate"
+    assert out[0].outcome.target == 10
+    assert out[0].outcome.actual == 4.2
+    assert out[0].outcome.direction == "up"
+    assert out[0].outcome.hypothesis_status == "falsified"
+
+
+async def test_loop_result_hypothesis_fields_stay_none():
+    """§6 무관 검증 — loop 엔티티 결과는 hypothesis 전용 enrichment 필드가 항상 None."""
+    lid = uuid.uuid4()
+    rows = [_emb_row("loop", lid, 0.3)]
+    session = _FakeSession(rows, alive_hyp_ids=set(), alive_loop_ids={lid})
+    out = await svc.search_similar_embeddings(session, uuid.uuid4(), uuid.uuid4(), [0.0] * 768)
+    assert out[0].hypothesis_status is None
+    assert out[0].outcome is None

--- a/backend/tests/test_e_sprint_loop_a353e88d_activation_gate_realdb.py
+++ b/backend/tests/test_e_sprint_loop_a353e88d_activation_gate_realdb.py
@@ -193,3 +193,88 @@ async def test_canonical_transition_router_surfaces_422():
             assert ei.value.detail["code"] == "HYPOTHESIS_REQUIRED_FOR_ACTIVATION"
     finally:
         await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_activate_endpoint_surfaces_422_with_structured_code():
+    """까심 codex QA(2026-07-03, #1867 BLOCKER①) — `POST /{id}/activate`도 게이트를 태우는
+    3경로 중 하나(SSOT `transition_sprint` 경유)인데, 서비스 raise만 테스트하면 이 경로의
+    에러 매핑 자체가 400+string으로 퇴화해도 안 잡힌다(cross-layer contract 갭). 실 엔드포인트를
+    때려 HTTP 422 + code가 그대로 노출되는지 실증(FE §5 handoff graceful 계약 전제)."""
+    from app.routers.sprints import activate_sprint
+    from app.dependencies.auth import AuthContext
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            sprint = await _make_sprint(s)
+            await s.commit()
+
+        async with Session() as s:
+            auth = AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+            with pytest.raises(HTTPException) as ei:
+                await activate_sprint(sprint.id, session=s, org_id=ORG, auth=auth)
+            assert ei.value.status_code == 422
+            assert ei.value.detail["code"] == "HYPOTHESIS_REQUIRED_FOR_ACTIVATION"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_patch_status_endpoint_surfaces_422_with_structured_code():
+    """까심 codex QA(2026-07-03, #1867 BLOCKER①) — `PATCH /{id}`(status 변경)도 동일 SSOT
+    경유 3경로 중 하나. 이 엔드포인트 역시 422 + 구조화 code로 노출돼야 FE가 다른 두 경로와
+    동일하게 graceful degrade 가능(3경로 중 하나만 계약이 다르면 FE가 경로별 분기해야 하는
+    회귀)."""
+    from app.routers.sprints import update_sprint
+    from app.schemas.sprint import SprintUpdate
+    from app.repositories.sprint import SprintRepository
+    from app.dependencies.auth import AuthContext
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            sprint = await _make_sprint(s)
+            await s.commit()
+
+        async with Session() as s:
+            auth = AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+            repo = SprintRepository(s, ORG)
+            with pytest.raises(HTTPException) as ei:
+                await update_sprint(
+                    sprint.id, SprintUpdate(status="active"),
+                    repo=repo, session=s, org_id=ORG, auth=auth,
+                )
+            assert ei.value.status_code == 422
+            assert ei.value.detail["code"] == "HYPOTHESIS_REQUIRED_FOR_ACTIVATION"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_activate_endpoint_preserves_400_shape_for_preexisting_codes():
+    """backward-compat 회귀 방지(PO 결, 2026-07-03) — 신규 code(HYPOTHESIS_REQUIRED_FOR_ACTIVATION)만
+    422+구조화로 승격됐고, 기존 코드(예: 이미 active인 스프린트 재활성화 시도 =
+    INVALID_SPRINT_TRANSITION류)는 이 엔드포인트에서 여전히 400+string shape 그대로임을
+    실증 — 기존 FE 소비자(400 문자열 파싱)를 깨지 않는다."""
+    from app.routers.sprints import activate_sprint
+    from app.dependencies.auth import AuthContext
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            sprint = await _make_sprint(s, status="active")  # 이미 active — planning→active 전이 아님
+            await _link_hypothesis(s, sprint.id, "proposed")  # 게이트는 통과, 전이 자체가 무효
+            await s.commit()
+
+        async with Session() as s:
+            auth = AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+            with pytest.raises(HTTPException) as ei:
+                await activate_sprint(sprint.id, session=s, org_id=ORG, auth=auth)
+            assert ei.value.status_code == 400
+            assert isinstance(ei.value.detail, str)
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_e_sprint_loop_a353e88d_activation_gate_realdb.py
+++ b/backend/tests/test_e_sprint_loop_a353e88d_activation_gate_realdb.py
@@ -1,0 +1,195 @@
+"""E-SPRINT-LOOP a353e88d: sprint-open 定 게이트 — realdb(생존 상태 필터·라우터 표면 실증).
+
+PO 결(2026-07-03): killed/archived만 링크돼 있으면 "검증 대상 0"인데 활성화되는 semantic
+구멍이므로 제외 — proposed/active/measuring/verified/falsified만 "생존 선언"으로 인정.
+실 Postgres로 status enum 전수 필터링과, 캐노니컬 라우터(`/transition`)가 422를 올바른
+code로 실제 노출하는지까지 검증한다(서비스 유닛 테스트는 mock이라 SQL WHERE 자체를
+실측 못 함 — 이 파일이 그 갭을 메운다)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("dd000000-0000-0000-0000-000000000001")
+PROJ = uuid.UUID("dd000000-0000-0000-0000-0000000000c1")
+OWNER = uuid.UUID("dd000000-0000-0000-0000-0000000000b1")
+USER = uuid.UUID("dd000000-0000-0000-0000-0000000000a1")
+OM = uuid.UUID("dd000000-0000-0000-0000-0000000000b2")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+async def _seed_org_project(s):
+    from sqlalchemy import text
+    for sql in [
+        f"DELETE FROM sprints WHERE org_id='{ORG}'",
+        f"DELETE FROM hypotheses WHERE org_id='{ORG}'",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','DD','dd-org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@dd.test','x','U',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ}','{ORG}','P','none')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _make_sprint(s, status="planning"):
+    from app.models.pm import Sprint
+    sprint = Sprint(id=uuid.uuid4(), org_id=ORG, project_id=PROJ, title="sp", status=status, duration=14)
+    s.add(sprint)
+    await s.flush()
+    return sprint
+
+
+async def _link_hypothesis(s, sprint_id, status):
+    from app.models.hypothesis import Hypothesis, HypothesisSprintLink
+    hyp = Hypothesis(
+        id=uuid.uuid4(), org_id=ORG, project_id=PROJ, owner_member_id=OWNER,
+        statement="s", metric_definition={"metric": "x", "source": "manual", "target": 1, "direction": "up"},
+        measure_after=datetime.now(timezone.utc) + timedelta(days=14), status=status,
+        human_accounting={}, gate_contract={},
+    )
+    s.add(hyp)
+    await s.flush()
+    s.add(HypothesisSprintLink(id=uuid.uuid4(), hypothesis_id=hyp.id, sprint_id=sprint_id, link_type="declared"))
+    await s.flush()
+
+
+def _caller():
+    from app.services.member_resolver import ResolvedMember
+    return ResolvedMember(id=uuid.uuid4(), user_id=uuid.uuid4(), name="h", type="human", role="member", org_id=ORG)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("dead_status", ["killed", "archived"])
+async def test_activation_blocked_when_only_dead_status_linked(dead_status):
+    from app.services.sprint import SprintTransitionError, transition_sprint
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            sprint = await _make_sprint(s)
+            await _link_hypothesis(s, sprint.id, dead_status)
+            await s.commit()
+
+        async with Session() as s:
+            with pytest.raises(SprintTransitionError) as ei:
+                await transition_sprint(s, ORG, _caller(), sprint.id, "active")
+            assert ei.value.code == "HYPOTHESIS_REQUIRED_FOR_ACTIVATION"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("alive_status", ["proposed", "active", "measuring", "verified", "falsified"])
+async def test_activation_succeeds_with_each_alive_status(alive_status):
+    from app.services.sprint import transition_sprint
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            sprint = await _make_sprint(s)
+            await _link_hypothesis(s, sprint.id, alive_status)
+            await s.commit()
+
+        async with Session() as s:
+            result = await transition_sprint(s, ORG, _caller(), sprint.id, "active")
+            await s.commit()
+        assert result.status == "active"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_activation_blocked_zero_links():
+    from app.services.sprint import SprintTransitionError, transition_sprint
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            sprint = await _make_sprint(s)
+            await s.commit()
+
+        async with Session() as s:
+            with pytest.raises(SprintTransitionError) as ei:
+                await transition_sprint(s, ORG, _caller(), sprint.id, "active")
+            assert ei.value.code == "HYPOTHESIS_REQUIRED_FOR_ACTIVATION"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_activation_succeeds_when_mix_of_dead_and_alive():
+    """죽은 상태 1개 + 생존 상태 1개 혼재 — 생존 1개만 있어도 통과(전부 죽은 상태여야 차단)."""
+    from app.services.sprint import transition_sprint
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            sprint = await _make_sprint(s)
+            await _link_hypothesis(s, sprint.id, "killed")
+            await _link_hypothesis(s, sprint.id, "proposed")
+            await s.commit()
+
+        async with Session() as s:
+            result = await transition_sprint(s, ORG, _caller(), sprint.id, "active")
+        assert result.status == "active"
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_canonical_transition_router_surfaces_422():
+    """캐노니컬 라우터(`POST /{id}/transition`)가 게이트 실패를 422 + 정확한 code로 노출.
+    router 함수를 직접 호출(story 1/2/3과 동형 패턴)."""
+    from app.routers.sprints import SprintTransitionRequest, transition_sprint_endpoint
+    from app.repositories.sprint import SprintRepository
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed_org_project(s)
+            sprint = await _make_sprint(s)
+            await s.commit()
+
+        async with Session() as s:
+            from app.dependencies.auth import AuthContext
+            auth = AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+            with pytest.raises(HTTPException) as ei:
+                await transition_sprint_endpoint(
+                    sprint.id, SprintTransitionRequest(status="active"),
+                    session=s, org_id=ORG, auth=auth,
+                )
+            assert ei.value.status_code == 422
+            assert ei.value.detail["code"] == "HYPOTHESIS_REQUIRED_FOR_ACTIVATION"
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_e_sprint_loop_a353e88d_activation_gate_service.py
+++ b/backend/tests/test_e_sprint_loop_a353e88d_activation_gate_service.py
@@ -1,0 +1,100 @@
+"""E-SPRINT-LOOP a353e88d: sprint-open 定 — planning→active 게이트(≥1 생존 가설) 서비스 단위.
+
+핵심 불변식: 게이트는 transition_sprint(SSOT) 안에 있어 to_status=="active"·
+from_status=="planning" 조합에서만 발동(다른 전이는 영향 없음). 생존 상태(killed/archived
+제외)만 카운트(PO 결 2026-07-03) — mock session이라 SQL WHERE 절 자체는 실측이 아니라
+realdb 스위트(test_e_sprint_loop_a353e88d_activation_gate_realdb.py)에서 검증하고, 여기선
+게이트의 분기 로직(있음/없음 → 통과/차단)만 빠르게 커버한다."""
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import sprint as svc
+from app.services.member_resolver import ResolvedMember
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+SPRINT_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _caller(member_type: str = "human") -> ResolvedMember:
+    return ResolvedMember(
+        id=uuid.uuid4(), user_id=uuid.uuid4() if member_type == "human" else None,
+        name="t", type=member_type, role="member", org_id=ORG_ID,
+    )
+
+
+def _mock_sprint(status: str = "planning") -> SimpleNamespace:
+    return SimpleNamespace(id=SPRINT_ID, org_id=ORG_ID, project_id=PROJECT_ID, status=status)
+
+
+def _mock_session(scalar_return) -> MagicMock:
+    """게이트 쿼리(session.scalar)만 통제 — 이후 overlay/apply 경로는 별도 patch로 격리."""
+    session = MagicMock()
+    session.scalar = AsyncMock(return_value=scalar_return)
+    session.commit = AsyncMock()
+    return session
+
+
+def _patch_repo(sprint, activated=None):
+    repo = MagicMock()
+    repo.get = AsyncMock(return_value=sprint)
+    repo.activate = AsyncMock(return_value=activated or _mock_sprint("active"))
+    return patch.object(svc, "SprintRepository", return_value=repo), repo
+
+
+async def test_activate_blocked_when_no_hypothesis_linked():
+    sprint = _mock_sprint("planning")
+    session = _mock_session(scalar_return=None)  # 링크 0건
+    p_repo, repo = _patch_repo(sprint)
+    with p_repo:
+        with pytest.raises(svc.SprintTransitionError) as ei:
+            await svc.transition_sprint(session, ORG_ID, _caller(), SPRINT_ID, "active")
+    assert ei.value.code == "HYPOTHESIS_REQUIRED_FOR_ACTIVATION"
+    repo.activate.assert_not_awaited()  # 게이트가 apply 전에 막음
+
+
+async def test_activate_succeeds_when_hypothesis_linked():
+    sprint = _mock_sprint("planning")
+    session = _mock_session(scalar_return=uuid.uuid4())  # 링크 존재(더미 link id)
+    p_repo, repo = _patch_repo(sprint)
+    with p_repo:
+        result = await svc.transition_sprint(session, ORG_ID, _caller(), SPRINT_ID, "active")
+    assert result.status == "active"
+    repo.activate.assert_awaited_once_with(SPRINT_ID)
+
+
+async def test_gate_only_applies_to_planning_to_active():
+    """다른 전이(예: active→closed)는 게이트 쿼리 자체를 안 탄다(회귀 0 — 범위 최소화)."""
+    sprint = _mock_sprint("active")
+    session = MagicMock()
+    session.scalar = AsyncMock(side_effect=AssertionError("게이트 쿼리가 호출되면 안 됨"))
+    session.commit = AsyncMock()
+    repo = MagicMock()
+    repo.get = AsyncMock(return_value=sprint)
+    repo.close = AsyncMock(return_value=_mock_sprint("closed"))
+    with patch.object(svc, "SprintRepository", return_value=repo):
+        result = await svc.transition_sprint(session, ORG_ID, _caller(), SPRINT_ID, "closed")
+    assert result.status == "closed"
+    session.scalar.assert_not_called()
+
+
+async def test_via_gate_true_still_enforces_hypothesis_gate():
+    """via_gate=True(overlay 승인 적용 경로)는 human-only inline만 skip하지, ≥1 가설 게이트는
+    여전히 통과해야 한다 — 우회 축이 아님을 명시 검증."""
+    sprint = _mock_sprint("planning")
+    session = _mock_session(scalar_return=None)
+    p_repo, repo = _patch_repo(sprint)
+    with p_repo:
+        with pytest.raises(svc.SprintTransitionError) as ei:
+            await svc.transition_sprint(
+                session, ORG_ID, _caller(), SPRINT_ID, "active", via_gate=True
+            )
+    assert ei.value.code == "HYPOTHESIS_REQUIRED_FOR_ACTIVATION"

--- a/backend/tests/test_edg_s26_sprint_overlay.py
+++ b/backend/tests/test_edg_s26_sprint_overlay.py
@@ -67,6 +67,26 @@ def _sr(to_status, from_status="planning"):
 
 
 # ── _apply_sprint_transition (real-PG·③SoD 없음·repo 위임) ────────────────────
+async def _seed_alive_hypothesis_link(s, org, proj, sprint_id):
+    """a353e88d — planning→active 게이트(≥1 생존 가설 링크)를 통과시키는 공용 시드 헬퍼.
+    이 파일의 activate 경로 테스트는 게이트 의도(1-active 제약 등)와 무관한 관심사라
+    항상 통과하도록 최소 fixture만 심는다(게이트 자체의 회귀/차단 테스트는
+    test_e_sprint_loop_a353e88d_*.py 별도)."""
+    import uuid as _uuid
+    from datetime import datetime, timedelta, timezone
+    from app.models.hypothesis import Hypothesis, HypothesisSprintLink
+    hyp = Hypothesis(
+        id=_uuid.uuid4(), org_id=org, project_id=proj, owner_member_id=_uuid.uuid4(),
+        statement="s", metric_definition={"metric": "x", "source": "manual", "target": 1, "direction": "up"},
+        measure_after=datetime.now(timezone.utc) + timedelta(days=14), status="proposed",
+        human_accounting={}, gate_contract={},
+    )
+    s.add(hyp)
+    await s.flush()
+    s.add(HypothesisSprintLink(id=_uuid.uuid4(), hypothesis_id=hyp.id, sprint_id=sprint_id, link_type="declared"))
+    await s.flush()
+
+
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
 async def test_apply_activates_no_sod():
@@ -84,6 +104,7 @@ async def test_apply_activates_no_sod():
         sprint = Sprint(org_id=org, project_id=proj, title="sp", status="planning")
         s.add(sprint)
         await s.flush()
+        await _seed_alive_hypothesis_link(s, org, proj, sprint.id)  # a353e88d 게이트 통과
         sr = WorkflowLineStepRun(
             org_id=org, project_id=proj, entity_type="sprint", entity_id=sprint.id,
             from_status="planning", to_status="active", status="gate_pending", mode="enforcing",
@@ -139,6 +160,8 @@ async def test_default_off_activate_any_caller():
         await s.flush()
         sprint = Sprint(org_id=org, project_id=proj, title="sp", status="planning")
         s.add(sprint)
+        await s.flush()
+        await _seed_alive_hypothesis_link(s, org, proj, sprint.id)  # a353e88d 게이트 통과
         await s.commit()
         agent = ResolvedMember(id=uuid.uuid4(), user_id=None, name="a", type="agent", role="member", org_id=org)
         result = await transition_sprint(s, org, agent, sprint.id, "active")  # agent·default-off→활성


### PR DESCRIPTION
## Summary
- E-SPRINT-LOOP BE(`a353e88d`) — retro(sprint-close, dc861e44/ecc531ce done)의 짝인 **sprint-open** 조각. 신규 코드는 AC1(≥1 가설 게이트) 1건뿐 — L1(선례 회수)·L3(초안 조력)는 기존 엔드포인트(`GET /context-pack/search`·`POST /hypotheses/draft`) 재사용만으로 스코프 충족
- **AC1**: `transition_sprint`(SSOT)에 planning→active 게이트 — **생존 상태**(proposed/active/measuring/verified/falsified) 가설이 ≥1 링크돼야 활성화 가능(killed/archived만 있으면 차단, PO 결). 게이트가 SSOT 안에 있어 PATCH/activate/transition 3개 라우터+MCP 경로까지 자동 커버(우회 축 0). `422 HYPOTHESIS_REQUIRED_FOR_ACTIVATION`
- **AC2**: `context-pack/search` 응답에 L1 enrichment(`hypothesis_status`·`outcome`, additive+nullable, 기존 `ContextPackOutcome` 재사용) — 서버사이드 배치(기존 alive-check 쿼리 확장, 신규 왕복 0). **§6 절대: 회수 스코프 무변경**
- **AC3**: L3는 기존 `POST /hypotheses/draft`(`source_type="loop_goal"`)를 그대로 FE가 사용 — 코드 변경 없음

## Design
설계 문서: sprintable docs `design-a353e88d-sprint-open`(PO crux 통과 2026-07-03, 3점 결정: 생존 상태만 카운트·422·서버사이드 batch enrich).

## Test plan
- [x] `pytest tests/ -k "sprint or context_pack or hypothesis"` — 251 passed, 0 회귀
- [x] `pytest tests/` 전체 — 2913 passed(story 前 대비 +7)·기존 8건 실패는 develop baseline과 동일(무관)
- [x] 신규 서비스 단위 테스트(`test_e_sprint_loop_a353e88d_activation_gate_service.py`, 4건): 게이트 차단/통과·다른 전이 무영향(범위 최소화)·via_gate=True도 게이트 우회 불가
- [x] **실 Postgres**(`test_e_sprint_loop_a353e88d_activation_gate_realdb.py`, 10건): killed/archived만→차단·5개 생존 상태 전수 통과·혼재 시 생존 1개면 통과·캐노니컬 `/transition` 라우터가 422+정확한 code 노출
- [x] `context_pack_search` enrichment 3건 신규(hypothesis_status/outcome populate·loop 엔티티는 항상 None)
- [x] **회귀 위험 전수 확인**: 기존 activate 테스트 2건(가설 링크 없이 activate 성공 기대)이 새 게이트로 깨질 것을 미리 발견 → fixture 보강(가설 링크 시드 헬퍼 추가). 로컬 pg16(pgvector 미설치) 환경 제약으로 4건 skip은 develop baseline과 동일 실패 확인(회귀 아님, git diff로 대조 검증)
- [x] `context_pack_search.py`의 회수 스코프(WHERE 절) 무변경 grep 확인

FE(미르코 `278314e9`)는 이 계약(엔드포인트 3개 전부 기존)으로 병행 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)