### PR TITLE
fix(infra): story 18eefc31 — realdb triage batch (edg 12·asyncpg loop-bound·presence·order-dep·ack_retire)

### DIFF
--- a/backend/tests/test_edg_s3_engine.py
+++ b/backend/tests/test_edg_s3_engine.py
@@ -116,8 +116,10 @@ async def test_off_mode_plain():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 @pytest.mark.anyio
-@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락 — 형제 파일(test_edg_s18/s19/s29)은 True로 patch하는데 이 파일은 안 함, default-off라 항상 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출 (파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
-async def test_shadow_mode_records_step_run_but_proceeds():
+async def test_shadow_mode_records_step_run_but_proceeds(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "decision_gate_line_enabled", True)
+    monkeypatch.setattr(settings, "decision_gate_line_mode", "enforcing")
     from app.services.workflow_line_engine import evaluate_line_for_transition
     from app.models.workflow_line import WorkflowLineStepRun
     from sqlalchemy import select
@@ -139,8 +141,10 @@ async def test_shadow_mode_records_step_run_but_proceeds():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 @pytest.mark.anyio
-@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락 — 형제 파일(test_edg_s18/s19/s29)은 True로 patch하는데 이 파일은 안 함, default-off라 항상 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출 (파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
-async def test_enforcing_static_block_blocked_by_policy():
+async def test_enforcing_static_block_blocked_by_policy(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "decision_gate_line_enabled", True)
+    monkeypatch.setattr(settings, "decision_gate_line_mode", "enforcing")
     from app.services.workflow_line_engine import evaluate_line_for_transition
     engine, Session = await _engine_session()
     async with Session() as session:
@@ -159,8 +163,10 @@ async def test_enforcing_static_block_blocked_by_policy():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 @pytest.mark.anyio
-@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락 — 형제 파일(test_edg_s18/s19/s29)은 True로 patch하는데 이 파일은 안 함, default-off라 항상 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출 (파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
-async def test_fault_injection_engine_failure_degrades_to_plain():
+async def test_fault_injection_engine_failure_degrades_to_plain(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "decision_gate_line_enabled", True)
+    monkeypatch.setattr(settings, "decision_gate_line_mode", "enforcing")
     """⭐P0-1: 엔진 내부 예외 → engine_failed + degraded_to_plain → 전이 진행(proceeds=True)."""
     from app.services import workflow_line_engine as eng
     engine, Session = await _engine_session()
@@ -189,8 +195,10 @@ async def test_fault_injection_engine_failure_degrades_to_plain():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 @pytest.mark.anyio
-@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락 — 형제 파일(test_edg_s18/s19/s29)은 True로 patch하는데 이 파일은 안 함, default-off라 항상 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출 (파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
-async def test_step_run_flush_failure_savepoint_does_not_poison_session():
+async def test_step_run_flush_failure_savepoint_does_not_poison_session(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "decision_gate_line_enabled", True)
+    monkeypatch.setattr(settings, "decision_gate_line_mode", "enforcing")
     """⭐P0-1(레드팀 적출): step_run insert flush 실패(active partial unique 충돌=double-fire)가
     outer 트랜잭션을 poison하면 안 된다. SAVEPOINT 격리로 outer tx 보존 → 후속 set_status/commit 정상.
     """

--- a/backend/tests/test_edg_s4_resolver.py
+++ b/backend/tests/test_edg_s4_resolver.py
@@ -147,8 +147,10 @@ async def test_routing_context_non_story_unsupported():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
-@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락(형제 s18/s19/s29 패턴 미적용) — default-off라 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출(파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
-async def test_engine_shadow_records_routing_context_and_trust():
+async def test_engine_shadow_records_routing_context_and_trust(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "decision_gate_line_enabled", True)
+    monkeypatch.setattr(settings, "decision_gate_line_mode", "enforcing")
     """S3 엔진 shadow 경로가 S4 resolver 산출(routing_context+trust_snapshot)을 step_run 에 기록."""
     from sqlalchemy import select
     from app.services.workflow_line_engine import evaluate_line_for_transition
@@ -188,8 +190,10 @@ async def test_engine_shadow_records_routing_context_and_trust():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
-@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락(형제 s18/s19/s29 패턴 미적용) — default-off라 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출(파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
-async def test_actor_propagates_to_step_run_snapshot():
+async def test_actor_propagates_to_step_run_snapshot(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "decision_gate_line_enabled", True)
+    monkeypatch.setattr(settings, "decision_gate_line_mode", "enforcing")
     """⭐SME blocking 회귀: 엔진에 actor_id/actor_type 을 넘기면 resolver→step_run.routing_context.actor
     까지 전파돼야 한다(라우터가 actor 미전달 시 항상 no_member 로 고정되던 통합 갭). actor.member_id 가
     실제 actor 로 채워져야 trust 가 그 actor 이력 기반(non-cold-start 가능)이 된다."""

--- a/backend/tests/test_edg_s5_merge_gate.py
+++ b/backend/tests/test_edg_s5_merge_gate.py
@@ -64,8 +64,10 @@ def _decision(decision, gate_id):
 # ── line_merge_gate_active (라우터 skip 판정) ─────────────────────────────────
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
-@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락(형제 s18/s19/s29 패턴 미적용) — default-off라 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출(파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
-async def test_line_merge_gate_active_only_for_enforcing_merge_gate():
+async def test_line_merge_gate_active_only_for_enforcing_merge_gate(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "decision_gate_line_enabled", True)
+    monkeypatch.setattr(settings, "decision_gate_line_mode", "enforcing")
     from app.services.workflow_line_engine import line_merge_gate_active
     engine, Session = await _session()
     kw = dict(entity_type="story", from_status="in-review", to_status="done")
@@ -90,8 +92,10 @@ async def test_line_merge_gate_active_only_for_enforcing_merge_gate():
 # ── wrapper decision 매핑 (evaluate_merge_gate patch로 결정 격리) ─────────────
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
-@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락(형제 s18/s19/s29 패턴 미적용) — default-off라 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출(파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
-async def test_merge_gate_wrapper_ask_human_uses_h1_gate_no_double():
+async def test_merge_gate_wrapper_ask_human_uses_h1_gate_no_double(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "decision_gate_line_enabled", True)
+    monkeypatch.setattr(settings, "decision_gate_line_mode", "enforcing")
     from sqlalchemy import func, select
     from app.services import workflow_line_engine as eng
     from app.services.merge_verdict_gate import ASK_HUMAN
@@ -121,8 +125,10 @@ async def test_merge_gate_wrapper_ask_human_uses_h1_gate_no_double():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
-@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락(형제 s18/s19/s29 패턴 미적용) — default-off라 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출(파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
-async def test_merge_gate_wrapper_auto_merge_and_block():
+async def test_merge_gate_wrapper_auto_merge_and_block(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "decision_gate_line_enabled", True)
+    monkeypatch.setattr(settings, "decision_gate_line_mode", "enforcing")
     from app.services import workflow_line_engine as eng
     from app.services.merge_verdict_gate import AUTO_MERGE, BLOCK
     engine, Session = await _session()
@@ -145,8 +151,10 @@ async def test_merge_gate_wrapper_auto_merge_and_block():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
-@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락(형제 s18/s19/s29 패턴 미적용) — default-off라 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출(파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
-async def test_merge_gate_wrapper_failopen():
+async def test_merge_gate_wrapper_failopen(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "decision_gate_line_enabled", True)
+    monkeypatch.setattr(settings, "decision_gate_line_mode", "enforcing")
     """⭐S3 fail-open 보존: merge-gate 평가(evaluate_merge_gate) 예외도 engine_failed→plain(전이 진행)."""
     from app.services import workflow_line_engine as eng
     engine, Session = await _session()
@@ -163,8 +171,10 @@ async def test_merge_gate_wrapper_failopen():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
-@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락(형제 s18/s19/s29 패턴 미적용) — default-off라 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출(파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
-async def test_merge_gate_audit_persists_after_raise_commit():
+async def test_merge_gate_audit_persists_after_raise_commit(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "decision_gate_line_enabled", True)
+    monkeypatch.setattr(settings, "decision_gate_line_mode", "enforcing")
     """⭐SME blocking 회귀: gate_pending(라우터가 raise 前 db.commit) 후 engine 이 만든 step_run audit
     이 살아남아야 한다. commit 없이 raise 하면 get_db rollback 으로 사라지던 갭."""
     from sqlalchemy import select

--- a/backend/tests/test_edg_s7_handoff_relay.py
+++ b/backend/tests/test_edg_s7_handoff_relay.py
@@ -170,8 +170,10 @@ async def test_relay_db_poison_isolated_by_savepoint():
 # ── 엔진 relay 플래그 (enforcing agent-handoff만) ────────────────────────────
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
-@pytest.mark.xfail(strict=False, reason="settings.decision_gate_line_enabled monkeypatch 누락(형제 s18/s19/s29 패턴 미적용) — default-off라 plain_transition로 퇴화. story 8236bbc3 e2e서 신규 노출(파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
-async def test_engine_sets_relay_only_for_enforcing_agent_handoff():
+async def test_engine_sets_relay_only_for_enforcing_agent_handoff(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "decision_gate_line_enabled", True)
+    monkeypatch.setattr(settings, "decision_gate_line_mode", "enforcing")
     from app.services.workflow_line_engine import evaluate_line_for_transition
     from app.models.workflow_line import WorkflowLineDefinition, WorkflowLineDefinitionVersion
 

--- a/backend/tests/test_event1config_ack_retire.py
+++ b/backend/tests/test_event1config_ack_retire.py
@@ -85,51 +85,59 @@ _requires_db = pytest.mark.skipif(
 
 
 @_requires_db
-@pytest.mark.xfail(strict=False, reason="story 8236bbc3 e2e 시뮬레이션서 order-dependent 플레이키 확인(84파일 풀런서만 간헐 실패 — 공유DB 상태 의존 의심). story 18eefc31 트래킹.")
 @pytest.mark.anyio
 async def test_ack_retire_semantics_realdb():
     """<=seq pending → delivered, >seq 유지, 재-ack idempotent."""
-    from app.core.database import async_session_factory
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
     org, proj, agent = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
-    async with async_session_factory() as db:
-        await db.execute(
-            text("INSERT INTO organizations (id, name, slug) VALUES (:i, :n, :s)"),
-            {"i": org, "n": f"ack-org-{org}", "s": f"ack-{org}"},
-        )
-        await db.execute(
-            text("INSERT INTO projects (id, org_id, name) VALUES (:i, :o, :n)"),
-            {"i": proj, "o": org, "n": f"ack-proj-{proj}"},
-        )
-        for seq in (1, 2, 3):
+    # story 18eefc31: 테스트 전용 엔진(+dispose) — 프로덕션 전역 싱글턴
+    # `app.core.database.async_session_factory` 는 pytest-asyncio 함수-스코프 이벤트루프와
+    # 부딪혀 "attached to a different loop"(84파일 풀런서만 노출) — 다른 realdb 테스트와
+    # 동일 관례로 전환.
+    engine = create_async_engine(_ASYNCPG_URL.replace("postgresql://", "postgresql+asyncpg://"))
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as db:
             await db.execute(
-                text(
-                    "INSERT INTO events "
-                    "(id, org_id, project_id, event_type, recipient_id, recipient_type, "
-                    " payload, status, recipient_seq) VALUES "
-                    "(gen_random_uuid(), :o, :p, 'conversation.message_created', :r, 'agent', "
-                    " '{}', 'pending', :seq)"
-                ),
-                {"o": org, "p": proj, "r": agent, "seq": seq},
+                text("INSERT INTO organizations (id, name, slug) VALUES (:i, :n, :s)"),
+                {"i": org, "n": f"ack-org-{org}", "s": f"ack-{org}"},
             )
-        await db.commit()
-        try:
-            await ack_event(AckRequest(seq=2), db=db, auth=_api_key_auth(agent))
-
-            rows = (await db.execute(
-                text("SELECT recipient_seq, status FROM events WHERE recipient_id = :r"),
-                {"r": agent},
-            )).all()
-            by_seq = {r[0]: r[1] for r in rows}
-            assert by_seq[1] == "delivered"
-            assert by_seq[2] == "delivered"
-            assert by_seq[3] == "pending", ">seq 이벤트는 유지(미-ack)"
-
-            # 재-ack: 동일 seq → no-op(idempotent), 에러 없음
-            await ack_event(AckRequest(seq=2), db=db, auth=_api_key_auth(agent))
-        finally:
-            await db.execute(text("DELETE FROM events WHERE recipient_id = :r"), {"r": agent})
-            await db.execute(text("DELETE FROM agent_event_cursors WHERE agent_id = :a"), {"a": agent})
-            await db.execute(text("DELETE FROM projects WHERE id = :i"), {"i": proj})
-            await db.execute(text("DELETE FROM organizations WHERE id = :i"), {"i": org})
+            await db.execute(
+                text("INSERT INTO projects (id, org_id, name) VALUES (:i, :o, :n)"),
+                {"i": proj, "o": org, "n": f"ack-proj-{proj}"},
+            )
+            for seq in (1, 2, 3):
+                await db.execute(
+                    text(
+                        "INSERT INTO events "
+                        "(id, org_id, project_id, event_type, recipient_id, recipient_type, "
+                        " payload, status, recipient_seq) VALUES "
+                        "(gen_random_uuid(), :o, :p, 'conversation.message_created', :r, 'agent', "
+                        " '{}', 'pending', :seq)"
+                    ),
+                    {"o": org, "p": proj, "r": agent, "seq": seq},
+                )
             await db.commit()
+            try:
+                await ack_event(AckRequest(seq=2), db=db, auth=_api_key_auth(agent))
+
+                rows = (await db.execute(
+                    text("SELECT recipient_seq, status FROM events WHERE recipient_id = :r"),
+                    {"r": agent},
+                )).all()
+                by_seq = {r[0]: r[1] for r in rows}
+                assert by_seq[1] == "delivered"
+                assert by_seq[2] == "delivered"
+                assert by_seq[3] == "pending", ">seq 이벤트는 유지(미-ack)"
+
+                # 재-ack: 동일 seq → no-op(idempotent), 에러 없음
+                await ack_event(AckRequest(seq=2), db=db, auth=_api_key_auth(agent))
+            finally:
+                await db.execute(text("DELETE FROM events WHERE recipient_id = :r"), {"r": agent})
+                await db.execute(text("DELETE FROM agent_event_cursors WHERE agent_id = :a"), {"a": agent})
+                await db.execute(text("DELETE FROM projects WHERE id = :i"), {"i": proj})
+                await db.execute(text("DELETE FROM organizations WHERE id = :i"), {"i": org})
+                await db.commit()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_event1config_expire_cron.py
+++ b/backend/tests/test_event1config_expire_cron.py
@@ -71,51 +71,60 @@ _requires_db = pytest.mark.skipif(
 
 
 @_requires_db
-@pytest.mark.xfail(strict=False, reason="asyncpg 'attached to a different loop' RuntimeError — story 8236bbc3 e2e 시뮬레이션서 신규 노출(격리 재현 확인). story 18eefc31 트래킹.")
 @pytest.mark.anyio
 async def test_global_cleanup_recovers_delivered_across_orgs_realdb():
-    """전 org cleanup: 7일 초과 delivered 삭제(ACK retire 회수)·org 무관."""
-    from app.core.database import async_session_factory
+    """전 org cleanup: 7일 초과 delivered 삭제(ACK retire 회수)·org 무관.
+
+    story 18eefc31: `app.core.database.async_session_factory`(프로덕션 전역 엔진) 대신
+    테스트 전용 엔진 사용 — 다른 모든 realdb 테스트와 동일 관례(test_event1config_
+    webhook_targets.py::test_resolve_predicate_realdb와 동일 근본원인/수정, 함수-스코프
+    이벤트루프 간 커넥션풀 공유가 "attached to a different loop"를 유발)."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
     org_a, org_b = uuid.uuid4(), uuid.uuid4()
     proj_a, proj_b = uuid.uuid4(), uuid.uuid4()
     agent = uuid.uuid4()
     old = datetime.now(timezone.utc) - timedelta(days=10)
 
-    async with async_session_factory() as db:
-        for org, proj in ((org_a, proj_a), (org_b, proj_b)):
-            await db.execute(
-                text("INSERT INTO organizations (id, name, slug) VALUES (:i, :n, :s)"),
-                {"i": org, "n": f"exp-org-{org}", "s": f"exp-{org}"},
-            )
-            await db.execute(
-                text("INSERT INTO projects (id, org_id, name) VALUES (:i, :o, :n)"),
-                {"i": proj, "o": org, "n": f"exp-proj-{proj}"},
-            )
-            # 오래된 delivered(ACK retire 산출물) — cleanup 대상
-            await db.execute(
-                text(
-                    "INSERT INTO events (id, org_id, project_id, event_type, recipient_id, "
-                    " recipient_type, payload, status, recipient_seq, delivered_at) VALUES "
-                    "(gen_random_uuid(), :o, :p, 'conversation.message_created', :r, 'agent', "
-                    " '{}', 'delivered', 1, :d)"
-                ),
-                {"o": org, "p": proj, "r": agent, "d": old},
-            )
-        await db.commit()
-        try:
-            out = await expire_stale_events_core(db, org_id=None)
-            assert out["cleaned"] >= 2, "양 org 의 오래된 delivered 모두 회수"
-
-            remaining = (await db.execute(
-                text("SELECT count(*) FROM events WHERE recipient_id = :r AND status = 'delivered'"),
-                {"r": agent},
-            )).scalar()
-            assert remaining == 0
-        finally:
-            await db.execute(text("DELETE FROM events WHERE recipient_id = :r"), {"r": agent})
-            for proj in (proj_a, proj_b):
-                await db.execute(text("DELETE FROM projects WHERE id = :i"), {"i": proj})
-            for org in (org_a, org_b):
-                await db.execute(text("DELETE FROM organizations WHERE id = :i"), {"i": org})
+    engine = create_async_engine(_ASYNCPG_URL.replace("postgresql://", "postgresql+asyncpg://"))
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as db:
+            for org, proj in ((org_a, proj_a), (org_b, proj_b)):
+                await db.execute(
+                    text("INSERT INTO organizations (id, name, slug) VALUES (:i, :n, :s)"),
+                    {"i": org, "n": f"exp-org-{org}", "s": f"exp-{org}"},
+                )
+                await db.execute(
+                    text("INSERT INTO projects (id, org_id, name) VALUES (:i, :o, :n)"),
+                    {"i": proj, "o": org, "n": f"exp-proj-{proj}"},
+                )
+                # 오래된 delivered(ACK retire 산출물) — cleanup 대상
+                await db.execute(
+                    text(
+                        "INSERT INTO events (id, org_id, project_id, event_type, recipient_id, "
+                        " recipient_type, payload, status, recipient_seq, delivered_at) VALUES "
+                        "(gen_random_uuid(), :o, :p, 'conversation.message_created', :r, 'agent', "
+                        " '{}', 'delivered', 1, :d)"
+                    ),
+                    {"o": org, "p": proj, "r": agent, "d": old},
+                )
             await db.commit()
+            try:
+                out = await expire_stale_events_core(db, org_id=None)
+                assert out["cleaned"] >= 2, "양 org 의 오래된 delivered 모두 회수"
+
+                remaining = (await db.execute(
+                    text("SELECT count(*) FROM events WHERE recipient_id = :r AND status = 'delivered'"),
+                    {"r": agent},
+                )).scalar()
+                assert remaining == 0
+            finally:
+                await db.execute(text("DELETE FROM events WHERE recipient_id = :r"), {"r": agent})
+                for proj in (proj_a, proj_b):
+                    await db.execute(text("DELETE FROM projects WHERE id = :i"), {"i": proj})
+                for org in (org_a, org_b):
+                    await db.execute(text("DELETE FROM organizations WHERE id = :i"), {"i": org})
+                await db.commit()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_event1config_webhook_targets.py
+++ b/backend/tests/test_event1config_webhook_targets.py
@@ -115,48 +115,76 @@ _requires_db = pytest.mark.skipif(
 
 
 @_requires_db
-@pytest.mark.xfail(strict=False, reason="asyncpg 'attached to a different loop' RuntimeError — story 8236bbc3 e2e 시뮬레이션서 신규 노출(격리 재현 확인, 세션결합 아티팩트 아님). story 18eefc31 트래킹.")
+@pytest.mark.xfail(
+    strict=False,
+    reason="story 18eefc31 — 원래 xfail 사유(asyncpg 'attached to a different loop')는 "
+    "테스트 전용 엔진으로 전환해 해결됐으나(다른 모든 realdb 테스트와 동일 관례), 그 뒤에서 "
+    "별개의 진짜 product 버그가 드러났다: 이 테스트가 만드는 member_id=None 행(§AC2 "
+    "'project-wide broadcast webhook' — conversation_webhook.py:149-150,192에 문서화된 "
+    "핵심 로직, member_id IS NULL이면 무조건 포함)이 실 스키마에서 NotNullViolationError로 "
+    "거부된다. baseline/schema.sql 실측 확인: `member_id uuid NOT NULL`(CREATE TABLE 원문) "
+    "— ORM 모델(webhook_config.py: `member_id: Mapped[uuid.UUID]`, Optional 아님)과 "
+    "생성 스키마(schemas/webhook_config.py: `member_id: uuid.UUID`, 필수)까지 전부 동일하게 "
+    "NOT NULL/필수라 실제 API로 broadcast(member_id=NULL) webhook을 만들 방법 자체가 없다 "
+    "— 이 AC2 브랜치는 100% 도달 불가 dead code. 테스트를 고쳐서(real member_id로 치환) "
+    "통과시키는 건 이 발견을 숨기는 것이라 하지 않음 — product 판단(§AC2 폐기 vs "
+    "member_id nullable 마이그+생성경로 복구) 필요 — follow-up story 34b3a8fb(E-EVENT-1CONFIG·"
+    "backlog)로 분리, 그 story 의 결정·구현 완료 후 이 xfail 해소 예정. story 18eefc31 트래킹.",
+)
 @pytest.mark.anyio
 async def test_resolve_predicate_realdb():
-    """실DB: member-bound project-독립 union·sender 제외·broadcast 포함."""
-    from app.core.database import async_session_factory
+    """실DB: member-bound project-독립 union·sender 제외·broadcast 포함.
+
+    story 18eefc31: `app.core.database.async_session_factory`(프로덕션 전역 엔진, import 시
+    1회 생성)를 쓰면 pytest-asyncio의 함수-스코프 이벤트루프와 부딪힌다 — 커넥션 풀이 처음
+    쓰인 루프에 바인딩되고, 같은 프로세스에서 다른 테스트가 새 루프로 그 풀을 재사용하려
+    하면 asyncpg가 "attached to a different loop"로 죽는다(story 8236bbc3 e2e서 84개
+    realdb 파일을 한 세션에 몰아 돌리며 실제로 재현·격리 시엔 안 남). 다른 모든 realdb
+    테스트가 쓰는 관례(테스트 전용 엔진을 만들고 끝에 dispose)로 맞췄다 — 그 뒤 드러난 진짜
+    product 버그(§AC2 broadcast dead code)는 위 xfail 사유 참고."""
     from app.models.webhook_config import WebhookConfig
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
     org = uuid.uuid4()
     proj_x, proj_y = uuid.uuid4(), uuid.uuid4()
     sender, agent_a = uuid.uuid4(), uuid.uuid4()
 
-    async with async_session_factory() as db:
-        # agent_a webhook 은 proj_y 스코프(메시지는 proj_x) — project 독립 union 검증
-        db.add_all([
-            WebhookConfig(id=uuid.uuid4(), org_id=org, project_id=proj_y,
-                          member_id=agent_a, url="https://h/a", is_active=True,
-                          events=[_EVENT_TYPE]),
-            WebhookConfig(id=uuid.uuid4(), org_id=org, project_id=proj_x,
-                          member_id=sender, url="https://h/s", is_active=True,
-                          events=[_EVENT_TYPE]),
-            WebhookConfig(id=uuid.uuid4(), org_id=org, project_id=proj_x,
-                          member_id=None, url="https://h/b", is_active=True,
-                          events=[_EVENT_TYPE]),
-        ])
-        await db.commit()
-        try:
-            targets = await resolve_conversation_webhook_targets(
-                db, conversation_id=uuid.uuid4(), org_id=org, project_id=proj_x,
-                sender_id=sender, mentioned_ids=[sender, agent_a],
-            )
-            member_ids = {t.member_id for t in targets}
-            assert agent_a in member_ids, "타 프로젝트 member-bound 도 union 으로 covered(project 독립)"
-            assert sender not in member_ids, "sender 제외(Finding 2)"
-            assert None in member_ids, "broadcast 포함"
-        finally:
-            for mid in (agent_a, sender):
-                await db.execute(
-                    WebhookConfig.__table__.delete().where(WebhookConfig.member_id == mid)
-                )
-            await db.execute(
-                WebhookConfig.__table__.delete().where(
-                    WebhookConfig.org_id == org, WebhookConfig.member_id.is_(None)
-                )
-            )
+    engine = create_async_engine(_ASYNCPG_URL.replace("postgresql://", "postgresql+asyncpg://"))
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as db:
+            # agent_a webhook 은 proj_y 스코프(메시지는 proj_x) — project 독립 union 검증
+            db.add_all([
+                WebhookConfig(id=uuid.uuid4(), org_id=org, project_id=proj_y,
+                              member_id=agent_a, url="https://h/a", is_active=True,
+                              events=[_EVENT_TYPE]),
+                WebhookConfig(id=uuid.uuid4(), org_id=org, project_id=proj_x,
+                              member_id=sender, url="https://h/s", is_active=True,
+                              events=[_EVENT_TYPE]),
+                WebhookConfig(id=uuid.uuid4(), org_id=org, project_id=proj_x,
+                              member_id=None, url="https://h/b", is_active=True,
+                              events=[_EVENT_TYPE]),
+            ])
             await db.commit()
+            try:
+                targets = await resolve_conversation_webhook_targets(
+                    db, conversation_id=uuid.uuid4(), org_id=org, project_id=proj_x,
+                    sender_id=sender, mentioned_ids=[sender, agent_a],
+                )
+                member_ids = {t.member_id for t in targets}
+                assert agent_a in member_ids, "타 프로젝트 member-bound 도 union 으로 covered(project 독립)"
+                assert sender not in member_ids, "sender 제외(Finding 2)"
+                assert None in member_ids, "broadcast 포함"
+            finally:
+                for mid in (agent_a, sender):
+                    await db.execute(
+                        WebhookConfig.__table__.delete().where(WebhookConfig.member_id == mid)
+                    )
+                await db.execute(
+                    WebhookConfig.__table__.delete().where(
+                        WebhookConfig.org_id == org, WebhookConfig.member_id.is_(None)
+                    )
+                )
+                await db.commit()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_gateway_realdb_race.py
+++ b/backend/tests/test_gateway_realdb_race.py
@@ -83,7 +83,19 @@ async def _scan_events(conn, recipient_id: uuid.UUID, after_seq: int) -> list[in
 
 # ─── 핵심 race 테스트 ─────────────────────────────────────────────────────────
 
-@pytest.mark.xfail(strict=False, reason="ForeignKeyViolationError(events.project_id) — story 8236bbc3 e2e 시뮬레이션서 신규 노출, 실 동시성 버그 의심(PO: prod 우려·최우선 조사 대상). story 18eefc31 트래킹.")
+@pytest.mark.skip(
+    reason="story 18eefc31 심층 재진단(원래 사유였던 FK violation은 org/project autocommit "
+    "순서 fix로 해결됨 — 별개). 남은 문제는 이 테스트의 race 시나리오 자체가 현재 "
+    "per-recipient dense-seq 설계(agent_event_seqs 카운터 row-lock 직렬화, event_seq.py 참고) "
+    "하에서는 구성 불가능하다는 것 — T2가 T1(같은 recipient_id, 미커밋)과 같은 카운터 row를 "
+    "잡으려 하면 T1 커밋까지 그냥 블록된다(race 아님, 진짜 교착). xfail(실행은 됨)로는 "
+    "30초 타임아웃까지 블록 후 DB 커넥션을 오염 상태로 남겨 후속 테스트/cleanup까지 연쇄로 "
+    "막는다(실측: pg_stat_activity에 idle-in-transaction+lock-wait 잔존 확인) — 그래서 "
+    "xfail이 아니라 skip(미실행). codex 교차검증도 동일 결론(\"현재 구현 하 재구성 불가, "
+    "재설계 필요\"). 이 테스트가 검증하려던 위협 모델이 이후 아키텍처 변경(dense-seq)으로 "
+    "폐기됐는지, 다른 방식(예: 별도 recipient)으로 재구성해야 하는지는 product 판단 필요. "
+    "story 18eefc31 트래킹.",
+)
 @pytest.mark.anyio
 async def test_acked_seq_rescan_catches_low_seq_late_commit():
     """실 DB race: T1(낮은 seq, 늦게 커밋) → acked_seq 재스캔에서 반드시 잡힘.
@@ -112,7 +124,12 @@ async def test_acked_seq_rescan_catches_low_seq_late_commit():
     recipient_id = uuid.uuid4()
 
     try:
-        await conn_setup.execute("BEGIN")
+        # story 18eefc31: org/project INSERT를 conn_setup의 명시 트랜잭션(BEGIN)에 넣고
+        # COMMIT을 함수 끝까지 미루면, 아래 conn1(별개 커넥션)의 events INSERT가 그 미커밋
+        # project_id를 FK로 참조 → ForeignKeyViolationError(Postgres MVCC — 다른 커넥션엔
+        # 미커밋 row가 안 보임). 이 테스트가 검증하려는 진짜 race와 무관한 fixture 순서 버그였다
+        # (codex 교차검증 완료 — 결정적 100% 재현, 실 prod 동시성 이슈 아님). autocommit(암묵
+        # BEGIN/COMMIT 없이)으로 즉시 커밋해 conn1이 참조하기 전에 반드시 보이게 한다.
         org_id, project_id = await _make_test_org_and_project(conn_setup)
 
         # ── T1 시작: events INSERT (seq 발급, 미커밋) ──────────────────────
@@ -154,8 +171,6 @@ async def test_acked_seq_rescan_catches_low_seq_late_commit():
             f"after_seq={seq_t2} skips seq_t1={seq_t1}"
         )
 
-        await conn_setup.execute("COMMIT")
-
     except Exception:
         # 롤백 후 정리
         try:
@@ -189,7 +204,6 @@ async def test_acked_seq_rescan_catches_low_seq_late_commit():
         await scan_conn.close()
 
 
-@pytest.mark.xfail(strict=False, reason="ForeignKeyViolationError(events.project_id) — story 8236bbc3 e2e 시뮬레이션서 신규 노출, 실 동시성 버그 의심(PO: prod 우려·최우선 조사 대상). story 18eefc31 트래킹.")
 @pytest.mark.anyio
 async def test_rescan_from_acked_seq_not_max_sent():
     """max-advance vs acked_seq 재스캔 동작 대비 명시 검증.
@@ -204,7 +218,9 @@ async def test_rescan_from_acked_seq_not_max_sent():
     recipient_id = uuid.uuid4()
 
     try:
-        await setup_conn.execute("BEGIN")
+        # story 18eefc31: autocommit(암묵 BEGIN/COMMIT 없이) — conn(별개 커넥션)이 뒤이어
+        # 참조하기 전에 org/project가 즉시 보여야 한다(위 test_acked_seq_rescan_...와 동일
+        # fixture 순서 버그, 동일 수정).
         org_id, project_id = await _make_test_org_and_project(setup_conn)
 
         # seq 3개 INSERT (모두 커밋)
@@ -222,8 +238,6 @@ async def test_rescan_from_acked_seq_not_max_sent():
         assert seqs[2] in visible
         assert seqs[0] not in visible  # acked는 제외
 
-        await setup_conn.execute("COMMIT")
-
     finally:
         cleanup = await asyncpg.connect(_ASYNCPG_URL)
         try:
@@ -236,7 +250,6 @@ async def test_rescan_from_acked_seq_not_max_sent():
         await conn.close()
         await setup_conn.close()
 
-@pytest.mark.xfail(strict=False, reason="ForeignKeyViolationError(events.project_id) — story 8236bbc3 e2e 시뮬레이션서 신규 노출, 실 동시성 버그 의심(PO: prod 우려·최우선 조사 대상). story 18eefc31 트래킹.")
 @pytest.mark.anyio
 async def test_per_recipient_dense_seq_prevents_ack_ordering_gap():
     """AC3: per-recipient dense seq → ack-후-늦커밋 gap 구조적 불가.
@@ -260,7 +273,7 @@ async def test_per_recipient_dense_seq_prevents_ack_ordering_gap():
     project_id = None
 
     try:
-        await conn_setup.execute("BEGIN")
+        # story 18eefc31: autocommit — 위 두 테스트와 동일 fixture 순서 버그·동일 수정.
         org_id, project_id = await _make_test_org_and_project(conn_setup)
 
         # T1: seq 발급 (카운터 row-lock 획득, 낮은 seq)
@@ -297,8 +310,6 @@ async def test_per_recipient_dense_seq_prevents_ack_ordering_gap():
         assert seq_t1 not in higher_ack_visible  # 이미 acked
         assert seq_t2 not in higher_ack_visible  # 이미 acked
         # 새 이벤트가 없으므로 빈 배열 = 누락 없음
-
-        await conn_setup.execute("COMMIT")
 
     except Exception:
         try: await conn1.execute("ROLLBACK")

--- a/backend/tests/test_h1_s10_e2e.py
+++ b/backend/tests/test_h1_s10_e2e.py
@@ -27,7 +27,6 @@ def anyio_backend():
 
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
-@pytest.mark.xfail(strict=False, reason="clean_pass_rate가 None(기대 non-None) — trust 계산 seed/calibration 갭 의심. story 8236bbc3 e2e서 신규 노출(파일 자체가 CI 최초 실행). story 18eefc31 트래킹.")
 @pytest.mark.anyio
 async def test_h1_end_to_end_ready_to_done():
     from sqlalchemy import text as _text
@@ -106,7 +105,13 @@ async def test_h1_end_to_end_ready_to_done():
             )).scalar()
             assert vcount >= 2, f"verdict(pr/ci/merge) 증가해야, got {vcount}"
 
-            trust = await compute_member_trust_scores(s, org, member, role_key="implementation")
+            # story 18eefc31: HO-S5(#1497, 이 E2E 원작 PR #1487 以後 병합)가 기본 trust
+            # source를 hypothesis_outcome_* 로 제한해 이 체인이 캡처하는 CI/pr/merge verdict는
+            # 기본 집계에서 제외된다 — include_legacy=True 로 legacy source 합산 명시(product
+            # 버그 아닌 API 변경에 뒤처진 테스트 staleness).
+            trust = await compute_member_trust_scores(
+                s, org, member, role_key="implementation", include_legacy=True
+            )
             assert trust["scores"], "trust scores가 비지 않아야(verdict 누적)"
             assert trust["scores"][0]["clean_pass_rate"] is not None, "trust null 아니어야"
 

--- a/backend/tests/test_h1_s7_gate_verdict.py
+++ b/backend/tests/test_h1_s7_gate_verdict.py
@@ -140,7 +140,6 @@ async def test_fast_reject_not_rubber_stamp():
 # ── AC④: 실DB — 사람 review verdict가 trust score에 반영 ───────────────────────
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
-@pytest.mark.xfail(strict=False, reason="clean_pass_rate가 None(기대 1.0) — trust 계산 seed/calibration 갭 의심(test_h1_s10_e2e와 동일 클래스). story 8236bbc3 e2e서 신규 노출. story 18eefc31 트래킹.")
 @pytest.mark.anyio
 async def test_human_review_verdict_reflected_in_trust_real_db():
     from sqlalchemy import text as _text
@@ -183,7 +182,14 @@ async def test_human_review_verdict_reflected_in_trust_real_db():
             await s.commit()
 
         async with Session() as s:
-            trust = await compute_member_trust_scores(s, org, member, role_key="implementation")
+            # story 18eefc31: HO-S5(#1497, 이 테스트 원작 PR #1489 以後 병합)가 기본 trust
+            # source를 hypothesis_outcome_* 로 제한해 CI/pr/merge verdict는 기본 집계에서
+            # 제외한다 — 이 테스트가 검증하려는 "사람 review(merge) verdict → trust 반영"은
+            # legacy source 이므로 include_legacy=True 로 명시(product 버그 아닌 API 변경에
+            # 뒤처진 테스트 staleness).
+            trust = await compute_member_trust_scores(
+                s, org, member, role_key="implementation", include_legacy=True
+            )
             scores = trust["scores"]
             # AC④: 사람 review verdict가 trust 집계에 반영(clean pass 1).
             assert scores and scores[0]["clean_pass_rate"] == 1.0

--- a/backend/tests/test_ho_s3_hypothesis_owner_seed.py
+++ b/backend/tests/test_ho_s3_hypothesis_owner_seed.py
@@ -25,7 +25,6 @@ def _load_migration():
 
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
-@pytest.mark.xfail(strict=False, reason="NotNullViolation(organizations.name) — story 8236bbc3 e2e 시뮬레이션서 신규 노출(격리 재현 확인). story 18eefc31 트래킹.")
 def test_seed_hypothesis_owner_per_org_idempotent():
     import sqlalchemy as sa
     from alembic.operations import Operations
@@ -46,7 +45,13 @@ def test_seed_hypothesis_owner_per_org_idempotent():
     try:
         with eng.begin() as c:
             # 마이그가 의존하는 테이블이 없으면 만든다(fresh DB 격리 — CI는 마이그 체인으로 존재).
-            c.execute(sa.text("CREATE TABLE IF NOT EXISTS organizations (id uuid PRIMARY KEY)"))
+            # story 18eefc31: name/slug는 실 baseline(organizations NOT NULL, 기본값 없음)과
+            # 정합해야 alembic-migrated DB(참 스키마)에서도 INSERT가 성립한다 — id만 있는
+            # 이전 버전은 fresh-DB 경로만 우연히 통과하고 migrated-DB 경로에서 항상 깨졌다.
+            c.execute(sa.text(
+                "CREATE TABLE IF NOT EXISTS organizations "
+                "(id uuid PRIMARY KEY, name text NOT NULL, slug text NOT NULL)"
+            ))
             c.execute(sa.text(
                 "CREATE TABLE IF NOT EXISTS participation_role (id uuid PRIMARY KEY, org_id uuid NOT NULL, "
                 "key varchar(50) NOT NULL, label text NOT NULL, is_default boolean NOT NULL DEFAULT false, "
@@ -56,7 +61,13 @@ def test_seed_hypothesis_owner_per_org_idempotent():
                 "CREATE UNIQUE INDEX IF NOT EXISTS uq_participation_role_org_key "
                 "ON participation_role (org_id, key)"
             ))
-            c.execute(sa.text("INSERT INTO organizations(id) VALUES (:a),(:b)"), {"a": org_a, "b": org_b})
+            c.execute(
+                sa.text("INSERT INTO organizations(id,name,slug) VALUES (:a,:na,:sa),(:b,:nb,:sb)"),
+                {
+                    "a": org_a, "na": f"ho-s3-org-{org_a}", "sa": f"ho-s3-{org_a}",
+                    "b": org_b, "nb": f"ho-s3-org-{org_b}", "sb": f"ho-s3-{org_b}",
+                },
+            )
             # org_a는 이미 hypothesis_owner 보유(중복 방지 검증).
             c.execute(sa.text(
                 "INSERT INTO participation_role(id,org_id,key,label) VALUES (:i,:o,'hypothesis_owner','기존')"

--- a/backend/tests/test_l1_consume_helpers.py
+++ b/backend/tests/test_l1_consume_helpers.py
@@ -53,9 +53,8 @@ async def _session():
     return engine, async_sessionmaker(engine, expire_on_commit=False)
 
 
-@pytest.mark.xfail(strict=False, reason="story 8236bbc3 e2e 시뮬레이션서 order-dependent 플레이키 확인(소배치 격리서는 통과·84파일 풀런서만 실패 — 공유DB 상태 의존 의심). story 18eefc31 트래킹.")
 async def test_poll_activities_after_seq_cursor_and_org_scope():
-    from sqlalchemy import select
+    from sqlalchemy import func, select
 
     from app.models.activity_event import ActivityEvent
     from app.services.activity_stream import poll_activities_after_seq
@@ -64,25 +63,34 @@ async def test_poll_activities_after_seq_cursor_and_org_scope():
     org_a, org_b = uuid.uuid4(), uuid.uuid4()
     try:
         async with Session() as s:
+            # story 18eefc31: activity_events 는 이 파일 전체·84파일 풀런에서 공유되는 테이블이라
+            # (cleanup 없음) 이전 테스트/파일이 심은 잔여행이 누적된다. 원래 base 계산(전체 테이블
+            # MIN(activity_seq))은 그 잔여행까지 잡아 poll_after(base-1)가 이 테스트의 4행보다
+            # 훨씬 많이 반환 — 소배치서는 우연히 통과(잔여 없음)·84파일 풀런서만 실패했다.
+            # 삽입 直前 워터마크(MAX, 순차실행이라 동시쓰기 없음 — 안전)를 cursor 기준으로 삼아
+            # "이 테스트가 심은 행만" 포착하도록 근본수정.
+            pre = (await s.execute(select(func.max(ActivityEvent.activity_seq)))).scalar() or 0
             s.add_all([_act(org_a), _act(org_a), _act(org_b), _act(org_a)])
             await s.commit()
-            base = (await s.execute(select(ActivityEvent.activity_seq).order_by(ActivityEvent.activity_seq.asc()))).scalars().first()
 
-            # org 생략 = 전 org poll. after_seq=base-1로 전체 4행.
-            allrows, _ = await poll_activities_after_seq(s, base - 1, limit=100)
+            # org 생략 = 전 org poll. after_seq=pre(삽입 直前 워터마크)로 이 테스트의 4행만.
+            allrows, _ = await poll_activities_after_seq(s, pre, limit=100)
             assert len(allrows) == 4
             assert [r.activity_seq for r in allrows] == sorted(r.activity_seq for r in allrows)  # ASC
 
             # org_a 스코프 = 3행(org_b 제외).
-            a_rows, _ = await poll_activities_after_seq(s, base - 1, limit=100, org_id=org_a)
+            a_rows, _ = await poll_activities_after_seq(s, pre, limit=100, org_id=org_a)
             assert len(a_rows) == 3 and all(r.org_id == org_a for r in a_rows)
 
             # cursor: limit=2 → next_after_seq, 이어 읽기 strict(중복 0).
-            p1, nxt1 = await poll_activities_after_seq(s, base - 1, limit=2, org_id=org_a)
+            p1, nxt1 = await poll_activities_after_seq(s, pre, limit=2, org_id=org_a)
             assert len(p1) == 2 and nxt1 == p1[-1].activity_seq
             p2, nxt2 = await poll_activities_after_seq(s, nxt1, limit=2, org_id=org_a)
             assert len(p2) == 1 and nxt2 is None
             assert p2[0].activity_seq > nxt1
+
+            await s.execute(ActivityEvent.__table__.delete().where(ActivityEvent.org_id.in_([org_a, org_b])))
+            await s.commit()
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_s2_3_presence_status.py
+++ b/backend/tests/test_s2_3_presence_status.py
@@ -19,8 +19,6 @@ ORG_ID = uuid.uuid4()
 PROJECT_ID = uuid.uuid4()
 MEMBER_ID = uuid.uuid4()
 
-NOW = datetime.now(timezone.utc)
-
 
 def _mock_member(type_: str = "agent", last_seen_at=None):
     m = MagicMock()
@@ -69,7 +67,8 @@ def test_presence_status_online():
 def test_presence_status_idle():
     """AC3: last_seen_at 15분 전 → idle."""
     from app.schemas.team_member import TeamMemberResponse
-    m = _mock_member(last_seen_at=NOW - timedelta(minutes=15))
+    now = datetime.now(timezone.utc)
+    m = _mock_member(last_seen_at=now - timedelta(minutes=15))
     resp = TeamMemberResponse.model_validate(m)
     assert resp.presence_status == "idle"
 
@@ -77,7 +76,8 @@ def test_presence_status_idle():
 def test_presence_status_offline_over_30():
     """AC4: last_seen_at 31분 전 → offline."""
     from app.schemas.team_member import TeamMemberResponse
-    m = _mock_member(last_seen_at=NOW - timedelta(minutes=31))
+    now = datetime.now(timezone.utc)
+    m = _mock_member(last_seen_at=now - timedelta(minutes=31))
     resp = TeamMemberResponse.model_validate(m)
     assert resp.presence_status == "offline"
 
@@ -93,7 +93,8 @@ def test_presence_status_offline_null_agent():
 def test_presence_status_null_for_human():
     """AC5: type=human → presence_status=null."""
     from app.schemas.team_member import TeamMemberResponse
-    m = _mock_member(type_="human", last_seen_at=NOW - timedelta(minutes=1))
+    now = datetime.now(timezone.utc)
+    m = _mock_member(type_="human", last_seen_at=now - timedelta(minutes=1))
     resp = TeamMemberResponse.model_validate(m)
     assert resp.presence_status is None
 
@@ -149,15 +150,15 @@ async def _client():
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
 
 
-@pytest.mark.xfail(strict=False, reason="시각-경계 플레이키 — 모듈 임포트 시점 고정 NOW상수 vs 실행 시점 datetime.now() 드리프트로 online/idle 경계 오검(real-DB 무관·순수 mock, 84파일 동시실행으로 세션 총 소요시간 늘어나며 경계 넘어감). story 8236bbc3 e2e서 신규 노출. story 18eefc31 트래킹.")
 @pytest.mark.anyio
 async def test_list_team_members_includes_presence_status():
     """AC1: GET /api/v2/team-members 응답에 presence_status 필드 포함."""
     client, session, app = await _client()
     try:
+        now = datetime.now(timezone.utc)
         mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = [
-            _mock_member(type_="agent", last_seen_at=NOW - timedelta(minutes=2))
+            _mock_member(type_="agent", last_seen_at=now - timedelta(minutes=2))
         ]
         session.execute = AsyncMock(return_value=mock_result)
 
@@ -173,18 +174,18 @@ async def test_list_team_members_includes_presence_status():
         app.dependency_overrides.clear()
 
 
-@pytest.mark.xfail(strict=False, reason="시각-경계 플레이키 — 모듈 임포트 시점 고정 NOW상수 vs 실행 시점 datetime.now() 드리프트(test_list_team_members_includes_presence_status와 동일 클래스). story 8236bbc3 e2e서 신규 노출. story 18eefc31 트래킹.")
 @pytest.mark.anyio
 async def test_list_members_mixed_presence():
     """AC1/2/3/4/5: 다양한 멤버 타입 + last_seen_at 혼합."""
     client, session, app = await _client()
     try:
+        now = datetime.now(timezone.utc)
         members = [
-            _mock_member(type_="agent", last_seen_at=NOW - timedelta(minutes=2)),   # online
-            _mock_member(type_="agent", last_seen_at=NOW - timedelta(minutes=15)),  # idle
-            _mock_member(type_="agent", last_seen_at=NOW - timedelta(minutes=60)),  # offline
+            _mock_member(type_="agent", last_seen_at=now - timedelta(minutes=2)),   # online
+            _mock_member(type_="agent", last_seen_at=now - timedelta(minutes=15)),  # idle
+            _mock_member(type_="agent", last_seen_at=now - timedelta(minutes=60)),  # offline
             _mock_member(type_="agent", last_seen_at=None),                         # offline
-            _mock_member(type_="human", last_seen_at=NOW - timedelta(minutes=1)),   # null
+            _mock_member(type_="human", last_seen_at=now - timedelta(minutes=1)),   # null
         ]
         # 고유 ID 부여
         for i, m in enumerate(members):

--- a/backend/tests/test_standup_org_level_3b6b567c.py
+++ b/backend/tests/test_standup_org_level_3b6b567c.py
@@ -138,8 +138,29 @@ _DEDUPE_SQL = [
 
 @pytest.mark.anyio
 @pytest.mark.skipif(not _ASYNC, reason="real-DB URL 미설정 — skip")
-@pytest.mark.xfail(strict=False, reason="asyncpg TypeError: expected datetime.date/datetime, got str — story 8236bbc3 e2e 시뮬레이션서 신규 노출(asyncpg 엄격 datetime 타이핑 패턴). story 18eefc31 트래킹.")
+@pytest.mark.xfail(
+    strict=False,
+    reason="story 18eefc31 — asyncpg datetime 타이핑(원 xfail 사유)은 실 datetime 객체 바인딩으로 "
+    "해결했으나(다른 realdb 테스트와 동일 관례), 그 뒤 별개의 진짜 product 버그가 드러났다: "
+    "2d text-MERGE 의 `count(*) OVER w`(ORDER BY 있는 named window, 명시 frame 없음)는 PG 기본"
+    "frame(RANGE UNBOUNDED PRECEDING AND CURRENT ROW)이 적용돼 partition 전체 크기가 아니라 "
+    "累積(cumulative) count 를 반환한다 — rn=1(파티션 첫 행)일 때 cnt 는 항상 1이라 "
+    "`WHERE r.rn=1 AND r.cnt>1`(keepers CTE)가 그룹 크기와 무관하게 영원히 0행이다. 즉 "
+    "done/plan/blockers MERGE(UPDATE)가 **항상 no-op**이고, 뒤이은 2e DELETE 는 keeper 이외 값을 "
+    "그대로 버린다 — winner-only lossy merge. 이 SQL은 alembic/versions/0099_standup_org_level.py "
+    "2d 와 완전 동형(migration 원문 그대로 복제)이며, 그 마이그의 docstring 은 명문으로 "
+    "'PO ①·dev lossy_rows=1 실적출 → winner-only 폐기'(즉 PO가 winner-only 를 명시 거부하고 "
+    "content-preserving MERGE 를 확정)라고 밝힌다 — 실제로는 그 반대(PO가 거부한 winner-only)가 "
+    "일어난다. 로컬 psql 로 최소 재현: 2-row 그룹에서 `count(*) OVER w`=[1,2], "
+    "`count(*) OVER (PARTITION BY org_id,author_id,date)`(명시 frame 없는 별도 window)=[2,2] — "
+    "cnt 컬럼 자체가 버그. 마이그는 이미 실행됐고(dev 최신 head 포함) 데이터 손실이 이미 "
+    "발생했을 가능성(당시 dedupe 대상 그룹이 실제 있었는지는 별도 포렌식 필요, prod 접근 없음 "
+    "— 에스컬 사유) — 이 story(test-infra 하드닝) 스코프 밖이라 테스트를 완화해 통과시키지 않고 "
+    "xfail+PO 에스컬 — SQL 프레임 근본수정은 follow-up story 4f88f7b7(E-STANDUP)로 분리, 그 "
+    "story 구현·머지 完了 後 이 xfail 해소. story 18eefc31 트래킹.",
+)
 async def test_dedupe_merge_lossless_and_idempotent_realdb():
+    from datetime import datetime, timezone
     from sqlalchemy import text
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
@@ -150,83 +171,97 @@ async def test_dedupe_merge_lossless_and_idempotent_realdb():
     eng = create_async_engine(_ASYNC)
     sm = async_sessionmaker(eng, expire_on_commit=False)
     try:
-        async with sm() as s:
-            # 격리: unique index 잠시 제거(테스트 dup 시드 허용)
-            await s.execute(text("DROP INDEX IF EXISTS uq_standup_org_author_date"))
-            for pid, nm in ((p1, "Alpha"), (p2, "Beta"), (p3, "Gamma")):
-                await s.execute(text("INSERT INTO projects (id,org_id,name,created_at) VALUES (:i,:o,:n,now())"),
-                                {"i": pid, "o": org, "n": nm})
-            rows = [
-                (e1, p1, "PLAN-ALPHA", "2026-06-05 10:00+00"),
-                (e2, p2, "PLAN-BETA", "2026-06-05 11:00+00"),
-                (e3, p3, "PLAN-GAMMA", "2026-06-05 12:00+00"),  # keeper(latest)
-            ]
-            for eid, pid, plan, ts in rows:
+        try:
+            async with sm() as s:
+                # 격리: unique index 잠시 제거(테스트 dup 시드 허용)
+                await s.execute(text("DROP INDEX IF EXISTS uq_standup_org_author_date"))
+                # story 18eefc31: organizations 행 없이 projects.org_id를 채우던 이전 버전은
+                # 실 FK(projects_org_id_fkey)가 있는 migrated DB에서 깨진다 — 명시 시드.
+                await s.execute(
+                    text("INSERT INTO organizations (id,name,slug) VALUES (:i,:n,:sl)"),
+                    {"i": org, "n": f"standup-org-{org}", "sl": f"standup-{org}"},
+                )
+                for pid, nm in ((p1, "Alpha"), (p2, "Beta"), (p3, "Gamma")):
+                    await s.execute(text("INSERT INTO projects (id,org_id,name,created_at) VALUES (:i,:o,:n,now())"),
+                                    {"i": pid, "o": org, "n": nm})
+                # story 18eefc31: asyncpg는 timestamptz 컬럼에 ISO 문자열을 직접 바인딩하면
+                # TypeError(expected datetime.date/datetime, got str)로 거부한다 — 실 datetime
+                # 객체로 바인딩(asyncpg 엄격 타이핑, 이 세션에서 반복 확인된 패턴).
+                rows = [
+                    (e1, p1, "PLAN-ALPHA", datetime(2026, 6, 5, 10, 0, tzinfo=timezone.utc)),
+                    (e2, p2, "PLAN-BETA", datetime(2026, 6, 5, 11, 0, tzinfo=timezone.utc)),
+                    (e3, p3, "PLAN-GAMMA", datetime(2026, 6, 5, 12, 0, tzinfo=timezone.utc)),  # keeper(latest)
+                ]
+                for eid, pid, plan, ts in rows:
+                    await s.execute(text(
+                        "INSERT INTO standup_entries (id,org_id,project_id,author_id,date,plan,plan_story_ids,created_at,updated_at)"
+                        " VALUES (:i,:o,:p,:a,:d,:pl,ARRAY[]::uuid[],:t,:t)"),
+                        {"i": eid, "o": org, "p": pid, "a": author, "d": d, "pl": plan, "t": ts})
+                    await s.execute(text(
+                        "INSERT INTO standup_entry_projects (id,entry_id,project_id,org_id) VALUES (gen_random_uuid(),:e,:p,:o)"),
+                        {"e": eid, "p": pid, "o": org})
+                # feedback on 비-keeper(e1)
                 await s.execute(text(
-                    "INSERT INTO standup_entries (id,org_id,project_id,author_id,date,plan,plan_story_ids,created_at,updated_at)"
-                    " VALUES (:i,:o,:p,:a,:d,:pl,ARRAY[]::uuid[],:t,:t)"),
-                    {"i": eid, "o": org, "p": pid, "a": author, "d": d, "pl": plan, "t": ts})
-                await s.execute(text(
-                    "INSERT INTO standup_entry_projects (id,entry_id,project_id,org_id) VALUES (gen_random_uuid(),:e,:p,:o)"),
-                    {"e": eid, "p": pid, "o": org})
-            # feedback on 비-keeper(e1)
-            await s.execute(text(
-                "INSERT INTO standup_feedback (id,org_id,project_id,standup_entry_id,feedback_by_id,review_type,feedback_text,created_at,updated_at)"
-                " VALUES (:i,:o,:p,:se,:fb,'comment','good',now(),now())"),
-                {"i": fb, "o": org, "p": p1, "se": e1, "fb": uuid.uuid4()})
-            await s.commit()
-
-            async def run_dedupe():
-                for sql in _DEDUPE_SQL:
-                    await s.execute(text(sql))
+                    "INSERT INTO standup_feedback (id,org_id,project_id,standup_entry_id,feedback_by_id,review_type,feedback_text,created_at,updated_at)"
+                    " VALUES (:i,:o,:p,:se,:fb,'comment','good',now(),now())"),
+                    {"i": fb, "o": org, "p": p1, "se": e1, "fb": uuid.uuid4()})
                 await s.commit()
 
-            await run_dedupe()
+                async def run_dedupe():
+                    for sql in _DEDUPE_SQL:
+                        await s.execute(text(sql))
+                    await s.commit()
 
-            # 1엔트리만 남음 = keeper(e3)
-            cnt = (await s.execute(text(
-                "SELECT count(*) FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d"),
-                {"o": org, "a": author, "d": d})).scalar_one()
-            assert cnt == 1
-            keeper_plan = (await s.execute(text(
-                "SELECT plan FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d"),
-                {"o": org, "a": author, "d": d})).scalar_one()
-            # 내용 0 소실 — 세 plan 전부 보존
-            assert "PLAN-GAMMA" in keeper_plan
-            assert "PLAN-ALPHA" in keeper_plan and "Alpha" in keeper_plan  # provenance
-            assert "PLAN-BETA" in keeper_plan and "Beta" in keeper_plan
-            # 링크 union = {p1,p2,p3} 가 keeper 에
-            links = set((await s.execute(text(
-                "SELECT project_id FROM standup_entry_projects WHERE entry_id IN "
-                "(SELECT id FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d)"),
-                {"o": org, "a": author, "d": d})).scalars().all())
-            assert links == {p1, p2, p3}
-            # feedback reattach → keeper(e3)
-            fb_entry = (await s.execute(text("SELECT standup_entry_id FROM standup_feedback WHERE id=:i"),
-                                        {"i": fb})).scalar_one()
-            assert fb_entry == e3
-            # lossy_rows = 0 재프로브(그룹 단일행 → dup 0)
-            lossy = (await s.execute(text("""
-                WITH ranked AS (SELECT id, row_number() OVER (PARTITION BY org_id,author_id,date) rn
-                                FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d)
-                SELECT count(*) FROM ranked WHERE rn>1"""), {"o": org, "a": author, "d": d})).scalar_one()
-            assert lossy == 0
+                await run_dedupe()
 
-            # 멱등: 재실행 무변화
-            await run_dedupe()
-            cnt2 = (await s.execute(text(
-                "SELECT count(*) FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d"),
-                {"o": org, "a": author, "d": d})).scalar_one()
-            assert cnt2 == 1
-        # cleanup + unique index 복원
-        async with sm() as s:
-            await s.execute(text("DELETE FROM standup_feedback WHERE org_id=:o"), {"o": org})
-            await s.execute(text("DELETE FROM standup_entry_projects WHERE org_id=:o"), {"o": org})
-            await s.execute(text("DELETE FROM standup_entries WHERE org_id=:o"), {"o": org})
-            await s.execute(text("DELETE FROM projects WHERE org_id=:o"), {"o": org})
-            await s.execute(text(
-                "CREATE UNIQUE INDEX IF NOT EXISTS uq_standup_org_author_date "
-                "ON standup_entries (org_id, author_id, date)"))
-            await s.commit()
+                # 1엔트리만 남음 = keeper(e3)
+                cnt = (await s.execute(text(
+                    "SELECT count(*) FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d"),
+                    {"o": org, "a": author, "d": d})).scalar_one()
+                assert cnt == 1
+                keeper_plan = (await s.execute(text(
+                    "SELECT plan FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d"),
+                    {"o": org, "a": author, "d": d})).scalar_one()
+                # 내용 0 소실 — 세 plan 전부 보존
+                assert "PLAN-GAMMA" in keeper_plan
+                assert "PLAN-ALPHA" in keeper_plan and "Alpha" in keeper_plan  # provenance
+                assert "PLAN-BETA" in keeper_plan and "Beta" in keeper_plan
+                # 링크 union = {p1,p2,p3} 가 keeper 에
+                links = set((await s.execute(text(
+                    "SELECT project_id FROM standup_entry_projects WHERE entry_id IN "
+                    "(SELECT id FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d)"),
+                    {"o": org, "a": author, "d": d})).scalars().all())
+                assert links == {p1, p2, p3}
+                # feedback reattach → keeper(e3)
+                fb_entry = (await s.execute(text("SELECT standup_entry_id FROM standup_feedback WHERE id=:i"),
+                                            {"i": fb})).scalar_one()
+                assert fb_entry == e3
+                # lossy_rows = 0 재프로브(그룹 단일행 → dup 0)
+                lossy = (await s.execute(text("""
+                    WITH ranked AS (SELECT id, row_number() OVER (PARTITION BY org_id,author_id,date) rn
+                                    FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d)
+                    SELECT count(*) FROM ranked WHERE rn>1"""), {"o": org, "a": author, "d": d})).scalar_one()
+                assert lossy == 0
+
+                # 멱등: 재실행 무변화
+                await run_dedupe()
+                cnt2 = (await s.execute(text(
+                    "SELECT count(*) FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d"),
+                    {"o": org, "a": author, "d": d})).scalar_one()
+                assert cnt2 == 1
+        finally:
+            # cleanup + unique index 복원 — story 18eefc31: assertion 실패(xfail) 시에도
+            # 항상 실행돼야 시드 데이터가 공유 job DB에 누적되지 않는다(다른 realdb 테스트와
+            # 동일 finally-cleanup 관례). 이전 버전은 이 블록이 try 밖에 있어 실패 시 스킵됐다.
+            async with sm() as s:
+                await s.execute(text("DELETE FROM standup_feedback WHERE org_id=:o"), {"o": org})
+                await s.execute(text("DELETE FROM standup_entry_projects WHERE org_id=:o"), {"o": org})
+                await s.execute(text("DELETE FROM standup_entries WHERE org_id=:o"), {"o": org})
+                await s.execute(text("DELETE FROM projects WHERE org_id=:o"), {"o": org})
+                await s.execute(text("DELETE FROM organizations WHERE id=:o"), {"o": org})
+                await s.execute(text(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS uq_standup_org_author_date "
+                    "ON standup_entries (org_id, author_id, date)"))
+                await s.commit()
     finally:
         await eng.dispose()

--- a/backend/tests/test_webhook_targeting.py
+++ b/backend/tests/test_webhook_targeting.py
@@ -91,11 +91,22 @@ _requires_db = pytest.mark.skipif(
 
 
 @_requires_db
-@pytest.mark.xfail(strict=False, reason="story 8236bbc3 e2e 시뮬레이션서 order-dependent 플레이키 확인(배치별로 다른 에러 — asyncio loop RuntimeError 또는 webhook_configs.member_id NotNullViolation). story 18eefc31 트래킹.")
+@pytest.mark.xfail(
+    strict=False,
+    reason="story 18eefc31 — 원 xfail 사유(order-dependent, 배치별 asyncio loop RuntimeError)는 "
+    "test_event1config_webhook_targets.py::test_resolve_predicate_realdb 와 동일 근본원인(공유 "
+    "singleton `app.core.database.async_session_factory` 를 pytest-asyncio 함수-스코프 루프에서 "
+    "사용)이라 동일 수정(테스트 전용 엔진+dispose)으로 해결했으나, 그 뒤에 남는 두 번째 에러 "
+    "(webhook_configs.member_id NotNullViolation, broadcast 행 member_id=None 시드)는 별개의 "
+    "이미-에스컬된 product 버그다 — §AC2 project-wide broadcast webhook 은 member_id NOT NULL "
+    "제약 때문에 100% 도달 불가 dead code(follow-up story 34b3a8fb 에서 폐기 vs 복구 결정 대기). "
+    "그 story 의 결정·구현 완료 後 이 xfail 도 함께 해소. story 18eefc31 트래킹.",
+)
 @pytest.mark.anyio
 async def test_predicate_semantics_realdb():
     """실DB: member-bound는 project 독립으로 covered, broadcast(null)은 제외, 타 org 격리."""
-    from app.core.database import async_session_factory
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
     from app.models.webhook_config import WebhookConfig
 
     org_a, org_b = uuid.uuid4(), uuid.uuid4()
@@ -105,37 +116,44 @@ async def test_predicate_semantics_realdb():
     agent_cross_org = uuid.uuid4()     # 타 org webhook
     agent_inactive = uuid.uuid4()      # is_active=False
 
-    async with async_session_factory() as db:
-        db.add_all([
-            WebhookConfig(id=uuid.uuid4(), org_id=org_a, project_id=proj_x,
-                          member_id=agent_member_proj, url="https://h/1", is_active=True),
-            WebhookConfig(id=uuid.uuid4(), org_id=org_a, project_id=proj_x,
-                          member_id=None, url="https://h/bcast", is_active=True),
-            WebhookConfig(id=uuid.uuid4(), org_id=org_b, project_id=proj_y,
-                          member_id=agent_cross_org, url="https://h/2", is_active=True),
-            WebhookConfig(id=uuid.uuid4(), org_id=org_a, project_id=proj_x,
-                          member_id=agent_inactive, url="https://h/3", is_active=False),
-        ])
-        await db.commit()
-        try:
-            # org_a 기준 조회: proj_y 대화여도 member-bound는 project 독립으로 covered.
-            out = await active_webhook_member_ids(
-                db, org_a,
-                [agent_member_proj, agent_broadcast_only, agent_cross_org, agent_inactive],
-            )
-            assert agent_member_proj in out, "member-bound는 project 독립으로 covered"
-            assert agent_broadcast_only not in out, "broadcast(null)은 멤버 커버 아님 — 제외"
-            assert agent_cross_org not in out, "타 org webhook 격리"
-            assert agent_inactive not in out, "비활성 webhook 제외"
-        finally:
-            for mid in (agent_member_proj, agent_cross_org, agent_inactive):
-                await db.execute(
-                    WebhookConfig.__table__.delete().where(WebhookConfig.member_id == mid)
-                )
-            await db.execute(
-                WebhookConfig.__table__.delete().where(
-                    WebhookConfig.org_id.in_([org_a, org_b]),
-                    WebhookConfig.member_id.is_(None),
-                )
-            )
+    # story 18eefc31: 테스트 전용 엔진(+dispose) — 프로덕션 전역 싱글턴 대신
+    # (다른 realdb 테스트와 동일 관례, "attached to a different loop" 방지).
+    engine = create_async_engine(_ASYNCPG_URL.replace("postgresql://", "postgresql+asyncpg://"))
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as db:
+            db.add_all([
+                WebhookConfig(id=uuid.uuid4(), org_id=org_a, project_id=proj_x,
+                              member_id=agent_member_proj, url="https://h/1", is_active=True),
+                WebhookConfig(id=uuid.uuid4(), org_id=org_a, project_id=proj_x,
+                              member_id=None, url="https://h/bcast", is_active=True),
+                WebhookConfig(id=uuid.uuid4(), org_id=org_b, project_id=proj_y,
+                              member_id=agent_cross_org, url="https://h/2", is_active=True),
+                WebhookConfig(id=uuid.uuid4(), org_id=org_a, project_id=proj_x,
+                              member_id=agent_inactive, url="https://h/3", is_active=False),
+            ])
             await db.commit()
+            try:
+                # org_a 기준 조회: proj_y 대화여도 member-bound는 project 독립으로 covered.
+                out = await active_webhook_member_ids(
+                    db, org_a,
+                    [agent_member_proj, agent_broadcast_only, agent_cross_org, agent_inactive],
+                )
+                assert agent_member_proj in out, "member-bound는 project 독립으로 covered"
+                assert agent_broadcast_only not in out, "broadcast(null)은 멤버 커버 아님 — 제외"
+                assert agent_cross_org not in out, "타 org webhook 격리"
+                assert agent_inactive not in out, "비활성 webhook 제외"
+            finally:
+                for mid in (agent_member_proj, agent_cross_org, agent_inactive):
+                    await db.execute(
+                        WebhookConfig.__table__.delete().where(WebhookConfig.member_id == mid)
+                    )
+                await db.execute(
+                    WebhookConfig.__table__.delete().where(
+                        WebhookConfig.org_id.in_([org_a, org_b]),
+                        WebhookConfig.member_id.is_(None),
+                    )
+                )
+                await db.commit()
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary

story `18eefc31` — full triage of the 26 pre-existing real-DB test bugs surfaced by story `8236bbc3`'s CI coverage-gap seal (93/106 realdb files, previously silently skipped, now run for the first time).

**Fixed (xfail removed, regression-guarded)**:
- **edg s3/s4/s5/s7 (12 tests, 1 root cause)**: missing `decision_gate_line_enabled`/`decision_gate_line_mode` monkeypatch — one fix pattern applied 12x.
- **gateway race (2/3, prior commit `82dc6c38`)**: test-setup bug (cross-connection MVCC visibility), confirmed prod-unrelated.
- **asyncpg "different loop" (4 files)**: shared production `async_session_factory` singleton vs pytest-asyncio's function-scoped event loop — switched to test-local engine + dispose (established convention).
- **ho_s3 hypothesis_owner_seed**: bootstrap DDL missing `organizations.name`/`slug` (NOT NULL in real baseline schema).
- **presence_status (2 tests)**: module-level `NOW` constant drifts against `datetime.now()` during long full-suite runs — removed the constant entirely.
- **l1_consume_helpers order-dependent poll**: cursor computed as global `MIN(activity_seq)` picked up leftover rows from other test files in the shared job DB — switched to a pre-insert `MAX()` watermark. Verified against a DB pre-seeded with 50 unrelated rows.
- **webhook_targeting / ack_retire order-dependent**: same shared-engine loop bug as above.
- **h1_s7 / h1_s10 trust-score E2Es**: predate HO-S5 (#1497) narrowing default trust source to `hypothesis_outcome_*` only — added `include_legacy=True` to keep asserting on the CI/PR/merge verdicts these E2Es actually capture.

**Escalated, not fixed here (real product findings, not test bugs — PO-owned follow-ups)**:
- `webhook_configs.member_id` is `NOT NULL`, making the documented §AC2 "project-wide broadcast webhook" feature (`conversation_webhook.py`) unreachable dead code. → story `34b3a8fb`.
- Standup dedupe MERGE (migration `0099_standup_org_level.py`): `count(*) OVER w` (named window, `ORDER BY`, no explicit frame) defaults to a cumulative count, not partition size — the `keepers` CTE (`rn=1 AND cnt>1`) never matches, so the content-preserving MERGE the migration's own docstring says PO explicitly required (rejecting winner-only) has always been a silent no-op. Confirmed via minimal psql repro. → story `4f88f7b7`.

**Deferred pending separate crux**: `test_acked_seq_rescan_catches_low_seq_late_commit` (3rd gateway race test) kept `skip` — dense-seq serialization makes its exact race scenario structurally unconstructible under the current design; redesign needs PO sign-off before implementation.

Dev-only CI hardening — no runtime deploy required.

## Test plan
- [x] All touched non-destructive-schema files run clean against a fresh `alembic upgrade head` Postgres (`3036 passed, 11 xfailed` full non-destructive suite; 7 unrelated failures confirmed pre-existing worktree-path artifacts in `test_s7_2_epic_dod.py`/`test_e2e_dev.py`, unrelated to this PR)
- [x] edg s3/4/5/7 + h1_s7/h1_s10 (destructive_schema) verified in isolated fresh DBs
- [x] l1_consume_helpers re-verified against a DB pre-seeded with 50 unrelated rows to prove pollution-independence, not accidental pass
- [ ] 까심 cross-model realdb QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)