### PR TITLE
[E-CANVAS C1-S5][FE·버그] PNG export oklch 캡처 실패 fix — html2canvas-pro + silent catch 제거 (story 2239501d)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,7 +48,7 @@
     "clsx": "^2.1.1",
     "dompurify": "^3.3.3",
     "framer-motion": "^12.38.0",
-    "html2canvas": "^1.4.1",
+    "html2canvas-pro": "^2.2.3",
     "jose": "^6.2.3",
     "katex": "^0.16.47",
     "lucide-react": "^1.7.0",

--- a/apps/web/src/components/canvas/export-dialog.tsx
+++ b/apps/web/src/components/canvas/export-dialog.tsx
@@ -40,9 +40,12 @@ export function ExportDialog({ open, onOpenChange, artifactId, versionNumber, ca
   const [theme, setTheme] = useState<ExportTheme>(resolvedTheme === 'dark' ? 'dark' : 'light');
   const [phase, setPhase] = useState<'idle' | 'exporting' | 'done' | 'error'>('idle');
   const [result, setResult] = useState<BeArtifactExport | null>(null);
+  // export 실패 원인(캡처 throw 등)을 UI/로그에 노출 — 빈 catch가 삼켜 진단 불가였던 회귀 방지.
+  const [errorDetail, setErrorDetail] = useState<string | null>(null);
 
   const handleExport = async () => {
     setPhase('exporting');
+    setErrorDetail(null);
     try {
       if (format === 'html') {
         const r = await createHtmlExport(artifactId, versionNumber);
@@ -61,13 +64,16 @@ export function ExportDialog({ open, onOpenChange, artifactId, versionNumber, ca
       }
       setResult(r);
       setPhase(r ? 'done' : 'error');
-    } catch {
+    } catch (err) {
+      // 빈 catch 금지(AC2) — 캡처/업로드 단계 throw의 원인을 로그+UI에 드러내 다음 진단 가능하게.
+      console.error('[canvas-export] PNG export failed', err);
+      setErrorDetail(err instanceof Error ? err.message : String(err));
       setPhase('error');
     }
   };
 
   const handleClose = (o: boolean) => {
-    if (!o) { setPhase('idle'); setResult(null); }
+    if (!o) { setPhase('idle'); setResult(null); setErrorDetail(null); }
     onOpenChange(o);
   };
 
@@ -92,7 +98,12 @@ export function ExportDialog({ open, onOpenChange, artifactId, versionNumber, ca
             ) : null}
           </div>
         ) : phase === 'error' ? (
-          <p className="rounded-md bg-muted/40 px-3 py-2 text-xs text-muted-foreground">{t('exportFailedNote')}</p>
+          <div className="space-y-1 rounded-md bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+            <p>{t('exportFailedNote')}</p>
+            {errorDetail ? (
+              <p className="break-words font-mono text-[10px] text-muted-foreground/70">{errorDetail}</p>
+            ) : null}
+          </div>
         ) : (
           <div className="space-y-3">
             <div>

--- a/apps/web/src/services/canvas-export.ts
+++ b/apps/web/src/services/canvas-export.ts
@@ -104,7 +104,10 @@ export function canPngExport(format: ArtifactFormat): boolean {
 }
 
 export async function captureElementAsPng(el: HTMLElement): Promise<Blob | null> {
-  const { default: html2canvas } = await import('html2canvas');
+  // html2canvas-pro(드롭인 fork) — 원본 html2canvas@1.4.1은 oklch()/color-mix(in oklch,…)를
+  // "unsupported color function"으로 throw했다(우리 디자인 토큰 globals.css 145곳). pro는 modern
+  // CSS 색 함수(oklch·color-mix·lab·lch)를 네이티브 파싱해 캡처가 throw 없이 성공한다.
+  const { default: html2canvas } = await import('html2canvas-pro');
   // 유나 §③ "2x retina·흐릿=신뢰 깎임" — scale 미지정 시 1x라 export 첫인상이 흐릿해진다.
   const canvas = await html2canvas(el, { backgroundColor: null, useCORS: true, scale: 2 });
   return new Promise((resolve) => canvas.toBlob((blob) => resolve(blob), 'image/png'));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,9 +129,9 @@ importers:
       framer-motion:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      html2canvas:
-        specifier: ^1.4.1
-        version: 1.4.1
+      html2canvas-pro:
+        specifier: ^2.2.3
+        version: 2.2.3
       jose:
         specifier: ^6.2.3
         version: 6.2.3
@@ -4031,9 +4031,9 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
-  html2canvas@1.4.1:
-    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
-    engines: {node: '>=8.0.0'}
+  html2canvas-pro@2.2.3:
+    resolution: {integrity: sha512-PHW1mo/AU4fxXZu2ONzOcSWDwXi3ul/qMqOlmM0uvfvJqw2/dsWIY1jxUqYutO3RaLHxVC6mLYG6Ewfo3xYvhg==}
+    engines: {node: '>=16.0.0'}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -10179,7 +10179,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html2canvas@1.4.1:
+  html2canvas-pro@2.2.3:
     dependencies:
       css-line-break: 2.1.0
       text-segmentation: 1.0.3


### PR DESCRIPTION
## 배경 (PO 라이브 done-gate 적출)
PNG export가 머지(#2028/#2032)됐지만 dev 라이브서 **한 번도 성공한 적 없음**("내보내기가 되지 않았습니다"). 근본 2겹:
- **① CORS** (버킷 CORS 부재→서명URL PUT 차단) — **PO가 이미 fix**(PUT 200 실증). 이 축 닫힘.
- **② 이 PR** — CORS 뒤에도 fetch가 아예 안 뜸 = **캡처 단계 throw**. `captureElementAsPng`의 `html2canvas@1.4.1`이 앱 디자인 토큰의 `oklch()`/`color-mix(in oklch,…)`(globals.css 145곳)를 "unsupported color function"으로 throw → `export-dialog.tsx`의 빈 `catch{}`가 삼켜 `phase='error'`(콘솔/네트워크 흔적 0)라 진단이 어려웠음.

## fix
### 1. html2canvas → **html2canvas-pro** (canvas-export.ts)
드롭인 fork로 modern CSS 색 함수(oklch·color-mix·lab·lch)를 **네이티브 파싱** → 캡처 throw 없이 성공. 유일 import site 1곳(`await import('html2canvas-pro')`) 교체.

**measurement-first (PO 조건부 판정 — (a) 채택, (b) 전환조건 3개 다 불충족):**
| escape 조건 | 실측 | 판정 |
|---|---|---|
| ① API 비호환(호출부 대수술) | 같은 시그니처·옵션(`{backgroundColor,useCORS,scale}`)·default export·types 동봉 → **tsc/build 통과 실증** | 미충족 |
| ② 번들 과증(수백KB+) | **dynamic `import()` = lazy 청크**(export 시에만 로드·메인 번들 무증) | 미충족 |
| ③ 죽은 포크 | 최신 릴리스 **2026-07-07**(v2.2.3) | 미충족 |

→ (a) html2canvas-pro 확定, (b) 전환 불요.

### 2. silent catch 제거 (export-dialog.tsx · AC2 · 무조건)
빈 `catch{}` → `console.error(err)` + `errorDetail` 상태로 원인을 **UI(에러 문구 아래 mono 라인) + 로그** 양쪽에 노출. 이 버그가 "흔적 0"이라 진단 불가였던 근본을 끊음.

## 게이트
| gate | 결과 |
|---|---|
| tsc --noEmit | **EXIT 0** (html2canvas-pro 드롭인 컴파일 실증) |
| eslint | **EXIT 0** |
| vitest (canvas) | **53/53 pass** (13파일·회귀 0) |
| next build | **EXIT 0** |

## AC 대사
1. ⏳ dev 라이브 tree/image PNG export 실제 성공(서명URL PUT→complete→다운로드) — **오르테가 라이브 done-gate**(jsdom서 canvas 캡처 불가라 이 축은 배포後 실측).
2. ✅ 캡처 실패 시 silent 아님 — 원인이 UI 문구/로그에 노출(빈 catch 제거).
3. ⏳ 양테마·양뷰포트 캡처 조건 — 라이브 확認(코드 경로는 `applyCaptureConditions` 무변경).
4. ✅ html export 경로 무변경(회귀 0·canvas vitest green).
5. ⏳ 유나 UX 가디언 + CI green.

## ⚠️ 테스트 갭 (정직 고지)
- oklch 캡처 fix는 **jsdom서 실행 불가**(html2canvas-pro는 실 브라우저 canvas 필요) → 라이브 픽셀이 유일한 실증 축(PO done-gate).
- silent-catch 제거의 인터랙티브 렌더 테스트는 repo에 `@testing-library/react` 미존재(전 canvas 테스트가 static `renderToStaticMarkup`·error phase는 async 상호작용 필요) → 새 test dep 추가는 버그fix 스코프 밖이라 미추가. 기존 canvas vitest 회귀0로 커버.

🤖 Generated with [Claude Code](https://claude.com/claude-code)