### PR TITLE
test(security): sibling-asymmetry advisory 공허-통과 갭 봉인 — positive 하한 이빨 (story 27e339bc)

### DIFF
--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -370,3 +370,36 @@ def test_sibling_asymmetry_advisory_surfaces_high_confidence_candidates():
     for r in surfaced:
         assert r.key in id_route_keys, f"advisory가 id-뮤테이션 아닌 라우트 surface: {r.key}"
         assert not has_id_mutation_guard(r), f"advisory가 guarded 라우트 surface(오탐): {r.key}"
+
+
+def test_sibling_asymmetry_advisory_has_teeth_on_synthetic_app():
+    """공허-통과 봉인(까심 #2093 QA·27e339bc fast-follow): 위 계약 테스트는 surfaced==[]면 for-루프가
+    **공허참**으로 통과 → advisory가 return []로 죽어도(휴리스틱 침묵) 못 잡는다. 합성 앱에 [guarded
+    project 형제(project_id param+has_project_access) + 미가드 {id}-뮤테이션]을 같은 모듈에 심어
+    advisory가 **최소 1건 surface**함을 실증(positive 하한 단언). 휴리스틱이 조용히 죽으면 RED."""
+    import uuid
+
+    from fastapi import FastAPI
+
+    from app.services.project_auth import has_project_access
+    from authz_coverage_lib import sibling_asymmetry_advisory
+
+    app = FastAPI()
+
+    @app.get("/synthadv/{project_id}/items")  # guarded project 형제 — 이 모듈을 guarded module로 만듦
+    async def _synthadv_list(project_id: uuid.UUID):  # noqa: ANN202
+        await has_project_access(None, None, project_id, None)  # noqa — 존재만 검증(AST 스캔 대상)
+        return []
+
+    @app.delete("/synthadv/{id}")  # 미가드 {id}-뮤테이션(같은 모듈) — advisory가 집어야 함
+    async def _synthadv_delete(id: uuid.UUID):  # noqa: ANN202
+        return {"ok": True}
+
+    surfaced = sibling_asymmetry_advisory(app)
+    assert len(surfaced) >= 1, (
+        "advisory가 [guarded 형제 + 미가드 {id}-뮤테이션] 모듈에서 아무것도 surface 안 함 — "
+        "휴리스틱이 조용히 죽었다(sibling_asymmetry_advisory return [] 회귀)."
+    )
+    assert any(r.qualname.endswith("_synthadv_delete") for r in surfaced), (
+        "advisory가 미가드 {id}-뮤테이션(_synthadv_delete)을 못 집음"
+    )


### PR DESCRIPTION
## sibling-asymmetry advisory 공허-통과 갭 봉인 — positive 하한 이빨 (story `27e339bc`)

까심 #2093 QA 발견(비-블로커 fast-follow). advisory 계약 테스트가 `surfaced==[]`면 `for r in surfaced` 루프가 **공허참**으로 통과 → `sibling_asymmetry_advisory()`가 `return []`로 죽어도(휴리스틱 침묵) 회귀를 못 잡았다. 비-강제 신호지만 회귀가드 없이는 휴리스틱이 조용히 죽을 수 있다.

### fix
합성 앱 **positive 하한 테스트** 추가 — `[guarded project 형제(project_id param+has_project_access) + 미가드 {id}-뮤테이션]`을 같은 모듈에 심어 advisory가 **최소 1건 surface**함을 실증. `return []` 회귀 시 RED. 기존 계약 테스트(surface 엔트리 유효성)는 보존.

### 검증
coverage 스위트 **8→9 pass**·⭐**sabotage로 갭 봉인 실증**(advisory를 `return []`로 무력화 → **신규 이빨 테스트 RED · 기존 계약 테스트는 여전히 pass** = 까심 지적 공허-통과 재현 + 봉인 확認). ruff clean·**마이그0**·**test-only**.

QA: 까심(합성 앱 하한 단언·sabotage로 return [] 회귀 잡히는지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
