### PR TITLE
feat(a2a): HITL Gate↔INPUT_REQUIRED 매핑 — reader + writer-stub (story 7726a003)

### DIFF
--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -83,6 +83,7 @@ from app.models.agent_deployment import AgentPersona
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.conversation_webhook_delivery import ConversationWebhookDelivery
 from app.models.event import Event
+from app.models.gate import Gate
 from app.models.role_template import RoleTemplate
 from app.models.team import TeamMember
 from app.repositories.team_member import TeamMemberRepository
@@ -517,7 +518,25 @@ async def _handle_get_task(
     if task is None:
         raise _JsonRpcException(_TASK_NOT_FOUND, "Task not found")
 
-    if task.state not in _TERMINAL_STATES and task.root_message_id is not None:
+    # HITL crux(story 7726a003, 문서 `a2a-hitl-input-auth-required-mapping-crux`, PO GO 승인
+    # 2026-07-07, 옵션 B): reader만 배선 — writer(task_metadata.linked_gate_id 기록)는 별도
+    # forward-work 스토리로 분리(아직 아무 delegate 경로도 이 필드를 안 씀 → 오늘은 항상
+    # no-op·무회귀). WORKING 에서만 판정(INPUT_REQUIRED 재진입 시 재판정 없음 — 복귀는
+    # transition_gate()의 전담 책임, 여기서 낙관적으로 되돌리지 않는다).
+    if task.state == "TASK_STATE_WORKING":
+        linked_gate_id = (task.task_metadata or {}).get("linked_gate_id")
+        if linked_gate_id is not None:
+            gate = (await session.execute(
+                select(Gate).where(Gate.id == uuid.UUID(linked_gate_id), Gate.org_id == member.org_id)
+            )).scalar_one_or_none()
+            if gate is not None and gate.status == "pending":
+                task.state = "TASK_STATE_INPUT_REQUIRED"
+                await session.flush()
+                await session.commit()
+                await session.refresh(task)
+                return _task_to_dict(task)
+
+    if task.state == "TASK_STATE_WORKING" and task.root_message_id is not None:
         reply = (await session.execute(
             select(ConversationMessage)
             .where(ConversationMessage.thread_id == task.root_message_id)

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -154,6 +154,8 @@ async def transition_gate(
         await _advance_story_on_merge_approve(session, gate, new_status)
         # E-DG doc-gate(48f064e5): doc 결재 게이트 approve→confirmed·reject→denied.
         await _resolve_doc_gate(session, gate, new_status)
+        # HITL crux(story 7726a003) — A2A task INPUT_REQUIRED 복귀. writer 미배선이라 오늘은 no-op.
+        await _resume_a2a_task_on_gate_resolve(session, gate, new_status)
 
     await session.flush()
     await session.refresh(gate)
@@ -366,6 +368,30 @@ async def _resolve_doc_gate(session: AsyncSession, gate: Gate, new_status: str) 
     if doc is None or doc.status != "pending":
         return  # 멱등·pending 아니면 no-op(double-resolve/취소 방어).
     doc.status = "confirmed" if new_status == "approved" else "denied"
+    await session.flush()
+
+
+async def _resume_a2a_task_on_gate_resolve(session: AsyncSession, gate: Gate, new_status: str) -> None:
+    """HITL crux(story 7726a003, 문서 `a2a-hitl-input-auth-required-mapping-crux`, PO GO
+    2026-07-07 옵션 B): `A2ATask.task_metadata.linked_gate_id` 로 이 게이트에 연결된 task를
+    복귀시킨다. **writer(그 필드를 실제로 채우는 delegate-측 경로)는 별도 forward-work
+    스토리** — 오늘은 그 필드를 쓰는 경로가 전무해 이 함수는 항상 no-op(무회귀). approve→
+    `TASK_STATE_WORKING`(재개, 이후 기존 reply-thread 폴링이 COMPLETED까지 캐리) ·
+    reject→`TASK_STATE_REJECTED`(기존 terminal state, 신규 처리 불요).
+    """
+    if new_status not in ("approved", "rejected"):
+        return
+    from app.models.a2a_task import A2ATask  # 순환 회피 lazy import.
+
+    task = (await session.execute(
+        select(A2ATask).where(
+            A2ATask.task_metadata["linked_gate_id"].astext == str(gate.id),
+            A2ATask.state == "TASK_STATE_INPUT_REQUIRED",
+        )
+    )).scalar_one_or_none()
+    if task is None:
+        return  # 링크 없음(writer 미배선) 또는 이미 다른 경로로 해소됨 — no-op.
+    task.state = "TASK_STATE_WORKING" if new_status == "approved" else "TASK_STATE_REJECTED"
     await session.flush()
 
 

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -1252,3 +1252,125 @@ async def test_agent_card_advertises_bearer_security_scheme():
         assert key in requirements[0]["schemes"]
     finally:
         app.dependency_overrides.clear()
+
+
+# ── HITL crux(story 7726a003) — INPUT_REQUIRED reader ─────────────────────────
+
+@pytest.mark.anyio
+async def test_get_task_input_required_when_linked_gate_pending():
+    """AC(Q2 reader): WORKING task + task_metadata.linked_gate_id가 pending Gate를 가리키면
+    reply-thread 폴링 전에 INPUT_REQUIRED로 단락(폴링 스킵 — delivery/timeout 로직 미도달)."""
+    client, session, app = await _authed_client(uuid.uuid4())
+    try:
+        member = _mock_member()
+        gate_id = uuid.uuid4()
+        task = _mock_task("TASK_STATE_WORKING", task_metadata={"linked_gate_id": str(gate_id)})
+        gate = MagicMock()
+        gate.status = "pending"
+
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _result(member)
+            if call_count == 2:
+                return _result(task)
+            if call_count == 3:
+                return _result(gate)
+            raise AssertionError("reply-thread 폴링까지 도달하면 안 됨(INPUT_REQUIRED 단락 실패)")
+
+        session.execute = mock_execute
+
+        req = {"jsonrpc": "2.0", "id": 6, "method": "GetTask", "params": {"id": str(task.id)}}
+
+        async with client as c:
+            resp = await c.post(f"/api/v2/a2a/members/{MEMBER_ID}/rpc", json=req)
+
+        body = resp.json()
+        assert body["result"]["status"]["state"] == "TASK_STATE_INPUT_REQUIRED"
+        assert call_count == 3
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_task_working_continues_when_linked_gate_not_pending():
+    """linked_gate_id가 있어도 Gate.status != 'pending'(예: approved)이면 정상 reply-thread
+    폴링 경로로 폴백 — 무회귀(WORKING 유지, 아직 답신 없으면)."""
+    client, session, app = await _authed_client(uuid.uuid4())
+    try:
+        member = _mock_member()
+        gate_id = uuid.uuid4()
+        root_message_id = uuid.uuid4()
+        task = _mock_task(
+            "TASK_STATE_WORKING", root_message_id=root_message_id,
+            task_metadata={"linked_gate_id": str(gate_id)},
+        )
+        gate = MagicMock()
+        gate.status = "approved"
+
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _result(member)
+            if call_count == 2:
+                return _result(task)
+            if call_count == 3:
+                return _result(gate)
+            if call_count == 4:
+                return _result(None)  # thread 폴링 — 아직 답신 없음
+            return _list_result([])  # delivery row 없음
+
+        session.execute = mock_execute
+
+        req = {"jsonrpc": "2.0", "id": 7, "method": "GetTask", "params": {"id": str(task.id)}}
+
+        async with client as c:
+            resp = await c.post(f"/api/v2/a2a/members/{MEMBER_ID}/rpc", json=req)
+
+        body = resp.json()
+        assert body["result"]["status"]["state"] == "TASK_STATE_WORKING"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_task_input_required_state_persists_without_regate_check():
+    """이미 INPUT_REQUIRED인 task는 재판정 없이 그대로 반환 — 복귀는 transition_gate()
+    전담(여기서 낙관적으로 되돌리지 않음). Gate 재조회/reply-thread 폴링 모두 안 함."""
+    client, session, app = await _authed_client(uuid.uuid4())
+    try:
+        member = _mock_member()
+        task = _mock_task(
+            "TASK_STATE_INPUT_REQUIRED",
+            task_metadata={"linked_gate_id": str(uuid.uuid4())},
+        )
+
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _result(member)
+            if call_count == 2:
+                return _result(task)
+            raise AssertionError("INPUT_REQUIRED 재진입 시 추가 쿼리 발생하면 안 됨")
+
+        session.execute = mock_execute
+
+        req = {"jsonrpc": "2.0", "id": 8, "method": "GetTask", "params": {"id": str(task.id)}}
+
+        async with client as c:
+            resp = await c.post(f"/api/v2/a2a/members/{MEMBER_ID}/rpc", json=req)
+
+        body = resp.json()
+        assert body["result"]["status"]["state"] == "TASK_STATE_INPUT_REQUIRED"
+        assert call_count == 2
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_e_cage_referee_p3_gate_object.py
+++ b/backend/tests/test_e_cage_referee_p3_gate_object.py
@@ -354,6 +354,81 @@ async def test_transition_rejected_empty_note_graceful():
     assert gate.resolution_note is None
 
 
+# ── HITL crux(story 7726a003) — A2A task INPUT_REQUIRED 복귀(Q3 writer-side resolver) ─────
+
+@pytest.mark.anyio
+async def test_resume_a2a_task_working_on_approve():
+    """연결된 A2ATask(INPUT_REQUIRED)가 있으면 approve 시 WORKING으로 복귀."""
+    from app.services.gate_service import _resume_a2a_task_on_gate_resolve
+
+    gate = MagicMock()
+    gate.id = GATE_ID
+    task = MagicMock()
+    task.state = "TASK_STATE_INPUT_REQUIRED"
+
+    session = AsyncMock()
+    task_r = MagicMock()
+    task_r.scalar_one_or_none.return_value = task
+    session.execute = AsyncMock(return_value=task_r)
+    session.flush = AsyncMock()
+
+    await _resume_a2a_task_on_gate_resolve(session, gate, "approved")
+    assert task.state == "TASK_STATE_WORKING"
+
+
+@pytest.mark.anyio
+async def test_resume_a2a_task_rejected_on_reject():
+    """연결된 A2ATask가 있으면 reject 시 REJECTED(기존 terminal state)로 전이."""
+    from app.services.gate_service import _resume_a2a_task_on_gate_resolve
+
+    gate = MagicMock()
+    gate.id = GATE_ID
+    task = MagicMock()
+    task.state = "TASK_STATE_INPUT_REQUIRED"
+
+    session = AsyncMock()
+    task_r = MagicMock()
+    task_r.scalar_one_or_none.return_value = task
+    session.execute = AsyncMock(return_value=task_r)
+    session.flush = AsyncMock()
+
+    await _resume_a2a_task_on_gate_resolve(session, gate, "rejected")
+    assert task.state == "TASK_STATE_REJECTED"
+
+
+@pytest.mark.anyio
+async def test_resume_a2a_task_noop_when_no_linked_task():
+    """writer 미배선(오늘 기본상태) — 연결된 task가 없으면 no-op·무크래시."""
+    from app.services.gate_service import _resume_a2a_task_on_gate_resolve
+
+    gate = MagicMock()
+    gate.id = GATE_ID
+
+    session = AsyncMock()
+    task_r = MagicMock()
+    task_r.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=task_r)
+    session.flush = AsyncMock()
+
+    await _resume_a2a_task_on_gate_resolve(session, gate, "approved")
+    session.flush.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_resume_a2a_task_skips_query_for_non_terminal_status():
+    """new_status가 approved/rejected가 아니면(auto_passed 등) 쿼리조차 안 함."""
+    from app.services.gate_service import _resume_a2a_task_on_gate_resolve
+
+    gate = MagicMock()
+    gate.id = GATE_ID
+
+    session = AsyncMock()
+    session.execute = AsyncMock()
+
+    await _resume_a2a_task_on_gate_resolve(session, gate, "auto_passed")
+    session.execute.assert_not_called()
+
+
 # ── org 격리 ──────────────────────────────────────────────────────────────────
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- crux doc `a2a-hitl-input-auth-required-mapping-crux`(PO GO 2026-07-07, 옵션 B) 그대로 구현.
- `GetTask`: `TASK_STATE_WORKING` task가 `task_metadata.linked_gate_id`로 pending `Gate`를 가리키면 reply-thread 폴링 전에 `TASK_STATE_INPUT_REQUIRED`로 단락(org-scoped gate lookup, `Gate.org_id == member.org_id`). `INPUT_REQUIRED` 재진입 시 재판정 없음 — 복귀는 `transition_gate()` 전담.
- `transition_gate()`: 기존 workflow_line/legacy-story/doc-gate 분기와 동형으로 `_resume_a2a_task_on_gate_resolve` 3번째 분기 추가 — approve→`WORKING`(재개, 이후 기존 reply-thread 폴링이 COMPLETED까지 캐리) / reject→`REJECTED`(기존 terminal state, 신규 처리 불요).
- `AUTH_REQUIRED`는 스코프 제외(코드 전체에 credential/auth-pending 신호 0 — 배선하면 아무도 트리거 못 하는 죽은 상태).
- **writer(delegate 에이전트가 `linked_gate_id`를 실제로 채우는 경로)는 이번 스코프에서 impl 안 함** — 6개 `create_gate()` 호출지점이 A2A 컨텍스트(conversation_id/task_id)를 전혀 모름(invasive 배관 필요), PO 명시 결정으로 별도 forward-work 스토리로 분리. 오늘은 이 필드를 쓰는 경로가 전무해 두 훅 모두 항상 no-op(무회귀).

## Test plan
- [x] `tests/test_a2a.py` 신규 3종: INPUT_REQUIRED 단락, non-pending gate 폴백(기존 폴링 경로), INPUT_REQUIRED 재진입 시 재판정 없음.
- [x] `tests/test_e_cage_referee_p3_gate_object.py` 신규 4종: approve→WORKING, reject→REJECTED, 연결 task 없으면 no-op, non-terminal status면 쿼리조차 안 함.
- [x] 기존 a2a/gate 관련 테스트 200+개 전부 통과(회귀 0).
- [x] 전체 백엔드 스위트: 3155 passed(+7 신규분), 7 failed는 이 PR과 무관한 pre-existing baseline(MCP python 경로 테스트).

🤖 Generated with [Claude Code](https://claude.com/claude-code)