### PR TITLE
fix(security): hypotheses update/unlink/archive project-scope 가드 — cross-project IDOR 봉인 (스캐너 라운드2 #2~4)

### DIFF
--- a/backend/app/routers/hypotheses.py
+++ b/backend/app/routers/hypotheses.py
@@ -35,8 +35,24 @@ from app.schemas.hypothesis import (
 )
 from app.services import hypothesis as svc
 from app.services.member_resolver import ResolvedMember, resolve_member
+from app.services.project_auth import has_project_access
 
 router = APIRouter(prefix="/api/v2/hypotheses", tags=["hypotheses"])
+
+
+async def _assert_hypothesis_project_access(
+    session: AsyncSession, user_id: uuid.UUID, org_id: uuid.UUID, hypothesis_id: uuid.UUID
+) -> None:
+    """update/unlink/archive는 hyp를 id로 잡는다(service가 org-scope get만 해 project 접근권 미검증).
+    resolved-resource(hyp.project_id)에 caller 접근권을 사전검증(404·존재 비노출·body-claimed 금지).
+    resolve_member(project_id=)는 no-access를 403으로 내 존재를 노출하므로, 여기선 has_project_access
+    직접호출로 404 통일(participation/epics 라운드 선례·존재 비노출)."""
+    hyp = await HypothesisRepository(session, org_id).get(hypothesis_id)
+    if hyp is None or not await has_project_access(session, user_id, hyp.project_id, org_id):
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "HYPOTHESIS_NOT_FOUND", "message": "가설을 찾을 수 없습니다."},
+        )
 
 _ADMIN_ROLES = frozenset({"owner", "admin"})
 
@@ -148,6 +164,7 @@ async def update_hypothesis(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> HypothesisResponse:
+    await _assert_hypothesis_project_access(session, uuid.UUID(auth.user_id), org_id, hypothesis_id)
     caller = await resolve_member(auth, org_id, session)
     try:
         return await svc.update_hypothesis(session, org_id, caller, hypothesis_id, body)
@@ -199,8 +216,10 @@ async def unlink_hypothesis(
     hypothesis_id: uuid.UUID,
     body: HypothesisUnlinkRequest,
     session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> HypothesisResponse:
+    await _assert_hypothesis_project_access(session, uuid.UUID(auth.user_id), org_id, hypothesis_id)
     try:
         return await svc.unlink_hypothesis(session, org_id, hypothesis_id, body)
     except svc.HypothesisServiceError as err:
@@ -211,8 +230,10 @@ async def unlink_hypothesis(
 async def archive_hypothesis(
     hypothesis_id: uuid.UUID,
     session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
+    await _assert_hypothesis_project_access(session, uuid.UUID(auth.user_id), org_id, hypothesis_id)
     try:
         await svc.archive_hypothesis(session, org_id, hypothesis_id)
     except svc.HypothesisServiceError as err:

--- a/backend/tests/authz_coverage_lib.py
+++ b/backend/tests/authz_coverage_lib.py
@@ -60,6 +60,7 @@ PROJECT_GUARD_FUNCTIONS: frozenset[str] = frozenset({
     "_assert_link_target_in_scope",
     "_assert_task_project_access",
     "_assert_story_project_access",
+    "_assert_hypothesis_project_access",
     "_require_doc_project_access",
     "_require_retro_project_access",
 })

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -246,12 +246,8 @@ _ID_MUTATION_FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
 _ID_MUTATION_KNOWN_DEBT_ALLOWLIST: dict[str, str] = {
     # 라운드1 상환(#1·epics:update_epic): resolved-resource has_project_access(current.project_id)
     # 사전검증으로 same-org cross-project epic 덮어쓰기 봉인 — 이제 스캐너가 guarded로 인식·감시.
-    "app.routers.hypotheses:update_hypothesis":
-        "MEDIUM — resolve_member(project_id 없음)·service org-scope get만·caller의 hyp.project_id 접근권 미검증",
-    "app.routers.hypotheses:unlink_hypothesis":
-        "MEDIUM — org_id만·service org-scope get→remove_links·project 가드 0",
-    "app.routers.hypotheses:archive_hypothesis":
-        "MEDIUM — org_id만·soft-delete(status=archived)·project 가드 0",
+    # 라운드2 상환(#2~4·hypotheses update/unlink/archive): _assert_hypothesis_project_access(hyp
+    # 조회→hyp.project_id has_project_access·404) 라우터 가드로 봉인 — 스캐너 감시 전환.
     "app.routers.agent_runs:update_agent_run":
         "MEDIUM — AgentRun.project_id NOT NULL인데 org 체크(org_id!=org_id→404)만·형제 list/create는 has_project_access 有",
     "app.routers.dependencies:delete_dependency":

--- a/backend/tests/test_e_sec_hypotheses_project_scope_realdb.py
+++ b/backend/tests/test_e_sec_hypotheses_project_scope_realdb.py
@@ -1,0 +1,221 @@
+"""E-SECURITY 스캐너 라운드2(#2~4·story 5285888c) — hypotheses update/unlink/archive PATH_ID
+project-scope IDOR, 실 PG.
+
+갭: PATCH /{hypothesis_id}(update)·DELETE /{hypothesis_id}/links(unlink)·DELETE /{hypothesis_id}
+(archive) 세 라우트 모두 hyp를 id로 잡되 service가 org-scope get만 해 resolved-resource
+(Hypothesis.project_id) has_project_access 검증이 0이었다(service-layer 갭). caller는 접근권 없는
+same-org 다른 project의 hyp를 덮어쓰기/링크해제/아카이브할 수 있었다. fix: 라우터 공통 가드
+_assert_hypothesis_project_access(hyp 조회→hyp.project_id has_project_access·404·존재 비노출).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+_METRIC = {"metric": "signups", "source": "db", "target": 100, "direction": "increase"}
+
+
+def _hyp(org_id, project_id, statement):
+    from app.models.hypothesis import Hypothesis
+    return Hypothesis(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, owner_member_id=uuid.uuid4(),
+        statement=statement, metric_definition=_METRIC,
+        measure_after=datetime(2026, 6, 1, tzinfo=timezone.utc), status="proposed",
+    )
+
+
+async def _seed(session):
+    """org(project_a[caller grant]·project_b[무접근]) + hyp_a(project_a)·hyp_b(project_b)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+    hyp_a = _hyp(org.id, project_a.id, "Hyp A")
+    hyp_b = _hyp(org.id, project_b.id, "Hyp B orig")
+    session.add_all([hyp_a, hyp_b])
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=caller_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "hyp_a_id": hyp_a.id, "hyp_b_id": hyp_b.id, "caller_id": caller_id}
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _hyp_col(Session, hyp_id, col):
+    from sqlalchemy import text
+    async with Session() as s:
+        return (await s.execute(
+            text(f"SELECT {col} FROM hypotheses WHERE id = :i"), {"i": hyp_id}
+        )).scalar_one()
+
+
+@pytest.mark.anyio
+async def test_update_hypothesis_own_project_200():
+    """회귀0: project_a grant caller가 project_a hyp statement 수정 → 200 + 반영."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/hypotheses/{seeded['hyp_a_id']}", json={"statement": "Hyp A updated"},
+            )
+            assert resp.status_code == 200, resp.text
+            assert await _hyp_col(Session, seeded["hyp_a_id"], "statement") == "Hyp A updated"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_hypothesis_cross_project_blocked_404_not_modified():
+    """봉인: 접근권 없는 project_b hyp를 id로 수정 시도 → 404 + **미변경 직조회**(statement 원본 유지)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/hypotheses/{seeded['hyp_b_id']}", json={"statement": "HACKED"},
+            )
+            assert resp.status_code == 404, resp.text
+            assert await _hyp_col(Session, seeded["hyp_b_id"], "statement") == "Hyp B orig", "cross-project hyp 변경됨(IDOR)"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_archive_hypothesis_cross_project_blocked_404_not_archived():
+    """봉인: 접근권 없는 project_b hyp archive 시도 → 404 + **미아카이브 직조회**(status='proposed' 유지)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/hypotheses/{seeded['hyp_b_id']}")
+            assert resp.status_code == 404, resp.text
+            assert await _hyp_col(Session, seeded["hyp_b_id"], "status") == "proposed", "cross-project hyp 아카이브됨(IDOR)"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unlink_hypothesis_cross_project_blocked_404():
+    """봉인: 접근권 없는 project_b hyp 링크해제 시도 → 404(가드가 service 前 차단)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.request(
+                "DELETE", f"/api/v2/hypotheses/{seeded['hyp_b_id']}/links",
+                json={"epic_ids": [], "story_ids": [], "unlink_sprint": True},
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## hypotheses update/unlink/archive project-scope 가드 — same-org cross-project IDOR 봉인 (스캐너 라운드2 · known-debt #2~4)

스캐너 PATH_ID 축(#2090) `_KNOWN_DEBT` **#2~4 상환**(계열째·라우터+service 쌍 분석).

`PATCH /{hypothesis_id}`(update)·`DELETE /{hypothesis_id}/links`(unlink)·`DELETE /{hypothesis_id}`(archive) 세 라우트가 hyp를 `id`로 잡되 **service가 org-scope get만** 해 resolved-resource(`Hypothesis.project_id`) `has_project_access` 검증 0(service-layer 갭·update는 `resolve_member`를 project_id 없이 호출·unlink/archive는 auth 자체 없음). caller가 접근권 없는 **same-org 다른 project**의 hyp를 덮어쓰기/링크해제/아카이브 가능.

### fix
라우터 공통 가드 `_assert_hypothesis_project_access`(hyp 조회→`hyp.project_id` `has_project_access` 사전검증·**404**·존재 비노출·body-claimed 금지). `resolve_member(project_id=)`는 no-access를 **403**으로 내 존재를 노출 → `has_project_access` 직접호출로 **404 통일**(participation/epics 선례). ⭐가드는 **라우터**에 둔다 — 스캐너가 라우터 바디를 스캔하므로 service-layer 가드는 감시 불가. `unlink`/`archive`엔 `auth` 추가. **마이그 0**.

- `routers/hypotheses.py`: 헬퍼 + update/unlink/archive 사전검증.
- `authz_coverage_lib.py`: `PROJECT_GUARD_FUNCTIONS`에 `_assert_hypothesis_project_access` 등재(스캐너 인식).
- `test_authz_project_scope_coverage.py`: `_KNOWN_DEBT`서 hyp 3건 제거(스캐너 감시 전환).
- `test_e_sec_hypotheses_project_scope_realdb.py`: realdb 4종(valid 200·update/archive/unlink cross-project→404+미변경/미아카이브).

### 검증
신규 realdb **4/4**·coverage ratchet **8/8**·⭐**sabotage 이중 이빨**(헬퍼 무력화→realdb cross-project 3종 RED[로직 이빨]·가드 콜 제거→스캐너 ratchet RED[콜-제거 이빨]·상보적). ruff clean·마이그0. 기존 hypotheses 175 pass·회귀0(2 real_db 실패는 pristine develop서도 동일=로컬 DB 상태·무관, stash 대조).

QA: 까심(3경로 cross-project·미변경/미아카이브 직조회·sabotage·ratchet 연동).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
