### PR TITLE
[E-GLANCE] 로드맵 blank 재발 3차 — useProjectSsot 하이드레이션 divergence 근본 fix

### DIFF
--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, useCallback, useEffect, useMemo } from 'react';
+import { createContext, useContext, useCallback, useEffect, useMemo, useState, startTransition } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import {
   TAB_PROJECT_STORAGE_KEY,
@@ -110,7 +110,17 @@ function useProjectSsot(serverProjectId: string | undefined, memberships: Dashbo
   const urlProjectId = searchParams.get('p');
 
   const accessibleIds = useMemo(() => new Set(memberships.map((m) => m.projectId)), [memberships]);
-  const effectiveProjectId = resolveEffectiveProjectId(urlProjectId, serverProjectId, accessibleIds);
+
+  // 라이브 재현(2026-07-11, React fiber 실측) — sessionStorage(브라우저 전용)는 `typeof window`
+  // 가드로만 갈리면 SSR(undefined→skip)과 첫 클라이언트 렌더(defined→읽음) 사이에서
+  // effectiveProjectId 값이 바뀔 수 있다. 그 값이 서버 렌더 결과와 다르면 하이드레이션 직후
+  // useEffect가 즉시 다른 URL로 replace를 걸어 자식(GlanceBoard 등) subtree를 다시 흔든다.
+  // hydrated로 한 틱 미뤄 첫 렌더(서버+첫 클라이언트 둘 다)를 항상 동일하게 만들면 이 잦은
+  // 재-replace 근원 하나가 사라진다 — router.replace 자체(2번째 소스)는 여전히 필요하면 실행.
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => { startTransition(() => setHydrated(true)); }, []);
+
+  const effectiveProjectId = resolveEffectiveProjectId(urlProjectId, serverProjectId, accessibleIds, hydrated);
 
   // ref 동기화 + 인터셉터 설치를 **렌더 단계**에서 — effect(자식→부모 순)에 두면 부모(DashboardShell)
   // 설치 effect 가 자식(app-sidebar·use-team-presence·kanban-board) 초기 fetch *후* 실행돼 첫 로드

--- a/apps/web/src/components/glance/glance-board.tsx
+++ b/apps/web/src/components/glance/glance-board.tsx
@@ -74,6 +74,9 @@ export function GlanceBoard({ projectId, className }: GlanceBoardProps) {
         // 이 인스턴스가 살아있으면 즉시 반영(최신 데이터로 갱신) — 죽었어도 load-glance-data.ts가
         // 이미 캐시에 써놨으므로 다음 마운트가 동기 읽기로 성공한다(위 주석 핵심).
         if (!cancelled) applyGlanceData(data, setRoadmap, setTotalEpicCount, setCollaboration, setEvents, setLoadedAt);
+      } catch {
+        // epics fetch 실패(load-glance-data.ts 참고) — 캐시에 안 쓰였으니 다음 마운트/재시도가
+        // 유령 빈 결과 대신 fresh fetch를 다시 시도한다. 이 인스턴스는 조용히 빈 상태로 유지.
       } finally {
         if (!cancelled) setLoading(false);
       }

--- a/apps/web/src/components/glance/load-glance-data.test.ts
+++ b/apps/web/src/components/glance/load-glance-data.test.ts
@@ -86,4 +86,32 @@ describe('getCachedGlanceData (해소된 데이터 module-level 캐시 — 2차 
     expect(second).toEqual(first); // same shape (mock always returns empty) but a fresh object from the 2nd fetch
     expect(vi.mocked(fetch).mock.calls.length).toBe(8); // confirms a real 2nd fetch happened, not a cache short-circuit
   });
+
+  function mockFetchWithEpicsFailure(epicsShouldFail: () => boolean) {
+    return vi.fn(async (url: string) => {
+      if (url.startsWith('/api/epics')) {
+        if (epicsShouldFail()) return { ok: false, json: async () => ({}) } as Response;
+        return jsonResponse([]);
+      }
+      if (url.startsWith('/api/dashboard/overview')) return jsonResponse({ project_status: { epics: [] } });
+      return jsonResponse([]);
+    });
+  }
+
+  it('never caches a result when the epics fetch itself failed (라이브 재현 — 실패를 "에픽 0개"로 오인해 캐시 오염하던 버그)', async () => {
+    vi.stubGlobal('fetch', mockFetchWithEpicsFailure(() => true));
+    await expect(loadGlanceData('proj-i')).rejects.toThrow();
+    expect(getCachedGlanceData('proj-i')).toBeNull();
+  });
+
+  it('lets a retry after an epics failure succeed and populate the cache normally', async () => {
+    let epicsShouldFail = true;
+    vi.stubGlobal('fetch', mockFetchWithEpicsFailure(() => epicsShouldFail));
+    await expect(loadGlanceData('proj-j')).rejects.toThrow();
+    expect(getCachedGlanceData('proj-j')).toBeNull();
+
+    epicsShouldFail = false;
+    await loadGlanceData('proj-j');
+    expect(getCachedGlanceData('proj-j')).not.toBeNull();
+  });
 });

--- a/apps/web/src/components/glance/load-glance-data.ts
+++ b/apps/web/src/components/glance/load-glance-data.ts
@@ -59,7 +59,15 @@ async function fetchGlanceData(projectId: string): Promise<GlanceData> {
     fetchJson(`/api/activity-logs?project_id=${projectId}&limit=20`),
   ]);
 
-  const arc = scopeRoadmapEpics(unwrap<BeEpicListItem[]>(epicsJson) ?? []);
+  // 라이브 재현(2026-07-11, 오르테가 fiber 실측) — epics fetch가 초기 remount/타이밍 창에서
+  // 실패(네트워크/401/헤더 미부착 등)하면 fetchJson이 null로 삼켜 "에픽 0개"와 구분이 안 된다.
+  // 이걸 그대로 캐시하면 이후 모든 동기 읽기가 진짜 데이터 대신 이 유령 빈 결과를 영구히 반환한다
+  // (resolvedCache 오염). epics는 로드맵의 필수 소스라 실패 시 reject해 caller가 재시도하게 한다
+  // (loadGlanceData가 이 경우 캐시하지 않음 — 아래 참고).
+  const epicsRaw = unwrap<BeEpicListItem[]>(epicsJson);
+  if (epicsRaw === null) throw new Error('glance: epics fetch failed');
+
+  const arc = scopeRoadmapEpics(epicsRaw);
   const overview = unwrap<{ project_status: { epics: EpicProgress[] } }>(overviewJson);
   const roadmap = mergeRoadmap(arc.epics, overview?.project_status.epics ?? []);
 

--- a/apps/web/src/lib/project-context-client.test.ts
+++ b/apps/web/src/lib/project-context-client.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { TAB_PROJECT_STORAGE_KEY, resolveEffectiveProjectId } from './project-context-client';
+
+describe('resolveEffectiveProjectId (hydrated 게이팅 — SSR/첫 CSR 렌더 divergence 방지, 2026-07-11 라이브 재현)', () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+  afterEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it('prefers a valid urlProjectId regardless of hydrated state', () => {
+    const accessible = new Set(['p1']);
+    expect(resolveEffectiveProjectId('p1', 'server-id', accessible, false)).toBe('p1');
+    expect(resolveEffectiveProjectId('p1', 'server-id', accessible, true)).toBe('p1');
+  });
+
+  it('ignores sessionStorage when hydrated=false, even if a valid stored value exists (SSR-consistent first render)', () => {
+    window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, 'stored-id');
+    const accessible = new Set(['stored-id', 'server-id']);
+    expect(resolveEffectiveProjectId(null, 'server-id', accessible, false)).toBe('server-id');
+  });
+
+  it('uses sessionStorage once hydrated=true (backstop restored after the settle tick)', () => {
+    window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, 'stored-id');
+    const accessible = new Set(['stored-id', 'server-id']);
+    expect(resolveEffectiveProjectId(null, 'server-id', accessible, true)).toBe('stored-id');
+  });
+
+  it('defaults hydrated to true when the 4th arg is omitted (backward compatible call sites)', () => {
+    window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, 'stored-id');
+    const accessible = new Set(['stored-id', 'server-id']);
+    expect(resolveEffectiveProjectId(null, 'server-id', accessible)).toBe('stored-id');
+  });
+
+  it('falls back to serverProjectId when neither URL nor an accessible stored value exists', () => {
+    const accessible = new Set(['server-id']);
+    expect(resolveEffectiveProjectId(null, 'server-id', accessible, true)).toBe('server-id');
+  });
+
+  it('rejects an inaccessible stored value even when hydrated', () => {
+    window.sessionStorage.setItem(TAB_PROJECT_STORAGE_KEY, 'not-a-member-project');
+    const accessible = new Set(['server-id']);
+    expect(resolveEffectiveProjectId(null, 'server-id', accessible, true)).toBe('server-id');
+  });
+});

--- a/apps/web/src/lib/project-context-client.ts
+++ b/apps/web/src/lib/project-context-client.ts
@@ -63,14 +63,21 @@ export function installProjectHeaderInterceptor(): void {
 /**
  * 탭 effective project 해소 — 우선순위: URL `?p=` → sessionStorage backstop → 서버 prop(쿠키 유래).
  * 후보가 accessible(`accessibleIds`)일 때만 채택(UX/intent 필터, 보안 아님). 무효면 다음 우선순위.
+ *
+ * `hydrated`(기본 true, 명시적으로 false를 넘길 때만 sessionStorage 무시) — 라이브 재현(2026-07-11)
+ * 대응: sessionStorage는 브라우저 전용이라 SSR(`window` 없음)에선 원천적으로 못 읽는다. 이 함수
+ * 호출부(`useProjectSsot`)가 하이드레이션 완료 전엔 `hydrated=false`를 넘겨, 첫 클라이언트 렌더가
+ * 서버 렌더와 동일한 값(URL/serverProjectId 기준)을 내도록 강제한다 — 안 그러면 SSR과 첫 CSR
+ * 사이에 값이 갈려 하이드레이션 직후 예상 밖 URL 정규화(router.replace)가 발동할 수 있다.
  */
 export function resolveEffectiveProjectId(
   urlProjectId: string | null,
   serverProjectId: string | undefined,
   accessibleIds: ReadonlySet<string>,
+  hydrated = true,
 ): string | undefined {
   if (urlProjectId && accessibleIds.has(urlProjectId)) return urlProjectId;
-  if (typeof window !== 'undefined') {
+  if (hydrated && typeof window !== 'undefined') {
     const stored = window.sessionStorage.getItem(TAB_PROJECT_STORAGE_KEY);
     if (stored && accessibleIds.has(stored)) return stored;
   }


### PR DESCRIPTION
## 요약
#2053(dedup)·#2054(resolvedCache)가 모두 dev 라이브에서 여전히 빈 화면 — 오르테가가 React fiber를 직접 열어 진짜 근본을 소스 레벨에서 확定. **원인은 `GlanceBoard`가 아니라 `dashboard-shell.tsx`의 `useProjectSsot`** — 3번의 시도가 전부 증상 패치였고, 뿌리는 shell이 자식 subtree를 재마운트시키는 것이었다.

## 근본 fix 1 — `useProjectSsot` 하이드레이션 divergence 제거
`resolveEffectiveProjectId`가 sessionStorage(브라우저 전용)를 `typeof window` 가드로만 읽으면, SSR(window 없음→skip)과 첫 클라이언트 렌더(window 있음→읽음) 사이에 값이 갈릴 수 있다 — 서버 렌더와 다른 값이면 하이드레이션 직후 `useEffect`가 즉시 다른 URL로 `router.replace`를 걸어 자식(GlanceBoard 등) subtree를 흔든다.

`hydrated` 플래그(첫 렌더=false→서버와 동일한 값 강제, mount 후 한 틱 뒤 true로 전환)로 이 SSR/CSR 발산을 원천 차단 — sessionStorage backstop 자체는 유지하되 타이밍만 한 틱 늦춘다. lint(`react-hooks/set-state-in-effect`) 정합은 이 코드베이스의 기존 하이드레이션-플래그 관례(`theme-toggle.tsx`의 `startTransition` 패턴)를 그대로 미러.

## 근본 fix 2 — `resolvedCache` 오염 방지 (`load-glance-data.ts`)
epics fetch가 초기 remount/타이밍 창에서 실패(네트워크/401 등)하면 `fetchJson`이 null로 삼켜 "에픽 0개"와 구분이 안 됐다 — 이걸 그대로 캐시하면 이후 모든 동기 읽기가 유령 빈 결과를 영구히 반환(#2054의 실제 라이브 실패 원인 중 하나로 추정). epics는 로드맵의 필수 소스라 실패 시 reject해 caller가 재시도하게 하고, `loadGlanceData`는 이 경우 캐시하지 않는다.

## ⚠️ 전역 영향 범위
`useProjectSsot`는 모든 인증 라우트가 쓰는 전역 SSOT다 — 이 fix는 `/glance`뿐 아니라 다른 페이지에도 영향을 준다. dev 배포 후 나와 오르테가 둘 다 `/glance` 포함 다른 대표 페이지(보드/대시보드)도 회귀 없는지 라이브 픽셀로 확인할 예정.

## 검증
- `pnpm vitest run` — 196 files / 1136 passed (2 pre-existing skip)
- `pnpm lint` — 0 errors
- `pnpm build` — exit 0
- 신규 테스트: `resolveEffectiveProjectId` hydrated 게이팅 6건, epics-실패-캐시오염방지 2건

## ⚠️ CI green ≠ done
오르테가 지시대로, dev 배포 후 **내가 직접 puppeteer로 `/glance` 로드맵 실렌더를 확인**한 뒤에만 story를 in-review로 올린다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)