### PR TITLE
[E-CANVAS] C4-S8 정본화 UX — 정본 제안 버튼 + GateInbox 승인

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3417,6 +3417,8 @@
     "replyPlaceholder": "Reply…",
     "resolvedByNote": "Resolved by {name}",
     "resultLinkNote": "↳ Became v{version} — this comment was the input",
+    "proposeCanonicalAction": "Propose as anchor",
+    "canonicalizePendingBadge": "Proposal pending",
     "editModeLabel": "Edit mode",
     "paletteLabel": "Components",
     "propertyPanelEmpty": "Select an element to see its properties here",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3417,6 +3417,8 @@
     "replyPlaceholder": "답글…",
     "resolvedByNote": "{name}가 해결함",
     "resultLinkNote": "↳ v{version} 생성 — 이 코멘트가 입력",
+    "proposeCanonicalAction": "정본으로 제안",
+    "canonicalizePendingBadge": "정본 제안 대기 중",
     "editModeLabel": "편집 모드",
     "paletteLabel": "부품",
     "propertyPanelEmpty": "요소를 선택하면 속성이 여기 표시됩니다",

--- a/apps/web/src/app/api/visual-artifacts/[id]/versions/[versionNumber]/canonicalize/route.ts
+++ b/apps/web/src/app/api/visual-artifacts/[id]/versions/[versionNumber]/canonicalize/route.ts
@@ -1,0 +1,24 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string; versionNumber: string }> };
+
+/**
+ * POST /api/visual-artifacts/{id}/versions/{versionNumber}/canonicalize — E-CANVAS C4-S8.
+ * 정본 제안(propose-only) — 승인은 always-HITL(gate_service), BE가 artifact_canonicalize
+ * Gate를 생성. 승인/반려는 신규 UI 없이 기존 /inbox?tab=gates(GateInbox)의 generic
+ * POST /api/gates/{id}/transition이 처리(§1 에이전트 제안/인간 승인 재사용).
+ */
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const { id, versionNumber } = await params;
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    const _r = await proxyToFastapi(request, `/api/v2/visual-artifacts/${id}/versions/${versionNumber}/canonicalize`);
+    if (!_r.ok) return _r;
+    const json = (await _r.json()) as { data?: unknown };
+    return apiSuccess(json.data ?? null, undefined, 201);
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/components/cage/gate-inbox.tsx
+++ b/apps/web/src/components/cage/gate-inbox.tsx
@@ -46,6 +46,9 @@ export function GateInbox({ memberId }: GateInboxProps) {
   // doc gate는 머지 verdict의 requires_human/auto_decision 메타가 없어 gateNeedsAction이 false → 사람 결재 액션이
   // 떠야 하므로 별도 분기로 승인/반려를 surface한다(human-only authz는 BE 강제).
   const isDocGate = (g: GateItem) => g.work_item_type === 'doc' || g.gate_type === 'doc_approval';
+  // C4-S8: artifact_canonicalize도 BE _ALWAYS_MANUAL_GATE_TYPES(항상 pending·requires_human 미설정)라
+  // isDocGate와 동일하게 별도 액션 노출 분기 필요(안 하면 gateNeedsAction()이 false라 승인/반려 버튼이 안 뜸).
+  const isCanonicalizeGate = (g: GateItem) => g.gate_type === 'artifact_canonicalize';
   const resolveName = (id: string) => memberNames[id] ?? id.slice(0, 6);
   // S11 ②: 라인 컨텍스트(active step_run by story_id) + approver 이름맵.
   const [lineMap, setLineMap] = useState<Record<string, WorkflowLineStepRun>>({});
@@ -220,6 +223,13 @@ export function GateInbox({ memberId }: GateInboxProps) {
                   <span className="truncate text-xs text-muted-foreground" title={gate.work_item_summary.title}>
                     {t('docGateTitlePrefix')}{gate.work_item_summary.title}
                   </span>
+                ) : isCanonicalizeGate(gate) && typeof gate.neutral_facts?.['artifact_title'] === 'string' ? (
+                  // C4-S8: work_item_summary enrich는 doc gate 전용이라 artifact gate는 대상 없음 —
+                  // BE가 gate 생성 시 이미 neutral_facts에 담아준 artifact_title/version_number로 대체(신규 fetch 0).
+                  <span className="truncate text-xs text-muted-foreground">
+                    {gate.neutral_facts['artifact_title'] as string}
+                    {typeof gate.neutral_facts['version_number'] === 'number' ? ` v${gate.neutral_facts['version_number']}` : ''}
+                  </span>
                 ) : (
                   <span className="truncate text-xs text-muted-foreground">#{gate.work_item_id.slice(0, 6)}</span>
                 )}
@@ -291,7 +301,7 @@ export function GateInbox({ memberId }: GateInboxProps) {
                     {t('resumeAction')}
                   </Button>
                 </>
-              ) : gateNeedsAction(gate) || isDocGate(gate) ? (
+              ) : gateNeedsAction(gate) || isDocGate(gate) || isCanonicalizeGate(gate) ? (
                 <>
                   {/* doc gate: "문서에서 검토" 딥링크 primary(in-context 결재·rubber-stamp 방지). slug null이면 omit. */}
                   {isDocGate(gate) && gate.work_item_summary?.slug ? (

--- a/apps/web/src/components/canvas/artifact-section.tsx
+++ b/apps/web/src/components/canvas/artifact-section.tsx
@@ -7,6 +7,7 @@ import {
   type VisualArtifact, type BeVisualArtifactDetail, type BeVisualArtifactSummary,
 } from '@/services/canvas';
 import { adaptComments, type BeArtifactComment, type CommentThread } from '@/services/canvas-comments';
+import { derivePendingCanonicalizeVersion, type CanonicalizeGateLookup } from '@/services/canvas-canonicalize';
 import type { ArtifactNode } from '@/services/canvas-nodes';
 
 interface ArtifactSectionProps {
@@ -20,6 +21,7 @@ interface ArtifactItem {
   versions: ArtifactVersion[];
   threads: CommentThread[];
   nodes: ArtifactNode[];
+  pendingCanonicalizeVersion: number | null;
 }
 
 async function fetchJson<T>(url: string, init?: RequestInit): Promise<T | null> {
@@ -39,6 +41,18 @@ async function loadArtifactThreads(artifactId: string, nodes: ArtifactNode[]): P
     fetchJson<BeArtifactVersionSummary[]>(`/api/visual-artifacts/${artifactId}/versions`),
   ]);
   return adaptComments(comments ?? [], nodes, versionSummaries ?? []);
+}
+
+/** GET /api/gates는 BE list_gates(response_model=list[...])를 그대로 pass-through — {data} 봉투가
+ * 없다(_ok() 미경유). fetchJson과 별개 helper로 raw 배열을 직접 받는다(gate-inbox.tsx와 동일 관례). */
+async function loadPendingCanonicalizeVersion(artifactId: string): Promise<number | null> {
+  try {
+    const res = await fetch(`/api/gates?work_item_id=${artifactId}&status=pending`);
+    const gates = res.ok ? (await res.json()) as CanonicalizeGateLookup[] : [];
+    return derivePendingCanonicalizeVersion(gates);
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -61,9 +75,12 @@ export function ArtifactSection({ storyId, memberMap = {}, className }: Artifact
           const detail = await fetchJson<BeVisualArtifactDetail>(`/api/visual-artifacts/${a.id}`);
           if (!detail) return null;
           const { artifact, versions } = adaptArtifactDetail(detail);
-          const threads = await loadArtifactThreads(a.id, detail.nodes);
+          const [threads, pendingCanonicalizeVersion] = await Promise.all([
+            loadArtifactThreads(a.id, detail.nodes),
+            loadPendingCanonicalizeVersion(a.id),
+          ]);
 
-          return { artifact, versions, threads, nodes: detail.nodes };
+          return { artifact, versions, threads, nodes: detail.nodes, pendingCanonicalizeVersion };
         }));
 
         if (!cancelled) setItems(resolved.filter((d): d is ArtifactItem => d !== null));
@@ -93,11 +110,17 @@ export function ArtifactSection({ storyId, memberMap = {}, className }: Artifact
     await refreshThreads(artifactId, nodes);
   }
 
+  async function handleProposeCanonical(artifactId: string, versionNumber: number) {
+    await fetchJson(`/api/visual-artifacts/${artifactId}/versions/${versionNumber}/canonicalize`, { method: 'POST' });
+    const pendingCanonicalizeVersion = await loadPendingCanonicalizeVersion(artifactId);
+    setItems((cur) => cur.map((it) => (it.artifact.id === artifactId ? { ...it, pendingCanonicalizeVersion } : it)));
+  }
+
   if (items.length === 0) return null;
 
   return (
     <div className={className}>
-      {items.map(({ artifact, versions, threads, nodes }) => (
+      {items.map(({ artifact, versions, threads, nodes, pendingCanonicalizeVersion }) => (
         <ArtifactViewer
           key={artifact.id}
           artifact={artifact}
@@ -107,6 +130,8 @@ export function ArtifactSection({ storyId, memberMap = {}, className }: Artifact
           nodes={nodes}
           onResolveThread={(threadId) => void handleResolve(artifact.id, nodes, threadId)}
           onReplyThread={(threadId, body) => void handleReply(artifact.id, nodes, threadId, body)}
+          pendingCanonicalizeVersion={pendingCanonicalizeVersion}
+          onProposeCanonical={(versionNumber) => void handleProposeCanonical(artifact.id, versionNumber)}
         />
       ))}
     </div>

--- a/apps/web/src/components/canvas/artifact-viewer.test.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.test.tsx
@@ -59,4 +59,36 @@ describe('ArtifactViewer (SSR snapshot)', () => {
     expect(markupNoThreads).not.toContain(MOCK_THREADS[0]!.comments[0]!.body);
     expect(markupEmptyThreads).not.toContain(MOCK_THREADS[0]!.comments[0]!.body);
   });
+
+  it('shows a propose-as-anchor button on a non-anchor version when onProposeCanonical is provided (C4-S8 §1 — 제안만, 승인은 GateInbox)', () => {
+    const markup = renderToStaticMarkup(
+      // MOCK_ARTIFACT.current_version=4 is selected by default, anchor_version=3 — non-anchor.
+      wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} onProposeCanonical={() => {}} />),
+    );
+    expect(markup).toContain('정본으로 제안');
+  });
+
+  it('shows a pending badge instead of the propose button when the selected version already has a pending proposal', () => {
+    const markup = renderToStaticMarkup(
+      wrap(
+        <ArtifactViewer
+          artifact={MOCK_ARTIFACT}
+          versions={MOCK_VERSIONS}
+          memberMap={MOCK_MEMBERS}
+          onProposeCanonical={() => {}}
+          pendingCanonicalizeVersion={MOCK_ARTIFACT.current_version}
+        />,
+      ),
+    );
+    expect(markup).toContain('정본 제안 대기 중');
+    expect(markup).not.toContain('정본으로 제안');
+  });
+
+  it('omits both the propose button and pending badge without onProposeCanonical (읽기전용 폴백)', () => {
+    const markup = renderToStaticMarkup(
+      wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+    );
+    expect(markup).not.toContain('정본으로 제안');
+    expect(markup).not.toContain('정본 제안 대기 중');
+  });
 });

--- a/apps/web/src/components/canvas/artifact-viewer.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRef, useState } from 'react';
-import { Check, Download, MessageCircle, Pencil } from 'lucide-react';
+import { Check, Clock, Download, MessageCircle, Pencil, Sparkles } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { ArtifactStage } from './artifact-stage';
 import { ArtifactVersionRail } from './artifact-version-rail';
@@ -33,6 +33,10 @@ interface ArtifactViewerProps {
   /** C2-S6 실 뮤테이션 — 생략하면 카드는 읽기전용(reply 입력/resolve 버튼이 no-op). */
   onResolveThread?: (threadId: string) => void;
   onReplyThread?: (threadId: string, body: string) => void;
+  /** C4-S8 정본화 — 승인은 새 UI 없이 기존 GateInbox가 처리(§1), 여기선 제안만. 선택된
+   * 버전에 이미 대기 중인 제안이 있으면 pendingCanonicalizeVersion === selectedVersion. */
+  pendingCanonicalizeVersion?: number | null;
+  onProposeCanonical?: (versionNumber: number) => void;
   className?: string;
 }
 
@@ -42,7 +46,8 @@ interface ArtifactViewerProps {
  * 받는 순수 뷰라 실 API 착지 시 fetch 래퍼만 새로 감싸면 됨(컴포넌트 자체는 안 바뀜).
  */
 export function ArtifactViewer({
-  artifact, versions, memberMap = {}, commentCount = 0, threads, nodes = [], onEnterEdit, onResolveThread, onReplyThread, className,
+  artifact, versions, memberMap = {}, commentCount = 0, threads, nodes = [], onEnterEdit, onResolveThread, onReplyThread,
+  pendingCanonicalizeVersion, onProposeCanonical, className,
 }: ArtifactViewerProps) {
   const t = useTranslations('canvas');
   const [selectedVersion, setSelectedVersion] = useState(artifact.current_version);
@@ -79,6 +84,25 @@ export function ArtifactViewer({
               <Check className="h-3 w-3" strokeWidth={2.6} aria-hidden />
               {t('anchorBadge', { version: artifact.anchor_version })}
             </span>
+          ) : null}
+          {/* C4-S8 §1 — 에이전트/사람 모두 제안만, 승인은 GateInbox(인간 전용). 이미 정본이거나
+           * 이미 대기 중인 제안이 있으면 제안 버튼을 숨긴다(중복 제안 방지). */}
+          {!isViewingAnchor && onProposeCanonical ? (
+            pendingCanonicalizeVersion === selectedVersion ? (
+              <span className="inline-flex items-center gap-1 text-[11px] font-medium text-muted-foreground">
+                <Clock className="h-3 w-3" aria-hidden />
+                {t('canonicalizePendingBadge')}
+              </span>
+            ) : (
+              <button
+                type="button"
+                onClick={() => onProposeCanonical(selectedVersion)}
+                className="flex items-center gap-1 rounded-md border border-border px-1.5 py-0.5 text-[11px] font-semibold text-foreground hover:bg-muted"
+              >
+                <Sparkles className="h-3 w-3" aria-hidden />
+                {t('proposeCanonicalAction')}
+              </button>
+            )
           ) : null}
           <span className="ml-auto flex items-center gap-3 text-muted-foreground">
             {artifact.format === 'tree' && onEnterEdit ? (

--- a/apps/web/src/services/canvas-canonicalize.test.ts
+++ b/apps/web/src/services/canvas-canonicalize.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { derivePendingCanonicalizeVersion } from './canvas-canonicalize';
+
+describe('derivePendingCanonicalizeVersion (gates 목록만으로 대기 중 정본 제안 버전 유도)', () => {
+  it('returns null when there are no artifact_canonicalize gates', () => {
+    expect(derivePendingCanonicalizeVersion([
+      { gate_type: 'doc_approval', status: 'pending', neutral_facts: { version_number: 2 } },
+    ])).toBeNull();
+  });
+
+  it('returns null when the only canonicalize gate is not pending', () => {
+    expect(derivePendingCanonicalizeVersion([
+      { gate_type: 'artifact_canonicalize', status: 'approved', neutral_facts: { version_number: 2 } },
+    ])).toBeNull();
+  });
+
+  it('returns the version_number of a pending artifact_canonicalize gate', () => {
+    expect(derivePendingCanonicalizeVersion([
+      { gate_type: 'artifact_canonicalize', status: 'pending', neutral_facts: { version_number: 3 } },
+    ])).toBe(3);
+  });
+
+  it('ignores gates with no neutral_facts or non-numeric version_number', () => {
+    expect(derivePendingCanonicalizeVersion([
+      { gate_type: 'artifact_canonicalize', status: 'pending', neutral_facts: null },
+      { gate_type: 'artifact_canonicalize', status: 'pending', neutral_facts: { version_number: '3' } },
+    ])).toBeNull();
+  });
+
+  it('picks the highest version_number when multiple pending canonicalize gates exist', () => {
+    expect(derivePendingCanonicalizeVersion([
+      { gate_type: 'artifact_canonicalize', status: 'pending', neutral_facts: { version_number: 2 } },
+      { gate_type: 'artifact_canonicalize', status: 'pending', neutral_facts: { version_number: 4 } },
+    ])).toBe(4);
+  });
+});

--- a/apps/web/src/services/canvas-canonicalize.ts
+++ b/apps/web/src/services/canvas-canonicalize.ts
@@ -1,0 +1,25 @@
+/**
+ * E-CANVAS C4-S8 — 정본화(canonicalize) 제안 상태 유도. 승인 자체는 새 UI 없이 기존
+ * E-DG Decision Gate(`/inbox?tab=gates`)가 처리(§1 에이전트 제안/인간 승인 재사용) — 여기선
+ * "이 버전에 이미 대기 중인 제안이 있나"만 gates 목록에서 읽어 뷰어의 제안 버튼/배지 상태를
+ * 결정한다. BE `POST .../canonicalize`가 만드는 Gate는 `neutral_facts.version_number`에
+ * 대상 버전을 담아 응답(routers/visual_artifacts.py) — 신규 필드 0.
+ */
+
+export interface CanonicalizeGateLookup {
+  gate_type: string;
+  status: string;
+  neutral_facts: Record<string, unknown> | null;
+}
+
+/** artifact_canonicalize gate 중 status='pending'인 것의 대상 버전을 유도. 여럿이면 최신(최대) 채택. */
+export function derivePendingCanonicalizeVersion(gates: CanonicalizeGateLookup[]): number | null {
+  let result: number | null = null;
+  for (const g of gates) {
+    if (g.gate_type !== 'artifact_canonicalize' || g.status !== 'pending') continue;
+    const v = g.neutral_facts?.['version_number'];
+    if (typeof v !== 'number') continue;
+    if (result === null || v > result) result = v;
+  }
+  return result;
+}


### PR DESCRIPTION
## 요약
- E-CANVAS C4-S8 정본화 UX — 로드맵 v3 "지금부터" 두 번째 조각(①정본 배지+③정본화 UX를 한 조각으로).
- `POST .../canonicalize`는 **제안만**(에이전트/사람 누구든), 승인은 always-HITL — BE가 만드는 Gate는 기존 E-DG Decision Gate 인프라(`/inbox?tab=gates`, GateInbox)의 generic transition으로 그대로 처리됨(§1 재사용, 새 승인 UI 0).

## 변경사항
- `services/canvas-canonicalize.ts` — `derivePendingCanonicalizeVersion()`: gates 목록에서 이 버전에 이미 대기 중인 제안이 있는지 유도(work_item_id 필터만, 신규 fetch 0)
- `components/canvas/artifact-viewer.tsx` — 비-정본 버전 볼 때 "정본으로 제안" 버튼, 이미 대기 중이면 "정본 제안 대기 중" 배지(중복 제안 방지)
- `components/canvas/artifact-section.tsx` — gates fetch + propose 뮤테이션 배선
- `api/visual-artifacts/[id]/versions/[versionNumber]/canonicalize/route.ts` — 신규 프록시

## ⭐ 그라운딩 중 발견한 latent 버그 — 같이 fix
`gate_type='artifact_canonicalize'`는 BE `_ALWAYS_MANUAL_GATE_TYPES`에 `doc_approval`/`loop_decision`과 함께 속해 항상 pending인데, `requires_human` 필드는 (H1 merge-verdict 게이트 전용이라) 설정되지 않는다. `GateInbox`의 액션 노출 조건이 지금까지 `gateNeedsAction(gate) || isDocGate(gate)`로 `doc_approval`만 예외 처리해왔던 터라, `artifact_canonicalize` gate는 **승인/반려 버튼이 아예 안 뜨는 상태**였을 것 — `isCanonicalizeGate` 분기를 doc gate와 동일하게 추가했다. 부수로 BE가 이미 `neutral_facts`에 담아주는 `artifact_title`/`version_number`로 raw work_item_id 프리픽스 대신 사람이 읽을 수 있는 라벨도 표시.

(`loop_decision`도 같은 latent 갭이 있어 보이나 이번 스코프 밖이라 별도 finding으로 보고 예정)

## 검증
- `pnpm vitest run` — 194 files / 1112 passed (2 pre-existing skip)
- `pnpm lint` — 0 errors
- `pnpm build` — exit 0
- 신규 테스트: `derivePendingCanonicalizeVersion` 5건, `ArtifactViewer` propose 버튼/대기 배지 3건

## 잔여
- 라이브픽셀 검증은 dev 배포 후(유나 몫)
- `loop_decision` gate의 동일 latent 갭은 별도 보고 예정(이 PR 스코프 아님)

🤖 Generated with [Claude Code](https://claude.com/claude-code)