### PR TITLE
feat(i18n): Phase B — role_templates/release_notes 번역 오버레이 스키마 (story 11f1087c)

### DIFF
--- a/backend/alembic/versions/0164_i18n_translation_columns.py
+++ b/backend/alembic/versions/0164_i18n_translation_columns.py
@@ -1,0 +1,51 @@
+"""E-I18N Phase B(story 11f1087c) — role_templates/release_notes i18n 병행 JSONB 컬럼.
+
+Revision ID: 0164
+Revises: 0163
+Create Date: 2026-07-08
+
+crux doc `i18n-architecture-design-crux`, 선생님 GO 2026-07-08. 스키마만(콘텐츠 데이터
+아님) — [[no-pr-for-data]] 게이트 무관.
+
+설계(순수 additive, 기존 Text 컬럼 무변경):
+- `role_templates.role_behaviors_i18n` / `release_notes.title_i18n` — 둘 다 JSONB
+  `NOT NULL DEFAULT '{}'::jsonb`. **기존 데이터를 이 컬럼으로 백필하지 않는다** — 빈
+  dict로 시작해 완전히 별개 오버레이로만 존재한다. 향후 소비 코드(Phase C 이후)가
+  `role_behaviors_i18n.get(locale) or role_behaviors`(레거시 Text 컬럼이 곧 "ko" 캐논
+  소스) 순서로 조회하면, en 키가 비어있는 한 자동으로 기존 한글 텍스트로 폴백한다 —
+  마이그레이션 시점엔 이 새 컬럼에 아무 콘텐츠 결정도 내리지 않으므로 데이터 변경
+  성격이 전혀 없다(순수 구조 추가).
+- release_notes는 title만(요청 스코프 — summary/items i18n은 미포함, 필요하면 후속).
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0164"
+down_revision = "0163"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "role_templates",
+        sa.Column(
+            "role_behaviors_i18n", postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False, server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+    op.add_column(
+        "release_notes",
+        sa.Column(
+            "title_i18n", postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False, server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("release_notes", "title_i18n")
+    op.drop_column("role_templates", "role_behaviors_i18n")

--- a/backend/app/models/release_note.py
+++ b/backend/app/models/release_note.py
@@ -33,7 +33,13 @@ class ReleaseNote(Base, TimestampMixin):
         DateTime(timezone=True), nullable=False, index=True
     )
     display_period: Mapped[str] = mapped_column(Text, nullable=False)
+    # 이 컬럼 자체가 "ko" 캐논 소스(오늘 유일한 실 콘텐츠) — title_i18n은 그 위 오버레이.
     title: Mapped[str] = mapped_column(Text, nullable=False)
+    # E-I18N Phase B(story 11f1087c, migration 0164) — locale별 번역 오버레이({"en": "...", ...}).
+    # 빈 dict가 기본(마이그 시점 백필 없음). 소비 코드는 `title_i18n.get(locale) or title` 순서로
+    # 조회해 빈 키는 자동으로 title(ko)로 폴백한다(Phase C 이후 배선 예정). summary/items i18n은
+    # 이번 스코프 밖(요청 범위 = title만 — 필요하면 후속 확장).
+    title_i18n: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
     summary: Mapped[str] = mapped_column(Text, nullable=False, server_default="", default="")
     # [{text: str, href?: str}, ...]
     items: Mapped[list] = mapped_column(

--- a/backend/app/models/role_template.py
+++ b/backend/app/models/role_template.py
@@ -31,7 +31,13 @@ class RoleTemplate(Base, TimestampMixin):
     category: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     # 자율 운영 지침(markdown) — 큰 정적 프롬프트가 아니라 날씬한 매뉴얼(블루프린트 §3 개정).
+    # 이 컬럼 자체가 "ko" 캐논 소스(오늘 유일한 실 콘텐츠) — role_behaviors_i18n은 그 위 오버레이.
     role_behaviors: Mapped[str] = mapped_column(Text, nullable=False)
+    # E-I18N Phase B(story 11f1087c, migration 0164) — locale별 번역 오버레이({"en": "...", ...}).
+    # 빈 dict가 기본(마이그 시점 백필 없음, 순수 구조 추가) — 소비 코드는
+    # `role_behaviors_i18n.get(locale) or role_behaviors` 순서로 조회해 빈 키는 자동으로
+    # role_behaviors(ko)로 폴백한다(Phase C 이후 배선 예정, 이 스키마 자체는 무관).
+    role_behaviors_i18n: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
     # mcp_toolset.py 의 그룹 vocabulary(stories/tasks/epics/chat/docs/sprints/...) — admin/
     # destructive-only 그룹 제외(직무별 최소권한). API key scope 로 그대로 흘러간다(S2/S3 소비).
     default_tool_groups: Mapped[list[str]] = mapped_column(

--- a/backend/tests/test_e_recruit_s1_role_templates.py
+++ b/backend/tests/test_e_recruit_s1_role_templates.py
@@ -71,6 +71,8 @@ def test_model_field_shape():
         "is_builtin", "is_published", "tier", "version", "created_at", "updated_at",
         # 카탈로그 트랙 S1(0161, 문서 role-template-crud-api-crux §4).
         "division", "emoji", "skills",
+        # E-I18N Phase B(story 11f1087c, migration 0164) — locale 번역 오버레이.
+        "role_behaviors_i18n",
     }
 
 

--- a/backend/tests/test_migration_0164_i18n_columns_realdb.py
+++ b/backend/tests/test_migration_0164_i18n_columns_realdb.py
@@ -1,0 +1,84 @@
+"""E-I18N Phase B(story 11f1087c) — migration 0164 실 Postgres 검증.
+
+DB env 없으면 skip(CI alembic-fresh 패턴, test_release_notes_realdb.py와 동형). 이 테스트는
+Base.metadata.create_all/drop_all로 스키마를 자체 관리하지 않는다(순수 SELECT, alembic이
+이미 만든 컬럼을 읽기만 함) — destructive_schema 마커 사용 금지(0163 테스트가 CI에서 겪은
+"격리 미마이그 DB에 role_templates 자체가 없음" 회귀와 동일 클래스 실수를 여기서 반복하지
+않기 위해 명시 확認해뒀다).
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_role_behaviors_i18n_column_exists_and_defaults_empty():
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    engine = create_async_engine(_async_url())
+    try:
+        async with engine.connect() as conn:
+            rows = (await conn.execute(text(
+                "SELECT role_behaviors_i18n FROM role_templates"
+            ))).scalars().all()
+        assert rows, "role_templates 비어있음 — seed 마이그 미적용?"
+        assert all(r == {} for r in rows), "기존 데이터 마이그 시점 백필 없음이 원칙(순수 구조 추가)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_role_behaviors_legacy_column_untouched():
+    """0163이 고친 정직한 ko 텍스트가 role_behaviors_i18n 신설과 무관하게 그대로 살아있어야
+    (레거시 Text 컬럼 = ko 캐논 소스, 스키마 마이그가 안 건드림)."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    engine = create_async_engine(_async_url())
+    try:
+        async with engine.connect() as conn:
+            stale_count = (await conn.execute(text(
+                "SELECT count(*) FROM role_templates WHERE role_behaviors LIKE "
+                "'%채용 시점 번들이 처리합니다%'"
+            ))).scalar_one()
+        assert stale_count == 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_release_notes_title_i18n_column_exists():
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    engine = create_async_engine(_async_url())
+    try:
+        async with engine.connect() as conn:
+            row = (await conn.execute(text(
+                "SELECT title, title_i18n FROM release_notes LIMIT 1"
+            ))).mappings().first()
+        if row is not None:  # release_notes 시드가 없는 환경이면 컬럼 존재만 확認(쿼리 성공 자체가 증거)
+            assert row["title_i18n"] == {}
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
crux doc `i18n-architecture-design-crux`(선생님 GO 2026-07-08). 스키마만 — 콘텐츠 데이터 아님, [[no-pr-for-data]] 게이트 무관.

migration `0164`(0163/#1962 위): `role_templates.role_behaviors_i18n` / `release_notes.title_i18n` JSONB 컬럼 병행 추가(둘 다 `NOT NULL DEFAULT '{}'::jsonb`). release_notes는 요청 스코프대로 title만(summary/items i18n 미포함 — 필요시 후속).

**설계(순수 additive, 기존 Text 컬럼 무변경)**: 마이그 시점에 기존 데이터를 이 컬럼으로 백필하지 않는다 — 완전히 빈 오버레이로 시작. 레거시 Text 컬럼(`role_behaviors`/`title`) 자체가 "ko" 캐논 소스가 된다. 향후 소비 코드(Phase C 이후)가 `X_i18n.get(locale) or X`(레거시 컬럼 폴백) 순서로 조회하면, en 키가 비어있는 한 자동으로 기존 한글 텍스트로 폴백 — 이 마이그는 콘텐츠 결정을 전혀 안 내리므로 데이터 변경 성격이 없다.

ORM 모델 필드 추가(`RoleTemplate.role_behaviors_i18n`·`ReleaseNote.title_i18n`) — 스키마 소비를 위한 필수 대응. Phase C(locale 소스 배선)나 실 번역 콘텐츠는 이번 스코프 아님(`compose_prompt`는 아직 안 건드림).

## Test plan
- [x] realdb 신규 3종(로컬 실 Postgres로 라이브 검증 — 컬럼 존재+빈 dict 기본값+레거시 컬럼 무변경).
- [x] `role_templates` 필드-shape 회귀가드(`test_model_field_shape`)도 새 컬럼 반영해 갱신(누락 시 실패 — 로컬에서 실제로 잡아서 고침).
- [x] `alembic heads` 단일 head(0164) 확認.
- [x] 전체 백엔드 스위트: 3168 passed, 7 failed는 이 PR과 무관한 pre-existing baseline(MCP python 경로 테스트).

🤖 Generated with [Claude Code](https://claude.com/claude-code)