### PR TITLE
feat(evidence): 실증-done 신뢰 신호 has_evidence + gate_approval 자동 편입 (E-VERIFY V0-S2)

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -96,6 +96,7 @@ async def list_stories(
     if no_sprint and project_id:
         stories = await repo.list_backlog(project_id, limit=limit)
         await _attach_assignee_ids(repo.session, repo.org_id, stories)
+        await _attach_has_evidence(repo.session, stories)
         return [StoryResponse.model_validate(s) for s in stories]
 
     # CB-S4: status + project_id 조합 시 board 쿼리 (order_by + cursor + done 7일 제한)
@@ -114,6 +115,7 @@ async def list_stories(
             if stories:
                 response.headers["X-Next-Cursor"] = stories[-1].created_at.isoformat()
         await _attach_assignee_ids(repo.session, repo.org_id, stories)
+        await _attach_has_evidence(repo.session, stories)
         return [StoryResponse.model_validate(s) for s in stories]
 
     filters: dict = {}
@@ -129,6 +131,7 @@ async def list_stories(
         filters["status"] = status_filter
     stories = await repo.list(limit=limit, **filters)
     await _attach_assignee_ids(repo.session, repo.org_id, stories)
+    await _attach_has_evidence(repo.session, stories)
     return [StoryResponse.model_validate(s) for s in stories]
 
 
@@ -146,6 +149,20 @@ async def _attach_assignee_ids(
         if not ids:
             ids = [s.assignee_id] if s.assignee_id else []
         s.assignee_ids = ids  # 매핑되지 않은 transient 속성 — from_attributes 전용
+
+
+async def _attach_has_evidence(session: AsyncSession, stories: list[Story]) -> None:
+    """E-VERIFY V0-S2(story 3fbd048d): evidence 있는 story에 has_evidence=True(transient attr) —
+    없으면 미설정(StoryResponse 기본값 None 유지, positive 단방향·부정 신호 0).
+    _attach_assignee_ids와 동형 배치 패턴."""
+    if not stories:
+        return
+    from app.services.evidence_service import batch_has_evidence
+
+    ids_with_evidence = await batch_has_evidence(session, [s.id for s in stories], "story")
+    for s in stories:
+        if s.id in ids_with_evidence:
+            s.has_evidence = True
 
 
 async def _upsert_assignee_participation(
@@ -345,6 +362,7 @@ async def get_story(
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")
     await _attach_assignee_ids(repo.session, repo.org_id, [story])
+    await _attach_has_evidence(repo.session, [story])
     return StoryResponse.model_validate(story)
 
 
@@ -541,6 +559,7 @@ async def bulk_update_stories(
         await db.refresh(s)
     # refresh 後 transient assignee_ids 세팅(refresh 는 매핑 컬럼만 reload·transient 보존).
     await _attach_assignee_ids(db, repo.org_id, updated)
+    await _attach_has_evidence(db, updated)
 
     # 응답(violation flag 포함) + violation 이벤트 페이로드를 commit 前에 빌드(commit 시 attr expire→
     # MissingGreenlet 방지·기존 results 빌드와 동일 시점). 이벤트 발화는 commit 後(/status 와 동일 순서).
@@ -822,6 +841,7 @@ async def update_story(
         )
 
     await _attach_assignee_ids(db, repo.org_id, [story])
+    await _attach_has_evidence(db, [story])
     return StoryResponse.model_validate(story)
 
 
@@ -1040,6 +1060,7 @@ async def update_story_status(
         )
 
     await _attach_assignee_ids(db, repo.org_id, [story])
+    await _attach_has_evidence(db, [story])
     resp = StoryResponse.model_validate(story)
     # 정공법 A: 비순차 점프면 응답에 violation flag(차단 없이 가시화·/bulk 와 동일 SSOT).
     resp.violation = build_violation_flag(old_status, story.status)

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -6,9 +6,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
-from app.models.pm import Story
+from app.models.pm import Story, Task
 from app.repositories.task import TaskRepository
 from app.schemas.task import TaskCreate, TaskResponse, TaskUpdate
+from app.services.evidence_service import batch_has_evidence
 from app.services.notification_dispatch import dispatch_notification
 
 router = APIRouter(prefix="/api/v2/tasks", tags=["tasks"])
@@ -19,6 +20,16 @@ def _get_repo(
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> TaskRepository:
     return TaskRepository(session, org_id)
+
+
+async def _attach_has_evidence(session: AsyncSession, tasks: list[Task]) -> None:
+    """E-VERIFY V0-S2(story 3fbd048d) — stories.py `_attach_has_evidence`와 동형(배치 조회)."""
+    if not tasks:
+        return
+    ids_with_evidence = await batch_has_evidence(session, [t.id for t in tasks], "task")
+    for t in tasks:
+        if t.id in ids_with_evidence:
+            t.has_evidence = True
 
 
 @router.get("", response_model=list[TaskResponse])
@@ -36,6 +47,7 @@ async def list_tasks(
     if status_filter:
         filters["status"] = status_filter
     tasks = await repo.list(**filters)
+    await _attach_has_evidence(repo.session, tasks)
     return [TaskResponse.model_validate(t) for t in tasks]
 
 
@@ -72,6 +84,7 @@ async def get_task(
     task = await repo.get(id)
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found")
+    await _attach_has_evidence(repo.session, [task])
     return TaskResponse.model_validate(task)
 
 
@@ -107,6 +120,7 @@ async def update_task(
                 # S2: 멀티프로젝트 에이전트 assignee를 스토리 프로젝트로 정확 라우팅
                 source_project_id=story_row.project_id,
             )
+    await _attach_has_evidence(db, [task])
     return TaskResponse.model_validate(task)
 
 

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -211,3 +211,13 @@ class StoryResponse(BaseModel):
         # violation 은 ORM 컬럼이 아님 — from_attributes 시 비-dict(MagicMock auto-attr 등)는 None 처리
         # (_coerce_attachments 와 동형). 실제 flag 는 라우터가 model_validate 後 dict 로 할당한다.
         return v if isinstance(v, dict) else None
+
+    # E-VERIFY V0-S2(story 3fbd048d): evidence-backed 신호(positive 단방향) — True(있음) 또는
+    # None(신호 부재, violation과 동형 — 부정값 False 절대 안 씀). ORM 컬럼 아님·라우터가
+    # model_validate 前 transient attr로 세팅(assignee_ids 패턴 동형).
+    has_evidence: bool | None = None
+
+    @field_validator("has_evidence", mode="before")
+    @classmethod
+    def _coerce_has_evidence(cls, v):
+        return v if isinstance(v, bool) else None

--- a/backend/app/schemas/task.py
+++ b/backend/app/schemas/task.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class TaskCreate(BaseModel):
@@ -32,3 +32,12 @@ class TaskResponse(BaseModel):
     story_points: int | None = None
     created_at: datetime
     updated_at: datetime
+
+    # E-VERIFY V0-S2(story 3fbd048d): evidence-backed 신호(positive 단방향) — story.has_evidence와
+    # 동형(True 또는 None, False 없음). 라우터가 model_validate 前 transient attr로 세팅.
+    has_evidence: bool | None = None
+
+    @field_validator("has_evidence", mode="before")
+    @classmethod
+    def _coerce_has_evidence(cls, v):
+        return v if isinstance(v, bool) else None

--- a/backend/app/services/evidence_service.py
+++ b/backend/app/services/evidence_service.py
@@ -1,0 +1,54 @@
+"""E-VERIFY V0-S2(story 3fbd048d): evidence-backed 신호 + gate_approval 자동 편입."""
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.evidence import Evidence
+from app.models.gate import Gate
+
+_EVIDENCE_WORK_ITEM_TYPES = frozenset({"story", "task"})
+
+
+async def batch_has_evidence(
+    session: AsyncSession, work_item_ids: list[uuid.UUID], work_item_type: str
+) -> set[uuid.UUID]:
+    """evidence가 1건이라도 있는 work_item_id 집합(N+1 회피 배치 조회) — story/task 응답의
+    has_evidence(positive 단방향) 신호원."""
+    if not work_item_ids:
+        return set()
+    result = await session.execute(
+        select(Evidence.work_item_id.distinct()).where(
+            Evidence.work_item_type == work_item_type,
+            Evidence.work_item_id.in_(work_item_ids),
+        )
+    )
+    return set(result.scalars().all())
+
+
+async def create_gate_approval_evidence_if_applicable(
+    session: AsyncSession, gate: Gate, new_status: str, resolver_id: uuid.UUID | None,
+) -> None:
+    """HITL gate 승인 → gate_approval evidence 자동 편입(blueprint §2-3, 휴먼이 이미 승인한 것도
+    증명의 일부). approved 전이 + work_item_type이 evidence 스코프(story/task) 안일 때만 —
+    reject/void/hold나 doc 등 V0 스코프 밖 work_item_type은 no-op(순수 additive, 회귀 0).
+    공개 API의 gate_approval 차단(app/routers/evidence.py)과 짝 — 이 경로만 유일한 생성 지점."""
+    if new_status != "approved":
+        return
+    if gate.work_item_type not in _EVIDENCE_WORK_ITEM_TYPES:
+        return
+    if resolver_id is None:
+        # approved 전이는 라우터에서 human-only 강제(agent API키 403)라 정상 경로엔 항상 있음 —
+        # 없으면(내부 직호출 등 예외 경로) 귀속시킬 사람이 없으므로 evidence 생성 skip(무회귀).
+        return
+    session.add(Evidence(
+        id=uuid.uuid4(),
+        org_id=gate.org_id,
+        work_item_id=gate.work_item_id,
+        work_item_type=gate.work_item_type,
+        type="gate_approval",
+        ref=str(gate.id),
+        source="gate",
+        note=gate.resolution_note,
+        created_by=resolver_id,
+    ))

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -157,6 +157,12 @@ async def transition_gate(
         # HITL crux(story 7726a003) — A2A task INPUT_REQUIRED 복귀. writer 미배선이라 오늘은 no-op.
         await _resume_a2a_task_on_gate_resolve(session, gate, new_status)
 
+    # E-VERIFY V0-S2(story 3fbd048d): 휴먼 gate 승인 → gate_approval evidence 자동 편입(순수
+    # additive — approved+story/task work_item_type 아니면 no-op).
+    from app.services.evidence_service import create_gate_approval_evidence_if_applicable
+
+    await create_gate_approval_evidence_if_applicable(session, gate, new_status, resolver_id)
+
     await session.flush()
     await session.refresh(gate)
     return gate

--- a/backend/tests/test_e_verify_v0_s2_evidence_signal_realdb.py
+++ b/backend/tests/test_e_verify_v0_s2_evidence_signal_realdb.py
@@ -1,0 +1,283 @@
+"""E-VERIFY V0-S2(story 3fbd048d): has_evidence 신호 + gate_approval 자동 편입 — 실 Postgres 검증."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+    from app.models.pm import Story, Task
+
+    org = Organization(id=uuid.uuid4(), name="V0-S2 Org", slug=f"v0s2-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="V0-S2 Project")
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Evidence Agent", is_active=True)
+    session.add_all([project, agent])
+    await session.commit()
+
+    grant = ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted", role="member",
+    )
+    session.add(grant)
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="V0-S2 Story", status="in-progress")
+    session.add(story)
+    await session.commit()
+
+    task = Task(id=uuid.uuid4(), org_id=org.id, story_id=story.id, title="V0-S2 Task", status="in-progress")
+    session.add(task)
+    await session.commit()
+
+    return org.id, project.id, agent.id, story.id, task.id
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, member_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            yield s
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(member_id), email="agent@test",
+            claims={"app_metadata": {"org_id": str(org_id), "api_key_id": "test-key"}},
+        )
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_story_has_evidence_none_by_default_true_after_attach():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id, agent_id, story_id, _task_id = await _seed(s)
+
+        await _setup_app(app, Session, agent_id, org_id)
+        client = _client_for(app)
+        try:
+            before = await client.get(f"/api/v2/stories/{story_id}")
+            assert before.status_code == 200, before.text
+            body_before = before.json()
+            assert body_before["has_evidence"] is None
+            assert "has_evidence" in body_before  # 필드 자체는 존재(None) — false 아님
+
+            create_resp = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(story_id), "work_item_type": "story",
+                "type": "pr", "ref": "https://github.com/org/repo/pull/2",
+            })
+            assert create_resp.status_code == 201, create_resp.text
+
+            after = await client.get(f"/api/v2/stories/{story_id}")
+            assert after.json()["has_evidence"] is True
+
+            list_resp = await client.get("/api/v2/stories", params={"project_id": str(project_id)})
+            assert list_resp.status_code == 200
+            matching = [s for s in list_resp.json() if s["id"] == str(story_id)]
+            assert len(matching) == 1
+            assert matching[0]["has_evidence"] is True
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_task_has_evidence_none_by_default_true_after_attach():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id, agent_id, story_id, task_id = await _seed(s)
+
+        await _setup_app(app, Session, agent_id, org_id)
+        client = _client_for(app)
+        try:
+            before = await client.get(f"/api/v2/tasks/{task_id}")
+            assert before.json()["has_evidence"] is None
+
+            create_resp = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(task_id), "work_item_type": "task",
+                "type": "deploy", "ref": "https://example.com/deploy/1",
+            })
+            assert create_resp.status_code == 201, create_resp.text
+
+            after = await client.get(f"/api/v2/tasks/{task_id}")
+            assert after.json()["has_evidence"] is True
+
+            list_resp = await client.get("/api/v2/tasks", params={"story_id": str(story_id)})
+            matching = [t for t in list_resp.json() if t["id"] == str(task_id)]
+            assert matching[0]["has_evidence"] is True
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_gate_approval_auto_creates_evidence_and_flips_signal():
+    """HITL gate 승인 → gate_approval evidence 자동 편입 → story.has_evidence=True."""
+    from app.models.gate import Gate
+    from app.services.gate_service import create_gate, transition_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id, agent_id, story_id, _task_id = await _seed(s)
+            approver_id = uuid.uuid4()
+            role_id = uuid.uuid4()
+
+            gate = await create_gate(
+                s, org_id=org_id, work_item_id=story_id, work_item_type="story",
+                gate_type="pr_review", member_id=agent_id, role_id=role_id,
+            )
+            await s.commit()
+            gate_id = gate.id
+
+            await transition_gate(s, org_id, gate_id, "approved", resolver_id=approver_id)
+            await s.commit()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.evidence import Evidence
+
+            rows = (await s.execute(
+                select(Evidence).where(
+                    Evidence.work_item_id == story_id, Evidence.work_item_type == "story",
+                    Evidence.type == "gate_approval",
+                )
+            )).scalars().all()
+            assert len(rows) == 1, "gate_approval evidence 자동 생성 안 됨"
+            assert rows[0].ref == str(gate_id)
+            assert rows[0].created_by == approver_id
+
+        from app.main import app
+        await _setup_app(app, Session, agent_id, org_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{story_id}")
+            assert resp.json()["has_evidence"] is True
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_gate_rejected_does_not_create_evidence():
+    """회귀: reject 전이는 gate_approval evidence를 만들지 않는다."""
+    from app.services.gate_service import create_gate, transition_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id, agent_id, story_id, _task_id = await _seed(s)
+            approver_id = uuid.uuid4()
+            role_id = uuid.uuid4()
+
+            gate = await create_gate(
+                s, org_id=org_id, work_item_id=story_id, work_item_type="story",
+                gate_type="pr_review", member_id=agent_id, role_id=role_id,
+            )
+            await s.commit()
+            gate_id = gate.id
+
+            await transition_gate(s, org_id, gate_id, "rejected", resolver_id=approver_id, note="no")
+            await s.commit()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.evidence import Evidence
+
+            rows = (await s.execute(
+                select(Evidence).where(Evidence.work_item_id == story_id, Evidence.type == "gate_approval")
+            )).scalars().all()
+            assert rows == []
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_gate_approval_for_non_story_task_work_item_type_is_noop():
+    """블라인드 스코프 가드: work_item_type이 story/task가 아니면(예: doc) evidence 생성 안 함
+    (Evidence CHECK 제약이 story/task만 허용 — 위반 시 500 방지)."""
+    from app.services.evidence_service import create_gate_approval_evidence_if_applicable
+    from app.models.gate import Gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id, agent_id, story_id, _task_id = await _seed(s)
+            fake_gate = Gate(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=uuid.uuid4(), work_item_type="doc",
+                gate_type="doc_approval", status="approved",
+            )
+            await create_gate_approval_evidence_if_applicable(s, fake_gate, "approved", uuid.uuid4())
+            await s.commit()
+
+            from sqlalchemy import select
+            from app.models.evidence import Evidence
+            rows = (await s.execute(
+                select(Evidence).where(Evidence.work_item_id == fake_gate.work_item_id)
+            )).scalars().all()
+            assert rows == []
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
Blueprint `e-verify-v0-blueprint` r2 §2-2/§2-3, V0-S1(#1994) 계약 위. S1 후속 — evidence 유무를 Story/Task 응답에 신뢰 신호로 노출하고, HITL gate 승인을 `gate_approval` evidence로 자동 편입.

## 설계
- **`has_evidence: bool | None`** — evidence 1건 이상이면 `true`, 없으면 **`false`가 아니라 `None`**(신호 부재). 기존 `violation` 필드(비순차 점프 flag)와 정확히 동형 패턴: ORM 컬럼 아님, 라우터가 `model_validate` 前 transient attr로 세팅 — 스키마 레벨에서 "낙인" 자체가 불가능한 구조(AC 문구 그대로).
- N+1 회피: `evidence_service.batch_has_evidence()` 단일 배치 쿼리, Story의 기존 `_attach_assignee_ids` 패턴을 그대로 재사용(같은 파일에 이미 확립된 컨벤션).
- 배선 지점: stories.py 6곳(list 3분기·get·bulk-update·status-update), tasks.py 3곳(list·get·update) — **create 엔드포인트는 의도적으로 제외**(신규 항목은 evidence가 있을 수 없음, 정합).
- **gate_approval 자동 편입**: `transition_gate`가 `approved`로 전이할 때 `evidence_service.create_gate_approval_evidence_if_applicable()` 호출 — `work_item_type`이 story/task 스코프 밖(doc 등)이면 no-op, `resolver_id` 없으면 skip(항상 실제 휴먼 승인 경로로만 생성 — V0-S1의 공개 API 차단과 짝을 이뤄 스푸핑 완전 차단).

## Test plan
- [x] 신규 realdb 테스트 5/5 — story/task 각각 신호 없음(None)→첨부 후 true(list+get 양쪽), gate 승인 자동 편입+신호 전파, gate 거부 시 미생성(회귀), story/task 스코프 밖 work_item_type no-op.
- [x] 기존 `test_stories.py`/`test_tasks.py`(mock 기반) 35+ 테스트 — 새 필드가 MagicMock auto-attr을 만나도 `_coerce_has_evidence` validator가 안전 처리, 전부 green.
- [x] MCP contract 27/27.
- [x] 전체 백엔드 스위트(`pytest -q -m "not destructive_schema"`) — 3439 passed, 6 failed(전부 기존 환경성, 무관·신규 회귀 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)