### PR TITLE
fix(e-security): SEC-S8 Z — Sprint/Standup/github delete_link project-scope 봉쇄

### DIFF
--- a/backend/app/routers/github_integration.py
+++ b/backend/app/routers/github_integration.py
@@ -282,11 +282,17 @@ async def list_links(
 async def delete_link(
     link_id: uuid.UUID,
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """PR↔story 링크 해제(Bot-L.2 UI '해제'·soft-delete). ⭐anti-IDOR: `link.id AND org_id` — 타 org/부재/
-    이미 삭제는 generic 404(존재 oracle 0). soft-delete(deleted_at) 라 close-on-merge resolver 에서 즉시 제외."""
+    이미 삭제는 generic 404(존재 oracle 0). soft-delete(deleted_at) 라 close-on-merge resolver 에서 즉시 제외.
+
+    E-SECURITY SEC-S8(story 83ea3d6a) Z(까심 QA, 라이브 확定): org_id만으론 부족했다 — create_explicit_
+    link/list_links(Y)는 project-scope를 이미 닫았는데 delete는 빠져 있었다(S/X와 동형 패턴). link이
+    가리키는 story의 project에 caller가 접근권 있는지도 검증."""
+    from app.services.project_auth import has_project_access
+
     link = (
         await session.execute(
             select(PullRequestStoryLink).where(
@@ -297,6 +303,13 @@ async def delete_link(
         )
     ).scalar_one_or_none()
     if link is None:
+        return JSONResponse(status_code=404, content={"error": "link_not_found"})
+    story_project_id = (
+        await session.execute(select(Story.project_id).where(Story.id == link.story_id))
+    ).scalar_one_or_none()
+    if story_project_id is None or not await has_project_access(
+        session, uuid.UUID(auth.user_id), story_project_id, org_id
+    ):
         return JSONResponse(status_code=404, content={"error": "link_not_found"})
     link.deleted_at = datetime.now(timezone.utc)
     await session.commit()

--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -228,6 +228,21 @@ async def update_sprint(
     auth: AuthContext = Depends(get_current_user),
 ) -> SprintResponse:
     data = body.model_dump(exclude_unset=True)
+    # E-SECURITY SEC-S8(story 83ea3d6a) Z(까심 전수스윕): report_doc_id가 sprint의 project 소속인지
+    # 검증 없이 그대로 repo.update에 전달됐다(T-class) — 같은 org 다른 project의 doc을 sprint
+    # report로 지정할 수 있었다.
+    if "report_doc_id" in data and data["report_doc_id"] is not None:
+        from app.models.doc import Doc
+        _sprint_for_doc_check = await repo.get(id)
+        if _sprint_for_doc_check is None:
+            raise HTTPException(status_code=404, detail="Sprint not found")
+        doc_project_id = (await session.execute(
+            select(Doc.project_id).where(
+                Doc.id == data["report_doc_id"], Doc.deleted_at.is_(None),
+            )
+        )).scalar_one_or_none()
+        if doc_project_id != _sprint_for_doc_check.project_id:
+            raise HTTPException(status_code=404, detail="Report doc not found")
     # ⭐E-DG S26: status 변경은 transition_sprint 단일경로(FSM/overlay/human-gate) 경유 — PATCH 옆문
     # 봉인(S25 epic PATCH-bypass 교훈). 나머지 필드만 repo.update.
     _status_change = data.pop("status", None)

--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -23,7 +23,7 @@ from app.services.project_auth import accessible_project_ids_in_org
 
 
 async def _entries_with_plan_stories(
-    entries: list[StandupEntry], session: AsyncSession, org_id: uuid.UUID
+    entries: list[StandupEntry], session: AsyncSession, org_id: uuid.UUID, viewer_user_id: uuid.UUID,
 ) -> list[StandupEntryResponse]:
     """a9e67531: 엔트리들의 plan_story_ids 를 **org-scope batch resolve**(N+1 회피) → plan_stories 주입.
 
@@ -31,10 +31,18 @@ async def _entries_with_plan_stories(
     stories 배열로는 미해소(미노출 버그). 여기서 org-scope 로 id+title+status(+priority/project/sprint) 해소해
     내려준다. ⭐org-scope 강제(`Story.org_id==org_id`)·삭제 제외·타org/미존재 id 는 **조용히 제외**(노출 0)·
     plan_story_ids **입력 순서 보존**. plan_story_ids 는 하위호환 유지(FE id-only fallback).
-    """
+
+    E-SECURITY SEC-S8(story 83ea3d6a) Z(까심 전수스윕, 실HTTP 확定): org-scope만으로는 부족했다 —
+    project_a만 grant된 caller가 project_b story_id를 plan_story_ids에 넣으면(쓰기 측 미검증) org-scope
+    enrich가 그대로 title/project_id를 노출했다(caller의 project 접근권과 무관한 read-side 정보유출).
+    viewer_user_id의 accessible_project_ids_in_org로 한 번 더 필터 — story의 project에 viewer가
+    접근권 없으면 조용히 제외(타org/삭제/미존재와 동일 취급, no oracle)."""
     all_ids = {sid for e in entries for sid in (e.plan_story_ids or [])}
     summaries: dict[uuid.UUID, PlanStorySummary] = {}
     if all_ids:
+        from app.services.project_auth import accessible_project_ids_in_org
+
+        accessible_pids = set(await accessible_project_ids_in_org(session, viewer_user_id, org_id))
         rows = (
             await session.execute(
                 select(
@@ -48,6 +56,8 @@ async def _entries_with_plan_stories(
             )
         ).all()
         for sid, title, status, priority, pid, spid in rows:
+            if pid not in accessible_pids:
+                continue  # viewer가 접근권 없는 project의 story는 조용히 제외(Z).
             summaries[sid] = PlanStorySummary(
                 id=sid, title=title, status=status, priority=priority,
                 project_id=pid, sprint_id=spid,
@@ -55,7 +65,7 @@ async def _entries_with_plan_stories(
     out: list[StandupEntryResponse] = []
     for e in entries:
         resp = StandupEntryResponse.model_validate(e)
-        # 순서 보존 + 미발견(타org/삭제/미존재) 조용히 제외.
+        # 순서 보존 + 미발견(타org/삭제/미존재/접근권 없음) 조용히 제외.
         resp.plan_stories = [summaries[sid] for sid in (e.plan_story_ids or []) if sid in summaries]
         out.append(resp)
     return out
@@ -81,6 +91,44 @@ async def _sync_org_level_links(
     await repo.resync_project_links(entry.id, accessible)
 
 
+async def _filter_write_links_to_accessible(
+    session: AsyncSession, org_id: uuid.UUID, caller_user_id: uuid.UUID,
+    sprint_id: uuid.UUID | None, plan_story_ids: list[uuid.UUID],
+) -> tuple[uuid.UUID | None, list[uuid.UUID]]:
+    """E-SECURITY SEC-S8(story 83ea3d6a) Z(까심 전수스윕, 실HTTP 확定): sprint_id/plan_story_ids가
+    caller 접근권 밖 project를 가리켜도 검증 없이 그대로 저장됐다(T-class) — project_a만 grant된
+    caller가 project_b sprint/story를 참조해도 막지 않았다. caller의 accessible_project_ids_in_org로
+    write 전에 필터 — 접근권 밖이면 sprint_id는 None으로, plan_story_ids는 조용히 제외(no oracle)."""
+    if sprint_id is None and not plan_story_ids:
+        return sprint_id, plan_story_ids  # 검증할 링크가 없으면 조회 자체를 스킵.
+
+    from app.services.project_auth import accessible_project_ids_in_org
+
+    accessible_pids = set(await accessible_project_ids_in_org(session, caller_user_id, org_id))
+
+    safe_sprint_id = sprint_id
+    if sprint_id is not None:
+        from app.models.pm import Sprint
+        sprint_pid = (await session.execute(
+            select(Sprint.project_id).where(Sprint.id == sprint_id, Sprint.org_id == org_id)
+        )).scalar_one_or_none()
+        if sprint_pid is None or sprint_pid not in accessible_pids:
+            safe_sprint_id = None
+
+    safe_plan_story_ids = plan_story_ids
+    if plan_story_ids:
+        rows = (await session.execute(
+            select(Story.id, Story.project_id).where(
+                Story.id.in_(plan_story_ids), Story.org_id == org_id, Story.deleted_at.is_(None),
+            )
+        )).all()
+        accessible_story_ids = {sid for sid, pid in rows if pid in accessible_pids}
+        # 순서 보존.
+        safe_plan_story_ids = [sid for sid in plan_story_ids if sid in accessible_story_ids]
+
+    return safe_sprint_id, safe_plan_story_ids
+
+
 def _get_repo(
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
@@ -95,6 +143,7 @@ async def list_standups(
     sprint_id: uuid.UUID | None = Query(default=None),
     date_filter: date | None = Query(default=None, alias="date"),
     repo: StandupEntryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[StandupEntryResponse]:
     filters: dict = {}
     if project_id:
@@ -108,7 +157,7 @@ async def list_standups(
     if date_filter:
         filters["date"] = date_filter
     entries = await repo.list(**filters)
-    return await _entries_with_plan_stories(entries, repo.session, repo.org_id)
+    return await _entries_with_plan_stories(entries, repo.session, repo.org_id, uuid.UUID(auth.user_id))
 
 
 @router.post("", response_model=StandupEntryResponse, status_code=201)
@@ -121,20 +170,23 @@ async def upsert_standup(
     # AC3-3: 작성자 신원을 canonical members.id로 정규화(레거시 휴먼 team_member.id → alias 치환).
     # write↔read(카드/missing) 동일 canonical 정합 — #1167 회귀(API 200≠카드표시) 방지.
     author_id = await canonicalize_member_id(body.author_id, session)
+    safe_sprint_id, safe_plan_story_ids = await _filter_write_links_to_accessible(
+        session, org_id, uuid.UUID(auth.user_id), body.sprint_id, body.plan_story_ids,
+    )
     repo = StandupEntryRepository(session, org_id)
     entry = await repo.upsert(
         project_id=body.project_id,
         author_id=author_id,
         date=body.date,
-        sprint_id=body.sprint_id,
+        sprint_id=safe_sprint_id,
         done=body.done,
         plan=body.plan,
         blockers=body.blockers,
-        plan_story_ids=body.plan_story_ids,
+        plan_story_ids=safe_plan_story_ids,
     )
     # 1c2be9db: org-level write(project_id 없음) → author 접근 프로젝트로 링크 full overwrite.
     await _sync_org_level_links(repo, session, entry, body.project_id, auth.user_id, org_id)
-    return (await _entries_with_plan_stories([entry], session, org_id))[0]
+    return (await _entries_with_plan_stories([entry], session, org_id, uuid.UUID(auth.user_id)))[0]
 
 
 @router.put("", response_model=StandupEntryResponse)
@@ -155,20 +207,23 @@ async def update_standup(
     canonical로 함께** 옮겨 멀티프로젝트 휴먼 단일 신원(48e653e9 해소) + saved-but-not-displayed 회귀 0.
     """
     member = await resolve_member(auth, org_id, session, project_id=body.project_id)
+    safe_sprint_id, safe_plan_story_ids = await _filter_write_links_to_accessible(
+        session, org_id, uuid.UUID(auth.user_id), body.sprint_id, body.plan_story_ids,
+    )
     repo = StandupEntryRepository(session, org_id)
     entry = await repo.upsert(
         project_id=body.project_id,
         author_id=member.id,
         date=body.date,
-        sprint_id=body.sprint_id,
+        sprint_id=safe_sprint_id,
         done=body.done,
         plan=body.plan,
         blockers=body.blockers,
-        plan_story_ids=body.plan_story_ids,
+        plan_story_ids=safe_plan_story_ids,
     )
     # 1c2be9db: org-level self-save(project_id 없음) → author 접근 프로젝트로 링크 full overwrite.
     await _sync_org_level_links(repo, session, entry, body.project_id, auth.user_id, org_id)
-    return (await _entries_with_plan_stories([entry], session, org_id))[0]
+    return (await _entries_with_plan_stories([entry], session, org_id, uuid.UUID(auth.user_id)))[0]
 
 
 @router.get("/history", response_model=list[StandupEntryResponse])
@@ -176,6 +231,7 @@ async def list_standup_history(
     project_id: uuid.UUID = Query(...),
     limit: int = Query(default=30, ge=1, le=200),
     repo: StandupEntryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[StandupEntryResponse]:
     """GET /api/v2/standups/history — 최근 N개 스탠드업 히스토리 조회 (AC2 S-STANDUP-FIX).
 
@@ -183,7 +239,7 @@ async def list_standup_history(
     백로그→데일리 할일(plan_story_ids)이 plan_stories 빈 채 내려가 cross-board 미노출(SaaS FE 프록시 포함).
     """
     entries = await repo.list(project_id=project_id, limit=limit)
-    return await _entries_with_plan_stories(entries, repo.session, repo.org_id)
+    return await _entries_with_plan_stories(entries, repo.session, repo.org_id, uuid.UUID(auth.user_id))
 
 
 @router.get("/missing", response_model=list[uuid.UUID])
@@ -224,12 +280,13 @@ async def list_feedback(
 async def get_standup(
     id: uuid.UUID,
     repo: StandupEntryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> StandupEntryResponse:
     entry = await repo.get(id)
     if entry is None:
         raise HTTPException(status_code=404, detail="Standup entry not found")
     # b47f9b05: 단건 조회도 plan_stories enrich(list/upsert/update 와 일관·cross-board 백로그 노출).
-    return (await _entries_with_plan_stories([entry], repo.session, repo.org_id))[0]
+    return (await _entries_with_plan_stories([entry], repo.session, repo.org_id, uuid.UUID(auth.user_id)))[0]
 
 
 @router.post("/{id}/feedback", response_model=FeedbackResponse, status_code=201)

--- a/backend/tests/test_bot_l2_be_links.py
+++ b/backend/tests/test_bot_l2_be_links.py
@@ -100,9 +100,11 @@ async def test_list_links_cross_org_story_404_no_oracle():
 # ── DELETE unlink ───────────────────────────────────────────────────────────────
 @pytest.mark.anyio
 async def test_delete_link_same_org_soft_deletes():
+    # execute: link → story.project_id(scalar) → has_project_access(truthy).
+    # E-SECURITY SEC-S8 Z: project-scope 검증(has_project_access) 호출이 추가돼 시퀀스가 둘 늘었다.
     link = _link(ORG_A)
     resp, session = await _req("DELETE", f"/api/v2/integrations/github/links/{LINK_ID}",
-                               execute_results=[link])
+                               execute_results=[link, uuid.uuid4(), 1])
     assert resp.status_code == 200
     assert link.deleted_at is not None      # soft-delete.
     session.commit.assert_awaited_once()

--- a/backend/tests/test_e_security_sec_s8_z_sprint_standup_github_project_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_z_sprint_standup_github_project_scope_realdb.py
@@ -1,0 +1,344 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) Z: Sprint/Standup/github delete_link project-scope
+미검증 봉쇄 실증 — 근본 하나(create/update/delete 경로 project-scope 부재)를 3개 라우터에서
+닫는다(Sprint report_doc_id·Standup sprint_id/plan_story_ids+read-side 정보유출·github delete_link).
+
+- Sprint report_doc_id: update_sprint이 소유권 검증 없이 그대로 repo.update에 전달(T-class).
+- Standup: 실HTTP 확定 — project_a만 grant된 caller가 project_b sprint_id/story를 PUT으로
+  참조하면 저장+응답에 그대로 title/project_id가 노출됐다(T-class + read-side 정보유출).
+- github delete_link: create/list(Y)는 project-scope를 닫았는데 delete가 빠져 있었다(S/X-class)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_base(session):
+    """org(project_a, project_b) + human_a(project_a에만 명시 grant)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"h-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ── Sprint report_doc_id ────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_update_sprint_cross_project_report_doc_blocked():
+    from app.main import app
+    from app.models.doc import Doc
+    from app.models.pm import Sprint
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_a = Sprint(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"], title="Sprint A")
+            doc_b = Doc(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_b_id"],
+                title="Doc B", slug=f"doc-b-{uuid.uuid4().hex[:8]}", content="",
+            )
+            s.add_all([sprint_a, doc_b])
+            await s.commit()
+            sprint_a_id, doc_b_id = sprint_a.id, doc_b.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/sprints/{sprint_a_id}", json={"report_doc_id": str(doc_b_id)},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_sprint_same_project_report_doc_still_works():
+    from app.main import app
+    from app.models.doc import Doc
+    from app.models.pm import Sprint
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_a = Sprint(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"], title="Sprint A")
+            doc_a = Doc(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"],
+                title="Doc A", slug=f"doc-a-{uuid.uuid4().hex[:8]}", content="",
+            )
+            s.add_all([sprint_a, doc_a])
+            await s.commit()
+            sprint_a_id, doc_a_id = sprint_a.id, doc_a.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/sprints/{sprint_a_id}", json={"report_doc_id": str(doc_a_id)},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["report_doc_id"] == str(doc_a_id)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── Standup sprint_id/plan_story_ids ──────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_standup_cross_project_sprint_and_story_not_leaked():
+    """Z 재현: project_a만 grant된 caller가 project_b sprint/story를 PUT으로 참조해도
+    저장/응답에 반영되면 안 됨(쓰기 필터 + read enrich 접근권 필터 둘 다 실증)."""
+    from app.main import app
+    from app.models.pm import Sprint, Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_b = Sprint(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_b_id"], title="Sprint B Secret")
+            story_b = Story(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_b_id"], title="SECRET STORY B")
+            s.add_all([sprint_b, story_b])
+            await s.commit()
+            sprint_b_id, story_b_id = sprint_b.id, story_b.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.put(
+                "/api/v2/standups",
+                json={
+                    "project_id": str(seeded["project_a_id"]), "date": str(date.today()),
+                    "sprint_id": str(sprint_b_id), "plan_story_ids": [str(story_b_id)],
+                    "plan": "attempt cross-project leak",
+                },
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["sprint_id"] is None, "무권한 project의 sprint_id는 저장/응답에서 제거돼야 함"
+            assert body["plan_stories"] == [], "무권한 project의 story는 enrich에서 제외돼야 함(정보유출 봉인)"
+            entry_id = body["id"]
+        finally:
+            await client.aclose()
+
+        # DB에도 실제로 스며들지 않았는지 확인.
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.standup import StandupEntry
+            entry = (await s.execute(select(StandupEntry).where(StandupEntry.id == uuid.UUID(entry_id)))).scalar_one()
+            assert entry.sprint_id is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_standup_same_project_sprint_and_story_still_works():
+    """회귀 0: project_a grant 보유 caller는 project_a sprint/story는 여전히 정상 저장+enrich."""
+    from app.main import app
+    from app.models.pm import Sprint, Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_a = Sprint(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"], title="Sprint A")
+            story_a = Story(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"], title="Story A")
+            s.add_all([sprint_a, story_a])
+            await s.commit()
+            sprint_a_id, story_a_id = sprint_a.id, story_a.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.put(
+                "/api/v2/standups",
+                json={
+                    "project_id": str(seeded["project_a_id"]), "date": str(date.today()),
+                    "sprint_id": str(sprint_a_id), "plan_story_ids": [str(story_a_id)],
+                    "plan": "legit plan",
+                },
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["sprint_id"] == str(sprint_a_id)
+            assert [ps["id"] for ps in body["plan_stories"]] == [str(story_a_id)]
+            assert body["plan_stories"][0]["title"] == "Story A"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── github delete_link ─────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_github_delete_link_cross_project_blocked():
+    from app.main import app
+    from app.models.github_installation import GithubInstallation
+    from app.models.pm import Story
+    from app.models.pull_request_story_link import PullRequestStoryLink
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            story_b = Story(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_b_id"], title="Story B")
+            s.add(story_b)
+            await s.commit()
+            link = PullRequestStoryLink(
+                id=uuid.uuid4(), org_id=seeded["org_id"], story_id=story_b.id,
+                repo_full_name="acme-corp/repo1", pr_number=99,
+                link_source="explicit", confidence="high",
+            )
+            s.add(link)
+            await s.commit()
+            link_id = link.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/integrations/github/links/{link_id}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            reloaded = (await s.execute(
+                select(PullRequestStoryLink).where(PullRequestStoryLink.id == link_id)
+            )).scalar_one()
+            assert reloaded.deleted_at is None, "무권한 project의 link이 삭제되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_github_delete_link_same_project_still_works():
+    from app.main import app
+    from app.models.pm import Story
+    from app.models.pull_request_story_link import PullRequestStoryLink
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            story_a = Story(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"], title="Story A")
+            s.add(story_a)
+            await s.commit()
+            link = PullRequestStoryLink(
+                id=uuid.uuid4(), org_id=seeded["org_id"], story_id=story_a.id,
+                repo_full_name="acme-corp/repo1", pr_number=100,
+                link_source="explicit", confidence="high",
+            )
+            s.add(link)
+            await s.commit()
+            link_id = link.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/integrations/github/links/{link_id}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_standup_plan_stories_enrich.py
+++ b/backend/tests/test_standup_plan_stories_enrich.py
@@ -2,19 +2,24 @@
 
 BE 가 plan_story_ids 를 org-scope resolve 해 plan_stories[{id,title,status,...}] 로 내려줌(FE 가 active-sprint
 stories 배열 의존 제거). 검증: 입력 순서 보존·타org/삭제/미존재 조용히 제외·plan_story_ids 하위호환 유지.
+
+E-SECURITY SEC-S8(story 83ea3d6a) Z: viewer의 accessible_project_ids_in_org로도 필터(접근권 밖
+project story는 조용히 제외) — 테스트는 accessible_project_ids_in_org를 patch해 격리 검증한다.
 """
 from __future__ import annotations
 
 import uuid
 from datetime import date as _date, datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from app.routers.standups import _entries_with_plan_stories
 
 ORG = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()  # accessible-by-default project used across tests.
+VIEWER_ID = uuid.uuid4()
 
 
 @pytest.fixture
@@ -31,8 +36,15 @@ def _entry(plan_story_ids):
     )
 
 
-def _row(sid, title="S", status="in-progress"):
-    return (sid, title, status, "medium", None, None)
+def _row(sid, title="S", status="in-progress", project_id=PROJECT_ID):
+    return (sid, title, status, "medium", project_id, None)
+
+
+def _accessible(*ids):
+    return patch(
+        "app.services.project_auth.accessible_project_ids_in_org",
+        new=AsyncMock(return_value=list(ids)),
+    )
 
 
 @pytest.mark.anyio
@@ -45,7 +57,8 @@ async def test_plan_stories_resolve_order_preserved_and_missing_excluded():
     result.all.return_value = [_row(s1, "One"), _row(s2, "Two")]
     session.execute = AsyncMock(return_value=result)
 
-    out = await _entries_with_plan_stories([entry], session, ORG)
+    with _accessible(PROJECT_ID):
+        out = await _entries_with_plan_stories([entry], session, ORG, VIEWER_ID)
     resp = out[0]
     # ⭐입력 순서 보존(s2→s1)·missing 조용히 제외.
     assert [ps.id for ps in resp.plan_stories] == [s2, s1]
@@ -59,7 +72,8 @@ async def test_no_plan_story_ids_no_query():
     entry = _entry([])
     session = AsyncMock()
     session.execute = AsyncMock()
-    out = await _entries_with_plan_stories([entry], session, ORG)
+    with _accessible(PROJECT_ID):
+        out = await _entries_with_plan_stories([entry], session, ORG, VIEWER_ID)
     assert out[0].plan_stories == []
     session.execute.assert_not_awaited()  # 빈 id → 쿼리 0.
 
@@ -73,9 +87,26 @@ async def test_org_scope_in_query():
     result = MagicMock()
     result.all.return_value = [_row(s1)]
     session.execute = AsyncMock(return_value=result)
-    await _entries_with_plan_stories([entry], session, ORG)
+    with _accessible(PROJECT_ID):
+        await _entries_with_plan_stories([entry], session, ORG, VIEWER_ID)
     stmt = str(session.execute.await_args.args[0])
     assert "org_id" in stmt and "deleted_at" in stmt  # org-scope + soft-delete 필터.
+
+
+@pytest.mark.anyio
+async def test_inaccessible_project_story_excluded():
+    """E-SECURITY SEC-S8 Z: viewer가 접근권 없는 project의 story는 org-scope 통과해도 제외."""
+    s1 = uuid.uuid4()
+    other_project = uuid.uuid4()
+    entry = _entry([s1])
+    session = AsyncMock()
+    result = MagicMock()
+    result.all.return_value = [_row(s1, "Hidden", project_id=other_project)]
+    session.execute = AsyncMock(return_value=result)
+    with _accessible(PROJECT_ID):  # viewer는 other_project 접근권 없음.
+        out = await _entries_with_plan_stories([entry], session, ORG, VIEWER_ID)
+    assert out[0].plan_stories == []
+    assert out[0].plan_story_ids == [s1]  # 원본 id 하위호환은 유지.
 
 
 # ─── b47f9b05: history + get_standup enrich 갭 회귀(원 시나리오) ──────────────
@@ -88,6 +119,10 @@ def _repo(*, list_ret=None, get_ret=None, session=None):
     )
 
 
+def _auth():
+    return MagicMock(user_id=str(VIEWER_ID))
+
+
 @pytest.mark.anyio
 async def test_history_endpoint_enriches_backlog_plan_story():
     """history 가 백로그(cross-board) plan_story 를 enrich — 미적용 시 plan_stories 빈 채 미노출 회귀."""
@@ -97,7 +132,8 @@ async def test_history_endpoint_enriches_backlog_plan_story():
     result = MagicMock(); result.all.return_value = [_row(backlog, "Backlog", "backlog")]
     session.execute = AsyncMock(return_value=result)
     repo = _repo(list_ret=[_entry([backlog])], session=session)
-    out = await list_standup_history(project_id=uuid.uuid4(), limit=30, repo=repo)
+    with _accessible(PROJECT_ID):
+        out = await list_standup_history(project_id=uuid.uuid4(), limit=30, repo=repo, auth=_auth())
     assert [ps.id for ps in out[0].plan_stories] == [backlog]  # 백로그 노출(enrich)
 
 
@@ -111,5 +147,6 @@ async def test_get_standup_endpoint_enriches_backlog_plan_story():
     result = MagicMock(); result.all.return_value = [_row(backlog, "Backlog", "backlog")]
     session.execute = AsyncMock(return_value=result)
     repo = _repo(get_ret=entry, session=session)
-    out = await get_standup(id=entry.id, repo=repo)
+    with _accessible(PROJECT_ID):
+        out = await get_standup(id=entry.id, repo=repo, auth=_auth())
     assert [ps.id for ps in out.plan_stories] == [backlog]


### PR DESCRIPTION
## Summary
- E-SECURITY SEC-S8(story 83ea3d6a) Z — 까심 전수스윕 + 실HTTP 확定(Standup). 같은 근본(create/update/delete 경로 project-scope 부재)이 3개 라우터에 걸쳐 있어 한 PR로 묶었다.
- **sprints.py**: `update_sprint`의 `report_doc_id`가 sprint의 project 소속 검증 없이 저장됐다(T-class).
- **standups.py**: `sprint_id`/`plan_story_ids`가 caller 접근권 밖 project를 가리켜도 검증 없이 저장됐다 — **실HTTP 확定**: project_a만 grant된 caller가 project_b sprint/story를 PUT으로 참조하면 저장+응답에 title/project_id가 그대로 노출됐다. write-side 필터(`_filter_write_links_to_accessible`) + read-side enrich 필터(`_entries_with_plan_stories`에 `viewer_user_id` 추가) 둘 다 봉인.
- **github_integration.py**: `DELETE /links/{id}`가 project-scope 없이(create/list는 Y로 이미 닫힘) Project A caller가 Project B story의 github link을 soft-delete할 수 있었다(S/X-class).

## Test plan
- [x] realdb 6건: Sprint cross-project report_doc 404+same-project 정상 / Standup cross-project sprint_id·story 저장·응답 모두 무노출(DB 확인 포함)+same-project 정상 / github delete cross-project 404+same-project 정상 — pass
- [x] 기존 94건 무회귀(`test_standup_plan_stories_enrich.py` project_id 필드 추가+`accessible_project_ids_in_org` patch로 재작성, `test_bot_l2_be_links.py` delete 시퀀스 반영)
- [x] full suite(`-m "not destructive_schema"`) 3576 passed, 7 pre-existing baseline failures만(무관)
- [x] 신규 마이그레이션 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)