### PR TITLE
fix(alembic): merge ee_pricing(0147)+core(0161) heads into single head

### DIFF
--- a/backend/alembic/versions/0162_merge_ee_pricing_core_heads.py
+++ b/backend/alembic/versions/0162_merge_ee_pricing_core_heads.py
@@ -1,0 +1,31 @@
+"""story 21ade1fa: alembic 2-head 병합 — ee_pricing(0147)·core(0161)를 단일 head로 수렴.
+
+Revision ID: 0162
+Revises: 0147, 0161
+Create Date: 2026-07-07
+
+develop에 0144에서 분기된 두 브랜치(ee_pricing: 0145-0147, core: 0148-0161)가
+`alembic upgrade head`(단수)를 실패시킴 — admin repo의 drift-check가 이를 노출.
+스키마 변경 없는 순수 병합 노드(양쪽 다 head였던 리비전을 하나로 합침).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0162'
+down_revision: Union[str, Sequence[str], None] = ('0147', '0161')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass


### PR DESCRIPTION
## Summary
- story 21ade1fa: develop currently has two alembic heads split at `0144` — `ee_pricing` branch (0145-0147) and `core` branch (0148-0161). `alembic upgrade head` (singular) fails; the admin repo's drift-check surfaced this.
- **Prod-promotion critical path**: 선생님 approved catalog prod promotion, but 0160/0161+S4 aren't on main yet and develop's 2-head state must resolve first, or the prod migrate DAG diverges (same failure class as the 2026-07-04 rollback).
- Adds a pure merge-migration node `0162` (`down_revision = ('0147', '0161')`), no schema changes — just joins the two heads into one.

## Verification (real Postgres, throwaway docker pgvector/pg16 containers)
- Fresh-DB `alembic upgrade head` (singular) now succeeds end-to-end (0132 → both branches → `0162`).
- `alembic heads` → single head confirmed (`0162`).
- Existing-DB simulation: a DB already at the old dual-heads (`0147`, `0161` — i.e. today's dev/prod state) advances cleanly to `0162` via `alembic upgrade heads`. This is the realistic deploy-time scenario.
- Downgrade roundtrip via explicit target (`0162` → `0147,0161` → `0162`) succeeds. (Relative `alembic downgrade -1` from a mergepoint raises `Ambiguous walk` — this is expected/documented alembic behavior for mergepoints, not a bug.)
- No changes needed to `migrate.sh` or CI — both already use `alembic upgrade heads` (plural), which continues to work identically now that there's exactly one head.
- Existing tests (`test_migrate_env.py`, `test_role_template_catalog_s1_schema.py`, `test_e_recruit_s1_role_templates.py`) pass unchanged.

## Test plan
- [x] Fresh-DB upgrade to head (singular) — real Postgres
- [x] Existing dual-head DB → single head via `upgrade heads` — real Postgres
- [x] Downgrade roundtrip (explicit target) — real Postgres
- [x] Relevant existing pytest suite — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)