### PR TITLE
fix(e-ui-daegbyeon): Workcell 실행중 no-fiction 정정

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -273,6 +273,7 @@
     "proofCapsuleStateReviewing": "Awaiting verification",
     "proofCapsuleStateProven": "Proven",
     "proofCapsuleStateViolation": "Policy violation",
+    "workcellStateInProgress": "In progress",
     "workcellDodMissing": "No DoD specified",
     "workcellBlockedReason": "Waiting on dependency stories",
     "workcellNextNeedInProgress": "Request review once work is done",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -273,6 +273,7 @@
     "proofCapsuleStateReviewing": "검증 대기",
     "proofCapsuleStateProven": "증명 완료",
     "proofCapsuleStateViolation": "정책 위반",
+    "workcellStateInProgress": "진행 중",
     "workcellDodMissing": "완료 조건 미기재",
     "workcellBlockedReason": "의존 스토리 대기 중",
     "workcellNextNeedInProgress": "작업 완료 후 리뷰 요청",

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -353,12 +353,20 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   // - Evidence는 ProofCapsuleProps 실 매핑 인프라(EvidenceSection 재사용)가 후속 스코프라
   //   지금은 null(정직한 "아직 증거 없음" — 스펙이 명시적으로 허용하는 케이스).
   // - human assignee 없으면 Workcell 렌더 자체를 생략(허구 human 금지, ProofCapsule 배선과 동일 규율).
+  // P0-04 그라운딩(2026-07-11): GET /api/v2/agent-runs가 story_id 필터를 지원하지 않아(BE
+  // AgentRunRepository.list()는 project_id/agent_id만 필터) FE가 "지금 실제로 도는 에이전트가
+  // 있는지" 알 방법이 없다. 종전엔 blue 상태에 공용 "실행 중"(proofCapsuleStateRunning) 라벨을
+  // 썼는데, 이는 story.status='in-progress'라는 coarse 신호를 "에이전트가 지금 실행 중"이라는
+  // 더 구체적인 주장으로 과장한 것 — no-fiction 위반(파운더 독트린: 실시간 이벤트 텍스트≠실
+  // 실시간 신호). Workcell 전용으로 "진행 중"(workcellStateInProgress, 순수 status 반영, 실행
+  // 주장 없음)으로 정정. Board/Audit의 공용 blue="실행 중" 라벨은 별개 표면이라 스코프 밖
+  // (그쪽도 같은 근본 갭이 있으면 후속 별도 판단). 실 AgentRun story_id 필터는 디디 BE 티켓.
   const PROOF_STATE_BY_STATUS: Record<string, ProofState> = {
     'in-progress': 'blue', 'in-review': 'amber', done: 'green',
   };
   const proofState = PROOF_STATE_BY_STATUS[localStatus];
   const proofStateLabel = proofState
-    ? { blue: t('proofCapsuleStateRunning'), amber: t('proofCapsuleStateReviewing'), green: t('proofCapsuleStateProven'), red: t('proofCapsuleStateViolation') }[proofState]
+    ? { blue: t('workcellStateInProgress'), amber: t('proofCapsuleStateReviewing'), green: t('proofCapsuleStateProven'), red: t('proofCapsuleStateViolation') }[proofState]
     : null;
   const assigneeIds = story.assignee_ids?.length ? story.assignee_ids : (story.assignee_id ? [story.assignee_id] : []);
   const proofHumanId = assigneeIds.find((id) => memberMap[id] && memberMap[id]!.type !== 'agent');


### PR DESCRIPTION
## 요약
P0-04(상태→신뢰 파이프라인) 그라운딩 中 발견한 배포된 P0 표면 결함 — Workcell의 blue 상태 라벨이 공용 `proofCapsuleStateRunning`("실행 중")을 재사용했는데, 실제로는 `story.status='in-progress'`라는 coarse 신호일 뿐 실 AgentRun(에이전트가 지금 실제로 도는지) 신호가 아니다. "실행 중"이라는 단어는 story.status보다 더 구체적인 주장(실시간 실행)을 하는 것이라 no-fiction 원칙 위반.

## 근본 원인
`GET /api/v2/agent-runs`가 `story_id` 필터를 지원하지 않음(BE `AgentRunRepository.list()`가 `project_id`/`agent_id`만 필터, 모델엔 `story_id` 컬럼이 있는데도 조회 경로가 안 씀) — FE가 story 단위로 "실제 실행 중인 agent run"을 가져올 방법이 없어 status 파생 coarse guess로 대체돼 있었음.

## 조치
- **(b) 경로 선택**(실 AgentRun story_id 필터가 없어 (a)는 불가 — 확인 완료): 순수 status를 반영하는 "진행 중"(`workcellStateInProgress`, 실행 주장 없음)으로 Workcell 전용 라벨 교체.
- 공용 `proofCapsuleStateRunning`("실행 중")은 손대지 않음 — `proofState`/`proofStateLabel`은 `story-detail-panel.tsx` 내에서 Workcell 배선에만 쓰이는 걸 grep으로 확인(Board card/Audit 등 다른 Proof Capsule 표면은 완전 무영향).
- BE 티켓 `7a7f6c36` 신규 등록(`GET /api/v2/agent-runs?story_id=`) — 착지하면 Workcell Run 레이어를 실 AgentRun.status로 재배선하는 후속 작업.

## 테스트
`vitest` workcell 9/9 green, `eslint` 0, `pnpm build` 성공.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>