### PR TITLE
fix(agent-runs): 모델↔DB 드리프트 회수(duration_ms·project_id) + create project-scope 가드 (story 2a5f21d3)

### DIFF
--- a/backend/app/models/agent_run.py
+++ b/backend/app/models/agent_run.py
@@ -1,8 +1,8 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Integer, Numeric, Text, func
-from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+from sqlalchemy import Computed, DateTime, ForeignKey, Integer, Numeric, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
@@ -15,8 +15,11 @@ class AgentRun(Base):
     org_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    project_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=True, index=True
+    # 2a5f21d3: DB(baseline schema.sql)는 project_id NOT NULL인데 모델이 nullable=True로 드리프트
+    # → create_agent_run이 project_id 미공급 시 NotNullViolation. DB(원설계 SSOT)에 정합.
+    # agent_run은 project 안에서 일어나는 개념이라 도메인상 필수(마이그 불요·DB 이미 NOT NULL).
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
     )
     agent_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), nullable=False, index=True
@@ -38,7 +41,24 @@ class AgentRun(Base):
     status: Mapped[str] = mapped_column(Text, nullable=False, default="running")
     result_summary: Mapped[str | None] = mapped_column(Text, nullable=True)
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
-    duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # 2a5f21d3: DB에선 GENERATED ALWAYS STORED(baseline schema.sql·started/finished_at 또는
+    # duration_ms_legacy 폴백에서 파생)인데 모델이 plain writable Integer로 매핑해 SQLAlchemy가
+    # INSERT/UPDATE에 이 컬럼을 항상 emit → GeneratedAlwaysError로 agent_runs 생성 전건 실패했다.
+    # Computed(persisted=True)로 read-only 선언 → DML서 제외(모델↔DB 드리프트 해소·create_all
+    # DDL도 prod와 동형 generated 컬럼 생성). 표현식은 baseline schema.sql과 byte-정합.
+    duration_ms: Mapped[int | None] = mapped_column(
+        Integer,
+        Computed(
+            "CASE "
+            "WHEN ((finished_at IS NOT NULL) AND (started_at IS NOT NULL)) "
+            "THEN GREATEST(((EXTRACT(epoch FROM (finished_at - started_at)) * (1000)::numeric))::integer, 0) "
+            "WHEN (duration_ms_legacy IS NOT NULL) THEN duration_ms_legacy "
+            "ELSE NULL::integer "
+            "END",
+            persisted=True,
+        ),
+        nullable=True,
+    )
     last_error_code: Mapped[str | None] = mapped_column(Text, nullable=True)
     failure_disposition: Mapped[str | None] = mapped_column(Text, nullable=True)
     retry_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)

--- a/backend/app/models/agent_run.py
+++ b/backend/app/models/agent_run.py
@@ -41,6 +41,11 @@ class AgentRun(Base):
     status: Mapped[str] = mapped_column(Text, nullable=False, default="running")
     result_summary: Mapped[str | None] = mapped_column(Text, nullable=True)
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # duration_ms_legacy: 백필-only vestigial 컬럼(baseline schema.sql). 모델엔 미매핑이었으나
+    # 아래 duration_ms의 GENERATED 표현식이 이를 참조하므로, create_all(모델 메타데이터로 테이블
+    # 구축하는 realdb 테스트)에서 컬럼 부재로 UndefinedColumnError가 났다. DB에 존재하는 컬럼을
+    # 명시 매핑해 create_all DDL이 prod(migrated)와 동형이 되게 한다(read-only 취급·write 경로 없음).
+    duration_ms_legacy: Mapped[int | None] = mapped_column(Integer, nullable=True)
     # 2a5f21d3: DB에선 GENERATED ALWAYS STORED(baseline schema.sql·started/finished_at 또는
     # duration_ms_legacy 폴백에서 파생)인데 모델이 plain writable Integer로 매핑해 SQLAlchemy가
     # INSERT/UPDATE에 이 컬럼을 항상 emit → GeneratedAlwaysError로 agent_runs 생성 전건 실패했다.

--- a/backend/app/routers/agent_runs.py
+++ b/backend/app/routers/agent_runs.py
@@ -59,13 +59,28 @@ async def create_agent_run(
     body: CreateAgentRun,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
     repo: AgentRunRepository = Depends(_get_repo),
 ) -> AgentRunResponse:
     """prod 핫픽스(S20 전수스캔 MUST): cross-org IDOR — org_id를 body.agent_id가 속한 org에서
     그대로 파생해(caller org 검증 없이) 타 org agent 명의로 run을 생성할 수 있었다. caller의
     get_verified_org_id로 파생하고 agent_id가 그 org 소속인지 검증한다.
+
+    2a5f21d3: project_id는 DB NOT NULL·모델 정합으로 이제 필수 입력이다. body로 project_id를
+    받는 순간 신규 mutation 인가 표면이 되므로 resource-actual has_project_access로 caller의
+    실 접근권을 검증(body-claimed 금지·round1~9 규율)한다. 존재/타org=404, same-org 무접근권=403.
     """
+    from app.services.project_auth import has_project_access
+
+    # project_id 인가: caller org 소속 project인지(존재/타org 비노출 404) + 실 접근권(403).
+    proj_r = await session.execute(
+        select(Project.id).where(Project.id == body.project_id, Project.org_id == org_id)
+    )
+    if proj_r.scalar_one_or_none() is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    if not await has_project_access(session, uuid.UUID(auth.user_id), body.project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to this project")
+
     # team_members 는 projection VIEW — 멀티프로젝트 grant 면 같은 agent_id 가 N 행. org_id 필터로
     # caller org 소속만 통과(cross-org 차단) — .limit(1) 로 MultipleResultsFound 회피.
     member_r = await session.execute(
@@ -80,6 +95,7 @@ async def create_agent_run(
     run = await repo.create(
         org_id=org_id,
         agent_id=body.agent_id,
+        project_id=body.project_id,
         trigger=body.trigger,
         model=body.model,
         story_id=body.story_id,
@@ -89,7 +105,6 @@ async def create_agent_run(
         input_tokens=body.input_tokens,
         output_tokens=body.output_tokens,
         cost_usd=body.cost_usd,
-        duration_ms=body.duration_ms,
     )
     return AgentRunResponse.model_validate(run)
 
@@ -114,7 +129,6 @@ async def update_agent_run(
         input_tokens=body.input_tokens,
         output_tokens=body.output_tokens,
         cost_usd=body.cost_usd,
-        duration_ms=body.duration_ms,
         last_error_code=body.last_error_code,
     )
     if run is None:

--- a/backend/app/schemas/agent_run.py
+++ b/backend/app/schemas/agent_run.py
@@ -9,6 +9,9 @@ from pydantic import BaseModel, ConfigDict
 
 class CreateAgentRun(BaseModel):
     agent_id: uuid.UUID
+    # project_id(2a5f21d3): agent_run 필수 개념(DB NOT NULL 정합). 라우터가 caller의
+    # has_project_access를 resource-actual로 검증(body-claimed 금지·신규 mutation 인가 표면).
+    project_id: uuid.UUID
     trigger: str = "manual"
     model: str | None = None
     story_id: uuid.UUID | None = None
@@ -18,7 +21,8 @@ class CreateAgentRun(BaseModel):
     input_tokens: int | None = None
     output_tokens: int | None = None
     cost_usd: float | None = None
-    duration_ms: int | None = None
+    # duration_ms(2a5f21d3): DB GENERATED ALWAYS(started/finished_at 파생)라 클라 입력 불가 —
+    # 명시 세팅 시 GeneratedAlwaysError. 입력 표면에서 제거(응답 AgentRunResponse엔 read-only 유지).
 
 
 class UpdateAgentRun(BaseModel):
@@ -27,7 +31,7 @@ class UpdateAgentRun(BaseModel):
     input_tokens: int | None = None
     output_tokens: int | None = None
     cost_usd: float | None = None
-    duration_ms: int | None = None
+    # duration_ms: GENERATED ALWAYS라 입력 불가(2a5f21d3) — 제거.
     last_error_code: str | None = None
 
 

--- a/backend/tests/test_agent_runs_create_project_scope_2a5f21d3_realdb.py
+++ b/backend/tests/test_agent_runs_create_project_scope_2a5f21d3_realdb.py
@@ -1,0 +1,240 @@
+"""2a5f21d3 — create_agent_run 모델↔DB 드리프트 회수 + project_id IDOR 가드, 실 Postgres 검증.
+
+드리프트: duration_ms(DB GENERATED ALWAYS vs 모델 plain writable)+project_id(DB NOT NULL vs
+모델 nullable=True)로 agent_runs 생성이 전건 500(GeneratedAlwaysError/NotNullViolation)이었다.
+fix: 모델 duration_ms=Computed(insert emit 방지)+project_id=NOT NULL, CreateAgentRun에 project_id
+필수 추가, duration_ms 입력 제거. project_id는 신규 mutation 인가 표면이라 resource-actual
+has_project_access로 가드(body-claimed 금지·round1~9 규율).
+
+realdb 2방향: (a)정당 project_id→201(GeneratedAlways/NotNull 둘 다 해소·duration_ms는 DB 계산)
+(b)cross-project/nonexistent project_id→403/404(IDOR 차단·비-동어반복).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a, project_b) + agent_a(project_a grant·team_members 뷰 진입) +
+    caller(휴먼·project_a에만 grant·project_b 접근권 없음)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    agent_a = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent A")
+    session.add(agent_a)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, member_id=agent_a.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=caller_om.id,
+        permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "agent_a_id": agent_a.id, "caller_id": caller_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_create_with_valid_project_id_returns_201_drift_resolved():
+    """정당 project_id(접근권 有) 공급 시 201 — GeneratedAlwaysError(duration_ms)/NotNull
+    (project_id) 둘 다 해소. duration_ms는 DB 계산(started/finished_at 없으면 None)."""
+    from app.main import app
+    from sqlalchemy import text
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/agent-runs", json={
+                "agent_id": str(seeded["agent_a_id"]),
+                "project_id": str(seeded["project_a_id"]),
+                "status": "running",
+            })
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["agent_id"] == str(seeded["agent_a_id"])
+            assert body["duration_ms"] is None  # DB GENERATED — started/finished_at 없어 None
+            # 영속 확認: run이 project_a로 실제 생성됐는지 DB 직조회(AgentRunResponse엔 project_id 미노출).
+            async with Session() as s2:
+                row = (await s2.execute(
+                    text("SELECT project_id, duration_ms FROM agent_runs WHERE id = :id"),
+                    {"id": body["id"]},
+                )).first()
+                assert row is not None
+                assert str(row[0]) == str(seeded["project_a_id"])
+                assert row[1] is None  # duration_ms DB 계산(입력 불가·started/finished 없어 None)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_with_cross_project_id_returns_403_idor_block():
+    """비-동어반복 IDOR: project_a grant caller가 접근권 없는 project_b를 body로 넣어 run 생성
+    시도 → 403(resource-actual has_project_access 가드). run은 생성되지 않는다."""
+    from app.main import app
+    from sqlalchemy import text
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/agent-runs", json={
+                "agent_id": str(seeded["agent_a_id"]),
+                "project_id": str(seeded["project_b_id"]),
+                "status": "running",
+            })
+            assert resp.status_code == 403, resp.text
+            # run이 실제로 안 생겼는지 확認(가드가 write 앞에서 차단).
+            async with Session() as s2:
+                cnt = (await s2.execute(
+                    text("SELECT count(*) FROM agent_runs WHERE project_id = :p"),
+                    {"p": seeded["project_b_id"]},
+                )).scalar_one()
+                assert cnt == 0
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_with_nonexistent_project_id_returns_404():
+    """존재하지 않는 project_id(또는 타org)는 404 — 존재여부 비노출."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/agent-runs", json={
+                "agent_id": str(seeded["agent_a_id"]),
+                "project_id": str(uuid.uuid4()),
+                "status": "running",
+            })
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_missing_project_id_returns_422():
+    """project_id는 이제 필수 — 누락 시 422(계약 강제)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/agent-runs", json={
+                "agent_id": str(seeded["agent_a_id"]),
+                "status": "running",
+            })
+            assert resp.status_code == 422, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_s36.py
+++ b/backend/tests/test_s36.py
@@ -131,9 +131,15 @@ async def test_list_agent_runs_missing_project_id_422():
 async def test_create_agent_run_201():
     client, session, app = await _client()
     try:
-        mock_member = MagicMock()
-        mock_member.scalar_one_or_none.return_value = ORG_ID
-        session.execute = AsyncMock(return_value=mock_member)
+        # 2a5f21d3: create가 project_id 필수 + project 존재(404)/has_project_access(403) 가드 →
+        # execute 3회(project·access·agent). 순서대로 truthy로 목킹.
+        proj_mock = MagicMock()
+        proj_mock.scalar_one_or_none.return_value = PROJECT_ID
+        access_mock = MagicMock()
+        access_mock.scalar_one_or_none.return_value = 1
+        agent_mock = MagicMock()
+        agent_mock.scalar_one_or_none.return_value = AGENT_ID
+        session.execute = AsyncMock(side_effect=[proj_mock, access_mock, agent_mock])
 
         with patch("app.repositories.agent_run.AgentRunRepository.create", new_callable=AsyncMock) as mock_create:
             mock_create.return_value = _mock_run()
@@ -141,6 +147,7 @@ async def test_create_agent_run_201():
             async with client as c:
                 resp = await c.post("/api/v2/agent-runs", json={
                     "agent_id": str(AGENT_ID),
+                    "project_id": str(PROJECT_ID),
                     "trigger": "manual",
                 })
 
@@ -155,13 +162,19 @@ async def test_create_agent_run_201():
 async def test_create_agent_run_invalid_agent_400():
     client, session, app = await _client()
     try:
-        mock_member = MagicMock()
-        mock_member.scalar_one_or_none.return_value = None
-        session.execute = AsyncMock(return_value=mock_member)
+        # project·access는 통과(truthy), agent만 None → 400에 도달(2a5f21d3 가드 순서 반영).
+        proj_mock = MagicMock()
+        proj_mock.scalar_one_or_none.return_value = PROJECT_ID
+        access_mock = MagicMock()
+        access_mock.scalar_one_or_none.return_value = 1
+        agent_mock = MagicMock()
+        agent_mock.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(side_effect=[proj_mock, access_mock, agent_mock])
 
         async with client as c:
             resp = await c.post("/api/v2/agent-runs", json={
                 "agent_id": str(uuid.uuid4()),
+                "project_id": str(PROJECT_ID),
                 "trigger": "manual",
             })
 


### PR DESCRIPTION
## agent-runs 모델↔DB 드리프트 회수 + create project-scope 가드 (story `2a5f21d3`)

**조사 확定(dev 실측)**: agent_runs 생성 **유일 경로** `create_agent_run`이 두 모델↔DB 드리프트로 **전건 실패(500)** 였다:
- ① **duration_ms**: DB=`GENERATED ALWAYS STORED`(baseline schema.sql), 모델=plain writable `Integer` → SQLAlchemy가 INSERT에 항상 emit → `GeneratedAlwaysError`.
- ② **project_id**: DB=`NOT NULL`, 모델=`nullable=True`인데 라우터가 project_id 미공급 → `NotNullViolation`.

마이그 아님·모델 드리프트(기원=pre-0096 #1249 baseline 스냅샷). create 100% 실패 = Workcell "실 AgentRun 없음"(#2079 no-fiction) 근본 후보.

### fix (모델을 DB=원설계 SSOT에 정합 · **마이그 불요** = DB 이미 해당 상태)
- `models/agent_run.py`: `duration_ms=Computed(<started/finished_at 파생식>, persisted=True)`(DML 제외)·`project_id=nullable=False`. (죽은 ARRAY import 정리.)
- `schemas/agent_run.py`: `CreateAgentRun`에 `project_id` **필수** 추가 · `CreateAgentRun/UpdateAgentRun`서 `duration_ms` 입력 제거(생성컬럼 클라 세팅 불가). `AgentRunResponse.duration_ms`는 read-only 유지.
- `routers/agent_runs.py`: create가 project_id를 body로 받는 순간 **신규 mutation 인가 표면** → resource-actual `has_project_access` 가드(존재/타org=404·same-org 무접근권=403·body-claimed 금지·**round1~9 규율 내장**) 후 `repo.create`에 project_id 전달. update의 duration_ms 전달도 제거.

### 검증 (신규 realdb 4종·실 PG)
- (a) 정당 project_id → **201** (GeneratedAlways/NotNull 둘 다 해소·duration_ms는 DB 계산 None·DB 영속 확認)
- (b) ⭐**cross-project project_id → 403** (IDOR 차단·run 미생성 직조회·비-동어반복)
- (c) nonexistent project_id → 404
- (d) project_id 누락 → 422

**sabotage**(가드 제거 → cross-project 201 + run 생성 재현)로 IDOR 비-공허 실증. pre-fix probe로 create 500(GeneratedAlways/NotNull) 직접 재현 → fix로 201 전환. 기존 `test_s36` create 2종을 project_id+가드 목킹 보정. agent-runs 계열·SEC-S8 Y·ratchet·MCP toolset **40+ green**. **ruff clean**. **FE 무영향**(create UI 호출자 0·실경로=MCP/agent-runtime).

### 승격 전 게이트 (머지 게이트 아님)
prod 스키마 + create 실파손 여부는 **오르테가 gcloud 병행 실측**. create 100% 실패 정황이 맞으면 이 PR은 latent 버그 회수(순수 개선).

QA: 까심(#2081→#2083→2a5f21d3 순차).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
