### PR TITLE
fix(infra): Dockerfile uv.lock pin + require COMMIT_SHA for manual migrate provisioning (E-RECRUIT S15, 19754b93)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,8 +6,12 @@ WORKDIR /app
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 # 의존성 설치 (레이어 캐싱)
-COPY pyproject.toml .
-RUN uv sync --no-dev
+# story 19754b93(E-RECRUIT S15): uv.lock 미COPY라 이미지가 실제로 lock-pin 안 됐음(까심 S13 QA
+# 실측 — alembic 1.18.5 vs uv.lock 1.18.4 드리프트). --frozen: lock 재계산 없이 uv.lock 그대로만
+# 설치(pyproject.toml과 lock이 어긋나면 조용히 재resolve 대신 build 자체를 실패시켜 드리프트를
+# 빌드 타임에 잡는다).
+COPY pyproject.toml uv.lock .
+RUN uv sync --no-dev --frozen
 
 # 소스 복사
 COPY app/ app/

--- a/backend/scripts/provision_migrate_job.sh
+++ b/backend/scripts/provision_migrate_job.sh
@@ -21,10 +21,11 @@
 #   GCP_PROJECT       (기본: sprintable-494803)
 #   GCP_REGION        (기본: asia-northeast3)
 #   AR_REPO           (기본: sprintable)
-#   COMMIT_SHA        이미지 태그 (기본: latest-<env>)
+#   COMMIT_SHA        이미지 태그 — **필수**(story 19754b93: `latest-<env>` floating 폴백 제거·
+#                     미지정 시 fail-fast, DRY_RUN=1 검증 시엔 예외)
 #   DEV_SQL_INSTANCE  (기본: sprintable-dev)
 #   PROD_SQL_INSTANCE (기본: sprintable-prod)
-#   DRY_RUN           1이면 gcloud 호출 없이 resolved config만 stdout 출력 (검증용)
+#   DRY_RUN           1이면 gcloud 호출 없이 resolved config만 stdout 출력 (검증용·COMMIT_SHA 불필요)
 
 set -euo pipefail
 
@@ -44,7 +45,18 @@ case "${ENV}" in
 esac
 
 JOB_NAME="sprintable-migrate-${ENV}"
-# dev 잡과 동일하게 env별 floating 태그를 기본 사용 (특정 SHA 고정 시 COMMIT_SHA 전달).
+# story 19754b93(E-RECRUIT S15): `${COMMIT_SHA:-latest-${ENV}}` floating-tag 폴백이 out-of-band
+# 수동 실행 시 stale 이미지에 도달할 수 있었다(#1886/S13 사고의 근본원인과 동형 — 잡이 코드와
+# 동기화 안 된 이미지를 물고 도는 것). cloudbuild.yaml(S13)의 자동 경로는 COMMIT_SHA를 항상
+# 명시 전달하므로 이 가드는 그 경로에 영향 없음 — 사람이 잊고 COMMIT_SHA 없이 수동 실행할 때만
+# fail-fast로 막는다(DRY_RUN=1 검증은 예외 — resolved config 확인 목적이라 SHA 없어도 됨).
+if [ -z "${COMMIT_SHA:-}" ] && [ "${DRY_RUN:-0}" != "1" ]; then
+    echo "ERROR: COMMIT_SHA is not set." >&2
+    echo "Manual provisioning requires an explicit image SHA — floating 'latest-${ENV}' tag fallback" >&2
+    echo "was removed (story 19754b93) to prevent stale-image drift on out-of-band runs." >&2
+    echo "Usage: COMMIT_SHA=<git-sha-or-image-tag> bash $0 ${ENV}" >&2
+    exit 1
+fi
 IMAGE_TAG="${COMMIT_SHA:-latest-${ENV}}"
 IMAGE="${GCP_REGION}-docker.pkg.dev/${GCP_PROJECT}/${AR_REPO}/backend:${IMAGE_TAG}"
 CLOUD_SQL_INSTANCE="${GCP_PROJECT}:${GCP_REGION}:${SQL_INSTANCE_NAME}"

--- a/backend/tests/test_deploy_env.py
+++ b/backend/tests/test_deploy_env.py
@@ -12,6 +12,7 @@ _SCRIPTS = os.path.join(os.path.dirname(__file__), "..", "scripts")
 _DEPLOY = os.path.join(_SCRIPTS, "deploy_backend.sh")
 _DEPLOY_FE = os.path.join(_SCRIPTS, "deploy_frontend.sh")
 _MIGRATE_JOB = os.path.join(_SCRIPTS, "provision_migrate_job.sh")
+_DOCKERFILE = os.path.join(os.path.dirname(__file__), "..", "Dockerfile")
 
 
 def _resolve(script: str, env: str, extra: dict | None = None) -> dict[str, str]:
@@ -93,6 +94,65 @@ def test_migrate_job_dev_prod_separated():
     assert dev["CLOUD_SQL_INSTANCE"] != prod["CLOUD_SQL_INSTANCE"]
     assert dev["ALEMBIC_SECRET_NAME"] != prod["ALEMBIC_SECRET_NAME"]
     assert dev["JOB_NAME"] != prod["JOB_NAME"]
+
+
+# ── story 19754b93(E-RECRUIT S15): 수동 실행 시 COMMIT_SHA 필수(latest-ENV 폴백 제거) ──────
+
+def test_migrate_job_requires_commit_sha_without_dry_run():
+    """COMMIT_SHA 없이 수동(DRY_RUN 아님) 실행 시 stale latest-ENV 태그로 조용히 폴백하지 않고
+    fail-fast — #1886/S13 사고(잡이 코드와 동기화 안 된 이미지를 물고 도는 것)의 재발 방지."""
+    environ = {k: v for k, v in os.environ.items() if k != "COMMIT_SHA"}
+    proc = subprocess.run(
+        ["bash", _MIGRATE_JOB, "dev"], capture_output=True, text=True, env=environ,
+    )
+    assert proc.returncode != 0
+    assert "COMMIT_SHA" in proc.stderr
+
+
+def test_migrate_job_dry_run_works_without_commit_sha():
+    """DRY_RUN=1(검증 목적)은 COMMIT_SHA 없이도 예외적으로 통과 — resolved config 확인용."""
+    environ = {k: v for k, v in os.environ.items() if k != "COMMIT_SHA"}
+    environ["DRY_RUN"] = "1"
+    proc = subprocess.run(
+        ["bash", _MIGRATE_JOB, "dev"], capture_output=True, text=True, env=environ, check=True,
+    )
+    assert "latest-dev" in proc.stdout
+
+
+def test_migrate_job_uses_exact_commit_sha_when_provided():
+    """COMMIT_SHA 제공 시 IMAGE가 정확히 그 태그를 쓰는지(floating latest-ENV 아님)."""
+    cfg = _resolve(_MIGRATE_JOB, "dev", {"COMMIT_SHA": "deadbeef123"})
+    assert cfg["IMAGE"].endswith(":deadbeef123")
+    assert "latest-dev" not in cfg["IMAGE"]
+
+
+# ── story 19754b93(E-RECRUIT S15): Dockerfile uv.lock lock-pin ─────────────────
+
+def test_dockerfile_copies_uv_lock_before_sync():
+    """까심 S13 QA 실측(alembic 1.18.5 vs uv.lock 1.18.4 드리프트): uv.lock을 COPY 안 하면
+    `uv sync`가 pyproject.toml 제약만으로 재resolve해 이미지가 실제로 lock-pin 안 된다."""
+    with open(_DOCKERFILE) as f:
+        lines = f.readlines()
+    # 실 Dockerfile 인스트럭션만(주석 제외) — strip 후 "COPY"로 시작해야 함.
+    copy_lock_idx = next(
+        (i for i, ln in enumerate(lines) if ln.strip().startswith("COPY") and "uv.lock" in ln), None
+    )
+    sync_idx = next(
+        (i for i, ln in enumerate(lines) if ln.strip().startswith("RUN") and "uv sync" in ln), None
+    )
+    assert copy_lock_idx is not None, "Dockerfile이 uv.lock을 COPY하지 않음(lock-pin 무효)"
+    assert sync_idx is not None
+    assert copy_lock_idx < sync_idx, "uv.lock COPY가 uv sync보다 먼저 와야 함"
+
+
+def test_dockerfile_uv_sync_uses_frozen():
+    """--frozen: lock 재계산 없이 uv.lock 그대로만 설치 — pyproject.toml과 어긋나면 조용히
+    재resolve하는 대신 build 자체가 실패해 드리프트를 빌드 타임에 잡는다."""
+    with open(_DOCKERFILE) as f:
+        src = f.read()
+    sync_lines = [ln for ln in src.splitlines() if "uv sync" in ln]
+    assert sync_lines, "uv sync 커맨드를 찾을 수 없음"
+    assert "--frozen" in sync_lines[0], f"--frozen 플래그 누락: {sync_lines[0]!r}"
 
 
 # ── deploy_backend.sh 4결함 fix (cutover 첫 prod 실행서 노출) ────────────────────


### PR DESCRIPTION
## Summary
까심's S13 QA found two deploy-reproducibility gaps (fast-follow, independent of the E-RECRUIT feature stories):

1. **Dockerfile lock-pin**: `backend/Dockerfile` never `COPY`s `uv.lock` before `uv sync`, so the image isn't actually lock-pinned — `uv sync` resolves fresh from `pyproject.toml`'s compatible-range constraints (codex measured alembic `1.18.5` installed vs `1.18.4` pinned in `uv.lock`). Fixed by copying `uv.lock` alongside `pyproject.toml` and adding `--frozen` (fails the build if lock and pyproject.toml disagree, instead of silently re-resolving).
2. **Manual migrate guard**: `provision_migrate_job.sh`'s `${COMMIT_SHA:-latest-${ENV}}` fallback let a manual, out-of-band run without `COMMIT_SHA` silently reach whatever the mutable `latest-${ENV}` tag currently points to — same failure shape as the #1886/S13 incident, just via the manual path. The automated path (`cloudbuild.yaml`, from S13) always passes `COMMIT_SHA` explicitly, so this only affects hand-run invocations — now fails fast with a clear message. `DRY_RUN=1` stays exempt (read-only config verification).

## Test plan
- [x] Real docker build reproduction: with the broken Dockerfile, alembic `1.18.5` gets installed; with the fix, exactly `1.18.4` (uv.lock's pinned version) — reproduced 까심's finding and confirmed the fix directly.
- [x] Verified all 3 script paths: no `COMMIT_SHA` + no `DRY_RUN` → fail-fast; `DRY_RUN=1` without `COMMIT_SHA` → still resolves; `COMMIT_SHA` set → image tag is the exact SHA.
- [x] Negative-tested both fixes (reverted each, confirmed the corresponding test fails with the exact predicted regression, restored).
- [x] Full backend suite: 3017 passed, 7 pre-existing failures (unrelated), 0 regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)