### PR TITLE
[E-CANVAS C3-S7][FE·배선] 휴먼 딸깍 편집 라이브 도달 — ArtifactEditor 마운트 + onEnterEdit 배선 (story 687f2863)

### DIFF
--- a/apps/web/src/app/api/visual-artifacts/[id]/edit/route.ts
+++ b/apps/web/src/app/api/visual-artifacts/[id]/edit/route.ts
@@ -1,0 +1,24 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/**
+ * POST /api/visual-artifacts/{id}/edit — E-CANVAS C3-S7 딸깍 편집(휴먼) 커밋.
+ * MCP `sprintable_edit_artifact`(에이전트)와 **동일 BE 엔드포인트**(`_apply_artifact_edit`)로
+ * 프록시 — operations diff를 적용해 새 버전 생성. artifact.updated 이벤트는 BE가 dispatch
+ * (휴먼↔에이전트 양방향 도달). 신규 BE 0·프록시 plumbing만.
+ */
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    const _r = await proxyToFastapi(request, `/api/v2/visual-artifacts/${id}/edit`);
+    if (!_r.ok) return _r;
+    const json = (await _r.json()) as { data?: unknown };
+    return apiSuccess(json.data ?? null, undefined, 201);
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/components/canvas/artifact-section.tsx
+++ b/apps/web/src/components/canvas/artifact-section.tsx
@@ -2,13 +2,14 @@
 
 import { useEffect, useState } from 'react';
 import { ArtifactViewer } from './artifact-viewer';
+import { ArtifactEditor } from './artifact-editor';
 import {
-  adaptArtifactDetail, type ArtifactVersion, type BeArtifactVersionSummary, type MemberRef,
+  adaptArtifactDetail, editArtifact, type ArtifactVersion, type BeArtifactVersionSummary, type MemberRef,
   type VisualArtifact, type BeVisualArtifactDetail, type BeVisualArtifactSummary,
 } from '@/services/canvas';
 import { adaptComments, type BeArtifactComment, type CommentThread } from '@/services/canvas-comments';
 import { derivePendingCanonicalizeVersion, type CanonicalizeGateLookup } from '@/services/canvas-canonicalize';
-import type { ArtifactNode } from '@/services/canvas-nodes';
+import { deriveNodeOperations, type ArtifactNode } from '@/services/canvas-nodes';
 
 interface ArtifactSectionProps {
   storyId: string;
@@ -63,6 +64,9 @@ async function loadPendingCanonicalizeVersion(artifactId: string): Promise<numbe
  */
 export function ArtifactSection({ storyId, memberMap = {}, className }: ArtifactSectionProps) {
   const [items, setItems] = useState<ArtifactItem[]>([]);
+  // C3-S7 휴먼 딸깍 편집 — 어느 artifact가 편집 모드인지(tree만 진입·viewer가 게이트). 커밋 성공
+  // 후 종료해 fresh 재로드(BE가 버전마다 node.id 리매핑하므로 stale id 재사용 원천 차단).
+  const [editingArtifactId, setEditingArtifactId] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -116,24 +120,65 @@ export function ArtifactSection({ storyId, memberMap = {}, className }: Artifact
     setItems((cur) => cur.map((it) => (it.artifact.id === artifactId ? { ...it, pendingCanonicalizeVersion } : it)));
   }
 
+  /**
+   * 딸깍 편집 커밋 — 편집기의 최종 노드셋을 baseline(현 버전 노드)과 diff해 operations로 유도,
+   * MCP와 동일한 `/edit` 엔드포인트로 커밋(새 버전). 성공 시 새 detail로 아이템을 갱신하고 편집
+   * 모드를 종료(fresh 재로드·정본 불변). 변경 0이면 조용히 종료, 실패면 편집 유지(원인 로깅).
+   */
+  async function handleCommitEdit(item: ArtifactItem, committedNodes: ArtifactNode[], summary: string) {
+    const operations = deriveNodeOperations(item.nodes, committedNodes);
+    if (operations.length === 0) { setEditingArtifactId(null); return; }
+    const detail = await editArtifact(item.artifact.id, operations, summary);
+    if (!detail) {
+      // 빈 catch 금지 계열 — 커밋 실패를 삼키지 않고 로깅, 편집 모드 유지(사용자 재시도 가능).
+      console.error('[canvas-edit] artifact edit commit failed', item.artifact.id);
+      return;
+    }
+    const { artifact, versions } = adaptArtifactDetail(detail);
+    const [threads, pendingCanonicalizeVersion] = await Promise.all([
+      loadArtifactThreads(artifact.id, detail.nodes),
+      loadPendingCanonicalizeVersion(artifact.id),
+    ]);
+    setItems((cur) => cur.map((it) => (it.artifact.id === artifact.id
+      ? { artifact, versions, threads, nodes: detail.nodes, pendingCanonicalizeVersion }
+      : it)));
+    setEditingArtifactId(null);
+  }
+
   if (items.length === 0) return null;
 
   return (
     <div className={className}>
-      {items.map(({ artifact, versions, threads, nodes, pendingCanonicalizeVersion }) => (
-        <ArtifactViewer
-          key={artifact.id}
-          artifact={artifact}
-          versions={versions}
-          memberMap={memberMap}
-          threads={threads}
-          nodes={nodes}
-          onResolveThread={(threadId) => void handleResolve(artifact.id, nodes, threadId)}
-          onReplyThread={(threadId, body) => void handleReply(artifact.id, nodes, threadId, body)}
-          pendingCanonicalizeVersion={pendingCanonicalizeVersion}
-          onProposeCanonical={(versionNumber) => void handleProposeCanonical(artifact.id, versionNumber)}
-        />
-      ))}
+      {items.map((item) => {
+        const { artifact, versions, threads, nodes, pendingCanonicalizeVersion } = item;
+        // 편집 모드 = 뷰어 대신 편집기(같은 자리). tree 진입은 viewer의 onEnterEdit 게이트가 보장.
+        if (editingArtifactId === artifact.id) {
+          return (
+            <ArtifactEditor
+              key={artifact.id}
+              title={artifact.title}
+              initialNodes={nodes}
+              onCommit={(committed, summary) => void handleCommitEdit(item, committed, summary)}
+              onDone={() => setEditingArtifactId(null)}
+            />
+          );
+        }
+        return (
+          <ArtifactViewer
+            key={artifact.id}
+            artifact={artifact}
+            versions={versions}
+            memberMap={memberMap}
+            threads={threads}
+            nodes={nodes}
+            onEnterEdit={() => setEditingArtifactId(artifact.id)}
+            onResolveThread={(threadId) => void handleResolve(artifact.id, nodes, threadId)}
+            onReplyThread={(threadId, body) => void handleReply(artifact.id, nodes, threadId, body)}
+            pendingCanonicalizeVersion={pendingCanonicalizeVersion}
+            onProposeCanonical={(versionNumber) => void handleProposeCanonical(artifact.id, versionNumber)}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/src/services/canvas-nodes.test.ts
+++ b/apps/web/src/services/canvas-nodes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   resolveNodeTree, addNode, deleteNode, updateNodeProp, countNodeChanges, commitNodesToNextVersion,
+  deriveNodeOperations,
   type ArtifactNode,
 } from './canvas-nodes';
 
@@ -97,5 +98,59 @@ describe('commitNodesToNextVersion (⭐node.id 버전 간 안정성 — C1 계�
     const newId = withNew[3]!.id;
     const committed = commitNodesToNextVersion(withNew);
     expect(committed.some((n) => n.id === newId)).toBe(true);
+  });
+});
+
+describe('deriveNodeOperations (편집 baseline↔committed → BE /edit operations diff)', () => {
+  it('returns [] when nothing changed (커밋이 no-op이면 호출 안 함의 근거)', () => {
+    expect(deriveNodeOperations(BASE, BASE)).toEqual([]);
+  });
+
+  it('emits an add op (full fields, id 보존) for a newly-added node', () => {
+    const withNew = addNode(BASE, 'Image', 'root');
+    const newNode = withNew.find((n) => !BASE.some((b) => b.id === n.id))!;
+    const ops = deriveNodeOperations(BASE, withNew);
+    expect(ops).toEqual([
+      { op: 'add', id: newNode.id, type: 'Image', props: {}, parent_id: 'root', sort_order: newNode.sort_order, description: null },
+    ]);
+  });
+
+  it('emits a delete op with the target id for a removed node', () => {
+    const ops = deriveNodeOperations(BASE, deleteNode(BASE, 'child-b'));
+    expect(ops).toEqual([{ op: 'delete', id: 'child-b' }]);
+  });
+
+  it('emits an update op (full editable fields) for a prop edit', () => {
+    const ops = deriveNodeOperations(BASE, updateNodeProp(BASE, 'child-a', 'text', 'edited'));
+    expect(ops).toEqual([
+      { op: 'update', id: 'child-a', type: 'Text', props: { text: 'edited' }, parent_id: 'root', sort_order: 0, description: null },
+    ]);
+  });
+
+  it('⭐ captures a reorder-only change (sort_order 변경·add/delete 없음) as an update — 재정렬 커밋이 silent no-op 되지 않음', () => {
+    const reordered = BASE.map((n) => (n.id === 'child-a' ? { ...n, sort_order: 5 } : n));
+    const ops = deriveNodeOperations(BASE, reordered);
+    expect(ops).toEqual([
+      { op: 'update', id: 'child-a', type: 'Text', props: { text: 'a' }, parent_id: 'root', sort_order: 5, description: null },
+    ]);
+  });
+
+  it('captures a move (parent_id 변경) as an update', () => {
+    const moved = BASE.map((n) => (n.id === 'child-b' ? { ...n, parent_id: 'child-a' } : n));
+    const ops = deriveNodeOperations(BASE, moved);
+    expect(ops).toEqual([
+      { op: 'update', id: 'child-b', type: 'Button', props: { text: 'b' }, parent_id: 'child-a', sort_order: 1, description: null },
+    ]);
+  });
+
+  it('combines add + delete + update in one diff', () => {
+    let current = addNode(BASE, 'Image', 'root');
+    current = deleteNode(current, 'child-b');
+    current = updateNodeProp(current, 'child-a', 'text', 'edited');
+    const ops = deriveNodeOperations(BASE, current);
+    expect(ops.filter((o) => o.op === 'add')).toHaveLength(1);
+    expect(ops).toContainEqual({ op: 'delete', id: 'child-b' });
+    expect(ops.some((o) => o.op === 'update' && o.id === 'child-a')).toBe(true);
+    expect(ops).toHaveLength(3);
   });
 });

--- a/apps/web/src/services/canvas-nodes.ts
+++ b/apps/web/src/services/canvas-nodes.ts
@@ -96,6 +96,47 @@ export function countNodeChanges(baseline: ArtifactNode[], current: ArtifactNode
   return changes;
 }
 
+/** BE `ArtifactNodeOperation`(schemas/visual_artifact.py) 미러 — `/edit` 커밋 diff의 한 연산. */
+export interface NodeOperation {
+  op: 'add' | 'update' | 'delete';
+  id?: string;
+  type?: string;
+  props?: Record<string, unknown>;
+  parent_id?: string | null;
+  sort_order?: number;
+  description?: string | null;
+}
+
+/** update 비교/전송 대상 = 노드의 편집 가능 필드(id 제외). BE update는 지정 필드 전체교체라 변경 노드는 전 필드 전송. */
+function editableFields(n: ArtifactNode) {
+  return { type: n.type, props: n.props, parent_id: n.parent_id, sort_order: n.sort_order, description: n.description ?? null };
+}
+
+/**
+ * 편집 baseline↔committed 노드셋을 BE `/edit` 연산(add/update/delete)으로 유도한다 — `countNodeChanges`
+ * 와 동형 diff. baseline에만 있으면 delete, committed에만 있으면 add(전 필드), 양쪽에 있고 편집 필드가
+ * 다르면 update(전 필드 재전송·BE props 전체교체 계약). 변경 없으면 빈 배열(호출부가 no-op 처리).
+ * 살아있는 노드의 id는 그대로 실려 BE가 update/delete 대상을 매칭한다(node.id 안정성 계약, canvas-nodes §3).
+ */
+export function deriveNodeOperations(baseline: ArtifactNode[], committed: ArtifactNode[]): NodeOperation[] {
+  const baseMap = new Map(baseline.map((n) => [n.id, n]));
+  const curMap = new Map(committed.map((n) => [n.id, n]));
+  const ops: NodeOperation[] = [];
+  for (const id of baseMap.keys()) {
+    if (!curMap.has(id)) ops.push({ op: 'delete', id });
+  }
+  for (const n of committed) {
+    const base = baseMap.get(n.id);
+    const fields = editableFields(n);
+    if (!base) {
+      ops.push({ op: 'add', id: n.id, ...fields });
+    } else if (JSON.stringify(editableFields(base)) !== JSON.stringify(fields)) {
+      ops.push({ op: 'update', id: n.id, ...fields });
+    }
+  }
+  return ops;
+}
+
 export const PALETTE_TYPES = ['Container', 'Text', 'Button', 'Card', 'Image'] as const;
 
 export const MOCK_EDITABLE_NODES: ArtifactNode[] = [

--- a/apps/web/src/services/canvas.ts
+++ b/apps/web/src/services/canvas.ts
@@ -8,7 +8,7 @@
  * 준비됐고 머지되는 순간 이 파이프가 실 렌더로 이어진다.
  */
 
-import type { ArtifactNode } from './canvas-nodes';
+import type { ArtifactNode, NodeOperation } from './canvas-nodes';
 import { resolveNodeTree } from './canvas-nodes';
 
 export type ArtifactFormat = 'html' | 'tree' | 'image';
@@ -197,6 +197,31 @@ export function adaptArtifactDetail(detail: BeVisualArtifactDetail): { artifact:
     created_at: detail.created_at,
   };
   return { artifact, versions: [version] };
+}
+
+/**
+ * 딸깍 편집 커밋(C3-S7 휴먼 절반) — MCP `sprintable_edit_artifact`와 **동일 BE 엔드포인트**
+ * (`POST /api/v2/visual-artifacts/{id}/edit`·같은 서비스 `_apply_artifact_edit`·신규 BE 0).
+ * operations diff를 적용해 새 버전을 만들고 갱신된 detail을 반환한다. `artifact.updated` 이벤트
+ * 전파(휴먼↔에이전트 양방향 도달)는 BE가 수행 — FE는 배선만. 변경 0(빈 operations)이면 호출
+ * 안 함(BE operations non-empty 계약·재정렬 없는 커밋 방지).
+ */
+export async function editArtifact(
+  artifactId: string, operations: NodeOperation[], summary?: string,
+): Promise<BeVisualArtifactDetail | null> {
+  if (operations.length === 0) return null;
+  try {
+    const res = await fetch(`/api/visual-artifacts/${artifactId}/edit`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ operations, summary: summary ?? null }),
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as { data?: BeVisualArtifactDetail };
+    return json.data ?? null;
+  } catch {
+    return null;
+  }
 }
 
 export const MOCK_VERSIONS: ArtifactVersion[] = [


### PR DESCRIPTION
## 배경 (PO 라이브 done-gate 적출 · "빌드≠배선" 계열)
C3-S7(#2031)이 `ArtifactEditor`(팔레트·edit-canvas·PropertyPanel·commit bar)를 빌드+단위테스트했으나 **어느 소비자도 마운트하지 않음**(grep `ArtifactEditor` 소비자 0). `artifact-viewer`엔 `onEnterEdit` prop이 있으나 `artifact-section`이 핸들러를 안 넘겨 **휴먼 딸깍 편집이 스토리 상세서 도달 불가** = "양방향 동일 객체"의 **MCP 절반만 라이브, 휴먼 절반 미배선**. (story `687f2863` · [[컴포넌트 존재≠실제 렌더 배선]] 계열)

## 변경
- **`artifact-section.tsx`** — `editingArtifactId` 상태 + `onEnterEdit` 배선 + 편집모드 시 `ArtifactEditor` 마운트(뷰어 자리 대체). **tree 게이트는 viewer가 이미 함**(`format==='tree' && onEnterEdit`) → html/image 자동 제외(AC3). 커밋 성공 → 새 detail 재조회 + 편집모드 종료.
- **`canvas.ts` `editArtifact`** — MCP `sprintable_edit_artifact`(에이전트)와 **동일 BE 엔드포인트** `POST /{id}/edit`(같은 서비스 `_apply_artifact_edit`) 커밋 · **신규 BE 0**. `artifact.updated` 이벤트(양방향 도달)는 BE가 dispatch.
- **`canvas-nodes.ts` `deriveNodeOperations`** (순수·테스트) — 계약 갭 해소: BE `/edit`는 operations diff를 받는데 editor는 full nodes를 줌 → baseline↔committed를 add/update/delete로 유도(`countNodeChanges` 미러). ⭐**재정렬(sort_order/parent_id만 변경)도 update로 포착**(PO 엣지 지적 — 안 잡으면 재정렬 커밋 silent no-op).
- **`app/api/visual-artifacts/[id]/edit/route.ts`** (신규 프록시) — BE `/edit` 도달 plumbing(UI 라우트 0).

## 정합성 포인트
- **정본 불변**: commit=항상 새 버전(BE `_apply_artifact_edit`)·정본(anchor) 무변경(AC3).
- **멀티커밋 안전**: BE가 버전마다 node.id 리매핑 → 커밋 후 fresh 재로드로 stale id 재사용 원천 차단.
- **AC③ 양방향**: `/edit`가 `artifact.updated`를 artifact 생성자(편집자 제외) dispatch → 휴먼↔에이전트 교차 도달 = 같은 객체·같은 서비스 경로.

## 게이트
| gate | 결과 |
|---|---|
| vitest | **80/80 pass** (15파일·`deriveNodeOperations` 7 신규·**reorder 엣지 포함**·회귀 0) |
| tsc --noEmit | **EXIT 0** |
| eslint | **EXIT 0** |
| next build | **EXIT 0** (`/api/visual-artifacts/[id]/edit` 라우트 등록) |

## AC 대사
1. ✅ 스토리 상세 tree artifact서 편집 버튼 노출·클릭 시 ArtifactEditor 마운트(배선 완료·라이브는 배포後).
2. ⏳ [실증] 딸깍 편집→commit→새 버전·artifact.updated — **오르테가 라이브 done-gate**.
3. ✅ 정본 편집=새 버전(BE 계약)·html/image 진입 미노출(viewer 게이트).
4. ⏳ MCP↔휴먼 양방향 교차 — 배포後 라이브 실증(BE 동일 서비스 경로라 구조적 보장).
5. ⏳ 유나 UX 가디언 + CI green · 회귀 0(vitest green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)