### PR TITLE
fix(security): SEC HIGH baseline paydown round9 (최종) — members.list_members project-scope 가드 (#2050 봉인)

### DIFF
--- a/backend/app/routers/members.py
+++ b/backend/app/routers/members.py
@@ -1,6 +1,6 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.team import TeamMember
-from app.services.project_auth import assert_target_in_caller_org
+from app.services.project_auth import assert_target_in_caller_org, has_project_access
 
 router = APIRouter(prefix="/api/v2/members", tags=["members"])
 
@@ -27,7 +27,7 @@ class MemberResponse(BaseModel):
 async def list_members(
     project_id: uuid.UUID = Query(...),
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> list[MemberResponse]:
     """프로젝트 멤버 목록.
@@ -44,6 +44,15 @@ async def list_members(
     )
     project_org_id = project_org_row.scalar_one_or_none()
     assert_target_in_caller_org(org_id, project_org_id, not_found_detail="Project not found")
+
+    # ratchet round9(#2050 SEC HIGH baseline 마지막 1건): 위 가드는 cross-org IDOR만 막고
+    # same-org cross-project는 미검증이라, 같은 org 내 접근권 없는 project_id를 주입하면
+    # 그 프로젝트의 휴먼+에이전트 로스터(name/role)가 그대로 열거됐다. project_id는 쿼리
+    # 파라미터 자체가 조회 대상이므로 resource-actual 직접검증. 유일한 project-환원 벡터이며
+    # (다른 필터/검색어 없음) EE RBAC 등 특수 훅도 없음을 그라운딩으로 확認(round7 교훈).
+    # 존재/무접근권 모두 404(존재 비노출·기존 가드와 동형 시맨틱).
+    if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
 
     result: list[MemberResponse] = []
 

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -125,8 +125,9 @@ _FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
 # ── known debt: 실 GAP(HIGH/MEDIUM/LOW) — CRITICAL 3건(EE #2048)은 이미 fix, 나머지는
 # ratchet(PO 결 2026-07-11: baseline 동결 + 점진 상환). fix되면 이 dict에서 제거할 것.
 _KNOWN_DEBT_ALLOWLIST: dict[str, str] = {
-    "app.routers.members:list_members":
-        "HIGH — assert_target_in_caller_org가 cross-org만 막고 same-org cross-project는 미검증",
+    # ratchet round9(#2050): app.routers.members:list_members 상환 완료 — HIGH baseline 0 도달.
+    # has_project_access 사전검증(404)으로 same-org cross-project 로스터 열거 봉인
+    # (test_e_security_sec_s8_ratchet_round9_members_realdb.py). 잔여는 MEDIUM/LOW.
     "app.routers.hypotheses:link_hypothesis":
         "MEDIUM — service._assert_targets_same_project가 sprint/epic/story 주입은 막지만 caller의 hyp.project_id 접근권 자체는 미검증",
     "app.routers.participation:add_participation":

--- a/backend/tests/test_e_security_sec_s6_roster_org_scope_realdb.py
+++ b/backend/tests/test_e_security_sec_s6_roster_org_scope_realdb.py
@@ -149,8 +149,14 @@ async def test_cross_org_project_id_roster_blocked():
 
 
 @pytest.mark.anyio
-async def test_same_org_project_id_roster_still_free():
-    """회귀 0: Org B caller가 자기 org의 project_id로 조회하면 정상 로스터(휴먼+에이전트) 반환."""
+async def test_same_org_no_project_access_now_blocked_round9():
+    """round9(#2050 SEC HIGH baseline 최종) 계약 강화: SEC-S6 시절엔 이 엔드포인트가
+    cross-org만 막고 same-org는 'JWT 클레임 org == project org'만 대조해 자유였다
+    (그래서 members가 _KNOWN_DEBT HIGH로 남았다). 여기 caller_user_id는 실제로는 Org A
+    소속 멤버이고 org_b_id를 JWT로 '주장'만 할 뿐 — Org B project_b에 대한 team_member/
+    grant/owner-admin 접근권이 하나도 없다. round9의 has_project_access 사전검증은 실
+    접근권을 요구하므로 이제 404(로스터 verbatim 비노출까지 실증). 정당한 org-wide 접근
+    (owner/admin) 회귀0는 round9 realdb의 test_org_owner_can_list_any_project_roster_unchanged가 커버."""
     from app.main import app
 
     engine, Session = await _session_factory()
@@ -162,11 +168,10 @@ async def test_same_org_project_id_roster_still_free():
         client = _client_for(app)
         try:
             resp = await client.get(f"/api/v2/members?project_id={seeded['project_b_id']}")
-            assert resp.status_code == 200, resp.text
-            members = resp.json()
-            names = {m["name"] for m in members}
-            assert seeded["target_admin_name"] in names
-            assert "Org B Agent" in names
+            assert resp.status_code == 404, resp.text
+            # 접근권 없는 same-org caller에게 로스터 PII가 새지 않는다.
+            assert seeded["target_admin_name"] not in resp.text
+            assert "Org B Agent" not in resp.text
         finally:
             await client.aclose()
     finally:

--- a/backend/tests/test_e_security_sec_s8_ratchet_round9_members_realdb.py
+++ b/backend/tests/test_e_security_sec_s8_ratchet_round9_members_realdb.py
@@ -1,0 +1,272 @@
+"""E-SECURITY SEC HIGH baseline paydown round9 (최종) — #2050 ratchet _KNOWN_DEBT_ALLOWLIST
+잔여 HIGH 1건 app.routers.members:list_members 상환. baseline HIGH 1→0(봉인 완결).
+
+근본: 기존 가드 assert_target_in_caller_org는 cross-org IDOR만 404로 막고, 같은 org 안의
+접근권 없는 project_id 주입(same-org cross-project)은 미검증이라 그 프로젝트의 휴먼+에이전트
+로스터(name/role/email)가 그대로 열거됐다. project_id는 쿼리 파라미터 자체가 조회 대상이라
+resource-actual has_project_access(session, user_id, project_id, org_id) 직접검증으로 봉인.
+project_id가 유일 project-환원 벡터이며 EE RBAC 등 특수 훅이 없음을 그라운딩으로 확認
+(round7 교훈 — diff 밖 side-effect 없음).
+
+로스터는 휴먼+에이전트 PII 표면(name/email)이므로 네거티브 컨트롤은 상태코드(404)뿐 아니라
+유출 대상 이름/이메일 문자열이 응답 바디에 verbatim 미노출까지 assert한다(동어반복 금지)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+# 유출 감시 대상 — project_b 로스터의 verbatim PII(응답 바디에 절대 나오면 안 됨). 에이전트
+# 이름은 고정 상수(name 유니크 제약 없음). 휴먼 이메일은 ix_users_email 유니크 제약 때문에
+# seed마다 uuid 접미로 고유화하되, seed dict로 실제 값을 반환해 그 실측 문자열로 assert한다.
+_SECRET_AGENT_NAME = "TopSecretAgentB"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a, project_b) 안에:
+    - agent_a(project_a grant, name="Agent Alpha") — 회귀0 positive 확인용
+    - secret_agent_b(project_b grant, name=_SECRET_AGENT_NAME) — 유출 감시 에이전트 로스터
+    - secret_human_b(project_b grant, email=고유 topsecret-human-b-*) — 유출 감시 휴먼 로스터
+    - caller_human(project_a에만 명시 grant·org role=member·project_b 접근권 없음) — 공격자/합법 caller
+    - owner_human(org owner·grant 없이 org-wide 접근) — over-block 회귀 확인용
+    team_members는 VIEW(members⋈project_access)라 에이전트는 Member + ProjectAccess(member_id)로 시드
+    하면 list_members 에이전트 분기(TeamMember type=agent)에 노출된다(round2 패턴)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    # project_a 에이전트(회귀0 positive) + project_b 시크릿 에이전트(유출 감시)
+    agent_a = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent Alpha")
+    secret_agent_b = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name=_SECRET_AGENT_NAME)
+    session.add_all([agent_a, secret_agent_b])
+    await session.commit()
+    session.add_all([
+        ProjectAccess(id=uuid.uuid4(), project_id=project_a.id, member_id=agent_a.id,
+                      permission="granted", role="member"),
+        ProjectAccess(id=uuid.uuid4(), project_id=project_b.id, member_id=secret_agent_b.id,
+                      permission="granted", role="member"),
+    ])
+    await session.commit()
+
+    # project_b 시크릿 휴먼(유출 감시) — org member + project_b grant.
+    secret_human_id = uuid.uuid4()
+    secret_human_email = f"topsecret-human-b-{secret_human_id.hex[:8]}@test.com"
+    secret_human = User(id=secret_human_id, email=secret_human_email, hashed_password="x")
+    session.add(secret_human)
+    await session.commit()
+    secret_human_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=secret_human_id, role="member")
+    session.add(secret_human_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_b.id, org_member_id=secret_human_om.id,
+        permission="granted", role="member",
+    ))
+    await session.commit()
+
+    # caller: project_a에만 명시 grant — project_b 접근권 없음(org owner/admin도 아님).
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=caller_om.id,
+        permission="granted", role="member",
+    ))
+    await session.commit()
+
+    # owner: grant 없이 org-wide 접근(over-block 회귀 확인용).
+    owner_id = uuid.uuid4()
+    owner = User(id=owner_id, email=f"owner-{owner_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(owner)
+    await session.commit()
+    owner_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=owner_id, role="owner")
+    session.add(owner_om)
+    await session.commit()
+
+    return {
+        "org_id": org.id,
+        "project_a_id": project_a.id,
+        "project_b_id": project_b.id,
+        "agent_a_id": agent_a.id,
+        "secret_agent_b_id": secret_agent_b.id,
+        "secret_human_email": secret_human_email,
+        "caller_id": caller_id,
+        "owner_id": owner_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_project_a_human_can_list_own_project_roster():
+    """회귀 0: project_a grant 보유 휴먼은 project_a 로스터(agent 포함)를 정상 조회(200).
+    그리고 project_b 시크릿 로스터(이름/이메일)는 절대 섞여 나오지 않는다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/members?project_id={seeded['project_a_id']}")
+            assert resp.status_code == 200, resp.text
+            ids = {item["id"] for item in resp.json()}
+            assert str(seeded["agent_a_id"]) in ids, "project_a 에이전트가 정상 로스터에 있어야 한다(회귀0)"
+            # 크로스-프로젝트 유출 없음(positive 응답에도 project_b PII 미혼입).
+            assert _SECRET_AGENT_NAME not in resp.text
+            assert seeded["secret_human_email"] not in resp.text
+            assert str(seeded["secret_agent_b_id"]) not in ids
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_grant_human_cannot_list_other_project_roster():
+    """봉인 실증(비-동어반복): project_a에만 grant된 휴먼이 project_b 로스터를 project_id
+    override로 조회 시도 → 404. 상태코드뿐 아니라 시크릿 에이전트 이름/시크릿 휴먼 이메일이
+    응답 바디에 verbatim 미노출까지 assert(기존엔 has_project_access 부재로 200+full leak)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/members?project_id={seeded['project_b_id']}")
+            assert resp.status_code == 404, resp.text
+            # PII verbatim 미노출 — 로스터 이름/이메일이 바디 어디에도 없어야 함.
+            assert _SECRET_AGENT_NAME not in resp.text, "에이전트 이름 유출"
+            assert seeded["secret_human_email"] not in resp.text, "휴먼 이메일 유출"
+            assert str(seeded["secret_agent_b_id"]) not in resp.text, "에이전트 member id 유출"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_owner_can_list_any_project_roster_unchanged():
+    """회귀 0(over-block 방지): org owner는 grant 없이도 org-wide 접근이라 project_b 로스터를
+    정상 조회(200)해야 한다 — has_project_access가 owner/admin 분기를 보존하는지 실증."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["owner_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/members?project_id={seeded['project_b_id']}")
+            assert resp.status_code == 200, resp.text
+            # owner는 정당 접근 — project_b 시크릿 에이전트가 로스터에 실제로 보인다.
+            ids = {item["id"] for item in resp.json()}
+            assert str(seeded["secret_agent_b_id"]) in ids
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_nonexistent_project_id_returns_404_not_leak():
+    """엣지: 존재하지 않는 project_id도 404(존재여부 자체를 흘리지 않음)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/members?project_id={uuid.uuid4()}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_s_mbr_03.py
+++ b/backend/tests/test_s_mbr_03.py
@@ -250,10 +250,16 @@ async def test_list_members_owner_always_included():
     agent_mock = MagicMock()
     agent_mock.scalars.return_value.all.return_value = []
 
-    mock_session.execute = AsyncMock(side_effect=[org_lookup_mock, human_mock, agent_mock])
-    mock_auth = MagicMock()
+    # round9(#2050): has_project_access 사전검증이 org_lookup과 human_rows 사이에 execute
+    # 1회를 추가한다(caller의 실 project 접근권 대조). 이 목이 그 호출에 truthy 응답.
+    access_mock = MagicMock()
+    access_mock.scalar_one_or_none.return_value = 1
 
-    result = await list_members(project_id=project_id, session=mock_session, _auth=mock_auth, org_id=org_id)
+    mock_session.execute = AsyncMock(side_effect=[org_lookup_mock, access_mock, human_mock, agent_mock])
+    mock_auth = MagicMock()
+    mock_auth.user_id = str(uuid.uuid4())
+
+    result = await list_members(project_id=project_id, session=mock_session, auth=mock_auth, org_id=org_id)
     # 두 멤버 모두 포함
     assert len(result) == 2
     roles = {r.role for r in result}

--- a/backend/tests/test_s_mbr_10.py
+++ b/backend/tests/test_s_mbr_10.py
@@ -96,10 +96,16 @@ async def test_list_members_org_member_requires_grant():
     agent_mock = MagicMock()
     agent_mock.scalars.return_value.all.return_value = []
 
-    mock_session.execute = AsyncMock(side_effect=[org_lookup_mock, human_mock, agent_mock])
-    mock_auth = MagicMock()
+    # round9(#2050): has_project_access 사전검증이 org_lookup과 human_rows 사이에 execute
+    # 1회를 추가한다(caller의 실 project 접근권 대조). 이 목이 그 호출에 truthy 응답.
+    access_mock = MagicMock()
+    access_mock.scalar_one_or_none.return_value = 1
 
-    result = await list_members(project_id=project_id, session=mock_session, _auth=mock_auth, org_id=org_id)
+    mock_session.execute = AsyncMock(side_effect=[org_lookup_mock, access_mock, human_mock, agent_mock])
+    mock_auth = MagicMock()
+    mock_auth.user_id = str(uuid.uuid4())
+
+    result = await list_members(project_id=project_id, session=mock_session, auth=mock_auth, org_id=org_id)
     assert len(result) == 1
     assert result[0].role == "owner"
 
@@ -130,10 +136,16 @@ async def test_list_members_member_with_grant_included():
     agent_mock = MagicMock()
     agent_mock.scalars.return_value.all.return_value = []
 
-    mock_session.execute = AsyncMock(side_effect=[org_lookup_mock, human_mock, agent_mock])
-    mock_auth = MagicMock()
+    # round9(#2050): has_project_access 사전검증이 org_lookup과 human_rows 사이에 execute
+    # 1회를 추가한다(caller의 실 project 접근권 대조). 이 목이 그 호출에 truthy 응답.
+    access_mock = MagicMock()
+    access_mock.scalar_one_or_none.return_value = 1
 
-    result = await list_members(project_id=project_id, session=mock_session, _auth=mock_auth, org_id=org_id)
+    mock_session.execute = AsyncMock(side_effect=[org_lookup_mock, access_mock, human_mock, agent_mock])
+    mock_auth = MagicMock()
+    mock_auth.user_id = str(uuid.uuid4())
+
+    result = await list_members(project_id=project_id, session=mock_session, auth=mock_auth, org_id=org_id)
     assert len(result) == 2
     roles = {r.role for r in result}
     assert "owner" in roles


### PR DESCRIPTION
## SEC HIGH baseline paydown round9 — **최종**(ratchet 봉인 완결)

`#2050` ratchet `_KNOWN_DEBT_ALLOWLIST` 잔여 HIGH 마지막 1건 `app.routers.members:list_members` 상환 → **HIGH baseline 1→0**.

### 갭 실체
기존 `assert_target_in_caller_org`는 **cross-org IDOR만** 404로 막고, 같은 org 안의 접근권 없는 `project_id` 주입(same-org cross-project)은 미검증 → 그 프로젝트의 **휴먼+에이전트 로스터(name/role/email)** 가 그대로 열거됐다.

### fix (round8 동형)
`project_id`는 쿼리 파라미터 자체가 조회 대상이라 resource-actual `has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id)` 직접검증(존재/무접근권 모두 404·존재 비노출). `project_id`가 유일 project-환원 벡터이며 EE RBAC 등 특수 훅 부재를 그라운딩으로 확認(round7 교훈 — diff 밖 side-effect 없음).

### 4축 규율
1. **resource-actual project-scope** — body-claimed 없이 쿼리 `project_id` 직접검증(404).
2. **realdb 네거티브(비-동어반복)** — no-grant 휴먼의 project_b 조회: 가드 제거 시 **200 + full roster PII leak 재현**(시크릿 에이전트 이름·시크릿 휴먼 이메일 verbatim), 복원 시 404 + 그 문자열들 바디 미노출까지 assert.
3. **reduction-vector 완전성 + EE 훅 부재** — project_id 외 project-환원 파라미터 없음·EE RBAC 미적용 직접 확認.
4. **ratchet 이빨 실증** — 가드 제거 시 `members:list_members`가 unguarded-not-baselined로 정확히 탐지돼 CI RED, 복원 시 green. baseline 항목 제거로 회귀0.

### 변경
- `app/routers/members.py` — `has_project_access` 사전검증 추가·`_auth`→`auth`.
- `tests/test_e_security_sec_s8_ratchet_round9_members_realdb.py` — 신규 realdb 4종(회귀0/봉인+PII 미노출/owner org-wide over-block 회귀0/nonexistent 404). team_members=VIEW라 에이전트는 `Member`+`ProjectAccess` 시드.
- `tests/test_authz_project_scope_coverage.py` — `_KNOWN_DEBT_ALLOWLIST`에서 members 제거(**HIGH 0**).
- `tests/test_e_security_sec_s6_roster_org_scope_realdb.py` — same-org "still_free"를 round9 계약(no-access same-org caller도 404·PII 비노출)으로 갱신+rename.
- `tests/test_s_mbr_03.py`, `tests/test_s_mbr_10.py` — 직호출 유닛 3종을 has_project_access execute 삽입+auth.user_id 배선 보정(round2 call-count 교훈).

### 검증
신규 realdb **4/4** · ratchet 회귀가드 **3/3** · ratchet 이빨 양방향(RED↔green) 실증 · realdb 네거티브 비-동어반복(leak 재현↔봉인) 실증 · members 계열 6파일 전부 green · 전체 비-realdb 스위트 8 failed(전부 MCP infra/`.mcp.json` 로컬경로 드리프트류 **pre-existing**, baseline 대조로 diff 무관·회귀0) · **migration 없음**. team_members VIEW·pg@16 pgvector 소스빌드로 alembic head 실검증.

QA: 까심(오르테가 라우팅). baseline 0 = ratchet 봉인 완결.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
