### PR TITLE
fix(e-sprint-loop): retro-session BE parity — hypotheses embed shape + has_project_access dedup (story 5feac498)

### DIFF
--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -169,7 +169,11 @@ async def _build_session_response(
     # (P0(9f27af8f) 이후 RetroVote.voter_id 는 vote_item 이 resolve_member 로 직접 써넣은
     # members.id 공간이고, 휴먼은 members.id=org_members.id 로 ID-preserving 백필돼 여기
     # resolve_member(레거시 경로).id 와 동일 공간 — 별도 매핑 불요).
-    resolved = await resolve_member(auth, session.org_id, db, project_id=session.project_id)
+    # story 5feac498: project_id 생략 — `_build_session_response`의 모든 호출부가 이미
+    # `_require_retro_project_access`로 이 session의 project 접근을 검증한 後에만 호출된다.
+    # project_id를 넘기면 resolve_member의 JWT 분기가 has_project_access(동일 4-EXISTS 쿼리)를
+    # 요청당 또 한 번(총 2회) 실행하는 순수 중복 — id 해소만 필요하므로 재검증 스킵.
+    resolved = await resolve_member(auth, session.org_id, db)
     voted_item_ids: set[uuid.UUID] = set()
     if items:
         voted_rows = await db.execute(

--- a/backend/app/schemas/retro.py
+++ b/backend/app/schemas/retro.py
@@ -55,7 +55,12 @@ class RetroHypothesisItem(BaseModel):
     target: float | None = None
     direction: str | None = None
     actual: float | None = None  # outcome_result.actual, 미확정이면 None(측정중)
-    href: str
+    measure_after: datetime | None = None
+    # story 5feac498: sprints.py `SprintHypothesisItem`(story fbf1c14b)과 동일 shape — FE에
+    # hypothesis 상세 페이지가 없어(API 프록시만 존재) href 추측은 죽은 링크였다(그 story의
+    # PO crux로 None 확정). 두 embed 경로가 동일 shape이어야 FE가 이걸 소비하고 별도
+    # /sprints/{id}/hypotheses 재조회를 없앨 수 있다.
+    href: str | None = None
 
 
 class SynthesisLearnedItem(BaseModel):

--- a/backend/app/services/retro_synthesis.py
+++ b/backend/app/services/retro_synthesis.py
@@ -130,7 +130,12 @@ async def build_hypotheses_items(
             "target": md.get("target"),
             "direction": md.get("direction"),
             "actual": actual,
-            "href": f"/hypotheses/{h.id}",
+            "measure_after": h.measure_after,
+            # story 5feac498: sprints.py `_flat_hypothesis`(story fbf1c14b)와 shape 정합 — FE에
+            # hypothesis 상세 페이지 라우트가 없어(API 프록시만 존재) 이 추측 URL은 죽은 링크였다
+            # (그 story의 PO crux로 href=None 확정). FE가 이 embed 필드를 소비하려면(별도
+            # /sprints/{id}/hypotheses 재조회 제거) 두 경로가 동일 shape이어야 한다.
+            "href": None,
         })
     return items
 

--- a/backend/tests/test_e_sprint_loop_dc861e44_retro_synthesis_realdb.py
+++ b/backend/tests/test_e_sprint_loop_dc861e44_retro_synthesis_realdb.py
@@ -126,7 +126,9 @@ async def test_hypotheses_embed_flattens_sprint_linked_hypothesis():
         assert h.target == 50
         assert h.direction == "up"
         assert h.actual == 42
-        assert h.href == f"/hypotheses/{HYP}"
+        # story 5feac498: sprints.py shape 정합 — href는 FE 상세페이지 부재로 fbf1c14b PO
+        # crux가 None 확정한 것과 동일하게 정정(retro-session embed를 FE가 재조회 없이 소비).
+        assert h.href is None
         assert resp.synthesis is None
         assert resp.next_hypotheses is None
     finally:

--- a/backend/tests/test_retro_synthesis_service.py
+++ b/backend/tests/test_retro_synthesis_service.py
@@ -51,17 +51,22 @@ async def test_build_hypotheses_items_no_sprint_returns_empty():
 
 
 async def test_build_hypotheses_items_flattens_metric_and_actual():
+    measure_after = datetime(2026, 7, 10, tzinfo=timezone.utc)
     hyp = SimpleNamespace(
         id=uuid.uuid4(), statement="stmt", status="falsified",
         metric_definition={"metric": "signup_rate", "target": 10, "direction": "up"},
-        outcome_result={"actual": 7.5},
+        outcome_result={"actual": 7.5}, measure_after=measure_after,
     )
     with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])):
         result = await svc.build_hypotheses_items(MagicMock(), ORG_ID, PROJECT_ID, SPRINT_ID)
+    # story 5feac498: sprints.py `_flat_hypothesis`(story fbf1c14b)와 shape 정합 —
+    # measure_after 추가·href는 FE에 상세 페이지가 없어 죽은 링크였던 추측을 None으로 정정
+    # (retro-session embed를 FE가 별도 재조회 없이 소비하려면 두 경로가 동일 shape이어야 함).
     assert result == [{
         "id": hyp.id, "statement": "stmt", "status": "falsified",
         "metric": "signup_rate", "target": 10, "direction": "up", "actual": 7.5,
-        "href": f"/hypotheses/{hyp.id}",
+        "measure_after": measure_after,
+        "href": None,
     }]
 
 
@@ -69,7 +74,7 @@ async def test_build_hypotheses_items_measuring_actual_none():
     hyp = SimpleNamespace(
         id=uuid.uuid4(), statement="stmt", status="measuring",
         metric_definition={"metric": "x", "target": 1, "direction": "up"},
-        outcome_result=None,
+        outcome_result=None, measure_after=None,
     )
     with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])):
         result = await svc.build_hypotheses_items(MagicMock(), ORG_ID, PROJECT_ID, SPRINT_ID)
@@ -95,7 +100,7 @@ async def test_synthesize_parses_valid_json():
     hyp = SimpleNamespace(
         id=uuid.uuid4(), statement="stmt", status="verified",
         metric_definition={"metric": "x", "target": 1, "direction": "up"},
-        outcome_result={"actual": 2},
+        outcome_result={"actual": 2}, measure_after=None,
     )
     raw = '{"items": [{"text": "가설이 검증됐다", "source": "가설 1"}]}'
     with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
@@ -118,7 +123,7 @@ async def test_synthesize_prose_only_response_returns_none():
     retro = _retro(sprint_id=SPRINT_ID)
     hyp = SimpleNamespace(
         id=uuid.uuid4(), statement="stmt", status="verified",
-        metric_definition={}, outcome_result=None,
+        metric_definition={}, outcome_result=None, measure_after=None,
     )
     raw = "죄송하지만 데이터가 부족해 종합을 생성할 수 없습니다."
     with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
@@ -136,7 +141,7 @@ async def test_synthesize_valid_object_wrong_item_shape_returns_none():
     retro = _retro(sprint_id=SPRINT_ID)
     hyp = SimpleNamespace(
         id=uuid.uuid4(), statement="stmt", status="verified",
-        metric_definition={}, outcome_result=None,
+        metric_definition={}, outcome_result=None, measure_after=None,
     )
     raw = '{"items": [{"no_text": 1}, {"text": "   "}]}'
     with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
@@ -152,7 +157,7 @@ async def test_synthesize_missing_source_drops_item():
     retro = _retro(sprint_id=SPRINT_ID)
     hyp = SimpleNamespace(
         id=uuid.uuid4(), statement="stmt", status="verified",
-        metric_definition={}, outcome_result=None,
+        metric_definition={}, outcome_result=None, measure_after=None,
     )
     raw = '{"items": [{"text": "근거 없는 배운 것"}, {"text": "진짜", "source": "가설 1"}]}'
     with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
@@ -169,7 +174,7 @@ async def test_synthesize_llm_none_returns_none_not_empty_success():
     retro = _retro(sprint_id=SPRINT_ID)
     hyp = SimpleNamespace(
         id=uuid.uuid4(), statement="stmt", status="verified",
-        metric_definition={}, outcome_result=None,
+        metric_definition={}, outcome_result=None, measure_after=None,
     )
     with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
          patch("app.services.llm_client.generate_text", return_value=None):
@@ -182,7 +187,7 @@ async def test_synthesize_llm_exception_returns_none():
     retro = _retro(sprint_id=SPRINT_ID)
     hyp = SimpleNamespace(
         id=uuid.uuid4(), statement="stmt", status="verified",
-        metric_definition={}, outcome_result=None,
+        metric_definition={}, outcome_result=None, measure_after=None,
     )
     with patch("app.services.hypothesis.list_hypotheses", new=AsyncMock(return_value=[hyp])), \
          patch("app.services.llm_client.generate_text", side_effect=RuntimeError("boom")):

--- a/backend/tests/test_retros.py
+++ b/backend/tests/test_retros.py
@@ -1416,7 +1416,7 @@ async def test_get_session_embeds_hypotheses_when_sprint_linked():
         hyp = SimpleNamespace(
             id=uuid.uuid4(), statement="stmt", status="verified",
             metric_definition={"metric": "x", "target": 1, "direction": "up"},
-            outcome_result={"actual": 2},
+            outcome_result={"actual": 2}, measure_after=None,
         )
 
         with (
@@ -1431,6 +1431,8 @@ async def test_get_session_embeds_hypotheses_when_sprint_linked():
         assert len(body["hypotheses"]) == 1
         assert body["hypotheses"][0]["statement"] == "stmt"
         assert body["hypotheses"][0]["actual"] == 2
+        # story 5feac498: sprints.py shape 정합 — href는 FE 상세페이지 부재로 None 확정(fbf1c14b).
+        assert body["hypotheses"][0]["href"] is None
         assert body["synthesis"] is None
         assert body["next_hypotheses"] is None
     finally:


### PR DESCRIPTION
## Summary

Follow-up from story `5feac498`'s retro-loading performance investigation. Diagnosis (findings-only phase, already reported) found the reported ~2s isn't backend query cost — direct live measurement of `GET /api/v2/retros/{id}` against dev came back at ~110-130ms. The dominant cost is almost certainly a sequential FE waterfall plus every Next.js API route independently re-resolving auth via its own `/api/v2/me` round-trip (no cross-call caching) — that's a separate, larger, app-wide FE-auth-layer story PO has split out.

Two small, real BE inefficiencies surfaced during that investigation, PO-approved to fix now independently of the FE-side work:

1. **hypotheses embed shape parity**: `GET /api/v2/retros/{id}` already embeds a `hypotheses[]` field (`build_hypotheses_items`), but FE ignores it and does a separate `GET /api/v2/sprints/{id}/hypotheses` round-trip for the same data — because the two BE paths didn't return the same shape. Embedded version was missing `measure_after` and returned a dead-link `href` guess (`/hypotheses/{id}` — FE has no detail route; the sibling `sprints.py` endpoint already fixed this to `href=None` per story `fbf1c14b`'s PO crux). Aligned both fields so FE can switch to consuming the embedded field and drop the redundant fetch (FE-side switch is a separate follow-up, not in this PR).
2. **`has_project_access` double-call**: running twice per request for human callers — once in `_require_retro_project_access` (the router's access gate), and again inside `resolve_member`'s JWT branch when called with `project_id=`. Every caller of the function that does this second call already passed the gate, so the second call was pure redundant work (confirmed the only downstream use of that `resolve_member` result is `.id`, not `.project_id`). Dropped the redundant arg.

Not in scope here (PO decision): sprint-outcome embed (small, non-blocking once FE does progressive render) and the `/api/v2/me` per-route round-trip itself.

## Test plan
- [x] `tests/test_retros.py` + `tests/test_retro_synthesis_service.py`: 86 passed (7 pre-existing mock fixtures updated for the new `measure_after`/`href` shape)
- [x] Realdb suite (`test_e_sprint_loop_a4acc4d0_sprint_link_realdb.py`, `test_e_sprint_loop_fbf1c14b_hypotheses_rest_realdb.py`, `test_e_sprint_loop_dc861e44_retro_synthesis_realdb.py`): 22 passed against a fresh migrated DB
- [x] Instrumented live verification (throwaway script against real seeded org/project/session): `has_project_access` call count confirmed **1** per `GET /{id}` request (was 2)
- [x] Full non-destructive suite re-run: 3038 passed, 10 xfailed, 0 new regressions (same 7 pre-existing worktree-path artifacts as the last known-good baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)