### PR TITLE
chore(promotion): develop→main — resolve 0146/0148 merge conflict per Option B (story bda4beac)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,9 +55,11 @@ jobs:
 
       # Empty DB → alembic/env.py provisions from the baseline snapshot (schema + global seed)
       # and stamps revision 0096. This is the exact path a freshly-wiped prod takes.
-      - name: alembic upgrade head (fresh DB → baseline)
+      # story bda4beac: 0148(core) 재부모 후 이 checkout(develop, ee_pricing 포함)은 dual-head
+      # (core 0155+ · ee_pricing 0147) — `head`(단수)는 이제 모호해 `heads`(복수)로 전환.
+      - name: alembic upgrade heads (fresh DB → baseline)
         working-directory: backend
-        run: uv run alembic upgrade head
+        run: uv run alembic upgrade heads
 
       - name: Verify tables created
         run: |
@@ -93,26 +95,32 @@ jobs:
         working-directory: backend
         run: uv run pytest -q -m "not destructive_schema"
 
-      - name: Verify fresh DB reached head (baseline + incremental)
+      # story bda4beac: dual-head(core+ee_pricing) checkout에서 "current == 단일 head" 비교는
+      # 항상 실패한다(current가 2행이라 head=1건과 부분일치 안 됨) — 두 head 집합이 정확히
+      # 일치하는지(comm -3, 차집합 0행) 비교로 교체. 단일-head 컨텍스트(main)에서도 그대로
+      # 성립(양쪽 다 1행이면 차집합도 0행).
+      - name: Verify fresh DB reached heads (baseline + incremental)
         working-directory: backend
         run: |
           set -e
-          cur=$(uv run alembic current 2>/dev/null | grep -oE '^[0-9a-z_]+' | head -1)
-          head=$(uv run alembic heads 2>/dev/null | grep -oE '^[0-9a-z_]+' | head -1)
-          echo "current=$cur head=$head"
-          test -n "$cur" && test "$cur" = "$head"  # fresh DB is AT head, not stuck at baseline
+          cur=$(uv run alembic current 2>/dev/null | grep -oE '^[0-9a-z_]+' | sort)
+          heads=$(uv run alembic heads 2>/dev/null | grep -oE '^[0-9a-z_]+' | sort)
+          echo "current=$cur"
+          echo "heads=$heads"
+          test -n "$cur"  # fresh DB is not stuck at baseline(0096) — reached at least one head
+          diff <(echo "$cur") <(echo "$heads")  # current head set == full head set(전 head 도달)
 
-      # existing-DB path: a DB already at head must be a pure no-op — no migration re-runs.
-      # (The fresh-DB run above already advanced this DB to head via baseline + incremental.)
-      - name: Existing-DB no-op (re-run upgrade head)
+      # existing-DB path: a DB already at heads must be a pure no-op — no migration re-runs.
+      # (The fresh-DB run above already advanced this DB to heads via baseline + incremental.)
+      - name: Existing-DB no-op (re-run upgrade heads)
         working-directory: backend
         run: |
           set -e
-          out=$(uv run alembic upgrade head 2>&1); echo "$out"
+          out=$(uv run alembic upgrade heads 2>&1); echo "$out"
           if echo "$out" | grep -q "Running upgrade"; then
-            echo "FAIL: migrations re-ran on a DB already at head (existing-DB path not a no-op)"; exit 1
+            echo "FAIL: migrations re-ran on a DB already at heads (existing-DB path not a no-op)"; exit 1
           fi
-          echo "OK: existing-DB upgrade head is a no-op"
+          echo "OK: existing-DB upgrade heads is a no-op"
 
       # story 8236bbc3: destructive_schema 마커 파일(Base.metadata.create_all/drop_all로 자체
       # 스키마 직접 관리)은 위 alembic-migrated 공유 DB(sprintable_test)에서 절대 실행하지
@@ -151,6 +159,70 @@ jobs:
             exit 1
           fi
           echo "OK: all ${#files[@]} isolated destructive-schema files passed"
+
+  # story bda4beac: alembic-fresh-db(위)는 checkout된 브랜치(develop/PR)의 파일셋 기준이라
+  # main이 develop과 다른 파일셋(ee_pricing 0146/0147 부재)일 때의 그래프 단절을 원천적으로
+  # 못 잡는다(실제로 못 잡아서 prod 승격이 롤백된 그 사고). PR base가 main일 때만 도는 이
+  # 프리플라이트가 "이 PR이 머지되면 main이 실제로 갖게 될 파일셋"으로 fresh-DB upgrade heads
+  # 를 실증한다 — develop→main 승격 PR은 그 시점에 이미 main-후보 파일셋으로 체크아웃되므로
+  # (선별 제외가 그 PR 자체의 diff), PR HEAD 그대로 체크아웃하면 된다.
+  main-alembic-preflight:
+    name: Main Alembic preflight (fresh DB, main file set)
+    if: github.base_ref == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: sprintable
+          POSTGRES_PASSWORD: sprintable
+          POSTGRES_DB: sprintable_main_preflight
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      ALEMBIC_DATABASE_URL: postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_main_preflight
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: 'latest'
+
+      # ee_pricing(0146/0147)이 main 승격分에 섞여 들어왔다면 여기서 즉시 실패 — main은
+      # 항상 단일 core head(0148 직계)여야 한다.
+      - name: Assert main migration file set (no ee_pricing, core 0148 present)
+        working-directory: backend
+        run: |
+          set -e
+          test -f alembic/versions/0148_org_subscriptions_org_id_unique.py
+          if [ -f alembic/versions/0146_pricing_versions.py ] || [ -f alembic/versions/0147_pricing_versions_live_seed.py ]; then
+            echo "FAIL: ee_pricing migration(s) present in a main-bound file set"; exit 1
+          fi
+          echo "OK: main file set has 0148(core), no ee_pricing"
+
+      - name: Build revision graph (single head expected)
+        working-directory: backend
+        run: |
+          set -e
+          heads=$(uv run alembic heads 2>/dev/null | grep -oE '^[0-9a-z_]+')
+          n=$(echo "$heads" | grep -c .)
+          echo "heads=$heads (count=$n)"
+          test "$n" = "1"  # main never carries the ee_pricing branch — exactly one head
+
+      - name: Fresh-DB upgrade heads (main file set)
+        working-directory: backend
+        run: uv run alembic upgrade heads
 
   backend-test:
     name: Backend pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ Workflow templates let contributors add new multi-step automation patterns witho
 3. Use `step_1`, `step_2`, ... as `role_ref` placeholders — they are resolved at apply time.
 4. Set `is_system: false` for community templates (users can delete them).
 5. Write a pytest test in `backend/tests/test_e2e_workflow_template.py` asserting the correct rule count after `apply_template`.
-6. Run `alembic upgrade head` locally and verify `GET /api/v2/workflow-templates` returns your new template.
+6. Run `alembic upgrade heads` locally and verify `GET /api/v2/workflow-templates` returns your new template.
 
 ### Template schema quick reference
 

--- a/backend/alembic/versions/0146_pricing_versions.py
+++ b/backend/alembic/versions/0146_pricing_versions.py
@@ -33,8 +33,17 @@ from sqlalchemy.dialects import postgresql
 
 revision = "0146"
 down_revision = "0145"
-branch_labels = None
-depends_on = None
+# story bda4beac: 0146/0147(pricing_versions 신설+시드)은 ee 전용 — main엔 이 두 파일
+# 자체가 없다(develop만 존재). 원래 0146→0147→0148→0149 리니어 체인이었으나 0148
+# (org_subscriptions.org_id UNIQUE 제약, core 버그 fix)이 사고로 146/147과 함께 순차적
+# 위치 때문에 main promotion에서 같이 빠졌었다(#bda4beac 발견 — 0148은 baseline core
+# 테이블 대상이라 pricing과 무관, main도 동일 model unique=True 선언 보유 확인).
+# 근본수정: 0148을 core 체인(0145 직계)으로 독립시키고, ee_pricing은 별도 head로 분리
+# (develop/ee 환경은 상시 dual-head — core head(0155+) + ee_pricing head(0147)).
+# depends_on="0148": 이 마이그도 org_subscriptions를 건드리므로(pricing_version_id 컬럼
+# 추가) core의 UNIQUE 제약 fix가 먼저 적용된 뒤 실행되도록 순서만 명시(브랜치 병합 아님).
+branch_labels = ("ee_pricing",)
+depends_on = "0148"
 
 
 def upgrade() -> None:

--- a/backend/alembic/versions/0148_org_subscriptions_org_id_unique.py
+++ b/backend/alembic/versions/0148_org_subscriptions_org_id_unique.py
@@ -17,8 +17,17 @@ from __future__ import annotations
 from alembic import op
 
 revision = "0148"
-down_revision = "0147"
-branch_labels = None
+# story bda4beac: 원래 down_revision="0147"(pricing 시드) — 0148은 pricing과 무관한
+# core 버그 fix(org_subscriptions는 baseline 테이블·같은 model unique=True 선언이 main에도
+# 있음)인데 0146/0147(진짜 ee 전용) 사이에 순차 배치된 탓에 main promotion 시 함께
+# 누락(#bda4beac 발견 — main엔 0146/0147 파일 자체가 없어 down_revision="0147" 참조가
+# KeyError로 그래프 구성 자체를 실패시켜 prod 승격이 막혔다). 0145(공통 core 조상) 직계로
+# 재부모해 main 단독으로도 승격 가능하게 근본수정 — main 체인은 이제 0145→0148→0149→...
+# 로 pricing 파일 존재 여부와 완전 무관해진다. develop/ee 환경은 이 재부모로 dual-head가
+# 된다(core head 0155+ · ee_pricing head 0147) — `alembic upgrade heads`(복수형)로 전환
+# 필요, 콜사이트는 ci.yml/migrate.sh/test_migrate_env.py 등에서 함께 갱신.
+down_revision = "0145"
+branch_labels = ("core",)
 depends_on = None
 
 

--- a/backend/bootstrap.py
+++ b/backend/bootstrap.py
@@ -1,18 +1,23 @@
-"""DB bootstrap entrypoint: always `alembic upgrade head`.
+"""DB bootstrap entrypoint: always `alembic upgrade heads`.
 
 On an EMPTY database, alembic/env.py provisions from the squashed baseline snapshot (dev's
 0096 end-state schema + global system seed) and stamps revision 0096. On an existing database
-it runs the normal incremental chain (a no-op for a DB already at head). There is no longer a
+it runs the normal incremental chain (a no-op for a DB already at heads). There is no longer a
 create_all shortcut — it built from the drifted models and produced a schema that diverged from
 the migrated one (the prod onboarding 500). See alembic/baseline/ and alembic/env.py.
+
+story bda4beac: ee_pricing(0146/0147) branched off the core chain (0145->0148->0149+) as its
+own head, so a checkout that has those files (local dev, EE builds) is dual-head. `heads`
+(plural) is safe for both that case and a single-head checkout (main/prod, which never has
+0146/0147 at all).
 """
 import subprocess
 import sys
 
 
 def main() -> None:
-    print("[bootstrap] Running alembic upgrade head")
-    subprocess.run(["alembic", "upgrade", "head"], check=True)
+    print("[bootstrap] Running alembic upgrade heads")
+    subprocess.run(["alembic", "upgrade", "heads"], check=True)
 
 
 if __name__ == "__main__":

--- a/backend/scripts/RUNBOOK_prod_db_split.md
+++ b/backend/scripts/RUNBOOK_prod_db_split.md
@@ -43,7 +43,7 @@ diff <(gcloud secrets versions access latest --secret=DATABASE_URL_DEV) \
 bash backend/scripts/provision_migrate_job.sh prod
 gcloud run jobs execute sprintable-migrate-prod --region=asia-northeast3 --project=sprintable-494803 --wait
 ```
-> `migrate.sh` 는 `alembic upgrade head` 만 실행 — seed 없음.
+> `migrate.sh` 는 `alembic upgrade heads`(story bda4beac 이후 복수형) 만 실행 — seed 없음.
 > 선생님 fresh-signup이 org를 새로 생성하므로 seed 데이터 불필요.
 
 ### 5. prod 백엔드 배포 (디디, GO 후)

--- a/backend/scripts/migrate.sh
+++ b/backend/scripts/migrate.sh
@@ -10,6 +10,9 @@ if [ -z "${ALEMBIC_DATABASE_URL:-}" ]; then
   exit 1
 fi
 
+# story bda4beac: pricing(ee) 마이그(0146/0147)가 core 체인(0145→0148→0149+)과 분기된
+# 별도 head라 이미지에 그 파일이 없는 환경(main/prod)에선 head가 1개, 있는 환경(develop/ee
+# 빌드)에선 2개다 — `heads`(복수)는 두 경우 모두 안전(단일-head 환경에서도 그대로 동작).
 cd /app
-echo "Running: alembic upgrade head"
-exec alembic upgrade head
+echo "Running: alembic upgrade heads"
+exec alembic upgrade heads

--- a/backend/scripts/provision_cloud_sql.sh
+++ b/backend/scripts/provision_cloud_sql.sh
@@ -143,8 +143,8 @@ print_proxy_instructions() {
 3. FastAPI .env 설정:
    DATABASE_URL=postgresql+asyncpg://sprintable:PASSWORD@127.0.0.1:5433/sprintable
 
-4. Alembic 마이그레이션 적용:
-   alembic upgrade head
+4. Alembic 마이그레이션 적용(story bda4beac 이후 복수형 — ee_pricing 별도 head 분기):
+   alembic upgrade heads
 
 5. 연결 검증:
    curl http://localhost:8000/api/v2/health

--- a/backend/scripts/provision_migrate_job.sh
+++ b/backend/scripts/provision_migrate_job.sh
@@ -5,7 +5,8 @@
 # 이 스크립트는 dev/prod 양쪽 마이그 잡을 동일 패턴으로 재현 가능하게 생성/갱신한다.
 #
 # 잡 구성 (라이브 sprintable-migrate-dev 미러):
-#   - command         : /app/scripts/migrate.sh  (alembic upgrade head)
+#   - command         : /app/scripts/migrate.sh  (alembic upgrade heads — story bda4beac,
+#                        ee_pricing 별도 head 분기 후 복수형으로 전환)
 #   - ALEMBIC_DATABASE_URL : 시크릿 ALEMBIC_DATABASE_URL_<ENV> (Private-IP psycopg2)
 #   - cloudsql-instances   : env별 인스턴스 (prod→sprintable-prod, dev→sprintable-dev)
 #   - network/vpc-egress   : default / private-ranges-only

--- a/backend/tests/test_migrate_env.py
+++ b/backend/tests/test_migrate_env.py
@@ -88,4 +88,6 @@ def test_migrate_sh_exists_and_has_alembic_check():
     assert "ALEMBIC_DATABASE_URL" in content
     assert "exit 1" in content
     assert "cd /app" in content
-    assert "alembic upgrade head" in content
+    # story bda4beac: ee_pricing(0146/0147)이 core 체인과 분기된 별도 head라 `heads`(복수)로
+    # 전환 — dual-head(develop/ee)·single-head(main) 양쪽에서 안전.
+    assert "alembic upgrade heads" in content

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,9 @@ services:
       # NOTE: a fresh OSS DB now provisions via the squashed baseline migration (revision 0096),
       # which builds the exact, view-aware schema + global system seed. We deliberately do NOT set
       # SPRINTABLE_OSS_FRESH_INSTALL anymore — the create_all shortcut builds from the (drifted)
-      # models and would miss the team_members VIEW etc. `bootstrap.py` → `alembic upgrade head`
-      # runs the baseline. The flag remains an explicit opt-in escape hatch only.
+      # models and would miss the team_members VIEW etc. `bootstrap.py` → `alembic upgrade heads`
+      # (story bda4beac: plural — ee_pricing branched as a separate head) runs the baseline.
+      # The flag remains an explicit opt-in escape hatch only.
       # Agent chat file uploads (POST /api/v2/channel/upload)
       CHANNEL_FILES_DIR: /app/data/channel_files
     volumes:

--- a/docs/workflow-templates.md
+++ b/docs/workflow-templates.md
@@ -140,7 +140,7 @@ Set `is_system = false` so users can delete it.
 Add a new entry to `SEED_TEMPLATES` in `backend/alembic/versions/0016_add_workflow_templates.py` and run:
 
 ```bash
-cd backend && alembic upgrade head
+cd backend && alembic upgrade heads
 ```
 
 ### Template Schema Reference


### PR DESCRIPTION
## Summary

Prepared promotion PR for story `bda4beac`'s prod-migration-chain blocker. This is a merge commit (not a squash), created by explicitly resolving the `develop`→`main` merge conflicts that a plain merge attempt would hit.

**Policy (PO-confirmed, Option B)**: `0146`/`0147` (`pricing_versions` table + live seed) stay excluded from `main` — genuinely EE/billing-only, and `docs/oss-saas-split.md` already categorizes billing DB migrations as SaaS-only (this isn't a new policy call, just confirming existing documented intent). `0148` (`org_subscriptions.org_id` UNIQUE constraint) IS promoted — it's core (baseline table, `main`'s own `app/models/org_subscription.py` already declares `org_id unique=True`), and its absence represents an active, unfixed prod billing bug (`ON CONFLICT` upsert 500ing on checkout).

**Why this needed manual conflict resolution, not a clean merge**: merge-base `af4a2572` has all three files (`0146`/`0147`/`0148`). `main` deleted all three; `develop` left `0147` untouched (clean delete) but modified `0146`/`0148` via PR #1884's reparenting (`91f7c0bf`) — a genuine modify/delete conflict on those two, not non-deterministic `git merge-tree` behavior as first suspected. Full reconstruction in the story thread if useful for future reference.

**Resolution**: kept `0146_pricing_versions.py` deleted. Restored `0148_org_subscriptions_org_id_unique.py` from develop's #1884-reparented version (`down_revision="0145"`, `branch_labels=("core",)`) — main's chain is now `0145→0148→0149→...→0155`, structurally independent of pricing.

This decision is now recorded directly in `main`'s history via this merge commit, so the next `develop`→`main` promotion won't rediscover the same ambiguity.

## Test plan (already run locally before this commit)
- [x] `alembic heads`: single head (`0155`) confirmed
- [x] Fresh-DB `alembic upgrade heads`: applies `0145→0148→0149→...→0155` cleanly
- [x] `uq_org_subscriptions_org_id` UNIQUE constraint confirmed created (fixes the live billing bug)
- [x] `tests/test_migrate_env.py`: 6/6 passing
- [ ] `main-alembic-preflight` CI job (from PR #1884, already on this tree) — should pass automatically on this PR since `github.base_ref == 'main'`
- [ ] Per PO: **admin-merge required** (promotion decisions are PO's lane) after CI green — this is prepared for that review, not for auto-merge
- [ ] Real dev/EE DB `alembic stamp heads` — separate, coordinated with PO/infra per the procedure already shared in the story thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)