### PR TITLE
feat(i18n): EN 네이티브 저작 — role_templates 24 + release_notes 4 backfill (PR2, story d6e3f407)

### DIFF
--- a/backend/alembic/versions/0166_role_templates_release_notes_en_native_content.py
+++ b/backend/alembic/versions/0166_role_templates_release_notes_en_native_content.py
@@ -18,6 +18,15 @@ items_i18n의 "en" 키에 **실 콘텐츠**를 채운다 — 데이터 마이그
 도구명 검증: 아래 EN 텍스트가 언급하는 모든 `sprintable_*` 식별자는 ko 원본과 동일한 실
 등록 도구명만 사용(신규 텍스트에서 새 도구를 지어내지 않음) — realdb 테스트가 EN 컬럼에도
 0163류 hallucinated-tool-name 가드를 동형 적용해 검증한다.
+
+까심 QA HIGH 수정(#1973 RC, 2026-07-08): 애널리스트 오프닝(overview→hypothesis→doc,
+claim/lock/status 없음)을 쓰는 ko 원본은 **data-analyst 1개뿐**이다 — product-analyst/
+ux-researcher는 ko(0157)에서 steps 1-5가 표준 템플릿(claim→lock→status)과 동일하고
+"자주 쓰는 도구" 목록만 애널리스트류로 다르다(ko 자체의 의도된 설계인지 내부모순인지는
+불명 — 그러나 **오늘 라이브 ko 캐논**이다). 최초 버전은 이 2롤을 도구 목록만 보고 애널리스트
+템플릿으로 잘못 분류해 claim/lock/status 워크플로우를 EN에서 조용히 제거했다(운영계약
+변경 — semantic fidelity 위반). 표준 템플릿(claim/lock/status 보존)+애널리스트 도구
+목록 유지로 정정.
 """
 from __future__ import annotations
 
@@ -33,7 +42,8 @@ depends_on = None
 
 
 # 영어권 에이전트 운영지침 관례로 네이티브 저작한 템플릿 2종(ko 원본의 두 갈래 구조와 동형) —
-# ko는 "표준"(claim→lock→status) vs "애널리스트"(overview→hypothesis→doc) 두 흐름으로 갈렸다.
+# ko는 "표준"(claim→lock→status, 23롤) vs "애널리스트"(overview→hypothesis→doc,
+# data-analyst 1롤뿐 — 까심 QA #1973 RC로 정정, 아래 참조)로 갈렸다.
 _STANDARD_TEMPLATE = """# {name} — Autonomous Operating Instructions
 
 You are the {name} on this project. You're responsible for {description}.
@@ -206,15 +216,12 @@ _STANDARD_ROLES: dict[str, dict[str, str]] = {
         step6="Only mark a design change done after confirming the actual rendering on screen — mockups alone aren't enough.",
         tools="`sprintable_list_stories` · `sprintable_update_story` · `sprintable_send_chat_message` · `sprintable_get_doc`.",
     ),
-}
-
-_ANALYST_ROLES: dict[str, dict[str, str]] = {
-    "data-analyst": dict(
-        name="Data Analyst",
-        description="data analysis, reporting, and surfacing insights",
-        step6="Always back your conclusions with evidence (queries, sample size) — never report a guess as a fact.",
-        tools="`sprintable_get_project_overview` · `sprintable_get_sprint_velocity_history` · `sprintable_create_hypothesis` · `sprintable_create_doc` · `sprintable_send_chat_message`.",
-    ),
+    # 까심 QA HIGH(#1973 RC, 2026-07-08): ko(0157 표준템플릿)는 이 2롤도 steps 1-5에 claim→
+    # lock→status 워크플로우를 그대로 지시한다("자주 쓰는 도구" 목록만 애널리스트류라 ko 자체가
+    # 내부모순 — 하지만 그게 오늘 라이브 ko 캐논이다). EN 네이티브 저작은 ko와 같은 콘텐츠의
+    # 영어 버전이지 조용한 운영계약 재설계가 아니므로, 이 2롤은 표준 템플릿(claim/lock/status
+    # 보존)으로 저작하고 도구 목록만 애널리스트류를 유지한다. ko 자체의 모순은 별도 백로그
+    # (PO가 스토리 개설 예정 — 두 locale 동시 수정 필요, EN만 조용히 고치면 로케일이 갈림).
     "product-analyst": dict(
         name="Product Analyst",
         description="metrics analysis, funnel diagnostics, and providing evidence for decisions",
@@ -226,6 +233,15 @@ _ANALYST_ROLES: dict[str, dict[str, str]] = {
         description="conducting user research and validating hypotheses",
         step6="Always back research conclusions with evidence (interviews, data) in a doc, tied to a hypothesis with a suggested next action.",
         tools="`sprintable_create_hypothesis` · `sprintable_confirm_hypothesis` · `sprintable_get_project_overview` · `sprintable_send_chat_message` · `sprintable_create_doc`.",
+    ),
+}
+
+_ANALYST_ROLES: dict[str, dict[str, str]] = {
+    "data-analyst": dict(
+        name="Data Analyst",
+        description="data analysis, reporting, and surfacing insights",
+        step6="Always back your conclusions with evidence (queries, sample size) — never report a guess as a fact.",
+        tools="`sprintable_get_project_overview` · `sprintable_get_sprint_velocity_history` · `sprintable_create_hypothesis` · `sprintable_create_doc` · `sprintable_send_chat_message`.",
     ),
 }
 

--- a/backend/alembic/versions/0166_role_templates_release_notes_en_native_content.py
+++ b/backend/alembic/versions/0166_role_templates_release_notes_en_native_content.py
@@ -1,0 +1,334 @@
+"""E-I18N EN 콘텐츠 PR2(story d6e3f407) — role_templates/release_notes EN 네이티브 저작 backfill.
+
+Revision ID: 0166
+Revises: 0165
+Create Date: 2026-07-08
+
+crux doc `en-content-native-generation-crux` §1(A) + 선생님 4결정(2026-07-08): 마이그레이션-
+임베드 네이티브 저작(기존 ko seed 0156/0157/0160과 동형 패턴). **번역이 아니라 네이티브
+저작** — 영어권 에이전트 운영지침 관례(간결한 명령형·직접적 지시문 — 흔한 AGENTS.md/CLAUDE.md
+톤)로 처음부터 썼다. ko 24 role_templates + 4 release_notes(title+summary+items, 선생님
+결정①) 전부 커버.
+
+[[no-pr-for-data]] 게이트: 이 마이그는 role_behaviors_i18n/title_i18n/summary_i18n/
+items_i18n의 "en" 키에 **실 콘텐츠**를 채운다 — 데이터 마이그레이션이라 병합 前 선생님 명시
+승인 필요(0163 선례와 동일 규칙). 소비 배선(PR1, #1969)은 이미 머지돼 있어 이 마이그가
+적용되는 즉시 en locale 요청에서 실효를 갖는다.
+
+도구명 검증: 아래 EN 텍스트가 언급하는 모든 `sprintable_*` 식별자는 ko 원본과 동일한 실
+등록 도구명만 사용(신규 텍스트에서 새 도구를 지어내지 않음) — realdb 테스트가 EN 컬럼에도
+0163류 hallucinated-tool-name 가드를 동형 적용해 검증한다.
+"""
+from __future__ import annotations
+
+import json
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0166"
+down_revision = "0165"
+branch_labels = None
+depends_on = None
+
+
+# 영어권 에이전트 운영지침 관례로 네이티브 저작한 템플릿 2종(ko 원본의 두 갈래 구조와 동형) —
+# ko는 "표준"(claim→lock→status) vs "애널리스트"(overview→hypothesis→doc) 두 흐름으로 갈렸다.
+_STANDARD_TEMPLATE = """# {name} — Autonomous Operating Instructions
+
+You are the {name} on this project. You're responsible for {description}.
+
+## How to operate autonomously
+1. Find work to pick up via `sprintable_list_backlog` or `sprintable_get_unassigned_stories`.
+2. Claim it with `sprintable_claim_story`, then move it to in-progress with `sprintable_update_story_status`.
+3. If the work touches files other agents could also be editing, lock them with `sprintable_lock_files` and release with `sprintable_unlock_files` when you're done.
+4. Don't go silent — share progress, questions, and blockers with `sprintable_send_chat_message` as soon as they come up.
+5. Once the acceptance criteria are met, move the story forward (e.g. to in-review) with `sprintable_update_story_status`.
+6. {step6}
+
+## When you're stuck, check for yourself
+The platform won't prompt you every turn — if something feels unfamiliar or you're blocked, proactively call `sprintable_get_workflow_guide` to check the current operating procedure. Don't guess.
+
+## Tools you'll use often
+{tools}
+Don't invent tool names you're not sure about — if it's not in the list above, check `sprintable_get_workflow_guide` first."""
+
+_ANALYST_TEMPLATE = """# {name} — Autonomous Operating Instructions
+
+You are the {name} on this project. You're responsible for {description}.
+
+## How to operate autonomously
+1. Get a read on current state and metrics via `sprintable_get_project_overview`, `sprintable_get_sprint_velocity_history`, and similar tools.
+2. When you spot a pattern or anomaly in the data, turn it into a hypothesis with `sprintable_create_hypothesis`.
+3. Write up your findings with `sprintable_create_doc` and share them right away via `sprintable_send_chat_message`.
+4. If you need follow-up discussion or confirmation, don't stay silent — ask clearly in chat.
+5. Once a hypothesis is validated (another role runs the experiment), reflect the outcome with `sprintable_confirm_hypothesis`.
+6. {step6}
+
+## When you're stuck, check for yourself
+The platform won't prompt you every turn — if something feels unfamiliar or you're blocked, proactively call `sprintable_get_workflow_guide` to check the current operating procedure. Don't guess.
+
+## Tools you'll use often
+{tools}
+Don't invent tool names you're not sure about — if it's not in the list above, check `sprintable_get_workflow_guide` first."""
+
+
+_STANDARD_ROLES: dict[str, dict[str, str]] = {
+    "accessibility": dict(
+        name="Accessibility Specialist",
+        description="accessibility (a11y) audits and compliance",
+        step6="Only mark a11y fixes done after verifying them with a real screen reader and keyboard navigation.",
+        tools="`sprintable_list_stories` · `sprintable_update_story` · `sprintable_send_chat_message` · `sprintable_get_doc`.",
+    ),
+    "ai-engineer": dict(
+        name="AI Engineer",
+        description="implementing and experimenting with LLM/ML features",
+        step6="Verify model or prompt changes against real inputs and confirm there's no quality regression before marking the work done.",
+        tools="`sprintable_list_stories` · `sprintable_create_hypothesis` · `sprintable_update_hypothesis` · `sprintable_get_agent_stats` · `sprintable_send_chat_message`.",
+    ),
+    "backend": dict(
+        name="Backend Engineer",
+        description="APIs, data models, migrations, and server-side logic",
+        step6="If you change the DB schema, apply the migration to a real database and verify it — writing the migration file alone isn't enough.",
+        tools="`sprintable_list_stories` · `sprintable_add_story` · `sprintable_update_story` · `sprintable_update_story_status` · `sprintable_add_task` · `sprintable_send_chat_message`.",
+    ),
+    "code-reviewer": dict(
+        name="Code Reviewer",
+        description="PR review and keeping the quality gate intact",
+        step6="Always back review feedback with evidence (repro steps, specific lines) and reflect approve/reject clearly in the story status.",
+        tools="`sprintable_list_stories` · `sprintable_get_task` · `sprintable_send_chat_message` · `sprintable_update_story_status`.",
+    ),
+    "data-engineer": dict(
+        name="Data Engineer",
+        description="building data pipelines and ETL work",
+        step6="Only mark a pipeline change done after running it end-to-end on real data and checking the output — a code review alone isn't enough.",
+        tools="`sprintable_list_stories` · `sprintable_add_task` · `sprintable_get_project_overview` · `sprintable_send_chat_message` · `sprintable_create_doc`.",
+    ),
+    "design-system": dict(
+        name="Design System Engineer",
+        description="managing design tokens and the component library",
+        step6="Only mark a component or token change done after confirming it doesn't break real call sites.",
+        tools="`sprintable_list_stories` · `sprintable_update_story` · `sprintable_send_chat_message` · `sprintable_update_doc`.",
+    ),
+    "devops": dict(
+        name="DevOps Engineer",
+        description="building and operating CI/CD, infrastructure, and deploy pipelines",
+        step6="Only mark infra or pipeline changes done after verifying them through a real deploy/rollback path — writing config alone isn't enough.",
+        tools="`sprintable_list_stories` · `sprintable_add_task` · `sprintable_update_task_status` · `sprintable_send_chat_message` · `sprintable_create_doc`.",
+    ),
+    "frontend": dict(
+        name="Frontend Engineer",
+        description="UI/UX implementation, component work, and FE bug fixes",
+        step6="For UI changes, verify the actual behavior on screen before marking done — passing type-check alone isn't enough.",
+        tools="`sprintable_list_stories` · `sprintable_add_story` · `sprintable_update_story` · `sprintable_update_story_status` · `sprintable_send_chat_message` · `sprintable_get_doc`.",
+    ),
+    "growth-engineer": dict(
+        name="Growth Engineer",
+        description="growth experiments, funnel improvements, and A/B tests",
+        step6="Always record experiment results with statistical evidence, and carry the learnings into the next experiment.",
+        tools="`sprintable_create_hypothesis` · `sprintable_confirm_hypothesis` · `sprintable_get_recent_activity` · `sprintable_send_chat_message`.",
+    ),
+    "growth-hacker": dict(
+        name="Growth Hacker",
+        description=(
+            "autonomously driving data-driven growth experiments, user acquisition, funnel "
+            "optimization, and retention analysis"
+        ),
+        step6="Only mark experiments or campaigns done after verifying them with real metrics (conversion rate, retention, acquisition data) — a hypothesis or estimate alone isn't enough.",
+        tools="`sprintable_create_hypothesis` · `sprintable_confirm_hypothesis` · `sprintable_get_recent_activity` · `sprintable_get_sprint_velocity_history` · `sprintable_send_chat_message`.",
+    ),
+    "mobile": dict(
+        name="Mobile Engineer",
+        description="implementing iOS/Android apps and fixing mobile bugs",
+        step6="Verify actual behavior on a real device or emulator before marking done — a successful build alone isn't enough.",
+        tools="`sprintable_list_stories` · `sprintable_add_story` · `sprintable_update_story` · `sprintable_update_story_status` · `sprintable_send_chat_message` · `sprintable_get_doc`.",
+    ),
+    "performance-marketer": dict(
+        name="Performance Marketer",
+        description=(
+            "autonomously driving paid acquisition, campaign optimization, and "
+            "attribution/ROAS performance"
+        ),
+        step6="Only mark campaign optimizations done after verifying them with real performance metrics (ROAS, attribution data) — projections or completed spend alone aren't enough.",
+        tools="`sprintable_get_recent_activity` · `sprintable_create_hypothesis` · `sprintable_confirm_hypothesis` · `sprintable_get_sprint_velocity_history` · `sprintable_send_chat_message`.",
+    ),
+    "pm": dict(
+        name="PM/PO",
+        description="story/epic planning, sprint operations, hypothesis management, and team communication",
+        step6="Back priority and scope decisions with evidence (hypotheses, metrics) and record them in a doc or chat so the team can follow along.",
+        tools="`sprintable_add_story` · `sprintable_add_epic` · `sprintable_create_sprint` · `sprintable_assign_story_to_sprint` · `sprintable_create_hypothesis` · `sprintable_get_project_overview` · `sprintable_send_chat_message` · `sprintable_create_meeting` · `sprintable_get_standup`.",
+    ),
+    "qa": dict(
+        name="QA Engineer",
+        description="verifying acceptance criteria, checking for regressions, and quality review",
+        step6="Back review results with evidence (repro steps, actual measurements) in chat, and clearly reflect pass/fail in the status.",
+        tools="`sprintable_list_stories` · `sprintable_get_task` · `sprintable_update_story_status` · `sprintable_send_chat_message` · `sprintable_add_retro_item` · `sprintable_get_doc`.",
+    ),
+    "qa-automation": dict(
+        name="QA Automation Engineer",
+        description="building test automation and preventing regressions",
+        step6="Only mark automated tests done after actually reproducing the failure (negative-path verification) to confirm it's a real guard.",
+        tools="`sprintable_list_stories` · `sprintable_update_story_status` · `sprintable_add_retro_item` · `sprintable_send_chat_message`.",
+    ),
+    "release-manager": dict(
+        name="Release Manager",
+        description="release planning and deployment coordination",
+        step6="Only mark a release plan done after it specifies the actual deploy order and rollback path, and stakeholders have signed off.",
+        tools="`sprintable_list_stories` · `sprintable_create_sprint` · `sprintable_send_chat_message` · `sprintable_create_doc`.",
+    ),
+    "scrum-master": dict(
+        name="Scrum Master",
+        description="managing sprint progress and removing blockers",
+        step6="Only close out a blocker after confirming with the people involved that it's actually resolved — a meeting alone isn't enough.",
+        tools="`sprintable_list_stories` · `sprintable_get_standup` · `sprintable_create_retro_session` · `sprintable_create_meeting` · `sprintable_send_chat_message`.",
+    ),
+    "security-engineer": dict(
+        name="Security Engineer",
+        description="finding vulnerabilities, security review, and hardening",
+        step6="Only mark a vulnerability fix done after reproducing the actual attack scenario and confirming it's blocked — don't claim safety from a code read alone.",
+        tools="`sprintable_list_stories` · `sprintable_add_story` · `sprintable_update_story_status` · `sprintable_send_chat_message` · `sprintable_create_doc`.",
+    ),
+    "sre": dict(
+        name="SRE",
+        description="service reliability, monitoring, and incident response",
+        step6="Record the root cause and prevention plan together for every incident, and confirm monitoring/alerting actually fires before marking done.",
+        tools="`sprintable_list_stories` · `sprintable_get_project_health` · `sprintable_get_recent_activity` · `sprintable_send_chat_message` · `sprintable_update_story_status`.",
+    ),
+    "technical-writer": dict(
+        name="Technical Writer",
+        description="product docs, release notes, and guides",
+        step6="Only mark docs done after cross-checking them against the real feature/API — don't fill gaps with guesses.",
+        tools="`sprintable_list_stories` · `sprintable_create_doc` · `sprintable_update_doc` · `sprintable_search_docs` · `sprintable_send_chat_message`.",
+    ),
+    "ui-designer": dict(
+        name="UI Designer",
+        description="visual design for screens and components",
+        step6="Only mark a design change done after confirming the actual rendering on screen — mockups alone aren't enough.",
+        tools="`sprintable_list_stories` · `sprintable_update_story` · `sprintable_send_chat_message` · `sprintable_get_doc`.",
+    ),
+}
+
+_ANALYST_ROLES: dict[str, dict[str, str]] = {
+    "data-analyst": dict(
+        name="Data Analyst",
+        description="data analysis, reporting, and surfacing insights",
+        step6="Always back your conclusions with evidence (queries, sample size) — never report a guess as a fact.",
+        tools="`sprintable_get_project_overview` · `sprintable_get_sprint_velocity_history` · `sprintable_create_hypothesis` · `sprintable_create_doc` · `sprintable_send_chat_message`.",
+    ),
+    "product-analyst": dict(
+        name="Product Analyst",
+        description="metrics analysis, funnel diagnostics, and providing evidence for decisions",
+        step6="Record your metric interpretations with evidence (query, data source) in a doc or chat so they're ready to act on.",
+        tools="`sprintable_get_sprint_velocity_history` · `sprintable_get_project_overview` · `sprintable_create_hypothesis` · `sprintable_send_chat_message` · `sprintable_create_doc`.",
+    ),
+    "ux-researcher": dict(
+        name="UX Researcher",
+        description="conducting user research and validating hypotheses",
+        step6="Always back research conclusions with evidence (interviews, data) in a doc, tied to a hypothesis with a suggested next action.",
+        tools="`sprintable_create_hypothesis` · `sprintable_confirm_hypothesis` · `sprintable_get_project_overview` · `sprintable_send_chat_message` · `sprintable_create_doc`.",
+    ),
+}
+
+_ROLE_BEHAVIORS_EN: dict[str, str] = {
+    **{
+        slug: _STANDARD_TEMPLATE.format(**data)
+        for slug, data in _STANDARD_ROLES.items()
+    },
+    **{
+        slug: _ANALYST_TEMPLATE.format(**data)
+        for slug, data in _ANALYST_ROLES.items()
+    },
+}
+
+_RELEASE_NOTES_EN: dict[str, dict[str, object]] = {
+    "2026-06-v1-5": dict(
+        title="File attachments and previews, right in your docs",
+        summary="Attach files and images to your docs, then find them all in one place in Storage.",
+        items=[
+            {"text": "Attach files and images directly in your doc body."},
+            {"text": "Manage everything you've attached in one place in Storage."},
+            {"text": "Preview content at a glance with image thumbnails."},
+            {"text": "Get a heads-up before you run out of storage space."},
+        ],
+    ),
+    "2026-06-v1-4": dict(
+        title="Switch accounts and confirm your notifications are landing",
+        summary=(
+            "Move between accounts without logging out, and see at a glance whether your "
+            "notifications are actually getting through."
+        ),
+        items=[
+            {"text": "Add multiple accounts and switch between them without logging out."},
+            {"text": "See, toggle, and test every notification destination in one screen."},
+            {"text": "Add an agent from start to finish in a single modal."},
+        ],
+    ),
+    "2026-06-v1-3": dict(
+        title="Onboarding now takes two minutes",
+        summary="Paste one config, then confirm right away that it actually works.",
+        items=[
+            {"text": "Copy your agent's connection config in a single step."},
+            {"text": "Confirm the connection is really working with the verification rail."},
+        ],
+    ),
+    "2026-05-v1-2": dict(
+        title="The board feels smoother now",
+        summary="We improved kanban drag-and-drop and mobile usability.",
+        items=[
+            {"text": "Made card drag-and-drop more precise."},
+            {"text": "Smoothed out board scrolling on mobile."},
+        ],
+    ),
+}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for slug, en_text in _ROLE_BEHAVIORS_EN.items():
+        conn.execute(
+            sa.text(
+                "UPDATE role_templates "
+                "SET role_behaviors_i18n = jsonb_set(role_behaviors_i18n, '{en}', to_jsonb(CAST(:en_text AS text))) "
+                "WHERE slug = :slug"
+            ),
+            {"slug": slug, "en_text": en_text},
+        )
+    for note_key, data in _RELEASE_NOTES_EN.items():
+        conn.execute(
+            sa.text(
+                "UPDATE release_notes SET "
+                "title_i18n = jsonb_set(title_i18n, '{en}', to_jsonb(CAST(:title AS text))), "
+                "summary_i18n = jsonb_set(summary_i18n, '{en}', to_jsonb(CAST(:summary AS text))), "
+                "items_i18n = jsonb_set(items_i18n, '{en}', CAST(:items AS jsonb)) "
+                "WHERE note_key = :note_key"
+            ),
+            {
+                "note_key": note_key,
+                "title": data["title"],
+                "summary": data["summary"],
+                "items": json.dumps(data["items"]),
+            },
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    for slug in _ROLE_BEHAVIORS_EN:
+        conn.execute(
+            sa.text(
+                "UPDATE role_templates SET role_behaviors_i18n = role_behaviors_i18n - 'en' "
+                "WHERE slug = :slug"
+            ),
+            {"slug": slug},
+        )
+    for note_key in _RELEASE_NOTES_EN:
+        conn.execute(
+            sa.text(
+                "UPDATE release_notes SET "
+                "title_i18n = title_i18n - 'en', "
+                "summary_i18n = summary_i18n - 'en', "
+                "items_i18n = items_i18n - 'en' "
+                "WHERE note_key = :note_key"
+            ),
+            {"note_key": note_key},
+        )

--- a/backend/tests/test_e_i18n_pr2_role_behaviors_en_native_content.py
+++ b/backend/tests/test_e_i18n_pr2_role_behaviors_en_native_content.py
@@ -47,6 +47,36 @@ def test_en_role_behaviors_covers_every_ko_role():
     )
 
 
+def _all_ko_role_behaviors() -> dict[str, str]:
+    behaviors: dict[str, str] = {}
+    for mod in (
+        _load(_S1_MIGRATION, "rev_0156_pr2fidelity"),
+        _load(_S14_MIGRATION, "rev_0157_pr2fidelity"),
+        _load(_MARKETING_MIGRATION, "rev_0160_pr2fidelity"),
+    ):
+        behaviors.update(mod._ROLE_BEHAVIORS)
+    return behaviors
+
+
+def test_en_role_behaviors_preserve_ko_operating_contract():
+    """까심 QA HIGH 회귀 가드(#1973 RC, 2026-07-08): EN 네이티브 저작은 ko와 같은 콘텐츠의
+    영어 버전이지 조용한 운영계약 재설계가 아니다 — ko가 claim/lock/status 워크플로우를
+    지시하면 EN도 반드시 지시해야 한다(그 반대도 마찬가지). product-analyst/ux-researcher를
+    도구 목록만 보고 애널리스트 템플릿으로 잘못 분류해 이 계약을 조용히 바꿨던 버그의 재발
+    방지 — 24 role 전부에 대해 claim_story 존재 여부가 ko/EN 간 일치하는지 직접 대조한다."""
+    ko_behaviors = _all_ko_role_behaviors()
+    mod = _load(_MIGRATION, "rev_0166")
+    en_behaviors = mod._ROLE_BEHAVIORS_EN
+
+    mismatches = []
+    for slug in ko_behaviors:
+        ko_has_claim = "sprintable_claim_story" in ko_behaviors[slug]
+        en_has_claim = "sprintable_claim_story" in en_behaviors[slug]
+        if ko_has_claim != en_has_claim:
+            mismatches.append(f"{slug}: ko_claim={ko_has_claim} en_claim={en_has_claim}")
+    assert not mismatches, "ko/EN claim-workflow 계약 불일치:\n" + "\n".join(mismatches)
+
+
 def test_en_role_behaviors_reference_verified_tool_names_only():
     """0163 교훈과 동형 — EN 신규 저작도 환각 도구명 0건이어야."""
     mod = _load(_MIGRATION, "rev_0166")

--- a/backend/tests/test_e_i18n_pr2_role_behaviors_en_native_content.py
+++ b/backend/tests/test_e_i18n_pr2_role_behaviors_en_native_content.py
@@ -1,0 +1,130 @@
+"""E-I18N EN 콘텐츠 PR2(story d6e3f407) — migration 0166의 EN 네이티브 저작 콘텐츠 검증(no-DB).
+
+0163/S1 선례와 동형: 마이그레이션 모듈을 직접 로드해(importlib) DB 없이 콘텐츠 자체의
+구조적 정합성(전체 role 커버·도구명 환각 0·release_notes 필드 커버)을 빠르게 검증한다.
+실 DB 적용 후 상태는 test_migration_0166_..._realdb.py가 별도로 검증.
+"""
+from __future__ import annotations
+
+import importlib.util
+import re
+from pathlib import Path
+
+import pytest
+
+_MIGRATION = Path(__file__).parent.parent / "alembic" / "versions" / "0166_role_templates_release_notes_en_native_content.py"
+_S1_MIGRATION = Path(__file__).parent.parent / "alembic" / "versions" / "0156_role_templates.py"
+_S14_MIGRATION = Path(__file__).parent.parent / "alembic" / "versions" / "0157_role_templates_catalog_buildout.py"
+_MARKETING_MIGRATION = Path(__file__).parent.parent / "alembic" / "versions" / "0160_role_templates_marketing_roster.py"
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _all_ko_slugs() -> set[str]:
+    """실 role_templates 24행의 slug 전체(S1 4 + S14 18 + marketing 2) — 0166의 EN 커버리지
+    기준선(실 시드 마이그를 참조, 하드코딩 중복 나열 안 함)."""
+    slugs: set[str] = set()
+    for mod, key in (
+        (_load(_S1_MIGRATION, "rev_0156_pr2check"), "_SEED"),
+        (_load(_S14_MIGRATION, "rev_0157_pr2check"), "_SEED"),
+        (_load(_MARKETING_MIGRATION, "rev_0160_pr2check"), "_SEED"),
+    ):
+        slugs |= {row[0] for row in getattr(mod, key)}
+    return slugs
+
+
+def test_en_role_behaviors_covers_every_ko_role():
+    mod = _load(_MIGRATION, "rev_0166")
+    ko_slugs = _all_ko_slugs()
+    en_slugs = set(mod._ROLE_BEHAVIORS_EN.keys())
+    assert en_slugs == ko_slugs, (
+        f"missing EN: {ko_slugs - en_slugs} / extra EN(ko에 없는 slug): {en_slugs - ko_slugs}"
+    )
+
+
+def test_en_role_behaviors_reference_verified_tool_names_only():
+    """0163 교훈과 동형 — EN 신규 저작도 환각 도구명 0건이어야."""
+    mod = _load(_MIGRATION, "rev_0166")
+    from sprintable_mcp.server import _TOOL_DEFS
+
+    real_names = {name for name, *_ in _TOOL_DEFS} | {"ping"}
+    for slug, behaviors in mod._ROLE_BEHAVIORS_EN.items():
+        mentioned = set(re.findall(r"`(sprintable_[a-z_]+)`", behaviors))
+        assert mentioned, f"{slug} EN role_behaviors mentions no sprintable_* tools"
+        unknown = mentioned - real_names
+        assert not unknown, f"{slug} EN role_behaviors invents non-existent tool names: {unknown}"
+
+
+def test_en_role_behaviors_are_english_not_korean():
+    """네이티브 저작 검증(정직화) — EN 컬럼에 한글 문자가 섞이면 안 됨(번역 잔재/복붙 실수 가드)."""
+    mod = _load(_MIGRATION, "rev_0166")
+    hangul = re.compile(r"[가-힣]")
+    for slug, behaviors in mod._ROLE_BEHAVIORS_EN.items():
+        assert not hangul.search(behaviors), f"{slug} EN role_behaviors contains Hangul characters"
+
+
+def test_en_role_behaviors_headings_match_locale_aware_compose_kit_sections():
+    """compose_kit이 만드는 4섹션 표제(Sprintable Role Context/Workflow/...)와 이 role_behaviors
+    자체 헤딩이 안 겹쳐도 되지만, role_behaviors 자체는 항상 '# {name} — Autonomous Operating
+    Instructions'로 시작해야 한다(포맷 회귀 가드)."""
+    mod = _load(_MIGRATION, "rev_0166")
+    for slug, behaviors in mod._ROLE_BEHAVIORS_EN.items():
+        assert behaviors.startswith("# "), f"{slug} EN role_behaviors doesn't start with a heading"
+        assert "Autonomous Operating Instructions" in behaviors.splitlines()[0], slug
+
+
+def test_release_notes_en_covers_all_four_notes():
+    mod = _load(_MIGRATION, "rev_0166")
+    expected_keys = {"2026-06-v1-5", "2026-06-v1-4", "2026-06-v1-3", "2026-05-v1-2"}
+    assert set(mod._RELEASE_NOTES_EN.keys()) == expected_keys
+
+
+def test_release_notes_en_have_title_summary_and_nonempty_items():
+    mod = _load(_MIGRATION, "rev_0166")
+    hangul = re.compile(r"[가-힣]")
+    for note_key, data in mod._RELEASE_NOTES_EN.items():
+        assert data["title"], note_key
+        assert data["summary"], note_key
+        assert data["items"], f"{note_key} has no items"
+        for item in data["items"]:
+            assert "text" in item and item["text"], f"{note_key} item missing text"
+            assert not hangul.search(item["text"]), f"{note_key} item text contains Hangul"
+        assert not hangul.search(data["title"]), note_key
+        assert not hangul.search(data["summary"]), note_key
+
+
+@pytest.mark.parametrize("slug_source", ["standard", "analyst"])
+def test_all_en_roles_compose_via_compose_kit_without_error(slug_source):
+    """S2/S14 교차검증 동형(EN 버전): EN role_behaviors가 실제로 compose_kit을 통과해 유효한
+    kit을 내는지(통합 스모크) — role_behaviors_i18n에 en 키가 있는 것처럼 SimpleNamespace로
+    duck-typing해 넘긴다."""
+    import re as _re
+    from types import SimpleNamespace
+
+    from app.services.agent_recruiter import compose_kit
+    from app.services.mcp_toolset import ALL_TOOL_NAMES
+
+    mod = _load(_MIGRATION, "rev_0166")
+    roles = mod._STANDARD_ROLES if slug_source == "standard" else mod._ANALYST_ROLES
+    template = mod._STANDARD_TEMPLATE if slug_source == "standard" else mod._ANALYST_TEMPLATE
+
+    for slug, data in roles.items():
+        behaviors_en = template.format(**data)
+        role = SimpleNamespace(
+            name=data["name"],
+            role_behaviors=f"(ko placeholder for {slug})",
+            role_behaviors_i18n={"en": behaviors_en},
+            default_tool_groups=["stories", "tasks", "chat", "docs"],
+            runtime_overrides={},
+        )
+        kit = compose_kit(role, "claude-code", locale="en")
+        assert behaviors_en in kit["role_context"]
+        mentioned = set(_re.findall(r"`(sprintable_[a-z_]+)`", kit["role_context"]))
+        assert mentioned <= set(ALL_TOOL_NAMES), (
+            f"{slug}: invented tool names {mentioned - set(ALL_TOOL_NAMES)}"
+        )

--- a/backend/tests/test_migration_0164_i18n_columns_realdb.py
+++ b/backend/tests/test_migration_0164_i18n_columns_realdb.py
@@ -30,7 +30,12 @@ def _async_url() -> str:
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 @pytest.mark.anyio
-async def test_role_behaviors_i18n_column_exists_and_defaults_empty():
+async def test_role_behaviors_i18n_column_exists_and_is_valid_dict():
+    """0164 자체는 순수 구조 추가(마이그 시점 백필 없음)가 원칙 — 컬럼 존재+dict 타입만 여기서
+    검증한다. "항상 빈 {}" 단정은 안 함: 후속 마이그(0166, PR2 EN 네이티브 저작)가 의도적으로
+    "en" 키를 채우므로, head 기준 실행되는 이 테스트가 그 상태와 모순되면 안 된다(0164가
+    스스로 데이터를 안 쓴다는 것과 "미래 마이그가 절대 안 채운다"는 다른 주장 — 후자는 검증
+    범위 밖)."""
     from sqlalchemy import text
     from sqlalchemy.ext.asyncio import create_async_engine
 
@@ -41,7 +46,7 @@ async def test_role_behaviors_i18n_column_exists_and_defaults_empty():
                 "SELECT role_behaviors_i18n FROM role_templates"
             ))).scalars().all()
         assert rows, "role_templates 비어있음 — seed 마이그 미적용?"
-        assert all(r == {} for r in rows), "기존 데이터 마이그 시점 백필 없음이 원칙(순수 구조 추가)"
+        assert all(isinstance(r, dict) for r in rows), "role_behaviors_i18n은 항상 dict(JSONB)여야"
     finally:
         await engine.dispose()
 
@@ -69,6 +74,9 @@ async def test_role_behaviors_legacy_column_untouched():
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 @pytest.mark.anyio
 async def test_release_notes_title_i18n_column_exists():
+    """0166(PR2)이 head에선 이미 "en" 키를 채우므로 "항상 빈 {}" 단정은 안 함 — 컬럼 존재+
+    dict 타입만 검증(0164 자체 파일: 0164_i18n_translation_columns.py의 upgrade()가 데이터를
+    안 쓴다는 건 그 파일 자체로 자명 — server_default '{}'만 추가)."""
     from sqlalchemy import text
     from sqlalchemy.ext.asyncio import create_async_engine
 
@@ -79,6 +87,6 @@ async def test_release_notes_title_i18n_column_exists():
                 "SELECT title, title_i18n FROM release_notes LIMIT 1"
             ))).mappings().first()
         if row is not None:  # release_notes 시드가 없는 환경이면 컬럼 존재만 확認(쿼리 성공 자체가 증거)
-            assert row["title_i18n"] == {}
+            assert isinstance(row["title_i18n"], dict)
     finally:
         await engine.dispose()

--- a/backend/tests/test_migration_0165_release_notes_summary_items_i18n_realdb.py
+++ b/backend/tests/test_migration_0165_release_notes_summary_items_i18n_realdb.py
@@ -28,7 +28,10 @@ def _async_url() -> str:
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
 @pytest.mark.anyio
-async def test_summary_items_i18n_columns_exist_and_default_empty():
+async def test_summary_items_i18n_columns_exist_and_are_valid_dicts():
+    """0165 자체는 순수 구조 추가(백필 없음)가 원칙 — 컬럼 존재+dict 타입만 여기서 검증한다.
+    "항상 빈 {}" 단정은 안 함: 후속 마이그(0166, PR2 EN 네이티브 저작)가 head에서 의도적으로
+    "en" 키를 채우므로 그 상태와 모순되면 안 된다."""
     from sqlalchemy import text
     from sqlalchemy.ext.asyncio import create_async_engine
 
@@ -39,8 +42,8 @@ async def test_summary_items_i18n_columns_exist_and_default_empty():
                 "SELECT summary_i18n, items_i18n FROM release_notes"
             ))).mappings().all()
         assert rows, "release_notes 비어있음 — seed 마이그 미적용?"
-        assert all(r["summary_i18n"] == {} for r in rows), "백필 없음이 원칙(순수 구조 추가)"
-        assert all(r["items_i18n"] == {} for r in rows), "백필 없음이 원칙(순수 구조 추가)"
+        assert all(isinstance(r["summary_i18n"], dict) for r in rows)
+        assert all(isinstance(r["items_i18n"], dict) for r in rows)
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_migration_0166_en_native_content_realdb.py
+++ b/backend/tests/test_migration_0166_en_native_content_realdb.py
@@ -1,0 +1,116 @@
+"""E-I18N EN 콘텐츠 PR2(story d6e3f407) — migration 0166 실 Postgres 검증.
+
+DB env 없으면 skip(0164/0165 realdb 패턴과 동형). 순수 SELECT — destructive_schema 마커
+사용 금지(0163 CI 회귀 교훈).
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_all_role_templates_have_en_role_behaviors():
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    engine = create_async_engine(_async_url())
+    try:
+        async with engine.connect() as conn:
+            rows = (await conn.execute(text(
+                "SELECT slug, role_behaviors_i18n->>'en' AS en FROM role_templates"
+            ))).mappings().all()
+        assert rows, "role_templates 비어있음 — seed 마이그 미적용?"
+        missing = [r["slug"] for r in rows if not r["en"]]
+        assert not missing, f"EN role_behaviors 누락: {missing}"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_legacy_ko_role_behaviors_untouched_by_en_backfill():
+    """EN 백필이 기존 ko role_behaviors(레거시 캐논 소스)를 안 건드렸는지 — 0163이 고친 정직한
+    텍스트가 그대로 살아있어야."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    engine = create_async_engine(_async_url())
+    try:
+        async with engine.connect() as conn:
+            stale_count = (await conn.execute(text(
+                "SELECT count(*) FROM role_templates WHERE role_behaviors LIKE "
+                "'%채용 시점 번들이 처리합니다%'"
+            ))).scalar_one()
+            ko_count = (await conn.execute(text(
+                "SELECT count(*) FROM role_templates WHERE role_behaviors LIKE '%자율 운영 지침%'"
+            ))).scalar_one()
+        assert stale_count == 0
+        assert ko_count == 24
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_all_release_notes_have_en_title_summary_items():
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    engine = create_async_engine(_async_url())
+    try:
+        async with engine.connect() as conn:
+            rows = (await conn.execute(text(
+                "SELECT note_key, title_i18n->>'en' AS title_en, summary_i18n->>'en' AS summary_en, "
+                "items_i18n->'en' AS items_en FROM release_notes"
+            ))).mappings().all()
+        assert rows, "release_notes 비어있음"
+        for r in rows:
+            assert r["title_en"], f"{r['note_key']} title_en 누락"
+            assert r["summary_en"], f"{r['note_key']} summary_en 누락"
+            assert r["items_en"], f"{r['note_key']} items_en 누락"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_compose_kit_en_locale_uses_native_content_for_real_seeded_role():
+    """소비 배선(PR1, #1969) + 데이터(PR2, #0166)가 실제로 맞물리는지 — 실 DB row로 compose_kit
+    locale="en" 호출, 결과에 legacy ko role_behaviors 텍스트가 안 남아있는지 확인."""
+    from types import SimpleNamespace
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import create_async_engine
+    from app.services.agent_recruiter import compose_kit
+
+    engine = create_async_engine(_async_url())
+    try:
+        async with engine.connect() as conn:
+            row = (await conn.execute(text(
+                "SELECT slug, name, role_behaviors, role_behaviors_i18n, default_tool_groups, "
+                "runtime_overrides FROM role_templates WHERE slug = 'backend'"
+            ))).mappings().first()
+        assert row is not None, "backend role_template 시드 없음"
+        role = SimpleNamespace(**dict(row))
+        kit = compose_kit(role, "claude-code", locale="en")
+        assert "Autonomous Operating Instructions" in kit["role_context"]
+        assert row["role_behaviors"] not in kit["role_context"], "ko 레거시 텍스트가 EN 결과에 새어나옴"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## ⚠️ [[no-pr-for-data]] 게이트 — 선생님 명시 승인 전 머지 보류

데이터 콘텐츠 마이그레이션(role_behaviors_i18n/title_i18n/summary_i18n/items_i18n의 "en" 키 실 콘텐츠 backfill). 테스트 통과와 별개로 0163 선례 규칙대로 선생님 승인 게이트 대상.

## Summary
crux(`en-content-native-generation-crux`) §1(A) + 선생님 4결정(2026-07-08) 반영. 마이그레이션-임베드 네이티브 저작(기존 ko seed 0156/0157/0160과 동형 패턴) — **번역이 아니라 처음부터 영어권 에이전트 운영지침 관례**(간결한 명령형·AGENTS.md/CLAUDE.md 톤)로 저작.

- `role_templates.role_behaviors_i18n["en"]`: 24행 전부. ko 원본의 두 갈래 구조(표준 claim→lock→status 21종 · 애널리스트 overview→hypothesis→doc 3종: data-analyst/product-analyst/ux-researcher)를 그대로 반영한 EN 템플릿 2종 + role별 설명/6번째 검증 스텝/도구 목록만 네이티브 저작.
- `release_notes`: `title_i18n`/`summary_i18n`/`items_i18n["en"]` 4건 전부(선생님 결정① — title만이 아니라 full EN). 캐주얼 프로덕트 톤을 영어로도 자연스럽게 재저작(직역 아님).
- 도구명 검증: EN 텍스트가 언급하는 `sprintable_*` 전부 실 등록 도구명만(0163 hallucinated-tool-name 교훈 동형 확장, 신규 테스트로 검증).
- PR1(#1969, 이미 머지)의 소비 배선이 이미 있어 이 마이그 적용 즉시 en locale 요청에서 실효.

## Test plan
- [x] 신규 테스트 12종(no-DB 8 + realdb 4): 24 role 전 커버리지 · 환각 도구명 0 · 한글 잔재 0(번역 아닌 네이티브 저작 정직화 가드) · release_notes 4건 완전성 · `compose_kit(locale="en")` 실 DB E2E(ko 레거시 텍스트 미노출 확인)
- [x] 전체 스위트 3213 passed(+12), 기존 7건 무관 실패만
- [x] 로컬 `hyp-ci-pg` 실 Postgres로 마이그 0166 적용(+downgrade round-trip) · `compose_kit(locale="en")` 실 산출 확인 완료

## 까심 QA 요청 사항(cross-model semantic review)
- 자연스러운 영어(직역투 아님)
- ko 원문과 의도/역할 정의 동일성(semantic — 축자 비교 아님)
- 도구명 오정보 0(테스트로 이미 검증됐으나 재확인 요청)

🤖 Generated with [Claude Code](https://claude.com/claude-code)