### PR TITLE
fix(security): agent_personas 생성 org/project 검증 — 타 org agent 페르소나 오염 방지 (E-SECURITY SEC-S7)

### DIFF
--- a/backend/app/routers/agent_personas.py
+++ b/backend/app/routers/agent_personas.py
@@ -2,12 +2,15 @@ import uuid
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
+from app.models.member import Member
 from app.repositories.agent_persona import AgentPersonaRepository
 from app.schemas.agent_persona import CreatePersonaRequest, UpdatePersonaRequest
+from app.services.project_auth import assert_target_in_caller_org
 
 router = APIRouter(prefix="/api/v2/agent-personas", tags=["agent-personas"])
 
@@ -33,6 +36,17 @@ def _get_org_project(auth: AuthContext) -> tuple[uuid.UUID, uuid.UUID]:
     return uuid.UUID(str(org_id_str)), uuid.UUID(str(project_id_str))
 
 
+async def _assert_agent_in_caller_org(session: AsyncSession, caller_org_id: uuid.UUID, agent_id: uuid.UUID) -> None:
+    """E-SECURITY SEC-S7(story a7dd0431·까심 QA 부수발견 E): create_persona/seed_builtin_personas가
+    caller의 org_id만으로 target agent_id에 persona를 생성해 타 org agent 오염(public AgentCard
+    내용 오염 + default persona collision DoS)이 가능했다. SEC-S6의 `assert_target_in_caller_org`
+    공통 가드 재사용 — target(agent)의 실제 org를 조회해 caller org와 대조."""
+    target_org_id = (await session.execute(
+        select(Member.org_id).where(Member.id == agent_id, Member.type == "agent")
+    )).scalar_one_or_none()
+    assert_target_in_caller_org(caller_org_id, target_org_id, not_found_detail="Agent not found")
+
+
 @router.get("")
 async def list_personas(
     agent_id: uuid.UUID = Query(...),
@@ -56,6 +70,7 @@ async def create_persona(
     org_id, project_id = _get_org_project(auth)
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
+    await _assert_agent_in_caller_org(repo.session, org_id, body.agent_id)
     try:
         persona = await repo.create(
             org_id=org_id,
@@ -86,6 +101,7 @@ async def seed_builtin_personas(
     org_id, project_id = _get_org_project(auth)
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
+    await _assert_agent_in_caller_org(repo.session, org_id, agent_id)
     result = await repo.seed_builtin(org_id, project_id, agent_id)
     return _ok(result)
 

--- a/backend/tests/test_e_security_sec_s7_persona_org_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s7_persona_org_scope_realdb.py
@@ -1,0 +1,205 @@
+"""E-SECURITY SEC-S7(story a7dd0431·까심 QA 부수발견 E): agent_personas 생성 org/project 검증 —
+타 org agent에 persona 주입(public AgentCard 오염 + default persona collision DoS) 봉쇄 실증.
+
+SEC-S6의 `assert_target_in_caller_org` 공통 가드를 그대로 배선(신설 없음)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_two_orgs(session):
+    """Org A caller·Org B agent — E 재현용."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
+    org_b = Organization(id=uuid.uuid4(), name="Org B", slug=f"org-b-{uuid.uuid4().hex[:8]}")
+    session.add_all([org_a, org_b])
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org_a.id, name="Org A Project")
+    project_b = Project(id=uuid.uuid4(), org_id=org_b.id, name="Org B Project")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    agent_a = Member(id=uuid.uuid4(), org_id=org_a.id, type="agent", name="Org A Agent", is_active=True)
+    agent_b = Member(id=uuid.uuid4(), org_id=org_b.id, type="agent", name="Org B Agent", is_active=True)
+    session.add_all([agent_a, agent_b])
+    await session.commit()
+
+    return {
+        "org_a_id": org_a.id, "org_b_id": org_b.id,
+        "project_a_id": project_a.id, "agent_a_id": agent_a.id, "agent_b_id": agent_b.id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, project_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(uuid.uuid4()), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_create_persona_cross_org_agent_blocked():
+    """까심 E 재현: Org A caller가 Org B agent_id로 persona 생성 시도 → 404(오염 차단)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_orgs(s)
+
+        await _setup_app(app, Session, seeded["org_a_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/agent-personas",
+                json={"agent_id": str(seeded["agent_b_id"]), "name": "Injected"},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+
+        # persona 미생성 확認
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.agent_deployment import AgentPersona
+            rows = (await s.execute(
+                select(AgentPersona).where(AgentPersona.agent_id == seeded["agent_b_id"])
+            )).scalars().all()
+            assert len(rows) == 0
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_persona_same_org_agent_still_free():
+    """회귀 0: Org A caller가 자기 org agent_id로 생성하면 정상 201."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_orgs(s)
+
+        await _setup_app(app, Session, seeded["org_a_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/agent-personas",
+                json={"agent_id": str(seeded["agent_a_id"]), "name": "Legit"},
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_seed_builtin_personas_cross_org_agent_blocked():
+    """seed_builtin_personas도 동일 갭·동일 가드로 봉쇄."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_orgs(s)
+
+        await _setup_app(app, Session, seeded["org_a_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/agent-personas/seed?agent_id={seeded['agent_b_id']}",
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_persona_nonexistent_agent_also_404():
+    """존재하지 않는 agent_id도 동일 404(존재 비노출)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_orgs(s)
+
+        await _setup_app(app, Session, seeded["org_a_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/agent-personas",
+                json={"agent_id": str(uuid.uuid4()), "name": "Ghost"},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_s42.py
+++ b/backend/tests/test_s42.py
@@ -119,6 +119,11 @@ async def test_get_persona_not_found_404():
 async def test_create_persona_201():
     client, session, app = await _client()
     try:
+        # E-SECURITY SEC-S7: create_persona가 먼저 target agent의 실 org_id를 조회해 caller org
+        # (ORG_ID)와 대조한다 — 이 목이 그 조회에 응답해야 가드를 통과한다.
+        org_lookup_mock = MagicMock()
+        org_lookup_mock.scalar_one_or_none.return_value = ORG_ID
+        session.execute = AsyncMock(return_value=org_lookup_mock)
         with patch("app.repositories.agent_persona.AgentPersonaRepository.create", new_callable=AsyncMock) as mock_create:
             mock_create.return_value = _make_persona_summary()
             payload = {"agent_id": str(AGENT_ID), "name": "Test Persona", "system_prompt": "You are a helpful assistant."}
@@ -210,6 +215,10 @@ async def test_update_builtin_persona_403():
 async def test_seed_builtin_200():
     client, session, app = await _client()
     try:
+        # E-SECURITY SEC-S7: seed_builtin_personas도 동일하게 target agent org_id를 먼저 조회.
+        org_lookup_mock = MagicMock()
+        org_lookup_mock.scalar_one_or_none.return_value = ORG_ID
+        session.execute = AsyncMock(return_value=org_lookup_mock)
         with patch("app.repositories.agent_persona.AgentPersonaRepository.seed_builtin", new_callable=AsyncMock) as mock_seed:
             mock_seed.return_value = {"seeded": True}
             async with client as c:


### PR DESCRIPTION
## Summary
- E-SECURITY SEC-S7(story `a7dd0431`, P2) — 까심 QA 부수발견 E, **라이브 재현 CONFIRMED**
- `create_persona`/`seed_builtin_personas`가 caller 자신의 JWT org_id만 확인하고 `agent_id`가 그 org 소속인지 검증하지 않아, **타 org agent에 persona 주입 가능**했음 — a2a.py의 default persona 조회 경로로 그 agent의 public AgentCard 내용이 오염되고, default persona 중복 생성으로 collision DoS도 가능
- C(refresh token, SEC-S5)·D(roster, SEC-S6)와 함께 **cross-org IDOR 계열**(공통 근본: 호출자 org를 body/param target의 org와 대조 안 함)

## 스택 PR 안내
⚠️ **이 PR은 #2005(SEC-S6)에 의존** — SEC-S6에서 만든 `assert_target_in_caller_org` 공통 가드를 그대로 재사용(신설 없음)하므로 base를 SEC-S6 브랜치로 잡았음. **#2005가 develop에 먼저 merge된 뒤 이 PR의 base를 develop으로 재조정**하면 됨(diff는 이 PR 고유 변경분 2파일만).

## Crux
SEC-S6 crux 때 이미 순수 함수 테스트로 재사용성을 실측해뒀던 그대로 — `_assert_agent_in_caller_org(session, caller_org_id, agent_id)` 헬퍼가 `members` 테이블에서 target agent의 실제 org_id를 조회해 `assert_target_in_caller_org`에 넘기는 구조. `create_persona`·`seed_builtin_personas`(둘 다 agent_id 기반 CREATE 뮤테이션) 적용. `list_personas`/`get_persona`/`update_persona`/`delete_persona`는 이미 org_id 필터링된 read/id-scoped 경로라 스코프 아님.

## Test plan
- [x] `tests/test_e_security_sec_s7_persona_org_scope_realdb.py`(신규 4건, 실 PG): cross-org agent_id 생성 차단(404·persona 미생성 확인) · same-org 정상 201 · seed_builtin도 동일 차단 · 존재하지 않는 agent_id도 404
- [x] 기존 `tests/test_s42.py` 2건(`test_create_persona_201`·`test_seed_builtin_200`) — 신규 org 조회 execute() 삽입으로 mock 갱신(회귀 아님)
- [x] 마이그레이션 없음
- [x] 전체 non-destructive 스위트: 3459 passed, 6 failed(모두 baseline 환경 실패)

🤖 Generated with [Claude Code](https://claude.com/claude-code)