### PR TITLE
[E-GLANCE] 로드맵 blank 재발 — 재마운트 커밋-취소 레이스 근본 fix

### DIFF
--- a/apps/web/src/components/glance/glance-board.tsx
+++ b/apps/web/src/components/glance/glance-board.tsx
@@ -4,18 +4,8 @@ import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Loader2 } from 'lucide-react';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
-import type { EpicProgress } from '@/components/dashboard/command-center/types';
-import {
-  deriveCollaboration,
-  filterMilestoneEvents,
-  mergeRoadmap,
-  scopeRoadmapEpics,
-  type BeActivityLogItem,
-  type BeEpicListItem,
-  type BeStoryListItem,
-  type EpicCollaboration,
-  type RoadmapEpic,
-} from '@/services/glance';
+import type { BeActivityLogItem, EpicCollaboration, RoadmapEpic } from '@/services/glance';
+import { loadGlanceData } from './load-glance-data';
 import { RoadmapFlow } from './roadmap-flow';
 import { ProgressTrajectory } from './progress-trajectory';
 import { CollaborationMap } from './collaboration-map';
@@ -26,21 +16,12 @@ interface GlanceBoardProps {
   className?: string;
 }
 
-function unwrap<T>(json: unknown): T | null {
-  if (!json || typeof json !== 'object') return null;
-  const d = (json as { data?: unknown }).data;
-  return (d ?? json) as T;
-}
-
-async function fetchJson(url: string): Promise<unknown> {
-  return fetch(url).then((r) => (r.ok ? r.json() : null)).catch(() => null);
-}
-
 /**
  * E-GLANCE C1 현황판 오케스트레이터 — 실 fetch, mock 폴백 0. 서브 컴포넌트(RoadmapFlow 등)는
  * 전부 순수 props라 여기서만 §10 데이터 소스 4종을 병합한다: /api/epics(순서 SSOT) ·
  * /api/dashboard/overview(진척) · /api/stories?epic_id=(참여) · /api/activity-logs(생동).
  * 아무 데이터도 없으면(신규 프로젝트 등) 로드맵 자체가 빈 배열 — §9 매트릭스의 calm 빈 상태.
+ * 실 fetch 자체는 `load-glance-data.ts`(module-level dedupe) — 재마운트 레이스 fix 이유는 그쪽 주석.
  */
 export function GlanceBoard({ projectId, className }: GlanceBoardProps) {
   const t = useTranslations('glance');
@@ -57,35 +38,12 @@ export function GlanceBoard({ projectId, className }: GlanceBoardProps) {
     void (async () => {
       setLoading(true);
       try {
-        const [epicsJson, overviewJson, membersJson, activityJson] = await Promise.all([
-          fetchJson(`/api/epics?project_id=${projectId}&limit=100`),
-          fetchJson('/api/dashboard/overview'),
-          fetchJson('/api/team-members'),
-          fetchJson(`/api/activity-logs?project_id=${projectId}&limit=20`),
-        ]);
-
-        const arc = scopeRoadmapEpics(unwrap<BeEpicListItem[]>(epicsJson) ?? []);
-        const overview = unwrap<{ project_status: { epics: EpicProgress[] } }>(overviewJson);
-        const mergedRoadmap = mergeRoadmap(arc.epics, overview?.project_status.epics ?? []);
-
-        const memberRows = unwrap<{ id: string; name: string }[]>(membersJson) ?? [];
-        const memberNames: Record<string, string> = {};
-        for (const m of memberRows) memberNames[m.id] = m.name;
-
-        const storyLists = await Promise.all(
-          mergedRoadmap.map((e) => fetchJson(`/api/stories?epic_id=${e.id}&limit=100`)),
-        );
-        const stories = storyLists.flatMap((s) => unwrap<BeStoryListItem[]>(s) ?? []);
-        const collab = deriveCollaboration(mergedRoadmap.map((e) => e.id), stories, memberNames);
-
-        const activityItems = unwrap<BeActivityLogItem[]>(activityJson) ?? [];
-        const milestoneEvents = filterMilestoneEvents(activityItems);
-
+        const data = await loadGlanceData(projectId);
         if (!cancelled) {
-          setRoadmap(mergedRoadmap);
-          setTotalEpicCount(arc.totalCount);
-          setCollaboration(collab);
-          setEvents(milestoneEvents);
+          setRoadmap(data.roadmap);
+          setTotalEpicCount(data.totalEpicCount);
+          setCollaboration(data.collaboration);
+          setEvents(data.events);
           setLoadedAt(Date.now());
         }
       } finally {

--- a/apps/web/src/components/glance/load-glance-data.test.ts
+++ b/apps/web/src/components/glance/load-glance-data.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadGlanceData } from './load-glance-data';
+
+function jsonResponse(data: unknown): Response {
+  return { ok: true, json: async () => ({ data }) } as Response;
+}
+
+function mockEmptyFetch() {
+  return vi.fn(async (url: string) => {
+    if (url.startsWith('/api/epics')) return jsonResponse([]);
+    if (url.startsWith('/api/dashboard/overview')) return jsonResponse({ project_status: { epics: [] } });
+    if (url.startsWith('/api/team-members')) return jsonResponse([]);
+    if (url.startsWith('/api/activity-logs')) return jsonResponse([]);
+    return jsonResponse([]);
+  });
+}
+
+describe('loadGlanceData (module-level in-flight dedupe — 재마운트 커밋-취소 레이스 fix)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockEmptyFetch());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('shares a single in-flight promise across two concurrent calls for the same projectId (remount-safe dedupe)', async () => {
+    const p1 = loadGlanceData('proj-a');
+    const p2 = loadGlanceData('proj-a');
+    expect(p1).toBe(p2); // same promise object — a remounted instance awaits the SAME in-flight work
+    await Promise.all([p1, p2]);
+    // 4 base endpoints, called once total (not once per caller) — dedupe confirmed.
+    expect(vi.mocked(fetch).mock.calls.length).toBe(4);
+  });
+
+  it('resolves both callers with the same data once the shared fetch settles', async () => {
+    const [a, b] = await Promise.all([loadGlanceData('proj-b'), loadGlanceData('proj-b')]);
+    expect(a).toEqual({ roadmap: [], totalEpicCount: 0, collaboration: [], events: [] });
+    expect(b).toEqual(a);
+  });
+
+  it('clears the in-flight cache after settling so a later call triggers a fresh fetch (no permanent stale cache)', async () => {
+    await loadGlanceData('proj-c');
+    expect(vi.mocked(fetch).mock.calls.length).toBe(4);
+    await loadGlanceData('proj-c');
+    expect(vi.mocked(fetch).mock.calls.length).toBe(8); // second cycle re-fetched, not reused
+  });
+
+  it('does not share in-flight work across different projectIds', async () => {
+    const p1 = loadGlanceData('proj-d');
+    const p2 = loadGlanceData('proj-e');
+    expect(p1).not.toBe(p2);
+    await Promise.all([p1, p2]);
+    expect(vi.mocked(fetch).mock.calls.length).toBe(8);
+  });
+});

--- a/apps/web/src/components/glance/load-glance-data.ts
+++ b/apps/web/src/components/glance/load-glance-data.ts
@@ -1,0 +1,81 @@
+import type { EpicProgress } from '@/components/dashboard/command-center/types';
+import {
+  deriveCollaboration,
+  mergeRoadmap,
+  filterMilestoneEvents,
+  scopeRoadmapEpics,
+  type BeActivityLogItem,
+  type BeEpicListItem,
+  type BeStoryListItem,
+  type EpicCollaboration,
+  type RoadmapEpic,
+} from '@/services/glance';
+
+export interface GlanceData {
+  roadmap: RoadmapEpic[];
+  totalEpicCount: number;
+  collaboration: EpicCollaboration[];
+  events: BeActivityLogItem[];
+}
+
+function unwrap<T>(json: unknown): T | null {
+  if (!json || typeof json !== 'object') return null;
+  const d = (json as { data?: unknown }).data;
+  return (d ?? json) as T;
+}
+
+async function fetchJson(url: string): Promise<unknown> {
+  return fetch(url).then((r) => (r.ok ? r.json() : null)).catch(() => null);
+}
+
+/**
+ * 라이브 픽셀(2026-07-11)로 실측된 커밋-취소 레이스 fix — `/glance` 진입 직후 `useProjectSsot`의
+ * URL `?p=` 정규화(router.replace)가 GlanceBoard를 재마운트시켜, 진행 중이던 fetch 체인이
+ * "완주는 했지만 그 인스턴스의 cancelled 플래그가 이미 true"인 채로 끝나 영구 빈 화면이 됐다
+ * (#2030의 "fan-out 100→8로 좁히면 레이스 소멸" 전제는 틀림 — fan-out 크기가 아니라 effect
+ * cleanup이 로드 중 발동하는 구조 자체가 원인).
+ *
+ * 근본 fix: fetch 자체를 컴포넌트 인스턴스 밖(module-level in-flight map)으로 옮겨 dedupe한다.
+ * 재마운트로 구 인스턴스가 취소돼도, 같은 projectId를 요청한 새 인스턴스가 **동일 in-flight
+ * promise**를 그대로 이어받아 기다리므로 그 인스턴스의 커밋은 막히지 않는다(재마운트가 몇 차례
+ * 일어나도 마지막으로 살아남은 인스턴스가 반드시 결과를 받는다). 완료 시 map에서 제거해 이후
+ * 진짜 재로드(다른 projectId 등)는 새 fetch로 이어진다 — 무기한 캐시 아님.
+ */
+const inFlightByProject = new Map<string, Promise<GlanceData>>();
+
+async function fetchGlanceData(projectId: string): Promise<GlanceData> {
+  const [epicsJson, overviewJson, membersJson, activityJson] = await Promise.all([
+    fetchJson(`/api/epics?project_id=${projectId}&limit=100`),
+    fetchJson('/api/dashboard/overview'),
+    fetchJson('/api/team-members'),
+    fetchJson(`/api/activity-logs?project_id=${projectId}&limit=20`),
+  ]);
+
+  const arc = scopeRoadmapEpics(unwrap<BeEpicListItem[]>(epicsJson) ?? []);
+  const overview = unwrap<{ project_status: { epics: EpicProgress[] } }>(overviewJson);
+  const roadmap = mergeRoadmap(arc.epics, overview?.project_status.epics ?? []);
+
+  const memberRows = unwrap<{ id: string; name: string }[]>(membersJson) ?? [];
+  const memberNames: Record<string, string> = {};
+  for (const m of memberRows) memberNames[m.id] = m.name;
+
+  const storyLists = await Promise.all(roadmap.map((e) => fetchJson(`/api/stories?epic_id=${e.id}&limit=100`)));
+  const stories = storyLists.flatMap((s) => unwrap<BeStoryListItem[]>(s) ?? []);
+  const collaboration = deriveCollaboration(roadmap.map((e) => e.id), stories, memberNames);
+
+  const activityItems = unwrap<BeActivityLogItem[]>(activityJson) ?? [];
+  const events = filterMilestoneEvents(activityItems);
+
+  return { roadmap, totalEpicCount: arc.totalCount, collaboration, events };
+}
+
+export function loadGlanceData(projectId: string): Promise<GlanceData> {
+  const existing = inFlightByProject.get(projectId);
+  if (existing) return existing;
+
+  const promise = fetchGlanceData(projectId).finally(() => {
+    inFlightByProject.delete(projectId);
+  });
+  inFlightByProject.set(projectId, promise);
+  return promise;
+}

--- a/apps/web/src/services/glance.test.ts
+++ b/apps/web/src/services/glance.test.ts
@@ -74,6 +74,20 @@ describe('scopeRoadmapEpics ("현재 궤적" window — 유나 서사 확定(b),
     expect(arc.epics.map((e) => e.id)).toEqual(['a', 'b']);
     expect(arc.totalCount).toBe(2);
   });
+
+  it('biases the bound cutoff toward the newest epics, not the oldest, when the active cluster itself is wider than bound (라이브 픽셀 2026-07-11 적출 — 200에픽/active44 실 데이터에서 old8개만 잡히던 버그)', () => {
+    // 100 epics ascending by created_at: idx 0-29 done, idx 30-99 active (mirrors the real
+    // project's "org never closes epics" shape reported live — active spans most of the array).
+    const epics = [
+      ...Array.from({ length: 30 }, (_, i) => epicAt(`d${i}`, 'done', i)),
+      ...Array.from({ length: 70 }, (_, i) => epicAt(`a${30 + i}`, 'active', 30 + i)),
+    ];
+    const arc = scopeRoadmapEpics(epics, { behind: 2, ahead: 2, bound: 8 });
+    // Old (buggy) behavior would take the OLDEST 8 of the [28,100) window → 'd28','d29','a30'..'a35'.
+    // Fixed behavior takes the NEWEST 8 — the tail closest to "now"/forward.
+    expect(arc.epics.map((e) => e.id)).toEqual(['a92', 'a93', 'a94', 'a95', 'a96', 'a97', 'a98', 'a99']);
+    expect(arc.totalCount).toBe(100);
+  });
 });
 
 describe('mergeRoadmap (epic 목록 순서 SSOT + 별도 진척 엔드포인트 병합)', () => {

--- a/apps/web/src/services/glance.ts
+++ b/apps/web/src/services/glance.ts
@@ -75,8 +75,12 @@ export function scopeRoadmapEpics(
     end = Math.min(asc.length, anchor + 1 + window.ahead);
   }
 
-  let windowed = asc.slice(start, end);
-  if (windowed.length > window.bound) windowed = windowed.slice(0, window.bound);
+  // 라이브 픽셀(2026-07-11) 적출 — active 클러스터가 넓게 퍼지면(behind~ahead 폭이 bound를
+  // 초과) 무조건 slice(0, bound)로 잘라내던 게 "가장 오래된 bound개"(대부분 done/archived)만
+  // 취해버려 "현재 궤적" 서사가 깨졌다. 잘라낼 땐 항상 뒤쪽(최신·anchor+ahead 방향)을 우선
+  // 남긴다 — "지금부터"(forward) 프레이밍과 정합.
+  if (end - start > window.bound) start = end - window.bound;
+  const windowed = asc.slice(start, end);
   return { epics: windowed, totalCount: asc.length };
 }
 


### PR DESCRIPTION
## 요약
PO 라이브 픽셀(puppeteer) 실측 리포트 기반 — #2030("fan-out 100→8로 좁히면 레이스 소멸") 머지·배포 후에도 `/glance`가 여전히 "아직 로드맵이 없습니다" 빈 화면인 문제의 근본 fix.

## 근본 원인 (fan-out 크기 아님)
`useProjectSsot`의 URL `?p=` 정규화(`router.replace`)가 `GlanceBoard`를 로드 중 재마운트시킨다 — fetch 체인은 완주하지만, 그 인스턴스의 `cancelled` 플래그가 이미 `true`가 된 채라 커밋(`setRoadmap` 등)이 영구 스킵된다. #2030의 전제(fan-out 크기 문제)는 틀렸다 — 구조적 문제(effect cleanup이 로드 중 발동)였다.

## 변경사항
### 근본 fix — 재마운트 레이스
- `components/glance/load-glance-data.ts`(신규) — 인라인 fetch 로직을 module-level in-flight promise map으로 dedupe. 재마운트로 구 인스턴스가 취소돼도, 같은 projectId를 요청한 새 인스턴스가 **동일 in-flight promise**를 이어받아 기다리므로 커밋이 막히지 않는다. 완료 시 map에서 제거(무기한 캐시 아님, 진짜 재로드는 새 fetch).
- `components/glance/glance-board.tsx` — 인라인 fetch 로직 제거, `loadGlanceData()` 호출로 교체.

### 부차 fix — bound 절단 방향
- `services/glance.ts` `scopeRoadmapEpics` — active 클러스터가 넓게 퍼지면(behind~ahead 폭 > bound) 무조건 `slice(0, bound)`로 잘라 "가장 오래된 bound개"만 취하던 버그. 뒤쪽(최신·anchor+ahead 방향)을 우선 남기도록 수정 — "지금부터"(forward) 프레이밍과 정합. 라이브 데이터(active 44개가 넓게 퍼진 상태)에서 실측된 문제.

## 검증
- `pnpm vitest run` — 195 files / 1124 passed (2 pre-existing skip)
- `pnpm lint` — 0 errors
- `pnpm build` — exit 0
- 신규 테스트: `load-glance-data` dedupe/재사용/캐시-클리어 4건, `scopeRoadmapEpics` 최신-편향 1건(active 44개 넓게 퍼진 100-에픽 실 시나리오 재현)

## 잔여
- **AC1(라이브 픽셀)은 dev 배포 후 검증 필요** — 이 PR은 단위 테스트로 레이스 로직을 재현했지만, 실제 브라우저의 재마운트 타이밍은 dev 배포 후 puppeteer로 최종 확인해야 함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)