### PR TITLE
feat(a2a): SendStreamingMessage SSE + AgentCard streaming=true (E-A2A-완성 S-A4)

### DIFF
--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -69,14 +69,18 @@ persona 존재 시 무조건 persona.slug/config.tool_allowlist 파생 단일 sk
 """
 from __future__ import annotations
 
+import asyncio
+import json
 import uuid
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.database import async_session_factory
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.a2a_task import A2ATask
@@ -262,7 +266,8 @@ async def _build_agent_card(session: AsyncSession, member: TeamMember, base_url:
         ],
         version="0.1.0-poc",
         capabilities=AgentCapabilities(
-            streaming=False, push_notifications=False, extended_agent_card=False,
+            # S-A4(story 03034d86): SendStreamingMessage 구현됨 — 정직 광고로 전환.
+            streaming=True, push_notifications=False, extended_agent_card=False,
             extensions=[
                 AgentExtension(
                     uri=PROJECT_CONTEXT_EXTENSION_URI,
@@ -528,39 +533,27 @@ async def _handle_send_message(
     return {"task": _task_to_dict(task)}
 
 
-async def _handle_get_task(
-    session: AsyncSession, member: TeamMember, params: dict,
-    active_extensions: frozenset[str] = frozenset(),  # noqa: ARG001 — 균일 dispatch 시그니처, 현재 미사용
-) -> dict:
-    try:
-        get_params = GetTaskParams.model_validate(params)
-    except Exception as exc:  # noqa: BLE001
-        raise _JsonRpcException(_INVALID_PARAMS, f"Invalid params: {exc}") from exc
+async def _advance_task_state(session: AsyncSession, task: A2ATask, org_id: uuid.UUID) -> A2ATask:
+    """GetTask의 반응형 상태-전이 판정 — S-A4(story 03034d86)에서 스트리밍 폴링 루프가 재사용
+    할 수 있도록 JSON-RPC 래핑에서 분리했다(GetTask도 동일 함수 호출 — 판정 규칙 이원화 방지).
 
-    result = await session.execute(
-        select(A2ATask).where(A2ATask.id == get_params.id, A2ATask.member_id == member.id)
-    )
-    task = result.scalar_one_or_none()
-    if task is None:
-        raise _JsonRpcException(_TASK_NOT_FOUND, "Task not found")
-
-    # HITL crux(story 7726a003, 문서 `a2a-hitl-input-auth-required-mapping-crux`, PO GO 승인
-    # 2026-07-07, 옵션 B): reader만 배선 — writer(task_metadata.linked_gate_id 기록)는 별도
-    # forward-work 스토리로 분리(아직 아무 delegate 경로도 이 필드를 안 씀 → 오늘은 항상
-    # no-op·무회귀). WORKING 에서만 판정(INPUT_REQUIRED 재진입 시 재판정 없음 — 복귀는
-    # transition_gate()의 전담 책임, 여기서 낙관적으로 되돌리지 않는다).
+    HITL crux(story 7726a003, 문서 `a2a-hitl-input-auth-required-mapping-crux`, PO GO 승인
+    2026-07-07, 옵션 B): reader만 배선 — writer(task_metadata.linked_gate_id 기록)는 별도
+    forward-work 스토리로 분리(아직 아무 delegate 경로도 이 필드를 안 씀 → 오늘은 항상
+    no-op·무회귀). WORKING 에서만 판정(INPUT_REQUIRED 재진입 시 재판정 없음 — 복귀는
+    transition_gate()의 전담 책임, 여기서 낙관적으로 되돌리지 않는다)."""
     if task.state == "TASK_STATE_WORKING":
         linked_gate_id = (task.task_metadata or {}).get("linked_gate_id")
         if linked_gate_id is not None:
             gate = (await session.execute(
-                select(Gate).where(Gate.id == uuid.UUID(linked_gate_id), Gate.org_id == member.org_id)
+                select(Gate).where(Gate.id == uuid.UUID(linked_gate_id), Gate.org_id == org_id)
             )).scalar_one_or_none()
             if gate is not None and gate.status == "pending":
                 task.state = "TASK_STATE_INPUT_REQUIRED"
                 await session.flush()
                 await session.commit()
                 await session.refresh(task)
-                return _task_to_dict(task)
+                return task
 
     if task.state == "TASK_STATE_WORKING" and task.root_message_id is not None:
         reply = (await session.execute(
@@ -628,6 +621,26 @@ async def _handle_get_task(
                 await session.commit()
                 await session.refresh(task)
 
+    return task
+
+
+async def _handle_get_task(
+    session: AsyncSession, member: TeamMember, params: dict,
+    active_extensions: frozenset[str] = frozenset(),  # noqa: ARG001 — 균일 dispatch 시그니처, 현재 미사용
+) -> dict:
+    try:
+        get_params = GetTaskParams.model_validate(params)
+    except Exception as exc:  # noqa: BLE001
+        raise _JsonRpcException(_INVALID_PARAMS, f"Invalid params: {exc}") from exc
+
+    result = await session.execute(
+        select(A2ATask).where(A2ATask.id == get_params.id, A2ATask.member_id == member.id)
+    )
+    task = result.scalar_one_or_none()
+    if task is None:
+        raise _JsonRpcException(_TASK_NOT_FOUND, "Task not found")
+
+    task = await _advance_task_state(session, task, member.org_id)
     return _task_to_dict(task)
 
 
@@ -689,8 +702,86 @@ _METHODS = {
     "ListTasks": _handle_list_tasks,
 }
 
+# S-A4(story 03034d86): 폴링 간격 — 기존 상태전이 로직(_advance_task_state)을 이 주기로
+# 재호출해 변화를 감시한다(신규 브로커/큐 불요, GetTask 로직 그대로 재사용).
+_STREAM_POLL_INTERVAL_SECONDS = 2.0
 
-@router.post("/members/{member_id}/rpc")
+
+def _sse_frame(request_id: str | int | None, result: dict) -> str:
+    """실 SDK(`JsonRpcTransport._send_stream_request`) 실측 계약 — 각 `data:` 라인이 완결된
+    JSON-RPC 2.0 envelope이어야 `StreamResponse` oneof로 파싱된다(`json_format.ParseDict`
+    직접 검증 완료: `task`/`statusUpdate`/`artifactUpdate` 카멜케이스 확認)."""
+    envelope = {"jsonrpc": "2.0", "id": request_id, "result": result}
+    return f"data: {json.dumps(envelope)}\n\n"
+
+
+async def _stream_send_message(
+    request: Request, request_id: str | int | None,
+    session: AsyncSession, member: TeamMember, org_id: uuid.UUID, params: dict,
+    active_extensions: frozenset[str],
+) -> StreamingResponse:
+    """S-A4 AC1: `SendStreamingMessage` — task 생성(기존 `_handle_send_message` 그대로 재사용)
+    확인 프레임 → 상태 변화 폴링(기존 `_advance_task_state`, GetTask와 100% 동일 규칙) →
+    터미널 도달 시 artifact + 최종 status 프레임 후 스트림 종료(커넥션 close = 실 SDK에게
+    "끝" 신호, 별도 `final` 필드 불요 — 이 SDK 버전 스키마 실측 확認).
+
+    커넥션 수명 동안 주입받은 `session`(request-scoped `get_db`)을 계속 쓰지 않는다 — 장수명
+    SSE가 커넥션을 오래 점유하는 문제(기존 `/agent/stream` 주석과 동일 근거)를 피하려 task
+    생성 직후 명시적으로 close하고, 폴링 루프는 매 tick마다 `async_session_factory()`로 짧게
+    여닫는다(AsyncSession.close()는 멱등이라 FastAPI의 get_db teardown이 나중에 또 불러도 안전)."""
+    send_result = await _handle_send_message(session, member, params, active_extensions)
+    await session.close()  # 장수명 스트림 동안 request-scoped 커넥션 점유 방지(멱등 close).
+
+    task_id = uuid.UUID(send_result["task"]["id"])
+    member_id = member.id
+
+    async def generate():
+        yield _sse_frame(request_id, {"task": send_result["task"]})
+
+        last_state: str | None = send_result["task"]["status"]["state"]
+        while not await request.is_disconnected():
+            async with async_session_factory() as db:
+                result = await db.execute(
+                    select(A2ATask).where(A2ATask.id == task_id, A2ATask.member_id == member_id)
+                )
+                task = result.scalar_one_or_none()
+                if task is None:
+                    return  # task 삭제 등 이상계 — 조용히 스트림 종료(방어적, 정상 경로 아님)
+
+                task = await _advance_task_state(db, task, org_id)
+                current_dict = _task_to_dict(task)
+
+            if task.state != last_state:
+                yield _sse_frame(request_id, {
+                    "statusUpdate": {
+                        "taskId": current_dict["id"],
+                        "contextId": current_dict["contextId"],
+                        "status": current_dict["status"],
+                    },
+                })
+                last_state = task.state
+
+            if task.state in _TERMINAL_STATES:
+                for artifact in current_dict.get("artifacts", []):
+                    yield _sse_frame(request_id, {
+                        "artifactUpdate": {
+                            "taskId": current_dict["id"],
+                            "contextId": current_dict["contextId"],
+                            "artifact": artifact,
+                        },
+                    })
+                return  # 커넥션 close = 종료 신호(이 SDK 스키마엔 별도 final 필드 없음, 실측)
+
+            await asyncio.sleep(_STREAM_POLL_INTERVAL_SECONDS)
+
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no", "Connection": "keep-alive"},
+    )
+
+
+@router.post("/members/{member_id}/rpc", response_model=None)
 async def a2a_rpc(
     request: Request,
     member_id: uuid.UUID,
@@ -698,7 +789,7 @@ async def a2a_rpc(
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
-) -> JsonRpcResponse:
+) -> JsonRpcResponse | StreamingResponse:
     """P1-S2: action-triggering 엔드포인트라 authed+org-scoped(PO 크럭스 — S1 PoC 리스크 노트
     봉인). Card fetch(GET .../agent-card.json)는 P1-S1 판단대로 unauth 유지, 여기만 인증."""
     version_header = request.headers.get("A2A-Version")
@@ -714,6 +805,18 @@ async def a2a_rpc(
             )
 
     member = await _get_agent_member(session, member_id, org_id)
+    active_extensions = _parse_active_extensions(request)
+
+    # S-A4(story 03034d86): 유일하게 StreamingResponse를 반환하는 메소드 — 나머지 3개와
+    # 응답 타입 자체가 달라(JsonRpcResponse 단일 vs SSE) 균일 _METHODS 디스패치에 안 넣고
+    # 여기서 조기 분기한다.
+    if body.method == "SendStreamingMessage":
+        try:
+            return await _stream_send_message(
+                request, body.id, session, member, org_id, body.params or {}, active_extensions,
+            )
+        except _JsonRpcException as exc:
+            return JsonRpcResponse(id=body.id, error=JsonRpcError(code=exc.code, message=exc.message))
 
     handler = _METHODS.get(body.method)
     if handler is None:
@@ -721,8 +824,6 @@ async def a2a_rpc(
             id=body.id,
             error=JsonRpcError(code=_METHOD_NOT_FOUND, message=f"Method not found: {body.method}"),
         )
-
-    active_extensions = _parse_active_extensions(request)
 
     try:
         result = await handler(session, member, body.params or {}, active_extensions)

--- a/backend/tests/test_a2a_sa4_streaming_realdb.py
+++ b/backend/tests/test_a2a_sa4_streaming_realdb.py
@@ -1,0 +1,201 @@
+"""E-A2A-완성 S-A4(story 03034d86): SendStreamingMessage — 실 Postgres 검증.
+
+ASGITransport(httpx 테스트용 in-process transport)는 StreamingResponse를 제너레이터
+완료 시점까지 통째로 버퍼링해 진짜 incremental 배달을 흉내내지 못한다(실측 확認 — 실 uvicorn
+TCP 서버에선 정상 동작). 그래서 이 테스트들은 HTTP 계층을 거치지 않고 `_stream_send_message`가
+반환하는 `StreamingResponse.body_iterator`를 직접 순회해 제너레이터 로직 자체를 검증한다
+([실증] 실 TCP 서버 E2E는 scratchpad 라이브 스크립트로 별도 완료 — story 8236bbc3 컨벤션:
+create_all 자체 스키마 관리)."""
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _bypass_fk(session) -> None:
+    from sqlalchemy import text as _text
+    await session.execute(_text("SET session_replication_role = replica"))
+
+
+def _mock_request() -> MagicMock:
+    req = MagicMock()
+    req.is_disconnected = AsyncMock(return_value=False)
+    return req
+
+
+def _send_params(text: str) -> dict:
+    return {
+        "message": {
+            "messageId": str(uuid.uuid4()),
+            "role": "ROLE_USER",
+            "parts": [{"text": text}],
+        }
+    }
+
+
+async def _collect_frames(body_iterator, *, max_frames: int) -> list[dict]:
+    """`data: {...}\\n\\n` SSE 프레임을 파싱된 dict 리스트로. StopAsyncIteration=스트림 종료."""
+    frames = []
+    async for chunk in body_iterator:
+        for line in chunk.split("\n"):
+            if line.startswith("data: "):
+                frames.append(json.loads(line[len("data: "):]))
+        if len(frames) >= max_frames:
+            break
+    return frames
+
+
+@pytest.mark.anyio
+async def test_streaming_yields_task_then_status_update_then_artifact_on_completion():
+    from app.models.team import TeamMember
+    from app.routers.a2a import _stream_send_message
+
+    engine, Session = await _session()
+    try:
+        org_id = uuid.uuid4()
+        async with Session() as s:
+            await _bypass_fk(s)
+            member = TeamMember(
+                id=uuid.uuid4(), org_id=org_id, project_id=uuid.uuid4(), type="agent",
+                name="Stream Test Agent", role="member", is_active=True,
+            )
+            s.add(member)
+            await s.commit()
+            member_id = member.id
+
+        async with Session() as s:
+            m = (await s.execute(
+                __import__("sqlalchemy").select(TeamMember).where(TeamMember.id == member_id)
+            )).scalar_one()
+            resp = await _stream_send_message(
+                _mock_request(), "req-1", s, m, org_id, _send_params("stream please"), frozenset(),
+            )
+
+        gen = resp.body_iterator
+        first = await gen.__anext__()
+        assert '"result": {"task"' in first or '"task"' in first
+        task_frame = json.loads(first.removeprefix("data: ").strip())
+        task_id = uuid.UUID(task_frame["result"]["task"]["id"])
+        assert task_frame["result"]["task"]["status"]["state"] == "TASK_STATE_WORKING"
+
+        # "CC의 답신"을 DB에 삽입 — 다음 폴링 tick이 감지하도록.
+        from sqlalchemy import select
+        from app.models.a2a_task import A2ATask
+        from app.models.conversation import ConversationMessage
+        async with Session() as s:
+            t = (await s.execute(select(A2ATask).where(A2ATask.id == task_id))).scalar_one()
+            s.add(ConversationMessage(
+                id=uuid.uuid4(), conversation_id=t.context_id, sender_id=None,
+                content="the real reply", thread_id=t.root_message_id,
+                created_at=datetime.now(timezone.utc),
+            ))
+            await s.commit()
+
+        remaining = []
+        async for chunk in gen:
+            for line in chunk.split("\n"):
+                if line.startswith("data: "):
+                    remaining.append(json.loads(line[len("data: "):]))
+            if len(remaining) >= 2:
+                break
+
+        kinds = [next(iter(f["result"].keys())) for f in remaining]
+        assert kinds == ["statusUpdate", "artifactUpdate"]
+        assert remaining[0]["result"]["statusUpdate"]["status"]["state"] == "TASK_STATE_COMPLETED"
+        assert remaining[1]["result"]["artifactUpdate"]["artifact"]["parts"][0]["text"] == "the real reply"
+
+        # 제너레이터가 스스로 종료됐는지(추가 프레임 없이 StopAsyncIteration).
+        with pytest.raises(StopAsyncIteration):
+            await gen.__anext__()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_streaming_stops_immediately_when_client_disconnects():
+    from app.models.team import TeamMember
+    from app.routers.a2a import _stream_send_message
+
+    engine, Session = await _session()
+    try:
+        org_id = uuid.uuid4()
+        async with Session() as s:
+            await _bypass_fk(s)
+            member = TeamMember(
+                id=uuid.uuid4(), org_id=org_id, project_id=uuid.uuid4(), type="agent",
+                name="Disconnect Test Agent", role="member", is_active=True,
+            )
+            s.add(member)
+            await s.commit()
+
+            disconnected_request = MagicMock()
+            disconnected_request.is_disconnected = AsyncMock(return_value=True)
+
+            resp = await _stream_send_message(
+                disconnected_request, "req-2", s, member, org_id,
+                _send_params("nobody's listening"), frozenset(),
+            )
+
+        gen = resp.body_iterator
+        first = await gen.__anext__()  # task 프레임은 disconnect 체크 이전이라 여전히 옴
+        assert '"task"' in first
+
+        # 다음 순회에서 is_disconnected=True라 루프 진입 없이 바로 종료돼야 함.
+        with pytest.raises(StopAsyncIteration):
+            await gen.__anext__()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_card_advertises_streaming_true():
+    from app.routers.a2a import _build_agent_card
+    from app.models.team import TeamMember
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            await _bypass_fk(s)
+            member = TeamMember(
+                id=uuid.uuid4(), org_id=uuid.uuid4(), project_id=uuid.uuid4(), type="agent",
+                name="Card Test Agent", role="member", is_active=True,
+            )
+            s.add(member)
+            await s.commit()
+            card = await _build_agent_card(s, member, "http://test")
+        assert card.capabilities.streaming is True
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
Story `03034d86`, blueprint Phase F (risk-tier, flagged for 까심 QA before merge).

- **Wire contract grounded in the real a2a-sdk (1.1.0) client's parsing code before writing server code**: each SSE `data:` line must be a complete JSON-RPC 2.0 envelope whose `result` parses as the `StreamResponse` oneof (`task`|`message`|`statusUpdate`|`artifactUpdate`); termination is just the connection closing — this SDK version's `TaskStatusUpdateEvent` schema has **no `final` field at all**, confirmed via direct protobuf `DESCRIPTOR` inspection, not assumed.
- **Refactored `_handle_get_task`'s reactive logic** (gate-linked INPUT_REQUIRED check, reply-thread completion check, delivery-failure/timeout check) into `_advance_task_state(session, task, org_id)`, shared by both `GetTask` and the new streaming poll loop — one set of transition rules, not two that can drift.
- **New `SendStreamingMessage` branch** in the shared `/rpc` endpoint: reuses `_handle_send_message` verbatim for task creation (first frame is byte-identical to `SendMessage`'s response), then polls `_advance_task_state` every 2s, emitting `statusUpdate` on state change and `artifactUpdate` per artifact on reaching a terminal state before closing. No new broker — this is the existing `GetTask` logic under server-side "watch and push."
- **Deliberately does not reuse `agent_gateway.py`'s `/agent/stream` infrastructure** (connection caps, presence, wake queues) — different concept (agent's own inbound stream vs. external client watching one task). Does follow its DB-session-lifetime pattern: the injected session is used once for task creation then explicitly closed, poll loop opens short-lived sessions per tick.
- `AgentCard.capabilities.streaming` flipped `true` now that the capability exists.
- `tasks/resubscribe` intentionally out of scope (spec-optional).

## A real bug this surfaced in my own testing methodology
Mid-implementation, found that httpx's `ASGITransport` (used for every live-proof this session) **buffers a `StreamingResponse`'s entire body until the generator completes** instead of delivering incrementally — invisible for single request/response proofs, silently wrong for anything needing real-time event observation. Rebuilt the proof against a real in-process **uvicorn server on a real TCP socket** (closer to actual Cloud Run characteristics too), which correctly showed `task → statusUpdate(COMPLETED) → artifactUpdate` delivered in real time as a concurrent DB write landed, then a clean connection close.

## Test plan
- [x] New `tests/test_a2a_sa4_streaming_realdb.py` (3 tests): full task→statusUpdate→artifactUpdate sequence with a real interleaved DB write, immediate stream termination on client disconnect, AgentCard advertises `streaming=true`. Drives `_stream_send_message`'s `StreamingResponse.body_iterator` directly (bypassing HTTP) to sidestep the same ASGITransport buffering limitation while still exercising the real generator.
- [x] **Live-proof with the real a2a-sdk streaming client against a real uvicorn TCP server**: `task` → `statusUpdate(COMPLETED)` → `artifactUpdate` received in real time; existing `GetTask` polling re-verified regression-free against the same server.
- [x] Existing `tests/test_a2a.py` (42 tests, unaffected — pure refactor of `_advance_task_state` extraction) — all pass.
- [x] Full backend suite: 3123 passed, same 22 pre-existing unrelated failures already triaged across this session's other A2A PRs.

## Note for review
Blueprint flags this story (streaming/risk tier) for 까심 QA before merge — requesting that pass before landing, same as S-A1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)