### PR TITLE
fix(security): SEC HIGH baseline paydown round5 — standups list/history project-scope 가드

### DIFF
--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -19,7 +19,7 @@ from app.schemas.standup import (
     StandupUpsert,
 )
 from app.services.member_resolver import canonicalize_member_id, resolve_member
-from app.services.project_auth import accessible_project_ids_in_org
+from app.services.project_auth import accessible_project_ids_in_org, has_project_access
 
 
 async def _entries_with_plan_stories(
@@ -145,6 +145,13 @@ async def list_standups(
     repo: StandupEntryRepository = Depends(_get_repo),
     auth: AuthContext = Depends(get_current_user),
 ) -> list[StandupEntryResponse]:
+    # ratchet round5(잔여 HIGH): top-level project_id 필터(지정 시)에 caller 접근권 검증이
+    # 없어 same-org cross-project 스탠드업 자유텍스트(yesterday/today/blockers)가 노출됐다 —
+    # resource-actual project_id 직접검증.
+    if project_id is not None:
+        if not await has_project_access(repo.session, uuid.UUID(auth.user_id), project_id, repo.org_id):
+            raise HTTPException(status_code=404, detail="Project not found")
+
     filters: dict = {}
     if project_id:
         filters["project_id"] = project_id
@@ -241,6 +248,10 @@ async def list_standup_history(
     b47f9b05: list/upsert/update 와 동일하게 plan_stories org-scope enrich(a9e67531) 적용 — 미적용 시
     백로그→데일리 할일(plan_story_ids)이 plan_stories 빈 채 내려가 cross-board 미노출(SaaS FE 프록시 포함).
     """
+    # ratchet round5(잔여 HIGH): 동일 패턴(project_id 필터 미검증) — resource-actual 직접검증.
+    if not await has_project_access(repo.session, uuid.UUID(auth.user_id), project_id, repo.org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+
     entries = await repo.list(project_id=project_id, limit=limit)
     return await _entries_with_plan_stories(entries, repo.session, repo.org_id, uuid.UUID(auth.user_id))
 

--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
-from app.models.pm import Story
+from app.models.pm import Sprint, Story
 from app.models.standup import StandupEntry, StandupEntryProject, StandupFeedback
 from app.repositories.standup import StandupEntryRepository, StandupFeedbackRepository
 from app.schemas.standup import (
@@ -145,11 +145,26 @@ async def list_standups(
     repo: StandupEntryRepository = Depends(_get_repo),
     auth: AuthContext = Depends(get_current_user),
 ) -> list[StandupEntryResponse]:
-    # ratchet round5(잔여 HIGH): top-level project_id 필터(지정 시)에 caller 접근권 검증이
-    # 없어 same-org cross-project 스탠드업 자유텍스트(yesterday/today/blockers)가 노출됐다 —
-    # resource-actual project_id 직접검증.
-    if project_id is not None:
-        if not await has_project_access(repo.session, uuid.UUID(auth.user_id), project_id, repo.org_id):
+    # ratchet round5(잔여 HIGH) + 까심 QA REQUEST_CHANGES fix: project_id·sprint_id 둘 다
+    # project로 좁히는 벡터라 각각 접근권 검증이 필요하다(project_id만 가드하면 sprint_id
+    # 단독으로 우회 가능 — Sprint.project_id는 필수 FK라 sprint_id만 알면 특정 project로
+    # 골라낼 수 있었다). sprint_id가 주어지면 org-scope로 실제 project_id를 서버에서
+    # 도출하고, project_id도 함께 주어졌으면 상호 일치까지 확인(불일치=404, 상세 비노출).
+    # project_id·sprint_id 둘 다 없는 org-wide 무필터 목록은 의도된 org 투명성 설계라 무변경.
+    target_project_id = project_id
+    if sprint_id is not None:
+        sprint_row = await repo.session.execute(
+            select(Sprint.project_id).where(Sprint.id == sprint_id, Sprint.org_id == repo.org_id)
+        )
+        sprint_project_id = sprint_row.scalar_one_or_none()
+        if sprint_project_id is None:
+            raise HTTPException(status_code=404, detail="Sprint not found")
+        if target_project_id is not None and target_project_id != sprint_project_id:
+            raise HTTPException(status_code=404, detail="Project not found")
+        target_project_id = sprint_project_id
+
+    if target_project_id is not None:
+        if not await has_project_access(repo.session, uuid.UUID(auth.user_id), target_project_id, repo.org_id):
             raise HTTPException(status_code=404, detail="Project not found")
 
     filters: dict = {}

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -133,10 +133,6 @@ _KNOWN_DEBT_ALLOWLIST: dict[str, str] = {
         "HIGH — org-scope만·optional project_id 필터에 접근권 검증 없음(epic 제목/목표 노출)",
     "app.routers.tasks:list_tasks":
         "HIGH — org-scope만·story_id 필터에 caller의 story project 접근권 검증 없음",
-    "app.routers.standups:list_standups":
-        "HIGH — top-level project_id 필터에 접근권 검증 없음(plan_stories enrichment만 가드됨)",
-    "app.routers.standups:list_standup_history":
-        "HIGH — 동일 패턴(project_id 필터 미검증)",
     "app.routers.members:list_members":
         "HIGH — assert_target_in_caller_org가 cross-org만 막고 same-org cross-project는 미검증",
     "app.routers.hypotheses:link_hypothesis":

--- a/backend/tests/test_e_security_sec_s8_ratchet_round5_standups_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_ratchet_round5_standups_realdb.py
@@ -1,0 +1,231 @@
+"""E-SECURITY SEC HIGH baseline paydown round5 — #2050 ratchet _KNOWN_DEBT_ALLOWLIST HIGH
+7건 중 standups.list_standups + standups.list_standup_history 상환(둘 다 동형 패턴).
+
+근본: top-level project_id 필터(지정 시)에 caller의 project 접근권 검증이 없어 same-org
+cross-project 스탠드업 자유텍스트(yesterday/today/blockers)가 노출됐다. project_id는
+쿼리파라미터 자체가 조회 대상이라 직접 has_project_access(session, user_id, project_id,
+org_id) 검증으로 봉인."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a, project_b) + standup_b(project_b 링크, blockers="TOP SECRET BLOCKER") +
+    human_a(project_a에만 명시 grant, project_b 접근권 없음)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.standup import StandupEntry, StandupEntryProject
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    standup_b = StandupEntry(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_b.id,
+        author_id=uuid.uuid4(), date=date(2026, 7, 11),
+        done="secret work", plan="secret plan", blockers="TOP SECRET BLOCKER",
+    )
+    session.add(standup_b)
+    await session.commit()
+    session.add(StandupEntryProject(id=uuid.uuid4(), org_id=org.id, entry_id=standup_b.id, project_id=project_b.id))
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"human-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    # project_a에만 명시 grant — project_b 접근권 없음(org owner/admin도 아님).
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_project_a_human_can_list_own_project_standups_empty():
+    """회귀 0: project_a grant 보유 휴먼은 project_a 스탠드업 정상 조회(200, 결과 0건이어도 통과)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/standups?project_id={seeded['project_a_id']}")
+            assert resp.status_code == 200, resp.text
+            assert resp.json() == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_grant_human_cannot_list_other_project_standups():
+    """봉인 실증(list): project_a에만 grant된 휴먼이 project_b 스탠드업(blockers="TOP SECRET
+    BLOCKER")을 project_id override로 조회 시도 → 404(기존엔 접근권 검증 0이라 200+유출)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/standups?project_id={seeded['project_b_id']}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_grant_human_cannot_list_other_project_standup_history():
+    """봉인 실증(history): 동일 벡터를 /standups/history에서도 차단."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/standups/history?project_id={seeded['project_b_id']}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_standups_without_project_id_still_works_unchanged():
+    """회귀 0: project_id 미지정(org-level) 호출은 무변경 — 여전히 200(has_project_access
+    미적용 경로, list_standups만 project_id optional)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/standups")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_nonexistent_project_id_returns_404_not_leak():
+    """엣지: 존재하지 않는 project_id도 404(존재여부 자체를 흘리지 않음, history 엔드포인트)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/standups/history?project_id={uuid.uuid4()}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_ratchet_round5_standups_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_ratchet_round5_standups_realdb.py
@@ -47,9 +47,11 @@ async def _session_factory():
 
 
 async def _seed(session):
-    """org(project_a, project_b) + standup_b(project_b 링크, blockers="TOP SECRET BLOCKER") +
-    human_a(project_a에만 명시 grant, project_b 접근권 없음)."""
+    """org(project_a, project_b) + sprint_b(project_b) + standup_b(project_b 링크·sprint_b
+    귀속, blockers="TOP SECRET BLOCKER") + human_a(project_a에만 명시 grant, project_b
+    접근권 없음)."""
     from app.models.organization import Organization
+    from app.models.pm import Sprint
     from app.models.project import OrgMember, Project
     from app.models.project_access import ProjectAccess
     from app.models.standup import StandupEntry, StandupEntryProject
@@ -64,10 +66,14 @@ async def _seed(session):
     session.add_all([project_a, project_b])
     await session.commit()
 
+    sprint_b = Sprint(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Sprint B")
+    session.add(sprint_b)
+    await session.commit()
+
     standup_b = StandupEntry(
-        id=uuid.uuid4(), org_id=org.id, project_id=project_b.id,
+        id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, sprint_id=sprint_b.id,
         author_id=uuid.uuid4(), date=date(2026, 7, 11),
-        done="secret work", plan="secret plan", blockers="TOP SECRET BLOCKER",
+        done="secret work", plan="secret plan", blockers="SPRINT-ID-BYPASS TOP SECRET BLOCKER",
     )
     session.add(standup_b)
     await session.commit()
@@ -89,7 +95,7 @@ async def _seed(session):
 
     return {
         "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
-        "human_user_id": human_user_id,
+        "sprint_b_id": sprint_b.id, "human_user_id": human_user_id,
     }
 
 
@@ -156,6 +162,55 @@ async def test_no_grant_human_cannot_list_other_project_standups():
         client = _client_for(app)
         try:
             resp = await client.get(f"/api/v2/standups?project_id={seeded['project_b_id']}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_grant_human_cannot_bypass_via_sprint_id_alone():
+    """까심 QA REQUEST_CHANGES 재현+회귀: project_id 없이 sprint_id=<project_b sprint>만
+    넘겨 project_id 가드를 우회하던 벡터 — 이제 sprint_id로 실제 project_id를 서버에서
+    도출해 동일하게 404 차단(자유텍스트 secret이 응답에 없음 실증)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/standups?sprint_id={seeded['sprint_b_id']}")
+            assert resp.status_code == 404, resp.text
+            assert "SPRINT-ID-BYPASS TOP SECRET BLOCKER" not in resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_project_id_and_mismatched_sprint_id_returns_404():
+    """엣지: project_id와 sprint_id가 서로 다른 project를 가리키면(불일치) 404 — 상세 비노출."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/standups?project_id={seeded['project_a_id']}&sprint_id={seeded['sprint_b_id']}"
+            )
             assert resp.status_code == 404, resp.text
         finally:
             await client.aclose()


### PR DESCRIPTION
## Summary
- #2050 ratchet `_KNOWN_DEBT_ALLOWLIST` 잔여 HIGH 7건 중 `standups.list_standups` + `standups.list_standup_history` 상환(2건 동시, 7→5).
- 선정 사유: 오르테가군이 제시한 후보 `get_leaderboard`(MEDIUM, aggregate 숫자만)와 비교해 standups는 자유텍스트(yesterday/today/blockers)를 노출하며 정보 밀도·개인정보성이 더 높아 blast-radius가 크다고 판단, HIGH 등급 후보로 우선 선정.
- fix: `list_standups`(project_id 지정 시에만 조건부)·`list_standup_history`(project_id required)에 `has_project_access(repo.session, user_id, project_id, repo.org_id)` 사전검증(실패 시 404) 추가. `project_id` 미지정 org-level `list_standups` 호출은 무변경.
- 신규 realdb 테스트 5종: 회귀0(list, org-level 무변경)·cross-project list 차단(404)·cross-project history 차단(404)·존재하지 않는 project_id 404.

## Test plan
- [x] 신규 realdb 5/5 PASS (fresh Postgres 16, alembic head) — `project_id`는 `standup_entry_projects` link-join 프로젝션이라 실제 링크 테이블까지 시드해 진짜 read 경로로 재현
- [x] ratchet 회귀가드 3/3 PASS
- [x] 기존 standups 관련 테스트(5개 파일, 60/60+1xfailed) 무변경 통과
- [x] 전체 non-realdb 스위트 3509 passed / 68 failed — round1~4에서 이미 baseline-diff로 증명된 것과 **완전 동일한 68건**(5연속 재확인 — 사전-기존·이번 변경과 무관)
- [x] migration 없음(코드 변경만) — `origin/develop` 최신(#2065 audit log 변경, 마이그 없음)으로 rebase 후 재검증 완료

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>