### PR TITLE
fix(mcp): recruit bundle uvx arg + docs — sprintable-mcp→sprintable rename follow-up

### DIFF
--- a/backend/app/services/agent_onboarding_config.py
+++ b/backend/app/services/agent_onboarding_config.py
@@ -190,11 +190,15 @@ def _build_stdio_config(api_key_plaintext: str | None) -> dict:
     ``AGENT_GATEWAY_V2="1"`` 을 박아 신규 에이전트를 **V2 로 통일** — mcp_reachable+acked_seq 정렬로
     verified-green 이 성립한다(서버 무변경·기존 에이전트 무영향).
 
-    E-RECRUIT S21(story 444d1d18): ``uvx sprintable-mcp``(bare)는 PyPI 미게시(pypi.org 404 실측,
+    E-RECRUIT S21(story 444d1d18): ``uvx sprintable``(bare)는 PyPI 미게시(pypi.org 404 실측,
     2026-07-07)라 복붙하면 100% 실패한다. PyPI 게시 전까지 ``uvx --from git+<repo>#subdirectory=...``
     로 emit — 레포 public(자격증명 없이 clone 가능, 실측 완료)이고 ``sprintable_mcp`` 는 flat
     레이아웃이라 backend app/* 비의존(subdirectory 단독 빌드 성립, 로컬 실행 검증 완료). PyPI 정식
     게시는 별도 스토리 OB-PUBLISH(f5e1742d)가 추적 — 게시되면 이 args 를 bare 형태로 되돌리는 게 후속.
+
+    OB-PUBLISH(f5e1742d) 이름 정합: PyPI distribution/콘솔 스크립트명 = ``sprintable``(모듈명
+    ``sprintable_mcp`` 와 별개 — pyproject.toml ``[project.scripts] sprintable = ...``). 마지막
+    실행 인자가 콘솔 스크립트명이라 ``"sprintable"``(subdirectory 경로 문자열은 모듈 디렉터리라 무관).
     """
     env: dict[str, str] = {
         "SPRINTABLE_API_URL": resolve_backend_direct_url(),
@@ -210,7 +214,7 @@ def _build_stdio_config(api_key_plaintext: str | None) -> dict:
                 "args": [
                     "--from",
                     f"git+{_SPRINTABLE_REPO_URL}#subdirectory=backend/sprintable_mcp",
-                    "sprintable-mcp",
+                    "sprintable",
                 ],
                 "env": env,
             }

--- a/backend/sprintable_mcp/README.md
+++ b/backend/sprintable_mcp/README.md
@@ -8,14 +8,14 @@ BYO 에이전트용 Sprintable MCP 서버. 에이전트 런타임을 Sprintable 
 ```bash
 export SPRINTABLE_API_URL=https://app.sprintable.ai     # 또는 dev 백엔드 URL
 export AGENT_API_KEY=sk_live_...                         # 에이전트 API 키
-uvx sprintable-mcp
+uvx sprintable
 ```
 
 설치형:
 
 ```bash
-pip install sprintable-mcp
-sprintable-mcp        # 엔트리포인트
+pip install sprintable
+sprintable        # 엔트리포인트
 # 또는
 python -m sprintable_mcp
 ```

--- a/backend/sprintable_mcp/README.md
+++ b/backend/sprintable_mcp/README.md
@@ -1,4 +1,4 @@
-# sprintable-mcp
+# Sprintable MCP
 
 BYO 에이전트용 Sprintable MCP 서버. 에이전트 런타임을 Sprintable API에 stdio로 연결한다.
 **레포 clone 불필요** — `uvx` 한 줄로 구동.

--- a/backend/sprintable_mcp/pyproject.toml
+++ b/backend/sprintable_mcp/pyproject.toml
@@ -3,7 +3,9 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "sprintable-mcp"
+# OB-PUBLISH(f5e1742d): distribution name = "sprintable" (선생님 PyPI project 등록값·uvx sprintable
+# 한 줄 정합). 내부 모듈명은 sprintable_mcp 그대로(dist명≠모듈명 — hatch sources remap 아래 유지).
+name = "sprintable"
 version = "0.1.0"
 description = "Sprintable MCP server — BYO agent toolset over the Sprintable API (stdio). No repo clone required."
 readme = "README.md"
@@ -21,10 +23,10 @@ dependencies = [
     "uvicorn>=0.30",   # http 모드 ASGI 서버(streamable_http_app + bearer auth 미들웨어 구동). stdio 무관.
 ]
 
-# E-MCP S4: 외부(레포 없음) 한 줄 구동 — `uvx sprintable-mcp`.
+# E-MCP S4: 외부(레포 없음) 한 줄 구동 — `uvx sprintable`.
 # 필수 env: SPRINTABLE_API_URL, AGENT_API_KEY (그 외 import 의존 0 — backend app/* 비의존).
 [project.scripts]
-sprintable-mcp = "sprintable_mcp.__main__:main"
+sprintable = "sprintable_mcp.__main__:main"
 
 [project.urls]
 Homepage = "https://sprintable.ai"

--- a/backend/tests/test_e_mcp_s4_standalone.py
+++ b/backend/tests/test_e_mcp_s4_standalone.py
@@ -57,8 +57,10 @@ def test_vendored_toolset_matches_backend_rules():
 def test_pyproject_metadata_and_entrypoint():
     with open(os.path.join(_PKG_DIR, "pyproject.toml"), "rb") as f:
         cfg = tomllib.load(f)
-    assert cfg["project"]["name"] == "sprintable-mcp"
-    assert cfg["project"]["scripts"]["sprintable-mcp"] == "sprintable_mcp.__main__:main"
+    # OB-PUBLISH(f5e1742d): dist/콘솔 스크립트명 = "sprintable"(PyPI project 등록값 정합). 모듈명은
+    # sprintable_mcp 그대로.
+    assert cfg["project"]["name"] == "sprintable"
+    assert cfg["project"]["scripts"]["sprintable"] == "sprintable_mcp.__main__:main"
     deps = " ".join(cfg["project"]["dependencies"])
     assert "mcp" in deps and "httpx" in deps and "pydantic" in deps
     # backend(app/*) 의존 미선언

--- a/backend/tests/test_ob1_agent_onboarding_config.py
+++ b/backend/tests/test_ob1_agent_onboarding_config.py
@@ -3,8 +3,9 @@
 AC1: stdio .mcp.json(type=stdio·uvx·sprintable-mcp·env{SPRINTABLE_API_URL=backend-direct,
 AGENT_API_KEY})·AGENT_ID/WS_URL/port 미포함. backend-direct URL=env(FASTAPI_URL)·CF 금지·local fallback.
 
-E-RECRUIT S21(story 444d1d18): bare `uvx sprintable-mcp`는 PyPI 미게시라 args가
+E-RECRUIT S21(story 444d1d18): bare `uvx sprintable`는 PyPI 미게시라 args가
 `--from git+<repo>#subdirectory=...` 형태로 emit된다(실동작 검증 완료 — crux 참조).
+OB-PUBLISH(f5e1742d): 콘솔 스크립트명 = `sprintable`(모듈명 `sprintable_mcp` 와 별개).
 """
 from __future__ import annotations
 
@@ -23,7 +24,7 @@ def test_stdio_shape_with_key():
     assert server["args"] == [
         "--from",
         "git+https://github.com/moonklabs/sprintable.git#subdirectory=backend/sprintable_mcp",
-        "sprintable-mcp",
+        "sprintable",
     ]
     assert server["env"]["AGENT_API_KEY"] == "sk_live_abc"
     assert "SPRINTABLE_API_URL" in server["env"]

--- a/docs/agent-integration-guide.md
+++ b/docs/agent-integration-guide.md
@@ -197,8 +197,9 @@ mcpServers:
     startupTimeout: 10
 ```
 
-> `sprintable_mcp` 패키지 설치: `pip install sprintable-mcp` 또는
-> `uv add sprintable-mcp` (pypi 배포 전에는 `pip install -e ./backend`).
+> `sprintable_mcp` 패키지 설치: `pip install sprintable` 또는 `uv add sprintable`
+> (PyPI dist/콘솔 스크립트명 = `sprintable`, 모듈명은 `sprintable_mcp`). 외부 레포 없이 한 줄
+> 구동은 `uvx sprintable`.
 
 Claude Code `.mcp.json` 형식이라면:
 


### PR DESCRIPTION
## Summary
- story f5e1742d [E-ONBOARDING-DX][OB-PUBLISH] — companion to #1941 (main). This is the develop-side half of the PyPI distribution rename `sprintable-mcp` → `sprintable`.
- `backend/sprintable_mcp/pyproject.toml`: same rename as #1941 (kept in sync for when develop/main next reconcile).
- `agent_onboarding_config.py` `_build_stdio_config()`: the git+subdirectory uvx fallback's final execution arg `sprintable-mcp` → `sprintable` (console script name — the `#subdirectory=backend/sprintable_mcp` path is the module directory, unrelated to the rename, left unchanged).
- `docs/agent-integration-guide.md`: pip/uv install examples updated to the new distribution name.
- Once the actual PyPI publish lands (#1941 merged to main → PO dispatches the first publish), a follow-up drops the git+subdirectory fallback back to bare `uvx sprintable`.

## Verification
- `uv run pytest tests/test_ob1_agent_onboarding_config.py tests/test_e_mcp_s4_standalone.py tests/test_e_mcp_opt_s3_hosted_transport.py` — 36 passed.
- Full backend `uv run pytest`: 3148 passed / 7 failed (pre-existing local-machine `.mcp.json` checks, unrelated to this diff) / 518 skipped / 8 xfailed.
- Local simulation confirms the recruit bundle's stdio variant now emits `args: ["--from", "git+.../sprintable.git#subdirectory=backend/sprintable_mcp", "sprintable"]`.

## Test plan
- [x] Relevant unit tests pass
- [x] Full backend suite regression-checked
- [x] Local bundle-emit simulation confirms the renamed arg
- [ ] 까심 크로스모델 QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)