### PR TITLE
feat(canvas): E-CANVAS C1-S5 F6 export(PNG signed-write-URL 3-step, HTML self-contained)

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 dist/
 build/
 .mypy_cache/
+.storage/

--- a/backend/alembic/versions/0173_artifact_exports.py
+++ b/backend/alembic/versions/0173_artifact_exports.py
@@ -1,0 +1,54 @@
+"""E-CANVAS C1-S5(story 1f365e33): artifact_exports — F6 export(PNG/HTML) 버전 귀속 기록.
+
+Revision ID: 0173
+Revises: 0172
+Create Date: 2026-07-10
+
+순수 additive — 신규 테이블 1개. 기존 스키마 무회귀. asset_id는 기존 assets 레지스트리(S1
+IStorageService 위 빌드) 재사용 — 별도 AssetLink 확장 없이 export 전용 귀속 테이블로 버전/포맷
+메타를 보관한다(crux: BE는 signed write URL 발급 + complete 시 head_object 검증 후 편입만,
+바이너리는 FE→GCS 직접 PUT).
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0173"
+down_revision = "0172"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "artifact_exports",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "artifact_id", postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("visual_artifacts.id", ondelete="CASCADE"), nullable=False,
+        ),
+        sa.Column(
+            "version_id", postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("artifact_versions.id", ondelete="CASCADE"), nullable=False,
+        ),
+        sa.Column("format", sa.Text(), nullable=False),
+        sa.Column(
+            "asset_id", postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("assets.id", ondelete="CASCADE"), nullable=False,
+        ),
+        sa.Column("created_by", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index("ix_artifact_exports_artifact_id", "artifact_exports", ["artifact_id"])
+    op.create_index("ix_artifact_exports_version_id", "artifact_exports", ["version_id"])
+    op.create_check_constraint(
+        "ck_artifact_exports_format",
+        "artifact_exports",
+        "format IN ('png','html')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("artifact_exports")

--- a/backend/app/models/visual_artifact.py
+++ b/backend/app/models/visual_artifact.py
@@ -109,3 +109,31 @@ class ArtifactComment(Base):
     resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+
+ARTIFACT_EXPORT_FORMATS = frozenset({"png", "html"})
+
+
+class ArtifactExport(Base):
+    """E-CANVAS C1-S5(story 1f365e33): F6 export(PNG/HTML) 버전 귀속 기록.
+
+    바이너리 자체는 여기 없음 — 기존 assets 레지스트리(S1 IStorageService)의 asset_id 참조만
+    보관(storage 좌표는 Asset.container/object_path가 SSOT). PNG는 FE가 캡처해 signed write URL로
+    GCS에 직접 PUT하고 BE는 head_object 검증 후 편입만(바이너리가 BE를 경유하지 않음). HTML은
+    BE가 nodes 트리를 직렬화해 즉시 생성(렌더 불요·client-trust 이슈 없음).
+    """
+    __tablename__ = "artifact_exports"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    artifact_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("visual_artifacts.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    version_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("artifact_versions.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    format: Mapped[str] = mapped_column(Text, nullable=False)
+    asset_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("assets.id", ondelete="CASCADE"), nullable=False
+    )
+    created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -9,13 +9,20 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
-from app.models.visual_artifact import ArtifactComment, ArtifactNode, ArtifactVersion, VisualArtifact
+from app.models.asset import Asset
+from app.models.visual_artifact import (
+    ArtifactComment, ArtifactExport, ArtifactNode, ArtifactVersion, VisualArtifact,
+)
 from app.schemas.visual_artifact import (
     ArtifactCommentResponse,
+    ArtifactExportResponse,
     ArtifactNodeOut,
     ArtifactVersionSummary,
+    CompleteExportRequest,
     CreateArtifactCommentRequest,
     CreateArtifactRequest,
+    ExportUploadUrlRequest,
+    ExportUploadUrlResponse,
     VisualArtifactDetail,
     VisualArtifactSummary,
 )
@@ -372,3 +379,293 @@ async def resolve_artifact_comment(
     await session.flush()
     await session.refresh(comment)
     return _ok(ArtifactCommentResponse.model_validate(comment).model_dump(mode="json"))
+
+
+# ─── Export (E-CANVAS C1-S5, story 1f365e33) ──────────────────────────────────
+# crux(오르테가 승인): PNG는 클라 캡처 — BE는 바이너리를 경유하지 않고 signed write URL만 발급,
+# FE가 GCS에 직접 PUT 후 complete로 편입 알림(head_object 실체 검증 — client-trust 금지 원칙
+# 계승). HTML은 렌더 불요라 BE가 즉시 생성+저장(client-trust 이슈 없음). asset_id는 유나 UX③
+# (공유 링크 1급)의 안정 참조 — 기존 attachments.authorize(asset_id=) 인프라 재사용.
+
+_EXPORT_TTL_MIN = 30
+
+
+def _export_container() -> str:
+    from app.services.asset_registry import DEFAULT_CONTAINER
+    return DEFAULT_CONTAINER
+
+
+def _export_object_path(org_id: uuid.UUID, project_id: uuid.UUID, artifact_id: uuid.UUID, ext: str) -> str:
+    """SEC 계열 스코프 원칙 계승(org/project/artifact 전 segment exact 바인딩) — cross-project
+    export asset 오염/IDOR 차단."""
+    return f"org/{org_id}/project/{project_id}/artifact/{artifact_id}/export/{uuid.uuid4()}.{ext}"
+
+
+def _export_path_in_scope(object_path: str, org_id: uuid.UUID, project_id: uuid.UUID, artifact_id: uuid.UUID) -> bool:
+    expected_prefix = f"org/{org_id}/project/{project_id}/artifact/{artifact_id}/export/"
+    return object_path.startswith(expected_prefix)
+
+
+async def _get_version_or_404(
+    session: AsyncSession, artifact_id: uuid.UUID, version_number: int
+) -> ArtifactVersion | None:
+    return (await session.execute(
+        select(ArtifactVersion).where(
+            ArtifactVersion.artifact_id == artifact_id, ArtifactVersion.version_number == version_number,
+        )
+    )).scalar_one_or_none()
+
+
+async def _upsert_export_asset(
+    session: AsyncSession, *, org_id: uuid.UUID, project_id: uuid.UUID,
+    object_path: str, name: str, content_type: str, size_bytes: int, created_by: uuid.UUID,
+) -> uuid.UUID:
+    """assets 레지스트리 upsert(멱등) — asset_registry.sync_attachment_assets와 동일 ON CONFLICT
+    키 규칙(org_id/project_id/container/object_path)이나 AssetLink 폴리모픽 확장 없이 단독 사용
+    (ArtifactExport가 자체 귀속 테이블이라 소스타입 CHECK 확장 불요)."""
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    container = _export_container()
+    base_ins = pg_insert(Asset).values(
+        org_id=org_id, project_id=project_id, container=container, object_path=object_path,
+        name=name, content_type=content_type, size_bytes=size_bytes, created_by=created_by,
+    )
+    ins = base_ins.on_conflict_do_nothing(
+        index_elements=[Asset.org_id, Asset.project_id, Asset.container, Asset.object_path],
+        index_where=Asset.project_id.isnot(None),
+    ).returning(Asset.id)
+    asset_id = (await session.execute(ins)).scalar_one_or_none()
+    if asset_id is None:
+        sel = select(Asset.id).where(
+            Asset.org_id == org_id, Asset.project_id == project_id,
+            Asset.container == container, Asset.object_path == object_path,
+        )
+        asset_id = (await session.execute(sel)).scalar_one()
+    return asset_id
+
+
+async def _export_response(
+    session: AsyncSession, export: ArtifactExport, version_number: int, *, container: str,
+) -> ArtifactExportResponse:
+    from datetime import timedelta
+
+    from app.services.storage import get_storage_provider
+
+    asset = (await session.execute(select(Asset).where(Asset.id == export.asset_id))).scalar_one()
+    download_url = await get_storage_provider().signed_read_url(
+        container, asset.object_path, ttl=timedelta(minutes=_EXPORT_TTL_MIN),
+    )
+    return ArtifactExportResponse(
+        id=export.id, artifact_id=export.artifact_id, version_id=export.version_id,
+        version_number=version_number, format=export.format, created_by=export.created_by,
+        created_at=export.created_at, asset_id=export.asset_id, download_url=download_url,
+    )
+
+
+@router.post("/{id}/versions/{version_number}/export/png/upload-url")
+async def create_export_upload_url(
+    id: uuid.UUID,
+    version_number: int,
+    body: ExportUploadUrlRequest,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    from datetime import datetime, timedelta, timezone
+
+    from app.services.storage import get_storage_provider
+
+    org_id, project_id = _get_org_project(auth)
+    if not org_id or not project_id:
+        return _err("FORBIDDEN", "org_id/project_id required", 403)
+    artifact = await _get_artifact_or_404(session, org_id, project_id, id)
+    if artifact is None:
+        return _err("NOT_FOUND", "Artifact not found", 404)
+    version = await _get_version_or_404(session, artifact.id, version_number)
+    if version is None:
+        return _err("NOT_FOUND", "Artifact version not found", 404)
+
+    object_path = _export_object_path(org_id, project_id, artifact.id, "png")
+    ttl = timedelta(minutes=_EXPORT_TTL_MIN)
+    upload_url = await get_storage_provider().signed_write_url(
+        _export_container(), object_path, ttl=ttl, content_type=body.content_type,
+    )
+    if upload_url is None:
+        return _err("STORAGE_ERROR", "signed write URL 발급 실패", 500)
+    return _ok(ExportUploadUrlResponse(
+        upload_url=upload_url, object_path=object_path,
+        expires_at=datetime.now(timezone.utc) + ttl,
+    ).model_dump(mode="json"))
+
+
+@router.post("/{id}/versions/{version_number}/export/png/complete", status_code=201)
+async def complete_png_export(
+    id: uuid.UUID,
+    version_number: int,
+    body: CompleteExportRequest,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    from app.services.storage import get_storage_provider
+
+    org_id, project_id = _get_org_project(auth)
+    if not org_id or not project_id:
+        return _err("FORBIDDEN", "org_id/project_id required", 403)
+    artifact = await _get_artifact_or_404(session, org_id, project_id, id)
+    if artifact is None:
+        return _err("NOT_FOUND", "Artifact not found", 404)
+    version = await _get_version_or_404(session, artifact.id, version_number)
+    if version is None:
+        return _err("NOT_FOUND", "Artifact version not found", 404)
+
+    if not _export_path_in_scope(body.object_path, org_id, project_id, artifact.id):
+        return _err("FORBIDDEN", "object_path not in artifact export scope", 403)
+
+    container = _export_container()
+    size_bytes = await get_storage_provider().head_object(container, body.object_path)
+    if size_bytes is None:
+        return _err("NOT_FOUND", "업로드된 객체를 찾을 수 없습니다(head_object 실패)", 404)
+
+    created_by = uuid.UUID(auth.user_id)
+    asset_id = await _upsert_export_asset(
+        session, org_id=org_id, project_id=project_id, object_path=body.object_path,
+        name=f"{artifact.title}-v{version_number}.png", content_type="image/png",
+        size_bytes=size_bytes, created_by=created_by,
+    )
+    export = ArtifactExport(
+        id=uuid.uuid4(), artifact_id=artifact.id, version_id=version.id, format="png",
+        asset_id=asset_id, created_by=created_by,
+    )
+    session.add(export)
+    await session.flush()
+    await session.refresh(export)
+
+    target_member_ids = list({artifact.created_by} - {created_by}) if artifact.created_by else []
+    if target_member_ids:
+        await dispatch_notification(
+            session, org_id=org_id, event_type="artifact.exported",
+            target_member_ids=target_member_ids,
+            title=f"산출물 export: {artifact.title}",
+            body="PNG export가 완료됐습니다.",
+            reference_type="visual_artifact", reference_id=artifact.id,
+            source_project_id=project_id,
+        )
+
+    resp = await _export_response(session, export, version_number, container=container)
+    return _ok(resp.model_dump(mode="json"), status=201)
+
+
+@router.post("/{id}/versions/{version_number}/export/html", status_code=201)
+async def create_html_export(
+    id: uuid.UUID,
+    version_number: int,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """self-contained HTML export — 렌더 불요(nodes 트리를 BE가 직렬화), client-trust 이슈 없어
+    즉시 put_object(유나 UX②: as-authored — 별도 재테마 없이 저장된 props 그대로 직렬화)."""
+    from app.services.storage import get_storage_provider
+
+    org_id, project_id = _get_org_project(auth)
+    if not org_id or not project_id:
+        return _err("FORBIDDEN", "org_id/project_id required", 403)
+    artifact = await _get_artifact_or_404(session, org_id, project_id, id)
+    if artifact is None:
+        return _err("NOT_FOUND", "Artifact not found", 404)
+    version = await _get_version_or_404(session, artifact.id, version_number)
+    if version is None:
+        return _err("NOT_FOUND", "Artifact version not found", 404)
+
+    node_rows = (await session.execute(
+        select(ArtifactNode).where(ArtifactNode.version_id == version.id).order_by(ArtifactNode.sort_order)
+    )).scalars().all()
+    html = _render_self_contained_html(artifact.title, node_rows)
+    html_bytes = html.encode("utf-8")
+
+    container = _export_container()
+    object_path = _export_object_path(org_id, project_id, artifact.id, "html")
+    ok = await get_storage_provider().put_object(
+        container, object_path, html_bytes, content_type="text/html; charset=utf-8",
+    )
+    if not ok:
+        return _err("STORAGE_ERROR", "HTML export 업로드 실패", 500)
+
+    created_by = uuid.UUID(auth.user_id)
+    asset_id = await _upsert_export_asset(
+        session, org_id=org_id, project_id=project_id, object_path=object_path,
+        name=f"{artifact.title}-v{version_number}.html", content_type="text/html; charset=utf-8",
+        size_bytes=len(html_bytes), created_by=created_by,
+    )
+    export = ArtifactExport(
+        id=uuid.uuid4(), artifact_id=artifact.id, version_id=version.id, format="html",
+        asset_id=asset_id, created_by=created_by,
+    )
+    session.add(export)
+    await session.flush()
+    await session.refresh(export)
+
+    target_member_ids = list({artifact.created_by} - {created_by}) if artifact.created_by else []
+    if target_member_ids:
+        await dispatch_notification(
+            session, org_id=org_id, event_type="artifact.exported",
+            target_member_ids=target_member_ids,
+            title=f"산출물 export: {artifact.title}",
+            body="HTML export가 완료됐습니다.",
+            reference_type="visual_artifact", reference_id=artifact.id,
+            source_project_id=project_id,
+        )
+
+    resp = await _export_response(session, export, version_number, container=container)
+    return _ok(resp.model_dump(mode="json"), status=201)
+
+
+def _render_self_contained_html(title: str, nodes: list[ArtifactNode]) -> str:
+    """nodes 트리를 as-authored 그대로 직렬화한 self-contained HTML(외부 리소스 참조 0).
+    html_blob 노드는 props.html을 그대로 삽입(임포트 raw HTML 계승), 그 외는 최소 wrapper."""
+    import html as _html_mod
+    import json as _json
+
+    parts: list[str] = [
+        "<!doctype html>", "<html>", "<head>",
+        f"<meta charset=\"utf-8\"><title>{_html_mod.escape(title)}</title>",
+        "</head>", "<body>",
+    ]
+    for n in sorted(nodes, key=lambda x: x.sort_order):
+        if n.type == "html_blob":
+            parts.append(str(n.props.get("html", "")))
+        else:
+            data_props = _html_mod.escape(_json.dumps(n.props, ensure_ascii=False))
+            parts.append(
+                f"<div data-node-type=\"{_html_mod.escape(n.type)}\" data-node-props=\"{data_props}\">"
+                f"</div>"
+            )
+    parts.append("</body></html>")
+    return "\n".join(parts)
+
+
+@router.get("/{id}/exports")
+async def list_artifact_exports(
+    id: uuid.UUID,
+    version_number: int | None = Query(default=None),
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id or not project_id:
+        return _err("FORBIDDEN", "org_id/project_id required", 403)
+    artifact = await _get_artifact_or_404(session, org_id, project_id, id)
+    if artifact is None:
+        return _err("NOT_FOUND", "Artifact not found", 404)
+
+    q = select(ArtifactExport, ArtifactVersion.version_number).join(
+        ArtifactVersion, ArtifactExport.version_id == ArtifactVersion.id,
+    ).where(ArtifactExport.artifact_id == artifact.id).order_by(ArtifactExport.created_at.desc())
+    if version_number is not None:
+        q = q.where(ArtifactVersion.version_number == version_number)
+    rows = (await session.execute(q)).all()
+
+    container = _export_container()
+    results = [
+        (await _export_response(session, export, vn, container=container)).model_dump(mode="json")
+        for export, vn in rows
+    ]
+    return _ok(results)

--- a/backend/app/schemas/visual_artifact.py
+++ b/backend/app/schemas/visual_artifact.py
@@ -118,3 +118,32 @@ class ArtifactCommentResponse(BaseModel):
     resolved_at: datetime | None = None
     created_by: uuid.UUID
     created_at: datetime
+
+
+class ExportUploadUrlRequest(BaseModel):
+    content_type: str = "image/png"
+
+
+class ExportUploadUrlResponse(BaseModel):
+    upload_url: str
+    object_path: str
+    expires_at: datetime
+
+
+class CompleteExportRequest(BaseModel):
+    object_path: str
+
+
+class ArtifactExportResponse(BaseModel):
+    id: uuid.UUID
+    artifact_id: uuid.UUID
+    version_id: uuid.UUID
+    version_number: int
+    format: str
+    created_by: uuid.UUID | None = None
+    created_at: datetime
+    # 유나 UX 결정③(공유 링크 1급): asset_id는 안정적 공유 참조 — FE가
+    # GET /api/v2/attachments/authorize?asset_id=... (기존 인프라 재사용)로 인가된 caller에게
+    # 언제든 재서명 다운로드 URL을 새로 받을 수 있다. download_url은 즉시 사용 편의용 단기 서명.
+    asset_id: uuid.UUID
+    download_url: str | None = None

--- a/backend/app/services/storage/base.py
+++ b/backend/app/services/storage/base.py
@@ -23,6 +23,13 @@ class StorageProvider(abc.ABC):
         """단기 만료 read 서명 URL. 실패 시 None(best-effort)."""
 
     @abc.abstractmethod
+    async def signed_write_url(
+        self, container: str, object_path: str, *, ttl: timedelta, content_type: str | None = None
+    ) -> str | None:
+        """단기 만료 write(PUT) 서명 URL — D3(put=FE) 원칙 유지하며 대용량 바이너리가 BE(Cloud Run)를
+        경유하지 않게 한다(E-CANVAS C1-S5: FE가 캡처한 PNG를 GCS에 직접 PUT). 실패 시 None(best-effort)."""
+
+    @abc.abstractmethod
     async def delete_object(self, container: str, object_path: str) -> bool:
         """객체 hard-delete(S8 grace cron). 이미 없으면 True(멱등)·실패 시 False(best-effort·호출부 계속)."""
 

--- a/backend/app/services/storage/gcs.py
+++ b/backend/app/services/storage/gcs.py
@@ -52,6 +52,37 @@ class GcsStorageProvider(StorageProvider):
             logger.warning("gcs storage: signed url 생성 실패 path=%s", object_path, exc_info=True)
             return None
 
+    async def signed_write_url(
+        self, container: str, object_path: str, *, ttl: timedelta, content_type: str | None = None
+    ) -> str | None:
+        """signed_read_url과 동형(IAM SignBlob V4) — method="PUT". content_type 지정 시 서명에
+        바인딩돼 FE PUT 요청의 Content-Type 헤더가 반드시 일치해야 한다(임의 타입 업로드 방지)."""
+
+        def _blocking() -> str:
+            import google.auth
+            from google.auth.transport.requests import Request as _AuthRequest
+            from google.cloud import storage
+
+            creds, _ = google.auth.default()
+            creds.refresh(_AuthRequest())
+            blob = storage.Client().bucket(container).blob(object_path)
+            kwargs: dict = {
+                "version": "v4",
+                "expiration": ttl,
+                "method": "PUT",
+                "service_account_email": getattr(creds, "service_account_email", None),
+                "access_token": creds.token,
+            }
+            if content_type:
+                kwargs["content_type"] = content_type
+            return blob.generate_signed_url(**kwargs)
+
+        try:
+            return await asyncio.to_thread(_blocking)
+        except Exception:
+            logger.warning("gcs storage: signed write url 생성 실패 path=%s", object_path, exc_info=True)
+            return None
+
     async def delete_object(self, container: str, object_path: str) -> bool:
         def _blocking() -> bool:
             from google.cloud import storage

--- a/backend/app/services/storage/local.py
+++ b/backend/app/services/storage/local.py
@@ -83,6 +83,24 @@ class LocalStorageProvider(StorageProvider):
             logger.warning("local storage: signed url 생성 실패 path=%s", object_path, exc_info=True)
             return None
 
+    async def signed_write_url(
+        self, container: str, object_path: str, *, ttl: timedelta, content_type: str | None = None
+    ) -> str | None:
+        """signed_read_url과 동형이나 payload에 method=PUT을 바인딩(read 서명 재사용 방지).
+        ⚠️ FE `/api/storage/local/...` serve 라우트가 현재 GET만 문서화돼 있어 PUT 수신을
+        지원하려면 FE 측 대응 핸들러가 필요(OSS local provider 후속 — BE 서명 계약만 여기 마련)."""
+        secret = _signing_secret()
+        try:
+            base = os.environ.get("STORAGE_LOCAL_SERVE_BASE_URL", _DEFAULT_SERVE_BASE).rstrip("/")
+            exp = int((time.time() + ttl.total_seconds()) * 1000)
+            payload = f"PUT:{container}/{object_path}:{exp}".encode()
+            sig = hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()
+            qs = urlencode({"exp": exp, "sig": sig, "method": "PUT"})
+            return f"{base}/api/storage/local/{container}/{object_path}?{qs}"
+        except Exception:
+            logger.warning("local storage: signed write url 생성 실패 path=%s", object_path, exc_info=True)
+            return None
+
     async def delete_object(self, container: str, object_path: str) -> bool:
         def _blocking() -> bool:
             _resolve_safe(container, object_path).unlink(missing_ok=True)  # 없어도 OK = 멱등

--- a/backend/app/services/storage/s3.py
+++ b/backend/app/services/storage/s3.py
@@ -56,6 +56,23 @@ class S3StorageProvider(StorageProvider):
             logger.warning("s3 storage: signed url 생성 실패 path=%s", object_path, exc_info=True)
             return None
 
+    async def signed_write_url(
+        self, container: str, object_path: str, *, ttl: timedelta, content_type: str | None = None
+    ) -> str | None:
+        def _blocking() -> str:
+            params: dict = {"Bucket": container, "Key": object_path}
+            if content_type:
+                params["ContentType"] = content_type
+            return _client().generate_presigned_url(
+                "put_object", Params=params, ExpiresIn=int(ttl.total_seconds()),
+            )
+
+        try:
+            return await asyncio.to_thread(_blocking)
+        except Exception:
+            logger.warning("s3 storage: signed write url 생성 실패 path=%s", object_path, exc_info=True)
+            return None
+
     async def delete_object(self, container: str, object_path: str) -> bool:
         def _blocking() -> bool:
             _client().delete_object(Bucket=container, Key=object_path)  # S3 delete=멱등(없어도 성공)

--- a/backend/tests/test_e_canvas_c1_s5_artifact_export_realdb.py
+++ b/backend/tests/test_e_canvas_c1_s5_artifact_export_realdb.py
@@ -1,0 +1,338 @@
+"""E-CANVAS C1-S5(story 1f365e33): artifact export(PNG signed-write-URL 3-step, HTML
+self-contained) 실증. crux: BE는 바이너리 미경유(FE→GCS 직접 PUT 시뮬레이션 = local provider
+직접 put_object) + object_path scope 강제(cross-project export asset 오염 차단) + head_object
+phantom 방지."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project) + artifact(1 version, 1 html_blob node)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+    from app.models.visual_artifact import ArtifactNode, ArtifactVersion, VisualArtifact
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    creator = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="exporter", is_active=True)
+    session.add(creator)
+    await session.commit()
+    creator_id = creator.id
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=creator_id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    artifact = VisualArtifact(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Export Artifact",
+        source="created", latest_version_number=1, created_by=creator_id,
+    )
+    session.add(artifact)
+    await session.commit()
+
+    version = ArtifactVersion(id=uuid.uuid4(), artifact_id=artifact.id, version_number=1, created_by=creator_id)
+    session.add(version)
+    await session.commit()
+
+    node = ArtifactNode(
+        id=uuid.uuid4(), artifact_id=artifact.id, version_id=version.id,
+        type="html_blob", props={"html": "<h1>Hello</h1>"}, sort_order=0,
+    )
+    session.add(node)
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "artifact_id": artifact.id,
+        "version_id": version.id, "creator_id": creator_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, project_id, user_id=None):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id or uuid.uuid4()), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_upload_url_scoped_to_org_project_artifact():
+    """upload-url이 반환하는 object_path가 org/project/artifact로 스코프됨(SEC 계열 원칙 계승)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/versions/1/export/png/upload-url",
+                json={"content_type": "image/png"},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()["data"]
+            expected_prefix = f"org/{seeded['org_id']}/project/{seeded['project_id']}/artifact/{seeded['artifact_id']}/export/"
+            assert body["object_path"].startswith(expected_prefix)
+            assert body["upload_url"]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_complete_png_export_with_real_uploaded_object():
+    """3-step 실증: upload-url → (FE PUT 시뮬레이션: local provider 직접 put_object) → complete
+    → asset 등록 + ArtifactExport row + download_url 반환."""
+    from app.main import app
+    from app.services.storage import get_storage_provider
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            url_resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/versions/1/export/png/upload-url",
+                json={"content_type": "image/png"},
+            )
+            object_path = url_resp.json()["data"]["object_path"]
+
+            # FE의 signed URL PUT을 로컬 provider put_object로 시뮬레이션(실 GCS 없이도 3-step 실증).
+            from app.services.asset_registry import DEFAULT_CONTAINER
+            put_ok = await get_storage_provider().put_object(
+                DEFAULT_CONTAINER, object_path, b"\x89PNG fake bytes", content_type="image/png",
+            )
+            assert put_ok
+
+            complete_resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/versions/1/export/png/complete",
+                json={"object_path": object_path},
+            )
+            assert complete_resp.status_code == 201, complete_resp.text
+            body = complete_resp.json()["data"]
+            assert body["format"] == "png"
+            assert body["version_number"] == 1
+            assert body["asset_id"]
+            assert body["download_url"]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_complete_png_export_phantom_object_rejected():
+    """실 업로드 없이 complete 시도 → 404(head_object 실패=phantom asset 등록 차단)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            phantom_path = (
+                f"org/{seeded['org_id']}/project/{seeded['project_id']}/artifact/"
+                f"{seeded['artifact_id']}/export/{uuid.uuid4()}.png"
+            )
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/versions/1/export/png/complete",
+                json={"object_path": phantom_path},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_complete_png_export_out_of_scope_path_rejected():
+    """crux: object_path가 다른 artifact/project로 스코프되면 403(SEC 계열과 동형 원칙)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            forged_path = f"org/{seeded['org_id']}/project/{seeded['project_id']}/artifact/{uuid.uuid4()}/export/x.png"
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/versions/1/export/png/complete",
+                json={"object_path": forged_path},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_html_export_self_contained():
+    """HTML export — 렌더 불요·즉시 BE 생성+저장(as-authored: html_blob 노드 그대로 삽입)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/versions/1/export/html",
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()["data"]
+            assert body["format"] == "html"
+            assert body["download_url"]
+
+            # 실제 저장된 HTML 내용 확認(as-authored html_blob 그대로).
+            from app.services.asset_registry import DEFAULT_CONTAINER
+            from app.services.storage import get_storage_provider
+            from app.models.asset import Asset
+            from sqlalchemy import select
+            async with Session() as s2:
+                asset = (await s2.execute(
+                    select(Asset).where(Asset.id == uuid.UUID(body["asset_id"]))
+                )).scalar_one()
+            html_bytes = await get_storage_provider().download_object(DEFAULT_CONTAINER, asset.object_path)
+            assert b"<h1>Hello</h1>" in html_bytes
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_exports_returns_both_formats():
+    """GET /exports가 png+html 둘 다 최신순으로 반환."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            await client.post(f"/api/v2/visual-artifacts/{seeded['artifact_id']}/versions/1/export/html")
+
+            list_resp = await client.get(f"/api/v2/visual-artifacts/{seeded['artifact_id']}/exports")
+            assert list_resp.status_code == 200
+            items = list_resp.json()["data"]
+            assert len(items) == 1
+            assert items[0]["format"] == "html"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_export_nonexistent_version_404():
+    """존재하지 않는 version_number → 404."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/versions/99/export/html",
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
E-CANVAS C1-S5(story `1f365e33`) — Blueprint §F6(선생님 r3 요건). crux(오르테가 승인): PNG는 클라 캡처(FE가 이미 라이브 렌더 중인 DOM을 html2canvas류로 캡처) — 서버 headless 렌더는 FE 렌더링 스택 중복 재현이라 근본 아님. BE는 바이너리를 경유하지 않고 signed write URL 발급 + complete 시 head_object 검증 후 asset 편입만 담당(D3 put=FE 원칙 계승). HTML export는 렌더 불요라 BE가 nodes 트리를 즉시 직렬화(client-trust 이슈 없음, 유나 UX②: as-authored).

- `StorageProvider.signed_write_url` 신규 추상 메서드 + gcs(IAM SignBlob PUT)/s3(presigned put_object)/local(HMAC PUT capability) 3종 구현.
- migration 0173(additive): `artifact_exports`(artifact_id/version_id/format/asset_id FK assets.id/created_by/created_at) — 기존 assets 레지스트리 재사용(AssetLink 폴리모픽 확장 없이 단독 귀속 테이블).
- 엔드포인트 4개: `POST .../export/png/upload-url`(object_path 스코프 계산 org/project/artifact 전 segment exact 바인딩 — SEC 계열 원칙 계승 + signed PUT URL)·`POST .../export/png/complete`(head_object 실체 검증 후 asset upsert+ArtifactExport row+artifact.exported 이벤트)·`POST .../export/html`(BE 즉시 생성)·`GET .../exports`(목록+매 요청 fresh signed_read_url).
- 유나 UX 결정③(공유 링크 1급): 응답에 `asset_id` 포함 — 기존 `GET /api/v2/attachments/authorize?asset_id=`(인가된 caller 재서명) 인프라 재사용, 신규 공유 링크 플러밍 불요.

## Test plan
- [x] realdb 7건: upload-url 스코프·3-step 완주(FE PUT 시뮬레이션→complete)·phantom object 404 차단·cross-artifact scope 위조 403 차단·HTML as-authored 내용 검증·목록·존재하지 않는 version 404
- [x] 기존 C1-S3/C2-S6/storage 테스트 45건 무변경 통과
- [x] 전체 스위트(`-m "not destructive_schema"`) 3517 passed, baseline 7건(무관) 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)