### PR TITLE
fix(e-security): SEC-S8 Y — 4개 라우터 project-scope 미검증 봉쇄

### DIFF
--- a/backend/app/routers/agent_runs.py
+++ b/backend/app/routers/agent_runs.py
@@ -26,14 +26,22 @@ async def list_agent_runs(
     cursor: str | None = Query(default=None),
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
     repo: AgentRunRepository = Depends(_get_repo),
 ) -> list[AgentRunResponse]:
     """prod 핫픽스(S20 전수스캔 — create_agent_run과 동일 클래스): project_id가 caller org
-    소속인지 검증 없이 임의 project의 agent run 목록을 열람할 수 있었다(cross-org)."""
+    소속인지 검증 없이 임의 project의 agent run 목록을 열람할 수 있었다(cross-org).
+
+    E-SECURITY SEC-S8(story 83ea3d6a) Y(까심 전수스윕): org-scope는 이미 닫혔으나 caller의
+    실제 project 접근권(has_project_access)은 검증하지 않아, 같은 org 다른 project 멤버가
+    project_id만 알면 그 project의 agent run을 열람할 수 있었다(G-class)."""
+    from app.services.project_auth import has_project_access
+
     proj_r = await session.execute(select(Project.id).where(Project.id == project_id, Project.org_id == org_id))
     if proj_r.scalar_one_or_none() is None:
         raise HTTPException(status_code=404, detail="Project not found")
+    if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to this project")
     runs = await repo.list(project_id=project_id, agent_id=agent_id, limit=limit, cursor=cursor)
     return [AgentRunResponse.model_validate(r) for r in runs]
 

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -127,6 +127,22 @@ async def list_docs(
     return [DocSummaryResponse.model_validate(d) for d in docs]
 
 
+async def _assert_doc_parent_in_project(
+    session: AsyncSession, project_id: uuid.UUID, parent_id: uuid.UUID | None,
+) -> None:
+    """E-SECURITY SEC-S8(story 83ea3d6a) Y(까심 전수스윕): parent_id가 project_id 소속인지
+    검증 없이 그대로 repo.create/setattr에 적용됐다(DocRepository.create는 BaseRepository
+    상속이라 소유권 검증 0) — 같은 org 다른 project의 doc을 parent로 지정해 doc 트리를
+    오염시킬 수 있었다(T/G와 동형 project-scope 부재). create/update 양쪽 재사용."""
+    if parent_id is None:
+        return
+    parent_project_id = (await session.execute(
+        select(Doc.project_id).where(Doc.id == parent_id, Doc.deleted_at.is_(None))
+    )).scalar_one_or_none()
+    if parent_project_id != project_id:
+        raise HTTPException(status_code=404, detail="Parent doc not found")
+
+
 @router.post("", response_model=DocResponse, status_code=201)
 async def create_doc(
     body: DocCreate,
@@ -143,6 +159,7 @@ async def create_doc(
         db=session,
         user_id=uuid.UUID(auth.user_id),
     )
+    await _assert_doc_parent_in_project(session, body.project_id, body.parent_id)
     # ⭐RC#1(body-trust 봉인): created_by 를 **인증 caller 로 강제**(body.created_by 무시·attribution
     # 위조 차단). 다른 doc write 경로(_resolve_doc_member_id·line~501)와 대칭. AC3-2d(2) canonical 유지.
     created_by = await _resolve_doc_member_id(auth, org_id, session)
@@ -330,6 +347,9 @@ async def update_doc(
                     "current_updated_at": doc.updated_at.isoformat(),
                 },
             )
+
+    if "parent_id" in data:
+        await _assert_doc_parent_in_project(session, doc.project_id, data["parent_id"])
 
     # 일반 필드 적용 (slug 제외)
     for attr, val in data.items():

--- a/backend/app/routers/file_locks.py
+++ b/backend/app/routers/file_locks.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, field_validator
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -281,14 +281,26 @@ async def unlock_files(
 
 @router.get("/api/v2/file-locks")
 async def list_file_locks(
+    project_id: uuid.UUID = Query(...),
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[dict]:
-    """AC6: 현재 프로젝트 내 활성 file lock 목록."""
+    """AC6: 현재 프로젝트 내 활성 file lock 목록.
+
+    E-SECURITY SEC-S8(story 83ea3d6a) Y(까심 전수스윕): 독스트링은 "현재 프로젝트 내"지만
+    실제 쿼리는 FileLock.org_id만 필터하고 project_id 필터 자체가 없어 org 전체 lock이
+    노출됐다(같은 org 다른 project 멤버도 전 project의 활성 lock을 열람 가능). project_id를
+    필수 쿼리 파라미터로 받아 has_project_access로 caller의 실제 접근권도 검증한다."""
+    from app.services.project_auth import has_project_access
+
+    if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
     result = await session.execute(
         select(FileLock).where(
             FileLock.org_id == org_id,
+            FileLock.project_id == project_id,
             FileLock.released_at.is_(None),
         )
     )

--- a/backend/app/routers/github_integration.py
+++ b/backend/app/routers/github_integration.py
@@ -173,8 +173,11 @@ async def create_explicit_link(
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """PR↔story **명시연결**(explicit·confidence high·Bot-L.2 UI 의 BE). resolver 체인 최우선·close-on-merge
-    가능. ⭐anti-IDOR **2층**: ①story 가 caller org 소속 ②**repo 가 org 의 설치 context**(installation account)에
-    속함. 둘 다 미충족 = generic 404(타 org/repo 존재 oracle 0). per-org 격리·upsert·created_by=caller member.
+    가능. ⭐anti-IDOR **2+1층**: ①story 가 caller org 소속 ②caller가 그 story의 project 접근권 보유
+    (E-SECURITY SEC-S8 Y, 까심 전수스윕 — 기존엔 org-scope만 있고 project-scope가 없어 같은 org
+    다른 project의 story에도 PR 링크를 생성할 수 있었다·T/X와 동형) ③**repo 가 org 의 설치 context**
+    (installation account)에 속함. 전부 미충족 = generic 404(타 org/repo 존재 oracle 0). per-org
+    격리·upsert·created_by=caller member.
     """
     if not body.repo_full_name.strip() or "/" not in body.repo_full_name or body.pr_number <= 0:
         return JSONResponse(status_code=422, content={"error": "invalid_pr_identity"})
@@ -187,6 +190,10 @@ async def create_explicit_link(
         )
     ).scalar_one_or_none()
     if story is None:
+        return JSONResponse(status_code=404, content={"error": "story_not_found"})
+    # ②project-scope 검증(SEC-S8 Y) — org만으론 same-org cross-project 링크 생성을 못 막는다.
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(session, uuid.UUID(auth.user_id), story.project_id, org_id):
         return JSONResponse(status_code=404, content={"error": "story_not_found"})
     # ②repo 가 org 의 설치 context 에 속하는지(anti-IDOR·임의 repo high link 차단). org 의 active installation
     # account_login 과 repo owner 일치 요구. 미설치/owner 불일치 = generic 404(repo 존재 oracle 0).
@@ -238,11 +245,14 @@ def _link_view(link: PullRequestStoryLink) -> dict:
 async def list_links(
     story_id: uuid.UUID = Query(...),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """story 의 PR↔story 링크 목록(Bot-L.2 UI '연결 PR 표시'). org-scope·story 선검증(anti-IDOR).
-    타 org/부재 story = generic 404(존재 oracle 0). 링크는 org+story+미삭제만 반환."""
+    """story 의 PR↔story 링크 목록(Bot-L.2 UI '연결 PR 표시'). org-scope·project-scope·story
+    선검증(anti-IDOR, SEC-S8 Y fix-on-sight — create_explicit_link 자매 갭). 타 org/무권한
+    project/부재 story = generic 404(존재 oracle 0). 링크는 org+story+미삭제만 반환."""
+    from app.services.project_auth import has_project_access
+
     story = (
         await session.execute(
             select(Story).where(
@@ -251,6 +261,8 @@ async def list_links(
         )
     ).scalar_one_or_none()
     if story is None:
+        return JSONResponse(status_code=404, content={"error": "story_not_found"})
+    if not await has_project_access(session, uuid.UUID(auth.user_id), story.project_id, org_id):
         return JSONResponse(status_code=404, content={"error": "story_not_found"})
     links = (
         await session.execute(

--- a/backend/tests/test_bot_l2_be_links.py
+++ b/backend/tests/test_bot_l2_be_links.py
@@ -77,9 +77,10 @@ async def _req(method, path, *, execute_results, org_id=ORG_A):
 # ── GET list ──────────────────────────────────────────────────────────────────
 @pytest.mark.anyio
 async def test_list_links_same_org_returns_links():
-    # execute: story(org_a) → links([link]).
+    # execute: story(org_a) → has_project_access(truthy) → links([link]).
+    # E-SECURITY SEC-S8 Y: project-scope 검증(has_project_access) 호출이 추가돼 시퀀스가 하나 늘었다.
     resp, _ = await _req("GET", f"/api/v2/integrations/github/links?story_id={STORY_ID}",
-                         execute_results=[_story(ORG_A), [_link(ORG_A)]])
+                         execute_results=[_story(ORG_A), 1, [_link(ORG_A)]])
     assert resp.status_code == 200
     body = resp.json()
     data = body.get("data", body)

--- a/backend/tests/test_e_security_sec_s8_y_project_scope_gaps_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_y_project_scope_gaps_realdb.py
@@ -1,0 +1,378 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) Y: 4개 라우터 project-scope 미검증 봉쇄 실증 — 근본은
+하나(create/list 경로 project-scope 부재)라 한 파일로 묶는다.
+
+- doc parent_id: create_doc이 parent_id를 소유권 검증 없이 그대로 repo.create에 전달(T-class).
+- agent_runs: list_agent_runs가 org-scope만 있고 has_project_access는 안 봄(G-class).
+- file_locks: list_file_locks가 독스트링("현재 프로젝트 내")과 달리 project_id 필터 자체가 없음.
+- github story-link: create_explicit_link/list_links가 story org-scope는 있으나 project-scope
+  없이 같은 org 다른 project story에 PR 링크 생성/열람 가능(T/X-class)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_base(session):
+    """org(project_a, project_b) + human_a(project_a에만 명시 grant)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"h-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ── doc parent_id ────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_doc_cross_project_parent_blocked():
+    from app.main import app
+    from app.models.doc import Doc
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            doc_b = Doc(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_b_id"],
+                title="Doc B", slug=f"doc-b-{uuid.uuid4().hex[:8]}", content="",
+            )
+            s.add(doc_b)
+            await s.commit()
+            doc_b_id = doc_b.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/docs",
+                json={
+                    "project_id": str(seeded["project_a_id"]), "org_id": str(seeded["org_id"]),
+                    "title": "Injected", "slug": f"injected-{uuid.uuid4().hex[:8]}",
+                    "parent_id": str(doc_b_id),
+                },
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_doc_same_project_parent_still_works():
+    from app.main import app
+    from app.models.doc import Doc
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            doc_a = Doc(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"],
+                title="Doc A", slug=f"doc-a-{uuid.uuid4().hex[:8]}", content="",
+            )
+            s.add(doc_a)
+            await s.commit()
+            doc_a_id = doc_a.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/docs",
+                json={
+                    "project_id": str(seeded["project_a_id"]), "org_id": str(seeded["org_id"]),
+                    "title": "Child", "slug": f"child-{uuid.uuid4().hex[:8]}",
+                    "parent_id": str(doc_a_id),
+                },
+            )
+            assert resp.status_code == 201, resp.text
+            assert resp.json()["parent_id"] == str(doc_a_id)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── agent_runs ────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_agent_runs_cross_project_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/agent-runs", params={"project_id": str(seeded["project_b_id"])},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_agent_runs_same_project_still_works():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/agent-runs", params={"project_id": str(seeded["project_a_id"])},
+            )
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── file_locks ────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_file_locks_scoped_to_own_project_only():
+    """B가 아니라 A의 lock만 보여야 함(org 전체 노출 봉쇄)."""
+    from app.main import app
+    from app.models.file_lock import FileLock
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            now_a = FileLock(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"],
+                member_id=uuid.uuid4(), file_path="a.py",
+            )
+            now_b = FileLock(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_b_id"],
+                member_id=uuid.uuid4(), file_path="b.py",
+            )
+            s.add_all([now_a, now_b])
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/file-locks", params={"project_id": str(seeded["project_a_id"])},
+            )
+            assert resp.status_code == 200, resp.text
+            paths = {row["file_path"] for row in resp.json()}
+            assert paths == {"a.py"}, f"project_b lock이 노출되면 안 됨: {paths}"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_file_locks_no_access_project_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/file-locks", params={"project_id": str(seeded["project_b_id"])},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── github story-link ──────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_github_link_cross_project_story_blocked():
+    from app.main import app
+    from app.models.github_installation import GithubInstallation
+    from app.models.pm import Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            story_b = Story(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_b_id"], title="Story B",
+            )
+            s.add(story_b)
+            s.add(GithubInstallation(
+                id=uuid.uuid4(), org_id=seeded["org_id"], installation_id=uuid.uuid4().int % 2_000_000_000,
+                account_login="acme-corp", account_type="Organization", repository_selection="all",
+            ))
+            await s.commit()
+            story_b_id = story_b.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/integrations/github/links",
+                json={"story_id": str(story_b_id), "repo_full_name": "acme-corp/repo1", "pr_number": 42},
+            )
+            assert resp.status_code == 404, resp.text
+
+            resp2 = await client.get(
+                "/api/v2/integrations/github/links", params={"story_id": str(story_b_id)},
+            )
+            assert resp2.status_code == 404, resp2.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_github_link_same_project_story_still_works():
+    from app.main import app
+    from app.models.github_installation import GithubInstallation
+    from app.models.pm import Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            story_a = Story(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"], title="Story A",
+            )
+            s.add(story_a)
+            s.add(GithubInstallation(
+                id=uuid.uuid4(), org_id=seeded["org_id"], installation_id=uuid.uuid4().int % 2_000_000_000,
+                account_login="acme-corp", account_type="Organization", repository_selection="all",
+            ))
+            await s.commit()
+            story_a_id = story_a.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/integrations/github/links",
+                json={"story_id": str(story_a_id), "repo_full_name": "acme-corp/repo1", "pr_number": 7},
+            )
+            assert resp.status_code == 200, resp.text
+
+            resp2 = await client.get(
+                "/api/v2/integrations/github/links", params={"story_id": str(story_a_id)},
+            )
+            assert resp2.status_code == 200, resp2.text
+            assert len(resp2.json()["links"]) == 1
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_s4_1_file_conflict.py
+++ b/backend/tests/test_s4_1_file_conflict.py
@@ -611,7 +611,10 @@ async def test_fetch_scoped_member_falls_back_directly():
 
 @pytest.mark.anyio
 async def test_list_file_locks_200():
-    """AC6: GET /api/v2/file-locks → 목록 반환."""
+    """AC6: GET /api/v2/file-locks?project_id=... → 목록 반환.
+
+    E-SECURITY SEC-S8 Y: project_id가 필수 쿼리 파라미터로 바뀌어(org 전체 노출 봉인)
+    has_project_access도 검증 대상 — 여기선 True로 patch해 목록 반환 경로만 격리 검증."""
     client, session, app = await _client()
     try:
         lock = MagicMock()
@@ -625,8 +628,9 @@ async def test_list_file_locks_200():
         mock_result.scalars.return_value.all.return_value = [lock]
         session.execute = AsyncMock(return_value=mock_result)
 
-        async with client as c:
-            resp = await c.get("/api/v2/file-locks")
+        with patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
+            async with client as c:
+                resp = await c.get("/api/v2/file-locks", params={"project_id": str(PROJECT_ID)})
 
         assert resp.status_code == 200
         body = resp.json()


### PR DESCRIPTION
## Summary
- E-SECURITY SEC-S8(story 83ea3d6a) Y — 까심 전수스윕. 같은 근본(create/list 경로 project-scope 부재)이 4개 라우터에 걸쳐 있어 한 PR로 묶었다.
- **docs.py**: `create_doc`/`update_doc`의 `parent_id`가 project 소속 검증 없이 적용됐다. `_assert_doc_parent_in_project` 신규 헬퍼로 create+update 양쪽 재사용.
- **agent_runs.py**: `list_agent_runs`가 org-scope만 있고 `has_project_access`는 검증하지 않았다.
- **file_locks.py**: `list_file_locks` 독스트링은 "현재 프로젝트 내"인데 실제 쿼리는 `org_id`만 필터. `project_id` 필수 쿼리 파라미터 추가 + `has_project_access` 검증.
- **github_integration.py**: `create_explicit_link`/`list_links`가 story org-scope(anti-IDOR 2층)는 있으나 project-scope가 없었다(`list_links`는 fix-on-sight).

## Test plan
- [x] realdb 8건: 각 라우터 cross-project 차단 + same-project 정상 회귀 — pass
- [x] docs/agent_runs/file_locks/github 기존 71건 무회귀(`test_bot_l2_be_links.py`의 mocked execute 시퀀스에 `has_project_access` 호출 1건 추가 반영)
- [x] full suite(`-m "not destructive_schema"`) 3562 passed, 7 pre-existing baseline failures만(무관)
- [x] 신규 마이그레이션 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)