### PR TITLE
feat(recruit): runtime-scoped MCP config emit + connection-artifact bundle (E-RECRUIT S5, 4fca5a3e)

### DIFF
--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -189,10 +189,19 @@ async def get_agent_connection_artifact(
         raise HTTPException(status_code=404, detail="Agent not found")
 
     # G4: persona가 있으면(is_default) 자율 운영 지침을 파일로 emit — recruit 전용 아닌 공용 레이어.
+    # 까심 QA RC(S5): list()는 `ORDER BY is_default DESC, created_at ASC` 정렬만 하지 실제
+    # is_default 여부를 보장 안 함 — is_default=True 행이 하나도 없으면(POST /agent-personas가
+    # is_default 생략 시 non-default 생성 가능·"정확히 1개 default" 불변식 없음) 가장 오래된
+    # persona가 [0]에 와서 임의 system_prompt가 authoritative처럼 emit된다(G4 목적과 정반대).
+    # is_default를 명시 확인 — 참인 행이 없으면 지침 파일 생략(안전 fallback, "미채용"과 동형).
     files: list[dict] = []
     personas = await AgentPersonaRepository(session).list(org_id, member.project_id, agent_id)
     default_persona = personas[0] if personas else None
-    if default_persona is not None and default_persona.resolved_system_prompt:
+    if (
+        default_persona is not None
+        and default_persona.is_default
+        and default_persona.resolved_system_prompt
+    ):
         files.append({
             "filename": resolve_instruction_filename(runtime),
             "content": default_persona.resolved_system_prompt,

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -18,15 +18,19 @@ from app.dependencies.auth import AuthContext, get_current_user, get_verified_or
 from app.dependencies.database import get_db
 from app.models.project import Project
 from app.models.team import TeamMember
+from app.repositories.agent_persona import AgentPersonaRepository
 from app.schemas.recruit import RecruitRequest
 from app.schemas.team_member import OrgAgentCreate, TeamMemberResponse
 from app.services.agent_onboarding_config import (
+    CONNECTOR_RUNTIME,
     DEFAULT_RUNTIME,
     SUPPORTED_RUNTIMES,
     SUPPORTED_TRANSPORTS,
     build_agent_mcp_config,
     build_agent_mcp_config_bundle,
+    build_connector_guidance,
     default_transport_for_edition,
+    resolve_instruction_filename,
 )
 from app.services.agent_verify import get_verification_state, start_verification
 from app.services.onboarding_funnel import emit_onboarding_event, safe_key_prefix
@@ -151,7 +155,7 @@ async def get_agent_connection_artifact(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
-    """OB-1 AC3: 에이전트 connection 아티팩트(.mcp.json) — 同 SSOT generator 소비.
+    """OB-1 AC3 + E-RECRUIT S5(story 4fca5a3e): 에이전트 activation 번들 — 同 SSOT generator 소비.
 
     기존 에이전트는 평문 키가 없으므로(생성 시 1회 노출) ``AGENT_API_KEY`` 는 placeholder 로 채운다 —
     사용자가 자기 키를 붙여 완성한다. wizard(OB-3)가 이 아티팩트를 렌더+copy+verify 한다.
@@ -160,14 +164,19 @@ async def get_agent_connection_artifact(
 
     E-MCP-OPT S3: ``transport`` 쿼리(``stdio``|``http``) — connect-step 토글이 다른 탭 선택 시 이
     파라미터로 재요청(§5, FE round-trip 방식 선택). 미지정 시 edition 기본(SaaS=http·OSS=stdio).
-    이 엔드포인트의 기존 "content=paste-ready 문자열" 계약은 그대로 — 요청된 단일 변형만 반환한다
-    (두 변형 동봉은 생성 시점 bundle 엔드포인트가 담당).
+
+    E-RECRUIT S5 G4(블루프린트 핵심 발견 — ``agent_personas.system_prompt``가 저장은 되나 어떤
+    런타임에도 전달 안 됨): 이 **공용** 레이어에 fix를 둬서 recruit(S3) 전용이 아니라 **일반
+    생성 에이전트도** persona 가 있으면(is_default) 그 자율 운영 지침을 파일로 받는다. persona
+    가 없으면(미채용) 지침 파일 없이 mcp_config 만(이전 동작과 동일 — 회귀 없음).
+
+    ⚠️ BREAKING(dev-only, 착수 전 미르코군 조율): 응답 shape 을 기존 ``{filename, content}``
+    단일 파일에서 ``{files[], mcp_config, api_key}``(``api_key`` 는 GET 이라 placeholder 뿐)로
+    교체 — S4 채용관 번들 프리뷰(파일 3종)와 recruit(S3) 응답 shape 에 맞춘다(G2: 재방문 시
+    placeholder만·실키는 recruit 시점 1회).
     """
     if runtime not in SUPPORTED_RUNTIMES:
         raise HTTPException(status_code=400, detail=f"unsupported runtime: {runtime}")
-    resolved_transport = transport or default_transport_for_edition()
-    if resolved_transport not in SUPPORTED_TRANSPORTS:
-        raise HTTPException(status_code=400, detail=f"unsupported transport: {transport}")
 
     member = (await session.execute(
         select(TeamMember).where(
@@ -179,12 +188,36 @@ async def get_agent_connection_artifact(
     if member is None:
         raise HTTPException(status_code=404, detail="Agent not found")
 
-    artifact = build_agent_mcp_config(
-        api_key_plaintext=_API_KEY_PLACEHOLDER, runtime=runtime, transport=resolved_transport,
-    )
-    if artifact is None:
-        # http 요청됐으나 이 환경엔 호스팅 배포가 없음(MCP_PUBLIC_URL 미설정) — 명시 요청이라 400.
-        raise HTTPException(status_code=400, detail=f"transport '{resolved_transport}' unavailable in this environment")
+    # G4: persona가 있으면(is_default) 자율 운영 지침을 파일로 emit — recruit 전용 아닌 공용 레이어.
+    files: list[dict] = []
+    personas = await AgentPersonaRepository(session).list(org_id, member.project_id, agent_id)
+    default_persona = personas[0] if personas else None
+    if default_persona is not None and default_persona.resolved_system_prompt:
+        files.append({
+            "filename": resolve_instruction_filename(runtime),
+            "content": default_persona.resolved_system_prompt,
+        })
+
+    if runtime == CONNECTOR_RUNTIME:
+        # Q2(PO 확정): connector = 포인터/안내만 — SSE dial-out은 `.mcp.json`과 별개 프로토콜이라
+        # transport 파라미터 자체가 의미 없음(무시).
+        resolved_transport = None
+        mcp_config: dict | None = None
+        files.append({"filename": "CONNECTOR_SETUP.md", "content": build_connector_guidance(runtime)})
+    else:
+        resolved_transport = transport or default_transport_for_edition()
+        if resolved_transport not in SUPPORTED_TRANSPORTS:
+            raise HTTPException(status_code=400, detail=f"unsupported transport: {transport}")
+        mcp_config = build_agent_mcp_config(
+            api_key_plaintext=_API_KEY_PLACEHOLDER, runtime=runtime, transport=resolved_transport,
+        )
+        if mcp_config is None:
+            # http 요청됐으나 이 환경엔 호스팅 배포가 없음(MCP_PUBLIC_URL 미설정) — 명시 요청이라 400.
+            raise HTTPException(status_code=400, detail=f"transport '{resolved_transport}' unavailable in this environment")
+        files.append({
+            "filename": ".mcp.json",
+            "content": json.dumps(mcp_config, indent=2, ensure_ascii=False),
+        })
 
     # OB-4 seam: config_generated (generator 아티팩트 반환·funnel·non-blocking).
     await emit_onboarding_event(
@@ -193,12 +226,13 @@ async def get_agent_connection_artifact(
     )
     await session.commit()
 
-    # BE↔FE 계약 락(OB-3 wizard 1:1 렌더): content = paste-ready .mcp.json **문자열**(dict 아님).
     return {
-        "filename": ".mcp.json",
-        "content": json.dumps(artifact, indent=2, ensure_ascii=False),
         "agent_id": str(member.id),
         "runtime": runtime,
+        "files": files,
+        "mcp_config": mcp_config,
+        # G2: GET 재방문 — full key 재발급 불가(생성/recruit 시점 1회만 노출). placeholder 로 표시.
+        "api_key": None,
     }
 
 

--- a/backend/app/services/agent_onboarding_config.py
+++ b/backend/app/services/agent_onboarding_config.py
@@ -16,10 +16,56 @@ from __future__ import annotations
 import os
 
 DEFAULT_RUNTIME = "claude-code"
-SUPPORTED_RUNTIMES = frozenset({"claude-code"})
+# E-RECRUIT S5(story 4fca5a3e) Q1(PO 확정): S4 픽커 그대로 — MCP-native 4(claude-code primary +
+# codex/gemini/cursor, transport config 공통) + "connector" 통칭 1개(9종 SSE 어댑터 개별 확장 X).
+CONNECTOR_RUNTIME = "connector"
+MCP_NATIVE_RUNTIMES = frozenset({"claude-code", "codex", "gemini", "cursor"})
+SUPPORTED_RUNTIMES = MCP_NATIVE_RUNTIMES | {CONNECTOR_RUNTIME}
 STDIO = "stdio"
 HTTP = "http"
 SUPPORTED_TRANSPORTS = frozenset({STDIO, HTTP})
+
+# E-RECRUIT S5 G4: 런타임별 자율 운영 지침 파일명 — 블루프린트 §4 어댑터 3축 중 "지침 파일명" 축.
+# P0=claude-code 만 확정(CLAUDE.md); 나머지 MCP-native 런타임(codex=AGENTS.md·cursor=.cursorrules
+# 등)의 정식 매핑은 S7 shaping(PO 확정) — 미확정 런타임은 이 기본값으로 폴백(크래시 없이 최선의
+# 파일명 제공, 회귀 없이 확장 여지만 남김).
+_INSTRUCTION_FILENAMES: dict[str, str] = {
+    "claude-code": "CLAUDE.md",
+}
+_DEFAULT_INSTRUCTION_FILENAME = "AGENT_INSTRUCTIONS.md"
+
+
+def resolve_instruction_filename(runtime: str) -> str:
+    """런타임별 자율 운영 지침 파일명(어댑터 3축 중 하나). 미확정 런타임은 generic 기본값."""
+    return _INSTRUCTION_FILENAMES.get(runtime, _DEFAULT_INSTRUCTION_FILENAME)
+
+
+def build_connector_guidance(runtime_hint: str | None = None) -> str:
+    """E-RECRUIT S5 Q2(PO 확정): connector 분기 = **포인터/안내만**(SSE dial-out은 `.mcp.json`과
+    완전 별개 프로토콜 — 실제 어댑터 조립은 S7/후속). `connectors/{runtime}-sprintable/` 각 폴더의
+    README가 5조 계약(SSE dial-out·turn 주입·응답·ack·에러)을 담고 있어 여기선 안내만 재생산한다."""
+    lines = [
+        "# Sprintable Connector 안내",
+        "",
+        "Claude Code/Codex/Gemini/Cursor 처럼 MCP를 네이티브 지원하지 않는 런타임은 별도 SSE",
+        "커넥터 어댑터로 연결합니다 — `.mcp.json`이 아니라 `connectors/{runtime}-sprintable/` 폴더의",
+        "어댑터를 사용해 서버에 아웃바운드로 접속합니다(인바운드 도메인/웹훅 불필요).",
+        "",
+        "## 사용 가능한 어댑터",
+        "`connectors/` 레포 경로 아래 각 폴더가 자기완결(self-contained) 어댑터입니다:",
+        "hermes-sprintable · openclaw-sprintable · opencode-sprintable · grok-sprintable ·",
+        "pi-sprintable · codex-sprintable · cursor-sprintable · gemini-sprintable",
+        "",
+        "## 설정",
+        "1. 위 폴더 중 사용 중인 런타임에 맞는 폴더를 복사하세요(각 폴더는 sibling import 없이",
+        "   독립 동작합니다).",
+        "2. 폴더의 `README.md` 안내대로 `AGENT_API_KEY`(이 에이전트의 scoped key) 등 env를 설정하세요.",
+        "3. 어댑터를 런타임 호스트에서 직접 실행하세요(호스팅 실행은 지원하지 않음 — 설치/실행은",
+        "   사용자 수동).",
+    ]
+    if runtime_hint:
+        lines.insert(2, f"(선택한 런타임: {runtime_hint})")
+    return "\n".join(lines)
 
 _LOCAL_FALLBACK_URL = "http://localhost:8000"
 # generator 가 backend-direct URL 을 읽는 런타임 env. 배포(deploy_backend.sh)가 주입한다.
@@ -130,12 +176,15 @@ def build_agent_mcp_config(
 ) -> dict | None:
     """`.mcp.json` 아티팩트 generator — transport 별 SSOT(E-MCP-OPT S3).
 
-    runtime 은 현재 ``claude-code`` 단일(향후 cursor 등 분기 여지). 미지원 값은 호출부(엔드포인트)가
-    400 으로 거른다 — generator 는 항상 canonical 아티팩트를 만든다.
+    E-RECRUIT S5: MCP-native 런타임(``MCP_NATIVE_RUNTIMES`` — transport config 공통, PO 확정)만
+    `.mcp.json`을 받는다. ``runtime == CONNECTOR_RUNTIME``이면 None(SSE dial-out은 완전 별개
+    프로토콜이라 `.mcp.json` 자체가 성립 안 함 — 호출부가 ``build_connector_guidance()``로 대체).
 
     ``transport="http"`` 인데 이 환경에 호스팅 배포가 없으면(``MCP_PUBLIC_URL`` 미설정) None 반환 —
     호출부가 이를 "그 변형 생성 불가"로 취급(에러 아님).
     """
+    if runtime == CONNECTOR_RUNTIME:
+        return None
     if transport == HTTP:
         return _build_http_config(api_key_plaintext)
     return _build_stdio_config(api_key_plaintext)
@@ -151,7 +200,13 @@ def build_agent_mcp_config_bundle(
     ``{"default_transport": ..., "mcp_config": <default 변형>,
     "mcp_config_alternatives": {<다른 transport>: <그 변형>, ...}}``. http 변형이 이 환경에서
     생성 불가(``MCP_PUBLIC_URL`` 미설정)면 alternatives 에서 생략(OSS 는 호스팅 탭 자체가 없음).
+
+    E-RECRUIT S5: ``runtime == CONNECTOR_RUNTIME``이면 mcp_config 자체가 성립 안 하므로 전부 None/
+    빈값(호출부가 ``build_connector_guidance()``로 안내 파일을 대신 emit — crash 대신 안전한 no-op).
     """
+    if runtime == CONNECTOR_RUNTIME:
+        return {"default_transport": None, "mcp_config": None, "mcp_config_alternatives": {}}
+
     default_transport = default_transport_for_edition()
     configs = {
         t: build_agent_mcp_config(api_key_plaintext=api_key_plaintext, runtime=runtime, transport=t)

--- a/backend/tests/test_e_mcp_opt_s3_hosted_transport.py
+++ b/backend/tests/test_e_mcp_opt_s3_hosted_transport.py
@@ -174,14 +174,16 @@ async def test_connection_artifact_transport_http_returns_http_content(monkeypat
     monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp")
     agent_id = uuid.uuid4()
     res = MagicMock()
-    res.scalar_one_or_none.return_value = SimpleNamespace(id=agent_id)
+    res.scalar_one_or_none.return_value = SimpleNamespace(id=agent_id, project_id=uuid.uuid4())
     db = AsyncMock()
     db.execute = AsyncMock(return_value=res)
-    out = await get_agent_connection_artifact(
-        agent_id, runtime="claude-code", transport="http",
-        session=db, auth=MagicMock(), org_id=uuid.uuid4(),
-    )
-    parsed = json.loads(out["content"])
+    with patch("app.routers.agents.AgentPersonaRepository.list", new_callable=AsyncMock, return_value=[]):
+        out = await get_agent_connection_artifact(
+            agent_id, runtime="claude-code", transport="http",
+            session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+        )
+    mcp_file = next(f for f in out["files"] if f["filename"] == ".mcp.json")
+    parsed = json.loads(mcp_file["content"])
     assert parsed["mcpServers"]["sprintable"]["type"] == "http"
 
 
@@ -195,14 +197,15 @@ async def test_connection_artifact_transport_http_unavailable_400(monkeypatch):
     monkeypatch.delenv("MCP_PUBLIC_URL", raising=False)
     agent_id = uuid.uuid4()
     res = MagicMock()
-    res.scalar_one_or_none.return_value = SimpleNamespace(id=agent_id)
+    res.scalar_one_or_none.return_value = SimpleNamespace(id=agent_id, project_id=uuid.uuid4())
     db = AsyncMock()
     db.execute = AsyncMock(return_value=res)
-    with pytest.raises(HTTPException) as ei:
-        await get_agent_connection_artifact(
-            agent_id, runtime="claude-code", transport="http",
-            session=db, auth=MagicMock(), org_id=uuid.uuid4(),
-        )
+    with patch("app.routers.agents.AgentPersonaRepository.list", new_callable=AsyncMock, return_value=[]):
+        with pytest.raises(HTTPException) as ei:
+            await get_agent_connection_artifact(
+                agent_id, runtime="claude-code", transport="http",
+                session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+            )
     assert ei.value.status_code == 400
 
 
@@ -211,10 +214,16 @@ async def test_connection_artifact_unsupported_transport_400():
     from fastapi import HTTPException
 
     from app.routers.agents import get_agent_connection_artifact
-    with pytest.raises(HTTPException) as ei:
+    agent_id = uuid.uuid4()
+    res = MagicMock()
+    res.scalar_one_or_none.return_value = SimpleNamespace(id=agent_id, project_id=uuid.uuid4())
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=res)
+    with patch("app.routers.agents.AgentPersonaRepository.list", new_callable=AsyncMock, return_value=[]), \
+         pytest.raises(HTTPException) as ei:
         await get_agent_connection_artifact(
-            uuid.uuid4(), runtime="claude-code", transport="carrier-pigeon",
-            session=AsyncMock(), auth=MagicMock(), org_id=uuid.uuid4(),
+            agent_id, runtime="claude-code", transport="carrier-pigeon",
+            session=db, auth=MagicMock(), org_id=uuid.uuid4(),
         )
     assert ei.value.status_code == 400
 

--- a/backend/tests/test_e_recruit_s5_connection_artifact_realdb.py
+++ b/backend/tests/test_e_recruit_s5_connection_artifact_realdb.py
@@ -1,0 +1,167 @@
+"""E-RECRUIT S5 (story 4fca5a3e): connection-artifact 번들 실 Postgres 검증.
+
+핵심: G4(persona.system_prompt가 공용 connection-artifact 레이어에서 파일로 emit되는지 — 실
+AgentPersonaRepository.list()/_decorate() 경로, mock 아님) + connector 분기(포인터만·mcp_config
+None) + 무-persona 하위호환(기존 .mcp.json 단일 파일 동작 회귀 없음).
+"""
+from __future__ import annotations
+
+import json
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_agent(session, *, with_persona: bool):
+    from sqlalchemy import text as _text
+    from app.models.team import TeamMember
+    from app.models.agent_deployment import AgentPersona
+
+    org_id, project_id = uuid.uuid4(), uuid.uuid4()
+    await session.execute(_text("SET session_replication_role = replica"))
+
+    agent = TeamMember(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent",
+        name="Test Agent", role="member",
+    )
+    session.add(agent)
+    await session.flush()
+
+    if with_persona:
+        persona = AgentPersona(
+            org_id=org_id, project_id=project_id, agent_id=agent.id,
+            name="Backend Engineer", slug="backend",
+            system_prompt="당신은 백엔드 엔지니어입니다. claim→status→소통 순으로 자율 운영하세요.",
+            is_builtin=False, is_default=True,
+            config={"role_template_id": str(uuid.uuid4()), "tool_allowlist": ["stories", "tasks"]},
+        )
+        session.add(persona)
+        await session.flush()
+
+    await session.commit()
+    return agent, org_id
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_connection_artifact_emits_persona_file_real_decorate_path():
+    """G4: 실 AgentPersonaRepository.list()/_decorate() 경로(mock 아님)로 CLAUDE.md + .mcp.json
+    두 파일이 정확히 나오는지."""
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.routers.agents import get_agent_connection_artifact
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            agent, org_id = await _seed_agent(s, with_persona=True)
+
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            out = await get_agent_connection_artifact(
+                agent.id, runtime="claude-code", session=s,
+                auth=MagicMock(), org_id=org_id,
+            )
+
+        assert len(out["files"]) == 2
+        filenames = {f["filename"] for f in out["files"]}
+        assert filenames == {"CLAUDE.md", ".mcp.json"}
+        instruction = next(f for f in out["files"] if f["filename"] == "CLAUDE.md")
+        assert "백엔드 엔지니어" in instruction["content"]
+        mcp_file = next(f for f in out["files"] if f["filename"] == ".mcp.json")
+        parsed = json.loads(mcp_file["content"])
+        assert parsed["mcpServers"]["sprintable"]["type"] in ("stdio", "http")
+        assert out["mcp_config"] == parsed
+        assert out["api_key"] is None
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_connection_artifact_no_persona_backward_compatible_real_db():
+    """무-persona 에이전트(미채용) — 지침 파일 없이 .mcp.json 만(기존 동작 회귀 없음)."""
+    from unittest.mock import MagicMock
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.routers.agents import get_agent_connection_artifact
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            agent, org_id = await _seed_agent(s, with_persona=False)
+
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            out = await get_agent_connection_artifact(
+                agent.id, runtime="claude-code", session=s,
+                auth=MagicMock(), org_id=org_id,
+            )
+
+        assert len(out["files"]) == 1
+        assert out["files"][0]["filename"] == ".mcp.json"
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_connection_artifact_connector_runtime_real_db():
+    """connector 런타임 — persona 있어도 mcp_config는 None, 포인터 파일만 추가(+ 지침 파일은 여전히
+    포함 — G4는 런타임 무관 공용 레이어)."""
+    from unittest.mock import MagicMock
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.routers.agents import get_agent_connection_artifact
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            agent, org_id = await _seed_agent(s, with_persona=True)
+
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            out = await get_agent_connection_artifact(
+                agent.id, runtime="connector", session=s,
+                auth=MagicMock(), org_id=org_id,
+            )
+
+        assert out["mcp_config"] is None
+        filenames = {f["filename"] for f in out["files"]}
+        assert filenames == {"AGENT_INSTRUCTIONS.md", "CONNECTOR_SETUP.md"}
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()

--- a/backend/tests/test_e_recruit_s5_connection_artifact_realdb.py
+++ b/backend/tests/test_e_recruit_s5_connection_artifact_realdb.py
@@ -165,3 +165,55 @@ async def test_connection_artifact_connector_runtime_real_db():
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)
         await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_connection_artifact_no_default_persona_omits_instruction_file():
+    """까심 QA RC(S5): persona가 존재해도 전부 ``is_default=False``면(POST /agent-personas가
+    is_default 생략 시 non-default 생성 가능 — "정확히 1개 default" 불변식 없음) list()의
+    ``ORDER BY is_default DESC, created_at ASC`` 정렬 때문에 가장 오래된 non-default persona가
+    [0]에 온다. 그 persona의 system_prompt를 authoritative처럼 emit하면 안 됨 — 지침 파일 생략
+    (안전 fallback, .mcp.json만)이 맞다."""
+    from unittest.mock import MagicMock
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.models.team import TeamMember
+    from app.models.agent_deployment import AgentPersona
+    from app.routers.agents import get_agent_connection_artifact
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org_id, project_id = uuid.uuid4(), uuid.uuid4()
+            await s.execute(_text("SET session_replication_role = replica"))
+            agent = TeamMember(
+                id=uuid.uuid4(), org_id=org_id, project_id=project_id, type="agent",
+                name="Test Agent", role="member",
+            )
+            s.add(agent)
+            await s.flush()
+            # 의도적으로 is_default=False인 persona만 존재(예: is_default 생략된 수기 생성).
+            persona = AgentPersona(
+                org_id=org_id, project_id=project_id, agent_id=agent.id,
+                name="Draft Persona", slug="draft",
+                system_prompt="이건 authoritative 지침이 아니어야 함.",
+                is_builtin=False, is_default=False,
+            )
+            s.add(persona)
+            await s.flush()
+            await s.commit()
+
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            out = await get_agent_connection_artifact(
+                agent.id, runtime="claude-code", session=s,
+                auth=MagicMock(), org_id=org_id,
+            )
+
+        assert len(out["files"]) == 1  # 지침 파일 생략 — .mcp.json만
+        assert out["files"][0]["filename"] == ".mcp.json"
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()

--- a/backend/tests/test_ob1_agent_onboarding_config.py
+++ b/backend/tests/test_ob1_agent_onboarding_config.py
@@ -69,8 +69,12 @@ from unittest.mock import AsyncMock, MagicMock  # noqa: E402
 
 
 def _db_returning(member):
+    """member 조회 mock + AgentPersonaRepository.list()가 쓰는 .scalars().all() 도 빈 리스트로
+    안전하게 반환(E-RECRUIT S5: connection-artifact가 이제 persona 조회도 하므로 — 이 헬퍼를 쓰는
+    기존 테스트들은 "persona 없음"(회귀 없는 기존 동작) 경로를 검증)."""
     res = MagicMock()
     res.scalar_one_or_none.return_value = member
+    res.scalars.return_value.all.return_value = []
     db = AsyncMock()
     db.execute = AsyncMock(return_value=res)
     return db
@@ -81,29 +85,79 @@ async def test_connection_artifact_returns_stdio_with_placeholder():
     from app.routers.agents import get_agent_connection_artifact
 
     agent_id = uuid.uuid4()
-    db = _db_returning(SimpleNamespace(id=agent_id))
+    db = _db_returning(SimpleNamespace(id=agent_id, project_id=uuid.uuid4()))
     out = await get_agent_connection_artifact(
         agent_id, runtime="claude-code", session=db, auth=MagicMock(), org_id=uuid.uuid4()
     )
-    # BE↔FE 계약 락: {filename, content(=문자열), agent_id, runtime}
-    assert out["filename"] == ".mcp.json"
+    # E-RECRUIT S5 BE↔FE 계약(story 4fca5a3e): {files[], mcp_config, api_key, agent_id, runtime}
     assert out["agent_id"] == str(agent_id)
     assert out["runtime"] == "claude-code"
-    assert isinstance(out["content"], str), "content 는 paste-ready json 문자열이어야(dict 아님)"
-    parsed = json.loads(out["content"])
+    assert out["api_key"] is None  # G2: GET 재방문은 placeholder만(실키 재노출 불가)
+    assert len(out["files"]) == 1  # persona 없음(mock) → .mcp.json 만(회귀 없음)
+    mcp_file = out["files"][0]
+    assert mcp_file["filename"] == ".mcp.json"
+    assert isinstance(mcp_file["content"], str), "content 는 paste-ready json 문자열이어야(dict 아님)"
+    parsed = json.loads(mcp_file["content"])
     server = parsed["mcpServers"]["sprintable"]
     assert server["type"] == "stdio"
     assert server["env"]["AGENT_API_KEY"] == "<YOUR_AGENT_API_KEY>"  # placeholder
+    assert out["mcp_config"] == parsed
+
+
+@pytest.mark.anyio
+async def test_connection_artifact_with_persona_emits_instruction_file():
+    """G4: persona(is_default)가 있으면 자율 운영 지침이 런타임별 파일명으로 files[]에 포함.
+
+    ``AgentPersonaRepository.list()`` 내부(_decorate → _get_base/_is_in_use)는 실 DB 조회를
+    거치므로, 이 라우터-계층 테스트는 그 메서드 자체를 patch(반환값만 확인)한다 — 실 DB 조회
+    시맨틱은 별도 realdb 테스트가 검증."""
+    from unittest.mock import patch
+    from app.routers.agents import get_agent_connection_artifact
+
+    agent_id = uuid.uuid4()
+    persona = SimpleNamespace(resolved_system_prompt="당신은 백엔드 엔지니어입니다.")
+    db = _db_returning(SimpleNamespace(id=agent_id, project_id=uuid.uuid4()))
+
+    with patch(
+        "app.routers.agents.AgentPersonaRepository.list",
+        new_callable=AsyncMock, return_value=[persona],
+    ):
+        out = await get_agent_connection_artifact(
+            agent_id, runtime="claude-code", session=db, auth=MagicMock(), org_id=uuid.uuid4()
+        )
+    assert len(out["files"]) == 2
+    filenames = {f["filename"] for f in out["files"]}
+    assert filenames == {"CLAUDE.md", ".mcp.json"}
+    instruction_file = next(f for f in out["files"] if f["filename"] == "CLAUDE.md")
+    assert instruction_file["content"] == "당신은 백엔드 엔지니어입니다."
+
+
+@pytest.mark.anyio
+async def test_connection_artifact_connector_runtime_returns_pointer_only():
+    """Q2(PO 확정): connector 런타임은 `.mcp.json` 없이 포인터/안내 파일만."""
+    from app.routers.agents import get_agent_connection_artifact
+
+    agent_id = uuid.uuid4()
+    db = _db_returning(SimpleNamespace(id=agent_id, project_id=uuid.uuid4()))
+    out = await get_agent_connection_artifact(
+        agent_id, runtime="connector", session=db, auth=MagicMock(), org_id=uuid.uuid4()
+    )
+    assert out["mcp_config"] is None
+    assert len(out["files"]) == 1
+    assert out["files"][0]["filename"] == "CONNECTOR_SETUP.md"
+    assert "connectors/" in out["files"][0]["content"]
 
 
 @pytest.mark.anyio
 async def test_connection_artifact_unsupported_runtime_400():
+    """Q1(PO 확정): S5 SUPPORTED_RUNTIMES는 S4 픽커 5종(claude-code/codex/gemini/cursor/connector)
+    으로 좁혔다 — RuntimeType 의 다른 9종 중 미채택 값(예: hermes)은 여전히 400."""
     from fastapi import HTTPException
 
     from app.routers.agents import get_agent_connection_artifact
     with pytest.raises(HTTPException) as ei:
         await get_agent_connection_artifact(
-            uuid.uuid4(), runtime="cursor", session=AsyncMock(), auth=MagicMock(), org_id=uuid.uuid4()
+            uuid.uuid4(), runtime="hermes", session=AsyncMock(), auth=MagicMock(), org_id=uuid.uuid4()
         )
     assert ei.value.status_code == 400
 

--- a/backend/tests/test_ob1_agent_onboarding_config.py
+++ b/backend/tests/test_ob1_agent_onboarding_config.py
@@ -115,7 +115,8 @@ async def test_connection_artifact_with_persona_emits_instruction_file():
     from app.routers.agents import get_agent_connection_artifact
 
     agent_id = uuid.uuid4()
-    persona = SimpleNamespace(resolved_system_prompt="당신은 백엔드 엔지니어입니다.")
+    # 까심 QA RC(S5): is_default=True 명시 — list()의 정렬 순서([0])만으론 default 보장 안 됨.
+    persona = SimpleNamespace(resolved_system_prompt="당신은 백엔드 엔지니어입니다.", is_default=True)
     db = _db_returning(SimpleNamespace(id=agent_id, project_id=uuid.uuid4()))
 
     with patch(
@@ -130,6 +131,28 @@ async def test_connection_artifact_with_persona_emits_instruction_file():
     assert filenames == {"CLAUDE.md", ".mcp.json"}
     instruction_file = next(f for f in out["files"] if f["filename"] == "CLAUDE.md")
     assert instruction_file["content"] == "당신은 백엔드 엔지니어입니다."
+
+
+@pytest.mark.anyio
+async def test_connection_artifact_non_default_persona_omits_instruction_file():
+    """까심 QA RC(S5): personas[0]가 is_default=False면(list() 정렬만으론 default 안 보장) 지침
+    파일을 emit하면 안 됨 — 안전 fallback으로 생략(.mcp.json만)."""
+    from unittest.mock import patch
+    from app.routers.agents import get_agent_connection_artifact
+
+    agent_id = uuid.uuid4()
+    persona = SimpleNamespace(resolved_system_prompt="이건 authoritative 아님.", is_default=False)
+    db = _db_returning(SimpleNamespace(id=agent_id, project_id=uuid.uuid4()))
+
+    with patch(
+        "app.routers.agents.AgentPersonaRepository.list",
+        new_callable=AsyncMock, return_value=[persona],
+    ):
+        out = await get_agent_connection_artifact(
+            agent_id, runtime="claude-code", session=db, auth=MagicMock(), org_id=uuid.uuid4()
+        )
+    assert len(out["files"]) == 1
+    assert out["files"][0]["filename"] == ".mcp.json"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- `SUPPORTED_RUNTIMES` expanded from claude-code-only to the S4 picker's 5 options — `claude-code` (primary) + `codex`/`gemini`/`cursor` (MCP-native, shared transport config) + `connector` (one generic catch-all for the 8 SSE dial-out adapters in `connectors/`). Scope confirmed with PO before implementing.
- **G4** (blueprint's core finding): `agent_personas.system_prompt` was stored but never delivered to any runtime. Fixed at the `connection-artifact` layer (shared by every agent, not just recruit) — an agent with a persona now gets its operating instructions as a file (`CLAUDE.md` for claude-code; generic `AGENT_INSTRUCTIONS.md` for other runtimes, per-runtime filenames deferred to S7 per PO). No persona → no instruction file (zero regression).
- `connector` runtime returns pointer/guidance only (`CONNECTOR_SETUP.md` naming the adapter folders + wiring notes) — not a `.mcp.json`, since SSE dial-out is a different protocol; assembling the actual adapter config is explicitly out of scope (S7/follow-up) per PO, matching the blueprint's "honest automation boundary."
- **BREAKING** (dev-only, coordinated with PO): `connection-artifact`'s response shape changes from `{filename, content}` to `{files[], mcp_config, api_key}` to match S3's recruit response and S4's 3-file bundle preview. `api_key` stays `null` here (GET can't re-expose a one-time key). **Flagging for Mirko's S4 FE work** — PO named shape coordination as a dependency.
- `build_agent_mcp_config`/`build_agent_mcp_config_bundle` made connector-aware (return `None`/empty instead of crashing) so `recruit()`'s existing unconditional call doesn't break now that `connector` is a valid runtime.

## Test plan
- [x] Real-Postgres verification (throwaway `pgvector/pg16`, real `AgentPersonaRepository.list()/_decorate()` path — not mocked): agent with persona → `CLAUDE.md` + `.mcp.json`; agent without persona → `.mcp.json` only; `connector` runtime → instruction file + `CONNECTOR_SETUP.md`, `mcp_config=null`.
- [x] Negative-tested the G4 file-emission guard (disabled, confirmed the test catches the predicted regression, restored).
- [x] Fixed 5 pre-existing mock-only tests broken by the new `AgentPersonaRepository` query (added `project_id` to fixtures, patched `.list`) and one that used `cursor` as its "unsupported runtime" example (no longer unsupported — switched to `hermes`).
- [x] Full backend suite: 3014 passed, 7 pre-existing failures (unrelated), 0 regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)