### PR TITLE
[SID:0870dfef] 채용관(Recruiter) 진입점 추가 — /agents 상단 CTA

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2374,6 +2374,7 @@
     "workflowVersionRemovedRules": "-{count}",
     "workflowVersionChangedRules": "~{count}",
     "title": "Agents",
+    "recruiterCta": "Recruiter",
     "tabDeployments": "Deployments",
     "tabPerformance": "Performance",
     "autoBadge": "Auto",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2374,6 +2374,7 @@
     "workflowVersionRemovedRules": "삭제 {count}",
     "workflowVersionChangedRules": "변경 {count}",
     "title": "에이전트",
+    "recruiterCta": "채용관",
     "tabDeployments": "배포",
     "tabPerformance": "퍼포먼스",
     "autoBadge": "Auto",

--- a/apps/web/src/components/agents/agents-page-tabs.tsx
+++ b/apps/web/src/components/agents/agents-page-tabs.tsx
@@ -1,8 +1,11 @@
 'use client';
 
+import Link from 'next/link';
 import { useTranslations } from 'next-intl';
+import { UserPlus } from 'lucide-react';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { AgentPerformancePanel } from '@/components/agents/agent-performance-panel';
+import { Button } from '@/components/ui/button';
 
 // E-SETTINGS S4: Deployments 탭(죽은 managed-deploy surface) 영구 숨김 — Performance 단독.
 // 2탭→1탭이라 토글 UI 제거(단일 토글 어색), deploy wizard CTA 미렌더. 라우트 무변경.
@@ -11,7 +14,17 @@ export function AgentsPageTabs() {
   const t = useTranslations('agents');
   return (
     <>
-      <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
+      <TopBarSlot
+        title={<h1 className="text-sm font-medium">{t('title')}</h1>}
+        actions={
+          <Button asChild size="sm" variant="outline">
+            <Link href="/agents/recruiter">
+              <UserPlus className="mr-1.5 h-3.5 w-3.5" />
+              {t('recruiterCta')}
+            </Link>
+          </Button>
+        }
+      />
       <AgentPerformancePanel />
     </>
   );


### PR DESCRIPTION
## Summary
- `/agents/recruiter` 라우트는 실재했으나 사이드바/Agents 페이지 어디에도 링크가 없어 직접 URL 입력 외엔 도달 불가(선생님 직접 지적, 2026-07-07)
- `AgentsPageTabs`(`/agents` 최상단)의 `TopBarSlot` `actions`에 채용관 CTA 버튼 추가 — 클릭 시 `/agents/recruiter`로 이동
- 기존 `mockups/page.tsx`와 동일한 `Button asChild` + `Link` 패턴 재사용(신규 스타일 없음)
- `recruiter-client.tsx` STEP1 플로우 확인 — role-template 기반으로 기존 에이전트 유무와 무관하게 시작 가능, 별도 empty-state 가드 불필요
- i18n(ko/en) `agents.recruiterCta` 키 추가

## Test plan
- [x] tsc --noEmit: 0 errors
- [x] eslint: 0 errors(무관 pre-existing warning만)
- [x] vitest: 1114 passed / 2 skipped (회귀 0)
- [x] next build: 성공
- [ ] dev 배포 후 라이브 클릭 경로 확인 — 로컬 FE는 JWT_SECRET↔dev BE 불일치로 인증된 대시보드 렌더 불가(기존 세션 제약), 배포 후 확인 필요

story: `0870dfef`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>