### PR TITLE
fix(canvas): 스토리 코멘트 부활 — comment.created webhook-agent 도달 + 반응 맥락 payload (C0-S2 8bace49e)

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -1289,6 +1289,13 @@ async def add_comment(
             reference_type="story",
             reference_id=story.id,
             source_project_id=story.project_id,
+            # C0-S2: 에이전트가 payload만 보고 답글 달 수 있는 최소 반응 맥락(webhook generic payload).
+            context={
+                "story_id": str(story.id),
+                "comment_id": str(comment.id),
+                "content": content,
+                "author_member_id": str(created_by),
+            },
         )
 
     return CommentResponse.model_validate(comment)

--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -30,6 +30,9 @@ async def _deliver_personal_webhooks(
     title: str,
     body: str | None,
     event_type: str,
+    reference_type: str | None = None,
+    reference_id: uuid.UUID | None = None,
+    context: dict | None = None,
 ) -> None:
     """96af343e: 활성 개인(member-scoped) WebhookConfig 보유 휴먼에게 알림 webhook POST.
 
@@ -85,7 +88,17 @@ async def _deliver_personal_webhooks(
             payload = {"content": text}
             secret = None  # Discord 자체 인증 방식
         else:
-            payload = {"event": event_type, "title": title, "body": body}
+            # C0-S2: 에이전트가 payload만 보고 반응(답글)할 수 있도록 반응 맥락을 실는다 —
+            # reference(story 등) + context(comment_id·content·author). Discord(휴먼)는 content
+            # 텍스트 제약이라 위 분기 유지·structured 맥락은 generic(에이전트 런타임 endpoint) payload.
+            payload = {
+                "event": event_type,
+                "title": title,
+                "body": body,
+                "reference_type": reference_type,
+                "reference_id": str(reference_id) if reference_id else None,
+                "context": context or {},
+            }
             secret = cfg.secret
         try:
             await _post_with_retry(cfg.url, payload, secret, str(cfg.member_id))
@@ -104,6 +117,7 @@ async def dispatch_notification(
     reference_type: str | None = None,
     reference_id: uuid.UUID | None = None,
     source_project_id: uuid.UUID | None = None,
+    context: dict | None = None,
 ) -> None:
     """notification_settings 필터 후 enabled member에게 알림 발송.
 
@@ -273,14 +287,20 @@ async def dispatch_notification(
             from app.services.activity_stream import extract_activities_best_effort
             await extract_activities_best_effort(db, [e.id for e in created_events])
 
-        # 96af343e (옵션 C): 휴먼 개인 webhook 발송 — in-app Notification 과 동일 flush 타이밍
-        # best-effort. 활성 member-scoped WebhookConfig 보유 휴먼만(agent SSE 경로 무관).
-        human_member_ids = [
+        # 96af343e(옵션 C) + C0-S2(8bace49e 부활): 개인 webhook 발송 — 휴먼 + agent(활성 webhook).
+        # ⭐agent(활성 webhook)는 위에서 Event INSERT를 스킵했다("외부 채널로 전달" 전제). 그런데 그
+        # webhook을 여기서 실제로 쏘지 않으면 Event도 스킵·webhook도 미발송 = comment.created가
+        # webhook-agent에 미도달(죽은 경로). 이 경로를 부활시켜 에이전트 반응 왕복을 잇는다 —
+        # member-bound WebhookConfig·mute(NotificationPreference)·SSRF 재검증 기존 SSOT 재사용·
+        # Event-skip 유지라 이중배달 0(webhook 단일 채널).
+        webhook_deliver_ids = [
             m.id for m in members
-            if m.type != "agent" and getattr(m, "user_id", None)
+            if (m.type != "agent" and getattr(m, "user_id", None))
+            or (m.type == "agent" and m.id in webhook_member_ids)
         ]
         await _deliver_personal_webhooks(
-            db, org_id, human_member_ids, title=title, body=body, event_type=event_type
+            db, org_id, webhook_deliver_ids, title=title, body=body, event_type=event_type,
+            reference_type=reference_type, reference_id=reference_id, context=context,
         )
 
     except Exception:

--- a/backend/tests/test_e_canvas_c0s2_comment_agent_webhook_realdb.py
+++ b/backend/tests/test_e_canvas_c0s2_comment_agent_webhook_realdb.py
@@ -1,0 +1,199 @@
+"""E-CANVAS C0-S2 (story 8bace49e) — 스토리 코멘트 부활: comment.created가 활성 webhook 보유
+에이전트에게 실제 도달(반응 왕복 부활)하는지 실 PG로 실증.
+
+갭(C0-S1 후 실측): dispatch_notification이 agent(활성 webhook)의 Event INSERT는 스킵("외부 채널로
+전달" 전제)하나 그 webhook 발송은 휴먼 전용(_deliver_personal_webhooks·m.type!='agent')이라
+comment.created가 webhook-agent에 **미도달**(죽은 경로). fix: agent(활성 webhook)도 webhook 발송
+(Event-skip 유지·이중배달 0)로 부활.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+_DISCORD_URL = "https://discord.com/api/webhooks/1/agent-relay-token"
+
+
+async def _seed(session):
+    """org + agent Member(활성 webhook·Discord) + 트리거 project."""
+    from app.models.member import AgentProjectProfile, Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.webhook_config import WebhookConfig
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent Bot")
+    session.add(agent)
+    await session.commit()
+    # 에이전트는 agent_project_profiles로 team_members 뷰에 surface(휴먼=project_access·에이전트=app).
+    session.add(AgentProjectProfile(id=uuid.uuid4(), member_id=agent.id, project_id=project.id))
+    await session.commit()
+    session.add(WebhookConfig(
+        id=uuid.uuid4(), org_id=org.id, member_id=agent.id, url=_DISCORD_URL, events=[], is_active=True,
+    ))
+    await session.commit()
+    return {"org_id": org.id, "agent_id": agent.id, "project_id": project.id}
+
+
+async def _count_agent_events(Session, agent_id):
+    from sqlalchemy import text
+    async with Session() as s:
+        return (await s.execute(
+            text("SELECT count(*) FROM events WHERE recipient_id = :a"), {"a": agent_id}
+        )).scalar_one()
+
+
+@pytest.mark.anyio
+async def test_comment_created_reaches_agent_webhook():
+    """부활 실증: comment.created가 활성 webhook 보유 에이전트의 webhook으로 실제 POST되고(도달),
+    Event INSERT는 스킵돼 이중배달이 없다(webhook 단일 채널)."""
+    from app.dependencies.database import get_db  # noqa: F401 (ensure app importable)
+    from app.services.notification_dispatch import dispatch_notification
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        posted: list[tuple] = []
+
+        async def _capture_post(url, payload, secret, member_id):
+            posted.append((url, payload, member_id))
+
+        # SSRF 검증은 no-op(로컬 DNS 회피)·POST는 캡처.
+        with (
+            patch("app.services.dispatch_router._post_with_retry", new=_capture_post),
+            patch("app.core.ssrf.validate_webhook_url_async", new=AsyncMock(return_value=None)),
+        ):
+            async with Session() as s:
+                await dispatch_notification(
+                    s,
+                    org_id=seeded["org_id"],
+                    event_type="comment.created",
+                    target_member_ids=[seeded["agent_id"]],
+                    title="새 코멘트: Story X",
+                    body="에이전트 확인 바람",
+                    reference_type="story",
+                    reference_id=uuid.uuid4(),
+                    source_project_id=seeded["project_id"],
+                )
+                await s.commit()
+
+        # ⭐도달: 에이전트 webhook으로 POST됨.
+        agent_posts = [p for p in posted if p[0] == _DISCORD_URL]
+        assert len(agent_posts) == 1, f"agent webhook 미도달(죽은 경로) — posted={posted}"
+        # Discord payload content에 event_type 포함.
+        assert "comment.created" in agent_posts[0][1].get("content", "")
+        # 이중배달 0: agent Event INSERT는 스킵(webhook만).
+        assert await _count_agent_events(Session, seeded["agent_id"]) == 0
+    finally:
+        await engine.dispose()
+
+
+_GENERIC_URL = "https://agent-runtime.example.com/inbound/webhook"
+
+
+@pytest.mark.anyio
+async def test_agent_webhook_payload_carries_reaction_context():
+    """계약(Ortega判定): generic(에이전트 런타임) webhook payload가 에이전트 반응에 필요한 최소
+    맥락(reference_id=story·context{story_id·comment_id·content·author})을 실어 payload만 보고
+    답글 달 수 있어야 한다."""
+    from app.services.notification_dispatch import dispatch_notification
+
+    engine, Session = await _session_factory()
+    try:
+        from app.models.member import AgentProjectProfile, Member
+        from app.models.organization import Organization
+        from app.models.project import Project
+        from app.models.webhook_config import WebhookConfig
+
+        async with Session() as s:
+            org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+            s.add(org)
+            await s.commit()
+            project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+            agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent")
+            s.add_all([project, agent])
+            await s.commit()
+            s.add(AgentProjectProfile(id=uuid.uuid4(), member_id=agent.id, project_id=project.id))
+            s.add(WebhookConfig(
+                id=uuid.uuid4(), org_id=org.id, member_id=agent.id, url=_GENERIC_URL, events=[], is_active=True,
+            ))
+            await s.commit()
+            agent_id, org_id, project_id = agent.id, org.id, project.id
+
+        posted: list[tuple] = []
+
+        async def _capture_post(url, payload, secret, member_id):
+            posted.append((url, payload, member_id))
+
+        story_id, comment_id, author_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        with (
+            patch("app.services.dispatch_router._post_with_retry", new=_capture_post),
+            patch("app.core.ssrf.validate_webhook_url_async", new=AsyncMock(return_value=None)),
+        ):
+            async with Session() as s:
+                await dispatch_notification(
+                    s, org_id=org_id, event_type="comment.created", target_member_ids=[agent_id],
+                    title="새 코멘트: Story X", body="확인 바람",
+                    reference_type="story", reference_id=story_id, source_project_id=project_id,
+                    context={"story_id": str(story_id), "comment_id": str(comment_id),
+                             "content": "확인 바람", "author_member_id": str(author_id)},
+                )
+                await s.commit()
+
+        agent_posts = [p for p in posted if p[0] == _GENERIC_URL]
+        assert len(agent_posts) == 1, f"agent generic webhook 미도달 — posted={posted}"
+        payload = agent_posts[0][1]
+        # 계약: reference + 반응 맥락 전부 실림.
+        assert payload["event"] == "comment.created"
+        assert payload["reference_type"] == "story"
+        assert payload["reference_id"] == str(story_id)
+        ctx = payload["context"]
+        assert ctx["story_id"] == str(story_id)
+        assert ctx["comment_id"] == str(comment_id)
+        assert ctx["content"] == "확인 바람"
+        assert ctx["author_member_id"] == str(author_id)
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## comment.created가 webhook-agent에 도달하도록 부활 + 반응 맥락 payload (C0-S2 · story `8bace49e`)

E-CANVAS C0-S2 — 죽어있던 스토리 코멘트를 C0 인프라 **기반층 검증 케이스**로 부활(Blueprint §F4·제1원칙 "이벤트 없는 기능 금지").

### 그라운딩 실측 갭
`dispatch_notification`이 agent(활성 webhook)의 Event INSERT를 스킵("외부 채널로 전달" 전제)하나, 그 webhook 발송은 `_deliver_personal_webhooks`가 **휴먼 전용**(`m.type != 'agent'`)이라 `comment.created`가 **webhook-agent에 미도달**(Event도 스킵·webhook도 미발송 = 죽은 경로). 에이전트는 대개 webhook(relay)로 돌아 comment→agent 반응 왕복이 끊겨 있었다.

### fix (PO判정: webhook 발송 · 이중배달 0 · Event-skip 유지)
- **agent(활성 webhook)를 webhook 발송 대상에 포함** — Event-skip 전제("외부 채널이 전달") 충족. member-bound gating·mute·SSRF·webhook-無 에이전트 Event 경로 전부 무변경(무회귀).
- ⭐**반응 맥락 payload 계약(PO 요건)**: generic(에이전트 런타임) webhook payload에 `reference_type`/`reference_id` + `context{story_id·comment_id·content·author_member_id}` — 에이전트가 **payload만 보고 답글** 가능. Discord(휴먼)는 content 텍스트 제약이라 기존 유지.
- `add_comment`: context 채워 전달.

### 검증
신규 realdb **2종**(agent webhook **도달**+Event-skip 이중배달0·**payload 계약** reference_id+context 4필드)·⭐**sabotage**(agent 포함 revert→agent 미도달 RED=갭 재확認). ruff clean·**마이그0**. 기존 notification_dispatch/comment **33 pass·회귀0**. 왕복 실증(실 팀원 webhook·미르코 32b8cff9)은 dev 배포 후 라이브.

QA: 까심(agent webhook 도달·payload 계약·mute/SSRF/무회귀·sabotage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
