### PR TITLE
feat(a2a): AUTH_REQUIRED via explicit declaration — S-A3 mechanism reused (E-A2A-완성 S-A5)

### DIFF
--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -538,10 +538,13 @@ async def _advance_task_state(session: AsyncSession, task: A2ATask, org_id: uuid
     할 수 있도록 JSON-RPC 래핑에서 분리했다(GetTask도 동일 함수 호출 — 판정 규칙 이원화 방지).
 
     HITL crux(story 7726a003, 문서 `a2a-hitl-input-auth-required-mapping-crux`, PO GO 승인
-    2026-07-07, 옵션 B): reader만 배선 — writer(task_metadata.linked_gate_id 기록)는 별도
-    forward-work 스토리로 분리(아직 아무 delegate 경로도 이 필드를 안 씀 → 오늘은 항상
-    no-op·무회귀). WORKING 에서만 판정(INPUT_REQUIRED 재진입 시 재판정 없음 — 복귀는
-    transition_gate()의 전담 책임, 여기서 낙관적으로 되돌리지 않는다)."""
+    2026-07-07, 옵션 B): reader만 배선 — writer(task_metadata.linked_gate_id 기록)는 S-A3
+    (story 6d0454c3)이 닫았다. WORKING 에서만 판정(INPUT_REQUIRED/AUTH_REQUIRED 재진입 시
+    재판정 없음 — 복귀는 transition_gate()의 전담 책임, 여기서 낙관적으로 되돌리지 않는다).
+
+    S-A5(story c140977f): `linked_gate_reason=="auth"`로 명시 선언된 경우만
+    TASK_STATE_AUTH_REQUIRED, 그 외(선언 없음 또는 다른 이유)는 기존과 동일 INPUT_REQUIRED —
+    크럭스 판정 유지(auth-pending **자동 감지**는 실신호 0이라 배제, 명시 선언만 유효 신호)."""
     if task.state == "TASK_STATE_WORKING":
         linked_gate_id = (task.task_metadata or {}).get("linked_gate_id")
         if linked_gate_id is not None:
@@ -549,7 +552,11 @@ async def _advance_task_state(session: AsyncSession, task: A2ATask, org_id: uuid
                 select(Gate).where(Gate.id == uuid.UUID(linked_gate_id), Gate.org_id == org_id)
             )).scalar_one_or_none()
             if gate is not None and gate.status == "pending":
-                task.state = "TASK_STATE_INPUT_REQUIRED"
+                linked_gate_reason = (task.task_metadata or {}).get("linked_gate_reason")
+                task.state = (
+                    "TASK_STATE_AUTH_REQUIRED" if linked_gate_reason == "auth"
+                    else "TASK_STATE_INPUT_REQUIRED"
+                )
                 await session.flush()
                 await session.commit()
                 await session.refresh(task)
@@ -833,8 +840,15 @@ async def a2a_rpc(
     return JsonRpcResponse(id=body.id, result=result)
 
 
+_VALID_LINK_GATE_REASONS = frozenset({"auth"})
+
+
 class LinkGateBody(BaseModel):
     gate_id: uuid.UUID
+    # S-A5(story c140977f): reason="auth" 는 "외부 크리덴셜 필요"의 명시 선언 — reader가
+    # TASK_STATE_AUTH_REQUIRED로 전이시키는 유일한 신호원(자동 감지는 크럭스가 배제한 죽은
+    # 배선). 미지정(None) = 기존 S-A3 동작(INPUT_REQUIRED) 그대로, 무회귀.
+    reason: str | None = None
 
 
 @router.post("/tasks/{task_id}/link-gate")
@@ -846,10 +860,10 @@ async def link_gate_to_task(
     session: AsyncSession = Depends(get_db),
 ) -> dict:
     """E-A2A-완성 S-A3(story `6d0454c3`, 크럭스 `a2a-hitl-input-auth-required-mapping-crux`
-    옵션 B — writer): delegate가 "이 gate가 이 A2A task를 블록한다"를 **명시 선언**한다.
-    reader(``_handle_get_task``의 ``linked_gate_id`` 체크, 이미 구현)와 복귀 트리거
-    (``gate_service.py::transition_gate`` 3번째 분기, 이미 구현)는 이 필드가 채워지길 그저
-    기다리고 있었을 뿐 — 이 엔드포인트가 그 유일한 writer다.
+    옵션 B — writer) + S-A5(story `c140977f`, auth 변형): delegate가 "이 gate가 이 A2A task를
+    블록한다"를 **명시 선언**한다. reader(``_advance_task_state``의 ``linked_gate_id``/
+    ``linked_gate_reason`` 체크)와 복귀 트리거(``gate_service.py::transition_gate`` 3번째
+    분기)는 이 필드가 채워지길 그저 기다리고 있었을 뿐 — 이 엔드포인트가 그 유일한 writer다.
 
     6개 ``create_gate()`` 호출지점에 conversation_id/task_id를 관통시키는 침습 배관(크럭스
     옵션 A)은 의도적으로 배제 — delegate가 자기 MCP 세션에서 이미 알고 있는 두 id(task_id는
@@ -858,6 +872,12 @@ async def link_gate_to_task(
 
     self-scope 게이트(``assert_caller_is_member`` 동형) — task.member_id 본인만 자기 task에
     링크 선언 가능(다른 에이전트의 task를 가로채 임의 gate로 블록시키는 것 방지)."""
+    if body.reason is not None and body.reason not in _VALID_LINK_GATE_REASONS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported reason: {body.reason!r} (supported: {sorted(_VALID_LINK_GATE_REASONS)})",
+        )
+
     task = (await session.execute(
         select(A2ATask).where(A2ATask.id == task_id)
     )).scalar_one_or_none()
@@ -879,8 +899,11 @@ async def link_gate_to_task(
     if gate is None:
         raise HTTPException(status_code=404, detail="Gate not found")
 
-    task.task_metadata = {**(task.task_metadata or {}), "linked_gate_id": str(gate.id)}
+    task_metadata = {**(task.task_metadata or {}), "linked_gate_id": str(gate.id)}
+    if body.reason is not None:
+        task_metadata["linked_gate_reason"] = body.reason
+    task.task_metadata = task_metadata
     await session.flush()
     await session.commit()
 
-    return {"linked": True, "task_id": str(task.id), "gate_id": str(gate.id)}
+    return {"linked": True, "task_id": str(task.id), "gate_id": str(gate.id), "reason": body.reason}

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -373,9 +373,9 @@ async def _resolve_doc_gate(session: AsyncSession, gate: Gate, new_status: str) 
 
 async def _resume_a2a_task_on_gate_resolve(session: AsyncSession, gate: Gate, new_status: str) -> None:
     """HITL crux(story 7726a003, 문서 `a2a-hitl-input-auth-required-mapping-crux`, PO GO
-    2026-07-07 옵션 B): `A2ATask.task_metadata.linked_gate_id` 로 이 게이트에 연결된 task를
-    복귀시킨다. **writer(그 필드를 실제로 채우는 delegate-측 경로)는 별도 forward-work
-    스토리** — 오늘은 그 필드를 쓰는 경로가 전무해 이 함수는 항상 no-op(무회귀). approve→
+    2026-07-07 옵션 B) + S-A5(story c140977f, auth 변형): `A2ATask.task_metadata.linked_gate_id`
+    로 이 게이트에 연결된 task를 복귀시킨다. INPUT_REQUIRED든 AUTH_REQUIRED든(S-A3 writer의
+    `linked_gate_reason` 선언에 따라 갈린 상태) 복귀 트리거는 동일 — approve→
     `TASK_STATE_WORKING`(재개, 이후 기존 reply-thread 폴링이 COMPLETED까지 캐리) ·
     reject→`TASK_STATE_REJECTED`(기존 terminal state, 신규 처리 불요).
     """
@@ -386,7 +386,7 @@ async def _resume_a2a_task_on_gate_resolve(session: AsyncSession, gate: Gate, ne
     task = (await session.execute(
         select(A2ATask).where(
             A2ATask.task_metadata["linked_gate_id"].astext == str(gate.id),
-            A2ATask.state == "TASK_STATE_INPUT_REQUIRED",
+            A2ATask.state.in_(["TASK_STATE_INPUT_REQUIRED", "TASK_STATE_AUTH_REQUIRED"]),
         )
     )).scalar_one_or_none()
     if task is None:

--- a/backend/sprintable_mcp/tools/a2a.py
+++ b/backend/sprintable_mcp/tools/a2a.py
@@ -1,4 +1,4 @@
-"""A2A HITL writer MCP 도구 (1개) — E-A2A-완성 S-A3(story 6d0454c3)."""
+"""A2A HITL writer MCP 도구 (1개) — E-A2A-완성 S-A3(story 6d0454c3) + S-A5(story c140977f)."""
 from __future__ import annotations
 
 from mcp.types import TextContent
@@ -11,16 +11,23 @@ from ..schemas import SprintableInput
 class LinkGateToTaskInput(SprintableInput):
     task_id: str
     gate_id: str
+    # S-A5: "auth"로 선언하면 INPUT_REQUIRED 대신 AUTH_REQUIRED로 전이("외부 크리덴셜 필요"
+    # 명시 신호). 생략(None) = 기존 S-A3 동작 그대로(INPUT_REQUIRED, 무회귀).
+    reason: str | None = None
 
 
 async def link_gate_to_task(args: LinkGateToTaskInput) -> list[TextContent]:
-    """이 gate가 이 A2A task를 블록한다고 명시 선언 — 외부 GetTask가 INPUT_REQUIRED로 승격되고,
-    사람이 gate를 승인/거부하면 task가 자동으로 WORKING/REJECTED 복귀한다. 자기 자신에게
-    위임된 task에만 선언 가능(다른 에이전트의 task는 403)."""
+    """이 gate가 이 A2A task를 블록한다고 명시 선언 — 외부 GetTask가 INPUT_REQUIRED(또는
+    reason="auth"면 AUTH_REQUIRED)로 승격되고, 사람이 gate를 승인/거부하면 task가 자동으로
+    WORKING/REJECTED 복귀한다. 자기 자신에게 위임된 task에만 선언 가능(다른 에이전트의 task는
+    403)."""
     try:
+        payload = {"gate_id": args.gate_id}
+        if args.reason is not None:
+            payload["reason"] = args.reason
         result = await client.post(
             f"/api/v2/a2a/tasks/{args.task_id}/link-gate",
-            json={"gate_id": args.gate_id},
+            json=payload,
         )
         return ok(result)
     except Exception as exc:

--- a/backend/tests/test_a2a_sa3_link_gate_to_task_realdb.py
+++ b/backend/tests/test_a2a_sa3_link_gate_to_task_realdb.py
@@ -109,7 +109,10 @@ async def test_delegate_can_link_gate_to_own_working_task():
                     f"/api/v2/a2a/tasks/{task.id}/link-gate", json={"gate_id": str(gate.id)},
                 )
             assert resp.status_code == 200
-            assert resp.json() == {"linked": True, "task_id": str(task.id), "gate_id": str(gate.id)}
+            # S-A5(story c140977f): 응답에 "reason" 키 추가(additive) — 미지정 시 None.
+            assert resp.json() == {
+                "linked": True, "task_id": str(task.id), "gate_id": str(gate.id), "reason": None,
+            }
 
             async with Session() as s:
                 reloaded = (await s.execute(select(A2ATask).where(A2ATask.id == task.id))).scalar_one()

--- a/backend/tests/test_a2a_sa5_auth_required_realdb.py
+++ b/backend/tests/test_a2a_sa5_auth_required_realdb.py
@@ -1,0 +1,285 @@
+"""E-A2A-완성 S-A5(story c140977f): AUTH_REQUIRED — auth 변형 명시 선언, 실 Postgres 검증.
+
+S-A3의 `link-gate` writer에 `reason="auth"` 옵션을 얹은 변형 — reader
+(``_advance_task_state``)가 그 reason을 보고 INPUT_REQUIRED 대신 AUTH_REQUIRED로 전이시키고,
+복귀 트리거(``transition_gate``)가 AUTH_REQUIRED에서도 WORKING/REJECTED로 되돌린다. 자동
+감지는 크럭스가 명시 배제(실신호 0) — 이 writer의 명시 선언만이 유일한 유효 신호원.
+story 8236bbc3 컨벤션: create_all 자체 스키마 관리."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.destructive_schema,
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    from sqlalchemy import text as _text
+    from app.models.a2a_task import A2ATask
+    from app.models.gate import Gate
+    from app.models.team import TeamMember
+
+    org_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    delegate_id = uuid.uuid4()
+
+    await session.execute(_text("SET session_replication_role = replica"))
+    member = TeamMember(
+        id=delegate_id, org_id=org_id, project_id=project_id, type="agent",
+        name="SA5 Delegate", role="member", is_active=True,
+    )
+    task = A2ATask(
+        id=uuid.uuid4(), context_id=uuid.uuid4(), root_message_id=uuid.uuid4(),
+        member_id=delegate_id, state="TASK_STATE_WORKING", history=[], artifacts=[],
+        task_metadata={},
+    )
+    gate = Gate(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=uuid.uuid4(), work_item_type="story",
+        gate_type="pr_review", status="pending",
+    )
+    session.add_all([member, task, gate])
+    await session.commit()
+    return org_id, delegate_id, task, gate
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _override_deps(app, Session, *, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            yield s
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email=None, claims={})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_link_gate_with_reason_auth_transitions_to_auth_required_not_input_required():
+    from app.main import app
+    from app.models.a2a_task import A2ATask
+    from sqlalchemy import select
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org_id, delegate_id, task, gate = await _seed(s)
+
+        await _override_deps(app, Session, user_id=delegate_id, org_id=org_id)
+        try:
+            async with _client_for(app) as c:
+                link_resp = await c.post(
+                    f"/api/v2/a2a/tasks/{task.id}/link-gate",
+                    json={"gate_id": str(gate.id), "reason": "auth"},
+                )
+            assert link_resp.status_code == 200
+            assert link_resp.json()["reason"] == "auth"
+
+            async with _client_for(app) as c:
+                get_resp = await c.post(
+                    f"/api/v2/a2a/members/{delegate_id}/rpc",
+                    json={"jsonrpc": "2.0", "id": 1, "method": "GetTask", "params": {"id": str(task.id)}},
+                )
+            body = get_resp.json()
+            assert body["result"]["status"]["state"] == "TASK_STATE_AUTH_REQUIRED"
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_link_gate_without_reason_still_yields_input_required_regression_check():
+    """S-A3 기존 동작(reason 미지정=INPUT_REQUIRED) 회귀 0 재확認."""
+    from app.main import app
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org_id, delegate_id, task, gate = await _seed(s)
+
+        await _override_deps(app, Session, user_id=delegate_id, org_id=org_id)
+        try:
+            async with _client_for(app) as c:
+                link_resp = await c.post(
+                    f"/api/v2/a2a/tasks/{task.id}/link-gate", json={"gate_id": str(gate.id)},
+                )
+            assert link_resp.status_code == 200
+            assert link_resp.json()["reason"] is None
+
+            async with _client_for(app) as c:
+                get_resp = await c.post(
+                    f"/api/v2/a2a/members/{delegate_id}/rpc",
+                    json={"jsonrpc": "2.0", "id": 1, "method": "GetTask", "params": {"id": str(task.id)}},
+                )
+            assert get_resp.json()["result"]["status"]["state"] == "TASK_STATE_INPUT_REQUIRED"
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_link_gate_rejects_unsupported_reason_value():
+    from app.main import app
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org_id, delegate_id, task, gate = await _seed(s)
+
+        await _override_deps(app, Session, user_id=delegate_id, org_id=org_id)
+        try:
+            async with _client_for(app) as c:
+                resp = await c.post(
+                    f"/api/v2/a2a/tasks/{task.id}/link-gate",
+                    json={"gate_id": str(gate.id), "reason": "not-a-real-reason"},
+                )
+            assert resp.status_code == 400
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_full_auth_required_roundtrip_declare_resolve_working_completed():
+    """[실증] AC2 축소판: 선언(auth)→AUTH_REQUIRED→해소(approve)→WORKING→(답신)→COMPLETED."""
+    from app.main import app
+    from app.models.a2a_task import A2ATask
+    from app.models.conversation import ConversationMessage
+    from app.services.gate_service import transition_gate
+    from sqlalchemy import select
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org_id, delegate_id, task, gate = await _seed(s)
+            task_id, gate_id = task.id, gate.id
+
+        await _override_deps(app, Session, user_id=delegate_id, org_id=org_id)
+        try:
+            async with _client_for(app) as c:
+                link_resp = await c.post(
+                    f"/api/v2/a2a/tasks/{task_id}/link-gate",
+                    json={"gate_id": str(gate_id), "reason": "auth"},
+                )
+            assert link_resp.status_code == 200
+
+            async with _client_for(app) as c:
+                get1 = await c.post(
+                    f"/api/v2/a2a/members/{delegate_id}/rpc",
+                    json={"jsonrpc": "2.0", "id": 1, "method": "GetTask", "params": {"id": str(task_id)}},
+                )
+            assert get1.json()["result"]["status"]["state"] == "TASK_STATE_AUTH_REQUIRED"
+        finally:
+            app.dependency_overrides.clear()
+
+        # 사람이 크리덴셜 해소 후 approve.
+        async with Session() as s:
+            await transition_gate(s, org_id, gate_id, "approved", resolver_id=uuid.uuid4())
+            await s.commit()
+
+        async with Session() as s:
+            reloaded = (await s.execute(select(A2ATask).where(A2ATask.id == task_id))).scalar_one()
+            assert reloaded.state == "TASK_STATE_WORKING"
+            # 답신 도착 시뮬레이션 — 기존 reply-thread 폴링이 COMPLETED까지 캐리.
+            s.add(ConversationMessage(
+                id=uuid.uuid4(), conversation_id=reloaded.context_id, sender_id=None,
+                content="credential resolved, task done", thread_id=reloaded.root_message_id,
+                created_at=datetime.now(timezone.utc),
+            ))
+            await s.commit()
+
+        await _override_deps(app, Session, user_id=delegate_id, org_id=org_id)
+        try:
+            async with _client_for(app) as c:
+                get2 = await c.post(
+                    f"/api/v2/a2a/members/{delegate_id}/rpc",
+                    json={"jsonrpc": "2.0", "id": 2, "method": "GetTask", "params": {"id": str(task_id)}},
+                )
+            assert get2.json()["result"]["status"]["state"] == "TASK_STATE_COMPLETED"
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reject_from_auth_required_transitions_to_rejected():
+    from app.main import app
+    from app.models.a2a_task import A2ATask
+    from app.services.gate_service import transition_gate
+    from sqlalchemy import select
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            org_id, delegate_id, task, gate = await _seed(s)
+            task_id, gate_id = task.id, gate.id
+
+        await _override_deps(app, Session, user_id=delegate_id, org_id=org_id)
+        try:
+            async with _client_for(app) as c:
+                await c.post(
+                    f"/api/v2/a2a/tasks/{task_id}/link-gate",
+                    json={"gate_id": str(gate_id), "reason": "auth"},
+                )
+            async with _client_for(app) as c:
+                await c.post(
+                    f"/api/v2/a2a/members/{delegate_id}/rpc",
+                    json={"jsonrpc": "2.0", "id": 1, "method": "GetTask", "params": {"id": str(task_id)}},
+                )
+        finally:
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            await transition_gate(s, org_id, gate_id, "rejected", resolver_id=uuid.uuid4())
+            await s.commit()
+
+        async with Session() as s:
+            reloaded = (await s.execute(select(A2ATask).where(A2ATask.id == task_id))).scalar_one()
+            assert reloaded.state == "TASK_STATE_REJECTED"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
Story `c140977f`, blueprint Phase F (final story). Reuses the S-A3 `link-gate` declaration mechanism exactly, per the crux's standing decision: automatic auth-pending detection stays out of scope (zero real signal in the codebase for it — wiring it up would be a dead state value that leaves external callers waiting forever). Only an explicit declaration from the delegate is a valid signal.

- `LinkGateBody` gains an optional `reason` field (validated against a small allow-list, currently `{"auth"}` — unsupported values 400 rather than silently no-op). Omitted (`None`) reproduces S-A3's existing behavior byte-for-byte — regression-zero by construction, not a separate code path.
- `_advance_task_state` reads `task_metadata.linked_gate_reason`: `"auth"` transitions to `TASK_STATE_AUTH_REQUIRED`, anything else (including absent) keeps the existing `INPUT_REQUIRED` behavior.
- `_resume_a2a_task_on_gate_resolve` widened from a single-state equality check to `state.in_([INPUT_REQUIRED, AUTH_REQUIRED])` — approve/reject resumes a task waiting in either state through the identical trigger.
- MCP tool `sprintable_link_gate_to_task` exposes the same optional `reason` parameter.
- S-A4's streaming `statusUpdate` already treats `AUTH_REQUIRED` as a regular state per its generic "did state change" check — no streaming-side change needed (confirmed by inspection).

## Test plan
- [x] New `tests/test_a2a_sa5_auth_required_realdb.py` (5 tests): `reason=auth` → `AUTH_REQUIRED` (not `INPUT_REQUIRED`), `reason` omitted → `INPUT_REQUIRED` regression check, unsupported `reason` value → 400, full round-trip (declare→AUTH_REQUIRED→approve→WORKING→reply→COMPLETED), reject-from-AUTH_REQUIRED→REJECTED.
- [x] Existing `tests/test_a2a_sa3_link_gate_to_task_realdb.py` (6 tests) — updated one assertion for the endpoint's now-additive response shape (`reason` key added), all pass.
- [x] **Live-proof with the real a2a-sdk client**: declare(`reason=auth`) → `GetTask` shows `AUTH_REQUIRED` → `transition_gate(approved)` → `GetTask` shows `WORKING` → reply arrives → `GetTask` shows `COMPLETED` with the real artifact.
- [x] Regression check on other gate_service-touching test files (`test_e_cage_referee_p3_gate_object.py`, `test_gate_can_approve_48f064e5.py`, `test_gate_transition_human_only.py`, `test_h1_fix2_approve_advances_done.py`) — all pass.
- [x] Full backend suite: 3123 passed, same 22 pre-existing unrelated failures already triaged across this session's other A2A PRs.

## Note for review
This is Phase F's last story — landing this completes Phase F, leaving only Phase P (S-A6, prod promotion) to finish A2A completion end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)