### PR TITLE
fix(ci): Cloud Build 워크플로우 직렬 큐잉 — 배포 리비전 역전 방지 (main)

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -12,7 +12,11 @@ on:
 
 concurrency:
   group: cloud-build-${{ github.ref }}
-  cancel-in-progress: true
+  # 근본원인(2026-07-06, story 6ac3e62f): true였을 때 GHA 워크플로우 실행만 취소되고 이미
+  # 원격 GCP에 제출된 Cloud Build는 계속 진행돼, 연속 push 시 먼저 취소된 실행의 원격 빌드가
+  # 나중 커밋의 배포를 늦게 덮어써 리비전 역전이 발생했다(GCP 이력상 동시빌드 실재 확認,
+  # 07:21↔07:23 겹침). false로 직렬 큐잉해 커밋 순서=배포 순서를 보장한다.
+  cancel-in-progress: false
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- story `6ac3e62f`. develop PR #1924과 동일 변경(cloud-build.yml `cancel-in-progress: true`→`false`)의 main 포팅 — 워크플로우 파일은 ref별로 평가되므로 dev/prod 양쪽 모두 필요.
- 근본원인: `cancel-in-progress: true`가 GHA 워크플로우 실행만 취소하고 이미 원격 GCP에 제출된 Cloud Build는 계속 진행됨 — 연속 push 시 리비전 역전 발생(PO 실측, GCP 이력상 동시빌드 실재 확認).

## Test plan
- [x] YAML 구문 검증
- [ ] main-preflight CI green
- [ ] 연속 push 시 직렬 큐잉 확認(추후 실배포 관찰)

🤖 Generated with [Claude Code](https://claude.com/claude-code)