### PR TITLE
fix(security): tasks org-wide result-level cross-project 누출 봉인 (story d3e5ca89)

### DIFF
--- a/backend/app/repositories/task.py
+++ b/backend/app/repositories/task.py
@@ -1,11 +1,42 @@
 import uuid
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.pm import Task
+from app.models.pm import Story, Task
 from app.repositories.base import BaseRepository
 
 
 class TaskRepository(BaseRepository[Task]):
     def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
         super().__init__(Task, session, org_id)
+
+    async def list_in_projects(
+        self,
+        project_ids: list[uuid.UUID],
+        *,
+        assignee_id: uuid.UUID | None = None,
+        status: str | None = None,
+        limit: int = 1000,
+    ) -> list[Task]:
+        """d3e5ca89(SEC fast-follow): org-wide task 조회를 caller 접근권 project 집합으로
+        result-level 스코프. Task엔 project_id 컬럼이 없어(story_id NN) Story JOIN으로 project를
+        환원한다. project_ids가 비면(접근권 0개) 빈 리스트 — org 전체 task title/assignee_id/
+        status가 새던 result-level 누출을 봉인. assignee_id/status는 추가 narrowing 필터."""
+        if not project_ids:
+            return []
+        q = (
+            select(Task)
+            .join(Story, Story.id == Task.story_id)
+            .where(
+                self._org_filter(),
+                Task.deleted_at.is_(None),
+                Story.project_id.in_(project_ids),
+            )
+        )
+        if assignee_id is not None:
+            q = q.where(Task.assignee_id == assignee_id)
+        if status is not None:
+            q = q.where(Task.status == status)
+        result = await self.session.execute(q.limit(limit))
+        return list(result.scalars().all())

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -66,22 +66,30 @@ async def list_tasks(
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> list[TaskResponse]:
-    # ratchet round6(잔여 HIGH): 이 엔드포인트엔 project_id 파라미터 자체가 없고 story_id가
-    # 유일한 project-환원 파라미터라, story_id 지정 시 _assert_task_project_access(기존
-    # G-fix 재사용)로 caller의 story project 접근권을 검증한다. story_id 미지정 시 org 전체
-    # task가 나가던 기존 갭은 baseline 기술 그대로("org-scope만") — 이 라운드는 story_id
-    # 벡터만 닫는다(project_id 필터 부재라 round1~5의 project_id 직접검증 패턴 적용 불가).
+    # story_id 지정 시: round6(#2072)에서 _assert_task_project_access(기존 G-fix 재사용)로
+    # caller의 story project 접근권을 직접 검증(단일 story 스코프).
     if story_id is not None:
         await _assert_task_project_access(repo.session, auth, org_id, story_id)
+        filters: dict = {"story_id": story_id}
+        if assignee_id:
+            filters["assignee_id"] = assignee_id
+        if status_filter:
+            filters["status"] = status_filter
+        tasks = await repo.list(**filters)
+    else:
+        # d3e5ca89(SEC fast-follow): story_id 미지정(org-wide) 분기는 예전엔 org 전체 task를
+        # result-level로 흘렸다 — 같은 org 다른 project의 task title/assignee_id/status를 접근권
+        # 없이 열거. round6은 story_id 벡터만 닫고 이 result-level 누출은 분리 트래킹됐다(d3e5ca89).
+        # caller가 실제 접근권을 가진 project의 task로만 스코프(Task엔 project_id가 없어 Story
+        # JOIN으로 환원). 접근권 0이면 빈 리스트. assignee_id/status는 그 위 추가 narrowing 필터.
+        from app.services.project_auth import accessible_project_ids_in_org
 
-    filters: dict = {}
-    if story_id:
-        filters["story_id"] = story_id
-    if assignee_id:
-        filters["assignee_id"] = assignee_id
-    if status_filter:
-        filters["status"] = status_filter
-    tasks = await repo.list(**filters)
+        accessible = await accessible_project_ids_in_org(
+            repo.session, uuid.UUID(auth.user_id), org_id
+        )
+        tasks = await repo.list_in_projects(
+            accessible, assignee_id=assignee_id, status=status_filter
+        )
     await _attach_has_evidence(repo.session, tasks)
     return [TaskResponse.model_validate(t) for t in tasks]
 

--- a/backend/tests/test_e_sec_tasks_result_scope_d3e5ca89_realdb.py
+++ b/backend/tests/test_e_sec_tasks_result_scope_d3e5ca89_realdb.py
@@ -1,0 +1,270 @@
+"""E-SECURITY fast-follow d3e5ca89 — GET /api/v2/tasks org-wide(story_id 미지정) 분기의
+result-level cross-project 누출 봉인, 실 Postgres 검증.
+
+갭: round6(#2072)은 story_id 벡터만 닫았고, story_id 미지정 분기는 org 전체 task를 그대로
+반환해 같은 org 안 접근권 없는 project의 task title/assignee_id/status가 열거됐다(result-level
+IDOR). fix: caller의 accessible_project_ids_in_org로 스코프(Task엔 project_id가 없어 Story JOIN).
+
+적대 축(비-동어반복): 시크릿 project_b task의 title/assignee_id가 응답 바디에 verbatim
+미노출까지 assert. + assignee_id 필터로도 cross-project task를 못 끌어옴을 실증.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+_SECRET_TASK_TITLE_B = "SECRET-TASK-B-TITLE"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a, project_b):
+    - caller(휴먼·org member·project_a에만 grant)
+    - owner(휴먼·org owner·grant 없이 org-wide)
+    - story_a∈project_a + task_a(title="Task A") / story_b∈project_b + task_b(title=시크릿·시크릿 assignee)
+    """
+    from app.models.organization import Organization
+    from app.models.pm import Story, Task
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    story_a = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Story A")
+    story_b = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Story B")
+    session.add_all([story_a, story_b])
+    await session.commit()
+
+    secret_assignee_id = uuid.uuid4()
+    task_a = Task(id=uuid.uuid4(), org_id=org.id, story_id=story_a.id, title="Task A", status="todo")
+    task_b = Task(
+        id=uuid.uuid4(), org_id=org.id, story_id=story_b.id, title=_SECRET_TASK_TITLE_B,
+        status="in-progress", assignee_id=secret_assignee_id,
+    )
+    session.add_all([task_a, task_b])
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=caller_om.id,
+        permission="granted", role="member",
+    ))
+    await session.commit()
+
+    owner_id = uuid.uuid4()
+    owner = User(id=owner_id, email=f"owner-{owner_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(owner)
+    await session.commit()
+    session.add(OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=owner_id, role="owner"))
+    await session.commit()
+
+    # 접근권 전무 caller(다른 org member·grant 0)
+    noaccess_id = uuid.uuid4()
+    noaccess = User(id=noaccess_id, email=f"noacc-{noaccess_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(noaccess)
+    await session.commit()
+    session.add(OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=noaccess_id, role="member"))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "story_a_id": story_a.id, "story_b_id": story_b.id,
+        "task_a_id": task_a.id, "task_b_id": task_b.id, "secret_assignee_id": secret_assignee_id,
+        "caller_id": caller_id, "owner_id": owner_id, "noaccess_id": noaccess_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_org_wide_list_scoped_to_accessible_projects_no_leak():
+    """봉인(비-동어반복): project_a grant caller가 story_id 없이 /tasks 조회 → task_a만.
+    project_b 시크릿 task의 title/assignee_id가 바디에 verbatim 미노출까지 assert."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/tasks")
+            assert resp.status_code == 200, resp.text
+            ids = {t["id"] for t in resp.json()}
+            assert ids == {str(seeded["task_a_id"])}
+            assert _SECRET_TASK_TITLE_B not in resp.text, "cross-project task title 유출"
+            assert str(seeded["secret_assignee_id"]) not in resp.text, "cross-project assignee_id 유출"
+            assert str(seeded["task_b_id"]) not in resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_owner_sees_all_projects_org_wide_unchanged():
+    """회귀0(over-block 방지): org owner는 grant 없이 org-wide 접근이라 /tasks에서 두 project
+    task를 모두 본다."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["owner_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/tasks")
+            assert resp.status_code == 200, resp.text
+            ids = {t["id"] for t in resp.json()}
+            assert ids == {str(seeded["task_a_id"]), str(seeded["task_b_id"])}
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_access_caller_gets_empty():
+    """접근권 0 caller(grant 없는 org member)는 org-wide /tasks에서 빈 리스트."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["noaccess_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/tasks")
+            assert resp.status_code == 200, resp.text
+            assert resp.json() == []
+            assert _SECRET_TASK_TITLE_B not in resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_assignee_filter_cannot_exfiltrate_cross_project():
+    """적대 축: project_a caller가 project_b 시크릿 assignee_id로 필터해도 0건 — assignee 필터로
+    cross-project task를 끌어올 수 없다(스코프가 필터보다 우선)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/tasks?assignee_id={seeded['secret_assignee_id']}")
+            assert resp.status_code == 200, resp.text
+            assert resp.json() == []
+            assert _SECRET_TASK_TITLE_B not in resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_story_id_branch_regression_unchanged():
+    """회귀0: story_id 지정 분기는 round6 가드 그대로 — 접근권 있는 story_a는 200(task_a),
+    접근권 없는 story_b는 403."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            ok = await client.get(f"/api/v2/tasks?story_id={seeded['story_a_id']}")
+            assert ok.status_code == 200, ok.text
+            assert {t["id"] for t in ok.json()} == {str(seeded["task_a_id"])}
+
+            blocked = await client.get(f"/api/v2/tasks?story_id={seeded['story_b_id']}")
+            assert blocked.status_code == 403, blocked.text
+            assert _SECRET_TASK_TITLE_B not in blocked.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## tasks org-wide result-level cross-project 누출 봉인 (story `d3e5ca89`, SEC fast-follow)

round6(#2072)에서 **분리 트래킹**된 별개 fix 클래스. `GET /api/v2/tasks`의 **story_id 미지정(org-wide) 분기**가 org 전체 task를 result-level로 반환해, 같은 org 안 **접근권 없는 project의 task `title`/`assignee_id`/`status`를 caller가 열거**할 수 있었다(result-level IDOR). round6은 story_id 벡터만 `_assert_task_project_access`로 닫았다.

### fix
story_id 미지정 분기를 `accessible_project_ids_in_org`(has_project_access lockstep)로 스코프. Task엔 `project_id` 컬럼이 없어(story_id NN·1:1) **Story JOIN으로 project 환원**. 접근권 0이면 빈 리스트. `assignee_id`/`status`는 그 위 narrowing 필터라 스코프를 못 뚫는다. story_id 지정 분기는 round6 가드 그대로.

- `repositories/task.py`: `TaskRepository.list_in_projects` 신설(Story JOIN·`project_ids IN`·org_filter·soft-delete·assignee/status narrowing).
- `routers/tasks.py`: `list_tasks`를 story_id 유무로 분기 — 지정=round6 경로, 미지정=accessible 스코프.

### 인가/ratchet
이 라우트는 이미 `_assert_task_project_access`를 호출해 ratchet(guard-function **CALL** 검사)은 green이었으나 **org-wide 분기가 result-level로 샜다** — ratchet이 못 잡는 별개 클래스라 수동 스토리. `accessible_project_ids_in_org`도 PROJECT_GUARD_FUNCTION이라 ratchet 계속 green(**allowlist 변경 없음**).

### 검증 (신규 realdb 5종·실-PG green)
1. **org-wide 봉인**(비-동어반복) — project_a grant caller가 /tasks 조회 시 task_a만, 시크릿 project_b task `title`/`assignee_id` verbatim 미노출.
2. **owner org-wide 무변경**(over-block 방지) — owner는 두 project task 모두.
3. **접근권 0 → 빈 리스트**.
4. **assignee_id 필터로 cross-project 탈취 불가** — project_b 시크릿 assignee로 필터해도 0건(스코프가 필터보다 우선).
5. **story_id 분기 회귀0** — round6 경로 200(task_a)+403(story_b).

**sabotage**(스코프 무력화 → 누출 의존 3종 즉시 RED)로 비-공허 실증. 기존 tasks·ratchet round6·SEC-S8 G/S/create-scope 등 26+ green. **ruff clean·마이그 0**.

QA: 까심(오르테가 라우팅). ⚠️#2080 까심 RC 시 그쪽 amend 최우선.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
