### PR TITLE
fix(security): SEC HIGH baseline paydown round1 — policy_documents project-scope 가드

### DIFF
--- a/backend/app/routers/policy_documents.py
+++ b/backend/app/routers/policy_documents.py
@@ -1,10 +1,10 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.policy_document import PolicyDocument
 from app.schemas.policy_document import PolicyDocumentResponse
@@ -19,7 +19,16 @@ async def list_policy_documents(
     q: str | None = Query(default=None),
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[PolicyDocumentResponse]:
+    # E-SECURITY SEC HIGH paydown round1(#2050 ratchet baseline 상환): org_id는 검증하나
+    # caller의 project_id 접근권 검증이 없어 같은 org 다른 project의 정책문서 본문(content)까지
+    # ILIKE 검색으로 노출됐다(오늘 R~EE와 동형 근본). resource-actual project_id(쿼리파라미터
+    # 자체가 조회 대상이라 body-claimed 개념 없음 — 직접 검증).
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+
     stmt = select(PolicyDocument).where(
         PolicyDocument.org_id == org_id,
         PolicyDocument.project_id == project_id,

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -145,8 +145,6 @@ _KNOWN_DEBT_ALLOWLIST: dict[str, str] = {
         "HIGH — org-scope만·project_id 필터에 접근권 검증 없음(리워드 원장 노출)",
     "app.routers.members:list_members":
         "HIGH — assert_target_in_caller_org가 cross-org만 막고 same-org cross-project는 미검증",
-    "app.routers.policy_documents:list_policy_documents":
-        "HIGH — org-scope만·project_id로 정책문서 content ILIKE 검색에 접근권 검증 없음",
     "app.routers.hypotheses:link_hypothesis":
         "MEDIUM — service._assert_targets_same_project가 sprint/epic/story 주입은 막지만 caller의 hyp.project_id 접근권 자체는 미검증",
     "app.routers.participation:add_participation":

--- a/backend/tests/test_e_security_sec_s8_ratchet_round1_policy_documents_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_ratchet_round1_policy_documents_realdb.py
@@ -1,0 +1,215 @@
+"""E-SECURITY SEC HIGH baseline paydown round1(story 8c29e926) — #2050 ratchet
+_KNOWN_DEBT_ALLOWLIST HIGH 11건 중 policy_documents.list_policy_documents 상환.
+
+근본: org_id/project_id 필터는 있으나 caller의 project 접근권(has_project_access) 검증이
+0이라, 같은 org 내 접근권 없는 project의 정책문서(content ILIKE 전문검색 포함)까지 노출됐다.
+project_id는 쿼리파라미터 자체가 조회 대상이라 body-claimed-vs-resource-actual 분기 없이
+직접 has_project_access(session, user_id, project_id, org_id) 검증으로 봉인."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a, project_b) + policy_document_a(project_a, content="SECRET POLICY A") +
+    human_a(project_a에만 명시 grant, project_b 접근권 없음)."""
+    from app.models.organization import Organization
+    from app.models.pm import Epic, Sprint
+    from app.models.policy_document import PolicyDocument
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    sprint_a = Sprint(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Sprint A")
+    epic_a = Epic(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Epic A")
+    session.add_all([sprint_a, epic_a])
+    await session.commit()
+
+    doc_a = PolicyDocument(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_a.id,
+        sprint_id=sprint_a.id, epic_id=epic_a.id,
+        title="Policy A", content="SECRET POLICY A",
+    )
+    session.add(doc_a)
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"human-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    # project_a에만 명시 grant — project_b 접근권 없음(org owner/admin도 아님).
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "doc_a_id": doc_a.id, "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_project_a_human_can_list_own_project_policy_documents():
+    """회귀 0: project_a grant 보유 휴먼은 project_a 정책문서 정상 조회(200)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/policy-documents?project_id={seeded['project_a_id']}")
+            assert resp.status_code == 200, resp.text
+            ids = {item["id"] for item in resp.json()}
+            assert str(seeded["doc_a_id"]) in ids
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_grant_human_cannot_list_other_project_policy_documents():
+    """봉인 실증: project_a에만 grant된 휴먼이 project_b 정책문서(content="SECRET POLICY A" 등
+    ILIKE 검색 포함)를 project_id override로 조회 시도 → 404(기존엔 접근권 검증 0이라 200+유출)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/policy-documents?project_id={seeded['project_b_id']}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_grant_human_cannot_leak_via_q_search_on_other_project():
+    """봉인 실증(정보밀도 최고 벡터): project_b content 전문검색(q=SECRET)도 접근권 검증으로
+    사전 차단 — ILIKE 도달 전에 404."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/policy-documents?project_id={seeded['project_b_id']}&q=SECRET"
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_nonexistent_project_id_returns_404_not_leak():
+    """엣지: 존재하지 않는 project_id도 404(존재여부 자체를 흘리지 않음)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/policy-documents?project_id={uuid.uuid4()}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- story 8c29e926 — #2050 ratchet `_KNOWN_DEBT_ALLOWLIST` HIGH 11건 중 `policy_documents.list_policy_documents` 상환(11→10).
- 선정 사유: org_id/project_id 필터는 있으나 caller의 project 접근권 검증이 0이라, 같은 org 내 접근권 없는 project의 정책문서 **content**까지 ILIKE 전문검색으로 노출됐다 — HIGH 11건 중 정보밀도 최고 벡터로 우선 선정.
- fix: `auth: AuthContext = Depends(get_current_user)` 추가 + `has_project_access(session, user_id, project_id, org_id)` 사전검증(실패 시 404). `project_id`가 쿼리파라미터 자체가 조회 대상이라 W/EE류 body-claimed-vs-resource-actual 분기는 해당 없음(직접검증으로 충분).
- 신규 realdb 테스트 4종: 회귀0(own-project 200)·cross-project 차단(404)·`q` 전문검색 유출 차단(404)·존재하지 않는 project_id 404(존재여부 자체 비노출).
- `tests/test_authz_project_scope_coverage.py`의 `_KNOWN_DEBT_ALLOWLIST`에서 policy_documents 항목 제거 — ratchet 스캐너가 이제 guard를 정상 감지함을 3종 테스트로 확인(`test_no_new_unguarded_project_scope_routes`/`test_baseline_entries_are_not_stale`/`test_known_debt_allowlist_shrinks_are_welcome_no_assertion` 전부 PASS).

## Test plan
- [x] 신규 realdb 4/4 PASS (fresh Postgres 16 container, alembic head)
- [x] ratchet 회귀가드 3/3 PASS
- [x] 전체 non-realdb 스위트 3509 passed / 68 failed — **68건 전부 baseline(stash) 상태에서도 동일하게 재현되는 사전-기존 실패**임을 직접 diff로 검증(로컬 `.mcp.json` 경로 드리프트·`test_s6_4_dod`/`test_s7_2_epic_dod` 등, 이번 변경과 무관). policy_documents를 참조하는 실패 0건.
- [x] `app.main` import 무회귀(449 routes)
- [x] migration 없음(코드 변경만) — migrate-dev 불요

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>