### PR TITLE
feat(recruit): 채용 출력 kit 재설계 — compose_kit + SPRINTABLE_ONBOARDING.md (story b1fe41cf)

### DIFF
--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -193,6 +193,12 @@ async def get_agent_connection_artifact(
     로직은 Header() 마커가 전혀 없는 ``_connection_artifact()``(plain str만 받음)로 옮기고, 이
     라우트 함수는 얇은 위임만 한다 — 직접-호출 테스트는 ``_connection_artifact``를 불러야 한다
     (Header DI는 라우트 경계에서만 받는다는 원칙).
+
+    채용-kit 재설계(story b1fe41cf, 선생님 GO 2026-07-08): ``resolve_instruction_filename()``이
+    이제 런타임 무관 단일 파일명(``KIT_FILENAME`` = ``SPRINTABLE_ONBOARDING.md``)을 반환한다 —
+    예전엔 CLAUDE.md/AGENTS.md 등 실제 정체성 파일명 리터럴을 써서, 유저가 다운로드해 프로젝트
+    루트에 저장하면 자기 에이전트의 진짜 정체성 파일을 덮어썼다(정체성 뭉갬 버그의 실제 코드
+    지점). 새 파일명은 그 어떤 런타임의 정체성 파일명과도 충돌하지 않는다.
     """
     return await _connection_artifact(
         agent_id, runtime, transport, locale, accept_language,
@@ -322,7 +328,7 @@ async def recruit_agent_endpoint(
     deactivate와 동일한 `assert_agent_owner`(생성자 또는 org-admin)로 닫는다.
 
     E-I18N Phase C(story 11f1087c): ``body.locale``(FE 명시 전달)→``Accept-Language`` 헤더(폴백)
-    순으로 정규화해 ``compose_prompt``에 배선 — 이 시점에 확정된 locale이 persona에 영속 기록된다
+    순으로 정규화해 ``compose_kit``에 배선 — 이 시점에 확정된 locale이 persona에 영속 기록된다
     (재채용 시 다른 locale로 다시 부르면 그 값으로 덮어씀, DB에 별도 locale 컬럼은 없음).
 
     까심 QA CI FAILURE 후속(2026-07-08, connection-artifact와 동형 근본 fix 선제 적용): Header()

--- a/backend/app/services/agent_onboarding_config.py
+++ b/backend/app/services/agent_onboarding_config.py
@@ -63,28 +63,22 @@ def resolve_locale_from_request(explicit: str | None, accept_language: str | Non
                 return primary
     return DEFAULT_LOCALE
 
-# E-RECRUIT S5 G4 + 전 런타임 올지원(story 6f6ac081) — 런타임별 자율 운영 지침 파일명. 공식
-# 문서 실측(추측 0, crux doc에 출처 전부 명시): codex/cursor/grok/pi/hermes/openclaw/opencode
-# 7종이 `AGENTS.md`로 수렴(신흥 cross-tool 표준) — gemini만 `GEMINI.md` 예외. hermes는 우선순위
-# 체인(.hermes.md/HERMES.md→AGENTS.md→CLAUDE.md→.cursorrules)이라 우리가 AGENTS.md 하나만
-# emit해도 그 체인에서 정상 로드된다(더 앞순위 파일은 우리 쪽에서 안 만듦).
-_INSTRUCTION_FILENAMES: dict[str, str] = {
-    "claude-code": "CLAUDE.md",
-    "gemini": "GEMINI.md",
-    "codex": "AGENTS.md",
-    "cursor": "AGENTS.md",
-    "grok": "AGENTS.md",
-    "pi": "AGENTS.md",
-    "hermes": "AGENTS.md",
-    "openclaw": "AGENTS.md",
-    "opencode": "AGENTS.md",
-}
-_DEFAULT_INSTRUCTION_FILENAME = "AGENT_INSTRUCTIONS.md"
+# 채용-kit 재설계(story b1fe41cf, 문서 `recruit-output-kit-redesign-crux`, 선생님 GO
+# 2026-07-08 결정①): 예전엔 런타임별 CLAUDE.md/GEMINI.md/AGENTS.md **리터럴**을 다운로드
+# 파일명으로 썼다 — 유저가 그 파일명 그대로 프로젝트 루트에 저장하면 자기 에이전트의 **실제
+# 기존 정체성 파일을 덮어썼다**(선생님이 지적한 정체성 뭉갬의 실제 코드 지점). 이제 런타임 무관
+# **단일** 파일명(그 어떤 런타임의 실 정체성 파일명과도 충돌하지 않는 이름)으로 통일 — 유저가
+# 이 파일을 "자기 에이전트에게 건네" 자기화하게 하는 kit 모델(§크럭스 2/3).
+KIT_FILENAME = "SPRINTABLE_ONBOARDING.md"
 
 
 def resolve_instruction_filename(runtime: str) -> str:
-    """런타임별 자율 운영 지침 파일명(어댑터 3축 중 하나). 미확정 런타임은 generic 기본값."""
-    return _INSTRUCTION_FILENAMES.get(runtime, _DEFAULT_INSTRUCTION_FILENAME)
+    """자율 운영 kit 파일명 — 채용-kit 재설계 이후 런타임 무관 단일 상수(KIT_FILENAME).
+
+    함수 시그니처(런타임 인자)는 호출부 변경을 최소화하려 유지하지만, 반환값은 이제 런타임에
+    의존하지 않는다(예전엔 CLAUDE.md/GEMINI.md/AGENTS.md로 갈렸음 — 정체성 파일 충돌 버그의
+    원인이라 제거)."""
+    return KIT_FILENAME
 
 
 _RUNTIME_DISPLAY_NAMES: dict[str, str] = {
@@ -109,8 +103,10 @@ def list_runtime_capabilities() -> list[dict]:
     6f6ac081) 이후: MCP-native 4종은 `.mcp.json`(transport 선택 가능), 나머지 지원 런타임
     (커넥터 전용 5종 + 범용 connector 버킷)은 전부 SSE 커넥터 경로(CONNECTOR_SETUP.md, transport
     개념 자체가 없음) — 이 두 그룹의 경계가 ``MCP_NATIVE_RUNTIMES``(``is_connector_routed``)다.
-    tier는 ``_INSTRUCTION_FILENAMES``에 확정 매핑이 있으면 "full"(모든 지원 런타임이 이제 여기
-    포함 — 축2 완료), 없으면(현재 없음, 확장 여지만 유지) "experimental".
+    tier는 구체적으로 이름 붙은 런타임이면 "full", 범용 ``connector`` 버킷(특정 런타임을 못
+    찾았을 때의 안내-only 폴백)이면 "experimental" — 채용-kit 재설계(story b1fe41cf) 이후
+    ``prompt_file``이 전 런타임 동일(``KIT_FILENAME``)이라 그걸로는 더 이상 tier를 구분할 수
+    없어, 원래 의도(구체 런타임 vs 범용 폴백)를 직접 표현한다.
 
     PO 확인(2026-07-06): FE 픽커의 "곧 지원" 섹션이 채워지려면 **미지원 런타임도 응답에
     포함**돼야 한다 — ``RuntimeType``(agent_runtime.py, member.runtime_type 9종 SSOT) 전부가
@@ -130,8 +126,8 @@ def list_runtime_capabilities() -> list[dict]:
             "supported": supported,
             "tier": (
                 None if not supported
-                else "full" if runtime in _INSTRUCTION_FILENAMES
-                else "experimental"
+                else "experimental" if runtime == CONNECTOR_RUNTIME
+                else "full"
             ),
             "transport": None if (is_connector_routed or not supported) else default_transport_for_hosting(),
             "mcp_transport": [] if (is_connector_routed or not supported) else sorted(SUPPORTED_TRANSPORTS),

--- a/backend/app/services/agent_recruiter.py
+++ b/backend/app/services/agent_recruiter.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from app.routers.workflow_recipes import _generate_guide
 from app.services.agent_onboarding_config import MCP_NATIVE_RUNTIMES, resolve_locale
 from app.services.mcp_toolset import ALL_GROUPS, ALL_TOOL_NAMES, _ALWAYS_ALLOWED, tool_group
 
@@ -166,78 +165,109 @@ def _runtime_notes(
 
 
 _SECTION_A_HEADER: dict[str, str] = {
-    "ko": "# {name} — 채용 지침",
-    "en": "# {name} — Recruitment Instructions",
+    "ko": "# {name} — Sprintable 역할 컨텍스트",
+    "en": "# {name} — Sprintable Role Context",
 }
 _SECTION_B_TEXT: dict[str, dict[str, str]] = {
     "ko": {
-        "heading": "## Sprintable 사용법",
+        "heading": "## Sprintable 워크플로",
         "footer": (
-            "\n이 가이드가 오래됐다고 느껴지거나 막히면, 플랫폼이 알려주길 기다리지 말고 "
-            "스스로 `sprintable_get_workflow_guide`를 불러 최신 운영법을 확인하세요."
+            "\n이 조직의 워크플로는 여기 고정해두지 않습니다(팀마다 커스터마이즈하므로 stale해질 "
+            "수 있어서입니다) — 스스로 `sprintable_get_workflow_guide`를 불러 최신 운영법을 "
+            "확인하세요."
         ),
     },
     "en": {
-        "heading": "## How to Use Sprintable",
+        "heading": "## Sprintable Workflow",
         "footer": (
-            "\nIf this guide feels outdated or you're stuck, don't wait for the platform to "
-            "tell you — proactively call `sprintable_get_workflow_guide` yourself to check the "
-            "latest operating procedure."
+            "\nThis org's workflow isn't hardcoded here (teams customize it, so a fixed copy "
+            "would go stale) — proactively call `sprintable_get_workflow_guide` yourself to "
+            "check the current operating procedure."
         ),
     },
 }
+# 채용-kit 재설계(story b1fe41cf, 문서 `recruit-output-kit-redesign-crux`, 선생님 GO
+# 2026-07-08 결정③): kit 말미의 자기통합/메모리 유도 지시문 — 정적 텍스트 주입이 아니라
+# "전달받은 에이전트가 스스로 판단해 자기 메모리에 반영"하도록 유도한다(선생님 원안 문구
+# 그대로, en은 그 의미를 보존한 번역). **기존 정체성을 덮지 말라**는 명시적 경고가 핵심.
+_INTEGRATION_PROMPT_TEXT: dict[str, str] = {
+    "ko": """## 전달받은 에이전트에게
+
+이 문서는 당신 자신의 정체성 파일(CLAUDE.md/AGENTS.md 등)이 아니라, 이 Sprintable 조직에서
+활동하기 위한 컨텍스트 kit입니다. 다음을 스스로 판단해 당신의 메모리(또는 이미 쓰고 있는
+메모리/시스템 체계)에 반영하세요 — 이 파일 내용을 그대로 복사해 자신을 덮어쓰지 마세요:
+
+- 이 조직에서 당신이 맡은 역할(위 "역할 컨텍스트" 참고)
+- 자주 쓰게 될 `sprintable_*` 도구(위 "사용 가능 도구" 참고)
+- 워크플로는 고정 절차로 외우지 말고, 매번 `sprintable_get_workflow_guide`로 최신 확인
+
+**기존 정체성을 덮지 말고, 당신 방식대로 자기화하세요.**""",
+    "en": """## To the agent receiving this
+
+This document is not your own identity file (CLAUDE.md/AGENTS.md, etc.) — it's a context kit
+for operating in this Sprintable org. Use your own judgment to fold the following into your
+memory (or whatever memory/system you already use) — don't copy this file verbatim over
+yourself:
+
+- Your role in this org (see "Role Context" above)
+- The `sprintable_*` tools you'll use often (see "Available Tools" above)
+- Don't memorize the workflow as a fixed procedure — re-check it every time via
+  `sprintable_get_workflow_guide`
+
+**Don't overwrite your existing identity — integrate this in your own way.**""",
+}
 
 
-def compose_prompt(
+def compose_kit(
     role_template: Any,
-    recipe: dict[str, Any] | None,
     runtime: str,
     locale: str = "ko",
-) -> str:
-    """자율 운영 지침 합성 — 순수 함수(네트워크/DB 호출 0·부수효과 0. G4).
+) -> dict[str, str]:
+    """채용 kit 합성 — 순수 함수(네트워크/DB 호출 0·부수효과 0. G4).
+
+    채용-kit 재설계(story b1fe41cf, 문서 `recruit-output-kit-redesign-crux`, 선생님 GO
+    2026-07-08)로 옛 `compose_prompt`(CLAUDE.md **전체 대체**를 노린 단일 문자열)를 대체한다.
+    유저가 이미 자기 정체성을 가진 에이전트를 쓴다는 전제 — 이 kit은 그 정체성을 덮어쓰는 게
+    아니라, "이 조직에서 이 역할로 일하는 법"을 전달해 에이전트가 스스로 자기화하게 한다.
 
     Args:
         role_template: role_templates 행(또는 동형 속성을 가진 객체) — role_behaviors·
-            default_tool_groups·runtime_overrides 를 속성으로 읽는다(ORM 인스턴스·SimpleNamespace
-            등 duck-typing — dict 도 `.get`이 아니라 속성 접근이 필요하면 호출부가 변환).
-        recipe: workflow_recipes 형태의 dict({name, description, steps, ...}) 또는 None(추천
-            워크플로우 없음 — 섹션 [B] 워크플로우 가이드 부분만 생략, 나머지 섹션은 정상 생성).
-        runtime: 실행 런타임 식별자(예: "claude-code").
-        locale: E-I18N Phase A(story 11f1087c) — "ko"|"en", 미지원 값은 호출부가
-            `agent_onboarding_config.resolve_locale()`로 정규화해 넘겨야 한다(이 함수 자체는
-            방어적으로 `_AGILE_OPERATING_RULES`류 dict에 없는 키가 오면 KeyError — 순수함수라
-            폴백 로직을 여기 넣지 않고 호출부 책임으로 둔다, 기존 `validate_tool_groups`
-            fail-closed 철학과 동형).
+            default_tool_groups·runtime_overrides 를 속성으로 읽는다(duck-typing).
+        runtime: 실행 런타임 식별자.
+        locale: "ko"|"en" — 미지원 값은 호출부가 `resolve_locale()`로 정규화해 넘겨야 한다
+            (이 함수는 방어적 폴백 없음 — `validate_tool_groups`와 동일한 fail-closed 철학).
 
     Returns:
-        5섹션([A]~[E])을 이어붙인 markdown 문자열(diffable — 순수 문자열 결합, LLM 비호출).
+        구조화된 kit dict — ``{role_context, onboarding, workflow_pointer, integration_prompt}``.
+        키 순서가 곧 권장 표시/결합 순서(다운로드 파일에서 이 순서로 이어붙임). 하위호환이
+        필요하면(예: DB의 단일 ``system_prompt`` 컬럼) 호출부가 ``"\\n\\n".join(kit.values())``로
+        문자열 재구성 가능 — 라이브 오케스트레이션 소비자가 없어(§크럭스 §0 확인) 순서/포맷
+        변경 자체는 breaking이 아니다.
 
-    E-I18N Phase A(2026-07-08, 선생님 GO): section [B]/[C]/[D]/[E]의 코드 상수 텍스트를
-    locale 분기했다. section [A](role_template.role_behaviors, DB 데이터)는 아직 한글 그대로
-    — Phase B(스키마: role_behaviors_i18n)+후속(번역 콘텐츠, [[no-pr-for-data]] 게이트) 이후
-    이 함수가 그 컬럼을 locale로 선택하도록 다시 손볼 예정(오늘은 미적용, 의도적).
-
-    까심 QA 후속(같은 날): section [B]가 recipe를 포함할 때 호출하는 `_generate_guide()`
-    (workflow_recipes.py)의 고정 구조 문자열도 locale 분기 완료 — [B] 전체가 이제 고정
-    문자열 기준 완전 locale화(recipe DATA 자체, 즉 `name`/`description`/`step.label`/
-    `step.action`은 여전히 미분기 — workflow_recipes 자체 i18n = 별도 트랙, 의도적 범위 밖).
+    분류 근거(크럭스 §1): **role_context**([A], 지속) — 이 조직에서 맡은 역할, 기존 정체성을
+    대체하지 않는 추가 컨텍스트. **onboarding**([C]+[D]+[E] 병합, 일회성) — 도구 목록·운영
+    룰·연결 셋업, 처음 한 번 알면 되는 내용. **workflow_pointer**([B], recipe 하드코딩 제거) —
+    워크플로는 팀이 커스터마이즈하는 유저것이라 고정 텍스트 대신 `sprintable_get_workflow_guide`
+    자가-pull 유도만 남긴다. **integration_prompt**(신규) — 정적 주입이 아니라 에이전트 스스로
+    메모리에 반영하도록 유도하는 지시문(결정③), 기존 정체성 보존을 명시.
     """
-    sections = [
+    role_context = (
         _SECTION_A_HEADER[locale].format(name=role_template.name)
-        + f"\n\n{role_template.role_behaviors}",
-    ]
-
-    guide_text = _SECTION_B_TEXT[locale]
-    guide_section = [guide_text["heading"]]
-    if recipe is not None:
-        guide_section.append(_generate_guide(recipe, locale))
-    guide_section.append(guide_text["footer"])
-    sections.append("\n".join(guide_section))
-
-    sections.append(_tool_cheat_sheet(list(role_template.default_tool_groups), locale))
-    sections.append(_AGILE_OPERATING_RULES[locale])
-    sections.append(
-        _runtime_notes(runtime, getattr(role_template, "runtime_overrides", None), locale)
+        + f"\n\n{role_template.role_behaviors}"
     )
 
-    return "\n\n".join(sections)
+    onboarding = "\n\n".join([
+        _tool_cheat_sheet(list(role_template.default_tool_groups), locale),
+        _AGILE_OPERATING_RULES[locale],
+        _runtime_notes(runtime, getattr(role_template, "runtime_overrides", None), locale),
+    ])
+
+    guide_text = _SECTION_B_TEXT[locale]
+    workflow_pointer = "\n".join([guide_text["heading"], guide_text["footer"]])
+
+    return {
+        "role_context": role_context,
+        "onboarding": onboarding,
+        "workflow_pointer": workflow_pointer,
+        "integration_prompt": _INTEGRATION_PROMPT_TEXT[locale],
+    }

--- a/backend/app/services/recruit_service.py
+++ b/backend/app/services/recruit_service.py
@@ -1,8 +1,13 @@
 """E-RECRUIT S3 (story ff2996d0): POST /recruit MVP 오케스트레이션.
 
-role_template + runtime → (S2) 합성 지침 + persona upsert(G7) + role-derived scope 로 API key
-회전(G2/G3) + 활성화 번들(mcp_config + 실 key 1회) 반환. compose_prompt 자체는 순수(S2 G4)라
-이 서비스가 그 순수 함수를 실 DB 상태(role_template/recipe/persona/key)에 배선하는 접합부다.
+role_template + runtime → (S2) 합성 kit + persona upsert(G7) + role-derived scope 로 API key
+회전(G2/G3) + 활성화 번들(mcp_config + 실 key 1회) 반환. compose_kit 자체는 순수(S2 G4)라
+이 서비스가 그 순수 함수를 실 DB 상태(role_template/persona/key)에 배선하는 접합부다.
+
+채용-kit 재설계(story b1fe41cf, 선생님 GO 2026-07-08) 이후: recipe DATA는 더 이상 kit
+합성에 쓰이지 않는다(워크플로는 유저것 — `sprintable_get_workflow_guide` 자가-pull로 대체,
+크럭스 결정①) — 이 파일이 예전에 갖고 있던 ``resolve_recipe_by_slug()``는 그래서 삭제됐다
+(다른 소비자 없음 확인, 죽은 코드 방치 안 함).
 """
 from __future__ import annotations
 
@@ -16,7 +21,7 @@ from app.models.role_template import RoleTemplate
 from app.repositories.agent_persona import AgentPersonaRepository
 from app.repositories.api_key import ApiKeyRepository
 from app.schemas.agent_persona import PersonaSummaryResponse
-from app.services.agent_recruiter import compose_prompt, validate_tool_groups
+from app.services.agent_recruiter import compose_kit, validate_tool_groups
 
 
 async def get_published_role_template(session: AsyncSession, slug: str) -> RoleTemplate | None:
@@ -24,24 +29,6 @@ async def get_published_role_template(session: AsyncSession, slug: str) -> RoleT
         select(RoleTemplate).where(RoleTemplate.slug == slug, RoleTemplate.is_published.is_(True))
     )
     return result.scalar_one_or_none()
-
-
-async def resolve_recipe_by_slug(session: AsyncSession, slug: str | None) -> dict[str, Any] | None:
-    """role_template.default_workflow_recipe_slug → workflow_recipes 형태 dict(builtin 또는 DB)."""
-    if not slug:
-        return None
-    from app.models.workflow_template import WorkflowTemplate
-    from app.routers.workflow_recipes import _BUILTIN_BY_ID, _template_to_recipe
-
-    if slug in _BUILTIN_BY_ID:
-        return _BUILTIN_BY_ID[slug]
-    result = await session.execute(
-        select(WorkflowTemplate).where(
-            WorkflowTemplate.slug == slug, WorkflowTemplate.is_enabled.is_(True)
-        )
-    )
-    template = result.scalar_one_or_none()
-    return _template_to_recipe(template) if template else None
 
 
 async def acquire_agent_mutation_lock(session: AsyncSession, agent_id: uuid.UUID) -> None:
@@ -96,16 +83,20 @@ async def recruit_agent(
     직렬화한다 — 트랜잭션 종료 시 자동 해제, 기존 `onboarding_first_auth:{member_id}` 관례와 동일 패턴.
 
     E-I18N Phase C(story 11f1087c): ``locale``은 request-scoped(호출부가 FE 전달값→Accept-Language
-    폴백으로 이미 정규화해 넘긴다) — 여기선 그대로 ``compose_prompt``에 전달만 한다. 기본값 "ko"라
+    폴백으로 이미 정규화해 넘긴다) — 여기선 그대로 ``compose_kit``에 전달만 한다. 기본값 "ko"라
     이 함수를 직접 호출하는 기존/테스트 코드는 무변경 하위호환.
+
+    채용-kit 재설계(story b1fe41cf): ``compose_kit``이 구조화 dict를 반환 — DB의 ``system_prompt``
+    컬럼(Text)은 여전히 단일 문자열이라 ``"\n\n".join(kit.values())``로 재구성한다(라이브
+    오케스트레이션 소비자가 없어 — §크럭스 §0 확인 — 이 join 순서/포맷 변경은 breaking 아님).
     """
     await acquire_agent_mutation_lock(session, agent_member.id)
 
     tool_allowlist = list(role_template.default_tool_groups)
     validate_tool_groups(tool_allowlist)  # fail-closed — ValueError 전파, 호출부가 400 매핑
 
-    recipe = await resolve_recipe_by_slug(session, role_template.default_workflow_recipe_slug)
-    system_prompt = compose_prompt(role_template, recipe, runtime, locale)
+    kit = compose_kit(role_template, runtime, locale)
+    system_prompt = "\n\n".join(kit.values())
 
     persona_repo = AgentPersonaRepository(session)
     existing = await persona_repo.get_recruited(org_id, agent_member.project_id, agent_member.id)

--- a/backend/tests/test_e_recruit_s14_catalog_buildout.py
+++ b/backend/tests/test_e_recruit_s14_catalog_buildout.py
@@ -92,10 +92,10 @@ def test_release_manager_tools_list_does_not_instruct_close_sprint():
 
 
 def test_all_18_roles_compose_without_error_and_validate_against_default_tool_groups():
-    """견고 기준(S2 교차검증): 각 role의 compose_prompt가 크래시 없이 완주하고, 치트시트가
+    """견고 기준(S2 교차검증): 각 role의 compose_kit가 크래시 없이 완주하고, 치트시트가
     실 default_tool_groups 로부터만 파생되는지(환각 0·G3 단일소스)."""
     from types import SimpleNamespace
-    from app.services.agent_recruiter import compose_prompt, validate_tool_groups
+    from app.services.agent_recruiter import compose_kit, validate_tool_groups
     from app.services.mcp_toolset import ALL_TOOL_NAMES
 
     mod = _load_migration()
@@ -105,7 +105,7 @@ def test_all_18_roles_compose_without_error_and_validate_against_default_tool_gr
             name=name, role_behaviors=mod._ROLE_BEHAVIORS[slug],
             default_tool_groups=tool_groups, runtime_overrides={},
         )
-        out = compose_prompt(role, None, "claude-code")
+        out = compose_kit(role, "claude-code")["onboarding"]
         mentioned = set(re.findall(r"`(sprintable_[a-z_]+)`", out))
         assert mentioned <= set(ALL_TOOL_NAMES), (
             f"{slug}: invented tool names {mentioned - set(ALL_TOOL_NAMES)}"

--- a/backend/tests/test_e_recruit_s2_compose_prompt.py
+++ b/backend/tests/test_e_recruit_s2_compose_prompt.py
@@ -1,10 +1,15 @@
-"""E-RECRUIT S2 (story 58c37f17): `agent_recruiter.compose_prompt` — deterministic composer.
+"""E-RECRUIT S2 (story 58c37f17): `agent_recruiter.compose_kit` — deterministic composer.
 
-G3(단일 소스): 섹션[C] 도구 치트시트는 role_template.default_tool_groups → mcp_toolset.tool_group()
-SSOT로만 파생(하드코딩 별도 목록 금지). G4(배달 분리): compose_prompt는 순수 합성만(네트워크/DB
-호출 0) — 이 테스트들은 전부 인자만으로 호출하고 어떤 I/O 도 mock 하지 않는다(진짜 순수함 증명).
-QA MINOR 하드닝: role_template.default_tool_groups 값이 실제 그룹 vocabulary 밖이면 fail-closed
-(resolve_policy 자체의 fail-open 은 S3 스코프 — 여긴 손대지 않는다).
+G3(단일 소스): onboarding 파트의 도구 치트시트는 role_template.default_tool_groups →
+mcp_toolset.tool_group() SSOT로만 파생(하드코딩 별도 목록 금지). G4(배달 분리): compose_kit는
+순수 합성만(네트워크/DB 호출 0) — 이 테스트들은 전부 인자만으로 호출하고 어떤 I/O 도 mock 하지
+않는다(진짜 순수함 증명). QA MINOR 하드닝: role_template.default_tool_groups 값이 실제 그룹
+vocabulary 밖이면 fail-closed(resolve_policy 자체의 fail-open 은 S3 스코프 — 여긴 손대지 않는다).
+
+채용-kit 재설계(story b1fe41cf, 문서 `recruit-output-kit-redesign-crux`, 선생님 GO
+2026-07-08) — 옛 `compose_prompt`(단일 문자열, CLAUDE.md 전체 대체 노림)를 `compose_kit`
+(구조화 dict: role_context/onboarding/workflow_pointer/integration_prompt)으로 대체했다.
+recipe DATA(steps 등)는 더 이상 kit 합성 인자가 아니다(워크플로=유저것, 크럭스 결정①).
 """
 from __future__ import annotations
 
@@ -15,7 +20,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from app.services.agent_recruiter import compose_prompt, validate_tool_groups
+from app.services.agent_recruiter import compose_kit, validate_tool_groups
 from app.services.mcp_toolset import ALL_GROUPS, ALL_TOOL_NAMES
 
 
@@ -30,11 +35,8 @@ def _role(**overrides) -> SimpleNamespace:
     return SimpleNamespace(**defaults)
 
 
-_RECIPE = {
-    "name": "칸반 심플",
-    "description": "할 일 → 진행 중 → 완료",
-    "steps": [{"role": "Dev", "label": "진행", "pattern": "in_progress", "action": "작업 수행"}],
-}
+def _joined(kit: dict[str, str]) -> str:
+    return "\n\n".join(kit.values())
 
 
 # ── validate_tool_groups ───────────────────────────────────────────────────────
@@ -53,177 +55,175 @@ def test_validate_tool_groups_rejects_admin_typo_variants():
         validate_tool_groups(["admin"])
 
 
-# ── compose_prompt — 순수성 + 결정론 ──────────────────────────────────────────
-def test_compose_prompt_is_deterministic_same_input_same_output():
+# ── compose_kit — 순수성 + 결정론 ──────────────────────────────────────────
+def test_compose_kit_is_deterministic_same_input_same_output():
     """diffable — 동일 입력 두 번 호출 결과가 문자 그대로 동일(LLM 비호출 증명)."""
     role = _role()
-    out1 = compose_prompt(role, _RECIPE, "claude-code")
-    out2 = compose_prompt(role, _RECIPE, "claude-code")
+    out1 = compose_kit(role, "claude-code")
+    out2 = compose_kit(role, "claude-code")
     assert out1 == out2
 
 
-def test_compose_prompt_contains_five_sections():
+def test_compose_kit_returns_four_parts():
     role = _role()
-    out = compose_prompt(role, _RECIPE, "claude-code")
-    assert "채용 지침" in out  # [A]
-    assert "Sprintable 사용법" in out  # [B]
-    assert "사용 가능 도구 (치트시트)" in out  # [C]
-    assert "애자일 자율 운영 룰" in out  # [D]
-    assert "런타임 노트" in out  # [E]
+    kit = compose_kit(role, "claude-code")
+    assert set(kit.keys()) == {"role_context", "onboarding", "workflow_pointer", "integration_prompt"}
+    assert "Sprintable 역할 컨텍스트" in kit["role_context"]  # role_context([A])
+    assert "사용 가능 도구 (치트시트)" in kit["onboarding"]  # onboarding([C])
+    assert "애자일 자율 운영 룰" in kit["onboarding"]  # onboarding([D])
+    assert "런타임 노트" in kit["onboarding"]  # onboarding([E])
+    assert "Sprintable 워크플로" in kit["workflow_pointer"]  # workflow_pointer([B])
 
 
-def test_compose_prompt_section_a_includes_role_behaviors_verbatim():
+def test_compose_kit_role_context_includes_role_behaviors_verbatim():
     role = _role(role_behaviors="스스로 판단해 claim하고 소통하세요.")
-    out = compose_prompt(role, _RECIPE, "claude-code")
-    assert "스스로 판단해 claim하고 소통하세요." in out
+    kit = compose_kit(role, "claude-code")
+    assert "스스로 판단해 claim하고 소통하세요." in kit["role_context"]
 
 
-def test_compose_prompt_handles_missing_recipe_gracefully():
-    """recipe=None — 워크플로우 가이드 부분만 생략, 나머지 섹션은 정상 생성(크래시 없음)."""
+def test_compose_kit_workflow_pointer_never_hardcodes_recipe_content():
+    """크럭스 결정①: 워크플로는 유저것 — recipe DATA를 kit에 하드코딩하지 않는다. compose_kit는
+    이제 recipe 인자 자체를 받지 않으므로(구조적으로 보장) workflow_pointer는 항상 동일한
+    자가-pull 유도 텍스트만 담는다(recipe 유무·내용과 무관)."""
     role = _role()
-    out = compose_prompt(role, None, "claude-code")
-    assert "사용 가능 도구 (치트시트)" in out
-    assert "get_workflow_guide" in out  # 자율-pull 안내는 recipe 유무와 무관하게 항상 존재
+    kit = compose_kit(role, "claude-code")
+    assert "sprintable_get_workflow_guide" in kit["workflow_pointer"]
 
 
-def test_compose_prompt_includes_runtime_identifier():
+def test_compose_kit_includes_runtime_identifier():
     role = _role()
-    out = compose_prompt(role, _RECIPE, "cursor")
-    assert "`cursor`" in out
+    kit = compose_kit(role, "cursor")
+    assert "`cursor`" in kit["onboarding"]
 
 
-def test_compose_prompt_includes_runtime_override_when_present():
+def test_compose_kit_includes_runtime_override_when_present():
     role = _role(runtime_overrides={"claude-code": "CLAUDE.md 에 이 지침을 저장하세요."})
-    out = compose_prompt(role, _RECIPE, "claude-code")
-    assert "CLAUDE.md 에 이 지침을 저장하세요." in out
+    kit = compose_kit(role, "claude-code")
+    assert "CLAUDE.md 에 이 지침을 저장하세요." in kit["onboarding"]
+
+
+def test_compose_kit_integration_prompt_warns_against_overwriting_existing_identity():
+    """선생님 결정③(2026-07-08): kit 말미 자기통합/메모리 유도 — 기존 정체성을 덮지 말라는
+    경고가 명시적으로 있어야 한다(정적 주입이 아니라 스스로 판단해 반영하라는 유도)."""
+    role = _role()
+    kit = compose_kit(role, "claude-code")
+    assert "기존 정체성을 덮지" in kit["integration_prompt"]
+    assert "sprintable_get_workflow_guide" in kit["integration_prompt"]
 
 
 # ── 까심 QA 후속(story 6f6ac081, 2026-07-08): 런타임 노트가 커넥터-라우팅 런타임에도 정직해야 함 ──
-def test_compose_prompt_mcp_native_runtime_says_no_setup_needed():
+def test_compose_kit_mcp_native_runtime_says_no_setup_needed():
     role = _role()
-    out = compose_prompt(role, _RECIPE, "claude-code")
-    assert "별도 설정이 필요 없습니다" in out
-    assert "SSE 커넥터" not in out
+    kit = compose_kit(role, "claude-code")
+    assert "별도 설정이 필요 없습니다" in kit["onboarding"]
+    assert "SSE 커넥터" not in kit["onboarding"]
 
 
-def test_compose_prompt_connector_only_runtime_gives_honest_setup_instructions():
+def test_compose_kit_connector_only_runtime_gives_honest_setup_instructions():
     """전에는 grok/pi/hermes/openclaw/opencode 도 "별도 설정 불요"라는 거짓 안내를 받았다(까심
     `compose_prompt(runtime="grok")` 재현) — mcp_config=None인 커넥터-라우팅 런타임은 실제로
     connectors/{runtime}-sprintable/ 복사 + AGENT_API_KEY 설정 + 어댑터 실행이 필요하다."""
     role = _role()
-    out = compose_prompt(role, _RECIPE, "grok")
-    assert "별도 설정이 필요 없습니다" not in out
-    assert "SSE 커넥터" in out
-    assert "connectors/grok-sprintable/" in out
-    assert "AGENT_API_KEY" in out
+    kit = compose_kit(role, "grok")
+    assert "별도 설정이 필요 없습니다" not in kit["onboarding"]
+    assert "SSE 커넥터" in kit["onboarding"]
+    assert "connectors/grok-sprintable/" in kit["onboarding"]
+    assert "AGENT_API_KEY" in kit["onboarding"]
 
 
-def test_compose_prompt_generic_connector_bucket_also_honest():
+def test_compose_kit_generic_connector_bucket_also_honest():
     role = _role()
-    out = compose_prompt(role, _RECIPE, "connector")
-    assert "별도 설정이 필요 없습니다" not in out
-    assert "SSE 커넥터" in out
+    kit = compose_kit(role, "connector")
+    assert "별도 설정이 필요 없습니다" not in kit["onboarding"]
+    assert "SSE 커넥터" in kit["onboarding"]
 
 
 # ── E-I18N Phase A(story 11f1087c, PO GO 2026-07-08) — 코드 상수 locale 분기 ────────
 
-def test_compose_prompt_default_locale_is_korean_backward_compatible():
-    """locale 인자를 안 주면(기존 호출부·recruit_service.py) 정확히 예전과 동일한 한글 출력."""
+def test_compose_kit_default_locale_is_korean_backward_compatible():
+    """locale 인자를 안 주면 정확히 예전과 동일한 한글 출력."""
     role = _role()
-    out = compose_prompt(role, _RECIPE, "claude-code")
+    out = _joined(compose_kit(role, "claude-code"))
     assert "## 애자일 자율 운영 룰" in out
-    assert "## Sprintable 사용법" in out
+    assert "## Sprintable 워크플로" in out
     assert "## 사용 가능 도구 (치트시트)" in out
     assert "## Agile Autonomous Operating Rules" not in out
 
 
-def test_compose_prompt_english_locale_localizes_code_sections():
-    """[B]/[C]/[D]/[E] 전부 영어로 나오되, [A](role_behaviors 데이터)는 아직 한글 그대로
-    (Phase A 스코프 — 데이터 i18n은 Phase B/후속, 의도적).
-
-    까심 QA MUST-FIX(2026-07-08): 이전 버전은 recipe가 있을 때 [B] 내부(_generate_guide 고정
-    구조 문자열)의 한글 leak을 assert하지 않아 "[B] 전부 영어"라는 주장을 실증 못 했다. 이제
-    recipe가 실제로 세팅된 상태에서 고정 문자열의 영어화 + 한글 leak 부재를 명시 확인한다."""
+def test_compose_kit_english_locale_localizes_all_parts():
+    """role_context 래퍼(헤더)/onboarding/workflow_pointer/integration_prompt 전부 영어로
+    나오되, role_context 내부의 role_behaviors(DATA)는 아직 한글 그대로(Phase A 스코프 —
+    데이터 i18n은 Phase B/후속, 의도적)."""
     role = _role(role_behaviors="스스로 판단해 claim하고 소통하세요.")
-    out = compose_prompt(role, _RECIPE, "claude-code", locale="en")
+    kit = compose_kit(role, "claude-code", locale="en")
+    out = _joined(kit)
     assert "## Agile Autonomous Operating Rules" in out
-    assert "## How to Use Sprintable" in out
+    assert "## Sprintable Workflow" in out
     assert "## Available Tools (Cheat Sheet)" in out
     assert "## Runtime Notes" in out
     assert "MCP connection/scope was already configured" in out
     assert "## 애자일 자율 운영 룰" not in out
-    # section [A]는 의도적으로 미번역(Phase A 스코프 밖)
-    assert "스스로 판단해 claim하고 소통하세요." in out
-    assert "# Backend Engineer — Recruitment Instructions" in out
-    # [B] 내부 _generate_guide() 고정 구조 문자열도 영어화(까심 MUST-FIX) — 한글 leak 0
-    assert "## Workflow Steps" in out
-    assert "Step 1" in out
-    assert "**Responsible role**" in out
-    assert "**Expected action**" in out
-    assert "## How to Use" in out
-    assert "## 워크플로우 단계" not in out
-    assert "담당 역할" not in out
-    assert "기대 행동" not in out
-    assert "## 사용 지침" not in out
-    # recipe DATA 콘텐츠(name/description/step.label/step.action)는 의도적으로 미번역
-    # (workflow_recipes 자체 i18n = 별도 트랙, out-of-scope) — 그대로 한글이어야 정상.
-    assert _RECIPE["name"] in out
-    assert _RECIPE["steps"][0]["label"] in out
+    # role_context 헤더는 번역, role_behaviors(DATA) 자체는 의도적으로 미번역(Phase A 스코프 밖)
+    assert "스스로 판단해 claim하고 소통하세요." in kit["role_context"]
+    assert "# Backend Engineer — Sprintable Role Context" in kit["role_context"]
+    # integration_prompt도 locale 분기
+    assert "Don't overwrite your existing identity" in kit["integration_prompt"]
+    assert "기존 정체성을 덮지" not in kit["integration_prompt"]
 
 
-def test_compose_prompt_english_connector_runtime_localized():
+def test_compose_kit_english_connector_runtime_localized():
     role = _role()
-    out = compose_prompt(role, _RECIPE, "grok", locale="en")
-    assert "no separate setup is needed" not in out
-    assert "SSE connector" in out
-    assert "connectors/grok-sprintable/" in out
-    assert "AGENT_API_KEY" in out
+    kit = compose_kit(role, "grok", locale="en")
+    assert "no separate setup is needed" not in kit["onboarding"]
+    assert "SSE connector" in kit["onboarding"]
+    assert "connectors/grok-sprintable/" in kit["onboarding"]
+    assert "AGENT_API_KEY" in kit["onboarding"]
 
 
-def test_compose_prompt_tool_names_and_group_labels_stay_unlocalized_identifiers():
+def test_compose_kit_tool_names_and_group_labels_stay_unlocalized_identifiers():
     """도구/그룹 이름은 실 레지스트리 식별자라 en/ko 무관하게 그대로 — 래퍼 텍스트만 번역."""
     role = _role(default_tool_groups=["stories", "tasks"])
-    out_ko = compose_prompt(role, None, "claude-code", locale="ko")
-    out_en = compose_prompt(role, None, "claude-code", locale="en")
+    out_ko = _joined(compose_kit(role, "claude-code", locale="ko"))
+    out_en = _joined(compose_kit(role, "claude-code", locale="en"))
     for out in (out_ko, out_en):
         assert "`sprintable_claim_story`" in out
         assert "**stories**:" in out
 
 
 # ── G3: 도구 치트시트 = 단일 소스(ALL_TOOL_NAMES) 파생, 환각 0 ─────────────────
-def test_compose_prompt_tool_cheat_sheet_only_references_real_tool_names():
+def test_compose_kit_tool_cheat_sheet_only_references_real_tool_names():
     role = _role(default_tool_groups=[
         "stories", "tasks", "epics", "sprints", "hypotheses", "chat", "docs",
         "analytics", "retro", "standup", "meetings", "notifications", "webhooks",
         "rewards", "audit", "agent_runs",
     ])
-    out = compose_prompt(role, _RECIPE, "claude-code")
+    out = compose_kit(role, "claude-code")["onboarding"]
     mentioned = set(re.findall(r"`(sprintable_[a-z_]+)`", out))
     assert mentioned  # 뭔가는 언급됨
     assert mentioned <= set(ALL_TOOL_NAMES), f"invented tool names: {mentioned - set(ALL_TOOL_NAMES)}"
 
 
-def test_compose_prompt_tool_cheat_sheet_excludes_ungranted_groups():
+def test_compose_kit_tool_cheat_sheet_excludes_ungranted_groups():
     """frontend(stories/tasks/chat/docs)만 준 role 은 epics/sprints 전용 도구를 언급하면 안 됨."""
     role = _role(default_tool_groups=["stories", "tasks", "chat", "docs"])
-    out = compose_prompt(role, _RECIPE, "claude-code")
+    out = compose_kit(role, "claude-code")["onboarding"]
     assert "sprintable_add_epic" not in out
     assert "sprintable_create_sprint" not in out
     assert "sprintable_add_story" in out  # stories 그룹은 포함
 
 
-def test_compose_prompt_always_allowed_tools_present_regardless_of_groups():
+def test_compose_kit_always_allowed_tools_present_regardless_of_groups():
     """core(_ALWAYS_ALLOWED) 도구는 role 의 default_tool_groups 와 무관하게 항상 치트시트에 존재."""
     role = _role(default_tool_groups=["stories"])
-    out = compose_prompt(role, _RECIPE, "claude-code")
+    out = compose_kit(role, "claude-code")["onboarding"]
     assert "sprintable_get_workflow_guide" in out
     assert "sprintable_ping" in out
 
 
-def test_compose_prompt_raises_on_unknown_default_tool_group():
+def test_compose_kit_raises_on_unknown_default_tool_group():
     role = _role(default_tool_groups=["stories", "typo-group"])
     with pytest.raises(ValueError, match="unknown group"):
-        compose_prompt(role, _RECIPE, "claude-code")
+        compose_kit(role, "claude-code")
 
 
 # ── 실 S1 seed 데이터 전수 검증(회귀 가드 — "seed 지점" 검증) ─────────────────
@@ -246,7 +246,7 @@ def test_all_s1_seeded_roles_default_tool_groups_are_valid_vocabulary():
 
 
 def test_all_s1_seeded_roles_compose_without_error():
-    """4직무 seed 전부가 실제로 compose_prompt 를 통과해 유효한 결과를 내는지(통합 스모크)."""
+    """4직무 seed 전부가 실제로 compose_kit 를 통과해 유효한 결과를 내는지(통합 스모크)."""
     mod = _load_s1_migration()
     for slug, name, _category, _description, tool_groups, _recipe_slug in mod._SEED:
         role = _role(
@@ -254,7 +254,7 @@ def test_all_s1_seeded_roles_compose_without_error():
             role_behaviors=mod._ROLE_BEHAVIORS[slug],
             default_tool_groups=tool_groups,
         )
-        out = compose_prompt(role, None, "claude-code")
+        out = compose_kit(role, "claude-code")["onboarding"]
         mentioned = set(re.findall(r"`(sprintable_[a-z_]+)`", out))
         assert mentioned <= set(ALL_TOOL_NAMES), (
             f"{slug}: invented tool names {mentioned - set(ALL_TOOL_NAMES)}"

--- a/backend/tests/test_e_recruit_s3_recruit_endpoint.py
+++ b/backend/tests/test_e_recruit_s3_recruit_endpoint.py
@@ -2,7 +2,7 @@
 
 DB write 시맨틱(persona upsert/키 회전)은 realdb 테스트(test_e_recruit_s3_recruit_service_realdb.py)
 가 실증한다. 여기선 라우터 계층의 404/400 분기 + 응답 shape만 확인(순수 도메인 로직은 이미
-compose_prompt(S2)/recruit_agent(realdb)가 커버).
+compose_kit(S2)/recruit_agent(realdb)가 커버).
 """
 from __future__ import annotations
 

--- a/backend/tests/test_e_recruit_s5_connection_artifact_realdb.py
+++ b/backend/tests/test_e_recruit_s5_connection_artifact_realdb.py
@@ -71,8 +71,8 @@ async def _seed_agent(session, *, with_persona: bool):
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 @pytest.mark.anyio
 async def test_connection_artifact_emits_persona_file_real_decorate_path():
-    """G4: 실 AgentPersonaRepository.list()/_decorate() 경로(mock 아님)로 CLAUDE.md + .mcp.json
-    두 파일이 정확히 나오는지."""
+    """G4: 실 AgentPersonaRepository.list()/_decorate() 경로(mock 아님)로 SPRINTABLE_ONBOARDING.md
+    + .mcp.json 두 파일이 정확히 나오는지."""
     from types import SimpleNamespace
     from unittest.mock import MagicMock
     from sqlalchemy import text as _text
@@ -88,13 +88,13 @@ async def test_connection_artifact_emits_persona_file_real_decorate_path():
             await s.execute(_text("SET session_replication_role = replica"))
             out = await get_agent_connection_artifact(
                 agent.id, runtime="claude-code", session=s,
-                auth=MagicMock(), org_id=org_id,
+                accept_language=None, auth=MagicMock(), org_id=org_id,
             )
 
         assert len(out["files"]) == 2
         filenames = {f["filename"] for f in out["files"]}
-        assert filenames == {"CLAUDE.md", ".mcp.json"}
-        instruction = next(f for f in out["files"] if f["filename"] == "CLAUDE.md")
+        assert filenames == {"SPRINTABLE_ONBOARDING.md", ".mcp.json"}
+        instruction = next(f for f in out["files"] if f["filename"] == "SPRINTABLE_ONBOARDING.md")
         assert "백엔드 엔지니어" in instruction["content"]
         mcp_file = next(f for f in out["files"] if f["filename"] == ".mcp.json")
         parsed = json.loads(mcp_file["content"])
@@ -125,7 +125,7 @@ async def test_connection_artifact_no_persona_backward_compatible_real_db():
             await s.execute(_text("SET session_replication_role = replica"))
             out = await get_agent_connection_artifact(
                 agent.id, runtime="claude-code", session=s,
-                auth=MagicMock(), org_id=org_id,
+                accept_language=None, auth=MagicMock(), org_id=org_id,
             )
 
         assert len(out["files"]) == 1
@@ -155,12 +155,12 @@ async def test_connection_artifact_connector_runtime_real_db():
             await s.execute(_text("SET session_replication_role = replica"))
             out = await get_agent_connection_artifact(
                 agent.id, runtime="connector", session=s,
-                auth=MagicMock(), org_id=org_id,
+                accept_language=None, auth=MagicMock(), org_id=org_id,
             )
 
         assert out["mcp_config"] is None
         filenames = {f["filename"] for f in out["files"]}
-        assert filenames == {"AGENT_INSTRUCTIONS.md", "CONNECTOR_SETUP.md"}
+        assert filenames == {"SPRINTABLE_ONBOARDING.md", "CONNECTOR_SETUP.md"}
     finally:
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)
@@ -172,8 +172,8 @@ async def test_connection_artifact_connector_runtime_real_db():
 @pytest.mark.parametrize("runtime", ["opencode", "openclaw", "hermes", "grok", "pi"])
 async def test_connection_artifact_connector_only_runtimes_real_db(runtime):
     """전 런타임 올지원(story 6f6ac081): 커넥터 전용 5종도 connector 버킷과 동형 — mcp_config는
-    None, CONNECTOR_SETUP.md 포인터 파일 emit. 단 instruction 파일명은 확정 매핑이 있어(공식
-    문서 실측, crux doc 참조) generic AGENT_INSTRUCTIONS.md가 아니라 AGENTS.md."""
+    None, CONNECTOR_SETUP.md 포인터 파일 emit. 채용-kit 재설계(story b1fe41cf) 이후 instruction
+    파일명은 런타임 무관 SPRINTABLE_ONBOARDING.md 단일 상수."""
     from unittest.mock import MagicMock
     from sqlalchemy import text as _text
     from app.core.database import Base
@@ -188,12 +188,12 @@ async def test_connection_artifact_connector_only_runtimes_real_db(runtime):
             await s.execute(_text("SET session_replication_role = replica"))
             out = await get_agent_connection_artifact(
                 agent.id, runtime=runtime, session=s,
-                auth=MagicMock(), org_id=org_id,
+                accept_language=None, auth=MagicMock(), org_id=org_id,
             )
 
         assert out["mcp_config"] is None
         filenames = {f["filename"] for f in out["files"]}
-        assert filenames == {"AGENTS.md", "CONNECTOR_SETUP.md"}
+        assert filenames == {"SPRINTABLE_ONBOARDING.md", "CONNECTOR_SETUP.md"}
     finally:
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)
@@ -241,7 +241,7 @@ async def test_connection_artifact_no_default_persona_omits_instruction_file():
             await s.execute(_text("SET session_replication_role = replica"))
             out = await get_agent_connection_artifact(
                 agent.id, runtime="claude-code", session=s,
-                auth=MagicMock(), org_id=org_id,
+                accept_language=None, auth=MagicMock(), org_id=org_id,
             )
 
         assert len(out["files"]) == 1  # 지침 파일 생략 — .mcp.json만

--- a/backend/tests/test_migration_0163_strip_stale_runtime_note_realdb.py
+++ b/backend/tests/test_migration_0163_strip_stale_runtime_note_realdb.py
@@ -55,13 +55,15 @@ async def test_no_role_template_retains_stale_runtime_note_block():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL) — alembic upgrade heads 전제")
 @pytest.mark.anyio
-async def test_compose_prompt_has_exactly_one_runtime_note_heading_for_seeded_role():
-    """0163 후 compose_prompt가 실 seed 데이터로 정확히 1개의 '## 런타임 노트' 헤딩만 생성 —
-    section [A](role_behaviors)와 section [E](_runtime_notes) 중복 없음."""
+async def test_compose_kit_has_exactly_one_runtime_note_heading_for_seeded_role():
+    """0163 후 compose_kit가 실 seed 데이터로 정확히 1개의 '## 런타임 노트' 헤딩만 생성 —
+    role_context(role_behaviors)와 onboarding(_runtime_notes) 중복 없음. 채용-kit
+    재설계(story b1fe41cf) 이후 compose_prompt→compose_kit로 전환됐어도 이 회귀가드의
+    의도(중복 0)는 그대로 유지."""
     from types import SimpleNamespace
     from sqlalchemy import text
     from sqlalchemy.ext.asyncio import create_async_engine
-    from app.services.agent_recruiter import compose_prompt
+    from app.services.agent_recruiter import compose_kit
 
     url = _REAL_DB_URL
     for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
@@ -81,7 +83,7 @@ async def test_compose_prompt_has_exactly_one_runtime_note_heading_for_seeded_ro
             default_tool_groups=row["default_tool_groups"], runtime_overrides=row["runtime_overrides"] or {},
         )
         for runtime in ("claude-code", "grok"):
-            out = compose_prompt(role, None, runtime)
+            out = "\n\n".join(compose_kit(role, runtime).values())
             assert out.count("## 런타임 노트") == 1, f"runtime={runtime}"
     finally:
         await engine.dispose()

--- a/backend/tests/test_ob1_agent_onboarding_config.py
+++ b/backend/tests/test_ob1_agent_onboarding_config.py
@@ -134,8 +134,8 @@ async def test_connection_artifact_with_persona_emits_instruction_file():
         )
     assert len(out["files"]) == 2
     filenames = {f["filename"] for f in out["files"]}
-    assert filenames == {"CLAUDE.md", ".mcp.json"}
-    instruction_file = next(f for f in out["files"] if f["filename"] == "CLAUDE.md")
+    assert filenames == {"SPRINTABLE_ONBOARDING.md", ".mcp.json"}
+    instruction_file = next(f for f in out["files"] if f["filename"] == "SPRINTABLE_ONBOARDING.md")
     assert instruction_file["content"] == "당신은 백엔드 엔지니어입니다."
 
 

--- a/backend/tests/test_role_templates_marketing_roster.py
+++ b/backend/tests/test_role_templates_marketing_roster.py
@@ -60,10 +60,10 @@ def test_role_behaviors_reference_verified_tool_names_only():
 
 
 def test_both_roles_compose_without_error_and_validate_against_default_tool_groups():
-    """S2 교차검증 동형: compose_prompt가 크래시 없이 완주하고, 치트시트가 실 default_tool_groups
+    """S2 교차검증 동형: compose_kit가 크래시 없이 완주하고, 치트시트가 실 default_tool_groups
     로부터만 파생되는지(환각 0·G3 단일소스)."""
     from types import SimpleNamespace
-    from app.services.agent_recruiter import compose_prompt, validate_tool_groups
+    from app.services.agent_recruiter import compose_kit, validate_tool_groups
     from app.services.mcp_toolset import ALL_TOOL_NAMES
 
     mod = _load_migration()
@@ -73,7 +73,7 @@ def test_both_roles_compose_without_error_and_validate_against_default_tool_grou
             name=name, role_behaviors=mod._ROLE_BEHAVIORS[slug],
             default_tool_groups=tool_groups, runtime_overrides={},
         )
-        out = compose_prompt(role, None, "claude-code")
+        out = compose_kit(role, "claude-code")["onboarding"]
         mentioned = set(re.findall(r"`(sprintable_[a-z_]+)`", out))
         assert mentioned <= set(ALL_TOOL_NAMES), (
             f"{slug}: invented tool names {mentioned - set(ALL_TOOL_NAMES)}"

--- a/backend/tests/test_s6_runtime_capabilities.py
+++ b/backend/tests/test_s6_runtime_capabilities.py
@@ -52,22 +52,24 @@ async def test_runtime_capabilities_401_when_unauthenticated():
 
 def test_instruction_filename_tiers_and_transport_by_runtime_class():
     """전 런타임 올지원(story 6f6ac081, 문서 `runtime-full-support-firstclass-crux`) 후 실기준:
-    _INSTRUCTION_FILENAMES에 확정 매핑이 있는 8종(claude-code·gemini·codex/cursor/grok/pi/
-    hermes/openclaw/opencode)은 tier=full — 매핑 없는 connector(범용·특정 툴 미확정)만
-    tier=experimental로 남는다(공식 문서 출처 실측 결과, crux doc 참조). MCP-native 4종만
-    mcp_transport 보유·event_push 지원 — 커넥터 전용 5종+connector는 SSE 경로라 전부 빈값."""
-    from app.services.agent_onboarding_config import list_runtime_capabilities
+    구체적으로 이름 붙은 8종(claude-code·gemini·codex/cursor/grok/pi/hermes/openclaw/opencode)은
+    tier=full — 범용 connector 버킷(특정 런타임 미확정)만 tier=experimental로 남는다. MCP-native
+    4종만 mcp_transport 보유·event_push 지원 — 커넥터 전용 5종+connector는 SSE 경로라 전부 빈값.
+
+    채용-kit 재설계(story b1fe41cf, 선생님 GO 2026-07-08): ``prompt_file``은 이제 런타임 무관
+    단일 파일명(``KIT_FILENAME`` = ``SPRINTABLE_ONBOARDING.md``) — 예전엔 CLAUDE.md/GEMINI.md/
+    AGENTS.md로 런타임별로 갈렸는데, 그 리터럴이 유저의 실제 정체성 파일을 덮어쓰는 버그의
+    원인이라 통일했다."""
+    from app.services.agent_onboarding_config import KIT_FILENAME, list_runtime_capabilities
 
     caps = {c["slug"]: c for c in list_runtime_capabilities()}
     assert caps["claude-code"]["tier"] == "full"
-    assert caps["claude-code"]["prompt_file"] == "CLAUDE.md"
     assert caps["gemini"]["tier"] == "full"
-    assert caps["gemini"]["prompt_file"] == "GEMINI.md"
     for slug in ("codex", "cursor", "grok", "pi", "hermes", "openclaw", "opencode"):
         assert caps[slug]["tier"] == "full", slug
-        assert caps[slug]["prompt_file"] == "AGENTS.md", slug
     assert caps["connector"]["tier"] == "experimental"
-    assert caps["connector"]["prompt_file"] == "AGENT_INSTRUCTIONS.md"
+    for slug in caps:
+        assert caps[slug]["prompt_file"] == KIT_FILENAME, slug
 
     for slug in ("claude-code", "codex", "gemini", "cursor"):
         assert caps[slug]["supports_event_push"] is True


### PR DESCRIPTION
## Summary
- crux(`recruit-output-kit-redesign-crux`, 선생님 GO 2026-07-08) — 유저는 이미 자기 정체성을 가진 에이전트를 쓴다. 예전 `compose_prompt`(단일 문자열, CLAUDE.md **전체 대체** 노림)를 `compose_kit`(구조화 dict: `role_context`/`onboarding`/`workflow_pointer`/`integration_prompt`)로 대체.
- **분류**: role_context([A], 지속) / onboarding([C]+[D]+[E] 병합, 일회성) / workflow_pointer([B], recipe 하드코딩 완전 제거 — `sprintable_get_workflow_guide` 자가-pull 유도만, 워크플로=유저것) / integration_prompt(신규 — 정적 주입 아닌 자기통합 유도, "기존 정체성을 덮지 말고 자기화하라" 명시).
- `resolve_instruction_filename()`이 런타임 무관 단일 `KIT_FILENAME`(`SPRINTABLE_ONBOARDING.md`) 반환 — 예전 CLAUDE.md/GEMINI.md/AGENTS.md 리터럴이 유저 다운로드 시 실제 정체성 파일을 덮어쓰던 버그의 코드 지점 제거. 새 이름은 어떤 런타임의 정체성 파일명과도 충돌 안 함.
- recipe DATA는 더 이상 kit 합성 인자가 아님 — `recruit_service.py`의 `resolve_recipe_by_slug()` 삭제(다른 소비자 없음, 죽은 코드 방치 안 함).
- 라이브 오케스트레이션 소비자 0 확인(크럭스 §0) — breaking 아님. `recruit_service.py`는 kit dict를 `"\n\n".join(kit.values())`로 DB `system_prompt` 컬럼에 하위호환 재구성.

## Not in this PR
FE(다운로드 UX·"에이전트에게 전달·기존 파일 덮지 마세요" 카피)는 미르코 몫 — BE 파일명 상수 변경만으로 이미 정체성 덮어쓰기의 핵심 위험은 해소됨.

## Stacking note
⚠️ i18n Phase C(#1966, 아직 `develop` 미병합)에 스택 — #1966 머지 후 `develop` 기준 clean cherry-pick으로 재작성 예정(0163→Phase B 선례와 동형 패턴).

## Test plan
- [x] `compose_kit` 전용 테스트 재작성(옛 `compose_prompt` 17종 → 신규 dict 구조 반영, integration_prompt/workflow_pointer 신규 검증 포함)
- [x] connection-artifact/S6 capabilities/0163 realdb 테스트 파일명 SPRINTABLE_ONBOARDING.md로 갱신
- [x] 전체 스위트 3191 passed, 기존 7건 무관 실패만

🤖 Generated with [Claude Code](https://claude.com/claude-code)