### PR TITLE
feat: GET /api/v2/runtime-capabilities (S6, unblocks Mirko FE)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,7 +57,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, retros, rewards, role_templates, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, retros, rewards, role_templates, runtime_capabilities, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -197,6 +197,7 @@ app.include_router(rewards.router)
 app.include_router(audit_logs.router)
 app.include_router(dashboard.router)
 app.include_router(current_project.router)
+app.include_router(runtime_capabilities.router)
 app.include_router(members.router)
 app.include_router(merge_gate.router)
 app.include_router(organizations.router)

--- a/backend/app/routers/runtime_capabilities.py
+++ b/backend/app/routers/runtime_capabilities.py
@@ -1,0 +1,32 @@
+"""S6(유나/미르코 정합용): 지원 런타임 목록 노출 — S4 픽커/온보딩 FE가 이 계약으로 소비한다.
+
+읽기전용·경량·인증만(org-무관 — 전 org에 동일 백엔드 capability). 계약/판정 근거는
+``app.services.agent_onboarding_config.list_runtime_capabilities`` SSOT 참조.
+"""
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.services.agent_onboarding_config import list_runtime_capabilities
+
+router = APIRouter(prefix="/api/v2/runtime-capabilities", tags=["runtime-capabilities"])
+
+
+class RuntimeCapability(BaseModel):
+    slug: str
+    display_name: str
+    supported: bool
+    tier: str | None = None
+    transport: str | None = None
+    mcp_transport: list[str] = []
+    prompt_file: str | None = None
+    guide_filename: str | None = None
+    supports_event_push: bool = False
+    icon: str | None = None
+
+
+@router.get("", response_model=list[RuntimeCapability])
+async def get_runtime_capabilities(
+    _auth: AuthContext = Depends(get_current_user),
+) -> list[dict]:
+    return list_runtime_capabilities()

--- a/backend/app/services/agent_onboarding_config.py
+++ b/backend/app/services/agent_onboarding_config.py
@@ -45,6 +45,11 @@ _RUNTIME_DISPLAY_NAMES: dict[str, str] = {
     "codex": "Codex",
     "gemini": "Gemini",
     "cursor": "Cursor",
+    "opencode": "OpenCode",
+    "openclaw": "OpenClaw",
+    "hermes": "Hermes",
+    "grok": "Grok",
+    "pi": "Pi",
     CONNECTOR_RUNTIME: "Connector",
 }
 
@@ -59,20 +64,36 @@ def list_runtime_capabilities() -> list[dict]:
     이고 나머지는 S7 shaping 전이라 generic fallback이므로 tier="experimental". connector는
     `.mcp.json`은 성립 안 하나(``build_agent_mcp_config``가 None 반환) 안내 파일(CONNECTOR_SETUP.md)
     emit은 성공하므로 supported=true·실 어댑터 조립은 후속이라 tier="experimental".
+
+    PO 확인(2026-07-06): FE 픽커의 "곧 지원" 섹션이 채워지려면 **미지원 런타임도 응답에
+    포함**돼야 한다 — ``RuntimeType``(agent_runtime.py, member.runtime_type 9종 SSOT) 중
+    ``SUPPORTED_RUNTIMES``에 없는 5종(opencode/openclaw/hermes/grok/pi)은 recruit/
+    connection-artifact에 그 값 그대로 넘기면 400("unsupported runtime")이 난다 — 즉 개별
+    선택지로는 아직 미지원. ``supported=false``·``tier=None``으로 정직하게 반환한다(이들은
+    오늘도 ``connector`` 버킷을 통해 수동 가이드로는 연결 가능하나, 그건 별도 엔트리로 이미
+    표현됨 — 개별 런타임 엔트리 자체를 과대약속하지 않는다).
     """
+    from app.services.agent_runtime import RuntimeType
+
     out = []
-    for runtime in sorted(SUPPORTED_RUNTIMES):
+    all_slugs = sorted({rt.value for rt in RuntimeType} | SUPPORTED_RUNTIMES)
+    for runtime in all_slugs:
         is_connector = runtime == CONNECTOR_RUNTIME
+        supported = runtime in SUPPORTED_RUNTIMES
         out.append({
             "slug": runtime,
             "display_name": _RUNTIME_DISPLAY_NAMES.get(runtime, runtime),
-            "supported": True,
-            "tier": "full" if runtime in _INSTRUCTION_FILENAMES else "experimental",
-            "transport": None if is_connector else default_transport_for_edition(),
-            "mcp_transport": [] if is_connector else sorted(SUPPORTED_TRANSPORTS),
-            "prompt_file": resolve_instruction_filename(runtime),
+            "supported": supported,
+            "tier": (
+                None if not supported
+                else "full" if runtime in _INSTRUCTION_FILENAMES
+                else "experimental"
+            ),
+            "transport": None if (is_connector or not supported) else default_transport_for_edition(),
+            "mcp_transport": [] if (is_connector or not supported) else sorted(SUPPORTED_TRANSPORTS),
+            "prompt_file": resolve_instruction_filename(runtime) if supported else None,
             "guide_filename": "CONNECTOR_SETUP.md" if is_connector else None,
-            "supports_event_push": not is_connector,
+            "supports_event_push": supported and not is_connector,
             "icon": None,
         })
     return out

--- a/backend/app/services/agent_onboarding_config.py
+++ b/backend/app/services/agent_onboarding_config.py
@@ -40,6 +40,44 @@ def resolve_instruction_filename(runtime: str) -> str:
     return _INSTRUCTION_FILENAMES.get(runtime, _DEFAULT_INSTRUCTION_FILENAME)
 
 
+_RUNTIME_DISPLAY_NAMES: dict[str, str] = {
+    "claude-code": "Claude Code",
+    "codex": "Codex",
+    "gemini": "Gemini",
+    "cursor": "Cursor",
+    CONNECTOR_RUNTIME: "Connector",
+}
+
+
+def list_runtime_capabilities() -> list[dict]:
+    """S6(유나/미르코 정합용) `GET /api/v2/runtime-capabilities` 계약 SSOT.
+
+    supported/tier는 **S5 emit 코드 실기준**(과대약속 금지) — recruiter/connection-artifact가
+    그 런타임으로 실제 아티팩트를 만들 수 있으면 supported=true. ``build_agent_mcp_config``는
+    MCP-native 4종(claude-code/codex/gemini/cursor) 모두 런타임-무관 동일 config를 emit하므로
+    전부 supported=true — 단 ``resolve_instruction_filename``이 claude-code만 확정 매핑(CLAUDE.md)
+    이고 나머지는 S7 shaping 전이라 generic fallback이므로 tier="experimental". connector는
+    `.mcp.json`은 성립 안 하나(``build_agent_mcp_config``가 None 반환) 안내 파일(CONNECTOR_SETUP.md)
+    emit은 성공하므로 supported=true·실 어댑터 조립은 후속이라 tier="experimental".
+    """
+    out = []
+    for runtime in sorted(SUPPORTED_RUNTIMES):
+        is_connector = runtime == CONNECTOR_RUNTIME
+        out.append({
+            "slug": runtime,
+            "display_name": _RUNTIME_DISPLAY_NAMES.get(runtime, runtime),
+            "supported": True,
+            "tier": "full" if runtime in _INSTRUCTION_FILENAMES else "experimental",
+            "transport": None if is_connector else default_transport_for_edition(),
+            "mcp_transport": [] if is_connector else sorted(SUPPORTED_TRANSPORTS),
+            "prompt_file": resolve_instruction_filename(runtime),
+            "guide_filename": "CONNECTOR_SETUP.md" if is_connector else None,
+            "supports_event_push": not is_connector,
+            "icon": None,
+        })
+    return out
+
+
 def build_connector_guidance(runtime_hint: str | None = None) -> str:
     """E-RECRUIT S5 Q2(PO 확정): connector 분기 = **포인터/안내만**(SSE dial-out은 `.mcp.json`과
     완전 별개 프로토콜 — 실제 어댑터 조립은 S7/후속). `connectors/{runtime}-sprintable/` 각 폴더의

--- a/backend/tests/test_s6_runtime_capabilities.py
+++ b/backend/tests/test_s6_runtime_capabilities.py
@@ -1,0 +1,63 @@
+"""S6(유나/미르코 정합용): GET /api/v2/runtime-capabilities 계약 테스트.
+
+supported/tier는 app.services.agent_onboarding_config.list_runtime_capabilities SSOT 기준
+(S5 emit 코드 실기준 — 과대약속 금지). 이 테스트는 계약 shape + 판정 근거 정합만 검증한다.
+"""
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_runtime_capabilities_200_and_shape():
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.main import app
+
+    ctx = AuthContext(user_id=str(uuid.uuid4()), email=None, claims={"app_metadata": {}})
+    app.dependency_overrides[get_current_user] = lambda: ctx
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get("/api/v2/runtime-capabilities")
+        assert resp.status_code == 200
+        data = resp.json()
+        slugs = {r["slug"] for r in data}
+        assert slugs == {"claude-code", "codex", "gemini", "cursor", "connector"}
+        for r in data:
+            assert r["supported"] is True
+            assert r["tier"] in ("full", "experimental")
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_runtime_capabilities_401_when_unauthenticated():
+    from app.main import app
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.get("/api/v2/runtime-capabilities")
+    assert resp.status_code in (401, 403)
+
+
+def test_claude_code_is_full_tier_others_experimental():
+    """S5 emit 실기준: instruction filename 확정 매핑(CLAUDE.md)이 있는 claude-code만 tier=full —
+    나머지 MCP-native(codex/gemini/cursor)는 S7 shaping 전 generic fallback이라 experimental.
+    connector는 실 어댑터 조립이 후속이라 experimental."""
+    from app.services.agent_onboarding_config import list_runtime_capabilities
+
+    caps = {c["slug"]: c for c in list_runtime_capabilities()}
+    assert caps["claude-code"]["tier"] == "full"
+    assert caps["claude-code"]["prompt_file"] == "CLAUDE.md"
+    for slug in ("codex", "gemini", "cursor", "connector"):
+        assert caps[slug]["tier"] == "experimental"
+    assert caps["connector"]["mcp_transport"] == []
+    assert caps["connector"]["supports_event_push"] is False
+    assert caps["connector"]["guide_filename"] == "CONNECTOR_SETUP.md"
+    for slug in ("claude-code", "codex", "gemini", "cursor"):
+        assert caps[slug]["supports_event_push"] is True
+        assert set(caps[slug]["mcp_transport"]) == {"stdio", "http"}

--- a/backend/tests/test_s6_runtime_capabilities.py
+++ b/backend/tests/test_s6_runtime_capabilities.py
@@ -27,10 +27,17 @@ async def test_runtime_capabilities_200_and_shape():
         assert resp.status_code == 200
         data = resp.json()
         slugs = {r["slug"] for r in data}
-        assert slugs == {"claude-code", "codex", "gemini", "cursor", "connector"}
+        assert slugs == {
+            "claude-code", "codex", "gemini", "cursor", "connector",
+            "opencode", "openclaw", "hermes", "grok", "pi",
+        }
+        supported = {r["slug"] for r in data if r["supported"]}
+        assert supported == {"claude-code", "codex", "gemini", "cursor", "connector"}
         for r in data:
-            assert r["supported"] is True
-            assert r["tier"] in ("full", "experimental")
+            if r["supported"]:
+                assert r["tier"] in ("full", "experimental")
+            else:
+                assert r["tier"] is None
     finally:
         app.dependency_overrides.clear()
 
@@ -61,3 +68,16 @@ def test_claude_code_is_full_tier_others_experimental():
     for slug in ("claude-code", "codex", "gemini", "cursor"):
         assert caps[slug]["supports_event_push"] is True
         assert set(caps[slug]["mcp_transport"]) == {"stdio", "http"}
+
+
+def test_unsupported_runtimes_reported_honestly_for_coming_soon_section():
+    """PO(2026-07-06): FE 픽커의 '곧 지원' 섹션을 채우려면 미지원 런타임(RuntimeType 9종 중
+    SUPPORTED_RUNTIMES 밖 5종)도 응답에 있어야 한다 — supported=false·tier=None으로 정직하게."""
+    from app.services.agent_onboarding_config import list_runtime_capabilities
+
+    caps = {c["slug"]: c for c in list_runtime_capabilities()}
+    for slug in ("opencode", "openclaw", "hermes", "grok", "pi"):
+        assert caps[slug]["supported"] is False
+        assert caps[slug]["tier"] is None
+        assert caps[slug]["prompt_file"] is None
+        assert caps[slug]["mcp_transport"] == []


### PR DESCRIPTION
## Summary
Split out of #1910 per PO request — this piece has no identity-param/security surface (pure
read-only, org-agnostic capability listing) and can go through independent FE+BE integration QA
without waiting on #1910's security review cycle (까심/산티아고 SME).

`GET /api/v2/runtime-capabilities` exposes which runtimes the recruiter/connection-artifact
pipeline can actually onboard — `supported`/`tier` derived from S5's actual emit code, not
aspirational (no over-promising).

## Contract
Returns all 10 slugs (9 `RuntimeType` values + `connector` bucket):
- `claude-code`: `supported=true, tier="full"` — confirmed instruction-filename mapping (CLAUDE.md)
- `codex`/`gemini`/`cursor`: `supported=true, tier="experimental"` — `build_agent_mcp_config` emits
  the same config regardless of runtime, but S7 instruction-file shaping hasn't happened for these
  yet (generic fallback filename)
- `connector`: `supported=true, tier="experimental"` — `.mcp.json` doesn't apply, but the guidance
  file (`CONNECTOR_SETUP.md`) emits successfully; real per-adapter assembly is follow-up work
- `opencode`/`openclaw`/`hermes`/`grok`/`pi`: `supported=false, tier=null` — passing these as
  `runtime=` to recruit/connection-artifact currently 400s ("unsupported runtime"). Included so
  the FE's "coming soon" section has something to render (PO confirmed 2026-07-06), not silently
  omitted.

Each entry also carries `mcp_transport`, `prompt_file`, `guide_filename`, `supports_event_push`.

Light + authenticated only (`get_current_user`) — no org scoping needed since this describes
backend capability, not org data.

## Test plan
- [x] Contract shape test (all 10 slugs present, `supported` split matches `SUPPORTED_RUNTIMES`)
- [x] tier/transport/prompt_file assertions against the `list_runtime_capabilities()` SSOT
- [x] Unsupported-5 explicit `supported=false`/`tier=null` assertions
- [x] `test_s6_runtime_capabilities.py`: 4 passed