### PR TITLE
feat(mcp): chat attachments — send_chat_message inline base64 upload (E-MCP-OPT S2, bbfd24ba)

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -1,8 +1,11 @@
 """E-EVENTBUS P7-A S37: conversations 테이블 + Chat API."""
 from __future__ import annotations
 
+import base64
+import binascii
 import json
 import logging
+import re
 import uuid
 from collections import defaultdict
 from datetime import datetime, timezone
@@ -26,7 +29,7 @@ from app.routers.events import _push_to_agent, publish_event
 from app.schemas.attachment import validate_attachment_url
 from app.services import chat_presence
 from app.services.agent_runtime import supports_deterministic_command
-from app.services.asset_registry import sync_attachment_assets
+from app.services.asset_registry import DEFAULT_CONTAINER, sync_attachment_assets
 from app.services.command_classifier import classify_command
 from app.services.event_seq import assign_recipient_seq
 from app.services.member_resolver import (
@@ -36,6 +39,7 @@ from app.services.member_resolver import (
     resolve_member,
     resolve_member_identity,
 )
+from app.services.storage import get_storage_provider
 
 logger = logging.getLogger(__name__)
 
@@ -582,6 +586,13 @@ class ConversationResponse(BaseModel):
 _MAX_ATTACHMENTS = 10
 _MAX_ATTACHMENT_SIZE = 100 * 1024 * 1024  # 100MB (메타 sanity 상한)
 
+# E-MCP-OPT S2(bbfd24ba): MCP(비-브라우저) 클라이언트용 JSON/base64 업로드 — 스샷/작은 문서가
+# 실사용(대용량 아님). FE-proxy 100MB 캡과 별개로 더 작게(Cloud Run HTTP/1 32MiB 요청 캡 대비
+# 여유 마진). sprintable_mcp 의 동일 상수(tools/chat.py `_MCP_MAX_ATTACHMENT_BYTES`)와 정합.
+_MAX_JSON_ATTACHMENT_UPLOAD_SIZE = 2 * 1024 * 1024  # 2MiB decoded
+_MAX_ATTACHMENT_NAME_LEN = 255
+_SAFE_ATTACHMENT_NAME_RE = re.compile(r"[^\w.\-]+")
+
 
 class MessageAttachment(BaseModel):
     url: str           # FE-proxy 업로드 객체 url(https GCS 또는 canonical bare path·provider 추상)
@@ -627,6 +638,29 @@ class SendMessageRequest(BaseModel):
     def _limit_attachments(cls, v: list[MessageAttachment]) -> list[MessageAttachment]:
         if len(v) > _MAX_ATTACHMENTS:
             raise ValueError(f"too many attachments (max {_MAX_ATTACHMENTS})")
+        return v
+
+
+class UploadConversationAttachmentRequest(BaseModel):
+    """E-MCP-OPT S2: MCP(비-브라우저)용 JSON/base64 첨부 업로드 요청."""
+
+    content_base64: str
+    name: str
+    content_type: str
+
+    @field_validator("content_base64", "name", "content_type")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("must not be empty")
+        return v
+
+    @field_validator("content_type")
+    @classmethod
+    def _content_type_sane(cls, v: str) -> str:
+        if len(v) > _MAX_ATTACHMENT_NAME_LEN or any(ord(ch) < 32 for ch in v):
+            raise ValueError("invalid content_type")
         return v
 
 
@@ -1445,6 +1479,83 @@ async def send_message(
     if command_hints:
         response["command_gate"] = {"blocked": command_hints}
     return response
+
+
+def _safe_attachment_filename(name: str) -> str:
+    safe = _SAFE_ATTACHMENT_NAME_RE.sub("_", name.strip())[-128:]
+    return safe or "file"
+
+
+@router.post(
+    "/{conversation_id}/attachments",
+    status_code=201,
+    response_model=MessageAttachment,
+    response_model_exclude_none=True,
+)
+async def upload_conversation_attachment(
+    conversation_id: uuid.UUID,
+    body: UploadConversationAttachmentRequest,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> MessageAttachment:
+    """E-MCP-OPT S2(bbfd24ba): 비-브라우저 클라이언트(MCP)용 JSON/base64 첨부 업로드.
+
+    인가는 `send_message`의 실제 발신 요건과 **동일**(참가자 필수) — 읽기 전용 엔드포인트의
+    admin-agent-only-conversation 우회는 여기 적용하지 않는다: 그 우회는 GET(list/get_conversation)
+    전용이고, 업로드는 결국 이 conversation 에 메시지를 보내는 것과 같은 쓰기 동작이라
+    `send_message`(에이전트 sender 는 참가자 아니면 무조건 403·우회/auto-join 없음)와 정합해야
+    한다 — 그렇지 않으면 비참가자 admin 에이전트가 업로드는 성공하고 뒤이은 send_chat_message 는
+    403 나는 모순이 생긴다.
+    """
+    conv = (await db.execute(
+        select(Conversation).where(Conversation.id == conversation_id, Conversation.org_id == org_id)
+    )).scalar_one_or_none()
+    if conv is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    sender = await _resolve_member(auth, org_id, db, project_id=conv.project_id)
+    participant = (await db.execute(
+        select(ConversationParticipant.id).where(
+            ConversationParticipant.conversation_id == conversation_id,
+            ConversationParticipant.member_id == sender.id,
+        )
+    )).scalar_one_or_none()
+    if participant is None:
+        raise HTTPException(status_code=403, detail="Not a participant")
+
+    try:
+        data = base64.b64decode(body.content_base64, validate=True)
+    except (binascii.Error, ValueError):
+        raise HTTPException(status_code=400, detail="content_base64 must be valid base64")
+    if not data:
+        raise HTTPException(status_code=400, detail="attachment must not be empty")
+    if len(data) > _MAX_JSON_ATTACHMENT_UPLOAD_SIZE:
+        raise HTTPException(
+            status_code=413,
+            detail=f"attachment too large (max {_MAX_JSON_ATTACHMENT_UPLOAD_SIZE} bytes)",
+        )
+
+    safe_name = _safe_attachment_filename(body.name)
+    # S7 namespace — FE 업로드 라우트(apps/web .../conversations/[id]/attachments/route.ts)와
+    # 정확히 동일한 shape(org/<org>/project/<project>/chat/<conv>/<file>). path_in_source_scope/
+    # sync_attachment_assets 가 기대하는 스코프와 일치해야 IDOR 가드·read-authorize 가 통과한다.
+    object_path = (
+        f"org/{org_id}/project/{conv.project_id}/chat/{conversation_id}/{uuid.uuid4()}-{safe_name}"
+    )
+
+    uploaded = await get_storage_provider().put_object(
+        DEFAULT_CONTAINER, object_path, data, content_type=body.content_type,
+    )
+    if not uploaded:
+        raise HTTPException(status_code=502, detail="upload failed")
+
+    return MessageAttachment(
+        url=object_path,
+        name=body.name,
+        content_type=body.content_type,
+        size=len(data),
+    )
 
 
 @router.patch("/{conversation_id}/status", status_code=200)

--- a/backend/sprintable_mcp/tools/chat.py
+++ b/backend/sprintable_mcp/tools/chat.py
@@ -1,11 +1,24 @@
 """채팅 MCP 도구 (3개)."""
 from __future__ import annotations
 
+import base64
+import binascii
+import logging
+
 from mcp.types import TextContent
 
 from ..api_client import client
 from ..response import err, ok
 from ..schemas import SprintableInput
+
+logger = logging.getLogger(__name__)
+
+# E-MCP-OPT S2(bbfd24ba): inline base64 첨부 — client-side fail-fast 가드(백엔드
+# `_MAX_JSON_ATTACHMENT_UPLOAD_SIZE`와 정합·MCP 페이로드 낭비 전 조기 거부).
+_MAX_ATTACHMENTS = 5
+_MAX_ATTACHMENT_BYTES = 2 * 1024 * 1024  # 2MiB decoded/file
+_MAX_TOTAL_ATTACHMENT_BYTES = 6 * 1024 * 1024  # 2MiB decoded/total
+_MAX_ATTACHMENT_BASE64_CHARS = ((_MAX_ATTACHMENT_BYTES + 2) // 3) * 4
 
 
 class SendChatInput(SprintableInput):
@@ -15,6 +28,8 @@ class SendChatInput(SprintableInput):
     message_type: str | None = None
     review_type: str | None = None
     metadata: dict | None = None
+    # [{content_base64, name, content_type}, ...] — 스샷/작은 문서(최대 5개·파일당 2MiB·총 6MiB).
+    attachments: list[dict] | None = None
 
 
 class CreateConversationInput(SprintableInput):
@@ -26,6 +41,62 @@ class ListChatMessagesInput(SprintableInput):
     thread_id: str
     limit: int | None = None
     before: str | None = None
+
+
+def _validate_attachment(att: dict, index: int) -> tuple[dict, int]:
+    if not isinstance(att, dict):
+        raise ValueError(f"attachments[{index}] must be an object")
+    name = str(att.get("name") or "").strip()
+    content_type = str(att.get("content_type") or "").strip()
+    content_base64 = str(att.get("content_base64") or "").strip()
+    if not name:
+        raise ValueError(f"attachments[{index}].name is required")
+    if not content_type:
+        raise ValueError(f"attachments[{index}].content_type is required")
+    if not content_base64:
+        raise ValueError(f"attachments[{index}].content_base64 is required")
+    if len(content_base64) > _MAX_ATTACHMENT_BASE64_CHARS:
+        raise ValueError(
+            f"attachments[{index}] too large (max {_MAX_ATTACHMENT_BYTES} decoded bytes)"
+        )
+    try:
+        decoded = base64.b64decode(content_base64, validate=True)
+    except (binascii.Error, ValueError):
+        raise ValueError(f"attachments[{index}].content_base64 must be valid base64")
+    if not decoded:
+        raise ValueError(f"attachments[{index}] must not be empty")
+    if len(decoded) > _MAX_ATTACHMENT_BYTES:
+        raise ValueError(
+            f"attachments[{index}] too large (max {_MAX_ATTACHMENT_BYTES} decoded bytes)"
+        )
+    return {"content_base64": content_base64, "name": name, "content_type": content_type}, len(decoded)
+
+
+async def _upload_attachments(thread_id: str, attachments: list[dict] | None) -> list[dict]:
+    """각 첨부를 신규 업로드 엔드포인트에 순차 업로드해 MessageAttachment 메타 리스트로 변환.
+
+    개수/사이즈 가드는 **전부 먼저 검증**(네트워크 호출 0)한 다음에야 업로드를 시작한다 — 순차
+    검증+업로드를 인터리빙하면 총량 초과가 마지막 파일에서만 드러날 때 앞선 파일들이 이미 실제
+    업로드돼 orphan blob 이 되고서야 실패하는 낭비/누출이 생긴다.
+    """
+    if not attachments:
+        return []
+    if len(attachments) > _MAX_ATTACHMENTS:
+        raise ValueError(f"too many attachments (max {_MAX_ATTACHMENTS})")
+
+    validated: list[tuple[dict, int]] = [_validate_attachment(att, i) for i, att in enumerate(attachments)]
+    total_size = sum(size for _payload, size in validated)
+    if total_size > _MAX_TOTAL_ATTACHMENT_BYTES:
+        raise ValueError(
+            f"attachments total too large (max {_MAX_TOTAL_ATTACHMENT_BYTES} decoded bytes)"
+        )
+
+    uploaded: list[dict] = []
+    for payload, _size in validated:
+        uploaded.append(
+            await client.post(f"/api/v2/conversations/{thread_id}/attachments", json=payload)
+        )
+    return uploaded
 
 
 async def send_chat_message(args: SendChatInput) -> list[TextContent]:
@@ -42,9 +113,23 @@ async def send_chat_message(args: SendChatInput) -> list[TextContent]:
         meta["review_type"] = args.review_type
     if meta:
         payload["metadata"] = meta
+    uploaded_urls: list[str] = []
     try:
+        attachments = await _upload_attachments(args.thread_id, args.attachments)
+        uploaded_urls = [a["url"] for a in attachments if isinstance(a, dict) and a.get("url")]
+        if attachments:
+            payload["attachments"] = attachments
         return ok(await client.post(f"/api/v2/conversations/{args.thread_id}/messages", json=payload))
     except Exception as exc:
+        if uploaded_urls:
+            # 업로드는 성공했으나 메시지 생성이 실패한 경우 — asset registry 는 SAVE-time(메시지
+            # 저장 트랜잭션)에만 동기화되므로 이 객체들은 미등록 orphan blob 으로 남는다(무해·
+            # data-loss 아님). 운영 가시성을 위해 로그만 남김(best-effort cleanup 대상 아님 —
+            # storage 자체 GC/grace cron 이 있다면 그쪽이 담당).
+            logger.warning(
+                "send_chat_message: message create failed after %d attachment upload(s) — "
+                "orphaned object(s): %s", len(uploaded_urls), uploaded_urls,
+            )
         return err(str(exc))
 
 

--- a/backend/tests/test_e_mcp_opt_s2_chat_attachment_tool.py
+++ b/backend/tests/test_e_mcp_opt_s2_chat_attachment_tool.py
@@ -1,0 +1,173 @@
+"""E-MCP-OPT S2 (bbfd24ba): `sprintable_send_chat_message` inline base64 첨부 — MCP 쪽 검증.
+
+client-side fail-fast 가드(개수/사이즈/base64) + 업로드→메시지 체이닝 + 회귀(첨부 없으면
+기존 payload 그대로) + 부분실패(업로드 성공·메시지 실패) 시 orphan 로그.
+"""
+from __future__ import annotations
+
+import base64
+import logging
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from sprintable_mcp.tools import chat as chat_mod
+from sprintable_mcp.tools.chat import SendChatInput, _upload_attachments, _validate_attachment, send_chat_message
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _b64(n: int) -> str:
+    return base64.b64encode(b"x" * n).decode()
+
+
+# ── _validate_attachment ──────────────────────────────────────────────────────
+def test_validate_attachment_accepts_valid():
+    payload, size = _validate_attachment(
+        {"content_base64": _b64(10), "name": "a.png", "content_type": "image/png"}, 0
+    )
+    assert size == 10
+    assert payload == {"content_base64": _b64(10), "name": "a.png", "content_type": "image/png"}
+
+
+def test_validate_attachment_missing_fields_raise():
+    with pytest.raises(ValueError, match="name is required"):
+        _validate_attachment({"content_base64": _b64(1), "content_type": "text/plain"}, 0)
+    with pytest.raises(ValueError, match="content_type is required"):
+        _validate_attachment({"content_base64": _b64(1), "name": "a"}, 0)
+    with pytest.raises(ValueError, match="content_base64 is required"):
+        _validate_attachment({"name": "a", "content_type": "text/plain"}, 0)
+
+
+def test_validate_attachment_invalid_base64_raises():
+    with pytest.raises(ValueError, match="must be valid base64"):
+        _validate_attachment({"content_base64": "not-base64!!!", "name": "a", "content_type": "t"}, 0)
+
+
+def test_validate_attachment_empty_content_base64_raises():
+    with pytest.raises(ValueError, match="content_base64 is required"):
+        _validate_attachment({"content_base64": "", "name": "a", "content_type": "t"}, 0)
+
+
+def test_validate_attachment_oversized_rejected_before_full_decode():
+    too_big = _b64(chat_mod._MAX_ATTACHMENT_BYTES + 1)
+    with pytest.raises(ValueError, match="too large"):
+        _validate_attachment({"content_base64": too_big, "name": "a", "content_type": "t"}, 0)
+
+
+# ── _upload_attachments ───────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_upload_attachments_empty_returns_empty():
+    assert await _upload_attachments("conv-1", None) == []
+    assert await _upload_attachments("conv-1", []) == []
+
+
+@pytest.mark.anyio
+async def test_upload_attachments_too_many_rejected():
+    atts = [{"content_base64": _b64(1), "name": f"{i}", "content_type": "t"} for i in range(chat_mod._MAX_ATTACHMENTS + 1)]
+    with pytest.raises(ValueError, match="too many attachments"):
+        await _upload_attachments("conv-1", atts)
+
+
+@pytest.mark.anyio
+async def test_upload_attachments_total_size_exceeded_rejected_before_any_network_call():
+    """총량 초과는 업로드 시작 前 전부 검증되어 걸러진다 — client.post 가 단 한 번도 안 불림
+    (마지막 파일에서만 드러나는 초과였다면 앞선 파일들이 실제 업로드→orphan 되는 낭비 없음)."""
+    per_file = chat_mod._MAX_ATTACHMENT_BYTES
+    atts = [{"content_base64": _b64(per_file), "name": f"{i}", "content_type": "t"} for i in range(4)]
+    assert len(atts) <= chat_mod._MAX_ATTACHMENTS
+    assert per_file * 4 > chat_mod._MAX_TOTAL_ATTACHMENT_BYTES
+    with patch.object(chat_mod.client, "post", new=AsyncMock()) as m:
+        with pytest.raises(ValueError, match="total too large"):
+            await _upload_attachments("conv-1", atts)
+        m.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_upload_attachments_calls_endpoint_per_file():
+    atts = [{"content_base64": _b64(5), "name": "a.png", "content_type": "image/png"}]
+    fake_result = {"url": "org/o/project/p/chat/c/x-a.png", "name": "a.png", "content_type": "image/png", "size": 5}
+    with patch.object(chat_mod.client, "post", new=AsyncMock(return_value=fake_result)) as m:
+        result = await _upload_attachments("conv-1", atts)
+        assert result == [fake_result]
+        m.assert_awaited_once_with(
+            "/api/v2/conversations/conv-1/attachments",
+            json={"content_base64": _b64(5), "name": "a.png", "content_type": "image/png"},
+        )
+
+
+# ── send_chat_message 회귀 + 체이닝 ────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_send_chat_message_no_attachments_unchanged_payload():
+    """첨부 없으면 기존 동작 그대로(회귀 0) — payload 에 attachments 키 자체가 없음."""
+    args = SendChatInput(thread_id="conv-1", content="hi")
+    with patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m:
+        await send_chat_message(args)
+        _, kwargs = m.call_args
+        assert "attachments" not in kwargs["json"]
+
+
+@pytest.mark.anyio
+async def test_send_chat_message_uploads_then_sends_with_attachments():
+    args = SendChatInput(
+        thread_id="conv-1", content="screenshot",
+        attachments=[{"content_base64": _b64(4), "name": "s.png", "content_type": "image/png"}],
+    )
+    upload_result = {"url": "org/o/project/p/chat/conv-1/x-s.png", "name": "s.png", "content_type": "image/png", "size": 4}
+    calls: list[tuple] = []
+
+    async def _fake_post(path, json=None):
+        calls.append((path, json))
+        if path.endswith("/attachments"):
+            return upload_result
+        return {"id": "m1"}
+
+    with patch.object(chat_mod.client, "post", new=AsyncMock(side_effect=_fake_post)):
+        result = await send_chat_message(args)
+        assert len(calls) == 2
+        assert calls[0][0] == "/api/v2/conversations/conv-1/attachments"
+        assert calls[1][0] == "/api/v2/conversations/conv-1/messages"
+        assert calls[1][1]["attachments"] == [upload_result]
+        assert "Error" not in result[0].text
+
+
+@pytest.mark.anyio
+async def test_send_chat_message_upload_failure_does_not_call_message_create():
+    args = SendChatInput(
+        thread_id="conv-1", content="x",
+        attachments=[{"content_base64": _b64(4), "name": "s.png", "content_type": "image/png"}],
+    )
+    calls: list[str] = []
+
+    async def _fake_post(path, json=None):
+        calls.append(path)
+        raise RuntimeError("upload 403")
+
+    with patch.object(chat_mod.client, "post", new=AsyncMock(side_effect=_fake_post)):
+        result = await send_chat_message(args)
+        assert calls == ["/api/v2/conversations/conv-1/attachments"]
+        assert result[0].text.startswith("Error")
+
+
+@pytest.mark.anyio
+async def test_send_chat_message_partial_failure_logs_orphan_warning(caplog):
+    """업로드 성공 後 메시지 생성 실패 — orphan blob 발생, 운영 가시성 위해 경고 로그."""
+    args = SendChatInput(
+        thread_id="conv-1", content="x",
+        attachments=[{"content_base64": _b64(4), "name": "s.png", "content_type": "image/png"}],
+    )
+    upload_result = {"url": "org/o/project/p/chat/conv-1/x-s.png", "name": "s.png", "content_type": "image/png", "size": 4}
+
+    async def _fake_post(path, json=None):
+        if path.endswith("/attachments"):
+            return upload_result
+        raise RuntimeError("message create failed")
+
+    with caplog.at_level(logging.WARNING, logger=chat_mod.logger.name):
+        with patch.object(chat_mod.client, "post", new=AsyncMock(side_effect=_fake_post)):
+            result = await send_chat_message(args)
+    assert result[0].text.startswith("Error")
+    assert any("orphaned" in r.message for r in caplog.records)

--- a/backend/tests/test_e_mcp_opt_s2_chat_attachment_upload_realdb.py
+++ b/backend/tests/test_e_mcp_opt_s2_chat_attachment_upload_realdb.py
@@ -1,0 +1,190 @@
+"""E-MCP-OPT S2 (bbfd24ba): 신규 `POST /{conversation_id}/attachments` 실 Postgres + 실 storage 검증.
+
+MCP(비-브라우저)가 chat 첨부를 올릴 수 있게 하는 새 엔드포인트. 인가는 `send_message`의 실제
+발신 요건과 동일해야 한다(참가자 필수·admin-agent-only-conversation 우회 없음 — 그 우회는
+GET(list/get_conversation) 전용). 이 테스트는 실 Postgres(seed) + 실 StorageProvider(local disk)로
+①참가자 업로드 성공+정확한 S7 path+실제 바이트 write ②비참가자 403 ③base64 오류 400 ④크기초과 413
+을 검증한다.
+"""
+from __future__ import annotations
+
+import base64
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("ab700000-0000-0000-0000-000000000001")
+PROJ = uuid.UUID("ab700000-0000-0000-0000-000000000002")
+CONV = uuid.UUID("ab700000-0000-0000-0000-000000000003")
+AGENT_IN = uuid.UUID("ab700000-0000-0000-0000-0000000000a1")   # conversation 참가자
+AGENT_OUT = uuid.UUID("ab700000-0000-0000-0000-0000000000a2")  # project grant는 있으나 비참가자
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth(member_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(member_id), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(ORG),
+    )
+
+
+async def _seed(s) -> None:
+    # team_members 는 뷰(members ⋈ project_access, 0110 3번째 agent-grant-only UNION 브랜치) —
+    # 직접 INSERT/DELETE 불가. members + project_access 만 심으면 뷰가 자동 파생.
+    for sql in [
+        f"DELETE FROM conversation_participants WHERE conversation_id='{CONV}'",
+        f"DELETE FROM conversation_messages WHERE conversation_id='{CONV}'",
+        f"DELETE FROM conversations WHERE id='{CONV}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','S2ATT','s2att-org','free')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ}','{ORG}','P','none')",
+        f"INSERT INTO members (id,org_id,type,name) VALUES ('{AGENT_IN}','{ORG}','agent','AgentIn')",
+        f"INSERT INTO members (id,org_id,type,name) VALUES ('{AGENT_OUT}','{ORG}','agent','AgentOut')",
+        f"INSERT INTO project_access (project_id,member_id,permission) VALUES "
+        f"('{PROJ}','{AGENT_IN}','granted')",
+        f"INSERT INTO project_access (project_id,member_id,permission) VALUES "
+        f"('{PROJ}','{AGENT_OUT}','granted')",
+        f"INSERT INTO conversations (id,org_id,project_id,type) VALUES ('{CONV}','{ORG}','{PROJ}','group')",
+        f"INSERT INTO conversation_participants (conversation_id,member_id) VALUES ('{CONV}','{AGENT_IN}')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+@pytest.mark.anyio
+async def test_participant_upload_writes_real_bytes_at_s7_path(monkeypatch, tmp_path):
+    """참가자 업로드 성공 — 정확한 S7 shape·실제 로컬 스토리지에 실 바이트 write 확인."""
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.conversations import UploadConversationAttachmentRequest, upload_conversation_attachment
+    from app.services.storage import get_storage_provider
+    from app.services.asset_registry import DEFAULT_CONTAINER
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            raw = b"\x89PNG\r\n\x1a\nfake-png-bytes"
+            body = UploadConversationAttachmentRequest(
+                content_base64=base64.b64encode(raw).decode(),
+                name="../../evil../screenshot.png",
+                content_type="image/png",
+            )
+            resp = await upload_conversation_attachment(
+                CONV, body, db=s, auth=_auth(AGENT_IN), org_id=ORG,
+            )
+            assert resp.size == len(raw)
+            assert resp.content_type == "image/png"
+            # S7 shape — FE 업로드 라우트와 정확히 동일: org/<org>/project/<project>/chat/<conv>/<file>
+            prefix = f"org/{ORG}/project/{PROJ}/chat/{CONV}/"
+            assert resp.url.startswith(prefix)
+            # traversal/부적절 문자 제거됨(파일명 안전화) — path 안에 ".." 세그먼트 없음.
+            assert ".." not in resp.url.split("/")
+
+            # 실제 바이트가 그 경로에 그대로 물리적으로 존재하는지 storage provider로 직접 재확인.
+            object_path = resp.url
+            downloaded = await get_storage_provider().download_object(DEFAULT_CONTAINER, object_path)
+            assert downloaded == raw
+    finally:
+        async with Session() as s:
+            await s.execute(text("DELETE FROM conversation_participants WHERE conversation_id=:c"), {"c": CONV})
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_non_participant_agent_rejected_403(monkeypatch, tmp_path):
+    """project access는 있으나 conversation 비참가자인 에이전트 — send_message와 동일하게 403.
+
+    admin-agent-only-conversation 우회는 여기 적용되지 않는다(그 우회는 GET 전용) — 비참가자는
+    project_access grant가 있어도 업로드 불가여야 send_chat_message의 최종 403과 정합된다.
+    """
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.conversations import UploadConversationAttachmentRequest, upload_conversation_attachment
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            body = UploadConversationAttachmentRequest(
+                content_base64=base64.b64encode(b"x").decode(), name="f.txt", content_type="text/plain",
+            )
+            with pytest.raises(HTTPException) as ei:
+                await upload_conversation_attachment(CONV, body, db=s, auth=_auth(AGENT_OUT), org_id=ORG)
+            assert ei.value.status_code == 403
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_invalid_base64_rejected_400(monkeypatch, tmp_path):
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.conversations import UploadConversationAttachmentRequest, upload_conversation_attachment
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            body = UploadConversationAttachmentRequest(
+                content_base64="not-valid-base64!!!", name="f.txt", content_type="text/plain",
+            )
+            with pytest.raises(HTTPException) as ei:
+                await upload_conversation_attachment(CONV, body, db=s, auth=_auth(AGENT_IN), org_id=ORG)
+            assert ei.value.status_code == 400
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_oversized_decoded_payload_rejected_413(monkeypatch, tmp_path):
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.conversations import (
+        UploadConversationAttachmentRequest,
+        _MAX_JSON_ATTACHMENT_UPLOAD_SIZE,
+        upload_conversation_attachment,
+    )
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            oversized = b"a" * (_MAX_JSON_ATTACHMENT_UPLOAD_SIZE + 1)
+            body = UploadConversationAttachmentRequest(
+                content_base64=base64.b64encode(oversized).decode(),
+                name="big.bin", content_type="application/octet-stream",
+            )
+            with pytest.raises(HTTPException) as ei:
+                await upload_conversation_attachment(CONV, body, db=s, auth=_auth(AGENT_IN), org_id=ORG)
+            assert ei.value.status_code == 413
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## Summary
- MCP agents couldn't attach files/images to chat messages. `send_chat_message`'s input had no attachments field, and the only existing upload path was 100% FE-direct-to-GCS (Next.js server route requiring a browser session cookie — unreachable by an agent's bearer API key).
- New endpoint `POST /api/v2/conversations/{conversation_id}/attachments` — JSON/base64 upload for non-browser clients. Writes via the existing (previously unwired) `StorageProvider.put_object()` into the exact same S7 object-path namespace the FE upload route already uses (`org/<org>/project/<project>/chat/<conversation>/<file>`) — confirmed byte-for-byte against `apps/web/.../conversations/[conversation_id]/attachments/route.ts`, so read-authorize + FE rendering need **zero changes**.
- Authorization mirrors `send_message`'s actual sender requirement exactly: participant required, **no** admin/agent-only-conversation bypass (that bypass is GET-only, used by `list_messages`/`get_conversation` — reusing it here would let an upload succeed into a conversation the same agent could never actually post a message to).
- `sprintable_mcp`'s `send_chat_message` gains an inline `attachments` param (`content_base64`/`name`/`content_type`, max 5 files / 2MiB each / 6MiB total decoded — comfortably under Cloud Run's documented 32MiB HTTP/1 request cap) — one agent-facing tool call chains upload-then-message-create internally. No new asset lifecycle: the existing save-time `sync_attachment_assets` registers the asset when the message is created, same as any FE-uploaded attachment.
- Partial failure (upload succeeds, message-create fails) logs the orphaned object URL for ops visibility — no data inconsistency since asset registration never ran for it.

## Design provenance
codex design (grounded in re-verified current code) → PO crux PASS, with one correction I made during implementation: the crux-approved design borrowed the *read*-endpoint's admin/agent-only-conversation bypass for authorization; I implemented the stricter `send_message`-equivalent (participant-only, no bypass) instead, since using the read-bypass would let uploads succeed where the actual message-post would still 403 — flagged to PO, who will see it in the diff.

## Test plan
- [x] Real Postgres + real local `StorageProvider` round-trip (fresh isolated throwaway PG, migrated to head): participant upload succeeds, writes real bytes at the exact S7 path, byte-identical round-trip via `download_object()`; non-participant agent (has project access, not a conversation participant) → 403; invalid base64 → 400; oversized decoded payload → 413.
- [x] Negative-tested the 403 guard: temporarily disabled the participant check, confirmed the 403 test genuinely fails, restored.
- [x] MCP-side unit tests: `_validate_attachment` (valid/missing fields/invalid base64/oversized), `_upload_attachments` (empty/too-many/total-size-exceeded/per-file endpoint calls), `send_chat_message` (no-attachments regression unchanged, upload-then-send chaining, upload failure short-circuits before message-create, partial-failure orphan logging).
- [x] Caught and fixed a real bug while writing tests: the total-size guard originally ran *after* each upload instead of validating all attachments upfront — fixed so size/count limits are fully checked before any network call (no wasted uploads/orphans on a late-attachment total-size violation).
- [x] Full backend suite: 2932 passed, 0 regressions (same 6 pre-existing unrelated failures as the prior PR: live-E2E hardcoded tool-count drift + local `.mcp.json` environment-config drift, both confirmed unrelated via revert-and-rerun).

🤖 Generated with [Claude Code](https://claude.com/claude-code)