### PR TITLE
fix(a2a): AgentCard interface url http-scheme 버그 — FASTAPI_URL SSOT로 교체 (story 52bb1975)

### DIFF
--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -89,6 +89,7 @@ from app.models.team import TeamMember
 from app.repositories.team_member import TeamMemberRepository
 from app.routers.agent_gateway import wake_agent
 from app.routers.events import _agent_connections
+from app.services.agent_onboarding_config import resolve_backend_direct_url
 from app.services.event_seq import assign_recipient_seq
 from app.services.webhook_targeting import active_webhook_member_ids
 from app.schemas.a2a import (
@@ -295,7 +296,6 @@ def _skill_matches(card: AgentCard, query: str) -> bool:
 
 @router.get("/members", response_model=list[AgentCard])
 async def list_agent_cards(
-    request: Request,
     skill: str | None = Query(default=None),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
@@ -307,7 +307,7 @@ async def list_agent_cards(
     repo = TeamMemberRepository(session, org_id)
     agents = await repo.list(type="agent", is_active=True)
 
-    base_url = str(request.base_url).rstrip("/")
+    base_url = resolve_backend_direct_url()
     cards = [await _build_agent_card(session, agent, base_url) for agent in agents]
 
     if skill:
@@ -319,11 +319,10 @@ async def list_agent_cards(
 @router.get("/members/{member_id}/agent-card.json")
 async def get_agent_card(
     member_id: uuid.UUID,
-    request: Request,
     session: AsyncSession = Depends(get_db),
 ) -> AgentCard:
     member = await _get_agent_member(session, member_id)
-    card = await _build_agent_card(session, member, str(request.base_url).rstrip("/"))
+    card = await _build_agent_card(session, member, resolve_backend_direct_url())
     return card
 
 

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -158,6 +158,43 @@ async def test_agent_card_200_reflects_role_template_skills():
 
 
 @pytest.mark.anyio
+async def test_agent_card_interface_url_uses_backend_direct_url_not_request_scheme():
+    """버그/A2A P0(story 52bb1975): 인터페이스 url은 request.base_url(Cloud Run 뒤에서 프록시
+    헤더 미신뢰 시 내부 스킴 http 노출)이 아니라 배포가 주입하는 FASTAPI_URL SSOT
+    (resolve_backend_direct_url, MCP onboarding config와 동일 소스)로 구성돼야 한다 —
+    테스트 클라이언트는 http://test로 요청해도 카드 url은 그 값을 반영하면 안 됨."""
+    from app.routers import a2a as a2a_mod
+
+    client, session, app = await _client()
+    try:
+        member = _mock_member()
+        persona = _mock_persona()
+
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            return _result(member) if call_count == 1 else _result(persona)
+
+        session.execute = mock_execute
+
+        with patch.object(
+            a2a_mod, "resolve_backend_direct_url",
+            return_value="https://sprintable-backend-dev-57iommnikq-du.a.run.app",
+        ):
+            async with client as c:
+                resp = await c.get(f"/api/v2/a2a/members/{MEMBER_ID}/agent-card.json")
+
+        card = resp.json()
+        url = card["supportedInterfaces"][0]["url"]
+        assert url.startswith("https://sprintable-backend-dev-57iommnikq-du.a.run.app/")
+        assert not url.startswith("http://test")
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_agent_card_prefers_role_template_skills_when_linked():
     """~300직군 카탈로그 S4: persona가 recruit_agent() 생성 marker(config.role_template_id)를
     가지면, 카드-빌드 시점에 그 role_template.skills(카탈로그 실시간 값)를 우선 반영 —


### PR DESCRIPTION
## Summary
- PO 라이브 실측: `GET /api/v2/a2a/members/{id}/agent-card.json`은 200이지만 `supportedInterfaces[0].url`이 `http://`(내부 스킴)로 발급됨 — A2A 스펙 "MUST HTTPS in production" 위반, 실 클라이언트가 SendMessage(위임)를 못 보냄.
- 근본원인: `_build_agent_card` 호출부(`list_agent_cards`/`get_agent_card`)가 URL을 `str(request.base_url)`로 구성 — Cloud Run이 TLS를 엣지에서 종료·컨테이너엔 평문 HTTP로 포워딩하는데 앱에 `X-Forwarded-Proto` 신뢰 설정이 없어 Starlette가 내부 스킴을 그대로 노출.
- repo 전체 스캔(`request.base_url`/`url_for`/`request.url.scheme`) 결과 이 2곳이 유일 — 시스템 클래스(ProxyHeadersMiddleware 부재) 문제가 아니라 a2a.py 고립 케이스로 확定(다른 절대 URL 생성은 전부 `settings.app_url` config-driven).
- fix: `request.base_url` 대신 배포가 이미 주입하는 `FASTAPI_URL` env(`resolve_backend_direct_url()`, MCP onboarding config와 동일 SSOT)로 URL 구성. 미사용 `request: Request` 파라미터도 함께 제거.

## Live verification
공식 `a2a-sdk`(PyPI)로 수정 전 배포의 정확한 실패를 재현:
```
A2ACardResolver.get_agent_card(): OK
ClientFactory.create(card): OK
client.send_message(): FAILED — A2AClientError("HTTP Error 302: Redirect
  http://sprintable-backend-dev-....run.app/... → https://...")
```
JSON-RPC POST가 Cloud Run의 http→https 302를 못 따라가 실패 — "발견은 되나 위임 반쪽"의 정확한 증거. 머지+dev 자동배포 후 같은 스크립트로 SendMessage→GetTask까지 재실측 예정.

## Test plan
- [x] 신규 테스트: interface url이 request scheme이 아니라 `resolve_backend_direct_url()`을 반영하는지 검증(`resolve_backend_direct_url` 패치 후 `http://test`(테스트 클라이언트 base_url) 미반영 확認).
- [x] 기존 a2a 테스트 전부 통과(회귀 0).
- [x] 전체 백엔드 스위트: 3156 passed(+1 신규분), 7 failed는 이 PR과 무관한 pre-existing baseline(MCP python 경로 테스트).
- [ ] 머지 후 dev 배포 확認 → 실 SDK E2E로 SendMessage→GetTask 재실측(PO 요청 AC2/AC3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)