### PR TITLE
feat(a2a): E-A2A-POC S3 — 발견→위임 E2E (Agent Card discovery)

### DIFF
--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -30,6 +30,13 @@ GetTask가 그 thread를 폴링해 첫 답신을 발견하면 `TASK_STATE_COMPLE
 `ConversationWebhookDelivery` retry+상태추적과 다름) CC가 그 순간 미접속이면 실시간 유실된다
 (단 `ConversationMessage` 자체는 DB에 영속). A2A는 인터페이스를 캡슐화하나 하위 채널의
 신뢰성 차이까지 없애진 못한다 — Phase 3 이후 재검토 대상.
+
+**S3(story 5578a8e2) — 발견→위임**: `GET /api/v2/a2a/members`(신규, 문서
+`e-a2a-poc-s3-design-crux`)가 org 내 활성 agent 전원의 Agent Card를 반환 + `?skill=` 필터.
+⚠️ **S1/S2의 개별 member_id 엔드포인트와 달리 이건 org 전체 로스터 열거라 인증 필수**
+(PO 판정 — 오늘 S20 IDOR 스윕과 동형 노출 클래스, `get_verified_org_id`+`get_current_user`로
+기존 `list_team_members`와 동일하게 authed). 발견된 member_id로 기존 S2 `SendMessage`/`GetTask`
+경로를 그대로 재사용(신규 위임 코드 없음).
 """
 from __future__ import annotations
 
@@ -37,16 +44,18 @@ import json
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.a2a_task import A2ATask
 from app.models.agent_deployment import AgentPersona
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.team import TeamMember
 from app.models.webhook_config import WebhookConfig
+from app.repositories.team_member import TeamMemberRepository
 from app.routers.ws_chat import _broadcast
 from app.schemas.a2a import (
     AgentCapabilities,
@@ -150,6 +159,41 @@ async def _build_agent_card(session: AsyncSession, member: TeamMember, base_url:
         default_output_modes=["text/plain"],
         skills=skills,
     )
+
+
+def _skill_matches(card: AgentCard, query: str) -> bool:
+    q = query.lower()
+    for skill in card.skills:
+        if q == skill.id.lower():
+            return True
+        if any(q in tag.lower() for tag in skill.tags):
+            return True
+        if q in skill.name.lower() or q in skill.description.lower():
+            return True
+    return False
+
+
+@router.get("/members", response_model=list[AgentCard])
+async def list_agent_cards(
+    request: Request,
+    skill: str | None = Query(default=None),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> list[AgentCard]:
+    """S3(story 5578a8e2) — 발견: caller org 내 활성 agent 전원의 Agent Card 열거 + `?skill=`
+    필터(id/tags/name/description OR 매칭, 대소문자 무시). 개별 member_id 엔드포인트와 달리
+    org 전체 로스터 열거라 인증 필수(PO 판정, 오늘 S20 IDOR 스윕과 동형 노출 클래스)."""
+    repo = TeamMemberRepository(session, org_id)
+    agents = await repo.list(type="agent", is_active=True)
+
+    base_url = str(request.base_url).rstrip("/")
+    cards = [await _build_agent_card(session, agent, base_url) for agent in agents]
+
+    if skill:
+        cards = [c for c in cards if _skill_matches(c, skill)]
+
+    return cards
 
 
 @router.get("/members/{member_id}/agent-card.json")

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -13,7 +13,7 @@ MEMBER_ID = uuid.uuid4()
 def _mock_member(agent_role: str | None = "qa") -> MagicMock:
     m = MagicMock()
     m.id = MEMBER_ID
-    m.name = "Kkasim"
+    m.name = "Qasim"
     m.type = "agent"
     m.is_active = True
     m.agent_role = agent_role
@@ -139,7 +139,7 @@ async def test_agent_card_200_reflects_role_template_skills():
 
         assert resp.status_code == 200
         card = resp.json()
-        assert card["name"] == "Kkasim"
+        assert card["name"] == "Qasim"
         assert card["skills"][0]["tags"] == ["stories", "tasks", "chat"]
         assert card["skills"][0]["id"] == "qa"
         assert card["supportedInterfaces"][0]["protocolBinding"] == "JSONRPC"
@@ -209,7 +209,7 @@ async def test_list_agent_cards_filters_by_skill_zero_hardcoding():
             nonlocal call_count
             call_count += 1
             if call_count == 1:
-                return _list_result([_mock_agent(qa_id, "Kkasim"), _mock_agent(backend_id, "Didi", "backend")])
+                return _list_result([_mock_agent(qa_id, "Qasim"), _mock_agent(backend_id, "Didi", "backend")])
             if call_count == 2:
                 return _result(qa_persona)
             return _result(None)  # backend agent has no matching persona in this fixture
@@ -221,7 +221,7 @@ async def test_list_agent_cards_filters_by_skill_zero_hardcoding():
 
         assert resp.status_code == 200
         cards = resp.json()
-        assert [c["name"] for c in cards] == ["Kkasim"]
+        assert [c["name"] for c in cards] == ["Qasim"]
         assert cards[0]["supportedInterfaces"][0]["tenant"] == str(qa_id)
     finally:
         app.dependency_overrides.clear()

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -60,6 +60,49 @@ def _result(value):
     return r
 
 
+def _list_result(items):
+    r = MagicMock()
+    r.scalars.return_value.all.return_value = items
+    return r
+
+
+def _mock_agent(member_id, name, agent_role="qa"):
+    m = MagicMock()
+    m.id = member_id
+    m.name = name
+    m.type = "agent"
+    m.is_active = True
+    m.agent_role = agent_role
+    return m
+
+
+async def _authed_client(org_id: uuid.UUID):
+    from app.main import app
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    from app.dependencies.database import get_db
+
+    async def override_auth():
+        ctx = MagicMock()
+        ctx.user_id = str(uuid.uuid4())
+        ctx.claims = {"app_metadata": {"org_id": str(org_id)}}
+        return ctx
+
+    async def override_org():
+        return org_id
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    app.dependency_overrides[get_verified_org_id] = override_org
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
 def _multi_row_result():
     """라이브 E2E MUST(2026-07-06): 활성 WebhookConfig가 여러 개인 멤버 — .scalar_one_or_none()/
     .scalar_one()을 호출하면 MultipleResultsFound가 나야 정상(회귀 감지용), .first()만 안전."""
@@ -143,6 +186,89 @@ async def test_agent_card_404_unknown_member():
             resp = await c.get(f"/api/v2/a2a/members/{uuid.uuid4()}/agent-card.json")
 
         assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── S3: 발견 — GET /members (authed, skill 필터) ──────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_list_agent_cards_filters_by_skill_zero_hardcoding():
+    """S3(story 5578a8e2): skill 쿼리 하나로 role-id 매칭 에이전트만 발견 — member_id 하드코딩 없음."""
+    org_id = uuid.uuid4()
+    qa_id, backend_id = uuid.uuid4(), uuid.uuid4()
+    client, session, app = await _authed_client(org_id)
+    try:
+        qa_persona = _mock_persona()
+        qa_persona.agent_id = qa_id
+
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _list_result([_mock_agent(qa_id, "Kkasim"), _mock_agent(backend_id, "Didi", "backend")])
+            if call_count == 2:
+                return _result(qa_persona)
+            return _result(None)  # backend agent has no matching persona in this fixture
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.get("/api/v2/a2a/members", params={"skill": "qa"})
+
+        assert resp.status_code == 200
+        cards = resp.json()
+        assert [c["name"] for c in cards] == ["Kkasim"]
+        assert cards[0]["supportedInterfaces"][0]["tenant"] == str(qa_id)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_agent_cards_no_filter_returns_all_org_agents():
+    org_id = uuid.uuid4()
+    a_id, b_id = uuid.uuid4(), uuid.uuid4()
+    client, session, app = await _authed_client(org_id)
+    try:
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _list_result([_mock_agent(a_id, "A"), _mock_agent(b_id, "B")])
+            return _result(None)
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.get("/api/v2/a2a/members")
+
+        assert resp.status_code == 200
+        assert {c["name"] for c in resp.json()} == {"A", "B"}
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_agent_cards_requires_auth():
+    """S3: 개별 member_id 엔드포인트(S1/S2)와 달리 로스터 열거는 인증 필수(PO 판정)."""
+    from app.main import app
+    from app.dependencies.database import get_db
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get("/api/v2/a2a/members")
+        assert resp.status_code in (401, 403)
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary
- Story `5578a8e2` (E-A2A-POC S3): agent-to-agent discovery via Agent Card `skills`/`tags`, zero hardcoded member_id — then delegation via the existing S2 path.
- New `GET /api/v2/a2a/members?skill=<query>` — lists Agent Cards for all active agents in the caller's org, reusing S1's `_build_agent_card`. Optional `skill` filter matches (OR, case-insensitive) against skill `id` (role_template slug), `tags` (tool-group capabilities), or `name`/`description`.
- **Auth decision (PO crux, important)**: unlike S1/S2's single opaque-`member_id` endpoints, this is N-member roster enumeration — the same exposure class as today's S20 IDOR sweep, just wider surface. PO ruled this endpoint must be authenticated (`get_current_user` + `get_verified_org_id`, same pattern as `list_team_members`) even though it's still PoC scope.
- Delegation is 100% S2 reuse — discovered `member_id` → existing `SendMessage`/`GetTask` (no new delegation code).

## Test plan
- [x] `tests/test_a2a.py` (+3 new tests): skill filter matches only the matching role and excludes others, no-filter lists all org agents, unauthenticated call is rejected.
- [x] Real-Postgres seeded E2E: `?skill=qa` matches only the QA-role agent (excludes a different-role agent in the same org AND an agent in a different org) → discovered `member_id` (no hardcoding) → `SendMessage` → `TASK_STATE_WORKING`. Unauthenticated call → 401 confirmed.
- [x] Full backend suite green: 3116 passed, only the 7 known pre-existing baseline failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)