### PR TITLE
fix(infra): migrate job drift hardening + #1886 EE-stamp self-heal (E-RECRUIT S13, dbda0baf)

### DIFF
--- a/backend/scripts/migrate.sh
+++ b/backend/scripts/migrate.sh
@@ -14,5 +14,42 @@ fi
 # 별도 head라 이미지에 그 파일이 없는 환경(main/prod)에선 head가 1개, 있는 환경(develop/ee
 # 빌드)에선 2개다 — `heads`(복수)는 두 경우 모두 안전(단일-head 환경에서도 그대로 동작).
 cd /app
+
+# story dbda0baf(E-RECRUIT S13) — #1886 EE-stamp 정합 게이트: bda4beac가 0146/0147을 별도
+# head(ee_pricing)로 분기하기 전, 이미 그 구 리니어 체인(0145→0146→0147→0148→...)을 물리
+# 실행한 DB는 alembic_version에 ee_pricing head(0147)가 기록돼 있지 않다 — `upgrade heads`가
+# 0147을 미적용으로 오인해 0146/0147 DDL을 재실행하려다 DuplicateTable로 죽는다(2026-07-05
+# dev 재현). uq_org_subscriptions_org_id(0148이 만드는 제약)는 이 구 체인을 이미 탔다는 정확한
+# 물리 신호(#1886 dev_ee_stamp_precheck.sh 에서 확립된 기준 — pricing_versions 테이블 존재만
+# 보는 것보다 정밀). 매 실행 시 자동 검사해 필요하면 self-heal stamp 하므로 더 이상 수동
+# override 스크립트를 기억해뒀다 돌릴 필요가 없다(이 파일이 canonical 진입점이라 드리프트 재발 불가).
+echo "[migrate] EE-stamp precheck: checking uq_org_subscriptions_org_id..."
+EE_STAMP_NEEDED=$(python3 <<'PYEOF'
+import os
+from sqlalchemy import create_engine, text
+
+engine = create_engine(os.environ["ALEMBIC_DATABASE_URL"])
+with engine.connect() as conn:
+    constraint_exists = conn.execute(
+        text("SELECT 1 FROM pg_constraint WHERE conname = 'uq_org_subscriptions_org_id'")
+    ).scalar()
+    if not constraint_exists:
+        print(0)
+    else:
+        try:
+            heads = {row[0] for row in conn.execute(text("SELECT version_num FROM alembic_version"))}
+        except Exception:
+            heads = set()
+        print(1 if "0147" not in heads else 0)
+PYEOF
+)
+
+if [ "${EE_STAMP_NEEDED}" = "1" ]; then
+  echo "[migrate] precheck: old-chain constraint present + 0147 not stamped — stamping 0147 (add, preserves other heads)."
+  alembic stamp 0147
+else
+  echo "[migrate] precheck: no action needed."
+fi
+
 echo "Running: alembic upgrade heads"
 exec alembic upgrade heads

--- a/backend/tests/test_cloudbuild_migrate_wiring.py
+++ b/backend/tests/test_cloudbuild_migrate_wiring.py
@@ -1,0 +1,69 @@
+"""story dbda0baf(E-RECRUIT S13): cloudbuild.yaml — migrate 잡이 배포 파이프라인에
+SHA-pinned 이미지로 자동 배선돼 있고, 실패 시 backend 배포가 abort되는지 구조 검증.
+
+근본원인(2026-07-05 dev 인시던트): migrate 잡이 파이프라인과 완전히 분리돼 있어
+COMMIT_SHA 없이 수동 provision하면 mutable `latest-${ENV}` 태그에 고정되고,
+잡 자체가 인라인 `head`(단수)로 드리프트해도 아무도 감지 못했다.
+"""
+from __future__ import annotations
+
+import os
+
+import yaml
+
+_CLOUDBUILD = os.path.join(os.path.dirname(__file__), "..", "..", "cloudbuild.yaml")
+
+
+def _load():
+    with open(_CLOUDBUILD) as f:
+        return yaml.safe_load(f)
+
+
+def _steps_by_id(doc):
+    return {s["id"]: s for s in doc["steps"]}
+
+
+def test_cloudbuild_yaml_is_valid():
+    doc = _load()
+    assert "steps" in doc
+
+
+def test_migrate_job_step_uses_provision_script_not_inline_gcloud():
+    """canonical provision_migrate_job.sh를 통해 잡을 갱신 — 인라인 ad-hoc gcloud 커맨드로
+    드리프트가 재발할 수 없게 한다."""
+    steps = _steps_by_id(_load())
+    assert "update-migrate-job" in steps
+    src = " ".join(steps["update-migrate-job"]["args"])
+    assert "provision_migrate_job.sh" in src
+
+
+def test_migrate_job_step_pins_commit_sha_not_floating_tag():
+    """COMMIT_SHA를 명시 주입 — provision_migrate_job.sh가 latest-${ENV}로 폴백하지 않게."""
+    steps = _steps_by_id(_load())
+    src = " ".join(steps["update-migrate-job"]["args"])
+    assert "COMMIT_SHA=" in src
+    assert "${COMMIT_SHA}" in src
+
+
+def test_migrate_job_executes_and_waits():
+    steps = _steps_by_id(_load())
+    assert "run-migrate-job" in steps
+    args = steps["run-migrate-job"]["args"]
+    assert "execute" in args
+    assert "--wait" in args
+    assert steps["run-migrate-job"]["waitFor"] == ["update-migrate-job"]
+
+
+def test_deploy_backend_blocked_by_migrate_job():
+    """핵심 AC: migrate 실패 시 배포 자동 abort — deploy-backend가 run-migrate-job에
+    waitFor로 의존해야 마이그 실패가 배포를 막는다(과거엔 push-backend에만 의존해
+    마이그와 무관하게 배포됐다)."""
+    steps = _steps_by_id(_load())
+    assert steps["deploy-backend"]["waitFor"] == ["run-migrate-job"]
+
+
+def test_migrate_pipeline_precedes_deploy_in_step_order():
+    doc = _load()
+    ids = [s["id"] for s in doc["steps"]]
+    assert ids.index("update-migrate-job") < ids.index("run-migrate-job")
+    assert ids.index("run-migrate-job") < ids.index("deploy-backend")

--- a/backend/tests/test_migrate_env.py
+++ b/backend/tests/test_migrate_env.py
@@ -91,3 +91,20 @@ def test_migrate_sh_exists_and_has_alembic_check():
     # story bda4beac: ee_pricing(0146/0147)이 core 체인과 분기된 별도 head라 `heads`(복수)로
     # 전환 — dual-head(develop/ee)·single-head(main) 양쪽에서 안전.
     assert "alembic upgrade heads" in content
+
+
+# ── story dbda0baf(E-RECRUIT S13): #1886 EE-stamp 정합 게이트 ─────────────────
+
+def test_migrate_sh_has_ee_stamp_precheck():
+    """migrate.sh가 canonical 진입점 자체에 EE-stamp self-heal 게이트를 포함하는지 —
+    더 이상 별도 수동 override 스크립트(#1886 dev_ee_stamp_precheck.sh)를 기억해뒀다
+    돌릴 필요가 없어야 한다(모든 migrate 실행에서 자동)."""
+    import os
+    path = os.path.join(os.path.dirname(__file__), "..", "scripts", "migrate.sh")
+    content = open(path).read()
+    assert "uq_org_subscriptions_org_id" in content
+    assert "alembic stamp 0147" in content
+    # precheck는 upgrade heads보다 반드시 먼저 실행돼야 한다(순서 자체가 AC).
+    precheck_idx = content.index("uq_org_subscriptions_org_id")
+    upgrade_idx = content.index("alembic upgrade heads")
+    assert precheck_idx < upgrade_idx, "precheck가 upgrade heads보다 먼저 와야 함"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -80,6 +80,39 @@ steps:
       - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend
     waitFor: [build-backend]
 
+  # ─── Migrate DB (story dbda0baf, E-RECRUIT S13) ────────────────────────────
+  # 근본원인(2026-07-05 dev 인시던트): migrate 잡이 파이프라인과 완전히 분리돼 있어 ⓐ
+  # provision_migrate_job.sh 를 COMMIT_SHA 없이 수동 실행하면 마지막 `latest-${ENV}` 태그에
+  # 조용히 고정되고(mutable·드리프트) ⓑ 잡 자체가 인라인 `head`(단수)로 수동 override 돼
+  # migrate.sh(정본 `heads` 복수)를 안 타는 상태였다. 매 배포마다 잡을 SHA-pinned 이미지 +
+  # canonical command(`/app/scripts/migrate.sh`)로 강제 재배포해 드리프트가 다시 쌓일 수 없게 한다.
+  - id: update-migrate-job
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -euo pipefail
+        GCP_PROJECT="${PROJECT_ID}" GCP_REGION="${_AR_REGION}" AR_REPO="${_AR_REPO}" COMMIT_SHA="${COMMIT_SHA}" \
+          bash backend/scripts/provision_migrate_job.sh ${_DEPLOY_ENV}
+    waitFor: [push-backend]
+
+  # `gcloud run jobs execute --wait`는 잡 실패 시 비-0 exit → 이 스텝이 실패 → Cloud Build가
+  # 빌드 전체를 실패 처리하고 뒤따르는 deploy-backend(waitFor 의존)는 아예 실행되지 않는다
+  # (migrate 실패 시 배포 자동 abort — "잡 성공≠앱DB 배포" 상태가 재발할 수 없음). 실패는
+  # Cloud Build 로그 + GHA 워크플로우 실패(빨간 X·커밋 상태)로 가시화된다.
+  - id: run-migrate-job
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    args:
+      - run
+      - jobs
+      - execute
+      - sprintable-migrate-${_DEPLOY_ENV}
+      - --region=${_AR_REGION}
+      - --wait
+    waitFor: [update-migrate-job]
+
   # ─── Deploy to Cloud Run ───────────────────────────────────────────────────
   - id: deploy-frontend
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
@@ -117,7 +150,9 @@ steps:
       # maxScale 와 짝으로 검토. (PO rev 01256 dev 429 right-size durable 화.)
       - --update-env-vars=FASTAPI_URL=${_FASTAPI_URL},DB_POOL_SIZE=3,DB_MAX_OVERFLOW=1
       - --quiet
-    waitFor: [push-backend]
+    # story dbda0baf: push-backend → run-migrate-job(위) 로 변경 — 신규 코드가 마이그 안 된
+    # 스키마를 상대로 뜨는 걸 막는다(migrate 실패 시 이 스텝 자체가 안 돎).
+    waitFor: [run-migrate-job]
 
 options:
   machineType: E2_HIGHCPU_8


### PR DESCRIPTION
## Summary
- 2026-07-05 dev incident root cause: `sprintable-migrate-dev` job drifted to an inline `alembic upgrade head` (singular) override bypassing `migrate.sh`, and the deploy pipeline never touched the job at all — a manual `provision_migrate_job.sh` run without `COMMIT_SHA` silently pins it to the mutable `latest-${ENV}` tag forever.
- Once corrected to `upgrade heads`, hit `pricing_versions` DuplicateTable: dev had physically run the pre-bda4beac linear chain (0146/0147 EE branch) but `alembic_version` never recorded 0147 as a head after the graph split.
- `cloudbuild.yaml`: added `update-migrate-job` (canonical `provision_migrate_job.sh`, COMMIT_SHA-pinned image) + `run-migrate-job` (`execute --wait`) between `push-backend` and `deploy-backend`. `deploy-backend` now `waitFor`s `run-migrate-job` instead of `push-backend`, so a migrate failure aborts the deploy.
- `migrate.sh`: folded the #1886 EE-stamp check (`uq_org_subscriptions_org_id` existence as the precise physical signal of the old chain) directly into the canonical entrypoint as a self-healing precheck — supersedes the standalone manual-override script from PR #1886 with a standing, idempotent guard that runs on every migrate execution.
- Known gap: no notification webhook secret exists in the repo (checked via `gh secret list`) — the "abort" half of the AC is fully implemented via the `waitFor` DAG, but active push notification (Discord/Slack) needs a new secret provisioned by PO/infra if desired. Left as a flagged follow-up rather than faked.

## Test plan
- [x] Real-Postgres reproduction (throwaway docker pgvector/pg16): replayed the exact drift state (0146/0147 DDL+seed physically applied, `alembic_version` missing the 0147 head row) and confirmed `migrate.sh` self-heals via `alembic stamp 0147` (add, not replace — 0155 row preserved empirically) then applies only 0156 cleanly, no duplicate `pricing_versions` rows.
- [x] Idempotent re-run confirmed clean no-op.
- [x] Fresh-install path (no drift) verified end-to-end from empty DB.
- [x] New tests: `test_migrate_sh_has_ee_stamp_precheck` (migrate.sh content + ordering), `test_cloudbuild_migrate_wiring.py` (6 tests: provision script reuse, COMMIT_SHA pinning, execute --wait, deploy-backend waitFor dependency, step ordering).
- [x] Negative-tested the critical `deploy-backend` waitFor assertion by reverting it, confirmed exactly that test fails, restored.
- [x] Full backend suite: 2991 passed, 7 failed — all pre-existing/environment (live E2E dev-backend connectivity test + known MCP python-path drift tests seen across every recent PR in this repo), 0 regressions from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)