### PR TITLE
fix(security): SEC HIGH baseline paydown round2 — team_members project-scope 가드

### DIFF
--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -18,6 +18,7 @@ from app.schemas.team_member import (
 )
 from app.services.agent_onboarding_config import build_agent_mcp_config_bundle
 from app.services.member_resolver import assert_caller_is_member, is_caller_member
+from app.services.project_auth import has_project_access
 
 
 class ClaimBody(BaseModel):
@@ -95,6 +96,7 @@ async def list_team_members(
     repo: TeamMemberRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[TeamMemberResponse]:
     # S:166051f0 — org-level(project_id 없음): 휴먼 = org_members SSOT **직접** 해소
     # (team_members 뷰=members⋈project_access 비의존 → project_access.member_id NULL 인
@@ -114,6 +116,12 @@ async def list_team_members(
             agents = await repo.list(**agent_filters)
             result.extend(await _inject_active_stories(agents, session))
         return result
+
+    # ratchet round2(story 8aec83b3): project_id 지정 분기가 접근권 검증 없이 repo.list로
+    # 직행해 same-org cross-project roster(이름/역할)가 노출됐다 — resource-actual project_id
+    # (쿼리파라미터 자체가 조회대상) 직접 검증.
+    if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
 
     filters: dict = {"project_id": project_id}
     if type_filter:

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -133,8 +133,6 @@ _KNOWN_DEBT_ALLOWLIST: dict[str, str] = {
         "HIGH — org-scope만·optional project_id 필터에 접근권 검증 없음(epic 제목/목표 노출)",
     "app.routers.tasks:list_tasks":
         "HIGH — org-scope만·story_id 필터에 caller의 story project 접근권 검증 없음",
-    "app.routers.team_members:list_team_members":
-        "HIGH — project_id 지정 분기가 접근권 검증 없이 repo.list(project_id=)로 직행(roster 노출)",
     "app.routers.standups:list_standups":
         "HIGH — top-level project_id 필터에 접근권 검증 없음(plan_stories enrichment만 가드됨)",
     "app.routers.standups:list_standup_history":

--- a/backend/tests/test_e_security_sec_s8_ratchet_round2_team_members_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_ratchet_round2_team_members_realdb.py
@@ -1,0 +1,206 @@
+"""E-SECURITY SEC HIGH baseline paydown round2(story 8aec83b3) — #2050 ratchet
+_KNOWN_DEBT_ALLOWLIST HIGH 10건 중 team_members.list_team_members 상환.
+
+근본: project_id 지정 분기가 접근권 검증 없이 repo.list(project_id=)로 직행해, 같은 org 내
+접근권 없는 project의 roster(멤버 이름/역할)까지 노출됐다. project_id는 쿼리파라미터 자체가
+조회 대상이라 직접 has_project_access(session, user_id, project_id, org_id) 검증으로 봉인."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a, project_b) + agent_member_a(project_a에 grant, name="Agent Alpha") +
+    human_a(project_a에만 명시 grant, project_b 접근권 없음)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    agent_member_a = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent Alpha")
+    session.add(agent_member_a)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, member_id=agent_member_a.id,
+        permission="granted", role="member",
+    ))
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"human-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    # project_a에만 명시 grant — project_b 접근권 없음(org owner/admin도 아님).
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "agent_member_a_id": agent_member_a.id, "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_project_a_human_can_list_own_project_roster():
+    """회귀 0: project_a grant 보유 휴먼은 project_a roster(agent 포함) 정상 조회(200)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/team-members?project_id={seeded['project_a_id']}")
+            assert resp.status_code == 200, resp.text
+            ids = {item["id"] for item in resp.json()}
+            assert str(seeded["agent_member_a_id"]) in ids
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_grant_human_cannot_list_other_project_roster():
+    """봉인 실증: project_a에만 grant된 휴먼이 project_b roster(이름 "Agent Alpha" 등 무관해도
+    다른 project 자체 roster)를 project_id override로 조회 시도 → 404(기존엔 접근권 검증 0)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/team-members?project_id={seeded['project_b_id']}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_level_query_without_project_id_still_works_unchanged():
+    """회귀 0: project_id 미지정(org-level) 분기는 무변경 — 여전히 200(has_project_access 미적용 경로)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/team-members")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_nonexistent_project_id_returns_404_not_leak():
+    """엣지: 존재하지 않는 project_id도 404(존재여부 자체를 흘리지 않음)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/team-members?project_id={uuid.uuid4()}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_s2_4_claim_unclaim.py
+++ b/backend/tests/test_s2_4_claim_unclaim.py
@@ -304,6 +304,9 @@ async def test_list_members_active_story_injected():
             call_count += 1
             result = MagicMock()
             if call_count == 1:
+                # ratchet round2: has_project_access 사전검증(project 소속 확認)
+                result.scalar_one_or_none.return_value = True
+            elif call_count == 2:
                 # list members
                 result.scalars.return_value.all.return_value = [member]
             else:
@@ -341,6 +344,9 @@ async def test_list_members_active_story_null_when_no_claim():
             call_count += 1
             result = MagicMock()
             if call_count == 1:
+                # ratchet round2: has_project_access 사전검증(project 소속 확認)
+                result.scalar_one_or_none.return_value = True
+            elif call_count == 2:
                 result.scalars.return_value.all.return_value = [member]
             else:
                 result.scalars.return_value.all.return_value = []


### PR DESCRIPTION
## Summary
- story 8aec83b3 — #2050 ratchet `_KNOWN_DEBT_ALLOWLIST` HIGH 10건 중 `team_members.list_team_members` 상환(10→9).
- 선정 사유: round1(policy_documents) 다음 순위 — roster(멤버 이름/역할) 노출이며, 이 엔드포인트가 여러 소비처(FE 팀 패널·스탠드업 등)에서 재사용되는 고-트래픽 경로라 blast-radius가 크다.
- fix: project-scoped 분기(`project_id` 쿼리파라미터 지정 시)에 `auth: AuthContext = Depends(get_current_user)` 추가 + `has_project_access(session, user_id, project_id, org_id)` 사전검증(실패 시 404). org-level 분기(`project_id=None`)는 이미 `org_members` SSOT로 완전 org-scope돼 무변경.
- 신규 realdb 테스트 4종: 회귀0(own-project 200, agent roster row 포함 확인)·cross-project 차단(404)·org-level 무변경(200)·존재하지 않는 project_id 404.
- `tests/test_authz_project_scope_coverage.py`의 `_KNOWN_DEBT_ALLOWLIST`에서 team_members 항목 제거 — ratchet 3종 재통과.

## Test plan
- [x] 신규 realdb 4/4 PASS (fresh Postgres 16, alembic head)
- [x] ratchet 회귀가드 3/3 PASS
- [x] 기존 `tests/test_team_members.py` 14/14 무변경 통과(MagicMock `.scalar_one_or_none()` auto-truthy로 자연 호환)
- [x] `tests/test_s2_4_claim_unclaim.py` — 신규 `has_project_access` 사전조회로 `session.execute` call-count가 1칸 밀려 mock 순서 명시 조정한 2건(12/12 전체 통과)
- [x] 전체 non-realdb 스위트 3509 passed / 68 failed — round1(#2059)에서 baseline-diff로 이미 증명된 것과 **완전 동일한 68건**(로컬 `.mcp.json` 경로 드리프트 등, 사전-기존·이번 변경과 무관)
- [x] migration 없음(코드 변경만)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>