### PR TITLE
[SID:e9527ed1] E-CANVAS C1-S4 artifact 뷰어 셸 (mock 데이터, BE 대기)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3358,5 +3358,16 @@
     "evidenceTypeMetric": "Metric",
     "evidenceTypeReport": "Report",
     "evidenceTypeGateApproval": "Gate approval"
+  },
+  "canvas": {
+    "versionLineage": "Version lineage",
+    "versionCurrentTag": "current",
+    "versionAnchorTag": "anchor",
+    "anchorBadge": "Anchor v{version}",
+    "descriptionPaneToggle": "description pane",
+    "descriptionPaneComingSoon": "Per-element spec (description pane) arrives in C2",
+    "exportComingSoon": "Export arrives in C1-S5",
+    "commentsComingSoon": "Comments arrive in C2",
+    "treeRenderPlaceholder": "Tree rendering coming soon"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3358,5 +3358,16 @@
     "evidenceTypeMetric": "지표",
     "evidenceTypeReport": "리포트",
     "evidenceTypeGateApproval": "게이트 승인"
+  },
+  "canvas": {
+    "versionLineage": "버전 lineage",
+    "versionCurrentTag": "지금",
+    "versionAnchorTag": "정본",
+    "anchorBadge": "정본 v{version}",
+    "descriptionPaneToggle": "description pane",
+    "descriptionPaneComingSoon": "요소별 스펙(description pane)은 C2에서 제공 예정",
+    "exportComingSoon": "export는 C1-S5에서 제공 예정",
+    "commentsComingSoon": "코멘트는 C2에서 제공 예정",
+    "treeRenderPlaceholder": "트리 렌더는 준비 중"
   }
 }

--- a/apps/web/src/app/(authenticated)/docs/canvas-preview/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/canvas-preview/page.tsx
@@ -1,0 +1,27 @@
+import { ArtifactViewer } from '@/components/canvas/artifact-viewer';
+import { MOCK_ARTIFACT, MOCK_VERSIONS, MOCK_MEMBERS } from '@/services/canvas';
+
+/**
+ * E-CANVAS C1-S4 내부 프리뷰 — `docs/design-tokens`와 동일한 "라이브 dev QA용 인증된
+ * 내부 라우트" 패턴. BE(`visual_artifact`) 계약 착지 前까지 mock 데이터로 뷰어 픽셀을
+ * 검증하는 용도. 계약 착지 후 실 데이터 소비처(스토리 상세 등)가 생기면 이 페이지는
+ * 회귀가드용 참조 렌더로 남겨둔다.
+ */
+export default function CanvasPreviewPage() {
+  return (
+    <div className="mx-auto max-w-2xl space-y-4 p-6">
+      <div>
+        <h1 className="text-lg font-semibold text-foreground">E-CANVAS C1 — Artifact Viewer 프리뷰</h1>
+        <p className="mt-1 text-xs text-muted-foreground">
+          mock 데이터(BE `visual_artifact` 계약 미착지) · 버전 클릭으로 lineage 전환 확인
+        </p>
+      </div>
+      <ArtifactViewer
+        artifact={MOCK_ARTIFACT}
+        versions={MOCK_VERSIONS}
+        memberMap={MOCK_MEMBERS}
+        commentCount={2}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/canvas/artifact-stage.test.ts
+++ b/apps/web/src/components/canvas/artifact-stage.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { parseArtifactTree } from './artifact-stage';
+
+describe('parseArtifactTree', () => {
+  it('parses a valid node array', () => {
+    const content = JSON.stringify([{ id: 'n1', type: 'Card', children: [{ id: 'n2', type: 'Text', props: { text: 'hi' } }] }]);
+    const tree = parseArtifactTree(content);
+    expect(tree).not.toBeNull();
+    expect(tree?.[0]?.id).toBe('n1');
+    expect(tree?.[0]?.children?.[0]?.props?.text).toBe('hi');
+  });
+
+  it('returns null for malformed JSON (no crash)', () => {
+    expect(parseArtifactTree('not json')).toBeNull();
+  });
+
+  it('returns null when content is not an array', () => {
+    expect(parseArtifactTree(JSON.stringify({ id: 'n1', type: 'Card' }))).toBeNull();
+  });
+
+  it('returns null when array items lack required fields', () => {
+    expect(parseArtifactTree(JSON.stringify([{ id: 'n1' }]))).toBeNull();
+  });
+});

--- a/apps/web/src/components/canvas/artifact-stage.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.tsx
@@ -47,9 +47,11 @@ interface ArtifactStageProps {
 }
 
 /**
- * 포맷별 렌더 스테이지. html=샌드박스 iframe(스크립트 차단 — `sandbox`에 allow-scripts 없음,
- * 핸드오프 §3-1)·image=바운드 img·tree=경량 노드 렌더(전신 componentCatalog의 리치 렌더는
- * 후속 — 지금은 shell 준비 단계).
+ * 포맷별 렌더 스테이지. html=완전 잠금 샌드박스 iframe(`sandbox=""` — allow-scripts·
+ * allow-same-origin 둘 다 없음, 핸드오프 §3-1 + 유나 디자인 가디언 보안 지적 반영).
+ * artifact HTML은 인라인 `<style>`만 쓰므로 same-origin 리소스 접근이 필요 없어 최대
+ * 잠금이 안전(CSS 렌더링은 sandbox 플래그와 무관하게 항상 동작함)·image=바운드 img·
+ * tree=경량 노드 렌더(전신 componentCatalog의 리치 렌더는 후속 — 지금은 shell 준비 단계).
  */
 export function ArtifactStage({ format, content, title }: ArtifactStageProps) {
   const t = useTranslations('canvas');
@@ -59,7 +61,7 @@ export function ArtifactStage({ format, content, title }: ArtifactStageProps) {
       <iframe
         title={title}
         srcDoc={content}
-        sandbox="allow-same-origin"
+        sandbox=""
         className="h-full min-h-[280px] w-full rounded-lg border border-border bg-background"
       />
     );

--- a/apps/web/src/components/canvas/artifact-stage.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.tsx
@@ -1,0 +1,82 @@
+import { useTranslations } from 'next-intl';
+import type { ArtifactFormat } from '@/services/canvas';
+
+/**
+ * E-CANVAS C1 — tree 포맷 최소 노드 shape. BE 계약(디디 C1-S3) 착지 전 잠정 — 실 계약이
+ * flat adjacency-list(전신 `/mockups` 패턴)로 오면 이 shape로 변환하는 어댑터만 추가하면 됨
+ * (렌더 로직 자체는 안 건드림).
+ */
+export interface ArtifactTreeNode {
+  id: string;
+  type: string;
+  props?: Record<string, unknown>;
+  children?: ArtifactTreeNode[];
+}
+
+/** content 문자열을 tree 노드 배열로 안전 파싱 — 형태가 아니면 null(크래시 대신 폴백 렌더). */
+export function parseArtifactTree(content: string): ArtifactTreeNode[] | null {
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    if (!Array.isArray(parsed)) return null;
+    if (!parsed.every((n) => typeof n === 'object' && n !== null && 'id' in n && 'type' in n)) return null;
+    return parsed as ArtifactTreeNode[];
+  } catch {
+    return null;
+  }
+}
+
+function TreeNodeBox({ node }: { node: ArtifactTreeNode }) {
+  const text = typeof node.props?.['text'] === 'string' ? (node.props['text'] as string) : node.type;
+  return (
+    <div className="rounded-md border border-border bg-card p-2 text-xs text-foreground">
+      <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{node.type}</span>
+      {text ? <p className="mt-0.5 truncate">{text}</p> : null}
+      {node.children && node.children.length > 0 ? (
+        <div className="mt-1.5 space-y-1.5 border-l border-border pl-2">
+          {node.children.map((c) => <TreeNodeBox key={c.id} node={c} />)}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+interface ArtifactStageProps {
+  format: ArtifactFormat;
+  content: string;
+  title: string;
+}
+
+/**
+ * 포맷별 렌더 스테이지. html=샌드박스 iframe(스크립트 차단 — `sandbox`에 allow-scripts 없음,
+ * 핸드오프 §3-1)·image=바운드 img·tree=경량 노드 렌더(전신 componentCatalog의 리치 렌더는
+ * 후속 — 지금은 shell 준비 단계).
+ */
+export function ArtifactStage({ format, content, title }: ArtifactStageProps) {
+  const t = useTranslations('canvas');
+
+  if (format === 'html') {
+    return (
+      <iframe
+        title={title}
+        srcDoc={content}
+        sandbox="allow-same-origin"
+        className="h-full min-h-[280px] w-full rounded-lg border border-border bg-background"
+      />
+    );
+  }
+
+  if (format === 'image') {
+    // eslint-disable-next-line @next/next/no-img-element -- artifact content는 외부/동적 URL(임의 도메인)이라 next/image 도메인 화이트리스트와 안 맞음.
+    return <img src={content} alt={title} className="mx-auto max-h-[420px] max-w-full rounded-lg object-contain" />;
+  }
+
+  const tree = parseArtifactTree(content);
+  if (!tree) {
+    return <p className="p-4 text-xs text-muted-foreground">{t('treeRenderPlaceholder')}</p>;
+  }
+  return (
+    <div className="space-y-2 p-2">
+      {tree.map((node) => <TreeNodeBox key={node.id} node={node} />)}
+    </div>
+  );
+}

--- a/apps/web/src/components/canvas/artifact-version-rail.tsx
+++ b/apps/web/src/components/canvas/artifact-version-rail.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+import type { ArtifactVersion, MemberRef, VisualArtifact } from '@/services/canvas';
+
+interface ArtifactVersionRailProps {
+  artifact: VisualArtifact;
+  versions: ArtifactVersion[];
+  selectedVersion: number;
+  onSelectVersion: (version: number) => void;
+  memberMap?: Record<string, MemberRef>;
+}
+
+/**
+ * E-CANVAS C1 Lv1 — 버전 lineage 레일. 각 엔트리 = 변경자·변경 이유(의미 단위)만.
+ * raw 편집 나열 금지(핸드오프 §6 감시 게이트) — 여기 보이는 게 실제 저장된 커밋 단위 전부다.
+ */
+export function ArtifactVersionRail({ artifact, versions, selectedVersion, onSelectVersion, memberMap = {} }: ArtifactVersionRailProps) {
+  const t = useTranslations('canvas');
+  const [descOpen, setDescOpen] = useState(false);
+  const sorted = [...versions].sort((a, b) => b.version - a.version);
+
+  return (
+    <div className="border-l border-border p-3">
+      <p className="mb-3 text-[10px] font-bold uppercase tracking-wide text-muted-foreground">{t('versionLineage')}</p>
+      <ul className="space-y-3">
+        {sorted.map((v) => {
+          const isCurrent = v.version === artifact.current_version;
+          const isAnchor = v.version === artifact.anchor_version;
+          const isSelected = v.version === selectedVersion;
+          const authorName = memberMap[v.created_by]?.name ?? '—';
+          return (
+            <li key={v.id}>
+              <button
+                type="button"
+                onClick={() => onSelectVersion(v.version)}
+                className={cn(
+                  'flex w-full items-start gap-2 rounded-md p-1 text-left transition-colors hover:bg-muted/40',
+                  isSelected && 'bg-muted/60',
+                )}
+              >
+                <span
+                  className={cn(
+                    'mt-0.5 h-2.5 w-2.5 shrink-0 rounded-full border-2',
+                    isAnchor ? 'border-success bg-success/85' : isCurrent ? 'border-info bg-info' : 'border-border bg-background',
+                  )}
+                  aria-hidden
+                />
+                <div className="min-w-0 flex-1">
+                  <p className="flex items-center gap-1.5 text-xs font-semibold text-foreground">
+                    v{v.version}
+                    {isCurrent ? (
+                      <span className="rounded bg-info/10 px-1 py-0.5 text-[9px] font-bold text-info">{t('versionCurrentTag')}</span>
+                    ) : null}
+                    {isAnchor ? (
+                      <span className="rounded bg-success/10 px-1 py-0.5 text-[9px] font-bold text-success">{t('versionAnchorTag')}</span>
+                    ) : null}
+                  </p>
+                  <p className="mt-0.5 truncate text-[11px] text-muted-foreground">
+                    {authorName}{v.summary ? ` · ${v.summary}` : ''}
+                  </p>
+                </div>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      <button
+        type="button"
+        onClick={() => setDescOpen((v) => !v)}
+        className="mt-3 flex w-full items-center gap-1 border-t border-border pt-3 text-left text-[11px] text-muted-foreground hover:text-foreground"
+      >
+        {t('descriptionPaneToggle')}
+        {descOpen ? <ChevronUp className="h-3 w-3" aria-hidden /> : <ChevronDown className="h-3 w-3" aria-hidden />}
+      </button>
+      {descOpen ? (
+        <p className="mt-1.5 text-[11px] text-muted-foreground/80">{t('descriptionPaneComingSoon')}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/canvas/artifact-viewer.test.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { ArtifactViewer } from './artifact-viewer';
+import { MOCK_ARTIFACT, MOCK_VERSIONS, MOCK_MEMBERS } from '@/services/canvas';
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+describe('ArtifactViewer (SSR snapshot)', () => {
+  it('renders the anchor badge for the artifact anchor version, not the currently-selected one', () => {
+    const markup = renderToStaticMarkup(
+      wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+    );
+    // MOCK_ARTIFACT.anchor_version = 3 — badge shows "정본 v3" regardless of current_version=4 being selected by default.
+    expect(markup).toContain('정본 v3');
+  });
+
+  it('sandboxes the html stage without allow-scripts (감시/보안 게이트 — 핸드오프 §3-1)', () => {
+    const markup = renderToStaticMarkup(
+      wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+    );
+    expect(markup).toContain('sandbox="allow-same-origin"');
+    expect(markup).not.toContain('allow-scripts');
+  });
+
+  it('omits the anchor badge entirely when the artifact has no anchor version yet (초안 중립·낙인 금지)', () => {
+    const draftArtifact = { ...MOCK_ARTIFACT, anchor_version: null };
+    const markup = renderToStaticMarkup(
+      wrap(<ArtifactViewer artifact={draftArtifact} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+    );
+    expect(markup).not.toContain('정본 v');
+  });
+});

--- a/apps/web/src/components/canvas/artifact-viewer.test.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.test.tsx
@@ -22,12 +22,13 @@ describe('ArtifactViewer (SSR snapshot)', () => {
     expect(markup).toContain('정본 v3');
   });
 
-  it('sandboxes the html stage without allow-scripts (감시/보안 게이트 — 핸드오프 §3-1)', () => {
+  it('fully locks down the html stage sandbox (no allow-scripts, no allow-same-origin — 유나 디자인 가디언 보안 지적 반영)', () => {
     const markup = renderToStaticMarkup(
       wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
     );
-    expect(markup).toContain('sandbox="allow-same-origin"');
+    expect(markup).toContain('sandbox=""');
     expect(markup).not.toContain('allow-scripts');
+    expect(markup).not.toContain('allow-same-origin');
   });
 
   it('omits the anchor badge entirely when the artifact has no anchor version yet (초안 중립·낙인 금지)', () => {

--- a/apps/web/src/components/canvas/artifact-viewer.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useState } from 'react';
+import { Check, Download, MessageCircle } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { ArtifactStage } from './artifact-stage';
+import { ArtifactVersionRail } from './artifact-version-rail';
+import type { ArtifactVersion, MemberRef, VisualArtifact } from '@/services/canvas';
+
+interface ArtifactViewerProps {
+  artifact: VisualArtifact;
+  versions: ArtifactVersion[];
+  memberMap?: Record<string, MemberRef>;
+  /** mock 목적 — 실 코멘트(C2) 착지 전까지 헤더 카운트 표시용. */
+  commentCount?: number;
+  className?: string;
+}
+
+/**
+ * E-CANVAS C1-S4 — Lv1 artifact 뷰어. 유나 핸드오프(`e-canvas-trust-surface-handoff` §3) 계약.
+ * BE(`visual_artifact`/`artifact_version`, 디디 C1-S3) 미착지 — 이 컴포넌트는 props로 데이터를
+ * 받는 순수 뷰라 실 API 착지 시 fetch 래퍼만 새로 감싸면 됨(컴포넌트 자체는 안 바뀜).
+ */
+export function ArtifactViewer({ artifact, versions, memberMap = {}, commentCount = 0, className }: ArtifactViewerProps) {
+  const t = useTranslations('canvas');
+  const [selectedVersion, setSelectedVersion] = useState(artifact.current_version);
+  const activeVersion = versions.find((v) => v.version === selectedVersion) ?? versions[0];
+
+  return (
+    <div className={className}>
+      <div className="overflow-hidden rounded-2xl border border-border bg-card shadow-sm">
+        <div className="flex items-center gap-2.5 border-b border-border px-4 py-3">
+          <span className="truncate text-sm font-semibold text-foreground">{artifact.title}</span>
+          <span className="rounded-md border border-border bg-muted px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-muted-foreground">
+            {artifact.format}
+          </span>
+          <select
+            value={selectedVersion}
+            onChange={(e) => setSelectedVersion(Number(e.target.value))}
+            className="rounded-md border border-border bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+          >
+            {[...versions].sort((a, b) => b.version - a.version).map((v) => (
+              <option key={v.id} value={v.version}>v{v.version}</option>
+            ))}
+          </select>
+          {artifact.anchor_version != null ? (
+            <span className="inline-flex items-center gap-1 text-[11px] font-semibold text-success/85">
+              <Check className="h-3 w-3" strokeWidth={2.6} aria-hidden />
+              {t('anchorBadge', { version: artifact.anchor_version })}
+            </span>
+          ) : null}
+          <span className="ml-auto flex items-center gap-3 text-muted-foreground">
+            <span title={t('exportComingSoon')} className="flex items-center gap-1 text-xs opacity-50">
+              <Download className="h-3.5 w-3.5" aria-hidden />
+            </span>
+            <span title={t('commentsComingSoon')} className="flex items-center gap-1 text-xs opacity-50">
+              <MessageCircle className="h-3.5 w-3.5" aria-hidden />
+              {commentCount > 0 ? commentCount : null}
+            </span>
+          </span>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-[1fr_232px]">
+          <div className="bg-muted/20 p-4">
+            {activeVersion ? (
+              <ArtifactStage format={artifact.format} content={activeVersion.content} title={artifact.title} />
+            ) : null}
+          </div>
+          <ArtifactVersionRail
+            artifact={artifact}
+            versions={versions}
+            selectedVersion={selectedVersion}
+            onSelectVersion={setSelectedVersion}
+            memberMap={memberMap}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/services/canvas.ts
+++ b/apps/web/src/services/canvas.ts
@@ -1,0 +1,88 @@
+/**
+ * E-CANVAS C1 — 시각 산출물(visual artifact) FE 타입. blueprint `e-canvas-blueprint`(r3) §2
+ * 객체 모델(초안) 미러 — BE 계약(디디 C1-S3, `visual_artifact`/`artifact_version`) 미착지 상태라
+ * 이 타입/목업 데이터는 **잠정**이다. 실 API 착지 시 이 파일 타입만 계약대로 정정하면
+ * 컴포넌트는 그대로 소비(props 인터페이스 유지가 목표).
+ */
+
+export type ArtifactFormat = 'html' | 'tree' | 'image';
+
+/** blueprint §2: `artifact_version`(내용 blob/tree·변경자·요약). */
+export interface ArtifactVersion {
+  id: string;
+  artifact_id: string;
+  version: number;
+  /** format='html'→HTML 문자열, format='image'→이미지 URL, format='tree'→JSON 직렬화 노드 트리(§2 tree 노드). */
+  content: string;
+  created_by: string;
+  /** 변경 이유(의미 단위) — raw 편집 나열 아님(핸드오프 §6 감시 게이트). */
+  summary: string | null;
+  created_at: string;
+}
+
+/** blueprint §2: `visual_artifact`(id·title·format·current/anchor_version·연결·created_by). */
+export interface VisualArtifact {
+  id: string;
+  title: string;
+  format: ArtifactFormat;
+  current_version: number;
+  /** 승인된 정본 버전 번호. null=아직 정본 없음(초안 중립 — 배지 무표시). */
+  anchor_version: number | null;
+  created_by: string;
+}
+
+export interface MemberRef {
+  id: string;
+  name: string;
+}
+
+// ─── 잠정 mock 데이터 (핸드오프 doc `e-canvas-trust-surface-mockup-render` 예시와 동일 콘텐츠) ──
+
+export const MOCK_MEMBERS: Record<string, MemberRef> = {
+  m1: { id: 'm1', name: '미르코 페트로비치' },
+  m2: { id: 'm2', name: '유나 홀름' },
+  m3: { id: 'm3', name: '디디 은와추쿠' },
+};
+
+export const MOCK_ARTIFACT: VisualArtifact = {
+  id: 'mock-artifact-1',
+  title: '결제 복구 플로우 목업',
+  format: 'html',
+  current_version: 4,
+  anchor_version: 3,
+  created_by: 'm2',
+};
+
+const MOCK_HTML_V4 = `<!doctype html><html><head><style>
+  body{font-family:-apple-system,'Segoe UI',Roboto,sans-serif;margin:0;padding:20px;background:#fff;color:#1a1a1a}
+  .card{max-width:320px;margin:0 auto;border:1px solid #e5e5e5;border-radius:12px;padding:20px}
+  h4{margin:0 0 4px;font-size:15px}
+  .sub{font-size:11.5px;color:#767676;margin-bottom:16px}
+  .field{height:34px;border:1px solid #e5e5e5;border-radius:8px;background:#fafafa;margin-bottom:9px}
+  .btn{height:38px;border-radius:9px;background:#3157ff;color:#fff;display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:600;margin-top:4px}
+  .toast{margin-top:12px;font-size:11px;color:#767676;background:#fafafa;border:1px solid #e5e5e5;border-radius:7px;padding:7px 9px}
+</style></head><body>
+  <div class="card">
+    <h4>결제 복구</h4>
+    <div class="sub">실패한 결제를 다시 시도합니다</div>
+    <div class="field"></div>
+    <div class="field"></div>
+    <div class="btn">다시 결제하기</div>
+    <div class="toast">카드가 거절되었습니다</div>
+  </div>
+</body></html>`;
+
+export const MOCK_VERSIONS: ArtifactVersion[] = [
+  {
+    id: 'v4', artifact_id: 'mock-artifact-1', version: 4, content: MOCK_HTML_V4,
+    created_by: 'm1', summary: '버튼 위계 상향', created_at: '2026-07-10T08:00:00Z',
+  },
+  {
+    id: 'v3', artifact_id: 'mock-artifact-1', version: 3, content: MOCK_HTML_V4,
+    created_by: 'm2', summary: '승인된 계약', created_at: '2026-07-09T14:00:00Z',
+  },
+  {
+    id: 'v2', artifact_id: 'mock-artifact-1', version: 2, content: MOCK_HTML_V4,
+    created_by: 'm3', summary: '에러 카피 추가', created_at: '2026-07-08T09:00:00Z',
+  },
+];


### PR DESCRIPTION
## 요약
오르테가 지시로 BE 계약(디디 C1-S3, `visual_artifact`/`artifact_version`) 대기 없이 병렬 착수. 유나 UX 핸드오프(`e-canvas-trust-surface-handoff`)만으로 뷰어 셸을 mock 데이터 기반으로 먼저 구현 — 컴포넌트는 순수 props 기반이라 실 API 착지 시 데이터 소스만 갈아끼우면 된다.

## 구현
- `components/canvas/artifact-viewer.tsx` — 헤더(제목·포맷배지·버전셀렉터·정본배지·export/comment 플레이스홀더) + 스테이지 + 버전 lineage 레일
- `components/canvas/artifact-stage.tsx` — 포맷별 렌더: `html`=샌드박스 iframe(`sandbox="allow-same-origin"`, **allow-scripts 없음** — 핸드오프 §3-1 스크립트 차단 요구사항), `image`=바운드 img, `tree`=경량 노드 렌더(전신 `/mockups`의 리치 componentCatalog 렌더는 후속)
- `components/canvas/artifact-version-rail.tsx` — 버전 lineage(변경자·변경 이유만 — raw 편집 나열 금지, 핸드오프 §6 감시 게이트) + description pane 토글(C2 예정 안내, 가짜 기능처럼 안 보이게 명시적 "제공 예정" 문구)
- `services/canvas.ts` — `VisualArtifact`/`ArtifactVersion` 타입(blueprint §2 객체 모델 미러) + mock 데이터(핸드오프 부록 A 목업과 동일 콘텐츠)
- `/docs/canvas-preview` — mock 데이터 라이브 프리뷰 페이지(`docs/design-tokens`와 동일한 "인증된 내부 QA 라우트" 패턴)

## 리트머스("누가 주어인가") 자체심사
- 정본(anchor) 배지 = `success` 저강도(E-VERIFY ✓씰과 동일 계열, 표면 언어 일관성) — anchor_version=null이면 완전 무표시(초안 중립, 낙인 금지·테스트로 회귀가드).
- 버전 lineage 엔트리 = "{변경자} · {변경 이유}" 1줄만(raw 편집/키스트로크 미노출).
- export/comment 아이콘은 비활성+"제공 예정" 툴팁 — 있지도 않은 기능을 있는 것처럼 위장하지 않음.

## 스코프
- **AC2("스토리 상세에 artifact 섹션")는 이번 PR 범위 밖** — 실 스토리에 mock 데이터를 가짜로 붙이면 오해 소지가 있어(회귀·정직성 문제), BE 계약 착지 후 실 데이터로 배선 예정. 지금은 독립 프리뷰 라우트로만 픽셀 검증.
- tree 포맷은 경량 MVP 렌더(전신 mockup의 리치 렌더러는 모놀리스라 재사용 불가 — [[project-ecanvas-c1-fe-prep]] 조사 결과 참고).

## 검증
- `pnpm vitest run` — 165파일/964테스트 PASS(신규 7건 — SSR 스냅샷으로 anchor 배지 조건부 렌더·iframe sandbox 속성[allow-scripts 부재] 회귀가드)
- `pnpm lint` — 신규 경고 0(기존 무관 파일 5건 pre-existing)
- `pnpm build` — EXIT 0, `/docs/canvas-preview` 라우트 확인
- worktree 격리(`sprintable-mirko-canvas-wt`), origin/develop 최신 기준 신규 브랜치

## 반응형/스크린샷
- mock 프리뷰(`/docs/canvas-preview`)는 dev 배포 후 라이브 픽셀(양테마) 확인 예정 — E-VERIFY V0-S3와 동일 흐름(로컬 FE↔dev BE 인증 불일치로 배포된 dev FE에서만 유효한 검증).

🤖 Generated with [Claude Code](https://claude.com/claude-code)