### PR TITLE
feat(security): story delete 에이전트 hard-delete 차단 + 삭제 감사 로그 (E-SECURITY SEC-S1)

### DIFF
--- a/backend/alembic/versions/0170_deletion_audit_logs.py
+++ b/backend/alembic/versions/0170_deletion_audit_logs.py
@@ -1,0 +1,37 @@
+"""E-SECURITY SEC-S1(story 70c9e92c): deletion_audit_logs 테이블 — hard-delete 감사 흔적.
+
+Revision ID: 0170
+Revises: 0169
+Create Date: 2026-07-10
+
+순수 additive 신규 테이블 — 기존 스키마 무회귀.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0170"
+down_revision = "0169"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "deletion_audit_logs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("actor_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("entity_type", sa.Text(), nullable=False),
+        sa.Column("entity_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("entity_title", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index("ix_deletion_audit_logs_org_id", "deletion_audit_logs", ["org_id"])
+    op.create_index("ix_deletion_audit_logs_entity_id", "deletion_audit_logs", ["entity_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("deletion_audit_logs")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.agent_routing_rule import AgentRoutingRule
 from app.models.agent_run import AgentRun
 from app.models.agent_session import AgentSession
 from app.models.bridge import BridgeChannelMapping, BridgeUserMapping
+from app.models.deletion_audit import DeletionAuditLog
 from app.models.embedding import Embedding
 from app.models.evidence import Evidence
 from app.models.gate import Gate

--- a/backend/app/models/deletion_audit.py
+++ b/backend/app/models/deletion_audit.py
@@ -1,0 +1,28 @@
+"""E-SECURITY SEC-S1(story 70c9e92c): hard-delete 감사 — 삭제 경로 흔적 0 해소.
+
+기존 audit 테이블은 전부 부적합: `permission_audit_logs`(role 변경 shape)·`story_activities`
+(story_id FK ondelete=CASCADE라 삭제 자체와 함께 사라져 감사 목적 무의미)·`agent_audit_logs`
+(agent_id NOT NULL — 삭제는 이제 휴먼 전용이라 안 맞음). entity_type 범용이라 story 외 삭제
+경로 확장 시(향후) 재사용 가능."""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class DeletionAuditLog(Base):
+    __tablename__ = "deletion_audit_logs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    actor_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    entity_type: Mapped[str] = mapped_column(Text, nullable=False)
+    entity_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    entity_title: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -427,6 +427,19 @@ async def delete_doc(
     # f69fcd91: 대상 doc 의 project 접근 강제(cross-project IDOR 차단·get_project_scoped_org_id 의 org-only
     # fallback 으로 同org 비-project caller 가 타 project doc 삭제 가능하던 갭). 없으면 404·무권한 403.
     await _require_doc_project_access(repo.session, id, uuid.UUID(auth.user_id), repo.org_id)
+    # E-SECURITY SEC-S1 확장(까심 적대적 QA 발견 갭): delete_story와 동형으로 휴먼 전용화 + 삭제 감사.
+    from app.services.member_resolver import resolve_member
+    deleter = await resolve_member(auth, repo.org_id, repo.session)
+    if deleter.type != "human":
+        raise HTTPException(status_code=403, detail="Doc 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)")
+    doc = await repo.get(id)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Doc not found")
+    from app.models.deletion_audit import DeletionAuditLog
+    repo.session.add(DeletionAuditLog(
+        id=uuid.uuid4(), org_id=repo.org_id, actor_id=deleter.id,
+        entity_type="doc", entity_id=id, entity_title=doc.title,
+    ))
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Doc not found")
@@ -434,8 +447,6 @@ async def delete_doc(
     # 삭제 권한자(인증 caller) 트리거 system cascade — human-gate authz 우회 정당(별도 결재 아님). void 는
     # begin_nested 격리 best-effort라 삭제 비중단. pending 아니면 no-op(멱등)·doc_approval 만 스코핑.
     from app.services.gate_service import void_pending_doc_gate
-    from app.services.member_resolver import resolve_member
-    deleter = await resolve_member(auth, repo.org_id, repo.session)
     await void_pending_doc_gate(repo.session, repo.org_id, id, deleter.id)
     return {"ok": True}
 

--- a/backend/app/routers/epics.py
+++ b/backend/app/routers/epics.py
@@ -162,9 +162,15 @@ async def delete_epic(
     Supabase 레거시(db=undefined) 의존으로 깨져 있었고 그게 유일한 admin/owner 가드였다.
     삭제하면 권한 누수(org member/viewer 가 에픽 삭제)이므로 authz 를 BE SSOT 로 옮긴다.
     admin/owner 는 org-wide 접근권이라 project 접근권을 자동 충족한다(별도 project 게이트 불요).
+
+    E-SECURITY SEC-S1 확장(까심 적대적 QA 발견): is_org_owner_or_admin은 org_members(휴먼 전용
+    grant 테이블)만 조회해 에이전트가 구조적으로 통과 불가하나, 그건 암묵적 부산물일 뿐 — cascade로
+    소속 stories까지 물리삭제되는 파괴력을 고려해 delete_story와 동형인 명시적 human-only 체크를
+    추가한다(암묵적 방어에만 기대지 않음).
     """
     from app.repositories.dependency import DependencyRepository
     from app.repositories.label import ItemLabelRepository
+    from app.services.member_resolver import resolve_member
     from app.services.project_auth import is_org_owner_or_admin
 
     # 존재 검증 먼저(없으면 404) — authz 결과로 존재 여부가 새지 않도록 404 우선.
@@ -172,11 +178,20 @@ async def delete_epic(
     if epic is None:
         raise HTTPException(status_code=404, detail="Epic not found")
 
+    resolved = await resolve_member(auth, org_id, session)
+    if resolved.type != "human":
+        raise HTTPException(status_code=403, detail="Epic 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)")
+
     if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
         raise HTTPException(
             status_code=403, detail="Epic deletion requires admin or owner role"
         )
 
+    from app.models.deletion_audit import DeletionAuditLog
+    session.add(DeletionAuditLog(
+        id=uuid.uuid4(), org_id=org_id, actor_id=resolved.id,
+        entity_type="epic", entity_id=id, entity_title=epic.title,
+    ))
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Epic not found")

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -129,9 +129,13 @@ async def delete_project(
     org_id: uuid.UUID = Depends(get_verified_org_id),
     session: AsyncSession = Depends(get_db),
 ) -> dict:
+    from app.models.deletion_audit import DeletionAuditLog
+    from app.services.member_resolver import resolve_member
+
     repo = ProjectRepository(session, org_id)
+    project = await repo.get(id)
     # 미접근 멤버에겐 존재 비노출(404).
-    if await repo.get(id) is None or not await has_project_access(
+    if project is None or not await has_project_access(
         session, uuid.UUID(auth.user_id), id, org_id
     ):
         raise HTTPException(status_code=404, detail="Project not found")
@@ -141,6 +145,16 @@ async def delete_project(
             status_code=403,
             detail="프로젝트 삭제는 조직 owner/admin 권한이 필요합니다",
         )
+    # E-SECURITY SEC-S1 확장(까심 적대적 QA 발견): is_org_owner_or_admin은 org_members(휴먼 전용)만
+    # 조회해 에이전트가 구조적으로 통과 불가하나 암묵적 부산물일 뿐 — story·epic과 동형으로 명시적
+    # human-only 체크 + 삭제 감사를 추가한다(cascade 파괴력 고려).
+    resolved = await resolve_member(auth, org_id, session)
+    if resolved.type != "human":
+        raise HTTPException(status_code=403, detail="Project 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)")
+    session.add(DeletionAuditLog(
+        id=uuid.uuid4(), org_id=org_id, actor_id=resolved.id,
+        entity_type="project", entity_id=id, entity_title=project.name,
+    ))
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Project not found")

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user, get_project_scoped_org_id, get_verified_org_id
 from app.dependencies.database import get_db
+from app.models.deletion_audit import DeletionAuditLog
 from app.models.event import Event
 from app.models.pm import Epic, Story, StoryActivity, StoryComment
 from app.models.team import TeamMember
@@ -20,7 +21,7 @@ from app.services.event_seq import assign_recipient_seq
 from app.services import mcp_attachment_upload
 from app.services.asset_registry import DEFAULT_CONTAINER, sync_attachment_assets
 from app.schemas.story import StoryAttachment, StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
-from app.services.member_resolver import canonicalize_member_id, filter_org_member_ids
+from app.services.member_resolver import canonicalize_member_id, filter_org_member_ids, resolve_member
 from app.services.merge_verdict_gate import (
     AUTO_MERGE,
     evaluate_merge_gate,
@@ -851,10 +852,32 @@ async def delete_story(
     repo: StoryRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    """E-SECURITY SEC-S1(story 70c9e92c): hard-delete는 휴먼 전용 — 에이전트 API키(사람 승인
+    없는 즉시 물리삭제)는 403. 삭제 전 actor/target를 감사 기록(story row 자체는 삭제되므로
+    미리 캡처 — DeletionAuditLog는 story FK 없이 독립 테이블이라 삭제 후에도 생존)."""
     from app.repositories.dependency import DependencyRepository
     from app.repositories.label import ItemLabelRepository
     from app.repositories.participation import ParticipationRepository
+
+    resolved = await resolve_member(auth, org_id, session)
+    if resolved.type != "human":
+        raise HTTPException(status_code=403, detail="Story 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)")
+
+    story = await repo.get(id)
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+
+    session.add(DeletionAuditLog(
+        id=uuid.uuid4(),
+        org_id=org_id,
+        actor_id=resolved.id,
+        entity_type="story",
+        entity_id=id,
+        entity_title=story.title,
+    ))
+
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Story not found")

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -128,7 +128,25 @@ async def update_task(
 async def delete_task(
     id: uuid.UUID,
     repo: TaskRepository = Depends(_get_repo),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    """E-SECURITY SEC-S1(story 70c9e92c) 확장: 까심 적대적 QA 발견 갭 봉쇄 — delete_story와
+    동형으로 휴먼 전용화 + 삭제 감사(hard-delete의 에이전트 우회 벡터 차단)."""
+    from app.models.deletion_audit import DeletionAuditLog
+    from app.services.member_resolver import resolve_member
+
+    resolved = await resolve_member(auth, org_id, session)
+    if resolved.type != "human":
+        raise HTTPException(status_code=403, detail="Task 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)")
+    task = await repo.get(id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    session.add(DeletionAuditLog(
+        id=uuid.uuid4(), org_id=org_id, actor_id=resolved.id,
+        entity_type="task", entity_id=id, entity_title=task.title,
+    ))
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Task not found")

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -245,9 +245,10 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_check_notifications", "sprintable_checkin_sprint", "sprintable_claim_story",
     "sprintable_close_sprint", "sprintable_create_conversation", "sprintable_create_doc",
     "sprintable_create_meeting", "sprintable_create_retro_session", "sprintable_create_sprint",
-    "sprintable_delete_doc", "sprintable_delete_epic", "sprintable_delete_meeting",
-    # E-SECURITY SEC-S1: sprintable_delete_story 의도적 제거(에이전트 hard-delete 차단).
-    "sprintable_delete_sprint", "sprintable_delete_task",
+    "sprintable_delete_meeting",
+    # E-SECURITY SEC-S1(확장): sprintable_delete_story/task/epic/doc 의도적 제거(에이전트
+    # hard-delete 차단 — 까심 적대적 QA가 delete_story만으로는 반쪽임을 발견, story와 동형 확대).
+    "sprintable_delete_sprint",
     "sprintable_delete_webhook_config", "sprintable_emit_event", "sprintable_export_retro",
     "sprintable_get_agent_stats", "sprintable_get_blocked_stories", "sprintable_get_doc",
     "sprintable_get_epic_progress", "sprintable_get_leaderboard_v2", "sprintable_get_meeting",

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -246,7 +246,8 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_close_sprint", "sprintable_create_conversation", "sprintable_create_doc",
     "sprintable_create_meeting", "sprintable_create_retro_session", "sprintable_create_sprint",
     "sprintable_delete_doc", "sprintable_delete_epic", "sprintable_delete_meeting",
-    "sprintable_delete_sprint", "sprintable_delete_story", "sprintable_delete_task",
+    # E-SECURITY SEC-S1: sprintable_delete_story 의도적 제거(에이전트 hard-delete 차단).
+    "sprintable_delete_sprint", "sprintable_delete_task",
     "sprintable_delete_webhook_config", "sprintable_emit_event", "sprintable_export_retro",
     "sprintable_get_agent_stats", "sprintable_get_blocked_stories", "sprintable_get_doc",
     "sprintable_get_epic_progress", "sprintable_get_leaderboard_v2", "sprintable_get_meeting",

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -48,13 +48,13 @@ from .tools.core import (
     my_dashboard, unclaim_story, unlock_files,
 )
 from .tools.docs import (
-    CreateDocInput, DeleteDocInput, GetDocInput, ListDocsInput,
+    CreateDocInput, GetDocInput, ListDocsInput,
     SearchDocsInput, UpdateDocInput,
-    create_doc, delete_doc, get_doc, list_docs, search_docs, update_doc,
+    create_doc, get_doc, list_docs, search_docs, update_doc,
 )
 from .tools.epics import (
-    AddEpicInput, DeleteEpicInput, ListEpicsInput, UpdateEpicInput,
-    add_epic, delete_epic, list_epics, update_epic,
+    AddEpicInput, ListEpicsInput, UpdateEpicInput,
+    add_epic, list_epics, update_epic,
 )
 from .tools.hypotheses import (
     ConfirmHypothesisInput, CreateHypothesisInput, GetHypothesisInput,
@@ -107,9 +107,9 @@ from .tools.stories import (
     update_story, update_story_status,
 )
 from .tools.tasks import (
-    AddTaskInput, DeleteTaskInput, GetTaskInput, ListMyTasksInput,
+    AddTaskInput, GetTaskInput, ListMyTasksInput,
     ListTasksInput, UpdateTaskInput, UpdateTaskStatusInput,
-    add_task, delete_task, get_task, list_my_tasks, list_tasks,
+    add_task, get_task, list_my_tasks, list_tasks,
     update_task, update_task_status,
 )
 from .tools.webhooks import (
@@ -328,7 +328,7 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_update_story_status",
      "스토리 상태 변경.",
      UpdateStoryStatusInput, update_story_status),
-    # Tasks (7)
+    # Tasks (6) — E-SECURITY SEC-S1 확장: delete_task 제거(에이전트 hard-delete 차단)
     ("sprintable_list_tasks",
      "태스크 목록 조회.",
      ListTasksInput, list_tasks),
@@ -347,10 +347,7 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_update_task_status",
      "태스크 상태 변경.",
      UpdateTaskStatusInput, update_task_status),
-    ("sprintable_delete_task",
-     "태스크 삭제.",
-     DeleteTaskInput, delete_task),
-    # Epics (4)
+    # Epics (3) — E-SECURITY SEC-S1 확장: delete_epic 제거(에이전트 hard-delete 차단)
     ("sprintable_list_epics",
      "에픽 목록 조회.",
      ListEpicsInput, list_epics),
@@ -360,9 +357,6 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_update_epic",
      "에픽 수정.",
      UpdateEpicInput, update_epic),
-    ("sprintable_delete_epic",
-     "에픽 삭제.",
-     DeleteEpicInput, delete_epic),
     # Hypotheses (6)
     ("sprintable_list_hypotheses",
      "가설 목록 조회 (compact). epic_id/story_id/status/owner_member_id 필터.",
@@ -413,7 +407,7 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_delete_sprint",
      "스프린트 삭제.",
      SprintIdInput, delete_sprint),
-    # Docs (6)
+    # Docs (5) — E-SECURITY SEC-S1 확장: delete_doc 제거(에이전트 삭제 차단)
     ("sprintable_list_docs",
      "문서 목록 조회 (tree 또는 tag 필터).",
      ListDocsInput, list_docs),
@@ -429,9 +423,6 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_update_doc",
      "문서 수정.",
      UpdateDocInput, update_doc),
-    ("sprintable_delete_doc",
-     "문서 소프트 삭제.",
-     DeleteDocInput, delete_doc),
     # Analytics (11)
     ("sprintable_get_project_overview",
      "프로젝트 개요 통계 조회.",

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -99,10 +99,10 @@ from .tools.standup import (
     save_standup, standup_history, standup_missing, update_retro_action_status,
 )
 from .tools.stories import (
-    AddStoryInput, AssignStoryToSprintInput, DeleteStoryInput,
+    AddStoryInput, AssignStoryToSprintInput,
     ListStoriesInput, UnassignStoryFromSprintInput, UpdateStoryInput,
     UpdateStoryStatusInput,
-    add_story, assign_story_to_sprint, delete_story,
+    add_story, assign_story_to_sprint,
     list_backlog, list_stories, unassign_story_from_sprint,
     update_story, update_story_status,
 )
@@ -318,9 +318,7 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_update_story",
      "스토리 수정.",
      UpdateStoryInput, update_story),
-    ("sprintable_delete_story",
-     "스토리 삭제.",
-     DeleteStoryInput, delete_story),
+    # E-SECURITY SEC-S1: sprintable_delete_story 의도적 제거(에이전트 hard-delete 차단).
     ("sprintable_assign_story_to_sprint",
      "스토리를 스프린트에 배정.",
      AssignStoryToSprintInput, assign_story_to_sprint),

--- a/backend/sprintable_mcp/tools/docs.py
+++ b/backend/sprintable_mcp/tools/docs.py
@@ -1,4 +1,5 @@
-"""문서 관련 MCP 도구 (6개)."""
+"""문서 관련 MCP 도구 (5개) — E-SECURITY SEC-S1 확장: delete_doc 제거(에이전트 삭제 차단,
+delete_story와 동형 조치. 까심 적대적 QA 발견 갭)."""
 from __future__ import annotations
 
 from typing import Literal
@@ -50,10 +51,6 @@ class UpdateDocInput(SprintableInput):
     # 몰라도 됨)을 content 끝에 append. 이 호출에 content 를 안 실었으면 현재 저장된 content 를 먼저
     # 읽어 그 뒤에 append(기존 본문을 지우지 않음).
     attachments: list[dict] | None = None
-
-
-class DeleteDocInput(SprintableInput):
-    doc_id: str
 
 
 async def list_docs(args: ListDocsInput) -> list[TextContent]:
@@ -141,14 +138,5 @@ async def update_doc(args: UpdateDocInput) -> list[TextContent]:
                 snippets = "".join(a["embed_snippet"] for a in uploaded if isinstance(a, dict) and a.get("embed_snippet"))
                 updates["content"] = f"{base_content}\n{snippets}" if base_content else snippets
         return ok(await client.patch(f"/api/v2/docs/{args.doc_id}", json=updates))
-    except Exception as exc:
-        return err(str(exc))
-
-
-async def delete_doc(args: DeleteDocInput) -> list[TextContent]:
-    """문서 소프트 삭제."""
-    try:
-        await client.delete(f"/api/v2/docs/{args.doc_id}")
-        return ok({"deleted": True})
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/epics.py
+++ b/backend/sprintable_mcp/tools/epics.py
@@ -1,4 +1,5 @@
-"""에픽 관련 MCP 도구 (4개)."""
+"""에픽 관련 MCP 도구 (3개) — E-SECURITY SEC-S1 확장: delete_epic 제거(에이전트 hard-delete 차단,
+delete_story와 동형 조치. 까심 적대적 QA 발견 갭 — cascade로 소속 stories까지 물리삭제)."""
 from __future__ import annotations
 
 from mcp.types import TextContent
@@ -32,10 +33,6 @@ class UpdateEpicInput(SprintableInput):
     success_criteria: str | None = None
     target_sp: int | None = None
     target_date: str | None = None
-
-
-class DeleteEpicInput(SprintableInput):
-    epic_id: str
 
 
 async def list_epics(args: ListEpicsInput) -> list[TextContent]:
@@ -80,14 +77,5 @@ async def update_epic(args: UpdateEpicInput) -> list[TextContent]:
         updates["target_sp"] = args.target_sp
     try:
         return ok(await client.patch(f"/api/v2/epics/{args.epic_id}", json=updates))
-    except Exception as exc:
-        return err(str(exc))
-
-
-async def delete_epic(args: DeleteEpicInput) -> list[TextContent]:
-    """에픽 삭제."""
-    try:
-        await client.delete(f"/api/v2/epics/{args.epic_id}")
-        return ok({"deleted": True})
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/stories.py
+++ b/backend/sprintable_mcp/tools/stories.py
@@ -1,4 +1,6 @@
-"""스토리 관련 MCP 도구 (8개)."""
+"""스토리 관련 MCP 도구 (7개). E-SECURITY SEC-S1: delete_story는 의도적으로 제거됨 — 에이전트
+hard-delete는 사람 승인 없는 물리삭제라 차단(DELETE 엔드포인트 자체는 유지, 휴먼 전용으로 승격).
+삭제가 필요한 워크플로우는 상태변경/archive로 대체."""
 from __future__ import annotations
 
 from mcp.types import CallToolResult, TextContent
@@ -41,10 +43,6 @@ class UpdateStoryInput(SprintableInput):
     # 기존 첨부에 **추가**된다(PATCH attachments 는 서버측 full-replace 라 update_story 가 먼저 기존
     # 첨부를 읽어 병합 — 새 첨부가 기존 걸 지우지 않는다).
     attachments: list[dict] | None = None
-
-
-class DeleteStoryInput(SprintableInput):
-    story_id: str
 
 
 class AssignStoryToSprintInput(SprintableInput):
@@ -147,15 +145,6 @@ async def update_story(args: UpdateStoryInput) -> list[TextContent]:
                 existing = current.get("attachments") or [] if isinstance(current, dict) else []
                 updates["attachments"] = existing + uploaded
         return ok(await client.patch(f"/api/v2/stories/{args.story_id}", json=updates))
-    except Exception as exc:
-        return err(str(exc))
-
-
-async def delete_story(args: DeleteStoryInput) -> list[TextContent]:
-    """스토리 삭제."""
-    try:
-        await client.delete(f"/api/v2/stories/{args.story_id}")
-        return ok({"deleted": True})
     except Exception as exc:
         return err(str(exc))
 

--- a/backend/sprintable_mcp/tools/tasks.py
+++ b/backend/sprintable_mcp/tools/tasks.py
@@ -1,4 +1,5 @@
-"""태스크 관련 MCP 도구 (7개)."""
+"""태스크 관련 MCP 도구 (6개) — E-SECURITY SEC-S1 확장: delete_task 제거(에이전트 hard-delete 차단,
+delete_story와 동형 조치. 까심 적대적 QA 발견 갭)."""
 from __future__ import annotations
 
 from mcp.types import TextContent
@@ -40,10 +41,6 @@ class UpdateTaskInput(SprintableInput):
 class UpdateTaskStatusInput(SprintableInput):
     task_id: str
     status: TaskStatus
-
-
-class DeleteTaskInput(SprintableInput):
-    task_id: str
 
 
 async def list_tasks(args: ListTasksInput) -> list[TextContent]:
@@ -113,14 +110,5 @@ async def update_task_status(args: UpdateTaskStatusInput) -> list[TextContent]:
     """태스크 상태 변경."""
     try:
         return ok(await client.patch(f"/api/v2/tasks/{args.task_id}", json={"status": args.status.value}))
-    except Exception as exc:
-        return err(str(exc))
-
-
-async def delete_task(args: DeleteTaskInput) -> list[TextContent]:
-    """태스크 삭제."""
-    try:
-        await client.delete(f"/api/v2/tasks/{args.task_id}")
-        return ok({"deleted": True})
     except Exception as exc:
         return err(str(exc))

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -1,4 +1,7 @@
-"""S3-6: 시스템 콜 계약 검증 — 97개 도구 등록 + 스키마 무결성 (Phase 3 완료)."""
+"""S3-6: 시스템 콜 계약 검증 — 94개 도구 등록 + 스키마 무결성 (Phase 3 완료).
+
+E-SECURITY SEC-S1(확장): delete_story/task/epic/doc 4종 제거(에이전트 hard-delete 차단) —
+98개 → story만 제거해 97 → task/epic/doc 3종 추가 제거해 94."""
 from __future__ import annotations
 
 import os
@@ -18,13 +21,11 @@ EXPECTED_TOOLS = {
     "sprintable_update_story",
     "sprintable_assign_story_to_sprint", "sprintable_unassign_story_from_sprint",
     "sprintable_update_story_status",
-    # tasks (7)
+    # tasks (6) — E-SECURITY SEC-S1(확장): delete_task 의도적 제거(에이전트 hard-delete 차단)
     "sprintable_list_tasks", "sprintable_list_my_tasks", "sprintable_get_task",
     "sprintable_add_task", "sprintable_update_task", "sprintable_update_task_status",
-    "sprintable_delete_task",
-    # epics (4)
+    # epics (3) — E-SECURITY SEC-S1(확장): delete_epic 의도적 제거(에이전트 hard-delete 차단)
     "sprintable_list_epics", "sprintable_add_epic", "sprintable_update_epic",
-    "sprintable_delete_epic",
     # hypotheses (6) — E1-S5
     "sprintable_list_hypotheses", "sprintable_get_hypothesis", "sprintable_create_hypothesis",
     "sprintable_update_hypothesis", "sprintable_link_hypothesis", "sprintable_confirm_hypothesis",
@@ -32,9 +33,9 @@ EXPECTED_TOOLS = {
     "sprintable_list_sprints", "sprintable_sprint_summary", "sprintable_activate_sprint",
     "sprintable_close_sprint", "sprintable_get_velocity", "sprintable_create_sprint",
     "sprintable_update_sprint", "sprintable_delete_sprint",
-    # docs (6)
+    # docs (5) — E-SECURITY SEC-S1(확장): delete_doc 의도적 제거(에이전트 삭제 차단)
     "sprintable_list_docs", "sprintable_get_doc", "sprintable_search_docs",
-    "sprintable_create_doc", "sprintable_update_doc", "sprintable_delete_doc",
+    "sprintable_create_doc", "sprintable_update_doc",
     # analytics (11)
     "sprintable_get_project_overview", "sprintable_get_member_workload",
     "sprintable_get_sprint_velocity_history", "sprintable_search_stories",
@@ -87,7 +88,7 @@ EXPECTED_TOOLS = {
 
 
 def test_total_tool_count():
-    assert len(_TOOLS) == 97
+    assert len(_TOOLS) == 94
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -1,4 +1,4 @@
-"""S3-6: 시스템 콜 계약 검증 — 98개 도구 등록 + 스키마 무결성 (Phase 3 완료)."""
+"""S3-6: 시스템 콜 계약 검증 — 97개 도구 등록 + 스키마 무결성 (Phase 3 완료)."""
 from __future__ import annotations
 
 import os
@@ -13,9 +13,9 @@ from sprintable_mcp.server import mcp  # noqa: E402
 _TOOLS: dict = mcp._tool_manager._tools
 
 EXPECTED_TOOLS = {
-    # stories (8)
+    # stories (7) — E-SECURITY SEC-S1: delete_story 의도적 제거(에이전트 hard-delete 차단)
     "sprintable_list_stories", "sprintable_list_backlog", "sprintable_add_story",
-    "sprintable_update_story", "sprintable_delete_story",
+    "sprintable_update_story",
     "sprintable_assign_story_to_sprint", "sprintable_unassign_story_from_sprint",
     "sprintable_update_story_status",
     # tasks (7)
@@ -87,7 +87,7 @@ EXPECTED_TOOLS = {
 
 
 def test_total_tool_count():
-    assert len(_TOOLS) == 98
+    assert len(_TOOLS) == 97
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -183,9 +183,11 @@ async def test_delete_doc_200():
         session.flush = AsyncMock()
 
         # b13352c2: delete_doc 가 cascade(resolve_member + void_pending_doc_gate) 호출 → 패치(이 테스트는 삭제만 검증·cascade는 별도).
+        # E-SECURITY SEC-S1(확장): resolve_member 결과의 type="human"이 아니면 delete_doc이 403을
+        # 내므로(에이전트 삭제 차단) 이 목의 type을 명시해야 한다.
         from unittest.mock import patch as _patch
         with _patch("app.services.member_resolver.resolve_member",
-                    new=AsyncMock(return_value=MagicMock(id=uuid.uuid4()))), \
+                    new=AsyncMock(return_value=MagicMock(id=uuid.uuid4(), type="human"))), \
              _patch("app.services.gate_service.void_pending_doc_gate", new=AsyncMock(return_value=False)):
             async with client as c:
                 resp = await c.delete(f"/api/v2/docs/{DOC_ID}")

--- a/backend/tests/test_e_mcp_s3_boot_filter.py
+++ b/backend/tests/test_e_mcp_s3_boot_filter.py
@@ -16,7 +16,8 @@ def test_disallowed_tools_explicit_group():
 def test_disallowed_tools_legacy_keeps_nondestructive_hides_destructive():
     d = server.disallowed_tools(["read", "write"])
     assert "sprintable_add_story" not in d     # 비파괴 → 노출
-    assert "sprintable_delete_story" in d       # destructive → 숨김(grant 없음)
+    # E-SECURITY SEC-S1: sprintable_delete_story 제거(에이전트 hard-delete 차단) — delete_task로 대체 예시
+    assert "sprintable_delete_task" in d        # destructive → 숨김(grant 없음)
     assert "sprintable_give_reward" in d
 
 
@@ -24,7 +25,7 @@ def test_disallowed_tools_none_fallback_equals_legacy():
     """매니페스트 fetch 실패(None) = 레거시 비파괴셋(destructive만 숨김)."""
     d = server.disallowed_tools(None)
     assert "sprintable_add_story" not in d
-    assert "sprintable_delete_story" in d
+    assert "sprintable_delete_task" in d
 
 
 def test_ping_never_in_disallowed():
@@ -48,5 +49,5 @@ def test_filter_fallback_none_hides_only_destructive(monkeypatch):
     removed: list[str] = []
     monkeypatch.setattr(server.mcp, "remove_tool", lambda name: removed.append(name))
     server.filter_tools_by_scope(None)  # degrade
-    assert "sprintable_delete_story" in removed     # destructive 숨김
-    assert "sprintable_add_story" not in removed     # 비파괴 보존
+    assert "sprintable_delete_task" in removed        # destructive 숨김
+    assert "sprintable_add_story" not in removed      # 비파괴 보존

--- a/backend/tests/test_e_mcp_s3_boot_filter.py
+++ b/backend/tests/test_e_mcp_s3_boot_filter.py
@@ -16,8 +16,9 @@ def test_disallowed_tools_explicit_group():
 def test_disallowed_tools_legacy_keeps_nondestructive_hides_destructive():
     d = server.disallowed_tools(["read", "write"])
     assert "sprintable_add_story" not in d     # 비파괴 → 노출
-    # E-SECURITY SEC-S1: sprintable_delete_story 제거(에이전트 hard-delete 차단) — delete_task로 대체 예시
-    assert "sprintable_delete_task" in d        # destructive → 숨김(grant 없음)
+    # E-SECURITY SEC-S1(확장): delete_story/task/epic/doc 제거(에이전트 hard-delete 차단) —
+    # delete_meeting으로 대체 예시(에이전트 MCP 표면에 남는 도메인 destructive 도구)
+    assert "sprintable_delete_meeting" in d        # destructive → 숨김(grant 없음)
     assert "sprintable_give_reward" in d
 
 
@@ -25,7 +26,7 @@ def test_disallowed_tools_none_fallback_equals_legacy():
     """매니페스트 fetch 실패(None) = 레거시 비파괴셋(destructive만 숨김)."""
     d = server.disallowed_tools(None)
     assert "sprintable_add_story" not in d
-    assert "sprintable_delete_task" in d
+    assert "sprintable_delete_meeting" in d
 
 
 def test_ping_never_in_disallowed():
@@ -49,5 +50,5 @@ def test_filter_fallback_none_hides_only_destructive(monkeypatch):
     removed: list[str] = []
     monkeypatch.setattr(server.mcp, "remove_tool", lambda name: removed.append(name))
     server.filter_tools_by_scope(None)  # degrade
-    assert "sprintable_delete_task" in removed        # destructive 숨김
+    assert "sprintable_delete_meeting" in removed        # destructive 숨김
     assert "sprintable_add_story" not in removed      # 비파괴 보존

--- a/backend/tests/test_e_security_sec_s1_delete_audit_realdb.py
+++ b/backend/tests/test_e_security_sec_s1_delete_audit_realdb.py
@@ -1,0 +1,206 @@
+"""E-SECURITY SEC-S1(story 70c9e92c): hard-delete 휴먼 전용화 + 삭제 감사 — 실 Postgres 검증."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session, *, human_id: uuid.UUID | None = None):
+    """org + project + agent + (선택) human org_member + story."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+    from app.models.pm import Story
+    from app.models.user import User
+    from app.models.project import OrgMember
+
+    org = Organization(id=uuid.uuid4(), name="SEC-S1 Org", slug=f"sec-s1-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="SEC-S1 Project")
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Deleting Agent", is_active=True)
+    session.add_all([project, agent])
+    await session.commit()
+
+    grant = ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted", role="member",
+    )
+    session.add(grant)
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="To Be Deleted", status="backlog")
+    session.add(story)
+    await session.commit()
+
+    human_user_id = None
+    human_org_member_id = None
+    if human_id is not None:
+        user = User(id=human_id, email=f"human-{human_id}@test.com", hashed_password="x")
+        session.add(user)
+        await session.commit()
+        om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_id, role="member")
+        session.add(om)
+        await session.commit()
+        human_user_id = human_id
+        human_org_member_id = om.id
+
+    return org.id, project.id, agent.id, story.id, human_user_id, human_org_member_id
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, member_id, org_id, *, is_agent: bool):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        claims = {"app_metadata": {"org_id": str(org_id)}}
+        if is_agent:
+            claims["app_metadata"]["api_key_id"] = "test-key"
+        return AuthContext(user_id=str(member_id), email="test@test", claims=claims)
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_agent_delete_forbidden():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id, agent_id, story_id, _hu, _ho = await _seed(s)
+
+        await _setup_app(app, Session, agent_id, org_id, is_agent=True)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/stories/{story_id}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+
+        # story는 그대로 존재
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.pm import Story
+            story = (await s.execute(select(Story).where(Story.id == story_id))).scalar_one_or_none()
+            assert story is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_human_delete_succeeds_and_audit_logged():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        human_id = uuid.uuid4()
+        async with Session() as s:
+            org_id, project_id, agent_id, story_id, human_user_id, human_org_member_id = await _seed(s, human_id=human_id)
+
+        await _setup_app(app, Session, human_id, org_id, is_agent=False)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/stories/{story_id}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.pm import Story
+            from app.models.deletion_audit import DeletionAuditLog
+
+            story = (await s.execute(select(Story).where(Story.id == story_id))).scalar_one_or_none()
+            assert story is None  # 실제로 삭제됨
+
+            logs = (await s.execute(
+                select(DeletionAuditLog).where(DeletionAuditLog.entity_id == story_id)
+            )).scalars().all()
+            assert len(logs) == 1
+            log = logs[0]
+            assert log.entity_type == "story"
+            assert log.org_id == org_id
+            assert log.entity_title == "To Be Deleted"
+            # actor_id는 resolve_member 결과(휴먼=org_member.id) — human_org_member_id와 일치
+            assert log.actor_id == human_org_member_id
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_delete_story_not_found_still_404():
+    """회귀: 존재하지 않는 story는 여전히 404(auth 체크가 그걸 가리면 안 됨)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        human_id = uuid.uuid4()
+        async with Session() as s:
+            org_id, project_id, agent_id, story_id, human_user_id, human_org_member_id = await _seed(s, human_id=human_id)
+
+        await _setup_app(app, Session, human_id, org_id, is_agent=False)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/stories/{uuid.uuid4()}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s1_ext_delete_audit_realdb.py
+++ b/backend/tests/test_e_security_sec_s1_ext_delete_audit_realdb.py
@@ -1,0 +1,369 @@
+"""E-SECURITY SEC-S1(확장, story 70c9e92c): delete_story와 동형으로 task/epic/doc/project
+hard-delete도 휴먼 전용화 + 삭제 감사 — 까심 적대적 QA 발견 갭(story만 막고 나머지는 그대로라
+prompt injection이 delete_epic/task/doc/project로 우회 가능했음) 봉쇄 실증."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session, *, admin_role: str | None = None):
+    """org + project + agent + human org_member(옵션 role) + task/epic/doc."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.pm import Epic, Story, Task
+    from app.models.doc import Doc
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="SEC-S1-EXT Org", slug=f"sec-s1-ext-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="SEC-S1-EXT Project")
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Deleting Agent", is_active=True)
+    session.add_all([project, agent])
+    await session.commit()
+
+    grant = ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted", role="member",
+    )
+    session.add(grant)
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Anchor Story", status="backlog")
+    session.add(story)
+    await session.commit()
+
+    task = Task(id=uuid.uuid4(), org_id=org.id, story_id=story.id, title="To Be Deleted Task", status="todo")
+    epic = Epic(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="To Be Deleted Epic")
+    doc = Doc(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="To Be Deleted Doc", slug=f"doc-{uuid.uuid4().hex[:8]}")
+    session.add_all([task, epic, doc])
+    await session.commit()
+
+    human_id = uuid.uuid4()
+    user = User(id=human_id, email=f"human-{human_id}@test.com", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_id, role=(admin_role or "member"))
+    session.add(om)
+    await session.commit()
+    human_grant = ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=om.id, permission="granted",
+    )
+    session.add(human_grant)
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "agent_id": agent.id,
+        "task_id": task.id, "epic_id": epic.id, "doc_id": doc.id,
+        "human_user_id": human_id, "human_org_member_id": om.id,
+    }
+
+
+async def _seed_project_only(session, *, admin_role: str | None = None):
+    """project delete 전용 최소 시드 — epic을 안 붙인다(project→epic FK가 ORM 세션에서
+    session.delete(project) 시 CASCADE 대신 SET NULL UPDATE를 먼저 시도해 NOT NULL 위반나는
+    사전 존재 버그를 이 테스트가 우연히 건드리는 것 회피. SEC-S1 스코프 밖이라 별도 플래그만)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="SEC-S1-EXT PrjOrg", slug=f"sec-s1-ext-p-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="SEC-S1-EXT Project Only")
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Deleting Agent", is_active=True)
+    session.add_all([project, agent])
+    await session.commit()
+
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    human_id = uuid.uuid4()
+    user = User(id=human_id, email=f"human-{human_id}@test.com", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_id, role=(admin_role or "member"))
+    session.add(om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=om.id, permission="granted",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "agent_id": agent.id,
+        "human_user_id": human_id, "human_org_member_id": om.id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, member_id, org_id, *, is_agent: bool):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        claims = {"app_metadata": {"org_id": str(org_id)}}
+        if is_agent:
+            claims["app_metadata"]["api_key_id"] = "test-key"
+        return AuthContext(user_id=str(member_id), email="test@test", claims=claims)
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_agent_delete_task_forbidden():
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["agent_id"], seeded["org_id"], is_agent=True)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/tasks/{seeded['task_id']}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.pm import Task
+            task = (await s.execute(select(Task).where(Task.id == seeded["task_id"]))).scalar_one_or_none()
+            assert task is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_human_delete_task_succeeds_and_audit_logged():
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], is_agent=False)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/tasks/{seeded['task_id']}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.pm import Task
+            from app.models.deletion_audit import DeletionAuditLog
+            task = (await s.execute(select(Task).where(Task.id == seeded["task_id"]))).scalar_one_or_none()
+            assert task is None
+            logs = (await s.execute(
+                select(DeletionAuditLog).where(DeletionAuditLog.entity_id == seeded["task_id"])
+            )).scalars().all()
+            assert len(logs) == 1
+            assert logs[0].entity_type == "task"
+            assert logs[0].actor_id == seeded["human_org_member_id"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_delete_doc_forbidden():
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["agent_id"], seeded["org_id"], is_agent=True)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/docs/{seeded['doc_id']}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_human_delete_doc_succeeds_and_audit_logged():
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], is_agent=False)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/docs/{seeded['doc_id']}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.deletion_audit import DeletionAuditLog
+            logs = (await s.execute(
+                select(DeletionAuditLog).where(DeletionAuditLog.entity_id == seeded["doc_id"])
+            )).scalars().all()
+            assert len(logs) == 1
+            assert logs[0].entity_type == "doc"
+            assert logs[0].actor_id == seeded["human_org_member_id"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_delete_epic_forbidden():
+    """에이전트는 admin/owner role을 org_members에 절대 가질 수 없어(휴먼 전용 grant 테이블)
+    기존 role 게이트만으로도 구조적으로 막혔으나, 명시적 human-only 체크도 독립적으로 403을 낸다."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["agent_id"], seeded["org_id"], is_agent=True)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/epics/{seeded['epic_id']}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_human_admin_delete_epic_succeeds_and_audit_logged():
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, admin_role="admin")
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], is_agent=False)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/epics/{seeded['epic_id']}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.deletion_audit import DeletionAuditLog
+            logs = (await s.execute(
+                select(DeletionAuditLog).where(DeletionAuditLog.entity_id == seeded["epic_id"])
+            )).scalars().all()
+            assert len(logs) == 1
+            assert logs[0].entity_type == "epic"
+            assert logs[0].actor_id == seeded["human_org_member_id"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_delete_project_forbidden():
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_project_only(s)
+        await _setup_app(app, Session, seeded["agent_id"], seeded["org_id"], is_agent=True)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/projects/{seeded['project_id']}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# NOTE(별개 발견·SEC-S1 스코프 밖): human-admin이 실제로 delete_project를 완주하는 realdb 테스트는
+# 의도적으로 뺐다 — `ProjectRepository.delete()`가 `session.delete(project)`를 호출할 때
+# SQLAlchemy ORM이 `Project.team_members` relationship(cascade 미설정)을 통해 관련
+# `team_members`(뷰) 행의 FK를 먼저 NULL로 UPDATE하려다 "cannot update view"로 죽는 사전 존재
+# 버그를 이 테스트가 우연히 밟았다(ObjectNotInPrerequisiteStateError) — 실 project_access grant가
+# 하나라도 있는 project는 delete_project가 이미 500일 가능성. human-only 게이트 코드 자체(위
+# agent 403 테스트로 검증됨)와는 무관한 별개 결함이라 여기서 안 건드리고 스레드에 별도 플래그.
+
+
+@pytest.mark.anyio
+async def test_human_member_role_delete_epic_still_403():
+    """member role(admin/owner 아님)인 휴먼도 기존 role 게이트로 403 — human-only 체크 추가가
+    기존 role 게이트를 우회시키지 않았음을 확인(회귀 0)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, admin_role="member")
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], is_agent=False)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/epics/{seeded['epic_id']}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_epics.py
+++ b/backend/tests/test_epics.py
@@ -374,11 +374,16 @@ def _delete_execute(*, epic, is_admin: bool):
     """delete_epic execute 시퀀스 모킹.
 
     1) repo.get → 존재 검증(scalar_one_or_none=에픽)
-    2) is_org_owner_or_admin → owner/admin 행 유무(scalar_one_or_none)
-    3) repo.delete 내부 self.get → 다시 에픽(없으면 False→404)
+    2) resolve_member — OrgMember 조회(E-SECURITY SEC-S1 확장: human-only 체크 신규 삽입)
+    3) resolve_member — User 조회(name 표시용, None이어도 무방)
+    4) is_org_owner_or_admin → owner/admin 행 유무(scalar_one_or_none)
+    5) repo.delete 내부 self.get → 다시 에픽(없으면 False→404)
     이후 cascade(dependency/label delete)는 영향 없음.
     """
     state = {"n": 0}
+    om_mock = MagicMock()
+    om_mock.id = uuid.uuid4()
+    om_mock.role = "admin" if is_admin else "member"
 
     async def _exec(stmt, *args, **kwargs):
         state["n"] += 1
@@ -386,8 +391,12 @@ def _delete_execute(*, epic, is_admin: bool):
         if state["n"] == 1:
             r.scalar_one_or_none.return_value = epic
         elif state["n"] == 2:
-            r.scalar_one_or_none.return_value = 1 if is_admin else None
+            r.scalar_one_or_none.return_value = om_mock
         elif state["n"] == 3:
+            r.scalar_one_or_none.return_value = None
+        elif state["n"] == 4:
+            r.scalar_one_or_none.return_value = 1 if is_admin else None
+        elif state["n"] == 5:
             r.scalar_one_or_none.return_value = epic
         else:
             r.scalar_one_or_none.return_value = None

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -186,9 +186,24 @@ async def test_delete_task_200():
 async def test_delete_task_404():
     client, session, app = await _client()
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        session.execute = AsyncMock(return_value=mock_result)
+        # E-SECURITY SEC-S1(확장): delete_task가 이제 resolve_member(OrgMember 조회)를 먼저
+        # 태우므로, 1번째 execute는 human org_member를 리턴하고 이후(User/task 조회)만 None이어야
+        # 의도한 404(존재하지 않는 task)를 재현한다 — 안 그러면 resolve_member 쪽 400이 먼저 뜬다.
+        om_mock = MagicMock()
+        om_mock.id = uuid.uuid4()
+        om_mock.role = "member"
+        om_mock.org_id = ORG_ID
+
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = om_mock if call_count == 1 else None
+            return result
+
+        session.execute = mock_execute
 
         async with client as c:
             resp = await c.delete(f"/api/v2/tasks/{uuid.uuid4()}")

--- a/backend/tests/test_toolset_catalog.py
+++ b/backend/tests/test_toolset_catalog.py
@@ -72,7 +72,8 @@ def test_every_tool_covered_exactly_once():
 def test_tool_group_mapping_examples():
     by_tool = {t: g["key"] for g in build_toolset_catalog()["groups"] for t in g["tools"]}
     # 도메인 destructive 는 도메인 그룹(admin 아님)
-    assert by_tool["sprintable_delete_story"] == "stories"
+    # E-SECURITY SEC-S1: sprintable_delete_story 제거(에이전트 hard-delete 차단) — delete_task로 대체 예시
+    assert by_tool["sprintable_delete_task"] == "tasks"
     assert by_tool["sprintable_give_reward"] == "rewards"
     assert by_tool["sprintable_delete_sprint"] == "sprints"
     # admin 그룹 = emit_event/trigger_ai/activate_sprint/close_sprint 등 진짜 파괴 작업만

--- a/backend/tests/test_toolset_catalog.py
+++ b/backend/tests/test_toolset_catalog.py
@@ -72,8 +72,9 @@ def test_every_tool_covered_exactly_once():
 def test_tool_group_mapping_examples():
     by_tool = {t: g["key"] for g in build_toolset_catalog()["groups"] for t in g["tools"]}
     # 도메인 destructive 는 도메인 그룹(admin 아님)
-    # E-SECURITY SEC-S1: sprintable_delete_story 제거(에이전트 hard-delete 차단) — delete_task로 대체 예시
-    assert by_tool["sprintable_delete_task"] == "tasks"
+    # E-SECURITY SEC-S1(확장): sprintable_delete_story/task/epic/doc 제거(에이전트 hard-delete
+    # 차단) — delete_meeting으로 대체 예시(에이전트 MCP 표면에 남는 도메인 destructive 도구)
+    assert by_tool["sprintable_delete_meeting"] == "meetings"
     assert by_tool["sprintable_give_reward"] == "rewards"
     assert by_tool["sprintable_delete_sprint"] == "sprints"
     # admin 그룹 = emit_event/trigger_ai/activate_sprint/close_sprint 등 진짜 파괴 작업만


### PR DESCRIPTION
## Summary
- E-SECURITY 에픽 SEC-S1(story `70c9e92c`, P0) — 외부 보안 문의(Arden) 촉발, 선생님 우선순위 상향
- `delete_story`를 휴먼 멤버 전용으로 승격: `resolve_member(auth, org_id, session).type != "human"` 이면 403 — 에이전트 API키로는 hard-delete 불가(자기 흔적 인멸 벡터 차단)
- `DeletionAuditLog` 신설 — 누가/무엇을/언제 삭제했는지 durable 기록. `entity_id`에 FK 없음(삭제 대상이 사라져도 감사 기록 생존 — story_activities는 CASCADE라 이 목적에 부적합해 배제)
- `sprintable_delete_story` MCP 툴 완전 제거(3-way sync: `sprintable_mcp/tools/stories.py`, `sprintable_mcp/server.py`, `app/services/mcp_toolset.py::ALL_TOOL_NAMES`). 총 도구 수 98→97

## Crux 요약
- 기존 "audit-like" 테이블 3종(`permission_audit_logs`, `story_activities`, `agent_audit_logs`) 검토 — 각각 role-change 전용 shape, CASCADE로 자기 자신도 삭제됨, agent_id NOT NULL로 구조가 안 맞아 전부 부적합. 신규 최소 테이블이 정당한 선택.
- delete 대상 감사(누가) 축은 A2A gate-approval 선례(`resolve_member` 기반 human-only 게이팅)를 재사용.

## Test plan
- [x] `tests/test_e_security_sec_s1_delete_audit_realdb.py` (신규 3건, 실 PG): agent 403(story 생존), human 200+감사로그(actor_id=휴먼 org_member.id) 검증, 존재하지 않는 story 404 회귀
- [x] `tests/test_stories.py::test_delete_story_200`(기존 mock 기반) 무회귀
- [x] `tests/mcp/test_contract.py` 97개 도구 카운트 갱신 + 무회귀
- [x] `tests/test_e_mcp_s3_boot_filter.py`, `tests/test_toolset_catalog.py` — `sprintable_delete_story` 예시를 `sprintable_delete_task`로 교체(툴 제거로 인한 회귀 4건 수정)
- [x] 전체 non-destructive 스위트: 3442 passed, 10 failed(수정 전) → 수정 후 baseline 환경 실패만 잔존(로컬 `.mcp.json`/python-path 무관 항목, 코드와 무관)
- [x] `alembic upgrade heads` — `0170` additive 마이그, 체인 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)