### PR TITLE
fix(ci): Cloud Build 워크플로우 직렬 큐잉 — 배포 리비전 역전 방지

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -12,7 +12,11 @@ on:
 
 concurrency:
   group: cloud-build-${{ github.ref }}
-  cancel-in-progress: true
+  # 근본원인(2026-07-06, story 6ac3e62f): true였을 때 GHA 워크플로우 실행만 취소되고 이미
+  # 원격 GCP에 제출된 Cloud Build는 계속 진행돼, 연속 push 시 먼저 취소된 실행의 원격 빌드가
+  # 나중 커밋의 배포를 늦게 덮어써 리비전 역전이 발생했다(GCP 이력상 동시빌드 실재 확認,
+  # 07:21↔07:23 겹침). false로 직렬 큐잉해 커밋 순서=배포 순서를 보장한다.
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- story `6ac3e62f`. 근본원인(PO 실측): `concurrency.cancel-in-progress: true`가 GHA 워크플로우 실행만 취소하고 이미 원격 GCP에 제출된 Cloud Build는 계속 진행됨 — 연속 push 시 먼저 취소된 실행의 원격 빌드가 나중 커밋의 배포를 늦게 덮어써 리비전 역전 발생(GCP 빌드 이력상 동시 실행 실재 확認, 07:21/07:23 겹침).
- `cancel-in-progress`를 `false`로 변경 — 같은 concurrency group의 실행을 취소 대신 직렬 큐잉해 커밋 순서=배포 순서를 보장.
- `.github/workflows/cloud-build.yml` 1줄 변경.

## Test plan
- [x] YAML 구문 검증
- [ ] 연속 push 시 GHA 워크플로우가 직렬 큐잉되는지(동시 실행 0) 확認
- [ ] 최종 배포 리비전이 최신 커밋과 일치하는지 확認
- [ ] 기존 단일-push 배포 무회귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)