### PR TITLE
fix(e-security): SEC-S8 T — create_story 링크 project-scope 검증 추가

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Query, Response
 from pydantic import BaseModel, field_validator
-from sqlalchemy import or_, select
+from sqlalchemy import or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -249,6 +249,31 @@ def _enforce_mcp_attachment_declared_limit(attachments: list[dict]) -> None:
         )
 
 
+_STORY_LINK_TABLES = {"epic_id": "epics", "sprint_id": "sprints", "meeting_id": "meetings"}
+
+
+async def _assert_story_link_targets_in_project(
+    session: AsyncSession, project_id: uuid.UUID, body: StoryCreate,
+) -> None:
+    """E-SECURITY SEC-S8(story 83ea3d6a) T(까심 전수스윕, 실HTTP 확定): epic_id/sprint_id/
+    meeting_id가 body.project_id 소속인지 검증 없이 그대로 repo.create에 전달됐다 — 같은 org
+    다른 project의 epic/sprint/meeting에 story를 링크할 수 있었다(G/R와 동형 project-scope
+    부재). enforce_body_context는 body.project_id 자체만 caller와 대조할 뿐, 그 project_id
+    "안에" 링크 대상이 실제로 속하는지는 안 본다."""
+    for field, table in _STORY_LINK_TABLES.items():
+        target_id = getattr(body, field)
+        if target_id is None:
+            continue
+        target_project_id = (await session.execute(
+            text(f"SELECT project_id FROM {table} WHERE id = :id"),  # noqa: S608 — table은 고정 allowlist(_STORY_LINK_TABLES), 요청값 아님
+            {"id": target_id},
+        )).scalar_one_or_none()
+        if target_project_id != project_id:
+            raise HTTPException(
+                status_code=404, detail=f"{field.replace('_id', '').title()} not found",
+            )
+
+
 @router.post("", response_model=StoryResponse, status_code=201)
 async def create_story(
     body: StoryCreate,
@@ -265,6 +290,7 @@ async def create_story(
         db=session,
         user_id=uuid.UUID(auth.user_id),
     )
+    await _assert_story_link_targets_in_project(session, body.project_id, body)
     repo = StoryRepository(session, org_id)
     # E-BOARD S5: assignee_ids 제공 시 단일 assignee_id(주담당)는 첫 요소로 동기화(미지정 시).
     effective_ids = (

--- a/backend/tests/test_e_security_sec_s8_t_story_link_project_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_t_story_link_project_scope_realdb.py
@@ -1,0 +1,255 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) T: create_story epic_id/sprint_id/meeting_id 링크의
+project-scope 미검증 봉쇄 실증.
+
+create_story가 epic_id/sprint_id/meeting_id를 소유권 검증 없이 그대로 repo.create에 넘겨서,
+같은 org 다른 project의 epic/sprint/meeting에 story를 링크할 수 있었다(까심 전수스윕, 실HTTP
+확定: project_a caller가 project_b epic_id로 201)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a, project_b) + epic_a/sprint_a/meeting_a(project_a) +
+    epic_b/sprint_b/meeting_b(project_b) + human_a(project_a에만 명시 grant)."""
+    from sqlalchemy import text
+    from app.models.organization import Organization
+    from app.models.pm import Epic, Sprint
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    epic_a = Epic(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Epic A")
+    epic_b = Epic(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Epic B")
+    sprint_a = Sprint(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Sprint A")
+    sprint_b = Sprint(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Sprint B")
+    session.add_all([epic_a, epic_b, sprint_a, sprint_b])
+    await session.commit()
+
+    meeting_a_id = uuid.uuid4()
+    meeting_b_id = uuid.uuid4()
+    for mid, pid, title in ((meeting_a_id, project_a.id, "Meeting A"), (meeting_b_id, project_b.id, "Meeting B")):
+        await session.execute(
+            text(
+                "INSERT INTO meetings (id, project_id, title, meeting_type, participants, decisions, action_items) "
+                "VALUES (:id, :pid, :title, 'general'::meeting_type, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb)"
+            ),
+            {"id": mid, "pid": pid, "title": title},
+        )
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"human-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "epic_a_id": epic_a.id, "epic_b_id": epic_b.id,
+        "sprint_a_id": sprint_a.id, "sprint_b_id": sprint_b.id,
+        "meeting_a_id": meeting_a_id, "meeting_b_id": meeting_b_id,
+        "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id, project_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+async def _post_story(client, seeded, **link_fields):
+    body = {
+        "project_id": str(seeded["project_a_id"]), "org_id": str(seeded["org_id"]),
+        "title": "Story",
+    }
+    body.update(link_fields)
+    return await client.post("/api/v2/stories", json=body)
+
+
+@pytest.mark.anyio
+async def test_cross_project_epic_link_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await _post_story(client, seeded, epic_id=str(seeded["epic_b_id"]))
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cross_project_sprint_link_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await _post_story(client, seeded, sprint_id=str(seeded["sprint_b_id"]))
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cross_project_meeting_link_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await _post_story(client, seeded, meeting_id=str(seeded["meeting_b_id"]))
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_same_project_links_still_work():
+    """회귀 0: same-project epic/sprint/meeting 링크는 여전히 정상(과차단 아님)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await _post_story(
+                client, seeded,
+                epic_id=str(seeded["epic_a_id"]), sprint_id=str(seeded["sprint_a_id"]),
+                meeting_id=str(seeded["meeting_a_id"]),
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["epic_id"] == str(seeded["epic_a_id"])
+            assert body["sprint_id"] == str(seeded["sprint_a_id"])
+            assert body["meeting_id"] == str(seeded["meeting_a_id"])
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_links_still_works():
+    """회귀 0: 링크 필드 전부 미지정이면 검증 스킵되고 정상 생성."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await _post_story(client, seeded)
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- E-SECURITY SEC-S8(story 83ea3d6a) T — 까심 전수스윕, 실HTTP 확定.
- `create_story`가 `epic_id`/`sprint_id`/`meeting_id`를 소유권 검증 없이 그대로 `repo.create`에 넘겨서, 같은 org 다른 project의 epic/sprint/meeting에 story를 링크할 수 있었다. `enforce_body_context`는 `body.project_id` 자체만 caller와 대조할 뿐, 그 project_id "안에" 링크 대상이 실제로 속하는지는 검증하지 않는다.
- `_assert_story_link_targets_in_project` 추가 — G/R와 동형(target project_id를 body.project_id와 대조, 불일치/미존재 모두 404·존재 비노출).

## Test plan
- [x] realdb 5건: epic/sprint/meeting 각각 cross-project 404 차단 + same-project 정상 + 링크 미지정 정상 — pass
- [x] full suite(`-m "not destructive_schema"`) 3547 passed, 7 pre-existing baseline failures만(무관)
- [x] 신규 마이그레이션 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)