### PR TITLE
feat(e-sprint-loop): retro synthesis+adopt REST contract fixes (2nd/3rd dead-path)

### DIFF
--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -21,6 +21,7 @@ from app.repositories.retro import (
 from app.schemas.hypothesis import HypothesisCreate, HypothesisLinkRequest
 from app.schemas.retro import (
     ActionResponse,
+    AdoptNextHypothesis,
     CreateAction,
     CreateItem,
     CreateSession,
@@ -279,10 +280,48 @@ async def recommend_next_session(
     return await _build_session_response(db, updated, auth)
 
 
-@router.post("/{id}/next-hypotheses/{candidate_id}/adopt", response_model=SessionResponse)
+# story 4b87d3a6: FE `retro/[id]/page.tsx`+BFF는 `POST /{id}/synthesis`(명사) 1콜로
+# {synthesis, next_hypotheses}를 한번에 기대하는데(retro-sessions/[id]/synthesis/route.ts),
+# 이 라우터엔 `/synthesize`+`/recommend-next` 2분리 동사 엔드포인트만 있어 `/synthesis` 자체가
+# dev 라이브 404였다. L2(synthesize)+L3(recommend_next)를 순차 오케스트레이션 — 새 로직 0줄,
+# 기존 두 서비스 함수 재사용.
+@router.post("/{id}/synthesis", response_model=SessionResponse)
+async def synthesize_and_recommend(
+    id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    repo: RetroSessionRepository = Depends(_get_session_repo),
+) -> SessionResponse:
+    """dc861e44 §3 L2+L3 combined(FE 계약 정합, story 4b87d3a6). L2 실패 → 502(`/synthesize`와
+    동일 코드). L2 성공+L3 실패는 **combined 호출 자체를 실패시키지 않는다**(PO crux
+    2026-07-04 ①): synthesis는 이미 확정 저장됐고, next_hypotheses는 기존 캐시를 그대로
+    유지(#1863 data-loss 방지 원칙 연장 — 방금 실패한 L3로 예전 good 캐시를 지우지 않음).
+    FE도 원래 next_hypotheses를 optional로 취급(`?? []`)이라 L3만 실패해도 L2 성과가
+    죽지 않는다."""
+    session = await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
+    sresult = await synth_svc.synthesize(db, session)
+    if sresult is None:
+        raise HTTPException(
+            status_code=502,
+            detail={"code": "SYNTHESIS_GENERATION_FAILED", "message": "AI 종합 생성에 실패했습니다. 잠시 후 다시 시도해주세요."},
+        )
+    updated = await repo.update(id, synthesis=sresult)
+    assert updated is not None
+
+    nresult = await synth_svc.recommend_next(updated.synthesis)
+    if nresult is not None:
+        updated = await repo.update(id, next_hypotheses=nresult)
+        assert updated is not None
+    # nresult is None → 조용히 스킵(위 docstring 참고) — updated.next_hypotheses는 DB의
+    # 기존(가능하면 예전) 값 그대로.
+
+    return await _build_session_response(db, updated, auth)
+
+
+@router.post("/{id}/next-hypotheses/adopt", response_model=SessionResponse)
 async def adopt_next_hypothesis(
     id: uuid.UUID,
-    candidate_id: uuid.UUID,
+    body: AdoptNextHypothesis,
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     repo: RetroSessionRepository = Depends(_get_session_repo),
@@ -291,6 +330,16 @@ async def adopt_next_hypothesis(
     link_type="seeded"로 링크(없으면 backlog proposed). 신규 hypothesis 서비스 로직 0줄 —
     기존 create_hypothesis + link_hypothesis 조합. sprint_id는 서버가 조회(§2 PO 결)해서
     클라이언트가 넘기지 않으므로 그 축의 IDOR가 설계상 없다.
+
+    story 4b87d3a6: candidate_id는 path가 아니라 body의 `id`(FE `{...rec, statement}`
+    spread가 실어보내는 필드 — FE 코드 변경 0). 누락/malformed면 Pydantic이 자동 422
+    (PO crux 2026-07-04: 암묵계약 drift 대비 graceful 422 확인 완료).
+
+    ⭐HITL statement 편집 반영(story 4b87d3a6, PO crux "§3.7.1 확정은 당신이" 위반 지적) —
+    body.statement가 있으면(사람이 sprint-close-cockpit의 OperatorTextarea로 편집한 값)
+    그걸 쓰고, 없으면 서버 저장 candidate의 statement 그대로. metric_definition/
+    measure_after는 여전히 서버 값만 신뢰(클라 위조 방지 — AI 산출 수치는 편집 대상 아님,
+    문구만 사람이 다듬는 게 UX 의도).
 
     SOUL-LOCK(유나 §6) "채택=인간 게이트" — agent caller는 403.
 
@@ -309,7 +358,7 @@ async def adopt_next_hypothesis(
     if locked is None:
         raise HTTPException(status_code=404, detail="Retro session not found")
 
-    candidate = seed_svc.find_candidate(locked.next_hypotheses, candidate_id)
+    candidate = seed_svc.find_candidate(locked.next_hypotheses, body.id)
     if candidate is None:
         raise HTTPException(
             status_code=404,
@@ -321,11 +370,13 @@ async def adopt_next_hypothesis(
             detail={"code": "ALREADY_ADOPTED", "message": "이미 채택된 추천입니다."},
         )
 
+    statement = body.statement.strip() if body.statement and body.statement.strip() else candidate["statement"]
+
     hyp = await hyp_svc.create_hypothesis(
         db, session.org_id, caller,
         HypothesisCreate(
             project_id=session.project_id,
-            statement=candidate["statement"],
+            statement=statement,
             metric_definition=candidate["metric_definition"],
             measure_after=candidate["measure_after"],
             status="proposed",
@@ -342,7 +393,7 @@ async def adopt_next_hypothesis(
         )
 
     updated_candidates = [
-        {**c, "adopted_hypothesis_id": str(hyp.id)} if str(c.get("id")) == str(candidate_id) else c
+        {**c, "adopted_hypothesis_id": str(hyp.id)} if str(c.get("id")) == str(body.id) else c
         for c in locked.next_hypotheses
     ]
     updated = await repo.update(id, next_hypotheses=updated_candidates)

--- a/backend/app/schemas/retro.py
+++ b/backend/app/schemas/retro.py
@@ -86,6 +86,20 @@ class NextHypothesisCandidate(BaseModel):
     adopted_hypothesis_id: uuid.UUID | None = None
 
 
+class AdoptNextHypothesis(BaseModel):
+    """story 4b87d3a6 — FE `handleAdoptRecommendation`가 `{...rec, statement}`(rec=
+    NextHypothesisCandidate 런타임 객체 — TS 타입엔 `id`가 없지만 실제 응답엔 있어 spread로
+    실려온다)를 body로 보낸다. candidate_id를 path가 아니라 이 body의 `id`로 받는다(FE
+    무변경). `statement`는 사람이 편집했을 수 있는 override — 없으면 서버 저장 candidate의
+    statement를 그대로 쓴다(§3.7.1 HITL: "확정은 당신이" — 편집을 무시하면 사람의 편집이
+    조용히 버려지는 위반이라 이 필드를 실반영해야 한다)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: uuid.UUID
+    statement: str | None = None
+
+
 class SessionResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/tests/test_e_sprint_loop_dc861e44_retro_synthesis_realdb.py
+++ b/backend/tests/test_e_sprint_loop_dc861e44_retro_synthesis_realdb.py
@@ -173,6 +173,79 @@ async def test_synthesize_then_recommend_next_full_flow():
 
 
 @pytest.mark.anyio
+async def test_synthesis_combined_endpoint_persists_both_in_one_call():
+    """story 4b87d3a6 — FE가 실제로 부르는 combined POST /{id}/synthesis 1콜로 L2+L3 둘 다
+    persist되고, 그 결과가 이후 GET에도 그대로 남아있는지(라우터 표면 실증 — 서비스 유닛
+    mock으론 못 잡는 엔드포인트 부재 클래스, 8236bbc3/18eefc31과 동형)."""
+    from app.routers.retros import synthesize_and_recommend
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        synth_raw = '{"items": [{"text": "가설이 반증됐다(온보딩 42% vs 목표 50%) — 학습 데이터", "source": "가설 1"}]}'
+        next_raw = '{"items": [{"statement": "온보딩 UX를 단순화하면 이탈이 줄 것이다.", "rationale": "가설 1 반증", "confidence": 0.55}]}'
+        async with Session() as s:
+            with patch("app.services.llm_client.generate_text", side_effect=[synth_raw, next_raw]):
+                resp = await synthesize_and_recommend(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
+            await s.commit()
+
+        assert resp.synthesis is not None
+        assert len(resp.synthesis.learned) == 1
+        assert resp.next_hypotheses is not None
+        assert len(resp.next_hypotheses) == 1
+        assert resp.next_hypotheses[0].statement == "온보딩 UX를 단순화하면 이탈이 줄 것이다."
+
+        from app.routers.retros import get_session
+        async with Session() as s:
+            resp2 = await get_session(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
+        assert resp2.synthesis is not None
+        assert resp2.next_hypotheses is not None
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_synthesis_combined_l3_failure_preserves_stale_next_hypotheses_not_502():
+    """PO crux(2026-07-04 ①) — 기존 good next_hypotheses가 있는 상태에서 재종합 시 L3만
+    실패하면(빈/malformed LLM 응답) combined 호출은 502가 아니라 200이고, 새 synthesis는
+    갱신되지만 next_hypotheses는 예전 캐시가 그대로 응답에 남는다(overwrite 안 됨)."""
+    from app.routers.retros import synthesize_and_recommend, synthesize_session, recommend_next_session
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        # 1) 먼저 정상 synthesize+recommend로 good 캐시를 만들어둔다.
+        synth_raw_1 = '{"items": [{"text": "1차 학습", "source": "가설 1"}]}'
+        async with Session() as s:
+            with patch("app.services.llm_client.generate_text", return_value=synth_raw_1):
+                await synthesize_session(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
+            await s.commit()
+        next_raw_1 = '{"items": [{"statement": "예전 추천(보존돼야 함)", "rationale": "r", "confidence": 0.5}]}'
+        async with Session() as s:
+            with patch("app.services.llm_client.generate_text", return_value=next_raw_1):
+                await recommend_next_session(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
+            await s.commit()
+
+        # 2) combined 재호출 — L2는 성공(새 synthesis), L3는 malformed(파싱 실패=None)로 재현.
+        synth_raw_2 = '{"items": [{"text": "2차 새 학습", "source": "가설 1"}]}'
+        async with Session() as s:
+            with patch("app.services.llm_client.generate_text", side_effect=[synth_raw_2, "이건 JSON이 아님"]):
+                resp = await synthesize_and_recommend(SESSION_A, db=s, auth=_auth(), repo=_repo(s))
+            await s.commit()
+
+        assert resp.synthesis is not None
+        assert resp.synthesis.learned[0].text == "2차 새 학습"
+        assert resp.next_hypotheses is not None
+        assert resp.next_hypotheses[0].statement == "예전 추천(보존돼야 함)"  # L3 실패로 미갱신
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
 async def test_recommend_next_without_synthesis_409():
     from app.routers.retros import recommend_next_session
 

--- a/backend/tests/test_e_sprint_loop_ecc531ce_adopt_seed_realdb.py
+++ b/backend/tests/test_e_sprint_loop_ecc531ce_adopt_seed_realdb.py
@@ -156,6 +156,7 @@ async def test_resolve_next_sprint_full_tie_breaks_deterministically_by_id():
 async def test_adopt_creates_proposed_hypothesis_seeds_earliest_planning_sprint():
     """§2 PO 결 — planning 중 가장 이른 start_date(0801)가 선택돼야 함(0901 아님)."""
     from app.routers.retros import adopt_next_hypothesis
+    from app.schemas.retro import AdoptNextHypothesis
 
     eng, Session = await _engine()
     try:
@@ -165,7 +166,7 @@ async def test_adopt_creates_proposed_hypothesis_seeds_earliest_planning_sprint(
         async with Session() as s:
             with _no_embed():
                 resp = await adopt_next_hypothesis(
-                    SESSION_A, CANDIDATE_ID, db=s, auth=_auth(), repo=_repo(s),
+                    SESSION_A, AdoptNextHypothesis(id=CANDIDATE_ID), db=s, auth=_auth(), repo=_repo(s),
                 )
             await s.commit()
 
@@ -190,6 +191,7 @@ async def test_adopt_creates_proposed_hypothesis_seeds_earliest_planning_sprint(
 async def test_adopt_no_planning_sprint_creates_backlog_proposed_no_link():
     """AC #2 — 다음 sprint 없으면 backlog proposed(링크 없음). PROJ_B는 seed에서 sprint 0개."""
     from app.routers.retros import adopt_next_hypothesis
+    from app.schemas.retro import AdoptNextHypothesis
 
     eng, Session = await _engine()
     try:
@@ -203,7 +205,7 @@ async def test_adopt_no_planning_sprint_creates_backlog_proposed_no_link():
         async with Session() as s:
             with _no_embed():
                 resp = await adopt_next_hypothesis(
-                    SESSION_A, CANDIDATE_ID, db=s, auth=_auth(), repo=_repo(s),
+                    SESSION_A, AdoptNextHypothesis(id=CANDIDATE_ID), db=s, auth=_auth(), repo=_repo(s),
                 )
             await s.commit()
 
@@ -225,6 +227,7 @@ async def test_adopt_no_planning_sprint_creates_backlog_proposed_no_link():
 @pytest.mark.anyio
 async def test_adopt_already_adopted_409():
     from app.routers.retros import adopt_next_hypothesis
+    from app.schemas.retro import AdoptNextHypothesis
 
     eng, Session = await _engine()
     try:
@@ -233,12 +236,12 @@ async def test_adopt_already_adopted_409():
 
         async with Session() as s:
             with _no_embed():
-                await adopt_next_hypothesis(SESSION_A, CANDIDATE_ID, db=s, auth=_auth(), repo=_repo(s))
+                await adopt_next_hypothesis(SESSION_A, AdoptNextHypothesis(id=CANDIDATE_ID), db=s, auth=_auth(), repo=_repo(s))
             await s.commit()
 
         async with Session() as s:
             with pytest.raises(HTTPException) as ei:
-                await adopt_next_hypothesis(SESSION_A, CANDIDATE_ID, db=s, auth=_auth(), repo=_repo(s))
+                await adopt_next_hypothesis(SESSION_A, AdoptNextHypothesis(id=CANDIDATE_ID), db=s, auth=_auth(), repo=_repo(s))
             assert ei.value.status_code == 409
             assert ei.value.detail["code"] == "ALREADY_ADOPTED"
     finally:
@@ -248,6 +251,7 @@ async def test_adopt_already_adopted_409():
 @pytest.mark.anyio
 async def test_adopt_cross_project_403():
     from app.routers.retros import adopt_next_hypothesis
+    from app.schemas.retro import AdoptNextHypothesis
 
     eng, Session = await _engine()
     try:
@@ -255,7 +259,7 @@ async def test_adopt_cross_project_403():
             await _seed(s)
         async with Session() as s:
             with pytest.raises(HTTPException) as ei:
-                await adopt_next_hypothesis(SESSION_B, CANDIDATE_ID, db=s, auth=_auth(), repo=_repo(s))
+                await adopt_next_hypothesis(SESSION_B, AdoptNextHypothesis(id=CANDIDATE_ID), db=s, auth=_auth(), repo=_repo(s))
             assert ei.value.status_code == 403
     finally:
         await eng.dispose()
@@ -268,6 +272,7 @@ async def test_concurrent_double_click_creates_exactly_one_hypothesis():
     여야 하고, hypotheses 테이블에는 정확히 1행만 생겨야 한다."""
     from app.models.retro import RetroSession
     from app.routers.retros import adopt_next_hypothesis
+    from app.schemas.retro import AdoptNextHypothesis
 
     eng, Session = await _engine()
     try:
@@ -282,7 +287,7 @@ async def test_concurrent_double_click_creates_exactly_one_hypothesis():
             async with Session() as s:
                 try:
                     resp = await adopt_next_hypothesis(
-                        SESSION_A_NOSPRINT, seeded_candidate_id,
+                        SESSION_A_NOSPRINT, AdoptNextHypothesis(id=seeded_candidate_id),
                         db=s, auth=_auth(), repo=_repo(s),
                     )
                     await s.commit()

--- a/backend/tests/test_retros.py
+++ b/backend/tests/test_retros.py
@@ -1248,6 +1248,150 @@ async def test_recommend_next_200_when_synthesis_present():
         app.dependency_overrides.clear()
 
 
+# ── story 4b87d3a6: combined POST /{id}/synthesis(FE 계약 정합) ────────────────
+
+@pytest.mark.anyio
+async def test_synthesis_combined_200_both_l2_and_l3_succeed():
+    """FE `retro/[id]/page.tsx`가 기대하는 정확한 shape — 1콜로 synthesis+next_hypotheses
+    둘 다 채워져 돌아온다."""
+    client, session, app = await _client()
+    try:
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = _mock_session()
+            else:
+                result.scalars.return_value.all.return_value = []
+            return result
+
+        session.execute = mock_execute
+
+        synthesis_result = {
+            "learned": [{"text": "배운 것", "source": "s"}],
+            "generated_at": "2026-07-04T00:00:00+00:00", "source": "ai_draft",
+        }
+        candidates = [{
+            "id": str(uuid.uuid4()), "statement": "다음엔 X를 검증할 것이다.",
+            "metric_definition": {"metric": "outcome", "source": "manual", "target": 1, "direction": "up"},
+            "measure_after": "2026-08-01T00:00:00+00:00", "confidence": 0.5,
+            "rationale": "r", "requires_confirmation": True,
+        }]
+
+        after_l2 = _mock_session()
+        after_l2.synthesis = synthesis_result
+        after_l3 = _mock_session()
+        after_l3.synthesis = synthesis_result
+        after_l3.next_hypotheses = candidates
+
+        with (
+            _allow_project_access(), _mock_resolve_member(),
+            patch("app.routers.retros.synth_svc.synthesize", new=AsyncMock(return_value=synthesis_result)),
+            patch("app.routers.retros.synth_svc.recommend_next", new=AsyncMock(return_value=candidates)),
+            patch(
+                "app.repositories.base.BaseRepository.update",
+                new=AsyncMock(side_effect=[after_l2, after_l3]),
+            ) as mock_update,
+        ):
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/synthesis")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["synthesis"]["learned"][0]["text"] == "배운 것"
+        assert body["next_hypotheses"][0]["statement"] == "다음엔 X를 검증할 것이다."
+        assert mock_update.await_count == 2
+        mock_update.assert_any_await(SESSION_ID, synthesis=synthesis_result)
+        mock_update.assert_any_await(SESSION_ID, next_hypotheses=candidates)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_synthesis_combined_l2_failure_502_no_persist():
+    """L2(synthesize) 실패 → 기존 /synthesize와 동일하게 502, repo.update 절대 호출 안 됨
+    (data-loss 방지 — 기존 good synthesis/next_hypotheses 캐시 그대로)."""
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with (
+            _allow_project_access(),
+            patch("app.routers.retros.synth_svc.synthesize", new=AsyncMock(return_value=None)),
+            patch("app.repositories.base.BaseRepository.update", new=AsyncMock()) as mock_update,
+        ):
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/synthesis")
+
+        assert resp.status_code == 502
+        assert resp.json()["error"]["code"] == "SYNTHESIS_GENERATION_FAILED"
+        mock_update.assert_not_awaited()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_synthesis_combined_l3_failure_still_200_preserves_cached_next_hypotheses():
+    """PO crux(2026-07-04 ①) — L2 성공+L3 실패는 combined 호출 자체를 안 죽인다. synthesis는
+    갱신 저장되고, next_hypotheses는 재저장 없이 기존(예전) 캐시가 응답에 그대로 노출된다
+    (#1863 data-loss 방지 원칙 연장 — 방금 실패한 L3로 예전 good 캐시를 지우지 않음)."""
+    client, session, app = await _client()
+    try:
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = _mock_session()
+            else:
+                result.scalars.return_value.all.return_value = []
+            return result
+
+        session.execute = mock_execute
+
+        synthesis_result = {
+            "learned": [{"text": "새 종합", "source": "s"}],
+            "generated_at": "2026-07-04T00:00:00+00:00", "source": "ai_draft",
+        }
+        stale_candidates = [{
+            "id": str(uuid.uuid4()), "statement": "예전 추천(재생성 실패로 그대로 유지됨)",
+            "metric_definition": {"metric": "outcome", "source": "manual", "target": 1, "direction": "up"},
+            "measure_after": "2026-08-01T00:00:00+00:00", "confidence": 0.5,
+            "rationale": "r", "requires_confirmation": True,
+        }]
+        after_l2 = _mock_session()
+        after_l2.synthesis = synthesis_result
+        after_l2.next_hypotheses = stale_candidates  # L3 미실행이라 재저장 없이 예전 값 그대로
+
+        with (
+            _allow_project_access(), _mock_resolve_member(),
+            patch("app.routers.retros.synth_svc.synthesize", new=AsyncMock(return_value=synthesis_result)),
+            patch("app.routers.retros.synth_svc.recommend_next", new=AsyncMock(return_value=None)),
+            patch(
+                "app.repositories.base.BaseRepository.update",
+                new=AsyncMock(return_value=after_l2),
+            ) as mock_update,
+        ):
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/synthesis")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["synthesis"]["learned"][0]["text"] == "새 종합"
+        assert body["next_hypotheses"][0]["statement"] == "예전 추천(재생성 실패로 그대로 유지됨)"
+        # L3 실패 시 next_hypotheses에 대한 repo.update 재호출이 없어야 함(synthesis만 1회).
+        mock_update.assert_awaited_once_with(SESSION_ID, synthesis=synthesis_result)
+    finally:
+        app.dependency_overrides.clear()
+
+
 @pytest.mark.anyio
 async def test_get_session_embeds_hypotheses_when_sprint_linked():
     """§5 hypotheses[] — sprint_id 있으면 story 1 필터 재사용해 채움."""
@@ -1326,7 +1470,7 @@ async def test_adopt_requires_human_403():
 
         with _allow_project_access(), _mock_resolve_member(member_type="agent"):
             async with client as c:
-                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/next-hypotheses/{CANDIDATE_ID}/adopt")
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/next-hypotheses/adopt", json={"id": str(CANDIDATE_ID)})
 
         assert resp.status_code == 403
         assert resp.json()["error"]["code"] == "ADOPTION_REQUIRES_HUMAN"
@@ -1344,7 +1488,7 @@ async def test_adopt_cross_project_403():
 
         with _deny_project_access():
             async with client as c:
-                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/next-hypotheses/{CANDIDATE_ID}/adopt")
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/next-hypotheses/adopt", json={"id": str(CANDIDATE_ID)})
 
         assert resp.status_code == 403
     finally:
@@ -1366,7 +1510,7 @@ async def test_adopt_candidate_not_found_404():
             patch("app.repositories.retro.RetroSessionRepository.get_for_update", new=AsyncMock(return_value=s)),
         ):
             async with client as c:
-                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/next-hypotheses/{CANDIDATE_ID}/adopt")
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/next-hypotheses/adopt", json={"id": str(CANDIDATE_ID)})
 
         assert resp.status_code == 404
         assert resp.json()["error"]["code"] == "CANDIDATE_NOT_FOUND"
@@ -1390,7 +1534,7 @@ async def test_adopt_already_adopted_409():
             patch("app.repositories.retro.RetroSessionRepository.get_for_update", new=AsyncMock(return_value=locked)),
         ):
             async with client as c:
-                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/next-hypotheses/{CANDIDATE_ID}/adopt")
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/next-hypotheses/adopt", json={"id": str(CANDIDATE_ID)})
 
         assert resp.status_code == 409
         assert resp.json()["error"]["code"] == "ALREADY_ADOPTED"
@@ -1433,7 +1577,7 @@ async def test_adopt_200_creates_hypothesis_and_seeds_next_sprint():
             patch("app.repositories.base.BaseRepository.update", new=AsyncMock(return_value=updated_session)) as mock_update,
         ):
             async with client as c:
-                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/next-hypotheses/{CANDIDATE_ID}/adopt")
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/next-hypotheses/adopt", json={"id": str(CANDIDATE_ID)})
 
         assert resp.status_code == 200
         mock_create.assert_awaited_once()
@@ -1444,6 +1588,130 @@ async def test_adopt_200_creates_hypothesis_and_seeds_next_sprint():
         assert link_args[3].link_type == "seeded"
         mock_update.assert_awaited_once()
         assert resp.json()["next_hypotheses"][0]["adopted_hypothesis_id"] == str(hyp_id)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_adopt_honors_human_edited_statement():
+    """story 4b87d3a6 — sprint-close-cockpit의 OperatorTextarea로 사람이 편집한 statement가
+    body에 실려오면 그걸 써야 한다(HITL "확정은 당신이" — 이전엔 body를 아예 안 읽고 서버
+    저장 candidate의 statement만 써 사람 편집이 조용히 버려졌음)."""
+    client, session, app = await _client()
+    try:
+        s = _mock_session()
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = s
+            else:
+                result.scalars.return_value.all.return_value = []
+            return result
+
+        session.execute = mock_execute
+
+        locked = _mock_session_with_candidate()  # statement="다음엔 온보딩을 개선하면 이탈이 줄 것이다."
+        hyp_id = uuid.uuid4()
+        hyp = SimpleNamespace(id=hyp_id, project_id=PROJECT_ID)
+        updated_session = _mock_session()
+        updated_session.next_hypotheses = [_candidate(adopted_hypothesis_id=str(hyp_id))]
+
+        with (
+            _allow_project_access(), _mock_resolve_member(),
+            patch("app.repositories.retro.RetroSessionRepository.get_for_update", new=AsyncMock(return_value=locked)),
+            patch("app.routers.retros.hyp_svc.create_hypothesis", new=AsyncMock(return_value=hyp)) as mock_create,
+            patch("app.routers.retros.seed_svc.resolve_next_sprint", new=AsyncMock(return_value=None)),
+            patch("app.routers.retros.hyp_svc.link_hypothesis", new=AsyncMock()),
+            patch("app.repositories.base.BaseRepository.update", new=AsyncMock(return_value=updated_session)),
+        ):
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/retros/{SESSION_ID}/next-hypotheses/adopt",
+                    json={"id": str(CANDIDATE_ID), "statement": "사람이 직접 편집한 문구"},
+                )
+
+        assert resp.status_code == 200
+        mock_create.assert_awaited_once()
+        payload = mock_create.await_args.args[3]
+        assert payload.statement == "사람이 직접 편집한 문구"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_adopt_blank_statement_override_falls_back_to_stored():
+    """body.statement가 공백뿐이면(사람이 지웠다가 빈칸으로 제출) 서버 저장값으로 폴백 —
+    빈 statement 가설이 만들어지지 않도록."""
+    client, session, app = await _client()
+    try:
+        s = _mock_session()
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = s
+            else:
+                result.scalars.return_value.all.return_value = []
+            return result
+
+        session.execute = mock_execute
+
+        locked = _mock_session_with_candidate()
+        hyp_id = uuid.uuid4()
+        hyp = SimpleNamespace(id=hyp_id, project_id=PROJECT_ID)
+        updated_session = _mock_session()
+        updated_session.next_hypotheses = [_candidate(adopted_hypothesis_id=str(hyp_id))]
+
+        with (
+            _allow_project_access(), _mock_resolve_member(),
+            patch("app.repositories.retro.RetroSessionRepository.get_for_update", new=AsyncMock(return_value=locked)),
+            patch("app.routers.retros.hyp_svc.create_hypothesis", new=AsyncMock(return_value=hyp)) as mock_create,
+            patch("app.routers.retros.seed_svc.resolve_next_sprint", new=AsyncMock(return_value=None)),
+            patch("app.routers.retros.hyp_svc.link_hypothesis", new=AsyncMock()),
+            patch("app.repositories.base.BaseRepository.update", new=AsyncMock(return_value=updated_session)),
+        ):
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/retros/{SESSION_ID}/next-hypotheses/adopt",
+                    json={"id": str(CANDIDATE_ID), "statement": "   "},
+                )
+
+        assert resp.status_code == 200
+        payload = mock_create.await_args.args[3]
+        assert payload.statement == "다음엔 온보딩을 개선하면 이탈이 줄 것이다."
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_adopt_missing_id_returns_422():
+    """PO crux(2026-07-04) — body.id 부재/malformed는 graceful 422(암묵계약 drift 대비).
+    project-access/human 게이트보다 먼저 Pydantic 검증이 걸려야 하므로 mock 없이도 422."""
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.post(f"/api/v2/retros/{SESSION_ID}/next-hypotheses/adopt", json={})
+        assert resp.status_code == 422
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_adopt_malformed_id_returns_422():
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.post(
+                f"/api/v2/retros/{SESSION_ID}/next-hypotheses/adopt", json={"id": "not-a-uuid"}
+            )
+        assert resp.status_code == 422
     finally:
         app.dependency_overrides.clear()
 
@@ -1483,7 +1751,7 @@ async def test_adopt_no_next_sprint_skips_link_backlog_proposed():
             patch("app.repositories.base.BaseRepository.update", new=AsyncMock(return_value=updated_session)),
         ):
             async with client as c:
-                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/next-hypotheses/{CANDIDATE_ID}/adopt")
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/next-hypotheses/adopt", json={"id": str(CANDIDATE_ID)})
 
         assert resp.status_code == 200
         mock_link.assert_not_called()


### PR DESCRIPTION
## Summary
Found via a full FE-BE contract sweep after `fbf1c14b` (the first dead-path fix in this series).

**Combined `/synthesis` endpoint**: FE `retro/[id]/page.tsx` + BFF call `POST /api/v2/retros/{id}/synthesis` expecting one call to return `{synthesis, next_hypotheses}` together, but the router only had two separate verb endpoints (`/synthesize`, `/recommend-next`) — `/synthesis` 404'd live. Added a combined endpoint orchestrating the existing `synth_svc.synthesize` (L2) then `recommend_next` (L3), reusing `_build_session_response` unchanged.
- L2 failure → 502, exactly like the standalone `/synthesize`.
- L2 success + L3 failure → does **not** fail the combined call. `synthesis` is already persisted; `next_hypotheses` is left as whatever was already cached rather than overwritten with a failed/empty result (PO crux: extends the `#1863` data-loss principle already established for the standalone endpoints — the FE already treats `next_hypotheses` as optional).

**Adopt endpoint path→body + a second bug it was masking**: FE `next-hypotheses/adopt/route.ts` posts to `/next-hypotheses/adopt` with no id in the path, but the router required a `{candidate_id}` path segment. Verified end-to-end (not just "looks like a path mismatch") that the candidate's real `id` (server-generated, just missing from the FE's narrower TS interface) survives into the outgoing POST body via `{...rec, statement}` — reading it from the body works with **zero FE changes**. Missing/malformed `id` now 422s via normal Pydantic validation instead of a routing 404.

That same trace surfaced a second, unrelated bug the "path fix" framing alone would have left in place: `sprint-close-cockpit.tsx` has an editable textarea letting a human revise the AI-drafted statement before adopting, and the edited value already flows into the request body — but the backend ignored the body entirely and always used the server-stored statement, silently discarding every edit. PO crux confirmed this violates the "확정은 당신이" HITL principle and must be fixed in this same PR. Now honored when present and non-blank; `metric_definition`/`measure_after` stay server-sourced (only the statement is human-editable, matching the existing UX intent).

## Test plan
- [x] New/updated unit tests in `test_retros.py`: combined `/synthesis` (both succeed / L2 fails 502 no-persist / L2 succeeds+L3 fails 200 with stale `next_hypotheses` preserved); adopt (statement-edit honored / blank-edit falls back to stored / missing `id` → 422 / malformed `id` → 422); existing 6 adopt path-based calls updated to body-based. 65/65 `test_retros.py` passed.
- [x] Realdb suites (real Postgres): `test_e_sprint_loop_dc861e44_retro_synthesis_realdb.py` (+2 new: combined endpoint persists both in one call, L3-only-failure preserves stale cache not 502) and `test_e_sprint_loop_ecc531ce_adopt_seed_realdb.py` (all 6 call sites updated to new body signature, including the concurrent-double-click serialization test). 102/102 passed across both + `test_retros.py` + `test_retro_synthesis_service.py`.
- [x] Full backend suite: 7 known pre-existing failures (local-only MCP/DoD path checks), 2911 passed — matches baseline exactly, 0 new regressions.
- [ ] 까심 cross-model QA (PO routing next) → merge → dev deploy → 유나 full E2E (declaration → synthesis loading capture → adopt with edited statement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)