### PR TITLE
feat(i18n): EN 콘텐츠 소비 배선 — compose_kit role_context + 릴노트 locale (PR1, story d6e3f407)

### DIFF
--- a/backend/alembic/versions/0165_release_notes_summary_items_i18n.py
+++ b/backend/alembic/versions/0165_release_notes_summary_items_i18n.py
@@ -1,0 +1,51 @@
+"""E-I18N EN 콘텐츠(story d6e3f407) — release_notes.summary_i18n/items_i18n 병행 JSONB 컬럼.
+
+Revision ID: 0165
+Revises: 0164
+Create Date: 2026-07-08
+
+crux doc `en-content-native-generation-crux`, 선생님 GO 2026-07-08(결정①: 릴노트 full EN =
+title+summary+items). 0164가 title만 오버레이했던 걸 확장 — summary/items도 동형 패턴(순수
+additive, 콘텐츠 데이터 아님 — [[no-pr-for-data]] 게이트 무관, 이 마이그는 PR1(코드+스키마)
+스코프. 실 EN 콘텐츠 backfill은 PR2(선생님 데이터 게이트) 몫).
+
+설계(title_i18n과 완전 동형):
+- `summary_i18n` — JSONB `NOT NULL DEFAULT '{}'::jsonb`(`{"en": "...", ...}`). 기존
+  `summary`(Text) 컬럼은 그대로 "ko" 캐논 소스. 백필 없음.
+- `items_i18n` — JSONB `NOT NULL DEFAULT '{}'::jsonb`(`{"en": [{"text":..., "href":...}, ...], ...}`).
+  기존 `items`(JSONB 배열) 컬럼은 그대로 "ko" 캐논 소스. 백필 없음.
+- 소비 코드(같은 PR1에서 배선): `summary_i18n.get(locale) or summary` / `items_i18n.get(locale) or items`
+  — en 키가 비어있는 한 자동으로 ko로 폴백(title_i18n과 동일한 무회귀 원칙).
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0165"
+down_revision = "0164"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "release_notes",
+        sa.Column(
+            "summary_i18n", postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False, server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+    op.add_column(
+        "release_notes",
+        sa.Column(
+            "items_i18n", postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False, server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("release_notes", "items_i18n")
+    op.drop_column("release_notes", "summary_i18n")

--- a/backend/app/models/release_note.py
+++ b/backend/app/models/release_note.py
@@ -37,14 +37,18 @@ class ReleaseNote(Base, TimestampMixin):
     title: Mapped[str] = mapped_column(Text, nullable=False)
     # E-I18N Phase B(story 11f1087c, migration 0164) — locale별 번역 오버레이({"en": "...", ...}).
     # 빈 dict가 기본(마이그 시점 백필 없음). 소비 코드는 `title_i18n.get(locale) or title` 순서로
-    # 조회해 빈 키는 자동으로 title(ko)로 폴백한다(Phase C 이후 배선 예정). summary/items i18n은
-    # 이번 스코프 밖(요청 범위 = title만 — 필요하면 후속 확장).
+    # 조회해 빈 키는 자동으로 title(ko)로 폴백한다.
     title_i18n: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
     summary: Mapped[str] = mapped_column(Text, nullable=False, server_default="", default="")
     # [{text: str, href?: str}, ...]
     items: Mapped[list] = mapped_column(
         JSONB, nullable=False, server_default=text("'[]'::jsonb"), default=list
     )
+    # E-I18N EN 콘텐츠(story d6e3f407, migration 0165) — title_i18n과 동형 오버레이(빈 dict
+    # 기본·백필 없음). 소비 코드: `summary_i18n.get(locale) or summary` / `items_i18n.get(locale)
+    # or items`.
+    summary_i18n: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    items_i18n: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
     is_published: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("true"), default=True, index=True
     )

--- a/backend/app/routers/release_notes.py
+++ b/backend/app/routers/release_notes.py
@@ -7,10 +7,15 @@ write(생성/수정/삭제)는 3f1f2408 에서 공개 API 에서 **제거**: 릴
 모델/서비스(`release_note.py`)는 GET + 향후 어드민이 재사용하므로 **보존**.
 
 GET response 는 FE `ReleaseNote` shape(`note_key→id`·`display_period→publishedAt`) 그대로 매핑(dialog 무회귀).
+
+E-I18N EN 콘텐츠(story d6e3f407, 문서 `en-content-native-generation-crux` §3): 소비 배선 —
+``locale`` 쿼리(명시)→``Accept-Language`` 헤더(폴백) 순으로 정규화(Phase C `resolve_locale_
+from_request`와 동일 SSOT), ``title_i18n``/``summary_i18n``/``items_i18n``이 비어있으면 자동
+ko 폴백(무회귀 — 오늘처럼 전부 빈 ``{}``이어도 기존과 동일 출력).
 """
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Header
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -18,6 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import get_current_user
 from app.dependencies.database import get_db
 from app.models.release_note import ReleaseNote
+from app.services.agent_onboarding_config import resolve_locale_from_request
 
 router = APIRouter(prefix="/api/v2/release-notes", tags=["release-notes"])
 
@@ -36,24 +42,37 @@ class ReleaseNoteResponse(BaseModel):
     items: list[ReleaseNoteItemModel]
 
 
-def _to_response(row: ReleaseNote) -> ReleaseNoteResponse:
+def _to_response(row: ReleaseNote, locale: str) -> ReleaseNoteResponse:
+    items = row.items_i18n.get(locale) or row.items
     return ReleaseNoteResponse(
         id=row.note_key,
         version=row.version,
         publishedAt=row.display_period,
-        title=row.title,
-        summary=row.summary,
-        items=[ReleaseNoteItemModel(**i) if isinstance(i, dict) else i for i in (row.items or [])],
+        title=row.title_i18n.get(locale) or row.title,
+        summary=row.summary_i18n.get(locale) or row.summary,
+        items=[ReleaseNoteItemModel(**i) if isinstance(i, dict) else i for i in (items or [])],
     )
 
 
 @router.get("", response_model=list[ReleaseNoteResponse])
 async def list_release_notes(
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
     session: AsyncSession = Depends(get_db),
     _auth=Depends(get_current_user),
 ) -> list[ReleaseNoteResponse]:
     """published 릴노트 newest-first(published_at desc). 전역(org 무관)·authed user. write 는 공개 API
-    미노출(비공개 운영자 어드민 전용·3f1f2408)."""
+    미노출(비공개 운영자 어드민 전용·3f1f2408).
+
+    까심 QA 근본fix 교훈(#1966, Header() DI는 라우트 경계에서만) — 이 라우트 함수는 Header/Depends
+    수신 후 plain str만 받는 ``_list_release_notes``로 위임한다. 직접-호출 테스트는 그쪽을 부른다.
+    """
+    resolved_locale = resolve_locale_from_request(locale, accept_language)
+    return await _list_release_notes(session, resolved_locale)
+
+
+async def _list_release_notes(session: AsyncSession, locale: str = "ko") -> list[ReleaseNoteResponse]:
+    """``list_release_notes`` 실 로직 — Header() DI 마커 없음(plain str만). 직접-호출 테스트 대상."""
     rows = (
         await session.execute(
             select(ReleaseNote)
@@ -61,4 +80,4 @@ async def list_release_notes(
             .order_by(ReleaseNote.published_at.desc())
         )
     ).scalars().all()
-    return [_to_response(r) for r in rows]
+    return [_to_response(r, locale) for r in rows]

--- a/backend/app/services/agent_recruiter.py
+++ b/backend/app/services/agent_recruiter.py
@@ -232,7 +232,8 @@ def compose_kit(
 
     Args:
         role_template: role_templates 행(또는 동형 속성을 가진 객체) — role_behaviors·
-            default_tool_groups·runtime_overrides 를 속성으로 읽는다(duck-typing).
+            role_behaviors_i18n(선택, 없으면 ko 그대로)·default_tool_groups·runtime_overrides
+            를 속성으로 읽는다(duck-typing).
         runtime: 실행 런타임 식별자.
         locale: "ko"|"en" — 미지원 값은 호출부가 `resolve_locale()`로 정규화해 넘겨야 한다
             (이 함수는 방어적 폴백 없음 — `validate_tool_groups`와 동일한 fail-closed 철학).
@@ -250,10 +251,18 @@ def compose_kit(
     워크플로는 팀이 커스터마이즈하는 유저것이라 고정 텍스트 대신 `sprintable_get_workflow_guide`
     자가-pull 유도만 남긴다. **integration_prompt**(신규) — 정적 주입이 아니라 에이전트 스스로
     메모리에 반영하도록 유도하는 지시문(결정③), 기존 정체성 보존을 명시.
+
+    E-I18N EN 콘텐츠(story d6e3f407, 문서 `en-content-native-generation-crux` §3): section
+    [A](role_behaviors) 데이터도 이제 locale 분기한다 — `role_behaviors_i18n.get(locale) or
+    role_behaviors` 폴백(en 키가 비어있으면 자동 ko). Phase A 시점엔 의도적으로 미분기였으나
+    (§크럭스 §0: role_behaviors_i18n이 그때 전부 빈 `{}`라 소비해봤자 무의미했음), 이제 PR2에서
+    EN 콘텐츠가 채워지면 이 배선이 실효를 갖는다.
     """
+    role_behaviors_i18n = getattr(role_template, "role_behaviors_i18n", None) or {}
+    role_behaviors = role_behaviors_i18n.get(locale) or role_template.role_behaviors
     role_context = (
         _SECTION_A_HEADER[locale].format(name=role_template.name)
-        + f"\n\n{role_template.role_behaviors}"
+        + f"\n\n{role_behaviors}"
     )
 
     onboarding = "\n\n".join([

--- a/backend/tests/test_e_recruit_s2_compose_prompt.py
+++ b/backend/tests/test_e_recruit_s2_compose_prompt.py
@@ -81,6 +81,43 @@ def test_compose_kit_role_context_includes_role_behaviors_verbatim():
     assert "스스로 판단해 claim하고 소통하세요." in kit["role_context"]
 
 
+# ── E-I18N EN 콘텐츠(story d6e3f407) — role_context 데이터 i18n 소비 배선 ──────────
+
+def test_compose_kit_role_context_falls_back_to_ko_when_role_behaviors_i18n_missing():
+    """role_behaviors_i18n 미설정(SimpleNamespace에 속성 자체 없음) — getattr 방어로 ko 그대로.
+    오늘 실 DB 상태(모든 role_templates.role_behaviors_i18n={})와 동형 — 무회귀 확인."""
+    role = _role(role_behaviors="스스로 판단해 claim하고 소통하세요.")
+    kit = compose_kit(role, "claude-code", locale="en")
+    assert "스스로 판단해 claim하고 소통하세요." in kit["role_context"]
+
+
+def test_compose_kit_role_context_falls_back_to_ko_when_en_key_empty():
+    role = _role(role_behaviors="한글 원문.", role_behaviors_i18n={})
+    kit = compose_kit(role, "claude-code", locale="en")
+    assert "한글 원문." in kit["role_context"]
+
+
+def test_compose_kit_role_context_uses_i18n_when_present():
+    role = _role(
+        role_behaviors="한글 원문.",
+        role_behaviors_i18n={"en": "You are a backend engineer, natively authored."},
+    )
+    kit = compose_kit(role, "claude-code", locale="en")
+    assert "You are a backend engineer, natively authored." in kit["role_context"]
+    assert "한글 원문." not in kit["role_context"]
+
+
+def test_compose_kit_role_context_ko_locale_uses_legacy_column_when_overlay_has_no_ko_key():
+    """locale="ko"인데 overlay엔 "en"만 있으면(오늘 생성 파이프라인이 실제로 채울 유일한 키)
+    레거시 ko 컬럼 그대로(캐논 소스) — overlay는 "en" 전용이라는 문서화된 설계와 정합."""
+    role = _role(
+        role_behaviors="한글 원문.",
+        role_behaviors_i18n={"en": "English content"},
+    )
+    kit = compose_kit(role, "claude-code", locale="ko")
+    assert "한글 원문." in kit["role_context"]
+
+
 def test_compose_kit_workflow_pointer_never_hardcodes_recipe_content():
     """크럭스 결정①: 워크플로는 유저것 — recipe DATA를 kit에 하드코딩하지 않는다. compose_kit는
     이제 recipe 인자 자체를 받지 않으므로(구조적으로 보장) workflow_pointer는 항상 동일한

--- a/backend/tests/test_migration_0165_release_notes_summary_items_i18n_realdb.py
+++ b/backend/tests/test_migration_0165_release_notes_summary_items_i18n_realdb.py
@@ -1,0 +1,64 @@
+"""E-I18N EN 콘텐츠(story d6e3f407) — migration 0165 실 Postgres 검증.
+
+DB env 없으면 skip(CI alembic-fresh 패턴, test_migration_0164_i18n_columns_realdb.py와 동형).
+순수 SELECT, Base.metadata.create_all/drop_all로 스키마를 자체 관리하지 않는다 —
+destructive_schema 마커 사용 금지(0163 CI 회귀·0164 realdb 테스트 명시 확認과 동일 클래스 교훈).
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_summary_items_i18n_columns_exist_and_default_empty():
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    engine = create_async_engine(_async_url())
+    try:
+        async with engine.connect() as conn:
+            rows = (await conn.execute(text(
+                "SELECT summary_i18n, items_i18n FROM release_notes"
+            ))).mappings().all()
+        assert rows, "release_notes 비어있음 — seed 마이그 미적용?"
+        assert all(r["summary_i18n"] == {} for r in rows), "백필 없음이 원칙(순수 구조 추가)"
+        assert all(r["items_i18n"] == {} for r in rows), "백필 없음이 원칙(순수 구조 추가)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_summary_items_legacy_columns_untouched():
+    """summary/items(레거시, ko 캐논 소스)가 신규 컬럼 추가와 무관하게 그대로 살아있어야."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    engine = create_async_engine(_async_url())
+    try:
+        async with engine.connect() as conn:
+            row = (await conn.execute(text(
+                "SELECT summary, items FROM release_notes WHERE note_key = '2026-06-v1-5'"
+            ))).mappings().first()
+        if row is not None:
+            assert row["items"], "0142/0143 시드 items 유실 — 마이그가 기존 데이터를 건드림"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_release_notes_i18n.py
+++ b/backend/tests/test_release_notes_i18n.py
@@ -1,0 +1,112 @@
+"""E-I18N EN 콘텐츠(story d6e3f407, 문서 `en-content-native-generation-crux` §3) — release_notes
+locale 소비 배선(no-DB 유닛). `_to_response`(순수 함수)와 `list_release_notes`(라우트, locale
+소스 우선순위)를 검증한다.
+
+까심 QA 근본fix 교훈(#1966): Header() DI는 라우트 경계에서만 — 직접-호출 테스트는 내부 함수
+(`_list_release_notes`)를 부른다.
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _row(**overrides) -> SimpleNamespace:
+    defaults = dict(
+        note_key="2026-06-v1-5", version="v1.5", display_period="2026년 6월",
+        title="파일 첨부와 미리보기가 생겼어요", title_i18n={},
+        summary="요약", summary_i18n={},
+        items=[{"text": "항목1"}], items_i18n={},
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── _to_response — 순수 함수, i18n 폴백 체인 ────────────────────────────────
+
+def test_to_response_ko_locale_uses_legacy_columns():
+    from app.routers.release_notes import _to_response
+
+    row = _row(title_i18n={"en": "unused"}, summary_i18n={"en": "unused"})
+    out = _to_response(row, "ko")
+    assert out.title == "파일 첨부와 미리보기가 생겼어요"
+    assert out.summary == "요약"
+
+
+def test_to_response_en_locale_falls_back_to_ko_when_overlay_empty():
+    """오늘 실 DB 상태(전부 빈 {})와 동형 — 무회귀."""
+    from app.routers.release_notes import _to_response
+
+    row = _row()
+    out = _to_response(row, "en")
+    assert out.title == "파일 첨부와 미리보기가 생겼어요"
+    assert out.summary == "요약"
+    assert out.items[0].text == "항목1"
+
+
+def test_to_response_en_locale_uses_i18n_overlay_when_present():
+    from app.routers.release_notes import _to_response
+
+    row = _row(
+        title_i18n={"en": "File attachments and previews are here"},
+        summary_i18n={"en": "Summary"},
+        items_i18n={"en": [{"text": "Item 1"}]},
+    )
+    out = _to_response(row, "en")
+    assert out.title == "File attachments and previews are here"
+    assert out.summary == "Summary"
+    assert out.items[0].text == "Item 1"
+    assert out.items[0].text != "항목1"
+
+
+# ── list_release_notes(route) — locale 소스 우선순위(Phase C 동형) ────────────
+
+def _db_returning(rows):
+    res = MagicMock()
+    res.scalars.return_value.all.return_value = rows
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=res)
+    return db
+
+
+@pytest.mark.anyio
+async def test_list_release_notes_explicit_locale_wins_over_header():
+    from app.routers.release_notes import list_release_notes
+
+    row = _row(title_i18n={"en": "EN title"})
+    db = _db_returning([row])
+    out = await list_release_notes(
+        locale="en", accept_language="ko-KR,ko;q=0.9",
+        session=db, _auth=MagicMock(),
+    )
+    assert out[0].title == "EN title"
+
+
+@pytest.mark.anyio
+async def test_list_release_notes_falls_back_to_accept_language_header():
+    from app.routers.release_notes import list_release_notes
+
+    row = _row(title_i18n={"en": "EN title"})
+    db = _db_returning([row])
+    out = await list_release_notes(
+        accept_language="en-US,en;q=0.9", session=db, _auth=MagicMock(),
+    )
+    assert out[0].title == "EN title"
+
+
+@pytest.mark.anyio
+async def test_list_release_notes_no_locale_signal_stays_korean_backward_compatible():
+    from app.routers.release_notes import list_release_notes
+
+    row = _row(title_i18n={"en": "EN title"})
+    db = _db_returning([row])
+    out = await list_release_notes(accept_language=None, session=db, _auth=MagicMock())
+    assert out[0].title == "파일 첨부와 미리보기가 생겼어요"

--- a/backend/tests/test_release_notes_realdb.py
+++ b/backend/tests/test_release_notes_realdb.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import os
 import uuid
 from datetime import datetime, timezone
-from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy import select
@@ -27,20 +26,14 @@ def anyio_backend():
     return "asyncio"
 
 
-def _auth():
-    a = MagicMock()
-    a.user_id = str(uuid.uuid4())
-    return a
-
-
 @pytest.mark.anyio
 async def test_list_returns_seeded_newest_first():
-    from app.routers.release_notes import list_release_notes
+    from app.routers.release_notes import _list_release_notes as list_release_notes
     engine = create_async_engine(_ASYNC)
     Session = async_sessionmaker(engine, expire_on_commit=False)
     try:
         async with Session() as s:
-            out = await list_release_notes(session=s, _auth=_auth())
+            out = await list_release_notes(session=s)
             keys = [r.id for r in out]
             # 시드 4개가 newest-first(v1.5→v1.2)로 선두에(다른 테스트가 추가했을 수 있어 포함 검사).
             assert "2026-06-v1-5" in keys and "2026-05-v1-2" in keys
@@ -59,7 +52,7 @@ async def test_list_returns_seeded_newest_first():
 async def test_unpublished_excluded_from_list():
     """is_published=False 노트는 GET 제외·True 면 포함(published 필터 검증). write 엔드포인트 없이 ORM 직시드."""
     from app.models.release_note import ReleaseNote
-    from app.routers.release_notes import list_release_notes
+    from app.routers.release_notes import _list_release_notes as list_release_notes
     engine = create_async_engine(_ASYNC)
     Session = async_sessionmaker(engine, expire_on_commit=False)
     key = f"unpub-{uuid.uuid4()}"
@@ -71,13 +64,13 @@ async def test_unpublished_excluded_from_list():
                 display_period="2026년 8월", title="U", summary="", items=[], is_published=False,
             ))
             await s.commit()
-            assert key not in [r.id for r in await list_release_notes(session=s, _auth=_auth())]
+            assert key not in [r.id for r in await list_release_notes(session=s)]
             row = (await s.execute(
                 select(ReleaseNote).where(ReleaseNote.note_key == key)
             )).scalar_one()
             row.is_published = True
             await s.commit()
-            assert key in [r.id for r in await list_release_notes(session=s, _auth=_auth())]
+            assert key in [r.id for r in await list_release_notes(session=s)]
             await s.delete(row)
             await s.commit()
     finally:


### PR DESCRIPTION
## Summary
crux(`en-content-native-generation-crux`) §3 + 선생님 결정①④ 반영. `role_behaviors_i18n`/`title_i18n`이 전부 빈 `{}`인데 소비자가 0이라(grep 확認) EN 콘텐츠를 채워도 무의미했다 — 이 PR이 그 소비 배선을 코드로 먼저 닫는다([[no-pr-for-data]] 무관, 무회귀).

- `compose_kit`의 `role_context`: `role_behaviors_i18n.get(locale) or role_behaviors` 폴백.
- `GET /api/v2/release-notes`: `locale` 쿼리(명시)→`Accept-Language` 헤더(폴백) 배선(Phase C `resolve_locale_from_request` 재사용), `_to_response`가 `title_i18n`/`summary_i18n`/`items_i18n` 폴백 체인 사용.
- migration 0165: `release_notes.summary_i18n`/`items_i18n` JSONB 병행 컬럼(`title_i18n`과 동형, 선생님 결정① — 릴노트 full EN 필요·백필 없음·순수 additive).
- 까심 QA #1966 근본fix 교훈 적용: `list_release_notes`도 Header() DI를 라우트 경계에서만 받고 실 로직은 `_list_release_notes`(plain str)로 위임 — 직접-호출 테스트 안전.

오늘 전부 빈 오버레이라 모든 신규 폴백은 ko로 떨어짐 — 기존 출력과 100% 동일(무회귀). EN 실 콘텐츠 backfill은 PR2(선생님 데이터 게이트) 몫.

## Test plan
- [x] 신규 유닛 테스트 10종(compose_kit role_context i18n 폴백 4 + release_notes `_to_response`/`list_release_notes` locale 배선 6)
- [x] 전체 스위트 3201 passed(+10), 기존 7건 무관 실패만
- [x] 로컬 `hyp-ci-pg` 실 Postgres에 마이그 0165 적용 + realdb 테스트 7건 전부 pass 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)