### PR TITLE
feat(e-glance): #2 wedge BE — 로드맵 조타(STEER) + 오르테가 이벤트 (story 96b19bc3)

### DIFF
--- a/backend/alembic/versions/0175_epic_position_source_loop_id.py
+++ b/backend/alembic/versions/0175_epic_position_source_loop_id.py
@@ -1,0 +1,47 @@
+"""E-GLANCE wedge #2(story 96b19bc3) — epics.position + epics.source_loop_id 컬럼.
+
+Revision ID: 0175
+Revises: 0174
+Create Date: 2026-07-11
+
+BE 설계 doc `be-design-roadmap-steer-ortega-events-96b19bc3` §1.1/§4.1. 둘 다 순수
+additive nullable — 기존 epic 전부 무영향, 백필 없음.
+
+- position: Story.position(BigInteger, nullable)과 완전 동형 — 로드맵 조타(재정렬)
+  큐레이션 필드. null=아직 큐레이션 안 됨(자동도출 순서 유지).
+- source_loop_id: loop_runs.id FK(ON DELETE SET NULL) — 어떤 epic이 어느 Loop 결과에서
+  파생 제안됐는지 계보 인터페이스만(이 스토리 스코프=컬럼 존재까지, 배선은 후속 P3).
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0175"
+down_revision = "0174"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "epics",
+        sa.Column("position", sa.BigInteger(), nullable=True),
+    )
+    op.add_column(
+        "epics",
+        sa.Column("source_loop_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_epics_source_loop_id_loop_runs",
+        "epics", "loop_runs",
+        ["source_loop_id"], ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_epics_source_loop_id_loop_runs", "epics", type_="foreignkey")
+    op.drop_column("epics", "source_loop_id")
+    op.drop_column("epics", "position")

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -70,6 +70,14 @@ class Epic(Base, OrgScopedMixin, TimestampMixin):
     # E-BOARD-SCHEMA: 채점 필드 (outcome, 채점잡 전용)
     outcome_status: Mapped[str] = mapped_column(String(20), nullable=False, server_default="n_a")
     outcome_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    # E-GLANCE wedge #2(story 96b19bc3) — 로드맵 조타 큐레이션. Story.position과 완전 동형
+    # (null=아직 큐레이션 안 됨·자동도출 순서 유지). 0175 additive nullable.
+    position: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    # source_loop_id: 어떤 epic이 어느 Loop 결과에서 파생 제안됐는지 계보 인터페이스(컬럼만·
+    # 배선은 P3 후속). Loop이 epic을 자동 생성하지 않음(STEER: 휴먼이 항상 약속을 얹는다).
+    source_loop_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("loop_runs.id", ondelete="SET NULL"), nullable=True
+    )
 
     project: Mapped["Project"] = relationship("Project", back_populates="epics")
     stories: Mapped[list["Story"]] = relationship("Story", back_populates="epic", lazy="select")

--- a/backend/app/repositories/epic.py
+++ b/backend/app/repositories/epic.py
@@ -36,13 +36,42 @@ class EpicRepository(BaseRepository[Epic]):
         **filters: Any,
     ) -> tuple[list[Epic], int]:
         """기본 페이지네이션 + 연결 가설 집계(hypothesis_count·risky_status) + 스토리 집계
-        (total_stories·done_stories) 부착."""
-        epics, total = await super().list_paginated(
-            limit=limit, cursor=cursor, order_by=order_by, **filters
-        )
+        (total_stories·done_stories) 부착.
+
+        E-GLANCE wedge #2(story 96b19bc3) §1.3: order_by="position"은 옵트인 로드맵 조타
+        정렬 — (position IS NULL) ASC, position ASC, created_at DESC 복합 규칙이라 BaseRepository의
+        단조-컬럼 cursor 메커니즘(datetime 비교)과 shape가 달라 별도 경로로 처리한다(cursor
+        파라미터는 이 모드에서 미지원 — v1 스코프, #2056 기본 정렬 경로는 완전 무변경).
+        """
+        if order_by == "position":
+            epics, total = await self._list_paginated_by_position(limit=limit, **filters)
+        else:
+            epics, total = await super().list_paginated(
+                limit=limit, cursor=cursor, order_by=order_by, **filters
+            )
         await self._attach_hypothesis_aggregates(epics)
         await self._attach_story_aggregates(epics)
         return epics, total
+
+    async def _list_paginated_by_position(
+        self, *, limit: int | None, **filters: Any,
+    ) -> tuple[list[Epic], int]:
+        conds = [self._org_filter()]
+        for attr, val in filters.items():
+            conds.append(getattr(Epic, attr) == val)
+
+        count_result = await self.session.execute(
+            select(func.count()).select_from(Epic).where(*conds)
+        )
+        total = int(count_result.scalar_one() or 0)
+
+        q = (
+            select(Epic).where(*conds)
+            .order_by(Epic.position.is_(None).asc(), Epic.position.asc(), Epic.created_at.desc())
+            .limit(limit if limit is not None else 1000)
+        )
+        result = await self.session.execute(q)
+        return list(result.scalars().all()), total
 
     async def _attach_hypothesis_aggregates(self, epics: Sequence[Epic]) -> None:
         """페이지 전체 epic의 연결 가설 수/최위험 상태를 단일 쿼리로 집계해 부착.

--- a/backend/app/routers/epics.py
+++ b/backend/app/routers/epics.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user, get_verified_org_id
@@ -67,7 +68,9 @@ async def list_epics(
         limit=limit, cursor=cursor_dt, order_by=order_by, **filters
     )
     response.headers["X-Total-Count"] = str(total)
-    if epics:
+    # order_by="position"(옵트인 로드맵 조타 정렬, wedge #2)은 복합 정렬이라 created_at cursor로
+    # 이어붙일 수 없다 — 이 모드에서는 X-Next-Cursor 미노출(호출자가 이어달리기 시도 안 하도록).
+    if epics and order_by != "position":
         response.headers["X-Next-Cursor"] = epics[-1].created_at.isoformat()
     return [EpicResponse.model_validate(e) for e in epics]
 
@@ -110,6 +113,17 @@ async def create_epic(
         measure_after=body.measure_after,
         outcome_status=_resolve_outcome_status(body.metric_definition, body.measure_after),
     )
+    # E-GLANCE wedge #2(story 96b19bc3): epic.created 이벤트 — 오르테가 구독 채널(fire_webhooks).
+    # actor 해소 실패는 emit 자체를 막지 않는다(bulk_update_stories와 동형 best-effort).
+    from app.services.epic_events import emit_epic_created
+    from app.services.member_resolver import resolve_member
+
+    _actor_id: uuid.UUID | None = None
+    try:
+        _actor_id = (await resolve_member(auth, org_id, session)).id
+    except Exception:  # noqa: BLE001
+        _actor_id = None
+    await emit_epic_created(session, org_id, epic, actor_id=_actor_id)
     return EpicResponse.model_validate(epic)
 
 
@@ -122,6 +136,76 @@ async def get_epic(
     if epic is None:
         raise HTTPException(status_code=404, detail="Epic not found")
     return EpicResponse.model_validate(epic)
+
+
+class BulkEpicPositionItem(BaseModel):
+    id: uuid.UUID
+    position: int
+
+
+class BulkEpicPositionRequest(BaseModel):
+    # stories.py bulk_update_stories와 동일 계약(items 래퍼) — FE dnd 공통 패턴.
+    items: list[BulkEpicPositionItem]
+
+
+# ⚠️ /bulk 은 /{id} 보다 **먼저** 선언해야 한다(FastAPI 라우트 매칭=선언 순서·specific-before-
+# parameterized) — stories.py bulk_update_stories와 동일 교훈(PATCH /bulk가 /{id}에 매칭돼
+# id="bulk" UUID 파싱 422로 shadow되는 사고 재발 방지).
+@router.patch("/bulk", response_model=list[EpicResponse])
+async def bulk_update_epics(
+    payload: BulkEpicPositionRequest,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> list[EpicResponse]:
+    """PATCH /api/v2/epics/bulk — 로드맵 조타(재정렬, story 96b19bc3 §1.4).
+
+    SEC-S8 W/W2 하드닝을 **처음부터** 내장(bulk_update_stories 템플릿 그대로 이식 — 회귀로
+    나중에 패치하지 않고 설계 단계서 봉인): org_id 필터로 cross-org IDOR 원천 차단(W) +
+    has_project_access(대상 epic.project_id, resource-actual — body-claimed 아님)로 same-org
+    cross-project도 차단(W2). 미접근 item은 not-found와 동형으로 조용히 스킵(존재 비노출·
+    나머지 정당 item은 진행).
+    """
+    from app.models.pm import Epic
+
+    updated: list[Epic] = []
+    reordered_items: list[dict] = []
+    for item in payload.items:
+        q = await session.execute(
+            select(Epic).where(Epic.id == item.id, Epic.org_id == org_id)
+        )
+        epic = q.scalar_one_or_none()
+        if not epic:
+            continue
+        if not await has_project_access(session, uuid.UUID(auth.user_id), epic.project_id, org_id):
+            continue
+        old_position = epic.position
+        epic.position = item.position
+        updated.append(epic)
+        reordered_items.append({
+            "id": epic.id, "title": epic.title, "project_id": epic.project_id,
+            "position": item.position, "old_position": old_position,
+        })
+
+    # P0/MissingGreenlet: setattr 후 flush만으로는 onupdate 서버생성 컬럼(updated_at)이 파이썬
+    # 객체에 반영 안 됨 — bulk_update_stories와 동형으로 flush+refresh 후 commit.
+    await session.flush()
+    for e in updated:
+        await session.refresh(e)
+    await session.commit()
+
+    # epic.reordered 배치당 1회 발화(N개 재정렬에 N번 웹훅 방지, §2.3).
+    from app.services.epic_events import emit_epic_reordered
+    from app.services.member_resolver import resolve_member
+
+    _actor_id: uuid.UUID | None = None
+    try:
+        _actor_id = (await resolve_member(auth, org_id, session)).id
+    except Exception:  # noqa: BLE001
+        _actor_id = None
+    await emit_epic_reordered(session, org_id, reordered_items, actor_id=_actor_id)
+
+    return [EpicResponse.model_validate(e) for e in updated]
 
 
 @router.patch("/{id}", response_model=EpicResponse)
@@ -202,11 +286,19 @@ async def delete_epic(
         id=uuid.uuid4(), org_id=org_id, actor_id=resolved.id,
         entity_type="epic", entity_id=id, entity_title=epic.title,
     ))
+    # E-GLANCE wedge #2: 삭제 前 title/project_id 캡처(삭제 後 조회 불가) — epic.removed 이벤트용.
+    _epic_title = epic.title
+    _epic_project_id = epic.project_id
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Epic not found")
     await DependencyRepository(session, org_id).delete_by_item(id, "epic")
     await ItemLabelRepository(session, org_id).delete_by_item(id, "epic")
+
+    from app.services.epic_events import emit_epic_removed
+    await emit_epic_removed(
+        session, org_id, id, _epic_title, _epic_project_id, actor_id=resolved.id,
+    )
     return {"ok": True}
 
 
@@ -235,13 +327,23 @@ async def transition_epic_endpoint(
 ) -> EpicResponse:
     """E-DG S25: epic decision lifecycle 전이(create/update 분리). draft→active(human-only)·active→done
     line overlay. caller 는 인증 컨텍스트에서 도출(RC① 패턴·body 신뢰 X)."""
+    from sqlalchemy import select
+
+    from app.models.pm import Epic
     from app.services.epic import EpicTransitionError, transition_epic
+    from app.services.epic_events import emit_epic_status_changed
     from app.services.member_resolver import resolve_member
 
     caller = await resolve_member(auth, org_id, session)
     try:
+        # E-GLANCE wedge #2: 전이 前 old_status 포착(overlay-gate로 실제 미변경일 수도 있음 —
+        # emit_epic_status_changed가 old==new no-op 자체 가드하므로 안전).
+        _old_status = (await session.execute(
+            select(Epic.status).where(Epic.id == id, Epic.org_id == org_id)
+        )).scalar_one_or_none()
         epic = await transition_epic(session, org_id, caller, id, body.status)
         await session.commit()
+        await emit_epic_status_changed(session, org_id, epic, _old_status, actor_id=caller.id)
         return EpicResponse.model_validate(epic)
     except EpicTransitionError as e:
         _codes = {

--- a/backend/app/schemas/epic.py
+++ b/backend/app/schemas/epic.py
@@ -85,6 +85,10 @@ class EpicResponse(BaseModel):
     # bloat 방지). 미부착 경로(get/create/update)는 기본값. detail은 별도 /progress 유지.
     total_stories: int = 0
     done_stories: int = 0
+    # E-GLANCE wedge #2(story 96b19bc3): 로드맵 조타 큐레이션(Story.position 동형) — null=아직
+    # 큐레이션 안 됨. source_loop_id는 계보 인터페이스뿐(배선은 P3 후속).
+    position: int | None = None
+    source_loop_id: uuid.UUID | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/services/epic_events.py
+++ b/backend/app/services/epic_events.py
@@ -1,0 +1,117 @@
+"""E-GLANCE wedge #2(story 96b19bc3) — epic.* 이벤트 발화(app/services/story_status_events.py
+축소판).
+
+Story의 5-effect(publish_event·fire_webhooks·process_event·dispatch_notification·
+StoryActivity) 전부를 복제하지 않는다 — 근거(BE design doc §2.2): 이 이벤트의 1차 소비자는
+오르테가(웹훅)이지 특정 assignee 알림이 아니다. v1 스코프 = 3-effect:
+publish_event(항상)·fire_webhooks(오르테가 구독 채널)·dispatch_notification(assignee 있을
+때만, 선택적). process_event(workflow_pipeline 에이전트 라우팅 룰 트리거)는 로드맵 이벤트가
+자동으로 에이전트 워크플로 룰을 발화해야 할 근거가 아직 없어 v1 제외(§2.2)."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+
+def _base_event_data(
+    epic_id: uuid.UUID, epic_title: str, project_id: uuid.UUID, org_id: uuid.UUID,
+    actor_id: uuid.UUID | None,
+) -> dict[str, Any]:
+    return {
+        "epic_id": str(epic_id),
+        "epic_title": epic_title,
+        "project_id": str(project_id),
+        "org_id": str(org_id),
+        "actor_id": str(actor_id) if actor_id else None,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+async def _emit(
+    db, org_id: uuid.UUID, event_type: str, event_data: dict[str, Any],
+    *, notify_member_id: uuid.UUID | None,
+) -> None:
+    """publish_event(항상)+fire_webhooks(관련자만 게이팅, member_id=null 브로드캐스트 보존)+
+    dispatch_notification(assignee 있을 때만). 각 effect는 best-effort(실패 격리)."""
+    from app.routers.events import publish_event
+    from app.services.notification_dispatch import dispatch_notification
+    from app.services.webhook_dispatch import fire_webhooks
+
+    notify_ids: set[uuid.UUID] = {notify_member_id} if notify_member_id else set()
+
+    publish_event(str(org_id), event_type, event_data)
+    try:
+        await fire_webhooks(db, org_id, event_type, event_data, recipient_member_ids=notify_ids)
+    except Exception:
+        pass
+
+    if notify_ids:
+        try:
+            await dispatch_notification(
+                db,
+                org_id=org_id,
+                event_type=event_type.replace(".", "_"),
+                target_member_ids=list(notify_ids),
+                title=f"에픽 {event_type.split('.')[-1]}: {event_data.get('epic_title')}",
+                body=None,
+                reference_type="epic",
+                reference_id=uuid.UUID(event_data["epic_id"]),
+                source_project_id=uuid.UUID(event_data["project_id"]),
+            )
+        except Exception:
+            pass
+
+
+async def emit_epic_created(db, org_id: uuid.UUID, epic, *, actor_id: uuid.UUID | None = None) -> None:
+    event_data = _base_event_data(epic.id, epic.title, epic.project_id, org_id, actor_id)
+    await _emit(db, org_id, "epic.created", event_data, notify_member_id=epic.assignee_id)
+
+
+async def emit_epic_status_changed(
+    db, org_id: uuid.UUID, epic, old_status: str | None, *, actor_id: uuid.UUID | None = None,
+) -> None:
+    """old==new면 no-op(emit_story_status_changed와 동형 규율)."""
+    if old_status == epic.status:
+        return
+    event_data = _base_event_data(epic.id, epic.title, epic.project_id, org_id, actor_id)
+    event_data["old_status"] = old_status
+    event_data["status"] = epic.status
+    await _emit(db, org_id, "epic.status_changed", event_data, notify_member_id=epic.assignee_id)
+
+
+async def emit_epic_removed(
+    db, org_id: uuid.UUID, epic_id: uuid.UUID, epic_title: str, project_id: uuid.UUID,
+    *, actor_id: uuid.UUID | None = None,
+) -> None:
+    """호출자가 삭제 직전에 epic_title/project_id를 캡처해 넘긴다(삭제 後엔 조회 불가)."""
+    event_data = _base_event_data(epic_id, epic_title, project_id, org_id, actor_id)
+    await _emit(db, org_id, "epic.removed", event_data, notify_member_id=None)
+
+
+async def emit_epic_reordered(
+    db, org_id: uuid.UUID, items: list[dict[str, Any]], *, actor_id: uuid.UUID | None = None,
+) -> None:
+    """배치당 1회 발화(N개 재정렬에 N번 웹훅 방지) — payload에 items 배열 통째로.
+
+    items: [{"id": uuid, "title": str, "project_id": uuid, "position": int,
+             "old_position": int | None}, ...] — 실제 변경 적용된 epic만(호출자가 필터).
+    project_id는 items의 첫 항목 기준(bulk는 단일-project 호출이 일반적이나 cross-project
+    silent-skip 후 남은 items가 여러 project에 걸칠 수 있어 대표값일 뿐 — FE는 items로 소비).
+    """
+    if not items:
+        return
+    representative = items[0]
+    event_data = _base_event_data(
+        representative["id"], representative["title"], representative["project_id"], org_id, actor_id,
+    )
+    event_data["position"] = str(representative["position"])
+    event_data["old_position"] = str(representative.get("old_position")) if representative.get("old_position") is not None else None
+    event_data["items"] = [
+        {
+            "id": str(it["id"]), "title": it["title"], "project_id": str(it["project_id"]),
+            "position": it["position"], "old_position": it.get("old_position"),
+        }
+        for it in items
+    ]
+    await _emit(db, org_id, "epic.reordered", event_data, notify_member_id=None)

--- a/backend/app/services/epic_events.py
+++ b/backend/app/services/epic_events.py
@@ -32,13 +32,22 @@ async def _emit(
     db, org_id: uuid.UUID, event_type: str, event_data: dict[str, Any],
     *, notify_member_id: uuid.UUID | None,
 ) -> None:
-    """publish_event(항상)+fire_webhooks(관련자만 게이팅, member_id=null 브로드캐스트 보존)+
-    dispatch_notification(assignee 있을 때만). 각 effect는 best-effort(실패 격리)."""
+    """publish_event(항상)+fire_webhooks(assignee 있으면 관련자 게이팅, 없으면 무-게이팅=org
+    전체 구독 웹훅 도달)+dispatch_notification(assignee 있을 때만). 각 effect는
+    best-effort(실패 격리).
+
+    까심 QA(#2076 REQUEST_CHANGES) 재현 fix: fire_webhooks(recipient_member_ids=)는
+    **빈 집합도 "게이팅 활성"으로 취급**해 member-bound 웹훅을 전부 drop한다
+    (WebhookConfig.member_id가 nullable=False라 broadcast(member_id=null) 개념 자체가
+    없음 — preserve_broadcast로 구제될 여지도 없음). notify_member_id가 None(assignee
+    없음 — epic.reordered/removed는 항상 이 케이스)이면 반드시 recipient_member_ids=None
+    (게이팅 미적용)으로 넘겨야 오르테가 같은 org-wide 구독 웹훅이 실제로 수신한다.
+    `{notify_member_id} if notify_member_id else set()`(빈 집합)이 이 버그의 근본이었다."""
     from app.routers.events import publish_event
     from app.services.notification_dispatch import dispatch_notification
     from app.services.webhook_dispatch import fire_webhooks
 
-    notify_ids: set[uuid.UUID] = {notify_member_id} if notify_member_id else set()
+    notify_ids: set[uuid.UUID] | None = {notify_member_id} if notify_member_id else None
 
     publish_event(str(org_id), event_type, event_data)
     try:

--- a/backend/app/services/event_taxonomy.py
+++ b/backend/app/services/event_taxonomy.py
@@ -37,6 +37,44 @@ EVENT_TAXONOMY: dict[str, list[EventParam]] = {
         EventParam("story_id", "str", True, "트리거된 스토리 UUID"),
         EventParam("actor_id", "uuid", False, "실행자 user UUID"),
     ],
+    # E-GLANCE wedge #2(story 96b19bc3): 로드맵 조타 + 오르테가 이벤트 구독. story.status_changed와
+    # 동일 shape(스키마 재사용, 신규 필드 패턴 발명 금지).
+    "epic.created": [
+        EventParam("epic_id", "uuid", True, "에픽 UUID"),
+        EventParam("epic_title", "str", True, "에픽 제목"),
+        EventParam("project_id", "uuid", True, "프로젝트 UUID"),
+        EventParam("org_id", "uuid", True, "조직 UUID"),
+        EventParam("actor_id", "uuid", False, "실행자 team_member UUID"),
+        EventParam("timestamp", "str", True, "ISO 8601 UTC 타임스탬프"),
+    ],
+    "epic.status_changed": [
+        EventParam("epic_id", "uuid", True, "에픽 UUID"),
+        EventParam("epic_title", "str", True, "에픽 제목"),
+        EventParam("old_status", "str", True, "변경 전 상태"),
+        EventParam("status", "str", True, "변경 후 상태"),
+        EventParam("project_id", "uuid", True, "프로젝트 UUID"),
+        EventParam("org_id", "uuid", True, "조직 UUID"),
+        EventParam("actor_id", "uuid", False, "실행자 team_member UUID"),
+        EventParam("timestamp", "str", True, "ISO 8601 UTC 타임스탬프"),
+    ],
+    "epic.reordered": [
+        EventParam("epic_id", "uuid", True, "에픽 UUID(배치 중 1건 대표 — items에 전체)"),
+        EventParam("epic_title", "str", True, "에픽 제목"),
+        EventParam("project_id", "uuid", True, "프로젝트 UUID"),
+        EventParam("org_id", "uuid", True, "조직 UUID"),
+        EventParam("position", "str", True, "변경 후 position(batch=list 직렬화)"),
+        EventParam("old_position", "str", False, "변경 전 position(batch=list 직렬화)"),
+        EventParam("actor_id", "uuid", False, "실행자 team_member UUID"),
+        EventParam("timestamp", "str", True, "ISO 8601 UTC 타임스탬프"),
+    ],
+    "epic.removed": [
+        EventParam("epic_id", "uuid", True, "에픽 UUID"),
+        EventParam("epic_title", "str", True, "에픽 제목"),
+        EventParam("project_id", "uuid", True, "프로젝트 UUID"),
+        EventParam("org_id", "uuid", True, "조직 UUID"),
+        EventParam("actor_id", "uuid", False, "실행자 team_member UUID"),
+        EventParam("timestamp", "str", True, "ISO 8601 UTC 타임스탬프"),
+    ],
 }
 
 

--- a/backend/tests/test_e_board_schema_s1_epic_outcome.py
+++ b/backend/tests/test_e_board_schema_s1_epic_outcome.py
@@ -115,6 +115,11 @@ def _base_epic_mock(outcome_status: str = "n_a") -> MagicMock:
     # E1 S8b: EpicResponse 신규 집계 필드 — MagicMock auto-attr ValidationError 방지.
     e.hypothesis_count = 0
     e.risky_status = None
+    e.total_stories = 0
+    e.done_stories = 0
+    # E-GLANCE wedge #2(story 96b19bc3): 신규 필드 — 동일 사유.
+    e.position = None
+    e.source_loop_id = None
     e.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     e.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     return e

--- a/backend/tests/test_e_glance_epic_events_unit.py
+++ b/backend/tests/test_e_glance_epic_events_unit.py
@@ -1,0 +1,166 @@
+"""E-GLANCE wedge #2(story 96b19bc3) — app/services/epic_events.py 단위 테스트.
+
+emit_story_status_changed 격리 테스트(test_emit_story_status_changed_isolation.py)와 동형
+패턴: publish_event/fire_webhooks/dispatch_notification을 mock해 (1) 각 이벤트타입의
+정확한 event_type+payload shape, (2) side-effect 실패가 전파되지 않음(best-effort 격리),
+(3) status_changed의 old==new no-op 가드를 검증한다."""
+from __future__ import annotations
+
+import uuid
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.epic_events import (
+    emit_epic_created,
+    emit_epic_reordered,
+    emit_epic_removed,
+    emit_epic_status_changed,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _epic(status: str = "active", assignee_id: uuid.UUID | None = None):
+    return SimpleNamespace(
+        id=uuid.uuid4(), title="Epic X", project_id=uuid.uuid4(), status=status,
+        assignee_id=assignee_id,
+    )
+
+
+def _base_patches(stack: ExitStack, *, publish=None, webhook=None, notif=None):
+    stack.enter_context(patch("app.routers.events.publish_event", publish or MagicMock()))
+    stack.enter_context(patch(
+        "app.services.webhook_dispatch.fire_webhooks", webhook or AsyncMock(),
+    ))
+    stack.enter_context(patch(
+        "app.services.notification_dispatch.dispatch_notification", notif or AsyncMock(),
+    ))
+
+
+@pytest.mark.anyio
+async def test_emit_epic_created_fires_publish_and_webhook_with_correct_shape():
+    epic = _epic()
+    publish = MagicMock()
+    webhook = AsyncMock()
+    with ExitStack() as stack:
+        _base_patches(stack, publish=publish, webhook=webhook)
+        await emit_epic_created(AsyncMock(), uuid.uuid4(), epic, actor_id=uuid.uuid4())
+
+    publish.assert_called_once()
+    args = publish.call_args[0]
+    assert args[1] == "epic.created"
+    assert args[2]["epic_id"] == str(epic.id)
+    assert args[2]["epic_title"] == "Epic X"
+
+    webhook.assert_awaited_once()
+    wh_args = webhook.call_args[0]
+    assert wh_args[2] == "epic.created"
+
+
+@pytest.mark.anyio
+async def test_emit_epic_status_changed_no_op_when_old_equals_new():
+    """old_status == epic.status면 완전 no-op(publish_event조차 호출 안 됨) —
+    emit_story_status_changed와 동형 규율."""
+    epic = _epic(status="active")
+    publish = MagicMock()
+    webhook = AsyncMock()
+    with ExitStack() as stack:
+        _base_patches(stack, publish=publish, webhook=webhook)
+        await emit_epic_status_changed(AsyncMock(), uuid.uuid4(), epic, "active")
+
+    publish.assert_not_called()
+    webhook.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_emit_epic_status_changed_fires_with_old_and_new_status():
+    epic = _epic(status="done")
+    publish = MagicMock()
+    with ExitStack() as stack:
+        _base_patches(stack, publish=publish)
+        await emit_epic_status_changed(AsyncMock(), uuid.uuid4(), epic, "active")
+
+    publish.assert_called_once()
+    payload = publish.call_args[0][2]
+    assert payload["old_status"] == "active"
+    assert payload["status"] == "done"
+
+
+@pytest.mark.anyio
+async def test_emit_epic_removed_uses_pre_captured_title_not_epic_object():
+    """삭제 後엔 epic 객체 조회 불가 — 호출자가 넘긴 title/project_id로만 payload 구성."""
+    publish = MagicMock()
+    epic_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    with ExitStack() as stack:
+        _base_patches(stack, publish=publish)
+        await emit_epic_removed(AsyncMock(), uuid.uuid4(), epic_id, "Deleted Epic", project_id)
+
+    payload = publish.call_args[0][2]
+    assert payload["epic_id"] == str(epic_id)
+    assert payload["epic_title"] == "Deleted Epic"
+    assert payload["project_id"] == str(project_id)
+
+
+@pytest.mark.anyio
+async def test_emit_epic_reordered_fires_once_for_batch_not_per_item():
+    """배치당 1회 발화(N개 재정렬에 N번 웹훅 방지, §2.3) — items 배열 통째로 payload에."""
+    items = [
+        {"id": uuid.uuid4(), "title": "A", "project_id": uuid.uuid4(), "position": 1, "old_position": None},
+        {"id": uuid.uuid4(), "title": "B", "project_id": uuid.uuid4(), "position": 2, "old_position": 5},
+    ]
+    publish = MagicMock()
+    webhook = AsyncMock()
+    with ExitStack() as stack:
+        _base_patches(stack, publish=publish, webhook=webhook)
+        await emit_epic_reordered(AsyncMock(), uuid.uuid4(), items)
+
+    publish.assert_called_once()
+    webhook.assert_awaited_once()
+    payload = publish.call_args[0][2]
+    assert len(payload["items"]) == 2
+    assert payload["items"][1]["old_position"] == 5
+
+
+@pytest.mark.anyio
+async def test_emit_epic_reordered_empty_items_is_noop():
+    publish = MagicMock()
+    with ExitStack() as stack:
+        _base_patches(stack, publish=publish)
+        await emit_epic_reordered(AsyncMock(), uuid.uuid4(), [])
+    publish.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_webhook_failure_does_not_propagate():
+    """side-effect 실패가 emit 흐름을 깨지 않음(best-effort 격리 — emit_story_status_changed와 동형)."""
+    epic = _epic()
+    webhook = AsyncMock(side_effect=RuntimeError("webhook down"))
+    with ExitStack() as stack:
+        _base_patches(stack, webhook=webhook)
+        await emit_epic_created(AsyncMock(), uuid.uuid4(), epic)  # 예외 없이 반환.
+    webhook.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_dispatch_notification_only_called_when_assignee_present():
+    """assignee_id 없으면 dispatch_notification 미호출(§2.2 "선택적")."""
+    epic = _epic(assignee_id=None)
+    notif = AsyncMock()
+    with ExitStack() as stack:
+        _base_patches(stack, notif=notif)
+        await emit_epic_created(AsyncMock(), uuid.uuid4(), epic)
+    notif.assert_not_awaited()
+
+    epic_with_assignee = _epic(assignee_id=uuid.uuid4())
+    notif2 = AsyncMock()
+    with ExitStack() as stack:
+        _base_patches(stack, notif=notif2)
+        await emit_epic_created(AsyncMock(), uuid.uuid4(), epic_with_assignee)
+    notif2.assert_awaited_once()

--- a/backend/tests/test_e_glance_epic_events_unit.py
+++ b/backend/tests/test_e_glance_epic_events_unit.py
@@ -61,6 +61,23 @@ async def test_emit_epic_created_fires_publish_and_webhook_with_correct_shape():
     webhook.assert_awaited_once()
     wh_args = webhook.call_args[0]
     assert wh_args[2] == "epic.created"
+    # 까심 QA(#2076 REQUEST_CHANGES) 회귀가드: assignee 없으면 recipient_member_ids는 반드시
+    # None(게이팅 미적용)이어야 한다 — 빈 집합이면 fire_webhooks가 member-bound 웹훅(오르테가
+    # 포함)을 전부 drop한다(WebhookConfig.member_id nullable=False, broadcast 개념 없음).
+    assert webhook.call_args.kwargs["recipient_member_ids"] is None
+
+
+@pytest.mark.anyio
+async def test_emit_epic_created_with_assignee_gates_to_that_member_not_empty_set():
+    """assignee 있으면 그 멤버로 게이팅(의도된 동작) — None도 빈 집합도 아님."""
+    assignee_id = uuid.uuid4()
+    epic = _epic(assignee_id=assignee_id)
+    webhook = AsyncMock()
+    with ExitStack() as stack:
+        _base_patches(stack, webhook=webhook)
+        await emit_epic_created(AsyncMock(), uuid.uuid4(), epic)
+
+    assert webhook.call_args.kwargs["recipient_member_ids"] == {assignee_id}
 
 
 @pytest.mark.anyio
@@ -96,16 +113,20 @@ async def test_emit_epic_status_changed_fires_with_old_and_new_status():
 async def test_emit_epic_removed_uses_pre_captured_title_not_epic_object():
     """삭제 後엔 epic 객체 조회 불가 — 호출자가 넘긴 title/project_id로만 payload 구성."""
     publish = MagicMock()
+    webhook = AsyncMock()
     epic_id = uuid.uuid4()
     project_id = uuid.uuid4()
     with ExitStack() as stack:
-        _base_patches(stack, publish=publish)
+        _base_patches(stack, publish=publish, webhook=webhook)
         await emit_epic_removed(AsyncMock(), uuid.uuid4(), epic_id, "Deleted Epic", project_id)
 
     payload = publish.call_args[0][2]
     assert payload["epic_id"] == str(epic_id)
     assert payload["epic_title"] == "Deleted Epic"
     assert payload["project_id"] == str(project_id)
+    # 까심 QA(#2076) 회귀가드: epic.removed엔 assignee 개념 자체가 없어 notify_member_id는
+    # 항상 None — recipient_member_ids도 반드시 None(빈 집합 아님)이어야 오르테가 도달.
+    assert webhook.call_args.kwargs["recipient_member_ids"] is None
 
 
 @pytest.mark.anyio
@@ -126,6 +147,11 @@ async def test_emit_epic_reordered_fires_once_for_batch_not_per_item():
     payload = publish.call_args[0][2]
     assert len(payload["items"]) == 2
     assert payload["items"][1]["old_position"] == 5
+    # 까심 QA(#2076) 재현 회귀가드: epic.reordered엔 assignee 개념이 없어 notify_member_id는
+    # 항상 None — recipient_member_ids도 반드시 None이어야 한다(까심이 실 배달 0건으로 재현한
+    # 정확한 버그: 이 값이 빈 집합이면 fire_webhooks가 게이팅을 활성화해 member-bound 웹훅을
+    # 전부 drop — WebhookConfig.member_id nullable=False라 broadcast 구제 경로도 없음).
+    assert webhook.call_args.kwargs["recipient_member_ids"] is None
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_e_glance_wedge_roadmap_steer_realdb.py
+++ b/backend/tests/test_e_glance_wedge_roadmap_steer_realdb.py
@@ -419,3 +419,63 @@ async def test_list_epics_default_order_unchanged_no_position_field_forced():
     finally:
         app.dependency_overrides.clear()
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_epic_reordered_real_webhook_config_actually_receives_delivery():
+    """까심 QA(#2076 REQUEST_CHANGES) #2 요구: fire_webhooks를 mock하지 않고 실 WebhookConfig
+    를 시드해 실제 함수(gating 로직 포함)를 그대로 실행 — 오직 네트워크 I/O 경계(httpx POST +
+    SSRF DNS 조회)만 캡처/우회한다. 이전 PR의 유닛테스트가 fire_webhooks 자체를 mock해서 empty-
+    set 게이팅 버그를 놓쳤던 정확한 갭을 닫는다. member-bound(오르테가류) WebhookConfig가
+    epic.reordered 구독 시 **실제로 정확히 1건 배달**됨을 증명(회귀 시 0건)."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from app.main import app
+    from app.models.member import Member
+    from app.models.webhook_config import WebhookConfig
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            ortega = Member(id=uuid.uuid4(), org_id=seeded["org_a_id"], type="agent", name="Ortega")
+            s.add(ortega)
+            await s.commit()
+            s.add(WebhookConfig(
+                id=uuid.uuid4(), org_id=seeded["org_a_id"], member_id=ortega.id,
+                project_id=seeded["project_a_id"], url="https://ortega.example.com/webhook",
+                events=["epic.reordered"], channel="generic", is_active=True,
+            ))
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        captured_posts: list[tuple[str, str]] = []
+
+        async def _fake_post(self, url, *, content=None, headers=None, **kwargs):
+            captured_posts.append((url, content))
+            return MagicMock(status_code=200)
+
+        try:
+            with (
+                patch("app.services.webhook_dispatch.validate_webhook_url_async", AsyncMock()),
+                patch("httpx.AsyncClient.post", _fake_post),
+            ):
+                resp = await client.patch("/api/v2/epics/bulk", json={
+                    "items": [
+                        {"id": str(seeded["epic_a1_id"]), "position": 1},
+                        {"id": str(seeded["epic_a2_id"]), "position": 2},
+                    ]
+                })
+            assert resp.status_code == 200, resp.text
+            # 핵심 단언: fire_webhooks의 실 gating 로직을 거쳐 실제로 정확히 1건 HTTP POST됐다
+            # (버그 상태에선 recipient_member_ids=set()로 인해 이 리스트가 비어 0건).
+            assert len(captured_posts) == 1, f"expected exactly 1 real delivery, got {len(captured_posts)}"
+            url, body = captured_posts[0]
+            assert url == "https://ortega.example.com/webhook"
+            assert "epic.reordered" in body
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_glance_wedge_roadmap_steer_realdb.py
+++ b/backend/tests/test_e_glance_wedge_roadmap_steer_realdb.py
@@ -1,0 +1,421 @@
+"""E-GLANCE wedge #2(story 96b19bc3) — 로드맵 조타(재정렬) + epic.* 이벤트, 실 Postgres 검증.
+
+⭐SEC-S8 하드닝을 처음부터 검증(회귀 아닌 설계 단계 봉인): PATCH /epics/bulk가 round1~8
+(W/W2)의 resource-actual project-scope 가드를 그대로 내장했는지 realdb 네거티브 컨트롤로
+증명. + list_epics order_by=position 옵트인 정렬 + epic.* 이벤트 발화(webhook 경로,
+monkeypatch로 캡처)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org_a(project_a·epic_a1/a2) + org_b(project_x·epic_x1, cross-org 컨트롤용) +
+    human_a(project_a에만 grant, org_b 및 project_x 접근권 없음)."""
+    from app.models.organization import Organization
+    from app.models.pm import Epic
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org_a = Organization(id=uuid.uuid4(), name="Org A", slug=f"org-a-{uuid.uuid4().hex[:8]}")
+    org_b = Organization(id=uuid.uuid4(), name="Org B", slug=f"org-b-{uuid.uuid4().hex[:8]}")
+    session.add_all([org_a, org_b])
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org_a.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org_a.id, name="Project B(same org, no access)")
+    project_x = Project(id=uuid.uuid4(), org_id=org_b.id, name="Project X(other org)")
+    session.add_all([project_a, project_b, project_x])
+    await session.commit()
+
+    epic_a1 = Epic(id=uuid.uuid4(), org_id=org_a.id, project_id=project_a.id, title="Epic A1")
+    epic_a2 = Epic(id=uuid.uuid4(), org_id=org_a.id, project_id=project_a.id, title="Epic A2")
+    epic_b1 = Epic(id=uuid.uuid4(), org_id=org_a.id, project_id=project_b.id, title="Epic B1(same-org other project)")
+    epic_x1 = Epic(id=uuid.uuid4(), org_id=org_b.id, project_id=project_x.id, title="Epic X1(cross-org)")
+    session.add_all([epic_a1, epic_a2, epic_b1, epic_x1])
+    await session.commit()
+
+    human_user_id = uuid.uuid4()
+    human_user = User(id=human_user_id, email=f"human-{human_user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(human_user)
+    await session.commit()
+    human_om = OrgMember(id=uuid.uuid4(), org_id=org_a.id, user_id=human_user_id, role="member")
+    session.add(human_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=human_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_a_id": org_a.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "epic_a1_id": epic_a1.id, "epic_a2_id": epic_a2.id, "epic_b1_id": epic_b1.id, "epic_x1_id": epic_x1.id,
+        "human_user_id": human_user_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_bulk_reorder_own_project_success():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch("/api/v2/epics/bulk", json={
+                "items": [
+                    {"id": str(seeded["epic_a1_id"]), "position": 10},
+                    {"id": str(seeded["epic_a2_id"]), "position": 20},
+                ]
+            })
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert len(body) == 2
+            positions = {item["id"]: item["position"] for item in body}
+            assert positions[str(seeded["epic_a1_id"])] == 10
+            assert positions[str(seeded["epic_a2_id"])] == 20
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_bulk_reorder_cross_org_item_silently_skipped():
+    """SEC-S8 W 패턴(cross-org IDOR): org_b의 epic_x1을 org_id=None 필터 없이 org_a 필터로
+    조회 실패 → not-found와 동형 조용히 스킵, 나머지 정당 item은 진행."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch("/api/v2/epics/bulk", json={
+                "items": [
+                    {"id": str(seeded["epic_a1_id"]), "position": 1},
+                    {"id": str(seeded["epic_x1_id"]), "position": 99},
+                ]
+            })
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            ids = {item["id"] for item in body}
+            assert str(seeded["epic_a1_id"]) in ids
+            assert str(seeded["epic_x1_id"]) not in ids
+            assert len(body) == 1
+        finally:
+            await client.aclose()
+
+        # DB 레벨로도 epic_x1.position이 변조 안 됐음을 확인(응답 미포함만으론 부족).
+        async with Session() as s2:
+            from sqlalchemy import select
+            from app.models.pm import Epic
+            row = (await s2.execute(select(Epic.position).where(Epic.id == seeded["epic_x1_id"]))).scalar_one()
+            assert row is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_bulk_reorder_same_org_cross_project_item_silently_skipped():
+    """SEC-S8 W2 패턴(same-org cross-project): project_a에만 grant된 휴먼이 같은 org의
+    project_b(접근권 없음) epic_b1을 재정렬 시도 → not-found와 동형 조용히 스킵."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch("/api/v2/epics/bulk", json={
+                "items": [
+                    {"id": str(seeded["epic_a1_id"]), "position": 1},
+                    {"id": str(seeded["epic_b1_id"]), "position": 99},
+                ]
+            })
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            ids = {item["id"] for item in body}
+            assert str(seeded["epic_a1_id"]) in ids
+            assert str(seeded["epic_b1_id"]) not in ids
+            assert len(body) == 1
+        finally:
+            await client.aclose()
+
+        async with Session() as s2:
+            from sqlalchemy import select
+            from app.models.pm import Epic
+            row = (await s2.execute(select(Epic.position).where(Epic.id == seeded["epic_b1_id"]))).scalar_one()
+            assert row is None
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_bulk_reorder_fires_single_epic_reordered_event():
+    """§2.3: 배치당 1회 발화 — 2건 재정렬해도 fire_webhooks는 정확히 1회."""
+    from unittest.mock import AsyncMock, patch
+
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        webhook = AsyncMock()
+        try:
+            with patch("app.services.webhook_dispatch.fire_webhooks", webhook):
+                resp = await client.patch("/api/v2/epics/bulk", json={
+                    "items": [
+                        {"id": str(seeded["epic_a1_id"]), "position": 1},
+                        {"id": str(seeded["epic_a2_id"]), "position": 2},
+                    ]
+                })
+            assert resp.status_code == 200, resp.text
+            webhook.assert_awaited_once()
+            assert webhook.call_args[0][2] == "epic.reordered"
+            payload = webhook.call_args[0][3]
+            assert len(payload["items"]) == 2
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_epic_status_changed_fires_webhook_via_transition():
+    from unittest.mock import AsyncMock, patch
+
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            from sqlalchemy import update
+            from app.models.pm import Epic
+            # active→archived는 native 전이(overlay-gate 없음) — human caller로 바로 검증.
+            await s.execute(update(Epic).where(Epic.id == seeded["epic_a1_id"]).values(status="active"))
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        webhook = AsyncMock()
+        try:
+            with patch("app.services.webhook_dispatch.fire_webhooks", webhook):
+                resp = await client.post(
+                    f"/api/v2/epics/{seeded['epic_a1_id']}/transition", json={"status": "archived"},
+                )
+            assert resp.status_code == 200, resp.text
+            webhook.assert_awaited_once()
+            assert webhook.call_args[0][2] == "epic.status_changed"
+            payload = webhook.call_args[0][3]
+            assert payload["old_status"] == "active"
+            assert payload["status"] == "archived"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_epic_created_fires_webhook():
+    from unittest.mock import AsyncMock, patch
+
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        webhook = AsyncMock()
+        try:
+            with patch("app.services.webhook_dispatch.fire_webhooks", webhook):
+                resp = await client.post("/api/v2/epics", json={
+                    "project_id": str(seeded["project_a_id"]), "org_id": str(seeded["org_a_id"]),
+                    "title": "New Epic",
+                })
+            assert resp.status_code == 201, resp.text
+            webhook.assert_awaited_once()
+            assert webhook.call_args[0][2] == "epic.created"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_epic_removed_fires_webhook_with_correct_title():
+    from unittest.mock import AsyncMock, patch
+
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_a_id"])
+        # delete는 org owner/admin 전용 — human_om role을 owner로 승격.
+        async with Session() as s3:
+            from sqlalchemy import update
+            from app.models.project import OrgMember
+            await s3.execute(
+                update(OrgMember).where(OrgMember.user_id == seeded["human_user_id"]).values(role="owner")
+            )
+            await s3.commit()
+
+        client = _client_for(app)
+        webhook = AsyncMock()
+        try:
+            with patch("app.services.webhook_dispatch.fire_webhooks", webhook):
+                resp = await client.delete(f"/api/v2/epics/{seeded['epic_a1_id']}")
+            assert resp.status_code == 200, resp.text
+            webhook.assert_awaited_once()
+            assert webhook.call_args[0][2] == "epic.removed"
+            payload = webhook.call_args[0][3]
+            assert payload["epic_title"] == "Epic A1"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_epics_order_by_position_sorts_curated_first():
+    """§1.3: position 설정된 에픽이 앞으로(오름차순)·NULL은 뒤로(자동도출 순서 유지)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            from sqlalchemy import update
+            from app.models.pm import Epic
+            # epic_a2를 먼저 큐레이션(position=1)·epic_a1은 NULL(미큐레이션) 유지.
+            await s.execute(update(Epic).where(Epic.id == seeded["epic_a2_id"]).values(position=1))
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/epics?project_id={seeded['project_a_id']}&order_by=position"
+            )
+            assert resp.status_code == 200, resp.text
+            ids_in_order = [item["id"] for item in resp.json()]
+            # position=1인 epic_a2가 NULL인 epic_a1보다 먼저 와야 한다.
+            assert ids_in_order.index(str(seeded["epic_a2_id"])) < ids_in_order.index(str(seeded["epic_a1_id"]))
+            assert "X-Next-Cursor" not in resp.headers
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_epics_default_order_unchanged_no_position_field_forced():
+    """회귀0(#2056 호환): order_by 미지정 시 기존 created_at 정렬 그대로."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["human_user_id"], seeded["org_a_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/epics?project_id={seeded['project_a_id']}")
+            assert resp.status_code == 200, resp.text
+            assert "X-Next-Cursor" in resp.headers
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_epics.py
+++ b/backend/tests/test_epics.py
@@ -38,6 +38,9 @@ def _mock_epic(status: str = "active") -> MagicMock:
     # 0d4c89e8: 연결 스토리 집계. 동일 사유(MagicMock auto-attr 방지)로 명시 세팅.
     e.total_stories = 0
     e.done_stories = 0
+    # E-GLANCE wedge #2(story 96b19bc3): 신규 필드 — MagicMock auto-attr ValidationError 방지.
+    e.position = None
+    e.source_loop_id = None
     e.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     e.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     return e


### PR DESCRIPTION
## Summary
BE design doc `be-design-roadmap-steer-ortega-events-96b19bc3`(PO 승인 완료) §1/§2/§4.1 P1 스코프 구현. 파운더 방향서 STEER 원칙("인간=책임 주체가 약속을 얹는다") — 휴먼이 로드맵을 조타하면 오르테가(PO 에이전트)가 이벤트로 받아 오케스트레이션.

### §1 에픽 순서/로드맵 모델
- 0175 마이그: `epics.position`(BigInteger nullable, `Story.position` 동형) + `epics.source_loop_id`(UUID FK→`loop_runs.id` ON DELETE SET NULL, Loop 계보 인터페이스뿐 — 배선은 P3 후속). 순수 additive.
- **`PATCH /api/v2/epics/bulk`(신규)** — 재정렬. ⭐**SEC-S8 W/W2 하드닝을 처음부터 내장**(회귀로 나중에 패치하지 않고 설계 단계서 봉인): `org_id` 필터(cross-org IDOR)+`has_project_access`(resource-actual, 대상 `epic.project_id` 기준 — body-claimed 아님)로 same-org cross-project까지 차단. 미접근 item은 not-found와 동형 조용히 스킵. `bulk_update_stories`(SEC-S8 W/W2 하드닝판) 템플릿 그대로 이식. `/bulk`를 `/{id}`보다 먼저 선언(라우트 shadow 방지, `stories.py` 교훈 재사용).
- `list_epics`에 `order_by=position` 옵트인 정렬 — 기본 정렬 완전 무변경(#2056 호환).

### §2 이벤트 발생
- `EVENT_TAXONOMY`에 `epic.created`/`status_changed`/`reordered`/`removed` 4종.
- `app/services/epic_events.py`(신규) — 3-effect(publish_event·fire_webhooks·dispatch_notification-if-assignee, `story_status_events.py` 축소판). `process_event`는 v1 제외(로드맵 이벤트가 자동으로 에이전트 워크플로 룰을 발화해야 할 근거 아직 없음).
- 배선: `create_epic`→`epic.created`·`transition_epic` 성공 후→`epic.status_changed`(old==new no-op 자체가드)·`delete_epic`→`epic.removed`·bulk reorder→`epic.reordered`(배치당 1회).

### §3 오르테가 구독
신규 구독 메커니즘 불요 — `WebhookConfig.events` 배열에 `epic.*` 4종 추가만(self-service, `sprintable_upsert_webhook_config`). 코드 변경 0.

### §4.1 Loop 계보 인터페이스
`Epic.source_loop_id` 컬럼만(마이그). Loop이 Epic을 자동 생성하지 않음(STEER 원칙) — 배선은 P3 후속.

## Test plan
- [x] 신규 unit 8/8(`epic_events.py` 격리+payload shape+no-op가드+배치1회) PASS
- [x] 신규 realdb 9/9 PASS — SEC-S8 cross-org/cross-project silent-skip DB레벨 확인·4개 이벤트 전부 webhook 발화 실증(monkeypatch 캡처)·position 정렬 정확성·기본정렬 무변경
- [x] 기존 epics/event 관련 4파일 47/47(MagicMock 신규필드 2건 명시세팅)
- [x] 전체 non-realdb 스위트 3517 passed / 68 failed — SEC 라운드들에서 이미 baseline-diff로 증명된 것과 완전 동일한 68건(사전-기존·이번 변경과 무관)
- [x] migration 0175 upgrade+downgrade 양방향 클린 검증

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>