### PR TITLE
fix(security): remove_participation project-scope 가드 — same-org cross-project delete IDOR 봉인 (story 5a19b637)

### DIFF
--- a/backend/app/routers/participation.py
+++ b/backend/app/routers/participation.py
@@ -87,8 +87,16 @@ async def list_participation(
 async def remove_participation(
     id: uuid.UUID,
     repo: ParticipationRepository = Depends(_get_repo),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    # 5a19b637(까심 fast-follow): repo.delete는 org_id 스코프만이라 접근권 없는 same-org
+    # 다른 project의 participation을 id만으로 삭제할 수 있었다(mutation 대상 project-scope IDOR).
+    # 대상 participation을 선조회해 그 story의 project 접근권을 resource-actual로 검증(404·존재
+    # 비노출·add/list와 동일 가드 재사용). 통과해야 delete.
+    p = await repo.get(id)
+    if p is None:
+        raise HTTPException(status_code=404, detail="참여 기록을 찾을 수 없음")
+    await _assert_story_project_access(repo.session, uuid.UUID(auth.user_id), repo.org_id, p.story_id)
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="참여 기록을 찾을 수 없음")

--- a/backend/tests/test_e_sec_participation_story_project_scope_realdb.py
+++ b/backend/tests/test_e_sec_participation_story_project_scope_realdb.py
@@ -75,9 +75,10 @@ async def _seed(session):
     role = ParticipationRole(id=uuid.uuid4(), org_id=org.id, key="reviewer", label="Reviewer")
     session.add(role)
     await session.commit()
-    # story_b(무접근)에 시크릿 participation — list 노출 감시.
+    # story_b(무접근)에 시크릿 participation — list 노출 감시 + cross-project delete 대상.
+    partic_b_id = uuid.uuid4()
     session.add(Participation(
-        id=uuid.uuid4(), org_id=org.id, story_id=story_b.id, member_id=_SECRET_MEMBER_ID, role_id=role.id,
+        id=partic_b_id, org_id=org.id, story_id=story_b.id, member_id=_SECRET_MEMBER_ID, role_id=role.id,
     ))
     await session.commit()
 
@@ -95,7 +96,7 @@ async def _seed(session):
 
     return {
         "org_id": org.id, "story_a_id": story_a.id, "story_b_id": story_b.id,
-        "role_id": role.id, "caller_id": caller_id,
+        "role_id": role.id, "caller_id": caller_id, "partic_b_id": partic_b_id,
     }
 
 
@@ -224,6 +225,70 @@ async def test_list_participation_cross_project_blocked_404_no_roster_leak():
             resp = await client.get(f"/api/v2/participation?story_id={seeded['story_b_id']}")
             assert resp.status_code == 404, resp.text
             assert str(_SECRET_MEMBER_ID) not in resp.text, "cross-project participation 로스터 유출"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_remove_participation_cross_project_blocked_404_not_deleted():
+    """봉인(mutation 대상 project-scope IDOR·5a19b637): project_a grant caller가 접근권 없는
+    project_b story의 participation을 id만으로 삭제 시도 → 404 + **미삭제 직조회**(seed된 시크릿
+    participation이 그대로 남아있음)."""
+    from sqlalchemy import text
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/participation/{seeded['partic_b_id']}")
+            assert resp.status_code == 404, resp.text
+            # 실제로 삭제 안 됐는지 직조회.
+            async with Session() as s2:
+                cnt = (await s2.execute(
+                    text("SELECT count(*) FROM participation WHERE id = :i"),
+                    {"i": seeded["partic_b_id"]},
+                )).scalar_one()
+                assert cnt == 1, "cross-project participation이 삭제됨(IDOR)"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_remove_participation_own_story_200():
+    """회귀0: 접근권 있는 story_a participation은 정상 삭제(200)."""
+    import uuid as _uuid
+    from sqlalchemy import text
+    from app.main import app
+    from app.models.participation import Participation
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            partic_a_id = _uuid.uuid4()
+            s.add(Participation(
+                id=partic_a_id, org_id=seeded["org_id"], story_id=seeded["story_a_id"],
+                member_id=_uuid.uuid4(), role_id=seeded["role_id"],
+            ))
+            await s.commit()
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/participation/{partic_a_id}")
+            assert resp.status_code == 200, resp.text
+            async with Session() as s2:
+                cnt = (await s2.execute(
+                    text("SELECT count(*) FROM participation WHERE id = :i"), {"i": partic_a_id}
+                )).scalar_one()
+                assert cnt == 0
         finally:
             await client.aclose()
     finally:

--- a/backend/tests/test_remove_participation_guard.py
+++ b/backend/tests/test_remove_participation_guard.py
@@ -1,0 +1,74 @@
+"""CI-gated 회귀가드 — remove_participation(DELETE /participation/{id})이 대상 participation의
+story-project 접근권을 강제하는지 검증. `{id}` 뮤테이션 라우트는 ratchet 스캐너 사각(PROJECT_PARAM_RE가
+story_id/project_id만 매치·id는 미매치)이라 add_feedback류처럼 consumer test로 CI에 영속화. realdb
+아님(mock)이라 CI backend-test에서 실행. 가드 제거/우회 시 즉시 RED.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+STORY_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+PARTICIPATION_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _client(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+@pytest.mark.anyio
+async def test_remove_participation_denies_when_no_access_to_target_story_project():
+    """대상 participation의 story project 접근권이 없으면(has_project_access=False) 404이고
+    repo.delete가 호출되지 않는다(삭제 미수행). ⭐가드가 대상 participation의 story의 project로
+    검증하는지(has_project_access가 그 project_id로 호출) 확認 — `{id}` 뮤테이션이 대상 리소스의
+    project를 검증하는 계약."""
+    from app.main import app
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    p = MagicMock()
+    p.story_id = STORY_ID
+    # _assert_story_project_access 내부의 Story.project_id 조회가 PROJECT_ID를 반환하도록.
+    story_res = MagicMock()
+    story_res.scalar_one_or_none.return_value = PROJECT_ID
+    sess = AsyncMock()
+    sess.execute = AsyncMock(return_value=story_res)
+
+    async def _db():
+        yield sess
+
+    async def _auth():
+        return AuthContext(user_id=str(USER_ID), email="c@test", claims={"app_metadata": {"org_id": str(ORG_ID)}})
+
+    async def _org():
+        return ORG_ID
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+    try:
+        with (
+            patch("app.routers.participation.ParticipationRepository.get", new_callable=AsyncMock, return_value=p),
+            patch("app.routers.participation.ParticipationRepository.delete", new_callable=AsyncMock) as mdel,
+            patch("app.routers.participation.has_project_access", new_callable=AsyncMock, return_value=False) as mhpa,
+        ):
+            async with _client(app) as c:
+                resp = await c.delete(f"/api/v2/participation/{PARTICIPATION_ID}")
+            assert resp.status_code == 404, resp.text
+            mdel.assert_not_awaited()  # 삭제 미수행
+            assert mhpa.await_count >= 1
+            # 대상 participation의 story→project(PROJECT_ID)로 검증했는지(body/query 아님).
+            assert mhpa.await_args.args[2] == PROJECT_ID
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## remove_participation project-scope 가드 — same-org cross-project delete IDOR 봉인 (story `5a19b637`)

까심 fast-follow(participation 계열 마무리). `DELETE /participation/{id}`가 `repo.delete(id)`=`BaseRepository.get(id)`(**org_id 스코프만**)+delete라, 접근권 없는 same-org 다른 project의 participation을 `id`만으로 **삭제**할 수 있었다(mutation 대상 project-scope IDOR).

⭐**스캐너 사각**: `{id}` 파라미터라 ratchet `PROJECT_PARAM_RE`(story_id/project_id만 매치)에 안 걸린다 — add_feedback body.project_id에 이은 **2번째 id-param 뮤테이션 사각**. 계열 근본(스캐너가 `{id}` 뮤테이션의 대상-리소스 project 검증을 인식)은 별도 스토리 제안(오르테가 체계 관찰).

### fix
`remove_participation`이 `repo.get(id)`로 대상 participation 선조회(None→404) 뒤 그 `p.story_id`에 **#2087서 만든 `_assert_story_project_access` 재사용**(resource-actual `has_project_access`·404·존재 비노출) 검증하고, 통과해야 delete. **마이그 0**.

- `routers/participation.py`: get → `_assert_story_project_access` → delete.
- `test_e_sec_participation_story_project_scope_realdb.py`: 신규 realdb 2종(**cross-project delete→404+미삭제 직조회**·valid delete 200).
- `test_remove_participation_guard.py`: ⭐**CI-gated 회귀가드**(non-realdb mock). `{id}` 뮤테이션이 스캐너 사각이라 consumer test로 영속화 — `has_project_access`가 **대상 participation의 story의 project**로 강제되는지 실증(가드 제거/우회 시 CI RED).

### 검증 (실 PG + mock)
신규 realdb **2/2**·CI 가드 **1/1**·**sabotage**(가드 무력화→cross-project delete + CI 가드 2종 즉시 RED)로 비-동어반복. participation SEC 전 6·ratchet 3·cage-referee 10·**ruff clean·마이그 0**.

QA: 까심(delete write-path·대상-리소스 project 검증·sabotage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
