### PR TITLE
fix(security): SEC-S8(G/H/M) 개별-ID project-scope + delete_sprint 인가 + workflow-line OR-fallback 봉쇄

### DIFF
--- a/backend/app/routers/meetings.py
+++ b/backend/app/routers/meetings.py
@@ -12,19 +12,32 @@ from app.schemas.meeting import MeetingCreate, MeetingResponse, MeetingUpdate
 router = APIRouter(prefix="/api/v2/meetings", tags=["meetings"])
 
 
-def _get_repo(
+async def _get_repo(
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
-    _org_id: uuid.UUID = Depends(get_verified_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     project_id_q: uuid.UUID | None = Query(default=None, alias="project_id"),
 ) -> MeetingRepository:
+    """E-SECURITY SEC-S8(story 83ea3d6a) G: `get_verified_org_id`가 계산만 되고(dead
+    computation) `MeetingRepository`는 project_id만으로 스코핑돼(org_id 개념 자체가 없는
+    repo) org/project 접근권 미검증인 채 임의 project_id(query param 또는 JWT app_metadata)를
+    그대로 받아들였다 — delete_meeting은 F에서 이미 봉쇄했으나 list/get/update/put은
+    미봉쇄였음(같은 `_get_repo` 공유라 여기 한 곳에서 닫으면 4개 핸들러 전부 커버).
+    has_project_access(org_id=)가 org-scope + project-scope(team_member/grant/owner-admin
+    floor)를 한 번에 강제한다."""
     pid = (str(project_id_q) if project_id_q else None) or auth.claims.get("app_metadata", {}).get("project_id")
     if not pid:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="project_id required (query param or JWT app_metadata)",
         )
-    return MeetingRepository(session, uuid.UUID(str(pid)))
+    project_id = uuid.UUID(str(pid))
+
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
+    return MeetingRepository(session, project_id)
 
 
 @router.get("", response_model=list[MeetingResponse])

--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -273,9 +273,29 @@ async def delete_sprint(
     repo: SprintRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    """E-SECURITY SEC-S8(story 83ea3d6a) H: delete_story/delete_task와 동형으로 휴먼
+    전용화 + 삭제 감사(hard-delete의 에이전트 우회 벡터 차단). org-scope 자체는
+    BaseRepository.get()이 org_id로 이미 필터해 안전(cross-org 삭제는 원래도 404) —
+    누락됐던 건 human-gate와 audit뿐."""
+    from app.models.deletion_audit import DeletionAuditLog
     from app.repositories.dependency import DependencyRepository
     from app.repositories.label import ItemLabelRepository
+
+    resolved = await resolve_member(auth, org_id, session)
+    if resolved.type != "human":
+        raise HTTPException(status_code=403, detail="Sprint 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)")
+
+    sprint = await repo.get(id)
+    if sprint is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+
+    session.add(DeletionAuditLog(
+        id=uuid.uuid4(), org_id=org_id, actor_id=resolved.id,
+        entity_type="sprint", entity_id=id, entity_title=sprint.title,
+    ))
+
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Sprint not found")

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -166,6 +166,19 @@ async def _attach_has_evidence(session: AsyncSession, stories: list[Story]) -> N
             s.has_evidence = True
 
 
+async def _assert_story_project_access(
+    session: AsyncSession, auth: AuthContext, org_id: uuid.UUID, project_id: uuid.UUID
+) -> None:
+    """E-SECURITY SEC-S8(story 83ea3d6a) G: 개별-ID story 접근(get/update/status)이 org-scope만
+    있고 project 접근권 미검증이던 갭 — 같은 org 다른 project 멤버가 story id만 알면 조회/수정
+    가능했다. upload_story_attachment와 동형으로 has_project_access 재사용(휴먼 team_member·
+    에이전트 project_access grant 양쪽 처리). delete_story는 SEC-S3(#2014)가 별도 처리."""
+    from app.services.project_auth import has_project_access
+
+    if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
+
 async def _upsert_assignee_participation(
     session: AsyncSession, org_id: uuid.UUID, story_id: uuid.UUID, assignee_id: uuid.UUID
 ) -> None:
@@ -358,10 +371,12 @@ async def get_workflow_line_metrics(
 async def get_story(
     id: uuid.UUID,
     repo: StoryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> StoryResponse:
     story = await repo.get(id)
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")
+    await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
     await _attach_assignee_ids(repo.session, repo.org_id, [story])
     await _attach_has_evidence(repo.session, [story])
     return StoryResponse.model_validate(story)
@@ -607,6 +622,11 @@ async def update_story(
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
 ) -> StoryResponse:
+    _story_for_access = await repo.get(id)
+    if _story_for_access is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+    await _assert_story_project_access(db, auth, repo.org_id, _story_for_access.project_id)
+
     data = body.model_dump(exclude_unset=True)
     # S7: client 제공 asset_id strip(서버 권위·drift 방지·까심)·아래 sync url_map 으로만 역기입.
     if data.get("attachments"):
@@ -898,6 +918,8 @@ async def update_story_status(
     auth: AuthContext = Depends(get_current_user),
 ) -> StoryResponse:
     story_before = await repo.get(id)
+    if story_before is not None:
+        await _assert_story_project_access(db, auth, repo.org_id, story_before.project_id)
     old_status = story_before.status if story_before else None
 
     # 정공법 A(c1cd484b·선생님 지시): 전이 순서 **하드블록 폐지** — 비순차 점프도 항상 allow,

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -32,6 +32,22 @@ async def _attach_has_evidence(session: AsyncSession, tasks: list[Task]) -> None
             t.has_evidence = True
 
 
+async def _assert_task_project_access(
+    session: AsyncSession, auth: AuthContext, org_id: uuid.UUID, story_id: uuid.UUID
+) -> None:
+    """E-SECURITY SEC-S8(story 83ea3d6a) G: Task는 project_id가 없어 story_id→project_id로
+    해소(org-scope만 있고 project 접근권 미검증이던 갭 — 같은 org 다른 project 멤버가 개별
+    task id만 알면 조회/수정 가능했다). upload_story_attachment와 동형으로 has_project_access
+    재사용(휴먼 team_member·에이전트 project_access grant 양쪽 처리)."""
+    from app.services.project_auth import has_project_access
+
+    project_id = (
+        await session.execute(select(Story.project_id).where(Story.id == story_id))
+    ).scalar_one_or_none()
+    if project_id is None or not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
+
 @router.get("", response_model=list[TaskResponse])
 async def list_tasks(
     story_id: uuid.UUID | None = Query(default=None),
@@ -80,10 +96,13 @@ async def create_task(
 async def get_task(
     id: uuid.UUID,
     repo: TaskRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> TaskResponse:
     task = await repo.get(id)
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found")
+    await _assert_task_project_access(repo.session, auth, org_id, task.story_id)
     await _attach_has_evidence(repo.session, [task])
     return TaskResponse.model_validate(task)
 
@@ -94,8 +113,13 @@ async def update_task(
     body: TaskUpdate,
     repo: TaskRepository = Depends(_get_repo),
     db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> TaskResponse:
     task_before = await repo.get(id)
+    if task_before is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    await _assert_task_project_access(db, auth, org_id, task_before.story_id)
     old_status = task_before.status if task_before else None
     data = body.model_dump(exclude_unset=True)
     task = await repo.update(id, **data)
@@ -143,6 +167,7 @@ async def delete_task(
     task = await repo.get(id)
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found")
+    await _assert_task_project_access(session, auth, org_id, task.story_id)
     session.add(DeletionAuditLog(
         id=uuid.uuid4(), org_id=org_id, actor_id=resolved.id,
         entity_type="task", entity_id=id, entity_title=task.title,

--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -205,11 +205,16 @@ async def list_artifacts(
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    org_id, _project_id = _get_org_project(auth)
-    if not org_id:
-        return _err("FORBIDDEN", "org_id required", 403)
+    # E-SECURITY SEC-S8(story 83ea3d6a) G(N): project_id 필터가 아예 없어 story_id/epic_id/
+    # doc_id 미지정 호출(파라미터 없는 목록 조회)이 org 전체 artifact를 반환했다(cross-project
+    # 노출·미르코 라이브 실측). create_artifact/get_artifact와 동형으로 JWT/API키 컨텍스트의
+    # project_id(비-caller-suppliable)로 항상 스코프.
+    org_id, project_id = _get_org_project(auth)
+    if not org_id or not project_id:
+        return _err("FORBIDDEN", "org_id/project_id required", 403)
     q = select(VisualArtifact).where(
-        VisualArtifact.org_id == org_id, VisualArtifact.deleted_at.is_(None),
+        VisualArtifact.org_id == org_id, VisualArtifact.project_id == project_id,
+        VisualArtifact.deleted_at.is_(None),
     )
     if story_id is not None:
         q = q.where(VisualArtifact.story_id == story_id)

--- a/backend/app/routers/workflow_line_config.py
+++ b/backend/app/routers/workflow_line_config.py
@@ -96,8 +96,22 @@ async def _load_version(session: AsyncSession, org_id: uuid.UUID, version_id: uu
 
 
 async def _require_draft_author(session, actor, org_id, project_id) -> None:
-    """draft 관리 권한: project 스코프면 project admin/owner 또는 org owner/admin, org 스코프면 org owner/admin."""
+    """draft 관리 권한: project 스코프면 project admin/owner 또는 org owner/admin, org 스코프면 org owner/admin.
+
+    E-SECURITY SEC-S8(story 83ea3d6a) M: `is_org_owner_or_admin(session, actor, org_id)` fallback이
+    project_id의 실제 소속 org를 검증하지 않아, caller org의 owner/admin이 **타 org 소속 project_id**를
+    넘기면 `get_project_role`이 None을 반환해도 OR-fallback으로 통과했다(caller org 권한을 임의
+    project에 적용). project_id가 caller org 소속인지 assert_target_in_caller_org(SEC-S6)로 먼저
+    검증 — 다른 org project면 404로 존재 자체를 숨긴다(권한 실패로 project 존재를 노출하지 않음)."""
     if project_id is not None:
+        from app.models.project import Project
+        from app.services.project_auth import assert_target_in_caller_org
+
+        target_org_id = (
+            await session.execute(select(Project.org_id).where(Project.id == project_id))
+        ).scalar_one_or_none()
+        assert_target_in_caller_org(org_id, target_org_id, not_found_detail="Project not found")
+
         role = await get_project_role(session, actor, project_id)
         if role in ("owner", "admin") or await is_org_owner_or_admin(session, actor, org_id):
             return

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -32,7 +32,7 @@ _GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
     ("tasks", ("task",)),
     ("stories", ("story", "stories", "backlog", "claim", "checkin")),
     ("admin", ("give_reward", "emit_event", "trigger_ai", "activate_sprint",
-               "close_sprint", "delete_sprint", "create_sprint", "upsert_webhook", "delete_webhook")),
+               "close_sprint", "create_sprint", "upsert_webhook", "delete_webhook")),
 ]
 
 _CORE = "core"  # ping/notifications-check 등 기본 — 항상 허용
@@ -253,7 +253,7 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_delete_meeting",
     # E-SECURITY SEC-S1(확장): sprintable_delete_story/task/epic/doc 의도적 제거(에이전트
     # hard-delete 차단 — 까심 적대적 QA가 delete_story만으로는 반쪽임을 발견, story와 동형 확대).
-    "sprintable_delete_sprint",
+    # E-SECURITY SEC-S8 확장: sprintable_delete_sprint도 동일 사유로 제거.
     "sprintable_delete_webhook_config", "sprintable_emit_event", "sprintable_export_retro",
     "sprintable_get_agent_stats", "sprintable_get_blocked_stories", "sprintable_get_doc",
     "sprintable_get_epic_progress", "sprintable_get_leaderboard_v2", "sprintable_get_meeting",

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -89,7 +89,7 @@ from .tools.rewards import (
 )
 from .tools.sprints import (
     CreateSprintInput, ListSprintsInput, SprintIdInput, UpdateSprintInput,
-    activate_sprint, close_sprint, create_sprint, delete_sprint,
+    activate_sprint, close_sprint, create_sprint,
     get_velocity, list_sprints, sprint_summary, update_sprint,
 )
 from .tools.standup import (
@@ -383,7 +383,7 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_confirm_hypothesis",
      "가설 확정(active) 또는 폐기(killed). active 확정은 휴먼 경로만.",
      ConfirmHypothesisInput, confirm_hypothesis),
-    # Sprints (8)
+    # Sprints (7) — E-SECURITY SEC-S8 확장: delete_sprint 제거(에이전트 hard-delete 차단)
     ("sprintable_list_sprints",
      "스프린트 목록 조회.",
      ListSprintsInput, list_sprints),
@@ -405,9 +405,6 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_update_sprint",
      "스프린트 수정.",
      UpdateSprintInput, update_sprint),
-    ("sprintable_delete_sprint",
-     "스프린트 삭제.",
-     SprintIdInput, delete_sprint),
     # Docs (5) — E-SECURITY SEC-S1 확장: delete_doc 제거(에이전트 삭제 차단)
     ("sprintable_list_docs",
      "문서 목록 조회 (tree 또는 tag 필터).",

--- a/backend/sprintable_mcp/tools/sprints.py
+++ b/backend/sprintable_mcp/tools/sprints.py
@@ -1,4 +1,5 @@
-"""스프린트 관련 MCP 도구 (8개)."""
+"""스프린트 관련 MCP 도구 (7개) — E-SECURITY SEC-S8 확장: delete_sprint 제거(에이전트
+hard-delete 차단, delete_story와 동형 조치. 까심 적대적 QA 발견 갭)."""
 from __future__ import annotations
 
 from mcp.types import TextContent
@@ -102,13 +103,5 @@ async def update_sprint(args: UpdateSprintInput) -> list[TextContent]:
         updates["team_size"] = args.team_size
     try:
         return ok(await client.patch(f"/api/v2/sprints/{args.sprint_id}", json=updates))
-    except Exception as exc:
-        return err(str(exc))
-
-
-async def delete_sprint(args: SprintIdInput) -> list[TextContent]:
-    """스프린트 삭제."""
-    try:
-        return ok(await client.delete(f"/api/v2/sprints/{args.sprint_id}"))
     except Exception as exc:
         return err(str(exc))

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -1,8 +1,8 @@
-"""S3-6: 시스템 콜 계약 검증 — 96개 도구 등록 + 스키마 무결성 (Phase 3 완료).
+"""S3-6: 시스템 콜 계약 검증 — 95개 도구 등록 + 스키마 무결성 (Phase 3 완료).
 
 E-SECURITY SEC-S1(확장): delete_story/task/epic/doc 4종 제거(에이전트 hard-delete 차단) —
 98개 → story만 제거해 97 → task/epic/doc 3종 추가 제거해 94. E-CANVAS C1-S3: create_artifact/
-get_artifact 2종 추가 — 94 → 96."""
+get_artifact 2종 추가 — 94 → 96. E-SECURITY SEC-S8(확장): delete_sprint 제거 — 96 → 95."""
 from __future__ import annotations
 
 import os
@@ -30,10 +30,10 @@ EXPECTED_TOOLS = {
     # hypotheses (6) — E1-S5
     "sprintable_list_hypotheses", "sprintable_get_hypothesis", "sprintable_create_hypothesis",
     "sprintable_update_hypothesis", "sprintable_link_hypothesis", "sprintable_confirm_hypothesis",
-    # sprints (8)
+    # sprints (7) — E-SECURITY SEC-S8(확장): delete_sprint 의도적 제거(에이전트 hard-delete 차단)
     "sprintable_list_sprints", "sprintable_sprint_summary", "sprintable_activate_sprint",
     "sprintable_close_sprint", "sprintable_get_velocity", "sprintable_create_sprint",
-    "sprintable_update_sprint", "sprintable_delete_sprint",
+    "sprintable_update_sprint",
     # docs (5) — E-SECURITY SEC-S1(확장): delete_doc 의도적 제거(에이전트 삭제 차단)
     "sprintable_list_docs", "sprintable_get_doc", "sprintable_search_docs",
     "sprintable_create_doc", "sprintable_update_doc",
@@ -91,7 +91,7 @@ EXPECTED_TOOLS = {
 
 
 def test_total_tool_count():
-    assert len(_TOOLS) == 96
+    assert len(_TOOLS) == 95
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_e_cage_referee_p1_exclusion.py
+++ b/backend/tests/test_e_cage_referee_p1_exclusion.py
@@ -97,10 +97,13 @@ async def test_patch_story_is_excluded_true():
     marked_story.assignee_ids = []
     marked_story.meeting_id = None
     # E-BOARD S5: update_story가 _attach_assignee_ids로 story_assignees 조회 → 빈 결과 모킹
+    # E-SECURITY SEC-S8(G): update_story가 이제 먼저 repo.get(id)(access 체크용) +
+    # has_project_access(project_auth 원시SQL도 scalar_one_or_none)를 조회 — marked_story를
+    # 반환해 존재+접근권 둘 다 통과시킨다(단일 정적 목이라 모든 scalar_one_or_none 호출이 동일값).
     _empty = MagicMock()
     _empty.all.return_value = []
     _empty.scalars.return_value.all.return_value = []
-    _empty.scalar_one_or_none.return_value = None
+    _empty.scalar_one_or_none.return_value = marked_story
     _empty.scalar.return_value = None
     mock_session.execute.return_value = _empty
     marked_story.title = "Story 1"

--- a/backend/tests/test_e_cage_referee_p1_participation_api.py
+++ b/backend/tests/test_e_cage_referee_p1_participation_api.py
@@ -138,10 +138,12 @@ async def test_update_story_assignee_auto_creates_participation():
     """update_story assignee 변경 → _upsert_assignee_participation 호출 단언."""
     mock_session = AsyncMock()
     # E-BOARD S5: update_story가 _attach_assignee_ids로 story_assignees 조회 → 빈 결과 모킹
+    # E-SECURITY SEC-S8(G): has_project_access(raw SQL) 도 scalar_one_or_none을 쓰므로 truthy로
+    # 설정해 접근권 통과시킴(StoryRepository.get은 아래서 별도 patch).
     _empty = MagicMock()
     _empty.all.return_value = []
     _empty.scalars.return_value.all.return_value = []
-    _empty.scalar_one_or_none.return_value = None
+    _empty.scalar_one_or_none.return_value = 1
     _empty.scalar.return_value = None
     mock_session.execute.return_value = _empty
     story = _mock_story_obj(assignee_id=MEMBER_ID)

--- a/backend/tests/test_e_security_sec_s8_g_cross_project_access_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_g_cross_project_access_realdb.py
@@ -1,0 +1,263 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) G: story/task/meeting/visual-artifacts 개별-ID 접근 +
+visual-artifacts list의 project-scope 미검증 봉쇄 실증.
+
+근본: 개별-ID GET/PATCH 계열이 org-scope만 있고 project 접근권(has_project_access) 미검증이라
+같은 org 내 다른 project의(자신은 접근권 없는) member가 story/task/meeting id만 알면 조회/수정
+가능했다. visual-artifacts list는 project_id 필터 자체가 없어 파라미터 없는 호출이 org 전체를
+반환했다(미르코 라이브 실측 N)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a, project_b) + story_a/task_a(project_a) + meeting_a(project_a) +
+    visual_artifact_a(project_a) + human_a(project_a에만 명시 grant, project_b 접근권 없음)."""
+    from sqlalchemy import text
+    from app.models.organization import Organization
+    from app.models.pm import Story, Task
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+    from app.models.visual_artifact import VisualArtifact
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    story_a = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Story A")
+    session.add(story_a)
+    await session.commit()
+
+    task_a = Task(id=uuid.uuid4(), org_id=org.id, story_id=story_a.id, title="Task A")
+    session.add(task_a)
+    await session.commit()
+
+    meeting_a_id = uuid.uuid4()
+    await session.execute(
+        text(
+            "INSERT INTO meetings (id, project_id, title, meeting_type, participants, decisions, action_items) "
+            "VALUES (:id, :pid, :title, 'general'::meeting_type, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb)"
+        ),
+        {"id": meeting_a_id, "pid": project_a.id, "title": "Meeting A"},
+    )
+    await session.commit()
+
+    artifact_a = VisualArtifact(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Artifact A",
+        source="created", latest_version_number=1, created_by=uuid.uuid4(),
+    )
+    artifact_b = VisualArtifact(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Artifact B",
+        source="created", latest_version_number=1, created_by=uuid.uuid4(),
+    )
+    session.add_all([artifact_a, artifact_b])
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"human-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    # project_a에만 명시 grant — project_b 접근권 없음(org owner/admin도 아님).
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "story_a_id": story_a.id, "task_a_id": task_a.id, "meeting_a_id": meeting_a_id,
+        "artifact_a_id": artifact_a.id, "artifact_b_id": artifact_b.id,
+        "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id, project_id=None):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    meta = {"org_id": str(org_id)}
+    if project_id is not None:
+        meta["project_id"] = str(project_id)
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": meta})
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_project_a_human_can_get_own_project_task():
+    """회귀 0: project_a grant 보유 휴먼은 project_a의 task 정상 조회."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/tasks/{seeded['task_a_id']}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_project_a_human_can_get_own_project_story():
+    """회귀 0: project_a grant 보유 휴먼은 project_a의 story 정상 조회."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{seeded['story_a_id']}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_project_a_human_can_get_own_project_meeting():
+    """회귀 0: project_a grant 보유 휴먼은 project_a의 meeting 정상 조회(project_id는 JWT context)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/meetings/{seeded['meeting_a_id']}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_grant_human_cannot_get_other_project_meeting():
+    """G 재현: project_a에만 grant된 휴먼이 project_b(query param override)로 meeting 접근 시도
+    → 403(기존엔 _get_repo가 project_id를 검증 없이 그대로 받아들여 열람 가능)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        # JWT context는 project_a지만 query param으로 project_b를 명시 override 시도.
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/meetings/{uuid.uuid4()}?project_id={seeded['project_b_id']}"
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_visual_artifacts_list_scoped_to_own_project_only():
+    """N 재현: visual-artifacts list가 project_id 필터 없이 org 전체를 반환하던 갭 —
+    이제 caller의 JWT project_id로 스코프돼 다른 project(project_b)의 artifact가 안 섞인다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/visual-artifacts")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()["data"]
+            ids = {item["id"] for item in items}
+            assert str(seeded["artifact_a_id"]) in ids
+            assert str(seeded["artifact_b_id"]) not in ids, "다른 project(B) artifact가 섞이면 안 됨"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_h_delete_sprint_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_h_delete_sprint_realdb.py
@@ -1,0 +1,200 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) H: delete_sprint 휴먼전용화 + 삭제감사 실증.
+
+delete_story/delete_task와 동형 갭 — 인가 검사 자체가 아예 없어(auth dependency도 없었음)
+에이전트 API키로도 hard-delete가 가능했고 DeletionAuditLog도 안 남았다. org-scope 자체는
+BaseRepository.get()이 org_id로 이미 필터해 안전(cross-org 삭제는 원래도 404)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project·sprint) + 휴먼(org member) + 에이전트(project grant)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.pm import Sprint
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    sprint = Sprint(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Sprint 1")
+    session.add(sprint)
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"human-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="agent-x", is_active=True)
+    session.add(agent)
+    await session.commit()
+    agent_id = agent.id
+    # resolve_member의 API키 분기는 team_members(뷰=members⋈project_access)에서 찾으므로
+    # grant가 있어야 "Team member not found" 400이 아니라 human-gate 403까지 도달한다.
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=agent_id,
+        permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "sprint_id": sprint.id,
+        "human_user_id": human_user_id, "agent_id": agent_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+async def _setup_app_agent(app, Session, agent_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(agent_id), email="agent@test",
+            claims={"app_metadata": {"org_id": str(org_id), "api_key_id": str(uuid.uuid4())}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_agent_cannot_delete_sprint():
+    """H 재현: 에이전트 API키로 hard-delete 시도 → 403(기존엔 인가 검사 자체가 없어 200)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/sprints/{seeded['sprint_id']}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_human_delete_sprint_succeeds_and_audit_logged():
+    """회귀 0: 정당한 org 소속 휴먼은 여전히 삭제 가능 + DeletionAuditLog 기록됨."""
+    from sqlalchemy import select
+
+    from app.main import app
+    from app.models.deletion_audit import DeletionAuditLog
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_human(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/sprints/{seeded['sprint_id']}")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["ok"] is True
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            logs = (await s.execute(
+                select(DeletionAuditLog).where(
+                    DeletionAuditLog.entity_id == seeded["sprint_id"],
+                    DeletionAuditLog.entity_type == "sprint",
+                )
+            )).scalars().all()
+            assert len(logs) == 1, "삭제 감사 로그가 정확히 1건 기록돼야 함"
+            assert logs[0].entity_title == "Sprint 1"
+            assert logs[0].org_id == seeded["org_id"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_m_workflow_line_config_org_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_m_workflow_line_config_org_scope_realdb.py
@@ -1,0 +1,198 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) M: workflow-line-config `_require_draft_author`의
+OR-fallback target-org 미검증 봉쇄 실증.
+
+`role in ("owner","admin") or is_org_owner_or_admin(caller org)` fallback이 project_id의
+실제 소속 org를 검증하지 않아 — caller org(A)의 owner/admin이 **타 org(B) 소속 project_id**를
+넘기면 get_project_role이 None을 반환해도 OR-fallback(자기 org A의 owner/admin 자격)으로
+통과했다. 즉 Org A owner가 Org B 프로젝트에 대한 workflow-line draft를 생성할 수 있었다."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org A(owner human) + org B(project, 대상) + org A project(정당 project-admin 휴먼용)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
+    org_b = Organization(id=uuid.uuid4(), name="Org B", slug=f"org-b-{uuid.uuid4().hex[:8]}")
+    session.add_all([org_a, org_b])
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org_a.id, name="Org A Project")
+    project_b = Project(id=uuid.uuid4(), org_id=org_b.id, name="Org B Project")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    # Org A owner — 정당하게 project_a에 대해선 draft author 자격(org owner floor), project_b(타org)는 아님.
+    owner_user_id = uuid.uuid4()
+    owner_user = User(id=owner_user_id, email=f"owner-{owner_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(owner_user)
+    await session.commit()
+    owner_om = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=owner_user_id, role="owner")
+    session.add(owner_om)
+    await session.commit()
+
+    # Org A 소속·project_a에 명시 project admin grant(org owner/admin 아닌 순수 project 권한 경로).
+    proj_admin_user_id = uuid.uuid4()
+    proj_admin_user = User(
+        id=proj_admin_user_id, email=f"padmin-{proj_admin_user_id.hex[:8]}@test.com", hashed_password="x",
+    )
+    session.add(proj_admin_user)
+    await session.commit()
+    proj_admin_om = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=proj_admin_user_id, role="member")
+    session.add(proj_admin_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=proj_admin_om.id,
+        permission="granted", role="admin",
+    ))
+    await session.commit()
+
+    return {
+        "org_a_id": org_a.id, "org_b_id": org_b.id,
+        "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "owner_user_id": owner_user_id, "proj_admin_user_id": proj_admin_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_org_owner_cannot_create_draft_for_other_org_project():
+    """M 재현: Org A owner가 Org B project_id로 draft 생성 시도 → 404(기존엔 OR-fallback으로 201)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["owner_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/workflow-line-config/versions",
+                json={"entity_type": "story", "config": {}, "project_id": str(seeded["project_b_id"])},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_owner_can_still_create_draft_for_own_org_project():
+    """회귀 0: Org A owner는 여전히 자기 org의 project(project_a)에 draft 생성 가능(org owner floor 유지)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["owner_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/workflow-line-config/versions",
+                json={"entity_type": "story", "config": {}, "project_id": str(seeded["project_a_id"])},
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_project_admin_without_org_role_can_still_create_draft():
+    """회귀 0: org owner/admin이 아니어도 project_access(role=admin) grant만으로 draft 생성 가능
+    (project 권한 경로 무변경 확認)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["proj_admin_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/workflow-line-config/versions",
+                json={"entity_type": "story", "config": {}, "project_id": str(seeded["project_a_id"])},
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_meetings.py
+++ b/backend/tests/test_meetings.py
@@ -127,9 +127,18 @@ async def test_get_meeting_200():
 async def test_get_meeting_404():
     client, session, app = await _client()
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        session.execute = AsyncMock(return_value=mock_result)
+        # E-SECURITY SEC-S8(G): _get_repo가 이제 먼저 has_project_access(scalar_one_or_none)를
+        # 조회한다 — 1st call=access granted(truthy), 2nd call(repo.get)=None(not found).
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            r = MagicMock()
+            r.scalar_one_or_none.return_value = 1 if call_count == 1 else None
+            return r
+
+        session.execute = mock_execute
 
         async with client as c:
             resp = await c.get(f"/api/v2/meetings/{uuid.uuid4()}?project_id={PROJECT_ID}")
@@ -164,9 +173,10 @@ async def test_update_meeting_200():
 async def test_delete_meeting_200():
     client, session, app = await _client()
     try:
-        # E-SECURITY SEC-S8(F): delete_meeting이 이제 순서대로 (1) target project의 org_id 조회
-        # (2) resolve_member의 OrgMember/User 조회 (3) repo.get (4) repo.delete 내부 get을
-        # 실행한다 — call_count 기반 목으로 각 단계에 맞는 응답을 준다.
+        # E-SECURITY SEC-S8(F/G): delete_meeting이 이제 순서대로 (1) _get_repo의
+        # has_project_access(G) (2) target project의 org_id 조회(F) (3) resolve_member의
+        # OrgMember/User 조회 (4) repo.get (5) repo.delete 내부 get을 실행한다 — call_count
+        # 기반 목으로 각 단계에 맞는 응답을 준다.
         om_mock = MagicMock()
         om_mock.id = uuid.uuid4()
         om_mock.role = "member"
@@ -179,10 +189,12 @@ async def test_delete_meeting_200():
             call_count += 1
             r = MagicMock()
             if call_count == 1:
-                r.scalar_one_or_none.return_value = ORG_ID  # project org lookup
+                r.scalar_one_or_none.return_value = 1  # _get_repo: has_project_access granted
             elif call_count == 2:
-                r.scalar_one_or_none.return_value = om_mock  # resolve_member: OrgMember
+                r.scalar_one_or_none.return_value = ORG_ID  # project org lookup
             elif call_count == 3:
+                r.scalar_one_or_none.return_value = om_mock  # resolve_member: OrgMember
+            elif call_count == 4:
                 r.scalar_one_or_none.return_value = None  # resolve_member: User(optional)
             else:
                 r.scalar_one_or_none.return_value = meeting  # repo.get / repo.delete 내부 get

--- a/backend/tests/test_ss2_auth_context.py
+++ b/backend/tests/test_ss2_auth_context.py
@@ -126,9 +126,18 @@ async def test_patch_meeting_with_org_context_passes_auth():
     ctx = _mk_ctx(org_id=ORG_ID)
     client, session, app = await _client(ctx)
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        session.execute = AsyncMock(return_value=mock_result)
+        # E-SECURITY SEC-S8(G): _get_repo가 이제 먼저 has_project_access를 조회한다 —
+        # 1st call=access granted(truthy), 2nd call(repo.update 내부 get)=None(not found).
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            r = MagicMock()
+            r.scalar_one_or_none.return_value = 1 if call_count == 1 else None
+            return r
+
+        session.execute = mock_execute
 
         async with client as c:
             resp = await c.patch(
@@ -146,9 +155,18 @@ async def test_put_meeting_with_org_context_passes_auth():
     ctx = _mk_ctx(org_id=ORG_ID)
     client, session, app = await _client(ctx)
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        session.execute = AsyncMock(return_value=mock_result)
+        # E-SECURITY SEC-S8(G): _get_repo가 이제 먼저 has_project_access를 조회한다 —
+        # 1st call=access granted(truthy), 2nd call(repo.update 내부 get)=None(not found).
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            r = MagicMock()
+            r.scalar_one_or_none.return_value = 1 if call_count == 1 else None
+            return r
+
+        session.execute = mock_execute
 
         async with client as c:
             resp = await c.put(

--- a/backend/tests/test_toolset_catalog.py
+++ b/backend/tests/test_toolset_catalog.py
@@ -74,9 +74,9 @@ def test_tool_group_mapping_examples():
     # 도메인 destructive 는 도메인 그룹(admin 아님)
     # E-SECURITY SEC-S1(확장): sprintable_delete_story/task/epic/doc 제거(에이전트 hard-delete
     # 차단) — delete_meeting으로 대체 예시(에이전트 MCP 표면에 남는 도메인 destructive 도구)
+    # E-SECURITY SEC-S8 확장: sprintable_delete_sprint도 동일 사유로 제거.
     assert by_tool["sprintable_delete_meeting"] == "meetings"
     assert by_tool["sprintable_give_reward"] == "rewards"
-    assert by_tool["sprintable_delete_sprint"] == "sprints"
     # admin 그룹 = emit_event/trigger_ai/activate_sprint/close_sprint 등 진짜 파괴 작업만
     assert by_tool["sprintable_emit_event"] == "admin"
     # always-allowed(+orphan)는 core 로 통합(키워드 그룹서 제외)


### PR DESCRIPTION
## Summary
E-SECURITY SEC-S8(story `83ea3d6a`) 까심 전수스윕 후속 3건 — 근본은 "project/org 접근권 검증 없이 caller가 지정한 대상에 작용" 하나로 수렴, `has_project_access`/`assert_target_in_caller_org`(SEC-S3/S6 기존 헬퍼) 재사용으로 닫음.

**G** — story/task/meeting 개별-ID GET/PATCH + visual-artifacts list가 org-scope만 있고 project 접근권 미검증:
- `tasks.py`: get_task/update_task/delete_task — Task는 project_id가 없어 story_id→project_id로 해소 후 has_project_access.
- `meetings.py`: `_get_repo`(list/get/update/put/delete 공유)가 `get_verified_org_id`를 계산만 하고(dead computation) project_id만으로 스코핑돼 org조차 무검증이었음 — 단일 지점에서 has_project_access(org_id=)로 org+project 스코프 동시 강제(delete_meeting은 SEC-S8 F가 이미 org-scope 봉쇄했으나 list/get/update/put 4개는 미봉쇄였음).
- `stories.py`: get_story/update_story/update_story_status — delete_story는 SEC-S3(#2014)가 별도 처리해 제외.
- `visual_artifacts.py`: list_artifacts — project_id 필터가 아예 없어 파라미터 없는 호출이 org 전체 artifact 반환(미르코 라이브 실측, N). create_artifact와 동형으로 JWT/API키 컨텍스트 project_id로 스코프.

**H** — `delete_sprint`에 인가 검사 자체가 없었음(auth dependency도 없음). org-scope는 `BaseRepository.get()`이 이미 안전 — 누락된 human-gate+삭제감사만 delete_story/task와 동형 추가. MCP `sprintable_delete_sprint`도 SEC-S1 선례대로 제거.

**M** — workflow-line-config `_require_draft_author`의 `role in ("owner","admin") or is_org_owner_or_admin(caller org)` OR-fallback이 project_id의 실제 소속 org를 검증 안 해, caller org owner/admin이 **타 org 소속 project_id**를 넘기면 통과했음. `assert_target_in_caller_org`로 project_id가 caller org 소속인지 먼저 검증 — `_require_draft_author`를 경유하는 모든 호출부(create_draft_version/list_versions/save_draft/get_active_line 등)가 단일 지점 수정으로 커버.

## Test plan
- [x] realdb: G 5건(same-project 정상·cross-project 차단·visual-artifacts list 스코프), H 2건(agent 차단·human+감사), M 3건(cross-org 차단·org-owner floor 회귀0·project-access-only 회귀0)
- [x] 기존 mock 테스트 회귀 수정(has_project_access 신규 조회로 call_count/dual-accessor 재구성): `test_meetings.py`, `test_ss2_auth_context.py`, `test_e_cage_referee_p1_exclusion.py`, `test_e_cage_referee_p1_participation_api.py`, `test_toolset_catalog.py`, `tests/mcp/test_contract.py`(96→95)
- [x] 전체 스위트(`-m "not destructive_schema"`) 3488 passed, baseline 7건(MCP tool-count/instance/json-path, 무관) 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)