### PR TITLE
feat(a2a): linked_gate declaration MCP tool — HITL writer (E-A2A-완성 S-A3)

### DIFF
--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -73,6 +73,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -720,3 +721,56 @@ async def a2a_rpc(
         return JsonRpcResponse(id=body.id, error=JsonRpcError(code=exc.code, message=exc.message))
 
     return JsonRpcResponse(id=body.id, result=result)
+
+
+class LinkGateBody(BaseModel):
+    gate_id: uuid.UUID
+
+
+@router.post("/tasks/{task_id}/link-gate")
+async def link_gate_to_task(
+    task_id: uuid.UUID,
+    body: LinkGateBody,
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> dict:
+    """E-A2A-완성 S-A3(story `6d0454c3`, 크럭스 `a2a-hitl-input-auth-required-mapping-crux`
+    옵션 B — writer): delegate가 "이 gate가 이 A2A task를 블록한다"를 **명시 선언**한다.
+    reader(``_handle_get_task``의 ``linked_gate_id`` 체크, 이미 구현)와 복귀 트리거
+    (``gate_service.py::transition_gate`` 3번째 분기, 이미 구현)는 이 필드가 채워지길 그저
+    기다리고 있었을 뿐 — 이 엔드포인트가 그 유일한 writer다.
+
+    6개 ``create_gate()`` 호출지점에 conversation_id/task_id를 관통시키는 침습 배관(크럭스
+    옵션 A)은 의도적으로 배제 — delegate가 자기 MCP 세션에서 이미 알고 있는 두 id(task_id는
+    SendMessage 응답에서, gate_id는 방금 자기가 만든 gate 응답에서)를 스스로 연결하는 경량
+    선언만 추가한다.
+
+    self-scope 게이트(``assert_caller_is_member`` 동형) — task.member_id 본인만 자기 task에
+    링크 선언 가능(다른 에이전트의 task를 가로채 임의 gate로 블록시키는 것 방지)."""
+    task = (await session.execute(
+        select(A2ATask).where(A2ATask.id == task_id)
+    )).scalar_one_or_none()
+    if task is None:
+        raise HTTPException(status_code=404, detail="A2A task not found")
+
+    if str(task.member_id) != auth.user_id:
+        raise HTTPException(status_code=403, detail="Cannot link a gate to another agent's task")
+
+    if task.state != "TASK_STATE_WORKING":
+        raise HTTPException(
+            status_code=400,
+            detail=f"Task must be WORKING to link a gate (current: {task.state})",
+        )
+
+    gate = (await session.execute(
+        select(Gate).where(Gate.id == body.gate_id, Gate.org_id == org_id)
+    )).scalar_one_or_none()
+    if gate is None:
+        raise HTTPException(status_code=404, detail="Gate not found")
+
+    task.task_metadata = {**(task.task_metadata or {}), "linked_gate_id": str(gate.id)}
+    await session.flush()
+    await session.commit()
+
+    return {"linked": True, "task_id": str(task.id), "gate_id": str(gate.id)}

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -53,6 +53,11 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # 무관하게 협업해야 하므로 stories/tasks 같은 특정 도메인 그룹에 묶지 않고, chat/team_members
     # 등과 동형인 cross-cutting 코디네이션 유틸로 core 취급(always-allow)한다.
     "sprintable_lock_files", "sprintable_unlock_files",
+    # E-A2A-완성 S-A3(story 6d0454c3): link_gate_to_task — lock/unlock_files와 동형 cross-cutting
+    # 선언 유틸(엔드포인트 자체가 self-scope 게이트를 가져 자기 소유 task에만 작용 — 데이터 파괴
+    # 아님). A2A 위임을 받은 어떤 역할의 에이전트든 default_tool_groups와 무관하게 써야 하는 협업
+    # 도구라 특정 도메인 그룹에 안 묶는다(lock/unlock과 동일 논리).
+    "sprintable_link_gate_to_task",
 })
 
 # scope 토큰: 그룹명 외에 read/write(레거시·전체 비파괴 의미), admin/destructive(파괴적 허용)
@@ -263,6 +268,8 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_update_hypothesis", "sprintable_link_hypothesis", "sprintable_confirm_hypothesis",
     # loops (E-LOOP-LEDGER P1-S12)
     "sprintable_get_loop_context",
+    # a2a HITL writer (E-A2A-완성 S-A3)
+    "sprintable_link_gate_to_task",
 )
 
 # picker 표시 순서(비파괴 먼저). order 필드 힌트 + 배열 순서 둘 다 이 순서.

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -1,4 +1,4 @@
-"""Sprintable MCP 서버 — 91개 도구 등록 (flat schema)."""
+"""Sprintable MCP 서버 — 92개 도구 등록 (flat schema)."""
 from __future__ import annotations
 
 import asyncio
@@ -27,6 +27,7 @@ from .schemas import SprintableInput
 # E-MCP S4: 독립 패키지 디탱글 — backend(app/*) import 제거. 규칙은 vendored .toolset 사용
 # (백엔드 app/services/mcp_toolset.py와 동일 규칙 유지·SSOT는 백엔드 매니페스트).
 from .toolset import is_tool_allowed
+from .tools.a2a import LinkGateToTaskInput, link_gate_to_task
 from .tools.agent_runs import (
     EmitEventInput, PollEventsInput, UpdateRunStatusInput,
     emit_event, poll_events, update_run_status,
@@ -491,6 +492,11 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_unlock_files",
      "파일 작업 완료 선언 — lock 해제.",
      UnlockFilesInput, unlock_files),
+    # A2A HITL writer (1) — E-A2A-완성 S-A3
+    ("sprintable_link_gate_to_task",
+     "이 gate가 이 A2A task를 블록한다고 명시 선언 — 외부 GetTask가 INPUT_REQUIRED로 승격되고,"
+     " 사람이 gate를 승인/거부하면 task가 자동으로 WORKING/REJECTED 복귀한다.",
+     LinkGateToTaskInput, link_gate_to_task),
     # Chat (3)
     ("sprintable_send_chat_message",
      "conversation thread에 채팅 메시지 발송.",

--- a/backend/sprintable_mcp/tools/a2a.py
+++ b/backend/sprintable_mcp/tools/a2a.py
@@ -1,0 +1,27 @@
+"""A2A HITL writer MCP 도구 (1개) — E-A2A-완성 S-A3(story 6d0454c3)."""
+from __future__ import annotations
+
+from mcp.types import TextContent
+
+from ..api_client import client
+from ..response import err, ok
+from ..schemas import SprintableInput
+
+
+class LinkGateToTaskInput(SprintableInput):
+    task_id: str
+    gate_id: str
+
+
+async def link_gate_to_task(args: LinkGateToTaskInput) -> list[TextContent]:
+    """이 gate가 이 A2A task를 블록한다고 명시 선언 — 외부 GetTask가 INPUT_REQUIRED로 승격되고,
+    사람이 gate를 승인/거부하면 task가 자동으로 WORKING/REJECTED 복귀한다. 자기 자신에게
+    위임된 task에만 선언 가능(다른 에이전트의 task는 403)."""
+    try:
+        result = await client.post(
+            f"/api/v2/a2a/tasks/{args.task_id}/link-gate",
+            json={"gate_id": args.gate_id},
+        )
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))

--- a/backend/sprintable_mcp/toolset.py
+++ b/backend/sprintable_mcp/toolset.py
@@ -45,6 +45,11 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # S17: lock/unlock — 백엔드 SSOT와 동일 사유(org/project-scoped advisory 조율 도구, 파괴 아님)
     # 로 core 취급. 드리프트 금지 원칙에 따라 백엔드와 동기화(app/services/mcp_toolset.py 참고).
     "sprintable_lock_files", "sprintable_unlock_files",
+    # E-A2A-완성 S-A3(story 6d0454c3): link_gate_to_task — lock/unlock_files와 동형 cross-cutting
+    # 선언 유틸(자기 소유 task에만 작용하는 self-scope 게이트가 서버측에 있어 데이터 파괴 아님).
+    # 특정 도메인 그룹(stories/tasks 등)에 안 묶는 이유도 lock/unlock과 동일 — A2A 위임을 받은
+    # 어떤 역할의 에이전트든 default_tool_groups와 무관하게 써야 하는 협업 도구.
+    "sprintable_link_gate_to_task",
 })
 
 _LEGACY_SCOPES: frozenset[str] = frozenset({"read", "write"})

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -1,4 +1,4 @@
-"""S3-6: 시스템 콜 계약 검증 — 96개 도구 등록 + 스키마 무결성 (Phase 3 완료)."""
+"""S3-6: 시스템 콜 계약 검증 — 97개 도구 등록 + 스키마 무결성 (Phase 3 완료)."""
 from __future__ import annotations
 
 import os
@@ -77,13 +77,15 @@ EXPECTED_TOOLS = {
     "sprintable_get_loop_context",
     # file locks (2)
     "sprintable_lock_files", "sprintable_unlock_files",
+    # a2a HITL writer (1) — E-A2A-완성 S-A3
+    "sprintable_link_gate_to_task",
     # smoke
     "ping",
 }
 
 
 def test_total_tool_count():
-    assert len(_TOOLS) == 96
+    assert len(_TOOLS) == 97
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_a2a_sa3_link_gate_to_task_realdb.py
+++ b/backend/tests/test_a2a_sa3_link_gate_to_task_realdb.py
@@ -1,0 +1,286 @@
+"""E-A2A-완성 S-A3(story 6d0454c3): linked_gate 선언 writer — 실 Postgres 검증.
+
+reader(``_handle_get_task`` linked_gate_id 체크)와 복귀 트리거(``transition_gate`` 3번째
+분기)는 이미 구현 — 이 테스트는 그 둘이 기다리던 유일한 writer(`POST .../tasks/{id}/link-gate`)
+가 정확히 배선됐는지만 검증한다. story 8236bbc3 컨벤션: create_all 자체 스키마 관리."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session, *, task_state="TASK_STATE_WORKING"):
+    from sqlalchemy import text as _text
+    from app.models.a2a_task import A2ATask
+    from app.models.gate import Gate
+
+    org_id = uuid.uuid4()
+    delegate_id = uuid.uuid4()
+    other_agent_id = uuid.uuid4()
+
+    await session.execute(_text("SET session_replication_role = replica"))
+    task = A2ATask(
+        id=uuid.uuid4(), context_id=uuid.uuid4(), root_message_id=uuid.uuid4(),
+        member_id=delegate_id, state=task_state, history=[], artifacts=[], task_metadata={},
+    )
+    gate = Gate(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=uuid.uuid4(), work_item_type="story",
+        gate_type="pr_review", status="pending",
+    )
+    other_org_gate = Gate(
+        id=uuid.uuid4(), org_id=uuid.uuid4(), work_item_id=uuid.uuid4(), work_item_type="story",
+        gate_type="pr_review", status="pending",
+    )
+    session.add_all([task, gate, other_org_gate])
+    await session.commit()
+    return org_id, delegate_id, other_agent_id, task, gate, other_org_gate
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _override_deps(app, Session, *, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            yield s
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email=None, claims={})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_delegate_can_link_gate_to_own_working_task():
+    from app.main import app
+    from app.models.a2a_task import A2ATask
+    from sqlalchemy import select
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org_id, delegate_id, _other, task, gate, _other_gate = await _seed(s)
+
+        await _override_deps(app, Session, user_id=delegate_id, org_id=org_id)
+        try:
+            async with _client_for(app) as c:
+                resp = await c.post(
+                    f"/api/v2/a2a/tasks/{task.id}/link-gate", json={"gate_id": str(gate.id)},
+                )
+            assert resp.status_code == 200
+            assert resp.json() == {"linked": True, "task_id": str(task.id), "gate_id": str(gate.id)}
+
+            async with Session() as s:
+                reloaded = (await s.execute(select(A2ATask).where(A2ATask.id == task.id))).scalar_one()
+                assert reloaded.task_metadata["linked_gate_id"] == str(gate.id)
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_other_agent_cannot_link_gate_to_someone_elses_task():
+    from app.main import app
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org_id, _delegate, other_agent_id, task, gate, _og = await _seed(s)
+
+        await _override_deps(app, Session, user_id=other_agent_id, org_id=org_id)
+        try:
+            async with _client_for(app) as c:
+                resp = await c.post(
+                    f"/api/v2/a2a/tasks/{task.id}/link-gate", json={"gate_id": str(gate.id)},
+                )
+            assert resp.status_code == 403
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_link_rejects_gate_from_a_different_org():
+    from app.main import app
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org_id, delegate_id, _other, task, _gate, other_org_gate = await _seed(s)
+
+        await _override_deps(app, Session, user_id=delegate_id, org_id=org_id)
+        try:
+            async with _client_for(app) as c:
+                resp = await c.post(
+                    f"/api/v2/a2a/tasks/{task.id}/link-gate", json={"gate_id": str(other_org_gate.id)},
+                )
+            assert resp.status_code == 404  # 타 org gate — IDOR 차단(org 스코프 조회가 못 찾음)
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_link_rejects_non_working_task():
+    from app.main import app
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org_id, delegate_id, _other, task, gate, _og = await _seed(s, task_state="TASK_STATE_COMPLETED")
+
+        await _override_deps(app, Session, user_id=delegate_id, org_id=org_id)
+        try:
+            async with _client_for(app) as c:
+                resp = await c.post(
+                    f"/api/v2/a2a/tasks/{task.id}/link-gate", json={"gate_id": str(gate.id)},
+                )
+            assert resp.status_code == 400
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_link_404s_on_unknown_task():
+    from app.main import app
+
+    engine, Session = await _session()
+    try:
+        org_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+        await _override_deps(app, Session, user_id=user_id, org_id=org_id)
+        try:
+            async with _client_for(app) as c:
+                resp = await c.post(
+                    f"/api/v2/a2a/tasks/{uuid.uuid4()}/link-gate", json={"gate_id": str(uuid.uuid4())},
+                )
+            assert resp.status_code == 404
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_end_to_end_full_hitl_roundtrip_via_real_gate_service():
+    """[실증] AC2 축소판(모듈 내부 함수 직접 호출로): 실 create_gate()(disposition 해소 포함,
+    system default=ask→pending) → link-gate 엔드포인트 → reader(GetTask)가 INPUT_REQUIRED로
+    승격 → transition_gate(사람 승인) → WORKING 복귀. HTTP 라운드트립은 별도 실 SDK 스크립트로
+    보강(scratchpad)."""
+    from app.main import app
+    from app.models.a2a_task import A2ATask
+    from app.models.team import TeamMember
+    from app.services.gate_service import create_gate, transition_gate
+    from sqlalchemy import select, text as _text
+
+    engine, Session = await _session()
+    try:
+        org_id = uuid.uuid4()
+        project_id = uuid.uuid4()
+        delegate_id = uuid.uuid4()
+        role_id = uuid.uuid4()
+        approver_id = uuid.uuid4()
+
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            delegate_member = TeamMember(
+                id=delegate_id, org_id=org_id, project_id=project_id, type="agent",
+                name="SA3 E2E Delegate", role="member", is_active=True,
+            )
+            task = A2ATask(
+                id=uuid.uuid4(), context_id=uuid.uuid4(), root_message_id=uuid.uuid4(),
+                member_id=delegate_id, state="TASK_STATE_WORKING", history=[], artifacts=[],
+                task_metadata={},
+            )
+            s.add_all([delegate_member, task])
+            await s.commit()
+            task_id = task.id
+
+            gate = await create_gate(
+                s, org_id=org_id, work_item_id=uuid.uuid4(), work_item_type="story",
+                gate_type="pr_review", member_id=delegate_id, role_id=role_id,
+            )
+            assert gate.status == "pending"  # system default(ask) — HITL 필요 케이스 확認
+            await s.commit()
+            gate_id = gate.id
+
+        # ── writer: delegate가 자기 task에 gate 링크 선언(실 HTTP 엔드포인트 경유) ──────
+        await _override_deps(app, Session, user_id=delegate_id, org_id=org_id)
+        try:
+            async with _client_for(app) as c:
+                link_resp = await c.post(
+                    f"/api/v2/a2a/tasks/{task_id}/link-gate", json={"gate_id": str(gate_id)},
+                )
+            assert link_resp.status_code == 200
+        finally:
+            app.dependency_overrides.clear()
+
+        # ── reader: GetTask JSON-RPC가 INPUT_REQUIRED로 단락하는지 ────────────────────
+        await _override_deps(app, Session, user_id=delegate_id, org_id=org_id)
+        try:
+            async with _client_for(app) as c:
+                get_resp = await c.post(
+                    f"/api/v2/a2a/members/{delegate_id}/rpc",
+                    json={"jsonrpc": "2.0", "id": 1, "method": "GetTask", "params": {"id": str(task_id)}},
+                )
+            get_body = get_resp.json()
+            assert get_body["result"]["status"]["state"] == "TASK_STATE_INPUT_REQUIRED"
+        finally:
+            app.dependency_overrides.clear()
+
+        # ── 사람 승인 → transition_gate(기존 구현, Q3) → WORKING 복귀 ─────────────────
+        async with Session() as s:
+            await transition_gate(s, org_id, gate_id, "approved", resolver_id=approver_id)
+            await s.commit()
+
+        async with Session() as s:
+            reloaded = (await s.execute(select(A2ATask).where(A2ATask.id == task_id))).scalar_one()
+            assert reloaded.state == "TASK_STATE_WORKING"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
Story `6d0454c3` (supersedes `5051b34e`), crux `a2a-hitl-input-auth-required-mapping-crux` option B (PO-approved).

The reader (`Gate.status=='pending'` → `TASK_STATE_INPUT_REQUIRED` in `_handle_get_task`) and the resume trigger (`transition_gate`'s third branch, approve→WORKING / reject→REJECTED) were **already implemented** — both were waiting on a writer that sets `task_metadata.linked_gate_id`, which never existed until now.

- **New `POST /api/v2/a2a/tasks/{task_id}/link-gate`**: the delegate declares "this gate blocks this A2A task" using two ids it already has from its own MCP session (`task_id` from `SendMessage`'s response, `gate_id` from the gate it just created). Self-scope guarded (task.member_id must equal the caller's own identity), gate must belong to the caller's org (IDOR), task must currently be WORKING.
- **New MCP tool `sprintable_link_gate_to_task`** — thin proxy matching the existing `tools/core.py` pattern. Registered in both `mcp_toolset.py` (backend SSOT) and the vendored `sprintable_mcp/toolset.py` copy, `_ALWAYS_ALLOWED` (same rationale as `lock_files`/`unlock_files` — cross-cutting coordination tool, non-destructive since the endpoint is self-scoped).
- **Deliberately did not** wire `conversation_id`/`task_id` through the 6 `create_gate()` call sites (crux option A) — invasive plumbing across 6 unrelated subsystems for a still-PoC-stage feature with no real usage yet would be over-engineering.

## Test plan
- [x] New `tests/test_a2a_sa3_link_gate_to_task_realdb.py` (6 tests): own-task link success, cross-agent 403, cross-org gate 404 (IDOR), non-WORKING task 400, unknown task 404, and a full internal round-trip (`create_gate` → link → GetTask INPUT_REQUIRED → `transition_gate` approve → WORKING).
- [x] **Live-proof with the real a2a-sdk client**: `create_gate()` (real disposition resolution, system default `ask`→`pending`) → link-gate endpoint → real SDK `GetTask` shows `INPUT_REQUIRED` → `transition_gate(approved)` → real SDK `GetTask` shows `WORKING` again.
- [x] Fixed the two hardcoded MCP tool-count assertions (`tests/mcp/test_contract.py`, 96→97) that legitimately needed bumping for the new tool — confirmed via signature triage this was the only fallout.
- [x] Full backend suite: 3123 passed, same 22 pre-existing unrelated failures already triaged across this session's other A2A PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)