### PR TITLE
fix(security): epics update_epic project-scope 가드 — cross-project 덮어쓰기 IDOR 봉인 (스캐너 라운드1 #1)

### DIFF
--- a/backend/app/routers/epics.py
+++ b/backend/app/routers/epics.py
@@ -276,9 +276,16 @@ async def update_epic(
     id: uuid.UUID,
     body: EpicUpdate,
     repo: EpicRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> EpicResponse:
     current = await repo.get(id)
     if current is None:
+        raise HTTPException(status_code=404, detail="Epic not found")
+    # 5285888c 라운드1(#1): repo는 org-scope만이라 접근권 없는 same-org 다른 project의 epic을
+    # title/goal/전략까지 무가드로 덮어쓸 수 있었다(PATH_ID 뮤테이션 project-scope IDOR). resolved
+    # -resource(현 epic의 실 project_id)에 has_project_access 사전검증(404·존재 비노출·body-claimed
+    # 금지). EpicUpdate엔 project_id 필드 없어 cross-project 이동 경로는 원천 부재.
+    if not await has_project_access(repo.session, uuid.UUID(auth.user_id), current.project_id, repo.org_id):
         raise HTTPException(status_code=404, detail="Epic not found")
     data = body.model_dump(exclude_unset=True)
     # ⭐RC#2(D1' 봉인): epic status(lifecycle) **변경**은 generic PATCH 금지 — 전용 transition 엔드포인트

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -244,8 +244,8 @@ _ID_MUTATION_FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
 
 # ── known-debt: 실 project-scoped IDOR — 후속 라운드 상환(6후보·story 5285888c 감사). ──
 _ID_MUTATION_KNOWN_DEBT_ALLOWLIST: dict[str, str] = {
-    "app.routers.epics:update_epic":
-        "MEDIUM — auth 의존성 시그니처 없음·repo org-scope만·same-org cross-project로 epic title/goal/전략 무가드 write(형제 list_epics는 has_project_access 有). round1 우선.",
+    # 라운드1 상환(#1·epics:update_epic): resolved-resource has_project_access(current.project_id)
+    # 사전검증으로 same-org cross-project epic 덮어쓰기 봉인 — 이제 스캐너가 guarded로 인식·감시.
     "app.routers.hypotheses:update_hypothesis":
         "MEDIUM — resolve_member(project_id 없음)·service org-scope get만·caller의 hyp.project_id 접근권 미검증",
     "app.routers.hypotheses:unlink_hypothesis":
@@ -366,5 +366,8 @@ def test_sibling_asymmetry_advisory_surfaces_high_confidence_candidates():
     from authz_coverage_lib import sibling_asymmetry_advisory
 
     flagged = {r.key for r in sibling_asymmetry_advisory(app)}
-    for expected in ("app.routers.epics:update_epic", "app.routers.agent_runs:update_agent_run"):
-        assert expected in flagged, f"형제-비대칭 휴리스틱이 고신뢰 후보 {expected}를 놓침"
+    # agent_runs(list/create 형제 가드 有·update_agent_run 미가드)는 상환 순서상 마지막이라 이 축의
+    # 안정적 회귀 기준. (epics:update_epic은 라운드1에서 상환돼 이제 guarded → advisory서 빠짐=정상.)
+    assert "app.routers.agent_runs:update_agent_run" in flagged, (
+        "형제-비대칭 휴리스틱이 고신뢰 후보 agent_runs:update_agent_run을 놓침"
+    )

--- a/backend/tests/test_e_sec_epics_update_project_scope_realdb.py
+++ b/backend/tests/test_e_sec_epics_update_project_scope_realdb.py
@@ -1,0 +1,162 @@
+"""E-SECURITY 스캐너 라운드1(#1·story 5285888c) — epics:update_epic PATH_ID project-scope IDOR, 실 PG.
+
+갭: PATCH /epics/{id}(update_epic)가 repo org-scope만이라 접근권 없는 same-org 다른 project의
+epic을 id만으로 title/goal/전략까지 덮어쓸 수 있었다(PATH_ID 뮤테이션 project-scope IDOR·스캐너
+_KNOWN_DEBT #1). fix: resolved-resource(현 epic의 실 project_id)에 has_project_access 사전검증
+(404·존재 비노출·body-claimed 금지·EpicUpdate엔 project_id 필드 없어 이동 경로 부재).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a[caller grant]·project_b[무접근]) + epic_a(project_a)·epic_b(project_b)."""
+    from app.models.organization import Organization
+    from app.models.pm import Epic
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+    epic_a = Epic(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="Epic A")
+    epic_b = Epic(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="Epic B orig")
+    session.add_all([epic_a, epic_b])
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=caller_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "epic_a_id": epic_a.id, "epic_b_id": epic_b.id, "caller_id": caller_id}
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _epic_title(Session, epic_id):
+    from sqlalchemy import text
+    async with Session() as s:
+        return (await s.execute(
+            text("SELECT title FROM epics WHERE id = :i"), {"i": epic_id}
+        )).scalar_one()
+
+
+@pytest.mark.anyio
+async def test_update_epic_own_project_200():
+    """회귀0: project_a grant caller가 project_a epic title 수정 → 200 + 반영."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(f"/api/v2/epics/{seeded['epic_a_id']}", json={"title": "Epic A updated"})
+            assert resp.status_code == 200, resp.text
+            assert await _epic_title(Session, seeded["epic_a_id"]) == "Epic A updated"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_epic_cross_project_blocked_404_not_modified():
+    """봉인(PATH_ID 뮤테이션 IDOR·비-동어반복): 접근권 없는 project_b epic을 id로 덮어쓰기 시도 →
+    404 + **미변경 직조회**(epic_b title 원본 유지)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/epics/{seeded['epic_b_id']}", json={"title": "HACKED", "objective": "pwned"},
+            )
+            assert resp.status_code == 404, resp.text
+            assert await _epic_title(Session, seeded["epic_b_id"]) == "Epic B orig", "cross-project epic이 변경됨(IDOR)"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## epics update_epic project-scope 가드 — same-org cross-project epic 덮어쓰기 IDOR 봉인 (스캐너 라운드1 · known-debt #1)

스캐너 PATH_ID 축(#2090) `_KNOWN_DEBT_ALLOWLIST` **#1 상환**(PO 순차 킥: epics→hyp→agent_runs).

`PATCH /epics/{id}`(update_epic)가 org-scope repo만 써서 접근권 없는 **same-org 다른 project**의 epic을 `id`만으로 title/goal/objective/success_criteria/전략까지 **덮어쓸** 수 있었다(resolved-resource project 가드 0·최고위험 무가드-write). 형제 `list_epics`는 `has_project_access` 有(비대칭 시그널).

### fix
핸들러에 `auth` 추가 + resolved-resource(현 epic의 실 `project_id`)에 `has_project_access` 사전검증(**404**·존재 비노출·body-claimed 금지). `EpicUpdate`엔 `project_id` 필드 없어 cross-project 이동 경로 원천 부재. status transition 가드는 기존대로 보존. **마이그 0**.

- `routers/epics.py`: `auth=Depends(get_current_user)` + `has_project_access(current.project_id)` 사전검증.
- `test_authz_project_scope_coverage.py`: `_KNOWN_DEBT`서 epics:update_epic 제거(이제 guarded·**스캐너 ratchet가 감시**). advisory 회귀기준 agent_runs로 갱신.
- `test_e_sec_epics_update_project_scope_realdb.py`: realdb 2종(valid 200·**cross-project→404+미변경 직조회**).

### 검증
신규 realdb **2/2**·coverage ratchet **8/8**(update_epic=guarded 인식)·⭐**sabotage 이중 이빨**(가드 무력화→realdb cross-project **+ 스캐너 ratchet** 둘 다 즉시 RED). ruff clean·마이그0. 기존 epics 테스트 회귀0(test_s7_2 mcp.json 6건은 pristine develop서도 동일 실패=로컬 `.mcp.json` 경로·본 변경 무관, stash 대조 확認).

QA: 까심(cross-project update·미변경 직조회·sabotage·스캐너 ratchet 연동).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
