### PR TITLE
test(canvas): E-CANVAS C3 미테스트 순수 컴포넌트 3종 추가 커버리지

### DIFF
--- a/apps/web/src/components/canvas/component-palette.test.tsx
+++ b/apps/web/src/components/canvas/component-palette.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { ComponentPalette } from './component-palette';
+import { PALETTE_TYPES } from '@/services/canvas-nodes';
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+describe('ComponentPalette (C3 §2 — 부품 팔레트, 클릭 추가 MVP)', () => {
+  it('renders one button per palette type', () => {
+    const markup = renderToStaticMarkup(wrap(<ComponentPalette onAdd={vi.fn()} />));
+    for (const type of PALETTE_TYPES) expect(markup).toContain(`>${type}<`);
+  });
+
+  it('disables every button when disabled=true (e.g. no container selected to add into)', () => {
+    const markup = renderToStaticMarkup(wrap(<ComponentPalette onAdd={vi.fn()} disabled />));
+    expect(markup).toContain('disabled=""');
+  });
+
+  it('leaves buttons enabled by default', () => {
+    const markup = renderToStaticMarkup(wrap(<ComponentPalette onAdd={vi.fn()} />));
+    expect(markup).not.toContain('disabled=""');
+  });
+});

--- a/apps/web/src/components/canvas/description-pane.test.tsx
+++ b/apps/web/src/components/canvas/description-pane.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { DescriptionPane } from './description-pane';
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+describe('DescriptionPane (C2 §4 — 요소별 "보이는 PRD", 읽기 전용·낙인 문구 금지)', () => {
+  it('renders the element label and description together when both are present', () => {
+    const markup = renderToStaticMarkup(wrap(<DescriptionPane description="에러 시 재시도 유도" elementLabel="다시 결제하기 버튼" />));
+    expect(markup).toContain('다시 결제하기 버튼');
+    expect(markup).toContain('에러 시 재시도 유도');
+  });
+
+  it('renders the description alone (no stray separator) when elementLabel is omitted', () => {
+    const markup = renderToStaticMarkup(wrap(<DescriptionPane description="에러 시 재시도 유도" />));
+    expect(markup).toContain('에러 시 재시도 유도');
+    expect(markup).not.toContain('·');
+  });
+
+  it('renders a neutral empty state (not a prompt/nag) when there is no description', () => {
+    const markup = renderToStaticMarkup(wrap(<DescriptionPane description={null} />));
+    expect(markup).not.toContain('에러 시 재시도 유도');
+  });
+});

--- a/apps/web/src/components/canvas/edit-canvas.test.tsx
+++ b/apps/web/src/components/canvas/edit-canvas.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { EditCanvas } from './edit-canvas';
+import type { ResolvedNode } from '@/services/canvas-nodes';
+
+describe('EditCanvas (C3 §2 — 클릭 선택만, 중첩 트리 재귀 렌더)', () => {
+  it('renders nested children indented under their parent', () => {
+    const tree: ResolvedNode[] = [
+      {
+        id: 'root', type: 'Container', props: {}, parent_id: null, sort_order: 0,
+        children: [
+          { id: 'child1', type: 'Text', props: { text: '안내 문구' }, parent_id: 'root', sort_order: 0, children: [] },
+        ],
+      },
+    ];
+    const markup = renderToStaticMarkup(<EditCanvas tree={tree} selectedId={null} onSelect={vi.fn()} />);
+    expect(markup).toContain('Container');
+    expect(markup).toContain('Text');
+    expect(markup).toContain('안내 문구');
+  });
+
+  it('falls back to the node type as the label when props.text is missing', () => {
+    const tree: ResolvedNode[] = [{ id: 'n1', type: 'Card', props: {}, parent_id: null, sort_order: 0, children: [] }];
+    const markup = renderToStaticMarkup(<EditCanvas tree={tree} selectedId={null} onSelect={vi.fn()} />);
+    expect(markup).toContain('Card');
+  });
+
+  it('applies the selected ring style only to the node matching selectedId', () => {
+    const tree: ResolvedNode[] = [
+      { id: 'n1', type: 'Card', props: {}, parent_id: null, sort_order: 0, children: [] },
+      { id: 'n2', type: 'Button', props: {}, parent_id: null, sort_order: 1, children: [] },
+    ];
+    const markup = renderToStaticMarkup(<EditCanvas tree={tree} selectedId="n2" onSelect={vi.fn()} />);
+    const buttons = markup.split('<button').slice(1);
+    expect(buttons[0]).not.toContain('ring-primary/40');
+    expect(buttons[1]).toContain('ring-primary/40');
+  });
+});


### PR DESCRIPTION
## 배경

#2016에서 못 채운 나머지 미테스트 순수 컴포넌트 3종. 동작 변경 0 — 테스트만 추가.

## 대상
- `edit-canvas.tsx` — 중첩 트리 재귀 렌더(children indent)·선택 상태에 따른 ring 스타일 전환
- `component-palette.tsx` — PALETTE_TYPES 전종 렌더·disabled 전파(컨테이너 미선택 시 전 버튼 비활성)
- `description-pane.tsx` — 요소 라벨+스펙 조합/단독 렌더·낙인 문구 없는 중립 빈 상태

`export-dialog.tsx`는 Radix `Dialog` 포탈 기반이라 SSR 스냅샷 컨벤션과 안 맞아 기존처럼 보류(#2016 때와 동일 판단).

## Test plan
- [x] `pnpm vitest run src/components/canvas/` — 13 files, 45 tests pass
- [x] `pnpm vitest run` (전체) — 185 files, 1065 pass
- [x] `pnpm build` — exit 0
- [x] `pnpm lint` — 0 errors