### PR TITLE
fix(auth): serve onboarding-guide.txt publicly (E-SLD S45a5a006)

### DIFF
--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -50,6 +50,13 @@ describe('proxy', () => {
     }
   });
 
+  it('serves onboarding-guide.txt as public — no 307-to-login (45a5a006)', async () => {
+    // PUBLIC_EXACT 누락 시 이 요청이 보호 라우트로 오인돼 /login 307로 튕겨나간다(공개 정적
+    // 문서가 로그인 뒤에 묶이는 회귀) — no-cookie 요청으로 그 정확한 실패 모드를 재현·가드.
+    const response = await middleware(makeRequest('/onboarding-guide.txt'));
+    expect(response.status).toBe(200);
+  });
+
   it('passes all /api/* paths without JWT check', async () => {
     const apiPaths = [
       '/api/v1/bridge/slack/interactions',

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -9,6 +9,9 @@ const PUBLIC_EXACT = [
   '/llms.txt',
   '/llms-full.txt',
   '/llms-baos.txt',
+  // 45a5a006: 공개 정적 문서(app 자체 온보딩 가이드, 랜딩과 내용 상이해 리다이렉트 대상 아님) —
+  // 누락 시 인증 미들웨어가 보호 라우트로 오인해 /login 307(공개 문서가 로그인 뒤에 묶이는 버그).
+  '/onboarding-guide.txt',
 ];
 
 // Fully public paths — no token check at all


### PR DESCRIPTION
## Summary
- `app.sprintable.ai/onboarding-guide.txt` returned `307 → /login` — the static public doc was missing from `proxy.ts`'s `PUBLIC_EXACT` allowlist (`llms.txt`/`llms-full.txt`/`llms-baos.txt` were already there, this one wasn't), so the auth middleware treated it as a protected route.
- Content differs between the app's copy (Korean) and the landing site's copy (English), so per this story's existing code comment this file is served directly rather than redirected to `sprintable.ai` — unlike `llms.txt`/`llms-full.txt`, which already 301 there via the host-scoped redirects in `next.config.ts` (that part of this story was already merged in #1269, found while investigating — this PR closes the one remaining gap).
- One-line fix: add `/onboarding-guide.txt` to `PUBLIC_EXACT`.

## Test plan
- [x] tsc: 0 errors
- [x] eslint: 0 errors
- [x] vitest: 932 passed / 2 skipped (0 regressions — 1 new regression test)
- [x] New test mutation-tested against the original `PUBLIC_EXACT` list (removed the new entry, confirmed the test fails with 307 instead of 200, restored the fix) to confirm it actually catches this exact bug class.
- [x] `pnpm build`: success

## Scope note
The host-scoped `llms.txt`/`llms-full.txt` 301 redirects (already merged, #1269) can only be live-verified on the real `app.sprintable.ai` prod domain — dev's Cloud Run URL doesn't match the host condition. That verification is tracked separately against the next prod promotion (confirmed with Ortega). This PR's `onboarding-guide.txt` fix has no host condition and is fully dev-verifiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)