### PR TITLE
refactor(a2a): §10 — webhook 판정을 active_webhook_member_ids SSOT로 교체

### DIFF
--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -56,9 +56,9 @@ from app.models.agent_deployment import AgentPersona
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.conversation_webhook_delivery import ConversationWebhookDelivery
 from app.models.team import TeamMember
-from app.models.webhook_config import WebhookConfig
 from app.repositories.team_member import TeamMemberRepository
 from app.routers.ws_chat import _broadcast, _rooms
+from app.services.webhook_targeting import active_webhook_member_ids
 from app.schemas.a2a import (
     AgentCapabilities,
     AgentCard,
@@ -270,19 +270,16 @@ async def _handle_send_message(session: AsyncSession, member: TeamMember, params
     member_project_id = member.project_id
     member_name = member.name
 
-    # S2(정정 2026-07-06): 플랫폼 기존 라우팅(webhook_targeting.py:active_webhook_member_ids)과
-    # 동형으로 택일 — member-bound WebhookConfig 有→Discord webhook, 無→fakechat WS(_broadcast).
-    # `_get_agent_member`가 이미 type="agent"+is_active를 강제해 여기 도달하는 멤버는 항상 둘 중
-    # 하나로 도달 가능하므로 REJECTED 분기는 없다(도달불가 케이스가 실제로 없음).
-    # 라이브 E2E(까심발견 아닌 오르테가군 직접 스모크)MUST: member-global+project별로 활성
-    # WebhookConfig가 여러 개일 수 있어(예: 디디 본인) — 여긴 "존재 여부"만 필요하므로
-    # scalar_one_or_none()(MultipleResultsFound 500) 대신 first() 사용. 실 전달은 다중 타깃
-    # resolve를 이미 하는 deliver_conversation_message_webhook에 위임(아래, 변경 없음).
-    has_webhook = (await session.execute(
-        select(WebhookConfig.id).where(
-            WebhookConfig.member_id == member_id, WebhookConfig.is_active.is_(True)
-        ).limit(1)
-    )).first() is not None
+    # S2(정정 2026-07-06)+P1-S3 §10(SSOT 교체): 플랫폼 기존 라우팅과 동형으로 택일 —
+    # member-bound WebhookConfig 有→Discord webhook, 無→fakechat WS(_broadcast). "존재 여부"
+    # 판정은 이제 인라인 쿼리가 아니라 플랫폼 SSOT(webhook_targeting.active_webhook_member_ids —
+    # notification_dispatch/conversations.py가 이미 공유하는 그 함수)를 그대로 호출한다 — 병렬
+    # 구현 박멸(멤버 다중 WebhookConfig 케이스도 이 함수가 이미 처리: member_id.in_() + 존재만
+    # 보므로 MultipleResultsFound 위험이 애초에 없다). `_get_agent_member`가 이미 type="agent"+
+    # is_active를 강제해 여기 도달하는 멤버는 항상 둘 중 하나로 도달 가능하므로 REJECTED 분기는
+    # 없다. 실 전달은 다중 타깃 resolve를 이미 하는 deliver_conversation_message_webhook에 위임
+    # (아래, 변경 없음).
+    has_webhook = member_id in await active_webhook_member_ids(session, member_org_id, [member_id])
 
     # S2: task-태깅 Conversation(=A2A context_id) — CC 어댑터가 이 두 경로 중 하나로 실 주입한다.
     conv_id = uuid.uuid4()

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -312,7 +312,6 @@ async def test_send_message_working_when_webhook_configured():
     client, session, app = await _authed_client(uuid.uuid4())
     try:
         member = _mock_member()
-        webhook = MagicMock()  # 활성 WebhookConfig 존재
         working_task = _mock_task("TASK_STATE_WORKING")
 
         call_count = 0
@@ -323,7 +322,7 @@ async def test_send_message_working_when_webhook_configured():
             if call_count == 1:
                 return _result(member)
             if call_count == 2:
-                return _result(webhook)
+                return _list_result([MEMBER_ID])  # active_webhook_member_ids: 활성 webhook 존재
             return _result(working_task)  # 최종 requery
 
         session.execute = mock_execute
@@ -345,9 +344,10 @@ async def test_send_message_working_when_webhook_configured():
 
 @pytest.mark.anyio
 async def test_send_message_working_when_member_has_multiple_active_webhooks():
-    """라이브 E2E MUST(2026-07-06, 오르테가군 스모크 발견): member-global+project별로 활성
-    WebhookConfig가 여러 개(디디 본인 케이스)여도 500(MultipleResultsFound) 없이 WORKING —
-    존재-여부 판정은 .first()만 쓰고 scalar_one_or_none()은 호출하지 않아야 한다."""
+    """라이브 E2E MUST(2026-07-06, 오르테가군 스모크 발견)+P1-S3 §10(SSOT 교체 후 회귀 확認):
+    member-global+project별로 활성 WebhookConfig가 여러 개(디디 본인 케이스)여도 500 없이
+    WORKING — active_webhook_member_ids는 .scalars().all()+set()이라 다중 행이 와도 예외가
+    없다(SSOT 자체가 이 케이스를 이미 안전하게 처리)."""
     client, session, app = await _authed_client(uuid.uuid4())
     try:
         member = _mock_member()
@@ -361,7 +361,7 @@ async def test_send_message_working_when_member_has_multiple_active_webhooks():
             if call_count == 1:
                 return _result(member)
             if call_count == 2:
-                return _multi_row_result()  # 활성 webhook 2개 이상 시뮬레이션
+                return _list_result([MEMBER_ID, MEMBER_ID])  # 활성 webhook 2개 이상(같은 멤버) 시뮬레이션
             return _result(working_task)
 
         session.execute = mock_execute
@@ -398,7 +398,7 @@ async def test_send_message_working_via_fakechat_ws_when_no_webhook():
             if call_count == 1:
                 return _result(member)
             if call_count == 2:
-                return _result(None)  # webhook 없음
+                return _list_result([])  # webhook 없음
             return _result(working_task)
 
         session.execute = mock_execute


### PR DESCRIPTION
## Summary
- E-A2A-P1 S3(story `1d9caeee`) 크럭스 §10 발견의 즉시 실행분(PO 승인, Approach A 무관·바로 가능).
- `a2a.py`의 webhook 존재판정이 `webhook_targeting.active_webhook_member_ids`(notification_dispatch/conversations.py가 이미 공유하는 플랫폼 canonical SSOT) 대신 자체 인라인 쿼리를 유지해 5번째 병렬구현으로 드리프트 중이었음 — 이를 SSOT 호출로 교체.
- 부수효과: SSOT 함수가 `.scalars().all()`+`set()` 기반이라 다중-webhook 멤버 케이스(디디 본인)를 이미 안전하게 처리 — 기존 `MultipleResultsFound` 회피용 `.first()` 임시조치가 자연히 사라짐.

## Test plan
- [x] 실 Postgres 3시나리오: 무-webhook 멤버 → `fakechat_ws`, 단일-webhook 멤버 → `webhook`, 동일 멤버 2개 활성 webhook(서로 다른 project로 시딩, unique 제약 준수) → 크래시 없이 `webhook` — 전부 pass
- [x] `tests/test_a2a.py` 19/19 (3개 테스트를 새 SSOT 호출 shape에 맞게 갱신)
- [x] 전체 백엔드 스위트: 3120 passed, 기존 baseline 7건 외 무회귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)