### PR TITLE
fix(security): SEC HIGH baseline paydown round7 — activity_logs+activity_stream project-scope 가드

### DIFF
--- a/backend/app/routers/activity_logs.py
+++ b/backend/app/routers/activity_logs.py
@@ -4,7 +4,7 @@ import uuid
 from collections import defaultdict
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.activity_log import ActivityLog
+from app.services.project_auth import has_project_access
 
 logger = logging.getLogger(__name__)
 
@@ -82,9 +83,18 @@ async def list_activity_logs(
     offset: int = Query(default=0, ge=0),
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> ActivityLogListResponse:
     from app.models.team import TeamMember
+
+    # ratchet round7(잔여 HIGH): project_id 필터(지정 시)에 caller 접근권 검증이 없어
+    # same-org cross-project 감사 로그(actor/action/entity/context 전문)가 노출됐다 —
+    # resource-actual project_id 직접검증. actor_id/entity_id/entity_type 등은 project로
+    # 직접 환원되는 FK가 아니라(result-level 노출 축은 별도 스토리 d3e5ca89로 분리 트래킹)
+    # 이 라운드 스코프 밖.
+    if project_id is not None:
+        if not await has_project_access(db, uuid.UUID(auth.user_id), project_id, org_id):
+            raise HTTPException(status_code=404, detail="Project not found")
 
     # AC5: org scope 필터 (외부 접근 불가 — get_verified_org_id가 403 처리)
     q = select(ActivityLog).where(ActivityLog.org_id == org_id)

--- a/backend/app/routers/activity_logs.py
+++ b/backend/app/routers/activity_logs.py
@@ -120,7 +120,7 @@ async def list_activity_logs(
         try:
             caller_tm = (await db.execute(
                 select(TeamMember).where(
-                    TeamMember.id == uuid.UUID(_auth.user_id),
+                    TeamMember.id == uuid.UUID(auth.user_id),
                     TeamMember.org_id == org_id,
                 ).limit(1)
             )).scalar_one_or_none()
@@ -131,8 +131,12 @@ async def list_activity_logs(
                     "activity_logs EE RBAC applied role=%s member_id=%s",
                     caller_tm.role, caller_tm.id,
                 )
-        except Exception:
-            logger.warning("activity_logs EE RBAC filter failed — fallback to flat log", exc_info=True)
+        # 까심 QA(#2073 REQUEST_CHANGES): 여기서 광범위 Exception을 삼키면 NameError류
+        # 코드버그까지 fail-open(무필터 flat log)으로 마스킹된다 — DB/타입 계열의 실제
+        # "필터 적용 실패"만 fail-open 허용하고, 나머지 코드 버그(NameError/AttributeError
+        # 등)는 그대로 전파해 500으로 가시화한다(조용한 권한 무력화 방지).
+        except (LookupError, ValueError, TypeError) as exc:
+            logger.warning("activity_logs EE RBAC filter failed — fallback to flat log: %s", exc, exc_info=True)
 
     total_result = await db.execute(select(func.count()).select_from(q.subquery()))
     total = total_result.scalar_one()

--- a/backend/app/routers/activity_stream.py
+++ b/backend/app/routers/activity_stream.py
@@ -1,13 +1,14 @@
 import uuid
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.schemas.activity_stream import ActivityStreamItem, ActivityStreamResponse
 from app.services.activity_stream import query_activity_stream
+from app.services.project_auth import has_project_access
 
 router = APIRouter(prefix="/api/v2/activity-stream", tags=["activity-stream"])
 
@@ -25,12 +26,21 @@ async def get_activity_stream(
     limit: int = Query(default=50, ge=1, le=200),
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
 ) -> ActivityStreamResponse:
     """GET /api/v2/activity-stream — 에이전트 team-context 읽기.
 
     org-scope 강제(AC①). activity_seq ASC cursor 페이지네이션(AC③). 응답은 canonical
     활동(source/recipient/payload·AC④)만 — delivery-only status/read는 미포함(AC⑤).
     """
+    # ratchet round7(잔여 HIGH) — activity_logs와 동형: project_id 필터(지정 시)에
+    # caller 접근권 검증이 없어 same-org cross-project 활동 스트림이 노출됐다.
+    # actor_id/object_id 등은 project로 직접 환원되는 FK가 아니라(result-level 노출 축은
+    # 별도 스토리 d3e5ca89) 이 라운드 스코프 밖.
+    if project_id is not None:
+        if not await has_project_access(db, uuid.UUID(auth.user_id), project_id, org_id):
+            raise HTTPException(status_code=404, detail="Project not found")
+
     rows, next_after_seq = await query_activity_stream(
         db,
         org_id,

--- a/backend/tests/test_activity_created_and_actor_404f9958.py
+++ b/backend/tests/test_activity_created_and_actor_404f9958.py
@@ -131,7 +131,7 @@ async def test_list_activity_logs_resolves_actor_name_via_member_resolver(
     resp = await router.list_activity_logs(
         project_id=None, actor_id=None, action=None, entity_type=None,
         entity_id=None, from_=None, to=None, limit=30, offset=0,
-        db=db, org_id=org, _auth=MagicMock(user_id=str(uuid.uuid4())),
+        db=db, org_id=org, auth=MagicMock(user_id=str(uuid.uuid4())),
     )
 
     assert resp.total == 1

--- a/backend/tests/test_activity_stream_api.py
+++ b/backend/tests/test_activity_stream_api.py
@@ -84,7 +84,7 @@ async def test_query_org_scope_filters_and_cursor():
 # ── 라우터 wiring/응답 shape — mock ───────────────────────────────────────────────
 
 async def _client(activity_rows):
-    from app.dependencies.auth import get_verified_org_id
+    from app.dependencies.auth import get_current_user, get_verified_org_id
     from app.dependencies.database import get_db
     from app.main import app
 
@@ -96,8 +96,12 @@ async def _client(activity_rows):
     async def override_db():
         yield mock_session
 
+    async def override_auth():
+        return MagicMock(user_id=str(uuid.uuid4()))
+
     app.dependency_overrides[get_db] = override_db
     app.dependency_overrides[get_verified_org_id] = lambda: uuid.uuid4()
+    app.dependency_overrides[get_current_user] = override_auth
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), app
 
 

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -125,10 +125,6 @@ _FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
 # ── known debt: 실 GAP(HIGH/MEDIUM/LOW) — CRITICAL 3건(EE #2048)은 이미 fix, 나머지는
 # ratchet(PO 결 2026-07-11: baseline 동결 + 점진 상환). fix되면 이 dict에서 제거할 것.
 _KNOWN_DEBT_ALLOWLIST: dict[str, str] = {
-    "app.routers.activity_logs:list_activity_logs":
-        "HIGH — org-scope만·optional project_id 필터에 접근권 검증 없음(actor/action/context 노출)",
-    "app.routers.activity_stream:get_activity_stream":
-        "HIGH — org-scope만·project_id 필터에 접근권 검증 없음",
     "app.routers.epics:list_epics":
         "HIGH — org-scope만·optional project_id 필터에 접근권 검증 없음(epic 제목/목표 노출)",
     "app.routers.members:list_members":

--- a/backend/tests/test_e_security_sec_s8_ratchet_round7_activity_logs_stream_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_ratchet_round7_activity_logs_stream_realdb.py
@@ -1,0 +1,263 @@
+"""E-SECURITY SEC HIGH baseline paydown round7 — #2050 ratchet _KNOWN_DEBT_ALLOWLIST HIGH
+4건 중 activity_logs.list_activity_logs + activity_stream.get_activity_stream 상환
+(둘 다 동형 패턴).
+
+근본: project_id 필터(지정 시)에 caller의 project 접근권 검증이 없어 same-org
+cross-project 감사 로그/활동 스트림(actor/action/entity/context 전문)이 노출됐다.
+project_id는 쿼리파라미터 자체가 조회 대상이라 직접 has_project_access(session, user_id,
+project_id, org_id) 검증으로 봉인. actor_id/entity_id/object_id 등은 project로 직접
+환원되는 FK가 아니라(result-level 노출 축은 별도 스토리 d3e5ca89) 이 라운드 스코프 밖."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a, project_b) + activity_log_b(project_b, action="TOP-SECRET-B-ACTION") +
+    activity_event_b(project_b, verb="top-secret-b-verb") + human_a(project_a에만 명시
+    grant, project_b 접근권 없음)."""
+    from app.models.activity_event import ActivityEvent
+    from app.models.activity_log import ActivityLog
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    log_b = ActivityLog(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_b.id,
+        actor_type="agent", action="TOP-SECRET-B-ACTION",
+    )
+    event_b = ActivityEvent(
+        activity_id=uuid.uuid4(), org_id=org.id, project_id=project_b.id,
+        verb="top-secret-b-verb", occurred_at=datetime.now(timezone.utc),
+        dedup_key=f"dedup-{uuid.uuid4().hex[:8]}",
+    )
+    session.add_all([log_b, event_b])
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"human-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    # project_a에만 명시 grant — project_b 접근권 없음(org owner/admin도 아님).
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_project_a_human_can_list_own_project_activity_logs_empty():
+    """회귀 0: project_a grant 보유 휴먼은 project_a 감사로그 정상 조회(200, 0건이어도 통과)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/activity-logs?project_id={seeded['project_a_id']}")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["items"] == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_grant_human_cannot_list_other_project_activity_logs():
+    """봉인 실증: project_a에만 grant된 휴먼이 project_b 감사로그(action="TOP-SECRET-B-ACTION")
+    를 project_id override로 조회 시도 → 404(기존엔 접근권 검증 0이라 200+유출)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/activity-logs?project_id={seeded['project_b_id']}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_nonexistent_project_id_returns_404_not_leak_activity_logs():
+    """엣지: 존재하지 않는 project_id도 404(존재여부 자체를 흘리지 않음)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/activity-logs?project_id={uuid.uuid4()}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_project_a_human_can_get_own_project_activity_stream_empty():
+    """회귀 0: project_a grant 보유 휴먼은 project_a 활동스트림 정상 조회(200, 0건이어도 통과)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/activity-stream?project_id={seeded['project_a_id']}")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["items"] == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_grant_human_cannot_get_other_project_activity_stream():
+    """봉인 실증: project_a에만 grant된 휴먼이 project_b 활동스트림(verb="top-secret-b-verb")을
+    project_id override로 조회 시도 → 404."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/activity-stream?project_id={seeded['project_b_id']}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_activity_logs_and_stream_without_project_id_still_work_unchanged():
+    """회귀 0: project_id 미지정(org-wide) 호출은 두 엔드포인트 모두 무변경 — 여전히 200
+    (has_project_access 미적용 경로)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp1 = await client.get("/api/v2/activity-logs")
+            assert resp1.status_code == 200, resp1.text
+            resp2 = await client.get("/api/v2/activity-stream")
+            assert resp2.status_code == 200, resp2.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_security_sec_s8_round7_ee_rbac_activity_logs_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_round7_ee_rbac_activity_logs_realdb.py
@@ -1,0 +1,212 @@
+"""까심 QA(#2073 REQUEST_CHANGES) 회귀 테스트: activity_logs의 EE RBAC(S-C4) 블록이
+`_auth`→`auth` rename 후 여전히 정상 동작하는지 실증(리네임 당시 line 123의 `_auth.user_id`
+참조를 놓쳐 EE 활성 시 NameError→광범위 except가 삼켜 fail-open으로 role 무관 flat org-wide
+노출됐던 버그의 회귀가드) + role별(owner 전체/admin agent만/member 본인만) 가시성이 실제
+적용됨을 실증.
+
+EE 모듈은 `app.routers.activity_logs`가 import될 때 `settings.is_ee_enabled`을 1회
+평가해 `_ee_rbac_filter`를 세팅하는 모듈-레벨 게이트라(테스트 세션 중 재평가 안 됨),
+테스트에서는 그 모듈-레벨 전역을 직접 실 함수로 monkeypatch해 EE RBAC 경로를 활성화한다."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org+project + agent 3종(owner/admin/member role, project_access.role로 team_members
+    뷰에 투영) + ActivityLog 3건(각 agent가 actor, action에 role 이름 박아 추적)."""
+    from app.models.activity_log import ActivityLog
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="EE-RBAC Org", slug=f"eerbac-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="EE-RBAC Project")
+    session.add(project)
+    await session.commit()
+
+    agent_owner = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent Owner")
+    agent_admin = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent Admin")
+    agent_member = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent Member")
+    # 4번째 별도 agent — "다른 멤버"의 행위(caller=agent_member 관점에서 절대 안 보여야 함)를
+    # 표현. agent_member 자신의 행위와 혼동되지 않도록 명시 분리.
+    agent_other = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent Other Member")
+    session.add_all([agent_owner, agent_admin, agent_member, agent_other])
+    await session.commit()
+
+    session.add_all([
+        ProjectAccess(id=uuid.uuid4(), project_id=project.id, member_id=agent_owner.id,
+                      permission="granted", role="owner"),
+        ProjectAccess(id=uuid.uuid4(), project_id=project.id, member_id=agent_admin.id,
+                      permission="granted", role="admin"),
+        ProjectAccess(id=uuid.uuid4(), project_id=project.id, member_id=agent_member.id,
+                      permission="granted", role="member"),
+        ProjectAccess(id=uuid.uuid4(), project_id=project.id, member_id=agent_other.id,
+                      permission="granted", role="member"),
+    ])
+    await session.commit()
+
+    log_admin = ActivityLog(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id,
+        actor_id=agent_admin.id, actor_type="agent", action="ADMIN-AGENT-ACTION",
+    )
+    log_other_member_secret = ActivityLog(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id,
+        actor_id=agent_other.id, actor_type="agent", action="OTHER-MEMBER-SECRET-ACTION-XYZ",
+    )
+    log_human = ActivityLog(
+        id=uuid.uuid4(), org_id=org.id, project_id=project.id,
+        actor_id=uuid.uuid4(), actor_type="human", action="HUMAN-ACTION",
+    )
+    session.add_all([log_admin, log_other_member_secret, log_human])
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id,
+        "agent_owner_id": agent_owner.id, "agent_admin_id": agent_admin.id, "agent_member_id": agent_member.id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, agent_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            yield s
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(agent_id), email="agent@test",
+            claims={"app_metadata": {"org_id": str(org_id), "api_key_id": "test-key"}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.fixture(autouse=True)
+def _force_ee_rbac_enabled(monkeypatch):
+    """모듈-레벨 import-time 게이트를 실 필터 함수로 강제 활성화(EE 라이브 재현 조건 시뮬)."""
+    import app.routers.activity_logs as activity_logs_module
+    from ee.services.audit_rbac import filter_activity_by_role
+
+    monkeypatch.setattr(activity_logs_module, "_ee_rbac_filter", filter_activity_by_role)
+
+
+@pytest.mark.anyio
+async def test_owner_agent_sees_all_activity_logs():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["agent_owner_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/activity-logs?project_id={seeded['project_id']}")
+            assert resp.status_code == 200, resp.text
+            actions = {item["action"] for item in resp.json()["items"]}
+            assert actions == {"ADMIN-AGENT-ACTION", "OTHER-MEMBER-SECRET-ACTION-XYZ", "HUMAN-ACTION"}
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_admin_agent_sees_only_agent_type_activity_logs():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["agent_admin_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/activity-logs?project_id={seeded['project_id']}")
+            assert resp.status_code == 200, resp.text
+            actions = {item["action"] for item in resp.json()["items"]}
+            assert actions == {"ADMIN-AGENT-ACTION", "OTHER-MEMBER-SECRET-ACTION-XYZ"}
+            assert "HUMAN-ACTION" not in actions
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_member_agent_sees_only_own_activity_logs_not_other_member_secret():
+    """까심 라이브 재현 그대로: member 역할 caller는 본인 actor_id 행위만 — 다른 멤버의
+    OTHER-MEMBER-SECRET-ACTION-XYZ가 노출되면 안 된다(NameError→fail-open 회귀가드 핵심)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["agent_member_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/activity-logs?project_id={seeded['project_id']}")
+            assert resp.status_code == 200, resp.text
+            actions = {item["action"] for item in resp.json()["items"]}
+            assert "OTHER-MEMBER-SECRET-ACTION-XYZ" not in actions
+            assert "ADMIN-AGENT-ACTION" not in actions
+            assert "HUMAN-ACTION" not in actions
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- #2050 ratchet `_KNOWN_DEBT_ALLOWLIST` 잔여 HIGH 4건 중 `activity_logs.list_activity_logs` + `activity_stream.get_activity_stream` 상환(2건 동시, 4→2).
- 선정 사유: 지시대로 "project로 환원되는 다른 param" 전수 확認했다 — `activity_logs`의 `actor_id`/`entity_id`, `activity_stream`의 `actor_id`/`object_id`는 단일 project로 직접 FK 환원되지 않아(round5 `sprint_id`/round6 `story_id`와 다른 축) 이 라운드 스코프 밖이며, 그런 result-level 노출은 이미 별도 스토리(`d3e5ca89`)로 트래킹 중이라 확認. 두 엔드포인트 모두 `project_id`만이 유일한 project-환원 벡터라 round1~4와 동형 단순 패턴. 잔여 HIGH 4건 중 감사 로그/활동 스트림(actor/action/entity/context 전문·canonical 활동 그래프)이 정보 밀도상 최고 blast-radius라 우선 선정 — 동일 패턴이라 번들.
- fix: 양쪽 다 `auth: AuthContext = Depends(get_current_user)` 추가(`activity_logs`는 기존 `_auth` 미사용 파라미터를 실사용으로 전환) + `has_project_access(db, user_id, project_id, org_id)` 사전검증(실패 시 404).
- 신규 realdb 테스트 6종: 양쪽 회귀0·cross-project 차단·nonexistent-project 404·org-wide 무필터 호출 무변경.

## Test plan
- [x] 신규 realdb 6/6 PASS (fresh Postgres 16, alembic head)
- [x] ratchet 회귀가드 3/3 PASS
- [x] 기존 activity 관련 2파일(`test_activity_created_and_actor_404f9958.py`, `test_activity_stream_api.py`) 9/9 통과 — `_auth=`→`auth=` 리네임(직접 라우터 호출 테스트) + `get_current_user` override 추가(HTTP client 경유 테스트) 반영
- [x] 전체 non-realdb 스위트 3509 passed / 68 failed — round1~6에서 이미 baseline-diff로 증명된 것과 **완전 동일한 68건**(8연속 재확인 — 사전-기존·이번 변경과 무관)
- [x] migration 없음(코드 변경만)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>