### PR TITLE
fix(a2a): SendMessage 응답 envelope — bare Task→spec 준수 {task:...} 래퍼 (story 52bb1975 후속)

### DIFF
--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -498,7 +498,11 @@ async def _handle_send_message(
     task = (await session.execute(
         select(A2ATask).where(A2ATask.id == task_id)
     )).scalar_one()
-    return _task_to_dict(task)
+    # 스펙(a2a.proto `rpc SendMessage(...) returns (SendMessageResponse)`) — result는 bare Task가
+    # 아니라 oneof 래퍼(`{"task": ...}` | `{"message": ...}`). GetTask/ListTasks와 달리(그쪽은
+    # 스펙상 bare Task/Task[] 리턴이 맞음) SendMessage만 이 래퍼가 필요 — 없으면 실 SDK 클라이언트
+    # 파서가 깨진다(a2a-sdk 라이브 실측, story 52bb1975 후속).
+    return {"task": _task_to_dict(task)}
 
 
 async def _handle_get_task(

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -458,7 +458,7 @@ async def test_send_message_working_when_webhook_configured():
 
         assert resp.status_code == 200
         body = resp.json()
-        assert body["result"]["status"]["state"] == "TASK_STATE_WORKING"
+        assert body["result"]["task"]["status"]["state"] == "TASK_STATE_WORKING"
         assert body["error"] is None
     finally:
         app.dependency_overrides.clear()
@@ -497,7 +497,7 @@ async def test_send_message_working_when_member_has_multiple_active_webhooks():
 
         assert resp.status_code == 200
         body = resp.json()
-        assert body["result"]["status"]["state"] == "TASK_STATE_WORKING"
+        assert body["result"]["task"]["status"]["state"] == "TASK_STATE_WORKING"
         assert body["error"] is None
     finally:
         app.dependency_overrides.clear()
@@ -539,7 +539,46 @@ async def test_send_message_working_via_sse_pipeline_when_no_webhook():
 
         assert resp.status_code == 200
         body = resp.json()
-        assert body["result"]["status"]["state"] == "TASK_STATE_WORKING"
+        assert body["result"]["task"]["status"]["state"] == "TASK_STATE_WORKING"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_send_message_response_wraps_task_in_spec_envelope():
+    """버그(story 52bb1975 후속, 실 a2a-sdk E2E 적출): a2a.proto `SendMessageResponse`는
+    bare Task가 아니라 oneof 래퍼(`{"task": {...}}`) — 안 씌우면 실 클라이언트 파서가
+    "SendMessageResponse has no field named 'id'"로 깨짐(라이브 실측). result의 최상위 키가
+    task의 필드(id/contextId 등)가 아니라 정확히 `task` 하나여야 한다."""
+    client, session, app = await _authed_client(uuid.uuid4())
+    try:
+        member = _mock_member()
+        working_task = _mock_task("TASK_STATE_WORKING")
+
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _result(member)
+            if call_count == 2:
+                return _list_result([])  # webhook 없음 → SSE 경로
+            return _result(working_task)
+
+        session.execute = mock_execute
+        session.flush = AsyncMock()
+        session.commit = AsyncMock()
+
+        with patch("app.routers.a2a.deliver_conversation_message_webhook", new_callable=AsyncMock), \
+             patch("app.routers.a2a.assign_recipient_seq", new_callable=AsyncMock, return_value=1), \
+             patch("app.routers.a2a.wake_agent"):
+            async with client as c:
+                resp = await c.post(f"/api/v2/a2a/members/{MEMBER_ID}/rpc", json=_SEND_REQ)
+
+        body = resp.json()
+        assert set(body["result"].keys()) == {"task"}
+        assert body["result"]["task"]["id"] == str(working_task.id)
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary
- #1953(https scheme fix) 배포 후 공식 `a2a-sdk`로 라이브 재실측하다가 새 갭 적출: `A2ACardResolver`→`ClientFactory.create()`까지는 OK, `send_message()`에서 `ParseError('SendMessageResponse has no field named "id"')`.
- 근본원인: `a2a.proto`의 `rpc SendMessage(...) returns (SendMessageResponse)` — response는 oneof 래퍼(`{"task": Task} | {"message": Message}`)여야 하는데 `_handle_send_message`가 bare Task 필드를 그대로 `result`에 리턴 → 실 클라이언트 파서가 깨짐.
- `GetTask`(`returns (Task)`)·`ListTasks`(`ListTasksResponse{tasks, next_page_token, page_size, total_size}`)는 proto 재검증 결과 이미 스펙 정합 — `_METHODS` 3개 전수 확認, **SendMessage만의 갭**.
- fix: `_handle_send_message` 최종 리턴을 `{"task": _task_to_dict(task)}`로 래핑.

## Live verification
수정 전(현재 develop) 배포에서 raw JSON-RPC로 정확한 증상 확認:
```json
{"jsonrpc":"2.0","id":1,"result":{"id":"...","contextId":"...","status":{...},"artifacts":[],"history":[...]}}
```
→ 스펙이 요구하는 `{"result":{"task":{...}}}` 형태가 아니라 Task 필드가 top-level에 그대로 노출됨.

## Test plan
- [x] 기존 3개 SendMessage 테스트의 result 경로 갱신(`result.status`→`result.task.status`, envelope 변경 반영).
- [x] 신규 테스트: envelope shape 자체를 명시 검증(`set(body["result"].keys()) == {"task"}`).
- [x] `tests/test_a2a.py` 41 passed(회귀 0).
- [x] 전체 백엔드 스위트: 3157 passed(+2 신규분), 7 failed는 이 PR과 무관한 pre-existing baseline(MCP python 경로 테스트).
- [ ] 머지 후 dev 배포 확認 → 공식 `a2a-sdk`로 발견→SendMessage→GetTask **ParseError 없이 green** 최종 재실측(PO 요청, story 52bb1975 AC2/AC3 완결).

🤖 Generated with [Claude Code](https://claude.com/claude-code)