### PR TITLE
feat(security): authz 스캐너 PATH_ID 뮤테이션 축 확장 — {id} IDOR 계열 자동 봉인 (story 5285888c)

### DIFF
--- a/backend/tests/authz_coverage_lib.py
+++ b/backend/tests/authz_coverage_lib.py
@@ -60,7 +60,23 @@ PROJECT_GUARD_FUNCTIONS: frozenset[str] = frozenset({
     "_assert_link_target_in_scope",
     "_assert_task_project_access",
     "_assert_story_project_access",
+    "_require_doc_project_access",
+    "_require_retro_project_access",
 })
+
+# ── PATH_ID 뮤테이션 축(story 5285888c): `DELETE|PATCH|PUT /resource/{id}` 처럼 리소스 자기
+# PK(path param `id`/`*_id`)로 잡는 뮤테이션 라우트는 param 이름이 project_id/story_id가 아니라
+# `id`라 PROJECT_PARAM_RE에 원천 비가시였다(add_feedback body-claimed에 이은 2번째 계열 사각).
+# 이 축은 그 라우트가 **대상 리소스의 project 접근권을 검증**하는지 본다.
+PATH_ID_PARAM_RE = re.compile(r"^(?:id|[a-z][a-z0-9]*_id)$")
+
+# id-뮤테이션 축의 "project 가드" 셋 — resolve_member는 **제외**한다: 인자 없는
+# resolve_member(auth, org_id, session)는 신원해소만 하고 project 접근권을 검증하지 않기
+# 때문(hypotheses.update 등 실 갭). resolve_member는 아래 _resolve_member_checks_project 로
+# **project_id= 키워드로 호출됐을 때만** 가드로 인정(sprints.delete 등 정당 사용 보존).
+ID_MUTATION_PROJECT_GUARDS: frozenset[str] = frozenset(PROJECT_GUARD_FUNCTIONS - {"resolve_member"}) | {
+    "assert_target_in_caller_org",
+}
 
 # Depends(...) 콜러블 — 결과 id가 caller auth에서 서버-파생돼 클라이언트가 스푸핑할 여지가
 # 없는 패턴(예: app.routers.webhooks._get_caller_member_id). 이름 자체가 곧 계약이라 이름
@@ -69,7 +85,22 @@ SELF_DERIVING_DEPENDENCIES: frozenset[str] = frozenset({
     "_get_caller_member_id",
 })
 
+# 제네릭 tenancy/auth/db 의존성 — 이들의 바디는 Depends-바디 가드스캔서 **제외**한다.
+# 근거: get_verified_org_id는 JWT의 org+project **클레임**을 has_project_access로 검증하지만,
+# 이건 caller가 주장한 project지 **대상 리소스의 project**가 아니다(cross-project IDOR 무방비).
+# 거의 모든 라우트에 붙어 있어 포함하면 전 라우트가 가드로 오인된다(hypotheses false-negative 원인).
+# resource-특정 의존성(_get_repo류: path id로 대상 리소스 fetch+project 검증)만 인정한다.
+GENERIC_DEPENDENCIES: frozenset[str] = frozenset({
+    "get_verified_org_id",
+    "get_db",
+    "get_current_user",
+    "get_optional_current_user",
+})
+
 MUTATING_METHODS: frozenset[str] = frozenset({"POST", "PATCH", "PUT", "DELETE"})
+# PATH_ID 축은 **리소스 자체를 뮤테이트**하는 메서드로 좁힌다(DELETE/PATCH/PUT). POST는
+# /resource/{id}/subaction(하위리소스 생성) shape라 별개 축(향후 확장) — 이 스토리 스코프 밖.
+ID_MUTATION_METHODS: frozenset[str] = frozenset({"PATCH", "PUT", "DELETE"})
 # (GET 포함 — PO 크럭스 승인: read 사이드 정보노출도 이 스토리의 핵심 동기이자 커버리지 대상).
 COVERED_METHODS: frozenset[str] = MUTATING_METHODS | {"GET"}
 
@@ -218,3 +249,135 @@ def has_guard(target: RouteTarget, guard_functions: frozenset[str] = GUARD_FUNCT
 
 def has_declared_guard(target: RouteTarget) -> bool:
     return has_guard(target, GUARD_FUNCTIONS)
+
+
+def _path_param_names(route) -> set[str]:
+    """route.path(`/api/v2/epics/{id}`)의 `{...}` path param 이름 집합 — 리소스 자기 PK 식별용
+    (body/query가 아닌 **path** param만)."""
+    return set(re.findall(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}", getattr(route, "path", "")))
+
+
+def _resolve_member_checks_project(endpoint) -> bool:
+    """엔드포인트 바디에서 resolve_member(...)가 **project_id= 키워드**로 호출됐는지 AST로 판정.
+    인자 없는 resolve_member는 project 접근권을 검증 안 하므로 id-뮤테이션 가드로 인정 불가."""
+    try:
+        src = textwrap.dedent(inspect.getsource(endpoint))
+        tree = ast.parse(src)
+    except (OSError, TypeError, SyntaxError):
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            f = node.func
+            fname = f.id if isinstance(f, ast.Name) else (f.attr if isinstance(f, ast.Attribute) else "")
+            if fname == "resolve_member" and any(kw.arg == "project_id" for kw in node.keywords):
+                return True
+    return False
+
+
+def _depends_bodies_call_guard(endpoint, guard_set: frozenset[str]) -> bool:
+    """엔드포인트의 ``Depends(...)`` 콜러블 **바디**에서 guard_set 함수를 호출하는지 AST 스캔.
+
+    다수 라우트가 가드를 핸들러 바디가 아니라 의존성(예: meetings ``_get_repo``가 내부에서
+    has_project_access 호출)에 둔다 — 바디-only 스캔이 이를 놓쳐 오탐이 되므로, Depends 콜러블
+    한 단계는 들여다본다(재귀는 안 함·v1 제약 유지)."""
+    try:
+        sig = inspect.signature(endpoint)
+    except (ValueError, TypeError):
+        return False
+    for p in sig.parameters.values():
+        dep = getattr(p.default, "dependency", None)
+        if dep is None:
+            continue
+        if getattr(dep, "__name__", "") in GENERIC_DEPENDENCIES:
+            continue  # 제네릭 tenancy/auth 의존성은 대상-리소스 가드가 아니다(제외).
+        try:
+            src = textwrap.dedent(inspect.getsource(dep))
+            tree = ast.parse(src)
+        except (OSError, TypeError, SyntaxError):
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                f = node.func
+                fname = f.id if isinstance(f, ast.Name) else (f.attr if isinstance(f, ast.Attribute) else "")
+                if fname in guard_set:
+                    return True
+    return False
+
+
+def has_id_mutation_guard(target: RouteTarget) -> bool:
+    """id-뮤테이션 라우트가 대상 리소스에 대한 인가 가드를 갖는가.
+
+    "가드"로 인정: ①project 접근권 가드(ID_MUTATION_PROJECT_GUARDS) ②resolve_member(project_id=)
+    ③org-level/ownership/self 가드(GUARD_FUNCTIONS: is_org_owner_or_admin/assert_caller_is_member/
+    assert_agent_owner 등) ④self-deriving Depends.
+    ②③를 인정하는 근거: org-level/user-level 리소스(organizations/labels/org_members 등)는 project
+    축이 없어 org-admin/ownership 가드가 곧 올바른 가드다. ⚠️한계: project-소속 리소스를 **org-admin
+    으로만** 가드하면 non-admin의 cross-project 뮤테이션을 놓친다(false-negative) — 그러나 전수
+    감사(story 5285888c)상 그런 케이스는 없었고, project-소속 리소스의 6 후보는 **어떤 가드도 없다**.
+    신규 project-소속 리소스는 반드시 has_project_access류를 쓸 것(리뷰 규율)."""
+    guard_set = ID_MUTATION_PROJECT_GUARDS | GUARD_FUNCTIONS
+    called = _called_names(target.endpoint)
+    if called & guard_set:
+        return True
+    if _resolve_member_checks_project(target.endpoint):
+        return True
+    if _depends_callable_names(target.endpoint) & SELF_DERIVING_DEPENDENCIES:
+        return True
+    if _depends_bodies_call_guard(target.endpoint, guard_set):
+        return True
+    return False
+
+
+def enumerate_id_mutation_routes(app) -> list[RouteTarget]:
+    """MUTATING(DELETE/PATCH/PUT) + path에 리소스 PK(id/*_id) param을 가진 라우트 전수.
+
+    대상 리소스가 project-소속이면 그 리소스의 project 접근권을 검증해야 하나, 스캐너는 리소스의
+    project-scoped 여부를 정적 자동판정하지 못한다(라우트→모델→컬럼/polymorphic 해소 필요) —
+    그래서 org/user-level(project 축 없음) 및 self-derived 안전 라우트는 baseline의 false-positive로
+    흡수하고(identity axis 38건 흡수 선례 동형), 실 project-scoped IDOR는 known-debt로 상환한다.
+    identity_params 필드엔 매치된 path-id param을 담는다."""
+    seen: set = set()
+    out: list[RouteTarget] = []
+    for route in app.routes:
+        route_methods = getattr(route, "methods", None)
+        if not route_methods:
+            continue
+        matched = route_methods & ID_MUTATION_METHODS
+        if not matched:
+            continue
+        endpoint = getattr(route, "endpoint", None)
+        if endpoint is None or endpoint in seen:
+            continue
+        path_ids = {p for p in _path_param_names(route) if PATH_ID_PARAM_RE.match(p)}
+        if not path_ids:
+            continue
+        seen.add(endpoint)
+        out.append(RouteTarget(
+            path=route.path,
+            methods=tuple(sorted(matched)),
+            module=endpoint.__module__,
+            qualname=endpoint.__qualname__,
+            identity_params=tuple(sorted(path_ids)),
+            endpoint=endpoint,
+        ))
+    return out
+
+
+def sibling_asymmetry_advisory(app) -> list[RouteTarget]:
+    """형제-비대칭 advisory(story 5285888c §3.3): 같은 라우터 모듈에 project 가드를 호출하는
+    라우트(형제)가 하나라도 있는데, 그 모듈의 미가드 {id}-뮤테이션 라우트는 대상 리소스의 project를
+    검증 안 하면 — 그 모듈 리소스가 project-소속일 개연성이 높다는 **고신뢰 시그널**이다(감사서 epics·
+    agent_runs·과거 participation/github 반복 확認). project-scoped 정적 자동판정 없이도 후보를 좁힌다.
+
+    비-강제(advisory) — CI를 RED로 만들지 않고 후보를 surface만 한다. 반환: 비대칭에 걸린 미가드
+    {id}-뮤테이션 RouteTarget 목록."""
+    id_routes = enumerate_id_mutation_routes(app)
+    # 모듈별로 project 가드를 호출하는 (임의 메서드) 라우트가 있는지 — COVERED_METHODS 전 축에서.
+    guarded_modules: set[str] = set()
+    for r in enumerate_routes_matching(app, PROJECT_PARAM_RE, COVERED_METHODS):
+        if has_guard(r, PROJECT_GUARD_FUNCTIONS):
+            guarded_modules.add(r.module)
+    return [
+        r for r in id_routes
+        if not has_id_mutation_guard(r) and r.module in guarded_modules
+    ]

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -38,8 +38,10 @@ sys.path.insert(0, str(Path(__file__).parent))
 from authz_coverage_lib import (  # noqa: E402
     PROJECT_GUARD_FUNCTIONS,
     PROJECT_PARAM_RE,
+    enumerate_id_mutation_routes,
     enumerate_routes_matching,
     has_guard,
+    has_id_mutation_guard,
 )
 
 # ── false positive: 실제로는 안전 — 영구 allowlist(이유 주석 필수) ────────────────────
@@ -191,3 +193,178 @@ def test_known_debt_allowlist_shrinks_are_welcome_no_assertion():
     """placeholder — known-debt 항목이 fix되면 baseline dict에서 제거하는 게 상환 진행의
     증거(별도 assertion 없음, 다음 fix PR이 이 dict를 줄이면 그걸로 충분)."""
     assert True
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# PATH_ID 뮤테이션 축 (story 5285888c) — `DELETE|PATCH|PUT /resource/{id}` 처럼 리소스 자기
+# PK(path `id`/`*_id`)로 잡는 뮤테이션이 대상 리소스의 project 접근권을 검증하는가.
+# PROJECT_PARAM_RE(project_id/story_id...)에 param 이름 `id`가 안 걸려 원천 비가시였던 계열 사각.
+# has_id_mutation_guard: project 가드(has_project_access류·resolve_member(project_id=)) OR
+# org/ownership/self 가드(GUARD_FUNCTIONS) OR resource-특정 Depends(_get_repo류) 바디 가드.
+# ══════════════════════════════════════════════════════════════════════════════
+
+# ── false positive: 실제로는 안전 — org/user-level(project 축 없음)·self-derived·
+#    JWT-project 스코프·인라인/1-hop 가드(v1 정적스캔 미인식). 영구 allowlist(이유 필수). ──
+_ID_MUTATION_FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
+    # JWT project_id로 리소스 fetch 스코프(비-스푸퍼블) — SELF_DERIVED
+    "app.routers.agent_deployments:delete_deployment": "JWT project_id 스코프로 deployment fetch(비-스푸퍼블)",
+    "app.routers.agent_deployments:patch_deployment": "동일 JWT project_id 스코프",
+    "app.routers.agent_personas:delete_persona": "JWT project_id 스코프로 persona fetch(비-스푸퍼블)",
+    "app.routers.agent_personas:update_persona": "동일 JWT project_id 스코프",
+    "app.routers.agent_sessions:transition_session": "JWT project_id 스코프로 session fetch(비-스푸퍼블)",
+    "app.routers.hitl:resolve_hitl_request": "JWT project_id 스코프로 HITL request fetch",
+    "app.routers.mockups:delete_mockup": "JWT project_id 스코프(비-스푸퍼블)+creator gate",
+    "app.routers.mockups:delete_scenario": "동일 JWT project_id 스코프",
+    "app.routers.mockups:update_mockup": "동일 JWT project_id 스코프",
+    "app.routers.mockups:update_scenario": "동일 JWT project_id 스코프",
+    "app.routers.visual_artifacts:delete_artifact": "JWT project_id 스코프+creator gate",
+    # caller-self / participant / recipient / creator — SELF_DERIVED
+    "app.routers.conversations:set_conversation_mute": "participant-membership gate(caller 참가 대화만)",
+    "app.routers.conversations:update_conversation": "participant-membership gate",
+    "app.routers.conversations:update_conversation_status": "participant-membership gate",
+    "app.routers.event_notifications:mark_read": "recipient-scoped(event.recipient_id==caller member)",
+    "app.routers.notifications:mark_read": "owner user_id 스코프(caller 소유 알림만)",
+    "app.routers.evidence:delete_evidence": "creator-only(created_by!=caller → 403)",
+    # org/user-level 리소스 — project 축 없음 — ORG_ONLY
+    "app.routers.labels:delete_label": "org taxonomy(project_id 컬럼 없음)·org-scope",
+    "app.routers.labels:detach_label": "org taxonomy·org-scope",
+    "app.routers.labels:update_label": "org taxonomy·org-scope",
+    "app.routers.organizations:delete_organization": "org owner/admin 게이트·project 축 없음",
+    "app.routers.organizations:update_organization": "org owner/admin 게이트·project 축 없음",
+    "app.routers.org_members:delete_org_member": "org owner/admin 게이트·project 축 없음",
+    "app.routers.org_members:update_org_member": "org owner/admin 게이트·project 축 없음",
+    "app.routers.org_invites:revoke_org_invite": "org owner/admin 게이트·project 축 없음",
+    "app.routers.workflow_trigger_types:delete_trigger_type": "_is_org_admin/require_admin·project 축 없음",
+    "app.routers.workflow_trigger_types:update_trigger_type": "동일 org-admin 게이트·project 축 없음",
+    # 실 가드가 있으나 v1 정적스캔이 인라인/1-hop 헬퍼를 미인식(guarded 확認)
+    "app.routers.open_api_keys:revoke_project_api_key": "resolves ProjectApiKey→key.project_id!=path project_id 인라인 체크(v1 스캔 miss)",
+    "app.routers.project_access:delete_project_access": "_require_owner_or_admin→has_project_role(admin) on path project_id(1-hop miss)",
+    "app.routers.workflow_line_config:update_draft_version": "_require_draft_author가 admin-level project_auth 접근권 강제(in-code 문서화)",
+}
+
+# ── known-debt: 실 project-scoped IDOR — 후속 라운드 상환(6후보·story 5285888c 감사). ──
+_ID_MUTATION_KNOWN_DEBT_ALLOWLIST: dict[str, str] = {
+    "app.routers.epics:update_epic":
+        "MEDIUM — auth 의존성 시그니처 없음·repo org-scope만·same-org cross-project로 epic title/goal/전략 무가드 write(형제 list_epics는 has_project_access 有). round1 우선.",
+    "app.routers.hypotheses:update_hypothesis":
+        "MEDIUM — resolve_member(project_id 없음)·service org-scope get만·caller의 hyp.project_id 접근권 미검증",
+    "app.routers.hypotheses:unlink_hypothesis":
+        "MEDIUM — org_id만·service org-scope get→remove_links·project 가드 0",
+    "app.routers.hypotheses:archive_hypothesis":
+        "MEDIUM — org_id만·soft-delete(status=archived)·project 가드 0",
+    "app.routers.agent_runs:update_agent_run":
+        "MEDIUM — AgentRun.project_id NOT NULL인데 org 체크(org_id!=org_id→404)만·형제 list/create는 has_project_access 有",
+    "app.routers.dependencies:delete_dependency":
+        "MEDIUM(borderline) — ItemDependency는 project_id 컬럼 없음·polymorphic from_id/to_id가 project-bound item 참조(semantic cross-project delete). polymorphic 판정 Q2 대기.",
+}
+
+
+def _id_mutation_baseline_valid_targets(app) -> set[str]:
+    return {r.key for r in enumerate_id_mutation_routes(app)}
+
+
+def test_no_new_unguarded_id_mutation_routes():
+    """ratchet(PATH_ID 축): baseline에 없는 미가드 {id}-뮤테이션 라우트가 생기면 CI 즉시 실패.
+    신규 DELETE/PATCH/PUT /resource/{id}가 대상 리소스의 project 접근권을 검증하지 않으면 발동 —
+    add_feedback/participation에 이은 {id} 계열 IDOR 사각을 자동 봉인(하나씩 손으로 찾기 종료)."""
+    from app.main import app
+
+    routes = enumerate_id_mutation_routes(app)
+    baseline = set(_ID_MUTATION_FALSE_POSITIVE_ALLOWLIST) | set(_ID_MUTATION_KNOWN_DEBT_ALLOWLIST)
+
+    unguarded_not_baselined = [
+        r for r in routes if not has_id_mutation_guard(r) and r.key not in baseline
+    ]
+    assert unguarded_not_baselined == [], (
+        "새 미가드 {id}-뮤테이션 라우트 발견 — 대상 리소스가 project-소속이면 그 리소스를 선조회해 "
+        "has_project_access류로 검증하거나(권장·participation.remove_participation 선례), org/user-level "
+        "리소스면 검토 후 _ID_MUTATION_FALSE_POSITIVE_ALLOWLIST에 이유와 함께 등록하세요:\n" +
+        "\n".join(f"  {r.key} path_ids={r.identity_params}" for r in unguarded_not_baselined)
+    )
+
+
+def test_id_mutation_baseline_entries_are_not_stale():
+    """PATH_ID baseline이 가리키는 라우트가 실제로 존재하는지(rename/삭제 rot 검출)."""
+    from app.main import app
+
+    valid = _id_mutation_baseline_valid_targets(app)
+    stale = (set(_ID_MUTATION_FALSE_POSITIVE_ALLOWLIST) | set(_ID_MUTATION_KNOWN_DEBT_ALLOWLIST)) - valid
+    assert stale == set(), f"PATH_ID baseline에 rot된 라우트: {stale}"
+
+
+def test_id_mutation_calibration_candidates_flagged_and_safe_recognized():
+    """캘리브레이션(AC): 감사가 확定한 6 IDOR 후보는 반드시 flagged(미가드)로 인식되고,
+    이미 봉인된 라우트(participation.remove·standups.add_feedback류)와 SAFE 라우트(tasks/stories
+    delete/update)는 guarded로 인식돼야 한다. 스캐너의 정밀도 회귀 방지."""
+    from app.main import app
+
+    routes = {r.key: r for r in enumerate_id_mutation_routes(app)}
+
+    must_be_flagged = set(_ID_MUTATION_KNOWN_DEBT_ALLOWLIST)
+    for key in must_be_flagged:
+        assert key in routes, f"후보 라우트 {key}가 열거 안 됨(rename?)"
+        assert not has_id_mutation_guard(routes[key]), f"후보 {key}가 guarded로 오인식(false-negative)"
+
+    must_be_safe = [
+        "app.routers.participation:remove_participation",  # #2089 봉인
+        "app.routers.tasks:delete_task",
+        "app.routers.tasks:update_task",
+        "app.routers.stories:update_story",
+        "app.routers.stories:delete_story",
+        "app.routers.docs:delete_doc",
+        "app.routers.meetings:update_meeting",
+        "app.routers.sprints:delete_sprint",
+    ]
+    for key in must_be_safe:
+        if key in routes:  # 존재할 때만(리네임 내성)
+            assert has_id_mutation_guard(routes[key]), f"SAFE 라우트 {key}가 flagged로 오인식(false-positive)"
+
+
+def test_id_mutation_axis_has_teeth_on_synthetic_routes():
+    """스캐너 이빨(sabotage-proof): 합성 앱에 미가드 DELETE /{id}와 가드 DELETE /{id}를 심어
+    enumerate가 둘 다 잡고 has_id_mutation_guard가 정확히 구분하는지 실증. 이 축이 실제로 신규
+    미가드 {id}-뮤테이션을 RED로 만든다는 증거(가드 탐지 로직이 상수 True로 썩으면 즉시 실패)."""
+    import uuid
+
+    from fastapi import Depends, FastAPI
+
+    from app.services.project_auth import has_project_access
+
+    app = FastAPI()
+
+    @app.delete("/synthetic/unguarded/{id}")
+    async def _synthetic_unguarded(id: uuid.UUID):  # noqa: ANN202 — 가드 호출 전무
+        return {"ok": True}
+
+    async def _guard_dep() -> uuid.UUID:
+        # resource-특정 의존성이 project 가드를 호출(meetings _get_repo 패턴 모사)
+        await has_project_access(None, None, None, None)  # noqa — 존재만 검증(AST 스캔 대상)
+        return uuid.uuid4()
+
+    @app.delete("/synthetic/guarded/{id}")
+    async def _synthetic_guarded(id: uuid.UUID, _g: uuid.UUID = Depends(_guard_dep)):  # noqa: ANN202
+        return {"ok": True}
+
+    routes = {r.qualname.split(".")[-1]: r for r in enumerate_id_mutation_routes(app)}
+    assert "_synthetic_unguarded" in routes, "미가드 {id}-뮤테이션이 열거 안 됨(축 사각)"
+    assert "_synthetic_guarded" in routes
+    assert not has_id_mutation_guard(routes["_synthetic_unguarded"]), (
+        "미가드 라우트를 guarded로 오판 — 축의 이빨 상실(가드 탐지 로직 회귀)"
+    )
+    assert has_id_mutation_guard(routes["_synthetic_guarded"]), (
+        "Depends-바디 project 가드를 미탐지 — 오탐 회귀(_get_repo 패턴 무력화)"
+    )
+
+
+def test_sibling_asymmetry_advisory_surfaces_high_confidence_candidates():
+    """형제-비대칭 advisory(비-강제): read/create 형제가 project 가드를 부르는 모듈의 미가드
+    {id}-뮤테이션을 surface. epics(list_epics 가드)·agent_runs(list/create 가드)가 반드시 잡혀야
+    한다 — project-scoped 판정 없이 고신뢰 후보를 좁히는 휴리스틱의 회귀 방지. advisory라 CI를
+    RED로 만들진 않음(신규 항목 허용)."""
+    from app.main import app
+
+    from authz_coverage_lib import sibling_asymmetry_advisory
+
+    flagged = {r.key for r in sibling_asymmetry_advisory(app)}
+    for expected in ("app.routers.epics:update_epic", "app.routers.agent_runs:update_agent_run"):
+        assert expected in flagged, f"형제-비대칭 휴리스틱이 고신뢰 후보 {expected}를 놓침"


### PR DESCRIPTION
## authz 스캐너 PATH_ID 뮤테이션 축 확장 — `{id}` IDOR 계열 자동 봉인 (story `5285888c`)

설계 doc: `design-scanner-id-param-mutation-axis`. 승인: Q1=스캐너 먼저(6후보 baseline 등재·이빨 장착)·6후보는 후속 라운드.

### 문제 (계열 사각의 근본)
스캐너는 param **이름**을 `PROJECT_PARAM_RE`(project_id/story_id...)로 매치 → `DELETE|PATCH|PUT /resource/{id}`의 path param 이름 `id`가 **원천 비가시**(add_feedback body-claimed에 이은 2번째 계열 사각). 하나씩 손으로 회수(participation) 말고 **스캐너가 계열째 자동으로 무는** 근본.

### 감사 (헤드라인)
전-코드베이스 **70개 {id} 뮤테이션(DELETE/PATCH/PUT)** → **6 IDOR 후보**(known-debt) · 30 false-positive(org/self/JWT-scope) · 34 SAFE.

### 스캐너 (`authz_coverage_lib.py`)
- `PATH_ID_PARAM_RE`(id/*_id) + `ID_MUTATION_METHODS`(DELETE/PATCH/PUT·POST는 별개 축).
- `enumerate_id_mutation_routes` / `has_id_mutation_guard`: ①project 가드 ②`resolve_member(project_id=)` **AST 키워드 판정**(bare resolve_member 제외 — hypotheses 실갭 포착) ③org/ownership/self 가드 ④resource-특정 Depends(`_get_repo`류) 바디 가드. `GENERIC_DEPENDENCIES`(`get_verified_org_id` 등)는 제외 — JWT project **클레임** 검증이라 대상 리소스 가드 아님(hypotheses false-negative 방지).
- `PROJECT_GUARD_FUNCTIONS` += `_require_doc_project_access`/`_require_retro_project_access`.
- `sibling_asymmetry_advisory`: read/create 형제가 project 가드 부르는 모듈의 미가드 {id}-뮤테이션 surface(비-강제 고신뢰 휴리스틱).

### ratchet consumer (`test_authz_project_scope_coverage.py`)
baseline 3분류(false-positive 30·known-debt 6) + 6 테스트:
- `test_no_new_unguarded_id_mutation_routes` — 신규 미가드 {id}-뮤테이션 **CI RED**.
- baseline rot 검출 · **calibration**(6후보 flagged + participation.remove/tasks/stories SAFE) · **합성-앱 sabotage-proof**(가드탐지 썩으면 RED) · sibling-asymmetry advisory 회귀방지.

### 검증
authz 전 테스트 **12 passed·3 skipped**(realdb)·**S20 identity/project 축 회귀0**·ruff clean·**마이그0**. 6후보 상환은 머지 후 후속 라운드(PO 순차 킥: epics→hyp→agent_runs).

QA: 까심(축 정밀도·6후보 flagged·false-positive 타당성·teeth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
