### PR TITLE
feat(e-verify): Claimed vs Verified BE 계약 — has_evidence 2신호 분리

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -153,17 +153,28 @@ async def _attach_assignee_ids(
 
 
 async def _attach_has_evidence(session: AsyncSession, stories: list[Story]) -> None:
-    """E-VERIFY V0-S2(story 3fbd048d): evidence 있는 story에 has_evidence=True(transient attr) —
-    없으면 미설정(StoryResponse 기본값 None 유지, positive 단방향·부정 신호 0).
+    """E-VERIFY V0-S2(story 3fbd048d) + Claimed vs Verified(doc
+    claimed-vs-verified-spec-handoff §3): evidence 있는 story에 has_evidence/self_reported=True
+    (transient attr) — 없으면 미설정(StoryResponse 기본값 None 유지, positive 단방향·부정
+    신호 0). gate_approval evidence(휴먼 책임자 gate 승인, 스푸핑 불가)가 있으면 추가로
+    human_verified=True+human_verified_by(who)·human_verified_at(when) 세팅.
     _attach_assignee_ids와 동형 배치 패턴."""
     if not stories:
         return
-    from app.services.evidence_service import batch_has_evidence
+    from app.services.evidence_service import batch_has_evidence, batch_human_verified
 
-    ids_with_evidence = await batch_has_evidence(session, [s.id for s in stories], "story")
+    story_ids = [s.id for s in stories]
+    ids_with_evidence = await batch_has_evidence(session, story_ids, "story")
+    verified_map = await batch_human_verified(session, story_ids, "story")
     for s in stories:
         if s.id in ids_with_evidence:
             s.has_evidence = True
+            s.self_reported = True
+        verified = verified_map.get(s.id)
+        if verified is not None:
+            s.human_verified = True
+            s.human_verified_by = verified.created_by
+            s.human_verified_at = verified.created_at
 
 
 async def _assert_story_project_access(

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -9,7 +9,7 @@ from app.dependencies.database import get_db
 from app.models.pm import Story, Task
 from app.repositories.task import TaskRepository
 from app.schemas.task import TaskCreate, TaskResponse, TaskUpdate
-from app.services.evidence_service import batch_has_evidence
+from app.services.evidence_service import batch_has_evidence, batch_human_verified
 from app.services.notification_dispatch import dispatch_notification
 
 router = APIRouter(prefix="/api/v2/tasks", tags=["tasks"])
@@ -23,13 +23,22 @@ def _get_repo(
 
 
 async def _attach_has_evidence(session: AsyncSession, tasks: list[Task]) -> None:
-    """E-VERIFY V0-S2(story 3fbd048d) — stories.py `_attach_has_evidence`와 동형(배치 조회)."""
+    """E-VERIFY V0-S2(story 3fbd048d) + Claimed vs Verified(doc
+    claimed-vs-verified-spec-handoff §3) — stories.py `_attach_has_evidence`와 동형(배치 조회)."""
     if not tasks:
         return
-    ids_with_evidence = await batch_has_evidence(session, [t.id for t in tasks], "task")
+    task_ids = [t.id for t in tasks]
+    ids_with_evidence = await batch_has_evidence(session, task_ids, "task")
+    verified_map = await batch_human_verified(session, task_ids, "task")
     for t in tasks:
         if t.id in ids_with_evidence:
             t.has_evidence = True
+            t.self_reported = True
+        verified = verified_map.get(t.id)
+        if verified is not None:
+            t.human_verified = True
+            t.human_verified_by = verified.created_by
+            t.human_verified_at = verified.created_at
 
 
 async def _assert_task_project_access(

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -221,3 +221,27 @@ class StoryResponse(BaseModel):
     @classmethod
     def _coerce_has_evidence(cls, v):
         return v if isinstance(v, bool) else None
+
+    # Claimed vs Verified(doc claimed-vs-verified-spec-handoff §3): has_evidence(1 boolean) →
+    # 2신호 분리. self_reported=agent가 증거 첨부(has_evidence와 동일 신호원, 하위호환 유지용
+    # 별칭 관계). human_verified=책임자가 gate 승인(=gate_approval evidence)+who/when(검토자
+    # 서명). 셋 다 positive 단방향(True 또는 None, False 없음) — has_evidence와 동형 규율.
+    self_reported: bool | None = None
+    human_verified: bool | None = None
+    human_verified_by: uuid.UUID | None = None
+    human_verified_at: datetime | None = None
+
+    @field_validator("self_reported", "human_verified", mode="before")
+    @classmethod
+    def _coerce_evidence_bool_signal(cls, v):
+        return v if isinstance(v, bool) else None
+
+    @field_validator("human_verified_by", mode="before")
+    @classmethod
+    def _coerce_human_verified_by(cls, v):
+        return v if isinstance(v, uuid.UUID) else None
+
+    @field_validator("human_verified_at", mode="before")
+    @classmethod
+    def _coerce_human_verified_at(cls, v):
+        return v if isinstance(v, datetime) else None

--- a/backend/app/schemas/task.py
+++ b/backend/app/schemas/task.py
@@ -41,3 +41,24 @@ class TaskResponse(BaseModel):
     @classmethod
     def _coerce_has_evidence(cls, v):
         return v if isinstance(v, bool) else None
+
+    # Claimed vs Verified(doc claimed-vs-verified-spec-handoff §3) — story.py와 동형.
+    self_reported: bool | None = None
+    human_verified: bool | None = None
+    human_verified_by: uuid.UUID | None = None
+    human_verified_at: datetime | None = None
+
+    @field_validator("self_reported", "human_verified", mode="before")
+    @classmethod
+    def _coerce_evidence_bool_signal(cls, v):
+        return v if isinstance(v, bool) else None
+
+    @field_validator("human_verified_by", mode="before")
+    @classmethod
+    def _coerce_human_verified_by(cls, v):
+        return v if isinstance(v, uuid.UUID) else None
+
+    @field_validator("human_verified_at", mode="before")
+    @classmethod
+    def _coerce_human_verified_at(cls, v):
+        return v if isinstance(v, datetime) else None

--- a/backend/app/services/evidence_service.py
+++ b/backend/app/services/evidence_service.py
@@ -14,7 +14,9 @@ async def batch_has_evidence(
     session: AsyncSession, work_item_ids: list[uuid.UUID], work_item_type: str
 ) -> set[uuid.UUID]:
     """evidence가 1건이라도 있는 work_item_id 집합(N+1 회피 배치 조회) — story/task 응답의
-    has_evidence(positive 단방향) 신호원."""
+    self_reported(구 has_evidence, positive 단방향) 신호원. gate_approval 타입도 포함(휴먼
+    서명도 그 자체로 evidence 존재 사실이므로 self_reported의 상위집합 — human_verified가
+    true면 self_reported도 항상 true)."""
     if not work_item_ids:
         return set()
     result = await session.execute(
@@ -24,6 +26,31 @@ async def batch_has_evidence(
         )
     )
     return set(result.scalars().all())
+
+
+async def batch_human_verified(
+    session: AsyncSession, work_item_ids: list[uuid.UUID], work_item_type: str
+) -> dict[uuid.UUID, Evidence]:
+    """Claimed vs Verified(doc claimed-vs-verified-spec-handoff §3): human_verified 신호원 —
+    gate_approval 타입 evidence(휴먼 책임자 gate 승인 시에만 시스템이 생성·스푸핑 불가,
+    create_gate_approval_evidence_if_applicable 참고)만 필터링해 work_item_id별 **최신 1건**
+    반환. "같은 증거, 다른 주어"(§1.5) — self_reported/human_verified가 같은 evidence 테이블을
+    공유하되 type=gate_approval만 인간 서명으로 승격. created_by=who(member_id)·
+    created_at=when — 검토자 서명."""
+    if not work_item_ids:
+        return {}
+    result = await session.execute(
+        select(Evidence).where(
+            Evidence.work_item_type == work_item_type,
+            Evidence.work_item_id.in_(work_item_ids),
+            Evidence.type == "gate_approval",
+        ).order_by(Evidence.created_at.desc())
+    )
+    latest: dict[uuid.UUID, Evidence] = {}
+    for ev in result.scalars().all():
+        if ev.work_item_id not in latest:
+            latest[ev.work_item_id] = ev
+    return latest
 
 
 async def create_gate_approval_evidence_if_applicable(

--- a/backend/tests/test_e_ui_daegbyeon_claimed_vs_verified_be_contract_realdb.py
+++ b/backend/tests/test_e_ui_daegbyeon_claimed_vs_verified_be_contract_realdb.py
@@ -1,0 +1,291 @@
+"""E-UI-DAEGBYEON P0-04(doc claimed-vs-verified-spec-handoff §3): has_evidence(1 boolean) →
+self_reported/human_verified 2신호 분리 BE 계약 — 실 Postgres 검증.
+
+3상태 파생 실증: !self_reported(무표시, D-03 "증거 없는 Done은 승격 불가") →
+self_reported & !human_verified(주장됨/claimed, agent 자가보고) →
+human_verified(검증됨/verified, 휴먼 책임자 gate 승인+who/when 서명)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.pm import Story, Task
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="CvV Org", slug=f"cvv-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="CvV Project")
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="CvV Agent", is_active=True)
+    session.add_all([project, agent])
+    await session.commit()
+
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted", role="member",
+    ))
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="CvV Story", status="in-progress")
+    session.add(story)
+    await session.commit()
+
+    task = Task(id=uuid.uuid4(), org_id=org.id, story_id=story.id, title="CvV Task", status="in-progress")
+    session.add(task)
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "agent_id": agent.id, "story_id": story.id, "task_id": task.id}
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, member_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            yield s
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(member_id), email="agent@test",
+            claims={"app_metadata": {"org_id": str(org_id), "api_key_id": "test-key"}},
+        )
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_story_unmarked_state_no_evidence():
+    """무표시(D-03): evidence 0건이면 self_reported/human_verified 둘 다 None(False 아님)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{seeded['story_id']}")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["self_reported"] is None
+            assert body["human_verified"] is None
+            assert body["human_verified_by"] is None
+            assert body["human_verified_at"] is None
+            assert body["has_evidence"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_story_claimed_state_self_reported_but_not_human_verified():
+    """주장됨(claimed): agent가 evidence(pr) 첨부 → self_reported=True·human_verified은 여전히
+    None(휴먼이 아직 승인 안 함). has_evidence(구 신호)도 하위호환으로 True."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/evidence", json={
+                "work_item_id": str(seeded["story_id"]), "work_item_type": "story",
+                "type": "pr", "ref": "https://github.com/org/repo/pull/10",
+            })
+            assert create_resp.status_code == 201, create_resp.text
+
+            resp = await client.get(f"/api/v2/stories/{seeded['story_id']}")
+            body = resp.json()
+            assert body["self_reported"] is True
+            assert body["has_evidence"] is True
+            assert body["human_verified"] is None
+            assert body["human_verified_by"] is None
+            assert body["human_verified_at"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_story_verified_state_after_gate_approval_with_who_and_when():
+    """검증됨(verified): 휴먼 책임자 gate 승인 → human_verified=True + human_verified_by(who)
+    = 승인자 member_id + human_verified_at(when) 설정. self_reported도 함께 True(같은 evidence
+    테이블 — "같은 증거, 다른 주어" §1.5)."""
+    from app.services.gate_service import create_gate, transition_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            approver_id = uuid.uuid4()
+            role_id = uuid.uuid4()
+
+            gate = await create_gate(
+                s, org_id=seeded["org_id"], work_item_id=seeded["story_id"], work_item_type="story",
+                gate_type="pr_review", member_id=seeded["agent_id"], role_id=role_id,
+            )
+            await s.commit()
+            gate_id = gate.id
+
+            await transition_gate(s, seeded["org_id"], gate_id, "approved", resolver_id=approver_id)
+            await s.commit()
+
+        from app.main import app
+        await _setup_app(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{seeded['story_id']}")
+            body = resp.json()
+            assert body["human_verified"] is True
+            assert body["human_verified_by"] == str(approver_id)
+            assert body["human_verified_at"] is not None
+            assert body["self_reported"] is True
+            assert body["has_evidence"] is True
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_task_verified_state_mirrors_story():
+    """story와 동형 — task도 gate_approval evidence로 human_verified+who/when 세팅."""
+    from app.services.gate_service import create_gate, transition_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            approver_id = uuid.uuid4()
+            role_id = uuid.uuid4()
+
+            gate = await create_gate(
+                s, org_id=seeded["org_id"], work_item_id=seeded["task_id"], work_item_type="task",
+                gate_type="pr_review", member_id=seeded["agent_id"], role_id=role_id,
+            )
+            await s.commit()
+            gate_id = gate.id
+
+            await transition_gate(s, seeded["org_id"], gate_id, "approved", resolver_id=approver_id)
+            await s.commit()
+
+        from app.main import app
+        await _setup_app(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/tasks/{seeded['task_id']}")
+            body = resp.json()
+            assert body["human_verified"] is True
+            assert body["human_verified_by"] == str(approver_id)
+            assert body["human_verified_at"] is not None
+            assert body["self_reported"] is True
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_most_recent_gate_approval_wins_who_when():
+    """엣지: 동일 work_item에 gate_approval evidence가 2건(재승인 등)이면 최신 1건의
+    who/when이 human_verified_by/at에 반영된다."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.models.evidence import Evidence
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            first_approver_id = uuid.uuid4()
+            second_approver_id = uuid.uuid4()
+            now = datetime.now(timezone.utc)
+
+            # gate 생애주기(auto-approve posture 등)와 무관하게 "복수 gate_approval evidence"
+            # 시나리오만 직접 재현 — create_gate_approval_evidence_if_applicable이 실제로 만드는
+            # 것과 동일 shape의 row 2건을 시간차로 삽입.
+            s.add(Evidence(
+                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=seeded["story_id"],
+                work_item_type="story", type="gate_approval", ref="gate-1", source="gate",
+                created_by=first_approver_id, created_at=now - timedelta(hours=1),
+            ))
+            s.add(Evidence(
+                id=uuid.uuid4(), org_id=seeded["org_id"], work_item_id=seeded["story_id"],
+                work_item_type="story", type="gate_approval", ref="gate-2", source="gate",
+                created_by=second_approver_id, created_at=now,
+            ))
+            await s.commit()
+
+        from app.main import app
+        await _setup_app(app, Session, seeded["agent_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/stories/{seeded['story_id']}")
+            body = resp.json()
+            assert body["human_verified"] is True
+            assert body["human_verified_by"] == str(second_approver_id)
+        finally:
+            await client.aclose()
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
doc `claimed-vs-verified-spec-handoff` §3 규정 그대로 구현(E-UI-DAEGBYEON P0-04, 유나 스펙 handoff). 근거: 파운더 방향서 D-03("Done은 증거가 아니라 주장이다 — 검토자 서명 없으면 낙관적 라벨")+원칙05("인간은 승인 버튼이 아니라 책임의 주체").

- **문제**: 현 `has_evidence`(1 boolean)가 agent 자가보고(self-report)와 인간 검증(gate 승인)을 하나로 뭉갠다 — agent가 증거만 붙여도 "검증됨"처럼 green으로 보임 = 거짓 신뢰 신호.
- **계약**: `has_evidence` → `self_reported`(agent 증거 첨부) + `human_verified`(+`human_verified_by`=who/member_id·`human_verified_at`=when=검토자 서명) 2신호로 분리.
- **파생 규칙**: `human_verified=true`→검증됨(green). `self_reported & !human_verified`→주장됨(amber). `!self_reported`→무표시(D-03 완료 기준).
- **"같은 증거, 다른 주어"(§1.5)**: `human_verified`는 `gate_approval` 타입 evidence(휴먼 gate 승인 시에만 시스템이 생성, 스푸핑 불가 — `create_gate_approval_evidence_if_applicable` 기존 로직 재사용)만 필터링. 다중 승인 시 최신 1건이 who/when 대표.
- **하위호환**: 기존 `has_evidence` 필드는 변경 없이 유지(self_reported와 동일 값) — FE 미마이그레이션 소비처 무파손. migration 없음(응답 계약만 확장, evidence 테이블/gate_approval 편입 로직 기존 그대로).

## Test plan
- [x] 신규 realdb 5/5 — 3상태(무표시/주장됨/검증됨) 전부 실증: unmarked(둘 다 None)·claimed(self_reported=True만)·verified(human_verified=True+who+when, self_reported도 True), task 동형 미러, 다중 gate_approval 시 최신 승자
- [x] 기존 evidence/gate/stories/tasks 관련 4파일(test_e_verify_v0_s2_evidence_signal_realdb.py 등) 42/42 무변경 통과
- [x] 전체 non-realdb 스위트 3509 passed / 68 failed — SEC 라운드 5건에서 이미 baseline-diff로 증명된 것과 완전 동일한 68건(사전-기존·이번 변경과 무관)
- [x] migration 없음(코드 변경만)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>