### PR TITLE
fix(security): S19 Phase A — caller-ownership IDOR fixes (recruit/verify-connection + team_members)

### DIFF
--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.dependencies.ownership import assert_agent_owner
 from app.models.project import Project
 from app.models.team import TeamMember
 from app.repositories.agent_persona import AgentPersonaRepository
@@ -269,10 +270,13 @@ async def recruit_agent_endpoint(
 
     G1: 에이전트가 없으면 FE가 먼저 기존 ``POST /agents``를 재사용해 만든다 — 이 엔드포인트는
     ``agent_id``가 이미 존재함을 전제(별도 인라인 분기 없음, 경로 divergence 방지).
+
+    S19(#8, 최고임팩트 MUST): 이전엔 org-scope 조회(`_fetch_org_agent`)만 있고 caller-ownership
+    확인이 없어 — org 내 임의 멤버가 자신이 만들지도 관리자도 아닌 agent를 재채용(키 로테이션+
+    role/system_prompt 변경, 채용 엔드포인트 자체 탈취)할 수 있었다. team_members.py 업데이트/
+    deactivate와 동일한 `assert_agent_owner`(생성자 또는 org-admin)로 닫는다.
     """
-    member = await _fetch_org_agent(session, agent_id, org_id)
-    if member is None:
-        raise HTTPException(status_code=404, detail="Agent not found")
+    member = await assert_agent_owner(agent_id, session, org_id, uuid.UUID(auth.user_id))
 
     if body.runtime not in SUPPORTED_RUNTIMES:
         raise HTTPException(status_code=400, detail=f"unsupported runtime: {body.runtime}")
@@ -342,10 +346,11 @@ async def verify_agent_connection(
     이 가드보다 먼저면 미배정 에이전트가 stdio=400/http=200으로 갈렸다(까심 QA). project 스코프가
     없는 에이전트는애초에 "연결 검증"이 의미가 없으므로(heartbeat 조차 project 컨텍스트 하 tool
     호출을 전제) 두 transport 모두 이 가드를 먼저 통과해야 한다.
+
+    S19(#9): recruit(#8)과 동일 갭 — org-scope만으로는 임의 org 멤버가 남의 agent 연결검증을
+    트리거할 수 있었다. `assert_agent_owner`로 닫는다.
     """
-    member = await _fetch_org_agent(session, agent_id, org_id)
-    if member is None:
-        raise HTTPException(status_code=404, detail="Agent not found")
+    member = await assert_agent_owner(agent_id, session, org_id, uuid.UUID(auth.user_id))
     if not member.project_id:
         raise HTTPException(status_code=400, detail="agent has no project scope to verify")
 

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -483,12 +483,21 @@ async def get_pending_events(
     include_recent_delivered_minutes: int = Query(default=30, le=120),
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[EventResponse]:
     """GET /api/v2/events/pending — 수신자별 pending + 최근 N분 delivered 이벤트 목록.
 
     include_recent_delivered_minutes: SSE로 delivered 마킹된 이벤트도 최근 N분 이내라면 반환.
     → SSE 전달과 poll_events 폴링 간 충돌(갭 2) 해소.
+
+    산티아고 SME 최종 MUST(S19): recipient_id 쿼리로 타 member 이벤트(payload/sender/source)를
+    auth·recipient 검증 없이 읽을 수 있었다 — mark_delivered(write)는 recipient==caller로
+    닫혔는데 같은 recipient 축의 이 read fallback이 열려있었다. 동일 패턴(순수 self, admin
+    대리열람 흐름 없음)으로 닫는다.
     """
+    await assert_caller_is_member(
+        recipient_id, auth, db, org_id, detail="Cannot read another member's events",
+    )
     cutoff = datetime.now(timezone.utc) - timedelta(minutes=include_recent_delivered_minutes)
     status_filter = or_(
         Event.status == "pending",

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -28,8 +28,9 @@ from app.dependencies.auth import (
     get_verified_org_id_streaming,
 )
 from app.dependencies.database import get_db
+from app.dependencies.ownership import _is_org_admin
 from app.models.event import Event
-from app.services.member_resolver import resolve_member_identity
+from app.services.member_resolver import assert_caller_is_member, resolve_member_identity
 
 router = APIRouter(prefix="/api/v2/events", tags=["events"])
 
@@ -405,13 +406,26 @@ async def create_event(
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> EventResponse:
     """POST /api/v2/events — 이벤트 생성 (내부용).
 
     recipient가 SSE 연결 중이면 즉시 전달 + status=delivered.
     미연결이면 status=pending 유지.
     Channel Router(S-A6)로 preference 기반 채널 결정 후 전달.
+
+    S19(SHOULD, PO 포함 승인): sender_id가 검증 없이 body에서 그대로 신뢰돼 caller가 임의
+    sender로 이벤트를 위조(임퍼스네이션)할 수 있었다. sender_id가 명시되면 caller 본인과
+    일치해야만 허용(시스템 이벤트의 sender_id=None 케이스는 그대로 무변경).
+
+    S19(발견·회귀수정): axis-safe 비교(assert_caller_is_member) 사용 — resolve_member()/.id
+    직접비교는 휴먼 JWT caller에서 축이 어긋나 본인 sender_id 지정도 403날 수 있었다.
     """
+    if body.sender_id is not None:
+        await assert_caller_is_member(
+            body.sender_id, auth, db, org_id, detail="sender_id must match the caller's own identity",
+        )
+
     # recipient가 동일 org 소속인지 + type 확정
     # E-MEMBER-SSOT Phase 0: grant-only 휴먼(org_member)도 수신자로 허용
     recipient = await resolve_member_identity(body.recipient_id, org_id, db)
@@ -499,14 +513,26 @@ async def mark_delivered(
     event_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> EventResponse:
-    """PATCH /api/v2/events/{id}/delivered — 전달 완료 마킹."""
+    """PATCH /api/v2/events/{id}/delivered — 전달 완료 마킹.
+
+    S19(#7 MUST): org-scope만 있고 recipient 확인이 없어 누구나 타 member의 이벤트를
+    delivered로 마킹(알림 은폐)할 수 있었다. caller==recipient 강제(axis-safe).
+
+    S19(발견·회귀수정): resolve_member()/.id 직접비교는 휴먼 JWT caller의 axis가 어긋나 본인
+    이벤트도 403날 수 있었다 — assert_caller_is_member로 교체.
+    """
     result = await db.execute(
         select(Event).where(Event.id == event_id, Event.org_id == org_id)
     )
     event = result.scalar_one_or_none()
     if event is None:
         raise HTTPException(status_code=404, detail="Event not found")
+
+    await assert_caller_is_member(
+        event.recipient_id, auth, db, org_id, detail="Not the recipient of this event",
+    )
 
     event.status = "delivered"
     event.delivered_at = datetime.now(timezone.utc)
@@ -554,6 +580,13 @@ async def expire_stale_events_core(
 async def expire_stale_events(
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
-    """POST /api/v2/events/expire-stale — 30일 초과 pending → expired, 7일 초과 delivered 삭제."""
+    """POST /api/v2/events/expire-stale — 30일 초과 pending → expired, 7일 초과 delivered 삭제.
+
+    S19(SHOULD, PO 포함 승인): per-resource ownership 문제가 아니라 privilege 게이트 자체가
+    없어 org 내 임의 멤버가 org 전체 이벤트 만료/삭제를 강제할 수 있었다. org-admin 전용으로 닫는다.
+    """
+    if not await _is_org_admin(db, org_id, uuid.UUID(auth.user_id)):
+        raise HTTPException(status_code=403, detail="org admin/owner required")
     return await expire_stale_events_core(db, org_id)

--- a/backend/app/routers/file_locks.py
+++ b/backend/app/routers/file_locks.py
@@ -16,7 +16,7 @@ from app.dependencies.database import get_db
 from app.models.file_lock import FileLock
 from app.models.team import TeamMember
 from app.routers.events import publish_event
-from app.services.member_resolver import resolve_member
+from app.services.member_resolver import assert_caller_is_member
 from app.services.webhook_dispatch import fire_webhooks
 
 router = APIRouter(tags=["file-locks"])
@@ -185,8 +185,13 @@ async def lock_files(
     """AC1/3: 파일 lock 등록 + 충돌 시 warning 반환.
 
     S17(산티아고 SME MUST②): member 조회에 org_id 필터 추가(타 org member_id로 org_id/project_id
-    불일치 row 생성 방지) + caller self-scope 확인(자기 자신 명의로만 lock 가능 — canonical
-    resolve_member 축 사용, TeamMember.id 문자열 비교로 우회하지 않게 [[member_bound_resource_resolve_member_axis]]).
+    불일치 row 생성 방지) + caller self-scope 확인(자기 자신 명의로만 lock 가능).
+
+    S19(발견·회귀수정): self-scope는 axis-safe해야 한다 — resolve_member()/.id 직접비교는
+    휴먼 JWT caller에게 org_member.id(별개 테이블 PK)를 반환하는데, 이 path의 member_id는
+    team_members뷰 id(members anchor)라 축이 달라 휴먼 본인이 자기 파일을 lock해도 항상
+    403났다(agent API키 caller만 실증했던 맹점 — auth.user_id가 이미 team_members.id라 안
+    드러남). assert_caller_is_member(agent=id 직접비교·human=user_id 비교)로 교체.
 
     S17 RC②(까심 델타 MED): member 조회에 project_id 힌트 없이 .limit(1)만 쓰면 멀티프로젝트
     휴먼이 엉뚱한 project row로 스코프돼 실제 충돌(타 프로젝트 락)을 놓칠 수 있었다 — caller의
@@ -197,9 +202,7 @@ async def lock_files(
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
 
-    caller = await resolve_member(auth, org_id, session, project_id=member.project_id)
-    if caller.id != member_id:
-        raise HTTPException(status_code=403, detail="Cannot lock files as another member")
+    await assert_caller_is_member(member_id, auth, session, org_id, detail="Cannot lock files as another member")
 
     # AC3: 충돌 체크
     conflicts = await _find_conflicts(session, org_id, member.project_id, member_id, body.file_paths)
@@ -248,14 +251,15 @@ async def unlock_files(
     여러 project에 동일 file_path를 lock 중이면, 한 project 컨텍스트에서의 unlock이 **다른
     project의 lock까지** 함께 release해 advisory-lock의 project 단위 무결성이 깨졌다(권한상승은
     아니고 데이터 무결성 문제). member.project_id(_fetch_scoped_member가 결정한 그 project)로 좁힌다.
+
+    S19(발견·회귀수정): self-scope를 axis-safe한 assert_caller_is_member로 교체(lock_files와
+    동일 사유 — resolve_member()/.id 직접비교는 휴먼 JWT caller의 axis가 어긋나 본인도 403남).
     """
     member = await _fetch_scoped_member(session, member_id, org_id, auth)
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
 
-    caller = await resolve_member(auth, org_id, session, project_id=member.project_id)
-    if caller.id != member_id:
-        raise HTTPException(status_code=403, detail="Cannot unlock files as another member")
+    await assert_caller_is_member(member_id, auth, session, org_id, detail="Cannot unlock files as another member")
 
     now = datetime.now(timezone.utc)
     await session.execute(

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.dependencies.ownership import _is_org_admin
 from app.models.team import TeamMember
 from app.repositories.notification import InboxRepository, NotificationRepository, NotificationSettingRepository
 from app.schemas.notification import (
@@ -15,8 +16,26 @@ from app.schemas.notification import (
     ResolveInboxItem,
     UpsertNotificationSetting,
 )
+from app.services.member_resolver import assert_caller_is_member, is_caller_member
 
 router = APIRouter(prefix="/api/v2", tags=["notifications"])
+
+
+async def _assert_self_or_org_admin(
+    member_id: uuid.UUID, auth: AuthContext, session: AsyncSession, org_id: uuid.UUID,
+) -> None:
+    """S19(#4-#6 MUST): notifications/inbox 리소스가 caller-ownership 확인 없이 임의 member_id를
+    받아들이던 갭 — self(axis-safe) 또는 org-admin만 허용한다.
+
+    S19(발견·회귀수정): resolve_member()/.id 직접비교(및 그 대체였던 resolve_auth_member 단독
+    사용)는 휴먼 JWT caller에서 축이 어긋날 수 있다 — is_caller_member(agent=id 직접비교·
+    human=team_members뷰의 user_id 컬럼과 비교)로 axis-safe하게 판정한다.
+    """
+    if await is_caller_member(member_id, auth, session, org_id):
+        return
+    if await _is_org_admin(session, org_id, uuid.UUID(auth.user_id)):
+        return
+    raise HTTPException(status_code=403, detail="Not authorized for this member")
 
 
 async def _resolve_notification_user_id(auth: AuthContext, db: AsyncSession) -> uuid.UUID:
@@ -133,7 +152,11 @@ async def upsert_notification_setting(
     body: UpsertNotificationSetting = ...,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> NotificationSettingResponse:
+    """S19(#4 MUST): member_id 쿼리파람에 caller-ownership 확인이 없어 누구나 타 member의 알림
+    설정을 덮어쓸 수 있었다. self-or-org-admin 게이트 추가."""
+    await _assert_self_or_org_admin(member_id, auth, session, org_id)
     repo = NotificationSettingRepository(session)
     setting = await repo.upsert(
         org_id=org_id,
@@ -168,25 +191,54 @@ async def list_incoming(
 async def resolve_inbox_item(
     id: uuid.UUID,
     body: ResolveInboxItem,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
     repo: InboxRepository = Depends(_inbox_repo),
 ) -> InboxItemResponse:
-    item = await repo.resolve(
+    """S19(#5 MUST): auth 파라미터 자체가 없어 caller가 이 inbox item의 assignee인지 확인이
+    전혀 없었다 — 누구나 타 member의 inbox item을 resolve할 수 있었고, `resolved_by` 바디값을
+    임의로 스푸핑할 수도 있었다. assignee==caller 강제(axis-safe) + resolved_by는 확인된
+    assignee_member_id에서 서버-파생(바디값 무시 — identity는 서버가 결정, 클라이언트가
+    주장하는 게 아니다). assert_caller_is_member 통과 = caller.id == assignee_member_id가
+    이미 확정이므로 별도 caller 재조회 없이 그 값을 그대로 쓴다."""
+    item = await repo.get(id)
+    if item is None:
+        raise HTTPException(status_code=404, detail="InboxItem not found")
+
+    await assert_caller_is_member(
+        item.assignee_member_id, auth, session, org_id, detail="Not the assignee of this inbox item",
+    )
+
+    resolved = await repo.resolve(
         id=id,
-        resolved_by=body.resolved_by,
+        resolved_by=item.assignee_member_id,
         resolved_option_id=body.resolved_option_id,
         resolved_note=body.resolved_note,
     )
-    if item is None:
+    if resolved is None:
         raise HTTPException(status_code=404, detail="InboxItem not found")
-    return InboxItemResponse.model_validate(item)
+    return InboxItemResponse.model_validate(resolved)
 
 
 @router.post("/inbox/{id}/dismiss", response_model=InboxItemResponse)
 async def dismiss_inbox_item(
     id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
     repo: InboxRepository = Depends(_inbox_repo),
 ) -> InboxItemResponse:
-    item = await repo.dismiss(id=id)
+    """S19(#6 MUST): resolve와 동일 갭 — assignee==caller 강제(axis-safe)."""
+    item = await repo.get(id)
     if item is None:
         raise HTTPException(status_code=404, detail="InboxItem not found")
-    return InboxItemResponse.model_validate(item)
+
+    await assert_caller_is_member(
+        item.assignee_member_id, auth, session, org_id, detail="Not the assignee of this inbox item",
+    )
+
+    dismissed = await repo.dismiss(id=id)
+    if dismissed is None:
+        raise HTTPException(status_code=404, detail="InboxItem not found")
+    return InboxItemResponse.model_validate(dismissed)

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -139,8 +139,12 @@ async def mark_read(
 async def get_notification_settings(
     member_id: uuid.UUID = Query(...),
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[NotificationSettingResponse]:
+    """까심 델타 재QA HIGH(S19): write(PUT)만 닫히고 이 GET은 무가드로 남아 타 member 알림설정을
+    누구나 조회할 수 있었다(정보노출). PUT과 동일한 self-or-org-admin 게이트 적용."""
+    await _assert_self_or_org_admin(member_id, auth, session, org_id)
     repo = NotificationSettingRepository(session)
     settings = await repo.get_by_member(member_id=member_id)
     return [NotificationSettingResponse.model_validate(s) for s in settings]
@@ -172,8 +176,14 @@ async def upsert_notification_setting(
 async def list_inbox(
     assignee_member_id: uuid.UUID = Query(...),
     state: str | None = Query(default=None),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
     repo: InboxRepository = Depends(_inbox_repo),
 ) -> list[InboxItemResponse]:
+    """까심 델타 재QA HIGH(S19): 무가드로 남아 타 member의 inbox를 누구나 조회할 수 있었다
+    (정보노출). resolve/dismiss와 동일한 self-or-org-admin 게이트 적용."""
+    await _assert_self_or_org_admin(assignee_member_id, auth, session, org_id)
     items = await repo.list(assignee_member_id=assignee_member_id, state=state)
     return [InboxItemResponse.model_validate(i) for i in items]
 
@@ -181,8 +191,13 @@ async def list_inbox(
 @router.get("/inbox/incoming", response_model=list[InboxItemResponse])
 async def list_incoming(
     assignee_member_id: uuid.UUID = Query(...),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
     repo: InboxRepository = Depends(_inbox_repo),
 ) -> list[InboxItemResponse]:
+    """까심 델타 재QA HIGH(S19): list_inbox와 동일 갭 — self-or-org-admin 게이트 적용."""
+    await _assert_self_or_org_admin(assignee_member_id, auth, session, org_id)
     items = await repo.list_incoming(assignee_member_id=assignee_member_id)
     return [InboxItemResponse.model_validate(i) for i in items]
 

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -17,7 +17,7 @@ from app.schemas.team_member import (
     ActiveStorySummary, TeamMemberCreate, TeamMemberResponse, TeamMemberUpdate,
 )
 from app.services.agent_onboarding_config import build_agent_mcp_config_bundle
-from app.services.member_resolver import resolve_member
+from app.services.member_resolver import assert_caller_is_member, is_caller_member
 
 
 class ClaimBody(BaseModel):
@@ -337,11 +337,21 @@ async def get_team_member(
     return TeamMemberResponse.model_validate(member)
 
 
+_SELF_EDITABLE_HUMAN_FIELDS: frozenset[str] = frozenset({"name", "avatar_url", "color"})
+
+
 async def _assert_can_manage_human(
     member: TeamMember, session: AsyncSession, org_id: uuid.UUID, auth: AuthContext,
+    data: dict | None = None,
 ) -> None:
-    """S19(#2/#3 MUST): human 대상 mutation(update/deactivate)이 caller-ownership 확인 없이
-    통과되던 갭 — self(본인) 또는 org-admin만 허용한다.
+    """S19(#2/#3 MUST + 산티아고 Phase A SME (c) MUST): human 대상 mutation(update/deactivate)이
+    caller-ownership 확인 없이 통과되던 갭 — self(본인) 또는 org-admin만 허용한다.
+
+    산티아고 (c): self 경로가 ``TeamMemberUpdate`` 전 필드를 허용해 self가 자기 ``role``/
+    ``can_manage_members``/``is_active``/``agent_config`` 등을 스스로 바꿔 권한상승할 수
+    있었다(update 한정 — deactivate는 ``data=None``으로 호출돼 필드 제약이 없다. 이진 동작이라
+    승격 벡터가 없기 때문). self가 프로필 3종(name/avatar_url/color) 외 필드를 건드리면
+    org-admin도 함께 요구한다 — allowlist 방식이라 스키마에 필드가 추가돼도 기본이 admin-only.
 
     ``auth.user_id``는 JWT 휴먼이면 users.id(=TeamMember.user_id와 직접 비교 가능), API키
     에이전트면 그 에이전트 자신의 team_member.id다 — 후자는 어떤 human의 user_id/org_members
@@ -349,10 +359,17 @@ async def _assert_can_manage_human(
     관리할 수 없다"는 의도된 거부까지 자연히 성립한다.
     """
     caller_id = uuid.UUID(auth.user_id)
-    if member.user_id == caller_id:
-        return
+    is_self = member.user_id == caller_id
+    if is_self:
+        if data is None or not (set(data.keys()) - _SELF_EDITABLE_HUMAN_FIELDS):
+            return
     if await _is_org_admin(session, org_id, caller_id):
         return
+    if is_self:
+        raise HTTPException(
+            status_code=403,
+            detail="Self cannot modify authority fields (role/is_active/can_manage_members/agent_config/etc.)",
+        )
     raise HTTPException(status_code=403, detail="Not authorized to manage this member")
 
 
@@ -365,16 +382,16 @@ async def update_team_member(
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> TeamMemberResponse:
     """S19(#2 MUST): human 경로에 caller-ownership 확인이 아예 없어 org 내 임의 멤버가 타 human의
-    role/color/name 등을 수정할 수 있었다. self-or-org-admin 게이트 추가."""
+    role/color/name 등을 수정할 수 있었다. self-or-org-admin 게이트 추가 — self는 프로필 필드만."""
     repo = TeamMemberRepository(session, org_id)
     member = await repo.get(id)
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
+    data = body.model_dump(exclude_unset=True)
     if member.type == "agent":
         await assert_agent_owner(id, session, org_id, uuid.UUID(auth.user_id))
     else:
-        await _assert_can_manage_human(member, session, org_id, auth)
-    data = body.model_dump(exclude_unset=True)
+        await _assert_can_manage_human(member, session, org_id, auth, data=data)
     # AC3-4 2-2: team_members 뷰 — 필드를 앵커 테이블로 라우팅(anchor-only). expire 후 뷰 재조회로 갱신값 반영.
     await repo.apply_anchor_update(member, data)
     session.expire(member)
@@ -393,16 +410,18 @@ async def heartbeat(
 
     S19(#1 MUST): auth 파라미터 자체가 없어 caller 확인이 전혀 없었다 — 누구나 임의 member의
     presence(last_seen_at/agent_status)를 스푸핑할 수 있었다. claim/unclaim과 동일한
-    resolve_member 기반 self-scope로 닫는다(대리 heartbeat 흐름 없음).
+    axis-safe self-scope(assert_caller_is_member)로 닫는다(대리 heartbeat 흐름 없음).
+
+    S19(발견·회귀수정): resolve_member()/.id 직접비교는 휴먼 JWT caller에서 OrgMember.id를
+    반환해 이 path의 team_members뷰 id와 축이 달라 본인 heartbeat도 403났다 —
+    assert_caller_is_member(agent=id 직접비교·human=user_id 비교)로 axis-safe하게 교체.
     """
     repo = TeamMemberRepository(session, org_id)
     member = await repo.get(id)
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
 
-    caller = await resolve_member(auth, org_id, session, project_id=member.project_id)
-    if caller.id != id:
-        raise HTTPException(status_code=403, detail="Cannot heartbeat as another member")
+    await assert_caller_is_member(id, auth, session, org_id, detail="Cannot heartbeat as another member")
 
     now = datetime.now(timezone.utc)
     # AC3-4 2-2: team_members 뷰 — presence는 agent_project_profiles가 유일 소스(anchor-only).
@@ -423,17 +442,17 @@ async def claim_story(
 
     S17(까심 델타 RC HIGH — file_locks.py와 같은 취약 클래스): auth 파라미터가 아예 없어
     caller가 이 member 본인인지 확인 0이었다 — 다른 멤버 명의로 claim(active_story/participation
-    오염) 가능했음. resolve_member() 기반 self-scope 확인 추가(관리자 대리 claim 흐름 없음 확인 후
-    순수 self-scope로 닫음).
+    오염) 가능했음(관리자 대리 claim 흐름 없음 확인 후 순수 self-scope로 닫음).
+
+    S19(발견·회귀수정): resolve_member()/.id 직접비교는 휴먼 JWT caller의 axis(OrgMember.id)가
+    이 path의 team_members뷰 id와 달라 본인 claim도 403났다 — assert_caller_is_member로 교체.
     """
     repo = TeamMemberRepository(session, org_id)
     member = await repo.get(id)
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
 
-    caller = await resolve_member(auth, org_id, session, project_id=member.project_id)
-    if caller.id != id:
-        raise HTTPException(status_code=403, detail="Cannot claim as another member")
+    await assert_caller_is_member(id, auth, session, org_id, detail="Cannot claim as another member")
 
     # AC3: story가 해당 project에 존재하는지 검증
     story_result = await session.execute(
@@ -466,15 +485,15 @@ async def unclaim_story(
     S17(까심 델타 RC HIGH — 파일락 경계의 마지막 구멍): auth 파라미터가 아예 없어 caller가
     본인인지 확인 0 — Bob이 Alice 명의로 unclaim 호출 시 release_all_file_locks(session, id)가
     org 필터도 없이 Alice의 모든 file lock을 해제할 수 있었다. claim과 동일 self-scope 패턴 적용.
+
+    S19(발견·회귀수정): assert_caller_is_member로 axis-safe 교체(claim과 동일 사유).
     """
     repo = TeamMemberRepository(session, org_id)
     member = await repo.get(id)
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
 
-    caller = await resolve_member(auth, org_id, session, project_id=member.project_id)
-    if caller.id != id:
-        raise HTTPException(status_code=403, detail="Cannot unclaim as another member")
+    await assert_caller_is_member(id, auth, session, org_id, detail="Cannot unclaim as another member")
 
     # AC3-4 2-2: anchor-only — agent_project_profiles가 presence 유일 소스.
     from app.services.agent_anchor_sync import sync_agent_profile_presence

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
-from app.dependencies.ownership import assert_agent_owner
+from app.dependencies.ownership import _is_org_admin, assert_agent_owner
 from app.models.pm import Story
 from app.models.team import TeamMember
 from app.repositories.team_member import TeamMemberRepository
@@ -337,6 +337,25 @@ async def get_team_member(
     return TeamMemberResponse.model_validate(member)
 
 
+async def _assert_can_manage_human(
+    member: TeamMember, session: AsyncSession, org_id: uuid.UUID, auth: AuthContext,
+) -> None:
+    """S19(#2/#3 MUST): human 대상 mutation(update/deactivate)이 caller-ownership 확인 없이
+    통과되던 갭 — self(본인) 또는 org-admin만 허용한다.
+
+    ``auth.user_id``는 JWT 휴먼이면 users.id(=TeamMember.user_id와 직접 비교 가능), API키
+    에이전트면 그 에이전트 자신의 team_member.id다 — 후자는 어떤 human의 user_id/org_members
+    행과도 절대 일치하지 않으므로 별도 is_api_key 분기 없이 이 비교만으로 "에이전트가 human을
+    관리할 수 없다"는 의도된 거부까지 자연히 성립한다.
+    """
+    caller_id = uuid.UUID(auth.user_id)
+    if member.user_id == caller_id:
+        return
+    if await _is_org_admin(session, org_id, caller_id):
+        return
+    raise HTTPException(status_code=403, detail="Not authorized to manage this member")
+
+
 @router.patch("/{id}", response_model=TeamMemberResponse)
 async def update_team_member(
     id: uuid.UUID,
@@ -345,12 +364,16 @@ async def update_team_member(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> TeamMemberResponse:
+    """S19(#2 MUST): human 경로에 caller-ownership 확인이 아예 없어 org 내 임의 멤버가 타 human의
+    role/color/name 등을 수정할 수 있었다. self-or-org-admin 게이트 추가."""
     repo = TeamMemberRepository(session, org_id)
     member = await repo.get(id)
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
     if member.type == "agent":
         await assert_agent_owner(id, session, org_id, uuid.UUID(auth.user_id))
+    else:
+        await _assert_can_manage_human(member, session, org_id, auth)
     data = body.model_dump(exclude_unset=True)
     # AC3-4 2-2: team_members 뷰 — 필드를 앵커 테이블로 라우팅(anchor-only). expire 후 뷰 재조회로 갱신값 반영.
     await repo.apply_anchor_update(member, data)
@@ -364,12 +387,23 @@ async def heartbeat(
     id: uuid.UUID,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
-    """AC1/2: last_seen_at = NOW(), agent_status = online 갱신."""
+    """AC1/2: last_seen_at = NOW(), agent_status = online 갱신.
+
+    S19(#1 MUST): auth 파라미터 자체가 없어 caller 확인이 전혀 없었다 — 누구나 임의 member의
+    presence(last_seen_at/agent_status)를 스푸핑할 수 있었다. claim/unclaim과 동일한
+    resolve_member 기반 self-scope로 닫는다(대리 heartbeat 흐름 없음).
+    """
     repo = TeamMemberRepository(session, org_id)
     member = await repo.get(id)
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
+
+    caller = await resolve_member(auth, org_id, session, project_id=member.project_id)
+    if caller.id != id:
+        raise HTTPException(status_code=403, detail="Cannot heartbeat as another member")
+
     now = datetime.now(timezone.utc)
     # AC3-4 2-2: team_members 뷰 — presence는 agent_project_profiles가 유일 소스(anchor-only).
     from app.services.agent_anchor_sync import sync_agent_profile_presence
@@ -458,12 +492,16 @@ async def deactivate_team_member(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
+    """S19(#3 MUST): human 경로에 caller-ownership 확인이 없어 org 내 임의 멤버가 타 human을
+    deactivate할 수 있었다. self-or-org-admin 게이트 추가(update_team_member와 동일 패턴)."""
     repo = TeamMemberRepository(session, org_id)
     member = await repo.get(id)
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
     if member.type == "agent":
         await assert_agent_owner(id, session, org_id, uuid.UUID(auth.user_id))
+    else:
+        await _assert_can_manage_human(member, session, org_id, auth)
     ok = await repo.deactivate(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Team member not found")

--- a/backend/app/services/member_resolver.py
+++ b/backend/app/services/member_resolver.py
@@ -387,6 +387,44 @@ async def _lookup_members_by_ids_anchor(
     return result
 
 
+async def is_caller_member(
+    member_id: uuid.UUID, auth: AuthContext, session: AsyncSession, org_id: uuid.UUID,
+) -> bool:
+    """S19(발견·회귀수정): caller가 team_members뷰 id 공간의 ``member_id`` 본인인지 axis-safe하게
+    확인한다.
+
+    ``resolve_member(auth,...).id != member_id`` 직접비교는 API키 에이전트(auth.user_id가 이미
+    team_member.id)엔 맞지만, JWT 휴먼은 ``resolve_member``가 ``OrgMember.id``(별개 테이블 PK)를
+    반환해 이 path의 ``member_id``(=members anchor/team_members뷰 id)와 축이 달라 **본인이 본인
+    claim/heartbeat/lock을 호출해도 403**나는 회귀를 냈다(까심의 "human 회귀 없음" 판정은 검증
+    시드가 같은 id를 재사용한 거짓양성 — 실 서로 다른 id로 재현하면 드러남).
+
+    axis-safe 비교: agent(API키)는 ``auth.user_id`` 자체가 이미 team_member.id이므로 직접비교.
+    human(JWT)은 ``auth.user_id``=users.id이므로, member_id가 가리키는 team_members뷰 행의
+    ``user_id`` 컬럼(동일 users.id 공간)과 비교한다 — org_member/members 어느 쪽도 개입하지 않음.
+    """
+    caller_id = uuid.UUID(auth.user_id)
+    is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
+    if is_api_key:
+        return member_id == caller_id
+    result = await session.execute(
+        select(TeamMember.user_id).where(
+            TeamMember.id == member_id, TeamMember.org_id == org_id,
+        ).limit(1)
+    )
+    row = result.first()
+    return row is not None and row[0] == caller_id
+
+
+async def assert_caller_is_member(
+    member_id: uuid.UUID, auth: AuthContext, session: AsyncSession, org_id: uuid.UUID,
+    detail: str = "Cannot act as another member",
+) -> None:
+    """``is_caller_member`` 결과가 False면 403. self-scope 게이트의 표준 형태."""
+    if not await is_caller_member(member_id, auth, session, org_id):
+        raise HTTPException(status_code=403, detail=detail)
+
+
 async def resolve_auth_member(
     auth: AuthContext,
     org_id: uuid.UUID,

--- a/backend/tests/test_e_mcp_opt_s3_hosted_transport.py
+++ b/backend/tests/test_e_mcp_opt_s3_hosted_transport.py
@@ -231,16 +231,18 @@ async def test_connection_artifact_unsupported_transport_400():
 @pytest.mark.anyio
 async def test_verify_connection_http_skips_synthetic_event_and_wake(monkeypatch):
     """transport='http' — start_verification/wake_agent(SSE 전용 경로) 전혀 호출 안 됨."""
+    from types import SimpleNamespace as _SN
     member = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
     db = AsyncMock()
-    db.execute = AsyncMock(return_value=_scalar(member))
     rail = [{"state": s, "status": "done"} for s in HTTP_RAIL_STATES]
-    with patch.object(ag, "start_verification", new=AsyncMock()) as start, \
+    with patch.object(ag, "assert_agent_owner", new=AsyncMock(return_value=member)), \
+         patch.object(ag, "start_verification", new=AsyncMock()) as start, \
          patch.object(ag, "get_verification_state",
                       new=AsyncMock(return_value={"verified": True, "rail": rail, "verify_seq": None})), \
          patch("app.routers.agent_gateway.wake_agent", new=MagicMock()) as wake:
         out = await ag.verify_agent_connection(
-            member.id, transport="http", session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+            member.id, transport="http", session=db,
+            auth=_SN(user_id=str(uuid.uuid4())), org_id=uuid.uuid4(),
         )
     assert out["verified"] is True and out["rail"] == rail
     start.assert_not_awaited()

--- a/backend/tests/test_e_mcp_opt_s5_hardening.py
+++ b/backend/tests/test_e_mcp_opt_s5_hardening.py
@@ -27,17 +27,21 @@ def _scalar(v):
     return r
 
 
+def _auth_ctx():
+    return SimpleNamespace(user_id=str(uuid.uuid4()))
+
+
 # ── #4: project 미배정 → transport 무관 동일 400 ──────────────────────────────
 @pytest.mark.anyio
 async def test_verify_connection_unassigned_agent_400_via_stdio():
     member = SimpleNamespace(id=uuid.uuid4(), project_id=None)
     db = AsyncMock()
-    db.execute = AsyncMock(return_value=_scalar(member))
     from fastapi import HTTPException
-    with pytest.raises(HTTPException) as ei:
-        await ag.verify_agent_connection(
-            member.id, transport=None, session=db, auth=MagicMock(), org_id=uuid.uuid4(),
-        )
+    with patch.object(ag, "assert_agent_owner", new=AsyncMock(return_value=member)):
+        with pytest.raises(HTTPException) as ei:
+            await ag.verify_agent_connection(
+                member.id, transport=None, session=db, auth=_auth_ctx(), org_id=uuid.uuid4(),
+            )
     assert ei.value.status_code == 400
 
 
@@ -46,12 +50,12 @@ async def test_verify_connection_unassigned_agent_400_via_http_too():
     """회귀 가드 — 이전엔 http 조기 return이 이 가드를 건너뛰어 200이 났었다(까심 QA #4)."""
     member = SimpleNamespace(id=uuid.uuid4(), project_id=None)
     db = AsyncMock()
-    db.execute = AsyncMock(return_value=_scalar(member))
     from fastapi import HTTPException
-    with pytest.raises(HTTPException) as ei:
-        await ag.verify_agent_connection(
-            member.id, transport="http", session=db, auth=MagicMock(), org_id=uuid.uuid4(),
-        )
+    with patch.object(ag, "assert_agent_owner", new=AsyncMock(return_value=member)):
+        with pytest.raises(HTTPException) as ei:
+            await ag.verify_agent_connection(
+                member.id, transport="http", session=db, auth=_auth_ctx(), org_id=uuid.uuid4(),
+            )
     assert ei.value.status_code == 400
 
 
@@ -60,14 +64,14 @@ async def test_verify_connection_assigned_agent_http_still_skips_sse(monkeypatch
     """project 배정된 에이전트는 http에서 여전히 합성이벤트/wake 스킵(#4가 이 동작을 안 건드림)."""
     member = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
     db = AsyncMock()
-    db.execute = AsyncMock(return_value=_scalar(member))
-    with patch.object(ag, "start_verification", new=AsyncMock()) as start, \
+    with patch.object(ag, "assert_agent_owner", new=AsyncMock(return_value=member)), \
+         patch.object(ag, "start_verification", new=AsyncMock()) as start, \
          patch.object(ag, "get_verification_state", new=AsyncMock(
              return_value={"verified": True, "rail": [], "verify_seq": None},
          )), \
          patch("app.routers.agent_gateway.wake_agent", new=MagicMock()) as wake:
         out = await ag.verify_agent_connection(
-            member.id, transport="http", session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+            member.id, transport="http", session=db, auth=_auth_ctx(), org_id=uuid.uuid4(),
         )
     assert out["verified"] is True
     start.assert_not_awaited()

--- a/backend/tests/test_e_recruit_s3_recruit_endpoint.py
+++ b/backend/tests/test_e_recruit_s3_recruit_endpoint.py
@@ -24,18 +24,38 @@ def _auth_ctx():
 
 @pytest.mark.anyio
 async def test_recruit_404_when_agent_not_found():
+    """S19(#8): 이제 agent 존재+ownership 확인이 assert_agent_owner 단일 호출로 합쳐졌다."""
     from fastapi import HTTPException
     from app.routers.agents import recruit_agent_endpoint
     from app.schemas.recruit import RecruitRequest
 
     session = MagicMock()
-    with patch("app.routers.agents._fetch_org_agent", AsyncMock(return_value=None)):
+    with patch("app.routers.agents.assert_agent_owner",
+               AsyncMock(side_effect=HTTPException(status_code=404, detail="Agent not found"))):
         with pytest.raises(HTTPException) as ei:
             await recruit_agent_endpoint(
                 uuid.uuid4(), RecruitRequest(role_template_slug="backend"),
                 session=session, auth=_auth_ctx(), org_id=uuid.uuid4(),
             )
     assert ei.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_recruit_403_when_caller_not_owner_or_admin():
+    """S19(#8 MUST): agent의 생성자도 org-admin도 아닌 caller는 재채용 불가."""
+    from fastapi import HTTPException
+    from app.routers.agents import recruit_agent_endpoint
+    from app.schemas.recruit import RecruitRequest
+
+    session = MagicMock()
+    with patch("app.routers.agents.assert_agent_owner",
+               AsyncMock(side_effect=HTTPException(status_code=403, detail="Not the owner of this agent"))):
+        with pytest.raises(HTTPException) as ei:
+            await recruit_agent_endpoint(
+                uuid.uuid4(), RecruitRequest(role_template_slug="backend"),
+                session=session, auth=_auth_ctx(), org_id=uuid.uuid4(),
+            )
+    assert ei.value.status_code == 403
 
 
 @pytest.mark.anyio
@@ -46,7 +66,7 @@ async def test_recruit_400_on_unsupported_runtime():
 
     session = MagicMock()
     member = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
-    with patch("app.routers.agents._fetch_org_agent", AsyncMock(return_value=member)):
+    with patch("app.routers.agents.assert_agent_owner", AsyncMock(return_value=member)):
         with pytest.raises(HTTPException) as ei:
             await recruit_agent_endpoint(
                 uuid.uuid4(), RecruitRequest(role_template_slug="backend", runtime="bogus-runtime"),
@@ -63,7 +83,7 @@ async def test_recruit_404_when_role_template_not_found():
 
     session = MagicMock()
     member = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
-    with patch("app.routers.agents._fetch_org_agent", AsyncMock(return_value=member)), \
+    with patch("app.routers.agents.assert_agent_owner", AsyncMock(return_value=member)), \
          patch("app.routers.agents.get_published_role_template", AsyncMock(return_value=None)):
         with pytest.raises(HTTPException) as ei:
             await recruit_agent_endpoint(
@@ -84,7 +104,7 @@ async def test_recruit_400_when_recruit_agent_raises_value_error():
     session.commit = AsyncMock()
     member = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
     role_template = SimpleNamespace(slug="bogus", default_tool_groups=["not-real"])
-    with patch("app.routers.agents._fetch_org_agent", AsyncMock(return_value=member)), \
+    with patch("app.routers.agents.assert_agent_owner", AsyncMock(return_value=member)), \
          patch("app.routers.agents.get_published_role_template", AsyncMock(return_value=role_template)), \
          patch("app.routers.agents.recruit_agent", AsyncMock(side_effect=ValueError("unknown group"))):
         with pytest.raises(HTTPException) as ei:
@@ -117,7 +137,7 @@ async def test_recruit_success_response_shape():
         "mcp_config_alternatives": {},
     }
 
-    with patch("app.routers.agents._fetch_org_agent", AsyncMock(return_value=member)), \
+    with patch("app.routers.agents.assert_agent_owner", AsyncMock(return_value=member)), \
          patch("app.routers.agents.get_published_role_template", AsyncMock(return_value=role_template)), \
          patch("app.routers.agents.recruit_agent", AsyncMock(return_value=recruit_result)), \
          patch("app.routers.agents.build_agent_mcp_config_bundle", MagicMock(return_value=bundle)), \

--- a/backend/tests/test_eventbus_s1.py
+++ b/backend/tests/test_eventbus_s1.py
@@ -200,6 +200,7 @@ async def test_create_event_recipient_not_found_returns_404(client, mock_session
 
 @pytest.mark.anyio
 async def test_get_pending_events_returns_list(client, mock_session):
+    """산티아고 SME 최종 MUST(S19): recipient==caller 통과 시 정상 동작."""
     recipient_id = uuid.uuid4()
     events = [_make_event(recipient_id=recipient_id, status="pending") for _ in range(3)]
 
@@ -209,11 +210,26 @@ async def test_get_pending_events_returns_list(client, mock_session):
     result_mock.scalars.return_value = scalars_mock
     mock_session.execute.return_value = result_mock
 
-    resp = await client.get(f"/api/v2/events/pending?recipient_id={recipient_id}")
+    with patch("app.routers.events.assert_caller_is_member", new_callable=AsyncMock,
+               return_value=None):
+        resp = await client.get(f"/api/v2/events/pending?recipient_id={recipient_id}")
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 3
     assert all(e["status"] == "pending" for e in data)
+
+
+@pytest.mark.anyio
+async def test_get_pending_events_403_when_caller_is_not_recipient(client, mock_session):
+    """산티아고 SME 최종 MUST(S19): recipient_id 쿼리로 타 member 이벤트(payload/sender/source)를
+    auth·recipient 검증 없이 읽을 수 있었다 — mark_delivered(write)는 이미 닫혔는데 같은
+    recipient 축의 이 read fallback이 열려있었다."""
+    recipient_id = uuid.uuid4()
+
+    with patch("app.routers.events.assert_caller_is_member", new_callable=AsyncMock,
+               side_effect=HTTPException(status_code=403, detail="Cannot read another member's events")):
+        resp = await client.get(f"/api/v2/events/pending?recipient_id={recipient_id}")
+    assert resp.status_code == 403
 
 
 # ─── AC4: PATCH /api/v2/events/{id}/delivered ─────────────────────────────────
@@ -330,7 +346,9 @@ async def test_get_pending_filters_by_org(client, mock_session, org_id):
     result_mock.scalars.return_value = scalars_mock
     mock_session.execute.return_value = result_mock
 
-    resp = await client.get(f"/api/v2/events/pending?recipient_id={recipient_id}")
+    with patch("app.routers.events.assert_caller_is_member", new_callable=AsyncMock,
+               return_value=None):
+        resp = await client.get(f"/api/v2/events/pending?recipient_id={recipient_id}")
     assert resp.status_code == 200
     # execute 호출 시 org_id 필터가 쿼리에 포함됐는지 — 실제 SQL은 mock이므로 호출 여부로 확인
     mock_session.execute.assert_called_once()

--- a/backend/tests/test_eventbus_s1.py
+++ b/backend/tests/test_eventbus_s1.py
@@ -3,12 +3,23 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 from httpx import ASGITransport, AsyncClient
 
 from app.models.event import Event
+
+
+def _resolved(member_id: uuid.UUID):
+    """S19(events sender_id 검증): resolve_member() 반환 mock — caller가 sender_id 본인임을 가장."""
+    from app.services.member_resolver import ResolvedMember
+
+    return ResolvedMember(
+        id=member_id, user_id=member_id, name="TestSender", type="human",
+        role="member", org_id=uuid.uuid4(), project_id=None,
+    )
 
 
 @pytest.fixture
@@ -91,7 +102,8 @@ async def client(mock_session, auth_ctx, org_id):
 @pytest.mark.anyio
 async def test_create_event_stores_in_db(client, mock_session):
     recipient_id = uuid.uuid4()
-    event = _make_event(recipient_id=recipient_id, recipient_type="agent")
+    sender_id = uuid.uuid4()
+    event = _make_event(recipient_id=recipient_id, recipient_type="agent", sender_id=sender_id)
 
     # team_members.type 조회 결과 mock
     member_result = MagicMock()
@@ -114,18 +126,55 @@ async def test_create_event_stores_in_db(client, mock_session):
         "event_type": "memo_created",
         "source_entity_type": "memo",
         "source_entity_id": str(uuid.uuid4()),
-        "sender_id": str(uuid.uuid4()),
+        "sender_id": str(sender_id),
         "recipient_id": str(recipient_id),
         "recipient_type": "agent",
         "payload": {"title": "킥오프"},
     }
-    resp = await client.post("/api/v2/events", json=payload)
+    with patch("app.routers.events.assert_caller_is_member", new_callable=AsyncMock,
+               return_value=None):
+        resp = await client.post("/api/v2/events", json=payload)
     assert resp.status_code == 201
     data = resp.json()
     assert data["status"] == "pending"
     assert data["event_type"] == "memo_created"
     mock_session.add.assert_called_once()
     mock_session.commit.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_create_event_403_when_sender_id_does_not_match_caller():
+    """S19(SHOULD): sender_id가 caller 본인과 다르면 403(임퍼스네이션 차단)."""
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+    from app.main import app
+
+    session = AsyncMock()
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.claims = {"app_metadata": {}}
+
+    async def _db():
+        yield session
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = lambda: ctx
+    app.dependency_overrides[get_verified_org_id] = lambda: uuid.uuid4()
+    try:
+        payload = {
+            "project_id": str(uuid.uuid4()),
+            "event_type": "memo_created",
+            "sender_id": str(uuid.uuid4()),  # resolve_member가 반환하는 caller와 다른 임의 sender
+            "recipient_id": str(uuid.uuid4()),
+            "recipient_type": "agent",
+        }
+        with patch("app.routers.events.assert_caller_is_member", new_callable=AsyncMock,
+                   side_effect=HTTPException(status_code=403, detail="sender_id must match the caller's own identity")):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.post("/api/v2/events", json=payload)
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
 
 
 @pytest.mark.anyio
@@ -171,6 +220,7 @@ async def test_get_pending_events_returns_list(client, mock_session):
 
 @pytest.mark.anyio
 async def test_mark_delivered_sets_status_and_timestamp(client, mock_session):
+    """S19(#7): caller가 event의 recipient 본인이어야 delivered로 마킹 가능."""
     event = _make_event(status="pending")
 
     async def _refresh(obj):
@@ -182,12 +232,30 @@ async def test_mark_delivered_sets_status_and_timestamp(client, mock_session):
     scalar_mock.scalar_one_or_none.return_value = event
     mock_session.execute.return_value = scalar_mock
 
-    resp = await client.patch(f"/api/v2/events/{event.id}/delivered")
+    with patch("app.routers.events.assert_caller_is_member", new_callable=AsyncMock,
+               return_value=None):
+        resp = await client.patch(f"/api/v2/events/{event.id}/delivered")
     assert resp.status_code == 200
     data = resp.json()
     assert data["status"] == "delivered"
     assert data["delivered_at"] is not None
     mock_session.commit.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_mark_delivered_403_when_caller_is_not_recipient(client, mock_session):
+    """S19(#7 MUST): recipient 확인 없이 org-scope만 있어 누구나 타 member 이벤트를 delivered로
+    마킹할 수 있었다(알림 은폐 가능) — caller==recipient 강제."""
+    event = _make_event(status="pending")
+
+    scalar_mock = MagicMock()
+    scalar_mock.scalar_one_or_none.return_value = event
+    mock_session.execute.return_value = scalar_mock
+
+    with patch("app.routers.events.assert_caller_is_member", new_callable=AsyncMock,
+               side_effect=HTTPException(status_code=403, detail="Not the recipient of this event")):
+        resp = await client.patch(f"/api/v2/events/{event.id}/delivered")
+    assert resp.status_code == 403
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_eventbus_s3.py
+++ b/backend/tests/test_eventbus_s3.py
@@ -299,7 +299,10 @@ def test_stream_batch_delivers_over_100_events(mock_session, org_id):
 
 @pytest.mark.anyio
 async def test_expire_stale_events(client, mock_session):
-    """POST /api/v2/events/expire-stale — expired + cleaned rowcount 반환."""
+    """POST /api/v2/events/expire-stale — expired + cleaned rowcount 반환.
+
+    S19(SHOULD): org-admin 전용 게이트 추가 — org-admin caller로 mock.
+    """
     expired_result = MagicMock()
     expired_result.rowcount = 5
     cleaned_result = MagicMock()
@@ -307,12 +310,21 @@ async def test_expire_stale_events(client, mock_session):
 
     mock_session.execute.side_effect = [expired_result, cleaned_result]
 
-    resp = await client.post("/api/v2/events/expire-stale")
+    with patch("app.routers.events._is_org_admin", new_callable=AsyncMock, return_value=True):
+        resp = await client.post("/api/v2/events/expire-stale")
     assert resp.status_code == 200
     data = resp.json()
     assert data["expired"] == 5
     assert data["cleaned"] == 3
     mock_session.commit.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_expire_stale_403_when_not_org_admin(client, mock_session):
+    """S19(SHOULD MUST급): per-resource IDOR이 아니라 privilege 게이트 부재 — org-admin 아니면 403."""
+    with patch("app.routers.events._is_org_admin", new_callable=AsyncMock, return_value=False):
+        resp = await client.post("/api/v2/events/expire-stale")
+    assert resp.status_code == 403
 
 
 @pytest.mark.anyio
@@ -324,7 +336,8 @@ async def test_expire_stale_uses_correct_cutoffs(client, mock_session):
     cleaned_result.rowcount = 0
     mock_session.execute.side_effect = [expired_result, cleaned_result]
 
-    resp = await client.post("/api/v2/events/expire-stale")
+    with patch("app.routers.events._is_org_admin", new_callable=AsyncMock, return_value=True):
+        resp = await client.post("/api/v2/events/expire-stale")
     assert resp.status_code == 200
     # execute 2번 호출 (update expired + delete cleaned)
     assert mock_session.execute.call_count == 2

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -1,6 +1,6 @@
 """S18+S25+S32: conftest fixture 기반 통합 테스트 — Sprint 3+4+5 도메인 헬스 체크."""
 import uuid
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -334,7 +334,8 @@ async def test_notification_settings_get_via_conftest_s6(test_client, mock_sessi
     mock_result.scalars.return_value.all.return_value = []
     mock_session.execute = AsyncMock(return_value=mock_result)
 
-    resp = await test_client.get(f"/api/v2/notification-settings?member_id={member_id}")
+    with patch("app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=True):
+        resp = await test_client.get(f"/api/v2/notification-settings?member_id={member_id}")
     assert resp.status_code == 200
     assert resp.json() == []
 

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -210,9 +210,11 @@ async def test_mark_read_single_404_when_not_owned():
 
 @pytest.mark.anyio
 async def test_get_notification_settings_200():
+    """까심 델타 재QA HIGH(S19): 이 GET이 무가드로 남아있었다 — self 통과 시 정상 동작 확인."""
     client, session, app = await _client()
     try:
-        with patch("app.repositories.notification.NotificationSettingRepository.get_by_member", new_callable=AsyncMock) as mock_get:
+        with patch("app.repositories.notification.NotificationSettingRepository.get_by_member", new_callable=AsyncMock) as mock_get, \
+             patch("app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=True):
             mock_get.return_value = [_mock_setting()]
 
             async with client as c:
@@ -221,6 +223,20 @@ async def test_get_notification_settings_200():
         assert resp.status_code == 200
         assert len(resp.json()) == 1
         assert resp.json()[0]["event_type"] == "story_assigned"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_notification_settings_403_when_not_self_or_admin():
+    """까심 델타 재QA HIGH(S19 MUST): 타 member의 알림설정 열람(정보노출) 차단."""
+    client, session, app = await _client()
+    try:
+        with patch("app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=False), \
+             patch("app.routers.notifications._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                resp = await c.get(f"/api/v2/notification-settings?member_id={MEMBER_ID}")
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 
@@ -265,9 +281,11 @@ async def test_upsert_notification_setting_403_when_not_self_or_admin():
 
 @pytest.mark.anyio
 async def test_list_inbox_200():
+    """까심 델타 재QA HIGH(S19): 무가드였던 GET — self 통과 시 정상 동작."""
     client, session, app = await _client()
     try:
-        with patch("app.repositories.notification.InboxRepository.list", new_callable=AsyncMock) as mock_list:
+        with patch("app.repositories.notification.InboxRepository.list", new_callable=AsyncMock) as mock_list, \
+             patch("app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=True):
             mock_list.return_value = [_mock_inbox()]
 
             async with client as c:
@@ -281,10 +299,26 @@ async def test_list_inbox_200():
 
 
 @pytest.mark.anyio
-async def test_list_incoming_200():
+async def test_list_inbox_403_when_not_self_or_admin():
+    """까심 델타 재QA HIGH(S19 MUST): 타 member의 inbox 열람(정보노출) 차단."""
     client, session, app = await _client()
     try:
-        with patch("app.repositories.notification.InboxRepository.list_incoming", new_callable=AsyncMock) as mock_list:
+        with patch("app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=False), \
+             patch("app.routers.notifications._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                resp = await c.get(f"/api/v2/inbox?assignee_member_id={MEMBER_ID}")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_incoming_200():
+    """까심 델타 재QA HIGH(S19): 무가드였던 GET — self 통과 시 정상 동작."""
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.notification.InboxRepository.list_incoming", new_callable=AsyncMock) as mock_list, \
+             patch("app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=True):
             mock_list.return_value = [_mock_inbox()]
 
             async with client as c:
@@ -292,6 +326,20 @@ async def test_list_incoming_200():
 
         assert resp.status_code == 200
         assert resp.json()[0]["kind"] == "approval"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_incoming_403_when_not_self_or_admin():
+    """까심 델타 재QA HIGH(S19 MUST): list_inbox와 동일 갭 — 정보노출 차단."""
+    client, session, app = await _client()
+    try:
+        with patch("app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=False), \
+             patch("app.routers.notifications._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                resp = await c.get(f"/api/v2/inbox/incoming?assignee_member_id={MEMBER_ID}")
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 
 ORG_ID = uuid.uuid4()
 PROJECT_ID = uuid.uuid4()
@@ -65,6 +66,16 @@ def _mock_inbox(state: str = "pending") -> MagicMock:
     i.created_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
     i.resolved_at = None
     return i
+
+
+def _resolved(member_id: uuid.UUID):
+    """S19: resolve_member() 반환 mock — caller가 member_id 본인/assignee임을 가장."""
+    from app.services.member_resolver import ResolvedMember
+
+    return ResolvedMember(
+        id=member_id, user_id=None, name="TestMember", type="human",
+        role="member", org_id=ORG_ID, project_id=PROJECT_ID,
+    )
 
 
 @pytest.fixture
@@ -216,9 +227,11 @@ async def test_get_notification_settings_200():
 
 @pytest.mark.anyio
 async def test_upsert_notification_setting_200():
+    """S19(#4): self-scope 통과 시(caller==member_id) 정상 동작."""
     client, session, app = await _client()
     try:
-        with patch("app.repositories.notification.NotificationSettingRepository.upsert", new_callable=AsyncMock) as mock_upsert:
+        with patch("app.repositories.notification.NotificationSettingRepository.upsert", new_callable=AsyncMock) as mock_upsert, \
+             patch("app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=True):
             mock_upsert.return_value = _mock_setting()
 
             async with client as c:
@@ -229,6 +242,23 @@ async def test_upsert_notification_setting_200():
 
         assert resp.status_code == 200
         assert resp.json()["enabled"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_upsert_notification_setting_403_when_not_self_or_admin():
+    """S19(#4 MUST): member_id가 caller 본인도 org-admin도 아니면 403(타 member 설정 덮어쓰기 차단)."""
+    client, session, app = await _client()
+    try:
+        with patch("app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=False), \
+             patch("app.routers.notifications._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                resp = await c.put(
+                    f"/api/v2/notification-settings?member_id={MEMBER_ID}",
+                    json={"channel": "in_app", "event_type": "story_assigned", "enabled": True},
+                )
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 
@@ -268,23 +298,55 @@ async def test_list_incoming_200():
 
 @pytest.mark.anyio
 async def test_resolve_inbox_200():
+    """S19(#5): assignee==caller일 때 정상 동작. resolved_by는 이제 caller에서 서버-파생."""
     client, session, app = await _client()
     try:
+        pending_item = _mock_inbox("pending")
         resolved = _mock_inbox("resolved")
         resolved.resolved_by = MEMBER_ID
         resolved.resolved_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
 
-        with patch("app.repositories.notification.InboxRepository.resolve", new_callable=AsyncMock) as mock_resolve:
+        with patch("app.repositories.notification.InboxRepository.get", new_callable=AsyncMock,
+                   return_value=pending_item), \
+             patch("app.repositories.notification.InboxRepository.resolve", new_callable=AsyncMock) as mock_resolve, \
+             patch("app.routers.notifications.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
             mock_resolve.return_value = resolved
 
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/inbox/{INBOX_ID}/resolve",
+                    json={"resolved_by": str(uuid.uuid4())},  # S19: 바디값 무시(caller에서 서버-파생)
+                )
+
+        assert resp.status_code == 200
+        assert resp.json()["state"] == "resolved"
+        mock_resolve.assert_awaited_once_with(
+            id=INBOX_ID, resolved_by=MEMBER_ID, resolved_option_id=None, resolved_note=None,
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_resolve_inbox_403_when_caller_is_not_assignee():
+    """S19(#5 MUST): auth 파라미터 자체가 없어 assignee 확인이 전혀 없었다 — 타 member의 inbox
+    item을 resolve할 수 있었고 resolved_by 바디값도 임의로 스푸핑 가능했다."""
+    client, session, app = await _client()
+    try:
+        pending_item = _mock_inbox("pending")  # assignee_member_id == MEMBER_ID
+
+        with patch("app.repositories.notification.InboxRepository.get", new_callable=AsyncMock,
+                   return_value=pending_item), \
+             patch("app.routers.notifications.assert_caller_is_member", new_callable=AsyncMock,
+                   side_effect=HTTPException(status_code=403, detail="Not the assignee of this inbox item")):  # caller != assignee
             async with client as c:
                 resp = await c.post(
                     f"/api/v2/inbox/{INBOX_ID}/resolve",
                     json={"resolved_by": str(MEMBER_ID)},
                 )
 
-        assert resp.status_code == 200
-        assert resp.json()["state"] == "resolved"
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 
@@ -293,9 +355,14 @@ async def test_resolve_inbox_200():
 async def test_dismiss_inbox_200():
     client, session, app = await _client()
     try:
+        pending_item = _mock_inbox("pending")
         dismissed = _mock_inbox("dismissed")
 
-        with patch("app.repositories.notification.InboxRepository.dismiss", new_callable=AsyncMock) as mock_dismiss:
+        with patch("app.repositories.notification.InboxRepository.get", new_callable=AsyncMock,
+                   return_value=pending_item), \
+             patch("app.repositories.notification.InboxRepository.dismiss", new_callable=AsyncMock) as mock_dismiss, \
+             patch("app.routers.notifications.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
             mock_dismiss.return_value = dismissed
 
             async with client as c:
@@ -308,12 +375,54 @@ async def test_dismiss_inbox_200():
 
 
 @pytest.mark.anyio
+async def test_dismiss_inbox_403_when_caller_is_not_assignee():
+    """S19(#6 MUST): resolve와 동일 갭 — assignee 아닌 caller의 dismiss 차단."""
+    client, session, app = await _client()
+    try:
+        pending_item = _mock_inbox("pending")
+
+        with patch("app.repositories.notification.InboxRepository.get", new_callable=AsyncMock,
+                   return_value=pending_item), \
+             patch("app.routers.notifications.assert_caller_is_member", new_callable=AsyncMock,
+                   side_effect=HTTPException(status_code=403, detail="Not the assignee of this inbox item")):
+            async with client as c:
+                resp = await c.post(f"/api/v2/inbox/{INBOX_ID}/dismiss")
+
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_resolve_inbox_404():
     client, session, app = await _client()
     try:
-        with patch("app.repositories.notification.InboxRepository.resolve", new_callable=AsyncMock) as mock_resolve:
+        pending_item = _mock_inbox("pending")
+        with patch("app.repositories.notification.InboxRepository.get", new_callable=AsyncMock,
+                   return_value=pending_item), \
+             patch("app.repositories.notification.InboxRepository.resolve", new_callable=AsyncMock) as mock_resolve, \
+             patch("app.routers.notifications.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
             mock_resolve.return_value = None
 
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/inbox/{INBOX_ID}/resolve",
+                    json={"resolved_by": str(MEMBER_ID)},
+                )
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_resolve_inbox_404_when_item_not_found():
+    """item 자체가 없으면(repo.get()==None) 404 — assignee 확인 전에 먼저 404."""
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.notification.InboxRepository.get", new_callable=AsyncMock,
+                   return_value=None):
             async with client as c:
                 resp = await c.post(
                     f"/api/v2/inbox/{uuid.uuid4()}/resolve",

--- a/backend/tests/test_ob2_verify_connection.py
+++ b/backend/tests/test_ob2_verify_connection.py
@@ -101,31 +101,50 @@ async def test_get_state_no_verify_all_pending():
 
 # ─── endpoints (handler-direct) ───────────────────────────────────────────────
 
+def _auth_ctx():
+    return SimpleNamespace(user_id=str(uuid.uuid4()))
+
+
 @pytest.mark.anyio
 async def test_verify_connection_404():
     from fastapi import HTTPException
     db = AsyncMock()
-    db.execute = AsyncMock(return_value=_scalar(None))
-    with pytest.raises(HTTPException) as ei:
-        await ag.verify_agent_connection(
-            uuid.uuid4(), session=db, auth=MagicMock(), org_id=uuid.uuid4()
-        )
+    with patch.object(ag, "assert_agent_owner",
+                      new=AsyncMock(side_effect=HTTPException(status_code=404, detail="Agent not found"))):
+        with pytest.raises(HTTPException) as ei:
+            await ag.verify_agent_connection(
+                uuid.uuid4(), session=db, auth=_auth_ctx(), org_id=uuid.uuid4()
+            )
     assert ei.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_verify_connection_403_when_caller_not_owner_or_admin():
+    """S19(#9 MUST): agent의 생성자도 org-admin도 아닌 caller는 연결검증 트리거 불가."""
+    from fastapi import HTTPException
+    db = AsyncMock()
+    with patch.object(ag, "assert_agent_owner",
+                      new=AsyncMock(side_effect=HTTPException(status_code=403, detail="Not the owner of this agent"))):
+        with pytest.raises(HTTPException) as ei:
+            await ag.verify_agent_connection(
+                uuid.uuid4(), session=db, auth=_auth_ctx(), org_id=uuid.uuid4()
+            )
+    assert ei.value.status_code == 403
 
 
 @pytest.mark.anyio
 async def test_verify_connection_starts_single_target_and_returns_rail():
     member = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
     db = AsyncMock()
-    db.execute = AsyncMock(return_value=_scalar(member))
     db.commit = AsyncMock()
     rail = [{"state": s, "status": "pending"} for s in RAIL_STATES]
-    with patch.object(ag, "start_verification", new=AsyncMock(return_value=42)) as start, \
+    with patch.object(ag, "assert_agent_owner", new=AsyncMock(return_value=member)), \
+         patch.object(ag, "start_verification", new=AsyncMock(return_value=42)) as start, \
          patch.object(ag, "get_verification_state",
                       new=AsyncMock(return_value={"verified": False, "rail": rail, "verify_seq": 42})), \
          patch("app.routers.agent_gateway.wake_agent", new=MagicMock()) as wake:
         out = await ag.verify_agent_connection(
-            member.id, session=db, auth=MagicMock(), org_id=uuid.uuid4()
+            member.id, session=db, auth=_auth_ctx(), org_id=uuid.uuid4()
         )
     assert out["verification_seq"] == 42 and out["rail"] == rail
     start.assert_awaited_once()  # single-target verify 시작

--- a/backend/tests/test_s2_2_passive_heartbeat.py
+++ b/backend/tests/test_s2_2_passive_heartbeat.py
@@ -77,16 +77,6 @@ def anyio_backend():
     return "asyncio"
 
 
-def _resolved_self(member_id: uuid.UUID):
-    """S19(#1): resolve_member() 반환 mock — heartbeat self-scope 검증 대상 caller 신원."""
-    from app.services.member_resolver import ResolvedMember
-
-    return ResolvedMember(
-        id=member_id, user_id=None, name="TestAgent", type="agent",
-        role="member", org_id=ORG_ID, project_id=uuid.uuid4(),
-    )
-
-
 @pytest.mark.anyio
 async def test_heartbeat_endpoint_200():
     """AC1: PATCH /api/v2/team-members/{id}/heartbeat → 200 (S19: self-scope 통과 시)."""
@@ -114,8 +104,8 @@ async def test_heartbeat_endpoint_200():
         session.flush = AsyncMock()
         session.refresh = AsyncMock()
 
-        with patch("app.routers.team_members.resolve_member", new_callable=AsyncMock,
-                   return_value=_resolved_self(MEMBER_ID)):
+        with patch("app.routers.team_members.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
             async with client as c:
                 resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}/heartbeat")
 
@@ -128,6 +118,8 @@ async def test_heartbeat_endpoint_200():
 async def test_heartbeat_403_when_caller_is_different_member():
     """S19(#1 MUST): auth 파라미터가 아예 없어 caller 확인이 전혀 없었다 — 타 member 명의로
     heartbeat(presence 스푸핑) 시도 시 403."""
+    from fastapi import HTTPException
+
     client, session, app = await _heartbeat_client()
     try:
         member = _mock_member_for_heartbeat()
@@ -135,9 +127,8 @@ async def test_heartbeat_403_when_caller_is_different_member():
         mock_get_result.scalars.return_value.first.return_value = member
         session.execute = AsyncMock(return_value=mock_get_result)
 
-        other_member_id = uuid.uuid4()
-        with patch("app.routers.team_members.resolve_member", new_callable=AsyncMock,
-                   return_value=_resolved_self(other_member_id)):
+        with patch("app.routers.team_members.assert_caller_is_member", new_callable=AsyncMock,
+                   side_effect=HTTPException(status_code=403, detail="Cannot heartbeat as another member")):
             async with client as c:
                 resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}/heartbeat")
 
@@ -170,8 +161,8 @@ async def test_heartbeat_response_shape():
         session.flush = AsyncMock()
         session.refresh = AsyncMock()
 
-        with patch("app.routers.team_members.resolve_member", new_callable=AsyncMock,
-                   return_value=_resolved_self(MEMBER_ID)):
+        with patch("app.routers.team_members.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
             async with client as c:
                 resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}/heartbeat")
 

--- a/backend/tests/test_s2_2_passive_heartbeat.py
+++ b/backend/tests/test_s2_2_passive_heartbeat.py
@@ -77,16 +77,26 @@ def anyio_backend():
     return "asyncio"
 
 
+def _resolved_self(member_id: uuid.UUID):
+    """S19(#1): resolve_member() 반환 mock — heartbeat self-scope 검증 대상 caller 신원."""
+    from app.services.member_resolver import ResolvedMember
+
+    return ResolvedMember(
+        id=member_id, user_id=None, name="TestAgent", type="agent",
+        role="member", org_id=ORG_ID, project_id=uuid.uuid4(),
+    )
+
+
 @pytest.mark.anyio
 async def test_heartbeat_endpoint_200():
-    """AC1: PATCH /api/v2/team-members/{id}/heartbeat → 200."""
+    """AC1: PATCH /api/v2/team-members/{id}/heartbeat → 200 (S19: self-scope 통과 시)."""
     client, session, app = await _heartbeat_client()
     try:
         member = _mock_member_for_heartbeat()
         updated = _mock_member_for_heartbeat()
 
         mock_get_result = MagicMock()
-        mock_get_result.scalar_one_or_none.return_value = member
+        mock_get_result.scalars.return_value.first.return_value = member
 
         mock_update_result = MagicMock()
         mock_update_result.scalar_one_or_none.return_value = updated
@@ -104,10 +114,34 @@ async def test_heartbeat_endpoint_200():
         session.flush = AsyncMock()
         session.refresh = AsyncMock()
 
-        async with client as c:
-            resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}/heartbeat")
+        with patch("app.routers.team_members.resolve_member", new_callable=AsyncMock,
+                   return_value=_resolved_self(MEMBER_ID)):
+            async with client as c:
+                resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}/heartbeat")
 
         assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_heartbeat_403_when_caller_is_different_member():
+    """S19(#1 MUST): auth 파라미터가 아예 없어 caller 확인이 전혀 없었다 — 타 member 명의로
+    heartbeat(presence 스푸핑) 시도 시 403."""
+    client, session, app = await _heartbeat_client()
+    try:
+        member = _mock_member_for_heartbeat()
+        mock_get_result = MagicMock()
+        mock_get_result.scalars.return_value.first.return_value = member
+        session.execute = AsyncMock(return_value=mock_get_result)
+
+        other_member_id = uuid.uuid4()
+        with patch("app.routers.team_members.resolve_member", new_callable=AsyncMock,
+                   return_value=_resolved_self(other_member_id)):
+            async with client as c:
+                resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}/heartbeat")
+
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 
@@ -126,15 +160,20 @@ async def test_heartbeat_response_shape():
             nonlocal call_count
             call_count += 1
             result = MagicMock()
-            result.scalar_one_or_none.return_value = member if call_count == 1 else updated
+            if call_count == 1:
+                result.scalars.return_value.first.return_value = member
+            else:
+                result.scalar_one_or_none.return_value = updated
             return result
 
         session.execute = mock_execute
         session.flush = AsyncMock()
         session.refresh = AsyncMock()
 
-        async with client as c:
-            resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}/heartbeat")
+        with patch("app.routers.team_members.resolve_member", new_callable=AsyncMock,
+                   return_value=_resolved_self(MEMBER_ID)):
+            async with client as c:
+                resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}/heartbeat")
 
         body = resp.json()
         assert body["ok"] is True

--- a/backend/tests/test_s2_4_claim_unclaim.py
+++ b/backend/tests/test_s2_4_claim_unclaim.py
@@ -16,6 +16,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 
 ORG_ID = uuid.uuid4()
 PROJECT_ID = uuid.uuid4()
@@ -128,8 +129,8 @@ async def test_claim_story_200():
         session.flush = AsyncMock()
         session.refresh = AsyncMock()
 
-        with patch("app.routers.team_members.resolve_member", new_callable=AsyncMock,
-                   return_value=_resolved(MEMBER_ID)):
+        with patch("app.routers.team_members.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
             async with client as c:
                 resp = await c.post(
                     f"/api/v2/team-members/{MEMBER_ID}/claim",
@@ -158,8 +159,8 @@ async def test_claim_story_403_when_caller_is_different_member():
         result.scalar_one_or_none.return_value = member
         session.execute = AsyncMock(return_value=result)
 
-        with patch("app.routers.team_members.resolve_member", new_callable=AsyncMock,
-                   return_value=_resolved(uuid.uuid4())):
+        with patch("app.routers.team_members.assert_caller_is_member", new_callable=AsyncMock,
+                   side_effect=HTTPException(status_code=403, detail="Cannot act as another member")):
             async with client as c:
                 resp = await c.post(
                     f"/api/v2/team-members/{MEMBER_ID}/claim",
@@ -194,8 +195,8 @@ async def test_unclaim_story_200():
         session.flush = AsyncMock()
         session.refresh = AsyncMock()
 
-        with patch("app.routers.team_members.resolve_member", new_callable=AsyncMock,
-                   return_value=_resolved(MEMBER_ID)):
+        with patch("app.routers.team_members.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
             async with client as c:
                 resp = await c.post(f"/api/v2/team-members/{MEMBER_ID}/unclaim")
 
@@ -218,8 +219,8 @@ async def test_unclaim_story_403_when_caller_is_different_member():
         result.scalar_one_or_none.return_value = member
         session.execute = AsyncMock(return_value=result)
 
-        with patch("app.routers.team_members.resolve_member", new_callable=AsyncMock,
-                   return_value=_resolved(uuid.uuid4())):
+        with patch("app.routers.team_members.assert_caller_is_member", new_callable=AsyncMock,
+                   side_effect=HTTPException(status_code=403, detail="Cannot act as another member")):
             async with client as c:
                 resp = await c.post(f"/api/v2/team-members/{MEMBER_ID}/unclaim")
 
@@ -251,8 +252,8 @@ async def test_claim_story_400_if_story_not_in_project():
 
         session.execute = mock_execute
 
-        with patch("app.routers.team_members.resolve_member", new_callable=AsyncMock,
-                   return_value=_resolved(MEMBER_ID)):
+        with patch("app.routers.team_members.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
             async with client as c:
                 resp = await c.post(
                     f"/api/v2/team-members/{MEMBER_ID}/claim",

--- a/backend/tests/test_s37.py
+++ b/backend/tests/test_s37.py
@@ -181,7 +181,9 @@ async def test_put_notification_setting_200():
         with patch(
             "app.repositories.notification.NotificationSettingRepository.upsert",
             new_callable=AsyncMock
-        ) as mock_upsert:
+        ) as mock_upsert, patch(
+            "app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=True,
+        ):
             mock_upsert.return_value = setting_mock
 
             async with client as c:

--- a/backend/tests/test_s37.py
+++ b/backend/tests/test_s37.py
@@ -154,7 +154,9 @@ async def test_get_notification_settings_200():
         with patch(
             "app.repositories.notification.NotificationSettingRepository.get_by_member",
             new_callable=AsyncMock
-        ) as mock_get:
+        ) as mock_get, patch(
+            "app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=True,
+        ):
             mock_get.return_value = []
 
             async with client as c:

--- a/backend/tests/test_s4_1_file_conflict.py
+++ b/backend/tests/test_s4_1_file_conflict.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 
 ORG_ID = uuid.uuid4()
 PROJECT_ID = uuid.uuid4()
@@ -169,8 +170,8 @@ async def test_file_lock_no_conflict_200():
         session.flush = AsyncMock()
         session.add = MagicMock()
 
-        with patch("app.routers.file_locks.resolve_member", new_callable=AsyncMock,
-                   return_value=_resolved(MEMBER_ID)):
+        with patch("app.routers.file_locks.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
             async with client as c:
                 resp = await c.post(
                     f"/api/v2/team-members/{MEMBER_ID}/file-lock",
@@ -195,8 +196,8 @@ async def test_file_lock_403_when_caller_is_different_member():
         result.scalars.return_value.first.return_value = member
         session.execute = AsyncMock(return_value=result)
 
-        with patch("app.routers.file_locks.resolve_member", new_callable=AsyncMock,
-                   return_value=_resolved(OTHER_MEMBER_ID)):
+        with patch("app.routers.file_locks.assert_caller_is_member", new_callable=AsyncMock,
+                   side_effect=HTTPException(status_code=403, detail="Cannot act as another member")):
             async with client as c:
                 resp = await c.post(
                     f"/api/v2/team-members/{MEMBER_ID}/file-lock",
@@ -258,8 +259,8 @@ async def test_file_lock_with_conflict_warning():
 
         with patch("app.routers.file_locks.publish_event"), \
              patch("app.routers.file_locks.fire_webhooks", new_callable=AsyncMock), \
-             patch("app.routers.file_locks.resolve_member", new_callable=AsyncMock,
-                   return_value=_resolved(MEMBER_ID)):
+             patch("app.routers.file_locks.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
             async with client as c:
                 resp = await c.post(
                     f"/api/v2/team-members/{MEMBER_ID}/file-lock",
@@ -296,8 +297,8 @@ async def test_file_unlock_200():
         session.execute = mock_execute
         session.flush = AsyncMock()
 
-        with patch("app.routers.file_locks.resolve_member", new_callable=AsyncMock,
-                   return_value=_resolved(MEMBER_ID)):
+        with patch("app.routers.file_locks.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
             async with client as c:
                 resp = await c.post(
                     f"/api/v2/team-members/{MEMBER_ID}/file-unlock",
@@ -337,8 +338,8 @@ async def test_file_unlock_update_where_scoped_to_member_project():
         session.execute = mock_execute
         session.flush = AsyncMock()
 
-        with patch("app.routers.file_locks.resolve_member", new_callable=AsyncMock,
-                   return_value=_resolved(MEMBER_ID)):
+        with patch("app.routers.file_locks.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
             async with client as c:
                 resp = await c.post(
                     f"/api/v2/team-members/{MEMBER_ID}/file-unlock",
@@ -366,8 +367,8 @@ async def test_file_unlock_403_when_caller_is_different_member():
         result.scalars.return_value.first.return_value = member
         session.execute = AsyncMock(return_value=result)
 
-        with patch("app.routers.file_locks.resolve_member", new_callable=AsyncMock,
-                   return_value=_resolved(OTHER_MEMBER_ID)):
+        with patch("app.routers.file_locks.assert_caller_is_member", new_callable=AsyncMock,
+                   side_effect=HTTPException(status_code=403, detail="Cannot act as another member")):
             async with client as c:
                 resp = await c.post(
                     f"/api/v2/team-members/{MEMBER_ID}/file-unlock",
@@ -519,8 +520,8 @@ async def test_file_lock_uses_project_hint_to_scope_member_query():
         session.flush = AsyncMock()
         session.add = MagicMock()
 
-        with patch("app.routers.file_locks.resolve_member", new_callable=AsyncMock,
-                   return_value=_resolved(MEMBER_ID)), \
+        with patch("app.routers.file_locks.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None), \
              patch("app.routers.file_locks._caller_project_hint", return_value=hint_project) as hint_mock:
             async with client as c:
                 resp = await c.post(
@@ -565,8 +566,8 @@ async def test_stale_project_hint_falls_back_instead_of_404():
         session.flush = AsyncMock()
         session.add = MagicMock()
 
-        with patch("app.routers.file_locks.resolve_member", new_callable=AsyncMock,
-                   return_value=_resolved(MEMBER_ID)), \
+        with patch("app.routers.file_locks.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None), \
              patch("app.routers.file_locks._caller_project_hint", return_value=stale_hint):
             async with client as c:
                 resp = await c.post(

--- a/backend/tests/test_team_members.py
+++ b/backend/tests/test_team_members.py
@@ -216,6 +216,84 @@ async def test_update_team_member_403_when_not_self_or_admin():
 
 
 @pytest.mark.anyio
+async def test_update_team_member_self_can_edit_profile_fields():
+    """산티아고 Phase A SME (c): self가 프로필 필드(color 등)만 건드리면 org-admin 없이도 통과."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    self_user_id = uuid.uuid4()
+    updated = _mock_member()
+    updated.user_id = self_user_id
+    updated.color = "#ff0000"
+
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.first.return_value = updated
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.expire = MagicMock()
+
+    ctx = MagicMock()
+    ctx.user_id = str(self_user_id)
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}", json={"color": "#ff0000"})
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_team_member_self_403_when_escalating_role():
+    """산티아고 Phase A SME (c) MUST: self가 자기 role/can_manage_members/is_active/agent_config를
+    스스로 바꾸는 건 권한상승이라 org-admin 없이는 403 — 이전엔 self 경로가 전 필드를 허용했다."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    self_user_id = uuid.uuid4()
+    target = _mock_member()
+    target.user_id = self_user_id
+
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.first.return_value = target
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    ctx = MagicMock()
+    ctx.user_id = str(self_user_id)
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    try:
+        with patch("app.routers.team_members._is_org_admin", AsyncMock(return_value=False)):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.patch(
+                    f"/api/v2/team-members/{MEMBER_ID}", json={"role": "admin"},
+                )
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_deactivate_team_member_200():
     """DELETE → soft deactivate (is_active=False). S19(#3): org-admin caller로 mock."""
     client, session, app = await _client()

--- a/backend/tests/test_team_members.py
+++ b/backend/tests/test_team_members.py
@@ -176,6 +176,7 @@ async def test_get_team_member_404():
 
 @pytest.mark.anyio
 async def test_update_team_member_200():
+    """S19(#2): human 경로가 self-or-org-admin 게이트를 통과해야 진행 — org-admin caller로 mock."""
     client, session, app = await _client()
     try:
         updated = _mock_member()
@@ -186,8 +187,9 @@ async def test_update_team_member_200():
         session.execute = AsyncMock(return_value=mock_result)
         session.expire = MagicMock()  # sync 메서드(AsyncMock 코루틴 경고 회피)
 
-        async with client as c:
-            resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}", json={"color": "#ff0000"})
+        with patch("app.routers.team_members._is_org_admin", AsyncMock(return_value=True)):
+            async with client as c:
+                resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}", json={"color": "#ff0000"})
 
         assert resp.status_code == 200
     finally:
@@ -195,8 +197,27 @@ async def test_update_team_member_200():
 
 
 @pytest.mark.anyio
+async def test_update_team_member_403_when_not_self_or_admin():
+    """S19(#2 MUST): human 대상이 본인도 org-admin도 아닌 caller가 수정 시 403."""
+    client, session, app = await _client()
+    try:
+        target = _mock_member()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.first.return_value = target
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with patch("app.routers.team_members._is_org_admin", AsyncMock(return_value=False)):
+            async with client as c:
+                resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}", json={"color": "#ff0000"})
+
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_deactivate_team_member_200():
-    """DELETE → soft deactivate (is_active=False)."""
+    """DELETE → soft deactivate (is_active=False). S19(#3): org-admin caller로 mock."""
     client, session, app = await _client()
     try:
         active_member = _mock_member(is_active=True)
@@ -217,13 +238,33 @@ async def test_deactivate_team_member_200():
 
         session.execute = mock_execute
 
-        async with client as c:
-            resp = await c.delete(f"/api/v2/team-members/{MEMBER_ID}")
+        with patch("app.routers.team_members._is_org_admin", AsyncMock(return_value=True)):
+            async with client as c:
+                resp = await c.delete(f"/api/v2/team-members/{MEMBER_ID}")
 
         assert resp.status_code == 200
         body = resp.json()
         assert body["ok"] is True
         assert body["deactivated"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_deactivate_team_member_403_when_not_self_or_admin():
+    """S19(#3 MUST): human 대상이 본인도 org-admin도 아닌 caller가 deactivate 시 403."""
+    client, session, app = await _client()
+    try:
+        active_member = _mock_member(is_active=True)
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.first.return_value = active_member
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with patch("app.routers.team_members._is_org_admin", AsyncMock(return_value=False)):
+            async with client as c:
+                resp = await c.delete(f"/api/v2/team-members/{MEMBER_ID}")
+
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary
S19 security audit (`5c399de5`, E-RECRUIT, high): scope-exempt path prefixes
(`_ALWAYS_ALLOWED_PATH_PREFIXES` in `mcp_toolset.py`) bypass tool-scope gating entirely, so every
mutating endpoint under them must enforce caller-ownership itself. Full audit table (9 MUST + 4
SHOULD/LOW findings, PO-approved) lives in Sprintable doc `s19-scope-exempt-caller-check-audit`
(S19 SSOT). This PR is **Phase A** — highest-impact findings first.

- **`agents.py` `POST /{agent_id}/recruit`, `POST /{agent_id}/verify-connection`** (highest
  impact — recruit endpoint itself takeover): org-scoped only, no `assert_agent_owner`. Any org
  member — not just the agent's creator or an org-admin — could re-recruit an arbitrary agent
  (rotating its API key, changing its role/system prompt) or trigger connection verification for
  it. Fixed by reusing `assert_agent_owner`, the same primitive `team_members.py` already uses
  for agent-type update/deactivate.
- **`team_members.py` `PATCH /{id}/heartbeat`**: no `auth` parameter at all — any caller could
  spoof any member's presence (`last_seen_at`/`agent_status`). Fixed with the same
  `resolve_member`-based self-scope pattern used for claim/unclaim (S17).
- **`team_members.py` `PATCH /{id}`, `DELETE /{id}`**: only checked ownership for agent targets —
  the human-target path had zero check, letting any org member edit or deactivate any other
  human member. Fixed with a new `_assert_can_manage_human` helper (self-or-org-admin, reusing
  `_is_org_admin`).

## Real-DB verification
Seeded Alice/Bob/OrgAdmin (humans) + AgentX (owned by Alice) in the same org/project against a
throwaway `pgvector/pg16` Postgres instance, called the actual router functions directly:
- Bob spoofing AgentX's heartbeat → 403; AgentX self-heartbeat → 200.
- Bob editing/deactivating Alice → 403; Alice self-edit → 200; org-admin edit/deactivate → 200.
- Bob calling `assert_agent_owner` on AgentX → 403; Alice (creator) and org-admin → both pass.

Negative-tested the human-path update gate by reverting it and confirming Bob could edit Alice
before restoring the fix.

Full suite: 3061 passed, 7 failed (same pre-existing unrelated baseline — `test_tools_list_89_tools`
+ `test_agent_mcp_json_uses_python`/`test_own_mcp_json_python_path` variants).

## Test plan
- [x] Real-Postgres exploit reproduction + fix verification (all 9 Phase-A cases)
- [x] Negative-tested the human self-or-admin gate
- [x] Updated mocked unit tests across `test_team_members.py`, `test_s2_2_passive_heartbeat.py`,
      `test_e_recruit_s3_recruit_endpoint.py`, `test_ob2_verify_connection.py`,
      `test_e_mcp_opt_s3_hosted_transport.py`, `test_e_mcp_opt_s5_hardening.py` (new 403
      regression tests added alongside the existing 200 cases)
- [x] Full backend suite green (baseline-only failures)
- [ ] 까심 cross-model QA (per-endpoint Bob→Alice mutation attempts)
- [ ] 산티아고 SME review

Story: S19 (`5c399de5`, E-RECRUIT, high, SECURITY) — Phase A of 3 (B: notifications/events,
C: read-only). Audit SSOT: Sprintable doc `s19-scope-exempt-caller-check-audit`.

---

## Update: Phase B + critical axis regression (A) + privilege-escalation fix (B)

### Phase B — notifications.py + events.py
- `PUT /notification-settings`, `POST /inbox/{id}/resolve`, `POST /inbox/{id}/dismiss`: added
  caller-ownership gates (self-or-org-admin / assignee==caller). `resolved_by` is now
  server-derived from the verified assignee — never trusted from the request body.
- `PATCH /{event_id}/delivered`: added recipient==caller enforcement.
- `POST /events` (`create_event`): `sender_id`, if provided, must now match the caller's own
  identity (blocks impersonation). `sender_id=None` — used for system-generated events — is
  unaffected.
- `POST /events/expire-stale`: added an org-admin-only gate (privilege category, not per-resource
  ownership — there was no gate at all before).

### Critical regression found while building Phase B (A)
Cross-checking notifications.py's target columns against `dispatch_notification`'s real write
site (`team_members.py`, `target_member_ids` populated from `TeamMember.id`) revealed that S17's
self-scope pattern (`resolve_member(auth, ...).id != path_id`) silently breaks for **human JWT
callers**: `resolve_member`'s human branch returns `OrgMember.id`, a different table's primary key
than the `team_members`-view id these paths actually key on. A human self-claiming their own
story, sending their own heartbeat, or locking their own files got **403'd**. Only agent (API-key)
callers were ever verified in S17, because an agent's own `auth.user_id` already equals its
`team_members` id — masking the bug entirely.

Root-fixed by adding `is_caller_member`/`assert_caller_is_member` to `member_resolver.py`: an
axis-safe comparison against the raw identity fields directly (agent → id equality; human →
`TeamMember.user_id` equality) instead of relying on any resolver's polymorphic `.id`. Applied
uniformly to `claim_story`, `unclaim_story`, `heartbeat` (`team_members.py`), `lock_files`,
`unlock_files` (`file_locks.py`), and this PR's own new self-scope checks.

### 산티아고 SME Phase-A follow-up (B)
`update_team_member`'s self-path allowed the full `TeamMemberUpdate` payload — including `role`,
`can_manage_members`, `is_active`, `agent_config` — letting a human self-escalate by PATCHing
their own role to admin. Fixed by narrowing self-editable fields to an explicit allowlist
(`name`/`avatar_url`/`color`); any other field on a self-target now also requires org-admin.
`deactivate` is unaffected (binary operation, no escalation vector — self-or-admin stays as-is).

### Real-DB verification (fresh, non-reused ids per role — no coincidental masking)
- Human self-claim/heartbeat/lock now succeed (previously 403'd).
- Self role/`can_manage_members` escalation → 403; self profile-field edits still succeed;
  org-admin can still edit any field.
- Notifications/events self-or-admin / assignee / recipient / sender checks all still correct.
- Negative-tested both the axis fix and the field-restriction fix by reverting each and confirming
  the respective exploit reproduces before restoring.

Full suite: 3070 passed, 7 failed (same pre-existing unrelated baseline).

## Test plan (updated)
- [x] Real-Postgres verification with genuinely distinct User/Member/OrgMember ids for all of A/B
- [x] Negative-tested both regression fixes
- [x] All mocked unit tests updated across 8 test files (403 + 200 cases both covered)
- [x] Full backend suite green (baseline-only failures)
- [ ] 까심 cross-model QA (re-run — prior "no human regression" verdict on S17 was itself a
      false negative from same-id test seeding, per PO)
- [ ] 산티아고 SME re-review

---

## Update: closing the last HIGH — read-exposure on notifications/inbox GETs

까심's delta re-QA confirmed A/B and all Phase B write endpoints, but caught that the sibling
**read** endpoints for the same resources were still unguarded: `GET /notification-settings`,
`GET /inbox`, `GET /inbox/incoming`. Any org member could read another member's notification
preferences or inbox items (information disclosure) despite the write side (PUT/POST) already
being gated in this PR.

Applied the identical `_assert_self_or_org_admin` gate used by the write endpoints.

Real-DB verification: Bob can no longer read Alice's settings/inbox; Alice still can. Negative-
tested by reverting the gate and confirming both exploits reproduce before restoring. Full suite:
3073 passed, 7 failed (same baseline).

This should close S19's MUST/HIGH scope. Phase C's remaining item (`current-project`) was already
judged a no-op skip.

## Update: last MUST closed — get_pending_events recipient check (산티아고 final SME pass)

산티아고's final SME pass caught one more sibling-read gap: `GET /api/v2/events/pending`
(`get_pending_events`) took `recipient_id` as a plain query param and returned that member's
events (payload/sender/source) with **zero auth/recipient check** — the exact same recurring
"write fixed, sibling read fallback missed" pattern as the notifications/inbox GETs above.
`PATCH /{event_id}/delivered` (write) already enforced recipient==caller; this read endpoint on
the same axis did not.

Fixed by adding `auth: AuthContext = Depends(get_current_user)` and calling
`assert_caller_is_member(recipient_id, auth, db, org_id, ...)` — mirrors `mark_delivered`'s pure
self-scope pattern (no org-admin override was indicated for this endpoint).

Real-DB verification (fresh alice/bob, non-reused ids): Bob querying `recipient_id=alice`'s
pending events → 403; Alice querying her own → 200 (1 event returned). Negative-tested by
reverting the guard and confirming Bob's read succeeds (`UNEXPECTED SUCCESS`) before restoring.

Full suite: 3074 passed, 7 failed (same pre-existing unrelated baseline —
`test_tools_list_89_tools`, `test_python_mcp_instances_running`,
`test_agent_mcp_json_uses_python[×4]`, `test_own_mcp_json_python_path`).

## Test plan (final)
- [x] Real-Postgres verification with genuinely distinct ids (all rounds, including this one)
- [x] Negative-tested every fix in this PR (axis regression, field-restriction, GET exposures ×4,
      get_pending_events)
- [x] All mocked unit tests updated (9 test files across the PR)
- [x] Full backend suite green (baseline-only failures)
- [x] 까심 cross-model QA — all rounds CLOSE (axis-safe self-scope, privilege-escalation fix,
      notifications/inbox GET exposure)
- [x] 산티아고 SME — all rounds PASS; this is the final MUST from 산티아고's last pass

This closes S19's full MUST scope. Awaiting 까심 delta re-QA on this last item, then 산티아고
confirm, then PO merge.
