### PR TITLE
[E-GLANCE] 로드맵 blank 진짜 근본 — activity-logs shape 불일치 크래시 fix

### DIFF
--- a/apps/web/src/components/glance/load-glance-data.test.ts
+++ b/apps/web/src/components/glance/load-glance-data.test.ts
@@ -10,7 +10,10 @@ function mockEmptyFetch() {
     if (url.startsWith('/api/epics')) return jsonResponse([]);
     if (url.startsWith('/api/dashboard/overview')) return jsonResponse({ project_status: { epics: [] } });
     if (url.startsWith('/api/team-members')) return jsonResponse([]);
-    if (url.startsWith('/api/activity-logs')) return jsonResponse([]);
+    // 실 BE shape(activity_logs.py ActivityLogListResponse) — flat 배열 아님. 이 mock이 예전엔
+    // jsonResponse([])(틀린 shape)였고, 그게 바로 fetchGlanceData 크래시(items.filter is not a
+    // function)를 이 테스트 스위트가 못 잡았던 이유다(2026-07-11 grounding).
+    if (url.startsWith('/api/activity-logs')) return jsonResponse({ items: [], total: 0, limit: 20, offset: 0 });
     return jsonResponse([]);
   });
 }
@@ -94,6 +97,7 @@ describe('getCachedGlanceData (해소된 데이터 module-level 캐시 — 2차 
         return jsonResponse([]);
       }
       if (url.startsWith('/api/dashboard/overview')) return jsonResponse({ project_status: { epics: [] } });
+      if (url.startsWith('/api/activity-logs')) return jsonResponse({ items: [], total: 0, limit: 20, offset: 0 });
       return jsonResponse([]);
     });
   }
@@ -113,5 +117,29 @@ describe('getCachedGlanceData (해소된 데이터 module-level 캐시 — 2차 
     epicsShouldFail = false;
     await loadGlanceData('proj-j');
     expect(getCachedGlanceData('proj-j')).not.toBeNull();
+  });
+});
+
+describe('fetchGlanceData activity-logs shape (2026-07-11 실 근본원인 — 5차례 remount fix가 전부 안 먹혔던 진짜 이유)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('does not throw when activity-logs returns the real BE envelope shape {items,total,limit,offset} (not a flat array)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.startsWith('/api/epics')) return jsonResponse([]);
+      if (url.startsWith('/api/dashboard/overview')) return jsonResponse({ project_status: { epics: [] } });
+      if (url.startsWith('/api/team-members')) return jsonResponse([]);
+      if (url.startsWith('/api/activity-logs')) {
+        return jsonResponse({
+          items: [{ id: 'a1', actor_type: 'human', action: 'story.status_changed', entity_type: 'story', entity_title: 'x', created_at: '2026-07-10T00:00:00Z' }],
+          total: 1, limit: 20, offset: 0,
+        });
+      }
+      return jsonResponse([]);
+    }));
+    const data = await loadGlanceData('proj-k');
+    expect(data.events).toHaveLength(1);
+    expect(data.events[0]!.id).toBe('a1');
   });
 });

--- a/apps/web/src/components/glance/load-glance-data.ts
+++ b/apps/web/src/components/glance/load-glance-data.ts
@@ -79,7 +79,13 @@ async function fetchGlanceData(projectId: string): Promise<GlanceData> {
   const stories = storyLists.flatMap((s) => unwrap<BeStoryListItem[]>(s) ?? []);
   const collaboration = deriveCollaboration(roadmap.map((e) => e.id), stories, memberNames);
 
-  const activityItems = unwrap<BeActivityLogItem[]>(activityJson) ?? [];
+  // 실 근본원인(2026-07-11, BE 소스+동작 레퍼런스로 확인) — GET /api/v2/activity-logs는 flat
+  // 배열이 아니라 `ActivityLogListResponse{items,total,limit,offset}`(activity_logs.py:65)를
+  // 반환한다. `.items` 추출 없이 이 wrapper를 배열인 척 filterMilestoneEvents에 넘기면
+  // `items.filter is not a function`으로 **fetchGlanceData 자체가 매번 throw**했다 — 레이스나
+  // 재마운트가 아니라 결정적 크래시였다(#2053~#2055가 전부 안 먹힌 진짜 이유). 같은 엔드포인트를
+  // 쓰는 dashboard-activity-timeline.tsx가 `json.data.items`로 정확히 추출하는 걸 대조해 확인.
+  const activityItems = unwrap<{ items: BeActivityLogItem[] }>(activityJson)?.items ?? [];
   const events = filterMilestoneEvents(activityItems);
 
   return { roadmap, totalEpicCount: arc.totalCount, collaboration, events };


### PR DESCRIPTION
## 요약
#2053(dedup)~#2055(하이드레이션)가 전부 dev 라이브에서 안 먹힌 진짜 이유를 BE 소스 그라운딩으로 확定 — 레이스/재마운트가 아니라 **결정적 크래시**였다.

`GET /api/v2/activity-logs`는 flat 배열이 아니라 `ActivityLogListResponse{items,total,limit,offset}`(`backend/app/routers/activity_logs.py:65`)를 반환하는데, `fetchGlanceData`는 `unwrap<BeActivityLogItem[]>(activityJson) ?? []`로 `.items` 추출 없이 이 wrapper 객체를 배열인 척 `filterMilestoneEvents`에 넘겼다 — `items.filter is not a function`으로 매번 throw. 같은 엔드포인트를 올바르게 쓰는 레퍼런스 컴포넌트(`dashboard-activity-timeline.tsx:93`, `json.data.items`)와 대조해 확인했다. E-GLANCE C1(#2015) 최초 작성 시 이 unwrap 스텝이 빠진 그라운딩 갭으로 추정된다.

## 왜 이게 진짜 근본인지 (오르테가 fiber 실측과 완전히 정합)
- fetch 전부 200(네트워크 정상)인데 컴포넌트는 `roadmap=[]·loading=false` — 처리 단계 크래시를 `catch{}`(글랜스보드의 기존 try/catch)가 조용히 삼킨 것.
- `resolvedCache`에 `.set`이 한 번도 안 잡힌 이유 = `.then(cache.set)` 전에 throw로 죽어서.
- "항상"(플레이키 아님) 빈 화면인 이유 = 레이스가 아니라 결정적 크래시.
- dedup/캐시/하이드레이션 4연속이 다 무의미했던 이유 = 애초에 성공 resolve가 없어서 무슨 레이스 방지책도 소용없었다.

## 4소스 shape 전수 감사
- **epics**: local repo + `apiSuccess(page)` = flat array — 코드 가정과 일치
- **overview**: raw `JSONResponse{project_status,...}` (command_center.py, `_ok()` 미경유) — 일치
- **team-members**: `response_model=list[TeamMemberResponse]` = flat array — 일치
- **stories**: local repo + `apiSuccess(page)` = flat array — 일치
- **activity-logs**: `ActivityLogListResponse{items,...}` — **불일치, 이번에 fix**

## 테스트 mock 자체도 틀린 shape이었던 것
`mockEmptyFetch()`가 activity-logs를 `jsonResponse([])`(틀린 shape)로 mock해서 이 스위트가 처음부터 이 크래시를 못 잡았다 — 실 shape으로 교정 + 비어있지 않은 activity 데이터로 end-to-end 회귀 테스트 신설.

## 검증
- `pnpm vitest run` — 196 files / 1137 passed (2 pre-existing skip)
- `pnpm lint` — 0 errors
- `pnpm build` — exit 0

## ⚠️ CI green ≠ done
배포 후 **내가 직접 puppeteer로 로드맵 실렌더를 확인**한 뒤에만 story를 in-review로 올린다. 되면 #2053/#2054의 dedup/캐시 복잡도는 불필요한 방지책이었던 셈이니 걷어내는 걸 다음 라운드에서 판단(#2055 하이드레이션 fix는 별개의 실 개선이라 유지 예정).

🤖 Generated with [Claude Code](https://claude.com/claude-code)