### PR TITLE
feat(canvas): sprintable_list_artifacts MCP 툴 — 에이전트 artifact 목록 조회 (C1-S3 e50563b4)

### DIFF
--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -68,7 +68,7 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # 묶기 애매한 cross-cutting 자기생성 유틸). C2-S6(코멘트 2종)+C3-S7(edit 1종)+C4-S8(정본
     # 제안 1종) 추가 — 6개(전신 C0~C5 트랙의 마지막 BE 배선). 여전히 story/epic/doc 무관
     # cross-cutting이라 always-allow 유지(추가 성장 시 전용 "canvas" 그룹 신설 고려).
-    "sprintable_create_artifact", "sprintable_get_artifact",
+    "sprintable_create_artifact", "sprintable_get_artifact", "sprintable_list_artifacts",
     "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
     "sprintable_edit_artifact", "sprintable_propose_canonical_version",
 })
@@ -291,7 +291,7 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     # evidence (E-VERIFY V0-S1)
     "sprintable_add_evidence",
     # visual artifacts (E-CANVAS C1-S3 + C2-S6 코멘트 + C3-S7 편집 + C4-S8 정본 제안)
-    "sprintable_create_artifact", "sprintable_get_artifact",
+    "sprintable_create_artifact", "sprintable_get_artifact", "sprintable_list_artifacts",
     "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
     "sprintable_edit_artifact", "sprintable_propose_canonical_version",
 )

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -504,7 +504,8 @@ _TOOL_DEFS: list[tuple] = [
      "시각 산출물 단건 조회(latest 버전 + nodes).",
      GetArtifactInput, get_artifact),
     ("sprintable_list_artifacts",
-     "현재 프로젝트 시각 산출물 목록 조회 — story_id/epic_id/doc_id로 필터(미지정=프로젝트 전체).",
+     "현재 프로젝트 시각 산출물 목록 조회(각 항목=메타+latest 버전 번호·노드 트리 미포함·상세는"
+     " get_artifact) — story_id/epic_id/doc_id로 필터(미지정=프로젝트 전체).",
      ListArtifactsInput, list_artifacts),
     ("sprintable_list_artifact_comments",
      "artifact 코멘트 스레드 조회(요소/좌표 앵커·resolve 상태) — 휴먼 피드백 왕복 입구.",

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -31,9 +31,9 @@ from .tools.a2a import LinkGateToTaskInput, link_gate_to_task
 from .tools.evidence import AddEvidenceInput, add_evidence
 from .tools.visual_artifacts import (
     AddArtifactCommentInput, CreateArtifactInput, EditArtifactInput, GetArtifactInput,
-    ListArtifactCommentsInput, ProposeCanonicalInput,
+    ListArtifactCommentsInput, ListArtifactsInput, ProposeCanonicalInput,
     add_artifact_comment, create_artifact, edit_artifact, get_artifact, list_artifact_comments,
-    propose_canonical_version,
+    list_artifacts, propose_canonical_version,
 )
 from .tools.agent_runs import (
     EmitEventInput, PollEventsInput, UpdateRunStatusInput,
@@ -495,7 +495,7 @@ _TOOL_DEFS: list[tuple] = [
      "done을 스스로 증명하는 자기 서명 첨부(PR·배포·지표·발행물 링크 등) — story/task에 evidence"
      " 남김. 선택제(첨부 안 해도 무불이익).",
      AddEvidenceInput, add_evidence),
-    # Visual artifacts (6) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안)
+    # Visual artifacts (7) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안)
     ("sprintable_create_artifact",
      "시각 산출물 생성(에이전트 생성 입구) — 트리(nodes[])로 구조화. 임포트된 raw HTML/이미지는"
      " type=\"html_blob\" 노드 하나로 감싸도 됨.",
@@ -503,6 +503,9 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_get_artifact",
      "시각 산출물 단건 조회(latest 버전 + nodes).",
      GetArtifactInput, get_artifact),
+    ("sprintable_list_artifacts",
+     "현재 프로젝트 시각 산출물 목록 조회 — story_id/epic_id/doc_id로 필터(미지정=프로젝트 전체).",
+     ListArtifactsInput, list_artifacts),
     ("sprintable_list_artifact_comments",
      "artifact 코멘트 스레드 조회(요소/좌표 앵커·resolve 상태) — 휴먼 피드백 왕복 입구.",
      ListArtifactCommentsInput, list_artifact_comments),

--- a/backend/sprintable_mcp/tools/visual_artifacts.py
+++ b/backend/sprintable_mcp/tools/visual_artifacts.py
@@ -1,4 +1,4 @@
-"""시각 산출물(visual_artifact) MCP 도구(6개) — E-CANVAS C1-S3(story 8bace49e)+
+"""시각 산출물(visual_artifact) MCP 도구(7개) — E-CANVAS C1-S3(story 8bace49e)+
 C2-S6(story 0edca31e, 코멘트 왕복)+C3-S7(story 940266db, 편집 왕복)+C4-S8(story a5118cb0,
 정본 제안 — 승인은 always-HITL이라 MCP 미제공)."""
 from __future__ import annotations
@@ -68,6 +68,13 @@ class ProposeCanonicalInput(SprintableInput):
     version_number: int
 
 
+class ListArtifactsInput(SprintableInput):
+    # 프로젝트 스코프는 서버-파생(키 컨텍스트·비-caller-suppliable) — 아래 필터만 선택 지정.
+    story_id: str | None = None
+    epic_id: str | None = None
+    doc_id: str | None = None
+
+
 async def create_artifact(args: CreateArtifactInput) -> list[TextContent]:
     """시각 산출물 생성(에이전트 생성 입구, blueprint §F1) — 트리(nodes[])로 구조화해 전달.
     임포트된 raw HTML/이미지는 type="html_blob" 노드 하나로 감싸도 된다."""
@@ -95,6 +102,23 @@ async def get_artifact(args: GetArtifactInput) -> list[TextContent]:
     """시각 산출물 단건 조회(latest 버전 + nodes)."""
     try:
         result = await client.get(f"/api/v2/visual-artifacts/{args.artifact_id}")
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def list_artifacts(args: ListArtifactsInput) -> list[TextContent]:
+    """현재 프로젝트의 시각 산출물 목록 조회 — story_id/epic_id/doc_id로 필터 가능(미지정 시
+    프로젝트 전체). 각 항목은 artifact 메타(title·story/epic/doc 연결·latest 버전)."""
+    try:
+        params: dict = {}
+        if args.story_id:
+            params["story_id"] = args.story_id
+        if args.epic_id:
+            params["epic_id"] = args.epic_id
+        if args.doc_id:
+            params["doc_id"] = args.doc_id
+        result = await client.get("/api/v2/visual-artifacts", params=params)
         return ok(result)
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/visual_artifacts.py
+++ b/backend/sprintable_mcp/tools/visual_artifacts.py
@@ -109,7 +109,8 @@ async def get_artifact(args: GetArtifactInput) -> list[TextContent]:
 
 async def list_artifacts(args: ListArtifactsInput) -> list[TextContent]:
     """현재 프로젝트의 시각 산출물 목록 조회 — story_id/epic_id/doc_id로 필터 가능(미지정 시
-    프로젝트 전체). 각 항목은 artifact 메타(title·story/epic/doc 연결·latest 버전)."""
+    프로젝트 전체). 각 항목은 artifact 메타(title·story/epic/doc 연결·latest 버전 번호)만 반환하며
+    노드 트리는 미포함 — 특정 artifact의 nodes/상세는 get_artifact로 조회."""
     try:
         params: dict = {}
         if args.story_id:

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -95,7 +95,8 @@ EXPECTED_TOOLS = {
 
 
 def test_total_tool_count():
-    assert len(_TOOLS) == 99
+    # C1-S3(e50563b4): sprintable_list_artifacts 추가로 98→99... +1=100.
+    assert len(_TOOLS) == 100
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -85,8 +85,8 @@ EXPECTED_TOOLS = {
     "sprintable_link_gate_to_task",
     # evidence (1) — E-VERIFY V0-S1
     "sprintable_add_evidence",
-    # visual artifacts (6) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안)
-    "sprintable_create_artifact", "sprintable_get_artifact",
+    # visual artifacts (7) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안)
+    "sprintable_create_artifact", "sprintable_get_artifact", "sprintable_list_artifacts",
     "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
     "sprintable_edit_artifact", "sprintable_propose_canonical_version",
     # smoke
@@ -103,6 +103,11 @@ def test_all_expected_tools_registered():
     registered = set(_TOOLS.keys())
     missing = EXPECTED_TOOLS - registered
     assert not missing, f"미등록 도구: {missing}"
+    # ⭐양방향 봉인(까심 QA #2106): EXPECTED-registered 한 방향만 검사하면 신규 등록 툴이
+    # EXPECTED_TOOLS에 빠져도 공허통과한다(#2093/#2096 advisory 공허통과와 동형). 역방향으로
+    # "등록됐는데 EXPECTED에 없는 툴"을 잡아 신규 툴이 계약 목록 누락 시 즉시 RED로 봉인.
+    extra = registered - EXPECTED_TOOLS
+    assert not extra, f"EXPECTED_TOOLS에 없는 등록 툴(계약 목록 갱신 필요): {extra}"
 
 
 @pytest.mark.parametrize("tool_name", [


### PR DESCRIPTION
## sprintable_list_artifacts MCP 툴 — 에이전트 artifact 목록 조회 (C1-S3 잔여 · story `e50563b4`)

### 실측 잔여 (measurement-first)
C1-S3(에이전트 생성 입구) artifact MCP 툴은 **create/get/edit/comments/propose가 이미 배선**(후속 canvas #2027/#2031/#2033) — AC② "조회(get/**list**)"의 **list만 부재**. `list_artifacts` MCP 래퍼 1개로 완결. **신규 BE 로직 0**(REST `GET /api/v2/visual-artifacts` 기존·SEC-S8로 project 서버-파생 스코프).

### 변경
- `tools/visual_artifacts.py`: `ListArtifactsInput`(story_id/epic_id/doc_id 선택 필터·project 서버파생) + `list_artifacts`(get_artifact 패턴 미러). 도구 6→7.
- `server.py`: import + 레지스트리 튜플(에이전트 친화 description).
- `mcp_toolset.py`: read_project + create_project 그룹 2곳 등재.
- `tests/mcp/test_contract.py`: 총 도구 수 99→100.

### 검증
MCP toolset/catalog/contract/scope-filter/standalone **59 pass**(list_artifacts 등록·read_project allowed 확認)·ruff clean(server.py E402는 pristine 동일·무관)·**마이그0**.

### ⚠️ 배포 함정 (오르테가 실측·PO lane)
호스팅 `sprintable-mcp-dev`가 **07-04 리비전**(canvas 툴 머지 07-10 이전)이라 툴들이 아직 라이브 아님 — MCP는 merge→배포 자동화 없고 `deploy_mcp_dev.sh` 수동(internal-api류 함정). **MCP dev 재배포 + 에이전트 MCP 생성→list/get→편집 왕복 실증 = PO lane**(머지 후).

QA: 까심(툴 등록·정책 그룹·description 에이전트 친화·contract count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
