### PR TITLE
[E-GLANCE] 로드맵 blank 재발 2차 — 해소된 데이터 module-level 캐시

### DIFF
--- a/apps/web/src/components/glance/glance-board.tsx
+++ b/apps/web/src/components/glance/glance-board.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from 'next-intl';
 import { Loader2 } from 'lucide-react';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import type { BeActivityLogItem, EpicCollaboration, RoadmapEpic } from '@/services/glance';
-import { loadGlanceData } from './load-glance-data';
+import { getCachedGlanceData, loadGlanceData, type GlanceData } from './load-glance-data';
 import { RoadmapFlow } from './roadmap-flow';
 import { ProgressTrajectory } from './progress-trajectory';
 import { CollaborationMap } from './collaboration-map';
@@ -23,29 +23,57 @@ interface GlanceBoardProps {
  * 아무 데이터도 없으면(신규 프로젝트 등) 로드맵 자체가 빈 배열 — §9 매트릭스의 calm 빈 상태.
  * 실 fetch 자체는 `load-glance-data.ts`(module-level dedupe) — 재마운트 레이스 fix 이유는 그쪽 주석.
  */
+function applyGlanceData(
+  data: GlanceData,
+  setRoadmap: (v: RoadmapEpic[]) => void,
+  setTotalEpicCount: (v: number) => void,
+  setCollaboration: (v: EpicCollaboration[]) => void,
+  setEvents: (v: BeActivityLogItem[]) => void,
+  setLoadedAt: (v: number) => void,
+) {
+  setRoadmap(data.roadmap);
+  setTotalEpicCount(data.totalEpicCount);
+  setCollaboration(data.collaboration);
+  setEvents(data.events);
+  setLoadedAt(Date.now());
+}
+
 export function GlanceBoard({ projectId, className }: GlanceBoardProps) {
   const t = useTranslations('glance');
-  const [roadmap, setRoadmap] = useState<RoadmapEpic[]>([]);
-  const [totalEpicCount, setTotalEpicCount] = useState(0);
-  const [collaboration, setCollaboration] = useState<EpicCollaboration[]>([]);
-  const [events, setEvents] = useState<BeActivityLogItem[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [loadedAt, setLoadedAt] = useState(0);
+  // 마운트 시 동기 캐시 읽기 — 재마운트 레이스 근본 fix(#2053 2차, load-glance-data.ts 주석 참고).
+  // useState 초기값은 첫 렌더에서만 쓰이므로, 재마운트된 새 인스턴스마다 새로 평가돼 그 시점의
+  // 캐시를 반영한다(await 없이 즉시 커밋 — 취소될 여지 자체가 없다).
+  const initial = getCachedGlanceData(projectId);
+  const [roadmap, setRoadmap] = useState<RoadmapEpic[]>(initial?.roadmap ?? []);
+  const [totalEpicCount, setTotalEpicCount] = useState(initial?.totalEpicCount ?? 0);
+  const [collaboration, setCollaboration] = useState<EpicCollaboration[]>(initial?.collaboration ?? []);
+  const [events, setEvents] = useState<BeActivityLogItem[]>(initial?.events ?? []);
+  const [loading, setLoading] = useState(!initial);
+  const [loadedAt, setLoadedAt] = useState(initial ? Date.now() : 0);
 
   useEffect(() => {
     if (!projectId) return;
+    // projectId가 바뀐 기존 인스턴스(재마운트 아님)도 새 프로젝트의 캐시를 즉시 반영 — 없으면
+    // 로딩으로 리셋(이전 프로젝트 데이터가 새 프로젝트인 척 잔존하지 않도록).
+    const cachedNow = getCachedGlanceData(projectId);
+    if (cachedNow) {
+      applyGlanceData(cachedNow, setRoadmap, setTotalEpicCount, setCollaboration, setEvents, setLoadedAt);
+      setLoading(false);
+    } else {
+      setRoadmap([]);
+      setTotalEpicCount(0);
+      setCollaboration([]);
+      setEvents([]);
+      setLoading(true);
+    }
+
     let cancelled = false;
     void (async () => {
-      setLoading(true);
       try {
         const data = await loadGlanceData(projectId);
-        if (!cancelled) {
-          setRoadmap(data.roadmap);
-          setTotalEpicCount(data.totalEpicCount);
-          setCollaboration(data.collaboration);
-          setEvents(data.events);
-          setLoadedAt(Date.now());
-        }
+        // 이 인스턴스가 살아있으면 즉시 반영(최신 데이터로 갱신) — 죽었어도 load-glance-data.ts가
+        // 이미 캐시에 써놨으므로 다음 마운트가 동기 읽기로 성공한다(위 주석 핵심).
+        if (!cancelled) applyGlanceData(data, setRoadmap, setTotalEpicCount, setCollaboration, setEvents, setLoadedAt);
       } finally {
         if (!cancelled) setLoading(false);
       }

--- a/apps/web/src/components/glance/load-glance-data.test.ts
+++ b/apps/web/src/components/glance/load-glance-data.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { loadGlanceData } from './load-glance-data';
+import { getCachedGlanceData, loadGlanceData } from './load-glance-data';
 
 function jsonResponse(data: unknown): Response {
   return { ok: true, json: async () => ({ data }) } as Response;
@@ -51,5 +51,39 @@ describe('loadGlanceData (module-level in-flight dedupe — 재마운트 커밋-
     expect(p1).not.toBe(p2);
     await Promise.all([p1, p2]);
     expect(vi.mocked(fetch).mock.calls.length).toBe(8);
+  });
+});
+
+describe('getCachedGlanceData (해소된 데이터 module-level 캐시 — 2차 근본 fix, dedup만으론 부족했음)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockEmptyFetch());
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns null before any load has ever settled for a projectId', () => {
+    expect(getCachedGlanceData('proj-never-loaded')).toBeNull();
+  });
+
+  it('is populated unconditionally once loadGlanceData settles — this is what makes a remounted instance able to read data synchronously without ever awaiting', async () => {
+    expect(getCachedGlanceData('proj-f')).toBeNull();
+    await loadGlanceData('proj-f');
+    expect(getCachedGlanceData('proj-f')).toEqual({ roadmap: [], totalEpicCount: 0, collaboration: [], events: [] });
+  });
+
+  it('keeps the resolved cache after the in-flight entry is cleared (not a short-lived cache tied to the in-flight window)', async () => {
+    await loadGlanceData('proj-g');
+    // in-flight map entry is gone by now (loadGlanceData already resolved), but the resolved cache persists.
+    expect(getCachedGlanceData('proj-g')).not.toBeNull();
+  });
+
+  it('overwrites with the freshest data on a subsequent load rather than accumulating stale copies', async () => {
+    await loadGlanceData('proj-h');
+    const first = getCachedGlanceData('proj-h');
+    await loadGlanceData('proj-h');
+    const second = getCachedGlanceData('proj-h');
+    expect(second).toEqual(first); // same shape (mock always returns empty) but a fresh object from the 2nd fetch
+    expect(vi.mocked(fetch).mock.calls.length).toBe(8); // confirms a real 2nd fetch happened, not a cache short-circuit
   });
 });

--- a/apps/web/src/components/glance/load-glance-data.ts
+++ b/apps/web/src/components/glance/load-glance-data.ts
@@ -29,19 +29,27 @@ async function fetchJson(url: string): Promise<unknown> {
 }
 
 /**
- * 라이브 픽셀(2026-07-11)로 실측된 커밋-취소 레이스 fix — `/glance` 진입 직후 `useProjectSsot`의
- * URL `?p=` 정규화(router.replace)가 GlanceBoard를 재마운트시켜, 진행 중이던 fetch 체인이
- * "완주는 했지만 그 인스턴스의 cancelled 플래그가 이미 true"인 채로 끝나 영구 빈 화면이 됐다
- * (#2030의 "fan-out 100→8로 좁히면 레이스 소멸" 전제는 틀림 — fan-out 크기가 아니라 effect
- * cleanup이 로드 중 발동하는 구조 자체가 원인).
+ * #2053 in-flight dedup(2026-07-11 1차)만으로는 부족했다 — 오르테가 라이브 재검증(puppeteer)이
+ * dedup은 실제로 작동함(epic fetch 1회만)을 확인했는데도 여전히 빈 화면이었다. **핵심 통찰(오르테가
+ * 진단)**: promise를 공유해도 그걸 `await`하는 지점은 여전히 컴포넌트 effect 안이라 그 인스턴스의
+ * `cancelled`에 걸린다 — 재마운트가 반복되면(원인은 `useProjectSsot`의 router.replace뿐 아니라
+ * 다른 remount 트리거도 있는 것으로 실측됨, 순수 reload에도 재현) 어느 인스턴스도 살아있는 채로
+ * await을 끝내지 못해 영구 스킵될 수 있다. **await 경계가 취소 가능한 한 이 레이스는 안 죽는다.**
  *
- * 근본 fix: fetch 자체를 컴포넌트 인스턴스 밖(module-level in-flight map)으로 옮겨 dedupe한다.
- * 재마운트로 구 인스턴스가 취소돼도, 같은 projectId를 요청한 새 인스턴스가 **동일 in-flight
- * promise**를 그대로 이어받아 기다리므로 그 인스턴스의 커밋은 막히지 않는다(재마운트가 몇 차례
- * 일어나도 마지막으로 살아남은 인스턴스가 반드시 결과를 받는다). 완료 시 map에서 제거해 이후
- * 진짜 재로드(다른 projectId 등)는 새 fetch로 이어진다 — 무기한 캐시 아님.
+ * 근본 fix(2차): 해소된 데이터를 module-level 캐시에 **컴포넌트 생존 여부와 무관하게 무조건** 쓴다
+ * (`.then()`이 `cancelled`를 확인하지 않음 — fetch 자체가 컴포넌트 라이프사이클 밖에 있으므로).
+ * `GlanceBoard`는 마운트 시 이 캐시를 **동기적으로**(useState 초기값) 읽어 렌더한다 — await을
+ * 전혀 거치지 않으므로 취소될 여지 자체가 없다. 마지막까지 살아남은 인스턴스가 마운트되는 시점에
+ * 이미 캐시가 있으면(직전 인스턴스가 fetch를 진행시켜 놨을 것이므로 거의 항상 있음) 그 즉시 렌더.
+ * 없으면(최초 로드) 종전처럼 async fetch → 그 fetch가 뭘 하든 완료 즉시 캐시에 쓰이므로, 설령 그
+ * 인스턴스가 취소돼도 캐시는 남고 **다음(몇 번째든) 마운트가 동기 읽기로 즉시 성공**한다.
  */
 const inFlightByProject = new Map<string, Promise<GlanceData>>();
+const resolvedCacheByProject = new Map<string, GlanceData>();
+
+export function getCachedGlanceData(projectId: string): GlanceData | null {
+  return resolvedCacheByProject.get(projectId) ?? null;
+}
 
 async function fetchGlanceData(projectId: string): Promise<GlanceData> {
   const [epicsJson, overviewJson, membersJson, activityJson] = await Promise.all([
@@ -73,9 +81,15 @@ export function loadGlanceData(projectId: string): Promise<GlanceData> {
   const existing = inFlightByProject.get(projectId);
   if (existing) return existing;
 
-  const promise = fetchGlanceData(projectId).finally(() => {
-    inFlightByProject.delete(projectId);
-  });
+  const promise = fetchGlanceData(projectId)
+    .then((data) => {
+      // 컴포넌트 생존 여부와 무관하게 무조건 캐시(재마운트 레이스의 핵심 fix — 위 주석).
+      resolvedCacheByProject.set(projectId, data);
+      return data;
+    })
+    .finally(() => {
+      inFlightByProject.delete(projectId);
+    });
   inFlightByProject.set(projectId, promise);
   return promise;
 }


### PR DESCRIPTION
## 요약
#2053(in-flight promise dedup)이 dev에서 여전히 빈 화면을 낸 것을 오르테가가 puppeteer로 직접 재검증(history.replaceState/fetch 패치 캡처) — dedup 자체는 작동했지만(epic fetch 1회만), **promise를 기다리는 지점 자체가 여전히 컴포넌트 effect 안이라 그 인스턴스의 `cancelled`에 걸려 커밋이 스킵됨**을 확인. 재마운트가 (router.replace 외의 다른 원인으로도, 순수 reload에서도) 반복될 수 있어 "await 경계가 취소 가능한 한 이 레이스는 안 죽는다"는 게 핵심 진단.

## fix (오르테가 지시 방향 ① 채택)
해소된 데이터를 module-level 캐시(`resolvedCacheByProject`)에 **컴포넌트 생존 여부와 무관하게 무조건** 쓴다 — fetch가 컴포넌트 라이프사이클 밖에 있으므로 `.then()`이 `cancelled`를 확인하지 않는다. `GlanceBoard`는 마운트 시 이 캐시를 **동기적으로**(`useState` 초기값)로 읽어 렌더한다 — await을 전혀 거치지 않으므로 취소될 여지가 없다.

재마운트가 몇 번이든, 마지막으로 살아남은 인스턴스가 마운트되는 시점에 캐시가 이미 있으면(직전 인스턴스가 fetch를 진행시켜 놨을 것이므로 거의 항상 있음) 그 즉시 렌더된다. 캐시가 없으면(최초 로드) 종전처럼 async fetch가 진행되고, 완료 즉시 캐시에 쓰이므로 설령 그 인스턴스도 취소돼도 다음 마운트가 동기 읽기로 성공한다. `projectId`가 바뀌는(재마운트 아닌) 케이스도 effect에서 새 프로젝트 캐시를 확인해 즉시 반영(없으면 로딩으로 리셋).

## 검증
- `pnpm vitest run` — 195 files / 1128 passed (2 pre-existing skip)
- `pnpm lint` — 0 errors
- `pnpm build` — exit 0
- 신규 테스트: `getCachedGlanceData` populate/persist/overwrite 4건

## ⚠️ 이 PR은 CI green만으로 done 아님
오르테가 지시대로, dev 배포 후 **내가 직접 puppeteer로 `/glance` 로드맵 실렌더를 확인**한 뒤에만 story를 in-review로 올린다. #2053이 CI green으로 머지됐지만 라이브에서 깨졌던 재발을 막기 위함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)