### PR TITLE
fix(a2a): S2 다중 WebhookConfig 멤버 500(MultipleResultsFound) 봉인

### DIFF
--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -204,11 +204,15 @@ async def _handle_send_message(session: AsyncSession, member: TeamMember, params
     # 동형으로 택일 — member-bound WebhookConfig 有→Discord webhook, 無→fakechat WS(_broadcast).
     # `_get_agent_member`가 이미 type="agent"+is_active를 강제해 여기 도달하는 멤버는 항상 둘 중
     # 하나로 도달 가능하므로 REJECTED 분기는 없다(도달불가 케이스가 실제로 없음).
-    webhook = (await session.execute(
-        select(WebhookConfig).where(
+    # 라이브 E2E(까심발견 아닌 오르테가군 직접 스모크)MUST: member-global+project별로 활성
+    # WebhookConfig가 여러 개일 수 있어(예: 디디 본인) — 여긴 "존재 여부"만 필요하므로
+    # scalar_one_or_none()(MultipleResultsFound 500) 대신 first() 사용. 실 전달은 다중 타깃
+    # resolve를 이미 하는 deliver_conversation_message_webhook에 위임(아래, 변경 없음).
+    has_webhook = (await session.execute(
+        select(WebhookConfig.id).where(
             WebhookConfig.member_id == member_id, WebhookConfig.is_active.is_(True)
-        )
-    )).scalar_one_or_none()
+        ).limit(1)
+    )).first() is not None
 
     # S2: task-태깅 Conversation(=A2A context_id) — CC 어댑터가 이 두 경로 중 하나로 실 주입한다.
     conv_id = uuid.uuid4()
@@ -236,7 +240,7 @@ async def _handle_send_message(session: AsyncSession, member: TeamMember, params
     await session.flush()
     await session.commit()
 
-    if webhook is not None:
+    if has_webhook:
         await deliver_conversation_message_webhook(
             message_id=root_message_id,
             conversation_id=conv_id,

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -56,6 +56,19 @@ def _result(value):
     r = MagicMock()
     r.scalar_one_or_none.return_value = value
     r.scalar_one.return_value = value
+    r.first.return_value = value
+    return r
+
+
+def _multi_row_result():
+    """라이브 E2E MUST(2026-07-06): 활성 WebhookConfig가 여러 개인 멤버 — .scalar_one_or_none()/
+    .scalar_one()을 호출하면 MultipleResultsFound가 나야 정상(회귀 감지용), .first()만 안전."""
+    from sqlalchemy.exc import MultipleResultsFound
+
+    r = MagicMock()
+    r.scalar_one_or_none.side_effect = MultipleResultsFound("multiple rows")
+    r.scalar_one.side_effect = MultipleResultsFound("multiple rows")
+    r.first.return_value = (uuid.uuid4(),)
     return r
 
 
@@ -183,6 +196,44 @@ async def test_send_message_working_when_webhook_configured():
             if call_count == 2:
                 return _result(webhook)
             return _result(working_task)  # 최종 requery
+
+        session.execute = mock_execute
+        session.flush = AsyncMock()
+        session.commit = AsyncMock()
+
+        with patch("app.routers.a2a.deliver_conversation_message_webhook", new_callable=AsyncMock) as mock_deliver:
+            async with client as c:
+                resp = await c.post(f"/api/v2/a2a/members/{MEMBER_ID}/rpc", json=_SEND_REQ)
+            mock_deliver.assert_called_once()
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["result"]["status"]["state"] == "TASK_STATE_WORKING"
+        assert body["error"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_send_message_working_when_member_has_multiple_active_webhooks():
+    """라이브 E2E MUST(2026-07-06, 오르테가군 스모크 발견): member-global+project별로 활성
+    WebhookConfig가 여러 개(디디 본인 케이스)여도 500(MultipleResultsFound) 없이 WORKING —
+    존재-여부 판정은 .first()만 쓰고 scalar_one_or_none()은 호출하지 않아야 한다."""
+    client, session, app = await _client()
+    try:
+        member = _mock_member()
+        working_task = _mock_task("TASK_STATE_WORKING")
+
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _result(member)
+            if call_count == 2:
+                return _multi_row_result()  # 활성 webhook 2개 이상 시뮬레이션
+            return _result(working_task)
 
         session.execute = mock_execute
         session.flush = AsyncMock()


### PR DESCRIPTION
## Summary
- Fresh branch off `origin/develop` (which already has squash-merged #1913) + cherry-pick of `354c804c` only — avoids re-diffing all of S2 (per PO's guidance: don't push more commits to an already squash-merged branch's PR).
- Live E2E smoke (오르테가군, post-#1913-merge) found: a member with both a member-global (`project_id IS NULL`) and a project-scoped active `WebhookConfig` row (e.g. 디디 자신) hit `MultipleResultsFound` → 500 on `SendMessage`, because the existence-check query used `.scalar_one_or_none()`.
- Fix: the branch decision only needs "does at least one active webhook exist" — switched to `.first()`. Actual delivery is unchanged, still delegated to `deliver_conversation_message_webhook` (which already resolves multiple targets correctly).

## Test plan
- [x] Real-Postgres reproduction of the exact live scenario (2 active WebhookConfig rows, one global + one project-scoped) — confirmed no 500, `TASK_STATE_WORKING` returned.
- [x] New regression test simulating multiple active webhooks (mock raises `MultipleResultsFound` if `.scalar_one_or_none()`/`.scalar_one()` is called, only `.first()` is safe) — catches any future regression to the old query shape.
- [x] Full backend suite green: 3113 passed, only the 7 known pre-existing baseline failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)