### PR TITLE
[SID:0edca31e] E-CANVAS C2-S6 요소 앵커 코멘트 + 전파 상태 셸 (mock 데이터, BE 대기)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3368,6 +3368,22 @@
     "descriptionPaneComingSoon": "Per-element spec (description pane) arrives in C2",
     "exportComingSoon": "Export arrives in C1-S5",
     "commentsComingSoon": "Comments arrive in C2",
-    "treeRenderPlaceholder": "Tree rendering coming soon"
+    "treeRenderPlaceholder": "Tree rendering coming soon",
+    "descriptionPaneHeading": "description — visible PRD",
+    "descriptionEmptyState": "Select a pin to see its element spec here",
+    "rollupOpen": "open",
+    "rollupInProgress": "in progress",
+    "rollupResolved": "resolved",
+    "deliveringTo": "Delivering to {name}…",
+    "moreReached": "+{count} more reached",
+    "stateDelivered": "delivered",
+    "stateRead": "read",
+    "stateActing": "in progress",
+    "stateResponded": "responded",
+    "linkedVersionResult": "v{version} created — this comment was the input",
+    "coordinateAnchorNote": "position as of v{version}",
+    "resolveAction": "Resolve",
+    "replyPlaceholder": "Reply…",
+    "resolvedByNote": "Resolved by {name}"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3368,6 +3368,22 @@
     "descriptionPaneComingSoon": "요소별 스펙(description pane)은 C2에서 제공 예정",
     "exportComingSoon": "export는 C1-S5에서 제공 예정",
     "commentsComingSoon": "코멘트는 C2에서 제공 예정",
-    "treeRenderPlaceholder": "트리 렌더는 준비 중"
+    "treeRenderPlaceholder": "트리 렌더는 준비 중",
+    "descriptionPaneHeading": "description — 보이는 PRD",
+    "descriptionEmptyState": "핀을 선택하면 요소 스펙이 여기 표시됩니다",
+    "rollupOpen": "열림",
+    "rollupInProgress": "처리 중",
+    "rollupResolved": "해결됨",
+    "deliveringTo": "{name}에게 전달 중…",
+    "moreReached": "+{count} 도달",
+    "stateDelivered": "도달",
+    "stateRead": "열람",
+    "stateActing": "처리 중",
+    "stateResponded": "응답함",
+    "linkedVersionResult": "v{version} 생성 — 이 코멘트가 입력",
+    "coordinateAnchorNote": "v{version} 기준 위치",
+    "resolveAction": "해결",
+    "replyPlaceholder": "답글…",
+    "resolvedByNote": "{name}가 해결함"
   }
 }

--- a/apps/web/src/app/(authenticated)/docs/canvas-preview/canvas-preview-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/canvas-preview/canvas-preview-client.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useState } from 'react';
+import { ArtifactViewer } from '@/components/canvas/artifact-viewer';
+import { CommentThreadCard } from '@/components/canvas/comment-thread-card';
+import { MOCK_ARTIFACT, MOCK_VERSIONS, MOCK_MEMBERS } from '@/services/canvas';
+import { MOCK_THREADS, MOCK_DESCRIPTIONS, type CommentThread } from '@/services/canvas-comments';
+
+/**
+ * E-CANVAS C1/C2 내부 프리뷰(client) — `docs/design-tokens`와 동일한 "라이브 dev QA용
+ * 인증된 내부 라우트" 패턴. resolve/reply는 로컬 mock 상태로만 동작(BE `comment`/
+ * `activity_event` 계약 미착지) — 디자인 가디언이 상태 전이를 눈으로 확인하는 용도.
+ */
+export function CanvasPreviewClient() {
+  const [threads, setThreads] = useState<CommentThread[]>(MOCK_THREADS);
+
+  const handleResolve = (threadId: string) => {
+    setThreads((prev) => prev.map((t) => (
+      t.id === threadId ? { ...t, rollup: 'resolved', resolved_by: 'm1', resolved_at: new Date().toISOString() } : t
+    )));
+  };
+
+  const handleReply = (threadId: string, body: string) => {
+    setThreads((prev) => prev.map((t) => (
+      t.id === threadId
+        ? {
+            ...t,
+            rollup: t.rollup === 'open' ? 'in_progress' : t.rollup,
+            comments: [...t.comments, { id: `local-${t.comments.length}`, author_id: 'm1', body, created_at: new Date().toISOString() }],
+            recipients: t.recipients.map((r) => (r.member_id === 'm1' ? { ...r, state: 'responded' } : r)),
+          }
+        : t
+    )));
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-8 p-6">
+      <div>
+        <h1 className="text-lg font-semibold text-foreground">E-CANVAS C1/C2 — Artifact Viewer 프리뷰</h1>
+        <p className="mt-1 text-xs text-muted-foreground">
+          mock 데이터(BE 계약 미착지) · 스테이지의 파란 핀 클릭 → description pane 전환 · 아래 카드에서 답글/해결 시연
+        </p>
+      </div>
+
+      <ArtifactViewer
+        artifact={MOCK_ARTIFACT}
+        versions={MOCK_VERSIONS}
+        memberMap={MOCK_MEMBERS}
+        threads={threads}
+        descriptions={MOCK_DESCRIPTIONS}
+      />
+
+      <div className="space-y-3">
+        <h2 className="text-xs font-bold uppercase tracking-wide text-muted-foreground">C2 — 코멘트 스레드(전파 상태 머신)</h2>
+        <div className="grid gap-3 sm:grid-cols-2">
+          {threads.map((thread) => (
+            <CommentThreadCard
+              key={thread.id}
+              thread={thread}
+              memberMap={MOCK_MEMBERS}
+              onResolve={handleResolve}
+              onReply={handleReply}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/docs/canvas-preview/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/canvas-preview/page.tsx
@@ -1,27 +1,11 @@
-import { ArtifactViewer } from '@/components/canvas/artifact-viewer';
-import { MOCK_ARTIFACT, MOCK_VERSIONS, MOCK_MEMBERS } from '@/services/canvas';
+import { CanvasPreviewClient } from './canvas-preview-client';
 
 /**
- * E-CANVAS C1-S4 내부 프리뷰 — `docs/design-tokens`와 동일한 "라이브 dev QA용 인증된
- * 내부 라우트" 패턴. BE(`visual_artifact`) 계약 착지 前까지 mock 데이터로 뷰어 픽셀을
- * 검증하는 용도. 계약 착지 후 실 데이터 소비처(스토리 상세 등)가 생기면 이 페이지는
+ * E-CANVAS C1/C2 내부 프리뷰 — `docs/design-tokens`와 동일한 "라이브 dev QA용 인증된
+ * 내부 라우트" 패턴. BE(`visual_artifact`/`comment`) 계약 착지 前까지 mock 데이터로 뷰어
+ * 픽셀을 검증하는 용도. 계약 착지 후 실 데이터 소비처(스토리 상세 등)가 생기면 이 페이지는
  * 회귀가드용 참조 렌더로 남겨둔다.
  */
 export default function CanvasPreviewPage() {
-  return (
-    <div className="mx-auto max-w-2xl space-y-4 p-6">
-      <div>
-        <h1 className="text-lg font-semibold text-foreground">E-CANVAS C1 — Artifact Viewer 프리뷰</h1>
-        <p className="mt-1 text-xs text-muted-foreground">
-          mock 데이터(BE `visual_artifact` 계약 미착지) · 버전 클릭으로 lineage 전환 확인
-        </p>
-      </div>
-      <ArtifactViewer
-        artifact={MOCK_ARTIFACT}
-        versions={MOCK_VERSIONS}
-        memberMap={MOCK_MEMBERS}
-        commentCount={2}
-      />
-    </div>
-  );
+  return <CanvasPreviewClient />;
 }

--- a/apps/web/src/components/canvas/anchor-pin.tsx
+++ b/apps/web/src/components/canvas/anchor-pin.tsx
@@ -1,0 +1,35 @@
+import { cn } from '@/lib/utils';
+
+interface AnchorPinProps {
+  number: number;
+  /** open=info 채움·resolved=muted 아웃라인(핸드오프 §1-2). */
+  state: 'open' | 'resolved';
+  active?: boolean;
+  onClick?: () => void;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+/**
+ * E-CANVAS C2 — 요소 앵커 핀. 헤더 배지·스테이지 오버레이 양쪽에서 재사용(§1-2 anatomy).
+ * 클릭 가능하면 버튼, 아니면 순수 표시(스테이지 오버레이는 항상 클릭 가능하게 쓸 예정).
+ */
+export function AnchorPin({ number, state, active, onClick, className, style }: AnchorPinProps) {
+  const Tag = onClick ? 'button' : 'span';
+  return (
+    <Tag
+      type={onClick ? 'button' : undefined}
+      onClick={onClick}
+      style={style}
+      className={cn(
+        'flex h-5 w-5 shrink-0 items-center justify-center rounded-full rounded-bl-none text-[10px] font-bold transition-transform',
+        state === 'open' ? 'bg-info text-white' : 'border-2 border-border bg-transparent text-muted-foreground',
+        active && 'ring-2 ring-info/40',
+        onClick && 'hover:scale-110',
+        className,
+      )}
+    >
+      {number}
+    </Tag>
+  );
+}

--- a/apps/web/src/components/canvas/artifact-version-rail.tsx
+++ b/apps/web/src/components/canvas/artifact-version-rail.tsx
@@ -12,13 +12,16 @@ interface ArtifactVersionRailProps {
   selectedVersion: number;
   onSelectVersion: (version: number) => void;
   memberMap?: Record<string, MemberRef>;
+  /** C2 착지 후 슬롯 — 넘기면 "coming soon" 대신 이 노드(보통 `<DescriptionPane/>`)를 렌더.
+   * ArtifactVersionRail 자체는 C2 타입을 몰라도 되게 순수 슬롯으로 받는다. */
+  descriptionSlot?: React.ReactNode;
 }
 
 /**
  * E-CANVAS C1 Lv1 — 버전 lineage 레일. 각 엔트리 = 변경자·변경 이유(의미 단위)만.
  * raw 편집 나열 금지(핸드오프 §6 감시 게이트) — 여기 보이는 게 실제 저장된 커밋 단위 전부다.
  */
-export function ArtifactVersionRail({ artifact, versions, selectedVersion, onSelectVersion, memberMap = {} }: ArtifactVersionRailProps) {
+export function ArtifactVersionRail({ artifact, versions, selectedVersion, onSelectVersion, memberMap = {}, descriptionSlot }: ArtifactVersionRailProps) {
   const t = useTranslations('canvas');
   const [descOpen, setDescOpen] = useState(false);
   const sorted = [...versions].sort((a, b) => b.version - a.version);
@@ -78,7 +81,7 @@ export function ArtifactVersionRail({ artifact, versions, selectedVersion, onSel
         {descOpen ? <ChevronUp className="h-3 w-3" aria-hidden /> : <ChevronDown className="h-3 w-3" aria-hidden />}
       </button>
       {descOpen ? (
-        <p className="mt-1.5 text-[11px] text-muted-foreground/80">{t('descriptionPaneComingSoon')}</p>
+        descriptionSlot ?? <p className="mt-1.5 text-[11px] text-muted-foreground/80">{t('descriptionPaneComingSoon')}</p>
       ) : null}
     </div>
   );

--- a/apps/web/src/components/canvas/artifact-viewer.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.tsx
@@ -5,14 +5,21 @@ import { Check, Download, MessageCircle } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { ArtifactStage } from './artifact-stage';
 import { ArtifactVersionRail } from './artifact-version-rail';
+import { AnchorPin } from './anchor-pin';
+import { DescriptionPane } from './description-pane';
 import type { ArtifactVersion, MemberRef, VisualArtifact } from '@/services/canvas';
+import type { CommentThread, DescriptionMap } from '@/services/canvas-comments';
 
 interface ArtifactViewerProps {
   artifact: VisualArtifact;
   versions: ArtifactVersion[];
   memberMap?: Record<string, MemberRef>;
-  /** mock 목적 — 실 코멘트(C2) 착지 전까지 헤더 카운트 표시용. */
+  /** mock 목적 — threads가 없을 때만 쓰이는 폴백 헤더 카운트(C2 착지 전). */
   commentCount?: number;
+  /** C2 — 좌표 앵커 스레드는 스테이지에 핀 오버레이. element 앵커는 후속(실 artifact tree
+   * 좌표 유도 필요 — 지금은 좌표 앵커만 오버레이). */
+  threads?: CommentThread[];
+  descriptions?: DescriptionMap;
   className?: string;
 }
 
@@ -21,10 +28,16 @@ interface ArtifactViewerProps {
  * BE(`visual_artifact`/`artifact_version`, 디디 C1-S3) 미착지 — 이 컴포넌트는 props로 데이터를
  * 받는 순수 뷰라 실 API 착지 시 fetch 래퍼만 새로 감싸면 됨(컴포넌트 자체는 안 바뀜).
  */
-export function ArtifactViewer({ artifact, versions, memberMap = {}, commentCount = 0, className }: ArtifactViewerProps) {
+export function ArtifactViewer({ artifact, versions, memberMap = {}, commentCount = 0, threads, descriptions = {}, className }: ArtifactViewerProps) {
   const t = useTranslations('canvas');
   const [selectedVersion, setSelectedVersion] = useState(artifact.current_version);
+  const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
   const activeVersion = versions.find((v) => v.version === selectedVersion) ?? versions[0];
+  const selectedThread = threads?.find((th) => th.id === selectedThreadId) ?? null;
+  const selectedThreadDescription = selectedThread?.anchor.element_id
+    ? (descriptions[selectedThread.anchor.element_id] ?? null)
+    : null;
+  const openThreadCount = threads?.filter((th) => th.rollup !== 'resolved').length ?? 0;
 
   return (
     <div className={className}>
@@ -53,18 +66,33 @@ export function ArtifactViewer({ artifact, versions, memberMap = {}, commentCoun
             <span title={t('exportComingSoon')} className="flex items-center gap-1 text-xs opacity-50">
               <Download className="h-3.5 w-3.5" aria-hidden />
             </span>
-            <span title={t('commentsComingSoon')} className="flex items-center gap-1 text-xs opacity-50">
+            <span
+              title={threads ? undefined : t('commentsComingSoon')}
+              className={`flex items-center gap-1 text-xs ${threads ? '' : 'opacity-50'}`}
+            >
               <MessageCircle className="h-3.5 w-3.5" aria-hidden />
-              {commentCount > 0 ? commentCount : null}
+              {threads ? (openThreadCount > 0 ? openThreadCount : null) : (commentCount > 0 ? commentCount : null)}
             </span>
           </span>
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-[1fr_232px]">
-          <div className="bg-muted/20 p-4">
+          <div className="relative bg-muted/20 p-4">
             {activeVersion ? (
               <ArtifactStage format={artifact.format} content={activeVersion.content} title={artifact.title} />
             ) : null}
+            {/* C2 §1 — 좌표 앵커 스레드만 오버레이(element 앵커는 실 artifact tree 좌표 유도 필요, 후속). */}
+            {threads?.filter((th) => th.anchor.kind === 'coordinate').map((th) => (
+              <AnchorPin
+                key={th.id}
+                number={th.pin_number}
+                state={th.rollup === 'resolved' ? 'resolved' : 'open'}
+                active={th.id === selectedThreadId}
+                onClick={() => setSelectedThreadId((cur) => (cur === th.id ? null : th.id))}
+                className="absolute z-10"
+                style={{ left: `${th.anchor.x}%`, top: `${th.anchor.y}%` }}
+              />
+            ))}
           </div>
           <ArtifactVersionRail
             artifact={artifact}
@@ -72,6 +100,13 @@ export function ArtifactViewer({ artifact, versions, memberMap = {}, commentCoun
             selectedVersion={selectedVersion}
             onSelectVersion={setSelectedVersion}
             memberMap={memberMap}
+            descriptionSlot={threads ? (
+              <DescriptionPane
+                description={selectedThreadDescription}
+                elementLabel={selectedThread?.element_label}
+                className="mt-1.5"
+              />
+            ) : undefined}
           />
         </div>
       </div>

--- a/apps/web/src/components/canvas/comment-thread-card.test.tsx
+++ b/apps/web/src/components/canvas/comment-thread-card.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { CommentThreadCard } from './comment-thread-card';
+import { MOCK_MEMBERS } from '@/services/canvas';
+import { MOCK_THREADS } from '@/services/canvas-comments';
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+describe('CommentThreadCard', () => {
+  it('shows the resolved-by note and dims the card once resolved', () => {
+    const resolved = MOCK_THREADS.find((t) => t.rollup === 'resolved')!;
+    const markup = renderToStaticMarkup(wrap(<CommentThreadCard thread={resolved} memberMap={MOCK_MEMBERS} />));
+    expect(markup).toContain('opacity-70');
+    expect(markup).toContain('해결됨');
+    expect(markup).toContain('미르코 페트로비치가 해결함');
+  });
+
+  it('hides the reply/resolve controls once a thread is resolved (no false affordance)', () => {
+    const resolved = MOCK_THREADS.find((t) => t.rollup === 'resolved')!;
+    const markup = renderToStaticMarkup(wrap(<CommentThreadCard thread={resolved} memberMap={MOCK_MEMBERS} />));
+    expect(markup).not.toContain('답글…');
+  });
+
+  it('shows reply/resolve controls for an open thread', () => {
+    const open = MOCK_THREADS.find((t) => t.rollup === 'open')!;
+    const markup = renderToStaticMarkup(wrap(<CommentThreadCard thread={open} memberMap={MOCK_MEMBERS} />));
+    expect(markup).toContain('답글…');
+    expect(markup).toContain('해결');
+  });
+
+  it('never uses surveillance vocabulary anywhere in the rendered markup (리트머스 회귀가드)', () => {
+    const markup = MOCK_THREADS.map((t) => renderToStaticMarkup(wrap(<CommentThreadCard thread={t} memberMap={MOCK_MEMBERS} />))).join('');
+    for (const forbidden of ['방치', '무시', '늦음', '감점', '응답률', '미처리']) {
+      expect(markup).not.toContain(forbidden);
+    }
+  });
+});

--- a/apps/web/src/components/canvas/comment-thread-card.tsx
+++ b/apps/web/src/components/canvas/comment-thread-card.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+import { AnchorPin } from './anchor-pin';
+import { PropagationStrip } from './propagation-strip';
+import type { MemberRef } from '@/services/canvas';
+import type { CommentThread } from '@/services/canvas-comments';
+
+const ROLLUP_LABEL_KEY: Record<CommentThread['rollup'], string> = {
+  open: 'rollupOpen',
+  in_progress: 'rollupInProgress',
+  resolved: 'rollupResolved',
+};
+
+interface CommentThreadCardProps {
+  thread: CommentThread;
+  memberMap?: Record<string, MemberRef>;
+  active?: boolean;
+  onSelectPin?: (threadId: string) => void;
+  onResolve?: (threadId: string) => void;
+  onReply?: (threadId: string, body: string) => void;
+  onLinkedVersionClick?: (version: number) => void;
+  className?: string;
+}
+
+/**
+ * E-CANVAS C2 §2 — 코멘트 스레드 카드. 공통 코멘트 프리미티브(스토리 코멘트와 동일 인프라)
+ * + artifact 앵커 필드만 additive. resolved 스레드는 가라앉음(opacity↓, §3 상태 매트릭스).
+ */
+export function CommentThreadCard({
+  thread, memberMap = {}, active, onSelectPin, onResolve, onReply, onLinkedVersionClick, className,
+}: CommentThreadCardProps) {
+  const t = useTranslations('canvas');
+  const [replyDraft, setReplyDraft] = useState('');
+  const resolved = thread.rollup === 'resolved';
+  const rollupTone = resolved ? 'text-success bg-success/10' : 'text-info bg-info/10';
+
+  const handleReply = () => {
+    const body = replyDraft.trim();
+    if (!body) return;
+    onReply?.(thread.id, body);
+    setReplyDraft('');
+  };
+
+  return (
+    <div className={cn('rounded-xl border border-border bg-card shadow-sm', resolved && 'opacity-70', className)}>
+      <div className="flex items-center gap-2 border-b border-border px-3 py-2">
+        <AnchorPin
+          number={thread.pin_number}
+          state={resolved ? 'resolved' : 'open'}
+          active={active}
+          onClick={onSelectPin ? () => onSelectPin(thread.id) : undefined}
+        />
+        <span className="text-xs font-semibold text-foreground">{thread.element_label}</span>
+        {thread.anchor.kind === 'coordinate' && thread.anchor.pinned_at_version != null ? (
+          <span className="text-[10px] text-muted-foreground">{t('coordinateAnchorNote', { version: thread.anchor.pinned_at_version })}</span>
+        ) : null}
+        <span className={cn('ml-auto rounded px-1.5 py-0.5 text-[9px] font-bold', rollupTone)}>
+          {t(ROLLUP_LABEL_KEY[thread.rollup])}
+        </span>
+      </div>
+
+      <div className="space-y-2 px-3 py-2.5">
+        {thread.comments.map((c) => (
+          <div key={c.id}>
+            <p className="text-[11px] text-muted-foreground">
+              <strong className="text-foreground">{memberMap[c.author_id]?.name ?? '—'}</strong>
+            </p>
+            <p className="mt-0.5 text-xs leading-relaxed text-foreground">{c.body}</p>
+          </div>
+        ))}
+
+        <PropagationStrip
+          recipients={thread.recipients}
+          memberMap={memberMap}
+          linkedVersion={thread.linked_version}
+          onLinkedVersionClick={onLinkedVersionClick}
+        />
+
+        {resolved && thread.resolved_by ? (
+          <p className="text-[10px] text-muted-foreground/80">{t('resolvedByNote', { name: memberMap[thread.resolved_by]?.name ?? '—' })}</p>
+        ) : null}
+
+        {!resolved ? (
+          <div className="flex items-center gap-1.5 pt-1">
+            <input
+              type="text"
+              value={replyDraft}
+              onChange={(e) => setReplyDraft(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleReply(); }}
+              placeholder={t('replyPlaceholder')}
+              className="min-w-0 flex-1 rounded-md border border-border bg-background px-2 py-1 text-[11px] text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary/40"
+            />
+            <button
+              type="button"
+              onClick={() => onResolve?.(thread.id)}
+              className="shrink-0 rounded-md border border-border px-2 py-1 text-[10px] font-semibold text-muted-foreground hover:bg-muted"
+            >
+              {t('resolveAction')}
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/canvas/description-pane.tsx
+++ b/apps/web/src/components/canvas/description-pane.tsx
@@ -1,0 +1,29 @@
+import { useTranslations } from 'next-intl';
+
+interface DescriptionPaneProps {
+  description: string | null;
+  elementLabel?: string | null;
+  className?: string;
+}
+
+/**
+ * E-CANVAS C2 §4 — 요소별 "보이는 PRD"(spec_description 유산). 읽기 전용(편집=C3 스코프).
+ * 선택된 요소가 없거나 스펙이 없으면 중립 안내(낙인/촉구 문구 금지 — E-VERIFY §6 원칙 계승).
+ */
+export function DescriptionPane({ description, elementLabel, className }: DescriptionPaneProps) {
+  const t = useTranslations('canvas');
+  return (
+    <div className={className}>
+      <p className="mb-1 text-[10px] font-bold uppercase tracking-wide text-muted-foreground">{t('descriptionPaneHeading')}</p>
+      {description ? (
+        <p className="text-[11px] leading-relaxed text-muted-foreground">
+          {elementLabel ? <strong className="text-foreground">{elementLabel}</strong> : null}
+          {elementLabel ? ' · ' : ''}
+          {description}
+        </p>
+      ) : (
+        <p className="text-[11px] text-muted-foreground/70">{t('descriptionEmptyState')}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/canvas/propagation-strip.test.tsx
+++ b/apps/web/src/components/canvas/propagation-strip.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { PropagationStrip } from './propagation-strip';
+import { MOCK_MEMBERS } from '@/services/canvas';
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+describe('PropagationStrip (§3-7 감시-게이트 회귀가드)', () => {
+  it('renders nothing when there are no recipients', () => {
+    const markup = renderToStaticMarkup(wrap(<PropagationStrip recipients={[]} memberMap={MOCK_MEMBERS} />));
+    expect(markup).toBe('');
+  });
+
+  it('renders a calm "delivering to" sentence for a single pending recipient — not an alarm', () => {
+    const markup = renderToStaticMarkup(
+      wrap(<PropagationStrip recipients={[{ member_id: 'm1', state: 'pending' }]} memberMap={MOCK_MEMBERS} />),
+    );
+    expect(markup).toContain('미르코 페트로비치에게 전달 중');
+  });
+
+  it('surfaces the most-advanced recipient and aggregates the rest as "+N 도달"', () => {
+    const markup = renderToStaticMarkup(
+      wrap(<PropagationStrip recipients={[{ member_id: 'm5', state: 'read' }, { member_id: 'm1', state: 'delivered' }]} memberMap={MOCK_MEMBERS} />),
+    );
+    expect(markup).toContain('담롱 온찬');
+    expect(markup).toContain('열람');
+    expect(markup).toContain('+1 도달');
+  });
+
+  it('renders the linked-version result line when a comment produced a new version', () => {
+    const markup = renderToStaticMarkup(
+      wrap(<PropagationStrip recipients={[{ member_id: 'm1', state: 'responded' }]} memberMap={MOCK_MEMBERS} linkedVersion={4} />),
+    );
+    expect(markup).toContain('v4 생성');
+  });
+
+  it('never emits destructive/warning color classes — pending stays calm muted (감시-게이트)', () => {
+    const markup = renderToStaticMarkup(
+      wrap(<PropagationStrip recipients={[{ member_id: 'm1', state: 'pending' }]} memberMap={MOCK_MEMBERS} />),
+    );
+    expect(markup).not.toContain('text-destructive');
+    expect(markup).not.toContain('text-warning');
+  });
+});

--- a/apps/web/src/components/canvas/propagation-strip.tsx
+++ b/apps/web/src/components/canvas/propagation-strip.tsx
@@ -1,0 +1,77 @@
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+import type { MemberRef } from '@/services/canvas';
+import type { CommentRecipient, PropagationState } from '@/services/canvas-comments';
+
+const STATE_ORDER: PropagationState[] = ['pending', 'delivered', 'read', 'acting', 'responded'];
+const STATE_LABEL_KEY: Record<PropagationState, string> = {
+  pending: '', // pending은 단독일 때 "{name}에게 전달 중…" 문장 자체로 표현(별도 라벨 없음)
+  delivered: 'stateDelivered',
+  read: 'stateRead',
+  acting: 'stateActing',
+  responded: 'stateResponded',
+};
+
+function isEngaged(state: PropagationState): boolean {
+  return state === 'acting' || state === 'responded';
+}
+
+function stateRank(state: PropagationState): number {
+  return STATE_ORDER.indexOf(state);
+}
+
+function initials(name: string): string {
+  return name.slice(0, 1);
+}
+
+interface PropagationStripProps {
+  recipients: CommentRecipient[];
+  memberMap?: Record<string, MemberRef>;
+  linkedVersion?: number | null;
+  onLinkedVersionClick?: (version: number) => void;
+  className?: string;
+}
+
+/**
+ * E-CANVAS C2 §3-6 전파 strip — "코멘트가 도달·응답됐는가"를 표면화. **감시-게이트(§3-7)**:
+ * 응답 시간 점수·리더보드·"방치" 낙인 전부 없음 — pending도 calm muted(빨강/경고색 0).
+ * 가장 진행된 상태의 수신자 하나만 강조 표시 + 나머지는 "+N 도달"로 aggregate(과부하 방지).
+ */
+export function PropagationStrip({ recipients, memberMap = {}, linkedVersion, onLinkedVersionClick, className }: PropagationStripProps) {
+  const t = useTranslations('canvas');
+  if (recipients.length === 0) return null;
+
+  const sorted = [...recipients].sort((a, b) => stateRank(b.state) - stateRank(a.state));
+  const primary = sorted[0]!;
+  const restCount = sorted.length - 1;
+  const primaryName = memberMap[primary.member_id]?.name ?? '—';
+  const engaged = isEngaged(primary.state);
+
+  return (
+    <div className={cn('rounded-lg px-2.5 py-1.5 text-[11px]', engaged ? 'bg-info/10' : 'bg-muted/40', className)}>
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-primary/20 text-[8px] font-bold text-primary">
+          {initials(primaryName)}
+        </span>
+        <span className={cn(engaged ? 'font-semibold text-info' : 'text-muted-foreground')}>
+          {primary.state === 'pending' && restCount === 0
+            ? t('deliveringTo', { name: primaryName })
+            : `${primaryName} ${t(STATE_LABEL_KEY[primary.state])}`}
+        </span>
+        {restCount > 0 ? <span className="text-muted-foreground">· {t('moreReached', { count: restCount })}</span> : null}
+      </div>
+      {linkedVersion != null ? (
+        <p className="mt-1 text-muted-foreground">
+          {'↳ '}
+          {onLinkedVersionClick ? (
+            <button type="button" onClick={() => onLinkedVersionClick(linkedVersion)} className="font-semibold text-info hover:underline">
+              {t('linkedVersionResult', { version: linkedVersion })}
+            </button>
+          ) : (
+            <span className="font-semibold text-info">{t('linkedVersionResult', { version: linkedVersion })}</span>
+          )}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/services/canvas-comments.ts
+++ b/apps/web/src/services/canvas-comments.ts
@@ -1,0 +1,96 @@
+/**
+ * E-CANVAS C2 — 요소 앵커 코멘트 + 전파 상태 FE 타입. 핸드오프
+ * `e-canvas-c2-comment-propagation-handoff` §1/§3 미러. BE(디디 C0/C2, `comment`/
+ * `activity_event`) 계약 미착지 상태라 잠정 — §3-5 매핑 표가 실 계약이 되면 이 파일의
+ * `PropagationState`만 정정하면 됨(컴포넌트는 그대로).
+ */
+
+/** §3-2 수신자별 상태 lifecycle. */
+export type PropagationState = 'pending' | 'delivered' | 'read' | 'acting' | 'responded';
+
+/** §3-3 스레드 rollup(헤더 배지). */
+export type ThreadRollup = 'open' | 'in_progress' | 'resolved';
+
+export type AnchorKind = 'element' | 'coordinate';
+
+/** §1-1 앵커 종류 2가지 — element 우선(버전 넘어 요소 따라감), coordinate는 fallback. */
+export interface CommentAnchor {
+  kind: AnchorKind;
+  element_id?: string;
+  /** coordinate 앵커 전용 — 스테이지 상대 좌표(%). */
+  x?: number;
+  y?: number;
+  /** coordinate 앵커가 어느 버전 기준인지(§1-2 "v3 기준 위치" 라벨). */
+  pinned_at_version?: number;
+}
+
+export interface CommentRecipient {
+  member_id: string;
+  state: PropagationState;
+}
+
+export interface ArtifactComment {
+  id: string;
+  author_id: string;
+  body: string;
+  created_at: string;
+}
+
+export interface CommentThread {
+  id: string;
+  artifact_id: string;
+  pin_number: number;
+  /** mock 편의 필드 — 실 계약에선 anchor.element_id로 artifact tree에서 유도. */
+  element_label: string;
+  anchor: CommentAnchor;
+  rollup: ThreadRollup;
+  comments: ArtifactComment[];
+  recipients: CommentRecipient[];
+  resolved_by?: string | null;
+  resolved_at?: string | null;
+  /** §3-4 결과 연결 — 이 코멘트가 입력이 된 버전 번호. */
+  linked_version?: number | null;
+}
+
+/** §4 요소별 spec(description pane) — mock 편의상 element_id→설명 맵. */
+export type DescriptionMap = Record<string, string>;
+
+// ─── mock 데이터 (핸드오프 부록A `e-canvas-c2-propagation-mockup-render` 4상태 그대로) ──
+
+export const MOCK_THREADS: CommentThread[] = [
+  {
+    id: 't1', artifact_id: 'mock-artifact-1', pin_number: 1, element_label: '결제 버튼',
+    anchor: { kind: 'coordinate', x: 82, y: 30 },
+    rollup: 'open',
+    comments: [{ id: 'c1', author_id: 'm2', body: '위계 낮은. primary로 키우고 정본 위치 유지 바라는.', created_at: '2026-07-10T08:00:00Z' }],
+    recipients: [{ member_id: 'm1', state: 'pending' }],
+  },
+  {
+    id: 't2', artifact_id: 'mock-artifact-1', pin_number: 2, element_label: '에러 토스트',
+    anchor: { kind: 'coordinate', x: 10, y: 68 },
+    rollup: 'open',
+    comments: [{ id: 'c2', author_id: 'm4', body: '거절 사유별 카피 분기 확認 필요한.', created_at: '2026-07-10T07:40:00Z' }],
+    recipients: [{ member_id: 'm5', state: 'read' }, { member_id: 'm1', state: 'delivered' }],
+  },
+  {
+    id: 't3', artifact_id: 'mock-artifact-1', pin_number: 3, element_label: '결제 버튼',
+    anchor: { kind: 'element', element_id: 'pay-btn' },
+    rollup: 'in_progress',
+    comments: [{ id: 'c3', author_id: 'm2', body: '위계 낮은. primary로 키우고 정본 위치 유지 바라는.', created_at: '2026-07-10T06:00:00Z' }],
+    recipients: [{ member_id: 'm1', state: 'responded' }],
+    linked_version: 4,
+  },
+  {
+    id: 't4', artifact_id: 'mock-artifact-1', pin_number: 4, element_label: '여백 간격',
+    anchor: { kind: 'coordinate', x: 50, y: 50 },
+    rollup: 'resolved',
+    comments: [{ id: 'c4', author_id: 'm3', body: '섹션 간격 8→16 조정 요청.', created_at: '2026-07-09T09:00:00Z' }],
+    recipients: [{ member_id: 'm1', state: 'responded' }],
+    resolved_by: 'm1',
+    resolved_at: '2026-07-09T10:00:00Z',
+  },
+];
+
+export const MOCK_DESCRIPTIONS: DescriptionMap = {
+  'pay-btn': 'variant=primary · 정본 위치=우하단 · 클릭 시 재시도 API 호출 · disabled=처리중',
+};

--- a/apps/web/src/services/canvas.ts
+++ b/apps/web/src/services/canvas.ts
@@ -42,6 +42,8 @@ export const MOCK_MEMBERS: Record<string, MemberRef> = {
   m1: { id: 'm1', name: '미르코 페트로비치' },
   m2: { id: 'm2', name: '유나 홀름' },
   m3: { id: 'm3', name: '디디 은와추쿠' },
+  m4: { id: 'm4', name: '파울로 오르테가' },
+  m5: { id: 'm5', name: '담롱 온찬' },
 };
 
 export const MOCK_ARTIFACT: VisualArtifact = {


### PR DESCRIPTION
## 요약
C1(#2006, 이미 머지) 위에서 오르테가 지시로 계속 병렬 착수. 유나 심화 핸드오프(`e-canvas-c2-comment-propagation-handoff` + `e-canvas-c2-propagation-mockup-render`)만으로 요소 앵커 코멘트 + ⭐전파 상태 표면을 mock 데이터 기반으로 먼저 구현.

## 구현
- `components/canvas/anchor-pin.tsx` — 요소 앵커 핀. open=`bg-info` 채움, resolved=muted 아웃라인(핸드오프 §1-2). 헤더 배지/스테이지 오버레이 겸용.
- `components/canvas/propagation-strip.tsx` — **전파 상태 머신의 얼굴**(§3, C2의 심장). 가장 진행된 수신자 1명 강조 + 나머지 "+N 도달" aggregate, 결과연결(`↳ v4 생성 — 이 코멘트가 입력`) 표시. **감시-게이트(§3-7) 준수**: 응답 시간 점수·리더보드 없음, `pending`도 calm muted(경고색/destructive 0 — 테스트로 회귀가드).
- `components/canvas/comment-thread-card.tsx` — 코멘트 스레드(작성자·본문·답글·resolve). resolved 시 카드 전체 가라앉음(`opacity-70`)+답글/resolve 컨트롤 완전 숨김(거짓 어포던스 방지 — 이미 끝난 스레드에 액션 버튼을 남기지 않음).
- `components/canvas/description-pane.tsx` — 요소별 spec("보이는 PRD", §4). 읽기 전용.
- `ArtifactViewer` 확장(하위호환) — `threads`/`descriptions` prop을 넘기면: 좌표 앵커 스레드는 스테이지에 핀 오버레이(element 앵커 오버레이는 실 artifact tree 좌표 유도가 필요해 후속), 핀 클릭 시 레일의 "coming soon" 플레이스홀더가 실제 `DescriptionPane`으로 전환. prop을 안 넘기면 C1 기존 동작 그대로(회귀 0).
- `/docs/canvas-preview` — client 컴포넌트로 분리(`canvas-preview-client.tsx`), 로컬 mock 상태로 답글/resolve 인터랙션을 실제로 시연(디자인 가디언이 상태 전이를 눈으로 확인 가능).

## 스코프
- **AC3(코멘트→C0 이벤트 전파)·AC4(코멘트→에이전트 반응 왕복 실증)는 이번 PR 범위 밖** — C0 BE(`activity_event`, 일부는 `#2000`으로 이미 착지) 실 연동이 필요한 항목. C1과 동일 원칙: mock으로 가짜 연동을 만들지 않음. §3-5 매핑 표(C0 activity_event → UI 전파 상태)가 계약이라, BE 스키마 확정 시 `PropagationState` 갱신 + fetch 배선만 추가하면 됨.
- element 앵커 스테이지 오버레이(현재는 coordinate 앵커만 오버레이)는 실 artifact 렌더 트리에서 요소 좌표를 구해야 해서 C1 BE 계약 이후로 미룸.

## 리트머스("누가 주어인가")·감시-게이트 자체심사
- pending 수신자 = "{name}에게 전달 중…"(calm, 낙인 없음). 응답한 수신자만 `info` 강조.
- 결과연결 = "이 코멘트가 v4의 입력"(주어=피드백→산출), "누가 시켰나" 프레이밍 없음.
- 금지 어휘(방치/무시/늦음/감점/응답률/미처리) grep 0 — 테스트로 회귀가드.

## 검증
- `pnpm vitest run` — 167파일/973테스트 PASS(신규 9건 — 전파strip aggregate 로직·감시게이트 색 회귀가드·resolved 카드 거짓어포던스 방지 회귀가드)
- `pnpm lint` — 신규 경고 0(기존 무관 파일 5건 pre-existing)
- `pnpm build` — EXIT 0
- worktree 격리(`sprintable-mirko-canvas-c2-wt`), origin/develop(C1 머지 반영) 기준 rebase 완료·클린 diff

## 반응형/스크린샷
- dev 배포 후 라이브 픽셀(양테마·핀↔description 연동·resolve 가라앉음) 확認 예정 — C1/E-VERIFY와 동일 흐름.

🤖 Generated with [Claude Code](https://claude.com/claude-code)