### PR TITLE
fix(infra): migrate.sh EE-stamp precheck — literal match to ancestry walk (CRITICAL, dev pipeline down)

### DIFF
--- a/backend/scripts/migrate.sh
+++ b/backend/scripts/migrate.sh
@@ -23,10 +23,20 @@ cd /app
 # 물리 신호(#1886 dev_ee_stamp_precheck.sh 에서 확립된 기준 — pricing_versions 테이블 존재만
 # 보는 것보다 정밀). 매 실행 시 자동 검사해 필요하면 self-heal stamp 하므로 더 이상 수동
 # override 스크립트를 기억해뒀다 돌릴 필요가 없다(이 파일이 canonical 진입점이라 드리프트 재발 불가).
+#
+# story 21ade1fa 후속(2026-07-07 dev 파이프라인 장애 근본수정): 원래 "0147" not in heads라는
+# **리터럴 문자열 매칭**이었다 — 0162(ee_pricing 0147 + core 0161 merge node) 적용 후 current가
+# "0162" 하나로 합쳐지면(0147을 정확히 승계했음에도) "0147"이라는 문자열이 alembic_version에
+# 더는 안 보여 매번 오탐 재발했다(실측: 04:43 정상 0162 도달 → 04:53 재실행에서 오탐으로 다시
+# `alembic stamp 0147` 실행 → 0148-0161 재실행 → role_templates DuplicateTable). 리터럴 매칭을
+# **그래프 조상관계(ancestry) 검증**으로 교체 — "0147"이 현재 head(들)의 실제 조상인지
+# ScriptDirectory로 walk해서 판단하므로, 0162 이후 어떤 미래 리비전이 추가돼도 영구히 안전하다.
 echo "[migrate] EE-stamp precheck: checking uq_org_subscriptions_org_id..."
 EE_STAMP_NEEDED=$(python3 <<'PYEOF'
 import os
 from sqlalchemy import create_engine, text
+from alembic.config import Config
+from alembic.script import ScriptDirectory
 
 engine = create_engine(os.environ["ALEMBIC_DATABASE_URL"])
 with engine.connect() as conn:
@@ -37,10 +47,25 @@ with engine.connect() as conn:
         print(0)
     else:
         try:
-            heads = {row[0] for row in conn.execute(text("SELECT version_num FROM alembic_version"))}
+            heads = [row[0] for row in conn.execute(text("SELECT version_num FROM alembic_version"))]
         except Exception:
-            heads = set()
-        print(1 if "0147" not in heads else 0)
+            heads = []
+        if not heads:
+            # alembic이 이 DB를 전혀 트래킹한 적 없는데 제약은 물리적으로 존재 — 진짜 구 체인 케이스.
+            print(1)
+        else:
+            try:
+                cfg = Config("alembic.ini")
+                script = ScriptDirectory.from_config(cfg)
+                already_applied = any(
+                    rev is not None and rev.revision == "0147"
+                    for rev in script.iterate_revisions(heads, "base")
+                )
+                print(0 if already_applied else 1)
+            except Exception:
+                # 그래프 walk 실패 시 안전한 쪽(스탬프 안 함)으로 fail — 잘못된 재스탬프로
+                # 이미 정상인 alembic_version을 파괴하는 것보다, 다음 실행에서 재판단하는 게 낫다.
+                print(0)
 PYEOF
 )
 


### PR DESCRIPTION
## Summary — CRITICAL, blocks all dev deploys until merged+deployed

The dev migrate job's EE-stamp precheck (story dbda0baf, #1886) broke every deploy today. Its condition `"0147" not in heads` is a **literal string match** against `alembic_version`'s raw rows. Once `0162` (the ee_pricing+core merge node from #1934/story 21ade1fa) applies successfully, current becomes just `{"0162"}` — which correctly carries `0147` in its ancestry, but the literal check doesn't know that, sees `"0147"` missing, and destructively re-stamps to bare `"0147"` via `alembic stamp 0147` (which **overwrites**, not merges, the tracked head). `alembic upgrade heads` then replays `0148`-`0161` against a DB that already has those tables/columns, failing with `DuplicateTable` on `0156`'s `role_templates` create.

Reproduced live in dev logs today: `04:43` successful `0162` merge → `04:53` next migrate run destructively re-stamped to `0147` → `DuplicateTable`. Manually restamped dev back to `0162` via a temporary job-command override (twice — the second time a verification run using the still-buggy deployed image broke it again, confirming this needs the actual image rebuilt).

## Fix
Replace the literal match with an actual **revision-graph ancestry check** via alembic's `ScriptDirectory` — walk from current head(s) down to `base` and check whether `"0147"` appears anywhere in that history. This is correct regardless of what current actually is (`0147` itself, `0161`, `0162`, or any future revision descending from `0162`) and won't need updating again for future merge nodes. On any ancestry-walk failure, fails closed to "no stamp" (safer than a destructive re-stamp of an already-healthy DB).

## Verification
Ran the actual precheck logic against the real alembic script directory (`uv run`):
- `heads=["0162"]` → `0147` found in ancestry → no stamp (the exact case that broke today)
- `heads=["0147","0161"]` → `0147` found → no stamp (today's other steady state, pre-merge)
- `heads=["0144"]` (pre-branchpoint) → `0147` NOT found → stamp needed (genuine legacy case still handled correctly)

## Test plan
- [x] Ancestry logic verified against real `ScriptDirectory` for all 3 scenarios above
- [ ] Needs a new backend image build + dev deploy to actually take effect — **until then, any deploy that triggers the migrate job will hit this bug again** (dev DB is currently manually restamped to 0162 as an interim state, but it's fragile against any further migrate-job execution using the old image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)