### PR TITLE
fix(security): human_verified SOUL-LOCK choke-point 가드 — gate_approval evidence는 휴먼 resolver만 (story e1063967)

### DIFF
--- a/backend/app/services/evidence_service.py
+++ b/backend/app/services/evidence_service.py
@@ -1,4 +1,5 @@
 """E-VERIFY V0-S2(story 3fbd048d): evidence-backed 신호 + gate_approval 자동 편입."""
+import logging
 import uuid
 
 from sqlalchemy import select
@@ -6,6 +7,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.evidence import Evidence
 from app.models.gate import Gate
+
+logger = logging.getLogger(__name__)
 
 _EVIDENCE_WORK_ITEM_TYPES = frozenset({"story", "task"})
 
@@ -67,6 +70,24 @@ async def create_gate_approval_evidence_if_applicable(
     if resolver_id is None:
         # approved 전이는 라우터에서 human-only 강제(agent API키 403)라 정상 경로엔 항상 있음 —
         # 없으면(내부 직호출 등 예외 경로) 귀속시킬 사람이 없으므로 evidence 생성 skip(무회귀).
+        return
+    # E-SECURITY e1063967 (human_verified SOUL-LOCK choke-point 가드): gate_approval evidence는
+    # human_verified 신호의 유일 신호원(batch_human_verified가 type=gate_approval만 인간 서명으로
+    # 승격)이라, resolver가 실제 휴먼일 때만 생성한다. approved 전이의 human-only 강제가 현재는
+    # gates.py 라우터에만 있고(agent API키 403) 이 심층함수는 그 강제를 신뢰만 했다 — 그 경로는
+    # 지금은 dead code지만 parallel-approval 등 새 라우터가 배선되는 순간 에이전트가 인간 검증
+    # 신호를 위조할 수 있다. 신뢰 대신 choke-point에서 선착 검증(트리거 게이트): resolver를 org
+    # 범위에서 신원해소해 휴먼이 아니거나(에이전트) 해소 불가면 fail-closed로 evidence 생성 skip.
+    # (gate 전이 자체는 무영향 — 여기선 SOUL-LOCK 신호만 게이팅. 정상 휴먼 resolver는 항상 통과.)
+    from app.services.member_resolver import resolve_member_identity
+
+    resolver = await resolve_member_identity(resolver_id, gate.org_id, session)
+    if resolver is None or resolver.type != "human":
+        logger.warning(
+            "gate_approval evidence skipped — resolver %s is not a verified human "
+            "(gate=%s, work_item=%s, resolved_type=%s). SOUL-LOCK: human_verified 신호는 휴먼만 생성.",
+            resolver_id, gate.id, gate.work_item_id, resolver.type if resolver else "unresolved",
+        )
         return
     session.add(Evidence(
         id=uuid.uuid4(),

--- a/backend/tests/test_e_ui_daegbyeon_claimed_vs_verified_be_contract_realdb.py
+++ b/backend/tests/test_e_ui_daegbyeon_claimed_vs_verified_be_contract_realdb.py
@@ -75,6 +75,22 @@ async def _seed(session):
     return {"org_id": org.id, "project_id": project.id, "agent_id": agent.id, "story_id": story.id, "task_id": task.id}
 
 
+async def _seed_human_approver(session, org_id: uuid.UUID) -> uuid.UUID:
+    """org owner 휴먼을 시드하고 org_member.id 반환 — e1063967 SOUL-LOCK choke-point가
+    gate_approval evidence를 실제 휴먼 resolver에만 생성하므로, gate 승인 시나리오의 resolver는
+    실 휴먼이어야 human_verified가 세팅된다(라우터가 강제하는 resolved.id와 동형)."""
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    session.add(User(id=user_id, email=f"approver-{user_id.hex[:8]}@test.com", hashed_password="x"))
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user_id, role="owner")
+    session.add(om)
+    await session.commit()
+    return om.id
+
+
 def _client_for(app):
     from httpx import AsyncClient, ASGITransport
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
@@ -175,7 +191,7 @@ async def test_story_verified_state_after_gate_approval_with_who_and_when():
     try:
         async with Session() as s:
             seeded = await _seed(s)
-            approver_id = uuid.uuid4()
+            approver_id = await _seed_human_approver(s, seeded["org_id"])
             role_id = uuid.uuid4()
 
             gate = await create_gate(
@@ -215,7 +231,7 @@ async def test_task_verified_state_mirrors_story():
     try:
         async with Session() as s:
             seeded = await _seed(s)
-            approver_id = uuid.uuid4()
+            approver_id = await _seed_human_approver(s, seeded["org_id"])
             role_id = uuid.uuid4()
 
             gate = await create_gate(

--- a/backend/tests/test_e_verify_v0_s2_evidence_signal_realdb.py
+++ b/backend/tests/test_e_verify_v0_s2_evidence_signal_realdb.py
@@ -71,6 +71,21 @@ async def _seed(session):
     return org.id, project.id, agent.id, story.id, task.id
 
 
+async def _seed_human_approver(session, org_id: uuid.UUID) -> uuid.UUID:
+    """org owner 휴먼을 시드하고 그 org_member.id를 반환 — resolve_member_identity가 OrgMember
+    분기에서 type=human으로 해소하는 값(= 라우터가 resolver_id로 강제하는 resolved.id와 동형)."""
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    session.add(User(id=user_id, email=f"approver-{user_id.hex[:8]}@test.com", hashed_password="x"))
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user_id, role="owner")
+    session.add(om)
+    await session.commit()
+    return om.id
+
+
 def _client_for(app):
     from httpx import AsyncClient, ASGITransport
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
@@ -174,14 +189,14 @@ async def test_task_has_evidence_none_by_default_true_after_attach():
 @pytest.mark.anyio
 async def test_gate_approval_auto_creates_evidence_and_flips_signal():
     """HITL gate 승인 → gate_approval evidence 자동 편입 → story.has_evidence=True."""
-    from app.models.gate import Gate
     from app.services.gate_service import create_gate, transition_gate
 
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
             org_id, project_id, agent_id, story_id, _task_id = await _seed(s)
-            approver_id = uuid.uuid4()
+            # e1063967 SOUL-LOCK: resolver는 실제 휴먼이어야 gate_approval evidence가 생성된다.
+            approver_id = await _seed_human_approver(s, org_id)
             role_id = uuid.uuid4()
 
             gate = await create_gate(
@@ -277,6 +292,95 @@ async def test_gate_approval_for_non_story_task_work_item_type_is_noop():
             from app.models.evidence import Evidence
             rows = (await s.execute(
                 select(Evidence).where(Evidence.work_item_id == fake_gate.work_item_id)
+            )).scalars().all()
+            assert rows == []
+    finally:
+        await engine.dispose()
+
+
+# ── e1063967 human_verified SOUL-LOCK choke-point 가드 ─────────────────────────
+# gate_approval evidence = human_verified 신호의 유일 신호원. choke-point가 resolver의
+# 휴먼성을 검증하지 않으면(현재는 라우터 강제에만 의존), parallel-approval 등 새 라우터가
+# 배선되는 순간 에이전트가 인간 검증 신호를 위조할 수 있다. 아래 3종으로 choke-point 자체가
+# 게이팅함을 실증(비-동어반복: 휴먼=생성 / 에이전트·미해소=차단).
+
+def _story_gate(org_id: uuid.UUID, story_id: uuid.UUID):
+    from app.models.gate import Gate
+    return Gate(
+        id=uuid.uuid4(), org_id=org_id, work_item_id=story_id, work_item_type="story",
+        gate_type="pr_review", status="approved",
+    )
+
+
+@pytest.mark.anyio
+async def test_chokepoint_human_resolver_creates_evidence():
+    """positive: resolver가 실제 휴먼이면 choke-point가 gate_approval evidence를 생성한다."""
+    from app.services.evidence_service import create_gate_approval_evidence_if_applicable
+    from sqlalchemy import select
+    from app.models.evidence import Evidence
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _project_id, _agent_id, story_id, _task_id = await _seed(s)
+            human_id = await _seed_human_approver(s, org_id)
+            await create_gate_approval_evidence_if_applicable(
+                s, _story_gate(org_id, story_id), "approved", human_id
+            )
+            await s.commit()
+            rows = (await s.execute(
+                select(Evidence).where(Evidence.work_item_id == story_id, Evidence.type == "gate_approval")
+            )).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].created_by == human_id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_chokepoint_agent_resolver_creates_no_evidence_soul_lock():
+    """SOUL-LOCK: resolver가 에이전트(team_members type=agent)면 choke-point가 인간 검증 신호
+    위조를 차단 — gate_approval evidence 0건(fail-closed). 위 positive와 동일 shape·resolver만
+    에이전트로 바꿔 비-동어반복 실증."""
+    from app.services.evidence_service import create_gate_approval_evidence_if_applicable
+    from sqlalchemy import select
+    from app.models.evidence import Evidence
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _project_id, agent_id, story_id, _task_id = await _seed(s)
+            # agent_id = _seed가 만든 Member(type=agent)+grant → team_members 뷰서 type=agent로 해소.
+            await create_gate_approval_evidence_if_applicable(
+                s, _story_gate(org_id, story_id), "approved", agent_id
+            )
+            await s.commit()
+            rows = (await s.execute(
+                select(Evidence).where(Evidence.work_item_id == story_id, Evidence.type == "gate_approval")
+            )).scalars().all()
+            assert rows == [], "에이전트 resolver가 human_verified 신호를 위조했다(SOUL-LOCK 파손)"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_chokepoint_unresolvable_resolver_creates_no_evidence_soul_lock():
+    """SOUL-LOCK: resolver_id가 org 범위서 해소 불가(무존재 member)면 fail-closed로 evidence
+    생성 skip — 이전엔 임의 uuid resolver로도 evidence가 생겼다(이 가드가 그 구멍을 봉인)."""
+    from app.services.evidence_service import create_gate_approval_evidence_if_applicable
+    from sqlalchemy import select
+    from app.models.evidence import Evidence
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, _project_id, _agent_id, story_id, _task_id = await _seed(s)
+            await create_gate_approval_evidence_if_applicable(
+                s, _story_gate(org_id, story_id), "approved", uuid.uuid4()
+            )
+            await s.commit()
+            rows = (await s.execute(
+                select(Evidence).where(Evidence.work_item_id == story_id, Evidence.type == "gate_approval")
             )).scalars().all()
             assert rows == []
     finally:


### PR DESCRIPTION
## human_verified SOUL-LOCK choke-point 가드 (story `e1063967`, E-SECURITY fast-follow)

### 갭 실체
`create_gate_approval_evidence_if_applicable`(`evidence_service.py`)는 **human_verified 신호의 유일 신호원**이다 — `batch_human_verified`가 `type=gate_approval` evidence만 인간 서명으로 승격한다. 그런데 이 심층함수는 `resolver_id`가 **실제 휴먼인지 검증하지 않고** `gates.py` 라우터의 human-only 강제(agent API키 403)를 **신뢰만** 했다. 그 강제가 라우터에만 있어 현재는 도달 불가(dead code)지만, **parallel-approval 등 새 결재 라우터가 배선되는 순간 에이전트가 인간 검증 신호를 위조**할 수 있다.

### fix — choke-point 선착 가드(트리거 게이트)
신뢰 대신 심층 choke-point에서 직접 검증: `resolver_id`를 `gate.org_id` 범위에서 `resolve_member_identity`로 신원해소해, **휴먼이 아니거나(에이전트) 해소 불가하면 fail-closed로 evidence 생성 skip + `logger.warning`**. gate 전이 자체는 무영향 — SOUL-LOCK 신호만 게이팅하고, 정상 휴먼 resolver는 항상 통과.

### 변경
- `services/evidence_service.py`: `resolver_id is None` 체크 뒤 human 검증 가드 추가(`resolve_member_identity` 로컬 import·순환 회피·fail-closed skip+warning).
- `tests/test_e_verify_v0_s2_evidence_signal_realdb.py`: happy-path resolver를 실 휴먼(org_member)으로 갱신 + **신규 SOUL-LOCK 3종**(choke-point 직호출: 휴먼→생성 / 에이전트→0건 / 미해소 uuid→0건).
- `tests/test_e_ui_daegbyeon_claimed_vs_verified_be_contract_realdb.py`: gate-approval 시나리오 2종 resolver를 실 휴먼으로 갱신. 직접-insert 테스트는 무변경.

기존 테스트들이 **random uuid resolver로도 evidence가 생기던 게 바로 이 구멍의 방증** — 이제 SOUL-LOCK에 막혀 실 휴먼 시드가 필수가 됐다.

### 검증 (실-PG)
- **13/13 green**(v0_s2 8·daegbyeon 5). **sabotage**(가드 무력화 → 에이전트·미해소 resolver 테스트 즉시 RED)로 비-공허 실증.
- 무접근권/reject/doc no-op 등 기존 경로 무변경. gate_service·gate-transition-human-only·capability_gate·doc_gate 등 23+ green. **ruff clean·마이그 0**.

### 무관 pre-existing (내 diff 밖·이중 확認)
`h1_s10`·`a2a_sa5`·`h1_fix2` 등 realdb 테스트가 `constraint "fk_artifact_versions_source_comment_id" 부재`로 RED — 백로그 **`9108cb4f`**(cron 테스트 constraint 드리프트)와 **동일 시그니처**. 그 이슈 blast-radius가 cron 단건보다 넓음(공유 realdb fixture DDL 계열 전반 — 재-스코프 검토 제안). `evidence_service`를 develop 버전으로 되돌려도 동일 7건 실패 = **내 변경 중립**(A/B revert + fresh DB 이중 확認).

### 설계 노트 (QA 판단 위임)
현재는 fail-closed **skip + warning**(gate 전이 무영향·기존 no-op 철학 계승). 더 강한 loud-fail(raise)도 가능하나, 정상 휴먼 경로는 이 분기에 도달 안 하므로 skip이 회귀-안전. 필요 시 조정.

QA: 까심(오르테가 라우팅). ⚠️#2079 까심 RC 시 그쪽 amend 최우선.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
