### PR TITLE
feat(a2a): E-A2A-EXTERNAL ① — securitySchemes 스키마 + 정직 광고

### DIFF
--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -83,12 +83,15 @@ from app.schemas.a2a import (
     AgentSkill,
     Artifact,
     GetTaskParams,
+    HTTPAuthSecurityScheme,
     JsonRpcError,
     JsonRpcRequest,
     JsonRpcResponse,
     ListTasksParams,
     Message,
     Part,
+    SecurityRequirement,
+    SecurityScheme,
     SendMessageParams,
     Task,
     TaskStatus,
@@ -114,6 +117,12 @@ A2A_PROTOCOL_VERSION = "1.0"
 # 코어 RPC 계약은 안 바꾸고 Message.metadata에 이 URI를 키로 한 구조화 payload를 얹는다.
 # opt-in만(A2A-Extensions 헤더에 이 URI를 선언한 요청에 한해 해석) — 미선언 시 완전 무회귀.
 PROJECT_CONTEXT_EXTENSION_URI = "https://sprintable.ai/a2a-ext/project-context/v1"
+
+# E-A2A-EXTERNAL(축4, 2026-07-06, 문서 `e-a2a-external-interop-crux`): Card.securitySchemes의
+# 키 이름 — 실제 /rpc 인증 요건(Bearer)을 스펙 표준으로 정직 광고. 외부 파트너용 자격증명
+# 발급 경로는 아직 없음(별도 crux 필요, 실 파트너 요청 대기) — 이 광고는 "우리가 뭘 요구하는지"
+# 정직하게 알리는 것뿐, 발급 메커니즘 자체를 새로 만드는 게 아니다.
+_SECURITY_SCHEME_KEY = "sprintableBearerAuth"
 
 
 def _parse_active_extensions(request: Request) -> frozenset[str]:
@@ -224,6 +233,16 @@ async def _build_agent_card(session: AsyncSession, member: TeamMember, base_url:
         default_input_modes=["text/plain"],
         default_output_modes=["text/plain"],
         skills=skills,
+        security_schemes={
+            _SECURITY_SCHEME_KEY: SecurityScheme(
+                http_auth_security_scheme=HTTPAuthSecurityScheme(
+                    scheme="Bearer",
+                    bearer_format="sk_live_ API key or JWT",
+                    description="/rpc 호출은 그 에이전트의 org에 소속된 Sprintable 발급 자격증명이 필요(외부 파트너 발급 경로는 미구현 — E-A2A-EXTERNAL 후속)",
+                ),
+            ),
+        },
+        security_requirements=[SecurityRequirement(schemes={_SECURITY_SCHEME_KEY: []})],
     )
 
 

--- a/backend/app/schemas/a2a.py
+++ b/backend/app/schemas/a2a.py
@@ -10,7 +10,12 @@ E-A2A-PROTO(2026-07-06, PO 크럭스 P0): v1.0.1 태그(gh api, main과 byte-ide
 발견한 누락 필드 추가 — `AgentCapabilities.extensions`(AgentExtension 목록, uri/description/
 required/params)·`Message.extensions`/`reference_task_ids`·`Part.raw`(base64 bytes)/`metadata`·
 `Artifact.metadata`/`extensions`. 전부 옵셔널/기본 빈값이라 회귀 없음 — `AgentCapabilities.
-extensions`는 향후 E-A2A-EXT(Sprintable 차별화를 A2A extension으로 정의) 축의 진입점."""
+extensions`는 향후 E-A2A-EXT(Sprintable 차별화를 A2A extension으로 정의) 축의 진입점.
+
+E-A2A-EXTERNAL(축4, 2026-07-06, 문서 `e-a2a-external-interop-crux`): `AgentCard.security_schemes`
+/`security_requirements` 추가 — 실제 `/rpc` 인증 요건(Bearer sk_live_ API key/JWT)을 스펙
+표준(§4.4)으로 정직 광고. `HTTPAuthSecurityScheme`만 구현(스펙 5종 중 우리가 실제 쓰는 하나만,
+OAuth2/mTLS 등은 미사용이라 미구현 — 과설계 회피)."""
 from __future__ import annotations
 
 import uuid
@@ -58,6 +63,32 @@ class AgentSkill(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
+class HTTPAuthSecurityScheme(BaseModel):
+    """스펙 §4.4 SecurityScheme의 5종(APIKey/HTTPAuth/OAuth2/OpenIdConnect/mTLS) 중 우리가
+    실제 쓰는 HTTPAuth(Bearer)만 구현 — 나머지는 미사용이라 모델링 생략(과설계 회피)."""
+    description: str | None = None
+    scheme: str
+    bearer_format: str | None = Field(default=None, alias="bearerFormat")
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SecurityScheme(BaseModel):
+    http_auth_security_scheme: HTTPAuthSecurityScheme | None = Field(
+        default=None, alias="httpAuthSecurityScheme"
+    )
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class SecurityRequirement(BaseModel):
+    """스펙 §4.4: scheme명 → 필요 scope 목록. 우리는 OAuth2 scope 개념이 없어 빈 리스트로
+    "이 scheme이 필요하다"만 표현(Bearer 토큰 자체가 요건, scope 세분화 없음)."""
+    schemes: dict[str, list[str]] = Field(default_factory=dict)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
 class AgentCard(BaseModel):
     name: str
     description: str
@@ -67,6 +98,12 @@ class AgentCard(BaseModel):
     default_input_modes: list[str] = Field(alias="defaultInputModes")
     default_output_modes: list[str] = Field(alias="defaultOutputModes")
     skills: list[AgentSkill]
+    security_schemes: dict[str, SecurityScheme] = Field(
+        default_factory=dict, alias="securitySchemes"
+    )
+    security_requirements: list[SecurityRequirement] = Field(
+        default_factory=list, alias="securityRequirements"
+    )
 
     model_config = ConfigDict(populate_by_name=True)
 

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -1074,3 +1074,41 @@ async def test_agent_card_advertises_project_context_extension():
         assert extensions[0]["required"] is False
     finally:
         app.dependency_overrides.clear()
+
+
+# ── E-A2A-EXTERNAL(축4, 2026-07-06): securitySchemes 정직 광고 ────────────────
+
+
+@pytest.mark.anyio
+async def test_agent_card_advertises_bearer_security_scheme():
+    client, session, app = await _client()
+    try:
+        member = _mock_member()
+        persona = _mock_persona()
+
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _result(member)
+            return _result(persona)
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/a2a/members/{MEMBER_ID}/agent-card.json")
+
+        body = resp.json()
+        schemes = body["securitySchemes"]
+        assert len(schemes) == 1
+        key = next(iter(schemes))
+        http_auth = schemes[key]["httpAuthSecurityScheme"]
+        assert http_auth["scheme"] == "Bearer"
+
+        requirements = body["securityRequirements"]
+        assert len(requirements) == 1
+        assert key in requirements[0]["schemes"]
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- 축4(외부 interop) 접근 크럭스(문서 `e-a2a-external-interop-crux`) 승인분.
- `AgentCard` 스키마에 `securitySchemes`/`securityRequirements` 필드가 아예 없었음(S1이 Phase 3로 미룬 부분) — 실제로는 `/rpc`가 이미 Bearer 인증을 요구하는데 Card가 그 요건을 스펙 표준(§4.4)으로 광고할 방법이 없었음.
- `HTTPAuthSecurityScheme`/`SecurityScheme`/`SecurityRequirement` 스키마 추가(스펙 5종 SecurityScheme 중 우리가 실제 쓰는 HTTPAuth만 구현 — 나머지는 미사용이라 미구현, 과설계 회피).
- `_build_agent_card`가 실제 요건(Bearer sk_live_ API key/JWT, org 소속 자격증명 필요)을 정직하게 광고 + "외부 파트너 발급 경로는 미구현"이라는 현실도 description에 명시(과대광고 방지).
- well-known 엔드포인트/registry는 스코프 아웃(스펙 §8.2 Direct Configuration이 우리 멀티테넌트 현실에 이미 부합 — 우리가 이미 unauth로 서빙 중인 멤버별 Card URL이 그 모델).

## Test plan
- [x] 신규 단위테스트 1개(`test_a2a.py` 33/33)
- [x] 전체 백엔드 스위트: 3134 passed, 기존 baseline 7건 외 무회귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)