### PR TITLE
[SID:d7f6aca2] E-VERIFY V0-S3 신뢰 표면 — done 카드 씰 + evidence 펼침

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3342,5 +3342,21 @@
     "viewInBoard": "View in board",
     "executionBoundaryNote": "Execution happens on your machine. Sprintable only generates the files — it doesn't run the compute.",
     "finish": "Go to dashboard"
+  },
+  "verify": {
+    "provenCompletion": "Proven completion",
+    "evidenceShow": "Show evidence",
+    "evidenceHide": "Hide evidence",
+    "evidenceCount": "{count} evidence items",
+    "evidenceSignedBy": "Evidence for this completion — left by {name}",
+    "evidenceMore": "{count} more evidence items",
+    "evidenceLoadError": "Couldn't load evidence",
+    "evidenceTypeUrl": "Link",
+    "evidenceTypeFile": "File",
+    "evidenceTypePr": "PR",
+    "evidenceTypeDeploy": "Deploy",
+    "evidenceTypeMetric": "Metric",
+    "evidenceTypeReport": "Report",
+    "evidenceTypeGateApproval": "Gate approval"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3342,5 +3342,21 @@
     "viewInBoard": "보드에서 보기",
     "executionBoundaryNote": "실행은 유저 머신에서 이뤄집니다. Sprintable은 파일만 만들고 컴퓨트는 짊어지지 않습니다.",
     "finish": "대시보드로"
+  },
+  "verify": {
+    "provenCompletion": "증명된 완결",
+    "evidenceShow": "근거 보기",
+    "evidenceHide": "근거 접기",
+    "evidenceCount": "근거 {count}건",
+    "evidenceSignedBy": "이 완결의 근거 — {name}가 남김",
+    "evidenceMore": "근거 {count}건 더 보기",
+    "evidenceLoadError": "근거를 불러오지 못했습니다",
+    "evidenceTypeUrl": "링크",
+    "evidenceTypeFile": "파일",
+    "evidenceTypePr": "PR",
+    "evidenceTypeDeploy": "배포",
+    "evidenceTypeMetric": "지표",
+    "evidenceTypeReport": "리포트",
+    "evidenceTypeGateApproval": "게이트 승인"
   }
 }

--- a/apps/web/src/app/api/evidence/route.ts
+++ b/apps/web/src/app/api/evidence/route.ts
@@ -1,0 +1,15 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+/** GET /api/evidence?work_item_id=&work_item_type= — E-VERIFY V0-S1/S2: done 항목의 근거 리스트(Lv2 펼침 전용). */
+export async function GET(request: Request) {
+  try {
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    const _r = await proxyToFastapi(request, '/api/v2/evidence');
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -8,6 +8,7 @@ import type { KanbanStory, KanbanMember, LineStatusSummary } from './types';
 import { Badge } from '@/components/ui/badge';
 import { AlertTriangle, ChevronRight, EyeOff, History, Pause, Rocket, Zap, ZapOff, type LucideIcon } from 'lucide-react';
 import { LabelChip } from '@/components/ui/label-chip';
+import { TrustSeal } from '@/components/verify/trust-seal';
 
 // E-MODERN A: 에픽 식별 dot — 기존 시맨틱 토큰만(신규 토큰/raw 팔레트 0). 신호색(warning=blocked·
 // accent-claim=agent·destructive) 회피해 의미 충돌 0. 랜덤 5색 채움 배지(loud)는 퇴출.
@@ -296,6 +297,9 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
           )}
         </div>
         <div className="flex items-center gap-2">
+          {/* E-VERIFY V0-S3 Lv0 — 증거 있는 done 카드에만(positive 단방향). 자리 예약 없이 조건부 렌더
+              (증거 없으면 완전 무표시 — 레이아웃 시프트 자체가 없음, §7 상태 매트릭스). */}
+          {story.status === 'done' && story.has_evidence ? <TrustSeal /> : null}
           {story.story_points != null ? (
             <span className="text-[11px] tabular-nums text-muted-foreground">{t('storyPointsBadge', { count: story.story_points })}</span>
           ) : null}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -17,6 +17,7 @@ import { DependencyGraph } from './dependency-graph';
 import { OutcomeResultCard, type OutcomeResult } from '@/components/outcome/outcome-result-card';
 import { StoryHypothesesSection } from '@/components/hypotheses/story-hypotheses-section';
 import { StoryMergeGate } from '@/components/cage/story-merge-gate';
+import { EvidenceSection } from '@/components/verify/evidence-section';
 import { StuckHandoffSection } from '@/components/cage/stuck-handoff-section';
 import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
 import { PrLinkSection } from '@/components/integrations/pr-link-section';
@@ -730,6 +731,14 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 })}
               </DropdownMenuContent>
             </DropdownMenu>
+            {/* E-VERIFY V0-S3 Lv1/Lv2 — 완료 badge의 연장으로 읽히도록 바로 아래. 증거 0이면
+                EvidenceSection 자체가 null 렌더(행 미노출, §7 상태 매트릭스). */}
+            <EvidenceSection
+              workItemId={story.id}
+              workItemType="story"
+              hasEvidence={story.has_evidence}
+              memberMap={memberMap}
+            />
           </div>
           <div className="flex shrink-0 items-center gap-2">
             <button

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -23,6 +23,8 @@ export interface KanbanStory {
   blocked_by?: string[];
   labels?: { id: string; name: string; color: string | null }[];
   gates?: { id: string; gate_type: string; status: string }[];
+  // E-VERIFY V0-S1/S2: 실증-done 신뢰 신호. true면 근거 有, null이면 완전 무표시.
+  has_evidence?: boolean | null;
 }
 
 export interface GateItem {

--- a/apps/web/src/components/verify/evidence-section.test.tsx
+++ b/apps/web/src/components/verify/evidence-section.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { EvidenceSection, isLinkableRef } from './evidence-section';
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+describe('isLinkableRef', () => {
+  it('treats http/https refs as linkable', () => {
+    expect(isLinkableRef('https://github.com/moonklabs/sprintable/pull/1985')).toBe(true);
+    expect(isLinkableRef('http://example.com')).toBe(true);
+  });
+
+  it('treats non-URL refs (e.g. a metric description) as non-linkable', () => {
+    expect(isLinkableRef('conversion rate +4.2%')).toBe(false);
+    expect(isLinkableRef('run-abc123-00208')).toBe(false);
+  });
+});
+
+describe('EvidenceSection (SSR snapshot — §7 상태 매트릭스)', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), { status: 200 }),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing when hasEvidence is null (증거 0 = 행 미렌더, "증명 안 됨" 표기 금지)', () => {
+    const markup = renderToStaticMarkup(
+      wrap(<EvidenceSection workItemId="s1" workItemType="story" hasEvidence={null} />),
+    );
+    expect(markup).toBe('');
+  });
+
+  it('renders nothing when hasEvidence is undefined (BE가 필드 자체를 안 내려도 안전한 폴백)', () => {
+    const markup = renderToStaticMarkup(
+      wrap(<EvidenceSection workItemId="s1" workItemType="story" hasEvidence={undefined} />),
+    );
+    expect(markup).toBe('');
+  });
+
+  it('renders the collapsed trust row when hasEvidence is true, without fetching evidence eagerly', () => {
+    const markup = renderToStaticMarkup(
+      wrap(<EvidenceSection workItemId="s1" workItemType="story" hasEvidence={true} />),
+    );
+    expect(markup).toContain('증명된 완결');
+    expect(markup).toContain('근거 보기');
+    // 디디 BE 가이드: "근거 보기" 클릭 전엔 evidence 리스트를 부르지 않는다(카드마다 N+1 방지).
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/verify/evidence-section.tsx
+++ b/apps/web/src/components/verify/evidence-section.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import {
+  ChevronDown, ChevronUp, ExternalLink, Link2, Paperclip,
+  GitPullRequest, Rocket, TrendingUp, FileText, CheckCircle2,
+} from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { TrustSeal } from './trust-seal';
+import type { EvidenceItem, EvidenceType } from '@/services/verify';
+
+const VISIBLE_LIMIT = 4;
+
+const TYPE_ICON: Record<EvidenceType, typeof Link2> = {
+  url: Link2,
+  file: Paperclip,
+  pr: GitPullRequest,
+  deploy: Rocket,
+  metric: TrendingUp,
+  report: FileText,
+  gate_approval: CheckCircle2,
+};
+
+const TYPE_LABEL_KEY: Record<EvidenceType, string> = {
+  url: 'evidenceTypeUrl',
+  file: 'evidenceTypeFile',
+  pr: 'evidenceTypePr',
+  deploy: 'evidenceTypeDeploy',
+  metric: 'evidenceTypeMetric',
+  report: 'evidenceTypeReport',
+  gate_approval: 'evidenceTypeGateApproval',
+};
+
+/** ref가 실제로 새 탭을 열 수 있는 URL인지 — 아닌 타입(예: metric 수치 설명)은 링크로 렌더하지 않는다. */
+export function isLinkableRef(ref: string): boolean {
+  return /^https?:\/\//i.test(ref);
+}
+
+interface EvidenceSectionProps {
+  workItemId: string;
+  workItemType: 'story' | 'task';
+  /** BE list/get 응답의 has_evidence 신호. false는 절대 오지 않음(null=무증거) — undefined도 무증거로 취급. */
+  hasEvidence: boolean | null | undefined;
+  memberMap?: Record<string, { name: string }>;
+  className?: string;
+}
+
+/**
+ * E-VERIFY V0-S3 Lv1(접힘 신뢰 행) + Lv2(펼침 evidence 카드). 유나 S4 핸드오프 §3/§4 준수.
+ * "근거 보기" 클릭 시에만 evidence 리스트를 호출한다(디디 BE 가이드 — 리스트 렌더 시 카드마다
+ * 부르지 않는 게 정합, has_evidence 하나로 Lv0 씰 표시는 충분). 그래서 fetch 전엔 건수를 모른다 —
+ * Lv1 라벨은 펼치기 전엔 카운트 없이 "증명된 완결"만, 펼친 후 실 카운트로 채워진다.
+ */
+export function EvidenceSection({ workItemId, workItemType, hasEvidence, memberMap = {}, className }: EvidenceSectionProps) {
+  const t = useTranslations('verify');
+  const tCommon = useTranslations('common');
+  const [expanded, setExpanded] = useState(false);
+  const [items, setItems] = useState<EvidenceItem[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+  const [showAll, setShowAll] = useState(false);
+
+  const fetchEvidence = useCallback(async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const res = await fetch(`/api/evidence?work_item_id=${workItemId}&work_item_type=${workItemType}`);
+      if (!res.ok) { setError(true); return; }
+      const json = (await res.json()) as { data?: EvidenceItem[] };
+      setItems(json.data ?? []);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [workItemId, workItemType]);
+
+  const handleToggle = () => {
+    if (!expanded && items === null) { void fetchEvidence(); }
+    setExpanded((v) => !v);
+  };
+
+  // 증거 0 = 신뢰 행 자체를 렌더하지 않는다(§7 상태 매트릭스 — 현행과 동일 무표시, "증명 안 됨" 금지).
+  if (!hasEvidence) return null;
+
+  const visibleItems = items && !showAll ? items.slice(0, VISIBLE_LIMIT) : items;
+  const hiddenCount = items ? items.length - VISIBLE_LIMIT : 0;
+  const signerId = items?.[0]?.created_by ?? null;
+  const signerName = signerId ? memberMap[signerId]?.name : null;
+
+  return (
+    <div className={className}>
+      <div className="rounded-lg border border-border p-2.5">
+        <button type="button" onClick={handleToggle} className="flex w-full items-center gap-2 text-left">
+          <TrustSeal />
+          <span className="text-xs font-semibold text-foreground">{t('provenCompletion')}</span>
+          {items ? (
+            <span className="text-[11px] text-muted-foreground">· {t('evidenceCount', { count: items.length })}</span>
+          ) : null}
+          <span className="ml-auto flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground">
+            {expanded ? t('evidenceHide') : t('evidenceShow')}
+            {expanded ? <ChevronUp className="h-3 w-3" aria-hidden /> : <ChevronDown className="h-3 w-3" aria-hidden />}
+          </span>
+        </button>
+
+        {expanded ? (
+          <div className="mt-2 border-t border-border pt-2">
+            {loading ? (
+              <p className="text-[11px] text-muted-foreground">{tCommon('loading')}</p>
+            ) : error ? (
+              <p className="text-[11px] text-destructive">{t('evidenceLoadError')}</p>
+            ) : items && items.length > 0 ? (
+              <>
+                {signerName ? (
+                  <p className="mb-1.5 text-[11px] text-muted-foreground">{t('evidenceSignedBy', { name: signerName })}</p>
+                ) : null}
+                <ul className="space-y-1">
+                  {(visibleItems ?? []).map((item) => {
+                    const Icon = TYPE_ICON[item.type] ?? Link2;
+                    const linkable = isLinkableRef(item.ref);
+                    const primaryText = item.note || item.ref;
+                    return (
+                      <li key={item.id} className="flex items-start gap-2 rounded-md px-1.5 py-1 hover:bg-muted/40">
+                        <Icon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+                        <div className="min-w-0 flex-1">
+                          {linkable ? (
+                            <a
+                              href={item.ref}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="flex items-center gap-1 text-xs font-medium text-foreground hover:underline"
+                            >
+                              <span className="truncate">{primaryText}</span>
+                              <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground/70" aria-hidden />
+                            </a>
+                          ) : (
+                            <span className="block truncate text-xs font-medium text-foreground">{primaryText}</span>
+                          )}
+                          {item.source ? <p className="truncate text-[11px] text-muted-foreground/80">{item.source}</p> : null}
+                        </div>
+                        <span className="mt-0.5 shrink-0 text-[10px] font-semibold text-muted-foreground">
+                          {t(TYPE_LABEL_KEY[item.type] ?? 'evidenceTypeUrl')}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+                {hiddenCount > 0 && !showAll ? (
+                  <button
+                    type="button"
+                    onClick={() => setShowAll(true)}
+                    className="mt-1.5 text-[11px] text-muted-foreground hover:text-foreground"
+                  >
+                    {t('evidenceMore', { count: hiddenCount })}
+                  </button>
+                ) : null}
+              </>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/verify/evidence-section.tsx
+++ b/apps/web/src/components/verify/evidence-section.tsx
@@ -108,7 +108,9 @@ export function EvidenceSection({ workItemId, workItemType, hasEvidence, memberM
             {loading ? (
               <p className="text-[11px] text-muted-foreground">{tCommon('loading')}</p>
             ) : error ? (
-              <p className="text-[11px] text-destructive">{t('evidenceLoadError')}</p>
+              // 유나 디자인 가디언 리뷰: fetch 실패는 시스템 에러(에이전트 판단 아님) — "안심" 표면
+              // 일관성을 위해 destructive(빨강) 대신 중립 톤.
+              <p className="text-[11px] text-muted-foreground">{t('evidenceLoadError')}</p>
             ) : items && items.length > 0 ? (
               <>
                 {signerName ? (

--- a/apps/web/src/components/verify/trust-seal.tsx
+++ b/apps/web/src/components/verify/trust-seal.tsx
@@ -1,0 +1,17 @@
+import { Check } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+
+/**
+ * E-VERIFY V0-S3 Lv0 — 보드 done 카드 신뢰 씰. 호출부가 `status==='done' && has_evidence`일 때만
+ * 렌더해야 한다(positive 단방향 — 이 컴포넌트 자체는 조건을 재검사하지 않음). 완료 badge보다 낮은
+ * 강도의 success 저강도 글리프 — 뱃지/배경/카운트 없이 단독 아이콘(유나 S4 §5 색 가이드).
+ */
+export function TrustSeal({ className }: { className?: string }) {
+  const t = useTranslations('verify');
+  return (
+    <span className={cn('inline-flex shrink-0 items-center text-success/85', className)} title={t('provenCompletion')}>
+      <Check className="h-3 w-3" strokeWidth={2.6} aria-hidden />
+    </span>
+  );
+}

--- a/apps/web/src/services/verify.ts
+++ b/apps/web/src/services/verify.ts
@@ -1,0 +1,19 @@
+/**
+ * E-VERIFY V0 — 신뢰 표면(trust surface) FE 타입. BE 계약(S1/S2, PR #1994/#1995) 그대로 미러.
+ * `GET /api/v2/evidence?work_item_id={id}&work_item_type=story|task` 응답 — 재조립 없이 서버 shape 그대로 소비.
+ */
+
+export type EvidenceType = 'url' | 'file' | 'pr' | 'deploy' | 'metric' | 'report' | 'gate_approval';
+
+export interface EvidenceItem {
+  id: string;
+  type: EvidenceType;
+  ref: string;
+  source: string | null;
+  note: string | null;
+  created_by: string | null;
+  created_at: string;
+  org_id: string;
+  work_item_id: string;
+  work_item_type: 'story' | 'task';
+}

--- a/packages/core-storage/src/interfaces/IStoryRepository.ts
+++ b/packages/core-storage/src/interfaces/IStoryRepository.ts
@@ -24,6 +24,9 @@ export interface Story {
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
+  // E-VERIFY V0-S1/S2: 실증-done 신뢰 신호. positive 단방향(false 절대 안 씀) — true면 근거 有,
+  // null이면 완전 무표시(신뢰 표면 렌더 조건 그 자체).
+  has_evidence?: boolean | null;
 }
 
 export interface CreateStoryInput {

--- a/packages/core-storage/src/interfaces/ITaskRepository.ts
+++ b/packages/core-storage/src/interfaces/ITaskRepository.ts
@@ -12,6 +12,9 @@ export interface Task {
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
+  // E-VERIFY V0-S1/S2: 실증-done 신뢰 신호(story와 동일 계약). V0-S3 FE 표면은 story 카드/상세
+  // 한정(design doc §9 scope) — task 표면은 후속 스토리 판단.
+  has_evidence?: boolean | null;
 }
 
 export interface CreateTaskInput {


### PR DESCRIPTION
## 요약
E-VERIFY V0-S3(story d7f6aca2) — 유나 UX 핸드오프(`e-verify-v0-s4-trust-surface-handoff`) + 디디 BE 계약(S1 #1994 · S2 #1995, 이미 develop에 머지됨)을 소비해 신뢰 표면 3단(Lv0/Lv1/Lv2)을 구현.

## 제1원칙
"검증 레이어의 목적은 휴먼이 에이전트를 더 들여다보게 만드는 게 아니라, 안심하고 덜 들여다봐도 되게 만드는 것." 리트머스 = "누가 주어인가" — 화면의 모든 요소는 에이전트/완결이 주어. 검사·채점·낙인 어휘 0.

## 구현
- **Lv0** (`story-card.tsx`) — done 보드 카드 footer에 조건부 ✓ 씰(`TrustSeal`, `status==='done' && has_evidence`일 때만). 증거 없으면 완전 무표시·레이아웃 시프트 없음.
- **Lv1** (`story-detail-panel.tsx`) — 완료 badge 바로 아래 접힘 신뢰 행("증명된 완결" · 근거 보기 ▾).
- **Lv2** (`components/verify/evidence-section.tsx`) — "근거 보기" 클릭 시에만 `GET /api/evidence?work_item_id=&work_item_type=` 호출(디디 BE 가이드: 리스트 렌더 단계서 카드마다 안 부르는 게 정합 — has_evidence 하나로 Lv0 씰 표시는 충분). 7종 타입(url/file/pr/deploy/metric/report/gate_approval) 아이콘·링크·출처·서명 헤더("이 완결의 근거 — {name}가 남김") 렌더, 4건 초과 시 더보기. 타입별 색 코딩 없음(전부 중립 잉크).
- 신규 thin proxy 라우트 `apps/web/src/app/api/evidence/route.ts` (기존 role-templates 패턴과 동일).
- `Story`/`Task` 타입(`@sprintable/core-storage`)에 `has_evidence?: boolean | null` 추가 — repository가 `fastapiCall<T>` 순수 캐스트라 런타임 변경 없이 타입만 정합.

## 스코프 결정
디디 BE 계약은 story·task 둘 다 `has_evidence`를 반환하지만, 유나 설계 문서 §9가 명시한 FE 표면은 "story 카드/상세" 3개뿐(task 상세 뷰 자체가 현재 이 코드베이스에 존재하지 않음 — Tasks 탭은 클릭/펼침 어포던스 없는 인라인 `<li>`). Task 표면은 이번 스코프 밖으로 두고 타입만 계약 정합상 추가.

## 검증
- `pnpm vitest run` — 163파일/957테스트 PASS(신규 5건 포함, SSR 스냅샷으로 "hasEvidence=null→무렌더"·"펼치기 전 eager fetch 없음" 회귀가드)
- `pnpm lint` — 신규 경고 0(기존 무관 파일 5건 pre-existing)
- `pnpm build` — EXIT 0
- **[실증]** dev BE(`sprintable-backend-dev-57iommnikq-du`)에 실제 evidence 레코드 1건 백필(내 S25 PR #1980 — 실제로 그 스토리를 완결시킨 진짜 PR)해 `has_evidence: null → true` 전환 확인. FE 픽셀 자체는 이 PR이 머지되어 dev 재배포된 후 확인 예정(로컬 FE↔dev BE는 JWT_SECRET 불일치로 인증 차단 — 배포된 dev FE에서만 유효한 라이브 검증).
- worktree 격리(`sprintable-mirko-verify-wt`), origin/develop 최신 기준 신규 브랜치

## 반응형/스크린샷
- 신규 표면이 컴팩트한 텍스트+아이콘 행이라 기존 브레이크포인트 그대로 상속. dev 배포 후 라이브 픽셀(라이트/다크 양테마 — 완료 badge와 ✓ 씰의 green-on-green 대비도 이때 함께 확認, 디자인 doc의 "열린 결정"항목)로 스크린샷 첨부 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)