### PR TITLE
feat(a2a): WORKING permanent-stall prevention + failure contract (E-A2A-완성 S-A1)

### DIFF
--- a/backend/alembic/versions/0168_a2a_tasks_deadline_at.py
+++ b/backend/alembic/versions/0168_a2a_tasks_deadline_at.py
@@ -1,0 +1,35 @@
+"""E-A2A-완성 S-A1(story 2a57dc0f) — a2a_tasks.deadline_at 컬럼.
+
+Revision ID: 0168
+Revises: 0167
+Create Date: 2026-07-09
+
+WORKING 영구정체 방지 blueprint(`a2a-completion-blueprint` Phase H). 기존 A2A_TASK_TIMEOUT_
+MINUTES(30분) 판정은 GetTask 폴링 시점에만 `created_at`에서 즉석 계산하는 100% 반응형이었다
+— 캐ller가 다시 폴링하지 않으면 task가 조용히 WORKING으로 남는다. 이 컬럼은 생성 시점에
+명시적으로 기한을 기록해, 별도 cron 스위퍼가 폴링과 무관하게 능동적으로 판정할 수 있게 한다.
+
+nullable(기존 행 백필 없음, 순수 additive) — 마이그 이전에 생성된 레거시 task는 NULL이며,
+소비 코드(스위퍼·GetTask 양쪽)가 `deadline_at ?? created_at + A2A_TASK_TIMEOUT_MINUTES`로
+폴백해 무회귀 처리한다.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0168"
+down_revision = "0167"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "a2a_tasks",
+        sa.Column("deadline_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("a2a_tasks", "deadline_at")

--- a/backend/app/models/a2a_task.py
+++ b/backend/app/models/a2a_task.py
@@ -31,3 +31,7 @@ class A2ATask(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
+    # E-A2A-완성 S-A1(story 2a57dc0f, migration 0168): WORKING 영구정체 방지 스위퍼가 폴링과
+    # 무관하게 판정할 수 있도록 생성 시점에 명시 기록. NULL=마이그 이전 레거시 행(폴백은
+    # 소비 코드가 created_at + A2A_TASK_TIMEOUT_MINUTES로 처리).
+    deadline_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -90,6 +90,11 @@ from app.repositories.team_member import TeamMemberRepository
 from app.routers.agent_gateway import wake_agent
 from app.routers.events import _agent_connections
 from app.services.agent_onboarding_config import resolve_backend_direct_url
+from app.services.a2a_task_lifecycle import (
+    A2A_TASK_TIMEOUT_MINUTES,
+    effective_deadline,
+    fail_task_in_place,
+)
 from app.services.event_seq import assign_recipient_seq
 from app.services.webhook_targeting import active_webhook_member_ids
 from app.schemas.a2a import (
@@ -156,13 +161,12 @@ _TERMINAL_STATES = {
     "TASK_STATE_REJECTED",
 }
 
-# P1-S2(story 7b93eb10, PO 크럭스 승인): model-mediated 완료신호 부재의 백스톱 — CC가 이 시간
-# 안에 task-thread 답신을 안 하면 GetTask가 폴링 시점에 TASK_STATE_FAILED로 전이한다(영구
-# WORKING 정체 방지). ⚠️ tradeoff(정직히 문서화, PO 지시): CC가 30분 넘게 조용히 오래 작업하는
-# 정상 케이스도 false-FAIL될 수 있다(interim ack 없는 model-mediated 구조의 근본 제약) — 실사용
-# 데이터가 쌓이면 이 값을 튜닝한다. PoC→P1 단계에선 설정가능화(요청별 override) 대신 고정 상수로
-# 시작(실사용 데이터 없이 설정 노출은 과설계).
-A2A_TASK_TIMEOUT_MINUTES = 30
+# P1-S2(story 7b93eb10, PO 크럭스 승인) + S-A1(story 2a57dc0f): model-mediated 완료신호 부재의
+# 백스톱 — CC가 이 시간 안에 task-thread 답신을 안 하면 FAILED로 전이한다(영구 WORKING 정체
+# 방지). ⚠️ tradeoff(정직히 문서화, PO 지시): CC가 30분 넘게 조용히 오래 작업하는 정상 케이스도
+# false-FAIL될 수 있다(interim ack 없는 model-mediated 구조의 근본 제약) — 실사용 데이터가
+# 쌓이면 이 값을 튜닝한다. 상수 자체는 `a2a_task_lifecycle`(cron 스위퍼와 공유 SSOT) 소유 —
+# 여기선 재-export만.
 
 
 class _JsonRpcException(Exception):
@@ -345,7 +349,7 @@ def _task_to_dict(task: A2ATask) -> dict:
         artifacts=[Artifact.model_validate(a) for a in task.artifacts],
         history=[Message.model_validate(m) for m in task.history],
         metadata=task.task_metadata,
-    ).model_dump(by_alias=True, mode="json")
+    ).model_dump(by_alias=True, mode="json", exclude_none=True)
 
 
 def _first_text(message: Message) -> str:
@@ -507,6 +511,8 @@ async def _handle_send_message(
         task_metadata=task_metadata,
         history=[incoming.model_dump(by_alias=True, mode="json")],
         artifacts=[],
+        # S-A1(story 2a57dc0f): 생성 시점에 명시 기록 — cron 스위퍼가 폴링과 무관하게 판정.
+        deadline_at=now + timedelta(minutes=A2A_TASK_TIMEOUT_MINUTES),
     ))
     await session.flush()
     await session.commit()
@@ -606,14 +612,14 @@ async def _handle_get_task(
                     f"webhook delivery failed on all {len(deliveries)} channel(s) after "
                     f"{latest.attempt_count} attempts: {latest.last_error or 'unknown error'}"
                 )
-            elif datetime.now(timezone.utc) - task.created_at > timedelta(minutes=A2A_TASK_TIMEOUT_MINUTES):
+            elif datetime.now(timezone.utc) > effective_deadline(task):
                 failure_reason = (
                     f"timed out waiting for agent response after {A2A_TASK_TIMEOUT_MINUTES}m"
                 )
 
             if failure_reason is not None:
-                task.state = "TASK_STATE_FAILED"
-                task.task_metadata = {**(task.task_metadata or {}), "failure_reason": failure_reason}
+                # S-A1(story 2a57dc0f): 스위퍼와 동일 SSOT(사유 문구 포맷·Artifact 첨부 일치).
+                fail_task_in_place(task, failure_reason)
                 await session.flush()
                 await session.commit()
                 await session.refresh(task)

--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -93,7 +93,7 @@ from app.services.agent_onboarding_config import resolve_backend_direct_url
 from app.services.a2a_task_lifecycle import (
     A2A_TASK_TIMEOUT_MINUTES,
     effective_deadline,
-    fail_task_in_place,
+    fail_task_if_still_working,
 )
 from app.services.event_seq import assign_recipient_seq
 from app.services.webhook_targeting import active_webhook_member_ids
@@ -618,9 +618,12 @@ async def _handle_get_task(
                 )
 
             if failure_reason is not None:
-                # S-A1(story 2a57dc0f): 스위퍼와 동일 SSOT(사유 문구 포맷·Artifact 첨부 일치).
-                fail_task_in_place(task, failure_reason)
-                await session.flush()
+                # S-A1(story 2a57dc0f): 스위퍼와 동일 SSOT + CAS(까심 QA HIGH C fix) — 이
+                # 함수가 읽은 task는 이 시점엔 stale일 수 있다(사이에 스위퍼/AC2 훅이 먼저
+                # 전이시켰을 수 있음). CAS UPDATE가 그 경합을 흡수하고, 결과와 무관하게
+                # refresh로 DB의 진짜 현재 상태를 반영한다(이미 다른 경로가 이겼으면 그 결과
+                # 그대로 반환 — stale WORKING 기준으로 덮어쓰지 않는다).
+                await fail_task_if_still_working(session, task.id, failure_reason)
                 await session.commit()
                 await session.refresh(task)
 

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -560,6 +560,25 @@ async def assets_grace_hard_delete(
         return _err("INTERNAL_ERROR", "Internal server error", 500)
 
 
+# ─── GET /api/v2/internal/cron/a2a-task-deadline-sweep ────────────────────────
+# E-A2A-완성 S-A1(story 2a57dc0f): WORKING 영구정체 방지 — 기존 GetTask 인라인 판정(반응형,
+# 캐ller 폴링 의존)과 별개로 폴링과 무관하게 기한 초과 task를 능동적으로 FAILED 전이한다.
+
+@router.get("/a2a-task-deadline-sweep")
+async def a2a_task_deadline_sweep(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    verify_cron(request)
+    try:
+        from app.services.a2a_task_lifecycle import sweep_expired_a2a_tasks
+        result = await sweep_expired_a2a_tasks(session)
+        return _ok(result)
+    except Exception as exc:
+        logger.exception("cron error (a2a-task-deadline-sweep): %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)
+
+
 @router.get("/storage-usage-warn")
 async def storage_usage_warn(
     request: Request,

--- a/backend/app/services/a2a_task_lifecycle.py
+++ b/backend/app/services/a2a_task_lifecycle.py
@@ -4,16 +4,30 @@
 실 delegate(CC) 완료는 model-mediated(비결정적)라 회신 누락이 구조적으로 가능하다 — 이
 모듈은 그 비결정성을 "정직한 상태 계약"(기한 초과 → FAILED + 사유 artifact)으로 감싼다.
 
-`app/routers/a2a.py`(GetTask 인라인 반응형 판정)와 `app/routers/cron.py`(능동 스위퍼)가
-이 모듈의 `fail_task_in_place`/`effective_deadline`을 공유 — 두 경로가 서로 다른 사유
+`app/routers/a2a.py`(GetTask 인라인 반응형 판정)·`app/routers/cron.py`(능동 스위퍼)·
+`app/services/conversation_webhook.py`(AC2 즉시-FAILED 훅) 세 경로가 이 모듈의
+`fail_task_if_still_working`/`effective_deadline`을 공유 — 두 경로가 서로 다른 사유
 문구/Artifact 포맷을 만들지 않는다(SSOT 원칙).
+
+까심 QA(2026-07-09, story 2a57dc0f 리스크축 검증) HIGH 블로커 C: 스위퍼가 SELECT로 대상을
+로드한 뒤 Python에서 상태를 뮤테이트하고 마지막에 한 번 커밋하는 구조라, 그 사이(로드~커밋)
+같은 task가 다른 트랜잭션(GetTask의 정상 완료 커밋)에서 이미 COMPLETED로 전이됐어도 스위퍼가
+그 사실을 모른 채 stale 상태 기준으로 FAILED를 덮어썼다 — 정상 완료된 task가 거짓 FAILED로
+오염되고, 이후 `state=='WORKING'` 게이트에 걸려 아무 경로도 재교정하지 않는 자가치유 불가
+버그였다(재현: 실 PG 2세션 직접 검증). fix = **CAS(compare-and-swap)**: FAILED로 쓰는 모든
+경로(스위퍼·GetTask 반응형·AC2 훅)를 `UPDATE ... WHERE id=X AND state='TASK_STATE_WORKING'`
+조건부로 바꾼다 — 영향행 0이면 이미 다른 경로가 그 task를 전이시켰다는 뜻이라(COMPLETED 등)
+그 결과를 존중하고 skip한다. 비관적 락(`with_for_update`)이나 버전 컬럼보다 경량 — Postgres
+READ COMMITTED 하에서 각 UPDATE 문은 실행 시점의 최신 커밋 상태를 보고 WHERE를 재평가하므로
+원자적 CAS가 된다.
 """
 from __future__ import annotations
 
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import select
+from sqlalchemy import cast, select, update
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.a2a_task import A2ATask
@@ -44,24 +58,44 @@ def build_failure_artifact(reason: str) -> dict:
     ).model_dump(by_alias=True, mode="json")
 
 
-def fail_task_in_place(task: A2ATask, reason: str) -> None:
-    """WORKING task를 FAILED로 전이 — task_metadata.failure_reason(기존 소비자 호환) + 실
-    Artifact 둘 다 기록. flush/commit은 호출부 책임(호출부마다 트랜잭션 경계가 다름 — GetTask
-    인라인은 요청-스코프 세션, 스위퍼는 배치 세션)."""
-    task.state = "TASK_STATE_FAILED"
-    task.task_metadata = {**(task.task_metadata or {}), "failure_reason": reason}
-    task.artifacts = [*task.artifacts, build_failure_artifact(reason)]
+async def fail_task_if_still_working(session: AsyncSession, task_id: uuid.UUID, reason: str) -> bool:
+    """CAS — WORKING인 경우에만 FAILED 전이(조건부 UPDATE, 까심 QA HIGH C fix). task_metadata는
+    JSONB `||`(얕은 병합, failure_reason 키 추가/덮어씀)·artifacts는 JSONB `||`(배열 concat)로
+    DB 레벨에서 원자적으로 갱신 — Python이 먼저 읽은 값을 그대로 되돌려쓰지 않으므로 그 사이
+    다른 트랜잭션이 커밋한 변경을 덮어쓸 수 없다.
+
+    Returns:
+        True면 이 호출이 실제로 FAILED 전이시켰음. False면 영향행 0(이미 다른 경로가 그 task를
+        전이시킴, 예: GetTask가 그 사이 COMPLETED로 커밋) — 그 결과를 존중하고 아무것도 안 한다.
+        호출부는 flush/commit 책임(트랜잭션 경계가 호출부마다 다름 — GetTask 인라인은 요청-스코프
+        세션, 스위퍼/AC2 훅은 각자의 배치·백그라운드 세션).
+    """
+    artifact = build_failure_artifact(reason)
+    stmt = (
+        update(A2ATask)
+        .where(A2ATask.id == task_id, A2ATask.state == "TASK_STATE_WORKING")
+        .values(
+            state="TASK_STATE_FAILED",
+            task_metadata=A2ATask.task_metadata.op("||")(cast({"failure_reason": reason}, JSONB)),
+            artifacts=A2ATask.artifacts.op("||")(cast([artifact], JSONB)),
+        )
+    )
+    result = await session.execute(stmt)
+    return result.rowcount > 0
 
 
 async def sweep_expired_a2a_tasks(session: AsyncSession) -> dict:
     """S-A1 AC1: 능동 스위퍼 — GetTask 폴링과 무관하게 기한 초과 WORKING task를 FAILED로
     승격한다(cron 진입점, `app/routers/cron.py`). SQL 레벨에서 deadline_at NULL(레거시)/
-    non-NULL 양쪽을 한 쿼리로 처리 — Python 필터링 없이 DB가 판정(대량 스캔 안전)."""
+    non-NULL 양쪽을 한 쿼리로 처리 — Python 필터링 없이 DB가 판정(대량 스캔 안전).
+
+    후보 목록은 SELECT로 뽑되, 실제 전이는 각 task마다 개별 CAS UPDATE로 — 다른 트랜잭션이
+    그 사이 먼저 종결시킨 task는 조용히 skip(까심 QA HIGH C fix)."""
     now = datetime.now(timezone.utc)
     legacy_cutoff = now - timedelta(minutes=A2A_TASK_TIMEOUT_MINUTES)
 
     result = await session.execute(
-        select(A2ATask).where(
+        select(A2ATask.id).where(
             A2ATask.state == "TASK_STATE_WORKING",
             (
                 (A2ATask.deadline_at.is_not(None)) & (A2ATask.deadline_at < now)
@@ -70,14 +104,13 @@ async def sweep_expired_a2a_tasks(session: AsyncSession) -> dict:
             ),
         )
     )
-    expired = list(result.scalars().all())
+    candidate_ids = [row[0] for row in result.all()]
 
-    for task in expired:
-        fail_task_in_place(
-            task,
-            f"deadline sweep: no agent response within "
-            f"{A2A_TASK_TIMEOUT_MINUTES}m of task creation",
-        )
+    reason = f"deadline sweep: no agent response within {A2A_TASK_TIMEOUT_MINUTES}m of task creation"
+    swept_ids = []
+    for task_id in candidate_ids:
+        if await fail_task_if_still_working(session, task_id, reason):
+            swept_ids.append(task_id)
 
     await session.commit()
-    return {"swept_count": len(expired), "task_ids": [str(t.id) for t in expired]}
+    return {"swept_count": len(swept_ids), "task_ids": [str(t) for t in swept_ids]}

--- a/backend/app/services/a2a_task_lifecycle.py
+++ b/backend/app/services/a2a_task_lifecycle.py
@@ -1,0 +1,83 @@
+"""E-A2A-완성 S-A1(story 2a57dc0f, blueprint `a2a-completion-blueprint` Phase H): WORKING
+영구정체 방지 + 실패 계약 — task 기한 판정/전이 로직의 단일 SSOT.
+
+실 delegate(CC) 완료는 model-mediated(비결정적)라 회신 누락이 구조적으로 가능하다 — 이
+모듈은 그 비결정성을 "정직한 상태 계약"(기한 초과 → FAILED + 사유 artifact)으로 감싼다.
+
+`app/routers/a2a.py`(GetTask 인라인 반응형 판정)와 `app/routers/cron.py`(능동 스위퍼)가
+이 모듈의 `fail_task_in_place`/`effective_deadline`을 공유 — 두 경로가 서로 다른 사유
+문구/Artifact 포맷을 만들지 않는다(SSOT 원칙).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.a2a_task import A2ATask
+from app.schemas.a2a import Artifact, Part
+
+# P1-S2(story 7b93eb10, PO 크럭스 승인): model-mediated 완료신호 부재의 백스톱 — 이 시간 안에
+# task-thread 답신이 없으면 FAILED로 전이한다(영구 WORKING 정체 방지). ⚠️tradeoff(정직히
+# 문서화, PO 지시): CC가 30분 넘게 조용히 오래 작업하는 정상 케이스도 false-FAIL될 수 있다
+# (interim ack 없는 model-mediated 구조의 근본 제약) — 실사용 데이터가 쌓이면 튜닝한다.
+A2A_TASK_TIMEOUT_MINUTES = 30
+
+
+def effective_deadline(task: A2ATask) -> datetime:
+    """S-A1: task.deadline_at(명시 기록, 신규 행) 우선 — NULL(마이그 이전 레거시 행)이면
+    기존 반응형 판정과 동일하게 created_at + 고정 타임아웃으로 폴백(무회귀)."""
+    if task.deadline_at is not None:
+        return task.deadline_at
+    return task.created_at + timedelta(minutes=A2A_TASK_TIMEOUT_MINUTES)
+
+
+def build_failure_artifact(reason: str) -> dict:
+    """FAILED 전이 사유를 구조화 Artifact로(A2A 스펙상 COMPLETED/FAILED엔 artifact가 정본 —
+    task_metadata.failure_reason만으론 스펙 정합이 부족했던 기존 갭)."""
+    return Artifact(
+        artifact_id=str(uuid.uuid4()),
+        name="failure-reason",
+        parts=[Part(text=reason)],
+    ).model_dump(by_alias=True, mode="json")
+
+
+def fail_task_in_place(task: A2ATask, reason: str) -> None:
+    """WORKING task를 FAILED로 전이 — task_metadata.failure_reason(기존 소비자 호환) + 실
+    Artifact 둘 다 기록. flush/commit은 호출부 책임(호출부마다 트랜잭션 경계가 다름 — GetTask
+    인라인은 요청-스코프 세션, 스위퍼는 배치 세션)."""
+    task.state = "TASK_STATE_FAILED"
+    task.task_metadata = {**(task.task_metadata or {}), "failure_reason": reason}
+    task.artifacts = [*task.artifacts, build_failure_artifact(reason)]
+
+
+async def sweep_expired_a2a_tasks(session: AsyncSession) -> dict:
+    """S-A1 AC1: 능동 스위퍼 — GetTask 폴링과 무관하게 기한 초과 WORKING task를 FAILED로
+    승격한다(cron 진입점, `app/routers/cron.py`). SQL 레벨에서 deadline_at NULL(레거시)/
+    non-NULL 양쪽을 한 쿼리로 처리 — Python 필터링 없이 DB가 판정(대량 스캔 안전)."""
+    now = datetime.now(timezone.utc)
+    legacy_cutoff = now - timedelta(minutes=A2A_TASK_TIMEOUT_MINUTES)
+
+    result = await session.execute(
+        select(A2ATask).where(
+            A2ATask.state == "TASK_STATE_WORKING",
+            (
+                (A2ATask.deadline_at.is_not(None)) & (A2ATask.deadline_at < now)
+            ) | (
+                (A2ATask.deadline_at.is_(None)) & (A2ATask.created_at < legacy_cutoff)
+            ),
+        )
+    )
+    expired = list(result.scalars().all())
+
+    for task in expired:
+        fail_task_in_place(
+            task,
+            f"deadline sweep: no agent response within "
+            f"{A2A_TASK_TIMEOUT_MINUTES}m of task creation",
+        )
+
+    await session.commit()
+    return {"swept_count": len(expired), "task_ids": [str(t.id) for t in expired]}

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -410,11 +410,15 @@ async def _update_delivery_status(
 async def _fail_linked_a2a_task_if_all_deliveries_failed(db, message_id: uuid.UUID) -> None:
     """S-A1 AC2 훅. multi-webhook 멤버(채널 2개 이상)는 그중 하나만 실패해도 다른 채널로는
     도달했을 수 있다(GetTask 인라인 판정의 기존 "전량 실패일 때만" 원칙과 동일 — story 652c2842
-    까심 QA 교정과 동형). 전량 실패 확認 후에만 A2A task를 즉시 FAILED로 승격한다."""
+    까심 QA 교정과 동형). 전량 실패 확認 후에만 A2A task를 즉시 FAILED로 승격한다.
+
+    까심 QA HIGH C fix(2026-07-09): CAS UPDATE(`fail_task_if_still_working`) 사용 — 이 함수가
+    task를 읽은 시점과 실 전이 시점 사이에 다른 경로(GetTask 정상완료 등)가 먼저 그 task를
+    COMPLETED로 커밋했으면 조용히 skip(그 결과 존중, stale WORKING 기준으로 덮어쓰지 않음)."""
     from sqlalchemy import select
 
     from app.models.a2a_task import A2ATask
-    from app.services.a2a_task_lifecycle import fail_task_in_place
+    from app.services.a2a_task_lifecycle import fail_task_if_still_working
 
     task = (await db.execute(
         select(A2ATask).where(
@@ -431,8 +435,8 @@ async def _fail_linked_a2a_task_if_all_deliveries_failed(db, message_id: uuid.UU
         return  # 다른 채널이 아직 진행 중/성공 — 이 판정에서는 실패 아님(응답 대기 지속)
 
     latest = max(deliveries, key=lambda d: d.updated_at)
-    fail_task_in_place(
-        task,
+    await fail_task_if_still_working(
+        db, task.id,
         f"webhook delivery failed on all {len(deliveries)} channel(s) after "
         f"{latest.attempt_count} attempts: {latest.last_error or 'unknown error'}",
     )

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -379,7 +379,13 @@ async def _update_delivery_status(
     attempt_count: int | None = None,
     last_error: str | None = None,
 ) -> None:
-    """delivery 상태 업데이트 — 별도 세션."""
+    """delivery 상태 업데이트 — 별도 세션.
+
+    E-A2A-완성 S-A1(story 2a57dc0f) AC2: 이 delivery가 "failed"(재시도 소진 영구실패)로
+    확定되는 순간, 그 message_id를 가리키는 A2A task(WORKING)가 있으면 **즉시** FAILED로
+    전이한다 — 다음 GetTask 폴링이나 기한 스위퍼를 기다리지 않는다. 일반 채팅 웹훅(A2A 아닌
+    메시지)은 대응하는 A2ATask 행이 애초에 없어 이 블록이 완전 no-op(순수 additive, 기존
+    재시도·일반 채팅 동작 무영향)."""
     from app.core.database import async_session_factory
     from sqlalchemy import select
 
@@ -394,7 +400,42 @@ async def _update_delivery_status(
                 delivery.attempt_count = attempt_count
             if last_error is not None:
                 delivery.last_error = last_error
+
+            if status == "failed":
+                await _fail_linked_a2a_task_if_all_deliveries_failed(db, delivery.message_id)
+
             await db.commit()
+
+
+async def _fail_linked_a2a_task_if_all_deliveries_failed(db, message_id: uuid.UUID) -> None:
+    """S-A1 AC2 훅. multi-webhook 멤버(채널 2개 이상)는 그중 하나만 실패해도 다른 채널로는
+    도달했을 수 있다(GetTask 인라인 판정의 기존 "전량 실패일 때만" 원칙과 동일 — story 652c2842
+    까심 QA 교정과 동형). 전량 실패 확認 후에만 A2A task를 즉시 FAILED로 승격한다."""
+    from sqlalchemy import select
+
+    from app.models.a2a_task import A2ATask
+    from app.services.a2a_task_lifecycle import fail_task_in_place
+
+    task = (await db.execute(
+        select(A2ATask).where(
+            A2ATask.root_message_id == message_id, A2ATask.state == "TASK_STATE_WORKING",
+        )
+    )).scalar_one_or_none()
+    if task is None:
+        return  # A2A task 아닌 일반 채팅 메시지(또는 이미 종결 상태) — no-op
+
+    deliveries = (await db.execute(
+        select(ConversationWebhookDelivery).where(ConversationWebhookDelivery.message_id == message_id)
+    )).scalars().all()
+    if not deliveries or not all(d.status == "failed" for d in deliveries):
+        return  # 다른 채널이 아직 진행 중/성공 — 이 판정에서는 실패 아님(응답 대기 지속)
+
+    latest = max(deliveries, key=lambda d: d.updated_at)
+    fail_task_in_place(
+        task,
+        f"webhook delivery failed on all {len(deliveries)} channel(s) after "
+        f"{latest.attempt_count} attempts: {latest.last_error or 'unknown error'}",
+    )
 
 
 async def mark_agent_replied(conversation_id: uuid.UUID) -> None:

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -74,6 +74,14 @@ def _list_result(items):
     return r
 
 
+def _update_result(rowcount: int):
+    """S-A1(story 2a57dc0f) CAS fix — `fail_task_if_still_working`가 실행하는 UPDATE 문의
+    mock 결과. rowcount=1이면 이 호출이 전이시켰음(경쟁 없음), 0이면 이미 다른 경로가 전이."""
+    r = MagicMock()
+    r.rowcount = rowcount
+    return r
+
+
 def _mock_agent(member_id, name, agent_role="qa"):
     m = MagicMock()
     m.id = member_id
@@ -887,12 +895,27 @@ async def test_get_task_transitions_to_failed_on_delivery_failure():
                 return _result(working_task)
             if call_count == 3:
                 return _result(None)  # thread 폴링 — 답신 없음
-            return _list_result([delivery])  # webhook delivery 조회 — 1건, 전량 failed
+            if call_count == 4:
+                return _list_result([delivery])  # webhook delivery 조회 — 1건, 전량 failed
+            return _update_result(1)  # CAS UPDATE(fail_task_if_still_working) — 경쟁 없음
+
+        async def mock_refresh(obj):
+            # S-A1(story 2a57dc0f) CAS fix — 실 DB라면 refresh()가 CAS UPDATE 결과(FAILED)를
+            # 반영한다. mock 세션은 그 UPDATE를 실행 안 하므로 refresh 시점에 동등 효과 시뮬레이션.
+            obj.state = "TASK_STATE_FAILED"
+            obj.task_metadata = {
+                **(obj.task_metadata or {}),
+                "failure_reason": "webhook delivery failed on all 1 channel(s) after 3 attempts: connection refused",
+            }
+            obj.artifacts = [*obj.artifacts, {
+                "artifactId": "x", "name": "failure-reason",
+                "parts": [{"text": "webhook delivery failed on all 1 channel(s) after 3 attempts: connection refused"}],
+            }]
 
         session.execute = mock_execute
         session.flush = AsyncMock()
         session.commit = AsyncMock()
-        session.refresh = AsyncMock()
+        session.refresh = mock_refresh
 
         req = {"jsonrpc": "2.0", "id": 7, "method": "GetTask", "params": {"id": str(working_task.id)}}
 
@@ -982,12 +1005,24 @@ async def test_get_task_transitions_to_failed_on_timeout():
                 return _result(working_task)
             if call_count == 3:
                 return _result(None)  # thread 폴링 — 답신 없음
-            return _list_result([])  # delivery row 없음(fakechat 경로)
+            if call_count == 4:
+                return _list_result([])  # delivery row 없음(fakechat 경로)
+            return _update_result(1)  # CAS UPDATE(fail_task_if_still_working) — 경쟁 없음
+
+        async def mock_refresh(obj):
+            # S-A1(story 2a57dc0f) CAS fix — 실 DB라면 refresh()가 CAS UPDATE 결과(FAILED)를
+            # 반영한다. mock 세션은 그 UPDATE를 실행 안 하므로 refresh 시점에 동등 효과 시뮬레이션.
+            reason = f"timed out waiting for agent response after {A2A_TASK_TIMEOUT_MINUTES}m"
+            obj.state = "TASK_STATE_FAILED"
+            obj.task_metadata = {**(obj.task_metadata or {}), "failure_reason": reason}
+            obj.artifacts = [*obj.artifacts, {
+                "artifactId": "x", "name": "failure-reason", "parts": [{"text": reason}],
+            }]
 
         session.execute = mock_execute
         session.flush = AsyncMock()
         session.commit = AsyncMock()
-        session.refresh = AsyncMock()
+        session.refresh = mock_refresh
 
         req = {"jsonrpc": "2.0", "id": 8, "method": "GetTask", "params": {"id": str(working_task.id)}}
 

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -399,7 +399,7 @@ async def test_list_agent_cards_requires_auth():
 
 
 def _mock_task(state: str, artifacts=None, history=None, root_message_id=None, context_id=None,
-               created_at=None, task_metadata=None) -> MagicMock:
+               created_at=None, task_metadata=None, deadline_at=None) -> MagicMock:
     t = MagicMock()
     t.id = uuid.uuid4()
     t.context_id = context_id or uuid.uuid4()
@@ -410,6 +410,10 @@ def _mock_task(state: str, artifacts=None, history=None, root_message_id=None, c
     t.updated_at = datetime.datetime.now(datetime.timezone.utc)
     t.created_at = created_at or datetime.datetime.now(datetime.timezone.utc)
     t.task_metadata = task_metadata
+    # S-A1(story 2a57dc0f): None(기본) = 레거시 행 시뮬레이션(effective_deadline이 created_at+
+    # 타임아웃으로 폴백) — MagicMock() 기본 auto-attr(항상 not-None)에 datetime 비교 연산자가
+    # TypeError 나는 걸 막는다. 명시 not-None 값을 넘기면 그 값을 deadline으로 그대로 사용.
+    t.deadline_at = deadline_at
     return t
 
 

--- a/backend/tests/test_a2a_sa1_deadline_sweeper_realdb.py
+++ b/backend/tests/test_a2a_sa1_deadline_sweeper_realdb.py
@@ -179,6 +179,63 @@ async def test_sweeper_ignores_non_working_states():
 
 
 @pytest.mark.anyio
+async def test_cas_prevents_sweeper_from_clobbering_concurrently_completed_task():
+    """까심 QA HIGH C 회귀 방지 — 실 PG 2세션 레이스 재현. 스위퍼가 후보를 SELECT한 *이후*,
+    다른 트랜잭션(GetTask 정상완료 경로 시뮬레이션)이 먼저 그 task를 진짜 artifact와 함께
+    COMPLETED로 커밋하면, 스위퍼의 CAS UPDATE는 `WHERE state='TASK_STATE_WORKING'`에 걸려
+    영향행 0 → skip해야 한다. fix 전엔 스위퍼가 무조건 덮어써 정상 완료된 task가 가짜
+    "deadline sweep" FAILED로 오염되고 자가치유되지 않았다(`state=='WORKING'` 게이트에
+    막혀 아무 경로도 재교정 안 함)."""
+    from app.models.a2a_task import A2ATask
+    from app.services.a2a_task_lifecycle import fail_task_if_still_working
+    from sqlalchemy import select, update
+
+    engine, Session = await _session()
+    try:
+        past_deadline = datetime.now(timezone.utc) - timedelta(minutes=1)
+        async with Session() as s:
+            task = await _make_task(s, deadline_at=past_deadline)
+            task_id = task.id
+
+        # TxA(스위퍼 시뮬레이션): 후보 SELECT — 이 시점엔 WORKING(TxB 커밋 전).
+        session_a = Session()
+        candidates = [
+            row[0] for row in (await session_a.execute(
+                select(A2ATask.id).where(A2ATask.id == task_id, A2ATask.state == "TASK_STATE_WORKING")
+            )).all()
+        ]
+        assert task_id in candidates
+
+        # TxB(GetTask 정상완료 경로): 독립 세션+독립 커밋 — SELECT~UPDATE 사이 윈도우에서
+        # 진짜로 먼저 COMPLETED 커밋(실 레이스 재현, mock 아님).
+        async with Session() as session_b:
+            await session_b.execute(
+                update(A2ATask).where(A2ATask.id == task_id).values(
+                    state="TASK_STATE_COMPLETED",
+                    artifacts=[{"artifactId": "real-reply", "name": "agent-reply",
+                                "parts": [{"text": "정상 완료된 실 작업 결과물"}]}],
+                )
+            )
+            await session_b.commit()
+
+        # TxA: 이제서야 CAS UPDATE 시도 — WHERE state='TASK_STATE_WORKING'에 이미 안 걸림.
+        transitioned = await fail_task_if_still_working(
+            session_a, task_id, "deadline sweep: no agent response within 30m of task creation",
+        )
+        await session_a.commit()
+        await session_a.close()
+        assert transitioned is False, "CAS가 이미 COMPLETED인 task를 덮어씀 — 회귀"
+
+        async with Session() as s:
+            final = (await s.execute(select(A2ATask).where(A2ATask.id == task_id))).scalar_one()
+            assert final.state == "TASK_STATE_COMPLETED"
+            assert final.artifacts[0]["name"] == "agent-reply"  # 진짜 artifact 보존
+            assert not any(a.get("name") == "failure-reason" for a in final.artifacts)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
 async def test_immediate_fail_hook_on_all_webhook_deliveries_permanently_failed():
     """AC2: `_update_delivery_status(..., "failed")` 도달 즉시(폴링 없이) A2A task FAILED."""
     from app.models.a2a_task import A2ATask

--- a/backend/tests/test_a2a_sa1_deadline_sweeper_realdb.py
+++ b/backend/tests/test_a2a_sa1_deadline_sweeper_realdb.py
@@ -1,0 +1,279 @@
+"""E-A2A-완성 S-A1(story 2a57dc0f): WORKING 영구정체 방지 — 실 Postgres 검증.
+
+핵심 3축: ⓐ 능동 스위퍼(폴링 무관)가 기한 초과 WORKING task를 FAILED로 승격 + Artifact 첨부
+ⓑ 레거시 행(deadline_at NULL)도 created_at 폴백으로 정상 처리 ⓒ webhook delivery 영구실패
+확定 시 GetTask 폴링 없이 즉시 FAILED(AC2 훅). story 8236bbc3 컨벤션: create_all 자체 스키마
+관리(공유 alembic-migrated DB 오염 방지)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """`_update_delivery_status`(AC2 훅 대상)는 `app.core.database`의 **모듈-전역** engine을
+    쓴다(자체 세션 팩토리) — anyio 테스트마다 새 이벤트루프가 뜨는데 이 전역 커넥션 풀은 첫
+    테스트의 루프에 바인딩된 채 남아 다음 테스트(다른 루프)에서 asyncpg가 cross-loop
+    RuntimeError를 낸다. 각 테스트 뒤 풀을 폐기해 다음 테스트가 새 루프에서 새 커넥션을
+    맺게 강제 — 실 프로덕션 동작과 무관한 순수 테스트 격리 조치."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _bypass_fk_for_seed(session) -> None:
+    """conversation_webhook_deliveries.message_id는 conversation_messages FK — 이 테스트들은
+    delivery-hook 검증이 목적이라 실 Conversation/ConversationMessage 그래프까지는 불필요.
+    test_e_recruit_s3_recruit_service_realdb.py와 동일 관례로 세션 스코프 FK 검증을 끈다."""
+    from sqlalchemy import text as _text
+    await session.execute(_text("SET session_replication_role = replica"))
+
+
+async def _make_task(session, *, state="TASK_STATE_WORKING", deadline_at=None, created_at=None,
+                      root_message_id=None):
+    from app.models.a2a_task import A2ATask
+
+    task = A2ATask(
+        id=uuid.uuid4(),
+        context_id=uuid.uuid4(),
+        root_message_id=root_message_id,
+        member_id=uuid.uuid4(),
+        state=state,
+        history=[],
+        artifacts=[],
+        task_metadata={},
+        deadline_at=deadline_at,
+    )
+    session.add(task)
+    await session.flush()
+    if created_at is not None:
+        # server_default=now() 를 테스트가 원하는 과거값으로 덮어써야 레거시-행 시나리오 재현.
+        from sqlalchemy import update
+        from app.models.a2a_task import A2ATask as _T
+        await session.execute(update(_T).where(_T.id == task.id).values(created_at=created_at))
+    await session.commit()
+    await session.refresh(task)
+    return task
+
+
+@pytest.mark.anyio
+async def test_sweeper_fails_expired_working_task_with_explicit_deadline():
+    from app.services.a2a_task_lifecycle import sweep_expired_a2a_tasks
+    from app.models.a2a_task import A2ATask
+    from sqlalchemy import select
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            past_deadline = datetime.now(timezone.utc) - timedelta(minutes=1)
+            task = await _make_task(s, deadline_at=past_deadline)
+
+            result = await sweep_expired_a2a_tasks(s)
+            assert result["swept_count"] == 1
+            assert str(task.id) in result["task_ids"]
+
+            reloaded = (await s.execute(select(A2ATask).where(A2ATask.id == task.id))).scalar_one()
+            assert reloaded.state == "TASK_STATE_FAILED"
+            assert "failure_reason" in reloaded.task_metadata
+            assert len(reloaded.artifacts) == 1
+            assert reloaded.artifacts[0]["name"] == "failure-reason"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sweeper_leaves_not_yet_expired_task_working():
+    from app.services.a2a_task_lifecycle import sweep_expired_a2a_tasks
+    from app.models.a2a_task import A2ATask
+    from sqlalchemy import select
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            future_deadline = datetime.now(timezone.utc) + timedelta(minutes=30)
+            task = await _make_task(s, deadline_at=future_deadline)
+
+            result = await sweep_expired_a2a_tasks(s)
+            assert result["swept_count"] == 0
+
+            reloaded = (await s.execute(select(A2ATask).where(A2ATask.id == task.id))).scalar_one()
+            assert reloaded.state == "TASK_STATE_WORKING"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sweeper_falls_back_to_created_at_for_legacy_null_deadline():
+    from app.services.a2a_task_lifecycle import sweep_expired_a2a_tasks, A2A_TASK_TIMEOUT_MINUTES
+    from app.models.a2a_task import A2ATask
+    from sqlalchemy import select
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            old_created_at = datetime.now(timezone.utc) - timedelta(minutes=A2A_TASK_TIMEOUT_MINUTES + 5)
+            task = await _make_task(s, deadline_at=None, created_at=old_created_at)
+
+            result = await sweep_expired_a2a_tasks(s)
+            assert result["swept_count"] == 1
+
+            reloaded = (await s.execute(select(A2ATask).where(A2ATask.id == task.id))).scalar_one()
+            assert reloaded.state == "TASK_STATE_FAILED"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sweeper_ignores_non_working_states():
+    from app.services.a2a_task_lifecycle import sweep_expired_a2a_tasks
+    from app.models.a2a_task import A2ATask
+    from sqlalchemy import select
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            past_deadline = datetime.now(timezone.utc) - timedelta(minutes=1)
+            completed = await _make_task(s, state="TASK_STATE_COMPLETED", deadline_at=past_deadline)
+            failed = await _make_task(s, state="TASK_STATE_FAILED", deadline_at=past_deadline)
+
+            result = await sweep_expired_a2a_tasks(s)
+            assert result["swept_count"] == 0
+
+            for tid in (completed.id, failed.id):
+                reloaded = (await s.execute(select(A2ATask).where(A2ATask.id == tid))).scalar_one()
+                assert reloaded.state in ("TASK_STATE_COMPLETED", "TASK_STATE_FAILED")
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_immediate_fail_hook_on_all_webhook_deliveries_permanently_failed():
+    """AC2: `_update_delivery_status(..., "failed")` 도달 즉시(폴링 없이) A2A task FAILED."""
+    from app.models.a2a_task import A2ATask
+    from app.models.conversation_webhook_delivery import ConversationWebhookDelivery
+    from app.services.conversation_webhook import _update_delivery_status
+    from sqlalchemy import select
+
+    engine, Session = await _session()
+    try:
+        message_id = uuid.uuid4()
+        async with Session() as s:
+            await _bypass_fk_for_seed(s)
+            task = await _make_task(
+                s, deadline_at=datetime.now(timezone.utc) + timedelta(minutes=30),
+                root_message_id=message_id,
+            )
+            delivery = ConversationWebhookDelivery(
+                id=uuid.uuid4(), message_id=message_id, webhook_config_id=uuid.uuid4(),
+                status="webhook_posted", attempt_count=0,
+            )
+            s.add(delivery)
+            await s.commit()
+            delivery_id = delivery.id
+
+        # 실제 함수는 자체 세션을 여는(async_session_factory) BackgroundTask 진입점 —
+        # 실 함수를 그대로 호출해 그 내부 세션 경로까지 실증(mock 아님).
+        await _update_delivery_status(delivery_id, "failed", attempt_count=3, last_error="connection refused")
+
+        async with Session() as s:
+            reloaded = (await s.execute(select(A2ATask).where(A2ATask.id == task.id))).scalar_one()
+            assert reloaded.state == "TASK_STATE_FAILED"
+            assert "webhook delivery failed" in reloaded.task_metadata["failure_reason"]
+            assert len(reloaded.artifacts) == 1
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_immediate_fail_hook_noop_when_other_channel_still_pending():
+    """multi-webhook: 하나만 failed·다른 채널 아직 진행 중이면 즉시-FAILED 훅 no-op(응답 대기 지속)."""
+    from app.models.a2a_task import A2ATask
+    from app.models.conversation_webhook_delivery import ConversationWebhookDelivery
+    from app.services.conversation_webhook import _update_delivery_status
+    from sqlalchemy import select
+
+    engine, Session = await _session()
+    try:
+        message_id = uuid.uuid4()
+        async with Session() as s:
+            await _bypass_fk_for_seed(s)
+            task = await _make_task(
+                s, deadline_at=datetime.now(timezone.utc) + timedelta(minutes=30),
+                root_message_id=message_id,
+            )
+            failing = ConversationWebhookDelivery(
+                id=uuid.uuid4(), message_id=message_id, webhook_config_id=uuid.uuid4(),
+                status="webhook_posted", attempt_count=0,
+            )
+            still_pending = ConversationWebhookDelivery(
+                id=uuid.uuid4(), message_id=message_id, webhook_config_id=uuid.uuid4(),
+                status="gateway_accepted", attempt_count=1,
+            )
+            s.add_all([failing, still_pending])
+            await s.commit()
+            failing_id = failing.id
+
+        await _update_delivery_status(failing_id, "failed", attempt_count=3, last_error="timeout")
+
+        async with Session() as s:
+            reloaded = (await s.execute(select(A2ATask).where(A2ATask.id == task.id))).scalar_one()
+            assert reloaded.state == "TASK_STATE_WORKING"  # 다른 채널 진행 중이라 무회귀
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_immediate_fail_hook_noop_for_non_a2a_message():
+    """A2A task와 무관한 일반 채팅 delivery 실패는 완전 no-op(순수 additive, 회귀 0 증명)."""
+    from app.models.conversation_webhook_delivery import ConversationWebhookDelivery
+    from app.services.conversation_webhook import _update_delivery_status
+
+    engine, Session = await _session()
+    try:
+        message_id = uuid.uuid4()  # 어떤 A2ATask.root_message_id도 안 가리킴
+        async with Session() as s:
+            await _bypass_fk_for_seed(s)
+            delivery = ConversationWebhookDelivery(
+                id=uuid.uuid4(), message_id=message_id, webhook_config_id=uuid.uuid4(),
+                status="webhook_posted", attempt_count=0,
+            )
+            s.add(delivery)
+            await s.commit()
+            delivery_id = delivery.id
+
+        # 예외 없이 끝나야(연결된 A2A task가 없어 no-op) — 크래시 0가 이 테스트의 assertion.
+        await _update_delivery_status(delivery_id, "failed", attempt_count=3, last_error="dns error")
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
Story `2a57dc0f`, blueprint `a2a-completion-blueprint` Phase H (risk-tier, PO-flagged for 까심 QA before merge).

- **New `app/services/a2a_task_lifecycle.py`**: single SSOT for task-deadline logic, shared by the router's reactive GetTask check and the new active sweeper.
- **Migration 0168**: `a2a_tasks.deadline_at` (nullable, additive, no backfill) — recorded explicitly at task creation instead of implicitly derived from `created_at + constant` at poll time.
- **New cron endpoint** `GET /api/v2/internal/cron/a2a-task-deadline-sweep` (follows the existing `hitl-timeouts`/`workflow-sla` pattern) — proactively fails expired WORKING tasks regardless of polling. Legacy rows (`deadline_at` NULL) fall back to `created_at + timeout`.
- **FAILED transitions now attach a real `Artifact`** (not just a `task_metadata` field) — matches spec expectations for COMPLETED/FAILED tasks.
- **Immediate-fail hook** in `conversation_webhook.py`: when a webhook delivery is confirmed permanently failed (after the existing 3x-retry pipeline exhausts, shared with regular chat), any WORKING A2A task tied to that message fails immediately — not on next poll or full deadline. Purely additive/no-op for non-A2A messages.
- **Deliberately no second A2A-specific retry layer** on top of the existing webhook retry (duplicate-injection risk) — scope confirmed with PO before implementation.

## Bonus fix (discovered live-proofing, pre-existing bug)
`_task_to_dict`'s `model_dump()` emitted explicit `null` for every unset oneof sibling on each `Part` (raw/url/data), which the real a2a-sdk's protobuf-JSON parser resolved into an **empty string** instead of the real text — silently breaking artifact/message text for every real A2A client already, including the existing COMPLETED-task reply artifact (not just this story's new FAILED path). Fixed with `exclude_none=True` at the single serialization choke point (`_task_to_dict`) shared by SendMessage/GetTask/ListTasks.

## Test plan
- [x] New `tests/test_a2a_sa1_deadline_sweeper_realdb.py` (7 tests): sweeper fails expired/leaves not-yet-expired/legacy-NULL-deadline fallback/ignores terminal states; immediate-fail hook fires on all-channels-failed, no-ops when another channel still pending, no-ops for non-A2A messages.
- [x] Existing `tests/test_a2a.py` (42 tests) — fixed a `MagicMock` fixture gap the new `deadline_at` field exposed (mock task's `deadline_at` defaulted to a non-None `MagicMock()`, breaking datetime comparison); all pass, zero regression.
- [x] **Live-proof with the real a2a-sdk 1.1.0 client** (not a direct function call) — real ASGI (Header DI/routing/dependency-injection all exercised), real ephemeral-Postgres-backed org/agent/task:
  - Normal roundtrip: `send_message` → WORKING → (reply inserted) → `get_task` → COMPLETED, artifact text correctly parsed. Regression 0.
  - No-reply delegate: `send_message` → WORKING → `deadline_at` manipulated to past (30-min real wait impractical) → active sweeper fails it → `get_task` (reactive path) confirms FAILED with correctly-parsed artifact reason via the real SDK. Both paths agree.
- [x] Full backend suite: 3123 passed. Same 22 pre-existing unrelated failures already triaged in prior PRs this session (realdb gateway/webhook/mcp-path/e2e-remote-drift) — none touch a2a/conversation_webhook code.

## Note for review
Blueprint explicitly flags this story (robustness-risk tier) for 까심 QA before merge — requesting that pass before landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)