### PR TITLE
feat(comments): comment.created 이벤트 전파 배선 — 스토리 코멘트 부활 (E-CANVAS C0-S1)

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -20,7 +20,7 @@ from app.services.event_seq import assign_recipient_seq
 from app.services import mcp_attachment_upload
 from app.services.asset_registry import DEFAULT_CONTAINER, sync_attachment_assets
 from app.schemas.story import StoryAttachment, StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
-from app.services.member_resolver import canonicalize_member_id
+from app.services.member_resolver import canonicalize_member_id, filter_org_member_ids
 from app.services.merge_verdict_gate import (
     AUTO_MERGE,
     evaluate_merge_gate,
@@ -1136,7 +1136,8 @@ async def _resolve_team_member_id(auth: AuthContext, org_id: uuid.UUID, db: Asyn
 @router.post("/{id}/comments", response_model=CommentResponse, status_code=201)
 async def add_comment(
     id: uuid.UUID,
-    content: str = Body(..., embed=True),
+    content: str = Body(...),
+    mentioned_ids: list[uuid.UUID] = Body(default=[]),
     db: AsyncSession = Depends(get_db),
     repo: StoryRepository = Depends(_get_repo),
     auth: AuthContext = Depends(get_current_user),
@@ -1156,6 +1157,31 @@ async def add_comment(
     db.add(comment)
     await db.commit()
     await db.refresh(comment)
+
+    # E-CANVAS C0-S1(story cfa61434) §F4: comment.created 이벤트 전파 — 기반층 검증 케이스
+    # (blueprint 제1원칙 "이벤트 없는 기능 금지"). 수신자 = story assignee(멀티) + mentioned_ids
+    # (cross-org 필터, conversations.py와 동형 컨벤션 — content regex 파싱은 이 코드베이스가
+    # 이미 폐기함[channel_router.py]) − 작성자 본인(자기알림 제외). dispatch_notification이
+    # 휴먼(in-app+webhook)/에이전트(Event INSERT→SSE·webhook) 양쪽 다 처리하는 기존 SSOT.
+    sa_repo = StoryAssigneeRepository(db, repo.org_id)
+    assignee_ids = set(await sa_repo.list_member_ids(story.id))
+    if not assignee_ids and story.assignee_id:
+        assignee_ids = {story.assignee_id}
+    valid_mentioned_ids = await filter_org_member_ids(set(mentioned_ids), repo.org_id, db)
+    target_member_ids = list((assignee_ids | valid_mentioned_ids) - {created_by})
+    if target_member_ids:
+        await dispatch_notification(
+            db,
+            org_id=repo.org_id,
+            event_type="comment.created",
+            target_member_ids=target_member_ids,
+            title=f"새 코멘트: {story.title}",
+            body=content[:200],
+            reference_type="story",
+            reference_id=story.id,
+            source_project_id=story.project_id,
+        )
+
     return CommentResponse.model_validate(comment)
 
 

--- a/backend/tests/test_e_canvas_c0_s1_comment_events_realdb.py
+++ b/backend/tests/test_e_canvas_c0_s1_comment_events_realdb.py
@@ -1,0 +1,291 @@
+"""E-CANVAS C0-S1(story cfa61434): comment.created 이벤트 전파 배선 — 실 Postgres 검증.
+
+crux 확定대로 신규 인프라 0 — `add_comment`→기존 `dispatch_notification` 배선만. 실 alembic
+마이그 필요(team_members 뷰 에이전트 인식 경로)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org + project + 3 agents(author·assignee·mentioned) + story(assignee 배정)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+    from app.models.pm import Story
+    from app.models.story_assignee import StoryAssignee
+
+    org = Organization(id=uuid.uuid4(), name="C0-S1 Org", slug=f"c0s1-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="C0-S1 Project")
+    author = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Comment Author", is_active=True)
+    assignee = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Story Assignee", is_active=True)
+    mentioned = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Mentioned Agent", is_active=True)
+    session.add_all([project, author, assignee, mentioned])
+    await session.commit()
+
+    grants = [
+        ProjectAccess(id=uuid.uuid4(), project_id=project.id, member_id=m.id, permission="granted", role="member")
+        for m in (author, assignee, mentioned)
+    ]
+    session.add_all(grants)
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="C0-S1 Story", status="in-progress")
+    session.add(story)
+    await session.commit()
+
+    session.add(StoryAssignee(id=uuid.uuid4(), org_id=org.id, story_id=story.id, member_id=assignee.id))
+    await session.commit()
+
+    return org.id, project.id, author.id, assignee.id, mentioned.id, story.id
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, member_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        # 실 app.core.database.get_db와 동형(post-yield commit) — dispatch_notification은
+        # flush()만 하고 최종 commit은 get_db 래퍼에 위임하는 컨벤션이라, 단순 yield-only
+        # override는 그 커밋을 누락해 flush된 Event가 세션 종료 시 조용히 버려진다(실측 확認).
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(member_id), email="agent@test",
+            claims={"app_metadata": {"org_id": str(org_id), "api_key_id": "test-key"}},
+        )
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_comment_creates_event_for_assignee_and_mentioned_not_author():
+    from app.main import app
+    from sqlalchemy import select
+    from app.models.event import Event
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id, author_id, assignee_id, mentioned_id, story_id = await _seed(s)
+
+        await _setup_app(app, Session, author_id, org_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{story_id}/comments",
+                json={"content": "리뷰 부탁하는", "mentioned_ids": [str(mentioned_id)]},
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Event).where(
+                    Event.org_id == org_id, Event.event_type == "dispatched",
+                )
+            )).scalars().all()
+            recipient_ids = {r.recipient_id for r in rows}
+            # assignee + mentioned 둘 다 받음, author(본인)는 제외
+            assert recipient_ids == {assignee_id, mentioned_id}
+            for r in rows:
+                assert r.status == "pending"
+                assert r.source_entity_type == "story"
+                assert r.source_entity_id == story_id
+                # Event.event_type 컬럼 자체는 "dispatched"(dispatch_notification 컨벤션) —
+                # 실 도메인 타입은 payload에 실려간다(established pattern, agent_dispatch.py 동형).
+                assert r.payload["event_type"] == "comment.created"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_comment_author_is_assignee_gets_no_self_notification():
+    """작성자 본인이 assignee여도 자기 자신에게 알림 안 감(회귀 방지)."""
+    from app.main import app
+    from sqlalchemy import select
+    from app.models.event import Event
+    from app.models.story_assignee import StoryAssignee
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id, author_id, assignee_id, mentioned_id, story_id = await _seed(s)
+            # author를 추가 assignee로도 등록
+            s.add(StoryAssignee(id=uuid.uuid4(), org_id=org_id, story_id=story_id, member_id=author_id))
+            await s.commit()
+
+        await _setup_app(app, Session, author_id, org_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{story_id}/comments",
+                json={"content": "셀프 코멘트", "mentioned_ids": []},
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Event).where(Event.org_id == org_id, Event.event_type == "dispatched")
+            )).scalars().all()
+            recipient_ids = {r.recipient_id for r in rows}
+            assert author_id not in recipient_ids
+            assert recipient_ids == {assignee_id}
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cross_org_mentioned_id_filtered_out():
+    """다른 org 소속 member_id를 mentioned_ids로 보내도 필터링(cross-org 누출 방지)."""
+    from app.main import app
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from sqlalchemy import select
+    from app.models.event import Event
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id, author_id, assignee_id, mentioned_id, story_id = await _seed(s)
+            other_org = Organization(id=uuid.uuid4(), name="Other Org", slug=f"other-{uuid.uuid4().hex[:8]}")
+            s.add(other_org)
+            await s.commit()
+            stranger = Member(id=uuid.uuid4(), org_id=other_org.id, type="agent", name="Stranger", is_active=True)
+            s.add(stranger)
+            await s.commit()
+            stranger_id = stranger.id
+
+        await _setup_app(app, Session, author_id, org_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{story_id}/comments",
+                json={"content": "cross-org mention test", "mentioned_ids": [str(stranger_id)]},
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Event).where(Event.org_id == org_id, Event.event_type == "dispatched")
+            )).scalars().all()
+            recipient_ids = {r.recipient_id for r in rows}
+            assert stranger_id not in recipient_ids
+            assert recipient_ids == {assignee_id}
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_comment_with_no_recipients_regression_zero():
+    """assignee·mention 둘 다 없으면 dispatch 자체를 안 함(빈 target_member_ids 스킵) — 회귀0."""
+    from app.main import app
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+    from app.models.pm import Story
+    from sqlalchemy import select
+    from app.models.event import Event
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = Organization(id=uuid.uuid4(), name="C0-S1 NoRecip Org", slug=f"c0s1n-{uuid.uuid4().hex[:8]}")
+            s.add(org)
+            await s.commit()
+            project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+            author = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Author", is_active=True)
+            s.add_all([project, author])
+            await s.commit()
+            grant = ProjectAccess(
+                id=uuid.uuid4(), project_id=project.id, member_id=author.id, permission="granted", role="member",
+            )
+            s.add(grant)
+            story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Unassigned Story", status="backlog")
+            s.add(story)
+            await s.commit()
+            org_id, author_id, story_id = org.id, author.id, story.id
+
+        await _setup_app(app, Session, author_id, org_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/stories/{story_id}/comments",
+                json={"content": "아무도 안 받는 코멘트", "mentioned_ids": []},
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Event).where(Event.org_id == org_id, Event.event_type == "dispatched")
+            )).scalars().all()
+            assert rows == []
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
Blueprint `e-canvas-blueprint` §F4/C0, 제1원칙("이벤트 없는 기능 금지" — 스토리 코멘트가 죽은 이유는 어떠한 이벤트도 전파되지 않기 때문).

## Crux (착수 전 실측, PO 후검토 요청)
- `stories.py::add_comment`가 `StoryComment` row를 만들고 그냥 끝남 — 알림·이벤트·SSE·webhook 전부 0(blueprint 진단 그대로 재확인).
- **결정적 발견**: `app/services/notification_dispatch.py::dispatch_notification()`이 이미 완비된 전파 기계 — 휴먼(in-app Notification + 개인 webhook)·에이전트(`events` 테이블 INSERT → 기존 SSE/webhook 브릿지가 픽업). `task_completed`/`story_assigned` 등에서 이미 재사용 중. **새 전파 인프라 불요 — 순수 배선 문제**.
- mention 컨벤션: 이 코드베이스는 content `@텍스트` 정규식 파싱을 이미 폐기(`channel_router.py` 주석 — "content regex 폐기"). `conversations.py`처럼 클라이언트가 `mentioned_ids: list[UUID]`를 명시 필드로 보내는 방식을 그대로 따름.
- `Event.event_type`은 enum 제약 없는 plain Text — `comment.created` literal 그대로 사용 가능(신규 타입 등록 절차 불요).

## 구현
- `POST /{id}/comments` body에 `mentioned_ids: list[UUID] = []` 추가.
- 수신자 = story assignee(멀티, 기존 `StoryAssigneeRepository` 재사용) + `mentioned_ids`(`filter_org_member_ids`로 cross-org 필터) − 작성자 본인.
- `dispatch_notification(event_type="comment.created", ...)` 호출. `Event.event_type` 컬럼 자체는 기존 컨벤션대로 `"dispatched"` 고정 — 실 도메인 타입은 `payload.event_type`에 실림(`agent_dispatch.py` 등 기존 선례와 동형, 새 컨벤션 발명 안 함).
- 신규 모델/테이블/마이그 **0** — 전부 재사용.

## Test plan
- [x] 신규 realdb 테스트 4/4: assignee+mention 둘 다 Event 수신(payload.event_type 확인 포함)·작성자 자기알림 제외 회귀·cross-org mention 필터·수신자 0명이면 dispatch 스킵.
- [x] 기존 `test_stories.py`(comment 관련 포함) 54개 — regression 0.
- [x] 전체 백엔드 스위트(`pytest -q -m "not destructive_schema"`) — 3443 passed, 6 failed(전부 기존 환경성, 무관·신규 회귀 0).

## Note (S2와의 관계)
`C0-S2`(에이전트 무개입 왕복 실증)는 이 PR로 배선이 끝나면 신규 코드 없이 순수 검증 단계로 남는 — A2A epic의 S-A1(구현)/S-A2(라이브검증) 선례와 동형 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)