### PR TITLE
fix(e-sprint-loop): strengthen fbf1c14b VERDICT_KEY tests, correct crash claim

### DIFF
--- a/apps/web/src/components/retro/sprint-close-cockpit.test.tsx
+++ b/apps/web/src/components/retro/sprint-close-cockpit.test.tsx
@@ -62,20 +62,25 @@ describe('SprintCloseCockpit (E-SPRINT-LOOP 1b9f4ecb)', () => {
   });
 
   // story fbf1c14b: 늦게 declare된 가설이 sprint-close 시점에도 아직 measuring 전(proposed/
-  // active)일 수 있다 — verdict 4종만 처리하던 VERDICT_KEY가 크래시했다(PO crux 확정).
-  it.each(['proposed', 'active', 'archived'] as const)(
-    'renders a %s hypothesis without crashing, honest label, no destructive color',
-    (status) => {
-      const h: RetroHypothesisResult = { id: `h-${status}`, statement: `${status} 가설`, status };
-      const markup = renderToStaticMarkup(wrap(
-        <SprintCloseCockpit hypotheses={[h]} synthesis={null} nextHypotheses={[]} onGenerateSynthesis={noop} onAdoptRecommendation={noop} />,
-      ));
-      expect(markup).toContain(`${status} 가설`);
-      expect(markup).not.toContain('text-destructive');
-      expect(markup).not.toContain('bg-destructive');
-      expect(markup).not.toMatch(/\btext-red-\d/);
-    },
-  );
+  // active)일 수 있다 — verdict 4종만 처리하던 VERDICT_KEY가 tr(undefined)를 냈다(PO crux
+  // 확정). 까심 QA 정정(2026-07-03): next-intl이 이걸 크래시 아닌 graceful fallback으로
+  // 흡수해 "폴백 텍스트" 버그였던 것 — 첫 구현의 "크래시 없음"만 보는 assertion은
+  // VERDICT_KEY서 키를 빼도 통과하는 tautological 테스트였다. 실 라벨을 직접 assert.
+  it.each([
+    ['proposed', '제안됨'],
+    ['active', '진행 중'],
+    ['archived', '보관됨'],
+  ] as const)('renders a %s hypothesis with the honest "%s" label (not a fallback), no destructive color', (status, label) => {
+    const h: RetroHypothesisResult = { id: `h-${status}`, statement: `${status} 가설`, status };
+    const markup = renderToStaticMarkup(wrap(
+      <SprintCloseCockpit hypotheses={[h]} synthesis={null} nextHypotheses={[]} onGenerateSynthesis={noop} onAdoptRecommendation={noop} />,
+    ));
+    expect(markup).toContain(`${status} 가설`);
+    expect(markup).toContain(label);
+    expect(markup).not.toContain('text-destructive');
+    expect(markup).not.toContain('bg-destructive');
+    expect(markup).not.toMatch(/\btext-red-\d/);
+  });
 
   it('tallies verified/falsified/measuring counts correctly', () => {
     const markup = renderToStaticMarkup(wrap(

--- a/apps/web/src/components/retro/sprint-close-cockpit.tsx
+++ b/apps/web/src/components/retro/sprint-close-cockpit.tsx
@@ -68,8 +68,10 @@ function useHeuristicStepIndex(generating: boolean, stepCount: number): number {
  */
 
 // story fbf1c14b: RetroHypothesisResult.status가 backend HYPOTHESIS_STATUSES 전체를 정직하게
-// 반영하도록 넓어져(proposed/active/archived 포함) verdict 4종만으로는 t(undefined) 크래시
-// 위험 — sprint-close 시점에도 늦게 declare돼 아직 measuring 전인 가설이 섞일 수 있다.
+// 반영하도록 넓어져(proposed/active/archived 포함) verdict 4종만으로는 VERDICT_KEY[status]가
+// undefined였다 — sprint-close 시점에도 늦게 declare돼 아직 measuring 전인 가설이 섞일 수
+// 있다. 까심 QA 정정(2026-07-03): t(undefined)는 크래시가 아니라 next-intl graceful
+// fallback으로 잘못된 텍스트를 냈던 것.
 const VERDICT_KEY = {
   verified: 'hVerdictVerified',
   falsified: 'hVerdictFalsified',

--- a/apps/web/src/components/sprints/open-loop-cockpit.test.tsx
+++ b/apps/web/src/components/sprints/open-loop-cockpit.test.tsx
@@ -41,17 +41,22 @@ describe('OpenLoopCockpit (E-SPRINT-LOOP sprint-open 278314e9, §10 P0)', () => 
 
   // story fbf1c14b: GET /{id}/hypotheses가 BE HYPOTHESIS_STATUSES 전체를 정직하게 반환 —
   // sprint-open 직후 선언된 가설은 proposed/active가 정상 케이스라 verdict 4종만으로는
-  // 크래시했다(PO crux — VERDICT_KEY 확장 확정). 이 3개 status에서 렌더 크래시 없이 라벨이
-  // 나오는지 + SOUL-LOCK 중립(빨강 0)을 실증.
-  it.each(['proposed', 'active', 'archived'] as const)(
-    'renders a %s hypothesis with its honest status label, no crash, no destructive color',
-    (status) => {
-      const h: RetroHypothesisResult = { id: `h-${status}`, statement: `${status} 가설`, status };
-      const markup = renderToStaticMarkup(wrap(<OpenLoopCockpit hypotheses={[h]} storyTitles={[]} />));
-      expect(markup).toContain(`${status} 가설`);
-      expect(markup).not.toContain('text-destructive');
-      expect(markup).not.toContain('bg-destructive');
-      expect(markup).not.toMatch(/\btext-red-\d/);
-    },
-  );
+  // VERDICT_KEY[status]가 undefined였다(PO crux — VERDICT_KEY 확장 확정).
+  // 까심 QA 정정(2026-07-03): next-intl의 tr(undefined)는 크래시가 아니라 graceful
+  // fallback으로 이상한 텍스트를 냈던 것 — 첫 구현은 "크래시 방지"만 assert해 VERDICT_KEY서
+  // 해당 키를 빼도 통과하는 tautological 테스트였다. 이제 실 라벨 문자열을 직접 assert해
+  // fallback 텍스트가 아니라 정확한 번역이 나오는지 실증(회귀 시 이 assertion이 먼저 깨짐).
+  it.each([
+    ['proposed', '제안됨'],
+    ['active', '진행 중'],
+    ['archived', '보관됨'],
+  ] as const)('renders a %s hypothesis with the honest "%s" label (not a fallback), no destructive color', (status, label) => {
+    const h: RetroHypothesisResult = { id: `h-${status}`, statement: `${status} 가설`, status };
+    const markup = renderToStaticMarkup(wrap(<OpenLoopCockpit hypotheses={[h]} storyTitles={[]} />));
+    expect(markup).toContain(`${status} 가설`);
+    expect(markup).toContain(label);
+    expect(markup).not.toContain('text-destructive');
+    expect(markup).not.toContain('bg-destructive');
+    expect(markup).not.toMatch(/\btext-red-\d/);
+  });
 });

--- a/apps/web/src/components/sprints/open-loop-cockpit.tsx
+++ b/apps/web/src/components/sprints/open-loop-cockpit.tsx
@@ -7,8 +7,10 @@ import type { RetroHypothesisResult as SprintHypothesisResult } from '@/services
 
 // story fbf1c14b: GET /{id}/hypotheses는 이 status 전체(HYPOTHESIS_STATUSES, backend
 // app/models/hypothesis.py)를 정직하게 그대로 반환한다 — sprint-open 직후 선언된 가설은
-// proposed/active가 정상 케이스라 verdict 4종만으로는 tr(undefined) 크래시(PO crux 확인·
-// SOUL 정직 원칙: BE가 measuring으로 강제 coercion하는 대안은 기각).
+// proposed/active가 정상 케이스라 verdict 4종만으로는 VERDICT_KEY[status]가 undefined였다.
+// 까심 QA 정정(2026-07-03): tr(undefined)는 크래시가 아니라 next-intl이 graceful하게
+// 흡수해 잘못된 폴백 텍스트를 냈던 것(SOUL 정직 원칙: BE가 measuring으로 강제 coercion하는
+// 대안은 기각 — PO crux 확인).
 const VERDICT_KEY = {
   verified: 'hVerdictVerified',
   falsified: 'hVerdictFalsified',


### PR DESCRIPTION
## Summary
까심 QA follow-up on #1872 (non-blocking, per PO): the 6 new `proposed`/`active`/`archived` tests were tautological — they only asserted "no crash + no destructive class," which still passes with the corresponding `VERDICT_KEY` entries removed entirely (verified directly: `next-intl`'s `t(undefined)` doesn't throw, it falls back gracefully to the namespace string, not a crash).

- Strengthened both test files to assert the actual translated label (`제안됨`/`진행 중`/`보관됨`) appears.
- Confirmed the negative case: temporarily removing an entry from `VERDICT_KEY` now makes the corresponding test fail (showing the wrong fallback text instead of the real label) — proving the tests now actually catch the regression.
- Corrected the "크래시"(crash) wording in both components' code comments to accurately describe what happens — a wrong fallback string, not a hard crash. The fix itself (#1872's three added `VERDICT_KEY` entries) was already correct; this is test/comment accuracy only, no behavior change.

## Test plan
- [x] `pnpm vitest run` on both files: 24/24 passed.
- [x] Negative-tested: removed `proposed` from `open-loop-cockpit.tsx`'s `VERDICT_KEY` → the strengthened test correctly failed (showed fallback text `"retro"` instead of `"제안됨"`); restored, re-ran clean.
- [x] `pnpm type-check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)