### PR TITLE
fix(mcp): E-MCP-OPT S5 hardening — attachment cap bypass, verify-connection asymmetry, transport telemetry (34e69685)

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -29,9 +29,16 @@ class AuthContext:
 
 
 async def _persist_first_auth_seen(
-    member_id: uuid.UUID, org_id: str | None, project_id: str | None
+    member_id: uuid.UUID, org_id: str | None, project_id: str | None,
+    transport: str | None = None,
 ) -> None:
     """OB-4b: 첫 인증 1회 ``first_auth_seen`` — caller 세션 commit 여부와 **무관하게** persist.
+
+    E-MCP-OPT S5(#5): 이 인증 경로(API키)는 REST 전반의 공용 진입점이라 ``transport``(stdio/http)를
+    자체적으론 전혀 알 수 없다 — MCP 클라이언트(``sprintable_mcp``)가 자기 신고하는
+    ``X-MCP-Transport`` 헤더(``get_current_user``가 읽어 여기로 전달)만이 유일한 신호. 헤더 미전송
+    (구버전 클라이언트·MCP 아닌 직접 API 호출)이면 기존 하드코딩과 동일하게 ``"stdio"`` 로 폴백
+    (레거시 무회귀 — 관측용 필드일 뿐 인가에 쓰이지 않음).
 
     ⚠️ streaming auth(``get_current_user_streaming``)는 세션을 commit 없이 close 하므로 caller-session
     emit 은 rollback 으로 미persist(V2 통일로 에이전트 첫 인증이 ``/agent/stream`` 인 게 가장 흔함) →
@@ -65,14 +72,16 @@ async def _persist_first_auth_seen(
                 s, event="first_auth_seen", agent_id=member_id,
                 org_id=(uuid.UUID(org_id) if org_id else None),
                 project_id=(uuid.UUID(project_id) if project_id else None),
-                runtime="claude-code", transport="stdio",
+                runtime="claude-code", transport=(transport or "stdio"),
             )
             await s.commit()
     except Exception:
         logger.warning("first_auth_seen persist failed agent=%s", member_id, exc_info=True)
 
 
-async def _resolve_api_key(raw_key: str, db: AsyncSession) -> AuthContext:
+async def _resolve_api_key(
+    raw_key: str, db: AsyncSession, transport: str | None = None,
+) -> AuthContext:
     """sk_live_* API key를 DB에서 조회하여 AuthContext 반환."""
     from app.models.api_key import ApiKey
     from app.models.team import TeamMember
@@ -181,7 +190,7 @@ async def _resolve_api_key(raw_key: str, db: AsyncSession) -> AuthContext:
     # OB-4b seam(first_auth_seen): 최초 인증 1회. caller 세션(특히 streaming auth=commit 없음)에 의존하면
     # 미persist + dedup 깨짐(까심 RC-1) → 전용 committed 세션에서 atomic 처리(경로 무관·race-safe·무중단).
     if _first_auth_seen:
-        await _persist_first_auth_seen(member_id, org_id, project_id)
+        await _persist_first_auth_seen(member_id, org_id, project_id, transport=transport)
 
     return AuthContext(
         user_id=str(member_id),
@@ -203,11 +212,12 @@ async def _resolve_api_key(raw_key: str, db: AsyncSession) -> AuthContext:
 async def get_current_user(
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
     x_agent_api_key: str | None = Header(default=None, alias="x-agent-api-key"),
+    x_mcp_transport: str | None = Header(default=None, alias="X-MCP-Transport"),
     db: AsyncSession = Depends(get_db),
 ) -> AuthContext:
     # x-agent-api-key 헤더 우선 처리 (SSE 브릿지 직접 연결용)
     if x_agent_api_key and x_agent_api_key.startswith("sk_live_"):
-        return await _resolve_api_key(x_agent_api_key, db)
+        return await _resolve_api_key(x_agent_api_key, db, transport=x_mcp_transport)
 
     if credentials is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing Authorization header")
@@ -216,7 +226,7 @@ async def get_current_user(
 
     # sk_live_* prefix → API key 경로 (DB 조회)
     if token.startswith("sk_live_"):
-        return await _resolve_api_key(token, db)
+        return await _resolve_api_key(token, db, transport=x_mcp_transport)
 
     # JWT 경로 (기존)
     try:

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -229,10 +229,17 @@ async def verify_agent_connection(
     에이전트 push 경로 자체가 없어(streamable, client-initiated) 보낼 곳이 없다. heartbeat 기반
     4단계 레일을 즉시 조회해 반환(사실상 GET verification-status 와 동형 — "확인" 버튼 클릭이 곧
     현재 heartbeat freshness 재조회를 뜻한다).
+
+    E-MCP-OPT S5(#4): project 미배정 에이전트는 **transport 무관 동일하게 400** — http 조기 return이
+    이 가드보다 먼저면 미배정 에이전트가 stdio=400/http=200으로 갈렸다(까심 QA). project 스코프가
+    없는 에이전트는애초에 "연결 검증"이 의미가 없으므로(heartbeat 조차 project 컨텍스트 하 tool
+    호출을 전제) 두 transport 모두 이 가드를 먼저 통과해야 한다.
     """
     member = await _fetch_org_agent(session, agent_id, org_id)
     if member is None:
         raise HTTPException(status_code=404, detail="Agent not found")
+    if not member.project_id:
+        raise HTTPException(status_code=400, detail="agent has no project scope to verify")
 
     if transport == "http":
         state = await get_verification_state(session, agent_id, transport="http")
@@ -242,9 +249,6 @@ async def verify_agent_connection(
             "verified": state["verified"],
             "rail": state["rail"],
         }
-
-    if not member.project_id:
-        raise HTTPException(status_code=400, detail="agent has no project scope to verify")
 
     seq = await start_verification(
         session, agent_id=agent_id, org_id=org_id, project_id=member.project_id

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -29,7 +29,7 @@ from app.routers.events import _push_to_agent, publish_event
 from app.schemas.attachment import validate_attachment_url
 from app.services import chat_presence
 from app.services.agent_runtime import supports_deterministic_command
-from app.services.asset_registry import DEFAULT_CONTAINER, sync_attachment_assets
+from app.services.asset_registry import DEFAULT_CONTAINER, canonical_object_path, sync_attachment_assets
 from app.services.command_classifier import classify_command
 from app.services.event_seq import assign_recipient_seq
 from app.services.member_resolver import (
@@ -592,6 +592,34 @@ _MAX_ATTACHMENT_SIZE = 100 * 1024 * 1024  # 100MB (메타 sanity 상한)
 _MAX_JSON_ATTACHMENT_UPLOAD_SIZE = 2 * 1024 * 1024  # 2MiB decoded
 _MAX_ATTACHMENT_NAME_LEN = 255
 _SAFE_ATTACHMENT_NAME_RE = re.compile(r"[^\w.\-]+")
+# E-MCP-OPT S5(#2, 까심 QA): 위 per-file 2MiB 캡은 걸지만 "선언 한도"(5개/6MiB 합계 — sprintable_mcp
+# `tools/chat.py` 의 client-side 가드와 동일 값)는 이 엔드포인트가 서버서 강제하지 않았다 —
+# participant 가 여러 번 개별 호출로(각 ≤2MiB) 메시지당 최대 10개(기존 `_MAX_ATTACHMENTS`)×2MiB≈
+# 20MiB 를 모아 SSOT 정책을 우회할 수 있었다(보안 취약점 아님·기존 message-level 캡으로 bounded — SSOT
+# 원칙 위반). object_path 에 `mcp/` 세그먼트를 심어 이 엔드포인트로 실제 업로드된 첨부만 식별하고,
+# `send_message` 가 그 부분집합에 한해 선언 한도를 재검증한다(새 테이블/시간창 추적 0 — 메시지 생성
+# 시점 1회 재검증으로 충분·메시지 없이 업로드만 반복하는 건 orphan blob 만 남길 뿐 이 한도와 무관).
+_MCP_MAX_ATTACHMENTS = 5
+_MCP_MAX_TOTAL_ATTACHMENT_BYTES = 6 * 1024 * 1024  # 6MiB decoded
+
+
+def _is_mcp_upload_object_path(url: str) -> bool:
+    """이 url 이 `upload_conversation_attachment`(MCP JSON 업로드)로 실제 생성된 객체 경로인지.
+
+    그 엔드포인트만 `org/<org>/project/<project>/chat/<conversation>/mcp/<file>` 형태(6번째
+    segment=``mcp``)로 서버가 직접 object_path 를 구성한다 — client 는 ``name``(파일명 suffix)
+    외에는 경로에 관여할 수 없어 이 segment 를 조작해 자신에게 더 엄격한 검사를 켜는 것 외엔
+    스푸핑 이득이 없다(false-positive 는 harmless·false-negative 는 발생하지 않음 — 이 엔드포인트가
+    쓰는 유일한 shape).
+    """
+    canon = canonical_object_path(url, DEFAULT_CONTAINER)
+    if not canon:
+        return False
+    parts = canon.split("/")
+    return (
+        len(parts) >= 7
+        and parts[0] == "org" and parts[2] == "project" and parts[4] == "chat" and parts[6] == "mcp"
+    )
 
 
 class MessageAttachment(BaseModel):
@@ -1245,6 +1273,23 @@ async def send_message(
         from ee.plan_limits import check_storage_capacity  # type: ignore[import]
         await check_storage_capacity(db, org_id, [a.model_dump() for a in body.attachments])
 
+    # E-MCP-OPT S5(#2): MCP JSON 업로드 엔드포인트가 개별 업로드마다 파일당 2MiB만 검사하고
+    # 선언 한도(5개/6MiB 합계)를 강제 안 해 다회 호출로 우회 가능했다 — 이 메시지가 실제로
+    # 참조하는 mcp-origin 첨부 부분집합에 한해 여기서 재검증(전체 attachments 가 아님 — FE 업로드
+    # 첨부는 기존 100MB/10개 한도만 적용받는다·회귀0).
+    if body.attachments:
+        mcp_origin = [a for a in body.attachments if _is_mcp_upload_object_path(a.url)]
+        if len(mcp_origin) > _MCP_MAX_ATTACHMENTS or (
+            sum(a.size for a in mcp_origin) > _MCP_MAX_TOTAL_ATTACHMENT_BYTES
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"mcp attachments exceed declared limit "
+                    f"(max {_MCP_MAX_ATTACHMENTS} files / {_MCP_MAX_TOTAL_ATTACHMENT_BYTES} bytes total)"
+                ),
+            )
+
     msg = ConversationMessage(
         conversation_id=conversation_id,
         sender_id=sender.id,
@@ -1537,11 +1582,13 @@ async def upload_conversation_attachment(
         )
 
     safe_name = _safe_attachment_filename(body.name)
-    # S7 namespace — FE 업로드 라우트(apps/web .../conversations/[id]/attachments/route.ts)와
-    # 정확히 동일한 shape(org/<org>/project/<project>/chat/<conv>/<file>). path_in_source_scope/
-    # sync_attachment_assets 가 기대하는 스코프와 일치해야 IDOR 가드·read-authorize 가 통과한다.
+    # S7 namespace — FE 업로드 라우트(apps/web .../conversations/[id]/attachments/route.ts)와 동일
+    # 접두(org/<org>/project/<project>/chat/<conv>/...). path_in_source_scope 는 이 접두까지만
+    # segment-match 하므로(그 뒤 세그먼트 수는 안 봄) 추가된 `mcp/` 세그먼트는 IDOR 가드/read-authorize
+    # 통과에 영향 없다 — E-MCP-OPT S5(#2): 이 엔드포인트로 실제 생성된 객체만 식별하는 마커
+    # (`_is_mcp_upload_object_path`)로 send_message 의 선언 한도 재검증이 소비한다.
     object_path = (
-        f"org/{org_id}/project/{conv.project_id}/chat/{conversation_id}/{uuid.uuid4()}-{safe_name}"
+        f"org/{org_id}/project/{conv.project_id}/chat/{conversation_id}/mcp/{uuid.uuid4()}-{safe_name}"
     )
 
     uploaded = await get_storage_provider().put_object(

--- a/backend/sprintable_mcp/api_client.py
+++ b/backend/sprintable_mcp/api_client.py
@@ -248,10 +248,16 @@ class SprintableClient:
         url = f"{self._base_url}{path}"
         # E-MCP-HTTP S1: effective 키 = per-request override(http 멀티테넌트) ∨ env 단일키(stdio·무회귀).
         _key = _api_key_override.get() or self._api_key
+        from .config import settings as _mcp_settings
+
         headers = {
             "Authorization": f"Bearer {_key}",
             "x-agent-api-key": _key,
             "Content-Type": "application/json",
+            # E-MCP-OPT S5(#5): BE 가 첫인증 등 텔레메트리에서 실 transport 를 알 수 있도록 자기신고
+            # (BE 는 이 값을 신뢰만 하고 인가에 쓰지 않음 — 순수 관측용, per-request bearer/scope 가 실
+            # SSOT). 미설정 시 BE 는 fallback "stdio"(레거시 무회귀).
+            "X-MCP-Transport": (_mcp_settings.mcp_transport or "stdio").strip().lower(),
         }
         # 85429ee0: per-call override 시 X-Project-Id 헤더 전송 — 백엔드 get_verified_org_id 가
         # has_project_access 로 멤버십 검증 후 그 프로젝트로 컨텍스트 전환(mutation 라우트). 미설정 시

--- a/backend/tests/test_e_mcp_opt_s5_hardening.py
+++ b/backend/tests/test_e_mcp_opt_s5_hardening.py
@@ -1,0 +1,160 @@
+"""E-MCP-OPT S5 (34e69685): S2+S3 QA MINOR 하드닝 모음.
+
+#4: verify-connection — project 미배정 에이전트는 transport 무관 동일하게 400(http 조기 return이
+    이 가드보다 먼저였던 비대칭 수정).
+#5: 첫인증 텔레메트리(_persist_first_auth_seen) transport 하드코딩 제거 — MCP 클라이언트 자기신고
+    (X-MCP-Transport 헤더) 기반으로 동적화.
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import app.routers.agents as ag
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _scalar(v):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = v
+    return r
+
+
+# ── #4: project 미배정 → transport 무관 동일 400 ──────────────────────────────
+@pytest.mark.anyio
+async def test_verify_connection_unassigned_agent_400_via_stdio():
+    member = SimpleNamespace(id=uuid.uuid4(), project_id=None)
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar(member))
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as ei:
+        await ag.verify_agent_connection(
+            member.id, transport=None, session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+        )
+    assert ei.value.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_verify_connection_unassigned_agent_400_via_http_too():
+    """회귀 가드 — 이전엔 http 조기 return이 이 가드를 건너뛰어 200이 났었다(까심 QA #4)."""
+    member = SimpleNamespace(id=uuid.uuid4(), project_id=None)
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar(member))
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as ei:
+        await ag.verify_agent_connection(
+            member.id, transport="http", session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+        )
+    assert ei.value.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_verify_connection_assigned_agent_http_still_skips_sse(monkeypatch):
+    """project 배정된 에이전트는 http에서 여전히 합성이벤트/wake 스킵(#4가 이 동작을 안 건드림)."""
+    member = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar(member))
+    with patch.object(ag, "start_verification", new=AsyncMock()) as start, \
+         patch.object(ag, "get_verification_state", new=AsyncMock(
+             return_value={"verified": True, "rail": [], "verify_seq": None},
+         )), \
+         patch("app.routers.agent_gateway.wake_agent", new=MagicMock()) as wake:
+        out = await ag.verify_agent_connection(
+            member.id, transport="http", session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+        )
+    assert out["verified"] is True
+    start.assert_not_awaited()
+    wake.assert_not_called()
+
+
+# ── #5: 첫인증 텔레메트리 transport 동적화 ────────────────────────────────────
+class _FakeSession:
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, *a):
+        return False
+    async def execute(self, *a, **kw):
+        m = MagicMock()
+        m.first.return_value = None  # dedup: 아직 기록 없음
+        return m
+    async def commit(self):
+        return None
+
+
+@pytest.mark.anyio
+async def test_persist_first_auth_seen_uses_passed_transport():
+    from app.dependencies import auth as authmod
+
+    captured = {}
+
+    async def _fake_record(s, *, event, agent_id, org_id, project_id, runtime, transport):
+        captured["transport"] = transport
+
+    with patch("app.core.database.async_session_factory", new=lambda: _FakeSession()), \
+         patch("app.services.onboarding_funnel.record_onboarding_event", new=_fake_record):
+        await authmod._persist_first_auth_seen(uuid.uuid4(), None, None, transport="http")
+    assert captured["transport"] == "http"
+
+
+@pytest.mark.anyio
+async def test_persist_first_auth_seen_falls_back_to_stdio_when_no_header():
+    """회귀 가드 — 헤더 미전송(구버전 클라이언트 등) 시 기존과 동일하게 'stdio'."""
+    from app.dependencies import auth as authmod
+
+    captured = {}
+
+    async def _fake_record(s, *, event, agent_id, org_id, project_id, runtime, transport):
+        captured["transport"] = transport
+
+    with patch("app.core.database.async_session_factory", new=lambda: _FakeSession()), \
+         patch("app.services.onboarding_funnel.record_onboarding_event", new=_fake_record):
+        await authmod._persist_first_auth_seen(uuid.uuid4(), None, None, transport=None)
+    assert captured["transport"] == "stdio"
+
+
+@pytest.mark.anyio
+async def test_get_current_user_passes_x_mcp_transport_header_through():
+    from app.dependencies.auth import get_current_user
+
+    with patch("app.dependencies.auth._resolve_api_key", new=AsyncMock()) as resolve:
+        await get_current_user(
+            credentials=None, x_agent_api_key="sk_live_abc", x_mcp_transport="http",
+            db=AsyncMock(),
+        )
+    resolve.assert_awaited_once_with("sk_live_abc", resolve.await_args.args[1], transport="http")
+
+
+def test_mcp_client_sends_x_mcp_transport_header(monkeypatch):
+    """sprintable_mcp 쪽 — 매 요청마다 자기신고 헤더가 실제로 실린다(both transport 값)."""
+    from sprintable_mcp import api_client as ac
+    from sprintable_mcp.config import settings as mcp_settings
+
+    monkeypatch.setattr(mcp_settings, "mcp_transport", "http", raising=False)
+    client = ac.SprintableClient()
+    client.configure("https://x", "envkey")
+
+    captured = {}
+
+    async def _fake_request(method, url, **kw):
+        captured["headers"] = kw.get("headers", {})
+        class R:
+            status_code = 200
+            is_success = True
+            headers = {"content-type": "application/json"}
+            def json(self): return {}
+            @property
+            def text(self): return "{}"
+        return R()
+
+    import asyncio
+    from unittest.mock import patch as _patch
+    with _patch("httpx.AsyncClient.request", new=AsyncMock(side_effect=_fake_request)):
+        asyncio.run(client.get("/x"))
+    assert captured["headers"]["X-MCP-Transport"] == "http"

--- a/backend/tests/test_e_mcp_opt_s5_hardening_realdb.py
+++ b/backend/tests/test_e_mcp_opt_s5_hardening_realdb.py
@@ -1,0 +1,198 @@
+"""E-MCP-OPT S5 (34e69685) #2 — 실 Postgres: mcp-origin 첨부 선언 한도(5개/6MiB) 우회 봉쇄.
+
+`upload_conversation_attachment`가 파일당 2MiB만 체크하고 선언 총량(5개/6MiB)을 강제하지 않아,
+participant가 다회 개별 업로드(각 ≤2MiB)로 메시지당 최대 10개(기존 message-level 캡)까지 모아
+SSOT 정책을 우회할 수 있었다(까심 QA #2). `send_message`가 mcp-origin(첨부 url이
+`.../chat/<conv>/mcp/<file>` shape) 부분집합에 한해 선언 한도를 재검증하는지 실 DB+실
+upload_conversation_attachment 왕복으로 확인한다.
+"""
+from __future__ import annotations
+
+import base64
+import os
+import uuid
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("ab800000-0000-0000-0000-000000000001")
+PROJ = uuid.UUID("ab800000-0000-0000-0000-000000000002")
+CONV = uuid.UUID("ab800000-0000-0000-0000-000000000003")
+AGENT = uuid.UUID("ab800000-0000-0000-0000-0000000000a1")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth(member_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(member_id), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(ORG),
+    )
+
+
+async def _seed(s) -> None:
+    for sql in [
+        f"DELETE FROM conversation_participants WHERE conversation_id='{CONV}'",
+        f"DELETE FROM conversation_messages WHERE conversation_id='{CONV}'",
+        f"DELETE FROM conversations WHERE id='{CONV}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','S5HARD','s5hard-org','free')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ}','{ORG}','P','none')",
+        f"INSERT INTO members (id,org_id,type,name) VALUES ('{AGENT}','{ORG}','agent','Agent')",
+        f"INSERT INTO project_access (project_id,member_id,permission) VALUES ('{PROJ}','{AGENT}','granted')",
+        f"INSERT INTO conversations (id,org_id,project_id,type) VALUES ('{CONV}','{ORG}','{PROJ}','group')",
+        f"INSERT INTO conversation_participants (conversation_id,member_id) VALUES ('{CONV}','{AGENT}')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+@pytest.mark.anyio
+async def test_many_individual_uploads_then_send_message_rejects_over_declared_limit(monkeypatch, tmp_path):
+    """6개(> 5개 cap)를 개별 업로드(각 1.5MiB, 합 9MiB > 6MiB)한 뒤 그 6개 전부를 참조하는
+    send_message 는 400 — 우회 봉쇄. 이전(fix 前)엔 message-level 캡(10)만 걸려 통과했다."""
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.conversations import (
+        MessageAttachment,
+        SendMessageRequest,
+        UploadConversationAttachmentRequest,
+        send_message,
+        upload_conversation_attachment,
+    )
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        uploaded: list[MessageAttachment] = []
+        async with Session() as s:
+            for i in range(6):
+                raw = b"a" * (1024 * 1024)  # 1MiB (per-file 2MiB 캡 안쪽)
+                body = UploadConversationAttachmentRequest(
+                    content_base64=base64.b64encode(raw).decode(),
+                    name=f"f{i}.bin", content_type="application/octet-stream",
+                )
+                resp = await upload_conversation_attachment(
+                    CONV, body, db=s, auth=_auth(AGENT), org_id=ORG,
+                )
+                uploaded.append(resp)
+
+        assert all("/mcp/" in a.url for a in uploaded)
+        total = sum(a.size for a in uploaded)
+        assert len(uploaded) == 6 and total == 6 * 1024 * 1024  # 6개>5·6MiB 경계선 초과
+
+        async with Session() as s:
+            send_body = SendMessageRequest(content="here are my files", attachments=uploaded)
+            with pytest.raises(HTTPException) as ei:
+                await send_message(
+                    CONV, send_body, BackgroundTasks(), db=s, auth=_auth(AGENT), org_id=ORG,
+                )
+            assert ei.value.status_code == 400
+
+            # 부분 커밋 없음 확인 — 메시지가 실제로 생성 안 됐는지.
+            cnt = (await s.execute(
+                text("SELECT count(*) FROM conversation_messages WHERE conversation_id=:c"),
+                {"c": CONV},
+            )).scalar_one()
+            assert cnt == 0
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_within_declared_limit_send_message_succeeds(monkeypatch, tmp_path):
+    """5개 이하·6MiB 이하면 정상 전송(회귀0 — 정당한 사용은 막히지 않음)."""
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.conversations import (
+        SendMessageRequest,
+        UploadConversationAttachmentRequest,
+        send_message,
+        upload_conversation_attachment,
+    )
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        uploaded = []
+        async with Session() as s:
+            for i in range(3):
+                raw = b"a" * (1024 * 1024)
+                body = UploadConversationAttachmentRequest(
+                    content_base64=base64.b64encode(raw).decode(),
+                    name=f"ok{i}.bin", content_type="application/octet-stream",
+                )
+                uploaded.append(await upload_conversation_attachment(
+                    CONV, body, db=s, auth=_auth(AGENT), org_id=ORG,
+                ))
+
+        async with Session() as s:
+            send_body = SendMessageRequest(content="within limit", attachments=uploaded)
+            resp = await send_message(
+                CONV, send_body, BackgroundTasks(), db=s, auth=_auth(AGENT), org_id=ORG,
+            )
+            assert resp["data"]["id"]
+    finally:
+        async with Session() as s:
+            await s.execute(text("DELETE FROM conversation_messages WHERE conversation_id=:c"), {"c": CONV})
+            await s.commit()
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_fe_uploaded_non_mcp_attachments_unaffected_by_mcp_cap(monkeypatch, tmp_path):
+    """FE(비-MCP) 첨부는 mcp/ 마커가 없어 이 새 한도의 영향을 받지 않는다(회귀0) — 6개(>5)를 FE-style
+    bare path 로 시뮬레이션해도 send_message 는 (기존 message-level 캡 10 이내라면) 통과해야 한다."""
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.conversations import MessageAttachment, SendMessageRequest, send_message
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        # FE-style 업로드 시뮬레이션 — mcp/ 세그먼트 없는 bare path(실제 FE 라우트가 만드는 shape).
+        fe_attachments = [
+            MessageAttachment(
+                url=f"org/{ORG}/project/{PROJ}/chat/{CONV}/{uuid.uuid4()}-f{i}.png",
+                name=f"f{i}.png", content_type="image/png", size=1024 * 1024,
+            )
+            for i in range(6)
+        ]
+        async with Session() as s:
+            send_body = SendMessageRequest(content="fe upload", attachments=fe_attachments)
+            resp = await send_message(
+                CONV, send_body, BackgroundTasks(), db=s, auth=_auth(AGENT), org_id=ORG,
+            )
+            assert resp["data"]["id"]
+    finally:
+        async with Session() as s:
+            await s.execute(text("DELETE FROM conversation_messages WHERE conversation_id=:c"), {"c": CONV})
+            await s.commit()
+        await eng.dispose()


### PR DESCRIPTION
## Summary
Bundles three MINOR BE findings from S2/S3 까심 QA (#3, FE stale rail flicker, was fixed separately by 미르코 in PR #1890):

**#2 — attachment declared-cap bypass (SSOT principle, not a security hole)**: `upload_conversation_attachment` only checked per-file size (2MiB), never the declared aggregate policy (5 files/6MiB total — the same limit `sprintable_mcp`'s client enforces). A participant could call it repeatedly (each call under the per-file cap) and accumulate up to the existing message-level cap (10 files, ~20MiB) before ever calling `send_message`, bypassing the declared MCP policy entirely — bounded (not unbounded), but breaks the "declared limit is authoritative" principle.

Fix: tag objects this endpoint creates with a `mcp/` path segment (server-controlled — the client only supplies a filename suffix, can't spoof or escape it), and have `send_message` re-validate the aggregate count/size of just the mcp-tagged attachments referenced in that specific message against the declared limit. No new schema or time-windowed tracking — message-create time is the one point where all of a message's attachment references are already assembled together, so that's where the aggregate concept naturally lives. FE-uploaded attachments (no `mcp/` segment) are completely unaffected by this new check.

**#4 — verify-connection transport asymmetry**: the `http`-transport early return happened *before* the stdio path's "agent has no project scope" 400 guard, so an unassigned agent got 400 via stdio but 200 via http. Reordered so both transports gate identically.

**#5 — dynamic transport telemetry**: `first_auth_seen`'s funnel event hardcoded `transport="stdio"` unconditionally, but that auth-resolution path (`_resolve_api_key`) is a generic entry point used by every API-key-authenticated request — it has no way to know which transport originated the call. Added a self-reported `X-MCP-Transport` header (both stdio and http `sprintable_mcp` clients send it via the same central `request()` method) and threaded it through `get_current_user` → `_resolve_api_key` → `_persist_first_auth_seen`, falling back to `"stdio"` when absent (older clients, non-MCP direct API callers — matches the prior unconditional behavior exactly, zero regression for anyone not sending the new header yet).

## Test plan
- [x] Real Postgres + real local storage round-trip for #2: 6 individual sub-2MiB uploads (6MiB total, over the 6-file... over the 5-file/6MiB declared cap) followed by one `send_message` referencing all 6 → 400, zero message rows persisted. Within-limit case (3 files) → 201 succeeds. FE-style (non-`mcp/`-tagged) attachments unaffected by the new cap even at the same count/size.
- [x] Negative-tested #2: disabled the new aggregate check, confirmed the bypass test genuinely fails (message created despite exceeding declared limits), restored.
- [x] #4: new tests confirm both transports now 400 identically for an unassigned agent; confirmed the reorder doesn't affect the existing assigned-agent http-skip-SSE behavior.
- [x] #5: confirmed `_persist_first_auth_seen` records the passed transport, falls back to `"stdio"` when none passed, `get_current_user` threads the header through, and `sprintable_mcp`'s client actually sends `X-MCP-Transport` on every request.
- [x] 65 pre-existing OB-1/OB-2/OB-2-align/S3-hosted-transport/E-MCP-HTTP-S1 tests pass unchanged.
- [x] Full backend suite: 2959 passed, 0 regressions (same 6 pre-existing unrelated failures — live-E2E hardcoded tool-count drift + local `.mcp.json` environment-config drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)