### PR TITLE
fix(recruit): stdio 채용 번들 uvx 명령 git+subdirectory 교체 — PyPI 미게시 갭

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Replace `localhost:3108` with your Sprintable URL if deployed remotely.
 
 Sprintable also runs a **hosted Streamable HTTP MCP** so external clients (e.g. [Poke](https://poke.com/integrations/new)) can connect without running a local server. Each connection authenticates with a **per-connection bearer token** (your agent's API key), and the key's scope decides which tools are exposed.
 
-- **Endpoint** (dev): `https://sprintable-mcp-dev-57iommnikq-du.a.run.app/mcp`
+- **Endpoint** (dev): `https://dev-mcp.sprintable.ai/mcp`
 - **Transport**: Streamable HTTP (stateless)
 - **Auth**: `Authorization: Bearer YOUR_AGENT_API_KEY` (per request)
 
@@ -219,7 +219,7 @@ Sprintable also runs a **hosted Streamable HTTP MCP** so external clients (e.g. 
   "mcpServers": {
     "sprintable": {
       "type": "http",
-      "url": "https://sprintable-mcp-dev-57iommnikq-du.a.run.app/mcp",
+      "url": "https://dev-mcp.sprintable.ai/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_AGENT_API_KEY"
       }

--- a/backend/app/services/agent_onboarding_config.py
+++ b/backend/app/services/agent_onboarding_config.py
@@ -135,6 +135,8 @@ _BACKEND_URL_ENV_KEY = "FASTAPI_URL"
 # E-MCP-OPT S3: 호스팅 MCP 깔끔 도메인 — README(구·문서만 언급) 대신 실제로 read. 미설정(OSS/로컬 —
 # 호스팅 배포 자체가 없음)이면 http 변형을 아예 생성하지 않는다(에러 아님·"그 탭 없음"이 정답).
 _MCP_PUBLIC_URL_ENV_KEY = "MCP_PUBLIC_URL"
+# E-RECRUIT S21: PyPI 미게시 동안 stdio uvx 가 clone 없이 이 subdirectory 를 직접 빌드하는 git 소스.
+_SPRINTABLE_REPO_URL = "https://github.com/moonklabs/sprintable.git"
 
 
 def resolve_backend_direct_url() -> str:
@@ -184,6 +186,12 @@ def _build_stdio_config(api_key_plaintext: str | None) -> dict:
     안 만들어 verify ``mcp_reachable`` 가 false-negative(통합 dogfood 적출). 따라서 아티팩트에
     ``AGENT_GATEWAY_V2="1"`` 을 박아 신규 에이전트를 **V2 로 통일** — mcp_reachable+acked_seq 정렬로
     verified-green 이 성립한다(서버 무변경·기존 에이전트 무영향).
+
+    E-RECRUIT S21(story 444d1d18): ``uvx sprintable-mcp``(bare)는 PyPI 미게시(pypi.org 404 실측,
+    2026-07-07)라 복붙하면 100% 실패한다. PyPI 게시 전까지 ``uvx --from git+<repo>#subdirectory=...``
+    로 emit — 레포 public(자격증명 없이 clone 가능, 실측 완료)이고 ``sprintable_mcp`` 는 flat
+    레이아웃이라 backend app/* 비의존(subdirectory 단독 빌드 성립, 로컬 실행 검증 완료). PyPI 정식
+    게시는 별도 스토리 OB-PUBLISH(f5e1742d)가 추적 — 게시되면 이 args 를 bare 형태로 되돌리는 게 후속.
     """
     env: dict[str, str] = {
         "SPRINTABLE_API_URL": resolve_backend_direct_url(),
@@ -196,7 +204,11 @@ def _build_stdio_config(api_key_plaintext: str | None) -> dict:
             "sprintable": {
                 "type": "stdio",
                 "command": "uvx",
-                "args": ["sprintable-mcp"],
+                "args": [
+                    "--from",
+                    f"git+{_SPRINTABLE_REPO_URL}#subdirectory=backend/sprintable_mcp",
+                    "sprintable-mcp",
+                ],
                 "env": env,
             }
         }

--- a/backend/tests/test_ob1_agent_onboarding_config.py
+++ b/backend/tests/test_ob1_agent_onboarding_config.py
@@ -2,6 +2,9 @@
 
 AC1: stdio .mcp.json(type=stdio·uvx·sprintable-mcp·env{SPRINTABLE_API_URL=backend-direct,
 AGENT_API_KEY})·AGENT_ID/WS_URL/port 미포함. backend-direct URL=env(FASTAPI_URL)·CF 금지·local fallback.
+
+E-RECRUIT S21(story 444d1d18): bare `uvx sprintable-mcp`는 PyPI 미게시라 args가
+`--from git+<repo>#subdirectory=...` 형태로 emit된다(실동작 검증 완료 — crux 참조).
 """
 from __future__ import annotations
 
@@ -17,7 +20,11 @@ def test_stdio_shape_with_key():
     server = cfg["mcpServers"]["sprintable"]
     assert server["type"] == "stdio"
     assert server["command"] == "uvx"
-    assert server["args"] == ["sprintable-mcp"]
+    assert server["args"] == [
+        "--from",
+        "git+https://github.com/moonklabs/sprintable.git#subdirectory=backend/sprintable_mcp",
+        "sprintable-mcp",
+    ]
     assert server["env"]["AGENT_API_KEY"] == "sk_live_abc"
     assert "SPRINTABLE_API_URL" in server["env"]
 


### PR DESCRIPTION
## Summary
- story 444d1d18 [E-RECRUIT] 채용 번들 MCP 안내 배포모드 분기 — 크럭스 게이트(오르테가군 승인) 완료 후 impl.
- **크럭스 결론**: SaaS/OSS 분기 로직(`default_transport_for_edition()` · `is_ee_enabled`)은 이미 완비 — 재구현 없음. dev의 edition 설정(EE 전환)은 PO 레벨에서 별도 처리됨(이 PR 스코프 아님).
- **실제 갭 2건 수정**:
  1. `_build_stdio_config()`의 uvx args를 bare `["sprintable-mcp"]` → `["--from", "git+https://github.com/moonklabs/sprintable.git#subdirectory=backend/sprintable_mcp", "sprintable-mcp"]`로 교체. `uvx sprintable-mcp`는 PyPI 미게시(pypi.org 404 실측) — 복붙하면 100% 실패. git+subdirectory 방식은 로컬 실행 검증 완료(레포 public, `sprintable_mcp`가 flat 레이아웃이라 backend app/* 비의존 — subdirectory 단독 빌드 성립).
  2. `README.md`(206·222행) hosted MCP 예시 URL을 raw Cloud Run URL → clean 도메인(`https://dev-mcp.sprintable.ai/mcp`)으로 정합.
- PyPI 정식 게시(bare `uvx sprintable-mcp`로 복귀)는 별도 스토리 **OB-PUBLISH(f5e1742d·E-ONBOARDING-DX)**가 추적 — 이 PR과 중복 아님, 게시 완료 시 이 args를 되돌리는 후속.

## Verification
- `uv run pytest backend/tests/test_ob1_agent_onboarding_config.py` 등 관련 스위트 통과, 전체 backend `uv run pytest` 3148 passed / 7 failed(baseline `origin/develop`에서도 동일하게 재현되는 로컬 머신 `.mcp.json` 상태 체크 — 이 diff와 무관, 회귀 아님) / 518 skipped / 8 xfailed.
- 로컬 실행으로 `uvx --from "git+https://github.com/moonklabs/sprintable.git#subdirectory=backend/sprintable_mcp" sprintable-mcp` 빌드·설치 성공 확인(필수 env 체크까지 정상 도달, import/빌드 실패 없음).
- SaaS(EE, dev 값 재현)·OSS(CE) 두 경로 번들 텍스트를 로컬 시뮬레이션(env 주입)으로 직접 생성해 AC2/AC3 형태 확인 — SaaS는 기존 http+clean 도메인 유지(무변경), OSS default(stdio)가 이제 동작하는 git+subdirectory 명령을 emit.

## Test plan
- [x] `backend/tests/test_ob1_agent_onboarding_config.py` 등 관련 유닛 테스트 통과
- [x] 전체 backend pytest 회귀 없음(baseline 대조 완료)
- [x] uvx git+subdirectory 로컬 실행 검증
- [ ] dev 배포 후 실 엔드포인트(`GET /agents/{id}/connection-artifact?transport=stdio`)로 최종 재확인 — merge 후 PO/까심 QA 단계에서 진행
- [ ] 까심 크로스모델 QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)