### PR TITLE
feat(glance): hero ProofCapsule envelope — story evidence 리치 배선 (story b464daa1)

### DIFF
--- a/backend/app/routers/glance.py
+++ b/backend/app/routers/glance.py
@@ -6,17 +6,20 @@ merge_ready(리뷰/머지 대기). 유나 spec(glance-focus-legible-fe-spec-hand
 3 신호 전부 project_id 직스코프(approval.project_id·story.project_id 직결·조인은 title enrich만).
 """
 import uuid
+from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.dependency import ItemDependency
+from app.models.evidence import Evidence
 from app.models.gate import Gate
+from app.models.member import Member
 from app.models.pm import Story
 from app.models.workflow_line import WorkflowLineStepApproval
 from app.services.project_auth import has_project_access
@@ -133,3 +136,161 @@ async def glance_attention(
         items.append(AttentionItem(kind="merge_ready", story_id=story_id, title=title))
 
     return AttentionResponse(items=items)
+
+
+# ── hero ProofCapsule envelope (story b464daa1·E-GLANCE 2D) ─────────────────────
+# 현재 에픽 활성 story의 Proof Capsule 소비 계약. no-fiction(계약 doc glance-hero-proofcapsule
+# -be-contract): 정직 소스만 — claim·status·proof_count·auto_verify(merge gate)·gate 구조필드·
+# trustSeal(self_reported/human_verified·E-VERIFY V0-S2·스푸핑불가). ⛔미포함(발명 금지):
+# ac_met/ac_total(acceptance_criteria=freeform Text)·risk(플랫폼 위험도판정 안 함)·diff(미저장).
+# PO判定(2026-07-12): BE는 구조화 필드만·표시문자열/라벨 금지(i18n=FE lane)·라벨 합성은 FE가
+# decision_basis/auto_decision_reason verbatim으로.
+_AUTO_VERIFY_MAP = {"sufficient": "passed", "blocked": "failed"}
+
+
+class HeroMember(BaseModel):
+    member_id: uuid.UUID
+    name: str
+    role: str | None = None
+
+
+class HeroTrust(BaseModel):
+    self_reported: bool
+    human_verified: bool
+    human_verified_by: HeroMember | None = None
+    human_verified_at: datetime | None = None
+
+
+class HeroGate(BaseModel):
+    status: str
+    gate_type: str
+    requires_human: bool
+    decision_basis: str | None = None  # verbatim(FE가 라벨 합성)
+    auto_decision_reason: str | None = None  # verbatim
+
+
+class HeroResponse(BaseModel):
+    story_id: uuid.UUID
+    claim: str
+    status: str
+    proof_count: int
+    auto_verify: str | None = None  # "passed" | "failed" | null
+    gate: HeroGate | None = None
+    trust: HeroTrust
+
+
+@router.get("/hero", response_model=HeroResponse)
+async def glance_hero(
+    story_id: uuid.UUID = Query(...),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> HeroResponse:
+    """현재 에픽 활성 story의 Proof Capsule 소비 payload. project-scope 가드·no-fiction 구조필드만."""
+    story = (
+        await session.execute(
+            select(Story).where(
+                Story.id == story_id, Story.org_id == org_id, Story.deleted_at.is_(None)
+            )
+        )
+    ).scalar_one_or_none()
+    # resolved-resource project-scope 가드(404·존재 비노출·스캐너 PROJECT_PARAM 감시축).
+    if story is None or not await has_project_access(
+        session, uuid.UUID(auth.user_id), story.project_id, org_id
+    ):
+        raise HTTPException(status_code=404, detail="Story not found")
+
+    # proof_count = evidence row 개수 → self_reported.
+    proof_count = (
+        await session.execute(
+            select(func.count(Evidence.id)).where(
+                Evidence.org_id == org_id,
+                Evidence.work_item_id == story_id,
+                Evidence.work_item_type == "story",
+            )
+        )
+    ).scalar_one()
+
+    # human_verified = 최신 gate_approval evidence(휴먼 서명·스푸핑불가). by/at + member name/role.
+    hv = (
+        await session.execute(
+            select(Evidence.created_by, Evidence.created_at)
+            .where(
+                Evidence.org_id == org_id,
+                Evidence.work_item_id == story_id,
+                Evidence.work_item_type == "story",
+                Evidence.type == "gate_approval",
+            )
+            .order_by(Evidence.created_at.desc())
+            .limit(1)
+        )
+    ).first()
+    hv_member: HeroMember | None = None
+    hv_at: datetime | None = None
+    if hv is not None:
+        hv_by, hv_at = hv
+        m = (
+            await session.execute(
+                select(Member.name, Member.org_role).where(Member.id == hv_by)
+            )
+        ).first()
+        hv_member = HeroMember(member_id=hv_by, name=m[0] if m else "", role=m[1] if m else None)
+
+    trust = HeroTrust(
+        self_reported=proof_count > 0,
+        human_verified=hv is not None,
+        human_verified_by=hv_member,
+        human_verified_at=hv_at,
+    )
+
+    # auto_verify = story의 merge gate evidence_status(없으면 null·대부분 story).
+    merge_status = (
+        await session.execute(
+            select(Gate.evidence_status)
+            .where(
+                Gate.org_id == org_id,
+                Gate.work_item_id == story_id,
+                Gate.work_item_type == "story",
+                Gate.gate_type == "merge",
+            )
+            .order_by(Gate.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    auto_verify = _AUTO_VERIFY_MAP.get(merge_status) if merge_status else None
+
+    # gate = story의 현재 pending gate(결정점) 구조필드·없으면 null.
+    gate_row = (
+        await session.execute(
+            select(Gate)
+            .where(
+                Gate.org_id == org_id,
+                Gate.work_item_id == story_id,
+                Gate.work_item_type == "story",
+                Gate.status == "pending",
+            )
+            .order_by(Gate.created_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    gate = (
+        HeroGate(
+            status=gate_row.status,
+            gate_type=gate_row.gate_type,
+            requires_human=gate_row.requires_human,
+            decision_basis=gate_row.decision_basis,
+            auto_decision_reason=gate_row.auto_decision_reason,
+        )
+        if gate_row is not None
+        else None
+    )
+
+    return HeroResponse(
+        story_id=story_id,
+        claim=story.title,
+        status=story.status,
+        proof_count=proof_count,
+        auto_verify=auto_verify,
+        gate=gate,
+        trust=trust,
+    )

--- a/backend/tests/test_e_glance_hero_realdb.py
+++ b/backend/tests/test_e_glance_hero_realdb.py
@@ -1,0 +1,217 @@
+"""E-GLANCE hero ProofCapsule envelope (story b464daa1) — 실 PG.
+
+현재 에픽 활성 story의 Proof Capsule 소비 payload를 no-fiction 정직 소스로 반환하고(claim·proof_count·
+auto_verify·gate 구조필드·trustSeal), project-scope 가드(cross-project 404)·무증거 story 정직 최소
+(proof_count 0·self_reported False·auto_verify null·gate null)임을 실증. ac_met/risk/diff는 계약상 미포함.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    from app.models.evidence import Evidence
+    from app.models.gate import Gate
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    pa = Project(id=uuid.uuid4(), org_id=org.id, name="A")
+    pb = Project(id=uuid.uuid4(), org_id=org.id, name="B")
+    session.add_all([pa, pb])
+    await session.commit()
+
+    # story_full: rich signals. story_empty: 무증거. story_b: cross-project.
+    story_full = Story(id=uuid.uuid4(), org_id=org.id, project_id=pa.id, title="Full Story", status="in-review")
+    story_empty = Story(id=uuid.uuid4(), org_id=org.id, project_id=pa.id, title="Empty Story", status="in-progress")
+    story_b = Story(id=uuid.uuid4(), org_id=org.id, project_id=pb.id, title="B Story", status="in-progress")
+    session.add_all([story_full, story_empty, story_b])
+    await session.commit()
+
+    reviewer = Member(id=uuid.uuid4(), org_id=org.id, type="human", name="Reviewer", org_role="admin")
+    session.add(reviewer)
+    await session.commit()
+    # evidence: self_reported(url) + human_verified(gate_approval by human reviewer).
+    session.add_all([
+        Evidence(id=uuid.uuid4(), org_id=org.id, work_item_id=story_full.id, work_item_type="story",
+                 type="url", ref="http://ev", created_by=uuid.uuid4()),
+        Evidence(id=uuid.uuid4(), org_id=org.id, work_item_id=story_full.id, work_item_type="story",
+                 type="gate_approval", ref="approved", created_by=reviewer.id),
+    ])
+    # merge gate(auto_verify=passed) + pending pr_review gate(결정점).
+    session.add_all([
+        Gate(id=uuid.uuid4(), org_id=org.id, work_item_id=story_full.id, work_item_type="story",
+             gate_type="merge", status="approved", evidence_status="sufficient"),
+        Gate(id=uuid.uuid4(), org_id=org.id, work_item_id=story_full.id, work_item_type="story",
+             gate_type="pr_review", status="pending", requires_human=True,
+             decision_basis="needs human review", auto_decision_reason="ask_human"),
+    ])
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=pa.id, org_member_id=om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "caller_id": caller_id,
+            "story_full": story_full.id, "story_empty": story_empty.id, "story_b": story_b.id}
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims={"app_metadata": {"org_id": str(org_id)}})
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+
+
+@pytest.mark.anyio
+async def test_hero_full_signals():
+    """회귀0: rich story → claim·proof_count·auto_verify(passed)·gate 구조필드·trustSeal(human_verified
+    +by name/role) 전부 정직 배선."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/glance/hero?story_id={seeded['story_full']}")
+            assert resp.status_code == 200, resp.text
+            b = resp.json()
+            assert b["claim"] == "Full Story"
+            assert b["proof_count"] == 2
+            assert b["auto_verify"] == "passed"
+            assert b["gate"]["gate_type"] == "pr_review"
+            assert b["gate"]["decision_basis"] == "needs human review"
+            assert b["gate"]["auto_decision_reason"] == "ask_human"
+            t = b["trust"]
+            assert t["self_reported"] is True
+            assert t["human_verified"] is True
+            assert t["human_verified_by"]["name"] == "Reviewer"
+            assert t["human_verified_by"]["role"] == "admin"
+            assert t["human_verified_at"] is not None
+            # no-fiction: ac/risk/diff 미포함.
+            assert "ac_met" not in b and "risk" not in b and "diff" not in b
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_hero_empty_story_honest_minimal():
+    """무증거 story → 정직 최소(proof_count 0·self_reported/human_verified False·auto_verify null·gate null)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/glance/hero?story_id={seeded['story_empty']}")
+            assert resp.status_code == 200, resp.text
+            b = resp.json()
+            assert b["proof_count"] == 0
+            assert b["auto_verify"] is None
+            assert b["gate"] is None
+            assert b["trust"]["self_reported"] is False
+            assert b["trust"]["human_verified"] is False
+            assert b["trust"]["human_verified_by"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_hero_cross_project_blocked_404():
+    """봉인: 접근권 없는 project_b story의 hero 조회 시도 → 404(존재 비노출)."""
+    from app.main import app
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/glance/hero?story_id={seeded['story_b']}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## hero ProofCapsule envelope — story evidence 리치 배선 (story `b464daa1`)

E-GLANCE 2D hero(현재 에픽 활성 story) ProofCapsule 소비 계약. 라이브 hero가 목업보다 얇던 원인 = story-evidence→ProofCapsuleProps 매핑 미배선. 계약 doc `glance-hero-proofcapsule-be-contract` 그라운딩 + PO判定 반영.

### no-fiction 정직 소스만 배선
- `claim`=Story.title·`status`=Story.status·`proof_count`=evidence row 개수.
- `auto_verify`=story merge gate `evidence_status`(sufficient→passed·blocked→failed·**없으면 null**).
- `gate`=현재 pending gate **구조필드**(status/gate_type/requires_human/decision_basis/auto_decision_reason).
- `trust`=`self_reported`(evidence 有)+`human_verified`(최신 `gate_approval` evidence·**E-VERIFY V0-S2·휴먼 서명·스푸핑불가**)+`human_verified_by`(member name/role)+`human_verified_at`.

⛔ **미포함(발명 금지·계약)**: ac_met/ac_total(acceptance_criteria=freeform Text)·risk(플랫폼 위험도판정 안 함)·diff(미저장) — 목업 3칩 렌더 불가(유나 가디언 정합).

### PO判定 반영 (2026-07-12)
**(B) 통합 envelope**(BE서 no-fiction/trust 조립·스푸핑불가·테스트 집중) · **BE는 구조화 필드만**(표시문자열/라벨 금지·i18n=FE lane·`decision_basis`/`auto_decision_reason` verbatim → FE 라벨 합성) · ship ref=develop.

### 구현
`GET /api/v2/glance/hero?story_id=` — **has_project_access(story.project_id) 가드**(404·존재 비노출·⭐내 스캐너 PROJECT_PARAM 감시축). Hero{Response,Trust,Gate,Member} 스키마.

### 검증
신규 realdb **3/3**(full 리치신호 다 배선+trustSeal name/role·무증거 story 정직 최소[proof_count 0·auto_verify null·gate null]·cross-project 404)·coverage ratchet **9/9**·⭐**sabotage 이중 이빨**(가드 무력화→cross-project 404 + **스캐너 ratchet 둘 다 RED**). ruff clean·**마이그0**.

FE(미르코)가 gate verbatim으로 action 라벨 합성·no-fiction 필드 렌더. QA: 까심(리치신호 정직 배선·trustSeal 스푸핑불가·cross-project 404·no-fiction 생략).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
