### PR TITLE
[SID:7ff12083] Attention Queue 뷰 i18n 배선 — 1단계 델타

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1621,6 +1621,27 @@
     "grantFailed": "Grant failed",
     "adminOnlyHint": "Only org admin/owner can grant rewards"
   },
+  "attentionQueue": {
+    "kicker": "Today · Attention Queue",
+    "title": "Needs your call",
+    "count": "<b>{count}</b> to review · no log needed",
+    "allClear": "ALL CLEAR",
+    "emptyTitle": "Nothing needs your call",
+    "emptyBody": "Everything's flowing. Exceptions will show up here.",
+    "flowDemoted": "The rest is flowing — {overflow} more not shown here",
+    "kindVerifyFail": "Verify failed",
+    "kindDecisionNeeded": "Decision needed",
+    "kindBlocked": "Blocked",
+    "kindMergeReady": "Merge ready",
+    "claimVerifyFail": "{title} — CI check failed, needs rework",
+    "claimMergeReady": "{title} — Verified, ready to merge",
+    "claimDecisionNeeded": "{title} — needs a direction call",
+    "claimBlocked": "{title} — blocked by {count}, needs coordination",
+    "actionRework": "Send back",
+    "actionMerge": "Merge",
+    "actionDecide": "Decide",
+    "actionCoordinate": "Coordinate"
+  },
   "inbox": {
     "title": "Inbox",
     "attentionTabLabel": "Today",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1621,6 +1621,27 @@
     "grantFailed": "지급 실패",
     "adminOnlyHint": "조직 관리자/소유자만 리워드 지급 가능"
   },
+  "attentionQueue": {
+    "kicker": "오늘 · Attention Queue",
+    "title": "지금 개입할 것",
+    "count": "<b>{count}</b>건 · 로그 안 열고 판단",
+    "allClear": "ALL CLEAR",
+    "emptyTitle": "지금 개입할 것 없음",
+    "emptyBody": "모든 작업이 흐르고 있는. 예외가 생기면 여기 올라오는.",
+    "flowDemoted": "나머지는 흐르는 중 — {overflow}건은 여기 안 올림",
+    "kindVerifyFail": "검증 실패",
+    "kindDecisionNeeded": "결정 필요",
+    "kindBlocked": "막힘",
+    "kindMergeReady": "병합 대기",
+    "claimVerifyFail": "{title} — CI 검증 실패, 재작업 필요",
+    "claimMergeReady": "{title} — 검증 완료, 병합 대기",
+    "claimDecisionNeeded": "{title} — 방향 결정 필요",
+    "claimBlocked": "{title} — {count}건에 막혀 진행 불가, 조율 필요",
+    "actionRework": "재작업 지시",
+    "actionMerge": "병합",
+    "actionDecide": "결정",
+    "actionCoordinate": "조율"
+  },
   "inbox": {
     "title": "인박스",
     "attentionTabLabel": "오늘",

--- a/apps/web/src/components/attention-queue/attention-queue-view.tsx
+++ b/apps/web/src/components/attention-queue/attention-queue-view.tsx
@@ -2,15 +2,16 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { ShieldCheck } from 'lucide-react';
 import { ProofCapsule } from '@/components/proof-capsule/proof-capsule';
 import type { GateItem, DependencyEdge } from '@/components/kanban/types';
 import {
   deriveGateAttentionItems, deriveBlockedAttentionItems, buildAttentionQueue,
-  type AttentionStoryLite, type AttentionMember, type AttentionQueueItem,
+  type AttentionStoryLite, type AttentionMember, type AttentionQueueItem, type AttentionQueueTranslator,
 } from './derive-attention-queue';
 
-// P0-06("오늘" 구역) 착지 전까지 임시 스코프 — kanban 활성 상태만(done 제외, 개입 후보 풀).
+// 지금/Now 존(P0-06) 안 개입 후보 풀 — kanban 활성 상태만(done 제외).
 const ACTIVE_STATUSES = ['backlog', 'ready-for-dev', 'in-progress', 'in-review'];
 const CAP = 7;
 
@@ -37,7 +38,7 @@ async function fetchActiveStories(projectId: string): Promise<StoryListItem[]> {
   return results.flat();
 }
 
-async function fetchAttentionQueue(projectId: string): Promise<AttentionQueueItem[]> {
+async function fetchAttentionQueue(projectId: string, t: AttentionQueueTranslator): Promise<AttentionQueueItem[]> {
   const [gatesJson, graphJson, membersJson, stories] = await Promise.all([
     fetch('/api/gates?status=pending').then((r) => (r.ok ? r.json() : [])).catch(() => [] as GateItem[]),
     fetch('/api/dependencies/graph?item_type=story')
@@ -64,8 +65,8 @@ async function fetchAttentionQueue(projectId: string): Promise<AttentionQueueIte
   );
 
   return [
-    ...deriveGateAttentionItems(gates, storiesById, membersById),
-    ...deriveBlockedAttentionItems(blockedByMap, storiesById, membersById),
+    ...deriveGateAttentionItems(gates, storiesById, membersById, t),
+    ...deriveBlockedAttentionItems(blockedByMap, storiesById, membersById, t),
   ];
 }
 
@@ -102,14 +103,17 @@ function AttentionRow({ item, onNavigate }: { item: AttentionQueueItem; onNaviga
 }
 
 /**
- * Attention Queue(E-UI-DAEGBYEON P0-05, story 5f25c615). "지금 개입할 3~7개"만 — 원시 이벤트
- * 나열 아니라 판단이 필요한 것만. Proof Capsule row density 재사용(신규 컴포넌트 아님).
+ * Attention Queue(E-UI-DAEGBYEON P0-05, story 7ff12083, 설계 5f25c615). "지금 개입할 3~7개"만 —
+ * 원시 이벤트 나열 아니라 판단이 필요한 것만. Proof Capsule row density 재사용(신규 컴포넌트 아님).
+ * 배치 = `/inbox?tab=attention`(지금/Now 존·기존 인박스 병행 — PO 확定 2026-07-13).
  *
- * v1 스코프: 5유형 중 4개만(검증실패/결정필요/막힘/병합대기) — 범위이탈(Red)은 BE에 "승인범위
- * 밖" 판정 신호가 아직 없어 no-fiction 원칙상 제외(P0-04 착지 후 추가 예정, PO 승인·2026-07-11).
+ * 1단계 스코프: 5유형 중 4개만(검증실패/결정필요/막힘/병합대기) — 범위이탈(Red)은 BE에 "승인범위
+ * 밖" 판정 신호가 아직 없어 no-fiction 원칙상 제외(P0-04 파이프라인 impl 착지 후 추가 예정).
+ * 데이터 소스=클라 파생(derive-attention-queue.ts); 2단계에서 `/glance/attention` BE 계약으로 스왑.
  */
 export function AttentionQueueView({ projectId }: { projectId: string }) {
   const router = useRouter();
+  const t = useTranslations('attentionQueue');
   const [loading, setLoading] = useState(true);
   const [items, setItems] = useState<AttentionQueueItem[]>([]);
 
@@ -117,14 +121,14 @@ export function AttentionQueueView({ projectId }: { projectId: string }) {
     let cancelled = false;
     async function load() {
       setLoading(true);
-      const result = await fetchAttentionQueue(projectId);
+      const result = await fetchAttentionQueue(projectId, t);
       if (cancelled) return;
       setItems(result);
       setLoading(false);
     }
     void load();
     return () => { cancelled = true; };
-  }, [projectId]);
+  }, [projectId, t]);
 
   const { shown, overflow } = buildAttentionQueue(items, CAP);
 
@@ -132,12 +136,12 @@ export function AttentionQueueView({ projectId }: { projectId: string }) {
     <div className="overflow-hidden rounded-2xl border border-proof-line bg-proof-panel" style={{ clipPath: 'polygon(0 0, calc(100% - 24px) 0, 100% 24px, 100% 100%, 0 100%)' }}>
       <div className="flex items-baseline justify-between gap-3 border-b border-proof-line-soft px-5 py-3.5">
         <div>
-          <div className="text-[11px] font-bold uppercase tracking-[0.12em] text-proof-faint">오늘 · Attention Queue</div>
-          <h2 className="text-[19px] font-extrabold leading-tight tracking-[-0.014em] text-proof-ink">지금 개입할 것</h2>
+          <div className="text-[11px] font-bold uppercase tracking-[0.12em] text-proof-faint">{t('kicker')}</div>
+          <h2 className="text-[19px] font-extrabold leading-tight tracking-[-0.014em] text-proof-ink">{t('title')}</h2>
         </div>
         {!loading ? (
           <div className="shrink-0 text-[13px] font-medium text-proof-ink-3">
-            <b className="text-proof-ink">{shown.length}</b>건 · 로그 안 열고 판단
+            {t.rich('count', { count: shown.length, b: (chunks) => <b className="text-proof-ink">{chunks}</b> })}
           </div>
         ) : null}
       </div>
@@ -147,10 +151,10 @@ export function AttentionQueueView({ projectId }: { projectId: string }) {
       ) : shown.length === 0 ? (
         <div className="flex flex-col items-center gap-2 px-5 py-10 text-center">
           <div className="inline-flex items-center gap-1.5 text-[11px] font-bold tracking-[0.02em] text-proof-green">
-            <ShieldCheck className="size-3.5" aria-hidden="true" />ALL CLEAR
+            <ShieldCheck className="size-3.5" aria-hidden="true" />{t('allClear')}
           </div>
-          <p className="text-[15px] font-semibold text-proof-ink-2">지금 개입할 것 없음</p>
-          <p className="text-[12.5px] text-proof-faint">모든 작업이 흐르고 있는. 예외가 생기면 여기 올라오는.</p>
+          <p className="text-[15px] font-semibold text-proof-ink-2">{t('emptyTitle')}</p>
+          <p className="text-[12.5px] text-proof-faint">{t('emptyBody')}</p>
         </div>
       ) : (
         <div>
@@ -160,7 +164,7 @@ export function AttentionQueueView({ projectId }: { projectId: string }) {
           {overflow > 0 ? (
             <div className="flex items-center gap-1.5 border-t border-proof-line-soft bg-proof-sunk px-5 py-2.5 text-[12.5px] text-proof-ink-3">
               <span className="size-1 rounded-full bg-proof-faint" aria-hidden="true" />
-              나머지는 흐르는 중 — {overflow}건은 여기 안 올림
+              {t('flowDemoted', { overflow })}
             </div>
           ) : null}
         </div>

--- a/apps/web/src/components/attention-queue/derive-attention-queue.test.ts
+++ b/apps/web/src/components/attention-queue/derive-attention-queue.test.ts
@@ -1,9 +1,25 @@
 import { describe, expect, it } from 'vitest';
+import { createTranslator } from 'next-intl';
 import {
   deriveGateAttentionItems, deriveBlockedAttentionItems, buildAttentionQueue,
-  type AttentionStoryLite, type AttentionMember, type AttentionQueueItem,
+  type AttentionStoryLite, type AttentionMember, type AttentionQueueItem, type AttentionQueueTranslator,
 } from './derive-attention-queue';
 import type { GateItem } from '@/components/kanban/types';
+import koMessagesRaw from '../../../messages/ko.json';
+import enMessagesRaw from '../../../messages/en.json';
+
+// production `t` (useTranslations()) resolves against the permissive default `IntlMessages`
+// generic (no global next-intl message-type augmentation in this repo) — cast here so the test
+// translator has the same loose type instead of the JSON import's inferred literal-key type.
+type LooseMessages = { [key: string]: string | LooseMessages };
+const koMessages = koMessagesRaw as unknown as LooseMessages;
+const enMessages = enMessagesRaw as unknown as LooseMessages;
+// next-intl's Translator<M,N> overload set doesn't structurally satisfy our minimal
+// AttentionQueueTranslator call-signature for a non-literal LooseMessages import (same
+// friction as loop-create-dialog.test.tsx's RecipeTranslator) — cast at the boundary, runtime
+// behavior is unaffected (createTranslator's t(key, values) works exactly as at production).
+const t = createTranslator({ locale: 'ko', messages: koMessages, namespace: 'attentionQueue' }) as unknown as AttentionQueueTranslator;
+const tEn = createTranslator({ locale: 'en', messages: enMessages, namespace: 'attentionQueue' }) as unknown as AttentionQueueTranslator;
 
 function gate(overrides: Partial<GateItem> = {}): GateItem {
   return {
@@ -26,7 +42,7 @@ const members = new Map<string, AttentionMember>([
 describe('deriveGateAttentionItems', () => {
   it('maps merge gate + ci_result=fail to verify_fail (amber, neutral tone)', () => {
     const items = deriveGateAttentionItems(
-      [gate({ neutral_facts: { ci_result: 'fail' } })], stories, members,
+      [gate({ neutral_facts: { ci_result: 'fail' } })], stories, members, t,
     );
     expect(items).toHaveLength(1);
     expect(items[0]!.kind).toBe('verify_fail');
@@ -37,7 +53,7 @@ describe('deriveGateAttentionItems', () => {
 
   it('maps merge gate + ci_result=pass to merge_ready (green, ready tone)', () => {
     const items = deriveGateAttentionItems(
-      [gate({ neutral_facts: { ci_result: 'pass' } })], stories, members,
+      [gate({ neutral_facts: { ci_result: 'pass' } })], stories, members, t,
     );
     expect(items[0]!.kind).toBe('merge_ready');
     expect(items[0]!.proofState).toBe('green');
@@ -46,25 +62,25 @@ describe('deriveGateAttentionItems', () => {
 
   it('maps loop_decision gate to decision_needed (amber, primary tone) regardless of ci_result', () => {
     const items = deriveGateAttentionItems(
-      [gate({ gate_type: 'loop_decision', neutral_facts: null })], stories, members,
+      [gate({ gate_type: 'loop_decision', neutral_facts: null })], stories, members, t,
     );
     expect(items[0]!.kind).toBe('decision_needed');
     expect(items[0]!.actionTone).toBe('primary');
   });
 
   it('resolves the assignee as actor when present, omits when absent (no-fiction)', () => {
-    const withActor = deriveGateAttentionItems([gate({ neutral_facts: { ci_result: 'fail' } })], stories, members);
+    const withActor = deriveGateAttentionItems([gate({ neutral_facts: { ci_result: 'fail' } })], stories, members, t);
     expect(withActor[0]!.actor).toEqual({ name: '미르코', isAgent: true });
 
     const withoutActor = deriveGateAttentionItems(
-      [gate({ work_item_id: 'story-2', neutral_facts: { ci_result: 'fail' } })], stories, members,
+      [gate({ work_item_id: 'story-2', neutral_facts: { ci_result: 'fail' } })], stories, members, t,
     );
     expect(withoutActor[0]!.actor).toBeNull();
   });
 
   it('skips gates whose story is unknown (never fabricates a claim)', () => {
     const items = deriveGateAttentionItems(
-      [gate({ work_item_id: 'story-unknown', neutral_facts: { ci_result: 'fail' } })], stories, members,
+      [gate({ work_item_id: 'story-unknown', neutral_facts: { ci_result: 'fail' } })], stories, members, t,
     );
     expect(items).toHaveLength(0);
   });
@@ -76,15 +92,25 @@ describe('deriveGateAttentionItems', () => {
         gate({ status: 'rejected', neutral_facts: { ci_result: 'fail' } }),
         gate({ gate_type: 'merge', neutral_facts: { ci_result: null } }), // no honest signal → skip
       ],
-      stories, members,
+      stories, members, t,
     );
     expect(items).toHaveLength(0);
+  });
+
+  it('renders claim/kindLabel/actionLabel in English when given the en translator (ko/en parity)', () => {
+    const items = deriveGateAttentionItems(
+      [gate({ neutral_facts: { ci_result: 'fail' } })], stories, members, tEn,
+    );
+    expect(items[0]!.kindLabel).toBe('Verify failed');
+    expect(items[0]!.actionLabel).toBe('Send back');
+    expect(items[0]!.claim).toContain('CI check failed');
+    expect(items[0]!.claim).not.toContain('CI 검증 실패');
   });
 });
 
 describe('deriveBlockedAttentionItems', () => {
   it('maps a non-empty blockedByMap entry to a blocked item with the real blocker count', () => {
-    const items = deriveBlockedAttentionItems({ 'story-1': ['story-9', 'story-10'] }, stories, members);
+    const items = deriveBlockedAttentionItems({ 'story-1': ['story-9', 'story-10'] }, stories, members, t);
     expect(items).toHaveLength(1);
     expect(items[0]!.kind).toBe('blocked');
     expect(items[0]!.claim).toContain('2건');
@@ -93,9 +119,14 @@ describe('deriveBlockedAttentionItems', () => {
 
   it('skips empty blocker arrays and unknown story ids', () => {
     const items = deriveBlockedAttentionItems(
-      { 'story-1': [], 'story-unknown': ['story-9'] }, stories, members,
+      { 'story-1': [], 'story-unknown': ['story-9'] }, stories, members, t,
     );
     expect(items).toHaveLength(0);
+  });
+
+  it('renders the blocked count in English when given the en translator', () => {
+    const items = deriveBlockedAttentionItems({ 'story-1': ['story-9', 'story-10'] }, stories, members, tEn);
+    expect(items[0]!.claim).toContain('blocked by 2');
   });
 });
 

--- a/apps/web/src/components/attention-queue/derive-attention-queue.ts
+++ b/apps/web/src/components/attention-queue/derive-attention-queue.ts
@@ -34,13 +34,14 @@ export interface AttentionMember {
   type: 'human' | 'agent';
 }
 
-export const ATTENTION_KIND_LABEL: Record<AttentionKind, string> = {
-  verify_fail: '검증 실패',
-  decision_needed: '결정 필요',
-  gate_pending: '승인 대기',
-  blocked: '막힘',
-  merge_ready: '병합 대기',
-};
+/** next-intl `useTranslations('attentionQueue')`의 `t` 표면만 뽑은 최소 구조 타입(call-signature) —
+ * 파생 함수는 React 밖이라 값으로 주입받는다(derive-exception-signals.ts의 ExceptionLabels 주입
+ * 패턴과 동형). 함수 타입 별칭 대신 call-signature로 선언해 next-intl `Translator<M,N>`의 깊은
+ * 오버로드 제네릭에 결합하지 않고 테스트의 `createTranslator()` 결과도 그대로 대입 가능
+ * (loop-create-dialog.tsx `RecipeTranslator` 선례). */
+export interface AttentionQueueTranslator {
+  (key: string, values?: Record<string, string | number>): string;
+}
 
 function actorFor(
   story: AttentionStoryLite | undefined,
@@ -75,6 +76,7 @@ export function deriveGateAttentionItems(
   gates: GateItem[],
   storiesById: Map<string, AttentionStoryLite>,
   membersById: Map<string, AttentionMember>,
+  t: AttentionQueueTranslator,
 ): AttentionQueueItem[] {
   const items: AttentionQueueItem[] = [];
   for (const gate of gates) {
@@ -87,21 +89,21 @@ export function deriveGateAttentionItems(
 
     if (gate.gate_type === 'merge' && ciResult === 'fail') {
       items.push({
-        ...base, kind: 'verify_fail', kindLabel: ATTENTION_KIND_LABEL.verify_fail,
-        proofState: PROOF_STATE.verify_fail, claim: `${story.title} — CI 검증 실패, 재작업 필요`,
-        actionLabel: '재작업 지시', actionTone: 'neutral',
+        ...base, kind: 'verify_fail', kindLabel: t('kindVerifyFail'),
+        proofState: PROOF_STATE.verify_fail, claim: t('claimVerifyFail', { title: story.title }),
+        actionLabel: t('actionRework'), actionTone: 'neutral',
       });
     } else if (gate.gate_type === 'merge' && ciResult === 'pass') {
       items.push({
-        ...base, kind: 'merge_ready', kindLabel: ATTENTION_KIND_LABEL.merge_ready,
-        proofState: PROOF_STATE.merge_ready, claim: `${story.title} — 검증 완료, 병합 대기`,
-        actionLabel: '병합', actionTone: 'ready',
+        ...base, kind: 'merge_ready', kindLabel: t('kindMergeReady'),
+        proofState: PROOF_STATE.merge_ready, claim: t('claimMergeReady', { title: story.title }),
+        actionLabel: t('actionMerge'), actionTone: 'ready',
       });
     } else if (gate.gate_type === 'loop_decision') {
       items.push({
-        ...base, kind: 'decision_needed', kindLabel: ATTENTION_KIND_LABEL.decision_needed,
-        proofState: PROOF_STATE.decision_needed, claim: `${story.title} — 방향 결정 필요`,
-        actionLabel: '결정', actionTone: 'primary',
+        ...base, kind: 'decision_needed', kindLabel: t('kindDecisionNeeded'),
+        proofState: PROOF_STATE.decision_needed, claim: t('claimDecisionNeeded', { title: story.title }),
+        actionLabel: t('actionDecide'), actionTone: 'primary',
       });
     }
   }
@@ -116,6 +118,7 @@ export function deriveBlockedAttentionItems(
   blockedByMap: Record<string, string[]>,
   storiesById: Map<string, AttentionStoryLite>,
   membersById: Map<string, AttentionMember>,
+  t: AttentionQueueTranslator,
 ): AttentionQueueItem[] {
   const items: AttentionQueueItem[] = [];
   for (const [storyId, blockers] of Object.entries(blockedByMap)) {
@@ -125,11 +128,11 @@ export function deriveBlockedAttentionItems(
     items.push({
       id: `blocked-${storyId}`,
       kind: 'blocked',
-      kindLabel: ATTENTION_KIND_LABEL.blocked,
+      kindLabel: t('kindBlocked'),
       proofState: PROOF_STATE.blocked,
-      claim: `${story.title} — ${blockers.length}건에 막혀 진행 불가, 조율 필요`,
+      claim: t('claimBlocked', { title: story.title, count: blockers.length }),
       actor: actorFor(story, membersById),
-      actionLabel: '조율',
+      actionLabel: t('actionCoordinate'),
       actionTone: 'neutral',
       href: `/board?story=${story.id}`,
       sortKey: 0,


### PR DESCRIPTION
## 요약
E-UI-DAEGBYEON P0-05 story `7ff12083`. 그라운딩 결과 **PR #2067**(story 5f25c615 인용으로 머지)이 이미 Attention Queue 1단계 대부분을 develop에 착지시켜 놓은 상태였음(오르테가 gh 대조 확認 완료, conv `32b8cff9`). 재작업 대신 실측 갭만 채우는 델타 PR — story는 반드시 이 PR로 추적(#2067이 설계 스토리 id로 나가는 바람에 보드↔코드 추적이 두 번 꼬였던 것 재발 방지).

## 확인된 기존 상태 (변경 없음)
- row 52px · Proofline 좌 레일(`CutCornerShell`) · 3–7 cap + overflow "흐름" 강등 · 빈상태 ALL CLEAR(positive) · Workcell 딥링크(`/board?story=`)
- 색 매핑이 오늘 확定된 `attention-queue-fe-spec-handoff`와 정확히 일치(검증실패/결정필요/막힘=Amber·병합대기=Green·범위이탈 Red는 no-fiction으로 생략)
- 데이터 소스 = 클라 파생(`derive-attention-queue.ts`) — 1단계 지시 그대로
- 배치(`/inbox?tab=attention`, 지금/Now 존) — PO 확定 유지, 별도 라우트 미분리(IA 1차 내비 7개 이하 원칙·"Inbox를 AQ로 재발명" 종착지 정합)

## 진짜 갭 — AC1(ko/en) 미달
뷰 전체 문자열이 next-intl 미경유·한국어 하드코딩(kicker/헤더/count/empty/flow/kind 라벨/claim 템플릿). en.json엔 탭 라벨(`attentionTabLabel`) 1개만 있고 뷰 본문은 0.

## 변경
- `messages/{ko,en}.json`: `attentionQueue` 네임스페이스 신설(19키).
- `derive-attention-queue.ts`: `AttentionQueueTranslator`(call-signature 타입 — `loop-create-dialog.tsx`의 `RecipeTranslator` 선례 재사용, next-intl `Translator<M,N>` 깊은 오버로드 제네릭에 결합 안 함)를 `deriveGateAttentionItems`/`deriveBlockedAttentionItems`에 주입 — `derive-exception-signals.ts`의 `ExceptionLabels` 값-주입 패턴과 동형(파생 함수는 React 밖이라 `t`를 값으로 받음). **`AttentionQueueItem` 타입 자체는 무변경** — `exception-stream.tsx`(E-GLANCE 예외 스트림) 등 기존 소비자 회귀 0(의존성 확인 완료).
- `attention-queue-view.tsx`: `useTranslations('attentionQueue')` 배선, `t.rich`로 count 안의 숫자만 bold 유지, 나머지 헤더/empty/flow 문자열 전부 `t()` 경유.

## 테스트
- `derive-attention-queue.test.ts`: `createTranslator`(ko/en 실 메시지 픽스처, `loop-create-dialog.test.tsx` 패턴 재사용)로 언어별 렌더 검증 2건 신규(en 로케일 시 `claim`/`kindLabel`/`actionLabel`이 영문으로 렌더되고 한국어 잔재 없음을 단언).
- 전체 vitest **1257 passed / 2 skipped**(회귀 0) · tsc **0** · eslint **0 warning** · `pnpm build` **exit 0**.

## 잔여
- 유나 UX 가디언 GREEN(리포트 P0-05 대조·양테마·배치 판단 포함) + 까심 QA APPROVE + CI green 후 오르테가 머지.
- dev 배포 후 라이브픽셀(양테마) done-gate.
- **2단계**(디디 `d17ac3c3` BE 계약 착지 後 `/glance/attention` 5신호로 데이터 소스 스왑) = 별도 후속, 이 PR 스코프 밖.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>