### PR TITLE
feat(security): A2A AgentCard 발견 authed+org-scoping (E-SECURITY SEC-S2)

### DIFF
--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -365,8 +365,19 @@ async def list_agent_cards(
 async def get_agent_card(
     member_id: uuid.UUID,
     session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> AgentCard:
-    member = await _get_agent_member(session, member_id)
+    """E-SECURITY SEC-S2(story 48ff642a): authed+same-org로 승격 — 이전엔 unauth+org무관이라
+    member_id만 알면 org 밖에서도 아무 agent 카드(이름·skills·URL) 조회 가능했다(멀티테넌트
+    격리 위반). action(/rpc)은 이미 P1-S2로 authed+org-scoped라 대칭 정합.
+
+    선생님 확認: A2A cross-org discovery(임대·마켓플레이스류) 자체는 버그 아닌 로드맵이었으나
+    멀티테넌트 격리가 성숙하기 前까지는 org로 좁히는 게 현시점 기본 정책 — `_get_agent_member`의
+    `org_id`가 이미 optional(None=무필터)이라 이 변경 자체가 영구 봉인이 아니라 "org_id를
+    지금 넘긴다"는 호출부 선택일 뿐, 재개는 이 인자를 안 넘기는 것으로 되돌릴 수 있다(코드 구조상
+    확장점 보존, 새 flag 불필요)."""
+    member = await _get_agent_member(session, member_id, org_id)
     card = await _build_agent_card(session, member, resolve_backend_direct_url())
     return card
 

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -8,6 +8,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 MEMBER_ID = uuid.uuid4()
+ORG_ID = uuid.uuid4()
 
 
 def _mock_member(agent_role: str | None = "qa") -> MagicMock:
@@ -139,7 +140,7 @@ def _multi_row_result():
 
 @pytest.mark.anyio
 async def test_agent_card_200_reflects_role_template_skills():
-    client, session, app = await _client()
+    client, session, app = await _authed_client(ORG_ID)
     try:
         member = _mock_member()
         persona = _mock_persona()
@@ -176,7 +177,7 @@ async def test_agent_card_interface_url_uses_backend_direct_url_not_request_sche
     테스트 클라이언트는 http://test로 요청해도 카드 url은 그 값을 반영하면 안 됨."""
     from app.routers import a2a as a2a_mod
 
-    client, session, app = await _client()
+    client, session, app = await _authed_client(ORG_ID)
     try:
         member = _mock_member()
         persona = _mock_persona()
@@ -210,7 +211,7 @@ async def test_agent_card_prefers_role_template_skills_when_linked():
     """~300직군 카탈로그 S4: persona가 recruit_agent() 생성 marker(config.role_template_id)를
     가지면, 카드-빌드 시점에 그 role_template.skills(카탈로그 실시간 값)를 우선 반영 —
     persona 생성 시점 스냅샷(slug/tool_allowlist 파생 단일 skill)이 아니라."""
-    client, session, app = await _client()
+    client, session, app = await _authed_client(ORG_ID)
     try:
         rt_id = str(uuid.uuid4())
         member = _mock_member()
@@ -250,7 +251,7 @@ async def test_agent_card_prefers_role_template_skills_when_linked():
 async def test_agent_card_falls_back_to_persona_when_role_template_skills_empty():
     """role_template_id는 있으나 그 role_template.skills가 아직 비어있으면(카탈로그 구조화
     미완료) persona-파생 단일 skill로 그레이스풀 폴백 — 빈 skills[] 노출 금지."""
-    client, session, app = await _client()
+    client, session, app = await _authed_client(ORG_ID)
     try:
         rt_id = str(uuid.uuid4())
         member = _mock_member()
@@ -285,7 +286,7 @@ async def test_agent_card_falls_back_to_persona_when_role_template_skills_empty(
 @pytest.mark.anyio
 async def test_agent_card_200_unassigned_agent_fallback_skill():
     """persona 없음(미채용) — team_members.agent_role 기반 최소 skill 하나로 폴백, 크래시 없음."""
-    client, session, app = await _client()
+    client, session, app = await _authed_client(ORG_ID)
     try:
         member = _mock_member(agent_role=None)
 
@@ -311,7 +312,7 @@ async def test_agent_card_200_unassigned_agent_fallback_skill():
 
 @pytest.mark.anyio
 async def test_agent_card_404_unknown_member():
-    client, session, app = await _client()
+    client, session, app = await _authed_client(ORG_ID)
     try:
         session.execute = AsyncMock(return_value=_result(None))
 
@@ -1357,7 +1358,7 @@ async def test_project_context_extension_ignored_when_not_declared():
 
 @pytest.mark.anyio
 async def test_agent_card_advertises_project_context_extension():
-    client, session, app = await _client()
+    client, session, app = await _authed_client(ORG_ID)
     try:
         member = _mock_member()
         persona = _mock_persona()
@@ -1390,7 +1391,7 @@ async def test_agent_card_advertises_project_context_extension():
 
 @pytest.mark.anyio
 async def test_agent_card_advertises_bearer_security_scheme():
-    client, session, app = await _client()
+    client, session, app = await _authed_client(ORG_ID)
     try:
         member = _mock_member()
         persona = _mock_persona()

--- a/backend/tests/test_a2a_sa8_multiproject_member_scope_realdb.py
+++ b/backend/tests/test_a2a_sa8_multiproject_member_scope_realdb.py
@@ -102,6 +102,23 @@ def _client_for(app):
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
 
 
+async def _authed_agent_card_overrides(app, org_id):
+    """E-SECURITY SEC-S2: agent-card.json이 authed+same-org로 승격 — 발견 테스트도 호출자 org 인증 필요."""
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(uuid.uuid4()), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
 @pytest.mark.anyio
 async def test_agent_card_multiproject_member_no_longer_500s():
     """S-A8 AC3: 멀티-project agent의 agent-card가 200 정상 카드(회귀: 이전엔 MultipleResultsFound 500)."""
@@ -111,6 +128,14 @@ async def test_agent_card_multiproject_member_no_longer_500s():
     try:
         async with Session() as s:
             org_id, project_a, project_b, agent_id = await _seed_multiproject_agent(s)
+
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        from app.dependencies.database import get_db
+        app.dependency_overrides[get_db] = _db
+        await _authed_agent_card_overrides(app, org_id)
 
         client = _client_for(app)
         try:
@@ -122,6 +147,7 @@ async def test_agent_card_multiproject_member_no_longer_500s():
         finally:
             await client.aclose()
     finally:
+        app.dependency_overrides.clear()
         await engine.dispose()
 
 
@@ -136,6 +162,14 @@ async def test_agent_card_single_project_member_regression_zero():
             org_id, project_a, project_b, _ = await _seed_multiproject_agent(s)
             solo_project_id, solo_agent_id = await _seed_single_project_agent(s, org_id)
 
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        from app.dependencies.database import get_db
+        app.dependency_overrides[get_db] = _db
+        await _authed_agent_card_overrides(app, org_id)
+
         client = _client_for(app)
         try:
             resp = await client.get(f"/api/v2/a2a/members/{solo_agent_id}/agent-card.json")
@@ -144,6 +178,7 @@ async def test_agent_card_single_project_member_regression_zero():
         finally:
             await client.aclose()
     finally:
+        app.dependency_overrides.clear()
         await engine.dispose()
 
 

--- a/backend/tests/test_e_security_sec_s2_agentcard_org_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s2_agentcard_org_scope_realdb.py
@@ -1,0 +1,175 @@
+"""E-SECURITY SEC-S2(story 48ff642a): AgentCard 발견 authed+org-scoping — 실 Postgres 검증."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_agent(session, org, project_name="P"):
+    from app.models.member import Member
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name=project_name)
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name=f"Agent-{project_name}", is_active=True)
+    session.add_all([project, agent])
+    await session.commit()
+    grant = ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted", role="member",
+    )
+    session.add(grant)
+    await session.commit()
+    return agent.id
+
+
+async def _seed_two_orgs(session):
+    from app.models.organization import Organization
+
+    org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
+    org_b = Organization(id=uuid.uuid4(), name="Org B", slug=f"org-b-{uuid.uuid4().hex[:8]}")
+    session.add_all([org_a, org_b])
+    await session.commit()
+
+    caller_id = await _seed_agent(session, org_a, "OrgA-Caller")
+    target_same_org_id = await _seed_agent(session, org_a, "OrgA-Target")
+    target_other_org_id = await _seed_agent(session, org_b, "OrgB-Target")
+
+    return org_a.id, org_b.id, caller_id, target_same_org_id, target_other_org_id
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, member_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(member_id), email="agent@test",
+            claims={"app_metadata": {"org_id": str(org_id), "api_key_id": "test-key"}},
+        )
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_agent_card_unauthenticated_now_rejected():
+    """auth override 없이 호출 시 401/403(실 get_current_user가 걸림) — unauth 시대 종료 확認."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_a_id, org_b_id, caller_id, same_org_id, other_org_id = await _seed_two_orgs(s)
+
+        # get_db만 override, auth는 실 의존성 그대로(토큰 없이 호출 → 401 기대)
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        from app.dependencies.database import get_db
+        app.dependency_overrides[get_db] = _db
+
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/a2a/members/{same_org_id}/agent-card.json")
+            assert resp.status_code in (401, 403), resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_same_org_discovery_still_free():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_a_id, org_b_id, caller_id, same_org_id, other_org_id = await _seed_two_orgs(s)
+
+        await _setup_app(app, Session, caller_id, org_a_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/a2a/members/{same_org_id}/agent-card.json")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["name"] == "Agent-OrgA-Target"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cross_org_discovery_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_a_id, org_b_id, caller_id, same_org_id, other_org_id = await _seed_two_orgs(s)
+
+        await _setup_app(app, Session, caller_id, org_a_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/a2a/members/{other_org_id}/agent-card.json")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- E-SECURITY 에픽 SEC-S2(story `48ff642a`, P0) — 외부 보안 문의(Arden) 촉발, 선생님 우선순위 상향
- `GET /api/v2/a2a/members/{id}/agent-card.json`을 무인증 공개 발견 → **authed + same-org** 로 승격
- 선생님 확認 맥락(로드맵 정합): A2A cross-org discovery(에이전트 임대/마켓플레이스류) 자체는 버그가 아니라 의도된 향후 로드맵 — 이번 변경은 **영구 폐쇄가 아니라 "현시점 기본 정책"**. `_get_agent_member(session, member_id, org_id)`의 `org_id`가 이미 optional 파라미터(A2A S-A8에서 구축)라, 이번 변경은 호출부에서 `org_id`를 넘기기 시작한 것뿐 — cross-org 재개는 이 인자를 안 넘기는 것으로 되돌릴 수 있어 코드에 영구 봉인이 없음

## Test plan
- [x] `tests/test_e_security_sec_s2_agentcard_org_scope_realdb.py` (신규 3건, 실 PG): 무인증 401/403, same-org 200, cross-org 404
- [x] 기존 `tests/test_a2a.py` agent-card 테스트 8건 — auth override 추가(unauth 시대 종료로 인한 예상된 마이그레이션, `_authed_client(ORG_ID)`로 전환)
- [x] 기존 `tests/test_a2a_sa8_multiproject_member_scope_realdb.py` agent-card 재현 테스트 2건 — 동일하게 auth override 추가
- [x] 마이그레이션 없음(순수 authz 변경, 0169 그대로)
- [x] 전체 non-destructive 스위트: 3446 passed, 6 failed(모두 baseline 환경 실패 — 로컬 `.mcp.json`/python-path 무관 항목, 코드와 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)