### PR TITLE
feat(recruit): role_templates 카탈로그 스키마 확장 — division·emoji·skills (S1)

### DIFF
--- a/backend/alembic/versions/0161_role_templates_catalog_schema_ext.py
+++ b/backend/alembic/versions/0161_role_templates_catalog_schema_ext.py
@@ -1,0 +1,39 @@
+"""~300직군 카탈로그 트랙 S1(문서 role-template-crud-api-crux): division·emoji·skills 컬럼 추가.
+
+Revision ID: 0161
+Revises: 0160
+Create Date: 2026-07-07
+
+agency-agents 참고 상위 산업/부문 분류(division)·시각코딩(emoji)·A2A 발견 키(skills, app.schemas.
+a2a.AgentSkill 형태 그대로 재사용)를 role_templates에 추가한다. 전부 nullable 또는 server_default
+있는 additive 컬럼이라 기존 24개 seed(0156/0157/0160) 무회귀 — skills는 기본값 `[]`로 채워져
+_build_agent_card가 아직 이를 소비하지 않는 한(S4 예정) 회귀 없음.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0161"
+down_revision = "0160"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("role_templates", sa.Column("division", sa.Text(), nullable=True))
+    op.add_column("role_templates", sa.Column("emoji", sa.Text(), nullable=True))
+    op.add_column(
+        "role_templates",
+        sa.Column(
+            "skills", postgresql.JSONB(), nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("role_templates", "skills")
+    op.drop_column("role_templates", "emoji")
+    op.drop_column("role_templates", "division")

--- a/backend/app/models/role_template.py
+++ b/backend/app/models/role_template.py
@@ -49,3 +49,13 @@ class RoleTemplate(Base, TimestampMixin):
     # (미래 recruit 서비스) 게이팅용 메타데이터일 뿐 이 S1 에선 아무 것도 강제하지 않는다.
     tier: Mapped[str] = mapped_column(Text, nullable=False, default="free")
     version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    # ~300직군 카탈로그 트랙 S1(문서 role-template-crud-api-crux §4): agency-agents 참고 상위
+    # 산업/부문 분류(15~25개 목표) — category(기존, 좁은 기능軸: engineering/design/growth 등)와
+    # 별개 축. curation 단계(S5)에서 값 확定, 지금은 nullable로 무회귀 확보.
+    division: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # 순수 표시용 시각코딩(agency-agents 차용) — 로직 무관.
+    emoji: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # A2A 발견 키 — app.schemas.a2a.AgentSkill(id·name·description·tags·examples) 그대로 재사용
+    # (신규 스키마 발명 안 함, A2A가 이미 소비하는 정확히 그 shape). S4에서 _build_agent_card가
+    # 이 필드를 직접 소비하게 되면 persona 수작업 없이 스케일에서 발견-by-capability가 열린다.
+    skills: Mapped[list[dict]] = mapped_column(JSONB, nullable=False, default=list)

--- a/backend/app/routers/role_templates.py
+++ b/backend/app/routers/role_templates.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.role_template import RoleTemplate
+from app.schemas.a2a import AgentSkill
 
 router = APIRouter(prefix="/api/v2/role-templates", tags=["role-templates"])
 
@@ -33,6 +34,11 @@ class RoleTemplateSummary(BaseModel):
     is_builtin: bool
     tier: str
     version: int
+    # ~300직군 카탈로그 트랙 S1(문서 role-template-crud-api-crux §4) — division/emoji nullable,
+    # skills는 app.schemas.a2a.AgentSkill 그대로 재사용(신규 스키마 발명 안 함).
+    division: str | None = None
+    emoji: str | None = None
+    skills: list[AgentSkill] = []
 
     model_config = {"from_attributes": True}
 

--- a/backend/tests/test_e_recruit_s1_role_templates.py
+++ b/backend/tests/test_e_recruit_s1_role_templates.py
@@ -69,6 +69,8 @@ def test_model_field_shape():
         "id", "slug", "name", "category", "description", "role_behaviors",
         "default_tool_groups", "default_workflow_recipe_slug", "runtime_overrides",
         "is_builtin", "is_published", "tier", "version", "created_at", "updated_at",
+        # 카탈로그 트랙 S1(0161, 문서 role-template-crud-api-crux §4).
+        "division", "emoji", "skills",
     }
 
 

--- a/backend/tests/test_role_template_catalog_s1_schema.py
+++ b/backend/tests/test_role_template_catalog_s1_schema.py
@@ -1,0 +1,85 @@
+"""~300직군 카탈로그 트랙 S1(문서 role-template-crud-api-crux): division·emoji·skills 스키마 확장.
+
+실 Postgres 검증(마이그 적용 + 기존 24 seed 무회귀)은 별도 스크립트로 수행 — 여기는 마이그
+파일 자체의 정적 검증(체인·컬럼 정의)과 스키마/모델 shape 검증.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_MIGRATION = Path(__file__).parent.parent / "alembic" / "versions" / "0161_role_templates_catalog_schema_ext.py"
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("rev_0161", _MIGRATION)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_migration_0161_chains_off_0160():
+    mod = _load_migration()
+    assert mod.revision == "0161"
+    assert mod.down_revision == "0160"
+    assert callable(mod.upgrade) and callable(mod.downgrade)
+
+
+def test_model_has_new_nullable_or_defaulted_fields():
+    from app.models.role_template import RoleTemplate
+
+    cols = RoleTemplate.__table__.columns
+    assert cols["division"].nullable is True
+    assert cols["emoji"].nullable is True
+    assert cols["skills"].nullable is False
+    assert cols["skills"].default is not None  # ORM-side default(list) — 어느 한쪽이라도 있으면 됨
+
+
+def test_role_template_summary_schema_exposes_new_fields_with_safe_defaults():
+    """기존 24개 seed(division/emoji/skills 값 미설정 시나리오)에서도 응답 직렬화가 깨지지 않는지 —
+    division/emoji=None·skills=[] 기본값으로 유효한지."""
+    from app.routers.role_templates import RoleTemplateSummary
+
+    payload = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "slug": "backend",
+        "name": "Backend Engineer",
+        "category": "engineering",
+        "description": None,
+        "default_tool_groups": ["stories", "tasks"],
+        "default_workflow_recipe_slug": None,
+        "is_builtin": True,
+        "tier": "free",
+        "version": 1,
+    }
+    summary = RoleTemplateSummary.model_validate(payload)
+    assert summary.division is None
+    assert summary.emoji is None
+    assert summary.skills == []
+
+
+def test_skills_field_reuses_a2a_agent_skill_schema():
+    """신규 스키마 발명 안 함 — role_templates.skills가 app.schemas.a2a.AgentSkill 그대로인지."""
+    from app.routers.role_templates import RoleTemplateSummary
+    from app.schemas.a2a import AgentSkill
+
+    payload = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "slug": "qa",
+        "name": "QA Engineer",
+        "category": "qa",
+        "description": None,
+        "default_tool_groups": ["stories"],
+        "default_workflow_recipe_slug": None,
+        "is_builtin": True,
+        "tier": "free",
+        "version": 1,
+        "division": "Quality",
+        "emoji": "\U0001f41b",
+        "skills": [{"id": "qa", "name": "QA", "description": "quality assurance", "tags": ["qa", "testing"]}],
+    }
+    summary = RoleTemplateSummary.model_validate(payload)
+    assert len(summary.skills) == 1
+    assert isinstance(summary.skills[0], AgentSkill)
+    assert summary.skills[0].id == "qa"
+    assert summary.skills[0].tags == ["qa", "testing"]


### PR DESCRIPTION
## Summary
- ~300직군 카탈로그 트랙 S1(문서 `role-template-crud-api-crux`) — `role_templates`에 `division`(상위 산업/부문 분류, agency-agents 참고)·`emoji`(시각코딩)·`skills`(A2A 발견 키) 3종 컬럼 추가.
- `skills`는 신규 스키마를 발명하지 않고 `app.schemas.a2a.AgentSkill`(id/name/description/tags/examples)을 그대로 재사용 — S4(추후)에서 `_build_agent_card`가 이 필드를 직접 소비하면, 오늘 8명에게 했던 수작업 persona 생성 없이 카탈로그 스케일에서 발견-by-capability가 자동으로 열린다.
- 전부 additive(nullable 또는 server_default) — 기존 24개 seed(0156/0157/0160) 무회귀.

## Test plan
- [x] 실 Postgres: 마이그 upgrade/downgrade/재upgrade 라운드트립 확인, 기존 24개 seed 전부 `division=NULL`·`emoji=NULL`·`skills='[]'`로 안전 백필
- [x] 신규 테스트(`test_role_template_catalog_s1_schema.py`) 4종 + 기존 S1 필드-shape lock 테스트 갱신
- [x] 전체 백엔드 스위트(clean env): 3146 passed, baseline 무관 실패 7건(MCP tooling) 그대로, 신규 실패 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)