### PR TITLE
feat(mcp): story/doc chat-pattern attachments (E-MCP-OPT S6, 029b7825)

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -1,11 +1,8 @@
 """E-EVENTBUS P7-A S37: conversations 테이블 + Chat API."""
 from __future__ import annotations
 
-import base64
-import binascii
 import json
 import logging
-import re
 import uuid
 from collections import defaultdict
 from datetime import datetime, timezone
@@ -29,7 +26,8 @@ from app.routers.events import _push_to_agent, publish_event
 from app.schemas.attachment import validate_attachment_url
 from app.services import chat_presence
 from app.services.agent_runtime import supports_deterministic_command
-from app.services.asset_registry import DEFAULT_CONTAINER, canonical_object_path, sync_attachment_assets
+from app.services import mcp_attachment_upload
+from app.services.asset_registry import DEFAULT_CONTAINER, sync_attachment_assets
 from app.services.command_classifier import classify_command
 from app.services.event_seq import assign_recipient_seq
 from app.services.member_resolver import (
@@ -586,40 +584,16 @@ class ConversationResponse(BaseModel):
 _MAX_ATTACHMENTS = 10
 _MAX_ATTACHMENT_SIZE = 100 * 1024 * 1024  # 100MB (메타 sanity 상한)
 
-# E-MCP-OPT S2(bbfd24ba): MCP(비-브라우저) 클라이언트용 JSON/base64 업로드 — 스샷/작은 문서가
-# 실사용(대용량 아님). FE-proxy 100MB 캡과 별개로 더 작게(Cloud Run HTTP/1 32MiB 요청 캡 대비
-# 여유 마진). sprintable_mcp 의 동일 상수(tools/chat.py `_MCP_MAX_ATTACHMENT_BYTES`)와 정합.
-_MAX_JSON_ATTACHMENT_UPLOAD_SIZE = 2 * 1024 * 1024  # 2MiB decoded
-_MAX_ATTACHMENT_NAME_LEN = 255
-_SAFE_ATTACHMENT_NAME_RE = re.compile(r"[^\w.\-]+")
-# E-MCP-OPT S5(#2, 까심 QA): 위 per-file 2MiB 캡은 걸지만 "선언 한도"(5개/6MiB 합계 — sprintable_mcp
-# `tools/chat.py` 의 client-side 가드와 동일 값)는 이 엔드포인트가 서버서 강제하지 않았다 —
-# participant 가 여러 번 개별 호출로(각 ≤2MiB) 메시지당 최대 10개(기존 `_MAX_ATTACHMENTS`)×2MiB≈
-# 20MiB 를 모아 SSOT 정책을 우회할 수 있었다(보안 취약점 아님·기존 message-level 캡으로 bounded — SSOT
-# 원칙 위반). object_path 에 `mcp/` 세그먼트를 심어 이 엔드포인트로 실제 업로드된 첨부만 식별하고,
-# `send_message` 가 그 부분집합에 한해 선언 한도를 재검증한다(새 테이블/시간창 추적 0 — 메시지 생성
-# 시점 1회 재검증으로 충분·메시지 없이 업로드만 반복하는 건 orphan blob 만 남길 뿐 이 한도와 무관).
-_MCP_MAX_ATTACHMENTS = 5
-_MCP_MAX_TOTAL_ATTACHMENT_BYTES = 6 * 1024 * 1024  # 6MiB decoded
+# E-MCP-OPT S2(bbfd24ba)/S6: MCP(비-브라우저) 클라이언트용 JSON/base64 업로드 공용 프리미티브
+# (S6 부터 story/doc 도 공유 — `app/services/mcp_attachment_upload.py` 참조).
+_MAX_JSON_ATTACHMENT_UPLOAD_SIZE = mcp_attachment_upload.MAX_JSON_ATTACHMENT_UPLOAD_SIZE
+_MAX_ATTACHMENT_NAME_LEN = mcp_attachment_upload.MAX_ATTACHMENT_NAME_LEN
+_MCP_MAX_ATTACHMENTS = mcp_attachment_upload.MCP_MAX_ATTACHMENTS
+_MCP_MAX_TOTAL_ATTACHMENT_BYTES = mcp_attachment_upload.MCP_MAX_TOTAL_ATTACHMENT_BYTES
 
 
 def _is_mcp_upload_object_path(url: str) -> bool:
-    """이 url 이 `upload_conversation_attachment`(MCP JSON 업로드)로 실제 생성된 객체 경로인지.
-
-    그 엔드포인트만 `org/<org>/project/<project>/chat/<conversation>/mcp/<file>` 형태(6번째
-    segment=``mcp``)로 서버가 직접 object_path 를 구성한다 — client 는 ``name``(파일명 suffix)
-    외에는 경로에 관여할 수 없어 이 segment 를 조작해 자신에게 더 엄격한 검사를 켜는 것 외엔
-    스푸핑 이득이 없다(false-positive 는 harmless·false-negative 는 발생하지 않음 — 이 엔드포인트가
-    쓰는 유일한 shape).
-    """
-    canon = canonical_object_path(url, DEFAULT_CONTAINER)
-    if not canon:
-        return False
-    parts = canon.split("/")
-    return (
-        len(parts) >= 7
-        and parts[0] == "org" and parts[2] == "project" and parts[4] == "chat" and parts[6] == "mcp"
-    )
+    return mcp_attachment_upload.is_mcp_upload_object_path(url, kind="chat")
 
 
 class MessageAttachment(BaseModel):
@@ -1526,11 +1500,6 @@ async def send_message(
     return response
 
 
-def _safe_attachment_filename(name: str) -> str:
-    safe = _SAFE_ATTACHMENT_NAME_RE.sub("_", name.strip())[-128:]
-    return safe or "file"
-
-
 @router.post(
     "/{conversation_id}/attachments",
     status_code=201,
@@ -1569,26 +1538,17 @@ async def upload_conversation_attachment(
     if participant is None:
         raise HTTPException(status_code=403, detail="Not a participant")
 
-    try:
-        data = base64.b64decode(body.content_base64, validate=True)
-    except (binascii.Error, ValueError):
-        raise HTTPException(status_code=400, detail="content_base64 must be valid base64")
-    if not data:
-        raise HTTPException(status_code=400, detail="attachment must not be empty")
-    if len(data) > _MAX_JSON_ATTACHMENT_UPLOAD_SIZE:
-        raise HTTPException(
-            status_code=413,
-            detail=f"attachment too large (max {_MAX_JSON_ATTACHMENT_UPLOAD_SIZE} bytes)",
-        )
+    data = mcp_attachment_upload.decode_json_attachment(body.content_base64)
 
-    safe_name = _safe_attachment_filename(body.name)
+    safe_name = mcp_attachment_upload.safe_attachment_filename(body.name)
     # S7 namespace — FE 업로드 라우트(apps/web .../conversations/[id]/attachments/route.ts)와 동일
     # 접두(org/<org>/project/<project>/chat/<conv>/...). path_in_source_scope 는 이 접두까지만
     # segment-match 하므로(그 뒤 세그먼트 수는 안 봄) 추가된 `mcp/` 세그먼트는 IDOR 가드/read-authorize
     # 통과에 영향 없다 — E-MCP-OPT S5(#2): 이 엔드포인트로 실제 생성된 객체만 식별하는 마커
     # (`_is_mcp_upload_object_path`)로 send_message 의 선언 한도 재검증이 소비한다.
-    object_path = (
-        f"org/{org_id}/project/{conv.project_id}/chat/{conversation_id}/mcp/{uuid.uuid4()}-{safe_name}"
+    object_path = mcp_attachment_upload.build_mcp_object_path(
+        org_id=org_id, project_id=conv.project_id, kind="chat", resource_id=conversation_id,
+        safe_name=safe_name,
     )
 
     uploaded = await get_storage_provider().put_object(

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -3,7 +3,7 @@ import uuid
 from datetime import datetime
 
 from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -741,4 +741,133 @@ async def register_doc_asset(
     await session.commit()
     return DocAssetRegisterResponse(
         asset_id=asset_id, filename=body.filename, size=real_size, mime=body.mime
+    )
+
+
+class UploadDocAttachmentRequest(BaseModel):
+    """E-MCP-OPT S6: MCP(비-브라우저)용 JSON/base64 첨부 업로드 요청(chat/story와 동형)."""
+
+    content_base64: str
+    name: str
+    content_type: str
+
+    @field_validator("content_base64", "name", "content_type")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("must not be empty")
+        return v
+
+    @field_validator("content_type")
+    @classmethod
+    def _content_type_sane(cls, v: str) -> str:
+        from app.services import mcp_attachment_upload
+        if len(v) > mcp_attachment_upload.MAX_ATTACHMENT_NAME_LEN or any(ord(ch) < 32 for ch in v):
+            raise ValueError("invalid content_type")
+        return v
+
+
+class UploadDocAttachmentResponse(BaseModel):
+    asset_id: uuid.UUID
+    filename: str
+    size: int
+    mime: str | None = None
+    # E-MCP-OPT S6: 에이전트가 doc 임베드 마크업(TipTap file-node/image-node 계약)을 몰라도 되게
+    # MCP 패키지가 그대로 content 에 붙일 수 있는 완성 HTML 스니펫. doc-content-renderer.tsx/
+    # file-node.tsx/image-node.tsx 의 실 렌더 계약과 정확히 일치(uploader 무관 렌더 — FE 변경 0).
+    embed_snippet: str
+
+
+def _build_doc_attachment_embed_snippet(
+    *, asset_id: uuid.UUID, name: str, content_type: str, size: int,
+) -> str:
+    """FE `file-node.tsx`/`image-node.tsx` renderHTML 계약과 정확히 일치하는 마크업 조립.
+
+    이미지(mime image/*) → `<img data-asset-id data-filename data-size data-mime-type alt>`.
+    그 외 → `<div data-type="fileAttachment" data-filename data-size data-mime-type data-asset-id>`.
+    파일명은 doc content(HTML)에 그대로 꽂히므로 attribute-context escape 필수(주입 방지).
+    """
+    import html as _html
+
+    safe_name = _html.escape(name, quote=True)
+    safe_mime = _html.escape(content_type or "application/octet-stream", quote=True)
+    if (content_type or "").lower().startswith("image/"):
+        return (
+            f'<img data-asset-id="{asset_id}" data-filename="{safe_name}" '
+            f'data-size="{size}" data-mime-type="{safe_mime}" alt="{safe_name}">'
+        )
+    return (
+        f'<div data-type="fileAttachment" data-filename="{safe_name}" data-size="{size}" '
+        f'data-mime-type="{safe_mime}" data-asset-id="{asset_id}"></div>'
+    )
+
+
+@router.post(
+    "/{doc_id}/attachments", response_model=UploadDocAttachmentResponse, status_code=201,
+)
+async def upload_doc_attachment(
+    doc_id: uuid.UUID,
+    body: UploadDocAttachmentRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> UploadDocAttachmentResponse:
+    """E-MCP-OPT S6: 비-브라우저 클라이언트(MCP)용 JSON/base64 doc 첨부 업로드 + 즉시 등록.
+
+    `register_doc_asset`(FE 2단계: FE putObject → 이 register)와 달리 MCP 는 base64 업로드+등록을
+    한 호출로 합친다(FE 세션 없이 base64 만으로 완결). 인가/등록 로직은 `register_doc_asset`과 동일
+    (has_project_access·sync_attachment_assets) — doc 은 업로드=등록이 곧 종결 액션이라(story/chat과
+    달리 별도 "메시지 생성" 시점이 없음) S5식 집계 재검증이 불필요하다(이 한 호출 자체가 그 지점).
+    """
+    from app.models.doc import Doc
+    from app.services import mcp_attachment_upload
+    from app.services.asset_registry import DEFAULT_CONTAINER, sync_attachment_assets
+    from app.services.member_resolver import resolve_member
+    from app.services.project_auth import has_project_access
+    from app.services.storage import get_storage_provider
+
+    doc = (await session.execute(
+        select(Doc).where(Doc.id == doc_id, Doc.org_id == org_id, Doc.deleted_at.is_(None))
+    )).scalar_one_or_none()
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Doc not found")
+    if not await has_project_access(session, uuid.UUID(auth.user_id), doc.project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
+    data = mcp_attachment_upload.decode_json_attachment(body.content_base64)
+    safe_name = mcp_attachment_upload.safe_attachment_filename(body.name)
+    object_path = mcp_attachment_upload.build_mcp_object_path(
+        org_id=org_id, project_id=doc.project_id, kind="doc", resource_id=doc_id, safe_name=safe_name,
+    )
+
+    uploaded = await get_storage_provider().put_object(
+        DEFAULT_CONTAINER, object_path, data, content_type=body.content_type,
+    )
+    if not uploaded:
+        raise HTTPException(status_code=502, detail="upload failed")
+
+    created_by: uuid.UUID | None = None
+    try:
+        created_by = (await resolve_member(auth, org_id, session)).id
+    except Exception:  # noqa: BLE001 — created_by 는 비필수(asset.created_by nullable).
+        created_by = None
+
+    att = {"url": object_path, "name": body.name, "content_type": body.content_type, "size": len(data)}
+    url_map = await sync_attachment_assets(
+        session, org_id=org_id, project_id=doc.project_id, source_type="doc",
+        source_id=doc_id, attachments=[att], created_by=created_by,
+    )
+    asset_id = url_map.get(object_path)
+    if asset_id is None:
+        # 우리가 방금 쓴 path 가 우리가 만든 접두를 못 지나면 path_in_source_scope 버그(방어적 500) —
+        # register_doc_asset 의 400(client 경로 스푸핑)과 원인이 다르므로 구분한다.
+        raise HTTPException(status_code=500, detail="asset registration failed for uploaded object")
+    await session.commit()
+
+    return UploadDocAttachmentResponse(
+        asset_id=asset_id, filename=body.name, size=len(data), mime=body.content_type,
+        embed_snippet=_build_doc_attachment_embed_snippet(
+            asset_id=asset_id, name=body.name, content_type=body.content_type, size=len(data),
+        ),
     )

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Query, Response
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -17,8 +17,9 @@ from app.repositories.story_assignee import StoryAssigneeRepository
 from app.routers.agent_gateway import wake_agent
 from app.routers.events import publish_event
 from app.services.event_seq import assign_recipient_seq
-from app.services.asset_registry import sync_attachment_assets
-from app.schemas.story import StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
+from app.services import mcp_attachment_upload
+from app.services.asset_registry import DEFAULT_CONTAINER, sync_attachment_assets
+from app.schemas.story import StoryAttachment, StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
 from app.services.member_resolver import canonicalize_member_id
 from app.services.merge_verdict_gate import (
     AUTO_MERGE,
@@ -200,6 +201,23 @@ async def _preflight_merge_gate(
         )
 
 
+def _enforce_mcp_attachment_declared_limit(attachments: list[dict]) -> None:
+    """E-MCP-OPT S6: chat(S5 #2)과 동일 갭을 story 에서 처음부터 막는다 — mcp-태그 첨부(dict shape:
+    url/size 키) 부분집합만 선언한도(5개/6MiB) 재검증. FE 업로드 첨부(마커 없음)는 무관."""
+    mcp_origin = [a for a in attachments if mcp_attachment_upload.is_mcp_upload_object_path(a["url"], kind="story")]
+    if len(mcp_origin) > mcp_attachment_upload.MCP_MAX_ATTACHMENTS or (
+        sum(a["size"] for a in mcp_origin) > mcp_attachment_upload.MCP_MAX_TOTAL_ATTACHMENT_BYTES
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"mcp attachments exceed declared limit "
+                f"(max {mcp_attachment_upload.MCP_MAX_ATTACHMENTS} files / "
+                f"{mcp_attachment_upload.MCP_MAX_TOTAL_ATTACHMENT_BYTES} bytes total)"
+            ),
+        )
+
+
 @router.post("", response_model=StoryResponse, status_code=201)
 async def create_story(
     body: StoryCreate,
@@ -226,6 +244,8 @@ async def create_story(
         body.assignee_id if body.assignee_id is not None
         else (effective_ids[0] if effective_ids else None)
     )
+    if body.attachments:
+        _enforce_mcp_attachment_declared_limit([a.model_dump() for a in body.attachments])
     # S8: 서버사이드 capacity 게이트(ee seam·SaaS only·OSS no-op) — asset commit 前 per-file+총량 enforce.
     if settings.is_ee_enabled and body.attachments:
         from ee.plan_limits import check_storage_capacity  # type: ignore[import]
@@ -326,6 +346,72 @@ async def get_story(
         raise HTTPException(status_code=404, detail="Story not found")
     await _attach_assignee_ids(repo.session, repo.org_id, [story])
     return StoryResponse.model_validate(story)
+
+
+class UploadStoryAttachmentRequest(BaseModel):
+    """E-MCP-OPT S6: MCP(비-브라우저)용 JSON/base64 첨부 업로드 요청(chat과 동형)."""
+
+    content_base64: str
+    name: str
+    content_type: str
+
+    @field_validator("content_base64", "name", "content_type")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("must not be empty")
+        return v
+
+    @field_validator("content_type")
+    @classmethod
+    def _content_type_sane(cls, v: str) -> str:
+        if len(v) > mcp_attachment_upload.MAX_ATTACHMENT_NAME_LEN or any(ord(ch) < 32 for ch in v):
+            raise ValueError("invalid content_type")
+        return v
+
+
+@router.post(
+    "/{id}/attachments", status_code=201, response_model=StoryAttachment, response_model_exclude_none=True,
+)
+async def upload_story_attachment(
+    id: uuid.UUID,
+    body: UploadStoryAttachmentRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> StoryAttachment:
+    """E-MCP-OPT S6: 비-브라우저 클라이언트(MCP)용 JSON/base64 스토리 첨부 업로드(chat과 동형).
+
+    인가 = `has_project_access`(story.project_id) — `register_doc_asset`/`enforce_body_context`(story
+    create)와 동일 SSOT. object_path 는 FE 업로드 라우트(`apps/web/.../stories/[id]/attachments/
+    route.ts`)와 동일 접두(org/<org>/project/<project>/story/<id>/...)+`mcp/` 마커(S5 패턴 재사용) —
+    create/update_story 가 그 부분집합만 선언한도(5개/6MiB)를 재검증한다.
+    """
+    story = (await session.execute(
+        select(Story).where(Story.id == id, Story.org_id == org_id)
+    )).scalar_one_or_none()
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(session, uuid.UUID(auth.user_id), story.project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
+    data = mcp_attachment_upload.decode_json_attachment(body.content_base64)
+    safe_name = mcp_attachment_upload.safe_attachment_filename(body.name)
+    object_path = mcp_attachment_upload.build_mcp_object_path(
+        org_id=org_id, project_id=story.project_id, kind="story", resource_id=id, safe_name=safe_name,
+    )
+
+    from app.services.storage import get_storage_provider
+    uploaded = await get_storage_provider().put_object(
+        DEFAULT_CONTAINER, object_path, data, content_type=body.content_type,
+    )
+    if not uploaded:
+        raise HTTPException(status_code=502, detail="upload failed")
+
+    return StoryAttachment(url=object_path, name=body.name, content_type=body.content_type, size=len(data))
 
 
 # E-DG S10(P1-4 observability): workflow-line 상태 read API — "왜 막혔나·어디로 relay 됐나"를
@@ -505,6 +591,7 @@ async def update_story(
     # S7: client 제공 asset_id strip(서버 권위·drift 방지·까심)·아래 sync url_map 으로만 역기입.
     if data.get("attachments"):
         data["attachments"] = [{**a, "asset_id": None} for a in data["attachments"]]
+        _enforce_mcp_attachment_declared_limit(data["attachments"])
         # S8: 서버사이드 capacity 게이트(ee seam·SaaS only·OSS no-op) — 첨부 교체 commit 前 enforce.
         if settings.is_ee_enabled:
             from ee.plan_limits import check_storage_capacity  # type: ignore[import]

--- a/backend/app/services/mcp_attachment_upload.py
+++ b/backend/app/services/mcp_attachment_upload.py
@@ -1,0 +1,75 @@
+"""E-MCP-OPT: MCP(비-브라우저) JSON/base64 첨부 업로드 공용 프리미티브 — S2(chat)·S6(story/doc) 공유.
+
+3번째 리소스 종류(story) 추가 시점에 chat 전용이던 상수/헬퍼를 여기로 추출(S2/S5 당시엔 chat 하나뿐이라
+로컬이었음). 값/로직은 chat 과 100% 동일(정합 유지) — object_path 의 5번째 세그먼트(kind)만 리소스별로
+다르다(chat|story|doc).
+"""
+from __future__ import annotations
+
+import base64
+import binascii
+import re
+import uuid
+
+from fastapi import HTTPException
+
+from app.services.asset_registry import DEFAULT_CONTAINER, canonical_object_path
+
+# 스샷/작은 문서가 실사용(대용량 아님). FE-proxy 100MB 캡과 별개로 더 작게(Cloud Run HTTP/1 32MiB 요청
+# 캡 대비 여유 마진). sprintable_mcp 의 동일 상수(tools/*.py)와 정합.
+MAX_JSON_ATTACHMENT_UPLOAD_SIZE = 2 * 1024 * 1024  # 2MiB decoded (per-file)
+MAX_ATTACHMENT_NAME_LEN = 255
+# 선언 한도(5개/6MiB 합계) — sprintable_mcp client-side 가드와 동일 값. 업로드 엔드포인트가 개별
+# 호출만 파일당 캡을 걸면 다회 호출로 이 선언 한도를 우회할 수 있어(S5 #2), 종결 액션(chat=send_message·
+# story=create/update) 에서 mcp-태그 부분집합에 한해 재검증한다. doc 은 업로드=즉시 등록이 종결 액션
+# 자체라 별도 재검증 불요(모듈별 라우터에서 각자 판단).
+MCP_MAX_ATTACHMENTS = 5
+MCP_MAX_TOTAL_ATTACHMENT_BYTES = 6 * 1024 * 1024  # 6MiB decoded (total)
+
+_SAFE_ATTACHMENT_NAME_RE = re.compile(r"[^\w.\-]+")
+
+
+def safe_attachment_filename(name: str) -> str:
+    safe = _SAFE_ATTACHMENT_NAME_RE.sub("_", name.strip())[-128:]
+    return safe or "file"
+
+
+def decode_json_attachment(content_base64: str, *, max_size: int = MAX_JSON_ATTACHMENT_UPLOAD_SIZE) -> bytes:
+    """base64 디코드 + 사이즈 가드. 실패 시 HTTPException(400/413) — 라우터가 그대로 propagate."""
+    try:
+        data = base64.b64decode(content_base64, validate=True)
+    except (binascii.Error, ValueError):
+        raise HTTPException(status_code=400, detail="content_base64 must be valid base64")
+    if not data:
+        raise HTTPException(status_code=400, detail="attachment must not be empty")
+    if len(data) > max_size:
+        raise HTTPException(status_code=413, detail=f"attachment too large (max {max_size} bytes)")
+    return data
+
+
+def build_mcp_object_path(
+    *, org_id: uuid.UUID, project_id: uuid.UUID, kind: str, resource_id: uuid.UUID, safe_name: str,
+) -> str:
+    """S7 namespace + `mcp/` 마커. FE 업로드 라우트(각 리소스의 apps/web .../attachments/route.ts)와
+    동일 접두(org/<org>/project/<project>/<kind>/<resource_id>/...) — path_in_source_scope 는 그
+    접두까지만 segment-match 하므로(그 뒤 세그먼트 수는 안 봄) `mcp/` 추가가 IDOR 가드에 영향 없다.
+    """
+    return f"org/{org_id}/project/{project_id}/{kind}/{resource_id}/mcp/{uuid.uuid4()}-{safe_name}"
+
+
+def is_mcp_upload_object_path(url: str, *, kind: str, container: str = DEFAULT_CONTAINER) -> bool:
+    """이 url 이 MCP JSON 업로드 엔드포인트로 실제 생성된 객체 경로인지(리소스 종류=kind 한정).
+
+    그 엔드포인트만 `org/<org>/project/<project>/<kind>/<resource_id>/mcp/<file>` 형태(6번째
+    segment=``mcp``)로 서버가 직접 object_path 를 구성한다 — client 는 ``name``(파일명 suffix) 외에는
+    경로에 관여할 수 없어 이 segment 를 조작해 자신에게 더 엄격한 검사를 켜는 것 외엔 스푸핑 이득이
+    없다(false-positive 는 harmless·false-negative 는 발생하지 않음 — 이 엔드포인트가 쓰는 유일한 shape).
+    """
+    canon = canonical_object_path(url, container)
+    if not canon:
+        return False
+    parts = canon.split("/")
+    return (
+        len(parts) >= 7
+        and parts[0] == "org" and parts[2] == "project" and parts[4] == kind and parts[6] == "mcp"
+    )

--- a/backend/sprintable_mcp/tools/attachments.py
+++ b/backend/sprintable_mcp/tools/attachments.py
@@ -1,0 +1,72 @@
+"""E-MCP-OPT: inline base64 첨부 업로드 공용 프리미티브 — chat(S2)·story/doc(S6) 공유.
+
+3번째 리소스 종류(story) 추가 시점에 chat 전용이던 검증/업로드 로직을 여기로 추출(S2 당시엔 chat
+하나뿐이라 로컬이었음). 값/로직은 chat 과 100% 동일 — 업로드 대상 엔드포인트 경로만 호출부가 넘긴다.
+"""
+from __future__ import annotations
+
+import base64
+import binascii
+
+from ..api_client import client
+
+# 백엔드 `app/services/mcp_attachment_upload.py`의 동일 상수와 정합(client-side fail-fast 가드 —
+# MCP 페이로드 낭비 전 조기 거부).
+MAX_ATTACHMENTS = 5
+MAX_ATTACHMENT_BYTES = 2 * 1024 * 1024  # 2MiB decoded/file
+MAX_TOTAL_ATTACHMENT_BYTES = 6 * 1024 * 1024  # 6MiB decoded/total
+_MAX_ATTACHMENT_BASE64_CHARS = ((MAX_ATTACHMENT_BYTES + 2) // 3) * 4
+
+
+def validate_attachment(att: dict, index: int) -> tuple[dict, int]:
+    if not isinstance(att, dict):
+        raise ValueError(f"attachments[{index}] must be an object")
+    name = str(att.get("name") or "").strip()
+    content_type = str(att.get("content_type") or "").strip()
+    content_base64 = str(att.get("content_base64") or "").strip()
+    if not name:
+        raise ValueError(f"attachments[{index}].name is required")
+    if not content_type:
+        raise ValueError(f"attachments[{index}].content_type is required")
+    if not content_base64:
+        raise ValueError(f"attachments[{index}].content_base64 is required")
+    if len(content_base64) > _MAX_ATTACHMENT_BASE64_CHARS:
+        raise ValueError(
+            f"attachments[{index}] too large (max {MAX_ATTACHMENT_BYTES} decoded bytes)"
+        )
+    try:
+        decoded = base64.b64decode(content_base64, validate=True)
+    except (binascii.Error, ValueError):
+        raise ValueError(f"attachments[{index}].content_base64 must be valid base64")
+    if not decoded:
+        raise ValueError(f"attachments[{index}] must not be empty")
+    if len(decoded) > MAX_ATTACHMENT_BYTES:
+        raise ValueError(
+            f"attachments[{index}] too large (max {MAX_ATTACHMENT_BYTES} decoded bytes)"
+        )
+    return {"content_base64": content_base64, "name": name, "content_type": content_type}, len(decoded)
+
+
+async def upload_attachments(upload_path: str, attachments: list[dict] | None) -> list[dict]:
+    """각 첨부를 `upload_path`(리소스별 신규 업로드 엔드포인트)에 순차 업로드.
+
+    개수/사이즈 가드는 **전부 먼저 검증**(네트워크 호출 0)한 다음에야 업로드를 시작한다 — 순차
+    검증+업로드를 인터리빙하면 총량 초과가 마지막 파일에서만 드러날 때 앞선 파일들이 이미 실제
+    업로드돼 orphan blob 이 되고서야 실패하는 낭비/누출이 생긴다(S5 #2 교훈).
+    """
+    if not attachments:
+        return []
+    if len(attachments) > MAX_ATTACHMENTS:
+        raise ValueError(f"too many attachments (max {MAX_ATTACHMENTS})")
+
+    validated: list[tuple[dict, int]] = [validate_attachment(att, i) for i, att in enumerate(attachments)]
+    total_size = sum(size for _payload, size in validated)
+    if total_size > MAX_TOTAL_ATTACHMENT_BYTES:
+        raise ValueError(
+            f"attachments total too large (max {MAX_TOTAL_ATTACHMENT_BYTES} decoded bytes)"
+        )
+
+    uploaded: list[dict] = []
+    for payload, _size in validated:
+        uploaded.append(await client.post(upload_path, json=payload))
+    return uploaded

--- a/backend/sprintable_mcp/tools/chat.py
+++ b/backend/sprintable_mcp/tools/chat.py
@@ -1,8 +1,6 @@
 """채팅 MCP 도구 (3개)."""
 from __future__ import annotations
 
-import base64
-import binascii
 import logging
 
 from mcp.types import TextContent
@@ -10,15 +8,9 @@ from mcp.types import TextContent
 from ..api_client import client
 from ..response import err, ok
 from ..schemas import SprintableInput
+from .attachments import upload_attachments
 
 logger = logging.getLogger(__name__)
-
-# E-MCP-OPT S2(bbfd24ba): inline base64 첨부 — client-side fail-fast 가드(백엔드
-# `_MAX_JSON_ATTACHMENT_UPLOAD_SIZE`와 정합·MCP 페이로드 낭비 전 조기 거부).
-_MAX_ATTACHMENTS = 5
-_MAX_ATTACHMENT_BYTES = 2 * 1024 * 1024  # 2MiB decoded/file
-_MAX_TOTAL_ATTACHMENT_BYTES = 6 * 1024 * 1024  # 2MiB decoded/total
-_MAX_ATTACHMENT_BASE64_CHARS = ((_MAX_ATTACHMENT_BYTES + 2) // 3) * 4
 
 
 class SendChatInput(SprintableInput):
@@ -43,62 +35,6 @@ class ListChatMessagesInput(SprintableInput):
     before: str | None = None
 
 
-def _validate_attachment(att: dict, index: int) -> tuple[dict, int]:
-    if not isinstance(att, dict):
-        raise ValueError(f"attachments[{index}] must be an object")
-    name = str(att.get("name") or "").strip()
-    content_type = str(att.get("content_type") or "").strip()
-    content_base64 = str(att.get("content_base64") or "").strip()
-    if not name:
-        raise ValueError(f"attachments[{index}].name is required")
-    if not content_type:
-        raise ValueError(f"attachments[{index}].content_type is required")
-    if not content_base64:
-        raise ValueError(f"attachments[{index}].content_base64 is required")
-    if len(content_base64) > _MAX_ATTACHMENT_BASE64_CHARS:
-        raise ValueError(
-            f"attachments[{index}] too large (max {_MAX_ATTACHMENT_BYTES} decoded bytes)"
-        )
-    try:
-        decoded = base64.b64decode(content_base64, validate=True)
-    except (binascii.Error, ValueError):
-        raise ValueError(f"attachments[{index}].content_base64 must be valid base64")
-    if not decoded:
-        raise ValueError(f"attachments[{index}] must not be empty")
-    if len(decoded) > _MAX_ATTACHMENT_BYTES:
-        raise ValueError(
-            f"attachments[{index}] too large (max {_MAX_ATTACHMENT_BYTES} decoded bytes)"
-        )
-    return {"content_base64": content_base64, "name": name, "content_type": content_type}, len(decoded)
-
-
-async def _upload_attachments(thread_id: str, attachments: list[dict] | None) -> list[dict]:
-    """각 첨부를 신규 업로드 엔드포인트에 순차 업로드해 MessageAttachment 메타 리스트로 변환.
-
-    개수/사이즈 가드는 **전부 먼저 검증**(네트워크 호출 0)한 다음에야 업로드를 시작한다 — 순차
-    검증+업로드를 인터리빙하면 총량 초과가 마지막 파일에서만 드러날 때 앞선 파일들이 이미 실제
-    업로드돼 orphan blob 이 되고서야 실패하는 낭비/누출이 생긴다.
-    """
-    if not attachments:
-        return []
-    if len(attachments) > _MAX_ATTACHMENTS:
-        raise ValueError(f"too many attachments (max {_MAX_ATTACHMENTS})")
-
-    validated: list[tuple[dict, int]] = [_validate_attachment(att, i) for i, att in enumerate(attachments)]
-    total_size = sum(size for _payload, size in validated)
-    if total_size > _MAX_TOTAL_ATTACHMENT_BYTES:
-        raise ValueError(
-            f"attachments total too large (max {_MAX_TOTAL_ATTACHMENT_BYTES} decoded bytes)"
-        )
-
-    uploaded: list[dict] = []
-    for payload, _size in validated:
-        uploaded.append(
-            await client.post(f"/api/v2/conversations/{thread_id}/attachments", json=payload)
-        )
-    return uploaded
-
-
 async def send_chat_message(args: SendChatInput) -> list[TextContent]:
     """conversation thread에 채팅 메시지 발송."""
     payload: dict = {"content": args.content}
@@ -115,7 +51,9 @@ async def send_chat_message(args: SendChatInput) -> list[TextContent]:
         payload["metadata"] = meta
     uploaded_urls: list[str] = []
     try:
-        attachments = await _upload_attachments(args.thread_id, args.attachments)
+        attachments = await upload_attachments(
+            f"/api/v2/conversations/{args.thread_id}/attachments", args.attachments,
+        )
         uploaded_urls = [a["url"] for a in attachments if isinstance(a, dict) and a.get("url")]
         if attachments:
             payload["attachments"] = attachments

--- a/backend/sprintable_mcp/tools/docs.py
+++ b/backend/sprintable_mcp/tools/docs.py
@@ -8,6 +8,7 @@ from mcp.types import TextContent
 from ..api_client import client
 from ..response import err, ok
 from ..schemas import SprintableInput
+from .attachments import upload_attachments
 
 
 class ListDocsInput(SprintableInput):
@@ -44,6 +45,11 @@ class UpdateDocInput(SprintableInput):
     parent_id: str | None = None
     expected_updated_at: str | None = None
     force_overwrite: bool | None = None
+    # [{content_base64, name, content_type}, ...] — 스샷/작은 문서(최대 5개·파일당 2MiB·총 6MiB).
+    # 업로드 後 완성된 embed HTML(TipTap file-node/image-node 계약과 정확히 일치 — 에이전트가 마크업을
+    # 몰라도 됨)을 content 끝에 append. 이 호출에 content 를 안 실었으면 현재 저장된 content 를 먼저
+    # 읽어 그 뒤에 append(기존 본문을 지우지 않음).
+    attachments: list[dict] | None = None
 
 
 class DeleteDocInput(SprintableInput):
@@ -123,6 +129,17 @@ async def update_doc(args: UpdateDocInput) -> list[TextContent]:
     if args.force_overwrite is not None:
         updates["force_overwrite"] = args.force_overwrite
     try:
+        if args.attachments:
+            uploaded = await upload_attachments(
+                f"/api/v2/docs/{args.doc_id}/attachments", args.attachments,
+            )
+            if uploaded:
+                base_content = updates.get("content")
+                if base_content is None:
+                    current = await client.get(f"/api/v2/docs/{args.doc_id}")
+                    base_content = (current.get("content") or "") if isinstance(current, dict) else ""
+                snippets = "".join(a["embed_snippet"] for a in uploaded if isinstance(a, dict) and a.get("embed_snippet"))
+                updates["content"] = f"{base_content}\n{snippets}" if base_content else snippets
         return ok(await client.patch(f"/api/v2/docs/{args.doc_id}", json=updates))
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/stories.py
+++ b/backend/sprintable_mcp/tools/stories.py
@@ -6,6 +6,7 @@ from mcp.types import CallToolResult, TextContent
 from ..api_client import client
 from ..response import err, ok
 from ..schemas import SprintableInput, StoryPoints, StoryPriority, StoryStatus
+from .attachments import upload_attachments
 
 
 class ListStoriesInput(SprintableInput):
@@ -36,6 +37,10 @@ class UpdateStoryInput(SprintableInput):
     acceptance_criteria: str | None = None
     assignee_id: str | None = None
     epic_id: str | None = None
+    # [{content_base64, name, content_type}, ...] — 스샷/작은 문서(최대 5개·파일당 2MiB·총 6MiB).
+    # 기존 첨부에 **추가**된다(PATCH attachments 는 서버측 full-replace 라 update_story 가 먼저 기존
+    # 첨부를 읽어 병합 — 새 첨부가 기존 걸 지우지 않는다).
+    attachments: list[dict] | None = None
 
 
 class DeleteStoryInput(SprintableInput):
@@ -131,6 +136,16 @@ async def update_story(args: UpdateStoryInput) -> list[TextContent]:
     if args.epic_id is not None:
         updates["epic_id"] = args.epic_id
     try:
+        if args.attachments:
+            uploaded = await upload_attachments(
+                f"/api/v2/stories/{args.story_id}/attachments", args.attachments,
+            )
+            if uploaded:
+                # PATCH attachments 는 서버측 full-replace(교체 SSOT 재동기화) — 기존 첨부를 먼저
+                # 읽어 병합해야 새 첨부가 기존 걸 지우지 않는다.
+                current = await client.get(f"/api/v2/stories/{args.story_id}")
+                existing = current.get("attachments") or [] if isinstance(current, dict) else []
+                updates["attachments"] = existing + uploaded
         return ok(await client.patch(f"/api/v2/stories/{args.story_id}", json=updates))
     except Exception as exc:
         return err(str(exc))

--- a/backend/tests/test_e_mcp_opt_s2_chat_attachment_tool.py
+++ b/backend/tests/test_e_mcp_opt_s2_chat_attachment_tool.py
@@ -11,8 +11,11 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from sprintable_mcp.tools import attachments as attachments_mod
 from sprintable_mcp.tools import chat as chat_mod
-from sprintable_mcp.tools.chat import SendChatInput, _upload_attachments, _validate_attachment, send_chat_message
+from sprintable_mcp.tools.attachments import upload_attachments as _upload_attachments
+from sprintable_mcp.tools.attachments import validate_attachment as _validate_attachment
+from sprintable_mcp.tools.chat import SendChatInput, send_chat_message
 
 
 @pytest.fixture
@@ -53,7 +56,7 @@ def test_validate_attachment_empty_content_base64_raises():
 
 
 def test_validate_attachment_oversized_rejected_before_full_decode():
-    too_big = _b64(chat_mod._MAX_ATTACHMENT_BYTES + 1)
+    too_big = _b64(attachments_mod.MAX_ATTACHMENT_BYTES + 1)
     with pytest.raises(ValueError, match="too large"):
         _validate_attachment({"content_base64": too_big, "name": "a", "content_type": "t"}, 0)
 
@@ -61,28 +64,28 @@ def test_validate_attachment_oversized_rejected_before_full_decode():
 # ── _upload_attachments ───────────────────────────────────────────────────────
 @pytest.mark.anyio
 async def test_upload_attachments_empty_returns_empty():
-    assert await _upload_attachments("conv-1", None) == []
-    assert await _upload_attachments("conv-1", []) == []
+    assert await _upload_attachments("/api/v2/conversations/conv-1/attachments", None) == []
+    assert await _upload_attachments("/api/v2/conversations/conv-1/attachments", []) == []
 
 
 @pytest.mark.anyio
 async def test_upload_attachments_too_many_rejected():
-    atts = [{"content_base64": _b64(1), "name": f"{i}", "content_type": "t"} for i in range(chat_mod._MAX_ATTACHMENTS + 1)]
+    atts = [{"content_base64": _b64(1), "name": f"{i}", "content_type": "t"} for i in range(attachments_mod.MAX_ATTACHMENTS + 1)]
     with pytest.raises(ValueError, match="too many attachments"):
-        await _upload_attachments("conv-1", atts)
+        await _upload_attachments("/api/v2/conversations/conv-1/attachments", atts)
 
 
 @pytest.mark.anyio
 async def test_upload_attachments_total_size_exceeded_rejected_before_any_network_call():
     """총량 초과는 업로드 시작 前 전부 검증되어 걸러진다 — client.post 가 단 한 번도 안 불림
     (마지막 파일에서만 드러나는 초과였다면 앞선 파일들이 실제 업로드→orphan 되는 낭비 없음)."""
-    per_file = chat_mod._MAX_ATTACHMENT_BYTES
+    per_file = attachments_mod.MAX_ATTACHMENT_BYTES
     atts = [{"content_base64": _b64(per_file), "name": f"{i}", "content_type": "t"} for i in range(4)]
-    assert len(atts) <= chat_mod._MAX_ATTACHMENTS
-    assert per_file * 4 > chat_mod._MAX_TOTAL_ATTACHMENT_BYTES
+    assert len(atts) <= attachments_mod.MAX_ATTACHMENTS
+    assert per_file * 4 > attachments_mod.MAX_TOTAL_ATTACHMENT_BYTES
     with patch.object(chat_mod.client, "post", new=AsyncMock()) as m:
         with pytest.raises(ValueError, match="total too large"):
-            await _upload_attachments("conv-1", atts)
+            await _upload_attachments("/api/v2/conversations/conv-1/attachments", atts)
         m.assert_not_awaited()
 
 
@@ -91,7 +94,7 @@ async def test_upload_attachments_calls_endpoint_per_file():
     atts = [{"content_base64": _b64(5), "name": "a.png", "content_type": "image/png"}]
     fake_result = {"url": "org/o/project/p/chat/c/x-a.png", "name": "a.png", "content_type": "image/png", "size": 5}
     with patch.object(chat_mod.client, "post", new=AsyncMock(return_value=fake_result)) as m:
-        result = await _upload_attachments("conv-1", atts)
+        result = await _upload_attachments("/api/v2/conversations/conv-1/attachments", atts)
         assert result == [fake_result]
         m.assert_awaited_once_with(
             "/api/v2/conversations/conv-1/attachments",

--- a/backend/tests/test_e_mcp_opt_s6_shared_upload_module.py
+++ b/backend/tests/test_e_mcp_opt_s6_shared_upload_module.py
@@ -1,0 +1,86 @@
+"""E-MCP-OPT S6: `app/services/mcp_attachment_upload.py` 공용 프리미티브 — chat/story/doc 공유.
+
+S2/S5 당시 chat 전용 로컬 정의였던 것을 3번째 리소스(story) 추가 시점에 추출(DRY). 값/로직은 기존
+chat 동작과 100% 동일해야 한다 — kind 파라미터만 리소스별로 다르다.
+"""
+from __future__ import annotations
+
+import base64
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+from app.services import mcp_attachment_upload as m
+
+
+def test_constants_match_previous_chat_values():
+    assert m.MAX_JSON_ATTACHMENT_UPLOAD_SIZE == 2 * 1024 * 1024
+    assert m.MCP_MAX_ATTACHMENTS == 5
+    assert m.MCP_MAX_TOTAL_ATTACHMENT_BYTES == 6 * 1024 * 1024
+
+
+def test_safe_attachment_filename_sanitizes_and_truncates():
+    assert m.safe_attachment_filename("../../evil/../x.png") == ".._.._evil_.._x.png"
+    assert m.safe_attachment_filename("") == "file"
+    assert m.safe_attachment_filename("   ") == "file"
+    assert len(m.safe_attachment_filename("a" * 300)) <= 128
+
+
+def test_decode_json_attachment_valid():
+    raw = b"hello world"
+    data = m.decode_json_attachment(base64.b64encode(raw).decode())
+    assert data == raw
+
+
+def test_decode_json_attachment_invalid_base64_400():
+    with pytest.raises(HTTPException) as ei:
+        m.decode_json_attachment("not-valid-base64!!!")
+    assert ei.value.status_code == 400
+
+
+def test_decode_json_attachment_empty_400():
+    with pytest.raises(HTTPException) as ei:
+        m.decode_json_attachment(base64.b64encode(b"").decode())
+    assert ei.value.status_code == 400
+
+
+def test_decode_json_attachment_oversized_413():
+    oversized = base64.b64encode(b"a" * (m.MAX_JSON_ATTACHMENT_UPLOAD_SIZE + 1)).decode()
+    with pytest.raises(HTTPException) as ei:
+        m.decode_json_attachment(oversized)
+    assert ei.value.status_code == 413
+
+
+def test_build_mcp_object_path_shape():
+    org = uuid.uuid4()
+    proj = uuid.uuid4()
+    conv = uuid.uuid4()
+    path = m.build_mcp_object_path(org_id=org, project_id=proj, kind="chat", resource_id=conv, safe_name="x.png")
+    parts = path.split("/")
+    assert parts[0] == "org" and parts[1] == str(org)
+    assert parts[2] == "project" and parts[3] == str(proj)
+    assert parts[4] == "chat" and parts[5] == str(conv)
+    assert parts[6] == "mcp"
+    assert parts[7].endswith("-x.png")
+
+
+@pytest.mark.parametrize("kind", ["chat", "story", "doc"])
+def test_is_mcp_upload_object_path_per_kind(kind):
+    org, proj, rid = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    path = m.build_mcp_object_path(org_id=org, project_id=proj, kind=kind, resource_id=rid, safe_name="a.bin")
+    assert m.is_mcp_upload_object_path(path, kind=kind) is True
+    # 다른 kind 로는 매칭 안 됨(교차 오염 방지).
+    other = "story" if kind != "story" else "doc"
+    assert m.is_mcp_upload_object_path(path, kind=other) is False
+
+
+def test_is_mcp_upload_object_path_rejects_non_mcp_path():
+    assert m.is_mcp_upload_object_path("org/o/project/p/story/s/uuid-x.png", kind="story") is False
+
+
+def test_is_mcp_upload_object_path_handles_gcs_public_url():
+    org, proj, rid = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    path = m.build_mcp_object_path(org_id=org, project_id=proj, kind="doc", resource_id=rid, safe_name="a.bin")
+    gcs_url = f"https://storage.googleapis.com/{m.DEFAULT_CONTAINER if hasattr(m, 'DEFAULT_CONTAINER') else 'sprintable-memo-attachments'}/{path}"
+    assert m.is_mcp_upload_object_path(gcs_url, kind="doc") is True

--- a/backend/tests/test_e_mcp_opt_s6_story_doc_tools.py
+++ b/backend/tests/test_e_mcp_opt_s6_story_doc_tools.py
@@ -1,0 +1,156 @@
+"""E-MCP-OPT S6: `update_story`/`update_doc` MCP 도구 첨부 파라미터 — 업로드 체이닝/병합 검증.
+
+story: 업로드 결과를 PATCH attachments 에 실을 때 **기존 첨부와 병합**(서버 full-replace 이므로
+먼저 GET 으로 기존 목록을 읽어 이어붙임 — 새 첨부가 기존 걸 지우지 않음).
+doc: 업로드 응답의 embed_snippet 을 content 끝에 append(현재 content 미제공 시 GET 으로 먼저 읽음).
+"""
+from __future__ import annotations
+
+import base64
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from sprintable_mcp.tools import docs as docs_mod
+from sprintable_mcp.tools import stories as stories_mod
+from sprintable_mcp.tools.docs import UpdateDocInput, update_doc
+from sprintable_mcp.tools.stories import UpdateStoryInput, update_story
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _b64(n: int) -> str:
+    return base64.b64encode(b"x" * n).decode()
+
+
+# ── story ──────────────────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_update_story_no_attachments_unchanged_payload():
+    args = UpdateStoryInput(story_id="s1", title="new title")
+    with patch.object(stories_mod.client, "patch", new=AsyncMock(return_value={})) as m:
+        await update_story(args)
+        _, kwargs = m.call_args
+        assert "attachments" not in kwargs["json"]
+
+
+@pytest.mark.anyio
+async def test_update_story_merges_new_attachments_with_existing():
+    args = UpdateStoryInput(
+        story_id="s1",
+        attachments=[{"content_base64": _b64(4), "name": "new.png", "content_type": "image/png"}],
+    )
+    existing_attachment = {"url": "org/o/project/p/story/s1/old.png", "name": "old.png", "content_type": "image/png", "size": 10}
+    uploaded_attachment = {"url": "org/o/project/p/story/s1/mcp/x-new.png", "name": "new.png", "content_type": "image/png", "size": 4}
+    calls: list[tuple] = []
+
+    async def _fake_post(path, json=None):
+        calls.append(("post", path, json))
+        return uploaded_attachment
+
+    async def _fake_get(path, params=None):
+        calls.append(("get", path, None))
+        return {"attachments": [existing_attachment]}
+
+    async def _fake_patch(path, json=None):
+        calls.append(("patch", path, json))
+        return {"id": "s1"}
+
+    with patch.object(stories_mod.client, "post", new=AsyncMock(side_effect=_fake_post)), \
+         patch.object(stories_mod.client, "get", new=AsyncMock(side_effect=_fake_get)), \
+         patch.object(stories_mod.client, "patch", new=AsyncMock(side_effect=_fake_patch)):
+        await update_story(args)
+
+    kinds = [c[0] for c in calls]
+    assert kinds == ["post", "get", "patch"]
+    patch_body = calls[-1][2]
+    assert patch_body["attachments"] == [existing_attachment, uploaded_attachment]
+
+
+@pytest.mark.anyio
+async def test_update_story_upload_failure_returns_error_no_patch():
+    args = UpdateStoryInput(
+        story_id="s1",
+        attachments=[{"content_base64": _b64(4), "name": "new.png", "content_type": "image/png"}],
+    )
+    with patch.object(stories_mod.client, "post", new=AsyncMock(side_effect=RuntimeError("403"))), \
+         patch.object(stories_mod.client, "patch", new=AsyncMock()) as patch_mock:
+        result = await update_story(args)
+    assert result[0].text.startswith("Error")
+    patch_mock.assert_not_awaited()
+
+
+# ── doc ────────────────────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_update_doc_no_attachments_unchanged_payload():
+    args = UpdateDocInput(doc_id="d1", title="new title")
+    with patch.object(docs_mod.client, "patch", new=AsyncMock(return_value={})) as m:
+        await update_doc(args)
+        _, kwargs = m.call_args
+        assert "content" not in kwargs["json"]
+
+
+@pytest.mark.anyio
+async def test_update_doc_appends_embed_snippet_to_provided_content():
+    args = UpdateDocInput(
+        doc_id="d1", content="# my doc\n\nsome text",
+        attachments=[{"content_base64": _b64(4), "name": "shot.png", "content_type": "image/png"}],
+    )
+    upload_result = {
+        "asset_id": "AID-1", "filename": "shot.png", "size": 4, "mime": "image/png",
+        "embed_snippet": '<img data-asset-id="AID-1" data-filename="shot.png" data-size="4" data-mime-type="image/png" alt="shot.png">',
+    }
+    with patch.object(docs_mod.client, "post", new=AsyncMock(return_value=upload_result)), \
+         patch.object(docs_mod.client, "patch", new=AsyncMock(return_value={})) as patch_mock:
+        await update_doc(args)
+    _, kwargs = patch_mock.call_args
+    assert kwargs["json"]["content"] == "# my doc\n\nsome text\n" + upload_result["embed_snippet"]
+
+
+@pytest.mark.anyio
+async def test_update_doc_fetches_existing_content_when_not_provided():
+    """content 미제공 시 현재 저장된 content 를 먼저 읽어 그 뒤에 append(기존 본문 유지)."""
+    args = UpdateDocInput(
+        doc_id="d1",
+        attachments=[{"content_base64": _b64(4), "name": "shot.png", "content_type": "image/png"}],
+    )
+    upload_result = {
+        "asset_id": "AID-1", "filename": "shot.png", "size": 4, "mime": "image/png",
+        "embed_snippet": '<img data-asset-id="AID-1" alt="shot.png">',
+    }
+    calls: list[tuple] = []
+
+    async def _fake_post(path, json=None):
+        calls.append(("post", path))
+        return upload_result
+
+    async def _fake_get(path, params=None):
+        calls.append(("get", path))
+        return {"content": "existing body"}
+
+    async def _fake_patch(path, json=None):
+        calls.append(("patch", path, json))
+        return {}
+
+    with patch.object(docs_mod.client, "post", new=AsyncMock(side_effect=_fake_post)), \
+         patch.object(docs_mod.client, "get", new=AsyncMock(side_effect=_fake_get)), \
+         patch.object(docs_mod.client, "patch", new=AsyncMock(side_effect=_fake_patch)):
+        await update_doc(args)
+
+    patch_call = next(c for c in calls if c[0] == "patch")
+    assert patch_call[2]["content"] == f"existing body\n{upload_result['embed_snippet']}"
+
+
+@pytest.mark.anyio
+async def test_update_doc_upload_failure_returns_error_no_patch():
+    args = UpdateDocInput(
+        doc_id="d1",
+        attachments=[{"content_base64": _b64(4), "name": "shot.png", "content_type": "image/png"}],
+    )
+    with patch.object(docs_mod.client, "post", new=AsyncMock(side_effect=RuntimeError("403"))), \
+         patch.object(docs_mod.client, "patch", new=AsyncMock()) as patch_mock:
+        result = await update_doc(args)
+    assert result[0].text.startswith("Error")
+    patch_mock.assert_not_awaited()

--- a/backend/tests/test_e_mcp_opt_s6_story_doc_upload_realdb.py
+++ b/backend/tests/test_e_mcp_opt_s6_story_doc_upload_realdb.py
@@ -1,0 +1,264 @@
+"""E-MCP-OPT S6 (029b7825): story/doc MCP 첨부 업로드 — 실 Postgres + 실 storage.
+
+story: `upload_story_attachment`(chat과 동형) + `update_story`의 mcp-태그 부분집합 선언한도
+재검증(S5 #2 처음부터 포함). doc: `upload_doc_attachment`(base64 업로드+즉시 asset 등록 한 호출)
++ `embed_snippet`이 실 TipTap 렌더 계약(data-asset-id/data-filename/data-size/data-mime-type)과
+정확히 일치하는지.
+"""
+from __future__ import annotations
+
+import base64
+import os
+import uuid
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("ab900000-0000-0000-0000-000000000001")
+PROJ = uuid.UUID("ab900000-0000-0000-0000-000000000002")
+STORY = uuid.UUID("ab900000-0000-0000-0000-000000000003")
+DOC = uuid.UUID("ab900000-0000-0000-0000-000000000004")
+AGENT_IN = uuid.UUID("ab900000-0000-0000-0000-0000000000a1")   # project access 있음
+AGENT_OUT = uuid.UUID("ab900000-0000-0000-0000-0000000000a2")  # project access 없음
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth(member_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(member_id), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(ORG),
+    )
+
+
+async def _seed(s) -> None:
+    for sql in [
+        f"DELETE FROM stories WHERE org_id='{ORG}'",
+        f"DELETE FROM docs WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','S6SD','s6sd-org','free')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ}','{ORG}','P','none')",
+        f"INSERT INTO members (id,org_id,type,name) VALUES ('{AGENT_IN}','{ORG}','agent','AgentIn')",
+        f"INSERT INTO members (id,org_id,type,name) VALUES ('{AGENT_OUT}','{ORG}','agent','AgentOut')",
+        f"INSERT INTO project_access (project_id,member_id,permission) VALUES ('{PROJ}','{AGENT_IN}','granted')",
+        f"INSERT INTO stories (id,org_id,project_id,title,status,priority) VALUES "
+        f"('{STORY}','{ORG}','{PROJ}','test story','backlog','medium')",
+        f"INSERT INTO docs (id,org_id,project_id,title,slug,content) VALUES "
+        f"('{DOC}','{ORG}','{PROJ}','test doc','test-doc-s6','')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+# ── story ──────────────────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_story_upload_writes_real_bytes_at_s7_path_with_mcp_marker(monkeypatch, tmp_path):
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.stories import UploadStoryAttachmentRequest, upload_story_attachment
+    from app.services.storage import get_storage_provider
+    from app.services.asset_registry import DEFAULT_CONTAINER
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            raw = b"\x89PNG story screenshot bytes"
+            body = UploadStoryAttachmentRequest(
+                content_base64=base64.b64encode(raw).decode(), name="shot.png", content_type="image/png",
+            )
+            resp = await upload_story_attachment(STORY, body, session=s, auth=_auth(AGENT_IN), org_id=ORG)
+            assert resp.size == len(raw)
+            prefix = f"org/{ORG}/project/{PROJ}/story/{STORY}/mcp/"
+            assert resp.url.startswith(prefix)
+            downloaded = await get_storage_provider().download_object(DEFAULT_CONTAINER, resp.url)
+            assert downloaded == raw
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_story_upload_no_project_access_403(monkeypatch, tmp_path):
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.stories import UploadStoryAttachmentRequest, upload_story_attachment
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            body = UploadStoryAttachmentRequest(
+                content_base64=base64.b64encode(b"x").decode(), name="f.txt", content_type="text/plain",
+            )
+            with pytest.raises(HTTPException) as ei:
+                await upload_story_attachment(STORY, body, session=s, auth=_auth(AGENT_OUT), org_id=ORG)
+            assert ei.value.status_code == 403
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_story_update_rejects_mcp_attachments_over_declared_limit(monkeypatch, tmp_path):
+    """S5 #2 와 동일 갭을 story 에서 처음부터 막는지 — 6개(>5) mcp-태그 첨부 참조 update_story 는 400."""
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.stories import (
+        UploadStoryAttachmentRequest,
+        upload_story_attachment,
+    )
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        uploaded = []
+        async with Session() as s:
+            for i in range(6):
+                raw = b"a" * (1024 * 1024)
+                body = UploadStoryAttachmentRequest(
+                    content_base64=base64.b64encode(raw).decode(),
+                    name=f"f{i}.bin", content_type="application/octet-stream",
+                )
+                uploaded.append(await upload_story_attachment(
+                    STORY, body, session=s, auth=_auth(AGENT_IN), org_id=ORG,
+                ))
+
+        async with Session() as s:
+            from app.repositories.story import StoryRepository
+            from app.routers.stories import update_story
+            repo = StoryRepository(s, ORG)
+            update_body = StoryUpdate(attachments=uploaded)
+            with pytest.raises(HTTPException) as ei:
+                await update_story(
+                    STORY, update_body, BackgroundTasks(), repo=repo, db=s, auth=_auth(AGENT_IN),
+                )
+            assert ei.value.status_code == 400
+    finally:
+        await eng.dispose()
+
+
+# ── doc ────────────────────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_doc_upload_registers_asset_and_returns_correct_embed_snippet(monkeypatch, tmp_path):
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.docs import UploadDocAttachmentRequest, upload_doc_attachment
+    from app.services.storage import get_storage_provider
+    from app.services.asset_registry import DEFAULT_CONTAINER
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            raw = b"doc-attached-png-bytes"
+            body = UploadDocAttachmentRequest(
+                content_base64=base64.b64encode(raw).decode(), name="diagram.png", content_type="image/png",
+            )
+            resp = await upload_doc_attachment(DOC, body, session=s, auth=_auth(AGENT_IN), org_id=ORG)
+            assert resp.size == len(raw)
+            assert resp.asset_id is not None
+            assert resp.embed_snippet == (
+                f'<img data-asset-id="{resp.asset_id}" data-filename="diagram.png" '
+                f'data-size="{len(raw)}" data-mime-type="image/png" alt="diagram.png">'
+            )
+            # asset 실제로 등록됐는지 확인(asset_links 경유 — Asset 존재 자체로 충분)
+            row = (await s.execute(
+                text("SELECT id FROM assets WHERE id=:aid"), {"aid": str(resp.asset_id)},
+            )).first()
+            assert row is not None
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_doc_upload_non_image_returns_file_div_snippet(monkeypatch, tmp_path):
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.docs import UploadDocAttachmentRequest, upload_doc_attachment
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            raw = b"%PDF-1.4 fake pdf bytes"
+            body = UploadDocAttachmentRequest(
+                content_base64=base64.b64encode(raw).decode(), name="report.pdf", content_type="application/pdf",
+            )
+            resp = await upload_doc_attachment(DOC, body, session=s, auth=_auth(AGENT_IN), org_id=ORG)
+            assert resp.embed_snippet == (
+                f'<div data-type="fileAttachment" data-filename="report.pdf" data-size="{len(raw)}" '
+                f'data-mime-type="application/pdf" data-asset-id="{resp.asset_id}"></div>'
+            )
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_doc_upload_escapes_html_in_filename(monkeypatch, tmp_path):
+    """파일명이 doc content(HTML)에 그대로 꽂히므로 injection 방지 — attribute-context escape 필수."""
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.docs import UploadDocAttachmentRequest, upload_doc_attachment
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            body = UploadDocAttachmentRequest(
+                content_base64=base64.b64encode(b"x").decode(),
+                name='evil"><script>alert(1)</script>.png', content_type="image/png",
+            )
+            resp = await upload_doc_attachment(DOC, body, session=s, auth=_auth(AGENT_IN), org_id=ORG)
+            assert "<script>" not in resp.embed_snippet
+            assert "&lt;script&gt;" in resp.embed_snippet
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_doc_upload_no_project_access_403(monkeypatch, tmp_path):
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.docs import UploadDocAttachmentRequest, upload_doc_attachment
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            body = UploadDocAttachmentRequest(
+                content_base64=base64.b64encode(b"x").decode(), name="f.txt", content_type="text/plain",
+            )
+            with pytest.raises(HTTPException) as ei:
+                await upload_doc_attachment(DOC, body, session=s, auth=_auth(AGENT_OUT), org_id=ORG)
+            assert ei.value.status_code == 403
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## Summary
S2 (bbfd24ba) only wired up inline base64 attachments for chat messages — stories and docs (which already fully support attachments end-to-end via their own FE-direct-upload flows) had no MCP-callable equivalent. This closes that gap.

**Shared extraction**: pulled the S2/S5 chat-specific constants/helpers (size limits, base64 decode, safe filename, `mcp/` path marker + detector) into two shared modules — `app/services/mcp_attachment_upload.py` (BE) and `sprintable_mcp/tools/attachments.py` (MCP) — since this is the 3rd near-identical implementation (DRY trigger point). `conversations.py`/`chat.py` refactored to consume the shared versions; behavior is unchanged (verified via the full existing chat test suite, including realdb, passing unmodified against the refactor).

**Story**: new `POST /api/v2/stories/{id}/attachments`, same shape as the chat endpoint (`has_project_access` authz, `mcp/`-tagged S7 path). `update_story`'s PATCH does a full attachments replace server-side, so the MCP tool reads the story's current attachments first and merges instead of overwriting them. Built the S5-style aggregate-cap re-validation in from day one this time — no reason to ship the same bypass gap chat had and fix it later.

**Doc**: docs don't have an attachments list field — attachments embed as inline HTML nodes directly in the doc's `content` (TipTap editor; markdown-format docs allow raw HTML islands via `rehypeRaw`). Verified the exact node markup against `doc-content-renderer.tsx`/`file-node.tsx`/`image-node.tsx` rather than guessing. New `POST /api/v2/docs/{doc_id}/attachments` combines upload + immediate asset registration in one call (docs have no separate "message create" moment to defer registration to — `register_doc_asset`'s existing two-step FE flow becomes one MCP call) and returns a ready-to-use `embed_snippet` (`<img data-asset-id=...>` for images, `<div data-type="fileAttachment" data-asset-id=...>` otherwise) so the agent never needs to know the markup contract — the MCP tool assembles it and appends to `content` (reading current content first if not provided in the same call, to avoid clobbering the doc body). Filenames are HTML-escaped before embedding since they land directly in rendered content.

`add_story`/`create_doc` do NOT get an `attachments` param — both new upload endpoints require an existing resource id to scope the path, matching the existing FE upload routes' own constraint (attach-after-create only, confirmed by reading those routes).

## Test plan
- [x] Refactor safety: all 13 pre-existing chat-attachment tests (mocked) + all 7 realdb chat-attachment tests pass unchanged after extracting shared constants/helpers.
- [x] New shared-module unit tests (12): constants, decode/size guards, filename sanitization, object-path building/detection per resource kind, cross-kind non-matching.
- [x] Real Postgres + real local storage round-trip (7 tests): story upload writes correct S7+`mcp/` path and real bytes; story upload without project access → 403; story update with 6 (>5) mcp-tagged attachments → 400 (negative-tested: disabled the check, confirmed it fails); doc upload registers a real `Asset` row and returns the exact expected `embed_snippet` for both image and non-image mime types; HTML-escaping of a filename containing `<script>` confirmed; doc upload without project access → 403.
- [x] MCP tool tests (7): `update_story`/`update_doc` no-attachments regression (payload unchanged), story attachment merge-not-replace behavior, doc embed-snippet append (both when `content` is provided and when it needs to be fetched first), upload-failure short-circuits before the PATCH in both.
- [x] Full backend suite: 2978 passed, 0 regressions (same 6 pre-existing unrelated failures as recent PRs — live-E2E hardcoded tool-count drift + local `.mcp.json` environment-config drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)