### PR TITLE
fix(security): SEC-S8(O) create_org_agent 에이전트-분기 grant-scope 미검증 봉쇄

### DIFF
--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -95,12 +95,22 @@ async def create_org_agent(
     # 권한: create_team_member 와 동일 규칙 재사용(agent actor 제약).
     from app.routers.team_members import _ROLE_RANK, _resolve_actor
 
+    # E-SECURITY SEC-S8(story 83ea3d6a) O: project_ids를 role 체크보다 먼저 해소해야 아래
+    # agent 분기가 실제 grant 대상 전체에 대해 admin 권한을 검증할 수 있다(기존엔 actor.project_id
+    # 하나만 봐서 grant 대상과 무관했다).
+    project_ids = await _resolve_org_project_ids(body, session, org_id)
+
     actor = await _resolve_actor(auth, session, org_id)
     if actor is not None and actor.type == "agent":
-        # S4: can_manage_members → has_project_role(min='admin') 단일 경로(role 에서 derived).
+        # E-SECURITY SEC-S8 O(까심 실HTTP 2단계 재현, PR#1557부터 존재): has_project_role이
+        # caller의 anchor project(actor.project_id) 하나만 검사해, P1에만 admin인 에이전트가
+        # scope_mode='projects'로 P2(본인 무권한 project)나 scope_mode='org'로 org 전체에
+        # 새 에이전트+API키를 찍어낼 수 있었다(grant 대상과 검증 대상 불일치). project_ids
+        # 전원에 대해 admin role을 요구 — 하나라도 admin이 아니면 전체 요청 차단.
         from app.services.project_auth import has_project_role
-        if not await has_project_role(session, actor.id, actor.project_id, min_role="admin"):
-            raise HTTPException(status_code=403, detail="project admin/owner role required to manage members")
+        for pid in project_ids:
+            if not await has_project_role(session, actor.id, pid, min_role="admin"):
+                raise HTTPException(status_code=403, detail="project admin/owner role required to manage members")
         if _ROLE_RANK.get(body.role, 1) > _ROLE_RANK.get(actor.role, 1):
             raise HTTPException(status_code=403, detail="Cannot assign role higher than your own")
         if body.name == actor.name:
@@ -115,8 +125,6 @@ async def create_org_agent(
         from app.services.project_auth import is_org_owner_or_admin
         if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
             raise HTTPException(status_code=403, detail="org admin/owner role required to manage members")
-
-    project_ids = await _resolve_org_project_ids(body, session, org_id)
 
     created_by = uuid.UUID(auth.user_id)  # 휴먼=user_id / 에이전트=member.id (anchor sync 가 휴먼만 owner 매칭)
     member, api_key_plaintext = await create_org_level_agent(

--- a/backend/tests/test_e_security_sec_s8_o_create_org_agent_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_o_create_org_agent_scope_realdb.py
@@ -1,0 +1,187 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) O: create_org_agent 에이전트-분기 grant-scope 미검증 봉쇄
+실증.
+
+`has_project_role`이 caller agent의 anchor project(actor.project_id) 하나만 검사해, P1에만
+admin인 에이전트가 scope_mode='projects'로 P2(본인 무권한 project)나 scope_mode='org'로 org
+전체에 새 에이전트+API키를 찍어낼 수 있었다(까심 실HTTP 2단계 재현, PR#1557부터 존재하던 갭)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_p1, project_p2) + agent(project_p1에만 role=admin grant)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_p1 = Project(id=uuid.uuid4(), org_id=org.id, name="Project P1")
+    project_p2 = Project(id=uuid.uuid4(), org_id=org.id, name="Project P2")
+    session.add_all([project_p1, project_p2])
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="agent-p1-admin", is_active=True)
+    session.add(agent)
+    await session.commit()
+    agent_id = agent.id
+    # P1에만 admin grant — P2는 무권한.
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_p1.id, member_id=agent_id, permission="granted", role="admin",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_p1_id": project_p1.id, "project_p2_id": project_p2.id,
+        "agent_id": agent_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_agent(app, Session, agent_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(agent_id), email="agent@test",
+            claims={"app_metadata": {"org_id": str(org_id), "api_key_id": str(uuid.uuid4())}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_p1_admin_agent_can_create_agent_scoped_to_p1():
+    """회귀 0: P1에서 admin인 에이전트는 P1로 scope_mode='projects' 새 에이전트 생성 가능."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/agents",
+                json={
+                    "name": "LegitChild", "scope_mode": "projects",
+                    "project_ids": [str(seeded["project_p1_id"])],
+                },
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_p1_admin_agent_cannot_create_agent_scoped_to_p2():
+    """O 재현: P1에서만 admin인 에이전트가 P2(무권한)로 scope_mode='projects' 시도 → 403
+    (기존엔 actor.project_id=P1만 검사해 통과·P2에 admin 에이전트+API키 찍힘)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/agents",
+                json={
+                    "name": "RogueChildP2", "scope_mode": "projects",
+                    "project_ids": [str(seeded["project_p2_id"])],
+                },
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_p1_admin_agent_cannot_create_org_wide_agent():
+    """O 재현(scope_mode='org' 축): P1에서만 admin인 에이전트가 scope_mode='org'(전 프로젝트
+    grant, P2 포함) 시도 → 403(P2에 admin 아니므로 전체 요청 차단)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/agents",
+                json={"name": "RogueOrgWide", "scope_mode": "org"},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_project_role_s4_can_manage.py
+++ b/backend/tests/test_project_role_s4_can_manage.py
@@ -100,7 +100,13 @@ async def test_org_agent_create_agent_no_admin_403():
     org = uuid.uuid4()
     body = OrgAgentCreate(name="cos", scope_mode="org")
     actor = _agent_actor()
-    session = MagicMock()
+    session = AsyncMock()
+    # E-SECURITY SEC-S8(O): _resolve_org_project_ids가 이제 role 체크보다 먼저 실행돼(grant
+    # 대상 전체를 role 검증 대상으로 삼기 위함) org 프로젝트 목록 조회를 먼저 만족시켜야 한다.
+    single_project_id = uuid.uuid4()
+    mock_result = MagicMock()
+    mock_result.all.return_value = [(single_project_id,)]
+    session.execute = AsyncMock(return_value=mock_result)
 
     with patch("app.routers.team_members._resolve_actor", new=AsyncMock(return_value=actor)), patch(
         "app.services.project_auth.has_project_role", new=AsyncMock(return_value=False)
@@ -110,3 +116,5 @@ async def test_org_agent_create_agent_no_admin_403():
     assert ei.value.status_code == 403
     hpr.assert_awaited_once()
     assert hpr.await_args.kwargs.get("min_role") == "admin"
+    # O 회귀 확認: grant 대상(single_project_id) 기준으로 검증됐지 actor.project_id가 아니어야 함.
+    assert hpr.await_args.args[2] == single_project_id


### PR DESCRIPTION
## Summary
- CRITICAL(E-SECURITY SEC-S8 story `83ea3d6a`, finding O, 까심이 L QA 중 실HTTP 2단계로 발견): `create_org_agent`의 agent-actor 인가 체크가 `has_project_role(actor.id, actor.project_id)`로 caller agent의 **anchor project 하나만** 검사했음. 실제 grant 대상은 `body.project_ids`(`scope_mode='projects'`) 또는 org 전체(`scope_mode='org'`)인데 검증 대상과 grant 대상이 불일치 — P1에서만 admin인 에이전트가 P2(무권한 project)나 org 전체 스코프로 새 admin 에이전트+API키를 찍어낼 수 있었음(PR#1557부터 존재하던 갭).
- Fix: `_resolve_org_project_ids`로 실제 grant 대상 `project_ids`를 먼저 해소한 뒤, agent 분기에서 **project_ids 전원**에 대해 `has_project_role(min_role="admin")`을 요구 — 하나라도 admin이 아니면 전체 요청 차단. human/미해소 분기(L 자매 갭, 이미 별도 PR #2019로 봉쇄됨)는 원래 로직 그대로 무회귀.

## Test plan
- [x] realdb 3건: P1 admin 에이전트가 P1로 정상 생성(201)·P2로 시도 시 차단(403)·`scope_mode='org'`(P2 포함 전체) 시도 시 차단(403)
- [x] 기존 mock 회귀 수정(`test_project_role_s4_can_manage.py::test_org_agent_create_agent_no_admin_403` — role 체크 순서 변경 반영 + grant 대상 기준 검증 확인 assertion 추가)
- [x] `test_org_agent_create.py`/`test_e_security_sec_s8_l_create_org_agent_realdb.py`/`test_e_mcp_opt_s3_hosted_transport.py` 무변경 통과(29건) — human 분기·기존 시나리오 무회귀
- [x] 전체 스위트(`-m "not destructive_schema"`) 3491 passed, baseline 7건(무관) 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)