### PR TITLE
fix(security): SEC-S8(L) create_team_member/create_org_agent 무인가 신원 발급 봉쇄

### DIFF
--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -105,6 +105,16 @@ async def create_org_agent(
             raise HTTPException(status_code=403, detail="Cannot assign role higher than your own")
         if body.name == actor.name:
             raise HTTPException(status_code=400, detail="Agent cannot create a member with the same name as itself")
+    else:
+        # E-SECURITY SEC-S8(story 83ea3d6a) L 자매 갭 — create_team_member와 동일 패턴으로
+        # `if actor.type == "agent"`에 갇혀 휴먼 caller(또는 actor 미해소)면 인가가 통째로
+        # 스킵됐다. 이 엔드포인트는 단일 project가 아니라 org 범위(scope_mode='org'|'projects')
+        # 라 project 단위 role 대신 org owner/admin을 요구(target-org 검증은
+        # `_resolve_org_project_ids`가 이미 project_ids⊂org 소속으로 강제해 별도 조치 불요).
+        # 에이전트 분기는 원래 로직 그대로 무회귀(위 if 블록 미변경).
+        from app.services.project_auth import is_org_owner_or_admin
+        if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
+            raise HTTPException(status_code=403, detail="org admin/owner role required to manage members")
 
     project_ids = await _resolve_org_project_ids(body, session, org_id)
 

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
@@ -153,16 +153,33 @@ async def create_team_member(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
-    # AC1/AC2: agent actor의 멤버 관리 권한 체크.
+    # AC1/AC2: 멤버 관리 권한 체크.
     # E-MEMBER-POLICY S4: can_manage_members 플래그 직접 읽기 → effective 프로젝트 역할(has_project_role)
     # 단일 경로로 전환(블루프린트 §6). can_manage_members 는 role 에서 derived(0122 백필 can_manage=
     # true→role admin). owner/admin 이 멤버 관리. 기존 통과자(can_manage=true→admin) 무회귀 +
     # owner/admin 추가 통과(additive).
+    #
+    # E-SECURITY SEC-S8(story 83ea3d6a) L — 까심 전수스윕 CRITICAL(누구나·라이브 확定): 이 게이트가
+    # `if actor is not None and actor.type == "agent":`에 갇혀 있어 **휴먼 caller(또는 actor 미해소)
+    # 면 인가가 통째로 스킵**됐다 — 아무 권한 없는 멤버가 role=admin 에이전트 + 작동 sk_live_
+    # API키(전체 스코프)를 임의 project_id(타 org 포함)로 찍어낼 수 있었음(201 실측). 게이트를
+    # actor 종류와 무관하게 무조건 실행하도록 승격 + target(body.project_id)의 실 org를 caller
+    # org와 대조(SEC-S6/S7 헬퍼 재사용) — 기존 agent 분기가 `actor.project_id`(actor 자신의
+    # project)로 역할을 검사하던 것도 `body.project_id`(실제 target)로 정정(잠재적 자기-분기
+    # target 불일치도 함께 봉합). auth.user_id는 API키(에이전트)=member.id·JWT(휴먼)=users.id라
+    # has_project_role이 이미 양쪽을 다 매칭하는 단일 호출로 충분(신규 분기 불요).
+    from app.services.project_auth import assert_target_in_caller_org, has_project_role
+
+    target_project_org_id = (await session.execute(
+        text("SELECT org_id FROM projects WHERE id = :pid"), {"pid": str(body.project_id)},
+    )).scalar_one_or_none()
+    assert_target_in_caller_org(org_id, target_project_org_id, not_found_detail="Project not found")
+
     actor = await _resolve_actor(auth, session, org_id)
+    if not await has_project_role(session, uuid.UUID(auth.user_id), body.project_id, min_role="admin"):
+        raise HTTPException(status_code=403, detail="project admin/owner role required to manage members")
+
     if actor is not None and actor.type == "agent":
-        from app.services.project_auth import has_project_role
-        if not await has_project_role(session, actor.id, actor.project_id, min_role="admin"):
-            raise HTTPException(status_code=403, detail="project admin/owner role required to manage members")
         # AC3: target.role > actor.role → 403 (격상 차단)
         target_rank = _ROLE_RANK.get(body.role, 1)
         actor_rank = _ROLE_RANK.get(actor.role, 1)

--- a/backend/tests/test_e_security_sec_s8_l_create_org_agent_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_l_create_org_agent_realdb.py
@@ -1,0 +1,163 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) L 자매 갭: create_org_agent(POST /api/v2/agents)도
+`if actor.type=="agent"`에 갇혀 휴먼 caller(또는 actor 미해소)면 인가가 통째로 스킵되던
+동일 패턴. create_team_member 수정 중 자체 발견(fix-on-sight) — org owner/admin 게이트로
+휴먼 분기를 봉쇄."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org A(project) + 무권한 휴먼(org A member·admin 아님) + org A admin 휴먼(정당 시나리오)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.user import User
+
+    org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
+    session.add(org_a)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org_a.id, name="Org A Project")
+    session.add(project_a)
+    await session.commit()
+
+    no_priv_user_id = uuid.uuid4()
+    no_priv_user = User(id=no_priv_user_id, email=f"nopriv-{no_priv_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(no_priv_user)
+    await session.commit()
+    no_priv_om = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=no_priv_user_id, role="member")
+    session.add(no_priv_om)
+    await session.commit()
+
+    admin_user_id = uuid.uuid4()
+    admin_user = User(id=admin_user_id, email=f"admin-{admin_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(admin_user)
+    await session.commit()
+    admin_om = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=admin_user_id, role="owner")
+    session.add(admin_om)
+    await session.commit()
+
+    return {
+        "org_a_id": org_a.id, "project_a_id": project_a.id,
+        "no_priv_user_id": no_priv_user_id, "admin_user_id": admin_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_no_privilege_human_cannot_create_org_agent():
+    """L 자매 갭 재현: 무권한 휴먼(org A member, owner/admin 아님)이 org agent 생성 시도
+    → 403(기존엔 human=인가 전면스킵으로 201 + api_key 자동발급)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["no_priv_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/agents",
+                json={
+                    "name": "RogueOrgAgent", "scope_mode": "projects",
+                    "project_ids": [str(seeded["project_a_id"])],
+                },
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_admin_human_can_still_create_org_agent():
+    """회귀 0: 정당한 org admin/owner 휴먼은 여전히 org agent 생성 가능(정당 시나리오 안 깨짐)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["admin_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/agents",
+                json={
+                    "name": "LegitOrgBot", "scope_mode": "projects",
+                    "project_ids": [str(seeded["project_a_id"])],
+                },
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_l_create_team_member_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_l_create_team_member_realdb.py
@@ -1,0 +1,198 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) L: create_team_member 무인가 신원 발급 봉쇄 실증.
+
+권한체크가 `if actor.type=="agent"`에 갇혀 있어 휴먼 caller(또는 actor 미해소)면 인가가
+통째로 스킵됐음 — 아무 권한 없는 멤버가 임의 project_id(타 org 포함)로 role=admin 에이전트를
+찍어낼 수 있었음(sk_live_ API키 자동발급까지 이어짐)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org A(project) + org B(project, 대상) + 무권한 휴먼(org A 소속·프로젝트 grant 0)
+    + org A admin 휴먼(정당 시나리오 회귀용)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.user import User
+
+    org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
+    org_b = Organization(id=uuid.uuid4(), name="Org B", slug=f"org-b-{uuid.uuid4().hex[:8]}")
+    session.add_all([org_a, org_b])
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org_a.id, name="Org A Project")
+    project_b = Project(id=uuid.uuid4(), org_id=org_b.id, name="Org B Project")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    # 무권한 휴먼 — org A 소속(member role)이나 project_a에 어떤 grant도 없음.
+    no_priv_user_id = uuid.uuid4()
+    no_priv_user = User(id=no_priv_user_id, email=f"nopriv-{no_priv_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(no_priv_user)
+    await session.commit()
+    no_priv_om = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=no_priv_user_id, role="member")
+    session.add(no_priv_om)
+    await session.commit()
+
+    # 정당 admin 휴먼 — org A owner.
+    admin_user_id = uuid.uuid4()
+    admin_user = User(id=admin_user_id, email=f"admin-{admin_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(admin_user)
+    await session.commit()
+    admin_om = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=admin_user_id, role="owner")
+    session.add(admin_om)
+    await session.commit()
+
+    return {
+        "org_a_id": org_a.id, "org_b_id": org_b.id,
+        "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "no_priv_user_id": no_priv_user_id, "admin_user_id": admin_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_no_privilege_human_cannot_create_admin_agent():
+    """L 재현: 무권한 휴먼(org A member·project grant 0)이 project_a에 role=admin agent 생성 시도
+    → 403(기존엔 human=인가 전면스킵으로 201)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["no_priv_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/team-members",
+                json={
+                    "project_id": str(seeded["project_a_id"]), "org_id": str(seeded["org_a_id"]),
+                    "type": "agent", "name": "RogueAdmin", "role": "admin",
+                },
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_privilege_human_cannot_create_agent_in_other_org_project():
+    """L 재현(target-org 축): 무권한 휴먼이 Org B project_id로 agent 생성 시도 → 차단(404, org 불일치)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["no_priv_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/team-members",
+                json={
+                    "project_id": str(seeded["project_b_id"]), "org_id": str(seeded["org_a_id"]),
+                    "type": "agent", "name": "CrossOrgAgent",
+                },
+            )
+            assert resp.status_code in (403, 404), resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_admin_human_can_still_create_agent():
+    """회귀 0: 정당한 org admin/owner 휴먼은 여전히 에이전트 생성 가능(정당 시나리오 안 깨짐)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["admin_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/team-members",
+                json={
+                    "project_id": str(seeded["project_a_id"]), "org_id": str(seeded["org_a_id"]),
+                    "type": "agent", "name": "LegitBot",
+                },
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_project_role_s4_can_manage.py
+++ b/backend/tests/test_project_role_s4_can_manage.py
@@ -45,22 +45,28 @@ async def test_team_member_create_agent_no_admin_403():
     org = uuid.uuid4()
     body = TeamMemberCreate(project_id=uuid.uuid4(), org_id=org, type="agent", name="new-agent")
     actor = _agent_actor()
-    session = MagicMock()
+    session = AsyncMock()
 
-    with patch("app.routers.team_members._resolve_actor", new=AsyncMock(return_value=actor)), patch(
-        "app.services.project_auth.has_project_role", new=AsyncMock(return_value=False)
-    ) as hpr:
+    # E-SECURITY SEC-S8(L): create_team_member가 이제 role 게이트 前 target-org 대조(신설)를
+    # 먼저 하므로 no-op으로 통과시켜 이 테스트의 실제 관심사(role 게이트 자체)만 검증.
+    with patch("app.routers.team_members._resolve_actor", new=AsyncMock(return_value=actor)), \
+         patch("app.services.project_auth.assert_target_in_caller_org", new=MagicMock(return_value=None)), \
+         patch("app.services.project_auth.has_project_role", new=AsyncMock(return_value=False)) as hpr:
         with pytest.raises(HTTPException) as ei:
             await create_team_member(body, session=session, auth=_auth(), org_id=org)
     assert ei.value.status_code == 403
-    # role 경로 사용 확認: actor.id·actor.project_id·min='admin'
+    # role 경로 사용 확認: 이제 actor 무관 target(body.project_id) 기준으로 단일 호출.
     hpr.assert_awaited_once()
     assert hpr.await_args.kwargs.get("min_role") == "admin"
+    assert hpr.await_args.args[2] == body.project_id
 
 
 @pytest.mark.anyio
-async def test_team_member_create_human_actor_skips_gate():
-    """human actor 는 agent 전용 게이트 미적용(has_project_role 미호출) — 무회귀."""
+async def test_team_member_create_human_actor_now_gated():
+    """E-SECURITY SEC-S8(L) 회귀: human actor(또는 actor 미해소)도 이제 동일 게이트 적용 —
+    과거엔 `if actor.type=="agent"`에 갇혀 human이면 인가가 통째로 스킵되던 CRITICAL 갭이었다.
+    무권한 human은 403(게이트가 410 deprecated-check보다 먼저 실행돼 has_project_role이 실제
+    호출됨)."""
     from app.routers.team_members import create_team_member
     from app.schemas.team_member import TeamMemberCreate
 
@@ -68,17 +74,17 @@ async def test_team_member_create_human_actor_skips_gate():
     body = TeamMemberCreate(project_id=uuid.uuid4(), org_id=org, type="human", name="x")
     human = MagicMock()
     human.type = "human"
-    session = MagicMock()
+    session = AsyncMock()
 
-    with patch("app.routers.team_members._resolve_actor", new=AsyncMock(return_value=human)), patch(
-        "app.services.project_auth.has_project_role", new=AsyncMock(return_value=False)
-    ) as hpr:
-        # human create 는 410(deprecated)로 끊기지만 게이트(has_project_role) 전에 막힘 → 미호출
+    with patch("app.routers.team_members._resolve_actor", new=AsyncMock(return_value=human)), \
+         patch("app.services.project_auth.assert_target_in_caller_org", new=MagicMock(return_value=None)), \
+         patch("app.services.project_auth.has_project_role", new=AsyncMock(return_value=False)) as hpr:
         from fastapi import HTTPException
 
-        with pytest.raises(HTTPException):
+        with pytest.raises(HTTPException) as ei:
             await create_team_member(body, session=session, auth=_auth(), org_id=org)
-    hpr.assert_not_awaited()
+        assert ei.value.status_code == 403
+    hpr.assert_awaited_once()
 
 
 # ── create_org_agent (agents.py) ─────────────────────────────────────────────

--- a/backend/tests/test_team_members.py
+++ b/backend/tests/test_team_members.py
@@ -112,6 +112,10 @@ async def test_create_team_member_201():
         mock_result = MagicMock()
         mock_result.scalars.return_value.first.return_value = None  # _resolve_actor → non-agent
         mock_result.all.return_value = []  # fakechat_port 쿼리 → 기존 포트 없음
+        # E-SECURITY SEC-S8(L): 신규 target-org 조회(.scalar_one_or_none)·has_project_role 내부
+        # get_project_role 조회(.one_or_none)가 같은 mock_result의 다른 accessor라 독립 설정 가능.
+        mock_result.scalar_one_or_none.return_value = ORG_ID  # target project org = caller org
+        mock_result.one_or_none.return_value = ("admin", None)  # org_role=admin → has_project_role 통과
         session.execute = AsyncMock(return_value=mock_result)
 
         with patch("app.routers.team_members._resolve_actor", new=AsyncMock(return_value=None)), \


### PR DESCRIPTION
## Summary
- CRITICAL(E-SECURITY SEC-S8 story `83ea3d6a`, finding L): `create_team_member`의 인가 검사 전체가 `if actor.type=="agent"` 분기에 갇혀 있어, human caller(또는 actor 미해소)면 검사가 통째로 스킵됐음. 아무 권한 없는 멤버가 임의 project_id(타 org 포함)로 `role=admin` 에이전트 + 작동하는 `sk_live_` API키를 자동 발급받을 수 있었음(까심 라이브 HTTP+DB 스윕 확定).
- Fix: target project의 org_id를 `assert_target_in_caller_org`(SEC-S6 헬퍼)로 먼저 검증한 뒤, actor 타입 무관하게 `has_project_role(min_role="admin")` 단일 게이트 적용.
- 자매 갭(fix-on-sight로 자체 발견): `create_org_agent`도 docstring이 "create_team_member 와 동일 규칙 재사용"이라 명시했고 실제로 동일한 `if actor.type=="agent"` 함정이 있었음. org 범위 엔드포인트(단일 project 아님)라 human/미해소 분기는 `is_org_owner_or_admin`으로 게이트(target-org는 기존 `_resolve_org_project_ids`가 `project_ids ⊂ org`로 이미 강제해 별도 조치 불요). 기존 agent 분기는 완전 무변경(회귀 0) — 첫 시도땐 이 헬퍼를 무조건 앞단에 넣으려다, `org_members`만 조회해 agent를 구조적으로 배제한다는 점을 재확인하고 agent 분기를 그대로 보존하도록 정정.

## Note
원래 PR #2017(J+K+F)에 3번째 커밋(`8d8f9711`)으로 push했으나, 그 커밋이 push되기 직전 #2017이 이미 admin-merge되어(develop에는 J+K+F만 반영) L 커밋이 develop에 누락됨 — 동일 커밋을 develop 최신 기준으로 cherry-pick해 이 신규 PR로 재제출.

## Test plan
- [x] realdb: `test_e_security_sec_s8_l_create_team_member_realdb.py`(3건) — 무권한 human 차단(admin agent 생성/cross-org), 정당 org-admin human 정상(201)
- [x] realdb: `test_e_security_sec_s8_l_create_org_agent_realdb.py`(2건) — 무권한 human 차단, 정당 org-admin human 정상(201)
- [x] 기존 mock 테스트 회귀 수정: `test_team_members.py`, `test_project_role_s4_can_manage.py`(구 취약-행동-단정 테스트를 신규 안전 행동 단정으로 재작성)
- [x] 기존 `test_org_agent_create_agent_no_admin_403`(agent 분기 전용) 무변경 통과 확認 — agent 경로 회귀 0
- [x] 전체 스위트(`-m "not destructive_schema"`) 3478 passed, baseline 7건(MCP tool-count/instance/json-path, 무관) 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)