### PR TITLE
fix(security): SEC HIGH baseline paydown round3 — rewards project-scope 가드

### DIFF
--- a/backend/app/routers/rewards.py
+++ b/backend/app/routers/rewards.py
@@ -11,6 +11,7 @@ from app.models.project import Project
 from app.repositories.reward import RewardRepository
 from app.schemas.reward import BalanceResponse, GrantReward, LeaderboardEntry, RewardLedgerResponse
 from app.services.member_resolver import is_caller_member, resolve_member
+from app.services.project_auth import has_project_access
 
 router = APIRouter(prefix="/api/v2/rewards", tags=["rewards"])
 
@@ -37,7 +38,15 @@ async def list_rewards(
     project_id: uuid.UUID = Query(...),
     member_id: uuid.UUID | None = Query(default=None),
     repo: RewardRepository = Depends(_get_repo),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[RewardLedgerResponse]:
+    # ratchet round3(story 8aec83b3 패턴): org_id는 RewardRepository 생성자에서 이미 스코프되나
+    # project_id 쿼리파라미터(조회대상 자체)에 caller 접근권 검증이 없어 same-org cross-project
+    # 리워드 원장이 노출됐다 — resource-actual project_id 직접검증.
+    if not await has_project_access(repo.session, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+
     items = await repo.list(project_id=project_id, member_id=member_id)
     return [RewardLedgerResponse.model_validate(i) for i in items]
 

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -139,8 +139,6 @@ _KNOWN_DEBT_ALLOWLIST: dict[str, str] = {
         "HIGH — 동일 패턴(project_id 필터 미검증)",
     "app.routers.entities:search_entities":
         "HIGH — org-scope만·project_id로 story/doc/epic/task 제목 검색에 접근권 검증 없음",
-    "app.routers.rewards:list_rewards":
-        "HIGH — org-scope만·project_id 필터에 접근권 검증 없음(리워드 원장 노출)",
     "app.routers.members:list_members":
         "HIGH — assert_target_in_caller_org가 cross-org만 막고 same-org cross-project는 미검증",
     "app.routers.hypotheses:link_hypothesis":

--- a/backend/tests/test_e_security_sec_s8_ratchet_round3_rewards_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_ratchet_round3_rewards_realdb.py
@@ -1,0 +1,183 @@
+"""E-SECURITY SEC HIGH baseline paydown round3(story 8aec83b3 패턴) — #2050 ratchet
+_KNOWN_DEBT_ALLOWLIST HIGH 9건 중 rewards.list_rewards 상환.
+
+근본: org_id는 RewardRepository 생성자에서 이미 스코프되나, project_id 쿼리파라미터(조회
+대상 자체)에 caller의 접근권 검증이 없어 same-org cross-project 리워드 원장(재무정보)이
+노출됐다. resource-actual project_id 직접 has_project_access 검증으로 봉인."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a, project_b) + reward_a(project_a, reason="TOP SECRET BONUS") +
+    human_a(project_a에만 명시 grant, project_b 접근권 없음)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.reward import RewardLedger
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    reward_a = RewardLedger(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_a.id,
+        member_id=uuid.uuid4(), amount=100, reason="TOP SECRET BONUS",
+    )
+    session.add(reward_a)
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"human-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    # project_a에만 명시 grant — project_b 접근권 없음(org owner/admin도 아님).
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "reward_a_id": reward_a.id, "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_project_a_human_can_list_own_project_rewards():
+    """회귀 0: project_a grant 보유 휴먼은 project_a 리워드 원장 정상 조회(200)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/rewards?project_id={seeded['project_a_id']}")
+            assert resp.status_code == 200, resp.text
+            ids = {item["id"] for item in resp.json()}
+            assert str(seeded["reward_a_id"]) in ids
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_grant_human_cannot_list_other_project_rewards():
+    """봉인 실증: project_a에만 grant된 휴먼이 project_b 리워드 원장(재무정보,
+    reason="TOP SECRET BONUS")을 project_id override로 조회 시도 → 404(기존엔 접근권
+    검증 0이라 200+유출)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/rewards?project_id={seeded['project_b_id']}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_nonexistent_project_id_returns_404_not_leak():
+    """엣지: 존재하지 않는 project_id도 404(존재여부 자체를 흘리지 않음)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/rewards?project_id={uuid.uuid4()}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- story 8aec83b3 패턴 — #2050 ratchet `_KNOWN_DEBT_ALLOWLIST` HIGH 9건 중 `rewards.list_rewards` 상환(9→8).
- 선정 사유: 남은 HIGH 중 3순위 — 리워드 원장은 재무정보(수령자/금액/사유)라 정보 민감도가 높다.
- fix: `org_id: uuid.UUID = Depends(get_verified_org_id)` + `auth: AuthContext = Depends(get_current_user)` 추가 + `has_project_access(repo.session, user_id, project_id, org_id)` 사전검증(실패 시 404). org_id는 `RewardRepository` 생성자에서 이미 스코프돼 있었으나(안전), `project_id` 쿼리파라미터 자체에는 접근권 검증이 없었다.
- 신규 realdb 테스트 3종: 회귀0(own-project 200)·cross-project 리워드 원장 유출 차단(404)·존재하지 않는 project_id 404.
- `tests/test_authz_project_scope_coverage.py`의 `_KNOWN_DEBT_ALLOWLIST`에서 rewards 항목 제거 — ratchet 3종 재통과.

## Test plan
- [x] 신규 realdb 3/3 PASS (fresh Postgres 16, alembic head)
- [x] ratchet 회귀가드 3/3 PASS
- [x] 기존 `tests/test_rewards.py` 11/11 무변경 통과
- [x] 전체 non-realdb 스위트 3509 passed / 68 failed — round1(#2059)/round2(#2060)에서 이미 baseline-diff로 증명된 것과 **완전 동일한 68건**(사전-기존·이번 변경과 무관)
- [x] migration 없음(코드 변경만)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>