### PR TITLE
fix(canvas): visual-artifacts 프록시 이중 봉투 fix — 실 artifact 있어도 무표시

### DIFF
--- a/apps/web/src/app/api/visual-artifacts/[id]/route.test.ts
+++ b/apps/web/src/app/api/visual-artifacts/[id]/route.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({ getAuthContext: vi.fn(), proxyToFastapi: vi.fn() }));
+vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
+
+import { GET } from './route';
+
+const agent = () => ({ id: 'a', type: 'agent' });
+const enveloped = (data: unknown) =>
+  new Response(JSON.stringify({ data, error: null, meta: null }), { status: 200, headers: { 'content-type': 'application/json' } });
+const req = () => new Request('http://localhost/api/visual-artifacts/a1');
+const params = { params: Promise.resolve({ id: 'a1' }) };
+
+describe('GET /api/visual-artifacts/[id] (BE _ok() 이중 봉투 unwrap 회귀가드)', () => {
+  beforeEach(() => { getAuthContext.mockReset(); proxyToFastapi.mockReset(); getAuthContext.mockResolvedValue(agent()); });
+
+  it('401 when unauthenticated', async () => {
+    getAuthContext.mockResolvedValue(null);
+    expect((await GET(req(), params)).status).toBe(401);
+    expect(proxyToFastapi).not.toHaveBeenCalled();
+  });
+
+  it('unwraps the FastAPI _ok() envelope — the detail object lands directly on .data, not .data.data', async () => {
+    const detail = { id: 'a1', title: 'X', story_id: 's1', epic_id: null, doc_id: null, source: 'created', latest_version_number: 1, anchor_version: null, created_by: null, created_at: '2026-07-10T00:00:00Z', version_number: 1, version_summary: null, nodes: [] };
+    proxyToFastapi.mockResolvedValue(enveloped(detail));
+    const res = await GET(req(), params);
+    const json = await res.json() as { data: unknown };
+    expect(json.data).toEqual(detail);
+  });
+
+  it('passes through proxy errors (e.g. 404 for an unknown id)', async () => {
+    proxyToFastapi.mockResolvedValue(new Response('not found', { status: 404 }));
+    expect((await GET(req(), params)).status).toBe(404);
+  });
+});

--- a/apps/web/src/app/api/visual-artifacts/[id]/route.ts
+++ b/apps/web/src/app/api/visual-artifacts/[id]/route.ts
@@ -5,7 +5,10 @@ import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
-/** GET /api/visual-artifacts/{id} — 최신(또는 지정) 버전의 nodes 포함 상세(§4). */
+/**
+ * GET /api/visual-artifacts/{id} — 최신(또는 지정) 버전의 nodes 포함 상세.
+ * BE `_ok()` 봉투를 벗기고 재포장(list route와 동일 이중-봉투 버그 fix — 상세 참고).
+ */
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
@@ -13,6 +16,7 @@ export async function GET(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, `/api/v2/visual-artifacts/${id}`);
     if (!_r.ok) return _r;
-    return apiSuccess(await _r.json());
+    const json = (await _r.json()) as { data?: unknown };
+    return apiSuccess(json.data ?? null);
   } catch (err: unknown) { return handleApiError(err); }
 }

--- a/apps/web/src/app/api/visual-artifacts/route.test.ts
+++ b/apps/web/src/app/api/visual-artifacts/route.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({ getAuthContext: vi.fn(), proxyToFastapi: vi.fn() }));
+vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
+
+import { GET } from './route';
+
+const agent = () => ({ id: 'a', type: 'agent' });
+const enveloped = (data: unknown) =>
+  new Response(JSON.stringify({ data, error: null, meta: null }), { status: 200, headers: { 'content-type': 'application/json' } });
+const req = () => new Request('http://localhost/api/visual-artifacts?story_id=s1');
+
+describe('GET /api/visual-artifacts (BE _ok() 이중 봉투 unwrap 회귀가드)', () => {
+  beforeEach(() => { getAuthContext.mockReset(); proxyToFastapi.mockReset(); getAuthContext.mockResolvedValue(agent()); });
+
+  it('401 when unauthenticated', async () => {
+    getAuthContext.mockResolvedValue(null);
+    expect((await GET(req())).status).toBe(401);
+    expect(proxyToFastapi).not.toHaveBeenCalled();
+  });
+
+  it('unwraps the FastAPI _ok() envelope into a single envelope — the array must land directly on .data, not .data.data', async () => {
+    const artifacts = [{ id: 'a1', title: 'X', story_id: 's1', epic_id: null, doc_id: null, source: 'created', latest_version_number: 1, anchor_version: null, created_by: null, created_at: '2026-07-10T00:00:00Z' }];
+    proxyToFastapi.mockResolvedValue(enveloped(artifacts));
+    const res = await GET(req());
+    const json = await res.json() as { data: unknown };
+    expect(Array.isArray(json.data)).toBe(true);
+    expect(json.data).toEqual(artifacts);
+  });
+
+  it('falls back to an empty array (not a crash) when the upstream envelope has no data field', async () => {
+    proxyToFastapi.mockResolvedValue(new Response(JSON.stringify({ error: null, meta: null }), { status: 200 }));
+    const res = await GET(req());
+    const json = await res.json() as { data: unknown };
+    expect(json.data).toEqual([]);
+  });
+
+  it('passes through proxy errors (e.g. 404 when BE route unavailable)', async () => {
+    proxyToFastapi.mockResolvedValue(new Response('not found', { status: 404 }));
+    expect((await GET(req())).status).toBe(404);
+  });
+});

--- a/apps/web/src/app/api/visual-artifacts/route.ts
+++ b/apps/web/src/app/api/visual-artifacts/route.ts
@@ -4,10 +4,13 @@ import { getAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 /**
- * GET /api/visual-artifacts?story_id=|epic_id=|doc_id= — E-CANVAS C1-S3(BE 계약
- * `e-canvas-c1-be-contract` §4). BE 라우터/모델 자체가 아직 미구현(§6 체크리스트 미완)이라
- * 지금은 항상 404를 그대로 프록시한다 — story-detail-panel의 ArtifactSection이 그 404를
- * "이 스토리엔 첨부 없음"과 동일하게 조용히 처리(회귀 없음, mock 폴백 없음).
+ * GET /api/visual-artifacts?story_id=|epic_id=|doc_id= — E-CANVAS C1-S3.
+ *
+ * BE 라우터(`visual_artifacts.py`)는 `_ok()` 헬퍼로 이미 `{data, error, meta}` 봉투를 씌워
+ * 응답한다 — `apiSuccess(await _r.json())`로 그대로 다시 감싸면 `{data:{data:[...],...},...}`
+ * **이중 봉투**가 되어 소비부(`ArtifactSection`)가 `listJson.data`를 배열이 아닌 봉투 객체로
+ * 받아 조용히 빈 목록으로 degrade한다(라이브 검증 中 발견 — 실 artifact가 있어도 무표시).
+ * FastAPI 응답의 `.data`만 벗겨서 재포장한다.
  */
 export async function GET(request: Request) {
   try {
@@ -15,6 +18,7 @@ export async function GET(request: Request) {
     if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapi(request, '/api/v2/visual-artifacts');
     if (!_r.ok) return _r;
-    return apiSuccess(await _r.json());
+    const json = (await _r.json()) as { data?: unknown };
+    return apiSuccess(json.data ?? []);
   } catch (err: unknown) { return handleApiError(err); }
 }


### PR DESCRIPTION
## 배경 (라이브 검증 中 발견 — 즉시 수정)

C1 BE(#2009) dev 착지 확인 후 실 artifact를 curl로 생성해 story-detail-panel에서 라이브 확인하던 중 발견: **실 artifact가 있는 스토리에서도 ArtifactSection이 계속 무표시**였다.

## 근본 원인

BE 라우터(`visual_artifacts.py`)는 `_ok()` 헬퍼로 이미 `{data, error, meta}` 봉투를 씌워 응답한다. 그런데 두 Next.js 프록시 라우트(`/api/visual-artifacts`, `/api/visual-artifacts/[id]`) 모두 `apiSuccess(await _r.json())`로 그 응답을 그대로 다시 감싸 **이중 봉투**가 만들어졌다:

```
실제 응답: {"data": {"data": [...artifacts...], "error": null, "meta": null}, "error": null, "meta": null}
기대 응답: {"data": [...artifacts...], "error": null, "meta": null}
```

`ArtifactSection`(`components/canvas/artifact-section.tsx`)의 `listJson.data`는 배열이 아닌 봉투 객체를 받아 `.length`가 `undefined`(→ `undefined === 0`이 false라 조기 return 안 됨) → `.map()` 호출 시 TypeError → catch로 **조용히 "첨부 없음"과 동일하게 degrade**. #2012/#2013 머지 이후 이 파이프는 한 번도 실제로 렌더된 적이 없었다.

## 재현/검증

```
curl -X POST .../api/v2/visual-artifacts -H "Authorization: Bearer $AGENT_API_KEY" \
  -d '{"title":"...", "story_id":"...", "nodes":[{"type":"html_blob","props":{"html":"..."}}]}'
# → 201, 실 artifact 생성 확인

# 프록시 경유 응답(수정 전):
curl dev-fe/api/visual-artifacts?story_id=... → {"data":{"data":[{...}],"error":null,"meta":null},"error":null,"meta":null}
```

## 수정

두 라우트 모두 FastAPI 응답의 `.data`만 벗겨 `apiSuccess()`에 넘기도록 수정. `GlanceBoard`(#2015)가 이미 방어적 `unwrap()` 헬퍼(`d.data ?? json`)를 써서 이 종류의 이중 봉투에도 안전했던 것과 대조 — `ArtifactSection`엔 그 방어 로직이 없어 실제로 터진 케이스.

## 변경 사항
- `app/api/visual-artifacts/route.ts`, `app/api/visual-artifacts/[id]/route.ts` — `.data` unwrap 후 재포장
- 회귀가드 테스트 2개 파일 신규(BE가 이중 봉투로 보내도 최종 응답은 단일 봉투인지 단언)

## Test plan
- [x] `pnpm vitest run "src/app/api/visual-artifacts/"` — 7/7 pass
- [x] `pnpm vitest run` (전체) — 172 files, 1006 pass
- [x] `pnpm lint` — 0 errors
- [x] 실 artifact curl 생성 후 dev FE에서 라이브 재확인 예정(이 PR 머지·배포 후)