### PR TITLE
feat(recruit): role_templates catalog model + P0 4-role seed (E-RECRUIT S1, a47e7374)

### DIFF
--- a/backend/alembic/versions/0156_role_templates.py
+++ b/backend/alembic/versions/0156_role_templates.py
@@ -1,0 +1,185 @@
+"""E-RECRUIT S1 (story a47e7374): role_templates 카탈로그 테이블 + 4직무 builtin seed.
+
+Revision ID: 0156
+Revises: 0155
+Create Date: 2026-07-05
+
+제품-소유 글로벌 채용 카탈로그(org/project 무관 — pricing_versions 와 동형). 기존 얕은
+builtin persona 4종(agent_personas: general/product-owner/developer/qa, packages/db/supabase
+경로·죽은 인프라 — PO crux 2026-07-05로 Alembic 경로 확정)를 **대체하되 제거하지 않는다**
+(agent_personas 는 fallback 으로 그대로 둔다).
+
+인가는 FastAPI 애플리케이션 레이어(member-SSOT·project_auth)가 SSOT — 이 테이블엔 RLS/
+SECURITY DEFINER 트리거가 불필요하다(0002_disable_rls.py 의 동일 원칙).
+
+P0 seed = frontend/backend/qa/pm 4직무(선생님 GO 2026-07-05, 블루프린트 §8-1). 각
+role_behaviors 는 "자율 운영 지침"(날씬한 매뉴얼) — 직무 정체성 + get_workflow_guide 를
+스스로 pull 하는 습관 + 검증된 sprintable_* 도구명 + claim→lock→status→소통 자율 운영 룰.
+default_tool_groups 는 mcp_toolset.py 그룹 vocabulary 중 직무별 최소권한만(admin 그룹·
+destructive-only 그룹 제외).
+"""
+from __future__ import annotations
+
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0156"
+down_revision = "0155"
+branch_labels = None
+depends_on = None
+
+
+def _behaviors(role: str, mission: str, tools: str, extra_rule: str) -> str:
+    return f"""# {role} — 자율 운영 지침
+
+당신은 이 프로젝트의 {role}입니다. {mission}
+
+## 스스로 판단해 운영하는 법
+1. `sprintable_list_backlog` 또는 `sprintable_get_unassigned_stories`로 착수할 작업을 찾습니다.
+2. `sprintable_claim_story`로 claim하고 `sprintable_update_story_status`로 in-progress로 옮깁니다.
+3. 여러 에이전트가 같은 파일을 동시에 건드릴 수 있는 작업이면 `sprintable_lock_files`로 잠그고, 끝나면 `sprintable_unlock_files`로 풉니다.
+4. 진행 상황·질문·블로커는 침묵하지 말고 `sprintable_send_chat_message`로 관련자에게 즉시 공유합니다.
+5. 완료 기준(AC)을 만족하면 `sprintable_update_story_status`로 다음 단계(in-review 등)로 옮깁니다.
+{extra_rule}
+
+## 막히면 스스로 확인하세요
+플랫폼이 매턴 지시하지 않습니다 — 방식이 낯설거나 막히면 스스로 `sprintable_get_workflow_guide`를 불러 최신 운영법을 확인하세요(추측 금지).
+
+## 자주 쓰는 도구
+{tools}
+확실하지 않은 도구 이름을 지어내지 마세요 — 위 목록에 없으면 `sprintable_get_workflow_guide`로 먼저 확인하세요.
+
+## 런타임 노트
+이 지침은 런타임(claude-code 등)에 관계없이 동일합니다. MCP 연결/스코프는 채용 시점 번들이 처리합니다.
+"""
+
+
+_ROLE_BEHAVIORS = {
+    "frontend": _behaviors(
+        "Frontend 엔지니어",
+        "UI/UX 구현, 컴포넌트 작업, FE 버그 수정을 담당합니다.",
+        "`sprintable_list_stories`·`sprintable_add_story`·`sprintable_update_story`·"
+        "`sprintable_update_story_status`·`sprintable_send_chat_message`·`sprintable_get_doc`.",
+        "6. UI 변경이면 실제로 화면에서 동작을 확인한 뒤에만 완료로 표시하세요(타입체크만으로 충분하다고 주장하지 마세요).",
+    ),
+    "backend": _behaviors(
+        "Backend 엔지니어",
+        "API·데이터 모델·마이그레이션·서버 로직 구현을 담당합니다.",
+        "`sprintable_list_stories`·`sprintable_add_story`·`sprintable_update_story`·"
+        "`sprintable_update_story_status`·`sprintable_add_task`·`sprintable_send_chat_message`.",
+        "6. DB 스키마를 바꾸면 마이그레이션을 실제 DB에 적용해 검증하세요(마이그 파일 작성만으론 안 됩니다).",
+    ),
+    "qa": _behaviors(
+        "QA 엔지니어",
+        "완료 기준(AC) 검증, 회귀 확인, 품질 리뷰를 담당합니다.",
+        "`sprintable_list_stories`·`sprintable_get_task`·`sprintable_update_story_status`·"
+        "`sprintable_send_chat_message`·`sprintable_add_retro_item`·`sprintable_get_doc`.",
+        "6. 리뷰 결과는 반드시 근거(재현 절차·실측)와 함께 채팅으로 남기고, 통과/반려를 명확히 상태로 반영하세요.",
+    ),
+    "pm": _behaviors(
+        "PM/PO",
+        "스토리·에픽 기획, 스프린트 운영, 가설 관리, 팀 커뮤니케이션을 담당합니다.",
+        "`sprintable_add_story`·`sprintable_add_epic`·`sprintable_create_sprint`·`sprintable_assign_story_to_sprint`·"
+        "`sprintable_create_hypothesis`·`sprintable_get_project_overview`·`sprintable_send_chat_message`·"
+        "`sprintable_create_meeting`·`sprintable_get_standup`.",
+        "6. 우선순위·범위 결정은 근거(가설·지표)와 함께 문서/채팅으로 남겨 팀이 따라올 수 있게 하세요.",
+    ),
+}
+
+# (slug, name, category, description, default_tool_groups, default_workflow_recipe_slug, tier)
+# admin/destructive-only 그룹(rewards/webhooks/audit/agent_runs) 제외 — 직무별 최소권한.
+_SEED = [
+    (
+        "frontend", "Frontend Engineer", "frontend",
+        "UI/UX 구현과 프론트엔드 버그 수정을 자율적으로 운영하는 프론트엔드 엔지니어.",
+        ["stories", "tasks", "chat", "docs"],
+        "kanban-simple",
+    ),
+    (
+        "backend", "Backend Engineer", "backend",
+        "API·데이터 모델·서버 로직 구현을 자율적으로 운영하는 백엔드 엔지니어.",
+        ["stories", "tasks", "epics", "chat", "docs"],
+        "kanban-simple",
+    ),
+    (
+        "qa", "QA Engineer", "qa",
+        "완료 기준 검증과 품질 리뷰를 자율적으로 운영하는 QA 엔지니어.",
+        ["stories", "tasks", "chat", "docs", "retro"],
+        "scrum-3step",
+    ),
+    (
+        "pm", "Product Manager", "pm",
+        "스토리/에픽 기획과 스프린트·가설 운영을 자율적으로 운영하는 PM/PO.",
+        ["stories", "tasks", "epics", "sprints", "hypotheses", "meetings", "analytics", "retro", "standup", "chat", "docs"],
+        "scrum-3step",
+    ),
+]
+
+_role_templates = sa.table(
+    "role_templates",
+    sa.column("id", postgresql.UUID(as_uuid=True)),
+    sa.column("slug", sa.Text),
+    sa.column("name", sa.Text),
+    sa.column("category", sa.Text),
+    sa.column("description", sa.Text),
+    sa.column("role_behaviors", sa.Text),
+    sa.column("default_tool_groups", postgresql.ARRAY(sa.Text)),
+    sa.column("default_workflow_recipe_slug", sa.Text),
+    sa.column("runtime_overrides", postgresql.JSONB),
+    sa.column("is_builtin", sa.Boolean),
+    sa.column("is_published", sa.Boolean),
+    sa.column("tier", sa.Text),
+    sa.column("version", sa.Integer),
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "role_templates",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("slug", sa.Text(), nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("category", sa.Text(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("role_behaviors", sa.Text(), nullable=False),
+        sa.Column("default_tool_groups", postgresql.ARRAY(sa.Text()), nullable=False, server_default="{}"),
+        sa.Column("default_workflow_recipe_slug", sa.Text(), nullable=True),
+        sa.Column("runtime_overrides", postgresql.JSONB(), nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column("is_builtin", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("is_published", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("tier", sa.Text(), nullable=False, server_default="free"),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.UniqueConstraint("slug", name="uq_role_templates_slug"),
+        sa.CheckConstraint("tier = ANY (ARRAY['free'::text, 'team'::text, 'pro'::text])", name="role_templates_tier_check"),
+    )
+
+    op.bulk_insert(
+        _role_templates,
+        [
+            {
+                "id": uuid.uuid4(),
+                "slug": slug,
+                "name": name,
+                "category": category,
+                "description": description,
+                "role_behaviors": _ROLE_BEHAVIORS[slug],
+                "default_tool_groups": tool_groups,
+                "default_workflow_recipe_slug": recipe_slug,
+                "runtime_overrides": {},
+                "is_builtin": True,
+                "is_published": True,
+                "tier": "free",
+                "version": 1,
+            }
+            for slug, name, category, description, tool_groups, recipe_slug in _SEED
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("role_templates")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,7 +57,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, retros, rewards, role_templates, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -184,6 +184,7 @@ app.include_router(team_presence.router)
 app.include_router(org_members.router)
 app.include_router(standups.router)
 app.include_router(retros.router)
+app.include_router(role_templates.router)
 app.include_router(entities.router)
 app.include_router(event_notifications.router)
 app.include_router(notifications.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -48,8 +48,10 @@ from app.models.member import AgentProjectProfile, Member, MemberIdentityAlias
 from app.models.activity_event import ActivityEvent
 from app.models.asset import Asset, AssetFolder, AssetLink
 from app.models.release_note import ReleaseNote
+from app.models.role_template import RoleTemplate
 
 __all__ = [
+    "RoleTemplate",
     "ActivityEvent",
     "ReleaseNote",
     "Asset",

--- a/backend/app/models/role_template.py
+++ b/backend/app/models/role_template.py
@@ -1,0 +1,51 @@
+"""role_templates — 제품-소유 글로벌 채용 카탈로그 (E-RECRUIT S1, story a47e7374).
+
+org/project 에 속하지 않는 전역 카탈로그(pricing_versions 와 동형 — org_id/project_id 없음).
+`is_builtin` 행은 이 seed 마이그가 심는 제품 기본 카탈로그(frontend/backend/qa/pm) — 향후
+관리자가 커스텀 role_template 을 추가할 수 있는 여지(is_builtin=False)를 남겨둔다.
+
+`role_behaviors`(markdown) = 자율 운영 지침("갖춰주고 → 자율 운영" — 블루프린트 개정 방향):
+직무 정체성 + 스스로 판단해 claim→status→소통하는 운영법. 플랫폼이 매턴 지시하는 프롬프트가
+아니라 에이전트가 알아서 굴러가게 하는 매뉴얼 — `get_workflow_guide` 를 스스로 pull 하는 습관도
+포함한다(플랫폼 push 아님).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import ARRAY, Boolean, Integer, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+from app.models.base import TimestampMixin
+
+
+class RoleTemplate(Base, TimestampMixin):
+    __tablename__ = "role_templates"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    slug: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    category: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # 자율 운영 지침(markdown) — 큰 정적 프롬프트가 아니라 날씬한 매뉴얼(블루프린트 §3 개정).
+    role_behaviors: Mapped[str] = mapped_column(Text, nullable=False)
+    # mcp_toolset.py 의 그룹 vocabulary(stories/tasks/epics/chat/docs/sprints/...) — admin/
+    # destructive-only 그룹 제외(직무별 최소권한). API key scope 로 그대로 흘러간다(S2/S3 소비).
+    default_tool_groups: Mapped[list[str]] = mapped_column(
+        ARRAY(Text), nullable=False, default=list
+    )
+    # workflow_recipes.slug 참조(느슨 — 코드 전용 builtin recipe 도 있어 FK 강제 안 함).
+    default_workflow_recipe_slug: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # 런타임별 오버라이드(파일명·MCP 배선 노트 등 — 블루프린트 §4 런타임 어댑터). 미정 = {}.
+    runtime_overrides: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    # true = 이 seed 마이그(제품 기본 카탈로그)가 심은 행 — 향후 커스텀 role_template 여지 남김.
+    is_builtin: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    # 카탈로그 노출 게이트 — false 면 GET 목록/단건에서 숨김(작업 중/철회 대비, 삭제 아님).
+    is_published: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    # 과금 게이트 — 직접 갖추기(BYO)는 free 여도 항상 가능(블루프린트 §5), tier 는 "자동 채용"
+    # (미래 recruit 서비스) 게이팅용 메타데이터일 뿐 이 S1 에선 아무 것도 강제하지 않는다.
+    tier: Mapped[str] = mapped_column(Text, nullable=False, default="free")
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)

--- a/backend/app/routers/role_templates.py
+++ b/backend/app/routers/role_templates.py
@@ -1,0 +1,77 @@
+"""Role Templates API — E-RECRUIT S1 (story a47e7374): 채용 카탈로그 조회.
+
+GET /api/v2/role-templates        발행된 role_template 목록
+GET /api/v2/role-templates/{slug} 단건 조회(role_behaviors 포함)
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.models.role_template import RoleTemplate
+
+router = APIRouter(prefix="/api/v2/role-templates", tags=["role-templates"])
+
+
+class RoleTemplateSummary(BaseModel):
+    """목록 응답 — role_behaviors(md 본문) 제외(목록 페이로드 절감, chat/story 패턴과 동형)."""
+
+    id: uuid.UUID
+    slug: str
+    name: str
+    category: str
+    description: str | None
+    default_tool_groups: list[str]
+    default_workflow_recipe_slug: str | None
+    is_builtin: bool
+    tier: str
+    version: int
+
+    model_config = {"from_attributes": True}
+
+
+class RoleTemplateDetail(RoleTemplateSummary):
+    """단건 응답 — role_behaviors(자율 운영 지침 본문) + runtime_overrides 포함."""
+
+    role_behaviors: str
+    runtime_overrides: dict
+    created_at: datetime
+    updated_at: datetime
+
+
+@router.get("", response_model=list[RoleTemplateSummary])
+async def list_role_templates(
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth=Depends(get_current_user),
+) -> list[RoleTemplateSummary]:
+    """발행된(is_published) role_template 카탈로그 — org/project 무관 전역 조회."""
+    result = await session.execute(
+        select(RoleTemplate)
+        .where(RoleTemplate.is_published.is_(True))
+        .order_by(RoleTemplate.category, RoleTemplate.name)
+    )
+    return [RoleTemplateSummary.model_validate(rt) for rt in result.scalars().all()]
+
+
+@router.get("/{slug}", response_model=RoleTemplateDetail)
+async def get_role_template(
+    slug: str,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth=Depends(get_current_user),
+) -> RoleTemplateDetail:
+    """단건 조회 — 미발행(is_published=False) 행은 404(카탈로그와 동일 가시성 규칙)."""
+    role_template = (await session.execute(
+        select(RoleTemplate).where(RoleTemplate.slug == slug, RoleTemplate.is_published.is_(True))
+    )).scalar_one_or_none()
+    if role_template is None:
+        raise HTTPException(status_code=404, detail="Role template not found")
+    return RoleTemplateDetail.model_validate(role_template)

--- a/backend/tests/test_e_recruit_s1_role_templates.py
+++ b/backend/tests/test_e_recruit_s1_role_templates.py
@@ -1,0 +1,168 @@
+"""E-RECRUIT S1 (story a47e7374): role_templates 카탈로그 모델 + seed + GET 엔드포인트.
+
+Alembic 경로로 확정(PO crux 2026-07-05 — packages/db/supabase 경로는 죽은 인프라, 0002_disable_rls.py
+가 명시한 FastAPI-authz SSOT 원칙과 정합). RLS/SECURITY DEFINER 불요 — 인가는 애플리케이션 레이어.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+
+_MIGRATION = Path(__file__).parent.parent / "alembic" / "versions" / "0156_role_templates.py"
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("rev_0156", _MIGRATION)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_migration_0156_chains_off_0155():
+    mod = _load_migration()
+    assert mod.revision == "0156"
+    assert mod.down_revision == "0155"
+    assert callable(mod.upgrade) and callable(mod.downgrade)
+
+
+def test_seed_covers_exactly_p0_four_roles():
+    mod = _load_migration()
+    slugs = {row[0] for row in mod._SEED}
+    assert slugs == {"frontend", "backend", "qa", "pm"}
+
+
+def test_seed_tool_groups_exclude_admin_and_destructive_only_groups():
+    """AC: default_tool_groups 는 직무별 최소권한 — admin/rewards/webhooks/audit/agent_runs 제외."""
+    mod = _load_migration()
+    excluded = {"admin", "rewards", "webhooks", "audit", "agent_runs"}
+    for slug, _name, _category, _description, tool_groups, _recipe in mod._SEED:
+        assert not (set(tool_groups) & excluded), f"{slug} leaks an excluded group: {tool_groups}"
+        assert tool_groups, f"{slug} has empty default_tool_groups"
+
+
+def test_role_behaviors_reference_verified_tool_names_only():
+    """AC: '검증된 도구 이름만' — role_behaviors 안의 sprintable_* 언급이 실제 등록 도구명과 일치."""
+    import re
+
+    mod = _load_migration()
+    from sprintable_mcp.server import _TOOL_DEFS
+
+    real_names = {name for name, *_ in _TOOL_DEFS} | {"ping"}
+    for slug, behaviors in mod._ROLE_BEHAVIORS.items():
+        mentioned = set(re.findall(r"`(sprintable_[a-z_]+)`", behaviors))
+        assert mentioned, f"{slug} role_behaviors mentions no sprintable_* tools"
+        unknown = mentioned - real_names
+        assert not unknown, f"{slug} role_behaviors invents non-existent tool names: {unknown}"
+
+
+def test_model_field_shape():
+    from app.models.role_template import RoleTemplate
+
+    cols = {c.name for c in RoleTemplate.__table__.columns}
+    assert cols == {
+        "id", "slug", "name", "category", "description", "role_behaviors",
+        "default_tool_groups", "default_workflow_recipe_slug", "runtime_overrides",
+        "is_builtin", "is_published", "tier", "version", "created_at", "updated_at",
+    }
+
+
+# ─── 실 Postgres — 실 마이그 적용 + GET 엔드포인트 ────────────────────────────
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _engine():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    eng = create_async_engine(_ASYNC)
+    return eng, async_sessionmaker(eng, expire_on_commit=False)
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+async def test_list_role_templates_returns_seeded_four_roles_realdb():
+    from app.routers.role_templates import list_role_templates
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            out = await list_role_templates(session=s, org_id=uuid.uuid4(), _auth=None)
+        slugs = {rt.slug for rt in out}
+        assert {"frontend", "backend", "qa", "pm"} <= slugs
+        # 목록 응답엔 role_behaviors(md 본문) 없음(페이로드 절감)
+        assert not hasattr(out[0], "role_behaviors")
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+async def test_get_role_template_by_slug_includes_behaviors_realdb():
+    from app.routers.role_templates import get_role_template
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            out = await get_role_template("backend", session=s, org_id=uuid.uuid4(), _auth=None)
+        assert out.slug == "backend"
+        assert "sprintable_" in out.role_behaviors
+        assert out.default_tool_groups == ["stories", "tasks", "epics", "chat", "docs"]
+        assert out.is_builtin is True
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+async def test_get_role_template_unknown_slug_404_realdb():
+    from app.routers.role_templates import get_role_template
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            with pytest.raises(HTTPException) as ei:
+                await get_role_template("nonexistent-role", session=s, org_id=uuid.uuid4(), _auth=None)
+            assert ei.value.status_code == 404
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+async def test_unpublished_role_template_hidden_from_list_and_get_realdb():
+    """is_published=False 는 목록/단건 둘 다 숨김(삭제 아닌 게이트)."""
+    from app.routers.role_templates import get_role_template, list_role_templates
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await s.execute(text(
+                "INSERT INTO role_templates (slug, name, category, role_behaviors, "
+                "default_tool_groups, is_published) VALUES "
+                "('draft-role', 'Draft', 'test', 'wip', ARRAY['stories'], false)"
+            ))
+            await s.commit()
+        async with Session() as s:
+            listed = await list_role_templates(session=s, org_id=uuid.uuid4(), _auth=None)
+            assert "draft-role" not in {rt.slug for rt in listed}
+            with pytest.raises(HTTPException) as ei:
+                await get_role_template("draft-role", session=s, org_id=uuid.uuid4(), _auth=None)
+            assert ei.value.status_code == 404
+    finally:
+        async with Session() as s:
+            await s.execute(text("DELETE FROM role_templates WHERE slug = 'draft-role'"))
+            await s.commit()
+        await eng.dispose()


### PR DESCRIPTION
## Summary
Foundation story for the E-RECRUIT epic (agent hiring/activation) — new product-owned global catalog of role templates (frontend/backend/qa/pm), each carrying an "autonomous operation guide" (`role_behaviors` markdown), a minimum-privilege default tool group set, and a default workflow recipe.

## Course-correction before implementing (PO crux-approved)
The blueprint named `packages/db/supabase/migrations/20260406210000_agent_persona_builtins.sql` (a SECURITY DEFINER trigger-based seeding mechanism in a separate Supabase-CLI-managed migration path) as "the pattern to follow" for this story. That path is dead infrastructure:
- Its own CI workflow (`migrate.yml`) ran exactly 4 times, all between 2026-04-27 and 04-29, **failed every single time in under 13 seconds**, and hasn't fired since.
- The backend's own Alembic migration `0002` (dated 2026-04-30, right after that path went quiet) explicitly documents why: *"PostgREST RLS dependency removed — the FastAPI layer handles org_id/project_id scoping and owner/role verification, so DB-level RLS is unnecessary."*
- Confirmed zero live Supabase dependency anywhere in `backend/app`.

PO crux-approved building this as a standard Alembic migration instead (`0156`, chained off the live `0155` head) with a plain SQL seed — no RLS, no SECURITY DEFINER trigger machinery needed, since authorization here is entirely FastAPI-application-level already.

## Implementation
- `role_templates` is unscoped (no `org_id`/`project_id`) — a shared catalog like `pricing_versions`, not a per-tenant table.
- Each seeded role's `default_tool_groups` draws only from `mcp_toolset.py`'s real group vocabulary, explicitly excluding `admin`/`rewards`/`webhooks`/`audit`/`agent_runs` (least privilege per role).
- Every `sprintable_*` tool name mentioned in a role's `role_behaviors` text is checked against the real registered MCP tool catalog (`sprintable_mcp.server._TOOL_DEFS`) — the migration cannot ship with an invented tool name.
- The existing 4 shallow builtin `agent_personas` (general/product-owner/developer/qa, seeded per-agent via that same dead Supabase trigger mechanism) are left untouched — this new catalog replaces their purpose going forward without removing them (fallback preserved, matching the "replace but do not remove" AC).
- `GET /api/v2/role-templates` and `/api/v2/role-templates/{slug}` — simple FastAPI-authenticated read endpoints (`is_published` gates visibility, unpublished rows 404 rather than being deleted).

## Test plan
- [x] Migration chains correctly off `0155` (verified via `alembic heads`), fresh-DB `upgrade heads` clean end-to-end, seed data confirmed landed correctly for all 4 roles (`psql` direct query).
- [x] 9 new tests: migration chain assertion, seed covers exactly the 4 P0 roles, tool-group exclusion set enforced, tool-name verification against the real MCP registry, model field shape, and 4 real-Postgres tests (list returns the seeded roles, get-by-slug includes behaviors, unknown slug → 404, unpublished row hidden from both list and get).
- [x] Negative-tested the tool-name-verification guard: injected a fabricated tool name into the seed content, confirmed the test genuinely catches it, reverted.
- [x] Full backend suite: 2983 passed, 0 regressions (same 6 pre-existing unrelated failures seen across every recent PR in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)