### PR TITLE
feat(recruit): 전 런타임 올지원(first-class) — 5종 승격 + AGENTS.md 모델별 instruction (story 6f6ac081)

### DIFF
--- a/apps/web/src/app/(authenticated)/agents/recruiter/recruiter-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/agents/recruiter/recruiter-client.test.tsx
@@ -44,10 +44,13 @@ function mkCap(overrides: Partial<RuntimeCapabilityItem> & Pick<RuntimeCapabilit
 }
 
 describe('splitRuntimeCapabilities (E-RECRUIT S6)', () => {
-  it('splits the BE-not-deployed fallback into 1 supported + 3 coming-soon, preserving order', () => {
+  it('splits the fallback into all 10 supported + 0 coming-soon (전 런타임 올지원, story 6f6ac081)', () => {
     const { supported, comingSoon } = splitRuntimeCapabilities(RUNTIME_CAPABILITIES_FALLBACK);
-    expect(supported.map((r) => r.slug)).toEqual(['claude-code']);
-    expect(comingSoon.map((r) => r.slug)).toEqual(['codex', 'gemini', 'cursor']);
+    expect(supported.map((r) => r.slug)).toEqual([
+      'claude-code', 'codex', 'connector', 'cursor', 'gemini',
+      'grok', 'hermes', 'openclaw', 'opencode', 'pi',
+    ]);
+    expect(comingSoon).toEqual([]);
   });
 
   it('splits a real BE response (PR #1911) with multiple supported runtimes, incl. connector as a normal entry', () => {
@@ -87,35 +90,41 @@ describe('pickDefaultRuntime (E-RECRUIT S6 — avoids recruit() 400 on an unsupp
   });
 });
 
-// 실측: PR #1911 브랜치를 로컬 uvicorn(8001)으로 띄우고 실 사용자 JWT로 curl한 그대로(2026-07-06,
-// 순서는 BE가 slug 알파벳순 정렬해 반환한 그대로 보존). 이 고정값이 실제로 바뀌면 계약 드리프트니
-// 이 테스트가 먼저 깨져야 한다(회귀 가드).
+// 전 런타임 올지원(story 6f6ac081, 문서 `runtime-full-support-firstclass-crux`, PO GO
+// 2026-07-08) 후 기대 계약(BE `list_runtime_capabilities()` SSOT와 동기화, 순서는 BE가 slug
+// 알파벳순 정렬해 반환하는 그대로 보존). 이 고정값이 실제로 바뀌면 계약 드리프트니 이 테스트가
+// 먼저 깨져야 한다(회귀 가드) — 배포 후 라이브 curl로 재확認 예정(디디).
 const REAL_BE_RESPONSE: RuntimeCapabilityItem[] = [
   { slug: 'claude-code', display_name: 'Claude Code', supported: true, tier: 'full', transport: 'stdio', mcp_transport: ['http', 'stdio'], prompt_file: 'CLAUDE.md', guide_filename: null, supports_event_push: true, icon: null },
-  { slug: 'codex', display_name: 'Codex', supported: true, tier: 'experimental', transport: 'stdio', mcp_transport: ['http', 'stdio'], prompt_file: 'AGENT_INSTRUCTIONS.md', guide_filename: null, supports_event_push: true, icon: null },
+  { slug: 'codex', display_name: 'Codex', supported: true, tier: 'full', transport: 'stdio', mcp_transport: ['http', 'stdio'], prompt_file: 'AGENTS.md', guide_filename: null, supports_event_push: true, icon: null },
   { slug: 'connector', display_name: 'Connector', supported: true, tier: 'experimental', transport: null, mcp_transport: [], prompt_file: 'AGENT_INSTRUCTIONS.md', guide_filename: 'CONNECTOR_SETUP.md', supports_event_push: false, icon: null },
-  { slug: 'cursor', display_name: 'Cursor', supported: true, tier: 'experimental', transport: 'stdio', mcp_transport: ['http', 'stdio'], prompt_file: 'AGENT_INSTRUCTIONS.md', guide_filename: null, supports_event_push: true, icon: null },
-  { slug: 'gemini', display_name: 'Gemini', supported: true, tier: 'experimental', transport: 'stdio', mcp_transport: ['http', 'stdio'], prompt_file: 'AGENT_INSTRUCTIONS.md', guide_filename: null, supports_event_push: true, icon: null },
-  { slug: 'grok', display_name: 'Grok', supported: false, tier: null, transport: null, mcp_transport: [], prompt_file: null, guide_filename: null, supports_event_push: false, icon: null },
-  { slug: 'hermes', display_name: 'Hermes', supported: false, tier: null, transport: null, mcp_transport: [], prompt_file: null, guide_filename: null, supports_event_push: false, icon: null },
-  { slug: 'openclaw', display_name: 'OpenClaw', supported: false, tier: null, transport: null, mcp_transport: [], prompt_file: null, guide_filename: null, supports_event_push: false, icon: null },
-  { slug: 'opencode', display_name: 'OpenCode', supported: false, tier: null, transport: null, mcp_transport: [], prompt_file: null, guide_filename: null, supports_event_push: false, icon: null },
-  { slug: 'pi', display_name: 'Pi', supported: false, tier: null, transport: null, mcp_transport: [], prompt_file: null, guide_filename: null, supports_event_push: false, icon: null },
+  { slug: 'cursor', display_name: 'Cursor', supported: true, tier: 'full', transport: 'stdio', mcp_transport: ['http', 'stdio'], prompt_file: 'AGENTS.md', guide_filename: null, supports_event_push: true, icon: null },
+  { slug: 'gemini', display_name: 'Gemini', supported: true, tier: 'full', transport: 'stdio', mcp_transport: ['http', 'stdio'], prompt_file: 'GEMINI.md', guide_filename: null, supports_event_push: true, icon: null },
+  { slug: 'grok', display_name: 'Grok', supported: true, tier: 'full', transport: null, mcp_transport: [], prompt_file: 'AGENTS.md', guide_filename: 'CONNECTOR_SETUP.md', supports_event_push: false, icon: null },
+  { slug: 'hermes', display_name: 'Hermes', supported: true, tier: 'full', transport: null, mcp_transport: [], prompt_file: 'AGENTS.md', guide_filename: 'CONNECTOR_SETUP.md', supports_event_push: false, icon: null },
+  { slug: 'openclaw', display_name: 'OpenClaw', supported: true, tier: 'full', transport: null, mcp_transport: [], prompt_file: 'AGENTS.md', guide_filename: 'CONNECTOR_SETUP.md', supports_event_push: false, icon: null },
+  { slug: 'opencode', display_name: 'OpenCode', supported: true, tier: 'full', transport: null, mcp_transport: [], prompt_file: 'AGENTS.md', guide_filename: 'CONNECTOR_SETUP.md', supports_event_push: false, icon: null },
+  { slug: 'pi', display_name: 'Pi', supported: true, tier: 'full', transport: null, mcp_transport: [], prompt_file: 'AGENTS.md', guide_filename: 'CONNECTOR_SETUP.md', supports_event_push: false, icon: null },
 ];
 
-describe('E-RECRUIT S6 — against the real captured GET /api/v2/runtime-capabilities response', () => {
-  it('splits into 5 supported (incl. connector) and 5 coming-soon', () => {
+describe('E-RECRUIT S6 — against the expected GET /api/v2/runtime-capabilities response (전 런타임 올지원)', () => {
+  it('splits into all 10 supported and 0 coming-soon', () => {
     const { supported, comingSoon } = splitRuntimeCapabilities(REAL_BE_RESPONSE);
-    expect(supported.map((r) => r.slug)).toEqual(['claude-code', 'codex', 'connector', 'cursor', 'gemini']);
-    expect(comingSoon.map((r) => r.slug)).toEqual(['grok', 'hermes', 'openclaw', 'opencode', 'pi']);
+    expect(supported.map((r) => r.slug)).toEqual([
+      'claude-code', 'codex', 'connector', 'cursor', 'gemini',
+      'grok', 'hermes', 'openclaw', 'opencode', 'pi',
+    ]);
+    expect(comingSoon).toEqual([]);
   });
 
-  it('exactly claude-code is tier=full (no badge); the other 4 supported are experimental (badge)', () => {
+  it('only connector is tier=experimental (badge); the other 9 are full (no badge)', () => {
     const { supported } = splitRuntimeCapabilities(REAL_BE_RESPONSE);
     const experimental = supported.filter((r) => r.tier === 'experimental').map((r) => r.slug);
     const full = supported.filter((r) => r.tier === 'full').map((r) => r.slug);
-    expect(full).toEqual(['claude-code']);
-    expect(experimental).toEqual(['codex', 'connector', 'cursor', 'gemini']);
+    expect(experimental).toEqual(['connector']);
+    expect(full).toEqual([
+      'claude-code', 'codex', 'cursor', 'gemini', 'grok', 'hermes', 'openclaw', 'opencode', 'pi',
+    ]);
   });
 
   it('default runtime stays claude-code (already first + tier=full)', () => {
@@ -123,12 +132,15 @@ describe('E-RECRUIT S6 — against the real captured GET /api/v2/runtime-capabil
     expect(pickDefaultRuntime(supported, 'claude-code')).toBe('claude-code');
   });
 
-  it("guideFilename derivation source: prompt_file carries the real per-runtime filename, guide_filename is connector-only", () => {
+  it("guideFilename derivation source: prompt_file carries the real per-runtime filename, guide_filename is connector-routed-only", () => {
     const bySlug = Object.fromEntries(REAL_BE_RESPONSE.map((r) => [r.slug, r]));
     expect(bySlug['claude-code'].prompt_file).toBe('CLAUDE.md');
-    expect(bySlug['codex'].prompt_file).toBe('AGENT_INSTRUCTIONS.md'); // generic fallback pre-S7 shaping
+    // 전 런타임 올지원(story 6f6ac081) — codex는 이제 확정 매핑(AGENTS.md), generic fallback 아님.
+    expect(bySlug['codex'].prompt_file).toBe('AGENTS.md');
+    expect(bySlug['grok'].prompt_file).toBe('AGENTS.md'); // 커넥터 전용 5종도 확정 매핑
     expect(bySlug['connector'].guide_filename).toBe('CONNECTOR_SETUP.md');
-    expect(bySlug['claude-code'].guide_filename).toBeNull(); // NOT where the regular filename lives
+    expect(bySlug['grok'].guide_filename).toBe('CONNECTOR_SETUP.md'); // 커넥터-라우팅이라 동일
+    expect(bySlug['claude-code'].guide_filename).toBeNull(); // MCP-native는 안내파일 없음
   });
 });
 

--- a/apps/web/src/services/recruit.ts
+++ b/apps/web/src/services/recruit.ts
@@ -74,8 +74,8 @@ export interface RuntimeCapabilityItem {
   slug: string;
   display_name: string;
   supported: boolean;
-  /** supported=false면 항상 null. "full"=확정 지침파일 매핑 있음(claude-code만)·"experimental"=
-   * config emit은 되나 S7 프롬프트 shaping 前 generic fallback(codex/gemini/cursor/connector). */
+  /** supported=false면 항상 null. "full"=확정 지침파일 매핑 있음(전 런타임 올지원 후 connector
+   * 제외 전부)·"experimental"=config emit은 되나 특정 툴 미확정이라 generic fallback(connector만). */
   tier: 'full' | 'experimental' | null;
   transport: string | null;
   mcp_transport: string[];
@@ -85,11 +85,19 @@ export interface RuntimeCapabilityItem {
   icon: string | null;
 }
 
-/** BE `runtime-capabilities` 미배포(디디 S6 미착지) 동안의 폴백 — S4 당시 하드코딩과 동일한
- * "Claude Code만 활성" 동작을 그대로 보존해 회귀 0(엔드포인트 배포되면 자동으로 동적 전환). */
+/** BE `runtime-capabilities` 미배포/장애 동안의 폴백 — 전 런타임 올지원(story 6f6ac081) 후 실
+ * SSOT(`list_runtime_capabilities()`)와 동기화한 스냅샷(2026-07-08). BE 엔드포인트 자체가
+ * 죽었을 때만 노출되는 극단 경로라 여기서 갱신을 놓쳐도 기능은 안 깨지나(회귀는 아님), 낡은
+ * "claude-code만" 상태를 보여주는 정합 갭이었음 — 실 응답과 동기화. */
 export const RUNTIME_CAPABILITIES_FALLBACK: RuntimeCapabilityItem[] = [
-  { slug: 'claude-code', display_name: 'Claude Code', supported: true, tier: 'full', transport: 'stdio', mcp_transport: ['stdio'], prompt_file: 'CLAUDE.md', guide_filename: null, supports_event_push: true, icon: null },
-  { slug: 'codex', display_name: 'Codex', supported: false, tier: null, transport: null, mcp_transport: [], prompt_file: null, guide_filename: null, supports_event_push: false, icon: null },
-  { slug: 'gemini', display_name: 'Gemini', supported: false, tier: null, transport: null, mcp_transport: [], prompt_file: null, guide_filename: null, supports_event_push: false, icon: null },
-  { slug: 'cursor', display_name: 'Cursor', supported: false, tier: null, transport: null, mcp_transport: [], prompt_file: null, guide_filename: null, supports_event_push: false, icon: null },
+  { slug: 'claude-code', display_name: 'Claude Code', supported: true, tier: 'full', transport: 'stdio', mcp_transport: ['http', 'stdio'], prompt_file: 'CLAUDE.md', guide_filename: null, supports_event_push: true, icon: null },
+  { slug: 'codex', display_name: 'Codex', supported: true, tier: 'full', transport: 'stdio', mcp_transport: ['http', 'stdio'], prompt_file: 'AGENTS.md', guide_filename: null, supports_event_push: true, icon: null },
+  { slug: 'connector', display_name: 'Connector', supported: true, tier: 'experimental', transport: null, mcp_transport: [], prompt_file: 'AGENT_INSTRUCTIONS.md', guide_filename: 'CONNECTOR_SETUP.md', supports_event_push: false, icon: null },
+  { slug: 'cursor', display_name: 'Cursor', supported: true, tier: 'full', transport: 'stdio', mcp_transport: ['http', 'stdio'], prompt_file: 'AGENTS.md', guide_filename: null, supports_event_push: true, icon: null },
+  { slug: 'gemini', display_name: 'Gemini', supported: true, tier: 'full', transport: 'stdio', mcp_transport: ['http', 'stdio'], prompt_file: 'GEMINI.md', guide_filename: null, supports_event_push: true, icon: null },
+  { slug: 'grok', display_name: 'Grok', supported: true, tier: 'full', transport: null, mcp_transport: [], prompt_file: 'AGENTS.md', guide_filename: 'CONNECTOR_SETUP.md', supports_event_push: false, icon: null },
+  { slug: 'hermes', display_name: 'Hermes', supported: true, tier: 'full', transport: null, mcp_transport: [], prompt_file: 'AGENTS.md', guide_filename: 'CONNECTOR_SETUP.md', supports_event_push: false, icon: null },
+  { slug: 'openclaw', display_name: 'OpenClaw', supported: true, tier: 'full', transport: null, mcp_transport: [], prompt_file: 'AGENTS.md', guide_filename: 'CONNECTOR_SETUP.md', supports_event_push: false, icon: null },
+  { slug: 'opencode', display_name: 'OpenCode', supported: true, tier: 'full', transport: null, mcp_transport: [], prompt_file: 'AGENTS.md', guide_filename: 'CONNECTOR_SETUP.md', supports_event_push: false, icon: null },
+  { slug: 'pi', display_name: 'Pi', supported: true, tier: 'full', transport: null, mcp_transport: [], prompt_file: 'AGENTS.md', guide_filename: 'CONNECTOR_SETUP.md', supports_event_push: false, icon: null },
 ];

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -23,8 +23,8 @@ from app.repositories.agent_persona import AgentPersonaRepository
 from app.schemas.recruit import RecruitRequest
 from app.schemas.team_member import OrgAgentCreate, TeamMemberResponse
 from app.services.agent_onboarding_config import (
-    CONNECTOR_RUNTIME,
     DEFAULT_RUNTIME,
+    MCP_NATIVE_RUNTIMES,
     SUPPORTED_RUNTIMES,
     SUPPORTED_TRANSPORTS,
     build_agent_mcp_config,
@@ -210,9 +210,12 @@ async def get_agent_connection_artifact(
             "content": default_persona.resolved_system_prompt,
         })
 
-    if runtime == CONNECTOR_RUNTIME:
-        # Q2(PO 확정): connector = 포인터/안내만 — SSE dial-out은 `.mcp.json`과 별개 프로토콜이라
-        # transport 파라미터 자체가 의미 없음(무시).
+    if runtime not in MCP_NATIVE_RUNTIMES:
+        # Q2(PO 확정) + 전 런타임 올지원(story 6f6ac081, PO 크럭스 승인): 범용 connector 버킷 +
+        # 커넥터 전용 5종(opencode/openclaw/hermes/grok/pi) 전부 이 분기 — 포인터/안내만(SSE
+        # dial-out은 `.mcp.json`과 별개 프로토콜이라 transport 파라미터 자체가 의미 없음/무시).
+        # 가드를 단일 sentinel(`== CONNECTOR_RUNTIME`) 대신 `not in MCP_NATIVE_RUNTIMES`로
+        # 반전한 이유: 전자는 커넥터 전용 5종을 그냥 통과시켜 `.mcp.json`을 오emit했다.
         resolved_transport = None
         mcp_config: dict | None = None
         files.append({"filename": "CONNECTOR_SETUP.md", "content": build_connector_guidance(runtime)})

--- a/backend/app/services/agent_onboarding_config.py
+++ b/backend/app/services/agent_onboarding_config.py
@@ -16,21 +16,33 @@ from __future__ import annotations
 import os
 
 DEFAULT_RUNTIME = "claude-code"
-# E-RECRUIT S5(story 4fca5a3e) Q1(PO 확정): S4 픽커 그대로 — MCP-native 4(claude-code primary +
-# codex/gemini/cursor, transport config 공통) + "connector" 통칭 1개(9종 SSE 어댑터 개별 확장 X).
+# 전 런타임 올지원(story 6f6ac081, 문서 `runtime-full-support-firstclass-crux`, PO GO
+# 2026-07-08): MCP-native 4(claude-code/codex/gemini/cursor, transport config 공통) +
+# 커넥터 전용 5(opencode/openclaw/hermes/grok/pi, 실 SSE 어댑터가 connectors/ 에 이미 존재 —
+# vaporware 아님) + 범용 "connector" 버킷(어댑터가 따로 없는 런타임용 포인터 안내).
 CONNECTOR_RUNTIME = "connector"
 MCP_NATIVE_RUNTIMES = frozenset({"claude-code", "codex", "gemini", "cursor"})
-SUPPORTED_RUNTIMES = MCP_NATIVE_RUNTIMES | {CONNECTOR_RUNTIME}
+CONNECTOR_ONLY_RUNTIMES = frozenset({"opencode", "openclaw", "hermes", "grok", "pi"})
+SUPPORTED_RUNTIMES = MCP_NATIVE_RUNTIMES | CONNECTOR_ONLY_RUNTIMES | {CONNECTOR_RUNTIME}
 STDIO = "stdio"
 HTTP = "http"
 SUPPORTED_TRANSPORTS = frozenset({STDIO, HTTP})
 
-# E-RECRUIT S5 G4: 런타임별 자율 운영 지침 파일명 — 블루프린트 §4 어댑터 3축 중 "지침 파일명" 축.
-# P0=claude-code 만 확정(CLAUDE.md); 나머지 MCP-native 런타임(codex=AGENTS.md·cursor=.cursorrules
-# 등)의 정식 매핑은 S7 shaping(PO 확정) — 미확정 런타임은 이 기본값으로 폴백(크래시 없이 최선의
-# 파일명 제공, 회귀 없이 확장 여지만 남김).
+# E-RECRUIT S5 G4 + 전 런타임 올지원(story 6f6ac081) — 런타임별 자율 운영 지침 파일명. 공식
+# 문서 실측(추측 0, crux doc에 출처 전부 명시): codex/cursor/grok/pi/hermes/openclaw/opencode
+# 7종이 `AGENTS.md`로 수렴(신흥 cross-tool 표준) — gemini만 `GEMINI.md` 예외. hermes는 우선순위
+# 체인(.hermes.md/HERMES.md→AGENTS.md→CLAUDE.md→.cursorrules)이라 우리가 AGENTS.md 하나만
+# emit해도 그 체인에서 정상 로드된다(더 앞순위 파일은 우리 쪽에서 안 만듦).
 _INSTRUCTION_FILENAMES: dict[str, str] = {
     "claude-code": "CLAUDE.md",
+    "gemini": "GEMINI.md",
+    "codex": "AGENTS.md",
+    "cursor": "AGENTS.md",
+    "grok": "AGENTS.md",
+    "pi": "AGENTS.md",
+    "hermes": "AGENTS.md",
+    "openclaw": "AGENTS.md",
+    "opencode": "AGENTS.md",
 }
 _DEFAULT_INSTRUCTION_FILENAME = "AGENT_INSTRUCTIONS.md"
 
@@ -58,28 +70,25 @@ def list_runtime_capabilities() -> list[dict]:
     """S6(유나/미르코 정합용) `GET /api/v2/runtime-capabilities` 계약 SSOT.
 
     supported/tier는 **S5 emit 코드 실기준**(과대약속 금지) — recruiter/connection-artifact가
-    그 런타임으로 실제 아티팩트를 만들 수 있으면 supported=true. ``build_agent_mcp_config``는
-    MCP-native 4종(claude-code/codex/gemini/cursor) 모두 런타임-무관 동일 config를 emit하므로
-    전부 supported=true — 단 ``resolve_instruction_filename``이 claude-code만 확정 매핑(CLAUDE.md)
-    이고 나머지는 S7 shaping 전이라 generic fallback이므로 tier="experimental". connector는
-    `.mcp.json`은 성립 안 하나(``build_agent_mcp_config``가 None 반환) 안내 파일(CONNECTOR_SETUP.md)
-    emit은 성공하므로 supported=true·실 어댑터 조립은 후속이라 tier="experimental".
+    그 런타임으로 실제 아티팩트를 만들 수 있으면 supported=true. 전 런타임 올지원(story
+    6f6ac081) 이후: MCP-native 4종은 `.mcp.json`(transport 선택 가능), 나머지 지원 런타임
+    (커넥터 전용 5종 + 범용 connector 버킷)은 전부 SSE 커넥터 경로(CONNECTOR_SETUP.md, transport
+    개념 자체가 없음) — 이 두 그룹의 경계가 ``MCP_NATIVE_RUNTIMES``(``is_connector_routed``)다.
+    tier는 ``_INSTRUCTION_FILENAMES``에 확정 매핑이 있으면 "full"(모든 지원 런타임이 이제 여기
+    포함 — 축2 완료), 없으면(현재 없음, 확장 여지만 유지) "experimental".
 
     PO 확인(2026-07-06): FE 픽커의 "곧 지원" 섹션이 채워지려면 **미지원 런타임도 응답에
-    포함**돼야 한다 — ``RuntimeType``(agent_runtime.py, member.runtime_type 9종 SSOT) 중
-    ``SUPPORTED_RUNTIMES``에 없는 5종(opencode/openclaw/hermes/grok/pi)은 recruit/
-    connection-artifact에 그 값 그대로 넘기면 400("unsupported runtime")이 난다 — 즉 개별
-    선택지로는 아직 미지원. ``supported=false``·``tier=None``으로 정직하게 반환한다(이들은
-    오늘도 ``connector`` 버킷을 통해 수동 가이드로는 연결 가능하나, 그건 별도 엔트리로 이미
-    표현됨 — 개별 런타임 엔트리 자체를 과대약속하지 않는다).
+    포함**돼야 한다 — ``RuntimeType``(agent_runtime.py, member.runtime_type 9종 SSOT) 전부가
+    이제 ``SUPPORTED_RUNTIMES``에 있어 "곧 지원" 섹션은 비게 된다(의도된 결과 — 전 런타임
+    올지원이 이 스토리의 목표).
     """
     from app.services.agent_runtime import RuntimeType
 
     out = []
     all_slugs = sorted({rt.value for rt in RuntimeType} | SUPPORTED_RUNTIMES)
     for runtime in all_slugs:
-        is_connector = runtime == CONNECTOR_RUNTIME
         supported = runtime in SUPPORTED_RUNTIMES
+        is_connector_routed = supported and runtime not in MCP_NATIVE_RUNTIMES
         out.append({
             "slug": runtime,
             "display_name": _RUNTIME_DISPLAY_NAMES.get(runtime, runtime),
@@ -89,11 +98,11 @@ def list_runtime_capabilities() -> list[dict]:
                 else "full" if runtime in _INSTRUCTION_FILENAMES
                 else "experimental"
             ),
-            "transport": None if (is_connector or not supported) else default_transport_for_hosting(),
-            "mcp_transport": [] if (is_connector or not supported) else sorted(SUPPORTED_TRANSPORTS),
+            "transport": None if (is_connector_routed or not supported) else default_transport_for_hosting(),
+            "mcp_transport": [] if (is_connector_routed or not supported) else sorted(SUPPORTED_TRANSPORTS),
             "prompt_file": resolve_instruction_filename(runtime) if supported else None,
-            "guide_filename": "CONNECTOR_SETUP.md" if is_connector else None,
-            "supports_event_push": supported and not is_connector,
+            "guide_filename": "CONNECTOR_SETUP.md" if is_connector_routed else None,
+            "supports_event_push": supported and not is_connector_routed,
             "icon": None,
         })
     return out
@@ -244,14 +253,17 @@ def build_agent_mcp_config(
 ) -> dict | None:
     """`.mcp.json` 아티팩트 generator — transport 별 SSOT(E-MCP-OPT S3).
 
-    E-RECRUIT S5: MCP-native 런타임(``MCP_NATIVE_RUNTIMES`` — transport config 공통, PO 확정)만
-    `.mcp.json`을 받는다. ``runtime == CONNECTOR_RUNTIME``이면 None(SSE dial-out은 완전 별개
-    프로토콜이라 `.mcp.json` 자체가 성립 안 함 — 호출부가 ``build_connector_guidance()``로 대체).
+    E-RECRUIT S5 + 전 런타임 올지원(story 6f6ac081): MCP-native 런타임(``MCP_NATIVE_RUNTIMES`` —
+    transport config 공통, PO 확정)만 `.mcp.json`을 받는다. 그 외(범용 ``connector`` 버킷 +
+    커넥터 전용 5종 ``CONNECTOR_ONLY_RUNTIMES``)는 전부 None(SSE dial-out은 완전 별개 프로토콜이라
+    `.mcp.json` 자체가 성립 안 함 — 호출부가 ``build_connector_guidance()``로 대체). 가드를
+    단일 sentinel(``== CONNECTOR_RUNTIME``) 대신 ``not in MCP_NATIVE_RUNTIMES``로 반전한 이유:
+    전자는 커넥터 전용 5종을 그냥 통과시켜 `.mcp.json`을 오emit했다(PO 크럭스 승인 fix).
 
     ``transport="http"`` 인데 이 환경에 호스팅 배포가 없으면(``MCP_PUBLIC_URL`` 미설정) None 반환 —
     호출부가 이를 "그 변형 생성 불가"로 취급(에러 아님).
     """
-    if runtime == CONNECTOR_RUNTIME:
+    if runtime not in MCP_NATIVE_RUNTIMES:
         return None
     if transport == HTTP:
         return _build_http_config(api_key_plaintext)
@@ -269,10 +281,11 @@ def build_agent_mcp_config_bundle(
     "mcp_config_alternatives": {<다른 transport>: <그 변형>, ...}}``. http 변형이 이 환경에서
     생성 불가(``MCP_PUBLIC_URL`` 미설정)면 alternatives 에서 생략(OSS 는 호스팅 탭 자체가 없음).
 
-    E-RECRUIT S5: ``runtime == CONNECTOR_RUNTIME``이면 mcp_config 자체가 성립 안 하므로 전부 None/
-    빈값(호출부가 ``build_connector_guidance()``로 안내 파일을 대신 emit — crash 대신 안전한 no-op).
+    E-RECRUIT S5 + 전 런타임 올지원(story 6f6ac081): MCP-native가 아니면(범용 connector 버킷 +
+    커넥터 전용 5종) mcp_config 자체가 성립 안 하므로 전부 None/빈값(호출부가
+    ``build_connector_guidance()``로 안내 파일을 대신 emit — crash 대신 안전한 no-op).
     """
-    if runtime == CONNECTOR_RUNTIME:
+    if runtime not in MCP_NATIVE_RUNTIMES:
         return {"default_transport": None, "mcp_config": None, "mcp_config_alternatives": {}}
 
     default_transport = default_transport_for_hosting()

--- a/backend/tests/test_e_recruit_s3_recruit_endpoint.py
+++ b/backend/tests/test_e_recruit_s3_recruit_endpoint.py
@@ -155,3 +155,39 @@ async def test_recruit_success_response_shape():
     assert response["default_transport"] == "stdio"
     assert response["mcp_config"] == bundle["mcp_config"]
     session.commit.assert_awaited_once()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("runtime", ["opencode", "openclaw", "hermes", "grok", "pi"])
+async def test_recruit_success_connector_only_runtime_mcp_config_null_no_crash(runtime):
+    """전 런타임 올지원(story 6f6ac081): 커넥터 전용 5종으로 recruit() — 실 SUPPORTED_RUNTIMES
+    가드 통과(400 아님) + 실 build_agent_mcp_config_bundle(mock 아님)이 mcp_config=None을
+    반환해도 응답 구성이 크래시 없이 완료돼야 한다."""
+    from app.routers.agents import recruit_agent_endpoint
+    from app.schemas.recruit import RecruitRequest
+
+    session = MagicMock()
+    session.commit = AsyncMock()
+    agent_id = uuid.uuid4()
+    member = SimpleNamespace(id=agent_id, project_id=uuid.uuid4())
+    role_template = SimpleNamespace(slug="backend", default_tool_groups=["stories", "tasks"])
+    persona = SimpleNamespace(id=uuid.uuid4(), system_prompt="합성된 지침 텍스트")
+    recruit_result = {
+        "persona": persona,
+        "api_key_plaintext": "sk_live_deadbeef",
+        "tool_allowlist": ["stories", "tasks"],
+    }
+
+    with patch("app.routers.agents.assert_agent_owner", AsyncMock(return_value=member)), \
+         patch("app.routers.agents.get_published_role_template", AsyncMock(return_value=role_template)), \
+         patch("app.routers.agents.recruit_agent", AsyncMock(return_value=recruit_result)), \
+         patch("app.routers.agents.emit_onboarding_event", AsyncMock()):
+        response = await recruit_agent_endpoint(
+            agent_id, RecruitRequest(role_template_slug="backend", runtime=runtime),
+            session=session, auth=_auth_ctx(), org_id=uuid.uuid4(),
+        )
+
+    assert response["default_transport"] is None
+    assert response["mcp_config"] is None
+    assert response["mcp_config_alternatives"] == {}
+    session.commit.assert_awaited_once()

--- a/backend/tests/test_e_recruit_s5_connection_artifact_realdb.py
+++ b/backend/tests/test_e_recruit_s5_connection_artifact_realdb.py
@@ -169,6 +169,39 @@ async def test_connection_artifact_connector_runtime_real_db():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 @pytest.mark.anyio
+@pytest.mark.parametrize("runtime", ["opencode", "openclaw", "hermes", "grok", "pi"])
+async def test_connection_artifact_connector_only_runtimes_real_db(runtime):
+    """전 런타임 올지원(story 6f6ac081): 커넥터 전용 5종도 connector 버킷과 동형 — mcp_config는
+    None, CONNECTOR_SETUP.md 포인터 파일 emit. 단 instruction 파일명은 확정 매핑이 있어(공식
+    문서 실측, crux doc 참조) generic AGENT_INSTRUCTIONS.md가 아니라 AGENTS.md."""
+    from unittest.mock import MagicMock
+    from sqlalchemy import text as _text
+    from app.core.database import Base
+    from app.routers.agents import get_agent_connection_artifact
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            agent, org_id = await _seed_agent(s, with_persona=True)
+
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            out = await get_agent_connection_artifact(
+                agent.id, runtime=runtime, session=s,
+                auth=MagicMock(), org_id=org_id,
+            )
+
+        assert out["mcp_config"] is None
+        filenames = {f["filename"] for f in out["files"]}
+        assert filenames == {"AGENTS.md", "CONNECTOR_SETUP.md"}
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
 async def test_connection_artifact_no_default_persona_omits_instruction_file():
     """까심 QA RC(S5): persona가 존재해도 전부 ``is_default=False``면(POST /agent-personas가
     is_default 생략 시 non-default 생성 가능 — "정확히 1개 default" 불변식 없음) list()의

--- a/backend/tests/test_ob1_agent_onboarding_config.py
+++ b/backend/tests/test_ob1_agent_onboarding_config.py
@@ -177,14 +177,16 @@ async def test_connection_artifact_connector_runtime_returns_pointer_only():
 
 @pytest.mark.anyio
 async def test_connection_artifact_unsupported_runtime_400():
-    """Q1(PO 확정): S5 SUPPORTED_RUNTIMES는 S4 픽커 5종(claude-code/codex/gemini/cursor/connector)
-    으로 좁혔다 — RuntimeType 의 다른 9종 중 미채택 값(예: hermes)은 여전히 400."""
+    """전 런타임 올지원(story 6f6ac081) 후: RuntimeType 9종 전부 SUPPORTED_RUNTIMES에 포함돼
+    (hermes 등 예전엔 400이던 값도 이제 지원) — 400 가드는 RuntimeType에도 없는 완전 미지의
+    문자열에만 여전히 걸려야 한다(방어 가드 자체는 무회귀)."""
     from fastapi import HTTPException
 
     from app.routers.agents import get_agent_connection_artifact
     with pytest.raises(HTTPException) as ei:
         await get_agent_connection_artifact(
-            uuid.uuid4(), runtime="hermes", session=AsyncMock(), auth=MagicMock(), org_id=uuid.uuid4()
+            uuid.uuid4(), runtime="totally-unknown-runtime", session=AsyncMock(),
+            auth=MagicMock(), org_id=uuid.uuid4(),
         )
     assert ei.value.status_code == 400
 

--- a/backend/tests/test_s6_runtime_capabilities.py
+++ b/backend/tests/test_s6_runtime_capabilities.py
@@ -31,13 +31,12 @@ async def test_runtime_capabilities_200_and_shape():
             "claude-code", "codex", "gemini", "cursor", "connector",
             "opencode", "openclaw", "hermes", "grok", "pi",
         }
+        # 전 런타임 올지원(story 6f6ac081) — RuntimeType 9종 전부 supported=true(connector 포함
+        # 10 전부). "곧 지원" 섹션은 비게 된다(의도된 결과).
         supported = {r["slug"] for r in data if r["supported"]}
-        assert supported == {"claude-code", "codex", "gemini", "cursor", "connector"}
+        assert supported == slugs
         for r in data:
-            if r["supported"]:
-                assert r["tier"] in ("full", "experimental")
-            else:
-                assert r["tier"] is None
+            assert r["tier"] in ("full", "experimental")
     finally:
         app.dependency_overrides.clear()
 
@@ -51,33 +50,40 @@ async def test_runtime_capabilities_401_when_unauthenticated():
     assert resp.status_code in (401, 403)
 
 
-def test_claude_code_is_full_tier_others_experimental():
-    """S5 emit 실기준: instruction filename 확정 매핑(CLAUDE.md)이 있는 claude-code만 tier=full —
-    나머지 MCP-native(codex/gemini/cursor)는 S7 shaping 전 generic fallback이라 experimental.
-    connector는 실 어댑터 조립이 후속이라 experimental."""
+def test_instruction_filename_tiers_and_transport_by_runtime_class():
+    """전 런타임 올지원(story 6f6ac081, 문서 `runtime-full-support-firstclass-crux`) 후 실기준:
+    _INSTRUCTION_FILENAMES에 확정 매핑이 있는 8종(claude-code·gemini·codex/cursor/grok/pi/
+    hermes/openclaw/opencode)은 tier=full — 매핑 없는 connector(범용·특정 툴 미확정)만
+    tier=experimental로 남는다(공식 문서 출처 실측 결과, crux doc 참조). MCP-native 4종만
+    mcp_transport 보유·event_push 지원 — 커넥터 전용 5종+connector는 SSE 경로라 전부 빈값."""
     from app.services.agent_onboarding_config import list_runtime_capabilities
 
     caps = {c["slug"]: c for c in list_runtime_capabilities()}
     assert caps["claude-code"]["tier"] == "full"
     assert caps["claude-code"]["prompt_file"] == "CLAUDE.md"
-    for slug in ("codex", "gemini", "cursor", "connector"):
-        assert caps[slug]["tier"] == "experimental"
-    assert caps["connector"]["mcp_transport"] == []
-    assert caps["connector"]["supports_event_push"] is False
-    assert caps["connector"]["guide_filename"] == "CONNECTOR_SETUP.md"
+    assert caps["gemini"]["tier"] == "full"
+    assert caps["gemini"]["prompt_file"] == "GEMINI.md"
+    for slug in ("codex", "cursor", "grok", "pi", "hermes", "openclaw", "opencode"):
+        assert caps[slug]["tier"] == "full", slug
+        assert caps[slug]["prompt_file"] == "AGENTS.md", slug
+    assert caps["connector"]["tier"] == "experimental"
+    assert caps["connector"]["prompt_file"] == "AGENT_INSTRUCTIONS.md"
+
     for slug in ("claude-code", "codex", "gemini", "cursor"):
         assert caps[slug]["supports_event_push"] is True
         assert set(caps[slug]["mcp_transport"]) == {"stdio", "http"}
+    for slug in ("connector", "opencode", "openclaw", "hermes", "grok", "pi"):
+        assert caps[slug]["mcp_transport"] == [], slug
+        assert caps[slug]["supports_event_push"] is False, slug
+        assert caps[slug]["transport"] is None, slug
+        assert caps[slug]["guide_filename"] == "CONNECTOR_SETUP.md", slug
 
 
-def test_unsupported_runtimes_reported_honestly_for_coming_soon_section():
-    """PO(2026-07-06): FE 픽커의 '곧 지원' 섹션을 채우려면 미지원 런타임(RuntimeType 9종 중
-    SUPPORTED_RUNTIMES 밖 5종)도 응답에 있어야 한다 — supported=false·tier=None으로 정직하게."""
+def test_no_unsupported_runtimes_left_coming_soon_section_empty():
+    """전 런타임 올지원(story 6f6ac081) 목표 — RuntimeType 9종(+connector) 전부 supported=true.
+    '곧 지원' 섹션은 이제 비어야 한다(vaporware 0)."""
     from app.services.agent_onboarding_config import list_runtime_capabilities
 
-    caps = {c["slug"]: c for c in list_runtime_capabilities()}
-    for slug in ("opencode", "openclaw", "hermes", "grok", "pi"):
-        assert caps[slug]["supported"] is False
-        assert caps[slug]["tier"] is None
-        assert caps[slug]["prompt_file"] is None
-        assert caps[slug]["mcp_transport"] == []
+    caps = list_runtime_capabilities()
+    assert all(c["supported"] for c in caps)
+    assert all(c["tier"] is not None for c in caps)


### PR DESCRIPTION
## Summary
crux doc `runtime-full-support-firstclass-crux`(PO GO 2026-07-08).

**축1 — 승격 메커니즘**: `CONNECTOR_ONLY_RUNTIMES`(opencode/openclaw/hermes/grok/pi) 추가 — `connectors/`에 이미 존재하는 실 SSE 어댑터 5종(vaporware 아님), `SUPPORTED_RUNTIMES`에 편입. 진짜 함정: `build_agent_mcp_config`/`_bundle`/`agents.py` connection-artifact 분기가 전부 단일 sentinel(`== CONNECTOR_RUNTIME`)만 체크 — 5종을 그냥 추가만 하면 이 가드를 안 타고 `.mcp.json`을 오emit(grok/pi 등은 MCP 안 씀). 가드를 `not in MCP_NATIVE_RUNTIMES`로 반전해 3곳 한 번에 정합.

**축2 — 런타임/모델별 맞춤 instruction**: `_INSTRUCTION_FILENAMES` 8종 확장 — 공식 문서 실측(추측 0, crux doc에 출처 전부 명시): codex/cursor/grok/pi/hermes/openclaw/opencode 7종이 `AGENTS.md`로 수렴(신흥 cross-tool 표준), gemini만 `GEMINI.md` 예외. 부수효과(의도된 결과, PO 승인): 이 8종이 tier="experimental"→"full" 자동 승격.

**FE**: `recruiter-client.tsx`는 `supported` boolean만 소비하는 범용 split이라 프로덕션 코드 변경 0. `RUNTIME_CAPABILITIES_FALLBACK`(BE 장애 시 degraded 폴백, PO 승인 스코프 포함)만 실 SSOT와 동기화.

## Test plan
- [x] 커넥터 전용 5종 connection-artifact realdb 테스트 신규(live Postgres 검증 — mcp_config=null + CONNECTOR_SETUP.md + AGENTS.md 확認).
- [x] recruit() 5종 mcp_config=null 무크래시 신규(mock 아닌 실 `build_agent_mcp_config_bundle` 함수 경로).
- [x] `test_s6_runtime_capabilities.py` 계약 갱신(전 10종 supported, connector만 tier=experimental).
- [x] `test_ob1_agent_onboarding_config.py`의 400 가드 테스트를 진짜 미지의 문자열로 교정(hermes는 이제 지원).
- [x] FE `recruiter-client.test.tsx` 17/17 passed(all-supported 계약 갱신) + `tsc --noEmit` clean.
- [x] 전체 백엔드 스위트: 3165 passed(+5 순증), 7 failed는 이 PR과 무관한 pre-existing baseline(MCP python 경로 테스트).

🤖 Generated with [Claude Code](https://claude.com/claude-code)