### PR TITLE
fix(e-standup): 0099 dedupe MERGE window-frame bug — story 4f88f7b7

### DIFF
--- a/backend/alembic/versions/0099_standup_org_level.py
+++ b/backend/alembic/versions/0099_standup_org_level.py
@@ -128,13 +128,29 @@ def upgrade() -> None:
 
     # 2d. text MERGE (winner 값 + 상이한 비-winner non-empty 값 provenance append) + plan_story_ids union
     #     CP4: project name NULL/soft-deleted → project:<id> 폴백 (LEFT JOIN 으로 행 자체는 확보).
+    #
+    #     story 4f88f7b7 (2026-07-03) — in-place hotfix, 선례 284c2611(0080)와 동일 관례:
+    #     아래 `cnt` 계산이 원래 `count(*) OVER w` 였다. `w`는 ORDER BY 가 있는 named window라
+    #     명시 frame 이 없으면 PG 기본 frame(RANGE UNBOUNDED PRECEDING AND CURRENT ROW)이 적용돼
+    #     partition 전체 크기가 아니라 累積(cumulative) count 를 반환했다 — rn=1(파티션 첫 행)일
+    #     때 cnt 는 항상 1이라 바로 아래 `keepers` CTE(`rn=1 AND cnt>1`)가 그룹 크기와 무관하게
+    #     영원히 0행이었다. 즉 이 UPDATE(done/plan/blockers MERGE)는 이 마이그가 실제 실행된
+    #     이래 항상 no-op 이었고, 2e DELETE 가 non-keeper 값을 그대로 버려 이 파일 docstring이
+    #     명시 거부한 winner-only lossy merge 가 실제로 일어났다(story 18eefc31 에서 발견,
+    #     4f88f7b7 에서 근본수정).
+    #     ⚠️ 이 수정은 이미 이 migration 을 실행한 환경(예: dev/prod)엔 아무 효과가 없다 —
+    #     Alembic 은 이미 적용된 revision 을 재실행하지 않고, 그 시점에 삭제된 non-keeper 값은
+    #     복구 불가(비가역, 위 downgrade 주석과 동일 정책). 이 수정은 앞으로 이 migration을
+    #     처음부터 재구동하는 환경(신규 dev clone·재난복구 rebuild·CI fresh-DB alembic chain)이
+    #     올바른 content-preserving 동작을 얻도록 하는 forward-correctness 전용이다. 실 데이터
+    #     손실 정량화(포렌식)는 이 story 스코프 밖 — 별도 트랙.
     op.execute(
         """
         WITH ranked AS (
             SELECT id, org_id, author_id, date,
                    row_number() OVER w AS rn,
                    first_value(id) OVER w AS keeper,
-                   count(*) OVER w AS cnt
+                   count(*) OVER (PARTITION BY org_id, author_id, date) AS cnt
             FROM standup_entries
             WINDOW w AS (PARTITION BY org_id, author_id, date ORDER BY updated_at DESC, id DESC)
         ),

--- a/backend/tests/test_standup_org_level_3b6b567c.py
+++ b/backend/tests/test_standup_org_level_3b6b567c.py
@@ -79,6 +79,10 @@ _ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace
 
 # 0099 upgrade 의 2a~2e 와 동형 (PARTITION (org,author,date)). 테스트가 unique index 를 잠시
 # drop 후 dup 시드 → 이 SQL 실행 → 재생성.
+# story 4f88f7b7: 2d 의 `cnt` 는 0099 in-place hotfix 와 동일하게
+# `count(*) OVER (PARTITION BY org_id, author_id, date)`(별도 unordered window) — `w`(ORDER BY
+# 있는 named window)에 그대로 두면 명시 frame 없어 cumulative count 버그 재현(test↔migration
+# coherence, 둘이 diverge 하면 test green 이 실 migration 을 검증 못 하는 false-assurance).
 _DEDUPE_SQL = [
     # 2a feedback reattach → keeper (先)
     """
@@ -99,22 +103,34 @@ _DEDUPE_SQL = [
     SELECT gen_random_uuid(), r.keeper, r.project_id, r.org_id FROM ranked r
     WHERE r.project_id IS NOT NULL AND EXISTS (SELECT 1 FROM projects p WHERE p.id=r.project_id) ON CONFLICT (entry_id, project_id) DO NOTHING
     """,
-    # 2d text MERGE + plan_story_ids union
+    # 2d text MERGE(done/plan/blockers 3필드 전부 — 0099 원문과 동형) + plan_story_ids union
     """
     WITH ranked AS (
         SELECT id, org_id, author_id, date,
-               row_number() OVER w AS rn, first_value(id) OVER w AS keeper, count(*) OVER w AS cnt
+               row_number() OVER w AS rn, first_value(id) OVER w AS keeper,
+               count(*) OVER (PARTITION BY org_id, author_id, date) AS cnt
         FROM standup_entries
         WINDOW w AS (PARTITION BY org_id, author_id, date ORDER BY updated_at DESC, id DESC)),
     keepers AS (
         SELECT k.id, k.org_id, k.author_id, k.date, k.done, k.plan, k.blockers
         FROM standup_entries k JOIN ranked r ON r.id = k.id WHERE r.rn = 1 AND r.cnt > 1)
     UPDATE standup_entries t SET
+        done = CASE WHEN sfx.done_sfx = '' THEN t.done ELSE COALESCE(t.done,'') || sfx.done_sfx END,
         plan = CASE WHEN sfx.plan_sfx = '' THEN t.plan ELSE COALESCE(t.plan,'') || sfx.plan_sfx END,
+        blockers = CASE WHEN sfx.blk_sfx = '' THEN t.blockers ELSE COALESCE(t.blockers,'') || sfx.blk_sfx END,
         plan_story_ids = COALESCE(sfx.psids, t.plan_story_ids)
     FROM keepers kp
     CROSS JOIN LATERAL (
-        SELECT COALESCE((
+        SELECT
+        COALESCE((
+            SELECT string_agg('\n\n--- merged from project: ' ||
+                COALESCE(NULLIF(p.name,''), se2.project_id::text) || ' ---\n' || se2.done,
+                '' ORDER BY se2.updated_at DESC, se2.id DESC)
+            FROM standup_entries se2 LEFT JOIN projects p ON p.id = se2.project_id
+            WHERE se2.org_id=kp.org_id AND se2.author_id=kp.author_id AND se2.date=kp.date
+              AND se2.id <> kp.id AND COALESCE(se2.done,'')<>'' AND COALESCE(se2.done,'')<>COALESCE(kp.done,'')
+        ), '') AS done_sfx,
+        COALESCE((
             SELECT string_agg('\n\n--- merged from project: ' ||
                 COALESCE(NULLIF(p.name,''), se2.project_id::text) || ' ---\n' || se2.plan,
                 '' ORDER BY se2.updated_at DESC, se2.id DESC)
@@ -122,6 +138,14 @@ _DEDUPE_SQL = [
             WHERE se2.org_id=kp.org_id AND se2.author_id=kp.author_id AND se2.date=kp.date
               AND se2.id <> kp.id AND COALESCE(se2.plan,'')<>'' AND COALESCE(se2.plan,'')<>COALESCE(kp.plan,'')
         ), '') AS plan_sfx,
+        COALESCE((
+            SELECT string_agg('\n\n--- merged from project: ' ||
+                COALESCE(NULLIF(p.name,''), se2.project_id::text) || ' ---\n' || se2.blockers,
+                '' ORDER BY se2.updated_at DESC, se2.id DESC)
+            FROM standup_entries se2 LEFT JOIN projects p ON p.id = se2.project_id
+            WHERE se2.org_id=kp.org_id AND se2.author_id=kp.author_id AND se2.date=kp.date
+              AND se2.id <> kp.id AND COALESCE(se2.blockers,'')<>'' AND COALESCE(se2.blockers,'')<>COALESCE(kp.blockers,'')
+        ), '') AS blk_sfx,
         (SELECT array_agg(DISTINCT x) FROM standup_entries se3, unnest(se3.plan_story_ids) AS x
          WHERE se3.org_id=kp.org_id AND se3.author_id=kp.author_id AND se3.date=kp.date) AS psids
     ) sfx WHERE t.id = kp.id
@@ -138,27 +162,6 @@ _DEDUPE_SQL = [
 
 @pytest.mark.anyio
 @pytest.mark.skipif(not _ASYNC, reason="real-DB URL 미설정 — skip")
-@pytest.mark.xfail(
-    strict=False,
-    reason="story 18eefc31 — asyncpg datetime 타이핑(원 xfail 사유)은 실 datetime 객체 바인딩으로 "
-    "해결했으나(다른 realdb 테스트와 동일 관례), 그 뒤 별개의 진짜 product 버그가 드러났다: "
-    "2d text-MERGE 의 `count(*) OVER w`(ORDER BY 있는 named window, 명시 frame 없음)는 PG 기본"
-    "frame(RANGE UNBOUNDED PRECEDING AND CURRENT ROW)이 적용돼 partition 전체 크기가 아니라 "
-    "累積(cumulative) count 를 반환한다 — rn=1(파티션 첫 행)일 때 cnt 는 항상 1이라 "
-    "`WHERE r.rn=1 AND r.cnt>1`(keepers CTE)가 그룹 크기와 무관하게 영원히 0행이다. 즉 "
-    "done/plan/blockers MERGE(UPDATE)가 **항상 no-op**이고, 뒤이은 2e DELETE 는 keeper 이외 값을 "
-    "그대로 버린다 — winner-only lossy merge. 이 SQL은 alembic/versions/0099_standup_org_level.py "
-    "2d 와 완전 동형(migration 원문 그대로 복제)이며, 그 마이그의 docstring 은 명문으로 "
-    "'PO ①·dev lossy_rows=1 실적출 → winner-only 폐기'(즉 PO가 winner-only 를 명시 거부하고 "
-    "content-preserving MERGE 를 확정)라고 밝힌다 — 실제로는 그 반대(PO가 거부한 winner-only)가 "
-    "일어난다. 로컬 psql 로 최소 재현: 2-row 그룹에서 `count(*) OVER w`=[1,2], "
-    "`count(*) OVER (PARTITION BY org_id,author_id,date)`(명시 frame 없는 별도 window)=[2,2] — "
-    "cnt 컬럼 자체가 버그. 마이그는 이미 실행됐고(dev 최신 head 포함) 데이터 손실이 이미 "
-    "발생했을 가능성(당시 dedupe 대상 그룹이 실제 있었는지는 별도 포렌식 필요, prod 접근 없음 "
-    "— 에스컬 사유) — 이 story(test-infra 하드닝) 스코프 밖이라 테스트를 완화해 통과시키지 않고 "
-    "xfail+PO 에스컬 — SQL 프레임 근본수정은 follow-up story 4f88f7b7(E-STANDUP)로 분리, 그 "
-    "story 구현·머지 完了 後 이 xfail 해소. story 18eefc31 트래킹.",
-)
 async def test_dedupe_merge_lossless_and_idempotent_realdb():
     from datetime import datetime, timezone
     from sqlalchemy import text
@@ -187,16 +190,18 @@ async def test_dedupe_merge_lossless_and_idempotent_realdb():
                 # story 18eefc31: asyncpg는 timestamptz 컬럼에 ISO 문자열을 직접 바인딩하면
                 # TypeError(expected datetime.date/datetime, got str)로 거부한다 — 실 datetime
                 # 객체로 바인딩(asyncpg 엄격 타이핑, 이 세션에서 반복 확인된 패턴).
+                # story 4f88f7b7: done/plan/blockers 3필드 전부 distinct non-empty로 시드(0099
+                # MERGE 대상 3필드 전부 검증 — 이전엔 plan만 시드해 done/blockers MERGE 미검증).
                 rows = [
-                    (e1, p1, "PLAN-ALPHA", datetime(2026, 6, 5, 10, 0, tzinfo=timezone.utc)),
-                    (e2, p2, "PLAN-BETA", datetime(2026, 6, 5, 11, 0, tzinfo=timezone.utc)),
-                    (e3, p3, "PLAN-GAMMA", datetime(2026, 6, 5, 12, 0, tzinfo=timezone.utc)),  # keeper(latest)
+                    (e1, p1, "DONE-ALPHA", "PLAN-ALPHA", "BLOCK-ALPHA", datetime(2026, 6, 5, 10, 0, tzinfo=timezone.utc)),
+                    (e2, p2, "DONE-BETA", "PLAN-BETA", "BLOCK-BETA", datetime(2026, 6, 5, 11, 0, tzinfo=timezone.utc)),
+                    (e3, p3, "DONE-GAMMA", "PLAN-GAMMA", "BLOCK-GAMMA", datetime(2026, 6, 5, 12, 0, tzinfo=timezone.utc)),  # keeper(latest)
                 ]
-                for eid, pid, plan, ts in rows:
+                for eid, pid, done, plan, blockers, ts in rows:
                     await s.execute(text(
-                        "INSERT INTO standup_entries (id,org_id,project_id,author_id,date,plan,plan_story_ids,created_at,updated_at)"
-                        " VALUES (:i,:o,:p,:a,:d,:pl,ARRAY[]::uuid[],:t,:t)"),
-                        {"i": eid, "o": org, "p": pid, "a": author, "d": d, "pl": plan, "t": ts})
+                        "INSERT INTO standup_entries (id,org_id,project_id,author_id,date,done,plan,blockers,plan_story_ids,created_at,updated_at)"
+                        " VALUES (:i,:o,:p,:a,:d,:dn,:pl,:bl,ARRAY[]::uuid[],:t,:t)"),
+                        {"i": eid, "o": org, "p": pid, "a": author, "d": d, "dn": done, "pl": plan, "bl": blockers, "t": ts})
                     await s.execute(text(
                         "INSERT INTO standup_entry_projects (id,entry_id,project_id,org_id) VALUES (gen_random_uuid(),:e,:p,:o)"),
                         {"e": eid, "p": pid, "o": org})
@@ -219,13 +224,20 @@ async def test_dedupe_merge_lossless_and_idempotent_realdb():
                     "SELECT count(*) FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d"),
                     {"o": org, "a": author, "d": d})).scalar_one()
                 assert cnt == 1
-                keeper_plan = (await s.execute(text(
-                    "SELECT plan FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d"),
-                    {"o": org, "a": author, "d": d})).scalar_one()
-                # 내용 0 소실 — 세 plan 전부 보존
-                assert "PLAN-GAMMA" in keeper_plan
-                assert "PLAN-ALPHA" in keeper_plan and "Alpha" in keeper_plan  # provenance
-                assert "PLAN-BETA" in keeper_plan and "Beta" in keeper_plan
+                keeper = (await s.execute(text(
+                    "SELECT done, plan, blockers FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d"),
+                    {"o": org, "a": author, "d": d})).one()
+                # 내용 0 소실 — done/plan/blockers 3필드 전부, 세 값 전부 보존(story 4f88f7b7: 이전엔
+                # plan만 검증해 done/blockers MERGE 회귀를 못 잡았다).
+                assert "DONE-GAMMA" in keeper.done
+                assert "DONE-ALPHA" in keeper.done and "Alpha" in keeper.done  # provenance
+                assert "DONE-BETA" in keeper.done and "Beta" in keeper.done
+                assert "PLAN-GAMMA" in keeper.plan
+                assert "PLAN-ALPHA" in keeper.plan and "Alpha" in keeper.plan
+                assert "PLAN-BETA" in keeper.plan and "Beta" in keeper.plan
+                assert "BLOCK-GAMMA" in keeper.blockers
+                assert "BLOCK-ALPHA" in keeper.blockers and "Alpha" in keeper.blockers
+                assert "BLOCK-BETA" in keeper.blockers and "Beta" in keeper.blockers
                 # 링크 union = {p1,p2,p3} 가 keeper 에
                 links = set((await s.execute(text(
                     "SELECT project_id FROM standup_entry_projects WHERE entry_id IN "
@@ -255,6 +267,111 @@ async def test_dedupe_merge_lossless_and_idempotent_realdb():
             # 동일 finally-cleanup 관례). 이전 버전은 이 블록이 try 밖에 있어 실패 시 스킵됐다.
             async with sm() as s:
                 await s.execute(text("DELETE FROM standup_feedback WHERE org_id=:o"), {"o": org})
+                await s.execute(text("DELETE FROM standup_entry_projects WHERE org_id=:o"), {"o": org})
+                await s.execute(text("DELETE FROM standup_entries WHERE org_id=:o"), {"o": org})
+                await s.execute(text("DELETE FROM projects WHERE org_id=:o"), {"o": org})
+                await s.execute(text("DELETE FROM organizations WHERE id=:o"), {"o": org})
+                await s.execute(text(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS uq_standup_org_author_date "
+                    "ON standup_entries (org_id, author_id, date)"))
+                await s.commit()
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(not _ASYNC, reason="real-DB URL 미설정 — skip")
+async def test_dedupe_merge_2row_window_frame_boundary_realdb():
+    """story 4f88f7b7: 버그의 최소 재현 케이스 — 2-row 그룹의 window-frame 경계 회귀가드.
+
+    원 버그는 `count(*) OVER w`(ORDER BY 있는 named window, 명시 frame 없음)가 partition
+    전체 크기 대신 累積(cumulative) count 를 반환해, rn=1(파티션 첫 행)의 cnt 가 그룹 크기와
+    무관하게 항상 1이었다(2-row 그룹이면 [1,2] — 둘 다 2 여야 하는데 첫 행만 1). 이 최소 케이스가
+    `WHERE r.rn=1 AND r.cnt>1` 게이트를 결정하는 정확한 경계 — 3-row 그룹(다른 테스트)은 이
+    정확한 [1,2] vs [2,2] 구분을 우연히 통과할 수 있어(cnt=1은 여전히 >1 이 아니므로 걸리지만,
+    회귀 방지 목적으로는 버그의 최소 표현형을 직접 못박는 편이 더 정확하다) 별도 케이스로 분리.
+    """
+    from datetime import datetime, timezone
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    org = uuid.uuid4(); author = uuid.uuid4(); d = _date(2026, 6, 5)
+    p1, p2 = uuid.uuid4(), uuid.uuid4()
+    e1, e2 = uuid.uuid4(), uuid.uuid4()
+    eng = create_async_engine(_ASYNC)
+    sm = async_sessionmaker(eng, expire_on_commit=False)
+    try:
+        try:
+            async with sm() as s:
+                await s.execute(text("DROP INDEX IF EXISTS uq_standup_org_author_date"))
+                await s.execute(
+                    text("INSERT INTO organizations (id,name,slug) VALUES (:i,:n,:sl)"),
+                    {"i": org, "n": f"standup-2row-org-{org}", "sl": f"standup-2row-{org}"},
+                )
+                for pid, nm in ((p1, "Alpha"), (p2, "Beta")):
+                    await s.execute(text("INSERT INTO projects (id,org_id,name,created_at) VALUES (:i,:o,:n,now())"),
+                                    {"i": pid, "o": org, "n": nm})
+                rows = [
+                    (e1, p1, "DONE-A", "PLAN-A", "BLOCK-A", datetime(2026, 6, 5, 10, 0, tzinfo=timezone.utc)),
+                    (e2, p2, "DONE-B", "PLAN-B", "BLOCK-B", datetime(2026, 6, 5, 11, 0, tzinfo=timezone.utc)),  # keeper(latest)
+                ]
+                for eid, pid, done, plan, blockers, ts in rows:
+                    await s.execute(text(
+                        "INSERT INTO standup_entries (id,org_id,project_id,author_id,date,done,plan,blockers,plan_story_ids,created_at,updated_at)"
+                        " VALUES (:i,:o,:p,:a,:d,:dn,:pl,:bl,ARRAY[]::uuid[],:t,:t)"),
+                        {"i": eid, "o": org, "p": pid, "a": author, "d": d, "dn": done, "pl": plan, "bl": blockers, "t": ts})
+                    await s.execute(text(
+                        "INSERT INTO standup_entry_projects (id,entry_id,project_id,org_id) VALUES (gen_random_uuid(),:e,:p,:o)"),
+                        {"e": eid, "p": pid, "o": org})
+                await s.commit()
+
+                # ── 버그의 정확한 경계 재현: dedupe 실행 前 cnt 진단 쿼리 자체를 못박는다.
+                # 고친 SQL(별도 unordered window)은 [2,2] — 원래 버그(named window w, ORDER BY,
+                # 명시 frame 없음)라면 [1,2] 였을 지점.
+                diag = (await s.execute(text("""
+                    SELECT row_number() OVER w AS rn,
+                           count(*) OVER (PARTITION BY org_id, author_id, date) AS cnt
+                    FROM standup_entries
+                    WHERE org_id=:o AND author_id=:a AND date=:d
+                    WINDOW w AS (PARTITION BY org_id, author_id, date ORDER BY updated_at DESC, id DESC)
+                    ORDER BY rn"""), {"o": org, "a": author, "d": d})).all()
+                assert [r.cnt for r in diag] == [2, 2], "고친 cnt는 rn 무관 그룹 전체 크기여야(버그면 [1,2])"
+
+                async def run_dedupe():
+                    for sql in _DEDUPE_SQL:
+                        await s.execute(text(sql))
+                    await s.commit()
+
+                await run_dedupe()
+
+                cnt = (await s.execute(text(
+                    "SELECT count(*) FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d"),
+                    {"o": org, "a": author, "d": d})).scalar_one()
+                assert cnt == 1, "2-row 그룹도 dedupe 대상이어야(버그면 cnt=1 그룹 첫 행이 keeper 조건 미충족 → no-op)"
+
+                keeper = (await s.execute(text(
+                    "SELECT done, plan, blockers FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d"),
+                    {"o": org, "a": author, "d": d})).one()
+                assert "DONE-B" in keeper.done and "DONE-A" in keeper.done and "Alpha" in keeper.done
+                assert "PLAN-B" in keeper.plan and "PLAN-A" in keeper.plan and "Alpha" in keeper.plan
+                assert "BLOCK-B" in keeper.blockers and "BLOCK-A" in keeper.blockers and "Alpha" in keeper.blockers
+
+                links = set((await s.execute(text(
+                    "SELECT project_id FROM standup_entry_projects WHERE entry_id IN "
+                    "(SELECT id FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d)"),
+                    {"o": org, "a": author, "d": d})).scalars().all())
+                assert links == {p1, p2}
+
+                # 멱등: 재실행 무변화(중복 append 없음)
+                await run_dedupe()
+                keeper2 = (await s.execute(text(
+                    "SELECT done, plan, blockers FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d"),
+                    {"o": org, "a": author, "d": d})).one()
+                assert keeper2.done == keeper.done
+                assert keeper2.plan == keeper.plan
+                assert keeper2.blockers == keeper.blockers
+        finally:
+            async with sm() as s:
                 await s.execute(text("DELETE FROM standup_entry_projects WHERE org_id=:o"), {"o": org})
                 await s.execute(text("DELETE FROM standup_entries WHERE org_id=:o"), {"o": org})
                 await s.execute(text("DELETE FROM projects WHERE org_id=:o"), {"o": org})


### PR DESCRIPTION
## Summary

story `4f88f7b7`, follow-up to `18eefc31`'s CI realdb triage which surfaced this.

Migration `0099_standup_org_level.py` step 2d's content-preserving `done`/`plan`/`blockers` MERGE has been a silent no-op since it first ran, because `count(*) OVER w` (a named window with `ORDER BY` and no explicit frame) defaults to Postgres's implicit `RANGE UNBOUNDED PRECEDING AND CURRENT ROW` frame — a *cumulative* count, not the partition's total size. At `rn=1` (first row in partition order) that's always `1`, so the `keepers` CTE's `rn=1 AND cnt>1` gate never matched any group, regardless of actual size. The migration's own docstring documents that PO explicitly rejected a winner-only lossy strategy after a dev dry-run showed `lossy_rows=1` — this bug silently did exactly that rejected thing anyway.

**Handling of the already-applied migration (PO crux, Option A)**: in-place hotfix on `0099_standup_org_level.py` itself, following the precedent of `284c2611`/#1181 (an in-place fix to migration `0080` for an analogous bug only reachable via real-DB, never caught by fresh-DB CI). The test file (`test_standup_org_level_3b6b567c.py`) hand-duplicates this exact SQL for testing purposes — fixing only the test copy would let it diverge from what the real migration actually runs, i.e. green but no longer verifying the real thing (the coherence argument PO raised in the crux, stronger than the fresh-DB-reproduction argument in the original design).

**Fix**: `count(*) OVER w` → `count(*) OVER (PARTITION BY org_id, author_id, date)` (separate, unordered window). `w` is left as-is for `row_number()`/`first_value()`.

⚠️ **No effect on already-applied dev/prod** — Alembic doesn't re-run applied revisions, and data already deleted by step 2e at the time 0099 ran is unrecoverable. Documented in-file per PO's explicit requirement (file itself must show the truth, not just the commit message). Real-data-loss forensics is out of scope — separate PO-owned track.

**Tests**:
- Existing 3-row realdb test strengthened to seed/assert all three merge fields (`done`/`plan`/`blockers`), not just `plan` as before.
- New dedicated 2-row test pinned to the exact window-frame boundary the bug lived at (`[1,2]` buggy vs `[2,2]` fixed) — the minimal reproduction case.
- Verified both realdb tests genuinely **fail** against the reverted buggy SQL before restoring the fix (not tautological).

Dev-only migration/test fix — no runtime deploy required (0099 doesn't re-run).

## Test plan
- [x] Fresh scratch DB, full `alembic upgrade head` chain applies cleanly with the fixed 0099
- [x] `test_standup_org_level_3b6b567c.py` (4 tests, including new 2-row test) pass against that DB
- [x] Negative-tested: both realdb tests fail when the buggy SQL is temporarily restored
- [x] Full non-destructive suite re-run: 3038 passed, 10 xfailed, 0 new regressions (same 7 pre-existing worktree-path artifacts as baseline)
- [ ] 까심 cross-model realdb QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)