### PR TITLE
fix(e-security): SEC-S8 R — create_artifact 링크 project-scope 검증

### DIFF
--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -55,22 +55,28 @@ def _get_org_project(auth: AuthContext) -> tuple[uuid.UUID | None, uuid.UUID | N
 _LINK_TABLES = {"story_id": "stories", "epic_id": "epics", "doc_id": "docs"}
 
 
-async def _assert_link_target_in_org(
-    session: AsyncSession, caller_org_id: uuid.UUID, body: CreateArtifactRequest,
+async def _assert_link_target_in_scope(
+    session: AsyncSession, caller_org_id: uuid.UUID, caller_project_id: uuid.UUID, body: CreateArtifactRequest,
 ) -> None:
-    """E-CANVAS C1-S3(story 8bace49e) crux 확認 사항: story_id/epic_id/doc_id 연결 시 SEC-S6/S7
-    공통 가드(`assert_target_in_caller_org`) 재사용 — tenant 격리를 신규 기능에 재발시키지 않는다."""
+    """E-CANVAS C1-S3(story 8bace49e) crux + E-SECURITY SEC-S8 R(까심 전수스윕): story_id/epic_id/
+    doc_id 연결 시 SEC-S6/S7 공통 가드(`assert_target_in_caller_org`)로 org만 대조하고 project는
+    안 봐서, 같은 org 다른 project 스토리/에픽/doc에 artifact를 링크할 수 있었다(G/Q와 동형
+    project-scope 부재). org 대조와 동일 지점에서 target의 project_id도 함께 조회해 caller
+    project와 대조 — 불일치/미존재 모두 404(존재 비노출)."""
     for field, table in _LINK_TABLES.items():
         target_id = getattr(body, field)
         if target_id is None:
             continue
-        target_org_id = (await session.execute(
-            text(f"SELECT org_id FROM {table} WHERE id = :id"),  # noqa: S608 — table은 고정 allowlist(_LINK_TABLES), 요청값 아님
+        row = (await session.execute(
+            text(f"SELECT org_id, project_id FROM {table} WHERE id = :id"),  # noqa: S608 — table은 고정 allowlist(_LINK_TABLES), 요청값 아님
             {"id": target_id},
-        )).scalar_one_or_none()
-        assert_target_in_caller_org(
-            caller_org_id, target_org_id, not_found_detail=f"{field.replace('_id', '').title()} not found",
-        )
+        )).first()
+        target_org_id = row.org_id if row is not None else None
+        target_project_id = row.project_id if row is not None else None
+        not_found_detail = f"{field.replace('_id', '').title()} not found"
+        assert_target_in_caller_org(caller_org_id, target_org_id, not_found_detail=not_found_detail)
+        if target_project_id != caller_project_id:
+            raise HTTPException(status_code=404, detail=not_found_detail)
 
 
 @router.post("", status_code=201)
@@ -83,7 +89,7 @@ async def create_artifact(
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
 
-    await _assert_link_target_in_org(session, org_id, body)
+    await _assert_link_target_in_scope(session, org_id, project_id, body)
 
     created_by = uuid.UUID(auth.user_id)
     artifact = VisualArtifact(

--- a/backend/tests/test_e_security_sec_s8_r_artifact_link_project_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_r_artifact_link_project_scope_realdb.py
@@ -1,0 +1,210 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) R: create_artifact story_id/epic_id/doc_id 링크의
+project-scope 미검증 봉쇄 실증.
+
+`_assert_link_target_in_org`(구)가 target의 org_id만 대조하고 project_id는 안 봐서, 같은 org
+내 다른 project의 story/epic/doc에 artifact를 링크할 수 있었다(G/Q와 동형 project-scope
+부재). fix=`_assert_link_target_in_scope`가 target project_id도 caller project_id와 대조."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a, project_b) + story_a(project_a)/epic_a(project_a)/doc_a(project_a) +
+    story_b/epic_b/doc_b(project_b, 같은 org) — same-org cross-project 링크 시도용."""
+    from app.models.doc import Doc
+    from app.models.organization import Organization
+    from app.models.pm import Epic, Story
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    story_a = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Story A", status="backlog")
+    story_b = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Story B", status="backlog")
+    epic_a = Epic(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Epic A")
+    epic_b = Epic(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Epic B")
+    doc_a = Doc(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Doc A",
+        slug=f"doc-a-{uuid.uuid4().hex[:8]}", content="",
+    )
+    doc_b = Doc(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Doc B",
+        slug=f"doc-b-{uuid.uuid4().hex[:8]}", content="",
+    )
+    session.add_all([story_a, story_b, epic_a, epic_b, doc_a, doc_b])
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "story_a_id": story_a.id, "story_b_id": story_b.id,
+        "epic_a_id": epic_a.id, "epic_b_id": epic_b.id,
+        "doc_a_id": doc_a.id, "doc_b_id": doc_b.id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, project_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(uuid.uuid4()), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_create_artifact_same_org_cross_project_story_link_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Injected", "story_id": str(seeded["story_b_id"])},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_artifact_same_org_cross_project_epic_link_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Injected", "epic_id": str(seeded["epic_b_id"])},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_artifact_same_org_cross_project_doc_link_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Injected", "doc_id": str(seeded["doc_b_id"])},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_artifact_same_project_story_link_still_works():
+    """회귀: same-org same-project 링크는 여전히 정상(과차단 아님)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Legit", "story_id": str(seeded["story_a_id"])},
+            )
+            assert resp.status_code == 201, resp.text
+            assert resp.json()["data"]["story_id"] == str(seeded["story_a_id"])
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- E-SECURITY SEC-S8(story 83ea3d6a) R — 까심 전수스윕 인접갭(G/Q와 동형).
- `_assert_link_target_in_org`가 story_id/epic_id/doc_id 연결 대상의 org_id만 대조하고 project_id는 확인하지 않아, 같은 org 내 다른 project의 story/epic/doc에 artifact를 링크할 수 있었다.
- `_assert_link_target_in_scope`로 개명 — 기존 `assert_target_in_caller_org` 재사용은 그대로, target project_id를 caller project_id와 추가 대조(불일치/미존재 모두 404, 존재 비노출 유지).

## Test plan
- [x] realdb 4건: story/epic/doc cross-project 링크 404 + same-project 링크는 여전히 정상(과차단 아님) — pass
- [x] 기존 C1-S3 cross-org 테스트 회귀 없음(org 대조 로직 그대로) — pass
- [x] full suite(`-m "not destructive_schema"`) 3536 passed, 7 pre-existing baseline failures만(무관)
- [x] 신규 마이그레이션 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)