### PR TITLE
docs(canvas): edit_artifact MCP desc에 operations 계약 명시 — 대상 노드=id (C1-S3 fast-follow)

### DIFF
--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -514,7 +514,9 @@ _TOOL_DEFS: list[tuple] = [
      "artifact에 코멘트 추가(요소/좌표 앵커·답글 가능) — 대상자에게 이벤트 전파.",
      AddArtifactCommentInput, add_artifact_comment),
     ("sprintable_edit_artifact",
-     "artifact 요소 add/update/delete 편집 — 휴먼 딸깍과 같은 경로, 항상 새 버전 생성·이벤트 전파.",
+     "artifact 요소를 operations[]로 편집(휴먼 딸깍과 같은 경로·항상 새 버전·이벤트 전파). 각 op="
+     "{op:add|update|delete, id, type?, props?}. ⭐update/delete 대상 노드는 `id` 필드로 지정"
+     "(get_artifact의 node.id·코멘트 앵커 node_id 아님)·add는 type 필수.",
      EditArtifactInput, edit_artifact),
     ("sprintable_propose_canonical_version",
      "이 버전을 정본으로 제안(게이트 생성) — 제안만, 승인/반려는 항상 휴먼.",

--- a/backend/sprintable_mcp/tools/visual_artifacts.py
+++ b/backend/sprintable_mcp/tools/visual_artifacts.py
@@ -157,9 +157,14 @@ async def add_artifact_comment(args: AddArtifactCommentInput) -> list[TextConten
 
 
 async def edit_artifact(args: EditArtifactInput) -> list[TextContent]:
-    """artifact 요소를 add/update/delete로 편집 — 휴먼 딸깍 편집과 동일 엔드포인트를 경유해
-    "같은 객체를 양쪽이 편집"(AC4 왕복). 편집은 항상 새 버전을 만든다(무-mutate 버전 원칙).
-    대상자에게 artifact.updated 이벤트 전파."""
+    """artifact 요소를 operations[]로 편집 — 휴먼 딸깍 편집과 동일 엔드포인트를 경유해 "같은 객체를
+    양쪽이 편집"(AC4 왕복). 편집은 항상 새 버전을 만든다(무-mutate 버전 원칙). 대상자에게
+    artifact.updated 이벤트 전파.
+    각 operation = {op, id, type?, props?, parent_id?, sort_order?, description?}:
+      · op="add": 새 노드(type 필수·props 초기값·id 미지정 시 서버 생성).
+      · op="update": **대상 노드 = `id`**(get_artifact의 node.id·`node_id` 아님)·props 지정 시 전체 교체.
+      · op="delete": **대상 노드 = `id`**만.
+    (대상 요소는 항상 `id` 필드로 지정 — 코멘트 앵커의 node_id와 혼동 주의.)"""
     try:
         body = {
             "operations": [op.model_dump(exclude_none=True) for op in args.operations],


### PR DESCRIPTION
라이브 실증서 edit_artifact가 node_id로 대상 지정→튕김(오르테가). desc가 operations 계약(op 어휘·대상 노드=`id`·코멘트 앵커 node_id 아님) 미문서화한 에이전트 저작 UX 갭. **doc-only·로직 무변경**.

- tools/visual_artifacts.py: edit_artifact docstring에 op별 계약(add:type 필수·update/delete 대상=`id`·props 전체 교체)+node_id 혼동 주의.
- server.py: 레지스트리 desc에도 op shape 1줄.

검증: MCP contract/toolset 40 pass·ruff clean·마이그0·스키마 무변경. PO fast-follow 노트(스토리 불요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)