### PR TITLE
[SID:e3e60839] 신뢰 파이프라인 최소 실현 — in-flight 전용 칩

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -275,6 +275,8 @@
     "proofCapsuleStateViolation": "Policy violation",
     "proofCapsuleStateClaimed": "Claimed",
     "proofCapsuleStateVerified": "Verified",
+    "trustChipNeedsInput": "Needs input",
+    "trustChipMergeReady": "Merge ready",
     "workcellStateInProgress": "In progress",
     "workcellDodMissing": "No DoD specified",
     "workcellBlockedReason": "Waiting on dependency stories",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -275,6 +275,8 @@
     "proofCapsuleStateViolation": "정책 위반",
     "proofCapsuleStateClaimed": "주장됨",
     "proofCapsuleStateVerified": "검증됨",
+    "trustChipNeedsInput": "입력 필요",
+    "trustChipMergeReady": "병합 대기",
     "workcellStateInProgress": "진행 중",
     "workcellDodMissing": "완료 조건 미기재",
     "workcellBlockedReason": "의존 스토리 대기 중",

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -18,6 +18,7 @@ import { OutcomeResultCard, type OutcomeResult } from '@/components/outcome/outc
 import { StoryHypothesesSection } from '@/components/hypotheses/story-hypotheses-section';
 import { StoryMergeGate } from '@/components/cage/story-merge-gate';
 import { EvidenceSection } from '@/components/verify/evidence-section';
+import { deriveInFlightTrustChip } from '@/services/verify';
 import type { ProofState } from '@/components/proof-capsule/proof-capsule';
 import { Workcell, type WorkcellMessage } from '@/components/workcell/workcell';
 import { initials } from '@/lib/storage/format';
@@ -161,6 +162,9 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
 
   const [deps, setDeps] = useState<DependencyEdge[]>([]);
   const [loadingDeps, setLoadingDeps] = useState(false);
+  // P0-04(trust-pipeline-minimal-decision) — in-flight 전용 신뢰 칩. gate_type/status/
+  // neutral_facts.ci_result만 필요(GateItem 전체 불요) — 얇은 로컬 타입으로 충분.
+  const [chipGates, setChipGates] = useState<{ gate_type: string; status: string; neutral_facts?: Record<string, unknown> | null }[]>([]);
   const [showAddDep, setShowAddDep] = useState(false);
   const [depQuery, setDepQuery] = useState('');
   const [depQueryResults, setDepQueryResults] = useState<{ id: string; title: string }[]>([]);
@@ -330,6 +334,16 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
       .finally(() => setLoadingDeps(false));
   }, [story.id]);
 
+  // P0-04 in-flight 신뢰 칩 — StoryMergeGate와 동형 데이터소스(work_item_id 필터, BE 추가 0).
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/gates?work_item_id=${story.id}&work_item_type=story`, { cache: 'no-store' })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((gates) => { if (!cancelled) setChipGates(Array.isArray(gates) ? gates : []); })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [story.id]);
+
   // Keep the locally-displayed status synced when a different story is selected or the
   // board pushes an external update. Optimistic in-panel changes set it directly (handler),
   // so the badge reflects immediately without waiting for the prop round-trip (S6 AC2 ④).
@@ -344,6 +358,11 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   };
   const statusKey = statusKeyMap[localStatus];
   const statusLabel = statusKey ? t(statusKey) : localStatus;
+
+  // P0-04(trust-pipeline-minimal-decision) — in-flight 전용 칩. done엔 항상 무표시(TrustSeal
+  // 담당·중복 금지, deriveInFlightTrustChip 내부에서 강제). 무신호=칩 자체 미렌더(no-fiction).
+  const trustChip = deriveInFlightTrustChip(localStatus, chipGates);
+  const trustChipLabel = trustChip === 'needs_input' ? t('trustChipNeedsInput') : trustChip === 'merge_ready' ? t('trustChipMergeReady') : null;
 
   // E-UI-DAEGBYEON P0 — Workcell 최소 실화면 배선(story `e5310d1b`, dead-path 방지).
   // 정직한 최소 표면: 실 필드(title/status/assignee/description/acceptance_criteria/
@@ -748,32 +767,49 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 <span className="mt-1 shrink-0 text-xs text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100">✎</span>
               </button>
             )}
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                render={
-                  <button type="button" disabled={savingStatus} aria-label={t('status')}>
-                    <StatusBadge status={localStatus} label={statusLabel} interactive />
-                  </button>
-                }
-              />
-              <DropdownMenuContent align="start">
-                {COLUMNS.map((col) => {
-                  const isCurrent = col.id === localStatus;
-                  // 정공법 A(c1cd484b): 전이-순서 disable 제거 — 어느 상태로든 선택 가능(하드블록 X).
-                  // 비정상 점프는 /status 응답 violation → 비차단 토스트로 가시화.
-                  return (
-                    <DropdownMenuItem
-                      key={col.id}
-                      disabled={savingStatus || isCurrent}
-                      onClick={() => { if (!isCurrent) void handleChangeStatus(col.id); }}
-                    >
-                      <Check className={`size-4 ${isCurrent ? '' : 'opacity-0'}`} />
-                      {t(statusKeyMap[col.id] ?? col.i18nKey)}
-                    </DropdownMenuItem>
-                  );
-                })}
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <div className="flex items-center gap-2">
+              <DropdownMenu>
+                <DropdownMenuTrigger
+                  render={
+                    <button type="button" disabled={savingStatus} aria-label={t('status')}>
+                      <StatusBadge status={localStatus} label={statusLabel} interactive />
+                    </button>
+                  }
+                />
+                <DropdownMenuContent align="start">
+                  {COLUMNS.map((col) => {
+                    const isCurrent = col.id === localStatus;
+                    // 정공법 A(c1cd484b): 전이-순서 disable 제거 — 어느 상태로든 선택 가능(하드블록 X).
+                    // 비정상 점프는 /status 응답 violation → 비차단 토스트로 가시화.
+                    return (
+                      <DropdownMenuItem
+                        key={col.id}
+                        disabled={savingStatus || isCurrent}
+                        onClick={() => { if (!isCurrent) void handleChangeStatus(col.id); }}
+                      >
+                        <Check className={`size-4 ${isCurrent ? '' : 'opacity-0'}`} />
+                        {t(statusKeyMap[col.id] ?? col.i18nKey)}
+                      </DropdownMenuItem>
+                    );
+                  })}
+                </DropdownMenuContent>
+              </DropdownMenu>
+              {/* P0-04(trust-pipeline-minimal-decision) — in-flight 전용 신뢰 칩(입력 필요/병합
+                  대기). done엔 렌더 0(TrustSeal 중복 방지)·무신호(gate 없음)면 칩 자체 미렌더. 5-status
+                  배지는 무변경(순수 additive 오버레이). 칸반 카드엔 안 얹음(Proofline이 이미 담당). */}
+              {trustChip && trustChipLabel ? (
+                <span
+                  className={
+                    trustChip === 'merge_ready'
+                      ? 'inline-flex items-center gap-1.5 rounded-[7px] bg-proof-green-soft px-2 py-0.5 text-[11px] font-semibold text-proof-green'
+                      : 'inline-flex items-center gap-1.5 rounded-[7px] bg-proof-amber-soft px-2 py-0.5 text-[11px] font-semibold text-proof-amber'
+                  }
+                >
+                  <span className={`size-1.5 rounded-full ${trustChip === 'merge_ready' ? 'bg-proof-green' : 'bg-proof-amber'}`} aria-hidden="true" />
+                  {trustChipLabel}
+                </span>
+              ) : null}
+            </div>
             {/* E-VERIFY V0-S3 Lv1/Lv2 + P0-04 Claimed-vs-Verified — 완료 badge의 연장으로 읽히도록
                 바로 아래. 증거 0이면 EvidenceSection 자체가 null 렌더(행 미노출, §7 상태 매트릭스). */}
             <EvidenceSection

--- a/apps/web/src/services/verify.test.ts
+++ b/apps/web/src/services/verify.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { deriveTrustStage } from './verify';
+import { deriveTrustStage, deriveInFlightTrustChip } from './verify';
 
 describe('deriveTrustStage (claimed-vs-verified-spec-handoff §3 파생 규칙)', () => {
   it('returns "verified" when human_verified is true (green 무결성 — human_verified가 유일한 green 조건)', () => {
@@ -18,5 +18,42 @@ describe('deriveTrustStage (claimed-vs-verified-spec-handoff §3 파생 규칙)'
 
   it('never returns "claimed" when human_verified is true, even if self_reported is somehow false (verified takes precedence)', () => {
     expect(deriveTrustStage({ self_reported: false, human_verified: true })).toBe('verified');
+  });
+});
+
+describe('deriveInFlightTrustChip (trust-pipeline-minimal-decision — in-flight 전용 칩)', () => {
+  it('returns "needs_input" when one of the 3 always-manual gate types is pending', () => {
+    expect(deriveInFlightTrustChip('in-review', [{ gate_type: 'loop_decision', status: 'pending' }])).toBe('needs_input');
+    expect(deriveInFlightTrustChip('in-review', [{ gate_type: 'doc_approval', status: 'pending' }])).toBe('needs_input');
+    expect(deriveInFlightTrustChip('in-review', [{ gate_type: 'artifact_canonicalize', status: 'pending' }])).toBe('needs_input');
+  });
+
+  it('returns "merge_ready" when a pending merge gate has ci_result=pass', () => {
+    expect(deriveInFlightTrustChip('in-review', [
+      { gate_type: 'merge', status: 'pending', neutral_facts: { ci_result: 'pass' } },
+    ])).toBe('merge_ready');
+  });
+
+  it('never returns a chip when story.status is "done" — TrustSeal already owns that surface (no duplication)', () => {
+    expect(deriveInFlightTrustChip('done', [{ gate_type: 'loop_decision', status: 'pending' }])).toBeNull();
+    expect(deriveInFlightTrustChip('done', [
+      { gate_type: 'merge', status: 'pending', neutral_facts: { ci_result: 'pass' } },
+    ])).toBeNull();
+  });
+
+  it('returns null when there is no honest signal (no-fiction — no gates, non-pending gates, or ci_result != pass)', () => {
+    expect(deriveInFlightTrustChip('in-progress', [])).toBeNull();
+    expect(deriveInFlightTrustChip('in-progress', [{ gate_type: 'loop_decision', status: 'approved' }])).toBeNull();
+    expect(deriveInFlightTrustChip('in-progress', [
+      { gate_type: 'merge', status: 'pending', neutral_facts: { ci_result: 'fail' } },
+    ])).toBeNull();
+    expect(deriveInFlightTrustChip('in-progress', [{ gate_type: 'merge', status: 'pending' }])).toBeNull();
+  });
+
+  it('prefers merge_ready over needs_input when both are somehow pending simultaneously', () => {
+    expect(deriveInFlightTrustChip('in-review', [
+      { gate_type: 'loop_decision', status: 'pending' },
+      { gate_type: 'merge', status: 'pending', neutral_facts: { ci_result: 'pass' } },
+    ])).toBe('merge_ready');
   });
 });

--- a/apps/web/src/services/verify.ts
+++ b/apps/web/src/services/verify.ts
@@ -41,3 +41,35 @@ export function deriveTrustStage(signal: TrustSignal): TrustStage {
   if (signal.self_reported) return 'claimed';
   return null;
 }
+
+/**
+ * P0-04 — trust-pipeline-minimal-decision(doc) 결정: 6레인 대시보드 기각·in-flight 전용 칩만
+ * 채택. done(주장됨/검증됨)엔 칩 0(TrustSeal이 담당·중복 금지). Queued/Running/범위이탈은
+ * BE 신호 자체가 없어(AgentRun story_id 필터 미착지·범위 스키마 무) 렌더 안 함(no-fiction).
+ */
+export type InFlightTrustChip = 'needs_input' | 'merge_ready' | null;
+
+interface ChipGate {
+  gate_type: string;
+  status: string;
+  neutral_facts?: Record<string, unknown> | null;
+}
+
+// _ALWAYS_MANUAL_GATE_TYPES(BE gate_service.py) 미러 — 항상 사람 입력 대기.
+const NEEDS_INPUT_GATE_TYPES = new Set(['doc_approval', 'loop_decision', 'artifact_canonicalize']);
+
+/**
+ * 결정 doc §스펙: Needs-input(gate 3종 pending)→"입력 필요"(amber)·Merge-ready(merge gate+
+ * ci_result=pass+pending)→"병합 대기"(green). story.status==='done'이면 항상 무표시.
+ */
+export function deriveInFlightTrustChip(storyStatus: string, gates: ChipGate[]): InFlightTrustChip {
+  if (storyStatus === 'done') return null;
+  const pending = gates.filter((g) => g.status === 'pending');
+  if (pending.some((g) => g.gate_type === 'merge' && g.neutral_facts?.['ci_result'] === 'pass')) {
+    return 'merge_ready';
+  }
+  if (pending.some((g) => NEEDS_INPUT_GATE_TYPES.has(g.gate_type))) {
+    return 'needs_input';
+  }
+  return null;
+}


### PR DESCRIPTION
## 요약
P0-04(상태→신뢰 파이프라인) 최종 결정: doc `trust-pipeline-minimal-decision`(유나 목업이 less-is-more로 판가름). 6레인 대시보드는 확定 기각(빈 스테이지 2개=no-fiction 위반 + 기존 표면과 중복 4개=slop). **in-flight 전용 칩**만 채택 — story-detail 헤더에 순수 additive 오버레이 1개.

## 결정 근거 (doc §결정3 요약)
- **Case A(in-flight, "리뷰 중"+gate 대기)**: zero는 신뢰단계가 5-status 뒤에 숨음. chip "입력 필요"는 net-new 레지빌리티 — **칩의 유일 순가치 구간**.
- **Case B(done, "주장됨")**: chip은 바로 아래 TrustSeal "에이전트 주장"과 같은 말 두 번 — 잉여.
→ **done엔 칩 0, in-flight 2스테이지에만 칩.**

## 변경
- `services/verify.ts`: `deriveInFlightTrustChip(storyStatus, gates)` 순수 파생함수.
  - `status==='done'` → 항상 `null`(TrustSeal 중복 방지, 함수 내부에서 강제).
  - pending gate 중 `gate_type==='merge' && neutral_facts.ci_result==='pass'` → `'merge_ready'`("병합 대기", green).
  - pending gate 중 `gate_type`이 `doc_approval`/`loop_decision`/`artifact_canonicalize`(BE `_ALWAYS_MANUAL_GATE_TYPES` 미러) → `'needs_input'`("입력 필요", amber).
  - 둘 다 없으면(또는 Queued/Running/범위이탈처럼 애초에 다루지 않는 스테이지) `null` — 칩 미렌더.
- `story-detail-panel.tsx`: `GET /api/gates?work_item_id={id}&work_item_type=story`(기존 `StoryMergeGate`와 동형 데이터소스, 신규 BE 0) fetch → 5-status 배지 옆(같은 행)에 칩 렌더. 칸반 카드엔 얹지 않음(Proofline이 이미 담당 — doc 명시).
- 신규 컴포넌트 0, 신규 토큰 0(`--proof-amber`/`--proof-green` 재사용).

## no-fiction
Queued/Running(AgentRun story_id 필터 미착지)·범위이탈(스키마 자체 없음)은 애초에 이 함수가 다루지 않음 — BE 신호 없는 스테이지의 렌더 코드조차 만들지 않음.

## 테스트
`deriveInFlightTrustChip` 5건(needs_input 3종·merge_ready·done 강제 null·무신호 null·merge_ready 우선순위). 전체 `vitest` 1200 green, `eslint` 0, `pnpm build` 성공.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>