### PR TITLE
fix(a2a): 위임 완수(WORKING→COMPLETED) 채널-불가지 근본 fix (story ebd5cf18)

### DIFF
--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -398,6 +398,22 @@ async def _handle_send_message(
     root_message_id = uuid.uuid4()
     now = datetime.now(timezone.utc)
 
+    # 완료 라운드트립 크럭스(story ebd5cf18, 문서 `a2a-task-completion-roundtrip-crux`, PO GO
+    # 2026-07-08): 완료 신호(=이 메시지 스레드에 답신)는 실동작하는 메커니즘이나(실측 GREEN),
+    # delegate 가 reply-target(root_message_id)을 전달 페이로드에서 알아낼 길이 없었다(webhook
+    # 경로는 Discord 렌더러가 그 필드를 안 읽음·fakechat 클라 노출 여부도 레포 밖이라 불확定).
+    # 채널-불가지 근본 fix: delegate 가 실제로 받는 content 자체에 완료 프로토콜을 박아넣는다 —
+    # 두 전달 경로(webhook/fakechat)가 이 문자열을 공유하므로 매체와 무관하게 항상 도달한다.
+    # `history`(원본 client 메시지, `incoming.model_dump()`)는 안 건드려 A2A 관찰가능성 무회귀.
+    completion_hint = (
+        "\n\n---\n[A2A] 이 task의 완료 신호는 이 메시지 스레드에 대한 답신입니다.\n"
+        f"reply_thread_id: {root_message_id}\n"
+        f"conversation_id: {conv_id}\n"
+        "완료 시 sprintable_send_chat_message(thread_id=conversation_id, "
+        "reply_thread_id=reply_thread_id, content=<결과>)로 회신하세요."
+    )
+    delivered_content = text + completion_hint
+
     session.add(Conversation(
         id=conv_id,
         project_id=member_project_id,
@@ -412,7 +428,7 @@ async def _handle_send_message(
         id=root_message_id,
         conversation_id=conv_id,
         sender_id=None,
-        content=text,
+        content=delivered_content,
         thread_id=None,
         created_at=now,
     ))
@@ -441,7 +457,7 @@ async def _handle_send_message(
             thread_id=None,
             created_at=now,
             mentioned_ids=None,
-            content=text,
+            content=delivered_content,
             targets=None,
         )
     else:
@@ -458,7 +474,7 @@ async def _handle_send_message(
         event_payload = {
             "message_id": str(root_message_id),
             "conversation_id": str(conv_id),
-            "content": text,
+            "content": delivered_content,
         }
         if project_context is not None:
             event_payload["project_context"] = project_context

--- a/backend/app/services/discord_webhook.py
+++ b/backend/app/services/discord_webhook.py
@@ -25,15 +25,19 @@ def to_discord_message_payload(payload: dict) -> dict:
     """
     content_text = (payload.get("content") or "")[:500]
     conversation_id = payload.get("conversation_id", "")
-    thread_id = payload.get("thread_id") or ""
+    # 정합 버그 fix(story ebd5cf18 크럭스 부수 발견, PO 승인): 예전엔 payload["thread_id"]를
+    # "message_id"로 오라벨했다 — 루트 메시지는 thread_id가 항상 None(자기 자신이 스레드
+    # 시작점)이라 정작 회신-대상 식별이 가장 필요한 순간(새 task 도착)에 표시가 사라졌다.
+    # 이 메시지 자신의 id(payload["message_id"])를 보여줘야 수신자가 그걸로 스레드 답신 가능.
+    message_id = payload.get("message_id") or ""
 
     discord_content = "📩 **새 메시지**"
     if content_text:
         discord_content += f"\n{content_text}"
     if conversation_id:
         discord_content += f"\n\nconversation_id: {conversation_id}"
-    if thread_id:
-        discord_content += f"\nmessage_id: {thread_id}"
+    if message_id:
+        discord_content += f"\nmessage_id: {message_id}"
 
     result: dict = {"content": discord_content}
     app_url = os.environ.get("NEXT_PUBLIC_APP_URL", "")

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -584,6 +584,57 @@ async def test_send_message_response_wraps_task_in_spec_envelope():
 
 
 @pytest.mark.anyio
+async def test_send_message_delivered_content_embeds_completion_protocol_hint():
+    """근본 fix(story ebd5cf18, 문서 `a2a-task-completion-roundtrip-crux`, PO GO 2026-07-08):
+    delegate에게 실제로 전달되는 content 자체에 완료 프로토콜(reply_thread_id=root_message_id·
+    conversation_id) 힌트가 파싱 가능한 `key: value` 라인으로 박혀 있어야 한다 — 전달 채널
+    (webhook/fakechat)과 무관하게 항상 도달(채널-불가지 fix)."""
+    import re
+
+    client, session, app = await _authed_client(uuid.uuid4())
+    try:
+        member = _mock_member()
+        working_task = _mock_task("TASK_STATE_WORKING")
+
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _result(member)
+            if call_count == 2:
+                return _list_result([MEMBER_ID])  # webhook 있음
+            return _result(working_task)
+
+        session.execute = mock_execute
+        session.flush = AsyncMock()
+        session.commit = AsyncMock()
+
+        with patch("app.routers.a2a.deliver_conversation_message_webhook", new_callable=AsyncMock) as mock_deliver:
+            async with client as c:
+                resp = await c.post(f"/api/v2/a2a/members/{MEMBER_ID}/rpc", json=_SEND_REQ)
+            assert resp.status_code == 200
+
+        delivered_content = mock_deliver.call_args.kwargs["content"]
+
+        # session.add로 실제 생성된 Conversation/ConversationMessage에서 진짜 id를 뽑아 대조
+        added = [c.args[0] for c in session.add.call_args_list]
+        conv = next(o for o in added if type(o).__name__ == "Conversation")
+        root_msg = next(o for o in added if type(o).__name__ == "ConversationMessage")
+
+        assert f"reply_thread_id: {root_msg.id}" in delivered_content
+        assert f"conversation_id: {conv.id}" in delivered_content
+        assert "sprintable_send_chat_message" in delivered_content
+        # 저장된 ConversationMessage.content 자체에도 동일 힌트가 있어야(채널 무관 단일 소스)
+        assert root_msg.content == delivered_content
+        # 원본 client 메시지 텍스트는 파싱 안전성을 위해 힌트와 정규식으로 분리 가능해야 함
+        assert re.search(r"reply_thread_id: [0-9a-f-]{36}", delivered_content)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_send_message_invalid_params_returns_jsonrpc_error():
     client, session, app = await _authed_client(uuid.uuid4())
     try:

--- a/backend/tests/test_c60dd33c_webhook_payload_gating.py
+++ b/backend/tests/test_c60dd33c_webhook_payload_gating.py
@@ -58,6 +58,23 @@ def test_conversation_message_payload_unchanged_regression():
     assert "안녕" in out["content"] and "conversation_id: c1" in out["content"]
 
 
+def test_message_id_line_reads_own_id_not_thread_id():
+    """버그 fix(story ebd5cf18 크럭스 부수 발견): "message_id:" 라인은 이 메시지 자신의
+    id(payload["message_id"])를 보여야 한다 — 예전엔 payload["thread_id"]를 오라벨해서,
+    thread_id가 항상 None인 루트 메시지(새 A2A task 등)에선 표시가 통째로 사라졌다."""
+    out = to_discord_message_payload({
+        "content": "hi", "conversation_id": "c1", "message_id": "m1", "thread_id": None,
+    })
+    assert "message_id: m1" in out["content"]
+    assert "message_id: None" not in out["content"]
+
+
+def test_message_id_line_absent_when_no_message_id_in_payload():
+    """message_id 자체가 payload에 없으면(예: deliver_injected_event_webhook 경로) 라인 생략."""
+    out = to_discord_message_payload({"content": "hi", "conversation_id": "c1"})
+    assert "message_id:" not in out["content"]
+
+
 # ─── fire_webhooks 통합: discord 변환 + 게이팅 ────────────────────────────────
 
 def _session(configs):

--- a/backend/tests/test_s0_2_chat_migration.py
+++ b/backend/tests/test_s0_2_chat_migration.py
@@ -25,10 +25,15 @@ def test_discord_payload_uses_conversation_id():
 
 
 def test_discord_payload_uses_message_id():
-    """_to_discord_payload에서 message_id 필드명 사용 (reply_id 아님)."""
+    """_to_discord_payload에서 message_id 필드명 사용 (reply_id 아님).
+
+    버그 fix(story ebd5cf18 크럭스 부수 발견, PO 승인 2026-07-08): 원래 이 라인이 자기 자신의
+    payload["thread_id"]를 "message_id"로 잘못 라벨링했다 — 루트 메시지는 thread_id가 항상
+    None이라 새 task 도착 시점에 정작 필요한 회신-대상 정보가 사라졌다. payload["message_id"]
+    (메시지 자신의 id)를 읽어야 한다."""
     from app.services.conversation_webhook import _to_discord_payload
     source = inspect.getsource(_to_discord_payload)
-    assert "message_id: {thread_id}" in source
+    assert "message_id: {message_id}" in source
     assert "reply_id:" not in source
 
 
@@ -51,7 +56,7 @@ def test_to_discord_payload_content_fields():
     payload = {
         "content": "안녕하세요",
         "conversation_id": "conv-abc-123",
-        "thread_id": "msg-xyz-456",
+        "message_id": "msg-xyz-456",
     }
     result = _to_discord_payload(payload)
     content = result["content"]


### PR DESCRIPTION
## Summary
crux doc `a2a-task-completion-roundtrip-crux`(PO GO 2026-07-08). 라이브 수동 round-trip으로 완료 메커니즘(reply-thread 폴링) 자체는 실동작함을 실증(SendMessage→root message 답신→GetTask COMPLETED+artifact 확認) — 진짜 갭은 delegate가 reply-target(root_message_id)을 전달 페이로드에서 알아낼 방법이 없었다는 디스커버러빌리티 문제.

- **fix 1(근본)**: `_handle_send_message`가 delegate에게 실제로 전달하는 `content` 자체에 완료 프로토콜 힌트(`reply_thread_id`/`conversation_id`, 파싱 가능한 `key: value` 라인)를 내장. webhook/fakechat 두 전달 경로가 이 문자열을 공유해 채널-불가지. `history`(원본 client 메시지)는 무변경 — A2A 관찰가능성 보존.
- **fix 2(부수 발견, PO 승인)**: `discord_webhook.py:to_discord_message_payload`가 `payload["thread_id"]`를 "message_id"로 오라벨 — 루트 메시지는 `thread_id`가 항상 `None`이라 새 task 도착 시점에 정작 필요한 정보가 사라졌다. `payload["message_id"]`(메시지 자신의 id)를 읽도록 교정. 이 필드-오독을 "정상"으로 pin하던 기존 회귀테스트(`test_s0_2_chat_migration.py`) 2종도 교정된 기대값으로 갱신.

## Test plan
- [x] content 힌트 검증 1종(실제 생성된 Conversation/ConversationMessage id와 대조, webhook delivery 호출 인자 검증).
- [x] discord 렌더러 fix 검증 2종 신규(`message_id` 라인이 올바른 필드 반영·부재 시 생략).
- [x] 기존 pin 테스트 2종(`test_s0_2_chat_migration.py`) 교정된 기대값으로 갱신 — 버그를 "정상"으로 고정하던 assertion 수정.
- [x] 전체 백엔드 스위트: 3160 passed(+2 순증), 7 failed는 이 PR과 무관한 pre-existing baseline(MCP python 경로 테스트).
- [x] 머지 후 dev 배포 확認 → **수동 개입 0**으로 공식 a2a-sdk E2E 자동화 스크립트가 delivered content에서 reply-target 파싱→자동 회신→GetTask COMPLETED+artifact 라이브 green 재실측 완료(2026-07-08 01:46, task `8ce3e1de-d759-4747-a756-d9e1aeba59c1`): SendMessage→content 정규식 파싱(reply_thread_id/conversation_id)→auto-reply→GetTask state=3(COMPLETED)+artifact(`57083cd4-...`, name=`agent-reply`) 확認. story `ebd5cf18` done 처리 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)