### PR TITLE
feat(agents): hosted MCP transport connect-step contract (E-MCP-OPT S3)

### DIFF
--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -22,7 +22,10 @@ from app.schemas.team_member import OrgAgentCreate, TeamMemberResponse
 from app.services.agent_onboarding_config import (
     DEFAULT_RUNTIME,
     SUPPORTED_RUNTIMES,
+    SUPPORTED_TRANSPORTS,
     build_agent_mcp_config,
+    build_agent_mcp_config_bundle,
+    default_transport_for_edition,
 )
 from app.services.agent_verify import get_verification_state, start_verification
 from app.services.onboarding_funnel import emit_onboarding_event, safe_key_prefix
@@ -118,8 +121,11 @@ async def create_org_agent(
     effective_port = member.fakechat_port or int(os.environ.get("FAKECHAT_PORT", _FAKECHAT_BASE_PORT))
     response["fakechat_port"] = effective_port
     response["api_key_created"] = bool(api_key_plaintext)
-    # OB-1 AC2: 단일 SSOT generator 소비(stdio 아티팩트). 로컬 _build_mcp_config 제거.
-    response["mcp_config"] = build_agent_mcp_config(api_key_plaintext=api_key_plaintext)
+    # E-MCP-OPT S3: 단일 SSOT generator 소비 — edition 기본 + 두 transport 변형 동봉(FE round-trip 0).
+    config_bundle = build_agent_mcp_config_bundle(api_key_plaintext=api_key_plaintext)
+    response["mcp_config"] = config_bundle["mcp_config"]
+    response["default_transport"] = config_bundle["default_transport"]
+    response["mcp_config_alternatives"] = config_bundle["mcp_config_alternatives"]
     if api_key_plaintext:
         response["api_key"] = api_key_plaintext
 
@@ -127,7 +133,8 @@ async def create_org_agent(
     await emit_onboarding_event(
         session, "agent_created", agent_id=member.id, org_id=org_id,
         project_id=(project_ids[0] if project_ids else None),
-        runtime="claude-code", transport="stdio", key_prefix=safe_key_prefix(api_key_plaintext),
+        runtime="claude-code", transport=config_bundle["default_transport"],
+        key_prefix=safe_key_prefix(api_key_plaintext),
     )
     await session.commit()
     return response
@@ -137,6 +144,7 @@ async def create_org_agent(
 async def get_agent_connection_artifact(
     agent_id: uuid.UUID,
     runtime: str = DEFAULT_RUNTIME,
+    transport: str | None = None,
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
@@ -147,9 +155,17 @@ async def get_agent_connection_artifact(
     사용자가 자기 키를 붙여 완성한다. wizard(OB-3)가 이 아티팩트를 렌더+copy+verify 한다.
     org-scope 로 조회(anti-IDOR). team_members 는 projection VIEW 라 멀티프로젝트 agent 가 N행이므로
     ``.limit(1)`` 로 MultipleResultsFound 차단(identity 조회·행 동형).
+
+    E-MCP-OPT S3: ``transport`` 쿼리(``stdio``|``http``) — connect-step 토글이 다른 탭 선택 시 이
+    파라미터로 재요청(§5, FE round-trip 방식 선택). 미지정 시 edition 기본(SaaS=http·OSS=stdio).
+    이 엔드포인트의 기존 "content=paste-ready 문자열" 계약은 그대로 — 요청된 단일 변형만 반환한다
+    (두 변형 동봉은 생성 시점 bundle 엔드포인트가 담당).
     """
     if runtime not in SUPPORTED_RUNTIMES:
         raise HTTPException(status_code=400, detail=f"unsupported runtime: {runtime}")
+    resolved_transport = transport or default_transport_for_edition()
+    if resolved_transport not in SUPPORTED_TRANSPORTS:
+        raise HTTPException(status_code=400, detail=f"unsupported transport: {transport}")
 
     member = (await session.execute(
         select(TeamMember).where(
@@ -161,12 +177,17 @@ async def get_agent_connection_artifact(
     if member is None:
         raise HTTPException(status_code=404, detail="Agent not found")
 
-    artifact = build_agent_mcp_config(api_key_plaintext=_API_KEY_PLACEHOLDER, runtime=runtime)
+    artifact = build_agent_mcp_config(
+        api_key_plaintext=_API_KEY_PLACEHOLDER, runtime=runtime, transport=resolved_transport,
+    )
+    if artifact is None:
+        # http 요청됐으나 이 환경엔 호스팅 배포가 없음(MCP_PUBLIC_URL 미설정) — 명시 요청이라 400.
+        raise HTTPException(status_code=400, detail=f"transport '{resolved_transport}' unavailable in this environment")
 
     # OB-4 seam: config_generated (generator 아티팩트 반환·funnel·non-blocking).
     await emit_onboarding_event(
         session, "config_generated", agent_id=member.id, org_id=org_id,
-        runtime=runtime, transport="stdio",
+        runtime=runtime, transport=resolved_transport,
     )
     await session.commit()
 
@@ -193,6 +214,7 @@ async def _fetch_org_agent(session: AsyncSession, agent_id: uuid.UUID, org_id: u
 @router.post("/{agent_id}/verify-connection")
 async def verify_agent_connection(
     agent_id: uuid.UUID,
+    transport: str | None = None,
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
@@ -202,10 +224,25 @@ async def verify_agent_connection(
     single-target(AC3): 해당 agent 1명에게만 — fire_webhooks/org 브로드캐스트 미사용. 이벤트는
     실 /agent/stream 경로(우회 X)로 가고, 에이전트가 ack 하면(acked_seq>=seq) verified 가 된다.
     응답은 verification-status 와 동일한 6단계 레일(초기 상태)을 같이 실어 FE 가 즉시 렌더하게 한다.
+
+    E-MCP-OPT S3: ``transport="http"`` 는 **합성 이벤트/SSE nudge 전부 스킵**한다 — http 는 서버→
+    에이전트 push 경로 자체가 없어(streamable, client-initiated) 보낼 곳이 없다. heartbeat 기반
+    4단계 레일을 즉시 조회해 반환(사실상 GET verification-status 와 동형 — "확인" 버튼 클릭이 곧
+    현재 heartbeat freshness 재조회를 뜻한다).
     """
     member = await _fetch_org_agent(session, agent_id, org_id)
     if member is None:
         raise HTTPException(status_code=404, detail="Agent not found")
+
+    if transport == "http":
+        state = await get_verification_state(session, agent_id, transport="http")
+        return {
+            "agent_id": str(agent_id),
+            "verification_seq": None,
+            "verified": state["verified"],
+            "rail": state["rail"],
+        }
+
     if not member.project_id:
         raise HTTPException(status_code=400, detail="agent has no project scope to verify")
 
@@ -235,19 +272,22 @@ async def verify_agent_connection(
 @router.get("/{agent_id}/verification-status")
 async def agent_verification_status(
     agent_id: uuid.UUID,
+    transport: str = "stdio",
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
-    """OB-2 AC2: 6단계 레일 폴링/조회(BE↔FE 계약 락). SSE 우선·이 poll 은 fallback.
+    """OB-2 AC2: 레일 폴링/조회(BE↔FE 계약 락). SSE 우선·이 poll 은 fallback.
 
-    각 단계 ``{state, status: pending|active|done}``. ack/verified 는 acked_seq>=seq 권위 신호만.
+    각 단계 ``{state, status: pending|active|done}``. ack/verified 는 acked_seq>=seq 권위 신호만
+    (stdio) 또는 heartbeat freshness(http, E-MCP-OPT S3 — 4단계 축소 레일).
+    ``transport`` 쿼리 — connect-step 이 보고 있는 탭과 정합(기본 stdio·회귀0).
     """
     member = await _fetch_org_agent(session, agent_id, org_id)
     if member is None:
         raise HTTPException(status_code=404, detail="Agent not found")
 
-    state = await get_verification_state(session, agent_id)
+    state = await get_verification_state(session, agent_id, transport=transport)
     return {
         "agent_id": str(agent_id),
         "verification_seq": state["verify_seq"],

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -16,7 +16,7 @@ from app.repositories.team_member import TeamMemberRepository
 from app.schemas.team_member import (
     ActiveStorySummary, TeamMemberCreate, TeamMemberResponse, TeamMemberUpdate,
 )
-from app.services.agent_onboarding_config import build_agent_mcp_config
+from app.services.agent_onboarding_config import build_agent_mcp_config_bundle
 
 
 class ClaimBody(BaseModel):
@@ -314,8 +314,11 @@ async def create_team_member(
         effective_port = fakechat_port or int(os.environ.get("FAKECHAT_PORT", _FAKECHAT_BASE_PORT))
         response["fakechat_port"] = effective_port
         response["api_key_created"] = bool(api_key_plaintext)
-        # OB-1 AC2: 단일 SSOT generator 소비(stdio 아티팩트). 인라인 sse config 제거.
-        response["mcp_config"] = build_agent_mcp_config(api_key_plaintext=api_key_plaintext)
+        # E-MCP-OPT S3: 단일 SSOT generator 소비 — edition 기본 + 두 transport 변형 동봉(FE round-trip 0).
+        config_bundle = build_agent_mcp_config_bundle(api_key_plaintext=api_key_plaintext)
+        response["mcp_config"] = config_bundle["mcp_config"]
+        response["default_transport"] = config_bundle["default_transport"]
+        response["mcp_config_alternatives"] = config_bundle["mcp_config_alternatives"]
         if api_key_plaintext:
             response["api_key"] = api_key_plaintext
 

--- a/backend/app/services/agent_onboarding_config.py
+++ b/backend/app/services/agent_onboarding_config.py
@@ -1,12 +1,15 @@
-"""에이전트 온보딩 config 단일 SSOT generator (OB-1 · 블루프린트 §2/§7).
+"""에이전트 온보딩 config 단일 SSOT generator (OB-1 · 블루프린트 §2/§7 + E-MCP-OPT S3).
 
 team_members·agents 라우트 + connection-artifact API 가 **모두 이 generator 하나만** 소비한다 —
 README·onboarding-form·in-app docs·로컬 buildMcpConfig 4갈래로 흩어져 모순되던 config 를 단일화.
 
-생성 아티팩트 = **stdio sprintable-mcp `.mcp.json`**(§2): stdio 만 툴+이벤트를 한 프로세스로 묶는다
-(HTTP=tools-only). ``SPRINTABLE_AGENT_ID``/``WS_URL``/``port`` 는 넣지 않는다(서버 자동 도출/불요).
-``SPRINTABLE_API_URL`` 은 **backend-direct Cloud Run URL** — CF-fronted 깔끔 도메인은 ①/agent/stream
-SSE 버퍼링 ②봇차단 때문에 금지(블루프린트 §2/§3·선생님 catch).
+두 transport 아티팩트를 생성한다(§2):
+- **stdio** `.mcp.json`(로컬 uvx) — 툴+이벤트를 한 프로세스로 묶는다(§2/§3). ``SPRINTABLE_API_URL`` 은
+  **backend-direct Cloud Run URL** — CF-fronted 깔끔 도메인은 ①/agent/stream SSE 버퍼링 ②봇차단
+  때문에 금지(블루프린트 §2/§3·선생님 catch).
+- **http**(E-MCP-OPT S3) — 호스팅(`sprintable-mcp-prod`) streamable-http, `MCP_PUBLIC_URL` 깔끔
+  도메인 + per-request bearer. **tools-only**(이벤트 경로 분리 — SSE bridge 미구동, `agent_verify.py`
+  가 transport-aware 축소 rail로 대응한다).
 """
 from __future__ import annotations
 
@@ -14,6 +17,9 @@ import os
 
 DEFAULT_RUNTIME = "claude-code"
 SUPPORTED_RUNTIMES = frozenset({"claude-code"})
+STDIO = "stdio"
+HTTP = "http"
+SUPPORTED_TRANSPORTS = frozenset({STDIO, HTTP})
 
 _LOCAL_FALLBACK_URL = "http://localhost:8000"
 # generator 가 backend-direct URL 을 읽는 런타임 env. 배포(deploy_backend.sh)가 주입한다.
@@ -21,6 +27,9 @@ _LOCAL_FALLBACK_URL = "http://localhost:8000"
 # ⚠️ `SPRINTABLE_API_URL`(=에이전트/MCP 측 env 이름)을 backend fallback 으로 읽지 않는다 — backend
 # 런타임엔 미설정이고, 혹 CF 도메인으로 새어 들어오면 잘못 집을 footgun(PO QA). 단일 canonical 키.
 _BACKEND_URL_ENV_KEY = "FASTAPI_URL"
+# E-MCP-OPT S3: 호스팅 MCP 깔끔 도메인 — README(구·문서만 언급) 대신 실제로 read. 미설정(OSS/로컬 —
+# 호스팅 배포 자체가 없음)이면 http 변형을 아예 생성하지 않는다(에러 아님·"그 탭 없음"이 정답).
+_MCP_PUBLIC_URL_ENV_KEY = "MCP_PUBLIC_URL"
 
 
 def resolve_backend_direct_url() -> str:
@@ -33,20 +42,33 @@ def resolve_backend_direct_url() -> str:
     return val.rstrip("/") if val else _LOCAL_FALLBACK_URL
 
 
-def build_agent_mcp_config(
-    *,
-    api_key_plaintext: str | None,
-    runtime: str = DEFAULT_RUNTIME,
-) -> dict:
+def resolve_mcp_public_url() -> str | None:
+    """호스팅 MCP 깔끔 도메인(``MCP_PUBLIC_URL``, 예 ``https://mcp.sprintable.ai/mcp``).
+
+    미설정(OSS/로컬 등 호스팅 배포가 없는 환경) → None(http 변형 생성 불가 신호 — 호출부가 이를
+    "그 옵션 자체가 없음"으로 취급한다. 에러 아님).
+    """
+    val = os.environ.get(_MCP_PUBLIC_URL_ENV_KEY, "").strip()
+    return val.rstrip("/") if val else None
+
+
+def default_transport_for_edition() -> str:
+    """edition별 기본 transport — SaaS(EE)=http(무마찰 호스팅) / OSS=stdio(호스팅 배포 없음).
+
+    기존 OSS/SaaS 스위치(``settings.is_ee_enabled``) 재사용 — 신규 플래그 0.
+    """
+    from app.core.config import settings
+
+    return HTTP if settings.is_ee_enabled else STDIO
+
+
+def _build_stdio_config(api_key_plaintext: str | None) -> dict:
     """stdio sprintable-mcp `.mcp.json` 아티팩트(SSOT · 블루프린트 §2).
 
     env = {``SPRINTABLE_API_URL`` = backend-direct, ``AGENT_API_KEY`` = (있을 때만)}.
     ``api_key_plaintext`` 가 없으면(미발급/회전·기존 sse 경로 동형) ``AGENT_API_KEY`` 키를 생략한다 —
     소비자(GET connection-artifact)가 placeholder 를 넣거나 사용자가 자기 키를 채운다(AC4: 기존
     SPRINTABLE_API_KEY fallback 호환·미발급 시 키 비노출).
-
-    runtime 은 현재 ``claude-code`` 단일(향후 cursor 등 분기 여지). 미지원 값은 호출부(엔드포인트)가
-    400 으로 거른다 — generator 는 항상 canonical stdio 아티팩트를 만든다.
 
     **OB-2-align — 두 SSE 시스템 통일(AC④)**: sse_bridge 는 ``AGENT_GATEWAY_V2`` env 로 수신 경로를
     가른다(sse_bridge.py). 두 경로 공존:
@@ -73,4 +95,74 @@ def build_agent_mcp_config(
                 "env": env,
             }
         }
+    }
+
+
+def _build_http_config(api_key_plaintext: str | None) -> dict | None:
+    """호스팅 streamable-http `.mcp.json` 변형(E-MCP-OPT S3).
+
+    ``MCP_PUBLIC_URL`` 미설정이면 None(이 환경엔 호스팅 배포가 없다는 뜻 — 호출부가 변형을 생략).
+    ``AGENT_API_KEY`` 는 env 가 아니라 **per-request bearer**(``Authorization`` 헤더)로 인증 —
+    stdio 의 env-key 단일 인증과 다른 http transport 의 실제 인증 방식과 정합.
+    """
+    url = resolve_mcp_public_url()
+    if url is None:
+        return None
+    headers: dict[str, str] = {}
+    if api_key_plaintext:
+        headers["Authorization"] = f"Bearer {api_key_plaintext}"
+    return {
+        "mcpServers": {
+            "sprintable": {
+                "type": "http",
+                "url": url,
+                "headers": headers,
+            }
+        }
+    }
+
+
+def build_agent_mcp_config(
+    *,
+    api_key_plaintext: str | None,
+    runtime: str = DEFAULT_RUNTIME,
+    transport: str = STDIO,
+) -> dict | None:
+    """`.mcp.json` 아티팩트 generator — transport 별 SSOT(E-MCP-OPT S3).
+
+    runtime 은 현재 ``claude-code`` 단일(향후 cursor 등 분기 여지). 미지원 값은 호출부(엔드포인트)가
+    400 으로 거른다 — generator 는 항상 canonical 아티팩트를 만든다.
+
+    ``transport="http"`` 인데 이 환경에 호스팅 배포가 없으면(``MCP_PUBLIC_URL`` 미설정) None 반환 —
+    호출부가 이를 "그 변형 생성 불가"로 취급(에러 아님).
+    """
+    if transport == HTTP:
+        return _build_http_config(api_key_plaintext)
+    return _build_stdio_config(api_key_plaintext)
+
+
+def build_agent_mcp_config_bundle(
+    *,
+    api_key_plaintext: str | None,
+    runtime: str = DEFAULT_RUNTIME,
+) -> dict:
+    """connect-step 토글용 — **두 transport 변형을 한 번에** 반환(FE round-trip 0, §5 SSOT 보존).
+
+    ``{"default_transport": ..., "mcp_config": <default 변형>,
+    "mcp_config_alternatives": {<다른 transport>: <그 변형>, ...}}``. http 변형이 이 환경에서
+    생성 불가(``MCP_PUBLIC_URL`` 미설정)면 alternatives 에서 생략(OSS 는 호스팅 탭 자체가 없음).
+    """
+    default_transport = default_transport_for_edition()
+    configs = {
+        t: build_agent_mcp_config(api_key_plaintext=api_key_plaintext, runtime=runtime, transport=t)
+        for t in SUPPORTED_TRANSPORTS
+    }
+    configs = {t: c for t, c in configs.items() if c is not None}
+    default_config = configs.get(default_transport) or configs[STDIO]
+    resolved_default = default_transport if default_transport in configs else STDIO
+    alternatives = {t: c for t, c in configs.items() if t != resolved_default}
+    return {
+        "default_transport": resolved_default,
+        "mcp_config": default_config,
+        "mcp_config_alternatives": alternatives,
     }

--- a/backend/app/services/agent_verify.py
+++ b/backend/app/services/agent_verify.py
@@ -8,6 +8,20 @@ verification-status` 가 ``acked_seq`` vs 그 seq + 세션 freshness 로 6단계
 재사용. **ack/verified 는 ``acked_seq >= seq`` 권위 신호만**(낙관 0). ``event_delivered`` 는
 reachable~ack 사이 active 로 표현한다 — 게이트웨이 ack-커서 모델상 per-event delivered 를 ack 와
 별개로 durable 마킹하는 신호가 없고, /agent/stream 핫패스를 건드리지 않는다(AC4·PO 확정).
+
+**E-MCP-OPT S3 — transport-aware 축소 레일(crux2)**: 위 6단계 레일은 전부 ``/agent/stream`` SSE
+라운드트립(``AgentGatewaySession``/``AgentEventCursor``) 전용이고, 그 세션/커서는 **stdio 로컬
+프로세스의 ``sse_bridge.py`` 만** 만든다(호스팅 http transport 는 SSE bridge 를 구동하지 않음 —
+``sprintable_mcp/__main__.py`` ``_run_http()`` 참조). 즉 http 로 연결한 에이전트는 이 레일을 그대로
+쓰면 **영구히 waiting 에 멈춰 고장난 것처럼 보인다**(실제로는 정상 동작 중이어도) — 합성 이벤트를
+보낼 서버→에이전트 push 경로 자체가 http(streamable, client-initiated) 에는 없다.
+
+대신 http 는 **모든 tool 호출마다(transport 무관) 찍히는 heartbeat**
+(``PATCH /team-members/{id}/heartbeat`` → ``agent_project_profiles.last_seen_at``)를 reachable
+신호로 재사용한다 — 4단계 축소 레일(``config_copied → waiting → mcp_reachable → verified``,
+event_delivered/ack 없음 — discrete 이벤트 왕복이 구조적으로 불가하므로 mcp_reachable 과 verified 가
+같은 heartbeat 신호에서 함께 파생된다). 신규 테이블/컬럼 0 — 기존 freshness TTL
+(``agent_gateway._SESSION_FRESH_TTL``) 재사용.
 """
 from __future__ import annotations
 
@@ -19,11 +33,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.agent_gateway import AgentEventCursor, AgentGatewaySession
 from app.models.event import Event
+from app.models.member import AgentProjectProfile
 from app.services.event_seq import assign_recipient_seq
 
 VERIFY_EVENT_TYPE = "onboarding.connection_test"
 # 6단계 canonical 레일(OB-3 1:1·OB-4 vocab 정합). config_copied 는 FE 권위(BE 는 waiting 부터 관측).
 RAIL_STATES = ("config_copied", "waiting", "mcp_reachable", "event_delivered", "ack", "verified")
+# E-MCP-OPT S3: http transport 4단계 축소 레일(event_delivered/ack 없음 — §agent_verify.py 상단 설명).
+HTTP_RAIL_STATES = ("config_copied", "waiting", "mcp_reachable", "verified")
 
 
 def build_verification_rail(
@@ -101,8 +118,51 @@ async def _has_fresh_session(db: AsyncSession, agent_id: uuid.UUID) -> bool:
     return row is not None
 
 
-async def get_verification_state(db: AsyncSession, agent_id: uuid.UUID) -> dict:
-    """최신 verify Event seq + acked_seq + 세션 freshness → 레일/verified."""
+async def _has_fresh_heartbeat(db: AsyncSession, agent_id: uuid.UUID) -> bool:
+    """E-MCP-OPT S3: http transport reachable 신호 — heartbeat freshness(agent_project_profiles.
+    last_seen_at). 모든 tool 호출마다 찍히므로(transport 무관) http 에서도 실제로 갱신된다.
+    stdio 의 게이트웨이 세션과 동일 TTL(``_SESSION_FRESH_TTL``) 재사용 — 새 설정 0."""
+    from app.routers.agent_gateway import _SESSION_FRESH_TTL  # lazy: 순환 import 회피
+
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=_SESSION_FRESH_TTL)
+    row = (await db.execute(
+        select(AgentProjectProfile.id).where(
+            AgentProjectProfile.member_id == agent_id,
+            AgentProjectProfile.last_seen_at.isnot(None),
+            AgentProjectProfile.last_seen_at >= cutoff,
+        ).limit(1)
+    )).first()
+    return row is not None
+
+
+def build_http_verification_rail(*, heartbeat_fresh: bool) -> list[dict]:
+    """4단계 축소 레일(http transport) — event_delivered/ack 없음(모듈 docstring 참조).
+
+    heartbeat_fresh 하나로 mcp_reachable/verified 가 함께 판정된다 — http 에는 discrete
+    event-round-trip 신호가 없어 이 둘을 구분할 별도 근거가 없다(설계상 의도·낙관 아님).
+    """
+    if heartbeat_fresh:
+        tail = [("waiting", "done"), ("mcp_reachable", "done"), ("verified", "done")]
+    else:
+        tail = [("waiting", "active"), ("mcp_reachable", "pending"), ("verified", "pending")]
+    return [{"state": "config_copied", "status": "done"}] + [
+        {"state": s, "status": st} for s, st in tail
+    ]
+
+
+async def get_verification_state(
+    db: AsyncSession, agent_id: uuid.UUID, *, transport: str = "stdio",
+) -> dict:
+    """최신 verify Event seq + acked_seq + 세션 freshness → 레일/verified.
+
+    E-MCP-OPT S3: ``transport="http"`` 는 완전히 다른(heartbeat 기반) 4단계 레일로 분기한다 — 6단계
+    SSE 레일은 http 에서 구조적으로 절대 전진하지 않으므로(모듈 docstring) 재사용하지 않는다.
+    """
+    if transport == "http":
+        fresh = await _has_fresh_heartbeat(db, agent_id)
+        rail = build_http_verification_rail(heartbeat_fresh=fresh)
+        return {"verify_seq": None, "acked_seq": None, "verified": fresh, "rail": rail}
+
     verify_seq = (await db.execute(
         select(Event.recipient_seq).where(
             Event.recipient_id == agent_id,

--- a/backend/tests/test_e_mcp_opt_s3_hosted_transport.py
+++ b/backend/tests/test_e_mcp_opt_s3_hosted_transport.py
@@ -1,0 +1,267 @@
+"""E-MCP-OPT S3: 호스팅(http) transport 유도 — connect-step BE 계약.
+
+①`build_agent_mcp_config` transport 분기 + edition 기본 + 두 변형 bundle
+②crux2 — verify rail transport-aware 분기(http=heartbeat 기반 4단계 축소 레일)
+③router 레벨 `transport` 쿼리 배선(connection-artifact/verify-connection/verification-status)
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import app.routers.agents as ag
+from app.services import agent_onboarding_config as cfg
+from app.services.agent_verify import (
+    HTTP_RAIL_STATES,
+    RAIL_STATES,
+    build_http_verification_rail,
+    get_verification_state,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── ① build_agent_mcp_config transport 분기 ───────────────────────────────────
+def test_stdio_default_unchanged_when_no_transport_kwarg():
+    """기존 호출부(회귀0) — transport 미지정이면 여전히 stdio."""
+    out = cfg.build_agent_mcp_config(api_key_plaintext="k")
+    assert out["mcpServers"]["sprintable"]["type"] == "stdio"
+
+
+def test_http_variant_none_when_mcp_public_url_unset(monkeypatch):
+    monkeypatch.delenv("MCP_PUBLIC_URL", raising=False)
+    assert cfg.resolve_mcp_public_url() is None
+    assert cfg.build_agent_mcp_config(api_key_plaintext="k", transport="http") is None
+
+
+def test_http_variant_shape_with_key(monkeypatch):
+    monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp/")
+    assert cfg.resolve_mcp_public_url() == "https://mcp.sprintable.ai/mcp"  # trailing slash 제거
+    out = cfg.build_agent_mcp_config(api_key_plaintext="sk_live_abc", transport="http")
+    server = out["mcpServers"]["sprintable"]
+    assert server == {
+        "type": "http",
+        "url": "https://mcp.sprintable.ai/mcp",
+        "headers": {"Authorization": "Bearer sk_live_abc"},
+    }
+
+
+def test_http_variant_no_auth_header_when_key_absent(monkeypatch):
+    monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp")
+    out = cfg.build_agent_mcp_config(api_key_plaintext=None, transport="http")
+    assert out["mcpServers"]["sprintable"]["headers"] == {}
+
+
+def test_default_transport_for_edition(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "license_consent", "", raising=False)
+    assert cfg.default_transport_for_edition() == "stdio"
+    monkeypatch.setattr(settings, "license_consent", "agreed", raising=False)
+    assert cfg.default_transport_for_edition() == "http"
+
+
+def test_bundle_saas_with_hosting_available(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "license_consent", "agreed", raising=False)
+    monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp")
+    bundle = cfg.build_agent_mcp_config_bundle(api_key_plaintext="k")
+    assert bundle["default_transport"] == "http"
+    assert bundle["mcp_config"]["mcpServers"]["sprintable"]["type"] == "http"
+    assert set(bundle["mcp_config_alternatives"]) == {"stdio"}
+
+
+def test_bundle_oss_no_hosting_falls_back_to_stdio_only(monkeypatch):
+    """OSS(호스팅 미배포) — MCP_PUBLIC_URL 미설정이면 default가 http여도 stdio로 폴백·alternatives 비움."""
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "license_consent", "agreed", raising=False)  # 가정: edition=SaaS이나
+    monkeypatch.delenv("MCP_PUBLIC_URL", raising=False)                  # 이 인스턴스엔 호스팅 미배포
+    bundle = cfg.build_agent_mcp_config_bundle(api_key_plaintext="k")
+    assert bundle["default_transport"] == "stdio"
+    assert bundle["mcp_config"]["mcpServers"]["sprintable"]["type"] == "stdio"
+    assert bundle["mcp_config_alternatives"] == {}
+
+
+def test_bundle_oss_default_stdio(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "license_consent", "", raising=False)
+    monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp")  # 배포는 있어도 OSS면 기본 stdio
+    bundle = cfg.build_agent_mcp_config_bundle(api_key_plaintext="k")
+    assert bundle["default_transport"] == "stdio"
+    assert set(bundle["mcp_config_alternatives"]) == {"http"}
+
+
+# ── ② crux2 — verify rail transport-aware ─────────────────────────────────────
+def _states(rail):
+    return {r["state"]: r["status"] for r in rail}
+
+
+def test_http_rail_is_4_states_no_event_delivered_ack():
+    rail = build_http_verification_rail(heartbeat_fresh=True)
+    assert [r["state"] for r in rail] == list(HTTP_RAIL_STATES)
+    assert len(HTTP_RAIL_STATES) == 4
+    assert "event_delivered" not in _states(rail) and "ack" not in _states(rail)
+
+
+def test_http_rail_fresh_heartbeat_all_done():
+    s = _states(build_http_verification_rail(heartbeat_fresh=True))
+    assert all(v == "done" for v in s.values())
+
+
+def test_http_rail_no_heartbeat_waiting_active():
+    s = _states(build_http_verification_rail(heartbeat_fresh=False))
+    assert s["config_copied"] == "done"
+    assert s["waiting"] == "active"
+    assert s["mcp_reachable"] == "pending" and s["verified"] == "pending"
+
+
+def _scalar(v):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = v
+    return r
+
+
+def _first(v):
+    r = MagicMock()
+    r.first.return_value = v
+    return r
+
+
+@pytest.mark.anyio
+async def test_get_verification_state_http_uses_heartbeat_not_sse(monkeypatch):
+    """transport='http' 는 Event/AgentEventCursor(SSE) 를 아예 조회 안 하고 heartbeat freshness 1회만."""
+    from app.routers import agent_gateway as gw
+    monkeypatch.setattr(gw, "_SESSION_FRESH_TTL", 60, raising=False)
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_first(("profile-row",)))  # fresh heartbeat 존재
+    out = await get_verification_state(db, uuid.uuid4(), transport="http")
+    assert db.execute.await_count == 1  # SSE 관련 verify_seq/acked_seq 조회 0회
+    assert out["verified"] is True
+    assert [r["state"] for r in out["rail"]] == list(HTTP_RAIL_STATES)
+    assert out["verify_seq"] is None and out["acked_seq"] is None  # http 는 이 개념 자체가 없음
+
+
+@pytest.mark.anyio
+async def test_get_verification_state_http_no_heartbeat_not_verified():
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_first(None))
+    out = await get_verification_state(db, uuid.uuid4(), transport="http")
+    assert out["verified"] is False
+
+
+@pytest.mark.anyio
+async def test_get_verification_state_stdio_default_unchanged():
+    """transport 미지정 = 기존 stdio 6단계 경로 그대로(회귀0)."""
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_scalar(5), _scalar(7), _first(("sess",))])
+    out = await get_verification_state(db, uuid.uuid4())
+    assert [r["state"] for r in out["rail"]] == list(RAIL_STATES)
+    assert out["verified"] is True
+
+
+# ── ③ router 레벨 transport 배선 ──────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_connection_artifact_transport_http_returns_http_content(monkeypatch):
+    from app.routers.agents import get_agent_connection_artifact
+
+    monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp")
+    agent_id = uuid.uuid4()
+    res = MagicMock()
+    res.scalar_one_or_none.return_value = SimpleNamespace(id=agent_id)
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=res)
+    out = await get_agent_connection_artifact(
+        agent_id, runtime="claude-code", transport="http",
+        session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+    )
+    parsed = json.loads(out["content"])
+    assert parsed["mcpServers"]["sprintable"]["type"] == "http"
+
+
+@pytest.mark.anyio
+async def test_connection_artifact_transport_http_unavailable_400(monkeypatch):
+    """http 명시 요청됐는데 이 환경엔 호스팅 배포가 없음(MCP_PUBLIC_URL 미설정) — 400."""
+    from fastapi import HTTPException
+
+    from app.routers.agents import get_agent_connection_artifact
+
+    monkeypatch.delenv("MCP_PUBLIC_URL", raising=False)
+    agent_id = uuid.uuid4()
+    res = MagicMock()
+    res.scalar_one_or_none.return_value = SimpleNamespace(id=agent_id)
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=res)
+    with pytest.raises(HTTPException) as ei:
+        await get_agent_connection_artifact(
+            agent_id, runtime="claude-code", transport="http",
+            session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+        )
+    assert ei.value.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_connection_artifact_unsupported_transport_400():
+    from fastapi import HTTPException
+
+    from app.routers.agents import get_agent_connection_artifact
+    with pytest.raises(HTTPException) as ei:
+        await get_agent_connection_artifact(
+            uuid.uuid4(), runtime="claude-code", transport="carrier-pigeon",
+            session=AsyncMock(), auth=MagicMock(), org_id=uuid.uuid4(),
+        )
+    assert ei.value.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_verify_connection_http_skips_synthetic_event_and_wake(monkeypatch):
+    """transport='http' — start_verification/wake_agent(SSE 전용 경로) 전혀 호출 안 됨."""
+    member = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar(member))
+    rail = [{"state": s, "status": "done"} for s in HTTP_RAIL_STATES]
+    with patch.object(ag, "start_verification", new=AsyncMock()) as start, \
+         patch.object(ag, "get_verification_state",
+                      new=AsyncMock(return_value={"verified": True, "rail": rail, "verify_seq": None})), \
+         patch("app.routers.agent_gateway.wake_agent", new=MagicMock()) as wake:
+        out = await ag.verify_agent_connection(
+            member.id, transport="http", session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+        )
+    assert out["verified"] is True and out["rail"] == rail
+    start.assert_not_awaited()
+    wake.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_verification_status_passes_transport_through():
+    member = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar(member))
+    with patch.object(ag, "get_verification_state", new=AsyncMock(
+        return_value={"verified": True, "rail": [], "verify_seq": None},
+    )) as get_state:
+        await ag.agent_verification_status(
+            member.id, transport="http", session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+        )
+    get_state.assert_awaited_once_with(db, member.id, transport="http")
+
+
+# ── emit_onboarding_event dynamic transport (하드코딩 제거 회귀 가드) ──────────
+def test_agents_router_no_longer_hardcodes_transport_stdio_literal():
+    """agents.py 소스에 `transport=\"stdio\"` 하드코딩 문자열이 (verify-connection 자체의
+    event_sent 콜 1곳 제외) 더는 없어야 한다 — agent_created/config_generated 는 실제
+    default_transport/resolved_transport 변수를 넘겨야(안 그러면 SaaS 퍼널이 전부 stdio로 오기록)."""
+    import inspect
+    src = inspect.getsource(ag)
+    create_src = inspect.getsource(ag.create_org_agent)
+    artifact_src = inspect.getsource(ag.get_agent_connection_artifact)
+    assert 'transport="stdio"' not in create_src
+    assert 'transport="stdio"' not in artifact_src
+    assert 'transport=config_bundle["default_transport"]' in create_src
+    assert "transport=resolved_transport" in artifact_src


### PR DESCRIPTION
## Summary
- Onboarding's `.mcp.json` generator only ever produced stdio/uvx — the hosted streamable-http MCP server has existed since E-MCP-HTTP S1, but `MCP_PUBLIC_URL` was documented (README only, line 53) and never actually read anywhere in `backend/app` (confirmed: zero code references before this PR). SaaS users were stuck on local-uvx, paying exactly the reinstall friction S1 (tools/list scope filter) and S2 (chat attachments) were meant to make moot by living server-side.
- `build_agent_mcp_config()` gains a `transport` branch: `http` reads `MCP_PUBLIC_URL` and emits `{type:"http", url, headers:{Authorization: Bearer <key>}}`; `stdio` (default) is byte-identical to before — zero existing callers change behavior. Returns `None` for `http` when `MCP_PUBLIC_URL` is unset (no hosted deployment in this environment — not an error, "that tab doesn't exist").
- New `build_agent_mcp_config_bundle()` returns both variants + the edition-driven default (SaaS=http, OSS=stdio, reusing the existing `settings.is_ee_enabled` switch — zero new flags) — used by the two agent-creation endpoints (`agents.py` org-level create, `team_members.py` create) so the connect-step toggle has both artifacts with **zero extra round-trips**. The existing single-artifact `GET connection-artifact` endpoint gets a `transport` query param instead (preserves its BE↔FE-locked paste-ready-string response contract unchanged).

## Load-bearing finding (crux2, PO-approved before implementation)
The existing 6-stage verify rail (`event_delivered → ack → verified`) is entirely gated on the `/agent/stream` SSE round-trip (`AgentGatewaySession` + `AgentEventCursor.acked_seq`), and **only `sse_bridge.py`** — the stdio-only local-process background task — ever creates that session/cursor. `_run_http()` never starts it (confirmed via source + its own docstring). Adopting http as the SaaS default without fixing this would leave every hosted agent's verify rail stuck at "waiting" forever, looking broken even when the agent is working perfectly fine via tool calls.

Resolved via a transport-aware 4-stage rail (`config_copied → waiting → mcp_reachable → verified`, no `event_delivered`/`ack` — no discrete event round-trip is possible over stateless client-initiated HTTP) for `http`, derived from the existing tool-call heartbeat (`PATCH /team-members/{id}/heartbeat`, already fired on every tool call regardless of transport) instead of the SSE session. No new schema — reuses the existing session-freshness TTL. `verify-connection`/`verification-status` take a `transport` query param; the `http` branch skips the synthetic-event/SSE-nudge machinery entirely (there's nothing to nudge) and just re-reads current heartbeat freshness.

This delta was relayed to 유나 (design) before implementation so her connect-step mockup/copy could reflect the 4-stage hosted rail honestly (not "less precise", just a different underlying mechanism) — she's already incorporated it.

## Test plan
- [x] 43 pre-existing OB-1/OB-2/OB-2-align tests pass unchanged (zero regressions in existing artifact-generation/verify-rail behavior).
- [x] 20 new tests: transport branching (`http` variant shape, `None` when `MCP_PUBLIC_URL` unset, edition-default resolution, bundle variants), 4-stage http rail construction + `get_verification_state(transport="http")` (confirmed it queries heartbeat freshness only — zero SSE/Event queries), router-level `transport` param wiring across all 3 consumer endpoints + the 2 verify endpoints, `verify-connection` http-mode skipping the synthetic-event/`wake_agent` calls entirely, and a source-level regression guard that the `emit_onboarding_event(transport="stdio")` hardcoding is gone (funnel now records the actual resolved transport).
- [x] Negative-tested the crux2 fix: temporarily disabled the `transport == "http"` branch in `get_verification_state`, confirmed the two targeted tests genuinely fail (fell through to the SSE path and crashed on the http-shaped mock), restored.
- [x] Confirmed FE proxy routes (`connection-artifact`, `verify-connection`, `verification-status`) are pure passthroughs with no response schema validation — the new response fields are purely additive, no BE/FE coordination blocker for the parallel FE work.
- [x] Full backend suite: 2952 passed, 0 regressions (same 6 pre-existing unrelated failures as the last two PRs — live-E2E hardcoded tool-count drift + local `.mcp.json` environment-config drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)