### PR TITLE
promote: develop→main — E-VERIFY V0 (Evidence 자기증명 신뢰 표면)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3342,5 +3342,21 @@
     "viewInBoard": "View in board",
     "executionBoundaryNote": "Execution happens on your machine. Sprintable only generates the files — it doesn't run the compute.",
     "finish": "Go to dashboard"
+  },
+  "verify": {
+    "provenCompletion": "Proven completion",
+    "evidenceShow": "Show evidence",
+    "evidenceHide": "Hide evidence",
+    "evidenceCount": "{count} evidence items",
+    "evidenceSignedBy": "Evidence for this completion — left by {name}",
+    "evidenceMore": "{count} more evidence items",
+    "evidenceLoadError": "Couldn't load evidence",
+    "evidenceTypeUrl": "Link",
+    "evidenceTypeFile": "File",
+    "evidenceTypePr": "PR",
+    "evidenceTypeDeploy": "Deploy",
+    "evidenceTypeMetric": "Metric",
+    "evidenceTypeReport": "Report",
+    "evidenceTypeGateApproval": "Gate approval"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3342,5 +3342,21 @@
     "viewInBoard": "보드에서 보기",
     "executionBoundaryNote": "실행은 유저 머신에서 이뤄집니다. Sprintable은 파일만 만들고 컴퓨트는 짊어지지 않습니다.",
     "finish": "대시보드로"
+  },
+  "verify": {
+    "provenCompletion": "증명된 완결",
+    "evidenceShow": "근거 보기",
+    "evidenceHide": "근거 접기",
+    "evidenceCount": "근거 {count}건",
+    "evidenceSignedBy": "이 완결의 근거 — {name}가 남김",
+    "evidenceMore": "근거 {count}건 더 보기",
+    "evidenceLoadError": "근거를 불러오지 못했습니다",
+    "evidenceTypeUrl": "링크",
+    "evidenceTypeFile": "파일",
+    "evidenceTypePr": "PR",
+    "evidenceTypeDeploy": "배포",
+    "evidenceTypeMetric": "지표",
+    "evidenceTypeReport": "리포트",
+    "evidenceTypeGateApproval": "게이트 승인"
   }
 }

--- a/apps/web/src/app/api/evidence/route.ts
+++ b/apps/web/src/app/api/evidence/route.ts
@@ -1,0 +1,15 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+/** GET /api/evidence?work_item_id=&work_item_type= — E-VERIFY V0-S1/S2: done 항목의 근거 리스트(Lv2 펼침 전용). */
+export async function GET(request: Request) {
+  try {
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    const _r = await proxyToFastapi(request, '/api/v2/evidence');
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -8,6 +8,7 @@ import type { KanbanStory, KanbanMember, LineStatusSummary } from './types';
 import { Badge } from '@/components/ui/badge';
 import { AlertTriangle, ChevronRight, EyeOff, History, Pause, Rocket, Zap, ZapOff, type LucideIcon } from 'lucide-react';
 import { LabelChip } from '@/components/ui/label-chip';
+import { TrustSeal } from '@/components/verify/trust-seal';
 
 // E-MODERN A: 에픽 식별 dot — 기존 시맨틱 토큰만(신규 토큰/raw 팔레트 0). 신호색(warning=blocked·
 // accent-claim=agent·destructive) 회피해 의미 충돌 0. 랜덤 5색 채움 배지(loud)는 퇴출.
@@ -296,6 +297,9 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
           )}
         </div>
         <div className="flex items-center gap-2">
+          {/* E-VERIFY V0-S3 Lv0 — 증거 있는 done 카드에만(positive 단방향). 자리 예약 없이 조건부 렌더
+              (증거 없으면 완전 무표시 — 레이아웃 시프트 자체가 없음, §7 상태 매트릭스). */}
+          {story.status === 'done' && story.has_evidence ? <TrustSeal /> : null}
           {story.story_points != null ? (
             <span className="text-[11px] tabular-nums text-muted-foreground">{t('storyPointsBadge', { count: story.story_points })}</span>
           ) : null}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -17,6 +17,7 @@ import { DependencyGraph } from './dependency-graph';
 import { OutcomeResultCard, type OutcomeResult } from '@/components/outcome/outcome-result-card';
 import { StoryHypothesesSection } from '@/components/hypotheses/story-hypotheses-section';
 import { StoryMergeGate } from '@/components/cage/story-merge-gate';
+import { EvidenceSection } from '@/components/verify/evidence-section';
 import { StuckHandoffSection } from '@/components/cage/stuck-handoff-section';
 import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
 import { PrLinkSection } from '@/components/integrations/pr-link-section';
@@ -730,6 +731,14 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 })}
               </DropdownMenuContent>
             </DropdownMenu>
+            {/* E-VERIFY V0-S3 Lv1/Lv2 — 완료 badge의 연장으로 읽히도록 바로 아래. 증거 0이면
+                EvidenceSection 자체가 null 렌더(행 미노출, §7 상태 매트릭스). */}
+            <EvidenceSection
+              workItemId={story.id}
+              workItemType="story"
+              hasEvidence={story.has_evidence}
+              memberMap={memberMap}
+            />
           </div>
           <div className="flex shrink-0 items-center gap-2">
             <button

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -23,6 +23,8 @@ export interface KanbanStory {
   blocked_by?: string[];
   labels?: { id: string; name: string; color: string | null }[];
   gates?: { id: string; gate_type: string; status: string }[];
+  // E-VERIFY V0-S1/S2: 실증-done 신뢰 신호. true면 근거 有, null이면 완전 무표시.
+  has_evidence?: boolean | null;
 }
 
 export interface GateItem {

--- a/apps/web/src/components/verify/evidence-section.test.tsx
+++ b/apps/web/src/components/verify/evidence-section.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { EvidenceSection, isLinkableRef } from './evidence-section';
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+describe('isLinkableRef', () => {
+  it('treats http/https refs as linkable', () => {
+    expect(isLinkableRef('https://github.com/moonklabs/sprintable/pull/1985')).toBe(true);
+    expect(isLinkableRef('http://example.com')).toBe(true);
+  });
+
+  it('treats non-URL refs (e.g. a metric description) as non-linkable', () => {
+    expect(isLinkableRef('conversion rate +4.2%')).toBe(false);
+    expect(isLinkableRef('run-abc123-00208')).toBe(false);
+  });
+});
+
+describe('EvidenceSection (SSR snapshot — §7 상태 매트릭스)', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), { status: 200 }),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing when hasEvidence is null (증거 0 = 행 미렌더, "증명 안 됨" 표기 금지)', () => {
+    const markup = renderToStaticMarkup(
+      wrap(<EvidenceSection workItemId="s1" workItemType="story" hasEvidence={null} />),
+    );
+    expect(markup).toBe('');
+  });
+
+  it('renders nothing when hasEvidence is undefined (BE가 필드 자체를 안 내려도 안전한 폴백)', () => {
+    const markup = renderToStaticMarkup(
+      wrap(<EvidenceSection workItemId="s1" workItemType="story" hasEvidence={undefined} />),
+    );
+    expect(markup).toBe('');
+  });
+
+  it('renders the collapsed trust row when hasEvidence is true, without fetching evidence eagerly', () => {
+    const markup = renderToStaticMarkup(
+      wrap(<EvidenceSection workItemId="s1" workItemType="story" hasEvidence={true} />),
+    );
+    expect(markup).toContain('증명된 완결');
+    expect(markup).toContain('근거 보기');
+    // 디디 BE 가이드: "근거 보기" 클릭 전엔 evidence 리스트를 부르지 않는다(카드마다 N+1 방지).
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/verify/evidence-section.tsx
+++ b/apps/web/src/components/verify/evidence-section.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import {
+  ChevronDown, ChevronUp, ExternalLink, Link2, Paperclip,
+  GitPullRequest, Rocket, TrendingUp, FileText, CheckCircle2,
+} from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { TrustSeal } from './trust-seal';
+import type { EvidenceItem, EvidenceType } from '@/services/verify';
+
+const VISIBLE_LIMIT = 4;
+
+const TYPE_ICON: Record<EvidenceType, typeof Link2> = {
+  url: Link2,
+  file: Paperclip,
+  pr: GitPullRequest,
+  deploy: Rocket,
+  metric: TrendingUp,
+  report: FileText,
+  gate_approval: CheckCircle2,
+};
+
+const TYPE_LABEL_KEY: Record<EvidenceType, string> = {
+  url: 'evidenceTypeUrl',
+  file: 'evidenceTypeFile',
+  pr: 'evidenceTypePr',
+  deploy: 'evidenceTypeDeploy',
+  metric: 'evidenceTypeMetric',
+  report: 'evidenceTypeReport',
+  gate_approval: 'evidenceTypeGateApproval',
+};
+
+/** ref가 실제로 새 탭을 열 수 있는 URL인지 — 아닌 타입(예: metric 수치 설명)은 링크로 렌더하지 않는다. */
+export function isLinkableRef(ref: string): boolean {
+  return /^https?:\/\//i.test(ref);
+}
+
+interface EvidenceSectionProps {
+  workItemId: string;
+  workItemType: 'story' | 'task';
+  /** BE list/get 응답의 has_evidence 신호. false는 절대 오지 않음(null=무증거) — undefined도 무증거로 취급. */
+  hasEvidence: boolean | null | undefined;
+  memberMap?: Record<string, { name: string }>;
+  className?: string;
+}
+
+/**
+ * E-VERIFY V0-S3 Lv1(접힘 신뢰 행) + Lv2(펼침 evidence 카드). 유나 S4 핸드오프 §3/§4 준수.
+ * "근거 보기" 클릭 시에만 evidence 리스트를 호출한다(디디 BE 가이드 — 리스트 렌더 시 카드마다
+ * 부르지 않는 게 정합, has_evidence 하나로 Lv0 씰 표시는 충분). 그래서 fetch 전엔 건수를 모른다 —
+ * Lv1 라벨은 펼치기 전엔 카운트 없이 "증명된 완결"만, 펼친 후 실 카운트로 채워진다.
+ */
+export function EvidenceSection({ workItemId, workItemType, hasEvidence, memberMap = {}, className }: EvidenceSectionProps) {
+  const t = useTranslations('verify');
+  const tCommon = useTranslations('common');
+  const [expanded, setExpanded] = useState(false);
+  const [items, setItems] = useState<EvidenceItem[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+  const [showAll, setShowAll] = useState(false);
+
+  const fetchEvidence = useCallback(async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const res = await fetch(`/api/evidence?work_item_id=${workItemId}&work_item_type=${workItemType}`);
+      if (!res.ok) { setError(true); return; }
+      const json = (await res.json()) as { data?: EvidenceItem[] };
+      setItems(json.data ?? []);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [workItemId, workItemType]);
+
+  const handleToggle = () => {
+    if (!expanded && items === null) { void fetchEvidence(); }
+    setExpanded((v) => !v);
+  };
+
+  // 증거 0 = 신뢰 행 자체를 렌더하지 않는다(§7 상태 매트릭스 — 현행과 동일 무표시, "증명 안 됨" 금지).
+  if (!hasEvidence) return null;
+
+  const visibleItems = items && !showAll ? items.slice(0, VISIBLE_LIMIT) : items;
+  const hiddenCount = items ? items.length - VISIBLE_LIMIT : 0;
+  const signerId = items?.[0]?.created_by ?? null;
+  const signerName = signerId ? memberMap[signerId]?.name : null;
+
+  return (
+    <div className={className}>
+      <div className="rounded-lg border border-border p-2.5">
+        <button type="button" onClick={handleToggle} className="flex w-full items-center gap-2 text-left">
+          <TrustSeal />
+          <span className="text-xs font-semibold text-foreground">{t('provenCompletion')}</span>
+          {items ? (
+            <span className="text-[11px] text-muted-foreground">· {t('evidenceCount', { count: items.length })}</span>
+          ) : null}
+          <span className="ml-auto flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground">
+            {expanded ? t('evidenceHide') : t('evidenceShow')}
+            {expanded ? <ChevronUp className="h-3 w-3" aria-hidden /> : <ChevronDown className="h-3 w-3" aria-hidden />}
+          </span>
+        </button>
+
+        {expanded ? (
+          <div className="mt-2 border-t border-border pt-2">
+            {loading ? (
+              <p className="text-[11px] text-muted-foreground">{tCommon('loading')}</p>
+            ) : error ? (
+              // 유나 디자인 가디언 리뷰: fetch 실패는 시스템 에러(에이전트 판단 아님) — "안심" 표면
+              // 일관성을 위해 destructive(빨강) 대신 중립 톤.
+              <p className="text-[11px] text-muted-foreground">{t('evidenceLoadError')}</p>
+            ) : items && items.length > 0 ? (
+              <>
+                {signerName ? (
+                  <p className="mb-1.5 text-[11px] text-muted-foreground">{t('evidenceSignedBy', { name: signerName })}</p>
+                ) : null}
+                <ul className="space-y-1">
+                  {(visibleItems ?? []).map((item) => {
+                    const Icon = TYPE_ICON[item.type] ?? Link2;
+                    const linkable = isLinkableRef(item.ref);
+                    const primaryText = item.note || item.ref;
+                    return (
+                      <li key={item.id} className="flex items-start gap-2 rounded-md px-1.5 py-1 hover:bg-muted/40">
+                        <Icon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+                        <div className="min-w-0 flex-1">
+                          {linkable ? (
+                            <a
+                              href={item.ref}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="flex items-center gap-1 text-xs font-medium text-foreground hover:underline"
+                            >
+                              <span className="truncate">{primaryText}</span>
+                              <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground/70" aria-hidden />
+                            </a>
+                          ) : (
+                            <span className="block truncate text-xs font-medium text-foreground">{primaryText}</span>
+                          )}
+                          {item.source ? <p className="truncate text-[11px] text-muted-foreground/80">{item.source}</p> : null}
+                        </div>
+                        <span className="mt-0.5 shrink-0 text-[10px] font-semibold text-muted-foreground">
+                          {t(TYPE_LABEL_KEY[item.type] ?? 'evidenceTypeUrl')}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+                {hiddenCount > 0 && !showAll ? (
+                  <button
+                    type="button"
+                    onClick={() => setShowAll(true)}
+                    className="mt-1.5 text-[11px] text-muted-foreground hover:text-foreground"
+                  >
+                    {t('evidenceMore', { count: hiddenCount })}
+                  </button>
+                ) : null}
+              </>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/verify/trust-seal.tsx
+++ b/apps/web/src/components/verify/trust-seal.tsx
@@ -1,0 +1,17 @@
+import { Check } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+
+/**
+ * E-VERIFY V0-S3 Lv0 — 보드 done 카드 신뢰 씰. 호출부가 `status==='done' && has_evidence`일 때만
+ * 렌더해야 한다(positive 단방향 — 이 컴포넌트 자체는 조건을 재검사하지 않음). 완료 badge보다 낮은
+ * 강도의 success 저강도 글리프 — 뱃지/배경/카운트 없이 단독 아이콘(유나 S4 §5 색 가이드).
+ */
+export function TrustSeal({ className }: { className?: string }) {
+  const t = useTranslations('verify');
+  return (
+    <span className={cn('inline-flex shrink-0 items-center text-success/85', className)} title={t('provenCompletion')}>
+      <Check className="h-3 w-3" strokeWidth={2.6} aria-hidden />
+    </span>
+  );
+}

--- a/apps/web/src/services/verify.ts
+++ b/apps/web/src/services/verify.ts
@@ -1,0 +1,19 @@
+/**
+ * E-VERIFY V0 — 신뢰 표면(trust surface) FE 타입. BE 계약(S1/S2, PR #1994/#1995) 그대로 미러.
+ * `GET /api/v2/evidence?work_item_id={id}&work_item_type=story|task` 응답 — 재조립 없이 서버 shape 그대로 소비.
+ */
+
+export type EvidenceType = 'url' | 'file' | 'pr' | 'deploy' | 'metric' | 'report' | 'gate_approval';
+
+export interface EvidenceItem {
+  id: string;
+  type: EvidenceType;
+  ref: string;
+  source: string | null;
+  note: string | null;
+  created_by: string | null;
+  created_at: string;
+  org_id: string;
+  work_item_id: string;
+  work_item_type: 'story' | 'task';
+}

--- a/backend/alembic/versions/0169_evidence_table.py
+++ b/backend/alembic/versions/0169_evidence_table.py
@@ -1,0 +1,52 @@
+"""E-VERIFY V0-S1(story 5a5ba27b): evidence 테이블 — 에이전트 자기증명 1급 객체.
+
+Revision ID: 0169
+Revises: 0168
+Create Date: 2026-07-10
+
+Gate(0075/0110류)와 동형 polymorphic 패턴 — work_item_id/work_item_type에 FK 없음(Story/Task
+양쪽 커버, 신규 domain 확장도 마이그 불요). 순수 additive 신규 테이블 — 기존 스키마 무회귀.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0169"
+down_revision = "0168"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "evidence",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("work_item_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("work_item_type", sa.String(length=20), nullable=False),
+        sa.Column("type", sa.String(length=20), nullable=False),
+        sa.Column("ref", sa.Text(), nullable=False),
+        sa.Column("source", sa.Text(), nullable=True),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column("created_by", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index("ix_evidence_org_id", "evidence", ["org_id"])
+    op.create_index("ix_evidence_work_item_id", "evidence", ["work_item_id"])
+    op.create_index("ix_evidence_work_item_lookup", "evidence", ["work_item_id", "work_item_type"])
+    op.create_check_constraint(
+        "ck_evidence_type",
+        "evidence",
+        "type IN ('url','file','pr','deploy','metric','report','gate_approval')",
+    )
+    op.create_check_constraint(
+        "ck_evidence_work_item_type",
+        "evidence",
+        "work_item_type IN ('story','task')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("evidence")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,7 +57,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import a2a, account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, retros, rewards, role_templates, runtime_capabilities, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import a2a, account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, retros, rewards, role_templates, runtime_capabilities, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -166,6 +166,7 @@ app.include_router(verdict_capture.router)
 app.include_router(trust_scores.router)
 app.include_router(hitl_config.router)
 app.include_router(gates.router)
+app.include_router(evidence.router)
 app.include_router(github_integration.router)
 app.include_router(gate_config.router)
 app.include_router(gate_config.org_router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -7,6 +7,7 @@ from app.models.agent_run import AgentRun
 from app.models.agent_session import AgentSession
 from app.models.bridge import BridgeChannelMapping, BridgeUserMapping
 from app.models.embedding import Embedding
+from app.models.evidence import Evidence
 from app.models.gate import Gate
 from app.models.hitl import HitlPolicy, HitlRequest
 from app.models.mockup import MockupComponent, MockupPage, MockupScenario, MockupVersion, UsageMeter

--- a/backend/app/models/evidence.py
+++ b/backend/app/models/evidence.py
@@ -1,0 +1,37 @@
+"""E-VERIFY V0-S1(story 5a5ba27b): Evidence 1급 객체 — 에이전트 자기증명.
+
+done의 검사지가 아니라 에이전트가 자기 완결을 표현하는 서명(blueprint `e-verify-v0-blueprint`
+§0 제1원칙: 감시가 아니라 신뢰). Gate(app/models/gate.py)의 검증된 polymorphic 패턴을 그대로
+재사용 — work_item_id/work_item_type에 FK 없음(Story/Task 양쪽 커버), org_id만 인덱스.
+"""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+EVIDENCE_TYPES = frozenset({"url", "file", "pr", "deploy", "metric", "report", "gate_approval"})
+
+# gate_approval은 시스템(V0-S2 게이트 승인 훅)만 생성 — 공개 API/MCP로 직접 생성 시 스푸핑
+# 위험(에이전트가 "이거 승인됐음" 허위 서명 가능)이라 라우터 레벨에서 별도 차단.
+_CLIENT_CREATABLE_TYPES = EVIDENCE_TYPES - {"gate_approval"}
+
+
+class Evidence(Base):
+    __tablename__ = "evidence"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    work_item_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    work_item_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    type: Mapped[str] = mapped_column(String(20), nullable=False)
+    ref: Mapped[str] = mapped_column(Text, nullable=False)
+    source: Mapped[str | None] = mapped_column(Text, nullable=True)
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/routers/evidence.py
+++ b/backend/app/routers/evidence.py
@@ -1,0 +1,167 @@
+"""E-VERIFY V0-S1(story 5a5ba27b): Evidence CRD(D 없는 U — 자기증명은 불변) — story/task 첨부."""
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, field_validator
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.models.evidence import _CLIENT_CREATABLE_TYPES, Evidence
+from app.models.pm import Story, Task
+from app.services.member_resolver import resolve_member
+from app.services.project_auth import has_project_access
+
+router = APIRouter(prefix="/api/v2/evidence", tags=["evidence"])
+
+_WORK_ITEM_TYPES = frozenset({"story", "task"})
+
+
+class EvidenceCreateRequest(BaseModel):
+    work_item_id: uuid.UUID
+    work_item_type: str
+    type: str
+    ref: str
+    source: str | None = None
+    note: str | None = None
+
+    @field_validator("work_item_type")
+    @classmethod
+    def _validate_work_item_type(cls, v: str) -> str:
+        if v not in _WORK_ITEM_TYPES:
+            raise ValueError(f"work_item_type must be one of {sorted(_WORK_ITEM_TYPES)}")
+        return v
+
+    @field_validator("type")
+    @classmethod
+    def _validate_type(cls, v: str) -> str:
+        # gate_approval은 시스템(V0-S2 게이트 승인 훅) 전용 — 공개 API로 직접 생성 시 "이거
+        # 승인됐음" 허위 서명 스푸핑 위험이라 여기서 차단(내부 서비스 호출은 이 검증을 안 탐).
+        if v not in _CLIENT_CREATABLE_TYPES:
+            raise ValueError(
+                f"type must be one of {sorted(_CLIENT_CREATABLE_TYPES)} "
+                "(gate_approval은 게이트 승인 시 시스템이 자동 생성)"
+            )
+        return v
+
+
+class EvidenceResponse(BaseModel):
+    id: uuid.UUID
+    org_id: uuid.UUID
+    work_item_id: uuid.UUID
+    work_item_type: str
+    type: str
+    ref: str
+    source: str | None
+    note: str | None
+    created_by: uuid.UUID
+    created_at: Any
+
+    model_config = {"from_attributes": True}
+
+
+async def _assert_work_item_access(
+    session: AsyncSession, work_item_id: uuid.UUID, work_item_type: str,
+    caller_id: uuid.UUID, org_id: uuid.UUID,
+) -> None:
+    """work_item 존재 + caller의 project 접근권 검증(mutation 대상 project-scope 강제
+    — [[feedback_mutation_target_resource_project_scope]] 동형)."""
+    if work_item_type == "story":
+        story = (await session.execute(
+            select(Story).where(Story.id == work_item_id, Story.org_id == org_id)
+        )).scalar_one_or_none()
+        if story is None:
+            raise HTTPException(status_code=404, detail="Story not found")
+        project_id = story.project_id
+    else:
+        task = (await session.execute(
+            select(Task).where(Task.id == work_item_id, Task.org_id == org_id)
+        )).scalar_one_or_none()
+        if task is None:
+            raise HTTPException(status_code=404, detail="Task not found")
+        story = (await session.execute(
+            select(Story).where(Story.id == task.story_id)
+        )).scalar_one_or_none()
+        if story is None:
+            raise HTTPException(status_code=404, detail="Parent story not found")
+        project_id = story.project_id
+
+    if not await has_project_access(session, caller_id, project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
+
+@router.post("", response_model=EvidenceResponse, status_code=201)
+async def create_evidence(
+    body: EvidenceCreateRequest,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> Evidence:
+    caller = await resolve_member(auth, org_id, session)
+    await _assert_work_item_access(session, body.work_item_id, body.work_item_type, caller.id, org_id)
+
+    evidence = Evidence(
+        id=uuid.uuid4(),
+        org_id=org_id,
+        work_item_id=body.work_item_id,
+        work_item_type=body.work_item_type,
+        type=body.type,
+        ref=body.ref,
+        source=body.source,
+        note=body.note,
+        created_by=caller.id,
+    )
+    session.add(evidence)
+    await session.commit()
+    await session.refresh(evidence)
+    return evidence
+
+
+@router.get("", response_model=list[EvidenceResponse])
+async def list_evidence(
+    work_item_id: uuid.UUID = Query(...),
+    work_item_type: str = Query(...),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> list[Evidence]:
+    if work_item_type not in _WORK_ITEM_TYPES:
+        raise HTTPException(status_code=400, detail=f"work_item_type must be one of {sorted(_WORK_ITEM_TYPES)}")
+
+    caller = await resolve_member(auth, org_id, session)
+    await _assert_work_item_access(session, work_item_id, work_item_type, caller.id, org_id)
+
+    result = await session.execute(
+        select(Evidence).where(
+            Evidence.org_id == org_id,
+            Evidence.work_item_id == work_item_id,
+            Evidence.work_item_type == work_item_type,
+        ).order_by(Evidence.created_at.asc())
+    )
+    return list(result.scalars().all())
+
+
+@router.delete("/{id}", status_code=204)
+async def delete_evidence(
+    id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> None:
+    """생성자 본인만 철회 가능(타인의 서명을 지울 수 있으면 신뢰 표면이 무너짐) — org-admin도
+    포함하지 않음(의도적, blueprint §0 감시-축 회피: admin이 에이전트 증거를 지울 수 있으면
+    "누가 주어인가"가 다시 휴먼으로 뒤집힘)."""
+    evidence = (await session.execute(
+        select(Evidence).where(Evidence.id == id, Evidence.org_id == org_id)
+    )).scalar_one_or_none()
+    if evidence is None:
+        raise HTTPException(status_code=404, detail="Evidence not found")
+
+    caller = await resolve_member(auth, org_id, session)
+    if evidence.created_by != caller.id:
+        raise HTTPException(status_code=403, detail="Only the creator can retract evidence")
+
+    await session.delete(evidence)
+    await session.commit()

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -96,6 +96,7 @@ async def list_stories(
     if no_sprint and project_id:
         stories = await repo.list_backlog(project_id, limit=limit)
         await _attach_assignee_ids(repo.session, repo.org_id, stories)
+        await _attach_has_evidence(repo.session, stories)
         return [StoryResponse.model_validate(s) for s in stories]
 
     # CB-S4: status + project_id 조합 시 board 쿼리 (order_by + cursor + done 7일 제한)
@@ -114,6 +115,7 @@ async def list_stories(
             if stories:
                 response.headers["X-Next-Cursor"] = stories[-1].created_at.isoformat()
         await _attach_assignee_ids(repo.session, repo.org_id, stories)
+        await _attach_has_evidence(repo.session, stories)
         return [StoryResponse.model_validate(s) for s in stories]
 
     filters: dict = {}
@@ -129,6 +131,7 @@ async def list_stories(
         filters["status"] = status_filter
     stories = await repo.list(limit=limit, **filters)
     await _attach_assignee_ids(repo.session, repo.org_id, stories)
+    await _attach_has_evidence(repo.session, stories)
     return [StoryResponse.model_validate(s) for s in stories]
 
 
@@ -146,6 +149,20 @@ async def _attach_assignee_ids(
         if not ids:
             ids = [s.assignee_id] if s.assignee_id else []
         s.assignee_ids = ids  # 매핑되지 않은 transient 속성 — from_attributes 전용
+
+
+async def _attach_has_evidence(session: AsyncSession, stories: list[Story]) -> None:
+    """E-VERIFY V0-S2(story 3fbd048d): evidence 있는 story에 has_evidence=True(transient attr) —
+    없으면 미설정(StoryResponse 기본값 None 유지, positive 단방향·부정 신호 0).
+    _attach_assignee_ids와 동형 배치 패턴."""
+    if not stories:
+        return
+    from app.services.evidence_service import batch_has_evidence
+
+    ids_with_evidence = await batch_has_evidence(session, [s.id for s in stories], "story")
+    for s in stories:
+        if s.id in ids_with_evidence:
+            s.has_evidence = True
 
 
 async def _upsert_assignee_participation(
@@ -345,6 +362,7 @@ async def get_story(
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")
     await _attach_assignee_ids(repo.session, repo.org_id, [story])
+    await _attach_has_evidence(repo.session, [story])
     return StoryResponse.model_validate(story)
 
 
@@ -541,6 +559,7 @@ async def bulk_update_stories(
         await db.refresh(s)
     # refresh 後 transient assignee_ids 세팅(refresh 는 매핑 컬럼만 reload·transient 보존).
     await _attach_assignee_ids(db, repo.org_id, updated)
+    await _attach_has_evidence(db, updated)
 
     # 응답(violation flag 포함) + violation 이벤트 페이로드를 commit 前에 빌드(commit 시 attr expire→
     # MissingGreenlet 방지·기존 results 빌드와 동일 시점). 이벤트 발화는 commit 後(/status 와 동일 순서).
@@ -822,6 +841,7 @@ async def update_story(
         )
 
     await _attach_assignee_ids(db, repo.org_id, [story])
+    await _attach_has_evidence(db, [story])
     return StoryResponse.model_validate(story)
 
 
@@ -1040,6 +1060,7 @@ async def update_story_status(
         )
 
     await _attach_assignee_ids(db, repo.org_id, [story])
+    await _attach_has_evidence(db, [story])
     resp = StoryResponse.model_validate(story)
     # 정공법 A: 비순차 점프면 응답에 violation flag(차단 없이 가시화·/bulk 와 동일 SSOT).
     resp.violation = build_violation_flag(old_status, story.status)

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -6,9 +6,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
-from app.models.pm import Story
+from app.models.pm import Story, Task
 from app.repositories.task import TaskRepository
 from app.schemas.task import TaskCreate, TaskResponse, TaskUpdate
+from app.services.evidence_service import batch_has_evidence
 from app.services.notification_dispatch import dispatch_notification
 
 router = APIRouter(prefix="/api/v2/tasks", tags=["tasks"])
@@ -19,6 +20,16 @@ def _get_repo(
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> TaskRepository:
     return TaskRepository(session, org_id)
+
+
+async def _attach_has_evidence(session: AsyncSession, tasks: list[Task]) -> None:
+    """E-VERIFY V0-S2(story 3fbd048d) — stories.py `_attach_has_evidence`와 동형(배치 조회)."""
+    if not tasks:
+        return
+    ids_with_evidence = await batch_has_evidence(session, [t.id for t in tasks], "task")
+    for t in tasks:
+        if t.id in ids_with_evidence:
+            t.has_evidence = True
 
 
 @router.get("", response_model=list[TaskResponse])
@@ -36,6 +47,7 @@ async def list_tasks(
     if status_filter:
         filters["status"] = status_filter
     tasks = await repo.list(**filters)
+    await _attach_has_evidence(repo.session, tasks)
     return [TaskResponse.model_validate(t) for t in tasks]
 
 
@@ -72,6 +84,7 @@ async def get_task(
     task = await repo.get(id)
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found")
+    await _attach_has_evidence(repo.session, [task])
     return TaskResponse.model_validate(task)
 
 
@@ -107,6 +120,7 @@ async def update_task(
                 # S2: 멀티프로젝트 에이전트 assignee를 스토리 프로젝트로 정확 라우팅
                 source_project_id=story_row.project_id,
             )
+    await _attach_has_evidence(db, [task])
     return TaskResponse.model_validate(task)
 
 

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -211,3 +211,13 @@ class StoryResponse(BaseModel):
         # violation 은 ORM 컬럼이 아님 — from_attributes 시 비-dict(MagicMock auto-attr 등)는 None 처리
         # (_coerce_attachments 와 동형). 실제 flag 는 라우터가 model_validate 後 dict 로 할당한다.
         return v if isinstance(v, dict) else None
+
+    # E-VERIFY V0-S2(story 3fbd048d): evidence-backed 신호(positive 단방향) — True(있음) 또는
+    # None(신호 부재, violation과 동형 — 부정값 False 절대 안 씀). ORM 컬럼 아님·라우터가
+    # model_validate 前 transient attr로 세팅(assignee_ids 패턴 동형).
+    has_evidence: bool | None = None
+
+    @field_validator("has_evidence", mode="before")
+    @classmethod
+    def _coerce_has_evidence(cls, v):
+        return v if isinstance(v, bool) else None

--- a/backend/app/schemas/task.py
+++ b/backend/app/schemas/task.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class TaskCreate(BaseModel):
@@ -32,3 +32,12 @@ class TaskResponse(BaseModel):
     story_points: int | None = None
     created_at: datetime
     updated_at: datetime
+
+    # E-VERIFY V0-S2(story 3fbd048d): evidence-backed 신호(positive 단방향) — story.has_evidence와
+    # 동형(True 또는 None, False 없음). 라우터가 model_validate 前 transient attr로 세팅.
+    has_evidence: bool | None = None
+
+    @field_validator("has_evidence", mode="before")
+    @classmethod
+    def _coerce_has_evidence(cls, v):
+        return v if isinstance(v, bool) else None

--- a/backend/app/services/evidence_service.py
+++ b/backend/app/services/evidence_service.py
@@ -1,0 +1,54 @@
+"""E-VERIFY V0-S2(story 3fbd048d): evidence-backed 신호 + gate_approval 자동 편입."""
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.evidence import Evidence
+from app.models.gate import Gate
+
+_EVIDENCE_WORK_ITEM_TYPES = frozenset({"story", "task"})
+
+
+async def batch_has_evidence(
+    session: AsyncSession, work_item_ids: list[uuid.UUID], work_item_type: str
+) -> set[uuid.UUID]:
+    """evidence가 1건이라도 있는 work_item_id 집합(N+1 회피 배치 조회) — story/task 응답의
+    has_evidence(positive 단방향) 신호원."""
+    if not work_item_ids:
+        return set()
+    result = await session.execute(
+        select(Evidence.work_item_id.distinct()).where(
+            Evidence.work_item_type == work_item_type,
+            Evidence.work_item_id.in_(work_item_ids),
+        )
+    )
+    return set(result.scalars().all())
+
+
+async def create_gate_approval_evidence_if_applicable(
+    session: AsyncSession, gate: Gate, new_status: str, resolver_id: uuid.UUID | None,
+) -> None:
+    """HITL gate 승인 → gate_approval evidence 자동 편입(blueprint §2-3, 휴먼이 이미 승인한 것도
+    증명의 일부). approved 전이 + work_item_type이 evidence 스코프(story/task) 안일 때만 —
+    reject/void/hold나 doc 등 V0 스코프 밖 work_item_type은 no-op(순수 additive, 회귀 0).
+    공개 API의 gate_approval 차단(app/routers/evidence.py)과 짝 — 이 경로만 유일한 생성 지점."""
+    if new_status != "approved":
+        return
+    if gate.work_item_type not in _EVIDENCE_WORK_ITEM_TYPES:
+        return
+    if resolver_id is None:
+        # approved 전이는 라우터에서 human-only 강제(agent API키 403)라 정상 경로엔 항상 있음 —
+        # 없으면(내부 직호출 등 예외 경로) 귀속시킬 사람이 없으므로 evidence 생성 skip(무회귀).
+        return
+    session.add(Evidence(
+        id=uuid.uuid4(),
+        org_id=gate.org_id,
+        work_item_id=gate.work_item_id,
+        work_item_type=gate.work_item_type,
+        type="gate_approval",
+        ref=str(gate.id),
+        source="gate",
+        note=gate.resolution_note,
+        created_by=resolver_id,
+    ))

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -157,6 +157,12 @@ async def transition_gate(
         # HITL crux(story 7726a003) — A2A task INPUT_REQUIRED 복귀. writer 미배선이라 오늘은 no-op.
         await _resume_a2a_task_on_gate_resolve(session, gate, new_status)
 
+    # E-VERIFY V0-S2(story 3fbd048d): 휴먼 gate 승인 → gate_approval evidence 자동 편입(순수
+    # additive — approved+story/task work_item_type 아니면 no-op).
+    from app.services.evidence_service import create_gate_approval_evidence_if_applicable
+
+    await create_gate_approval_evidence_if_applicable(session, gate, new_status, resolver_id)
+
     await session.flush()
     await session.refresh(gate)
     return gate

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -58,6 +58,11 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # 아님). A2A 위임을 받은 어떤 역할의 에이전트든 default_tool_groups와 무관하게 써야 하는 협업
     # 도구라 특정 도메인 그룹에 안 묶는다(lock/unlock과 동일 논리).
     "sprintable_link_gate_to_task",
+    # E-VERIFY V0-S1(story 5a5ba27b): add_evidence — story/task 자기증명 첨부. work_item_id로
+    # story든 task든 첨부 가능해 단일 도메인 그룹(stories 또는 tasks)에 못 묶고, link_gate_to_task와
+    # 동형(자기 작업에 self-proof 첨부 = 데이터 파괴 아닌 협업/증명 유틸) — 어떤 역할의 working
+    # agent든 default_tool_groups 무관하게 done 첨부해야 하므로 always-allow.
+    "sprintable_add_evidence",
 })
 
 # scope 토큰: 그룹명 외에 read/write(레거시·전체 비파괴 의미), admin/destructive(파괴적 허용)
@@ -163,6 +168,9 @@ _ALWAYS_ALLOWED_PATH_PREFIXES: tuple[str, ...] = (
     "/api/v2/auth",
     "/api/v2/current-project",
     "/api/v2/agent",
+    # E-VERIFY V0-S1: evidence는 story/task 어느 쪽이든 첨부되는 cross-cutting 자기증명이라
+    # 단일 도메인 그룹에 안 묶임(_ALWAYS_ALLOWED의 sprintable_add_evidence와 동일 근거).
+    "/api/v2/evidence",
 )
 
 # path-prefix → toolset group(라우터 리소스 정렬). 모든 group 은 ALL_GROUPS 소속이어야 함.
@@ -270,6 +278,8 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_get_loop_context",
     # a2a HITL writer (E-A2A-완성 S-A3)
     "sprintable_link_gate_to_task",
+    # evidence (E-VERIFY V0-S1)
+    "sprintable_add_evidence",
 )
 
 # picker 표시 순서(비파괴 먼저). order 필드 힌트 + 배열 순서 둘 다 이 순서.

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -28,6 +28,7 @@ from .schemas import SprintableInput
 # (백엔드 app/services/mcp_toolset.py와 동일 규칙 유지·SSOT는 백엔드 매니페스트).
 from .toolset import is_tool_allowed
 from .tools.a2a import LinkGateToTaskInput, link_gate_to_task
+from .tools.evidence import AddEvidenceInput, add_evidence
 from .tools.agent_runs import (
     EmitEventInput, PollEventsInput, UpdateRunStatusInput,
     emit_event, poll_events, update_run_status,
@@ -497,6 +498,11 @@ _TOOL_DEFS: list[tuple] = [
      "이 gate가 이 A2A task를 블록한다고 명시 선언 — 외부 GetTask가 INPUT_REQUIRED로 승격되고,"
      " 사람이 gate를 승인/거부하면 task가 자동으로 WORKING/REJECTED 복귀한다.",
      LinkGateToTaskInput, link_gate_to_task),
+    # Evidence 자기증명 (1) — E-VERIFY V0-S1
+    ("sprintable_add_evidence",
+     "done을 스스로 증명하는 자기 서명 첨부(PR·배포·지표·발행물 링크 등) — story/task에 evidence"
+     " 남김. 선택제(첨부 안 해도 무불이익).",
+     AddEvidenceInput, add_evidence),
     # Chat (3)
     ("sprintable_send_chat_message",
      "conversation thread에 채팅 메시지 발송.",

--- a/backend/sprintable_mcp/tools/evidence.py
+++ b/backend/sprintable_mcp/tools/evidence.py
@@ -1,0 +1,37 @@
+"""Evidence 자기증명 MCP 도구(1개) — E-VERIFY V0-S1(story 5a5ba27b)."""
+from __future__ import annotations
+
+from mcp.types import TextContent
+
+from ..api_client import client
+from ..response import err, ok
+from ..schemas import SprintableInput
+
+
+class AddEvidenceInput(SprintableInput):
+    work_item_id: str
+    work_item_type: str  # "story" | "task"
+    type: str  # url | file | pr | deploy | metric | report (gate_approval은 시스템 전용)
+    ref: str
+    source: str | None = None
+    note: str | None = None
+
+
+async def add_evidence(args: AddEvidenceInput) -> list[TextContent]:
+    """done을 스스로 증명하는 자기 서명 첨부(검사지 아님) — story/task에 evidence(PR·배포·지표·
+    발행물 링크 등)를 남긴다. 강제 아닌 선택제(경고나 낙인은 없음, 없으면 현행과 동일)."""
+    try:
+        payload = {
+            "work_item_id": args.work_item_id,
+            "work_item_type": args.work_item_type,
+            "type": args.type,
+            "ref": args.ref,
+        }
+        if args.source is not None:
+            payload["source"] = args.source
+        if args.note is not None:
+            payload["note"] = args.note
+        result = await client.post("/api/v2/evidence", json=payload)
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))

--- a/backend/sprintable_mcp/toolset.py
+++ b/backend/sprintable_mcp/toolset.py
@@ -50,6 +50,10 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # 특정 도메인 그룹(stories/tasks 등)에 안 묶는 이유도 lock/unlock과 동일 — A2A 위임을 받은
     # 어떤 역할의 에이전트든 default_tool_groups와 무관하게 써야 하는 협업 도구.
     "sprintable_link_gate_to_task",
+    # E-VERIFY V0-S1(story 5a5ba27b): add_evidence — story/task 어느 쪽에나 붙는 자기증명 첨부
+    # 유틸이라 단일 도메인 그룹에 못 묶음. link_gate_to_task와 동일 논리로 core 취급(백엔드
+    # SSOT와 동기화, app/services/mcp_toolset.py 참고).
+    "sprintable_add_evidence",
 })
 
 _LEGACY_SCOPES: frozenset[str] = frozenset({"read", "write"})

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -1,4 +1,4 @@
-"""S3-6: 시스템 콜 계약 검증 — 97개 도구 등록 + 스키마 무결성 (Phase 3 완료)."""
+"""S3-6: 시스템 콜 계약 검증 — 98개 도구 등록 + 스키마 무결성 (Phase 3 완료)."""
 from __future__ import annotations
 
 import os
@@ -79,13 +79,15 @@ EXPECTED_TOOLS = {
     "sprintable_lock_files", "sprintable_unlock_files",
     # a2a HITL writer (1) — E-A2A-완성 S-A3
     "sprintable_link_gate_to_task",
+    # evidence (1) — E-VERIFY V0-S1
+    "sprintable_add_evidence",
     # smoke
     "ping",
 }
 
 
 def test_total_tool_count():
-    assert len(_TOOLS) == 97
+    assert len(_TOOLS) == 98
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_e_verify_v0_s1_evidence_realdb.py
+++ b/backend/tests/test_e_verify_v0_s1_evidence_realdb.py
@@ -1,0 +1,281 @@
+"""E-VERIFY V0-S1(story 5a5ba27b): Evidence CRD API — 실 Postgres 검증.
+
+team_members는 뷰(members⋈project_access)라 `resolve_member`/`has_project_access`의 에이전트
+분기가 실동작하려면 실 Alembic 마이그(진짜 VIEW)가 필요 — create_all은 부적합
+([[reference_local_migration_verify]] 패턴)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요 — alembic upgrade heads 적용된 DB"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    """established pattern(test_a2a_sa1_deadline_sweeper_realdb.py) — 전역 engine cross-loop 방지."""
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org + project + agent(grant된) + story + task."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+    from app.models.pm import Story, Task
+
+    org = Organization(id=uuid.uuid4(), name="V0-S1 Org", slug=f"v0s1-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="V0-S1 Project")
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Evidence Agent", is_active=True)
+    other_agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Other Agent", is_active=True)
+    session.add_all([project, agent, other_agent])
+    await session.commit()
+
+    grant = ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted", role="member",
+    )
+    other_grant = ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=other_agent.id, permission="granted", role="member",
+    )
+    session.add_all([grant, other_grant])
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="V0-S1 Story", status="in-progress")
+    session.add(story)
+    await session.commit()
+
+    task = Task(id=uuid.uuid4(), org_id=org.id, story_id=story.id, title="V0-S1 Task", status="in-progress")
+    session.add(task)
+    await session.commit()
+
+    return org.id, project.id, agent.id, other_agent.id, story.id, task.id
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+def _auth_override(member_id, org_id):
+    async def _auth():
+        from app.dependencies.auth import AuthContext
+        # api_key_id 신호가 있어야 resolve_member가 agent(API키) 분기로 간다([[feedback_actor_type_failclosed]]).
+        return AuthContext(
+            user_id=str(member_id), email="agent@test",
+            claims={"app_metadata": {"org_id": str(org_id), "api_key_id": "test-key"}},
+        )
+    return _auth
+
+
+async def _setup_app(app, Session, member_id, org_id):
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            yield s
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth_override(member_id, org_id)
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_create_and_list_evidence_on_story():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id, agent_id, _other_id, story_id, _task_id = await _seed(s)
+
+        await _setup_app(app, Session, agent_id, org_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(story_id), "work_item_type": "story",
+                "type": "pr", "ref": "https://github.com/org/repo/pull/1", "source": "github",
+            })
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["type"] == "pr"
+            assert body["created_by"] == str(agent_id)
+
+            list_resp = await client.get(
+                "/api/v2/evidence", params={"work_item_id": str(story_id), "work_item_type": "story"}
+            )
+            assert list_resp.status_code == 200
+            items = list_resp.json()
+            assert len(items) == 1
+            assert items[0]["ref"] == "https://github.com/org/repo/pull/1"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_evidence_on_task_resolves_project_via_story():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id, agent_id, _other_id, _story_id, task_id = await _seed(s)
+
+        await _setup_app(app, Session, agent_id, org_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(task_id), "work_item_type": "task",
+                "type": "deploy", "ref": "https://console.cloud.google.com/run/deploy/1",
+            })
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_gate_approval_type_rejected_from_public_api():
+    """스푸핑 방지 — gate_approval은 시스템 전용, 공개 API로 직접 생성 400."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id, agent_id, _other_id, story_id, _task_id = await _seed(s)
+
+        await _setup_app(app, Session, agent_id, org_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(story_id), "work_item_type": "story",
+                "type": "gate_approval", "ref": "fake-approval",
+            })
+            assert resp.status_code == 422, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_project_access_forbidden():
+    """target project에 grant 없는 에이전트는 403(mutation 대상 project-scope 강제) — stranger는
+    *다른* project에 grant를 둬 resolve_member(team_members 뷰 조회)는 통과시키고, has_project_access
+    단독으로 걸리게 격리한다(완전 무-grant agent는 team_members 뷰에 행 자체가 없어 resolve_member가
+    먼저 400으로 죽어 이 403 경로를 못 격리 — 실측으로 확認된 별개 계층)."""
+    from app.main import app
+    from app.models.member import Member
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id, agent_id, _other_id, story_id, _task_id = await _seed(s)
+            other_project = Project(id=uuid.uuid4(), org_id=org_id, name="Other Project")
+            stranger = Member(id=uuid.uuid4(), org_id=org_id, type="agent", name="Stranger", is_active=True)
+            s.add_all([other_project, stranger])
+            await s.commit()
+            stranger_grant = ProjectAccess(
+                id=uuid.uuid4(), project_id=other_project.id, member_id=stranger.id,
+                permission="granted", role="member",
+            )
+            s.add(stranger_grant)
+            await s.commit()
+            stranger_id = stranger.id
+
+        await _setup_app(app, Session, stranger_id, org_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(story_id), "work_item_type": "story",
+                "type": "url", "ref": "https://example.com",
+            })
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_delete_by_creator_succeeds_by_other_forbidden():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id, agent_id, other_agent_id, story_id, _task_id = await _seed(s)
+
+        await _setup_app(app, Session, agent_id, org_id)
+        client = _client_for(app)
+        evidence_id = None
+        try:
+            create_resp = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(story_id), "work_item_type": "story",
+                "type": "report", "ref": "https://example.com/report",
+            })
+            evidence_id = create_resp.json()["id"]
+
+            # 타인(다른 agent)이 삭제 시도 → 403
+            app.dependency_overrides.clear()
+            await _setup_app(app, Session, other_agent_id, org_id)
+            forbidden_resp = await client.delete(f"/api/v2/evidence/{evidence_id}")
+            assert forbidden_resp.status_code == 403, forbidden_resp.text
+
+            # 생성자 본인은 삭제 성공
+            app.dependency_overrides.clear()
+            await _setup_app(app, Session, agent_id, org_id)
+            ok_resp = await client.delete(f"/api/v2/evidence/{evidence_id}")
+            assert ok_resp.status_code == 204, ok_resp.text
+
+            list_resp = await client.get(
+                "/api/v2/evidence", params={"work_item_id": str(story_id), "work_item_type": "story"}
+            )
+            assert list_resp.json() == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_verify_v0_s2_evidence_signal_realdb.py
+++ b/backend/tests/test_e_verify_v0_s2_evidence_signal_realdb.py
@@ -1,0 +1,283 @@
+"""E-VERIFY V0-S2(story 3fbd048d): has_evidence 신호 + gate_approval 자동 편입 — 실 Postgres 검증."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+    from app.models.pm import Story, Task
+
+    org = Organization(id=uuid.uuid4(), name="V0-S2 Org", slug=f"v0s2-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="V0-S2 Project")
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Evidence Agent", is_active=True)
+    session.add_all([project, agent])
+    await session.commit()
+
+    grant = ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted", role="member",
+    )
+    session.add(grant)
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="V0-S2 Story", status="in-progress")
+    session.add(story)
+    await session.commit()
+
+    task = Task(id=uuid.uuid4(), org_id=org.id, story_id=story.id, title="V0-S2 Task", status="in-progress")
+    session.add(task)
+    await session.commit()
+
+    return org.id, project.id, agent.id, story.id, task.id
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, member_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            yield s
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(member_id), email="agent@test",
+            claims={"app_metadata": {"org_id": str(org_id), "api_key_id": "test-key"}},
+        )
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_story_has_evidence_none_by_default_true_after_attach():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id, agent_id, story_id, _task_id = await _seed(s)
+
+        await _setup_app(app, Session, agent_id, org_id)
+        client = _client_for(app)
+        try:
+            before = await client.get(f"/api/v2/stories/{story_id}")
+            assert before.status_code == 200, before.text
+            body_before = before.json()
+            assert body_before["has_evidence"] is None
+            assert "has_evidence" in body_before  # 필드 자체는 존재(None) — false 아님
+
+            create_resp = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(story_id), "work_item_type": "story",
+                "type": "pr", "ref": "https://github.com/org/repo/pull/2",
+            })
+            assert create_resp.status_code == 201, create_resp.text
+
+            after = await client.get(f"/api/v2/stories/{story_id}")
+            assert after.json()["has_evidence"] is True
+
+            list_resp = await client.get("/api/v2/stories", params={"project_id": str(project_id)})
+            assert list_resp.status_code == 200
+            matching = [s for s in list_resp.json() if s["id"] == str(story_id)]
+            assert len(matching) == 1
+            assert matching[0]["has_evidence"] is True
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_task_has_evidence_none_by_default_true_after_attach():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id, agent_id, story_id, task_id = await _seed(s)
+
+        await _setup_app(app, Session, agent_id, org_id)
+        client = _client_for(app)
+        try:
+            before = await client.get(f"/api/v2/tasks/{task_id}")
+            assert before.json()["has_evidence"] is None
+
+            create_resp = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(task_id), "work_item_type": "task",
+                "type": "deploy", "ref": "https://example.com/deploy/1",
+            })
+            assert create_resp.status_code == 201, create_resp.text
+
+            after = await client.get(f"/api/v2/tasks/{task_id}")
+            assert after.json()["has_evidence"] is True
+
+            list_resp = await client.get("/api/v2/tasks", params={"story_id": str(story_id)})
+            matching = [t for t in list_resp.json() if t["id"] == str(task_id)]
+            assert matching[0]["has_evidence"] is True
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_gate_approval_auto_creates_evidence_and_flips_signal():
+    """HITL gate 승인 → gate_approval evidence 자동 편입 → story.has_evidence=True."""
+    from app.models.gate import Gate
+    from app.services.gate_service import create_gate, transition_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id, agent_id, story_id, _task_id = await _seed(s)
+            approver_id = uuid.uuid4()
+            role_id = uuid.uuid4()
+
+            gate = await create_gate(
+                s, org_id=org_id, work_item_id=story_id, work_item_type="story",
+                gate_type="pr_review", member_id=agent_id, role_id=role_id,
+            )
+            await s.commit()
+            gate_id = gate.id
+
+            await transition_gate(s, org_id, gate_id, "approved", resolver_id=approver_id)
+            await s.commit()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.evidence import Evidence
+
+            rows = (await s.execute(
+                select(Evidence).where(
+                    Evidence.work_item_id == story_id, Evidence.work_item_type == "story",
+                    Evidence.type == "gate_approval",
+                )
+            )).scalars().all()
+            assert len(rows) == 1, "gate_approval evidence 자동 생성 안 됨"
+            assert rows[0].ref == str(gate_id)
+            assert rows[0].created_by == approver_id
+
+        from app.main import app
+        await _setup_app(app, Session, agent_id, org_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{story_id}")
+            assert resp.json()["has_evidence"] is True
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_gate_rejected_does_not_create_evidence():
+    """회귀: reject 전이는 gate_approval evidence를 만들지 않는다."""
+    from app.services.gate_service import create_gate, transition_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id, agent_id, story_id, _task_id = await _seed(s)
+            approver_id = uuid.uuid4()
+            role_id = uuid.uuid4()
+
+            gate = await create_gate(
+                s, org_id=org_id, work_item_id=story_id, work_item_type="story",
+                gate_type="pr_review", member_id=agent_id, role_id=role_id,
+            )
+            await s.commit()
+            gate_id = gate.id
+
+            await transition_gate(s, org_id, gate_id, "rejected", resolver_id=approver_id, note="no")
+            await s.commit()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.evidence import Evidence
+
+            rows = (await s.execute(
+                select(Evidence).where(Evidence.work_item_id == story_id, Evidence.type == "gate_approval")
+            )).scalars().all()
+            assert rows == []
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_gate_approval_for_non_story_task_work_item_type_is_noop():
+    """블라인드 스코프 가드: work_item_type이 story/task가 아니면(예: doc) evidence 생성 안 함
+    (Evidence CHECK 제약이 story/task만 허용 — 위반 시 500 방지)."""
+    from app.services.evidence_service import create_gate_approval_evidence_if_applicable
+    from app.models.gate import Gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id, agent_id, story_id, _task_id = await _seed(s)
+            fake_gate = Gate(
+                id=uuid.uuid4(), org_id=org_id, work_item_id=uuid.uuid4(), work_item_type="doc",
+                gate_type="doc_approval", status="approved",
+            )
+            await create_gate_approval_evidence_if_applicable(s, fake_gate, "approved", uuid.uuid4())
+            await s.commit()
+
+            from sqlalchemy import select
+            from app.models.evidence import Evidence
+            rows = (await s.execute(
+                select(Evidence).where(Evidence.work_item_id == fake_gate.work_item_id)
+            )).scalars().all()
+            assert rows == []
+    finally:
+        await engine.dispose()

--- a/packages/core-storage/src/interfaces/IStoryRepository.ts
+++ b/packages/core-storage/src/interfaces/IStoryRepository.ts
@@ -24,6 +24,9 @@ export interface Story {
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
+  // E-VERIFY V0-S1/S2: 실증-done 신뢰 신호. positive 단방향(false 절대 안 씀) — true면 근거 有,
+  // null이면 완전 무표시(신뢰 표면 렌더 조건 그 자체).
+  has_evidence?: boolean | null;
 }
 
 export interface CreateStoryInput {

--- a/packages/core-storage/src/interfaces/ITaskRepository.ts
+++ b/packages/core-storage/src/interfaces/ITaskRepository.ts
@@ -12,6 +12,9 @@ export interface Task {
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
+  // E-VERIFY V0-S1/S2: 실증-done 신뢰 신호(story와 동일 계약). V0-S3 FE 표면은 story 카드/상세
+  // 한정(design doc §9 scope) — task 표면은 후속 스토리 판단.
+  has_evidence?: boolean | null;
 }
 
 export interface CreateTaskInput {


### PR DESCRIPTION
## Summary
E-VERIFY V0 prod promotion, following the #1985/#1990/#1992 procedure exactly. 3 commits ahead of main.

Blueprint `e-verify-v0-blueprint` r2, §0 제1원칙("감시가 아니라 신뢰"): evidence는 done의 검사지가 아니라 에이전트가 자기 완결을 표현하는 서명 — 강제 아닌 선택제.

- **S1** (#1994): Evidence 1급 모델·API — story/task 자기증명 첨부(C+R+D, `gate_approval` 스푸핑 차단 422), MCP 툴 `sprintable_add_evidence`.
- **S2** (#1995): `has_evidence` 신뢰 신호(positive 단방향 — `false` 없음, `None`=신호 부재) + HITL gate 승인 → `gate_approval` evidence 자동 편입.
- **S3** (#1996): FE 신뢰 표면 — 보드 카드 ✓ 씰(Lv0)·상세 접힘 신뢰 행(Lv1)·evidence 펼침 카드(Lv2, lazy fetch). 유나(UX, V0-S4) 리트머스("누가 주어인가") 통과.

## 마이그레이션
`0169_evidence_table` — `evidence` 신규 테이블(additive, CHECK 제약 2종). **배포 후 `sprintable-migrate-prod` job 수동 실행 필요**(Cloud Build 자동 미실행).

## Crux 검증(로컬)
- ① billing/pricing 유입: grep = 0
- ② 마이그 diff: `origin/main` 대비 신규 마이그는 `0169` 하나뿐(`down_revision=0168`, main 현재 head와 정합)
- ③ 스코프: 27개 파일 전부 E-VERIFY(BE+FE+shared packages) 내, 무관 파일 0
- ④ 테스트: `git merge origin/develop --no-commit --no-ff`(실 병합, merge-tree 아님) — 충돌 0. `alembic upgrade heads`(0168→0169 정합 체인) + `uv run pytest -q -m "not destructive_schema"` 로컬 재현 → **3435 passed, 6 failed**(전부 기존 환경성 실패 — MCP tool-count/`.mcp.json` 로컬 python-path, E-VERIFY 무관·회귀 0)
- ⑤ FE: Mirko가 S3에서 이미 검증(`pnpm vitest` 163파일/957테스트 PASS·lint 신규경고 0·build EXIT 0·dev 실 evidence 백필로 `has_evidence: null→true` 전환 실측)

## Test plan
- [x] `git merge --no-commit --no-ff` 실 병합 무충돌
- [x] billing 경계 leak-grep = 0
- [x] 마이그 diff = 0169 하나만(additive)
- [x] `alembic upgrade heads` 정합 체인 확인(0168→0169)
- [x] `pytest -q -m "not destructive_schema"` 로컬 그린(신규 실패 0)
- [ ] Ortega 독립 crux 재검증
- [ ] merge → prod backend 배포 → `migrate-prod` job 실행 → prod 검증(유나 픽셀 가디언 + evidence API 실측)

🤖 Generated with [Claude Code](https://claude.com/claude-code)