### PR TITLE
fix(canvas): C1 어댑터 실 BE 스키마 정정 (flat envelope + format 유도)

### DIFF
--- a/apps/web/src/components/canvas/artifact-section.tsx
+++ b/apps/web/src/components/canvas/artifact-section.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { ArtifactViewer } from './artifact-viewer';
-import { adaptArtifactDetail, type ArtifactVersion, type MemberRef, type VisualArtifact, type VisualArtifactDetailResponse } from '@/services/canvas';
+import { adaptArtifactDetail, type ArtifactVersion, type MemberRef, type VisualArtifact, type BeVisualArtifactDetail, type BeVisualArtifactSummary } from '@/services/canvas';
 
 interface ArtifactSectionProps {
   storyId: string;
@@ -12,9 +12,9 @@ interface ArtifactSectionProps {
 
 /**
  * E-CANVAS AC2(스토리 상세 첨부) — 실 데이터 attachment point. BE(`GET /api/visual-artifacts`,
- * C1-S3)가 아직 라우터 자체를 안 갖고 있어(§6 체크리스트 미완) 지금은 모든 스토리에서 404 →
- * **완전 무표시**로 귀결된다(mock 폴백 0 — 선생님 slop 지적 반영, 없는 걸 있는 척 안 함).
- * BE 착지 즉시 이 컴포넌트가 살아서 실 artifact를 렌더한다.
+ * C1-S3)는 실 스키마가 확定됐으나 아직 develop에 미머지(`feat/e-canvas-c1-s3-visual-artifact`,
+ * PR 대기) — 그동안은 모든 스토리에서 404 → **완전 무표시**로 귀결된다(mock 폴백 0 — 선생님
+ * slop 지적 반영, 없는 걸 있는 척 안 함). BE 머지·배포 즉시 이 컴포넌트가 실 artifact를 렌더한다.
  */
 export function ArtifactSection({ storyId, memberMap = {}, className }: ArtifactSectionProps) {
   const [items, setItems] = useState<{ artifact: VisualArtifact; versions: ArtifactVersion[] }[]>([]);
@@ -25,14 +25,14 @@ export function ArtifactSection({ storyId, memberMap = {}, className }: Artifact
       try {
         const listRes = await fetch(`/api/visual-artifacts?story_id=${storyId}`);
         if (!listRes.ok) return; // 404(BE 미착지) = "첨부 없음"과 동일 취급, 조용히 무표시
-        const listJson = (await listRes.json()) as { data?: VisualArtifact[] };
+        const listJson = (await listRes.json()) as { data?: BeVisualArtifactSummary[] };
         const artifacts = listJson.data ?? [];
         if (artifacts.length === 0) return;
 
         const details = await Promise.all(artifacts.map(async (a) => {
           const detailRes = await fetch(`/api/visual-artifacts/${a.id}`);
           if (!detailRes.ok) return null;
-          const detailJson = (await detailRes.json()) as { data?: VisualArtifactDetailResponse };
+          const detailJson = (await detailRes.json()) as { data?: BeVisualArtifactDetail };
           if (!detailJson.data) return null;
           return adaptArtifactDetail(detailJson.data);
         }));

--- a/apps/web/src/services/canvas.test.ts
+++ b/apps/web/src/services/canvas.test.ts
@@ -1,52 +1,86 @@
 import { describe, expect, it } from 'vitest';
-import { adaptArtifactDetail, type VisualArtifactDetailResponse } from './canvas';
+import { adaptArtifactDetail, deriveFormat, type BeVisualArtifactDetail } from './canvas';
 
-const BASE_ARTIFACT = {
-  id: 'a1', title: 'Test', current_version: 1, anchor_version: null,
-  created_by: 'm1', source: 'created' as const,
+const BASE_DETAIL = {
+  id: 'a1', title: 'Test', story_id: 's1', epic_id: null, doc_id: null,
+  source: 'created' as const, latest_version_number: 1, anchor_version: null,
+  created_by: 'm1', created_at: '2026-07-10T00:00:00Z',
+  version_number: 1, version_summary: null,
 };
 
-describe('adaptArtifactDetail (AC2 attachment point — provisional BE envelope)', () => {
+describe('deriveFormat (BE has no format column — derived from node composition)', () => {
+  it('returns tree when no html_blob catch-all node is present', () => {
+    expect(deriveFormat([{ id: 'n1', type: 'Card', props: {}, parent_id: null, sort_order: 0 }])).toBe('tree');
+  });
+
+  it('returns html when html_blob node has an html prop', () => {
+    expect(deriveFormat([{ id: 'blob', type: 'html_blob', props: { html: '<p>hi</p>' }, parent_id: null, sort_order: 0 }])).toBe('html');
+  });
+
+  it('returns image when html_blob node has a src prop', () => {
+    expect(deriveFormat([{ id: 'blob', type: 'html_blob', props: { src: 'https://example.com/x.png' }, parent_id: null, sort_order: 0 }])).toBe('image');
+  });
+});
+
+describe('adaptArtifactDetail (AC2 attachment point — real BE schema, flat envelope)', () => {
   it('serializes a tree-format artifact into nested-tree JSON content via resolveNodeTree', () => {
-    const detail: VisualArtifactDetailResponse = {
-      artifact: { ...BASE_ARTIFACT, format: 'tree' },
-      version_number: 1,
+    const detail: BeVisualArtifactDetail = {
+      ...BASE_DETAIL,
       nodes: [{ id: 'n1', type: 'Card', props: {}, parent_id: null, sort_order: 0 }],
     };
-    const { versions } = adaptArtifactDetail(detail);
+    const { artifact, versions } = adaptArtifactDetail(detail);
+    expect(artifact.format).toBe('tree');
+    expect(artifact.current_version).toBe(1);
     expect(versions).toHaveLength(1);
     const parsed = JSON.parse(versions[0]!.content);
     expect(parsed[0].id).toBe('n1');
   });
 
   it('extracts html content from the html_blob catch-all node for html-format artifacts', () => {
-    const detail: VisualArtifactDetailResponse = {
-      artifact: { ...BASE_ARTIFACT, format: 'html' },
+    const detail: BeVisualArtifactDetail = {
+      ...BASE_DETAIL,
       version_number: 2,
       nodes: [{ id: 'blob', type: 'html_blob', props: { html: '<p>hi</p>' }, parent_id: null, sort_order: 0 }],
     };
-    const { versions } = adaptArtifactDetail(detail);
+    const { artifact, versions } = adaptArtifactDetail(detail);
+    expect(artifact.format).toBe('html');
     expect(versions[0]!.content).toBe('<p>hi</p>');
     expect(versions[0]!.version).toBe(2);
   });
 
   it('extracts the src field from the html_blob node for image-format artifacts', () => {
-    const detail: VisualArtifactDetailResponse = {
-      artifact: { ...BASE_ARTIFACT, format: 'image' },
-      version_number: 1,
+    const detail: BeVisualArtifactDetail = {
+      ...BASE_DETAIL,
       nodes: [{ id: 'blob', type: 'html_blob', props: { src: 'https://example.com/x.png' }, parent_id: null, sort_order: 0 }],
     };
-    const { versions } = adaptArtifactDetail(detail);
+    const { artifact, versions } = adaptArtifactDetail(detail);
+    expect(artifact.format).toBe('image');
     expect(versions[0]!.content).toBe('https://example.com/x.png');
   });
 
-  it('falls back to empty content (not a crash) when the expected blob node is missing', () => {
-    const detail: VisualArtifactDetailResponse = {
-      artifact: { ...BASE_ARTIFACT, format: 'html' },
-      version_number: 1,
-      nodes: [],
+  it('treats an empty node list as an empty tree (not a crash) — format is derived, so no-blob always means tree', () => {
+    const detail: BeVisualArtifactDetail = { ...BASE_DETAIL, nodes: [] };
+    const { artifact, versions } = adaptArtifactDetail(detail);
+    expect(artifact.format).toBe('tree');
+    expect(versions[0]!.content).toBe('[]');
+  });
+
+  it('falls back to empty content (not a crash) when an html_blob node exists but its expected prop key is missing', () => {
+    const detail: BeVisualArtifactDetail = {
+      ...BASE_DETAIL,
+      nodes: [{ id: 'blob', type: 'html_blob', props: {}, parent_id: null, sort_order: 0 }],
     };
-    const { versions } = adaptArtifactDetail(detail);
+    const { artifact, versions } = adaptArtifactDetail(detail);
+    expect(artifact.format).toBe('html');
     expect(versions[0]!.content).toBe('');
+  });
+
+  it('maps latest_version_number to current_version and preserves story/epic/doc link keys', () => {
+    const detail: BeVisualArtifactDetail = { ...BASE_DETAIL, latest_version_number: 7, nodes: [] };
+    const { artifact } = adaptArtifactDetail(detail);
+    expect(artifact.current_version).toBe(7);
+    expect(artifact.story_id).toBe('s1');
+    expect(artifact.epic_id).toBeNull();
+    expect(artifact.doc_id).toBeNull();
   });
 });

--- a/apps/web/src/services/canvas.ts
+++ b/apps/web/src/services/canvas.ts
@@ -1,8 +1,11 @@
 /**
- * E-CANVAS C1 — 시각 산출물(visual artifact) FE 타입. blueprint `e-canvas-blueprint`(r3) §2
- * 객체 모델(초안) 미러 — BE 계약(디디 C1-S3, `visual_artifact`/`artifact_version`) 미착지 상태라
- * 이 타입/목업 데이터는 **잠정**이다. 실 API 착지 시 이 파일 타입만 계약대로 정정하면
- * 컴포넌트는 그대로 소비(props 인터페이스 유지가 목표).
+ * E-CANVAS C1 — 시각 산출물(visual artifact) FE 타입.
+ *
+ * `VisualArtifact`/`ArtifactVersion`(아래)은 **컴포넌트가 소비하는 FE-내부 shape**이고, 실
+ * BE 응답(flat, `format` 없음)과는 다르다 — 그 변환은 `adaptArtifactDetail`이 전담한다(§ 하단).
+ * BE 실 스키마는 2026-07-10 `feat/e-canvas-c1-s3-visual-artifact`(PR 대기 중) 소스를 직접 읽고
+ * 확認 — 더 이상 blueprint 추상 모델 추정이 아니다. dev 배포는 아직(브랜치 미머지) — 어댑터는
+ * 준비됐고 머지되는 순간 이 파이프가 실 렌더로 이어진다.
  */
 
 import type { ArtifactNode } from './canvas-nodes';
@@ -99,39 +102,87 @@ const MOCK_HTML_V4 = `<!doctype html><html><head><style>
   </div>
 </body></html>`;
 
-// ─── 실 API 어댑터 (AC2 attachment point 준비) ──────────────────────────────
-// BE(`e-canvas-c1-be-contract` §4) `GET /api/v2/visual-artifacts/{id}` 구현 자체가 아직
-// 안 됐음(§6 체크리스트 전부 미완) — 정확한 응답 envelope은 실측 전. 이 어댑터의 입력 타입은
-// 계약 §3 스키마 기반 최선 추정이며, 실 응답 관찰 후 이 함수 시그니처만 정정하면
-// ArtifactSection/ArtifactViewer 등 하위 컴포넌트는 그대로 유지된다.
+// ─── 실 API 어댑터 (AC2 attachment point) ───────────────────────────────────
+// BE(`feat/e-canvas-c1-s3-visual-artifact` — 실측 완료, PR 대기 중·2026-07-10) 실 라우터/스키마
+// (`backend/app/routers/visual_artifacts.py`·`schemas/visual_artifact.py`)를 직접 읽고 정정 —
+// 더 이상 추정 아님. 실 계약의 중요한 이탈점: **`format` 컬럼이 BE에 없다** — blueprint 추상
+// 모델엔 있었지만 실 스키마는 노드 구성으로 format을 암묵 표현한다(`html_blob` 캐치올 노드가
+// 있으면 그 props로 html/image 판별, 없으면 구조화 tree). `latest_version_number`도 실 필드명
+// (내 FE 컴포넌트의 `current_version`과 이름이 다름 — 여기 어댑터가 흡수, 컴포넌트는 안 건드림).
 
-export interface VisualArtifactDetailResponse {
-  artifact: VisualArtifact;
-  version_number: number;
-  nodes: ArtifactNode[];
+/** 살아있는 노드 구성으로 format을 유도 — BE가 저장하지 않는 파생값. */
+export function deriveFormat(nodes: ArtifactNode[]): ArtifactFormat {
+  const blob = nodes.find((n) => n.type === 'html_blob');
+  if (!blob) return 'tree';
+  return typeof blob.props['src'] === 'string' ? 'image' : 'html';
 }
 
-export function adaptArtifactDetail(detail: VisualArtifactDetailResponse): { artifact: VisualArtifact; versions: ArtifactVersion[] } {
+/** BE `ArtifactNodeOut`(schemas/visual_artifact.py) 미러 — canvas-nodes.ts의 `ArtifactNode`와 동형. */
+export type BeArtifactNode = ArtifactNode;
+
+/** BE `VisualArtifactDetail`(schemas/visual_artifact.py) 미러 — flat 응답(중첩 아님). */
+export interface BeVisualArtifactDetail {
+  id: string;
+  title: string;
+  story_id: string | null;
+  epic_id: string | null;
+  doc_id: string | null;
+  source: 'created' | 'imported';
+  latest_version_number: number;
+  anchor_version: number | null;
+  created_by: string | null;
+  created_at: string;
+  version_number: number;
+  version_summary: string | null;
+  nodes: BeArtifactNode[];
+}
+
+/** BE `VisualArtifactSummary` 미러 — `GET /api/v2/visual-artifacts?story_id=` 목록 항목(nodes 없음). */
+export interface BeVisualArtifactSummary {
+  id: string;
+  title: string;
+  story_id: string | null;
+  epic_id: string | null;
+  doc_id: string | null;
+  source: 'created' | 'imported';
+  latest_version_number: number;
+  anchor_version: number | null;
+  created_by: string | null;
+  created_at: string;
+}
+
+export function adaptArtifactDetail(detail: BeVisualArtifactDetail): { artifact: VisualArtifact; versions: ArtifactVersion[] } {
+  const format = deriveFormat(detail.nodes);
   let content: string;
-  if (detail.artifact.format === 'tree') {
+  if (format === 'tree') {
     content = JSON.stringify(resolveNodeTree(detail.nodes));
   } else {
-    // html_blob 캐치올 노드(§3)가 임포트/생성된 raw 콘텐츠를 담는다 — html은 props.html,
-    // image는 props.src(BE 계약 §3 "html_blob이면 {html, src} 등").
     const blob = detail.nodes.find((n) => n.type === 'html_blob');
-    const key = detail.artifact.format === 'image' ? 'src' : 'html';
+    const key = format === 'image' ? 'src' : 'html';
     content = typeof blob?.props[key] === 'string' ? (blob.props[key] as string) : '';
   }
+  const artifact: VisualArtifact = {
+    id: detail.id,
+    title: detail.title,
+    format,
+    current_version: detail.latest_version_number,
+    anchor_version: detail.anchor_version,
+    created_by: detail.created_by ?? '',
+    source: detail.source,
+    story_id: detail.story_id,
+    epic_id: detail.epic_id,
+    doc_id: detail.doc_id,
+  };
   const version: ArtifactVersion = {
-    id: `${detail.artifact.id}-v${detail.version_number}`,
-    artifact_id: detail.artifact.id,
+    id: `${detail.id}-v${detail.version_number}`,
+    artifact_id: detail.id,
     version: detail.version_number,
     content,
-    created_by: detail.artifact.created_by,
-    summary: null,
-    created_at: new Date().toISOString(),
+    created_by: detail.created_by ?? '',
+    summary: detail.version_summary,
+    created_at: detail.created_at,
   };
-  return { artifact: detail.artifact, versions: [version] };
+  return { artifact, versions: [version] };
 }
 
 export const MOCK_VERSIONS: ArtifactVersion[] = [


### PR DESCRIPTION
## 배경

E-CANVAS AC2(#2012)에서 만든 `adaptArtifactDetail`/`VisualArtifactDetailResponse`는 당시 실 BE 코드가 아직 없어(design doc SSOT만 존재) **최선 추정으로 작성한 임시 계약**이었다. 이후 C1-S3 BE 실 소스(`feat/e-canvas-c1-s3-visual-artifact`, PR 대기 중)를 직접 읽고 확인한 결과, 추정이 틀렸음을 발견 — 이 PR로 정정한다.

## 실 계약과 추정의 차이

| | 추정(기존) | 실 BE(정정) |
|---|---|---|
| 응답 형태 | 중첩 `{artifact, version_number, nodes}` | **flat** (모든 필드 최상위) |
| `format` 필드 | BE가 저장/응답 | **BE에 컬럼 자체가 없음** — `html_blob` 노드 유무·props로 클라이언트가 유도 |
| 버전 필드명 | `current_version` | `latest_version_number` |

## 변경 사항

- `services/canvas.ts`: `BeVisualArtifactSummary`/`BeVisualArtifactDetail` 타입을 실 Pydantic 스키마(`schemas/visual_artifact.py`)와 1:1로 미러링, `deriveFormat()` 순수 함수 추가, `adaptArtifactDetail`이 flat 응답을 소비하도록 재작성.
- `components/canvas/artifact-section.tsx`: 신 타입명으로 fetch/cast 갱신 (fetch 로직 자체는 무변경 — 404=첨부없음 무표시 그대로).
- `services/canvas.test.ts`: flat 픽스처로 재작성 + `deriveFormat` 단위테스트 추가.

컴포넌트(`ArtifactViewer` 등)는 어댑터 출력 shape(`VisualArtifact`/`ArtifactVersion`)이 그대로라 무변경.

## 참고

C1-S3 BE는 아직 develop 미머지(PR 대기 중) — 이 PR은 BE 머지 전에도 안전하게 병합 가능(프록시가 404 시 조용히 no-op). BE 머지·배포되는 즉시 이 어댑터로 실 렌더가 이어진다.

## Test plan
- [x] `pnpm vitest run src/services/canvas.test.ts src/components/canvas/` — 31/31 pass
- [x] `pnpm build` — exit 0
- [x] `pnpm lint` — 0 errors (기존 무관 warning 5건만)