### PR TITLE
fix(security): dependencies 서브시스템 project-scope 하드닝 — cross-project IDOR 봉인 (스캐너 #6·6후보 완결)

### DIFF
--- a/backend/app/routers/dependencies.py
+++ b/backend/app/routers/dependencies.py
@@ -1,16 +1,23 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import get_current_user, get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.dependency import ITEM_TYPES
+from app.models.pm import Epic, Sprint, Story
 from app.repositories.dependency import DependencyRepository
 from app.schemas.dependency import DependencyCreate, DependencyGraphResponse, DependencyResponse
 from app.services.dependency_graph import get_graph, would_create_cycle
+from app.services.project_auth import accessible_project_ids_in_org, has_project_access
 
 router = APIRouter(prefix="/api/v2/dependencies", tags=["dependencies"])
+
+# item_type → project-소속 모델. epic/sprint/story 셋 다 project_id 직접 컬럼(pm.py) — polymorphic
+# 간접(task→story) 없음. dependency 자체엔 project_id가 없어 아이템→project로 해소해 게이팅한다.
+_ITEM_MODEL = {"epic": Epic, "sprint": Sprint, "story": Story}
 
 
 def _get_repo(
@@ -20,21 +27,68 @@ def _get_repo(
     return DependencyRepository(session, org_id)
 
 
+async def _item_project_id(
+    session: AsyncSession, org_id: uuid.UUID, item_id: uuid.UUID, item_type: str
+) -> uuid.UUID | None:
+    model = _ITEM_MODEL[item_type]
+    return (
+        await session.execute(
+            select(model.project_id).where(model.id == item_id, model.org_id == org_id)
+        )
+    ).scalar_one_or_none()
+
+
+async def _assert_item_project_access(
+    session: AsyncSession, user_id: uuid.UUID, org_id: uuid.UUID, item_id: uuid.UUID, item_type: str
+) -> None:
+    """dependency 대상 아이템(epic/sprint/story)의 실 project 접근권을 resource-actual 검증(404·존재
+    비노출). dependency는 project_id 컬럼이 없어 아이템→project로 해소한다. 서브시스템 전체(create/
+    delete/list/graph) 공통 게이트 — 반쪽 전환 금지(story aa365768·스캐너 #6)."""
+    project_id = await _item_project_id(session, org_id, item_id, item_type)
+    if project_id is None or not await has_project_access(session, user_id, project_id, org_id):
+        raise HTTPException(status_code=404, detail="의존성 대상 아이템을 찾을 수 없음")
+
+
+async def _items_project_map(
+    session: AsyncSession, org_id: uuid.UUID, item_type: str, ids: list[uuid.UUID]
+) -> dict[uuid.UUID, uuid.UUID]:
+    """아이템 id 집합 → project_id 맵(graph 응답 필터용·배치 조회)."""
+    if not ids:
+        return {}
+    model = _ITEM_MODEL[item_type]
+    rows = (
+        await session.execute(
+            select(model.id, model.project_id).where(model.id.in_(ids), model.org_id == org_id)
+        )
+    ).all()
+    return {row[0]: row[1] for row in rows}
+
+
 @router.post("", response_model=DependencyResponse, status_code=201)
 async def create_dependency(
     body: DependencyCreate,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> DependencyResponse:
+    if body.item_type not in ITEM_TYPES:
+        raise HTTPException(status_code=422, detail=f"item_type must be one of {sorted(ITEM_TYPES)}")
     if body.from_id == body.to_id:
         raise HTTPException(status_code=422, detail="자기참조 의존성은 허용되지 않음")
+
+    # 양쪽-아이템 게이트(AC1): from·to 둘 다 caller 접근권 있는 project의 아이템이어야 한다. 접근권
+    # 없는 project의 아이템을 링크에 끼워 그 project 상태를 조작하는 것을 차단(cross-project 자체는
+    # (a)설계상 허용이나 양쪽 모두 접근권 요구·반쪽 금지).
+    user_id = uuid.UUID(auth.user_id)
+    await _assert_item_project_access(session, user_id, org_id, body.from_id, body.item_type)
+    await _assert_item_project_access(session, user_id, org_id, body.to_id, body.item_type)
 
     repo = DependencyRepository(session, org_id)
 
     if await repo.exists(body.from_id, body.to_id, body.item_type):
         raise HTTPException(status_code=409, detail="이미 존재하는 의존성")
 
+    # 사이클 탐지는 org-wide 유지(AC3 — cross-project 사이클도 잡아야 하므로 project-partition 금지).
     if await would_create_cycle(session, org_id, body.from_id, body.to_id, body.item_type):
         raise HTTPException(status_code=422, detail="사이클이 발생하는 의존성은 허용되지 않음")
 
@@ -52,9 +106,12 @@ async def list_dependencies(
     item_type: str = Query(...),
     item_id: uuid.UUID = Query(...),
     repo: DependencyRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[DependencyResponse]:
     if item_type not in ITEM_TYPES:
         raise HTTPException(status_code=422, detail=f"item_type must be one of {sorted(ITEM_TYPES)}")
+    # 조회 아이템의 project 접근권(AC2·read exposure 봉인) — 접근권 없는 아이템의 의존성 로스터 차단.
+    await _assert_item_project_access(repo.session, uuid.UUID(auth.user_id), repo.org_id, item_id, item_type)
     deps = await repo.list_by_item(item_id, item_type)
     return [DependencyResponse.model_validate(d) for d in deps]
 
@@ -63,8 +120,16 @@ async def list_dependencies(
 async def delete_dependency(
     id: uuid.UUID,
     repo: DependencyRepository = Depends(_get_repo),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    # 대상 dependency를 선조회해 from·to 양쪽 아이템 project 접근권을 사전검증(AC1). id+org로만 잡던
+    # 것을 양쪽-아이템 게이트로(반쪽 금지). dep 미존재 시 404.
+    dep = await repo.get(id)
+    if dep is None:
+        raise HTTPException(status_code=404, detail="의존성을 찾을 수 없음")
+    user_id = uuid.UUID(auth.user_id)
+    await _assert_item_project_access(repo.session, user_id, repo.org_id, dep.from_id, dep.item_type)
+    await _assert_item_project_access(repo.session, user_id, repo.org_id, dep.to_id, dep.item_type)
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="의존성을 찾을 수 없음")
@@ -77,10 +142,24 @@ async def dependency_graph(
     item_id: uuid.UUID | None = Query(default=None),
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-    _auth=Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> DependencyGraphResponse:
     if item_type not in ITEM_TYPES:
         raise HTTPException(status_code=422, detail=f"item_type must be one of {sorted(ITEM_TYPES)}")
+    user_id = uuid.UUID(auth.user_id)
+    if item_id is not None:
+        await _assert_item_project_access(session, user_id, org_id, item_id, item_type)
+
     item_ids = [item_id] if item_id else None
+    # 그래프/사이클 계산은 org-wide 유지(AC3) — 응답만 caller-accessible project로 필터해 접근권 없는
+    # project의 노드·엣지를 노출하지 않는다(graph read-exposure 봉인).
     nodes, edges = await get_graph(session, org_id, item_type, item_ids)
-    return DependencyGraphResponse(item_type=item_type, nodes=nodes, edges=edges)
+    accessible = set(await accessible_project_ids_in_org(session, user_id, org_id))
+    node_project = await _items_project_map(session, org_id, item_type, nodes)
+    visible = {n for n in nodes if node_project.get(n) in accessible}
+    visible_nodes = [n for n in nodes if n in visible]
+    visible_edges = [
+        e for e in edges
+        if uuid.UUID(e["from_id"]) in visible and uuid.UUID(e["to_id"]) in visible
+    ]
+    return DependencyGraphResponse(item_type=item_type, nodes=visible_nodes, edges=visible_edges)

--- a/backend/tests/authz_coverage_lib.py
+++ b/backend/tests/authz_coverage_lib.py
@@ -61,6 +61,7 @@ PROJECT_GUARD_FUNCTIONS: frozenset[str] = frozenset({
     "_assert_task_project_access",
     "_assert_story_project_access",
     "_assert_hypothesis_project_access",
+    "_assert_item_project_access",
     "_require_doc_project_access",
     "_require_retro_project_access",
 })

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -250,8 +250,9 @@ _ID_MUTATION_KNOWN_DEBT_ALLOWLIST: dict[str, str] = {
     # 조회→hyp.project_id has_project_access·404) 라우터 가드로 봉인 — 스캐너 감시 전환.
     # 라운드3 상환(#5·agent_runs:update_agent_run): resolved-resource(existing.project_id) has_project_access
     # 사전검증으로 same-org cross-project run 덮어쓰기 봉인 — 스캐너 감시 전환.
-    "app.routers.dependencies:delete_dependency":
-        "MEDIUM(borderline) — ItemDependency는 project_id 컬럼 없음·polymorphic from_id/to_id가 project-bound item 참조(semantic cross-project delete). polymorphic 판정 Q2 대기.",
+    # 라운드4 상환(#6·dependencies 서브시스템·story aa365768): create+delete+list+graph 전부 양쪽
+    # -아이템/조회-아이템 project 게이트(_assert_item_project_access)로 봉인·graph 응답 필터. 반쪽
+    # 금지(delete만 아닌 서브시스템 전체). 6후보 상환 완결 → id-뮤테이션 IDOR 계열 known-debt 0.
 }
 
 

--- a/backend/tests/test_e_board_schema_s2_dependency_graph.py
+++ b/backend/tests/test_e_board_schema_s2_dependency_graph.py
@@ -97,7 +97,7 @@ async def test_cycle_chain_detected():
 @pytest.mark.anyio
 async def test_cycle_safe_addition():
     """A→B, A→C 있는 상태에서 B→C 추가는 사이클 없음."""
-    a, b, c = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    _a, b, c = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
 
     call_count = 0
 
@@ -122,6 +122,22 @@ async def test_cycle_safe_addition():
 @pytest.fixture
 def anyio_backend():
     return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _bypass_project_gate():
+    """이 파일은 dependency CRUD/그래프 메커닉을 mock 세션으로 검증한다. 서브시스템 project 게이트
+    (_assert_item_project_access·graph 응답 필터)는 별도 realdb 스위트(test_e_sec_dependencies_
+    subsystem_project_scope_realdb)가 실 PG로 커버하므로, 여기선 no-op/pass-through 패치해 mock
+    세션과의 충돌을 피한다(create/delete/list 가드 우회 + graph 필터를 전-노드 visible로)."""
+    from unittest.mock import patch
+    _p = uuid.uuid4()
+    _pmap = MagicMock()
+    _pmap.get.return_value = _p  # 모든 노드가 accessible project에 속한 것처럼
+    with patch("app.routers.dependencies._assert_item_project_access", new_callable=AsyncMock), \
+         patch("app.routers.dependencies.accessible_project_ids_in_org", new_callable=AsyncMock, return_value=[_p]), \
+         patch("app.routers.dependencies._items_project_map", new_callable=AsyncMock, return_value=_pmap):
+        yield
 
 
 DEP_ID = uuid.uuid4()
@@ -365,7 +381,7 @@ async def test_graph_endpoint_200():
     client, app = await _make_client(mock_session)
     try:
         async with client as c:
-            resp = await c.get(f"/api/v2/dependencies/graph?item_type=story")
+            resp = await c.get("/api/v2/dependencies/graph?item_type=story")
         assert resp.status_code == 200
         body = resp.json()
         assert body["item_type"] == "story"
@@ -402,7 +418,7 @@ async def test_delete_story_cleans_up_dependencies():
     흐름: DELETE /stories/{id} → repo.delete() → DependencyRepository.delete_by_item() 호출.
     이 테스트는 delete_by_item이 실제로 와이어링됐는지 검증 — seed로 우회 없이.
     """
-    from unittest.mock import patch, AsyncMock as AM
+    from unittest.mock import patch
 
     story_id = uuid.uuid4()
     mock_session = AsyncMock()

--- a/backend/tests/test_e_sec_dependencies_subsystem_project_scope_realdb.py
+++ b/backend/tests/test_e_sec_dependencies_subsystem_project_scope_realdb.py
@@ -1,0 +1,302 @@
+"""E-SECURITY 스캐너 #6 서브시스템(story aa365768) — dependencies create/delete/list/graph
+project-scope IDOR, 실 PG.
+
+갭: dependency 서브시스템 전체가 project-blind였다(project_id 컬럼 없음·create/delete/list/graph
+전부 org-scope만). caller가 접근권 없는 project의 아이템 간 의존성을 생성/삭제하거나(무단 mutation)
+그 로스터/그래프를 열람(read exposure)할 수 있었다. fix: 아이템(epic/sprint/story)→project 해소 후
+공통 게이트 — create/delete=양쪽 아이템(from+to) 접근권·list=조회 아이템 접근권·graph=응답을
+caller-accessible project로 필터(사이클/그래프 계산은 org-wide 보존·설계의도 (a) cross-project 허용).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _story(org_id, project_id, title):
+    from app.models.pm import Story
+    return Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title)
+
+
+async def _seed(session):
+    """org(project_a[caller grant]·project_b[무접근]) + story a1/a2(project_a)·b1/b2(project_b) +
+    dep_aa(a1→a2)·dep_bb(b1→b2). item_type=story."""
+    from app.models.dependency import ItemDependency
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    pa = Project(id=uuid.uuid4(), org_id=org.id, name="A")
+    pb = Project(id=uuid.uuid4(), org_id=org.id, name="B")
+    session.add_all([pa, pb])
+    await session.commit()
+    a1, a2, a3 = _story(org.id, pa.id, "A1"), _story(org.id, pa.id, "A2"), _story(org.id, pa.id, "A3")
+    b1, b2 = _story(org.id, pb.id, "B1"), _story(org.id, pb.id, "B2")
+    session.add_all([a1, a2, a3, b1, b2])
+    await session.commit()
+    dep_aa = ItemDependency(id=uuid.uuid4(), org_id=org.id, from_id=a1.id, to_id=a2.id, dep_type="blocks", item_type="story")
+    dep_bb = ItemDependency(id=uuid.uuid4(), org_id=org.id, from_id=b1.id, to_id=b2.id, dep_type="blocks", item_type="story")
+    session.add_all([dep_aa, dep_bb])
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=pa.id, org_member_id=om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "caller_id": caller_id,
+        "a1": a1.id, "a2": a2.id, "a3": a3.id, "b1": b1.id, "b2": b2.id,
+        "dep_aa": dep_aa.id, "dep_bb": dep_bb.id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+async def _dep_count(Session, dep_id):
+    from sqlalchemy import text
+    async with Session() as s:
+        return (await s.execute(
+            text("SELECT count(*) FROM item_dependency WHERE id = :i"), {"i": dep_id}
+        )).scalar_one()
+
+
+# ── create ────────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_dependency_own_project_201():
+    """회귀0: project_a 아이템끼리 의존성 생성 → 201."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/dependencies", json={
+                "from_id": str(seeded["a2"]), "to_id": str(seeded["a3"]),
+                "dep_type": "blocks", "item_type": "story",
+            })
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_dependency_cross_project_blocked_404():
+    """봉인: 접근권 없는 project_b 아이템끼리 의존성 생성 시도 → 404(양쪽 무접근)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/dependencies", json={
+                "from_id": str(seeded["b1"]), "to_id": str(seeded["b2"]),
+                "dep_type": "blocks", "item_type": "story",
+            })
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_dependency_mixed_one_inaccessible_blocked_404():
+    """봉인(양쪽-아이템 규칙·비-동어반복): from=접근O(a1)·to=접근X(b1) 혼합 → 404(한쪽만 무접근도
+    차단). 반쪽 게이트였다면 통과했을 케이스."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/dependencies", json={
+                "from_id": str(seeded["a1"]), "to_id": str(seeded["b1"]),
+                "dep_type": "blocks", "item_type": "story",
+            })
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── delete ────────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_delete_dependency_own_project_200():
+    """회귀0: project_a 의존성 삭제 → 200."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/dependencies/{seeded['dep_aa']}")
+            assert resp.status_code == 200, resp.text
+            assert await _dep_count(Session, seeded["dep_aa"]) == 0
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_delete_dependency_cross_project_blocked_404_not_deleted():
+    """봉인: 접근권 없는 project_b 의존성 삭제 시도 → 404 + **미삭제 직조회**."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/dependencies/{seeded['dep_bb']}")
+            assert resp.status_code == 404, resp.text
+            assert await _dep_count(Session, seeded["dep_bb"]) == 1, "cross-project 의존성이 삭제됨(IDOR)"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── list ──────────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_dependencies_cross_project_blocked_404():
+    """봉인(read exposure): 접근권 없는 project_b 아이템의 의존성 로스터 조회 시도 → 404."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/dependencies?item_type=story&item_id={seeded['b1']}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── graph (AC3: 응답 필터·사이클 org-wide 보존) ─────────────────────────────────
+
+@pytest.mark.anyio
+async def test_dependency_graph_filters_inaccessible_project():
+    """봉인(graph read-exposure·AC3): org-wide graph 조회 시 응답이 caller-accessible project로
+    필터돼 접근권 없는 project_b의 노드(b1/b2)·엣지(dep_bb)가 노출되지 않는다. project_a 것만 보임."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/dependencies/graph?item_type=story")
+            assert resp.status_code == 200, resp.text
+            body = resp.text
+            # project_b 노드는 응답 바디에 verbatim 미노출.
+            assert str(seeded["b1"]) not in body, "graph가 접근권 없는 project 노드 노출(exposure)"
+            assert str(seeded["b2"]) not in body
+            # project_a 노드는 보임(회귀0).
+            data = resp.json()
+            node_strs = {str(n) for n in data["nodes"]}
+            assert str(seeded["a1"]) in node_strs and str(seeded["a2"]) in node_strs
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## dependencies 서브시스템 project-scope 하드닝 — cross-project IDOR 봉인 (스캐너 #6 · 6후보 완결)

스캐너 PATH_ID 축(#2090) **마지막 후보 #6** 상환(story `aa365768`). dependency 서브시스템 **전체가 project-blind**였다(ItemDependency에 `project_id` 컬럼 없음·create/delete/list/graph 전부 org-scope만). caller가 접근권 없는 project의 아이템 간 의존성을 생성/삭제(무단 mutation)하거나 로스터/그래프를 열람(read exposure)할 수 있었다. **realdb 재현 실증**: caller(project_a)가 project_b 의존성 삭제 → 200.

### 설계의도 판정 (PO)
**(a) cross-project dependency 허용하되 접근권으로 게이트** — 멀티프로젝트 org의 합당 use case·구조가 이미 org-wide 그래프. **반쪽 전환 금지** — delete만 아닌 **서브시스템 전체 게이트**.

### fix
- 공통 헬퍼 `_assert_item_project_access`(아이템→project 해소[epic/sprint/story 셋 다 project_id 직접 컬럼]→`has_project_access`·404).
- **create/delete = 양쪽 아이템(from+to) project 접근권**(한쪽만 무접근도 차단).
- **list = 조회 아이템** project 접근권(read exposure 봉인).
- **graph = 응답을 caller-accessible project로 필터**(노드·엣지)·⭐**사이클/그래프 계산은 org-wide 보존**(AC3 — cross-project 사이클도 잡아야 함·project-partition 금지).
- `_KNOWN_DEBT`서 delete_dependency 제거 → **known-debt 0 (6후보 상환 완결)**.

### 검증
신규 realdb **7/7**(create own 201·cross 404·**mixed 한쪽무접근 404**·delete own 200·cross 404+미삭제·list cross 404·**graph 필터 노출0**)·coverage ratchet **8/8**·⭐**sabotage 이중 계열**(헬퍼 무력화→create/delete/list cross 4종 RED·graph 필터 무력화→graph 노출 RED·상보). ruff clean·마이그0. 기존 dependency 32 pass·회귀0.

### 🎯 6후보 완결
epics·hypotheses×3·agent_runs·dependencies — **id-뮤테이션 IDOR 계열 baseline 청산**. 신규 무가드 {id} 뮤테이션은 이제 스캐너 ratchet이 자동 차단.

QA: 까심(4엔드포인트 cross-project·양쪽-아이템 규칙·graph 필터 노출·sabotage 이중계열).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
