### PR TITLE
fix(epics): restore mobile scroll — missing min-h-0 (선생님 제보)

### DIFF
--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -906,11 +906,14 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
       </div>
 
       {/* Mobile layout */}
-      <div className="flex flex-1 flex-col overflow-hidden lg:hidden">
+      {/* min-h-0 필수 — 없으면 flex item 기본 min-height:auto가 content 높이만큼 커져
+          이 wrapper의 overflow-hidden이 하단 콘텐츠를 스크롤 불가하게 clip한다(desktop
+          분기 L893의 min-h-0와 동형·모바일 스크롤 불가 재현+근본 확인 후 정정). */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden lg:hidden">
         {mobileView === 'list' ? (
-          <div className="flex-1">{listPanel}</div>
+          <div className="min-h-0 flex-1">{listPanel}</div>
         ) : (
-          <div className="flex-1">
+          <div className="min-h-0 flex-1">
             {selectedEpic ? (
               <EpicDetailPanel
                 epic={selectedEpic}


### PR DESCRIPTION
## Summary
- **Reported**: epics page doesn't scroll on mobile (선생님, seen on prod app.sprintable.ai). Other pages scroll fine — local to the epics page.
- **Reproduced** on deployed dev FE (`sprintable-frontend-dev-57iommnikq-du.a.run.app/epics`) at a 390×844 viewport via Puppeteer: the mobile-only list/detail wrapper (`flex flex-1 flex-col overflow-hidden lg:hidden`) measured `scrollHeight: 3073` vs `clientHeight: 796` with `overflowY: hidden` and computed `min-height: auto` — the classic missing-`min-h-0` flex trap. ~2277px of epic cards were clipped with literally no scrollbar anywhere (native page scroll never engaged either, since the wrapper never grows the ancestor scroll container's height — it just clips in place).
- **Root cause confirmed by comparison**: the *desktop* branch two lines above (`hidden min-h-0 flex-1 overflow-hidden lg:flex ...`) already carries `min-h-0` on its equivalent wrapper. The mobile-only branch (and the two `flex-1` inner wrappers around the list/detail panels) never got it — this has been present since the epics page was first added (`de971a92d`, 2026-04-25), not a recent regression.
- **Fix**: add `min-h-0` to the mobile wrapper and its two `flex-1` children, mirroring the desktop pattern exactly.
- **Live-verified the fix itself** (pre-merge, can't deploy yet): patched the deployed page's live DOM with the equivalent `min-height:0` change and re-measured — wrapper's `scrollHeight` collapsed to match `clientHeight` (796=796, properly bounded now), and the *intended* internal scroll container (`listPanel`'s `overflow-y-auto` body, previously starved of a bounded parent height) took over as the actual scroller (`scrollHeight: 3031` vs `clientHeight: 754`, `overflowY: auto`) and responded correctly to `scrollTop` — screenshotted the previously-clipped epics (E-ADMIN, E-STORAGE-SSOT, E-ONBOARDING-DX, etc.) now reachable by scroll.
- Scoped to the epics list page only — the epic detail route (`epics/[id]/page.tsx`) has no equivalent full-screen flex/overflow wrapper (its `overflow-hidden` usages are just rounded-corner clip containers), so it's unaffected and untouched.

## Test plan
- [x] tsc: 0 errors
- [x] eslint: 0 errors
- [x] vitest: 928 passed / 2 skipped (0 regressions — no test coverage on this page, matches existing convention)
- [x] `pnpm build`: success
- [x] Live repro + live fix-verification via Puppeteer against deployed dev FE (see above) — before/after screenshots taken
- [ ] Real-device mobile pixel post-deploy (다음 게이트: 까심 QA + dev 배포 후 재확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)