### PR TITLE
fix(security): cross-org IDOR in POST /api-keys/rotate — CRITICAL prod hotfix (561fd294)

### DIFF
--- a/backend/app/routers/api_keys.py
+++ b/backend/app/routers/api_keys.py
@@ -24,10 +24,21 @@ def _get_repo(session: AsyncSession = Depends(get_db)) -> ApiKeyRepository:
 @router.post("/api-keys/rotate", response_model=ApiKeyCreatedResponse, status_code=201)
 async def rotate_api_key(
     body: RotateApiKeyRequest,
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     repo: ApiKeyRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
 ) -> ApiKeyCreatedResponse:
+    """story 561fd294(CRITICAL 보안 핫픽스): cross-org IDOR fix — 자매 3엔드포인트(list/create/
+    revoke)와 달리 이 엔드포인트만 org_id dependency 자체가 없어 rotate 대상 조회가 org 무관
+    글로벌 lookup이었다 — 인증만 되면 타 org api_key_id로 그 키를 회전시켜 새 평문 시크릿을
+    탈취할 수 있었다(크로스-테넌트, prod 실존 확認·까심 실 exploit 재현). 자매 엔드포인트와
+    동일하게 ``assert_agent_owner``로 대상 키가 가리키는 agent가 호출자의 org 소속(+생성자 or
+    org admin/owner)인지 검증 — rotate 전에 반드시 통과해야 한다."""
+    existing = await repo.get(body.api_key_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="API key not found")
+    await assert_agent_owner(existing.team_member_id, session, org_id, uuid.UUID(auth.user_id))
     result = await repo.rotate(body.api_key_id)
     if result is None:
         raise HTTPException(status_code=404, detail="API key not found")

--- a/backend/tests/test_s35.py
+++ b/backend/tests/test_s35.py
@@ -124,7 +124,12 @@ async def test_rotate_key_201():
         new_plaintext = _PREFIX_MARKER + "n" * 64
 
         with patch("app.services.agent_message_policy.ensure_creator_allowlisted", new_callable=AsyncMock), \
+             patch("app.routers.api_keys.assert_agent_owner", new_callable=AsyncMock), \
+             patch("app.repositories.api_key.ApiKeyRepository.get", new_callable=AsyncMock) as mock_get, \
              patch("app.repositories.api_key.ApiKeyRepository.rotate", new_callable=AsyncMock) as mock_rotate:
+            # story 561fd294(CRITICAL 보안): rotate_api_key가 이제 rotate() 전에 get()으로 대상
+            # 키의 team_member_id를 확인해 ownership guard(assert_agent_owner)를 건다.
+            mock_get.return_value = _mock_key()
             mock_rotate.return_value = (new_key, new_plaintext)
 
             async with client as c:
@@ -139,15 +144,60 @@ async def test_rotate_key_201():
 
 @pytest.mark.anyio
 async def test_rotate_key_404():
+    """존재하는 키(get 성공)인데 rotate가 None인 케이스 — 404 매핑."""
     client, session, app = await _client()
     try:
-        with patch("app.repositories.api_key.ApiKeyRepository.rotate", new_callable=AsyncMock) as mock_rotate:
+        with patch("app.routers.api_keys.assert_agent_owner", new_callable=AsyncMock), \
+             patch("app.repositories.api_key.ApiKeyRepository.get", new_callable=AsyncMock) as mock_get, \
+             patch("app.repositories.api_key.ApiKeyRepository.rotate", new_callable=AsyncMock) as mock_rotate:
+            mock_get.return_value = _mock_key()
             mock_rotate.return_value = None
 
             async with client as c:
                 resp = await c.post("/api/v2/api-keys/rotate", json={"api_key_id": str(uuid.uuid4())})
 
         assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_rotate_key_404_when_key_missing():
+    """story 561fd294: get()이 애초에 키를 못 찾으면 ownership/rotate 호출 전에 404."""
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.api_key.ApiKeyRepository.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = None
+
+            async with client as c:
+                resp = await c.post("/api/v2/api-keys/rotate", json={"api_key_id": str(uuid.uuid4())})
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_rotate_key_rejects_cross_org_key_403_or_404():
+    """story 561fd294(CRITICAL 보안): 대상 키가 가리키는 agent가 호출자의 org 소속이 아니면
+    (assert_agent_owner가 org_id 불일치로 agent 조회 실패→404, 또는 소유자 아니면 403) rotate가
+    실행되면 안 된다 — 크로스-org IDOR 회귀 가드. assert_agent_owner가 실제로 HTTPException을
+    던지는지로 가드 실효성을 검증(단순 존재 확인이 아니라 실제 예외 발생 확인)."""
+    from fastapi import HTTPException
+
+    client, session, app = await _client()
+    try:
+        with patch("app.routers.api_keys.assert_agent_owner", new_callable=AsyncMock) as mock_owner, \
+             patch("app.repositories.api_key.ApiKeyRepository.get", new_callable=AsyncMock) as mock_get, \
+             patch("app.repositories.api_key.ApiKeyRepository.rotate", new_callable=AsyncMock) as mock_rotate:
+            mock_get.return_value = _mock_key()  # 다른 org 소속 agent의 키(team_member_id=AGENT_ID)
+            mock_owner.side_effect = HTTPException(status_code=403, detail="Not the owner of this agent")
+
+            async with client as c:
+                resp = await c.post("/api/v2/api-keys/rotate", json={"api_key_id": str(KEY_ID)})
+
+        assert resp.status_code == 403
+        mock_rotate.assert_not_awaited()  # ownership 실패 시 rotate()가 아예 호출되면 안 됨
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary
**Prod hotfix.** Same vulnerability as dev PR #1902, applied as a minimal hand-adapted diff against main's current (pre-E-RECRUIT, simpler) code rather than a direct cherry-pick — develop's fix commit sits on top of S3's advisory-lock/CAS additions that don't exist on main, so cherry-picking as-is wouldn't apply cleanly and would pull in unrelated scope.

`rotate_api_key` was the one endpoint with no `org_id` dependency — its three sibling endpoints (list/create/revoke) all call `assert_agent_owner` before touching a key; rotate went straight to `repo.rotate(body.api_key_id)` with no org scoping. Any authenticated caller who knew/enumerated another org's `api_key_id` could rotate it, revoking the victim's key and receiving a fresh plaintext secret for an agent they had no relationship to. PO confirmed this exact path is live in prod via the current openapi spec.

Fix: added `org_id: Depends(get_verified_org_id)`, resolved the target key via `repo.get()`, then called `assert_agent_owner(existing.team_member_id, ...)` before rotating — same pattern as the 3 sibling endpoints.

## Test plan
- [x] Updated 2 existing rotate tests (main didn't have a pre-rotate `get()` step — added the mock) and added a cross-org regression test asserting `rotate()` is never awaited when ownership fails.
- [x] Negative-tested by removing the `assert_agent_owner` call: the regression test crashes trying to unpack a `None` rotate result instead of cleanly 403'ing — confirming the guard is what actually blocks the cross-org path.
- [x] Full suite (main): 2980 passed, 7 pre-existing failures (unrelated — same set as develop's known failures), 0 regressions.

No migration. Scope: this fix only — E-RECRUIT epic changes stay on develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)