### PR TITLE
feat(canvas): E-CANVAS C3-S7 딸깍/MCP 양방향 편집 + source_comment_id closed-loop

### DIFF
--- a/backend/alembic/versions/0174_artifact_version_source_comment.py
+++ b/backend/alembic/versions/0174_artifact_version_source_comment.py
@@ -1,0 +1,38 @@
+"""E-CANVAS C3-S7(story 940266db): artifact_versions.source_comment_id — 코멘트→편집 결과
+연결(closed-loop: C2 코멘트가 C3 편집을 낳은 계보만 기록, resolve와는 독립).
+
+Revision ID: 0174
+Revises: 0173
+Create Date: 2026-07-11
+
+순수 additive — nullable 컬럼 1개. 기존 스키마 무회귀. ON DELETE SET NULL(코멘트 삭제되어도
+버전 이력 자체는 유지, 링크만 소실).
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0174"
+down_revision = "0173"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "artifact_versions",
+        sa.Column(
+            "source_comment_id", postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("artifact_comments.id", ondelete="SET NULL"), nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_artifact_versions_source_comment_id", "artifact_versions", ["source_comment_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_artifact_versions_source_comment_id", table_name="artifact_versions")
+    op.drop_column("artifact_versions", "source_comment_id")

--- a/backend/app/models/visual_artifact.py
+++ b/backend/app/models/visual_artifact.py
@@ -56,8 +56,18 @@ class ArtifactVersion(Base):
     summary: Mapped[str | None] = mapped_column(Text, nullable=True)
     # E-CANVAS C3-S7(story 940266db): 코멘트→편집 결과 연결(closed-loop) — 이 버전이 어느
     # 코멘트에 응답해 만들어졌는지의 계보만 기록(resolve와 독립·감시 아닌 신뢰 조각).
+    # ⚠️ use_alter=True 필수: artifact_versions→artifact_comments(이 FK)→artifact_nodes
+    # (comments.node_id)→artifact_versions(nodes.version_id)로 순환 FK가 생겨 Base.metadata.
+    # create_all()(destructive_schema 테스트가 씀)가 CircularDependencyError로 실패했다(CI가
+    # 실측으로 잡음) — use_alter은 SQLAlchemy가 이 제약만 별도 ALTER TABLE로 뒤늦게 추가해
+    # 순환을 깬다(실제 alembic 마이그레이션은 원래도 순차 DDL이라 영향 없음).
     source_comment_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("artifact_comments.id", ondelete="SET NULL"), nullable=True,
+        UUID(as_uuid=True),
+        ForeignKey(
+            "artifact_comments.id", ondelete="SET NULL",
+            use_alter=True, name="fk_artifact_versions_source_comment_id",
+        ),
+        nullable=True,
     )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 

--- a/backend/app/models/visual_artifact.py
+++ b/backend/app/models/visual_artifact.py
@@ -54,6 +54,11 @@ class ArtifactVersion(Base):
     # 유나 §11 field-level 대조 갭②: 변경 이유(커밋 요약) — raw diff가 아닌 lineage 서사(§6
     # 감시-게이트 핵심). C1은 POST body로 선택 set, C3 커밋 시 본격 사용.
     summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # E-CANVAS C3-S7(story 940266db): 코멘트→편집 결과 연결(closed-loop) — 이 버전이 어느
+    # 코멘트에 응답해 만들어졌는지의 계보만 기록(resolve와 독립·감시 아닌 신뢰 조각).
+    source_comment_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("artifact_comments.id", ondelete="SET NULL"), nullable=True,
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
 

--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -16,11 +16,13 @@ from app.models.visual_artifact import (
 from app.schemas.visual_artifact import (
     ArtifactCommentResponse,
     ArtifactExportResponse,
+    ArtifactNodeOperation,
     ArtifactNodeOut,
     ArtifactVersionSummary,
     CompleteExportRequest,
     CreateArtifactCommentRequest,
     CreateArtifactRequest,
+    EditArtifactRequest,
     ExportUploadUrlRequest,
     ExportUploadUrlResponse,
     VisualArtifactDetail,
@@ -669,3 +671,137 @@ async def list_artifact_exports(
         for export, vn in rows
     ]
     return _ok(results)
+
+
+# ─── Edit (E-CANVAS C3-S7, story 940266db) ────────────────────────────────────
+# crux: 휴먼 딸깍(REST)과 에이전트 MCP(POST 동일 엔드포인트)가 **같은 서비스 경로**를 경유해
+# "같은 객체를 양쪽이 편집"을 보장한다(서로 다른 코드 경로면 drift 위험). 버전은 무-mutate
+# 원칙(C1-S3) 계승 — 편집은 항상 새 버전을 만든다. ⚠️ node id는 버전 간 안정하지 않다
+# (ArtifactNode.id가 테이블 전역 PK라 버전마다 독립 row=새 id 필수 — C1-S3의 "버전마다 자기
+# 소유 node row 세트" 설계와 정합). update/delete op은 편집 시점 최신 버전의 id로 대상만
+# 지정하고, 응답으로 돌아오는 새 id를 다음 편집에 사용한다.
+
+
+async def _apply_artifact_edit(
+    session: AsyncSession, artifact: VisualArtifact, operations: list[ArtifactNodeOperation],
+    *, actor_id: uuid.UUID, summary: str | None,
+) -> ArtifactVersion:
+    latest = await _get_version_or_404(session, artifact.id, artifact.latest_version_number)
+    if latest is None:
+        raise ValueError("latest version not found — artifact 상태 비정상")
+
+    existing_rows = (await session.execute(
+        select(ArtifactNode).where(ArtifactNode.version_id == latest.id)
+    )).scalars().all()
+    working: dict[uuid.UUID, dict] = {
+        n.id: {
+            "type": n.type, "props": n.props, "parent_id": n.parent_id,
+            "sort_order": n.sort_order, "description": n.description,
+        }
+        for n in existing_rows
+    }
+
+    for op in operations:
+        if op.op == "add":
+            new_id = op.id or uuid.uuid4()
+            working[new_id] = {
+                "type": op.type or "text", "props": op.props or {}, "parent_id": op.parent_id,
+                "sort_order": op.sort_order or 0, "description": op.description,
+            }
+        elif op.op == "update":
+            if op.id is None or op.id not in working:
+                raise ValueError(f"update 대상 node를 찾을 수 없습니다: {op.id}")
+            node = working[op.id]
+            if op.type is not None:
+                node["type"] = op.type
+            if op.props is not None:
+                node["props"] = op.props
+            if op.parent_id is not None:
+                node["parent_id"] = op.parent_id
+            if op.sort_order is not None:
+                node["sort_order"] = op.sort_order
+            if op.description is not None:
+                node["description"] = op.description
+        elif op.op == "delete":
+            if op.id is None:
+                raise ValueError("delete op에는 id가 필요합니다")
+            working.pop(op.id, None)
+
+    new_version_number = artifact.latest_version_number + 1
+    new_version = ArtifactVersion(
+        id=uuid.uuid4(), artifact_id=artifact.id, version_number=new_version_number,
+        created_by=actor_id, summary=summary,
+    )
+    session.add(new_version)
+    await session.flush()
+
+    # ⚠️ ArtifactNode.id는 테이블 전역 PK다(버전별 복합키 아님) — C1-S3 "버전마다 자기 소유
+    # node row 세트" 설계상 매 버전은 독립 row 집합이라 이전 버전의 id를 재사용하면 PK 충돌.
+    # working 딕셔너리 키(현재 버전 id)는 연산 매칭(update/delete 대상 지정)에만 쓰고, 실제
+    # INSERT는 새 id로 한다 — parent_id가 "같은 편집에서 새로 추가된 부모"를 가리키면 그 새
+    # id로 리매핑(트리 구조 보존), 그 외(이전 버전에 이미 있던 parent)는 parent_id를 그대로
+    # 둔다(과거 버전 트리 참조는 새 버전에서 무의미하므로 앱 레이어가 무시·FE는 매 버전 응답의
+    # nodes[]를 그대로 신뢰).
+    id_remap: dict[uuid.UUID, uuid.UUID] = {old_id: uuid.uuid4() for old_id in working}
+    for old_id, data in working.items():
+        parent_id = data["parent_id"]
+        remapped_parent_id = id_remap.get(parent_id, parent_id) if parent_id is not None else None
+        session.add(ArtifactNode(
+            id=id_remap[old_id], artifact_id=artifact.id, version_id=new_version.id,
+            type=data["type"], props=data["props"], parent_id=remapped_parent_id,
+            sort_order=data["sort_order"], description=data["description"],
+        ))
+
+    artifact.latest_version_number = new_version_number
+    await session.flush()
+    return new_version
+
+
+async def _notify_artifact_updated(
+    session: AsyncSession, artifact: VisualArtifact, *, org_id: uuid.UUID, project_id: uuid.UUID,
+    editor_id: uuid.UUID,
+) -> None:
+    """AC③: 어느 쪽 수정이든(휴먼/에이전트) artifact.updated 이벤트가 상대에게 도달 — 대상=
+    artifact 생성자(편집자 본인 제외). C2-S6 comment.created 전파와 동형 패턴."""
+    target_member_ids = list({artifact.created_by} - {editor_id}) if artifact.created_by else []
+    if target_member_ids:
+        await dispatch_notification(
+            session, org_id=org_id, event_type="artifact.updated",
+            target_member_ids=target_member_ids,
+            title=f"산출물 수정됨: {artifact.title}",
+            body="artifact가 새 버전으로 갱신됐습니다.",
+            reference_type="visual_artifact", reference_id=artifact.id,
+            source_project_id=project_id,
+        )
+
+
+@router.post("/{id}/edit", status_code=201)
+async def edit_artifact(
+    id: uuid.UUID,
+    body: EditArtifactRequest,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """딸깍 편집(FE) + MCP 편집(에이전트) 공용 엔드포인트 — 요소 add/update/delete를 적용해
+    새 버전을 만든다(무-mutate 버전 원칙 계승)."""
+    org_id, project_id = _get_org_project(auth)
+    if not org_id or not project_id:
+        return _err("FORBIDDEN", "org_id/project_id required", 403)
+    artifact = await _get_artifact_or_404(session, org_id, project_id, id)
+    if artifact is None:
+        return _err("NOT_FOUND", "Artifact not found", 404)
+
+    actor_id = uuid.UUID(auth.user_id)
+    try:
+        new_version = await _apply_artifact_edit(
+            session, artifact, body.operations, actor_id=actor_id, summary=body.summary,
+        )
+    except ValueError as exc:
+        return _err("INVALID_OPERATION", str(exc), 422)
+
+    await _notify_artifact_updated(session, artifact, org_id=org_id, project_id=project_id, editor_id=actor_id)
+
+    detail = await _load_detail(session, artifact, new_version.version_number)
+    if detail is None:
+        return _err("NOT_FOUND", "Artifact version not found", 404)
+    return _ok(detail.model_dump(mode="json"), status=201)

--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -119,6 +119,7 @@ async def create_artifact(
         anchor_version=artifact.anchor_version,
         created_by=artifact.created_by, created_at=artifact.created_at, updated_at=artifact.updated_at,
         version_number=version.version_number, version_summary=version.summary,
+        version_source_comment_id=version.source_comment_id,
         nodes=[ArtifactNodeOut.model_validate(n) for n in nodes],
     )
     return _ok(detail.model_dump(mode="json"), status=201)
@@ -156,6 +157,7 @@ async def _load_detail(session: AsyncSession, artifact: VisualArtifact, version_
         anchor_version=artifact.anchor_version,
         created_by=artifact.created_by, created_at=artifact.created_at, updated_at=artifact.updated_at,
         version_number=version.version_number, version_summary=version.summary,
+        version_source_comment_id=version.source_comment_id,
         nodes=[ArtifactNodeOut.model_validate(n) for n in node_rows],
     )
 
@@ -684,7 +686,7 @@ async def list_artifact_exports(
 
 async def _apply_artifact_edit(
     session: AsyncSession, artifact: VisualArtifact, operations: list[ArtifactNodeOperation],
-    *, actor_id: uuid.UUID, summary: str | None,
+    *, actor_id: uuid.UUID, summary: str | None, source_comment_id: uuid.UUID | None = None,
 ) -> ArtifactVersion:
     latest = await _get_version_or_404(session, artifact.id, artifact.latest_version_number)
     if latest is None:
@@ -730,7 +732,7 @@ async def _apply_artifact_edit(
     new_version_number = artifact.latest_version_number + 1
     new_version = ArtifactVersion(
         id=uuid.uuid4(), artifact_id=artifact.id, version_number=new_version_number,
-        created_by=actor_id, summary=summary,
+        created_by=actor_id, summary=summary, source_comment_id=source_comment_id,
     )
     session.add(new_version)
     await session.flush()
@@ -791,10 +793,20 @@ async def edit_artifact(
     if artifact is None:
         return _err("NOT_FOUND", "Artifact not found", 404)
 
+    if body.source_comment_id is not None:
+        # 결과 연결도 cross-artifact 위조 차단(오늘 계열 SEC 원칙 동형) — 남의 artifact
+        # 코멘트를 내 편집 결과로 링크할 수 없음. 403(검증 오류 422와 구분되는 인가 축).
+        comment_owner = (await session.execute(
+            select(ArtifactComment.artifact_id).where(ArtifactComment.id == body.source_comment_id)
+        )).scalar_one_or_none()
+        if comment_owner != artifact.id:
+            return _err("FORBIDDEN", "source_comment_id가 이 artifact 소속이 아닙니다", 403)
+
     actor_id = uuid.UUID(auth.user_id)
     try:
         new_version = await _apply_artifact_edit(
             session, artifact, body.operations, actor_id=actor_id, summary=body.summary,
+            source_comment_id=body.source_comment_id,
         )
     except ValueError as exc:
         return _err("INVALID_OPERATION", str(exc), 422)

--- a/backend/app/schemas/visual_artifact.py
+++ b/backend/app/schemas/visual_artifact.py
@@ -52,6 +52,8 @@ class ArtifactVersionSummary(BaseModel):
     summary: str | None = None
     created_by: uuid.UUID | None = None
     created_at: datetime
+    # E-CANVAS C3-S7: 이 버전이 응답한 코멘트(closed-loop, 선택제).
+    source_comment_id: uuid.UUID | None = None
 
 
 class VisualArtifactSummary(BaseModel):
@@ -84,6 +86,8 @@ class VisualArtifactDetail(BaseModel):
     updated_at: datetime
     version_number: int
     version_summary: str | None = None
+    # E-CANVAS C3-S7: 이 버전이 응답한 코멘트(closed-loop, 선택제).
+    version_source_comment_id: uuid.UUID | None = None
     nodes: list[ArtifactNodeOut]
 
 
@@ -172,6 +176,9 @@ class EditArtifactRequest(BaseModel):
     operations: list[ArtifactNodeOperation]
     # 새 버전의 변경 이유(선택) — ArtifactVersion.summary와 동형(C1-S3 §11 갭②).
     summary: str | None = None
+    # 이 편집 커밋이 어느 코멘트에 응답했는지(선택, closed-loop). op-level 아닌 request-level
+    # — 편집=코멘트 응답 단위. auto-resolve 안 함(링크≠해결, 해결은 별도 명시 액션).
+    source_comment_id: uuid.UUID | None = None
 
     @field_validator("operations")
     @classmethod

--- a/backend/app/schemas/visual_artifact.py
+++ b/backend/app/schemas/visual_artifact.py
@@ -147,3 +147,35 @@ class ArtifactExportResponse(BaseModel):
     # 언제든 재서명 다운로드 URL을 새로 받을 수 있다. download_url은 즉시 사용 편의용 단기 서명.
     asset_id: uuid.UUID
     download_url: str | None = None
+
+
+class ArtifactNodeOperation(BaseModel):
+    """E-CANVAS C3-S7(story 940266db): 딸깍 편집(휴먼)·MCP 편집(에이전트) 공용 연산 — 동일
+    서비스 경로를 경유해 "같은 객체를 양쪽이 편집"을 보장한다."""
+    op: str  # "add" | "update" | "delete"
+    id: uuid.UUID | None = None  # add: 선택(미지정 시 서버 생성) / update·delete: 필수(대상 node id)
+    type: str | None = None  # add 필수
+    props: dict[str, Any] | None = None  # add: 초기값(미지정 {}) / update: 지정 시 전체 교체
+    parent_id: uuid.UUID | None = None
+    sort_order: int | None = None
+    description: str | None = None
+
+    @field_validator("op")
+    @classmethod
+    def _validate_op(cls, v: str) -> str:
+        if v not in ("add", "update", "delete"):
+            raise ValueError("op must be 'add', 'update', or 'delete'")
+        return v
+
+
+class EditArtifactRequest(BaseModel):
+    operations: list[ArtifactNodeOperation]
+    # 새 버전의 변경 이유(선택) — ArtifactVersion.summary와 동형(C1-S3 §11 갭②).
+    summary: str | None = None
+
+    @field_validator("operations")
+    @classmethod
+    def _non_empty_operations(cls, v: list) -> list:
+        if not v:
+            raise ValueError("operations must not be empty")
+        return v

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -65,11 +65,12 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     "sprintable_add_evidence",
     # E-CANVAS C1-S3(story 8bace49e): create_artifact/get_artifact — story/epic/doc 中 어디에도
     # (또는 아무데도) 붙을 수 있는 시각 산출물 생성/조회. add_evidence와 동형(단일 도메인 그룹에
-    # 묶기 애매한 cross-cutting 자기생성 유틸). C2-S6(story 0edca31e)에서 코멘트 2종 추가 — 4개로
-    # 늘었으나 여전히 story/epic/doc 무관 cross-cutting이라 always-allow 유지(C3/C4가 더 늘리면
-    # 그때 전용 "canvas" 그룹 신설 고려).
+    # 묶기 애매한 cross-cutting 자기생성 유틸). C2-S6(story 0edca31e) 코멘트 2종 + C3-S7
+    # (story 940266db) edit_artifact 1종 추가 — 5개로 늘었으나 여전히 story/epic/doc 무관
+    # cross-cutting이라 always-allow 유지(C4가 더 늘리면 그때 전용 "canvas" 그룹 신설 고려).
     "sprintable_create_artifact", "sprintable_get_artifact",
     "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
+    "sprintable_edit_artifact",
 })
 
 # scope 토큰: 그룹명 외에 read/write(레거시·전체 비파괴 의미), admin/destructive(파괴적 허용)
@@ -289,9 +290,10 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_link_gate_to_task",
     # evidence (E-VERIFY V0-S1)
     "sprintable_add_evidence",
-    # visual artifacts (E-CANVAS C1-S3 + C2-S6 코멘트)
+    # visual artifacts (E-CANVAS C1-S3 + C2-S6 코멘트 + C3-S7 편집)
     "sprintable_create_artifact", "sprintable_get_artifact",
     "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
+    "sprintable_edit_artifact",
 )
 
 # picker 표시 순서(비파괴 먼저). order 필드 힌트 + 배열 순서 둘 다 이 순서.

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -30,8 +30,9 @@ from .toolset import is_tool_allowed
 from .tools.a2a import LinkGateToTaskInput, link_gate_to_task
 from .tools.evidence import AddEvidenceInput, add_evidence
 from .tools.visual_artifacts import (
-    AddArtifactCommentInput, CreateArtifactInput, GetArtifactInput, ListArtifactCommentsInput,
-    add_artifact_comment, create_artifact, get_artifact, list_artifact_comments,
+    AddArtifactCommentInput, CreateArtifactInput, EditArtifactInput, GetArtifactInput,
+    ListArtifactCommentsInput,
+    add_artifact_comment, create_artifact, edit_artifact, get_artifact, list_artifact_comments,
 )
 from .tools.agent_runs import (
     EmitEventInput, PollEventsInput, UpdateRunStatusInput,
@@ -493,7 +494,7 @@ _TOOL_DEFS: list[tuple] = [
      "done을 스스로 증명하는 자기 서명 첨부(PR·배포·지표·발행물 링크 등) — story/task에 evidence"
      " 남김. 선택제(첨부 안 해도 무불이익).",
      AddEvidenceInput, add_evidence),
-    # Visual artifacts (4) — E-CANVAS C1-S3 + C2-S6(코멘트)
+    # Visual artifacts (5) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집)
     ("sprintable_create_artifact",
      "시각 산출물 생성(에이전트 생성 입구) — 트리(nodes[])로 구조화. 임포트된 raw HTML/이미지는"
      " type=\"html_blob\" 노드 하나로 감싸도 됨.",
@@ -507,6 +508,9 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_add_artifact_comment",
      "artifact에 코멘트 추가(요소/좌표 앵커·답글 가능) — 대상자에게 이벤트 전파.",
      AddArtifactCommentInput, add_artifact_comment),
+    ("sprintable_edit_artifact",
+     "artifact 요소 add/update/delete 편집 — 휴먼 딸깍과 같은 경로, 항상 새 버전 생성·이벤트 전파.",
+     EditArtifactInput, edit_artifact),
     # Chat (3)
     ("sprintable_send_chat_message",
      "conversation thread에 채팅 메시지 발송.",

--- a/backend/sprintable_mcp/tools/visual_artifacts.py
+++ b/backend/sprintable_mcp/tools/visual_artifacts.py
@@ -59,6 +59,7 @@ class EditArtifactInput(SprintableInput):
     artifact_id: str
     operations: list[ArtifactNodeOperationInput]
     summary: str | None = None  # 새 버전 변경 이유(선택)
+    source_comment_id: str | None = None  # 이 편집이 응답한 코멘트(선택, closed-loop)
 
 
 async def create_artifact(args: CreateArtifactInput) -> list[TextContent]:
@@ -134,6 +135,8 @@ async def edit_artifact(args: EditArtifactInput) -> list[TextContent]:
         }
         if args.summary:
             body["summary"] = args.summary
+        if args.source_comment_id:
+            body["source_comment_id"] = args.source_comment_id
         result = await client.post(f"/api/v2/visual-artifacts/{args.artifact_id}/edit", json=body)
         return ok(result)
     except Exception as exc:

--- a/backend/sprintable_mcp/tools/visual_artifacts.py
+++ b/backend/sprintable_mcp/tools/visual_artifacts.py
@@ -1,5 +1,5 @@
-"""시각 산출물(visual_artifact) MCP 도구(4개) — E-CANVAS C1-S3(story 8bace49e)+
-C2-S6(story 0edca31e, 코멘트 왕복)."""
+"""시각 산출물(visual_artifact) MCP 도구(5개) — E-CANVAS C1-S3(story 8bace49e)+
+C2-S6(story 0edca31e, 코멘트 왕복)+C3-S7(story 940266db, 편집 왕복)."""
 from __future__ import annotations
 
 from mcp.types import TextContent
@@ -43,6 +43,22 @@ class AddArtifactCommentInput(SprintableInput):
     anchor_y: float | None = None
     parent_id: str | None = None  # 답글이면 부모 코멘트 id
     mentioned_ids: list[str] | None = None
+
+
+class ArtifactNodeOperationInput(SprintableInput):
+    op: str  # "add" | "update" | "delete"
+    id: str | None = None  # add: 선택 / update·delete: 필수(대상 node id)
+    type: str | None = None  # add 필수
+    props: dict | None = None  # add: 초기값 / update: 지정 시 전체 교체
+    parent_id: str | None = None
+    sort_order: int | None = None
+    description: str | None = None
+
+
+class EditArtifactInput(SprintableInput):
+    artifact_id: str
+    operations: list[ArtifactNodeOperationInput]
+    summary: str | None = None  # 새 버전 변경 이유(선택)
 
 
 async def create_artifact(args: CreateArtifactInput) -> list[TextContent]:
@@ -103,6 +119,22 @@ async def add_artifact_comment(args: AddArtifactCommentInput) -> list[TextConten
         if args.mentioned_ids:
             body["mentioned_ids"] = args.mentioned_ids
         result = await client.post(f"/api/v2/visual-artifacts/{args.artifact_id}/comments", json=body)
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def edit_artifact(args: EditArtifactInput) -> list[TextContent]:
+    """artifact 요소를 add/update/delete로 편집 — 휴먼 딸깍 편집과 동일 엔드포인트를 경유해
+    "같은 객체를 양쪽이 편집"(AC4 왕복). 편집은 항상 새 버전을 만든다(무-mutate 버전 원칙).
+    대상자에게 artifact.updated 이벤트 전파."""
+    try:
+        body = {
+            "operations": [op.model_dump(exclude_none=True) for op in args.operations],
+        }
+        if args.summary:
+            body["summary"] = args.summary
+        result = await client.post(f"/api/v2/visual-artifacts/{args.artifact_id}/edit", json=body)
         return ok(result)
     except Exception as exc:
         return err(str(exc))

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -1,9 +1,10 @@
-"""S3-6: 시스템 콜 계약 검증 — 97개 도구 등록 + 스키마 무결성 (Phase 3 완료).
+"""S3-6: 시스템 콜 계약 검증 — 98개 도구 등록 + 스키마 무결성 (Phase 3 완료).
 
 E-SECURITY SEC-S1(확장): delete_story/task/epic/doc 4종 제거(에이전트 hard-delete 차단) —
 98개 → story만 제거해 97 → task/epic/doc 3종 추가 제거해 94. E-CANVAS C1-S3: create_artifact/
 get_artifact 2종 추가 — 94 → 96. E-SECURITY SEC-S8(확장): delete_sprint 제거 — 96 → 95.
-E-CANVAS C2-S6: list_artifact_comments/add_artifact_comment 2종 추가 — 95 → 97."""
+E-CANVAS C2-S6: list_artifact_comments/add_artifact_comment 2종 추가 — 95 → 97.
+E-CANVAS C3-S7: edit_artifact 1종 추가 — 97 → 98."""
 from __future__ import annotations
 
 import os
@@ -84,16 +85,17 @@ EXPECTED_TOOLS = {
     "sprintable_link_gate_to_task",
     # evidence (1) — E-VERIFY V0-S1
     "sprintable_add_evidence",
-    # visual artifacts (4) — E-CANVAS C1-S3 + C2-S6(코멘트)
+    # visual artifacts (5) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집)
     "sprintable_create_artifact", "sprintable_get_artifact",
     "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
+    "sprintable_edit_artifact",
     # smoke
     "ping",
 }
 
 
 def test_total_tool_count():
-    assert len(_TOOLS) == 97
+    assert len(_TOOLS) == 98
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_e_canvas_c3_s7_artifact_edit_realdb.py
+++ b/backend/tests/test_e_canvas_c3_s7_artifact_edit_realdb.py
@@ -1,6 +1,6 @@
 """E-CANVAS C3-S7(story 940266db): 딸깍 편집(REST) + MCP 편집이 공용 서비스 경로를 경유해
-같은 artifact를 편집(add/update/delete → 새 버전, node id 버전 간 안정)함을 실증. AC3(양방향
-이벤트 전파)·AC4(휴먼↔에이전트 편집 왕복) 검증."""
+같은 artifact를 편집(add/update/delete → 새 버전)함을 실증. AC3(양방향 이벤트 전파)·AC4
+(휴먼↔에이전트 편집 왕복)·source_comment_id(코멘트→편집 결과 연결, closed-loop) 검증."""
 from __future__ import annotations
 
 import os
@@ -375,6 +375,98 @@ async def test_ac4_agent_edits_human_creator_notified():
                 )
             )).scalars().all()
             assert len(rows) == 1, "휴먼 생성자에게 in-app 알림이 기록돼야 함"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_source_comment_id_links_edit_result_to_comment():
+    """closed-loop: 편집에 source_comment_id를 넘기면 새 버전에 링크되고(응답 노출), 코멘트
+    자체는 auto-resolve 안 됨(링크≠해결, 오르테가 승인 사항)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            comment_resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/comments",
+                json={"content": "이 버튼 라벨 바꿔주세요", "node_id": str(seeded["node_a_id"])},
+            )
+            comment_id = comment_resp.json()["data"]["id"]
+
+            edit_resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/edit",
+                json={
+                    "operations": [
+                        {"op": "update", "id": str(seeded["node_a_id"]), "props": {"content": "Fixed"}},
+                    ],
+                    "source_comment_id": comment_id,
+                },
+            )
+            assert edit_resp.status_code == 201, edit_resp.text
+            assert edit_resp.json()["data"]["version_source_comment_id"] == comment_id
+
+            comments_resp = await client.get(f"/api/v2/visual-artifacts/{seeded['artifact_id']}/comments")
+            comment_after = next(c for c in comments_resp.json()["data"] if c["id"] == comment_id)
+            assert comment_after["resolved"] is False, "링크는 resolve를 자동으로 하지 않아야 함"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_source_comment_id_cross_artifact_forgery_blocked():
+    """crux: source_comment_id가 다른 artifact 소속 코멘트를 가리키면 403(오늘 SEC 계열과 동형).
+    같은 org/project 내 서로 다른 두 artifact로 구성(org 경계 문제인 Q와는 다른 축)."""
+    from app.models.visual_artifact import ArtifactVersion, VisualArtifact
+
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            other_artifact = VisualArtifact(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_id"],
+                title="Other Artifact", source="created", latest_version_number=1,
+                created_by=seeded["creator_id"],
+            )
+            s.add(other_artifact)
+            await s.commit()
+            s.add(ArtifactVersion(
+                id=uuid.uuid4(), artifact_id=other_artifact.id, version_number=1,
+                created_by=seeded["creator_id"],
+            ))
+            await s.commit()
+            other_artifact_id = other_artifact.id
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            other_comment_resp = await client.post(
+                f"/api/v2/visual-artifacts/{other_artifact_id}/comments",
+                json={"content": "다른 artifact의 코멘트"},
+            )
+            other_comment_id = other_comment_resp.json()["data"]["id"]
+
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/edit",
+                json={
+                    "operations": [{"op": "add", "type": "text", "props": {}}],
+                    "source_comment_id": other_comment_id,
+                },
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()

--- a/backend/tests/test_e_canvas_c3_s7_artifact_edit_realdb.py
+++ b/backend/tests/test_e_canvas_c3_s7_artifact_edit_realdb.py
@@ -1,0 +1,380 @@
+"""E-CANVAS C3-S7(story 940266db): 딸깍 편집(REST) + MCP 편집이 공용 서비스 경로를 경유해
+같은 artifact를 편집(add/update/delete → 새 버전, node id 버전 간 안정)함을 실증. AC3(양방향
+이벤트 전파)·AC4(휴먼↔에이전트 편집 왕복) 검증."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session, *, creator_type: str = "agent"):
+    """org(project) + artifact(1 version, 2 nodes) — creator_type로 생성자를 human/agent 중
+    택해 AC4 양방향 이벤트 전파 검증에 사용."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+    from app.models.visual_artifact import ArtifactNode, ArtifactVersion, VisualArtifact
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    creator_user_id = None
+    if creator_type == "agent":
+        creator = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="creator-agent", is_active=True)
+        session.add(creator)
+        await session.commit()
+        creator_id = creator.id
+        session.add(ProjectAccess(
+            id=uuid.uuid4(), project_id=project.id, member_id=creator_id, permission="granted", role="member",
+        ))
+        await session.commit()
+    else:
+        user = User(id=uuid.uuid4(), email=f"creator-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+        session.add(user)
+        await session.commit()
+        creator_user_id = user.id
+        om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=user.id, role="member")
+        session.add(om)
+        await session.commit()
+        session.add(ProjectAccess(
+            id=uuid.uuid4(), project_id=project.id, org_member_id=om.id, permission="granted",
+        ))
+        await session.commit()
+        creator_id = om.id
+
+    artifact = VisualArtifact(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Edit Artifact",
+        source="created", latest_version_number=1, created_by=creator_id,
+    )
+    session.add(artifact)
+    await session.commit()
+
+    version = ArtifactVersion(id=uuid.uuid4(), artifact_id=artifact.id, version_number=1, created_by=creator_id)
+    session.add(version)
+    await session.commit()
+
+    node_a = ArtifactNode(
+        id=uuid.uuid4(), artifact_id=artifact.id, version_id=version.id,
+        type="text", props={"content": "Node A"}, sort_order=0,
+    )
+    node_b = ArtifactNode(
+        id=uuid.uuid4(), artifact_id=artifact.id, version_id=version.id,
+        type="text", props={"content": "Node B"}, sort_order=1,
+    )
+    session.add_all([node_a, node_b])
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "artifact_id": artifact.id,
+        "creator_id": creator_id, "creator_user_id": creator_user_id,
+        "node_a_id": node_a.id, "node_b_id": node_b.id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, project_id, user_id=None):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id or uuid.uuid4()), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_add_operation_creates_new_version_with_node():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/edit",
+                json={"operations": [{"op": "add", "type": "button", "props": {"label": "Click"}}]},
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()["data"]
+            assert body["version_number"] == 2
+            node_types = {n["type"] for n in body["nodes"]}
+            assert "button" in node_types
+            # 기존 노드 2개도 새 버전에 계승됨.
+            assert len(body["nodes"]) == 3
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_operation_changes_props_in_new_version():
+    """update 대상은 편집 시점 최신 버전의 id로 지정 — 결과는 props 내용으로 검증한다.
+    (ArtifactNode.id는 테이블 전역 PK라 버전마다 새 row=새 id — C1-S3 "버전마다 자기 소유
+    node row 세트" 설계 계승. cross-version 안정 식별은 op 호출 시점의 id로 대상만 지정하고,
+    응답의 새 id는 다음 편집에서 다시 조회해 얻는다.)"""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/edit",
+                json={"operations": [
+                    {"op": "update", "id": str(seeded["node_a_id"]), "props": {"content": "Node A Updated"}},
+                ]},
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()["data"]
+            contents = {n["props"].get("content") for n in body["nodes"]}
+            assert "Node A Updated" in contents
+            assert "Node A" not in contents  # 교체됐지 병행 존재 아님
+            assert "Node B" in contents  # 미편집 노드는 내용 그대로 계승
+            assert len(body["nodes"]) == 2  # 노드 수는 그대로(update는 add가 아님)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_delete_operation_removes_node_from_new_version():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/edit",
+                json={"operations": [{"op": "delete", "id": str(seeded["node_b_id"])}]},
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()["data"]
+            contents = {n["props"].get("content") for n in body["nodes"]}
+            assert "Node B" not in contents
+            assert "Node A" in contents
+            assert len(body["nodes"]) == 1
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_nonexistent_node_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/edit",
+                json={"operations": [{"op": "update", "id": str(uuid.uuid4()), "props": {}}]},
+            )
+            assert resp.status_code == 422, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_previous_version_nodes_untouched_after_edit():
+    """무-mutate 원칙: v1 조회 시 편집 전 상태 그대로(버전 전환은 무-mutate — C1-S3 설계 계승)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/edit",
+                json={"operations": [{"op": "delete", "id": str(seeded["node_b_id"])}]},
+            )
+            v1_resp = await client.get(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/versions/1",
+            )
+            assert v1_resp.status_code == 200
+            v1_node_ids = {n["id"] for n in v1_resp.json()["data"]["nodes"]}
+            assert str(seeded["node_b_id"]) in v1_node_ids, "v1은 편집 후에도 원본 유지돼야 함"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac4_human_edits_agent_creator_notified():
+    """AC4 왕복①: 생성자=에이전트, 편집자=휴먼 → 에이전트에게 artifact.updated 이벤트 전파."""
+    from sqlalchemy import select
+
+    from app.main import app
+    from app.models.event import Event
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, creator_type="agent")
+
+        human_editor_id = uuid.uuid4()
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], user_id=human_editor_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/edit",
+                json={"operations": [{"op": "add", "type": "text", "props": {}}]},
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Event).where(Event.org_id == seeded["org_id"], Event.event_type == "dispatched")
+            )).scalars().all()
+            payloads = [r.payload for r in rows]
+            assert any(p.get("event_type") == "artifact.updated" for p in payloads if isinstance(p, dict))
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac4_agent_edits_human_creator_notified():
+    """AC4 왕복②: 생성자=휴먼, 편집자=에이전트 → 휴먼에게 artifact.updated 이벤트 전파(양방향
+    실증 — 한쪽만 되면 왕복이 아니라 편도)."""
+    from sqlalchemy import select
+
+    from app.main import app
+    from app.models.notification import Notification
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, creator_type="human")
+
+        agent_editor = None
+        async with Session() as s:
+            from app.models.member import Member
+            from app.models.project_access import ProjectAccess
+            agent_editor = Member(
+                id=uuid.uuid4(), org_id=seeded["org_id"], type="agent", name="editor-agent", is_active=True,
+            )
+            s.add(agent_editor)
+            await s.commit()
+            s.add(ProjectAccess(
+                id=uuid.uuid4(), project_id=seeded["project_id"], member_id=agent_editor.id,
+                permission="granted", role="member",
+            ))
+            await s.commit()
+            agent_editor_id = agent_editor.id
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"], user_id=agent_editor_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/edit",
+                json={"operations": [{"op": "add", "type": "text", "props": {}}]},
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Notification).where(
+                    Notification.org_id == seeded["org_id"],
+                    Notification.user_id == seeded["creator_user_id"],
+                    Notification.type == "artifact.updated",
+                )
+            )).scalars().all()
+            assert len(rows) == 1, "휴먼 생성자에게 in-app 알림이 기록돼야 함"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
E-CANVAS C3-S7(story `940266db`) — Blueprint §F2/C3. 휴먼 딸깍(REST)과 에이전트 MCP가 같은 엔드포인트(`POST /{id}/edit`)를 경유해 "같은 객체를 양쪽이 편집"을 보장 — 단일 서비스 함수(`_apply_artifact_edit`)로 합류(서로 다른 코드 경로면 drift 위험).

- `ArtifactNodeOperation`(op: add|update|delete) 기반 배치 편집 — 현재 최신 버전의 node 집합에 연산 적용 후 새 `ArtifactVersion` + node row 세트 생성(C1-S3 무-mutate 버전 원칙 계승).
- ⚠️ **구현 중 발견·즉시 수정한 버그**: 최초 설계는 node id가 버전 간 안정하다고 가정했으나 `ArtifactNode.id`는 테이블 **전역** PK(버전별 복합키 아님)라 이전 버전 id를 새 row에 재사용하면 PK 충돌(500). update/delete op은 편집 시점 최신 버전의 id로 대상만 지정하고, 실제 INSERT는 매번 새 id 생성(parent_id 트리 참조는 같은 편집 내 신규 부모면 리매핑)으로 고침 — **realdb 테스트가 이 갭을 직접 잡아냈다**.
- MCP 도구(`sprintable_edit_artifact`) — REST와 동일 요청 스키마.
- AC3(artifact.updated 이벤트 양방향 전파) — `dispatch_notification` 재사용, 대상=artifact 생성자(편집자 본인 제외). C2-S6 `comment.created`와 동형 패턴.
- **`source_comment_id`(closed-loop, 오르테가·유나·미르코 합의)**: migration 0174(additive) `artifact_versions.source_comment_id`(FK, ON DELETE SET NULL) — 이 편집 커밋이 어느 코멘트에 응답했는지 링크. cross-artifact 위조 차단(403)·**auto-resolve 안 함**(링크≠해결, 코멘트 resolve는 별도 명시 액션).

## Test plan
- [x] realdb 9건: add/update/delete·존재하지 않는 update 대상 422·v1 무-mutate 확認·AC4 양방향 왕복(휴먼편집→에이전트 생성자 알림/에이전트편집→휴먼 생성자 알림)·source_comment_id 링크+resolve 미변경·cross-artifact 위조 403 차단
- [x] 기존 C1-S3/C2-S6/C1-S5/toolset 테스트 무변경 통과
- [x] 전체 스위트(`-m "not destructive_schema"`) 3526 passed, baseline 7건(무관) 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)