### PR TITLE
[E-GLANCE][#2 wedge][FE] 로드맵 조타 — /epics 드래그 재정렬 + 조타→핸드오프 compact (story 2258ccd6)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2706,7 +2706,16 @@
     "deleteEpic": "Delete Epic",
     "deleteConfirmTitle": "Delete Epic?",
     "deleteConfirmDescription": "This is permanent and cannot be undone. All stories in this epic will be unlinked.",
-    "deleteConfirmButton": "Delete permanently"
+    "deleteConfirmButton": "Delete permanently",
+    "steerCurated": "Curated",
+    "steerAuto": "Auto (NULL)",
+    "steerLoopSuggest": "Loop suggestion",
+    "steerReorderAria": "Reorder {title}",
+    "steerHandoffReceived": "Steering received",
+    "steerHandoffOrchestrating": "Orchestrating",
+    "steerHandoffAgent": "Ortega",
+    "steerError": "Couldn't save the new order. Please try again.",
+    "steerCappedNote": "Showing the top {count}. Steering (curation) floats items to the front."
   },
   "glance": {
     "pageTitle": "Project Glance",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2706,7 +2706,16 @@
     "deleteEpic": "에픽 삭제",
     "deleteConfirmTitle": "에픽을 삭제하시겠습니까?",
     "deleteConfirmDescription": "이 작업은 되돌릴 수 없습니다. 에픽에 포함된 스토리는 연결이 해제됩니다.",
-    "deleteConfirmButton": "영구 삭제"
+    "deleteConfirmButton": "영구 삭제",
+    "steerCurated": "큐레이션",
+    "steerAuto": "자동(NULL)",
+    "steerLoopSuggest": "Loop 제안",
+    "steerReorderAria": "{title} 순서 변경",
+    "steerHandoffReceived": "조타 접수",
+    "steerHandoffOrchestrating": "오케스트레이션 중",
+    "steerHandoffAgent": "오르테가군",
+    "steerError": "재정렬을 저장하지 못했습니다. 다시 시도해 주세요.",
+    "steerCappedNote": "상위 {count}개만 표시됩니다. 조타(큐레이션)는 상위 항목을 앞으로 올립니다."
   },
   "glance": {
     "pageTitle": "프로젝트 현황판",

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -3,7 +3,11 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { ChevronLeft, Plus, Trash2, X } from 'lucide-react';
+import { ChevronLeft, GripVertical, Plus, Trash2, X } from 'lucide-react';
+import { DndContext, type DragEndEvent, PointerSensor, useSensor, useSensors, closestCenter } from '@dnd-kit/core';
+import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { computeReorderPatch } from '@/lib/epic-steer';
 import { Button } from '@/components/ui/button';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { Badge } from '@/components/ui/badge';
@@ -15,6 +19,25 @@ import {
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { OutcomeStatusBadge } from '@/components/outcome/outcome-status-badge';
 import { HypothesesSummary } from '@/components/hypotheses/hypotheses-summary';
+
+// ─── Drag sensor ──────────────────────────────────────────────────────────────
+
+/**
+ * 좌클릭(button===0)·비터치만 드래그 — 터치는 네이티브 스크롤(kanban-board.tsx 0d142311 RC와
+ * 동형·산티아고 QA 확定). 로드맵 조타 리스트도 터치 no-drag 가디언 락을 이 센서로 충족한다.
+ */
+class MousePointerSensor extends PointerSensor {
+  static activators = [
+    {
+      eventName: 'onPointerDown' as const,
+      handler: ({ nativeEvent }: { nativeEvent: PointerEvent }) =>
+        nativeEvent.isPrimary && nativeEvent.button === 0 && nativeEvent.pointerType !== 'touch',
+    },
+  ];
+}
+
+/** 조타 모드 전량 로드 상한(BE/route maxLimit=100). 초과분은 honest 표시(silent-truncation 금지). */
+const STEER_LIMIT = 100;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -49,6 +72,10 @@ interface Epic {
   // 0d4c89e8: BE list 응답 story count 집계(#1527). detail/미부착 경로는 stories 폴백.
   total_stories?: number;
   done_stories?: number;
+  // wedge #2(로드맵 조타·BE #2076): 큐레이션 순서(null=미조타·자동도출). source_loop_id는 Loop
+  // 제안 hook — 실 배선 P3/v2, v1은 미표시(no-fiction).
+  position?: number | null;
+  source_loop_id?: string | null;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -393,10 +420,22 @@ interface EpicRowProps {
   isSelected: boolean;
   onClick: () => void;
   onDeleteRequest: (id: string) => void;
+  /** 조타 모드(status 필터=전체)일 때만 드래그 핸들·큐레이션 마커 노출. */
+  sortable: boolean;
 }
 
-function EpicRow({ epic, isSelected, onClick, onDeleteRequest }: EpicRowProps) {
+function EpicRow({ epic, isSelected, onClick, onDeleteRequest, sortable }: EpicRowProps) {
   const t = useTranslations('epics');
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: epic.id,
+    disabled: !sortable,
+  });
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    ...(isDragging ? { zIndex: 20, opacity: 0.9 } : {}),
+  };
+  const curated = typeof epic.position === 'number';
   const stories = epic.stories ?? [];
   // 0d4c89e8: BE 집계(total_stories/done_stories·#1527) 우선·detail-shape(집계 미부착)는 stories 폴백.
   // list 응답은 stories 미부착이라 폴백만으론 0/0 → BE 집계로 카드 카운트/진행바 정상화.
@@ -423,20 +462,52 @@ function EpicRow({ epic, isSelected, onClick, onDeleteRequest }: EpicRowProps) {
 
   return (
     <div
-      className={`group relative w-full rounded-xl border px-4 py-3.5 text-left transition-all duration-150 cursor-pointer ${
+      ref={setNodeRef}
+      style={style}
+      className={`group relative flex w-full items-start gap-2 rounded-xl border px-3 py-3.5 text-left transition-all duration-150 ${
         isSelected
           ? 'border-primary/40 bg-primary/5'
           : 'border-border bg-card hover:border-primary/30 hover:bg-primary/5'
-      }`}
-      onClick={onClick}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onClick(); }}
+      } ${isDragging ? 'shadow-lg' : ''}`}
     >
-      <div className="space-y-2.5">
+      {sortable ? (
+        <button
+          type="button"
+          aria-label={t('steerReorderAria', { title: epic.title })}
+          onClick={(e) => e.stopPropagation()}
+          className="mt-0.5 flex shrink-0 cursor-grab touch-none items-center text-muted-foreground/50 transition-colors hover:text-muted-foreground active:cursor-grabbing"
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical className="size-4" aria-hidden="true" />
+        </button>
+      ) : null}
+      <div
+        className="min-w-0 flex-1 cursor-pointer space-y-2.5"
+        onClick={onClick}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onClick(); }}
+      >
         <div className="flex items-start justify-between gap-2">
           <p className="text-sm font-semibold leading-snug text-foreground">{epic.title}</p>
           <div className="flex shrink-0 items-center gap-1.5">
+            {sortable ? (
+              curated ? (
+                <span className="inline-flex items-center gap-1 rounded bg-proof-amber-soft px-1.5 py-0.5 text-[10px] font-bold text-proof-amber">
+                  {t('steerCurated')} {epic.position}
+                </span>
+              ) : (
+                <span className="text-[10px] font-medium text-muted-foreground/70">{t('steerAuto')}</span>
+              )
+            ) : null}
+            {/* Loop 제안 hook — source_loop_id 배선(P3/v2) 전엔 미표시(no-fiction·sparkle 0·claimed amber 언어). */}
+            {epic.source_loop_id ? (
+              <span className="inline-flex items-center gap-1 rounded bg-proof-amber-soft px-1.5 py-0.5 text-[10px] font-bold text-proof-amber">
+                <span className="size-1 rounded-full bg-proof-amber" aria-hidden="true" />
+                {t('steerLoopSuggest')}
+              </span>
+            ) : null}
             <Badge variant={statusBadgeVariant(epic.status)}>{statusLabel[epic.status]}</Badge>
             <Badge variant={priorityBadgeVariant(epic.priority)}>{priorityLabel[epic.priority]}</Badge>
             <button
@@ -714,49 +785,72 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
   const [loading, setLoading] = useState(true);
   const [showCreate, setShowCreate] = useState(false);
   const [mobileView, setMobileView] = useState<'list' | 'detail'>('list');
-  const [epicsHasMore, setEpicsHasMore] = useState(false);
-  const [epicsNextCursor, setEpicsNextCursor] = useState<string | null>(null);
-  const [epicsLoadingMore, setEpicsLoadingMore] = useState(false);
-  const [epicsLoadMoreError, setEpicsLoadMoreError] = useState(false);
   const [statusFilter, setStatusFilter] = useState<EpicStatus | 'all'>('all');
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
+  // wedge #2 로드맵 조타
+  const [capped, setCapped] = useState(false);          // 상위 STEER_LIMIT 초과(honest 표시·silent-truncation 금지)
+  const [justSteered, setJustSteered] = useState(false); // 조타 후 핸드오프 compact("받았고 움직인다")
+  const [reordering, setReordering] = useState(false);   // bulk PATCH in-flight
+  const sensors = useSensors(useSensor(MousePointerSensor, { activationConstraint: { distance: 8 } }));
 
-  const fetchEpics = useCallback(async (cursor?: string | null) => {
+  // wedge #2: order_by=position 옵트인 — 큐레이션 prefix + 자동(NULL) tail. position 모드는 BE가
+  // 커서를 발행하지 않으므로 이어달리기(cursor pagination) 없이 전량(상위 STEER_LIMIT) 로드한다(AC4).
+  const fetchEpics = useCallback(async () => {
     try {
-      const params = new URLSearchParams({ project_id: projectId, limit: '20' });
-      if (cursor) params.set('cursor', cursor);
+      const params = new URLSearchParams({ project_id: projectId, limit: String(STEER_LIMIT), order_by: 'position' });
       const res = await fetch(`/api/epics?${params.toString()}`);
       if (!res.ok) throw new Error(`Failed to fetch epics: ${res.status}`);
-      const { data, meta } = await res.json() as { data: Epic[]; meta?: { hasMore?: boolean; nextCursor?: string | null } };
-      if (cursor) {
-        // append 시 id 기준 중복 방어 (cursor 전진 버그 재발 대비 안전망)
-        setEpics((prev) => {
-          const seen = new Set(prev.map((e) => e.id));
-          return [...prev, ...(data ?? []).filter((e) => !seen.has(e.id))];
-        });
-      } else {
-        setEpics(data ?? []);
-      }
-      setEpicsHasMore(meta?.hasMore ?? false);
-      setEpicsNextCursor(meta?.nextCursor ?? null);
-      setEpicsLoadMoreError(false);
+      const { data } = await res.json() as { data: Epic[] };
+      setEpics(data ?? []);
+      setCapped((data?.length ?? 0) >= STEER_LIMIT);
     } catch (err) {
-      // AC3: silent-swallow 금지 — 최소 로깅 + (더보기 실패 시) 인라인 표시
+      // AC3: silent-swallow 금지 — 최소 로깅.
       console.error('[epics] 목록을 불러오지 못했습니다', err);
-      if (cursor) setEpicsLoadMoreError(true);
     } finally {
       setLoading(false);
-      setEpicsLoadingMore(false);
     }
   }, [projectId]);
 
-  const loadMoreEpics = useCallback(async () => {
-    if (!epicsHasMore || !epicsNextCursor || epicsLoadingMore) return;
-    setEpicsLoadingMore(true);
-    setEpicsLoadMoreError(false);
-    await fetchEpics(epicsNextCursor);
-  }, [epicsHasMore, epicsNextCursor, epicsLoadingMore, fetchEpics]);
+  const handleDragEnd = useCallback(async (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    // 조타는 전체(status=all) 뷰에서만 — 필터 서브셋 재정렬은 전역 position을 오염시킨다(가드).
+    if (statusFilter !== 'all') return;
+    const oldIndex = epics.findIndex((e) => e.id === active.id);
+    const newIndex = epics.findIndex((e) => e.id === over.id);
+    if (oldIndex < 0 || newIndex < 0) return;
+
+    const reordered = arrayMove(epics, oldIndex, newIndex);
+    const patch = computeReorderPatch(reordered, newIndex);
+    if (patch.length === 0) { setEpics(reordered); return; }
+
+    // 낙관 반영(마커 즉시 갱신) 후 실 PATCH — 성공 시 서버 확정본으로 정합, 실패 시 롤백.
+    const posById = new Map(patch.map((p) => [p.id, p.position]));
+    const optimistic = reordered.map((e) => (posById.has(e.id) ? { ...e, position: posById.get(e.id)! } : e));
+    const prev = epics;
+    setEpics(optimistic);
+    setReordering(true);
+    try {
+      const res = await fetch('/api/epics/bulk', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ items: patch }),
+      });
+      if (!res.ok) throw new Error(`bulk reorder failed: ${res.status}`);
+      const { data } = await res.json() as { data: Epic[] };
+      // 응답=갱신본만 → 서버 position으로 정합(실 persist 확인·끝단 반영).
+      const updById = new Map((data ?? []).map((e) => [e.id, e.position]));
+      setEpics((cur) => cur.map((e) => (updById.has(e.id) ? { ...e, position: updById.get(e.id) ?? e.position } : e)));
+      setJustSteered(true); // 핸드오프 compact 노출("조타 접수·오케스트레이션 중")
+    } catch (err) {
+      console.error('[epics] 재정렬 저장 실패', err);
+      setEpics(prev); // 롤백(낙관 UI ≠ 저장)
+      addToast({ type: 'error', title: t('steerError') });
+    } finally {
+      setReordering(false);
+    }
+  }, [epics, statusFilter, addToast, t]);
 
   // (silent-catch sweep) `_fetchEpicDetail`(dead·호출처 0·handleSelectEpic이 /epics/[id]
   // 딥링크로 대체)는 제거했다 — 실행되지 않던 silent catch였으므로 toast가 아니라 dead code 삭제.
@@ -813,6 +907,8 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
   }
 
   const filteredEpics = statusFilter === 'all' ? epics : epics.filter((e) => e.status === statusFilter);
+  // 조타(드래그 재정렬)는 전체 뷰에서만 — 필터 서브셋은 전역 position을 오염시킨다.
+  const sortable = statusFilter === 'all';
 
   const listPanel = (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-muted/35">
@@ -835,8 +931,18 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
         ))}
       </div>
 
+      {/* wedge #2 조타→핸드오프 confirm — "감시 아니라 신뢰": 현재 신뢰단계 1개만("받았고 움직인다").
+          활동량/타임스탬프/이벤트 나열 0. Proof Blue·부드러운 호흡·reduced-motion 대응. */}
+      {justSteered ? (
+        <div className="flex shrink-0 items-center gap-2 border-y border-proof-line-soft bg-proof-blue-soft px-4 py-2 text-[11.5px] font-semibold text-proof-blue">
+          <span className="size-1.5 shrink-0 rounded-full bg-proof-blue motion-safe:animate-pulse" aria-hidden="true" />
+          <span>{t('steerHandoffReceived')} · <b className="font-bold">{t('steerHandoffOrchestrating')}</b></span>
+          <span className="ml-auto text-[9.5px] font-bold text-proof-blue/80">{t('steerHandoffAgent')}</span>
+        </div>
+      ) : null}
+
       {/* List body */}
-      <div className="flex-1 overflow-y-auto p-4">
+      <div className="flex-1 overflow-y-auto p-4" aria-busy={reordering}>
         {filteredEpics.length === 0 ? (
           <EmptyState
             title={t('noEpics')}
@@ -849,29 +955,25 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
             }
           />
         ) : (
-          <div className="space-y-2">
-            {filteredEpics.map((epic) => (
-              <EpicRow
-                key={epic.id}
-                epic={epic}
-                isSelected={selectedEpic?.id === epic.id}
-                onClick={() => { void handleSelectEpic(epic); }}
-                onDeleteRequest={(id) => setDeleteConfirmId(id)}
-              />
-            ))}
-            {epicsLoadMoreError ? (
-              <div className="flex flex-col items-center gap-1 py-2">
-                <p className="text-xs text-destructive">에픽을 더 불러오지 못했습니다.</p>
-                <Button variant="ghost" size="sm" onClick={() => void loadMoreEpics()} disabled={epicsLoadingMore}>
-                  {epicsLoadingMore ? '로딩 중...' : '다시 시도'}
-                </Button>
+          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={(e) => void handleDragEnd(e)}>
+            <SortableContext items={filteredEpics.map((e) => e.id)} strategy={verticalListSortingStrategy}>
+              <div className="space-y-2">
+                {filteredEpics.map((epic) => (
+                  <EpicRow
+                    key={epic.id}
+                    epic={epic}
+                    sortable={sortable}
+                    isSelected={selectedEpic?.id === epic.id}
+                    onClick={() => { void handleSelectEpic(epic); }}
+                    onDeleteRequest={(id) => setDeleteConfirmId(id)}
+                  />
+                ))}
+                {capped ? (
+                  <p className="pt-1 text-center text-[11px] text-muted-foreground/70">{t('steerCappedNote', { count: STEER_LIMIT })}</p>
+                ) : null}
               </div>
-            ) : epicsHasMore ? (
-              <Button variant="ghost" size="sm" className="w-full text-muted-foreground" onClick={() => void loadMoreEpics()} disabled={epicsLoadingMore}>
-                {epicsLoadingMore ? '로딩 중...' : '더 보기'}
-              </Button>
-            ) : null}
-          </div>
+            </SortableContext>
+          </DndContext>
         )}
       </div>
     </div>

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -475,7 +475,7 @@ function EpicRow({ epic, isSelected, onClick, onDeleteRequest, sortable }: EpicR
           type="button"
           aria-label={t('steerReorderAria', { title: epic.title })}
           onClick={(e) => e.stopPropagation()}
-          className="mt-0.5 flex shrink-0 cursor-grab touch-none items-center text-muted-foreground/50 transition-colors hover:text-muted-foreground active:cursor-grabbing"
+          className="mt-0.5 flex shrink-0 cursor-grab items-center text-muted-foreground/50 transition-colors hover:text-muted-foreground active:cursor-grabbing"
           {...attributes}
           {...listeners}
         >

--- a/apps/web/src/app/api/epics/bulk/route.ts
+++ b/apps/web/src/app/api/epics/bulk/route.ts
@@ -1,0 +1,51 @@
+import { EpicService, type EpicPositionItem } from '@/services/epic';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { createEpicRepository } from '@/lib/storage/factory';
+
+/**
+ * PATCH /api/epics/bulk — 로드맵 조타 재정렬(wedge #2·story 2258ccd6). 큐레이션한 에픽만
+ * position 세팅(백필0)해 BE `PATCH /api/v2/epics/bulk`로 실 persist(낙관 아님). 인가(org/project·
+ * SEC-S8 W/W2)는 BE 단일 소스라 FE는 thin proxy — 형상만 검증하고 items를 그대로 포워드한다.
+ */
+export async function PATCH(request: Request) {
+  try {
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return apiError('BAD_REQUEST', 'Invalid JSON body', 400);
+    }
+    if (!rawBody || typeof rawBody !== 'object') {
+      return apiError('BAD_REQUEST', 'Body must be an object', 400);
+    }
+    const rawItems = (rawBody as Record<string, unknown>).items;
+    if (!Array.isArray(rawItems) || rawItems.length === 0) {
+      return apiError('VALIDATION_ERROR', 'items must be a non-empty array', 400);
+    }
+    const items: EpicPositionItem[] = [];
+    for (const it of rawItems) {
+      if (!it || typeof it !== 'object') {
+        return apiError('VALIDATION_ERROR', 'each item must be an object', 400);
+      }
+      const { id, position } = it as Record<string, unknown>;
+      if (typeof id !== 'string' || !id) {
+        return apiError('VALIDATION_ERROR', 'item.id must be a non-empty string', 400);
+      }
+      if (typeof position !== 'number' || !Number.isInteger(position)) {
+        return apiError('VALIDATION_ERROR', 'item.position must be an integer', 400);
+      }
+      items.push({ id, position });
+    }
+
+    const repo = await createEpicRepository();
+    const service = new EpicService(repo);
+    const updated = await service.bulkUpdatePositions(items);
+    return apiSuccess(updated);
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/app/api/epics/route.ts
+++ b/apps/web/src/app/api/epics/route.ts
@@ -14,9 +14,14 @@ export async function GET(request: Request) {
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
     const { searchParams } = new URL(request.url);
+    const orderBy = searchParams.get('order_by') ?? undefined;
+    // 로드맵 조타(wedge #2): order_by="position"은 복합 정렬((position IS NULL) ASC, position ASC,
+    // created_at DESC)이라 BE가 X-Next-Cursor를 내지 않는다 → 커서 이어달리기 불가. 이 모드는
+    // 전량 로드가 전제이므로 over-fetch(+1)/커서 없이 요청 limit 그대로 받아 hasMore=false로 봉인(AC4).
+    const positionMode = orderBy === 'position';
     const pageInput = parseCursorPageInput({
       limit: searchParams.get('limit') ? Number(searchParams.get('limit')) : undefined,
-      cursor: searchParams.get('cursor'),
+      cursor: positionMode ? undefined : searchParams.get('cursor'),
     }, { defaultLimit: 50, maxLimit: 100 });
     const repo = await createEpicRepository();
     const service = new EpicService(repo);
@@ -24,9 +29,13 @@ export async function GET(request: Request) {
     // in-memory 페이징(1000+ silent-truncation 유발) 대신 BE에 위임한다. over-fetch(+1)로 hasMore 판단.
     const epics = await service.list({
       project_id: searchParams.get('project_id') ?? undefined,
-      limit: pageInput.limit + 1,
-      cursor: pageInput.cursor,
+      limit: positionMode ? pageInput.limit : pageInput.limit + 1,
+      cursor: positionMode ? undefined : pageInput.cursor,
+      order_by: orderBy,
     });
+    if (positionMode) {
+      return apiSuccess(epics, { limit: pageInput.limit, hasMore: false, nextCursor: null });
+    }
     const { page, meta } = buildCursorPageMeta(epics, pageInput.limit, 'created_at');
     return apiSuccess(page, meta);
   } catch (err: unknown) { return handleApiError(err); }

--- a/apps/web/src/components/glance/load-glance-data.ts
+++ b/apps/web/src/components/glance/load-glance-data.ts
@@ -40,7 +40,9 @@ async function fetchJson(url: string): Promise<unknown> {
  */
 export async function loadGlanceData(projectId: string): Promise<GlanceData> {
   const [epicsJson, overviewJson, membersJson, activityJson] = await Promise.all([
-    fetchJson(`/api/epics?project_id=${projectId}&limit=100`),
+    // wedge #2: order_by=position 옵트인 — 조타(큐레이션) 결과를 아크가 curated-first로 소비만
+    // 반영(드래그 없음). position 모드는 커서 미발행이나 아크는 원래 전량로드(limit=100)라 무관.
+    fetchJson(`/api/epics?project_id=${projectId}&limit=100&order_by=position`),
     fetchJson('/api/dashboard/overview'),
     fetchJson('/api/team-members'),
     fetchJson(`/api/activity-logs?project_id=${projectId}&limit=20`),

--- a/apps/web/src/lib/epic-steer.test.ts
+++ b/apps/web/src/lib/epic-steer.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { computeReorderPatch, type SteerEpic } from './epic-steer';
+
+const e = (id: string, position?: number | null): SteerEpic => ({ id, position });
+
+describe('computeReorderPatch (로드맵 조타 재정렬 → bulk PATCH diff·wedge #2)', () => {
+  it('null 에픽을 맨 앞으로 끌면 그 항목만 position=1(나머지 null tail 유지·백필0)', () => {
+    // 원래 [A,B,E] 전부 null → E를 idx0으로. reordered=[E,A,B], movedNewIndex=0.
+    const patch = computeReorderPatch([e('E'), e('A'), e('B')], 0);
+    expect(patch).toEqual([{ id: 'E', position: 1 }]);
+  });
+
+  it('null만 있는 목록에서 idx2로 끌면 prefix 0..2를 1,2,3으로 큐레이션(시각 순서 persist)', () => {
+    const patch = computeReorderPatch([e('A'), e('B'), e('E')], 2);
+    expect(patch).toEqual([
+      { id: 'A', position: 1 },
+      { id: 'B', position: 2 },
+      { id: 'E', position: 3 },
+    ]);
+  });
+
+  it('드롭 지점 아래에 이미 큐레이션된 항목이 있으면 cutoff가 거기까지 확장돼 renumber된다', () => {
+    // idx3에 원래 position=5인 큐레이션. movedNewIndex=1 → cutoff=max(1,3)=3.
+    const patch = computeReorderPatch([e('A'), e('X'), e('B'), e('C', 5)], 1);
+    expect(patch).toEqual([
+      { id: 'A', position: 1 },
+      { id: 'X', position: 2 },
+      { id: 'B', position: 3 },
+      { id: 'C', position: 4 }, // 5→4로 정합
+    ]);
+  });
+
+  it('prefix position이 이미 정확하면 그 항목은 diff에서 제외(최소 쓰기)', () => {
+    const patch = computeReorderPatch([e('X', 1), e('Y', 2), e('Z')], 1);
+    expect(patch).toEqual([]);
+  });
+
+  it('순수 null tail(cutoff 이후)은 절대 건드리지 않는다(백필0)', () => {
+    // cur-1(pos1) 고정, 그 뒤 null 3개. movedNewIndex=0 → cutoff=0 → prefix만.
+    const patch = computeReorderPatch([e('cur-1', 1), e('n1'), e('n2'), e('n3')], 0);
+    expect(patch).toEqual([]); // 이미 pos1 정확 → 변경 0, tail 무손
+  });
+});

--- a/apps/web/src/lib/epic-steer.ts
+++ b/apps/web/src/lib/epic-steer.ts
@@ -1,0 +1,38 @@
+import type { EpicPositionItem } from '@sprintable/core-storage';
+
+/** 재정렬 계산에 필요한 최소 형상(로드맵 조타·wedge #2). */
+export interface SteerEpic {
+  id: string;
+  position?: number | null;
+}
+
+/**
+ * 드래그 재정렬 → BE `PATCH /epics/bulk`로 보낼 `{id,position}` diff 산출.
+ *
+ * 모델(BE §1.3 · order_by=position = (position IS NULL) ASC, position ASC, created_at DESC):
+ * 큐레이션(position≠null)은 **명시 prefix**(1..k)로 앞에 고정되고, 안 건드린 null tail은
+ * created_at 순 자동도출로 뒤에 남는다. 어떤 항목을 시각적으로 null tail보다 앞에 두려면
+ * 그 위쪽(0..지점) 전체가 큐레이션돼야 하므로 — cutoff까지 prefix를 1..k로 renumber한다.
+ *
+ * `cutoff = max(이동 항목의 새 인덱스, 원래 큐레이션돼 있던 최대 인덱스)`. cutoff 이후(순수
+ * null tail)는 손대지 않는다(백필0). 반환은 **실제로 값이 바뀌는 항목만**(최소 쓰기).
+ *
+ * @param reordered arrayMove로 새 시각 순서가 반영된 배열(각 항목은 원래 position 보유)
+ * @param movedNewIndex 이동한 항목의 새 인덱스
+ */
+export function computeReorderPatch(reordered: SteerEpic[], movedNewIndex: number): EpicPositionItem[] {
+  let maxCuratedIdx = -1;
+  reordered.forEach((e, i) => {
+    if (e.position != null) maxCuratedIdx = i;
+  });
+  const cutoff = Math.max(movedNewIndex, maxCuratedIdx);
+
+  const patch: EpicPositionItem[] = [];
+  for (let i = 0; i <= cutoff; i++) {
+    const e = reordered[i];
+    if (!e) continue;
+    const newPos = i + 1;
+    if (e.position !== newPos) patch.push({ id: e.id, position: newPos });
+  }
+  return patch;
+}

--- a/apps/web/src/services/epic.ts
+++ b/apps/web/src/services/epic.ts
@@ -1,5 +1,5 @@
-import type { IEpicRepository, CreateEpicInput, UpdateEpicInput, RepositoryScopeContext } from '@sprintable/core-storage';
-export type { CreateEpicInput, UpdateEpicInput } from '@sprintable/core-storage';
+import type { IEpicRepository, CreateEpicInput, UpdateEpicInput, EpicPositionItem, RepositoryScopeContext } from '@sprintable/core-storage';
+export type { CreateEpicInput, UpdateEpicInput, EpicPositionItem } from '@sprintable/core-storage';
 import { validateStatusTransition } from '@/lib/epic-permissions';
 
 export class EpicService {
@@ -12,8 +12,13 @@ export class EpicService {
     return this.repository.create(input);
   }
 
-  async list(filters: { project_id?: string; limit?: number; cursor?: string | null }) {
+  async list(filters: { project_id?: string; limit?: number; cursor?: string | null; order_by?: string }) {
     return this.repository.list(filters);
+  }
+
+  /** 로드맵 조타 재정렬 — 큐레이션한 에픽만 position 갱신(백필0). */
+  async bulkUpdatePositions(items: EpicPositionItem[]) {
+    return this.repository.bulkUpdatePositions(items);
   }
 
   async getById(id: string, scope?: RepositoryScopeContext) {

--- a/apps/web/src/services/glance.test.ts
+++ b/apps/web/src/services/glance.test.ts
@@ -90,6 +90,29 @@ describe('scopeRoadmapEpics ("현재 궤적" window — 유나 서사 확定(b),
   });
 });
 
+describe('scopeRoadmapEpics — 로드맵 조타 curated-first 소비(wedge #2·position 반영·#2056 회귀0)', () => {
+  function epic(id: string, status: string, day: number, position?: number | null): BeEpicListItem {
+    return { id, title: id, status, created_at: `2026-01-${String(day).padStart(2, '0')}T00:00:00Z`, position };
+  }
+
+  it('position 전무(미조타) 시 created_at ASC 폴백 — 기존 렌더와 동일(#2056 회귀0)', () => {
+    const epics = [epic('c', 'active', 3), epic('a', 'done', 1), epic('b', 'done', 2)];
+    const arc = scopeRoadmapEpics(epics, { behind: 5, ahead: 5, bound: 8 });
+    expect(arc.epics.map((e) => e.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('큐레이션(position≠null)을 position ASC로 앞에 고정, 나머지 null은 created_at ASC로 뒤에', () => {
+    const epics = [
+      epic('auto-old', 'active', 1),   // null → tail(created_at ASC)
+      epic('auto-new', 'draft', 9),    // null → tail
+      epic('cur-2', 'done', 5, 2),     // 큐레이션 2
+      epic('cur-1', 'draft', 8, 1),    // 큐레이션 1(가장 앞)
+    ];
+    const arc = scopeRoadmapEpics(epics, { behind: 9, ahead: 9, bound: 20 });
+    expect(arc.epics.map((e) => e.id)).toEqual(['cur-1', 'cur-2', 'auto-old', 'auto-new']);
+  });
+});
+
 describe('mergeRoadmap (epic 목록 순서 SSOT + 별도 진척 엔드포인트 병합)', () => {
   const epics: BeEpicListItem[] = [
     { id: 'e1', title: 'E-VERIFY', status: 'done', created_at: '2026-06-01T00:00:00Z' },

--- a/apps/web/src/services/glance.ts
+++ b/apps/web/src/services/glance.ts
@@ -32,6 +32,10 @@ export interface BeEpicListItem {
   title: string;
   status: string;
   created_at: string;
+  // E-GLANCE wedge #2(로드맵 조타): 큐레이션 순서(null=미조타). 아크는 이 순서를 소비만 한다
+  // (드래그 없음). BE order_by=position 미지정/미보유 시 전부 null 취급 → 기존 created_at 정렬과
+  // 동일(#2056 회귀0).
+  position?: number | null;
 }
 
 /**
@@ -56,7 +60,18 @@ export function scopeRoadmapEpics(
   epics: BeEpicListItem[],
   window: { behind: number; ahead: number; bound: number } = DEFAULT_ARC_WINDOW,
 ): RoadmapArc {
-  const asc = [...epics].sort((a, b) => a.created_at.localeCompare(b.created_at));
+  // 큐레이션(position≠null) 우선(position ASC) → 나머지는 created_at ASC(아크의 과거→현재
+  // 시간 읽기 유지). BE order_by=position((position IS NULL) ASC, position ASC, created_at DESC)의
+  // curated-first를 아크가 소비만 반영 — 조타 결과가 로드맵 아크에도 비친다(wedge #2·소비 전용).
+  // position 전무 시(미조타) 전부 created_at ASC로 폴백 → 기존 렌더 100% 동일(#2056 회귀0).
+  const asc = [...epics].sort((a, b) => {
+    const ap = a.position;
+    const bp = b.position;
+    if (ap != null && bp != null) return ap - bp;
+    if (ap != null) return -1;
+    if (bp != null) return 1;
+    return a.created_at.localeCompare(b.created_at);
+  });
   const activeIndices: number[] = [];
   for (let i = 0; i < asc.length; i++) if (asc[i]!.status === 'active') activeIndices.push(i);
 

--- a/packages/core-storage/src/index.ts
+++ b/packages/core-storage/src/index.ts
@@ -8,6 +8,7 @@ export type {
   CreateEpicInput,
   UpdateEpicInput,
   EpicListFilters,
+  EpicPositionItem,
   RepositoryScopeContext,
 } from './interfaces/IEpicRepository';
 

--- a/packages/core-storage/src/interfaces/IEpicRepository.ts
+++ b/packages/core-storage/src/interfaces/IEpicRepository.ts
@@ -20,6 +20,10 @@ export interface Epic {
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
+  // E-GLANCE wedge #2(로드맵 조타·BE #2076): 큐레이션 순서. null=미조타(자동도출). source_loop_id는
+  // 계보 인터페이스(Loop 제안 hook)뿐 — 실 배선은 P3/v2, v1은 타입만 통과(no-fiction).
+  position?: number | null;
+  source_loop_id?: string | null;
 }
 
 export interface CreateEpicInput {
@@ -48,13 +52,23 @@ export interface UpdateEpicInput {
 
 export interface EpicListFilters extends PaginationOptions {
   project_id?: string;
-  /** 단조 정렬 컬럼(created_at/updated_at). BE에 위임해 true cursor 페이지네이션에 사용. */
+  /** 단조 정렬 컬럼(created_at/updated_at). BE에 위임해 true cursor 페이지네이션에 사용.
+   * "position"(로드맵 조타·wedge #2)은 복합 정렬((position IS NULL) ASC, position ASC,
+   * created_at DESC)이라 BE가 X-Next-Cursor를 내지 않는다 — 소비 측은 커서 이어달리기 금지. */
   order_by?: string;
+}
+
+/** 로드맵 조타 재정렬(wedge #2·BE `PATCH /api/v2/epics/bulk`). 큐레이션한 에픽만 position 세팅. */
+export interface EpicPositionItem {
+  id: string;
+  position: number;
 }
 
 export interface IEpicRepository {
   create(input: CreateEpicInput): Promise<Epic>;
   list(filters: EpicListFilters): Promise<Epic[]>;
+  /** 로드맵 조타 재정렬 — items의 에픽만 position 갱신(백필0). 갱신본만 반환. */
+  bulkUpdatePositions(items: EpicPositionItem[]): Promise<Epic[]>;
   getById(id: string, scope?: RepositoryScopeContext): Promise<Epic>;
   getByIdWithStories(id: string, scope?: RepositoryScopeContext): Promise<Epic & { stories: unknown[] }>;
   update(id: string, input: UpdateEpicInput): Promise<Epic>;

--- a/packages/storage-api/src/ApiEpicRepository.ts
+++ b/packages/storage-api/src/ApiEpicRepository.ts
@@ -1,4 +1,4 @@
-import type { IEpicRepository, Epic, CreateEpicInput, UpdateEpicInput, EpicListFilters, RepositoryScopeContext } from '@sprintable/core-storage';
+import type { IEpicRepository, Epic, CreateEpicInput, UpdateEpicInput, EpicListFilters, EpicPositionItem, RepositoryScopeContext } from '@sprintable/core-storage';
 import { fastapiCall } from './utils';
 
 export class ApiEpicRepository implements IEpicRepository {
@@ -19,6 +19,12 @@ export class ApiEpicRepository implements IEpicRepository {
         order_by: filters.order_by,
       },
     });
+  }
+
+  async bulkUpdatePositions(items: EpicPositionItem[]): Promise<Epic[]> {
+    // 로드맵 조타 재정렬(wedge #2·BE §1.4). org_id/project 인가는 BE 단일 소스(SEC-S8 W/W2)라
+    // FE는 thin proxy — items만 포워드(백필0·갱신본만 반환). /{id}보다 먼저 매칭되도록 BE가 /bulk 선언.
+    return fastapiCall<Epic[]>('PATCH', '/api/v2/epics/bulk', this.accessToken, { body: { items } });
   }
 
   async getById(id: string, _scope?: RepositoryScopeContext): Promise<Epic> {


### PR DESCRIPTION
## 무엇 (STEER v1 FE · story 2258ccd6)
로드맵 조타 wedge #2 FE. 근거: doc `roadmap-steer-v1-handoff`(유나 락·시각 SSOT=임베드 목업) + BE #2076(develop `b663c4ae` 머지본) 필드/이벤트 계약.
**PO 표면 확定(b):** 큐레이션 편집 표면 = `/epics` 풀리스트(기존 표면·신규표면0)·E-GLANCE `RoadmapFlow` 아크 = 소비 전용.

## 변경
| # | 표면 | 내용 |
|---|---|---|
| ① | `app/api/epics/route.ts` | `order_by` 패스스루·`position` 모드는 커서 meta 미부착(전량로드·이어달리기 금지) |
| ② | `app/api/epics/bulk/route.ts` (신규) | BE `PATCH /api/v2/epics/bulk` 프록시(실 persist·thin proxy·형상검증) |
| ③ | `services/glance.ts` | `RoadmapEpic`/`BeEpicListItem` position 스레드·`scopeRoadmapEpics` curated-first 정렬 |
| ④ | `epics-client.tsx` | @dnd-kit sortable(터치 no-drag)·drop→bulk PATCH·큐레이션/자동(NULL) 마커·핸드오프 compact·Loop hook |
| ⑤ | `RoadmapFlow` | 무변경 — 아크는 ③ 정렬을 소비만(드래그 0) |
| — | `core-storage`/`storage-api` | `Epic.position`/`source_loop_id` 타입·`EpicPositionItem`·`bulkUpdatePositions` |

## AC 대응
1. ✅ `/epics` 드래그 재정렬 → 실 `PATCH /epics/bulk` persist(prefix-renumber·백필0)·큐레이션+자동(NULL) 혼합 마커
2. ✅ 조타→핸드오프 compact 1개("● 조타 접수 · 오케스트레이션 중 · 오르테가군")·활동량/타임스탬프/이벤트 나열 0·Proof Blue·`motion-safe` 호흡(reduced-motion 대응)
3. ✅ Loop 제안 배지 = hook만·`source_loop_id` 배선(P3/v2) 전엔 미표시(no-fiction·sparkle 0·claimed amber)
4. ✅ `RoadmapFlow` = curated-first 소비만·드래그 0·#2056 회귀0(order_by 미지정 시 기존 렌더 100% 동일·position 모드 커서 이어달리기 코드 없음)
5. ✅ 양테마(proof 토큰)·vitest 1225 green·type-check clean·eslint 0

## 유나 가디언 4락
- 핸드오프 신뢰단계 **1개만**(리스트 헤더·활동량 0) ✅
- 드래그 = **실 PATCH persist**(낙관 후 서버 확정본 정합·실패 롤백) ✅
- 제안 배지 **배선 전 미표시**(no-fiction) ✅
- **#2056 회귀0**(scopeRoadmapEpics position-less → created_at 폴백 동일·기존 테스트 green) ✅

## 검증
- `pnpm type-check` clean · `eslint` 0 · `vitest run` **1225 passed / 0 failed** · `next build` ✅
- 신규 유닛: `computeReorderPatch`(prefix-renumber 5케이스)·`scopeRoadmapEpics` curated-first
- ⏳ dev 라이브픽셀(드래그→persist·핸드오프·양테마·모바일 터치 no-drag)은 develop 배포 後 done-gate(로컬 FE는 dev BE JWT 불일치로 인증 차단)

## 표면 결정(b) 근거
목업 ①(세로 풀리스트)과 실 `RoadmapFlow`(가로 window 아크)의 문서 내부 모순 → PO/유나 콜로 편집=/epics·아크=소비 확定(doc 상단 🔒 블록). window 부분집합 드래그로는 전량 position 큐레이션 불가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)