### PR TITLE
fix(mcp): 호스팅-기본 판정을 EE 과금 스위치서 분리 — MCP_PUBLIC_URL 존재 기준

### DIFF
--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -30,7 +30,7 @@ from app.services.agent_onboarding_config import (
     build_agent_mcp_config,
     build_agent_mcp_config_bundle,
     build_connector_guidance,
-    default_transport_for_edition,
+    default_transport_for_hosting,
     resolve_instruction_filename,
 )
 from app.services.agent_verify import get_verification_state, start_verification
@@ -128,7 +128,8 @@ async def create_org_agent(
     effective_port = member.fakechat_port or int(os.environ.get("FAKECHAT_PORT", _FAKECHAT_BASE_PORT))
     response["fakechat_port"] = effective_port
     response["api_key_created"] = bool(api_key_plaintext)
-    # E-MCP-OPT S3: 단일 SSOT generator 소비 — edition 기본 + 두 transport 변형 동봉(FE round-trip 0).
+    # E-MCP-OPT S3/S7: 단일 SSOT generator 소비 — 호스팅 가용성 기본(MCP_PUBLIC_URL 존재) + 두
+    # transport 변형 동봉(FE round-trip 0).
     config_bundle = build_agent_mcp_config_bundle(api_key_plaintext=api_key_plaintext)
     response["mcp_config"] = config_bundle["mcp_config"]
     response["default_transport"] = config_bundle["default_transport"]
@@ -164,7 +165,8 @@ async def get_agent_connection_artifact(
     ``.limit(1)`` 로 MultipleResultsFound 차단(identity 조회·행 동형).
 
     E-MCP-OPT S3: ``transport`` 쿼리(``stdio``|``http``) — connect-step 토글이 다른 탭 선택 시 이
-    파라미터로 재요청(§5, FE round-trip 방식 선택). 미지정 시 edition 기본(SaaS=http·OSS=stdio).
+    파라미터로 재요청(§5, FE round-trip 방식 선택). 미지정 시 호스팅 가용성 기본(S7: MCP_PUBLIC_URL
+    세팅=http·미설정=stdio — 과금/EE 무관).
 
     E-RECRUIT S5 G4(블루프린트 핵심 발견 — ``agent_personas.system_prompt``가 저장은 되나 어떤
     런타임에도 전달 안 됨): 이 **공용** 레이어에 fix를 둬서 recruit(S3) 전용이 아니라 **일반
@@ -215,7 +217,7 @@ async def get_agent_connection_artifact(
         mcp_config: dict | None = None
         files.append({"filename": "CONNECTOR_SETUP.md", "content": build_connector_guidance(runtime)})
     else:
-        resolved_transport = transport or default_transport_for_edition()
+        resolved_transport = transport or default_transport_for_hosting()
         if resolved_transport not in SUPPORTED_TRANSPORTS:
             raise HTTPException(status_code=400, detail=f"unsupported transport: {transport}")
         mcp_config = build_agent_mcp_config(

--- a/backend/app/services/agent_onboarding_config.py
+++ b/backend/app/services/agent_onboarding_config.py
@@ -89,7 +89,7 @@ def list_runtime_capabilities() -> list[dict]:
                 else "full" if runtime in _INSTRUCTION_FILENAMES
                 else "experimental"
             ),
-            "transport": None if (is_connector or not supported) else default_transport_for_edition(),
+            "transport": None if (is_connector or not supported) else default_transport_for_hosting(),
             "mcp_transport": [] if (is_connector or not supported) else sorted(SUPPORTED_TRANSPORTS),
             "prompt_file": resolve_instruction_filename(runtime) if supported else None,
             "guide_filename": "CONNECTOR_SETUP.md" if is_connector else None,
@@ -159,14 +159,17 @@ def resolve_mcp_public_url() -> str | None:
     return val.rstrip("/") if val else None
 
 
-def default_transport_for_edition() -> str:
-    """edition별 기본 transport — SaaS(EE)=http(무마찰 호스팅) / OSS=stdio(호스팅 배포 없음).
+def default_transport_for_hosting() -> str:
+    """호스팅 가용성별 기본 transport — MCP_PUBLIC_URL 세팅됨(호스팅 MCP 가용)=http(무마찰) /
+    미설정(자체호스팅·호스팅 배포 없음)=stdio.
 
-    기존 OSS/SaaS 스위치(``settings.is_ee_enabled``) 재사용 — 신규 플래그 0.
+    E-MCP-OPT S7(선생님 지적 2026-07-04·S3 근본 fix): 예전엔 ``settings.is_ee_enabled``(과금
+    스위치)로 갈랐으나, 이는 틀린 커플링 — EE 꺼진 배포(예: dev 기본값)에서도 호스팅 MCP가 실제로
+    떠 있으면(``MCP_PUBLIC_URL`` 세팅) 그 호스팅을 기본으로 써야 무마찰이 성립한다. 과금/EE 여부와
+    무관하게 "호스팅 MCP가 있느냐"만으로 판정 — ``resolve_mcp_public_url()``(= ``_build_http_config()``
+    non-None 가드)과 동일 신호를 재사용해 판정 신호가 하나로 정합된다.
     """
-    from app.core.config import settings
-
-    return HTTP if settings.is_ee_enabled else STDIO
+    return HTTP if resolve_mcp_public_url() is not None else STDIO
 
 
 def _build_stdio_config(api_key_plaintext: str | None) -> dict:
@@ -278,7 +281,7 @@ def build_agent_mcp_config_bundle(
     if runtime == CONNECTOR_RUNTIME:
         return {"default_transport": None, "mcp_config": None, "mcp_config_alternatives": {}}
 
-    default_transport = default_transport_for_edition()
+    default_transport = default_transport_for_hosting()
     configs = {
         t: build_agent_mcp_config(api_key_plaintext=api_key_plaintext, runtime=runtime, transport=t)
         for t in SUPPORTED_TRANSPORTS

--- a/backend/tests/test_e_mcp_opt_s3_hosted_transport.py
+++ b/backend/tests/test_e_mcp_opt_s3_hosted_transport.py
@@ -59,17 +59,15 @@ def test_http_variant_no_auth_header_when_key_absent(monkeypatch):
     assert out["mcpServers"]["sprintable"]["headers"] == {}
 
 
-def test_default_transport_for_edition(monkeypatch):
-    from app.core.config import settings
-    monkeypatch.setattr(settings, "license_consent", "", raising=False)
-    assert cfg.default_transport_for_edition() == "stdio"
-    monkeypatch.setattr(settings, "license_consent", "agreed", raising=False)
-    assert cfg.default_transport_for_edition() == "http"
+def test_default_transport_for_hosting(monkeypatch):
+    """E-MCP-OPT S7: 판정 신호는 MCP_PUBLIC_URL 존재 단독 — is_ee_enabled/license_consent 무관."""
+    monkeypatch.delenv("MCP_PUBLIC_URL", raising=False)
+    assert cfg.default_transport_for_hosting() == "stdio"
+    monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp")
+    assert cfg.default_transport_for_hosting() == "http"
 
 
-def test_bundle_saas_with_hosting_available(monkeypatch):
-    from app.core.config import settings
-    monkeypatch.setattr(settings, "license_consent", "agreed", raising=False)
+def test_bundle_hosted_with_mcp_public_url_set(monkeypatch):
     monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp")
     bundle = cfg.build_agent_mcp_config_bundle(api_key_plaintext="k")
     assert bundle["default_transport"] == "http"
@@ -77,24 +75,25 @@ def test_bundle_saas_with_hosting_available(monkeypatch):
     assert set(bundle["mcp_config_alternatives"]) == {"stdio"}
 
 
-def test_bundle_oss_no_hosting_falls_back_to_stdio_only(monkeypatch):
-    """OSS(호스팅 미배포) — MCP_PUBLIC_URL 미설정이면 default가 http여도 stdio로 폴백·alternatives 비움."""
-    from app.core.config import settings
-    monkeypatch.setattr(settings, "license_consent", "agreed", raising=False)  # 가정: edition=SaaS이나
-    monkeypatch.delenv("MCP_PUBLIC_URL", raising=False)                  # 이 인스턴스엔 호스팅 미배포
+def test_bundle_self_hosted_no_mcp_public_url_defaults_stdio(monkeypatch):
+    """자체호스팅(호스팅 MCP 미배포) — MCP_PUBLIC_URL 미설정이면 default=stdio·alternatives 비움."""
+    monkeypatch.delenv("MCP_PUBLIC_URL", raising=False)
     bundle = cfg.build_agent_mcp_config_bundle(api_key_plaintext="k")
     assert bundle["default_transport"] == "stdio"
     assert bundle["mcp_config"]["mcpServers"]["sprintable"]["type"] == "stdio"
     assert bundle["mcp_config_alternatives"] == {}
 
 
-def test_bundle_oss_default_stdio(monkeypatch):
+def test_bundle_hosting_decoupled_from_ee_flag(monkeypatch):
+    """E-MCP-OPT S7 회귀 가드: is_ee_enabled(License_consent)=False(dev 기본값)여도 MCP_PUBLIC_URL만
+    있으면 http가 기본 — 과금/EE 스위치와 완전 분리됐는지 직접 검증."""
     from app.core.config import settings
     monkeypatch.setattr(settings, "license_consent", "", raising=False)
-    monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp")  # 배포는 있어도 OSS면 기본 stdio
+    monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp")
+    assert settings.is_ee_enabled is False
     bundle = cfg.build_agent_mcp_config_bundle(api_key_plaintext="k")
-    assert bundle["default_transport"] == "stdio"
-    assert set(bundle["mcp_config_alternatives"]) == {"http"}
+    assert bundle["default_transport"] == "http"
+    assert set(bundle["mcp_config_alternatives"]) == {"stdio"}
 
 
 # ── ② crux2 — verify rail transport-aware ─────────────────────────────────────


### PR DESCRIPTION
## Summary
- story 69aaf490 [E-MCP-OPT·S7] 호스팅-기본을 EE 커플링서 분리 — S3 근본 fix (선생님 지적 2026-07-04).
- **근본 문제**: `default_transport_for_edition()`이 `settings.is_ee_enabled`(과금 스위치)로 http/stdio를 갈랐다 → EE 꺼진 배포(예: dev 기본값)에서는 `MCP_PUBLIC_URL`이 세팅돼 있어도 기본이 로컬 `uvx`로 떨어져, 만들어둔 무마찰 호스팅이 기본으로 안 쓰이는 반창고 상태였다.
- **수정**: `default_transport_for_hosting()`으로 개명하고 판정 신호를 `resolve_mcp_public_url() is not None`(= `_build_http_config()` non-None 가드와 동일 신호)로 교체 — 과금/EE와 완전 분리. `MCP_PUBLIC_URL` 세팅된 환경(dev·prod)=호스팅 http 기본, 없는 환경(자체호스팅 OSS)=stdio 기본.
- 호출부(`agents.py`) 개명 반영 + 관련 주석 2곳을 "edition 기본" → "호스팅 가용성 기본" 의미로 정합(AC5).
- **is_ee_enabled 다른 의존 audit**: transport 판정 목적으로는 이 함수 단 한 곳만 소비했음을 grep으로 확인 — billing.py/activity_logs.py/org_invites.py/organizations.py/projects.py/stories.py/main.py/plan_limits.py 등 나머지 전체 사용처는 billing/RBAC/plan-limit 전용이라 이번 변경과 무관, 손대지 않음.

## Verification
- `backend/tests/test_e_mcp_opt_s3_hosted_transport.py` 관련 유닛테스트 재작성 + 신규 회귀가드 `test_bundle_hosting_decoupled_from_ee_flag`(is_ee_enabled=False인데 MCP_PUBLIC_URL만 있어도 http가 기본으로 나오는지 직접 검증).
- 전체 backend `uv run pytest`: 3148 passed / 7 failed(로컬 머신별 `.mcp.json` 상태 체크 — 이 diff와 무관한 baseline 재현, 회귀 아님) / 518 skipped / 8 xfailed.
- **로컬 실측(dev 실제값 재현)**: `LICENSE_CONSENT` 미설정(`is_ee_enabled=False`, dev 실제 상태) + `MCP_PUBLIC_URL=https://dev-mcp.sprintable.ai/mcp`로 직접 함수 호출 — 수정 전엔 stdio로 떨어졌던 것(크럭스에서 재현 확인)이 이제 `default_transport=http`로 정상 전환됨을 확인.

## Test plan
- [x] 관련 유닛 테스트 통과 + 회귀가드 추가
- [x] 전체 backend pytest 회귀 없음(baseline 대조 완료)
- [x] 로컬 시뮬레이션으로 EE-무관 동작 확인
- [ ] dev 배포 후 실 엔드포인트에서 기본 탭=호스팅 실측(AC4) — merge 후 진행
- [ ] 까심 크로스모델 QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)