### PR TITLE
fix(e-security): SEC-S8 BB — workflow_templates apply + workflow_executions project-scope 봉쇄

### DIFF
--- a/backend/app/routers/workflow_executions.py
+++ b/backend/app/routers/workflow_executions.py
@@ -58,9 +58,17 @@ async def story_execution_summary(
     story_ids: list[str] = Query(default=[]),
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict[str, StorySummaryItem]:
-    """Return latest execution status per story (no admin required — board/member view)."""
+    """Return latest execution status per story (no admin required — board/member view).
+
+    E-SECURITY SEC-S8(story 83ea3d6a) BB(까심 전수스윕, HIGH·읽기): project_id에 project 접근권
+    검증이 없어 남의 project 워크플로 실행 상태(story-level status/rule_name)가 노출됐다.
+    """
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(db, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+
     if not story_ids:
         return {}
 

--- a/backend/app/routers/workflow_templates.py
+++ b/backend/app/routers/workflow_templates.py
@@ -96,6 +96,14 @@ async def apply_template(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> ApplyTemplateResponse:
+    # E-SECURITY SEC-S8(story 83ea3d6a) BB(까심 전수스윕, CRITICAL·라이브 확定): body.project_id에
+    # has_project_access 검증 자체가 없어, project_a member가 project_b에 AgentRoutingRule을
+    # 생성(201)할 수 있었다 — overwrite_existing=true면 기존 룰 삭제까지 겸해 파괴적 쓰기(남의
+    # project 자동화 룰 심기/지우기).
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(db, uuid.UUID(auth.user_id), body.project_id, org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+
     repo = WorkflowTemplateRepository(db)
     tmpl = await repo.get_by_slug(slug)
     if tmpl is None:

--- a/backend/tests/test_e2e_workflow_template.py
+++ b/backend/tests/test_e2e_workflow_template.py
@@ -62,7 +62,8 @@ async def test_e2e_template_apply_three_step():
         role_mapping={f"step_{i+1}": str(agent_ids[i]) for i in range(3)},
     )
 
-    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo, \
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
         instance = AsyncMock()
         instance.get_by_slug = AsyncMock(return_value=tmpl)
         MockRepo.return_value = instance
@@ -90,7 +91,8 @@ async def test_e2e_template_apply_solo():
         role_mapping={"step_1": str(agent_ids[0])},
     )
 
-    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo, \
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
         instance = AsyncMock()
         instance.get_by_slug = AsyncMock(return_value=tmpl)
         MockRepo.return_value = instance
@@ -124,7 +126,8 @@ async def test_e2e_template_overwrite():
         overwrite_existing=True,
     )
 
-    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo, \
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
         instance = AsyncMock()
         instance.get_by_slug = AsyncMock(return_value=tmpl)
         MockRepo.return_value = instance

--- a/backend/tests/test_e_security_sec_s8_bb_workflow_templates_executions_project_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_bb_workflow_templates_executions_project_scope_realdb.py
@@ -1,0 +1,259 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) BB: workflow_templates apply + workflow_executions
+story-summary project-scope 미검증 봉쇄 실증(까심 전수스윕, 실HTTP 확定).
+
+- apply_template: body.project_id에 has_project_access 검증 자체가 없어, project_a만
+  grant된 caller가 project_b로 template apply 시 실제로 AgentRoutingRule이 생성됐다(201).
+- story_execution_summary: project_id에 project 접근권 검증이 없어 남의 project 워크플로
+  실행 상태(story-level status/rule_name)가 노출됐다(200)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_base(session):
+    """org(project_a, project_b) + human_a(project_a에만 명시 grant)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"h-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ── apply_template ───────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_apply_template_cross_project_blocked_no_rule_created():
+    """BB 재현: project_a만 grant된 caller가 project_b로 template apply → 404·룰 생성 0."""
+    from app.main import app
+    from app.models.agent_routing_rule import AgentRoutingRule
+    from app.models.member import Member
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            agent = Member(id=uuid.uuid4(), org_id=seeded["org_id"], type="agent", name="agent", is_active=True)
+            s.add(agent)
+            await s.commit()
+            agent_id = agent.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/workflow-templates/solo/apply",
+                json={
+                    "project_id": str(seeded["project_b_id"]),
+                    "role_mapping": {"step_1": str(agent_id)},
+                },
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            rules = (await s.execute(
+                select(AgentRoutingRule).where(AgentRoutingRule.project_id == seeded["project_b_id"])
+            )).scalars().all()
+            assert rules == [], "무권한 project에 AgentRoutingRule이 생성되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_apply_template_same_project_still_works():
+    from app.main import app
+    from app.models.member import Member
+    from app.models.project_access import ProjectAccess
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            agent = Member(id=uuid.uuid4(), org_id=seeded["org_id"], type="agent", name="agent", is_active=True)
+            s.add(agent)
+            await s.commit()
+            s.add(ProjectAccess(
+                id=uuid.uuid4(), project_id=seeded["project_a_id"], member_id=agent.id,
+                permission="granted", role="member",
+            ))
+            await s.commit()
+            agent_id = agent.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/workflow-templates/solo/apply",
+                json={
+                    "project_id": str(seeded["project_a_id"]),
+                    "role_mapping": {"step_1": str(agent_id)},
+                },
+            )
+            assert resp.status_code == 201, resp.text
+            assert resp.json()["rules_created"] == 1
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── story_execution_summary ──────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_story_execution_summary_cross_project_blocked():
+    """BB 재현: project_a만 grant된 caller가 project_b의 실행 요약 조회 → 404·노출 0."""
+    from app.main import app
+    from app.models.workflow_execution_log import WorkflowExecutionLog
+
+    engine, Session = await _session_factory()
+    try:
+        story_id = str(uuid.uuid4())
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            s.add(WorkflowExecutionLog(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_b_id"],
+                event_type="story.status_changed", status="success",
+                event_context={"metadata": {"story_id": story_id}},
+            ))
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/workflow-executions/story-summary",
+                params={"project_id": str(seeded["project_b_id"]), "story_ids": [story_id]},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_story_execution_summary_same_project_still_works():
+    from app.main import app
+    from app.models.workflow_execution_log import WorkflowExecutionLog
+
+    engine, Session = await _session_factory()
+    try:
+        story_id = str(uuid.uuid4())
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            s.add(WorkflowExecutionLog(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"],
+                event_type="story.status_changed", status="success",
+                event_context={"metadata": {"story_id": story_id}},
+            ))
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/workflow-executions/story-summary",
+                params={"project_id": str(seeded["project_a_id"]), "story_ids": [story_id]},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert story_id in body
+            assert body[story_id]["status"] == "success"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_workflow_template_api.py
+++ b/backend/tests/test_workflow_template_api.py
@@ -146,12 +146,16 @@ async def test_apply_template_cross_org_agent_422():
         role_mapping={"step_1": str(cross_org_id), "step_2": str(uuid.uuid4())},
     )
 
-    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo, \
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
         instance = AsyncMock()
         instance.get_by_slug = AsyncMock(return_value=tmpl)
         MockRepo.return_value = instance
         with pytest.raises(HTTPException) as exc:
-            await apply_template(slug="two-step", body=body, db=db, auth=MagicMock(), org_id=uuid.uuid4())
+            await apply_template(
+                slug="two-step", body=body, db=db,
+                auth=MagicMock(user_id=str(uuid.uuid4())), org_id=uuid.uuid4(),
+            )
 
     assert exc.value.status_code == 422
 
@@ -169,12 +173,16 @@ async def test_apply_template_missing_role_mapping_422():
         role_mapping={"step_1": str(uuid.uuid4())},
     )
 
-    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo, \
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
         instance = AsyncMock()
         instance.get_by_slug = AsyncMock(return_value=tmpl)
         MockRepo.return_value = instance
         with pytest.raises(HTTPException) as exc:
-            await apply_template(slug="two-step", body=body, db=db, auth=MagicMock(), org_id=uuid.uuid4())
+            await apply_template(
+                slug="two-step", body=body, db=db,
+                auth=MagicMock(user_id=str(uuid.uuid4())), org_id=uuid.uuid4(),
+            )
 
     assert exc.value.status_code == 422
 
@@ -187,12 +195,16 @@ async def test_apply_template_404():
     db = _mock_db()
     body = ApplyTemplateRequest(project_id=uuid.uuid4(), role_mapping={})
 
-    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo, \
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
         instance = AsyncMock()
         instance.get_by_slug = AsyncMock(return_value=None)
         MockRepo.return_value = instance
         with pytest.raises(HTTPException) as exc:
-            await apply_template(slug="ghost", body=body, db=db, auth=MagicMock(), org_id=uuid.uuid4())
+            await apply_template(
+                slug="ghost", body=body, db=db,
+                auth=MagicMock(user_id=str(uuid.uuid4())), org_id=uuid.uuid4(),
+            )
 
     assert exc.value.status_code == 404
 
@@ -229,11 +241,15 @@ async def test_apply_template_overwrite_deletes_existing():
         overwrite_existing=True,
     )
 
-    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo, \
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
         instance = AsyncMock()
         instance.get_by_slug = AsyncMock(return_value=tmpl)
         MockRepo.return_value = instance
-        result = await apply_template(slug="two-step", body=body, db=db, auth=MagicMock(), org_id=uuid.uuid4())
+        result = await apply_template(
+            slug="two-step", body=body, db=db,
+            auth=MagicMock(user_id=str(uuid.uuid4())), org_id=uuid.uuid4(),
+        )
 
     assert result.ok is True
     assert result.rules_deleted == 1


### PR DESCRIPTION
## Summary
- story 83ea3d6a(E-SECURITY SEC-S8, 까심 전수스윕) BB: `workflow_templates.apply_template`(CRITICAL·라이브확定) + `workflow_executions.story_execution_summary`(HIGH·읽기) project-scope 미검증 봉쇄.
- 근본 패턴은 R~AA와 동형: org_id는 검증하나 caller-supplied `project_id`에 `has_project_access` 부재 → same-org cross-project IDOR.
- `apply_template`: body.project_id 접근권 없이 project_a member가 project_b에 AgentRoutingRule 생성(201) 가능했음. `overwrite_existing=true`면 기존 룰 삭제까지 겸해 파괴적 쓰기.
- `story_execution_summary`: project_id 접근권 없이 남의 project 워크플로 실행 상태(story-level status/rule_name)가 노출(200)됐음.
- `get_execution`(admin-only)·`list_executions`(자기-스코프 필터 기존)는 설계상 안전 확인 후 미변경(범위 밖).

## Test plan
- [x] realdb 4테스트 신규(cross-project 차단 확인+무생성/무노출 실증, same-project 정상동작 확인) — 실 PG 라이브 재현
- [x] 기존 mock 회귀 7건 fix(`has_project_access` 패치 + `auth.user_id` 정정) — `test_e2e_workflow_template.py`(3), `test_workflow_template_api.py`(4)
- [x] `test_workflow_template_api.py` + `test_e2e_workflow_template.py` + `test_s3_1_workflow_recipes.py` + `test_workflow_template.py` = 42/42 PASS
- [x] `test_sweep_multiproject_teammember_services.py`(workflow_executions 참조) 무회귀 확인
- [x] `app.main` 449 routes import OK
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)