### PR TITLE
fix(security): prod hotfix — S19 caller-ownership 가드 main 이식 (CRITICAL)

### DIFF
--- a/backend/app/repositories/analytics.py
+++ b/backend/app/repositories/analytics.py
@@ -339,6 +339,9 @@ class AnalyticsRepository:
     ) -> list[dict]:
         limit = min(limit, 100)
 
+        # S20 전수스캔(산티아고 SME fast-follow, sibling — reward.py:leaderboard와 동형):
+        # reward_balances 뷰는 org_id 컬럼이 없어 SQL 필터 불가·caller가 project_id를 caller
+        # org 소속인지 사전 검증해야 한다(현재 미라우팅 dead code지만 향후 재배선 landmine 방지).
         if period == "all":
             q = "SELECT member_id, balance FROM reward_balances WHERE project_id = :pid ORDER BY balance DESC"
             params: dict = {"pid": str(project_id), "lim": limit}
@@ -351,10 +354,11 @@ class AnalyticsRepository:
 
         period_ms = {"daily": 86400, "weekly": 7 * 86400, "monthly": 30 * 86400}
         seconds = period_ms.get(period, 86400)
-        params2: dict = {"pid": str(project_id), "seconds": seconds}
+        params2: dict = {"pid": str(project_id), "org_id": str(self.org_id), "seconds": seconds}
         q2 = (
             "SELECT member_id, SUM(amount) AS balance FROM reward_ledger"
-            " WHERE project_id = :pid AND created_at >= NOW() - (:seconds || ' seconds')::interval"
+            " WHERE project_id = :pid AND org_id = :org_id"
+            " AND created_at >= NOW() - (:seconds || ' seconds')::interval"
             " GROUP BY member_id ORDER BY balance DESC LIMIT :lim"
         )
         params2["lim"] = limit

--- a/backend/app/repositories/reward.py
+++ b/backend/app/repositories/reward.py
@@ -80,6 +80,9 @@ class RewardRepository:
     ) -> list[dict]:
         limit = min(limit, 100)
 
+        # S20 전수스캔(산티아고 SME fast-follow): reward_balances 뷰는 org_id 컬럼이 없어(member_id,
+        # project_id, balance만) SQL 레벨 org_id 필터가 불가 — project_id가 caller org 소속인지는
+        # 라우터(get_leaderboard)에서 사전 검증한다(project_id는 org 1:1이라 그걸로 충분).
         if period == "all":
             q = (
                 "SELECT member_id, balance FROM reward_balances"
@@ -95,10 +98,12 @@ class RewardRepository:
 
         period_seconds = {"daily": 86400, "weekly": 7 * 86400, "monthly": 30 * 86400}
         seconds = period_seconds.get(period, 86400)
-        params2: dict = {"pid": str(project_id), "seconds": seconds, "lim": limit}
+        # S20 전수스캔(산티아고 SME fast-follow): reward_ledger는 org_id 보유 — list()/get_balance()와
+        # 동형으로 org_id 필터 추가(project_id만으론 타 org 리더보드 노출 가능했다).
+        params2: dict = {"pid": str(project_id), "org_id": str(self.org_id), "seconds": seconds, "lim": limit}
         q2 = (
             "SELECT member_id, CAST(SUM(amount) AS float) AS balance FROM reward_ledger"
-            " WHERE project_id = :pid"
+            " WHERE project_id = :pid AND org_id = :org_id"
             " AND created_at >= NOW() - (:seconds || ' seconds')::interval"
             " GROUP BY member_id ORDER BY balance DESC LIMIT :lim"
         )

--- a/backend/app/routers/agent_runs.py
+++ b/backend/app/routers/agent_runs.py
@@ -4,8 +4,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.models.project import Project
 from app.models.team import TeamMember
 from app.repositories.agent_run import AgentRunRepository
 from app.schemas.agent_run import AgentRunResponse, CreateAgentRun, UpdateAgentRun
@@ -23,9 +24,16 @@ async def list_agent_runs(
     agent_id: uuid.UUID | None = Query(default=None),
     limit: int = Query(default=50, ge=1, le=200),
     cursor: str | None = Query(default=None),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     _auth: AuthContext = Depends(get_current_user),
     repo: AgentRunRepository = Depends(_get_repo),
 ) -> list[AgentRunResponse]:
+    """prod 핫픽스(S20 전수스캔 — create_agent_run과 동일 클래스): project_id가 caller org
+    소속인지 검증 없이 임의 project의 agent run 목록을 열람할 수 있었다(cross-org)."""
+    proj_r = await session.execute(select(Project.id).where(Project.id == project_id, Project.org_id == org_id))
+    if proj_r.scalar_one_or_none() is None:
+        raise HTTPException(status_code=404, detail="Project not found")
     runs = await repo.list(project_id=project_id, agent_id=agent_id, limit=limit, cursor=cursor)
     return [AgentRunResponse.model_validate(r) for r in runs]
 
@@ -34,19 +42,23 @@ async def list_agent_runs(
 async def create_agent_run(
     body: CreateAgentRun,
     session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     _auth: AuthContext = Depends(get_current_user),
     repo: AgentRunRepository = Depends(_get_repo),
 ) -> AgentRunResponse:
-    # team_members 는 projection VIEW — 멀티프로젝트 grant 면 같은 agent_id 가 N 행. org_id 는 전
-    # projection 행에서 동형이라 .limit(1) 로 MultipleResultsFound 회피(아무 행 OK).
+    """prod 핫픽스(S20 전수스캔 MUST): cross-org IDOR — org_id를 body.agent_id가 속한 org에서
+    그대로 파생해(caller org 검증 없이) 타 org agent 명의로 run을 생성할 수 있었다. caller의
+    get_verified_org_id로 파생하고 agent_id가 그 org 소속인지 검증한다.
+    """
+    # team_members 는 projection VIEW — 멀티프로젝트 grant 면 같은 agent_id 가 N 행. org_id 필터로
+    # caller org 소속만 통과(cross-org 차단) — .limit(1) 로 MultipleResultsFound 회피.
     member_r = await session.execute(
-        select(TeamMember.org_id).where(
-            TeamMember.id == body.agent_id, TeamMember.type == "agent",
+        select(TeamMember.id).where(
+            TeamMember.id == body.agent_id, TeamMember.type == "agent", TeamMember.org_id == org_id,
             TeamMember.is_active.is_(True),  # deactivated agent 는 run 생성 비도달(정합)
         ).limit(1)
     )
-    org_id = member_r.scalar_one_or_none()
-    if org_id is None:
+    if member_r.scalar_one_or_none() is None:
         raise HTTPException(status_code=400, detail="agent_id not found or not an agent")
 
     run = await repo.create(
@@ -70,9 +82,15 @@ async def create_agent_run(
 async def update_agent_run(
     id: uuid.UUID,
     body: UpdateAgentRun,
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     _auth: AuthContext = Depends(get_current_user),
     repo: AgentRunRepository = Depends(_get_repo),
 ) -> AgentRunResponse:
+    """prod 핫픽스(S20 전수스캔 — create_agent_run과 동일 클래스): run id만으로 org 검증 없이
+    임의 org의 agent run을 수정할 수 있었다."""
+    existing = await repo.get(id)
+    if existing is None or existing.org_id != org_id:
+        raise HTTPException(status_code=404, detail="Agent run not found")
     run = await repo.update(
         id,
         status=body.status,

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.dependencies.ownership import assert_agent_owner
 from app.models.project import Project
 from app.models.team import TeamMember
 from app.schemas.team_member import OrgAgentCreate, TeamMemberResponse
@@ -234,10 +235,11 @@ async def verify_agent_connection(
     이 가드보다 먼저면 미배정 에이전트가 stdio=400/http=200으로 갈렸다(까심 QA). project 스코프가
     없는 에이전트는애초에 "연결 검증"이 의미가 없으므로(heartbeat 조차 project 컨텍스트 하 tool
     호출을 전제) 두 transport 모두 이 가드를 먼저 통과해야 한다.
+
+    S19(#9 MUST, prod 핫픽스): org-scope 조회(`_fetch_org_agent`)만으로는 org 내 임의 멤버가
+    남의 agent 연결검증을 트리거할 수 있었다. `assert_agent_owner`(생성자 또는 org-admin)로 닫는다.
     """
-    member = await _fetch_org_agent(session, agent_id, org_id)
-    if member is None:
-        raise HTTPException(status_code=404, detail="Agent not found")
+    member = await assert_agent_owner(agent_id, session, org_id, uuid.UUID(auth.user_id))
     if not member.project_id:
         raise HTTPException(status_code=400, detail="agent has no project scope to verify")
 

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.pm import Story, Task
 from app.models.team import TeamMember
@@ -18,17 +18,27 @@ async def get_dashboard(
     member_id: uuid.UUID = Query(...),
     project_id: uuid.UUID | None = Query(default=None),
     session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     _auth: AuthContext = Depends(get_current_user),
 ) -> DashboardResponse:
+    """prod 핫픽스(S20 전수스캔 MUST): cross-org 데이터 누출 차단.
+
+    이전엔 org_id 검증 자체가 없어(get_verified_org_id 미호출) 임의 member_id로 타 org 멤버의
+    대시보드(할당 스토리/태스크)를 그대로 열람할 수 있었다 — `project_id`를 명시하면 member 조회
+    자체가 생략돼 더 심했다. member가 caller org 소속인지 항상 검증(project_id 명시 여부 무관).
+    assignee 기준 열람 자체는 stories/tasks 목록 필터와 동일한 프로젝트 협업 시야라 자기 자신으로
+    제한하지 않는다(PO 확인).
+    """
+    member_check = await session.execute(
+        select(TeamMember.project_id).where(
+            TeamMember.id == member_id, TeamMember.org_id == org_id, TeamMember.is_active.is_(True)
+        ).limit(1)
+    )
+    member_project_id = member_check.scalar_one_or_none()
+    if member_project_id is None:
+        raise HTTPException(status_code=404, detail="Member not found or inactive")
     if project_id is None:
-        tm_r = await session.execute(
-            select(TeamMember.project_id).where(
-                TeamMember.id == member_id, TeamMember.is_active.is_(True)
-            ).limit(1)
-        )
-        project_id = tm_r.scalar_one_or_none()
-        if project_id is None:
-            raise HTTPException(status_code=404, detail="Member not found or inactive")
+        project_id = member_project_id
 
     stories_r = await session.execute(
         select(Story.id, Story.title, Story.status, Story.story_points).where(

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -28,8 +28,9 @@ from app.dependencies.auth import (
     get_verified_org_id_streaming,
 )
 from app.dependencies.database import get_db
+from app.dependencies.ownership import _is_org_admin
 from app.models.event import Event
-from app.services.member_resolver import resolve_member_identity
+from app.services.member_resolver import assert_caller_is_member, resolve_member_identity
 
 router = APIRouter(prefix="/api/v2/events", tags=["events"])
 
@@ -405,13 +406,26 @@ async def create_event(
     background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> EventResponse:
     """POST /api/v2/events — 이벤트 생성 (내부용).
 
     recipient가 SSE 연결 중이면 즉시 전달 + status=delivered.
     미연결이면 status=pending 유지.
     Channel Router(S-A6)로 preference 기반 채널 결정 후 전달.
+
+    S19(SHOULD, PO 포함 승인): sender_id가 검증 없이 body에서 그대로 신뢰돼 caller가 임의
+    sender로 이벤트를 위조(임퍼스네이션)할 수 있었다. sender_id가 명시되면 caller 본인과
+    일치해야만 허용(시스템 이벤트의 sender_id=None 케이스는 그대로 무변경).
+
+    S19(발견·회귀수정): axis-safe 비교(assert_caller_is_member) 사용 — resolve_member()/.id
+    직접비교는 휴먼 JWT caller에서 축이 어긋나 본인 sender_id 지정도 403날 수 있었다.
     """
+    if body.sender_id is not None:
+        await assert_caller_is_member(
+            body.sender_id, auth, db, org_id, detail="sender_id must match the caller's own identity",
+        )
+
     # recipient가 동일 org 소속인지 + type 확정
     # E-MEMBER-SSOT Phase 0: grant-only 휴먼(org_member)도 수신자로 허용
     recipient = await resolve_member_identity(body.recipient_id, org_id, db)
@@ -469,12 +483,21 @@ async def get_pending_events(
     include_recent_delivered_minutes: int = Query(default=30, le=120),
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[EventResponse]:
     """GET /api/v2/events/pending — 수신자별 pending + 최근 N분 delivered 이벤트 목록.
 
     include_recent_delivered_minutes: SSE로 delivered 마킹된 이벤트도 최근 N분 이내라면 반환.
     → SSE 전달과 poll_events 폴링 간 충돌(갭 2) 해소.
+
+    산티아고 SME 최종 MUST(S19): recipient_id 쿼리로 타 member 이벤트(payload/sender/source)를
+    auth·recipient 검증 없이 읽을 수 있었다 — mark_delivered(write)는 recipient==caller로
+    닫혔는데 같은 recipient 축의 이 read fallback이 열려있었다. 동일 패턴(순수 self, admin
+    대리열람 흐름 없음)으로 닫는다.
     """
+    await assert_caller_is_member(
+        recipient_id, auth, db, org_id, detail="Cannot read another member's events",
+    )
     cutoff = datetime.now(timezone.utc) - timedelta(minutes=include_recent_delivered_minutes)
     status_filter = or_(
         Event.status == "pending",
@@ -499,14 +522,26 @@ async def mark_delivered(
     event_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> EventResponse:
-    """PATCH /api/v2/events/{id}/delivered — 전달 완료 마킹."""
+    """PATCH /api/v2/events/{id}/delivered — 전달 완료 마킹.
+
+    S19(#7 MUST): org-scope만 있고 recipient 확인이 없어 누구나 타 member의 이벤트를
+    delivered로 마킹(알림 은폐)할 수 있었다. caller==recipient 강제(axis-safe).
+
+    S19(발견·회귀수정): resolve_member()/.id 직접비교는 휴먼 JWT caller의 axis가 어긋나 본인
+    이벤트도 403날 수 있었다 — assert_caller_is_member로 교체.
+    """
     result = await db.execute(
         select(Event).where(Event.id == event_id, Event.org_id == org_id)
     )
     event = result.scalar_one_or_none()
     if event is None:
         raise HTTPException(status_code=404, detail="Event not found")
+
+    await assert_caller_is_member(
+        event.recipient_id, auth, db, org_id, detail="Not the recipient of this event",
+    )
 
     event.status = "delivered"
     event.delivered_at = datetime.now(timezone.utc)
@@ -554,6 +589,13 @@ async def expire_stale_events_core(
 async def expire_stale_events(
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
-    """POST /api/v2/events/expire-stale — 30일 초과 pending → expired, 7일 초과 delivered 삭제."""
+    """POST /api/v2/events/expire-stale — 30일 초과 pending → expired, 7일 초과 delivered 삭제.
+
+    S19(SHOULD, PO 포함 승인): per-resource ownership 문제가 아니라 privilege 게이트 자체가
+    없어 org 내 임의 멤버가 org 전체 이벤트 만료/삭제를 강제할 수 있었다. org-admin 전용으로 닫는다.
+    """
+    if not await _is_org_admin(db, org_id, uuid.UUID(auth.user_id)):
+        raise HTTPException(status_code=403, detail="org admin/owner required")
     return await expire_stale_events_core(db, org_id)

--- a/backend/app/routers/file_locks.py
+++ b/backend/app/routers/file_locks.py
@@ -10,11 +10,12 @@ from pydantic import BaseModel
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import get_current_user, get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.file_lock import FileLock
 from app.models.team import TeamMember
 from app.routers.events import publish_event
+from app.services.member_resolver import assert_caller_is_member
 from app.services.webhook_dispatch import fire_webhooks
 
 router = APIRouter(tags=["file-locks"])
@@ -99,16 +100,24 @@ async def lock_files(
     body: FileLockBody,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
-    """AC1/3: 파일 lock 등록 + 충돌 시 warning 반환."""
-    # AC3-5 ②: team_members가 뷰(0088) — multi-row 안전(휴먼 multi-project) .limit(1).first().
+    """AC1/3: 파일 lock 등록 + 충돌 시 warning 반환.
+
+    prod 핫픽스(까심 재QA CRITICAL): ``_auth``가 선언만 되고 미사용 — caller-ownership 확인이
+    전혀 없었고, member 조회도 org_id 필터가 없어 타 org의 member_id를 targeting할 수 있었다.
+    self-scope(assert_caller_is_member) + org_id 필터 추가(core IDOR 가드만 — S17의
+    reclassify/cap/project-determinism 확장은 dev 기능이라 제외).
+    """
+    # org_id 필터: 타 org의 member_id를 targeting하는 cross-org IDOR 방지.
     member_result = await session.execute(
-        select(TeamMember).where(TeamMember.id == member_id).limit(1)
+        select(TeamMember).where(TeamMember.id == member_id, TeamMember.org_id == org_id).limit(1)
     )
     member = member_result.scalars().first()
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
+
+    await assert_caller_is_member(member_id, auth, session, org_id, detail="Cannot lock files as another member")
 
     # AC3: 충돌 체크
     conflicts = await _find_conflicts(session, member.project_id, member_id, body.file_paths)
@@ -145,13 +154,19 @@ async def unlock_files(
     body: FileUnlockBody,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
-    """AC2: 파일 lock 해제."""
+    """AC2: 파일 lock 해제.
+
+    prod 핫픽스(까심 재QA CRITICAL): lock_files와 동일 갭 — self-scope + org_id 필터 추가.
+    """
+    await assert_caller_is_member(member_id, auth, session, org_id, detail="Cannot unlock files as another member")
+
     now = datetime.now(timezone.utc)
     await session.execute(
         update(FileLock)
         .where(
+            FileLock.org_id == org_id,
             FileLock.member_id == member_id,
             FileLock.file_path.in_(body.file_paths),
             FileLock.released_at.is_(None),

--- a/backend/app/routers/hitl_config.py
+++ b/backend/app/routers/hitl_config.py
@@ -6,8 +6,9 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import get_current_user, get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.dependencies.ownership import _is_org_admin
 from app.models.hitl_config import MemberGateOverride, OrgGateOverride, OrgGatePolicy
 from app.repositories.base import BaseRepository
 from app.schemas.hitl_config import (
@@ -48,8 +49,12 @@ async def upsert_org_policy(
     body: OrgGatePolicyCreate,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> OrgGatePolicyResponse:
+    """prod 핫픽스(S20 전수스캔 HIGH, expire-stale 동형): org-admin 게이트 — 이전엔 admin 체크가
+    전무해 org 내 임의 멤버가 org 전체 HITL gate posture를 바꿀 수 있었다."""
+    if not await _is_org_admin(session, org_id, uuid.UUID(auth.user_id)):
+        raise HTTPException(status_code=403, detail="org admin/owner required")
     r = await session.execute(
         select(OrgGatePolicy).where(OrgGatePolicy.org_id == org_id).limit(1)
     )
@@ -83,8 +88,11 @@ async def upsert_org_override(
     body: OrgGateOverrideCreate,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> OrgGateOverrideResponse:
+    """prod 핫픽스(S20 전수스캔 HIGH): org-admin 게이트 추가."""
+    if not await _is_org_admin(session, org_id, uuid.UUID(auth.user_id)):
+        raise HTTPException(status_code=403, detail="org admin/owner required")
     r = await session.execute(
         select(OrgGateOverride).where(
             OrgGateOverride.org_id == org_id,
@@ -111,8 +119,11 @@ async def delete_org_override(
     id: uuid.UUID,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    """prod 핫픽스(S20 전수스캔 HIGH): org-admin 게이트 추가."""
+    if not await _is_org_admin(session, org_id, uuid.UUID(auth.user_id)):
+        raise HTTPException(status_code=403, detail="org admin/owner required")
     r = await session.execute(
         select(OrgGateOverride).where(OrgGateOverride.id == id, OrgGateOverride.org_id == org_id)
     )
@@ -131,8 +142,12 @@ async def upsert_member_override(
     body: MemberGateOverrideCreate,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> MemberGateOverrideResponse:
+    """prod 핫픽스(S20 전수스캔 HIGH): org-admin 게이트 — 이전엔 org 내 임의 멤버가 타 멤버의
+    gate override를 조작할 수 있었다."""
+    if not await _is_org_admin(session, org_id, uuid.UUID(auth.user_id)):
+        raise HTTPException(status_code=403, detail="org admin/owner required")
     r = await session.execute(
         select(MemberGateOverride).where(
             MemberGateOverride.org_id == org_id,
@@ -159,8 +174,11 @@ async def delete_member_override(
     id: uuid.UUID,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    """prod 핫픽스(S20 전수스캔 HIGH): org-admin 게이트 추가."""
+    if not await _is_org_admin(session, org_id, uuid.UUID(auth.user_id)):
+        raise HTTPException(status_code=403, detail="org admin/owner required")
     r = await session.execute(
         select(MemberGateOverride).where(
             MemberGateOverride.id == id, MemberGateOverride.org_id == org_id
@@ -247,14 +265,19 @@ async def apply_adjustment(
     body: ApplyRecommendationRequest,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
     """인간 승인 후 override 적용.
 
     ⚠️ 자동 호출 금지 — 반드시 인간이 추천 검토 후 명시 호출.
     apply_as='member': member_gate_override upsert.
     apply_as='org_role': org_gate_override upsert (role_id 필수).
+
+    prod 핫픽스(S20 전수스캔 — upsert_org_policy/overrides와 동일 클래스, 스캔표엔 5건으로
+    적혔지만 이 엔드포인트도 override를 직접 upsert하면서 admin 게이트가 없었다): org-admin 게이트 추가.
     """
+    if not await _is_org_admin(session, org_id, uuid.UUID(auth.user_id)):
+        raise HTTPException(status_code=403, detail="org admin/owner required")
     from app.models.hitl_config import DISPOSITIONS
 
     if body.disposition not in DISPOSITIONS:

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -27,7 +27,13 @@ async def get_me(
     is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
 
     if member_id:
-        where_clause = TeamMember.id == member_id
+        # S20(authz-coverage 스캐너 발견 — update_me엔 있는 self-check가 이 GET엔 없었다):
+        # 명시 member_id가 caller 본인일 때만 매칭 — 아니면 임의 member의 email 등 PII를
+        # 그대로 반환하던 갭(MeResponse.email 노출).
+        if is_api_key:
+            where_clause = (TeamMember.id == member_id) & (TeamMember.id == uid)
+        else:
+            where_clause = (TeamMember.id == member_id) & (TeamMember.user_id == uid)
     elif is_api_key:
         # API key 인증: auth.user_id = TeamMember.id
         where_clause = TeamMember.id == uid

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.dependencies.ownership import _is_org_admin
 from app.models.team import TeamMember
 from app.repositories.notification import InboxRepository, NotificationRepository, NotificationSettingRepository
 from app.schemas.notification import (
@@ -15,8 +16,26 @@ from app.schemas.notification import (
     ResolveInboxItem,
     UpsertNotificationSetting,
 )
+from app.services.member_resolver import assert_caller_is_member, is_caller_member
 
 router = APIRouter(prefix="/api/v2", tags=["notifications"])
+
+
+async def _assert_self_or_org_admin(
+    member_id: uuid.UUID, auth: AuthContext, session: AsyncSession, org_id: uuid.UUID,
+) -> None:
+    """S19(#4-#6 MUST): notifications/inbox 리소스가 caller-ownership 확인 없이 임의 member_id를
+    받아들이던 갭 — self(axis-safe) 또는 org-admin만 허용한다.
+
+    S19(발견·회귀수정): resolve_member()/.id 직접비교(및 그 대체였던 resolve_auth_member 단독
+    사용)는 휴먼 JWT caller에서 축이 어긋날 수 있다 — is_caller_member(agent=id 직접비교·
+    human=team_members뷰의 user_id 컬럼과 비교)로 axis-safe하게 판정한다.
+    """
+    if await is_caller_member(member_id, auth, session, org_id):
+        return
+    if await _is_org_admin(session, org_id, uuid.UUID(auth.user_id)):
+        return
+    raise HTTPException(status_code=403, detail="Not authorized for this member")
 
 
 async def _resolve_notification_user_id(auth: AuthContext, db: AsyncSession) -> uuid.UUID:
@@ -120,8 +139,12 @@ async def mark_read(
 async def get_notification_settings(
     member_id: uuid.UUID = Query(...),
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[NotificationSettingResponse]:
+    """까심 델타 재QA HIGH(S19): write(PUT)만 닫히고 이 GET은 무가드로 남아 타 member 알림설정을
+    누구나 조회할 수 있었다(정보노출). PUT과 동일한 self-or-org-admin 게이트 적용."""
+    await _assert_self_or_org_admin(member_id, auth, session, org_id)
     repo = NotificationSettingRepository(session)
     settings = await repo.get_by_member(member_id=member_id)
     return [NotificationSettingResponse.model_validate(s) for s in settings]
@@ -133,7 +156,11 @@ async def upsert_notification_setting(
     body: UpsertNotificationSetting = ...,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> NotificationSettingResponse:
+    """S19(#4 MUST): member_id 쿼리파람에 caller-ownership 확인이 없어 누구나 타 member의 알림
+    설정을 덮어쓸 수 있었다. self-or-org-admin 게이트 추가."""
+    await _assert_self_or_org_admin(member_id, auth, session, org_id)
     repo = NotificationSettingRepository(session)
     setting = await repo.upsert(
         org_id=org_id,
@@ -149,8 +176,14 @@ async def upsert_notification_setting(
 async def list_inbox(
     assignee_member_id: uuid.UUID = Query(...),
     state: str | None = Query(default=None),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
     repo: InboxRepository = Depends(_inbox_repo),
 ) -> list[InboxItemResponse]:
+    """까심 델타 재QA HIGH(S19): 무가드로 남아 타 member의 inbox를 누구나 조회할 수 있었다
+    (정보노출). resolve/dismiss와 동일한 self-or-org-admin 게이트 적용."""
+    await _assert_self_or_org_admin(assignee_member_id, auth, session, org_id)
     items = await repo.list(assignee_member_id=assignee_member_id, state=state)
     return [InboxItemResponse.model_validate(i) for i in items]
 
@@ -158,8 +191,13 @@ async def list_inbox(
 @router.get("/inbox/incoming", response_model=list[InboxItemResponse])
 async def list_incoming(
     assignee_member_id: uuid.UUID = Query(...),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
     repo: InboxRepository = Depends(_inbox_repo),
 ) -> list[InboxItemResponse]:
+    """까심 델타 재QA HIGH(S19): list_inbox와 동일 갭 — self-or-org-admin 게이트 적용."""
+    await _assert_self_or_org_admin(assignee_member_id, auth, session, org_id)
     items = await repo.list_incoming(assignee_member_id=assignee_member_id)
     return [InboxItemResponse.model_validate(i) for i in items]
 
@@ -168,25 +206,54 @@ async def list_incoming(
 async def resolve_inbox_item(
     id: uuid.UUID,
     body: ResolveInboxItem,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
     repo: InboxRepository = Depends(_inbox_repo),
 ) -> InboxItemResponse:
-    item = await repo.resolve(
+    """S19(#5 MUST): auth 파라미터 자체가 없어 caller가 이 inbox item의 assignee인지 확인이
+    전혀 없었다 — 누구나 타 member의 inbox item을 resolve할 수 있었고, `resolved_by` 바디값을
+    임의로 스푸핑할 수도 있었다. assignee==caller 강제(axis-safe) + resolved_by는 확인된
+    assignee_member_id에서 서버-파생(바디값 무시 — identity는 서버가 결정, 클라이언트가
+    주장하는 게 아니다). assert_caller_is_member 통과 = caller.id == assignee_member_id가
+    이미 확정이므로 별도 caller 재조회 없이 그 값을 그대로 쓴다."""
+    item = await repo.get(id)
+    if item is None:
+        raise HTTPException(status_code=404, detail="InboxItem not found")
+
+    await assert_caller_is_member(
+        item.assignee_member_id, auth, session, org_id, detail="Not the assignee of this inbox item",
+    )
+
+    resolved = await repo.resolve(
         id=id,
-        resolved_by=body.resolved_by,
+        resolved_by=item.assignee_member_id,
         resolved_option_id=body.resolved_option_id,
         resolved_note=body.resolved_note,
     )
-    if item is None:
+    if resolved is None:
         raise HTTPException(status_code=404, detail="InboxItem not found")
-    return InboxItemResponse.model_validate(item)
+    return InboxItemResponse.model_validate(resolved)
 
 
 @router.post("/inbox/{id}/dismiss", response_model=InboxItemResponse)
 async def dismiss_inbox_item(
     id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
     repo: InboxRepository = Depends(_inbox_repo),
 ) -> InboxItemResponse:
-    item = await repo.dismiss(id=id)
+    """S19(#6 MUST): resolve와 동일 갭 — assignee==caller 강제(axis-safe)."""
+    item = await repo.get(id)
     if item is None:
         raise HTTPException(status_code=404, detail="InboxItem not found")
-    return InboxItemResponse.model_validate(item)
+
+    await assert_caller_is_member(
+        item.assignee_member_id, auth, session, org_id, detail="Not the assignee of this inbox item",
+    )
+
+    dismissed = await repo.dismiss(id=id)
+    if dismissed is None:
+        raise HTTPException(status_code=404, detail="InboxItem not found")
+    return InboxItemResponse.model_validate(dismissed)

--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -11,7 +11,7 @@ from app.models.retro import RetroItem, RetroSession, RetroVote
 from app.services import hypothesis as hyp_svc
 from app.services import retro_hypothesis_seed as seed_svc
 from app.services import retro_synthesis as synth_svc
-from app.services.member_resolver import canonicalize_member_id, resolve_member
+from app.services.member_resolver import canonicalize_member_id, lookup_members_by_ids, resolve_member
 from app.services.project_auth import has_project_access
 from app.repositories.retro import (
     RetroActionRepository,
@@ -552,6 +552,16 @@ async def list_actions(
     return [ActionResponse.model_validate(a) for a in actions]
 
 
+async def _verify_assignee_in_org(db: AsyncSession, org_id: uuid.UUID, assignee_id: uuid.UUID) -> None:
+    """prod 핫픽스(S20 전수스캔 MUST, hypothesis._verify_human_owner와 동일 클래스): assignee_id가
+    caller org 소속인지 검증 없이(canonicalize_member_id는 alias 정규화일 뿐 org 검증이 아님)
+    임의 org의 멤버를 action 담당자로 지정할 수 있었다(오귀속/신원 스푸핑)."""
+    members = await lookup_members_by_ids({assignee_id}, db)
+    rm = members.get(assignee_id)
+    if rm is None or rm.org_id != org_id:
+        raise HTTPException(status_code=400, detail="assignee_id must be a member of this organization")
+
+
 @router.post("/{id}/actions", response_model=ActionResponse, status_code=201)
 async def create_action(
     id: uuid.UUID,
@@ -563,6 +573,8 @@ async def create_action(
     await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
     action_repo = RetroActionRepository(db)
     assignee_id = (await canonicalize_member_id(body.assignee_id, db)) if body.assignee_id else None
+    if assignee_id is not None:
+        await _verify_assignee_in_org(db, repo.org_id, assignee_id)
     action = await action_repo.create(
         session_id=id, title=body.title, assignee_id=assignee_id
     )
@@ -582,6 +594,8 @@ async def update_action(
     await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
     action_repo = RetroActionRepository(db)
     data = body.model_dump(exclude_unset=True)
+    if data.get("assignee_id") is not None:
+        await _verify_assignee_in_org(db, repo.org_id, data["assignee_id"])
     action = await action_repo.update_in_session(id, action_id, **data)
     if action is None:
         raise HTTPException(status_code=404, detail="Action not found")

--- a/backend/app/routers/rewards.py
+++ b/backend/app/routers/rewards.py
@@ -3,10 +3,12 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.dependencies.ownership import _is_org_admin
 from app.repositories.reward import RewardRepository
 from app.schemas.reward import BalanceResponse, GrantReward, LeaderboardEntry, RewardLedgerResponse
+from app.services.member_resolver import is_caller_member, resolve_member
 
 router = APIRouter(prefix="/api/v2/rewards", tags=["rewards"])
 
@@ -16,6 +18,16 @@ def _get_repo(
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> RewardRepository:
     return RewardRepository(session, org_id)
+
+
+async def _assert_self_or_org_admin(
+    member_id: uuid.UUID, auth: AuthContext, session: AsyncSession, org_id: uuid.UUID,
+) -> None:
+    if await is_caller_member(member_id, auth, session, org_id):
+        return
+    if await _is_org_admin(session, org_id, uuid.UUID(auth.user_id)):
+        return
+    raise HTTPException(status_code=403, detail="Not authorized for this member")
 
 
 @router.get("", response_model=list[RewardLedgerResponse])
@@ -32,8 +44,13 @@ async def list_rewards(
 async def get_balance(
     project_id: uuid.UUID = Query(...),
     member_id: uuid.UUID = Query(...),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
     repo: RewardRepository = Depends(_get_repo),
 ) -> BalanceResponse:
+    """prod 핫픽스(S20 전수스캔 MUST): self-or-org-admin — 이전엔 caller-ownership 확인이 전혀
+    없어 org 내 임의 멤버가 타 멤버의 리워드 잔액(재무정보)을 열람할 수 있었다."""
+    await _assert_self_or_org_admin(member_id, auth, repo.session, org_id)
     balance = await repo.get_balance(project_id=project_id, member_id=member_id)
     return BalanceResponse(project_id=project_id, member_id=member_id, balance=balance)
 
@@ -41,12 +58,24 @@ async def get_balance(
 @router.post("", response_model=RewardLedgerResponse, status_code=201)
 async def grant_reward(
     body: GrantReward,
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
     repo: RewardRepository = Depends(_get_repo),
 ) -> RewardLedgerResponse:
-    # AC3-2d(2): member_id(수령자)·granted_by(지급자) canonical 정규화. (A) write. agent id는 no-op.
+    """prod 핫픽스(S20 전수스캔 MUST, 최우선): org-admin 게이트 + granted_by 서버파생.
+
+    이전엔 admin/role 체크가 전무해 org 내 임의 멤버가 타 멤버에게 임의 금액의 리워드를 발행할
+    수 있었고, `granted_by`도 body에서 그대로 신뢰돼(client-supplied) 지급자를 스푸핑할 수
+    있었다. org-admin 전용으로 닫고, granted_by는 caller 본인에서 서버-파생(body 값 무시).
+    """
+    if not await _is_org_admin(repo.session, org_id, uuid.UUID(auth.user_id)):
+        raise HTTPException(status_code=403, detail="org admin/owner required")
+
+    # AC3-2d(2): member_id(수령자)·granted_by(지급자) canonical 정규화. (A) write.
     from app.services.member_resolver import canonicalize_member_id
     member_id = await canonicalize_member_id(body.member_id, repo.session)
-    granted_by = (await canonicalize_member_id(body.granted_by, repo.session)) if body.granted_by else None
+    caller_member = await resolve_member(auth, org_id, repo.session)
+    granted_by = await canonicalize_member_id(caller_member.id, repo.session)  # S20: caller에서 서버-파생(body 무시)
     entry = await repo.grant(
         project_id=body.project_id,
         member_id=member_id,

--- a/backend/app/routers/rewards.py
+++ b/backend/app/routers/rewards.py
@@ -1,11 +1,13 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.dependencies.ownership import _is_org_admin
+from app.models.project import Project
 from app.repositories.reward import RewardRepository
 from app.schemas.reward import BalanceResponse, GrantReward, LeaderboardEntry, RewardLedgerResponse
 from app.services.member_resolver import is_caller_member, resolve_member
@@ -96,9 +98,17 @@ async def get_leaderboard(
     period: str = Query(default="all"),
     limit: int = Query(default=50, ge=1, le=100),
     cursor: str | None = Query(default=None),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     repo: RewardRepository = Depends(_get_repo),
 ) -> list[LeaderboardEntry]:
+    """산티아고 SME fast-follow(S20 전수봉인): project_id가 caller org 소속인지 검증 없어
+    타 org의 리더보드(재무/성과 aggregate)가 project_id만 알면 노출됐다 — 이제 명시 403."""
     if period not in ("daily", "weekly", "monthly", "all"):
         raise HTTPException(status_code=400, detail="period must be one of: daily, weekly, monthly, all")
+    proj_check = await repo.session.execute(
+        select(Project.id).where(Project.id == project_id, Project.org_id == org_id)
+    )
+    if proj_check.scalar_one_or_none() is None:
+        raise HTTPException(status_code=403, detail="project not accessible")
     items = await repo.leaderboard(project_id=project_id, period=period, limit=limit, cursor=cursor)
     return [LeaderboardEntry.model_validate(i) for i in items]

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
-from app.dependencies.ownership import assert_agent_owner
+from app.dependencies.ownership import _is_org_admin, assert_agent_owner
 from app.models.pm import Story
 from app.models.team import TeamMember
 from app.repositories.team_member import TeamMemberRepository
@@ -17,6 +17,7 @@ from app.schemas.team_member import (
     ActiveStorySummary, TeamMemberCreate, TeamMemberResponse, TeamMemberUpdate,
 )
 from app.services.agent_onboarding_config import build_agent_mcp_config_bundle
+from app.services.member_resolver import assert_caller_is_member, is_caller_member
 
 
 class ClaimBody(BaseModel):
@@ -336,6 +337,42 @@ async def get_team_member(
     return TeamMemberResponse.model_validate(member)
 
 
+_SELF_EDITABLE_HUMAN_FIELDS: frozenset[str] = frozenset({"name", "avatar_url", "color"})
+
+
+async def _assert_can_manage_human(
+    member: TeamMember, session: AsyncSession, org_id: uuid.UUID, auth: AuthContext,
+    data: dict | None = None,
+) -> None:
+    """S19(#2/#3 MUST + 산티아고 Phase A SME (c) MUST): human 대상 mutation(update/deactivate)이
+    caller-ownership 확인 없이 통과되던 갭 — self(본인) 또는 org-admin만 허용한다.
+
+    산티아고 (c): self 경로가 ``TeamMemberUpdate`` 전 필드를 허용해 self가 자기 ``role``/
+    ``can_manage_members``/``is_active``/``agent_config`` 등을 스스로 바꿔 권한상승할 수
+    있었다(update 한정 — deactivate는 ``data=None``으로 호출돼 필드 제약이 없다. 이진 동작이라
+    승격 벡터가 없기 때문). self가 프로필 3종(name/avatar_url/color) 외 필드를 건드리면
+    org-admin도 함께 요구한다 — allowlist 방식이라 스키마에 필드가 추가돼도 기본이 admin-only.
+
+    ``auth.user_id``는 JWT 휴먼이면 users.id(=TeamMember.user_id와 직접 비교 가능), API키
+    에이전트면 그 에이전트 자신의 team_member.id다 — 후자는 어떤 human의 user_id/org_members
+    행과도 절대 일치하지 않으므로 별도 is_api_key 분기 없이 이 비교만으로 "에이전트가 human을
+    관리할 수 없다"는 의도된 거부까지 자연히 성립한다.
+    """
+    caller_id = uuid.UUID(auth.user_id)
+    is_self = member.user_id == caller_id
+    if is_self:
+        if data is None or not (set(data.keys()) - _SELF_EDITABLE_HUMAN_FIELDS):
+            return
+    if await _is_org_admin(session, org_id, caller_id):
+        return
+    if is_self:
+        raise HTTPException(
+            status_code=403,
+            detail="Self cannot modify authority fields (role/is_active/can_manage_members/agent_config/etc.)",
+        )
+    raise HTTPException(status_code=403, detail="Not authorized to manage this member")
+
+
 @router.patch("/{id}", response_model=TeamMemberResponse)
 async def update_team_member(
     id: uuid.UUID,
@@ -344,13 +381,17 @@ async def update_team_member(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> TeamMemberResponse:
+    """S19(#2 MUST): human 경로에 caller-ownership 확인이 아예 없어 org 내 임의 멤버가 타 human의
+    role/color/name 등을 수정할 수 있었다. self-or-org-admin 게이트 추가 — self는 프로필 필드만."""
     repo = TeamMemberRepository(session, org_id)
     member = await repo.get(id)
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
+    data = body.model_dump(exclude_unset=True)
     if member.type == "agent":
         await assert_agent_owner(id, session, org_id, uuid.UUID(auth.user_id))
-    data = body.model_dump(exclude_unset=True)
+    else:
+        await _assert_can_manage_human(member, session, org_id, auth, data=data)
     # AC3-4 2-2: team_members 뷰 — 필드를 앵커 테이블로 라우팅(anchor-only). expire 후 뷰 재조회로 갱신값 반영.
     await repo.apply_anchor_update(member, data)
     session.expire(member)
@@ -363,12 +404,25 @@ async def heartbeat(
     id: uuid.UUID,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
-    """AC1/2: last_seen_at = NOW(), agent_status = online 갱신."""
+    """AC1/2: last_seen_at = NOW(), agent_status = online 갱신.
+
+    S19(#1 MUST): auth 파라미터 자체가 없어 caller 확인이 전혀 없었다 — 누구나 임의 member의
+    presence(last_seen_at/agent_status)를 스푸핑할 수 있었다. claim/unclaim과 동일한
+    axis-safe self-scope(assert_caller_is_member)로 닫는다(대리 heartbeat 흐름 없음).
+
+    S19(발견·회귀수정): resolve_member()/.id 직접비교는 휴먼 JWT caller에서 OrgMember.id를
+    반환해 이 path의 team_members뷰 id와 축이 달라 본인 heartbeat도 403났다 —
+    assert_caller_is_member(agent=id 직접비교·human=user_id 비교)로 axis-safe하게 교체.
+    """
     repo = TeamMemberRepository(session, org_id)
     member = await repo.get(id)
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
+
+    await assert_caller_is_member(id, auth, session, org_id, detail="Cannot heartbeat as another member")
+
     now = datetime.now(timezone.utc)
     # AC3-4 2-2: team_members 뷰 — presence는 agent_project_profiles가 유일 소스(anchor-only).
     from app.services.agent_anchor_sync import sync_agent_profile_presence
@@ -382,12 +436,23 @@ async def claim_story(
     body: ClaimBody,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
-    """AC1/3: active_story_id 갱신 + story 존재 검증."""
+    """AC1/3: active_story_id 갱신 + story 존재 검증.
+
+    S17(까심 델타 RC HIGH — file_locks.py와 같은 취약 클래스): auth 파라미터가 아예 없어
+    caller가 이 member 본인인지 확인 0이었다 — 다른 멤버 명의로 claim(active_story/participation
+    오염) 가능했음(관리자 대리 claim 흐름 없음 확인 후 순수 self-scope로 닫음).
+
+    S19(발견·회귀수정): resolve_member()/.id 직접비교는 휴먼 JWT caller의 axis(OrgMember.id)가
+    이 path의 team_members뷰 id와 달라 본인 claim도 403났다 — assert_caller_is_member로 교체.
+    """
     repo = TeamMemberRepository(session, org_id)
     member = await repo.get(id)
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
+
+    await assert_caller_is_member(id, auth, session, org_id, detail="Cannot claim as another member")
 
     # AC3: story가 해당 project에 존재하는지 검증
     story_result = await session.execute(
@@ -413,12 +478,23 @@ async def unclaim_story(
     id: uuid.UUID,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
-    """AC2: active_story_id = NULL. AC7: file lock 자동 해제."""
+    """AC2: active_story_id = NULL. AC7: file lock 자동 해제.
+
+    S17(까심 델타 RC HIGH — 파일락 경계의 마지막 구멍): auth 파라미터가 아예 없어 caller가
+    본인인지 확인 0 — Bob이 Alice 명의로 unclaim 호출 시 release_all_file_locks(session, id)가
+    org 필터도 없이 Alice의 모든 file lock을 해제할 수 있었다. claim과 동일 self-scope 패턴 적용.
+
+    S19(발견·회귀수정): assert_caller_is_member로 axis-safe 교체(claim과 동일 사유).
+    """
     repo = TeamMemberRepository(session, org_id)
     member = await repo.get(id)
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
+
+    await assert_caller_is_member(id, auth, session, org_id, detail="Cannot unclaim as another member")
+
     # AC3-4 2-2: anchor-only — agent_project_profiles가 presence 유일 소스.
     from app.services.agent_anchor_sync import sync_agent_profile_presence
     await sync_agent_profile_presence(session, id, active_story_id=None)
@@ -435,12 +511,16 @@ async def deactivate_team_member(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
+    """S19(#3 MUST): human 경로에 caller-ownership 확인이 없어 org 내 임의 멤버가 타 human을
+    deactivate할 수 있었다. self-or-org-admin 게이트 추가(update_team_member와 동일 패턴)."""
     repo = TeamMemberRepository(session, org_id)
     member = await repo.get(id)
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
     if member.type == "agent":
         await assert_agent_owner(id, session, org_id, uuid.UUID(auth.user_id))
+    else:
+        await _assert_can_manage_human(member, session, org_id, auth)
     ok = await repo.deactivate(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Team member not found")

--- a/backend/app/routers/trust_scores.py
+++ b/backend/app/routers/trust_scores.py
@@ -1,13 +1,25 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import get_current_user, get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.dependencies.ownership import _is_org_admin
+from app.services.member_resolver import is_caller_member
 from app.services.trust_score import DEFAULT_WINDOW_DAYS, compute_member_trust_scores
 
 router = APIRouter(prefix="/api/v2/trust-scores", tags=["trust-scores"])
+
+
+async def _assert_self_or_org_admin(
+    member_id: uuid.UUID, auth: AuthContext, session: AsyncSession, org_id: uuid.UUID,
+) -> None:
+    if await is_caller_member(member_id, auth, session, org_id):
+        return
+    if await _is_org_admin(session, org_id, uuid.UUID(auth.user_id)):
+        return
+    raise HTTPException(status_code=403, detail="Not authorized for this member")
 
 
 @router.get("")
@@ -17,8 +29,11 @@ async def get_trust_scores(
     window_days: int = Query(default=DEFAULT_WINDOW_DAYS, ge=1, le=365),
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    # S20 전수스캔 findings #11: member_id에 caller-ownership 확인이 전혀 없어 임의 org member가
+    # 다른 member의 신뢰점수(성과 유사 민감정보)를 열람할 수 있었다 — rewards.get_balance와 동형.
+    await _assert_self_or_org_admin(member_id, auth, session, org_id)
     return await compute_member_trust_scores(
         session=session,
         org_id=org_id,

--- a/backend/app/routers/workflow_report.py
+++ b/backend/app/routers/workflow_report.py
@@ -9,10 +9,11 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.gate import Gate
 from app.models.pm import Story
+from app.models.team import TeamMember
 from app.repositories.story import StoryRepository
 from app.services.merge_verdict_gate import (
     AUTO_MERGE,
@@ -129,6 +130,7 @@ async def report_done(
     background_tasks: BackgroundTasks,
     response: Response,
     session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> ReportDoneResponse:
     if body.stage not in _VALID_STAGES:
@@ -137,11 +139,24 @@ async def report_done(
             detail=f"Invalid stage '{body.stage}'. Valid: {list(_VALID_STAGES)}",
         )
 
-    # 스토리 조회
-    result = await session.execute(select(Story).where(Story.id == body.story_id))
+    # S20 전수스캔 finding #12: org_id 검증이 전혀 없어 임의 org의 caller가 다른 org 소유
+    # story를 조회/전이(cross-org story-pipeline 조작)할 수 있었다 — 이제 caller org로 필터.
+    result = await session.execute(
+        select(Story).where(Story.id == body.story_id, Story.org_id == org_id)
+    )
     story = result.scalar_one_or_none()
     if story is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Story not found")
+
+    # S20 finding #12(sibling): body.agent_id도 검증 없이 gate/line 평가의 actor로 그대로
+    # 쓰였다 — 임의 agent_id로 actor 스푸핑 가능했던 갭. caller org 소속 member인지 확인.
+    agent_check = await session.execute(
+        select(TeamMember.id).where(
+            TeamMember.id == body.agent_id, TeamMember.org_id == org_id,
+        ).limit(1)
+    )
+    if agent_check.scalar_one_or_none() is None:
+        raise HTTPException(status_code=400, detail="agent_id not found in this organization")
 
     transition = _TRANSITIONS[body.stage]
     next_stage: str = transition["next_stage"]

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -65,12 +65,16 @@ def map_legacy_outcome_status(outcome_status: str | None) -> str | None:
     return _LEGACY_OUTCOME_TO_STATUS.get(outcome_status)
 
 
-async def _verify_human_owner(session: AsyncSession, owner_id: uuid.UUID) -> None:
+async def _verify_human_owner(session: AsyncSession, org_id: uuid.UUID, owner_id: uuid.UUID) -> None:
+    """prod 핫픽스(S20 전수스캔 MUST): 이전엔 org_id 검증이 없어(``lookup_members_by_ids``가
+    org 필터 없이 순수 id로만 조회) caller가 임의 org의 human을 owner_member_id로 지정할 수
+    있었다(cross-org 오귀속 — 데이터 유출은 아니나 신원 스푸핑). 조회된 멤버가 caller의 org
+    소속인지 검증한다."""
     members = await lookup_members_by_ids({owner_id}, session)
     rm = members.get(owner_id)
-    if rm is None or rm.type != "human":
+    if rm is None or rm.type != "human" or rm.org_id != org_id:
         raise HypothesisServiceError(
-            "HUMAN_OWNER_REQUIRED", "owner_member_id는 type='human' 멤버여야 합니다."
+            "HUMAN_OWNER_REQUIRED", "owner_member_id는 caller와 동일 org의 type='human' 멤버여야 합니다."
         )
 
 
@@ -138,7 +142,7 @@ async def create_hypothesis(
                 "HUMAN_OWNER_REQUIRED", "agent caller는 휴먼 owner_member_id를 명시해야 합니다."
             )
         owner_id = caller.id
-    await _verify_human_owner(session, owner_id)
+    await _verify_human_owner(session, org_id, owner_id)
 
     # 상태 — agent/API key는 proposed로 강제(에러 아님). 생성 허용 상태는 proposed|active.
     status = payload.status or "proposed"
@@ -253,7 +257,7 @@ async def update_hypothesis(
     sprint_id = fields.pop("sprint_id", None)
     new_owner = fields.get("owner_member_id")
     if new_owner is not None:
-        await _verify_human_owner(session, new_owner)
+        await _verify_human_owner(session, org_id, new_owner)
     # cross-project 가드는 어떤 컬럼 mutation보다 먼저 — 거부 시 부분 update 0(create 경로와 동형).
     if sprint_id_provided and sprint_id is not None:
         await _assert_targets_same_project(session, hyp.project_id, [], [], sprint_id)

--- a/backend/app/services/member_resolver.py
+++ b/backend/app/services/member_resolver.py
@@ -387,6 +387,44 @@ async def _lookup_members_by_ids_anchor(
     return result
 
 
+async def is_caller_member(
+    member_id: uuid.UUID, auth: AuthContext, session: AsyncSession, org_id: uuid.UUID,
+) -> bool:
+    """S19(발견·회귀수정): caller가 team_members뷰 id 공간의 ``member_id`` 본인인지 axis-safe하게
+    확인한다.
+
+    ``resolve_member(auth,...).id != member_id`` 직접비교는 API키 에이전트(auth.user_id가 이미
+    team_member.id)엔 맞지만, JWT 휴먼은 ``resolve_member``가 ``OrgMember.id``(별개 테이블 PK)를
+    반환해 이 path의 ``member_id``(=members anchor/team_members뷰 id)와 축이 달라 **본인이 본인
+    claim/heartbeat/lock을 호출해도 403**나는 회귀를 냈다(까심의 "human 회귀 없음" 판정은 검증
+    시드가 같은 id를 재사용한 거짓양성 — 실 서로 다른 id로 재현하면 드러난다).
+
+    axis-safe 비교: agent(API키)는 ``auth.user_id`` 자체가 이미 team_member.id이므로 직접비교.
+    human(JWT)은 ``auth.user_id``=users.id이므로, member_id가 가리키는 team_members뷰 행의
+    ``user_id`` 컬럼(동일 users.id 공간)과 비교한다 — org_member/members 어느 쪽도 개입하지 않음.
+    """
+    caller_id = uuid.UUID(auth.user_id)
+    is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
+    if is_api_key:
+        return member_id == caller_id
+    result = await session.execute(
+        select(TeamMember.user_id).where(
+            TeamMember.id == member_id, TeamMember.org_id == org_id,
+        ).limit(1)
+    )
+    row = result.first()
+    return row is not None and row[0] == caller_id
+
+
+async def assert_caller_is_member(
+    member_id: uuid.UUID, auth: AuthContext, session: AsyncSession, org_id: uuid.UUID,
+    detail: str = "Cannot act as another member",
+) -> None:
+    """``is_caller_member`` 결과가 False면 403. self-scope 게이트의 표준 형태."""
+    if not await is_caller_member(member_id, auth, session, org_id):
+        raise HTTPException(status_code=403, detail=detail)
+
+
 async def resolve_auth_member(
     auth: AuthContext,
     org_id: uuid.UUID,

--- a/backend/tests/test_e_cage_referee_p2_trust_score.py
+++ b/backend/tests/test_e_cage_referee_p2_trust_score.py
@@ -1,7 +1,7 @@
 """E-CAGE-REFEREE P2: 신뢰 점수 집계 엔진 테스트."""
 import uuid
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -312,13 +312,50 @@ async def test_get_trust_scores_endpoint_200():
     app.dependency_overrides[get_current_user] = override_auth
 
     try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-            resp = await c.get(f"/api/v2/trust-scores?member_id={MEMBER_ID}")
+        with patch("app.routers.trust_scores.is_caller_member", new_callable=AsyncMock, return_value=True):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.get(f"/api/v2/trust-scores?member_id={MEMBER_ID}")
         assert resp.status_code == 200
         body = resp.json()
         assert body["member_id"] == str(MEMBER_ID)
         assert body["scores"] == []
         assert "window_days" in body
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_trust_scores_403_when_not_self_or_admin():
+    """S20 전수스캔 finding #11: member_id가 caller 본인도 org-admin도 아니면 403
+    (이전엔 org_id만 검증되고 member_id ownership 확인이 아예 없어 임의 member의
+    신뢰점수를 열람할 수 있었다)."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    try:
+        with patch("app.routers.trust_scores.is_caller_member", new_callable=AsyncMock, return_value=False), \
+             patch("app.routers.trust_scores._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.get(f"/api/v2/trust-scores?member_id={MEMBER_ID}")
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 

--- a/backend/tests/test_e_cage_referee_p3_dynamic_adjustment.py
+++ b/backend/tests/test_e_cage_referee_p3_dynamic_adjustment.py
@@ -223,18 +223,54 @@ async def test_apply_endpoint_member_override():
     app.dependency_overrides[get_current_user] = override_auth
 
     try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-            resp = await c.post("/api/v2/gate-config/recommendations/apply", json={
-                "member_id": str(MEMBER_ID),
-                "gate_type": "pr_review",
-                "disposition": "allow_auto",
-                "apply_as": "member",
-            })
+        with patch("app.routers.hitl_config._is_org_admin", new_callable=AsyncMock, return_value=True):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.post("/api/v2/gate-config/recommendations/apply", json={
+                    "member_id": str(MEMBER_ID),
+                    "gate_type": "pr_review",
+                    "disposition": "allow_auto",
+                    "apply_as": "member",
+                })
         assert resp.status_code == 200
         body = resp.json()
         assert body["applied"] is True
         assert body["disposition"] == "allow_auto"
         mock_session.add.assert_called_once()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_apply_endpoint_403_when_not_org_admin():
+    """prod 핫픽스(S20 전수스캔 HIGH): org-admin 아니면 gate override 적용 차단."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    async def override_db():
+        yield AsyncMock()
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    try:
+        with patch("app.routers.hitl_config._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.post("/api/v2/gate-config/recommendations/apply", json={
+                    "member_id": str(MEMBER_ID),
+                    "gate_type": "pr_review",
+                    "disposition": "allow_auto",
+                    "apply_as": "member",
+                })
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 

--- a/backend/tests/test_e_mcp_opt_s3_hosted_transport.py
+++ b/backend/tests/test_e_mcp_opt_s3_hosted_transport.py
@@ -226,12 +226,13 @@ async def test_verify_connection_http_skips_synthetic_event_and_wake(monkeypatch
     db = AsyncMock()
     db.execute = AsyncMock(return_value=_scalar(member))
     rail = [{"state": s, "status": "done"} for s in HTTP_RAIL_STATES]
-    with patch.object(ag, "start_verification", new=AsyncMock()) as start, \
+    with patch.object(ag, "assert_agent_owner", new=AsyncMock(return_value=member)), \
+         patch.object(ag, "start_verification", new=AsyncMock()) as start, \
          patch.object(ag, "get_verification_state",
                       new=AsyncMock(return_value={"verified": True, "rail": rail, "verify_seq": None})), \
          patch("app.routers.agent_gateway.wake_agent", new=MagicMock()) as wake:
         out = await ag.verify_agent_connection(
-            member.id, transport="http", session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+            member.id, transport="http", session=db, auth=MagicMock(user_id=str(uuid.uuid4())), org_id=uuid.uuid4(),
         )
     assert out["verified"] is True and out["rail"] == rail
     start.assert_not_awaited()

--- a/backend/tests/test_e_mcp_opt_s5_hardening.py
+++ b/backend/tests/test_e_mcp_opt_s5_hardening.py
@@ -34,10 +34,11 @@ async def test_verify_connection_unassigned_agent_400_via_stdio():
     db = AsyncMock()
     db.execute = AsyncMock(return_value=_scalar(member))
     from fastapi import HTTPException
-    with pytest.raises(HTTPException) as ei:
-        await ag.verify_agent_connection(
-            member.id, transport=None, session=db, auth=MagicMock(), org_id=uuid.uuid4(),
-        )
+    with patch.object(ag, "assert_agent_owner", new=AsyncMock(return_value=member)):
+        with pytest.raises(HTTPException) as ei:
+            await ag.verify_agent_connection(
+                member.id, transport=None, session=db, auth=MagicMock(user_id=str(uuid.uuid4())), org_id=uuid.uuid4(),
+            )
     assert ei.value.status_code == 400
 
 
@@ -48,10 +49,11 @@ async def test_verify_connection_unassigned_agent_400_via_http_too():
     db = AsyncMock()
     db.execute = AsyncMock(return_value=_scalar(member))
     from fastapi import HTTPException
-    with pytest.raises(HTTPException) as ei:
-        await ag.verify_agent_connection(
-            member.id, transport="http", session=db, auth=MagicMock(), org_id=uuid.uuid4(),
-        )
+    with patch.object(ag, "assert_agent_owner", new=AsyncMock(return_value=member)):
+        with pytest.raises(HTTPException) as ei:
+            await ag.verify_agent_connection(
+                member.id, transport="http", session=db, auth=MagicMock(user_id=str(uuid.uuid4())), org_id=uuid.uuid4(),
+            )
     assert ei.value.status_code == 400
 
 
@@ -61,13 +63,14 @@ async def test_verify_connection_assigned_agent_http_still_skips_sse(monkeypatch
     member = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
     db = AsyncMock()
     db.execute = AsyncMock(return_value=_scalar(member))
-    with patch.object(ag, "start_verification", new=AsyncMock()) as start, \
+    with patch.object(ag, "assert_agent_owner", new=AsyncMock(return_value=member)), \
+         patch.object(ag, "start_verification", new=AsyncMock()) as start, \
          patch.object(ag, "get_verification_state", new=AsyncMock(
              return_value={"verified": True, "rail": [], "verify_seq": None},
          )), \
          patch("app.routers.agent_gateway.wake_agent", new=MagicMock()) as wake:
         out = await ag.verify_agent_connection(
-            member.id, transport="http", session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+            member.id, transport="http", session=db, auth=MagicMock(user_id=str(uuid.uuid4())), org_id=uuid.uuid4(),
         )
     assert out["verified"] is True
     start.assert_not_awaited()

--- a/backend/tests/test_eventbus_s1.py
+++ b/backend/tests/test_eventbus_s1.py
@@ -3,12 +3,23 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 from httpx import ASGITransport, AsyncClient
 
 from app.models.event import Event
+
+
+def _resolved(member_id: uuid.UUID):
+    """S19(events sender_id 검증): resolve_member() 반환 mock — caller가 sender_id 본인임을 가장."""
+    from app.services.member_resolver import ResolvedMember
+
+    return ResolvedMember(
+        id=member_id, user_id=member_id, name="TestSender", type="human",
+        role="member", org_id=uuid.uuid4(), project_id=None,
+    )
 
 
 @pytest.fixture
@@ -91,7 +102,8 @@ async def client(mock_session, auth_ctx, org_id):
 @pytest.mark.anyio
 async def test_create_event_stores_in_db(client, mock_session):
     recipient_id = uuid.uuid4()
-    event = _make_event(recipient_id=recipient_id, recipient_type="agent")
+    sender_id = uuid.uuid4()
+    event = _make_event(recipient_id=recipient_id, recipient_type="agent", sender_id=sender_id)
 
     # team_members.type 조회 결과 mock
     member_result = MagicMock()
@@ -114,18 +126,55 @@ async def test_create_event_stores_in_db(client, mock_session):
         "event_type": "memo_created",
         "source_entity_type": "memo",
         "source_entity_id": str(uuid.uuid4()),
-        "sender_id": str(uuid.uuid4()),
+        "sender_id": str(sender_id),
         "recipient_id": str(recipient_id),
         "recipient_type": "agent",
         "payload": {"title": "킥오프"},
     }
-    resp = await client.post("/api/v2/events", json=payload)
+    with patch("app.routers.events.assert_caller_is_member", new_callable=AsyncMock,
+               return_value=None):
+        resp = await client.post("/api/v2/events", json=payload)
     assert resp.status_code == 201
     data = resp.json()
     assert data["status"] == "pending"
     assert data["event_type"] == "memo_created"
     mock_session.add.assert_called_once()
     mock_session.commit.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_create_event_403_when_sender_id_does_not_match_caller():
+    """S19(SHOULD): sender_id가 caller 본인과 다르면 403(임퍼스네이션 차단)."""
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+    from app.main import app
+
+    session = AsyncMock()
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.claims = {"app_metadata": {}}
+
+    async def _db():
+        yield session
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = lambda: ctx
+    app.dependency_overrides[get_verified_org_id] = lambda: uuid.uuid4()
+    try:
+        payload = {
+            "project_id": str(uuid.uuid4()),
+            "event_type": "memo_created",
+            "sender_id": str(uuid.uuid4()),  # resolve_member가 반환하는 caller와 다른 임의 sender
+            "recipient_id": str(uuid.uuid4()),
+            "recipient_type": "agent",
+        }
+        with patch("app.routers.events.assert_caller_is_member", new_callable=AsyncMock,
+                   side_effect=HTTPException(status_code=403, detail="sender_id must match the caller's own identity")):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.post("/api/v2/events", json=payload)
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
 
 
 @pytest.mark.anyio
@@ -151,6 +200,7 @@ async def test_create_event_recipient_not_found_returns_404(client, mock_session
 
 @pytest.mark.anyio
 async def test_get_pending_events_returns_list(client, mock_session):
+    """산티아고 SME 최종 MUST(S19): recipient==caller 통과 시 정상 동작."""
     recipient_id = uuid.uuid4()
     events = [_make_event(recipient_id=recipient_id, status="pending") for _ in range(3)]
 
@@ -160,17 +210,33 @@ async def test_get_pending_events_returns_list(client, mock_session):
     result_mock.scalars.return_value = scalars_mock
     mock_session.execute.return_value = result_mock
 
-    resp = await client.get(f"/api/v2/events/pending?recipient_id={recipient_id}")
+    with patch("app.routers.events.assert_caller_is_member", new_callable=AsyncMock,
+               return_value=None):
+        resp = await client.get(f"/api/v2/events/pending?recipient_id={recipient_id}")
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 3
     assert all(e["status"] == "pending" for e in data)
 
 
+@pytest.mark.anyio
+async def test_get_pending_events_403_when_caller_is_not_recipient(client, mock_session):
+    """산티아고 SME 최종 MUST(S19): recipient_id 쿼리로 타 member 이벤트(payload/sender/source)를
+    auth·recipient 검증 없이 읽을 수 있었다 — mark_delivered(write)는 이미 닫혔는데 같은
+    recipient 축의 이 read fallback이 열려있었다."""
+    recipient_id = uuid.uuid4()
+
+    with patch("app.routers.events.assert_caller_is_member", new_callable=AsyncMock,
+               side_effect=HTTPException(status_code=403, detail="Cannot read another member's events")):
+        resp = await client.get(f"/api/v2/events/pending?recipient_id={recipient_id}")
+    assert resp.status_code == 403
+
+
 # ─── AC4: PATCH /api/v2/events/{id}/delivered ─────────────────────────────────
 
 @pytest.mark.anyio
 async def test_mark_delivered_sets_status_and_timestamp(client, mock_session):
+    """S19(#7): caller가 event의 recipient 본인이어야 delivered로 마킹 가능."""
     event = _make_event(status="pending")
 
     async def _refresh(obj):
@@ -182,12 +248,30 @@ async def test_mark_delivered_sets_status_and_timestamp(client, mock_session):
     scalar_mock.scalar_one_or_none.return_value = event
     mock_session.execute.return_value = scalar_mock
 
-    resp = await client.patch(f"/api/v2/events/{event.id}/delivered")
+    with patch("app.routers.events.assert_caller_is_member", new_callable=AsyncMock,
+               return_value=None):
+        resp = await client.patch(f"/api/v2/events/{event.id}/delivered")
     assert resp.status_code == 200
     data = resp.json()
     assert data["status"] == "delivered"
     assert data["delivered_at"] is not None
     mock_session.commit.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_mark_delivered_403_when_caller_is_not_recipient(client, mock_session):
+    """S19(#7 MUST): recipient 확인 없이 org-scope만 있어 누구나 타 member 이벤트를 delivered로
+    마킹할 수 있었다(알림 은폐 가능) — caller==recipient 강제."""
+    event = _make_event(status="pending")
+
+    scalar_mock = MagicMock()
+    scalar_mock.scalar_one_or_none.return_value = event
+    mock_session.execute.return_value = scalar_mock
+
+    with patch("app.routers.events.assert_caller_is_member", new_callable=AsyncMock,
+               side_effect=HTTPException(status_code=403, detail="Not the recipient of this event")):
+        resp = await client.patch(f"/api/v2/events/{event.id}/delivered")
+    assert resp.status_code == 403
 
 
 @pytest.mark.anyio
@@ -262,7 +346,9 @@ async def test_get_pending_filters_by_org(client, mock_session, org_id):
     result_mock.scalars.return_value = scalars_mock
     mock_session.execute.return_value = result_mock
 
-    resp = await client.get(f"/api/v2/events/pending?recipient_id={recipient_id}")
+    with patch("app.routers.events.assert_caller_is_member", new_callable=AsyncMock,
+               return_value=None):
+        resp = await client.get(f"/api/v2/events/pending?recipient_id={recipient_id}")
     assert resp.status_code == 200
     # execute 호출 시 org_id 필터가 쿼리에 포함됐는지 — 실제 SQL은 mock이므로 호출 여부로 확인
     mock_session.execute.assert_called_once()

--- a/backend/tests/test_eventbus_s3.py
+++ b/backend/tests/test_eventbus_s3.py
@@ -299,7 +299,10 @@ def test_stream_batch_delivers_over_100_events(mock_session, org_id):
 
 @pytest.mark.anyio
 async def test_expire_stale_events(client, mock_session):
-    """POST /api/v2/events/expire-stale — expired + cleaned rowcount 반환."""
+    """POST /api/v2/events/expire-stale — expired + cleaned rowcount 반환.
+
+    S19(SHOULD): org-admin 전용 게이트 추가 — org-admin caller로 mock.
+    """
     expired_result = MagicMock()
     expired_result.rowcount = 5
     cleaned_result = MagicMock()
@@ -307,12 +310,21 @@ async def test_expire_stale_events(client, mock_session):
 
     mock_session.execute.side_effect = [expired_result, cleaned_result]
 
-    resp = await client.post("/api/v2/events/expire-stale")
+    with patch("app.routers.events._is_org_admin", new_callable=AsyncMock, return_value=True):
+        resp = await client.post("/api/v2/events/expire-stale")
     assert resp.status_code == 200
     data = resp.json()
     assert data["expired"] == 5
     assert data["cleaned"] == 3
     mock_session.commit.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_expire_stale_403_when_not_org_admin(client, mock_session):
+    """S19(SHOULD MUST급): per-resource IDOR이 아니라 privilege 게이트 부재 — org-admin 아니면 403."""
+    with patch("app.routers.events._is_org_admin", new_callable=AsyncMock, return_value=False):
+        resp = await client.post("/api/v2/events/expire-stale")
+    assert resp.status_code == 403
 
 
 @pytest.mark.anyio
@@ -324,7 +336,8 @@ async def test_expire_stale_uses_correct_cutoffs(client, mock_session):
     cleaned_result.rowcount = 0
     mock_session.execute.side_effect = [expired_result, cleaned_result]
 
-    resp = await client.post("/api/v2/events/expire-stale")
+    with patch("app.routers.events._is_org_admin", new_callable=AsyncMock, return_value=True):
+        resp = await client.post("/api/v2/events/expire-stale")
     assert resp.status_code == 200
     # execute 2번 호출 (update expired + delete cleaned)
     assert mock_session.execute.call_count == 2

--- a/backend/tests/test_hitl_config_admin_gate.py
+++ b/backend/tests/test_hitl_config_admin_gate.py
@@ -1,0 +1,129 @@
+"""prod 핫픽스(S20 전수스캔 HIGH, expire-stale 동형): hitl_config.py의 mutating 엔드포인트
+전부가 org-admin 게이트 없이(``_auth`` 선언만) 열려있었다 — org 내 임의 멤버가 org 전체 HITL
+gate posture를 바꾸거나 타 멤버의 override를 조작할 수 있었다. 각 엔드포인트에 admin 게이트를
+추가 — 이 테스트는 그 게이트가 실제로 403을 내는지만 확인한다(200 경로는 기존 테스트가 커버).
+"""
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+ORG_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+ROLE_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client_not_admin():
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.mark.anyio
+async def test_upsert_org_policy_403_when_not_org_admin():
+    client, session, app = await _client_not_admin()
+    try:
+        with patch("app.routers.hitl_config._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                resp = await c.put("/api/v2/gate-config/policy", json={"posture": "conservative"})
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_upsert_org_override_403_when_not_org_admin():
+    client, session, app = await _client_not_admin()
+    try:
+        with patch("app.routers.hitl_config._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                resp = await c.post("/api/v2/gate-config/overrides/org", json={
+                    "role_id": str(ROLE_ID), "gate_type": "pr_review", "disposition": "allow_auto",
+                })
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_org_override_403_when_not_org_admin():
+    client, session, app = await _client_not_admin()
+    try:
+        with patch("app.routers.hitl_config._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                resp = await c.delete(f"/api/v2/gate-config/overrides/org/{uuid.uuid4()}")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_upsert_member_override_403_when_not_org_admin():
+    client, session, app = await _client_not_admin()
+    try:
+        with patch("app.routers.hitl_config._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                resp = await c.post("/api/v2/gate-config/overrides/member", json={
+                    "member_id": str(MEMBER_ID), "gate_type": "pr_review", "disposition": "allow_auto",
+                })
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_member_override_403_when_not_org_admin():
+    client, session, app = await _client_not_admin()
+    try:
+        with patch("app.routers.hitl_config._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                resp = await c.delete(f"/api/v2/gate-config/overrides/member/{uuid.uuid4()}")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_upsert_org_policy_200_when_org_admin():
+    from datetime import datetime, timezone
+
+    client, session, app = await _client_not_admin()
+    try:
+        mock_r = MagicMock()
+        mock_r.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_r)
+        session.flush = AsyncMock()
+
+        async def _fake_refresh(obj):
+            obj.created_at = datetime.now(timezone.utc)
+            obj.updated_at = datetime.now(timezone.utc)
+
+        session.refresh = AsyncMock(side_effect=_fake_refresh)
+        with patch("app.routers.hitl_config._is_org_admin", new_callable=AsyncMock, return_value=True):
+            async with client as c:
+                resp = await c.put("/api/v2/gate-config/policy", json={"posture": "conservative"})
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_hypothesis_service.py
+++ b/backend/tests/test_hypothesis_service.py
@@ -328,6 +328,24 @@ async def test_update_owner_agent_raises():
     assert ei.value.code == "HUMAN_OWNER_REQUIRED"
 
 
+async def test_update_owner_cross_org_raises():
+    """prod 핫픽스(S20 전수스캔 MUST): owner_member_id가 caller org와 다른 org의 human이면
+    거부(오귀속/cross-org 스푸핑 차단) — type='human'만으로는 부족, org 일치도 필요."""
+    repo = _repo_mock(_hyp_stub())
+    other_org_member = ResolvedMember(
+        id=OWNER_ID, user_id=uuid.uuid4(), name="o", type="human",
+        role="member", org_id=uuid.uuid4(),  # ORG_ID와 다름
+    )
+    p_repo = patch.object(svc, "HypothesisRepository", return_value=repo)
+    p_lookup = patch.object(svc, "lookup_members_by_ids", AsyncMock(return_value={OWNER_ID: other_org_member}))
+    with p_repo, p_lookup, pytest.raises(svc.HypothesisServiceError) as ei:
+        await svc.update_hypothesis(
+            MagicMock(), ORG_ID, _caller("human"), HYP_ID,
+            HypothesisUpdate(owner_member_id=OWNER_ID),
+        )
+    assert ei.value.code == "HUMAN_OWNER_REQUIRED"
+
+
 async def test_update_statement_ok():
     repo = _repo_mock(_hyp_stub())
     p_repo, p_lookup = _patch(repo, "human")

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -1,6 +1,6 @@
 """S18+S25+S32: conftest fixture 기반 통합 테스트 — Sprint 3+4+5 도메인 헬스 체크."""
 import uuid
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -334,7 +334,8 @@ async def test_notification_settings_get_via_conftest_s6(test_client, mock_sessi
     mock_result.scalars.return_value.all.return_value = []
     mock_session.execute = AsyncMock(return_value=mock_result)
 
-    resp = await test_client.get(f"/api/v2/notification-settings?member_id={member_id}")
+    with patch("app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=True):
+        resp = await test_client.get(f"/api/v2/notification-settings?member_id={member_id}")
     assert resp.status_code == 200
     assert resp.json() == []
 

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 
 ORG_ID = uuid.uuid4()
 PROJECT_ID = uuid.uuid4()
@@ -65,6 +66,16 @@ def _mock_inbox(state: str = "pending") -> MagicMock:
     i.created_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
     i.resolved_at = None
     return i
+
+
+def _resolved(member_id: uuid.UUID):
+    """S19: resolve_member() 반환 mock — caller가 member_id 본인/assignee임을 가장."""
+    from app.services.member_resolver import ResolvedMember
+
+    return ResolvedMember(
+        id=member_id, user_id=None, name="TestMember", type="human",
+        role="member", org_id=ORG_ID, project_id=PROJECT_ID,
+    )
 
 
 @pytest.fixture
@@ -199,9 +210,11 @@ async def test_mark_read_single_404_when_not_owned():
 
 @pytest.mark.anyio
 async def test_get_notification_settings_200():
+    """까심 델타 재QA HIGH(S19): 이 GET이 무가드로 남아있었다 — self 통과 시 정상 동작 확인."""
     client, session, app = await _client()
     try:
-        with patch("app.repositories.notification.NotificationSettingRepository.get_by_member", new_callable=AsyncMock) as mock_get:
+        with patch("app.repositories.notification.NotificationSettingRepository.get_by_member", new_callable=AsyncMock) as mock_get, \
+             patch("app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=True):
             mock_get.return_value = [_mock_setting()]
 
             async with client as c:
@@ -215,10 +228,26 @@ async def test_get_notification_settings_200():
 
 
 @pytest.mark.anyio
-async def test_upsert_notification_setting_200():
+async def test_get_notification_settings_403_when_not_self_or_admin():
+    """까심 델타 재QA HIGH(S19 MUST): 타 member의 알림설정 열람(정보노출) 차단."""
     client, session, app = await _client()
     try:
-        with patch("app.repositories.notification.NotificationSettingRepository.upsert", new_callable=AsyncMock) as mock_upsert:
+        with patch("app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=False), \
+             patch("app.routers.notifications._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                resp = await c.get(f"/api/v2/notification-settings?member_id={MEMBER_ID}")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_upsert_notification_setting_200():
+    """S19(#4): self-scope 통과 시(caller==member_id) 정상 동작."""
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.notification.NotificationSettingRepository.upsert", new_callable=AsyncMock) as mock_upsert, \
+             patch("app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=True):
             mock_upsert.return_value = _mock_setting()
 
             async with client as c:
@@ -234,10 +263,29 @@ async def test_upsert_notification_setting_200():
 
 
 @pytest.mark.anyio
-async def test_list_inbox_200():
+async def test_upsert_notification_setting_403_when_not_self_or_admin():
+    """S19(#4 MUST): member_id가 caller 본인도 org-admin도 아니면 403(타 member 설정 덮어쓰기 차단)."""
     client, session, app = await _client()
     try:
-        with patch("app.repositories.notification.InboxRepository.list", new_callable=AsyncMock) as mock_list:
+        with patch("app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=False), \
+             patch("app.routers.notifications._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                resp = await c.put(
+                    f"/api/v2/notification-settings?member_id={MEMBER_ID}",
+                    json={"channel": "in_app", "event_type": "story_assigned", "enabled": True},
+                )
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_inbox_200():
+    """까심 델타 재QA HIGH(S19): 무가드였던 GET — self 통과 시 정상 동작."""
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.notification.InboxRepository.list", new_callable=AsyncMock) as mock_list, \
+             patch("app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=True):
             mock_list.return_value = [_mock_inbox()]
 
             async with client as c:
@@ -251,10 +299,26 @@ async def test_list_inbox_200():
 
 
 @pytest.mark.anyio
-async def test_list_incoming_200():
+async def test_list_inbox_403_when_not_self_or_admin():
+    """까심 델타 재QA HIGH(S19 MUST): 타 member의 inbox 열람(정보노출) 차단."""
     client, session, app = await _client()
     try:
-        with patch("app.repositories.notification.InboxRepository.list_incoming", new_callable=AsyncMock) as mock_list:
+        with patch("app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=False), \
+             patch("app.routers.notifications._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                resp = await c.get(f"/api/v2/inbox?assignee_member_id={MEMBER_ID}")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_incoming_200():
+    """까심 델타 재QA HIGH(S19): 무가드였던 GET — self 통과 시 정상 동작."""
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.notification.InboxRepository.list_incoming", new_callable=AsyncMock) as mock_list, \
+             patch("app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=True):
             mock_list.return_value = [_mock_inbox()]
 
             async with client as c:
@@ -267,24 +331,70 @@ async def test_list_incoming_200():
 
 
 @pytest.mark.anyio
-async def test_resolve_inbox_200():
+async def test_list_incoming_403_when_not_self_or_admin():
+    """까심 델타 재QA HIGH(S19 MUST): list_inbox와 동일 갭 — 정보노출 차단."""
     client, session, app = await _client()
     try:
+        with patch("app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=False), \
+             patch("app.routers.notifications._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                resp = await c.get(f"/api/v2/inbox/incoming?assignee_member_id={MEMBER_ID}")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_resolve_inbox_200():
+    """S19(#5): assignee==caller일 때 정상 동작. resolved_by는 이제 caller에서 서버-파생."""
+    client, session, app = await _client()
+    try:
+        pending_item = _mock_inbox("pending")
         resolved = _mock_inbox("resolved")
         resolved.resolved_by = MEMBER_ID
         resolved.resolved_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
 
-        with patch("app.repositories.notification.InboxRepository.resolve", new_callable=AsyncMock) as mock_resolve:
+        with patch("app.repositories.notification.InboxRepository.get", new_callable=AsyncMock,
+                   return_value=pending_item), \
+             patch("app.repositories.notification.InboxRepository.resolve", new_callable=AsyncMock) as mock_resolve, \
+             patch("app.routers.notifications.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
             mock_resolve.return_value = resolved
 
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/inbox/{INBOX_ID}/resolve",
+                    json={"resolved_by": str(uuid.uuid4())},  # S19: 바디값 무시(caller에서 서버-파생)
+                )
+
+        assert resp.status_code == 200
+        assert resp.json()["state"] == "resolved"
+        mock_resolve.assert_awaited_once_with(
+            id=INBOX_ID, resolved_by=MEMBER_ID, resolved_option_id=None, resolved_note=None,
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_resolve_inbox_403_when_caller_is_not_assignee():
+    """S19(#5 MUST): auth 파라미터 자체가 없어 assignee 확인이 전혀 없었다 — 타 member의 inbox
+    item을 resolve할 수 있었고 resolved_by 바디값도 임의로 스푸핑 가능했다."""
+    client, session, app = await _client()
+    try:
+        pending_item = _mock_inbox("pending")  # assignee_member_id == MEMBER_ID
+
+        with patch("app.repositories.notification.InboxRepository.get", new_callable=AsyncMock,
+                   return_value=pending_item), \
+             patch("app.routers.notifications.assert_caller_is_member", new_callable=AsyncMock,
+                   side_effect=HTTPException(status_code=403, detail="Not the assignee of this inbox item")):  # caller != assignee
             async with client as c:
                 resp = await c.post(
                     f"/api/v2/inbox/{INBOX_ID}/resolve",
                     json={"resolved_by": str(MEMBER_ID)},
                 )
 
-        assert resp.status_code == 200
-        assert resp.json()["state"] == "resolved"
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 
@@ -293,9 +403,14 @@ async def test_resolve_inbox_200():
 async def test_dismiss_inbox_200():
     client, session, app = await _client()
     try:
+        pending_item = _mock_inbox("pending")
         dismissed = _mock_inbox("dismissed")
 
-        with patch("app.repositories.notification.InboxRepository.dismiss", new_callable=AsyncMock) as mock_dismiss:
+        with patch("app.repositories.notification.InboxRepository.get", new_callable=AsyncMock,
+                   return_value=pending_item), \
+             patch("app.repositories.notification.InboxRepository.dismiss", new_callable=AsyncMock) as mock_dismiss, \
+             patch("app.routers.notifications.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
             mock_dismiss.return_value = dismissed
 
             async with client as c:
@@ -308,12 +423,54 @@ async def test_dismiss_inbox_200():
 
 
 @pytest.mark.anyio
+async def test_dismiss_inbox_403_when_caller_is_not_assignee():
+    """S19(#6 MUST): resolve와 동일 갭 — assignee 아닌 caller의 dismiss 차단."""
+    client, session, app = await _client()
+    try:
+        pending_item = _mock_inbox("pending")
+
+        with patch("app.repositories.notification.InboxRepository.get", new_callable=AsyncMock,
+                   return_value=pending_item), \
+             patch("app.routers.notifications.assert_caller_is_member", new_callable=AsyncMock,
+                   side_effect=HTTPException(status_code=403, detail="Not the assignee of this inbox item")):
+            async with client as c:
+                resp = await c.post(f"/api/v2/inbox/{INBOX_ID}/dismiss")
+
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_resolve_inbox_404():
     client, session, app = await _client()
     try:
-        with patch("app.repositories.notification.InboxRepository.resolve", new_callable=AsyncMock) as mock_resolve:
+        pending_item = _mock_inbox("pending")
+        with patch("app.repositories.notification.InboxRepository.get", new_callable=AsyncMock,
+                   return_value=pending_item), \
+             patch("app.repositories.notification.InboxRepository.resolve", new_callable=AsyncMock) as mock_resolve, \
+             patch("app.routers.notifications.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
             mock_resolve.return_value = None
 
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/inbox/{INBOX_ID}/resolve",
+                    json={"resolved_by": str(MEMBER_ID)},
+                )
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_resolve_inbox_404_when_item_not_found():
+    """item 자체가 없으면(repo.get()==None) 404 — assignee 확인 전에 먼저 404."""
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.notification.InboxRepository.get", new_callable=AsyncMock,
+                   return_value=None):
             async with client as c:
                 resp = await c.post(
                     f"/api/v2/inbox/{uuid.uuid4()}/resolve",

--- a/backend/tests/test_ob2_verify_connection.py
+++ b/backend/tests/test_ob2_verify_connection.py
@@ -101,31 +101,50 @@ async def test_get_state_no_verify_all_pending():
 
 # ─── endpoints (handler-direct) ───────────────────────────────────────────────
 
+def _auth_ctx():
+    return SimpleNamespace(user_id=str(uuid.uuid4()))
+
+
 @pytest.mark.anyio
 async def test_verify_connection_404():
     from fastapi import HTTPException
     db = AsyncMock()
-    db.execute = AsyncMock(return_value=_scalar(None))
-    with pytest.raises(HTTPException) as ei:
-        await ag.verify_agent_connection(
-            uuid.uuid4(), session=db, auth=MagicMock(), org_id=uuid.uuid4()
-        )
+    with patch.object(ag, "assert_agent_owner",
+                      new=AsyncMock(side_effect=HTTPException(status_code=404, detail="Agent not found"))):
+        with pytest.raises(HTTPException) as ei:
+            await ag.verify_agent_connection(
+                uuid.uuid4(), session=db, auth=_auth_ctx(), org_id=uuid.uuid4()
+            )
     assert ei.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_verify_connection_403_when_caller_not_owner_or_admin():
+    """S19(#9 MUST): agent의 생성자도 org-admin도 아닌 caller는 연결검증 트리거 불가."""
+    from fastapi import HTTPException
+    db = AsyncMock()
+    with patch.object(ag, "assert_agent_owner",
+                      new=AsyncMock(side_effect=HTTPException(status_code=403, detail="Not the owner of this agent"))):
+        with pytest.raises(HTTPException) as ei:
+            await ag.verify_agent_connection(
+                uuid.uuid4(), session=db, auth=_auth_ctx(), org_id=uuid.uuid4()
+            )
+    assert ei.value.status_code == 403
 
 
 @pytest.mark.anyio
 async def test_verify_connection_starts_single_target_and_returns_rail():
     member = SimpleNamespace(id=uuid.uuid4(), project_id=uuid.uuid4())
     db = AsyncMock()
-    db.execute = AsyncMock(return_value=_scalar(member))
     db.commit = AsyncMock()
     rail = [{"state": s, "status": "pending"} for s in RAIL_STATES]
-    with patch.object(ag, "start_verification", new=AsyncMock(return_value=42)) as start, \
+    with patch.object(ag, "assert_agent_owner", new=AsyncMock(return_value=member)), \
+         patch.object(ag, "start_verification", new=AsyncMock(return_value=42)) as start, \
          patch.object(ag, "get_verification_state",
                       new=AsyncMock(return_value={"verified": False, "rail": rail, "verify_seq": 42})), \
          patch("app.routers.agent_gateway.wake_agent", new=MagicMock()) as wake:
         out = await ag.verify_agent_connection(
-            member.id, session=db, auth=MagicMock(), org_id=uuid.uuid4()
+            member.id, session=db, auth=_auth_ctx(), org_id=uuid.uuid4()
         )
     assert out["verification_seq"] == 42 and out["rail"] == rail
     start.assert_awaited_once()  # single-target verify 시작

--- a/backend/tests/test_retros.py
+++ b/backend/tests/test_retros.py
@@ -936,6 +936,116 @@ async def test_update_action_200():
 
 
 @pytest.mark.anyio
+async def test_create_action_with_assignee_in_org_200():
+    """prod 핫픽스(S20 전수스캔 MUST): assignee_id가 caller org 소속이면 정상 동작."""
+    from app.services.member_resolver import ResolvedMember
+
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        assignee_id = uuid.uuid4()
+        created = _mock_action()
+        created.assignee_id = assignee_id
+        resolved = ResolvedMember(
+            id=assignee_id, user_id=uuid.uuid4(), name="a", type="human",
+            role="member", org_id=ORG_ID,
+        )
+
+        with (
+            _allow_project_access(),
+            patch("app.routers.retros.canonicalize_member_id", new_callable=AsyncMock, return_value=assignee_id),
+            patch("app.routers.retros.lookup_members_by_ids", new_callable=AsyncMock, return_value={assignee_id: resolved}),
+            patch("app.repositories.retro.RetroActionRepository.create", new_callable=AsyncMock) as mock_create,
+        ):
+            mock_create.return_value = created
+
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/retros/{SESSION_ID}/actions",
+                    json={"title": "follow up", "assignee_id": str(assignee_id)},
+                )
+
+        assert resp.status_code == 201
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_action_with_cross_org_assignee_400():
+    """prod 핫픽스(S20 전수스캔 MUST): assignee_id가 caller org 소속이 아니면 400(오귀속 차단)."""
+    from app.services.member_resolver import ResolvedMember
+
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        assignee_id = uuid.uuid4()
+        resolved = ResolvedMember(
+            id=assignee_id, user_id=uuid.uuid4(), name="a", type="human",
+            role="member", org_id=uuid.uuid4(),  # ORG_ID와 다름
+        )
+
+        with (
+            _allow_project_access(),
+            patch("app.routers.retros.canonicalize_member_id", new_callable=AsyncMock, return_value=assignee_id),
+            patch("app.routers.retros.lookup_members_by_ids", new_callable=AsyncMock, return_value={assignee_id: resolved}),
+            patch("app.repositories.retro.RetroActionRepository.create", new_callable=AsyncMock) as mock_create,
+        ):
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/retros/{SESSION_ID}/actions",
+                    json={"title": "follow up", "assignee_id": str(assignee_id)},
+                )
+
+        assert resp.status_code == 400
+        mock_create.assert_not_awaited()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_action_cross_org_assignee_400():
+    """prod 핫픽스(S20 전수스캔 MUST): update_action도 동일 갭 — cross-org assignee 재배정 차단."""
+    from app.services.member_resolver import ResolvedMember
+
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        assignee_id = uuid.uuid4()
+        resolved = ResolvedMember(
+            id=assignee_id, user_id=uuid.uuid4(), name="a", type="human",
+            role="member", org_id=uuid.uuid4(),  # ORG_ID와 다름
+        )
+
+        with (
+            _allow_project_access(),
+            patch("app.routers.retros.lookup_members_by_ids", new_callable=AsyncMock, return_value={assignee_id: resolved}),
+            patch(
+                "app.repositories.retro.RetroActionRepository.update_in_session",
+                new_callable=AsyncMock,
+            ) as mock_update,
+        ):
+            async with client as c:
+                resp = await c.patch(
+                    f"/api/v2/retros/{SESSION_ID}/actions/{uuid.uuid4()}",
+                    json={"assignee_id": str(assignee_id)},
+                )
+
+        assert resp.status_code == 400
+        mock_update.assert_not_awaited()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_update_action_cross_project_403():
     """#1801 원 적출 지점 — parent session이 caller 무권한 project 소속이면 403."""
     client, session, app = await _client()

--- a/backend/tests/test_rewards.py
+++ b/backend/tests/test_rewards.py
@@ -94,9 +94,11 @@ async def test_list_rewards_with_member_filter_200():
 
 @pytest.mark.anyio
 async def test_get_balance_200():
+    """prod 핫픽스(S20 MUST): self-or-org-admin 통과 시(caller 본인) 정상 동작."""
     client, session, app = await _client()
     try:
-        with patch("app.repositories.reward.RewardRepository.get_balance", new_callable=AsyncMock) as mock_bal:
+        with patch("app.repositories.reward.RewardRepository.get_balance", new_callable=AsyncMock) as mock_bal, \
+             patch("app.routers.rewards.is_caller_member", new_callable=AsyncMock, return_value=True):
             mock_bal.return_value = 150.0
 
             async with client as c:
@@ -109,12 +111,55 @@ async def test_get_balance_200():
 
 
 @pytest.mark.anyio
-async def test_grant_reward_201():
+async def test_get_balance_403_when_not_self_or_admin():
+    """prod 핫픽스(S20 MUST): 타 멤버 잔액 열람 차단(재무정보 노출)."""
     client, session, app = await _client()
     try:
-        with patch("app.repositories.reward.RewardRepository.grant", new_callable=AsyncMock) as mock_grant:
+        with patch("app.routers.rewards.is_caller_member", new_callable=AsyncMock, return_value=False), \
+             patch("app.routers.rewards._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                resp = await c.get(f"/api/v2/rewards/balance?project_id={PROJECT_ID}&member_id={MEMBER_ID}")
+
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_grant_reward_201():
+    """prod 핫픽스(S20 MUST, 최우선): org-admin 통과 시 정상 동작·granted_by는 caller에서 서버파생."""
+    client, session, app = await _client()
+    try:
+        resolved = MagicMock()
+        resolved.id = GRANTER_ID
+        with patch("app.repositories.reward.RewardRepository.grant", new_callable=AsyncMock) as mock_grant, \
+             patch("app.routers.rewards._is_org_admin", new_callable=AsyncMock, return_value=True), \
+             patch("app.routers.rewards.resolve_member", new_callable=AsyncMock, return_value=resolved), \
+             patch("app.services.member_resolver.canonicalize_member_id", new_callable=AsyncMock, side_effect=lambda mid, _s: mid):
             mock_grant.return_value = _mock_entry(25.0)
 
+            async with client as c:
+                resp = await c.post("/api/v2/rewards", json={
+                    "project_id": str(PROJECT_ID),
+                    "member_id": str(MEMBER_ID),
+                    "amount": 25.0,
+                    "reason": "스프린트 완료",
+                    "granted_by": str(uuid.uuid4()),  # S20: 바디값 무시(caller에서 서버-파생)
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["currency"] == "TJSB"
+        assert mock_grant.await_args.kwargs["granted_by"] == GRANTER_ID
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_grant_reward_403_when_not_org_admin():
+    """prod 핫픽스(S20 MUST): org-admin 아니면 임의 리워드 발행 차단."""
+    client, session, app = await _client()
+    try:
+        with patch("app.routers.rewards._is_org_admin", new_callable=AsyncMock, return_value=False):
             async with client as c:
                 resp = await c.post("/api/v2/rewards", json={
                     "project_id": str(PROJECT_ID),
@@ -124,8 +169,7 @@ async def test_grant_reward_201():
                     "granted_by": str(GRANTER_ID),
                 })
 
-        assert resp.status_code == 201
-        assert resp.json()["currency"] == "TJSB"
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 
@@ -134,7 +178,12 @@ async def test_grant_reward_201():
 async def test_grant_reward_404_member_not_in_project():
     client, session, app = await _client()
     try:
-        with patch("app.repositories.reward.RewardRepository.grant", new_callable=AsyncMock) as mock_grant:
+        resolved = MagicMock()
+        resolved.id = GRANTER_ID
+        with patch("app.repositories.reward.RewardRepository.grant", new_callable=AsyncMock) as mock_grant, \
+             patch("app.routers.rewards._is_org_admin", new_callable=AsyncMock, return_value=True), \
+             patch("app.routers.rewards.resolve_member", new_callable=AsyncMock, return_value=resolved), \
+             patch("app.services.member_resolver.canonicalize_member_id", new_callable=AsyncMock, side_effect=lambda mid, _s: mid):
             mock_grant.return_value = None
 
             async with client as c:

--- a/backend/tests/test_rewards.py
+++ b/backend/tests/test_rewards.py
@@ -247,3 +247,21 @@ async def test_leaderboard_invalid_period_400():
         assert resp.status_code == 400
     finally:
         app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_leaderboard_403_when_project_not_in_caller_org():
+    """산티아고 SME fast-follow(S20 전수봉인): project_id가 caller org 소속 아니면 403
+    (이전엔 project 소속 검증 자체가 없어 project_id만 알면 타 org 리더보드가 노출됐다)."""
+    client, session, app = await _client()
+    try:
+        not_found = MagicMock()
+        not_found.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=not_found)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/rewards/leaderboard?project_id={PROJECT_ID}&period=all")
+
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_s2_2_passive_heartbeat.py
+++ b/backend/tests/test_s2_2_passive_heartbeat.py
@@ -79,14 +79,14 @@ def anyio_backend():
 
 @pytest.mark.anyio
 async def test_heartbeat_endpoint_200():
-    """AC1: PATCH /api/v2/team-members/{id}/heartbeat → 200."""
+    """AC1: PATCH /api/v2/team-members/{id}/heartbeat → 200 (S19: self-scope 통과 시)."""
     client, session, app = await _heartbeat_client()
     try:
         member = _mock_member_for_heartbeat()
         updated = _mock_member_for_heartbeat()
 
         mock_get_result = MagicMock()
-        mock_get_result.scalar_one_or_none.return_value = member
+        mock_get_result.scalars.return_value.first.return_value = member
 
         mock_update_result = MagicMock()
         mock_update_result.scalar_one_or_none.return_value = updated
@@ -104,10 +104,35 @@ async def test_heartbeat_endpoint_200():
         session.flush = AsyncMock()
         session.refresh = AsyncMock()
 
-        async with client as c:
-            resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}/heartbeat")
+        with patch("app.routers.team_members.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
+            async with client as c:
+                resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}/heartbeat")
 
         assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_heartbeat_403_when_caller_is_different_member():
+    """S19(#1 MUST): auth 파라미터가 아예 없어 caller 확인이 전혀 없었다 — 타 member 명의로
+    heartbeat(presence 스푸핑) 시도 시 403."""
+    from fastapi import HTTPException
+
+    client, session, app = await _heartbeat_client()
+    try:
+        member = _mock_member_for_heartbeat()
+        mock_get_result = MagicMock()
+        mock_get_result.scalars.return_value.first.return_value = member
+        session.execute = AsyncMock(return_value=mock_get_result)
+
+        with patch("app.routers.team_members.assert_caller_is_member", new_callable=AsyncMock,
+                   side_effect=HTTPException(status_code=403, detail="Cannot heartbeat as another member")):
+            async with client as c:
+                resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}/heartbeat")
+
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 
@@ -126,15 +151,20 @@ async def test_heartbeat_response_shape():
             nonlocal call_count
             call_count += 1
             result = MagicMock()
-            result.scalar_one_or_none.return_value = member if call_count == 1 else updated
+            if call_count == 1:
+                result.scalars.return_value.first.return_value = member
+            else:
+                result.scalar_one_or_none.return_value = updated
             return result
 
         session.execute = mock_execute
         session.flush = AsyncMock()
         session.refresh = AsyncMock()
 
-        async with client as c:
-            resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}/heartbeat")
+        with patch("app.routers.team_members.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
+            async with client as c:
+                resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}/heartbeat")
 
         body = resp.json()
         assert body["ok"] is True

--- a/backend/tests/test_s2_4_claim_unclaim.py
+++ b/backend/tests/test_s2_4_claim_unclaim.py
@@ -16,6 +16,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 
 ORG_ID = uuid.uuid4()
 PROJECT_ID = uuid.uuid4()
@@ -56,6 +57,16 @@ def _mock_story(id=None, title="Test Story", status="in-progress"):
     s.status = status
     s.project_id = PROJECT_ID
     return s
+
+
+def _resolved(member_id: uuid.UUID):
+    """S17 RC②: resolve_member() 반환 mock — claim/unclaim self-scope 검증 대상 caller 신원."""
+    from app.services.member_resolver import ResolvedMember
+
+    return ResolvedMember(
+        id=member_id, user_id=None, name="TestAgent", type="agent",
+        role="member", org_id=ORG_ID, project_id=PROJECT_ID,
+    )
 
 
 @pytest.fixture
@@ -118,16 +129,45 @@ async def test_claim_story_200():
         session.flush = AsyncMock()
         session.refresh = AsyncMock()
 
-        async with client as c:
-            resp = await c.post(
-                f"/api/v2/team-members/{MEMBER_ID}/claim",
-                json={"story_id": str(STORY_ID)},
-            )
+        with patch("app.routers.team_members.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/team-members/{MEMBER_ID}/claim",
+                    json={"story_id": str(STORY_ID)},
+                )
 
         assert resp.status_code == 200
         body = resp.json()
         assert body["claimed"] is True
         assert body["story_id"] == str(STORY_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_claim_story_403_when_caller_is_different_member():
+    """S17 RC②(까심 델타 HIGH): self-scope — 타 member 명의로 claim 시도 시 403.
+
+    이전엔 claim_story가 auth 파라미터 자체를 받지 않아 caller 확인이 전혀 없었다 — Bob이
+    Alice member_id로 claim해 active_story/participation을 오염시킬 수 있는 구조였다.
+    """
+    client, session, app = await _client()
+    try:
+        member = _mock_member()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = member
+        session.execute = AsyncMock(return_value=result)
+
+        with patch("app.routers.team_members.assert_caller_is_member", new_callable=AsyncMock,
+                   side_effect=HTTPException(status_code=403, detail="Cannot act as another member")):
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/team-members/{MEMBER_ID}/claim",
+                    json={"story_id": str(STORY_ID)},
+                )
+
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 
@@ -155,11 +195,36 @@ async def test_unclaim_story_200():
         session.flush = AsyncMock()
         session.refresh = AsyncMock()
 
-        async with client as c:
-            resp = await c.post(f"/api/v2/team-members/{MEMBER_ID}/unclaim")
+        with patch("app.routers.team_members.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
+            async with client as c:
+                resp = await c.post(f"/api/v2/team-members/{MEMBER_ID}/unclaim")
 
         assert resp.status_code == 200
         assert resp.json()["unclaimed"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_unclaim_story_403_when_caller_is_different_member():
+    """S17 RC②(까심 델타 HIGH — 파일락 경계의 마지막 구멍): self-scope — 타 member 명의로
+    unclaim 시도 시 403. 이전엔 auth 파라미터 자체가 없어 Bob이 Alice 명의로 unclaim 호출 시
+    release_all_file_locks(session, id)가 Alice의 모든 file lock을 해제할 수 있었다.
+    """
+    client, session, app = await _client()
+    try:
+        member = _mock_member(active_story_id=STORY_ID)
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = member
+        session.execute = AsyncMock(return_value=result)
+
+        with patch("app.routers.team_members.assert_caller_is_member", new_callable=AsyncMock,
+                   side_effect=HTTPException(status_code=403, detail="Cannot act as another member")):
+            async with client as c:
+                resp = await c.post(f"/api/v2/team-members/{MEMBER_ID}/unclaim")
+
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 
@@ -187,11 +252,13 @@ async def test_claim_story_400_if_story_not_in_project():
 
         session.execute = mock_execute
 
-        async with client as c:
-            resp = await c.post(
-                f"/api/v2/team-members/{MEMBER_ID}/claim",
-                json={"story_id": str(uuid.uuid4())},
-            )
+        with patch("app.routers.team_members.assert_caller_is_member", new_callable=AsyncMock,
+                   return_value=None):
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/team-members/{MEMBER_ID}/claim",
+                    json={"story_id": str(uuid.uuid4())},
+                )
 
         assert resp.status_code == 400
     finally:

--- a/backend/tests/test_s31.py
+++ b/backend/tests/test_s31.py
@@ -278,6 +278,23 @@ async def test_get_me_200():
 
 
 @pytest.mark.anyio
+async def test_get_me_404_when_member_id_is_not_self():
+    """S20(authz-coverage 스캐너 발견): member_id가 caller 본인이 아니면 조회 실패(404) —
+    이전엔 member_id를 그대로 신뢰해 임의 member의 email 등 PII를 노출했다(update_me엔 있는
+    self-check가 get_me엔 없었다). 본인이 아니면 where_clause가 0행 → repo가 None 반환."""
+    client, session, app = await _client()
+    try:
+        session.execute = AsyncMock(return_value=_mock_result(None))
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/me?member_id={uuid.uuid4()}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_get_me_via_api_key_200():
     """API key 인증: auth.user_id = TeamMember.id → id 분기로 조회."""
     client, session, app = await _client_api_key()

--- a/backend/tests/test_s33.py
+++ b/backend/tests/test_s33.py
@@ -94,6 +94,24 @@ async def test_dashboard_empty_result_200():
         app.dependency_overrides.clear()
 
 
+@pytest.mark.anyio
+async def test_dashboard_404_when_member_not_in_caller_org():
+    """prod 핫픽스(S20 MUST): member_id가 caller org 소속 아니면 404(cross-org 데이터 누출 차단)
+    — project_id를 명시해도 member org 검증은 항상 수행된다."""
+    client, session, app = await _client()
+    try:
+        not_found = MagicMock()
+        not_found.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=not_found)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/dashboard?member_id={MEMBER_ID}&project_id={PROJECT_ID}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
 # ── Current Project ──────────────────────────────────────────────────────────
 
 @pytest.mark.anyio

--- a/backend/tests/test_s36.py
+++ b/backend/tests/test_s36.py
@@ -98,6 +98,24 @@ async def test_list_agent_runs_empty_200():
 
 
 @pytest.mark.anyio
+async def test_list_agent_runs_404_when_project_not_in_caller_org():
+    """prod 핫픽스(S20 전수스캔): project_id가 caller org 소속 아니면 404(cross-org 차단)."""
+    client, session, app = await _client()
+    try:
+        no_proj = MagicMock()
+        no_proj.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=no_proj)
+        with patch("app.repositories.agent_run.AgentRunRepository.list", new_callable=AsyncMock) as mock_list:
+            async with client as c:
+                resp = await c.get(f"/api/v2/agent-runs?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 404
+        mock_list.assert_not_awaited()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_list_agent_runs_missing_project_id_422():
     client, session, app = await _client()
     try:
@@ -161,7 +179,8 @@ async def test_update_agent_run_completed_200():
         completed.input_tokens = 1500
         completed.output_tokens = 300
 
-        with patch("app.repositories.agent_run.AgentRunRepository.update", new_callable=AsyncMock) as mock_update:
+        with patch("app.repositories.agent_run.AgentRunRepository.get", new_callable=AsyncMock, return_value=completed), \
+             patch("app.repositories.agent_run.AgentRunRepository.update", new_callable=AsyncMock) as mock_update:
             mock_update.return_value = completed
 
             async with client as c:
@@ -185,7 +204,8 @@ async def test_update_agent_run_failed_200():
         failed = _mock_run("failed")
         failed.last_error_code = "timeout"
 
-        with patch("app.repositories.agent_run.AgentRunRepository.update", new_callable=AsyncMock) as mock_update:
+        with patch("app.repositories.agent_run.AgentRunRepository.get", new_callable=AsyncMock, return_value=failed), \
+             patch("app.repositories.agent_run.AgentRunRepository.update", new_callable=AsyncMock) as mock_update:
             mock_update.return_value = failed
 
             async with client as c:
@@ -204,12 +224,32 @@ async def test_update_agent_run_failed_200():
 async def test_update_agent_run_404():
     client, session, app = await _client()
     try:
-        with patch("app.repositories.agent_run.AgentRunRepository.update", new_callable=AsyncMock) as mock_update:
+        with patch("app.repositories.agent_run.AgentRunRepository.get", new_callable=AsyncMock, return_value=None), \
+             patch("app.repositories.agent_run.AgentRunRepository.update", new_callable=AsyncMock) as mock_update:
             mock_update.return_value = None
 
             async with client as c:
                 resp = await c.patch(f"/api/v2/agent-runs/{uuid.uuid4()}", json={"status": "completed"})
 
         assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_agent_run_404_cross_org():
+    """prod 핫픽스(S20 전수스캔): 다른 org의 run id를 patch 시도해도 404(cross-org 차단)."""
+    client, session, app = await _client()
+    try:
+        other_org_run = _mock_run("completed")
+        other_org_run.org_id = uuid.uuid4()  # caller org(ORG_ID)와 다름
+
+        with patch("app.repositories.agent_run.AgentRunRepository.get", new_callable=AsyncMock, return_value=other_org_run), \
+             patch("app.repositories.agent_run.AgentRunRepository.update", new_callable=AsyncMock) as mock_update:
+            async with client as c:
+                resp = await c.patch(f"/api/v2/agent-runs/{RUN_ID}", json={"status": "completed"})
+
+        assert resp.status_code == 404
+        mock_update.assert_not_awaited()
     finally:
         app.dependency_overrides.clear()

--- a/backend/tests/test_s37.py
+++ b/backend/tests/test_s37.py
@@ -154,7 +154,9 @@ async def test_get_notification_settings_200():
         with patch(
             "app.repositories.notification.NotificationSettingRepository.get_by_member",
             new_callable=AsyncMock
-        ) as mock_get:
+        ) as mock_get, patch(
+            "app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=True,
+        ):
             mock_get.return_value = []
 
             async with client as c:
@@ -181,7 +183,9 @@ async def test_put_notification_setting_200():
         with patch(
             "app.repositories.notification.NotificationSettingRepository.upsert",
             new_callable=AsyncMock
-        ) as mock_upsert:
+        ) as mock_upsert, patch(
+            "app.routers.notifications.is_caller_member", new_callable=AsyncMock, return_value=True,
+        ):
             mock_upsert.return_value = setting_mock
 
             async with client as c:

--- a/backend/tests/test_s4_1_file_conflict.py
+++ b/backend/tests/test_s4_1_file_conflict.py
@@ -159,16 +159,43 @@ async def test_file_lock_no_conflict_200():
         session.flush = AsyncMock()
         session.add = MagicMock()
 
-        async with client as c:
-            resp = await c.post(
-                f"/api/v2/team-members/{MEMBER_ID}/file-lock",
-                json={"file_paths": ["src/foo.py"]},
-            )
+        with patch("app.routers.file_locks.assert_caller_is_member", new_callable=AsyncMock, return_value=None):
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/team-members/{MEMBER_ID}/file-lock",
+                    json={"file_paths": ["src/foo.py"]},
+                )
 
         assert resp.status_code == 200
         body = resp.json()
         assert body["locked"] is True
         assert body["warning"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_file_lock_403_when_caller_is_not_member():
+    """prod 핫픽스(까심 재QA CRITICAL): Bob이 Alice member_id로 file-lock 시도 시 403
+    (이전엔 _auth가 선언만 되고 미사용이라 caller-ownership 확인이 전혀 없었다)."""
+    from fastapi import HTTPException
+
+    client, session, app = await _client()
+    try:
+        member = _mock_member()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = member
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with patch("app.routers.file_locks.assert_caller_is_member", new_callable=AsyncMock,
+                   side_effect=HTTPException(status_code=403, detail="Cannot lock files as another member")):
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/team-members/{MEMBER_ID}/file-lock",
+                    json={"file_paths": ["src/foo.py"]},
+                )
+
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 
@@ -202,7 +229,8 @@ async def test_file_lock_with_conflict_warning():
         session.add = MagicMock()
 
         with patch("app.routers.file_locks.publish_event"), \
-             patch("app.routers.file_locks.fire_webhooks", new_callable=AsyncMock):
+             patch("app.routers.file_locks.fire_webhooks", new_callable=AsyncMock), \
+             patch("app.routers.file_locks.assert_caller_is_member", new_callable=AsyncMock, return_value=None):
             async with client as c:
                 resp = await c.post(
                     f"/api/v2/team-members/{MEMBER_ID}/file-lock",
@@ -228,14 +256,38 @@ async def test_file_unlock_200():
         session.execute = AsyncMock(return_value=mock_result)
         session.flush = AsyncMock()
 
-        async with client as c:
-            resp = await c.post(
-                f"/api/v2/team-members/{MEMBER_ID}/file-unlock",
-                json={"file_paths": ["src/foo.py"]},
-            )
+        with patch("app.routers.file_locks.assert_caller_is_member", new_callable=AsyncMock, return_value=None):
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/team-members/{MEMBER_ID}/file-unlock",
+                    json={"file_paths": ["src/foo.py"]},
+                )
 
         assert resp.status_code == 200
         assert resp.json()["unlocked"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_file_unlock_403_when_caller_is_not_member():
+    """prod 핫픽스(까심 재QA CRITICAL): lock과 동일 갭 — Bob이 Alice 명의로 unlock 시도 시 403."""
+    from fastapi import HTTPException
+
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with patch("app.routers.file_locks.assert_caller_is_member", new_callable=AsyncMock,
+                   side_effect=HTTPException(status_code=403, detail="Cannot unlock files as another member")):
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/team-members/{MEMBER_ID}/file-unlock",
+                    json={"file_paths": ["src/foo.py"]},
+                )
+
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 

--- a/backend/tests/test_team_members.py
+++ b/backend/tests/test_team_members.py
@@ -176,6 +176,7 @@ async def test_get_team_member_404():
 
 @pytest.mark.anyio
 async def test_update_team_member_200():
+    """S19(#2): human 경로가 self-or-org-admin 게이트를 통과해야 진행 — org-admin caller로 mock."""
     client, session, app = await _client()
     try:
         updated = _mock_member()
@@ -186,8 +187,9 @@ async def test_update_team_member_200():
         session.execute = AsyncMock(return_value=mock_result)
         session.expire = MagicMock()  # sync 메서드(AsyncMock 코루틴 경고 회피)
 
-        async with client as c:
-            resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}", json={"color": "#ff0000"})
+        with patch("app.routers.team_members._is_org_admin", AsyncMock(return_value=True)):
+            async with client as c:
+                resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}", json={"color": "#ff0000"})
 
         assert resp.status_code == 200
     finally:
@@ -195,8 +197,105 @@ async def test_update_team_member_200():
 
 
 @pytest.mark.anyio
+async def test_update_team_member_403_when_not_self_or_admin():
+    """S19(#2 MUST): human 대상이 본인도 org-admin도 아닌 caller가 수정 시 403."""
+    client, session, app = await _client()
+    try:
+        target = _mock_member()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.first.return_value = target
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with patch("app.routers.team_members._is_org_admin", AsyncMock(return_value=False)):
+            async with client as c:
+                resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}", json={"color": "#ff0000"})
+
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_team_member_self_can_edit_profile_fields():
+    """산티아고 Phase A SME (c): self가 프로필 필드(color 등)만 건드리면 org-admin 없이도 통과."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    self_user_id = uuid.uuid4()
+    updated = _mock_member()
+    updated.user_id = self_user_id
+    updated.color = "#ff0000"
+
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.first.return_value = updated
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.expire = MagicMock()
+
+    ctx = MagicMock()
+    ctx.user_id = str(self_user_id)
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}", json={"color": "#ff0000"})
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_team_member_self_403_when_escalating_role():
+    """산티아고 Phase A SME (c) MUST: self가 자기 role/can_manage_members/is_active/agent_config를
+    스스로 바꾸는 건 권한상승이라 org-admin 없이는 403 — 이전엔 self 경로가 전 필드를 허용했다."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    self_user_id = uuid.uuid4()
+    target = _mock_member()
+    target.user_id = self_user_id
+
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.first.return_value = target
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    ctx = MagicMock()
+    ctx.user_id = str(self_user_id)
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    try:
+        with patch("app.routers.team_members._is_org_admin", AsyncMock(return_value=False)):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.patch(
+                    f"/api/v2/team-members/{MEMBER_ID}", json={"role": "admin"},
+                )
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_deactivate_team_member_200():
-    """DELETE → soft deactivate (is_active=False)."""
+    """DELETE → soft deactivate (is_active=False). S19(#3): org-admin caller로 mock."""
     client, session, app = await _client()
     try:
         active_member = _mock_member(is_active=True)
@@ -217,13 +316,33 @@ async def test_deactivate_team_member_200():
 
         session.execute = mock_execute
 
-        async with client as c:
-            resp = await c.delete(f"/api/v2/team-members/{MEMBER_ID}")
+        with patch("app.routers.team_members._is_org_admin", AsyncMock(return_value=True)):
+            async with client as c:
+                resp = await c.delete(f"/api/v2/team-members/{MEMBER_ID}")
 
         assert resp.status_code == 200
         body = resp.json()
         assert body["ok"] is True
         assert body["deactivated"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_deactivate_team_member_403_when_not_self_or_admin():
+    """S19(#3 MUST): human 대상이 본인도 org-admin도 아닌 caller가 deactivate 시 403."""
+    client, session, app = await _client()
+    try:
+        active_member = _mock_member(is_active=True)
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.first.return_value = active_member
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with patch("app.routers.team_members._is_org_admin", AsyncMock(return_value=False)):
+            async with client as c:
+                resp = await c.delete(f"/api/v2/team-members/{MEMBER_ID}")
+
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 

--- a/backend/tests/test_workflow_report.py
+++ b/backend/tests/test_workflow_report.py
@@ -287,6 +287,59 @@ async def test_next_assignee_mapping():
 
 
 @pytest.mark.anyio
+async def test_story_cross_org_404():
+    """S20 전수스캔 finding #12: story_id가 caller org 소속 아니면 404
+    (이전엔 org_id 검증 자체가 없어 임의 org의 story를 조회/전이시킬 수 있었다)."""
+    client, session, app = await _client()
+    try:
+        not_found = MagicMock()
+        not_found.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=not_found)
+
+        async with client as c:
+            resp = await c.post("/api/v2/workflow/report-done", json={
+                "story_id": str(STORY_ID),
+                "stage": "kickoff",
+                "agent_id": str(AGENT_ID),
+            })
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_agent_id_cross_org_400():
+    """S20 전수스캔 finding #12(sibling): agent_id가 caller org 소속 member 아니면 400
+    (이전엔 검증 없이 gate/line 평가의 actor로 그대로 스푸핑 가능했다)."""
+    client, session, app = await _client()
+    try:
+        story = _mock_story(status="ready-for-dev")
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = story
+            else:
+                result.scalar_one_or_none.return_value = None
+            return result
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.post("/api/v2/workflow/report-done", json={
+                "story_id": str(STORY_ID),
+                "stage": "kickoff",
+                "agent_id": str(uuid.uuid4()),
+            })
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_pipeline_sequence():
     """kickoff→dev→review→qa→merge→done 순서가 올바르다."""
     from app.routers.workflow_report import _TRANSITIONS


### PR DESCRIPTION
## Summary
dev(develop)에서 확정된 S19(`5c399de5`, E-RECRUIT, high, SECURITY) 감사·수정을 prod-live `main`
컨텍스트로 포팅. `_ALWAYS_ALLOWED_PATH_PREFIXES`(scope-exempt path) 하의 mutating/read
엔드포인트는 tool-scope 게이팅을 우회하므로 handler 자체의 caller-ownership 강제가 유일한
방어선인데, 그게 12곳에서 빠져 있었다.

main엔 recruit/S17(file_locks)/S14(dev-only) 기능이 없어 develop과의 파일별 diff를 실제로
대조해 dev-only 의존이 없는 부분만 선택 이식했다(develop diff 통째 적용 아님).

## 이식된 helper
`member_resolver.py`: `is_caller_member`/`assert_caller_is_member` — axis-safe self-scope
비교(agent=id 직접비교, human=team_members뷰 user_id 컬럼 비교). 기존 `resolve_member().id`
직접비교는 human JWT caller에서 축이 어긋나 본인 요청도 403나는 회귀를 낼 수 있어(develop에서
실제로 겪음) 이 axis-safe 버전으로 처음부터 이식.

## 포팅된 12건
| # | 파일 | 엔드포인트 | fix |
|---|---|---|---|
| 1 | agents.py | `POST /{agent_id}/verify-connection` | org-scope 조회 → `assert_agent_owner` |
| 2 | team_members.py | `PATCH /{id}/heartbeat` | auth 파라미터 자체 없음 → self-scope 추가 |
| 3 | team_members.py | `PATCH /{id}` (human) | self-or-org-admin, self는 프로필 필드만 |
| 4 | team_members.py | `DELETE /{id}` (human) | self-or-org-admin |
| 5 | notifications.py | `PUT /notification-settings` | self-or-org-admin |
| 6 | notifications.py | `GET /notification-settings` | self-or-org-admin(정보노출 차단) |
| 7 | notifications.py | `POST /inbox/{id}/resolve` | assignee==caller, resolved_by 서버파생 |
| 8 | notifications.py | `POST /inbox/{id}/dismiss` | assignee==caller |
| 9 | notifications.py | `GET /inbox`, `GET /inbox/incoming` | self-or-org-admin(정보노출 차단) |
| 10 | events.py | `PATCH /{id}/delivered` | recipient==caller |
| 11 | events.py | `GET /pending`, `POST /events`(sender_id) | recipient==caller / sender 스푸핑 차단 |
| 12 | events.py | `POST /expire-stale` | org-admin 전용 게이트(데이터파괴급 — 최우선 검증) |

**보너스(같은 파일 diff에 자연 포함, 별도 리스크 없음)**: `team_members.py`의
`claim_story`/`unclaim_story`도 auth 파라미터가 아예 없던 동일 클래스 갭이라 self-scope로
같이 닫힘.

**제외**: recruit(`POST /{agent_id}/recruit`)는 main에 기능 자체가 없어 대상 아님.

## 실PG 검증
throwaway `pgvector/pg16`에 `alembic upgrade heads` 적용 후, alice/bob/admin을 각각 독립
UUID로 시딩(같은-id 시딩 마스킹 금지 — dev S19에서 겪은 거짓양성 교훈)해 12개 엔드포인트
전부를 실 라우터 함수 직접호출로 왕복: bob→alice 전부 403, alice 본인/admin 전부 200.

## 네거티브 테스트
- `expire-stale` 가드(org-admin 체크)를 임시 제거 → non-admin(bob) 호출이 그대로 통과됨을
  확인(SECURITY BUG 재현) → 복원 후 403 재확인.
- `heartbeat`의 axis-safe self-scope를 임시 제거 → bob이 alice 명의로 heartbeat 성공함을
  확인(재현) → 복원 후 403 재확인.

## Test plan
- [x] 실PG 12개 엔드포인트 왕복(distinct alice/bob/admin ids)
- [x] expire-stale·heartbeat 네거티브 테스트(가드 제거→재현→복원→재확인)
- [x] 관련 유닛 테스트 갱신(9개 파일: mock 대상 함수명 rename에 따른 patch target 교체 + 신규
      403 케이스 추가)
- [x] 전체 백엔드 스위트: 2999 passed, 7 failed(기존 베이스라인과 동일 — `test_tools_list_89_tools`
      + `mcp_json_python_path`류, 이 PR 무관)
- [ ] 까심 realdb+realistic-id 재QA(12건 가드 실효·회귀0·특히 expire-stale·events 축-safe)
- [ ] 산티아고 SME
- [ ] main-preflight CI
- [ ] PO 최종 GO 후 prod 배포(S16 절차)

Story: S19(`5c399de5`) prod 포팅. 마이그레이션 없음(코드-only).