### PR TITLE
feat(agents): GET /api/v2/agents/access-matrix bulk endpoint

### DIFF
--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -11,7 +11,7 @@ import os
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
@@ -413,3 +413,56 @@ async def agent_verification_status(
         "verified": state["verified"],
         "rail": state["rail"],
     }
+
+
+@router.get("/access-matrix")
+async def get_agent_access_matrix(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> list[dict]:
+    """[에이전트 관리 IA·Phase 2] org-wide 에이전트×프로젝트 접근권한 매트릭스 시드(story da4c6b2d).
+
+    PO crux 승인(2026-07-07): 후보 A 채택 — 프로젝트별 fan-out(N agents × M projects 왕복) 대신
+    단일 인덱스드 쿼리로 org 전체 grant 를 한 번에 반환. FE 는 이미 별도로 가진 org 에이전트
+    전체 목록·org 프로젝트 전체 목록에 이 sparse grant 목록만 겹쳐 매트릭스 셀 상태를 정한다
+    (record_id 있음=허용, 없음=차단). 경로에 org path-param 을 안 둔다 — `get_verified_org_id` 로
+    caller 의 검증된 org 만 암묵 사용(클라이언트가 org id 조작해 타org 조회하는 경로 원천 차단).
+
+    **에이전트 격리(PO 승인조건 #1)**: `project_access.member_id` 는 에이전트 전용이 아니다 —
+    휴먼 grant 도 `ensure_human_member` 성공 시 member_id 를 org_member.id(=members.id 미러)로
+    세팅한다(`project_access.py` 휴먼 분기). 그래서 `member_id IS NOT NULL` 만으론 휴먼이 섞인다 —
+    `members` 를 명시 JOIN 해 `type = 'agent'` 로 직접 격리.
+
+    **인가(PO 승인조건 #2)**: 고객대면(org admin 이 자기 에이전트 접근을 조망) — `require_operator`
+    (플랫폼 운영자) 아닌 **org admin/owner**. 기존 `is_org_owner_or_admin`(project_access.py 의
+    role-설정 엔드포인트가 이미 씀) 재사용, 신규 프리미티브 0.
+    """
+    from app.services.project_auth import is_org_owner_or_admin
+
+    if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
+        raise HTTPException(status_code=403, detail="org owner or admin required")
+
+    rows = (
+        await session.execute(
+            text(
+                """
+                SELECT pa.id AS record_id, pa.member_id AS agent_member_id, pa.project_id
+                FROM project_access pa
+                JOIN members m ON m.id = pa.member_id
+                JOIN projects p ON p.id = pa.project_id
+                WHERE m.type = 'agent' AND m.deleted_at IS NULL
+                  AND p.org_id = :org_id AND p.deleted_at IS NULL
+                """
+            ),
+            {"org_id": org_id},
+        )
+    ).mappings().all()
+    return [
+        {
+            "agent_member_id": str(r["agent_member_id"]),
+            "project_id": str(r["project_id"]),
+            "record_id": str(r["record_id"]),
+        }
+        for r in rows
+    ]

--- a/backend/tests/test_agent_access_matrix_realdb.py
+++ b/backend/tests/test_agent_access_matrix_realdb.py
@@ -1,0 +1,208 @@
+"""[에이전트 관리 IA·Phase 2] GET /api/v2/agents/access-matrix 실 Postgres 검증 (story da4c6b2d).
+
+PO crux 승인조건 실측: (1) 휴먼 grant도 project_access.member_id를 미러 세팅하므로
+members JOIN type='agent'로 명시 격리해야 함 — 섞이면 회귀. (2) org 스코프(타org 누출 금지).
+(3) org admin/owner만 통과(403 회귀 가드).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session, *, admin_user_id: uuid.UUID) -> tuple[uuid.UUID, uuid.UUID]:
+    """org + project + org_members(admin) 시드(ORM — 모델 default 활용) — is_org_owner_or_admin 통과용."""
+    from sqlalchemy import text as _text
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+
+    org_id, project_id = uuid.uuid4(), uuid.uuid4()
+    await session.execute(_text("SET session_replication_role = replica"))
+    session.add(Organization(id=org_id, name="x", slug=f"x-{org_id}"))
+    session.add(Project(id=project_id, org_id=org_id, name="p"))
+    session.add(OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=admin_user_id, role="admin"))
+    await session.flush()
+    await session.commit()
+    return org_id, project_id
+
+
+async def _seed_agent_grant(session, *, org_id, project_id, name="agent"):
+    from app.models.member import Member
+    from app.models.project_access import ProjectAccess
+
+    agent = Member(id=uuid.uuid4(), org_id=org_id, type="agent", name=name, is_active=True)
+    session.add(agent)
+    await session.flush()
+    record = ProjectAccess(project_id=project_id, member_id=agent.id, org_member_id=None, permission="granted")
+    session.add(record)
+    await session.flush()
+    await session.commit()
+    return agent, record
+
+
+async def _seed_human_grant(session, *, org_id, project_id):
+    """휴먼 grant — project_access.py 실 동작 재현: member_id도 org_member.id로 미러 세팅."""
+    from app.models.member import Member
+    from app.models.project_access import ProjectAccess
+
+    human_member = Member(id=uuid.uuid4(), org_id=org_id, type="human", name="human", is_active=True)
+    session.add(human_member)
+    await session.flush()
+    record = ProjectAccess(
+        project_id=project_id, org_member_id=human_member.id, member_id=human_member.id, permission="granted",
+    )
+    session.add(record)
+    await session.flush()
+    await session.commit()
+    return human_member, record
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_access_matrix_isolates_agents_from_humans():
+    """승인조건 #1: member_id IS NOT NULL만으론 휴먼이 섞임 — type='agent' 명시 격리 검증."""
+    from unittest.mock import MagicMock
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.routers.agents import get_agent_access_matrix
+
+    engine, Session = await _session()
+    try:
+        admin_user_id = uuid.uuid4()
+        async with Session() as s:
+            org_id, project_id = await _seed_org_project(s, admin_user_id=admin_user_id)
+            agent, agent_record = await _seed_agent_grant(s, org_id=org_id, project_id=project_id)
+            await _seed_human_grant(s, org_id=org_id, project_id=project_id)
+
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            auth = MagicMock(user_id=str(admin_user_id))
+            out = await get_agent_access_matrix(session=s, auth=auth, org_id=org_id)
+
+        assert len(out) == 1, f"휴먼 grant 섞임 — {out}"
+        assert out[0]["agent_member_id"] == str(agent.id)
+        assert out[0]["project_id"] == str(project_id)
+        assert out[0]["record_id"] == str(agent_record.id)
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_access_matrix_scoped_to_caller_org():
+    """승인조건 #2: 타org grant 누출 금지 — org_id는 get_verified_org_id로 caller org 고정."""
+    from unittest.mock import MagicMock
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.routers.agents import get_agent_access_matrix
+
+    engine, Session = await _session()
+    try:
+        admin_user_id = uuid.uuid4()
+        async with Session() as s:
+            org_a, project_a = await _seed_org_project(s, admin_user_id=admin_user_id)
+            await _seed_agent_grant(s, org_id=org_a, project_id=project_a, name="agent-a")
+            # 타 org — admin 은 org_a 에만 admin (org_members 별도 재확認 안 함, org_id 스코프만 검증)
+            org_b, project_b = await _seed_org_project(s, admin_user_id=uuid.uuid4())
+            await _seed_agent_grant(s, org_id=org_b, project_id=project_b, name="agent-b")
+
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            auth = MagicMock(user_id=str(admin_user_id))
+            out = await get_agent_access_matrix(session=s, auth=auth, org_id=org_a)
+
+        assert len(out) == 1
+        assert out[0]["project_id"] == str(project_a)
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_access_matrix_403_for_non_admin():
+    """승인조건 #2: org admin/owner 아니면 403(member role)."""
+    from unittest.mock import MagicMock
+    from fastapi import HTTPException
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.routers.agents import get_agent_access_matrix
+
+    engine, Session = await _session()
+    try:
+        admin_user_id = uuid.uuid4()
+        member_user_id = uuid.uuid4()
+        async with Session() as s:
+            from app.models.project import OrgMember
+
+            org_id, project_id = await _seed_org_project(s, admin_user_id=admin_user_id)
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add(OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=member_user_id, role="member"))
+            await s.flush()
+            await s.commit()
+
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            auth = MagicMock(user_id=str(member_user_id))
+            with pytest.raises(HTTPException) as ei:
+                await get_agent_access_matrix(session=s, auth=auth, org_id=org_id)
+        assert ei.value.status_code == 403
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_access_matrix_empty_when_no_grants():
+    from unittest.mock import MagicMock
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.routers.agents import get_agent_access_matrix
+
+    engine, Session = await _session()
+    try:
+        admin_user_id = uuid.uuid4()
+        async with Session() as s:
+            org_id, _ = await _seed_org_project(s, admin_user_id=admin_user_id)
+
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            auth = MagicMock(user_id=str(admin_user_id))
+            out = await get_agent_access_matrix(session=s, auth=auth, org_id=org_id)
+        assert out == []
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- story da4c6b2d [에이전트 관리 IA · Phase 2] 접근권한 매트릭스 — BE 선행(bulk endpoint). Crux(candidate A) already PO-approved in the kickoff thread before implementation.
- Adds `GET /api/v2/agents/access-matrix` — single indexed query (`project_access JOIN members JOIN projects`) returning the org's full agent×project grant seed, instead of N(agents)×M(projects) fan-out.
- **Approval condition #1 (agent isolation)**: `project_access.member_id` is not agent-exclusive — human grants also mirror `member_id = org_member.id` when `ensure_human_member` succeeds (`project_access.py`). Explicit `JOIN members ... WHERE type = 'agent'` isolates correctly; `member_id IS NOT NULL` alone would leak human grants into the matrix.
- **Approval condition #2 (authz)**: customer-facing feature → reused existing `is_org_owner_or_admin` (no new `require_operator` primitive). No org path param — `org_id` comes from `get_verified_org_id` (caller's verified org only), narrower IDOR surface than the originally-proposed `/orgs/{org}/agent-access` literal path.
- **Approval condition #3 (record_id)**: included in the response for the FE's `DELETE .../{recordId}` revoke call.
- Write paths (grant/revoke) unchanged — reuses existing `POST`/`DELETE /api/v2/projects/{id}/access`.

## Verification
- 4 realdb tests (`pytest.mark.destructive_schema`, skipped without `ALEMBIC_DATABASE_URL`) against a disposable Postgres: agent/human isolation, cross-org scoping, 403 for non-admin, empty-result case — all passed.
- Full backend `uv run pytest`: 3148 passed / 7 failed (pre-existing baseline, unrelated) / 522 skipped (includes the 4 new realdb tests skipping cleanly without a DB URL).

## Test plan
- [x] Realdb tests cover isolation/scope/authz/empty
- [x] Full backend suite regression-checked
- [ ] dev deploy + 유나 BE 계약 끝단검증
- [ ] 까심 크로스모델 QA
- [ ] 미르코 FE 매트릭스 탭 (depends on this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)