### PR TITLE
fix(infra): CI realdb gap seal — 93/106 real-DB test files never ran in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,9 @@ jobs:
   alembic-fresh-db:
     name: Alembic upgrade head (fresh DB)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # story 8236bbc3(2026-07-03): 217초 실측(전체 스위트 3391개 대다수, 비파괴 real-DB 84개
+    # 파일 포함) + 파괴적 54개 파일 격리 순회 오버헤드 버퍼. 규모상 샤딩 불요(설계 §1-D).
+    timeout-minutes: 20
 
     services:
       postgres:
@@ -33,6 +35,15 @@ jobs:
           --health-timeout 5s
           --health-retries 10
 
+    # story 8236bbc3: job 레벨로 승격(기존 스텝마다 중복 선언되던 5개 env var 통합) — 이 job의
+    # 모든 pytest 호출(비파괴/파괴 공통)이 동일 자격증명을 쓴다.
+    env:
+      ALEMBIC_DATABASE_URL: postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test
+      PARITY_TEST_DATABASE_URL: postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test
+      DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
+      JWT_SECRET: ci-test-secret-at-least-32-chars-long
+      SECRET_KEY: ci-test-secret-at-least-32-chars-long
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,23 +57,7 @@ jobs:
       # and stamps revision 0096. This is the exact path a freshly-wiped prod takes.
       - name: alembic upgrade head (fresh DB → baseline)
         working-directory: backend
-        env:
-          ALEMBIC_DATABASE_URL: postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test
-          DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
-          JWT_SECRET: ci-test-secret-at-least-32-chars-long
-          SECRET_KEY: ci-test-secret-at-least-32-chars-long
         run: uv run alembic upgrade head
-
-      # 멀티계정 auth 보안 테스트는 real-DB 필수(backend-test 잡엔 PG 없음). 이 회귀(끝단 검증 부족)
-      # 재발 방지 위해 PG 백드 잡에서 실행 — auth resolve/switch IDOR/replay 회귀를 CI 가 가드.
-      - name: account resolve/switch real-DB tests
-        working-directory: backend
-        env:
-          ALEMBIC_DATABASE_URL: postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test
-          DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
-          JWT_SECRET: ci-test-secret-at-least-32-chars-long
-          SECRET_KEY: ci-test-secret-at-least-32-chars-long
-        run: uv run pytest tests/test_account_resolve_realdb.py -q
 
       - name: Verify tables created
         run: |
@@ -88,21 +83,18 @@ jobs:
           test "$(P "SELECT count(*) FROM pg_constraint WHERE conname='ck_asset_links_source_type'")" = "1"
           echo "baseline parity OK: team_members=VIEW, org_member_id nullable, seed present, 0097 applied, asset registry present, REVISION=0096"
 
-      # E-STORAGE-SSOT: asset registry IDOR/정합 게이트는 real-DB 가 필수(backend-test 잡엔 PG 없음).
-      # 이 PG 백드 잡에서 실행해 S2~S8 IDOR/멀티테넌시 회귀를 CI 가 잡도록 박는다(까심#4).
-      - name: asset registry real-DB tests (IDOR / sync / backfill / authorize)
+      # story 8236bbc3: 기존 "account resolve/switch"(1개 파일)·"asset registry"(13개 파일)
+      # 하드코딩 리스트 2스텝을 흡수 — real-DB 게이팅(ALEMBIC_DATABASE_URL/PARITY_TEST_DATABASE_URL)
+      # 전체(파일명 무관, destructive_schema 마커 제외 84개 파일)가 자기 skipif로 자동 활성화된다.
+      # 신규 real-DB 테스트 파일은 이 스텝에 아무것도 안 해도 자동 편입(누락 원천차단).
+      # test_member_ssot_parity_realdb.py는 파일 자체 무조건 skip(post-cutover 불일치 — 파일
+      # 상단 주석·design-ci-realdb-gap-8236bbc3 §1 참고).
+      - name: Real-DB tests (non-destructive, auto-discovered via marker)
         working-directory: backend
-        env:
-          ALEMBIC_DATABASE_URL: postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test
-          DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
-          JWT_SECRET: ci-test-secret-at-least-32-chars-long
-          SECRET_KEY: ci-test-secret-at-least-32-chars-long
-        run: uv run pytest tests/test_asset_registry_realdb.py tests/test_asset_canonical.py tests/test_attachment_authorize_asset_s3.py tests/test_conv_human_participant_realdb.py tests/test_doc_asset_backfill_realdb.py tests/test_release_notes_realdb.py tests/test_audit_apikey_parity_realdb.py tests/test_doc_gate_cascade_scope_realdb.py tests/test_doc_mutation_project_scope_idor_realdb.py tests/test_retro_mutation_project_scope_idor_realdb.py tests/test_retro_voted_by_me_realdb.py tests/test_retro_grouping_vote_count_realdb.py tests/test_retro_phase_transitions_realdb.py -q
+        run: uv run pytest -q -m "not destructive_schema"
 
       - name: Verify fresh DB reached head (baseline + incremental)
         working-directory: backend
-        env:
-          ALEMBIC_DATABASE_URL: postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test
         run: |
           set -e
           cur=$(uv run alembic current 2>/dev/null | grep -oE '^[0-9a-z_]+' | head -1)
@@ -114,11 +106,6 @@ jobs:
       # (The fresh-DB run above already advanced this DB to head via baseline + incremental.)
       - name: Existing-DB no-op (re-run upgrade head)
         working-directory: backend
-        env:
-          ALEMBIC_DATABASE_URL: postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test
-          DATABASE_URL: postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test
-          JWT_SECRET: ci-test-secret-at-least-32-chars-long
-          SECRET_KEY: ci-test-secret-at-least-32-chars-long
         run: |
           set -e
           out=$(uv run alembic upgrade head 2>&1); echo "$out"
@@ -127,14 +114,43 @@ jobs:
           fi
           echo "OK: existing-DB upgrade head is a no-op"
 
-      # NOTE: the member-ssot real-DB parity test (tests/test_member_ssot_parity_realdb.py) was
-      # removed from this gate. It validated the legacy→anchor *dual-write transition* and only
-      # ever ran against the create_all schema (team_members as a writable table). The baseline
-      # captures the COMPLETED cutover, where team_members is a read-only VIEW projecting the
-      # anchor tables (members + project_access + agent_project_profiles) with no INSTEAD OF
-      # triggers — so its fixtures (INSERT INTO team_members, agents without agent_config) are
-      # structurally incompatible. The view definition now guarantees the parity invariant by
-      # construction. Rewriting this test for the post-cutover schema is tracked as follow-up.
+      # story 8236bbc3: destructive_schema 마커 파일(Base.metadata.create_all/drop_all로 자체
+      # 스키마 직접 관리)은 위 alembic-migrated 공유 DB(sprintable_test)에서 절대 실행하지
+      # 않는다 — 실측(design doc §1-C): 단 1개 파일의 drop_all()이 DROP TABLE
+      # agent_project_profiles→ForeignKeyViolationError로 DB를 오염시키고 같은 세션 후속
+      # 테스트 전부가 연쇄 실패(116건). 파일마다 독립 throwaway DB(sprintable_test_iso)로
+      # 완전 격리 — sprintable_test는 절대 건드리지 않는다.
+      - name: Real-DB tests (destructive schema — isolated fresh DB per file)
+        working-directory: backend
+        run: |
+          set -uo pipefail
+          # ⭐set -e를 여기선 안 쓴다(로컬 e2e 시뮬레이션 실측 교훈, 2026-07-03) — 파일별
+          # 루프에서 첫 실패 파일이 스크립트를 즉시 죽이면 나머지 파일은 전혀 실행되지 않고
+          # 조용히 스킵된 것과 동일한 결과가 된다(이 스토리가 막으려는 바로 그 실패 유형).
+          # 전체 파일을 끝까지 돌리고 실패를 누적, 마지막에 하나라도 있으면 exit 1.
+          mapfile -t files < <(
+            uv run pytest -q -m destructive_schema --collect-only \
+              | grep -oE '^tests/[a-zA-Z0-9_]+\.py' | sort -u
+          )
+          echo "destructive files: ${#files[@]}"
+          failed_files=()
+          for f in "${files[@]}"; do
+            echo "::group::isolated $f"
+            PGPASSWORD=sprintable dropdb -h localhost -U sprintable --if-exists sprintable_test_iso
+            PGPASSWORD=sprintable createdb -h localhost -U sprintable sprintable_test_iso
+            PGPASSWORD=sprintable psql -h localhost -U sprintable -d sprintable_test_iso \
+              -c 'CREATE EXTENSION IF NOT EXISTS vector;'
+            ALEMBIC_DATABASE_URL=postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test_iso \
+            PARITY_TEST_DATABASE_URL=postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test_iso \
+            DATABASE_URL=postgresql+asyncpg://sprintable:sprintable@localhost:5432/sprintable_test_iso \
+            uv run pytest -q "$f" || failed_files+=("$f")
+            echo "::endgroup::"
+          done
+          if [ "${#failed_files[@]}" -gt 0 ]; then
+            echo "FAILED files: ${failed_files[*]}"
+            exit 1
+          fi
+          echo "OK: all ${#files[@]} isolated destructive-schema files passed"
 
   backend-test:
     name: Backend pytest

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -50,3 +50,6 @@ dev = [
 asyncio_mode = "auto"
 testpaths = ["tests"]
 timeout = 30
+markers = [
+    "destructive_schema: module calls Base.metadata.create_all()/drop_all() directly to build/tear down its own schema — must run against an isolated throwaway DB, never the shared alembic-migrated baseline DB (drop_all issues DROP TABLE against objects that are VIEWs in baseline, e.g. team_members, and corrupts the DB for every later test in the same session). See story 8236bbc3 / docs/design-ci-realdb-gap-8236bbc3.",
+]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,8 @@
 """Shared pytest fixtures for backend tests."""
+import ast
 import os
 import uuid
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -8,6 +10,49 @@ from httpx import ASGITransport, AsyncClient
 
 # 테스트 환경 기본 환경변수
 os.environ.setdefault("JWT_SECRET", "test-secret-key-for-pytest-only")
+
+
+# story 8236bbc3: destructive_schema 마커 drift 자기표면화 가드(PO crux 게이트②, 2026-07-03).
+# 마커 부여 자체는 수동이라(하드코딩 파일리스트와 동일 클래스의 drift 위험) 이 가드가 없으면
+# "새 create_all/drop_all 테스트가 마커 없이 들어오면?" 질문에 "alembic-fresh-db job에서 공유
+# DB를 오염시켜 무관한 다른 테스트가 연쇄 실패하는 간접 신호"로만 답할 수 있었다(실측: 파일 1개의
+# 누락이 116건 연쇄 실패로 나타남 — loud하지만 원인 파일을 바로 못 짚는 혼란스러운 실패). 이
+# 가드는 collection 시점에 AST로 create_all/drop_all 호출(`X.metadata.create_all` 형태 —
+# `conn.run_sync(Base.metadata.create_all)`처럼 콜백으로 전달되는 경우도 Attribute 노드로 잡힘)을
+# 정적 스캔해 마커 누락을 즉시·정확한 파일명으로 표면화한다(로컬 개발 시점에도 동일하게 발동 —
+# CI까지 갈 필요도 없음).
+_DESTRUCTIVE_ATTRS = {"create_all", "drop_all"}
+_MARKER_NAME = "destructive_schema"
+
+
+def _calls_destructive_schema_api(filepath: Path) -> bool:
+    try:
+        tree = ast.parse(filepath.read_text(encoding="utf-8"))
+    except (SyntaxError, OSError, UnicodeDecodeError):
+        return False
+    return any(
+        isinstance(node, ast.Attribute) and node.attr in _DESTRUCTIVE_ATTRS
+        for node in ast.walk(tree)
+    )
+
+
+def pytest_collection_modifyitems(items: list) -> None:
+    checked: dict[Path, bool] = {}
+    violations: set[str] = set()
+    for item in items:
+        filepath = Path(str(item.fspath))
+        if filepath not in checked:
+            checked[filepath] = _calls_destructive_schema_api(filepath)
+        if checked[filepath] and _MARKER_NAME not in {m.name for m in item.iter_markers()}:
+            violations.add(str(filepath))
+    if violations:
+        raise pytest.UsageError(
+            "다음 테스트 파일이 Base.metadata.create_all/drop_all을 호출하지만 "
+            f"@pytest.mark.{_MARKER_NAME} 마커가 없습니다(alembic-migrated 공유 DB를 오염시켜 "
+            "무관한 테스트를 연쇄 실패시킬 수 있음 — story 8236bbc3). 파일 최상단에 "
+            f"`pytestmark = pytest.mark.{_MARKER_NAME}` 를 추가하세요:\n"
+            + "\n".join(sorted(violations))
+        )
 
 
 @pytest.fixture

--- a/backend/tests/test_claim_participation.py
+++ b/backend/tests/test_claim_participation.py
@@ -13,9 +13,12 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
-pytestmark = pytest.mark.skipif(
-    not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)"
-)
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)"),
+    pytest.mark.destructive_schema,
+]
 
 
 @pytest.fixture

--- a/backend/tests/test_cron_retry_dry_run.py
+++ b/backend/tests/test_cron_retry_dry_run.py
@@ -13,9 +13,12 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
-pytestmark = pytest.mark.skipif(
-    not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)"
-)
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)"),
+    pytest.mark.destructive_schema,
+]
 
 
 @pytest.fixture

--- a/backend/tests/test_doc_gate_cascade_scope_realdb.py
+++ b/backend/tests/test_doc_gate_cascade_scope_realdb.py
@@ -15,6 +15,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_e_loop_ledger_p1_s11_dispatch_context_pack_realdb.py
+++ b/backend/tests/test_e_loop_ledger_p1_s11_dispatch_context_pack_realdb.py
@@ -19,6 +19,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_e_loop_ledger_p1_s12_context_pack_items_realdb.py
+++ b/backend/tests/test_e_loop_ledger_p1_s12_context_pack_items_realdb.py
@@ -15,6 +15,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 ORG = uuid.uuid4()
 PROJECT = uuid.uuid4()
 

--- a/backend/tests/test_e_loop_ledger_p1_s3_embed_backlog_realdb.py
+++ b/backend/tests/test_e_loop_ledger_p1_s3_embed_backlog_realdb.py
@@ -14,6 +14,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_e_loop_ledger_p1_s3f_poison_pill_terminal.py
+++ b/backend/tests/test_e_loop_ledger_p1_s3f_poison_pill_terminal.py
@@ -22,6 +22,10 @@ from app.services import embedding_backlog as backlog
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_e_loop_ledger_p1_s3g_score_hypotheses_savepoint_realdb.py
+++ b/backend/tests/test_e_loop_ledger_p1_s3g_score_hypotheses_savepoint_realdb.py
@@ -16,6 +16,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_e_loop_ledger_p1_s5_embedding_backfill_realdb.py
+++ b/backend/tests/test_e_loop_ledger_p1_s5_embedding_backfill_realdb.py
@@ -14,6 +14,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_e_loop_ledger_p1_s6_context_pack_search_realdb.py
+++ b/backend/tests/test_e_loop_ledger_p1_s6_context_pack_search_realdb.py
@@ -14,6 +14,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_e_loop_ledger_s26_context_pack_synthesis.py
+++ b/backend/tests/test_e_loop_ledger_s26_context_pack_synthesis.py
@@ -35,6 +35,10 @@ from app.services.context_pack_items import (
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_e_loop_ledger_s27_context_pack_recommendation.py
+++ b/backend/tests/test_e_loop_ledger_s27_context_pack_recommendation.py
@@ -26,6 +26,10 @@ from app.services.context_pack_items import _build_recommendation_prompt, _recom
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_edg_batch_line_status.py
+++ b/backend/tests/test_edg_batch_line_status.py
@@ -12,6 +12,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_edg_s10_status_api.py
+++ b/backend/tests/test_edg_s10_status_api.py
@@ -12,6 +12,10 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
 _NOW = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
 
 

--- a/backend/tests/test_edg_s12be_recipient_fallback.py
+++ b/backend/tests/test_edg_s12be_recipient_fallback.py
@@ -12,6 +12,10 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
 _NOTIFY = "app.services.notification_dispatch.dispatch_notification"
 
 

--- a/backend/tests/test_edg_s13_sla_processor.py
+++ b/backend/tests/test_edg_s13_sla_processor.py
@@ -14,6 +14,10 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
 _NOW = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
 _NOTIFY = "app.services.notification_dispatch.dispatch_notification"
 

--- a/backend/tests/test_edg_s14_role_resolver.py
+++ b/backend/tests/test_edg_s14_role_resolver.py
@@ -12,6 +12,10 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
 _NOW = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
 
 

--- a/backend/tests/test_edg_s15_metrics.py
+++ b/backend/tests/test_edg_s15_metrics.py
@@ -12,6 +12,10 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
 _NOW = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
 
 

--- a/backend/tests/test_edg_s16_seed.py
+++ b/backend/tests/test_edg_s16_seed.py
@@ -11,6 +11,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_edg_s17_recall.py
+++ b/backend/tests/test_edg_s17_recall.py
@@ -12,6 +12,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_edg_s18_runtime_mode.py
+++ b/backend/tests/test_edg_s18_runtime_mode.py
@@ -12,6 +12,10 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
 _NOW = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
 
 

--- a/backend/tests/test_edg_s19_grandfather.py
+++ b/backend/tests/test_edg_s19_grandfather.py
@@ -12,6 +12,10 @@ from datetime import datetime, timezone
 import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
 _NOW = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
 
 

--- a/backend/tests/test_edg_s22_doc_overlay.py
+++ b/backend/tests/test_edg_s22_doc_overlay.py
@@ -12,6 +12,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_edg_s23_hypothesis_overlay.py
+++ b/backend/tests/test_edg_s23_hypothesis_overlay.py
@@ -13,6 +13,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_edg_s25_epic_overlay.py
+++ b/backend/tests/test_edg_s25_epic_overlay.py
@@ -12,6 +12,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_edg_s26_sprint_overlay.py
+++ b/backend/tests/test_edg_s26_sprint_overlay.py
@@ -13,6 +13,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_edg_s28_doc_resubmit.py
+++ b/backend/tests/test_edg_s28_doc_resubmit.py
@@ -15,7 +15,12 @@ from app.services.doc import transition_doc
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
-pytestmark = pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요"),
+    pytest.mark.destructive_schema,
+]
 
 
 @pytest.fixture

--- a/backend/tests/test_edg_s29_dryrun_preview.py
+++ b/backend/tests/test_edg_s29_dryrun_preview.py
@@ -16,6 +16,10 @@ from app.services.workflow_line_engine import LineDecision
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_edg_s2_config_governance.py
+++ b/backend/tests/test_edg_s2_config_governance.py
@@ -20,6 +20,10 @@ from app.services.workflow_line_config import (
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_edg_s30_void_recovery.py
+++ b/backend/tests/test_edg_s30_void_recovery.py
@@ -15,6 +15,10 @@ from app.models.gate import GATE_STATUSES, is_valid_transition
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_edg_s31_hold.py
+++ b/backend/tests/test_edg_s31_hold.py
@@ -16,6 +16,10 @@ from app.models.gate import GATE_STATUSES, is_valid_transition
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_edg_s32_reassign.py
+++ b/backend/tests/test_edg_s32_reassign.py
@@ -13,6 +13,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_edg_s33_override.py
+++ b/backend/tests/test_edg_s33_override.py
@@ -15,6 +15,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_edg_s34_line_versions.py
+++ b/backend/tests/test_edg_s34_line_versions.py
@@ -13,6 +13,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_edg_s3_engine.py
+++ b/backend/tests/test_edg_s3_engine.py
@@ -15,6 +15,10 @@ from app.services.workflow_line_engine import LineDecision
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():
@@ -112,6 +116,7 @@ async def test_off_mode_plain():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 @pytest.mark.anyio
+@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락 — 형제 파일(test_edg_s18/s19/s29)은 True로 patch하는데 이 파일은 안 함, default-off라 항상 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출 (파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
 async def test_shadow_mode_records_step_run_but_proceeds():
     from app.services.workflow_line_engine import evaluate_line_for_transition
     from app.models.workflow_line import WorkflowLineStepRun
@@ -134,6 +139,7 @@ async def test_shadow_mode_records_step_run_but_proceeds():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 @pytest.mark.anyio
+@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락 — 형제 파일(test_edg_s18/s19/s29)은 True로 patch하는데 이 파일은 안 함, default-off라 항상 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출 (파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
 async def test_enforcing_static_block_blocked_by_policy():
     from app.services.workflow_line_engine import evaluate_line_for_transition
     engine, Session = await _engine_session()
@@ -153,6 +159,7 @@ async def test_enforcing_static_block_blocked_by_policy():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 @pytest.mark.anyio
+@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락 — 형제 파일(test_edg_s18/s19/s29)은 True로 patch하는데 이 파일은 안 함, default-off라 항상 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출 (파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
 async def test_fault_injection_engine_failure_degrades_to_plain():
     """⭐P0-1: 엔진 내부 예외 → engine_failed + degraded_to_plain → 전이 진행(proceeds=True)."""
     from app.services import workflow_line_engine as eng
@@ -182,6 +189,7 @@ async def test_fault_injection_engine_failure_degrades_to_plain():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 @pytest.mark.anyio
+@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락 — 형제 파일(test_edg_s18/s19/s29)은 True로 patch하는데 이 파일은 안 함, default-off라 항상 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출 (파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
 async def test_step_run_flush_failure_savepoint_does_not_poison_session():
     """⭐P0-1(레드팀 적출): step_run insert flush 실패(active partial unique 충돌=double-fire)가
     outer 트랜잭션을 poison하면 안 된다. SAVEPOINT 격리로 outer tx 보존 → 후속 set_status/commit 정상.

--- a/backend/tests/test_edg_s4_resolver.py
+++ b/backend/tests/test_edg_s4_resolver.py
@@ -14,6 +14,10 @@ from app.services.workflow_line_resolver import _risk_flags, _story_predicate
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():
@@ -143,6 +147,7 @@ async def test_routing_context_non_story_unsupported():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
+@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락(형제 s18/s19/s29 패턴 미적용) — default-off라 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출(파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
 async def test_engine_shadow_records_routing_context_and_trust():
     """S3 엔진 shadow 경로가 S4 resolver 산출(routing_context+trust_snapshot)을 step_run 에 기록."""
     from sqlalchemy import select
@@ -183,6 +188,7 @@ async def test_engine_shadow_records_routing_context_and_trust():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
+@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락(형제 s18/s19/s29 패턴 미적용) — default-off라 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출(파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
 async def test_actor_propagates_to_step_run_snapshot():
     """⭐SME blocking 회귀: 엔진에 actor_id/actor_type 을 넘기면 resolver→step_run.routing_context.actor
     까지 전파돼야 한다(라우터가 actor 미전달 시 항상 no_member 로 고정되던 통합 갭). actor.member_id 가

--- a/backend/tests/test_edg_s5_merge_gate.py
+++ b/backend/tests/test_edg_s5_merge_gate.py
@@ -14,6 +14,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():
@@ -60,6 +64,7 @@ def _decision(decision, gate_id):
 # ── line_merge_gate_active (라우터 skip 판정) ─────────────────────────────────
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
+@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락(형제 s18/s19/s29 패턴 미적용) — default-off라 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출(파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
 async def test_line_merge_gate_active_only_for_enforcing_merge_gate():
     from app.services.workflow_line_engine import line_merge_gate_active
     engine, Session = await _session()
@@ -85,6 +90,7 @@ async def test_line_merge_gate_active_only_for_enforcing_merge_gate():
 # ── wrapper decision 매핑 (evaluate_merge_gate patch로 결정 격리) ─────────────
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
+@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락(형제 s18/s19/s29 패턴 미적용) — default-off라 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출(파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
 async def test_merge_gate_wrapper_ask_human_uses_h1_gate_no_double():
     from sqlalchemy import func, select
     from app.services import workflow_line_engine as eng
@@ -115,6 +121,7 @@ async def test_merge_gate_wrapper_ask_human_uses_h1_gate_no_double():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
+@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락(형제 s18/s19/s29 패턴 미적용) — default-off라 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출(파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
 async def test_merge_gate_wrapper_auto_merge_and_block():
     from app.services import workflow_line_engine as eng
     from app.services.merge_verdict_gate import AUTO_MERGE, BLOCK
@@ -138,6 +145,7 @@ async def test_merge_gate_wrapper_auto_merge_and_block():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
+@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락(형제 s18/s19/s29 패턴 미적용) — default-off라 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출(파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
 async def test_merge_gate_wrapper_failopen():
     """⭐S3 fail-open 보존: merge-gate 평가(evaluate_merge_gate) 예외도 engine_failed→plain(전이 진행)."""
     from app.services import workflow_line_engine as eng
@@ -155,6 +163,7 @@ async def test_merge_gate_wrapper_failopen():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
+@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락(형제 s18/s19/s29 패턴 미적용) — default-off라 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출(파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
 async def test_merge_gate_audit_persists_after_raise_commit():
     """⭐SME blocking 회귀: gate_pending(라우터가 raise 前 db.commit) 후 engine 이 만든 step_run audit
     이 살아남아야 한다. commit 없이 raise 하면 get_db rollback 으로 사라지던 갭."""

--- a/backend/tests/test_edg_s6_gate_hook.py
+++ b/backend/tests/test_edg_s6_gate_hook.py
@@ -14,6 +14,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_edg_s7_handoff_relay.py
+++ b/backend/tests/test_edg_s7_handoff_relay.py
@@ -13,6 +13,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():
@@ -166,6 +170,7 @@ async def test_relay_db_poison_isolated_by_savepoint():
 # ── 엔진 relay 플래그 (enforcing agent-handoff만) ────────────────────────────
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
+@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락(형제 s18/s19/s29 패턴 미적용) — default-off라 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출(파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
 async def test_engine_sets_relay_only_for_enforcing_agent_handoff():
     from app.services.workflow_line_engine import evaluate_line_for_transition
     from app.models.workflow_line import WorkflowLineDefinition, WorkflowLineDefinitionVersion

--- a/backend/tests/test_edg_s8_watchdog.py
+++ b/backend/tests/test_edg_s8_watchdog.py
@@ -13,6 +13,10 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
 _NOW = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
 
 

--- a/backend/tests/test_edg_s9_parallel_quorum.py
+++ b/backend/tests/test_edg_s9_parallel_quorum.py
@@ -12,6 +12,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_event1config_ack_retire.py
+++ b/backend/tests/test_event1config_ack_retire.py
@@ -85,6 +85,7 @@ _requires_db = pytest.mark.skipif(
 
 
 @_requires_db
+@pytest.mark.xfail(strict=False, reason="story 8236bbc3 e2e 시뮬레이션서 order-dependent 플레이키 확인(84파일 풀런서만 간헐 실패 — 공유DB 상태 의존 의심). story 18eefc31 트래킹.")
 @pytest.mark.anyio
 async def test_ack_retire_semantics_realdb():
     """<=seq pending → delivered, >seq 유지, 재-ack idempotent."""

--- a/backend/tests/test_event1config_expire_cron.py
+++ b/backend/tests/test_event1config_expire_cron.py
@@ -71,6 +71,7 @@ _requires_db = pytest.mark.skipif(
 
 
 @_requires_db
+@pytest.mark.xfail(strict=False, reason="asyncpg 'attached to a different loop' RuntimeError — story 8236bbc3 e2e 시뮬레이션서 신규 노출(격리 재현 확인). story 18eefc31 트래킹.")
 @pytest.mark.anyio
 async def test_global_cleanup_recovers_delivered_across_orgs_realdb():
     """전 org cleanup: 7일 초과 delivered 삭제(ACK retire 회수)·org 무관."""

--- a/backend/tests/test_event1config_webhook_targets.py
+++ b/backend/tests/test_event1config_webhook_targets.py
@@ -115,6 +115,7 @@ _requires_db = pytest.mark.skipif(
 
 
 @_requires_db
+@pytest.mark.xfail(strict=False, reason="asyncpg 'attached to a different loop' RuntimeError — story 8236bbc3 e2e 시뮬레이션서 신규 노출(격리 재현 확인, 세션결합 아티팩트 아님). story 18eefc31 트래킹.")
 @pytest.mark.anyio
 async def test_resolve_predicate_realdb():
     """실DB: member-bound project-독립 union·sender 제외·broadcast 포함."""

--- a/backend/tests/test_gateway_realdb_race.py
+++ b/backend/tests/test_gateway_realdb_race.py
@@ -83,6 +83,7 @@ async def _scan_events(conn, recipient_id: uuid.UUID, after_seq: int) -> list[in
 
 # ─── 핵심 race 테스트 ─────────────────────────────────────────────────────────
 
+@pytest.mark.xfail(strict=False, reason="ForeignKeyViolationError(events.project_id) — story 8236bbc3 e2e 시뮬레이션서 신규 노출, 실 동시성 버그 의심(PO: prod 우려·최우선 조사 대상). story 18eefc31 트래킹.")
 @pytest.mark.anyio
 async def test_acked_seq_rescan_catches_low_seq_late_commit():
     """실 DB race: T1(낮은 seq, 늦게 커밋) → acked_seq 재스캔에서 반드시 잡힘.
@@ -188,6 +189,7 @@ async def test_acked_seq_rescan_catches_low_seq_late_commit():
         await scan_conn.close()
 
 
+@pytest.mark.xfail(strict=False, reason="ForeignKeyViolationError(events.project_id) — story 8236bbc3 e2e 시뮬레이션서 신규 노출, 실 동시성 버그 의심(PO: prod 우려·최우선 조사 대상). story 18eefc31 트래킹.")
 @pytest.mark.anyio
 async def test_rescan_from_acked_seq_not_max_sent():
     """max-advance vs acked_seq 재스캔 동작 대비 명시 검증.
@@ -234,6 +236,7 @@ async def test_rescan_from_acked_seq_not_max_sent():
         await conn.close()
         await setup_conn.close()
 
+@pytest.mark.xfail(strict=False, reason="ForeignKeyViolationError(events.project_id) — story 8236bbc3 e2e 시뮬레이션서 신규 노출, 실 동시성 버그 의심(PO: prod 우려·최우선 조사 대상). story 18eefc31 트래킹.")
 @pytest.mark.anyio
 async def test_per_recipient_dense_seq_prevents_ack_ordering_gap():
     """AC3: per-recipient dense seq → ack-후-늦커밋 gap 구조적 불가.

--- a/backend/tests/test_h1_fix2_approve_advances_done.py
+++ b/backend/tests/test_h1_fix2_approve_advances_done.py
@@ -16,6 +16,10 @@ from app.services.gate_service import _advance_story_on_merge_approve
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_h1_s10_e2e.py
+++ b/backend/tests/test_h1_s10_e2e.py
@@ -16,6 +16,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():
@@ -23,6 +27,7 @@ def anyio_backend():
 
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.xfail(strict=False, reason="clean_pass_rate가 None(기대 non-None) — trust 계산 seed/calibration 갭 의심. story 8236bbc3 e2e서 신규 노출(파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
 @pytest.mark.anyio
 async def test_h1_end_to_end_ready_to_done():
     from sqlalchemy import text as _text

--- a/backend/tests/test_h1_s7_gate_verdict.py
+++ b/backend/tests/test_h1_s7_gate_verdict.py
@@ -17,6 +17,10 @@ from app.services import gate_service as gs
 from app.services.gate_service import _record_gate_review_verdict
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
 ORG = uuid.uuid4()
 
 
@@ -136,6 +140,7 @@ async def test_fast_reject_not_rubber_stamp():
 # ── AC④: 실DB — 사람 review verdict가 trust score에 반영 ───────────────────────
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.xfail(strict=False, reason="clean_pass_rate가 None(기대 1.0) — trust 계산 seed/calibration 갭 의심(test_h1_s10_e2e와 동일 클래스). story 8236bbc3 e2e서 신규 노출. story 18eefc31 트래킹.")
 @pytest.mark.anyio
 async def test_human_review_verdict_reflected_in_trust_real_db():
     from sqlalchemy import text as _text

--- a/backend/tests/test_h1_s9_merge_gate_metrics.py
+++ b/backend/tests/test_h1_s9_merge_gate_metrics.py
@@ -14,6 +14,10 @@ from app.services.merge_gate_metrics import _ratio, compute_merge_gate_metrics
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_ho_gate_done_side_effects.py
+++ b/backend/tests/test_ho_gate_done_side_effects.py
@@ -15,9 +15,12 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
-pytestmark = pytest.mark.skipif(
-    not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)"
-)
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)"),
+    pytest.mark.destructive_schema,
+]
 
 
 @pytest.fixture

--- a/backend/tests/test_ho_s1_score_hypotheses_smoke.py
+++ b/backend/tests/test_ho_s1_score_hypotheses_smoke.py
@@ -14,6 +14,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_ho_s2_outcome_verdict.py
+++ b/backend/tests/test_ho_s2_outcome_verdict.py
@@ -22,6 +22,10 @@ from app.services.hypothesis_outcome_verdict import (
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_ho_s3_hypothesis_owner_seed.py
+++ b/backend/tests/test_ho_s3_hypothesis_owner_seed.py
@@ -25,6 +25,7 @@ def _load_migration():
 
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.xfail(strict=False, reason="NotNullViolation(organizations.name) — story 8236bbc3 e2e 시뮬레이션서 신규 노출(격리 재현 확인). story 18eefc31 트래킹.")
 def test_seed_hypothesis_owner_per_org_idempotent():
     import sqlalchemy as sa
     from alembic.operations import Operations

--- a/backend/tests/test_ho_s4_scorer_verdict_wiring.py
+++ b/backend/tests/test_ho_s4_scorer_verdict_wiring.py
@@ -17,6 +17,10 @@ from app.services import hypothesis_scorer as sc
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_ho_s7_cold_start_seed.py
+++ b/backend/tests/test_ho_s7_cold_start_seed.py
@@ -16,6 +16,10 @@ from app.services.cold_start_seed import SEED_SOURCE, _is_cold_start, record_col
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_ho_s9_e2e_closed_loop.py
+++ b/backend/tests/test_ho_s9_e2e_closed_loop.py
@@ -22,9 +22,12 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
-pytestmark = pytest.mark.skipif(
-    not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)"
-)
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)"),
+    pytest.mark.destructive_schema,
+]
 
 _PAST = datetime(2026, 6, 1, tzinfo=timezone.utc)
 

--- a/backend/tests/test_l1_consume_helpers.py
+++ b/backend/tests/test_l1_consume_helpers.py
@@ -53,6 +53,7 @@ async def _session():
     return engine, async_sessionmaker(engine, expire_on_commit=False)
 
 
+@pytest.mark.xfail(strict=False, reason="story 8236bbc3 e2e 시뮬레이션서 order-dependent 플레이키 확인(소배치 격리서는 통과·84파일 풀런서만 실패 — 공유DB 상태 의존 의심). story 18eefc31 트래킹.")
 async def test_poll_activities_after_seq_cursor_and_org_scope():
     from sqlalchemy import select
 

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -3,8 +3,16 @@
 legacy(org_members/team_members) vs anchor(members/aliases) resolver를 **동일 실 데이터**로
 대조해 0-diff 입증. mocked로는 못 잡는 실데이터 정합(orphan·멀티프로젝트·휴먼 name)을 검증.
 
-DB env(ALEMBIC_DATABASE_URL 또는 PARITY_TEST_DATABASE_URL) 없으면 skip — CI alembic-fresh-db
-잡(postgres + alembic upgrade head)에서 실행되며, 로컬은 throwaway PG로 실행.
+story 8236bbc3(2026-07-03, PO crux 확인): 이 파일은 CI에서 **의도적으로 제외**한다(silent
+아님 — design-ci-realdb-gap-8236bbc3 §1 참고). legacy(org_members/team_members 직접 write)
+↔ anchor(members/aliases) dual-write **전환 기간**을 검증하던 parity 테스트인데, 그 전환은
+이미 완료됐다 — baseline은 `team_members`를 앵커 테이블(members+project_access+
+agent_project_profiles) 위의 **읽기전용 VIEW**로 제공하고(INSTEAD OF 트리거 없음), 이
+파일의 픽스처(`INSERT INTO team_members` 등)는 VIEW에 직접 쓰기 시도라 구조적으로
+불가능하다. 즉 "cutover 완료로 obsolete"이지 "진짜 사각"이 아니다 — 이 파일이 원래
+검증하던 정합 불변식은 이제 VIEW 정의 자체가 구조적으로 보장한다(런타임 재검증 불요).
+스토리 8236bbc3 스코프 밖 — 포스트-컷오버 스키마로 재작성하거나 폐기하는 follow-up으로
+추적(기존 파일 유지, 무조건 skip으로 명시).
 """
 from __future__ import annotations
 
@@ -21,7 +29,11 @@ _ASYNC_URL = _RAW_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://")
     "postgresql://", "postgresql+asyncpg://"
 )
 
-pytestmark = pytest.mark.skipif(not _ASYNC_URL, reason="parity real-DB URL 미설정 — skip")
+pytestmark = pytest.mark.skip(
+    reason="post-cutover baseline과 구조적 불일치(team_members=읽기전용 VIEW, dual-write "
+    "픽스처 무효) — story 8236bbc3 스코프 밖, 재작성/폐기 follow-up 추적. design-ci-realdb-"
+    "gap-8236bbc3 §1 참고."
+)
 
 
 @pytest.fixture

--- a/backend/tests/test_merge_verdict_gate.py
+++ b/backend/tests/test_merge_verdict_gate.py
@@ -29,6 +29,10 @@ from app.services import merge_verdict_gate as _mvg
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all/drop_all로 자체 스키마 직접 관리 — 공유 alembic-migrated DB
+# 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_project_relay_owner.py
+++ b/backend/tests/test_project_relay_owner.py
@@ -16,7 +16,12 @@ from app.services.project_auth import resolve_project_relay_owner
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
-pytestmark = pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(raw SQL UNION/COALESCE)")
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(raw SQL UNION/COALESCE)"),
+    pytest.mark.destructive_schema,
+]
 
 
 @pytest.fixture

--- a/backend/tests/test_s29_active_line_get.py
+++ b/backend/tests/test_s29_active_line_get.py
@@ -8,6 +8,10 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
 
 @pytest.fixture
 def anyio_backend():

--- a/backend/tests/test_s2_3_presence_status.py
+++ b/backend/tests/test_s2_3_presence_status.py
@@ -149,6 +149,7 @@ async def _client():
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
 
 
+@pytest.mark.xfail(strict=False, reason="시각-경계 플레이키 — 모듈 임포트 시점 고정 NOW상수 vs 실행 시점 datetime.now() 드리프트로 online/idle 경계 오검(real-DB 무관·순수 mock, 84파일 동시실행으로 세션 총 소요시간 늘어나며 경계 넘어감). story 8236bbc3 e2e서 신규 노출. story 18eefc31 트래킹.")
 @pytest.mark.anyio
 async def test_list_team_members_includes_presence_status():
     """AC1: GET /api/v2/team-members 응답에 presence_status 필드 포함."""
@@ -172,6 +173,7 @@ async def test_list_team_members_includes_presence_status():
         app.dependency_overrides.clear()
 
 
+@pytest.mark.xfail(strict=False, reason="시각-경계 플레이키 — 모듈 임포트 시점 고정 NOW상수 vs 실행 시점 datetime.now() 드리프트(test_list_team_members_includes_presence_status와 동일 클래스). story 8236bbc3 e2e서 신규 노출. story 18eefc31 트래킹.")
 @pytest.mark.anyio
 async def test_list_members_mixed_presence():
     """AC1/2/3/4/5: 다양한 멤버 타입 + last_seen_at 혼합."""

--- a/backend/tests/test_standup_org_level_3b6b567c.py
+++ b/backend/tests/test_standup_org_level_3b6b567c.py
@@ -138,6 +138,7 @@ _DEDUPE_SQL = [
 
 @pytest.mark.anyio
 @pytest.mark.skipif(not _ASYNC, reason="real-DB URL 미설정 — skip")
+@pytest.mark.xfail(strict=False, reason="asyncpg TypeError: expected datetime.date/datetime, got str — story 8236bbc3 e2e 시뮬레이션서 신규 노출(asyncpg 엄격 datetime 타이핑 패턴). story 18eefc31 트래킹.")
 async def test_dedupe_merge_lossless_and_idempotent_realdb():
     from sqlalchemy import text
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine

--- a/backend/tests/test_webhook_targeting.py
+++ b/backend/tests/test_webhook_targeting.py
@@ -91,6 +91,7 @@ _requires_db = pytest.mark.skipif(
 
 
 @_requires_db
+@pytest.mark.xfail(strict=False, reason="story 8236bbc3 e2e 시뮬레이션서 order-dependent 플레이키 확인(배치별로 다른 에러 — asyncio loop RuntimeError 또는 webhook_configs.member_id NotNullViolation). story 18eefc31 트래킹.")
 @pytest.mark.anyio
 async def test_predicate_semantics_realdb():
     """실DB: member-bound는 project 독립으로 covered, broadcast(null)은 제외, 타 org 격리."""


### PR DESCRIPTION
## Summary
- **Root cause (grounded via live grep, not literal AC wording)**: `backend-test`("Backend pytest") runs with zero DB env, so every `ALEMBIC_DATABASE_URL`/`PARITY_TEST_DATABASE_URL`-gated test silently skips. `alembic-fresh-db` has a real Postgres service but only ever runs a hardcoded 13-file list. The gating pattern actually spans **106 files** (not just the 31 named `*_realdb.py`) — **93 (88%) never ran against real Postgres in CI**. commit `a6becbfd`'s unnamed circular-FK regression was only ever caught by manual QA because of exactly this gap.
- **Root fix, not a bigger list**: new `destructive_schema` pytest marker (registered in `pyproject.toml`) for the 54 files that call `Base.metadata.create_all()`/`drop_all()` directly — running even one against the shared alembic-migrated DB corrupts it (reproduced live: `DROP TABLE agent_project_profiles` → `ForeignKeyViolationError`, cascading to 116 unrelated failures).
- `conftest.py` gains a **collection-time AST guard**: any test module calling `create_all`/`drop_all` without the marker fails collection immediately with the exact file path — this is what makes marker-drift self-surfacing (it caught 32 `create_all`-only files a plain `grep drop_all` missed).
- `ci.yml`'s `alembic-fresh-db` job: env vars promoted to job level, the two hardcoded per-file steps replaced with `pytest -m "not destructive_schema"` (auto-activates all 84 non-destructive real-DB files via their own existing `skipif` — no list to maintain) plus a per-file isolated-DB loop for the 54 destructive files. `backend-test`/`ci` jobs untouched.
- `test_member_ssot_parity_realdb.py`: explicit unconditional skip with an in-file rationale (post-cutover baseline incompatibility, not a real gap — tracked as follow-up), matching the PO-confirmed classification.

## Regression proof (AC2)
Checked out `a6becbfd~1` and reproduced the exact `CircularDependencyError: ... loop_artifacts, loop_runs` in an isolated DB (RED), then confirmed GREEN on `a6becbfd` itself with the same repro steps.

## A bug in my own first draft, caught by full e2e simulation
Ran the whole redesigned job locally against a live `pgvector/pgvector:pg16` container mirroring CI. That run caught a real design flaw: the destructive-file loop used `set -e`, so the first failing file aborted the whole step and silently skipped everything after it — the exact failure class this story exists to close. Fixed to accumulate failures across all 54 files and fail once at the end, so a partial-coverage run can never masquerade as a clean pass.

## Pre-existing issues surfaced (tracked, not fixed here)
Running every previously-never-executed file for the first time surfaced **26 genuinely pre-existing issues** unrelated to this change:
- 12 tests across `test_edg_s3/s4/s5/s7_*.py` — one shared root cause (sibling files `test_edg_s18/s19/s29` correctly `monkeypatch.setattr(settings, "decision_gate_line_enabled", True)`; these 4 don't, so they always degrade to `plain_transition`)
- 2 tests (`test_h1_s10_e2e.py`, `test_h1_s7_gate_verdict.py`) — `clean_pass_rate` computes `None` instead of an expected value (trust-calibration gap, suspected)
- 2 tests (`test_s2_3_presence_status.py`) — pure time-boundary flake, unrelated to real DB (module-import-time `NOW` constant vs. live `datetime.now()` drift)
- 1 test (`test_event1config_ack_retire.py`) — order-dependent, only fails in the full 84-file run
- 9 tests reported earlier in PO crux (asyncpg event-loop errors, gateway FK race — PO flagged as prod-concurrency-suspect, top priority for follow-up — NotNull seed gap, standup datetime typing)

Per PO direction: sealing the gap is this story's job, not fixing 26 unrelated bugs it exposed. Each is marked `xfail(strict=False, reason="<diagnosed symptom> — story 18eefc31 트래킹")` individually (no blanket markers) and tracked under follow-up story `18eefc31`.

## Test plan
- [x] `pytest --collect-only` (conftest AST guard): exit 0, 3391 tests collected, 0 marker-drift violations. Negative-tested by removing a marker — guard fires with exact file path (exit 4).
- [x] AC2 regression repro: RED on `a6becbfd~1`, GREEN on `a6becbfd` (both against isolated real Postgres, logs captured).
- [x] Full local e2e simulation against `pgvector/pgvector:pg16` (matching CI's exact image): non-destructive step 0 failed / 3001 passed / 17 xfailed / 3 xpassed (safe, `strict=False`); destructive step 0 failed files, all 54 files executed in full isolation.
- [x] Standard no-DB-env run (mirrors `backend-test` job as-is): 7 failed (known local-machine-only MCP/DoD path checks, unrelated), 2904 passed — matches established baseline exactly, 0 new regressions.
- [ ] 까심 cross-model QA (PO routing this next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)