### PR TITLE
fix(recruiter): Step4 key banner mismatched .mcp.json copy for connector runtimes

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3284,6 +3284,7 @@
     "recruitFailed": "Recruiting failed. Please try again.",
     "keyOnceTitle": "This key is shown only now —",
     "keyOnceBody": "save it somewhere safe. Copy or download the .mcp.json below.",
+    "keyOnceBodyNoMcp": "save it somewhere safe. This runtime doesn't use MCP transport — see the connector setup guidance in the instruction file below.",
     "guideFileNote": "· autonomous operating guide · read-only",
     "mcpFileNote": "· connection · real key inline",
     "mcpNotApplicable": "This runtime doesn't use MCP transport — it connects via a separate SSE connector setup instead.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3284,6 +3284,7 @@
     "recruitFailed": "채용 처리에 실패했습니다. 다시 시도해 주세요.",
     "keyOnceTitle": "이 키는 지금만 보입니다 —",
     "keyOnceBody": "안전한 곳에 저장하세요. 아래 .mcp.json을 복사·다운로드하면 됩니다.",
+    "keyOnceBodyNoMcp": "안전한 곳에 저장하세요. 이 런타임은 MCP transport를 사용하지 않으니, 아래 지침 파일의 커넥터 설정 안내를 참고하세요.",
     "guideFileNote": "· 자율 운영 지침 · read-only",
     "mcpFileNote": "· 연결 · 실 key inline",
     "mcpNotApplicable": "이 런타임은 MCP transport를 사용하지 않습니다 — SSE 커넥터 방식으로 별도 연결 설정이 필요합니다.",

--- a/apps/web/src/app/(authenticated)/agents/recruiter/recruiter-client.tsx
+++ b/apps/web/src/app/(authenticated)/agents/recruiter/recruiter-client.tsx
@@ -977,7 +977,7 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
               <Alert variant="warning">
                 <AlertDescription className="flex items-start gap-2">
                   <span aria-hidden>🔑</span>
-                  <span><b>{t('keyOnceTitle')}</b> {t('keyOnceBody')}</span>
+                  <span><b>{t('keyOnceTitle')}</b> {recruitResult.mcp_config ? t('keyOnceBody') : t('keyOnceBodyNoMcp')}</span>
                 </AlertDescription>
               </Alert>
 


### PR DESCRIPTION
## Summary
Found live while verifying #1958/#1959 (recruited a Grok agent on dev): Step4's `.mcp.json` card correctly disappears for connector-routed runtimes (`mcp_config=null`), but the API-key banner directly above it still unconditionally says "아래 .mcp.json을 복사·다운로드하면 됩니다" / "Copy or download the .mcp.json below" — there's no such card below for ~6 runtimes (connector/grok/pi/hermes/openclaw/opencode).

Fix: branch the banner body text on `recruitResult.mcp_config`, same condition the card below already uses. New key `keyOnceBodyNoMcp` (ko/en) for the connector-routed case.

## Screenshots
Before (pre-existing, still live): banner says ".mcp.json 복사·다운로드" while the card below it is the honest "MCP transport 안 씀" placeholder (no .mcp.json card at all) — confirmed via live recruit of a Grok agent on dev.

## Test plan
- [x] `pnpm --filter web exec tsc --noEmit` clean
- [x] `pnpm --filter web lint` — no new warnings (5 pre-existing, unrelated files)
- [x] `pnpm --filter web exec vitest run` — 946 passed, 2 skipped, 0 failed
- [x] Live-verified root cause via deployed dev FE (recruited a real Grok agent, Step4 screenshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)