### PR TITLE
fix(recruit): runtime-capabilities.prompt_file — kit filename과 conflate 해소

### DIFF
--- a/backend/app/services/agent_onboarding_config.py
+++ b/backend/app/services/agent_onboarding_config.py
@@ -81,6 +81,31 @@ def resolve_instruction_filename(runtime: str) -> str:
     return KIT_FILENAME
 
 
+# 유나 라이브픽셀 발견(2026-07-08, 승격 前 fix): 위 KIT_FILENAME/resolve_instruction_filename은
+# "우리가 쓰는 kit 파일"(런타임 무관, 의도된 단일 상수) 개념인데, list_runtime_capabilities()의
+# ``prompt_file``은 그와 **다른** 개념 — "그 런타임 자신의 기존 정체성 지침 파일명"(FE STEP4
+# 전달노트가 "기존 X 파일은 그대로 둬라"에 채워 넣는 값)이다. #1967/#1974가 이 둘을 conflate해
+# 전 런타임에 SPRINTABLE_ONBOARDING.md를 반환 — "기존 SPRINTABLE_ONBOARDING.md 그대로"라는
+# 자기모순 문구를 냈다(SPRINTABLE_ONBOARDING.md는 방금 새로 놓이는 파일이지 "기존" 파일이 아님).
+# apps/web/src/services/recruit.ts::RUNTIME_CAPABILITIES_FALLBACK(2026-07-08 동기화판)과 값을
+# 맞춘다 — claude-code/codex/gemini만 실제 컨벤션 리터럴, connector(범용 버킷)는
+# AGENT_INSTRUCTIONS.md, 나머지(cursor + 커넥터 전용 5종)는 S7 shaping 전 generic fallback으로
+# AGENTS.md.
+_RUNTIME_PROMPT_FILENAMES: dict[str, str] = {
+    "claude-code": "CLAUDE.md",
+    "codex": "AGENTS.md",
+    "gemini": "GEMINI.md",
+    CONNECTOR_RUNTIME: "AGENT_INSTRUCTIONS.md",
+}
+_DEFAULT_RUNTIME_PROMPT_FILENAME = "AGENTS.md"
+
+
+def resolve_runtime_prompt_filename(runtime: str) -> str:
+    """런타임 자신의 기존 정체성 지침 파일명 — resolve_instruction_filename()(kit write-target,
+    런타임 무관 단일 상수)과는 별개 개념이니 혼동 금지."""
+    return _RUNTIME_PROMPT_FILENAMES.get(runtime, _DEFAULT_RUNTIME_PROMPT_FILENAME)
+
+
 _RUNTIME_DISPLAY_NAMES: dict[str, str] = {
     "claude-code": "Claude Code",
     "codex": "Codex",
@@ -104,9 +129,11 @@ def list_runtime_capabilities() -> list[dict]:
     (커넥터 전용 5종 + 범용 connector 버킷)은 전부 SSE 커넥터 경로(CONNECTOR_SETUP.md, transport
     개념 자체가 없음) — 이 두 그룹의 경계가 ``MCP_NATIVE_RUNTIMES``(``is_connector_routed``)다.
     tier는 구체적으로 이름 붙은 런타임이면 "full", 범용 ``connector`` 버킷(특정 런타임을 못
-    찾았을 때의 안내-only 폴백)이면 "experimental" — 채용-kit 재설계(story b1fe41cf) 이후
-    ``prompt_file``이 전 런타임 동일(``KIT_FILENAME``)이라 그걸로는 더 이상 tier를 구분할 수
-    없어, 원래 의도(구체 런타임 vs 범용 폴백)를 직접 표현한다.
+    찾았을 때의 안내-only 폴백)이면 "experimental" — 원래 의도(구체 런타임 vs 범용 폴백)를
+    직접 표현한다(``prompt_file``에 더는 얹지 않음 — 아래 참고).
+
+    ``prompt_file``은 kit 파일명(KIT_FILENAME)이 **아니다** — 그 런타임 자신의 기존 정체성
+    지침 파일명이다(resolve_runtime_prompt_filename() 참고, 유나 라이브픽셀 발견 fix).
 
     PO 확인(2026-07-06): FE 픽커의 "곧 지원" 섹션이 채워지려면 **미지원 런타임도 응답에
     포함**돼야 한다 — ``RuntimeType``(agent_runtime.py, member.runtime_type 9종 SSOT) 전부가
@@ -131,7 +158,7 @@ def list_runtime_capabilities() -> list[dict]:
             ),
             "transport": None if (is_connector_routed or not supported) else default_transport_for_hosting(),
             "mcp_transport": [] if (is_connector_routed or not supported) else sorted(SUPPORTED_TRANSPORTS),
-            "prompt_file": resolve_instruction_filename(runtime) if supported else None,
+            "prompt_file": resolve_runtime_prompt_filename(runtime) if supported else None,
             "guide_filename": "CONNECTOR_SETUP.md" if is_connector_routed else None,
             "supports_event_push": supported and not is_connector_routed,
             "icon": None,

--- a/backend/tests/test_s6_runtime_capabilities.py
+++ b/backend/tests/test_s6_runtime_capabilities.py
@@ -56,11 +56,13 @@ def test_instruction_filename_tiers_and_transport_by_runtime_class():
     tier=full — 범용 connector 버킷(특정 런타임 미확정)만 tier=experimental로 남는다. MCP-native
     4종만 mcp_transport 보유·event_push 지원 — 커넥터 전용 5종+connector는 SSE 경로라 전부 빈값.
 
-    채용-kit 재설계(story b1fe41cf, 선생님 GO 2026-07-08): ``prompt_file``은 이제 런타임 무관
-    단일 파일명(``KIT_FILENAME`` = ``SPRINTABLE_ONBOARDING.md``) — 예전엔 CLAUDE.md/GEMINI.md/
-    AGENTS.md로 런타임별로 갈렸는데, 그 리터럴이 유저의 실제 정체성 파일을 덮어쓰는 버그의
-    원인이라 통일했다."""
-    from app.services.agent_onboarding_config import KIT_FILENAME, list_runtime_capabilities
+    유나 라이브픽셀 발견(2026-07-08, 승격 前 fix): ``prompt_file``은 kit 파일명(KIT_FILENAME=
+    SPRINTABLE_ONBOARDING.md, `agents.py`의 다운로드 아티팩트 — 그건 계속 런타임 무관 단일)이
+    **아니다** — 그 런타임 자신의 기존 정체성 지침 파일명이다(FE STEP4 전달노트 "기존 X 그대로"
+    문구용). #1967/#1974가 이 둘을 conflate해 전 런타임에 SPRINTABLE_ONBOARDING.md를 반환하는
+    자기모순("기존 SPRINTABLE_ONBOARDING.md 그대로" — 방금 새로 놓이는 파일인데 "기존"이라니)
+    버그를 냈다. apps/web/src/services/recruit.ts::RUNTIME_CAPABILITIES_FALLBACK과 값 동기화."""
+    from app.services.agent_onboarding_config import list_runtime_capabilities
 
     caps = {c["slug"]: c for c in list_runtime_capabilities()}
     assert caps["claude-code"]["tier"] == "full"
@@ -68,8 +70,16 @@ def test_instruction_filename_tiers_and_transport_by_runtime_class():
     for slug in ("codex", "cursor", "grok", "pi", "hermes", "openclaw", "opencode"):
         assert caps[slug]["tier"] == "full", slug
     assert caps["connector"]["tier"] == "experimental"
+    assert caps["claude-code"]["prompt_file"] == "CLAUDE.md"
+    assert caps["codex"]["prompt_file"] == "AGENTS.md"
+    assert caps["gemini"]["prompt_file"] == "GEMINI.md"
+    assert caps["connector"]["prompt_file"] == "AGENT_INSTRUCTIONS.md"
+    for slug in ("cursor", "grok", "pi", "hermes", "openclaw", "opencode"):
+        assert caps[slug]["prompt_file"] == "AGENTS.md", slug
     for slug in caps:
-        assert caps[slug]["prompt_file"] == KIT_FILENAME, slug
+        assert caps[slug]["prompt_file"] != "SPRINTABLE_ONBOARDING.md", (
+            f"{slug}: prompt_file must never equal the kit write-target filename"
+        )
 
     for slug in ("claude-code", "codex", "gemini", "cursor"):
         assert caps[slug]["supports_event_push"] is True


### PR DESCRIPTION
## Summary
- 유나 라이브픽셀 발견(승격 前 fix, prod-relevant·전 런타임 유저-facing): `GET /api/v2/runtime-capabilities`의 `prompt_file`이 전 10런타임에 `KIT_FILENAME`(SPRINTABLE_ONBOARDING.md)을 반환 — #1967/#1974 채용-kit 재설계가 "kit 파일명"(런타임 무관, 의도된 단일 상수)과 "런타임 자신의 기존 정체성 지침 파일명"(FE STEP4 전달노트 "기존 X 그대로" 문구용) 두 개념을 `resolve_instruction_filename()` 하나로 conflate.
- fix: `resolve_runtime_prompt_filename()` 신규 함수로 분리. `list_runtime_capabilities()`의 `prompt_file`만 전환, `agents.py`의 kit write-target(`resolve_instruction_filename()`)은 무변경.
- 값은 `apps/web/src/services/recruit.ts::RUNTIME_CAPABILITIES_FALLBACK`(2026-07-08 동기화판)과 일치: claude-code=CLAUDE.md·codex/cursor/커넥터전용5종=AGENTS.md(S7 shaping 전 generic)·gemini=GEMINI.md·connector(범용버킷)=AGENT_INSTRUCTIONS.md.

## Test plan
- [x] `test_s6_runtime_capabilities.py`: 기존 "prompt_file == KIT_FILENAME 전 런타임 동일" assertion을 정확한 런타임별 값 + "prompt_file은 절대 kit 파일명과 같을 수 없다" 회귀 가드로 교체 — 통과.
- [x] `test_ob1_agent_onboarding_config.py`/`test_ob2_verify_connection.py`/`test_e_mcp_opt_s3_hosted_transport.py` 등 recruit/onboarding/connection-artifact 관련 전체(141 passed) — 무회귀.

🤖 Generated with [Claude Code](https://claude.com/claude-code)