### PR TITLE
feat(i18n): Phase C — recruit/connection-artifact locale 소스 배선 (story 11f1087c)

### DIFF
--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -185,7 +185,34 @@ async def get_agent_connection_artifact(
     정규화해 ``build_connector_guidance()``(CONNECTOR_SETUP.md)에만 적용 — 이미 채용 시점에
     확정 locale로 저장된 ``resolved_system_prompt``(persona 파일)는 재합성하지 않는다(그 값은
     recruit() 호출 당시 locale의 정확한 기록이라, 여기서 다시 손대면 오히려 왜곡).
+
+    까심 QA CI FAILURE(2026-07-08, 근본 fix): ``accept_language``의 ``Header()`` DI 마커는
+    FastAPI ASGI 파이프라인을 통해서만 plain str/None으로 풀린다 — 이 함수를 realdb 테스트처럼
+    **Python에서 직접 호출**하면 ``Header`` 객체 그대로 남아 ``resolve_locale_from_request()``가
+    ``.split()``에서 AttributeError로 죽는다(HTTP 경로만 통과하는 QA로는 안 잡힘). 그래서 실제
+    로직은 Header() 마커가 전혀 없는 ``_connection_artifact()``(plain str만 받음)로 옮기고, 이
+    라우트 함수는 얇은 위임만 한다 — 직접-호출 테스트는 ``_connection_artifact``를 불러야 한다
+    (Header DI는 라우트 경계에서만 받는다는 원칙).
     """
+    return await _connection_artifact(
+        agent_id, runtime, transport, locale, accept_language,
+        session=session, auth=auth, org_id=org_id,
+    )
+
+
+async def _connection_artifact(
+    agent_id: uuid.UUID,
+    runtime: str = DEFAULT_RUNTIME,
+    transport: str | None = None,
+    locale: str | None = None,
+    accept_language: str | None = None,
+    *,
+    session: AsyncSession,
+    auth: AuthContext,
+    org_id: uuid.UUID,
+) -> dict:
+    """``get_agent_connection_artifact`` 실 로직 — Header() DI 마커 없음(plain str만).
+    직접-호출(realdb·유닛 테스트)은 이 함수를 부른다."""
     if runtime not in SUPPORTED_RUNTIMES:
         raise HTTPException(status_code=400, detail=f"unsupported runtime: {runtime}")
     resolved_locale = resolve_locale_from_request(locale, accept_language)
@@ -297,7 +324,28 @@ async def recruit_agent_endpoint(
     E-I18N Phase C(story 11f1087c): ``body.locale``(FE 명시 전달)→``Accept-Language`` 헤더(폴백)
     순으로 정규화해 ``compose_prompt``에 배선 — 이 시점에 확정된 locale이 persona에 영속 기록된다
     (재채용 시 다른 locale로 다시 부르면 그 값으로 덮어씀, DB에 별도 locale 컬럼은 없음).
+
+    까심 QA CI FAILURE 후속(2026-07-08, connection-artifact와 동형 근본 fix 선제 적용): Header()
+    DI 마커는 라우트 경계에서만 받고, 실 로직은 plain str만 받는 ``_recruit_agent_endpoint()``로
+    분리 — 직접-호출 테스트가 FastAPI ASGI 파이프라인을 안 거쳐도 Header sentinel leak이 날 수
+    없다.
     """
+    return await _recruit_agent_endpoint(
+        agent_id, body, accept_language, session=session, auth=auth, org_id=org_id,
+    )
+
+
+async def _recruit_agent_endpoint(
+    agent_id: uuid.UUID,
+    body: RecruitRequest,
+    accept_language: str | None = None,
+    *,
+    session: AsyncSession,
+    auth: AuthContext,
+    org_id: uuid.UUID,
+) -> dict:
+    """``recruit_agent_endpoint`` 실 로직 — Header() DI 마커 없음(plain str만).
+    직접-호출(realdb·유닛 테스트)은 이 함수를 부른다."""
     member = await assert_agent_owner(agent_id, session, org_id, uuid.UUID(auth.user_id))
 
     if body.runtime not in SUPPORTED_RUNTIMES:

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -10,7 +10,7 @@ import json
 import os
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -32,6 +32,7 @@ from app.services.agent_onboarding_config import (
     build_connector_guidance,
     default_transport_for_hosting,
     resolve_instruction_filename,
+    resolve_locale_from_request,
 )
 from app.services.agent_verify import get_verification_state, start_verification
 from app.services.onboarding_funnel import emit_onboarding_event, safe_key_prefix
@@ -153,6 +154,8 @@ async def get_agent_connection_artifact(
     agent_id: uuid.UUID,
     runtime: str = DEFAULT_RUNTIME,
     transport: str | None = None,
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
@@ -177,9 +180,15 @@ async def get_agent_connection_artifact(
     단일 파일에서 ``{files[], mcp_config, api_key}``(``api_key`` 는 GET 이라 placeholder 뿐)로
     교체 — S4 채용관 번들 프리뷰(파일 3종)와 recruit(S3) 응답 shape 에 맞춘다(G2: 재방문 시
     placeholder만·실키는 recruit 시점 1회).
+
+    E-I18N Phase C(story 11f1087c): ``locale`` 쿼리(명시)→``Accept-Language`` 헤더(폴백) 순으로
+    정규화해 ``build_connector_guidance()``(CONNECTOR_SETUP.md)에만 적용 — 이미 채용 시점에
+    확정 locale로 저장된 ``resolved_system_prompt``(persona 파일)는 재합성하지 않는다(그 값은
+    recruit() 호출 당시 locale의 정확한 기록이라, 여기서 다시 손대면 오히려 왜곡).
     """
     if runtime not in SUPPORTED_RUNTIMES:
         raise HTTPException(status_code=400, detail=f"unsupported runtime: {runtime}")
+    resolved_locale = resolve_locale_from_request(locale, accept_language)
 
     member = (await session.execute(
         select(TeamMember).where(
@@ -218,7 +227,10 @@ async def get_agent_connection_artifact(
         # 반전한 이유: 전자는 커넥터 전용 5종을 그냥 통과시켜 `.mcp.json`을 오emit했다.
         resolved_transport = None
         mcp_config: dict | None = None
-        files.append({"filename": "CONNECTOR_SETUP.md", "content": build_connector_guidance(runtime)})
+        files.append({
+            "filename": "CONNECTOR_SETUP.md",
+            "content": build_connector_guidance(runtime, resolved_locale),
+        })
     else:
         resolved_transport = transport or default_transport_for_hosting()
         if resolved_transport not in SUPPORTED_TRANSPORTS:
@@ -266,6 +278,7 @@ async def _fetch_org_agent(session: AsyncSession, agent_id: uuid.UUID, org_id: u
 async def recruit_agent_endpoint(
     agent_id: uuid.UUID,
     body: RecruitRequest,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
@@ -280,6 +293,10 @@ async def recruit_agent_endpoint(
     확인이 없어 — org 내 임의 멤버가 자신이 만들지도 관리자도 아닌 agent를 재채용(키 로테이션+
     role/system_prompt 변경, 채용 엔드포인트 자체 탈취)할 수 있었다. team_members.py 업데이트/
     deactivate와 동일한 `assert_agent_owner`(생성자 또는 org-admin)로 닫는다.
+
+    E-I18N Phase C(story 11f1087c): ``body.locale``(FE 명시 전달)→``Accept-Language`` 헤더(폴백)
+    순으로 정규화해 ``compose_prompt``에 배선 — 이 시점에 확정된 locale이 persona에 영속 기록된다
+    (재채용 시 다른 locale로 다시 부르면 그 값으로 덮어씀, DB에 별도 locale 컬럼은 없음).
     """
     member = await assert_agent_owner(agent_id, session, org_id, uuid.UUID(auth.user_id))
 
@@ -290,6 +307,7 @@ async def recruit_agent_endpoint(
     if role_template is None:
         raise HTTPException(status_code=404, detail="role_template not found")
 
+    resolved_locale = resolve_locale_from_request(body.locale, accept_language)
     try:
         result = await recruit_agent(
             session,
@@ -298,6 +316,7 @@ async def recruit_agent_endpoint(
             role_template=role_template,
             runtime=body.runtime,
             actor_id=uuid.UUID(auth.user_id),
+            locale=resolved_locale,
         )
     except ValueError as exc:
         # validate_tool_groups fail-closed(QA MINOR 하드닝) — 오염된 role_template 데이터 400.

--- a/backend/app/schemas/recruit.py
+++ b/backend/app/schemas/recruit.py
@@ -9,3 +9,6 @@ from app.services.agent_onboarding_config import DEFAULT_RUNTIME
 class RecruitRequest(BaseModel):
     role_template_slug: str
     runtime: str = DEFAULT_RUNTIME
+    # E-I18N Phase C(story 11f1087c): FE가 자기 next-intl locale을 명시 전달(정확) — 없으면
+    # 라우터가 Accept-Language 헤더로 폴백(resolve_locale_from_request). DB 영속 저장 없음.
+    locale: str | None = None

--- a/backend/app/services/agent_onboarding_config.py
+++ b/backend/app/services/agent_onboarding_config.py
@@ -14,6 +14,7 @@ README·onboarding-form·in-app docs·로컬 buildMcpConfig 4갈래로 흩어져
 from __future__ import annotations
 
 import os
+from typing import Any
 
 DEFAULT_RUNTIME = "claude-code"
 # 전 런타임 올지원(story 6f6ac081, 문서 `runtime-full-support-firstclass-crux`, PO GO
@@ -42,6 +43,25 @@ DEFAULT_LOCALE = "ko"
 def resolve_locale(locale: str | None) -> str:
     """미지원/None locale → DEFAULT_LOCALE 폴백(크래시 없이 항상 유효한 locale 반환)."""
     return locale if locale in SUPPORTED_LOCALES else DEFAULT_LOCALE
+
+
+def resolve_locale_from_request(explicit: str | None, accept_language: str | None) -> str:
+    """E-I18N Phase C(story 11f1087c, 문서 `i18n-architecture-design-crux` §1 결정 (a)+(b)):
+    콘텐츠-생성 엔드포인트의 locale 소스 우선순위 — ① FE가 명시 전달한 ``locale``(자기
+    next-intl locale 쿠키값, 가장 정확) ② 없으면 ``Accept-Language`` 헤더에서 유도(브라우저
+    기본 — FE 미변경 클라이언트에도 무회귀 폴백) ③ 그래도 없으면 ``DEFAULT_LOCALE``.
+
+    DB 영속 저장 없음(request-scoped) — org/user에 locale 컬럼을 두지 않는다는 crux 결정과 동형
+    (FE도 쿠키만 쓰고 DB엔 안 둔다 — 대칭 유지).
+    """
+    if explicit:
+        return resolve_locale(explicit)
+    if accept_language:
+        for tag in accept_language.split(","):
+            primary = tag.split(";", 1)[0].strip().split("-", 1)[0].lower()
+            if primary in SUPPORTED_LOCALES:
+                return primary
+    return DEFAULT_LOCALE
 
 # E-RECRUIT S5 G4 + 전 런타임 올지원(story 6f6ac081) — 런타임별 자율 운영 지침 파일명. 공식
 # 문서 실측(추측 0, crux doc에 출처 전부 명시): codex/cursor/grok/pi/hermes/openclaw/opencode
@@ -123,31 +143,61 @@ def list_runtime_capabilities() -> list[dict]:
     return out
 
 
-def build_connector_guidance(runtime_hint: str | None = None) -> str:
+_CONNECTOR_GUIDANCE_TEXT: dict[str, dict[str, Any]] = {
+    "ko": {
+        "title": "# Sprintable Connector 안내",
+        "intro": [
+            "Claude Code/Codex/Gemini/Cursor 처럼 MCP를 네이티브 지원하지 않는 런타임은 별도 SSE",
+            "커넥터 어댑터로 연결합니다 — `.mcp.json`이 아니라 `connectors/{runtime}-sprintable/` 폴더의",
+            "어댑터를 사용해 서버에 아웃바운드로 접속합니다(인바운드 도메인/웹훅 불필요).",
+        ],
+        "adapters_heading": "## 사용 가능한 어댑터",
+        "adapters_intro": "`connectors/` 레포 경로 아래 각 폴더가 자기완결(self-contained) 어댑터입니다:",
+        "setup_heading": "## 설정",
+        "setup_steps": [
+            "위 폴더 중 사용 중인 런타임에 맞는 폴더를 복사하세요(각 폴더는 sibling import 없이 독립 동작합니다).",
+            "폴더의 `README.md` 안내대로 `AGENT_API_KEY`(이 에이전트의 scoped key) 등 env를 설정하세요.",
+            "어댑터를 런타임 호스트에서 직접 실행하세요(호스팅 실행은 지원하지 않음 — 설치/실행은 사용자 수동).",
+        ],
+        "runtime_hint": "(선택한 런타임: {runtime})",
+    },
+    "en": {
+        "title": "# Sprintable Connector Guide",
+        "intro": [
+            "Runtimes that don't natively support MCP (e.g. Claude Code/Codex/Gemini/Cursor don't",
+            "need this — this is for the rest) connect via a separate SSE connector adapter instead",
+            "of `.mcp.json` — the adapter in `connectors/{runtime}-sprintable/` dials out to the",
+            "server (no inbound domain/webhook needed).",
+        ],
+        "adapters_heading": "## Available Adapters",
+        "adapters_intro": "Each folder under the `connectors/` repo path is a self-contained adapter:",
+        "setup_heading": "## Setup",
+        "setup_steps": [
+            "Copy the folder matching your runtime (each folder is self-contained, no sibling imports).",
+            "Set env vars per the folder's `README.md` (including `AGENT_API_KEY`, this agent's scoped key).",
+            "Run the adapter yourself on your runtime host (hosted execution isn't supported — install/run manually).",
+        ],
+        "runtime_hint": "(Selected runtime: {runtime})",
+    },
+}
+
+
+def build_connector_guidance(runtime_hint: str | None = None, locale: str = DEFAULT_LOCALE) -> str:
     """E-RECRUIT S5 Q2(PO 확정): connector 분기 = **포인터/안내만**(SSE dial-out은 `.mcp.json`과
     완전 별개 프로토콜 — 실제 어댑터 조립은 S7/후속). `connectors/{runtime}-sprintable/` 각 폴더의
-    README가 5조 계약(SSE dial-out·turn 주입·응답·ack·에러)을 담고 있어 여기선 안내만 재생산한다."""
-    lines = [
-        "# Sprintable Connector 안내",
-        "",
-        "Claude Code/Codex/Gemini/Cursor 처럼 MCP를 네이티브 지원하지 않는 런타임은 별도 SSE",
-        "커넥터 어댑터로 연결합니다 — `.mcp.json`이 아니라 `connectors/{runtime}-sprintable/` 폴더의",
-        "어댑터를 사용해 서버에 아웃바운드로 접속합니다(인바운드 도메인/웹훅 불필요).",
-        "",
-        "## 사용 가능한 어댑터",
-        "`connectors/` 레포 경로 아래 각 폴더가 자기완결(self-contained) 어댑터입니다:",
+    README가 5조 계약(SSE dial-out·turn 주입·응답·ack·에러)을 담고 있어 여기선 안내만 재생산한다.
+
+    E-I18N Phase C(story 11f1087c) — locale 분기(compose_prompt류와 동형 dict 패턴). 기본값
+    ``DEFAULT_LOCALE``이라 기존 호출부(locale 인자 없이 호출)는 무변경 하위호환.
+    """
+    text = _CONNECTOR_GUIDANCE_TEXT[resolve_locale(locale)]
+    lines = [text["title"], "", *text["intro"], "", text["adapters_heading"], text["adapters_intro"],
         "hermes-sprintable · openclaw-sprintable · opencode-sprintable · grok-sprintable ·",
         "pi-sprintable · codex-sprintable · cursor-sprintable · gemini-sprintable",
-        "",
-        "## 설정",
-        "1. 위 폴더 중 사용 중인 런타임에 맞는 폴더를 복사하세요(각 폴더는 sibling import 없이",
-        "   독립 동작합니다).",
-        "2. 폴더의 `README.md` 안내대로 `AGENT_API_KEY`(이 에이전트의 scoped key) 등 env를 설정하세요.",
-        "3. 어댑터를 런타임 호스트에서 직접 실행하세요(호스팅 실행은 지원하지 않음 — 설치/실행은",
-        "   사용자 수동).",
-    ]
+        "", text["setup_heading"]]
+    lines += [f"{i}. {step}" for i, step in enumerate(text["setup_steps"], 1)]
     if runtime_hint:
-        lines.insert(2, f"(선택한 런타임: {runtime_hint})")
+        lines.insert(2, text["runtime_hint"].format(runtime=runtime_hint))
     return "\n".join(lines)
 
 _LOCAL_FALLBACK_URL = "http://localhost:8000"

--- a/backend/app/services/agent_onboarding_config.py
+++ b/backend/app/services/agent_onboarding_config.py
@@ -154,10 +154,13 @@ _CONNECTOR_GUIDANCE_TEXT: dict[str, dict[str, Any]] = {
         "adapters_heading": "## 사용 가능한 어댑터",
         "adapters_intro": "`connectors/` 레포 경로 아래 각 폴더가 자기완결(self-contained) 어댑터입니다:",
         "setup_heading": "## 설정",
+        # 까심 QA MUST-FIX(2026-07-08, #1966): dict화 전 원문의 줄바꿈(1·3번 항목이 2줄로
+        # 쪼개져 있었음)을 그대로 보존 — PR이 "default-ko 100% 무변경"이라 주장했는데 실제로는
+        # 한 줄로 합쳐져 byte-diff가 있었다. 여기 임베드된 "\n   "이 원문 join 결과를 재현한다.
         "setup_steps": [
-            "위 폴더 중 사용 중인 런타임에 맞는 폴더를 복사하세요(각 폴더는 sibling import 없이 독립 동작합니다).",
+            "위 폴더 중 사용 중인 런타임에 맞는 폴더를 복사하세요(각 폴더는 sibling import 없이\n   독립 동작합니다).",
             "폴더의 `README.md` 안내대로 `AGENT_API_KEY`(이 에이전트의 scoped key) 등 env를 설정하세요.",
-            "어댑터를 런타임 호스트에서 직접 실행하세요(호스팅 실행은 지원하지 않음 — 설치/실행은 사용자 수동).",
+            "어댑터를 런타임 호스트에서 직접 실행하세요(호스팅 실행은 지원하지 않음 — 설치/실행은\n   사용자 수동).",
         ],
         "runtime_hint": "(선택한 런타임: {runtime})",
     },
@@ -188,7 +191,9 @@ def build_connector_guidance(runtime_hint: str | None = None, locale: str = DEFA
     README가 5조 계약(SSE dial-out·turn 주입·응답·ack·에러)을 담고 있어 여기선 안내만 재생산한다.
 
     E-I18N Phase C(story 11f1087c) — locale 분기(compose_prompt류와 동형 dict 패턴). 기본값
-    ``DEFAULT_LOCALE``이라 기존 호출부(locale 인자 없이 호출)는 무변경 하위호환.
+    ``DEFAULT_LOCALE``이라 기존 호출부(locale 인자 없이 호출)는 **byte-identical** 하위호환
+    (까심 QA MUST-FIX: dict화 시 실수로 원문 줄바꿈이 사라졌던 걸 복원 — 아래 realdb 테스트가
+    아니라 유닛 테스트가 원문 리터럴과 정확히 일치하는지 직접 assert한다).
     """
     text = _CONNECTOR_GUIDANCE_TEXT[resolve_locale(locale)]
     lines = [text["title"], "", *text["intro"], "", text["adapters_heading"], text["adapters_intro"],

--- a/backend/app/services/recruit_service.py
+++ b/backend/app/services/recruit_service.py
@@ -80,6 +80,7 @@ async def recruit_agent(
     role_template: RoleTemplate,
     runtime: str,
     actor_id: uuid.UUID,
+    locale: str = "ko",
 ) -> dict[str, Any]:
     """recruit 본체 — 반환: ``{persona, api_key_plaintext, tool_allowlist}``.
 
@@ -93,6 +94,10 @@ async def recruit_agent(
     존재하지 않는 행은 못 잠그므로(check-then-insert TOCTOU — 기존 [[feedback_check_then_insert_toctou]]
     교훈과 동형) agent-scoped `pg_advisory_xact_lock` 으로 이 함수 본문 전체(조회→분기→write)를
     직렬화한다 — 트랜잭션 종료 시 자동 해제, 기존 `onboarding_first_auth:{member_id}` 관례와 동일 패턴.
+
+    E-I18N Phase C(story 11f1087c): ``locale``은 request-scoped(호출부가 FE 전달값→Accept-Language
+    폴백으로 이미 정규화해 넘긴다) — 여기선 그대로 ``compose_prompt``에 전달만 한다. 기본값 "ko"라
+    이 함수를 직접 호출하는 기존/테스트 코드는 무변경 하위호환.
     """
     await acquire_agent_mutation_lock(session, agent_member.id)
 
@@ -100,7 +105,7 @@ async def recruit_agent(
     validate_tool_groups(tool_allowlist)  # fail-closed — ValueError 전파, 호출부가 400 매핑
 
     recipe = await resolve_recipe_by_slug(session, role_template.default_workflow_recipe_slug)
-    system_prompt = compose_prompt(role_template, recipe, runtime)
+    system_prompt = compose_prompt(role_template, recipe, runtime, locale)
 
     persona_repo = AgentPersonaRepository(session)
     existing = await persona_repo.get_recruited(org_id, agent_member.project_id, agent_member.id)

--- a/backend/tests/test_e_mcp_opt_s3_hosted_transport.py
+++ b/backend/tests/test_e_mcp_opt_s3_hosted_transport.py
@@ -168,7 +168,7 @@ async def test_get_verification_state_stdio_default_unchanged():
 # ── ③ router 레벨 transport 배선 ──────────────────────────────────────────────
 @pytest.mark.anyio
 async def test_connection_artifact_transport_http_returns_http_content(monkeypatch):
-    from app.routers.agents import get_agent_connection_artifact
+    from app.routers.agents import _connection_artifact as get_agent_connection_artifact
 
     monkeypatch.setenv("MCP_PUBLIC_URL", "https://mcp.sprintable.ai/mcp")
     agent_id = uuid.uuid4()
@@ -191,7 +191,7 @@ async def test_connection_artifact_transport_http_unavailable_400(monkeypatch):
     """http 명시 요청됐는데 이 환경엔 호스팅 배포가 없음(MCP_PUBLIC_URL 미설정) — 400."""
     from fastapi import HTTPException
 
-    from app.routers.agents import get_agent_connection_artifact
+    from app.routers.agents import _connection_artifact as get_agent_connection_artifact
 
     monkeypatch.delenv("MCP_PUBLIC_URL", raising=False)
     agent_id = uuid.uuid4()
@@ -212,7 +212,7 @@ async def test_connection_artifact_transport_http_unavailable_400(monkeypatch):
 async def test_connection_artifact_unsupported_transport_400():
     from fastapi import HTTPException
 
-    from app.routers.agents import get_agent_connection_artifact
+    from app.routers.agents import _connection_artifact as get_agent_connection_artifact
     agent_id = uuid.uuid4()
     res = MagicMock()
     res.scalar_one_or_none.return_value = SimpleNamespace(id=agent_id, project_id=uuid.uuid4())
@@ -270,7 +270,9 @@ def test_agents_router_no_longer_hardcodes_transport_stdio_literal():
     import inspect
     src = inspect.getsource(ag)
     create_src = inspect.getsource(ag.create_org_agent)
-    artifact_src = inspect.getsource(ag.get_agent_connection_artifact)
+    # 까심 QA 근본 fix(2026-07-08) 후속: 실 로직이 `_connection_artifact`(Header() DI 없는
+    # 내부 함수)로 옮겨졌다 — 라우트 함수(get_agent_connection_artifact)는 얇은 위임만.
+    artifact_src = inspect.getsource(ag._connection_artifact)
     assert 'transport="stdio"' not in create_src
     assert 'transport="stdio"' not in artifact_src
     assert 'transport=config_bundle["default_transport"]' in create_src

--- a/backend/tests/test_e_mcp_opt_s3_hosted_transport.py
+++ b/backend/tests/test_e_mcp_opt_s3_hosted_transport.py
@@ -179,7 +179,7 @@ async def test_connection_artifact_transport_http_returns_http_content(monkeypat
     with patch("app.routers.agents.AgentPersonaRepository.list", new_callable=AsyncMock, return_value=[]):
         out = await get_agent_connection_artifact(
             agent_id, runtime="claude-code", transport="http",
-            session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+            accept_language=None, session=db, auth=MagicMock(), org_id=uuid.uuid4(),
         )
     mcp_file = next(f for f in out["files"] if f["filename"] == ".mcp.json")
     parsed = json.loads(mcp_file["content"])
@@ -203,7 +203,7 @@ async def test_connection_artifact_transport_http_unavailable_400(monkeypatch):
         with pytest.raises(HTTPException) as ei:
             await get_agent_connection_artifact(
                 agent_id, runtime="claude-code", transport="http",
-                session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+                accept_language=None, session=db, auth=MagicMock(), org_id=uuid.uuid4(),
             )
     assert ei.value.status_code == 400
 
@@ -222,7 +222,7 @@ async def test_connection_artifact_unsupported_transport_400():
          pytest.raises(HTTPException) as ei:
         await get_agent_connection_artifact(
             agent_id, runtime="claude-code", transport="carrier-pigeon",
-            session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+            accept_language=None, session=db, auth=MagicMock(), org_id=uuid.uuid4(),
         )
     assert ei.value.status_code == 400
 

--- a/backend/tests/test_e_recruit_s3_recruit_endpoint.py
+++ b/backend/tests/test_e_recruit_s3_recruit_endpoint.py
@@ -26,7 +26,7 @@ def _auth_ctx():
 async def test_recruit_404_when_agent_not_found():
     """S19(#8): 이제 agent 존재+ownership 확인이 assert_agent_owner 단일 호출로 합쳐졌다."""
     from fastapi import HTTPException
-    from app.routers.agents import recruit_agent_endpoint
+    from app.routers.agents import _recruit_agent_endpoint as recruit_agent_endpoint
     from app.schemas.recruit import RecruitRequest
 
     session = MagicMock()
@@ -44,7 +44,7 @@ async def test_recruit_404_when_agent_not_found():
 async def test_recruit_403_when_caller_not_owner_or_admin():
     """S19(#8 MUST): agent의 생성자도 org-admin도 아닌 caller는 재채용 불가."""
     from fastapi import HTTPException
-    from app.routers.agents import recruit_agent_endpoint
+    from app.routers.agents import _recruit_agent_endpoint as recruit_agent_endpoint
     from app.schemas.recruit import RecruitRequest
 
     session = MagicMock()
@@ -61,7 +61,7 @@ async def test_recruit_403_when_caller_not_owner_or_admin():
 @pytest.mark.anyio
 async def test_recruit_400_on_unsupported_runtime():
     from fastapi import HTTPException
-    from app.routers.agents import recruit_agent_endpoint
+    from app.routers.agents import _recruit_agent_endpoint as recruit_agent_endpoint
     from app.schemas.recruit import RecruitRequest
 
     session = MagicMock()
@@ -78,7 +78,7 @@ async def test_recruit_400_on_unsupported_runtime():
 @pytest.mark.anyio
 async def test_recruit_404_when_role_template_not_found():
     from fastapi import HTTPException
-    from app.routers.agents import recruit_agent_endpoint
+    from app.routers.agents import _recruit_agent_endpoint as recruit_agent_endpoint
     from app.schemas.recruit import RecruitRequest
 
     session = MagicMock()
@@ -97,7 +97,7 @@ async def test_recruit_404_when_role_template_not_found():
 async def test_recruit_400_when_recruit_agent_raises_value_error():
     """QA MINOR 하드닝: recruit_agent의 fail-closed ValueError가 400으로 매핑되는지(500 아님)."""
     from fastapi import HTTPException
-    from app.routers.agents import recruit_agent_endpoint
+    from app.routers.agents import _recruit_agent_endpoint as recruit_agent_endpoint
     from app.schemas.recruit import RecruitRequest
 
     session = MagicMock()
@@ -117,7 +117,7 @@ async def test_recruit_400_when_recruit_agent_raises_value_error():
 
 @pytest.mark.anyio
 async def test_recruit_success_response_shape():
-    from app.routers.agents import recruit_agent_endpoint
+    from app.routers.agents import _recruit_agent_endpoint as recruit_agent_endpoint
     from app.schemas.recruit import RecruitRequest
 
     session = MagicMock()
@@ -163,7 +163,7 @@ async def test_recruit_success_connector_only_runtime_mcp_config_null_no_crash(r
     """전 런타임 올지원(story 6f6ac081): 커넥터 전용 5종으로 recruit() — 실 SUPPORTED_RUNTIMES
     가드 통과(400 아님) + 실 build_agent_mcp_config_bundle(mock 아님)이 mcp_config=None을
     반환해도 응답 구성이 크래시 없이 완료돼야 한다."""
-    from app.routers.agents import recruit_agent_endpoint
+    from app.routers.agents import _recruit_agent_endpoint as recruit_agent_endpoint
     from app.schemas.recruit import RecruitRequest
 
     session = MagicMock()
@@ -196,7 +196,7 @@ async def test_recruit_success_connector_only_runtime_mcp_config_null_no_crash(r
 # ── E-I18N Phase C(story 11f1087c) — locale 소스 배선(body.locale → Accept-Language 폴백) ──
 
 async def _recruit_with_locale(body, accept_language=None):
-    from app.routers.agents import recruit_agent_endpoint
+    from app.routers.agents import _recruit_agent_endpoint as recruit_agent_endpoint
 
     session = MagicMock()
     session.commit = AsyncMock()

--- a/backend/tests/test_e_recruit_s3_recruit_endpoint.py
+++ b/backend/tests/test_e_recruit_s3_recruit_endpoint.py
@@ -109,7 +109,7 @@ async def test_recruit_400_when_recruit_agent_raises_value_error():
          patch("app.routers.agents.recruit_agent", AsyncMock(side_effect=ValueError("unknown group"))):
         with pytest.raises(HTTPException) as ei:
             await recruit_agent_endpoint(
-                uuid.uuid4(), RecruitRequest(role_template_slug="bogus"),
+                uuid.uuid4(), RecruitRequest(role_template_slug="bogus"), accept_language=None,
                 session=session, auth=_auth_ctx(), org_id=uuid.uuid4(),
             )
     assert ei.value.status_code == 400
@@ -143,7 +143,7 @@ async def test_recruit_success_response_shape():
          patch("app.routers.agents.build_agent_mcp_config_bundle", MagicMock(return_value=bundle)), \
          patch("app.routers.agents.emit_onboarding_event", AsyncMock()):
         response = await recruit_agent_endpoint(
-            agent_id, RecruitRequest(role_template_slug="backend"),
+            agent_id, RecruitRequest(role_template_slug="backend"), accept_language=None,
             session=session, auth=_auth_ctx(), org_id=uuid.uuid4(),
         )
 
@@ -183,7 +183,7 @@ async def test_recruit_success_connector_only_runtime_mcp_config_null_no_crash(r
          patch("app.routers.agents.recruit_agent", AsyncMock(return_value=recruit_result)), \
          patch("app.routers.agents.emit_onboarding_event", AsyncMock()):
         response = await recruit_agent_endpoint(
-            agent_id, RecruitRequest(role_template_slug="backend", runtime=runtime),
+            agent_id, RecruitRequest(role_template_slug="backend", runtime=runtime), accept_language=None,
             session=session, auth=_auth_ctx(), org_id=uuid.uuid4(),
         )
 
@@ -191,3 +191,62 @@ async def test_recruit_success_connector_only_runtime_mcp_config_null_no_crash(r
     assert response["mcp_config"] is None
     assert response["mcp_config_alternatives"] == {}
     session.commit.assert_awaited_once()
+
+
+# ── E-I18N Phase C(story 11f1087c) — locale 소스 배선(body.locale → Accept-Language 폴백) ──
+
+async def _recruit_with_locale(body, accept_language=None):
+    from app.routers.agents import recruit_agent_endpoint
+
+    session = MagicMock()
+    session.commit = AsyncMock()
+    agent_id = uuid.uuid4()
+    member = SimpleNamespace(id=agent_id, project_id=uuid.uuid4())
+    role_template = SimpleNamespace(slug="backend", default_tool_groups=["stories", "tasks"])
+    persona = SimpleNamespace(id=uuid.uuid4(), system_prompt="합성된 지침 텍스트")
+    recruit_result = {
+        "persona": persona,
+        "api_key_plaintext": "sk_live_deadbeef",
+        "tool_allowlist": ["stories", "tasks"],
+    }
+    recruit_mock = AsyncMock(return_value=recruit_result)
+    with patch("app.routers.agents.assert_agent_owner", AsyncMock(return_value=member)), \
+         patch("app.routers.agents.get_published_role_template", AsyncMock(return_value=role_template)), \
+         patch("app.routers.agents.recruit_agent", recruit_mock), \
+         patch("app.routers.agents.emit_onboarding_event", AsyncMock()):
+        await recruit_agent_endpoint(
+            agent_id, body, accept_language=accept_language,
+            session=session, auth=_auth_ctx(), org_id=uuid.uuid4(),
+        )
+    return recruit_mock
+
+
+@pytest.mark.anyio
+async def test_recruit_locale_explicit_body_field_wins_over_header():
+    from app.schemas.recruit import RecruitRequest
+
+    recruit_mock = await _recruit_with_locale(
+        RecruitRequest(role_template_slug="backend", locale="en"),
+        accept_language="ko-KR,ko;q=0.9",
+    )
+    assert recruit_mock.call_args.kwargs["locale"] == "en"
+
+
+@pytest.mark.anyio
+async def test_recruit_locale_falls_back_to_accept_language_header():
+    from app.schemas.recruit import RecruitRequest
+
+    recruit_mock = await _recruit_with_locale(
+        RecruitRequest(role_template_slug="backend"),
+        accept_language="en-US,en;q=0.9",
+    )
+    assert recruit_mock.call_args.kwargs["locale"] == "en"
+
+
+@pytest.mark.anyio
+async def test_recruit_locale_no_signal_defaults_to_korean_backward_compatible():
+    """body.locale도 Accept-Language도 없으면(기존 FE 무변경 호출) 예전과 동일하게 ko."""
+    from app.schemas.recruit import RecruitRequest
+
+    recruit_mock = await _recruit_with_locale(RecruitRequest(role_template_slug="backend"))
+    assert recruit_mock.call_args.kwargs["locale"] == "ko"

--- a/backend/tests/test_e_recruit_s5_connection_artifact_realdb.py
+++ b/backend/tests/test_e_recruit_s5_connection_artifact_realdb.py
@@ -77,7 +77,7 @@ async def test_connection_artifact_emits_persona_file_real_decorate_path():
     from unittest.mock import MagicMock
     from sqlalchemy import text as _text
     from app.core.database import Base
-    from app.routers.agents import get_agent_connection_artifact
+    from app.routers.agents import _connection_artifact as get_agent_connection_artifact
 
     engine, Session = await _session()
     try:
@@ -114,7 +114,7 @@ async def test_connection_artifact_no_persona_backward_compatible_real_db():
     from unittest.mock import MagicMock
     from sqlalchemy import text as _text
     from app.core.database import Base
-    from app.routers.agents import get_agent_connection_artifact
+    from app.routers.agents import _connection_artifact as get_agent_connection_artifact
 
     engine, Session = await _session()
     try:
@@ -144,7 +144,7 @@ async def test_connection_artifact_connector_runtime_real_db():
     from unittest.mock import MagicMock
     from sqlalchemy import text as _text
     from app.core.database import Base
-    from app.routers.agents import get_agent_connection_artifact
+    from app.routers.agents import _connection_artifact as get_agent_connection_artifact
 
     engine, Session = await _session()
     try:
@@ -177,7 +177,7 @@ async def test_connection_artifact_connector_only_runtimes_real_db(runtime):
     from unittest.mock import MagicMock
     from sqlalchemy import text as _text
     from app.core.database import Base
-    from app.routers.agents import get_agent_connection_artifact
+    from app.routers.agents import _connection_artifact as get_agent_connection_artifact
 
     engine, Session = await _session()
     try:
@@ -213,7 +213,7 @@ async def test_connection_artifact_no_default_persona_omits_instruction_file():
     from app.core.database import Base
     from app.models.team import TeamMember
     from app.models.agent_deployment import AgentPersona
-    from app.routers.agents import get_agent_connection_artifact
+    from app.routers.agents import _connection_artifact as get_agent_connection_artifact
 
     engine, Session = await _session()
     try:

--- a/backend/tests/test_ob1_agent_onboarding_config.py
+++ b/backend/tests/test_ob1_agent_onboarding_config.py
@@ -86,7 +86,7 @@ def _db_returning(member):
 
 @pytest.mark.anyio
 async def test_connection_artifact_returns_stdio_with_placeholder():
-    from app.routers.agents import get_agent_connection_artifact
+    from app.routers.agents import _connection_artifact as get_agent_connection_artifact
 
     agent_id = uuid.uuid4()
     db = _db_returning(SimpleNamespace(id=agent_id, project_id=uuid.uuid4()))
@@ -117,7 +117,7 @@ async def test_connection_artifact_with_persona_emits_instruction_file():
     거치므로, 이 라우터-계층 테스트는 그 메서드 자체를 patch(반환값만 확인)한다 — 실 DB 조회
     시맨틱은 별도 realdb 테스트가 검증."""
     from unittest.mock import patch
-    from app.routers.agents import get_agent_connection_artifact
+    from app.routers.agents import _connection_artifact as get_agent_connection_artifact
 
     agent_id = uuid.uuid4()
     # 까심 QA RC(S5): is_default=True 명시 — list()의 정렬 순서([0])만으론 default 보장 안 됨.
@@ -144,7 +144,7 @@ async def test_connection_artifact_non_default_persona_omits_instruction_file():
     """까심 QA RC(S5): personas[0]가 is_default=False면(list() 정렬만으론 default 안 보장) 지침
     파일을 emit하면 안 됨 — 안전 fallback으로 생략(.mcp.json만)."""
     from unittest.mock import patch
-    from app.routers.agents import get_agent_connection_artifact
+    from app.routers.agents import _connection_artifact as get_agent_connection_artifact
 
     agent_id = uuid.uuid4()
     persona = SimpleNamespace(resolved_system_prompt="이건 authoritative 아님.", is_default=False)
@@ -165,7 +165,7 @@ async def test_connection_artifact_non_default_persona_omits_instruction_file():
 @pytest.mark.anyio
 async def test_connection_artifact_connector_runtime_returns_pointer_only():
     """Q2(PO 확정): connector 런타임은 `.mcp.json` 없이 포인터/안내 파일만."""
-    from app.routers.agents import get_agent_connection_artifact
+    from app.routers.agents import _connection_artifact as get_agent_connection_artifact
 
     agent_id = uuid.uuid4()
     db = _db_returning(SimpleNamespace(id=agent_id, project_id=uuid.uuid4()))
@@ -182,7 +182,7 @@ async def test_connection_artifact_connector_runtime_returns_pointer_only():
 @pytest.mark.anyio
 async def test_connection_artifact_connector_guidance_locale_from_explicit_query():
     """E-I18N Phase C: locale 쿼리 파라미터가 CONNECTOR_SETUP.md 내용에 반영."""
-    from app.routers.agents import get_agent_connection_artifact
+    from app.routers.agents import _connection_artifact as get_agent_connection_artifact
 
     agent_id = uuid.uuid4()
     db = _db_returning(SimpleNamespace(id=agent_id, project_id=uuid.uuid4()))
@@ -197,7 +197,7 @@ async def test_connection_artifact_connector_guidance_locale_from_explicit_query
 @pytest.mark.anyio
 async def test_connection_artifact_connector_guidance_locale_from_accept_language_fallback():
     """locale 쿼리 미지정 시 Accept-Language 헤더로 폴백."""
-    from app.routers.agents import get_agent_connection_artifact
+    from app.routers.agents import _connection_artifact as get_agent_connection_artifact
 
     agent_id = uuid.uuid4()
     db = _db_returning(SimpleNamespace(id=agent_id, project_id=uuid.uuid4()))
@@ -212,7 +212,7 @@ async def test_connection_artifact_connector_guidance_locale_from_accept_languag
 @pytest.mark.anyio
 async def test_connection_artifact_connector_guidance_no_locale_signal_stays_korean():
     """locale도 Accept-Language도 없으면(기존 호출부 무변경) 기존과 동일한 한글 출력."""
-    from app.routers.agents import get_agent_connection_artifact
+    from app.routers.agents import _connection_artifact as get_agent_connection_artifact
 
     agent_id = uuid.uuid4()
     db = _db_returning(SimpleNamespace(id=agent_id, project_id=uuid.uuid4()))
@@ -231,7 +231,7 @@ async def test_connection_artifact_unsupported_runtime_400():
     문자열에만 여전히 걸려야 한다(방어 가드 자체는 무회귀)."""
     from fastapi import HTTPException
 
-    from app.routers.agents import get_agent_connection_artifact
+    from app.routers.agents import _connection_artifact as get_agent_connection_artifact
     with pytest.raises(HTTPException) as ei:
         await get_agent_connection_artifact(
             uuid.uuid4(), runtime="totally-unknown-runtime", session=AsyncMock(),
@@ -244,7 +244,7 @@ async def test_connection_artifact_unsupported_runtime_400():
 async def test_connection_artifact_not_found_404():
     from fastapi import HTTPException
 
-    from app.routers.agents import get_agent_connection_artifact
+    from app.routers.agents import _connection_artifact as get_agent_connection_artifact
     db = _db_returning(None)
     with pytest.raises(HTTPException) as ei:
         await get_agent_connection_artifact(

--- a/backend/tests/test_ob1_agent_onboarding_config.py
+++ b/backend/tests/test_ob1_agent_onboarding_config.py
@@ -91,7 +91,8 @@ async def test_connection_artifact_returns_stdio_with_placeholder():
     agent_id = uuid.uuid4()
     db = _db_returning(SimpleNamespace(id=agent_id, project_id=uuid.uuid4()))
     out = await get_agent_connection_artifact(
-        agent_id, runtime="claude-code", session=db, auth=MagicMock(), org_id=uuid.uuid4()
+        agent_id, runtime="claude-code", accept_language=None,
+        session=db, auth=MagicMock(), org_id=uuid.uuid4()
     )
     # E-RECRUIT S5 BE↔FE 계약(story 4fca5a3e): {files[], mcp_config, api_key, agent_id, runtime}
     assert out["agent_id"] == str(agent_id)
@@ -128,7 +129,8 @@ async def test_connection_artifact_with_persona_emits_instruction_file():
         new_callable=AsyncMock, return_value=[persona],
     ):
         out = await get_agent_connection_artifact(
-            agent_id, runtime="claude-code", session=db, auth=MagicMock(), org_id=uuid.uuid4()
+            agent_id, runtime="claude-code", accept_language=None,
+            session=db, auth=MagicMock(), org_id=uuid.uuid4()
         )
     assert len(out["files"]) == 2
     filenames = {f["filename"] for f in out["files"]}
@@ -153,7 +155,8 @@ async def test_connection_artifact_non_default_persona_omits_instruction_file():
         new_callable=AsyncMock, return_value=[persona],
     ):
         out = await get_agent_connection_artifact(
-            agent_id, runtime="claude-code", session=db, auth=MagicMock(), org_id=uuid.uuid4()
+            agent_id, runtime="claude-code", accept_language=None,
+            session=db, auth=MagicMock(), org_id=uuid.uuid4()
         )
     assert len(out["files"]) == 1
     assert out["files"][0]["filename"] == ".mcp.json"
@@ -167,12 +170,58 @@ async def test_connection_artifact_connector_runtime_returns_pointer_only():
     agent_id = uuid.uuid4()
     db = _db_returning(SimpleNamespace(id=agent_id, project_id=uuid.uuid4()))
     out = await get_agent_connection_artifact(
-        agent_id, runtime="connector", session=db, auth=MagicMock(), org_id=uuid.uuid4()
+        agent_id, runtime="connector", accept_language=None,
+        session=db, auth=MagicMock(), org_id=uuid.uuid4()
     )
     assert out["mcp_config"] is None
     assert len(out["files"]) == 1
     assert out["files"][0]["filename"] == "CONNECTOR_SETUP.md"
     assert "connectors/" in out["files"][0]["content"]
+
+
+@pytest.mark.anyio
+async def test_connection_artifact_connector_guidance_locale_from_explicit_query():
+    """E-I18N Phase C: locale 쿼리 파라미터가 CONNECTOR_SETUP.md 내용에 반영."""
+    from app.routers.agents import get_agent_connection_artifact
+
+    agent_id = uuid.uuid4()
+    db = _db_returning(SimpleNamespace(id=agent_id, project_id=uuid.uuid4()))
+    out = await get_agent_connection_artifact(
+        agent_id, runtime="grok", locale="en", session=db, auth=MagicMock(), org_id=uuid.uuid4()
+    )
+    content = out["files"][0]["content"]
+    assert "# Sprintable Connector Guide" in content
+    assert "# Sprintable Connector 안내" not in content
+
+
+@pytest.mark.anyio
+async def test_connection_artifact_connector_guidance_locale_from_accept_language_fallback():
+    """locale 쿼리 미지정 시 Accept-Language 헤더로 폴백."""
+    from app.routers.agents import get_agent_connection_artifact
+
+    agent_id = uuid.uuid4()
+    db = _db_returning(SimpleNamespace(id=agent_id, project_id=uuid.uuid4()))
+    out = await get_agent_connection_artifact(
+        agent_id, runtime="grok", accept_language="en-US,en;q=0.9",
+        session=db, auth=MagicMock(), org_id=uuid.uuid4(),
+    )
+    content = out["files"][0]["content"]
+    assert "# Sprintable Connector Guide" in content
+
+
+@pytest.mark.anyio
+async def test_connection_artifact_connector_guidance_no_locale_signal_stays_korean():
+    """locale도 Accept-Language도 없으면(기존 호출부 무변경) 기존과 동일한 한글 출력."""
+    from app.routers.agents import get_agent_connection_artifact
+
+    agent_id = uuid.uuid4()
+    db = _db_returning(SimpleNamespace(id=agent_id, project_id=uuid.uuid4()))
+    out = await get_agent_connection_artifact(
+        agent_id, runtime="grok", accept_language=None,
+        session=db, auth=MagicMock(), org_id=uuid.uuid4()
+    )
+    content = out["files"][0]["content"]
+    assert "# Sprintable Connector 안내" in content
 
 
 @pytest.mark.anyio
@@ -199,7 +248,8 @@ async def test_connection_artifact_not_found_404():
     db = _db_returning(None)
     with pytest.raises(HTTPException) as ei:
         await get_agent_connection_artifact(
-            uuid.uuid4(), runtime="claude-code", session=db, auth=MagicMock(), org_id=uuid.uuid4()
+            uuid.uuid4(), runtime="claude-code", accept_language=None,
+            session=db, auth=MagicMock(), org_id=uuid.uuid4()
         )
     assert ei.value.status_code == 404
 
@@ -227,3 +277,53 @@ def test_default_locale_is_korean():
     """FE 기본값(en, "방문자 신호 0"용)과 의도적으로 다르다 — BE는 오늘 실 콘텐츠가 있는
     locale(ko)이 안전한 폴백(en 콘텐츠는 아직 없음, Phase A 스코프)."""
     assert gen.DEFAULT_LOCALE == "ko"
+
+
+# ── E-I18N Phase C(story 11f1087c) — locale 소스 배선(FE 명시→Accept-Language 폴백) ──────
+
+def test_resolve_locale_from_request_prefers_explicit_over_header():
+    assert gen.resolve_locale_from_request("en", "ko-KR,ko;q=0.9") == "en"
+
+
+def test_resolve_locale_from_request_falls_back_to_accept_language_header():
+    assert gen.resolve_locale_from_request(None, "en-US,en;q=0.9,ko;q=0.8") == "en"
+    assert gen.resolve_locale_from_request(None, "ko-KR,ko;q=0.9") == "ko"
+
+
+def test_resolve_locale_from_request_ignores_unsupported_header_tags():
+    """Accept-Language가 미지원 언어들뿐이면(fr 등) DEFAULT_LOCALE로 폴백 — 크래시 없음."""
+    assert gen.resolve_locale_from_request(None, "fr-FR,fr;q=0.9,de;q=0.8") == gen.DEFAULT_LOCALE
+
+
+def test_resolve_locale_from_request_no_signal_falls_back_to_default():
+    assert gen.resolve_locale_from_request(None, None) == gen.DEFAULT_LOCALE
+
+
+def test_resolve_locale_from_request_explicit_unsupported_falls_back_to_default():
+    """explicit이 있어도 미지원 값이면(resolve_locale 위임) DEFAULT_LOCALE — 헤더로 폴백하지
+    않는다(명시 전달 우선순위가 명확히 이겼으면 그 판단을 신뢰, 헤더 재시도는 안 함)."""
+    assert gen.resolve_locale_from_request("fr", "en-US,en;q=0.9") == gen.DEFAULT_LOCALE
+
+
+# ── E-I18N Phase C — build_connector_guidance locale 분기 ──────────────────────────
+
+def test_build_connector_guidance_default_locale_is_korean_backward_compatible():
+    out = gen.build_connector_guidance("grok")
+    assert "# Sprintable Connector 안내" in out
+    assert "(선택한 런타임: grok)" in out
+    assert "grok-sprintable" in out
+
+
+def test_build_connector_guidance_english_locale():
+    out = gen.build_connector_guidance("grok", locale="en")
+    assert "# Sprintable Connector Guide" in out
+    assert "(Selected runtime: grok)" in out
+    assert "## Available Adapters" in out
+    assert "## Setup" in out
+    assert "# Sprintable Connector 안내" not in out
+    assert "선택한 런타임" not in out
+
+
+def test_build_connector_guidance_unsupported_locale_falls_back_to_default():
+    out = gen.build_connector_guidance(locale="fr")
+    assert "# Sprintable Connector 안내" in out

--- a/backend/tests/test_ob1_agent_onboarding_config.py
+++ b/backend/tests/test_ob1_agent_onboarding_config.py
@@ -308,10 +308,31 @@ def test_resolve_locale_from_request_explicit_unsupported_falls_back_to_default(
 # ── E-I18N Phase C — build_connector_guidance locale 분기 ──────────────────────────
 
 def test_build_connector_guidance_default_locale_is_korean_backward_compatible():
+    """까심 QA MUST-FIX(2026-07-08, #1966): substring만 체크하면 dict화 과정에서 원문 줄바꿈이
+    사라지는 byte-diff를 못 잡는다(실제로 한 번 놓쳤다) — default-ko 출력이 dict화 이전 원문
+    리터럴과 정확히 byte-identical 인지 직접 assert한다."""
     out = gen.build_connector_guidance("grok")
-    assert "# Sprintable Connector 안내" in out
-    assert "(선택한 런타임: grok)" in out
-    assert "grok-sprintable" in out
+    expected = "\n".join([
+        "# Sprintable Connector 안내",
+        "",
+        "(선택한 런타임: grok)",
+        "Claude Code/Codex/Gemini/Cursor 처럼 MCP를 네이티브 지원하지 않는 런타임은 별도 SSE",
+        "커넥터 어댑터로 연결합니다 — `.mcp.json`이 아니라 `connectors/{runtime}-sprintable/` 폴더의",
+        "어댑터를 사용해 서버에 아웃바운드로 접속합니다(인바운드 도메인/웹훅 불필요).",
+        "",
+        "## 사용 가능한 어댑터",
+        "`connectors/` 레포 경로 아래 각 폴더가 자기완결(self-contained) 어댑터입니다:",
+        "hermes-sprintable · openclaw-sprintable · opencode-sprintable · grok-sprintable ·",
+        "pi-sprintable · codex-sprintable · cursor-sprintable · gemini-sprintable",
+        "",
+        "## 설정",
+        "1. 위 폴더 중 사용 중인 런타임에 맞는 폴더를 복사하세요(각 폴더는 sibling import 없이",
+        "   독립 동작합니다).",
+        "2. 폴더의 `README.md` 안내대로 `AGENT_API_KEY`(이 에이전트의 scoped key) 등 env를 설정하세요.",
+        "3. 어댑터를 런타임 호스트에서 직접 실행하세요(호스팅 실행은 지원하지 않음 — 설치/실행은",
+        "   사용자 수동).",
+    ])
+    assert out == expected
 
 
 def test_build_connector_guidance_english_locale():


### PR DESCRIPTION
## Summary
- crux(`i18n-architecture-design-crux` §1) 결정대로 콘텐츠-생성 엔드포인트에 locale 소스를 배선 — ① FE 명시 전달(`POST /recruit` body.locale, `GET connection-artifact` ?locale=) ② 없으면 `Accept-Language` 헤더 폴백 ③ 그래도 없으면 `DEFAULT_LOCALE`(ko). DB 영속 저장 없음(request-scoped).
- 신규 `resolve_locale_from_request()`(agent_onboarding_config.py)가 이 우선순위를 캡슐화.
- `recruit_agent_endpoint` → `recruit_agent()` → `compose_prompt()`에 resolved locale 배선 — 채용 시점 locale이 persona에 영속 기록.
- `get_agent_connection_artifact` → `build_connector_guidance()`에 resolved locale 배선. 이 함수 자체도 이전엔 100% 하드코딩 한글이었던 걸 [C]/[D]/[E]와 동형 dict 패턴으로 locale 분기(신규 발견 표면, Phase A/B 스코프 밖이었음).
- 이미 채용 시점 locale로 확정 저장된 `persona.resolved_system_prompt`는 connection-artifact GET에서 재합성하지 않음(재손대면 그 시점 기록이 왜곡됨).
- 모든 신규 파라미터 기본값 유지 — 기존 호출부 100% 하위호환.

## Test plan
- [x] 신규 유닛 테스트(resolve_locale_from_request 5종, build_connector_guidance locale 3종, connection-artifact locale 배선 3종, recruit locale 배선 3종)
- [x] 전체 스위트 3189 passed, 8 failed(기존 7건 무관 + live dev backend 네트워크 500 flake 1건, 이 diff와 무관 — `tests/mcp/test_e2e_dev.py::test_read_only_tools_succeed`가 실 배포된 `sprintable-backend-dev-...run.app`에 HTTP 요청해 발생, 로컬 코드 변경과 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)