### PR TITLE
fix(security): SEC HIGH baseline paydown round4 — entities.search_entities project-scope 가드

### DIFF
--- a/backend/app/routers/entities.py
+++ b/backend/app/routers/entities.py
@@ -1,15 +1,16 @@
 import uuid
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.doc import Doc
 from app.models.pm import Epic, Story, Task
+from app.services.project_auth import has_project_access
 
 router = APIRouter(prefix="/api/v2/entities", tags=["entities"])
 
@@ -32,7 +33,13 @@ async def search_entities(
     types: str | None = Query(default=None, description="Comma-separated: story,doc,epic,task"),
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[EntitySearchResult]:
+    # ratchet round4(story 03ee87cc): project_id 쿼리파라미터(조회대상 자체)에 caller
+    # 접근권 검증이 없어 same-org cross-project의 story/doc/epic/task 4종 title(+ILIKE 검색
+    # 매칭 시 내용 존재여부)까지 한 엔드포인트에서 동시 노출됐다 — resource-actual 직접검증.
+    if not await has_project_access(db, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
 
     requested = set(types.split(",")) if types else VALID_TYPES
     requested = requested & VALID_TYPES

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -137,8 +137,6 @@ _KNOWN_DEBT_ALLOWLIST: dict[str, str] = {
         "HIGH — top-level project_id 필터에 접근권 검증 없음(plan_stories enrichment만 가드됨)",
     "app.routers.standups:list_standup_history":
         "HIGH — 동일 패턴(project_id 필터 미검증)",
-    "app.routers.entities:search_entities":
-        "HIGH — org-scope만·project_id로 story/doc/epic/task 제목 검색에 접근권 검증 없음",
     "app.routers.members:list_members":
         "HIGH — assert_target_in_caller_org가 cross-org만 막고 same-org cross-project는 미검증",
     "app.routers.hypotheses:link_hypothesis":

--- a/backend/tests/test_e_security_sec_s8_ratchet_round4_entities_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_ratchet_round4_entities_realdb.py
@@ -1,0 +1,214 @@
+"""E-SECURITY SEC HIGH baseline paydown round4(story 03ee87cc) — #2050 ratchet
+_KNOWN_DEBT_ALLOWLIST HIGH 8건 중 entities.search_entities 상환.
+
+근본: org_id/project_id 필터는 있으나 caller의 project 접근권 검증이 0이라, 같은 org 내
+접근권 없는 project의 story/doc/epic/task 4종 title(+검색 매칭 시 존재여부)까지 한
+엔드포인트에서 동시 노출됐다. project_id는 쿼리파라미터 자체가 조회 대상이라 직접
+has_project_access(session, user_id, project_id, org_id) 검증으로 봉인."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a, project_b) + project_b에 4종 엔티티(story/doc/epic/task, title
+    "TOP SECRET B ...") + human_a(project_a에만 명시 grant, project_b 접근권 없음)."""
+    from app.models.doc import Doc
+    from app.models.organization import Organization
+    from app.models.pm import Epic, Story, Task
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    story_b = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="TOP SECRET B Story")
+    epic_b = Epic(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="TOP SECRET B Epic")
+    doc_b = Doc(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_b.id,
+        title="TOP SECRET B Doc", slug=f"top-secret-b-{uuid.uuid4().hex[:8]}",
+    )
+    session.add_all([story_b, epic_b, doc_b])
+    await session.commit()
+
+    task_b = Task(id=uuid.uuid4(), org_id=org.id, story_id=story_b.id, title="TOP SECRET B Task")
+    session.add(task_b)
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"human-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    # project_a에만 명시 grant — project_b 접근권 없음(org owner/admin도 아님).
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_project_a_human_can_search_own_project_empty_result():
+    """회귀 0: project_a grant 보유 휴먼은 project_a 검색 정상 조회(200, 결과 0건이어도 통과)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/entities/search?project_id={seeded['project_a_id']}")
+            assert resp.status_code == 200, resp.text
+            assert resp.json() == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_grant_human_cannot_search_other_project_all_4_entity_types_blocked():
+    """봉인 실증: project_a에만 grant된 휴먼이 project_b(story/doc/epic/task 4종 모두 존재)를
+    project_id override로 검색 시도 → 404(기존엔 접근권 검증 0이라 200+4종 title 전부 유출)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/entities/search?project_id={seeded['project_b_id']}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_grant_human_cannot_leak_via_q_search_on_other_project():
+    """봉인 실증(전문검색 벡터): project_b title 검색(q=SECRET)도 접근권 검증으로 사전 차단
+    — ILIKE 도달 전에 404."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/entities/search?project_id={seeded['project_b_id']}&q=SECRET"
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_nonexistent_project_id_returns_404_not_leak():
+    """엣지: 존재하지 않는 project_id도 404(존재여부 자체를 흘리지 않음)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/entities/search?project_id={uuid.uuid4()}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- story 03ee87cc — #2050 ratchet `_KNOWN_DEBT_ALLOWLIST` HIGH 8건 중 `entities.search_entities` 상환(8→7).
- 선정 사유: story/doc/epic/task **4종 title**(+ILIKE 전문검색)이 한 엔드포인트에서 동시 노출돼 blast-radius가 큼 — round3 까심 QA가 다음 후보로 짚었던 항목.
- fix: `auth: AuthContext = Depends(get_current_user)` 추가 + `has_project_access(db, user_id, project_id, org_id)` 사전검증(실패 시 404). `project_id`가 쿼리파라미터 자체가 조회대상이라 직접검증으로 충분(body-claimed 분기 없음).
- 신규 realdb 테스트 4종: 회귀0(own-project 200)·cross-project **4종 엔티티 동시 차단**(project_b에 story/doc/epic/task 전부 시드해 404 실증)·`q` 전문검색 유출 차단(404)·존재하지 않는 project_id 404.
- `tests/test_authz_project_scope_coverage.py`의 `_KNOWN_DEBT_ALLOWLIST`에서 entities 항목 제거 — ratchet 3종 재통과.

## Test plan
- [x] 신규 realdb 4/4 PASS (fresh Postgres 16, alembic head) — 4종 엔티티 모두 project_b에 시드해 동시 차단 실증
- [x] ratchet 회귀가드 3/3 PASS
- [x] `search_entities`에는 기존 테스트가 0건이었음(round1 policy_documents와 동일 — 이번 커밋이 최초 커버리지)
- [x] 전체 non-realdb 스위트 3509 passed / 68 failed — round1(#2059)/round2(#2060)/round3(#2063)에서 이미 baseline-diff로 증명된 것과 **완전 동일한 68건**(4연속 재확인 — 사전-기존·이번 변경과 무관)
- [x] migration 없음(코드 변경만)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>