### PR TITLE
feat(security): S20 authz-coverage CI guard + current-project fix + runtime-capabilities

### DIFF
--- a/backend/app/repositories/analytics.py
+++ b/backend/app/repositories/analytics.py
@@ -339,6 +339,9 @@ class AnalyticsRepository:
     ) -> list[dict]:
         limit = min(limit, 100)
 
+        # S20 전수스캔(산티아고 SME fast-follow, sibling — reward.py:leaderboard와 동형):
+        # reward_balances 뷰는 org_id 컬럼이 없어 SQL 필터 불가·caller가 project_id를 caller
+        # org 소속인지 사전 검증해야 한다(현재 미라우팅 dead code지만 향후 재배선 landmine 방지).
         if period == "all":
             q = "SELECT member_id, balance FROM reward_balances WHERE project_id = :pid ORDER BY balance DESC"
             params: dict = {"pid": str(project_id), "lim": limit}
@@ -351,10 +354,11 @@ class AnalyticsRepository:
 
         period_ms = {"daily": 86400, "weekly": 7 * 86400, "monthly": 30 * 86400}
         seconds = period_ms.get(period, 86400)
-        params2: dict = {"pid": str(project_id), "seconds": seconds}
+        params2: dict = {"pid": str(project_id), "org_id": str(self.org_id), "seconds": seconds}
         q2 = (
             "SELECT member_id, SUM(amount) AS balance FROM reward_ledger"
-            " WHERE project_id = :pid AND created_at >= NOW() - (:seconds || ' seconds')::interval"
+            " WHERE project_id = :pid AND org_id = :org_id"
+            " AND created_at >= NOW() - (:seconds || ' seconds')::interval"
             " GROUP BY member_id ORDER BY balance DESC LIMIT :lim"
         )
         params2["lim"] = limit

--- a/backend/app/repositories/reward.py
+++ b/backend/app/repositories/reward.py
@@ -80,6 +80,9 @@ class RewardRepository:
     ) -> list[dict]:
         limit = min(limit, 100)
 
+        # S20 전수스캔(산티아고 SME fast-follow): reward_balances 뷰는 org_id 컬럼이 없어(member_id,
+        # project_id, balance만) SQL 레벨 org_id 필터가 불가 — project_id가 caller org 소속인지는
+        # 라우터(get_leaderboard)에서 사전 검증한다(project_id는 org 1:1이라 그걸로 충분).
         if period == "all":
             q = (
                 "SELECT member_id, balance FROM reward_balances"
@@ -95,10 +98,12 @@ class RewardRepository:
 
         period_seconds = {"daily": 86400, "weekly": 7 * 86400, "monthly": 30 * 86400}
         seconds = period_seconds.get(period, 86400)
-        params2: dict = {"pid": str(project_id), "seconds": seconds, "lim": limit}
+        # S20 전수스캔(산티아고 SME fast-follow): reward_ledger는 org_id 보유 — list()/get_balance()와
+        # 동형으로 org_id 필터 추가(project_id만으론 타 org 리더보드 노출 가능했다).
+        params2: dict = {"pid": str(project_id), "org_id": str(self.org_id), "seconds": seconds, "lim": limit}
         q2 = (
             "SELECT member_id, CAST(SUM(amount) AS float) AS balance FROM reward_ledger"
-            " WHERE project_id = :pid"
+            " WHERE project_id = :pid AND org_id = :org_id"
             " AND created_at >= NOW() - (:seconds || ' seconds')::interval"
             " GROUP BY member_id ORDER BY balance DESC LIMIT :lim"
         )

--- a/backend/app/routers/agent_runs.py
+++ b/backend/app/routers/agent_runs.py
@@ -4,8 +4,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.models.project import Project
 from app.models.team import TeamMember
 from app.repositories.agent_run import AgentRunRepository
 from app.schemas.agent_run import AgentRunResponse, CreateAgentRun, UpdateAgentRun
@@ -23,9 +24,16 @@ async def list_agent_runs(
     agent_id: uuid.UUID | None = Query(default=None),
     limit: int = Query(default=50, ge=1, le=200),
     cursor: str | None = Query(default=None),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     _auth: AuthContext = Depends(get_current_user),
     repo: AgentRunRepository = Depends(_get_repo),
 ) -> list[AgentRunResponse]:
+    """prod 핫픽스(S20 전수스캔 — create_agent_run과 동일 클래스): project_id가 caller org
+    소속인지 검증 없이 임의 project의 agent run 목록을 열람할 수 있었다(cross-org)."""
+    proj_r = await session.execute(select(Project.id).where(Project.id == project_id, Project.org_id == org_id))
+    if proj_r.scalar_one_or_none() is None:
+        raise HTTPException(status_code=404, detail="Project not found")
     runs = await repo.list(project_id=project_id, agent_id=agent_id, limit=limit, cursor=cursor)
     return [AgentRunResponse.model_validate(r) for r in runs]
 
@@ -34,19 +42,23 @@ async def list_agent_runs(
 async def create_agent_run(
     body: CreateAgentRun,
     session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     _auth: AuthContext = Depends(get_current_user),
     repo: AgentRunRepository = Depends(_get_repo),
 ) -> AgentRunResponse:
-    # team_members 는 projection VIEW — 멀티프로젝트 grant 면 같은 agent_id 가 N 행. org_id 는 전
-    # projection 행에서 동형이라 .limit(1) 로 MultipleResultsFound 회피(아무 행 OK).
+    """prod 핫픽스(S20 전수스캔 MUST): cross-org IDOR — org_id를 body.agent_id가 속한 org에서
+    그대로 파생해(caller org 검증 없이) 타 org agent 명의로 run을 생성할 수 있었다. caller의
+    get_verified_org_id로 파생하고 agent_id가 그 org 소속인지 검증한다.
+    """
+    # team_members 는 projection VIEW — 멀티프로젝트 grant 면 같은 agent_id 가 N 행. org_id 필터로
+    # caller org 소속만 통과(cross-org 차단) — .limit(1) 로 MultipleResultsFound 회피.
     member_r = await session.execute(
-        select(TeamMember.org_id).where(
-            TeamMember.id == body.agent_id, TeamMember.type == "agent",
+        select(TeamMember.id).where(
+            TeamMember.id == body.agent_id, TeamMember.type == "agent", TeamMember.org_id == org_id,
             TeamMember.is_active.is_(True),  # deactivated agent 는 run 생성 비도달(정합)
         ).limit(1)
     )
-    org_id = member_r.scalar_one_or_none()
-    if org_id is None:
+    if member_r.scalar_one_or_none() is None:
         raise HTTPException(status_code=400, detail="agent_id not found or not an agent")
 
     run = await repo.create(
@@ -70,9 +82,15 @@ async def create_agent_run(
 async def update_agent_run(
     id: uuid.UUID,
     body: UpdateAgentRun,
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     _auth: AuthContext = Depends(get_current_user),
     repo: AgentRunRepository = Depends(_get_repo),
 ) -> AgentRunResponse:
+    """prod 핫픽스(S20 전수스캔 — create_agent_run과 동일 클래스): run id만으로 org 검증 없이
+    임의 org의 agent run을 수정할 수 있었다."""
+    existing = await repo.get(id)
+    if existing is None or existing.org_id != org_id:
+        raise HTTPException(status_code=404, detail="Agent run not found")
     run = await repo.update(
         id,
         status=body.status,

--- a/backend/app/routers/current_project.py
+++ b/backend/app/routers/current_project.py
@@ -4,11 +4,12 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.project import Project
 from app.models.team import TeamMember
 from app.schemas.current_project import CurrentProjectResponse, SetCurrentProject
+from app.services.member_resolver import assert_caller_is_member
 
 router = APIRouter(prefix="/api/v2/current-project", tags=["current-project"])
 
@@ -17,8 +18,13 @@ router = APIRouter(prefix="/api/v2/current-project", tags=["current-project"])
 async def get_current_project(
     member_id: uuid.UUID = Query(...),
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> CurrentProjectResponse:
+    """S20(authz-coverage 스캐너 발견 — S19 Phase C서 no-op으로 skip 판단했던 그 오라클):
+    member_id로 임의 member의 project_id/org_id/project_name을 caller-ownership 검증 없이
+    조회할 수 있었다(membership-existence 오라클). self-scope 추가."""
+    await assert_caller_is_member(member_id, auth, session, org_id)
     tm_r = await session.execute(
         select(TeamMember.project_id, TeamMember.org_id).where(
             TeamMember.id == member_id, TeamMember.is_active.is_(True)
@@ -45,8 +51,13 @@ async def set_current_project(
     body: SetCurrentProject,
     member_id: uuid.UUID = Query(...),
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> CurrentProjectResponse:
+    """S20(산티아고 재확인 대상 — S19 Phase C서 no-op으로 skip 판단했던 그 오라클을 authz-coverage
+    스캐너가 재발견): member_id가 caller 본인인지 검증 없이 임의 member의 project 전환 결과
+    (project_name/org_id)를 열람할 수 있었다. self-scope 추가."""
+    await assert_caller_is_member(member_id, auth, session, org_id)
     tm_r = await session.execute(
         select(TeamMember.org_id).where(
             TeamMember.id == member_id,

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.pm import Story, Task
 from app.models.team import TeamMember
@@ -18,17 +18,27 @@ async def get_dashboard(
     member_id: uuid.UUID = Query(...),
     project_id: uuid.UUID | None = Query(default=None),
     session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     _auth: AuthContext = Depends(get_current_user),
 ) -> DashboardResponse:
+    """prod 핫픽스(S20 전수스캔 MUST): cross-org 데이터 누출 차단.
+
+    이전엔 org_id 검증 자체가 없어(get_verified_org_id 미호출) 임의 member_id로 타 org 멤버의
+    대시보드(할당 스토리/태스크)를 그대로 열람할 수 있었다 — `project_id`를 명시하면 member 조회
+    자체가 생략돼 더 심했다. member가 caller org 소속인지 항상 검증(project_id 명시 여부 무관).
+    assignee 기준 열람 자체는 stories/tasks 목록 필터와 동일한 프로젝트 협업 시야라 자기 자신으로
+    제한하지 않는다(PO 확인).
+    """
+    member_check = await session.execute(
+        select(TeamMember.project_id).where(
+            TeamMember.id == member_id, TeamMember.org_id == org_id, TeamMember.is_active.is_(True)
+        ).limit(1)
+    )
+    member_project_id = member_check.scalar_one_or_none()
+    if member_project_id is None:
+        raise HTTPException(status_code=404, detail="Member not found or inactive")
     if project_id is None:
-        tm_r = await session.execute(
-            select(TeamMember.project_id).where(
-                TeamMember.id == member_id, TeamMember.is_active.is_(True)
-            ).limit(1)
-        )
-        project_id = tm_r.scalar_one_or_none()
-        if project_id is None:
-            raise HTTPException(status_code=404, detail="Member not found or inactive")
+        project_id = member_project_id
 
     stories_r = await session.execute(
         select(Story.id, Story.title, Story.status, Story.story_points).where(

--- a/backend/app/routers/hitl_config.py
+++ b/backend/app/routers/hitl_config.py
@@ -6,8 +6,9 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import get_current_user, get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.dependencies.ownership import _is_org_admin
 from app.models.hitl_config import MemberGateOverride, OrgGateOverride, OrgGatePolicy
 from app.repositories.base import BaseRepository
 from app.schemas.hitl_config import (
@@ -48,8 +49,12 @@ async def upsert_org_policy(
     body: OrgGatePolicyCreate,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> OrgGatePolicyResponse:
+    """prod 핫픽스(S20 전수스캔 HIGH, expire-stale 동형): org-admin 게이트 — 이전엔 admin 체크가
+    전무해 org 내 임의 멤버가 org 전체 HITL gate posture를 바꿀 수 있었다."""
+    if not await _is_org_admin(session, org_id, uuid.UUID(auth.user_id)):
+        raise HTTPException(status_code=403, detail="org admin/owner required")
     r = await session.execute(
         select(OrgGatePolicy).where(OrgGatePolicy.org_id == org_id).limit(1)
     )
@@ -83,8 +88,11 @@ async def upsert_org_override(
     body: OrgGateOverrideCreate,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> OrgGateOverrideResponse:
+    """prod 핫픽스(S20 전수스캔 HIGH): org-admin 게이트 추가."""
+    if not await _is_org_admin(session, org_id, uuid.UUID(auth.user_id)):
+        raise HTTPException(status_code=403, detail="org admin/owner required")
     r = await session.execute(
         select(OrgGateOverride).where(
             OrgGateOverride.org_id == org_id,
@@ -111,8 +119,11 @@ async def delete_org_override(
     id: uuid.UUID,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    """prod 핫픽스(S20 전수스캔 HIGH): org-admin 게이트 추가."""
+    if not await _is_org_admin(session, org_id, uuid.UUID(auth.user_id)):
+        raise HTTPException(status_code=403, detail="org admin/owner required")
     r = await session.execute(
         select(OrgGateOverride).where(OrgGateOverride.id == id, OrgGateOverride.org_id == org_id)
     )
@@ -131,8 +142,12 @@ async def upsert_member_override(
     body: MemberGateOverrideCreate,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> MemberGateOverrideResponse:
+    """prod 핫픽스(S20 전수스캔 HIGH): org-admin 게이트 — 이전엔 org 내 임의 멤버가 타 멤버의
+    gate override를 조작할 수 있었다."""
+    if not await _is_org_admin(session, org_id, uuid.UUID(auth.user_id)):
+        raise HTTPException(status_code=403, detail="org admin/owner required")
     r = await session.execute(
         select(MemberGateOverride).where(
             MemberGateOverride.org_id == org_id,
@@ -159,8 +174,11 @@ async def delete_member_override(
     id: uuid.UUID,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    """prod 핫픽스(S20 전수스캔 HIGH): org-admin 게이트 추가."""
+    if not await _is_org_admin(session, org_id, uuid.UUID(auth.user_id)):
+        raise HTTPException(status_code=403, detail="org admin/owner required")
     r = await session.execute(
         select(MemberGateOverride).where(
             MemberGateOverride.id == id, MemberGateOverride.org_id == org_id
@@ -247,14 +265,19 @@ async def apply_adjustment(
     body: ApplyRecommendationRequest,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
     """인간 승인 후 override 적용.
 
     ⚠️ 자동 호출 금지 — 반드시 인간이 추천 검토 후 명시 호출.
     apply_as='member': member_gate_override upsert.
     apply_as='org_role': org_gate_override upsert (role_id 필수).
+
+    prod 핫픽스(S20 전수스캔 — upsert_org_policy/overrides와 동일 클래스, 스캔표엔 5건으로
+    적혔지만 이 엔드포인트도 override를 직접 upsert하면서 admin 게이트가 없었다): org-admin 게이트 추가.
     """
+    if not await _is_org_admin(session, org_id, uuid.UUID(auth.user_id)):
+        raise HTTPException(status_code=403, detail="org admin/owner required")
     from app.models.hitl_config import DISPOSITIONS
 
     if body.disposition not in DISPOSITIONS:

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -27,7 +27,13 @@ async def get_me(
     is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
 
     if member_id:
-        where_clause = TeamMember.id == member_id
+        # S20(authz-coverage 스캐너 발견 — update_me엔 있는 self-check가 이 GET엔 없었다):
+        # 명시 member_id가 caller 본인일 때만 매칭 — 아니면 임의 member의 email 등 PII를
+        # 그대로 반환하던 갭(MeResponse.email 노출).
+        if is_api_key:
+            where_clause = (TeamMember.id == member_id) & (TeamMember.id == uid)
+        else:
+            where_clause = (TeamMember.id == member_id) & (TeamMember.user_id == uid)
     elif is_api_key:
         # API key 인증: auth.user_id = TeamMember.id
         where_clause = TeamMember.id == uid

--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -11,7 +11,7 @@ from app.models.retro import RetroItem, RetroSession, RetroVote
 from app.services import hypothesis as hyp_svc
 from app.services import retro_hypothesis_seed as seed_svc
 from app.services import retro_synthesis as synth_svc
-from app.services.member_resolver import canonicalize_member_id, resolve_member
+from app.services.member_resolver import canonicalize_member_id, lookup_members_by_ids, resolve_member
 from app.services.project_auth import has_project_access
 from app.repositories.retro import (
     RetroActionRepository,
@@ -552,6 +552,16 @@ async def list_actions(
     return [ActionResponse.model_validate(a) for a in actions]
 
 
+async def _verify_assignee_in_org(db: AsyncSession, org_id: uuid.UUID, assignee_id: uuid.UUID) -> None:
+    """prod 핫픽스(S20 전수스캔 MUST, hypothesis._verify_human_owner와 동일 클래스): assignee_id가
+    caller org 소속인지 검증 없이(canonicalize_member_id는 alias 정규화일 뿐 org 검증이 아님)
+    임의 org의 멤버를 action 담당자로 지정할 수 있었다(오귀속/신원 스푸핑)."""
+    members = await lookup_members_by_ids({assignee_id}, db)
+    rm = members.get(assignee_id)
+    if rm is None or rm.org_id != org_id:
+        raise HTTPException(status_code=400, detail="assignee_id must be a member of this organization")
+
+
 @router.post("/{id}/actions", response_model=ActionResponse, status_code=201)
 async def create_action(
     id: uuid.UUID,
@@ -563,6 +573,8 @@ async def create_action(
     await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
     action_repo = RetroActionRepository(db)
     assignee_id = (await canonicalize_member_id(body.assignee_id, db)) if body.assignee_id else None
+    if assignee_id is not None:
+        await _verify_assignee_in_org(db, repo.org_id, assignee_id)
     action = await action_repo.create(
         session_id=id, title=body.title, assignee_id=assignee_id
     )
@@ -582,6 +594,8 @@ async def update_action(
     await _require_retro_project_access(db, id, uuid.UUID(auth.user_id), repo.org_id)
     action_repo = RetroActionRepository(db)
     data = body.model_dump(exclude_unset=True)
+    if data.get("assignee_id") is not None:
+        await _verify_assignee_in_org(db, repo.org_id, data["assignee_id"])
     action = await action_repo.update_in_session(id, action_id, **data)
     if action is None:
         raise HTTPException(status_code=404, detail="Action not found")

--- a/backend/app/routers/rewards.py
+++ b/backend/app/routers/rewards.py
@@ -3,10 +3,12 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.dependencies.ownership import _is_org_admin
 from app.repositories.reward import RewardRepository
 from app.schemas.reward import BalanceResponse, GrantReward, LeaderboardEntry, RewardLedgerResponse
+from app.services.member_resolver import is_caller_member, resolve_member
 
 router = APIRouter(prefix="/api/v2/rewards", tags=["rewards"])
 
@@ -16,6 +18,16 @@ def _get_repo(
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> RewardRepository:
     return RewardRepository(session, org_id)
+
+
+async def _assert_self_or_org_admin(
+    member_id: uuid.UUID, auth: AuthContext, session: AsyncSession, org_id: uuid.UUID,
+) -> None:
+    if await is_caller_member(member_id, auth, session, org_id):
+        return
+    if await _is_org_admin(session, org_id, uuid.UUID(auth.user_id)):
+        return
+    raise HTTPException(status_code=403, detail="Not authorized for this member")
 
 
 @router.get("", response_model=list[RewardLedgerResponse])
@@ -32,8 +44,13 @@ async def list_rewards(
 async def get_balance(
     project_id: uuid.UUID = Query(...),
     member_id: uuid.UUID = Query(...),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
     repo: RewardRepository = Depends(_get_repo),
 ) -> BalanceResponse:
+    """prod 핫픽스(S20 전수스캔 MUST): self-or-org-admin — 이전엔 caller-ownership 확인이 전혀
+    없어 org 내 임의 멤버가 타 멤버의 리워드 잔액(재무정보)을 열람할 수 있었다."""
+    await _assert_self_or_org_admin(member_id, auth, repo.session, org_id)
     balance = await repo.get_balance(project_id=project_id, member_id=member_id)
     return BalanceResponse(project_id=project_id, member_id=member_id, balance=balance)
 
@@ -41,12 +58,24 @@ async def get_balance(
 @router.post("", response_model=RewardLedgerResponse, status_code=201)
 async def grant_reward(
     body: GrantReward,
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
     repo: RewardRepository = Depends(_get_repo),
 ) -> RewardLedgerResponse:
-    # AC3-2d(2): member_id(수령자)·granted_by(지급자) canonical 정규화. (A) write. agent id는 no-op.
+    """prod 핫픽스(S20 전수스캔 MUST, 최우선): org-admin 게이트 + granted_by 서버파생.
+
+    이전엔 admin/role 체크가 전무해 org 내 임의 멤버가 타 멤버에게 임의 금액의 리워드를 발행할
+    수 있었고, `granted_by`도 body에서 그대로 신뢰돼(client-supplied) 지급자를 스푸핑할 수
+    있었다. org-admin 전용으로 닫고, granted_by는 caller 본인에서 서버-파생(body 값 무시).
+    """
+    if not await _is_org_admin(repo.session, org_id, uuid.UUID(auth.user_id)):
+        raise HTTPException(status_code=403, detail="org admin/owner required")
+
+    # AC3-2d(2): member_id(수령자)·granted_by(지급자) canonical 정규화. (A) write.
     from app.services.member_resolver import canonicalize_member_id
     member_id = await canonicalize_member_id(body.member_id, repo.session)
-    granted_by = (await canonicalize_member_id(body.granted_by, repo.session)) if body.granted_by else None
+    caller_member = await resolve_member(auth, org_id, repo.session)
+    granted_by = await canonicalize_member_id(caller_member.id, repo.session)  # S20: caller에서 서버-파생(body 무시)
     entry = await repo.grant(
         project_id=body.project_id,
         member_id=member_id,

--- a/backend/app/routers/rewards.py
+++ b/backend/app/routers/rewards.py
@@ -1,11 +1,13 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.dependencies.ownership import _is_org_admin
+from app.models.project import Project
 from app.repositories.reward import RewardRepository
 from app.schemas.reward import BalanceResponse, GrantReward, LeaderboardEntry, RewardLedgerResponse
 from app.services.member_resolver import is_caller_member, resolve_member
@@ -96,9 +98,17 @@ async def get_leaderboard(
     period: str = Query(default="all"),
     limit: int = Query(default=50, ge=1, le=100),
     cursor: str | None = Query(default=None),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     repo: RewardRepository = Depends(_get_repo),
 ) -> list[LeaderboardEntry]:
+    """산티아고 SME fast-follow(S20 전수봉인): project_id가 caller org 소속인지 검증 없어
+    타 org의 리더보드(재무/성과 aggregate)가 project_id만 알면 노출됐다 — 이제 명시 403."""
     if period not in ("daily", "weekly", "monthly", "all"):
         raise HTTPException(status_code=400, detail="period must be one of: daily, weekly, monthly, all")
+    proj_check = await repo.session.execute(
+        select(Project.id).where(Project.id == project_id, Project.org_id == org_id)
+    )
+    if proj_check.scalar_one_or_none() is None:
+        raise HTTPException(status_code=403, detail="project not accessible")
     items = await repo.leaderboard(project_id=project_id, period=period, limit=limit, cursor=cursor)
     return [LeaderboardEntry.model_validate(i) for i in items]

--- a/backend/app/routers/trust_scores.py
+++ b/backend/app/routers/trust_scores.py
@@ -1,13 +1,25 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import get_current_user, get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.dependencies.ownership import _is_org_admin
+from app.services.member_resolver import is_caller_member
 from app.services.trust_score import DEFAULT_WINDOW_DAYS, compute_member_trust_scores
 
 router = APIRouter(prefix="/api/v2/trust-scores", tags=["trust-scores"])
+
+
+async def _assert_self_or_org_admin(
+    member_id: uuid.UUID, auth: AuthContext, session: AsyncSession, org_id: uuid.UUID,
+) -> None:
+    if await is_caller_member(member_id, auth, session, org_id):
+        return
+    if await _is_org_admin(session, org_id, uuid.UUID(auth.user_id)):
+        return
+    raise HTTPException(status_code=403, detail="Not authorized for this member")
 
 
 @router.get("")
@@ -17,8 +29,11 @@ async def get_trust_scores(
     window_days: int = Query(default=DEFAULT_WINDOW_DAYS, ge=1, le=365),
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    # S20 전수스캔 findings #11: member_id에 caller-ownership 확인이 전혀 없어 임의 org member가
+    # 다른 member의 신뢰점수(성과 유사 민감정보)를 열람할 수 있었다 — rewards.get_balance와 동형.
+    await _assert_self_or_org_admin(member_id, auth, session, org_id)
     return await compute_member_trust_scores(
         session=session,
         org_id=org_id,

--- a/backend/app/routers/workflow_report.py
+++ b/backend/app/routers/workflow_report.py
@@ -9,10 +9,11 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.gate import Gate
 from app.models.pm import Story
+from app.models.team import TeamMember
 from app.repositories.story import StoryRepository
 from app.services.merge_verdict_gate import (
     AUTO_MERGE,
@@ -129,6 +130,7 @@ async def report_done(
     background_tasks: BackgroundTasks,
     response: Response,
     session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> ReportDoneResponse:
     if body.stage not in _VALID_STAGES:
@@ -137,11 +139,24 @@ async def report_done(
             detail=f"Invalid stage '{body.stage}'. Valid: {list(_VALID_STAGES)}",
         )
 
-    # 스토리 조회
-    result = await session.execute(select(Story).where(Story.id == body.story_id))
+    # S20 전수스캔 finding #12: org_id 검증이 전혀 없어 임의 org의 caller가 다른 org 소유
+    # story를 조회/전이(cross-org story-pipeline 조작)할 수 있었다 — 이제 caller org로 필터.
+    result = await session.execute(
+        select(Story).where(Story.id == body.story_id, Story.org_id == org_id)
+    )
     story = result.scalar_one_or_none()
     if story is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Story not found")
+
+    # S20 finding #12(sibling): body.agent_id도 검증 없이 gate/line 평가의 actor로 그대로
+    # 쓰였다 — 임의 agent_id로 actor 스푸핑 가능했던 갭. caller org 소속 member인지 확인.
+    agent_check = await session.execute(
+        select(TeamMember.id).where(
+            TeamMember.id == body.agent_id, TeamMember.org_id == org_id,
+        ).limit(1)
+    )
+    if agent_check.scalar_one_or_none() is None:
+        raise HTTPException(status_code=400, detail="agent_id not found in this organization")
 
     transition = _TRANSITIONS[body.stage]
     next_stage: str = transition["next_stage"]

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -65,12 +65,16 @@ def map_legacy_outcome_status(outcome_status: str | None) -> str | None:
     return _LEGACY_OUTCOME_TO_STATUS.get(outcome_status)
 
 
-async def _verify_human_owner(session: AsyncSession, owner_id: uuid.UUID) -> None:
+async def _verify_human_owner(session: AsyncSession, org_id: uuid.UUID, owner_id: uuid.UUID) -> None:
+    """prod 핫픽스(S20 전수스캔 MUST): 이전엔 org_id 검증이 없어(``lookup_members_by_ids``가
+    org 필터 없이 순수 id로만 조회) caller가 임의 org의 human을 owner_member_id로 지정할 수
+    있었다(cross-org 오귀속 — 데이터 유출은 아니나 신원 스푸핑). 조회된 멤버가 caller의 org
+    소속인지 검증한다."""
     members = await lookup_members_by_ids({owner_id}, session)
     rm = members.get(owner_id)
-    if rm is None or rm.type != "human":
+    if rm is None or rm.type != "human" or rm.org_id != org_id:
         raise HypothesisServiceError(
-            "HUMAN_OWNER_REQUIRED", "owner_member_id는 type='human' 멤버여야 합니다."
+            "HUMAN_OWNER_REQUIRED", "owner_member_id는 caller와 동일 org의 type='human' 멤버여야 합니다."
         )
 
 
@@ -138,7 +142,7 @@ async def create_hypothesis(
                 "HUMAN_OWNER_REQUIRED", "agent caller는 휴먼 owner_member_id를 명시해야 합니다."
             )
         owner_id = caller.id
-    await _verify_human_owner(session, owner_id)
+    await _verify_human_owner(session, org_id, owner_id)
 
     # 상태 — agent/API key는 proposed로 강제(에러 아님). 생성 허용 상태는 proposed|active.
     status = payload.status or "proposed"
@@ -253,7 +257,7 @@ async def update_hypothesis(
     sprint_id = fields.pop("sprint_id", None)
     new_owner = fields.get("owner_member_id")
     if new_owner is not None:
-        await _verify_human_owner(session, new_owner)
+        await _verify_human_owner(session, org_id, new_owner)
     # cross-project 가드는 어떤 컬럼 mutation보다 먼저 — 거부 시 부분 update 0(create 경로와 동형).
     if sprint_id_provided and sprint_id is not None:
         await _assert_targets_same_project(session, hyp.project_id, [], [], sprint_id)

--- a/backend/tests/authz_coverage_lib.py
+++ b/backend/tests/authz_coverage_lib.py
@@ -1,0 +1,177 @@
+"""S20(`5736c1a5`): authz-coverage 스캐너 — enumerate/scan 유틸.
+
+설계 근거: Sprintable 문서 `s20-authz-coverage-design`(SSOT). 핵심 발견 두 가지가 이 구현을
+결정한다:
+
+1. 기존 caller-ownership 가드(assert_caller_is_member 등)는 전부 핸들러 **바디 안에서 직접
+   await 호출**되고 FastAPI ``Depends()``로 선언되지 않는다(실측: ``Depends(assert_...)`` /
+   ``Depends(_assert...)`` 매치 0건) — 그래서 가드 탐지는 **정적(AST) 바디 스캔**이 필수다.
+   런타임(``app.routes``)은 "실제 서빙되는 라우트" 캐노니컬 소스로만 쓴다.
+2. 앱의 mutating 라우트 대다수(story/task/sprint 등 협업 리소스)는 caller-identity ownership이
+   아니라 **tenancy 스코프**(``get_verified_org_id``/``enforce_body_context`` 등, Depends 체인)로
+   보호된다 — 이건 다른 축의 관심사라 스캐너 대상에서 자연히 제외해야 한다(안 그러면 오탐 100+건).
+   그래서 대상은 "identity-shaped 파라미터를 가진" 라우트로 좁힌다(member_id/assignee_id/
+   recipient_id/sender_id/agent_id/user_id — path/query든 body 모델 필드든).
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+import textwrap
+from dataclasses import dataclass, field
+
+from pydantic import BaseModel
+
+# ── (b) "가드 선언" 인정 기준 — 기존 프리미티브 재사용만(신규 프리미티브 발명 금지) ────────────
+GUARD_FUNCTIONS: frozenset[str] = frozenset({
+    "assert_caller_is_member",
+    "is_caller_member",
+    "assert_agent_owner",
+    "_is_org_admin",
+    "has_project_role",
+    "has_project_access",
+    "is_org_owner_or_admin",
+    "is_org_owner",
+    "_assert_can_manage_human",
+    "_assert_self_or_org_admin",
+})
+
+# Depends(...) 콜러블 — 결과 id가 caller auth에서 서버-파생돼 클라이언트가 스푸핑할 여지가
+# 없는 패턴(예: app.routers.webhooks._get_caller_member_id). 이름 자체가 곧 계약이라 이름
+# registry로 관리 — 새 self-deriving dependency 추가 시 여기만 갱신.
+SELF_DERIVING_DEPENDENCIES: frozenset[str] = frozenset({
+    "_get_caller_member_id",
+})
+
+MUTATING_METHODS: frozenset[str] = frozenset({"POST", "PATCH", "PUT", "DELETE"})
+# (GET 포함 — PO 크럭스 승인: read 사이드 정보노출도 이 스토리의 핵심 동기이자 커버리지 대상).
+COVERED_METHODS: frozenset[str] = MUTATING_METHODS | {"GET"}
+
+IDENTITY_PARAM_RE = re.compile(
+    r"(?:^|_)(member_id|assignee_member_id|assignee_id|recipient_id|sender_id|agent_id|user_id)$"
+)
+
+
+@dataclass(frozen=True)
+class RouteTarget:
+    path: str
+    methods: tuple[str, ...]
+    module: str
+    qualname: str
+    identity_params: tuple[str, ...]
+    endpoint: object = field(repr=False, compare=False)
+
+    @property
+    def key(self) -> str:
+        """중앙 allowlist 키 — ``<module>:<qualname>`` 형식."""
+        return f"{self.module}:{self.qualname}"
+
+
+def _identity_fields_from_annotation(annotation) -> set[str]:
+    """파라미터 타입이 Pydantic body 모델이면 그 필드명 중 identity-shaped 것도 대상에 포함.
+
+    (예: events.py create_event의 ``body: CreateEventRequest``의 ``sender_id`` 필드 — 최상위
+    함수 시그니처엔 안 보이지만 body 모델 필드로 존재.)
+    """
+    try:
+        if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+            return {name for name in annotation.model_fields if IDENTITY_PARAM_RE.search(name)}
+    except TypeError:
+        pass
+    return set()
+
+
+def _identity_params(endpoint) -> set[str]:
+    try:
+        sig = inspect.signature(endpoint)
+    except (ValueError, TypeError):
+        return set()
+    found: set[str] = set()
+    for name, p in sig.parameters.items():
+        if IDENTITY_PARAM_RE.search(name):
+            found.add(name)
+        found |= _identity_fields_from_annotation(p.annotation)
+    return found
+
+
+def _called_names(endpoint) -> set[str]:
+    """엔드포인트 함수 바디의 Call 노드 이름(Name/Attribute 양쪽) 전부 — AST 정적 스캔.
+
+    v1 제약(설계 문서에 명시): 이 함수 자신의 바디만 본다 — 헬퍼 함수 한 단계 아래 감긴 가드는
+    안 보인다(예: channel.py의 ``_resolve_agent``). 대상 규모가 작아(식별된 identity-param
+    라우트 기준 수십 건 이내) 이런 케이스는 findings 리뷰에서 수동 확인 후 allowlist하는 편이
+    재귀 콜그래프 분석의 자체 실패모드(동적 임포트·repo 간접호출 등)보다 안전하다는 판단.
+    """
+    try:
+        src = textwrap.dedent(inspect.getsource(endpoint))
+        tree = ast.parse(src)
+    except (OSError, TypeError, SyntaxError):
+        return set()
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            f = node.func
+            if isinstance(f, ast.Name):
+                names.add(f.id)
+            elif isinstance(f, ast.Attribute):
+                names.add(f.attr)
+    return names
+
+
+def _depends_callable_names(endpoint) -> set[str]:
+    """시그니처의 ``Depends(...)`` 콜러블 이름 — 자가파생 의존성(SELF_DERIVING_DEPENDENCIES) 인식용.
+
+    미래 대비: 가드가 언젠가 Depends 기반으로 리팩터되면 이 경로로도 잡히게(현재는 실사용 0건).
+    """
+    try:
+        sig = inspect.signature(endpoint)
+    except (ValueError, TypeError):
+        return set()
+    names: set[str] = set()
+    for p in sig.parameters.values():
+        dependency = getattr(p.default, "dependency", None)
+        if dependency is not None:
+            names.add(getattr(dependency, "__name__", ""))
+    return names
+
+
+def enumerate_identity_routes(app, methods: frozenset[str] = COVERED_METHODS) -> list[RouteTarget]:
+    """앱의 전 라우트 중 covered method + identity-shaped param을 가진 것만 열거.
+
+    같은 엔드포인트 함수가 여러 route(예: 여러 path alias)에 바인딩된 경우 중복 제거.
+    """
+    seen: set = set()
+    out: list[RouteTarget] = []
+    for route in app.routes:
+        route_methods = getattr(route, "methods", None)
+        if not route_methods:
+            continue
+        matched = route_methods & methods
+        if not matched:
+            continue
+        endpoint = getattr(route, "endpoint", None)
+        if endpoint is None or endpoint in seen:
+            continue
+        seen.add(endpoint)
+        identity_params = _identity_params(endpoint)
+        if not identity_params:
+            continue
+        out.append(RouteTarget(
+            path=route.path,
+            methods=tuple(sorted(matched)),
+            module=endpoint.__module__,
+            qualname=endpoint.__qualname__,
+            identity_params=tuple(sorted(identity_params)),
+            endpoint=endpoint,
+        ))
+    return out
+
+
+def has_declared_guard(target: RouteTarget) -> bool:
+    """이름 registry 매치(바디 호출) 또는 self-deriving Depends 매치 — 둘 중 하나면 가드 有."""
+    if _called_names(target.endpoint) & GUARD_FUNCTIONS:
+        return True
+    if _depends_callable_names(target.endpoint) & SELF_DERIVING_DEPENDENCIES:
+        return True
+    return False

--- a/backend/tests/test_e_cage_referee_p2_trust_score.py
+++ b/backend/tests/test_e_cage_referee_p2_trust_score.py
@@ -1,7 +1,7 @@
 """E-CAGE-REFEREE P2: 신뢰 점수 집계 엔진 테스트."""
 import uuid
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -312,13 +312,50 @@ async def test_get_trust_scores_endpoint_200():
     app.dependency_overrides[get_current_user] = override_auth
 
     try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-            resp = await c.get(f"/api/v2/trust-scores?member_id={MEMBER_ID}")
+        with patch("app.routers.trust_scores.is_caller_member", new_callable=AsyncMock, return_value=True):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.get(f"/api/v2/trust-scores?member_id={MEMBER_ID}")
         assert resp.status_code == 200
         body = resp.json()
         assert body["member_id"] == str(MEMBER_ID)
         assert body["scores"] == []
         assert "window_days" in body
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_trust_scores_403_when_not_self_or_admin():
+    """S20 전수스캔 finding #11: member_id가 caller 본인도 org-admin도 아니면 403
+    (이전엔 org_id만 검증되고 member_id ownership 확인이 아예 없어 임의 member의
+    신뢰점수를 열람할 수 있었다)."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    try:
+        with patch("app.routers.trust_scores.is_caller_member", new_callable=AsyncMock, return_value=False), \
+             patch("app.routers.trust_scores._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.get(f"/api/v2/trust-scores?member_id={MEMBER_ID}")
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 

--- a/backend/tests/test_e_cage_referee_p3_dynamic_adjustment.py
+++ b/backend/tests/test_e_cage_referee_p3_dynamic_adjustment.py
@@ -223,18 +223,54 @@ async def test_apply_endpoint_member_override():
     app.dependency_overrides[get_current_user] = override_auth
 
     try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-            resp = await c.post("/api/v2/gate-config/recommendations/apply", json={
-                "member_id": str(MEMBER_ID),
-                "gate_type": "pr_review",
-                "disposition": "allow_auto",
-                "apply_as": "member",
-            })
+        with patch("app.routers.hitl_config._is_org_admin", new_callable=AsyncMock, return_value=True):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.post("/api/v2/gate-config/recommendations/apply", json={
+                    "member_id": str(MEMBER_ID),
+                    "gate_type": "pr_review",
+                    "disposition": "allow_auto",
+                    "apply_as": "member",
+                })
         assert resp.status_code == 200
         body = resp.json()
         assert body["applied"] is True
         assert body["disposition"] == "allow_auto"
         mock_session.add.assert_called_once()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_apply_endpoint_403_when_not_org_admin():
+    """prod 핫픽스(S20 전수스캔 HIGH): org-admin 아니면 gate override 적용 차단."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    async def override_db():
+        yield AsyncMock()
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    try:
+        with patch("app.routers.hitl_config._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.post("/api/v2/gate-config/recommendations/apply", json={
+                    "member_id": str(MEMBER_ID),
+                    "gate_type": "pr_review",
+                    "disposition": "allow_auto",
+                    "apply_as": "member",
+                })
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 

--- a/backend/tests/test_hitl_config_admin_gate.py
+++ b/backend/tests/test_hitl_config_admin_gate.py
@@ -1,0 +1,129 @@
+"""prod 핫픽스(S20 전수스캔 HIGH, expire-stale 동형): hitl_config.py의 mutating 엔드포인트
+전부가 org-admin 게이트 없이(``_auth`` 선언만) 열려있었다 — org 내 임의 멤버가 org 전체 HITL
+gate posture를 바꾸거나 타 멤버의 override를 조작할 수 있었다. 각 엔드포인트에 admin 게이트를
+추가 — 이 테스트는 그 게이트가 실제로 403을 내는지만 확인한다(200 경로는 기존 테스트가 커버).
+"""
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+ORG_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+ROLE_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client_not_admin():
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.mark.anyio
+async def test_upsert_org_policy_403_when_not_org_admin():
+    client, session, app = await _client_not_admin()
+    try:
+        with patch("app.routers.hitl_config._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                resp = await c.put("/api/v2/gate-config/policy", json={"posture": "conservative"})
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_upsert_org_override_403_when_not_org_admin():
+    client, session, app = await _client_not_admin()
+    try:
+        with patch("app.routers.hitl_config._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                resp = await c.post("/api/v2/gate-config/overrides/org", json={
+                    "role_id": str(ROLE_ID), "gate_type": "pr_review", "disposition": "allow_auto",
+                })
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_org_override_403_when_not_org_admin():
+    client, session, app = await _client_not_admin()
+    try:
+        with patch("app.routers.hitl_config._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                resp = await c.delete(f"/api/v2/gate-config/overrides/org/{uuid.uuid4()}")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_upsert_member_override_403_when_not_org_admin():
+    client, session, app = await _client_not_admin()
+    try:
+        with patch("app.routers.hitl_config._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                resp = await c.post("/api/v2/gate-config/overrides/member", json={
+                    "member_id": str(MEMBER_ID), "gate_type": "pr_review", "disposition": "allow_auto",
+                })
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_member_override_403_when_not_org_admin():
+    client, session, app = await _client_not_admin()
+    try:
+        with patch("app.routers.hitl_config._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                resp = await c.delete(f"/api/v2/gate-config/overrides/member/{uuid.uuid4()}")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_upsert_org_policy_200_when_org_admin():
+    from datetime import datetime, timezone
+
+    client, session, app = await _client_not_admin()
+    try:
+        mock_r = MagicMock()
+        mock_r.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_r)
+        session.flush = AsyncMock()
+
+        async def _fake_refresh(obj):
+            obj.created_at = datetime.now(timezone.utc)
+            obj.updated_at = datetime.now(timezone.utc)
+
+        session.refresh = AsyncMock(side_effect=_fake_refresh)
+        with patch("app.routers.hitl_config._is_org_admin", new_callable=AsyncMock, return_value=True):
+            async with client as c:
+                resp = await c.put("/api/v2/gate-config/policy", json={"posture": "conservative"})
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_hypothesis_service.py
+++ b/backend/tests/test_hypothesis_service.py
@@ -328,6 +328,24 @@ async def test_update_owner_agent_raises():
     assert ei.value.code == "HUMAN_OWNER_REQUIRED"
 
 
+async def test_update_owner_cross_org_raises():
+    """prod 핫픽스(S20 전수스캔 MUST): owner_member_id가 caller org와 다른 org의 human이면
+    거부(오귀속/cross-org 스푸핑 차단) — type='human'만으로는 부족, org 일치도 필요."""
+    repo = _repo_mock(_hyp_stub())
+    other_org_member = ResolvedMember(
+        id=OWNER_ID, user_id=uuid.uuid4(), name="o", type="human",
+        role="member", org_id=uuid.uuid4(),  # ORG_ID와 다름
+    )
+    p_repo = patch.object(svc, "HypothesisRepository", return_value=repo)
+    p_lookup = patch.object(svc, "lookup_members_by_ids", AsyncMock(return_value={OWNER_ID: other_org_member}))
+    with p_repo, p_lookup, pytest.raises(svc.HypothesisServiceError) as ei:
+        await svc.update_hypothesis(
+            MagicMock(), ORG_ID, _caller("human"), HYP_ID,
+            HypothesisUpdate(owner_member_id=OWNER_ID),
+        )
+    assert ei.value.code == "HUMAN_OWNER_REQUIRED"
+
+
 async def test_update_statement_ok():
     repo = _repo_mock(_hyp_stub())
     p_repo, p_lookup = _patch(repo, "human")

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -270,7 +270,8 @@ async def test_current_project_get_via_conftest(test_client, mock_session):
     mock_result.first.return_value = None
     mock_session.execute = AsyncMock(return_value=mock_result)
 
-    resp = await test_client.get(f"/api/v2/current-project?member_id={member_id}")
+    with patch("app.routers.current_project.assert_caller_is_member", new_callable=AsyncMock, return_value=None):
+        resp = await test_client.get(f"/api/v2/current-project?member_id={member_id}")
     assert resp.status_code == 200
     assert resp.json()["project_id"] is None
 

--- a/backend/tests/test_retros.py
+++ b/backend/tests/test_retros.py
@@ -936,6 +936,116 @@ async def test_update_action_200():
 
 
 @pytest.mark.anyio
+async def test_create_action_with_assignee_in_org_200():
+    """prod 핫픽스(S20 전수스캔 MUST): assignee_id가 caller org 소속이면 정상 동작."""
+    from app.services.member_resolver import ResolvedMember
+
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        assignee_id = uuid.uuid4()
+        created = _mock_action()
+        created.assignee_id = assignee_id
+        resolved = ResolvedMember(
+            id=assignee_id, user_id=uuid.uuid4(), name="a", type="human",
+            role="member", org_id=ORG_ID,
+        )
+
+        with (
+            _allow_project_access(),
+            patch("app.routers.retros.canonicalize_member_id", new_callable=AsyncMock, return_value=assignee_id),
+            patch("app.routers.retros.lookup_members_by_ids", new_callable=AsyncMock, return_value={assignee_id: resolved}),
+            patch("app.repositories.retro.RetroActionRepository.create", new_callable=AsyncMock) as mock_create,
+        ):
+            mock_create.return_value = created
+
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/retros/{SESSION_ID}/actions",
+                    json={"title": "follow up", "assignee_id": str(assignee_id)},
+                )
+
+        assert resp.status_code == 201
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_action_with_cross_org_assignee_400():
+    """prod 핫픽스(S20 전수스캔 MUST): assignee_id가 caller org 소속이 아니면 400(오귀속 차단)."""
+    from app.services.member_resolver import ResolvedMember
+
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        assignee_id = uuid.uuid4()
+        resolved = ResolvedMember(
+            id=assignee_id, user_id=uuid.uuid4(), name="a", type="human",
+            role="member", org_id=uuid.uuid4(),  # ORG_ID와 다름
+        )
+
+        with (
+            _allow_project_access(),
+            patch("app.routers.retros.canonicalize_member_id", new_callable=AsyncMock, return_value=assignee_id),
+            patch("app.routers.retros.lookup_members_by_ids", new_callable=AsyncMock, return_value={assignee_id: resolved}),
+            patch("app.repositories.retro.RetroActionRepository.create", new_callable=AsyncMock) as mock_create,
+        ):
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/retros/{SESSION_ID}/actions",
+                    json={"title": "follow up", "assignee_id": str(assignee_id)},
+                )
+
+        assert resp.status_code == 400
+        mock_create.assert_not_awaited()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_action_cross_org_assignee_400():
+    """prod 핫픽스(S20 전수스캔 MUST): update_action도 동일 갭 — cross-org assignee 재배정 차단."""
+    from app.services.member_resolver import ResolvedMember
+
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        assignee_id = uuid.uuid4()
+        resolved = ResolvedMember(
+            id=assignee_id, user_id=uuid.uuid4(), name="a", type="human",
+            role="member", org_id=uuid.uuid4(),  # ORG_ID와 다름
+        )
+
+        with (
+            _allow_project_access(),
+            patch("app.routers.retros.lookup_members_by_ids", new_callable=AsyncMock, return_value={assignee_id: resolved}),
+            patch(
+                "app.repositories.retro.RetroActionRepository.update_in_session",
+                new_callable=AsyncMock,
+            ) as mock_update,
+        ):
+            async with client as c:
+                resp = await c.patch(
+                    f"/api/v2/retros/{SESSION_ID}/actions/{uuid.uuid4()}",
+                    json={"assignee_id": str(assignee_id)},
+                )
+
+        assert resp.status_code == 400
+        mock_update.assert_not_awaited()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_update_action_cross_project_403():
     """#1801 원 적출 지점 — parent session이 caller 무권한 project 소속이면 403."""
     client, session, app = await _client()

--- a/backend/tests/test_rewards.py
+++ b/backend/tests/test_rewards.py
@@ -94,9 +94,11 @@ async def test_list_rewards_with_member_filter_200():
 
 @pytest.mark.anyio
 async def test_get_balance_200():
+    """prod 핫픽스(S20 MUST): self-or-org-admin 통과 시(caller 본인) 정상 동작."""
     client, session, app = await _client()
     try:
-        with patch("app.repositories.reward.RewardRepository.get_balance", new_callable=AsyncMock) as mock_bal:
+        with patch("app.repositories.reward.RewardRepository.get_balance", new_callable=AsyncMock) as mock_bal, \
+             patch("app.routers.rewards.is_caller_member", new_callable=AsyncMock, return_value=True):
             mock_bal.return_value = 150.0
 
             async with client as c:
@@ -109,12 +111,55 @@ async def test_get_balance_200():
 
 
 @pytest.mark.anyio
-async def test_grant_reward_201():
+async def test_get_balance_403_when_not_self_or_admin():
+    """prod 핫픽스(S20 MUST): 타 멤버 잔액 열람 차단(재무정보 노출)."""
     client, session, app = await _client()
     try:
-        with patch("app.repositories.reward.RewardRepository.grant", new_callable=AsyncMock) as mock_grant:
+        with patch("app.routers.rewards.is_caller_member", new_callable=AsyncMock, return_value=False), \
+             patch("app.routers.rewards._is_org_admin", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                resp = await c.get(f"/api/v2/rewards/balance?project_id={PROJECT_ID}&member_id={MEMBER_ID}")
+
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_grant_reward_201():
+    """prod 핫픽스(S20 MUST, 최우선): org-admin 통과 시 정상 동작·granted_by는 caller에서 서버파생."""
+    client, session, app = await _client()
+    try:
+        resolved = MagicMock()
+        resolved.id = GRANTER_ID
+        with patch("app.repositories.reward.RewardRepository.grant", new_callable=AsyncMock) as mock_grant, \
+             patch("app.routers.rewards._is_org_admin", new_callable=AsyncMock, return_value=True), \
+             patch("app.routers.rewards.resolve_member", new_callable=AsyncMock, return_value=resolved), \
+             patch("app.services.member_resolver.canonicalize_member_id", new_callable=AsyncMock, side_effect=lambda mid, _s: mid):
             mock_grant.return_value = _mock_entry(25.0)
 
+            async with client as c:
+                resp = await c.post("/api/v2/rewards", json={
+                    "project_id": str(PROJECT_ID),
+                    "member_id": str(MEMBER_ID),
+                    "amount": 25.0,
+                    "reason": "스프린트 완료",
+                    "granted_by": str(uuid.uuid4()),  # S20: 바디값 무시(caller에서 서버-파생)
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["currency"] == "TJSB"
+        assert mock_grant.await_args.kwargs["granted_by"] == GRANTER_ID
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_grant_reward_403_when_not_org_admin():
+    """prod 핫픽스(S20 MUST): org-admin 아니면 임의 리워드 발행 차단."""
+    client, session, app = await _client()
+    try:
+        with patch("app.routers.rewards._is_org_admin", new_callable=AsyncMock, return_value=False):
             async with client as c:
                 resp = await c.post("/api/v2/rewards", json={
                     "project_id": str(PROJECT_ID),
@@ -124,8 +169,7 @@ async def test_grant_reward_201():
                     "granted_by": str(GRANTER_ID),
                 })
 
-        assert resp.status_code == 201
-        assert resp.json()["currency"] == "TJSB"
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 
@@ -134,7 +178,12 @@ async def test_grant_reward_201():
 async def test_grant_reward_404_member_not_in_project():
     client, session, app = await _client()
     try:
-        with patch("app.repositories.reward.RewardRepository.grant", new_callable=AsyncMock) as mock_grant:
+        resolved = MagicMock()
+        resolved.id = GRANTER_ID
+        with patch("app.repositories.reward.RewardRepository.grant", new_callable=AsyncMock) as mock_grant, \
+             patch("app.routers.rewards._is_org_admin", new_callable=AsyncMock, return_value=True), \
+             patch("app.routers.rewards.resolve_member", new_callable=AsyncMock, return_value=resolved), \
+             patch("app.services.member_resolver.canonicalize_member_id", new_callable=AsyncMock, side_effect=lambda mid, _s: mid):
             mock_grant.return_value = None
 
             async with client as c:

--- a/backend/tests/test_rewards.py
+++ b/backend/tests/test_rewards.py
@@ -247,3 +247,21 @@ async def test_leaderboard_invalid_period_400():
         assert resp.status_code == 400
     finally:
         app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_leaderboard_403_when_project_not_in_caller_org():
+    """산티아고 SME fast-follow(S20 전수봉인): project_id가 caller org 소속 아니면 403
+    (이전엔 project 소속 검증 자체가 없어 project_id만 알면 타 org 리더보드가 노출됐다)."""
+    client, session, app = await _client()
+    try:
+        not_found = MagicMock()
+        not_found.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=not_found)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/rewards/leaderboard?project_id={PROJECT_ID}&period=all")
+
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_s31.py
+++ b/backend/tests/test_s31.py
@@ -278,6 +278,23 @@ async def test_get_me_200():
 
 
 @pytest.mark.anyio
+async def test_get_me_404_when_member_id_is_not_self():
+    """S20(authz-coverage 스캐너 발견): member_id가 caller 본인이 아니면 조회 실패(404) —
+    이전엔 member_id를 그대로 신뢰해 임의 member의 email 등 PII를 노출했다(update_me엔 있는
+    self-check가 get_me엔 없었다). 본인이 아니면 where_clause가 0행 → repo가 None 반환."""
+    client, session, app = await _client()
+    try:
+        session.execute = AsyncMock(return_value=_mock_result(None))
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/me?member_id={uuid.uuid4()}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_get_me_via_api_key_200():
     """API key 인증: auth.user_id = TeamMember.id → id 분기로 조회."""
     client, session, app = await _client_api_key()

--- a/backend/tests/test_s33.py
+++ b/backend/tests/test_s33.py
@@ -1,7 +1,7 @@
 """S33 AC: Dashboard + Current Project + Members 라우터 (7건 이상)."""
 import uuid
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -114,11 +114,29 @@ async def test_current_project_get_200():
 
         session.execute = mock_execute
 
-        async with client as c:
-            resp = await c.get(f"/api/v2/current-project?member_id={MEMBER_ID}")
+        with patch("app.routers.current_project.assert_caller_is_member", new_callable=AsyncMock, return_value=None):
+            async with client as c:
+                resp = await c.get(f"/api/v2/current-project?member_id={MEMBER_ID}")
 
         assert resp.status_code == 200
         assert resp.json()["project_id"] == str(PROJECT_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_current_project_get_403_when_not_self():
+    """S20(authz-coverage 스캐너 발견): member_id가 caller 본인 아니면 403(membership-existence
+    오라클 차단 — S19 Phase C서 no-op 판단했다가 스캐너가 재발견)."""
+    from fastapi import HTTPException
+
+    client, session, app = await _client()
+    try:
+        with patch("app.routers.current_project.assert_caller_is_member", new_callable=AsyncMock,
+                   side_effect=HTTPException(status_code=403, detail="Cannot act as another member")):
+            async with client as c:
+                resp = await c.get(f"/api/v2/current-project?member_id={MEMBER_ID}")
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 
@@ -141,14 +159,34 @@ async def test_current_project_post_200():
 
         session.execute = mock_execute
 
-        async with client as c:
-            resp = await c.post(
-                f"/api/v2/current-project?member_id={MEMBER_ID}",
-                json={"project_id": str(PROJECT_ID)},
-            )
+        with patch("app.routers.current_project.assert_caller_is_member", new_callable=AsyncMock, return_value=None):
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/current-project?member_id={MEMBER_ID}",
+                    json={"project_id": str(PROJECT_ID)},
+                )
 
         assert resp.status_code == 200
         assert resp.json()["project_id"] == str(PROJECT_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_current_project_post_403_when_not_self():
+    """S20: POST도 GET과 동일 갭 — self-scope 강제."""
+    from fastapi import HTTPException
+
+    client, session, app = await _client()
+    try:
+        with patch("app.routers.current_project.assert_caller_is_member", new_callable=AsyncMock,
+                   side_effect=HTTPException(status_code=403, detail="Cannot act as another member")):
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/current-project?member_id={MEMBER_ID}",
+                    json={"project_id": str(PROJECT_ID)},
+                )
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
 

--- a/backend/tests/test_s33.py
+++ b/backend/tests/test_s33.py
@@ -94,6 +94,24 @@ async def test_dashboard_empty_result_200():
         app.dependency_overrides.clear()
 
 
+@pytest.mark.anyio
+async def test_dashboard_404_when_member_not_in_caller_org():
+    """prod 핫픽스(S20 MUST): member_id가 caller org 소속 아니면 404(cross-org 데이터 누출 차단)
+    — project_id를 명시해도 member org 검증은 항상 수행된다."""
+    client, session, app = await _client()
+    try:
+        not_found = MagicMock()
+        not_found.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=not_found)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/dashboard?member_id={MEMBER_ID}&project_id={PROJECT_ID}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
 # ── Current Project ──────────────────────────────────────────────────────────
 
 @pytest.mark.anyio

--- a/backend/tests/test_s36.py
+++ b/backend/tests/test_s36.py
@@ -98,6 +98,24 @@ async def test_list_agent_runs_empty_200():
 
 
 @pytest.mark.anyio
+async def test_list_agent_runs_404_when_project_not_in_caller_org():
+    """prod 핫픽스(S20 전수스캔): project_id가 caller org 소속 아니면 404(cross-org 차단)."""
+    client, session, app = await _client()
+    try:
+        no_proj = MagicMock()
+        no_proj.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=no_proj)
+        with patch("app.repositories.agent_run.AgentRunRepository.list", new_callable=AsyncMock) as mock_list:
+            async with client as c:
+                resp = await c.get(f"/api/v2/agent-runs?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 404
+        mock_list.assert_not_awaited()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_list_agent_runs_missing_project_id_422():
     client, session, app = await _client()
     try:
@@ -161,7 +179,8 @@ async def test_update_agent_run_completed_200():
         completed.input_tokens = 1500
         completed.output_tokens = 300
 
-        with patch("app.repositories.agent_run.AgentRunRepository.update", new_callable=AsyncMock) as mock_update:
+        with patch("app.repositories.agent_run.AgentRunRepository.get", new_callable=AsyncMock, return_value=completed), \
+             patch("app.repositories.agent_run.AgentRunRepository.update", new_callable=AsyncMock) as mock_update:
             mock_update.return_value = completed
 
             async with client as c:
@@ -185,7 +204,8 @@ async def test_update_agent_run_failed_200():
         failed = _mock_run("failed")
         failed.last_error_code = "timeout"
 
-        with patch("app.repositories.agent_run.AgentRunRepository.update", new_callable=AsyncMock) as mock_update:
+        with patch("app.repositories.agent_run.AgentRunRepository.get", new_callable=AsyncMock, return_value=failed), \
+             patch("app.repositories.agent_run.AgentRunRepository.update", new_callable=AsyncMock) as mock_update:
             mock_update.return_value = failed
 
             async with client as c:
@@ -204,12 +224,32 @@ async def test_update_agent_run_failed_200():
 async def test_update_agent_run_404():
     client, session, app = await _client()
     try:
-        with patch("app.repositories.agent_run.AgentRunRepository.update", new_callable=AsyncMock) as mock_update:
+        with patch("app.repositories.agent_run.AgentRunRepository.get", new_callable=AsyncMock, return_value=None), \
+             patch("app.repositories.agent_run.AgentRunRepository.update", new_callable=AsyncMock) as mock_update:
             mock_update.return_value = None
 
             async with client as c:
                 resp = await c.patch(f"/api/v2/agent-runs/{uuid.uuid4()}", json={"status": "completed"})
 
         assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_agent_run_404_cross_org():
+    """prod 핫픽스(S20 전수스캔): 다른 org의 run id를 patch 시도해도 404(cross-org 차단)."""
+    client, session, app = await _client()
+    try:
+        other_org_run = _mock_run("completed")
+        other_org_run.org_id = uuid.uuid4()  # caller org(ORG_ID)와 다름
+
+        with patch("app.repositories.agent_run.AgentRunRepository.get", new_callable=AsyncMock, return_value=other_org_run), \
+             patch("app.repositories.agent_run.AgentRunRepository.update", new_callable=AsyncMock) as mock_update:
+            async with client as c:
+                resp = await c.patch(f"/api/v2/agent-runs/{RUN_ID}", json={"status": "completed"})
+
+        assert resp.status_code == 404
+        mock_update.assert_not_awaited()
     finally:
         app.dependency_overrides.clear()

--- a/backend/tests/test_workflow_report.py
+++ b/backend/tests/test_workflow_report.py
@@ -287,6 +287,59 @@ async def test_next_assignee_mapping():
 
 
 @pytest.mark.anyio
+async def test_story_cross_org_404():
+    """S20 전수스캔 finding #12: story_id가 caller org 소속 아니면 404
+    (이전엔 org_id 검증 자체가 없어 임의 org의 story를 조회/전이시킬 수 있었다)."""
+    client, session, app = await _client()
+    try:
+        not_found = MagicMock()
+        not_found.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=not_found)
+
+        async with client as c:
+            resp = await c.post("/api/v2/workflow/report-done", json={
+                "story_id": str(STORY_ID),
+                "stage": "kickoff",
+                "agent_id": str(AGENT_ID),
+            })
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_agent_id_cross_org_400():
+    """S20 전수스캔 finding #12(sibling): agent_id가 caller org 소속 member 아니면 400
+    (이전엔 검증 없이 gate/line 평가의 actor로 그대로 스푸핑 가능했다)."""
+    client, session, app = await _client()
+    try:
+        story = _mock_story(status="ready-for-dev")
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = story
+            else:
+                result.scalar_one_or_none.return_value = None
+            return result
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.post("/api/v2/workflow/report-done", json={
+                "story_id": str(STORY_ID),
+                "stage": "kickoff",
+                "agent_id": str(uuid.uuid4()),
+            })
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_pipeline_sequence():
     """kickoff→dev→review→qa→merge→done 순서가 올바르다."""
     from app.routers.workflow_report import _TRANSITIONS


### PR DESCRIPTION
## Summary
Story S20 (`5736c1a5`, high, SECURITY, root-fix): automated CI-resident authz-coverage test
that enumerates mutating+identity-param-bearing FastAPI routes and fails the build if none of
them declares a recognized caller-ownership guard. Design doc (SSOT):
Sprintable doc `s20-authz-coverage-design`.

(runtime-capabilities was split out to #1911 per PO request — no identity-param surface, doesn't
need to wait on this PR's security QA cycle.)

### fix(security): current-project GET/POST self-scope
While prototyping the scanner's identity-param heuristic, `set_current_project`
(and its sibling `get_current_project`, same file) turned out to have zero caller-ownership
check — `_auth` was declared but never used. Any authenticated caller could pass an arbitrary
`member_id` and get back `project_id`/`org_id`/`project_name` (membership-existence oracle).
This is the exact item S19 Phase C judged "no-op, skip" — the scanner re-surfaced it, which is
itself the proof-of-value for this story. Fixed with `assert_caller_is_member`.

Real-PG verified (bob→alice 403, alice self 200) + negative-tested (guard removed → reproduces
→ restored → re-confirmed).

## Test plan
- [x] current-project: real-PG verification + negative test + updated mocked tests
- [x] Full backend suite: 3079 passed, 7 failed (same pre-existing unrelated baseline)

## Next (this PR will grow)
- Authz-coverage scanner implementation (two guard registries, route enumeration, central
  allowlist) per the design doc
- Full-codebase first sweep (findings crux with PO) — in progress, refining the identity-param
  heuristic to exclude list-filter false positives (collaborative-resource assignee/owner filters,
  manager-visibility reporting endpoints) while keeping true personal-resource ownership gaps
- Fixes for confirmed findings (`get_me` missing the self-check `update_me` has, `channel/upload`,
  `agent-personas/seed` pending review)
- Wire into CI
- 산티아고 SME on both design and resulting coverage