### PR TITLE
[SID:ae844d74] recruit·카탈로그 locale 배선

### DIFF
--- a/apps/web/src/app/(authenticated)/agents/recruiter/recruiter-client.tsx
+++ b/apps/web/src/app/(authenticated)/agents/recruiter/recruiter-client.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import {
   Check, CheckCircle2, Copy, Download, RefreshCw, ChevronLeft, Info, Sparkles,
   Palette, Cog, Search, ClipboardList, Briefcase, IdCard,
@@ -216,6 +216,9 @@ interface RecruiterClientProps {
 }
 
 export function RecruiterClient({ projectId, showTopBar = true, onExit }: RecruiterClientProps) {
+  // S25(ae844d74): 카탈로그·recruit이 소비할 활성 UI locale — locale-switcher가 쿠키 전환 후 풀
+  // 리로드하므로 마운트 시점 값이면 충분(별도 리스너 불필요).
+  const locale = useLocale();
   const t = useTranslations('recruiter');
   const tAgents = useTranslations('agents');
   // story d82c1092: 스코프 step(§3③) 카피는 AddAgentForm에서 그대로 하베스트(신규 토큰 0).
@@ -236,14 +239,15 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
   const fetchRoleTemplates = useCallback(async () => {
     setRoleError(false);
     try {
-      const res = await fetch('/api/role-templates');
+      // S25(ae844d74): 활성 UI locale 전달 → BE(S24)가 카드 name/description을 locale별로 반환.
+      const res = await fetch(`/api/role-templates?locale=${locale}`);
       if (!res.ok) { setRoleError(true); return; }
       const json = (await res.json()) as { data?: RoleTemplateSummary[] };
       setRoleTemplates(json.data ?? []);
     } catch {
       setRoleError(true);
     }
-  }, []);
+  }, [locale]);
 
   useEffect(() => { void fetchRoleTemplates(); }, [fetchRoleTemplates]);
 
@@ -474,10 +478,11 @@ export function RecruiterClient({ projectId, showTopBar = true, onExit }: Recrui
         agentName = existingAgents?.find((a) => a.id === agentId)?.name ?? '';
       }
 
+      // S25(ae844d74): 활성 UI locale 전달 → BE(S24)가 role_behaviors_i18n에서 해당 locale kit 합성.
       const recruitRes = await fetch(`/api/agents/${agentId}/recruit`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ role_template_slug: selectedRoleSlug, runtime }),
+        body: JSON.stringify({ role_template_slug: selectedRoleSlug, runtime, locale }),
       });
       const recruitJson = (await recruitRes.json().catch(() => null)) as { data?: RecruitResponse } | null;
       if (!recruitRes.ok || !recruitJson?.data) throw new Error(t('recruitFailed'));


### PR DESCRIPTION
## 요약
- E-RECRUIT S25(story ae844d74) — 유나 dev 스모크가 잡은 승격 전 블로커.
- 현 FE recruit 콜이 body에 locale을 안 실어(`{role_template_slug, runtime}`뿐) UI 언어 토글이 kit 생성 언어에 무영향 → EN 워크스페이스 유저가 KO kit를 받는 배선 갭.
- `useLocale()`(next-intl)로 얻은 활성 UI locale을 `POST /api/agents/{id}/recruit` body와 `GET /api/role-templates?locale=` 콜에 배선. 프록시 라우트(`proxyToFastapi`)는 body/querystring을 그대로 forward하므로 라우트 코드 변경 없이 클라이언트 fetch 2곳만 수정.

## 짝 스토리
- BE(S24, story 25e8828d) 미착지 — 브랜치 `feat/e-recruit-s24-catalog-locale`엔 아직 커밋 없음. 계약(recruit body `locale` 필드 · list `?locale=` 쿼리)은 오르테가 킥오프 메시지에서 확정. **S24 머지 전까지는 BE가 locale을 무시하므로 KO 회귀 없음** — S24 랜딩 후 실 EN kit 검증(유나 재스모크)이 완료 신호.

## 변경
- `apps/web/src/app/(authenticated)/agents/recruiter/recruiter-client.tsx`
  - `useLocale()` 추가, `fetchRoleTemplates()` → `/api/role-templates?locale=${locale}`
  - `handleRecruit()` → recruit body에 `locale` 필드 추가
  - locale toggle은 쿠키 전환 후 풀 리로드하므로 마운트 시점 값으로 충분(별도 리스너 불필요)

## 검증
- `pnpm vitest run` — 162 files / 952 tests PASS (기존 23건 포함, 신규 실패 0)
- `pnpm lint` — 신규 경고 0(기존 무관 파일 5건 pre-existing)
- `pnpm build` — EXIT 0
- worktree 격리(`sprintable-mirko-s25-wt`), origin/develop 최신 기준 신규 브랜치

## 반응형/스크린샷
- 순수 데이터 배선(body/querystring 필드 추가)이라 렌더 표면 변경 없음 — 기존 role picker 카드 레이아웃 그대로. S24 랜딩 후 EN 콘텐츠 실 렌더는 유나 재스모크에서 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)