### PR TITLE
[E-CANVAS] 결과연결 ↳vN + 코멘트 스레드 실 렌더 갭 fix

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3416,6 +3416,7 @@
     "resolveAction": "Resolve",
     "replyPlaceholder": "Reply…",
     "resolvedByNote": "Resolved by {name}",
+    "resultLinkNote": "↳ Became v{version} — this comment was the input",
     "editModeLabel": "Edit mode",
     "paletteLabel": "Components",
     "propertyPanelEmpty": "Select an element to see its properties here",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3416,6 +3416,7 @@
     "resolveAction": "해결",
     "replyPlaceholder": "답글…",
     "resolvedByNote": "{name}가 해결함",
+    "resultLinkNote": "↳ v{version} 생성 — 이 코멘트가 입력",
     "editModeLabel": "편집 모드",
     "paletteLabel": "부품",
     "propertyPanelEmpty": "요소를 선택하면 속성이 여기 표시됩니다",

--- a/apps/web/src/app/api/visual-artifacts/[id]/versions/route.ts
+++ b/apps/web/src/app/api/visual-artifacts/[id]/versions/route.ts
@@ -1,0 +1,19 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/** GET /api/visual-artifacts/{id}/versions — 버전 목록(요약, source_comment_id 포함). */
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    const _r = await proxyToFastapi(request, `/api/v2/visual-artifacts/${id}/versions`);
+    if (!_r.ok) return _r;
+    const json = (await _r.json()) as { data?: unknown };
+    return apiSuccess(json.data ?? []);
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/components/canvas/artifact-section.tsx
+++ b/apps/web/src/components/canvas/artifact-section.tsx
@@ -2,7 +2,12 @@
 
 import { useEffect, useState } from 'react';
 import { ArtifactViewer } from './artifact-viewer';
-import { adaptArtifactDetail, type ArtifactVersion, type MemberRef, type VisualArtifact, type BeVisualArtifactDetail, type BeVisualArtifactSummary } from '@/services/canvas';
+import {
+  adaptArtifactDetail, type ArtifactVersion, type BeArtifactVersionSummary, type MemberRef,
+  type VisualArtifact, type BeVisualArtifactDetail, type BeVisualArtifactSummary,
+} from '@/services/canvas';
+import { adaptComments, type BeArtifactComment, type CommentThread } from '@/services/canvas-comments';
+import type { ArtifactNode } from '@/services/canvas-nodes';
 
 interface ArtifactSectionProps {
   storyId: string;
@@ -10,34 +15,58 @@ interface ArtifactSectionProps {
   className?: string;
 }
 
+interface ArtifactItem {
+  artifact: VisualArtifact;
+  versions: ArtifactVersion[];
+  threads: CommentThread[];
+  nodes: ArtifactNode[];
+}
+
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T | null> {
+  try {
+    const res = await fetch(url, init);
+    if (!res.ok) return null;
+    const json = (await res.json()) as { data?: T };
+    return json.data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function loadArtifactThreads(artifactId: string, nodes: ArtifactNode[]): Promise<CommentThread[]> {
+  const [comments, versionSummaries] = await Promise.all([
+    fetchJson<BeArtifactComment[]>(`/api/visual-artifacts/${artifactId}/comments`),
+    fetchJson<BeArtifactVersionSummary[]>(`/api/visual-artifacts/${artifactId}/versions`),
+  ]);
+  return adaptComments(comments ?? [], nodes, versionSummaries ?? []);
+}
+
 /**
- * E-CANVAS AC2(스토리 상세 첨부) — 실 데이터 attachment point. BE(`GET /api/visual-artifacts`,
- * C1-S3)는 실 스키마가 확定됐으나 아직 develop에 미머지(`feat/e-canvas-c1-s3-visual-artifact`,
- * PR 대기) — 그동안은 모든 스토리에서 404 → **완전 무표시**로 귀결된다(mock 폴백 0 — 선생님
- * slop 지적 반영, 없는 걸 있는 척 안 함). BE 머지·배포 즉시 이 컴포넌트가 실 artifact를 렌더한다.
+ * E-CANVAS AC2(스토리 상세 첨부) — 실 데이터 attachment point. C1(artifact/version)·
+ * C2(comments)·C3(source_comment_id 결과 연결)를 한 컴포넌트에서 병합 — 각자 실 엔드포인트가
+ * 있으니 신규 BE 0(2026-07-11 그라운딩). 404/빈 목록은 "첨부 없음"과 동일 취급, mock 폴백 0
+ * (선생님 slop 지적 반영 원칙 계승).
  */
 export function ArtifactSection({ storyId, memberMap = {}, className }: ArtifactSectionProps) {
-  const [items, setItems] = useState<{ artifact: VisualArtifact; versions: ArtifactVersion[] }[]>([]);
+  const [items, setItems] = useState<ArtifactItem[]>([]);
 
   useEffect(() => {
     let cancelled = false;
     void (async () => {
       try {
-        const listRes = await fetch(`/api/visual-artifacts?story_id=${storyId}`);
-        if (!listRes.ok) return; // 404(BE 미착지) = "첨부 없음"과 동일 취급, 조용히 무표시
-        const listJson = (await listRes.json()) as { data?: BeVisualArtifactSummary[] };
-        const artifacts = listJson.data ?? [];
+        const artifacts = await fetchJson<BeVisualArtifactSummary[]>(`/api/visual-artifacts?story_id=${storyId}`) ?? [];
         if (artifacts.length === 0) return;
 
-        const details = await Promise.all(artifacts.map(async (a) => {
-          const detailRes = await fetch(`/api/visual-artifacts/${a.id}`);
-          if (!detailRes.ok) return null;
-          const detailJson = (await detailRes.json()) as { data?: BeVisualArtifactDetail };
-          if (!detailJson.data) return null;
-          return adaptArtifactDetail(detailJson.data);
+        const resolved = await Promise.all(artifacts.map(async (a): Promise<ArtifactItem | null> => {
+          const detail = await fetchJson<BeVisualArtifactDetail>(`/api/visual-artifacts/${a.id}`);
+          if (!detail) return null;
+          const { artifact, versions } = adaptArtifactDetail(detail);
+          const threads = await loadArtifactThreads(a.id, detail.nodes);
+
+          return { artifact, versions, threads, nodes: detail.nodes };
         }));
 
-        if (!cancelled) setItems(details.filter((d) => d !== null));
+        if (!cancelled) setItems(resolved.filter((d): d is ArtifactItem => d !== null));
       } catch {
         // 네트워크 예외도 "첨부 없음"과 동일 취급 — 스토리 상세 화면 자체를 깨뜨리지 않는다.
       }
@@ -45,12 +74,40 @@ export function ArtifactSection({ storyId, memberMap = {}, className }: Artifact
     return () => { cancelled = true; };
   }, [storyId]);
 
+  async function refreshThreads(artifactId: string, nodes: ArtifactNode[]) {
+    const threads = await loadArtifactThreads(artifactId, nodes);
+    setItems((cur) => cur.map((it) => (it.artifact.id === artifactId ? { ...it, threads } : it)));
+  }
+
+  async function handleResolve(artifactId: string, nodes: ArtifactNode[], threadId: string) {
+    await fetchJson(`/api/visual-artifacts/${artifactId}/comments/${threadId}/resolve`, { method: 'POST' });
+    await refreshThreads(artifactId, nodes);
+  }
+
+  async function handleReply(artifactId: string, nodes: ArtifactNode[], threadId: string, body: string) {
+    await fetchJson(`/api/visual-artifacts/${artifactId}/comments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content: body, parent_id: threadId }),
+    });
+    await refreshThreads(artifactId, nodes);
+  }
+
   if (items.length === 0) return null;
 
   return (
     <div className={className}>
-      {items.map(({ artifact, versions }) => (
-        <ArtifactViewer key={artifact.id} artifact={artifact} versions={versions} memberMap={memberMap} />
+      {items.map(({ artifact, versions, threads, nodes }) => (
+        <ArtifactViewer
+          key={artifact.id}
+          artifact={artifact}
+          versions={versions}
+          memberMap={memberMap}
+          threads={threads}
+          nodes={nodes}
+          onResolveThread={(threadId) => void handleResolve(artifact.id, nodes, threadId)}
+          onReplyThread={(threadId, body) => void handleReply(artifact.id, nodes, threadId, body)}
+        />
       ))}
     </div>
   );

--- a/apps/web/src/components/canvas/artifact-viewer.test.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.test.tsx
@@ -4,6 +4,7 @@ import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
 import { ArtifactViewer } from './artifact-viewer';
 import { MOCK_ARTIFACT, MOCK_VERSIONS, MOCK_MEMBERS } from '@/services/canvas';
+import { MOCK_THREADS } from '@/services/canvas-comments';
 
 function wrap(node: React.ReactNode) {
   return (
@@ -37,5 +38,25 @@ describe('ArtifactViewer (SSR snapshot)', () => {
       wrap(<ArtifactViewer artifact={draftArtifact} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
     );
     expect(markup).not.toContain('정본 v');
+  });
+
+  it('renders every thread as a comment card when threads is passed (C2 — 지금까지 핀/카운트 배지만 있고 실제 카드 목록이 없던 갭)', () => {
+    const markup = renderToStaticMarkup(
+      wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} threads={MOCK_THREADS} />),
+    );
+    for (const thread of MOCK_THREADS) {
+      expect(markup).toContain(thread.comments[0]!.body);
+    }
+  });
+
+  it('renders no comment panel when threads is omitted or empty', () => {
+    const markupNoThreads = renderToStaticMarkup(
+      wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+    );
+    const markupEmptyThreads = renderToStaticMarkup(
+      wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} threads={[]} />),
+    );
+    expect(markupNoThreads).not.toContain(MOCK_THREADS[0]!.comments[0]!.body);
+    expect(markupEmptyThreads).not.toContain(MOCK_THREADS[0]!.comments[0]!.body);
   });
 });

--- a/apps/web/src/components/canvas/artifact-viewer.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl';
 import { ArtifactStage } from './artifact-stage';
 import { ArtifactVersionRail } from './artifact-version-rail';
 import { AnchorPin } from './anchor-pin';
+import { CommentThreadCard } from './comment-thread-card';
 import { DescriptionPane } from './description-pane';
 import { ExportDialog } from './export-dialog';
 import type { ArtifactVersion, MemberRef, VisualArtifact } from '@/services/canvas';
@@ -19,7 +20,8 @@ interface ArtifactViewerProps {
   /** mock 목적 — threads가 없을 때만 쓰이는 폴백 헤더 카운트(C2 착지 전). */
   commentCount?: number;
   /** C2 — 좌표 앵커 스레드는 스테이지에 핀 오버레이. element 앵커는 후속(실 artifact tree
-   * 좌표 유도 필요 — 지금은 좌표 앵커만 오버레이). */
+   * 좌표 유도 필요 — 지금은 좌표 앵커만 오버레이). 헤더 아래 스레드 목록 패널도 이 prop으로
+   * 렌더(있으면 element/coordinate 앵커 모두 카드로 나열 — 좌표 앵커만 핀 오버레이도 겸함). */
   threads?: CommentThread[];
   /** description pane 소스 — C2-S6 실 컬럼(node.description)을 element 앵커 코멘트가 가리키는
    * 노드에서 직접 조회(mock 시절 별도 DescriptionMap은 폐기 — 실 데이터 그대로 사용). */
@@ -28,6 +30,9 @@ interface ArtifactViewerProps {
    * 불가). 정본 버전을 보는 중이면 "새 버전으로 편집" 라벨(정본 계약 보호 — 실제 분기 로직은
    * BE 연동 시, 지금은 라벨만 다르고 동일 콜백). */
   onEnterEdit?: () => void;
+  /** C2-S6 실 뮤테이션 — 생략하면 카드는 읽기전용(reply 입력/resolve 버튼이 no-op). */
+  onResolveThread?: (threadId: string) => void;
+  onReplyThread?: (threadId: string, body: string) => void;
   className?: string;
 }
 
@@ -36,7 +41,9 @@ interface ArtifactViewerProps {
  * BE(`visual_artifact`/`artifact_version`, 디디 C1-S3) 미착지 — 이 컴포넌트는 props로 데이터를
  * 받는 순수 뷰라 실 API 착지 시 fetch 래퍼만 새로 감싸면 됨(컴포넌트 자체는 안 바뀜).
  */
-export function ArtifactViewer({ artifact, versions, memberMap = {}, commentCount = 0, threads, nodes = [], onEnterEdit, className }: ArtifactViewerProps) {
+export function ArtifactViewer({
+  artifact, versions, memberMap = {}, commentCount = 0, threads, nodes = [], onEnterEdit, onResolveThread, onReplyThread, className,
+}: ArtifactViewerProps) {
   const t = useTranslations('canvas');
   const [selectedVersion, setSelectedVersion] = useState(artifact.current_version);
   const isViewingAnchor = selectedVersion === artifact.anchor_version;
@@ -135,6 +142,22 @@ export function ArtifactViewer({ artifact, versions, memberMap = {}, commentCoun
             ) : undefined}
           />
         </div>
+
+        {threads && threads.length > 0 ? (
+          <div className="space-y-2 border-t border-border bg-muted/10 p-3">
+            {threads.map((th) => (
+              <CommentThreadCard
+                key={th.id}
+                thread={th}
+                memberMap={memberMap}
+                active={th.id === selectedThreadId}
+                onSelectPin={(id) => setSelectedThreadId((cur) => (cur === id ? null : id))}
+                onResolve={onResolveThread}
+                onReply={onReplyThread}
+              />
+            ))}
+          </div>
+        ) : null}
       </div>
       <ExportDialog
         open={exportOpen}

--- a/apps/web/src/components/canvas/comment-thread-card.test.tsx
+++ b/apps/web/src/components/canvas/comment-thread-card.test.tsx
@@ -36,6 +36,19 @@ describe('CommentThreadCard', () => {
     expect(markup).toContain('해결');
   });
 
+  it('shows the result-link note when the thread has a resultVersion (C3-S7 closed-loop, "주어=결과")', () => {
+    const open = MOCK_THREADS.find((t) => t.rollup === 'open')!;
+    const withResult = { ...open, resultVersion: 5 };
+    const markup = renderToStaticMarkup(wrap(<CommentThreadCard thread={withResult} memberMap={MOCK_MEMBERS} />));
+    expect(markup).toContain('v5 생성');
+  });
+
+  it('omits the result-link note when resultVersion is null', () => {
+    const open = MOCK_THREADS.find((t) => t.rollup === 'open')!;
+    const markup = renderToStaticMarkup(wrap(<CommentThreadCard thread={{ ...open, resultVersion: null }} memberMap={MOCK_MEMBERS} />));
+    expect(markup).not.toContain('생성 — 이 코멘트가 입력');
+  });
+
   it('never uses surveillance vocabulary anywhere in the rendered markup (리트머스 회귀가드)', () => {
     const markup = MOCK_THREADS.map((t) => renderToStaticMarkup(wrap(<CommentThreadCard thread={t} memberMap={MOCK_MEMBERS} />))).join('');
     for (const forbidden of ['방치', '무시', '늦음', '감점', '응답률', '미처리']) {

--- a/apps/web/src/components/canvas/comment-thread-card.tsx
+++ b/apps/web/src/components/canvas/comment-thread-card.tsx
@@ -27,6 +27,8 @@ interface CommentThreadCardProps {
  * + artifact 앵커 필드만 additive. resolved 스레드는 가라앉음(opacity↓, §3 상태 매트릭스).
  * 수신자별 읽음/응답 추적(PropagationStrip)은 실 BE에 데이터가 없고 §1 감시 리트머스에도
  * 걸려 뺐다(오르테가/PO 승인, 2026-07-10) — resolved/resolved_by 2단계 실 신호만 노출.
+ * 결과 연결(resultVersion, C3-S7 source_comment_id closed-loop)은 §1 "주어=결과" —
+ * 누가/언제 응답했는지 아닌 "이 피드백이 vN을 낳았다"만 표시(오르테가/유나 승인, 2026-07-11).
  */
 export function CommentThreadCard({
   thread, memberMap = {}, active, onSelectPin, onResolve, onReply, className,
@@ -67,6 +69,10 @@ export function CommentThreadCard({
             <p className="mt-0.5 text-xs leading-relaxed text-foreground">{c.body}</p>
           </div>
         ))}
+
+        {thread.resultVersion != null ? (
+          <p className="text-[10px] font-semibold text-info">{t('resultLinkNote', { version: thread.resultVersion })}</p>
+        ) : null}
 
         {resolved && thread.resolved_by ? (
           <p className="text-[10px] text-muted-foreground/80">{t('resolvedByNote', { name: memberMap[thread.resolved_by]?.name ?? '—' })}</p>

--- a/apps/web/src/services/canvas-comments.test.ts
+++ b/apps/web/src/services/canvas-comments.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { adaptComments, deriveAnchorKind, type BeArtifactComment } from './canvas-comments';
+import { adaptComments, deriveAnchorKind, deriveResultLinks, type BeArtifactComment } from './canvas-comments';
 
 const BASE = {
   artifact_id: 'a1', anchor_x: null, anchor_y: null, node_id: null, parent_id: null,
@@ -64,5 +64,46 @@ describe('adaptComments (flat parent_id 1단 스레드 → pin 번호 매긴 Com
     ];
     const [thread] = adaptComments(comments);
     expect(thread!.anchor).toMatchObject({ kind: 'coordinate', x: 82, y: 30 });
+  });
+
+  it('leaves resultVersion null when no version references this comment as its source', () => {
+    const comments: BeArtifactComment[] = [
+      { ...BASE, id: 'c1', content: 'x', created_by: 'm1', created_at: '2026-07-10T08:00:00Z' },
+    ];
+    const [thread] = adaptComments(comments, [], [{ version_number: 2, source_comment_id: null }]);
+    expect(thread!.resultVersion).toBeNull();
+  });
+
+  it('sets resultVersion from a version whose source_comment_id matches this thread root (C3-S7 closed-loop)', () => {
+    const comments: BeArtifactComment[] = [
+      { ...BASE, id: 'c1', content: 'x', created_by: 'm1', created_at: '2026-07-10T08:00:00Z' },
+    ];
+    const versions = [
+      { version_number: 1, source_comment_id: null },
+      { version_number: 2, source_comment_id: 'c1' },
+    ];
+    const [thread] = adaptComments(comments, [], versions);
+    expect(thread!.resultVersion).toBe(2);
+  });
+});
+
+describe('deriveResultLinks (버전 요약만으로 코멘트→결과버전 유도, 신규 fetch 0)', () => {
+  it('maps a source_comment_id to its version_number', () => {
+    const links = deriveResultLinks([{ version_number: 3, source_comment_id: 'c1' }]);
+    expect(links.get('c1')).toBe(3);
+  });
+
+  it('ignores versions with no source_comment_id', () => {
+    const links = deriveResultLinks([{ version_number: 1, source_comment_id: null }]);
+    expect(links.size).toBe(0);
+  });
+
+  it('picks the highest version_number when multiple versions cite the same comment', () => {
+    const links = deriveResultLinks([
+      { version_number: 2, source_comment_id: 'c1' },
+      { version_number: 5, source_comment_id: 'c1' },
+      { version_number: 3, source_comment_id: 'c1' },
+    ]);
+    expect(links.get('c1')).toBe(5);
   });
 });

--- a/apps/web/src/services/canvas-comments.ts
+++ b/apps/web/src/services/canvas-comments.ts
@@ -42,6 +42,9 @@ export interface CommentThread {
   comments: ArtifactComment[];
   resolved_by?: string | null;
   resolved_at?: string | null;
+  /** C3-S7 결과 연결(closed-loop) — 이 코멘트에 응답해 만들어진 버전 번호(있으면).
+   * 주어=결과("이 피드백이 vN을 낳았다") — 누가/언제 응답했는지는 노출 안 함(§1). */
+  resultVersion?: number | null;
 }
 
 // ─── mock 데이터 (컴포넌트 개발용 — 실 라우트에 노출 금지, mock-preview-slop 교훈) ──────
@@ -111,12 +114,36 @@ function labelForNode(node: NodeLabelLookup | undefined, fallback: string): stri
   return typeof text === 'string' && text.trim() ? text : node.type;
 }
 
+interface VersionSourceLookup {
+  version_number: number;
+  source_comment_id: string | null;
+}
+
+/**
+ * C3-S7 결과 연결(closed-loop) — 버전 요약 목록만으로 "이 코멘트가 어느 버전을 낳았나"
+ * 유도(신규 fetch 0, `ArtifactVersionSummary.source_comment_id`가 이미 읽기에 노출돼있음).
+ * 같은 코멘트를 응답한 버전이 여럿이면 가장 최신(version_number 최대)만 표시.
+ */
+export function deriveResultLinks(versions: VersionSourceLookup[]): Map<string, number> {
+  const result = new Map<string, number>();
+  for (const v of versions) {
+    if (!v.source_comment_id) continue;
+    const existing = result.get(v.source_comment_id);
+    if (existing === undefined || v.version_number > existing) result.set(v.source_comment_id, v.version_number);
+  }
+  return result;
+}
+
 /**
  * flat 코멘트 목록(parent_id 얕은 1단 스레드 — 답글은 항상 루트에 붙는 UI 계약) →
  * pin 번호가 매겨진 스레드 목록. 루트(parent_id=null)만 pin_number를 받고 생성시각 순.
+ * `versions`를 넘기면 결과 연결(resultVersion)도 같이 유도(생략 시 undefined).
  */
-export function adaptComments(comments: BeArtifactComment[], nodes: NodeLabelLookup[] = []): CommentThread[] {
+export function adaptComments(
+  comments: BeArtifactComment[], nodes: NodeLabelLookup[] = [], versions: VersionSourceLookup[] = [],
+): CommentThread[] {
   const nodeById = new Map(nodes.map((n) => [n.id, n]));
+  const resultLinks = deriveResultLinks(versions);
   const roots = comments
     .filter((c) => c.parent_id === null)
     .sort((a, b) => a.created_at.localeCompare(b.created_at));
@@ -146,6 +173,7 @@ export function adaptComments(comments: BeArtifactComment[], nodes: NodeLabelLoo
       comments: allComments,
       resolved_by: root.resolved_by,
       resolved_at: root.resolved_at,
+      resultVersion: resultLinks.get(root.id) ?? null,
     };
   });
 }

--- a/apps/web/src/services/canvas.ts
+++ b/apps/web/src/services/canvas.ts
@@ -151,6 +151,20 @@ export interface BeVisualArtifactSummary {
   created_at: string;
 }
 
+/**
+ * BE `ArtifactVersionSummary` 미러 — `GET /{id}/versions`(C1-S3) 목록 항목(nodes 없음).
+ * `source_comment_id`는 C3-S7(story 940266db) closed-loop 필드: 이 버전이 어느 코멘트에
+ * 응답해 생성됐는지. 신규 fetch 없이 이 목록만으로 "결과 연결(↳ vN)"을 유도할 수 있다.
+ */
+export interface BeArtifactVersionSummary {
+  id: string;
+  version_number: number;
+  summary: string | null;
+  created_by: string | null;
+  created_at: string;
+  source_comment_id: string | null;
+}
+
 export function adaptArtifactDetail(detail: BeVisualArtifactDetail): { artifact: VisualArtifact; versions: ArtifactVersion[] } {
   const format = deriveFormat(detail.nodes);
   let content: string;


### PR DESCRIPTION
## 요약
- E-CANVAS C3-S7 "결과연결(↳vN)" — 코멘트가 어떤 버전을 낳았는지 `source_comment_id` 기반으로 표시. `ArtifactVersionSummary.source_comment_id`가 이미 읽기 응답에 노출돼있어 **신규 BE 0**.
- 착수 중 그라운딩하다 발견한 갭 2건을 같이 고침(별도 트래킹 없이 fix-forward, 오르테가 승인):
  1. `ArtifactSection`(스토리 상세 첨부점)이 comments/versions를 **한 번도 fetch한 적이 없었음** — artifact detail만 가져오고 있었음.
  2. `ArtifactViewer`가 `CommentThreadCard`를 **어디에도 렌더한 적이 없었음** — 좌표 핀 오버레이 + 헤더 카운트 배지만 있고, 실제 스레드 카드 목록(내용/답글/resolve UI)은 #2029에서 만들어진 이후 한 번도 화면에 나온 적이 없었음.

## 변경사항
- `services/canvas.ts` — `BeArtifactVersionSummary` 타입 추가
- `services/canvas-comments.ts` — `deriveResultLinks()`, `CommentThread.resultVersion`, `adaptComments(comments, nodes, versions)` 3번째 파라미터
- `components/canvas/comment-thread-card.tsx` — "↳ v{N} 생성" 결과연결 표시줄(§1 감시 리트머스 준수 — 누가/언제 아닌 "이 코멘트가 결과를 낳았다"만 표시)
- `components/canvas/artifact-viewer.tsx` — 스레드 목록 패널 신설(그동안 없었던 실제 `CommentThreadCard` 렌더), `onResolveThread`/`onReplyThread` 콜백
- `components/canvas/artifact-section.tsx` — comments/versions fetch 신설 + resolve/reply 뮤테이션 배선(기존 C2-S6 엔드포인트 재사용, 신규 BE 0)
- `api/visual-artifacts/[id]/versions/route.ts` — 신규 프록시(이중봉투 fix 처음부터 적용)
- i18n `resultLinkNote` 키(ko/en)

## 검증
- `pnpm vitest run` — 193 files / 1104 passed (2 pre-existing skip)
- `pnpm lint` — 0 errors (5 warnings, 전부 이 PR 무관 기존 파일)
- `pnpm build` — exit 0
- 신규 테스트: `deriveResultLinks` 단위 3건, `adaptComments` resultVersion 배선 2건, `CommentThreadCard` 결과연결 표시/생략 2건, `ArtifactViewer` 스레드 카드 렌더/미렌더 2건

## 잔여
- 라이브픽셀 검증은 dev 배포 후(유나 몫)
- 다음 트랙: 정본 배지①+정본화 UX③(GateInbox 연동) 착수 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)