### PR TITLE
fix(a2a): GetTask multi-webhook FAILED 오판 fix (story 652c2842)

### DIFF
--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -52,6 +52,12 @@ retry+상태추적)와는 신뢰성 메커니즘이 다르나, 이제 최소한 
 `task_metadata["project_context"]`(GetTask로 조회 가능) + fakechat 전달 payload에 보존한다.
 ⚠️webhook 경로는 스코프 밖(공유 함수 `deliver_conversation_message_webhook`이 plain text만
 받아 계약 확장은 과설계 — 코드 주석 참조). 헤더 미선언 시 이 로직 전체가 스킵돼 무회귀.
+
+**완료신호 multi-webhook 오판 fix(2026-07-07, story 652c2842, 까심 크로스모델 QA root 확定)**:
+`_handle_get_task`의 delivery 실패 판정이 `ConversationWebhookDelivery`를 "최신 1건만" 보고 있어
+multi-webhook 멤버(채널 2개 이상)가 그중 하나만 실패해도 거짓 FAILED를 냈다(task bd4a6c0b 재현).
+그 메시지의 전 delivery를 모아 **전량 실패일 때만** FAILED로 승격하도록 교정 — 하나라도
+delivered면 이 판정에서는 실패 아님(응답 대기 지속, 타임아웃 백스톱은 그대로 유효).
 """
 from __future__ import annotations
 
@@ -515,18 +521,24 @@ async def _handle_get_task(
             # 실 배달상태(ConversationWebhookDelivery, root_message_id로 조인 — 신규 컬럼 불요)로
             # 확실히 아는 실패를 우선 반영. (2) 그것도 아니면 생성 후 타임아웃 경과를 두 경로
             # 공통 백스톱으로 사용(fakechat WS는 ack가 없어 이게 유일한 실패 신호).
+            #
+            # 까심 크로스모델 QA(story 652c2842) — "최신 1건"이 아니라 **그 메시지의 전 delivery**를
+            # 봐야 한다: multi-webhook 멤버(웹훅 2개 이상)는 메시지당 delivery 행이 webhook_config
+            # 개수만큼 생기고, 그중 하나만 우연히 실패해도 "최신"이 그 실패행이면 다른 채널로는
+            # 실제 도달했음에도 거짓 FAILED가 났다(task bd4a6c0b 재현 케이스). 전량 실패일 때만
+            # FAILED로 승격 — 하나라도 delivered면 이 판정에서는 실패 아님(응답 대기 지속).
             failure_reason: str | None = None
 
-            delivery = (await session.execute(
+            deliveries = (await session.execute(
                 select(ConversationWebhookDelivery)
                 .where(ConversationWebhookDelivery.message_id == task.root_message_id)
                 .order_by(ConversationWebhookDelivery.created_at.desc())
-                .limit(1)
-            )).scalar_one_or_none()
-            if delivery is not None and delivery.status == "failed":
+            )).scalars().all()
+            if deliveries and all(d.status == "failed" for d in deliveries):
+                latest = deliveries[0]
                 failure_reason = (
-                    f"webhook delivery failed after {delivery.attempt_count} attempts: "
-                    f"{delivery.last_error or 'unknown error'}"
+                    f"webhook delivery failed on all {len(deliveries)} channel(s) after "
+                    f"{latest.attempt_count} attempts: {latest.last_error or 'unknown error'}"
                 )
             elif datetime.now(timezone.utc) - task.created_at > timedelta(minutes=A2A_TASK_TIMEOUT_MINUTES):
                 failure_reason = (

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -498,7 +498,9 @@ async def test_get_task_still_working_when_no_reply_yet():
                 return _result(member)
             if call_count == 2:
                 return _result(working_task)
-            return _result(None)  # thread 폴링 — 아직 답신 없음
+            if call_count == 3:
+                return _result(None)  # thread 폴링 — 아직 답신 없음
+            return _list_result([])  # delivery row 없음
 
         session.execute = mock_execute
 
@@ -645,7 +647,7 @@ async def test_rpc_cross_org_blocked():
 
 @pytest.mark.anyio
 async def test_get_task_transitions_to_failed_on_delivery_failure():
-    """P1-S2(B): 답신 없고 ConversationWebhookDelivery.status=="failed"면 타임아웃 전이라도
+    """P1-S2(B): 답신 없고 전 ConversationWebhookDelivery.status=="failed"면 타임아웃 전이라도
     즉시 FAILED(실제 아는 정보 우선)."""
     client, session, app = await _authed_client(uuid.uuid4())
     try:
@@ -669,7 +671,7 @@ async def test_get_task_transitions_to_failed_on_delivery_failure():
                 return _result(working_task)
             if call_count == 3:
                 return _result(None)  # thread 폴링 — 답신 없음
-            return _result(delivery)  # webhook delivery 조회 — failed
+            return _list_result([delivery])  # webhook delivery 조회 — 1건, 전량 failed
 
         session.execute = mock_execute
         session.flush = AsyncMock()
@@ -684,6 +686,57 @@ async def test_get_task_transitions_to_failed_on_delivery_failure():
         body = resp.json()
         assert body["result"]["status"]["state"] == "TASK_STATE_FAILED"
         assert "webhook delivery failed" in body["result"]["status"]["message"]["parts"][0]["text"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_task_not_failed_when_one_of_multiple_webhook_deliveries_succeeds():
+    """까심 크로스모델 QA(story 652c2842, task bd4a6c0b 재현): multi-webhook 멤버가 채널 2개 중
+    하나만 실패해도 "최신 1건"이 그 실패행이면 거짓 FAILED가 났던 버그. 전량 실패일 때만 FAILED로
+    승격해야 하며, 하나라도 delivered면 이 판정에서는 FAILED로 전이하지 않는다(WORKING 유지)."""
+    client, session, app = await _authed_client(uuid.uuid4())
+    try:
+        member = _mock_member()
+        root_message_id = uuid.uuid4()
+        working_task = _mock_task("TASK_STATE_WORKING", root_message_id=root_message_id)
+
+        delivered = MagicMock()
+        delivered.status = "delivered"
+        delivered.attempt_count = 1
+        delivered.last_error = None
+
+        failed = MagicMock()
+        failed.status = "failed"
+        failed.attempt_count = 3
+        failed.last_error = "connection refused"
+
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _result(member)
+            if call_count == 2:
+                return _result(working_task)
+            if call_count == 3:
+                return _result(None)  # thread 폴링 — 답신 없음
+            # webhook delivery 조회 — 최신순 2건(가장 최신이 failed여도 다른 채널은 delivered)
+            return _list_result([failed, delivered])
+
+        session.execute = mock_execute
+        session.flush = AsyncMock()
+        session.commit = AsyncMock()
+        session.refresh = AsyncMock()
+
+        req = {"jsonrpc": "2.0", "id": 9, "method": "GetTask", "params": {"id": str(working_task.id)}}
+
+        async with client as c:
+            resp = await c.post(f"/api/v2/a2a/members/{MEMBER_ID}/rpc", json=req)
+
+        body = resp.json()
+        assert body["result"]["status"]["state"] == "TASK_STATE_WORKING"
     finally:
         app.dependency_overrides.clear()
 
@@ -711,7 +764,9 @@ async def test_get_task_transitions_to_failed_on_timeout():
                 return _result(member)
             if call_count == 2:
                 return _result(working_task)
-            return _result(None)  # 답신 없음 + delivery row 없음(fakechat 경로)
+            if call_count == 3:
+                return _result(None)  # thread 폴링 — 답신 없음
+            return _list_result([])  # delivery row 없음(fakechat 경로)
 
         session.execute = mock_execute
         session.flush = AsyncMock()


### PR DESCRIPTION
## Summary
- `_handle_get_task`의 delivery 실패 판정이 `ConversationWebhookDelivery`를 최신 1건만 보고 있어, webhook 채널이 2개 이상인 멤버(예: 까심)가 그중 하나만 실패해도 거짓 FAILED가 났다(task `bd4a6c0b` 재현, 까심 크로스모델 QA가 root 확정).
- 그 메시지의 전 delivery를 모아 **전량 실패일 때만** FAILED로 승격하도록 교정 — 하나라도 delivered면 이 판정에서는 실패 아님(응답 대기 지속, 타임아웃 백스톱은 그대로 유효).
- 회귀: 기존 전량-실패 FAILED 케이스는 그대로 유지, 신규 부분-실패(2건 중 1건만 failed) 케이스는 WORKING 유지로 검증.

## Test plan
- [x] `tests/test_a2a.py` 34/34 passed (신규 `test_get_task_not_failed_when_one_of_multiple_webhook_deliveries_succeeds` 포함)
- [x] 전체 백엔드 스위트: 3135 passed, 기존 baseline 무관 실패 7건 그대로(MCP tooling), 0 신규 실패

🤖 Generated with [Claude Code](https://claude.com/claude-code)