### PR TITLE
feat(glance): E-GLANCE C1 현황판 — 로드맵·진척·참여·생동 (감시 아닌 신뢰)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -66,6 +66,7 @@
     "chats": "Chats",
     "activity": "Activity Log",
     "epics": "Epics",
+    "glance": "Glance",
     "loops": "Loop",
     "storage": "Storage"
   },
@@ -2690,6 +2691,38 @@
     "deleteConfirmTitle": "Delete Epic?",
     "deleteConfirmDescription": "This is permanent and cannot be undone. All stories in this epic will be unlinked.",
     "deleteConfirmButton": "Delete permanently"
+  },
+  "glance": {
+    "pageTitle": "Project Glance",
+    "pageDescription": "See how far this project has come, together, at a glance",
+    "noProject": "No project selected.",
+    "loading": "Loading...",
+    "roadmapEmpty": "No roadmap yet.",
+    "roadmapTitle": "Roadmap",
+    "roadmapSummary": "Milestone {position} of {total}",
+    "currentMarker": "● here",
+    "progressTitle": "Where we are",
+    "progressDetail": "{done}/{total} stories done",
+    "progressNoStories": "No stories yet",
+    "phrase": {
+      "notStarted": "Not started",
+      "justStarted": "Just started",
+      "underway": "Underway",
+      "almostThere": "Almost there",
+      "wrappingUp": "Wrapping up"
+    },
+    "collaborationTitle": "Who's building together",
+    "collaborationEmpty": "Not yet assigned.",
+    "collaborationTogether": "building together",
+    "liveStreamTitle": "Happening now",
+    "liveStreamEmpty": "No recent activity.",
+    "eventStoryStatus": "Story status changed — {entity}",
+    "eventStoryCreated": "New story — {entity}",
+    "eventRunCompleted": "Run completed — {entity}",
+    "eventRunFailed": "Run failed — {entity}",
+    "eventSprintStarted": "Sprint started — {entity}",
+    "eventSprintClosed": "Sprint closed — {entity}",
+    "eventDocCreated": "New doc — {entity}"
   },
   "loops": {
     "title": "Loop Board",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -66,6 +66,7 @@
     "chats": "채팅",
     "activity": "활동 로그",
     "epics": "에픽",
+    "glance": "현황판",
     "loops": "Loop",
     "storage": "스토리지"
   },
@@ -2690,6 +2691,38 @@
     "deleteConfirmTitle": "에픽을 삭제하시겠습니까?",
     "deleteConfirmDescription": "이 작업은 되돌릴 수 없습니다. 에픽에 포함된 스토리는 연결이 해제됩니다.",
     "deleteConfirmButton": "영구 삭제"
+  },
+  "glance": {
+    "pageTitle": "프로젝트 현황판",
+    "pageDescription": "이 프로젝트가 어디까지 함께 왔는지 한눈에",
+    "noProject": "프로젝트가 선택되지 않았습니다.",
+    "loading": "불러오는 중...",
+    "roadmapEmpty": "아직 로드맵이 없습니다.",
+    "roadmapTitle": "로드맵 흐름",
+    "roadmapSummary": "{total}개 마일스톤 중 {position}번째",
+    "currentMarker": "● 여기",
+    "progressTitle": "현재 위치 · 진척",
+    "progressDetail": "{done}/{total} 스토리 완료",
+    "progressNoStories": "아직 스토리가 없습니다",
+    "phrase": {
+      "notStarted": "시작 전",
+      "justStarted": "시작 단계",
+      "underway": "진행 중",
+      "almostThere": "거의 다 왔는",
+      "wrappingUp": "막바지"
+    },
+    "collaborationTitle": "참여 협업 지도",
+    "collaborationEmpty": "아직 배정 전입니다.",
+    "collaborationTogether": "함께 구축 중",
+    "liveStreamTitle": "지금",
+    "liveStreamEmpty": "최근 활동이 없습니다.",
+    "eventStoryStatus": "스토리 상태 변경 — {entity}",
+    "eventStoryCreated": "새 스토리 등록 — {entity}",
+    "eventRunCompleted": "실행 완료 — {entity}",
+    "eventRunFailed": "실행 실패 — {entity}",
+    "eventSprintStarted": "스프린트 시작 — {entity}",
+    "eventSprintClosed": "스프린트 종료 — {entity}",
+    "eventDocCreated": "새 문서 등록 — {entity}"
   },
   "loops": {
     "title": "Loop 보드",

--- a/apps/web/src/app/(authenticated)/glance/page.tsx
+++ b/apps/web/src/app/(authenticated)/glance/page.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { useDashboardContext } from '../../dashboard/dashboard-shell';
+import { GlanceBoard } from '@/components/glance/glance-board';
+
+export default function GlancePage() {
+  const { projectId } = useDashboardContext();
+  const t = useTranslations('glance');
+
+  if (!projectId) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <p className="text-sm text-muted-foreground">{t('noProject')}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4 p-4 sm:p-6">
+      <div>
+        <h1 className="text-lg font-semibold text-foreground">{t('pageTitle')}</h1>
+        <p className="mt-0.5 text-xs text-muted-foreground">{t('pageDescription')}</p>
+      </div>
+      <GlanceBoard projectId={projectId} />
+    </div>
+  );
+}

--- a/apps/web/src/components/glance/collaboration-map.test.tsx
+++ b/apps/web/src/components/glance/collaboration-map.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { CollaborationMap } from './collaboration-map';
+import type { EpicCollaboration, RoadmapEpic } from '@/services/glance';
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+const ROADMAP: RoadmapEpic[] = [
+  { id: 'e1', title: 'E-CANVAS', roadmapStatus: 'active', done: 5, total: 8, completionPct: 62 },
+];
+
+describe('CollaborationMap (§5 ⭐감시 최고 위험 지점 — presence만, 개수/처리량 절대 노출 0)', () => {
+  it('renders participant initials without ever emitting a count or quantity string', () => {
+    const collab: EpicCollaboration[] = [
+      { epicId: 'e1', collaborators: [{ id: 'm1', name: '미르코 페트로비치' }, { id: 'm2', name: '유나 홀름' }] },
+    ];
+    const markup = renderToStaticMarkup(wrap(<CollaborationMap roadmap={ROADMAP} collaboration={collab} />));
+    expect(markup).toContain('함께 구축 중');
+    expect(markup).toContain('미르코 페트로비치');
+    // 감시-게이트 리트머스: "2명"·"N개"류 수량화 문자열이 아예 나오면 안 된다.
+    expect(markup).not.toMatch(/\d+\s*명/);
+    expect(markup).not.toMatch(/\d+\s*개\s*완료/);
+  });
+
+  it('renders a calm "not yet assigned" state (not an error) when no epic has any collaborator', () => {
+    const collab: EpicCollaboration[] = [{ epicId: 'e1', collaborators: [] }];
+    const markup = renderToStaticMarkup(wrap(<CollaborationMap roadmap={ROADMAP} collaboration={collab} />));
+    expect(markup).toContain('아직 배정 전');
+  });
+});

--- a/apps/web/src/components/glance/collaboration-map.tsx
+++ b/apps/web/src/components/glance/collaboration-map.tsx
@@ -1,0 +1,49 @@
+import { useTranslations } from 'next-intl';
+import type { EpicCollaboration, RoadmapEpic } from '@/services/glance';
+
+interface CollaborationMapProps {
+  roadmap: RoadmapEpic[];
+  collaboration: EpicCollaboration[];
+  className?: string;
+}
+
+/**
+ * E-GLANCE §5 참여 협업 지도 — ⭐감시 최고 위험 지점. 절대 금지: 개인별 "N개 완료"·처리량·
+ * 순위·기여도 %(§5 하드라인). 아바타 옆 숫자 배지 0 — 오직 "누가 함께 있나"(presence)만.
+ * 참여 0인 에픽은 빈 슬롯 우아(§9) — 결핍 표시 아님.
+ */
+export function CollaborationMap({ roadmap, collaboration, className }: CollaborationMapProps) {
+  const t = useTranslations('glance');
+  const titleById = new Map(roadmap.map((r) => [r.id, r.title]));
+  const withPeople = collaboration.filter((c) => c.collaborators.length > 0);
+
+  if (withPeople.length === 0) {
+    return <p className="py-2 text-[11px] text-muted-foreground">{t('collaborationEmpty')}</p>;
+  }
+
+  return (
+    <div className={className}>
+      <ul className="space-y-2.5">
+        {withPeople.map((c) => (
+          <li key={c.epicId} className="flex items-center gap-2.5">
+            <span className="w-24 shrink-0 truncate text-[11px] font-medium text-foreground">
+              {titleById.get(c.epicId) ?? c.epicId}
+            </span>
+            <div className="flex -space-x-1.5">
+              {c.collaborators.map((p) => (
+                <span
+                  key={p.id}
+                  title={p.name}
+                  className="flex size-6 items-center justify-center rounded-full border-2 border-card bg-primary/15 text-[10px] font-semibold text-primary"
+                >
+                  {p.name.slice(0, 1)}
+                </span>
+              ))}
+            </div>
+            <span className="text-[11px] text-muted-foreground">{t('collaborationTogether')}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/components/glance/glance-board.tsx
+++ b/apps/web/src/components/glance/glance-board.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Loader2 } from 'lucide-react';
+import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
+import type { EpicProgress } from '@/components/dashboard/command-center/types';
+import {
+  deriveCollaboration,
+  filterMilestoneEvents,
+  mergeRoadmap,
+  type BeActivityLogItem,
+  type BeEpicListItem,
+  type BeStoryListItem,
+  type EpicCollaboration,
+  type RoadmapEpic,
+} from '@/services/glance';
+import { RoadmapFlow } from './roadmap-flow';
+import { ProgressTrajectory } from './progress-trajectory';
+import { CollaborationMap } from './collaboration-map';
+import { LiveStream } from './live-stream';
+
+interface GlanceBoardProps {
+  projectId: string;
+  className?: string;
+}
+
+function unwrap<T>(json: unknown): T | null {
+  if (!json || typeof json !== 'object') return null;
+  const d = (json as { data?: unknown }).data;
+  return (d ?? json) as T;
+}
+
+async function fetchJson(url: string): Promise<unknown> {
+  return fetch(url).then((r) => (r.ok ? r.json() : null)).catch(() => null);
+}
+
+/**
+ * E-GLANCE C1 현황판 오케스트레이터 — 실 fetch, mock 폴백 0. 서브 컴포넌트(RoadmapFlow 등)는
+ * 전부 순수 props라 여기서만 §10 데이터 소스 4종을 병합한다: /api/epics(순서 SSOT) ·
+ * /api/dashboard/overview(진척) · /api/stories?epic_id=(참여) · /api/activity-logs(생동).
+ * 아무 데이터도 없으면(신규 프로젝트 등) 로드맵 자체가 빈 배열 — §9 매트릭스의 calm 빈 상태.
+ */
+export function GlanceBoard({ projectId, className }: GlanceBoardProps) {
+  const t = useTranslations('glance');
+  const [roadmap, setRoadmap] = useState<RoadmapEpic[]>([]);
+  const [collaboration, setCollaboration] = useState<EpicCollaboration[]>([]);
+  const [events, setEvents] = useState<BeActivityLogItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!projectId) return;
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      try {
+        const [epicsJson, overviewJson, membersJson, activityJson] = await Promise.all([
+          fetchJson(`/api/epics?project_id=${projectId}&limit=100`),
+          fetchJson('/api/dashboard/overview'),
+          fetchJson('/api/team-members'),
+          fetchJson(`/api/activity-logs?project_id=${projectId}&limit=20`),
+        ]);
+
+        const epics = unwrap<BeEpicListItem[]>(epicsJson) ?? [];
+        const overview = unwrap<{ project_status: { epics: EpicProgress[] } }>(overviewJson);
+        const mergedRoadmap = mergeRoadmap(epics, overview?.project_status.epics ?? []);
+
+        const memberRows = unwrap<{ id: string; name: string }[]>(membersJson) ?? [];
+        const memberNames: Record<string, string> = {};
+        for (const m of memberRows) memberNames[m.id] = m.name;
+
+        const storyLists = await Promise.all(
+          mergedRoadmap.map((e) => fetchJson(`/api/stories?epic_id=${e.id}&limit=100`)),
+        );
+        const stories = storyLists.flatMap((s) => unwrap<BeStoryListItem[]>(s) ?? []);
+        const collab = deriveCollaboration(mergedRoadmap.map((e) => e.id), stories, memberNames);
+
+        const activityItems = unwrap<BeActivityLogItem[]>(activityJson) ?? [];
+        const milestoneEvents = filterMilestoneEvents(activityItems);
+
+        if (!cancelled) {
+          setRoadmap(mergedRoadmap);
+          setCollaboration(collab);
+          setEvents(milestoneEvents);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [projectId]);
+
+  const activeEpic = roadmap.find((e) => e.roadmapStatus === 'active') ?? null;
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 py-12 text-xs text-muted-foreground">
+        <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+        {t('loading')}
+      </div>
+    );
+  }
+
+  if (roadmap.length === 0) {
+    return <p className="py-12 text-center text-sm text-muted-foreground">{t('roadmapEmpty')}</p>;
+  }
+
+  return (
+    <div className={className}>
+      <div className="space-y-4">
+        <SectionCard>
+          <SectionCardHeader>
+            <div className="text-sm font-semibold text-foreground">{t('roadmapTitle')}</div>
+          </SectionCardHeader>
+          <SectionCardBody>
+            <RoadmapFlow epics={roadmap} />
+          </SectionCardBody>
+        </SectionCard>
+
+        {activeEpic ? (
+          <SectionCard>
+            <SectionCardHeader>
+              <div className="text-sm font-semibold text-foreground">{t('progressTitle')}</div>
+            </SectionCardHeader>
+            <SectionCardBody>
+              <ProgressTrajectory epic={activeEpic} />
+            </SectionCardBody>
+          </SectionCard>
+        ) : null}
+
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <SectionCard>
+            <SectionCardHeader>
+              <div className="text-sm font-semibold text-foreground">{t('collaborationTitle')}</div>
+            </SectionCardHeader>
+            <SectionCardBody>
+              <CollaborationMap roadmap={roadmap} collaboration={collaboration} />
+            </SectionCardBody>
+          </SectionCard>
+          <SectionCard>
+            <SectionCardHeader>
+              <div className="text-sm font-semibold text-foreground">{t('liveStreamTitle')}</div>
+            </SectionCardHeader>
+            <SectionCardBody>
+              <LiveStream events={events} />
+            </SectionCardBody>
+          </SectionCard>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/glance/live-stream.test.tsx
+++ b/apps/web/src/components/glance/live-stream.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { LiveStream } from './live-stream';
+import type { BeActivityLogItem } from '@/services/glance';
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+describe('LiveStream (§6 "누가 주어인가" 리트머스 — 이벤트가 주어, 액터/시간 노출 0)', () => {
+  it('renders the event copy without ever surfacing an actor name (actor fields are not even accepted)', () => {
+    const events: BeActivityLogItem[] = [
+      { id: 'a1', actor_type: 'agent', action: 'doc.created', entity_type: 'doc', entity_title: 'C5 handoff', created_at: '2026-07-10T00:00:00Z' },
+    ];
+    const markup = renderToStaticMarkup(wrap(<LiveStream events={events} />));
+    expect(markup).toContain('새 문서 등록');
+    expect(markup).toContain('C5 handoff');
+  });
+
+  it('renders a calm "no recent activity" state for an empty stream', () => {
+    const markup = renderToStaticMarkup(wrap(<LiveStream events={[]} />));
+    expect(markup).toContain('최근 활동이 없습니다');
+  });
+
+  it('falls back to a humanized action label for an unmapped action string', () => {
+    const events: BeActivityLogItem[] = [
+      { id: 'a2', actor_type: 'human', action: 'gate.approved', entity_type: 'gate', entity_title: null, created_at: '2026-07-10T00:00:00Z' },
+    ];
+    const markup = renderToStaticMarkup(wrap(<LiveStream events={events} />));
+    expect(markup).toContain('gate approved');
+  });
+});

--- a/apps/web/src/components/glance/live-stream.tsx
+++ b/apps/web/src/components/glance/live-stream.tsx
@@ -1,0 +1,52 @@
+import { useTranslations } from 'next-intl';
+import type { BeActivityLogItem } from '@/services/glance';
+
+interface LiveStreamProps {
+  events: BeActivityLogItem[];
+  className?: string;
+}
+
+function eventLabel(
+  action: string,
+  entityType: string | null,
+  entityTitle: string | null,
+  t: ReturnType<typeof useTranslations<'glance'>>,
+): string {
+  const entity = entityTitle ? `"${entityTitle.slice(0, 30)}"` : (entityType ?? '');
+  switch (action) {
+    case 'story.status_changed': return t('eventStoryStatus', { entity });
+    case 'story.created': return t('eventStoryCreated', { entity });
+    case 'agent_run.completed': return t('eventRunCompleted', { entity });
+    case 'agent_run.failed': return t('eventRunFailed', { entity });
+    case 'sprint.started': return t('eventSprintStarted', { entity });
+    case 'sprint.closed': return t('eventSprintClosed', { entity });
+    case 'doc.created': return t('eventDocCreated', { entity });
+    default: {
+      const label = action.replace(/[._]/g, ' ');
+      return entity ? `${label} — ${entity}` : label;
+    }
+  }
+}
+
+/**
+ * E-GLANCE §6 생동 스트림 — "누가 주어인가" 리트머스: 이벤트가 주어(액터 정보는 애초에
+ * props에 안 실려 옴, glance.ts filterMilestoneEvents가 actor 필드를 걷어냄). 시간 표시도
+ * 생략 — "N분째" 류 지연 낙인 리스크를 원천 차단(§8 "시간 강조 0").
+ */
+export function LiveStream({ events, className }: LiveStreamProps) {
+  const t = useTranslations('glance');
+  if (events.length === 0) {
+    return <p className="py-2 text-[11px] text-muted-foreground">{t('liveStreamEmpty')}</p>;
+  }
+
+  return (
+    <ul className={className}>
+      {events.map((e) => (
+        <li key={e.id} className="flex items-center gap-2 py-1 text-[11px]">
+          <span className="size-1.5 shrink-0 rounded-full bg-info/60" aria-hidden="true" />
+          <span className="text-foreground">{eventLabel(e.action, e.entity_type, e.entity_title, t)}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/web/src/components/glance/progress-trajectory.test.tsx
+++ b/apps/web/src/components/glance/progress-trajectory.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { ProgressTrajectory } from './progress-trajectory';
+import type { RoadmapEpic } from '@/services/glance';
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+describe('ProgressTrajectory (§4 정성 언어 우선 — %는 보조, 0/0=결핍 아닌 "시작 전")', () => {
+  it('shows a qualitative phrase (not a bald percentage) for an in-progress epic', () => {
+    const epic: RoadmapEpic = { id: 'e1', title: 'E-CANVAS', roadmapStatus: 'active', done: 5, total: 8, completionPct: 62 };
+    const markup = renderToStaticMarkup(wrap(<ProgressTrajectory epic={epic} />));
+    expect(markup).toContain('거의 다 왔는');
+    expect(markup).toContain('5/8');
+  });
+
+  it('renders a calm "no stories yet" line (not a deficiency framing) for a zero-story epic', () => {
+    const epic: RoadmapEpic = { id: 'e2', title: 'E-GLANCE', roadmapStatus: 'upcoming', done: 0, total: 0, completionPct: 0 };
+    const markup = renderToStaticMarkup(wrap(<ProgressTrajectory epic={epic} />));
+    expect(markup).toContain('시작 전');
+    expect(markup).toContain('아직 스토리가 없습니다');
+  });
+});

--- a/apps/web/src/components/glance/progress-trajectory.tsx
+++ b/apps/web/src/components/glance/progress-trajectory.tsx
@@ -1,0 +1,32 @@
+import { useTranslations } from 'next-intl';
+import { derivePhrase, type RoadmapEpic } from '@/services/glance';
+
+interface ProgressTrajectoryProps {
+  epic: RoadmapEpic;
+  className?: string;
+}
+
+/**
+ * E-GLANCE §4 현재 위치 — 신뢰 형성 궤적. 정성 언어 우선(§4 "%숫자 강박 아님")·%는 보조.
+ * 0/0(아직 스토리 없음)은 결핍 아닌 "시작 전" calm 상태(§9).
+ */
+export function ProgressTrajectory({ epic, className }: ProgressTrajectoryProps) {
+  const t = useTranslations('glance');
+  const phrase = derivePhrase(epic.completionPct, epic.total);
+  const width = Math.min(100, Math.max(0, epic.completionPct));
+
+  return (
+    <div className={className}>
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-sm font-semibold text-foreground">{epic.title}</span>
+        <span className="text-[11px] text-muted-foreground">{t(`phrase.${phrase}`)}</span>
+      </div>
+      <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-muted/50">
+        <div className="h-full rounded-full bg-info transition-all" style={{ width: `${width}%` }} />
+      </div>
+      <p className="mt-1 text-[11px] text-muted-foreground">
+        {epic.total === 0 ? t('progressNoStories') : t('progressDetail', { done: epic.done, total: epic.total })}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/glance/roadmap-flow.test.tsx
+++ b/apps/web/src/components/glance/roadmap-flow.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { RoadmapFlow } from './roadmap-flow';
+import type { RoadmapEpic } from '@/services/glance';
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+const EPICS: RoadmapEpic[] = [
+  { id: 'e1', title: 'E-VERIFY', roadmapStatus: 'done', done: 5, total: 5, completionPct: 100 },
+  { id: 'e2', title: 'E-CANVAS', roadmapStatus: 'active', done: 5, total: 8, completionPct: 62 },
+  { id: 'e3', title: 'E-GLANCE', roadmapStatus: 'upcoming', done: 0, total: 0, completionPct: 0 },
+];
+
+describe('RoadmapFlow (§3 로드맵 흐름 — 주어=프로젝트, 개인/시간 지연 강조 0)', () => {
+  it('renders nothing for an empty epic list', () => {
+    expect(renderToStaticMarkup(wrap(<RoadmapFlow epics={[]} />))).toBe('');
+  });
+
+  it('marks the active epic with the current-position marker', () => {
+    const markup = renderToStaticMarkup(wrap(<RoadmapFlow epics={EPICS} />));
+    expect(markup).toContain('E-CANVAS');
+    expect(markup).toContain('여기');
+  });
+
+  it('renders a project-subject summary line, never an individual-attribution phrase', () => {
+    const markup = renderToStaticMarkup(wrap(<RoadmapFlow epics={EPICS} />));
+    expect(markup).toContain('3개 마일스톤 중 2번째');
+  });
+
+  it('falls back to marking the last epic as current when no epic is active', () => {
+    const allDone: RoadmapEpic[] = EPICS.map((e) => ({ ...e, roadmapStatus: 'done' as const }));
+    const markup = renderToStaticMarkup(wrap(<RoadmapFlow epics={allDone} />));
+    expect(markup).toContain('3개 마일스톤 중 3번째');
+  });
+});

--- a/apps/web/src/components/glance/roadmap-flow.tsx
+++ b/apps/web/src/components/glance/roadmap-flow.tsx
@@ -1,0 +1,49 @@
+import { useTranslations } from 'next-intl';
+import { Check } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { RoadmapEpic } from '@/services/glance';
+
+interface RoadmapFlowProps {
+  epics: RoadmapEpic[];
+  className?: string;
+}
+
+/**
+ * E-GLANCE §3 로드맵 흐름 — 시퀀스(가로 흐름), 상태 3종(완료·진행·예정). 주어=프로젝트:
+ * "6개 중 3번째"(개인/시간 지연 강조 0). 유나 UX handoff §3 권장(가로 타임라인) 채택.
+ */
+export function RoadmapFlow({ epics, className }: RoadmapFlowProps) {
+  const t = useTranslations('glance');
+  if (epics.length === 0) return null;
+
+  const activeIndex = epics.findIndex((e) => e.roadmapStatus === 'active');
+  const currentIndex = activeIndex >= 0 ? activeIndex : epics.length - 1;
+
+  return (
+    <div className={className}>
+      <div className="flex flex-wrap items-center gap-x-1 gap-y-2">
+        {epics.map((e, i) => (
+          <div key={e.id} className="flex items-center gap-1">
+            <span
+              className={cn(
+                'inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[11px] font-medium',
+                e.roadmapStatus === 'done' && 'border-success/30 bg-success/10 text-success',
+                e.roadmapStatus === 'active' && 'border-info/40 bg-info/10 text-info',
+                e.roadmapStatus === 'upcoming' && 'border-border bg-muted/30 text-muted-foreground',
+              )}
+            >
+              {e.roadmapStatus === 'done' ? <Check className="size-3" aria-hidden="true" /> : null}
+              {e.roadmapStatus === 'active' ? <span className="size-1.5 rounded-full bg-info" aria-hidden="true" /> : null}
+              {e.title}
+              {i === currentIndex ? <span className="ml-0.5 text-[9px] opacity-70">{t('currentMarker')}</span> : null}
+            </span>
+            {i < epics.length - 1 ? <span className="text-muted-foreground/40" aria-hidden="true">─</span> : null}
+          </div>
+        ))}
+      </div>
+      <p className="mt-2 text-[11px] text-muted-foreground">
+        {t('roadmapSummary', { position: currentIndex + 1, total: epics.length })}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -16,6 +16,7 @@ import {
   Inbox,
   Layers,
   LayoutDashboard,
+  Map,
   MessageSquare,
   Repeat,
   Search,
@@ -229,6 +230,16 @@ export function AppSidebar({
                 >
                   <Layers />
                   <span>{t('epics')}</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/glance" />}
+                  isActive={isActive('/glance')}
+                  tooltip={t('glance')}
+                >
+                  <Map />
+                  <span>{t('glance')}</span>
                 </SidebarMenuButton>
               </SidebarMenuItem>
               <SidebarMenuItem>

--- a/apps/web/src/services/glance.test.ts
+++ b/apps/web/src/services/glance.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deriveCollaboration,
+  deriveRoadmapStatus,
+  derivePhrase,
+  filterMilestoneEvents,
+  mergeRoadmap,
+  type BeActivityLogItem,
+  type BeEpicListItem,
+  type BeStoryListItem,
+} from './glance';
+import type { EpicProgress } from '@/components/dashboard/command-center/types';
+
+describe('deriveRoadmapStatus (epic.status → 3버킷, done/archived 통합)', () => {
+  it('maps done and archived to done', () => {
+    expect(deriveRoadmapStatus('done')).toBe('done');
+    expect(deriveRoadmapStatus('archived')).toBe('done');
+  });
+  it('maps active to active', () => {
+    expect(deriveRoadmapStatus('active')).toBe('active');
+  });
+  it('maps draft and any unknown value to upcoming (safe fallback)', () => {
+    expect(deriveRoadmapStatus('draft')).toBe('upcoming');
+    expect(deriveRoadmapStatus('something-unexpected')).toBe('upcoming');
+  });
+});
+
+describe('mergeRoadmap (epic 목록 순서 SSOT + 별도 진척 엔드포인트 병합)', () => {
+  const epics: BeEpicListItem[] = [
+    { id: 'e1', title: 'E-VERIFY', status: 'done', created_at: '2026-06-01T00:00:00Z' },
+    { id: 'e2', title: 'E-CANVAS', status: 'active', created_at: '2026-06-15T00:00:00Z' },
+    { id: 'e3', title: 'E-GLANCE', status: 'draft', created_at: '2026-07-01T00:00:00Z' },
+  ];
+
+  it('preserves the epic list order and merges progress by epic_id', () => {
+    const progress: EpicProgress[] = [
+      { epic_id: 'e2', title: 'E-CANVAS', status: 'active', total: 8, done: 5, completion_pct: 62 },
+    ];
+    const roadmap = mergeRoadmap(epics, progress);
+    expect(roadmap.map((r) => r.id)).toEqual(['e1', 'e2', 'e3']);
+    expect(roadmap[1]).toMatchObject({ done: 5, total: 8, completionPct: 62, roadmapStatus: 'active' });
+  });
+
+  it('falls back to 0/0 (calm "시작 전", not a deficiency) when progress data is missing for an epic', () => {
+    const roadmap = mergeRoadmap(epics, []);
+    expect(roadmap[2]).toMatchObject({ done: 0, total: 0, completionPct: 0, roadmapStatus: 'upcoming' });
+  });
+});
+
+describe('derivePhrase (정성 진척 언어 — %는 보조)', () => {
+  it('returns notStarted for a zero-story epic', () => {
+    expect(derivePhrase(0, 0)).toBe('notStarted');
+  });
+  it('returns notStarted for 0% even with stories present', () => {
+    expect(derivePhrase(0, 5)).toBe('notStarted');
+  });
+  it('buckets mid-range progress as underway', () => {
+    expect(derivePhrase(45, 10)).toBe('underway');
+  });
+  it('buckets high progress as almostThere', () => {
+    expect(derivePhrase(75, 8)).toBe('almostThere');
+  });
+  it('buckets near-complete progress as wrappingUp', () => {
+    expect(derivePhrase(95, 20)).toBe('wrappingUp');
+  });
+});
+
+describe('deriveCollaboration (참여=presence만, 개수 집계 0)', () => {
+  const stories: BeStoryListItem[] = [
+    { id: 's1', epic_id: 'e1', assignee_id: 'm1' },
+    { id: 's2', epic_id: 'e1', assignee_id: 'm1' }, // 같은 사람 중복 스토리 — collaborator는 1명이어야
+    { id: 's3', epic_id: 'e1', assignee_id: 'm2' },
+    { id: 's4', epic_id: 'e2', assignee_id: null }, // 미배정
+  ];
+  const memberNames = { m1: '미르코 페트로비치', m2: '유나 홀름' };
+
+  it('dedupes repeated assignees on the same epic into a single presence entry', () => {
+    const [e1] = deriveCollaboration(['e1'], stories, memberNames);
+    expect(e1!.collaborators).toHaveLength(2);
+    expect(e1!.collaborators.map((c) => c.name).sort()).toEqual(['미르코 페트로비치', '유나 홀름']);
+  });
+
+  it('returns an empty collaborator list (not a crash) when no story is assigned', () => {
+    const [e2] = deriveCollaboration(['e2'], stories, memberNames);
+    expect(e2!.collaborators).toEqual([]);
+  });
+
+  it('returns an empty collaborator list for an epic with no stories at all', () => {
+    const [e3] = deriveCollaboration(['e3'], stories, memberNames);
+    expect(e3!.collaborators).toEqual([]);
+  });
+});
+
+describe('filterMilestoneEvents ("누가"가 아닌 "무슨 일" — 허용목록 기반)', () => {
+  const base = { id: 'a1', actor_type: 'agent' as const, entity_type: 'story', entity_title: 'X', created_at: '2026-07-10T00:00:00Z' };
+
+  it('keeps known milestone actions', () => {
+    const items: BeActivityLogItem[] = [{ ...base, action: 'story.status_changed' }];
+    expect(filterMilestoneEvents(items)).toHaveLength(1);
+  });
+
+  it('drops unknown/noise actions (e.g. raw keystroke or heartbeat events)', () => {
+    const items: BeActivityLogItem[] = [{ ...base, action: 'agent.heartbeat' }];
+    expect(filterMilestoneEvents(items)).toHaveLength(0);
+  });
+});

--- a/apps/web/src/services/glance.ts
+++ b/apps/web/src/services/glance.ts
@@ -1,0 +1,139 @@
+/**
+ * E-GLANCE C1 — "감시 아닌 신뢰" 현황판. UX handoff doc(`e-glance-glance-board-handoff`, 유나
+ * 2026-07-10) §1 감시-게이트 리트머스: 주어=프로젝트/팀(개인 성적·순위·처리량 절대 노출 0).
+ *
+ * 데이터 소스는 전부 실 확인(grounding, 추정 0):
+ * - 로드맵 순서: `GET /api/epics?project_id=`(created_at asc) — 에픽에 전용 큐 순서 컬럼 없음
+ *   (`IEpicRepository.ts` 확인) 확인 후 fallback으로 created_at 사용(§10 "없으면 sort_order"
+ *   상당 — 실제로는 sort_order 컬럼 자체가 없어 created_at이 유일한 실 정렬키).
+ * - 진척(done/total/completion_pct): `GET /api/dashboard/overview`의
+ *   `project_status.epics: EpicProgress[]`(command-center/types.ts 기존 실 타입 재사용).
+ * - 참여(협업 지도): `GET /api/stories?epic_id=`의 `assignee_id`(core-storage `Story` 인터페이스
+ *   확인 — `assignee_ids` 배열은 이 FE 스토리 레포지토리엔 없음, 단일 `assignee_id`만 실재).
+ * - 생동 스트림: `GET /api/activity-logs?project_id=`(기존 `DashboardActivityTimeline` 소비 확인).
+ */
+
+import type { EpicProgress } from '@/components/dashboard/command-center/types';
+
+export type RoadmapStatus = 'done' | 'active' | 'upcoming';
+
+export interface RoadmapEpic {
+  id: string;
+  title: string;
+  roadmapStatus: RoadmapStatus;
+  done: number;
+  total: number;
+  completionPct: number;
+}
+
+/** `GET /api/epics` 응답 항목(core-storage `Epic` 인터페이스 미러, 필요 필드만). */
+export interface BeEpicListItem {
+  id: string;
+  title: string;
+  status: string;
+  created_at: string;
+}
+
+/** epic.status(draft|active|done|archived — `epic-permissions.ts` ALLOWED_TRANSITIONS 확인)를 3버킷 로드맵 상태로 유도. */
+export function deriveRoadmapStatus(beStatus: string): RoadmapStatus {
+  if (beStatus === 'done' || beStatus === 'archived') return 'done';
+  if (beStatus === 'active') return 'active';
+  return 'upcoming';
+}
+
+/** 에픽 목록(순서 SSOT) + 진척 데이터(별 엔드포인트)를 epic id로 병합 — 진척 누락 시 0/0(결핍 아닌 "시작 전"). */
+export function mergeRoadmap(epics: BeEpicListItem[], progress: EpicProgress[]): RoadmapEpic[] {
+  const progressById = new Map(progress.map((p) => [p.epic_id, p]));
+  return epics.map((e) => {
+    const p = progressById.get(e.id);
+    return {
+      id: e.id,
+      title: e.title,
+      roadmapStatus: deriveRoadmapStatus(e.status),
+      done: p?.done ?? 0,
+      total: p?.total ?? 0,
+      completionPct: p?.completion_pct ?? 0,
+    };
+  });
+}
+
+export type ProgressPhrase = 'notStarted' | 'justStarted' | 'underway' | 'almostThere' | 'wrappingUp';
+
+/** %숫자 강박 아닌 정성 언어 우선(§4) — 숫자는 보조. */
+export function derivePhrase(completionPct: number, total: number): ProgressPhrase {
+  if (total === 0 || completionPct <= 0) return 'notStarted';
+  if (completionPct < 25) return 'justStarted';
+  if (completionPct < 60) return 'underway';
+  if (completionPct < 90) return 'almostThere';
+  return 'wrappingUp';
+}
+
+/** `GET /api/stories?epic_id=` 항목(core-storage `Story` 인터페이스 미러, 필요 필드만). */
+export interface BeStoryListItem {
+  id: string;
+  epic_id: string | null;
+  assignee_id: string | null;
+}
+
+export interface EpicCollaborator {
+  id: string;
+  name: string;
+}
+
+export interface EpicCollaboration {
+  epicId: string;
+  collaborators: EpicCollaborator[];
+}
+
+/**
+ * 참여 = "붙어있나" 여부만(§5 하드라인) — 개수·처리량 절대 집계 안 함. 스토리를 배정자별로
+ * 세지 않고 distinct assignee_id만 뽑아 "이 사람이 이 에픽에 함께 있다"만 표현.
+ */
+export function deriveCollaboration(
+  epicIds: string[],
+  stories: BeStoryListItem[],
+  memberNames: Record<string, string>,
+): EpicCollaboration[] {
+  const storiesByEpic = new Map<string, BeStoryListItem[]>();
+  for (const s of stories) {
+    if (!s.epic_id) continue;
+    const list = storiesByEpic.get(s.epic_id) ?? [];
+    list.push(s);
+    storiesByEpic.set(s.epic_id, list);
+  }
+  return epicIds.map((epicId) => {
+    const list = storiesByEpic.get(epicId) ?? [];
+    const ids = Array.from(new Set(list.map((s) => s.assignee_id).filter((id): id is string => !!id)));
+    return { epicId, collaborators: ids.map((id) => ({ id, name: memberNames[id] ?? id })) };
+  });
+}
+
+/** `GET /api/activity-logs` 항목(`dashboard-activity-timeline.tsx`의 로컬 인터페이스 미러). */
+export interface BeActivityLogItem {
+  id: string;
+  actor_type: 'human' | 'agent' | null;
+  action: string;
+  entity_type: string | null;
+  entity_title: string | null;
+  created_at: string;
+}
+
+/**
+ * "누가 주어인가" 리트머스(§6) — 이 리스트는 액터(누가 했나) 아닌 이벤트(무슨 일이 일어났나)가
+ * 주어가 되도록 actor 정보를 아예 실어보내지 않는다(개인 미시활동 미노출). 마일스톤 관련
+ * action만 허용목록(기존 `dashboard-activity-timeline`과 동일 집합 재사용 — 신규 action 문자열
+ * 추정 안 함), 그 외는 무시(생동 스트림은 "일어난 일 중 의미 있는 것"만).
+ */
+const MILESTONE_ACTIONS = new Set([
+  'story.status_changed',
+  'story.created',
+  'agent_run.completed',
+  'agent_run.failed',
+  'sprint.started',
+  'sprint.closed',
+  'doc.created',
+]);
+
+export function filterMilestoneEvents(items: BeActivityLogItem[]): BeActivityLogItem[] {
+  return items.filter((i) => MILESTONE_ACTIONS.has(i.action));
+}


### PR DESCRIPTION
## 배경

유나 UX handoff(`e-glance-glance-board-handoff`, §1 감시-게이트 리트머스=이 에픽의 뼈대) 기반 E-GLANCE C1 — 프로젝트 현황판 첫 shell. 오르테가군 지시(C2/C3 BE gated 확인 후 E-GLANCE FE 선행)로 착수.

**#2012/#2013 slop 교훈 반영**: mock 프리뷰 라우트 없이 처음부터 실 fetch로 착지. 신규 BE 0개 — 4개 요소 전부 기존 실 엔드포인트를 직접 확인 후 재사용:

| 요소 | 데이터 소스(실 확인) |
|---|---|
| 로드맵 흐름(순서) | `GET /api/epics?project_id=`(created_at asc — 에픽에 전용 정렬 컬럼 없음을 `IEpicRepository.ts` 확인 후 fallback) |
| 진척(done/total/%) | `GET /api/dashboard/overview`의 `project_status.epics: EpicProgress[]`(기존 커맨드센터 타입 재사용) |
| 참여 협업 지도 | `GET /api/stories?epic_id=`의 `assignee_id` + `GET /api/team-members`(core-storage `Story` 인터페이스 확인 — `assignee_ids` 배열은 이 레포지토리엔 없음) |
| 생동 스트림 | `GET /api/activity-logs`(기존 `DashboardActivityTimeline` 소비 확인) |

## 감시-게이트 리트머스 반영 (§1/§5/§6)

- **참여 협업 지도**: presence만(누가 붙어있나) — 개수·처리량·순위 절대 미노출. 테스트로 박음(`/\d+명/` 미매치 단언).
- **생동 스트림**: "누가 주어인가" — actor 필드를 애초에 props에 안 실어보냄(`filterMilestoneEvents`가 걷어냄). 시간 표시도 생략(지연 낙인 리스크 원천 차단).
- **진척**: 정성 언어 우선(`derivePhrase` 5버킷)·%는 보조. 0/0=결핍 아닌 "시작 전" calm.
- 색: done=`success`, active=`info`, upcoming/neutral=`muted-foreground`. `warning`/`destructive` 미사용.

## 변경 사항

- `services/glance.ts` — 순수 어댑터(`mergeRoadmap`/`derivePhrase`/`deriveCollaboration`/`filterMilestoneEvents`), 타입 전부 실 BE 응답 미러.
- `components/glance/{roadmap-flow,progress-trajectory,collaboration-map,live-stream}.tsx` — 순수 props 컴포넌트.
- `components/glance/glance-board.tsx` — 유일한 fetch 지점(4개 엔드포인트 병렬 fetch + 병합).
- `app/(authenticated)/glance/page.tsx` — 실 라우트(유나 UX doc 열린결정#2 "전용 뷰" 채택).
- `components/nav/app-sidebar.tsx` — `/glance` 진입점 신설.
- `messages/{ko,en}.json` — `nav.glance` + `glance` 네임스페이스 전체(Edit 수술 삽입, 무관 섹션 diff 0).

## 열린 결정(유나 doc §11 "FE 픽셀서") — 이번 PR에서 채택한 것

1. 로드맵 시각 = 가로 흐름(유나 권장 채택)
2. E-GLANCE = 전용 뷰(유나 권장 채택), 커맨드센터 요약 카드는 후속
3. 진척 = 정성 우선·% 보조(유나 권장 채택)
4. 참여 = presence만(하드라인 그대로)
5. 커맨드센터 "0분째 멈춤" 재프레임은 이 PR 스코프 밖(PO 판단 보류)

## Test plan
- [x] `pnpm vitest run src/services/glance.test.ts src/components/glance/` — 26/26 pass
- [x] `pnpm build` — exit 0, `/glance` 라우트 생성 확인
- [x] `pnpm lint` — 0 errors
- [ ] 라이브픽셀(양테마) — 로컬 인증 제약([[reference-live-fe-verify-deployed-only]])으로 dev 배포 후 유나 확인 필요