### PR TITLE
fix(security): agent_runs update_agent_run project-scope 가드 — cross-project run 덮어쓰기 IDOR 봉인 (스캐너 라운드3 #5)

### DIFF
--- a/backend/app/routers/agent_runs.py
+++ b/backend/app/routers/agent_runs.py
@@ -124,13 +124,20 @@ async def update_agent_run(
     id: uuid.UUID,
     body: UpdateAgentRun,
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
     repo: AgentRunRepository = Depends(_get_repo),
 ) -> AgentRunResponse:
     """prod 핫픽스(S20 전수스캔 — create_agent_run과 동일 클래스): run id만으로 org 검증 없이
     임의 org의 agent run을 수정할 수 있었다."""
+    from app.services.project_auth import has_project_access
+
     existing = await repo.get(id)
     if existing is None or existing.org_id != org_id:
+        raise HTTPException(status_code=404, detail="Agent run not found")
+    # 스캐너 라운드3(#5): org 검증은 있으나 resolved-resource(existing.project_id·AgentRun.project_id
+    # NOT NULL)의 project 접근권 미검증 → same-org 다른 project 멤버가 run status/tokens/cost/error를
+    # 덮어쓸 수 있었다(형제 list/create는 이미 has_project_access 有·불일치 시그널이 지목). 404·body-claimed 금지.
+    if not await has_project_access(repo.session, uuid.UUID(auth.user_id), existing.project_id, org_id):
         raise HTTPException(status_code=404, detail="Agent run not found")
     run = await repo.update(
         id,

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -248,8 +248,8 @@ _ID_MUTATION_KNOWN_DEBT_ALLOWLIST: dict[str, str] = {
     # 사전검증으로 same-org cross-project epic 덮어쓰기 봉인 — 이제 스캐너가 guarded로 인식·감시.
     # 라운드2 상환(#2~4·hypotheses update/unlink/archive): _assert_hypothesis_project_access(hyp
     # 조회→hyp.project_id has_project_access·404) 라우터 가드로 봉인 — 스캐너 감시 전환.
-    "app.routers.agent_runs:update_agent_run":
-        "MEDIUM — AgentRun.project_id NOT NULL인데 org 체크(org_id!=org_id→404)만·형제 list/create는 has_project_access 有",
+    # 라운드3 상환(#5·agent_runs:update_agent_run): resolved-resource(existing.project_id) has_project_access
+    # 사전검증으로 same-org cross-project run 덮어쓰기 봉인 — 스캐너 감시 전환.
     "app.routers.dependencies:delete_dependency":
         "MEDIUM(borderline) — ItemDependency는 project_id 컬럼 없음·polymorphic from_id/to_id가 project-bound item 참조(semantic cross-project delete). polymorphic 판정 Q2 대기.",
 }
@@ -361,9 +361,11 @@ def test_sibling_asymmetry_advisory_surfaces_high_confidence_candidates():
 
     from authz_coverage_lib import sibling_asymmetry_advisory
 
-    flagged = {r.key for r in sibling_asymmetry_advisory(app)}
-    # agent_runs(list/create 형제 가드 有·update_agent_run 미가드)는 상환 순서상 마지막이라 이 축의
-    # 안정적 회귀 기준. (epics:update_epic은 라운드1에서 상환돼 이제 guarded → advisory서 빠짐=정상.)
-    assert "app.routers.agent_runs:update_agent_run" in flagged, (
-        "형제-비대칭 휴리스틱이 고신뢰 후보 agent_runs:update_agent_run을 놓침"
-    )
+    surfaced = sibling_asymmetry_advisory(app)
+    # 계약(paydown-무관 안정 기준): advisory가 surface하는 모든 엔트리는 반드시 (a) id-뮤테이션
+    # 라우트이고 (b) has_id_mutation_guard 미충족이며 (c) 형제가 project 가드를 부르는 모듈에 속한다.
+    # (특정 라우트 이름은 상환마다 바뀌므로 assert 안 함 — 후보가 상환되면 advisory서 빠지는 게 정상.)
+    id_route_keys = {r.key for r in enumerate_id_mutation_routes(app)}
+    for r in surfaced:
+        assert r.key in id_route_keys, f"advisory가 id-뮤테이션 아닌 라우트 surface: {r.key}"
+        assert not has_id_mutation_guard(r), f"advisory가 guarded 라우트 surface(오탐): {r.key}"

--- a/backend/tests/test_e_sec_agent_runs_update_project_scope_realdb.py
+++ b/backend/tests/test_e_sec_agent_runs_update_project_scope_realdb.py
@@ -1,0 +1,167 @@
+"""E-SECURITY 스캐너 라운드3(#5·story 5285888c) — agent_runs:update_agent_run PATH_ID project-scope
+IDOR, 실 PG.
+
+갭: PATCH /agent-runs/{id}(update_agent_run)가 org 검증(existing.org_id != org_id)은 하나
+resolved-resource(AgentRun.project_id·NOT NULL)의 project 접근권 검증이 0이었다 → same-org 다른
+project 멤버가 run status/tokens/cost/error를 덮어쓸 수 있었다(형제 list/create는 이미
+has_project_access 有). fix: existing.project_id에 has_project_access 사전검증(404·body-claimed 금지).
+비-동어반복: 실 status 변경(running→completed)을 시도해 404 + 미변경(status 원본 유지) 직조회.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org(project_a[caller grant]·project_b[무접근]) + run_a(project_a)·run_b(project_b·status=running)."""
+    from app.models.agent_run import AgentRun
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="Project A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="Project B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+    run_a = AgentRun(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id,
+                     agent_id=uuid.uuid4(), trigger="manual", status="running")
+    run_b = AgentRun(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id,
+                     agent_id=uuid.uuid4(), trigger="manual", status="running")
+    session.add_all([run_a, run_b])
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    caller_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(caller_om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=caller_om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "run_a_id": run_a.id, "run_b_id": run_b.id, "caller_id": caller_id}
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _run_status(Session, run_id):
+    from sqlalchemy import text
+    async with Session() as s:
+        return (await s.execute(
+            text("SELECT status FROM agent_runs WHERE id = :i"), {"i": run_id}
+        )).scalar_one()
+
+
+@pytest.mark.anyio
+async def test_update_agent_run_own_project_200():
+    """회귀0: project_a grant caller가 project_a run status 수정 → 200 + 반영."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(f"/api/v2/agent-runs/{seeded['run_a_id']}", json={"status": "completed"})
+            assert resp.status_code == 200, resp.text
+            assert await _run_status(Session, seeded["run_a_id"]) == "completed"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_agent_run_cross_project_blocked_404_not_modified():
+    """봉인(비-동어반복): 접근권 없는 project_b run status를 running→completed로 변경 시도 →
+    404 + **미변경 직조회**(status='running' 유지)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.patch(
+                f"/api/v2/agent-runs/{seeded['run_b_id']}",
+                json={"status": "completed", "result_summary": "pwned"},
+            )
+            assert resp.status_code == 404, resp.text
+            assert await _run_status(Session, seeded["run_b_id"]) == "running", "cross-project run이 변경됨(IDOR)"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## agent_runs update_agent_run project-scope 가드 — same-org cross-project run 덮어쓰기 IDOR 봉인 (스캐너 라운드3 · known-debt #5)

스캐너 PATH_ID 축(#2090) `_KNOWN_DEBT` **#5 상환**(6후보 중 5건째).

`PATCH /agent-runs/{id}`(update_agent_run)가 org 검증(`existing.org_id != org_id` → 404)은 하나 resolved-resource(`AgentRun.project_id`·NOT NULL)의 project 접근권 검증 0 → same-org 다른 project 멤버가 run status/tokens/cost/error를 덮어쓸 수 있었다. 형제 `list`/`create`는 이미 `has_project_access` 有 — ⭐**스캐너 형제-비대칭 시그널이 정확히 이걸 지목**했었다.

### fix
`existing.project_id`에 `has_project_access` 사전검증(404·body-claimed 금지·파일 idiom대로 inline import). **마이그 0**.

- `routers/agent_runs.py`: `has_project_access(existing.project_id)` 사전검증.
- `test_authz_project_scope_coverage.py`: `_KNOWN_DEBT`서 제거(스캐너 감시 전환). advisory 테스트를 **계약-단언**(surface 엔트리는 전부 미가드 id-뮤테이션)으로 전환 — 상환마다 라우트명이 바뀌어도 안정.
- `test_e_sec_agent_runs_update_project_scope_realdb.py`: realdb 2종(valid 200·**cross-project status running→completed 시도→404+미변경 직조회**·비-동어반복).

### 검증
신규 realdb **2/2**·coverage ratchet **8/8**·⭐**sabotage 이중 이빨**(inline 가드라 한 sabotage로 realdb cross-project + 스캐너 ratchet 둘 다 즉시 RED). ruff clean·마이그0. 기존 agent_run 23 pass·회귀0.

**진척**: 6후보 중 **5건 상환 완료**(epics·hyp×3·agent_runs). 남은 1건=dependencies #6(borderline·polymorphic·Q2 대기).

QA: 까심(cross-project status 변경·미변경 직조회·비-동어반복·sabotage·ratchet 연동).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
