### PR TITLE
[SID:81b0d17e] AI 생성 로딩 강화 — 지능 사다리 내러티브 + 결과 스켈레톤

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1372,7 +1372,15 @@
     "hitlBanner": "This is only a recommendation. Adopting seeds a draft (proposed) hypothesis for the next sprint — activating, editing, or discarding it is the team's call.",
     "evidenceStripLabel": "Hypothesis status",
     "evidenceStripEmpty": "No hypotheses linked",
-    "evidenceStripMore": "See details at close →"
+    "evidenceStripMore": "See details at close →",
+    "loadingHeadlineSynthesis": "is scanning this sprint…",
+    "loadingStep1Label": "Recalling similar precedents from past loops",
+    "loadingStep1Desc": "Searching org memory for similar hypotheses, decisions, and outcomes",
+    "loadingStep2Label": "Synthesizing this sprint's results",
+    "loadingStep2Desc": "Drawing lessons from hypothesis verdicts and top retro signals",
+    "loadingStep3Label": "Deriving the next hypothesis to test",
+    "loadingStep3Desc": "Suggesting a direction worth testing next sprint",
+    "loadingTranslineSynthesis": "Sprintable AI is preparing reference material. The judgment call is yours."
   },
   "share": {
     "share": "Share",
@@ -2807,7 +2815,11 @@
     "cockpitHypothesesTitle": "{count} hypotheses in progress",
     "cockpitMeasureCountdown": "Measuring in D-{days}",
     "cockpitMeasureOverdue": "Measuring soon — auto-scored after close",
-    "cockpitExperimentsLabel": "Experiments"
+    "cockpitExperimentsLabel": "Experiments",
+    "loadingHeadlineDraft": "is drafting a hypothesis…",
+    "loadingStepDraftLabel": "Drafting a hypothesis",
+    "loadingStepDraftDesc": "Proposing a statement, metric, and measurement date from the goal context",
+    "loadingTranslineDraft": "This is an AI draft. Review and edit it — you confirm it."
   },
   "presence": {
     "panelTitle": "Team presence",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1372,7 +1372,15 @@
     "hitlBanner": "추천일 뿐이다. 채택하면 다음 스프린트 가설 초안(proposed)으로 시드되고, 활성화·수정·폐기는 팀이 결정한다.",
     "evidenceStripLabel": "가설 현황",
     "evidenceStripEmpty": "연결된 가설이 없습니다",
-    "evidenceStripMore": "종료 단계에서 자세히 →"
+    "evidenceStripMore": "종료 단계에서 자세히 →",
+    "loadingHeadlineSynthesis": "가 이번 스프린트를 훑는 중…",
+    "loadingStep1Label": "과거 루프에서 유사 선례 회수",
+    "loadingStep1Desc": "비슷한 가설·결정·성과를 조직 기억에서 찾음",
+    "loadingStep2Label": "이번 스프린트 결과 종합",
+    "loadingStep2Desc": "가설별 검증/반증 + 상위 회고 신호에서 배운 것 도출",
+    "loadingStep3Label": "다음 검증 가설 도출",
+    "loadingStep3Desc": "다음 스프린트에서 검증해볼 만한 방향 제안",
+    "loadingTranslineSynthesis": "Sprintable AI가 참고 자료를 만드는 중입니다 · 판단은 당신이 합니다."
   },
   "share": {
     "share": "공유",
@@ -2807,7 +2815,11 @@
     "cockpitHypothesesTitle": "검증 중인 가설 {count}",
     "cockpitMeasureCountdown": "측정 예정 D-{days}",
     "cockpitMeasureOverdue": "측정 예정 — 종료 후 자동 채점",
-    "cockpitExperimentsLabel": "실험"
+    "cockpitExperimentsLabel": "실험",
+    "loadingHeadlineDraft": "가 초안을 짓는 중…",
+    "loadingStepDraftLabel": "가설 초안 짓는 중",
+    "loadingStepDraftDesc": "목표 맥락에서 statement·지표·측정 시점을 한 번에 제안",
+    "loadingTranslineDraft": "AI 초안입니다 · 검토·수정 후 확정은 당신이 합니다."
   },
   "presence": {
     "panelTitle": "팀 presence",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -43,6 +43,16 @@
   100% { background-position:  200% 0; }
 }
 
+/* E-SPRINT-LOOP 81b0d17e: AiGenerationLoading 인디터미닛 바 — 가짜 진행 %가 아닌 슬라이딩
+   하이라이트(honest indeterminate, handoff §4③). */
+@keyframes ai-loading-indeterminate {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(360%); }
+}
+.animate-ai-loading-indeterminate {
+  animation: ai-loading-indeterminate 1.5s ease-in-out infinite;
+}
+
 @theme inline {
   --font-heading: var(--font-sans);
   --font-sans: var(--font-sans);

--- a/apps/web/src/components/ai/ai-generation-loading.test.tsx
+++ b/apps/web/src/components/ai/ai-generation-loading.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { AiGenerationLoading } from './ai-generation-loading';
+
+const SYNTHESIS_STEPS = [
+  { label: '과거 루프에서 유사 선례 회수', desc: '비슷한 가설·결정·성과를 조직 기억에서 찾음' },
+  { label: '이번 스프린트 결과 종합', desc: '가설별 검증/반증 + 상위 회고 신호에서 배운 것 도출' },
+  { label: '다음 검증 가설 도출', desc: '다음 스프린트에서 검증해볼 만한 방향 제안' },
+];
+
+describe('AiGenerationLoading (E-SPRINT-LOOP 81b0d17e — honest indeterminate)', () => {
+  it('renders the brand header, all step labels, and the transparency line', () => {
+    const markup = renderToStaticMarkup(
+      <AiGenerationLoading headline="가 이번 스프린트를 훑는 중…" steps={SYNTHESIS_STEPS} activeIndex={1} skeleton="synthesis" transline="판단은 당신이 합니다." />,
+    );
+    expect(markup).toContain('Sprintable AI');
+    expect(markup).toContain('가 이번 스프린트를 훑는 중…');
+    for (const step of SYNTHESIS_STEPS) expect(markup).toContain(step.label);
+    expect(markup).toContain('판단은 당신이 합니다.');
+  });
+
+  it('never renders a fake percentage as visible text (CSS width utilities like w-[36%] are fine — only text nodes matter)', () => {
+    const markup = renderToStaticMarkup(
+      <AiGenerationLoading headline="h" steps={SYNTHESIS_STEPS} activeIndex={1} skeleton="synthesis" transline="t" />,
+    );
+    // honest-indeterminate contract: no rendered text node is a bare "NN%" progress readout
+    expect(markup).not.toMatch(/>\s*\d+\s*%\s*</);
+  });
+
+  it('renders exactly one active step (indeterminate bar) even mid-sequence — steps before are done, after are pending', () => {
+    const markup = renderToStaticMarkup(
+      <AiGenerationLoading headline="h" steps={SYNTHESIS_STEPS} activeIndex={1} skeleton="synthesis" transline="t" />,
+    );
+    const barCount = (markup.match(/animate-ai-loading-indeterminate/g) ?? []).length;
+    expect(barCount).toBe(1);
+  });
+
+  it('the last step keeps its indeterminate bar at the final index (never fake-completes before the caller flips activeIndex away)', () => {
+    const markup = renderToStaticMarkup(
+      <AiGenerationLoading headline="h" steps={SYNTHESIS_STEPS} activeIndex={SYNTHESIS_STEPS.length - 1} skeleton="synthesis" transline="t" />,
+    );
+    expect(markup).toContain('animate-ai-loading-indeterminate');
+    expect(markup.match(/✓/g)?.length).toBe(2); // first two steps done, last one still active/shimmering
+  });
+
+  it('a single-step surface (sprint-open L3 draft) renders one active node with no connector line', () => {
+    const markup = renderToStaticMarkup(
+      <AiGenerationLoading headline="가 초안을 짓는 중…" steps={[{ label: '가설 초안 짓는 중', desc: '한 번에 제안' }]} activeIndex={0} skeleton="draft" transline="확정은 당신이." />,
+    );
+    expect(markup).toContain('가설 초안 짓는 중');
+    expect(markup).not.toContain('✓'); // nothing "done" yet in a 1-step pipeline
+  });
+
+  it('SOUL-LOCK: never renders destructive styling regardless of skeleton variant', () => {
+    const synth = renderToStaticMarkup(
+      <AiGenerationLoading headline="h" steps={SYNTHESIS_STEPS} activeIndex={0} skeleton="synthesis" transline="t" />,
+    );
+    const draft = renderToStaticMarkup(
+      <AiGenerationLoading headline="h" steps={[{ label: 's' }]} activeIndex={0} skeleton="draft" transline="t" />,
+    );
+    for (const markup of [synth, draft]) {
+      expect(markup).not.toContain('data-variant="destructive"');
+      expect(markup).not.toMatch(/\btext-red-\d|\bbg-red-\d/);
+    }
+  });
+
+  it('synthesis and draft skeletons render distinct placeholder shapes', () => {
+    const synth = renderToStaticMarkup(
+      <AiGenerationLoading headline="h" steps={SYNTHESIS_STEPS} activeIndex={0} skeleton="synthesis" transline="t" />,
+    );
+    const draft = renderToStaticMarkup(
+      <AiGenerationLoading headline="h" steps={[{ label: 's' }]} activeIndex={0} skeleton="draft" transline="t" />,
+    );
+    expect(synth).toContain('곧 나올 종합');
+    expect(draft).toContain('곧 나올 초안');
+  });
+});

--- a/apps/web/src/components/ai/ai-generation-loading.test.tsx
+++ b/apps/web/src/components/ai/ai-generation-loading.test.tsx
@@ -60,7 +60,11 @@ describe('AiGenerationLoading (E-SPRINT-LOOP 81b0d17e — honest indeterminate)'
     );
     for (const markup of [synth, draft]) {
       expect(markup).not.toContain('data-variant="destructive"');
-      expect(markup).not.toMatch(/\btext-red-\d|\bbg-red-\d/);
+      // 까심 QA 적출(2026-07-03): 시맨틱 destructive 토큰(text-destructive/bg-destructive)은
+      // 별도 assert 필요 — red-* 유틸/data-variant 체크가 이 시맨틱 클래스명을 못 잡는다.
+      expect(markup).not.toMatch(/\btext-destructive\b/);
+      expect(markup).not.toMatch(/\bbg-destructive\b/);
+      expect(markup).not.toMatch(/\btext-red-\d|\bbg-red-\d|\bborder-red-\d/);
     }
   });
 

--- a/apps/web/src/components/ai/ai-generation-loading.tsx
+++ b/apps/web/src/components/ai/ai-generation-loading.tsx
@@ -35,10 +35,10 @@ export function AiGenerationLoading({
   transline: string;
 }) {
   return (
-    <div className="flex flex-col gap-3.5 rounded-xl border border-primary/20 bg-primary/[0.04] p-4">
+    <div className="flex flex-col gap-3.5 rounded-xl border border-border bg-info-tint/10 p-4">
       <div className="flex items-center gap-2">
         <span className="flex items-center gap-1.5 text-sm font-bold text-foreground">
-          <Sparkles className="size-3.5 text-primary" aria-hidden />
+          <Sparkles className="size-3.5 text-info" aria-hidden />
           Sprintable AI
         </span>
         <span className="text-[10.5px] font-medium text-muted-foreground">{headline}</span>
@@ -55,7 +55,7 @@ export function AiGenerationLoading({
                 <span
                   className={cn(
                     'absolute left-[9px] top-[26px] bottom-[-6px] w-px',
-                    isDone ? 'bg-primary/40' : 'bg-border',
+                    isDone ? 'bg-info-border' : 'bg-border',
                   )}
                   aria-hidden
                 />
@@ -63,14 +63,14 @@ export function AiGenerationLoading({
               <span
                 className={cn(
                   'relative z-[1] mt-0.5 flex size-[18px] shrink-0 items-center justify-center rounded-full text-[10px]',
-                  isDone && 'border border-primary/40 bg-primary/15 text-primary',
-                  isActive && 'bg-primary text-primary-foreground',
+                  isDone && 'border border-info-border bg-info-tint text-info',
+                  isActive && 'bg-info text-background',
                   isPending && 'border border-border bg-muted text-muted-foreground',
                 )}
               >
                 {isDone ? '✓' : isActive ? <span className="animate-pulse">✦</span> : i + 1}
                 {isActive ? (
-                  <span className="absolute -inset-1 rounded-full border border-primary/40 animate-pulse" aria-hidden />
+                  <span className="absolute -inset-1 rounded-full border border-info-border animate-pulse" aria-hidden />
                 ) : null}
               </span>
               <div className="min-w-0 flex-1 space-y-1">
@@ -80,7 +80,7 @@ export function AiGenerationLoading({
                 {step.desc ? <p className="text-[10px] leading-snug text-muted-foreground">{step.desc}</p> : null}
                 {isActive ? (
                   <div className="relative h-[3px] w-full max-w-[220px] overflow-hidden rounded-full bg-muted">
-                    <span className="absolute inset-y-0 left-0 w-[36%] animate-ai-loading-indeterminate rounded-full bg-gradient-to-r from-transparent via-primary to-transparent" aria-hidden />
+                    <span className="absolute inset-y-0 left-0 w-[36%] animate-ai-loading-indeterminate rounded-full bg-gradient-to-r from-transparent via-info to-transparent" aria-hidden />
                   </div>
                 ) : null}
               </div>
@@ -92,7 +92,7 @@ export function AiGenerationLoading({
       <GenerationSkeleton variant={skeleton} />
 
       <p className="flex items-center gap-1.5 rounded-lg border border-dashed border-border px-2.5 py-1.5 text-[10px] leading-snug text-muted-foreground">
-        <Sparkles className="size-3 shrink-0 text-primary" aria-hidden />
+        <Sparkles className="size-3 shrink-0 text-info" aria-hidden />
         {transline}
       </p>
     </div>
@@ -122,7 +122,7 @@ function GenerationSkeleton({ variant }: { variant: 'synthesis' | 'draft' }) {
       <div className="space-y-2.5 rounded-lg border border-border bg-card p-2.5">
         {[0, 1].map((i) => (
           <div key={i} className="flex items-start gap-2">
-            <span className="mt-1.5 size-1.5 shrink-0 rounded-full bg-primary/40" aria-hidden />
+            <span className="mt-1.5 size-1.5 shrink-0 rounded-full bg-info-border" aria-hidden />
             <div className="flex-1 space-y-1.5">
               <Skeleton variant="text" className="w-[90%]" />
               <Skeleton variant="text" className="w-[60%]" />

--- a/apps/web/src/components/ai/ai-generation-loading.tsx
+++ b/apps/web/src/components/ai/ai-generation-loading.tsx
@@ -1,0 +1,143 @@
+import { Sparkles } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+
+/**
+ * E-SPRINT-LOOP(81b0d17e) — 공용 pro-backed 생성 로딩 컴포넌트. 핸드오프
+ * `ai-generation-loading-handoff` §4/§7. 지능 사다리 내러티브(실 파이프라인 순서=진실) +
+ * 결과 스켈레톤 + honest 인디터미닛(가짜 % 절대 금지)으로 gemini-3.1-pro-preview(~9초) 대기를
+ * 목적성 있게 만든다.
+ *
+ * ⭐honest 계약(§7, 비협상): steps 배열 길이 = 실 백엔드 phase 수(가짜 phase 발명 금지 — retro
+ * 종합=3=실 2 LLM콜, sprint-open L3 초안=1=단일 generate_text 콜). activeIndex는 호출부가
+ * heuristic 타이밍으로 advance하되, 응답 도착 전까지는 마지막 스텝에서 절대 넘어가지 않는다
+ * (거짓 완료 금지) — 이 컴포넌트 자체는 순수 렌더만 하고 타이머는 소비부 책임.
+ *
+ * SOUL-LOCK: brand/info/muted 토큰·shimmer·pulse만 사용, destructive(빨강) 0.
+ */
+export interface AiGenerationLoadingStep {
+  label: string;
+  desc?: string;
+}
+
+export function AiGenerationLoading({
+  headline,
+  steps,
+  activeIndex,
+  skeleton,
+  transline,
+}: {
+  /** 브랜드마크 옆에 붙는 서술("가 이번 스프린트를 훑는 중…" 등). */
+  headline: string;
+  steps: AiGenerationLoadingStep[];
+  activeIndex: number;
+  skeleton: 'synthesis' | 'draft';
+  transline: string;
+}) {
+  return (
+    <div className="flex flex-col gap-3.5 rounded-xl border border-primary/20 bg-primary/[0.04] p-4">
+      <div className="flex items-center gap-2">
+        <span className="flex items-center gap-1.5 text-sm font-bold text-foreground">
+          <Sparkles className="size-3.5 text-primary" aria-hidden />
+          Sprintable AI
+        </span>
+        <span className="text-[10.5px] font-medium text-muted-foreground">{headline}</span>
+      </div>
+
+      <div className="flex flex-col">
+        {steps.map((step, i) => {
+          const isDone = i < activeIndex;
+          const isActive = i === activeIndex;
+          const isPending = i > activeIndex;
+          return (
+            <div key={i} className="relative flex items-start gap-2.5 py-1.5">
+              {i < steps.length - 1 ? (
+                <span
+                  className={cn(
+                    'absolute left-[9px] top-[26px] bottom-[-6px] w-px',
+                    isDone ? 'bg-primary/40' : 'bg-border',
+                  )}
+                  aria-hidden
+                />
+              ) : null}
+              <span
+                className={cn(
+                  'relative z-[1] mt-0.5 flex size-[18px] shrink-0 items-center justify-center rounded-full text-[10px]',
+                  isDone && 'border border-primary/40 bg-primary/15 text-primary',
+                  isActive && 'bg-primary text-primary-foreground',
+                  isPending && 'border border-border bg-muted text-muted-foreground',
+                )}
+              >
+                {isDone ? '✓' : isActive ? <span className="animate-pulse">✦</span> : i + 1}
+                {isActive ? (
+                  <span className="absolute -inset-1 rounded-full border border-primary/40 animate-pulse" aria-hidden />
+                ) : null}
+              </span>
+              <div className="min-w-0 flex-1 space-y-1">
+                <p className={cn('text-xs leading-tight', isPending ? 'text-muted-foreground' : 'font-semibold text-foreground')}>
+                  {step.label}
+                </p>
+                {step.desc ? <p className="text-[10px] leading-snug text-muted-foreground">{step.desc}</p> : null}
+                {isActive ? (
+                  <div className="relative h-[3px] w-full max-w-[220px] overflow-hidden rounded-full bg-muted">
+                    <span className="absolute inset-y-0 left-0 w-[36%] animate-ai-loading-indeterminate rounded-full bg-gradient-to-r from-transparent via-primary to-transparent" aria-hidden />
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <GenerationSkeleton variant={skeleton} />
+
+      <p className="flex items-center gap-1.5 rounded-lg border border-dashed border-border px-2.5 py-1.5 text-[10px] leading-snug text-muted-foreground">
+        <Sparkles className="size-3 shrink-0 text-primary" aria-hidden />
+        {transline}
+      </p>
+    </div>
+  );
+}
+
+function GenerationSkeleton({ variant }: { variant: 'synthesis' | 'draft' }) {
+  if (variant === 'draft') {
+    return (
+      <div className="flex flex-col gap-2 border-t border-dashed border-border pt-3">
+        <p className="text-[9.5px] font-bold uppercase tracking-[0.14em] text-muted-foreground">곧 나올 초안</p>
+        <div className="space-y-2 rounded-lg border border-border bg-card p-2.5">
+          <Skeleton variant="text" className="w-[85%]" />
+          <Skeleton variant="text" className="w-[55%]" />
+          <div className="flex gap-1.5 pt-0.5">
+            <Skeleton className="h-4 w-16 rounded-full" />
+            <Skeleton className="h-4 w-11 rounded-full" />
+            <Skeleton className="h-4 w-14 rounded-full" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-col gap-2 border-t border-dashed border-border pt-3">
+      <p className="text-[9.5px] font-bold uppercase tracking-[0.14em] text-muted-foreground">곧 나올 종합</p>
+      <div className="space-y-2.5 rounded-lg border border-border bg-card p-2.5">
+        {[0, 1].map((i) => (
+          <div key={i} className="flex items-start gap-2">
+            <span className="mt-1.5 size-1.5 shrink-0 rounded-full bg-primary/40" aria-hidden />
+            <div className="flex-1 space-y-1.5">
+              <Skeleton variant="text" className="w-[90%]" />
+              <Skeleton variant="text" className="w-[60%]" />
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        {[0, 1].map((i) => (
+          <div key={i} className="space-y-1.5 rounded-lg border border-border bg-card p-2.5">
+            <Skeleton variant="text" className="w-[70%]" />
+            <Skeleton variant="text" className="h-2 w-[45%]" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/retro/sprint-close-cockpit.test.tsx
+++ b/apps/web/src/components/retro/sprint-close-cockpit.test.tsx
@@ -1,8 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
-import { SprintCloseCockpit } from './sprint-close-cockpit';
+import { createHeuristicStepSchedule, SprintCloseCockpit } from './sprint-close-cockpit';
 import { EvidenceStrip } from './evidence-strip';
 import type { RetroHypothesisResult, RetroNextHypothesis, RetroSynthesis } from '@/services/retro-session';
 
@@ -141,5 +141,60 @@ describe('EvidenceStrip (thin in-progress-stage strip)', () => {
   it('renders dot counts once hypotheses are linked', () => {
     const markup = renderToStaticMarkup(wrap(<EvidenceStrip hypotheses={[VERIFIED, FALSIFIED, MEASURING]} />));
     expect(markup).toContain('가설 현황');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createHeuristicStepSchedule — 까심 QA 적출 test-gap fold(2026-07-03). honest
+// indeterminate 계약의 핵심 회귀막: 6초를 넘겨도 마지막 스텝(stepCount-1)에서 캡되고,
+// 그 이상은 절대 진행하지 않는다(거짓 완료 방지). createAutosaveScheduler(use-doc-sync.ts)와
+// 동형의 순수 스케줄 팩토리 패턴 — React 렌더 없이 fake timer로 직접 검증.
+// ---------------------------------------------------------------------------
+describe('createHeuristicStepSchedule (honest indeterminate 타이머 캡)', () => {
+  beforeEach(() => { vi.useFakeTimers(); });
+  afterEach(() => { vi.useRealTimers(); });
+
+  it('advances to index 1 at 1.2s, then to the last index at 6s (3-step retro synthesis)', () => {
+    const onAdvance = vi.fn();
+    createHeuristicStepSchedule(3, onAdvance);
+
+    vi.advanceTimersByTime(1199);
+    expect(onAdvance).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onAdvance).toHaveBeenCalledTimes(1);
+    expect(onAdvance).toHaveBeenCalledWith(1);
+
+    vi.advanceTimersByTime(6000 - 1200 - 1);
+    expect(onAdvance).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(1);
+    expect(onAdvance).toHaveBeenNthCalledWith(2, 2); // stepCount-1 = 2
+  });
+
+  it('never advances past the last index — no third call even far beyond 6s (거짓 완료 방지, honest 계약 핵심)', () => {
+    const onAdvance = vi.fn();
+    createHeuristicStepSchedule(3, onAdvance);
+
+    vi.advanceTimersByTime(60_000);
+    expect(onAdvance).toHaveBeenCalledTimes(2);
+    expect(onAdvance).toHaveBeenLastCalledWith(2);
+  });
+
+  it('schedules no timers at all for a 1-step surface (sprint-open draft) — stays active immediately, no fake "done" step', () => {
+    const onAdvance = vi.fn();
+    createHeuristicStepSchedule(1, onAdvance);
+
+    vi.advanceTimersByTime(60_000);
+    expect(onAdvance).not.toHaveBeenCalled();
+  });
+
+  it('cancel() stops any pending advance', () => {
+    const onAdvance = vi.fn();
+    const schedule = createHeuristicStepSchedule(3, onAdvance);
+    schedule.cancel();
+
+    vi.advanceTimersByTime(60_000);
+    expect(onAdvance).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/retro/sprint-close-cockpit.tsx
+++ b/apps/web/src/components/retro/sprint-close-cockpit.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Sparkles } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
@@ -8,11 +8,45 @@ import { Button } from '@/components/ui/button';
 import { OperatorTextarea } from '@/components/ui/operator-control';
 import { cn } from '@/lib/utils';
 import { DeltaTrack, fmt } from '@/components/outcome/outcome-result-card';
+import { AiGenerationLoading, type AiGenerationLoadingStep } from '@/components/ai/ai-generation-loading';
 import type {
   RetroHypothesisResult,
   RetroNextHypothesis,
   RetroSynthesis,
 } from '@/services/retro-session';
+
+/**
+ * E-SPRINT-LOOP(81b0d17e) §7 — 스텝 수 = 실 백엔드 phase 수(가짜 phase 발명 금지). retro
+ * synthesize()는 context 수집 + 2 순차 gemini 콜(L2 종합·L3 추천) = 3 스텝. 순서=파이프라인
+ * 순서와 동일(진실). 타이밍은 FE heuristic — 마지막 스텝은 응답 전까지 절대 안 넘어간다.
+ */
+function useSynthesisLoadingSteps(t: ReturnType<typeof useTranslations>): AiGenerationLoadingStep[] {
+  return [
+    { label: t('loadingStep1Label'), desc: t('loadingStep1Desc') },
+    { label: t('loadingStep2Label'), desc: t('loadingStep2Desc') },
+    { label: t('loadingStep3Label'), desc: t('loadingStep3Desc') },
+  ];
+}
+
+/** heuristic advance — 실측 근거 없는 판단값(핸드오프 관찰 ~9초 기준 비례 배분), 라이브 픽셀 시 조정 가능. */
+function useHeuristicStepIndex(generating: boolean, stepCount: number): number {
+  const [index, setIndex] = useState(0);
+  // generating 전환 시 리셋 — render-phase adjustment(SynthesisBlock의 syncedFor와 동일 패턴),
+  // effect body에서 곧바로 setState하지 않도록(react-hooks/set-state-in-effect).
+  const [syncedFor, setSyncedFor] = useState(generating);
+  if (syncedFor !== generating) {
+    setSyncedFor(generating);
+    if (!generating) setIndex(0);
+  }
+  useEffect(() => {
+    if (!generating) return;
+    const timers = stepCount > 1
+      ? [setTimeout(() => setIndex(1), 1200), setTimeout(() => setIndex(stepCount - 1), 6000)]
+      : [];
+    return () => timers.forEach(clearTimeout);
+  }, [generating, stepCount]);
+  return index;
+}
 
 /**
  * E-SPRINT-LOOP FE(1b9f4ecb) — 회고 `closed` 단계 = sprint-close 종합 cockpit.
@@ -132,11 +166,9 @@ function HypothesisCard({ hypothesis }: { hypothesis: RetroHypothesisResult }) {
 
 function SynthesisBlock({
   synthesis,
-  generating,
   onRegenerate,
 }: {
   synthesis: RetroSynthesis;
-  generating: boolean;
   onRegenerate: () => void;
 }) {
   const t = useTranslations('retro');
@@ -185,8 +217,8 @@ function SynthesisBlock({
         <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={() => setEditing((v) => !v)}>
           {editing ? t('synthesisEditDone') : t('synthesisEdit')}
         </Button>
-        <Button variant="outline" size="sm" className="h-6 px-2 text-xs" onClick={onRegenerate} disabled={generating}>
-          {generating ? t('synthesisRegenerating') : t('synthesisRegenerate')}
+        <Button variant="outline" size="sm" className="h-6 px-2 text-xs" onClick={onRegenerate}>
+          {t('synthesisRegenerate')}
         </Button>
       </div>
     </div>
@@ -301,6 +333,8 @@ export function SprintCloseCockpit({
   const [ignoredIndexes, setIgnoredIndexes] = useState<Set<number>>(new Set());
   const [adoptingIndex, setAdoptingIndex] = useState<number | null>(null);
   const [adoptError, setAdoptError] = useState<number | null>(null);
+  const loadingSteps = useSynthesisLoadingSteps(t);
+  const activeStepIndex = useHeuristicStepIndex(generating, loadingSteps.length);
 
   const measuringOnly = hypotheses.length > 0 && hypotheses.every((h) => h.status === 'measuring');
 
@@ -344,20 +378,28 @@ export function SprintCloseCockpit({
         )}
       </div>
 
-      {synthesis ? (
-        <SynthesisBlock synthesis={synthesis} generating={generating} onRegenerate={() => void handleGenerate()} />
+      {generating ? (
+        <AiGenerationLoading
+          headline={t('loadingHeadlineSynthesis')}
+          steps={loadingSteps}
+          activeIndex={activeStepIndex}
+          skeleton="synthesis"
+          transline={t('loadingTranslineSynthesis')}
+        />
+      ) : synthesis ? (
+        <SynthesisBlock synthesis={synthesis} onRegenerate={() => void handleGenerate()} />
       ) : (
         <div className="flex flex-col items-center gap-2.5 rounded-xl border border-dashed border-border bg-muted/20 p-5 text-center">
           <Sparkles className="size-4 text-info" aria-hidden />
           <p className="text-xs text-muted-foreground">{t('synthesisGenerateHint')}</p>
           {generateError ? <p className="text-xs text-destructive">{t('synthesisGenerateFailed')}</p> : null}
-          <Button variant="outline" size="sm" onClick={() => void handleGenerate()} disabled={generating}>
-            {generating ? t('synthesisGenerating') : t('synthesisGenerateCta')}
+          <Button variant="outline" size="sm" onClick={() => void handleGenerate()}>
+            {t('synthesisGenerateCta')}
           </Button>
         </div>
       )}
 
-      {synthesis && nextHypotheses.length > 0 ? (
+      {!generating && synthesis && nextHypotheses.length > 0 ? (
         <div className="space-y-2.5">
           <div className="flex items-center gap-2">
             <Sparkles className="size-3.5 text-info" aria-hidden />

--- a/apps/web/src/components/retro/sprint-close-cockpit.tsx
+++ b/apps/web/src/components/retro/sprint-close-cockpit.tsx
@@ -28,7 +28,21 @@ function useSynthesisLoadingSteps(t: ReturnType<typeof useTranslations>): AiGene
   ];
 }
 
-/** heuristic advance — 실측 근거 없는 판단값(핸드오프 관찰 ~9초 기준 비례 배분), 라이브 픽셀 시 조정 가능. */
+/**
+ * 순수 타이머 스케줄 팩토리(React 비의존 — `use-doc-sync.ts`의 `createAutosaveScheduler`와 동형
+ * 패턴, fake-timer 유닛테스트 용이). 실측 근거 없는 heuristic 판단값(핸드오프 관찰 ~9초 기준
+ * 비례 배분, 라이브 픽셀 시 조정 가능) — 단, **캡(stepCount-1)은 honest 계약의 핵심**: 6초
+ * 이후로는 절대 더 진행하지 않아 응답 도착 전까지 마지막 스텝이 계속 shimmer한다(거짓 완료 방지).
+ */
+export function createHeuristicStepSchedule(stepCount: number, onAdvance: (index: number) => void): { cancel: () => void } {
+  const timers: ReturnType<typeof setTimeout>[] = [];
+  if (stepCount > 1) {
+    timers.push(setTimeout(() => onAdvance(1), 1200));
+    timers.push(setTimeout(() => onAdvance(stepCount - 1), 6000));
+  }
+  return { cancel: () => timers.forEach(clearTimeout) };
+}
+
 function useHeuristicStepIndex(generating: boolean, stepCount: number): number {
   const [index, setIndex] = useState(0);
   // generating 전환 시 리셋 — render-phase adjustment(SynthesisBlock의 syncedFor와 동일 패턴),
@@ -40,10 +54,8 @@ function useHeuristicStepIndex(generating: boolean, stepCount: number): number {
   }
   useEffect(() => {
     if (!generating) return;
-    const timers = stepCount > 1
-      ? [setTimeout(() => setIndex(1), 1200), setTimeout(() => setIndex(stepCount - 1), 6000)]
-      : [];
-    return () => timers.forEach(clearTimeout);
+    const schedule = createHeuristicStepSchedule(stepCount, setIndex);
+    return () => schedule.cancel();
   }, [generating, stepCount]);
   return index;
 }

--- a/apps/web/src/components/sprints/hypothesis-declaration-card.tsx
+++ b/apps/web/src/components/sprints/hypothesis-declaration-card.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import type { Hypothesis, HypothesisDraft, MetricDefinition } from '@sprintable/core-storage';
 import type { ContextPackSearchResult, HypothesisDeclarationValue } from '@/services/hypothesis-declaration';
+import { AiGenerationLoading } from '@/components/ai/ai-generation-loading';
 
 const GA4_METRICS = ['activeUsers', 'newUsers', 'sessions', 'conversions', 'eventCount', 'screenPageViews'] as const;
 const SOURCES: MetricDefinition['source'][] = ['internal_ops', 'ga4', 'manual'];
@@ -122,7 +123,15 @@ export function HypothesisDeclarationCard({
         ) : null}
       </div>
 
-      {value.mode === 'new' ? (
+      {value.mode === 'new' && drafting ? (
+        <AiGenerationLoading
+          headline={t('loadingHeadlineDraft')}
+          steps={[{ label: t('loadingStepDraftLabel'), desc: t('loadingStepDraftDesc') }]}
+          activeIndex={0}
+          skeleton="draft"
+          transline={t('loadingTranslineDraft')}
+        />
+      ) : value.mode === 'new' ? (
         <>
           <div className="flex items-center justify-between gap-2">
             <span className="text-xs font-medium text-muted-foreground">{t('declareStatementLabel')}</span>
@@ -133,7 +142,7 @@ export function HypothesisDeclarationCard({
               className="inline-flex items-center gap-1 rounded-lg border border-dashed border-border px-2 py-0.5 text-[10.5px] font-medium text-muted-foreground transition hover:border-primary hover:text-primary disabled:opacity-50"
             >
               <Sparkles className="size-3" />
-              {drafting ? t('declareDrafting') : t('declareDraftCta')}
+              {t('declareDraftCta')}
             </button>
           </div>
           <textarea


### PR DESCRIPTION
## 요약
핸드오프 `ai-generation-loading-handoff`(`297f1592`) + 렌더 시안 `ai-generation-loading-render`(`5c786c24`) 구현. story `81b0d17e`. gemini-3.1-pro-preview 확정으로 응답 지연 ~9초 — 단순 스피너를 목적성 있는 로딩(지능 사다리 내러티브+결과 스켈레톤)으로 강화해 지각성능을 개선.

## 변경

**공용 컴포넌트 `AiGenerationLoading`** (`apps/web/src/components/ai/ai-generation-loading.tsx`) 신설 — `{headline, steps, activeIndex, skeleton, transline}`. retro 종합 cockpit(3스텝) · sprint-open L3 초안(1스텝) 양쪽 재사용.

## ⭐ Honest 인디터미닛 계약 (§7, 비협상)
- **스텝 수 = 실 백엔드 phase 수** — 가짜 phase 발명 금지. retro `synthesize()`는 context 수집 + 순차 2 gemini 콜(L2+L3) = 3스텝. sprint-open draft는 단일 `generate_text` 콜 = 1스텝(PO가 정직성 델타로 2→1 fold함).
- **순서=진실**(실 파이프라인 순서 그대로) · **타이밍/%=인디터미닛**(슬라이딩 하이라이트, 가짜 진행 % 절대 금지) · **카피=실제 작업**.
- 백엔드 non-streaming → 스텝 advance는 **호출부의 FE heuristic 타이머** 책임(컴포넌트 자체는 순수 렌더만). 응답 도착 전까지 마지막 스텝은 계속 shimmer — 거짓 완료 없음.

## 대상 표면
- `sprint-close-cockpit.tsx` — `handleGenerate` 중(최초 생성+재생성 둘 다) CTA/기존 SynthesisBlock을 3스텝 로딩으로 교체, 완료 시 실 결과로 교체.
- `hypothesis-declaration-card.tsx` — L3 "AI 초안" 트리거 중 폼 필드를 1스텝 로딩+초안 스켈레톤으로 교체.

## 불변식
- SOUL-LOCK 중립(brand/info/muted만·destructive 0) — 유닛테스트로 회귀 가드.
- S28 브랜딩 "✦ Sprintable AI" + 투명성 voice.
- 양테마 · **신규 디자인 토큰 0**(기존 `--skeleton-base`/`--skeleton-highlight` DS-S11 스켈레톤 토큰 그대로 재사용, `globals.css`엔 인디터미닛 바 keyframe 1개만 기존 관례(entrance-spin/skeleton-shimmer 등)와 동일 패턴으로 추가).
- BE 무변경(FE-only, v1 시뮬-honest — SSE 실 phase 스트리밍은 backlog).
- 회귀 0(생성 트리거·완료 후 결과 렌더·실패 에러/fallback 경로 전부 유지).

## 검증
- [x] `tsc --noEmit` 0 errors
- [x] `eslint` 0 errors — `react-hooks/set-state-in-effect` 1건 발견 즉시 fold(`SynthesisBlock`의 기존 `syncedFor` render-phase-adjustment 패턴 재사용해 정정)
- [x] `vitest run` 1071 passed / 2 skipped (회귀 0, 신규 7건 — honest-indeterminate 계약·SOUL-LOCK 가드·1스텝/N스텝 렌더 분기)
- [x] `next build` 성공
- [ ] 라이브 픽셀(실 9초 pro 생성 타이밍 체감) — 다음 게이트(유나 가디언)

## 게이트
PO crux → 유나 정적 가디언(시안 1:1·토큰·양테마) → 까심 크로스모델 QA → 머지 → dev 배포 → 유나 라이브 픽셀. 이 PR은 정적 가디언 이전 단계.

🤖 Generated with [Claude Code](https://claude.com/claude-code)