### PR TITLE
feat(mcp): PyPI Trusted Publishing workflow + sprintable-mcp→sprintable rename

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,51 @@
+name: Publish sprintable-mcp to PyPI
+
+# OB-PUBLISH(f5e1742d): uvx sprintable-mcp is currently PyPI 404 — this workflow is the
+# prerequisite. Filename/environment name below must match PyPI's registered pending
+# publisher exactly (repo: moonklabs/sprintable, workflow: publish-mcp.yml, environment: pypi).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Build and publish sprintable-mcp
+    runs-on: ubuntu-latest
+    # First publish creates the PyPI project from the pending publisher — no API token needed,
+    # OIDC only (id-token: write below). Never add a token/twine step here.
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: read
+    # Defense-in-depth: this is a monorepo, `release: published` could in principle fire for a
+    # release unrelated to sprintable-mcp. Require an explicit sprintable-mcp-v* tag (manual
+    # workflow_dispatch runs skip this guard — those are always intentional).
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'sprintable-mcp-v')
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Sanity-check release tag matches package version
+        if: github.event_name == 'release'
+        working-directory: backend/sprintable_mcp
+        run: |
+          pkg_version=$(grep -m1 '^version = ' pyproject.toml | sed -E 's/version = "(.*)"/\1/')
+          tag_version="${GITHUB_REF_NAME#sprintable-mcp-v}"
+          if [ "$pkg_version" != "$tag_version" ]; then
+            echo "::error::release tag sprintable-mcp-v$tag_version does not match pyproject.toml version $pkg_version — bump pyproject.toml before tagging"
+            exit 1
+          fi
+
+      - name: Build sdist and wheel
+        working-directory: backend/sprintable_mcp
+        run: uv build --out-dir dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: backend/sprintable_mcp/dist

--- a/backend/sprintable_mcp/README.md
+++ b/backend/sprintable_mcp/README.md
@@ -8,14 +8,14 @@ BYO 에이전트용 Sprintable MCP 서버. 에이전트 런타임을 Sprintable 
 ```bash
 export SPRINTABLE_API_URL=https://app.sprintable.ai     # 또는 dev 백엔드 URL
 export AGENT_API_KEY=sk_live_...                         # 에이전트 API 키
-uvx sprintable-mcp
+uvx sprintable
 ```
 
 설치형:
 
 ```bash
-pip install sprintable-mcp
-sprintable-mcp        # 엔트리포인트
+pip install sprintable
+sprintable        # 엔트리포인트
 # 또는
 python -m sprintable_mcp
 ```

--- a/backend/sprintable_mcp/README.md
+++ b/backend/sprintable_mcp/README.md
@@ -1,4 +1,4 @@
-# sprintable-mcp
+# Sprintable MCP
 
 BYO 에이전트용 Sprintable MCP 서버. 에이전트 런타임을 Sprintable API에 stdio로 연결한다.
 **레포 clone 불필요** — `uvx` 한 줄로 구동.

--- a/backend/sprintable_mcp/pyproject.toml
+++ b/backend/sprintable_mcp/pyproject.toml
@@ -3,7 +3,9 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "sprintable-mcp"
+# OB-PUBLISH(f5e1742d): distribution name = "sprintable" (선생님 PyPI project 등록값·uvx sprintable
+# 한 줄 정합). 내부 모듈명은 sprintable_mcp 그대로(dist명≠모듈명 — hatch sources remap 아래 유지).
+name = "sprintable"
 version = "0.1.0"
 description = "Sprintable MCP server — BYO agent toolset over the Sprintable API (stdio). No repo clone required."
 readme = "README.md"
@@ -21,10 +23,10 @@ dependencies = [
     "uvicorn>=0.30",   # http 모드 ASGI 서버(streamable_http_app + bearer auth 미들웨어 구동). stdio 무관.
 ]
 
-# E-MCP S4: 외부(레포 없음) 한 줄 구동 — `uvx sprintable-mcp`.
+# E-MCP S4: 외부(레포 없음) 한 줄 구동 — `uvx sprintable`.
 # 필수 env: SPRINTABLE_API_URL, AGENT_API_KEY (그 외 import 의존 0 — backend app/* 비의존).
 [project.scripts]
-sprintable-mcp = "sprintable_mcp.__main__:main"
+sprintable = "sprintable_mcp.__main__:main"
 
 [project.urls]
 Homepage = "https://sprintable.ai"

--- a/backend/tests/test_e_mcp_s4_standalone.py
+++ b/backend/tests/test_e_mcp_s4_standalone.py
@@ -57,8 +57,10 @@ def test_vendored_toolset_matches_backend_rules():
 def test_pyproject_metadata_and_entrypoint():
     with open(os.path.join(_PKG_DIR, "pyproject.toml"), "rb") as f:
         cfg = tomllib.load(f)
-    assert cfg["project"]["name"] == "sprintable-mcp"
-    assert cfg["project"]["scripts"]["sprintable-mcp"] == "sprintable_mcp.__main__:main"
+    # OB-PUBLISH(f5e1742d): dist/콘솔 스크립트명 = "sprintable"(PyPI project 등록값 정합). 모듈명은
+    # sprintable_mcp 그대로.
+    assert cfg["project"]["name"] == "sprintable"
+    assert cfg["project"]["scripts"]["sprintable"] == "sprintable_mcp.__main__:main"
     deps = " ".join(cfg["project"]["dependencies"])
     assert "mcp" in deps and "httpx" in deps and "pydantic" in deps
     # backend(app/*) 의존 미선언


### PR DESCRIPTION
## Summary
- story f5e1742d [E-ONBOARDING-DX][OB-PUBLISH] — `uvx sprintable-mcp` is currently PyPI 404, breaking the onboarding artifact's headline one-liner.
- **Express PR→main** (per PO branch strategy): PyPI's registered pending publisher requires this workflow to land on the repo's default branch (`main`) before the first publish can succeed. Scoped to main-safe files only — workflow + standalone package metadata, zero prod runtime impact.
- Adds `.github/workflows/publish-mcp.yml`: OIDC via `pypa/gh-action-pypi-publish@release/v1` (no token/twine), `environment: pypi`, `permissions: {id-token: write, contents: read}`. Triggers: `workflow_dispatch` (manual first publish) + `release: published` (guarded by a `sprintable-mcp-v*` tag check so an unrelated monorepo release can't accidentally fire it).
- Renames `backend/sprintable_mcp` PyPI distribution + console script from `sprintable-mcp` → `sprintable` (matches the PyPI project name 선생님 is registering). Internal module stays `sprintable_mcp` (dist name ≠ module name is fine).
- Updated `test_e_mcp_s4_standalone.py`'s pyproject-metadata assertions to match the rename (would otherwise fail CI on main — caught while verifying, included here rather than left broken).
- The develop-side follow-up (recruit bundle emit arg `_build_stdio_config` for #1939 + docs) ships separately, per PO split.

## Verification
- `uv build` in `backend/sprintable_mcp` → `sprintable-0.1.0.tar.gz` + `sprintable-0.1.0-py3-none-any.whl` (correct renamed artifact names).
- `twine check dist/*` → PASSED for both.
- Live smoke test: `uvx --from ./dist/sprintable-0.1.0-py3-none-any.whl sprintable` actually ran — resolved auth against dev backend, started the SSE bridge (then killed the process — this was a real connectivity check, not just an import test).
- `actionlint .github/workflows/publish-mcp.yml` — clean, no errors.
- `uv run pytest tests/test_e_mcp_s4_standalone.py` — 4 passed.
- Full backend `uv run pytest` on this branch: 3022 passed / 7 failed (pre-existing local-machine `.mcp.json` checks, reproduced identically on `origin/main` before this change — unrelated, not a regression) / 496 skipped / 8 xfailed.

## Test plan
- [x] Build dry-run produces correctly-named sdist+wheel
- [x] twine check passes
- [x] Renamed console script verified live (real auth + SSE bridge start)
- [x] actionlint clean
- [x] Full backend suite regression-checked against main baseline
- [ ] PO admin-merge → manual `workflow_dispatch` run for the actual first publish (creates the PyPI project from the pending publisher)

## Notes for reviewer
- `pypi` GitHub environment: referencing it in the workflow auto-creates it on first run if it doesn't exist yet, but if you want a protection rule (e.g. required reviewers before OIDC-publish jobs run), that needs to be configured manually in repo Settings → Environments — not something this PR can set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)