### PR TITLE
promote: develop→main — SEC-S8 prod 승격 (SEC-S1~EE, 24커밋 selective)

### DIFF
--- a/backend/alembic/versions/0170_deletion_audit_logs.py
+++ b/backend/alembic/versions/0170_deletion_audit_logs.py
@@ -1,0 +1,37 @@
+"""E-SECURITY SEC-S1(story 70c9e92c): deletion_audit_logs 테이블 — hard-delete 감사 흔적.
+
+Revision ID: 0170
+Revises: 0169
+Create Date: 2026-07-10
+
+순수 additive 신규 테이블 — 기존 스키마 무회귀.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0170"
+down_revision = "0169"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "deletion_audit_logs",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("actor_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("entity_type", sa.Text(), nullable=False),
+        sa.Column("entity_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("entity_title", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index("ix_deletion_audit_logs_org_id", "deletion_audit_logs", ["org_id"])
+    op.create_index("ix_deletion_audit_logs_entity_id", "deletion_audit_logs", ["entity_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("deletion_audit_logs")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.agent_routing_rule import AgentRoutingRule
 from app.models.agent_run import AgentRun
 from app.models.agent_session import AgentSession
 from app.models.bridge import BridgeChannelMapping, BridgeUserMapping
+from app.models.deletion_audit import DeletionAuditLog
 from app.models.embedding import Embedding
 from app.models.evidence import Evidence
 from app.models.gate import Gate

--- a/backend/app/models/deletion_audit.py
+++ b/backend/app/models/deletion_audit.py
@@ -1,0 +1,28 @@
+"""E-SECURITY SEC-S1(story 70c9e92c): hard-delete 감사 — 삭제 경로 흔적 0 해소.
+
+기존 audit 테이블은 전부 부적합: `permission_audit_logs`(role 변경 shape)·`story_activities`
+(story_id FK ondelete=CASCADE라 삭제 자체와 함께 사라져 감사 목적 무의미)·`agent_audit_logs`
+(agent_id NOT NULL — 삭제는 이제 휴먼 전용이라 안 맞음). entity_type 범용이라 story 외 삭제
+경로 확장 시(향후) 재사용 가능."""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class DeletionAuditLog(Base):
+    __tablename__ = "deletion_audit_logs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    actor_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    entity_type: Mapped[str] = mapped_column(Text, nullable=False)
+    entity_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    entity_title: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/repositories/analytics.py
+++ b/backend/app/repositories/analytics.py
@@ -266,8 +266,11 @@ class AnalyticsRepository:
         }
 
     async def get_burndown(self, sprint_id: uuid.UUID) -> dict | None:
+        # E-SECURITY SEC-S8(story 83ea3d6a) DD(까심 라이브확定, CRITICAL·cross-org): 이 파일의
+        # 다른 메소드는 전부 org_id를 필터에 넣는데(예: get_overview) 이 둘만 org_id 필터가
+        # 없어 완전 무관 org가 sprint UUID만 알면 velocity/status를 그대로 열람할 수 있었다.
         sprint_r = await self.session.execute(
-            select(Sprint).where(Sprint.id == sprint_id)
+            select(Sprint).where(Sprint.id == sprint_id, Sprint.org_id == self.org_id)
         )
         sprint = sprint_r.scalar_one_or_none()
         if sprint is None:
@@ -275,7 +278,7 @@ class AnalyticsRepository:
 
         stories_r = await self.session.execute(
             select(Story.story_points, Story.status, Story.updated_at)
-            .where(Story.sprint_id == sprint_id, Story.deleted_at.is_(None))
+            .where(Story.sprint_id == sprint_id, Story.org_id == self.org_id, Story.deleted_at.is_(None))
         )
         stories = stories_r.all()
 
@@ -322,8 +325,11 @@ class AnalyticsRepository:
         }
 
     async def get_sprint_velocity(self, sprint_id: uuid.UUID) -> dict | None:
+        # E-SECURITY SEC-S8(story 83ea3d6a) DD: get_burndown과 동형 cross-org 갭.
         result = await self.session.execute(
-            select(Sprint.velocity, Sprint.title, Sprint.status).where(Sprint.id == sprint_id)
+            select(Sprint.velocity, Sprint.title, Sprint.status).where(
+                Sprint.id == sprint_id, Sprint.org_id == self.org_id
+            )
         )
         row = result.first()
         if row is None:

--- a/backend/app/routers/a2a.py
+++ b/backend/app/routers/a2a.py
@@ -365,8 +365,19 @@ async def list_agent_cards(
 async def get_agent_card(
     member_id: uuid.UUID,
     session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> AgentCard:
-    member = await _get_agent_member(session, member_id)
+    """E-SECURITY SEC-S2(story 48ff642a): authed+same-org로 승격 — 이전엔 unauth+org무관이라
+    member_id만 알면 org 밖에서도 아무 agent 카드(이름·skills·URL) 조회 가능했다(멀티테넌트
+    격리 위반). action(/rpc)은 이미 P1-S2로 authed+org-scoped라 대칭 정합.
+
+    선생님 확認: A2A cross-org discovery(임대·마켓플레이스류) 자체는 버그 아닌 로드맵이었으나
+    멀티테넌트 격리가 성숙하기 前까지는 org로 좁히는 게 현시점 기본 정책 — `_get_agent_member`의
+    `org_id`가 이미 optional(None=무필터)이라 이 변경 자체가 영구 봉인이 아니라 "org_id를
+    지금 넘긴다"는 호출부 선택일 뿐, 재개는 이 인자를 안 넘기는 것으로 되돌릴 수 있다(코드 구조상
+    확장점 보존, 새 flag 불필요)."""
+    member = await _get_agent_member(session, member_id, org_id)
     card = await _build_agent_card(session, member, resolve_backend_direct_url())
     return card
 

--- a/backend/app/routers/agent_runs.py
+++ b/backend/app/routers/agent_runs.py
@@ -26,14 +26,22 @@ async def list_agent_runs(
     cursor: str | None = Query(default=None),
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
     repo: AgentRunRepository = Depends(_get_repo),
 ) -> list[AgentRunResponse]:
     """prod 핫픽스(S20 전수스캔 — create_agent_run과 동일 클래스): project_id가 caller org
-    소속인지 검증 없이 임의 project의 agent run 목록을 열람할 수 있었다(cross-org)."""
+    소속인지 검증 없이 임의 project의 agent run 목록을 열람할 수 있었다(cross-org).
+
+    E-SECURITY SEC-S8(story 83ea3d6a) Y(까심 전수스윕): org-scope는 이미 닫혔으나 caller의
+    실제 project 접근권(has_project_access)은 검증하지 않아, 같은 org 다른 project 멤버가
+    project_id만 알면 그 project의 agent run을 열람할 수 있었다(G-class)."""
+    from app.services.project_auth import has_project_access
+
     proj_r = await session.execute(select(Project.id).where(Project.id == project_id, Project.org_id == org_id))
     if proj_r.scalar_one_or_none() is None:
         raise HTTPException(status_code=404, detail="Project not found")
+    if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to this project")
     runs = await repo.list(project_id=project_id, agent_id=agent_id, limit=limit, cursor=cursor)
     return [AgentRunResponse.model_validate(r) for r in runs]
 

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -107,11 +107,19 @@ async def create_org_agent(
         # scope_mode='projects'로 P2(본인 무권한 project)나 scope_mode='org'로 org 전체에
         # 새 에이전트+API키를 찍어낼 수 있었다(grant 대상과 검증 대상 불일치). project_ids
         # 전원에 대해 admin role을 요구 — 하나라도 admin이 아니면 전체 요청 차단.
-        from app.services.project_auth import has_project_role
+        from app.services.project_auth import get_project_role, has_project_role
         for pid in project_ids:
             if not await has_project_role(session, actor.id, pid, min_role="admin"):
                 raise HTTPException(status_code=403, detail="project admin/owner role required to manage members")
-        if _ROLE_RANK.get(body.role, 1) > _ROLE_RANK.get(actor.role, 1):
+        # E-SECURITY SEC-S8(story 83ea3d6a) P 자매 갭(fix-on-sight, create_team_member와 동일
+        # `_resolve_actor().first()` 비결정 row-pick 원인): actor.role이 grant 대상과 무관한
+        # project의 role일 수 있어, scope_mode='org'|'projects'로 여러 project_ids 전원에 대해
+        # get_project_role의 최솟값(가장 낮은 role)으로 비교 — 하나라도 부족하면 격상 차단.
+        actor_ranks = [
+            _ROLE_RANK.get(await get_project_role(session, actor.id, pid), 1) for pid in project_ids
+        ]
+        actor_rank = min(actor_ranks) if actor_ranks else 1
+        if _ROLE_RANK.get(body.role, 1) > actor_rank:
             raise HTTPException(status_code=403, detail="Cannot assign role higher than your own")
         if body.name == actor.name:
             raise HTTPException(status_code=400, detail="Agent cannot create a member with the same name as itself")

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -105,6 +105,16 @@ async def create_org_agent(
             raise HTTPException(status_code=403, detail="Cannot assign role higher than your own")
         if body.name == actor.name:
             raise HTTPException(status_code=400, detail="Agent cannot create a member with the same name as itself")
+    else:
+        # E-SECURITY SEC-S8(story 83ea3d6a) L 자매 갭 — create_team_member와 동일 패턴으로
+        # `if actor.type == "agent"`에 갇혀 휴먼 caller(또는 actor 미해소)면 인가가 통째로
+        # 스킵됐다. 이 엔드포인트는 단일 project가 아니라 org 범위(scope_mode='org'|'projects')
+        # 라 project 단위 role 대신 org owner/admin을 요구(target-org 검증은
+        # `_resolve_org_project_ids`가 이미 project_ids⊂org 소속으로 강제해 별도 조치 불요).
+        # 에이전트 분기는 원래 로직 그대로 무회귀(위 if 블록 미변경).
+        from app.services.project_auth import is_org_owner_or_admin
+        if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
+            raise HTTPException(status_code=403, detail="org admin/owner role required to manage members")
 
     project_ids = await _resolve_org_project_ids(body, session, org_id)
 

--- a/backend/app/routers/agents.py
+++ b/backend/app/routers/agents.py
@@ -95,12 +95,22 @@ async def create_org_agent(
     # 권한: create_team_member 와 동일 규칙 재사용(agent actor 제약).
     from app.routers.team_members import _ROLE_RANK, _resolve_actor
 
+    # E-SECURITY SEC-S8(story 83ea3d6a) O: project_ids를 role 체크보다 먼저 해소해야 아래
+    # agent 분기가 실제 grant 대상 전체에 대해 admin 권한을 검증할 수 있다(기존엔 actor.project_id
+    # 하나만 봐서 grant 대상과 무관했다).
+    project_ids = await _resolve_org_project_ids(body, session, org_id)
+
     actor = await _resolve_actor(auth, session, org_id)
     if actor is not None and actor.type == "agent":
-        # S4: can_manage_members → has_project_role(min='admin') 단일 경로(role 에서 derived).
+        # E-SECURITY SEC-S8 O(까심 실HTTP 2단계 재현, PR#1557부터 존재): has_project_role이
+        # caller의 anchor project(actor.project_id) 하나만 검사해, P1에만 admin인 에이전트가
+        # scope_mode='projects'로 P2(본인 무권한 project)나 scope_mode='org'로 org 전체에
+        # 새 에이전트+API키를 찍어낼 수 있었다(grant 대상과 검증 대상 불일치). project_ids
+        # 전원에 대해 admin role을 요구 — 하나라도 admin이 아니면 전체 요청 차단.
         from app.services.project_auth import has_project_role
-        if not await has_project_role(session, actor.id, actor.project_id, min_role="admin"):
-            raise HTTPException(status_code=403, detail="project admin/owner role required to manage members")
+        for pid in project_ids:
+            if not await has_project_role(session, actor.id, pid, min_role="admin"):
+                raise HTTPException(status_code=403, detail="project admin/owner role required to manage members")
         if _ROLE_RANK.get(body.role, 1) > _ROLE_RANK.get(actor.role, 1):
             raise HTTPException(status_code=403, detail="Cannot assign role higher than your own")
         if body.name == actor.name:
@@ -115,8 +125,6 @@ async def create_org_agent(
         from app.services.project_auth import is_org_owner_or_admin
         if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
             raise HTTPException(status_code=403, detail="org admin/owner role required to manage members")
-
-    project_ids = await _resolve_org_project_ids(body, session, org_id)
 
     created_by = uuid.UUID(auth.user_id)  # 휴먼=user_id / 에이전트=member.id (anchor sync 가 휴먼만 owner 매칭)
     member, api_key_plaintext = await create_org_level_agent(

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -1,10 +1,12 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.models.pm import Sprint
 from app.repositories.analytics import AnalyticsRepository
 from app.schemas.analytics import (
     AgentStatsResponse,
@@ -17,6 +19,7 @@ from app.schemas.analytics import (
     SprintVelocityItem,
     SprintVelocityResponse,
 )
+from app.services.project_auth import has_project_access
 
 router = APIRouter(prefix="/api/v2", tags=["analytics"])
 
@@ -28,11 +31,21 @@ def _get_repo(
     return AnalyticsRepository(session, org_id)
 
 
+async def _assert_project_access(repo: AnalyticsRepository, auth: AuthContext, project_id: uuid.UUID) -> None:
+    """E-SECURITY SEC-S8(story 83ea3d6a) DD 후속: analytics.py 전 엔드포인트가 org_id는
+    필터하나 caller의 project 접근권 검증이 없어 same-org 다른 project의 집계 데이터가
+    노출됐다(오늘 R~CC와 동형)."""
+    if not await has_project_access(repo.session, uuid.UUID(auth.user_id), project_id, repo.org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+
+
 @router.get("/analytics/overview", response_model=ProjectOverviewResponse)
 async def get_overview(
     project_id: uuid.UUID = Query(...),
     repo: AnalyticsRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> ProjectOverviewResponse:
+    await _assert_project_access(repo, auth, project_id)
     data = await repo.get_overview(project_id)
     return ProjectOverviewResponse.model_validate(data)
 
@@ -42,7 +55,9 @@ async def get_member_workload(
     project_id: uuid.UUID = Query(...),
     member_id: uuid.UUID = Query(...),
     repo: AnalyticsRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> MemberWorkloadResponse:
+    await _assert_project_access(repo, auth, project_id)
     data = await repo.get_member_workload(project_id, member_id)
     return MemberWorkloadResponse.model_validate(data)
 
@@ -51,7 +66,9 @@ async def get_member_workload(
 async def get_velocity_history(
     project_id: uuid.UUID = Query(...),
     repo: AnalyticsRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[SprintVelocityItem]:
+    await _assert_project_access(repo, auth, project_id)
     items = await repo.get_velocity_history(project_id)
     return [SprintVelocityItem.model_validate(i) for i in items]
 
@@ -61,7 +78,9 @@ async def get_recent_activity(
     project_id: uuid.UUID = Query(...),
     limit: int = Query(default=10, ge=1, le=100),
     repo: AnalyticsRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> RecentActivityResponse:
+    await _assert_project_access(repo, auth, project_id)
     data = await repo.get_recent_activity(project_id, limit)
     return RecentActivityResponse.model_validate(data)
 
@@ -71,7 +90,9 @@ async def get_epic_progress(
     project_id: uuid.UUID = Query(...),
     epic_id: uuid.UUID = Query(...),
     repo: AnalyticsRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> EpicProgressResponse:
+    await _assert_project_access(repo, auth, project_id)
     data = await repo.get_epic_progress(project_id, epic_id)
     return EpicProgressResponse.model_validate(data)
 
@@ -81,7 +102,9 @@ async def get_agent_stats(
     project_id: uuid.UUID = Query(...),
     agent_id: uuid.UUID = Query(...),
     repo: AnalyticsRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> AgentStatsResponse:
+    await _assert_project_access(repo, auth, project_id)
     data = await repo.get_agent_stats(project_id, agent_id)
     if data is None:
         raise HTTPException(status_code=404, detail="Agent not found in project")
@@ -92,7 +115,9 @@ async def get_agent_stats(
 async def get_project_health(
     project_id: uuid.UUID = Query(...),
     repo: AnalyticsRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> ProjectHealthResponse:
+    await _assert_project_access(repo, auth, project_id)
     data = await repo.get_project_health(project_id)
     return ProjectHealthResponse.model_validate(data)
 
@@ -101,7 +126,14 @@ async def get_project_health(
 async def get_burndown(
     sprint_id: uuid.UUID,
     repo: AnalyticsRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> BurndownResponse:
+    sprint_project_id = (await repo.session.execute(
+        select(Sprint.project_id).where(Sprint.id == sprint_id, Sprint.org_id == repo.org_id)
+    )).scalar_one_or_none()
+    if sprint_project_id is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    await _assert_project_access(repo, auth, sprint_project_id)
     data = await repo.get_burndown(sprint_id)
     if data is None:
         raise HTTPException(status_code=404, detail="Sprint not found")
@@ -112,7 +144,14 @@ async def get_burndown(
 async def get_sprint_velocity(
     sprint_id: uuid.UUID,
     repo: AnalyticsRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> SprintVelocityResponse:
+    sprint_project_id = (await repo.session.execute(
+        select(Sprint.project_id).where(Sprint.id == sprint_id, Sprint.org_id == repo.org_id)
+    )).scalar_one_or_none()
+    if sprint_project_id is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    await _assert_project_access(repo, auth, sprint_project_id)
     data = await repo.get_sprint_velocity(sprint_id)
     if data is None:
         raise HTTPException(status_code=404, detail="Sprint not found")

--- a/backend/app/routers/attachments.py
+++ b/backend/app/routers/attachments.py
@@ -127,7 +127,11 @@ async def authorize_attachment(
                 _conversation_has_human_participant,
                 _effective_org_role,
             )
-            role = await _effective_org_role(auth, org_id, db, member)
+            # E-SECURITY SEC-S8(story 83ea3d6a) V 자매 갭(fix-on-sight): project_id 미전달이면
+            # 에이전트는 임의 project row role을 org-wide인 척 신뢰하던 갭(conversations.py
+            # get_conversation/list_messages와 동일 SSOT) — conv_proj(이미 해소된 이 conversation의
+            # 실 project)를 넘겨 그 project 전용 effective role로 재평가.
+            role = await _effective_org_role(auth, org_id, db, member, project_id=conv_proj)
             if not (
                 role in ("owner", "admin")
                 and not await _conversation_has_human_participant(conversation_id, db)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1275,8 +1275,15 @@ async def switch_project(
     if user is None:
         return _err("USER_NOT_FOUND", "User not found", 404)
 
+    # E-SECURITY SEC-S8(story 83ea3d6a) K — org_id 미전달이면 has_project_access가 org 필터
+    # 없이 판정해, J(cross-org project_access grant)로 생긴 행 하나만 있어도 target org의
+    # 정식 access+refresh 토큰이 발급되는 증폭 경로였다(SEC-S5~S8 가드를 우회하는 크리덴셜
+    # 발급 자체이므로 단순 열람보다 파급이 큼). 현재 세션의 org 컨텍스트로 명시 스코핑.
+    caller_org_id_str = auth.claims.get("app_metadata", {}).get("org_id")
+    caller_org_id = uuid.UUID(str(caller_org_id_str)) if caller_org_id_str else None
+
     # 인가 체크 — team_member ∪ project_access(granted) ∪ owner/admin (me/memberships 3-branch 정합)
-    if not await has_project_access(session, user.id, body.project_id):
+    if not await has_project_access(session, user.id, body.project_id, caller_org_id):
         return _err("NOT_MEMBER", "Not an active member of this project", 403)
 
     # target 캡처 — _build_app_metadata가 내부 fallback으로 last_project_id를 덮어쓰므로 먼저 고정

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -695,15 +695,20 @@ async def create_conversation(
     """POST /api/v2/conversations — dm/group 생성 (dm 중복 방지)."""
     sender = await _resolve_member(auth, org_id, db, project_id=body.project_id)
 
+    # E-SECURITY SEC-S3(story 90cd7e57): participant_ids가 org 멤버십 필터 없이 그대로 insert
+    # 됐음(add_participant/멘션발송과 비대칭 — 그 두 경로는 이미 org-scope 검증). cross-org UUID를
+    # 참가자로 넣을 수 있던 갭 봉쇄 — 조용히 제거(에러 아님, 존재하는 유효 참가자만 방에 남음).
+    valid_participant_ids = await filter_org_member_ids(set(body.participant_ids), org_id, db)
+
     # ⭐ 인가 불변식: 휴먼↔에이전트 대화 — 에이전트 creator 동석 필수
-    await _enforce_agent_creator_policy(sender, body.participant_ids, db)
+    await _enforce_agent_creator_policy(sender, list(valid_participant_ids), db)
 
     # EF-S2 (db75ecd0): "기존방 다이렉트" 제거 — 동일 2인 pair여도 매 호출 신규 conversation 생성
     # (여러 conversation 공존·각 1주제·hermes 세션별 1방=1주제). 179db213 의 1-DM-per-pair
     # dedup + uq_conversations_dm_pair 정책 회귀(마이그 0111 에서 unique index drop).
     # 불변 보존: creator 동석/allow_list(_enforce_agent_creator_policy 위), 메시지 dedup(send_message·별개),
     # thread=스토리. dm_pair_key 컬럼은 2인 룸 태깅용으로 유지(non-unique·dedup 아님).
-    all_members = sorted({sender.id, *body.participant_ids})
+    all_members = sorted({sender.id, *valid_participant_ids})
     is_dm = len(all_members) == 2
     dm_pair_key = "|".join(str(m) for m in all_members) if is_dm else None
 

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -169,15 +169,27 @@ async def _resolve_member(
 
 
 async def _effective_org_role(
-    auth: AuthContext, org_id: uuid.UUID, db: AsyncSession, sender: "ResolvedMember | TeamMember"
+    auth: AuthContext, org_id: uuid.UUID, db: AsyncSession, sender: "ResolvedMember | TeamMember",
+    project_id: uuid.UUID | None = None,
 ) -> str:
     """sender.role에 org owner/admin 상속(S-MBR-03). team_members 뷰는 **project role만** 주므로
     org owner/admin이 project-member로 나오는 갭(#1223 agent-view 게이트 ↔ 멤버-SSOT 뷰)을 보정 —
-    /me effective-role과 일관(버그: org owner/admin이 agent-view 403). 에이전트(API키)는 org role
-    무관이라 sender.role 그대로."""
-    if sender.role in ("owner", "admin"):
-        return sender.role
+    /me effective-role과 일관(버그: org owner/admin이 agent-view 403).
+
+    E-SECURITY SEC-S8(story 83ea3d6a) V(까심 전수스윕, 실HTTP 확定): 에이전트는 org-wide role
+    개념이 없음(project_access.role만 존재)인데 `_resolve_member`의 agent 분기가 project_id
+    무관하게 `.first()`로 임의 1행을 뽑아(P와 동형 비결정 row-pick) sender.role을 그대로
+    신뢰했다 — mixed-role 에이전트(예: X=admin·Y=grant 0)가 project_x의 admin 지위를 빌려와
+    project_y의 agent-only 대화를 admin-bypass로 열람할 수 있었다(참가자 아님에도 200). fix=
+    project_id가 주어지면 **그 project 전용** effective role을 get_project_role(P가 쓴 SSOT)로
+    재평가 — 휴먼은 원래대로 org-wide OrgMember.role(진짜 org 전체 권한이라 무관)."""
     if bool(auth.claims.get("app_metadata", {}).get("api_key_id")):
+        if project_id is None:
+            return sender.role  # 레거시 폴백(project_id 미전달 호출부 — 현재 전 호출부가 전달함)
+        from app.services.project_auth import get_project_role
+        role = await get_project_role(db, sender.id, project_id)
+        return role or "member"
+    if sender.role in ("owner", "admin"):
         return sender.role
     om_role = (await db.execute(
         select(OrgMember.role).where(
@@ -749,7 +761,9 @@ async def list_conversations(
 
     # AC5: include_agent_conversations는 owner/admin만 허용 (org-effective role — project team_member
     # role이 낮아도 org owner/admin이면 상속·#1223↔SSOT뷰 갭 보정)
-    if include_agent_conversations and await _effective_org_role(auth, org_id, db, sender) not in ("owner", "admin"):
+    if include_agent_conversations and await _effective_org_role(
+        auth, org_id, db, sender, project_id=project_id,
+    ) not in ("owner", "admin"):
         raise HTTPException(status_code=403, detail="Only owner/admin can view agent conversations.")
 
     conv_ids_result = await db.execute(
@@ -885,7 +899,9 @@ async def get_conversation(
         raise HTTPException(status_code=404, detail="Conversation not found")
 
     sender = await _resolve_member(auth, org_id, db, project_id=None)
-    is_admin = await _effective_org_role(auth, org_id, db, sender) in ("owner", "admin")
+    is_admin = await _effective_org_role(
+        auth, org_id, db, sender, project_id=conv.project_id,
+    ) in ("owner", "admin")
     # admin이어도 휴먼 참가(private) 대화면 participant 체크 폴백
     if (not is_admin) or await _conversation_has_human_participant(conversation_id, db):
         sender = await _resolve_member(auth, org_id, db, project_id=conv.project_id)
@@ -936,7 +952,9 @@ async def list_messages(
     sender = await _resolve_member(auth, org_id, db, project_id=None)
 
     # org-effective role(S-MBR-03·#1223↔SSOT뷰 갭 보정) — project role 낮아도 org owner/admin 상속
-    is_admin = await _effective_org_role(auth, org_id, db, sender) in ("owner", "admin")
+    is_admin = await _effective_org_role(
+        auth, org_id, db, sender, project_id=conv_project_id,
+    ) in ("owner", "admin")
     # admin이어도 휴먼 참가(private) 대화면 participant 체크 폴백(사적 DM 프라이버시)
     if (not is_admin) or await _conversation_has_human_participant(conversation_id, db):
         # project isolation 보존 — project 소속 member 재확인

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -427,6 +427,19 @@ async def delete_doc(
     # f69fcd91: 대상 doc 의 project 접근 강제(cross-project IDOR 차단·get_project_scoped_org_id 의 org-only
     # fallback 으로 同org 비-project caller 가 타 project doc 삭제 가능하던 갭). 없으면 404·무권한 403.
     await _require_doc_project_access(repo.session, id, uuid.UUID(auth.user_id), repo.org_id)
+    # E-SECURITY SEC-S1 확장(까심 적대적 QA 발견 갭): delete_story와 동형으로 휴먼 전용화 + 삭제 감사.
+    from app.services.member_resolver import resolve_member
+    deleter = await resolve_member(auth, repo.org_id, repo.session)
+    if deleter.type != "human":
+        raise HTTPException(status_code=403, detail="Doc 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)")
+    doc = await repo.get(id)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Doc not found")
+    from app.models.deletion_audit import DeletionAuditLog
+    repo.session.add(DeletionAuditLog(
+        id=uuid.uuid4(), org_id=repo.org_id, actor_id=deleter.id,
+        entity_type="doc", entity_id=id, entity_title=doc.title,
+    ))
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Doc not found")
@@ -434,8 +447,6 @@ async def delete_doc(
     # 삭제 권한자(인증 caller) 트리거 system cascade — human-gate authz 우회 정당(별도 결재 아님). void 는
     # begin_nested 격리 best-effort라 삭제 비중단. pending 아니면 no-op(멱등)·doc_approval 만 스코핑.
     from app.services.gate_service import void_pending_doc_gate
-    from app.services.member_resolver import resolve_member
-    deleter = await resolve_member(auth, repo.org_id, repo.session)
     await void_pending_doc_gate(repo.session, repo.org_id, id, deleter.id)
     return {"ok": True}
 

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -127,6 +127,22 @@ async def list_docs(
     return [DocSummaryResponse.model_validate(d) for d in docs]
 
 
+async def _assert_doc_parent_in_project(
+    session: AsyncSession, project_id: uuid.UUID, parent_id: uuid.UUID | None,
+) -> None:
+    """E-SECURITY SEC-S8(story 83ea3d6a) Y(까심 전수스윕): parent_id가 project_id 소속인지
+    검증 없이 그대로 repo.create/setattr에 적용됐다(DocRepository.create는 BaseRepository
+    상속이라 소유권 검증 0) — 같은 org 다른 project의 doc을 parent로 지정해 doc 트리를
+    오염시킬 수 있었다(T/G와 동형 project-scope 부재). create/update 양쪽 재사용."""
+    if parent_id is None:
+        return
+    parent_project_id = (await session.execute(
+        select(Doc.project_id).where(Doc.id == parent_id, Doc.deleted_at.is_(None))
+    )).scalar_one_or_none()
+    if parent_project_id != project_id:
+        raise HTTPException(status_code=404, detail="Parent doc not found")
+
+
 @router.post("", response_model=DocResponse, status_code=201)
 async def create_doc(
     body: DocCreate,
@@ -143,6 +159,7 @@ async def create_doc(
         db=session,
         user_id=uuid.UUID(auth.user_id),
     )
+    await _assert_doc_parent_in_project(session, body.project_id, body.parent_id)
     # ⭐RC#1(body-trust 봉인): created_by 를 **인증 caller 로 강제**(body.created_by 무시·attribution
     # 위조 차단). 다른 doc write 경로(_resolve_doc_member_id·line~501)와 대칭. AC3-2d(2) canonical 유지.
     created_by = await _resolve_doc_member_id(auth, org_id, session)
@@ -330,6 +347,9 @@ async def update_doc(
                     "current_updated_at": doc.updated_at.isoformat(),
                 },
             )
+
+    if "parent_id" in data:
+        await _assert_doc_parent_in_project(session, doc.project_id, data["parent_id"])
 
     # 일반 필드 적용 (slug 제외)
     for attr, val in data.items():

--- a/backend/app/routers/epics.py
+++ b/backend/app/routers/epics.py
@@ -162,9 +162,15 @@ async def delete_epic(
     Supabase 레거시(db=undefined) 의존으로 깨져 있었고 그게 유일한 admin/owner 가드였다.
     삭제하면 권한 누수(org member/viewer 가 에픽 삭제)이므로 authz 를 BE SSOT 로 옮긴다.
     admin/owner 는 org-wide 접근권이라 project 접근권을 자동 충족한다(별도 project 게이트 불요).
+
+    E-SECURITY SEC-S1 확장(까심 적대적 QA 발견): is_org_owner_or_admin은 org_members(휴먼 전용
+    grant 테이블)만 조회해 에이전트가 구조적으로 통과 불가하나, 그건 암묵적 부산물일 뿐 — cascade로
+    소속 stories까지 물리삭제되는 파괴력을 고려해 delete_story와 동형인 명시적 human-only 체크를
+    추가한다(암묵적 방어에만 기대지 않음).
     """
     from app.repositories.dependency import DependencyRepository
     from app.repositories.label import ItemLabelRepository
+    from app.services.member_resolver import resolve_member
     from app.services.project_auth import is_org_owner_or_admin
 
     # 존재 검증 먼저(없으면 404) — authz 결과로 존재 여부가 새지 않도록 404 우선.
@@ -172,11 +178,20 @@ async def delete_epic(
     if epic is None:
         raise HTTPException(status_code=404, detail="Epic not found")
 
+    resolved = await resolve_member(auth, org_id, session)
+    if resolved.type != "human":
+        raise HTTPException(status_code=403, detail="Epic 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)")
+
     if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
         raise HTTPException(
             status_code=403, detail="Epic deletion requires admin or owner role"
         )
 
+    from app.models.deletion_audit import DeletionAuditLog
+    session.add(DeletionAuditLog(
+        id=uuid.uuid4(), org_id=org_id, actor_id=resolved.id,
+        entity_type="epic", entity_id=id, entity_title=epic.title,
+    ))
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Epic not found")

--- a/backend/app/routers/file_locks.py
+++ b/backend/app/routers/file_locks.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, field_validator
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -281,14 +281,26 @@ async def unlock_files(
 
 @router.get("/api/v2/file-locks")
 async def list_file_locks(
+    project_id: uuid.UUID = Query(...),
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[dict]:
-    """AC6: 현재 프로젝트 내 활성 file lock 목록."""
+    """AC6: 현재 프로젝트 내 활성 file lock 목록.
+
+    E-SECURITY SEC-S8(story 83ea3d6a) Y(까심 전수스윕): 독스트링은 "현재 프로젝트 내"지만
+    실제 쿼리는 FileLock.org_id만 필터하고 project_id 필터 자체가 없어 org 전체 lock이
+    노출됐다(같은 org 다른 project 멤버도 전 project의 활성 lock을 열람 가능). project_id를
+    필수 쿼리 파라미터로 받아 has_project_access로 caller의 실제 접근권도 검증한다."""
+    from app.services.project_auth import has_project_access
+
+    if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
     result = await session.execute(
         select(FileLock).where(
             FileLock.org_id == org_id,
+            FileLock.project_id == project_id,
             FileLock.released_at.is_(None),
         )
     )

--- a/backend/app/routers/github_integration.py
+++ b/backend/app/routers/github_integration.py
@@ -173,8 +173,11 @@ async def create_explicit_link(
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """PR↔story **명시연결**(explicit·confidence high·Bot-L.2 UI 의 BE). resolver 체인 최우선·close-on-merge
-    가능. ⭐anti-IDOR **2층**: ①story 가 caller org 소속 ②**repo 가 org 의 설치 context**(installation account)에
-    속함. 둘 다 미충족 = generic 404(타 org/repo 존재 oracle 0). per-org 격리·upsert·created_by=caller member.
+    가능. ⭐anti-IDOR **2+1층**: ①story 가 caller org 소속 ②caller가 그 story의 project 접근권 보유
+    (E-SECURITY SEC-S8 Y, 까심 전수스윕 — 기존엔 org-scope만 있고 project-scope가 없어 같은 org
+    다른 project의 story에도 PR 링크를 생성할 수 있었다·T/X와 동형) ③**repo 가 org 의 설치 context**
+    (installation account)에 속함. 전부 미충족 = generic 404(타 org/repo 존재 oracle 0). per-org
+    격리·upsert·created_by=caller member.
     """
     if not body.repo_full_name.strip() or "/" not in body.repo_full_name or body.pr_number <= 0:
         return JSONResponse(status_code=422, content={"error": "invalid_pr_identity"})
@@ -187,6 +190,10 @@ async def create_explicit_link(
         )
     ).scalar_one_or_none()
     if story is None:
+        return JSONResponse(status_code=404, content={"error": "story_not_found"})
+    # ②project-scope 검증(SEC-S8 Y) — org만으론 same-org cross-project 링크 생성을 못 막는다.
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(session, uuid.UUID(auth.user_id), story.project_id, org_id):
         return JSONResponse(status_code=404, content={"error": "story_not_found"})
     # ②repo 가 org 의 설치 context 에 속하는지(anti-IDOR·임의 repo high link 차단). org 의 active installation
     # account_login 과 repo owner 일치 요구. 미설치/owner 불일치 = generic 404(repo 존재 oracle 0).
@@ -238,11 +245,14 @@ def _link_view(link: PullRequestStoryLink) -> dict:
 async def list_links(
     story_id: uuid.UUID = Query(...),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    """story 의 PR↔story 링크 목록(Bot-L.2 UI '연결 PR 표시'). org-scope·story 선검증(anti-IDOR).
-    타 org/부재 story = generic 404(존재 oracle 0). 링크는 org+story+미삭제만 반환."""
+    """story 의 PR↔story 링크 목록(Bot-L.2 UI '연결 PR 표시'). org-scope·project-scope·story
+    선검증(anti-IDOR, SEC-S8 Y fix-on-sight — create_explicit_link 자매 갭). 타 org/무권한
+    project/부재 story = generic 404(존재 oracle 0). 링크는 org+story+미삭제만 반환."""
+    from app.services.project_auth import has_project_access
+
     story = (
         await session.execute(
             select(Story).where(
@@ -251,6 +261,8 @@ async def list_links(
         )
     ).scalar_one_or_none()
     if story is None:
+        return JSONResponse(status_code=404, content={"error": "story_not_found"})
+    if not await has_project_access(session, uuid.UUID(auth.user_id), story.project_id, org_id):
         return JSONResponse(status_code=404, content={"error": "story_not_found"})
     links = (
         await session.execute(

--- a/backend/app/routers/github_integration.py
+++ b/backend/app/routers/github_integration.py
@@ -282,11 +282,17 @@ async def list_links(
 async def delete_link(
     link_id: uuid.UUID,
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     """PR↔story 링크 해제(Bot-L.2 UI '해제'·soft-delete). ⭐anti-IDOR: `link.id AND org_id` — 타 org/부재/
-    이미 삭제는 generic 404(존재 oracle 0). soft-delete(deleted_at) 라 close-on-merge resolver 에서 즉시 제외."""
+    이미 삭제는 generic 404(존재 oracle 0). soft-delete(deleted_at) 라 close-on-merge resolver 에서 즉시 제외.
+
+    E-SECURITY SEC-S8(story 83ea3d6a) Z(까심 QA, 라이브 확定): org_id만으론 부족했다 — create_explicit_
+    link/list_links(Y)는 project-scope를 이미 닫았는데 delete는 빠져 있었다(S/X와 동형 패턴). link이
+    가리키는 story의 project에 caller가 접근권 있는지도 검증."""
+    from app.services.project_auth import has_project_access
+
     link = (
         await session.execute(
             select(PullRequestStoryLink).where(
@@ -297,6 +303,13 @@ async def delete_link(
         )
     ).scalar_one_or_none()
     if link is None:
+        return JSONResponse(status_code=404, content={"error": "link_not_found"})
+    story_project_id = (
+        await session.execute(select(Story.project_id).where(Story.id == link.story_id))
+    ).scalar_one_or_none()
+    if story_project_id is None or not await has_project_access(
+        session, uuid.UUID(auth.user_id), story_project_id, org_id
+    ):
         return JSONResponse(status_code=404, content={"error": "link_not_found"})
     link.deleted_at = datetime.now(timezone.utc)
     await session.commit()

--- a/backend/app/routers/meetings.py
+++ b/backend/app/routers/meetings.py
@@ -12,19 +12,32 @@ from app.schemas.meeting import MeetingCreate, MeetingResponse, MeetingUpdate
 router = APIRouter(prefix="/api/v2/meetings", tags=["meetings"])
 
 
-def _get_repo(
+async def _get_repo(
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
-    _org_id: uuid.UUID = Depends(get_verified_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     project_id_q: uuid.UUID | None = Query(default=None, alias="project_id"),
 ) -> MeetingRepository:
+    """E-SECURITY SEC-S8(story 83ea3d6a) G: `get_verified_org_id`가 계산만 되고(dead
+    computation) `MeetingRepository`는 project_id만으로 스코핑돼(org_id 개념 자체가 없는
+    repo) org/project 접근권 미검증인 채 임의 project_id(query param 또는 JWT app_metadata)를
+    그대로 받아들였다 — delete_meeting은 F에서 이미 봉쇄했으나 list/get/update/put은
+    미봉쇄였음(같은 `_get_repo` 공유라 여기 한 곳에서 닫으면 4개 핸들러 전부 커버).
+    has_project_access(org_id=)가 org-scope + project-scope(team_member/grant/owner-admin
+    floor)를 한 번에 강제한다."""
     pid = (str(project_id_q) if project_id_q else None) or auth.claims.get("app_metadata", {}).get("project_id")
     if not pid:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="project_id required (query param or JWT app_metadata)",
         )
-    return MeetingRepository(session, uuid.UUID(str(pid)))
+    project_id = uuid.UUID(str(pid))
+
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
+    return MeetingRepository(session, project_id)
 
 
 @router.get("", response_model=list[MeetingResponse])

--- a/backend/app/routers/meetings.py
+++ b/backend/app/routers/meetings.py
@@ -1,6 +1,7 @@
 import uuid
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user, get_verified_org_id
@@ -104,7 +105,38 @@ async def put_meeting(
 async def delete_meeting(
     id: uuid.UUID,
     repo: MeetingRepository = Depends(_get_repo),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    """E-SECURITY SEC-S8(story 83ea3d6a) F — 까심 전수스윕 CRITICAL: `_get_repo`가
+    `get_verified_org_id`를 계산만 하고(`_org_id`, dead computation) `MeetingRepository`는
+    project_id만으로 스코핑돼(org_id 개념 자체가 없는 repo) org 무관 임의 project_id를 그대로
+    받아들였다 — Org B agent가 Org A meeting을 무인증 삭제(200·무감사) 가능했음. SEC-S1과
+    동형으로 human-gate + 삭제 감사 추가, 그 위에 target project의 실 org를 caller org와 대조
+    (SEC-S6/S7 헬퍼 재사용)."""
+    from app.services.member_resolver import resolve_member
+    from app.services.project_auth import assert_target_in_caller_org
+
+    target_org_id = (await session.execute(
+        text("SELECT org_id FROM projects WHERE id = :pid"), {"pid": str(repo.project_id)},
+    )).scalar_one_or_none()
+    assert_target_in_caller_org(org_id, target_org_id, not_found_detail="Meeting not found")
+
+    resolved = await resolve_member(auth, org_id, session)
+    if resolved.type != "human":
+        raise HTTPException(status_code=403, detail="Meeting 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)")
+
+    meeting = await repo.get(id)
+    if meeting is None:
+        raise HTTPException(status_code=404, detail="Meeting not found")
+
+    from app.models.deletion_audit import DeletionAuditLog
+    session.add(DeletionAuditLog(
+        id=uuid.uuid4(), org_id=org_id, actor_id=resolved.id,
+        entity_type="meeting", entity_id=id, entity_title=meeting.title,
+    ))
+
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Meeting not found")

--- a/backend/app/routers/members.py
+++ b/backend/app/routers/members.py
@@ -5,9 +5,10 @@ from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.team import TeamMember
+from app.services.project_auth import assert_target_in_caller_org
 
 router = APIRouter(prefix="/api/v2/members", tags=["members"])
 
@@ -27,12 +28,23 @@ async def list_members(
     project_id: uuid.UUID = Query(...),
     session: AsyncSession = Depends(get_db),
     _auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> list[MemberResponse]:
     """프로젝트 멤버 목록.
 
     Human: org_members + project_access JOIN (grant 모델 — 레코드 있음 = 접근 허용).
     Agent: team_members(type=agent) 그대로 유지.
     """
+    # E-SECURITY SEC-S6(story 54248174·까심 QA 부수발견 D): project_id가 caller org 소속인지
+    # 대조한 적이 없어 타 org project_id로 그 org 멤버 로스터가 그대로 열거됐다(cross-org IDOR).
+    # 존재/타org 둘 다 404(존재 비노출).
+    project_org_row = await session.execute(
+        text("SELECT org_id FROM projects WHERE id = :project_id"),
+        {"project_id": project_id},
+    )
+    project_org_id = project_org_row.scalar_one_or_none()
+    assert_target_in_caller_org(org_id, project_org_id, not_found_detail="Project not found")
+
     result: list[MemberResponse] = []
 
     # Human members — org owner/admin은 grant 없이도 항상 포함 (S-MBR-03).
@@ -42,6 +54,8 @@ async def list_members(
     # 기존 `COALESCE(u.email,'')`는 휴먼을 항상 raw 이메일로 노출해, 동일 휴먼을
     # 실명(display_name)으로 보여주는 org 로스터(team_member.py list_org_human_members)와
     # 어긋났다(보드/Dispatch assignee 가 email 노출). 두 경로를 동일 COALESCE 로 정렬한다.
+    #
+    # p.org_id = :org_id — 위 가드로 이미 보장되지만 defense-in-depth로 join에도 명시.
     human_rows = await session.execute(
         text(
             """
@@ -50,7 +64,7 @@ async def list_members(
                    om.role
             FROM org_members om
             JOIN users u ON u.id = om.user_id
-            JOIN projects p ON p.org_id = om.org_id AND p.id = :project_id
+            JOIN projects p ON p.org_id = om.org_id AND p.id = :project_id AND p.org_id = :org_id
             LEFT JOIN members m ON m.org_id = om.org_id AND m.user_id = om.user_id
                                AND m.type = 'human' AND m.deleted_at IS NULL
             WHERE om.deleted_at IS NULL
@@ -66,7 +80,7 @@ async def list_members(
             ORDER BY name
             """
         ),
-        {"project_id": str(project_id)},
+        {"project_id": str(project_id), "org_id": str(org_id)},
     )
     for row in human_rows:
         result.append(MemberResponse(id=row[0], name=row[1], type="human", role=row[2], is_active=True))

--- a/backend/app/routers/oss.py
+++ b/backend/app/routers/oss.py
@@ -5,9 +5,10 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.pm import Story
+from app.services.project_auth import has_project_access
 
 router = APIRouter(prefix="/api/v2/oss", tags=["oss"])
 
@@ -21,10 +22,17 @@ _SAMPLE_STORIES = [
 @router.post("/seed")
 async def oss_seed(
     project_id: uuid.UUID,
-    org_id: uuid.UUID,
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
+    # E-SECURITY SEC-S8(story 83ea3d6a) EE(까심 전수스윕, CRITICAL): org_id가 get_verified_org_id를
+    # 거치지 않는 raw client query param이라 인증 유저가 소속 여부와 무관하게 임의 org_id로
+    # 시드를 심을 수 있었다(access-control 자체 부재). org_id는 이제 서버파생(JWT/X-Org-Id
+    # membership 검증) + project_id도 caller 접근권 검증.
+    if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+
     count_r = await session.execute(
         select(func.count()).select_from(Story).where(
             Story.project_id == project_id, Story.org_id == org_id, Story.deleted_at.is_(None)

--- a/backend/app/routers/project_access.py
+++ b/backend/app/routers/project_access.py
@@ -134,6 +134,26 @@ async def create_project_access(
             session, member_id=body.member_id, project_id=project_id
         )
     else:
+        # E-SECURITY SEC-S8(story 83ea3d6a) J — 까심 전수스윕 CRITICAL: 에이전트 분기는
+        # target agent의 org가 project org와 일치하는지 검증하나(`m.org_id = p.org_id`), 휴먼
+        # 분기는 대칭 검증이 없었다(`ensure_human_member`는 org_member 존재만 확인). Org A
+        # owner가 임의 Org B org_member_id로 이 project에 grant 행을 만들 수 있었음(라이브
+        # 201 재현) — cross-org project_access 생성 자체가 SEC-S8 K(switch-project)의 토큰
+        # 발급 증폭으로 이어지는 근본. #1549(X-Project-Id 헤더 오버라이드)와는 무관한 축이라
+        # 회귀 없음 — 여기서 검증하는 건 body.org_member_id가 "이 project의 org" 소속인지뿐.
+        from sqlalchemy import text
+        target_org_ok = (await session.execute(
+            text(
+                "SELECT 1 FROM org_members om JOIN projects p ON p.id = :pid "
+                "WHERE om.id = :omid AND om.deleted_at IS NULL AND om.org_id = p.org_id LIMIT 1"
+            ),
+            {"pid": str(project_id), "omid": str(body.org_member_id)},
+        )).scalar_one_or_none()
+        if target_org_ok is None:
+            raise HTTPException(
+                status_code=400, detail="org_member_id must belong to the project's org"
+            )
+
         existing = await session.execute(
             select(ProjectAccess).where(
                 ProjectAccess.project_id == project_id,

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -129,9 +129,13 @@ async def delete_project(
     org_id: uuid.UUID = Depends(get_verified_org_id),
     session: AsyncSession = Depends(get_db),
 ) -> dict:
+    from app.models.deletion_audit import DeletionAuditLog
+    from app.services.member_resolver import resolve_member
+
     repo = ProjectRepository(session, org_id)
+    project = await repo.get(id)
     # 미접근 멤버에겐 존재 비노출(404).
-    if await repo.get(id) is None or not await has_project_access(
+    if project is None or not await has_project_access(
         session, uuid.UUID(auth.user_id), id, org_id
     ):
         raise HTTPException(status_code=404, detail="Project not found")
@@ -141,6 +145,16 @@ async def delete_project(
             status_code=403,
             detail="프로젝트 삭제는 조직 owner/admin 권한이 필요합니다",
         )
+    # E-SECURITY SEC-S1 확장(까심 적대적 QA 발견): is_org_owner_or_admin은 org_members(휴먼 전용)만
+    # 조회해 에이전트가 구조적으로 통과 불가하나 암묵적 부산물일 뿐 — story·epic과 동형으로 명시적
+    # human-only 체크 + 삭제 감사를 추가한다(cascade 파괴력 고려).
+    resolved = await resolve_member(auth, org_id, session)
+    if resolved.type != "human":
+        raise HTTPException(status_code=403, detail="Project 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)")
+    session.add(DeletionAuditLog(
+        id=uuid.uuid4(), org_id=org_id, actor_id=resolved.id,
+        entity_type="project", entity_id=id, entity_title=project.name,
+    ))
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Project not found")

--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -228,6 +228,21 @@ async def update_sprint(
     auth: AuthContext = Depends(get_current_user),
 ) -> SprintResponse:
     data = body.model_dump(exclude_unset=True)
+    # E-SECURITY SEC-S8(story 83ea3d6a) Z(까심 전수스윕): report_doc_id가 sprint의 project 소속인지
+    # 검증 없이 그대로 repo.update에 전달됐다(T-class) — 같은 org 다른 project의 doc을 sprint
+    # report로 지정할 수 있었다.
+    if "report_doc_id" in data and data["report_doc_id"] is not None:
+        from app.models.doc import Doc
+        _sprint_for_doc_check = await repo.get(id)
+        if _sprint_for_doc_check is None:
+            raise HTTPException(status_code=404, detail="Sprint not found")
+        doc_project_id = (await session.execute(
+            select(Doc.project_id).where(
+                Doc.id == data["report_doc_id"], Doc.deleted_at.is_(None),
+            )
+        )).scalar_one_or_none()
+        if doc_project_id != _sprint_for_doc_check.project_id:
+            raise HTTPException(status_code=404, detail="Report doc not found")
     # ⭐E-DG S26: status 변경은 transition_sprint 단일경로(FSM/overlay/human-gate) 경유 — PATCH 옆문
     # 봉인(S25 epic PATCH-bypass 교훈). 나머지 필드만 repo.update.
     _status_change = data.pop("status", None)

--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -96,13 +96,25 @@ async def list_sprints(
     project_id: uuid.UUID | None = Query(default=None),
     status_filter: str | None = Query(default=None, alias="status"),
     repo: SprintRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[SprintResponse]:
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC(선생님 "sprint org-level=갭" 확定): 라우터 13개
+    # 전부 org-scope만이고 project-scope 0이던 것 중 하나 — project_id 미지정 시 caller의
+    # project 접근권과 무관하게 org 전체 sprint가 노출됐다. project_id 지정 시엔 접근권 검증,
+    # 미지정 시엔 accessible_project_ids_in_org로 필터(완전봉인, Z-standup 패턴 동형).
+    from app.services.project_auth import accessible_project_ids_in_org, has_project_access
+
     filters: dict = {}
     if project_id:
+        if not await has_project_access(repo.session, uuid.UUID(auth.user_id), project_id, repo.org_id):
+            raise HTTPException(status_code=404, detail="Project not found")
         filters["project_id"] = project_id
     if status_filter:
         filters["status"] = status_filter
     sprints = await repo.list(**filters)
+    if not project_id:
+        accessible = set(await accessible_project_ids_in_org(repo.session, uuid.UUID(auth.user_id), repo.org_id))
+        sprints = [s for s in sprints if s.project_id in accessible]
     return [SprintResponse.model_validate(s) for s in sprints]
 
 
@@ -114,6 +126,12 @@ async def create_sprint(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> SprintResponse:
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: body.project_id에 접근권 검증 없이 caller가
+    # 임의 org-내 project에 sprint를 생성할 수 있었다.
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(session, uuid.UUID(auth.user_id), body.project_id, org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+
     repo = SprintRepository(session, org_id)
     # 8a2bbda2: 날짜에서 duration 산출 저장(dates 단일진실·신규 정합). 날짜 없으면 model default(14).
     _dur = compute_sprint_duration(body.start_date, body.end_date)
@@ -144,9 +162,15 @@ async def create_sprint(
 async def get_sprint(
     id: uuid.UUID,
     repo: SprintRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> SprintResponse:
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: sprint id-scoped 조회에 project 접근권 검증 없이
+    # org 내 어느 project의 sprint든 조회 가능했다.
+    from app.services.project_auth import has_project_access
     sprint = await repo.get(id)
     if sprint is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    if not await has_project_access(repo.session, uuid.UUID(auth.user_id), sprint.project_id, repo.org_id):
         raise HTTPException(status_code=404, detail="Sprint not found")
     return SprintResponse.model_validate(sprint)
 
@@ -162,9 +186,17 @@ async def list_sprint_hypotheses(
     repo: SprintRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[SprintHypothesisItem]:
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: read-쌍둥이(POST declare_sprint_hypothesis는 이미
+    # resolve_member(project_id=)로 검증하는데 이 GET은 검증 없이 미러링 안 됐던 갭 — 발견즉시수정.
+    from app.services.project_auth import has_project_access
     sprint = await repo.get(id)
     if sprint is None:
+        raise HTTPException(
+            status_code=404, detail={"code": "SPRINT_NOT_FOUND", "message": "스프린트를 찾을 수 없습니다."}
+        )
+    if not await has_project_access(session, uuid.UUID(auth.user_id), sprint.project_id, org_id):
         raise HTTPException(
             status_code=404, detail={"code": "SPRINT_NOT_FOUND", "message": "스프린트를 찾을 수 없습니다."}
         )
@@ -227,6 +259,15 @@ async def update_sprint(
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> SprintResponse:
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: PATCH가 project 접근권 검증 없이 org 내 어느
+    # project의 sprint든 갱신 가능했다(report_doc_id Z-fix는 별개 갭 — 이건 sprint 자체 접근권).
+    from app.services.project_auth import has_project_access
+    _scope_sprint = await repo.get(id)
+    if _scope_sprint is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    if not await has_project_access(session, uuid.UUID(auth.user_id), _scope_sprint.project_id, org_id):
+        raise HTTPException(status_code=404, detail="Sprint not found")
+
     data = body.model_dump(exclude_unset=True)
     # E-SECURITY SEC-S8(story 83ea3d6a) Z(까심 전수스윕): report_doc_id가 sprint의 project 소속인지
     # 검증 없이 그대로 repo.update에 전달됐다(T-class) — 같은 org 다른 project의 doc을 sprint
@@ -251,7 +292,7 @@ async def update_sprint(
         from app.services.member_resolver import resolve_member
         current = await repo.get(id)
         if current is not None and _status_change != current.status:
-            caller = await resolve_member(auth, org_id, session)
+            caller = await resolve_member(auth, org_id, session, project_id=current.project_id)
             try:
                 await transition_sprint(session, org_id, caller, id, _status_change)
             except SprintTransitionError as exc:
@@ -293,18 +334,22 @@ async def delete_sprint(
     """E-SECURITY SEC-S8(story 83ea3d6a) H: delete_story/delete_task와 동형으로 휴먼
     전용화 + 삭제 감사(hard-delete의 에이전트 우회 벡터 차단). org-scope 자체는
     BaseRepository.get()이 org_id로 이미 필터해 안전(cross-org 삭제는 원래도 404) —
-    누락됐던 건 human-gate와 audit뿐."""
+    누락됐던 건 human-gate와 audit뿐.
+
+    E-SECURITY SEC-S8(story 83ea3d6a) CC(까심 전수스윕): H가 "org-scope는 안전"이라 명시했던
+    범위는 cross-org뿐 — cross-project(같은 org 다른 project sprint 삭제)는 그대로 뚫려
+    있었다. resolve_member(project_id=)로 human-gate와 project 접근권을 한 번에 강제."""
     from app.models.deletion_audit import DeletionAuditLog
     from app.repositories.dependency import DependencyRepository
     from app.repositories.label import ItemLabelRepository
 
-    resolved = await resolve_member(auth, org_id, session)
-    if resolved.type != "human":
-        raise HTTPException(status_code=403, detail="Sprint 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)")
-
     sprint = await repo.get(id)
     if sprint is None:
         raise HTTPException(status_code=404, detail="Sprint not found")
+
+    resolved = await resolve_member(auth, org_id, session, project_id=sprint.project_id)
+    if resolved.type != "human":
+        raise HTTPException(status_code=403, detail="Sprint 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)")
 
     session.add(DeletionAuditLog(
         id=uuid.uuid4(), org_id=org_id, actor_id=resolved.id,
@@ -330,7 +375,12 @@ async def activate_sprint(
     # 제약) 로직은 transition_sprint 가 위임 보존. default-off 면 즉시 활성(거동 동일).
     from app.services.sprint import SprintTransitionError, transition_sprint
     from app.services.member_resolver import resolve_member
-    caller = await resolve_member(auth, org_id, session)
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: project 접근권 검증 없이 caller가 resolve_member(project_id
+    # 없이)로만 통과 → org 내 어느 project의 sprint든 활성화 가능했다.
+    _sprint_for_scope = await SprintRepository(session, org_id).get(id)
+    if _sprint_for_scope is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    caller = await resolve_member(auth, org_id, session, project_id=_sprint_for_scope.project_id)
     try:
         sprint = await transition_sprint(session, org_id, caller, id, "active")
         await session.commit()
@@ -358,7 +408,11 @@ async def close_sprint(
     # active|review 수용) 로직 위임 보존. default-off/advisory 면 즉시 마감(거동 동일).
     from app.services.sprint import SprintTransitionError, transition_sprint
     from app.services.member_resolver import resolve_member
-    caller = await resolve_member(auth, org_id, db)
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: activate_sprint와 동형 갭 — project 접근권 미검증.
+    _sprint_for_scope = await SprintRepository(db, org_id).get(id)
+    if _sprint_for_scope is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    caller = await resolve_member(auth, org_id, db, project_id=_sprint_for_scope.project_id)
     try:
         sprint = await transition_sprint(db, org_id, caller, id, "closed")
     except (SprintTransitionError, ValueError) as exc:
@@ -393,9 +447,15 @@ async def kickoff_sprint(
     id: uuid.UUID,
     body: KickoffBody = KickoffBody(),
     repo: SprintRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: project 접근권 검증 없이 org 내 어느 project의
+    # sprint든 kickoff 발동 가능했다.
+    from app.services.project_auth import has_project_access
     sprint = await repo.get(id)
     if sprint is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    if not await has_project_access(repo.session, uuid.UUID(auth.user_id), sprint.project_id, repo.org_id):
         raise HTTPException(status_code=404, detail="Sprint not found")
     # Notification dispatch is Phase D — return stub for Phase B
     return {"notified": 0, "sprint_id": str(id), "message": body.message}
@@ -406,10 +466,16 @@ async def sprint_summary(
     id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
     repo: SprintRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
     """GET /api/v2/sprints/{id}/summary — 스프린트 스토리 상태별 집계 (AC3 S-STANDUP-FIX)."""
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: project 접근권 검증 없이 남의 project sprint의
+    # 스토리 상태별 집계가 노출됐다.
+    from app.services.project_auth import has_project_access
     sprint = await repo.get(id)
     if sprint is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    if not await has_project_access(db, uuid.UUID(auth.user_id), sprint.project_id, repo.org_id):
         raise HTTPException(status_code=404, detail="Sprint not found")
 
     stories_result = await db.execute(
@@ -448,9 +514,15 @@ async def checkin_sprint(
     date: str = Query(..., description="YYYY-MM-DD"),
     db: AsyncSession = Depends(get_db),
     repo: SprintRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: project 접근권 검증 없이 남의 project sprint의
+    # standup 미제출자 명단(이름 포함)이 노출됐다.
+    from app.services.project_auth import has_project_access
     sprint = await repo.get(id)
     if sprint is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    if not await has_project_access(db, uuid.UUID(auth.user_id), sprint.project_id, repo.org_id):
         raise HTTPException(status_code=404, detail="Sprint not found")
 
     try:
@@ -513,7 +585,11 @@ async def transition_sprint_endpoint(
     human-gate(enforcing) 단일 SSOT. caller 인증 컨텍스트 도출(RC① 패턴)."""
     from app.services.sprint import SprintTransitionError, transition_sprint
     from app.services.member_resolver import resolve_member
-    caller = await resolve_member(auth, org_id, session)
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: activate/close와 동형 갭 — project 접근권 미검증.
+    _sprint_for_scope = await SprintRepository(session, org_id).get(id)
+    if _sprint_for_scope is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    caller = await resolve_member(auth, org_id, session, project_id=_sprint_for_scope.project_id)
     try:
         sprint = await transition_sprint(session, org_id, caller, id, body.status)
         await session.commit()

--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -273,9 +273,29 @@ async def delete_sprint(
     repo: SprintRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    """E-SECURITY SEC-S8(story 83ea3d6a) H: delete_story/delete_task와 동형으로 휴먼
+    전용화 + 삭제 감사(hard-delete의 에이전트 우회 벡터 차단). org-scope 자체는
+    BaseRepository.get()이 org_id로 이미 필터해 안전(cross-org 삭제는 원래도 404) —
+    누락됐던 건 human-gate와 audit뿐."""
+    from app.models.deletion_audit import DeletionAuditLog
     from app.repositories.dependency import DependencyRepository
     from app.repositories.label import ItemLabelRepository
+
+    resolved = await resolve_member(auth, org_id, session)
+    if resolved.type != "human":
+        raise HTTPException(status_code=403, detail="Sprint 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)")
+
+    sprint = await repo.get(id)
+    if sprint is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+
+    session.add(DeletionAuditLog(
+        id=uuid.uuid4(), org_id=org_id, actor_id=resolved.id,
+        entity_type="sprint", entity_id=id, entity_title=sprint.title,
+    ))
+
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Sprint not found")

--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -23,7 +23,7 @@ from app.services.project_auth import accessible_project_ids_in_org
 
 
 async def _entries_with_plan_stories(
-    entries: list[StandupEntry], session: AsyncSession, org_id: uuid.UUID
+    entries: list[StandupEntry], session: AsyncSession, org_id: uuid.UUID, viewer_user_id: uuid.UUID,
 ) -> list[StandupEntryResponse]:
     """a9e67531: 엔트리들의 plan_story_ids 를 **org-scope batch resolve**(N+1 회피) → plan_stories 주입.
 
@@ -31,10 +31,18 @@ async def _entries_with_plan_stories(
     stories 배열로는 미해소(미노출 버그). 여기서 org-scope 로 id+title+status(+priority/project/sprint) 해소해
     내려준다. ⭐org-scope 강제(`Story.org_id==org_id`)·삭제 제외·타org/미존재 id 는 **조용히 제외**(노출 0)·
     plan_story_ids **입력 순서 보존**. plan_story_ids 는 하위호환 유지(FE id-only fallback).
-    """
+
+    E-SECURITY SEC-S8(story 83ea3d6a) Z(까심 전수스윕, 실HTTP 확定): org-scope만으로는 부족했다 —
+    project_a만 grant된 caller가 project_b story_id를 plan_story_ids에 넣으면(쓰기 측 미검증) org-scope
+    enrich가 그대로 title/project_id를 노출했다(caller의 project 접근권과 무관한 read-side 정보유출).
+    viewer_user_id의 accessible_project_ids_in_org로 한 번 더 필터 — story의 project에 viewer가
+    접근권 없으면 조용히 제외(타org/삭제/미존재와 동일 취급, no oracle)."""
     all_ids = {sid for e in entries for sid in (e.plan_story_ids or [])}
     summaries: dict[uuid.UUID, PlanStorySummary] = {}
     if all_ids:
+        from app.services.project_auth import accessible_project_ids_in_org
+
+        accessible_pids = set(await accessible_project_ids_in_org(session, viewer_user_id, org_id))
         rows = (
             await session.execute(
                 select(
@@ -48,6 +56,8 @@ async def _entries_with_plan_stories(
             )
         ).all()
         for sid, title, status, priority, pid, spid in rows:
+            if pid not in accessible_pids:
+                continue  # viewer가 접근권 없는 project의 story는 조용히 제외(Z).
             summaries[sid] = PlanStorySummary(
                 id=sid, title=title, status=status, priority=priority,
                 project_id=pid, sprint_id=spid,
@@ -55,7 +65,7 @@ async def _entries_with_plan_stories(
     out: list[StandupEntryResponse] = []
     for e in entries:
         resp = StandupEntryResponse.model_validate(e)
-        # 순서 보존 + 미발견(타org/삭제/미존재) 조용히 제외.
+        # 순서 보존 + 미발견(타org/삭제/미존재/접근권 없음) 조용히 제외.
         resp.plan_stories = [summaries[sid] for sid in (e.plan_story_ids or []) if sid in summaries]
         out.append(resp)
     return out
@@ -81,6 +91,44 @@ async def _sync_org_level_links(
     await repo.resync_project_links(entry.id, accessible)
 
 
+async def _filter_write_links_to_accessible(
+    session: AsyncSession, org_id: uuid.UUID, caller_user_id: uuid.UUID,
+    sprint_id: uuid.UUID | None, plan_story_ids: list[uuid.UUID],
+) -> tuple[uuid.UUID | None, list[uuid.UUID]]:
+    """E-SECURITY SEC-S8(story 83ea3d6a) Z(까심 전수스윕, 실HTTP 확定): sprint_id/plan_story_ids가
+    caller 접근권 밖 project를 가리켜도 검증 없이 그대로 저장됐다(T-class) — project_a만 grant된
+    caller가 project_b sprint/story를 참조해도 막지 않았다. caller의 accessible_project_ids_in_org로
+    write 전에 필터 — 접근권 밖이면 sprint_id는 None으로, plan_story_ids는 조용히 제외(no oracle)."""
+    if sprint_id is None and not plan_story_ids:
+        return sprint_id, plan_story_ids  # 검증할 링크가 없으면 조회 자체를 스킵.
+
+    from app.services.project_auth import accessible_project_ids_in_org
+
+    accessible_pids = set(await accessible_project_ids_in_org(session, caller_user_id, org_id))
+
+    safe_sprint_id = sprint_id
+    if sprint_id is not None:
+        from app.models.pm import Sprint
+        sprint_pid = (await session.execute(
+            select(Sprint.project_id).where(Sprint.id == sprint_id, Sprint.org_id == org_id)
+        )).scalar_one_or_none()
+        if sprint_pid is None or sprint_pid not in accessible_pids:
+            safe_sprint_id = None
+
+    safe_plan_story_ids = plan_story_ids
+    if plan_story_ids:
+        rows = (await session.execute(
+            select(Story.id, Story.project_id).where(
+                Story.id.in_(plan_story_ids), Story.org_id == org_id, Story.deleted_at.is_(None),
+            )
+        )).all()
+        accessible_story_ids = {sid for sid, pid in rows if pid in accessible_pids}
+        # 순서 보존.
+        safe_plan_story_ids = [sid for sid in plan_story_ids if sid in accessible_story_ids]
+
+    return safe_sprint_id, safe_plan_story_ids
+
+
 def _get_repo(
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
@@ -95,6 +143,7 @@ async def list_standups(
     sprint_id: uuid.UUID | None = Query(default=None),
     date_filter: date | None = Query(default=None, alias="date"),
     repo: StandupEntryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[StandupEntryResponse]:
     filters: dict = {}
     if project_id:
@@ -108,7 +157,7 @@ async def list_standups(
     if date_filter:
         filters["date"] = date_filter
     entries = await repo.list(**filters)
-    return await _entries_with_plan_stories(entries, repo.session, repo.org_id)
+    return await _entries_with_plan_stories(entries, repo.session, repo.org_id, uuid.UUID(auth.user_id))
 
 
 @router.post("", response_model=StandupEntryResponse, status_code=201)
@@ -121,20 +170,23 @@ async def upsert_standup(
     # AC3-3: 작성자 신원을 canonical members.id로 정규화(레거시 휴먼 team_member.id → alias 치환).
     # write↔read(카드/missing) 동일 canonical 정합 — #1167 회귀(API 200≠카드표시) 방지.
     author_id = await canonicalize_member_id(body.author_id, session)
+    safe_sprint_id, safe_plan_story_ids = await _filter_write_links_to_accessible(
+        session, org_id, uuid.UUID(auth.user_id), body.sprint_id, body.plan_story_ids,
+    )
     repo = StandupEntryRepository(session, org_id)
     entry = await repo.upsert(
         project_id=body.project_id,
         author_id=author_id,
         date=body.date,
-        sprint_id=body.sprint_id,
+        sprint_id=safe_sprint_id,
         done=body.done,
         plan=body.plan,
         blockers=body.blockers,
-        plan_story_ids=body.plan_story_ids,
+        plan_story_ids=safe_plan_story_ids,
     )
     # 1c2be9db: org-level write(project_id 없음) → author 접근 프로젝트로 링크 full overwrite.
     await _sync_org_level_links(repo, session, entry, body.project_id, auth.user_id, org_id)
-    return (await _entries_with_plan_stories([entry], session, org_id))[0]
+    return (await _entries_with_plan_stories([entry], session, org_id, uuid.UUID(auth.user_id)))[0]
 
 
 @router.put("", response_model=StandupEntryResponse)
@@ -155,20 +207,23 @@ async def update_standup(
     canonical로 함께** 옮겨 멀티프로젝트 휴먼 단일 신원(48e653e9 해소) + saved-but-not-displayed 회귀 0.
     """
     member = await resolve_member(auth, org_id, session, project_id=body.project_id)
+    safe_sprint_id, safe_plan_story_ids = await _filter_write_links_to_accessible(
+        session, org_id, uuid.UUID(auth.user_id), body.sprint_id, body.plan_story_ids,
+    )
     repo = StandupEntryRepository(session, org_id)
     entry = await repo.upsert(
         project_id=body.project_id,
         author_id=member.id,
         date=body.date,
-        sprint_id=body.sprint_id,
+        sprint_id=safe_sprint_id,
         done=body.done,
         plan=body.plan,
         blockers=body.blockers,
-        plan_story_ids=body.plan_story_ids,
+        plan_story_ids=safe_plan_story_ids,
     )
     # 1c2be9db: org-level self-save(project_id 없음) → author 접근 프로젝트로 링크 full overwrite.
     await _sync_org_level_links(repo, session, entry, body.project_id, auth.user_id, org_id)
-    return (await _entries_with_plan_stories([entry], session, org_id))[0]
+    return (await _entries_with_plan_stories([entry], session, org_id, uuid.UUID(auth.user_id)))[0]
 
 
 @router.get("/history", response_model=list[StandupEntryResponse])
@@ -176,6 +231,7 @@ async def list_standup_history(
     project_id: uuid.UUID = Query(...),
     limit: int = Query(default=30, ge=1, le=200),
     repo: StandupEntryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[StandupEntryResponse]:
     """GET /api/v2/standups/history — 최근 N개 스탠드업 히스토리 조회 (AC2 S-STANDUP-FIX).
 
@@ -183,7 +239,7 @@ async def list_standup_history(
     백로그→데일리 할일(plan_story_ids)이 plan_stories 빈 채 내려가 cross-board 미노출(SaaS FE 프록시 포함).
     """
     entries = await repo.list(project_id=project_id, limit=limit)
-    return await _entries_with_plan_stories(entries, repo.session, repo.org_id)
+    return await _entries_with_plan_stories(entries, repo.session, repo.org_id, uuid.UUID(auth.user_id))
 
 
 @router.get("/missing", response_model=list[uuid.UUID])
@@ -224,12 +280,13 @@ async def list_feedback(
 async def get_standup(
     id: uuid.UUID,
     repo: StandupEntryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> StandupEntryResponse:
     entry = await repo.get(id)
     if entry is None:
         raise HTTPException(status_code=404, detail="Standup entry not found")
     # b47f9b05: 단건 조회도 plan_stories enrich(list/upsert/update 와 일관·cross-board 백로그 노출).
-    return (await _entries_with_plan_stories([entry], repo.session, repo.org_id))[0]
+    return (await _entries_with_plan_stories([entry], repo.session, repo.org_id, uuid.UUID(auth.user_id)))[0]
 
 
 @router.post("/{id}/feedback", response_model=FeedbackResponse, status_code=201)

--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -167,16 +167,19 @@ async def upsert_standup(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> StandupEntryResponse:
-    # AC3-3: 작성자 신원을 canonical members.id로 정규화(레거시 휴먼 team_member.id → alias 치환).
-    # write↔read(카드/missing) 동일 canonical 정합 — #1167 회귀(API 200≠카드표시) 방지.
-    author_id = await canonicalize_member_id(body.author_id, session)
+    # E-SECURITY SEC-S8(story 83ea3d6a) EE(까심 전수스윕, CRITICAL·라이브확定): body.project_id
+    # 접근권 검증이 없었고 + body.author_id가 client-supplied 그대로 신뢰돼(canonicalize만·
+    # self-scope 검증 0) 남의 project에 남의 이름으로 standup을 위조할 수 있었다(impersonation).
+    # update_standup(PUT)은 이미 resolve_member(project_id=)로 안전했던 것과 동형으로 맞춘다 —
+    # body.author_id는 이제 무시(하위호환 위해 스키마엔 유지)하고 caller 신원을 서버파생한다.
+    member = await resolve_member(auth, org_id, session, project_id=body.project_id)
     safe_sprint_id, safe_plan_story_ids = await _filter_write_links_to_accessible(
         session, org_id, uuid.UUID(auth.user_id), body.sprint_id, body.plan_story_ids,
     )
     repo = StandupEntryRepository(session, org_id)
     entry = await repo.upsert(
         project_id=body.project_id,
-        author_id=author_id,
+        author_id=member.id,
         date=body.date,
         sprint_id=safe_sprint_id,
         done=body.done,
@@ -294,7 +297,7 @@ async def add_feedback(
     id: uuid.UUID,
     body: FeedbackCreate,
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> FeedbackResponse:
     from app.schemas.standup import REVIEW_TYPES
@@ -306,12 +309,25 @@ async def add_feedback(
     if entry is None:
         raise HTTPException(status_code=404, detail="Standup entry not found")
 
-    # AC3-3 (트랩#9 co-write): feedback 작성자도 author_id와 동일 canonical members.id로 정규화.
-    feedback_by_id = await canonicalize_member_id(body.feedback_by_id, session)
+    # E-SECURITY SEC-S8(story 83ea3d6a) EE(까심 전수스윕, CRITICAL·라이브확定): "트랩#9" 주석으로
+    # 위험을 인지하고도 body.project_id 접근권 검증이 없었고 + body.feedback_by_id가
+    # client-supplied 그대로 신뢰돼(canonicalize만·self-scope 검증 0) 남의 project에 남의
+    # 이름으로 feedback을 위조할 수 있었다(upsert_standup과 동형 impersonation).
+    #
+    # 까심 QA(1차 fix 이후 재확定): body.project_id(호출자 주장값)로만 접근권을 검증하면
+    # caller가 project_a grant인데 project_b entry에 body.project_id=project_a라 주장해
+    # 우회할 수 있었다 — "body가 주장하는 project를 믿지 말고 실제 리소스(entry)의 project를
+    # 써라"가 근본. entry.project_id(org-level entry면 None=project-scope 검사 스킵)로 검증.
+    member = await resolve_member(auth, org_id, session, project_id=entry.project_id)
+    safe_sprint_id, _ = await _filter_write_links_to_accessible(
+        session, org_id, uuid.UUID(auth.user_id), body.sprint_id, [],
+    )
+
+    feedback_by_id = member.id
     fb_repo = StandupFeedbackRepository(session, org_id)
     feedback = await fb_repo.create(
         project_id=body.project_id,
-        sprint_id=body.sprint_id,
+        sprint_id=safe_sprint_id,
         standup_entry_id=id,
         feedback_by_id=feedback_by_id,
         review_type=body.review_type,

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -253,13 +253,17 @@ _STORY_LINK_TABLES = {"epic_id": "epics", "sprint_id": "sprints", "meeting_id": 
 
 
 async def _assert_story_link_targets_in_project(
-    session: AsyncSession, project_id: uuid.UUID, body: StoryCreate,
+    session: AsyncSession, project_id: uuid.UUID, body: "StoryCreate | StoryUpdate",
 ) -> None:
     """E-SECURITY SEC-S8(story 83ea3d6a) T(까심 전수스윕, 실HTTP 확定): epic_id/sprint_id/
     meeting_id가 body.project_id 소속인지 검증 없이 그대로 repo.create에 전달됐다 — 같은 org
     다른 project의 epic/sprint/meeting에 story를 링크할 수 있었다(G/R와 동형 project-scope
     부재). enforce_body_context는 body.project_id 자체만 caller와 대조할 뿐, 그 project_id
-    "안에" 링크 대상이 실제로 속하는지는 안 본다."""
+    "안에" 링크 대상이 실제로 속하는지는 안 본다.
+
+    E-SECURITY SEC-S8 X(까심 전수스윕): T는 create_story만 닫았고 update_story(PATCH) 경로가
+    남아있었다 — 여기서 StoryUpdate도 받아 같은 검증을 update_story에도 재사용(대상 project는
+    기존 story 자신의 project_id, StoryUpdate엔 project_id 필드 자체가 없어 변경 불가)."""
     for field, table in _STORY_LINK_TABLES.items():
         target_id = getattr(body, field)
         if target_id is None:
@@ -658,6 +662,7 @@ async def update_story(
     if _story_for_access is None:
         raise HTTPException(status_code=404, detail="Story not found")
     await _assert_story_project_access(db, auth, repo.org_id, _story_for_access.project_id)
+    await _assert_story_link_targets_in_project(db, _story_for_access.project_id, body)
 
     data = body.model_dump(exclude_unset=True)
     # S7: client 제공 asset_id strip(서버 권위·drift 방지·까심)·아래 sync url_map 으로만 역기입.

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -578,7 +578,13 @@ async def bulk_update_stories(
     updated: list[Story] = []
     old_status_by_id: dict[uuid.UUID, str] = {}
     for item in payload.items:
-        q = await db.execute(select(Story).where(Story.id == item.id))
+        # E-SECURITY SEC-S8(story 83ea3d6a) W(까심 QA, CRITICAL·실HTTP 확定): 이 raw 쿼리가
+        # org_id 필터 자체가 없어(정상 repo.get()은 self._org_filter() 명시·RLS도 0002서 off)
+        # 타 org의 story UUID만 알면 status/sprint_id/assignee_id/priority/position 전부
+        # 변조 가능했다(cross-org IDOR). repo.org_id로 스코프.
+        q = await db.execute(
+            select(Story).where(Story.id == item.id, Story.org_id == repo.org_id)
+        )
         story = q.scalar_one_or_none()
         if not story:
             continue

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user, get_project_scoped_org_id, get_verified_org_id
 from app.dependencies.database import get_db
+from app.models.deletion_audit import DeletionAuditLog
 from app.models.event import Event
 from app.models.pm import Epic, Story, StoryActivity, StoryComment
 from app.models.team import TeamMember
@@ -20,7 +21,7 @@ from app.services.event_seq import assign_recipient_seq
 from app.services import mcp_attachment_upload
 from app.services.asset_registry import DEFAULT_CONTAINER, sync_attachment_assets
 from app.schemas.story import StoryAttachment, StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
-from app.services.member_resolver import canonicalize_member_id, filter_org_member_ids
+from app.services.member_resolver import canonicalize_member_id, filter_org_member_ids, resolve_member
 from app.services.merge_verdict_gate import (
     AUTO_MERGE,
     evaluate_merge_gate,
@@ -851,10 +852,32 @@ async def delete_story(
     repo: StoryRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    """E-SECURITY SEC-S1(story 70c9e92c): hard-delete는 휴먼 전용 — 에이전트 API키(사람 승인
+    없는 즉시 물리삭제)는 403. 삭제 전 actor/target를 감사 기록(story row 자체는 삭제되므로
+    미리 캡처 — DeletionAuditLog는 story FK 없이 독립 테이블이라 삭제 후에도 생존)."""
     from app.repositories.dependency import DependencyRepository
     from app.repositories.label import ItemLabelRepository
     from app.repositories.participation import ParticipationRepository
+
+    resolved = await resolve_member(auth, org_id, session)
+    if resolved.type != "human":
+        raise HTTPException(status_code=403, detail="Story 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)")
+
+    story = await repo.get(id)
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+
+    session.add(DeletionAuditLog(
+        id=uuid.uuid4(),
+        org_id=org_id,
+        actor_id=resolved.id,
+        entity_type="story",
+        entity_id=id,
+        entity_title=story.title,
+    ))
+
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Story not found")

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -166,6 +166,19 @@ async def _attach_has_evidence(session: AsyncSession, stories: list[Story]) -> N
             s.has_evidence = True
 
 
+async def _assert_story_project_access(
+    session: AsyncSession, auth: AuthContext, org_id: uuid.UUID, project_id: uuid.UUID
+) -> None:
+    """E-SECURITY SEC-S8(story 83ea3d6a) G: 개별-ID story 접근(get/update/status)이 org-scope만
+    있고 project 접근권 미검증이던 갭 — 같은 org 다른 project 멤버가 story id만 알면 조회/수정
+    가능했다. upload_story_attachment와 동형으로 has_project_access 재사용(휴먼 team_member·
+    에이전트 project_access grant 양쪽 처리). delete_story는 SEC-S3(#2014)가 별도 처리."""
+    from app.services.project_auth import has_project_access
+
+    if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
+
 async def _upsert_assignee_participation(
     session: AsyncSession, org_id: uuid.UUID, story_id: uuid.UUID, assignee_id: uuid.UUID
 ) -> None:
@@ -358,10 +371,12 @@ async def get_workflow_line_metrics(
 async def get_story(
     id: uuid.UUID,
     repo: StoryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> StoryResponse:
     story = await repo.get(id)
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")
+    await _assert_story_project_access(repo.session, auth, repo.org_id, story.project_id)
     await _attach_assignee_ids(repo.session, repo.org_id, [story])
     await _attach_has_evidence(repo.session, [story])
     return StoryResponse.model_validate(story)
@@ -607,6 +622,11 @@ async def update_story(
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
 ) -> StoryResponse:
+    _story_for_access = await repo.get(id)
+    if _story_for_access is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+    await _assert_story_project_access(db, auth, repo.org_id, _story_for_access.project_id)
+
     data = body.model_dump(exclude_unset=True)
     # S7: client 제공 asset_id strip(서버 권위·drift 방지·까심)·아래 sync url_map 으로만 역기입.
     if data.get("attachments"):
@@ -898,6 +918,8 @@ async def update_story_status(
     auth: AuthContext = Depends(get_current_user),
 ) -> StoryResponse:
     story_before = await repo.get(id)
+    if story_before is not None:
+        await _assert_story_project_access(db, auth, repo.org_id, story_before.project_id)
     old_status = story_before.status if story_before else None
 
     # 정공법 A(c1cd484b·선생님 지시): 전이 순서 **하드블록 폐지** — 비순차 점프도 항상 allow,

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -889,6 +889,14 @@ async def delete_story(
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")
 
+    # E-SECURITY SEC-S3(story 90cd7e57): DELETE가 org-only 스코핑이라 프로젝트 미멤버(같은 org의
+    # 다른 프로젝트 소속)도 스토리 삭제 가능했음 — upload_story_attachment와 동일 SSOT
+    # (has_project_access)로 project 인가 적용. SEC-S1의 human-gate(에이전트 차단)와는 직교 축
+    # (actor 타입 vs project 소속) — human이어도 무관한 project면 여전히 403.
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(session, uuid.UUID(auth.user_id), story.project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
     session.add(DeletionAuditLog(
         id=uuid.uuid4(),
         org_id=org_id,

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -579,6 +579,8 @@ async def bulk_update_stories(
     except Exception:  # noqa: BLE001 — actor 해소 실패도 bulk 비차단.
         actor_id = None
 
+    from app.services.project_auth import has_project_access
+
     updated: list[Story] = []
     old_status_by_id: dict[uuid.UUID, str] = {}
     for item in payload.items:
@@ -591,6 +593,12 @@ async def bulk_update_stories(
         )
         story = q.scalar_one_or_none()
         if not story:
+            continue
+        # E-SECURITY SEC-S8(story 83ea3d6a) W2(까심 QA): org_id 필터로 cross-org는 닫혔으나
+        # same-org 다른 project의 story는 여전히 변조 가능했다(project-scope 부재, G/T와 동형).
+        # 개별-ID PATCH(_assert_story_project_access)와 동일 기준(has_project_access) 재사용 —
+        # 미접근 item은 not-found와 동형으로 조용히 스킵(존재 비노출·나머지 정당 item은 진행).
+        if not await has_project_access(db, uuid.UUID(auth.user_id), story.project_id, repo.org_id):
             continue
         update_data = item.model_dump(exclude={"id"}, exclude_none=True)
         # status 변경이면 전이 前 old_status 포착(violation 판정용·setattr 前).

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Query, Response
 from pydantic import BaseModel, field_validator
-from sqlalchemy import or_, select
+from sqlalchemy import or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -249,6 +249,31 @@ def _enforce_mcp_attachment_declared_limit(attachments: list[dict]) -> None:
         )
 
 
+_STORY_LINK_TABLES = {"epic_id": "epics", "sprint_id": "sprints", "meeting_id": "meetings"}
+
+
+async def _assert_story_link_targets_in_project(
+    session: AsyncSession, project_id: uuid.UUID, body: StoryCreate,
+) -> None:
+    """E-SECURITY SEC-S8(story 83ea3d6a) T(까심 전수스윕, 실HTTP 확定): epic_id/sprint_id/
+    meeting_id가 body.project_id 소속인지 검증 없이 그대로 repo.create에 전달됐다 — 같은 org
+    다른 project의 epic/sprint/meeting에 story를 링크할 수 있었다(G/R와 동형 project-scope
+    부재). enforce_body_context는 body.project_id 자체만 caller와 대조할 뿐, 그 project_id
+    "안에" 링크 대상이 실제로 속하는지는 안 본다."""
+    for field, table in _STORY_LINK_TABLES.items():
+        target_id = getattr(body, field)
+        if target_id is None:
+            continue
+        target_project_id = (await session.execute(
+            text(f"SELECT project_id FROM {table} WHERE id = :id"),  # noqa: S608 — table은 고정 allowlist(_STORY_LINK_TABLES), 요청값 아님
+            {"id": target_id},
+        )).scalar_one_or_none()
+        if target_project_id != project_id:
+            raise HTTPException(
+                status_code=404, detail=f"{field.replace('_id', '').title()} not found",
+            )
+
+
 @router.post("", response_model=StoryResponse, status_code=201)
 async def create_story(
     body: StoryCreate,
@@ -265,6 +290,7 @@ async def create_story(
         db=session,
         user_id=uuid.UUID(auth.user_id),
     )
+    await _assert_story_link_targets_in_project(session, body.project_id, body)
     repo = StoryRepository(session, org_id)
     # E-BOARD S5: assignee_ids 제공 시 단일 assignee_id(주담당)는 첫 요소로 동기화(미지정 시).
     effective_ids = (

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -128,7 +128,25 @@ async def update_task(
 async def delete_task(
     id: uuid.UUID,
     repo: TaskRepository = Depends(_get_repo),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    """E-SECURITY SEC-S1(story 70c9e92c) 확장: 까심 적대적 QA 발견 갭 봉쇄 — delete_story와
+    동형으로 휴먼 전용화 + 삭제 감사(hard-delete의 에이전트 우회 벡터 차단)."""
+    from app.models.deletion_audit import DeletionAuditLog
+    from app.services.member_resolver import resolve_member
+
+    resolved = await resolve_member(auth, org_id, session)
+    if resolved.type != "human":
+        raise HTTPException(status_code=403, detail="Task 삭제는 휴먼 멤버만 가능합니다 (에이전트 API키 차단)")
+    task = await repo.get(id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    session.add(DeletionAuditLog(
+        id=uuid.uuid4(), org_id=org_id, actor_id=resolved.id,
+        entity_type="task", entity_id=id, entity_title=task.title,
+    ))
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Task not found")

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -81,6 +81,11 @@ async def create_task(
         db=session,
         user_id=uuid.UUID(auth.user_id),
     )
+    # E-SECURITY SEC-S8(story 83ea3d6a) S: create_task는 GET/PATCH/DELETE와 달리
+    # `_assert_task_project_access`를 호출하지 않아 org-scope만(enforce_body_context는
+    # body_project_id 미전달이라 project 검증 스킵) — 같은 org 다른 project 멤버가 임의
+    # story_id로 task를 생성할 수 있었다(create 경로만 남은 갭). GET/PATCH/DELETE 동형 재사용.
+    await _assert_task_project_access(session, auth, org_id, body.story_id)
     repo = TaskRepository(session, org_id)
     task = await repo.create(
         story_id=body.story_id,

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -32,6 +32,22 @@ async def _attach_has_evidence(session: AsyncSession, tasks: list[Task]) -> None
             t.has_evidence = True
 
 
+async def _assert_task_project_access(
+    session: AsyncSession, auth: AuthContext, org_id: uuid.UUID, story_id: uuid.UUID
+) -> None:
+    """E-SECURITY SEC-S8(story 83ea3d6a) G: Task는 project_id가 없어 story_id→project_id로
+    해소(org-scope만 있고 project 접근권 미검증이던 갭 — 같은 org 다른 project 멤버가 개별
+    task id만 알면 조회/수정 가능했다). upload_story_attachment와 동형으로 has_project_access
+    재사용(휴먼 team_member·에이전트 project_access grant 양쪽 처리)."""
+    from app.services.project_auth import has_project_access
+
+    project_id = (
+        await session.execute(select(Story.project_id).where(Story.id == story_id))
+    ).scalar_one_or_none()
+    if project_id is None or not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
+
 @router.get("", response_model=list[TaskResponse])
 async def list_tasks(
     story_id: uuid.UUID | None = Query(default=None),
@@ -80,10 +96,13 @@ async def create_task(
 async def get_task(
     id: uuid.UUID,
     repo: TaskRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> TaskResponse:
     task = await repo.get(id)
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found")
+    await _assert_task_project_access(repo.session, auth, org_id, task.story_id)
     await _attach_has_evidence(repo.session, [task])
     return TaskResponse.model_validate(task)
 
@@ -94,8 +113,13 @@ async def update_task(
     body: TaskUpdate,
     repo: TaskRepository = Depends(_get_repo),
     db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> TaskResponse:
     task_before = await repo.get(id)
+    if task_before is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    await _assert_task_project_access(db, auth, org_id, task_before.story_id)
     old_status = task_before.status if task_before else None
     data = body.model_dump(exclude_unset=True)
     task = await repo.update(id, **data)
@@ -143,6 +167,7 @@ async def delete_task(
     task = await repo.get(id)
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found")
+    await _assert_task_project_access(session, auth, org_id, task.story_id)
     session.add(DeletionAuditLog(
         id=uuid.uuid4(), org_id=org_id, actor_id=resolved.id,
         entity_type="task", entity_id=id, entity_title=task.title,

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
@@ -153,16 +153,33 @@ async def create_team_member(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
-    # AC1/AC2: agent actor의 멤버 관리 권한 체크.
+    # AC1/AC2: 멤버 관리 권한 체크.
     # E-MEMBER-POLICY S4: can_manage_members 플래그 직접 읽기 → effective 프로젝트 역할(has_project_role)
     # 단일 경로로 전환(블루프린트 §6). can_manage_members 는 role 에서 derived(0122 백필 can_manage=
     # true→role admin). owner/admin 이 멤버 관리. 기존 통과자(can_manage=true→admin) 무회귀 +
     # owner/admin 추가 통과(additive).
+    #
+    # E-SECURITY SEC-S8(story 83ea3d6a) L — 까심 전수스윕 CRITICAL(누구나·라이브 확定): 이 게이트가
+    # `if actor is not None and actor.type == "agent":`에 갇혀 있어 **휴먼 caller(또는 actor 미해소)
+    # 면 인가가 통째로 스킵**됐다 — 아무 권한 없는 멤버가 role=admin 에이전트 + 작동 sk_live_
+    # API키(전체 스코프)를 임의 project_id(타 org 포함)로 찍어낼 수 있었음(201 실측). 게이트를
+    # actor 종류와 무관하게 무조건 실행하도록 승격 + target(body.project_id)의 실 org를 caller
+    # org와 대조(SEC-S6/S7 헬퍼 재사용) — 기존 agent 분기가 `actor.project_id`(actor 자신의
+    # project)로 역할을 검사하던 것도 `body.project_id`(실제 target)로 정정(잠재적 자기-분기
+    # target 불일치도 함께 봉합). auth.user_id는 API키(에이전트)=member.id·JWT(휴먼)=users.id라
+    # has_project_role이 이미 양쪽을 다 매칭하는 단일 호출로 충분(신규 분기 불요).
+    from app.services.project_auth import assert_target_in_caller_org, has_project_role
+
+    target_project_org_id = (await session.execute(
+        text("SELECT org_id FROM projects WHERE id = :pid"), {"pid": str(body.project_id)},
+    )).scalar_one_or_none()
+    assert_target_in_caller_org(org_id, target_project_org_id, not_found_detail="Project not found")
+
     actor = await _resolve_actor(auth, session, org_id)
+    if not await has_project_role(session, uuid.UUID(auth.user_id), body.project_id, min_role="admin"):
+        raise HTTPException(status_code=403, detail="project admin/owner role required to manage members")
+
     if actor is not None and actor.type == "agent":
-        from app.services.project_auth import has_project_role
-        if not await has_project_role(session, actor.id, actor.project_id, min_role="admin"):
-            raise HTTPException(status_code=403, detail="project admin/owner role required to manage members")
         # AC3: target.role > actor.role → 403 (격상 차단)
         target_rank = _ROLE_RANK.get(body.role, 1)
         actor_rank = _ROLE_RANK.get(actor.role, 1)

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -168,7 +168,7 @@ async def create_team_member(
     # project)로 역할을 검사하던 것도 `body.project_id`(실제 target)로 정정(잠재적 자기-분기
     # target 불일치도 함께 봉합). auth.user_id는 API키(에이전트)=member.id·JWT(휴먼)=users.id라
     # has_project_role이 이미 양쪽을 다 매칭하는 단일 호출로 충분(신규 분기 불요).
-    from app.services.project_auth import assert_target_in_caller_org, has_project_role
+    from app.services.project_auth import assert_target_in_caller_org, get_project_role, has_project_role
 
     target_project_org_id = (await session.execute(
         text("SELECT org_id FROM projects WHERE id = :pid"), {"pid": str(body.project_id)},
@@ -180,9 +180,15 @@ async def create_team_member(
         raise HTTPException(status_code=403, detail="project admin/owner role required to manage members")
 
     if actor is not None and actor.type == "agent":
-        # AC3: target.role > actor.role → 403 (격상 차단)
+        # E-SECURITY SEC-S8(story 83ea3d6a) P — 까심 전수스윕: `_resolve_actor`가 team_members
+        # 뷰(멀티프로젝트 grant 시 member당 N행)에서 `.first()`로 임의 1행을 뽑아, actor.role이
+        # body.project_id와 무관한 다른 project의 role일 수 있었다(비결정). mixed-role 에이전트가
+        # role 낮은 target project에서도 다른 project의 높은 role을 빌려와 AC3를 우회 격상.
+        # fix=target project(body.project_id) 전용 effective role을 조회(위 has_project_role
+        # 게이트와 동일 project·SSOT)해 actor.role 대신 사용.
         target_rank = _ROLE_RANK.get(body.role, 1)
-        actor_rank = _ROLE_RANK.get(actor.role, 1)
+        actor_project_role = await get_project_role(session, uuid.UUID(auth.user_id), body.project_id)
+        actor_rank = _ROLE_RANK.get(actor_project_role, 1)
         if target_rank > actor_rank:
             raise HTTPException(status_code=403, detail="Cannot assign role higher than your own")
         # AC4: target.alias(name) == actor.name → 400 (self-replication 차단)

--- a/backend/app/routers/workflow_executions.py
+++ b/backend/app/routers/workflow_executions.py
@@ -58,9 +58,17 @@ async def story_execution_summary(
     story_ids: list[str] = Query(default=[]),
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict[str, StorySummaryItem]:
-    """Return latest execution status per story (no admin required — board/member view)."""
+    """Return latest execution status per story (no admin required — board/member view).
+
+    E-SECURITY SEC-S8(story 83ea3d6a) BB(까심 전수스윕, HIGH·읽기): project_id에 project 접근권
+    검증이 없어 남의 project 워크플로 실행 상태(story-level status/rule_name)가 노출됐다.
+    """
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(db, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+
     if not story_ids:
         return {}
 

--- a/backend/app/routers/workflow_line_config.py
+++ b/backend/app/routers/workflow_line_config.py
@@ -96,8 +96,22 @@ async def _load_version(session: AsyncSession, org_id: uuid.UUID, version_id: uu
 
 
 async def _require_draft_author(session, actor, org_id, project_id) -> None:
-    """draft 관리 권한: project 스코프면 project admin/owner 또는 org owner/admin, org 스코프면 org owner/admin."""
+    """draft 관리 권한: project 스코프면 project admin/owner 또는 org owner/admin, org 스코프면 org owner/admin.
+
+    E-SECURITY SEC-S8(story 83ea3d6a) M: `is_org_owner_or_admin(session, actor, org_id)` fallback이
+    project_id의 실제 소속 org를 검증하지 않아, caller org의 owner/admin이 **타 org 소속 project_id**를
+    넘기면 `get_project_role`이 None을 반환해도 OR-fallback으로 통과했다(caller org 권한을 임의
+    project에 적용). project_id가 caller org 소속인지 assert_target_in_caller_org(SEC-S6)로 먼저
+    검증 — 다른 org project면 404로 존재 자체를 숨긴다(권한 실패로 project 존재를 노출하지 않음)."""
     if project_id is not None:
+        from app.models.project import Project
+        from app.services.project_auth import assert_target_in_caller_org
+
+        target_org_id = (
+            await session.execute(select(Project.org_id).where(Project.id == project_id))
+        ).scalar_one_or_none()
+        assert_target_in_caller_org(org_id, target_org_id, not_found_detail="Project not found")
+
         role = await get_project_role(session, actor, project_id)
         if role in ("owner", "admin") or await is_org_owner_or_admin(session, actor, org_id):
             return

--- a/backend/app/routers/workflow_report.py
+++ b/backend/app/routers/workflow_report.py
@@ -148,6 +148,14 @@ async def report_done(
     if story is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Story not found")
 
+    # E-SECURITY SEC-S8(story 83ea3d6a) Z2(까심 전수스윕, 실HTTP 확定): org-scope(#12)는 있으나
+    # caller의 실제 project 접근권(has_project_access) 검증이 없어, project_a만 grant된 caller가
+    # project_b story_id로 이 엔드포인트를 호출하면 stage 전이가 실제로 반영됐다(DB 재조회로
+    # backlog→in-progress 변조 확定, G-class).
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(session, uuid.UUID(auth.user_id), story.project_id, org_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Story not found")
+
     # S20 finding #12(sibling): body.agent_id도 검증 없이 gate/line 평가의 actor로 그대로
     # 쓰였다 — 임의 agent_id로 actor 스푸핑 가능했던 갭. caller org 소속 member인지 확인.
     agent_check = await session.execute(

--- a/backend/app/routers/workflow_templates.py
+++ b/backend/app/routers/workflow_templates.py
@@ -96,6 +96,14 @@ async def apply_template(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> ApplyTemplateResponse:
+    # E-SECURITY SEC-S8(story 83ea3d6a) BB(까심 전수스윕, CRITICAL·라이브 확定): body.project_id에
+    # has_project_access 검증 자체가 없어, project_a member가 project_b에 AgentRoutingRule을
+    # 생성(201)할 수 있었다 — overwrite_existing=true면 기존 룰 삭제까지 겸해 파괴적 쓰기(남의
+    # project 자동화 룰 심기/지우기).
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(db, uuid.UUID(auth.user_id), body.project_id, org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+
     repo = WorkflowTemplateRepository(db)
     tmpl = await repo.get_by_slug(slug)
     if tmpl is None:

--- a/backend/app/routers/workflow_trigger.py
+++ b/backend/app/routers/workflow_trigger.py
@@ -36,6 +36,15 @@ async def trigger_workflow(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> TriggerResponse:
+    # E-SECURITY SEC-S8(story 83ea3d6a) Z2(까심 전수스윕, 실HTTP 확定): body.project_id에
+    # has_project_access 검증 자체가 없어, project_a만 grant된 caller가 body.project_id=project_b로
+    # 요청하면 project_b 전용 enabled rule이 실제로 매치되고 WorkflowExecutionLog가 생성됐다
+    # (남의 project 워크플로 실행 트리거). has_project_access(org_id 지정)가 "project가 caller
+    # org 소속"과 "caller 접근권" 둘 다 커버.
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(db, uuid.UUID(auth.user_id), body.project_id, org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+
     cutoff = datetime.now(timezone.utc) - timedelta(seconds=_DEDUP_SECONDS)
     recent = await db.execute(
         select(WorkflowExecutionLog.id)

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -245,9 +245,10 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_check_notifications", "sprintable_checkin_sprint", "sprintable_claim_story",
     "sprintable_close_sprint", "sprintable_create_conversation", "sprintable_create_doc",
     "sprintable_create_meeting", "sprintable_create_retro_session", "sprintable_create_sprint",
-    "sprintable_delete_doc", "sprintable_delete_epic", "sprintable_delete_meeting",
-    # E-SECURITY SEC-S1: sprintable_delete_story 의도적 제거(에이전트 hard-delete 차단).
-    "sprintable_delete_sprint", "sprintable_delete_task",
+    "sprintable_delete_meeting",
+    # E-SECURITY SEC-S1(확장): sprintable_delete_story/task/epic/doc 의도적 제거(에이전트
+    # hard-delete 차단 — 까심 적대적 QA가 delete_story만으로는 반쪽임을 발견, story와 동형 확대).
+    "sprintable_delete_sprint",
     "sprintable_delete_webhook_config", "sprintable_emit_event", "sprintable_export_retro",
     "sprintable_get_agent_stats", "sprintable_get_blocked_stories", "sprintable_get_doc",
     "sprintable_get_epic_progress", "sprintable_get_leaderboard_v2", "sprintable_get_meeting",

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -32,7 +32,7 @@ _GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
     ("tasks", ("task",)),
     ("stories", ("story", "stories", "backlog", "claim", "checkin")),
     ("admin", ("give_reward", "emit_event", "trigger_ai", "activate_sprint",
-               "close_sprint", "delete_sprint", "create_sprint", "upsert_webhook", "delete_webhook")),
+               "close_sprint", "create_sprint", "upsert_webhook", "delete_webhook")),
 ]
 
 _CORE = "core"  # ping/notifications-check 등 기본 — 항상 허용
@@ -248,7 +248,7 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_delete_meeting",
     # E-SECURITY SEC-S1(확장): sprintable_delete_story/task/epic/doc 의도적 제거(에이전트
     # hard-delete 차단 — 까심 적대적 QA가 delete_story만으로는 반쪽임을 발견, story와 동형 확대).
-    "sprintable_delete_sprint",
+    # E-SECURITY SEC-S8 확장: sprintable_delete_sprint도 동일 사유로 제거.
     "sprintable_delete_webhook_config", "sprintable_emit_event", "sprintable_export_retro",
     "sprintable_get_agent_stats", "sprintable_get_blocked_stories", "sprintable_get_doc",
     "sprintable_get_epic_progress", "sprintable_get_leaderboard_v2", "sprintable_get_meeting",

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -246,7 +246,8 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_close_sprint", "sprintable_create_conversation", "sprintable_create_doc",
     "sprintable_create_meeting", "sprintable_create_retro_session", "sprintable_create_sprint",
     "sprintable_delete_doc", "sprintable_delete_epic", "sprintable_delete_meeting",
-    "sprintable_delete_sprint", "sprintable_delete_story", "sprintable_delete_task",
+    # E-SECURITY SEC-S1: sprintable_delete_story 의도적 제거(에이전트 hard-delete 차단).
+    "sprintable_delete_sprint", "sprintable_delete_task",
     "sprintable_delete_webhook_config", "sprintable_emit_event", "sprintable_export_retro",
     "sprintable_get_agent_stats", "sprintable_get_blocked_stories", "sprintable_get_doc",
     "sprintable_get_epic_progress", "sprintable_get_leaderboard_v2", "sprintable_get_meeting",

--- a/backend/app/services/project_auth.py
+++ b/backend/app/services/project_auth.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import uuid
 
+from fastapi import HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -15,6 +16,25 @@ from sqlalchemy.ext.asyncio import AsyncSession
 # 이 집합으로 clamp 돼야 CHECK 위반(500)이 없다. 랭크: owner > admin > member.
 PROJECT_ROLES: tuple[str, ...] = ("owner", "admin", "member")
 PROJECT_ROLE_RANK: dict[str, int] = {"owner": 3, "admin": 2, "member": 1}
+
+
+def assert_target_in_caller_org(
+    caller_org_id: uuid.UUID,
+    target_org_id: uuid.UUID | None,
+    *,
+    not_found_detail: str = "Not found",
+) -> None:
+    """E-SECURITY SEC-S6/S7 계열 cross-org IDOR 공통 가드.
+
+    까심 QA 부수발견 D(roster: project_id)·E(persona: agent_id) 공통 근본 — 호출자 org를 body/
+    query param으로 받은 target(project·agent 등 어떤 org-scoped 엔티티든)의 **실제** org와 대조한
+    적이 없어, target_id만 알면 어느 org 소속이든 caller org와 무관하게 통과됐다. 호출부가
+    target의 실 org_id를 먼저 조회(엔티티마다 다른 쿼리)해 이 단일 비교 지점으로 넘기면 된다.
+    미존재(target_org_id=None)도 불일치와 동일하게 404 — 존재 비노출(타 org에 그 리소스가 있는지
+    자체가 정보 누수).
+    """
+    if target_org_id is None or target_org_id != caller_org_id:
+        raise HTTPException(status_code=404, detail=not_found_detail)
 
 
 def clamp_project_role(role: str | None) -> str:

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -48,13 +48,13 @@ from .tools.core import (
     my_dashboard, unclaim_story, unlock_files,
 )
 from .tools.docs import (
-    CreateDocInput, DeleteDocInput, GetDocInput, ListDocsInput,
+    CreateDocInput, GetDocInput, ListDocsInput,
     SearchDocsInput, UpdateDocInput,
-    create_doc, delete_doc, get_doc, list_docs, search_docs, update_doc,
+    create_doc, get_doc, list_docs, search_docs, update_doc,
 )
 from .tools.epics import (
-    AddEpicInput, DeleteEpicInput, ListEpicsInput, UpdateEpicInput,
-    add_epic, delete_epic, list_epics, update_epic,
+    AddEpicInput, ListEpicsInput, UpdateEpicInput,
+    add_epic, list_epics, update_epic,
 )
 from .tools.hypotheses import (
     ConfirmHypothesisInput, CreateHypothesisInput, GetHypothesisInput,
@@ -107,9 +107,9 @@ from .tools.stories import (
     update_story, update_story_status,
 )
 from .tools.tasks import (
-    AddTaskInput, DeleteTaskInput, GetTaskInput, ListMyTasksInput,
+    AddTaskInput, GetTaskInput, ListMyTasksInput,
     ListTasksInput, UpdateTaskInput, UpdateTaskStatusInput,
-    add_task, delete_task, get_task, list_my_tasks, list_tasks,
+    add_task, get_task, list_my_tasks, list_tasks,
     update_task, update_task_status,
 )
 from .tools.webhooks import (
@@ -328,7 +328,7 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_update_story_status",
      "스토리 상태 변경.",
      UpdateStoryStatusInput, update_story_status),
-    # Tasks (7)
+    # Tasks (6) — E-SECURITY SEC-S1 확장: delete_task 제거(에이전트 hard-delete 차단)
     ("sprintable_list_tasks",
      "태스크 목록 조회.",
      ListTasksInput, list_tasks),
@@ -347,10 +347,7 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_update_task_status",
      "태스크 상태 변경.",
      UpdateTaskStatusInput, update_task_status),
-    ("sprintable_delete_task",
-     "태스크 삭제.",
-     DeleteTaskInput, delete_task),
-    # Epics (4)
+    # Epics (3) — E-SECURITY SEC-S1 확장: delete_epic 제거(에이전트 hard-delete 차단)
     ("sprintable_list_epics",
      "에픽 목록 조회.",
      ListEpicsInput, list_epics),
@@ -360,9 +357,6 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_update_epic",
      "에픽 수정.",
      UpdateEpicInput, update_epic),
-    ("sprintable_delete_epic",
-     "에픽 삭제.",
-     DeleteEpicInput, delete_epic),
     # Hypotheses (6)
     ("sprintable_list_hypotheses",
      "가설 목록 조회 (compact). epic_id/story_id/status/owner_member_id 필터.",
@@ -413,7 +407,7 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_delete_sprint",
      "스프린트 삭제.",
      SprintIdInput, delete_sprint),
-    # Docs (6)
+    # Docs (5) — E-SECURITY SEC-S1 확장: delete_doc 제거(에이전트 삭제 차단)
     ("sprintable_list_docs",
      "문서 목록 조회 (tree 또는 tag 필터).",
      ListDocsInput, list_docs),
@@ -429,9 +423,6 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_update_doc",
      "문서 수정.",
      UpdateDocInput, update_doc),
-    ("sprintable_delete_doc",
-     "문서 소프트 삭제.",
-     DeleteDocInput, delete_doc),
     # Analytics (11)
     ("sprintable_get_project_overview",
      "프로젝트 개요 통계 조회.",

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -99,10 +99,10 @@ from .tools.standup import (
     save_standup, standup_history, standup_missing, update_retro_action_status,
 )
 from .tools.stories import (
-    AddStoryInput, AssignStoryToSprintInput, DeleteStoryInput,
+    AddStoryInput, AssignStoryToSprintInput,
     ListStoriesInput, UnassignStoryFromSprintInput, UpdateStoryInput,
     UpdateStoryStatusInput,
-    add_story, assign_story_to_sprint, delete_story,
+    add_story, assign_story_to_sprint,
     list_backlog, list_stories, unassign_story_from_sprint,
     update_story, update_story_status,
 )
@@ -318,9 +318,7 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_update_story",
      "스토리 수정.",
      UpdateStoryInput, update_story),
-    ("sprintable_delete_story",
-     "스토리 삭제.",
-     DeleteStoryInput, delete_story),
+    # E-SECURITY SEC-S1: sprintable_delete_story 의도적 제거(에이전트 hard-delete 차단).
     ("sprintable_assign_story_to_sprint",
      "스토리를 스프린트에 배정.",
      AssignStoryToSprintInput, assign_story_to_sprint),

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -88,7 +88,7 @@ from .tools.rewards import (
 )
 from .tools.sprints import (
     CreateSprintInput, ListSprintsInput, SprintIdInput, UpdateSprintInput,
-    activate_sprint, close_sprint, create_sprint, delete_sprint,
+    activate_sprint, close_sprint, create_sprint,
     get_velocity, list_sprints, sprint_summary, update_sprint,
 )
 from .tools.standup import (
@@ -382,7 +382,7 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_confirm_hypothesis",
      "가설 확정(active) 또는 폐기(killed). active 확정은 휴먼 경로만.",
      ConfirmHypothesisInput, confirm_hypothesis),
-    # Sprints (8)
+    # Sprints (7) — E-SECURITY SEC-S8 확장: delete_sprint 제거(에이전트 hard-delete 차단)
     ("sprintable_list_sprints",
      "스프린트 목록 조회.",
      ListSprintsInput, list_sprints),
@@ -404,9 +404,6 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_update_sprint",
      "스프린트 수정.",
      UpdateSprintInput, update_sprint),
-    ("sprintable_delete_sprint",
-     "스프린트 삭제.",
-     SprintIdInput, delete_sprint),
     # Docs (5) — E-SECURITY SEC-S1 확장: delete_doc 제거(에이전트 삭제 차단)
     ("sprintable_list_docs",
      "문서 목록 조회 (tree 또는 tag 필터).",

--- a/backend/sprintable_mcp/tools/docs.py
+++ b/backend/sprintable_mcp/tools/docs.py
@@ -1,4 +1,5 @@
-"""문서 관련 MCP 도구 (6개)."""
+"""문서 관련 MCP 도구 (5개) — E-SECURITY SEC-S1 확장: delete_doc 제거(에이전트 삭제 차단,
+delete_story와 동형 조치. 까심 적대적 QA 발견 갭)."""
 from __future__ import annotations
 
 from typing import Literal
@@ -50,10 +51,6 @@ class UpdateDocInput(SprintableInput):
     # 몰라도 됨)을 content 끝에 append. 이 호출에 content 를 안 실었으면 현재 저장된 content 를 먼저
     # 읽어 그 뒤에 append(기존 본문을 지우지 않음).
     attachments: list[dict] | None = None
-
-
-class DeleteDocInput(SprintableInput):
-    doc_id: str
 
 
 async def list_docs(args: ListDocsInput) -> list[TextContent]:
@@ -141,14 +138,5 @@ async def update_doc(args: UpdateDocInput) -> list[TextContent]:
                 snippets = "".join(a["embed_snippet"] for a in uploaded if isinstance(a, dict) and a.get("embed_snippet"))
                 updates["content"] = f"{base_content}\n{snippets}" if base_content else snippets
         return ok(await client.patch(f"/api/v2/docs/{args.doc_id}", json=updates))
-    except Exception as exc:
-        return err(str(exc))
-
-
-async def delete_doc(args: DeleteDocInput) -> list[TextContent]:
-    """문서 소프트 삭제."""
-    try:
-        await client.delete(f"/api/v2/docs/{args.doc_id}")
-        return ok({"deleted": True})
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/epics.py
+++ b/backend/sprintable_mcp/tools/epics.py
@@ -1,4 +1,5 @@
-"""에픽 관련 MCP 도구 (4개)."""
+"""에픽 관련 MCP 도구 (3개) — E-SECURITY SEC-S1 확장: delete_epic 제거(에이전트 hard-delete 차단,
+delete_story와 동형 조치. 까심 적대적 QA 발견 갭 — cascade로 소속 stories까지 물리삭제)."""
 from __future__ import annotations
 
 from mcp.types import TextContent
@@ -32,10 +33,6 @@ class UpdateEpicInput(SprintableInput):
     success_criteria: str | None = None
     target_sp: int | None = None
     target_date: str | None = None
-
-
-class DeleteEpicInput(SprintableInput):
-    epic_id: str
 
 
 async def list_epics(args: ListEpicsInput) -> list[TextContent]:
@@ -80,14 +77,5 @@ async def update_epic(args: UpdateEpicInput) -> list[TextContent]:
         updates["target_sp"] = args.target_sp
     try:
         return ok(await client.patch(f"/api/v2/epics/{args.epic_id}", json=updates))
-    except Exception as exc:
-        return err(str(exc))
-
-
-async def delete_epic(args: DeleteEpicInput) -> list[TextContent]:
-    """에픽 삭제."""
-    try:
-        await client.delete(f"/api/v2/epics/{args.epic_id}")
-        return ok({"deleted": True})
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/sprints.py
+++ b/backend/sprintable_mcp/tools/sprints.py
@@ -1,4 +1,5 @@
-"""스프린트 관련 MCP 도구 (8개)."""
+"""스프린트 관련 MCP 도구 (7개) — E-SECURITY SEC-S8 확장: delete_sprint 제거(에이전트
+hard-delete 차단, delete_story와 동형 조치. 까심 적대적 QA 발견 갭)."""
 from __future__ import annotations
 
 from mcp.types import TextContent
@@ -102,13 +103,5 @@ async def update_sprint(args: UpdateSprintInput) -> list[TextContent]:
         updates["team_size"] = args.team_size
     try:
         return ok(await client.patch(f"/api/v2/sprints/{args.sprint_id}", json=updates))
-    except Exception as exc:
-        return err(str(exc))
-
-
-async def delete_sprint(args: SprintIdInput) -> list[TextContent]:
-    """스프린트 삭제."""
-    try:
-        return ok(await client.delete(f"/api/v2/sprints/{args.sprint_id}"))
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/stories.py
+++ b/backend/sprintable_mcp/tools/stories.py
@@ -1,4 +1,6 @@
-"""스토리 관련 MCP 도구 (8개)."""
+"""스토리 관련 MCP 도구 (7개). E-SECURITY SEC-S1: delete_story는 의도적으로 제거됨 — 에이전트
+hard-delete는 사람 승인 없는 물리삭제라 차단(DELETE 엔드포인트 자체는 유지, 휴먼 전용으로 승격).
+삭제가 필요한 워크플로우는 상태변경/archive로 대체."""
 from __future__ import annotations
 
 from mcp.types import CallToolResult, TextContent
@@ -41,10 +43,6 @@ class UpdateStoryInput(SprintableInput):
     # 기존 첨부에 **추가**된다(PATCH attachments 는 서버측 full-replace 라 update_story 가 먼저 기존
     # 첨부를 읽어 병합 — 새 첨부가 기존 걸 지우지 않는다).
     attachments: list[dict] | None = None
-
-
-class DeleteStoryInput(SprintableInput):
-    story_id: str
 
 
 class AssignStoryToSprintInput(SprintableInput):
@@ -147,15 +145,6 @@ async def update_story(args: UpdateStoryInput) -> list[TextContent]:
                 existing = current.get("attachments") or [] if isinstance(current, dict) else []
                 updates["attachments"] = existing + uploaded
         return ok(await client.patch(f"/api/v2/stories/{args.story_id}", json=updates))
-    except Exception as exc:
-        return err(str(exc))
-
-
-async def delete_story(args: DeleteStoryInput) -> list[TextContent]:
-    """스토리 삭제."""
-    try:
-        await client.delete(f"/api/v2/stories/{args.story_id}")
-        return ok({"deleted": True})
     except Exception as exc:
         return err(str(exc))
 

--- a/backend/sprintable_mcp/tools/tasks.py
+++ b/backend/sprintable_mcp/tools/tasks.py
@@ -1,4 +1,5 @@
-"""태스크 관련 MCP 도구 (7개)."""
+"""태스크 관련 MCP 도구 (6개) — E-SECURITY SEC-S1 확장: delete_task 제거(에이전트 hard-delete 차단,
+delete_story와 동형 조치. 까심 적대적 QA 발견 갭)."""
 from __future__ import annotations
 
 from mcp.types import TextContent
@@ -40,10 +41,6 @@ class UpdateTaskInput(SprintableInput):
 class UpdateTaskStatusInput(SprintableInput):
     task_id: str
     status: TaskStatus
-
-
-class DeleteTaskInput(SprintableInput):
-    task_id: str
 
 
 async def list_tasks(args: ListTasksInput) -> list[TextContent]:
@@ -113,14 +110,5 @@ async def update_task_status(args: UpdateTaskStatusInput) -> list[TextContent]:
     """태스크 상태 변경."""
     try:
         return ok(await client.patch(f"/api/v2/tasks/{args.task_id}", json={"status": args.status.value}))
-    except Exception as exc:
-        return err(str(exc))
-
-
-async def delete_task(args: DeleteTaskInput) -> list[TextContent]:
-    """태스크 삭제."""
-    try:
-        await client.delete(f"/api/v2/tasks/{args.task_id}")
-        return ok({"deleted": True})
     except Exception as exc:
         return err(str(exc))

--- a/backend/tests/authz_coverage_lib.py
+++ b/backend/tests/authz_coverage_lib.py
@@ -1,4 +1,4 @@
-"""S20(`5736c1a5`): authz-coverage 스캐너 — enumerate/scan 유틸.
+"""S20(`5736c1a5`) + SEC-S8 CC 후속(`83ea3d6a`): authz-coverage 스캐너 — enumerate/scan 유틸.
 
 설계 근거: Sprintable 문서 `s20-authz-coverage-design`(SSOT). 핵심 발견 두 가지가 이 구현을
 결정한다:
@@ -12,7 +12,15 @@
    보호된다 — 이건 다른 축의 관심사라 스캐너 대상에서 자연히 제외해야 한다(안 그러면 오탐 100+건).
    그래서 대상은 "identity-shaped 파라미터를 가진" 라우트로 좁힌다(member_id/assignee_id/
    recipient_id/sender_id/agent_id/user_id — path/query든 body 모델 필드든).
-"""
+
+SEC-S8 CC 후속(2026-07-11): E-SECURITY SEC-S8(story `83ea3d6a`) R~CC 스윕이 발견한 취약점
+클래스는 identity-shaped가 아니라 **project-shaped**(project_id/story_id/sprint_id/epic_id/
+doc_id/meeting_id/parent_id) 파라미터에 caller의 project 접근권 검증이 없는 것 — org_id는
+검증하나 caller-supplied project-scoped id에 has_project_access류가 없어 same-org
+cross-project IDOR가 발생했다. 같은 스캔 축을 param-pattern/guard-set만 갈아끼워 재사용
+(신규 프리미티브 발명 금지) — 아래 ``enumerate_routes_matching``/``has_guard``가 일반화된
+버전이고, ``enumerate_identity_routes``/``has_declared_guard``는 S20 기존 axis용 thin wrapper로
+그대로 보존(회귀 0)."""
 from __future__ import annotations
 
 import ast
@@ -35,6 +43,22 @@ GUARD_FUNCTIONS: frozenset[str] = frozenset({
     "is_org_owner",
     "_assert_can_manage_human",
     "_assert_self_or_org_admin",
+})
+
+# ── SEC-S8 CC 후속: project-scope axis (identity axis와 별개 파라미터 클래스+가드셋) ──────────
+PROJECT_PARAM_RE = re.compile(
+    r"(?:^|_)(project_id|story_id|sprint_id|epic_id|doc_id|meeting_id|parent_id)$"
+)
+
+PROJECT_GUARD_FUNCTIONS: frozenset[str] = frozenset({
+    "has_project_access",
+    "resolve_member",
+    "accessible_project_ids_in_org",
+    "get_project_role",
+    "_assert_story_link_targets_in_project",
+    "_assert_doc_parent_in_project",
+    "_assert_link_target_in_scope",
+    "_assert_task_project_access",
 })
 
 # Depends(...) 콜러블 — 결과 id가 caller auth에서 서버-파생돼 클라이언트가 스푸핑할 여지가
@@ -68,31 +92,39 @@ class RouteTarget:
         return f"{self.module}:{self.qualname}"
 
 
-def _identity_fields_from_annotation(annotation) -> set[str]:
-    """파라미터 타입이 Pydantic body 모델이면 그 필드명 중 identity-shaped 것도 대상에 포함.
+def _fields_from_annotation(annotation, pattern: re.Pattern) -> set[str]:
+    """파라미터 타입이 Pydantic body 모델이면 그 필드명 중 pattern-shaped 것도 대상에 포함.
 
     (예: events.py create_event의 ``body: CreateEventRequest``의 ``sender_id`` 필드 — 최상위
     함수 시그니처엔 안 보이지만 body 모델 필드로 존재.)
     """
     try:
         if isinstance(annotation, type) and issubclass(annotation, BaseModel):
-            return {name for name in annotation.model_fields if IDENTITY_PARAM_RE.search(name)}
+            return {name for name in annotation.model_fields if pattern.search(name)}
     except TypeError:
         pass
     return set()
 
 
-def _identity_params(endpoint) -> set[str]:
+def _matched_params(endpoint, pattern: re.Pattern) -> set[str]:
     try:
         sig = inspect.signature(endpoint)
     except (ValueError, TypeError):
         return set()
     found: set[str] = set()
     for name, p in sig.parameters.items():
-        if IDENTITY_PARAM_RE.search(name):
+        if pattern.search(name):
             found.add(name)
-        found |= _identity_fields_from_annotation(p.annotation)
+        found |= _fields_from_annotation(p.annotation, pattern)
     return found
+
+
+def _identity_fields_from_annotation(annotation) -> set[str]:
+    return _fields_from_annotation(annotation, IDENTITY_PARAM_RE)
+
+
+def _identity_params(endpoint) -> set[str]:
+    return _matched_params(endpoint, IDENTITY_PARAM_RE)
 
 
 def _called_names(endpoint) -> set[str]:
@@ -136,8 +168,10 @@ def _depends_callable_names(endpoint) -> set[str]:
     return names
 
 
-def enumerate_identity_routes(app, methods: frozenset[str] = COVERED_METHODS) -> list[RouteTarget]:
-    """앱의 전 라우트 중 covered method + identity-shaped param을 가진 것만 열거.
+def enumerate_routes_matching(
+    app, pattern: re.Pattern, methods: frozenset[str] = COVERED_METHODS,
+) -> list[RouteTarget]:
+    """앱의 전 라우트 중 covered method + pattern-shaped param을 가진 것만 열거.
 
     같은 엔드포인트 함수가 여러 route(예: 여러 path alias)에 바인딩된 경우 중복 제거.
     """
@@ -154,24 +188,32 @@ def enumerate_identity_routes(app, methods: frozenset[str] = COVERED_METHODS) ->
         if endpoint is None or endpoint in seen:
             continue
         seen.add(endpoint)
-        identity_params = _identity_params(endpoint)
-        if not identity_params:
+        matched_params = _matched_params(endpoint, pattern)
+        if not matched_params:
             continue
         out.append(RouteTarget(
             path=route.path,
             methods=tuple(sorted(matched)),
             module=endpoint.__module__,
             qualname=endpoint.__qualname__,
-            identity_params=tuple(sorted(identity_params)),
+            identity_params=tuple(sorted(matched_params)),
             endpoint=endpoint,
         ))
     return out
 
 
-def has_declared_guard(target: RouteTarget) -> bool:
+def enumerate_identity_routes(app, methods: frozenset[str] = COVERED_METHODS) -> list[RouteTarget]:
+    return enumerate_routes_matching(app, IDENTITY_PARAM_RE, methods)
+
+
+def has_guard(target: RouteTarget, guard_functions: frozenset[str] = GUARD_FUNCTIONS) -> bool:
     """이름 registry 매치(바디 호출) 또는 self-deriving Depends 매치 — 둘 중 하나면 가드 有."""
-    if _called_names(target.endpoint) & GUARD_FUNCTIONS:
+    if _called_names(target.endpoint) & guard_functions:
         return True
     if _depends_callable_names(target.endpoint) & SELF_DERIVING_DEPENDENCIES:
         return True
     return False
+
+
+def has_declared_guard(target: RouteTarget) -> bool:
+    return has_guard(target, GUARD_FUNCTIONS)

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -1,7 +1,9 @@
-"""S3-6: 시스템 콜 계약 검증 — 94개 도구 등록 + 스키마 무결성 (Phase 3 완료).
+"""S3-6: 시스템 콜 계약 검증 — 93개 도구 등록 + 스키마 무결성 (Phase 3 완료).
 
 E-SECURITY SEC-S1(확장): delete_story/task/epic/doc 4종 제거(에이전트 hard-delete 차단) —
-98개 → story만 제거해 97 → task/epic/doc 3종 추가 제거해 94."""
+98개 → story만 제거해 97 → task/epic/doc 3종 추가 제거해 94. E-SECURITY SEC-S8(확장):
+delete_sprint 제거 — 94 → 93. (prod 선택승격: E-CANVAS create_artifact/get_artifact 미포함이라
+develop의 95와 다름 — 이 브랜치 스코프 기준 정확한 카운트.)"""
 from __future__ import annotations
 
 import os
@@ -29,10 +31,10 @@ EXPECTED_TOOLS = {
     # hypotheses (6) — E1-S5
     "sprintable_list_hypotheses", "sprintable_get_hypothesis", "sprintable_create_hypothesis",
     "sprintable_update_hypothesis", "sprintable_link_hypothesis", "sprintable_confirm_hypothesis",
-    # sprints (8)
+    # sprints (7) — E-SECURITY SEC-S8(확장): delete_sprint 의도적 제거(에이전트 hard-delete 차단)
     "sprintable_list_sprints", "sprintable_sprint_summary", "sprintable_activate_sprint",
     "sprintable_close_sprint", "sprintable_get_velocity", "sprintable_create_sprint",
-    "sprintable_update_sprint", "sprintable_delete_sprint",
+    "sprintable_update_sprint",
     # docs (5) — E-SECURITY SEC-S1(확장): delete_doc 의도적 제거(에이전트 삭제 차단)
     "sprintable_list_docs", "sprintable_get_doc", "sprintable_search_docs",
     "sprintable_create_doc", "sprintable_update_doc",
@@ -88,7 +90,7 @@ EXPECTED_TOOLS = {
 
 
 def test_total_tool_count():
-    assert len(_TOOLS) == 94
+    assert len(_TOOLS) == 93
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -1,4 +1,7 @@
-"""S3-6: 시스템 콜 계약 검증 — 97개 도구 등록 + 스키마 무결성 (Phase 3 완료)."""
+"""S3-6: 시스템 콜 계약 검증 — 94개 도구 등록 + 스키마 무결성 (Phase 3 완료).
+
+E-SECURITY SEC-S1(확장): delete_story/task/epic/doc 4종 제거(에이전트 hard-delete 차단) —
+98개 → story만 제거해 97 → task/epic/doc 3종 추가 제거해 94."""
 from __future__ import annotations
 
 import os
@@ -18,13 +21,11 @@ EXPECTED_TOOLS = {
     "sprintable_update_story",
     "sprintable_assign_story_to_sprint", "sprintable_unassign_story_from_sprint",
     "sprintable_update_story_status",
-    # tasks (7)
+    # tasks (6) — E-SECURITY SEC-S1(확장): delete_task 의도적 제거(에이전트 hard-delete 차단)
     "sprintable_list_tasks", "sprintable_list_my_tasks", "sprintable_get_task",
     "sprintable_add_task", "sprintable_update_task", "sprintable_update_task_status",
-    "sprintable_delete_task",
-    # epics (4)
+    # epics (3) — E-SECURITY SEC-S1(확장): delete_epic 의도적 제거(에이전트 hard-delete 차단)
     "sprintable_list_epics", "sprintable_add_epic", "sprintable_update_epic",
-    "sprintable_delete_epic",
     # hypotheses (6) — E1-S5
     "sprintable_list_hypotheses", "sprintable_get_hypothesis", "sprintable_create_hypothesis",
     "sprintable_update_hypothesis", "sprintable_link_hypothesis", "sprintable_confirm_hypothesis",
@@ -32,9 +33,9 @@ EXPECTED_TOOLS = {
     "sprintable_list_sprints", "sprintable_sprint_summary", "sprintable_activate_sprint",
     "sprintable_close_sprint", "sprintable_get_velocity", "sprintable_create_sprint",
     "sprintable_update_sprint", "sprintable_delete_sprint",
-    # docs (6)
+    # docs (5) — E-SECURITY SEC-S1(확장): delete_doc 의도적 제거(에이전트 삭제 차단)
     "sprintable_list_docs", "sprintable_get_doc", "sprintable_search_docs",
-    "sprintable_create_doc", "sprintable_update_doc", "sprintable_delete_doc",
+    "sprintable_create_doc", "sprintable_update_doc",
     # analytics (11)
     "sprintable_get_project_overview", "sprintable_get_member_workload",
     "sprintable_get_sprint_velocity_history", "sprintable_search_stories",
@@ -87,7 +88,7 @@ EXPECTED_TOOLS = {
 
 
 def test_total_tool_count():
-    assert len(_TOOLS) == 97
+    assert len(_TOOLS) == 94
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -1,4 +1,4 @@
-"""S3-6: 시스템 콜 계약 검증 — 98개 도구 등록 + 스키마 무결성 (Phase 3 완료)."""
+"""S3-6: 시스템 콜 계약 검증 — 97개 도구 등록 + 스키마 무결성 (Phase 3 완료)."""
 from __future__ import annotations
 
 import os
@@ -13,9 +13,9 @@ from sprintable_mcp.server import mcp  # noqa: E402
 _TOOLS: dict = mcp._tool_manager._tools
 
 EXPECTED_TOOLS = {
-    # stories (8)
+    # stories (7) — E-SECURITY SEC-S1: delete_story 의도적 제거(에이전트 hard-delete 차단)
     "sprintable_list_stories", "sprintable_list_backlog", "sprintable_add_story",
-    "sprintable_update_story", "sprintable_delete_story",
+    "sprintable_update_story",
     "sprintable_assign_story_to_sprint", "sprintable_unassign_story_from_sprint",
     "sprintable_update_story_status",
     # tasks (7)
@@ -87,7 +87,7 @@ EXPECTED_TOOLS = {
 
 
 def test_total_tool_count():
-    assert len(_TOOLS) == 98
+    assert len(_TOOLS) == 97
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_908075db_stage3_switch_guards.py
+++ b/backend/tests/test_908075db_stage3_switch_guards.py
@@ -34,6 +34,10 @@ def _user():
 def _auth():
     a = MagicMock()
     a.user_id = str(USER)
+    # E-SECURITY SEC-S8(K): switch_project가 이제 auth.claims에서 caller org_id를 읽는다 —
+    # has_project_access는 이 테스트에서 AsyncMock(True)로 무조건 통과라 실제 org 검증은
+    # 무관하지만, .claims가 dict여야 .get() 체인이 MagicMock 대신 None을 정상 반환한다.
+    a.claims = {"app_metadata": {"org_id": str(ORG)}}
     return a
 
 

--- a/backend/tests/test_a2a.py
+++ b/backend/tests/test_a2a.py
@@ -8,6 +8,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 MEMBER_ID = uuid.uuid4()
+ORG_ID = uuid.uuid4()
 
 
 def _mock_member(agent_role: str | None = "qa") -> MagicMock:
@@ -139,7 +140,7 @@ def _multi_row_result():
 
 @pytest.mark.anyio
 async def test_agent_card_200_reflects_role_template_skills():
-    client, session, app = await _client()
+    client, session, app = await _authed_client(ORG_ID)
     try:
         member = _mock_member()
         persona = _mock_persona()
@@ -176,7 +177,7 @@ async def test_agent_card_interface_url_uses_backend_direct_url_not_request_sche
     테스트 클라이언트는 http://test로 요청해도 카드 url은 그 값을 반영하면 안 됨."""
     from app.routers import a2a as a2a_mod
 
-    client, session, app = await _client()
+    client, session, app = await _authed_client(ORG_ID)
     try:
         member = _mock_member()
         persona = _mock_persona()
@@ -210,7 +211,7 @@ async def test_agent_card_prefers_role_template_skills_when_linked():
     """~300직군 카탈로그 S4: persona가 recruit_agent() 생성 marker(config.role_template_id)를
     가지면, 카드-빌드 시점에 그 role_template.skills(카탈로그 실시간 값)를 우선 반영 —
     persona 생성 시점 스냅샷(slug/tool_allowlist 파생 단일 skill)이 아니라."""
-    client, session, app = await _client()
+    client, session, app = await _authed_client(ORG_ID)
     try:
         rt_id = str(uuid.uuid4())
         member = _mock_member()
@@ -250,7 +251,7 @@ async def test_agent_card_prefers_role_template_skills_when_linked():
 async def test_agent_card_falls_back_to_persona_when_role_template_skills_empty():
     """role_template_id는 있으나 그 role_template.skills가 아직 비어있으면(카탈로그 구조화
     미완료) persona-파생 단일 skill로 그레이스풀 폴백 — 빈 skills[] 노출 금지."""
-    client, session, app = await _client()
+    client, session, app = await _authed_client(ORG_ID)
     try:
         rt_id = str(uuid.uuid4())
         member = _mock_member()
@@ -285,7 +286,7 @@ async def test_agent_card_falls_back_to_persona_when_role_template_skills_empty(
 @pytest.mark.anyio
 async def test_agent_card_200_unassigned_agent_fallback_skill():
     """persona 없음(미채용) — team_members.agent_role 기반 최소 skill 하나로 폴백, 크래시 없음."""
-    client, session, app = await _client()
+    client, session, app = await _authed_client(ORG_ID)
     try:
         member = _mock_member(agent_role=None)
 
@@ -311,7 +312,7 @@ async def test_agent_card_200_unassigned_agent_fallback_skill():
 
 @pytest.mark.anyio
 async def test_agent_card_404_unknown_member():
-    client, session, app = await _client()
+    client, session, app = await _authed_client(ORG_ID)
     try:
         session.execute = AsyncMock(return_value=_result(None))
 
@@ -1357,7 +1358,7 @@ async def test_project_context_extension_ignored_when_not_declared():
 
 @pytest.mark.anyio
 async def test_agent_card_advertises_project_context_extension():
-    client, session, app = await _client()
+    client, session, app = await _authed_client(ORG_ID)
     try:
         member = _mock_member()
         persona = _mock_persona()
@@ -1390,7 +1391,7 @@ async def test_agent_card_advertises_project_context_extension():
 
 @pytest.mark.anyio
 async def test_agent_card_advertises_bearer_security_scheme():
-    client, session, app = await _client()
+    client, session, app = await _authed_client(ORG_ID)
     try:
         member = _mock_member()
         persona = _mock_persona()

--- a/backend/tests/test_a2a_sa8_multiproject_member_scope_realdb.py
+++ b/backend/tests/test_a2a_sa8_multiproject_member_scope_realdb.py
@@ -102,6 +102,23 @@ def _client_for(app):
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
 
 
+async def _authed_agent_card_overrides(app, org_id):
+    """E-SECURITY SEC-S2: agent-card.json이 authed+same-org로 승격 — 발견 테스트도 호출자 org 인증 필요."""
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(uuid.uuid4()), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
 @pytest.mark.anyio
 async def test_agent_card_multiproject_member_no_longer_500s():
     """S-A8 AC3: 멀티-project agent의 agent-card가 200 정상 카드(회귀: 이전엔 MultipleResultsFound 500)."""
@@ -111,6 +128,14 @@ async def test_agent_card_multiproject_member_no_longer_500s():
     try:
         async with Session() as s:
             org_id, project_a, project_b, agent_id = await _seed_multiproject_agent(s)
+
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        from app.dependencies.database import get_db
+        app.dependency_overrides[get_db] = _db
+        await _authed_agent_card_overrides(app, org_id)
 
         client = _client_for(app)
         try:
@@ -122,6 +147,7 @@ async def test_agent_card_multiproject_member_no_longer_500s():
         finally:
             await client.aclose()
     finally:
+        app.dependency_overrides.clear()
         await engine.dispose()
 
 
@@ -136,6 +162,14 @@ async def test_agent_card_single_project_member_regression_zero():
             org_id, project_a, project_b, _ = await _seed_multiproject_agent(s)
             solo_project_id, solo_agent_id = await _seed_single_project_agent(s, org_id)
 
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        from app.dependencies.database import get_db
+        app.dependency_overrides[get_db] = _db
+        await _authed_agent_card_overrides(app, org_id)
+
         client = _client_for(app)
         try:
             resp = await client.get(f"/api/v2/a2a/members/{solo_agent_id}/agent-card.json")
@@ -144,6 +178,7 @@ async def test_agent_card_single_project_member_regression_zero():
         finally:
             await client.aclose()
     finally:
+        app.dependency_overrides.clear()
         await engine.dispose()
 
 

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -112,8 +112,6 @@ _FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
         "동일 패턴(sprint.project_id 조회 후 _assert_project_access)",
     "app.routers.workflow_executions:list_executions":
         "설계상 안전(SEC-S8 BB 정리) — non-admin은 target_agent_id==member_id로 self-scope, admin은 org 전체 권한으로 통과",
-    "app.routers.visual_artifacts:list_artifacts":
-        "이전 SEC-S8 finding(G/N)으로 이미 봉인 — project_id가 클라 파라미터가 아니라 auth 컨텍스트에서 서버파생(_get_org_project)",
     "app.routers.open_api_keys:create_project_api_key":
         "require_admin 가드 + project_id가 클라 파라미터가 아니라 JWT app_metadata에서 서버파생(_get_project_id)",
     "app.routers.open_api_keys:list_project_api_keys":

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -1,0 +1,215 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) 회귀가드 — CI 강제 consumer test.
+
+S20(`5736c1a5`) authz_coverage_lib.py의 project-scope axis(PROJECT_PARAM_RE/
+PROJECT_GUARD_FUNCTIONS)를 실제로 CI에 물리는 첫 consumer(S20 자체는 스캐너만 만들고
+"새 라우트가 가드 없으면 CI가 막는" 강제 테스트를 커밋하지 않은 게 오늘 R~EE 스윕이
+반복적으로 재발한 진짜 근본 — supply(스캐너) 있는데 demand(CI 강제)가 없었다).
+
+ratchet 패턴: 오늘 스윕(2026-07-11) 시점 기준 project-scope 파라미터(project_id/story_id/
+sprint_id/epic_id/doc_id/meeting_id/parent_id)를 가졌는데 가드가 감지되지 않는 라우트
+62건을 파일-단위로 직접 실사해 분류했다 — CRITICAL 3건(standups.upsert_standup/add_feedback·
+oss.oss_seed)은 EE(#2048)로 즉시 봉인했고, 나머지는 두 그룹으로 baseline에 동결한다:
+
+- ``_FALSE_POSITIVE_ALLOWLIST``: 실제로는 안전(다른 이름의 가드를 1-hop 아래서 호출하거나,
+  admin-gate·server-derived param 등으로 스캐너의 단일-바디-스캔이 못 본 것) — 영구 유지,
+  이유 주석 필수.
+- ``_KNOWN_DEBT_ALLOWLIST``: 실 GAP이지만 CRITICAL이 아니라 오늘 즉시 fix 대상은 아님
+  (HIGH/MEDIUM/LOW) — 점진적으로 fix하며 이 dict에서 하나씩 빼는 게 상환 진행의 증거.
+
+⚠️알려진 스캐너 한계(EE #2048 까심 QA가 재확認): 이 스캐너는 "가드 함수가 body 안에서
+호출됐는가"만 보고 "그 가드에 넘긴 project_id가 **실제 리소스의 project**인지 **caller가
+body에서 주장한 값**인지"는 구분 못한다 — add_feedback이 처음엔 `resolve_member(project_id=
+body.project_id)`를 호출해 스캐너 통과였지만, body.project_id(호출자 주장값)만 검증하고
+path의 entry가 실제 그 project 소속인지 대조하지 않아 우회 가능했다("body-claimed vs
+resource-actual" 클래스). 이건 정적 AST로는 못 잡는 축이라 — 새 project-scope 가드를 추가할
+때는 반드시 realdb 테스트로 "리소스가 실제로 caller 무권한 project 소속인데 body가 다른
+project를 주장하는" 시나리오까지 실증해야 한다(단순 "가드 호출 여부"로 안심 금지).
+
+이 테스트가 강제하는 것은 ONE 방향뿐이다: **baseline에 없는 새 미가드 라우트가 생기면
+CI가 즉시 RED**. baseline 안의 기존 62건(현재는 fix로 줄어든 상태)은 조용히 pass —
+그것들을 fix하는 게 이 테스트의 책임이 아니라 각자의 SEC-S8 개별 PR(R~EE류)의 책임이다."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from authz_coverage_lib import (  # noqa: E402
+    PROJECT_GUARD_FUNCTIONS,
+    PROJECT_PARAM_RE,
+    enumerate_routes_matching,
+    has_guard,
+)
+
+# ── false positive: 실제로는 안전 — 영구 allowlist(이유 주석 필수) ────────────────────
+_FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
+    "app.routers.dispatch:dispatch_entity":
+        "body.project_id는 사용되지 않는 dead field — entity_project_id는 서버가 엔티티 조회로 도출",
+    "app.routers.assets:list_assets":
+        "_scope_filter(auth,org_id,project_id) 헬퍼가 has_project_access/accessible_project_ids_in_org를 1-hop 아래서 호출",
+    "app.routers.conversations:list_conversations":
+        "_resolve_member(auth,org_id,db,project_id=) 로컬 wrapper가 resolve_member(project_id=)를 1-hop 아래서 호출",
+    "app.routers.epics:create_epic":
+        "enforce_body_context()가 has_project_access를 내부에서 호출(캐노니컬 가드, 이름만 다름)",
+    "app.routers.hypotheses:list_hypotheses":
+        "Depends(get_project_scoped_org_id)가 동일 project_id 쿼리파라미터로 has_project_access 검증",
+    "app.routers.loops:list_loops":
+        "Depends(get_project_scoped_org_id) 동일 패턴",
+    "app.routers.gate_metrics:get_hitl_gate_metrics":
+        "is_org_owner_or_admin 가드 — 거버넌스/오버사이트 데이터는 의도적으로 org 전체 admin 시야",
+    "app.routers.workflow_line_config:create_draft_version":
+        "_require_draft_author(session,actor,org_id,project_id)가 이름과 달리 admin-level project_auth 접근권을 강제(in-code 문서화됨)",
+    "app.routers.workflow_line_config:list_versions_endpoint":
+        "동일 _require_draft_author admin-gate",
+    "app.routers.workflow_line_config:resolve_preview":
+        "동일 _require_draft_author admin-gate",
+    "app.routers.workflow_line_config:get_active_line":
+        "동일 _require_draft_author admin-gate",
+    "app.routers.docs:list_docs":
+        "Depends(get_project_scoped_org_id) 동일 패턴",
+    "app.routers.meetings:create_meeting":
+        "enforce_body_context()가 has_project_access를 내부에서 호출",
+    "app.routers.stories:list_stories":
+        "Depends(get_project_scoped_org_id) 동일 패턴",
+    "app.routers.project_access:list_project_access":
+        "_require_owner_or_admin(project_id,...)가 has_project_role(min_role=admin)을 1-hop 아래서 호출",
+    "app.routers.project_access:create_project_access":
+        "동일 _require_owner_or_admin/has_project_role 가드",
+    "app.routers.project_access:delete_project_access":
+        "동일 _require_owner_or_admin/has_project_role 가드",
+    "app.routers.team_members:claim_story":
+        "assert_caller_is_member(id,...)로 self-scope 강제 후 body.story_id는 Story.project_id==member.project_id로 서버파생 제약(클라 project 주입 불가)",
+    "app.routers.event_notifications:list_notifications":
+        "_resolve_member_id(auth,org_id,db,project_id=) 로컬 wrapper가 resolve_member(project_id=)를 1-hop 아래서 호출",
+    "app.routers.event_notifications:get_unread_count":
+        "동일 _resolve_member_id 가드",
+    "app.routers.event_notifications:mark_all_read":
+        "동일 _resolve_member_id 가드",
+    "app.routers.rewards:get_balance":
+        "_assert_self_or_org_admin(member_id,...) — 본인 잔액 또는 org admin만 조회 가능해 project_id 자체는 blast-radius가 self-data로 제한",
+    "app.routers.current_project:set_current_project":
+        "assert_caller_is_member self-scope 후 (member_id, body.project_id) TeamMember 행 존재를 요구 — has_project_access보다 엄격(IDOR 아님)",
+    "app.routers.project_settings:upsert_project_settings":
+        "has_project_role(body.project_id, min_role=admin) 가드",
+    "app.routers.analytics:get_overview":
+        "SEC-S8 DD(#2047)에서 추가된 로컬 _assert_project_access(repo,auth,project_id) wrapper가 has_project_access를 1-hop 아래서 호출",
+    "app.routers.analytics:get_member_workload":
+        "동일 _assert_project_access 가드",
+    "app.routers.analytics:get_velocity_history":
+        "동일 _assert_project_access 가드",
+    "app.routers.analytics:get_recent_activity":
+        "동일 _assert_project_access 가드",
+    "app.routers.analytics:get_epic_progress":
+        "동일 _assert_project_access 가드",
+    "app.routers.analytics:get_agent_stats":
+        "동일 _assert_project_access 가드",
+    "app.routers.analytics:get_project_health":
+        "동일 _assert_project_access 가드",
+    "app.routers.analytics:get_burndown":
+        "DD(#2047)에서 sprint.project_id 조회 후 _assert_project_access 호출(org_id 자체는 CRITICAL cross-org fix로 별도 봉인 완료)",
+    "app.routers.analytics:get_sprint_velocity":
+        "동일 패턴(sprint.project_id 조회 후 _assert_project_access)",
+    "app.routers.workflow_executions:list_executions":
+        "설계상 안전(SEC-S8 BB 정리) — non-admin은 target_agent_id==member_id로 self-scope, admin은 org 전체 권한으로 통과",
+    "app.routers.visual_artifacts:list_artifacts":
+        "이전 SEC-S8 finding(G/N)으로 이미 봉인 — project_id가 클라 파라미터가 아니라 auth 컨텍스트에서 서버파생(_get_org_project)",
+    "app.routers.open_api_keys:create_project_api_key":
+        "require_admin 가드 + project_id가 클라 파라미터가 아니라 JWT app_metadata에서 서버파생(_get_project_id)",
+    "app.routers.open_api_keys:list_project_api_keys":
+        "동일 require_admin + JWT-derived project_id",
+    "app.routers.open_api_keys:revoke_project_api_key":
+        "동일 require_admin + JWT-derived project_id, 추가로 key.project_id==project_id 소유권 검증",
+}
+
+# ── known debt: 실 GAP(HIGH/MEDIUM/LOW) — CRITICAL 3건(EE #2048)은 이미 fix, 나머지는
+# ratchet(PO 결 2026-07-11: baseline 동결 + 점진 상환). fix되면 이 dict에서 제거할 것.
+_KNOWN_DEBT_ALLOWLIST: dict[str, str] = {
+    "app.routers.activity_logs:list_activity_logs":
+        "HIGH — org-scope만·optional project_id 필터에 접근권 검증 없음(actor/action/context 노출)",
+    "app.routers.activity_stream:get_activity_stream":
+        "HIGH — org-scope만·project_id 필터에 접근권 검증 없음",
+    "app.routers.epics:list_epics":
+        "HIGH — org-scope만·optional project_id 필터에 접근권 검증 없음(epic 제목/목표 노출)",
+    "app.routers.tasks:list_tasks":
+        "HIGH — org-scope만·story_id 필터에 caller의 story project 접근권 검증 없음",
+    "app.routers.team_members:list_team_members":
+        "HIGH — project_id 지정 분기가 접근권 검증 없이 repo.list(project_id=)로 직행(roster 노출)",
+    "app.routers.standups:list_standups":
+        "HIGH — top-level project_id 필터에 접근권 검증 없음(plan_stories enrichment만 가드됨)",
+    "app.routers.standups:list_standup_history":
+        "HIGH — 동일 패턴(project_id 필터 미검증)",
+    "app.routers.entities:search_entities":
+        "HIGH — org-scope만·project_id로 story/doc/epic/task 제목 검색에 접근권 검증 없음",
+    "app.routers.rewards:list_rewards":
+        "HIGH — org-scope만·project_id 필터에 접근권 검증 없음(리워드 원장 노출)",
+    "app.routers.members:list_members":
+        "HIGH — assert_target_in_caller_org가 cross-org만 막고 same-org cross-project는 미검증",
+    "app.routers.policy_documents:list_policy_documents":
+        "HIGH — org-scope만·project_id로 정책문서 content ILIKE 검색에 접근권 검증 없음",
+    "app.routers.hypotheses:link_hypothesis":
+        "MEDIUM — service._assert_targets_same_project가 sprint/epic/story 주입은 막지만 caller의 hyp.project_id 접근권 자체는 미검증",
+    "app.routers.participation:add_participation":
+        "MEDIUM — org-scope만·body.story_id에 caller의 project 접근권 검증 없음",
+    "app.routers.participation:list_participation":
+        "MEDIUM — org-scope만·story_id 쿼리에 접근권 검증 없음",
+    "app.routers.exclusion:exclusion_dry_run":
+        "MEDIUM — org-scope만·optional project_id에 접근권 검증 없음",
+    "app.routers.standups:get_missing_standups":
+        "MEDIUM — required project_id를 repo.get_missing에 직행(미제출자 roster 노출)",
+    "app.routers.standups:list_feedback":
+        "MEDIUM — required project_id로 EXISTS join 필터, 접근권 검증 없음(피드백 텍스트 노출)",
+    "app.routers.rewards:get_leaderboard":
+        "MEDIUM — S20 fast-follow가 cross-org만 막았고 same-org cross-project는 오늘 계열과 동형 미검증",
+    "app.routers.dashboard:get_dashboard":
+        "MEDIUM — member_id는 org-scope 검증하나 explicit project_id에 접근권 검증 없음(assignee 필터로 blast-radius는 좁음)",
+    "app.routers.agent_runs:create_agent_run":
+        "MEDIUM — body.agent_id의 org 소속만 검증하고 body.story_id는 caller org/project 접근권 미검증",
+    "app.routers.merge_gate:get_merge_gate_metrics":
+        "LOW — org-scope만·optional project_id 필터 미검증이나 응답이 집계 비율/카운트뿐(원본 콘텐츠 노출 없음)",
+}
+
+
+def _baseline_key_valid_targets(app) -> set[str]:
+    """baseline이 가리키는 실제 module:qualname 집합 — 존재하지 않는(rot된) 엔트리 검출용."""
+    routes = enumerate_routes_matching(app, PROJECT_PARAM_RE)
+    return {r.key for r in routes}
+
+
+def test_no_new_unguarded_project_scope_routes():
+    """ratchet: baseline(false-positive+known-debt)에 없는 미가드 project-scope 라우트가
+    생기면 CI가 즉시 실패 — 신규 라우터가 project_id/story_id/sprint_id/epic_id/doc_id/
+    meeting_id/parent_id를 받으면서 has_project_access류 가드를 호출하지 않을 때 발동."""
+    from app.main import app
+
+    routes = enumerate_routes_matching(app, PROJECT_PARAM_RE)
+    baseline = set(_FALSE_POSITIVE_ALLOWLIST) | set(_KNOWN_DEBT_ALLOWLIST)
+
+    unguarded_not_baselined = [
+        r for r in routes
+        if not has_guard(r, PROJECT_GUARD_FUNCTIONS) and r.key not in baseline
+    ]
+    assert unguarded_not_baselined == [], (
+        "새 project-scope 미가드 라우트 발견 — has_project_access/resolve_member/"
+        "accessible_project_ids_in_org류 가드를 추가하거나(권장), 검토 후 baseline에 "
+        "이유와 함께 등록하세요(tests/test_authz_project_scope_coverage.py):\n" +
+        "\n".join(f"  {r.key} params={r.identity_params}" for r in unguarded_not_baselined)
+    )
+
+
+def test_baseline_entries_are_not_stale():
+    """baseline이 가리키는 module:qualname이 실제 라우트로 여전히 존재하는지(리네임/삭제로
+    인한 rot 검출) — 존재하지 않으면 baseline 정리 필요."""
+    from app.main import app
+
+    valid = _baseline_key_valid_targets(app)
+    stale = (set(_FALSE_POSITIVE_ALLOWLIST) | set(_KNOWN_DEBT_ALLOWLIST)) - valid
+    assert stale == set(), (
+        f"baseline에 더 이상 존재하지 않는 라우트가 있습니다(rename/삭제로 rot) — 정리하세요: {stale}"
+    )
+
+
+def test_known_debt_allowlist_shrinks_are_welcome_no_assertion():
+    """placeholder — known-debt 항목이 fix되면 baseline dict에서 제거하는 게 상환 진행의
+    증거(별도 assertion 없음, 다음 fix PR이 이 dict를 줄이면 그걸로 충분)."""
+    assert True

--- a/backend/tests/test_bot_l2_be_links.py
+++ b/backend/tests/test_bot_l2_be_links.py
@@ -77,9 +77,10 @@ async def _req(method, path, *, execute_results, org_id=ORG_A):
 # ── GET list ──────────────────────────────────────────────────────────────────
 @pytest.mark.anyio
 async def test_list_links_same_org_returns_links():
-    # execute: story(org_a) → links([link]).
+    # execute: story(org_a) → has_project_access(truthy) → links([link]).
+    # E-SECURITY SEC-S8 Y: project-scope 검증(has_project_access) 호출이 추가돼 시퀀스가 하나 늘었다.
     resp, _ = await _req("GET", f"/api/v2/integrations/github/links?story_id={STORY_ID}",
-                         execute_results=[_story(ORG_A), [_link(ORG_A)]])
+                         execute_results=[_story(ORG_A), 1, [_link(ORG_A)]])
     assert resp.status_code == 200
     body = resp.json()
     data = body.get("data", body)

--- a/backend/tests/test_bot_l2_be_links.py
+++ b/backend/tests/test_bot_l2_be_links.py
@@ -100,9 +100,11 @@ async def test_list_links_cross_org_story_404_no_oracle():
 # ── DELETE unlink ───────────────────────────────────────────────────────────────
 @pytest.mark.anyio
 async def test_delete_link_same_org_soft_deletes():
+    # execute: link → story.project_id(scalar) → has_project_access(truthy).
+    # E-SECURITY SEC-S8 Z: project-scope 검증(has_project_access) 호출이 추가돼 시퀀스가 둘 늘었다.
     link = _link(ORG_A)
     resp, session = await _req("DELETE", f"/api/v2/integrations/github/links/{LINK_ID}",
-                               execute_results=[link])
+                               execute_results=[link, uuid.uuid4(), 1])
     assert resp.status_code == 200
     assert link.deleted_at is not None      # soft-delete.
     session.commit.assert_awaited_once()

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -215,12 +215,18 @@ async def test_group_request_2members_coerced_to_dm():
             obj.title = None
         session.refresh.side_effect = _refresh
 
-        async with client as c:
-            resp = await c.post("/api/v2/conversations", json={
-                "type": "group",   # label 은 group 이지만 2-member → DM 강제
-                "participant_ids": [str(uuid.uuid4())],
-                "project_id": str(PROJECT_ID),
-            })
+        # E-SECURITY SEC-S3: create_conversation이 먼저 participant_ids를 org 필터한다 — 이
+        # 테스트는 DM 강제 로직 검증이 목적이라 필터 자체는 통과-그대로(bypass)로 패치.
+        with patch(
+            "app.routers.conversations.filter_org_member_ids",
+            new=AsyncMock(side_effect=lambda ids, *a, **kw: ids),
+        ):
+            async with client as c:
+                resp = await c.post("/api/v2/conversations", json={
+                    "type": "group",   # label 은 group 이지만 2-member → DM 강제
+                    "participant_ids": [str(uuid.uuid4())],
+                    "project_id": str(PROJECT_ID),
+                })
         assert resp.status_code == 201
         body = resp.json()
         assert body["type"] == "dm", f"2-member group → DM 강제 실패: {body}"
@@ -253,12 +259,16 @@ async def test_create_dm_no_dedup_creates_new_session():
             obj.title = None
         session.refresh.side_effect = _refresh
 
-        async with client as c:
-            resp = await c.post("/api/v2/conversations", json={
-                "type": "dm",
-                "participant_ids": [str(other_id)],
-                "project_id": str(PROJECT_ID),
-            })
+        with patch(
+            "app.routers.conversations.filter_org_member_ids",
+            new=AsyncMock(side_effect=lambda ids, *a, **kw: ids),
+        ):
+            async with client as c:
+                resp = await c.post("/api/v2/conversations", json={
+                    "type": "dm",
+                    "participant_ids": [str(other_id)],
+                    "project_id": str(PROJECT_ID),
+                })
 
         assert resp.status_code == 201
         body = resp.json()

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -183,9 +183,11 @@ async def test_delete_doc_200():
         session.flush = AsyncMock()
 
         # b13352c2: delete_doc 가 cascade(resolve_member + void_pending_doc_gate) 호출 → 패치(이 테스트는 삭제만 검증·cascade는 별도).
+        # E-SECURITY SEC-S1(확장): resolve_member 결과의 type="human"이 아니면 delete_doc이 403을
+        # 내므로(에이전트 삭제 차단) 이 목의 type을 명시해야 한다.
         from unittest.mock import patch as _patch
         with _patch("app.services.member_resolver.resolve_member",
-                    new=AsyncMock(return_value=MagicMock(id=uuid.uuid4()))), \
+                    new=AsyncMock(return_value=MagicMock(id=uuid.uuid4(), type="human"))), \
              _patch("app.services.gate_service.void_pending_doc_gate", new=AsyncMock(return_value=False)):
             async with client as c:
                 resp = await c.delete(f"/api/v2/docs/{DOC_ID}")

--- a/backend/tests/test_e2e_workflow_template.py
+++ b/backend/tests/test_e2e_workflow_template.py
@@ -62,7 +62,8 @@ async def test_e2e_template_apply_three_step():
         role_mapping={f"step_{i+1}": str(agent_ids[i]) for i in range(3)},
     )
 
-    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo, \
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
         instance = AsyncMock()
         instance.get_by_slug = AsyncMock(return_value=tmpl)
         MockRepo.return_value = instance
@@ -90,7 +91,8 @@ async def test_e2e_template_apply_solo():
         role_mapping={"step_1": str(agent_ids[0])},
     )
 
-    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo, \
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
         instance = AsyncMock()
         instance.get_by_slug = AsyncMock(return_value=tmpl)
         MockRepo.return_value = instance
@@ -124,7 +126,8 @@ async def test_e2e_template_overwrite():
         overwrite_existing=True,
     )
 
-    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo, \
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
         instance = AsyncMock()
         instance.get_by_slug = AsyncMock(return_value=tmpl)
         MockRepo.return_value = instance

--- a/backend/tests/test_e_cage_referee_p1_exclusion.py
+++ b/backend/tests/test_e_cage_referee_p1_exclusion.py
@@ -97,10 +97,13 @@ async def test_patch_story_is_excluded_true():
     marked_story.assignee_ids = []
     marked_story.meeting_id = None
     # E-BOARD S5: update_story가 _attach_assignee_ids로 story_assignees 조회 → 빈 결과 모킹
+    # E-SECURITY SEC-S8(G): update_story가 이제 먼저 repo.get(id)(access 체크용) +
+    # has_project_access(project_auth 원시SQL도 scalar_one_or_none)를 조회 — marked_story를
+    # 반환해 존재+접근권 둘 다 통과시킨다(단일 정적 목이라 모든 scalar_one_or_none 호출이 동일값).
     _empty = MagicMock()
     _empty.all.return_value = []
     _empty.scalars.return_value.all.return_value = []
-    _empty.scalar_one_or_none.return_value = None
+    _empty.scalar_one_or_none.return_value = marked_story
     _empty.scalar.return_value = None
     mock_session.execute.return_value = _empty
     marked_story.title = "Story 1"

--- a/backend/tests/test_e_cage_referee_p1_participation_api.py
+++ b/backend/tests/test_e_cage_referee_p1_participation_api.py
@@ -138,10 +138,12 @@ async def test_update_story_assignee_auto_creates_participation():
     """update_story assignee 변경 → _upsert_assignee_participation 호출 단언."""
     mock_session = AsyncMock()
     # E-BOARD S5: update_story가 _attach_assignee_ids로 story_assignees 조회 → 빈 결과 모킹
+    # E-SECURITY SEC-S8(G): has_project_access(raw SQL) 도 scalar_one_or_none을 쓰므로 truthy로
+    # 설정해 접근권 통과시킴(StoryRepository.get은 아래서 별도 patch).
     _empty = MagicMock()
     _empty.all.return_value = []
     _empty.scalars.return_value.all.return_value = []
-    _empty.scalar_one_or_none.return_value = None
+    _empty.scalar_one_or_none.return_value = 1
     _empty.scalar.return_value = None
     mock_session.execute.return_value = _empty
     story = _mock_story_obj(assignee_id=MEMBER_ID)

--- a/backend/tests/test_e_mcp_s3_boot_filter.py
+++ b/backend/tests/test_e_mcp_s3_boot_filter.py
@@ -16,7 +16,8 @@ def test_disallowed_tools_explicit_group():
 def test_disallowed_tools_legacy_keeps_nondestructive_hides_destructive():
     d = server.disallowed_tools(["read", "write"])
     assert "sprintable_add_story" not in d     # 비파괴 → 노출
-    assert "sprintable_delete_story" in d       # destructive → 숨김(grant 없음)
+    # E-SECURITY SEC-S1: sprintable_delete_story 제거(에이전트 hard-delete 차단) — delete_task로 대체 예시
+    assert "sprintable_delete_task" in d        # destructive → 숨김(grant 없음)
     assert "sprintable_give_reward" in d
 
 
@@ -24,7 +25,7 @@ def test_disallowed_tools_none_fallback_equals_legacy():
     """매니페스트 fetch 실패(None) = 레거시 비파괴셋(destructive만 숨김)."""
     d = server.disallowed_tools(None)
     assert "sprintable_add_story" not in d
-    assert "sprintable_delete_story" in d
+    assert "sprintable_delete_task" in d
 
 
 def test_ping_never_in_disallowed():
@@ -48,5 +49,5 @@ def test_filter_fallback_none_hides_only_destructive(monkeypatch):
     removed: list[str] = []
     monkeypatch.setattr(server.mcp, "remove_tool", lambda name: removed.append(name))
     server.filter_tools_by_scope(None)  # degrade
-    assert "sprintable_delete_story" in removed     # destructive 숨김
-    assert "sprintable_add_story" not in removed     # 비파괴 보존
+    assert "sprintable_delete_task" in removed        # destructive 숨김
+    assert "sprintable_add_story" not in removed      # 비파괴 보존

--- a/backend/tests/test_e_mcp_s3_boot_filter.py
+++ b/backend/tests/test_e_mcp_s3_boot_filter.py
@@ -16,8 +16,9 @@ def test_disallowed_tools_explicit_group():
 def test_disallowed_tools_legacy_keeps_nondestructive_hides_destructive():
     d = server.disallowed_tools(["read", "write"])
     assert "sprintable_add_story" not in d     # 비파괴 → 노출
-    # E-SECURITY SEC-S1: sprintable_delete_story 제거(에이전트 hard-delete 차단) — delete_task로 대체 예시
-    assert "sprintable_delete_task" in d        # destructive → 숨김(grant 없음)
+    # E-SECURITY SEC-S1(확장): delete_story/task/epic/doc 제거(에이전트 hard-delete 차단) —
+    # delete_meeting으로 대체 예시(에이전트 MCP 표면에 남는 도메인 destructive 도구)
+    assert "sprintable_delete_meeting" in d        # destructive → 숨김(grant 없음)
     assert "sprintable_give_reward" in d
 
 
@@ -25,7 +26,7 @@ def test_disallowed_tools_none_fallback_equals_legacy():
     """매니페스트 fetch 실패(None) = 레거시 비파괴셋(destructive만 숨김)."""
     d = server.disallowed_tools(None)
     assert "sprintable_add_story" not in d
-    assert "sprintable_delete_task" in d
+    assert "sprintable_delete_meeting" in d
 
 
 def test_ping_never_in_disallowed():
@@ -49,5 +50,5 @@ def test_filter_fallback_none_hides_only_destructive(monkeypatch):
     removed: list[str] = []
     monkeypatch.setattr(server.mcp, "remove_tool", lambda name: removed.append(name))
     server.filter_tools_by_scope(None)  # degrade
-    assert "sprintable_delete_task" in removed        # destructive 숨김
+    assert "sprintable_delete_meeting" in removed        # destructive 숨김
     assert "sprintable_add_story" not in removed      # 비파괴 보존

--- a/backend/tests/test_e_security_sec_s1_delete_audit_realdb.py
+++ b/backend/tests/test_e_security_sec_s1_delete_audit_realdb.py
@@ -1,0 +1,206 @@
+"""E-SECURITY SEC-S1(story 70c9e92c): hard-delete 휴먼 전용화 + 삭제 감사 — 실 Postgres 검증."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session, *, human_id: uuid.UUID | None = None):
+    """org + project + agent + (선택) human org_member + story."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+    from app.models.pm import Story
+    from app.models.user import User
+    from app.models.project import OrgMember
+
+    org = Organization(id=uuid.uuid4(), name="SEC-S1 Org", slug=f"sec-s1-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="SEC-S1 Project")
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Deleting Agent", is_active=True)
+    session.add_all([project, agent])
+    await session.commit()
+
+    grant = ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted", role="member",
+    )
+    session.add(grant)
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="To Be Deleted", status="backlog")
+    session.add(story)
+    await session.commit()
+
+    human_user_id = None
+    human_org_member_id = None
+    if human_id is not None:
+        user = User(id=human_id, email=f"human-{human_id}@test.com", hashed_password="x")
+        session.add(user)
+        await session.commit()
+        om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_id, role="member")
+        session.add(om)
+        await session.commit()
+        human_user_id = human_id
+        human_org_member_id = om.id
+
+    return org.id, project.id, agent.id, story.id, human_user_id, human_org_member_id
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, member_id, org_id, *, is_agent: bool):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        claims = {"app_metadata": {"org_id": str(org_id)}}
+        if is_agent:
+            claims["app_metadata"]["api_key_id"] = "test-key"
+        return AuthContext(user_id=str(member_id), email="test@test", claims=claims)
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_agent_delete_forbidden():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, project_id, agent_id, story_id, _hu, _ho = await _seed(s)
+
+        await _setup_app(app, Session, agent_id, org_id, is_agent=True)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/stories/{story_id}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+
+        # story는 그대로 존재
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.pm import Story
+            story = (await s.execute(select(Story).where(Story.id == story_id))).scalar_one_or_none()
+            assert story is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_human_delete_succeeds_and_audit_logged():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        human_id = uuid.uuid4()
+        async with Session() as s:
+            org_id, project_id, agent_id, story_id, human_user_id, human_org_member_id = await _seed(s, human_id=human_id)
+
+        await _setup_app(app, Session, human_id, org_id, is_agent=False)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/stories/{story_id}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.pm import Story
+            from app.models.deletion_audit import DeletionAuditLog
+
+            story = (await s.execute(select(Story).where(Story.id == story_id))).scalar_one_or_none()
+            assert story is None  # 실제로 삭제됨
+
+            logs = (await s.execute(
+                select(DeletionAuditLog).where(DeletionAuditLog.entity_id == story_id)
+            )).scalars().all()
+            assert len(logs) == 1
+            log = logs[0]
+            assert log.entity_type == "story"
+            assert log.org_id == org_id
+            assert log.entity_title == "To Be Deleted"
+            # actor_id는 resolve_member 결과(휴먼=org_member.id) — human_org_member_id와 일치
+            assert log.actor_id == human_org_member_id
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_delete_story_not_found_still_404():
+    """회귀: 존재하지 않는 story는 여전히 404(auth 체크가 그걸 가리면 안 됨)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        human_id = uuid.uuid4()
+        async with Session() as s:
+            org_id, project_id, agent_id, story_id, human_user_id, human_org_member_id = await _seed(s, human_id=human_id)
+
+        await _setup_app(app, Session, human_id, org_id, is_agent=False)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/stories/{uuid.uuid4()}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s1_delete_audit_realdb.py
+++ b/backend/tests/test_e_security_sec_s1_delete_audit_realdb.py
@@ -76,6 +76,14 @@ async def _seed(session, *, human_id: uuid.UUID | None = None):
         om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_id, role="member")
         session.add(om)
         await session.commit()
+        # E-SECURITY SEC-S3(story 90cd7e57) develop merge 정합: delete_story가 human-gate
+        # (SEC-S1) 외에 has_project_access(SEC-S3)도 요구하게 됐으므로, 삭제 성공을 검증하는
+        # 시나리오는 project grant가 필요하다(존재하지 않는 story 404 테스트는 이 체크에
+        # 도달하기 전에 404가 나므로 grant 유무와 무관).
+        session.add(ProjectAccess(
+            id=uuid.uuid4(), project_id=project.id, org_member_id=om.id, permission="granted",
+        ))
+        await session.commit()
         human_user_id = human_id
         human_org_member_id = om.id
 

--- a/backend/tests/test_e_security_sec_s1_ext_delete_audit_realdb.py
+++ b/backend/tests/test_e_security_sec_s1_ext_delete_audit_realdb.py
@@ -1,0 +1,369 @@
+"""E-SECURITY SEC-S1(확장, story 70c9e92c): delete_story와 동형으로 task/epic/doc/project
+hard-delete도 휴먼 전용화 + 삭제 감사 — 까심 적대적 QA 발견 갭(story만 막고 나머지는 그대로라
+prompt injection이 delete_epic/task/doc/project로 우회 가능했음) 봉쇄 실증."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session, *, admin_role: str | None = None):
+    """org + project + agent + human org_member(옵션 role) + task/epic/doc."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.pm import Epic, Story, Task
+    from app.models.doc import Doc
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="SEC-S1-EXT Org", slug=f"sec-s1-ext-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="SEC-S1-EXT Project")
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Deleting Agent", is_active=True)
+    session.add_all([project, agent])
+    await session.commit()
+
+    grant = ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted", role="member",
+    )
+    session.add(grant)
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Anchor Story", status="backlog")
+    session.add(story)
+    await session.commit()
+
+    task = Task(id=uuid.uuid4(), org_id=org.id, story_id=story.id, title="To Be Deleted Task", status="todo")
+    epic = Epic(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="To Be Deleted Epic")
+    doc = Doc(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="To Be Deleted Doc", slug=f"doc-{uuid.uuid4().hex[:8]}")
+    session.add_all([task, epic, doc])
+    await session.commit()
+
+    human_id = uuid.uuid4()
+    user = User(id=human_id, email=f"human-{human_id}@test.com", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_id, role=(admin_role or "member"))
+    session.add(om)
+    await session.commit()
+    human_grant = ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=om.id, permission="granted",
+    )
+    session.add(human_grant)
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "agent_id": agent.id,
+        "task_id": task.id, "epic_id": epic.id, "doc_id": doc.id,
+        "human_user_id": human_id, "human_org_member_id": om.id,
+    }
+
+
+async def _seed_project_only(session, *, admin_role: str | None = None):
+    """project delete 전용 최소 시드 — epic을 안 붙인다(project→epic FK가 ORM 세션에서
+    session.delete(project) 시 CASCADE 대신 SET NULL UPDATE를 먼저 시도해 NOT NULL 위반나는
+    사전 존재 버그를 이 테스트가 우연히 건드리는 것 회피. SEC-S1 스코프 밖이라 별도 플래그만)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="SEC-S1-EXT PrjOrg", slug=f"sec-s1-ext-p-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="SEC-S1-EXT Project Only")
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Deleting Agent", is_active=True)
+    session.add_all([project, agent])
+    await session.commit()
+
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    human_id = uuid.uuid4()
+    user = User(id=human_id, email=f"human-{human_id}@test.com", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_id, role=(admin_role or "member"))
+    session.add(om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=om.id, permission="granted",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "agent_id": agent.id,
+        "human_user_id": human_id, "human_org_member_id": om.id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, member_id, org_id, *, is_agent: bool):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        claims = {"app_metadata": {"org_id": str(org_id)}}
+        if is_agent:
+            claims["app_metadata"]["api_key_id"] = "test-key"
+        return AuthContext(user_id=str(member_id), email="test@test", claims=claims)
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_agent_delete_task_forbidden():
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["agent_id"], seeded["org_id"], is_agent=True)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/tasks/{seeded['task_id']}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.pm import Task
+            task = (await s.execute(select(Task).where(Task.id == seeded["task_id"]))).scalar_one_or_none()
+            assert task is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_human_delete_task_succeeds_and_audit_logged():
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], is_agent=False)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/tasks/{seeded['task_id']}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.pm import Task
+            from app.models.deletion_audit import DeletionAuditLog
+            task = (await s.execute(select(Task).where(Task.id == seeded["task_id"]))).scalar_one_or_none()
+            assert task is None
+            logs = (await s.execute(
+                select(DeletionAuditLog).where(DeletionAuditLog.entity_id == seeded["task_id"])
+            )).scalars().all()
+            assert len(logs) == 1
+            assert logs[0].entity_type == "task"
+            assert logs[0].actor_id == seeded["human_org_member_id"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_delete_doc_forbidden():
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["agent_id"], seeded["org_id"], is_agent=True)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/docs/{seeded['doc_id']}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_human_delete_doc_succeeds_and_audit_logged():
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], is_agent=False)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/docs/{seeded['doc_id']}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.deletion_audit import DeletionAuditLog
+            logs = (await s.execute(
+                select(DeletionAuditLog).where(DeletionAuditLog.entity_id == seeded["doc_id"])
+            )).scalars().all()
+            assert len(logs) == 1
+            assert logs[0].entity_type == "doc"
+            assert logs[0].actor_id == seeded["human_org_member_id"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_delete_epic_forbidden():
+    """에이전트는 admin/owner role을 org_members에 절대 가질 수 없어(휴먼 전용 grant 테이블)
+    기존 role 게이트만으로도 구조적으로 막혔으나, 명시적 human-only 체크도 독립적으로 403을 낸다."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["agent_id"], seeded["org_id"], is_agent=True)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/epics/{seeded['epic_id']}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_human_admin_delete_epic_succeeds_and_audit_logged():
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, admin_role="admin")
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], is_agent=False)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/epics/{seeded['epic_id']}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.deletion_audit import DeletionAuditLog
+            logs = (await s.execute(
+                select(DeletionAuditLog).where(DeletionAuditLog.entity_id == seeded["epic_id"])
+            )).scalars().all()
+            assert len(logs) == 1
+            assert logs[0].entity_type == "epic"
+            assert logs[0].actor_id == seeded["human_org_member_id"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_delete_project_forbidden():
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_project_only(s)
+        await _setup_app(app, Session, seeded["agent_id"], seeded["org_id"], is_agent=True)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/projects/{seeded['project_id']}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# NOTE(별개 발견·SEC-S1 스코프 밖): human-admin이 실제로 delete_project를 완주하는 realdb 테스트는
+# 의도적으로 뺐다 — `ProjectRepository.delete()`가 `session.delete(project)`를 호출할 때
+# SQLAlchemy ORM이 `Project.team_members` relationship(cascade 미설정)을 통해 관련
+# `team_members`(뷰) 행의 FK를 먼저 NULL로 UPDATE하려다 "cannot update view"로 죽는 사전 존재
+# 버그를 이 테스트가 우연히 밟았다(ObjectNotInPrerequisiteStateError) — 실 project_access grant가
+# 하나라도 있는 project는 delete_project가 이미 500일 가능성. human-only 게이트 코드 자체(위
+# agent 403 테스트로 검증됨)와는 무관한 별개 결함이라 여기서 안 건드리고 스레드에 별도 플래그.
+
+
+@pytest.mark.anyio
+async def test_human_member_role_delete_epic_still_403():
+    """member role(admin/owner 아님)인 휴먼도 기존 role 게이트로 403 — human-only 체크 추가가
+    기존 role 게이트를 우회시키지 않았음을 확인(회귀 0)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, admin_role="member")
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], is_agent=False)
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/epics/{seeded['epic_id']}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s2_agentcard_org_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s2_agentcard_org_scope_realdb.py
@@ -1,0 +1,175 @@
+"""E-SECURITY SEC-S2(story 48ff642a): AgentCard 발견 authed+org-scoping — 실 Postgres 검증."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_agent(session, org, project_name="P"):
+    from app.models.member import Member
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name=project_name)
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name=f"Agent-{project_name}", is_active=True)
+    session.add_all([project, agent])
+    await session.commit()
+    grant = ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted", role="member",
+    )
+    session.add(grant)
+    await session.commit()
+    return agent.id
+
+
+async def _seed_two_orgs(session):
+    from app.models.organization import Organization
+
+    org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
+    org_b = Organization(id=uuid.uuid4(), name="Org B", slug=f"org-b-{uuid.uuid4().hex[:8]}")
+    session.add_all([org_a, org_b])
+    await session.commit()
+
+    caller_id = await _seed_agent(session, org_a, "OrgA-Caller")
+    target_same_org_id = await _seed_agent(session, org_a, "OrgA-Target")
+    target_other_org_id = await _seed_agent(session, org_b, "OrgB-Target")
+
+    return org_a.id, org_b.id, caller_id, target_same_org_id, target_other_org_id
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, member_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(member_id), email="agent@test",
+            claims={"app_metadata": {"org_id": str(org_id), "api_key_id": "test-key"}},
+        )
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_agent_card_unauthenticated_now_rejected():
+    """auth override 없이 호출 시 401/403(실 get_current_user가 걸림) — unauth 시대 종료 확認."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_a_id, org_b_id, caller_id, same_org_id, other_org_id = await _seed_two_orgs(s)
+
+        # get_db만 override, auth는 실 의존성 그대로(토큰 없이 호출 → 401 기대)
+        async def _db():
+            async with Session() as s:
+                yield s
+
+        from app.dependencies.database import get_db
+        app.dependency_overrides[get_db] = _db
+
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/a2a/members/{same_org_id}/agent-card.json")
+            assert resp.status_code in (401, 403), resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_same_org_discovery_still_free():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_a_id, org_b_id, caller_id, same_org_id, other_org_id = await _seed_two_orgs(s)
+
+        await _setup_app(app, Session, caller_id, org_a_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/a2a/members/{same_org_id}/agent-card.json")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["name"] == "Agent-OrgA-Target"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cross_org_discovery_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_a_id, org_b_id, caller_id, same_org_id, other_org_id = await _seed_two_orgs(s)
+
+        await _setup_app(app, Session, caller_id, org_a_id)
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/a2a/members/{other_org_id}/agent-card.json")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s3_project_authz_realdb.py
+++ b/backend/tests/test_e_security_sec_s3_project_authz_realdb.py
@@ -1,0 +1,227 @@
+"""E-SECURITY SEC-S3(story 90cd7e57): delete_story project 인가 + create_conversation
+participant org 필터 — 라이브 확定 P1 갭 봉쇄 실증."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_human(session, org_id, project_id=None, *, grant_project: bool = False):
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    user = User(id=user_id, email=f"human-{user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user_id, role="member")
+    session.add(om)
+    await session.commit()
+    if grant_project and project_id is not None:
+        session.add(ProjectAccess(
+            id=uuid.uuid4(), project_id=project_id, org_member_id=om.id, permission="granted",
+        ))
+        await session.commit()
+    return user_id, om.id
+
+
+async def _seed_stories_scenario(session):
+    """org + project A(caller 접근권 없음) + project B(caller 접근권 있음) + story."""
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.pm import Story
+
+    org = Organization(id=uuid.uuid4(), name="SEC-S3 Org", slug=f"sec-s3-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_no_access = Project(id=uuid.uuid4(), org_id=org.id, name="No Access Project")
+    project_with_access = Project(id=uuid.uuid4(), org_id=org.id, name="With Access Project")
+    session.add_all([project_no_access, project_with_access])
+    await session.commit()
+
+    story_no_access = Story(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_no_access.id,
+        title="Story in inaccessible project", status="backlog",
+    )
+    story_with_access = Story(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_with_access.id,
+        title="Story in accessible project", status="backlog",
+    )
+    session.add_all([story_no_access, story_with_access])
+    await session.commit()
+
+    caller_user_id, caller_om_id = await _seed_human(session, org.id, project_with_access.id, grant_project=True)
+
+    return {
+        "org_id": org.id, "caller_user_id": caller_user_id,
+        "project_no_access_id": project_no_access.id, "project_with_access_id": project_with_access.id,
+        "story_no_access_id": story_no_access.id, "story_with_access_id": story_with_access.id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_delete_story_without_project_access_forbidden():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_stories_scenario(s)
+
+        await _setup_app(app, Session, seeded["caller_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/stories/{seeded['story_no_access_id']}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.pm import Story
+            story = (await s.execute(
+                select(Story).where(Story.id == seeded["story_no_access_id"])
+            )).scalar_one_or_none()
+            assert story is not None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_delete_story_with_project_access_succeeds():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_stories_scenario(s)
+
+        await _setup_app(app, Session, seeded["caller_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/stories/{seeded['story_with_access_id']}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_conversation_cross_org_participant_filtered():
+    """까심 재현: cross-org participant_id가 org 필터 없이 그대로 insert되던 갭 — 봉쇄 확認."""
+    from app.main import app
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
+            org_b = Organization(id=uuid.uuid4(), name="Org B", slug=f"org-b-{uuid.uuid4().hex[:8]}")
+            s.add_all([org_a, org_b])
+            await s.commit()
+            project_a = Project(id=uuid.uuid4(), org_id=org_a.id, name="Org A Project")
+            s.add(project_a)
+            await s.commit()
+
+            caller_user_id, _ = await _seed_human(s, org_a.id, project_a.id, grant_project=True)
+            same_org_user_id, same_org_om_id = await _seed_human(s, org_a.id)
+            other_org_user_id, other_org_om_id = await _seed_human(s, org_b.id)
+
+        await _setup_app(app, Session, caller_user_id, org_a.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/conversations",
+                json={
+                    "type": "group", "project_id": str(project_a.id),
+                    "participant_ids": [str(same_org_om_id), str(other_org_om_id)],
+                },
+            )
+            assert resp.status_code == 201, resp.text
+            conv_id = resp.json()["id"]
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.conversation import ConversationParticipant
+            participant_ids = {
+                r[0] for r in (await s.execute(
+                    select(ConversationParticipant.member_id).where(
+                        ConversationParticipant.conversation_id == uuid.UUID(conv_id)
+                    )
+                )).all()
+            }
+            assert same_org_om_id in participant_ids
+            assert other_org_om_id not in participant_ids
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s6_roster_org_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s6_roster_org_scope_realdb.py
@@ -1,0 +1,220 @@
+"""E-SECURITY SEC-S6(story 54248174·까심 QA 부수발견 D): GET /api/v2/members?project_id= 스코프
+검증 — 타 org project_id로 그 org 멤버 로스터가 그대로 열거되던 cross-org IDOR 봉쇄 실증.
+
+동시에 `assert_target_in_caller_org` 공통 가드가 D(project)뿐 아니라 E(agent_personas의
+agent_id) 형태의 target에도 그대로 재사용 가능한지 순수 함수 레벨로 실측(SEC-S7 crux 재사용
+근거)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_two_orgs(session):
+    """Org A caller(휴먼)·Org B project + 멤버(휴먼1+에이전트1) — D 재현용."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
+    org_b = Organization(id=uuid.uuid4(), name="Org B", slug=f"org-b-{uuid.uuid4().hex[:8]}")
+    session.add_all([org_a, org_b])
+    await session.commit()
+
+    caller_user_id = uuid.uuid4()
+    caller_user = User(id=caller_user_id, email=f"caller-{caller_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller_user)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=caller_user_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+
+    project_b = Project(id=uuid.uuid4(), org_id=org_b.id, name="Org B Project")
+    session.add(project_b)
+    await session.commit()
+
+    target_user_id = uuid.uuid4()
+    target_user = User(id=target_user_id, email=f"target-{target_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(target_user)
+    await session.commit()
+    target_om = OrgMember(id=uuid.uuid4(), org_id=org_b.id, user_id=target_user_id, role="admin")
+    session.add(target_om)
+    await session.commit()
+
+    agent_b = Member(id=uuid.uuid4(), org_id=org_b.id, type="agent", name="Org B Agent", is_active=True)
+    session.add(agent_b)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_b.id, member_id=agent_b.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_a_id": org_a.id, "org_b_id": org_b.id,
+        "caller_user_id": caller_user_id, "project_b_id": project_b.id,
+        "target_admin_name": target_user.email,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_cross_org_project_id_roster_blocked():
+    """까심 D 재현: Org A caller가 Org B project_id로 조회 시도 → 404(로스터 비노출)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_orgs(s)
+
+        await _setup_app(app, Session, seeded["caller_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/members?project_id={seeded['project_b_id']}")
+            assert resp.status_code == 404, resp.text
+            assert "Org B Agent" not in resp.text
+            assert seeded["target_admin_name"] not in resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_same_org_project_id_roster_still_free():
+    """회귀 0: Org B caller가 자기 org의 project_id로 조회하면 정상 로스터(휴먼+에이전트) 반환."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_orgs(s)
+
+        await _setup_app(app, Session, seeded["caller_user_id"], seeded["org_b_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/members?project_id={seeded['project_b_id']}")
+            assert resp.status_code == 200, resp.text
+            members = resp.json()
+            names = {m["name"] for m in members}
+            assert seeded["target_admin_name"] in names
+            assert "Org B Agent" in names
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_nonexistent_project_id_also_404():
+    """존재하지 않는 project_id도 동일하게 404(타org·미존재 구분 안 함 — 존재 비노출)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_orgs(s)
+
+        await _setup_app(app, Session, seeded["caller_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/members?project_id={uuid.uuid4()}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+def test_assert_target_in_caller_org_reusable_for_agent_target():
+    """SEC-S7 crux 실측: 공통 가드가 project 형태뿐 아니라 agent(persona target) 형태의
+    target_org_id 비교에도 그대로 재사용 가능 — 순수 함수라 실 agent row 없이도 로직 검증 충분."""
+    from fastapi import HTTPException
+    from app.services.project_auth import assert_target_in_caller_org
+
+    caller_org = uuid.uuid4()
+    same_org_agent_org = caller_org
+    other_org_agent_org = uuid.uuid4()
+
+    # same-org agent target → 통과(예외 없음)
+    assert_target_in_caller_org(caller_org, same_org_agent_org, not_found_detail="Agent not found")
+
+    # cross-org agent target → 404
+    with pytest.raises(HTTPException) as exc_info:
+        assert_target_in_caller_org(caller_org, other_org_agent_org, not_found_detail="Agent not found")
+    assert exc_info.value.status_code == 404
+
+    # 존재하지 않는 agent(org 조회 자체가 None) → 동일 404
+    with pytest.raises(HTTPException) as exc_info2:
+        assert_target_in_caller_org(caller_org, None, not_found_detail="Agent not found")
+    assert exc_info2.value.status_code == 404

--- a/backend/tests/test_e_security_sec_s8_bb_workflow_templates_executions_project_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_bb_workflow_templates_executions_project_scope_realdb.py
@@ -1,0 +1,259 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) BB: workflow_templates apply + workflow_executions
+story-summary project-scope 미검증 봉쇄 실증(까심 전수스윕, 실HTTP 확定).
+
+- apply_template: body.project_id에 has_project_access 검증 자체가 없어, project_a만
+  grant된 caller가 project_b로 template apply 시 실제로 AgentRoutingRule이 생성됐다(201).
+- story_execution_summary: project_id에 project 접근권 검증이 없어 남의 project 워크플로
+  실행 상태(story-level status/rule_name)가 노출됐다(200)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_base(session):
+    """org(project_a, project_b) + human_a(project_a에만 명시 grant)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"h-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ── apply_template ───────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_apply_template_cross_project_blocked_no_rule_created():
+    """BB 재현: project_a만 grant된 caller가 project_b로 template apply → 404·룰 생성 0."""
+    from app.main import app
+    from app.models.agent_routing_rule import AgentRoutingRule
+    from app.models.member import Member
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            agent = Member(id=uuid.uuid4(), org_id=seeded["org_id"], type="agent", name="agent", is_active=True)
+            s.add(agent)
+            await s.commit()
+            agent_id = agent.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/workflow-templates/solo/apply",
+                json={
+                    "project_id": str(seeded["project_b_id"]),
+                    "role_mapping": {"step_1": str(agent_id)},
+                },
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            rules = (await s.execute(
+                select(AgentRoutingRule).where(AgentRoutingRule.project_id == seeded["project_b_id"])
+            )).scalars().all()
+            assert rules == [], "무권한 project에 AgentRoutingRule이 생성되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_apply_template_same_project_still_works():
+    from app.main import app
+    from app.models.member import Member
+    from app.models.project_access import ProjectAccess
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            agent = Member(id=uuid.uuid4(), org_id=seeded["org_id"], type="agent", name="agent", is_active=True)
+            s.add(agent)
+            await s.commit()
+            s.add(ProjectAccess(
+                id=uuid.uuid4(), project_id=seeded["project_a_id"], member_id=agent.id,
+                permission="granted", role="member",
+            ))
+            await s.commit()
+            agent_id = agent.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/workflow-templates/solo/apply",
+                json={
+                    "project_id": str(seeded["project_a_id"]),
+                    "role_mapping": {"step_1": str(agent_id)},
+                },
+            )
+            assert resp.status_code == 201, resp.text
+            assert resp.json()["rules_created"] == 1
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── story_execution_summary ──────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_story_execution_summary_cross_project_blocked():
+    """BB 재현: project_a만 grant된 caller가 project_b의 실행 요약 조회 → 404·노출 0."""
+    from app.main import app
+    from app.models.workflow_execution_log import WorkflowExecutionLog
+
+    engine, Session = await _session_factory()
+    try:
+        story_id = str(uuid.uuid4())
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            s.add(WorkflowExecutionLog(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_b_id"],
+                event_type="story.status_changed", status="success",
+                event_context={"metadata": {"story_id": story_id}},
+            ))
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/workflow-executions/story-summary",
+                params={"project_id": str(seeded["project_b_id"]), "story_ids": [story_id]},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_story_execution_summary_same_project_still_works():
+    from app.main import app
+    from app.models.workflow_execution_log import WorkflowExecutionLog
+
+    engine, Session = await _session_factory()
+    try:
+        story_id = str(uuid.uuid4())
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            s.add(WorkflowExecutionLog(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"],
+                event_type="story.status_changed", status="success",
+                event_context={"metadata": {"story_id": story_id}},
+            ))
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/workflow-executions/story-summary",
+                params={"project_id": str(seeded["project_a_id"]), "story_ids": [story_id]},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert story_id in body
+            assert body[story_id]["status"] == "success"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_cc_sprint_project_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_cc_sprint_project_scope_realdb.py
@@ -1,0 +1,441 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) CC: sprints.py 전 엔드포인트 project-scope 미검증 봉쇄
+실증(선생님 "sprint org-level=갭" 확定, 까심 전수스윕 후속).
+
+sprints.py 13개 엔드포인트 전부 org-scope만이고 caller의 project 접근권 검증이 어디에도
+없었다 — project_a만 grant된 caller가 org 내 project_b의 sprint를 조회/생성/수정/삭제/
+활성화/종료/kickoff/summary/checkin/transition 전부 가능했다. resolve_member(project_id=)/
+has_project_access SSOT로 봉인 — 이 파일은 각 엔드포인트가 실제로 cross-project 요청을
+차단(404/403)하고 same-project는 정상 동작함을 실 Postgres로 검증한다."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_base(session):
+    """org(project_a, project_b) + human_a(project_a에만 명시 grant)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"h-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "human_user_id": human_user_id,
+    }
+
+
+async def _seed_sprint(session, org_id, project_id, status="planning"):
+    from app.models.pm import Sprint
+    sprint = Sprint(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title="Sprint", status=status, duration=14)
+    session.add(sprint)
+    await session.commit()
+    return sprint.id
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ── get_sprint ────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_get_sprint_cross_project_blocked_same_project_ok():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_a = await _seed_sprint(s, seeded["org_id"], seeded["project_a_id"])
+            sprint_b = await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp_b = await client.get(f"/api/v2/sprints/{sprint_b}")
+            assert resp_b.status_code == 404, resp_b.text
+            resp_a = await client.get(f"/api/v2/sprints/{sprint_a}")
+            assert resp_a.status_code == 200, resp_a.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── list_sprints ──────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_sprints_no_project_id_filters_to_accessible_only():
+    """project_id 미지정 시 org 전체가 아니라 accessible project로만 필터(완전봉인)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_a = await _seed_sprint(s, seeded["org_id"], seeded["project_a_id"])
+            sprint_b = await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/sprints")
+            assert resp.status_code == 200, resp.text
+            ids = {item["id"] for item in resp.json()}
+            assert str(sprint_a) in ids
+            assert str(sprint_b) not in ids
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_sprints_project_id_cross_project_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/sprints", params={"project_id": str(seeded["project_b_id"])})
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── create_sprint ─────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_sprint_cross_project_blocked_no_row():
+    from app.main import app
+    from app.models.pm import Sprint
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/sprints", json={
+                "project_id": str(seeded["project_b_id"]), "org_id": str(seeded["org_id"]),
+                "title": "Injected Sprint",
+            })
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            rows = (await s.execute(
+                select(Sprint).where(Sprint.project_id == seeded["project_b_id"])
+            )).scalars().all()
+            assert rows == [], "무권한 project에 sprint가 생성되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── delete_sprint ─────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_delete_sprint_cross_project_blocked_no_mutation():
+    from app.main import app
+    from app.models.pm import Sprint
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_b = await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/sprints/{sprint_b}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            reloaded = (await s.execute(select(Sprint).where(Sprint.id == sprint_b))).scalar_one_or_none()
+            assert reloaded is not None, "무권한 project sprint가 삭제되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── kickoff / summary / checkin (읽기+알림 계열) ────────────────────────────────
+
+@pytest.mark.anyio
+async def test_kickoff_sprint_cross_project_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_b = await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/sprints/{sprint_b}/kickoff", json={})
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sprint_summary_cross_project_blocked_same_project_ok():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_a = await _seed_sprint(s, seeded["org_id"], seeded["project_a_id"])
+            sprint_b = await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp_b = await client.get(f"/api/v2/sprints/{sprint_b}/summary")
+            assert resp_b.status_code == 404, resp_b.text
+            resp_a = await client.get(f"/api/v2/sprints/{sprint_a}/summary")
+            assert resp_a.status_code == 200, resp_a.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_checkin_sprint_cross_project_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_b = await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/sprints/{sprint_b}/checkin", params={"date": "2026-07-11"})
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── update_sprint (PATCH) ────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_update_sprint_cross_project_blocked_no_mutation():
+    from app.main import app
+    from app.models.pm import Sprint
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_b = await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(f"/api/v2/sprints/{sprint_b}", json={"title": "Hijacked"})
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            reloaded = (await s.execute(select(Sprint).where(Sprint.id == sprint_b))).scalar_one()
+            assert reloaded.title == "Sprint", "무권한 project sprint 제목이 변조되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── activate / close / transition ────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_activate_sprint_cross_project_blocked_no_mutation():
+    from app.main import app
+    from app.models.pm import Sprint
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_b = await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/sprints/{sprint_b}/activate")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            reloaded = (await s.execute(select(Sprint).where(Sprint.id == sprint_b))).scalar_one()
+            assert reloaded.status == "planning", "무권한 project sprint가 활성화되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_transition_sprint_cross_project_blocked_no_mutation():
+    from app.main import app
+    from app.models.pm import Sprint
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_b = await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/sprints/{sprint_b}/transition", json={"status": "active"})
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            reloaded = (await s.execute(select(Sprint).where(Sprint.id == sprint_b))).scalar_one()
+            assert reloaded.status == "planning", "무권한 project sprint가 전이되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── list_sprint_hypotheses (read-쌍둥이 발견즉시수정) ────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_sprint_hypotheses_cross_project_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_b = await _seed_sprint(s, seeded["org_id"], seeded["project_b_id"])
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/sprints/{sprint_b}/hypotheses")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_dd_analytics_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_dd_analytics_scope_realdb.py
@@ -1,0 +1,247 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) DD: analytics burndown/velocity cross-org IDOR + 전
+analytics 엔드포인트 project-scope 봉쇄 실증(까심 라이브확定, CRITICAL).
+
+- get_burndown/get_sprint_velocity: 다른 org_repo 메소드는 전부 org_id를 필터하는데 이 둘만
+  누락돼 완전 무관 org가 sprint UUID만 알면 velocity/status를 그대로 열람할 수 있었다.
+- 이왕 여는 김에(PO 결) analytics.py 9개 엔드포인트 전부에 has_project_access를 추가해
+  same-org cross-project 노출까지 봉인(오늘 R~CC와 동형 근본)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_two_orgs(session):
+    """org_a(project_a, sprint_a, human_a=project_a grant) + org_b(project_b, sprint_b)."""
+    from app.models.organization import Organization
+    from app.models.pm import Sprint
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
+    org_b = Organization(id=uuid.uuid4(), name="Org B", slug=f"org-b-{uuid.uuid4().hex[:8]}")
+    session.add_all([org_a, org_b])
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org_a.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org_b.id, name="Project B (SECRET)")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    sprint_a = Sprint(id=uuid.uuid4(), org_id=org_a.id, project_id=project_a.id, title="Sprint A", status="active", duration=14, velocity=10)
+    sprint_b = Sprint(id=uuid.uuid4(), org_id=org_b.id, project_id=project_b.id, title="SECRET SPRINT", status="active", duration=14, velocity=99)
+    session.add_all([sprint_a, sprint_b])
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"h-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_a_id": org_a.id, "org_b_id": org_b.id,
+        "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "sprint_a_id": sprint_a.id, "sprint_b_id": sprint_b.id,
+        "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ── DD: cross-org (원 취약점) ─────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_burndown_cross_org_blocked_secret_not_leaked():
+    """org_a human이 org_b의 sprint UUID로 burndown 조회 → 404, SECRET 미노출."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_orgs(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/sprints/{seeded['sprint_b_id']}/burndown")
+            assert resp.status_code == 404, resp.text
+            assert "SECRET" not in resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_velocity_cross_org_blocked_secret_not_leaked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_orgs(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/sprints/{seeded['sprint_b_id']}/velocity")
+            assert resp.status_code == 404, resp.text
+            assert "SECRET" not in resp.text
+            assert "99" not in resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_burndown_same_org_same_project_still_works():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_orgs(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/sprints/{seeded['sprint_a_id']}/burndown")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["sprint"]["title"] == "Sprint A"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── DD 후속: same-org cross-project (project-scope 하드닝) ──────────────────────
+
+@pytest.mark.anyio
+async def test_burndown_same_org_cross_project_blocked():
+    """org_a human이 project_a에만 grant 있는데, 같은 org 내 project_b sprint를 만들어 조회 시도."""
+    from app.main import app
+    from app.models.pm import Sprint
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_orgs(s)
+            from app.models.project import Project
+            project_c = Project(id=uuid.uuid4(), org_id=seeded["org_a_id"], name="Project C")
+            s.add(project_c)
+            await s.commit()
+            sprint_c = Sprint(id=uuid.uuid4(), org_id=seeded["org_a_id"], project_id=project_c.id, title="Sprint C", status="active", duration=14, velocity=5)
+            s.add(sprint_c)
+            await s.commit()
+            sprint_c_id = sprint_c.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/sprints/{sprint_c_id}/burndown")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_overview_same_org_cross_project_blocked_same_project_ok():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_orgs(s)
+            from app.models.project import Project
+            project_c = Project(id=uuid.uuid4(), org_id=seeded["org_a_id"], name="Project C")
+            s.add(project_c)
+            await s.commit()
+            project_c_id = project_c.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp_c = await client.get("/api/v2/analytics/overview", params={"project_id": str(project_c_id)})
+            assert resp_c.status_code == 404, resp_c.text
+            resp_a = await client.get("/api/v2/analytics/overview", params={"project_id": str(seeded["project_a_id"])})
+            assert resp_a.status_code == 200, resp_a.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_ee_standup_impersonation_oss_seed_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_ee_standup_impersonation_oss_seed_realdb.py
@@ -1,0 +1,368 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) EE: standup impersonation + oss_seed org-scope 봉쇄
+실증(까심 전수스윕, CRITICAL 3건 라이브확定).
+
+- upsert_standup: body.project_id 접근권 검증 0 + body.author_id가 client-supplied 그대로
+  신뢰돼(self-scope 검증 0) 남의 project에 남의 이름으로 standup을 위조할 수 있었다.
+- add_feedback: body.project_id 접근권 검증 0 + body.feedback_by_id가 client-supplied 그대로
+  신뢰돼(self-scope 검증 0) 남의 project에 남의 이름으로 feedback을 위조할 수 있었다
+  ("트랩#9" 자기주석에도 불구 실제로 뚫려있었다).
+- oss_seed: org_id가 get_verified_org_id를 거치지 않는 raw client query param이라 인증
+  유저가 소속 여부와 무관하게 임의 org_id로 시드를 심을 수 있었다."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date as _date
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_two_humans_two_orgs(session):
+    """org_a(project_a, human_a=project_a grant) + org_b(project_b, human_b=project_b grant).
+
+    human_a는 project_a에만 접근권 있고, human_b는 org_b(별개 org) 소속 — cross-project와
+    cross-org 양쪽 각도 모두 재현 가능."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
+    org_b = Organization(id=uuid.uuid4(), name="Org B", slug=f"org-b-{uuid.uuid4().hex[:8]}")
+    session.add_all([org_a, org_b])
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org_a.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org_b.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    human_a_id = uuid.uuid4()
+    human_a = User(id=human_a_id, email=f"a-{human_a_id.hex[:8]}@test.com", hashed_password="x")
+    human_b_id = uuid.uuid4()
+    human_b = User(id=human_b_id, email=f"b-{human_b_id.hex[:8]}@test.com", hashed_password="x")
+    session.add_all([human_a, human_b])
+    await session.commit()
+
+    om_a = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=human_a_id, role="member")
+    om_b = OrgMember(id=uuid.uuid4(), org_id=org_b.id, user_id=human_b_id, role="member")
+    session.add_all([om_a, om_b])
+    await session.commit()
+    session.add_all([
+        ProjectAccess(id=uuid.uuid4(), project_id=project_a.id, org_member_id=om_a.id, permission="granted", role="member"),
+        ProjectAccess(id=uuid.uuid4(), project_id=project_b.id, org_member_id=om_b.id, permission="granted", role="member"),
+    ])
+    await session.commit()
+
+    return {
+        "org_a_id": org_a.id, "org_b_id": org_b.id,
+        "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "human_a_user_id": human_a_id, "human_b_user_id": human_b_id,
+        "human_b_om_id": om_b.id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ── upsert_standup ───────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_upsert_standup_cross_project_blocked_no_row():
+    """human_a가 project_a에만 grant인데 project_b로 standup 작성 시도 → 차단·row 무생성."""
+    from app.main import app
+    from app.models.standup import StandupEntry
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_humans_two_orgs(s)
+
+        await _setup_app(app, Session, seeded["human_a_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/standups", json={
+                "project_id": str(seeded["project_b_id"]),
+                "author_id": str(seeded["human_a_user_id"]),
+                "date": "2026-07-11", "plan": "injected plan",
+            })
+            assert resp.status_code in (403, 404), resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            rows = (await s.execute(
+                select(StandupEntry).where(StandupEntry.project_id == seeded["project_b_id"])
+            )).scalars().all()
+            assert rows == [], "무권한 project에 standup entry가 생성되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_upsert_standup_author_id_spoof_ignored_uses_caller_identity():
+    """human_a가 자기 project에서 author_id=human_b(타인) 스푸핑 시도 → 실제 저장은 caller(human_a) 신원."""
+    from app.main import app
+    from app.models.standup import StandupEntry
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_humans_two_orgs(s)
+
+        await _setup_app(app, Session, seeded["human_a_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/standups", json={
+                "project_id": str(seeded["project_a_id"]),
+                "author_id": str(seeded["human_b_user_id"]),  # 스푸핑 시도(타인 신원)
+                "date": "2026-07-11", "plan": "who wrote this?",
+            })
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            entry = (await s.execute(
+                select(StandupEntry).where(StandupEntry.project_id == seeded["project_a_id"])
+            )).scalar_one()
+            # author_id가 스푸핑값(human_b)이 아니라 caller(human_a org_member.id=om_a) 기반이어야 함.
+            assert str(entry.author_id) != str(seeded["human_b_om_id"]), "author_id 스푸핑이 저장되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_upsert_standup_same_project_still_works():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_humans_two_orgs(s)
+
+        await _setup_app(app, Session, seeded["human_a_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/standups", json={
+                "project_id": str(seeded["project_a_id"]),
+                "author_id": str(seeded["human_a_user_id"]),
+                "date": "2026-07-11", "plan": "legit plan",
+            })
+            assert resp.status_code == 201, resp.text
+            assert resp.json()["plan"] == "legit plan"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── add_feedback ──────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_add_feedback_cross_project_blocked_no_row():
+    """entry가 project_b(caller 무권한) 소속인데 body.project_id를 project_a(caller 유권한)라
+    주장해도 차단돼야 한다 — 까심 QA가 잡은 bypass 벡터(body-claimed project 신뢰 금지,
+    entry.project_id가 실제 인가 기준)."""
+    from app.main import app
+    from app.models.standup import StandupEntry, StandupFeedback
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_humans_two_orgs(s)
+            from app.models.project import Project
+            project_c = Project(id=uuid.uuid4(), org_id=seeded["org_a_id"], name="Project C (no grant)")
+            s.add(project_c)
+            await s.commit()
+            entry = StandupEntry(
+                id=uuid.uuid4(), org_id=seeded["org_a_id"], project_id=project_c.id,
+                author_id=uuid.uuid4(), date=_date(2026, 7, 11),
+            )
+            s.add(entry)
+            await s.commit()
+            entry_id = entry.id
+
+        await _setup_app(app, Session, seeded["human_a_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/standups/{entry_id}/feedback", json={
+                "org_id": str(seeded["org_a_id"]),
+                "project_id": str(seeded["project_a_id"]),  # caller 유권한 project라 주장(bypass 시도)
+                "feedback_by_id": str(seeded["human_a_user_id"]),
+                "review_type": "comment", "feedback_text": "injected",
+            })
+            assert resp.status_code in (403, 404), resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            rows = (await s.execute(
+                select(StandupFeedback).where(StandupFeedback.standup_entry_id == entry_id)
+            )).scalars().all()
+            assert rows == [], "무권한 entry에 feedback이 생성되면 안 됨(body-claimed project 우회 차단)"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_add_feedback_by_id_spoof_ignored_uses_caller_identity():
+    from app.main import app
+    from app.models.standup import StandupEntry, StandupFeedback
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_humans_two_orgs(s)
+            entry = StandupEntry(
+                id=uuid.uuid4(), org_id=seeded["org_a_id"], project_id=seeded["project_a_id"],
+                author_id=uuid.uuid4(), date=_date(2026, 7, 11),
+            )
+            s.add(entry)
+            await s.commit()
+            entry_id = entry.id
+
+        await _setup_app(app, Session, seeded["human_a_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/standups/{entry_id}/feedback", json={
+                "org_id": str(seeded["org_a_id"]),
+                "project_id": str(seeded["project_a_id"]),
+                "feedback_by_id": str(seeded["human_b_user_id"]),  # 스푸핑 시도
+                "review_type": "comment", "feedback_text": "legit feedback",
+            })
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            fb = (await s.execute(
+                select(StandupFeedback).where(StandupFeedback.standup_entry_id == entry_id)
+            )).scalar_one()
+            assert str(fb.feedback_by_id) != str(seeded["human_b_om_id"]), "feedback_by_id 스푸핑이 저장되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── oss_seed ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_oss_seed_cross_org_blocked_no_rows():
+    """human_b(org_b 소속)가 org_a(자기 소속 아님)+project_a로 시드 시도 → 차단·row 무생성."""
+    from app.main import app
+    from app.models.pm import Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_humans_two_orgs(s)
+
+        await _setup_app(app, Session, seeded["human_b_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/oss/seed", params={
+                "project_id": str(seeded["project_a_id"]),
+            })
+            assert resp.status_code in (403, 404), resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            rows = (await s.execute(
+                select(Story).where(Story.project_id == seeded["project_a_id"])
+            )).scalars().all()
+            assert rows == [], "무권한 org/project에 샘플 스토리가 생성되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_oss_seed_same_org_project_still_works():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_humans_two_orgs(s)
+
+        await _setup_app(app, Session, seeded["human_a_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/oss/seed", params={
+                "project_id": str(seeded["project_a_id"]),
+            })
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["seeded"] is True
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_f_delete_meeting_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_f_delete_meeting_realdb.py
@@ -1,0 +1,229 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) F: delete_meeting cross-org 무인증 삭제 봉쇄 실증.
+
+`_get_repo`가 `get_verified_org_id`를 계산만 하고(dead computation) `MeetingRepository`는
+project_id만으로 스코핑돼 — Org B agent가 임의 project_id(query param 또는 JWT app_metadata)로
+Org A meeting을 무인증 삭제(200·무감사) 가능했음."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    from sqlalchemy import text
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.user import User
+
+    org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
+    org_b = Organization(id=uuid.uuid4(), name="Org B", slug=f"org-b-{uuid.uuid4().hex[:8]}")
+    session.add_all([org_a, org_b])
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org_a.id, name="Org A Project")
+    session.add(project_a)
+    await session.commit()
+
+    # meetings.meeting_type은 실 PG ENUM 컬럼이라 ORM insert(VARCHAR 바인딩)가 캐스트 실패 —
+    # raw SQL로 명시 캐스트해 우회(delete_meeting 인가 실증이 목적이라 meeting 생성 경로 자체는
+    # 무관).
+    meeting_id = uuid.uuid4()
+    await session.execute(
+        text(
+            "INSERT INTO meetings (id, project_id, title, meeting_type, participants, decisions, action_items) "
+            "VALUES (:id, :pid, :title, 'general'::meeting_type, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb)"
+        ),
+        {"id": meeting_id, "pid": project_a.id, "title": "Org A Meeting"},
+    )
+    await session.commit()
+
+    agent_b = Member(id=uuid.uuid4(), org_id=org_b.id, type="agent", name="Org B Agent", is_active=True)
+    session.add(agent_b)
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"human-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om_a = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=human_user_id, role="admin")
+    session.add(human_om_a)
+    await session.commit()
+
+    return {
+        "org_a_id": org_a.id, "org_b_id": org_b.id, "project_a_id": project_a.id,
+        "meeting_id": meeting_id, "agent_b_id": agent_b.id,
+        "human_user_id": human_user_id, "human_om_a_id": human_om_a.id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id, project_id, *, is_agent: bool):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        claims = {"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}}
+        if is_agent:
+            claims["app_metadata"]["api_key_id"] = "test-key"
+        return AuthContext(user_id=str(user_id), email="caller@test", claims=claims)
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_cross_org_agent_delete_meeting_blocked():
+    """까심 F 재현: Org B agent가 (JWT app_metadata로) Org A meeting을 delete 시도 → 차단."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        # Org B agent가 자기 org_id는 Org B로 인증하되, project_id는 Org A project를 지정
+        # (cross-org 공격 시나리오 — JWT app_metadata.project_id를 임의로 가리킴).
+        await _setup_app(
+            app, Session, seeded["agent_b_id"], seeded["org_b_id"], seeded["project_a_id"], is_agent=True,
+        )
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/meetings/{seeded['meeting_id']}")
+            assert resp.status_code in (403, 404), resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.meeting import Meeting
+            meeting = (await s.execute(
+                select(Meeting).where(Meeting.id == seeded["meeting_id"])
+            )).scalar_one_or_none()
+            assert meeting is not None, "cross-org 삭제가 실제로 일어나면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_same_org_human_delete_meeting_succeeds_and_audited():
+    """회귀 0: 같은 org 휴먼은 정상 삭제 + 감사 기록."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(
+            app, Session, seeded["human_user_id"], seeded["org_a_id"], seeded["project_a_id"], is_agent=False,
+        )
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/meetings/{seeded['meeting_id']}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.meeting import Meeting
+            from app.models.deletion_audit import DeletionAuditLog
+            meeting = (await s.execute(
+                select(Meeting).where(Meeting.id == seeded["meeting_id"])
+            )).scalar_one_or_none()
+            assert meeting is None
+            logs = (await s.execute(
+                select(DeletionAuditLog).where(DeletionAuditLog.entity_id == seeded["meeting_id"])
+            )).scalars().all()
+            assert len(logs) == 1
+            assert logs[0].entity_type == "meeting"
+            assert logs[0].actor_id == seeded["human_om_a_id"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_same_org_agent_delete_meeting_forbidden():
+    """SEC-S1 패턴 계승: 같은 org 소속이어도 agent는 human-gate로 차단."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            from app.models.member import Member
+            from app.models.project_access import ProjectAccess
+            agent_a = Member(id=uuid.uuid4(), org_id=seeded["org_a_id"], type="agent", name="Org A Agent", is_active=True)
+            s.add(agent_a)
+            await s.commit()
+            agent_a_id = agent_a.id
+            # resolve_member의 API키 분기는 team_members(뷰=members⋈project_access)에서 찾으므로
+            # grant가 있어야 "Team member not found" 400이 아니라 human-gate 403까지 도달한다.
+            s.add(ProjectAccess(
+                id=uuid.uuid4(), project_id=seeded["project_a_id"], member_id=agent_a_id,
+                permission="granted", role="member",
+            ))
+            await s.commit()
+
+        await _setup_app(
+            app, Session, agent_a_id, seeded["org_a_id"], seeded["project_a_id"], is_agent=True,
+        )
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/meetings/{seeded['meeting_id']}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_g_cross_project_access_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_g_cross_project_access_realdb.py
@@ -1,10 +1,11 @@
-"""E-SECURITY SEC-S8(story 83ea3d6a) G: story/task/meeting/visual-artifacts 개별-ID 접근 +
-visual-artifacts list의 project-scope 미검증 봉쇄 실증.
+"""E-SECURITY SEC-S8(story 83ea3d6a) G: story/task/meeting 개별-ID 접근 project-scope 봉쇄 실증.
 
 근본: 개별-ID GET/PATCH 계열이 org-scope만 있고 project 접근권(has_project_access) 미검증이라
 같은 org 내 다른 project의(자신은 접근권 없는) member가 story/task/meeting id만 알면 조회/수정
-가능했다. visual-artifacts list는 project_id 필터 자체가 없어 파라미터 없는 호출이 org 전체를
-반환했다(미르코 라이브 실측 N)."""
+가능했다.
+
+(prod 선택승격 스코프 조정: G는 원래 visual-artifacts list의 project-scope 미검증도 포함했으나
+E-CANVAS가 이번 승격 범위 밖이라 그 부분/테스트는 제외 — develop 원본은 무영향.)"""
 from __future__ import annotations
 
 import os
@@ -47,14 +48,13 @@ async def _session_factory():
 
 async def _seed(session):
     """org(project_a, project_b) + story_a/task_a(project_a) + meeting_a(project_a) +
-    visual_artifact_a(project_a) + human_a(project_a에만 명시 grant, project_b 접근권 없음)."""
+    human_a(project_a에만 명시 grant, project_b 접근권 없음)."""
     from sqlalchemy import text
     from app.models.organization import Organization
     from app.models.pm import Story, Task
     from app.models.project import OrgMember, Project
     from app.models.project_access import ProjectAccess
     from app.models.user import User
-    from app.models.visual_artifact import VisualArtifact
 
     org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
     session.add(org)
@@ -83,17 +83,6 @@ async def _seed(session):
     )
     await session.commit()
 
-    artifact_a = VisualArtifact(
-        id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Artifact A",
-        source="created", latest_version_number=1, created_by=uuid.uuid4(),
-    )
-    artifact_b = VisualArtifact(
-        id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Artifact B",
-        source="created", latest_version_number=1, created_by=uuid.uuid4(),
-    )
-    session.add_all([artifact_a, artifact_b])
-    await session.commit()
-
     human_user_id = uuid.uuid4()
     human_user = User(id=human_user_id, email=f"human-{human_user_id.hex[:8]}@test.com", hashed_password="x")
     session.add(human_user)
@@ -110,7 +99,6 @@ async def _seed(session):
     return {
         "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
         "story_a_id": story_a.id, "task_a_id": task_a.id, "meeting_a_id": meeting_a_id,
-        "artifact_a_id": artifact_a.id, "artifact_b_id": artifact_b.id,
         "human_user_id": human_user_id,
     }
 
@@ -229,33 +217,6 @@ async def test_no_grant_human_cannot_get_other_project_meeting():
                 f"/api/v2/meetings/{uuid.uuid4()}?project_id={seeded['project_b_id']}"
             )
             assert resp.status_code == 403, resp.text
-        finally:
-            await client.aclose()
-    finally:
-        app.dependency_overrides.clear()
-        await engine.dispose()
-
-
-@pytest.mark.anyio
-async def test_visual_artifacts_list_scoped_to_own_project_only():
-    """N 재현: visual-artifacts list가 project_id 필터 없이 org 전체를 반환하던 갭 —
-    이제 caller의 JWT project_id로 스코프돼 다른 project(project_b)의 artifact가 안 섞인다."""
-    from app.main import app
-
-    engine, Session = await _session_factory()
-    try:
-        async with Session() as s:
-            seeded = await _seed(s)
-
-        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
-        client = _client_for(app)
-        try:
-            resp = await client.get("/api/v2/visual-artifacts")
-            assert resp.status_code == 200, resp.text
-            items = resp.json()["data"]
-            ids = {item["id"] for item in items}
-            assert str(seeded["artifact_a_id"]) in ids
-            assert str(seeded["artifact_b_id"]) not in ids, "다른 project(B) artifact가 섞이면 안 됨"
         finally:
             await client.aclose()
     finally:

--- a/backend/tests/test_e_security_sec_s8_g_cross_project_access_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_g_cross_project_access_realdb.py
@@ -1,0 +1,263 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) G: story/task/meeting/visual-artifacts 개별-ID 접근 +
+visual-artifacts list의 project-scope 미검증 봉쇄 실증.
+
+근본: 개별-ID GET/PATCH 계열이 org-scope만 있고 project 접근권(has_project_access) 미검증이라
+같은 org 내 다른 project의(자신은 접근권 없는) member가 story/task/meeting id만 알면 조회/수정
+가능했다. visual-artifacts list는 project_id 필터 자체가 없어 파라미터 없는 호출이 org 전체를
+반환했다(미르코 라이브 실측 N)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a, project_b) + story_a/task_a(project_a) + meeting_a(project_a) +
+    visual_artifact_a(project_a) + human_a(project_a에만 명시 grant, project_b 접근권 없음)."""
+    from sqlalchemy import text
+    from app.models.organization import Organization
+    from app.models.pm import Story, Task
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+    from app.models.visual_artifact import VisualArtifact
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    story_a = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Story A")
+    session.add(story_a)
+    await session.commit()
+
+    task_a = Task(id=uuid.uuid4(), org_id=org.id, story_id=story_a.id, title="Task A")
+    session.add(task_a)
+    await session.commit()
+
+    meeting_a_id = uuid.uuid4()
+    await session.execute(
+        text(
+            "INSERT INTO meetings (id, project_id, title, meeting_type, participants, decisions, action_items) "
+            "VALUES (:id, :pid, :title, 'general'::meeting_type, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb)"
+        ),
+        {"id": meeting_a_id, "pid": project_a.id, "title": "Meeting A"},
+    )
+    await session.commit()
+
+    artifact_a = VisualArtifact(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Artifact A",
+        source="created", latest_version_number=1, created_by=uuid.uuid4(),
+    )
+    artifact_b = VisualArtifact(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Artifact B",
+        source="created", latest_version_number=1, created_by=uuid.uuid4(),
+    )
+    session.add_all([artifact_a, artifact_b])
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"human-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    # project_a에만 명시 grant — project_b 접근권 없음(org owner/admin도 아님).
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "story_a_id": story_a.id, "task_a_id": task_a.id, "meeting_a_id": meeting_a_id,
+        "artifact_a_id": artifact_a.id, "artifact_b_id": artifact_b.id,
+        "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id, project_id=None):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    meta = {"org_id": str(org_id)}
+    if project_id is not None:
+        meta["project_id"] = str(project_id)
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": meta})
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_project_a_human_can_get_own_project_task():
+    """회귀 0: project_a grant 보유 휴먼은 project_a의 task 정상 조회."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/tasks/{seeded['task_a_id']}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_project_a_human_can_get_own_project_story():
+    """회귀 0: project_a grant 보유 휴먼은 project_a의 story 정상 조회."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{seeded['story_a_id']}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_project_a_human_can_get_own_project_meeting():
+    """회귀 0: project_a grant 보유 휴먼은 project_a의 meeting 정상 조회(project_id는 JWT context)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/meetings/{seeded['meeting_a_id']}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_grant_human_cannot_get_other_project_meeting():
+    """G 재현: project_a에만 grant된 휴먼이 project_b(query param override)로 meeting 접근 시도
+    → 403(기존엔 _get_repo가 project_id를 검증 없이 그대로 받아들여 열람 가능)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        # JWT context는 project_a지만 query param으로 project_b를 명시 override 시도.
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/meetings/{uuid.uuid4()}?project_id={seeded['project_b_id']}"
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_visual_artifacts_list_scoped_to_own_project_only():
+    """N 재현: visual-artifacts list가 project_id 필터 없이 org 전체를 반환하던 갭 —
+    이제 caller의 JWT project_id로 스코프돼 다른 project(project_b)의 artifact가 안 섞인다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/visual-artifacts")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()["data"]
+            ids = {item["id"] for item in items}
+            assert str(seeded["artifact_a_id"]) in ids
+            assert str(seeded["artifact_b_id"]) not in ids, "다른 project(B) artifact가 섞이면 안 됨"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_h_delete_sprint_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_h_delete_sprint_realdb.py
@@ -71,6 +71,13 @@ async def _seed(session):
     human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
     session.add(human_om)
     await session.commit()
+    # E-SECURITY SEC-S8(story 83ea3d6a) CC: delete_sprint가 project-scope를 강제하게 되며
+    # 이 휴먼(role=member)도 project 접근권 grant가 있어야 삭제가 통과한다.
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=human_om.id,
+        permission="granted", role="member",
+    ))
+    await session.commit()
 
     agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="agent-x", is_active=True)
     session.add(agent)

--- a/backend/tests/test_e_security_sec_s8_h_delete_sprint_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_h_delete_sprint_realdb.py
@@ -1,0 +1,200 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) H: delete_sprint 휴먼전용화 + 삭제감사 실증.
+
+delete_story/delete_task와 동형 갭 — 인가 검사 자체가 아예 없어(auth dependency도 없었음)
+에이전트 API키로도 hard-delete가 가능했고 DeletionAuditLog도 안 남았다. org-scope 자체는
+BaseRepository.get()이 org_id로 이미 필터해 안전(cross-org 삭제는 원래도 404)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project·sprint) + 휴먼(org member) + 에이전트(project grant)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.pm import Sprint
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    sprint = Sprint(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Sprint 1")
+    session.add(sprint)
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"human-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="agent-x", is_active=True)
+    session.add(agent)
+    await session.commit()
+    agent_id = agent.id
+    # resolve_member의 API키 분기는 team_members(뷰=members⋈project_access)에서 찾으므로
+    # grant가 있어야 "Team member not found" 400이 아니라 human-gate 403까지 도달한다.
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=agent_id,
+        permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "sprint_id": sprint.id,
+        "human_user_id": human_user_id, "agent_id": agent_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_human(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+async def _setup_app_agent(app, Session, agent_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(agent_id), email="agent@test",
+            claims={"app_metadata": {"org_id": str(org_id), "api_key_id": str(uuid.uuid4())}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_agent_cannot_delete_sprint():
+    """H 재현: 에이전트 API키로 hard-delete 시도 → 403(기존엔 인가 검사 자체가 없어 200)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/sprints/{seeded['sprint_id']}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_human_delete_sprint_succeeds_and_audit_logged():
+    """회귀 0: 정당한 org 소속 휴먼은 여전히 삭제 가능 + DeletionAuditLog 기록됨."""
+    from sqlalchemy import select
+
+    from app.main import app
+    from app.models.deletion_audit import DeletionAuditLog
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_human(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/sprints/{seeded['sprint_id']}")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["ok"] is True
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            logs = (await s.execute(
+                select(DeletionAuditLog).where(
+                    DeletionAuditLog.entity_id == seeded["sprint_id"],
+                    DeletionAuditLog.entity_type == "sprint",
+                )
+            )).scalars().all()
+            assert len(logs) == 1, "삭제 감사 로그가 정확히 1건 기록돼야 함"
+            assert logs[0].entity_title == "Sprint 1"
+            assert logs[0].org_id == seeded["org_id"]
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_jk_token_theft_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_jk_token_theft_realdb.py
@@ -1,0 +1,253 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) J+K: cross-org 토큰 탈취 체인 봉쇄 실증.
+
+J(근본): create_project_access 휴먼분기(org_member_id)가 target-org 미검증 — Org A owner가
+Org B org_member_id로 Org A project에 cross-org grant 행을 만들 수 있었음.
+K(방어심화): switch-project의 has_project_access가 org_id 없이 호출돼, J로 생긴 (또는 다른
+경로의) cross-org grant 행이 있으면 target org의 정식 access+refresh 토큰이 발급됐음.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_two_orgs(session):
+    """Org A(owner) + Org A project + Org B(target org_member) — J 재현용."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.user import User
+
+    org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
+    org_b = Organization(id=uuid.uuid4(), name="Org B", slug=f"org-b-{uuid.uuid4().hex[:8]}")
+    session.add_all([org_a, org_b])
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org_a.id, name="Org A Project")
+    session.add(project_a)
+    await session.commit()
+
+    owner_user_id = uuid.uuid4()
+    owner_user = User(id=owner_user_id, email=f"owner-{owner_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(owner_user)
+    await session.commit()
+    owner_om = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=owner_user_id, role="owner")
+    session.add(owner_om)
+    await session.commit()
+
+    target_user_id = uuid.uuid4()
+    target_user = User(id=target_user_id, email=f"target-{target_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(target_user)
+    await session.commit()
+    target_om_b = OrgMember(id=uuid.uuid4(), org_id=org_b.id, user_id=target_user_id, role="member")
+    session.add(target_om_b)
+    await session.commit()
+
+    same_org_user_id = uuid.uuid4()
+    same_org_user = User(id=same_org_user_id, email=f"member-{same_org_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(same_org_user)
+    await session.commit()
+    same_org_om_a = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=same_org_user_id, role="member")
+    session.add(same_org_om_a)
+    await session.commit()
+
+    return {
+        "org_a_id": org_a.id, "org_b_id": org_b.id, "project_a_id": project_a.id,
+        "owner_user_id": owner_user_id, "target_om_b_id": target_om_b.id,
+        "same_org_om_a_id": same_org_om_a.id,
+        "target_user_id": target_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_j_cross_org_project_access_grant_blocked():
+    """J 재현: Org A owner가 Org B org_member_id로 Org A project에 grant 시도 → 400."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_orgs(s)
+
+        await _setup_app(app, Session, seeded["owner_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/projects/{seeded['project_a_id']}/access",
+                json={"org_member_id": str(seeded["target_om_b_id"]), "permission": "granted"},
+            )
+            assert resp.status_code == 400, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.project_access import ProjectAccess
+            rows = (await s.execute(
+                select(ProjectAccess).where(
+                    ProjectAccess.project_id == seeded["project_a_id"],
+                    ProjectAccess.org_member_id == seeded["target_om_b_id"],
+                )
+            )).scalars().all()
+            assert len(rows) == 0, "cross-org grant 행이 생성되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_j_same_org_project_access_grant_still_free():
+    """회귀 0: 같은 org org_member_id는 정상 201."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_orgs(s)
+
+        await _setup_app(app, Session, seeded["owner_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/projects/{seeded['project_a_id']}/access",
+                json={"org_member_id": str(seeded["same_org_om_a_id"]), "permission": "granted"},
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_k_switch_project_blocked_despite_rogue_cross_org_grant():
+    """K 재현: J 봉쇄와 무관하게(예: 레거시로 이미 존재하는 rogue 행을 직접 시뮬레이션) —
+    Org B 유저가 Org A project_id로 switch-project 시도 시, 자신의 세션 org(Org B)로 스코프된
+    has_project_access가 org_id 불일치로 403을 내야 한다(K fix 전이면 무필터로 200+토큰 발급)."""
+    from app.main import app
+    from app.models.project_access import ProjectAccess
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_orgs(s)
+            # rogue cross-org grant 직접 시뮬레이션(J가 막아도 레거시/다른 경로로 이미 존재할 수
+            # 있는 상태를 가정 — K는 이 상태에서도 방어해야 하는 defense-in-depth).
+            s.add(ProjectAccess(
+                id=uuid.uuid4(), project_id=seeded["project_a_id"],
+                org_member_id=seeded["target_om_b_id"], permission="granted",
+            ))
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["target_user_id"], seeded["org_b_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/auth/switch-project",
+                json={"project_id": str(seeded["project_a_id"])},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_k_switch_project_same_org_still_free():
+    """회귀 0: 정상 same-org project로 switch하면 200 + 새 토큰."""
+    from app.main import app
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_orgs(s)
+            grant = ProjectAccess(
+                id=uuid.uuid4(), project_id=seeded["project_a_id"],
+                org_member_id=seeded["same_org_om_a_id"], permission="granted",
+            )
+            s.add(grant)
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["owner_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            # owner는 org owner라 has_project_access org-wide floor로 통과.
+            resp = await client.post(
+                "/api/v2/auth/switch-project",
+                json={"project_id": str(seeded["project_a_id"])},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()["data"]
+            assert "access_token" in body
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_l_create_org_agent_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_l_create_org_agent_realdb.py
@@ -1,0 +1,163 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) L 자매 갭: create_org_agent(POST /api/v2/agents)도
+`if actor.type=="agent"`에 갇혀 휴먼 caller(또는 actor 미해소)면 인가가 통째로 스킵되던
+동일 패턴. create_team_member 수정 중 자체 발견(fix-on-sight) — org owner/admin 게이트로
+휴먼 분기를 봉쇄."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org A(project) + 무권한 휴먼(org A member·admin 아님) + org A admin 휴먼(정당 시나리오)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.user import User
+
+    org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
+    session.add(org_a)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org_a.id, name="Org A Project")
+    session.add(project_a)
+    await session.commit()
+
+    no_priv_user_id = uuid.uuid4()
+    no_priv_user = User(id=no_priv_user_id, email=f"nopriv-{no_priv_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(no_priv_user)
+    await session.commit()
+    no_priv_om = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=no_priv_user_id, role="member")
+    session.add(no_priv_om)
+    await session.commit()
+
+    admin_user_id = uuid.uuid4()
+    admin_user = User(id=admin_user_id, email=f"admin-{admin_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(admin_user)
+    await session.commit()
+    admin_om = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=admin_user_id, role="owner")
+    session.add(admin_om)
+    await session.commit()
+
+    return {
+        "org_a_id": org_a.id, "project_a_id": project_a.id,
+        "no_priv_user_id": no_priv_user_id, "admin_user_id": admin_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_no_privilege_human_cannot_create_org_agent():
+    """L 자매 갭 재현: 무권한 휴먼(org A member, owner/admin 아님)이 org agent 생성 시도
+    → 403(기존엔 human=인가 전면스킵으로 201 + api_key 자동발급)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["no_priv_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/agents",
+                json={
+                    "name": "RogueOrgAgent", "scope_mode": "projects",
+                    "project_ids": [str(seeded["project_a_id"])],
+                },
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_admin_human_can_still_create_org_agent():
+    """회귀 0: 정당한 org admin/owner 휴먼은 여전히 org agent 생성 가능(정당 시나리오 안 깨짐)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["admin_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/agents",
+                json={
+                    "name": "LegitOrgBot", "scope_mode": "projects",
+                    "project_ids": [str(seeded["project_a_id"])],
+                },
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_l_create_team_member_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_l_create_team_member_realdb.py
@@ -1,0 +1,198 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) L: create_team_member 무인가 신원 발급 봉쇄 실증.
+
+권한체크가 `if actor.type=="agent"`에 갇혀 있어 휴먼 caller(또는 actor 미해소)면 인가가
+통째로 스킵됐음 — 아무 권한 없는 멤버가 임의 project_id(타 org 포함)로 role=admin 에이전트를
+찍어낼 수 있었음(sk_live_ API키 자동발급까지 이어짐)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org A(project) + org B(project, 대상) + 무권한 휴먼(org A 소속·프로젝트 grant 0)
+    + org A admin 휴먼(정당 시나리오 회귀용)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.user import User
+
+    org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
+    org_b = Organization(id=uuid.uuid4(), name="Org B", slug=f"org-b-{uuid.uuid4().hex[:8]}")
+    session.add_all([org_a, org_b])
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org_a.id, name="Org A Project")
+    project_b = Project(id=uuid.uuid4(), org_id=org_b.id, name="Org B Project")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    # 무권한 휴먼 — org A 소속(member role)이나 project_a에 어떤 grant도 없음.
+    no_priv_user_id = uuid.uuid4()
+    no_priv_user = User(id=no_priv_user_id, email=f"nopriv-{no_priv_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(no_priv_user)
+    await session.commit()
+    no_priv_om = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=no_priv_user_id, role="member")
+    session.add(no_priv_om)
+    await session.commit()
+
+    # 정당 admin 휴먼 — org A owner.
+    admin_user_id = uuid.uuid4()
+    admin_user = User(id=admin_user_id, email=f"admin-{admin_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(admin_user)
+    await session.commit()
+    admin_om = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=admin_user_id, role="owner")
+    session.add(admin_om)
+    await session.commit()
+
+    return {
+        "org_a_id": org_a.id, "org_b_id": org_b.id,
+        "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "no_priv_user_id": no_priv_user_id, "admin_user_id": admin_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_no_privilege_human_cannot_create_admin_agent():
+    """L 재현: 무권한 휴먼(org A member·project grant 0)이 project_a에 role=admin agent 생성 시도
+    → 403(기존엔 human=인가 전면스킵으로 201)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["no_priv_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/team-members",
+                json={
+                    "project_id": str(seeded["project_a_id"]), "org_id": str(seeded["org_a_id"]),
+                    "type": "agent", "name": "RogueAdmin", "role": "admin",
+                },
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_privilege_human_cannot_create_agent_in_other_org_project():
+    """L 재현(target-org 축): 무권한 휴먼이 Org B project_id로 agent 생성 시도 → 차단(404, org 불일치)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["no_priv_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/team-members",
+                json={
+                    "project_id": str(seeded["project_b_id"]), "org_id": str(seeded["org_a_id"]),
+                    "type": "agent", "name": "CrossOrgAgent",
+                },
+            )
+            assert resp.status_code in (403, 404), resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_admin_human_can_still_create_agent():
+    """회귀 0: 정당한 org admin/owner 휴먼은 여전히 에이전트 생성 가능(정당 시나리오 안 깨짐)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["admin_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/team-members",
+                json={
+                    "project_id": str(seeded["project_a_id"]), "org_id": str(seeded["org_a_id"]),
+                    "type": "agent", "name": "LegitBot",
+                },
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_m_workflow_line_config_org_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_m_workflow_line_config_org_scope_realdb.py
@@ -1,0 +1,198 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) M: workflow-line-config `_require_draft_author`의
+OR-fallback target-org 미검증 봉쇄 실증.
+
+`role in ("owner","admin") or is_org_owner_or_admin(caller org)` fallback이 project_id의
+실제 소속 org를 검증하지 않아 — caller org(A)의 owner/admin이 **타 org(B) 소속 project_id**를
+넘기면 get_project_role이 None을 반환해도 OR-fallback(자기 org A의 owner/admin 자격)으로
+통과했다. 즉 Org A owner가 Org B 프로젝트에 대한 workflow-line draft를 생성할 수 있었다."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org A(owner human) + org B(project, 대상) + org A project(정당 project-admin 휴먼용)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
+    org_b = Organization(id=uuid.uuid4(), name="Org B", slug=f"org-b-{uuid.uuid4().hex[:8]}")
+    session.add_all([org_a, org_b])
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org_a.id, name="Org A Project")
+    project_b = Project(id=uuid.uuid4(), org_id=org_b.id, name="Org B Project")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    # Org A owner — 정당하게 project_a에 대해선 draft author 자격(org owner floor), project_b(타org)는 아님.
+    owner_user_id = uuid.uuid4()
+    owner_user = User(id=owner_user_id, email=f"owner-{owner_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(owner_user)
+    await session.commit()
+    owner_om = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=owner_user_id, role="owner")
+    session.add(owner_om)
+    await session.commit()
+
+    # Org A 소속·project_a에 명시 project admin grant(org owner/admin 아닌 순수 project 권한 경로).
+    proj_admin_user_id = uuid.uuid4()
+    proj_admin_user = User(
+        id=proj_admin_user_id, email=f"padmin-{proj_admin_user_id.hex[:8]}@test.com", hashed_password="x",
+    )
+    session.add(proj_admin_user)
+    await session.commit()
+    proj_admin_om = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=proj_admin_user_id, role="member")
+    session.add(proj_admin_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=proj_admin_om.id,
+        permission="granted", role="admin",
+    ))
+    await session.commit()
+
+    return {
+        "org_a_id": org_a.id, "org_b_id": org_b.id,
+        "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "owner_user_id": owner_user_id, "proj_admin_user_id": proj_admin_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_org_owner_cannot_create_draft_for_other_org_project():
+    """M 재현: Org A owner가 Org B project_id로 draft 생성 시도 → 404(기존엔 OR-fallback으로 201)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["owner_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/workflow-line-config/versions",
+                json={"entity_type": "story", "config": {}, "project_id": str(seeded["project_b_id"])},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_owner_can_still_create_draft_for_own_org_project():
+    """회귀 0: Org A owner는 여전히 자기 org의 project(project_a)에 draft 생성 가능(org owner floor 유지)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["owner_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/workflow-line-config/versions",
+                json={"entity_type": "story", "config": {}, "project_id": str(seeded["project_a_id"])},
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_project_admin_without_org_role_can_still_create_draft():
+    """회귀 0: org owner/admin이 아니어도 project_access(role=admin) grant만으로 draft 생성 가능
+    (project 권한 경로 무변경 확認)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["proj_admin_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/workflow-line-config/versions",
+                json={"entity_type": "story", "config": {}, "project_id": str(seeded["project_a_id"])},
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_o_create_org_agent_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_o_create_org_agent_scope_realdb.py
@@ -1,0 +1,187 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) O: create_org_agent 에이전트-분기 grant-scope 미검증 봉쇄
+실증.
+
+`has_project_role`이 caller agent의 anchor project(actor.project_id) 하나만 검사해, P1에만
+admin인 에이전트가 scope_mode='projects'로 P2(본인 무권한 project)나 scope_mode='org'로 org
+전체에 새 에이전트+API키를 찍어낼 수 있었다(까심 실HTTP 2단계 재현, PR#1557부터 존재하던 갭)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_p1, project_p2) + agent(project_p1에만 role=admin grant)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_p1 = Project(id=uuid.uuid4(), org_id=org.id, name="Project P1")
+    project_p2 = Project(id=uuid.uuid4(), org_id=org.id, name="Project P2")
+    session.add_all([project_p1, project_p2])
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="agent-p1-admin", is_active=True)
+    session.add(agent)
+    await session.commit()
+    agent_id = agent.id
+    # P1에만 admin grant — P2는 무권한.
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_p1.id, member_id=agent_id, permission="granted", role="admin",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_p1_id": project_p1.id, "project_p2_id": project_p2.id,
+        "agent_id": agent_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_agent(app, Session, agent_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(agent_id), email="agent@test",
+            claims={"app_metadata": {"org_id": str(org_id), "api_key_id": str(uuid.uuid4())}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_p1_admin_agent_can_create_agent_scoped_to_p1():
+    """회귀 0: P1에서 admin인 에이전트는 P1로 scope_mode='projects' 새 에이전트 생성 가능."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/agents",
+                json={
+                    "name": "LegitChild", "scope_mode": "projects",
+                    "project_ids": [str(seeded["project_p1_id"])],
+                },
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_p1_admin_agent_cannot_create_agent_scoped_to_p2():
+    """O 재현: P1에서만 admin인 에이전트가 P2(무권한)로 scope_mode='projects' 시도 → 403
+    (기존엔 actor.project_id=P1만 검사해 통과·P2에 admin 에이전트+API키 찍힘)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/agents",
+                json={
+                    "name": "RogueChildP2", "scope_mode": "projects",
+                    "project_ids": [str(seeded["project_p2_id"])],
+                },
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_p1_admin_agent_cannot_create_org_wide_agent():
+    """O 재현(scope_mode='org' 축): P1에서만 admin인 에이전트가 scope_mode='org'(전 프로젝트
+    grant, P2 포함) 시도 → 403(P2에 admin 아니므로 전체 요청 차단)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/agents",
+                json={"name": "RogueOrgWide", "scope_mode": "org"},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_p_role_rank_cross_project_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_p_role_rank_cross_project_realdb.py
@@ -1,0 +1,279 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) P: 에이전트 role-rank 격상(mixed-role cross-project) 봉쇄
+실증 — create_team_member(AC3) + create_org_agent(자매 갭, fix-on-sight) 둘 다.
+
+`_resolve_actor()`가 team_members 뷰(멀티프로젝트 grant 시 member당 N행)에서 `.first()`로
+임의 1행을 뽑아, actor.role이 target project와 무관한 다른 project의 role일 수 있었다.
+mixed-role 에이전트(예: P1=owner, P2=admin)가 role 낮은 target(P2)에서도 다른 project(P1)의
+높은 role을 빌려와 상위 role 멤버/에이전트를 찍어낼 수 있었다(비결정 row-pick)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_p1, project_p2) + mixed-role agent(P1=owner grant, P2=admin grant)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_p1 = Project(id=uuid.uuid4(), org_id=org.id, name="Project P1")
+    project_p2 = Project(id=uuid.uuid4(), org_id=org.id, name="Project P2")
+    session.add_all([project_p1, project_p2])
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="mixed-role-agent", is_active=True)
+    session.add(agent)
+    await session.commit()
+    agent_id = agent.id
+    session.add_all([
+        ProjectAccess(id=uuid.uuid4(), project_id=project_p1.id, member_id=agent_id, permission="granted", role="owner"),
+        ProjectAccess(id=uuid.uuid4(), project_id=project_p2.id, member_id=agent_id, permission="granted", role="admin"),
+    ])
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_p1_id": project_p1.id, "project_p2_id": project_p2.id,
+        "agent_id": agent_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_agent(app, Session, agent_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(agent_id), email="agent@test",
+            claims={"app_metadata": {"org_id": str(org_id), "api_key_id": str(uuid.uuid4())}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ── create_team_member(P 본체): mixed-role 에이전트가 target project 전용 role로 평가되는지 ──
+
+@pytest.mark.anyio
+async def test_mixed_role_agent_cannot_borrow_p1_owner_role_for_p2_target():
+    """P 재현: P1=owner·P2=admin인 에이전트가 P2(target)로 role=owner 멤버 생성 시도 → 403
+    (기존엔 .first()가 P1 row를 뽑으면 owner>=owner로 통과할 수 있었음·비결정 격상)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/team-members",
+                json={
+                    "project_id": str(seeded["project_p2_id"]), "org_id": str(seeded["org_id"]),
+                    "type": "agent", "name": "RogueOwnerViaP2", "role": "owner",
+                },
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mixed_role_agent_can_create_admin_member_at_own_admin_project():
+    """회귀 0: P2에서 admin인 에이전트는 P2에 role=admin 멤버는 여전히 생성 가능(과차단 아님)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/team-members",
+                json={
+                    "project_id": str(seeded["project_p2_id"]), "org_id": str(seeded["org_id"]),
+                    "type": "agent", "name": "LegitAdminAtP2", "role": "admin",
+                },
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mixed_role_agent_can_create_owner_member_at_own_owner_project():
+    """회귀 0: P1에서 owner인 에이전트는 P1 자체에는 role=owner 멤버도 정상 생성(제 project 내 정당 권한)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/team-members",
+                json={
+                    "project_id": str(seeded["project_p1_id"]), "org_id": str(seeded["org_id"]),
+                    "type": "agent", "name": "LegitOwnerAtP1", "role": "owner",
+                },
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── create_org_agent(자매 갭, fix-on-sight): 멀티 project_ids 최솟값 rank로 평가되는지 ──
+
+@pytest.mark.anyio
+async def test_org_agent_multi_project_owner_blocked_by_weakest_target():
+    """자매갭 재현: scope_mode='projects'[P1,P2]로 role=owner 요청 → 403(P2에선 admin뿐이라
+    최솟값 rank=admin<owner)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/agents",
+                json={
+                    "name": "RogueOwnerMulti", "role": "owner", "scope_mode": "projects",
+                    "project_ids": [str(seeded["project_p1_id"]), str(seeded["project_p2_id"])],
+                },
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_agent_multi_project_admin_allowed():
+    """회귀 0: scope_mode='projects'[P1,P2]로 role=admin 요청 → 201(두 project 다 admin 이상)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/agents",
+                json={
+                    "name": "LegitAdminMulti", "role": "admin", "scope_mode": "projects",
+                    "project_ids": [str(seeded["project_p1_id"]), str(seeded["project_p2_id"])],
+                },
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_agent_single_p1_owner_allowed():
+    """회귀 0: scope_mode='projects'[P1]만으로 role=owner 요청 → 201(P1 단독은 owner 정당)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/agents",
+                json={
+                    "name": "LegitOwnerP1Only", "role": "owner", "scope_mode": "projects",
+                    "project_ids": [str(seeded["project_p1_id"])],
+                },
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_s_create_task_project_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_s_create_task_project_scope_realdb.py
@@ -1,0 +1,172 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) S: create_task project-scope 미검증 봉쇄 실증.
+
+create_task가 GET/PATCH/DELETE와 달리 `_assert_task_project_access`를 호출하지 않아
+org-scope만(enforce_body_context는 body_project_id 미전달이라 project 검증 스킵) — 같은 org
+다른 project의(자신은 접근권 없는) member가 임의 story_id로 task를 생성할 수 있었다
+(까심 실HTTP 확定: Project A caller가 Project B story_id로 201)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a, project_b) + story_a(project_a)/story_b(project_b) +
+    human_a(project_a에만 명시 grant, project_b 접근권 없음)."""
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    story_a = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Story A")
+    story_b = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Story B")
+    session.add_all([story_a, story_b])
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"human-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    # project_a에만 명시 grant — project_b 접근권 없음(org owner/admin도 아님).
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "story_a_id": story_a.id, "story_b_id": story_b.id, "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_no_grant_human_cannot_create_task_on_other_project_story():
+    """S 재현: project_a에만 grant된 휴먼이 project_b의 story_id로 task 생성 시도 → 403
+    (기존엔 org-scope만 봐서 201로 통과했음)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/tasks",
+                json={
+                    "story_id": str(seeded["story_b_id"]), "org_id": str(seeded["org_id"]),
+                    "title": "Injected Task",
+                },
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_project_a_human_can_still_create_task_on_own_project_story():
+    """회귀 0: project_a grant 보유 휴먼은 project_a의 story_id로 task 생성 여전히 정상."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/tasks",
+                json={
+                    "story_id": str(seeded["story_a_id"]), "org_id": str(seeded["org_id"]),
+                    "title": "Legit Task",
+                },
+            )
+            assert resp.status_code == 201, resp.text
+            assert resp.json()["story_id"] == str(seeded["story_a_id"])
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_t_story_link_project_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_t_story_link_project_scope_realdb.py
@@ -1,0 +1,255 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) T: create_story epic_id/sprint_id/meeting_id 링크의
+project-scope 미검증 봉쇄 실증.
+
+create_story가 epic_id/sprint_id/meeting_id를 소유권 검증 없이 그대로 repo.create에 넘겨서,
+같은 org 다른 project의 epic/sprint/meeting에 story를 링크할 수 있었다(까심 전수스윕, 실HTTP
+확定: project_a caller가 project_b epic_id로 201)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a, project_b) + epic_a/sprint_a/meeting_a(project_a) +
+    epic_b/sprint_b/meeting_b(project_b) + human_a(project_a에만 명시 grant)."""
+    from sqlalchemy import text
+    from app.models.organization import Organization
+    from app.models.pm import Epic, Sprint
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    epic_a = Epic(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Epic A")
+    epic_b = Epic(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Epic B")
+    sprint_a = Sprint(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Sprint A")
+    sprint_b = Sprint(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Sprint B")
+    session.add_all([epic_a, epic_b, sprint_a, sprint_b])
+    await session.commit()
+
+    meeting_a_id = uuid.uuid4()
+    meeting_b_id = uuid.uuid4()
+    for mid, pid, title in ((meeting_a_id, project_a.id, "Meeting A"), (meeting_b_id, project_b.id, "Meeting B")):
+        await session.execute(
+            text(
+                "INSERT INTO meetings (id, project_id, title, meeting_type, participants, decisions, action_items) "
+                "VALUES (:id, :pid, :title, 'general'::meeting_type, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb)"
+            ),
+            {"id": mid, "pid": pid, "title": title},
+        )
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"human-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "epic_a_id": epic_a.id, "epic_b_id": epic_b.id,
+        "sprint_a_id": sprint_a.id, "sprint_b_id": sprint_b.id,
+        "meeting_a_id": meeting_a_id, "meeting_b_id": meeting_b_id,
+        "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id, project_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+async def _post_story(client, seeded, **link_fields):
+    body = {
+        "project_id": str(seeded["project_a_id"]), "org_id": str(seeded["org_id"]),
+        "title": "Story",
+    }
+    body.update(link_fields)
+    return await client.post("/api/v2/stories", json=body)
+
+
+@pytest.mark.anyio
+async def test_cross_project_epic_link_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await _post_story(client, seeded, epic_id=str(seeded["epic_b_id"]))
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cross_project_sprint_link_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await _post_story(client, seeded, sprint_id=str(seeded["sprint_b_id"]))
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cross_project_meeting_link_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await _post_story(client, seeded, meeting_id=str(seeded["meeting_b_id"]))
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_same_project_links_still_work():
+    """회귀 0: same-project epic/sprint/meeting 링크는 여전히 정상(과차단 아님)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await _post_story(
+                client, seeded,
+                epic_id=str(seeded["epic_a_id"]), sprint_id=str(seeded["sprint_a_id"]),
+                meeting_id=str(seeded["meeting_a_id"]),
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["epic_id"] == str(seeded["epic_a_id"])
+            assert body["sprint_id"] == str(seeded["sprint_a_id"])
+            assert body["meeting_id"] == str(seeded["meeting_a_id"])
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_links_still_works():
+    """회귀 0: 링크 필드 전부 미지정이면 검증 스킵되고 정상 생성."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await _post_story(client, seeded)
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_v_conversation_agent_admin_bypass_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_v_conversation_agent_admin_bypass_realdb.py
@@ -1,0 +1,255 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) V: 대화(conversation) 에이전트 admin-bypass의 project-scope
+미검증 봉쇄 실증.
+
+`_effective_org_role`이 에이전트 호출에 대해 sender.role(=`_resolve_member`의 비결정 `.first()`가
+뽑은 임의 project row role)을 org-wide 권한인 것처럼 신뢰했다 — mixed-role 에이전트(예:
+project_x=admin·project_y=grant 0)가 project_x의 admin 지위를 빌려와 project_y의 agent-only
+대화를 admin-bypass로 열람할 수 있었다(참가자 아님에도 200, 까심 전수스윕 실HTTP 확定)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_x, project_y) + mixed-role agent(X=admin grant, Y=grant 0) +
+    other_agent(Y=member grant, Y 대화의 유일 참가자)."""
+    from app.models.conversation import Conversation, ConversationParticipant
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_x = Project(id=uuid.uuid4(), org_id=org.id, name="Project X")
+    project_y = Project(id=uuid.uuid4(), org_id=org.id, name="Project Y")
+    session.add_all([project_x, project_y])
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="mixed-role-agent", is_active=True)
+    session.add(agent)
+    await session.commit()
+    agent_id = agent.id
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_x.id, member_id=agent_id, permission="granted", role="admin",
+    ))
+    await session.commit()
+
+    other_agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="other-agent-y", is_active=True)
+    session.add(other_agent)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_y.id, member_id=other_agent.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    # project_y agent-only 대화 — 유일 참가자는 other_agent(mixed-role 에이전트는 참가자 아님).
+    conv_y = Conversation(
+        id=uuid.uuid4(), project_id=project_y.id, org_id=org.id, type="dm",
+        title="Y-only agent convo", created_by=other_agent.id,
+    )
+    session.add(conv_y)
+    await session.flush()
+    session.add(ConversationParticipant(conversation_id=conv_y.id, member_id=other_agent.id))
+    await session.commit()
+
+    # project_x agent-only 대화 — mixed-role 에이전트가 X에서는 진짜 admin(회귀 0 확인용).
+    conv_x = Conversation(
+        id=uuid.uuid4(), project_id=project_x.id, org_id=org.id, type="dm",
+        title="X-only agent convo", created_by=other_agent.id,
+    )
+    session.add(conv_x)
+    await session.flush()
+    session.add(ConversationParticipant(conversation_id=conv_x.id, member_id=other_agent.id))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_x_id": project_x.id, "project_y_id": project_y.id,
+        "agent_id": agent_id, "conv_x_id": conv_x.id, "conv_y_id": conv_y.id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_agent(app, Session, agent_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(agent_id), email="agent@test",
+            claims={"app_metadata": {"org_id": str(org_id), "api_key_id": str(uuid.uuid4())}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_mixed_role_agent_cannot_get_conversation_without_project_grant():
+    """V 재현: project_x=admin·project_y=grant 0인 에이전트가 project_y 대화 GET → 403
+    (기존엔 admin-bypass가 임의 row role로 통과해 200이었음)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/conversations/{seeded['conv_y_id']}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mixed_role_agent_cannot_list_messages_without_project_grant():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/conversations/{seeded['conv_y_id']}/messages")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_admin_agent_can_still_bypass_in_own_admin_project():
+    """회귀 0: project_x에서 진짜 admin인 에이전트는 project_x의 agent-only 대화를 여전히
+    admin-bypass로 열람 가능(과차단 아님)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/conversations/{seeded['conv_x_id']}")
+            assert resp.status_code == 200, resp.text
+
+            resp2 = await client.get(f"/api/v2/conversations/{seeded['conv_x_id']}/messages")
+            assert resp2.status_code == 200, resp2.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_include_agent_conversations_blocked_for_non_admin_project():
+    """V 재현(list_conversations 축): mixed-role 에이전트가 project_y로 include_agent_conversations
+    요청 → 403(project_y에선 admin 아님)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/conversations",
+                params={"project_id": str(seeded["project_y_id"]), "include_agent_conversations": "true"},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_include_agent_conversations_allowed_for_admin_project():
+    """회귀 0: project_x(진짜 admin)로 include_agent_conversations 요청 시 여전히 정상 통과."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_agent(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/conversations",
+                params={"project_id": str(seeded["project_x_id"]), "include_agent_conversations": "true"},
+            )
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_w2_bulk_update_project_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_w2_bulk_update_project_scope_realdb.py
@@ -1,0 +1,207 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) W2: bulk_update_stories same-org cross-project 미검증
+봉쇄 실증 — W(#2039, CRITICAL cross-org)의 후속(project-scope는 별도 PR로 미뤄뒀던 부분).
+
+org_id 필터(W)로 cross-org는 막혔으나, 같은 org 다른 project의(자신은 접근권 없는) story도
+bulk PATCH로 여전히 변조할 수 있었다(project-scope 부재, G/T와 동형)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a, project_b) + story_a(project_a)/story_b(project_b) +
+    human_a(project_a에만 명시 grant, project_b 접근권 없음)."""
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    story_a = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Story A", status="backlog")
+    story_b = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Story B", status="backlog")
+    session.add_all([story_a, story_b])
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"h-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "story_a_id": story_a.id, "story_b_id": story_b.id,
+        "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_same_org_cross_project_bulk_update_does_not_mutate():
+    """W2 재현: project_a에만 grant된 휴먼이 project_b story를 bulk PATCH 시도 → 조용히 스킵(변조 0)."""
+    from sqlalchemy import select
+
+    from app.main import app
+    from app.models.pm import Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                "/api/v2/stories/bulk",
+                json={"items": [{"id": str(seeded["story_b_id"]), "status": "done", "priority": "critical"}]},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json() == [], "무권한 project의 story는 결과에 포함되면 안 됨(존재 비노출)"
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            victim = (await s.execute(select(Story).where(Story.id == seeded["story_b_id"]))).scalar_one()
+            assert victim.status == "backlog", "project-scope 밖 변조가 실제로 반영되면 안 됨"
+            assert victim.priority == "medium"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_own_project_bulk_update_still_works():
+    """회귀 0: project_a grant 보유 휴먼은 project_a의 story는 여전히 정상 bulk 업데이트."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                "/api/v2/stories/bulk",
+                json={"items": [{"id": str(seeded["story_a_id"]), "status": "in-review"}]},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert len(body) == 1
+            assert body[0]["id"] == str(seeded["story_a_id"])
+            assert body[0]["status"] == "in-review"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mixed_batch_only_accessible_item_updates():
+    """혼합 배치: project_a story는 반영·project_b story는 스킵(부분 성공, 전체차단 아님)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                "/api/v2/stories/bulk",
+                json={"items": [
+                    {"id": str(seeded["story_a_id"]), "priority": "high"},
+                    {"id": str(seeded["story_b_id"]), "priority": "critical"},
+                ]},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert len(body) == 1
+            assert body[0]["id"] == str(seeded["story_a_id"])
+            assert body[0]["priority"] == "high"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_w_bulk_update_cross_org_idor_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_w_bulk_update_cross_org_idor_realdb.py
@@ -1,0 +1,178 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) W: bulk_update_stories cross-org IDOR 봉쇄 실증(CRITICAL).
+
+PATCH /api/v2/stories/bulk의 raw 쿼리(select(Story).where(Story.id==item.id))가 org_id 필터
+자체가 없어, 다른 org의 story UUID만 알면 status/sprint_id/assignee_id/priority/position을
+전부 변조할 수 있었다(까심 실HTTP 확定: 다른 org sprint_id 변경 200)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org_a(caller) + org_b(victim) — 각자 project+story 1개씩. 완전 별개 org(org 경계 축)."""
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
+    org_b = Organization(id=uuid.uuid4(), name="Org B", slug=f"org-b-{uuid.uuid4().hex[:8]}")
+    session.add_all([org_a, org_b])
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org_a.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org_b.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    story_a = Story(id=uuid.uuid4(), org_id=org_a.id, project_id=project_a.id, title="Story A", status="backlog")
+    story_b = Story(id=uuid.uuid4(), org_id=org_b.id, project_id=project_b.id, title="Story B", status="backlog")
+    session.add_all([story_a, story_b])
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"h-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_a_id": org_a.id, "org_b_id": org_b.id,
+        "story_a_id": story_a.id, "story_b_id": story_b.id,
+        "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_cross_org_bulk_update_does_not_mutate_victim_story():
+    """W 재현: org_a caller가 org_b story_id로 bulk PATCH 시도 → 조용히 스킵(변조 0)."""
+    from sqlalchemy import select
+
+    from app.main import app
+    from app.models.pm import Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                "/api/v2/stories/bulk",
+                json={"items": [{
+                    "id": str(seeded["story_b_id"]), "status": "done", "priority": "critical",
+                }]},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json() == [], "org 경계 밖 story는 결과에 포함되면 안 됨(존재 비노출)"
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            victim = (await s.execute(select(Story).where(Story.id == seeded["story_b_id"]))).scalar_one()
+            assert victim.status == "backlog", "cross-org 변조가 실제로 반영되면 안 됨(CRITICAL 회귀)"
+            assert victim.priority == "medium"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_same_org_bulk_update_still_works():
+    """회귀 0: 같은 org 자기 story는 여전히 정상 bulk 업데이트."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                "/api/v2/stories/bulk",
+                json={"items": [{"id": str(seeded["story_a_id"]), "status": "in-progress"}]},
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert len(body) == 1
+            assert body[0]["id"] == str(seeded["story_a_id"])
+            assert body[0]["status"] == "in-progress"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_x_update_story_link_project_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_x_update_story_link_project_scope_realdb.py
@@ -1,0 +1,265 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) X: update_story epic_id/sprint_id/meeting_id 링크의
+project-scope 미검증 봉쇄 실증.
+
+T가 create_story의 링크 검증(_assert_story_link_targets_in_project)만 닫고 update_story(PATCH)
+경로가 남아있었다 — 같은 org 다른 project의 epic/sprint/meeting으로 기존 story를 재링크할 수
+있었다(까심 전수스윕)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a, project_b) + story_a(project_a) + epic_a/sprint_a/meeting_a(project_a) +
+    epic_b/sprint_b/meeting_b(project_b) + human_a(project_a에만 명시 grant)."""
+    from sqlalchemy import text
+    from app.models.organization import Organization
+    from app.models.pm import Epic, Sprint, Story
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    story_a = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Story A")
+    session.add(story_a)
+    await session.commit()
+
+    epic_a = Epic(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Epic A")
+    epic_b = Epic(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Epic B")
+    sprint_a = Sprint(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Sprint A")
+    sprint_b = Sprint(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Sprint B")
+    session.add_all([epic_a, epic_b, sprint_a, sprint_b])
+    await session.commit()
+
+    meeting_a_id = uuid.uuid4()
+    meeting_b_id = uuid.uuid4()
+    for mid, pid, title in ((meeting_a_id, project_a.id, "Meeting A"), (meeting_b_id, project_b.id, "Meeting B")):
+        await session.execute(
+            text(
+                "INSERT INTO meetings (id, project_id, title, meeting_type, participants, decisions, action_items) "
+                "VALUES (:id, :pid, :title, 'general'::meeting_type, '[]'::jsonb, '[]'::jsonb, '[]'::jsonb)"
+            ),
+            {"id": mid, "pid": pid, "title": title},
+        )
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"human-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "story_a_id": story_a.id,
+        "epic_a_id": epic_a.id, "epic_b_id": epic_b.id,
+        "sprint_a_id": sprint_a.id, "sprint_b_id": sprint_b.id,
+        "meeting_a_id": meeting_a_id, "meeting_b_id": meeting_b_id,
+        "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id, project_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_cross_project_epic_relink_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{seeded['story_a_id']}",
+                json={"epic_id": str(seeded["epic_b_id"])},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cross_project_sprint_relink_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{seeded['story_a_id']}",
+                json={"sprint_id": str(seeded["sprint_b_id"])},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cross_project_meeting_relink_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{seeded['story_a_id']}",
+                json={"meeting_id": str(seeded["meeting_b_id"])},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_same_project_relink_still_works():
+    """회귀 0: same-project epic/sprint/meeting 재링크는 여전히 정상(과차단 아님)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{seeded['story_a_id']}",
+                json={
+                    "epic_id": str(seeded["epic_a_id"]), "sprint_id": str(seeded["sprint_a_id"]),
+                    "meeting_id": str(seeded["meeting_a_id"]),
+                },
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["epic_id"] == str(seeded["epic_a_id"])
+            assert body["sprint_id"] == str(seeded["sprint_a_id"])
+            assert body["meeting_id"] == str(seeded["meeting_a_id"])
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unrelated_field_update_without_links_still_works():
+    """회귀 0: 링크 필드 미지정 PATCH(예: title만)는 검증 스킵되고 정상."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"], seeded["project_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/stories/{seeded['story_a_id']}",
+                json={"title": "Renamed"},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["title"] == "Renamed"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_y_project_scope_gaps_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_y_project_scope_gaps_realdb.py
@@ -1,0 +1,378 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) Y: 4개 라우터 project-scope 미검증 봉쇄 실증 — 근본은
+하나(create/list 경로 project-scope 부재)라 한 파일로 묶는다.
+
+- doc parent_id: create_doc이 parent_id를 소유권 검증 없이 그대로 repo.create에 전달(T-class).
+- agent_runs: list_agent_runs가 org-scope만 있고 has_project_access는 안 봄(G-class).
+- file_locks: list_file_locks가 독스트링("현재 프로젝트 내")과 달리 project_id 필터 자체가 없음.
+- github story-link: create_explicit_link/list_links가 story org-scope는 있으나 project-scope
+  없이 같은 org 다른 project story에 PR 링크 생성/열람 가능(T/X-class)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_base(session):
+    """org(project_a, project_b) + human_a(project_a에만 명시 grant)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"h-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ── doc parent_id ────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_doc_cross_project_parent_blocked():
+    from app.main import app
+    from app.models.doc import Doc
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            doc_b = Doc(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_b_id"],
+                title="Doc B", slug=f"doc-b-{uuid.uuid4().hex[:8]}", content="",
+            )
+            s.add(doc_b)
+            await s.commit()
+            doc_b_id = doc_b.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/docs",
+                json={
+                    "project_id": str(seeded["project_a_id"]), "org_id": str(seeded["org_id"]),
+                    "title": "Injected", "slug": f"injected-{uuid.uuid4().hex[:8]}",
+                    "parent_id": str(doc_b_id),
+                },
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_doc_same_project_parent_still_works():
+    from app.main import app
+    from app.models.doc import Doc
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            doc_a = Doc(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"],
+                title="Doc A", slug=f"doc-a-{uuid.uuid4().hex[:8]}", content="",
+            )
+            s.add(doc_a)
+            await s.commit()
+            doc_a_id = doc_a.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/docs",
+                json={
+                    "project_id": str(seeded["project_a_id"]), "org_id": str(seeded["org_id"]),
+                    "title": "Child", "slug": f"child-{uuid.uuid4().hex[:8]}",
+                    "parent_id": str(doc_a_id),
+                },
+            )
+            assert resp.status_code == 201, resp.text
+            assert resp.json()["parent_id"] == str(doc_a_id)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── agent_runs ────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_agent_runs_cross_project_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/agent-runs", params={"project_id": str(seeded["project_b_id"])},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_agent_runs_same_project_still_works():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/agent-runs", params={"project_id": str(seeded["project_a_id"])},
+            )
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── file_locks ────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_file_locks_scoped_to_own_project_only():
+    """B가 아니라 A의 lock만 보여야 함(org 전체 노출 봉쇄)."""
+    from app.main import app
+    from app.models.file_lock import FileLock
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            now_a = FileLock(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"],
+                member_id=uuid.uuid4(), file_path="a.py",
+            )
+            now_b = FileLock(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_b_id"],
+                member_id=uuid.uuid4(), file_path="b.py",
+            )
+            s.add_all([now_a, now_b])
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/file-locks", params={"project_id": str(seeded["project_a_id"])},
+            )
+            assert resp.status_code == 200, resp.text
+            paths = {row["file_path"] for row in resp.json()}
+            assert paths == {"a.py"}, f"project_b lock이 노출되면 안 됨: {paths}"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_file_locks_no_access_project_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                "/api/v2/file-locks", params={"project_id": str(seeded["project_b_id"])},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── github story-link ──────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_github_link_cross_project_story_blocked():
+    from app.main import app
+    from app.models.github_installation import GithubInstallation
+    from app.models.pm import Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            story_b = Story(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_b_id"], title="Story B",
+            )
+            s.add(story_b)
+            s.add(GithubInstallation(
+                id=uuid.uuid4(), org_id=seeded["org_id"], installation_id=uuid.uuid4().int % 2_000_000_000,
+                account_login="acme-corp", account_type="Organization", repository_selection="all",
+            ))
+            await s.commit()
+            story_b_id = story_b.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/integrations/github/links",
+                json={"story_id": str(story_b_id), "repo_full_name": "acme-corp/repo1", "pr_number": 42},
+            )
+            assert resp.status_code == 404, resp.text
+
+            resp2 = await client.get(
+                "/api/v2/integrations/github/links", params={"story_id": str(story_b_id)},
+            )
+            assert resp2.status_code == 404, resp2.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_github_link_same_project_story_still_works():
+    from app.main import app
+    from app.models.github_installation import GithubInstallation
+    from app.models.pm import Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            story_a = Story(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"], title="Story A",
+            )
+            s.add(story_a)
+            s.add(GithubInstallation(
+                id=uuid.uuid4(), org_id=seeded["org_id"], installation_id=uuid.uuid4().int % 2_000_000_000,
+                account_login="acme-corp", account_type="Organization", repository_selection="all",
+            ))
+            await s.commit()
+            story_a_id = story_a.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/integrations/github/links",
+                json={"story_id": str(story_a_id), "repo_full_name": "acme-corp/repo1", "pr_number": 7},
+            )
+            assert resp.status_code == 200, resp.text
+
+            resp2 = await client.get(
+                "/api/v2/integrations/github/links", params={"story_id": str(story_a_id)},
+            )
+            assert resp2.status_code == 200, resp2.text
+            assert len(resp2.json()["links"]) == 1
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_z2_workflow_project_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_z2_workflow_project_scope_realdb.py
@@ -1,0 +1,249 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) Z2: workflow_report/workflow_trigger project-scope
+미검증 봉쇄 실증(까심 전수스윕, 실HTTP 확定).
+
+- report_done: org-scope(#12)는 있으나 has_project_access 부재 — project_a만 grant된 caller가
+  project_b story_id로 report-done 호출 시 story.status가 실제로 변조됐다(backlog→in-progress).
+- trigger_workflow: body.project_id에 has_project_access 검증 자체가 없어 project_b 전용
+  enabled rule이 실제로 매치되고 WorkflowExecutionLog가 생성됐다(남의 project 워크플로 트리거)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_base(session):
+    """org(project_a, project_b) + human_a(project_a에만 명시 grant)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"h-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ── report_done ─────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_report_done_cross_project_blocked_no_mutation():
+    """Z2 재현: project_a만 grant된 caller가 project_b story로 report-done → story 무변조."""
+    from app.main import app
+    from app.models.member import Member
+    from app.models.pm import Story
+    from app.models.project_access import ProjectAccess
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            story_b = Story(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_b_id"], title="Story B", status="backlog")
+            agent = Member(id=uuid.uuid4(), org_id=seeded["org_id"], type="agent", name="agent", is_active=True)
+            s.add_all([story_b, agent])
+            await s.commit()
+            s.add(ProjectAccess(id=uuid.uuid4(), project_id=seeded["project_a_id"], member_id=agent.id, permission="granted", role="member"))
+            await s.commit()
+            story_b_id, agent_id = story_b.id, agent.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/workflow/report-done",
+                json={"story_id": str(story_b_id), "stage": "kickoff", "agent_id": str(agent_id)},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            reloaded = (await s.execute(select(Story).where(Story.id == story_b_id))).scalar_one()
+            assert reloaded.status == "backlog", "무권한 project story 상태가 변조되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_report_done_same_project_still_works():
+    from app.main import app
+    from app.models.member import Member
+    from app.models.pm import Story
+    from app.models.project_access import ProjectAccess
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            story_a = Story(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"], title="Story A", status="backlog")
+            agent = Member(id=uuid.uuid4(), org_id=seeded["org_id"], type="agent", name="agent", is_active=True)
+            s.add_all([story_a, agent])
+            await s.commit()
+            s.add(ProjectAccess(id=uuid.uuid4(), project_id=seeded["project_a_id"], member_id=agent.id, permission="granted", role="member"))
+            await s.commit()
+            story_a_id, agent_id = story_a.id, agent.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/workflow/report-done",
+                json={"story_id": str(story_a_id), "stage": "kickoff", "agent_id": str(agent_id)},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["story_status"] == "in-progress"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── trigger_workflow ─────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_trigger_workflow_cross_project_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/workflow/trigger",
+                json={
+                    "project_id": str(seeded["project_b_id"]), "story_id": str(uuid.uuid4()),
+                    "trigger_type_slug": "kickoff",
+                },
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.workflow_execution_log import WorkflowExecutionLog
+            logs = (await s.execute(
+                select(WorkflowExecutionLog).where(WorkflowExecutionLog.project_id == seeded["project_b_id"])
+            )).scalars().all()
+            assert logs == [], "무권한 project에 워크플로 실행 로그가 생성되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_trigger_workflow_same_project_still_works():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/workflow/trigger",
+                json={
+                    "project_id": str(seeded["project_a_id"]), "story_id": str(uuid.uuid4()),
+                    "trigger_type_slug": "kickoff",
+                },
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["status"] in ("no_match", "triggered")
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_z_sprint_standup_github_project_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_z_sprint_standup_github_project_scope_realdb.py
@@ -1,0 +1,344 @@
+"""E-SECURITY SEC-S8(story 83ea3d6a) Z: Sprint/Standup/github delete_link project-scope
+미검증 봉쇄 실증 — 근본 하나(create/update/delete 경로 project-scope 부재)를 3개 라우터에서
+닫는다(Sprint report_doc_id·Standup sprint_id/plan_story_ids+read-side 정보유출·github delete_link).
+
+- Sprint report_doc_id: update_sprint이 소유권 검증 없이 그대로 repo.update에 전달(T-class).
+- Standup: 실HTTP 확定 — project_a만 grant된 caller가 project_b sprint_id/story를 PUT으로
+  참조하면 저장+응답에 그대로 title/project_id가 노출됐다(T-class + read-side 정보유출).
+- github delete_link: create/list(Y)는 project-scope를 닫았는데 delete가 빠져 있었다(S/X-class)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_base(session):
+    """org(project_a, project_b) + human_a(project_a에만 명시 grant)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"h-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ── Sprint report_doc_id ────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_update_sprint_cross_project_report_doc_blocked():
+    from app.main import app
+    from app.models.doc import Doc
+    from app.models.pm import Sprint
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_a = Sprint(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"], title="Sprint A")
+            doc_b = Doc(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_b_id"],
+                title="Doc B", slug=f"doc-b-{uuid.uuid4().hex[:8]}", content="",
+            )
+            s.add_all([sprint_a, doc_b])
+            await s.commit()
+            sprint_a_id, doc_b_id = sprint_a.id, doc_b.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/sprints/{sprint_a_id}", json={"report_doc_id": str(doc_b_id)},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_sprint_same_project_report_doc_still_works():
+    from app.main import app
+    from app.models.doc import Doc
+    from app.models.pm import Sprint
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_a = Sprint(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"], title="Sprint A")
+            doc_a = Doc(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"],
+                title="Doc A", slug=f"doc-a-{uuid.uuid4().hex[:8]}", content="",
+            )
+            s.add_all([sprint_a, doc_a])
+            await s.commit()
+            sprint_a_id, doc_a_id = sprint_a.id, doc_a.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/sprints/{sprint_a_id}", json={"report_doc_id": str(doc_a_id)},
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["report_doc_id"] == str(doc_a_id)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── Standup sprint_id/plan_story_ids ──────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_standup_cross_project_sprint_and_story_not_leaked():
+    """Z 재현: project_a만 grant된 caller가 project_b sprint/story를 PUT으로 참조해도
+    저장/응답에 반영되면 안 됨(쓰기 필터 + read enrich 접근권 필터 둘 다 실증)."""
+    from app.main import app
+    from app.models.pm import Sprint, Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_b = Sprint(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_b_id"], title="Sprint B Secret")
+            story_b = Story(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_b_id"], title="SECRET STORY B")
+            s.add_all([sprint_b, story_b])
+            await s.commit()
+            sprint_b_id, story_b_id = sprint_b.id, story_b.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.put(
+                "/api/v2/standups",
+                json={
+                    "project_id": str(seeded["project_a_id"]), "date": str(date.today()),
+                    "sprint_id": str(sprint_b_id), "plan_story_ids": [str(story_b_id)],
+                    "plan": "attempt cross-project leak",
+                },
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["sprint_id"] is None, "무권한 project의 sprint_id는 저장/응답에서 제거돼야 함"
+            assert body["plan_stories"] == [], "무권한 project의 story는 enrich에서 제외돼야 함(정보유출 봉인)"
+            entry_id = body["id"]
+        finally:
+            await client.aclose()
+
+        # DB에도 실제로 스며들지 않았는지 확인.
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.standup import StandupEntry
+            entry = (await s.execute(select(StandupEntry).where(StandupEntry.id == uuid.UUID(entry_id)))).scalar_one()
+            assert entry.sprint_id is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_standup_same_project_sprint_and_story_still_works():
+    """회귀 0: project_a grant 보유 caller는 project_a sprint/story는 여전히 정상 저장+enrich."""
+    from app.main import app
+    from app.models.pm import Sprint, Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            sprint_a = Sprint(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"], title="Sprint A")
+            story_a = Story(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"], title="Story A")
+            s.add_all([sprint_a, story_a])
+            await s.commit()
+            sprint_a_id, story_a_id = sprint_a.id, story_a.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.put(
+                "/api/v2/standups",
+                json={
+                    "project_id": str(seeded["project_a_id"]), "date": str(date.today()),
+                    "sprint_id": str(sprint_a_id), "plan_story_ids": [str(story_a_id)],
+                    "plan": "legit plan",
+                },
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["sprint_id"] == str(sprint_a_id)
+            assert [ps["id"] for ps in body["plan_stories"]] == [str(story_a_id)]
+            assert body["plan_stories"][0]["title"] == "Story A"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── github delete_link ─────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_github_delete_link_cross_project_blocked():
+    from app.main import app
+    from app.models.github_installation import GithubInstallation
+    from app.models.pm import Story
+    from app.models.pull_request_story_link import PullRequestStoryLink
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            story_b = Story(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_b_id"], title="Story B")
+            s.add(story_b)
+            await s.commit()
+            link = PullRequestStoryLink(
+                id=uuid.uuid4(), org_id=seeded["org_id"], story_id=story_b.id,
+                repo_full_name="acme-corp/repo1", pr_number=99,
+                link_source="explicit", confidence="high",
+            )
+            s.add(link)
+            await s.commit()
+            link_id = link.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/integrations/github/links/{link_id}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            reloaded = (await s.execute(
+                select(PullRequestStoryLink).where(PullRequestStoryLink.id == link_id)
+            )).scalar_one()
+            assert reloaded.deleted_at is None, "무권한 project의 link이 삭제되면 안 됨"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_github_delete_link_same_project_still_works():
+    from app.main import app
+    from app.models.pm import Story
+    from app.models.pull_request_story_link import PullRequestStoryLink
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_base(s)
+            story_a = Story(id=uuid.uuid4(), org_id=seeded["org_id"], project_id=seeded["project_a_id"], title="Story A")
+            s.add(story_a)
+            await s.commit()
+            link = PullRequestStoryLink(
+                id=uuid.uuid4(), org_id=seeded["org_id"], story_id=story_a.id,
+                repo_full_name="acme-corp/repo1", pr_number=100,
+                link_source="explicit", confidence="high",
+            )
+            s.add(link)
+            await s.commit()
+            link_id = link.id
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/integrations/github/links/{link_id}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_sprint_loop_a353e88d_activation_gate_realdb.py
+++ b/backend/tests/test_e_sprint_loop_a353e88d_activation_gate_realdb.py
@@ -44,6 +44,7 @@ async def _seed_org_project(s):
     for sql in [
         f"DELETE FROM sprints WHERE org_id='{ORG}'",
         f"DELETE FROM hypotheses WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE org_member_id='{OM}'",
         f"DELETE FROM org_members WHERE org_id='{ORG}'",
         f"DELETE FROM projects WHERE org_id='{ORG}'",
         f"DELETE FROM users WHERE id='{USER}'",
@@ -53,6 +54,11 @@ async def _seed_org_project(s):
         f"login_fail_count,totp_enabled,totp_fail_count) VALUES ('{USER}','u@dd.test','x','U',true,true,0,false,0)",
         f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM}','{ORG}','{USER}','member')",
         f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ}','{ORG}','P','none')",
+        # E-SECURITY SEC-S8(story 83ea3d6a) CC: sprint 라우터가 project-scope를 강제하게 되며
+        # 이 파일의 USER(role=member, 별도 grant 없음)가 sprint.project_id(PROJ) 접근권을
+        # 갖도록 명시 grant 필요(레거시 시드는 project-scope 이전 세계관).
+        f"INSERT INTO project_access (id,project_id,org_member_id,permission,role) "
+        f"VALUES ('{uuid.uuid4()}','{PROJ}','{OM}','granted','member')",
     ]:
         await s.execute(text(sql))
     await s.commit()

--- a/backend/tests/test_e_sprint_loop_fbf1c14b_hypotheses_rest_realdb.py
+++ b/backend/tests/test_e_sprint_loop_fbf1c14b_hypotheses_rest_realdb.py
@@ -108,7 +108,7 @@ async def test_get_returns_linked_hypotheses_flat_shape():
 
         async with Session() as s:
             repo = SprintRepository(s, ORG)
-            result = await list_sprint_hypotheses(sprint.id, repo=repo, session=s, org_id=ORG)
+            result = await list_sprint_hypotheses(sprint.id, repo=repo, session=s, org_id=ORG, auth=_auth())
         assert len(result) == 1
         item = result[0]
         assert item.id == hyp.id
@@ -138,7 +138,7 @@ async def test_get_unlinked_hypothesis_not_included():
 
         async with Session() as s:
             repo = SprintRepository(s, ORG)
-            result = await list_sprint_hypotheses(sprint.id, repo=repo, session=s, org_id=ORG)
+            result = await list_sprint_hypotheses(sprint.id, repo=repo, session=s, org_id=ORG, auth=_auth())
         assert result == []
     finally:
         await eng.dispose()
@@ -158,7 +158,7 @@ async def test_get_sprint_not_found_404():
         async with Session() as s:
             repo = SprintRepository(s, ORG)
             with pytest.raises(HTTPException) as ei:
-                await list_sprint_hypotheses(uuid.uuid4(), repo=repo, session=s, org_id=ORG)
+                await list_sprint_hypotheses(uuid.uuid4(), repo=repo, session=s, org_id=ORG, auth=_auth())
         assert ei.value.status_code == 404
         assert ei.value.detail["code"] == "SPRINT_NOT_FOUND"
     finally:

--- a/backend/tests/test_epics.py
+++ b/backend/tests/test_epics.py
@@ -374,11 +374,16 @@ def _delete_execute(*, epic, is_admin: bool):
     """delete_epic execute 시퀀스 모킹.
 
     1) repo.get → 존재 검증(scalar_one_or_none=에픽)
-    2) is_org_owner_or_admin → owner/admin 행 유무(scalar_one_or_none)
-    3) repo.delete 내부 self.get → 다시 에픽(없으면 False→404)
+    2) resolve_member — OrgMember 조회(E-SECURITY SEC-S1 확장: human-only 체크 신규 삽입)
+    3) resolve_member — User 조회(name 표시용, None이어도 무방)
+    4) is_org_owner_or_admin → owner/admin 행 유무(scalar_one_or_none)
+    5) repo.delete 내부 self.get → 다시 에픽(없으면 False→404)
     이후 cascade(dependency/label delete)는 영향 없음.
     """
     state = {"n": 0}
+    om_mock = MagicMock()
+    om_mock.id = uuid.uuid4()
+    om_mock.role = "admin" if is_admin else "member"
 
     async def _exec(stmt, *args, **kwargs):
         state["n"] += 1
@@ -386,8 +391,12 @@ def _delete_execute(*, epic, is_admin: bool):
         if state["n"] == 1:
             r.scalar_one_or_none.return_value = epic
         elif state["n"] == 2:
-            r.scalar_one_or_none.return_value = 1 if is_admin else None
+            r.scalar_one_or_none.return_value = om_mock
         elif state["n"] == 3:
+            r.scalar_one_or_none.return_value = None
+        elif state["n"] == 4:
+            r.scalar_one_or_none.return_value = 1 if is_admin else None
+        elif state["n"] == 5:
             r.scalar_one_or_none.return_value = epic
         else:
             r.scalar_one_or_none.return_value = None

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -277,10 +277,13 @@ async def test_current_project_get_via_conftest(test_client, mock_session):
 
 
 @pytest.mark.anyio
-async def test_members_list_via_conftest_s6(test_client, mock_session, project_id):
+async def test_members_list_via_conftest_s6(test_client, mock_session, project_id, org_id):
     """GET /api/v2/members 200."""
     mock_result = MagicMock()
     mock_result.scalars.return_value.all.return_value = []
+    # E-SECURITY SEC-S6: list_members가 먼저 project의 실 org_id를 조회해 caller org(=org_id
+    # fixture)와 대조한다 — 블랑켓 목이라 이 값을 맞춰야 그 가드를 통과한다.
+    mock_result.scalar_one_or_none.return_value = org_id
     mock_session.execute = AsyncMock(return_value=mock_result)
 
     resp = await test_client.get(f"/api/v2/members?project_id={project_id}")

--- a/backend/tests/test_meetings.py
+++ b/backend/tests/test_meetings.py
@@ -164,9 +164,31 @@ async def test_update_meeting_200():
 async def test_delete_meeting_200():
     client, session, app = await _client()
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = _mock_meeting()
-        session.execute = AsyncMock(return_value=mock_result)
+        # E-SECURITY SEC-S8(F): delete_meeting이 이제 순서대로 (1) target project의 org_id 조회
+        # (2) resolve_member의 OrgMember/User 조회 (3) repo.get (4) repo.delete 내부 get을
+        # 실행한다 — call_count 기반 목으로 각 단계에 맞는 응답을 준다.
+        om_mock = MagicMock()
+        om_mock.id = uuid.uuid4()
+        om_mock.role = "member"
+        meeting = _mock_meeting()
+
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            r = MagicMock()
+            if call_count == 1:
+                r.scalar_one_or_none.return_value = ORG_ID  # project org lookup
+            elif call_count == 2:
+                r.scalar_one_or_none.return_value = om_mock  # resolve_member: OrgMember
+            elif call_count == 3:
+                r.scalar_one_or_none.return_value = None  # resolve_member: User(optional)
+            else:
+                r.scalar_one_or_none.return_value = meeting  # repo.get / repo.delete 내부 get
+            return r
+
+        session.execute = mock_execute
         session.delete = AsyncMock()
         session.flush = AsyncMock()
 

--- a/backend/tests/test_meetings.py
+++ b/backend/tests/test_meetings.py
@@ -127,9 +127,18 @@ async def test_get_meeting_200():
 async def test_get_meeting_404():
     client, session, app = await _client()
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        session.execute = AsyncMock(return_value=mock_result)
+        # E-SECURITY SEC-S8(G): _get_repo가 이제 먼저 has_project_access(scalar_one_or_none)를
+        # 조회한다 — 1st call=access granted(truthy), 2nd call(repo.get)=None(not found).
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            r = MagicMock()
+            r.scalar_one_or_none.return_value = 1 if call_count == 1 else None
+            return r
+
+        session.execute = mock_execute
 
         async with client as c:
             resp = await c.get(f"/api/v2/meetings/{uuid.uuid4()}?project_id={PROJECT_ID}")
@@ -164,9 +173,10 @@ async def test_update_meeting_200():
 async def test_delete_meeting_200():
     client, session, app = await _client()
     try:
-        # E-SECURITY SEC-S8(F): delete_meeting이 이제 순서대로 (1) target project의 org_id 조회
-        # (2) resolve_member의 OrgMember/User 조회 (3) repo.get (4) repo.delete 내부 get을
-        # 실행한다 — call_count 기반 목으로 각 단계에 맞는 응답을 준다.
+        # E-SECURITY SEC-S8(F/G): delete_meeting이 이제 순서대로 (1) _get_repo의
+        # has_project_access(G) (2) target project의 org_id 조회(F) (3) resolve_member의
+        # OrgMember/User 조회 (4) repo.get (5) repo.delete 내부 get을 실행한다 — call_count
+        # 기반 목으로 각 단계에 맞는 응답을 준다.
         om_mock = MagicMock()
         om_mock.id = uuid.uuid4()
         om_mock.role = "member"
@@ -179,10 +189,12 @@ async def test_delete_meeting_200():
             call_count += 1
             r = MagicMock()
             if call_count == 1:
-                r.scalar_one_or_none.return_value = ORG_ID  # project org lookup
+                r.scalar_one_or_none.return_value = 1  # _get_repo: has_project_access granted
             elif call_count == 2:
-                r.scalar_one_or_none.return_value = om_mock  # resolve_member: OrgMember
+                r.scalar_one_or_none.return_value = ORG_ID  # project org lookup
             elif call_count == 3:
+                r.scalar_one_or_none.return_value = om_mock  # resolve_member: OrgMember
+            elif call_count == 4:
                 r.scalar_one_or_none.return_value = None  # resolve_member: User(optional)
             else:
                 r.scalar_one_or_none.return_value = meeting  # repo.get / repo.delete 내부 get

--- a/backend/tests/test_project_role_s4_can_manage.py
+++ b/backend/tests/test_project_role_s4_can_manage.py
@@ -100,7 +100,13 @@ async def test_org_agent_create_agent_no_admin_403():
     org = uuid.uuid4()
     body = OrgAgentCreate(name="cos", scope_mode="org")
     actor = _agent_actor()
-    session = MagicMock()
+    session = AsyncMock()
+    # E-SECURITY SEC-S8(O): _resolve_org_project_ids가 이제 role 체크보다 먼저 실행돼(grant
+    # 대상 전체를 role 검증 대상으로 삼기 위함) org 프로젝트 목록 조회를 먼저 만족시켜야 한다.
+    single_project_id = uuid.uuid4()
+    mock_result = MagicMock()
+    mock_result.all.return_value = [(single_project_id,)]
+    session.execute = AsyncMock(return_value=mock_result)
 
     with patch("app.routers.team_members._resolve_actor", new=AsyncMock(return_value=actor)), patch(
         "app.services.project_auth.has_project_role", new=AsyncMock(return_value=False)
@@ -110,3 +116,5 @@ async def test_org_agent_create_agent_no_admin_403():
     assert ei.value.status_code == 403
     hpr.assert_awaited_once()
     assert hpr.await_args.kwargs.get("min_role") == "admin"
+    # O 회귀 확認: grant 대상(single_project_id) 기준으로 검증됐지 actor.project_id가 아니어야 함.
+    assert hpr.await_args.args[2] == single_project_id

--- a/backend/tests/test_project_role_s4_can_manage.py
+++ b/backend/tests/test_project_role_s4_can_manage.py
@@ -45,22 +45,28 @@ async def test_team_member_create_agent_no_admin_403():
     org = uuid.uuid4()
     body = TeamMemberCreate(project_id=uuid.uuid4(), org_id=org, type="agent", name="new-agent")
     actor = _agent_actor()
-    session = MagicMock()
+    session = AsyncMock()
 
-    with patch("app.routers.team_members._resolve_actor", new=AsyncMock(return_value=actor)), patch(
-        "app.services.project_auth.has_project_role", new=AsyncMock(return_value=False)
-    ) as hpr:
+    # E-SECURITY SEC-S8(L): create_team_member가 이제 role 게이트 前 target-org 대조(신설)를
+    # 먼저 하므로 no-op으로 통과시켜 이 테스트의 실제 관심사(role 게이트 자체)만 검증.
+    with patch("app.routers.team_members._resolve_actor", new=AsyncMock(return_value=actor)), \
+         patch("app.services.project_auth.assert_target_in_caller_org", new=MagicMock(return_value=None)), \
+         patch("app.services.project_auth.has_project_role", new=AsyncMock(return_value=False)) as hpr:
         with pytest.raises(HTTPException) as ei:
             await create_team_member(body, session=session, auth=_auth(), org_id=org)
     assert ei.value.status_code == 403
-    # role 경로 사용 확認: actor.id·actor.project_id·min='admin'
+    # role 경로 사용 확認: 이제 actor 무관 target(body.project_id) 기준으로 단일 호출.
     hpr.assert_awaited_once()
     assert hpr.await_args.kwargs.get("min_role") == "admin"
+    assert hpr.await_args.args[2] == body.project_id
 
 
 @pytest.mark.anyio
-async def test_team_member_create_human_actor_skips_gate():
-    """human actor 는 agent 전용 게이트 미적용(has_project_role 미호출) — 무회귀."""
+async def test_team_member_create_human_actor_now_gated():
+    """E-SECURITY SEC-S8(L) 회귀: human actor(또는 actor 미해소)도 이제 동일 게이트 적용 —
+    과거엔 `if actor.type=="agent"`에 갇혀 human이면 인가가 통째로 스킵되던 CRITICAL 갭이었다.
+    무권한 human은 403(게이트가 410 deprecated-check보다 먼저 실행돼 has_project_role이 실제
+    호출됨)."""
     from app.routers.team_members import create_team_member
     from app.schemas.team_member import TeamMemberCreate
 
@@ -68,17 +74,17 @@ async def test_team_member_create_human_actor_skips_gate():
     body = TeamMemberCreate(project_id=uuid.uuid4(), org_id=org, type="human", name="x")
     human = MagicMock()
     human.type = "human"
-    session = MagicMock()
+    session = AsyncMock()
 
-    with patch("app.routers.team_members._resolve_actor", new=AsyncMock(return_value=human)), patch(
-        "app.services.project_auth.has_project_role", new=AsyncMock(return_value=False)
-    ) as hpr:
-        # human create 는 410(deprecated)로 끊기지만 게이트(has_project_role) 전에 막힘 → 미호출
+    with patch("app.routers.team_members._resolve_actor", new=AsyncMock(return_value=human)), \
+         patch("app.services.project_auth.assert_target_in_caller_org", new=MagicMock(return_value=None)), \
+         patch("app.services.project_auth.has_project_role", new=AsyncMock(return_value=False)) as hpr:
         from fastapi import HTTPException
 
-        with pytest.raises(HTTPException):
+        with pytest.raises(HTTPException) as ei:
             await create_team_member(body, session=session, auth=_auth(), org_id=org)
-    hpr.assert_not_awaited()
+        assert ei.value.status_code == 403
+    hpr.assert_awaited_once()
 
 
 # ── create_org_agent (agents.py) ─────────────────────────────────────────────

--- a/backend/tests/test_s33.py
+++ b/backend/tests/test_s33.py
@@ -224,6 +224,9 @@ async def test_members_list_200():
 
         mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = [member_mock]
+        # E-SECURITY SEC-S6: list_members가 먼저 project의 실 org_id를 조회해 caller org(ORG_ID)와
+        # 대조한다 — 블랑켓 목이라 이 값을 맞춰야 그 가드를 통과한다.
+        mock_result.scalar_one_or_none.return_value = ORG_ID
         session.execute = AsyncMock(return_value=mock_result)
 
         async with client as c:

--- a/backend/tests/test_s4_1_file_conflict.py
+++ b/backend/tests/test_s4_1_file_conflict.py
@@ -611,7 +611,10 @@ async def test_fetch_scoped_member_falls_back_directly():
 
 @pytest.mark.anyio
 async def test_list_file_locks_200():
-    """AC6: GET /api/v2/file-locks → 목록 반환."""
+    """AC6: GET /api/v2/file-locks?project_id=... → 목록 반환.
+
+    E-SECURITY SEC-S8 Y: project_id가 필수 쿼리 파라미터로 바뀌어(org 전체 노출 봉인)
+    has_project_access도 검증 대상 — 여기선 True로 patch해 목록 반환 경로만 격리 검증."""
     client, session, app = await _client()
     try:
         lock = MagicMock()
@@ -625,8 +628,9 @@ async def test_list_file_locks_200():
         mock_result.scalars.return_value.all.return_value = [lock]
         session.execute = AsyncMock(return_value=mock_result)
 
-        async with client as c:
-            resp = await c.get("/api/v2/file-locks")
+        with patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
+            async with client as c:
+                resp = await c.get("/api/v2/file-locks", params={"project_id": str(PROJECT_ID)})
 
         assert resp.status_code == 200
         body = resp.json()

--- a/backend/tests/test_s_mbr_03.py
+++ b/backend/tests/test_s_mbr_03.py
@@ -229,7 +229,13 @@ async def test_list_members_owner_always_included():
     from app.routers.members import list_members
 
     project_id = uuid.uuid4()
+    org_id = uuid.uuid4()
     mock_session = AsyncMock()
+
+    # E-SECURITY SEC-S6: list_members가 이제 먼저 project의 실 org_id를 조회해 caller org와
+    # 대조한다 — 이 목이 그 1번째 execute()에 응답.
+    org_lookup_mock = MagicMock()
+    org_lookup_mock.scalar_one_or_none.return_value = org_id
 
     # Human rows: org owner (id=owner_id) + org member (id=member_id)
     owner_id = uuid.uuid4()
@@ -244,10 +250,10 @@ async def test_list_members_owner_always_included():
     agent_mock = MagicMock()
     agent_mock.scalars.return_value.all.return_value = []
 
-    mock_session.execute = AsyncMock(side_effect=[human_mock, agent_mock])
+    mock_session.execute = AsyncMock(side_effect=[org_lookup_mock, human_mock, agent_mock])
     mock_auth = MagicMock()
 
-    result = await list_members(project_id=project_id, session=mock_session, _auth=mock_auth)
+    result = await list_members(project_id=project_id, session=mock_session, _auth=mock_auth, org_id=org_id)
     # 두 멤버 모두 포함
     assert len(result) == 2
     roles = {r.role for r in result}

--- a/backend/tests/test_s_mbr_10.py
+++ b/backend/tests/test_s_mbr_10.py
@@ -76,10 +76,15 @@ async def test_list_members_org_member_requires_grant():
     from app.routers.members import list_members
 
     project_id = uuid.uuid4()
+    org_id = uuid.uuid4()
     mock_session = AsyncMock()
 
     owner_id = uuid.uuid4()
     member_id = uuid.uuid4()
+
+    # E-SECURITY SEC-S6: list_members가 먼저 project의 실 org_id를 조회해 caller org와 대조한다.
+    org_lookup_mock = MagicMock()
+    org_lookup_mock.scalar_one_or_none.return_value = org_id
 
     # owner 포함, member 미포함 (grant 없음)
     human_mock = MagicMock()
@@ -91,10 +96,10 @@ async def test_list_members_org_member_requires_grant():
     agent_mock = MagicMock()
     agent_mock.scalars.return_value.all.return_value = []
 
-    mock_session.execute = AsyncMock(side_effect=[human_mock, agent_mock])
+    mock_session.execute = AsyncMock(side_effect=[org_lookup_mock, human_mock, agent_mock])
     mock_auth = MagicMock()
 
-    result = await list_members(project_id=project_id, session=mock_session, _auth=mock_auth)
+    result = await list_members(project_id=project_id, session=mock_session, _auth=mock_auth, org_id=org_id)
     assert len(result) == 1
     assert result[0].role == "owner"
 
@@ -105,10 +110,15 @@ async def test_list_members_member_with_grant_included():
     from app.routers.members import list_members
 
     project_id = uuid.uuid4()
+    org_id = uuid.uuid4()
     mock_session = AsyncMock()
 
     owner_id = uuid.uuid4()
     member_id = uuid.uuid4()
+
+    # E-SECURITY SEC-S6: list_members가 먼저 project의 실 org_id를 조회해 caller org와 대조한다.
+    org_lookup_mock = MagicMock()
+    org_lookup_mock.scalar_one_or_none.return_value = org_id
 
     # owner + member(grant 있음) 둘 다 포함
     human_mock = MagicMock()
@@ -120,10 +130,10 @@ async def test_list_members_member_with_grant_included():
     agent_mock = MagicMock()
     agent_mock.scalars.return_value.all.return_value = []
 
-    mock_session.execute = AsyncMock(side_effect=[human_mock, agent_mock])
+    mock_session.execute = AsyncMock(side_effect=[org_lookup_mock, human_mock, agent_mock])
     mock_auth = MagicMock()
 
-    result = await list_members(project_id=project_id, session=mock_session, _auth=mock_auth)
+    result = await list_members(project_id=project_id, session=mock_session, _auth=mock_auth, org_id=org_id)
     assert len(result) == 2
     roles = {r.role for r in result}
     assert "owner" in roles

--- a/backend/tests/test_sprints.py
+++ b/backend/tests/test_sprints.py
@@ -219,6 +219,9 @@ async def test_activate_sprint_200():
         active_sprint = _mock_sprint("active")
         caller = ResolvedMember(
             id=uuid.uuid4(), user_id=None, name="h", type="human", role="member", org_id=ORG_ID)
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = active_sprint
+        session.execute = AsyncMock(return_value=mock_result)
         with patch("app.services.sprint.transition_sprint", AsyncMock(return_value=active_sprint)), \
              patch("app.services.member_resolver.resolve_member", AsyncMock(return_value=caller)):
             async with client as c:
@@ -694,7 +697,11 @@ async def test_update_sprint_goal_capacity_200():
 
     client, session, app = await _client()
     try:
-        with patch("app.repositories.base.BaseRepository.update", new_callable=AsyncMock) as mock_update:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = updated
+        session.execute = AsyncMock(return_value=mock_result)
+        with patch("app.repositories.base.BaseRepository.update", new_callable=AsyncMock) as mock_update, \
+             patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
             mock_update.return_value = updated
             async with client as c:
                 resp = await c.patch(f"/api/v2/sprints/{SPRINT_ID}", json={

--- a/backend/tests/test_ss2_auth_context.py
+++ b/backend/tests/test_ss2_auth_context.py
@@ -126,9 +126,18 @@ async def test_patch_meeting_with_org_context_passes_auth():
     ctx = _mk_ctx(org_id=ORG_ID)
     client, session, app = await _client(ctx)
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        session.execute = AsyncMock(return_value=mock_result)
+        # E-SECURITY SEC-S8(G): _get_repo가 이제 먼저 has_project_access를 조회한다 —
+        # 1st call=access granted(truthy), 2nd call(repo.update 내부 get)=None(not found).
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            r = MagicMock()
+            r.scalar_one_or_none.return_value = 1 if call_count == 1 else None
+            return r
+
+        session.execute = mock_execute
 
         async with client as c:
             resp = await c.patch(
@@ -146,9 +155,18 @@ async def test_put_meeting_with_org_context_passes_auth():
     ctx = _mk_ctx(org_id=ORG_ID)
     client, session, app = await _client(ctx)
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        session.execute = AsyncMock(return_value=mock_result)
+        # E-SECURITY SEC-S8(G): _get_repo가 이제 먼저 has_project_access를 조회한다 —
+        # 1st call=access granted(truthy), 2nd call(repo.update 내부 get)=None(not found).
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            r = MagicMock()
+            r.scalar_one_or_none.return_value = 1 if call_count == 1 else None
+            return r
+
+        session.execute = mock_execute
 
         async with client as c:
             resp = await c.put(

--- a/backend/tests/test_standup_org_write_1c2be9db.py
+++ b/backend/tests/test_standup_org_write_1c2be9db.py
@@ -71,8 +71,11 @@ async def test_org_level_post_resyncs_to_accessible_projects():
     p1, p2 = uuid.uuid4(), uuid.uuid4()
     client, app = await _client(uid, org)
     resync = AsyncMock()
+    from app.services.member_resolver import ResolvedMember
+    member = ResolvedMember(id=uuid.uuid4(), user_id=uid, name="h", type="human", role="member", org_id=org)
     try:
         with patch("app.routers.standups.canonicalize_member_id", new=AsyncMock(return_value=uuid.uuid4())), \
+             patch("app.routers.standups.resolve_member", new=AsyncMock(return_value=member)), \
              patch("app.routers.standups.accessible_project_ids_in_org", new=AsyncMock(return_value=[p1, p2])), \
              patch("app.repositories.standup.StandupEntryRepository.upsert", new=AsyncMock(return_value=_entry(org))), \
              patch("app.repositories.standup.StandupEntryRepository.resync_project_links", new=resync):
@@ -95,8 +98,11 @@ async def test_legacy_post_with_project_id_no_resync():
     client, app = await _client(uid, org)
     resync = AsyncMock()
     accessible = AsyncMock(return_value=[])
+    from app.services.member_resolver import ResolvedMember
+    member = ResolvedMember(id=uuid.uuid4(), user_id=uid, name="h", type="human", role="member", org_id=org)
     try:
         with patch("app.routers.standups.canonicalize_member_id", new=AsyncMock(return_value=uuid.uuid4())), \
+             patch("app.routers.standups.resolve_member", new=AsyncMock(return_value=member)), \
              patch("app.routers.standups.accessible_project_ids_in_org", new=accessible), \
              patch("app.repositories.standup.StandupEntryRepository.upsert", new=AsyncMock(return_value=_entry(org, uuid.uuid4()))), \
              patch("app.repositories.standup.StandupEntryRepository.resync_project_links", new=resync):

--- a/backend/tests/test_standup_plan_stories_enrich.py
+++ b/backend/tests/test_standup_plan_stories_enrich.py
@@ -2,19 +2,24 @@
 
 BE 가 plan_story_ids 를 org-scope resolve 해 plan_stories[{id,title,status,...}] 로 내려줌(FE 가 active-sprint
 stories 배열 의존 제거). 검증: 입력 순서 보존·타org/삭제/미존재 조용히 제외·plan_story_ids 하위호환 유지.
+
+E-SECURITY SEC-S8(story 83ea3d6a) Z: viewer의 accessible_project_ids_in_org로도 필터(접근권 밖
+project story는 조용히 제외) — 테스트는 accessible_project_ids_in_org를 patch해 격리 검증한다.
 """
 from __future__ import annotations
 
 import uuid
 from datetime import date as _date, datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from app.routers.standups import _entries_with_plan_stories
 
 ORG = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()  # accessible-by-default project used across tests.
+VIEWER_ID = uuid.uuid4()
 
 
 @pytest.fixture
@@ -31,8 +36,15 @@ def _entry(plan_story_ids):
     )
 
 
-def _row(sid, title="S", status="in-progress"):
-    return (sid, title, status, "medium", None, None)
+def _row(sid, title="S", status="in-progress", project_id=PROJECT_ID):
+    return (sid, title, status, "medium", project_id, None)
+
+
+def _accessible(*ids):
+    return patch(
+        "app.services.project_auth.accessible_project_ids_in_org",
+        new=AsyncMock(return_value=list(ids)),
+    )
 
 
 @pytest.mark.anyio
@@ -45,7 +57,8 @@ async def test_plan_stories_resolve_order_preserved_and_missing_excluded():
     result.all.return_value = [_row(s1, "One"), _row(s2, "Two")]
     session.execute = AsyncMock(return_value=result)
 
-    out = await _entries_with_plan_stories([entry], session, ORG)
+    with _accessible(PROJECT_ID):
+        out = await _entries_with_plan_stories([entry], session, ORG, VIEWER_ID)
     resp = out[0]
     # ⭐입력 순서 보존(s2→s1)·missing 조용히 제외.
     assert [ps.id for ps in resp.plan_stories] == [s2, s1]
@@ -59,7 +72,8 @@ async def test_no_plan_story_ids_no_query():
     entry = _entry([])
     session = AsyncMock()
     session.execute = AsyncMock()
-    out = await _entries_with_plan_stories([entry], session, ORG)
+    with _accessible(PROJECT_ID):
+        out = await _entries_with_plan_stories([entry], session, ORG, VIEWER_ID)
     assert out[0].plan_stories == []
     session.execute.assert_not_awaited()  # 빈 id → 쿼리 0.
 
@@ -73,9 +87,26 @@ async def test_org_scope_in_query():
     result = MagicMock()
     result.all.return_value = [_row(s1)]
     session.execute = AsyncMock(return_value=result)
-    await _entries_with_plan_stories([entry], session, ORG)
+    with _accessible(PROJECT_ID):
+        await _entries_with_plan_stories([entry], session, ORG, VIEWER_ID)
     stmt = str(session.execute.await_args.args[0])
     assert "org_id" in stmt and "deleted_at" in stmt  # org-scope + soft-delete 필터.
+
+
+@pytest.mark.anyio
+async def test_inaccessible_project_story_excluded():
+    """E-SECURITY SEC-S8 Z: viewer가 접근권 없는 project의 story는 org-scope 통과해도 제외."""
+    s1 = uuid.uuid4()
+    other_project = uuid.uuid4()
+    entry = _entry([s1])
+    session = AsyncMock()
+    result = MagicMock()
+    result.all.return_value = [_row(s1, "Hidden", project_id=other_project)]
+    session.execute = AsyncMock(return_value=result)
+    with _accessible(PROJECT_ID):  # viewer는 other_project 접근권 없음.
+        out = await _entries_with_plan_stories([entry], session, ORG, VIEWER_ID)
+    assert out[0].plan_stories == []
+    assert out[0].plan_story_ids == [s1]  # 원본 id 하위호환은 유지.
 
 
 # ─── b47f9b05: history + get_standup enrich 갭 회귀(원 시나리오) ──────────────
@@ -88,6 +119,10 @@ def _repo(*, list_ret=None, get_ret=None, session=None):
     )
 
 
+def _auth():
+    return MagicMock(user_id=str(VIEWER_ID))
+
+
 @pytest.mark.anyio
 async def test_history_endpoint_enriches_backlog_plan_story():
     """history 가 백로그(cross-board) plan_story 를 enrich — 미적용 시 plan_stories 빈 채 미노출 회귀."""
@@ -97,7 +132,8 @@ async def test_history_endpoint_enriches_backlog_plan_story():
     result = MagicMock(); result.all.return_value = [_row(backlog, "Backlog", "backlog")]
     session.execute = AsyncMock(return_value=result)
     repo = _repo(list_ret=[_entry([backlog])], session=session)
-    out = await list_standup_history(project_id=uuid.uuid4(), limit=30, repo=repo)
+    with _accessible(PROJECT_ID):
+        out = await list_standup_history(project_id=uuid.uuid4(), limit=30, repo=repo, auth=_auth())
     assert [ps.id for ps in out[0].plan_stories] == [backlog]  # 백로그 노출(enrich)
 
 
@@ -111,5 +147,6 @@ async def test_get_standup_endpoint_enriches_backlog_plan_story():
     result = MagicMock(); result.all.return_value = [_row(backlog, "Backlog", "backlog")]
     session.execute = AsyncMock(return_value=result)
     repo = _repo(get_ret=entry, session=session)
-    out = await get_standup(id=entry.id, repo=repo)
+    with _accessible(PROJECT_ID):
+        out = await get_standup(id=entry.id, repo=repo, auth=_auth())
     assert [ps.id for ps in out.plan_stories] == [backlog]

--- a/backend/tests/test_standups.py
+++ b/backend/tests/test_standups.py
@@ -95,10 +95,16 @@ async def test_list_standups_200():
 @pytest.mark.anyio
 async def test_upsert_standup_insert_201():
     """신규 스탠드업 upsert → INSERT."""
+    from app.services.member_resolver import ResolvedMember
+
     client, session, app = await _client()
     try:
         entry = _mock_entry()
-        with patch("app.repositories.standup.StandupEntryRepository.upsert", new_callable=AsyncMock) as mock_upsert:
+        member = ResolvedMember(
+            id=AUTHOR_ID, user_id=AUTHOR_ID, name="h", type="human", role="member", org_id=ORG_ID,
+        )
+        with patch("app.repositories.standup.StandupEntryRepository.upsert", new_callable=AsyncMock) as mock_upsert, \
+             patch("app.routers.standups.resolve_member", new=AsyncMock(return_value=member)):
             mock_upsert.return_value = entry
 
             async with client as c:

--- a/backend/tests/test_stories_bulk_body_contract.py
+++ b/backend/tests/test_stories_bulk_body_contract.py
@@ -68,7 +68,7 @@ async def test_bulk_handler_refreshes_and_serializes(monkeypatch):
     # ⚠️ model_validate 는 모킹하지 않는다 — 실 직렬화를 태워야 P0 3차류를 잡는다.
 
     payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": "done"}])
-    result = await bulk_update_stories(payload, db, repo, auth=MagicMock())
+    result = await bulk_update_stories(payload, db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
 
     assert story.status == "done"  # setattr 적용
     db.refresh.assert_awaited_once_with(story)  # MissingGreenlet fix 가드(refresh 누락 시 실패)
@@ -98,7 +98,7 @@ async def test_bulk_nonsequential_jump_flags_violation_but_allows(monkeypatch):
     monkeypatch.setattr(stories_mod, "fire_webhooks", _fire)
 
     payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": "in-progress"}])
-    result = await bulk_update_stories(payload, db, repo, auth=MagicMock())
+    result = await bulk_update_stories(payload, db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
 
     assert story.status == "in-progress"  # allow(차단 X)
     assert result[0].violation == {
@@ -128,7 +128,7 @@ async def test_bulk_adjacent_and_reopen_no_violation(monkeypatch):
         monkeypatch.setattr(stories_mod, "publish_event", MagicMock())
 
         payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": new}])
-        result = await bulk_update_stories(payload, db, repo, auth=MagicMock())
+        result = await bulk_update_stories(payload, db, repo, auth=MagicMock(user_id=str(uuid.uuid4())))
 
         assert story.status == new  # allow
         assert result[0].violation is None, f"{old}->{new} should be no-violation"

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -186,9 +186,24 @@ async def test_delete_task_200():
 async def test_delete_task_404():
     client, session, app = await _client()
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        session.execute = AsyncMock(return_value=mock_result)
+        # E-SECURITY SEC-S1(확장): delete_task가 이제 resolve_member(OrgMember 조회)를 먼저
+        # 태우므로, 1번째 execute는 human org_member를 리턴하고 이후(User/task 조회)만 None이어야
+        # 의도한 404(존재하지 않는 task)를 재현한다 — 안 그러면 resolve_member 쪽 400이 먼저 뜬다.
+        om_mock = MagicMock()
+        om_mock.id = uuid.uuid4()
+        om_mock.role = "member"
+        om_mock.org_id = ORG_ID
+
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = om_mock if call_count == 1 else None
+            return result
+
+        session.execute = mock_execute
 
         async with client as c:
             resp = await c.delete(f"/api/v2/tasks/{uuid.uuid4()}")

--- a/backend/tests/test_team_members.py
+++ b/backend/tests/test_team_members.py
@@ -112,6 +112,10 @@ async def test_create_team_member_201():
         mock_result = MagicMock()
         mock_result.scalars.return_value.first.return_value = None  # _resolve_actor → non-agent
         mock_result.all.return_value = []  # fakechat_port 쿼리 → 기존 포트 없음
+        # E-SECURITY SEC-S8(L): 신규 target-org 조회(.scalar_one_or_none)·has_project_role 내부
+        # get_project_role 조회(.one_or_none)가 같은 mock_result의 다른 accessor라 독립 설정 가능.
+        mock_result.scalar_one_or_none.return_value = ORG_ID  # target project org = caller org
+        mock_result.one_or_none.return_value = ("admin", None)  # org_role=admin → has_project_role 통과
         session.execute = AsyncMock(return_value=mock_result)
 
         with patch("app.routers.team_members._resolve_actor", new=AsyncMock(return_value=None)), \

--- a/backend/tests/test_toolset_catalog.py
+++ b/backend/tests/test_toolset_catalog.py
@@ -72,7 +72,8 @@ def test_every_tool_covered_exactly_once():
 def test_tool_group_mapping_examples():
     by_tool = {t: g["key"] for g in build_toolset_catalog()["groups"] for t in g["tools"]}
     # 도메인 destructive 는 도메인 그룹(admin 아님)
-    assert by_tool["sprintable_delete_story"] == "stories"
+    # E-SECURITY SEC-S1: sprintable_delete_story 제거(에이전트 hard-delete 차단) — delete_task로 대체 예시
+    assert by_tool["sprintable_delete_task"] == "tasks"
     assert by_tool["sprintable_give_reward"] == "rewards"
     assert by_tool["sprintable_delete_sprint"] == "sprints"
     # admin 그룹 = emit_event/trigger_ai/activate_sprint/close_sprint 등 진짜 파괴 작업만

--- a/backend/tests/test_toolset_catalog.py
+++ b/backend/tests/test_toolset_catalog.py
@@ -72,8 +72,9 @@ def test_every_tool_covered_exactly_once():
 def test_tool_group_mapping_examples():
     by_tool = {t: g["key"] for g in build_toolset_catalog()["groups"] for t in g["tools"]}
     # 도메인 destructive 는 도메인 그룹(admin 아님)
-    # E-SECURITY SEC-S1: sprintable_delete_story 제거(에이전트 hard-delete 차단) — delete_task로 대체 예시
-    assert by_tool["sprintable_delete_task"] == "tasks"
+    # E-SECURITY SEC-S1(확장): sprintable_delete_story/task/epic/doc 제거(에이전트 hard-delete
+    # 차단) — delete_meeting으로 대체 예시(에이전트 MCP 표면에 남는 도메인 destructive 도구)
+    assert by_tool["sprintable_delete_meeting"] == "meetings"
     assert by_tool["sprintable_give_reward"] == "rewards"
     assert by_tool["sprintable_delete_sprint"] == "sprints"
     # admin 그룹 = emit_event/trigger_ai/activate_sprint/close_sprint 등 진짜 파괴 작업만

--- a/backend/tests/test_toolset_catalog.py
+++ b/backend/tests/test_toolset_catalog.py
@@ -74,9 +74,9 @@ def test_tool_group_mapping_examples():
     # 도메인 destructive 는 도메인 그룹(admin 아님)
     # E-SECURITY SEC-S1(확장): sprintable_delete_story/task/epic/doc 제거(에이전트 hard-delete
     # 차단) — delete_meeting으로 대체 예시(에이전트 MCP 표면에 남는 도메인 destructive 도구)
+    # E-SECURITY SEC-S8 확장: sprintable_delete_sprint도 동일 사유로 제거.
     assert by_tool["sprintable_delete_meeting"] == "meetings"
     assert by_tool["sprintable_give_reward"] == "rewards"
-    assert by_tool["sprintable_delete_sprint"] == "sprints"
     # admin 그룹 = emit_event/trigger_ai/activate_sprint/close_sprint 등 진짜 파괴 작업만
     assert by_tool["sprintable_emit_event"] == "admin"
     # always-allowed(+orphan)는 core 로 통합(키워드 그룹서 제외)

--- a/backend/tests/test_workflow_report.py
+++ b/backend/tests/test_workflow_report.py
@@ -322,6 +322,10 @@ async def test_agent_id_cross_org_400():
             result = MagicMock()
             if call_count == 1:
                 result.scalar_one_or_none.return_value = story
+            elif call_count == 2:
+                # E-SECURITY SEC-S8 Z2: has_project_access 호출(story project 접근권) — 이
+                # 테스트는 그 뒤의 agent_id 검증(call 3)만 검증 대상이라 여기선 통과시킨다.
+                result.scalar_one_or_none.return_value = 1
             else:
                 result.scalar_one_or_none.return_value = None
             return result

--- a/backend/tests/test_workflow_template_api.py
+++ b/backend/tests/test_workflow_template_api.py
@@ -146,12 +146,16 @@ async def test_apply_template_cross_org_agent_422():
         role_mapping={"step_1": str(cross_org_id), "step_2": str(uuid.uuid4())},
     )
 
-    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo, \
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
         instance = AsyncMock()
         instance.get_by_slug = AsyncMock(return_value=tmpl)
         MockRepo.return_value = instance
         with pytest.raises(HTTPException) as exc:
-            await apply_template(slug="two-step", body=body, db=db, auth=MagicMock(), org_id=uuid.uuid4())
+            await apply_template(
+                slug="two-step", body=body, db=db,
+                auth=MagicMock(user_id=str(uuid.uuid4())), org_id=uuid.uuid4(),
+            )
 
     assert exc.value.status_code == 422
 
@@ -169,12 +173,16 @@ async def test_apply_template_missing_role_mapping_422():
         role_mapping={"step_1": str(uuid.uuid4())},
     )
 
-    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo, \
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
         instance = AsyncMock()
         instance.get_by_slug = AsyncMock(return_value=tmpl)
         MockRepo.return_value = instance
         with pytest.raises(HTTPException) as exc:
-            await apply_template(slug="two-step", body=body, db=db, auth=MagicMock(), org_id=uuid.uuid4())
+            await apply_template(
+                slug="two-step", body=body, db=db,
+                auth=MagicMock(user_id=str(uuid.uuid4())), org_id=uuid.uuid4(),
+            )
 
     assert exc.value.status_code == 422
 
@@ -187,12 +195,16 @@ async def test_apply_template_404():
     db = _mock_db()
     body = ApplyTemplateRequest(project_id=uuid.uuid4(), role_mapping={})
 
-    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo, \
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
         instance = AsyncMock()
         instance.get_by_slug = AsyncMock(return_value=None)
         MockRepo.return_value = instance
         with pytest.raises(HTTPException) as exc:
-            await apply_template(slug="ghost", body=body, db=db, auth=MagicMock(), org_id=uuid.uuid4())
+            await apply_template(
+                slug="ghost", body=body, db=db,
+                auth=MagicMock(user_id=str(uuid.uuid4())), org_id=uuid.uuid4(),
+            )
 
     assert exc.value.status_code == 404
 
@@ -229,11 +241,15 @@ async def test_apply_template_overwrite_deletes_existing():
         overwrite_existing=True,
     )
 
-    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo, \
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
         instance = AsyncMock()
         instance.get_by_slug = AsyncMock(return_value=tmpl)
         MockRepo.return_value = instance
-        result = await apply_template(slug="two-step", body=body, db=db, auth=MagicMock(), org_id=uuid.uuid4())
+        result = await apply_template(
+            slug="two-step", body=body, db=db,
+            auth=MagicMock(user_id=str(uuid.uuid4())), org_id=uuid.uuid4(),
+        )
 
     assert result.ok is True
     assert result.rules_deleted == 1


### PR DESCRIPTION
## Summary
- **selective 승격**: 오늘 E-SECURITY 감사(SEC-S1~S8, story 83ea3d6a 등) 전체 — 비-보안(E-CANVAS FE/E-GLANCE/로드맵)은 제외.
- 범위가 애초 "SEC-S8 J~EE"에서 **"SEC-S1~EE"(24커밋)로 확장**된 이유: 드라이런 중 SEC-S8(G/H/M #2021)의 delete_sprint 인가 갭 fix가 SEC-S1(확장) 휴먼전용화+삭제감사 인프라(같은 함수 시그니처)에 의존하는 걸 발견 — self-contained 승격을 위해 그 prerequisite까지 포함(선생님 확認 완료).
- **제외**: R(#2034)/Q(#2026) — 둘 다 `visual_artifacts.py`(E-CANVAS)만 건드리는데 main에 그 파일/기능 자체가 없음(`git grep visual_artifact` main 전체 0건) — 공격 표면 부재라 지킬 게 없는 상태. E-CANVAS가 별도로 prod 갈 때 자동 포함됨.

## 커밋 목록(24개, chronological)
SEC-S1 · SEC-S2 · SEC-S1(확장) · SEC-S6 · SEC-S7(빈 커밋, no-op) · SEC-S8: J+K · L · O · G/H/M(conflict resolve) · SEC-S3 · P · S · T · V · W(CRITICAL) · X · Y · W2 · Z · Z2 · BB · CC · DD(CRITICAL) · EE(CRITICAL×3) · 회귀가드(#2050) + 이 브랜치 전용 baseline 조정 1건.

## Conflict resolve (1곳)
G/H/M(#2021)에서만 발생 — 원인은 G의 `visual_artifacts.py` 부분(main에 파일 없음). `git rm`으로 그 hunk만 drop, H(delete_sprint)/M(workflow-line-config)/G의 task·meeting·story 부분은 auto-merge로 100% 보존(로직 무수정). `tests/mcp/test_contract.py` 툴카운트는 이 스코프 기준 93으로 재계산(develop의 95는 E-CANVAS 포함 카운트).

## Billing / Migration
- **billing 유입 0**: 24커밋 전체 diff grep(`pricing_version|grandfather|billing|polar|org_subscriptions|plan_tier`) 0건.
- **마이그 1개**: `0170_deletion_audit_logs.py` — `down_revision=0169`(main 현재 head와 gap 0로 이어짐), 순수 additive 신규 테이블, `downgrade()` 완비(완전 가역). EE-stamp precheck(별개 리비전 "0147"/ee_pricing 계열 판정 전용)와 무관 확認.

## Test plan
- [x] `app.main` import OK(434 routes)
- [x] `tests/mcp/test_contract.py` + `tests/test_toolset_catalog.py` 35/35 PASS
- [x] `tests/test_authz_project_scope_coverage.py` 3/3 PASS(baseline 조정 후)
- [x] 전체 non-realdb 스위트: 3264 passed, 6 failed(전부 `test_s6_4_dod`/`test_s7_2_epic_dod` — 로컬 경로 의존 pre-existing, 이 승격과 무관), 0 regression
- [ ] CI

## Rollback
단일 merge commit이라 `git revert -m 1 <merge_sha>` 한 번으로 전체 원복. 마이그 0170은 additive라 코드 롤백만으로 안전(테이블 잔존해도 무해).

🤖 Generated with [Claude Code](https://claude.com/claude-code)