### PR TITLE
[E-UI-DAEGBYEON][P0-06][FE] IA 4구역 nav 재배치 — 확定 라벨 (story 32419578)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -68,7 +68,11 @@
     "epics": "Epics",
     "glance": "Glance",
     "loops": "Loop",
-    "storage": "Storage"
+    "storage": "Storage",
+    "zoneNow": "Now",
+    "zoneWork": "Work",
+    "zoneTrust": "Trust",
+    "zoneKnowledge": "Knowledge"
   },
   "storage": {
     "title": "Storage",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -68,7 +68,11 @@
     "epics": "에픽",
     "glance": "현황판",
     "loops": "Loop",
-    "storage": "스토리지"
+    "storage": "스토리지",
+    "zoneNow": "지금",
+    "zoneWork": "작업",
+    "zoneTrust": "신뢰",
+    "zoneKnowledge": "지식"
   },
   "storage": {
     "title": "스토리지",

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -155,7 +155,9 @@ export function AppSidebar({
       </SidebarHeader>
 
       <SidebarContent>
+        {/* ① 지금 / Now — 개입할 것(인박스·대시보드·채팅). ia-4zone SSOT 확定. */}
         <SidebarGroup>
+          <SidebarGroupLabel>{t('zoneNow')}</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
               <SidebarMenuItem>
@@ -197,8 +199,9 @@ export function AppSidebar({
           </SidebarGroupContent>
         </SidebarGroup>
 
+        {/* ② 작업 / Work — 흐르는 일(보드·스프린트·에픽·현황판·Loop·스탠드업·회고). ia-4zone SSOT 확定. */}
         <SidebarGroup>
-          <SidebarGroupLabel>{t('sprint')}</SidebarGroupLabel>
+          <SidebarGroupLabel>{t('zoneWork')}</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
               <SidebarMenuItem>
@@ -278,41 +281,11 @@ export function AppSidebar({
           </SidebarGroupContent>
         </SidebarGroup>
 
+        {/* ③ 신뢰 / Trust — 증명된 일(활동 로그·감사). 검증 표면 확장 자리(ia-4zone SSOT 확定). */}
         <SidebarGroup>
-          <SidebarGroupLabel>{t('workspace')}</SidebarGroupLabel>
+          <SidebarGroupLabel>{t('zoneTrust')}</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href="/docs" />}
-                  isActive={isActive('/docs')}
-                  tooltip={t('docs')}
-                >
-                  <BookOpen />
-                  <span>{t('docs')}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              {/* E-SETTINGS S5: Meetings 메뉴 숨김 — /meetings 진입 차단(route thin guard 404). */}
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href="/agents" />}
-                  isActive={isActive('/agents')}
-                  tooltip={t('agents')}
-                >
-                  <Bot />
-                  <span>{t('agents')}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href="/storage" />}
-                  isActive={isActive('/storage')}
-                  tooltip={t('storage')}
-                >
-                  <HardDrive />
-                  <span>{t('storage')}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
               <SidebarMenuItem>
                 <SidebarMenuButton
                   render={<Link href="/activity" />}
@@ -327,8 +300,48 @@ export function AppSidebar({
           </SidebarGroupContent>
         </SidebarGroup>
 
+        {/* ④ 지식 / Knowledge — 팀 기억(문서·스토리지·에이전트). ia-4zone SSOT 확定. */}
         <SidebarGroup>
-          <SidebarGroupLabel>{t('configure')}</SidebarGroupLabel>
+          <SidebarGroupLabel>{t('zoneKnowledge')}</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/docs" />}
+                  isActive={isActive('/docs')}
+                  tooltip={t('docs')}
+                >
+                  <BookOpen />
+                  <span>{t('docs')}</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/storage" />}
+                  isActive={isActive('/storage')}
+                  tooltip={t('storage')}
+                >
+                  <HardDrive />
+                  <span>{t('storage')}</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              {/* E-SETTINGS S5: Meetings 메뉴 숨김 — /meetings 진입 차단(route thin guard 404). */}
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/agents" />}
+                  isActive={isActive('/agents')}
+                  tooltip={t('agents')}
+                >
+                  <Bot />
+                  <span>{t('agents')}</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        {/* 설정 — zone 밖·하단(ia-4zone 확定: 유틸 푸터·zone 라벨 없음). */}
+        <SidebarGroup>
           <SidebarGroupContent>
             <SidebarMenu>
               <SidebarMenuItem>


### PR DESCRIPTION
## 배경
선생님 확定 IA(구조 2026-07-11 + 라벨 2026-07-12): 사이드바를 **4 주의모드 + 하단 설정**으로 재그룹핑. (story `32419578` · E-UI-DAEGBYEON P0-06)
**SSOT**: doc `ia-4zone-regroup-handoff`(구조/매핑 🔒) + `ia-4zone-label-candidates`(🔒확定 라벨).

## 변경 — 매핑 SSOT 표와 1:1
| Zone (ko / en) | 메뉴 | 델타 |
|---|---|---|
| **지금 / Now** | 인박스·대시보드·채팅 | 구역 라벨 신설(기존 무라벨) |
| **작업 / Work** | 보드·스프린트·에픽·현황판·Loop·스탠드업·회고 | `sprint`→`work` relabel |
| **신뢰 / Trust** | 활동 로그 | Workspace서 분리(검증 표면 확장 자리) |
| **지식 / Knowledge** | 문서·스토리지·에이전트 | `workspace`→`knowledge` relabel·SSOT 순서 |
| (하단·zone 밖) | 설정 | `configure` 라벨 제거 |

## 규율
- **render-now** — 신규 라우트/페이지 0. 기존 href·단축키(B/S/R)·인박스 unread 뱃지·모바일 auto-close 전부 유지(**회귀 0**).
- i18n `nav` 네임스페이스에 zone 4키(ko/en 1:1). 라벨 = 🔒확定안 정확 일치.
- 매핑 SSOT 표 1:1(임의 재배치 0).

## ⚠️ 그라운딩 정정 (투명 공유)
착수 초기 **stale 체크아웃**(브랜치 `pr-1910-s20-dev-ff`)을 봐서 "`/glance` nav 없음→추가 필요"로 오판했으나, `origin/develop` 실측 결과 **현황판(`/glance`)은 이미 Work zone에 존재**(Map 아이콘)했음. `fetch-before-grounding` 규율로 즉시 원복(불필요 import 제거), develop 실체 기준으로 재배치. → 실 델타 = 순수 relabel + activity를 Trust로 분리 + Knowledge 순서 + 설정 라벨 제거.

## 게이트
| gate | 결과 |
|---|---|
| tsc --noEmit | **EXIT 0** |
| eslint | **EXIT 0** (warning 0) |
| next build | **EXIT 0** |
| i18n parity (zone 4키 ko/en) | **OK** |

## AC 대사
1. ✅ 4구역+하단 설정 재그룹핑·구역 라벨 확定안 ko/en 1:1 일치.
2. ✅ 신규 라우트 0·기존 링크/단축키/뱃지 동작(회귀 0).
3. ✅ 구조/매핑 doc `ia-4zone-regroup-handoff` 표와 1:1.
4. ⏳ 양테마 — dev 라이브 픽셀(nav 레이아웃 회귀는 정적/CI 못잡음).
5. ⏳ 유나 UX 가디언 GREEN + 까심 QA + CI green.

## 잔여
- dev 배포 後 라이브 픽셀(4구역 렌더·양테마·**모바일 nav**·전 메뉴 도달성) — AC4.
- 유나 UX 가디언 + 까심 QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)