### PR TITLE
feat(a2a): E-A2A-PROTO P0 — v1.0.1 스펙 정합 누락 필드 추가

### DIFF
--- a/backend/app/schemas/a2a.py
+++ b/backend/app/schemas/a2a.py
@@ -4,7 +4,13 @@
 **현재 spec의 PascalCase JSON-RPC 메소드명**(`SendMessage`/`GetTask`) + camelCase 필드 +
 `TASK_STATE_`/`ROLE_` 접두 enum을 기준으로 구현한다. PoC는 필수 필드 + AgentInterface만
 채우고, provider/securitySchemes/signatures 등 선택 필드는 생략(Phase 3, 인증/signed Card
-붙을 때 추가)."""
+붙을 때 추가).
+
+E-A2A-PROTO(2026-07-06, PO 크럭스 P0): v1.0.1 태그(gh api, main과 byte-identical) 재실측으로
+발견한 누락 필드 추가 — `AgentCapabilities.extensions`(AgentExtension 목록, uri/description/
+required/params)·`Message.extensions`/`reference_task_ids`·`Part.raw`(base64 bytes)/`metadata`·
+`Artifact.metadata`/`extensions`. 전부 옵셔널/기본 빈값이라 회귀 없음 — `AgentCapabilities.
+extensions`는 향후 E-A2A-EXT(Sprintable 차별화를 A2A extension으로 정의) 축의 진입점."""
 from __future__ import annotations
 
 import uuid
@@ -24,9 +30,19 @@ class AgentInterface(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
+class AgentExtension(BaseModel):
+    uri: str
+    description: str | None = None
+    required: bool = False
+    params: dict | None = None
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 class AgentCapabilities(BaseModel):
     streaming: bool = False
     push_notifications: bool = Field(default=False, alias="pushNotifications")
+    extensions: list[AgentExtension] = Field(default_factory=list)
     extended_agent_card: bool = Field(default=False, alias="extendedAgentCard")
 
     model_config = ConfigDict(populate_by_name=True)
@@ -60,8 +76,10 @@ class AgentCard(BaseModel):
 
 class Part(BaseModel):
     text: str | None = None
+    raw: str | None = None
     url: str | None = None
     data: Any | None = None
+    metadata: dict | None = None
     filename: str | None = None
     media_type: str | None = Field(default=None, alias="mediaType")
 
@@ -75,6 +93,8 @@ class Message(BaseModel):
     role: Literal["ROLE_USER", "ROLE_AGENT", "ROLE_UNSPECIFIED"]
     parts: list[Part]
     metadata: dict | None = None
+    extensions: list[str] = Field(default_factory=list)
+    reference_task_ids: list[str] = Field(default_factory=list, alias="referenceTaskIds")
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -105,6 +125,8 @@ class Artifact(BaseModel):
     name: str | None = None
     description: str | None = None
     parts: list[Part]
+    metadata: dict | None = None
+    extensions: list[str] = Field(default_factory=list)
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -728,3 +728,70 @@ async def test_get_task_transitions_to_failed_on_timeout():
         assert "timed out" in body["result"]["status"]["message"]["parts"][0]["text"]
     finally:
         app.dependency_overrides.clear()
+
+
+# ── E-A2A-PROTO P0(2026-07-06): 스펙 정합 필드 회귀 lock ──────────────────────
+
+
+def test_agent_capabilities_has_extensions_field_defaults_empty():
+    from app.schemas.a2a import AgentCapabilities
+
+    caps = AgentCapabilities(streaming=False, push_notifications=False, extended_agent_card=False)
+    assert caps.extensions == []
+    dumped = caps.model_dump(by_alias=True, mode="json")
+    assert dumped["extensions"] == []
+    assert dumped["pushNotifications"] is False
+    assert dumped["extendedAgentCard"] is False
+
+
+def test_agent_extension_roundtrip_camelcase():
+    from app.schemas.a2a import AgentExtension
+
+    ext = AgentExtension(uri="https://example.com/ext/v1", description="test ext", required=True, params={"k": "v"})
+    dumped = ext.model_dump(by_alias=True, mode="json")
+    assert dumped == {"uri": "https://example.com/ext/v1", "description": "test ext", "required": True, "params": {"k": "v"}}
+
+
+def test_message_has_extensions_and_reference_task_ids_fields():
+    from app.schemas.a2a import Message, Part
+
+    msg = Message(
+        message_id="m1", role="ROLE_USER", parts=[Part(text="hi")],
+        extensions=["https://example.com/ext/v1"], reference_task_ids=["t1", "t2"],
+    )
+    dumped = msg.model_dump(by_alias=True, mode="json")
+    assert dumped["extensions"] == ["https://example.com/ext/v1"]
+    assert dumped["referenceTaskIds"] == ["t1", "t2"]
+    # 기본값(누락 시) — 회귀 없이 빈 리스트
+    msg2 = Message(message_id="m2", role="ROLE_USER", parts=[Part(text="hi")])
+    assert msg2.extensions == []
+    assert msg2.reference_task_ids == []
+
+
+def test_part_has_raw_and_metadata_fields():
+    from app.schemas.a2a import Part
+
+    part = Part(raw="base64data==", metadata={"k": "v"})
+    dumped = part.model_dump(by_alias=True, mode="json")
+    assert dumped["raw"] == "base64data=="
+    assert dumped["metadata"] == {"k": "v"}
+    # text 전용 Part는 raw/metadata가 None이어도 무방(oneof 성격)
+    text_part = Part(text="hi")
+    assert text_part.raw is None
+    assert text_part.metadata is None
+
+
+def test_artifact_has_metadata_and_extensions_fields():
+    from app.schemas.a2a import Artifact, Part
+
+    artifact = Artifact(
+        artifact_id="a1", parts=[Part(text="result")],
+        metadata={"k": "v"}, extensions=["https://example.com/ext/v1"],
+    )
+    dumped = artifact.model_dump(by_alias=True, mode="json")
+    assert dumped["metadata"] == {"k": "v"}
+    assert dumped["extensions"] == ["https://example.com/ext/v1"]
+    # 기본값 회귀 없음
+    artifact2 = Artifact(artifact_id="a2", parts=[Part(text="result")])
+    assert artifact2.metadata is None
+    assert artifact2.extensions == []


### PR DESCRIPTION
## Summary
- E-A2A-PROTO 정합 감사(문서 `e-a2a-proto-spec-conformance-crux`, `a2aproject/A2A` v1.0.1 태그 gh api 재실측) 발견 갭의 P0(스키마 필드, 회귀 없음) 해소.
- `AgentCapabilities.extensions`(신규 `AgentExtension` 모델: uri/description/required/params) — E-A2A-EXT 축의 스키마 진입점.
- `Message.extensions`/`reference_task_ids`(camelCase `referenceTaskIds`).
- `Part.raw`(base64 bytes)/`metadata`.
- `Artifact.metadata`/`extensions`.
- 전부 옵셔널/기본 빈값 — 기존 직렬화 shape 변경 없음.

## Test plan
- [x] 신규 5개 필드 회귀테스트(camelCase 직렬화 + 기본값 확認)
- [x] 기존 `test_a2a.py` 19개 무회귀(24/24 passing)
- [x] 전체 백엔드 스위트: 3125 passed, 기존 baseline 7건 외 무회귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)