### PR TITLE
[E-GLANCE] 로드맵 로더 단순화 — 팬텀 레이스 방지책 걷어내기

### DIFF
--- a/apps/web/src/components/glance/glance-board.tsx
+++ b/apps/web/src/components/glance/glance-board.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from 'next-intl';
 import { Loader2 } from 'lucide-react';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import type { BeActivityLogItem, EpicCollaboration, RoadmapEpic } from '@/services/glance';
-import { getCachedGlanceData, loadGlanceData, type GlanceData } from './load-glance-data';
+import { loadGlanceData } from './load-glance-data';
 import { RoadmapFlow } from './roadmap-flow';
 import { ProgressTrajectory } from './progress-trajectory';
 import { CollaborationMap } from './collaboration-map';
@@ -18,65 +18,34 @@ interface GlanceBoardProps {
 
 /**
  * E-GLANCE C1 현황판 오케스트레이터 — 실 fetch, mock 폴백 0. 서브 컴포넌트(RoadmapFlow 등)는
- * 전부 순수 props라 여기서만 §10 데이터 소스 4종을 병합한다: /api/epics(순서 SSOT) ·
- * /api/dashboard/overview(진척) · /api/stories?epic_id=(참여) · /api/activity-logs(생동).
+ * 전부 순수 props라 여기서만 §10 데이터 소스 4종을 병합한다(실 fetch는 `load-glance-data.ts`).
  * 아무 데이터도 없으면(신규 프로젝트 등) 로드맵 자체가 빈 배열 — §9 매트릭스의 calm 빈 상태.
- * 실 fetch 자체는 `load-glance-data.ts`(module-level dedupe) — 재마운트 레이스 fix 이유는 그쪽 주석.
  */
-function applyGlanceData(
-  data: GlanceData,
-  setRoadmap: (v: RoadmapEpic[]) => void,
-  setTotalEpicCount: (v: number) => void,
-  setCollaboration: (v: EpicCollaboration[]) => void,
-  setEvents: (v: BeActivityLogItem[]) => void,
-  setLoadedAt: (v: number) => void,
-) {
-  setRoadmap(data.roadmap);
-  setTotalEpicCount(data.totalEpicCount);
-  setCollaboration(data.collaboration);
-  setEvents(data.events);
-  setLoadedAt(Date.now());
-}
-
 export function GlanceBoard({ projectId, className }: GlanceBoardProps) {
   const t = useTranslations('glance');
-  // 마운트 시 동기 캐시 읽기 — 재마운트 레이스 근본 fix(#2053 2차, load-glance-data.ts 주석 참고).
-  // useState 초기값은 첫 렌더에서만 쓰이므로, 재마운트된 새 인스턴스마다 새로 평가돼 그 시점의
-  // 캐시를 반영한다(await 없이 즉시 커밋 — 취소될 여지 자체가 없다).
-  const initial = getCachedGlanceData(projectId);
-  const [roadmap, setRoadmap] = useState<RoadmapEpic[]>(initial?.roadmap ?? []);
-  const [totalEpicCount, setTotalEpicCount] = useState(initial?.totalEpicCount ?? 0);
-  const [collaboration, setCollaboration] = useState<EpicCollaboration[]>(initial?.collaboration ?? []);
-  const [events, setEvents] = useState<BeActivityLogItem[]>(initial?.events ?? []);
-  const [loading, setLoading] = useState(!initial);
-  const [loadedAt, setLoadedAt] = useState(initial ? Date.now() : 0);
+  const [roadmap, setRoadmap] = useState<RoadmapEpic[]>([]);
+  const [totalEpicCount, setTotalEpicCount] = useState(0);
+  const [collaboration, setCollaboration] = useState<EpicCollaboration[]>([]);
+  const [events, setEvents] = useState<BeActivityLogItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadedAt, setLoadedAt] = useState(0);
 
   useEffect(() => {
     if (!projectId) return;
-    // projectId가 바뀐 기존 인스턴스(재마운트 아님)도 새 프로젝트의 캐시를 즉시 반영 — 없으면
-    // 로딩으로 리셋(이전 프로젝트 데이터가 새 프로젝트인 척 잔존하지 않도록).
-    const cachedNow = getCachedGlanceData(projectId);
-    if (cachedNow) {
-      applyGlanceData(cachedNow, setRoadmap, setTotalEpicCount, setCollaboration, setEvents, setLoadedAt);
-      setLoading(false);
-    } else {
-      setRoadmap([]);
-      setTotalEpicCount(0);
-      setCollaboration([]);
-      setEvents([]);
-      setLoading(true);
-    }
-
     let cancelled = false;
     void (async () => {
+      setLoading(true);
       try {
         const data = await loadGlanceData(projectId);
-        // 이 인스턴스가 살아있으면 즉시 반영(최신 데이터로 갱신) — 죽었어도 load-glance-data.ts가
-        // 이미 캐시에 써놨으므로 다음 마운트가 동기 읽기로 성공한다(위 주석 핵심).
-        if (!cancelled) applyGlanceData(data, setRoadmap, setTotalEpicCount, setCollaboration, setEvents, setLoadedAt);
+        if (!cancelled) {
+          setRoadmap(data.roadmap);
+          setTotalEpicCount(data.totalEpicCount);
+          setCollaboration(data.collaboration);
+          setEvents(data.events);
+          setLoadedAt(Date.now());
+        }
       } catch {
-        // epics fetch 실패(load-glance-data.ts 참고) — 캐시에 안 쓰였으니 다음 마운트/재시도가
-        // 유령 빈 결과 대신 fresh fetch를 다시 시도한다. 이 인스턴스는 조용히 빈 상태로 유지.
+        // epics fetch 실패(load-glance-data.ts 참고) — 조용히 빈 상태로 유지, 크래시시키지 않음.
       } finally {
         if (!cancelled) setLoading(false);
       }

--- a/apps/web/src/components/glance/load-glance-data.test.ts
+++ b/apps/web/src/components/glance/load-glance-data.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getCachedGlanceData, loadGlanceData } from './load-glance-data';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { loadGlanceData } from './load-glance-data';
 
 function jsonResponse(data: unknown): Response {
   return { ok: true, json: async () => ({ data }) } as Response;
@@ -11,121 +11,25 @@ function mockEmptyFetch() {
     if (url.startsWith('/api/dashboard/overview')) return jsonResponse({ project_status: { epics: [] } });
     if (url.startsWith('/api/team-members')) return jsonResponse([]);
     // 실 BE shape(activity_logs.py ActivityLogListResponse) — flat 배열 아님. 이 mock이 예전엔
-    // jsonResponse([])(틀린 shape)였고, 그게 바로 fetchGlanceData 크래시(items.filter is not a
-    // function)를 이 테스트 스위트가 못 잡았던 이유다(2026-07-11 grounding).
+    // jsonResponse([])(틀린 shape)였고, 그게 로드맵 blank의 진짜 근본(items.filter is not a
+    // function)을 이 테스트 스위트가 못 잡았던 이유였다(2026-07-11 grounding).
     if (url.startsWith('/api/activity-logs')) return jsonResponse({ items: [], total: 0, limit: 20, offset: 0 });
     return jsonResponse([]);
   });
 }
 
-describe('loadGlanceData (module-level in-flight dedupe — 재마운트 커밋-취소 레이스 fix)', () => {
-  beforeEach(() => {
+describe('loadGlanceData (§10 데이터 소스 4종 단순 1회 fetch — dedup/캐시는 불필요한 복잡도로 판명돼 걷어냄, c3d1565d)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('resolves an empty-but-valid GlanceData when every source is genuinely empty', async () => {
     vi.stubGlobal('fetch', mockEmptyFetch());
-  });
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it('shares a single in-flight promise across two concurrent calls for the same projectId (remount-safe dedupe)', async () => {
-    const p1 = loadGlanceData('proj-a');
-    const p2 = loadGlanceData('proj-a');
-    expect(p1).toBe(p2); // same promise object — a remounted instance awaits the SAME in-flight work
-    await Promise.all([p1, p2]);
-    // 4 base endpoints, called once total (not once per caller) — dedupe confirmed.
-    expect(vi.mocked(fetch).mock.calls.length).toBe(4);
+    const data = await loadGlanceData('proj-a');
+    expect(data).toEqual({ roadmap: [], totalEpicCount: 0, collaboration: [], events: [] });
   });
 
-  it('resolves both callers with the same data once the shared fetch settles', async () => {
-    const [a, b] = await Promise.all([loadGlanceData('proj-b'), loadGlanceData('proj-b')]);
-    expect(a).toEqual({ roadmap: [], totalEpicCount: 0, collaboration: [], events: [] });
-    expect(b).toEqual(a);
-  });
-
-  it('clears the in-flight cache after settling so a later call triggers a fresh fetch (no permanent stale cache)', async () => {
-    await loadGlanceData('proj-c');
-    expect(vi.mocked(fetch).mock.calls.length).toBe(4);
-    await loadGlanceData('proj-c');
-    expect(vi.mocked(fetch).mock.calls.length).toBe(8); // second cycle re-fetched, not reused
-  });
-
-  it('does not share in-flight work across different projectIds', async () => {
-    const p1 = loadGlanceData('proj-d');
-    const p2 = loadGlanceData('proj-e');
-    expect(p1).not.toBe(p2);
-    await Promise.all([p1, p2]);
-    expect(vi.mocked(fetch).mock.calls.length).toBe(8);
-  });
-});
-
-describe('getCachedGlanceData (해소된 데이터 module-level 캐시 — 2차 근본 fix, dedup만으론 부족했음)', () => {
-  beforeEach(() => {
-    vi.stubGlobal('fetch', mockEmptyFetch());
-  });
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it('returns null before any load has ever settled for a projectId', () => {
-    expect(getCachedGlanceData('proj-never-loaded')).toBeNull();
-  });
-
-  it('is populated unconditionally once loadGlanceData settles — this is what makes a remounted instance able to read data synchronously without ever awaiting', async () => {
-    expect(getCachedGlanceData('proj-f')).toBeNull();
-    await loadGlanceData('proj-f');
-    expect(getCachedGlanceData('proj-f')).toEqual({ roadmap: [], totalEpicCount: 0, collaboration: [], events: [] });
-  });
-
-  it('keeps the resolved cache after the in-flight entry is cleared (not a short-lived cache tied to the in-flight window)', async () => {
-    await loadGlanceData('proj-g');
-    // in-flight map entry is gone by now (loadGlanceData already resolved), but the resolved cache persists.
-    expect(getCachedGlanceData('proj-g')).not.toBeNull();
-  });
-
-  it('overwrites with the freshest data on a subsequent load rather than accumulating stale copies', async () => {
-    await loadGlanceData('proj-h');
-    const first = getCachedGlanceData('proj-h');
-    await loadGlanceData('proj-h');
-    const second = getCachedGlanceData('proj-h');
-    expect(second).toEqual(first); // same shape (mock always returns empty) but a fresh object from the 2nd fetch
-    expect(vi.mocked(fetch).mock.calls.length).toBe(8); // confirms a real 2nd fetch happened, not a cache short-circuit
-  });
-
-  function mockFetchWithEpicsFailure(epicsShouldFail: () => boolean) {
-    return vi.fn(async (url: string) => {
-      if (url.startsWith('/api/epics')) {
-        if (epicsShouldFail()) return { ok: false, json: async () => ({}) } as Response;
-        return jsonResponse([]);
-      }
-      if (url.startsWith('/api/dashboard/overview')) return jsonResponse({ project_status: { epics: [] } });
-      if (url.startsWith('/api/activity-logs')) return jsonResponse({ items: [], total: 0, limit: 20, offset: 0 });
-      return jsonResponse([]);
-    });
-  }
-
-  it('never caches a result when the epics fetch itself failed (라이브 재현 — 실패를 "에픽 0개"로 오인해 캐시 오염하던 버그)', async () => {
-    vi.stubGlobal('fetch', mockFetchWithEpicsFailure(() => true));
-    await expect(loadGlanceData('proj-i')).rejects.toThrow();
-    expect(getCachedGlanceData('proj-i')).toBeNull();
-  });
-
-  it('lets a retry after an epics failure succeed and populate the cache normally', async () => {
-    let epicsShouldFail = true;
-    vi.stubGlobal('fetch', mockFetchWithEpicsFailure(() => epicsShouldFail));
-    await expect(loadGlanceData('proj-j')).rejects.toThrow();
-    expect(getCachedGlanceData('proj-j')).toBeNull();
-
-    epicsShouldFail = false;
-    await loadGlanceData('proj-j');
-    expect(getCachedGlanceData('proj-j')).not.toBeNull();
-  });
-});
-
-describe('fetchGlanceData activity-logs shape (2026-07-11 실 근본원인 — 5차례 remount fix가 전부 안 먹혔던 진짜 이유)', () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it('does not throw when activity-logs returns the real BE envelope shape {items,total,limit,offset} (not a flat array)', async () => {
+  it('does not throw when activity-logs returns the real BE envelope shape {items,total,limit,offset} (not a flat array) — 로드맵 blank 진짜 근본 회귀가드', async () => {
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
       if (url.startsWith('/api/epics')) return jsonResponse([]);
       if (url.startsWith('/api/dashboard/overview')) return jsonResponse({ project_status: { epics: [] } });
@@ -138,8 +42,24 @@ describe('fetchGlanceData activity-logs shape (2026-07-11 실 근본원인 — 5
       }
       return jsonResponse([]);
     }));
-    const data = await loadGlanceData('proj-k');
+    const data = await loadGlanceData('proj-b');
     expect(data.events).toHaveLength(1);
     expect(data.events[0]!.id).toBe('a1');
+  });
+
+  it('rejects when the epics fetch fails (essential source — failure must not be mistaken for "0 epics")', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.startsWith('/api/epics')) return { ok: false, json: async () => ({}) } as Response;
+      if (url.startsWith('/api/activity-logs')) return jsonResponse({ items: [], total: 0, limit: 20, offset: 0 });
+      return jsonResponse([]);
+    }));
+    await expect(loadGlanceData('proj-c')).rejects.toThrow();
+  });
+
+  it('fetches fresh every call (no dedup/memoization — each call issues its own network round trip)', async () => {
+    vi.stubGlobal('fetch', mockEmptyFetch());
+    await loadGlanceData('proj-d');
+    await loadGlanceData('proj-d');
+    expect(vi.mocked(fetch).mock.calls.length).toBe(8); // 4 endpoints × 2 calls
   });
 });

--- a/apps/web/src/components/glance/load-glance-data.ts
+++ b/apps/web/src/components/glance/load-glance-data.ts
@@ -29,29 +29,16 @@ async function fetchJson(url: string): Promise<unknown> {
 }
 
 /**
- * #2053 in-flight dedup(2026-07-11 1차)만으로는 부족했다 — 오르테가 라이브 재검증(puppeteer)이
- * dedup은 실제로 작동함(epic fetch 1회만)을 확인했는데도 여전히 빈 화면이었다. **핵심 통찰(오르테가
- * 진단)**: promise를 공유해도 그걸 `await`하는 지점은 여전히 컴포넌트 effect 안이라 그 인스턴스의
- * `cancelled`에 걸린다 — 재마운트가 반복되면(원인은 `useProjectSsot`의 router.replace뿐 아니라
- * 다른 remount 트리거도 있는 것으로 실측됨, 순수 reload에도 재현) 어느 인스턴스도 살아있는 채로
- * await을 끝내지 못해 영구 스킵될 수 있다. **await 경계가 취소 가능한 한 이 레이스는 안 죽는다.**
- *
- * 근본 fix(2차): 해소된 데이터를 module-level 캐시에 **컴포넌트 생존 여부와 무관하게 무조건** 쓴다
- * (`.then()`이 `cancelled`를 확인하지 않음 — fetch 자체가 컴포넌트 라이프사이클 밖에 있으므로).
- * `GlanceBoard`는 마운트 시 이 캐시를 **동기적으로**(useState 초기값) 읽어 렌더한다 — await을
- * 전혀 거치지 않으므로 취소될 여지 자체가 없다. 마지막까지 살아남은 인스턴스가 마운트되는 시점에
- * 이미 캐시가 있으면(직전 인스턴스가 fetch를 진행시켜 놨을 것이므로 거의 항상 있음) 그 즉시 렌더.
- * 없으면(최초 로드) 종전처럼 async fetch → 그 fetch가 뭘 하든 완료 즉시 캐시에 쓰이므로, 설령 그
- * 인스턴스가 취소돼도 캐시는 남고 **다음(몇 번째든) 마운트가 동기 읽기로 즉시 성공**한다.
+ * E-GLANCE 현황판 데이터 병합 — §10 소스 4종: /api/epics(순서 SSOT) · /api/dashboard/overview
+ * (진척) · /api/stories?epic_id=(참여) · /api/activity-logs(생동). 로드맵 blank 재발(2026-07-11)
+ * 진짜 근본은 이 함수의 activity-logs 처리였다 — `GET /api/v2/activity-logs`는 flat 배열이
+ * 아니라 `ActivityLogListResponse{items,total,limit,offset}`(activity_logs.py:65)를 반환하는데
+ * `.items` 추출 없이 그 wrapper를 배열인 척 넘겨 매번 throw했다(dashboard-activity-timeline.tsx의
+ * `json.data.items`와 대조해 확인). 애초에 재마운트 레이스가 아니라 이 결정적 크래시였던 것으로
+ * 밝혀져, 이전 라운드(in-flight dedup·resolvedCache·동기 마운트 읽기)의 module-level 캐시
+ * 복잡도는 걷어냈다(#c3d1565d, less-is-more) — 단순 1회 fetch로 되돌린다.
  */
-const inFlightByProject = new Map<string, Promise<GlanceData>>();
-const resolvedCacheByProject = new Map<string, GlanceData>();
-
-export function getCachedGlanceData(projectId: string): GlanceData | null {
-  return resolvedCacheByProject.get(projectId) ?? null;
-}
-
-async function fetchGlanceData(projectId: string): Promise<GlanceData> {
+export async function loadGlanceData(projectId: string): Promise<GlanceData> {
   const [epicsJson, overviewJson, membersJson, activityJson] = await Promise.all([
     fetchJson(`/api/epics?project_id=${projectId}&limit=100`),
     fetchJson('/api/dashboard/overview'),
@@ -59,11 +46,8 @@ async function fetchGlanceData(projectId: string): Promise<GlanceData> {
     fetchJson(`/api/activity-logs?project_id=${projectId}&limit=20`),
   ]);
 
-  // 라이브 재현(2026-07-11, 오르테가 fiber 실측) — epics fetch가 초기 remount/타이밍 창에서
-  // 실패(네트워크/401/헤더 미부착 등)하면 fetchJson이 null로 삼켜 "에픽 0개"와 구분이 안 된다.
-  // 이걸 그대로 캐시하면 이후 모든 동기 읽기가 진짜 데이터 대신 이 유령 빈 결과를 영구히 반환한다
-  // (resolvedCache 오염). epics는 로드맵의 필수 소스라 실패 시 reject해 caller가 재시도하게 한다
-  // (loadGlanceData가 이 경우 캐시하지 않음 — 아래 참고).
+  // epics는 로드맵의 필수 소스 — fetch 실패를 "에픽 0개"로 오인하면 정직하지 않은 빈 상태가
+  // 된다(정책 실패 ≠ 실제 empty). 실패 시 throw해 caller(glance-board)가 조용히 빈 상태로 유지.
   const epicsRaw = unwrap<BeEpicListItem[]>(epicsJson);
   if (epicsRaw === null) throw new Error('glance: epics fetch failed');
 
@@ -79,31 +63,9 @@ async function fetchGlanceData(projectId: string): Promise<GlanceData> {
   const stories = storyLists.flatMap((s) => unwrap<BeStoryListItem[]>(s) ?? []);
   const collaboration = deriveCollaboration(roadmap.map((e) => e.id), stories, memberNames);
 
-  // 실 근본원인(2026-07-11, BE 소스+동작 레퍼런스로 확인) — GET /api/v2/activity-logs는 flat
-  // 배열이 아니라 `ActivityLogListResponse{items,total,limit,offset}`(activity_logs.py:65)를
-  // 반환한다. `.items` 추출 없이 이 wrapper를 배열인 척 filterMilestoneEvents에 넘기면
-  // `items.filter is not a function`으로 **fetchGlanceData 자체가 매번 throw**했다 — 레이스나
-  // 재마운트가 아니라 결정적 크래시였다(#2053~#2055가 전부 안 먹힌 진짜 이유). 같은 엔드포인트를
-  // 쓰는 dashboard-activity-timeline.tsx가 `json.data.items`로 정확히 추출하는 걸 대조해 확인.
+  // activity-logs는 flat 배열이 아니라 {items,...} wrapper — 위 함수 doc 참고.
   const activityItems = unwrap<{ items: BeActivityLogItem[] }>(activityJson)?.items ?? [];
   const events = filterMilestoneEvents(activityItems);
 
   return { roadmap, totalEpicCount: arc.totalCount, collaboration, events };
-}
-
-export function loadGlanceData(projectId: string): Promise<GlanceData> {
-  const existing = inFlightByProject.get(projectId);
-  if (existing) return existing;
-
-  const promise = fetchGlanceData(projectId)
-    .then((data) => {
-      // 컴포넌트 생존 여부와 무관하게 무조건 캐시(재마운트 레이스의 핵심 fix — 위 주석).
-      resolvedCacheByProject.set(projectId, data);
-      return data;
-    })
-    .finally(() => {
-      inFlightByProject.delete(projectId);
-    });
-  inFlightByProject.set(projectId, promise);
-  return promise;
 }


### PR DESCRIPTION
## 요약
로드맵 blank의 진짜 근본은 activity-logs 응답 shape 크래시(#2056)였고 재마운트 레이스는 red herring이었음이 확인됨(오르테가 dev 라이브 픽셀 FULL GREEN, story `f916345a` done). #2053(in-flight promise dedup)·#2054(resolvedCache + 동기 마운트 읽기)는 존재하지 않는 레이스를 막으려 넣은 복잡도라 이제 불필요 — less-is-more로 걷어내고 원래 단순 1회 fetch 구조로 되돌린다.

## 변경사항
- `load-glance-data.ts`: `inFlightByProject`/`resolvedCacheByProject`/`getCachedGlanceData` 제거, `fetchGlanceData`를 `loadGlanceData`로 직접 export(dedup/캐시 없는 단순 fetch). activity-logs `.items` 추출(진짜 근본 fix)은 유지. epics 실패 시 throw("실패≠0개", 정직한 빈 상태)도 유지 — 캐시 오염 방지 목적은 사라졌지만 그 자체로 유효한 동작이라 남김.
- `glance-board.tsx`: 동기 캐시 읽기(useState 초기값) + projectId 변경 시 캐시 재확인 로직 제거, 원래의 단순 `cancelled`-guard 패턴으로 복귀.
- `load-glance-data.test.ts`: dedup/캐시 테스트 7건 제거, activity-logs shape 크래시 회귀가드·epics 실패 시 reject·dedup 없음(매 호출 fresh fetch) 확인 테스트로 교체(4건).

#2055(`useProjectSsot` 하이드레이션 fix)는 별개의 실 개선이라 미변경.

## 검증
- `pnpm vitest run` — 196 files / 1130 passed (2 pre-existing skip, -7 불필요 테스트 제거)
- `pnpm lint` — 0 errors
- `pnpm build` — exit 0

## ⚠️ 필수 — dev 픽셀 재확인
되돌린 게 지금 작동 중인 로드맵을 깨지 않았는지 dev 배포 후 **puppeteer로 라이브 픽셀 재확인** 예정(오르테가 명시 조건 — "지금 작동하는 걸 깨지 말 것").

🤖 Generated with [Claude Code](https://claude.com/claude-code)