### PR TITLE
Promote develop→main: E-MCP-OPT S1-S6 + epics mobile-scroll fix

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -432,7 +432,16 @@
     "advancedSubtitle": "Webhook notifications · alternate transports (HTTP, fakechat)",
     "advancedNote": "Configure webhook notifications and alternate connection methods later.",
     "dashboardCta": "Go to dashboard",
-    "connectFooterHint": "Once verified you're ready — you can skip for now."
+    "connectFooterHint": "Once verified you're ready — you can skip for now.",
+    "transportHosted": "Hosted",
+    "transportLocal": "Local (uvx)",
+    "transportRecommended": "Recommended",
+    "hostedBenefit": "No reinstall when features change — the server always serves the latest version.",
+    "hostedVerifyNote": "Hosted verifies via tool-call heartbeat — a different path than local SSE, but verification completes just the same.",
+    "localGuideNote": "Runs locally — for self-hosted/offline use. uvx re-fetches the latest version when tools change.",
+    "railStageHosted": "Hosted · 4 steps",
+    "railStageLocal": "Local · 6 steps",
+    "artifactUnavailable": "No hosted deployment in this environment."
   },
   "settings": {
     "title": "Settings",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -432,7 +432,16 @@
     "advancedSubtitle": "Webhook 알림 · 대체 연결 방식 (HTTP, fakechat)",
     "advancedNote": "Webhook 알림과 대체 연결 방식은 나중에 설정할 수 있습니다.",
     "dashboardCta": "대시보드로",
-    "connectFooterHint": "확인되면 준비 완료 — 지금 건너뛰어도 됩니다."
+    "connectFooterHint": "확인되면 준비 완료 — 지금 건너뛰어도 됩니다.",
+    "transportHosted": "호스팅",
+    "transportLocal": "로컬 (uvx)",
+    "transportRecommended": "권장",
+    "hostedBenefit": "기능이 바뀌어도 재설치가 없습니다. 서버가 자동으로 최신 상태를 서빙합니다.",
+    "hostedVerifyNote": "호스팅은 tool 호출 신호(heartbeat)로 연결을 확인합니다 — 로컬 SSE 방식과 다른 경로일 뿐, 검증은 동일하게 완료됩니다.",
+    "localGuideNote": "로컬 실행 — 셀프호스트/오프라인용. 툴 변경 시 uvx가 최신 버전을 재fetch합니다.",
+    "railStageHosted": "호스팅 · 4단계",
+    "railStageLocal": "로컬 · 6단계",
+    "artifactUnavailable": "이 환경에는 호스팅 배포가 없습니다."
   },
   "settings": {
     "title": "설정",

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -906,11 +906,14 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
       </div>
 
       {/* Mobile layout */}
-      <div className="flex flex-1 flex-col overflow-hidden lg:hidden">
+      {/* min-h-0 필수 — 없으면 flex item 기본 min-height:auto가 content 높이만큼 커져
+          이 wrapper의 overflow-hidden이 하단 콘텐츠를 스크롤 불가하게 clip한다(desktop
+          분기 L893의 min-h-0와 동형·모바일 스크롤 불가 재현+근본 확인 후 정정). */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden lg:hidden">
         {mobileView === 'list' ? (
-          <div className="flex-1">{listPanel}</div>
+          <div className="min-h-0 flex-1">{listPanel}</div>
         ) : (
-          <div className="flex-1">
+          <div className="min-h-0 flex-1">
             {selectedEpic ? (
               <EpicDetailPanel
                 epic={selectedEpic}

--- a/apps/web/src/app/onboarding/connect-step.test.tsx
+++ b/apps/web/src/app/onboarding/connect-step.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { inferTransport } from './connect-step';
+import { RAIL_ORDER, HTTP_RAIL_ORDER } from './verify-rail';
+
+describe('inferTransport (E-MCP-OPT S3 — transport 미지정 default-resolve 응답 판별)', () => {
+  it('reads type:"http" from a hosted artifact', () => {
+    const content = JSON.stringify({
+      mcpServers: { sprintable: { type: 'http', url: 'https://mcp.sprintable.ai/mcp', headers: {} } },
+    });
+    expect(inferTransport(content)).toBe('http');
+  });
+
+  it('reads type:"stdio" from a local artifact', () => {
+    const content = JSON.stringify({
+      mcpServers: { sprintable: { type: 'stdio', command: 'uvx', args: ['sprintable-mcp'] } },
+    });
+    expect(inferTransport(content)).toBe('stdio');
+  });
+
+  it('falls back to stdio on malformed content (never throws, never defaults to hosted)', () => {
+    expect(inferTransport('not json')).toBe('stdio');
+    expect(inferTransport('{}')).toBe('stdio');
+  });
+});
+
+describe('rail orders (E-MCP-OPT S3 — transport-aware verify rail shape)', () => {
+  it('stdio rail keeps the full 6-stage canonical order (regression guard)', () => {
+    expect(RAIL_ORDER).toEqual([
+      'config_copied', 'waiting', 'mcp_reachable', 'event_delivered', 'ack', 'verified',
+    ]);
+  });
+
+  it('http rail is a 4-stage reduction with no event_delivered/ack (structurally impossible over http)', () => {
+    expect(HTTP_RAIL_ORDER).toEqual(['config_copied', 'waiting', 'mcp_reachable', 'verified']);
+    expect(HTTP_RAIL_ORDER).not.toContain('event_delivered');
+    expect(HTTP_RAIL_ORDER).not.toContain('ack');
+  });
+});

--- a/apps/web/src/app/onboarding/connect-step.tsx
+++ b/apps/web/src/app/onboarding/connect-step.tsx
@@ -2,12 +2,12 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
-import { FileText, Copy, Check, RefreshCw, ChevronRight, Info } from 'lucide-react';
+import { FileText, Copy, Check, RefreshCw, ChevronRight, Info, Cloud, Terminal, Sparkles } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
-import { VerifyRail, RAIL_ORDER, type DisplayStep, type RailState, type RailStatus } from './verify-rail';
+import { VerifyRail, RAIL_ORDER, HTTP_RAIL_ORDER, type DisplayStep, type RailState, type RailStatus } from './verify-rail';
 import { emitOnboardingEvent, beaconOnboardingEvent } from './onboarding-telemetry';
 
 const RAIL_LABEL_KEY: Record<RailState, string> = {
@@ -19,10 +19,24 @@ const RAIL_LABEL_KEY: Record<RailState, string> = {
   verified: 'railVerified',
 };
 
+/** E-MCP-OPT S3: SaaS 기본=호스팅(http)·OSS 기본=로컬(stdio) — BE `default_transport_for_edition()` 따름. */
+export type Transport = 'http' | 'stdio';
+
 interface RawStep {
   state: RailState;
   status: RailStatus;
   reason?: string;
+}
+
+/** connection-artifact content(JSON)의 `mcpServers.sprintable.type` 필드만 읽는다(재조립 아님) —
+ * transport 미지정 최초 요청은 BE edition 기본을 반환하므로, 어느 탭을 pre-select할지 이걸로 판별. */
+export function inferTransport(content: string): Transport {
+  try {
+    const parsed = JSON.parse(content) as { mcpServers?: { sprintable?: { type?: string } } };
+    return parsed?.mcpServers?.sprintable?.type === 'http' ? 'http' : 'stdio';
+  } catch {
+    return 'stdio';
+  }
 }
 
 interface ConnectStepProps {
@@ -87,20 +101,26 @@ function HighlightedJson({ text }: { text: string }) {
 export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
   const t = useTranslations('onboarding');
 
-  const [artifactBase, setArtifactBase] = useState<string | null>(null);
-  const [artifactError, setArtifactError] = useState(false);
+  // transport=null: 최초 default-resolve 응답 대기 中(BE edition 기본 판별 前).
+  const [transport, setTransport] = useState<Transport | null>(null);
+  const [artifacts, setArtifacts] = useState<Partial<Record<Transport, string>>>({});
+  const [artifactErrors, setArtifactErrors] = useState<Partial<Record<Transport, boolean>>>({});
+  // transport 미판별 상태(최초 default-resolve 요청)에서의 실패 — 이후엔 위 per-transport 에러로 대체.
+  const [initialError, setInitialError] = useState(false);
+  const [hostedUnavailable, setHostedUnavailable] = useState(false);
   const [beSteps, setBeSteps] = useState<RawStep[] | null>(null);
-  const [hasCopied, setHasCopied] = useState(false);
+  const [hasCopiedMap, setHasCopiedMap] = useState<Partial<Record<Transport, boolean>>>({});
   const [justCopied, setJustCopied] = useState(false);
   const [verifying, setVerifying] = useState(false);
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const leftRef = useRef(false);
 
   // OB-2 verification-status poll (SSE-우선은 OB-2 SSE 포맷 확정 후 follow-up·현재 poll). 404 graceful.
-  const pollStatus = useCallback(async () => {
+  // E-MCP-OPT S3: transport별 레일 shape 다름(호스팅=4단계, event/ack 없음) — 쿼리로 분기.
+  const pollStatus = useCallback(async (forTransport: Transport) => {
     if (!agentId) return;
     try {
-      const res = await fetch(`/api/agents/${agentId}/verification-status`);
+      const res = await fetch(`/api/agents/${agentId}/verification-status?transport=${forTransport}`);
       if (!res.ok) return; // 미머지/404 → pending 유지(가짜 에러 안 띄움)
       const json = (await res.json()) as { data?: { steps?: RawStep[] } | RawStep[]; steps?: RawStep[] };
       const d = json?.data;
@@ -112,35 +132,74 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
   }, [agentId]);
 
   useEffect(() => {
-    if (!agentId || !apiKey) return;
-    void pollStatus();
-    const iv = setInterval(() => void pollStatus(), 2500);
+    if (!agentId || !apiKey || !transport) return;
+    setBeSteps(null); // transport 전환 시 이전 transport의 레일 상태가 새 레일에 새는 것 방지
+    void pollStatus(transport);
+    const iv = setInterval(() => void pollStatus(transport), 2500);
     return () => clearInterval(iv);
-  }, [agentId, apiKey, pollStatus]);
+  }, [agentId, apiKey, transport, pollStatus]);
 
   // OB-1 connection-artifact = 아티팩트 SSOT(구조+backend-direct URL). OB-1 라이브라 정상응답 디폴트.
   // 실패 시 클라빌드로 메우지 않고(§2 CF env 노출 금지·AC3) pending+재시도 유지.
-  const fetchArtifact = useCallback(async () => {
+  // E-MCP-OPT S3: reqTransport 생략 시 BE가 edition 기본을 판별해 반환 — 최초 1회만 이렇게 호출해
+  // 어느 탭을 pre-select할지 응답 content의 `type` 필드로 역산한다(§5, FE round-trip 없이 SSOT 보존).
+  const fetchArtifact = useCallback(async (reqTransport?: Transport) => {
     if (!agentId) return;
-    setArtifactError(false);
+    if (!reqTransport) setInitialError(false);
     try {
-      const res = await fetch(`/api/agents/${agentId}/connection-artifact`);
-      if (!res.ok) { setArtifactError(true); return; }
+      const qs = reqTransport ? `?transport=${reqTransport}` : '';
+      const res = await fetch(`/api/agents/${agentId}/connection-artifact${qs}`);
+      if (!res.ok) {
+        if (reqTransport === 'http' && res.status === 400) {
+          // MCP_PUBLIC_URL 미설정 환경(OSS/로컬) — "탭 자체가 없음"(BE 계약), 에러 아님.
+          setHostedUnavailable(true);
+          return;
+        }
+        if (!reqTransport && res.status === 400) {
+          // edition 기본이 http로 잡혔는데 이 환경엔 배포가 없는 misconfig — stdio는 항상 가능하다는
+          // BE invariant를 믿고 명시 폴백(무한 pending 방치 금지).
+          setHostedUnavailable(true);
+          void fetchArtifact('stdio');
+          return;
+        }
+        if (reqTransport) setArtifactErrors((p) => ({ ...p, [reqTransport]: true }));
+        else setInitialError(true);
+        return;
+      }
       const json = (await res.json()) as { data?: { content?: string }; content?: string };
       const content = json?.data?.content ?? json?.content;
-      if (typeof content === 'string') setArtifactBase(content);
-      else setArtifactError(true);
+      if (typeof content !== 'string') {
+        if (reqTransport) setArtifactErrors((p) => ({ ...p, [reqTransport]: true }));
+        else setInitialError(true);
+        return;
+      }
+      const resolved = reqTransport ?? inferTransport(content);
+      setArtifacts((p) => ({ ...p, [resolved]: content }));
+      setArtifactErrors((p) => ({ ...p, [resolved]: false }));
+      setTransport((cur) => cur ?? resolved);
     } catch {
-      setArtifactError(true);
+      if (reqTransport) setArtifactErrors((p) => ({ ...p, [reqTransport]: true }));
+      else setInitialError(true);
     }
   }, [agentId]);
 
+  // 최초 마운트 — transport 미지정 요청으로 BE edition 기본 판별.
   useEffect(() => {
     if (!agentId || !apiKey) return;
     void fetchArtifact();
   }, [agentId, apiKey, fetchArtifact]);
 
-  const displaySteps: DisplayStep[] = RAIL_ORDER.map((state) => {
+  // 탭 전환 — 아직 fetch 안 한 transport 만 재요청(§5 "탭 전환마다 재요청"·이미 캐시된 건 재요청 생략).
+  useEffect(() => {
+    if (!agentId || !apiKey || !transport) return;
+    if (artifacts[transport]) return;
+    if (transport === 'http' && hostedUnavailable) return;
+    void fetchArtifact(transport);
+  }, [agentId, apiKey, transport, artifacts, hostedUnavailable, fetchArtifact]);
+
+  const railOrder = transport === 'http' ? HTTP_RAIL_ORDER : RAIL_ORDER;
+  const hasCopied = transport ? Boolean(hasCopiedMap[transport]) : false;
+  const displaySteps: DisplayStep[] = railOrder.map((state) => {
     const be = beSteps?.find((s) => s.state === state);
     let status: RailStatus = be?.status ?? 'pending';
     // whichever-first: Copy 클릭 OR 첫 OB-2 신호 — config_copied done
@@ -162,31 +221,31 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
   }, [agentId, verified]);
 
   const handleCopy = async () => {
-    if (!apiKey) return;
-    const cfg = renderArtifact(artifactBase, apiKey, false);
+    if (!apiKey || !transport) return;
+    const cfg = renderArtifact(artifacts[transport] ?? null, apiKey, false);
     if (!cfg) return; // 아티팩트 미준비(pending) — copy 불가
     try {
       await navigator.clipboard.writeText(cfg);
     } catch {
       // ignore clipboard failure
     }
-    setHasCopied(true);
+    setHasCopiedMap((p) => ({ ...p, [transport]: true }));
     setJustCopied(true);
     setTimeout(() => setJustCopied(false), 2000);
     emitOnboardingEvent('config_copied', { agent_id: agentId });
   };
 
   const handleVerify = async () => {
-    if (!agentId) return;
+    if (!agentId || !transport) return;
     setVerifying(true);
     emitOnboardingEvent('verify_started', { agent_id: agentId });
     try {
-      await fetch(`/api/agents/${agentId}/verify-connection`, {
+      await fetch(`/api/agents/${agentId}/verify-connection?transport=${transport}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: '{}',
       }).catch(() => {});
-      await pollStatus();
+      await pollStatus(transport);
     } finally {
       setVerifying(false);
     }
@@ -220,10 +279,42 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
     );
   }
 
+  const artifactBase = transport ? (artifacts[transport] ?? null) : null;
+  const artifactError = transport ? Boolean(artifactErrors[transport]) : initialError;
+  const isHostedUnavailable = transport === 'http' && hostedUnavailable;
   const displayConfig = renderArtifact(artifactBase, apiKey, true);
 
   return (
     <div className="space-y-4">
+      {/* [0] transport 세그먼트 토글 */}
+      <div className="flex gap-0 rounded-md border border-border bg-muted p-[3px]">
+        <button
+          type="button"
+          onClick={() => setTransport('http')}
+          disabled={!transport}
+          className={cn(
+            'flex flex-1 items-center justify-center gap-1.5 rounded px-2 py-1.5 text-xs font-medium text-muted-foreground transition-colors',
+            transport === 'http' && 'bg-background text-foreground shadow-sm',
+          )}
+        >
+          <Cloud className="h-3.5 w-3.5" aria-hidden />
+          {t('transportHosted')}
+          <Badge variant="info" className="px-1.5 py-0 text-[9px]">{t('transportRecommended')}</Badge>
+        </button>
+        <button
+          type="button"
+          onClick={() => setTransport('stdio')}
+          disabled={!transport}
+          className={cn(
+            'flex flex-1 items-center justify-center gap-1.5 rounded px-2 py-1.5 text-xs font-medium text-muted-foreground transition-colors',
+            transport === 'stdio' && 'bg-background text-foreground shadow-sm',
+          )}
+        >
+          <Terminal className="h-3.5 w-3.5" aria-hidden />
+          {t('transportLocal')}
+        </button>
+      </div>
+
       {/* [1] 아티팩트 카드 */}
       <section className="space-y-2">
         <div className="overflow-hidden rounded-md border border-border">
@@ -253,17 +344,19 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
               <code className="font-mono"><HighlightedJson text={displayConfig} /></code>
             </pre>
           ) : (
-            <div className="space-y-2 bg-muted/40 p-3" aria-busy={!artifactError}>
-              <div className={cn('h-3 w-3/4 rounded bg-muted', !artifactError && 'animate-pulse')} />
-              <div className={cn('h-3 w-1/2 rounded bg-muted', !artifactError && 'animate-pulse')} />
-              <div className={cn('h-3 w-2/3 rounded bg-muted', !artifactError && 'animate-pulse')} />
+            <div className="space-y-2 bg-muted/40 p-3" aria-busy={!artifactError && !isHostedUnavailable}>
+              <div className={cn('h-3 w-3/4 rounded bg-muted', !artifactError && !isHostedUnavailable && 'animate-pulse')} />
+              <div className={cn('h-3 w-1/2 rounded bg-muted', !artifactError && !isHostedUnavailable && 'animate-pulse')} />
+              <div className={cn('h-3 w-2/3 rounded bg-muted', !artifactError && !isHostedUnavailable && 'animate-pulse')} />
               <div className="flex items-center gap-2 pt-1">
-                <p className="text-xs text-muted-foreground">{t('artifactPending')}</p>
-                {artifactError && (
+                <p className="text-xs text-muted-foreground">
+                  {isHostedUnavailable ? t('artifactUnavailable') : t('artifactPending')}
+                </p>
+                {artifactError && !isHostedUnavailable && (
                   <Button
                     variant="ghost"
                     size="sm"
-                    onClick={() => void fetchArtifact()}
+                    onClick={() => void fetchArtifact(transport ?? undefined)}
                     className="h-auto px-2 py-0.5 text-xs"
                   >
                     {t('artifactRetry')}
@@ -273,6 +366,18 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
             </div>
           )}
         </div>
+        {transport === 'http' && !isHostedUnavailable && (
+          <div className="flex items-start gap-2 rounded-md border border-info-border bg-info-tint px-3 py-2.5 text-xs text-info">
+            <Sparkles className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+            <span>{t('hostedBenefit')}</span>
+          </div>
+        )}
+        {transport === 'stdio' && (
+          <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
+            <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+            {t('localGuideNote')}
+          </p>
+        )}
         <p className="flex items-start gap-1.5 text-xs text-muted-foreground">
           <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
           {t('artifactGuide')}
@@ -283,12 +388,17 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
       {/* [2] verify 상태레일 */}
       <section className="space-y-3 border-t border-border pt-4">
         <div className="flex items-center justify-between gap-2">
-          <p className="text-sm font-medium">{t('verifyTitle')}</p>
+          <p className="text-sm font-medium">
+            {t('verifyTitle')}{' '}
+            <span className={cn('text-xs font-normal', transport === 'http' ? 'text-info' : 'text-muted-foreground')}>
+              {transport === 'http' ? t('railStageHosted') : t('railStageLocal')}
+            </span>
+          </p>
           <Button
             variant="ghost"
             size="sm"
             onClick={() => void handleVerify()}
-            disabled={verifying}
+            disabled={verifying || !transport}
             aria-label={t('verifyRetry')}
             className="shrink-0 whitespace-nowrap"
           >
@@ -297,6 +407,12 @@ export function ConnectStep({ agentId, apiKey, onFinish }: ConnectStepProps) {
           </Button>
         </div>
         <VerifyRail steps={displaySteps} />
+        {transport === 'http' && (
+          <p className="flex items-start gap-1.5 text-xs text-info">
+            <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+            {t('hostedVerifyNote')}
+          </p>
+        )}
         {verified && (
           <div className="rounded-md border border-success/20 bg-success/10 px-3 py-2.5 text-sm text-success">
             {t('verifiedBanner')}

--- a/apps/web/src/app/onboarding/verify-rail.tsx
+++ b/apps/web/src/app/onboarding/verify-rail.tsx
@@ -17,6 +17,9 @@ export const RAIL_ORDER = [
 
 export type RailState = (typeof RAIL_ORDER)[number];
 
+/** E-MCP-OPT S3: 호스팅(http) transport 축소 레일 — event_delivered/ack 없음(구조적으로 불가·BE agent_verify.py). */
+export const HTTP_RAIL_ORDER = ['config_copied', 'waiting', 'mcp_reachable', 'verified'] as const;
+
 export interface DisplayStep {
   state: RailState;
   status: RailStatus;

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -29,9 +29,16 @@ class AuthContext:
 
 
 async def _persist_first_auth_seen(
-    member_id: uuid.UUID, org_id: str | None, project_id: str | None
+    member_id: uuid.UUID, org_id: str | None, project_id: str | None,
+    transport: str | None = None,
 ) -> None:
     """OB-4b: 첫 인증 1회 ``first_auth_seen`` — caller 세션 commit 여부와 **무관하게** persist.
+
+    E-MCP-OPT S5(#5): 이 인증 경로(API키)는 REST 전반의 공용 진입점이라 ``transport``(stdio/http)를
+    자체적으론 전혀 알 수 없다 — MCP 클라이언트(``sprintable_mcp``)가 자기 신고하는
+    ``X-MCP-Transport`` 헤더(``get_current_user``가 읽어 여기로 전달)만이 유일한 신호. 헤더 미전송
+    (구버전 클라이언트·MCP 아닌 직접 API 호출)이면 기존 하드코딩과 동일하게 ``"stdio"`` 로 폴백
+    (레거시 무회귀 — 관측용 필드일 뿐 인가에 쓰이지 않음).
 
     ⚠️ streaming auth(``get_current_user_streaming``)는 세션을 commit 없이 close 하므로 caller-session
     emit 은 rollback 으로 미persist(V2 통일로 에이전트 첫 인증이 ``/agent/stream`` 인 게 가장 흔함) →
@@ -65,14 +72,16 @@ async def _persist_first_auth_seen(
                 s, event="first_auth_seen", agent_id=member_id,
                 org_id=(uuid.UUID(org_id) if org_id else None),
                 project_id=(uuid.UUID(project_id) if project_id else None),
-                runtime="claude-code", transport="stdio",
+                runtime="claude-code", transport=(transport or "stdio"),
             )
             await s.commit()
     except Exception:
         logger.warning("first_auth_seen persist failed agent=%s", member_id, exc_info=True)
 
 
-async def _resolve_api_key(raw_key: str, db: AsyncSession) -> AuthContext:
+async def _resolve_api_key(
+    raw_key: str, db: AsyncSession, transport: str | None = None,
+) -> AuthContext:
     """sk_live_* API key를 DB에서 조회하여 AuthContext 반환."""
     from app.models.api_key import ApiKey
     from app.models.team import TeamMember
@@ -181,7 +190,7 @@ async def _resolve_api_key(raw_key: str, db: AsyncSession) -> AuthContext:
     # OB-4b seam(first_auth_seen): 최초 인증 1회. caller 세션(특히 streaming auth=commit 없음)에 의존하면
     # 미persist + dedup 깨짐(까심 RC-1) → 전용 committed 세션에서 atomic 처리(경로 무관·race-safe·무중단).
     if _first_auth_seen:
-        await _persist_first_auth_seen(member_id, org_id, project_id)
+        await _persist_first_auth_seen(member_id, org_id, project_id, transport=transport)
 
     return AuthContext(
         user_id=str(member_id),
@@ -203,11 +212,12 @@ async def _resolve_api_key(raw_key: str, db: AsyncSession) -> AuthContext:
 async def get_current_user(
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
     x_agent_api_key: str | None = Header(default=None, alias="x-agent-api-key"),
+    x_mcp_transport: str | None = Header(default=None, alias="X-MCP-Transport"),
     db: AsyncSession = Depends(get_db),
 ) -> AuthContext:
     # x-agent-api-key 헤더 우선 처리 (SSE 브릿지 직접 연결용)
     if x_agent_api_key and x_agent_api_key.startswith("sk_live_"):
-        return await _resolve_api_key(x_agent_api_key, db)
+        return await _resolve_api_key(x_agent_api_key, db, transport=x_mcp_transport)
 
     if credentials is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing Authorization header")
@@ -216,7 +226,7 @@ async def get_current_user(
 
     # sk_live_* prefix → API key 경로 (DB 조회)
     if token.startswith("sk_live_"):
-        return await _resolve_api_key(token, db)
+        return await _resolve_api_key(token, db, transport=x_mcp_transport)
 
     # JWT 경로 (기존)
     try:

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -229,10 +229,17 @@ async def verify_agent_connection(
     에이전트 push 경로 자체가 없어(streamable, client-initiated) 보낼 곳이 없다. heartbeat 기반
     4단계 레일을 즉시 조회해 반환(사실상 GET verification-status 와 동형 — "확인" 버튼 클릭이 곧
     현재 heartbeat freshness 재조회를 뜻한다).
+
+    E-MCP-OPT S5(#4): project 미배정 에이전트는 **transport 무관 동일하게 400** — http 조기 return이
+    이 가드보다 먼저면 미배정 에이전트가 stdio=400/http=200으로 갈렸다(까심 QA). project 스코프가
+    없는 에이전트는애초에 "연결 검증"이 의미가 없으므로(heartbeat 조차 project 컨텍스트 하 tool
+    호출을 전제) 두 transport 모두 이 가드를 먼저 통과해야 한다.
     """
     member = await _fetch_org_agent(session, agent_id, org_id)
     if member is None:
         raise HTTPException(status_code=404, detail="Agent not found")
+    if not member.project_id:
+        raise HTTPException(status_code=400, detail="agent has no project scope to verify")
 
     if transport == "http":
         state = await get_verification_state(session, agent_id, transport="http")
@@ -242,9 +249,6 @@ async def verify_agent_connection(
             "verified": state["verified"],
             "rail": state["rail"],
         }
-
-    if not member.project_id:
-        raise HTTPException(status_code=400, detail="agent has no project scope to verify")
 
     seq = await start_verification(
         session, agent_id=agent_id, org_id=org_id, project_id=member.project_id

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -22,7 +22,10 @@ from app.schemas.team_member import OrgAgentCreate, TeamMemberResponse
 from app.services.agent_onboarding_config import (
     DEFAULT_RUNTIME,
     SUPPORTED_RUNTIMES,
+    SUPPORTED_TRANSPORTS,
     build_agent_mcp_config,
+    build_agent_mcp_config_bundle,
+    default_transport_for_edition,
 )
 from app.services.agent_verify import get_verification_state, start_verification
 from app.services.onboarding_funnel import emit_onboarding_event, safe_key_prefix
@@ -118,8 +121,11 @@ async def create_org_agent(
     effective_port = member.fakechat_port or int(os.environ.get("FAKECHAT_PORT", _FAKECHAT_BASE_PORT))
     response["fakechat_port"] = effective_port
     response["api_key_created"] = bool(api_key_plaintext)
-    # OB-1 AC2: 단일 SSOT generator 소비(stdio 아티팩트). 로컬 _build_mcp_config 제거.
-    response["mcp_config"] = build_agent_mcp_config(api_key_plaintext=api_key_plaintext)
+    # E-MCP-OPT S3: 단일 SSOT generator 소비 — edition 기본 + 두 transport 변형 동봉(FE round-trip 0).
+    config_bundle = build_agent_mcp_config_bundle(api_key_plaintext=api_key_plaintext)
+    response["mcp_config"] = config_bundle["mcp_config"]
+    response["default_transport"] = config_bundle["default_transport"]
+    response["mcp_config_alternatives"] = config_bundle["mcp_config_alternatives"]
     if api_key_plaintext:
         response["api_key"] = api_key_plaintext
 
@@ -127,7 +133,8 @@ async def create_org_agent(
     await emit_onboarding_event(
         session, "agent_created", agent_id=member.id, org_id=org_id,
         project_id=(project_ids[0] if project_ids else None),
-        runtime="claude-code", transport="stdio", key_prefix=safe_key_prefix(api_key_plaintext),
+        runtime="claude-code", transport=config_bundle["default_transport"],
+        key_prefix=safe_key_prefix(api_key_plaintext),
     )
     await session.commit()
     return response
@@ -137,6 +144,7 @@ async def create_org_agent(
 async def get_agent_connection_artifact(
     agent_id: uuid.UUID,
     runtime: str = DEFAULT_RUNTIME,
+    transport: str | None = None,
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
@@ -147,9 +155,17 @@ async def get_agent_connection_artifact(
     사용자가 자기 키를 붙여 완성한다. wizard(OB-3)가 이 아티팩트를 렌더+copy+verify 한다.
     org-scope 로 조회(anti-IDOR). team_members 는 projection VIEW 라 멀티프로젝트 agent 가 N행이므로
     ``.limit(1)`` 로 MultipleResultsFound 차단(identity 조회·행 동형).
+
+    E-MCP-OPT S3: ``transport`` 쿼리(``stdio``|``http``) — connect-step 토글이 다른 탭 선택 시 이
+    파라미터로 재요청(§5, FE round-trip 방식 선택). 미지정 시 edition 기본(SaaS=http·OSS=stdio).
+    이 엔드포인트의 기존 "content=paste-ready 문자열" 계약은 그대로 — 요청된 단일 변형만 반환한다
+    (두 변형 동봉은 생성 시점 bundle 엔드포인트가 담당).
     """
     if runtime not in SUPPORTED_RUNTIMES:
         raise HTTPException(status_code=400, detail=f"unsupported runtime: {runtime}")
+    resolved_transport = transport or default_transport_for_edition()
+    if resolved_transport not in SUPPORTED_TRANSPORTS:
+        raise HTTPException(status_code=400, detail=f"unsupported transport: {transport}")
 
     member = (await session.execute(
         select(TeamMember).where(
@@ -161,12 +177,17 @@ async def get_agent_connection_artifact(
     if member is None:
         raise HTTPException(status_code=404, detail="Agent not found")
 
-    artifact = build_agent_mcp_config(api_key_plaintext=_API_KEY_PLACEHOLDER, runtime=runtime)
+    artifact = build_agent_mcp_config(
+        api_key_plaintext=_API_KEY_PLACEHOLDER, runtime=runtime, transport=resolved_transport,
+    )
+    if artifact is None:
+        # http 요청됐으나 이 환경엔 호스팅 배포가 없음(MCP_PUBLIC_URL 미설정) — 명시 요청이라 400.
+        raise HTTPException(status_code=400, detail=f"transport '{resolved_transport}' unavailable in this environment")
 
     # OB-4 seam: config_generated (generator 아티팩트 반환·funnel·non-blocking).
     await emit_onboarding_event(
         session, "config_generated", agent_id=member.id, org_id=org_id,
-        runtime=runtime, transport="stdio",
+        runtime=runtime, transport=resolved_transport,
     )
     await session.commit()
 
@@ -193,6 +214,7 @@ async def _fetch_org_agent(session: AsyncSession, agent_id: uuid.UUID, org_id: u
 @router.post("/{agent_id}/verify-connection")
 async def verify_agent_connection(
     agent_id: uuid.UUID,
+    transport: str | None = None,
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
@@ -202,10 +224,25 @@ async def verify_agent_connection(
     single-target(AC3): 해당 agent 1명에게만 — fire_webhooks/org 브로드캐스트 미사용. 이벤트는
     실 /agent/stream 경로(우회 X)로 가고, 에이전트가 ack 하면(acked_seq>=seq) verified 가 된다.
     응답은 verification-status 와 동일한 6단계 레일(초기 상태)을 같이 실어 FE 가 즉시 렌더하게 한다.
+
+    E-MCP-OPT S3: ``transport="http"`` 는 **합성 이벤트/SSE nudge 전부 스킵**한다 — http 는 서버→
+    에이전트 push 경로 자체가 없어(streamable, client-initiated) 보낼 곳이 없다. heartbeat 기반
+    4단계 레일을 즉시 조회해 반환(사실상 GET verification-status 와 동형 — "확인" 버튼 클릭이 곧
+    현재 heartbeat freshness 재조회를 뜻한다).
     """
     member = await _fetch_org_agent(session, agent_id, org_id)
     if member is None:
         raise HTTPException(status_code=404, detail="Agent not found")
+
+    if transport == "http":
+        state = await get_verification_state(session, agent_id, transport="http")
+        return {
+            "agent_id": str(agent_id),
+            "verification_seq": None,
+            "verified": state["verified"],
+            "rail": state["rail"],
+        }
+
     if not member.project_id:
         raise HTTPException(status_code=400, detail="agent has no project scope to verify")
 
@@ -235,19 +272,22 @@ async def verify_agent_connection(
 @router.get("/{agent_id}/verification-status")
 async def agent_verification_status(
     agent_id: uuid.UUID,
+    transport: str = "stdio",
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
-    """OB-2 AC2: 6단계 레일 폴링/조회(BE↔FE 계약 락). SSE 우선·이 poll 은 fallback.
+    """OB-2 AC2: 레일 폴링/조회(BE↔FE 계약 락). SSE 우선·이 poll 은 fallback.
 
-    각 단계 ``{state, status: pending|active|done}``. ack/verified 는 acked_seq>=seq 권위 신호만.
+    각 단계 ``{state, status: pending|active|done}``. ack/verified 는 acked_seq>=seq 권위 신호만
+    (stdio) 또는 heartbeat freshness(http, E-MCP-OPT S3 — 4단계 축소 레일).
+    ``transport`` 쿼리 — connect-step 이 보고 있는 탭과 정합(기본 stdio·회귀0).
     """
     member = await _fetch_org_agent(session, agent_id, org_id)
     if member is None:
         raise HTTPException(status_code=404, detail="Agent not found")
 
-    state = await get_verification_state(session, agent_id)
+    state = await get_verification_state(session, agent_id, transport=transport)
     return {
         "agent_id": str(agent_id),
         "verification_seq": state["verify_seq"],

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -1,11 +1,8 @@
 """E-EVENTBUS P7-A S37: conversations 테이블 + Chat API."""
 from __future__ import annotations
 
-import base64
-import binascii
 import json
 import logging
-import re
 import uuid
 from collections import defaultdict
 from datetime import datetime, timezone
@@ -29,7 +26,8 @@ from app.routers.events import _push_to_agent, publish_event
 from app.schemas.attachment import validate_attachment_url
 from app.services import chat_presence
 from app.services.agent_runtime import supports_deterministic_command
-from app.services.asset_registry import DEFAULT_CONTAINER, canonical_object_path, sync_attachment_assets
+from app.services import mcp_attachment_upload
+from app.services.asset_registry import DEFAULT_CONTAINER, sync_attachment_assets
 from app.services.command_classifier import classify_command
 from app.services.event_seq import assign_recipient_seq
 from app.services.member_resolver import (
@@ -586,40 +584,16 @@ class ConversationResponse(BaseModel):
 _MAX_ATTACHMENTS = 10
 _MAX_ATTACHMENT_SIZE = 100 * 1024 * 1024  # 100MB (메타 sanity 상한)
 
-# E-MCP-OPT S2(bbfd24ba): MCP(비-브라우저) 클라이언트용 JSON/base64 업로드 — 스샷/작은 문서가
-# 실사용(대용량 아님). FE-proxy 100MB 캡과 별개로 더 작게(Cloud Run HTTP/1 32MiB 요청 캡 대비
-# 여유 마진). sprintable_mcp 의 동일 상수(tools/chat.py `_MCP_MAX_ATTACHMENT_BYTES`)와 정합.
-_MAX_JSON_ATTACHMENT_UPLOAD_SIZE = 2 * 1024 * 1024  # 2MiB decoded
-_MAX_ATTACHMENT_NAME_LEN = 255
-_SAFE_ATTACHMENT_NAME_RE = re.compile(r"[^\w.\-]+")
-# E-MCP-OPT S5(#2, 까심 QA): 위 per-file 2MiB 캡은 걸지만 "선언 한도"(5개/6MiB 합계 — sprintable_mcp
-# `tools/chat.py` 의 client-side 가드와 동일 값)는 이 엔드포인트가 서버서 강제하지 않았다 —
-# participant 가 여러 번 개별 호출로(각 ≤2MiB) 메시지당 최대 10개(기존 `_MAX_ATTACHMENTS`)×2MiB≈
-# 20MiB 를 모아 SSOT 정책을 우회할 수 있었다(보안 취약점 아님·기존 message-level 캡으로 bounded — SSOT
-# 원칙 위반). object_path 에 `mcp/` 세그먼트를 심어 이 엔드포인트로 실제 업로드된 첨부만 식별하고,
-# `send_message` 가 그 부분집합에 한해 선언 한도를 재검증한다(새 테이블/시간창 추적 0 — 메시지 생성
-# 시점 1회 재검증으로 충분·메시지 없이 업로드만 반복하는 건 orphan blob 만 남길 뿐 이 한도와 무관).
-_MCP_MAX_ATTACHMENTS = 5
-_MCP_MAX_TOTAL_ATTACHMENT_BYTES = 6 * 1024 * 1024  # 6MiB decoded
+# E-MCP-OPT S2(bbfd24ba)/S6: MCP(비-브라우저) 클라이언트용 JSON/base64 업로드 공용 프리미티브
+# (S6 부터 story/doc 도 공유 — `app/services/mcp_attachment_upload.py` 참조).
+_MAX_JSON_ATTACHMENT_UPLOAD_SIZE = mcp_attachment_upload.MAX_JSON_ATTACHMENT_UPLOAD_SIZE
+_MAX_ATTACHMENT_NAME_LEN = mcp_attachment_upload.MAX_ATTACHMENT_NAME_LEN
+_MCP_MAX_ATTACHMENTS = mcp_attachment_upload.MCP_MAX_ATTACHMENTS
+_MCP_MAX_TOTAL_ATTACHMENT_BYTES = mcp_attachment_upload.MCP_MAX_TOTAL_ATTACHMENT_BYTES
 
 
 def _is_mcp_upload_object_path(url: str) -> bool:
-    """이 url 이 `upload_conversation_attachment`(MCP JSON 업로드)로 실제 생성된 객체 경로인지.
-
-    그 엔드포인트만 `org/<org>/project/<project>/chat/<conversation>/mcp/<file>` 형태(6번째
-    segment=``mcp``)로 서버가 직접 object_path 를 구성한다 — client 는 ``name``(파일명 suffix)
-    외에는 경로에 관여할 수 없어 이 segment 를 조작해 자신에게 더 엄격한 검사를 켜는 것 외엔
-    스푸핑 이득이 없다(false-positive 는 harmless·false-negative 는 발생하지 않음 — 이 엔드포인트가
-    쓰는 유일한 shape).
-    """
-    canon = canonical_object_path(url, DEFAULT_CONTAINER)
-    if not canon:
-        return False
-    parts = canon.split("/")
-    return (
-        len(parts) >= 7
-        and parts[0] == "org" and parts[2] == "project" and parts[4] == "chat" and parts[6] == "mcp"
-    )
+    return mcp_attachment_upload.is_mcp_upload_object_path(url, kind="chat")
 
 
 class MessageAttachment(BaseModel):
@@ -1526,11 +1500,6 @@ async def send_message(
     return response
 
 
-def _safe_attachment_filename(name: str) -> str:
-    safe = _SAFE_ATTACHMENT_NAME_RE.sub("_", name.strip())[-128:]
-    return safe or "file"
-
-
 @router.post(
     "/{conversation_id}/attachments",
     status_code=201,
@@ -1569,26 +1538,17 @@ async def upload_conversation_attachment(
     if participant is None:
         raise HTTPException(status_code=403, detail="Not a participant")
 
-    try:
-        data = base64.b64decode(body.content_base64, validate=True)
-    except (binascii.Error, ValueError):
-        raise HTTPException(status_code=400, detail="content_base64 must be valid base64")
-    if not data:
-        raise HTTPException(status_code=400, detail="attachment must not be empty")
-    if len(data) > _MAX_JSON_ATTACHMENT_UPLOAD_SIZE:
-        raise HTTPException(
-            status_code=413,
-            detail=f"attachment too large (max {_MAX_JSON_ATTACHMENT_UPLOAD_SIZE} bytes)",
-        )
+    data = mcp_attachment_upload.decode_json_attachment(body.content_base64)
 
-    safe_name = _safe_attachment_filename(body.name)
+    safe_name = mcp_attachment_upload.safe_attachment_filename(body.name)
     # S7 namespace — FE 업로드 라우트(apps/web .../conversations/[id]/attachments/route.ts)와 동일
     # 접두(org/<org>/project/<project>/chat/<conv>/...). path_in_source_scope 는 이 접두까지만
     # segment-match 하므로(그 뒤 세그먼트 수는 안 봄) 추가된 `mcp/` 세그먼트는 IDOR 가드/read-authorize
     # 통과에 영향 없다 — E-MCP-OPT S5(#2): 이 엔드포인트로 실제 생성된 객체만 식별하는 마커
     # (`_is_mcp_upload_object_path`)로 send_message 의 선언 한도 재검증이 소비한다.
-    object_path = (
-        f"org/{org_id}/project/{conv.project_id}/chat/{conversation_id}/mcp/{uuid.uuid4()}-{safe_name}"
+    object_path = mcp_attachment_upload.build_mcp_object_path(
+        org_id=org_id, project_id=conv.project_id, kind="chat", resource_id=conversation_id,
+        safe_name=safe_name,
     )
 
     uploaded = await get_storage_provider().put_object(

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -1,8 +1,11 @@
 """E-EVENTBUS P7-A S37: conversations 테이블 + Chat API."""
 from __future__ import annotations
 
+import base64
+import binascii
 import json
 import logging
+import re
 import uuid
 from collections import defaultdict
 from datetime import datetime, timezone
@@ -26,7 +29,7 @@ from app.routers.events import _push_to_agent, publish_event
 from app.schemas.attachment import validate_attachment_url
 from app.services import chat_presence
 from app.services.agent_runtime import supports_deterministic_command
-from app.services.asset_registry import sync_attachment_assets
+from app.services.asset_registry import DEFAULT_CONTAINER, sync_attachment_assets
 from app.services.command_classifier import classify_command
 from app.services.event_seq import assign_recipient_seq
 from app.services.member_resolver import (
@@ -36,6 +39,7 @@ from app.services.member_resolver import (
     resolve_member,
     resolve_member_identity,
 )
+from app.services.storage import get_storage_provider
 
 logger = logging.getLogger(__name__)
 
@@ -582,6 +586,13 @@ class ConversationResponse(BaseModel):
 _MAX_ATTACHMENTS = 10
 _MAX_ATTACHMENT_SIZE = 100 * 1024 * 1024  # 100MB (메타 sanity 상한)
 
+# E-MCP-OPT S2(bbfd24ba): MCP(비-브라우저) 클라이언트용 JSON/base64 업로드 — 스샷/작은 문서가
+# 실사용(대용량 아님). FE-proxy 100MB 캡과 별개로 더 작게(Cloud Run HTTP/1 32MiB 요청 캡 대비
+# 여유 마진). sprintable_mcp 의 동일 상수(tools/chat.py `_MCP_MAX_ATTACHMENT_BYTES`)와 정합.
+_MAX_JSON_ATTACHMENT_UPLOAD_SIZE = 2 * 1024 * 1024  # 2MiB decoded
+_MAX_ATTACHMENT_NAME_LEN = 255
+_SAFE_ATTACHMENT_NAME_RE = re.compile(r"[^\w.\-]+")
+
 
 class MessageAttachment(BaseModel):
     url: str           # FE-proxy 업로드 객체 url(https GCS 또는 canonical bare path·provider 추상)
@@ -627,6 +638,29 @@ class SendMessageRequest(BaseModel):
     def _limit_attachments(cls, v: list[MessageAttachment]) -> list[MessageAttachment]:
         if len(v) > _MAX_ATTACHMENTS:
             raise ValueError(f"too many attachments (max {_MAX_ATTACHMENTS})")
+        return v
+
+
+class UploadConversationAttachmentRequest(BaseModel):
+    """E-MCP-OPT S2: MCP(비-브라우저)용 JSON/base64 첨부 업로드 요청."""
+
+    content_base64: str
+    name: str
+    content_type: str
+
+    @field_validator("content_base64", "name", "content_type")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("must not be empty")
+        return v
+
+    @field_validator("content_type")
+    @classmethod
+    def _content_type_sane(cls, v: str) -> str:
+        if len(v) > _MAX_ATTACHMENT_NAME_LEN or any(ord(ch) < 32 for ch in v):
+            raise ValueError("invalid content_type")
         return v
 
 
@@ -1445,6 +1479,83 @@ async def send_message(
     if command_hints:
         response["command_gate"] = {"blocked": command_hints}
     return response
+
+
+def _safe_attachment_filename(name: str) -> str:
+    safe = _SAFE_ATTACHMENT_NAME_RE.sub("_", name.strip())[-128:]
+    return safe or "file"
+
+
+@router.post(
+    "/{conversation_id}/attachments",
+    status_code=201,
+    response_model=MessageAttachment,
+    response_model_exclude_none=True,
+)
+async def upload_conversation_attachment(
+    conversation_id: uuid.UUID,
+    body: UploadConversationAttachmentRequest,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> MessageAttachment:
+    """E-MCP-OPT S2(bbfd24ba): 비-브라우저 클라이언트(MCP)용 JSON/base64 첨부 업로드.
+
+    인가는 `send_message`의 실제 발신 요건과 **동일**(참가자 필수) — 읽기 전용 엔드포인트의
+    admin-agent-only-conversation 우회는 여기 적용하지 않는다: 그 우회는 GET(list/get_conversation)
+    전용이고, 업로드는 결국 이 conversation 에 메시지를 보내는 것과 같은 쓰기 동작이라
+    `send_message`(에이전트 sender 는 참가자 아니면 무조건 403·우회/auto-join 없음)와 정합해야
+    한다 — 그렇지 않으면 비참가자 admin 에이전트가 업로드는 성공하고 뒤이은 send_chat_message 는
+    403 나는 모순이 생긴다.
+    """
+    conv = (await db.execute(
+        select(Conversation).where(Conversation.id == conversation_id, Conversation.org_id == org_id)
+    )).scalar_one_or_none()
+    if conv is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    sender = await _resolve_member(auth, org_id, db, project_id=conv.project_id)
+    participant = (await db.execute(
+        select(ConversationParticipant.id).where(
+            ConversationParticipant.conversation_id == conversation_id,
+            ConversationParticipant.member_id == sender.id,
+        )
+    )).scalar_one_or_none()
+    if participant is None:
+        raise HTTPException(status_code=403, detail="Not a participant")
+
+    try:
+        data = base64.b64decode(body.content_base64, validate=True)
+    except (binascii.Error, ValueError):
+        raise HTTPException(status_code=400, detail="content_base64 must be valid base64")
+    if not data:
+        raise HTTPException(status_code=400, detail="attachment must not be empty")
+    if len(data) > _MAX_JSON_ATTACHMENT_UPLOAD_SIZE:
+        raise HTTPException(
+            status_code=413,
+            detail=f"attachment too large (max {_MAX_JSON_ATTACHMENT_UPLOAD_SIZE} bytes)",
+        )
+
+    safe_name = _safe_attachment_filename(body.name)
+    # S7 namespace — FE 업로드 라우트(apps/web .../conversations/[id]/attachments/route.ts)와
+    # 정확히 동일한 shape(org/<org>/project/<project>/chat/<conv>/<file>). path_in_source_scope/
+    # sync_attachment_assets 가 기대하는 스코프와 일치해야 IDOR 가드·read-authorize 가 통과한다.
+    object_path = (
+        f"org/{org_id}/project/{conv.project_id}/chat/{conversation_id}/{uuid.uuid4()}-{safe_name}"
+    )
+
+    uploaded = await get_storage_provider().put_object(
+        DEFAULT_CONTAINER, object_path, data, content_type=body.content_type,
+    )
+    if not uploaded:
+        raise HTTPException(status_code=502, detail="upload failed")
+
+    return MessageAttachment(
+        url=object_path,
+        name=body.name,
+        content_type=body.content_type,
+        size=len(data),
+    )
 
 
 @router.patch("/{conversation_id}/status", status_code=200)

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -29,7 +29,7 @@ from app.routers.events import _push_to_agent, publish_event
 from app.schemas.attachment import validate_attachment_url
 from app.services import chat_presence
 from app.services.agent_runtime import supports_deterministic_command
-from app.services.asset_registry import DEFAULT_CONTAINER, sync_attachment_assets
+from app.services.asset_registry import DEFAULT_CONTAINER, canonical_object_path, sync_attachment_assets
 from app.services.command_classifier import classify_command
 from app.services.event_seq import assign_recipient_seq
 from app.services.member_resolver import (
@@ -592,6 +592,34 @@ _MAX_ATTACHMENT_SIZE = 100 * 1024 * 1024  # 100MB (메타 sanity 상한)
 _MAX_JSON_ATTACHMENT_UPLOAD_SIZE = 2 * 1024 * 1024  # 2MiB decoded
 _MAX_ATTACHMENT_NAME_LEN = 255
 _SAFE_ATTACHMENT_NAME_RE = re.compile(r"[^\w.\-]+")
+# E-MCP-OPT S5(#2, 까심 QA): 위 per-file 2MiB 캡은 걸지만 "선언 한도"(5개/6MiB 합계 — sprintable_mcp
+# `tools/chat.py` 의 client-side 가드와 동일 값)는 이 엔드포인트가 서버서 강제하지 않았다 —
+# participant 가 여러 번 개별 호출로(각 ≤2MiB) 메시지당 최대 10개(기존 `_MAX_ATTACHMENTS`)×2MiB≈
+# 20MiB 를 모아 SSOT 정책을 우회할 수 있었다(보안 취약점 아님·기존 message-level 캡으로 bounded — SSOT
+# 원칙 위반). object_path 에 `mcp/` 세그먼트를 심어 이 엔드포인트로 실제 업로드된 첨부만 식별하고,
+# `send_message` 가 그 부분집합에 한해 선언 한도를 재검증한다(새 테이블/시간창 추적 0 — 메시지 생성
+# 시점 1회 재검증으로 충분·메시지 없이 업로드만 반복하는 건 orphan blob 만 남길 뿐 이 한도와 무관).
+_MCP_MAX_ATTACHMENTS = 5
+_MCP_MAX_TOTAL_ATTACHMENT_BYTES = 6 * 1024 * 1024  # 6MiB decoded
+
+
+def _is_mcp_upload_object_path(url: str) -> bool:
+    """이 url 이 `upload_conversation_attachment`(MCP JSON 업로드)로 실제 생성된 객체 경로인지.
+
+    그 엔드포인트만 `org/<org>/project/<project>/chat/<conversation>/mcp/<file>` 형태(6번째
+    segment=``mcp``)로 서버가 직접 object_path 를 구성한다 — client 는 ``name``(파일명 suffix)
+    외에는 경로에 관여할 수 없어 이 segment 를 조작해 자신에게 더 엄격한 검사를 켜는 것 외엔
+    스푸핑 이득이 없다(false-positive 는 harmless·false-negative 는 발생하지 않음 — 이 엔드포인트가
+    쓰는 유일한 shape).
+    """
+    canon = canonical_object_path(url, DEFAULT_CONTAINER)
+    if not canon:
+        return False
+    parts = canon.split("/")
+    return (
+        len(parts) >= 7
+        and parts[0] == "org" and parts[2] == "project" and parts[4] == "chat" and parts[6] == "mcp"
+    )
 
 
 class MessageAttachment(BaseModel):
@@ -1245,6 +1273,23 @@ async def send_message(
         from ee.plan_limits import check_storage_capacity  # type: ignore[import]
         await check_storage_capacity(db, org_id, [a.model_dump() for a in body.attachments])
 
+    # E-MCP-OPT S5(#2): MCP JSON 업로드 엔드포인트가 개별 업로드마다 파일당 2MiB만 검사하고
+    # 선언 한도(5개/6MiB 합계)를 강제 안 해 다회 호출로 우회 가능했다 — 이 메시지가 실제로
+    # 참조하는 mcp-origin 첨부 부분집합에 한해 여기서 재검증(전체 attachments 가 아님 — FE 업로드
+    # 첨부는 기존 100MB/10개 한도만 적용받는다·회귀0).
+    if body.attachments:
+        mcp_origin = [a for a in body.attachments if _is_mcp_upload_object_path(a.url)]
+        if len(mcp_origin) > _MCP_MAX_ATTACHMENTS or (
+            sum(a.size for a in mcp_origin) > _MCP_MAX_TOTAL_ATTACHMENT_BYTES
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"mcp attachments exceed declared limit "
+                    f"(max {_MCP_MAX_ATTACHMENTS} files / {_MCP_MAX_TOTAL_ATTACHMENT_BYTES} bytes total)"
+                ),
+            )
+
     msg = ConversationMessage(
         conversation_id=conversation_id,
         sender_id=sender.id,
@@ -1537,11 +1582,13 @@ async def upload_conversation_attachment(
         )
 
     safe_name = _safe_attachment_filename(body.name)
-    # S7 namespace — FE 업로드 라우트(apps/web .../conversations/[id]/attachments/route.ts)와
-    # 정확히 동일한 shape(org/<org>/project/<project>/chat/<conv>/<file>). path_in_source_scope/
-    # sync_attachment_assets 가 기대하는 스코프와 일치해야 IDOR 가드·read-authorize 가 통과한다.
+    # S7 namespace — FE 업로드 라우트(apps/web .../conversations/[id]/attachments/route.ts)와 동일
+    # 접두(org/<org>/project/<project>/chat/<conv>/...). path_in_source_scope 는 이 접두까지만
+    # segment-match 하므로(그 뒤 세그먼트 수는 안 봄) 추가된 `mcp/` 세그먼트는 IDOR 가드/read-authorize
+    # 통과에 영향 없다 — E-MCP-OPT S5(#2): 이 엔드포인트로 실제 생성된 객체만 식별하는 마커
+    # (`_is_mcp_upload_object_path`)로 send_message 의 선언 한도 재검증이 소비한다.
     object_path = (
-        f"org/{org_id}/project/{conv.project_id}/chat/{conversation_id}/{uuid.uuid4()}-{safe_name}"
+        f"org/{org_id}/project/{conv.project_id}/chat/{conversation_id}/mcp/{uuid.uuid4()}-{safe_name}"
     )
 
     uploaded = await get_storage_provider().put_object(

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -3,7 +3,7 @@ import uuid
 from datetime import datetime
 
 from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from sqlalchemy import delete, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -741,4 +741,133 @@ async def register_doc_asset(
     await session.commit()
     return DocAssetRegisterResponse(
         asset_id=asset_id, filename=body.filename, size=real_size, mime=body.mime
+    )
+
+
+class UploadDocAttachmentRequest(BaseModel):
+    """E-MCP-OPT S6: MCP(비-브라우저)용 JSON/base64 첨부 업로드 요청(chat/story와 동형)."""
+
+    content_base64: str
+    name: str
+    content_type: str
+
+    @field_validator("content_base64", "name", "content_type")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("must not be empty")
+        return v
+
+    @field_validator("content_type")
+    @classmethod
+    def _content_type_sane(cls, v: str) -> str:
+        from app.services import mcp_attachment_upload
+        if len(v) > mcp_attachment_upload.MAX_ATTACHMENT_NAME_LEN or any(ord(ch) < 32 for ch in v):
+            raise ValueError("invalid content_type")
+        return v
+
+
+class UploadDocAttachmentResponse(BaseModel):
+    asset_id: uuid.UUID
+    filename: str
+    size: int
+    mime: str | None = None
+    # E-MCP-OPT S6: 에이전트가 doc 임베드 마크업(TipTap file-node/image-node 계약)을 몰라도 되게
+    # MCP 패키지가 그대로 content 에 붙일 수 있는 완성 HTML 스니펫. doc-content-renderer.tsx/
+    # file-node.tsx/image-node.tsx 의 실 렌더 계약과 정확히 일치(uploader 무관 렌더 — FE 변경 0).
+    embed_snippet: str
+
+
+def _build_doc_attachment_embed_snippet(
+    *, asset_id: uuid.UUID, name: str, content_type: str, size: int,
+) -> str:
+    """FE `file-node.tsx`/`image-node.tsx` renderHTML 계약과 정확히 일치하는 마크업 조립.
+
+    이미지(mime image/*) → `<img data-asset-id data-filename data-size data-mime-type alt>`.
+    그 외 → `<div data-type="fileAttachment" data-filename data-size data-mime-type data-asset-id>`.
+    파일명은 doc content(HTML)에 그대로 꽂히므로 attribute-context escape 필수(주입 방지).
+    """
+    import html as _html
+
+    safe_name = _html.escape(name, quote=True)
+    safe_mime = _html.escape(content_type or "application/octet-stream", quote=True)
+    if (content_type or "").lower().startswith("image/"):
+        return (
+            f'<img data-asset-id="{asset_id}" data-filename="{safe_name}" '
+            f'data-size="{size}" data-mime-type="{safe_mime}" alt="{safe_name}">'
+        )
+    return (
+        f'<div data-type="fileAttachment" data-filename="{safe_name}" data-size="{size}" '
+        f'data-mime-type="{safe_mime}" data-asset-id="{asset_id}"></div>'
+    )
+
+
+@router.post(
+    "/{doc_id}/attachments", response_model=UploadDocAttachmentResponse, status_code=201,
+)
+async def upload_doc_attachment(
+    doc_id: uuid.UUID,
+    body: UploadDocAttachmentRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> UploadDocAttachmentResponse:
+    """E-MCP-OPT S6: 비-브라우저 클라이언트(MCP)용 JSON/base64 doc 첨부 업로드 + 즉시 등록.
+
+    `register_doc_asset`(FE 2단계: FE putObject → 이 register)와 달리 MCP 는 base64 업로드+등록을
+    한 호출로 합친다(FE 세션 없이 base64 만으로 완결). 인가/등록 로직은 `register_doc_asset`과 동일
+    (has_project_access·sync_attachment_assets) — doc 은 업로드=등록이 곧 종결 액션이라(story/chat과
+    달리 별도 "메시지 생성" 시점이 없음) S5식 집계 재검증이 불필요하다(이 한 호출 자체가 그 지점).
+    """
+    from app.models.doc import Doc
+    from app.services import mcp_attachment_upload
+    from app.services.asset_registry import DEFAULT_CONTAINER, sync_attachment_assets
+    from app.services.member_resolver import resolve_member
+    from app.services.project_auth import has_project_access
+    from app.services.storage import get_storage_provider
+
+    doc = (await session.execute(
+        select(Doc).where(Doc.id == doc_id, Doc.org_id == org_id, Doc.deleted_at.is_(None))
+    )).scalar_one_or_none()
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Doc not found")
+    if not await has_project_access(session, uuid.UUID(auth.user_id), doc.project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
+    data = mcp_attachment_upload.decode_json_attachment(body.content_base64)
+    safe_name = mcp_attachment_upload.safe_attachment_filename(body.name)
+    object_path = mcp_attachment_upload.build_mcp_object_path(
+        org_id=org_id, project_id=doc.project_id, kind="doc", resource_id=doc_id, safe_name=safe_name,
+    )
+
+    uploaded = await get_storage_provider().put_object(
+        DEFAULT_CONTAINER, object_path, data, content_type=body.content_type,
+    )
+    if not uploaded:
+        raise HTTPException(status_code=502, detail="upload failed")
+
+    created_by: uuid.UUID | None = None
+    try:
+        created_by = (await resolve_member(auth, org_id, session)).id
+    except Exception:  # noqa: BLE001 — created_by 는 비필수(asset.created_by nullable).
+        created_by = None
+
+    att = {"url": object_path, "name": body.name, "content_type": body.content_type, "size": len(data)}
+    url_map = await sync_attachment_assets(
+        session, org_id=org_id, project_id=doc.project_id, source_type="doc",
+        source_id=doc_id, attachments=[att], created_by=created_by,
+    )
+    asset_id = url_map.get(object_path)
+    if asset_id is None:
+        # 우리가 방금 쓴 path 가 우리가 만든 접두를 못 지나면 path_in_source_scope 버그(방어적 500) —
+        # register_doc_asset 의 400(client 경로 스푸핑)과 원인이 다르므로 구분한다.
+        raise HTTPException(status_code=500, detail="asset registration failed for uploaded object")
+    await session.commit()
+
+    return UploadDocAttachmentResponse(
+        asset_id=asset_id, filename=body.name, size=len(data), mime=body.content_type,
+        embed_snippet=_build_doc_attachment_embed_snippet(
+            asset_id=asset_id, name=body.name, content_type=body.content_type, size=len(data),
+        ),
     )

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Query, Response
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -17,8 +17,9 @@ from app.repositories.story_assignee import StoryAssigneeRepository
 from app.routers.agent_gateway import wake_agent
 from app.routers.events import publish_event
 from app.services.event_seq import assign_recipient_seq
-from app.services.asset_registry import sync_attachment_assets
-from app.schemas.story import StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
+from app.services import mcp_attachment_upload
+from app.services.asset_registry import DEFAULT_CONTAINER, sync_attachment_assets
+from app.schemas.story import StoryAttachment, StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
 from app.services.member_resolver import canonicalize_member_id
 from app.services.merge_verdict_gate import (
     AUTO_MERGE,
@@ -200,6 +201,23 @@ async def _preflight_merge_gate(
         )
 
 
+def _enforce_mcp_attachment_declared_limit(attachments: list[dict]) -> None:
+    """E-MCP-OPT S6: chat(S5 #2)과 동일 갭을 story 에서 처음부터 막는다 — mcp-태그 첨부(dict shape:
+    url/size 키) 부분집합만 선언한도(5개/6MiB) 재검증. FE 업로드 첨부(마커 없음)는 무관."""
+    mcp_origin = [a for a in attachments if mcp_attachment_upload.is_mcp_upload_object_path(a["url"], kind="story")]
+    if len(mcp_origin) > mcp_attachment_upload.MCP_MAX_ATTACHMENTS or (
+        sum(a["size"] for a in mcp_origin) > mcp_attachment_upload.MCP_MAX_TOTAL_ATTACHMENT_BYTES
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"mcp attachments exceed declared limit "
+                f"(max {mcp_attachment_upload.MCP_MAX_ATTACHMENTS} files / "
+                f"{mcp_attachment_upload.MCP_MAX_TOTAL_ATTACHMENT_BYTES} bytes total)"
+            ),
+        )
+
+
 @router.post("", response_model=StoryResponse, status_code=201)
 async def create_story(
     body: StoryCreate,
@@ -226,6 +244,8 @@ async def create_story(
         body.assignee_id if body.assignee_id is not None
         else (effective_ids[0] if effective_ids else None)
     )
+    if body.attachments:
+        _enforce_mcp_attachment_declared_limit([a.model_dump() for a in body.attachments])
     # S8: 서버사이드 capacity 게이트(ee seam·SaaS only·OSS no-op) — asset commit 前 per-file+총량 enforce.
     if settings.is_ee_enabled and body.attachments:
         from ee.plan_limits import check_storage_capacity  # type: ignore[import]
@@ -326,6 +346,72 @@ async def get_story(
         raise HTTPException(status_code=404, detail="Story not found")
     await _attach_assignee_ids(repo.session, repo.org_id, [story])
     return StoryResponse.model_validate(story)
+
+
+class UploadStoryAttachmentRequest(BaseModel):
+    """E-MCP-OPT S6: MCP(비-브라우저)용 JSON/base64 첨부 업로드 요청(chat과 동형)."""
+
+    content_base64: str
+    name: str
+    content_type: str
+
+    @field_validator("content_base64", "name", "content_type")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("must not be empty")
+        return v
+
+    @field_validator("content_type")
+    @classmethod
+    def _content_type_sane(cls, v: str) -> str:
+        if len(v) > mcp_attachment_upload.MAX_ATTACHMENT_NAME_LEN or any(ord(ch) < 32 for ch in v):
+            raise ValueError("invalid content_type")
+        return v
+
+
+@router.post(
+    "/{id}/attachments", status_code=201, response_model=StoryAttachment, response_model_exclude_none=True,
+)
+async def upload_story_attachment(
+    id: uuid.UUID,
+    body: UploadStoryAttachmentRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> StoryAttachment:
+    """E-MCP-OPT S6: 비-브라우저 클라이언트(MCP)용 JSON/base64 스토리 첨부 업로드(chat과 동형).
+
+    인가 = `has_project_access`(story.project_id) — `register_doc_asset`/`enforce_body_context`(story
+    create)와 동일 SSOT. object_path 는 FE 업로드 라우트(`apps/web/.../stories/[id]/attachments/
+    route.ts`)와 동일 접두(org/<org>/project/<project>/story/<id>/...)+`mcp/` 마커(S5 패턴 재사용) —
+    create/update_story 가 그 부분집합만 선언한도(5개/6MiB)를 재검증한다.
+    """
+    story = (await session.execute(
+        select(Story).where(Story.id == id, Story.org_id == org_id)
+    )).scalar_one_or_none()
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(session, uuid.UUID(auth.user_id), story.project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
+    data = mcp_attachment_upload.decode_json_attachment(body.content_base64)
+    safe_name = mcp_attachment_upload.safe_attachment_filename(body.name)
+    object_path = mcp_attachment_upload.build_mcp_object_path(
+        org_id=org_id, project_id=story.project_id, kind="story", resource_id=id, safe_name=safe_name,
+    )
+
+    from app.services.storage import get_storage_provider
+    uploaded = await get_storage_provider().put_object(
+        DEFAULT_CONTAINER, object_path, data, content_type=body.content_type,
+    )
+    if not uploaded:
+        raise HTTPException(status_code=502, detail="upload failed")
+
+    return StoryAttachment(url=object_path, name=body.name, content_type=body.content_type, size=len(data))
 
 
 # E-DG S10(P1-4 observability): workflow-line 상태 read API — "왜 막혔나·어디로 relay 됐나"를
@@ -505,6 +591,7 @@ async def update_story(
     # S7: client 제공 asset_id strip(서버 권위·drift 방지·까심)·아래 sync url_map 으로만 역기입.
     if data.get("attachments"):
         data["attachments"] = [{**a, "asset_id": None} for a in data["attachments"]]
+        _enforce_mcp_attachment_declared_limit(data["attachments"])
         # S8: 서버사이드 capacity 게이트(ee seam·SaaS only·OSS no-op) — 첨부 교체 commit 前 enforce.
         if settings.is_ee_enabled:
             from ee.plan_limits import check_storage_capacity  # type: ignore[import]

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -16,7 +16,7 @@ from app.repositories.team_member import TeamMemberRepository
 from app.schemas.team_member import (
     ActiveStorySummary, TeamMemberCreate, TeamMemberResponse, TeamMemberUpdate,
 )
-from app.services.agent_onboarding_config import build_agent_mcp_config
+from app.services.agent_onboarding_config import build_agent_mcp_config_bundle
 
 
 class ClaimBody(BaseModel):
@@ -314,8 +314,11 @@ async def create_team_member(
         effective_port = fakechat_port or int(os.environ.get("FAKECHAT_PORT", _FAKECHAT_BASE_PORT))
         response["fakechat_port"] = effective_port
         response["api_key_created"] = bool(api_key_plaintext)
-        # OB-1 AC2: 단일 SSOT generator 소비(stdio 아티팩트). 인라인 sse config 제거.
-        response["mcp_config"] = build_agent_mcp_config(api_key_plaintext=api_key_plaintext)
+        # E-MCP-OPT S3: 단일 SSOT generator 소비 — edition 기본 + 두 transport 변형 동봉(FE round-trip 0).
+        config_bundle = build_agent_mcp_config_bundle(api_key_plaintext=api_key_plaintext)
+        response["mcp_config"] = config_bundle["mcp_config"]
+        response["default_transport"] = config_bundle["default_transport"]
+        response["mcp_config_alternatives"] = config_bundle["mcp_config_alternatives"]
         if api_key_plaintext:
             response["api_key"] = api_key_plaintext
 

--- a/backend/app/services/agent_onboarding_config.py
+++ b/backend/app/services/agent_onboarding_config.py
@@ -1,12 +1,15 @@
-"""에이전트 온보딩 config 단일 SSOT generator (OB-1 · 블루프린트 §2/§7).
+"""에이전트 온보딩 config 단일 SSOT generator (OB-1 · 블루프린트 §2/§7 + E-MCP-OPT S3).
 
 team_members·agents 라우트 + connection-artifact API 가 **모두 이 generator 하나만** 소비한다 —
 README·onboarding-form·in-app docs·로컬 buildMcpConfig 4갈래로 흩어져 모순되던 config 를 단일화.
 
-생성 아티팩트 = **stdio sprintable-mcp `.mcp.json`**(§2): stdio 만 툴+이벤트를 한 프로세스로 묶는다
-(HTTP=tools-only). ``SPRINTABLE_AGENT_ID``/``WS_URL``/``port`` 는 넣지 않는다(서버 자동 도출/불요).
-``SPRINTABLE_API_URL`` 은 **backend-direct Cloud Run URL** — CF-fronted 깔끔 도메인은 ①/agent/stream
-SSE 버퍼링 ②봇차단 때문에 금지(블루프린트 §2/§3·선생님 catch).
+두 transport 아티팩트를 생성한다(§2):
+- **stdio** `.mcp.json`(로컬 uvx) — 툴+이벤트를 한 프로세스로 묶는다(§2/§3). ``SPRINTABLE_API_URL`` 은
+  **backend-direct Cloud Run URL** — CF-fronted 깔끔 도메인은 ①/agent/stream SSE 버퍼링 ②봇차단
+  때문에 금지(블루프린트 §2/§3·선생님 catch).
+- **http**(E-MCP-OPT S3) — 호스팅(`sprintable-mcp-prod`) streamable-http, `MCP_PUBLIC_URL` 깔끔
+  도메인 + per-request bearer. **tools-only**(이벤트 경로 분리 — SSE bridge 미구동, `agent_verify.py`
+  가 transport-aware 축소 rail로 대응한다).
 """
 from __future__ import annotations
 
@@ -14,6 +17,9 @@ import os
 
 DEFAULT_RUNTIME = "claude-code"
 SUPPORTED_RUNTIMES = frozenset({"claude-code"})
+STDIO = "stdio"
+HTTP = "http"
+SUPPORTED_TRANSPORTS = frozenset({STDIO, HTTP})
 
 _LOCAL_FALLBACK_URL = "http://localhost:8000"
 # generator 가 backend-direct URL 을 읽는 런타임 env. 배포(deploy_backend.sh)가 주입한다.
@@ -21,6 +27,9 @@ _LOCAL_FALLBACK_URL = "http://localhost:8000"
 # ⚠️ `SPRINTABLE_API_URL`(=에이전트/MCP 측 env 이름)을 backend fallback 으로 읽지 않는다 — backend
 # 런타임엔 미설정이고, 혹 CF 도메인으로 새어 들어오면 잘못 집을 footgun(PO QA). 단일 canonical 키.
 _BACKEND_URL_ENV_KEY = "FASTAPI_URL"
+# E-MCP-OPT S3: 호스팅 MCP 깔끔 도메인 — README(구·문서만 언급) 대신 실제로 read. 미설정(OSS/로컬 —
+# 호스팅 배포 자체가 없음)이면 http 변형을 아예 생성하지 않는다(에러 아님·"그 탭 없음"이 정답).
+_MCP_PUBLIC_URL_ENV_KEY = "MCP_PUBLIC_URL"
 
 
 def resolve_backend_direct_url() -> str:
@@ -33,20 +42,33 @@ def resolve_backend_direct_url() -> str:
     return val.rstrip("/") if val else _LOCAL_FALLBACK_URL
 
 
-def build_agent_mcp_config(
-    *,
-    api_key_plaintext: str | None,
-    runtime: str = DEFAULT_RUNTIME,
-) -> dict:
+def resolve_mcp_public_url() -> str | None:
+    """호스팅 MCP 깔끔 도메인(``MCP_PUBLIC_URL``, 예 ``https://mcp.sprintable.ai/mcp``).
+
+    미설정(OSS/로컬 등 호스팅 배포가 없는 환경) → None(http 변형 생성 불가 신호 — 호출부가 이를
+    "그 옵션 자체가 없음"으로 취급한다. 에러 아님).
+    """
+    val = os.environ.get(_MCP_PUBLIC_URL_ENV_KEY, "").strip()
+    return val.rstrip("/") if val else None
+
+
+def default_transport_for_edition() -> str:
+    """edition별 기본 transport — SaaS(EE)=http(무마찰 호스팅) / OSS=stdio(호스팅 배포 없음).
+
+    기존 OSS/SaaS 스위치(``settings.is_ee_enabled``) 재사용 — 신규 플래그 0.
+    """
+    from app.core.config import settings
+
+    return HTTP if settings.is_ee_enabled else STDIO
+
+
+def _build_stdio_config(api_key_plaintext: str | None) -> dict:
     """stdio sprintable-mcp `.mcp.json` 아티팩트(SSOT · 블루프린트 §2).
 
     env = {``SPRINTABLE_API_URL`` = backend-direct, ``AGENT_API_KEY`` = (있을 때만)}.
     ``api_key_plaintext`` 가 없으면(미발급/회전·기존 sse 경로 동형) ``AGENT_API_KEY`` 키를 생략한다 —
     소비자(GET connection-artifact)가 placeholder 를 넣거나 사용자가 자기 키를 채운다(AC4: 기존
     SPRINTABLE_API_KEY fallback 호환·미발급 시 키 비노출).
-
-    runtime 은 현재 ``claude-code`` 단일(향후 cursor 등 분기 여지). 미지원 값은 호출부(엔드포인트)가
-    400 으로 거른다 — generator 는 항상 canonical stdio 아티팩트를 만든다.
 
     **OB-2-align — 두 SSE 시스템 통일(AC④)**: sse_bridge 는 ``AGENT_GATEWAY_V2`` env 로 수신 경로를
     가른다(sse_bridge.py). 두 경로 공존:
@@ -73,4 +95,74 @@ def build_agent_mcp_config(
                 "env": env,
             }
         }
+    }
+
+
+def _build_http_config(api_key_plaintext: str | None) -> dict | None:
+    """호스팅 streamable-http `.mcp.json` 변형(E-MCP-OPT S3).
+
+    ``MCP_PUBLIC_URL`` 미설정이면 None(이 환경엔 호스팅 배포가 없다는 뜻 — 호출부가 변형을 생략).
+    ``AGENT_API_KEY`` 는 env 가 아니라 **per-request bearer**(``Authorization`` 헤더)로 인증 —
+    stdio 의 env-key 단일 인증과 다른 http transport 의 실제 인증 방식과 정합.
+    """
+    url = resolve_mcp_public_url()
+    if url is None:
+        return None
+    headers: dict[str, str] = {}
+    if api_key_plaintext:
+        headers["Authorization"] = f"Bearer {api_key_plaintext}"
+    return {
+        "mcpServers": {
+            "sprintable": {
+                "type": "http",
+                "url": url,
+                "headers": headers,
+            }
+        }
+    }
+
+
+def build_agent_mcp_config(
+    *,
+    api_key_plaintext: str | None,
+    runtime: str = DEFAULT_RUNTIME,
+    transport: str = STDIO,
+) -> dict | None:
+    """`.mcp.json` 아티팩트 generator — transport 별 SSOT(E-MCP-OPT S3).
+
+    runtime 은 현재 ``claude-code`` 단일(향후 cursor 등 분기 여지). 미지원 값은 호출부(엔드포인트)가
+    400 으로 거른다 — generator 는 항상 canonical 아티팩트를 만든다.
+
+    ``transport="http"`` 인데 이 환경에 호스팅 배포가 없으면(``MCP_PUBLIC_URL`` 미설정) None 반환 —
+    호출부가 이를 "그 변형 생성 불가"로 취급(에러 아님).
+    """
+    if transport == HTTP:
+        return _build_http_config(api_key_plaintext)
+    return _build_stdio_config(api_key_plaintext)
+
+
+def build_agent_mcp_config_bundle(
+    *,
+    api_key_plaintext: str | None,
+    runtime: str = DEFAULT_RUNTIME,
+) -> dict:
+    """connect-step 토글용 — **두 transport 변형을 한 번에** 반환(FE round-trip 0, §5 SSOT 보존).
+
+    ``{"default_transport": ..., "mcp_config": <default 변형>,
+    "mcp_config_alternatives": {<다른 transport>: <그 변형>, ...}}``. http 변형이 이 환경에서
+    생성 불가(``MCP_PUBLIC_URL`` 미설정)면 alternatives 에서 생략(OSS 는 호스팅 탭 자체가 없음).
+    """
+    default_transport = default_transport_for_edition()
+    configs = {
+        t: build_agent_mcp_config(api_key_plaintext=api_key_plaintext, runtime=runtime, transport=t)
+        for t in SUPPORTED_TRANSPORTS
+    }
+    configs = {t: c for t, c in configs.items() if c is not None}
+    default_config = configs.get(default_transport) or configs[STDIO]
+    resolved_default = default_transport if default_transport in configs else STDIO
+    alternatives = {t: c for t, c in configs.items() if t != resolved_default}
+    return {
+        "default_transport": resolved_default,
+        "mcp_config": default_config,
+        "mcp_config_alternatives": alternatives,
     }

--- a/backend/app/services/agent_verify.py
+++ b/backend/app/services/agent_verify.py
@@ -8,6 +8,20 @@ verification-status` 가 ``acked_seq`` vs 그 seq + 세션 freshness 로 6단계
 재사용. **ack/verified 는 ``acked_seq >= seq`` 권위 신호만**(낙관 0). ``event_delivered`` 는
 reachable~ack 사이 active 로 표현한다 — 게이트웨이 ack-커서 모델상 per-event delivered 를 ack 와
 별개로 durable 마킹하는 신호가 없고, /agent/stream 핫패스를 건드리지 않는다(AC4·PO 확정).
+
+**E-MCP-OPT S3 — transport-aware 축소 레일(crux2)**: 위 6단계 레일은 전부 ``/agent/stream`` SSE
+라운드트립(``AgentGatewaySession``/``AgentEventCursor``) 전용이고, 그 세션/커서는 **stdio 로컬
+프로세스의 ``sse_bridge.py`` 만** 만든다(호스팅 http transport 는 SSE bridge 를 구동하지 않음 —
+``sprintable_mcp/__main__.py`` ``_run_http()`` 참조). 즉 http 로 연결한 에이전트는 이 레일을 그대로
+쓰면 **영구히 waiting 에 멈춰 고장난 것처럼 보인다**(실제로는 정상 동작 중이어도) — 합성 이벤트를
+보낼 서버→에이전트 push 경로 자체가 http(streamable, client-initiated) 에는 없다.
+
+대신 http 는 **모든 tool 호출마다(transport 무관) 찍히는 heartbeat**
+(``PATCH /team-members/{id}/heartbeat`` → ``agent_project_profiles.last_seen_at``)를 reachable
+신호로 재사용한다 — 4단계 축소 레일(``config_copied → waiting → mcp_reachable → verified``,
+event_delivered/ack 없음 — discrete 이벤트 왕복이 구조적으로 불가하므로 mcp_reachable 과 verified 가
+같은 heartbeat 신호에서 함께 파생된다). 신규 테이블/컬럼 0 — 기존 freshness TTL
+(``agent_gateway._SESSION_FRESH_TTL``) 재사용.
 """
 from __future__ import annotations
 
@@ -19,11 +33,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.agent_gateway import AgentEventCursor, AgentGatewaySession
 from app.models.event import Event
+from app.models.member import AgentProjectProfile
 from app.services.event_seq import assign_recipient_seq
 
 VERIFY_EVENT_TYPE = "onboarding.connection_test"
 # 6단계 canonical 레일(OB-3 1:1·OB-4 vocab 정합). config_copied 는 FE 권위(BE 는 waiting 부터 관측).
 RAIL_STATES = ("config_copied", "waiting", "mcp_reachable", "event_delivered", "ack", "verified")
+# E-MCP-OPT S3: http transport 4단계 축소 레일(event_delivered/ack 없음 — §agent_verify.py 상단 설명).
+HTTP_RAIL_STATES = ("config_copied", "waiting", "mcp_reachable", "verified")
 
 
 def build_verification_rail(
@@ -101,8 +118,51 @@ async def _has_fresh_session(db: AsyncSession, agent_id: uuid.UUID) -> bool:
     return row is not None
 
 
-async def get_verification_state(db: AsyncSession, agent_id: uuid.UUID) -> dict:
-    """최신 verify Event seq + acked_seq + 세션 freshness → 레일/verified."""
+async def _has_fresh_heartbeat(db: AsyncSession, agent_id: uuid.UUID) -> bool:
+    """E-MCP-OPT S3: http transport reachable 신호 — heartbeat freshness(agent_project_profiles.
+    last_seen_at). 모든 tool 호출마다 찍히므로(transport 무관) http 에서도 실제로 갱신된다.
+    stdio 의 게이트웨이 세션과 동일 TTL(``_SESSION_FRESH_TTL``) 재사용 — 새 설정 0."""
+    from app.routers.agent_gateway import _SESSION_FRESH_TTL  # lazy: 순환 import 회피
+
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=_SESSION_FRESH_TTL)
+    row = (await db.execute(
+        select(AgentProjectProfile.id).where(
+            AgentProjectProfile.member_id == agent_id,
+            AgentProjectProfile.last_seen_at.isnot(None),
+            AgentProjectProfile.last_seen_at >= cutoff,
+        ).limit(1)
+    )).first()
+    return row is not None
+
+
+def build_http_verification_rail(*, heartbeat_fresh: bool) -> list[dict]:
+    """4단계 축소 레일(http transport) — event_delivered/ack 없음(모듈 docstring 참조).
+
+    heartbeat_fresh 하나로 mcp_reachable/verified 가 함께 판정된다 — http 에는 discrete
+    event-round-trip 신호가 없어 이 둘을 구분할 별도 근거가 없다(설계상 의도·낙관 아님).
+    """
+    if heartbeat_fresh:
+        tail = [("waiting", "done"), ("mcp_reachable", "done"), ("verified", "done")]
+    else:
+        tail = [("waiting", "active"), ("mcp_reachable", "pending"), ("verified", "pending")]
+    return [{"state": "config_copied", "status": "done"}] + [
+        {"state": s, "status": st} for s, st in tail
+    ]
+
+
+async def get_verification_state(
+    db: AsyncSession, agent_id: uuid.UUID, *, transport: str = "stdio",
+) -> dict:
+    """최신 verify Event seq + acked_seq + 세션 freshness → 레일/verified.
+
+    E-MCP-OPT S3: ``transport="http"`` 는 완전히 다른(heartbeat 기반) 4단계 레일로 분기한다 — 6단계
+    SSE 레일은 http 에서 구조적으로 절대 전진하지 않으므로(모듈 docstring) 재사용하지 않는다.
+    """
+    if transport == "http":
+        fresh = await _has_fresh_heartbeat(db, agent_id)
+        rail = build_http_verification_rail(heartbeat_fresh=fresh)
+        return {"verify_seq": None, "acked_seq": None, "verified": fresh, "rail": rail}
+
     verify_seq = (await db.execute(
         select(Event.recipient_seq).where(
             Event.recipient_id == agent_id,

--- a/backend/app/services/mcp_attachment_upload.py
+++ b/backend/app/services/mcp_attachment_upload.py
@@ -1,0 +1,75 @@
+"""E-MCP-OPT: MCP(비-브라우저) JSON/base64 첨부 업로드 공용 프리미티브 — S2(chat)·S6(story/doc) 공유.
+
+3번째 리소스 종류(story) 추가 시점에 chat 전용이던 상수/헬퍼를 여기로 추출(S2/S5 당시엔 chat 하나뿐이라
+로컬이었음). 값/로직은 chat 과 100% 동일(정합 유지) — object_path 의 5번째 세그먼트(kind)만 리소스별로
+다르다(chat|story|doc).
+"""
+from __future__ import annotations
+
+import base64
+import binascii
+import re
+import uuid
+
+from fastapi import HTTPException
+
+from app.services.asset_registry import DEFAULT_CONTAINER, canonical_object_path
+
+# 스샷/작은 문서가 실사용(대용량 아님). FE-proxy 100MB 캡과 별개로 더 작게(Cloud Run HTTP/1 32MiB 요청
+# 캡 대비 여유 마진). sprintable_mcp 의 동일 상수(tools/*.py)와 정합.
+MAX_JSON_ATTACHMENT_UPLOAD_SIZE = 2 * 1024 * 1024  # 2MiB decoded (per-file)
+MAX_ATTACHMENT_NAME_LEN = 255
+# 선언 한도(5개/6MiB 합계) — sprintable_mcp client-side 가드와 동일 값. 업로드 엔드포인트가 개별
+# 호출만 파일당 캡을 걸면 다회 호출로 이 선언 한도를 우회할 수 있어(S5 #2), 종결 액션(chat=send_message·
+# story=create/update) 에서 mcp-태그 부분집합에 한해 재검증한다. doc 은 업로드=즉시 등록이 종결 액션
+# 자체라 별도 재검증 불요(모듈별 라우터에서 각자 판단).
+MCP_MAX_ATTACHMENTS = 5
+MCP_MAX_TOTAL_ATTACHMENT_BYTES = 6 * 1024 * 1024  # 6MiB decoded (total)
+
+_SAFE_ATTACHMENT_NAME_RE = re.compile(r"[^\w.\-]+")
+
+
+def safe_attachment_filename(name: str) -> str:
+    safe = _SAFE_ATTACHMENT_NAME_RE.sub("_", name.strip())[-128:]
+    return safe or "file"
+
+
+def decode_json_attachment(content_base64: str, *, max_size: int = MAX_JSON_ATTACHMENT_UPLOAD_SIZE) -> bytes:
+    """base64 디코드 + 사이즈 가드. 실패 시 HTTPException(400/413) — 라우터가 그대로 propagate."""
+    try:
+        data = base64.b64decode(content_base64, validate=True)
+    except (binascii.Error, ValueError):
+        raise HTTPException(status_code=400, detail="content_base64 must be valid base64")
+    if not data:
+        raise HTTPException(status_code=400, detail="attachment must not be empty")
+    if len(data) > max_size:
+        raise HTTPException(status_code=413, detail=f"attachment too large (max {max_size} bytes)")
+    return data
+
+
+def build_mcp_object_path(
+    *, org_id: uuid.UUID, project_id: uuid.UUID, kind: str, resource_id: uuid.UUID, safe_name: str,
+) -> str:
+    """S7 namespace + `mcp/` 마커. FE 업로드 라우트(각 리소스의 apps/web .../attachments/route.ts)와
+    동일 접두(org/<org>/project/<project>/<kind>/<resource_id>/...) — path_in_source_scope 는 그
+    접두까지만 segment-match 하므로(그 뒤 세그먼트 수는 안 봄) `mcp/` 추가가 IDOR 가드에 영향 없다.
+    """
+    return f"org/{org_id}/project/{project_id}/{kind}/{resource_id}/mcp/{uuid.uuid4()}-{safe_name}"
+
+
+def is_mcp_upload_object_path(url: str, *, kind: str, container: str = DEFAULT_CONTAINER) -> bool:
+    """이 url 이 MCP JSON 업로드 엔드포인트로 실제 생성된 객체 경로인지(리소스 종류=kind 한정).
+
+    그 엔드포인트만 `org/<org>/project/<project>/<kind>/<resource_id>/mcp/<file>` 형태(6번째
+    segment=``mcp``)로 서버가 직접 object_path 를 구성한다 — client 는 ``name``(파일명 suffix) 외에는
+    경로에 관여할 수 없어 이 segment 를 조작해 자신에게 더 엄격한 검사를 켜는 것 외엔 스푸핑 이득이
+    없다(false-positive 는 harmless·false-negative 는 발생하지 않음 — 이 엔드포인트가 쓰는 유일한 shape).
+    """
+    canon = canonical_object_path(url, container)
+    if not canon:
+        return False
+    parts = canon.split("/")
+    return (
+        len(parts) >= 7
+        and parts[0] == "org" and parts[2] == "project" and parts[4] == kind and parts[6] == "mcp"
+    )

--- a/backend/sprintable_mcp/api_client.py
+++ b/backend/sprintable_mcp/api_client.py
@@ -248,10 +248,16 @@ class SprintableClient:
         url = f"{self._base_url}{path}"
         # E-MCP-HTTP S1: effective 키 = per-request override(http 멀티테넌트) ∨ env 단일키(stdio·무회귀).
         _key = _api_key_override.get() or self._api_key
+        from .config import settings as _mcp_settings
+
         headers = {
             "Authorization": f"Bearer {_key}",
             "x-agent-api-key": _key,
             "Content-Type": "application/json",
+            # E-MCP-OPT S5(#5): BE 가 첫인증 등 텔레메트리에서 실 transport 를 알 수 있도록 자기신고
+            # (BE 는 이 값을 신뢰만 하고 인가에 쓰지 않음 — 순수 관측용, per-request bearer/scope 가 실
+            # SSOT). 미설정 시 BE 는 fallback "stdio"(레거시 무회귀).
+            "X-MCP-Transport": (_mcp_settings.mcp_transport or "stdio").strip().lower(),
         }
         # 85429ee0: per-call override 시 X-Project-Id 헤더 전송 — 백엔드 get_verified_org_id 가
         # has_project_access 로 멤버십 검증 후 그 프로젝트로 컨텍스트 전환(mutation 라우트). 미설정 시

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 from mcp.server.fastmcp import FastMCP
 from mcp.types import TextContent
+from mcp.types import Tool as MCPTool
 from pydantic import BaseModel
 from pydantic.fields import PydanticUndefined
 
@@ -257,7 +258,29 @@ _transport_security = TransportSecuritySettings(
     allowed_origins=_allowed_origins,
 )
 
-mcp = FastMCP(
+# E-MCP-OPT S1: hosted(http) tools/list 요청별 scope 필터. FastMCP.__init__ → _setup_handlers()가
+# `self._mcp_server.list_tools()(self.list_tools)`로 **구성 시점 bound method**를 저수준 핸들러에
+# 등록한다 — 구성 後 인스턴스 몽키패치(mcp.list_tools = fn)는 이미 캡처된 참조에 안 먹는다(실측 확인:
+# 코덱스 + 별도 독립 재현 스크립트 둘 다). 서브클래스 오버라이드는 __init__ 이전에 존재해 self.list_tools
+# 속성조회(MRO)가 오버라이드로 해소되므로 저수준 핸들러가 정확히 이걸 호출한다 — 유일하게 먹는 방식.
+#
+# stdio는 부팅 시 filter_tools_by_scope(레지스트리 destructive mutation)로 이미 걸러진 목록만 남아
+# 있어 이 필터가 다시 돌아도 무해한 no-op(전 도구 이미 허용된 것들)이지만, mcp_transport 가드로 아예
+# 스킵해 시맨틱을 명확히 하고 매 stdio list_tools 호출마다 불필요한 manifest 캐시 조회도 피한다.
+# fail-open(scope=None → 비파괴셋)은 call-time(_flat wrapper)과 동일 철학 — 백엔드가 최종 SSOT라 list는
+# degrade(더 보여줌)해도 call은 여전히 403 차단.
+class SprintableFastMCP(FastMCP):
+    async def list_tools(self) -> list[MCPTool]:
+        tools = await super().list_tools()
+        if (settings.mcp_transport or "stdio").strip().lower() != "http":
+            return tools
+
+        _eff_key = _api_key_override.get() or settings.agent_api_key
+        _scope = await _load_scope_for(_eff_key)
+        return [tool for tool in tools if is_tool_allowed(tool.name, _scope)]
+
+
+mcp = SprintableFastMCP(
     name="sprintable-mcp-python",
     instructions=(
         "Sprintable Python MCP server. "

--- a/backend/sprintable_mcp/tools/attachments.py
+++ b/backend/sprintable_mcp/tools/attachments.py
@@ -1,0 +1,72 @@
+"""E-MCP-OPT: inline base64 첨부 업로드 공용 프리미티브 — chat(S2)·story/doc(S6) 공유.
+
+3번째 리소스 종류(story) 추가 시점에 chat 전용이던 검증/업로드 로직을 여기로 추출(S2 당시엔 chat
+하나뿐이라 로컬이었음). 값/로직은 chat 과 100% 동일 — 업로드 대상 엔드포인트 경로만 호출부가 넘긴다.
+"""
+from __future__ import annotations
+
+import base64
+import binascii
+
+from ..api_client import client
+
+# 백엔드 `app/services/mcp_attachment_upload.py`의 동일 상수와 정합(client-side fail-fast 가드 —
+# MCP 페이로드 낭비 전 조기 거부).
+MAX_ATTACHMENTS = 5
+MAX_ATTACHMENT_BYTES = 2 * 1024 * 1024  # 2MiB decoded/file
+MAX_TOTAL_ATTACHMENT_BYTES = 6 * 1024 * 1024  # 6MiB decoded/total
+_MAX_ATTACHMENT_BASE64_CHARS = ((MAX_ATTACHMENT_BYTES + 2) // 3) * 4
+
+
+def validate_attachment(att: dict, index: int) -> tuple[dict, int]:
+    if not isinstance(att, dict):
+        raise ValueError(f"attachments[{index}] must be an object")
+    name = str(att.get("name") or "").strip()
+    content_type = str(att.get("content_type") or "").strip()
+    content_base64 = str(att.get("content_base64") or "").strip()
+    if not name:
+        raise ValueError(f"attachments[{index}].name is required")
+    if not content_type:
+        raise ValueError(f"attachments[{index}].content_type is required")
+    if not content_base64:
+        raise ValueError(f"attachments[{index}].content_base64 is required")
+    if len(content_base64) > _MAX_ATTACHMENT_BASE64_CHARS:
+        raise ValueError(
+            f"attachments[{index}] too large (max {MAX_ATTACHMENT_BYTES} decoded bytes)"
+        )
+    try:
+        decoded = base64.b64decode(content_base64, validate=True)
+    except (binascii.Error, ValueError):
+        raise ValueError(f"attachments[{index}].content_base64 must be valid base64")
+    if not decoded:
+        raise ValueError(f"attachments[{index}] must not be empty")
+    if len(decoded) > MAX_ATTACHMENT_BYTES:
+        raise ValueError(
+            f"attachments[{index}] too large (max {MAX_ATTACHMENT_BYTES} decoded bytes)"
+        )
+    return {"content_base64": content_base64, "name": name, "content_type": content_type}, len(decoded)
+
+
+async def upload_attachments(upload_path: str, attachments: list[dict] | None) -> list[dict]:
+    """각 첨부를 `upload_path`(리소스별 신규 업로드 엔드포인트)에 순차 업로드.
+
+    개수/사이즈 가드는 **전부 먼저 검증**(네트워크 호출 0)한 다음에야 업로드를 시작한다 — 순차
+    검증+업로드를 인터리빙하면 총량 초과가 마지막 파일에서만 드러날 때 앞선 파일들이 이미 실제
+    업로드돼 orphan blob 이 되고서야 실패하는 낭비/누출이 생긴다(S5 #2 교훈).
+    """
+    if not attachments:
+        return []
+    if len(attachments) > MAX_ATTACHMENTS:
+        raise ValueError(f"too many attachments (max {MAX_ATTACHMENTS})")
+
+    validated: list[tuple[dict, int]] = [validate_attachment(att, i) for i, att in enumerate(attachments)]
+    total_size = sum(size for _payload, size in validated)
+    if total_size > MAX_TOTAL_ATTACHMENT_BYTES:
+        raise ValueError(
+            f"attachments total too large (max {MAX_TOTAL_ATTACHMENT_BYTES} decoded bytes)"
+        )
+
+    uploaded: list[dict] = []
+    for payload, _size in validated:
+        uploaded.append(await client.post(upload_path, json=payload))
+    return uploaded

--- a/backend/sprintable_mcp/tools/chat.py
+++ b/backend/sprintable_mcp/tools/chat.py
@@ -1,8 +1,6 @@
 """채팅 MCP 도구 (3개)."""
 from __future__ import annotations
 
-import base64
-import binascii
 import logging
 
 from mcp.types import TextContent
@@ -10,15 +8,9 @@ from mcp.types import TextContent
 from ..api_client import client
 from ..response import err, ok
 from ..schemas import SprintableInput
+from .attachments import upload_attachments
 
 logger = logging.getLogger(__name__)
-
-# E-MCP-OPT S2(bbfd24ba): inline base64 첨부 — client-side fail-fast 가드(백엔드
-# `_MAX_JSON_ATTACHMENT_UPLOAD_SIZE`와 정합·MCP 페이로드 낭비 전 조기 거부).
-_MAX_ATTACHMENTS = 5
-_MAX_ATTACHMENT_BYTES = 2 * 1024 * 1024  # 2MiB decoded/file
-_MAX_TOTAL_ATTACHMENT_BYTES = 6 * 1024 * 1024  # 2MiB decoded/total
-_MAX_ATTACHMENT_BASE64_CHARS = ((_MAX_ATTACHMENT_BYTES + 2) // 3) * 4
 
 
 class SendChatInput(SprintableInput):
@@ -43,62 +35,6 @@ class ListChatMessagesInput(SprintableInput):
     before: str | None = None
 
 
-def _validate_attachment(att: dict, index: int) -> tuple[dict, int]:
-    if not isinstance(att, dict):
-        raise ValueError(f"attachments[{index}] must be an object")
-    name = str(att.get("name") or "").strip()
-    content_type = str(att.get("content_type") or "").strip()
-    content_base64 = str(att.get("content_base64") or "").strip()
-    if not name:
-        raise ValueError(f"attachments[{index}].name is required")
-    if not content_type:
-        raise ValueError(f"attachments[{index}].content_type is required")
-    if not content_base64:
-        raise ValueError(f"attachments[{index}].content_base64 is required")
-    if len(content_base64) > _MAX_ATTACHMENT_BASE64_CHARS:
-        raise ValueError(
-            f"attachments[{index}] too large (max {_MAX_ATTACHMENT_BYTES} decoded bytes)"
-        )
-    try:
-        decoded = base64.b64decode(content_base64, validate=True)
-    except (binascii.Error, ValueError):
-        raise ValueError(f"attachments[{index}].content_base64 must be valid base64")
-    if not decoded:
-        raise ValueError(f"attachments[{index}] must not be empty")
-    if len(decoded) > _MAX_ATTACHMENT_BYTES:
-        raise ValueError(
-            f"attachments[{index}] too large (max {_MAX_ATTACHMENT_BYTES} decoded bytes)"
-        )
-    return {"content_base64": content_base64, "name": name, "content_type": content_type}, len(decoded)
-
-
-async def _upload_attachments(thread_id: str, attachments: list[dict] | None) -> list[dict]:
-    """각 첨부를 신규 업로드 엔드포인트에 순차 업로드해 MessageAttachment 메타 리스트로 변환.
-
-    개수/사이즈 가드는 **전부 먼저 검증**(네트워크 호출 0)한 다음에야 업로드를 시작한다 — 순차
-    검증+업로드를 인터리빙하면 총량 초과가 마지막 파일에서만 드러날 때 앞선 파일들이 이미 실제
-    업로드돼 orphan blob 이 되고서야 실패하는 낭비/누출이 생긴다.
-    """
-    if not attachments:
-        return []
-    if len(attachments) > _MAX_ATTACHMENTS:
-        raise ValueError(f"too many attachments (max {_MAX_ATTACHMENTS})")
-
-    validated: list[tuple[dict, int]] = [_validate_attachment(att, i) for i, att in enumerate(attachments)]
-    total_size = sum(size for _payload, size in validated)
-    if total_size > _MAX_TOTAL_ATTACHMENT_BYTES:
-        raise ValueError(
-            f"attachments total too large (max {_MAX_TOTAL_ATTACHMENT_BYTES} decoded bytes)"
-        )
-
-    uploaded: list[dict] = []
-    for payload, _size in validated:
-        uploaded.append(
-            await client.post(f"/api/v2/conversations/{thread_id}/attachments", json=payload)
-        )
-    return uploaded
-
-
 async def send_chat_message(args: SendChatInput) -> list[TextContent]:
     """conversation thread에 채팅 메시지 발송."""
     payload: dict = {"content": args.content}
@@ -115,7 +51,9 @@ async def send_chat_message(args: SendChatInput) -> list[TextContent]:
         payload["metadata"] = meta
     uploaded_urls: list[str] = []
     try:
-        attachments = await _upload_attachments(args.thread_id, args.attachments)
+        attachments = await upload_attachments(
+            f"/api/v2/conversations/{args.thread_id}/attachments", args.attachments,
+        )
         uploaded_urls = [a["url"] for a in attachments if isinstance(a, dict) and a.get("url")]
         if attachments:
             payload["attachments"] = attachments

--- a/backend/sprintable_mcp/tools/chat.py
+++ b/backend/sprintable_mcp/tools/chat.py
@@ -1,11 +1,24 @@
 """채팅 MCP 도구 (3개)."""
 from __future__ import annotations
 
+import base64
+import binascii
+import logging
+
 from mcp.types import TextContent
 
 from ..api_client import client
 from ..response import err, ok
 from ..schemas import SprintableInput
+
+logger = logging.getLogger(__name__)
+
+# E-MCP-OPT S2(bbfd24ba): inline base64 첨부 — client-side fail-fast 가드(백엔드
+# `_MAX_JSON_ATTACHMENT_UPLOAD_SIZE`와 정합·MCP 페이로드 낭비 전 조기 거부).
+_MAX_ATTACHMENTS = 5
+_MAX_ATTACHMENT_BYTES = 2 * 1024 * 1024  # 2MiB decoded/file
+_MAX_TOTAL_ATTACHMENT_BYTES = 6 * 1024 * 1024  # 2MiB decoded/total
+_MAX_ATTACHMENT_BASE64_CHARS = ((_MAX_ATTACHMENT_BYTES + 2) // 3) * 4
 
 
 class SendChatInput(SprintableInput):
@@ -15,6 +28,8 @@ class SendChatInput(SprintableInput):
     message_type: str | None = None
     review_type: str | None = None
     metadata: dict | None = None
+    # [{content_base64, name, content_type}, ...] — 스샷/작은 문서(최대 5개·파일당 2MiB·총 6MiB).
+    attachments: list[dict] | None = None
 
 
 class CreateConversationInput(SprintableInput):
@@ -26,6 +41,62 @@ class ListChatMessagesInput(SprintableInput):
     thread_id: str
     limit: int | None = None
     before: str | None = None
+
+
+def _validate_attachment(att: dict, index: int) -> tuple[dict, int]:
+    if not isinstance(att, dict):
+        raise ValueError(f"attachments[{index}] must be an object")
+    name = str(att.get("name") or "").strip()
+    content_type = str(att.get("content_type") or "").strip()
+    content_base64 = str(att.get("content_base64") or "").strip()
+    if not name:
+        raise ValueError(f"attachments[{index}].name is required")
+    if not content_type:
+        raise ValueError(f"attachments[{index}].content_type is required")
+    if not content_base64:
+        raise ValueError(f"attachments[{index}].content_base64 is required")
+    if len(content_base64) > _MAX_ATTACHMENT_BASE64_CHARS:
+        raise ValueError(
+            f"attachments[{index}] too large (max {_MAX_ATTACHMENT_BYTES} decoded bytes)"
+        )
+    try:
+        decoded = base64.b64decode(content_base64, validate=True)
+    except (binascii.Error, ValueError):
+        raise ValueError(f"attachments[{index}].content_base64 must be valid base64")
+    if not decoded:
+        raise ValueError(f"attachments[{index}] must not be empty")
+    if len(decoded) > _MAX_ATTACHMENT_BYTES:
+        raise ValueError(
+            f"attachments[{index}] too large (max {_MAX_ATTACHMENT_BYTES} decoded bytes)"
+        )
+    return {"content_base64": content_base64, "name": name, "content_type": content_type}, len(decoded)
+
+
+async def _upload_attachments(thread_id: str, attachments: list[dict] | None) -> list[dict]:
+    """각 첨부를 신규 업로드 엔드포인트에 순차 업로드해 MessageAttachment 메타 리스트로 변환.
+
+    개수/사이즈 가드는 **전부 먼저 검증**(네트워크 호출 0)한 다음에야 업로드를 시작한다 — 순차
+    검증+업로드를 인터리빙하면 총량 초과가 마지막 파일에서만 드러날 때 앞선 파일들이 이미 실제
+    업로드돼 orphan blob 이 되고서야 실패하는 낭비/누출이 생긴다.
+    """
+    if not attachments:
+        return []
+    if len(attachments) > _MAX_ATTACHMENTS:
+        raise ValueError(f"too many attachments (max {_MAX_ATTACHMENTS})")
+
+    validated: list[tuple[dict, int]] = [_validate_attachment(att, i) for i, att in enumerate(attachments)]
+    total_size = sum(size for _payload, size in validated)
+    if total_size > _MAX_TOTAL_ATTACHMENT_BYTES:
+        raise ValueError(
+            f"attachments total too large (max {_MAX_TOTAL_ATTACHMENT_BYTES} decoded bytes)"
+        )
+
+    uploaded: list[dict] = []
+    for payload, _size in validated:
+        uploaded.append(
+            await client.post(f"/api/v2/conversations/{thread_id}/attachments", json=payload)
+        )
+    return uploaded
 
 
 async def send_chat_message(args: SendChatInput) -> list[TextContent]:
@@ -42,9 +113,23 @@ async def send_chat_message(args: SendChatInput) -> list[TextContent]:
         meta["review_type"] = args.review_type
     if meta:
         payload["metadata"] = meta
+    uploaded_urls: list[str] = []
     try:
+        attachments = await _upload_attachments(args.thread_id, args.attachments)
+        uploaded_urls = [a["url"] for a in attachments if isinstance(a, dict) and a.get("url")]
+        if attachments:
+            payload["attachments"] = attachments
         return ok(await client.post(f"/api/v2/conversations/{args.thread_id}/messages", json=payload))
     except Exception as exc:
+        if uploaded_urls:
+            # 업로드는 성공했으나 메시지 생성이 실패한 경우 — asset registry 는 SAVE-time(메시지
+            # 저장 트랜잭션)에만 동기화되므로 이 객체들은 미등록 orphan blob 으로 남는다(무해·
+            # data-loss 아님). 운영 가시성을 위해 로그만 남김(best-effort cleanup 대상 아님 —
+            # storage 자체 GC/grace cron 이 있다면 그쪽이 담당).
+            logger.warning(
+                "send_chat_message: message create failed after %d attachment upload(s) — "
+                "orphaned object(s): %s", len(uploaded_urls), uploaded_urls,
+            )
         return err(str(exc))
 
 

--- a/backend/sprintable_mcp/tools/docs.py
+++ b/backend/sprintable_mcp/tools/docs.py
@@ -8,6 +8,7 @@ from mcp.types import TextContent
 from ..api_client import client
 from ..response import err, ok
 from ..schemas import SprintableInput
+from .attachments import upload_attachments
 
 
 class ListDocsInput(SprintableInput):
@@ -44,6 +45,11 @@ class UpdateDocInput(SprintableInput):
     parent_id: str | None = None
     expected_updated_at: str | None = None
     force_overwrite: bool | None = None
+    # [{content_base64, name, content_type}, ...] — 스샷/작은 문서(최대 5개·파일당 2MiB·총 6MiB).
+    # 업로드 後 완성된 embed HTML(TipTap file-node/image-node 계약과 정확히 일치 — 에이전트가 마크업을
+    # 몰라도 됨)을 content 끝에 append. 이 호출에 content 를 안 실었으면 현재 저장된 content 를 먼저
+    # 읽어 그 뒤에 append(기존 본문을 지우지 않음).
+    attachments: list[dict] | None = None
 
 
 class DeleteDocInput(SprintableInput):
@@ -123,6 +129,17 @@ async def update_doc(args: UpdateDocInput) -> list[TextContent]:
     if args.force_overwrite is not None:
         updates["force_overwrite"] = args.force_overwrite
     try:
+        if args.attachments:
+            uploaded = await upload_attachments(
+                f"/api/v2/docs/{args.doc_id}/attachments", args.attachments,
+            )
+            if uploaded:
+                base_content = updates.get("content")
+                if base_content is None:
+                    current = await client.get(f"/api/v2/docs/{args.doc_id}")
+                    base_content = (current.get("content") or "") if isinstance(current, dict) else ""
+                snippets = "".join(a["embed_snippet"] for a in uploaded if isinstance(a, dict) and a.get("embed_snippet"))
+                updates["content"] = f"{base_content}\n{snippets}" if base_content else snippets
         return ok(await client.patch(f"/api/v2/docs/{args.doc_id}", json=updates))
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/stories.py
+++ b/backend/sprintable_mcp/tools/stories.py
@@ -6,6 +6,7 @@ from mcp.types import CallToolResult, TextContent
 from ..api_client import client
 from ..response import err, ok
 from ..schemas import SprintableInput, StoryPoints, StoryPriority, StoryStatus
+from .attachments import upload_attachments
 
 
 class ListStoriesInput(SprintableInput):
@@ -36,6 +37,10 @@ class UpdateStoryInput(SprintableInput):
     acceptance_criteria: str | None = None
     assignee_id: str | None = None
     epic_id: str | None = None
+    # [{content_base64, name, content_type}, ...] — 스샷/작은 문서(최대 5개·파일당 2MiB·총 6MiB).
+    # 기존 첨부에 **추가**된다(PATCH attachments 는 서버측 full-replace 라 update_story 가 먼저 기존
+    # 첨부를 읽어 병합 — 새 첨부가 기존 걸 지우지 않는다).
+    attachments: list[dict] | None = None
 
 
 class DeleteStoryInput(SprintableInput):
@@ -131,6 +136,16 @@ async def update_story(args: UpdateStoryInput) -> list[TextContent]:
     if args.epic_id is not None:
         updates["epic_id"] = args.epic_id
     try:
+        if args.attachments:
+            uploaded = await upload_attachments(
+                f"/api/v2/stories/{args.story_id}/attachments", args.attachments,
+            )
+            if uploaded:
+                # PATCH attachments 는 서버측 full-replace(교체 SSOT 재동기화) — 기존 첨부를 먼저
+                # 읽어 병합해야 새 첨부가 기존 걸 지우지 않는다.
+                current = await client.get(f"/api/v2/stories/{args.story_id}")
+                existing = current.get("attachments") or [] if isinstance(current, dict) else []
+                updates["attachments"] = existing + uploaded
         return ok(await client.patch(f"/api/v2/stories/{args.story_id}", json=updates))
     except Exception as exc:
         return err(str(exc))

--- a/backend/tests/test_e_mcp_opt_s1_tools_list_scope_filter.py
+++ b/backend/tests/test_e_mcp_opt_s1_tools_list_scope_filter.py
@@ -1,0 +1,207 @@
+"""E-MCP-OPT S1 (bec3a480): 호스팅(http) MCP tools/list 요청별 scope 필터.
+
+문제: http 모드는 멀티테넌트(多키 동시서비스)인데 tools/list 가 항상 전체 ~95개 도구를 반환
+(call-time enforcement는 이미 키별로 정확하지만 list 는 그대로) — 컨텍스트 낭비.
+
+해법: `SprintableFastMCP(FastMCP)` 서브클래스가 `list_tools()`를 오버라이드해 call-time과 동일
+primitive(`_api_key_override`·`_load_scope_for`·`is_tool_allowed`)로 http 모드에서만 응답을
+필터링한다. **왜 서브클래스인가**: FastMCP.__init__ → _setup_handlers() 가
+`self._mcp_server.list_tools()(self.list_tools)`로 **구성 시점 bound method**를 저수준
+프로토콜 핸들러에 등록 — 구성 後 인스턴스 몽키패치는 이미 캡처된 참조라 안 먹지만, 서브클래스
+오버라이드는 __init__ 이전에 존재해 `self.list_tools` 속성조회(MRO)가 오버라이드로 해소되므로
+정확히 먹는다(PO crux 확認: mcp/server/fastmcp/server.py:304 소스 직접 대조).
+
+3개 검증축(PO crux 명시):
+①unit — 핸들러 자체(전체 필터 로직) 직접 호출, 키별 scope 상이 시 결과 상이
+②ASGI 2-bearer 통합(실경로 핵심) — 실제 streamable_http_app()+bearer_auth_asgi() 스택을
+  진짜 MCP client(streamablehttp_client+ClientSession)로 initialize+tools/list 왕복
+③stdio 회귀 — 부팅 필터(filter_tools_by_scope)·도구 수·manifest 미조회 무영향
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_scope_cache():
+    """모든 테스트가 격리된 scope 캐시로 시작(다른 테스트 파일의 캐시 오염 방지)."""
+    import sprintable_mcp.server as srv
+    srv._scope_cache = srv._ScopeCache(10, 100)
+    yield
+
+
+# ── ① unit: SprintableFastMCP.list_tools() 핵심 로직 ──────────────────────────
+@pytest.mark.anyio
+async def test_list_tools_filters_by_scope_in_http_mode(monkeypatch):
+    from sprintable_mcp import server as srv
+
+    monkeypatch.setattr(srv.settings, "mcp_transport", "http")
+
+    async def _fake_get(path):
+        return {"scope": ["stories"]}
+
+    with patch.object(srv.client, "get", new=AsyncMock(side_effect=_fake_get)):
+        tools = await srv.mcp.list_tools()
+        names = {t.name for t in tools}
+        assert "sprintable_add_story" in names       # stories 허용 → 노출
+        assert "sprintable_send_chat_message" not in names  # chat 미허용 → 숨김
+        assert "ping" in names                          # 항상-노출 도구는 유지
+
+
+@pytest.mark.anyio
+async def test_list_tools_differs_per_key_scope(monkeypatch):
+    """다른 키 = 다른 scope = 다른 tools/list 결과 (call-time enforcement와 동일 키잉)."""
+    from sprintable_mcp import server as srv
+    from sprintable_mcp.api_client import reset_api_key_override, set_api_key_override
+
+    monkeypatch.setattr(srv.settings, "mcp_transport", "http")
+
+    async def _fake_get(path):
+        from sprintable_mcp.api_client import _api_key_override
+        key = _api_key_override.get()
+        return {"scope": ["stories"]} if key == "keyA" else {"scope": ["chat"]}
+
+    with patch.object(srv.client, "get", new=AsyncMock(side_effect=_fake_get)):
+        tok_a = set_api_key_override("keyA")
+        try:
+            names_a = {t.name for t in await srv.mcp.list_tools()}
+        finally:
+            reset_api_key_override(tok_a)
+
+        tok_b = set_api_key_override("keyB")
+        try:
+            names_b = {t.name for t in await srv.mcp.list_tools()}
+        finally:
+            reset_api_key_override(tok_b)
+
+    assert "sprintable_add_story" in names_a and "sprintable_send_chat_message" not in names_a
+    assert "sprintable_send_chat_message" in names_b and "sprintable_add_story" not in names_b
+
+
+@pytest.mark.anyio
+async def test_list_tools_fail_open_on_manifest_error(monkeypatch):
+    """manifest 조회 실패 = fail-open(레거시 비파괴셋) — call-time(_load_scope_for)과 동일 철학.
+    백엔드가 최종 SSOT라 list 는 더 보여줘도(noisy) call 은 여전히 403 차단되므로 안전."""
+    from sprintable_mcp import server as srv
+
+    monkeypatch.setattr(srv.settings, "mcp_transport", "http")
+
+    async def _boom(path):
+        raise RuntimeError("manifest unavailable")
+
+    with patch.object(srv.client, "get", new=AsyncMock(side_effect=_boom)):
+        names = {t.name for t in await srv.mcp.list_tools()}
+        assert "sprintable_add_story" in names        # 비파괴 → 노출(fail-open)
+        assert "sprintable_delete_story" not in names  # destructive → 여전히 숨김(레거시 비파괴셋)
+
+
+@pytest.mark.anyio
+async def test_list_tools_skips_scope_load_when_not_http(monkeypatch):
+    """mcp_transport != 'http'(기본 stdio)면 filter 로직 자체를 스킵 — manifest 재조회 0회."""
+    from sprintable_mcp import server as srv
+
+    monkeypatch.setattr(srv.settings, "mcp_transport", "stdio")
+    calls = {"n": 0}
+
+    async def _fake_get(path):
+        calls["n"] += 1
+        return {"scope": []}
+
+    with patch.object(srv.client, "get", new=AsyncMock(side_effect=_fake_get)):
+        tools = await srv.mcp.list_tools()
+        assert calls["n"] == 0                          # manifest 미조회
+        assert {t.name for t in tools} == {n for n, *_ in srv._TOOL_DEFS} | {"ping"}
+
+
+# ── ② ASGI 2-bearer 통합(실경로 핵심) ─────────────────────────────────────────
+@pytest.mark.anyio
+async def test_http_transport_tools_list_real_path_differs_per_bearer(monkeypatch):
+    """실제 streamable_http_app()+bearer_auth_asgi() 스택을 진짜 MCP client(initialize+
+    tools/list JSON-RPC 왕복)로 구동 — PO 지정 '실경로 핵심' 검증. 서로 다른 bearer 토큰이
+    서로 다른 tools/list 응답을 받는지 세션-레벨에서 확인(핸들러 직접호출이 아닌 전체 스택)."""
+    from mcp.client.session import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    from sprintable_mcp import server as srv
+    from sprintable_mcp.http_auth import bearer_auth_asgi
+
+    monkeypatch.setattr(srv.settings, "mcp_transport", "http")
+
+    async def _fake_get(path):
+        from sprintable_mcp.api_client import _api_key_override
+        key = _api_key_override.get()
+        return {"scope": ["stories"]} if key == "keyA" else {"scope": ["chat"]}
+
+    app = bearer_auth_asgi(srv.mcp.streamable_http_app())
+
+    def _factory(headers=None, timeout=None, auth=None):
+        return httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://testserver",
+            headers=headers,
+            timeout=timeout or 30,
+        )
+
+    results: dict[str, set[str]] = {}
+    async with srv.mcp.session_manager.run():
+        with patch.object(srv.client, "get", new=AsyncMock(side_effect=_fake_get)):
+            for key in ("keyA", "keyB"):
+                async with streamablehttp_client(
+                    url="http://testserver/mcp",
+                    headers={"Authorization": f"Bearer {key}"},
+                    httpx_client_factory=_factory,
+                ) as (read, write, _get_session_id):
+                    async with ClientSession(read, write) as session:
+                        await session.initialize()
+                        result = await session.list_tools()
+                        results[key] = {t.name for t in result.tools}
+
+    assert "sprintable_add_story" in results["keyA"]
+    assert "sprintable_send_chat_message" not in results["keyA"]
+    assert "sprintable_send_chat_message" in results["keyB"]
+    assert "sprintable_add_story" not in results["keyB"]
+    assert results["keyA"] != results["keyB"]
+
+
+# ── ③ stdio 회귀 ───────────────────────────────────────────────────────────
+def test_stdio_boot_filter_behavior_unchanged(monkeypatch):
+    """S3 부팅 필터(filter_tools_by_scope) 로직·제거 대상은 이 변경으로 전혀 안 건드림."""
+    from sprintable_mcp import server as srv
+
+    removed: list[str] = []
+    monkeypatch.setattr(srv.mcp, "remove_tool", lambda name: removed.append(name))
+    n = srv.filter_tools_by_scope(["stories"])
+    assert n == len(removed) > 0
+    assert "sprintable_add_task" in removed
+    assert "sprintable_add_story" not in removed
+    assert "sprintable_ping" not in removed
+
+
+@pytest.mark.anyio
+async def test_stdio_list_tools_reflects_real_boot_removal(monkeypatch):
+    """stdio 는 list_tools() 필터 로직 자체가 skip(③ 위 유닛 테스트로 이미 확認)이므로, 부팅 시
+    filter_tools_by_scope 가 레지스트리에서 실제로 제거한 도구는 list_tools() 에도 그대로
+    반영된다(추가 축소도 유령노출도 없음) — 실 레지스트리에 1개 도구를 등록/제거해 최소 재현."""
+    from sprintable_mcp import server as srv
+
+    monkeypatch.setattr(srv.settings, "mcp_transport", "stdio")
+    before = {t.name for t in await srv.mcp.list_tools()}
+    assert "sprintable_add_task" in before
+
+    srv.mcp.remove_tool("sprintable_add_task")   # 실제 레지스트리 mutate(S3 부팅 필터와 동일 API)
+    try:
+        after = {t.name for t in await srv.mcp.list_tools()}
+        assert "sprintable_add_task" not in after
+        assert before - after == {"sprintable_add_task"}
+    finally:
+        # 다른 테스트 파일에 영향 없도록 재등록(원래 등록 코드와 동일한 경로로 복구)
+        name, doc, input_cls, fn = next(d for d in srv._TOOL_DEFS if d[0] == "sprintable_add_task")
+        srv.mcp.tool()(srv._flat(name, doc, input_cls, fn))

--- a/backend/tests/test_e_mcp_opt_s2_chat_attachment_tool.py
+++ b/backend/tests/test_e_mcp_opt_s2_chat_attachment_tool.py
@@ -1,0 +1,173 @@
+"""E-MCP-OPT S2 (bbfd24ba): `sprintable_send_chat_message` inline base64 첨부 — MCP 쪽 검증.
+
+client-side fail-fast 가드(개수/사이즈/base64) + 업로드→메시지 체이닝 + 회귀(첨부 없으면
+기존 payload 그대로) + 부분실패(업로드 성공·메시지 실패) 시 orphan 로그.
+"""
+from __future__ import annotations
+
+import base64
+import logging
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from sprintable_mcp.tools import chat as chat_mod
+from sprintable_mcp.tools.chat import SendChatInput, _upload_attachments, _validate_attachment, send_chat_message
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _b64(n: int) -> str:
+    return base64.b64encode(b"x" * n).decode()
+
+
+# ── _validate_attachment ──────────────────────────────────────────────────────
+def test_validate_attachment_accepts_valid():
+    payload, size = _validate_attachment(
+        {"content_base64": _b64(10), "name": "a.png", "content_type": "image/png"}, 0
+    )
+    assert size == 10
+    assert payload == {"content_base64": _b64(10), "name": "a.png", "content_type": "image/png"}
+
+
+def test_validate_attachment_missing_fields_raise():
+    with pytest.raises(ValueError, match="name is required"):
+        _validate_attachment({"content_base64": _b64(1), "content_type": "text/plain"}, 0)
+    with pytest.raises(ValueError, match="content_type is required"):
+        _validate_attachment({"content_base64": _b64(1), "name": "a"}, 0)
+    with pytest.raises(ValueError, match="content_base64 is required"):
+        _validate_attachment({"name": "a", "content_type": "text/plain"}, 0)
+
+
+def test_validate_attachment_invalid_base64_raises():
+    with pytest.raises(ValueError, match="must be valid base64"):
+        _validate_attachment({"content_base64": "not-base64!!!", "name": "a", "content_type": "t"}, 0)
+
+
+def test_validate_attachment_empty_content_base64_raises():
+    with pytest.raises(ValueError, match="content_base64 is required"):
+        _validate_attachment({"content_base64": "", "name": "a", "content_type": "t"}, 0)
+
+
+def test_validate_attachment_oversized_rejected_before_full_decode():
+    too_big = _b64(chat_mod._MAX_ATTACHMENT_BYTES + 1)
+    with pytest.raises(ValueError, match="too large"):
+        _validate_attachment({"content_base64": too_big, "name": "a", "content_type": "t"}, 0)
+
+
+# ── _upload_attachments ───────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_upload_attachments_empty_returns_empty():
+    assert await _upload_attachments("conv-1", None) == []
+    assert await _upload_attachments("conv-1", []) == []
+
+
+@pytest.mark.anyio
+async def test_upload_attachments_too_many_rejected():
+    atts = [{"content_base64": _b64(1), "name": f"{i}", "content_type": "t"} for i in range(chat_mod._MAX_ATTACHMENTS + 1)]
+    with pytest.raises(ValueError, match="too many attachments"):
+        await _upload_attachments("conv-1", atts)
+
+
+@pytest.mark.anyio
+async def test_upload_attachments_total_size_exceeded_rejected_before_any_network_call():
+    """총량 초과는 업로드 시작 前 전부 검증되어 걸러진다 — client.post 가 단 한 번도 안 불림
+    (마지막 파일에서만 드러나는 초과였다면 앞선 파일들이 실제 업로드→orphan 되는 낭비 없음)."""
+    per_file = chat_mod._MAX_ATTACHMENT_BYTES
+    atts = [{"content_base64": _b64(per_file), "name": f"{i}", "content_type": "t"} for i in range(4)]
+    assert len(atts) <= chat_mod._MAX_ATTACHMENTS
+    assert per_file * 4 > chat_mod._MAX_TOTAL_ATTACHMENT_BYTES
+    with patch.object(chat_mod.client, "post", new=AsyncMock()) as m:
+        with pytest.raises(ValueError, match="total too large"):
+            await _upload_attachments("conv-1", atts)
+        m.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_upload_attachments_calls_endpoint_per_file():
+    atts = [{"content_base64": _b64(5), "name": "a.png", "content_type": "image/png"}]
+    fake_result = {"url": "org/o/project/p/chat/c/x-a.png", "name": "a.png", "content_type": "image/png", "size": 5}
+    with patch.object(chat_mod.client, "post", new=AsyncMock(return_value=fake_result)) as m:
+        result = await _upload_attachments("conv-1", atts)
+        assert result == [fake_result]
+        m.assert_awaited_once_with(
+            "/api/v2/conversations/conv-1/attachments",
+            json={"content_base64": _b64(5), "name": "a.png", "content_type": "image/png"},
+        )
+
+
+# ── send_chat_message 회귀 + 체이닝 ────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_send_chat_message_no_attachments_unchanged_payload():
+    """첨부 없으면 기존 동작 그대로(회귀 0) — payload 에 attachments 키 자체가 없음."""
+    args = SendChatInput(thread_id="conv-1", content="hi")
+    with patch.object(chat_mod.client, "post", new=AsyncMock(return_value={"id": "m1"})) as m:
+        await send_chat_message(args)
+        _, kwargs = m.call_args
+        assert "attachments" not in kwargs["json"]
+
+
+@pytest.mark.anyio
+async def test_send_chat_message_uploads_then_sends_with_attachments():
+    args = SendChatInput(
+        thread_id="conv-1", content="screenshot",
+        attachments=[{"content_base64": _b64(4), "name": "s.png", "content_type": "image/png"}],
+    )
+    upload_result = {"url": "org/o/project/p/chat/conv-1/x-s.png", "name": "s.png", "content_type": "image/png", "size": 4}
+    calls: list[tuple] = []
+
+    async def _fake_post(path, json=None):
+        calls.append((path, json))
+        if path.endswith("/attachments"):
+            return upload_result
+        return {"id": "m1"}
+
+    with patch.object(chat_mod.client, "post", new=AsyncMock(side_effect=_fake_post)):
+        result = await send_chat_message(args)
+        assert len(calls) == 2
+        assert calls[0][0] == "/api/v2/conversations/conv-1/attachments"
+        assert calls[1][0] == "/api/v2/conversations/conv-1/messages"
+        assert calls[1][1]["attachments"] == [upload_result]
+        assert "Error" not in result[0].text
+
+
+@pytest.mark.anyio
+async def test_send_chat_message_upload_failure_does_not_call_message_create():
+    args = SendChatInput(
+        thread_id="conv-1", content="x",
+        attachments=[{"content_base64": _b64(4), "name": "s.png", "content_type": "image/png"}],
+    )
+    calls: list[str] = []
+
+    async def _fake_post(path, json=None):
+        calls.append(path)
+        raise RuntimeError("upload 403")
+
+    with patch.object(chat_mod.client, "post", new=AsyncMock(side_effect=_fake_post)):
+        result = await send_chat_message(args)
+        assert calls == ["/api/v2/conversations/conv-1/attachments"]
+        assert result[0].text.startswith("Error")
+
+
+@pytest.mark.anyio
+async def test_send_chat_message_partial_failure_logs_orphan_warning(caplog):
+    """업로드 성공 後 메시지 생성 실패 — orphan blob 발생, 운영 가시성 위해 경고 로그."""
+    args = SendChatInput(
+        thread_id="conv-1", content="x",
+        attachments=[{"content_base64": _b64(4), "name": "s.png", "content_type": "image/png"}],
+    )
+    upload_result = {"url": "org/o/project/p/chat/conv-1/x-s.png", "name": "s.png", "content_type": "image/png", "size": 4}
+
+    async def _fake_post(path, json=None):
+        if path.endswith("/attachments"):
+            return upload_result
+        raise RuntimeError("message create failed")
+
+    with caplog.at_level(logging.WARNING, logger=chat_mod.logger.name):
+        with patch.object(chat_mod.client, "post", new=AsyncMock(side_effect=_fake_post)):
+            result = await send_chat_message(args)
+    assert result[0].text.startswith("Error")
+    assert any("orphaned" in r.message for r in caplog.records)

--- a/backend/tests/test_e_mcp_opt_s2_chat_attachment_tool.py
+++ b/backend/tests/test_e_mcp_opt_s2_chat_attachment_tool.py
@@ -11,8 +11,11 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from sprintable_mcp.tools import attachments as attachments_mod
 from sprintable_mcp.tools import chat as chat_mod
-from sprintable_mcp.tools.chat import SendChatInput, _upload_attachments, _validate_attachment, send_chat_message
+from sprintable_mcp.tools.attachments import upload_attachments as _upload_attachments
+from sprintable_mcp.tools.attachments import validate_attachment as _validate_attachment
+from sprintable_mcp.tools.chat import SendChatInput, send_chat_message
 
 
 @pytest.fixture
@@ -53,7 +56,7 @@ def test_validate_attachment_empty_content_base64_raises():
 
 
 def test_validate_attachment_oversized_rejected_before_full_decode():
-    too_big = _b64(chat_mod._MAX_ATTACHMENT_BYTES + 1)
+    too_big = _b64(attachments_mod.MAX_ATTACHMENT_BYTES + 1)
     with pytest.raises(ValueError, match="too large"):
         _validate_attachment({"content_base64": too_big, "name": "a", "content_type": "t"}, 0)
 
@@ -61,28 +64,28 @@ def test_validate_attachment_oversized_rejected_before_full_decode():
 # ── _upload_attachments ───────────────────────────────────────────────────────
 @pytest.mark.anyio
 async def test_upload_attachments_empty_returns_empty():
-    assert await _upload_attachments("conv-1", None) == []
-    assert await _upload_attachments("conv-1", []) == []
+    assert await _upload_attachments("/api/v2/conversations/conv-1/attachments", None) == []
+    assert await _upload_attachments("/api/v2/conversations/conv-1/attachments", []) == []
 
 
 @pytest.mark.anyio
 async def test_upload_attachments_too_many_rejected():
-    atts = [{"content_base64": _b64(1), "name": f"{i}", "content_type": "t"} for i in range(chat_mod._MAX_ATTACHMENTS + 1)]
+    atts = [{"content_base64": _b64(1), "name": f"{i}", "content_type": "t"} for i in range(attachments_mod.MAX_ATTACHMENTS + 1)]
     with pytest.raises(ValueError, match="too many attachments"):
-        await _upload_attachments("conv-1", atts)
+        await _upload_attachments("/api/v2/conversations/conv-1/attachments", atts)
 
 
 @pytest.mark.anyio
 async def test_upload_attachments_total_size_exceeded_rejected_before_any_network_call():
     """총량 초과는 업로드 시작 前 전부 검증되어 걸러진다 — client.post 가 단 한 번도 안 불림
     (마지막 파일에서만 드러나는 초과였다면 앞선 파일들이 실제 업로드→orphan 되는 낭비 없음)."""
-    per_file = chat_mod._MAX_ATTACHMENT_BYTES
+    per_file = attachments_mod.MAX_ATTACHMENT_BYTES
     atts = [{"content_base64": _b64(per_file), "name": f"{i}", "content_type": "t"} for i in range(4)]
-    assert len(atts) <= chat_mod._MAX_ATTACHMENTS
-    assert per_file * 4 > chat_mod._MAX_TOTAL_ATTACHMENT_BYTES
+    assert len(atts) <= attachments_mod.MAX_ATTACHMENTS
+    assert per_file * 4 > attachments_mod.MAX_TOTAL_ATTACHMENT_BYTES
     with patch.object(chat_mod.client, "post", new=AsyncMock()) as m:
         with pytest.raises(ValueError, match="total too large"):
-            await _upload_attachments("conv-1", atts)
+            await _upload_attachments("/api/v2/conversations/conv-1/attachments", atts)
         m.assert_not_awaited()
 
 
@@ -91,7 +94,7 @@ async def test_upload_attachments_calls_endpoint_per_file():
     atts = [{"content_base64": _b64(5), "name": "a.png", "content_type": "image/png"}]
     fake_result = {"url": "org/o/project/p/chat/c/x-a.png", "name": "a.png", "content_type": "image/png", "size": 5}
     with patch.object(chat_mod.client, "post", new=AsyncMock(return_value=fake_result)) as m:
-        result = await _upload_attachments("conv-1", atts)
+        result = await _upload_attachments("/api/v2/conversations/conv-1/attachments", atts)
         assert result == [fake_result]
         m.assert_awaited_once_with(
             "/api/v2/conversations/conv-1/attachments",

--- a/backend/tests/test_e_mcp_opt_s2_chat_attachment_upload_realdb.py
+++ b/backend/tests/test_e_mcp_opt_s2_chat_attachment_upload_realdb.py
@@ -1,0 +1,190 @@
+"""E-MCP-OPT S2 (bbfd24ba): 신규 `POST /{conversation_id}/attachments` 실 Postgres + 실 storage 검증.
+
+MCP(비-브라우저)가 chat 첨부를 올릴 수 있게 하는 새 엔드포인트. 인가는 `send_message`의 실제
+발신 요건과 동일해야 한다(참가자 필수·admin-agent-only-conversation 우회 없음 — 그 우회는
+GET(list/get_conversation) 전용). 이 테스트는 실 Postgres(seed) + 실 StorageProvider(local disk)로
+①참가자 업로드 성공+정확한 S7 path+실제 바이트 write ②비참가자 403 ③base64 오류 400 ④크기초과 413
+을 검증한다.
+"""
+from __future__ import annotations
+
+import base64
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("ab700000-0000-0000-0000-000000000001")
+PROJ = uuid.UUID("ab700000-0000-0000-0000-000000000002")
+CONV = uuid.UUID("ab700000-0000-0000-0000-000000000003")
+AGENT_IN = uuid.UUID("ab700000-0000-0000-0000-0000000000a1")   # conversation 참가자
+AGENT_OUT = uuid.UUID("ab700000-0000-0000-0000-0000000000a2")  # project grant는 있으나 비참가자
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth(member_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(member_id), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(ORG),
+    )
+
+
+async def _seed(s) -> None:
+    # team_members 는 뷰(members ⋈ project_access, 0110 3번째 agent-grant-only UNION 브랜치) —
+    # 직접 INSERT/DELETE 불가. members + project_access 만 심으면 뷰가 자동 파생.
+    for sql in [
+        f"DELETE FROM conversation_participants WHERE conversation_id='{CONV}'",
+        f"DELETE FROM conversation_messages WHERE conversation_id='{CONV}'",
+        f"DELETE FROM conversations WHERE id='{CONV}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','S2ATT','s2att-org','free')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ}','{ORG}','P','none')",
+        f"INSERT INTO members (id,org_id,type,name) VALUES ('{AGENT_IN}','{ORG}','agent','AgentIn')",
+        f"INSERT INTO members (id,org_id,type,name) VALUES ('{AGENT_OUT}','{ORG}','agent','AgentOut')",
+        f"INSERT INTO project_access (project_id,member_id,permission) VALUES "
+        f"('{PROJ}','{AGENT_IN}','granted')",
+        f"INSERT INTO project_access (project_id,member_id,permission) VALUES "
+        f"('{PROJ}','{AGENT_OUT}','granted')",
+        f"INSERT INTO conversations (id,org_id,project_id,type) VALUES ('{CONV}','{ORG}','{PROJ}','group')",
+        f"INSERT INTO conversation_participants (conversation_id,member_id) VALUES ('{CONV}','{AGENT_IN}')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+@pytest.mark.anyio
+async def test_participant_upload_writes_real_bytes_at_s7_path(monkeypatch, tmp_path):
+    """참가자 업로드 성공 — 정확한 S7 shape·실제 로컬 스토리지에 실 바이트 write 확인."""
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.conversations import UploadConversationAttachmentRequest, upload_conversation_attachment
+    from app.services.storage import get_storage_provider
+    from app.services.asset_registry import DEFAULT_CONTAINER
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            raw = b"\x89PNG\r\n\x1a\nfake-png-bytes"
+            body = UploadConversationAttachmentRequest(
+                content_base64=base64.b64encode(raw).decode(),
+                name="../../evil../screenshot.png",
+                content_type="image/png",
+            )
+            resp = await upload_conversation_attachment(
+                CONV, body, db=s, auth=_auth(AGENT_IN), org_id=ORG,
+            )
+            assert resp.size == len(raw)
+            assert resp.content_type == "image/png"
+            # S7 shape — FE 업로드 라우트와 정확히 동일: org/<org>/project/<project>/chat/<conv>/<file>
+            prefix = f"org/{ORG}/project/{PROJ}/chat/{CONV}/"
+            assert resp.url.startswith(prefix)
+            # traversal/부적절 문자 제거됨(파일명 안전화) — path 안에 ".." 세그먼트 없음.
+            assert ".." not in resp.url.split("/")
+
+            # 실제 바이트가 그 경로에 그대로 물리적으로 존재하는지 storage provider로 직접 재확인.
+            object_path = resp.url
+            downloaded = await get_storage_provider().download_object(DEFAULT_CONTAINER, object_path)
+            assert downloaded == raw
+    finally:
+        async with Session() as s:
+            await s.execute(text("DELETE FROM conversation_participants WHERE conversation_id=:c"), {"c": CONV})
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_non_participant_agent_rejected_403(monkeypatch, tmp_path):
+    """project access는 있으나 conversation 비참가자인 에이전트 — send_message와 동일하게 403.
+
+    admin-agent-only-conversation 우회는 여기 적용되지 않는다(그 우회는 GET 전용) — 비참가자는
+    project_access grant가 있어도 업로드 불가여야 send_chat_message의 최종 403과 정합된다.
+    """
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.conversations import UploadConversationAttachmentRequest, upload_conversation_attachment
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            body = UploadConversationAttachmentRequest(
+                content_base64=base64.b64encode(b"x").decode(), name="f.txt", content_type="text/plain",
+            )
+            with pytest.raises(HTTPException) as ei:
+                await upload_conversation_attachment(CONV, body, db=s, auth=_auth(AGENT_OUT), org_id=ORG)
+            assert ei.value.status_code == 403
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_invalid_base64_rejected_400(monkeypatch, tmp_path):
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.conversations import UploadConversationAttachmentRequest, upload_conversation_attachment
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            body = UploadConversationAttachmentRequest(
+                content_base64="not-valid-base64!!!", name="f.txt", content_type="text/plain",
+            )
+            with pytest.raises(HTTPException) as ei:
+                await upload_conversation_attachment(CONV, body, db=s, auth=_auth(AGENT_IN), org_id=ORG)
+            assert ei.value.status_code == 400
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_oversized_decoded_payload_rejected_413(monkeypatch, tmp_path):
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.conversations import (
+        UploadConversationAttachmentRequest,
+        _MAX_JSON_ATTACHMENT_UPLOAD_SIZE,
+        upload_conversation_attachment,
+    )
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            oversized = b"a" * (_MAX_JSON_ATTACHMENT_UPLOAD_SIZE + 1)
+            body = UploadConversationAttachmentRequest(
+                content_base64=base64.b64encode(oversized).decode(),
+                name="big.bin", content_type="application/octet-stream",
+            )
+            with pytest.raises(HTTPException) as ei:
+                await upload_conversation_attachment(CONV, body, db=s, auth=_auth(AGENT_IN), org_id=ORG)
+            assert ei.value.status_code == 413
+    finally:
+        await eng.dispose()

--- a/backend/tests/test_e_mcp_opt_s3_hosted_transport.py
+++ b/backend/tests/test_e_mcp_opt_s3_hosted_transport.py
@@ -1,0 +1,267 @@
+"""E-MCP-OPT S3: 호스팅(http) transport 유도 — connect-step BE 계약.
+
+①`build_agent_mcp_config` transport 분기 + edition 기본 + 두 변형 bundle
+②crux2 — verify rail transport-aware 분기(http=heartbeat 기반 4단계 축소 레일)
+③router 레벨 `transport` 쿼리 배선(connection-artifact/verify-connection/verification-status)
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import app.routers.agents as ag
+from app.services import agent_onboarding_config as cfg
+from app.services.agent_verify import (
+    HTTP_RAIL_STATES,
+    RAIL_STATES,
+    build_http_verification_rail,
+    get_verification_state,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── ① build_agent_mcp_config transport 분기 ───────────────────────────────────
+def test_stdio_default_unchanged_when_no_transport_kwarg():
+    """기존 호출부(회귀0) — transport 미지정이면 여전히 stdio."""
+    out = cfg.build_agent_mcp_config(api_key_plaintext="k")
+    assert out["mcpServers"]["sprintable"]["type"] == "stdio"
+
+
+def test_http_variant_none_when_mcp_public_url_unset(monkeypatch):
+    monkeypatch.delenv("MCP_PUBLIC_URL", raising=False)
+    assert cfg.resolve_mcp_public_url() is None
+    assert cfg.build_agent_mcp_config(api_key_plaintext="k", transport="http") is None
+
+
+def test_http_variant_shape_with_key(monkeypatch):
+    monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp/")
+    assert cfg.resolve_mcp_public_url() == "https://mcp.sprintable.ai/mcp"  # trailing slash 제거
+    out = cfg.build_agent_mcp_config(api_key_plaintext="sk_live_abc", transport="http")
+    server = out["mcpServers"]["sprintable"]
+    assert server == {
+        "type": "http",
+        "url": "https://mcp.sprintable.ai/mcp",
+        "headers": {"Authorization": "Bearer sk_live_abc"},
+    }
+
+
+def test_http_variant_no_auth_header_when_key_absent(monkeypatch):
+    monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp")
+    out = cfg.build_agent_mcp_config(api_key_plaintext=None, transport="http")
+    assert out["mcpServers"]["sprintable"]["headers"] == {}
+
+
+def test_default_transport_for_edition(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "license_consent", "", raising=False)
+    assert cfg.default_transport_for_edition() == "stdio"
+    monkeypatch.setattr(settings, "license_consent", "agreed", raising=False)
+    assert cfg.default_transport_for_edition() == "http"
+
+
+def test_bundle_saas_with_hosting_available(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "license_consent", "agreed", raising=False)
+    monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp")
+    bundle = cfg.build_agent_mcp_config_bundle(api_key_plaintext="k")
+    assert bundle["default_transport"] == "http"
+    assert bundle["mcp_config"]["mcpServers"]["sprintable"]["type"] == "http"
+    assert set(bundle["mcp_config_alternatives"]) == {"stdio"}
+
+
+def test_bundle_oss_no_hosting_falls_back_to_stdio_only(monkeypatch):
+    """OSS(호스팅 미배포) — MCP_PUBLIC_URL 미설정이면 default가 http여도 stdio로 폴백·alternatives 비움."""
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "license_consent", "agreed", raising=False)  # 가정: edition=SaaS이나
+    monkeypatch.delenv("MCP_PUBLIC_URL", raising=False)                  # 이 인스턴스엔 호스팅 미배포
+    bundle = cfg.build_agent_mcp_config_bundle(api_key_plaintext="k")
+    assert bundle["default_transport"] == "stdio"
+    assert bundle["mcp_config"]["mcpServers"]["sprintable"]["type"] == "stdio"
+    assert bundle["mcp_config_alternatives"] == {}
+
+
+def test_bundle_oss_default_stdio(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "license_consent", "", raising=False)
+    monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp")  # 배포는 있어도 OSS면 기본 stdio
+    bundle = cfg.build_agent_mcp_config_bundle(api_key_plaintext="k")
+    assert bundle["default_transport"] == "stdio"
+    assert set(bundle["mcp_config_alternatives"]) == {"http"}
+
+
+# ── ② crux2 — verify rail transport-aware ─────────────────────────────────────
+def _states(rail):
+    return {r["state"]: r["status"] for r in rail}
+
+
+def test_http_rail_is_4_states_no_event_delivered_ack():
+    rail = build_http_verification_rail(heartbeat_fresh=True)
+    assert [r["state"] for r in rail] == list(HTTP_RAIL_STATES)
+    assert len(HTTP_RAIL_STATES) == 4
+    assert "event_delivered" not in _states(rail) and "ack" not in _states(rail)
+
+
+def test_http_rail_fresh_heartbeat_all_done():
+    s = _states(build_http_verification_rail(heartbeat_fresh=True))
+    assert all(v == "done" for v in s.values())
+
+
+def test_http_rail_no_heartbeat_waiting_active():
+    s = _states(build_http_verification_rail(heartbeat_fresh=False))
+    assert s["config_copied"] == "done"
+    assert s["waiting"] == "active"
+    assert s["mcp_reachable"] == "pending" and s["verified"] == "pending"
+
+
+def _scalar(v):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = v
+    return r
+
+
+def _first(v):
+    r = MagicMock()
+    r.first.return_value = v
+    return r
+
+
+@pytest.mark.anyio
+async def test_get_verification_state_http_uses_heartbeat_not_sse(monkeypatch):
+    """transport='http' 는 Event/AgentEventCursor(SSE) 를 아예 조회 안 하고 heartbeat freshness 1회만."""
+    from app.routers import agent_gateway as gw
+    monkeypatch.setattr(gw, "_SESSION_FRESH_TTL", 60, raising=False)
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_first(("profile-row",)))  # fresh heartbeat 존재
+    out = await get_verification_state(db, uuid.uuid4(), transport="http")
+    assert db.execute.await_count == 1  # SSE 관련 verify_seq/acked_seq 조회 0회
+    assert out["verified"] is True
+    assert [r["state"] for r in out["rail"]] == list(HTTP_RAIL_STATES)
+    assert out["verify_seq"] is None and out["acked_seq"] is None  # http 는 이 개념 자체가 없음
+
+
+@pytest.mark.anyio
+async def test_get_verification_state_http_no_heartbeat_not_verified():
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_first(None))
+    out = await get_verification_state(db, uuid.uuid4(), transport="http")
+    assert out["verified"] is False
+
+
+@pytest.mark.anyio
+async def test_get_verification_state_stdio_default_unchanged():
+    """transport 미지정 = 기존 stdio 6단계 경로 그대로(회귀0)."""
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_scalar(5), _scalar(7), _first(("sess",))])
+    out = await get_verification_state(db, uuid.uuid4())
+    assert [r["state"] for r in out["rail"]] == list(RAIL_STATES)
+    assert out["verified"] is True
+
+
+# ── ③ router 레벨 transport 배선 ──────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_connection_artifact_transport_http_returns_http_content(monkeypatch):
+    from app.routers.agents import get_agent_connection_artifact
+
+    monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp")
+    agent_id = uuid.uuid4()
+    res = MagicMock()
+    res.scalar_one_or_none.return_value = SimpleNamespace(id=agent_id)
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=res)
+    out = await get_agent_connection_artifact(
+        agent_id, runtime="claude-code", transport="http",
+        session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+    )
+    parsed = json.loads(out["content"])
+    assert parsed["mcpServers"]["sprintable"]["type"] == "http"
+
+
+@pytest.mark.anyio
+async def test_connection_artifact_transport_http_unavailable_400(monkeypatch):
+    """http 명시 요청됐는데 이 환경엔 호스팅 배포가 없음(MCP_PUBLIC_URL 미설정) — 400."""
+    from fastapi import HTTPException
+
+    from app.routers.agents import get_agent_connection_artifact
+
+    monkeypatch.delenv("MCP_PUBLIC_URL", raising=False)
+    agent_id = uuid.uuid4()
+    res = MagicMock()
+    res.scalar_one_or_none.return_value = SimpleNamespace(id=agent_id)
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=res)
+    with pytest.raises(HTTPException) as ei:
+        await get_agent_connection_artifact(
+            agent_id, runtime="claude-code", transport="http",
+            session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+        )
+    assert ei.value.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_connection_artifact_unsupported_transport_400():
+    from fastapi import HTTPException
+
+    from app.routers.agents import get_agent_connection_artifact
+    with pytest.raises(HTTPException) as ei:
+        await get_agent_connection_artifact(
+            uuid.uuid4(), runtime="claude-code", transport="carrier-pigeon",
+            session=AsyncMock(), auth=MagicMock(), org_id=uuid.uuid4(),
+        )
+    assert ei.value.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_verify_connection_http_skips_synthetic_event_and_wake(monkeypatch):
+    """transport='http' — start_verification/wake_agent(SSE 전용 경로) 전혀 호출 안 됨."""
+    member = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar(member))
+    rail = [{"state": s, "status": "done"} for s in HTTP_RAIL_STATES]
+    with patch.object(ag, "start_verification", new=AsyncMock()) as start, \
+         patch.object(ag, "get_verification_state",
+                      new=AsyncMock(return_value={"verified": True, "rail": rail, "verify_seq": None})), \
+         patch("app.routers.agent_gateway.wake_agent", new=MagicMock()) as wake:
+        out = await ag.verify_agent_connection(
+            member.id, transport="http", session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+        )
+    assert out["verified"] is True and out["rail"] == rail
+    start.assert_not_awaited()
+    wake.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_verification_status_passes_transport_through():
+    member = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar(member))
+    with patch.object(ag, "get_verification_state", new=AsyncMock(
+        return_value={"verified": True, "rail": [], "verify_seq": None},
+    )) as get_state:
+        await ag.agent_verification_status(
+            member.id, transport="http", session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+        )
+    get_state.assert_awaited_once_with(db, member.id, transport="http")
+
+
+# ── emit_onboarding_event dynamic transport (하드코딩 제거 회귀 가드) ──────────
+def test_agents_router_no_longer_hardcodes_transport_stdio_literal():
+    """agents.py 소스에 `transport=\"stdio\"` 하드코딩 문자열이 (verify-connection 자체의
+    event_sent 콜 1곳 제외) 더는 없어야 한다 — agent_created/config_generated 는 실제
+    default_transport/resolved_transport 변수를 넘겨야(안 그러면 SaaS 퍼널이 전부 stdio로 오기록)."""
+    import inspect
+    src = inspect.getsource(ag)
+    create_src = inspect.getsource(ag.create_org_agent)
+    artifact_src = inspect.getsource(ag.get_agent_connection_artifact)
+    assert 'transport="stdio"' not in create_src
+    assert 'transport="stdio"' not in artifact_src
+    assert 'transport=config_bundle["default_transport"]' in create_src
+    assert "transport=resolved_transport" in artifact_src

--- a/backend/tests/test_e_mcp_opt_s5_hardening.py
+++ b/backend/tests/test_e_mcp_opt_s5_hardening.py
@@ -1,0 +1,160 @@
+"""E-MCP-OPT S5 (34e69685): S2+S3 QA MINOR 하드닝 모음.
+
+#4: verify-connection — project 미배정 에이전트는 transport 무관 동일하게 400(http 조기 return이
+    이 가드보다 먼저였던 비대칭 수정).
+#5: 첫인증 텔레메트리(_persist_first_auth_seen) transport 하드코딩 제거 — MCP 클라이언트 자기신고
+    (X-MCP-Transport 헤더) 기반으로 동적화.
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import app.routers.agents as ag
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _scalar(v):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = v
+    return r
+
+
+# ── #4: project 미배정 → transport 무관 동일 400 ──────────────────────────────
+@pytest.mark.anyio
+async def test_verify_connection_unassigned_agent_400_via_stdio():
+    member = SimpleNamespace(id=uuid.uuid4(), project_id=None)
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar(member))
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as ei:
+        await ag.verify_agent_connection(
+            member.id, transport=None, session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+        )
+    assert ei.value.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_verify_connection_unassigned_agent_400_via_http_too():
+    """회귀 가드 — 이전엔 http 조기 return이 이 가드를 건너뛰어 200이 났었다(까심 QA #4)."""
+    member = SimpleNamespace(id=uuid.uuid4(), project_id=None)
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar(member))
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as ei:
+        await ag.verify_agent_connection(
+            member.id, transport="http", session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+        )
+    assert ei.value.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_verify_connection_assigned_agent_http_still_skips_sse(monkeypatch):
+    """project 배정된 에이전트는 http에서 여전히 합성이벤트/wake 스킵(#4가 이 동작을 안 건드림)."""
+    member = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_scalar(member))
+    with patch.object(ag, "start_verification", new=AsyncMock()) as start, \
+         patch.object(ag, "get_verification_state", new=AsyncMock(
+             return_value={"verified": True, "rail": [], "verify_seq": None},
+         )), \
+         patch("app.routers.agent_gateway.wake_agent", new=MagicMock()) as wake:
+        out = await ag.verify_agent_connection(
+            member.id, transport="http", session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+        )
+    assert out["verified"] is True
+    start.assert_not_awaited()
+    wake.assert_not_called()
+
+
+# ── #5: 첫인증 텔레메트리 transport 동적화 ────────────────────────────────────
+class _FakeSession:
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, *a):
+        return False
+    async def execute(self, *a, **kw):
+        m = MagicMock()
+        m.first.return_value = None  # dedup: 아직 기록 없음
+        return m
+    async def commit(self):
+        return None
+
+
+@pytest.mark.anyio
+async def test_persist_first_auth_seen_uses_passed_transport():
+    from app.dependencies import auth as authmod
+
+    captured = {}
+
+    async def _fake_record(s, *, event, agent_id, org_id, project_id, runtime, transport):
+        captured["transport"] = transport
+
+    with patch("app.core.database.async_session_factory", new=lambda: _FakeSession()), \
+         patch("app.services.onboarding_funnel.record_onboarding_event", new=_fake_record):
+        await authmod._persist_first_auth_seen(uuid.uuid4(), None, None, transport="http")
+    assert captured["transport"] == "http"
+
+
+@pytest.mark.anyio
+async def test_persist_first_auth_seen_falls_back_to_stdio_when_no_header():
+    """회귀 가드 — 헤더 미전송(구버전 클라이언트 등) 시 기존과 동일하게 'stdio'."""
+    from app.dependencies import auth as authmod
+
+    captured = {}
+
+    async def _fake_record(s, *, event, agent_id, org_id, project_id, runtime, transport):
+        captured["transport"] = transport
+
+    with patch("app.core.database.async_session_factory", new=lambda: _FakeSession()), \
+         patch("app.services.onboarding_funnel.record_onboarding_event", new=_fake_record):
+        await authmod._persist_first_auth_seen(uuid.uuid4(), None, None, transport=None)
+    assert captured["transport"] == "stdio"
+
+
+@pytest.mark.anyio
+async def test_get_current_user_passes_x_mcp_transport_header_through():
+    from app.dependencies.auth import get_current_user
+
+    with patch("app.dependencies.auth._resolve_api_key", new=AsyncMock()) as resolve:
+        await get_current_user(
+            credentials=None, x_agent_api_key="sk_live_abc", x_mcp_transport="http",
+            db=AsyncMock(),
+        )
+    resolve.assert_awaited_once_with("sk_live_abc", resolve.await_args.args[1], transport="http")
+
+
+def test_mcp_client_sends_x_mcp_transport_header(monkeypatch):
+    """sprintable_mcp 쪽 — 매 요청마다 자기신고 헤더가 실제로 실린다(both transport 값)."""
+    from sprintable_mcp import api_client as ac
+    from sprintable_mcp.config import settings as mcp_settings
+
+    monkeypatch.setattr(mcp_settings, "mcp_transport", "http", raising=False)
+    client = ac.SprintableClient()
+    client.configure("https://x", "envkey")
+
+    captured = {}
+
+    async def _fake_request(method, url, **kw):
+        captured["headers"] = kw.get("headers", {})
+        class R:
+            status_code = 200
+            is_success = True
+            headers = {"content-type": "application/json"}
+            def json(self): return {}
+            @property
+            def text(self): return "{}"
+        return R()
+
+    import asyncio
+    from unittest.mock import patch as _patch
+    with _patch("httpx.AsyncClient.request", new=AsyncMock(side_effect=_fake_request)):
+        asyncio.run(client.get("/x"))
+    assert captured["headers"]["X-MCP-Transport"] == "http"

--- a/backend/tests/test_e_mcp_opt_s5_hardening_realdb.py
+++ b/backend/tests/test_e_mcp_opt_s5_hardening_realdb.py
@@ -1,0 +1,198 @@
+"""E-MCP-OPT S5 (34e69685) #2 — 실 Postgres: mcp-origin 첨부 선언 한도(5개/6MiB) 우회 봉쇄.
+
+`upload_conversation_attachment`가 파일당 2MiB만 체크하고 선언 총량(5개/6MiB)을 강제하지 않아,
+participant가 다회 개별 업로드(각 ≤2MiB)로 메시지당 최대 10개(기존 message-level 캡)까지 모아
+SSOT 정책을 우회할 수 있었다(까심 QA #2). `send_message`가 mcp-origin(첨부 url이
+`.../chat/<conv>/mcp/<file>` shape) 부분집합에 한해 선언 한도를 재검증하는지 실 DB+실
+upload_conversation_attachment 왕복으로 확인한다.
+"""
+from __future__ import annotations
+
+import base64
+import os
+import uuid
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("ab800000-0000-0000-0000-000000000001")
+PROJ = uuid.UUID("ab800000-0000-0000-0000-000000000002")
+CONV = uuid.UUID("ab800000-0000-0000-0000-000000000003")
+AGENT = uuid.UUID("ab800000-0000-0000-0000-0000000000a1")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth(member_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(member_id), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(ORG),
+    )
+
+
+async def _seed(s) -> None:
+    for sql in [
+        f"DELETE FROM conversation_participants WHERE conversation_id='{CONV}'",
+        f"DELETE FROM conversation_messages WHERE conversation_id='{CONV}'",
+        f"DELETE FROM conversations WHERE id='{CONV}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','S5HARD','s5hard-org','free')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ}','{ORG}','P','none')",
+        f"INSERT INTO members (id,org_id,type,name) VALUES ('{AGENT}','{ORG}','agent','Agent')",
+        f"INSERT INTO project_access (project_id,member_id,permission) VALUES ('{PROJ}','{AGENT}','granted')",
+        f"INSERT INTO conversations (id,org_id,project_id,type) VALUES ('{CONV}','{ORG}','{PROJ}','group')",
+        f"INSERT INTO conversation_participants (conversation_id,member_id) VALUES ('{CONV}','{AGENT}')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+@pytest.mark.anyio
+async def test_many_individual_uploads_then_send_message_rejects_over_declared_limit(monkeypatch, tmp_path):
+    """6개(> 5개 cap)를 개별 업로드(각 1.5MiB, 합 9MiB > 6MiB)한 뒤 그 6개 전부를 참조하는
+    send_message 는 400 — 우회 봉쇄. 이전(fix 前)엔 message-level 캡(10)만 걸려 통과했다."""
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.conversations import (
+        MessageAttachment,
+        SendMessageRequest,
+        UploadConversationAttachmentRequest,
+        send_message,
+        upload_conversation_attachment,
+    )
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        uploaded: list[MessageAttachment] = []
+        async with Session() as s:
+            for i in range(6):
+                raw = b"a" * (1024 * 1024)  # 1MiB (per-file 2MiB 캡 안쪽)
+                body = UploadConversationAttachmentRequest(
+                    content_base64=base64.b64encode(raw).decode(),
+                    name=f"f{i}.bin", content_type="application/octet-stream",
+                )
+                resp = await upload_conversation_attachment(
+                    CONV, body, db=s, auth=_auth(AGENT), org_id=ORG,
+                )
+                uploaded.append(resp)
+
+        assert all("/mcp/" in a.url for a in uploaded)
+        total = sum(a.size for a in uploaded)
+        assert len(uploaded) == 6 and total == 6 * 1024 * 1024  # 6개>5·6MiB 경계선 초과
+
+        async with Session() as s:
+            send_body = SendMessageRequest(content="here are my files", attachments=uploaded)
+            with pytest.raises(HTTPException) as ei:
+                await send_message(
+                    CONV, send_body, BackgroundTasks(), db=s, auth=_auth(AGENT), org_id=ORG,
+                )
+            assert ei.value.status_code == 400
+
+            # 부분 커밋 없음 확인 — 메시지가 실제로 생성 안 됐는지.
+            cnt = (await s.execute(
+                text("SELECT count(*) FROM conversation_messages WHERE conversation_id=:c"),
+                {"c": CONV},
+            )).scalar_one()
+            assert cnt == 0
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_within_declared_limit_send_message_succeeds(monkeypatch, tmp_path):
+    """5개 이하·6MiB 이하면 정상 전송(회귀0 — 정당한 사용은 막히지 않음)."""
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.conversations import (
+        SendMessageRequest,
+        UploadConversationAttachmentRequest,
+        send_message,
+        upload_conversation_attachment,
+    )
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        uploaded = []
+        async with Session() as s:
+            for i in range(3):
+                raw = b"a" * (1024 * 1024)
+                body = UploadConversationAttachmentRequest(
+                    content_base64=base64.b64encode(raw).decode(),
+                    name=f"ok{i}.bin", content_type="application/octet-stream",
+                )
+                uploaded.append(await upload_conversation_attachment(
+                    CONV, body, db=s, auth=_auth(AGENT), org_id=ORG,
+                ))
+
+        async with Session() as s:
+            send_body = SendMessageRequest(content="within limit", attachments=uploaded)
+            resp = await send_message(
+                CONV, send_body, BackgroundTasks(), db=s, auth=_auth(AGENT), org_id=ORG,
+            )
+            assert resp["data"]["id"]
+    finally:
+        async with Session() as s:
+            await s.execute(text("DELETE FROM conversation_messages WHERE conversation_id=:c"), {"c": CONV})
+            await s.commit()
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_fe_uploaded_non_mcp_attachments_unaffected_by_mcp_cap(monkeypatch, tmp_path):
+    """FE(비-MCP) 첨부는 mcp/ 마커가 없어 이 새 한도의 영향을 받지 않는다(회귀0) — 6개(>5)를 FE-style
+    bare path 로 시뮬레이션해도 send_message 는 (기존 message-level 캡 10 이내라면) 통과해야 한다."""
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.conversations import MessageAttachment, SendMessageRequest, send_message
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        # FE-style 업로드 시뮬레이션 — mcp/ 세그먼트 없는 bare path(실제 FE 라우트가 만드는 shape).
+        fe_attachments = [
+            MessageAttachment(
+                url=f"org/{ORG}/project/{PROJ}/chat/{CONV}/{uuid.uuid4()}-f{i}.png",
+                name=f"f{i}.png", content_type="image/png", size=1024 * 1024,
+            )
+            for i in range(6)
+        ]
+        async with Session() as s:
+            send_body = SendMessageRequest(content="fe upload", attachments=fe_attachments)
+            resp = await send_message(
+                CONV, send_body, BackgroundTasks(), db=s, auth=_auth(AGENT), org_id=ORG,
+            )
+            assert resp["data"]["id"]
+    finally:
+        async with Session() as s:
+            await s.execute(text("DELETE FROM conversation_messages WHERE conversation_id=:c"), {"c": CONV})
+            await s.commit()
+        await eng.dispose()

--- a/backend/tests/test_e_mcp_opt_s6_shared_upload_module.py
+++ b/backend/tests/test_e_mcp_opt_s6_shared_upload_module.py
@@ -1,0 +1,86 @@
+"""E-MCP-OPT S6: `app/services/mcp_attachment_upload.py` 공용 프리미티브 — chat/story/doc 공유.
+
+S2/S5 당시 chat 전용 로컬 정의였던 것을 3번째 리소스(story) 추가 시점에 추출(DRY). 값/로직은 기존
+chat 동작과 100% 동일해야 한다 — kind 파라미터만 리소스별로 다르다.
+"""
+from __future__ import annotations
+
+import base64
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+from app.services import mcp_attachment_upload as m
+
+
+def test_constants_match_previous_chat_values():
+    assert m.MAX_JSON_ATTACHMENT_UPLOAD_SIZE == 2 * 1024 * 1024
+    assert m.MCP_MAX_ATTACHMENTS == 5
+    assert m.MCP_MAX_TOTAL_ATTACHMENT_BYTES == 6 * 1024 * 1024
+
+
+def test_safe_attachment_filename_sanitizes_and_truncates():
+    assert m.safe_attachment_filename("../../evil/../x.png") == ".._.._evil_.._x.png"
+    assert m.safe_attachment_filename("") == "file"
+    assert m.safe_attachment_filename("   ") == "file"
+    assert len(m.safe_attachment_filename("a" * 300)) <= 128
+
+
+def test_decode_json_attachment_valid():
+    raw = b"hello world"
+    data = m.decode_json_attachment(base64.b64encode(raw).decode())
+    assert data == raw
+
+
+def test_decode_json_attachment_invalid_base64_400():
+    with pytest.raises(HTTPException) as ei:
+        m.decode_json_attachment("not-valid-base64!!!")
+    assert ei.value.status_code == 400
+
+
+def test_decode_json_attachment_empty_400():
+    with pytest.raises(HTTPException) as ei:
+        m.decode_json_attachment(base64.b64encode(b"").decode())
+    assert ei.value.status_code == 400
+
+
+def test_decode_json_attachment_oversized_413():
+    oversized = base64.b64encode(b"a" * (m.MAX_JSON_ATTACHMENT_UPLOAD_SIZE + 1)).decode()
+    with pytest.raises(HTTPException) as ei:
+        m.decode_json_attachment(oversized)
+    assert ei.value.status_code == 413
+
+
+def test_build_mcp_object_path_shape():
+    org = uuid.uuid4()
+    proj = uuid.uuid4()
+    conv = uuid.uuid4()
+    path = m.build_mcp_object_path(org_id=org, project_id=proj, kind="chat", resource_id=conv, safe_name="x.png")
+    parts = path.split("/")
+    assert parts[0] == "org" and parts[1] == str(org)
+    assert parts[2] == "project" and parts[3] == str(proj)
+    assert parts[4] == "chat" and parts[5] == str(conv)
+    assert parts[6] == "mcp"
+    assert parts[7].endswith("-x.png")
+
+
+@pytest.mark.parametrize("kind", ["chat", "story", "doc"])
+def test_is_mcp_upload_object_path_per_kind(kind):
+    org, proj, rid = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    path = m.build_mcp_object_path(org_id=org, project_id=proj, kind=kind, resource_id=rid, safe_name="a.bin")
+    assert m.is_mcp_upload_object_path(path, kind=kind) is True
+    # 다른 kind 로는 매칭 안 됨(교차 오염 방지).
+    other = "story" if kind != "story" else "doc"
+    assert m.is_mcp_upload_object_path(path, kind=other) is False
+
+
+def test_is_mcp_upload_object_path_rejects_non_mcp_path():
+    assert m.is_mcp_upload_object_path("org/o/project/p/story/s/uuid-x.png", kind="story") is False
+
+
+def test_is_mcp_upload_object_path_handles_gcs_public_url():
+    org, proj, rid = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    path = m.build_mcp_object_path(org_id=org, project_id=proj, kind="doc", resource_id=rid, safe_name="a.bin")
+    gcs_url = f"https://storage.googleapis.com/{m.DEFAULT_CONTAINER if hasattr(m, 'DEFAULT_CONTAINER') else 'sprintable-memo-attachments'}/{path}"
+    assert m.is_mcp_upload_object_path(gcs_url, kind="doc") is True

--- a/backend/tests/test_e_mcp_opt_s6_story_doc_tools.py
+++ b/backend/tests/test_e_mcp_opt_s6_story_doc_tools.py
@@ -1,0 +1,156 @@
+"""E-MCP-OPT S6: `update_story`/`update_doc` MCP 도구 첨부 파라미터 — 업로드 체이닝/병합 검증.
+
+story: 업로드 결과를 PATCH attachments 에 실을 때 **기존 첨부와 병합**(서버 full-replace 이므로
+먼저 GET 으로 기존 목록을 읽어 이어붙임 — 새 첨부가 기존 걸 지우지 않음).
+doc: 업로드 응답의 embed_snippet 을 content 끝에 append(현재 content 미제공 시 GET 으로 먼저 읽음).
+"""
+from __future__ import annotations
+
+import base64
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from sprintable_mcp.tools import docs as docs_mod
+from sprintable_mcp.tools import stories as stories_mod
+from sprintable_mcp.tools.docs import UpdateDocInput, update_doc
+from sprintable_mcp.tools.stories import UpdateStoryInput, update_story
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _b64(n: int) -> str:
+    return base64.b64encode(b"x" * n).decode()
+
+
+# ── story ──────────────────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_update_story_no_attachments_unchanged_payload():
+    args = UpdateStoryInput(story_id="s1", title="new title")
+    with patch.object(stories_mod.client, "patch", new=AsyncMock(return_value={})) as m:
+        await update_story(args)
+        _, kwargs = m.call_args
+        assert "attachments" not in kwargs["json"]
+
+
+@pytest.mark.anyio
+async def test_update_story_merges_new_attachments_with_existing():
+    args = UpdateStoryInput(
+        story_id="s1",
+        attachments=[{"content_base64": _b64(4), "name": "new.png", "content_type": "image/png"}],
+    )
+    existing_attachment = {"url": "org/o/project/p/story/s1/old.png", "name": "old.png", "content_type": "image/png", "size": 10}
+    uploaded_attachment = {"url": "org/o/project/p/story/s1/mcp/x-new.png", "name": "new.png", "content_type": "image/png", "size": 4}
+    calls: list[tuple] = []
+
+    async def _fake_post(path, json=None):
+        calls.append(("post", path, json))
+        return uploaded_attachment
+
+    async def _fake_get(path, params=None):
+        calls.append(("get", path, None))
+        return {"attachments": [existing_attachment]}
+
+    async def _fake_patch(path, json=None):
+        calls.append(("patch", path, json))
+        return {"id": "s1"}
+
+    with patch.object(stories_mod.client, "post", new=AsyncMock(side_effect=_fake_post)), \
+         patch.object(stories_mod.client, "get", new=AsyncMock(side_effect=_fake_get)), \
+         patch.object(stories_mod.client, "patch", new=AsyncMock(side_effect=_fake_patch)):
+        await update_story(args)
+
+    kinds = [c[0] for c in calls]
+    assert kinds == ["post", "get", "patch"]
+    patch_body = calls[-1][2]
+    assert patch_body["attachments"] == [existing_attachment, uploaded_attachment]
+
+
+@pytest.mark.anyio
+async def test_update_story_upload_failure_returns_error_no_patch():
+    args = UpdateStoryInput(
+        story_id="s1",
+        attachments=[{"content_base64": _b64(4), "name": "new.png", "content_type": "image/png"}],
+    )
+    with patch.object(stories_mod.client, "post", new=AsyncMock(side_effect=RuntimeError("403"))), \
+         patch.object(stories_mod.client, "patch", new=AsyncMock()) as patch_mock:
+        result = await update_story(args)
+    assert result[0].text.startswith("Error")
+    patch_mock.assert_not_awaited()
+
+
+# ── doc ────────────────────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_update_doc_no_attachments_unchanged_payload():
+    args = UpdateDocInput(doc_id="d1", title="new title")
+    with patch.object(docs_mod.client, "patch", new=AsyncMock(return_value={})) as m:
+        await update_doc(args)
+        _, kwargs = m.call_args
+        assert "content" not in kwargs["json"]
+
+
+@pytest.mark.anyio
+async def test_update_doc_appends_embed_snippet_to_provided_content():
+    args = UpdateDocInput(
+        doc_id="d1", content="# my doc\n\nsome text",
+        attachments=[{"content_base64": _b64(4), "name": "shot.png", "content_type": "image/png"}],
+    )
+    upload_result = {
+        "asset_id": "AID-1", "filename": "shot.png", "size": 4, "mime": "image/png",
+        "embed_snippet": '<img data-asset-id="AID-1" data-filename="shot.png" data-size="4" data-mime-type="image/png" alt="shot.png">',
+    }
+    with patch.object(docs_mod.client, "post", new=AsyncMock(return_value=upload_result)), \
+         patch.object(docs_mod.client, "patch", new=AsyncMock(return_value={})) as patch_mock:
+        await update_doc(args)
+    _, kwargs = patch_mock.call_args
+    assert kwargs["json"]["content"] == "# my doc\n\nsome text\n" + upload_result["embed_snippet"]
+
+
+@pytest.mark.anyio
+async def test_update_doc_fetches_existing_content_when_not_provided():
+    """content 미제공 시 현재 저장된 content 를 먼저 읽어 그 뒤에 append(기존 본문 유지)."""
+    args = UpdateDocInput(
+        doc_id="d1",
+        attachments=[{"content_base64": _b64(4), "name": "shot.png", "content_type": "image/png"}],
+    )
+    upload_result = {
+        "asset_id": "AID-1", "filename": "shot.png", "size": 4, "mime": "image/png",
+        "embed_snippet": '<img data-asset-id="AID-1" alt="shot.png">',
+    }
+    calls: list[tuple] = []
+
+    async def _fake_post(path, json=None):
+        calls.append(("post", path))
+        return upload_result
+
+    async def _fake_get(path, params=None):
+        calls.append(("get", path))
+        return {"content": "existing body"}
+
+    async def _fake_patch(path, json=None):
+        calls.append(("patch", path, json))
+        return {}
+
+    with patch.object(docs_mod.client, "post", new=AsyncMock(side_effect=_fake_post)), \
+         patch.object(docs_mod.client, "get", new=AsyncMock(side_effect=_fake_get)), \
+         patch.object(docs_mod.client, "patch", new=AsyncMock(side_effect=_fake_patch)):
+        await update_doc(args)
+
+    patch_call = next(c for c in calls if c[0] == "patch")
+    assert patch_call[2]["content"] == f"existing body\n{upload_result['embed_snippet']}"
+
+
+@pytest.mark.anyio
+async def test_update_doc_upload_failure_returns_error_no_patch():
+    args = UpdateDocInput(
+        doc_id="d1",
+        attachments=[{"content_base64": _b64(4), "name": "shot.png", "content_type": "image/png"}],
+    )
+    with patch.object(docs_mod.client, "post", new=AsyncMock(side_effect=RuntimeError("403"))), \
+         patch.object(docs_mod.client, "patch", new=AsyncMock()) as patch_mock:
+        result = await update_doc(args)
+    assert result[0].text.startswith("Error")
+    patch_mock.assert_not_awaited()

--- a/backend/tests/test_e_mcp_opt_s6_story_doc_upload_realdb.py
+++ b/backend/tests/test_e_mcp_opt_s6_story_doc_upload_realdb.py
@@ -1,0 +1,264 @@
+"""E-MCP-OPT S6 (029b7825): story/doc MCP 첨부 업로드 — 실 Postgres + 실 storage.
+
+story: `upload_story_attachment`(chat과 동형) + `update_story`의 mcp-태그 부분집합 선언한도
+재검증(S5 #2 처음부터 포함). doc: `upload_doc_attachment`(base64 업로드+즉시 asset 등록 한 호출)
++ `embed_snippet`이 실 TipTap 렌더 계약(data-asset-id/data-filename/data-size/data-mime-type)과
+정확히 일치하는지.
+"""
+from __future__ import annotations
+
+import base64
+import os
+import uuid
+
+import pytest
+from fastapi import BackgroundTasks, HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("ab900000-0000-0000-0000-000000000001")
+PROJ = uuid.UUID("ab900000-0000-0000-0000-000000000002")
+STORY = uuid.UUID("ab900000-0000-0000-0000-000000000003")
+DOC = uuid.UUID("ab900000-0000-0000-0000-000000000004")
+AGENT_IN = uuid.UUID("ab900000-0000-0000-0000-0000000000a1")   # project access 있음
+AGENT_OUT = uuid.UUID("ab900000-0000-0000-0000-0000000000a2")  # project access 없음
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth(member_id: uuid.UUID) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(member_id), email=None,
+        claims={"app_metadata": {"api_key_id": str(uuid.uuid4())}}, org_id=str(ORG),
+    )
+
+
+async def _seed(s) -> None:
+    for sql in [
+        f"DELETE FROM stories WHERE org_id='{ORG}'",
+        f"DELETE FROM docs WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id='{PROJ}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','S6SD','s6sd-org','free')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ}','{ORG}','P','none')",
+        f"INSERT INTO members (id,org_id,type,name) VALUES ('{AGENT_IN}','{ORG}','agent','AgentIn')",
+        f"INSERT INTO members (id,org_id,type,name) VALUES ('{AGENT_OUT}','{ORG}','agent','AgentOut')",
+        f"INSERT INTO project_access (project_id,member_id,permission) VALUES ('{PROJ}','{AGENT_IN}','granted')",
+        f"INSERT INTO stories (id,org_id,project_id,title,status,priority) VALUES "
+        f"('{STORY}','{ORG}','{PROJ}','test story','backlog','medium')",
+        f"INSERT INTO docs (id,org_id,project_id,title,slug,content) VALUES "
+        f"('{DOC}','{ORG}','{PROJ}','test doc','test-doc-s6','')",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _engine():
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+# ── story ──────────────────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_story_upload_writes_real_bytes_at_s7_path_with_mcp_marker(monkeypatch, tmp_path):
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.stories import UploadStoryAttachmentRequest, upload_story_attachment
+    from app.services.storage import get_storage_provider
+    from app.services.asset_registry import DEFAULT_CONTAINER
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            raw = b"\x89PNG story screenshot bytes"
+            body = UploadStoryAttachmentRequest(
+                content_base64=base64.b64encode(raw).decode(), name="shot.png", content_type="image/png",
+            )
+            resp = await upload_story_attachment(STORY, body, session=s, auth=_auth(AGENT_IN), org_id=ORG)
+            assert resp.size == len(raw)
+            prefix = f"org/{ORG}/project/{PROJ}/story/{STORY}/mcp/"
+            assert resp.url.startswith(prefix)
+            downloaded = await get_storage_provider().download_object(DEFAULT_CONTAINER, resp.url)
+            assert downloaded == raw
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_story_upload_no_project_access_403(monkeypatch, tmp_path):
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.stories import UploadStoryAttachmentRequest, upload_story_attachment
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            body = UploadStoryAttachmentRequest(
+                content_base64=base64.b64encode(b"x").decode(), name="f.txt", content_type="text/plain",
+            )
+            with pytest.raises(HTTPException) as ei:
+                await upload_story_attachment(STORY, body, session=s, auth=_auth(AGENT_OUT), org_id=ORG)
+            assert ei.value.status_code == 403
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_story_update_rejects_mcp_attachments_over_declared_limit(monkeypatch, tmp_path):
+    """S5 #2 와 동일 갭을 story 에서 처음부터 막는지 — 6개(>5) mcp-태그 첨부 참조 update_story 는 400."""
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.stories import (
+        UploadStoryAttachmentRequest,
+        upload_story_attachment,
+    )
+    from app.schemas.story import StoryUpdate
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        uploaded = []
+        async with Session() as s:
+            for i in range(6):
+                raw = b"a" * (1024 * 1024)
+                body = UploadStoryAttachmentRequest(
+                    content_base64=base64.b64encode(raw).decode(),
+                    name=f"f{i}.bin", content_type="application/octet-stream",
+                )
+                uploaded.append(await upload_story_attachment(
+                    STORY, body, session=s, auth=_auth(AGENT_IN), org_id=ORG,
+                ))
+
+        async with Session() as s:
+            from app.repositories.story import StoryRepository
+            from app.routers.stories import update_story
+            repo = StoryRepository(s, ORG)
+            update_body = StoryUpdate(attachments=uploaded)
+            with pytest.raises(HTTPException) as ei:
+                await update_story(
+                    STORY, update_body, BackgroundTasks(), repo=repo, db=s, auth=_auth(AGENT_IN),
+                )
+            assert ei.value.status_code == 400
+    finally:
+        await eng.dispose()
+
+
+# ── doc ────────────────────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_doc_upload_registers_asset_and_returns_correct_embed_snippet(monkeypatch, tmp_path):
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.docs import UploadDocAttachmentRequest, upload_doc_attachment
+    from app.services.storage import get_storage_provider
+    from app.services.asset_registry import DEFAULT_CONTAINER
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            raw = b"doc-attached-png-bytes"
+            body = UploadDocAttachmentRequest(
+                content_base64=base64.b64encode(raw).decode(), name="diagram.png", content_type="image/png",
+            )
+            resp = await upload_doc_attachment(DOC, body, session=s, auth=_auth(AGENT_IN), org_id=ORG)
+            assert resp.size == len(raw)
+            assert resp.asset_id is not None
+            assert resp.embed_snippet == (
+                f'<img data-asset-id="{resp.asset_id}" data-filename="diagram.png" '
+                f'data-size="{len(raw)}" data-mime-type="image/png" alt="diagram.png">'
+            )
+            # asset 실제로 등록됐는지 확인(asset_links 경유 — Asset 존재 자체로 충분)
+            row = (await s.execute(
+                text("SELECT id FROM assets WHERE id=:aid"), {"aid": str(resp.asset_id)},
+            )).first()
+            assert row is not None
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_doc_upload_non_image_returns_file_div_snippet(monkeypatch, tmp_path):
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.docs import UploadDocAttachmentRequest, upload_doc_attachment
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            raw = b"%PDF-1.4 fake pdf bytes"
+            body = UploadDocAttachmentRequest(
+                content_base64=base64.b64encode(raw).decode(), name="report.pdf", content_type="application/pdf",
+            )
+            resp = await upload_doc_attachment(DOC, body, session=s, auth=_auth(AGENT_IN), org_id=ORG)
+            assert resp.embed_snippet == (
+                f'<div data-type="fileAttachment" data-filename="report.pdf" data-size="{len(raw)}" '
+                f'data-mime-type="application/pdf" data-asset-id="{resp.asset_id}"></div>'
+            )
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_doc_upload_escapes_html_in_filename(monkeypatch, tmp_path):
+    """파일명이 doc content(HTML)에 그대로 꽂히므로 injection 방지 — attribute-context escape 필수."""
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.docs import UploadDocAttachmentRequest, upload_doc_attachment
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            body = UploadDocAttachmentRequest(
+                content_base64=base64.b64encode(b"x").decode(),
+                name='evil"><script>alert(1)</script>.png', content_type="image/png",
+            )
+            resp = await upload_doc_attachment(DOC, body, session=s, auth=_auth(AGENT_IN), org_id=ORG)
+            assert "<script>" not in resp.embed_snippet
+            assert "&lt;script&gt;" in resp.embed_snippet
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+async def test_doc_upload_no_project_access_403(monkeypatch, tmp_path):
+    monkeypatch.setenv("STORAGE_PROVIDER", "local")
+    monkeypatch.setenv("STORAGE_LOCAL_ROOT", str(tmp_path))
+    from app.routers.docs import UploadDocAttachmentRequest, upload_doc_attachment
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            body = UploadDocAttachmentRequest(
+                content_base64=base64.b64encode(b"x").decode(), name="f.txt", content_type="text/plain",
+            )
+            with pytest.raises(HTTPException) as ei:
+                await upload_doc_attachment(DOC, body, session=s, auth=_auth(AGENT_OUT), org_id=ORG)
+            assert ei.value.status_code == 403
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## Summary
Promotes 7 commits from `develop` to `main` per 선생님/PO GO:
- `f6ddbca8` fix(mcp): hosted HTTP tools/list per-request key scope filter (bec3a480, S1)
- `f52886a9` feat(mcp): chat attachments — inline base64 upload (bbfd24ba, S2)
- `7e4baaf2`/`8580cd32` feat(agents/onboarding): hosted MCP transport connect-step (emcpopt-s3, S3, BE+FE)
- `63e7dd3b` fix(mcp): E-MCP-OPT S5 hardening (34e69685)
- `dc270f03` feat(mcp): story/doc chat-pattern attachments (029b7825, S6)
- `4e531917` fix(epics): restore mobile scroll (unrelated bundled fix)

Confirmed scope via `git log --oneline origin/main..origin/develop` before merging — exactly these 7 commits, no other team's work mixed in.

## Migration policy (Option B, same as #1885)
`0146`/`0147` (`pricing_versions`, EE-only) are excluded from `main`, per the established policy. This time git's 3-way merge **auto-resolved the exclusion with zero conflicts** — `main` already deleted these two files in the prior promotion (#1885) and `develop` never touched them afterward, so "unchanged vs. deleted" resolves cleanly to deleted with no manual `git rm` needed (confirmed no conflict markers anywhere in the tree).

E-MCP-OPT introduced **zero new core migrations** — all six stories build on existing tables (`conversation_messages.attachments`, asset registry, `team_members`/`members`, `agent_project_profiles`) plus new Python modules/MCP tool wiring only. Confirmed via `git diff origin/main origin/develop -- backend/alembic/versions/` before merging: the only migration-file delta between the branches was `0146`/`0147` themselves.

**`main`'s alembic chain stays at a single head, `0155`, completely unchanged by this promotion** — verified locally:
- `alembic heads` → single `0155 (core) (head)`
- Fresh throwaway Postgres `alembic upgrade heads` → clean full `0001`→`0155` chain, `pricing_versions` table confirmed absent, stamped at `0155`.
- Prod migrate should be a no-op for this promotion.

## Test plan
- [x] Full backend suite on the merged tree: 2977 passed, 0 regressions (same 6 pre-existing environment-drift failures seen across every recent PR in this repo — unrelated to this promotion).
- [x] No conflict markers anywhere in the merged tree.
- [x] `main-preflight` CI job should confirm the same single-head, clean-migration state locally verified above.

Per established lane split: promotion PR/branch is mine, **admin-merge is PO's lane** — leaving this open for 오르테가군's crux + merge once `main-preflight` CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)