### PR TITLE
[E-GLANCE][STEER v2][FE] 조타 커밋 액션 + 수신자 선택 UI — 드래그=조용한 초안·"보내기"만 발화 (story 2628a53b)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2715,7 +2715,16 @@
     "steerHandoffOrchestrating": "Orchestrating",
     "steerHandoffAgent": "Ortega",
     "steerError": "Couldn't save the new order. Please try again.",
-    "steerCappedNote": "Showing the top {count}. Steering (curation) floats items to the front."
+    "steerCappedNote": "Showing the top {count}. Steering (curation) floats items to the front.",
+    "steerCommit": "Send steering",
+    "steerCommitHint": "Dragging saves a draft",
+    "steerCommitTitle": "Send steering",
+    "steerCommitDesc": "Choose which agents receive this order.",
+    "steerRecipientRequired": "Select at least one agent.",
+    "steerNoAgents": "No agents are assigned to this project.",
+    "steerDispatchSend": "Send",
+    "steerDispatchConflict": "The order wasn't saved. Refresh the list and try again.",
+    "steerDispatchError": "Couldn't send the steering. Please try again."
   },
   "glance": {
     "pageTitle": "Project Glance",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2715,7 +2715,16 @@
     "steerHandoffOrchestrating": "오케스트레이션 중",
     "steerHandoffAgent": "오르테가군",
     "steerError": "재정렬을 저장하지 못했습니다. 다시 시도해 주세요.",
-    "steerCappedNote": "상위 {count}개만 표시됩니다. 조타(큐레이션)는 상위 항목을 앞으로 올립니다."
+    "steerCappedNote": "상위 {count}개만 표시됩니다. 조타(큐레이션)는 상위 항목을 앞으로 올립니다.",
+    "steerCommit": "조타 보내기",
+    "steerCommitHint": "드래그는 초안으로 저장됩니다",
+    "steerCommitTitle": "조타 보내기",
+    "steerCommitDesc": "이 순서를 받을 에이전트를 지정하세요.",
+    "steerRecipientRequired": "받을 에이전트를 1명 이상 선택하세요.",
+    "steerNoAgents": "이 프로젝트에 배정된 에이전트가 없습니다.",
+    "steerDispatchSend": "보내기",
+    "steerDispatchConflict": "순서가 저장되지 않았습니다. 목록을 새로고침하고 다시 시도하세요.",
+    "steerDispatchError": "조타 전송에 실패했습니다. 다시 시도해 주세요."
   },
   "glance": {
     "pageTitle": "프로젝트 현황판",

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { ChevronLeft, GripVertical, Plus, Trash2, X } from 'lucide-react';
+import { ChevronLeft, GripVertical, Plus, Send, Trash2, X } from 'lucide-react';
 import { DndContext, type DragEndEvent, PointerSensor, useSensor, useSensors, closestCenter } from '@dnd-kit/core';
 import { SortableContext, useSortable, verticalListSortingStrategy, arrayMove } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -19,6 +19,7 @@ import {
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { OutcomeStatusBadge } from '@/components/outcome/outcome-status-badge';
 import { HypothesesSummary } from '@/components/hypotheses/hypotheses-summary';
+import { SteerDispatchModal } from './steer-dispatch-modal';
 
 // ─── Drag sensor ──────────────────────────────────────────────────────────────
 
@@ -790,8 +791,11 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
   const [deleting, setDeleting] = useState(false);
   // wedge #2 로드맵 조타
   const [capped, setCapped] = useState(false);          // 상위 STEER_LIMIT 초과(honest 표시·silent-truncation 금지)
-  const [justSteered, setJustSteered] = useState(false); // 조타 후 핸드오프 compact("받았고 움직인다")
-  const [reordering, setReordering] = useState(false);   // bulk PATCH in-flight
+  const [reordering, setReordering] = useState(false);   // bulk PATCH(초안 저장) in-flight
+  // STEER v2: 드래그=조용한 초안(핸드오프 없음). 핸드오프는 명시적 커밋("조타 보내기") 성공 後에만.
+  const [showDispatch, setShowDispatch] = useState(false);
+  const [justDispatched, setJustDispatched] = useState(false);
+  const [dispatchedTo, setDispatchedTo] = useState<string[]>([]); // 지정 수신자 이름(핸드오프 표시용)
   const sensors = useSensors(useSensor(MousePointerSensor, { activationConstraint: { distance: 8 } }));
 
   // wedge #2: order_by=position 옵트인 — 큐레이션 prefix + 자동(NULL) tail. position 모드는 BE가
@@ -842,7 +846,8 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
       // 응답=갱신본만 → 서버 position으로 정합(실 persist 확인·끝단 반영).
       const updById = new Map((data ?? []).map((e) => [e.id, e.position]));
       setEpics((cur) => cur.map((e) => (updById.has(e.id) ? { ...e, position: updById.get(e.id) ?? e.position } : e)));
-      setJustSteered(true); // 핸드오프 compact 노출("조타 접수·오케스트레이션 중")
+      // STEER v2: 드래그는 조용한 초안 저장 — 핸드오프/이벤트 없음(#2078 배선 제거). 신뢰 발화는
+      // 명시적 커밋(POST /epics/steer-dispatch)에서만. 인간이 A→B→A로 번복하는 초안은 새지 않는다.
     } catch (err) {
       console.error('[epics] 재정렬 저장 실패', err);
       setEpics(prev); // 롤백(낙관 UI ≠ 저장)
@@ -909,6 +914,8 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
   const filteredEpics = statusFilter === 'all' ? epics : epics.filter((e) => e.status === statusFilter);
   // 조타(드래그 재정렬)는 전체 뷰에서만 — 필터 서브셋은 전역 position을 오염시킨다.
   const sortable = statusFilter === 'all';
+  // 커밋("조타 보내기")은 큐레이션(position≠null)이 하나라도 있을 때만 의미 있다.
+  const hasCurated = epics.some((e) => typeof e.position === 'number');
 
   const listPanel = (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-muted/35">
@@ -931,13 +938,28 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
         ))}
       </div>
 
-      {/* wedge #2 조타→핸드오프 confirm — "감시 아니라 신뢰": 현재 신뢰단계 1개만("받았고 움직인다").
-          활동량/타임스탬프/이벤트 나열 0. Proof Blue·부드러운 호흡·reduced-motion 대응. */}
-      {justSteered ? (
+      {/* STEER v2 조타 보내기(커밋) — 드래그(조용한 초안)와 분리된 명시적 발화. 큐레이션이 있고
+          전체 뷰일 때만. 누르면 수신자 선택 모달 → POST /epics/steer-dispatch. */}
+      {sortable && hasCurated ? (
+        <div className="flex shrink-0 items-center justify-between gap-2 border-b border-proof-line-soft px-4 py-2">
+          <span className="min-w-0 truncate text-[11px] text-muted-foreground">{t('steerCommitHint')}</span>
+          <Button size="sm" variant="outline" className="shrink-0" onClick={() => setShowDispatch(true)}>
+            <Send className="mr-1.5 h-3.5 w-3.5" />
+            {t('steerCommit')}
+          </Button>
+        </div>
+      ) : null}
+
+      {/* 조타→핸드오프 confirm — "감시 아니라 신뢰": 신뢰단계 1개만("받았고 움직인다"). STEER v2에선
+          **커밋 성공 後에만** 표시(드래그 아님·no-fiction). 지정 수신자만 표기·활동량/타임스탬프 0.
+          Proof Blue·부드러운 호흡·reduced-motion 대응. */}
+      {justDispatched ? (
         <div className="flex shrink-0 items-center gap-2 border-y border-proof-line-soft bg-proof-blue-soft px-4 py-2 text-[11.5px] font-semibold text-proof-blue">
           <span className="size-1.5 shrink-0 rounded-full bg-proof-blue motion-safe:animate-pulse" aria-hidden="true" />
           <span>{t('steerHandoffReceived')} · <b className="font-bold">{t('steerHandoffOrchestrating')}</b></span>
-          <span className="ml-auto text-[9.5px] font-bold text-proof-blue/80">{t('steerHandoffAgent')}</span>
+          {dispatchedTo.length > 0 ? (
+            <span className="ml-auto max-w-[45%] truncate text-[9.5px] font-bold text-proof-blue/80">{dispatchedTo.join(', ')}</span>
+          ) : null}
         </div>
       ) : null}
 
@@ -1034,6 +1056,18 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
           orgId={orgId}
           onCreated={handleCreated}
           onClose={() => setShowCreate(false)}
+        />
+      ) : null}
+
+      {/* STEER v2 조타 보내기(커밋) 모달 — 지정 수신자 선택 → POST /epics/steer-dispatch */}
+      {showDispatch ? (
+        <SteerDispatchModal
+          projectId={projectId}
+          items={epics
+            .filter((e) => typeof e.position === 'number')
+            .map((e) => ({ id: e.id, position: e.position as number }))}
+          onClose={() => setShowDispatch(false)}
+          onDispatched={(names) => { setDispatchedTo(names); setJustDispatched(true); setShowDispatch(false); }}
         />
       ) : null}
 

--- a/apps/web/src/app/(authenticated)/epics/steer-dispatch-modal.tsx
+++ b/apps/web/src/app/(authenticated)/epics/steer-dispatch-modal.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Check } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog, DialogContent, DialogDescription,
+  DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
+import { resolveRecipientPrefill } from '@/lib/epic-steer';
+
+interface AgentMember {
+  id: string;
+  name: string;
+}
+
+interface CuratedItem {
+  id: string;
+  position: number;
+}
+
+interface SteerDispatchModalProps {
+  projectId: string;
+  /** 커밋할 순서 스냅샷 = 큐레이션된 에픽(position≠null)의 {id, position}. */
+  items: CuratedItem[];
+  onClose: () => void;
+  /** 커밋 성공 시 지정 수신자 이름 목록을 상위로(핸드오프 compact 표시용). */
+  onDispatched: (recipientNames: string[]) => void;
+}
+
+/** 프리필 = 프로젝트별 마지막 선택 기억(일반적·org-agnostic·하드코딩/오르테가 고정 금지). */
+function lastRecipientsKey(projectId: string): string {
+  return `steer-recipients:${projectId}`;
+}
+
+function readRemembered(projectId: string): string[] {
+  try {
+    const raw = JSON.parse(localStorage.getItem(lastRecipientsKey(projectId)) ?? '[]') as unknown;
+    return Array.isArray(raw) ? (raw as string[]).filter((x) => typeof x === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * STEER v2 조타 커밋 모달(story 2628a53b). 드래그는 조용한 초안, 이 "보내기"에서만 지정 수신자에게
+ * 커밋을 전달한다(POST /api/epics/steer-dispatch → epic.reordered 1회). 수신자는 프로젝트 에이전트
+ * 중 인간이 명시(필수). BE엔 기본 수신자가 없으므로(보편 orchestrator 가정 금지) 프리필은 순전히
+ * FE 편의 = 마지막 선택 기억. 409(스냅샷 conflict)는 재확認 안내로 구분 처리.
+ */
+export function SteerDispatchModal({ projectId, items, onClose, onDispatched }: SteerDispatchModalProps) {
+  const t = useTranslations('epics');
+  const [agents, setAgents] = useState<AgentMember[] | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    void (async () => {
+      try {
+        const res = await fetch('/api/team-members');
+        if (!res.ok) throw new Error(`team-members ${res.status}`);
+        const { data } = await res.json() as {
+          data: Array<{ id: string; name: string; type: string; is_active: boolean }>;
+        };
+        const list = (data ?? [])
+          .filter((m) => m.type === 'agent' && m.is_active)
+          .map((m) => ({ id: m.id, name: m.name }));
+        if (!alive) return;
+        setAgents(list);
+        // 프리필 = 마지막 선택 ∩ 현재 가용(사라진 멤버는 자동 탈락·하드코딩 없음).
+        setSelected(new Set(resolveRecipientPrefill(readRemembered(projectId), list.map((a) => a.id))));
+      } catch (err) {
+        console.error('[steer] 프로젝트 멤버 로드 실패', err);
+        if (alive) setAgents([]);
+      }
+    })();
+    return () => { alive = false; };
+  }, [projectId]);
+
+  const toggle = useCallback((id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+    setError(null);
+  }, []);
+
+  const handleSend = useCallback(async () => {
+    if (selected.size === 0) { setError(t('steerRecipientRequired')); return; } // 클라 사전검증(BE 400 前)
+    setSending(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/epics/steer-dispatch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ items, recipient_member_ids: [...selected] }),
+      });
+      if (res.status === 409) { setError(t('steerDispatchConflict')); setSending(false); return; }
+      if (!res.ok) { setError(t('steerDispatchError')); setSending(false); return; }
+      try { localStorage.setItem(lastRecipientsKey(projectId), JSON.stringify([...selected])); } catch { /* localStorage 불가 무시 */ }
+      const names = (agents ?? []).filter((a) => selected.has(a.id)).map((a) => a.name);
+      onDispatched(names);
+    } catch (err) {
+      console.error('[steer] 조타 디스패치 실패', err);
+      setError(t('steerDispatchError'));
+      setSending(false);
+    }
+  }, [selected, items, projectId, agents, onDispatched, t]);
+
+  const noAgents = (agents?.length ?? 0) === 0;
+
+  return (
+    <Dialog open onOpenChange={(o) => { if (!o) onClose(); }}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('steerCommitTitle')}</DialogTitle>
+          <DialogDescription>{t('steerCommitDesc')}</DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-64 overflow-y-auto py-1">
+          {agents === null ? (
+            <p className="py-4 text-center text-sm text-muted-foreground">{t('loading')}</p>
+          ) : agents.length === 0 ? (
+            <p className="py-4 text-center text-sm text-muted-foreground">{t('steerNoAgents')}</p>
+          ) : (
+            <ul className="space-y-1">
+              {agents.map((a) => {
+                const on = selected.has(a.id);
+                return (
+                  <li key={a.id}>
+                    <button
+                      type="button"
+                      onClick={() => toggle(a.id)}
+                      aria-pressed={on}
+                      className={`flex w-full items-center gap-2.5 rounded-lg border px-3 py-2 text-left text-sm transition-colors ${
+                        on ? 'border-proof-blue/40 bg-proof-blue-soft text-foreground' : 'border-border hover:bg-muted/50'
+                      }`}
+                    >
+                      <span className={`flex size-4 shrink-0 items-center justify-center rounded border ${
+                        on ? 'border-proof-blue bg-proof-blue text-white' : 'border-border'
+                      }`}>
+                        {on ? <Check className="size-3" strokeWidth={3} aria-hidden="true" /> : null}
+                      </span>
+                      <span className="truncate">{a.name}</span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        {error ? <p className="text-xs text-destructive">{error}</p> : null}
+
+        <DialogFooter>
+          <Button variant="ghost" size="sm" onClick={onClose} disabled={sending}>{t('cancel')}</Button>
+          <Button size="sm" onClick={() => void handleSend()} disabled={sending || selected.size === 0 || noAgents}>
+            {sending ? '…' : t('steerDispatchSend')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/app/api/epics/steer-dispatch/route.ts
+++ b/apps/web/src/app/api/epics/steer-dispatch/route.ts
@@ -1,0 +1,14 @@
+import { proxyToFastapiWrapped } from '@/lib/fastapi-proxy';
+
+/**
+ * POST /api/epics/steer-dispatch — STEER v2 조타 커밋(story 2628a53b·BE #2086).
+ * 드래그(/epics/bulk)는 무이벤트 초안 저장이고, 이 명시적 커밋에서만 epic.reordered 1회 발화한다.
+ * payload={items:[{id,position}](커밋 스냅샷), recipient_member_ids:[uuid](필수)}.
+ *
+ * proxyToFastapiWrapped 사용 이유: BE 상태코드를 그대로 forward해야 한다 — 특히 **409**(스냅샷
+ * position≠저장·"save draft before dispatch")를 클라가 구분해 재확認 UX를 띄운다. 리포지토리
+ * (fastapiCall) 경로는 mapApiError가 409를 일반 Error로 뭉개 handleApiError서 400으로 붕괴시킨다.
+ */
+export async function POST(request: Request): Promise<Response> {
+  return proxyToFastapiWrapped(request, '/api/v2/epics/steer-dispatch');
+}

--- a/apps/web/src/lib/epic-steer.test.ts
+++ b/apps/web/src/lib/epic-steer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { computeReorderPatch, type SteerEpic } from './epic-steer';
+import { computeReorderPatch, resolveRecipientPrefill, type SteerEpic } from './epic-steer';
 
 const e = (id: string, position?: number | null): SteerEpic => ({ id, position });
 
@@ -54,5 +54,23 @@ describe('computeReorderPatch (로드맵 조타 재정렬 → bulk PATCH diff·w
     // A·B 둘 다 pos1(이상). cutoff=1까지 renumber → B가 2로 밀려 중복 제거·A는 그대로.
     const patch = computeReorderPatch([e('A', 1), e('B', 1), e('C')], 1);
     expect(patch).toEqual([{ id: 'B', position: 2 }]);
+  });
+});
+
+describe('resolveRecipientPrefill (STEER v2 커밋 수신자 프리필·마지막 선택 ∩ 가용·하드코딩 없음)', () => {
+  it('기억된 선택을 현재 가용 멤버와 교집합(순서 보존)', () => {
+    expect(resolveRecipientPrefill(['m2', 'm1'], ['m1', 'm2', 'm3'])).toEqual(['m2', 'm1']);
+  });
+
+  it('떠난/사라진 멤버는 자동 탈락', () => {
+    expect(resolveRecipientPrefill(['gone', 'm1'], ['m1', 'm2'])).toEqual(['m1']);
+  });
+
+  it('기억 없음 → 빈 배열(인간이 새로 선택·필수)', () => {
+    expect(resolveRecipientPrefill([], ['m1', 'm2'])).toEqual([]);
+  });
+
+  it('전부 무효 → 빈 배열(하드코딩 폴백 없음·org-agnostic)', () => {
+    expect(resolveRecipientPrefill(['x', 'y'], ['m1'])).toEqual([]);
   });
 });

--- a/apps/web/src/lib/epic-steer.ts
+++ b/apps/web/src/lib/epic-steer.ts
@@ -36,3 +36,14 @@ export function computeReorderPatch(reordered: SteerEpic[], movedNewIndex: numbe
   }
   return patch;
 }
+
+/**
+ * STEER v2 조타 커밋 수신자 프리필(story 2628a53b). 기억된 마지막 선택(`remembered`)을 현재
+ * 가용 멤버(`availableIds`)와 교집합해 돌려준다 — 사라진/떠난 멤버는 자동 탈락하고, 순서는
+ * remembered를 보존한다. **하드코딩/오르테가 고정 없음**(org-agnostic·순전히 인간의 이전 선택).
+ * 기억이 없거나 전부 무효면 빈 배열 → 인간이 새로 선택(필수).
+ */
+export function resolveRecipientPrefill(remembered: string[], availableIds: string[]): string[] {
+  const available = new Set(availableIds);
+  return remembered.filter((id) => available.has(id));
+}


### PR DESCRIPTION
## 무엇 (STEER v2 FE · story 2628a53b)
BE #2086(merged `19662eba`·doc `design-roadmap-steer-draft-commit-dispatch`) FE 소비. 선생님 재정의: 인간의 고민(드래그 번복)은 사적 초안, **확定된 조타만 지정 수신자에게** 전달. 보편 orchestrator 가정 없음(org-agnostic).

## 변경
| # | 표면 | 내용 |
|---|---|---|
| ① | `epics-client` | 드래그(PATCH /epics/bulk)=**조용한 초안** — #2078의 드래그→핸드오프(justSteered) 배선 **제거**·순수 position 저장 |
| ② | `epics-client` | **"조타 보내기"(커밋)** 버튼 — 큐레이션(position≠null) + 전체 뷰일 때 노출 |
| ③ | `steer-dispatch-modal`(신규) | 수신자 선택 모달 — `/api/team-members` 프로젝트 에이전트 멀티셀렉트·필수(클라 사전검증)·프리필=마지막 선택 기억 |
| ④ | `epics-client` | 핸드오프 compact("조타 접수·오케스트레이션 중·{지정 수신자}") = **커밋 성공 後에만** |
| ⑤ | `api/epics/steer-dispatch`(신규) | proxyToFastapiWrapped — BE 상태코드 forward(**409** 구분 위해) |
| — | `lib/epic-steer` | `resolveRecipientPrefill`(마지막선택 ∩ 가용·하드코딩 없음) 추출+테스트 |

## AC 대응
1. ✅ 드래그=조용한 초안(핸드오프/이벤트 배선 제거·순수 큐레이션 저장·#2078 회귀0)
2. ✅ "조타 보내기" → POST /epics/steer-dispatch `{items, recipient_member_ids}`·**409 스냅샷 conflict 구분 처리**(재확認 안내)
3. ✅ 수신자 선택 UI(프로젝트 에이전트·필수·클라 사전검증)·⚠️프리필=**마지막 선택 기억**(localStorage·`resolveRecipientPrefill`·**하드코딩/오르테가 고정 없음**·org마다 다름)
4. ✅ 핸드오프 compact=**커밋 성공 後에만**(no-fiction)·지정 수신자 표기·활동량/타임스탬프 0·Proof Blue·motion-safe(reduced-motion)
5. ✅ 양테마(proof 토큰)·#2056/#2078 회귀0·vitest **1232 green**·type-check clean·eslint 0·build ✓

## ⚠️ 계약 drift(확認 요청)
story AC2/doc는 `note?` 언급하나 **머지된 BE `SteerDispatchRequest` 스키마엔 note 필드 없음**(items+recipient_member_ids만). → v1 FE는 **note 미포함**(no-fiction). BE가 note 추가하면 후속.

## UX 결정(유나 UX 가디언 확認)
- 프리필=프로젝트별 마지막 선택(최초엔 빈 상태·인간 필수 선택)·relay-owner 폴백 없음(BE 제거 정합)
- 커밋 버튼=리스트 헤더·큐레이션 존재 시·수신자 피커=커밋 모달 안 멀티셀렉트·409="순서 미저장·새로고침 후 재시도"

## 검증
- `type-check` clean · `eslint` 0 · `vitest run` **1232 passed / 0 failed**(신규 resolveRecipientPrefill 4케이스) · `next build` ✓
- ⏳ dev 라이브픽셀(드래그=조용·커밋→지정 수신자만 🔔) done-gate는 배포 後

🤖 Generated with [Claude Code](https://claude.com/claude-code)