### PR TITLE
fix(security): refresh token 타입혼동 봉인 — Bearer 인증 우회 차단 (E-SECURITY SEC-S5 P0 핫픽스)

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -234,6 +234,15 @@ async def get_current_user(
     except JWTError as exc:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token") from exc
 
+    # E-SECURITY SEC-S5(story 278fe427·P0 핫픽스): refresh 토큰이 이 경로로 그대로 Bearer 인증을
+    # 통과하던 타입혼동 — create_access_token/create_refresh_token 둘 다 payload에 "type"을 이미
+    # 싣고 있었으나(access/refresh) 여기서 검사한 적이 없었다. refresh 토큰은 /auth/refresh 전용
+    # RefreshToken 테이블(revoked_at)로만 무효화되는데, get_current_user는 그 테이블을 전혀 보지
+    # 않고 서명·exp만 확인해 통과시켜 왔다 — 제거된 멤버의 (아직 만료 안 된) refresh 토큰이 access
+    # 토큰 대신 그대로 쓰일 수 있어 revoke가 사실상 무력화(까심 라이브 재현). access 전용으로 강제.
+    if payload.get("type") != "access":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token type")
+
     user_id: str | None = payload.get("sub")
     if not user_id:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token missing sub claim")
@@ -621,6 +630,11 @@ async def get_current_user_streaming(
         payload = decode_jwt(token)
     except JWTError as exc:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token") from exc
+
+    # E-SECURITY SEC-S5(story 278fe427·P0 핫픽스): get_current_user와 동일 타입혼동 갭 — SSE 전용
+    # 변형도 동일하게 refresh 토큰을 Bearer로 받아버려 별도 봉인 필요.
+    if payload.get("type") != "access":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token type")
 
     user_id: str | None = payload.get("sub")
     if not user_id:

--- a/backend/app/routers/ws_chat.py
+++ b/backend/app/routers/ws_chat.py
@@ -56,6 +56,10 @@ async def _authenticate(api_key: str | None, token: str | None) -> TeamMember | 
                 payload = decode_jwt(token)
             except JWTError:
                 return None
+            # E-SECURITY SEC-S5(story 278fe427·P0 핫픽스): get_current_user와 동일 타입혼동 갭 —
+            # WS 인증도 refresh 토큰을 그대로 받아들이던 봉인.
+            if payload.get("type") != "access":
+                return None
             user_id = payload.get("sub")
             if not user_id:
                 return None

--- a/backend/tests/test_e_security_sec_s5_e2e_realdb.py
+++ b/backend/tests/test_e_security_sec_s5_e2e_realdb.py
@@ -1,0 +1,122 @@
+"""E-SECURITY SEC-S5(story 278fe427·P0 핫픽스) E2E: 실 get_current_user 경로(override 없음)로
+(a)정상 access 토큰 로그인 무회귀 (b)refresh 토큰 Bearer 거부 (c)제거된 멤버의 refresh 토큰도
+거부 3종을 실증 — 오르테가 crux 요청("인증 핫픽스는 정상 로그인이 그대로 통과하는 게 생명줄") 대응.
+
+`/api/v2/accounts/resolve`는 get_current_user만 의존(DB 미의존 JWT 경로)이라 override 없이
+실 디펜던시 체인을 그대로 태울 수 있는 최소 엔드포인트."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import create_engine, text
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_SYNC = _RAW.replace("postgresql+asyncpg://", "postgresql+psycopg2://").replace(
+    "postgresql://", "postgresql+psycopg2://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _client():
+    from app.main import app
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+@pytest.mark.anyio
+async def test_normal_access_token_login_still_works_e2e():
+    """(a) 정상 access 토큰 — override 없이 실 get_current_user 경유, 200 무회귀."""
+    from app.core.security import create_access_token
+
+    user_id = str(uuid.uuid4())
+    token = create_access_token(user_id, email="alice@acme.test", app_metadata={"org_id": str(uuid.uuid4())})
+    client = _client()
+    try:
+        r = await client.post(
+            "/api/v2/accounts/resolve",
+            json={"refresh_tokens": []},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["accounts"] == []
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_refresh_token_as_bearer_rejected_e2e():
+    """(b) refresh 토큰을 Bearer로 — 실 경로에서 401(까심 재현 시나리오)."""
+    from app.core.security import create_refresh_token
+
+    user_id = str(uuid.uuid4())
+    token, _exp = create_refresh_token(user_id, app_metadata={"org_id": str(uuid.uuid4())})
+    client = _client()
+    try:
+        r = await client.post(
+            "/api/v2/accounts/resolve",
+            json={"refresh_tokens": []},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert r.status_code == 401, r.text
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_removed_member_refresh_token_still_blocked_e2e():
+    """(c) 실 DB에 human user+org_member 시드 후 org에서 제거(soft-delete)한 상태에서, 그 멤버가
+    (제거 前 발급받은) refresh 토큰을 Bearer로 재사용해도 여전히 401 — SEC-S5 원 취약점의 정확한
+    시나리오(제거된 멤버가 org 리소스 계속 접근)가 봉인됐음을 실증."""
+    from app.core.security import create_refresh_token
+
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    om_id = uuid.uuid4()
+    engine = create_engine(_SYNC)
+    try:
+        with engine.begin() as conn:
+            conn.execute(text(
+                f"INSERT INTO organizations (id,name,slug,plan) VALUES "
+                f"('{org_id}','SEC-S5 Org','sec-s5-{org_id.hex[:8]}','free')"
+            ))
+            conn.execute(text(
+                "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+                "login_fail_count,totp_enabled,totp_fail_count) "
+                f"VALUES ('{user_id}','removed-{user_id.hex[:8]}@test.com','x','Removed',true,true,0,false,0)"
+            ))
+            conn.execute(text(
+                f"INSERT INTO org_members (id,org_id,user_id,role) VALUES "
+                f"('{om_id}','{org_id}','{user_id}','member')"
+            ))
+
+        # 발급(제거 前) — SEC-S5 취약점의 실제 조건: 이미 손에 쥔 refresh 토큰.
+        token, _exp = create_refresh_token(str(user_id), app_metadata={"org_id": str(org_id)})
+
+        # 멤버 제거(soft-delete) — 실 org_members.deleted_at.
+        with engine.begin() as conn:
+            conn.execute(text(f"UPDATE org_members SET deleted_at = now() WHERE id = '{om_id}'"))
+
+        client = _client()
+        try:
+            r = await client.post(
+                "/api/v2/accounts/resolve",
+                json={"refresh_tokens": []},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            assert r.status_code == 401, r.text
+        finally:
+            await client.aclose()
+    finally:
+        with engine.begin() as conn:
+            conn.execute(text(f"DELETE FROM org_members WHERE org_id='{org_id}'"))
+            conn.execute(text(f"DELETE FROM users WHERE id='{user_id}'"))
+            conn.execute(text(f"DELETE FROM organizations WHERE id='{org_id}'"))
+        engine.dispose()

--- a/backend/tests/test_e_security_sec_s5_token_type_confusion.py
+++ b/backend/tests/test_e_security_sec_s5_token_type_confusion.py
@@ -1,0 +1,77 @@
+"""E-SECURITY SEC-S5(story 278fe427·P0 핫픽스): refresh 토큰 타입혼동 봉인.
+
+까심 라이브 재현: refresh 토큰(JWT payload에 type="refresh")이 get_current_user의 JWT 경로를
+그대로 통과해 access 토큰 대신 쓰였다(200 OK) — RefreshToken.revoked_at은 /auth/refresh 전용
+경로에서만 조회돼 제거된 멤버의 이미 발급된 refresh 토큰이 그대로 API 접근에 재사용 가능했다.
+고정 후: type != "access"는 401.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+
+from app.core.security import create_access_token, create_refresh_token
+from app.dependencies.auth import get_current_user, get_current_user_streaming
+
+
+def _creds(token: str) -> HTTPAuthorizationCredentials:
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+
+@pytest.mark.anyio
+async def test_access_token_passes_get_current_user():
+    user_id = str(uuid.uuid4())
+    token = create_access_token(user_id, app_metadata={"org_id": str(uuid.uuid4())})
+    ctx = await get_current_user(credentials=_creds(token), x_agent_api_key=None, x_mcp_transport=None, db=AsyncMock())
+    assert ctx.user_id == user_id
+
+
+@pytest.mark.anyio
+async def test_refresh_token_rejected_by_get_current_user():
+    """까심 재현 시나리오의 정확한 봉인 대상 — refresh 토큰이 Bearer로 더 이상 안 먹힌다."""
+    user_id = str(uuid.uuid4())
+    token, _exp = create_refresh_token(user_id, app_metadata={"org_id": str(uuid.uuid4())})
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user(credentials=_creds(token), x_agent_api_key=None, x_mcp_transport=None, db=AsyncMock())
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_access_token_passes_get_current_user_streaming():
+    user_id = str(uuid.uuid4())
+    token = create_access_token(user_id, app_metadata={"org_id": str(uuid.uuid4())})
+    ctx = await get_current_user_streaming(credentials=_creds(token), x_agent_api_key=None)
+    assert ctx.user_id == user_id
+
+
+@pytest.mark.anyio
+async def test_refresh_token_rejected_by_get_current_user_streaming():
+    user_id = str(uuid.uuid4())
+    token, _exp = create_refresh_token(user_id, app_metadata={"org_id": str(uuid.uuid4())})
+    with pytest.raises(HTTPException) as exc_info:
+        await get_current_user_streaming(credentials=_creds(token), x_agent_api_key=None)
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_ws_chat_authenticate_rejects_refresh_token(monkeypatch):
+    """ws_chat._authenticate도 동일 봉인 — refresh 토큰이면 None(인증 실패)."""
+    from app.routers import ws_chat
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return AsyncMock()
+
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr(ws_chat, "async_session_factory", lambda: _FakeSession())
+
+    user_id = str(uuid.uuid4())
+    refresh, _exp = create_refresh_token(user_id)
+    result = await ws_chat._authenticate(api_key=None, token=refresh)
+    assert result is None


### PR DESCRIPTION
## Summary
- E-SECURITY 에픽 SEC-S5(story `278fe427`, P0·시급 핫픽스) — 까심이 라이브 재현한 refresh token 인증 우회. 외부 보안 문의(Arden) 대응 중 발견, 선생님 최우선 지시로 SEC-S1 확장·SEC-S2 merge보다 먼저 처리
- **근본 원인**: `create_access_token`/`create_refresh_token`(`app/core/security.py:70,88`) 둘 다 JWT payload에 `type`("access"/"refresh")을 이미 싣고 있었지만, Bearer 인증 경로 3곳(`get_current_user`, `get_current_user_streaming`, `ws_chat._authenticate`) 어디도 이를 검사하지 않았다 — `sub`/서명/`exp`만 확인하면 통과
- **영향**: refresh 토큰은 access 토큰보다 훨씬 장수명(`REFRESH_TOKEN_EXPIRE_DAYS`)이고, 그 revoke는 `RefreshToken.revoked_at`(DB 컬럼)으로만 관리되는데 이 컬럼은 `/auth/refresh` 전용 경로에서만 조회된다. 즉 제거된 멤버가 이미 발급받은 refresh 토큰을 Bearer로 직접 사용하면, revoke가 전혀 반영되지 않은 채(JWT `exp`까지) org 리소스에 계속 접근 가능했다
- **수정**: 3개 인증 경로 모두 JWT 디코드 후 `payload.get("type") != "access"`면 거부(HTTPException 401 / WS는 None) — access 토큰만 Bearer로 허용

## Test plan
- [x] `tests/test_e_security_sec_s5_token_type_confusion.py` (신규 5건): access 토큰은 3경로 모두 통과, refresh 토큰은 3경로 모두 거부(까심 재현 시나리오의 정확한 봉인)
- [x] 기존 auth 관련 테스트 94건(`test_auth_security.py`·`test_auth_password_reset.py`·`test_auth_email_verification.py`·`test_supabase_vestige_fc7bce47.py`·`test_c_s1.py`·`test_e_org_multi_s2_1_switch_organization.py`·`test_908075db_stage3_switch_guards.py` 등) 무회귀 — password_reset/email_verification/oauth_state 토큰은 이미 자체 `type` 검사를 갖고 있어 이 경로와 무관
- [x] `tests/test_account_resolve_realdb.py`(실 PG, refresh rotation 왕복 포함) 6건 무회귀
- [x] 전체 non-destructive 스위트: 3448 passed, 6 failed(모두 baseline 환경 실패 — 로컬 `.mcp.json`/python-path 무관 항목)
- [x] 마이그레이션 없음(순수 인증 로직)
- [x] JWT 발급 경로 전수 확인(`jwt.encode` grep) — 이 Bearer 경로로 흘러들 수 있는 모든 토큰(access/refresh)이 이미 `type` claim을 갖고 있어 레거시 토큰 파손 없음(github_app.py는 별도 시크릿·별도 용도라 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)