### PR TITLE
fix(security): participation add/list story-project scope 가드 — write-path IDOR + read exposure 봉인 (_KNOWN_DEBT 2건)

### DIFF
--- a/backend/app/routers/participation.py
+++ b/backend/app/routers/participation.py
@@ -1,14 +1,32 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import get_current_user, get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.models.pm import Story
 from app.repositories.participation import ParticipationRepository, ParticipationRoleRepository
 from app.schemas.participation import ParticipationCreate, ParticipationResponse, ParticipationRoleResponse
+from app.services.project_auth import has_project_access
 
 router = APIRouter(prefix="/api/v2/participation", tags=["participation"])
+
+
+async def _assert_story_project_access(
+    session: AsyncSession, user_id: uuid.UUID, org_id: uuid.UUID, story_id: uuid.UUID
+) -> None:
+    """participation은 story-bound다. story_id의 실 project 접근권을 resource-actual로 검증한다
+    (body/query-claimed story_id를 믿지 않음). story가 caller org에 없거나 그 project 접근권이
+    없으면 404(존재 비노출). round1~9/add_feedback와 동형 규율 — has_project_access 직접호출."""
+    project_id = (
+        await session.execute(
+            select(Story.project_id).where(Story.id == story_id, Story.org_id == org_id)
+        )
+    ).scalar_one_or_none()
+    if project_id is None or not await has_project_access(session, user_id, project_id, org_id):
+        raise HTTPException(status_code=404, detail="Story not found")
 
 
 def _get_role_repo(
@@ -38,8 +56,11 @@ async def list_roles(
 async def add_participation(
     body: ParticipationCreate,
     repo: ParticipationRepository = Depends(_get_repo),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> ParticipationResponse:
+    # write-path IDOR 봉인: body.story_id에 caller 접근권 검증 없이 임의 story에 participation을
+    # 주입할 수 있었다(cross-project/org). resource-actual project-scope 가드.
+    await _assert_story_project_access(repo.session, uuid.UUID(auth.user_id), repo.org_id, body.story_id)
     if await repo.exists(body.story_id, body.member_id, body.role_id):
         raise HTTPException(status_code=409, detail="이미 존재하는 참여 기록")
     p = await repo.create(
@@ -54,8 +75,10 @@ async def add_participation(
 async def list_participation(
     story_id: uuid.UUID = Query(...),
     repo: ParticipationRepository = Depends(_get_repo),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[ParticipationResponse]:
+    # read exposure 봉인: 접근권 없는 story의 participation 로스터 열람 차단.
+    await _assert_story_project_access(repo.session, uuid.UUID(auth.user_id), repo.org_id, story_id)
     items = await repo.list_by_story(story_id)
     return [ParticipationResponse.model_validate(i) for i in items]
 

--- a/backend/tests/authz_coverage_lib.py
+++ b/backend/tests/authz_coverage_lib.py
@@ -59,6 +59,7 @@ PROJECT_GUARD_FUNCTIONS: frozenset[str] = frozenset({
     "_assert_doc_parent_in_project",
     "_assert_link_target_in_scope",
     "_assert_task_project_access",
+    "_assert_story_project_access",
 })
 
 # Depends(...) 콜러블 — 결과 id가 caller auth에서 서버-파생돼 클라이언트가 스푸핑할 여지가

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -130,10 +130,7 @@ _KNOWN_DEBT_ALLOWLIST: dict[str, str] = {
     # (test_e_security_sec_s8_ratchet_round9_members_realdb.py). 잔여는 MEDIUM/LOW.
     "app.routers.hypotheses:link_hypothesis":
         "MEDIUM — service._assert_targets_same_project가 sprint/epic/story 주입은 막지만 caller의 hyp.project_id 접근권 자체는 미검증",
-    "app.routers.participation:add_participation":
-        "MEDIUM — org-scope만·body.story_id에 caller의 project 접근권 검증 없음",
-    "app.routers.participation:list_participation":
-        "MEDIUM — org-scope만·story_id 쿼리에 접근권 검증 없음",
+    # participation add/list 2건 상환(story-bound·_assert_story_project_access resource-actual 가드).
     "app.routers.exclusion:exclusion_dry_run":
         "MEDIUM — org-scope만·optional project_id에 접근권 검증 없음",
     "app.routers.standups:get_missing_standups":

--- a/backend/tests/test_e_cage_referee_p1_participation.py
+++ b/backend/tests/test_e_cage_referee_p1_participation.py
@@ -17,6 +17,16 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+def _bypass_story_project_guard():
+    """이 파일은 participation CRUD 메커닉을 mock 세션으로 검증한다. add/list의 story-project
+    인가 가드(_assert_story_project_access·resource-actual has_project_access)는 별도 realdb
+    스위트(test_e_sec_participation_story_project_scope_realdb)가 실 PG로 커버하므로, 여기선
+    no-op 패치해 mock 세션(모든 execute가 None 반환)과의 충돌(가드 404)을 피한다."""
+    with patch("app.routers.participation._assert_story_project_access", new_callable=AsyncMock):
+        yield
+
+
 def _mock_role(role_id=None, key="implementation", label="구현", is_default=True):
     r = MagicMock()
     r.id = role_id or ROLE_ID

--- a/backend/tests/test_e_sec_participation_story_project_scope_realdb.py
+++ b/backend/tests/test_e_sec_participation_story_project_scope_realdb.py
@@ -1,0 +1,231 @@
+"""E-SECURITY (유휴방지 MEDIUM 상환) — participation add/list story-project scope IDOR, 실 PG.
+
+갭: add_participation(write)·list_participation(read) 둘 다 story_id를 접근권 검증 0으로 받아
+(1) 임의 story에 participation(멤버-역할 배정) 주입(cross-project/org write-path IDOR·body-claimed)
+(2) 임의 story의 participation 로스터 열람(read exposure)이 가능했다. _KNOWN_DEBT baseline MEDIUM
+2건(add/list). fix: story_id→story.project_id(Story.org_id 스코프) 해소 후 resource-actual
+has_project_access(404·존재 비노출). add/list 동일 가드.
+
+참고(add_feedback org-level 교훈): Story.project_id는 NOT NULL(모든 story는 project 소속·org-level
+story 없음)이라 가드가 항상 project를 해소한다 — None/org-level 분기 없음.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+_SECRET_MEMBER_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a·project_b) + story_a(project_a)·story_b(project_b) + ParticipationRole +
+    story_b에 시크릿 participation(로스터 노출 감시) + caller(project_a에만 grant)."""
+    from app.models.organization import Organization
+    from app.models.participation import Participation, ParticipationRole
+    from app.models.pm import Story
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+    story_a = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Story A")
+    story_b = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Story B")
+    session.add_all([story_a, story_b])
+    await session.commit()
+    role = ParticipationRole(id=uuid.uuid4(), org_id=org.id, key="reviewer", label="Reviewer")
+    session.add(role)
+    await session.commit()
+    # story_b(무접근)에 시크릿 participation — list 노출 감시.
+    session.add(Participation(
+        id=uuid.uuid4(), org_id=org.id, story_id=story_b.id, member_id=_SECRET_MEMBER_ID, role_id=role.id,
+    ))
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=caller_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "story_a_id": story_a.id, "story_b_id": story_b.id,
+        "role_id": role.id, "caller_id": caller_id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _partic_count(Session, org_id, story_id):
+    from sqlalchemy import text
+    async with Session() as s:
+        return (await s.execute(
+            text("SELECT count(*) FROM participation WHERE org_id=:o AND story_id=:s"),
+            {"o": org_id, "s": story_id},
+        )).scalar_one()
+
+
+@pytest.mark.anyio
+async def test_add_participation_own_story_201():
+    """회귀0: project_a grant caller가 project_a story에 participation 추가 → 201."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/participation", json={
+                "story_id": str(seeded["story_a_id"]),
+                "member_id": str(uuid.uuid4()),
+                "role_id": str(seeded["role_id"]),
+            })
+            assert resp.status_code == 201, resp.text
+            assert await _partic_count(Session, seeded["org_id"], seeded["story_a_id"]) == 1
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_add_participation_cross_project_blocked_404():
+    """봉인(write-path IDOR·비-동어반복): 접근권 없는 project_b story에 participation 주입 시도 →
+    404 + 미생성(직조회로 project_b participation 개수 불변 확認)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        before = await _partic_count(Session, seeded["org_id"], seeded["story_b_id"])
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/participation", json={
+                "story_id": str(seeded["story_b_id"]),
+                "member_id": str(uuid.uuid4()),
+                "role_id": str(seeded["role_id"]),
+            })
+            assert resp.status_code == 404, resp.text
+            assert await _partic_count(Session, seeded["org_id"], seeded["story_b_id"]) == before
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_participation_own_story_200():
+    """회귀0: 접근권 있는 story_a participation 조회 → 200."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/participation?story_id={seeded['story_a_id']}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_participation_cross_project_blocked_404_no_roster_leak():
+    """봉인(read exposure·비-동어반복): 접근권 없는 project_b story의 participation 로스터 조회
+    시도 → 404 + 시크릿 participant member_id가 응답 바디에 verbatim 미노출."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/participation?story_id={seeded['story_b_id']}")
+            assert resp.status_code == 404, resp.text
+            assert str(_SECRET_MEMBER_ID) not in resp.text, "cross-project participation 로스터 유출"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## participation add/list story-project scope 가드 — write-path IDOR + read exposure 봉인 (유휴방지 MEDIUM · _KNOWN_DEBT 2건 회수)

`add_participation`(POST·write)과 `list_participation`(GET·read) 둘 다 `story_id`를 **접근권 검증 0**으로 받아(`_auth` 미사용):
- ① 임의 story에 participation(멤버-역할 배정) **주입**(cross-project/org write-path IDOR·body-claimed)
- ② 임의 story의 participation 로스터 **열람**(read exposure)

이 가능했다. **`_KNOWN_DEBT` baseline MEDIUM 2건**(라인 133/135).

### fix
공통 헬퍼 `_assert_story_project_access` — `story_id`→`story.project_id`(`Story.org_id` 스코프) 해소 후 resource-actual `has_project_access` 사전검증(**404**·존재 비노출·body-claimed 금지). add(write)·list(read) **동일 가드**. `Story.project_id`는 **NOT NULL**(모든 story는 project 소속·org-level story 없음)이라 가드가 항상 project를 해소 — None/org-level 분기 없음(add_feedback org-level 교훈 반영해 명시 확認). **마이그 0**.

- `routers/participation.py`: `_assert_story_project_access` 헬퍼 + add/list 사전검증·`_auth`→`auth`.
- `authz_coverage_lib.py`: `PROJECT_GUARD_FUNCTIONS`에 `_assert_story_project_access` 등재(ratchet 인식).
- `test_authz_project_scope_coverage.py`: `_KNOWN_DEBT_ALLOWLIST`서 participation 2건 제거.
- `test_e_sec_participation_story_project_scope_realdb.py`: 신규 realdb 4종.
- `test_e_cage_referee_p1_participation.py`: mock CRUD 파일에 가드 no-op autouse fixture(인가는 realdb가 커버·mock 세션 충돌 회피).

### 검증 (실 PG)
- 신규 realdb **4/4**: valid add 201·**cross-project add→404+미생성 직조회**·valid list 200·**cross-project list→404+시크릿 participant member_id verbatim 미노출**(비-동어반복).
- **ratchet 3/3**(2건 제거 후 green·rot 0·`_assert_story_project_access` 등재로 인식).
- **sabotage**(가드 무력화→cross-project add/list 2종 즉시 RED).
- cage-referee 10·claim_participation(create_all 모드) green. **ruff clean·마이그 0**.

QA: 까심(write-path add·read list·sabotage·baseline 2건 회수).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
