### PR TITLE
[SID:4bde30f9] Claimed vs Verified 데이터 배선 — has_evidence→2신호 전환

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3402,6 +3402,7 @@
     "trustSealClaimedBy": "Agent claim",
     "trustSealVerifiedBy": "{name} verified",
     "trustSealAwaitingVerification": "Awaiting verification",
+    "trustSealAwaitingVerificationLong": "Awaiting human verification",
     "trustSealSignedOff": "Signed off",
     "evidenceShow": "Show evidence",
     "evidenceHide": "Hide evidence",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3402,6 +3402,7 @@
     "trustSealClaimedBy": "에이전트 주장",
     "trustSealVerifiedBy": "{name} 검증",
     "trustSealAwaitingVerification": "검증 대기",
+    "trustSealAwaitingVerificationLong": "인간 검증 대기",
     "trustSealSignedOff": "책임 서명",
     "evidenceShow": "근거 보기",
     "evidenceHide": "근거 접기",

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -1247,6 +1247,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
                     assignees={(activeStory.assignee_ids ?? []).flatMap((id) => memberMap[id] ? [memberMap[id]] : [])}
                     onClick={() => {}}
                     lineStatus={storyLineMap[activeStory.id]}
+                    verifiedBy={activeStory.human_verified_by ? memberMap[activeStory.human_verified_by] : undefined}
                   />
                 </div>
               )}

--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -315,6 +315,7 @@ export function KanbanColumn({
                   labels={storyLabelsMap?.[story.id] ?? []}
                   gates={storyGatesMap?.[story.id] ?? []}
                   lineStatus={storyLineMap?.[story.id]}
+                  verifiedBy={story.human_verified_by ? memberMap[story.human_verified_by] : undefined}
                 />
               ))}
             </div>

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -9,6 +9,8 @@ import { Badge } from '@/components/ui/badge';
 import { AlertTriangle, ChevronRight, EyeOff, History, Pause, Rocket, Zap, ZapOff, type LucideIcon } from 'lucide-react';
 import { LabelChip } from '@/components/ui/label-chip';
 import { TrustSeal } from '@/components/verify/trust-seal';
+import { deriveTrustStage } from '@/services/verify';
+import { formatRelativeTime } from '@/lib/storage/format';
 import { ProofCapsule, type ProofState } from '@/components/proof-capsule/proof-capsule';
 
 // E-UI-DAEGBYEON P0 — Proof Capsule 확산(story `bf9037cb`). 상태→신뢰 파이프라인(후속 P0)이
@@ -86,13 +88,21 @@ interface StoryCardProps {
   labels?: { id: string; name: string; color: string | null }[];
   gates?: { id: string; gate_type: string; status: string }[];
   lineStatus?: LineStatusSummary;
+  /** E-VERIFY P0-04 — story.human_verified_by(UUID)를 호출부가 미리 resolve해 넘긴 것(assignee/
+   * assignees와 동일 패턴). 결재자가 현재 담당자가 아닐 수 있어(assigneeList와 별개 조회). */
+  verifiedBy?: KanbanMember;
 }
 
-export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdit, onChangeStatus, onAssign, onDelete, projectId, onKickoff, lastExecution, blockedBy = [], labels = [], gates = [], lineStatus }: StoryCardProps) {
+export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdit, onChangeStatus, onAssign, onDelete, projectId, onKickoff, lastExecution, blockedBy = [], labels = [], gates = [], lineStatus, verifiedBy }: StoryCardProps) {
   const t = useTranslations('board');
   // E-BOARD S6: 복수 assignee. assignees 우선, 없으면 단일 assignee 폴백. agent 한 명이라도 있으면 agent 취급(glow).
   const assigneeList = (assignees && assignees.length > 0) ? assignees : (assignee ? [assignee] : []);
   const hasAgent = assigneeList.some((m) => m.type === 'agent');
+  // E-VERIFY P0-04(claimed-vs-verified-spec-handoff §3) — has_evidence 뭉갬을 2신호로 분리.
+  // verified는 human_verified_by 실 resolve 성공 시만(없으면 "누가"를 지어내지 않고 무표시로
+  // 후퇴 — claimed는 특정 신원 없이도 범용 봇 아이콘으로 정직 렌더 가능해 후퇴 불필요).
+  const trustStage = deriveTrustStage(story);
+  const trustAgent = assigneeList.find((m) => m.type === 'agent');
   const tCage = useTranslations('cage');
   // S11 ①: line badge — 신규 4상태(LineStatusSummary) + 기존 pending gate merge, boy-scout 1배지.
   const hasPendingGate = gates.some((g) => g.status === 'pending');
@@ -319,9 +329,20 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
                 )}
               </div>
               <div className="flex items-center gap-2">
-                {/* E-VERIFY V0-S3 Lv0 — 증거 있는 done 카드에만(positive 단방향). 자리 예약 없이 조건부 렌더
-                    (증거 없으면 완전 무표시 — 레이아웃 시프트 자체가 없음, §7 상태 매트릭스). */}
-                {story.status === 'done' && story.has_evidence ? <TrustSeal /> : null}
+                {/* E-VERIFY P0-04(claimed-vs-verified-spec-handoff §3) — 증거 있는 done 카드에만
+                    (positive 단방향). 자리 예약 없이 조건부 렌더(무증거=완전 무표시, §7 상태
+                    매트릭스). human_verified→verified(green·who/when 실명)·self_reported만→
+                    claimed(amber) — 과거 has_evidence 기반 green 단일표시 중 인간 미검증 건은
+                    여기서 amber로 "정정"된다(회귀 아님, 거짓 신뢰 신호 제거). */}
+                {story.status === 'done' && trustStage === 'verified' && verifiedBy ? (
+                  <TrustSeal
+                    variant="verified"
+                    humanName={verifiedBy.name}
+                    when={story.human_verified_at ? formatRelativeTime(story.human_verified_at) : ''}
+                  />
+                ) : story.status === 'done' && trustStage === 'claimed' ? (
+                  <TrustSeal variant="claimed" agentInitial={trustAgent ? getInitials(trustAgent.name) : undefined} />
+                ) : null}
                 {story.story_points != null ? (
                   <span className="text-[11px] tabular-nums text-muted-foreground">{t('storyPointsBadge', { count: story.story_points })}</span>
                 ) : null}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -774,12 +774,15 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 })}
               </DropdownMenuContent>
             </DropdownMenu>
-            {/* E-VERIFY V0-S3 Lv1/Lv2 — 완료 badge의 연장으로 읽히도록 바로 아래. 증거 0이면
-                EvidenceSection 자체가 null 렌더(행 미노출, §7 상태 매트릭스). */}
+            {/* E-VERIFY V0-S3 Lv1/Lv2 + P0-04 Claimed-vs-Verified — 완료 badge의 연장으로 읽히도록
+                바로 아래. 증거 0이면 EvidenceSection 자체가 null 렌더(행 미노출, §7 상태 매트릭스). */}
             <EvidenceSection
               workItemId={story.id}
               workItemType="story"
-              hasEvidence={story.has_evidence}
+              selfReported={story.self_reported}
+              humanVerified={story.human_verified}
+              humanVerifiedBy={story.human_verified_by}
+              humanVerifiedAt={story.human_verified_at}
               memberMap={memberMap}
             />
           </div>

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -24,7 +24,14 @@ export interface KanbanStory {
   labels?: { id: string; name: string; color: string | null }[];
   gates?: { id: string; gate_type: string; status: string }[];
   // E-VERIFY V0-S1/S2: 실증-done 신뢰 신호. true면 근거 有, null이면 완전 무표시.
+  // has_evidence는 BE 하위호환용으로 유지(self_reported와 동일 값) — 신규 소비처는 아래 2신호 사용.
   has_evidence?: boolean | null;
+  // E-VERIFY P0-04(claimed-vs-verified-spec-handoff §3, PR #2069) — has_evidence를 대체하는
+  // 2신호. self_reported=agent 자가보고(증거 첨부)·human_verified=책임자 gate 승인(who/when 동봉).
+  self_reported?: boolean | null;
+  human_verified?: boolean | null;
+  human_verified_by?: string | null;
+  human_verified_at?: string | null;
 }
 
 export interface GateItem {

--- a/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
@@ -173,12 +173,12 @@ describe('ProofCapsule (trustSeal slot — claimed-vs-verified-spec-handoff, ful
         proofState="amber"
         stateLabel="주장됨"
         density="full"
-        trustSeal={{ variant: 'claimed', agentName: '미르코', agentInitial: '미' }}
+        trustSeal={{ variant: 'claimed', agentInitial: '미' }}
       />,
     );
     expect(markup).toContain('주장됨');
     expect(markup).toContain('에이전트 주장');
-    expect(markup).toContain('검증 대기');
+    expect(markup).toContain('인간 검증 대기');
   });
 
   it('renders the verified strip (green, human subject) when trustSeal.variant is "verified"', () => {
@@ -203,7 +203,7 @@ describe('ProofCapsule (trustSeal slot — claimed-vs-verified-spec-handoff, ful
         proofState="amber"
         stateLabel="주장됨"
         density="full"
-        trustSeal={{ variant: 'claimed', agentName: '미르코', agentInitial: '미' }}
+        trustSeal={{ variant: 'claimed', agentInitial: '미' }}
       />,
     );
     expect(markup.toLowerCase()).not.toContain('proof-green');

--- a/apps/web/src/components/verify/evidence-section.test.tsx
+++ b/apps/web/src/components/verify/evidence-section.test.tsx
@@ -24,7 +24,7 @@ describe('isLinkableRef', () => {
   });
 });
 
-describe('EvidenceSection (SSR snapshot — §7 상태 매트릭스)', () => {
+describe('EvidenceSection (SSR snapshot — §7 상태 매트릭스 + P0-04 Claimed-vs-Verified)', () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -37,27 +37,66 @@ describe('EvidenceSection (SSR snapshot — §7 상태 매트릭스)', () => {
     vi.restoreAllMocks();
   });
 
-  it('renders nothing when hasEvidence is null (증거 0 = 행 미렌더, "증명 안 됨" 표기 금지)', () => {
+  it('renders nothing when selfReported is null (증거 0 = 행 미렌더, "증명 안 됨" 표기 금지)', () => {
     const markup = renderToStaticMarkup(
-      wrap(<EvidenceSection workItemId="s1" workItemType="story" hasEvidence={null} />),
+      wrap(<EvidenceSection workItemId="s1" workItemType="story" selfReported={null} humanVerified={null} humanVerifiedBy={null} humanVerifiedAt={null} />),
     );
     expect(markup).toBe('');
   });
 
-  it('renders nothing when hasEvidence is undefined (BE가 필드 자체를 안 내려도 안전한 폴백)', () => {
+  it('renders nothing when all fields are undefined (BE가 필드 자체를 안 내려도 안전한 폴백)', () => {
     const markup = renderToStaticMarkup(
-      wrap(<EvidenceSection workItemId="s1" workItemType="story" hasEvidence={undefined} />),
+      wrap(<EvidenceSection workItemId="s1" workItemType="story" selfReported={undefined} humanVerified={undefined} humanVerifiedBy={undefined} humanVerifiedAt={undefined} />),
     );
     expect(markup).toBe('');
   });
 
-  it('renders the collapsed trust row when hasEvidence is true, without fetching evidence eagerly', () => {
+  it('renders the amber "claimed" row when self_reported is true but human_verified is not, without fetching evidence eagerly', () => {
     const markup = renderToStaticMarkup(
-      wrap(<EvidenceSection workItemId="s1" workItemType="story" hasEvidence={true} />),
+      wrap(<EvidenceSection workItemId="s1" workItemType="story" selfReported={true} humanVerified={null} humanVerifiedBy={null} humanVerifiedAt={null} />),
     );
-    expect(markup).toContain('증명된 완결');
+    expect(markup).toContain('에이전트 주장');
+    expect(markup).toContain('text-warning');
+    expect(markup).not.toContain('text-success');
     expect(markup).toContain('근거 보기');
     // 디디 BE 가이드: "근거 보기" 클릭 전엔 evidence 리스트를 부르지 않는다(카드마다 N+1 방지).
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('renders the green "verified" row with the resolved human name when human_verified is true (거짓 green→amber 정정의 반대편 — 실제로 검증된 건 정확히 green)', () => {
+    const markup = renderToStaticMarkup(
+      wrap(
+        <EvidenceSection
+          workItemId="s1"
+          workItemType="story"
+          selfReported={true}
+          humanVerified={true}
+          humanVerifiedBy="member-1"
+          humanVerifiedAt="2026-07-11T00:00:00Z"
+          memberMap={{ 'member-1': { name: '김민서' } }}
+        />,
+      ),
+    );
+    expect(markup).toContain('김민서');
+    expect(markup).toContain('text-success');
+    expect(markup).not.toContain('에이전트 주장');
+  });
+
+  it('falls back to a short id + generic label when the verifier is not in memberMap (no-fiction — never invents a name)', () => {
+    const markup = renderToStaticMarkup(
+      wrap(
+        <EvidenceSection
+          workItemId="s1"
+          workItemType="story"
+          selfReported={true}
+          humanVerified={true}
+          humanVerifiedBy="deadbeef-0000-0000-0000-000000000000"
+          humanVerifiedAt="2026-07-11T00:00:00Z"
+          memberMap={{}}
+        />,
+      ),
+    );
+    expect(markup).toContain('deadbe');
+    expect(markup).not.toContain('undefined');
   });
 });

--- a/apps/web/src/components/verify/evidence-section.tsx
+++ b/apps/web/src/components/verify/evidence-section.tsx
@@ -2,12 +2,13 @@
 
 import { useCallback, useState } from 'react';
 import {
-  ChevronDown, ChevronUp, ExternalLink, Link2, Paperclip,
+  Check, ChevronDown, ChevronUp, ExternalLink, Link2, Paperclip,
   GitPullRequest, Rocket, TrendingUp, FileText, CheckCircle2,
 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { TrustSeal } from './trust-seal';
-import type { EvidenceItem, EvidenceType } from '@/services/verify';
+import { cn } from '@/lib/utils';
+import { formatRelativeTime } from '@/lib/storage/format';
+import { deriveTrustStage, type EvidenceItem, type EvidenceType } from '@/services/verify';
 
 const VISIBLE_LIMIT = 4;
 
@@ -39,19 +40,29 @@ export function isLinkableRef(ref: string): boolean {
 interface EvidenceSectionProps {
   workItemId: string;
   workItemType: 'story' | 'task';
-  /** BE list/get 응답의 has_evidence 신호. false는 절대 오지 않음(null=무증거) — undefined도 무증거로 취급. */
-  hasEvidence: boolean | null | undefined;
+  /** E-VERIFY P0-04(claimed-vs-verified-spec-handoff §3) — has_evidence(1 boolean) 대체 2신호.
+   * false는 절대 오지 않음(null=무증거) — undefined도 무증거로 취급. */
+  selfReported: boolean | null | undefined;
+  humanVerified: boolean | null | undefined;
+  humanVerifiedBy: string | null | undefined;
+  humanVerifiedAt: string | null | undefined;
   memberMap?: Record<string, { name: string }>;
   className?: string;
 }
 
 /**
- * E-VERIFY V0-S3 Lv1(접힘 신뢰 행) + Lv2(펼침 evidence 카드). 유나 S4 핸드오프 §3/§4 준수.
+ * E-VERIFY V0-S3 Lv1(접힘 신뢰 행) + Lv2(펼침 evidence 카드) + P0-04 Claimed-vs-Verified 데이터
+ * 배선. 유나 S4 핸드오프 §3/§4 + claimed-vs-verified-spec-handoff §3 준수.
  * "근거 보기" 클릭 시에만 evidence 리스트를 호출한다(디디 BE 가이드 — 리스트 렌더 시 카드마다
- * 부르지 않는 게 정합, has_evidence 하나로 Lv0 씰 표시는 충분). 그래서 fetch 전엔 건수를 모른다 —
+ * 부르지 않는 게 정합, self_reported 하나로 Lv0 씰 표시는 충분). 그래서 fetch 전엔 건수를 모른다 —
  * Lv1 라벨은 펼치기 전엔 카운트 없이 "증명된 완결"만, 펼친 후 실 카운트로 채워진다.
+ *
+ * Lv0/Lv1 씰은 story/task 응답에 이미 동봉된 human_verified_by/at으로 즉시 정확하게 렌더된다
+ * (evidence 리스트 fetch를 기다릴 필요 없음 — verified 여부/who/when은 집계 필드).
  */
-export function EvidenceSection({ workItemId, workItemType, hasEvidence, memberMap = {}, className }: EvidenceSectionProps) {
+export function EvidenceSection({
+  workItemId, workItemType, selfReported, humanVerified, humanVerifiedBy, humanVerifiedAt, memberMap = {}, className,
+}: EvidenceSectionProps) {
   const t = useTranslations('verify');
   const tCommon = useTranslations('common');
   const [expanded, setExpanded] = useState(false);
@@ -81,19 +92,32 @@ export function EvidenceSection({ workItemId, workItemType, hasEvidence, memberM
   };
 
   // 증거 0 = 신뢰 행 자체를 렌더하지 않는다(§7 상태 매트릭스 — 현행과 동일 무표시, "증명 안 됨" 금지).
-  if (!hasEvidence) return null;
+  const trustStage = deriveTrustStage({ self_reported: selfReported, human_verified: humanVerified });
+  if (!trustStage) return null;
 
   const visibleItems = items && !showAll ? items.slice(0, VISIBLE_LIMIT) : items;
   const hiddenCount = items ? items.length - VISIBLE_LIMIT : 0;
   const signerId = items?.[0]?.created_by ?? null;
   const signerName = signerId ? memberMap[signerId]?.name : null;
+  // E-VERIFY P0-04 — Lv0/Lv1 씰은 이 자리에서 즉시 정확하게(evidence fetch 대기 없이): verified는
+  // human_verified_by 실명(who), claimed는 "에이전트 주장"(self_reported엔 who가 없어 일반화,
+  // §3 계약 그대로). 과거 무조건 초록 체크였던 자리 — human 미검증 건은 여기서 amber로 정정된다.
+  const verifiedByName = humanVerifiedBy ? (memberMap[humanVerifiedBy]?.name ?? humanVerifiedBy.slice(0, 6)) : null;
+  const verifiedWhen = humanVerifiedAt ? formatRelativeTime(humanVerifiedAt) : null;
+  const sealLabel = trustStage === 'verified'
+    ? (verifiedByName ? `${t('trustSealVerifiedBy', { name: verifiedByName })}${verifiedWhen ? ` · ${verifiedWhen}` : ''}` : t('provenCompletion'))
+    : t('trustSealClaimedBy');
 
   return (
     <div className={className}>
       <div className="rounded-lg border border-border p-2.5">
         <button type="button" onClick={handleToggle} className="flex w-full items-center gap-2 text-left">
-          <TrustSeal />
-          <span className="text-xs font-semibold text-foreground">{t('provenCompletion')}</span>
+          <Check
+            className={cn('h-3 w-3 shrink-0', trustStage === 'verified' ? 'text-success/85' : 'text-warning')}
+            strokeWidth={2.6}
+            aria-hidden
+          />
+          <span className="text-xs font-semibold text-foreground">{sealLabel}</span>
           {items ? (
             <span className="text-[11px] text-muted-foreground">· {t('evidenceCount', { count: items.length })}</span>
           ) : null}

--- a/apps/web/src/components/verify/trust-seal.test.tsx
+++ b/apps/web/src/components/verify/trust-seal.test.tsx
@@ -23,17 +23,24 @@ describe('TrustSeal (legacy icon — 하위호환, story-card.tsx has_evidence �
 
 describe('TrustSeal (claimed — Green 무결성 SOUL-LOCK, claimed-vs-verified-spec-handoff §1.3)', () => {
   it('never references any green token — agent 주장 단독은 Green이 될 수 없다', () => {
-    const markup = render({ variant: 'claimed', agentName: '미르코', agentInitial: '미' });
+    const markup = render({ variant: 'claimed', agentInitial: '미' });
     expect(markup.toLowerCase()).not.toContain('proof-green');
     expect(markup.toLowerCase()).not.toContain('text-success');
   });
 
-  it('renders the amber "주장" framing with agent avatar + text-paired "검증 대기" (색만 금지)', () => {
-    const markup = render({ variant: 'claimed', agentName: '미르코', agentInitial: '미' });
+  it('renders the amber "주장" framing with a specific agent avatar when agentInitial is given', () => {
+    const markup = render({ variant: 'claimed', agentInitial: '미' });
     expect(markup).toContain('proof-amber');
     expect(markup).toContain('에이전트 주장');
-    expect(markup).toContain('검증 대기');
-    expect(markup).toContain('>미<'); // agent initial avatar
+    expect(markup).toContain('인간 검증 대기');
+    expect(markup).toContain('>미<');
+  });
+
+  it('falls back to a generic bot glyph when no specific agent identity is known (no-fiction — self_reported has no "who" signal)', () => {
+    const markup = render({ variant: 'claimed' });
+    expect(markup).toContain('svg'); // Bot icon
+    expect(markup).toContain('에이전트 주장');
+    expect(markup).not.toContain('undefined');
   });
 });
 

--- a/apps/web/src/components/verify/trust-seal.tsx
+++ b/apps/web/src/components/verify/trust-seal.tsx
@@ -1,12 +1,14 @@
-import { Check } from 'lucide-react';
+import { Bot, Check } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
 import { initials } from '@/lib/storage/format';
 
 export interface TrustSealClaimedProps {
   variant: 'claimed';
-  agentName: string;
-  agentInitial: string;
+  /** 특정 에이전트를 식별할 수 있을 때만(예: story assignee) — self_reported 신호 자체엔 "who"가
+   * 없어(BE 계약, human_verified만 _by를 동봉) 모르는 맥락(예: EvidenceSection Lv1)에선 생략하고
+   * 범용 봇 아이콘으로 정직하게 대체한다(없는 신원을 지어내지 않음). */
+  agentInitial?: string;
   className?: string;
 }
 
@@ -45,10 +47,10 @@ export function TrustSeal(props: TrustSealProps) {
     return (
       <div className={cn('flex items-center gap-2 rounded-[10px] bg-proof-amber-soft px-2.5 py-2 text-[11.5px]', props.className)}>
         <span className="flex size-[22px] shrink-0 items-center justify-center rounded-full border border-proof-blue bg-proof-blue-soft text-[9px] font-bold text-proof-blue">
-          {props.agentInitial}
+          {props.agentInitial ?? <Bot className="size-3" aria-hidden="true" />}
         </span>
         <span className="min-w-0 flex-1 text-proof-ink-3">
-          <b className="font-bold text-proof-ink">{t('trustSealClaimedBy')}</b> · {t('trustSealAwaitingVerification')}
+          <b className="font-bold text-proof-ink">{t('trustSealClaimedBy')}</b> · {t('trustSealAwaitingVerificationLong')}
         </span>
         <span className="shrink-0 text-[10.5px] font-bold text-proof-amber">{t('trustSealAwaitingVerification')}</span>
       </div>

--- a/apps/web/src/services/verify.test.ts
+++ b/apps/web/src/services/verify.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { deriveTrustStage } from './verify';
+
+describe('deriveTrustStage (claimed-vs-verified-spec-handoff §3 파생 규칙)', () => {
+  it('returns "verified" when human_verified is true (green 무결성 — human_verified가 유일한 green 조건)', () => {
+    expect(deriveTrustStage({ human_verified: true, self_reported: true })).toBe('verified');
+  });
+
+  it('returns "claimed" when self_reported is true but human_verified is not', () => {
+    expect(deriveTrustStage({ self_reported: true, human_verified: null })).toBe('claimed');
+    expect(deriveTrustStage({ self_reported: true, human_verified: false })).toBe('claimed');
+  });
+
+  it('returns null (무표시) when self_reported is falsy — D-03 완료 기준(증거 없는 Done은 승격 불가)', () => {
+    expect(deriveTrustStage({ self_reported: null, human_verified: null })).toBeNull();
+    expect(deriveTrustStage({})).toBeNull();
+  });
+
+  it('never returns "claimed" when human_verified is true, even if self_reported is somehow false (verified takes precedence)', () => {
+    expect(deriveTrustStage({ self_reported: false, human_verified: true })).toBe('verified');
+  });
+});

--- a/apps/web/src/services/verify.ts
+++ b/apps/web/src/services/verify.ts
@@ -17,3 +17,27 @@ export interface EvidenceItem {
   work_item_id: string;
   work_item_type: 'story' | 'task';
 }
+
+/**
+ * E-VERIFY P0-04 — claimed-vs-verified-spec-handoff §3 BE 계약(PR #2069) 미러. `has_evidence`
+ * (1 boolean, self-report와 human-verified를 뭉갬)를 대체하는 2신호 — story/task 응답에 그대로
+ * 동봉. null=미측정(0건), false는 오지 않음(BE 계약).
+ */
+export interface TrustSignal {
+  self_reported?: boolean | null;
+  human_verified?: boolean | null;
+  human_verified_by?: string | null;
+  human_verified_at?: string | null;
+}
+
+export type TrustStage = 'claimed' | 'verified' | null;
+
+/**
+ * claimed-vs-verified-spec-handoff §3 파생 규칙 그대로: human_verified→verified(green)·
+ * self_reported & !human_verified→claimed(amber)·!self_reported→무표시(null, D-03 완료 기준).
+ */
+export function deriveTrustStage(signal: TrustSignal): TrustStage {
+  if (signal.human_verified) return 'verified';
+  if (signal.self_reported) return 'claimed';
+  return null;
+}


### PR DESCRIPTION
## 요약
E-UI-DAEGBYEON P0 Claimed-vs-Verified 마지막 슬라이스(시각 스캐폴딩 #2070 후속). BE 계약 #2069(머지 완료, develop live) — `self_reported`·`human_verified`·`human_verified_by`·`human_verified_at` 4필드를 실제로 소비.

## 변경
- `services/verify.ts`: `deriveTrustStage()` 순수 파생함수(§3 규칙: `human_verified`→verified, `self_reported && !human_verified`→claimed, `!self_reported`→null).
- `story-card.tsx`(보드 카드): `<TrustSeal/>`(`status==='done' && has_evidence`면 무조건 렌더) → 파생 규칙대로 verified(`human_verified_by`를 `kanban-column.tsx`/`kanban-board.tsx`가 memberMap으로 resolve해 `verifiedBy` prop 전달)·claimed(담당 agent 이니셜, 없으면 범용 봇 아이콘)·무표시 3분기.
- `evidence-section.tsx`(스토리 상세 Lv1/Lv2): 동일 파생 규칙. Lv0 씰이 evidence 리스트 fetch를 기다릴 필요 없이(story/task 응답에 이미 동봉된 집계 필드라) 즉시 "{who} 검증 · {when}" / "에이전트 주장"으로 정확해짐.
- ⭐**거짓 green→amber 정정**: 과거 `has_evidence`만으로 무조건 green 체크였던 done 카드 중 인간 미검증 건은 여기서 amber(주장됨)로 정정됩니다 — 회귀가 아니라 거짓 신뢰 신호 제거입니다.
- TrustSeal micro-polish(유나 코드 가디언 지적 반영): claimed tail "검증 대기"→"인간 검증 대기"(chip과 중복 해소), `agentInitial` optional화 + Bot 아이콘 폴백(`self_reported` 신호엔 "who"가 없어 — BE 계약상 `human_verified`만 `_by`/`_at`을 동봉 — 특정 신원을 강제할 수 없음. 없는 신원을 지어내지 않고 정직하게 범용 아이콘으로 대체).

## 테스트
- `deriveTrustStage` 4건, `TrustSeal` 신규 폴백 케이스, `EvidenceSection` 3-분기(무표시/claimed/verified) + 미상 verifier 폴백, `ProofCapsule` trustSeal 슬롯 갱신.
- 전체 `vitest` 1195 green, `eslint` 0, `pnpm build` 성공.
- `develop`(#2069 포함) 기준 rebase 완료, 재검증 전부 green.

## Done-gate
develop 머지 → dev 배포 → 라이브 픽셀로 "거짓 green→amber 정정" 실증(과거 has_evidence=true & human 미검증 done 카드가 amber로 바뀌는지) + claimed/verified 실 렌더 + 양테마 확인 → 유나 최종 가디언 → 오르테가 머지.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>