### PR TITLE
feat(recruit): S24 — 카탈로그/recruit locale 서빙 + description_i18n 신설

### DIFF
--- a/backend/alembic/versions/0167_role_templates_description_i18n.py
+++ b/backend/alembic/versions/0167_role_templates_description_i18n.py
@@ -1,0 +1,46 @@
+"""E-RECRUIT S24(story 25e8828d) — role_templates.description_i18n 병행 JSONB 컬럼.
+
+Revision ID: 0167
+Revises: 0166
+Create Date: 2026-07-09
+
+선생님 결정 B(2026-07-09, 카탈로그 카드 완전 KO) — 유나 dev 스모크가 카탈로그 카드
+(description)가 영어 단일이라 KO 워크스페이스에서도 항상 영어로 뜨는 걸 발견. role_behaviors
+는 이미 0164(role_behaviors_i18n)로 이 문제를 풀었으니 description도 동형 병행 컬럼.
+
+**role_behaviors_i18n과 오버레이 방향이 반대**임에 주의 — role_behaviors_i18n은 "ko가
+canon(레거시 Text 컬럼) → en을 오버레이로 채운다"(role_behaviors 원본이 한글). 반면 신규
+80직군 카탈로그의 description은 애초에 **영어로 저작**됐다(원본이 이미 영어) — 그래서
+description_i18n은 "en(=description 원문)이 canon → **ko를 오버레이로 채운다**"가 맞다.
+소비 코드는 `description_i18n.get(locale) or description`(role_behaviors_i18n과 동일
+폴백 함수 재사용) — locale="ko"인데 아직 ko 콘텐츠가 없는 행은 자동으로 기존 영어
+description으로 무회귀 폴백(정확히 지금 상태 유지, 회귀 0).
+
+스키마만(콘텐츠 데이터 아님) — [[no-pr-for-data]] 게이트 무관. 순수 additive(기존
+description Text 컬럼 무변경) — 기존 데이터 백필 없음(빈 dict 시작, PO 병행 저작·주입은
+internal-api enrichment 경로로 별도 무-PR 처리, S23 화이트리스트 확장과 짝).
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0167"
+down_revision = "0166"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "role_templates",
+        sa.Column(
+            "description_i18n", postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False, server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("role_templates", "description_i18n")

--- a/backend/app/models/role_template.py
+++ b/backend/app/models/role_template.py
@@ -29,6 +29,8 @@ class RoleTemplate(Base, TimestampMixin):
     slug: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
     name: Mapped[str] = mapped_column(Text, nullable=False)
     category: Mapped[str] = mapped_column(Text, nullable=False)
+    # ~80직군 카탈로그(track C)는 이 컬럼을 영어로 저작 — description_i18n(0167)이 그 위
+    # ko 오버레이(role_behaviors 와 오버레이 방향이 반대인 이유는 그 필드 주석 참고).
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     # 자율 운영 지침(markdown) — 큰 정적 프롬프트가 아니라 날씬한 매뉴얼(블루프린트 §3 개정).
     # 이 컬럼 자체가 "ko" 캐논 소스(오늘 유일한 실 콘텐츠) — role_behaviors_i18n은 그 위 오버레이.
@@ -65,3 +67,8 @@ class RoleTemplate(Base, TimestampMixin):
     # (신규 스키마 발명 안 함, A2A가 이미 소비하는 정확히 그 shape). S4에서 _build_agent_card가
     # 이 필드를 직접 소비하게 되면 persona 수작업 없이 스케일에서 발견-by-capability가 열린다.
     skills: Mapped[list[dict]] = mapped_column(JSONB, nullable=False, default=list)
+    # E-RECRUIT S24(story 25e8828d, migration 0167) — description locale 오버레이. 원본
+    # description 이 이미 영어(track C 저작)라 role_behaviors_i18n 과 반대로 **en(=원본)이
+    # canon, ko를 오버레이로 채운다**({"ko": "..."}). 소비 코드는 동일 원칙(
+    # `description_i18n.get(locale) or description`) — ko 콘텐츠 없는 행은 영어로 무회귀 폴백.
+    description_i18n: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)

--- a/backend/app/routers/role_templates.py
+++ b/backend/app/routers/role_templates.py
@@ -2,13 +2,26 @@
 
 GET /api/v2/role-templates        발행된 role_template 목록
 GET /api/v2/role-templates/{slug} 단건 조회(role_behaviors 포함)
+
+E-RECRUIT S24(story 25e8828d, 선생님 결정 B — 카탈로그 카드 완전 KO): locale 서빙 —
+`resolve_locale_from_request`(release_notes/recruit와 동형: 명시 `?locale=` →
+`Accept-Language` 헤더 폴백 → DEFAULT_LOCALE)로 정규화한 locale에 맞춰:
+- `role_behaviors`: `role_behaviors_i18n.get(locale) or role_behaviors`(ko가 원본/canon,
+  en 오버레이 — compose_kit과 동일 폴백).
+- `description`: `description_i18n.get(locale) or description`(migration 0167 — 반대
+  방향: en이 원본/canon(track C 저작이 영어), ko 오버레이). PO 병행 저작·주입 전엔 ko
+  콘텐츠가 비어있어 자동으로 기존 영어로 무회귀 폴백.
+- `division`: 12개 고정 enum 값을 `_DIVISION_DISPLAY_NAMES`(코드 상수 — 값 자체가 유한
+  집합이라 no-PR-for-data 무관, agent_recruiter의 다른 locale dict와 동형)로 표시명 매핑.
+`name`/`category`는 이번 스코프 제외 — category는 78개 거의 1:1 세분류 태그라 브라우징
+그룹핑 축이 아님(division이 그 역할), name은 고유명사라 영어 유지(PO+유나 합의).
 """
 from __future__ import annotations
 
 import uuid
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,8 +30,33 @@ from app.dependencies.auth import get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.role_template import RoleTemplate
 from app.schemas.a2a import AgentSkill
+from app.services.agent_onboarding_config import resolve_locale_from_request
 
 router = APIRouter(prefix="/api/v2/role-templates", tags=["role-templates"])
+
+# S24(story 25e8828d) — division 12개 고정값 → ko 표시명(PO 제공·선생님 확認 2026-07-09).
+# en(기본)은 저장된 원문 그대로(매핑 불요) — ko 요청시에만 이 dict로 치환.
+_DIVISION_DISPLAY_NAMES_KO: dict[str, str] = {
+    "Content": "콘텐츠",
+    "Data": "데이터",
+    "Design": "디자인",
+    "Engineering": "엔지니어링",
+    "Growth": "그로스",
+    "Marketing": "마케팅",
+    "Operations": "오퍼레이션",
+    "Platform / DevOps": "플랫폼/DevOps",
+    "Product": "프로덕트",
+    "Quality": "품질",
+    "Sales": "세일즈",
+    "Security": "보안",
+}
+
+
+def _localize_division(division: str | None, locale: str) -> str | None:
+    """알려지지 않은/미래 division 값은 매핑 미스여도 원문 그대로(무회귀 폴백) — reject 안 함."""
+    if division is None or locale != "ko":
+        return division
+    return _DIVISION_DISPLAY_NAMES_KO.get(division, division)
 
 
 class RoleTemplateSummary(BaseModel):
@@ -52,32 +90,89 @@ class RoleTemplateDetail(RoleTemplateSummary):
     updated_at: datetime
 
 
+def _to_summary_response(rt: RoleTemplate, locale: str) -> RoleTemplateSummary:
+    """release_notes `_to_response`/`compose_kit`과 동형 폴백 — i18n 오버레이가 그 locale에
+    콘텐츠가 없으면 원문으로 무회귀 폴백."""
+    description = (rt.description_i18n or {}).get(locale) or rt.description
+    return RoleTemplateSummary(
+        id=rt.id, slug=rt.slug, name=rt.name, category=rt.category, description=description,
+        default_tool_groups=rt.default_tool_groups,
+        default_workflow_recipe_slug=rt.default_workflow_recipe_slug, is_builtin=rt.is_builtin,
+        tier=rt.tier, version=rt.version, division=_localize_division(rt.division, locale),
+        emoji=rt.emoji, skills=[AgentSkill.model_validate(s) for s in rt.skills],
+    )
+
+
+def _to_detail_response(rt: RoleTemplate, locale: str) -> RoleTemplateDetail:
+    role_behaviors = (rt.role_behaviors_i18n or {}).get(locale) or rt.role_behaviors
+    description = (rt.description_i18n or {}).get(locale) or rt.description
+    return RoleTemplateDetail(
+        id=rt.id, slug=rt.slug, name=rt.name, category=rt.category, description=description,
+        default_tool_groups=rt.default_tool_groups,
+        default_workflow_recipe_slug=rt.default_workflow_recipe_slug, is_builtin=rt.is_builtin,
+        tier=rt.tier, version=rt.version, division=_localize_division(rt.division, locale),
+        emoji=rt.emoji, skills=[AgentSkill.model_validate(s) for s in rt.skills],
+        role_behaviors=role_behaviors, runtime_overrides=rt.runtime_overrides,
+        created_at=rt.created_at, updated_at=rt.updated_at,
+    )
+
+
 @router.get("", response_model=list[RoleTemplateSummary])
 async def list_role_templates(
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     _auth=Depends(get_current_user),
 ) -> list[RoleTemplateSummary]:
-    """발행된(is_published) role_template 카탈로그 — org/project 무관 전역 조회."""
+    """발행된(is_published) role_template 카탈로그 — org/project 무관 전역 조회.
+
+    Header() DI 마커는 라우트 경계에서만 받고 실 로직은 ``_list_role_templates()``(plain
+    str만)로 위임 — 직접-호출 realdb 테스트가 ASGI 파이프라인 없이도 Header sentinel leak
+    없이 부를 수 있게 한다(recruit 엔드포인트 S19/E-I18N 선례와 동형)."""
+    return await _list_role_templates(session=session, locale=locale, accept_language=accept_language)
+
+
+async def _list_role_templates(
+    *, session: AsyncSession, locale: str | None = None, accept_language: str | None = None,
+) -> list[RoleTemplateSummary]:
+    """``description``·``division``이 locale에 맞춰 선택/매핑된다(``category``/``name``은
+    이번 스코프 제외 — 모듈 docstring 참고)."""
+    resolved_locale = resolve_locale_from_request(locale, accept_language)
     result = await session.execute(
         select(RoleTemplate)
         .where(RoleTemplate.is_published.is_(True))
         .order_by(RoleTemplate.category, RoleTemplate.name)
     )
-    return [RoleTemplateSummary.model_validate(rt) for rt in result.scalars().all()]
+    return [_to_summary_response(rt, resolved_locale) for rt in result.scalars().all()]
 
 
 @router.get("/{slug}", response_model=RoleTemplateDetail)
 async def get_role_template(
     slug: str,
+    locale: str | None = None,
+    accept_language: str | None = Header(None, alias="Accept-Language"),
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     _auth=Depends(get_current_user),
 ) -> RoleTemplateDetail:
-    """단건 조회 — 미발행(is_published=False) 행은 404(카탈로그와 동일 가시성 규칙)."""
+    """단건 조회 — Header() DI 마커는 라우트 경계에서만, 실 로직은 ``_get_role_template()``
+    (plain str)로 위임(위 list와 동일 이유)."""
+    return await _get_role_template(slug, session=session, locale=locale, accept_language=accept_language)
+
+
+async def _get_role_template(
+    slug: str, *, session: AsyncSession, locale: str | None = None, accept_language: str | None = None,
+) -> RoleTemplateDetail:
+    """미발행(is_published=False) 행은 404(카탈로그와 동일 가시성 규칙).
+
+    ``role_behaviors``는 ``?locale=``(명시) → ``Accept-Language``(폴백) → ko(기본)로 정규화한
+    locale에 맞춰 ``role_behaviors_i18n``에서 선택(recruit ``compose_kit``과 동일 원칙) —
+    en 콘텐츠가 없으면 자동으로 ko 원문 폴백(무회귀)."""
     role_template = (await session.execute(
         select(RoleTemplate).where(RoleTemplate.slug == slug, RoleTemplate.is_published.is_(True))
     )).scalar_one_or_none()
     if role_template is None:
         raise HTTPException(status_code=404, detail="Role template not found")
-    return RoleTemplateDetail.model_validate(role_template)
+    resolved_locale = resolve_locale_from_request(locale, accept_language)
+    return _to_detail_response(role_template, resolved_locale)

--- a/backend/tests/test_e_recruit_s14_catalog_buildout.py
+++ b/backend/tests/test_e_recruit_s14_catalog_buildout.py
@@ -156,12 +156,12 @@ async def _engine():
 @pytest.mark.anyio
 @pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
 async def test_list_role_templates_returns_all_22_roles_realdb():
-    from app.routers.role_templates import list_role_templates
+    from app.routers.role_templates import _list_role_templates as list_role_templates
 
     eng, Session = await _engine()
     try:
         async with Session() as s:
-            out = await list_role_templates(session=s, org_id=uuid.uuid4(), _auth=None)
+            out = await list_role_templates(session=s)
         slugs = {rt.slug for rt in out}
         expected_new = {
             "mobile", "devops", "sre", "data-engineer", "ai-engineer", "security-engineer",
@@ -180,12 +180,12 @@ async def test_list_role_templates_returns_all_22_roles_realdb():
 @pytest.mark.anyio
 @pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
 async def test_get_role_template_data_analyst_by_slug_realdb():
-    from app.routers.role_templates import get_role_template
+    from app.routers.role_templates import _get_role_template as get_role_template
 
     eng, Session = await _engine()
     try:
         async with Session() as s:
-            out = await get_role_template("data-analyst", session=s, org_id=uuid.uuid4(), _auth=None)
+            out = await get_role_template("data-analyst", session=s)
         assert out.slug == "data-analyst"
         assert out.category == "growth"
         assert "stories" not in out.default_tool_groups

--- a/backend/tests/test_e_recruit_s1_role_templates.py
+++ b/backend/tests/test_e_recruit_s1_role_templates.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import importlib.util
 import os
-import uuid
 from pathlib import Path
 
 import pytest
@@ -73,6 +72,8 @@ def test_model_field_shape():
         "division", "emoji", "skills",
         # E-I18N Phase B(story 11f1087c, migration 0164) — locale 번역 오버레이.
         "role_behaviors_i18n",
+        # E-RECRUIT S24(story 25e8828d, migration 0167) — description locale 오버레이.
+        "description_i18n",
     }
 
 
@@ -98,12 +99,12 @@ async def _engine():
 @pytest.mark.anyio
 @pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
 async def test_list_role_templates_returns_seeded_four_roles_realdb():
-    from app.routers.role_templates import list_role_templates
+    from app.routers.role_templates import _list_role_templates as list_role_templates
 
     eng, Session = await _engine()
     try:
         async with Session() as s:
-            out = await list_role_templates(session=s, org_id=uuid.uuid4(), _auth=None)
+            out = await list_role_templates(session=s)
         slugs = {rt.slug for rt in out}
         assert {"frontend", "backend", "qa", "pm"} <= slugs
         # 목록 응답엔 role_behaviors(md 본문) 없음(페이로드 절감)
@@ -115,12 +116,12 @@ async def test_list_role_templates_returns_seeded_four_roles_realdb():
 @pytest.mark.anyio
 @pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
 async def test_get_role_template_by_slug_includes_behaviors_realdb():
-    from app.routers.role_templates import get_role_template
+    from app.routers.role_templates import _get_role_template as get_role_template
 
     eng, Session = await _engine()
     try:
         async with Session() as s:
-            out = await get_role_template("backend", session=s, org_id=uuid.uuid4(), _auth=None)
+            out = await get_role_template("backend", session=s)
         assert out.slug == "backend"
         assert "sprintable_" in out.role_behaviors
         assert out.default_tool_groups == ["stories", "tasks", "epics", "chat", "docs"]
@@ -132,13 +133,13 @@ async def test_get_role_template_by_slug_includes_behaviors_realdb():
 @pytest.mark.anyio
 @pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
 async def test_get_role_template_unknown_slug_404_realdb():
-    from app.routers.role_templates import get_role_template
+    from app.routers.role_templates import _get_role_template as get_role_template
 
     eng, Session = await _engine()
     try:
         async with Session() as s:
             with pytest.raises(HTTPException) as ei:
-                await get_role_template("nonexistent-role", session=s, org_id=uuid.uuid4(), _auth=None)
+                await get_role_template("nonexistent-role", session=s)
             assert ei.value.status_code == 404
     finally:
         await eng.dispose()
@@ -148,7 +149,8 @@ async def test_get_role_template_unknown_slug_404_realdb():
 @pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
 async def test_unpublished_role_template_hidden_from_list_and_get_realdb():
     """is_published=False 는 목록/단건 둘 다 숨김(삭제 아닌 게이트)."""
-    from app.routers.role_templates import get_role_template, list_role_templates
+    from app.routers.role_templates import _get_role_template as get_role_template
+    from app.routers.role_templates import _list_role_templates as list_role_templates
 
     eng, Session = await _engine()
     try:
@@ -160,13 +162,180 @@ async def test_unpublished_role_template_hidden_from_list_and_get_realdb():
             ))
             await s.commit()
         async with Session() as s:
-            listed = await list_role_templates(session=s, org_id=uuid.uuid4(), _auth=None)
+            listed = await list_role_templates(session=s)
             assert "draft-role" not in {rt.slug for rt in listed}
             with pytest.raises(HTTPException) as ei:
-                await get_role_template("draft-role", session=s, org_id=uuid.uuid4(), _auth=None)
+                await get_role_template("draft-role", session=s)
             assert ei.value.status_code == 404
     finally:
         async with Session() as s:
             await s.execute(text("DELETE FROM role_templates WHERE slug = 'draft-role'"))
+            await s.commit()
+        await eng.dispose()
+
+
+# ─── E-RECRUIT S24(story 25e8828d): 카탈로그 detail locale 서빙 ───────────────
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+async def test_get_role_template_locale_en_selects_i18n_overlay_realdb():
+    """locale=en 명시 시 role_behaviors_i18n.en 을 반환(0166 EN 백필이 backend 에 이미 존재)."""
+    from app.routers.role_templates import _get_role_template as get_role_template
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            ko = await get_role_template("backend", session=s)
+            en = await get_role_template("backend", session=s, locale="en")
+        assert en.role_behaviors != ko.role_behaviors
+        assert "sprintable_" in en.role_behaviors  # EN 본문도 실 도구명 참조
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+async def test_get_role_template_locale_unset_preserves_ko_regression_realdb():
+    """AC3(KO 워크스페이스 회귀 0) — locale 미지정 시 기존 ko role_behaviors 그대로."""
+    from app.routers.role_templates import _get_role_template as get_role_template
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            no_locale = await get_role_template("backend", session=s)
+            explicit_ko = await get_role_template("backend", session=s, locale="ko")
+        assert no_locale.role_behaviors == explicit_ko.role_behaviors
+        assert "sprintable_" in no_locale.role_behaviors
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+async def test_get_role_template_accept_language_header_fallback_realdb():
+    """명시 locale 없이 Accept-Language 헤더만으로 en 선택(recruit 엔드포인트와 동일 폴백)."""
+    from app.routers.role_templates import _get_role_template as get_role_template
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            via_header = await get_role_template(
+                "backend", session=s, accept_language="en-US,en;q=0.9,ko;q=0.5",
+            )
+            explicit_en = await get_role_template("backend", session=s, locale="en")
+        assert via_header.role_behaviors == explicit_en.role_behaviors
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+async def test_get_role_template_locale_falls_back_to_ko_when_i18n_missing_realdb():
+    """role_behaviors_i18n 에 그 locale 콘텐츠가 없으면(빈 dict) ko 원문으로 무회귀 폴백."""
+    from app.routers.role_templates import _get_role_template as get_role_template
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await s.execute(text(
+                "INSERT INTO role_templates (slug, name, category, role_behaviors, "
+                "default_tool_groups, is_published, role_behaviors_i18n) VALUES "
+                "('no-i18n-role', 'No I18N', 'test', 'ko-only-body', ARRAY['stories'], "
+                "true, '{}'::jsonb)"
+            ))
+            await s.commit()
+        async with Session() as s:
+            out = await get_role_template("no-i18n-role", session=s, locale="en")
+        assert out.role_behaviors == "ko-only-body"
+    finally:
+        async with Session() as s:
+            await s.execute(text("DELETE FROM role_templates WHERE slug = 'no-i18n-role'"))
+            await s.commit()
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+async def test_list_role_templates_description_unaffected_when_no_ko_overlay_yet_realdb():
+    """0156/0157/0160 builtin seed는 description_i18n 백필이 없다(순수 구조 추가, 0167) —
+    PO ko 저작·주입 전까지는 locale 무관 항상 영어 원문(회귀 0)."""
+    from app.routers.role_templates import _list_role_templates as list_role_templates
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            ko_list = await list_role_templates(session=s, locale="ko")
+            en_list = await list_role_templates(session=s, locale="en")
+        ko_by_slug = {rt.slug: rt.description for rt in ko_list}
+        en_by_slug = {rt.slug: rt.description for rt in en_list}
+        assert ko_by_slug == en_by_slug
+    finally:
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+async def test_list_role_templates_division_localized_to_ko_realdb():
+    """division(코드 상수 매핑, 데이터 백필 불요) — ko 요청 시 12개 고정값이 한글 표시명으로,
+    en/미지정 시 저장된 영문 원문 그대로."""
+    from app.routers.role_templates import _get_role_template as get_role_template
+    from app.routers.role_templates import _list_role_templates as list_role_templates
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await s.execute(text(
+                "INSERT INTO role_templates (slug, name, category, role_behaviors, "
+                "default_tool_groups, is_published, division) VALUES "
+                "('division-probe', 'Division Probe', 'test', 'body', ARRAY['stories'], "
+                "true, 'Engineering')"
+            ))
+            await s.commit()
+        async with Session() as s:
+            ko_list = await list_role_templates(session=s, locale="ko")
+            en_list = await list_role_templates(session=s, locale="en")
+            ko_detail = await get_role_template("division-probe", session=s, locale="ko")
+        ko_division = next(rt.division for rt in ko_list if rt.slug == "division-probe")
+        en_division = next(rt.division for rt in en_list if rt.slug == "division-probe")
+        assert ko_division == "엔지니어링"
+        assert en_division == "Engineering"
+        assert ko_detail.division == "엔지니어링"
+    finally:
+        async with Session() as s:
+            await s.execute(text("DELETE FROM role_templates WHERE slug = 'division-probe'"))
+            await s.commit()
+        await eng.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+async def test_get_role_template_description_locale_selects_i18n_overlay_realdb():
+    """description_i18n 에 ko 콘텐츠가 있으면 locale=ko 요청이 그걸 선택(en은 항상 원문)."""
+    from app.routers.role_templates import _get_role_template as get_role_template
+
+    eng, Session = await _engine()
+    try:
+        async with Session() as s:
+            await s.execute(text(
+                "INSERT INTO role_templates (slug, name, category, role_behaviors, "
+                "default_tool_groups, is_published, description, description_i18n) VALUES "
+                "('desc-i18n-probe', 'Desc Probe', 'test', 'body', ARRAY['stories'], true, "
+                "'English description', '{\"ko\": \"한글 설명\"}'::jsonb)"
+            ))
+            await s.commit()
+        async with Session() as s:
+            ko = await get_role_template("desc-i18n-probe", session=s, locale="ko")
+            en = await get_role_template("desc-i18n-probe", session=s, locale="en")
+            unset = await get_role_template("desc-i18n-probe", session=s)
+        assert ko.description == "한글 설명"
+        assert en.description == "English description"
+        # locale 미지정 → resolve_locale_from_request 의 DEFAULT_LOCALE="ko" 로 정규화되므로
+        # ko 콘텐츠가 있으면 그게 선택된다(회귀 0은 "ko 콘텐츠가 아직 없는 행"에 한정 — 있는
+        # 행에서 ko 유저가 한글을 보는 건 이 스토리가 의도하는 개선 그 자체).
+        assert unset.description == "한글 설명"
+    finally:
+        async with Session() as s:
+            await s.execute(text("DELETE FROM role_templates WHERE slug = 'desc-i18n-probe'"))
             await s.commit()
         await eng.dispose()

--- a/backend/tests/test_e_recruit_s1_role_templates.py
+++ b/backend/tests/test_e_recruit_s1_role_templates.py
@@ -339,3 +339,110 @@ async def test_get_role_template_description_locale_selects_i18n_overlay_realdb(
             await s.execute(text("DELETE FROM role_templates WHERE slug = 'desc-i18n-probe'"))
             await s.commit()
         await eng.dispose()
+
+
+# ─── ASGI 레벨(실 HTTP 쿼리파라미터·헤더 파싱) — mock_session/test_client(conftest) ────
+# 위 realdb 테스트는 `_get_role_template()`/`_list_role_templates()`를 직접 호출해 Header()
+# DI 마커·쿼리파라미터 파싱 자체(FastAPI 라우팅 레이어)는 안 거친다 — 그 레이어까지 실제로
+# 도는지는 여기서 실 ASGI 요청으로 확인한다.
+
+
+def _mock_role_template(**overrides):
+    from datetime import datetime, timezone
+    from unittest.mock import MagicMock
+    import uuid as uuid_mod
+
+    rt = MagicMock()
+    rt.id = uuid_mod.uuid4()
+    rt.slug = "http-probe"
+    rt.name = "HTTP Probe"
+    rt.category = "test"
+    rt.description = "English description"
+    rt.description_i18n = {"ko": "한글 설명"}
+    rt.default_tool_groups = ["stories"]
+    rt.default_workflow_recipe_slug = None
+    rt.is_builtin = False
+    rt.tier = "free"
+    rt.version = 1
+    rt.division = "Engineering"
+    rt.emoji = None
+    rt.skills = []
+    rt.role_behaviors = "ko body"
+    rt.role_behaviors_i18n = {"en": "en body"}
+    rt.runtime_overrides = {}
+    rt.created_at = datetime.now(timezone.utc)
+    rt.updated_at = datetime.now(timezone.utc)
+    for k, v in overrides.items():
+        setattr(rt, k, v)
+    return rt
+
+
+def _scalar_result(obj):
+    from unittest.mock import MagicMock
+
+    res = MagicMock()
+    res.scalar_one_or_none.return_value = obj
+    return res
+
+
+@pytest.mark.anyio
+async def test_get_role_template_locale_query_param_http(test_client, mock_session):
+    """실 HTTP GET ?locale=en — FastAPI 쿼리파라미터 파싱이 실제로 EN 을 골라내는지."""
+    from unittest.mock import AsyncMock
+
+    rt = _mock_role_template()
+    mock_session.execute = AsyncMock(return_value=_scalar_result(rt))
+    resp = await test_client.get("/api/v2/role-templates/http-probe", params={"locale": "en"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["role_behaviors"] == "en body"
+    assert body["description"] == "English description"
+    assert body["division"] == "Engineering"  # en → 매핑 미적용, 원문
+
+
+@pytest.mark.anyio
+async def test_get_role_template_accept_language_header_http(test_client, mock_session):
+    """실 HTTP GET — 명시 locale 없이 Accept-Language 헤더만으로 ko 표시명/en 오버레이 선택."""
+    from unittest.mock import AsyncMock
+
+    rt = _mock_role_template()
+    mock_session.execute = AsyncMock(return_value=_scalar_result(rt))
+    resp = await test_client.get(
+        "/api/v2/role-templates/http-probe",
+        headers={"Accept-Language": "ko-KR,ko;q=0.9"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["role_behaviors"] == "ko body"  # ko는 role_behaviors_i18n에 en만 있어 원문 폴백
+    assert body["description"] == "한글 설명"  # ko 오버레이 선택
+    assert body["division"] == "엔지니어링"  # ko 표시명 매핑 적용
+
+
+@pytest.mark.anyio
+async def test_get_role_template_no_locale_signal_defaults_ko_http(test_client, mock_session):
+    """locale 쿼리도 Accept-Language 헤더도 없으면 DEFAULT_LOCALE=ko(회귀 0 — 기존 클라이언트)."""
+    from unittest.mock import AsyncMock
+
+    rt = _mock_role_template()
+    mock_session.execute = AsyncMock(return_value=_scalar_result(rt))
+    resp = await test_client.get("/api/v2/role-templates/http-probe")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["description"] == "한글 설명"
+    assert body["division"] == "엔지니어링"
+
+
+@pytest.mark.anyio
+async def test_list_role_templates_locale_query_param_http(test_client, mock_session):
+    """실 HTTP GET list ?locale=ko — division/description 이 실제로 로케일 적용되는지."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    rt = _mock_role_template()
+    res = MagicMock()
+    res.scalars.return_value.all.return_value = [rt]
+    mock_session.execute = AsyncMock(return_value=res)
+    resp = await test_client.get("/api/v2/role-templates", params={"locale": "ko"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body[0]["division"] == "엔지니어링"
+    assert body[0]["description"] == "한글 설명"


### PR DESCRIPTION
## Summary
E-RECRUIT S24(story `25e8828d`) — 유나 dev 스모크 발견(블로커): `role_behaviors_i18n.en`이 DB에 실재하는데도 recruit이 locale을 안 받아 항상 ko만 반환.

**조사 결과 — recruit 자체는 이미 완전 구현**(E-I18N Phase C, story 11f1087c): `agents.py`의 `_recruit_agent_endpoint`가 `body.locale`→`Accept-Language` 헤더 폴백→`compose_kit`까지 이미 배선돼 있고, 하드코딩 ko 없음(기존 테스트 `test_recruit_locale_*` 3종이 이미 이걸 검증). **진짜 갭은 고객 카탈로그 GET(`role_templates.py`)에 locale 자체가 없었던 것.**

- `GET /api/v2/role-templates`(list)·`/{slug}`(detail)에 `locale` 쿼리 + `Accept-Language` 헤더 폴백 추가(`resolve_locale_from_request`, recruit과 동형). `Header()` DI 마커는 라우트 경계에서만, 실 로직은 `_list_role_templates()`/`_get_role_template()`(plain str)로 위임 — 직접-호출 realdb 테스트가 sentinel leak 없이 부를 수 있게(S19/E-I18N 선례 동형).
- `role_behaviors`: `role_behaviors_i18n.get(locale) or role_behaviors` 선택을 detail에 신규 노출(compose_kit과 동일 폴백).
- **신규 migration 0167**: `role_templates.description_i18n` JSONB 오버레이(선생님 결정 B — 카탈로그 카드 완전 KO). `role_behaviors_i18n`과 오버레이 방향이 반대 — description 원문이 이미 영어(track C 저작)라 en이 canon, **ko를 오버레이로 채운다**(`{"ko": "..."}`). 순수 additive(백필 없음) — PO 병행 저작·주입은 internal-api enrichment 경로(별 PR)로.
- `division`: 12개 고정값 → ko 표시명 코드 상수 매핑(`_DIVISION_DISPLAY_NAMES_KO`, PO 제공·선생님 확인) — no-PR-for-data 무관(유한 enum, 다른 locale dict와 동형).
- `category`/`name`은 스코프 제외 — category는 78개 거의 1:1 세분류 태그(division이 이미 브라우징 그룹핑 역할), name은 고유명사라 영어 유지(PO+유나 합의).

## Test plan
- [x] 신규 realdb 테스트 다수(locale=en role_behaviors_i18n 선택·locale 미지정 ko 회귀 0·Accept-Language 폴백·i18n 없는 행 무회귀 폴백·division ko 매핑·description_i18n 선택) — 45 passed
- [x] alembic 단일 head 유지(`0167`), fresh-DB `upgrade heads` 통과
- [x] cross-repo drift-check(internal-api vendored model vs 이 마이그로 만든 실 스키마) PASS
- [x] 전체 backend 스위트(destructive_schema 마커 제외) 회귀 0 — role_templates 무관 pre-existing 실패(MCP 프로세스 체크 등) 외 신규 실패 없음
- [x] worktree 격리·gh auth 스위치 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)