### PR TITLE
feat(e-canvas): C4-S8 — 정본화(canonicalize) 게이트 재사용

### DIFF
--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -817,3 +817,48 @@ async def edit_artifact(
     if detail is None:
         return _err("NOT_FOUND", "Artifact version not found", 404)
     return _ok(detail.model_dump(mode="json"), status=201)
+
+
+# ─── Canonicalize (E-CANVAS C4-S8, story a5118cb0) ────────────────────────────
+# crux(유나 handoff `e-canvas-c4-canonical-handoff`): 정본화 = 합의된 계약(§1, 감시 관문 아님).
+# 기존 E-DG Decision Gate 재사용(신규 게이트 발명 금지) — 제안(이 엔드포인트)이 Gate를 만들고,
+# 승인/반려는 **기존 범용** `POST /api/v2/gates/{id}/transition`이 처리(human-only authz 이미
+# 강제됨). 여기서는 gate_service._resolve_artifact_canonicalize_gate가 해소를 anchor_version
+# set(승인)/재논의 코멘트(반려)로 연결.
+
+
+@router.post("/{id}/versions/{version_number}/canonicalize", status_code=201)
+async def propose_canonical_version(
+    id: uuid.UUID,
+    version_number: int,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """정본으로 제안 — AI는 제안만(MCP도 동일 엔드포인트), 승인은 always-HITL(gate_service).
+    이미 pending 제안이 있으면 멱등(create_gate 자체 멱등 재사용)."""
+    from app.services.gate_service import create_gate
+
+    org_id, project_id = _get_org_project(auth)
+    if not org_id or not project_id:
+        return _err("FORBIDDEN", "org_id/project_id required", 403)
+    artifact = await _get_artifact_or_404(session, org_id, project_id, id)
+    if artifact is None:
+        return _err("NOT_FOUND", "Artifact not found", 404)
+    version = await _get_version_or_404(session, artifact.id, version_number)
+    if version is None:
+        return _err("NOT_FOUND", "Artifact version not found", 404)
+
+    proposer_id = uuid.UUID(auth.user_id)
+    gate = await create_gate(
+        session, org_id, artifact.id, "visual_artifact", "artifact_canonicalize",
+        proposer_id, uuid.uuid4(),  # role_id: always-manual이라 disposition 미사용(placeholder)
+        neutral_facts={
+            "version_number": version_number, "requested_by_member_id": str(proposer_id),
+            "artifact_title": artifact.title,
+        },
+    )
+    await session.commit()
+    return _ok({
+        "gate_id": str(gate.id), "status": gate.status,
+        "artifact_id": str(artifact.id), "version_number": version_number,
+    }, status=201)

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -51,7 +51,10 @@ _DISPOSITION_TO_STATUS: dict[str, str] = {
 # disposition auto-pass/auto-deny 제외(인간 deliberation 이 정책 자동결정보다 우선).
 # 'loop_decision'(E-LOOP-LEDGER S5): variant 선택도 동일 이유로 항상 human pending — GATE_TYPES에도
 # 미등록(doc_approval과 동일 선례. org gate override 설정 대상에서 제외=애초에 자동화 불가 명시).
-_ALWAYS_MANUAL_GATE_TYPES: frozenset[str] = frozenset({"doc_approval", "loop_decision"})
+# 'artifact_canonicalize'(E-CANVAS C4-S8): 정본화=계약(§1) — org auto posture 무관 항상 HITL.
+_ALWAYS_MANUAL_GATE_TYPES: frozenset[str] = frozenset(
+    {"doc_approval", "loop_decision", "artifact_canonicalize"}
+)
 
 
 async def create_gate(
@@ -154,6 +157,8 @@ async def transition_gate(
         await _advance_story_on_merge_approve(session, gate, new_status)
         # E-DG doc-gate(48f064e5): doc 결재 게이트 approve→confirmed·reject→denied.
         await _resolve_doc_gate(session, gate, new_status)
+        # E-CANVAS C4-S8(story a5118cb0): 정본화 게이트 approve→anchor_version set·reject→재논의 코멘트.
+        await _resolve_artifact_canonicalize_gate(session, gate, new_status)
         # HITL crux(story 7726a003) — A2A task INPUT_REQUIRED 복귀. writer 미배선이라 오늘은 no-op.
         await _resume_a2a_task_on_gate_resolve(session, gate, new_status)
 
@@ -375,6 +380,65 @@ async def _resolve_doc_gate(session: AsyncSession, gate: Gate, new_status: str) 
         return  # 멱등·pending 아니면 no-op(double-resolve/취소 방어).
     doc.status = "confirmed" if new_status == "approved" else "denied"
     await session.flush()
+
+
+async def _resolve_artifact_canonicalize_gate(session: AsyncSession, gate: Gate, new_status: str) -> None:
+    """E-CANVAS C4-S8(story a5118cb0): 정본화 게이트 해소.
+
+    approve → anchor_version = 제안된 버전 번호(neutral_facts.version_number)·artifact.canonicalized
+    이벤트 전파. reject → **destructive 색 금지, info "재논의"** — resolution_note(사유)가 있으면
+    제안자에게 C2 앵커 스레드로 코멘트 전파(§5: 반려=학습 신호·죽은 반려 금지). anchor_version은
+    변경 안 함(멱등 no-op이 정답 — 재논의는 새 제안 사이클에서 다시 결정).
+    """
+    if gate.work_item_type != "visual_artifact" or gate.gate_type != "artifact_canonicalize":
+        return
+    if new_status not in ("approved", "rejected"):
+        return
+
+    from app.models.visual_artifact import ArtifactComment, VisualArtifact
+
+    artifact = (await session.execute(
+        select(VisualArtifact).where(
+            VisualArtifact.id == gate.work_item_id,
+            VisualArtifact.org_id == gate.org_id,
+            VisualArtifact.deleted_at.is_(None),
+        )
+    )).scalar_one_or_none()
+    if artifact is None:
+        return  # 멱등·삭제된 artifact no-op(방어심층).
+
+    facts = gate.neutral_facts or {}
+    version_number = facts.get("version_number")
+    requested_by = facts.get("requested_by_member_id")
+
+    if new_status == "approved":
+        if version_number is not None:
+            artifact.anchor_version = int(version_number)
+            await session.flush()
+        target_ids = {artifact.created_by}
+        if requested_by:
+            target_ids.add(uuid.UUID(str(requested_by)))
+        if gate.resolver_id:
+            target_ids.discard(gate.resolver_id)  # 승인자 본인 알림 제외
+        target_ids.discard(None)
+        if target_ids:
+            from app.services.notification_dispatch import dispatch_notification
+            await dispatch_notification(
+                session, org_id=gate.org_id, event_type="artifact.canonicalized",
+                target_member_ids=list(target_ids),
+                title=f"정본 확定: {artifact.title}",
+                body=f"v{version_number}이(가) 정본으로 확定됐습니다." if version_number else None,
+                reference_type="visual_artifact", reference_id=artifact.id,
+                source_project_id=artifact.project_id,
+            )
+    else:  # rejected — info 재논의(§5: destructive 색 절대 금지). 사유=코멘트로 제안자에게 전파.
+        if gate.resolution_note and requested_by:
+            session.add(ArtifactComment(
+                id=uuid.uuid4(), artifact_id=artifact.id, org_id=gate.org_id,
+                project_id=artifact.project_id, content=gate.resolution_note,
+                created_by=gate.resolver_id or artifact.created_by,
+            ))
+            await session.flush()
 
 
 async def _resume_a2a_task_on_gate_resolve(session: AsyncSession, gate: Gate, new_status: str) -> None:

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -65,12 +65,12 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     "sprintable_add_evidence",
     # E-CANVAS C1-S3(story 8bace49e): create_artifact/get_artifact — story/epic/doc 中 어디에도
     # (또는 아무데도) 붙을 수 있는 시각 산출물 생성/조회. add_evidence와 동형(단일 도메인 그룹에
-    # 묶기 애매한 cross-cutting 자기생성 유틸). C2-S6(story 0edca31e) 코멘트 2종 + C3-S7
-    # (story 940266db) edit_artifact 1종 추가 — 5개로 늘었으나 여전히 story/epic/doc 무관
-    # cross-cutting이라 always-allow 유지(C4가 더 늘리면 그때 전용 "canvas" 그룹 신설 고려).
+    # 묶기 애매한 cross-cutting 자기생성 유틸). C2-S6(코멘트 2종)+C3-S7(edit 1종)+C4-S8(정본
+    # 제안 1종) 추가 — 6개(전신 C0~C5 트랙의 마지막 BE 배선). 여전히 story/epic/doc 무관
+    # cross-cutting이라 always-allow 유지(추가 성장 시 전용 "canvas" 그룹 신설 고려).
     "sprintable_create_artifact", "sprintable_get_artifact",
     "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
-    "sprintable_edit_artifact",
+    "sprintable_edit_artifact", "sprintable_propose_canonical_version",
 })
 
 # scope 토큰: 그룹명 외에 read/write(레거시·전체 비파괴 의미), admin/destructive(파괴적 허용)
@@ -290,10 +290,10 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_link_gate_to_task",
     # evidence (E-VERIFY V0-S1)
     "sprintable_add_evidence",
-    # visual artifacts (E-CANVAS C1-S3 + C2-S6 코멘트 + C3-S7 편집)
+    # visual artifacts (E-CANVAS C1-S3 + C2-S6 코멘트 + C3-S7 편집 + C4-S8 정본 제안)
     "sprintable_create_artifact", "sprintable_get_artifact",
     "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
-    "sprintable_edit_artifact",
+    "sprintable_edit_artifact", "sprintable_propose_canonical_version",
 )
 
 # picker 표시 순서(비파괴 먼저). order 필드 힌트 + 배열 순서 둘 다 이 순서.

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -31,8 +31,9 @@ from .tools.a2a import LinkGateToTaskInput, link_gate_to_task
 from .tools.evidence import AddEvidenceInput, add_evidence
 from .tools.visual_artifacts import (
     AddArtifactCommentInput, CreateArtifactInput, EditArtifactInput, GetArtifactInput,
-    ListArtifactCommentsInput,
+    ListArtifactCommentsInput, ProposeCanonicalInput,
     add_artifact_comment, create_artifact, edit_artifact, get_artifact, list_artifact_comments,
+    propose_canonical_version,
 )
 from .tools.agent_runs import (
     EmitEventInput, PollEventsInput, UpdateRunStatusInput,
@@ -494,7 +495,7 @@ _TOOL_DEFS: list[tuple] = [
      "done을 스스로 증명하는 자기 서명 첨부(PR·배포·지표·발행물 링크 등) — story/task에 evidence"
      " 남김. 선택제(첨부 안 해도 무불이익).",
      AddEvidenceInput, add_evidence),
-    # Visual artifacts (5) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집)
+    # Visual artifacts (6) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안)
     ("sprintable_create_artifact",
      "시각 산출물 생성(에이전트 생성 입구) — 트리(nodes[])로 구조화. 임포트된 raw HTML/이미지는"
      " type=\"html_blob\" 노드 하나로 감싸도 됨.",
@@ -511,6 +512,9 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_edit_artifact",
      "artifact 요소 add/update/delete 편집 — 휴먼 딸깍과 같은 경로, 항상 새 버전 생성·이벤트 전파.",
      EditArtifactInput, edit_artifact),
+    ("sprintable_propose_canonical_version",
+     "이 버전을 정본으로 제안(게이트 생성) — 제안만, 승인/반려는 항상 휴먼.",
+     ProposeCanonicalInput, propose_canonical_version),
     # Chat (3)
     ("sprintable_send_chat_message",
      "conversation thread에 채팅 메시지 발송.",

--- a/backend/sprintable_mcp/tools/visual_artifacts.py
+++ b/backend/sprintable_mcp/tools/visual_artifacts.py
@@ -1,5 +1,6 @@
-"""시각 산출물(visual_artifact) MCP 도구(5개) — E-CANVAS C1-S3(story 8bace49e)+
-C2-S6(story 0edca31e, 코멘트 왕복)+C3-S7(story 940266db, 편집 왕복)."""
+"""시각 산출물(visual_artifact) MCP 도구(6개) — E-CANVAS C1-S3(story 8bace49e)+
+C2-S6(story 0edca31e, 코멘트 왕복)+C3-S7(story 940266db, 편집 왕복)+C4-S8(story a5118cb0,
+정본 제안 — 승인은 always-HITL이라 MCP 미제공)."""
 from __future__ import annotations
 
 from mcp.types import TextContent
@@ -60,6 +61,11 @@ class EditArtifactInput(SprintableInput):
     operations: list[ArtifactNodeOperationInput]
     summary: str | None = None  # 새 버전 변경 이유(선택)
     source_comment_id: str | None = None  # 이 편집이 응답한 코멘트(선택, closed-loop)
+
+
+class ProposeCanonicalInput(SprintableInput):
+    artifact_id: str
+    version_number: int
 
 
 async def create_artifact(args: CreateArtifactInput) -> list[TextContent]:
@@ -138,6 +144,18 @@ async def edit_artifact(args: EditArtifactInput) -> list[TextContent]:
         if args.source_comment_id:
             body["source_comment_id"] = args.source_comment_id
         result = await client.post(f"/api/v2/visual-artifacts/{args.artifact_id}/edit", json=body)
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def propose_canonical_version(args: ProposeCanonicalInput) -> list[TextContent]:
+    """이 버전을 정본으로 제안(E-DG 게이트 생성) — 제안만, **승인은 항상 휴먼**(에이전트는
+    이 도구로 제안까지만 가능. 승인/반려는 POST /api/v2/gates/{id}/transition, human-only)."""
+    try:
+        result = await client.post(
+            f"/api/v2/visual-artifacts/{args.artifact_id}/versions/{args.version_number}/canonicalize",
+        )
         return ok(result)
     except Exception as exc:
         return err(str(exc))

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -85,17 +85,17 @@ EXPECTED_TOOLS = {
     "sprintable_link_gate_to_task",
     # evidence (1) — E-VERIFY V0-S1
     "sprintable_add_evidence",
-    # visual artifacts (5) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집)
+    # visual artifacts (6) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안)
     "sprintable_create_artifact", "sprintable_get_artifact",
     "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
-    "sprintable_edit_artifact",
+    "sprintable_edit_artifact", "sprintable_propose_canonical_version",
     # smoke
     "ping",
 }
 
 
 def test_total_tool_count():
-    assert len(_TOOLS) == 98
+    assert len(_TOOLS) == 99
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_e_canvas_c4_s8_canonicalize_realdb.py
+++ b/backend/tests/test_e_canvas_c4_s8_canonicalize_realdb.py
@@ -1,0 +1,369 @@
+"""E-CANVAS C4-S8(story a5118cb0): 정본화(canonicalize) — 기존 E-DG Decision Gate 재사용 실증.
+AI는 제안만(propose), 승인/반려는 항상 휴먼(범용 POST /api/v2/gates/{id}/transition 경유).
+approve→anchor_version set+artifact.canonicalized 전파, reject→anchor_version 불변+재논의 코멘트."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project) + artifact(1 version, agent 생성) + 승인용 실 휴먼(User+OrgMember).
+    propose 호출은 auth.user_id를 그대로 created_by/requested_by로 쓰므로(멤버 조회 없음)
+    creator == proposer(agent, 자기 산출물 제안)로 단순화. approve/reject만 resolve_member를
+    타므로 그 경로에만 실 휴먼 row가 필요하다."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+    from app.models.visual_artifact import ArtifactVersion, VisualArtifact
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    creator = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="creator-agent", is_active=True)
+    session.add(creator)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=creator.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    approver_user = User(id=uuid.uuid4(), email=f"approver-{uuid.uuid4().hex[:8]}@test.com", hashed_password="x")
+    session.add(approver_user)
+    await session.commit()
+    approver_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=approver_user.id, role="member")
+    session.add(approver_om)
+    await session.commit()
+
+    artifact = VisualArtifact(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Canon Artifact",
+        source="created", latest_version_number=1, created_by=creator.id,
+    )
+    session.add(artifact)
+    await session.commit()
+
+    version = ArtifactVersion(id=uuid.uuid4(), artifact_id=artifact.id, version_number=1, created_by=creator.id)
+    session.add(version)
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "artifact_id": artifact.id,
+        "creator_id": creator.id, "approver_user_id": approver_user.id, "approver_om_id": approver_om.id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_propose_app(app, Session, org_id, project_id, user_id):
+    """propose 호출용 — get_db + get_current_user(app_metadata.org_id/project_id)."""
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="proposer@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+async def _setup_transition_app(app, Session, org_id, user_id):
+    """gates/{id}/transition 호출용 — get_db + get_current_user + get_verified_org_id
+    (resolve_member가 이 조합을 타서 JWT 휴먼 분기로 해소됨, api_key_id 미설정)."""
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="approver@test", claims={"app_metadata": {}})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_propose_creates_pending_gate():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_propose_app(app, Session, seeded["org_id"], seeded["project_id"], seeded["creator_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/versions/1/canonicalize",
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()["data"]
+            assert body["status"] == "pending"  # always-manual — org auto-posture 무관
+            assert body["artifact_id"] == str(seeded["artifact_id"])
+            assert body["version_number"] == 1
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_propose_idempotent_returns_same_gate():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_propose_app(app, Session, seeded["org_id"], seeded["project_id"], seeded["creator_id"])
+        client = _client_for(app)
+        try:
+            r1 = await client.post(f"/api/v2/visual-artifacts/{seeded['artifact_id']}/versions/1/canonicalize")
+            r2 = await client.post(f"/api/v2/visual-artifacts/{seeded['artifact_id']}/versions/1/canonicalize")
+            assert r1.json()["data"]["gate_id"] == r2.json()["data"]["gate_id"]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_propose_nonexistent_version_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_propose_app(app, Session, seeded["org_id"], seeded["project_id"], seeded["creator_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/versions/99/canonicalize",
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_approve_sets_anchor_version_and_notifies_creator():
+    from sqlalchemy import select
+
+    from app.main import app
+    from app.models.event import Event
+    from app.models.visual_artifact import VisualArtifact
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_propose_app(app, Session, seeded["org_id"], seeded["project_id"], seeded["creator_id"])
+        client = _client_for(app)
+        try:
+            propose_resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/versions/1/canonicalize",
+            )
+            gate_id = propose_resp.json()["data"]["gate_id"]
+        finally:
+            await client.aclose()
+
+        app.dependency_overrides.clear()
+        await _setup_transition_app(app, Session, seeded["org_id"], seeded["approver_user_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/gates/{gate_id}/transition", json={"status": "approved"})
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            artifact = (await s.execute(
+                select(VisualArtifact).where(VisualArtifact.id == seeded["artifact_id"])
+            )).scalar_one()
+            assert artifact.anchor_version == 1
+
+            rows = (await s.execute(
+                select(Event).where(Event.org_id == seeded["org_id"], Event.event_type == "dispatched")
+            )).scalars().all()
+            payloads = [r.payload for r in rows]
+            assert any(
+                p.get("event_type") == "artifact.canonicalized" for p in payloads if isinstance(p, dict)
+            ), f"artifact.canonicalized 이벤트 미전파: {payloads}"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_reject_does_not_set_anchor_and_creates_redisc_comment():
+    from sqlalchemy import select
+
+    from app.main import app
+    from app.models.visual_artifact import ArtifactComment, VisualArtifact
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_propose_app(app, Session, seeded["org_id"], seeded["project_id"], seeded["creator_id"])
+        client = _client_for(app)
+        try:
+            propose_resp = await client.post(
+                f"/api/v2/visual-artifacts/{seeded['artifact_id']}/versions/1/canonicalize",
+            )
+            gate_id = propose_resp.json()["data"]["gate_id"]
+        finally:
+            await client.aclose()
+
+        app.dependency_overrides.clear()
+        await _setup_transition_app(app, Session, seeded["org_id"], seeded["approver_user_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/gates/{gate_id}/transition",
+                json={"status": "rejected", "note": "아직 승인 안 됨 — 색상 토큰 재논의 필요"},
+            )
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            artifact = (await s.execute(
+                select(VisualArtifact).where(VisualArtifact.id == seeded["artifact_id"])
+            )).scalar_one()
+            assert artifact.anchor_version is None, "반려는 anchor_version을 바꾸지 않아야 함(멱등 no-op)"
+
+            comments = (await s.execute(
+                select(ArtifactComment).where(ArtifactComment.artifact_id == seeded["artifact_id"])
+            )).scalars().all()
+            assert len(comments) == 1
+            assert comments[0].content == "아직 승인 안 됨 — 색상 토큰 재논의 필요"
+            assert comments[0].created_by == seeded["approver_om_id"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mcp_propose_canonical_version_roundtrip():
+    """AI 제안 왕복: MCP sprintable_propose_canonical_version → gate pending 확認."""
+    import json as _json
+    import os as _os
+
+    import httpx
+
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_propose_app(app, Session, seeded["org_id"], seeded["project_id"], seeded["creator_id"])
+
+        _os.environ.setdefault("SPRINTABLE_API_URL", "http://test")
+        _os.environ.setdefault("AGENT_API_KEY", "sk_test")
+
+        from sprintable_mcp.tools.visual_artifacts import ProposeCanonicalInput, propose_canonical_version
+        from sprintable_mcp import api_client as api_client_mod
+
+        transport = httpx.ASGITransport(app=app)
+        real_client = api_client_mod.client
+        test_http_client = httpx.AsyncClient(transport=transport, base_url="http://test")
+
+        async def _post(path, **kwargs):
+            r = await test_http_client.post(path, **kwargs)
+            r.raise_for_status()
+            return r.json()["data"]
+
+        orig_post = real_client.post
+        real_client.post = _post
+        try:
+            result = await propose_canonical_version(ProposeCanonicalInput(
+                artifact_id=str(seeded["artifact_id"]), version_number=1,
+            ))
+            body = _json.loads(result[0].text)
+            assert body["status"] == "pending"
+        finally:
+            real_client.post = orig_post
+            await test_http_client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- story a5118cb0 — E-CANVAS C4-S8, 유나 handoff(`e-canvas-c4-canonical-handoff`) 기반.
- 기존 E-DG Decision Gate 재사용(신규 게이트 발명 금지): `POST /{id}/versions/{n}/canonicalize`가 `gate_type=artifact_canonicalize` Gate를 생성(멱등)하고, 승인/반려는 기존 범용 `POST /api/v2/gates/{id}/transition`이 처리(human-only authz 이미 강제됨 — 신규 approve/reject 엔드포인트 0).
- `_ALWAYS_MANUAL_GATE_TYPES`에 `artifact_canonicalize` 추가 — org auto-posture 무관 항상 HITL(정본화=합의된 계약, 감시 관문 아님).
- 해소: approve → `anchor_version` set + `artifact.canonicalized` 이벤트 전파 / reject → `anchor_version` 불변(멱등 no-op) + `resolution_note`를 재논의 코멘트로 전파(destructive 색 금지).
- MCP `sprintable_propose_canonical_version` — AI는 제안만, 승인 도구는 미제공.
- E-CANVAS BE 트랙(C1-S3~C4-S8) 마지막 조각 — 미르코 FE 언블록 완료.

## Test plan
- [x] realdb 6종: propose 생성/idempotent/nonexistent-404, approve(anchor_version+event), reject(anchor 불변+comment), MCP round-trip — 전부 pass
- [x] `tests/mcp/test_contract.py`/`tests/test_toolset_catalog.py` tool count 98→99 갱신 + 카탈로그 그룹 배선 — pass
- [x] full suite(`-m "not destructive_schema"`) 3531 passed, 7 pre-existing baseline failures만(무관·env/hardcoded-count)
- [x] 신규 컬럼/마이그레이션 없음(anchor_version은 C1-S3에서 이미 준비된 컬럼)

🤖 Generated with [Claude Code](https://claude.com/claude-code)