### PR TITLE
feat(canvas): E-CANVAS C2-S6 요소/좌표 앵커 코멘트(스레드·resolve) + description pane

### DIFF
--- a/backend/alembic/versions/0172_artifact_comments.py
+++ b/backend/alembic/versions/0172_artifact_comments.py
@@ -1,0 +1,64 @@
+"""E-CANVAS C2-S6(story 0edca31e): artifact_comments(요소/좌표 앵커 핀·스레드·resolve) +
+artifact_nodes.description(description pane — 요소별 스펙, 에이전트 MCP 읽기).
+
+Revision ID: 0172
+Revises: 0171
+Create Date: 2026-07-10
+
+순수 additive — 신규 테이블 1개 + 기존 테이블 nullable 컬럼 1개 추가. 기존 스키마 무회귀.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0172"
+down_revision = "0171"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("artifact_nodes", sa.Column("description", sa.Text(), nullable=True))
+
+    op.create_table(
+        "artifact_comments",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "artifact_id", postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("visual_artifacts.id", ondelete="CASCADE"), nullable=False,
+        ),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), nullable=False),
+        # 앵커: node_id(요소 단위) 또는 anchor_x/anchor_y(자유 좌표 핀) — 둘 중 하나(또는 둘 다
+        # None=artifact 전체 코멘트). 삭제된 node를 참조하면 코멘트가 orphan되지 않도록 SET NULL
+        # (좌표 핀으로 폴백 표시 가능·코멘트 자체는 보존).
+        sa.Column(
+            "node_id", postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("artifact_nodes.id", ondelete="SET NULL"), nullable=True,
+        ),
+        sa.Column("anchor_x", sa.Float(), nullable=True),
+        sa.Column("anchor_y", sa.Float(), nullable=True),
+        sa.Column("content", sa.Text(), nullable=False),
+        # 스레드: 최상위 코멘트는 NULL, 답글은 루트(또는 부모) 코멘트를 가리킴. 스레드 루트 삭제는
+        # 이 스코프에서 미제공(삭제 API 없음)이라 CASCADE 대신 SET NULL로 방어적 설계(향후 삭제
+        # 추가 시 답글이 orphan top-level로 남되 데이터 유실은 없음).
+        sa.Column(
+            "parent_id", postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("artifact_comments.id", ondelete="SET NULL"), nullable=True,
+        ),
+        sa.Column("resolved", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("resolved_by", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("resolved_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_by", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index("ix_artifact_comments_artifact_id", "artifact_comments", ["artifact_id"])
+    op.create_index("ix_artifact_comments_node_id", "artifact_comments", ["node_id"])
+    op.create_index("ix_artifact_comments_parent_id", "artifact_comments", ["parent_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("artifact_comments")
+    op.drop_column("artifact_nodes", "description")

--- a/backend/app/models/visual_artifact.py
+++ b/backend/app/models/visual_artifact.py
@@ -74,4 +74,38 @@ class ArtifactNode(Base):
     props: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
     parent_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     sort_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # E-CANVAS C2-S6(story 0edca31e): description pane — 요소별 스펙 서술(전신 spec_description
+    # 유산·"보이는 PRD"). 에이전트가 MCP로 읽어 요소 단위 계약으로 소비.
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+
+class ArtifactComment(Base):
+    """E-CANVAS C2-S6(story 0edca31e): 요소/좌표 앵커 코멘트(Figma식 핀·스레드·resolve).
+
+    스토리 코멘트(StoryComment)와 공통 프리미티브(content/created_by/created_at + C0 이벤트
+    전파)를 공유하되, artifact 특유의 앵커(node_id 요소단위 또는 anchor_x/y 좌표핀)·스레드
+    (parent_id)·resolve 상태를 추가로 가진다.
+    """
+    __tablename__ = "artifact_comments"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    artifact_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("visual_artifacts.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    node_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("artifact_nodes.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    anchor_x: Mapped[float | None] = mapped_column(nullable=True)
+    anchor_y: Mapped[float | None] = mapped_column(nullable=True)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    parent_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("artifact_comments.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    resolved: Mapped[bool] = mapped_column(nullable=False, default=False)
+    resolved_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -9,14 +9,18 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
-from app.models.visual_artifact import ArtifactNode, ArtifactVersion, VisualArtifact
+from app.models.visual_artifact import ArtifactComment, ArtifactNode, ArtifactVersion, VisualArtifact
 from app.schemas.visual_artifact import (
+    ArtifactCommentResponse,
     ArtifactNodeOut,
     ArtifactVersionSummary,
+    CreateArtifactCommentRequest,
     CreateArtifactRequest,
     VisualArtifactDetail,
     VisualArtifactSummary,
 )
+from app.services.member_resolver import filter_org_member_ids
+from app.services.notification_dispatch import dispatch_notification
 from app.services.project_auth import assert_target_in_caller_org
 
 router = APIRouter(prefix="/api/v2/visual-artifacts", tags=["visual-artifacts"])
@@ -93,6 +97,7 @@ async def create_artifact(
         node = ArtifactNode(
             id=n.id or uuid.uuid4(), artifact_id=artifact.id, version_id=version.id,
             type=n.type, props=n.props, parent_id=n.parent_id, sort_order=n.sort_order,
+            description=n.description,
         )
         session.add(node)
         nodes.append(node)
@@ -252,3 +257,118 @@ async def delete_artifact(
     artifact.deleted_at = datetime.now(timezone.utc)
     await session.flush()
     return _ok({"ok": True, "id": str(id)})
+
+
+# ─── Comments (E-CANVAS C2-S6, story 0edca31e) ────────────────────────────────
+# 스토리 코멘트(stories.py add_comment/list_comments)와 공통 프리미티브(content/created_by/
+# created_at + C0 이벤트 전파) 계승. artifact 특유의 앵커(node_id 또는 anchor_x/y)·스레드
+# (parent_id)·resolve 추가.
+
+
+@router.get("/{id}/comments")
+async def list_artifact_comments(
+    id: uuid.UUID,
+    limit: int = Query(default=50, le=200),
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id or not project_id:
+        return _err("FORBIDDEN", "org_id/project_id required", 403)
+    artifact = await _get_artifact_or_404(session, org_id, project_id, id)
+    if artifact is None:
+        return _err("NOT_FOUND", "Artifact not found", 404)
+    rows = (await session.execute(
+        select(ArtifactComment).where(ArtifactComment.artifact_id == id)
+        .order_by(ArtifactComment.created_at.asc()).limit(limit)
+    )).scalars().all()
+    return _ok([ArtifactCommentResponse.model_validate(r).model_dump(mode="json") for r in rows])
+
+
+@router.post("/{id}/comments", status_code=201)
+async def add_artifact_comment(
+    id: uuid.UUID,
+    body: CreateArtifactCommentRequest,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id or not project_id:
+        return _err("FORBIDDEN", "org_id/project_id required", 403)
+    artifact = await _get_artifact_or_404(session, org_id, project_id, id)
+    if artifact is None:
+        return _err("NOT_FOUND", "Artifact not found", 404)
+
+    if body.node_id is not None:
+        node_owner = (await session.execute(
+            select(ArtifactNode.artifact_id).where(ArtifactNode.id == body.node_id)
+        )).scalar_one_or_none()
+        if node_owner != artifact.id:
+            return _err("NOT_FOUND", "Node not found on this artifact", 404)
+
+    if body.parent_id is not None:
+        parent_owner = (await session.execute(
+            select(ArtifactComment.artifact_id).where(ArtifactComment.id == body.parent_id)
+        )).scalar_one_or_none()
+        if parent_owner != artifact.id:
+            return _err("NOT_FOUND", "Parent comment not found on this artifact", 404)
+
+    created_by = uuid.UUID(auth.user_id)
+    comment = ArtifactComment(
+        id=uuid.uuid4(), artifact_id=artifact.id, org_id=org_id, project_id=project_id,
+        node_id=body.node_id, anchor_x=body.anchor_x, anchor_y=body.anchor_y,
+        content=body.content, parent_id=body.parent_id, created_by=created_by,
+    )
+    session.add(comment)
+    await session.flush()
+    await session.refresh(comment)
+
+    # E-CANVAS C0-S1 §F4 계승(stories.py add_comment와 동형): comment.created 이벤트 전파.
+    # 수신자 = artifact 생성자 + mentioned_ids(cross-org 필터) - 작성자 본인.
+    valid_mentioned_ids = await filter_org_member_ids(set(body.mentioned_ids), org_id, session)
+    target_member_ids = list(
+        (valid_mentioned_ids | ({artifact.created_by} if artifact.created_by else set())) - {created_by}
+    )
+    if target_member_ids:
+        await dispatch_notification(
+            session,
+            org_id=org_id,
+            event_type="comment.created",
+            target_member_ids=target_member_ids,
+            title=f"새 코멘트: {artifact.title}",
+            body=body.content[:200],
+            reference_type="visual_artifact",
+            reference_id=artifact.id,
+            source_project_id=project_id,
+        )
+
+    return _ok(ArtifactCommentResponse.model_validate(comment).model_dump(mode="json"), status=201)
+
+
+@router.post("/{id}/comments/{comment_id}/resolve")
+async def resolve_artifact_comment(
+    id: uuid.UUID,
+    comment_id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id or not project_id:
+        return _err("FORBIDDEN", "org_id/project_id required", 403)
+    artifact = await _get_artifact_or_404(session, org_id, project_id, id)
+    if artifact is None:
+        return _err("NOT_FOUND", "Artifact not found", 404)
+    comment = (await session.execute(
+        select(ArtifactComment).where(
+            ArtifactComment.id == comment_id, ArtifactComment.artifact_id == artifact.id,
+        )
+    )).scalar_one_or_none()
+    if comment is None:
+        return _err("NOT_FOUND", "Comment not found", 404)
+    from datetime import datetime, timezone
+    comment.resolved = True
+    comment.resolved_by = uuid.UUID(auth.user_id)
+    comment.resolved_at = datetime.now(timezone.utc)
+    await session.flush()
+    await session.refresh(comment)
+    return _ok(ArtifactCommentResponse.model_validate(comment).model_dump(mode="json"))

--- a/backend/app/schemas/visual_artifact.py
+++ b/backend/app/schemas/visual_artifact.py
@@ -13,6 +13,8 @@ class ArtifactNodeIn(BaseModel):
     props: dict[str, Any] = {}
     parent_id: uuid.UUID | None = None
     sort_order: int = 0
+    # E-CANVAS C2-S6: description pane(요소별 스펙 서술). 선택제(미지정=None).
+    description: str | None = None
 
 
 class ArtifactNodeOut(BaseModel):
@@ -22,6 +24,7 @@ class ArtifactNodeOut(BaseModel):
     props: dict[str, Any]
     parent_id: uuid.UUID | None = None
     sort_order: int
+    description: str | None = None
 
 
 class CreateArtifactRequest(BaseModel):
@@ -82,3 +85,36 @@ class VisualArtifactDetail(BaseModel):
     version_number: int
     version_summary: str | None = None
     nodes: list[ArtifactNodeOut]
+
+
+class CreateArtifactCommentRequest(BaseModel):
+    content: str
+    node_id: uuid.UUID | None = None
+    anchor_x: float | None = None
+    anchor_y: float | None = None
+    parent_id: uuid.UUID | None = None
+    mentioned_ids: list[uuid.UUID] = []
+
+    @field_validator("content")
+    @classmethod
+    def _content_non_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("content must not be empty")
+        return v
+
+
+class ArtifactCommentResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    artifact_id: uuid.UUID
+    node_id: uuid.UUID | None = None
+    anchor_x: float | None = None
+    anchor_y: float | None = None
+    content: str
+    parent_id: uuid.UUID | None = None
+    resolved: bool
+    resolved_by: uuid.UUID | None = None
+    resolved_at: datetime | None = None
+    created_by: uuid.UUID
+    created_at: datetime

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -65,9 +65,11 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     "sprintable_add_evidence",
     # E-CANVAS C1-S3(story 8bace49e): create_artifact/get_artifact — story/epic/doc 中 어디에도
     # (또는 아무데도) 붙을 수 있는 시각 산출물 생성/조회. add_evidence와 동형(단일 도메인 그룹에
-    # 묶기 애매한 cross-cutting 자기생성 유틸) — 향후 C2/C3가 관련 도구를 늘리면 그때 전용
-    # "canvas" 그룹 신설을 고려(지금은 2개뿐이라 조기 그룹화 안 함).
+    # 묶기 애매한 cross-cutting 자기생성 유틸). C2-S6(story 0edca31e)에서 코멘트 2종 추가 — 4개로
+    # 늘었으나 여전히 story/epic/doc 무관 cross-cutting이라 always-allow 유지(C3/C4가 더 늘리면
+    # 그때 전용 "canvas" 그룹 신설 고려).
     "sprintable_create_artifact", "sprintable_get_artifact",
+    "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
 })
 
 # scope 토큰: 그룹명 외에 read/write(레거시·전체 비파괴 의미), admin/destructive(파괴적 허용)
@@ -287,8 +289,9 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_link_gate_to_task",
     # evidence (E-VERIFY V0-S1)
     "sprintable_add_evidence",
-    # visual artifacts (E-CANVAS C1-S3)
+    # visual artifacts (E-CANVAS C1-S3 + C2-S6 코멘트)
     "sprintable_create_artifact", "sprintable_get_artifact",
+    "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
 )
 
 # picker 표시 순서(비파괴 먼저). order 필드 힌트 + 배열 순서 둘 다 이 순서.

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -29,7 +29,10 @@ from .schemas import SprintableInput
 from .toolset import is_tool_allowed
 from .tools.a2a import LinkGateToTaskInput, link_gate_to_task
 from .tools.evidence import AddEvidenceInput, add_evidence
-from .tools.visual_artifacts import CreateArtifactInput, GetArtifactInput, create_artifact, get_artifact
+from .tools.visual_artifacts import (
+    AddArtifactCommentInput, CreateArtifactInput, GetArtifactInput, ListArtifactCommentsInput,
+    add_artifact_comment, create_artifact, get_artifact, list_artifact_comments,
+)
 from .tools.agent_runs import (
     EmitEventInput, PollEventsInput, UpdateRunStatusInput,
     emit_event, poll_events, update_run_status,
@@ -490,7 +493,7 @@ _TOOL_DEFS: list[tuple] = [
      "done을 스스로 증명하는 자기 서명 첨부(PR·배포·지표·발행물 링크 등) — story/task에 evidence"
      " 남김. 선택제(첨부 안 해도 무불이익).",
      AddEvidenceInput, add_evidence),
-    # Visual artifacts (2) — E-CANVAS C1-S3
+    # Visual artifacts (4) — E-CANVAS C1-S3 + C2-S6(코멘트)
     ("sprintable_create_artifact",
      "시각 산출물 생성(에이전트 생성 입구) — 트리(nodes[])로 구조화. 임포트된 raw HTML/이미지는"
      " type=\"html_blob\" 노드 하나로 감싸도 됨.",
@@ -498,6 +501,12 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_get_artifact",
      "시각 산출물 단건 조회(latest 버전 + nodes).",
      GetArtifactInput, get_artifact),
+    ("sprintable_list_artifact_comments",
+     "artifact 코멘트 스레드 조회(요소/좌표 앵커·resolve 상태) — 휴먼 피드백 왕복 입구.",
+     ListArtifactCommentsInput, list_artifact_comments),
+    ("sprintable_add_artifact_comment",
+     "artifact에 코멘트 추가(요소/좌표 앵커·답글 가능) — 대상자에게 이벤트 전파.",
+     AddArtifactCommentInput, add_artifact_comment),
     # Chat (3)
     ("sprintable_send_chat_message",
      "conversation thread에 채팅 메시지 발송.",

--- a/backend/sprintable_mcp/tools/visual_artifacts.py
+++ b/backend/sprintable_mcp/tools/visual_artifacts.py
@@ -1,4 +1,5 @@
-"""시각 산출물(visual_artifact) MCP 도구(2개) — E-CANVAS C1-S3(story 8bace49e)."""
+"""시각 산출물(visual_artifact) MCP 도구(4개) — E-CANVAS C1-S3(story 8bace49e)+
+C2-S6(story 0edca31e, 코멘트 왕복)."""
 from __future__ import annotations
 
 from mcp.types import TextContent
@@ -13,6 +14,7 @@ class ArtifactNodeInput(SprintableInput):
     props: dict | None = None
     parent_id: str | None = None
     sort_order: int | None = None
+    description: str | None = None  # C2-S6: description pane(요소별 스펙)
 
 
 class CreateArtifactInput(SprintableInput):
@@ -27,6 +29,20 @@ class CreateArtifactInput(SprintableInput):
 
 class GetArtifactInput(SprintableInput):
     artifact_id: str
+
+
+class ListArtifactCommentsInput(SprintableInput):
+    artifact_id: str
+
+
+class AddArtifactCommentInput(SprintableInput):
+    artifact_id: str
+    content: str
+    node_id: str | None = None  # 요소 앵커(특정 노드에 코멘트)
+    anchor_x: float | None = None  # 좌표 앵커(자유 핀 — node_id 대신 또는 병행)
+    anchor_y: float | None = None
+    parent_id: str | None = None  # 답글이면 부모 코멘트 id
+    mentioned_ids: list[str] | None = None
 
 
 async def create_artifact(args: CreateArtifactInput) -> list[TextContent]:
@@ -56,6 +72,37 @@ async def get_artifact(args: GetArtifactInput) -> list[TextContent]:
     """시각 산출물 단건 조회(latest 버전 + nodes)."""
     try:
         result = await client.get(f"/api/v2/visual-artifacts/{args.artifact_id}")
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def list_artifact_comments(args: ListArtifactCommentsInput) -> list[TextContent]:
+    """artifact 코멘트 스레드 조회(요소/좌표 앵커·resolve 상태 포함) — 휴먼 딸깍 피드백을
+    에이전트가 읽고 반응하는 왕복 입구."""
+    try:
+        result = await client.get(f"/api/v2/visual-artifacts/{args.artifact_id}/comments")
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def add_artifact_comment(args: AddArtifactCommentInput) -> list[TextContent]:
+    """artifact에 코멘트 추가 — node_id(요소 앵커) 또는 anchor_x/anchor_y(좌표 핀)로 위치 지정,
+    parent_id로 답글. 대상자에게 comment.created 이벤트 전파(C0)."""
+    try:
+        body: dict = {"content": args.content}
+        if args.node_id:
+            body["node_id"] = args.node_id
+        if args.anchor_x is not None:
+            body["anchor_x"] = args.anchor_x
+        if args.anchor_y is not None:
+            body["anchor_y"] = args.anchor_y
+        if args.parent_id:
+            body["parent_id"] = args.parent_id
+        if args.mentioned_ids:
+            body["mentioned_ids"] = args.mentioned_ids
+        result = await client.post(f"/api/v2/visual-artifacts/{args.artifact_id}/comments", json=body)
         return ok(result)
     except Exception as exc:
         return err(str(exc))

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -1,8 +1,9 @@
-"""S3-6: 시스템 콜 계약 검증 — 95개 도구 등록 + 스키마 무결성 (Phase 3 완료).
+"""S3-6: 시스템 콜 계약 검증 — 97개 도구 등록 + 스키마 무결성 (Phase 3 완료).
 
 E-SECURITY SEC-S1(확장): delete_story/task/epic/doc 4종 제거(에이전트 hard-delete 차단) —
 98개 → story만 제거해 97 → task/epic/doc 3종 추가 제거해 94. E-CANVAS C1-S3: create_artifact/
-get_artifact 2종 추가 — 94 → 96. E-SECURITY SEC-S8(확장): delete_sprint 제거 — 96 → 95."""
+get_artifact 2종 추가 — 94 → 96. E-SECURITY SEC-S8(확장): delete_sprint 제거 — 96 → 95.
+E-CANVAS C2-S6: list_artifact_comments/add_artifact_comment 2종 추가 — 95 → 97."""
 from __future__ import annotations
 
 import os
@@ -83,15 +84,16 @@ EXPECTED_TOOLS = {
     "sprintable_link_gate_to_task",
     # evidence (1) — E-VERIFY V0-S1
     "sprintable_add_evidence",
-    # visual artifacts (2) — E-CANVAS C1-S3
+    # visual artifacts (4) — E-CANVAS C1-S3 + C2-S6(코멘트)
     "sprintable_create_artifact", "sprintable_get_artifact",
+    "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
     # smoke
     "ping",
 }
 
 
 def test_total_tool_count():
-    assert len(_TOOLS) == 95
+    assert len(_TOOLS) == 97
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_e_canvas_c2_s6_artifact_comments_realdb.py
+++ b/backend/tests/test_e_canvas_c2_s6_artifact_comments_realdb.py
@@ -1,0 +1,430 @@
+"""E-CANVAS C2-S6(story 0edca31e): artifact 코멘트(요소/좌표 앵커·스레드·resolve) + description
+pane 실증. 스토리 코멘트와 공통 프리미티브(content/created_by/created_at + C0 이벤트 전파)
+계승 확認·MCP list/add 왕복(AC4)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project) + artifact(1 node, description 포함) — created_by는 실 agent member(project
+    grant 보유)라 dispatch_notification의 team_members 조회가 실제로 매치돼 이벤트 전파를
+    실증할 수 있다(랜덤 UUID는 team_members에 없어 조용히 스킵됨)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+    from app.models.visual_artifact import ArtifactNode, ArtifactVersion, VisualArtifact
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    creator = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="artifact-creator", is_active=True)
+    session.add(creator)
+    await session.commit()
+    creator_id = creator.id
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=creator_id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    artifact = VisualArtifact(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Artifact",
+        source="created", latest_version_number=1, created_by=creator_id,
+    )
+    session.add(artifact)
+    await session.commit()
+
+    version = ArtifactVersion(id=uuid.uuid4(), artifact_id=artifact.id, version_number=1, created_by=creator_id)
+    session.add(version)
+    await session.commit()
+
+    node = ArtifactNode(
+        id=uuid.uuid4(), artifact_id=artifact.id, version_id=version.id,
+        type="text", props={"content": "hello"}, sort_order=0,
+        description="이 요소는 헤더 카피 슬롯입니다.",
+    )
+    session.add(node)
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "artifact_id": artifact.id,
+        "node_id": node.id, "creator_id": creator_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, project_id, user_id=None):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id or uuid.uuid4()), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_node_description_roundtrip():
+    """회귀 0: get_artifact가 node.description을 그대로 반환(description pane 데이터)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/visual-artifacts/{seeded['artifact_id']}")
+            assert resp.status_code == 200
+            node = resp.json()["data"]["nodes"][0]
+            assert node["description"] == "이 요소는 헤더 카피 슬롯입니다."
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_add_comment_element_anchor_and_list():
+    """요소 앵커(node_id) 코멘트 생성 → list에서 조회."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/comments",
+                json={"content": "이 헤더 좀 더 크게", "node_id": str(seeded["node_id"])},
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()["data"]
+            assert body["node_id"] == str(seeded["node_id"])
+            assert body["resolved"] is False
+
+            list_resp = await client.get(f"/api/v2/visual-artifacts/{seeded['artifact_id']}/comments")
+            assert list_resp.status_code == 200
+            items = list_resp.json()["data"]
+            assert len(items) == 1
+            assert items[0]["content"] == "이 헤더 좀 더 크게"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_add_comment_coordinate_anchor():
+    """좌표 앵커(anchor_x/anchor_y) 코멘트 — node_id 없이 자유 핀."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/comments",
+                json={"content": "여기 여백 좁아요", "anchor_x": 120.5, "anchor_y": 340.2},
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()["data"]
+            assert body["node_id"] is None
+            assert body["anchor_x"] == 120.5
+            assert body["anchor_y"] == 340.2
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_threaded_reply():
+    """스레드: parent_id로 답글 생성."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            root_resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/comments",
+                json={"content": "루트 코멘트"},
+            )
+            root_id = root_resp.json()["data"]["id"]
+
+            reply_resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/comments",
+                json={"content": "답글입니다", "parent_id": root_id},
+            )
+            assert reply_resp.status_code == 201, reply_resp.text
+            assert reply_resp.json()["data"]["parent_id"] == root_id
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reply_to_comment_on_other_artifact_blocked():
+    """crux: parent_id가 다른 artifact 소속 코멘트를 가리키면 404(cross-artifact 스레드 위조 차단).
+    같은 org/project 내 서로 다른 두 artifact로 구성 — org 경계 문제(Q)와는 다른 축."""
+    from app.models.visual_artifact import ArtifactVersion, VisualArtifact
+
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            other_artifact = VisualArtifact(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+                title="Other Artifact", source="created", latest_version_number=1,
+                created_by=seeded["creator_id"],
+            )
+            s.add(other_artifact)
+            await s.commit()
+            s.add(ArtifactVersion(
+                id=uuid.uuid4(), artifact_id=other_artifact.id, version_number=1,
+                created_by=seeded["creator_id"],
+            ))
+            await s.commit()
+            other_artifact_id = other_artifact.id
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            other_root = await client.post(
+                f"/api/v2/visual-artifacts/{other_artifact_id}/comments",
+                json={"content": "다른 artifact의 코멘트"},
+            )
+            other_root_id = other_root.json()["data"]["id"]
+
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/comments",
+                json={"content": "위조 스레드 시도", "parent_id": other_root_id},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_resolve_comment():
+    """resolve → resolved=True + resolved_by/resolved_at 기록."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        resolver_id = uuid.uuid4()
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], user_id=resolver_id)
+        client = _client_for(app)
+        try:
+            create_resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/comments",
+                json={"content": "이거 고쳐주세요"},
+            )
+            comment_id = create_resp.json()["data"]["id"]
+
+            resolve_resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/comments/{comment_id}/resolve",
+            )
+            assert resolve_resp.status_code == 200, resolve_resp.text
+            body = resolve_resp.json()["data"]
+            assert body["resolved"] is True
+            assert body["resolved_by"] == str(resolver_id)
+            assert body["resolved_at"] is not None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_comment_event_propagation_to_creator():
+    """C0 §F4: 코멘트 작성 시 artifact 생성자에게 comment.created 이벤트 전파(작성자 자신 제외)."""
+    from sqlalchemy import select
+
+    from app.main import app
+    from app.models.event import Event
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        commenter_id = uuid.uuid4()
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], user_id=commenter_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/comments",
+                json={"content": "확認 부탁"},
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Event).where(
+                    Event.org_id == seeded["org_id"],
+                    Event.event_type == "dispatched",
+                )
+            )).scalars().all()
+            # dispatch_notification의 에이전트 경로가 Event INSERT(payload.event_type=comment.created)
+            payloads = [r.payload for r in rows]
+            assert any(p.get("event_type") == "comment.created" for p in payloads if isinstance(p, dict)), (
+                f"comment.created 이벤트 미전파: {payloads}"
+            )
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mcp_add_and_list_comments_roundtrip():
+    """AC4 실증: MCP sprintable_add_artifact_comment → sprintable_list_artifact_comments 왕복."""
+    import json as _json
+    import os as _os
+
+    import httpx
+
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+
+        _os.environ.setdefault("SPRINTABLE_API_URL", "http://test")
+        _os.environ.setdefault("AGENT_API_KEY", "sk_test")
+
+        from sprintable_mcp.tools.visual_artifacts import (
+            AddArtifactCommentInput, ListArtifactCommentsInput, add_artifact_comment, list_artifact_comments,
+        )
+        from sprintable_mcp import api_client as api_client_mod
+
+        transport = httpx.ASGITransport(app=app)
+        real_client = api_client_mod.client
+        test_http_client = httpx.AsyncClient(transport=transport, base_url="http://test")
+
+        async def _post(path, **kwargs):
+            r = await test_http_client.post(path, **kwargs)
+            r.raise_for_status()
+            return r.json()["data"]
+
+        async def _get(path, **kwargs):
+            r = await test_http_client.get(path, **kwargs)
+            r.raise_for_status()
+            return r.json()["data"]
+
+        orig_post, orig_get = real_client.post, real_client.get
+        real_client.post = _post
+        real_client.get = _get
+        try:
+            add_result = await add_artifact_comment(AddArtifactCommentInput(
+                artifact_id=str(seeded["artifact_id"]),
+                content="MCP에서 남긴 코멘트",
+                node_id=str(seeded["node_id"]),
+            ))
+            added = _json.loads(add_result[0].text)
+            assert added["content"] == "MCP에서 남긴 코멘트"
+
+            list_result = await list_artifact_comments(ListArtifactCommentsInput(
+                artifact_id=str(seeded["artifact_id"]),
+            ))
+            listed = _json.loads(list_result[0].text)
+            assert len(listed) == 1
+            assert listed[0]["content"] == "MCP에서 남긴 코멘트"
+        finally:
+            real_client.post = orig_post
+            real_client.get = orig_get
+            await test_http_client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
E-CANVAS C2-S6(story `0edca31e`) — Blueprint §F3/C2 BE. 코멘트=스토리 코멘트(`StoryComment`)와 공통 프리미티브(content/created_by/created_at + C0 이벤트 전파)를 계승하되, artifact 특유의 앵커(node_id 요소단위 또는 anchor_x/y 좌표핀)·스레드(parent_id)·resolve 상태를 추가. description pane=전신 spec_description 유산("보이는 PRD") — `ArtifactNode`에 `description` 컬럼 추가, 에이전트가 MCP로 읽는 요소 단위 계약.

- migration 0172(additive): `artifact_comments` 테이블 신설 + `artifact_nodes.description` 컬럼 추가.
- `app/models/visual_artifact.py`: `ArtifactComment` 모델.
- `app/routers/visual_artifacts.py`: `GET/POST /{id}/comments`, `POST /{id}/comments/{comment_id}/resolve`. node_id/parent_id 모두 같은 artifact 소속인지 검증(cross-artifact 스레드 위조 차단). `comment.created` 이벤트는 `dispatch_notification` 재사용(대상=artifact 생성자+mentioned_ids, cross-org 필터, 작성자 본인 제외) — `stories.py add_comment`와 동형 패턴.
- MCP 도구 2종(`sprintable_list_artifact_comments`/`sprintable_add_artifact_comment`) — 휴먼 딸깍 피드백↔에이전트 반응 왕복 입구(AC4).

## Test plan
- [x] realdb 8건: 요소 앵커·좌표 앵커·스레드·cross-artifact 스레드 위조 차단·resolve·comment.created 이벤트 전파(실 agent 수신자)·MCP list/add 왕복·description 라운드트립
- [x] 기존 C1-S3/G/Q 테스트(`test_e_canvas_c1_s3_visual_artifact_realdb.py`, `test_e_security_sec_s8_q_visual_artifacts_individual_id_realdb.py`, `test_e_security_sec_s8_g_cross_project_access_realdb.py`) 16건 무변경 통과
- [x] MCP 계약 테스트(`tests/mcp/test_contract.py` 95→97, `test_toolset_catalog.py`, `test_e_mcp_s2_toolset.py`) 48건 통과
- [x] 전체 스위트(`-m "not destructive_schema"`) 3510 passed, baseline 7건(무관) 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)