### PR TITLE
fix(security): GET /members?project_id= 스코프 검증 — 타 org 멤버 로스터 열거 차단 (E-SECURITY SEC-S6)

### DIFF
--- a/backend/app/routers/members.py
+++ b/backend/app/routers/members.py
@@ -5,9 +5,10 @@ from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.team import TeamMember
+from app.services.project_auth import assert_target_in_caller_org
 
 router = APIRouter(prefix="/api/v2/members", tags=["members"])
 
@@ -27,12 +28,23 @@ async def list_members(
     project_id: uuid.UUID = Query(...),
     session: AsyncSession = Depends(get_db),
     _auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> list[MemberResponse]:
     """프로젝트 멤버 목록.
 
     Human: org_members + project_access JOIN (grant 모델 — 레코드 있음 = 접근 허용).
     Agent: team_members(type=agent) 그대로 유지.
     """
+    # E-SECURITY SEC-S6(story 54248174·까심 QA 부수발견 D): project_id가 caller org 소속인지
+    # 대조한 적이 없어 타 org project_id로 그 org 멤버 로스터가 그대로 열거됐다(cross-org IDOR).
+    # 존재/타org 둘 다 404(존재 비노출).
+    project_org_row = await session.execute(
+        text("SELECT org_id FROM projects WHERE id = :project_id"),
+        {"project_id": project_id},
+    )
+    project_org_id = project_org_row.scalar_one_or_none()
+    assert_target_in_caller_org(org_id, project_org_id, not_found_detail="Project not found")
+
     result: list[MemberResponse] = []
 
     # Human members — org owner/admin은 grant 없이도 항상 포함 (S-MBR-03).
@@ -42,6 +54,8 @@ async def list_members(
     # 기존 `COALESCE(u.email,'')`는 휴먼을 항상 raw 이메일로 노출해, 동일 휴먼을
     # 실명(display_name)으로 보여주는 org 로스터(team_member.py list_org_human_members)와
     # 어긋났다(보드/Dispatch assignee 가 email 노출). 두 경로를 동일 COALESCE 로 정렬한다.
+    #
+    # p.org_id = :org_id — 위 가드로 이미 보장되지만 defense-in-depth로 join에도 명시.
     human_rows = await session.execute(
         text(
             """
@@ -50,7 +64,7 @@ async def list_members(
                    om.role
             FROM org_members om
             JOIN users u ON u.id = om.user_id
-            JOIN projects p ON p.org_id = om.org_id AND p.id = :project_id
+            JOIN projects p ON p.org_id = om.org_id AND p.id = :project_id AND p.org_id = :org_id
             LEFT JOIN members m ON m.org_id = om.org_id AND m.user_id = om.user_id
                                AND m.type = 'human' AND m.deleted_at IS NULL
             WHERE om.deleted_at IS NULL
@@ -66,7 +80,7 @@ async def list_members(
             ORDER BY name
             """
         ),
-        {"project_id": str(project_id)},
+        {"project_id": str(project_id), "org_id": str(org_id)},
     )
     for row in human_rows:
         result.append(MemberResponse(id=row[0], name=row[1], type="human", role=row[2], is_active=True))

--- a/backend/app/services/project_auth.py
+++ b/backend/app/services/project_auth.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import uuid
 
+from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -15,6 +16,25 @@ from sqlalchemy.ext.asyncio import AsyncSession
 # 이 집합으로 clamp 돼야 CHECK 위반(500)이 없다. 랭크: owner > admin > member.
 PROJECT_ROLES: tuple[str, ...] = ("owner", "admin", "member")
 PROJECT_ROLE_RANK: dict[str, int] = {"owner": 3, "admin": 2, "member": 1}
+
+
+def assert_target_in_caller_org(
+    caller_org_id: uuid.UUID,
+    target_org_id: uuid.UUID | None,
+    *,
+    not_found_detail: str = "Not found",
+) -> None:
+    """E-SECURITY SEC-S6/S7 계열 cross-org IDOR 공통 가드.
+
+    까심 QA 부수발견 D(roster: project_id)·E(persona: agent_id) 공통 근본 — 호출자 org를 body/
+    query param으로 받은 target(project·agent 등 어떤 org-scoped 엔티티든)의 **실제** org와 대조한
+    적이 없어, target_id만 알면 어느 org 소속이든 caller org와 무관하게 통과됐다. 호출부가
+    target의 실 org_id를 먼저 조회(엔티티마다 다른 쿼리)해 이 단일 비교 지점으로 넘기면 된다.
+    미존재(target_org_id=None)도 불일치와 동일하게 404 — 존재 비노출(타 org에 그 리소스가 있는지
+    자체가 정보 누수).
+    """
+    if target_org_id is None or target_org_id != caller_org_id:
+        raise HTTPException(status_code=404, detail=not_found_detail)
 
 
 def clamp_project_role(role: str | None) -> str:

--- a/backend/tests/test_e_security_sec_s6_roster_org_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s6_roster_org_scope_realdb.py
@@ -1,0 +1,220 @@
+"""E-SECURITY SEC-S6(story 54248174·까심 QA 부수발견 D): GET /api/v2/members?project_id= 스코프
+검증 — 타 org project_id로 그 org 멤버 로스터가 그대로 열거되던 cross-org IDOR 봉쇄 실증.
+
+동시에 `assert_target_in_caller_org` 공통 가드가 D(project)뿐 아니라 E(agent_personas의
+agent_id) 형태의 target에도 그대로 재사용 가능한지 순수 함수 레벨로 실측(SEC-S7 crux 재사용
+근거)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_two_orgs(session):
+    """Org A caller(휴먼)·Org B project + 멤버(휴먼1+에이전트1) — D 재현용."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
+    org_b = Organization(id=uuid.uuid4(), name="Org B", slug=f"org-b-{uuid.uuid4().hex[:8]}")
+    session.add_all([org_a, org_b])
+    await session.commit()
+
+    caller_user_id = uuid.uuid4()
+    caller_user = User(id=caller_user_id, email=f"caller-{caller_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller_user)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=caller_user_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+
+    project_b = Project(id=uuid.uuid4(), org_id=org_b.id, name="Org B Project")
+    session.add(project_b)
+    await session.commit()
+
+    target_user_id = uuid.uuid4()
+    target_user = User(id=target_user_id, email=f"target-{target_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(target_user)
+    await session.commit()
+    target_om = OrgMember(id=uuid.uuid4(), org_id=org_b.id, user_id=target_user_id, role="admin")
+    session.add(target_om)
+    await session.commit()
+
+    agent_b = Member(id=uuid.uuid4(), org_id=org_b.id, type="agent", name="Org B Agent", is_active=True)
+    session.add(agent_b)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_b.id, member_id=agent_b.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_a_id": org_a.id, "org_b_id": org_b.id,
+        "caller_user_id": caller_user_id, "project_b_id": project_b.id,
+        "target_admin_name": target_user.email,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_cross_org_project_id_roster_blocked():
+    """까심 D 재현: Org A caller가 Org B project_id로 조회 시도 → 404(로스터 비노출)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_orgs(s)
+
+        await _setup_app(app, Session, seeded["caller_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/members?project_id={seeded['project_b_id']}")
+            assert resp.status_code == 404, resp.text
+            assert "Org B Agent" not in resp.text
+            assert seeded["target_admin_name"] not in resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_same_org_project_id_roster_still_free():
+    """회귀 0: Org B caller가 자기 org의 project_id로 조회하면 정상 로스터(휴먼+에이전트) 반환."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_orgs(s)
+
+        await _setup_app(app, Session, seeded["caller_user_id"], seeded["org_b_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/members?project_id={seeded['project_b_id']}")
+            assert resp.status_code == 200, resp.text
+            members = resp.json()
+            names = {m["name"] for m in members}
+            assert seeded["target_admin_name"] in names
+            assert "Org B Agent" in names
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_nonexistent_project_id_also_404():
+    """존재하지 않는 project_id도 동일하게 404(타org·미존재 구분 안 함 — 존재 비노출)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_orgs(s)
+
+        await _setup_app(app, Session, seeded["caller_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/members?project_id={uuid.uuid4()}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+def test_assert_target_in_caller_org_reusable_for_agent_target():
+    """SEC-S7 crux 실측: 공통 가드가 project 형태뿐 아니라 agent(persona target) 형태의
+    target_org_id 비교에도 그대로 재사용 가능 — 순수 함수라 실 agent row 없이도 로직 검증 충분."""
+    from fastapi import HTTPException
+    from app.services.project_auth import assert_target_in_caller_org
+
+    caller_org = uuid.uuid4()
+    same_org_agent_org = caller_org
+    other_org_agent_org = uuid.uuid4()
+
+    # same-org agent target → 통과(예외 없음)
+    assert_target_in_caller_org(caller_org, same_org_agent_org, not_found_detail="Agent not found")
+
+    # cross-org agent target → 404
+    with pytest.raises(HTTPException) as exc_info:
+        assert_target_in_caller_org(caller_org, other_org_agent_org, not_found_detail="Agent not found")
+    assert exc_info.value.status_code == 404
+
+    # 존재하지 않는 agent(org 조회 자체가 None) → 동일 404
+    with pytest.raises(HTTPException) as exc_info2:
+        assert_target_in_caller_org(caller_org, None, not_found_detail="Agent not found")
+    assert exc_info2.value.status_code == 404

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -277,10 +277,13 @@ async def test_current_project_get_via_conftest(test_client, mock_session):
 
 
 @pytest.mark.anyio
-async def test_members_list_via_conftest_s6(test_client, mock_session, project_id):
+async def test_members_list_via_conftest_s6(test_client, mock_session, project_id, org_id):
     """GET /api/v2/members 200."""
     mock_result = MagicMock()
     mock_result.scalars.return_value.all.return_value = []
+    # E-SECURITY SEC-S6: list_members가 먼저 project의 실 org_id를 조회해 caller org(=org_id
+    # fixture)와 대조한다 — 블랑켓 목이라 이 값을 맞춰야 그 가드를 통과한다.
+    mock_result.scalar_one_or_none.return_value = org_id
     mock_session.execute = AsyncMock(return_value=mock_result)
 
     resp = await test_client.get(f"/api/v2/members?project_id={project_id}")

--- a/backend/tests/test_s33.py
+++ b/backend/tests/test_s33.py
@@ -224,6 +224,9 @@ async def test_members_list_200():
 
         mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = [member_mock]
+        # E-SECURITY SEC-S6: list_members가 먼저 project의 실 org_id를 조회해 caller org(ORG_ID)와
+        # 대조한다 — 블랑켓 목이라 이 값을 맞춰야 그 가드를 통과한다.
+        mock_result.scalar_one_or_none.return_value = ORG_ID
         session.execute = AsyncMock(return_value=mock_result)
 
         async with client as c:

--- a/backend/tests/test_s_mbr_03.py
+++ b/backend/tests/test_s_mbr_03.py
@@ -229,7 +229,13 @@ async def test_list_members_owner_always_included():
     from app.routers.members import list_members
 
     project_id = uuid.uuid4()
+    org_id = uuid.uuid4()
     mock_session = AsyncMock()
+
+    # E-SECURITY SEC-S6: list_members가 이제 먼저 project의 실 org_id를 조회해 caller org와
+    # 대조한다 — 이 목이 그 1번째 execute()에 응답.
+    org_lookup_mock = MagicMock()
+    org_lookup_mock.scalar_one_or_none.return_value = org_id
 
     # Human rows: org owner (id=owner_id) + org member (id=member_id)
     owner_id = uuid.uuid4()
@@ -244,10 +250,10 @@ async def test_list_members_owner_always_included():
     agent_mock = MagicMock()
     agent_mock.scalars.return_value.all.return_value = []
 
-    mock_session.execute = AsyncMock(side_effect=[human_mock, agent_mock])
+    mock_session.execute = AsyncMock(side_effect=[org_lookup_mock, human_mock, agent_mock])
     mock_auth = MagicMock()
 
-    result = await list_members(project_id=project_id, session=mock_session, _auth=mock_auth)
+    result = await list_members(project_id=project_id, session=mock_session, _auth=mock_auth, org_id=org_id)
     # 두 멤버 모두 포함
     assert len(result) == 2
     roles = {r.role for r in result}

--- a/backend/tests/test_s_mbr_10.py
+++ b/backend/tests/test_s_mbr_10.py
@@ -76,10 +76,15 @@ async def test_list_members_org_member_requires_grant():
     from app.routers.members import list_members
 
     project_id = uuid.uuid4()
+    org_id = uuid.uuid4()
     mock_session = AsyncMock()
 
     owner_id = uuid.uuid4()
     member_id = uuid.uuid4()
+
+    # E-SECURITY SEC-S6: list_members가 먼저 project의 실 org_id를 조회해 caller org와 대조한다.
+    org_lookup_mock = MagicMock()
+    org_lookup_mock.scalar_one_or_none.return_value = org_id
 
     # owner 포함, member 미포함 (grant 없음)
     human_mock = MagicMock()
@@ -91,10 +96,10 @@ async def test_list_members_org_member_requires_grant():
     agent_mock = MagicMock()
     agent_mock.scalars.return_value.all.return_value = []
 
-    mock_session.execute = AsyncMock(side_effect=[human_mock, agent_mock])
+    mock_session.execute = AsyncMock(side_effect=[org_lookup_mock, human_mock, agent_mock])
     mock_auth = MagicMock()
 
-    result = await list_members(project_id=project_id, session=mock_session, _auth=mock_auth)
+    result = await list_members(project_id=project_id, session=mock_session, _auth=mock_auth, org_id=org_id)
     assert len(result) == 1
     assert result[0].role == "owner"
 
@@ -105,10 +110,15 @@ async def test_list_members_member_with_grant_included():
     from app.routers.members import list_members
 
     project_id = uuid.uuid4()
+    org_id = uuid.uuid4()
     mock_session = AsyncMock()
 
     owner_id = uuid.uuid4()
     member_id = uuid.uuid4()
+
+    # E-SECURITY SEC-S6: list_members가 먼저 project의 실 org_id를 조회해 caller org와 대조한다.
+    org_lookup_mock = MagicMock()
+    org_lookup_mock.scalar_one_or_none.return_value = org_id
 
     # owner + member(grant 있음) 둘 다 포함
     human_mock = MagicMock()
@@ -120,10 +130,10 @@ async def test_list_members_member_with_grant_included():
     agent_mock = MagicMock()
     agent_mock.scalars.return_value.all.return_value = []
 
-    mock_session.execute = AsyncMock(side_effect=[human_mock, agent_mock])
+    mock_session.execute = AsyncMock(side_effect=[org_lookup_mock, human_mock, agent_mock])
     mock_auth = MagicMock()
 
-    result = await list_members(project_id=project_id, session=mock_session, _auth=mock_auth)
+    result = await list_members(project_id=project_id, session=mock_session, _auth=mock_auth, org_id=org_id)
     assert len(result) == 2
     roles = {r.role for r in result}
     assert "owner" in roles


### PR DESCRIPTION
## Summary
- E-SECURITY SEC-S6(story `54248174`, P1) — 까심 QA 부수발견 D, **라이브 재현 CONFIRMED**(2026-07-10·HIGH·develop `30da25c2`)
- `GET /api/v2/members?project_id=`가 `get_current_user` 인증만 요구(`_auth` 미사용)하고, 로스터 쿼리는 `project_id`가 속한 org의 `org_members`를 그대로 나열 — **호출자가 그 org 소속인지 검증한 적이 없어** project_id만 알면 어느 org의 멤버 로스터(이름/역할/활성상태)든 cross-org로 열람 가능했음(refresh token 갭 C와 함께 라이브 확정된 보안 갭)

## Crux — 공통 헬퍼
D(roster: project_id)와 E(persona: agent_id, SEC-S7)는 같은 근본(**호출자 org를 body/param target의 실제 org와 대조 안 함**)이라, 오르테가 요청대로 공통 가드를 만들었음:
```python
def assert_target_in_caller_org(caller_org_id, target_org_id, *, not_found_detail="Not found") -> None:
    if target_org_id is None or target_org_id != caller_org_id:
        raise HTTPException(status_code=404, detail=not_found_detail)
```
호출부가 target의 실제 org_id를 먼저 조회(엔티티마다 다른 쿼리)해 이 단일 비교 지점으로 넘기는 구조. `test_assert_target_in_caller_org_reusable_for_agent_target`로 agent target 시나리오까지 순수 함수 레벨에서 재사용성을 실측(SEC-S7이 그대로 가져다 쓸 수 있음을 증명) — 단 실제 `agent_personas.py` 배선은 SEC-S7 스코프로 남김.

## Test plan
- [x] `tests/test_e_security_sec_s6_roster_org_scope_realdb.py`(신규 4건, 실 PG): cross-org project_id → 404(로스터 비노출), same-org → 200(정상 로스터), 미존재 project_id → 404, 헬퍼의 agent-target 재사용성 단위 테스트
- [x] 기존 mock 기반 members 테스트 5건(`test_s33`·`test_s_mbr_03`·`test_s_mbr_10`×2·`test_integration`) — 신규 org_id 조회 execute() 삽입으로 mock 시퀀스가 밀려 실패 → 갱신(회귀 아님)
- [x] 마이그레이션 없음
- [x] 전체 non-destructive 스위트: 3455 passed, 6 failed(모두 baseline 환경 실패)

🤖 Generated with [Claude Code](https://claude.com/claude-code)