### PR TITLE
feat(fe-perf): JWT app_metadata claims for org/project authz — skip /api/v2/me on 63 pure-proxy routes (story 7d6b770b)

### DIFF
--- a/apps/web/src/app/api/activity-logs/route.ts
+++ b/apps/web/src/app/api/activity-logs/route.ts
@@ -1,12 +1,12 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/activity-logs?project_id=X&limit=30&offset=0&actor_id=&action=&entity_type=&from=&to=
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const res = await proxyToFastapi(request, '/api/v2/activity-logs');

--- a/apps/web/src/app/api/activity-stream/route.ts
+++ b/apps/web/src/app/api/activity-stream/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/activity-stream?project_id=X&actor_id=&verb=&object_type=&object_id=&since=&until=&after_seq=&limit=
@@ -9,7 +9,7 @@ import { proxyToFastapi } from '@/lib/fastapi-proxy';
 // 명단 미노출)·delivery status 미포함은 BE에서 강제 — FE는 표시만(개수=recipient_ids.length).
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const res = await proxyToFastapi(request, '/api/v2/activity-stream');

--- a/apps/web/src/app/api/agents/[id]/api-key/[keyId]/route.ts
+++ b/apps/web/src/app/api/agents/[id]/api-key/[keyId]/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string; keyId: string }> };
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string; keyId: string }> };
 export async function DELETE(request: Request, { params }: RouteParams) {
   try {
     const { id, keyId } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, `/api/v2/agents/${id}/api-keys/${keyId}`);
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/agents/[id]/api-key/route.ts
+++ b/apps/web/src/app/api/agents/[id]/api-key/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, `/api/v2/agents/${id}/api-keys`);
     if (!_r.ok) return _r;
@@ -21,7 +21,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, `/api/v2/agents/${id}/api-keys`);
     if (!_r.ok) return _r;
@@ -36,7 +36,7 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     const { searchParams } = new URL(request.url);
     const keyId = searchParams.get('key_id');
     if (!keyId) return ApiErrors.badRequest('key_id required');
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, `/api/v2/agents/${id}/api-keys/${keyId}`);
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/agents/[id]/api-keys/route.ts
+++ b/apps/web/src/app/api/agents/[id]/api-keys/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, `/api/v2/agents/${id}/api-keys`);
     if (!_r.ok) return _r;
@@ -21,7 +21,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, `/api/v2/agents/${id}/api-keys`);
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/agents/[id]/connection-artifact/route.ts
+++ b/apps/web/src/app/api/agents/[id]/connection-artifact/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, `/api/v2/agents/${id}/connection-artifact`);
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/agents/[id]/message-policy/allowlist/[memberId]/route.ts
+++ b/apps/web/src/app/api/agents/[id]/message-policy/allowlist/[memberId]/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string; memberId: string }> };
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string; memberId: string }> };
 export async function DELETE(request: Request, { params }: RouteParams) {
   try {
     const { id, memberId } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, `/api/v2/agents/${id}/message-policy/allowlist/${memberId}`);
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/agents/[id]/message-policy/allowlist/route.ts
+++ b/apps/web/src/app/api/agents/[id]/message-policy/allowlist/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, `/api/v2/agents/${id}/message-policy/allowlist`);
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/agents/[id]/message-policy/route.ts
+++ b/apps/web/src/app/api/agents/[id]/message-policy/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, `/api/v2/agents/${id}/message-policy`);
     if (!_r.ok) return _r;
@@ -21,7 +21,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 export async function PUT(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, `/api/v2/agents/${id}/message-policy`);
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/agents/[id]/verification-status/route.ts
+++ b/apps/web/src/app/api/agents/[id]/verification-status/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, `/api/v2/agents/${id}/verification-status`);
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/agents/[id]/verify-connection/route.ts
+++ b/apps/web/src/app/api/agents/[id]/verify-connection/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, `/api/v2/agents/${id}/verify-connection`);
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/analytics/activity/route.test.ts
+++ b/apps/web/src/app/api/analytics/activity/route.test.ts
@@ -3,11 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // 837a36c4(Group B): 라우트가 FastAPI proxy 위임으로 리팩토링됨 — 테스트를 현 계약
 // (auth → proxyToFastapi → apiSuccess 래핑)에 맞춰 재작성. 구 createDbServerClient 직쿼리
 // mock은 폐기(라우트가 더는 DB를 직접 안 쓰며, 비즈니스 로직은 FastAPI backend pytest가 검증).
-const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({
-  getAuthContext: vi.fn(),
+const { getOrgProjectAuthContext, proxyToFastapi } = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(),
   proxyToFastapi: vi.fn(),
 }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
@@ -18,19 +18,19 @@ const agent = () => ({ id: 'a', type: 'agent', rateLimitExceeded: false, rateLim
 
 describe('GET /api/analytics/activity', () => {
   beforeEach(() => {
-    getAuthContext.mockReset();
+    getOrgProjectAuthContext.mockReset();
     proxyToFastapi.mockReset();
-    getAuthContext.mockResolvedValue(agent());
+    getOrgProjectAuthContext.mockResolvedValue(agent());
   });
 
   it('returns 401 when unauthenticated', async () => {
-    getAuthContext.mockResolvedValue(null);
+    getOrgProjectAuthContext.mockResolvedValue(null);
     expect((await GET(new Request(URL))).status).toBe(401);
     expect(proxyToFastapi).not.toHaveBeenCalled();
   });
 
   it('returns 429 when rate limited', async () => {
-    getAuthContext.mockResolvedValue({ ...agent(), rateLimitExceeded: true });
+    getOrgProjectAuthContext.mockResolvedValue({ ...agent(), rateLimitExceeded: true });
     expect((await GET(new Request(URL))).status).toBe(429);
   });
 

--- a/apps/web/src/app/api/analytics/activity/route.ts
+++ b/apps/web/src/app/api/analytics/activity/route.ts
@@ -1,12 +1,12 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/analytics/activity?project_id=X&limit=N
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const res = await proxyToFastapi(request, '/api/v2/analytics/activity');

--- a/apps/web/src/app/api/analytics/agent-stats/route.ts
+++ b/apps/web/src/app/api/analytics/agent-stats/route.ts
@@ -1,12 +1,12 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/analytics/agent-stats?project_id=X&agent_id=Y
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const res = await proxyToFastapi(request, '/api/v2/analytics/agent-stats');

--- a/apps/web/src/app/api/analytics/epic-progress/route.test.ts
+++ b/apps/web/src/app/api/analytics/epic-progress/route.test.ts
@@ -3,11 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // 837a36c4(Group B): 라우트가 FastAPI proxy 위임으로 리팩토링됨 — 테스트를 현 계약
 // (auth → proxyToFastapi → apiSuccess 래핑)에 맞춰 재작성. 구 createDbServerClient 직쿼리
 // mock은 폐기(라우트가 더는 DB를 직접 안 쓰며, 비즈니스 로직은 FastAPI backend pytest가 검증).
-const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({
-  getAuthContext: vi.fn(),
+const { getOrgProjectAuthContext, proxyToFastapi } = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(),
   proxyToFastapi: vi.fn(),
 }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
@@ -18,19 +18,19 @@ const agent = () => ({ id: 'a', type: 'agent', rateLimitExceeded: false, rateLim
 
 describe('GET /api/analytics/epic-progress', () => {
   beforeEach(() => {
-    getAuthContext.mockReset();
+    getOrgProjectAuthContext.mockReset();
     proxyToFastapi.mockReset();
-    getAuthContext.mockResolvedValue(agent());
+    getOrgProjectAuthContext.mockResolvedValue(agent());
   });
 
   it('returns 401 when unauthenticated', async () => {
-    getAuthContext.mockResolvedValue(null);
+    getOrgProjectAuthContext.mockResolvedValue(null);
     expect((await GET(new Request(URL))).status).toBe(401);
     expect(proxyToFastapi).not.toHaveBeenCalled();
   });
 
   it('returns 429 when rate limited', async () => {
-    getAuthContext.mockResolvedValue({ ...agent(), rateLimitExceeded: true });
+    getOrgProjectAuthContext.mockResolvedValue({ ...agent(), rateLimitExceeded: true });
     expect((await GET(new Request(URL))).status).toBe(429);
   });
 

--- a/apps/web/src/app/api/analytics/epic-progress/route.ts
+++ b/apps/web/src/app/api/analytics/epic-progress/route.ts
@@ -1,12 +1,12 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/analytics/epic-progress?project_id=X&epic_id=Y
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const res = await proxyToFastapi(request, '/api/v2/analytics/epic-progress');

--- a/apps/web/src/app/api/analytics/health/route.test.ts
+++ b/apps/web/src/app/api/analytics/health/route.test.ts
@@ -3,11 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // 837a36c4(Group B): 라우트가 FastAPI proxy 위임으로 리팩토링됨 — 테스트를 현 계약
 // (auth → proxyToFastapi → apiSuccess 래핑)에 맞춰 재작성. 구 createDbServerClient 직쿼리
 // mock은 폐기(라우트가 더는 DB를 직접 안 쓰며, 비즈니스 로직은 FastAPI backend pytest가 검증).
-const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({
-  getAuthContext: vi.fn(),
+const { getOrgProjectAuthContext, proxyToFastapi } = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(),
   proxyToFastapi: vi.fn(),
 }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
@@ -18,19 +18,19 @@ const agent = () => ({ id: 'a', type: 'agent', rateLimitExceeded: false, rateLim
 
 describe('GET /api/analytics/health', () => {
   beforeEach(() => {
-    getAuthContext.mockReset();
+    getOrgProjectAuthContext.mockReset();
     proxyToFastapi.mockReset();
-    getAuthContext.mockResolvedValue(agent());
+    getOrgProjectAuthContext.mockResolvedValue(agent());
   });
 
   it('returns 401 when unauthenticated', async () => {
-    getAuthContext.mockResolvedValue(null);
+    getOrgProjectAuthContext.mockResolvedValue(null);
     expect((await GET(new Request(URL))).status).toBe(401);
     expect(proxyToFastapi).not.toHaveBeenCalled();
   });
 
   it('returns 429 when rate limited', async () => {
-    getAuthContext.mockResolvedValue({ ...agent(), rateLimitExceeded: true });
+    getOrgProjectAuthContext.mockResolvedValue({ ...agent(), rateLimitExceeded: true });
     expect((await GET(new Request(URL))).status).toBe(429);
   });
 

--- a/apps/web/src/app/api/analytics/health/route.ts
+++ b/apps/web/src/app/api/analytics/health/route.ts
@@ -1,12 +1,12 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/analytics/health?project_id=X
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const res = await proxyToFastapi(request, '/api/v2/analytics/health');

--- a/apps/web/src/app/api/analytics/overview/route.test.ts
+++ b/apps/web/src/app/api/analytics/overview/route.test.ts
@@ -3,11 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // 837a36c4(Group B): 라우트가 FastAPI proxy 위임으로 리팩토링됨 — 테스트를 현 계약
 // (auth → proxyToFastapi → apiSuccess 래핑)에 맞춰 재작성. 구 createDbServerClient 직쿼리
 // mock은 폐기(라우트가 더는 DB를 직접 안 쓰며, 비즈니스 로직은 FastAPI backend pytest가 검증).
-const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({
-  getAuthContext: vi.fn(),
+const { getOrgProjectAuthContext, proxyToFastapi } = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(),
   proxyToFastapi: vi.fn(),
 }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
@@ -18,19 +18,19 @@ const agent = () => ({ id: 'a', type: 'agent', rateLimitExceeded: false, rateLim
 
 describe('GET /api/analytics/overview', () => {
   beforeEach(() => {
-    getAuthContext.mockReset();
+    getOrgProjectAuthContext.mockReset();
     proxyToFastapi.mockReset();
-    getAuthContext.mockResolvedValue(agent());
+    getOrgProjectAuthContext.mockResolvedValue(agent());
   });
 
   it('returns 401 when unauthenticated', async () => {
-    getAuthContext.mockResolvedValue(null);
+    getOrgProjectAuthContext.mockResolvedValue(null);
     expect((await GET(new Request(URL))).status).toBe(401);
     expect(proxyToFastapi).not.toHaveBeenCalled();
   });
 
   it('returns 429 when rate limited', async () => {
-    getAuthContext.mockResolvedValue({ ...agent(), rateLimitExceeded: true });
+    getOrgProjectAuthContext.mockResolvedValue({ ...agent(), rateLimitExceeded: true });
     expect((await GET(new Request(URL))).status).toBe(429);
   });
 

--- a/apps/web/src/app/api/analytics/overview/route.ts
+++ b/apps/web/src/app/api/analytics/overview/route.ts
@@ -1,12 +1,12 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/analytics/overview?project_id=X
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const res = await proxyToFastapi(request, '/api/v2/analytics/overview');

--- a/apps/web/src/app/api/analytics/velocity-history/route.test.ts
+++ b/apps/web/src/app/api/analytics/velocity-history/route.test.ts
@@ -3,11 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // 837a36c4(Group B): 라우트가 FastAPI proxy 위임으로 리팩토링됨 — 테스트를 현 계약
 // (auth → proxyToFastapi → apiSuccess 래핑)에 맞춰 재작성. 구 createDbServerClient 직쿼리
 // mock은 폐기(라우트가 더는 DB를 직접 안 쓰며, 비즈니스 로직은 FastAPI backend pytest가 검증).
-const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({
-  getAuthContext: vi.fn(),
+const { getOrgProjectAuthContext, proxyToFastapi } = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(),
   proxyToFastapi: vi.fn(),
 }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
@@ -18,19 +18,19 @@ const agent = () => ({ id: 'a', type: 'agent', rateLimitExceeded: false, rateLim
 
 describe('GET /api/analytics/velocity-history', () => {
   beforeEach(() => {
-    getAuthContext.mockReset();
+    getOrgProjectAuthContext.mockReset();
     proxyToFastapi.mockReset();
-    getAuthContext.mockResolvedValue(agent());
+    getOrgProjectAuthContext.mockResolvedValue(agent());
   });
 
   it('returns 401 when unauthenticated', async () => {
-    getAuthContext.mockResolvedValue(null);
+    getOrgProjectAuthContext.mockResolvedValue(null);
     expect((await GET(new Request(URL))).status).toBe(401);
     expect(proxyToFastapi).not.toHaveBeenCalled();
   });
 
   it('returns 429 when rate limited', async () => {
-    getAuthContext.mockResolvedValue({ ...agent(), rateLimitExceeded: true });
+    getOrgProjectAuthContext.mockResolvedValue({ ...agent(), rateLimitExceeded: true });
     expect((await GET(new Request(URL))).status).toBe(429);
   });
 

--- a/apps/web/src/app/api/analytics/velocity-history/route.ts
+++ b/apps/web/src/app/api/analytics/velocity-history/route.ts
@@ -1,12 +1,12 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/analytics/velocity-history?project_id=X
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const res = await proxyToFastapi(request, '/api/v2/analytics/velocity-history');

--- a/apps/web/src/app/api/analytics/workload/route.test.ts
+++ b/apps/web/src/app/api/analytics/workload/route.test.ts
@@ -3,11 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // 837a36c4(Group B): 라우트가 FastAPI proxy 위임으로 리팩토링됨 — 테스트를 현 계약
 // (auth → proxyToFastapi → apiSuccess 래핑)에 맞춰 재작성. 구 createDbServerClient 직쿼리
 // mock은 폐기(라우트가 더는 DB를 직접 안 쓰며, 비즈니스 로직은 FastAPI backend pytest가 검증).
-const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({
-  getAuthContext: vi.fn(),
+const { getOrgProjectAuthContext, proxyToFastapi } = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(),
   proxyToFastapi: vi.fn(),
 }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
@@ -18,19 +18,19 @@ const agent = () => ({ id: 'a', type: 'agent', rateLimitExceeded: false, rateLim
 
 describe('GET /api/analytics/workload', () => {
   beforeEach(() => {
-    getAuthContext.mockReset();
+    getOrgProjectAuthContext.mockReset();
     proxyToFastapi.mockReset();
-    getAuthContext.mockResolvedValue(agent());
+    getOrgProjectAuthContext.mockResolvedValue(agent());
   });
 
   it('returns 401 when unauthenticated', async () => {
-    getAuthContext.mockResolvedValue(null);
+    getOrgProjectAuthContext.mockResolvedValue(null);
     expect((await GET(new Request(URL))).status).toBe(401);
     expect(proxyToFastapi).not.toHaveBeenCalled();
   });
 
   it('returns 429 when rate limited', async () => {
-    getAuthContext.mockResolvedValue({ ...agent(), rateLimitExceeded: true });
+    getOrgProjectAuthContext.mockResolvedValue({ ...agent(), rateLimitExceeded: true });
     expect((await GET(new Request(URL))).status).toBe(429);
   });
 

--- a/apps/web/src/app/api/analytics/workload/route.ts
+++ b/apps/web/src/app/api/analytics/workload/route.ts
@@ -1,12 +1,12 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/analytics/workload?project_id=X&member_id=Y
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const res = await proxyToFastapi(request, '/api/v2/analytics/workload');

--- a/apps/web/src/app/api/dashboard/my-actions/route.ts
+++ b/apps/web/src/app/api/dashboard/my-actions/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // E-MODERN CC-FE: 커맨드 센터 ① 내 할 일 프록시. raw passthrough(body/query strip 0·Bot-L.2 #1673 동형).
@@ -9,7 +9,7 @@ import { proxyToFastapi } from '@/lib/fastapi-proxy';
 /** GET /api/dashboard/my-actions → /api/v2/command-center/my-actions */
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, '/api/v2/command-center/my-actions');
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/dashboard/overview/route.ts
+++ b/apps/web/src/app/api/dashboard/overview/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // E-MODERN CC-FE: 커맨드 센터 ② 프로젝트 현황 + 헤더 함대 프록시. raw passthrough(Bot-L.2 #1673 동형).
@@ -10,7 +10,7 @@ import { proxyToFastapi } from '@/lib/fastapi-proxy';
 /** GET /api/dashboard/overview → /api/v2/command-center/overview */
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, '/api/v2/command-center/overview');
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/dashboard/route.test.ts
+++ b/apps/web/src/app/api/dashboard/route.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // 837a36c4(Group B b5): proxy 위임 리팩토링 후 stale 재작성 — auth 게이트 → proxyToFastapi → 래핑.
-const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({ getAuthContext: vi.fn(), proxyToFastapi: vi.fn() }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+const { getOrgProjectAuthContext, proxyToFastapi } = vi.hoisted(() => ({ getOrgProjectAuthContext: vi.fn(), proxyToFastapi: vi.fn() }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
@@ -14,9 +14,9 @@ const okRes = (b: unknown = { ok: 1 }) =>
 const req = () => new Request('http://localhost/api/dashboard?member_id=a');
 
 describe('GET /api/dashboard (proxy 위임)', () => {
-  beforeEach(() => { getAuthContext.mockReset(); proxyToFastapi.mockReset(); getAuthContext.mockResolvedValue(agent()); });
+  beforeEach(() => { getOrgProjectAuthContext.mockReset(); proxyToFastapi.mockReset(); getOrgProjectAuthContext.mockResolvedValue(agent()); });
   it('401 when unauthenticated', async () => {
-    getAuthContext.mockResolvedValue(null);
+    getOrgProjectAuthContext.mockResolvedValue(null);
     expect((await GET(req())).status).toBe(401);
     expect(proxyToFastapi).not.toHaveBeenCalled();
   });

--- a/apps/web/src/app/api/dashboard/route.ts
+++ b/apps/web/src/app/api/dashboard/route.ts
@@ -1,12 +1,12 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/dashboard?member_id=X[&project_id=X]
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/dispatch/route.ts
+++ b/apps/web/src/app/api/dispatch/route.ts
@@ -1,11 +1,11 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function POST(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const _r = await proxyToFastapi(request, '/api/v2/dispatch');

--- a/apps/web/src/app/api/docs/[id]/assets/route.ts
+++ b/apps/web/src/app/api/docs/[id]/assets/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -12,7 +12,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/docs/[id]/comments/route.test.ts
+++ b/apps/web/src/app/api/docs/[id]/comments/route.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // 837a36c4(Group B b6): proxy 위임 리팩토링 후 stale 재작성 — proxyToFastapiWithParams·auth 게이트. POST는 201.
-const { getAuthContext, proxyToFastapiWithParams } = vi.hoisted(() => ({
-  getAuthContext: vi.fn(), proxyToFastapiWithParams: vi.fn(),
+const { getOrgProjectAuthContext, proxyToFastapiWithParams } = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(), proxyToFastapiWithParams: vi.fn(),
 }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
 
 import { GET, POST } from './route';
@@ -18,10 +18,10 @@ const okRes = (b: unknown = { ok: 1 }) =>
 const req = (m = 'GET') => new Request(`http://localhost/x/${ID}/comments`, { method: m });
 
 describe('/api/docs/[id]/comments (proxyWithParams 위임)', () => {
-  beforeEach(() => { getAuthContext.mockReset(); proxyToFastapiWithParams.mockReset(); getAuthContext.mockResolvedValue(agent()); });
+  beforeEach(() => { getOrgProjectAuthContext.mockReset(); proxyToFastapiWithParams.mockReset(); getOrgProjectAuthContext.mockResolvedValue(agent()); });
   for (const [name, fn] of [['GET', GET], ['POST', POST]] as const) {
     it(`${name}: 401 when unauthenticated`, async () => {
-      getAuthContext.mockResolvedValue(null);
+      getOrgProjectAuthContext.mockResolvedValue(null);
       expect((await fn(req(name), ctx())).status).toBe(401);
       expect(proxyToFastapiWithParams).not.toHaveBeenCalled();
     });

--- a/apps/web/src/app/api/docs/[id]/comments/route.ts
+++ b/apps/web/src/app/api/docs/[id]/comments/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -8,7 +8,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
@@ -21,7 +21,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/docs/[id]/revisions/route.ts
+++ b/apps/web/src/app/api/docs/[id]/revisions/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -8,7 +8,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/docs/[id]/route.test.ts
+++ b/apps/web/src/app/api/docs/[id]/route.test.ts
@@ -2,10 +2,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // 837a36c4(Group B b10): 혼합 핸들러 — PATCH=proxyToFastapi(verbatim) / GET·DELETE=DocsService 직접.
 const h = vi.hoisted(() => ({
-  getAuthContext: vi.fn(), createDocRepository: vi.fn(), proxyToFastapi: vi.fn(),
+  getOrgProjectAuthContext: vi.fn(), createDocRepository: vi.fn(), proxyToFastapi: vi.fn(),
   getDocTimestamp: vi.fn(), deleteDoc: vi.fn(),
 }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext: h.getAuthContext }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext: h.getOrgProjectAuthContext }));
 vi.mock('@/lib/storage/factory', () => ({ createDocRepository: h.createDocRepository }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi: h.proxyToFastapi }));
 vi.mock('@/services/docs', async (importActual) => ({
@@ -25,12 +25,12 @@ const req = (m = 'GET') => new Request(`http://localhost/x/${ID}`, { method: m }
 describe('/api/docs/[id] (혼합: proxy + DocsService)', () => {
   beforeEach(() => {
     Object.values(h).forEach((m) => m.mockReset());
-    h.getAuthContext.mockResolvedValue(agent());
+    h.getOrgProjectAuthContext.mockResolvedValue(agent());
     h.createDocRepository.mockResolvedValue({});
   });
 
   it('PATCH: 401 when unauthenticated', async () => {
-    h.getAuthContext.mockResolvedValue(null);
+    h.getOrgProjectAuthContext.mockResolvedValue(null);
     expect((await PATCH(req('PATCH'), ctx())).status).toBe(401);
   });
   it('PATCH: proxies to /api/v2/docs/{id} verbatim (200)', async () => {
@@ -45,7 +45,7 @@ describe('/api/docs/[id] (혼합: proxy + DocsService)', () => {
   });
 
   it('GET: 401 when unauthenticated', async () => {
-    h.getAuthContext.mockResolvedValue(null);
+    h.getOrgProjectAuthContext.mockResolvedValue(null);
     expect((await GET(req(), ctx())).status).toBe(401);
   });
   it('GET: returns timestamp via DocsService.getDocTimestamp(id)', async () => {

--- a/apps/web/src/app/api/docs/[id]/route.ts
+++ b/apps/web/src/app/api/docs/[id]/route.ts
@@ -1,6 +1,6 @@
 import { DocsService } from '@/services/docs';
 import { handleApiError } from '@/lib/api-error';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { createDocRepository } from '@/lib/storage/factory';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 
 export async function PATCH(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  const me = await getAuthContext(request);
+  const me = await getOrgProjectAuthContext(request);
   if (!me) return ApiErrors.unauthorized();
   if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
   // Thin proxy to the FastAPI BE, which owns the authoritative slug logic
@@ -27,7 +27,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const dbClient = undefined;
@@ -40,7 +40,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 export async function DELETE(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const dbClient = undefined;

--- a/apps/web/src/app/api/docs/[id]/transition/route.ts
+++ b/apps/web/src/app/api/docs/[id]/transition/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -11,7 +11,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/docs/preview/route.test.ts
+++ b/apps/web/src/app/api/docs/preview/route.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // 837a36c4(Group B b6): proxy 위임 리팩토링 후 stale 재작성 — proxyToFastapi·auth 게이트·q 필수·embed_chain→embedChain 매핑.
-const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({ getAuthContext: vi.fn(), proxyToFastapi: vi.fn() }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+const { getOrgProjectAuthContext, proxyToFastapi } = vi.hoisted(() => ({ getOrgProjectAuthContext: vi.fn(), proxyToFastapi: vi.fn() }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
@@ -15,9 +15,9 @@ const previewRes = () => new Response(
 const req = (q = 'slug-x') => new Request(`http://localhost/api/docs/preview?q=${q}`);
 
 describe('GET /api/docs/preview (proxy 위임)', () => {
-  beforeEach(() => { getAuthContext.mockReset(); proxyToFastapi.mockReset(); getAuthContext.mockResolvedValue(agent()); });
+  beforeEach(() => { getOrgProjectAuthContext.mockReset(); proxyToFastapi.mockReset(); getOrgProjectAuthContext.mockResolvedValue(agent()); });
   it('401 when unauthenticated', async () => {
-    getAuthContext.mockResolvedValue(null);
+    getOrgProjectAuthContext.mockResolvedValue(null);
     expect((await GET(req())).status).toBe(401);
   });
   it('400 when q missing', async () => {

--- a/apps/web/src/app/api/docs/preview/route.ts
+++ b/apps/web/src/app/api/docs/preview/route.ts
@@ -1,4 +1,4 @@
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { handleApiError } from '@/lib/api-error';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
@@ -8,7 +8,7 @@ import { proxyToFastapi } from '@/lib/fastapi-proxy';
  */
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded)
       return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);

--- a/apps/web/src/app/api/entities/search/route.ts
+++ b/apps/web/src/app/api/entities/search/route.ts
@@ -1,11 +1,11 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const res = await proxyToFastapi(request, '/api/v2/entities/search');
     if (!res.ok) return res;

--- a/apps/web/src/app/api/integrations/github/links/[id]/route.ts
+++ b/apps/web/src/app/api/integrations/github/links/[id]/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -11,7 +11,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function DELETE(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, `/api/v2/integrations/github/links/${id}`);
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/integrations/github/links/route.ts
+++ b/apps/web/src/app/api/integrations/github/links/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // E-GHAPP Bot-L.2: PR↔story 명시연결 프록시. raw passthrough(proxyToFastapi) — body/query 검증·strip 0
@@ -9,7 +9,7 @@ import { proxyToFastapi } from '@/lib/fastapi-proxy';
 /** GET /api/integrations/github/links?story_id= — story의 연결 PR 리스트(url.search로 query forward) */
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, '/api/v2/integrations/github/links');
     if (!_r.ok) return _r;
@@ -20,7 +20,7 @@ export async function GET(request: Request) {
 /** POST /api/integrations/github/links — 명시 연결 추가(source=explicit·confidence=high). body=repo+pr(+story_id) */
 export async function POST(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, '/api/v2/integrations/github/links');
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/integrations/github/status/route.ts
+++ b/apps/web/src/app/api/integrations/github/status/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // E-GHAPP Bot-L.2: GitHub App 연결상태 프록시(Bot-S BE /status). raw passthrough.
@@ -9,7 +9,7 @@ import { proxyToFastapi } from '@/lib/fastapi-proxy';
 /** GET /api/integrations/github/status — 현 org GitHub App 연결상태(connect-prompt 구동 신호) */
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, '/api/v2/integrations/github/status');
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/meetings/[id]/recording/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/recording/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -8,7 +8,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/meetings/[id]/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
@@ -23,7 +23,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 export async function PUT(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
@@ -37,7 +37,7 @@ export async function PUT(request: Request, { params }: RouteParams) {
 export async function DELETE(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/meetings/[id]/summarize/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/summarize/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 export const maxDuration = 60;
@@ -10,7 +10,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/meetings/[id]/summary/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/summary/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 export const maxDuration = 60;
@@ -10,7 +10,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/meetings/[id]/transcribe/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/transcribe/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 export const maxDuration = 60;
@@ -10,7 +10,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/retro-sessions/[id]/actions/[action_id]/route.test.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/actions/[action_id]/route.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getAuthContext, proxyToFastapiWithParams } = vi.hoisted(() => ({
-  getAuthContext: vi.fn(),
+const { getOrgProjectAuthContext, proxyToFastapiWithParams } = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(),
   proxyToFastapiWithParams: vi.fn(),
 }));
 
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
 
 import { PATCH } from './route';
@@ -16,13 +16,13 @@ function makeAgent() {
 
 describe('PATCH /api/retro-sessions/[id]/actions/[action_id]', () => {
   beforeEach(() => {
-    getAuthContext.mockReset();
+    getOrgProjectAuthContext.mockReset();
     proxyToFastapiWithParams.mockReset();
-    getAuthContext.mockResolvedValue(makeAgent());
+    getOrgProjectAuthContext.mockResolvedValue(makeAgent());
   });
 
   it('returns 401 when not authenticated', async () => {
-    getAuthContext.mockResolvedValue(null);
+    getOrgProjectAuthContext.mockResolvedValue(null);
 
     const response = await PATCH(
       new Request('http://localhost/api/retro-sessions/session-1/actions/action-1?project_id=project-1', {

--- a/apps/web/src/app/api/retro-sessions/[id]/actions/[action_id]/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/actions/[action_id]/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string; action_id: string }> };
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string; action_id: string }> };
 export async function PATCH(request: Request, { params }: RouteParams) {
   try {
     const { id, action_id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/retro-sessions/[id]/actions/route.test.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/actions/route.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getAuthContext } = vi.hoisted(() => ({
-  getAuthContext: vi.fn(),
+const { getOrgProjectAuthContext } = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(),
 }));
 
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 
 import { POST } from './route';
 
@@ -14,8 +14,8 @@ function makeAgent() {
 
 describe('POST /api/retro-sessions/[id]/actions', () => {
   beforeEach(() => {
-    getAuthContext.mockReset();
-    getAuthContext.mockResolvedValue(makeAgent());
+    getOrgProjectAuthContext.mockReset();
+    getOrgProjectAuthContext.mockResolvedValue(makeAgent());
     vi.restoreAllMocks();
   });
 

--- a/apps/web/src/app/api/retro-sessions/[id]/actions/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/actions/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
@@ -30,7 +30,7 @@ const _r = await proxyToFastapiWithParams(request, '/api/v2/retros/[id]/actions'
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/retro-sessions/[id]/export/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/export/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/retro-sessions/[id]/items/[item_id]/group/route.test.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/items/[item_id]/group/route.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getAuthContext, proxyToFastapiWithParams } = vi.hoisted(() => ({
-  getAuthContext: vi.fn(),
+const { getOrgProjectAuthContext, proxyToFastapiWithParams } = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(),
   proxyToFastapiWithParams: vi.fn(),
 }));
 
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
 
 import { POST } from './route';
@@ -16,13 +16,13 @@ function makeAgent() {
 
 describe('POST /api/retro-sessions/[id]/items/[item_id]/group', () => {
   beforeEach(() => {
-    getAuthContext.mockReset();
+    getOrgProjectAuthContext.mockReset();
     proxyToFastapiWithParams.mockReset();
-    getAuthContext.mockResolvedValue(makeAgent());
+    getOrgProjectAuthContext.mockResolvedValue(makeAgent());
   });
 
   it('returns 401 when not authenticated', async () => {
-    getAuthContext.mockResolvedValue(null);
+    getOrgProjectAuthContext.mockResolvedValue(null);
 
     const response = await POST(
       new Request('http://localhost/api/retro-sessions/session-1/items/item-1/group', {

--- a/apps/web/src/app/api/retro-sessions/[id]/items/[item_id]/group/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/items/[item_id]/group/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string; item_id: string }> };
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string; item_id: string }> };
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id, item_id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/retro-sessions/[id]/items/[item_id]/ungroup/route.test.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/items/[item_id]/ungroup/route.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getAuthContext, proxyToFastapiWithParams } = vi.hoisted(() => ({
-  getAuthContext: vi.fn(),
+const { getOrgProjectAuthContext, proxyToFastapiWithParams } = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(),
   proxyToFastapiWithParams: vi.fn(),
 }));
 
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
 
 import { POST } from './route';
@@ -16,13 +16,13 @@ function makeAgent() {
 
 describe('POST /api/retro-sessions/[id]/items/[item_id]/ungroup', () => {
   beforeEach(() => {
-    getAuthContext.mockReset();
+    getOrgProjectAuthContext.mockReset();
     proxyToFastapiWithParams.mockReset();
-    getAuthContext.mockResolvedValue(makeAgent());
+    getOrgProjectAuthContext.mockResolvedValue(makeAgent());
   });
 
   it('returns 401 when not authenticated', async () => {
-    getAuthContext.mockResolvedValue(null);
+    getOrgProjectAuthContext.mockResolvedValue(null);
 
     const response = await POST(
       new Request('http://localhost/api/retro-sessions/session-1/items/item-1/ungroup', { method: 'POST' }),

--- a/apps/web/src/app/api/retro-sessions/[id]/items/[item_id]/ungroup/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/items/[item_id]/ungroup/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string; item_id: string }> };
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string; item_id: string }> };
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id, item_id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/retro-sessions/[id]/items/[item_id]/vote/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/items/[item_id]/vote/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string; item_id: string }> };
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string; item_id: string }> };
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id, item_id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/retro-sessions/[id]/items/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/items/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
@@ -26,7 +26,7 @@ const _r = await proxyToFastapiWithParams(request, '/api/v2/retros/[id]/items', 
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/retro-sessions/[id]/route.test.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/route.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getAuthContext, proxyToFastapiWithParams } = vi.hoisted(() => ({
-  getAuthContext: vi.fn(),
+const { getOrgProjectAuthContext, proxyToFastapiWithParams } = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(),
   proxyToFastapiWithParams: vi.fn(),
 }));
 
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
 
 import { PATCH } from './route';
@@ -16,13 +16,13 @@ function makeAgent() {
 
 describe('PATCH /api/retro-sessions/[id]', () => {
   beforeEach(() => {
-    getAuthContext.mockReset();
+    getOrgProjectAuthContext.mockReset();
     proxyToFastapiWithParams.mockReset();
-    getAuthContext.mockResolvedValue(makeAgent());
+    getOrgProjectAuthContext.mockResolvedValue(makeAgent());
   });
 
   it('returns 401 when not authenticated', async () => {
-    getAuthContext.mockResolvedValue(null);
+    getOrgProjectAuthContext.mockResolvedValue(null);
 
     const response = await PATCH(
       new Request('http://localhost/api/retro-sessions/session-1?project_id=project-1', {

--- a/apps/web/src/app/api/retro-sessions/[id]/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
@@ -30,7 +30,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 export async function PATCH(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/retro-sessions/route.test.ts
+++ b/apps/web/src/app/api/retro-sessions/route.test.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // 837a36c4(Group B b5): proxy 위임 리팩토링 후 stale 재작성 — auth 게이트 → proxyToFastapi → 래핑.
-const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({ getAuthContext: vi.fn(), proxyToFastapi: vi.fn() }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+const { getOrgProjectAuthContext, proxyToFastapi } = vi.hoisted(() => ({ getOrgProjectAuthContext: vi.fn(), proxyToFastapi: vi.fn() }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET, POST } from './route';
@@ -14,10 +14,10 @@ const okRes = (b: unknown = { ok: 1 }) =>
 const req = (m = 'GET') => new Request('http://localhost/api/retro-sessions?project_id=p', { method: m });
 
 describe('/api/retro-sessions (proxy 위임)', () => {
-  beforeEach(() => { getAuthContext.mockReset(); proxyToFastapi.mockReset(); getAuthContext.mockResolvedValue(agent()); });
+  beforeEach(() => { getOrgProjectAuthContext.mockReset(); proxyToFastapi.mockReset(); getOrgProjectAuthContext.mockResolvedValue(agent()); });
   for (const [name, fn] of [['GET', GET], ['POST', POST]] as const) {
     it(`${name}: 401 when unauthenticated`, async () => {
-      getAuthContext.mockResolvedValue(null);
+      getOrgProjectAuthContext.mockResolvedValue(null);
       expect((await fn(req(name))).status).toBe(401);
     });
     it(`${name}: delegates to ${PATH} and wraps`, async () => {

--- a/apps/web/src/app/api/retro-sessions/route.ts
+++ b/apps/web/src/app/api/retro-sessions/route.ts
@@ -1,12 +1,12 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/retro-sessions?project_id=X
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
@@ -22,7 +22,7 @@ export async function GET(request: Request) {
 // POST /api/retro-sessions
 export async function POST(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/sprints/[id]/checkin/route.test.ts
+++ b/apps/web/src/app/api/sprints/[id]/checkin/route.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // 837a36c4(Group B b6): proxy 위임 리팩토링 후 stale 재작성 — proxyToFastapiWithParams·auth 게이트.
-const { getAuthContext, proxyToFastapiWithParams } = vi.hoisted(() => ({
-  getAuthContext: vi.fn(), proxyToFastapiWithParams: vi.fn(),
+const { getOrgProjectAuthContext, proxyToFastapiWithParams } = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(), proxyToFastapiWithParams: vi.fn(),
 }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
 
 import { GET } from './route';
@@ -18,9 +18,9 @@ const okRes = (b: unknown = { ok: 1 }) =>
 const req = () => new Request(`http://localhost/x/${ID}/checkin?date=2026-06-11`);
 
 describe('GET /api/sprints/[id]/checkin (proxyWithParams 위임)', () => {
-  beforeEach(() => { getAuthContext.mockReset(); proxyToFastapiWithParams.mockReset(); getAuthContext.mockResolvedValue(agent()); });
+  beforeEach(() => { getOrgProjectAuthContext.mockReset(); proxyToFastapiWithParams.mockReset(); getOrgProjectAuthContext.mockResolvedValue(agent()); });
   it('401 when unauthenticated', async () => {
-    getAuthContext.mockResolvedValue(null);
+    getOrgProjectAuthContext.mockResolvedValue(null);
     expect((await GET(req(), ctx())).status).toBe(401);
     expect(proxyToFastapiWithParams).not.toHaveBeenCalled();
   });

--- a/apps/web/src/app/api/sprints/[id]/checkin/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/checkin/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/standup/history/route.test.ts
+++ b/apps/web/src/app/api/standup/history/route.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({
-  getAuthContext: vi.fn(),
+const { getOrgProjectAuthContext, proxyToFastapi } = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(),
   proxyToFastapi: vi.fn(),
 }));
 
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
@@ -16,13 +16,13 @@ function makeAgent() {
 
 describe('GET /api/standup/history', () => {
   beforeEach(() => {
-    getAuthContext.mockReset();
+    getOrgProjectAuthContext.mockReset();
     proxyToFastapi.mockReset();
-    getAuthContext.mockResolvedValue(makeAgent());
+    getOrgProjectAuthContext.mockResolvedValue(makeAgent());
   });
 
   it('returns 401 when not authenticated', async () => {
-    getAuthContext.mockResolvedValue(null);
+    getOrgProjectAuthContext.mockResolvedValue(null);
 
     const response = await GET(
       new Request('http://localhost/api/standup/history?project_id=project-1'),

--- a/apps/web/src/app/api/standup/history/route.ts
+++ b/apps/web/src/app/api/standup/history/route.ts
@@ -2,13 +2,13 @@
 
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/standup/history?project_id=X[&limit=N]
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/standup/missing/route.test.ts
+++ b/apps/web/src/app/api/standup/missing/route.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // 837a36c4(Group B b2): proxy 위임 리팩토링 후 stale 테스트 재작성.
-const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({
-  getAuthContext: vi.fn(),
+const { getOrgProjectAuthContext, proxyToFastapi } = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(),
   proxyToFastapi: vi.fn(),
 }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
@@ -16,13 +16,13 @@ const req = () => new Request('http://localhost/api/standup/missing?project_id=p
 
 describe('GET /api/standup/missing (proxy 위임)', () => {
   beforeEach(() => {
-    getAuthContext.mockReset();
+    getOrgProjectAuthContext.mockReset();
     proxyToFastapi.mockReset();
-    getAuthContext.mockResolvedValue(agent());
+    getOrgProjectAuthContext.mockResolvedValue(agent());
   });
 
   it('401 when unauthenticated', async () => {
-    getAuthContext.mockResolvedValue(null);
+    getOrgProjectAuthContext.mockResolvedValue(null);
     expect((await GET(req())).status).toBe(401);
     expect(proxyToFastapi).not.toHaveBeenCalled();
   });

--- a/apps/web/src/app/api/standup/missing/route.ts
+++ b/apps/web/src/app/api/standup/missing/route.ts
@@ -2,13 +2,13 @@
 
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/standup/missing?project_id=X&date=YYYY-MM-DD
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/standup/route.test.ts
+++ b/apps/web/src/app/api/standup/route.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // 837a36c4(Group B b2): proxy 위임 리팩토링 후 stale 테스트 재작성 — auth → proxyToFastapi → 래핑.
-const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({
-  getAuthContext: vi.fn(),
+const { getOrgProjectAuthContext, proxyToFastapi } = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(),
   proxyToFastapi: vi.fn(),
 }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET, POST, PUT } from './route';
@@ -18,14 +18,14 @@ const req = (method = 'GET') => new Request('http://localhost/api/standup?projec
 
 describe('/api/standup (proxy 위임)', () => {
   beforeEach(() => {
-    getAuthContext.mockReset();
+    getOrgProjectAuthContext.mockReset();
     proxyToFastapi.mockReset();
-    getAuthContext.mockResolvedValue(agent());
+    getOrgProjectAuthContext.mockResolvedValue(agent());
   });
 
   for (const [name, fn] of [['GET', GET], ['POST', POST], ['PUT', PUT]] as const) {
     it(`${name}: 401 when unauthenticated`, async () => {
-      getAuthContext.mockResolvedValue(null);
+      getOrgProjectAuthContext.mockResolvedValue(null);
       expect((await fn(req(name))).status).toBe(401);
       expect(proxyToFastapi).not.toHaveBeenCalled();
     });

--- a/apps/web/src/app/api/standup/route.ts
+++ b/apps/web/src/app/api/standup/route.ts
@@ -2,12 +2,12 @@
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 
 // GET /api/standup?project_id=...&date=YYYY-MM-DD[&member_id=...]
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
@@ -23,7 +23,7 @@ export async function GET(request: Request) {
 // POST /api/standup
 export async function POST(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
@@ -39,7 +39,7 @@ export async function POST(request: Request) {
 // PUT /api/standup — kept for backwards compatibility
 export async function PUT(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/stories/[id]/activities/route.ts
+++ b/apps/web/src/app/api/stories/[id]/activities/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -8,7 +8,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/stories/[id]/comments/route.ts
+++ b/apps/web/src/app/api/stories/[id]/comments/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -8,7 +8,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
@@ -23,7 +23,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/stories/[id]/status/route.ts
+++ b/apps/web/src/app/api/stories/[id]/status/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -8,7 +8,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function PATCH(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/stories/[id]/workflow-line/fallback-notify/route.ts
+++ b/apps/web/src/app/api/stories/[id]/workflow-line/fallback-notify/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -13,7 +13,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/stories/[id]/workflow-line/status/route.ts
+++ b/apps/web/src/app/api/stories/[id]/workflow-line/status/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -13,7 +13,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/stories/backlog/route.ts
+++ b/apps/web/src/app/api/stories/backlog/route.ts
@@ -1,11 +1,11 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/stories/bulk/route.ts
+++ b/apps/web/src/app/api/stories/bulk/route.ts
@@ -1,12 +1,12 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // PATCH /api/stories/bulk — 벌크 수정 (칸반 드래그앤드롭용)
 export async function PATCH(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/stories/workflow-line/status/route.ts
+++ b/apps/web/src/app/api/stories/workflow-line/status/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // E-DG S11 ①: workflow-line 상태 배치 read 프록시(보드 카드 badge용).
@@ -10,7 +10,7 @@ import { proxyToFastapi } from '@/lib/fastapi-proxy';
 // query(?ids=)는 proxyToFastapi 가 url.search 로 자동 forward(중복 append 금지).
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/team-members/[id]/api-key/route.ts
+++ b/apps/web/src/app/api/team-members/[id]/api-key/route.ts
@@ -1,5 +1,5 @@
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 import { handleApiError } from '@/lib/api-error';
 
@@ -8,7 +8,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapiWithParams(request, '/api/v2/team-members/[id]/api-key', { id });
     if (!_r.ok) return _r;
@@ -19,7 +19,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapiWithParams(request, '/api/v2/team-members/[id]/api-key', { id });
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/team-members/[id]/route.test.ts
+++ b/apps/web/src/app/api/team-members/[id]/route.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // 837a36c4(Group B b6): proxy 위임 리팩토링 후 stale 재작성 — proxyToFastapiWithParams(경로 템플릿+{id})·auth 게이트.
-const { getAuthContext, proxyToFastapiWithParams } = vi.hoisted(() => ({
-  getAuthContext: vi.fn(), proxyToFastapiWithParams: vi.fn(),
+const { getOrgProjectAuthContext, proxyToFastapiWithParams } = vi.hoisted(() => ({
+  getOrgProjectAuthContext: vi.fn(), proxyToFastapiWithParams: vi.fn(),
 }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/auth-helpers', () => ({ getOrgProjectAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
 
 import { GET, PATCH, DELETE } from './route';
@@ -18,10 +18,10 @@ const okRes = (b: unknown = { ok: 1 }) =>
 const req = (m = 'GET') => new Request(`http://localhost/x/${ID}`, { method: m });
 
 describe('/api/team-members/[id] (proxyWithParams 위임)', () => {
-  beforeEach(() => { getAuthContext.mockReset(); proxyToFastapiWithParams.mockReset(); getAuthContext.mockResolvedValue(agent()); });
+  beforeEach(() => { getOrgProjectAuthContext.mockReset(); proxyToFastapiWithParams.mockReset(); getOrgProjectAuthContext.mockResolvedValue(agent()); });
   for (const [name, fn] of [['GET', GET], ['PATCH', PATCH], ['DELETE', DELETE]] as const) {
     it(`${name}: 401 when unauthenticated`, async () => {
-      getAuthContext.mockResolvedValue(null);
+      getOrgProjectAuthContext.mockResolvedValue(null);
       expect((await fn(req(name), ctx())).status).toBe(401);
       expect(proxyToFastapiWithParams).not.toHaveBeenCalled();
     });

--- a/apps/web/src/app/api/team-members/[id]/route.ts
+++ b/apps/web/src/app/api/team-members/[id]/route.ts
@@ -1,5 +1,5 @@
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 import { handleApiError } from '@/lib/api-error';
 
@@ -8,7 +8,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapiWithParams(request, '/api/v2/team-members/[id]', { id });
     if (!_r.ok) return _r;
@@ -19,7 +19,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 export async function PATCH(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapiWithParams(request, '/api/v2/team-members/[id]', { id });
     if (!_r.ok) return _r;
@@ -31,7 +31,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
 export async function DELETE(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapiWithParams(request, '/api/v2/team-members/[id]', { id });
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/webhooks/config/[id]/test-send/route.ts
+++ b/apps/web/src/app/api/webhooks/config/[id]/test-send/route.ts
@@ -1,6 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -9,7 +9,7 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, `/api/v2/webhooks/config/${id}/test-send`);
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/workflow-line-config/active/route.ts
+++ b/apps/web/src/app/api/workflow-line-config/active/route.ts
@@ -1,6 +1,6 @@
 import { ApiErrors } from '@/lib/api-response';
 import { handleApiError } from '@/lib/api-error';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // E-DG S29 follow-up: 좌-pane 데이터소스 — 현 active published 라인 config(steps/gates) 조회 프록시(admin·#1637).
@@ -8,7 +8,7 @@ import { proxyToFastapi } from '@/lib/fastapi-proxy';
 // proxyToFastapi가 url.search(entity_type/project_id) 자동 전달. raw passthrough(workflow-line 도메인 일관).
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/app/api/workflow-line-config/resolve-preview/route.ts
+++ b/apps/web/src/app/api/workflow-line-config/resolve-preview/route.ts
@@ -1,6 +1,6 @@
 import { ApiErrors } from '@/lib/api-response';
 import { handleApiError } from '@/lib/api-error';
-import { getAuthContext } from '@/lib/auth-helpers';
+import { getOrgProjectAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // E-DG S29: workflow line policy dry-run resolve-preview 프록시(admin·라인 config publish 前 시뮬레이션).
@@ -8,7 +8,7 @@ import { proxyToFastapi } from '@/lib/fastapi-proxy';
 //   → 3축 {routing_path, gates, trust_branch}. raw passthrough(workflow-line 도메인 일관·소비부서 직접 read).
 export async function POST(request: Request) {
   try {
-    const me = await getAuthContext(request);
+    const me = await getOrgProjectAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 

--- a/apps/web/src/lib/auth-helpers.test.ts
+++ b/apps/web/src/lib/auth-helpers.test.ts
@@ -10,7 +10,7 @@ vi.mock('@sprintable/storage-api', () => ({ fastapiCall: fastapiCallMock }));
 vi.mock('@/lib/rate-limiter', () => ({ checkRateLimit: checkRateLimitMock }));
 vi.mock('@/lib/db/server', () => ({ getServerSession: getServerSessionMock }));
 
-import { getAuthContext } from './auth-helpers';
+import { getAuthContext, getOrgProjectAuthContext } from './auth-helpers';
 
 describe('getAuthContext — SaaS 모드', () => {
   beforeEach(() => {
@@ -63,5 +63,83 @@ describe('getAuthContext — SaaS 모드', () => {
     const result = await getAuthContext(request);
 
     expect(result).toBeNull();
+  });
+});
+
+// story 7d6b770b: authz-only(org/project) 라우트 전용 경량 경로 — JWT claim 있으면
+// GET /api/v2/me 재호출 없이 스킵, 없으면 fail-closed로 기존 /me fallback.
+describe('getOrgProjectAuthContext — light path (story 7d6b770b)', () => {
+  beforeEach(() => {
+    fastapiCallMock.mockReset();
+    checkRateLimitMock.mockReset();
+    getServerSessionMock.mockReset();
+    checkRateLimitMock.mockReturnValue({ allowed: true, remaining: 299, resetAt: 0 });
+  });
+
+  it('세션에 org_id/project_id claim 있으면 /me 호출 없이 스킵', async () => {
+    getServerSessionMock.mockResolvedValue({
+      access_token: 'valid-token', org_id: 'org-1', project_id: 'proj-1',
+    });
+
+    const request = new Request('http://localhost');
+    const result = await getOrgProjectAuthContext(request);
+
+    expect(result).toEqual({ org_id: 'org-1', project_id: 'proj-1', type: 'human' });
+    expect(fastapiCallMock).not.toHaveBeenCalled();
+  });
+
+  it('claim 없으면(fail-closed) 기존 /me 왕복으로 fallback', async () => {
+    getServerSessionMock.mockResolvedValue({
+      access_token: 'valid-token', org_id: null, project_id: null,
+    });
+    fastapiCallMock.mockResolvedValue({
+      id: 'member-2', org_id: 'org-1', project_id: 'proj-1', project_name: 'Test Project',
+    });
+
+    const request = new Request('http://localhost');
+    const result = await getOrgProjectAuthContext(request);
+
+    expect(fastapiCallMock).toHaveBeenCalledWith('GET', '/api/v2/me', 'valid-token');
+    expect(result?.org_id).toBe('org-1');
+    expect(result?.project_id).toBe('proj-1');
+  });
+
+  it('claim 중 하나만 있어도(부분) fail-closed로 /me fallback', async () => {
+    getServerSessionMock.mockResolvedValue({
+      access_token: 'valid-token', org_id: 'org-1', project_id: null,
+    });
+    fastapiCallMock.mockResolvedValue({
+      id: 'member-2', org_id: 'org-1', project_id: 'proj-1', project_name: 'Test Project',
+    });
+
+    const request = new Request('http://localhost');
+    await getOrgProjectAuthContext(request);
+
+    expect(fastapiCallMock).toHaveBeenCalled();
+  });
+
+  it('세션 없음 → null 반환', async () => {
+    getServerSessionMock.mockResolvedValue(null);
+
+    const request = new Request('http://localhost');
+    const result = await getOrgProjectAuthContext(request);
+
+    expect(result).toBeNull();
+  });
+
+  it('API 키 경로는 무변경 — 여전히 /me 호출 + rate-limit 적용', async () => {
+    fastapiCallMock.mockResolvedValue({
+      id: 'member-1', org_id: 'org-1', project_id: 'proj-1',
+      project_name: 'Test Project', type: 'agent', scope: [],
+    });
+
+    const request = new Request('http://localhost', {
+      headers: { Authorization: 'Bearer sk_live_test123' },
+    });
+    const result = await getOrgProjectAuthContext(request);
+
+    expect(fastapiCallMock).toHaveBeenCalledWith('GET', '/api/v2/me', 'sk_live_test123');
+    expect(checkRateLimitMock).toHaveBeenCalledWith('member-1');
+    expect(result?.type).toBe('agent');
   });
 });

--- a/apps/web/src/lib/auth-helpers.ts
+++ b/apps/web/src/lib/auth-helpers.ts
@@ -170,6 +170,77 @@ async function resolveTeamMemberFromMemberships(
   };
 }
 
+export interface AuthContext {
+  id: string;
+  org_id: string;
+  project_id: string;
+  project_name: string;
+  type?: 'human' | 'agent';
+  scope?: string[];
+  rateLimitExceeded?: boolean;
+  rateLimitRemaining?: number;
+  rateLimitResetAt?: number;
+}
+
+// story 7d6b770b: authz-only(org/project 스코프만 필요) 라우트가 소비하는 축소 shape.
+// id/project_name/type/scope는 light path(JWT claim)에선 안 채워지므로 optional로 남긴다 —
+// 이 필드들이 실제로 필요한 라우트는 애초에 getOrgProjectAuthContext를 쓰면 안 된다(9건
+// "needs_full_identity" 버킷은 getAuthContext 유지).
+export type OrgProjectAuthContext = Pick<AuthContext, 'org_id' | 'project_id' | 'type'>
+  & Partial<Pick<AuthContext, 'id' | 'project_name' | 'scope' | 'rateLimitExceeded' | 'rateLimitRemaining' | 'rateLimitResetAt'>>;
+
+function getRawApiKey(request: Request): string | null {
+  // x-api-key 헤더는 Authorization 헤더가 CDN에서 strip될 때를 위한 fallback
+  const authHeader = request.headers.get('Authorization');
+  const xApiKey = request.headers.get('x-api-key');
+  return authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : (xApiKey ?? null);
+}
+
+async function resolveApiKeyAuthContext(rawApiKey: string): Promise<AuthContext | null> {
+  try {
+    const { fastapiCall } = await import('@sprintable/storage-api');
+    const apiKeyMember = await fastapiCall<{
+      id: string; org_id: string; project_id: string; project_name: string;
+      type: 'human' | 'agent'; scope?: string[];
+    }>('GET', '/api/v2/me', rawApiKey);
+
+    if (!apiKeyMember) return null;
+
+    const { checkRateLimit } = await import('./rate-limiter');
+    const { allowed, remaining, resetAt } = checkRateLimit(apiKeyMember.id);
+    return {
+      id: apiKeyMember.id,
+      org_id: apiKeyMember.org_id,
+      project_id: apiKeyMember.project_id,
+      project_name: apiKeyMember.project_name ?? '',
+      type: apiKeyMember.type,
+      scope: apiKeyMember.scope,
+      rateLimitExceeded: !allowed,
+      rateLimitRemaining: remaining,
+      rateLimitResetAt: resetAt,
+    };
+  } catch {
+    // API key 인증 실패 — OAuth 경로로 계속(호출부가 판단)
+    return null;
+  }
+}
+
+async function resolveHumanAuthContextFromMe(accessToken: string): Promise<AuthContext | null> {
+  const { fastapiCall } = await import('@sprintable/storage-api');
+  const meData = await fastapiCall<{ id: string; org_id: string; project_id: string; project_name: string } | null>(
+    'GET', '/api/v2/me', accessToken
+  ).catch(() => null);
+  if (!meData) return null;
+
+  return {
+    id: meData.id,
+    org_id: meData.org_id,
+    project_id: meData.project_id,
+    project_name: meData.project_name,
+    type: 'human' as const,
+  };
+}
+
 /**
  * Dual auth: OAuth 또는 API Key로 인증
  *
@@ -183,50 +254,13 @@ async function resolveTeamMemberFromMemberships(
  *
  * @returns team_member context { id, org_id, project_id, project_name, type?, rateLimitExceeded? }
  */
-export const getAuthContext = cache(async (
-  request: Request
-): Promise<{
-  id: string;
-  org_id: string;
-  project_id: string;
-  project_name: string;
-  type?: 'human' | 'agent';
-  scope?: string[];
-  rateLimitExceeded?: boolean;
-  rateLimitRemaining?: number;
-  rateLimitResetAt?: number;
-} | null> => {
+export const getAuthContext = cache(async (request: Request): Promise<AuthContext | null> => {
   // 1. API Key 인증 — FastAPI /api/v2/me에 rawApiKey를 Bearer 토큰으로 전달
-  // x-api-key 헤더는 Authorization 헤더가 CDN에서 strip될 때를 위한 fallback
-  const authHeader = request.headers.get('Authorization');
-  const xApiKey = request.headers.get('x-api-key');
-  const rawApiKey = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : (xApiKey ?? null);
+  const rawApiKey = getRawApiKey(request);
   if (rawApiKey) {
-    try {
-      const { fastapiCall } = await import('@sprintable/storage-api');
-      const apiKeyMember = await fastapiCall<{
-        id: string; org_id: string; project_id: string; project_name: string;
-        type: 'human' | 'agent'; scope?: string[];
-      }>('GET', '/api/v2/me', rawApiKey);
-
-      if (apiKeyMember) {
-        const { checkRateLimit } = await import('./rate-limiter');
-        const { allowed, remaining, resetAt } = checkRateLimit(apiKeyMember.id);
-        return {
-          id: apiKeyMember.id,
-          org_id: apiKeyMember.org_id,
-          project_id: apiKeyMember.project_id,
-          project_name: apiKeyMember.project_name ?? '',
-          type: apiKeyMember.type,
-          scope: apiKeyMember.scope,
-          rateLimitExceeded: !allowed,
-          rateLimitRemaining: remaining,
-          rateLimitResetAt: resetAt,
-        };
-      }
-    } catch {
-      // API key 인증 실패 — OAuth 경로로 계속
-    }
+    const apiKeyContext = await resolveApiKeyAuthContext(rawApiKey);
+    if (apiKeyContext) return apiKeyContext;
+    // API key 인증 실패 — OAuth 경로로 계속
   }
 
   // 2. OAuth 세션 — JWT 쿠키 파싱
@@ -235,17 +269,45 @@ export const getAuthContext = cache(async (
   if (!session) return null;
 
   // FastAPI로 team member 조회
-  const { fastapiCall } = await import('@sprintable/storage-api');
-  const meData = await fastapiCall<{ id: string; org_id: string; project_id: string; project_name: string } | null>(
-    'GET', '/api/v2/me', session.access_token
-  ).catch(() => null);
-  if (!meData) return null;
+  return resolveHumanAuthContextFromMe(session.access_token);
+});
 
-  return {
-    id: meData.id,
-    org_id: meData.org_id,
-    project_id: meData.project_id,
-    project_name: meData.project_name,
-    type: 'human' as const,
-  };
+/**
+ * story 7d6b770b: getAuthContext의 경량 변형 — org/project 스코프 authz만 필요하고
+ * member_id(id)/project_name/type/scope는 안 쓰는 BFF 라우트 전용("pure proxy gate"
+ * 버킷, 63건 — FastAPI가 같은 토큰으로 재검증하므로 이 값들이 FE측 authz 결정에 쓰이지
+ * 않는 라우트). JWT app_metadata에 org_id·project_id가 **둘 다** 있으면 GET /api/v2/me
+ * 재호출 없이 그 claim을 쓴다(신규 네트워크 호출 0) — 없거나 malformed면 fail-closed로
+ * 기존 /me 경로로 fallback(기능 무손, 절대 fail-open 아님).
+ *
+ * ⚠️기존 getAuthContext()의 계약/동작은 이 함수 도입으로 전혀 바뀌지 않는다(94개 기존
+ * 호출부 무변경) — 이 함수를 명시적으로 opt-in한 라우트만 영향받는다.
+ *
+ * API 키(에이전트) 경로는 이 light path를 타지 않고 항상 기존 /me 경로를 그대로 쓴다 —
+ * API 키는 이 JWT claim shape이 아니고, rate-limit 키잉(checkRateLimit)에 apiKeyMember.id가
+ * 필요해 애초에 /me 응답이 필요하다.
+ */
+export const getOrgProjectAuthContext = cache(async (request: Request): Promise<OrgProjectAuthContext | null> => {
+  const rawApiKey = getRawApiKey(request);
+  if (rawApiKey) {
+    const apiKeyContext = await resolveApiKeyAuthContext(rawApiKey);
+    if (apiKeyContext) return apiKeyContext;
+    // API key 인증 실패 — OAuth 경로로 계속
+  }
+
+  const { getServerSession } = await import('./db/server');
+  const session = await getServerSession();
+  if (!session) return null;
+
+  if (session.org_id && session.project_id) {
+    return {
+      org_id: session.org_id,
+      project_id: session.project_id,
+      type: 'human' as const,
+    };
+  }
+
+  // fail-closed: claim 없거나 malformed면 기존 /me 왕복으로 fallback(스킵 최적화 포기,
+  // 기능은 항상 보존).
+  return resolveHumanAuthContextFromMe(session.access_token);
 });

--- a/apps/web/src/lib/db/server.test.ts
+++ b/apps/web/src/lib/db/server.test.ts
@@ -1,0 +1,123 @@
+// story 7d6b770b: getServerSession()이 JWT app_metadata의 org_id/project_id를 노출하는지
+// 실 서명토큰(jose SignJWT, BE create_access_token과 동일 HS256+JWT_SECRET)으로 round-trip
+// 검증. malformed/missing claim은 null(fail-closed) — 호출부가 /me fallback으로 넘어가게.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SignJWT } from 'jose';
+
+const { cookiesGetMock } = vi.hoisted(() => ({
+  cookiesGetMock: vi.fn(),
+}));
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(async () => ({ get: cookiesGetMock })),
+}));
+
+const JWT_SECRET = 'test-secret-7d6b770b';
+
+async function signAccessToken(payload: Record<string, unknown>): Promise<string> {
+  const secretBytes = new TextEncoder().encode(JWT_SECRET);
+  return new SignJWT({ type: 'access', ...payload })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setSubject((payload['sub'] as string) ?? 'user-1')
+    .setIssuedAt()
+    .setExpirationTime('15m')
+    .sign(secretBytes);
+}
+
+describe('getServerSession — JWT app_metadata org_id/project_id claim', () => {
+  beforeEach(() => {
+    cookiesGetMock.mockReset();
+    process.env['JWT_SECRET'] = JWT_SECRET;
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('app_metadata.org_id/project_id가 있으면 그대로 노출', async () => {
+    const token = await signAccessToken({
+      email: 'u@test.com',
+      app_metadata: { org_id: 'org-1', project_id: 'proj-1' },
+    });
+    cookiesGetMock.mockReturnValue({ value: token });
+
+    const { getServerSession } = await import('./server');
+    const session = await getServerSession();
+
+    expect(session).not.toBeNull();
+    expect(session?.org_id).toBe('org-1');
+    expect(session?.project_id).toBe('proj-1');
+    expect(session?.user_id).toBe('user-1');
+  });
+
+  it('app_metadata 없음 → org_id/project_id null(fail-closed, /me fallback 유도)', async () => {
+    const token = await signAccessToken({ email: 'u@test.com' });
+    cookiesGetMock.mockReturnValue({ value: token });
+
+    const { getServerSession } = await import('./server');
+    const session = await getServerSession();
+
+    expect(session).not.toBeNull();
+    expect(session?.org_id).toBeNull();
+    expect(session?.project_id).toBeNull();
+  });
+
+  it('app_metadata가 malformed(배열/원시값)여도 null(크래시 아님)', async () => {
+    const token = await signAccessToken({ email: 'u@test.com', app_metadata: ['not', 'an', 'object'] });
+    cookiesGetMock.mockReturnValue({ value: token });
+
+    const { getServerSession } = await import('./server');
+    const session = await getServerSession();
+
+    expect(session).not.toBeNull();
+    expect(session?.org_id).toBeNull();
+    expect(session?.project_id).toBeNull();
+  });
+
+  it('만료된 토큰 → null(fail-open 아님)', async () => {
+    const secretBytes = new TextEncoder().encode(JWT_SECRET);
+    const expiredToken = await new SignJWT({
+      type: 'access',
+      app_metadata: { org_id: 'org-1', project_id: 'proj-1' },
+    })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setSubject('user-1')
+      .setIssuedAt(Math.floor(Date.now() / 1000) - 3600)
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 1800)
+      .sign(secretBytes);
+    cookiesGetMock.mockReturnValue({ value: expiredToken });
+
+    const { getServerSession } = await import('./server');
+    const session = await getServerSession();
+
+    expect(session).toBeNull();
+  });
+
+  it('변조된(다른 secret으로 서명된) 토큰 → null', async () => {
+    const wrongSecretBytes = new TextEncoder().encode('wrong-secret');
+    const tamperedToken = await new SignJWT({
+      type: 'access',
+      app_metadata: { org_id: 'org-1', project_id: 'proj-1' },
+    })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setSubject('user-1')
+      .setIssuedAt()
+      .setExpirationTime('15m')
+      .sign(wrongSecretBytes);
+    cookiesGetMock.mockReturnValue({ value: tamperedToken });
+
+    const { getServerSession } = await import('./server');
+    const session = await getServerSession();
+
+    expect(session).toBeNull();
+  });
+
+  it('쿠키 없음 → null', async () => {
+    cookiesGetMock.mockReturnValue(undefined);
+
+    const { getServerSession } = await import('./server');
+    const session = await getServerSession();
+
+    expect(session).toBeNull();
+  });
+});

--- a/apps/web/src/lib/db/server.ts
+++ b/apps/web/src/lib/db/server.ts
@@ -8,11 +8,34 @@ export interface ServerSession {
   user_id: string;
   email: string;
   access_token: string;
+  // story 7d6b770b: app_metadata.org_id/project_id는 BE(get_verified_org_id)가 이미 이
+  // 서명검증된 claim으로 DB 왕복 없이 authz 스코프를 판단한다 — FE도 동일 claim을 읽으면
+  // "authz-only"(org/project만 필요) BFF 라우트가 GET /api/v2/me 재호출을 생략할 수 있다.
+  // 신규 네트워크 호출 0(이미 하던 jwtVerify 서명검증 결과에서 파싱만 추가). claim 부재/
+  // malformed면 null(fail-closed) — 호출부가 /me fallback으로 넘어가게.
+  org_id: string | null;
+  project_id: string | null;
 }
 
 function getJwtSecretBytes(): Uint8Array {
   const secret = process.env['JWT_SECRET'] ?? '';
   return new TextEncoder().encode(secret);
+}
+
+function readStringClaim(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function readAppMetadataClaims(payload: Record<string, unknown>): Pick<ServerSession, 'org_id' | 'project_id'> {
+  const appMetadata = payload['app_metadata'];
+  if (!appMetadata || typeof appMetadata !== 'object' || Array.isArray(appMetadata)) {
+    return { org_id: null, project_id: null };
+  }
+  const metadata = appMetadata as Record<string, unknown>;
+  return {
+    org_id: readStringClaim(metadata['org_id']),
+    project_id: readStringClaim(metadata['project_id']),
+  };
 }
 
 export async function getServerSession(): Promise<ServerSession | null> {
@@ -22,7 +45,14 @@ export async function getServerSession(): Promise<ServerSession | null> {
   try {
     const { payload } = await jwtVerify(token, getJwtSecretBytes());
     if (payload['type'] !== 'access' || !payload.sub) return null;
-    return { user_id: payload.sub, email: (payload['email'] as string) ?? '', access_token: token };
+    const claims = readAppMetadataClaims(payload);
+    return {
+      user_id: payload.sub,
+      email: readStringClaim(payload['email']) ?? '',
+      access_token: token,
+      org_id: claims.org_id,
+      project_id: claims.project_id,
+    };
   } catch {
     return null;
   }

--- a/apps/web/src/lib/fastapi-proxy.test.ts
+++ b/apps/web/src/lib/fastapi-proxy.test.ts
@@ -1,0 +1,62 @@
+// story 7d6b770b PO 승인조건 ⭐1급 게이트: X-Project-Id(project-switch override)가
+// getAuthContext/getOrgProjectAuthContext 변경과 완전히 독립적으로 원본 request에서
+// FastAPI로 그대로 전달되는지(스테일 JWT project_id로 덮이지 않는지) 증명.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getServerSessionMock } = vi.hoisted(() => ({
+  getServerSessionMock: vi.fn(),
+}));
+
+vi.mock('@/lib/db/server', () => ({ getServerSession: getServerSessionMock }));
+
+import { proxyToFastapi, proxyToFastapiWithParams } from './fastapi-proxy';
+
+describe('fastapi-proxy — X-Project-Id override passthrough (story 7d6b770b 회귀가드)', () => {
+  beforeEach(() => {
+    getServerSessionMock.mockReset();
+    getServerSessionMock.mockResolvedValue({
+      // JWT claim의 project_id는 'jwt-stale-proj'(과거 탭에서 발급) — 실제 요청은 다른
+      // project로 override했다고 가정. 이 값이 절대 승리하면 안 된다(cross-project 오작동).
+      access_token: 'token-1', org_id: 'org-1', project_id: 'jwt-stale-proj',
+    });
+    global.fetch = vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+  });
+
+  it('X-Project-Id 헤더가 있으면 JWT claim project_id 무시하고 그대로 FastAPI에 전달', async () => {
+    const request = new Request('http://localhost/api/retro-sessions/abc', {
+      headers: { 'x-project-id': 'override-proj-live' },
+    });
+
+    await proxyToFastapi(request, '/api/v2/retros/abc');
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers['x-project-id']).toBe('override-proj-live');
+    // JWT의 stale project_id 값이 어디에도 섞여 나가면 안 됨.
+    expect(Object.values(headers)).not.toContain('jwt-stale-proj');
+  });
+
+  it('proxyToFastapiWithParams도 동일하게 X-Project-Id를 그대로 전달', async () => {
+    const request = new Request('http://localhost/api/retro-sessions/abc', {
+      headers: { 'x-project-id': 'override-proj-live' },
+    });
+
+    await proxyToFastapiWithParams(request, '/api/v2/retros/[id]', { id: 'abc' });
+
+    const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/api/v2/retros/abc');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['x-project-id']).toBe('override-proj-live');
+  });
+
+  it('X-Project-Id 헤더가 없으면 아예 안 실림(JWT project_id로 대체 주입되지 않음)', async () => {
+    const request = new Request('http://localhost/api/retro-sessions/abc');
+
+    await proxyToFastapi(request, '/api/v2/retros/abc');
+
+    const [, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers['x-project-id']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Story `7d6b770b`. Every authenticated Next.js BFF route calls `getAuthContext()`, which for human callers always does a full `GET /api/v2/me` HTTP round-trip to FastAPI — even though `org_id`/`project_id` are already present, signature-verified, inside the JWT's `app_metadata` claims (the same claims `get_verified_org_id` already reads directly BE-side, no DB round-trip). Quantified across 3 representative screens in the design phase (retro/[id]: 4 routes/2 stages; **board/kanban — worst case: ~13 routes across 7 sequential stages**; sprints-list: 5 routes/2 stages) — every route pays a redundant ~90-145ms auth tax on top of its real data fetch.

**Scope (per PO/까심-reviewed design crux)**: swept all 95 `getAuthContext` call sites, categorized by which fields each route actually consumes:
- **63 "pure proxy gates"** — only check auth-truthiness/rate-limit before delegating to `proxyToFastapi`, which forwards the caller's own token to FastAPI, which re-verifies everything independently anyway. These never use `org_id`/`project_id`/`id` for their own authz decisions on the FE side. **Converted in this PR.**
- **32 deferred, untouched**: 10 org/project-local consumers (need individual project-switch-safety review), 2 manual-forward gates, 11 direct-local-service gates, 9 needing full resolved identity (`member_id`/`project_name`/actor-attribution). Explicit follow-up, not silently dropped.

## Changes
- `ServerSession` (`db/server.ts`) now also carries `org_id`/`project_id` parsed from the JWT's `app_metadata` — **zero new network calls** (the `jwtVerify()` signature check was already happening). Missing/malformed claims fail closed to `null`.
- New `getOrgProjectAuthContext()` alongside the existing `getAuthContext()` — **`getAuthContext()` itself is unchanged in behavior/contract** (internal refactor only extracted shared helpers; the other 94 existing call sites are unaffected). Uses JWT claims when both `org_id` and `project_id` are present; falls back to the full `/api/v2/me` round-trip otherwise. API-key (agent) path is untouched — always calls `/me`, since API keys don't carry this claim shape and rate-limiting needs the resolved member id regardless.
- 63 route files converted (2-line mechanical swap each) + 21 corresponding test files' mocks updated.

## Test plan
- [x] New tests: JWT-claims path genuinely skips `/api/v2/me` when claims present; genuinely falls back (fail-**closed**, not fail-open) when missing/malformed — using a real `jose`-signed token verified through the actual `jwtVerify()` path, not a mocked decode
- [x] Expired and tampered-signature tokens both still return `null` exactly as before
- [x] **⭐PO's top-priority gate**: new `fastapi-proxy.test.ts` proves `X-Project-Id` (project-switch override) reaches FastAPI unmodified — read directly from the incoming `Request`'s headers in `proxyToFastapi`, structurally independent of this change, including a test that seeds a deliberately **stale** JWT `project_id` claim and proves it never leaks into the forwarded headers
- [x] Full regression: `tsc --noEmit` clean, 923/923 tests passing (0 regressions)
- [ ] Not performed: a live browser OAuth-session test — this environment can't mint a valid `sp_at` cookie without an actual login flow. The API-key path was live-verified unchanged against dev during the design/quantification phase; the human-JWT light path is verified via the new unit tests against a real signed token rather than a live session — flagging this gap explicitly for 까심/PO's authz-no-loss QA pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)