### PR TITLE
fix(e-sprint-loop): create_session cross-validate sprint↔project (404 on mismatch)

### DIFF
--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.models.pm import Sprint
 from app.models.retro import RetroItem, RetroSession, RetroVote
 from app.services import hypothesis as hyp_svc
 from app.services import retro_hypothesis_seed as seed_svc
@@ -134,6 +135,23 @@ async def create_session(
     # body.project_id 를 검증 없이 신뢰하면 무권한 project 에 session 을 심는 mutation IDOR.
     if not await has_project_access(db, uuid.UUID(auth.user_id), body.project_id, org_id):
         raise HTTPException(status_code=403, detail="해당 프로젝트 접근 권한이 없습니다")
+    # 까심 QA(#1880 embed-switch 中 실 Postgres 재현) — body.sprint_id가 실제 body.project_id
+    # 소속인지 검증하는 FK/CHECK가 없어 project A 세션에 project B sprint를 링크 가능했다.
+    # embed(session.project_id로 스코프)와 별도 /sprints/{id}/hypotheses(sprint의 실제
+    # project_id로 스코프) 응답이 갈라져 FE엔 "가설이 사라진" 것처럼 보였다(데이터 유실 아님,
+    # 애초 정합 안 된 링크). `_require_item_in_session`(아래, item_id가 부모 session 소속 아니면
+    # 404)과 동일 컨벤션 — 존재하나 이 스코프엔 없는 리소스는 404. org_id는 위 has_project_access
+    # 컨텍스트와 동일한 caller의 검증된 org(get_verified_org_id) — 테넌트 스코프 유지. 이 조회
+    # 1발이 "존재하지 않는 sprint_id"(오늘은 FK violation 500)까지 자연스럽게 404로 흡수한다.
+    # has_project_access 검증 後·이 체크를 두는 순서 — 무권한 caller에게 sprint 존재 유출 방지.
+    if body.sprint_id is not None:
+        sprint = (
+            await db.execute(
+                select(Sprint).where(Sprint.id == body.sprint_id, Sprint.org_id == org_id)
+            )
+        ).scalar_one_or_none()
+        if sprint is None or sprint.project_id != body.project_id:
+            raise HTTPException(status_code=404, detail="Sprint not found")
     # P0(9f27af8f): created_by는 "누가 이 session을 만들었나"라는 행위자(actor) attribution —
     # body.created_by(client 지정)를 신뢰하면 타인 명의 spoofing 벡터. auth로 canonical
     # requester id를 직접 해소(B4/vote_item과 동일 SSOT 패턴), body.created_by는 무시.

--- a/backend/tests/test_retro_create_session_sprint_project_crossvalidate_realdb.py
+++ b/backend/tests/test_retro_create_session_sprint_project_crossvalidate_realdb.py
@@ -1,0 +1,147 @@
+"""까심 QA(#1880 embed-switch 中 실 Postgres 재현) — create_session의 sprint↔project 정합 가드.
+
+`POST /api/v2/retros`가 body.sprint_id를 body.project_id 소속인지 검증 없이 신뢰해(FK/CHECK도
+부재) 실제로는 다른 project 소속인 sprint를 링크할 수 있었다 — retro-session embed
+hypotheses[](session.project_id로 스코프)와 별도 /sprints/{id}/hypotheses(sprint의 실제
+project_id로 스코프) 응답이 갈라져 FE엔 "가설이 사라진" 것처럼 보였다.
+
+`_require_item_in_session`(같은 라우터, item_id가 부모 session 소속 아니면 404)과 동일
+컨벤션 — 존재하나 이 스코프엔 없는 리소스는 404. 부수효과로 존재하지 않는 sprint_id도
+같은 조회 1발로 404 흡수됨을 함께 가드한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("db100000-0000-0000-0000-000000000001")
+USER = uuid.UUID("db100000-0000-0000-0000-0000000000a1")
+OM = uuid.UUID("db100000-0000-0000-0000-0000000000b1")
+PROJ_A = uuid.UUID("db100000-0000-0000-0000-0000000000c1")
+PROJ_B = uuid.UUID("db100000-0000-0000-0000-0000000000c2")
+SPRINT_A = uuid.UUID("db100000-0000-0000-0000-0000000000d1")  # PROJ_A 소속(정상 케이스)
+SPRINT_B = uuid.UUID("db100000-0000-0000-0000-0000000000d2")  # PROJ_B 소속(mismatch 케이스)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(USER), email=None, claims={}, org_id=str(ORG))
+
+
+async def _seed(s):
+    for sql in [
+        f"DELETE FROM retro_sessions WHERE org_id='{ORG}'",
+        f"DELETE FROM sprints WHERE id IN ('{SPRINT_A}','{SPRINT_B}')",
+        f"DELETE FROM project_access WHERE project_id IN ('{PROJ_A}','{PROJ_B}')",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id='{USER}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','XVAL','xval-org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@xval.test','x','U',true,true,0,false,0)",
+        # owner — PROJ_A/PROJ_B 둘 다 org-wide 접근(create_session의 body.project_id 게이트를
+        # 항상 통과시켜, 아래 sprint↔project 정합 체크 자체만 정확히 표적 검증한다).
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','owner')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ_A}','{ORG}','A','none')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ_B}','{ORG}','B','none')",
+        f"INSERT INTO sprints (id,org_id,project_id,title,status,duration) VALUES "
+        f"('{SPRINT_A}','{ORG}','{PROJ_A}','sprint-a','planning',14)",
+        f"INSERT INTO sprints (id,org_id,project_id,title,status,duration) VALUES "
+        f"('{SPRINT_B}','{ORG}','{PROJ_B}','sprint-b','planning',14)",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+@pytest.mark.anyio
+async def test_cross_project_sprint_link_rejected_404():
+    from app.routers.retros import create_session
+    from app.schemas.retro import CreateSession
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            body = CreateSession(
+                project_id=PROJ_A, org_id=ORG, title="mismatch", sprint_id=SPRINT_B,
+            )
+            with pytest.raises(HTTPException) as ei:
+                await create_session(body, db=s, auth=_auth(), org_id=ORG)
+            assert ei.value.status_code == 404
+
+            # 미생성 확인 — 실패한 mutation이 부분 커밋으로 새지 않았는지.
+            cnt = (await s.execute(
+                text("SELECT count(*) FROM retro_sessions WHERE org_id=:o AND title='mismatch'"),
+                {"o": ORG},
+            )).scalar_one()
+            assert cnt == 0
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_same_project_sprint_link_succeeds_201():
+    from app.routers.retros import create_session
+    from app.schemas.retro import CreateSession
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            body = CreateSession(
+                project_id=PROJ_A, org_id=ORG, title="legit", sprint_id=SPRINT_A,
+            )
+            resp = await create_session(body, db=s, auth=_auth(), org_id=ORG)
+            assert resp.sprint_id == SPRINT_A
+            assert resp.project_id == PROJ_A
+    finally:
+        async with Session() as s:
+            await s.execute(text("DELETE FROM retro_sessions WHERE org_id=:o"), {"o": ORG})
+            await s.commit()
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_nonexistent_sprint_id_rejected_404_not_500():
+    """존재 자체가 없는 sprint_id — FK violation(500)이 아니라 동일 조회 1발로 404 흡수."""
+    from app.routers.retros import create_session
+    from app.schemas.retro import CreateSession
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            body = CreateSession(
+                project_id=PROJ_A, org_id=ORG, title="ghost-sprint", sprint_id=uuid.uuid4(),
+            )
+            with pytest.raises(HTTPException) as ei:
+                await create_session(body, db=s, auth=_auth(), org_id=ORG)
+            assert ei.value.status_code == 404
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## Summary

까심 QA finding during PR #1880 (embed-switch), live-reproduced on real Postgres: `create_session` (`POST /api/v2/retros`) accepted `body.sprint_id` without verifying it actually belongs to `body.project_id`. No FK/CHECK enforces this — `RetroSession.sprint_id` only FKs to `sprints.id`, not to a `(id, project_id)` pair. A retro session in project A could link to a sprint that actually belongs to project B.

This surfaced as apparent data loss: the retro-session's embedded `hypotheses[]` (scoped through `session.project_id`) diverged from the separate `GET /api/v2/sprints/{id}/hypotheses` endpoint (scoped through the sprint's real `project_id`) — FE saw hypotheses "disappear," when really the link was never valid in the first place.

**Fix**: single lookup added after the existing `has_project_access` gate (so sprint existence isn't leaked to a caller without project access) and before `resolve_member`/`repo.create` — fetch the sprint by `id + org_id`, `404` if missing or if its `project_id` doesn't match `body.project_id`. Same convention as this file's existing `_require_item_in_session` (an item not belonging to its parent session's scope → 404, not 403/422): a sprint that exists but isn't in the declared project's scope is "not found" from that scope's point of view. The single query also naturally absorbs the previously-unhandled completely-nonexistent-`sprint_id` case into the same clean 404 (verified below: this case ALSO silently succeeded before the fix — no FK enforcement at all, not just a project mismatch gap).

**Existing-data audit**: spot-checked the one dev org/project my agent API key can access (6 sessions, 2 unique `sprint_id`s) — no mismatch found there, but this is a partial check (agent key is org-scoped, no direct dev DB credentials in this environment). Handing PO a ready-to-run audit query for exhaustive checking across all dev orgs:
```sql
SELECT rs.id, rs.org_id, rs.project_id AS retro_project_id, rs.sprint_id,
       s.project_id AS sprint_project_id, rs.title, rs.created_at
FROM retro_sessions rs JOIN sprints s ON s.id = rs.sprint_id
WHERE rs.sprint_id IS NOT NULL AND s.project_id <> rs.project_id
ORDER BY rs.org_id, rs.created_at;
```

## Test plan
- [x] New realdb test file (3 tests): cross-project mismatch → 404 + no session created; same-project → 201 with correct fields; nonexistent `sprint_id` → 404 (not the previously-unhandled path)
- [x] Negative-tested: reverted the fix, confirmed both failure-path tests genuinely `DID NOT RAISE` (proves they weren't tautological) — including confirming the nonexistent-sprint_id case *also* silently succeeded pre-fix
- [x] `tests/test_retros.py`: 65 passed, unaffected (no existing test exercises `sprint_id` on create)
- [x] Full non-destructive suite: 3041 passed (+3 new), 10 xfailed, 0 regressions vs. last known-good baseline (same 7 pre-existing worktree-path artifacts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)