### PR TITLE
feat(glance): glance/attention 예외 스트림 엔드포인트 — project-scope human-attention 실신호 (story db7eb049)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,7 +57,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import a2a, account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, retros, rewards, role_templates, runtime_capabilities, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import a2a, account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, retros, rewards, role_templates, runtime_capabilities, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -198,6 +198,7 @@ app.include_router(command_center.router)
 app.include_router(rewards.router)
 app.include_router(audit_logs.router)
 app.include_router(dashboard.router)
+app.include_router(glance.router)
 app.include_router(current_project.router)
 app.include_router(runtime_capabilities.router)
 app.include_router(members.router)

--- a/backend/app/routers/glance.py
+++ b/backend/app/routers/glance.py
@@ -1,0 +1,135 @@
+"""글랜스 '손이 필요한 것' 예외 스트림 BE (story db7eb049·E-GLANCE 2D).
+
+현 프로젝트의 human-attention **실신호만** 반환한다 — gate_pending(인간 승인 대기)·blocked(의존 대기)·
+merge_ready(리뷰/머지 대기). 유나 spec(glance-focus-legible-fe-spec-handoff ⓓ) 계약: 활동량/타임스탬프/
+순위 0·감시 아니라 신뢰(주어=프로젝트/팀·예외만)·실신호 없으면 정직 빈배열(FE "손 필요한 것 없음").
+3 신호 전부 project_id 직스코프(approval.project_id·story.project_id 직결·조인은 title enrich만).
+"""
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.models.dependency import ItemDependency
+from app.models.gate import Gate
+from app.models.pm import Story
+from app.models.workflow_line import WorkflowLineStepApproval
+from app.services.project_auth import has_project_access
+
+router = APIRouter(prefix="/api/v2/glance", tags=["glance"])
+
+# blocked/merge_ready 판정의 "아직 open" = non-done(command_center 규율 재사용).
+_OPEN_EXCLUDED_STATUSES = ("done",)
+_LIMIT = 100
+
+
+class AttentionItem(BaseModel):
+    kind: str  # "gate_pending" | "blocked" | "merge_ready"
+    story_id: uuid.UUID | None = None
+    title: str | None = None
+    ref: dict = Field(default_factory=dict)
+
+
+class AttentionResponse(BaseModel):
+    items: list[AttentionItem]
+
+
+@router.get("/attention", response_model=AttentionResponse)
+async def glance_attention(
+    project_id: uuid.UUID = Query(...),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> AttentionResponse:
+    """현 프로젝트 예외 스트림. project-scope 실신호만·활동량/순위 0·없으면 빈배열."""
+    # project-scope 가드(resource-actual): 접근권 없는 project의 예외 신호 노출 차단(404·존재 비노출).
+    if not await has_project_access(session, uuid.UUID(auth.user_id), project_id, org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    items: list[AttentionItem] = []
+
+    # ① gate_pending = 프로젝트의 pending blocking approval(그 gate의 story title enrich).
+    gate_story = aliased(Story)
+    gate_rows = (
+        await session.execute(
+            select(
+                WorkflowLineStepApproval.id,
+                WorkflowLineStepApproval.gate_id,
+                gate_story.id,
+                gate_story.title,
+            )
+            .select_from(WorkflowLineStepApproval)
+            .outerjoin(Gate, Gate.id == WorkflowLineStepApproval.gate_id)
+            .outerjoin(
+                gate_story,
+                (gate_story.id == Gate.work_item_id) & (Gate.work_item_type == "story"),
+            )
+            .where(
+                WorkflowLineStepApproval.org_id == org_id,
+                WorkflowLineStepApproval.project_id == project_id,
+                WorkflowLineStepApproval.status == "pending",
+                WorkflowLineStepApproval.blocking.is_(True),
+            )
+            .limit(_LIMIT)
+        )
+    ).all()
+    for approval_id, gate_id, story_id, title in gate_rows:
+        items.append(AttentionItem(
+            kind="gate_pending",
+            story_id=story_id,
+            title=title,
+            ref={"approval_id": str(approval_id), "gate_id": str(gate_id) if gate_id else None},
+        ))
+
+    # ② blocked = 프로젝트의 open story를 막고 있는 미해소 blocks-dependency(막는 쪽도 미완).
+    blocker = aliased(Story)
+    blocked = aliased(Story)
+    blocked_rows = (
+        await session.execute(
+            select(blocked.id, blocked.title, blocker.id)
+            .select_from(ItemDependency)
+            .join(blocker, blocker.id == ItemDependency.from_id)
+            .join(blocked, blocked.id == ItemDependency.to_id)
+            .where(
+                ItemDependency.org_id == org_id,
+                ItemDependency.dep_type == "blocks",
+                ItemDependency.item_type == "story",
+                blocked.project_id == project_id,
+                blocked.status.not_in(_OPEN_EXCLUDED_STATUSES),
+                blocked.deleted_at.is_(None),
+                blocker.status.not_in(_OPEN_EXCLUDED_STATUSES),
+                blocker.deleted_at.is_(None),
+            )
+            .limit(_LIMIT)
+        )
+    ).all()
+    for blocked_id, title, blocker_id in blocked_rows:
+        items.append(AttentionItem(
+            kind="blocked",
+            story_id=blocked_id,
+            title=title,
+            ref={"blocker_story_id": str(blocker_id)},
+        ))
+
+    # ③ merge_ready = 프로젝트의 in-review story(리뷰/머지 대기).
+    review_rows = (
+        await session.execute(
+            select(Story.id, Story.title)
+            .where(
+                Story.org_id == org_id,
+                Story.project_id == project_id,
+                Story.status == "in-review",
+                Story.deleted_at.is_(None),
+            )
+            .limit(_LIMIT)
+        )
+    ).all()
+    for story_id, title in review_rows:
+        items.append(AttentionItem(kind="merge_ready", story_id=story_id, title=title))
+
+    return AttentionResponse(items=items)

--- a/backend/tests/test_e_glance_attention_realdb.py
+++ b/backend/tests/test_e_glance_attention_realdb.py
@@ -1,0 +1,209 @@
+"""E-GLANCE glance/attention 예외 스트림 BE (story db7eb049) — 실 PG.
+
+현 프로젝트 human-attention 실신호 3종(gate_pending·blocked·merge_ready)을 project-scope로 반환하고
+접근권 없는 project는 404(존재 비노출)·신호 없으면 빈배열임을 실증.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _story(org_id, project_id, title, status="in-progress"):
+    from app.models.pm import Story
+    return Story(id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=title, status=status)
+
+
+async def _seed(session):
+    """project_a(grant·3신호 다 有)·project_b(무접근)·project_c(grant·신호0)."""
+    from app.models.gate import Gate
+    from app.models.dependency import ItemDependency
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+    from app.models.workflow_line import WorkflowLineStepApproval
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    pa = Project(id=uuid.uuid4(), org_id=org.id, name="A")
+    pb = Project(id=uuid.uuid4(), org_id=org.id, name="B")
+    pc = Project(id=uuid.uuid4(), org_id=org.id, name="C")
+    session.add_all([pa, pb, pc])
+    await session.commit()
+
+    # gate_pending: story_g + gate(story) + pending blocking approval(project_a).
+    story_g = _story(org.id, pa.id, "Gate Story")
+    session.add(story_g)
+    await session.commit()
+    gate = Gate(id=uuid.uuid4(), org_id=org.id, work_item_id=story_g.id, work_item_type="story",
+                gate_type="review", status="pending")
+    session.add(gate)
+    await session.commit()
+    session.add(WorkflowLineStepApproval(
+        id=uuid.uuid4(), org_id=org.id, project_id=pa.id, step_run_id=uuid.uuid4(),
+        approval_group_id=uuid.uuid4(), approver_member_id=uuid.uuid4(), approver_member_type="agent",
+        gate_id=gate.id, kind="approver", blocking=True, status="pending",
+    ))
+    # blocked: story_blocked(open) blocked-by story_blocker(open) in project_a.
+    story_blocker = _story(org.id, pa.id, "Blocker")
+    story_blocked = _story(org.id, pa.id, "Blocked Story")
+    session.add_all([story_blocker, story_blocked])
+    await session.commit()
+    session.add(ItemDependency(
+        id=uuid.uuid4(), org_id=org.id, from_id=story_blocker.id, to_id=story_blocked.id,
+        dep_type="blocks", item_type="story",
+    ))
+    # merge_ready: in-review story in project_a.
+    session.add(_story(org.id, pa.id, "Review Story", status="in-review"))
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(om)
+    await session.commit()
+    # caller는 project_a·project_c만 grant(project_b 무접근).
+    session.add_all([
+        ProjectAccess(id=uuid.uuid4(), project_id=pa.id, org_member_id=om.id, permission="granted", role="member"),
+        ProjectAccess(id=uuid.uuid4(), project_id=pc.id, org_member_id=om.id, permission="granted", role="member"),
+    ])
+    await session.commit()
+
+    return {"org_id": org.id, "caller_id": caller_id, "pa": pa.id, "pb": pb.id, "pc": pc.id,
+            "gate_story_title": "Gate Story"}
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_attention_own_project_returns_all_three_signals():
+    """회귀0: project_a grant caller → 3신호(gate_pending·blocked·merge_ready) 다 반환·gate title enrich."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/glance/attention?project_id={seeded['pa']}")
+            assert resp.status_code == 200, resp.text
+            items = resp.json()["items"]
+            kinds = {i["kind"] for i in items}
+            assert kinds == {"gate_pending", "blocked", "merge_ready"}, kinds
+            gate = next(i for i in items if i["kind"] == "gate_pending")
+            assert gate["title"] == seeded["gate_story_title"]  # title enrich via gate→story
+            blocked = next(i for i in items if i["kind"] == "blocked")
+            assert blocked["title"] == "Blocked Story"
+            assert "blocker_story_id" in blocked["ref"]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_attention_cross_project_blocked_404():
+    """봉인: 접근권 없는 project_b 예외 스트림 조회 시도 → 404(존재 비노출·read exposure 차단)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/glance/attention?project_id={seeded['pb']}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_attention_empty_project_returns_empty_array():
+    """정직 빈상태: 신호 없는 project_c(grant) → 200 + items=[](FE '손 필요한 것 없음' 폴백·억지 0)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/glance/attention?project_id={seeded['pc']}")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["items"] == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## glance/attention 예외 스트림 엔드포인트 — project-scope human-attention 실신호 (story `db7eb049`)

E-GLANCE 2D 예외 스트림("손이 필요한 것") BE. 유나 spec(`glance-focus-legible-fe-spec-handoff` ⓓ) 계약: 현 프로젝트의 human-attention **실신호 3종만** — gate_pending(인간 승인 대기)·blocked(의존 대기)·merge_ready(리뷰/머지 대기). **활동량/타임스탬프/순위 0**·감시 아니라 신뢰·실신호 없으면 **정직 빈배열**(FE "손 필요한 것 없음").

### 조사 판정
신호 쿼리 로직은 `command_center /my-actions`에 존재하나 **member-private/org-scope**라 project-team 뷰 아님 → 신규 최소 project-scoped 엔드포인트. `approval.project_id`가 직접 NOT NULL이라 **3신호 전부 project_id 직스코프**(조인은 gate title enrich만).

### 구현
- `GET /api/v2/glance/attention?project_id=` — **has_project_access 가드**(resource-actual·404·존재 비노출·⭐내가 만든 스캐너 PROJECT_PARAM 축이 이 라우트를 guarded로 인식). items `[{kind, story_id, title, ref}]`·빈배열 폴백.
- 신규 라우트 = BE API 1개(FE `/glance`는 loadGlanceData fetch 1줄·라우트0).

### 검증
신규 realdb **3/3**(3신호 다 반환+title enrich·cross-project 404·빈 project 200+[])·coverage ratchet **9/9**·⭐**sabotage 이중 이빨**(가드 무력화→cross-project 404 test + **스캐너 ratchet 둘 다 RED** = 이 세션 만든 스캐너가 신규 라우트 자동 가드). ruff clean·**마이그0**.

미르코 빈상태 폴백에 배선(병렬). QA: 까심(3신호 project-scope·cross-project 404·빈배열·title enrich).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
