### PR TITLE
fix(recruit): STEP4 kit download still uses identity-colliding filename

### DIFF
--- a/apps/web/src/app/(authenticated)/agents/recruiter/recruiter-client.test.tsx
+++ b/apps/web/src/app/(authenticated)/agents/recruiter/recruiter-client.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { spliceApiKey, splitRuntimeCapabilities, pickDefaultRuntime, groupAndFilterRoleTemplates } from './recruiter-client';
+import { spliceApiKey, splitRuntimeCapabilities, pickDefaultRuntime, groupAndFilterRoleTemplates, resolveKitFilename } from './recruiter-client';
 import type { McpConfigBundle, RuntimeCapabilityItem, RoleTemplateSummary } from '@/services/recruit';
-import { RUNTIME_CAPABILITIES_FALLBACK } from '@/services/recruit';
+import { RUNTIME_CAPABILITIES_FALLBACK, KIT_FILENAME } from '@/services/recruit';
 
 describe('spliceApiKey (까심 QA RC HIGH① — transport별 키 위치)', () => {
   it('replaces the key in headers.Authorization for the http (hosted) shape', () => {
@@ -87,6 +87,35 @@ describe('pickDefaultRuntime (E-RECRUIT S6 — avoids recruit() 400 on an unsupp
 
   it('leaves the current value untouched when the supported list is empty (defensive, never crashes)', () => {
     expect(pickDefaultRuntime([], 'claude-code')).toBe('claude-code');
+  });
+});
+
+describe('resolveKitFilename (identity-overwrite regression guard — 까심 QA RC, 2026-07-08)', () => {
+  // 정체성 덮어쓰기 버그(recruit-output-kit-redesign-crux §0): STEP4 다운로드 파일명이 런타임의
+  // 진짜 정체성 파일명(prompt_file — CLAUDE.md/AGENTS.md/GEMINI.md)을 그대로 쓰면, 유저가 저장 시
+  // 자기 에이전트 정체성 파일을 덮어쓴다. BE #1967이 사후 재발급 엔드포인트만 고치고 이 위저드는
+  // 놓쳐 한 번 조용히 재발했다 — 이 테스트가 세 번째 재발을 막는다.
+  const identityFilenamesByRuntime: RuntimeCapabilityItem[] = [
+    mkCap({ slug: 'claude-code', display_name: 'Claude Code', supported: true, prompt_file: 'CLAUDE.md' }),
+    mkCap({ slug: 'codex', display_name: 'Codex', supported: true, prompt_file: 'AGENTS.md' }),
+    mkCap({ slug: 'gemini', display_name: 'Gemini', supported: true, prompt_file: 'GEMINI.md' }),
+    mkCap({ slug: 'cursor', display_name: 'Cursor', supported: true, prompt_file: 'AGENTS.md' }),
+  ];
+
+  it.each(identityFilenamesByRuntime.map((rc) => [rc.slug, rc.prompt_file] as const))(
+    'stays KIT_FILENAME for %s even though runtime-capabilities carries a real identity filename (%s)',
+    (slug) => {
+      expect(resolveKitFilename(slug, identityFilenamesByRuntime)).toBe(KIT_FILENAME);
+    },
+  );
+
+  it('never falls back to a runtime-literal filename when runtimeCapabilities is null/loading', () => {
+    expect(resolveKitFilename('claude-code', null)).toBe(KIT_FILENAME);
+  });
+
+  it('KIT_FILENAME itself does not collide with any known runtime identity filename', () => {
+    const identityFilenames = new Set(identityFilenamesByRuntime.map((rc) => rc.prompt_file));
+    expect(identityFilenames.has(KIT_FILENAME)).toBe(false);
   });
 });
 

--- a/apps/web/src/app/(authenticated)/agents/recruiter/recruiter-client.tsx
+++ b/apps/web/src/app/(authenticated)/agents/recruiter/recruiter-client.tsx
@@ -18,7 +18,7 @@ import {
   VerifyRail, RAIL_ORDER, HTTP_RAIL_ORDER, type DisplayStep, type RailState, type RailStatus,
 } from '@/app/onboarding/verify-rail';
 import type { RoleTemplateSummary, RecruitResponse, McpConfigBundle, RuntimeCapabilityItem } from '@/services/recruit';
-import { RUNTIME_GUIDE_FILENAME_FALLBACK, RUNTIME_CAPABILITIES_FALLBACK } from '@/services/recruit';
+import { RUNTIME_CAPABILITIES_FALLBACK, KIT_FILENAME } from '@/services/recruit';
 
 // ─── 상수/헬퍼 ──────────────────────────────────────────────────────────────
 
@@ -400,10 +400,12 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
   const [rotating, setRotating] = useState(false);
   const [rotateError, setRotateError] = useState<string | null>(null);
 
-  // 실측(BE PR #1911): 일반 런타임 지침 파일명은 `prompt_file`(`guide_filename`은 connector 전용
-  // "CONNECTOR_SETUP.md") — 당초 안내와 필드명이 달라 실 스키마로 정정.
-  const guideFilename = runtimeCapabilities?.find((r) => r.slug === runtime)?.prompt_file
-    ?? RUNTIME_GUIDE_FILENAME_FALLBACK[runtime] ?? 'CLAUDE.md';
+  // 2026-07-08 재발견(크럭스 recruit-output-kit-redesign-crux §0이 지목한 "리터럴 코드 지점" —
+  // #1967은 사후 재발급 엔드포인트(_connection_artifact)만 고치고 이 채용 위저드는 안 건드렸다):
+  // 다운로드/표시 파일명은 런타임별 리터럴(prompt_file — CLAUDE.md/AGENTS.md/GEMINI.md)을 쓰면
+  // 유저가 그 파일을 프로젝트 루트에 저장할 때 실제 정체성 파일을 덮어쓴다. KIT_FILENAME(런타임
+  // 무관 단일 상수)으로 고정 — BE `_connection_artifact`가 #1967 이후 쓰는 것과 동일 문자열.
+  const guideFilename = KIT_FILENAME;
 
   const handleRecruit = async () => {
     if (!selectedRoleSlug) return;

--- a/apps/web/src/app/(authenticated)/agents/recruiter/recruiter-client.tsx
+++ b/apps/web/src/app/(authenticated)/agents/recruiter/recruiter-client.tsx
@@ -92,6 +92,21 @@ export function pickDefaultRuntime(supported: RuntimeCapabilityItem[], current: 
   return supported[0].slug;
 }
 
+/**
+ * 채용 kit 다운로드/표시 파일명 — 항상 `KIT_FILENAME`(런타임 무관 상수). 회귀가드(까심 QA RC,
+ * 2026-07-08): 이 함수가 `runtime`/`runtimeCapabilities`를 받고도 입력과 무관하게 상수만
+ * 반환하는 게 의도다 — 예전엔 여기서 `prompt_file`(CLAUDE.md/AGENTS.md/GEMINI.md 런타임별
+ * 리터럴)을 읽어서 유저 정체성 파일 덮어쓰기 버그를 냈다. BE #1967이 사후 재발급 엔드포인트만
+ * 고치고 이 채용 위저드는 놓쳐 한 번 재발했다(§0 참고) — "더 정확한 파일명"으로 되돌리고 싶은
+ * 유혹을 아래 테스트가 막는다. 시그니처는 호출부 변경을 최소화하려 유지.
+ */
+export function resolveKitFilename(
+  _runtime: string,
+  _runtimeCapabilities: RuntimeCapabilityItem[] | null,
+): string {
+  return KIT_FILENAME;
+}
+
 export interface RoleGroup {
   label: string;
   roles: RoleTemplateSummary[];
@@ -403,9 +418,9 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
   // 2026-07-08 재발견(크럭스 recruit-output-kit-redesign-crux §0이 지목한 "리터럴 코드 지점" —
   // #1967은 사후 재발급 엔드포인트(_connection_artifact)만 고치고 이 채용 위저드는 안 건드렸다):
   // 다운로드/표시 파일명은 런타임별 리터럴(prompt_file — CLAUDE.md/AGENTS.md/GEMINI.md)을 쓰면
-  // 유저가 그 파일을 프로젝트 루트에 저장할 때 실제 정체성 파일을 덮어쓴다. KIT_FILENAME(런타임
-  // 무관 단일 상수)으로 고정 — BE `_connection_artifact`가 #1967 이후 쓰는 것과 동일 문자열.
-  const guideFilename = KIT_FILENAME;
+  // 유저가 그 파일을 프로젝트 루트에 저장할 때 실제 정체성 파일을 덮어쓴다. resolveKitFilename()이
+  // 항상 KIT_FILENAME(런타임 무관 단일 상수)을 반환 — 회귀가드 테스트 대상(아래 함수 정의 참고).
+  const guideFilename = resolveKitFilename(runtime, runtimeCapabilities);
 
   const handleRecruit = async () => {
     if (!selectedRoleSlug) return;

--- a/apps/web/src/services/recruit.ts
+++ b/apps/web/src/services/recruit.ts
@@ -49,13 +49,26 @@ export interface RecruitResponse {
 }
 
 /** 런타임별 지침 파일명(P0=Claude Code 기준·핸드오프 §STEP3) — BE `runtime-capabilities`가 아직
- * 배포 전(디디 미착지)이거나 응답에 `prompt_file`이 없을 때만 쓰는 폴백. */
+ * 배포 전(디디 미착지)이거나 응답에 `prompt_file`이 없을 때만 쓰는 폴백. **다운로드 파일명으로는
+ * 쓰지 말 것** — 유저 정체성 파일(CLAUDE.md 등)과 이름이 충돌한다(아래 KIT_FILENAME 참고). 전달
+ * 카피에서 "이 런타임의 지침파일 컨벤션은 X"를 설명하는 용도로만 참조한다. */
 export const RUNTIME_GUIDE_FILENAME_FALLBACK: Record<string, string> = {
   'claude-code': 'CLAUDE.md',
   codex: 'AGENTS.md',
   gemini: 'GEMINI.md',
   cursor: 'CLAUDE.md',
 };
+
+/**
+ * 채용 kit 다운로드/복사 파일명 — BE `agent_onboarding_config.py::KIT_FILENAME`과 동일 문자열,
+ * 런타임 무관 단일 상수(story b1fe41cf, 정체성 파일 덮어쓰기 버그 fix). 예전엔 이 값을
+ * `RUNTIME_GUIDE_FILENAME_FALLBACK`/`prompt_file`(CLAUDE.md/AGENTS.md/GEMINI.md 런타임별 리터럴)로
+ * 채웠는데, 유저가 그 파일을 프로젝트 루트에 저장하면 자기 에이전트의 진짜 정체성 파일을 그대로
+ * 덮어썼다 — BE의 `_connection_artifact` 엔드포인트(사후 재발급용)는 #1967에서 이미 고쳤으나,
+ * recruit() 응답을 직접 쓰는 이 채용 위저드(STEP4)는 별개 경로라 반영이 안 돼 있었다(2026-07-08
+ * 재발견). 그 어떤 런타임의 정체성 파일명과도 충돌하지 않는다.
+ */
+export const KIT_FILENAME = 'SPRINTABLE_ONBOARDING.md';
 
 /**
  * E-RECRUIT S6 — `GET /api/v2/runtime-capabilities` 응답 항목. **실측 계약**(BE PR #1911,


### PR DESCRIPTION
## Summary
**Urgent fix, split out of story 5ea9bafe per 오르테가's explicit call** — a real correctness bug (identity-file overwrite), not UX polish.

`recruit-output-kit-redesign-crux` (story b1fe41cf, #1967) describes the bug and claims it's fixed: the kit download used to be named after the runtime's real identity file (CLAUDE.md/AGENTS.md/GEMINI.md), so saving it to a project root overwrote the user's actual identity file. #1967 fixed `resolve_instruction_filename()` in `backend/app/services/agent_onboarding_config.py` to always return the runtime-agnostic `KIT_FILENAME` ("SPRINTABLE_ONBOARDING.md").

**But that function is only called from `_connection_artifact`** — the GET endpoint for already-recruited agents (used by `onboarding/connect-step.tsx`). `recruiter-client.tsx`'s STEP4 (the actual hiring wizard — the exact file the crux's own §0 names as "the literal code location") is a separate path: it uses the `POST /recruit` response directly and derived its download/display filename from `runtime-capabilities`' `prompt_file` field, which is still runtime-literal. So the primary recruit flow's download button still handed out a file named e.g. `CLAUDE.md`.

## Fix
- `apps/web/src/services/recruit.ts`: added `KIT_FILENAME = 'SPRINTABLE_ONBOARDING.md'` (same string as the BE constant).
- `recruiter-client.tsx`: STEP4's `guideFilename` now uses `KIT_FILENAME` instead of `prompt_file`/`RUNTIME_GUIDE_FILENAME_FALLBACK`. Those stay in place — not wrong, just wrongly reused as a download filename — for future runtime-aware delivery copy (story 5ea9bafe, next up).

## Test plan
- [x] `pnpm --filter web exec tsc --noEmit` — clean
- [x] `pnpm --filter web lint` — 5 pre-existing warnings (unrelated files), 0 new
- [x] `pnpm --filter web exec vitest run` — 946 passed, 2 skipped, 0 failed (existing `guideFilename derivation source` test targets the raw `prompt_file` data contract, unaffected by this change)
- [x] Root `pnpm build` (turbo, matches Dockerfile) — EXIT 0
- [ ] Live-pixel — post-merge (local FE can't auth against dev BE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)