### PR TITLE
fix(test-infra): create_all fixture 스키마 자기청소 — migrated-DB teardown 드리프트 봉인 (story 9108cb4f)

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,15 +1,90 @@
 """Shared pytest fixtures for backend tests."""
 import ast
 import os
+import re
 import uuid
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import create_engine, text
 
 # 테스트 환경 기본 환경변수
 os.environ.setdefault("JWT_SECRET", "test-secret-key-for-pytest-only")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# story 9108cb4f: create_all/drop_all 테스트 스키마 자기청소 (migrated-DB teardown 드리프트 봉인).
+#
+# 근본(디디 조사 2026-07-12·실측): create_all 테스트를 alembic-migrated DB에 실행하면 teardown
+# drop_all이 Base.metadata에 없는 migrated-only 오브젝트(team_members VIEW·마이그 전용 FK 등)를
+# 못 지워 DependentObjectsStillExistError로 false-fail한다(fresh empty DB엔 clean). 매 realdb QA에
+# "pre-existing 아티팩트" 노이즈로 반복 등장했다. fix: destructive_schema 테스트 실행 **전에** 대상
+# 스키마를 풀리셋(DROP SCHEMA public CASCADE)해 migrated/잔류 스키마 무관 clean-slate로 만든다 —
+# 이러면 create_all은 항상 빈 스키마 위에 모델 테이블만 짓고(VIEW 없음), teardown drop_all도 clean.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ⛔ 안전가드(비협상): DROP SCHEMA는 파괴적이라 오배치 시 실 DB 전소. dev/prod 마커는 명시 flag가
+# 있어도 하드-거부(deny-list)하고, 그 외엔 테스트 신호(이름 패턴) 또는 명시 opt-in env가 있을 때만
+# 허용(allow-list). 둘 다 통과해야 리셋 — 아니면 즉시 fail-fast(실 DB는 절대 건드리지 않는다).
+_FORBIDDEN_DB_RE = re.compile(r"prod|production|sprintable-dev|sprintable-prod", re.IGNORECASE)
+_TEST_DB_SIGNAL_RE = re.compile(r"test|parity|_ca\d*|_ci\b|ci_|ephemeral|scratch|tmp", re.IGNORECASE)
+
+
+def _db_name(url: str) -> str:
+    return url.rsplit("/", 1)[-1].split("?")[0] if "/" in url else url
+
+
+def assert_disposable_test_db(url: str) -> None:
+    """DROP SCHEMA 대상이 disposable 테스트 DB임을 강제. dev/prod 마커면 무조건 거부, 테스트 신호도
+    opt-in flag도 없으면 거부. 통과 못 하면 RuntimeError로 즉시 fail-fast(파괴 DDL 미실행)."""
+    name = _db_name(url)
+    if _FORBIDDEN_DB_RE.search(url):
+        raise RuntimeError(
+            f"안전가드: DROP SCHEMA 대상 URL에 dev/prod 마커 — 파괴 DDL 거부(DB='{name}'). "
+            "테스트 스키마 리셋은 실 DB에서 절대 실행되지 않습니다."
+        )
+    allow_flag = os.environ.get("ALLOW_DESTRUCTIVE_SCHEMA_RESET") == "1"
+    if not (_TEST_DB_SIGNAL_RE.search(name) or allow_flag):
+        raise RuntimeError(
+            f"안전가드: DROP SCHEMA는 테스트 DB(이름에 test/parity/ci 등) 또는 "
+            f"ALLOW_DESTRUCTIVE_SCHEMA_RESET=1 일 때만 허용 — 거부(DB='{name}')."
+        )
+
+
+def _sync_url(url: str) -> str:
+    for prefix in ("postgresql+asyncpg://", "postgresql+psycopg2://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+psycopg2://" + url[len(prefix):]
+    return url
+
+
+def _reset_public_schema(url: str) -> None:
+    """대상 스키마 풀리셋 — DROP SCHEMA public CASCADE; CREATE SCHEMA public; + 필요한 extension
+    재생성(vector 등, baseline/모델이 요구). 안전가드 통과 후에만 호출."""
+    assert_disposable_test_db(url)
+    engine = create_engine(_sync_url(url))
+    try:
+        with engine.begin() as conn:
+            conn.execute(text("DROP SCHEMA IF EXISTS public CASCADE"))
+            conn.execute(text("CREATE SCHEMA public"))
+            conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _reset_schema_for_destructive_tests(request):
+    """destructive_schema 마커 테스트는 실행 **전** 대상 스키마를 풀리셋해 clean-slate 보장(9108cb4f).
+    마커 없는 테스트엔 no-op. realdb URL(PARITY/ALEMBIC) 미설정 시(=테스트 skip 대상) 리셋 생략."""
+    if request.node.get_closest_marker(_MARKER_NAME) is None:
+        yield
+        return
+    url = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+    if url:
+        _reset_public_schema(url)
+    yield
 
 
 # story 8236bbc3: destructive_schema 마커 drift 자기표면화 가드(PO crux 게이트②, 2026-07-03).

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -29,7 +29,14 @@ os.environ.setdefault("JWT_SECRET", "test-secret-key-for-pytest-only")
 # 있어도 하드-거부(deny-list)하고, 그 외엔 테스트 신호(이름 패턴) 또는 명시 opt-in env가 있을 때만
 # 허용(allow-list). 둘 다 통과해야 리셋 — 아니면 즉시 fail-fast(실 DB는 절대 건드리지 않는다).
 _FORBIDDEN_DB_RE = re.compile(r"prod|production|sprintable-dev|sprintable-prod", re.IGNORECASE)
-_TEST_DB_SIGNAL_RE = re.compile(r"test|parity|_ca\d*|_ci\b|ci_|ephemeral|scratch|tmp", re.IGNORECASE)
+# ⚠️ 까심 QA(#2095 RC): 테스트 신호는 반드시 **토큰 경계**로 매치한다 — substring 매치는 fail-open이라
+# "test"가 다른 단어 안에 우연히 든 실 DB 이름(customer_data_latest·contest_entries·protest_data·
+# orders_latest_snapshot)이 opt-in 없이 통과해 파괴적 DROP SCHEMA가 발동했다. `_`/`-` 또는 문자열
+# 경계로 구분된 **온전한 토큰**일 때만 인정(latest 안의 test·contest 안의 test는 불인정).
+_TEST_DB_SIGNAL_RE = re.compile(
+    r"(?:^|[_-])(?:test\d*|parity|ci|ca\d+|ephemeral|scratch|tmp)(?=$|[_-])",
+    re.IGNORECASE,
+)
 
 
 def _db_name(url: str) -> str:

--- a/backend/tests/test_schema_reset_safety_guard.py
+++ b/backend/tests/test_schema_reset_safety_guard.py
@@ -48,6 +48,34 @@ def test_rejects_unrecognized_dbs_without_optin(url):
         assert_disposable_test_db(url)
 
 
+@pytest.mark.parametrize("url", [
+    # 까심 QA(#2095 RC) fail-open 회귀 방지: "test"/"latest"가 다른 단어 안에 우연히 포함된 실 DB
+    # 이름 — substring 매치면 통과했으나 토큰 경계 매치로 반드시 거부(dev/prod 마커도 없어 deny-list
+    # 도 안 걸리는 "모르는 DB"라 파괴 DDL 절대 불가).
+    "postgresql+psycopg2://u@host:5432/customer_data_latest",
+    "postgresql+psycopg2://u@host:5432/contest_entries",
+    "postgresql+psycopg2://u@host:5432/protest_data",
+    "postgresql+psycopg2://u@host:5432/orders_latest_snapshot",
+    "postgresql+psycopg2://u@host:5432/precision_analytics",
+    "postgresql+psycopg2://u@host:5432/municipal_records",
+])
+def test_rejects_substring_fail_open_names(url):
+    """substring fail-open 봉인: 'test'가 latest/contest/protest 안에 우연히 들어도 토큰 경계가
+    아니면 테스트 신호로 불인정 → 거부(까심 적출 catastrophic fail-open)."""
+    with pytest.raises(RuntimeError, match="안전가드"):
+        assert_disposable_test_db(url)
+
+
+@pytest.mark.parametrize("url", [
+    # CI 실 DB명은 반드시 허용돼야 한다(과잉거부 회귀 방지 — 토큰 경계로 test 온전 포함).
+    "postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test",
+    "postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test_iso",
+])
+def test_allows_ci_db_names(url):
+    """CI가 쓰는 sprintable_test / sprintable_test_iso는 test 온전 토큰이라 허용(guard가 CI를 막지 않음)."""
+    assert_disposable_test_db(url)
+
+
 def test_optin_flag_allows_unrecognized(monkeypatch):
     """명시 opt-in(ALLOW_DESTRUCTIVE_SCHEMA_RESET=1)이면 테스트-신호 없는 이름도 허용 —
     단 prod/dev 마커는 flag가 있어도 여전히 거부(deny-list 우선)."""

--- a/backend/tests/test_schema_reset_safety_guard.py
+++ b/backend/tests/test_schema_reset_safety_guard.py
@@ -1,0 +1,57 @@
+"""story 9108cb4f 안전가드 테스트 — DROP SCHEMA 자기청소가 dev/prod DB를 절대 건드리지 않는지.
+
+⛔ 이 가드가 없으면 스키마 리셋 fixture 자체가 사고 무기(오배치 시 실 DB 전소). 까심 QA 핵심:
+dev/prod URL이 확실히 거부되고, 테스트 DB만 허용되는지. realdb 불요(순수 로직 단위 테스트)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from conftest import assert_disposable_test_db  # noqa: E402
+
+
+@pytest.mark.parametrize("url", [
+    "postgresql+psycopg2://u@localhost:5432/steer_test2",
+    "postgresql+psycopg2://u@localhost:5432/backend_parity",
+    "postgresql+asyncpg://u@localhost:5432/ci_scratch",
+    "postgresql://u@localhost:5432/ephemeral_1234",
+])
+def test_allows_disposable_test_dbs(url):
+    """테스트 신호(test/parity/ci/ephemeral) 있는 DB는 허용(예외 없음)."""
+    assert_disposable_test_db(url)  # should not raise
+
+
+@pytest.mark.parametrize("url", [
+    "postgresql+psycopg2://u@/cloudsql/moonklabs:asia:sprintable-prod/sprintable",
+    "postgresql+psycopg2://u@10.0.0.5:5432/sprintable-dev",
+    "postgresql+psycopg2://u@host:5432/production",
+    "postgresql+psycopg2://u@host:5432/sprintable_prod",
+])
+def test_rejects_dev_prod_dbs(url):
+    """⛔ dev/prod 마커 DB는 무조건 거부(RuntimeError·파괴 DDL 미실행)."""
+    with pytest.raises(RuntimeError, match="안전가드"):
+        assert_disposable_test_db(url)
+
+
+@pytest.mark.parametrize("url", [
+    "postgresql+psycopg2://u@host:5432/randomname",
+    "postgresql+psycopg2://u@host:5432/app_main",
+    "postgresql+psycopg2://u@host:5432/customer_data",
+])
+def test_rejects_unrecognized_dbs_without_optin(url):
+    """테스트 신호도 opt-in flag도 없는 DB는 거부(fail-safe·모르는 DB는 안 건드림)."""
+    with pytest.raises(RuntimeError, match="안전가드"):
+        assert_disposable_test_db(url)
+
+
+def test_optin_flag_allows_unrecognized(monkeypatch):
+    """명시 opt-in(ALLOW_DESTRUCTIVE_SCHEMA_RESET=1)이면 테스트-신호 없는 이름도 허용 —
+    단 prod/dev 마커는 flag가 있어도 여전히 거부(deny-list 우선)."""
+    monkeypatch.setenv("ALLOW_DESTRUCTIVE_SCHEMA_RESET", "1")
+    assert_disposable_test_db("postgresql+psycopg2://u@host:5432/randomname")  # ok with flag
+    with pytest.raises(RuntimeError, match="안전가드"):
+        assert_disposable_test_db("postgresql+psycopg2://u@host:5432/sprintable-prod")  # deny-list 우선


### PR DESCRIPTION
## create_all fixture 스키마 자기청소 — migrated-DB teardown 드리프트 계열 봉인 (story `9108cb4f`)

### 근본 (조사·실측)
`create_all`/`drop_all`(destructive_schema) 테스트를 alembic-migrated DB에 실행하면 teardown `drop_all`이 `Base.metadata`에 없는 **migrated-only 오브젝트**(`team_members` VIEW·마이그 전용 FK `fk_artifact_versions_source_comment_id` 등)를 못 지워 `DependentObjectsStillExistError`로 false-fail. **fresh empty DB엔 clean.** 매 realdb QA에 "pre-existing·PR무관 아티팩트" 노이즈로 반복 등장했다(fk_artifact_versions는 **증상 하나**·진짜 클래스=migrated-DB teardown drift).

### fix
conftest 공유 **autouse fixture** — destructive_schema 마커 테스트 실행 **전** 대상 스키마를 풀리셋(`DROP SCHEMA public CASCADE; CREATE SCHEMA public;` + vector 재생성)해 migrated/잔류 스키마 무관 **clean-slate** 보장. create_all이 항상 빈 스키마 위에 모델 테이블만 짓고(VIEW 없음) teardown도 clean. 마커 없는(migrated-mode) 테스트엔 **no-op** — 공유 migrated `sprintable_test`는 절대 안 건드림.

### ⛔ 안전가드 (비협상 · 까심 QA 핵심)
DROP SCHEMA는 파괴적 → 오배치 시 실 DB 전소. `assert_disposable_test_db()`:
- ①**dev/prod 마커**(prod/production/sprintable-dev/sprintable-prod) **하드-거부**(deny-list·flag 있어도).
- ②**테스트 신호**(test/parity/ci/ephemeral 등) 또는 `ALLOW_DESTRUCTIVE_SCHEMA_RESET=1` 없으면 거부(allow-list).
- 둘 다 통과해야 리셋·아니면 `RuntimeError` **fail-fast**. **dev/prod URL은 절대 실행 안 됨.**

### 검증
- 안전가드 단위 **12/12**(test DB 허용·dev/prod 거부·미인식 이름 거부·opt-in flag는 미인식만 허용하되 prod/dev는 여전히 거부).
- ⭐**전 destructive_schema 테스트(381개)를 단일 공유 DB 한 invocation에서 377 pass** — 기존엔 CI가 파일별 dropdb/createdb 격리 필요했던 것을 pre-reset 자기청소로 **order-independent**화. (잔여 4=test_a2a_sa1/sa4 **pristine develop서도 동일 실패**=본 변경 무관·stash 대조.)
- migrated 테스트 no-op 확認·mock 테스트 무영향·ruff clean·**마이그0**·CI 무변경(파일별 격리는 무해 잔존).

참고: FK명 파리티 갭(모델 use_alter-named `fk_` ↔ 마이그 `_fkey`)은 **별개 이슈**(마이그 편집·prod 함의)로 본 PR 미포함·별도 트래킹.

QA 핵심: **안전가드가 dev/prod URL을 확실히 거부하는지**(test_schema_reset_safety_guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
