### PR TITLE
fix(e-security): SEC-S8 P — 에이전트 role-rank 격상(mixed-role cross-project) 봉쇄

### DIFF
--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -107,11 +107,19 @@ async def create_org_agent(
         # scope_mode='projects'로 P2(본인 무권한 project)나 scope_mode='org'로 org 전체에
         # 새 에이전트+API키를 찍어낼 수 있었다(grant 대상과 검증 대상 불일치). project_ids
         # 전원에 대해 admin role을 요구 — 하나라도 admin이 아니면 전체 요청 차단.
-        from app.services.project_auth import has_project_role
+        from app.services.project_auth import get_project_role, has_project_role
         for pid in project_ids:
             if not await has_project_role(session, actor.id, pid, min_role="admin"):
                 raise HTTPException(status_code=403, detail="project admin/owner role required to manage members")
-        if _ROLE_RANK.get(body.role, 1) > _ROLE_RANK.get(actor.role, 1):
+        # E-SECURITY SEC-S8(story 83ea3d6a) P 자매 갭(fix-on-sight, create_team_member와 동일
+        # `_resolve_actor().first()` 비결정 row-pick 원인): actor.role이 grant 대상과 무관한
+        # project의 role일 수 있어, scope_mode='org'|'projects'로 여러 project_ids 전원에 대해
+        # get_project_role의 최솟값(가장 낮은 role)으로 비교 — 하나라도 부족하면 격상 차단.
+        actor_ranks = [
+            _ROLE_RANK.get(await get_project_role(session, actor.id, pid), 1) for pid in project_ids
+        ]
+        actor_rank = min(actor_ranks) if actor_ranks else 1
+        if _ROLE_RANK.get(body.role, 1) > actor_rank:
             raise HTTPException(status_code=403, detail="Cannot assign role higher than your own")
         if body.name == actor.name:
             raise HTTPException(status_code=400, detail="Agent cannot create a member with the same name as itself")

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -168,7 +168,7 @@ async def create_team_member(
     # project)로 역할을 검사하던 것도 `body.project_id`(실제 target)로 정정(잠재적 자기-분기
     # target 불일치도 함께 봉합). auth.user_id는 API키(에이전트)=member.id·JWT(휴먼)=users.id라
     # has_project_role이 이미 양쪽을 다 매칭하는 단일 호출로 충분(신규 분기 불요).
-    from app.services.project_auth import assert_target_in_caller_org, has_project_role
+    from app.services.project_auth import assert_target_in_caller_org, get_project_role, has_project_role
 
     target_project_org_id = (await session.execute(
         text("SELECT org_id FROM projects WHERE id = :pid"), {"pid": str(body.project_id)},
@@ -180,9 +180,15 @@ async def create_team_member(
         raise HTTPException(status_code=403, detail="project admin/owner role required to manage members")
 
     if actor is not None and actor.type == "agent":
-        # AC3: target.role > actor.role → 403 (격상 차단)
+        # E-SECURITY SEC-S8(story 83ea3d6a) P — 까심 전수스윕: `_resolve_actor`가 team_members
+        # 뷰(멀티프로젝트 grant 시 member당 N행)에서 `.first()`로 임의 1행을 뽑아, actor.role이
+        # body.project_id와 무관한 다른 project의 role일 수 있었다(비결정). mixed-role 에이전트가
+        # role 낮은 target project에서도 다른 project의 높은 role을 빌려와 AC3를 우회 격상.
+        # fix=target project(body.project_id) 전용 effective role을 조회(위 has_project_role
+        # 게이트와 동일 project·SSOT)해 actor.role 대신 사용.
         target_rank = _ROLE_RANK.get(body.role, 1)
-        actor_rank = _ROLE_RANK.get(actor.role, 1)
+        actor_project_role = await get_project_role(session, uuid.UUID(auth.user_id), body.project_id)
+        actor_rank = _ROLE_RANK.get(actor_project_role, 1)
         if target_rank > actor_rank:
             raise HTTPException(status_code=403, detail="Cannot assign role higher than your own")
         # AC4: target.alias(name) == actor.name → 400 (self-replication 차단)

--- a/backend/tests/test_e_security_sec_s8_p_role_rank_cross_project_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_p_role_rank_cross_project_realdb.py
@@ -1,0 +1,279 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) P: 에이전트 role-rank 격상(mixed-role cross-project) 봉쇄
+실증 — create_team_member(AC3) + create_org_agent(자매 갭, fix-on-sight) 둘 다.
+
+`_resolve_actor()`가 team_members 뷰(멀티프로젝트 grant 시 member당 N행)에서 `.first()`로
+임의 1행을 뽑아, actor.role이 target project와 무관한 다른 project의 role일 수 있었다.
+mixed-role 에이전트(예: P1=owner, P2=admin)가 role 낮은 target(P2)에서도 다른 project(P1)의
+높은 role을 빌려와 상위 role 멤버/에이전트를 찍어낼 수 있었다(비결정 row-pick)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_p1, project_p2) + mixed-role agent(P1=owner grant, P2=admin grant)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_p1 = Project(id=uuid.uuid4(), org_id=org.id, name="Project P1")
+    project_p2 = Project(id=uuid.uuid4(), org_id=org.id, name="Project P2")
+    session.add_all([project_p1, project_p2])
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="mixed-role-agent", is_active=True)
+    session.add(agent)
+    await session.commit()
+    agent_id = agent.id
+    session.add_all([
+        ProjectAccess(id=uuid.uuid4(), project_id=project_p1.id, member_id=agent_id, permission="granted", role="owner"),
+        ProjectAccess(id=uuid.uuid4(), project_id=project_p2.id, member_id=agent_id, permission="granted", role="admin"),
+    ])
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_p1_id": project_p1.id, "project_p2_id": project_p2.id,
+        "agent_id": agent_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_agent(app, Session, agent_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(agent_id), email="agent@test",
+            claims={"app_metadata": {"org_id": str(org_id), "api_key_id": str(uuid.uuid4())}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ── create_team_member(P 본체): mixed-role 에이전트가 target project 전용 role로 평가되는지 ──
+
+@pytest.mark.anyio
+async def test_mixed_role_agent_cannot_borrow_p1_owner_role_for_p2_target():
+    """P 재현: P1=owner·P2=admin인 에이전트가 P2(target)로 role=owner 멤버 생성 시도 → 403
+    (기존엔 .first()가 P1 row를 뽑으면 owner>=owner로 통과할 수 있었음·비결정 격상)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/team-members",
+                json={
+                    "project_id": str(seeded["project_p2_id"]), "org_id": str(seeded["org_id"]),
+                    "type": "agent", "name": "RogueOwnerViaP2", "role": "owner",
+                },
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mixed_role_agent_can_create_admin_member_at_own_admin_project():
+    """회귀 0: P2에서 admin인 에이전트는 P2에 role=admin 멤버는 여전히 생성 가능(과차단 아님)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/team-members",
+                json={
+                    "project_id": str(seeded["project_p2_id"]), "org_id": str(seeded["org_id"]),
+                    "type": "agent", "name": "LegitAdminAtP2", "role": "admin",
+                },
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mixed_role_agent_can_create_owner_member_at_own_owner_project():
+    """회귀 0: P1에서 owner인 에이전트는 P1 자체에는 role=owner 멤버도 정상 생성(제 project 내 정당 권한)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/team-members",
+                json={
+                    "project_id": str(seeded["project_p1_id"]), "org_id": str(seeded["org_id"]),
+                    "type": "agent", "name": "LegitOwnerAtP1", "role": "owner",
+                },
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── create_org_agent(자매 갭, fix-on-sight): 멀티 project_ids 최솟값 rank로 평가되는지 ──
+
+@pytest.mark.anyio
+async def test_org_agent_multi_project_owner_blocked_by_weakest_target():
+    """자매갭 재현: scope_mode='projects'[P1,P2]로 role=owner 요청 → 403(P2에선 admin뿐이라
+    최솟값 rank=admin<owner)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/agents",
+                json={
+                    "name": "RogueOwnerMulti", "role": "owner", "scope_mode": "projects",
+                    "project_ids": [str(seeded["project_p1_id"]), str(seeded["project_p2_id"])],
+                },
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_agent_multi_project_admin_allowed():
+    """회귀 0: scope_mode='projects'[P1,P2]로 role=admin 요청 → 201(두 project 다 admin 이상)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/agents",
+                json={
+                    "name": "LegitAdminMulti", "role": "admin", "scope_mode": "projects",
+                    "project_ids": [str(seeded["project_p1_id"]), str(seeded["project_p2_id"])],
+                },
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_agent_single_p1_owner_allowed():
+    """회귀 0: scope_mode='projects'[P1]만으로 role=owner 요청 → 201(P1 단독은 owner 정당)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/agents",
+                json={
+                    "name": "LegitOwnerP1Only", "role": "owner", "scope_mode": "projects",
+                    "project_ids": [str(seeded["project_p1_id"])],
+                },
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- E-SECURITY SEC-S8(story 83ea3d6a) P — 까심 전수스윕.
- `_resolve_actor()`가 team_members 뷰(멀티프로젝트 grant 시 member당 N행)에서 `.first()`로 임의 1행을 뽑아, AC3 role-rank 비교가 target project와 무관한 다른 project의 role과 비교됐다. mixed-role 에이전트(예: P1=owner, P2=admin)가 role 낮은 target(P2)에서도 다른 project(P1)의 높은 role을 빌려와 상위 role 멤버를 찍어낼 수 있었다(비결정 row-pick 격상).
- `create_team_member`(team_members.py): `actor.role` → `get_project_role(session, auth.user_id, body.project_id)`로 대체 — 이미 admin-gate(`has_project_role`)가 같은 project로 검증한 SSOT 재사용.
- `create_org_agent`(agents.py, **fix-on-sight 자매 갭**): scope_mode='org'|'projects'로 여러 project_ids를 대상으로 하므로, 각 target project의 `get_project_role` 중 최솟값(가장 낮은 role)으로 비교 — 하나라도 부족하면 격상 차단.

## Test plan
- [x] realdb 6건: mixed-role 격상 차단(create_team_member) + same-project 정상 2종 + multi-project 최솟값 차단/허용 2종(create_org_agent) + 단일-project owner 허용 — pass
- [x] 기존 L/O/team_members 회귀 25건 무회귀 — pass
- [x] full suite(`-m "not destructive_schema"`) 3538 passed, 7 pre-existing baseline failures만(무관)
- [x] 신규 마이그레이션 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)