### PR TITLE
fix(security): delete_story 프로젝트 인가 + create_conversation participant org 필터 (E-SECURITY SEC-S3)

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -695,15 +695,20 @@ async def create_conversation(
     """POST /api/v2/conversations — dm/group 생성 (dm 중복 방지)."""
     sender = await _resolve_member(auth, org_id, db, project_id=body.project_id)
 
+    # E-SECURITY SEC-S3(story 90cd7e57): participant_ids가 org 멤버십 필터 없이 그대로 insert
+    # 됐음(add_participant/멘션발송과 비대칭 — 그 두 경로는 이미 org-scope 검증). cross-org UUID를
+    # 참가자로 넣을 수 있던 갭 봉쇄 — 조용히 제거(에러 아님, 존재하는 유효 참가자만 방에 남음).
+    valid_participant_ids = await filter_org_member_ids(set(body.participant_ids), org_id, db)
+
     # ⭐ 인가 불변식: 휴먼↔에이전트 대화 — 에이전트 creator 동석 필수
-    await _enforce_agent_creator_policy(sender, body.participant_ids, db)
+    await _enforce_agent_creator_policy(sender, list(valid_participant_ids), db)
 
     # EF-S2 (db75ecd0): "기존방 다이렉트" 제거 — 동일 2인 pair여도 매 호출 신규 conversation 생성
     # (여러 conversation 공존·각 1주제·hermes 세션별 1방=1주제). 179db213 의 1-DM-per-pair
     # dedup + uq_conversations_dm_pair 정책 회귀(마이그 0111 에서 unique index drop).
     # 불변 보존: creator 동석/allow_list(_enforce_agent_creator_policy 위), 메시지 dedup(send_message·별개),
     # thread=스토리. dm_pair_key 컬럼은 2인 룸 태깅용으로 유지(non-unique·dedup 아님).
-    all_members = sorted({sender.id, *body.participant_ids})
+    all_members = sorted({sender.id, *valid_participant_ids})
     is_dm = len(all_members) == 2
     dm_pair_key = "|".join(str(m) for m in all_members) if is_dm else None
 

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -851,10 +851,22 @@ async def delete_story(
     repo: StoryRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
     from app.repositories.dependency import DependencyRepository
     from app.repositories.label import ItemLabelRepository
     from app.repositories.participation import ParticipationRepository
+
+    # E-SECURITY SEC-S3(story 90cd7e57): DELETE가 org-only 스코핑이라 프로젝트 미멤버(같은 org의
+    # 다른 프로젝트 소속)도 스토리 삭제 가능했음 — upload_story_attachment와 동일 SSOT
+    # (has_project_access)로 project 인가 적용.
+    story = await repo.get(id)
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(session, uuid.UUID(auth.user_id), story.project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Story not found")

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -215,12 +215,18 @@ async def test_group_request_2members_coerced_to_dm():
             obj.title = None
         session.refresh.side_effect = _refresh
 
-        async with client as c:
-            resp = await c.post("/api/v2/conversations", json={
-                "type": "group",   # label 은 group 이지만 2-member → DM 강제
-                "participant_ids": [str(uuid.uuid4())],
-                "project_id": str(PROJECT_ID),
-            })
+        # E-SECURITY SEC-S3: create_conversation이 먼저 participant_ids를 org 필터한다 — 이
+        # 테스트는 DM 강제 로직 검증이 목적이라 필터 자체는 통과-그대로(bypass)로 패치.
+        with patch(
+            "app.routers.conversations.filter_org_member_ids",
+            new=AsyncMock(side_effect=lambda ids, *a, **kw: ids),
+        ):
+            async with client as c:
+                resp = await c.post("/api/v2/conversations", json={
+                    "type": "group",   # label 은 group 이지만 2-member → DM 강제
+                    "participant_ids": [str(uuid.uuid4())],
+                    "project_id": str(PROJECT_ID),
+                })
         assert resp.status_code == 201
         body = resp.json()
         assert body["type"] == "dm", f"2-member group → DM 강제 실패: {body}"
@@ -253,12 +259,16 @@ async def test_create_dm_no_dedup_creates_new_session():
             obj.title = None
         session.refresh.side_effect = _refresh
 
-        async with client as c:
-            resp = await c.post("/api/v2/conversations", json={
-                "type": "dm",
-                "participant_ids": [str(other_id)],
-                "project_id": str(PROJECT_ID),
-            })
+        with patch(
+            "app.routers.conversations.filter_org_member_ids",
+            new=AsyncMock(side_effect=lambda ids, *a, **kw: ids),
+        ):
+            async with client as c:
+                resp = await c.post("/api/v2/conversations", json={
+                    "type": "dm",
+                    "participant_ids": [str(other_id)],
+                    "project_id": str(PROJECT_ID),
+                })
 
         assert resp.status_code == 201
         body = resp.json()

--- a/backend/tests/test_e_security_sec_s1_delete_audit_realdb.py
+++ b/backend/tests/test_e_security_sec_s1_delete_audit_realdb.py
@@ -76,6 +76,14 @@ async def _seed(session, *, human_id: uuid.UUID | None = None):
         om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_id, role="member")
         session.add(om)
         await session.commit()
+        # E-SECURITY SEC-S3(story 90cd7e57) develop merge 정합: delete_story가 human-gate
+        # (SEC-S1) 외에 has_project_access(SEC-S3)도 요구하게 됐으므로, 삭제 성공을 검증하는
+        # 시나리오는 project grant가 필요하다(존재하지 않는 story 404 테스트는 이 체크에
+        # 도달하기 전에 404가 나므로 grant 유무와 무관).
+        session.add(ProjectAccess(
+            id=uuid.uuid4(), project_id=project.id, org_member_id=om.id, permission="granted",
+        ))
+        await session.commit()
         human_user_id = human_id
         human_org_member_id = om.id
 

--- a/backend/tests/test_e_security_sec_s3_project_authz_realdb.py
+++ b/backend/tests/test_e_security_sec_s3_project_authz_realdb.py
@@ -1,0 +1,227 @@
+"""E-SECURITY SEC-S3(story 90cd7e57): delete_story project 인가 + create_conversation
+participant org 필터 — 라이브 확定 P1 갭 봉쇄 실증."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_human(session, org_id, project_id=None, *, grant_project: bool = False):
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    user = User(id=user_id, email=f"human-{user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user_id, role="member")
+    session.add(om)
+    await session.commit()
+    if grant_project and project_id is not None:
+        session.add(ProjectAccess(
+            id=uuid.uuid4(), project_id=project_id, org_member_id=om.id, permission="granted",
+        ))
+        await session.commit()
+    return user_id, om.id
+
+
+async def _seed_stories_scenario(session):
+    """org + project A(caller 접근권 없음) + project B(caller 접근권 있음) + story."""
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.pm import Story
+
+    org = Organization(id=uuid.uuid4(), name="SEC-S3 Org", slug=f"sec-s3-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_no_access = Project(id=uuid.uuid4(), org_id=org.id, name="No Access Project")
+    project_with_access = Project(id=uuid.uuid4(), org_id=org.id, name="With Access Project")
+    session.add_all([project_no_access, project_with_access])
+    await session.commit()
+
+    story_no_access = Story(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_no_access.id,
+        title="Story in inaccessible project", status="backlog",
+    )
+    story_with_access = Story(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_with_access.id,
+        title="Story in accessible project", status="backlog",
+    )
+    session.add_all([story_no_access, story_with_access])
+    await session.commit()
+
+    caller_user_id, caller_om_id = await _seed_human(session, org.id, project_with_access.id, grant_project=True)
+
+    return {
+        "org_id": org.id, "caller_user_id": caller_user_id,
+        "project_no_access_id": project_no_access.id, "project_with_access_id": project_with_access.id,
+        "story_no_access_id": story_no_access.id, "story_with_access_id": story_with_access.id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_delete_story_without_project_access_forbidden():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_stories_scenario(s)
+
+        await _setup_app(app, Session, seeded["caller_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/stories/{seeded['story_no_access_id']}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.pm import Story
+            story = (await s.execute(
+                select(Story).where(Story.id == seeded["story_no_access_id"])
+            )).scalar_one_or_none()
+            assert story is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_delete_story_with_project_access_succeeds():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_stories_scenario(s)
+
+        await _setup_app(app, Session, seeded["caller_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/stories/{seeded['story_with_access_id']}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_conversation_cross_org_participant_filtered():
+    """까심 재현: cross-org participant_id가 org 필터 없이 그대로 insert되던 갭 — 봉쇄 확認."""
+    from app.main import app
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
+            org_b = Organization(id=uuid.uuid4(), name="Org B", slug=f"org-b-{uuid.uuid4().hex[:8]}")
+            s.add_all([org_a, org_b])
+            await s.commit()
+            project_a = Project(id=uuid.uuid4(), org_id=org_a.id, name="Org A Project")
+            s.add(project_a)
+            await s.commit()
+
+            caller_user_id, _ = await _seed_human(s, org_a.id, project_a.id, grant_project=True)
+            same_org_user_id, same_org_om_id = await _seed_human(s, org_a.id)
+            other_org_user_id, other_org_om_id = await _seed_human(s, org_b.id)
+
+        await _setup_app(app, Session, caller_user_id, org_a.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/conversations",
+                json={
+                    "type": "group", "project_id": str(project_a.id),
+                    "participant_ids": [str(same_org_om_id), str(other_org_om_id)],
+                },
+            )
+            assert resp.status_code == 201, resp.text
+            conv_id = resp.json()["id"]
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.conversation import ConversationParticipant
+            participant_ids = {
+                r[0] for r in (await s.execute(
+                    select(ConversationParticipant.member_id).where(
+                        ConversationParticipant.conversation_id == uuid.UUID(conv_id)
+                    )
+                )).all()
+            }
+            assert same_org_om_id in participant_ids
+            assert other_org_om_id not in participant_ids
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- E-SECURITY SEC-S3(story `90cd7e57`, P1) — 보안 감사 defense-in-depth 갭 2건
- ①잔여 DELETE 경로가 org-only 스코핑이라 프로젝트 미멤버(같은 org 내 타 project 소속)도 스토리 삭제 가능(`has_project_access` 미적용, SEC-S1로 에이전트 경로는 막혔으나 휴먼 DELETE도 점검 필요했음)
- ②`create_conversation`의 `participant_ids`가 org 멤버십 필터 없이 그대로 insert됨(`add_participant`/멘션발송과 비대칭 — 그 두 경로는 이미 org-scope 검증)

## Crux
SEC-S6/S7의 `assert_target_in_caller_org`(cross-org 대조)와는 다른 축 — 이건 within-org project-level 인가(`has_project_access`)와 org-membership 필터(`filter_org_member_ids`) 몫이라 겹치지 않음. 기존 SSOT 헬퍼를 그대로 재사용(신설 없음), `upload_story_attachment`/멘션발송과 동일 패턴으로 대칭 확보.

## 변경
- `delete_story`: `repo.get(id)`로 story 선조회 → `has_project_access(session, auth.user_id, story.project_id, org_id)` 인가 → 미인가 403.
- `create_conversation`: `participant_ids`를 `filter_org_member_ids`로 선-필터(cross-org UUID 조용히 제거) 후 `all_members` 계산.

## Test plan
- [x] `tests/test_e_security_sec_s3_project_authz_realdb.py`(신규 3건, 실 PG): 프로젝트 미접근 삭제 차단(403·story 생존) · 접근권 있는 삭제 정상(200) · cross-org participant 필터(same-org 유지·other-org 제거) 확인
- [x] 기존 `tests/test_conversations.py` 2건 — 신규 `filter_org_member_ids` 호출로 mock 순서 밀려 실패 → 필터를 patch로 bypass(DM 강제/dedup 로직 자체 검증이 목적이라 필터와 무관, 회귀 아님)
- [x] 마이그레이션 없음
- [x] 전체 non-destructive 스위트: 3454 passed, 6 failed(전부 baseline 환경 실패)

🤖 Generated with [Claude Code](https://claude.com/claude-code)