### PR TITLE
feat(recruit): POST /recruit MVP — persona + scoped key provisioning (E-RECRUIT S3, ff2996d0)

### DIFF
--- a/backend/app/repositories/agent_persona.py
+++ b/backend/app/repositories/agent_persona.py
@@ -17,6 +17,13 @@ def _slugify(value: str) -> str:
     return slug or "persona"
 
 
+# E-RECRUIT S3 QA MEDIUM(config 병합 orphan 키 잔존, story ff2996d0): role_template 유래 config
+# 필드의 단일 소스 — update()가 이 키들을 전량 pop 후 새 값만 재설정(wholesale 교체)한다. 개별
+# if-in-fields 산발 patch였다면 S14 카탈로그 확장으로 필드가 늘 때 "이번엔 안 왔다"를 "그대로
+# 둬라"로 오독해 이전 role 의 값이 orphan 으로 남는다 — 이 상수 하나만 갱신하면 재발 안 함.
+_RECRUIT_CONFIG_KEYS = frozenset({"role_template_id", "tool_allowlist"})
+
+
 def _build_summary(persona: AgentPersona, is_in_use: bool, base: AgentPersona | None = None) -> PersonaSummaryResponse:
     config: dict[str, Any] = persona.config or {}
     base_persona_id = config.get("base_persona_id") if isinstance(config.get("base_persona_id"), str) else None
@@ -209,8 +216,14 @@ class AgentPersonaRepository:
         org_id: uuid.UUID,
         project_id: uuid.UUID,
         actor_id: uuid.UUID,
+        force_none_fields: set[str] | None = None,
         **fields: Any,
     ) -> PersonaSummaryResponse | None:
+        """``force_none_fields``: E-RECRUIT S3 QA MEDIUM(persona description stale, story ff2996d0)
+        — 기본은 ``fields[key] is None`` 을 "이 필드 안 건드림"(부분 PATCH 관례, 기존 persona 편집
+        엔드포인트 호출부가 이미 그렇게 pre-filter 함)으로 해석한다. recruit 은 매번 role_template
+        전체를 명시 반영해야 하므로(새 role 의 description 이 None 이면 이전 role 의 description 이
+        잔존하면 안 됨) 이 집합에 있는 키만 None 도 "명시적으로 지워라"로 승격한다."""
         r = await self.session.execute(
             select(AgentPersona).where(
                 AgentPersona.id == persona_id,
@@ -225,24 +238,28 @@ class AgentPersonaRepository:
         if persona.is_builtin:
             raise ValueError("Built-in personas cannot be modified")
 
+        force_none_fields = force_none_fields or set()
+
         config = dict(persona.config or {})
         if "base_persona_id" in fields:
             bpid = fields.pop("base_persona_id")
             config["base_persona_id"] = str(bpid) if bpid else None
-        if "tool_allowlist" in fields:
-            tl = fields.pop("tool_allowlist")
+        if "tool_allowlist" in fields or "role_template_id" in fields:
+            tl = fields.pop("tool_allowlist", None)
+            rtid = fields.pop("role_template_id", None)
+            for key in _RECRUIT_CONFIG_KEYS:
+                config.pop(key, None)
             if tl is not None:
                 config["tool_allowlist"] = tl
-        if "role_template_id" in fields:
-            rtid = fields.pop("role_template_id")
-            config["role_template_id"] = str(rtid) if rtid else None
+            if rtid:
+                config["role_template_id"] = str(rtid)
 
         if fields.get("is_default"):
             await self._clear_default(org_id, project_id, persona.agent_id, exclude_id=persona_id)
 
         patch: dict[str, Any] = {"config": config, "updated_at": datetime.now(timezone.utc)}
         for key in ("name", "slug", "description", "system_prompt", "style_prompt", "model", "is_default"):
-            if key in fields and fields[key] is not None:
+            if key in fields and (fields[key] is not None or key in force_none_fields):
                 val = fields[key]
                 if key == "name":
                     val = val.strip()

--- a/backend/app/repositories/agent_persona.py
+++ b/backend/app/repositories/agent_persona.py
@@ -135,6 +135,24 @@ class AgentPersonaRepository:
             return None
         return await self._decorate(persona)
 
+    async def get_recruited(
+        self, org_id: uuid.UUID, project_id: uuid.UUID, agent_id: uuid.UUID
+    ) -> AgentPersona | None:
+        """E-RECRUIT S3(story ff2996d0) G7: 이 에이전트를 위해 recruit이 이미 만든 persona(있으면
+        정확히 1개 — ``config.role_template_id`` 로 표식) 조회. 재채용/역할변경은 이 행을 upsert
+        한다(수기 생성 persona 와 별개 — 그건 role_template_id 마커가 없다). raw ORM 행 반환(호출부가
+        직접 갱신하거나 rotate 대상 판별에 쓴다 — decorate 불필요한 내부 오케스트레이션용)."""
+        r = await self.session.execute(
+            select(AgentPersona).where(
+                AgentPersona.org_id == org_id,
+                AgentPersona.project_id == project_id,
+                AgentPersona.agent_id == agent_id,
+                AgentPersona.deleted_at.is_(None),
+                AgentPersona.config["role_template_id"].isnot(None),
+            )
+        )
+        return r.scalars().first()
+
     async def create(
         self,
         org_id: uuid.UUID,
@@ -150,6 +168,7 @@ class AgentPersonaRepository:
         base_persona_id: uuid.UUID | None = None,
         tool_allowlist: list[str] | None = None,
         is_default: bool = False,
+        role_template_id: uuid.UUID | None = None,
     ) -> PersonaSummaryResponse:
         if is_default:
             await self._clear_default(org_id, project_id, agent_id)
@@ -159,6 +178,10 @@ class AgentPersonaRepository:
             config["base_persona_id"] = str(base_persona_id)
         if tool_allowlist is not None:
             config["tool_allowlist"] = tool_allowlist
+        # E-RECRUIT S3(story ff2996d0): recruit이 생성한 persona 표식 — 재채용/역할변경 upsert(G7)
+        # 대상 판별에 쓰인다(get_recruited).
+        if role_template_id:
+            config["role_template_id"] = str(role_template_id)
 
         persona = AgentPersona(
             org_id=org_id,
@@ -210,6 +233,9 @@ class AgentPersonaRepository:
             tl = fields.pop("tool_allowlist")
             if tl is not None:
                 config["tool_allowlist"] = tl
+        if "role_template_id" in fields:
+            rtid = fields.pop("role_template_id")
+            config["role_template_id"] = str(rtid) if rtid else None
 
         if fields.get("is_default"):
             await self._clear_default(org_id, project_id, persona.agent_id, exclude_id=persona_id)

--- a/backend/app/repositories/api_key.py
+++ b/backend/app/repositories/api_key.py
@@ -68,14 +68,19 @@ class ApiKeyRepository:
         await self.session.refresh(key)
         return key
 
-    async def rotate(self, api_key_id: uuid.UUID) -> tuple[ApiKey, str] | None:
+    async def rotate(
+        self, api_key_id: uuid.UUID, scope: list[str] | None = None
+    ) -> tuple[ApiKey, str] | None:
+        """이전 키 revoke + 신규 발급. ``scope`` 미지정 시 이전 scope 그대로 승계(기존 동작 보존) —
+        E-RECRUIT S3(story ff2996d0)가 역할변경 시 scope 를 새 role_template 파생값으로 교체하려고
+        명시 override 를 추가했다(sentinel: None=승계 vs []=빈 scope 의도적 지정 구분)."""
         old = await self.get(api_key_id)
         if old is None:
             return None
         old.revoked_at = datetime.now(timezone.utc)
         new_key, plaintext = await self.create(
             team_member_id=old.team_member_id,
-            scope=old.scope,
+            scope=scope if scope is not None else old.scope,
             expires_at=None,
         )
         return new_key, plaintext

--- a/backend/app/repositories/api_key.py
+++ b/backend/app/repositories/api_key.py
@@ -6,6 +6,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import select
+from sqlalchemy import update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.api_key import ApiKey
@@ -73,11 +74,25 @@ class ApiKeyRepository:
     ) -> tuple[ApiKey, str] | None:
         """이전 키 revoke + 신규 발급. ``scope`` 미지정 시 이전 scope 그대로 승계(기존 동작 보존) —
         E-RECRUIT S3(story ff2996d0)가 역할변경 시 scope 를 새 role_template 파생값으로 교체하려고
-        명시 override 를 추가했다(sentinel: None=승계 vs []=빈 scope 의도적 지정 구분)."""
+        명시 override 를 추가했다(sentinel: None=승계 vs []=빈 scope 의도적 지정 구분).
+
+        까심 QA HIGH(S3 RC) 방어: revoke를 compare-and-swap(``UPDATE ... WHERE revoked_at IS NULL``)
+        으로 실행한다 — 동시 두 rotate 호출이 같은 키를 둘 다 "성공"으로 revoke+재발급해 active 키가
+        2개 남는 레이스를 막는다. Postgres의 UPDATE 자체가 대상 행을 잠그므로 두번째 호출은 첫번째
+        커밋 후 재평가돼 ``revoked_at IS NULL`` 이 거짓 → rowcount 0 → None(이미 다른 호출이 회전함).
+        """
         old = await self.get(api_key_id)
         if old is None:
             return None
-        old.revoked_at = datetime.now(timezone.utc)
+
+        result = await self.session.execute(
+            sa_update(ApiKey)
+            .where(ApiKey.id == api_key_id, ApiKey.revoked_at.is_(None))
+            .values(revoked_at=datetime.now(timezone.utc))
+        )
+        if result.rowcount == 0:
+            return None  # 레이스 패배 — 다른 호출이 이미 이 키를 회전시킴
+
         new_key, plaintext = await self.create(
             team_member_id=old.team_member_id,
             scope=scope if scope is not None else old.scope,

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -18,6 +18,7 @@ from app.dependencies.auth import AuthContext, get_current_user, get_verified_or
 from app.dependencies.database import get_db
 from app.models.project import Project
 from app.models.team import TeamMember
+from app.schemas.recruit import RecruitRequest
 from app.schemas.team_member import OrgAgentCreate, TeamMemberResponse
 from app.services.agent_onboarding_config import (
     DEFAULT_RUNTIME,
@@ -30,6 +31,7 @@ from app.services.agent_onboarding_config import (
 from app.services.agent_verify import get_verification_state, start_verification
 from app.services.onboarding_funnel import emit_onboarding_event, safe_key_prefix
 from app.services.org_agent import create_org_level_agent
+from app.services.recruit_service import get_published_role_template, recruit_agent
 
 router = APIRouter(prefix="/api/v2/agents", tags=["agents"])
 
@@ -209,6 +211,69 @@ async def _fetch_org_agent(session: AsyncSession, agent_id: uuid.UUID, org_id: u
             TeamMember.type == "agent",
         ).limit(1)
     )).scalar_one_or_none()
+
+
+@router.post("/{agent_id}/recruit", status_code=201)
+async def recruit_agent_endpoint(
+    agent_id: uuid.UUID,
+    body: RecruitRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """E-RECRUIT S3(story ff2996d0): role_template + runtime → 자율 운영 지침 합성(S2) + persona
+    upsert(G7) + role-derived scope 로 키 회전(G2/G3) + 활성화 번들(``.mcp.json`` + 실 key 1회) 반환.
+
+    G1: 에이전트가 없으면 FE가 먼저 기존 ``POST /agents``를 재사용해 만든다 — 이 엔드포인트는
+    ``agent_id``가 이미 존재함을 전제(별도 인라인 분기 없음, 경로 divergence 방지).
+    """
+    member = await _fetch_org_agent(session, agent_id, org_id)
+    if member is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    if body.runtime not in SUPPORTED_RUNTIMES:
+        raise HTTPException(status_code=400, detail=f"unsupported runtime: {body.runtime}")
+
+    role_template = await get_published_role_template(session, body.role_template_slug)
+    if role_template is None:
+        raise HTTPException(status_code=404, detail="role_template not found")
+
+    try:
+        result = await recruit_agent(
+            session,
+            agent_member=member,
+            org_id=org_id,
+            role_template=role_template,
+            runtime=body.runtime,
+            actor_id=uuid.UUID(auth.user_id),
+        )
+    except ValueError as exc:
+        # validate_tool_groups fail-closed(QA MINOR 하드닝) — 오염된 role_template 데이터 400.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    persona = result["persona"]
+    api_key_plaintext = result["api_key_plaintext"]
+    bundle = build_agent_mcp_config_bundle(api_key_plaintext=api_key_plaintext, runtime=body.runtime)
+
+    # OB-4 seam: config_generated(recruit 도 번들 생성 지점 — connection-artifact 와 동일 이벤트 재사용).
+    await emit_onboarding_event(
+        session, "config_generated", agent_id=member.id, org_id=org_id,
+        project_id=member.project_id, runtime=body.runtime,
+        transport=bundle["default_transport"], key_prefix=safe_key_prefix(api_key_plaintext),
+    )
+    await session.commit()
+
+    return {
+        "agent_id": str(member.id),
+        "persona_id": str(persona.id),
+        "role_template_slug": role_template.slug,
+        "system_prompt": persona.system_prompt,
+        "tool_allowlist": result["tool_allowlist"],
+        "api_key": api_key_plaintext,
+        "default_transport": bundle["default_transport"],
+        "mcp_config": bundle["mcp_config"],
+        "mcp_config_alternatives": bundle["mcp_config_alternatives"],
+    }
 
 
 @router.post("/{agent_id}/verify-connection")

--- a/backend/app/routers/api_keys.py
+++ b/backend/app/routers/api_keys.py
@@ -13,6 +13,7 @@ from app.schemas.api_key import (
     CreateApiKeyRequest,
     RotateApiKeyRequest,
 )
+from app.services.recruit_service import acquire_agent_mutation_lock
 
 router = APIRouter(prefix="/api/v2", tags=["api-keys"])
 
@@ -28,6 +29,12 @@ async def rotate_api_key(
     repo: ApiKeyRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
 ) -> ApiKeyCreatedResponse:
+    existing = await repo.get(body.api_key_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="API key not found")
+    # E-RECRUIT S3 QA 재QA 잔여1건(크로스엔드포인트 레이스): recruit_agent()와 같은 agent-scoped
+    # lock을 여기도 걸어 동시 rotate가 CAS 손실→AssertionError→500으로 새는 걸 막는다(PO 선호안 a).
+    await acquire_agent_mutation_lock(session, existing.team_member_id)
     result = await repo.rotate(body.api_key_id)
     if result is None:
         raise HTTPException(status_code=404, detail="API key not found")

--- a/backend/app/schemas/recruit.py
+++ b/backend/app/schemas/recruit.py
@@ -1,0 +1,11 @@
+"""E-RECRUIT S3 (story ff2996d0): POST /recruit 요청 스키마."""
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from app.services.agent_onboarding_config import DEFAULT_RUNTIME
+
+
+class RecruitRequest(BaseModel):
+    role_template_slug: str
+    runtime: str = DEFAULT_RUNTIME

--- a/backend/app/services/recruit_service.py
+++ b/backend/app/services/recruit_service.py
@@ -44,6 +44,17 @@ async def resolve_recipe_by_slug(session: AsyncSession, slug: str | None) -> dic
     return _template_to_recipe(template) if template else None
 
 
+async def acquire_agent_mutation_lock(session: AsyncSession, agent_id: uuid.UUID) -> None:
+    """까심 QA 재QA 잔여1건(S3, 크로스엔드포인트 레이스): ``recruit_agent()``와 standalone
+    ``POST /api-keys/rotate``(``api_keys.py``)가 같은 키를 동시 rotate하면, advisory lock이
+    recruit 본문에만 걸려 있어 standalone 쪽이 락 없이 끼어들어 CAS 를 이겼다. 두 진입점이 반드시
+    **같은 네임스페이스 문자열**로 이 함수를 호출해야 서로 직렬화된다(데이터는 그때도 안전했지만
+    —패배 트랜잭션 롤백— 정상 요청이 500 으로 크래시하는 게 문제였음). PO 선호안(a): 양쪽 다 감싼다."""
+    await session.execute(
+        select(func.pg_advisory_xact_lock(func.hashtext(f"recruit_agent:{agent_id}")))
+    )
+
+
 async def _rotate_or_create_key(
     session: AsyncSession, *, agent_id: uuid.UUID, scope: list[str]
 ) -> tuple[Any, str]:
@@ -83,9 +94,7 @@ async def recruit_agent(
     교훈과 동형) agent-scoped `pg_advisory_xact_lock` 으로 이 함수 본문 전체(조회→분기→write)를
     직렬화한다 — 트랜잭션 종료 시 자동 해제, 기존 `onboarding_first_auth:{member_id}` 관례와 동일 패턴.
     """
-    await session.execute(
-        select(func.pg_advisory_xact_lock(func.hashtext(f"recruit_agent:{agent_member.id}")))
-    )
+    await acquire_agent_mutation_lock(session, agent_member.id)
 
     tool_allowlist = list(role_template.default_tool_groups)
     validate_tool_groups(tool_allowlist)  # fail-closed — ValueError 전파, 호출부가 400 매핑

--- a/backend/app/services/recruit_service.py
+++ b/backend/app/services/recruit_service.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import uuid
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.role_template import RoleTemplate
@@ -75,7 +75,18 @@ async def recruit_agent(
     QA MINOR 하드닝(S2에서 명시 유보된 부분의 소비 지점): ``validate_tool_groups``를 어떤 write
     (persona/key)도 하기 전에 먼저 호출 — role_template.default_tool_groups 가 오염돼 있으면
     ``resolve_policy``의 미인식-그룹 fail-open(전체 비파괴 허용)으로 새는 걸 fail-closed 로 막는다.
+
+    까심 QA HIGH(S3 RC): ``get_recruited()`` 조회→create 사이 + 키 rotate 의 old조회→revoke→insert
+    사이에 락이 없으면 동일 agent 에 대한 동시 recruit 2콜이 persona 2행 + active 키 2개(scope
+    서로 다름)를 만들어 G2/G3 단일소스 전제가 깨진다(codex 실재현). SELECT FOR UPDATE 는 아직
+    존재하지 않는 행은 못 잠그므로(check-then-insert TOCTOU — 기존 [[feedback_check_then_insert_toctou]]
+    교훈과 동형) agent-scoped `pg_advisory_xact_lock` 으로 이 함수 본문 전체(조회→분기→write)를
+    직렬화한다 — 트랜잭션 종료 시 자동 해제, 기존 `onboarding_first_auth:{member_id}` 관례와 동일 패턴.
     """
+    await session.execute(
+        select(func.pg_advisory_xact_lock(func.hashtext(f"recruit_agent:{agent_member.id}")))
+    )
+
     tool_allowlist = list(role_template.default_tool_groups)
     validate_tool_groups(tool_allowlist)  # fail-closed — ValueError 전파, 호출부가 400 매핑
 
@@ -95,6 +106,9 @@ async def recruit_agent(
             tool_allowlist=tool_allowlist,
             role_template_id=role_template.id,
             is_default=True,
+            # QA MEDIUM(persona description stale): 새 role의 description이 None이어도 이전
+            # role의 값이 잔존하면 안 됨 — 이 필드만 None도 명시 반영으로 승격.
+            force_none_fields={"description"},
         )
     else:
         persona = await persona_repo.create(

--- a/backend/app/services/recruit_service.py
+++ b/backend/app/services/recruit_service.py
@@ -1,0 +1,122 @@
+"""E-RECRUIT S3 (story ff2996d0): POST /recruit MVP 오케스트레이션.
+
+role_template + runtime → (S2) 합성 지침 + persona upsert(G7) + role-derived scope 로 API key
+회전(G2/G3) + 활성화 번들(mcp_config + 실 key 1회) 반환. compose_prompt 자체는 순수(S2 G4)라
+이 서비스가 그 순수 함수를 실 DB 상태(role_template/recipe/persona/key)에 배선하는 접합부다.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.role_template import RoleTemplate
+from app.repositories.agent_persona import AgentPersonaRepository
+from app.repositories.api_key import ApiKeyRepository
+from app.schemas.agent_persona import PersonaSummaryResponse
+from app.services.agent_recruiter import compose_prompt, validate_tool_groups
+
+
+async def get_published_role_template(session: AsyncSession, slug: str) -> RoleTemplate | None:
+    result = await session.execute(
+        select(RoleTemplate).where(RoleTemplate.slug == slug, RoleTemplate.is_published.is_(True))
+    )
+    return result.scalar_one_or_none()
+
+
+async def resolve_recipe_by_slug(session: AsyncSession, slug: str | None) -> dict[str, Any] | None:
+    """role_template.default_workflow_recipe_slug → workflow_recipes 형태 dict(builtin 또는 DB)."""
+    if not slug:
+        return None
+    from app.models.workflow_template import WorkflowTemplate
+    from app.routers.workflow_recipes import _BUILTIN_BY_ID, _template_to_recipe
+
+    if slug in _BUILTIN_BY_ID:
+        return _BUILTIN_BY_ID[slug]
+    result = await session.execute(
+        select(WorkflowTemplate).where(
+            WorkflowTemplate.slug == slug, WorkflowTemplate.is_enabled.is_(True)
+        )
+    )
+    template = result.scalar_one_or_none()
+    return _template_to_recipe(template) if template else None
+
+
+async def _rotate_or_create_key(
+    session: AsyncSession, *, agent_id: uuid.UUID, scope: list[str]
+) -> tuple[Any, str]:
+    """recruit은 매 호출(신규·재채용 무관)마다 에이전트의 활성 키를 role-derived scope 로 회전한다
+    — 신규 채용도 ``POST /agents`` 가 만든 ALL_GROUPS 기본 키를 role scope 로 좁히는 게 맞다(G2/G3:
+    scope 는 항상 default_tool_groups 파생 하나여야 하고, 채용 후에도 더 넓은 키가 살아있으면 G3
+    단일소스 원칙이 깨진다)."""
+    key_repo = ApiKeyRepository(session)
+    keys = await key_repo.list_by_member(agent_id)
+    active = next((k for k in keys if k.revoked_at is None), None)
+    if active is not None:
+        result = await key_repo.rotate(active.id, scope=scope)
+        assert result is not None  # active 조회 직후 rotate — 레이스 없는 한 항상 존재
+        return result
+    return await key_repo.create(team_member_id=agent_id, scope=scope)
+
+
+async def recruit_agent(
+    session: AsyncSession,
+    *,
+    agent_member: Any,
+    org_id: uuid.UUID,
+    role_template: RoleTemplate,
+    runtime: str,
+    actor_id: uuid.UUID,
+) -> dict[str, Any]:
+    """recruit 본체 — 반환: ``{persona, api_key_plaintext, tool_allowlist}``.
+
+    QA MINOR 하드닝(S2에서 명시 유보된 부분의 소비 지점): ``validate_tool_groups``를 어떤 write
+    (persona/key)도 하기 전에 먼저 호출 — role_template.default_tool_groups 가 오염돼 있으면
+    ``resolve_policy``의 미인식-그룹 fail-open(전체 비파괴 허용)으로 새는 걸 fail-closed 로 막는다.
+    """
+    tool_allowlist = list(role_template.default_tool_groups)
+    validate_tool_groups(tool_allowlist)  # fail-closed — ValueError 전파, 호출부가 400 매핑
+
+    recipe = await resolve_recipe_by_slug(session, role_template.default_workflow_recipe_slug)
+    system_prompt = compose_prompt(role_template, recipe, runtime)
+
+    persona_repo = AgentPersonaRepository(session)
+    existing = await persona_repo.get_recruited(org_id, agent_member.project_id, agent_member.id)
+
+    if existing is not None:
+        persona: PersonaSummaryResponse = await persona_repo.update(
+            existing.id, org_id, agent_member.project_id, actor_id,
+            name=role_template.name,
+            slug=role_template.slug,
+            description=role_template.description,
+            system_prompt=system_prompt,
+            tool_allowlist=tool_allowlist,
+            role_template_id=role_template.id,
+            is_default=True,
+        )
+    else:
+        persona = await persona_repo.create(
+            org_id=org_id,
+            project_id=agent_member.project_id,
+            agent_id=agent_member.id,
+            actor_id=actor_id,
+            name=role_template.name,
+            slug=role_template.slug,
+            description=role_template.description,
+            system_prompt=system_prompt,
+            tool_allowlist=tool_allowlist,
+            role_template_id=role_template.id,
+            is_default=True,
+        )
+
+    _new_key, api_key_plaintext = await _rotate_or_create_key(
+        session, agent_id=agent_member.id, scope=tool_allowlist
+    )
+
+    return {
+        "persona": persona,
+        "api_key_plaintext": api_key_plaintext,
+        "tool_allowlist": tool_allowlist,
+    }

--- a/backend/tests/test_e_recruit_s3_recruit_endpoint.py
+++ b/backend/tests/test_e_recruit_s3_recruit_endpoint.py
@@ -1,0 +1,137 @@
+"""E-RECRUIT S3 (story ff2996d0): POST /agents/{id}/recruit 라우터 계약 — mock 기반.
+
+DB write 시맨틱(persona upsert/키 회전)은 realdb 테스트(test_e_recruit_s3_recruit_service_realdb.py)
+가 실증한다. 여기선 라우터 계층의 404/400 분기 + 응답 shape만 확인(순수 도메인 로직은 이미
+compose_prompt(S2)/recruit_agent(realdb)가 커버).
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth_ctx():
+    return SimpleNamespace(user_id=str(uuid.uuid4()))
+
+
+@pytest.mark.anyio
+async def test_recruit_404_when_agent_not_found():
+    from fastapi import HTTPException
+    from app.routers.agents import recruit_agent_endpoint
+    from app.schemas.recruit import RecruitRequest
+
+    session = MagicMock()
+    with patch("app.routers.agents._fetch_org_agent", AsyncMock(return_value=None)):
+        with pytest.raises(HTTPException) as ei:
+            await recruit_agent_endpoint(
+                uuid.uuid4(), RecruitRequest(role_template_slug="backend"),
+                session=session, auth=_auth_ctx(), org_id=uuid.uuid4(),
+            )
+    assert ei.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_recruit_400_on_unsupported_runtime():
+    from fastapi import HTTPException
+    from app.routers.agents import recruit_agent_endpoint
+    from app.schemas.recruit import RecruitRequest
+
+    session = MagicMock()
+    member = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    with patch("app.routers.agents._fetch_org_agent", AsyncMock(return_value=member)):
+        with pytest.raises(HTTPException) as ei:
+            await recruit_agent_endpoint(
+                uuid.uuid4(), RecruitRequest(role_template_slug="backend", runtime="bogus-runtime"),
+                session=session, auth=_auth_ctx(), org_id=uuid.uuid4(),
+            )
+    assert ei.value.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_recruit_404_when_role_template_not_found():
+    from fastapi import HTTPException
+    from app.routers.agents import recruit_agent_endpoint
+    from app.schemas.recruit import RecruitRequest
+
+    session = MagicMock()
+    member = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    with patch("app.routers.agents._fetch_org_agent", AsyncMock(return_value=member)), \
+         patch("app.routers.agents.get_published_role_template", AsyncMock(return_value=None)):
+        with pytest.raises(HTTPException) as ei:
+            await recruit_agent_endpoint(
+                uuid.uuid4(), RecruitRequest(role_template_slug="nonexistent"),
+                session=session, auth=_auth_ctx(), org_id=uuid.uuid4(),
+            )
+    assert ei.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_recruit_400_when_recruit_agent_raises_value_error():
+    """QA MINOR 하드닝: recruit_agent의 fail-closed ValueError가 400으로 매핑되는지(500 아님)."""
+    from fastapi import HTTPException
+    from app.routers.agents import recruit_agent_endpoint
+    from app.schemas.recruit import RecruitRequest
+
+    session = MagicMock()
+    session.commit = AsyncMock()
+    member = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
+    role_template = SimpleNamespace(slug="bogus", default_tool_groups=["not-real"])
+    with patch("app.routers.agents._fetch_org_agent", AsyncMock(return_value=member)), \
+         patch("app.routers.agents.get_published_role_template", AsyncMock(return_value=role_template)), \
+         patch("app.routers.agents.recruit_agent", AsyncMock(side_effect=ValueError("unknown group"))):
+        with pytest.raises(HTTPException) as ei:
+            await recruit_agent_endpoint(
+                uuid.uuid4(), RecruitRequest(role_template_slug="bogus"),
+                session=session, auth=_auth_ctx(), org_id=uuid.uuid4(),
+            )
+    assert ei.value.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_recruit_success_response_shape():
+    from app.routers.agents import recruit_agent_endpoint
+    from app.schemas.recruit import RecruitRequest
+
+    session = MagicMock()
+    session.commit = AsyncMock()
+    agent_id = uuid.uuid4()
+    member = SimpleNamespace(id=agent_id, project_id=uuid.uuid4())
+    role_template = SimpleNamespace(slug="backend", default_tool_groups=["stories", "tasks"])
+    persona = SimpleNamespace(id=uuid.uuid4(), system_prompt="합성된 지침 텍스트")
+    recruit_result = {
+        "persona": persona,
+        "api_key_plaintext": "sk_live_deadbeef",
+        "tool_allowlist": ["stories", "tasks"],
+    }
+    bundle = {
+        "default_transport": "stdio",
+        "mcp_config": {"mcpServers": {"sprintable": {"type": "stdio"}}},
+        "mcp_config_alternatives": {},
+    }
+
+    with patch("app.routers.agents._fetch_org_agent", AsyncMock(return_value=member)), \
+         patch("app.routers.agents.get_published_role_template", AsyncMock(return_value=role_template)), \
+         patch("app.routers.agents.recruit_agent", AsyncMock(return_value=recruit_result)), \
+         patch("app.routers.agents.build_agent_mcp_config_bundle", MagicMock(return_value=bundle)), \
+         patch("app.routers.agents.emit_onboarding_event", AsyncMock()):
+        response = await recruit_agent_endpoint(
+            agent_id, RecruitRequest(role_template_slug="backend"),
+            session=session, auth=_auth_ctx(), org_id=uuid.uuid4(),
+        )
+
+    assert response["agent_id"] == str(agent_id)
+    assert response["role_template_slug"] == "backend"
+    assert response["system_prompt"] == "합성된 지침 텍스트"
+    assert response["tool_allowlist"] == ["stories", "tasks"]
+    assert response["api_key"] == "sk_live_deadbeef"
+    assert response["default_transport"] == "stdio"
+    assert response["mcp_config"] == bundle["mcp_config"]
+    session.commit.assert_awaited_once()

--- a/backend/tests/test_e_recruit_s3_recruit_service_realdb.py
+++ b/backend/tests/test_e_recruit_s3_recruit_service_realdb.py
@@ -3,9 +3,13 @@
 핵심: G7(재채용/역할변경=persona upsert — 같은 agent 재recruit이 새 행을 만들지 않고 기존
 recruit-persona 행을 갱신하는지) + 키 revoke-후-재발급(이전 키 비활성화·신규 키가 새 role
 scope 를 갖는지) + QA MINOR fail-closed(오염된 tool_groups 면 아무 write 도 없이 raise).
+
+까심 QA RC(S3) 후속 fix 검증: HIGH(동시 recruit 2콜 직렬화 — advisory lock) + MEDIUM
+(description stale + config 병합 orphan 키 잔존).
 """
 from __future__ import annotations
 
+import asyncio
 import os
 import uuid
 
@@ -197,6 +201,7 @@ async def test_corrupt_tool_groups_fails_closed_with_no_writes():
     try:
         async with Session() as s:
             agent, _backend_rt, _qa_rt, bogus_rt, org_id = await _seed_agent_and_role_templates(s)
+            agent_id = agent.id  # rollback 이 agent 인스턴스를 expire 시키므로 값을 미리 캡처
 
             with pytest.raises(ValueError, match="unknown group"):
                 await recruit_agent(
@@ -207,15 +212,175 @@ async def test_corrupt_tool_groups_fails_closed_with_no_writes():
 
         async with Session() as s:
             personas = (await s.execute(
-                select(AgentPersona).where(AgentPersona.agent_id == agent.id)
+                select(AgentPersona).where(AgentPersona.agent_id == agent_id)
             )).scalars().all()
             assert personas == []  # fail-closed — persona 미생성
 
             keys = (await s.execute(
-                select(ApiKey).where(ApiKey.team_member_id == agent.id)
+                select(ApiKey).where(ApiKey.team_member_id == agent_id)
             )).scalars().all()
             assert len(keys) == 1  # 시드 시점 원본 키만(회전 없음)
             assert keys[0].revoked_at is None
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_concurrent_recruit_calls_serialize_to_one_persona_and_one_active_key():
+    """까심 QA HIGH(S3 RC): 동일 agent 에 대한 동시 recruit 2콜(서로 다른 role_template, 서로 다른
+    DB 커넥션/세션)이 advisory lock 으로 직렬화돼 persona 2행/active 키 2개로 안 갈라지는지 실증.
+    """
+    from sqlalchemy import select
+    from app.core.database import Base
+    from app.models.agent_deployment import AgentPersona
+    from app.models.api_key import ApiKey
+    from app.models.role_template import RoleTemplate
+    from app.models.team import TeamMember
+    from app.services.recruit_service import recruit_agent
+
+    engine, Session = await _session()
+
+    async def _do_recruit(agent_id, org_id, role_template_id):
+        from sqlalchemy import text as _text
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            agent_ref = (await s.execute(
+                select(TeamMember).where(TeamMember.id == agent_id)
+            )).scalar_one()
+            rt_ref = (await s.execute(
+                select(RoleTemplate).where(RoleTemplate.id == role_template_id)
+            )).scalar_one()
+            result = await recruit_agent(
+                s, agent_member=agent_ref, org_id=org_id, role_template=rt_ref,
+                runtime="claude-code", actor_id=uuid.uuid4(),
+            )
+            await s.commit()
+            return result
+
+    try:
+        async with Session() as s:
+            agent, backend_rt, qa_rt, _bogus_rt, org_id = await _seed_agent_and_role_templates(s)
+            agent_id = agent.id
+
+        results = await asyncio.gather(
+            _do_recruit(agent_id, org_id, backend_rt.id),
+            _do_recruit(agent_id, org_id, qa_rt.id),
+        )
+        assert all(r is not None for r in results)
+
+        async with Session() as s:
+            personas = (await s.execute(
+                select(AgentPersona).where(AgentPersona.agent_id == agent_id)
+            )).scalars().all()
+            assert len(personas) == 1  # 락 없으면 2행이 됐을 시나리오
+
+            keys = (await s.execute(
+                select(ApiKey).where(ApiKey.team_member_id == agent_id)
+            )).scalars().all()
+            active = [k for k in keys if k.revoked_at is None]
+            assert len(active) == 1  # 락 없으면 scope 다른 active 키 2개가 됐을 시나리오
+            # 승자가 backend 든 qa 든, persona.config 와 active key.scope 는 반드시 같은 role 값이어야 함
+            # (G2/G3 단일소스 — 서로 다른 role 값이 섞이면 안 됨).
+            assert personas[0].config["tool_allowlist"] == active[0].scope
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_re_recruit_into_null_description_role_clears_stale_description():
+    """까심 QA MEDIUM(persona description stale, agent_persona.py:244): 새 role_template 의
+    description 이 None 이면, 이전 role 에서 물려받은 description 이 잔존하면 안 된다."""
+    from sqlalchemy import select
+    from app.core.database import Base
+    from app.models.agent_deployment import AgentPersona
+    from app.models.role_template import RoleTemplate
+    from app.services.recruit_service import recruit_agent
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            agent, backend_rt, _qa_rt, _bogus_rt, org_id = await _seed_agent_and_role_templates(s)
+            backend_rt.description = "백엔드 직무 설명(1차 채용에 남아있으면 안 되는 값)"
+            no_desc_rt = RoleTemplate(
+                id=uuid.uuid4(), slug="no-desc", name="No Description Role", category="misc",
+                role_behaviors="설명 없는 role.", default_tool_groups=["stories"],
+                description=None, is_published=True,
+            )
+            s.add(no_desc_rt)
+            await s.flush()
+
+            await recruit_agent(
+                s, agent_member=agent, org_id=org_id, role_template=backend_rt,
+                runtime="claude-code", actor_id=uuid.uuid4(),
+            )
+            await s.commit()
+
+        async with Session() as s:
+            agent_ref = (await s.execute(
+                select(agent.__class__).where(agent.__class__.id == agent.id)
+            )).scalar_one()
+            await recruit_agent(
+                s, agent_member=agent_ref, org_id=org_id, role_template=no_desc_rt,
+                runtime="claude-code", actor_id=uuid.uuid4(),
+            )
+            await s.commit()
+
+        async with Session() as s:
+            persona = (await s.execute(
+                select(AgentPersona).where(AgentPersona.agent_id == agent.id)
+            )).scalar_one()
+            assert persona.description is None  # 이전 role 의 description 잔존 X
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_partial_recruit_config_touch_does_not_leak_stale_key_but_preserves_unrelated():
+    """까심 QA MEDIUM(config 병합 orphan 키 잔존, agent_persona.py:228): recruit-managed 네임스페이스
+    (role_template_id/tool_allowlist) 중 일부만 갱신되는 상황에서도 이전 값이 orphan 으로 안 남고,
+    recruit 과 무관한 config 키(base_persona_id)는 그대로 보존되는지 — repository 레벨 화이트박스 검증
+    (오늘의 recruit_agent 호출 패턴은 항상 둘 다 같이 넘기지만, 이 계약 자체를 직접 확인)."""
+    from app.core.database import Base
+    from app.repositories.agent_persona import AgentPersonaRepository
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            repo = AgentPersonaRepository(s)
+            org_id, project_id, agent_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+            from sqlalchemy import text as _text
+            await s.execute(_text("SET session_replication_role = replica"))
+
+            created = await repo.create(
+                org_id=org_id, project_id=project_id, agent_id=agent_id, actor_id=uuid.uuid4(),
+                name="Stale Role", tool_allowlist=["stale-group"],
+                role_template_id=uuid.uuid4(), base_persona_id=uuid.uuid4(),
+            )
+            await s.commit()
+            persona_id = created.id
+
+        async with Session() as s:
+            repo = AgentPersonaRepository(s)
+            # role_template_id 를 생략하고 tool_allowlist 만 갱신(부분 touch) — 이전 role_template_id
+            # 가 orphan 으로 남으면 안 됨.
+            updated = await repo.update(
+                persona_id, org_id, project_id, uuid.uuid4(),
+                tool_allowlist=["fresh-group"],
+            )
+            await s.commit()
+
+            assert updated.config["tool_allowlist"] == ["fresh-group"]
+            assert "role_template_id" not in updated.config  # orphan 안 남음(wholesale 클리어)
+            assert updated.base_persona_id is not None  # recruit 과 무관한 키는 보존
     finally:
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)

--- a/backend/tests/test_e_recruit_s3_recruit_service_realdb.py
+++ b/backend/tests/test_e_recruit_s3_recruit_service_realdb.py
@@ -385,3 +385,92 @@ async def test_partial_recruit_config_touch_does_not_leak_stale_key_but_preserve
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)
         await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_recruit_vs_standalone_rotate_cross_endpoint_race_no_crash():
+    """까심 재QA 잔여1건(크로스엔드포인트 레이스): advisory lock이 recruit_agent() 본문에만 걸려
+    있으면 standalone POST /api-keys/rotate 가 같은 키를 동시 rotate할 때 락 없이 끼어들어 recruit
+    측 CAS 를 이기고, recruit 의 ``assert result is not None``이 터져 정상 요청이 500 크래시했다
+    (데이터 자체는 안전 — 패배 트랜잭션 전체 롤백). ``acquire_agent_mutation_lock``을 양쪽이 공유
+    하면 크래시 없이 안전하게 직렬화되는지 실증."""
+    from types import SimpleNamespace
+
+    from sqlalchemy import select
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.models.api_key import ApiKey
+    from app.models.role_template import RoleTemplate
+    from app.models.team import TeamMember
+    from app.repositories.api_key import ApiKeyRepository
+    from app.routers.api_keys import rotate_api_key
+    from app.schemas.api_key import RotateApiKeyRequest
+    from app.services.recruit_service import recruit_agent
+
+    engine, Session = await _session()
+
+    async def _do_recruit(agent_id, org_id, role_template_id):
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            agent_ref = (await s.execute(
+                select(TeamMember).where(TeamMember.id == agent_id)
+            )).scalar_one()
+            rt_ref = (await s.execute(
+                select(RoleTemplate).where(RoleTemplate.id == role_template_id)
+            )).scalar_one()
+            try:
+                result = await recruit_agent(
+                    s, agent_member=agent_ref, org_id=org_id, role_template=rt_ref,
+                    runtime="claude-code", actor_id=uuid.uuid4(),
+                )
+                await s.commit()
+                return result
+            except Exception as exc:
+                await s.rollback()
+                return exc
+
+    async def _do_standalone_rotate(active_key_id):
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            repo = ApiKeyRepository(s)
+            try:
+                result = await rotate_api_key(
+                    RotateApiKeyRequest(api_key_id=active_key_id),
+                    _auth=SimpleNamespace(user_id=str(uuid.uuid4())),
+                    repo=repo, session=s,
+                )
+                await s.commit()
+                return result
+            except Exception as exc:
+                await s.rollback()
+                return exc
+
+    try:
+        async with Session() as s:
+            agent, backend_rt, _qa_rt, _bogus_rt, org_id = await _seed_agent_and_role_templates(s)
+            agent_id = agent.id
+            keys = (await s.execute(
+                select(ApiKey).where(ApiKey.team_member_id == agent_id)
+            )).scalars().all()
+            active_key_id = next(k.id for k in keys if k.revoked_at is None)
+
+        results = await asyncio.gather(
+            _do_recruit(agent_id, org_id, backend_rt.id),
+            _do_standalone_rotate(active_key_id),
+        )
+        # 핵심 단정: 어느 쪽도 AssertionError(500 매핑 전 단계)로 안 죽어야 함 — 패자는 CAS 손실을
+        # 정상적인 404(이미 회전된 키)로 받거나, 락 직렬화 후 자기 차례에 정상 완주해야 한다.
+        for r in results:
+            assert not isinstance(r, AssertionError), f"crashed with AssertionError: {r!r}"
+
+        async with Session() as s:
+            keys = (await s.execute(
+                select(ApiKey).where(ApiKey.team_member_id == agent_id)
+            )).scalars().all()
+            active = [k for k in keys if k.revoked_at is None]
+            assert len(active) == 1  # 데이터 정합성도 그대로 유지
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()

--- a/backend/tests/test_e_recruit_s3_recruit_service_realdb.py
+++ b/backend/tests/test_e_recruit_s3_recruit_service_realdb.py
@@ -1,0 +1,222 @@
+"""E-RECRUIT S3 (story ff2996d0): recruit_agent 실 Postgres 검증.
+
+핵심: G7(재채용/역할변경=persona upsert — 같은 agent 재recruit이 새 행을 만들지 않고 기존
+recruit-persona 행을 갱신하는지) + 키 revoke-후-재발급(이전 키 비활성화·신규 키가 새 role
+scope 를 갖는지) + QA MINOR fail-closed(오염된 tool_groups 면 아무 write 도 없이 raise).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# story 8236bbc3 컨벤션: create_all/drop_all 자체 스키마 관리 — 공유 alembic-migrated DB 오염 방지.
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_agent_and_role_templates(session):
+    from sqlalchemy import text as _text
+    from app.models.team import TeamMember
+    from app.models.role_template import RoleTemplate
+    from app.repositories.api_key import ApiKeyRepository
+    from app.services.mcp_toolset import ALL_GROUPS
+
+    org_id, project_id = uuid.uuid4(), uuid.uuid4()
+    await session.execute(_text("SET session_replication_role = replica"))
+
+    agent = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent",
+        name="Test Agent", role="member",
+    )
+    backend_rt = RoleTemplate(
+        id=uuid.uuid4(), slug="backend", name="Backend Engineer", category="engineering",
+        role_behaviors="백엔드 자율 운영 지침.",
+        default_tool_groups=["stories", "tasks", "chat", "docs"],
+        is_published=True,
+    )
+    qa_rt = RoleTemplate(
+        id=uuid.uuid4(), slug="qa", name="QA Engineer", category="quality",
+        role_behaviors="QA 자율 운영 지침.",
+        default_tool_groups=["stories", "tasks", "chat", "docs", "retro"],
+        is_published=True,
+    )
+    bogus_rt = RoleTemplate(
+        id=uuid.uuid4(), slug="bogus", name="Bogus Role", category="broken",
+        role_behaviors="오염된 role.",
+        default_tool_groups=["stories", "not-a-real-group"],
+        is_published=True,
+    )
+    session.add_all([agent, backend_rt, qa_rt, bogus_rt])
+    await session.flush()
+
+    # POST /agents 가 만드는 것과 동일한 초기 ALL_GROUPS 기본 키(recruit이 이걸 좁혀야 함).
+    _key, _plaintext = await ApiKeyRepository(session).create(
+        team_member_id=agent.id, scope=list(ALL_GROUPS)
+    )
+    await session.commit()
+    return agent, backend_rt, qa_rt, bogus_rt, org_id
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_first_recruit_creates_persona_and_narrows_key_scope():
+    from sqlalchemy import select
+    from app.core.database import Base
+    from app.models.agent_deployment import AgentPersona
+    from app.models.api_key import ApiKey
+    from app.services.recruit_service import recruit_agent
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            agent, backend_rt, _qa_rt, _bogus_rt, org_id = await _seed_agent_and_role_templates(s)
+
+            result = await recruit_agent(
+                s, agent_member=agent, org_id=org_id, role_template=backend_rt,
+                runtime="claude-code", actor_id=uuid.uuid4(),
+            )
+            await s.commit()
+
+            assert result["tool_allowlist"] == ["stories", "tasks", "chat", "docs"]
+            assert result["api_key_plaintext"].startswith("sk_live_")
+
+        async with Session() as s:
+            personas = (await s.execute(
+                select(AgentPersona).where(AgentPersona.agent_id == agent.id)
+            )).scalars().all()
+            assert len(personas) == 1
+            assert personas[0].config["role_template_id"] == str(backend_rt.id)
+            assert personas[0].config["tool_allowlist"] == ["stories", "tasks", "chat", "docs"]
+            assert personas[0].is_default is True
+
+            keys = (await s.execute(
+                select(ApiKey).where(ApiKey.team_member_id == agent.id)
+            )).scalars().all()
+            assert len(keys) == 2  # 원본(ALL_GROUPS) + recruit이 회전한 신규
+            active = [k for k in keys if k.revoked_at is None]
+            revoked = [k for k in keys if k.revoked_at is not None]
+            assert len(active) == 1
+            assert len(revoked) == 1
+            assert active[0].scope == ["stories", "tasks", "chat", "docs"]
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_re_recruit_into_different_role_upserts_same_persona_and_rotates_key():
+    from sqlalchemy import select
+    from app.core.database import Base
+    from app.models.agent_deployment import AgentPersona
+    from app.models.api_key import ApiKey
+    from app.services.recruit_service import recruit_agent
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            agent, backend_rt, qa_rt, _bogus_rt, org_id = await _seed_agent_and_role_templates(s)
+            first = await recruit_agent(
+                s, agent_member=agent, org_id=org_id, role_template=backend_rt,
+                runtime="claude-code", actor_id=uuid.uuid4(),
+            )
+            await s.commit()
+            first_persona_id = first["persona"].id
+
+        async with Session() as s:
+            # role change: backend → qa (동일 agent)
+            agent_ref = (await s.execute(
+                select(agent.__class__).where(agent.__class__.id == agent.id)
+            )).scalar_one()
+            second = await recruit_agent(
+                s, agent_member=agent_ref, org_id=org_id, role_template=qa_rt,
+                runtime="claude-code", actor_id=uuid.uuid4(),
+            )
+            await s.commit()
+
+        async with Session() as s:
+            personas = (await s.execute(
+                select(AgentPersona).where(AgentPersona.agent_id == agent.id)
+            )).scalars().all()
+            # G7: 새 행이 아니라 같은 행 upsert — 정확히 1개만 존재.
+            assert len(personas) == 1
+            assert personas[0].id == first_persona_id
+            assert personas[0].config["role_template_id"] == str(qa_rt.id)
+            assert personas[0].config["tool_allowlist"] == ["stories", "tasks", "chat", "docs", "retro"]
+            assert personas[0].name == "QA Engineer"
+
+            keys = (await s.execute(
+                select(ApiKey).where(ApiKey.team_member_id == agent.id)
+            )).scalars().all()
+            assert len(keys) == 3  # 원본 + 1차 recruit 회전 + 2차 recruit 회전
+            active = [k for k in keys if k.revoked_at is None]
+            assert len(active) == 1
+            assert active[0].scope == ["stories", "tasks", "chat", "docs", "retro"]
+            assert second["persona"].id == first_persona_id
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_corrupt_tool_groups_fails_closed_with_no_writes():
+    from sqlalchemy import select
+    from app.core.database import Base
+    from app.models.agent_deployment import AgentPersona
+    from app.models.api_key import ApiKey
+    from app.services.recruit_service import recruit_agent
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            agent, _backend_rt, _qa_rt, bogus_rt, org_id = await _seed_agent_and_role_templates(s)
+
+            with pytest.raises(ValueError, match="unknown group"):
+                await recruit_agent(
+                    s, agent_member=agent, org_id=org_id, role_template=bogus_rt,
+                    runtime="claude-code", actor_id=uuid.uuid4(),
+                )
+            await s.rollback()
+
+        async with Session() as s:
+            personas = (await s.execute(
+                select(AgentPersona).where(AgentPersona.agent_id == agent.id)
+            )).scalars().all()
+            assert personas == []  # fail-closed — persona 미생성
+
+            keys = (await s.execute(
+                select(ApiKey).where(ApiKey.team_member_id == agent.id)
+            )).scalars().all()
+            assert len(keys) == 1  # 시드 시점 원본 키만(회전 없음)
+            assert keys[0].revoked_at is None
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()

--- a/backend/tests/test_s35.py
+++ b/backend/tests/test_s35.py
@@ -124,7 +124,12 @@ async def test_rotate_key_201():
         new_plaintext = _PREFIX_MARKER + "n" * 64
 
         with patch("app.services.agent_message_policy.ensure_creator_allowlisted", new_callable=AsyncMock), \
+             patch("app.repositories.api_key.ApiKeyRepository.get", new_callable=AsyncMock) as mock_get, \
+             patch("app.services.recruit_service.acquire_agent_mutation_lock", new_callable=AsyncMock), \
              patch("app.repositories.api_key.ApiKeyRepository.rotate", new_callable=AsyncMock) as mock_rotate:
+            # E-RECRUIT S3 QA 재QA 잔여1건 fix: rotate_api_key가 이제 rotate() 전에 get()으로
+            # 대상 키의 team_member_id를 확인해 크로스엔드포인트 advisory lock을 건다.
+            mock_get.return_value = _mock_key()
             mock_rotate.return_value = (new_key, new_plaintext)
 
             async with client as c:
@@ -139,10 +144,30 @@ async def test_rotate_key_201():
 
 @pytest.mark.anyio
 async def test_rotate_key_404():
+    """존재하는 키(get 성공)인데 rotate가 None(CAS 손실/레이스 패배)인 케이스 — 404 매핑."""
     client, session, app = await _client()
     try:
-        with patch("app.repositories.api_key.ApiKeyRepository.rotate", new_callable=AsyncMock) as mock_rotate:
+        with patch("app.repositories.api_key.ApiKeyRepository.get", new_callable=AsyncMock) as mock_get, \
+             patch("app.services.recruit_service.acquire_agent_mutation_lock", new_callable=AsyncMock), \
+             patch("app.repositories.api_key.ApiKeyRepository.rotate", new_callable=AsyncMock) as mock_rotate:
+            mock_get.return_value = _mock_key()
             mock_rotate.return_value = None
+
+            async with client as c:
+                resp = await c.post("/api/v2/api-keys/rotate", json={"api_key_id": str(uuid.uuid4())})
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_rotate_key_404_when_key_missing():
+    """E-RECRUIT S3 QA 재QA 잔여1건 fix: get()이 애초에 키를 못 찾으면 rotate/lock 호출 전에 404."""
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.api_key.ApiKeyRepository.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = None
 
             async with client as c:
                 resp = await c.post("/api/v2/api-keys/rotate", json={"api_key_id": str(uuid.uuid4())})


### PR DESCRIPTION
## Summary
- `POST /api/v2/agents/{agent_id}/recruit {role_template_slug, runtime}`: composes the autonomous operating guide via S2's `compose_prompt`, upserts an `AgentPersona`, rotates the agent's API key to a role-derived scope, returns the activation bundle (system_prompt + `.mcp.json` + plaintext key, one-time).
- **G1**: assumes `agent_id` already exists — FE reuses the existing `POST /agents` inline for "create new" before calling recruit, no separate branch here.
- **G2/G3**: every recruit call (first time or role change) rotates the agent's active key to `scope=role_template.default_tool_groups` — first recruit narrows the `ALL_GROUPS` default key from `create_org_level_agent` down to the role's actual scope, so `default_tool_groups` stays the single source for both `persona.tool_allowlist` and `key.scope`.
- **G7**: re-recruiting (initial retry or role change) upserts the same `AgentPersona` row instead of creating a second one — tracked via a new `config.role_template_id` marker (`AgentPersonaRepository.get_recruited`), mirroring the existing `config.base_persona_id` convention.
- **QA MINOR hardening** (explicitly deferred from S2 to this story): `validate_tool_groups` runs before any persona/key write, so a corrupted `role_template.default_tool_groups` fails closed (400) instead of falling through `resolve_policy`'s unrecognized-group fail-open (grants every non-destructive group).
- `ApiKeyRepository.rotate()` gained an optional `scope` override (defaults to preserving old scope — unchanged behavior for the existing `/api-keys/rotate` endpoint).

## Test plan
- [x] Real-Postgres verification (throwaway docker `pgvector/pg16`): first recruit narrows the default `ALL_GROUPS` key + creates exactly one persona; second recruit into a different role_template updates the *same* persona row (not a second one) and rotates the key to the new scope, leaving exactly one active key; corrupted tool group raises before any write.
- [x] Negative-tested both guards (fail-closed validation, G7 upsert) by disabling each in turn and confirming the corresponding test fails, then restored.
- [x] Router-level mock tests: 404 (agent not found / role_template not found), 400 (unsupported runtime, fail-closed ValueError→400 mapping), success response shape.
- [x] Full backend suite: 3004 passed, 7 pre-existing failures (live E2E dev-connectivity test + known MCP python-path drift tests seen across every recent PR in this repo), 0 regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)