### PR TITLE
fix(recruit): 두 번째 오정보 소스 — role_templates.role_behaviors 하드코딩 런타임 노트 제거 (0163)

### DIFF
--- a/backend/alembic/versions/0156_role_templates.py
+++ b/backend/alembic/versions/0156_role_templates.py
@@ -33,6 +33,13 @@ depends_on = None
 
 
 def _behaviors(role: str, mission: str, tools: str, extra_rule: str) -> str:
+    """⚠️ DEPRECATED tail block(2026-07-08, migration 0163 참조): 아래 반환문 마지막
+    "## 런타임 노트" 문단은 런타임 무관 고정 문구라 커넥터-라우팅 런타임(grok/pi/hermes/
+    openclaw/opencode)엔 거짓이었다 — 0163이 이미 심긴 DB 데이터에서 제거했다. 이 마이그
+    자체는 역사 기록이라 upgrade()는 그대로 두지만, **향후 role_templates seed 마이그를
+    이 헬퍼 복사해서 작성한다면 그 tail 블록은 절대 넣지 마라** — 그 정보는 이제
+    app.services.agent_recruiter._runtime_notes()가 런타임별로 정확하게 동적 생성한다
+    (compose_prompt section [E])."""
     return f"""# {role} — 자율 운영 지침
 
 당신은 이 프로젝트의 {role}입니다. {mission}

--- a/backend/alembic/versions/0157_role_templates_catalog_buildout.py
+++ b/backend/alembic/versions/0157_role_templates_catalog_buildout.py
@@ -37,7 +37,14 @@ depends_on = None
 
 
 def _behaviors(role: str, mission: str, tools: str, extra_rule: str) -> str:
-    """S1(0156)과 동일한 5요소 템플릿 — claim→lock→status→소통 표준 오프닝."""
+    """S1(0156)과 동일한 5요소 템플릿 — claim→lock→status→소통 표준 오프닝.
+
+    ⚠️ DEPRECATED tail block(2026-07-08, migration 0163 참조): 아래 반환문 마지막
+    "## 런타임 노트" 문단은 런타임 무관 고정 문구라 커넥터-라우팅 런타임(grok/pi/hermes/
+    openclaw/opencode)엔 거짓이었다 — 0163이 이미 심긴 DB 데이터에서 제거했다. **향후
+    role_templates seed 마이그를 이 헬퍼 복사해서 작성한다면 그 tail 블록은 절대 넣지
+    마라** — 그 정보는 이제 app.services.agent_recruiter._runtime_notes()가 런타임별로
+    정확하게 동적 생성한다(compose_prompt section [E])."""
     return f"""# {role} — 자율 운영 지침
 
 당신은 이 프로젝트의 {role}입니다. {mission}
@@ -63,7 +70,11 @@ def _behaviors(role: str, mission: str, tools: str, extra_rule: str) -> str:
 
 
 def _behaviors_analyst(role: str, mission: str, tools: str, extra_rule: str) -> str:
-    """stories/tasks 그룹이 없는 순수 분석 역할용 커스텀 오프닝(claim 워크플로우 불성립)."""
+    """stories/tasks 그룹이 없는 순수 분석 역할용 커스텀 오프닝(claim 워크플로우 불성립).
+
+    ⚠️ DEPRECATED tail block(2026-07-08, migration 0163 참조) — `_behaviors()`와 동일 사유로
+    마지막 "## 런타임 노트" 문단을 향후 복사하지 말 것(app.services.agent_recruiter.
+    _runtime_notes()가 이제 담당)."""
     return f"""# {role} — 자율 운영 지침
 
 당신은 이 프로젝트의 {role}입니다. {mission}

--- a/backend/alembic/versions/0160_role_templates_marketing_roster.py
+++ b/backend/alembic/versions/0160_role_templates_marketing_roster.py
@@ -31,7 +31,14 @@ depends_on = None
 
 
 def _behaviors(role: str, mission: str, tools: str, extra_rule: str) -> str:
-    """0156/0157과 동일한 5요소 템플릿 — claim→lock→status→소통 표준 오프닝."""
+    """0156/0157과 동일한 5요소 템플릿 — claim→lock→status→소통 표준 오프닝.
+
+    ⚠️ DEPRECATED tail block(2026-07-08, migration 0163 참조): 아래 반환문 마지막
+    "## 런타임 노트" 문단은 런타임 무관 고정 문구라 커넥터-라우팅 런타임(grok/pi/hermes/
+    openclaw/opencode)엔 거짓이었다 — 0163이 이미 심긴 DB 데이터에서 제거했다. **향후
+    role_templates seed 마이그를 이 헬퍼 복사해서 작성한다면 그 tail 블록은 절대 넣지
+    마라** — 그 정보는 이제 app.services.agent_recruiter._runtime_notes()가 런타임별로
+    정확하게 동적 생성한다(compose_prompt section [E])."""
     return f"""# {role} — 자율 운영 지침
 
 당신은 이 프로젝트의 {role}입니다. {mission}

--- a/backend/alembic/versions/0163_strip_stale_runtime_note_from_role_behaviors.py
+++ b/backend/alembic/versions/0163_strip_stale_runtime_note_from_role_behaviors.py
@@ -1,0 +1,56 @@
+"""전 런타임 올지원(story 6f6ac081) 까심 QA 후속 — role_templates.role_behaviors의 중복·거짓
+"## 런타임 노트" 블록 제거.
+
+Revision ID: 0163
+Revises: 0162
+Create Date: 2026-07-08
+
+미르코 라이브 확認(2026-07-08): grok/hermes 등 커넥터-라우팅 런타임 채용 산출물(AGENTS.md)에
+"## 런타임 노트"가 두 번 등장 — compose_prompt의 section [E](agent_recruiter._runtime_notes,
+#1959로 이미 런타임별 정직하게 분기됨)와, section [A](role_template.role_behaviors 그대로 삽입)
+안에 0156/0157/0160이 하드코딩해 seed한 옛 문구("MCP 연결/스코프는 채용 시점 번들이 처리합니다")
+가 중복 등장한다. 이 하드코딩은 런타임 무관 고정 텍스트라 커넥터 런타임엔 처음부터 거짓이었고,
+이제 section [E]가 이 역할을 완전히 대체하므로(동적·런타임별 정확) role_behaviors 쪽 사본은
+그냥 제거한다 — 정보 손실 없음(같은 정보가 [E]에 더 정확한 형태로 남음), 중복도 해소.
+
+전 role_templates 행 대상(0156/0157/0160이 심은 catalog 전체가 이 정확히 동일한 tail 블록을
+공유 — repo grep으로 3개 마이그 전부 byte-identical 확認). 정확한 substring REPLACE만 수행 —
+role_behaviors의 나머지 내용(직무별 미션/도구/6번째 게이트 규칙)은 전혀 건드리지 않는다.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0163"
+down_revision = "0162"
+branch_labels = None
+depends_on = None
+
+_STALE_BLOCK = (
+    "\n\n## 런타임 노트\n"
+    "이 지침은 런타임(claude-code 등)에 관계없이 동일합니다. "
+    "MCP 연결/스코프는 채용 시점 번들이 처리합니다.\n"
+)
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE role_templates "
+            "SET role_behaviors = REPLACE(role_behaviors, :stale, '') "
+            "WHERE role_behaviors LIKE '%' || :stale || '%'"
+        ).bindparams(sa.bindparam("stale", value=_STALE_BLOCK, type_=sa.Text))
+    )
+
+
+def downgrade() -> None:
+    # 원문 복원(re-append) — 0156/0157/0160 seed 당시 이 블록은 항상 role_behaviors의 마지막
+    # 내용이었다(repo 확認). 이미 tail에서 제거된 행에만 다시 붙인다(멱등 — 중복 재부착 방지).
+    op.execute(
+        sa.text(
+            "UPDATE role_templates "
+            "SET role_behaviors = role_behaviors || :stale "
+            "WHERE role_behaviors NOT LIKE '%' || :stale || '%'"
+        ).bindparams(sa.bindparam("stale", value=_STALE_BLOCK, type_=sa.Text))
+    )

--- a/backend/tests/test_migration_0163_strip_stale_runtime_note_realdb.py
+++ b/backend/tests/test_migration_0163_strip_stale_runtime_note_realdb.py
@@ -13,7 +13,11 @@ import pytest
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
-pytestmark = pytest.mark.destructive_schema
+# CI 회귀(2026-07-08): destructive_schema 마커 안 씀 — 이 테스트는 Base.metadata.create_all/
+# drop_all로 스키마를 자체 관리하지 않는다(순수 SELECT, 마이그레이션이 이미 심은 role_templates
+# 데이터를 읽기만 함). destructive_schema로 마킹하면 CI가 격리된 미마이그 fresh DB(sprintable_
+# test_iso, alembic 미실행)를 배정해 role_templates 테이블 자체가 없어 UndefinedTableError.
+# 이 테스트는 "alembic upgrade heads가 이미 실행된 공유 DB"(non-destructive 버킷)를 전제한다.
 
 
 @pytest.fixture

--- a/backend/tests/test_migration_0163_strip_stale_runtime_note_realdb.py
+++ b/backend/tests/test_migration_0163_strip_stale_runtime_note_realdb.py
@@ -1,0 +1,83 @@
+"""전 런타임 올지원(story 6f6ac081) 까심 QA 후속(2026-07-08) — migration 0163 실 Postgres 검증.
+
+미르코 라이브 확認: grok/hermes 등 커넥터-라우팅 런타임 채용 산출물에 "## 런타임 노트"가
+두 번 등장(section [A] role_behaviors에 0156/0157/0160이 하드코딩한 옛 거짓 문구 + section [E]
+_runtime_notes의 정직한 버전, #1959). 0163이 role_behaviors 쪽 사본을 제거한다 — 이 테스트는
+그 결과를 실 DB(마이그 실행 후)로 검증한다.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL) — alembic upgrade heads 전제")
+@pytest.mark.anyio
+async def test_no_role_template_retains_stale_runtime_note_block():
+    """0163 적용 후 모든 role_templates.role_behaviors에서 옛 하드코딩 문구가 완전히 사라져야 한다."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    try:
+        async with engine.connect() as conn:
+            stale_count = (await conn.execute(text(
+                "SELECT count(*) FROM role_templates WHERE role_behaviors LIKE "
+                "'%채용 시점 번들이 처리합니다%'"
+            ))).scalar_one()
+            heading_count = (await conn.execute(text(
+                "SELECT count(*) FROM role_templates WHERE role_behaviors LIKE '%## 런타임 노트%'"
+            ))).scalar_one()
+        assert stale_count == 0
+        assert heading_count == 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL) — alembic upgrade heads 전제")
+@pytest.mark.anyio
+async def test_compose_prompt_has_exactly_one_runtime_note_heading_for_seeded_role():
+    """0163 후 compose_prompt가 실 seed 데이터로 정확히 1개의 '## 런타임 노트' 헤딩만 생성 —
+    section [A](role_behaviors)와 section [E](_runtime_notes) 중복 없음."""
+    from types import SimpleNamespace
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+    from app.services.agent_recruiter import compose_prompt
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    try:
+        async with engine.connect() as conn:
+            row = (await conn.execute(text(
+                "SELECT slug, role_behaviors, default_tool_groups, runtime_overrides "
+                "FROM role_templates LIMIT 1"
+            ))).mappings().first()
+        assert row is not None, "role_templates 비어있음 — 0156/0157/0160 seed 마이그 미적용?"
+        role = SimpleNamespace(
+            name=row["slug"], role_behaviors=row["role_behaviors"],
+            default_tool_groups=row["default_tool_groups"], runtime_overrides=row["runtime_overrides"] or {},
+        )
+        for runtime in ("claude-code", "grok"):
+            out = compose_prompt(role, None, runtime)
+            assert out.count("## 런타임 노트") == 1, f"runtime={runtime}"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
미르코 라이브 확認(2026-07-08): #1959로 section [E](`_runtime_notes`)는 고쳤으나, grok/hermes 등 채용 산출물에 `## 런타임 노트`가 여전히 두 번 등장 — section [A](`role_template.role_behaviors` 그대로 삽입)에 0156/0157/0160이 심은 옛 하드코딩 문구("MCP 연결/스코프는 채용 시점 번들이 처리합니다")가 남아있었다. 런타임 무관 고정 텍스트라 커넥터 런타임엔 처음부터 거짓 + 이제 [E]와 중복.

fix: 신규 data migration(`0163`) — 3개 seed 마이그(0156/0157/0160)가 byte-identical하게 심은 이 tail 블록을 REPLACE로 제거. 나머지 `role_behaviors` 내용(직무 미션·도구·품질게이트)은 무변경. section [E]가 이제 이 정보의 유일한 출처(정확·런타임별).

**⚠️ Alembic은 Cloud Build에서 자동 실행 안 됨** — 머지 후 `sprintable-migrate-dev` job 수동 실행 필요(기존 팀 컨벤션).

## Test plan
- [x] 로컬 실 Postgres로 `alembic upgrade heads`(0163까지) 실행 — 24개 role_templates 전부 stale 블록 제거 확認.
- [x] `compose_prompt(role, "grok")`가 `## 런타임 노트` 정확히 1회만 생성함을 실측(이전엔 2회) — 실 seed 데이터로 검증.
- [x] downgrade도 원문 재부착(멱등)으로 작성.
- [x] realdb 신규 테스트 2종(로컬 Postgres로 라이브 검증 완료, CI에서는 DB URL 없으면 skip).
- [x] 전체 백엔드 스위트: 3168 passed, 7 failed는 이 PR과 무관한 pre-existing baseline(MCP python 경로 테스트).

🤖 Generated with [Claude Code](https://claude.com/claude-code)