### PR TITLE
fix(e-security): SEC-S8 Z2 — workflow_report/workflow_trigger project-scope 봉쇄

### DIFF
--- a/backend/app/routers/workflow_report.py
+++ b/backend/app/routers/workflow_report.py
@@ -148,6 +148,14 @@ async def report_done(
     if story is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Story not found")
 
+    # E-SECURITY SEC-S8(story 83ea3d6a) Z2(까심 전수스윕, 실HTTP 확定): org-scope(#12)는 있으나
+    # caller의 실제 project 접근권(has_project_access) 검증이 없어, project_a만 grant된 caller가
+    # project_b story_id로 이 엔드포인트를 호출하면 stage 전이가 실제로 반영됐다(DB 재조회로
+    # backlog→in-progress 변조 확定, G-class).
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(session, uuid.UUID(auth.user_id), story.project_id, org_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Story not found")
+
     # S20 finding #12(sibling): body.agent_id도 검증 없이 gate/line 평가의 actor로 그대로
     # 쓰였다 — 임의 agent_id로 actor 스푸핑 가능했던 갭. caller org 소속 member인지 확인.
     agent_check = await session.execute(

--- a/backend/app/routers/workflow_trigger.py
+++ b/backend/app/routers/workflow_trigger.py
@@ -36,6 +36,15 @@ async def trigger_workflow(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> TriggerResponse:
+    # E-SECURITY SEC-S8(story 83ea3d6a) Z2(까심 전수스윕, 실HTTP 확定): body.project_id에
+    # has_project_access 검증 자체가 없어, project_a만 grant된 caller가 body.project_id=project_b로
+    # 요청하면 project_b 전용 enabled rule이 실제로 매치되고 WorkflowExecutionLog가 생성됐다
+    # (남의 project 워크플로 실행 트리거). has_project_access(org_id 지정)가 "project가 caller
+    # org 소속"과 "caller 접근권" 둘 다 커버.
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(db, uuid.UUID(auth.user_id), body.project_id, org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+
     cutoff = datetime.now(timezone.utc) - timedelta(seconds=_DEDUP_SECONDS)
     recent = await db.execute(
         select(WorkflowExecutionLog.id)

--- a/backend/tests/test_e_security_sec_s8_z2_workflow_project_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_z2_workflow_project_scope_realdb.py
@@ -1,0 +1,249 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) Z2: workflow_report/workflow_trigger project-scope
+미검증 봉쇄 실증(까심 전수스윕, 실HTTP 확定).
+
+- report_done: org-scope(#12)는 있으나 has_project_access 부재 — project_a만 grant된 caller가
+  project_b story_id로 report-done 호출 시 story.status가 실제로 변조됐다(backlog→in-progress).
+- trigger_workflow: body.project_id에 has_project_access 검증 자체가 없어 project_b 전용
+  enabled rule이 실제로 매치되고 WorkflowExecutionLog가 생성됐다(남의 project 워크플로 트리거)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_base(session):
+    """org(project_a, project_b) + human_a(project_a에만 명시 grant)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"h-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ── report_done ─────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_report_done_cross_project_blocked_no_mutation():
+    """Z2 재현: project_a만 grant된 caller가 project_b story로 report-done → story 무변조."""
+    from app.main import app
+    from app.models.member import Member
+    from app.models.pm import Story
+    from app.models.project_access import ProjectAccess
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            story_b = Story(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_b_id"], title="Story B", status="backlog")
+            agent = Member(id=uuid.uuid4(), org_id=seeded["org_id"], type="agent", name="agent", is_active=True)
+            s.add_all([story_b, agent])
+            await s.commit()
+            s.add(ProjectAccess(id=uuid.uuid4(), project_id=seeded["project_a_id"], member_id=agent.id, permission="granted", role="member"))
+            await s.commit()
+            story_b_id, agent_id = story_b.id, agent.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/workflow/report-done",
+                json={"story_id": str(story_b_id), "stage": "kickoff", "agent_id": str(agent_id)},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            reloaded = (await s.execute(select(Story).where(Story.id == story_b_id))).scalar_one()
+            assert reloaded.status == "backlog", "무권한 project story 상태가 변조되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_report_done_same_project_still_works():
+    from app.main import app
+    from app.models.member import Member
+    from app.models.pm import Story
+    from app.models.project_access import ProjectAccess
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            story_a = Story(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"], title="Story A", status="backlog")
+            agent = Member(id=uuid.uuid4(), org_id=seeded["org_id"], type="agent", name="agent", is_active=True)
+            s.add_all([story_a, agent])
+            await s.commit()
+            s.add(ProjectAccess(id=uuid.uuid4(), project_id=seeded["project_a_id"], member_id=agent.id, permission="granted", role="member"))
+            await s.commit()
+            story_a_id, agent_id = story_a.id, agent.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/workflow/report-done",
+                json={"story_id": str(story_a_id), "stage": "kickoff", "agent_id": str(agent_id)},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["story_status"] == "in-progress"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── trigger_workflow ─────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_trigger_workflow_cross_project_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/workflow/trigger",
+                json={
+                    "project_id": str(seeded["project_b_id"]), "story_id": str(uuid.uuid4()),
+                    "trigger_type_slug": "kickoff",
+                },
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.workflow_execution_log import WorkflowExecutionLog
+            logs = (await s.execute(
+                select(WorkflowExecutionLog).where(WorkflowExecutionLog.project_id == seeded["project_b_id"])
+            )).scalars().all()
+            assert logs == [], "무권한 project에 워크플로 실행 로그가 생성되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_trigger_workflow_same_project_still_works():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/workflow/trigger",
+                json={
+                    "project_id": str(seeded["project_a_id"]), "story_id": str(uuid.uuid4()),
+                    "trigger_type_slug": "kickoff",
+                },
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["status"] in ("no_match", "triggered")
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_workflow_report.py
+++ b/backend/tests/test_workflow_report.py
@@ -322,6 +322,10 @@ async def test_agent_id_cross_org_400():
             result = MagicMock()
             if call_count == 1:
                 result.scalar_one_or_none.return_value = story
+            elif call_count == 2:
+                # E-SECURITY SEC-S8 Z2: has_project_access 호출(story project 접근권) — 이
+                # 테스트는 그 뒤의 agent_id 검증(call 3)만 검증 대상이라 여기선 통과시킨다.
+                result.scalar_one_or_none.return_value = 1
             else:
                 result.scalar_one_or_none.return_value = None
             return result


### PR DESCRIPTION
## Summary
- E-SECURITY SEC-S8(story 83ea3d6a) Z2 — 까심 전수스윕 + 실HTTP 확定. 둘 다 org-scope는 있으나 caller의 실제 project 접근권(`has_project_access`)이 없어 same-org cross-project 조작이 가능했다(G-class).
- **workflow_report.py `report_done`**: story org-scope(#12)는 이미 닫혀 있었으나 project-scope가 없어, project_a만 grant된 caller가 project_b story_id로 stage 전이를 시도하면 실제로 반영됐다(**라이브 재현**: DB 재조회로 backlog→in-progress 변조 확定).
- **workflow_trigger.py `trigger_workflow`**: `body.project_id`에 `has_project_access` 검증 자체가 없어, project_a만 grant된 caller가 project_b_id로 요청하면 project_b 전용 enabled rule이 실제로 매치되고 `WorkflowExecutionLog`가 생성됐다(**라이브 재현**: 남의 project 워크플로 실행 트리거 확定).

## Test plan
- [x] realdb 4건: `report_done` cross-project 404+DB 무변조 + same-project 정상 / `trigger_workflow` cross-project 404+로그 생성 0 + same-project 정상 — pass
- [x] 기존 21건 무회귀(`test_workflow_report.py`의 `test_agent_id_cross_org_400`이 새 `has_project_access` 호출을 mock 시퀀스에 반영)
- [x] full suite(`-m "not destructive_schema"`) 3576 passed, 7 pre-existing baseline failures만(무관)
- [x] 신규 마이그레이션 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)