### PR TITLE
feat(recruit): deterministic compose_prompt for autonomous operation guides (E-RECRUIT S2, 58c37f17)

### DIFF
--- a/backend/app/services/agent_recruiter.py
+++ b/backend/app/services/agent_recruiter.py
@@ -1,0 +1,127 @@
+"""E-RECRUIT S2 (story 58c37f17): 자율 운영 지침 합성 — deterministic composer.
+
+블루프린트 §3 개정 방향(2026-07-04): "갖춰주고 → 자율 운영"(agentic). `compose_prompt`는
+**결정론적 template-composition**만 한다(LLM 합성 아님) — role_template.role_behaviors·
+workflow recipe·검증된 ALL_TOOL_NAMES·고정 애자일 룰·runtime 노트를 그대로 이어붙일 뿐, 새
+텍스트를 생성/추론하지 않는다. 툴 이름을 지어낼 여지 자체가 없다(도구 치트시트는 실 레지스트리
+에서 파생).
+
+G4(설계 갭 반영): 이 함수는 **순수 합성만** 반환한다 — 네트워크/DB 호출 0, 부수효과 0.
+런타임 배달(connection-artifact 번들 삽입 등)은 이 함수의 책임이 아니다(S5 공용 레이어).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from app.routers.workflow_recipes import _generate_guide
+from app.services.mcp_toolset import ALL_GROUPS, ALL_TOOL_NAMES, _ALWAYS_ALLOWED, tool_group
+
+_AGILE_OPERATING_RULES = """## 애자일 자율 운영 룰
+
+- **claim**: 작업을 시작하기 전에 반드시 claim 하세요. 이미 누군가 진행 중인 작업을 가로채지 마세요.
+- **lock**: 같은 파일을 동시에 여러 에이전트가 건드릴 수 있는 작업이면 시작 전 잠그고, 끝나면 즉시 풉니다.
+- **status**: 작업 시작·완료·블로커 발생 시점마다 상태를 갱신하세요. 상태가 실제 진행과 어긋나면 팀 전체가 헷갈립니다.
+- **소통**: 막히거나 방향을 바꿨거나 완료했으면 침묵하지 말고 즉시 채팅으로 알리세요. 아무도 몰래 혼자 진행하지 마세요.
+- **정직**: 실제로 확인/실행하지 않은 것을 완료로 보고하지 마세요. 근거(실행 결과·재현 절차)와 함께 보고하세요.
+"""
+
+
+def validate_tool_groups(groups: list[str]) -> None:
+    """E-RECRUIT S2(QA G3 관련 하드닝): role_template.default_tool_groups 값이 실제 존재하는
+    그룹 vocabulary(mcp_toolset.ALL_GROUPS) 안에 있는지 검증 — 소비 지점(compose_prompt) fail-closed.
+
+    ⚠️ `resolve_policy`(mcp_toolset.py) 자체의 fail-open(미인식 그룹→전체 허용 폴백) 은 이 스토리의
+    스코프가 아니다(S3 하드닝 대상·PO 확정) — 여긴 **synthesis 가 잘못된 그룹명으로 치트시트를
+    조용히 비우거나 엉뚱하게 구성하는 것만** 막는다.
+    """
+    unknown = [g for g in groups if g not in ALL_GROUPS]
+    if unknown:
+        raise ValueError(
+            f"role_template.default_tool_groups contains unknown group(s): {unknown} "
+            f"(valid: {sorted(ALL_GROUPS)})"
+        )
+
+
+def _tool_cheat_sheet(tool_groups: list[str]) -> str:
+    """[C] tool 치트시트 — 그룹→**실 등록 도구명**(ALL_TOOL_NAMES·tool_group() SSOT 파생. G3).
+
+    core(_ALWAYS_ALLOWED) 도구는 role 무관 항상 포함 — 그 어떤 scope 로도 항상 허용되는 도구라
+    치트시트에서 빠지면 존재를 모른 채 있는 것처럼 재발명할 위험이 있다.
+    """
+    validate_tool_groups(tool_groups)
+    wanted = set(tool_groups)
+    always_on = sorted(t for t in ALL_TOOL_NAMES if t in _ALWAYS_ALLOWED)
+    by_group: dict[str, list[str]] = {}
+    for name in ALL_TOOL_NAMES:
+        if name in _ALWAYS_ALLOWED:
+            continue
+        group = tool_group(name)
+        if group in wanted:
+            by_group.setdefault(group, []).append(name)
+
+    lines = ["## 사용 가능 도구 (치트시트)", "", "**항상 사용 가능**:"]
+    lines += [f"- `{t}`" for t in always_on]
+    for group in sorted(by_group):
+        lines.append(f"\n**{group}**:")
+        lines += [f"- `{t}`" for t in sorted(by_group[group])]
+    lines.append(
+        "\n위 목록에 없는 도구 이름을 지어내지 마세요 — 확실하지 않으면 "
+        "`sprintable_get_workflow_guide`로 먼저 확인하세요."
+    )
+    return "\n".join(lines)
+
+
+def _runtime_notes(runtime: str, runtime_overrides: dict[str, Any] | None) -> str:
+    """[E] 런타임 노트 — runtime_overrides(JSONB)에 해당 runtime 항목이 있으면 이어붙인다.
+
+    E-RECRUIT S1 seed 는 runtime_overrides={} 라 오늘은 기본 문구만 나간다(메커니즘은 향후
+    런타임별 파일명/MCP 배선 노트(블루프린트 §4·S7)가 채워질 자리를 그대로 지원).
+    """
+    lines = [
+        "## 런타임 노트",
+        "",
+        f"이 프로젝트에서 당신의 실행 런타임은 `{runtime}` 입니다.",
+        "MCP 연결/스코프는 채용 시 제공된 번들이 이미 구성했습니다 — 별도 설정이 필요 없습니다.",
+    ]
+    override = (runtime_overrides or {}).get(runtime)
+    if override:
+        lines += ["", f"**{runtime} 전용 노트**:", str(override)]
+    return "\n".join(lines)
+
+
+def compose_prompt(
+    role_template: Any,
+    recipe: dict[str, Any] | None,
+    runtime: str,
+) -> str:
+    """자율 운영 지침 합성 — 순수 함수(네트워크/DB 호출 0·부수효과 0. G4).
+
+    Args:
+        role_template: role_templates 행(또는 동형 속성을 가진 객체) — role_behaviors·
+            default_tool_groups·runtime_overrides 를 속성으로 읽는다(ORM 인스턴스·SimpleNamespace
+            등 duck-typing — dict 도 `.get`이 아니라 속성 접근이 필요하면 호출부가 변환).
+        recipe: workflow_recipes 형태의 dict({name, description, steps, ...}) 또는 None(추천
+            워크플로우 없음 — 섹션 [B] 워크플로우 가이드 부분만 생략, 나머지 섹션은 정상 생성).
+        runtime: 실행 런타임 식별자(예: "claude-code").
+
+    Returns:
+        5섹션([A]~[E])을 이어붙인 markdown 문자열(diffable — 순수 문자열 결합, LLM 비호출).
+    """
+    sections = [
+        f"# {role_template.name} — 채용 지침\n\n{role_template.role_behaviors}",
+    ]
+
+    guide_section = ["## Sprintable 사용법"]
+    if recipe is not None:
+        guide_section.append(_generate_guide(recipe))
+    guide_section.append(
+        "\n이 가이드가 오래됐다고 느껴지거나 막히면, 플랫폼이 알려주길 기다리지 말고 "
+        "스스로 `sprintable_get_workflow_guide`를 불러 최신 운영법을 확인하세요."
+    )
+    sections.append("\n".join(guide_section))
+
+    sections.append(_tool_cheat_sheet(list(role_template.default_tool_groups)))
+    sections.append(_AGILE_OPERATING_RULES)
+    sections.append(_runtime_notes(runtime, getattr(role_template, "runtime_overrides", None)))
+
+    return "\n\n".join(sections)

--- a/backend/tests/test_e_recruit_s2_compose_prompt.py
+++ b/backend/tests/test_e_recruit_s2_compose_prompt.py
@@ -1,0 +1,169 @@
+"""E-RECRUIT S2 (story 58c37f17): `agent_recruiter.compose_prompt` — deterministic composer.
+
+G3(단일 소스): 섹션[C] 도구 치트시트는 role_template.default_tool_groups → mcp_toolset.tool_group()
+SSOT로만 파생(하드코딩 별도 목록 금지). G4(배달 분리): compose_prompt는 순수 합성만(네트워크/DB
+호출 0) — 이 테스트들은 전부 인자만으로 호출하고 어떤 I/O 도 mock 하지 않는다(진짜 순수함 증명).
+QA MINOR 하드닝: role_template.default_tool_groups 값이 실제 그룹 vocabulary 밖이면 fail-closed
+(resolve_policy 자체의 fail-open 은 S3 스코프 — 여긴 손대지 않는다).
+"""
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.agent_recruiter import compose_prompt, validate_tool_groups
+from app.services.mcp_toolset import ALL_GROUPS, ALL_TOOL_NAMES
+
+
+def _role(**overrides) -> SimpleNamespace:
+    defaults = dict(
+        name="Backend Engineer",
+        role_behaviors="당신은 백엔드 엔지니어입니다.",
+        default_tool_groups=["stories", "tasks", "chat", "docs"],
+        runtime_overrides={},
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+_RECIPE = {
+    "name": "칸반 심플",
+    "description": "할 일 → 진행 중 → 완료",
+    "steps": [{"role": "Dev", "label": "진행", "pattern": "in_progress", "action": "작업 수행"}],
+}
+
+
+# ── validate_tool_groups ───────────────────────────────────────────────────────
+def test_validate_tool_groups_accepts_real_groups():
+    validate_tool_groups(["stories", "tasks", "chat"])  # 예외 없이 통과
+
+
+def test_validate_tool_groups_rejects_unknown_group():
+    with pytest.raises(ValueError, match="unknown group"):
+        validate_tool_groups(["stories", "not-a-real-group"])
+
+
+def test_validate_tool_groups_rejects_admin_typo_variants():
+    """admin 자체도 ALL_GROUPS 밖(의도적 제외) — role_template 이 admin 을 담고 있으면 거부."""
+    with pytest.raises(ValueError):
+        validate_tool_groups(["admin"])
+
+
+# ── compose_prompt — 순수성 + 결정론 ──────────────────────────────────────────
+def test_compose_prompt_is_deterministic_same_input_same_output():
+    """diffable — 동일 입력 두 번 호출 결과가 문자 그대로 동일(LLM 비호출 증명)."""
+    role = _role()
+    out1 = compose_prompt(role, _RECIPE, "claude-code")
+    out2 = compose_prompt(role, _RECIPE, "claude-code")
+    assert out1 == out2
+
+
+def test_compose_prompt_contains_five_sections():
+    role = _role()
+    out = compose_prompt(role, _RECIPE, "claude-code")
+    assert "채용 지침" in out  # [A]
+    assert "Sprintable 사용법" in out  # [B]
+    assert "사용 가능 도구 (치트시트)" in out  # [C]
+    assert "애자일 자율 운영 룰" in out  # [D]
+    assert "런타임 노트" in out  # [E]
+
+
+def test_compose_prompt_section_a_includes_role_behaviors_verbatim():
+    role = _role(role_behaviors="스스로 판단해 claim하고 소통하세요.")
+    out = compose_prompt(role, _RECIPE, "claude-code")
+    assert "스스로 판단해 claim하고 소통하세요." in out
+
+
+def test_compose_prompt_handles_missing_recipe_gracefully():
+    """recipe=None — 워크플로우 가이드 부분만 생략, 나머지 섹션은 정상 생성(크래시 없음)."""
+    role = _role()
+    out = compose_prompt(role, None, "claude-code")
+    assert "사용 가능 도구 (치트시트)" in out
+    assert "get_workflow_guide" in out  # 자율-pull 안내는 recipe 유무와 무관하게 항상 존재
+
+
+def test_compose_prompt_includes_runtime_identifier():
+    role = _role()
+    out = compose_prompt(role, _RECIPE, "cursor")
+    assert "`cursor`" in out
+
+
+def test_compose_prompt_includes_runtime_override_when_present():
+    role = _role(runtime_overrides={"claude-code": "CLAUDE.md 에 이 지침을 저장하세요."})
+    out = compose_prompt(role, _RECIPE, "claude-code")
+    assert "CLAUDE.md 에 이 지침을 저장하세요." in out
+
+
+# ── G3: 도구 치트시트 = 단일 소스(ALL_TOOL_NAMES) 파생, 환각 0 ─────────────────
+def test_compose_prompt_tool_cheat_sheet_only_references_real_tool_names():
+    role = _role(default_tool_groups=[
+        "stories", "tasks", "epics", "sprints", "hypotheses", "chat", "docs",
+        "analytics", "retro", "standup", "meetings", "notifications", "webhooks",
+        "rewards", "audit", "agent_runs",
+    ])
+    out = compose_prompt(role, _RECIPE, "claude-code")
+    mentioned = set(re.findall(r"`(sprintable_[a-z_]+)`", out))
+    assert mentioned  # 뭔가는 언급됨
+    assert mentioned <= set(ALL_TOOL_NAMES), f"invented tool names: {mentioned - set(ALL_TOOL_NAMES)}"
+
+
+def test_compose_prompt_tool_cheat_sheet_excludes_ungranted_groups():
+    """frontend(stories/tasks/chat/docs)만 준 role 은 epics/sprints 전용 도구를 언급하면 안 됨."""
+    role = _role(default_tool_groups=["stories", "tasks", "chat", "docs"])
+    out = compose_prompt(role, _RECIPE, "claude-code")
+    assert "sprintable_add_epic" not in out
+    assert "sprintable_create_sprint" not in out
+    assert "sprintable_add_story" in out  # stories 그룹은 포함
+
+
+def test_compose_prompt_always_allowed_tools_present_regardless_of_groups():
+    """core(_ALWAYS_ALLOWED) 도구는 role 의 default_tool_groups 와 무관하게 항상 치트시트에 존재."""
+    role = _role(default_tool_groups=["stories"])
+    out = compose_prompt(role, _RECIPE, "claude-code")
+    assert "sprintable_get_workflow_guide" in out
+    assert "sprintable_ping" in out
+
+
+def test_compose_prompt_raises_on_unknown_default_tool_group():
+    role = _role(default_tool_groups=["stories", "typo-group"])
+    with pytest.raises(ValueError, match="unknown group"):
+        compose_prompt(role, _RECIPE, "claude-code")
+
+
+# ── 실 S1 seed 데이터 전수 검증(회귀 가드 — "seed 지점" 검증) ─────────────────
+_MIGRATION = Path(__file__).parent.parent / "alembic" / "versions" / "0156_role_templates.py"
+
+
+def _load_s1_migration():
+    spec = importlib.util.spec_from_file_location("rev_0156_s2check", _MIGRATION)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_all_s1_seeded_roles_default_tool_groups_are_valid_vocabulary():
+    """S1 이 실제로 심은 4직무 seed 의 default_tool_groups 전부가 ALL_GROUPS 안에 있는지 —
+    S1 자체 테스트는 exclusion(denylist)만 확인했었다·이건 전체 vocabulary 소속을 확인(더 엄격)."""
+    mod = _load_s1_migration()
+    for slug, _name, _category, _description, tool_groups, _recipe in mod._SEED:
+        validate_tool_groups(tool_groups)  # 예외 없어야 함
+
+
+def test_all_s1_seeded_roles_compose_without_error():
+    """4직무 seed 전부가 실제로 compose_prompt 를 통과해 유효한 결과를 내는지(통합 스모크)."""
+    mod = _load_s1_migration()
+    for slug, name, _category, _description, tool_groups, _recipe_slug in mod._SEED:
+        role = _role(
+            name=name,
+            role_behaviors=mod._ROLE_BEHAVIORS[slug],
+            default_tool_groups=tool_groups,
+        )
+        out = compose_prompt(role, None, "claude-code")
+        mentioned = set(re.findall(r"`(sprintable_[a-z_]+)`", out))
+        assert mentioned <= set(ALL_TOOL_NAMES), (
+            f"{slug}: invented tool names {mentioned - set(ALL_TOOL_NAMES)}"
+        )


### PR DESCRIPTION
## Summary
`agent_recruiter.compose_prompt(role_template, recipe, runtime)` — pure, deterministic template composition (no LLM, no I/O) producing a 5-section markdown guide:

- **[A] role behaviors** — `role_template.role_behaviors` verbatim
- **[B] Sprintable usage** — reuses `workflow_recipes._generate_guide`, plus an explicit instruction to self-pull `sprintable_get_workflow_guide` when the static guide feels stale (agent-initiated refresh, not platform push — matches the blueprint's "equip, don't drive" direction)
- **[C] tool cheat sheet** — derived solely from `mcp_toolset.tool_group()` + `ALL_TOOL_NAMES` against `role_template.default_tool_groups` (single source, per **G3**) — structurally cannot list a tool name that isn't actually registered
- **[D]** fixed agile operating rules (claim → lock → status → communicate)
- **[E] runtime notes** — runtime identifier + any `runtime_overrides` entry

Per **G4**, `compose_prompt` makes zero network/DB calls — the caller resolves `role_template` and `recipe` beforehand; runtime delivery (bundling into a connection-artifact) is a separate concern for S5, not this function's job.

## QA MINOR hardening (from S1 review)
Added `validate_tool_groups()` addressing a gap 까심/codex flagged during S1's review: `resolve_policy` (`mcp_toolset.py`) fails open on unrecognized group names (falls back to "allow everything" rather than rejecting), which is out of scope here per PO's explicit deferral to S3 hardening — but `compose_prompt` itself now fails closed if a role_template's `default_tool_groups` contains anything outside the real group vocabulary, so a bad catalog entry can't silently produce an empty or wrong tool cheat sheet.

## Test plan
- [x] 15 new tests: `validate_tool_groups` accept/reject (including the `admin` group itself, deliberately excluded), determinism (identical output across repeated calls with the same inputs), all 5 sections present, section [A] carries `role_behaviors` verbatim, graceful handling of `recipe=None`, runtime identifier + override inclusion, tool cheat sheet only ever references real `ALL_TOOL_NAMES` entries, ungranted groups' tools correctly excluded, always-allowed core tools present regardless of granted groups, and a hard failure on an unknown `default_tool_groups` value.
- [x] Cross-checked against the **actual S1-seeded data** (loaded directly from the merged `0156_role_templates.py` migration) — all 4 real seeded roles compose without error and never reference an invented tool name; their `default_tool_groups` values are validated against the full group vocabulary (stronger than S1's own exclusion-only check).
- [x] Negative-tested the hallucination/validation guard: disabled `validate_tool_groups`'s check, confirmed exactly the 3 targeted tests fail, restored.
- [x] Full backend suite: 2998 passed, 0 regressions (same 6 pre-existing unrelated failures seen across every recent PR in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)