### PR TITLE
feat(a2a): E-A2A-PROTO P1 — A2A-Version 헤더 체크 + ListTasks 메소드

### DIFF
--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -52,7 +52,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
@@ -78,6 +78,7 @@ from app.schemas.a2a import (
     JsonRpcError,
     JsonRpcRequest,
     JsonRpcResponse,
+    ListTasksParams,
     Message,
     Part,
     SendMessageParams,
@@ -91,6 +92,15 @@ router = APIRouter(prefix="/api/v2/a2a", tags=["a2a"])
 _METHOD_NOT_FOUND = -32601
 _INVALID_PARAMS = -32602
 _TASK_NOT_FOUND = -32001  # A2A-specific error range(-32001~-32099)
+_VERSION_NOT_SUPPORTED = -32009  # 스펙 §14.2.1: A2A-Version 헤더가 지원 범위 밖일 때
+
+# E-A2A-PROTO P1(2026-07-06): 스펙 §14.2.1 — 클라이언트는 A2A-Version 헤더를 MUST 전송.
+# 우리는 1.0만 지원(Card의 protocol_version과 동일 소스). ⚠️tradeoff(정직 문서화): 헤더
+# 부재 시 하드 거부하면 헤더를 아직 안 보내는 기존 PoC/내부 dogfood 트래픽이 전부 깨진다 —
+# PoC→Phase1 단계에선 **부재는 관대하게 허용**(스펙의 MUST는 클라 책무일 뿐 서버 강제는
+# 아님)하고, **명시적으로 잘못된 Major**(우리가 지원 안 하는 값)만 거부한다. 트래픽이
+# 실제로 헤더를 보내기 시작하면 이 관용을 좁히는 재검토가 필요하다.
+A2A_PROTOCOL_VERSION = "1.0"
 
 _TERMINAL_STATES = {
     "TASK_STATE_COMPLETED",
@@ -175,7 +185,7 @@ async def _build_agent_card(session: AsyncSession, member: TeamMember, base_url:
             AgentInterface(
                 url=interface_url,
                 protocol_binding="JSONRPC",
-                protocol_version="1.0",
+                protocol_version=A2A_PROTOCOL_VERSION,
                 tenant=str(member.id),
             )
         ],
@@ -458,14 +468,65 @@ async def _handle_get_task(session: AsyncSession, member: TeamMember, params: di
     return _task_to_dict(task)
 
 
+_DEFAULT_PAGE_SIZE = 50
+_MAX_PAGE_SIZE = 100
+
+
+async def _handle_list_tasks(session: AsyncSession, member: TeamMember, params: dict) -> dict:
+    """E-A2A-PROTO P1(story 미배정): ListTasksRequest 필수 필터만 구현(PoC) — tenant·
+    status_timestamp_after·history_length·include_artifacts는 REQUIRED 아니라 생략.
+    스코프는 GetTask와 동형으로 caller가 위임한 member 자신의 task만(`A2ATask.member_id`)."""
+    try:
+        list_params = ListTasksParams.model_validate(params)
+    except Exception as exc:  # noqa: BLE001
+        raise _JsonRpcException(_INVALID_PARAMS, f"Invalid params: {exc}") from exc
+
+    page_size = list_params.page_size or _DEFAULT_PAGE_SIZE
+    page_size = max(1, min(page_size, _MAX_PAGE_SIZE))
+    offset = 0
+    if list_params.page_token:
+        try:
+            offset = max(0, int(list_params.page_token))
+        except ValueError as exc:
+            raise _JsonRpcException(_INVALID_PARAMS, "Invalid pageToken") from exc
+
+    conditions = [A2ATask.member_id == member.id]
+    if list_params.context_id is not None:
+        conditions.append(A2ATask.context_id == uuid.UUID(list_params.context_id))
+    if list_params.status is not None:
+        conditions.append(A2ATask.state == list_params.status)
+
+    total_size = (await session.execute(
+        select(func.count()).select_from(A2ATask).where(*conditions)
+    )).scalar_one()
+
+    result = await session.execute(
+        select(A2ATask).where(*conditions).order_by(A2ATask.created_at.desc(), A2ATask.id.desc())
+        .offset(offset).limit(page_size)
+    )
+    tasks = result.scalars().all()
+
+    next_offset = offset + len(tasks)
+    next_page_token = str(next_offset) if next_offset < total_size else ""
+
+    return {
+        "tasks": [_task_to_dict(t) for t in tasks],
+        "nextPageToken": next_page_token,
+        "pageSize": page_size,
+        "totalSize": total_size,
+    }
+
+
 _METHODS = {
     "SendMessage": _handle_send_message,
     "GetTask": _handle_get_task,
+    "ListTasks": _handle_list_tasks,
 }
 
 
 @router.post("/members/{member_id}/rpc")
 async def a2a_rpc(
+    request: Request,
     member_id: uuid.UUID,
     body: JsonRpcRequest,
     org_id: uuid.UUID = Depends(get_verified_org_id),
@@ -474,6 +535,18 @@ async def a2a_rpc(
 ) -> JsonRpcResponse:
     """P1-S2: action-triggering 엔드포인트라 authed+org-scoped(PO 크럭스 — S1 PoC 리스크 노트
     봉인). Card fetch(GET .../agent-card.json)는 P1-S1 판단대로 unauth 유지, 여기만 인증."""
+    version_header = request.headers.get("A2A-Version")
+    if version_header:
+        major = version_header.split(".", 1)[0]
+        if major != A2A_PROTOCOL_VERSION.split(".", 1)[0]:
+            return JsonRpcResponse(
+                id=body.id,
+                error=JsonRpcError(
+                    code=_VERSION_NOT_SUPPORTED,
+                    message=f"Unsupported A2A-Version: {version_header} (server supports {A2A_PROTOCOL_VERSION})",
+                ),
+            )
+
     member = await _get_agent_member(session, member_id, org_id)
 
     handler = _METHODS.get(body.method)

--- a/backend/app/schemas/a2a.py
+++ b/backend/app/schemas/a2a.py
@@ -169,6 +169,17 @@ class GetTaskParams(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
+class ListTasksParams(BaseModel):
+    """E-A2A-PROTO P1: ListTasksRequest 필수 필터만 구현(PoC) — tenant/status_timestamp_after/
+    history_length/include_artifacts는 스펙엔 있으나 REQUIRED 아니라 생략(Phase 3 후속)."""
+    context_id: str | None = Field(default=None, alias="contextId")
+    status: TaskState | None = None
+    page_size: int | None = Field(default=None, alias="pageSize")
+    page_token: str | None = Field(default=None, alias="pageToken")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 class JsonRpcRequest(BaseModel):
     jsonrpc: Literal["2.0"] = "2.0"
     id: str | int

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -795,3 +795,128 @@ def test_artifact_has_metadata_and_extensions_fields():
     artifact2 = Artifact(artifact_id="a2", parts=[Part(text="result")])
     assert artifact2.metadata is None
     assert artifact2.extensions == []
+
+
+# ── E-A2A-PROTO P1(2026-07-06): A2A-Version 헤더 + ListTasks ──────────────────
+
+
+@pytest.mark.anyio
+async def test_rpc_accepts_matching_a2a_version_header():
+    client, session, app = await _authed_client(uuid.uuid4())
+    try:
+        member = _mock_member()
+        session.execute = AsyncMock(return_value=_result(member))
+
+        async with client as c:
+            resp = await c.post(
+                f"/api/v2/a2a/members/{MEMBER_ID}/rpc",
+                json={"jsonrpc": "2.0", "id": 1, "method": "UnknownMethod", "params": {}},
+                headers={"A2A-Version": "1.0"},
+            )
+        body = resp.json()
+        # 버전 통과 후 정상적으로 method-not-found까지 도달(버전 게이트에서 안 막힘)
+        assert body["error"]["code"] == -32601
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_rpc_rejects_unsupported_a2a_version_major():
+    client, session, app = await _authed_client(uuid.uuid4())
+    try:
+        async with client as c:
+            resp = await c.post(
+                f"/api/v2/a2a/members/{MEMBER_ID}/rpc",
+                json={"jsonrpc": "2.0", "id": 1, "method": "SendMessage", "params": {}},
+                headers={"A2A-Version": "2.0"},
+            )
+        body = resp.json()
+        assert body["error"]["code"] == -32009
+        assert "Unsupported A2A-Version" in body["error"]["message"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_rpc_allows_missing_a2a_version_header_lenient():
+    """PoC→Phase1 tradeoff(문서화됨): 헤더 부재는 관대하게 허용 — 기존 dogfood 트래픽 무회귀."""
+    client, session, app = await _authed_client(uuid.uuid4())
+    try:
+        member = _mock_member()
+        session.execute = AsyncMock(return_value=_result(member))
+
+        async with client as c:
+            resp = await c.post(
+                f"/api/v2/a2a/members/{MEMBER_ID}/rpc",
+                json={"jsonrpc": "2.0", "id": 1, "method": "UnknownMethod", "params": {}},
+            )
+        body = resp.json()
+        assert body["error"]["code"] == -32601  # 버전 게이트 안 걸림, method-not-found까지 도달
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_tasks_returns_paginated_tasks_scoped_to_member():
+    client, session, app = await _authed_client(uuid.uuid4())
+    try:
+        member = _mock_member()
+        t1 = _mock_task("TASK_STATE_COMPLETED")
+        t2 = _mock_task("TASK_STATE_WORKING")
+
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _result(member)
+            if call_count == 2:
+                return _result(2)  # total_size count
+            return _list_result([t1, t2])
+
+        session.execute = mock_execute
+
+        req = {"jsonrpc": "2.0", "id": 1, "method": "ListTasks", "params": {}}
+        async with client as c:
+            resp = await c.post(f"/api/v2/a2a/members/{MEMBER_ID}/rpc", json=req)
+
+        body = resp.json()
+        assert body["error"] is None
+        assert len(body["result"]["tasks"]) == 2
+        assert body["result"]["totalSize"] == 2
+        assert body["result"]["pageSize"] == 50
+        assert body["result"]["nextPageToken"] == ""
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_tasks_next_page_token_when_more_results():
+    client, session, app = await _authed_client(uuid.uuid4())
+    try:
+        member = _mock_member()
+        t1 = _mock_task("TASK_STATE_COMPLETED")
+
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _result(member)
+            if call_count == 2:
+                return _result(5)  # total_size larger than returned page
+            return _list_result([t1])
+
+        session.execute = mock_execute
+
+        req = {"jsonrpc": "2.0", "id": 1, "method": "ListTasks", "params": {"pageSize": 1}}
+        async with client as c:
+            resp = await c.post(f"/api/v2/a2a/members/{MEMBER_ID}/rpc", json=req)
+
+        body = resp.json()
+        assert body["result"]["nextPageToken"] == "1"
+        assert body["result"]["pageSize"] == 1
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- E-A2A-PROTO 정합 감사(문서 `e-a2a-proto-spec-conformance-crux`) P1 해소.
- `A2A-Version` 헤더 체크(스펙 §14.2.1 MUST 요건): Major.Minor 헤더의 Major가 서버 지원 버전(`A2A_PROTOCOL_VERSION="1.0"`)과 다르면 `VersionNotSupportedError`(-32009). 헤더 부재는 관대하게 허용(정직한 tradeoff 문서화 — 기존 dogfood 트래픽 무회귀 우선, PoC→Phase1 단계).
- `ListTasks` 메소드(읽기전용): `contextId`/`status` 필터 + `page_size`/`page_token` 페이징. GetTask와 동형으로 caller가 위임한 member 자신의 task만 스코프.

## Test plan
- [x] 실PG 5시나리오: ListTasks 페이지1/페이지2/contextId+status 필터·A2A-Version 미지원 거부·헤더 부재 관대허용 — 전부 pass
- [x] 신규 6개 단위테스트(`test_a2a.py` 29/29)
- [x] 전체 백엔드 스위트: 3130 passed, 기존 baseline 7건 외 무회귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)