### PR TITLE
fix(e-security): SEC-S8 CC — sprints.py 전 엔드포인트 project-scope 봉쇄

### DIFF
--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -96,13 +96,25 @@ async def list_sprints(
     project_id: uuid.UUID | None = Query(default=None),
     status_filter: str | None = Query(default=None, alias="status"),
     repo: SprintRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[SprintResponse]:
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC(선생님 "sprint org-level=갭" 확定): 라우터 13개
+    # 전부 org-scope만이고 project-scope 0이던 것 중 하나 — project_id 미지정 시 caller의
+    # project 접근권과 무관하게 org 전체 sprint가 노출됐다. project_id 지정 시엔 접근권 검증,
+    # 미지정 시엔 accessible_project_ids_in_org로 필터(완전봉인, Z-standup 패턴 동형).
+    from app.services.project_auth import accessible_project_ids_in_org, has_project_access
+
     filters: dict = {}
     if project_id:
+        if not await has_project_access(repo.session, uuid.UUID(auth.user_id), project_id, repo.org_id):
+            raise HTTPException(status_code=404, detail="Project not found")
         filters["project_id"] = project_id
     if status_filter:
         filters["status"] = status_filter
     sprints = await repo.list(**filters)
+    if not project_id:
+        accessible = set(await accessible_project_ids_in_org(repo.session, uuid.UUID(auth.user_id), repo.org_id))
+        sprints = [s for s in sprints if s.project_id in accessible]
     return [SprintResponse.model_validate(s) for s in sprints]
 
 
@@ -114,6 +126,12 @@ async def create_sprint(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> SprintResponse:
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: body.project_id에 접근권 검증 없이 caller가
+    # 임의 org-내 project에 sprint를 생성할 수 있었다.
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(session, uuid.UUID(auth.user_id), body.project_id, org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+
     repo = SprintRepository(session, org_id)
     # 8a2bbda2: 날짜에서 duration 산출 저장(dates 단일진실·신규 정합). 날짜 없으면 model default(14).
     _dur = compute_sprint_duration(body.start_date, body.end_date)
@@ -144,9 +162,15 @@ async def create_sprint(
 async def get_sprint(
     id: uuid.UUID,
     repo: SprintRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> SprintResponse:
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: sprint id-scoped 조회에 project 접근권 검증 없이
+    # org 내 어느 project의 sprint든 조회 가능했다.
+    from app.services.project_auth import has_project_access
     sprint = await repo.get(id)
     if sprint is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    if not await has_project_access(repo.session, uuid.UUID(auth.user_id), sprint.project_id, repo.org_id):
         raise HTTPException(status_code=404, detail="Sprint not found")
     return SprintResponse.model_validate(sprint)
 
@@ -162,9 +186,17 @@ async def list_sprint_hypotheses(
     repo: SprintRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[SprintHypothesisItem]:
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: read-쌍둥이(POST declare_sprint_hypothesis는 이미
+    # resolve_member(project_id=)로 검증하는데 이 GET은 검증 없이 미러링 안 됐던 갭 — 발견즉시수정.
+    from app.services.project_auth import has_project_access
     sprint = await repo.get(id)
     if sprint is None:
+        raise HTTPException(
+            status_code=404, detail={"code": "SPRINT_NOT_FOUND", "message": "스프린트를 찾을 수 없습니다."}
+        )
+    if not await has_project_access(session, uuid.UUID(auth.user_id), sprint.project_id, org_id):
         raise HTTPException(
             status_code=404, detail={"code": "SPRINT_NOT_FOUND", "message": "스프린트를 찾을 수 없습니다."}
         )
@@ -227,6 +259,15 @@ async def update_sprint(
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> SprintResponse:
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: PATCH가 project 접근권 검증 없이 org 내 어느
+    # project의 sprint든 갱신 가능했다(report_doc_id Z-fix는 별개 갭 — 이건 sprint 자체 접근권).
+    from app.services.project_auth import has_project_access
+    _scope_sprint = await repo.get(id)
+    if _scope_sprint is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    if not await has_project_access(session, uuid.UUID(auth.user_id), _scope_sprint.project_id, org_id):
+        raise HTTPException(status_code=404, detail="Sprint not found")
+
     data = body.model_dump(exclude_unset=True)
     # E-SECURITY SEC-S8(story 83ea3d6a) Z(까심 전수스윕): report_doc_id가 sprint의 project 소속인지
     # 검증 없이 그대로 repo.update에 전달됐다(T-class) — 같은 org 다른 project의 doc을 sprint
@@ -251,7 +292,7 @@ async def update_sprint(
         from app.services.member_resolver import resolve_member
         current = await repo.get(id)
         if current is not None and _status_change != current.status:
-            caller = await resolve_member(auth, org_id, session)
+            caller = await resolve_member(auth, org_id, session, project_id=current.project_id)
             try:
                 await transition_sprint(session, org_id, caller, id, _status_change)
             except SprintTransitionError as exc:
@@ -293,18 +334,22 @@ async def delete_sprint(
     """E-SECURITY SEC-S8(story 83ea3d6a) H: delete_story/delete_task와 동형으로 휴먼
     전용화 + 삭제 감사(hard-delete의 에이전트 우회 벡터 차단). org-scope 자체는
     BaseRepository.get()이 org_id로 이미 필터해 안전(cross-org 삭제는 원래도 404) —
-    누락됐던 건 human-gate와 audit뿐."""
+    누락됐던 건 human-gate와 audit뿐.
+
+    E-SECURITY SEC-S8(story 83ea3d6a) CC(까심 전수스윕): H가 "org-scope는 안전"이라 명시했던
+    범위는 cross-org뿐 — cross-project(같은 org 다른 project sprint 삭제)는 그대로 뚫려
+    있었다. resolve_member(project_id=)로 human-gate와 project 접근권을 한 번에 강제."""
     from app.models.deletion_audit import DeletionAuditLog
     from app.repositories.dependency import DependencyRepository
     from app.repositories.label import ItemLabelRepository
 
-    resolved = await resolve_member(auth, org_id, session)
-    if resolved.type != "human":
-        raise HTTPException(status_code=403, detail="Sprint 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)")
-
     sprint = await repo.get(id)
     if sprint is None:
         raise HTTPException(status_code=404, detail="Sprint not found")
+
+    resolved = await resolve_member(auth, org_id, session, project_id=sprint.project_id)
+    if resolved.type != "human":
+        raise HTTPException(status_code=403, detail="Sprint 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)")
 
     session.add(DeletionAuditLog(
         id=uuid.uuid4(), org_id=org_id, actor_id=resolved.id,
@@ -330,7 +375,12 @@ async def activate_sprint(
     # 제약) 로직은 transition_sprint 가 위임 보존. default-off 면 즉시 활성(거동 동일).
     from app.services.sprint import SprintTransitionError, transition_sprint
     from app.services.member_resolver import resolve_member
-    caller = await resolve_member(auth, org_id, session)
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: project 접근권 검증 없이 caller가 resolve_member(project_id
+    # 없이)로만 통과 → org 내 어느 project의 sprint든 활성화 가능했다.
+    _sprint_for_scope = await SprintRepository(session, org_id).get(id)
+    if _sprint_for_scope is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    caller = await resolve_member(auth, org_id, session, project_id=_sprint_for_scope.project_id)
     try:
         sprint = await transition_sprint(session, org_id, caller, id, "active")
         await session.commit()
@@ -358,7 +408,11 @@ async def close_sprint(
     # active|review 수용) 로직 위임 보존. default-off/advisory 면 즉시 마감(거동 동일).
     from app.services.sprint import SprintTransitionError, transition_sprint
     from app.services.member_resolver import resolve_member
-    caller = await resolve_member(auth, org_id, db)
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: activate_sprint와 동형 갭 — project 접근권 미검증.
+    _sprint_for_scope = await SprintRepository(db, org_id).get(id)
+    if _sprint_for_scope is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    caller = await resolve_member(auth, org_id, db, project_id=_sprint_for_scope.project_id)
     try:
         sprint = await transition_sprint(db, org_id, caller, id, "closed")
     except (SprintTransitionError, ValueError) as exc:
@@ -393,9 +447,15 @@ async def kickoff_sprint(
     id: uuid.UUID,
     body: KickoffBody = KickoffBody(),
     repo: SprintRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: project 접근권 검증 없이 org 내 어느 project의
+    # sprint든 kickoff 발동 가능했다.
+    from app.services.project_auth import has_project_access
     sprint = await repo.get(id)
     if sprint is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    if not await has_project_access(repo.session, uuid.UUID(auth.user_id), sprint.project_id, repo.org_id):
         raise HTTPException(status_code=404, detail="Sprint not found")
     # Notification dispatch is Phase D — return stub for Phase B
     return {"notified": 0, "sprint_id": str(id), "message": body.message}
@@ -406,10 +466,16 @@ async def sprint_summary(
     id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
     repo: SprintRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
     """GET /api/v2/sprints/{id}/summary — 스프린트 스토리 상태별 집계 (AC3 S-STANDUP-FIX)."""
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: project 접근권 검증 없이 남의 project sprint의
+    # 스토리 상태별 집계가 노출됐다.
+    from app.services.project_auth import has_project_access
     sprint = await repo.get(id)
     if sprint is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    if not await has_project_access(db, uuid.UUID(auth.user_id), sprint.project_id, repo.org_id):
         raise HTTPException(status_code=404, detail="Sprint not found")
 
     stories_result = await db.execute(
@@ -448,9 +514,15 @@ async def checkin_sprint(
     date: str = Query(..., description="YYYY-MM-DD"),
     db: AsyncSession = Depends(get_db),
     repo: SprintRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: project 접근권 검증 없이 남의 project sprint의
+    # standup 미제출자 명단(이름 포함)이 노출됐다.
+    from app.services.project_auth import has_project_access
     sprint = await repo.get(id)
     if sprint is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    if not await has_project_access(db, uuid.UUID(auth.user_id), sprint.project_id, repo.org_id):
         raise HTTPException(status_code=404, detail="Sprint not found")
 
     try:
@@ -513,7 +585,11 @@ async def transition_sprint_endpoint(
     human-gate(enforcing) 단일 SSOT. caller 인증 컨텍스트 도출(RC① 패턴)."""
     from app.services.sprint import SprintTransitionError, transition_sprint
     from app.services.member_resolver import resolve_member
-    caller = await resolve_member(auth, org_id, session)
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: activate/close와 동형 갭 — project 접근권 미검증.
+    _sprint_for_scope = await SprintRepository(session, org_id).get(id)
+    if _sprint_for_scope is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    caller = await resolve_member(auth, org_id, session, project_id=_sprint_for_scope.project_id)
     try:
         sprint = await transition_sprint(session, org_id, caller, id, body.status)
         await session.commit()

--- a/backend/tests/test_e_security_sec_s8_cc_sprint_project_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_cc_sprint_project_scope_realdb.py
@@ -1,0 +1,441 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) CC: sprints.py 전 엔드포인트 project-scope 미검증 봉쇄
+실증(선생님 "sprint org-level=갭" 확定, 까심 전수스윕 후속).
+
+sprints.py 13개 엔드포인트 전부 org-scope만이고 caller의 project 접근권 검증이 어디에도
+없었다 — project_a만 grant된 caller가 org 내 project_b의 sprint를 조회/생성/수정/삭제/
+활성화/종료/kickoff/summary/checkin/transition 전부 가능했다. resolve_member(project_id=)/
+has_project_access SSOT로 봉인 — 이 파일은 각 엔드포인트가 실제로 cross-project 요청을
+차단(404/403)하고 same-project는 정상 동작함을 실 Postgres로 검증한다."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_base(session):
+    """org(project_a, project_b) + human_a(project_a에만 명시 grant)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"h-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "human_user_id": human_user_id,
+    }
+
+
+async def _seed_sprint(session, org_id, project_id, status="planning"):
+    from app.models.pm import Sprint
+    sprint = Sprint(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="Sprint", status=status, duration=14)
+    session.add(sprint)
+    await session.commit()
+    return sprint.id
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ── get_sprint ────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_get_sprint_cross_project_blocked_same_project_ok():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_a = await _seed_sprint(s, seeded["org_id"], seeded["project_a_id"])
+            sprint_b = await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp_b = await client.get(f"/api/v2/sprints/{sprint_b}")
+            assert resp_b.status_code == 404, resp_b.text
+            resp_a = await client.get(f"/api/v2/sprints/{sprint_a}")
+            assert resp_a.status_code == 200, resp_a.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── list_sprints ──────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_sprints_no_project_id_filters_to_accessible_only():
+    """project_id 미지정 시 org 전체가 아니라 accessible project로만 필터(완전봉인)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_a = await _seed_sprint(s, seeded["org_id"], seeded["project_a_id"])
+            sprint_b = await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/sprints")
+            assert resp.status_code == 200, resp.text
+            ids = {item["id"] for item in resp.json()}
+            assert str(sprint_a) in ids
+            assert str(sprint_b) not in ids
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_sprints_project_id_cross_project_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/sprints", params={"project_id": str(seeded["project_b_id"])})
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── create_sprint ─────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_sprint_cross_project_blocked_no_row():
+    from app.main import app
+    from app.models.pm import Sprint
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/sprints", json={
+                "project_id": str(seeded["project_b_id"]), "org_id": str(seeded["org_id"]),
+                "title": "Injected Sprint",
+            })
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            rows = (await s.execute(
+                select(Sprint).where(Sprint.project_id == seeded["project_b_id"])
+            )).scalars().all()
+            assert rows == [], "무권한 project에 sprint가 생성되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── delete_sprint ─────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_delete_sprint_cross_project_blocked_no_mutation():
+    from app.main import app
+    from app.models.pm import Sprint
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_b = await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/sprints/{sprint_b}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            reloaded = (await s.execute(select(Sprint).where(Sprint.id == sprint_b))).scalar_one_or_none()
+            assert reloaded is not None, "무권한 project sprint가 삭제되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── kickoff / summary / checkin (읽기+알림 계열) ────────────────────────────────
+
+@pytest.mark.anyio
+async def test_kickoff_sprint_cross_project_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_b = await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/sprints/{sprint_b}/kickoff", json={})
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sprint_summary_cross_project_blocked_same_project_ok():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_a = await _seed_sprint(s, seeded["org_id"], seeded["project_a_id"])
+            sprint_b = await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp_b = await client.get(f"/api/v2/sprints/{sprint_b}/summary")
+            assert resp_b.status_code == 404, resp_b.text
+            resp_a = await client.get(f"/api/v2/sprints/{sprint_a}/summary")
+            assert resp_a.status_code == 200, resp_a.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_checkin_sprint_cross_project_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_b = await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/sprints/{sprint_b}/checkin", params={"date": "2026-07-11"})
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── update_sprint (PATCH) ────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_update_sprint_cross_project_blocked_no_mutation():
+    from app.main import app
+    from app.models.pm import Sprint
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_b = await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(f"/api/v2/sprints/{sprint_b}", json={"title": "Hijacked"})
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            reloaded = (await s.execute(select(Sprint).where(Sprint.id == sprint_b))).scalar_one()
+            assert reloaded.title == "Sprint", "무권한 project sprint 제목이 변조되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── activate / close / transition ────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_activate_sprint_cross_project_blocked_no_mutation():
+    from app.main import app
+    from app.models.pm import Sprint
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_b = await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/sprints/{sprint_b}/activate")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            reloaded = (await s.execute(select(Sprint).where(Sprint.id == sprint_b))).scalar_one()
+            assert reloaded.status == "planning", "무권한 project sprint가 활성화되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_transition_sprint_cross_project_blocked_no_mutation():
+    from app.main import app
+    from app.models.pm import Sprint
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_b = await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/sprints/{sprint_b}/transition", json={"status": "active"})
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            reloaded = (await s.execute(select(Sprint).where(Sprint.id == sprint_b))).scalar_one()
+            assert reloaded.status == "planning", "무권한 project sprint가 전이되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── list_sprint_hypotheses (read-쌍둥이 발견즉시수정) ────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_sprint_hypotheses_cross_project_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_b = await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/sprints/{sprint_b}/hypotheses")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_h_delete_sprint_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_h_delete_sprint_realdb.py
@@ -71,6 +71,13 @@ async def _seed(session):
     human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
     session.add(human_om)
     await session.commit()
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: delete_sprint가 project-scope를 강제하게 되며
+    # 이 휴먼(role=member)도 project 접근권 grant가 있어야 삭제가 통과한다.
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=human_om.id,
+        permission="granted", role="member",
+    ))
+    await session.commit()
 
     agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="agent-x", is_active=True)
     session.add(agent)

--- a/backend/tests/test_e_sprint_loop_a353e88d_activation_gate_realdb.py
+++ b/backend/tests/test_e_sprint_loop_a353e88d_activation_gate_realdb.py
@@ -44,6 +44,7 @@ async def _seed_org_project(s):
     for sql in [
         f"DELETE FROM sprints WHERE org_id='{ORG}'",
         f"DELETE FROM hypotheses WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE org_member_id='{OM}'",
         f"DELETE FROM org_members WHERE org_id='{ORG}'",
         f"DELETE FROM projects WHERE org_id='{ORG}'",
         f"DELETE FROM users WHERE id='{USER}'",
@@ -53,6 +54,11 @@ async def _seed_org_project(s):
         f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@dd.test','x','U',true,true,0,false,0)",
         f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
         f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ}','{ORG}','P','none')",
+        # E-SECURITY SEC-S8(story 83ea3d6a) CC: sprint 라우터가 project-scope를 강제하게 되며
+        # 이 파일의 USER(role=member, 별도 grant 없음)가 sprint.project_id(PROJ) 접근권을
+        # 갖도록 명시 grant 필요(레거시 시드는 project-scope 이전 세계관).
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission,role) "
+        f"VALUES ('{uuid.uuid4()}','{PROJ}','{OM}','granted','member')",
     ]:
         await s.execute(text(sql))
     await s.commit()

--- a/backend/tests/test_e_sprint_loop_fbf1c14b_hypotheses_rest_realdb.py
+++ b/backend/tests/test_e_sprint_loop_fbf1c14b_hypotheses_rest_realdb.py
@@ -108,7 +108,7 @@ async def test_get_returns_linked_hypotheses_flat_shape():
 
         async with Session() as s:
             repo = SprintRepository(s, ORG)
-            result = await list_sprint_hypotheses(sprint.id, repo=repo, session=s, org_id=ORG)
+            result = await list_sprint_hypotheses(sprint.id, repo=repo, session=s, org_id=ORG, auth=_auth())
         assert len(result) == 1
         item = result[0]
         assert item.id == hyp.id
@@ -138,7 +138,7 @@ async def test_get_unlinked_hypothesis_not_included():
 
         async with Session() as s:
             repo = SprintRepository(s, ORG)
-            result = await list_sprint_hypotheses(sprint.id, repo=repo, session=s, org_id=ORG)
+            result = await list_sprint_hypotheses(sprint.id, repo=repo, session=s, org_id=ORG, auth=_auth())
         assert result == []
     finally:
         await eng.dispose()
@@ -158,7 +158,7 @@ async def test_get_sprint_not_found_404():
         async with Session() as s:
             repo = SprintRepository(s, ORG)
             with pytest.raises(HTTPException) as ei:
-                await list_sprint_hypotheses(uuid.uuid4(), repo=repo, session=s, org_id=ORG)
+                await list_sprint_hypotheses(uuid.uuid4(), repo=repo, session=s, org_id=ORG, auth=_auth())
         assert ei.value.status_code == 404
         assert ei.value.detail["code"] == "SPRINT_NOT_FOUND"
     finally:

--- a/backend/tests/test_sprints.py
+++ b/backend/tests/test_sprints.py
@@ -219,6 +219,9 @@ async def test_activate_sprint_200():
         active_sprint = _mock_sprint("active")
         caller = ResolvedMember(
             id=uuid.uuid4(), user_id=None, name="h", type="human", role="member", org_id=ORG_ID)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = active_sprint
+        session.execute = AsyncMock(return_value=mock_result)
         with patch("app.services.sprint.transition_sprint", AsyncMock(return_value=active_sprint)), \
              patch("app.services.member_resolver.resolve_member", AsyncMock(return_value=caller)):
             async with client as c:
@@ -694,7 +697,11 @@ async def test_update_sprint_goal_capacity_200():
 
     client, session, app = await _client()
     try:
-        with patch("app.repositories.base.BaseRepository.update", new_callable=AsyncMock) as mock_update:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = updated
+        session.execute = AsyncMock(return_value=mock_result)
+        with patch("app.repositories.base.BaseRepository.update", new_callable=AsyncMock) as mock_update, \
+             patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
             mock_update.return_value = updated
             async with client as c:
                 resp = await c.patch(f"/api/v2/sprints/{SPRINT_ID}", json={


### PR DESCRIPTION
## Summary
- story 83ea3d6a(E-SECURITY SEC-S8) CC: 선생님이 "sprint org-level = 갭"이라 직접 지목한 것을 코드로 확認 — `sprints.py` 13개 엔드포인트 전부 org-scope만이고 project-scope 검증이 어디에도 없었다.
- `delete_sprint`의 기존 H-fix(#2032류) 코멘트가 "org-scope는 BaseRepository.get()이 안전"이라 적었던 건 cross-org만이고, cross-project(같은 org 다른 project sprint 조작)는 그대로 뚫려 있었다.
- SSOT 재사용: `resolve_member(auth, org_id, session, project_id=sprint.project_id)`(legacy/anchor 양쪽 has_project_access 403 강제 — 이미 `declare_sprint_hypothesis`가 쓰던 패턴) + `has_project_access` 직접 호출(읽기 전용 엔드포인트).
- id-scoped 10종(get/patch/delete/activate/close/kickoff/summary/checkin/transition/list_sprint_hypotheses) + create_sprint(body.project_id) + list_sprints(project_id 지정 시 검증, 미지정 시 `accessible_project_ids_in_org`로 완전 필터).
- `list_sprint_hypotheses`는 `declare_sprint_hypothesis`의 read-쌍둥이인데 검증이 미러링 안 됐던 갭 — 발견즉시수정.

## Test plan
- [x] realdb 12테스트 신규 — 13개 엔드포인트 전부 cross-project 차단(404/403) + 무생성/무변조/무노출 + same-project 정상동작 실증
- [x] 기존 실DB 테스트 3파일(H/`a353e88d`/`fbf1c14b`) 시드가 project-scope 이전 세계관이라 project_access grant 추가로 정합화 + `auth` 파라미터 보강
- [x] `test_sprints.py` 2건 회귀 fix(has_project_access/repo.get mock 정합)
- [x] 관련 파일 176/176 PASS + `app.main` 449 routes import OK
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)