### PR TITLE
fix(recruit): 런타임 노트가 커넥터-라우팅 런타임에 거짓 "설정 불요" 안내 (story 6f6ac081 후속)

### DIFF
--- a/backend/app/services/agent_recruiter.py
+++ b/backend/app/services/agent_recruiter.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from typing import Any
 
 from app.routers.workflow_recipes import _generate_guide
+from app.services.agent_onboarding_config import MCP_NATIVE_RUNTIMES
 from app.services.mcp_toolset import ALL_GROUPS, ALL_TOOL_NAMES, _ALWAYS_ALLOWED, tool_group
 
 _AGILE_OPERATING_RULES = """## 애자일 자율 운영 룰
@@ -74,15 +75,24 @@ def _tool_cheat_sheet(tool_groups: list[str]) -> str:
 def _runtime_notes(runtime: str, runtime_overrides: dict[str, Any] | None) -> str:
     """[E] 런타임 노트 — runtime_overrides(JSONB)에 해당 runtime 항목이 있으면 이어붙인다.
 
-    E-RECRUIT S1 seed 는 runtime_overrides={} 라 오늘은 기본 문구만 나간다(메커니즘은 향후
-    런타임별 파일명/MCP 배선 노트(블루프린트 §4·S7)가 채워질 자리를 그대로 지원).
+    전 런타임 올지원(story 6f6ac081) 까심 QA 후속(2026-07-08): MCP-native 런타임만 채용 번들이
+    `.mcp.json`을 구성해 "별도 설정 불요"가 참이다. 커넥터-라우팅 런타임(MCP_NATIVE_RUNTIMES
+    밖 — connector 버킷 + 5종 커넥터 전용)은 `mcp_config=None`이라 그 문구가 거짓이었다(까심이
+    `compose_prompt(runtime="grok")`로 재현) — 실제로는 `connectors/{runtime}-sprintable/`
+    복사 + `AGENT_API_KEY` env 설정 + 어댑터 실행이 필요하다. 정직한 두 갈래로 분기.
     """
-    lines = [
-        "## 런타임 노트",
-        "",
-        f"이 프로젝트에서 당신의 실행 런타임은 `{runtime}` 입니다.",
-        "MCP 연결/스코프는 채용 시 제공된 번들이 이미 구성했습니다 — 별도 설정이 필요 없습니다.",
-    ]
+    lines = ["## 런타임 노트", "", f"이 프로젝트에서 당신의 실행 런타임은 `{runtime}` 입니다."]
+    if runtime in MCP_NATIVE_RUNTIMES:
+        lines.append(
+            "MCP 연결/스코프는 채용 시 제공된 번들이 이미 구성했습니다 — 별도 설정이 필요 없습니다."
+        )
+    else:
+        lines.append(
+            "이 런타임은 MCP가 아니라 SSE 커넥터 방식으로 연결합니다 — 채용 시 제공된 번들만으론 "
+            "연결이 자동 구성되지 않습니다. `connectors/{}-sprintable/` 폴더를 복사해 README "
+            "안내대로 `AGENT_API_KEY` 등 환경변수를 설정하고 어댑터를 직접 실행하세요."
+            .format(runtime if runtime != "connector" else "<선택한 런타임>")
+        )
     override = (runtime_overrides or {}).get(runtime)
     if override:
         lines += ["", f"**{runtime} 전용 노트**:", str(override)]

--- a/backend/tests/test_e_recruit_s2_compose_prompt.py
+++ b/backend/tests/test_e_recruit_s2_compose_prompt.py
@@ -98,6 +98,33 @@ def test_compose_prompt_includes_runtime_override_when_present():
     assert "CLAUDE.md 에 이 지침을 저장하세요." in out
 
 
+# ── 까심 QA 후속(story 6f6ac081, 2026-07-08): 런타임 노트가 커넥터-라우팅 런타임에도 정직해야 함 ──
+def test_compose_prompt_mcp_native_runtime_says_no_setup_needed():
+    role = _role()
+    out = compose_prompt(role, _RECIPE, "claude-code")
+    assert "별도 설정이 필요 없습니다" in out
+    assert "SSE 커넥터" not in out
+
+
+def test_compose_prompt_connector_only_runtime_gives_honest_setup_instructions():
+    """전에는 grok/pi/hermes/openclaw/opencode 도 "별도 설정 불요"라는 거짓 안내를 받았다(까심
+    `compose_prompt(runtime="grok")` 재현) — mcp_config=None인 커넥터-라우팅 런타임은 실제로
+    connectors/{runtime}-sprintable/ 복사 + AGENT_API_KEY 설정 + 어댑터 실행이 필요하다."""
+    role = _role()
+    out = compose_prompt(role, _RECIPE, "grok")
+    assert "별도 설정이 필요 없습니다" not in out
+    assert "SSE 커넥터" in out
+    assert "connectors/grok-sprintable/" in out
+    assert "AGENT_API_KEY" in out
+
+
+def test_compose_prompt_generic_connector_bucket_also_honest():
+    role = _role()
+    out = compose_prompt(role, _RECIPE, "connector")
+    assert "별도 설정이 필요 없습니다" not in out
+    assert "SSE 커넥터" in out
+
+
 # ── G3: 도구 치트시트 = 단일 소스(ALL_TOOL_NAMES) 파생, 환각 0 ─────────────────
 def test_compose_prompt_tool_cheat_sheet_only_references_real_tool_names():
     role = _role(default_tool_groups=[


### PR DESCRIPTION
## Summary
까심 QA 발견(2026-07-08, `compose_prompt(runtime="grok")` 재현): `_runtime_notes()`(`agent_recruiter.py`)가 runtime 무관하게 "MCP 연결/스코프는 채용 시 번들이 이미 구성 — 별도 설정 불요"를 하드코딩. 커넥터-라우팅 런타임(connector 버킷 + 5종 커넥터 전용, `mcp_config=None`)엔 거짓 — 실제로는 `connectors/{runtime}-sprintable/` 복사 + `AGENT_API_KEY` env + 어댑터 직접 실행이 필요하다.

전 런타임 올지원(#1957, story 6f6ac081)으로 5종이 승격되면서 드러난 갭 — 그 전엔 이 5종이 애초에 `recruit()` 자체가 400이라 도달 불가했다.

fix: `MCP_NATIVE_RUNTIMES` 기준으로 정직하게 분기 — MCP-native는 현행 문구 유지, 그 외(connector + 5종)는 SSE 커넥터 셋업 안내(폴더 경로+env 변수 명시).

## Test plan
- [x] MCP-native 런타임(claude-code)은 기존 "별도 설정 불요" 문구 유지 확認.
- [x] 커넥터 전용 런타임(grok)은 "SSE 커넥터"+`connectors/grok-sprintable/`+`AGENT_API_KEY` 안내로 교체 확認.
- [x] 제네릭 connector 버킷도 동일하게 정직한 안내 확認.
- [x] 전체 백엔드 스위트: 3168 passed(+3 신규분), 7 failed는 이 PR과 무관한 pre-existing baseline(MCP python 경로 테스트).

🤖 Generated with [Claude Code](https://claude.com/claude-code)