### PR TITLE
feat(story): P0-03 human_owner_member_id (story 23b9bdac)

### DIFF
--- a/backend/alembic/versions/0176_story_human_owner_member_id.py
+++ b/backend/alembic/versions/0176_story_human_owner_member_id.py
@@ -1,0 +1,39 @@
+"""P0-03(story 23b9bdac·doc trust-pipeline-be-design §5) — stories.human_owner_member_id.
+
+Revision ID: 0176
+Revises: 0175
+Create Date: 2026-07-13
+
+"에이전트가 교체되어도 인간 책임과 승인 라인이 사라지지 않음" — Human owner를 기존
+assignee_id/assignee_ids(혼합 human/agent 리스트)와 별도 필드로 분리. 순수 additive
+nullable 컬럼 — 기존 story 전부 무영향, 백필 없음. agent_delegate_ids는 신규 저장 없이
+기존 assignee_ids를 Member.type=="agent"로 필터한 파생 뷰(BE 서비스 레이어)로 충분하다.
+
+⚠️ FK 의도적 미부여: member 참조는 team_members(VIEW, TeamMember 모델)/org_members
+양쪽에 걸쳐 해소되는 값이라 단일 물리 테이블을 대상으로 한 DB-level FK가 성립하지
+않는다(Gate.resolver_id·Evidence.created_by·Story.assignee_id와 동일 기존 패턴 — 전부
+bare UUID 컬럼, app-level resolve_member_identity 검증만). members(앵커) 테이블은
+"코드가 아직 읽지/쓰지 않는" 별도 토대(app/models/member.py 문서화)라 그걸 FK 타겟으로
+쓰면 실제 회수되는 team_member id와 어긋난다.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0176"
+down_revision = "0175"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "stories",
+        sa.Column("human_owner_member_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("stories", "human_owner_member_id")

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -102,6 +102,13 @@ class Story(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True
     )
+    # P0-03(doc trust-pipeline-be-design §5·story 23b9bdac): Human owner — assignee_id/assignee_ids
+    # (혼합 human/agent)와 별도 필드. 0176 additive nullable. FK 미부여(assignee_id와 동일 이유 —
+    # team_members VIEW/org_members 양쪽 해소값이라 단일 물리 FK 불가). write-time에 resolve_
+    # member_identity로 human 강제(app-level).
+    human_owner_member_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True
+    )
     meeting_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("meetings.id", ondelete="SET NULL"), nullable=True
     )

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -136,11 +136,32 @@ async def list_stories(
     return [StoryResponse.model_validate(s) for s in stories]
 
 
+async def _attach_agent_delegate_ids(session: AsyncSession, stories: list[Story]) -> None:
+    """P0-03(doc trust-pipeline-be-design §5): 각 Story에 agent_delegate_ids(transient attr)를
+    채운다 — assignee_ids(이미 세팅돼 있다고 가정)를 Member.type=="agent"로 필터한 파생 뷰(신규
+    저장 0). N+1 회피 위해 배치. `_attach_assignee_ids` 뒤에, 또는 create_story처럼 assignee_ids를
+    인라인으로 세팅한 직후 호출한다."""
+    if not stories:
+        return
+    from app.services.member_resolver import lookup_members_by_ids
+
+    all_ids: set[uuid.UUID] = set()
+    for s in stories:
+        all_ids.update(s.assignee_ids)
+    resolved = await lookup_members_by_ids(all_ids, session)
+    for s in stories:
+        s.agent_delegate_ids = [
+            mid for mid in s.assignee_ids if resolved.get(mid) and resolved[mid].type == "agent"
+        ]
+
+
 async def _attach_assignee_ids(
     session: AsyncSession, org_id: uuid.UUID, stories: list[Story]
 ) -> None:
     """E-BOARD S5: 각 Story에 assignee_ids(transient attr)를 채워 StoryResponse.from_attributes가
-    읽도록 한다. join 비어있으면 단일 assignee_id로 폴백(레거시 행 back-compat). N+1 회피 위해 배치."""
+    읽도록 한다. join 비어있으면 단일 assignee_id로 폴백(레거시 행 back-compat). N+1 회피 위해 배치.
+
+    P0-03(doc trust-pipeline-be-design §5): 같은 배치에서 agent_delegate_ids도 채운다."""
     if not stories:
         return
     sa_repo = StoryAssigneeRepository(session, org_id)
@@ -150,6 +171,7 @@ async def _attach_assignee_ids(
         if not ids:
             ids = [s.assignee_id] if s.assignee_id else []
         s.assignee_ids = ids  # 매핑되지 않은 transient 속성 — from_attributes 전용
+    await _attach_agent_delegate_ids(session, stories)
 
 
 async def _attach_has_evidence(session: AsyncSession, stories: list[Story]) -> None:
@@ -289,6 +311,24 @@ async def _assert_story_link_targets_in_project(
             )
 
 
+async def _assert_human_owner(
+    session: AsyncSession, org_id: uuid.UUID, member_id: uuid.UUID | None,
+) -> None:
+    """P0-03(doc trust-pipeline-be-design §5) write-time 강제: human_owner_member_id로 지정된
+    member가 human이 아니면(에이전트·미해소) 400. resolve_member_identity 재사용(evidence_service의
+    gate_approval choke-point와 동일 SOUL-LOCK 규율 — body-claimed 신뢰 대신 서버 해소값만 신뢰)."""
+    if member_id is None:
+        return
+    from app.services.member_resolver import resolve_member_identity
+
+    resolved = await resolve_member_identity(member_id, org_id, session)
+    if resolved is None or resolved.type != "human":
+        raise HTTPException(
+            status_code=400,
+            detail="human_owner_member_id는 human member만 지정할 수 있습니다.",
+        )
+
+
 @router.post("", response_model=StoryResponse, status_code=201)
 async def create_story(
     body: StoryCreate,
@@ -306,6 +346,7 @@ async def create_story(
         user_id=uuid.UUID(auth.user_id),
     )
     await _assert_story_link_targets_in_project(session, body.project_id, body)
+    await _assert_human_owner(session, org_id, body.human_owner_member_id)
     repo = StoryRepository(session, org_id)
     # E-BOARD S5: assignee_ids 제공 시 단일 assignee_id(주담당)는 첫 요소로 동기화(미지정 시).
     effective_ids = (
@@ -328,6 +369,7 @@ async def create_story(
         epic_id=body.epic_id,
         sprint_id=body.sprint_id,
         assignee_id=primary_assignee,
+        human_owner_member_id=body.human_owner_member_id,
         meeting_id=body.meeting_id,
         status=body.status,
         priority=body.priority,
@@ -369,6 +411,9 @@ async def create_story(
     if primary_assignee:
         await _upsert_assignee_participation(session, org_id, story.id, primary_assignee)
     story.assignee_ids = saved_ids or ([story.assignee_id] if story.assignee_id else [])
+    # P0-03(doc trust-pipeline-be-design §5): agent_delegate_ids(transient) — update_story는
+    # _attach_assignee_ids 경유로 이미 채워지나, create_story는 인라인 경로라 별도 호출 필요.
+    await _attach_agent_delegate_ids(session, [story])
     # 활동로그: story 생성 이벤트 기록 (생성류 미기록 갭 — 피드 정상화)
     from app.services.activity_log import record_created_activity
     await record_created_activity(
@@ -682,6 +727,8 @@ async def update_story(
         raise HTTPException(status_code=404, detail="Story not found")
     await _assert_story_project_access(db, auth, repo.org_id, _story_for_access.project_id)
     await _assert_story_link_targets_in_project(db, _story_for_access.project_id, body)
+    if body.human_owner_member_id is not None:
+        await _assert_human_owner(db, repo.org_id, body.human_owner_member_id)
 
     data = body.model_dump(exclude_unset=True)
     # S7: client 제공 asset_id strip(서버 권위·drift 방지·까심)·아래 sync url_map 으로만 역기입.

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -101,6 +101,9 @@ class StoryCreate(BaseModel):
     assignee_id: uuid.UUID | None = None
     # E-BOARD S5: 복수 assignee. 미지정(None)이면 assignee_id 단독 동작(back-compat).
     assignee_ids: list[uuid.UUID] | None = None
+    # P0-03(doc trust-pipeline-be-design §5): Human owner(assignee와 별도 책임 필드). 라우터가
+    # write-time에 human 강제(비-human 지정 시 400).
+    human_owner_member_id: uuid.UUID | None = None
     # E-FILE S4: 보드 스토리 첨부 (기본 [], 최대 10).
     attachments: list[StoryAttachment] = []
     meeting_id: uuid.UUID | None = None
@@ -133,6 +136,8 @@ class StoryUpdate(BaseModel):
     assignee_id: uuid.UUID | None = None
     # E-BOARD S5: 복수 assignee. 미지정(None)이면 join 미변경(back-compat).
     assignee_ids: list[uuid.UUID] | None = None
+    # P0-03(doc trust-pipeline-be-design §5): Human owner. 미지정(exclude_unset)이면 변경 안 함.
+    human_owner_member_id: uuid.UUID | None = None
     # E-FILE S4: 보드 스토리 첨부. 미지정(None)이면 변경 안 함(back-compat).
     attachments: list[StoryAttachment] | None = None
     meeting_id: uuid.UUID | None = None
@@ -175,6 +180,16 @@ class StoryResponse(BaseModel):
     assignee_id: uuid.UUID | None = None
     # E-BOARD S5: 복수 assignee. join 테이블 멤버. 레거시 행은 [assignee_id] 폴백.
     assignee_ids: list[uuid.UUID] = []
+    # P0-03(doc trust-pipeline-be-design §5): Human owner — 실 컬럼(ORM 그대로 노출).
+    human_owner_member_id: uuid.UUID | None = None
+    # agent_delegate_ids: assignee_ids를 Member.type=="agent"로 필터한 파생 뷰(신규 저장 0) —
+    # ORM 컬럼 아님·라우터가 model_validate 前 transient attr로 세팅(assignee_ids 패턴 동형).
+    agent_delegate_ids: list[uuid.UUID] = []
+
+    @field_validator("agent_delegate_ids", mode="before")
+    @classmethod
+    def _coerce_agent_delegate_ids(cls, v):
+        return v if isinstance(v, list) else []
     # E-FILE S4: 보드 스토리 첨부 (column 값). list 아니면 [](레거시 None/mock 안전).
     attachments: list[dict] = []
     meeting_id: uuid.UUID | None = None

--- a/backend/tests/test_e_cage_referee_p1_exclusion.py
+++ b/backend/tests/test_e_cage_referee_p1_exclusion.py
@@ -95,6 +95,10 @@ async def test_patch_story_is_excluded_true():
     marked_story.sprint_id = None
     marked_story.assignee_id = None
     marked_story.assignee_ids = []
+    # P0-03(doc trust-pipeline-be-design §5): 신규 필드 — MagicMock 반환 MagicMock이 Pydantic UUID
+    # 검증 실패하므로 명시 세팅.
+    marked_story.human_owner_member_id = None
+    marked_story.agent_delegate_ids = []
     marked_story.meeting_id = None
     # E-BOARD S5: update_story가 _attach_assignee_ids로 story_assignees 조회 → 빈 결과 모킹
     # E-SECURITY SEC-S8(G): update_story가 이제 먼저 repo.get(id)(access 체크용) +

--- a/backend/tests/test_e_cage_referee_p1_participation_api.py
+++ b/backend/tests/test_e_cage_referee_p1_participation_api.py
@@ -26,6 +26,10 @@ def _mock_story_obj(assignee_id=None):
     s.sprint_id = None
     s.assignee_id = assignee_id
     s.assignee_ids = [assignee_id] if assignee_id else []  # E-BOARD S5
+    # P0-03(doc trust-pipeline-be-design §5): 신규 필드 — MagicMock 반환 MagicMock이 Pydantic UUID
+    # 검증 실패하므로 명시 세팅.
+    s.human_owner_member_id = None
+    s.agent_delegate_ids = []
     s.meeting_id = None
     s.title = "Story 1"
     s.status = "backlog"
@@ -84,6 +88,15 @@ async def _make_client(mock_session):
 async def test_create_story_with_assignee_auto_creates_participation():
     """create_story + assignee → _upsert_assignee_participation 호출 단언."""
     mock_session = AsyncMock()
+    # P0-03(doc trust-pipeline-be-design §5): create_story가 assignee 有 시 _attach_agent_delegate_ids
+    # →lookup_members_by_ids로 신규 session.execute(select(TeamMember)...) 호출 — 미설정 AsyncMock은
+    # .scalars()가 코루틴을 반환해 .all() 실패(test_update_story_...와 동일 _empty 패턴 재사용).
+    _empty = MagicMock()
+    _empty.all.return_value = []
+    _empty.scalars.return_value.all.return_value = []
+    _empty.scalar_one_or_none.return_value = 1
+    _empty.scalar.return_value = None
+    mock_session.execute.return_value = _empty
     story = _mock_story_obj(assignee_id=MEMBER_ID)
 
     client, app = await _make_client(mock_session)

--- a/backend/tests/test_e_event_inject_s3_assignment_wake.py
+++ b/backend/tests/test_e_event_inject_s3_assignment_wake.py
@@ -30,6 +30,10 @@ def _story(assignee_id):
     s.sprint_id = None
     s.assignee_id = assignee_id
     s.assignee_ids = [assignee_id] if assignee_id else []
+    # P0-03(doc trust-pipeline-be-design §5): 신규 필드 — MagicMock 반환 MagicMock이 Pydantic UUID
+    # 검증 실패하므로 명시 세팅.
+    s.human_owner_member_id = None
+    s.agent_delegate_ids = []
     s.meeting_id = None
     s.title = "Build login"
     s.description = "OAuth + password"

--- a/backend/tests/test_e_ui_daegbyeon_p0_03_human_owner_realdb.py
+++ b/backend/tests/test_e_ui_daegbyeon_p0_03_human_owner_realdb.py
@@ -1,0 +1,296 @@
+"""E-UI-DAEGBYEON P0-03(story 23b9bdac·doc trust-pipeline-be-design §5) — 실 PG.
+
+Story.human_owner_member_id(신규 additive 컬럼) write-time human 강제 + agent_delegate_ids
+(assignee_ids를 Member.type=="agent"로 필터한 파생 뷰) + 에이전트 교체 후 owner 생존 실증.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org+project + human(Member type=human+project_access)·agent1/agent2(Member type=agent+
+    agent_project_profiles) — team_members VIEW(members⋈project_access/agent_project_profiles)를
+    통해 resolve_member_identity/lookup_members_by_ids가 찾도록 실제 backing 테이블에 시드.
+    + caller(OrgMember·project grant, 별도 auth 경로)."""
+    from app.models.member import AgentProjectProfile, Member
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="A")
+    session.add(project)
+    await session.commit()
+
+    human_member = Member(id=uuid.uuid4(), org_id=org.id, type="human", name="Human Owner")
+    agent1 = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent One")
+    agent2 = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent Two")
+    session.add_all([human_member, agent1, agent2])
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, member_id=human_member.id,
+        permission="granted", role="member",
+    ))
+    session.add_all([
+        AgentProjectProfile(id=uuid.uuid4(), member_id=agent1.id, project_id=project.id),
+        AgentProjectProfile(id=uuid.uuid4(), member_id=agent2.id, project_id=project.id),
+    ])
+    await session.commit()
+
+    caller_id = uuid.uuid4()
+    caller = User(id=caller_id, email=f"caller-{caller_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(caller)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=caller_id, role="member")
+    session.add(om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=om.id, permission="granted", role="member",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "caller_id": caller_id,
+        "human_id": human_member.id, "agent1_id": agent1.id, "agent2_id": agent2.id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id, project_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_create_story_with_human_owner_201():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/stories", json={
+                "project_id": str(seeded["project_id"]), "org_id": str(seeded["org_id"]),
+                "title": "Story", "human_owner_member_id": str(seeded["human_id"]),
+            })
+            assert resp.status_code == 201, resp.text
+            assert resp.json()["human_owner_member_id"] == str(seeded["human_id"])
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_story_with_agent_owner_400():
+    """write-time 강제(AC2) — agent를 human_owner로 지정 시 400·story 자체도 미생성."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/stories", json={
+                "project_id": str(seeded["project_id"]), "org_id": str(seeded["org_id"]),
+                "title": "Story", "human_owner_member_id": str(seeded["agent1_id"]),
+            })
+            assert resp.status_code == 400, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_agent_delegate_ids_derived_from_assignee_ids():
+    """agent_delegate_ids = assignee_ids를 Member.type=='agent'로 필터(신규 저장 0). human
+    assignee는 delegate에서 제외되고 assignee_ids 자체는 무변경(회귀0)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/stories", json={
+                "project_id": str(seeded["project_id"]), "org_id": str(seeded["org_id"]),
+                "title": "Story",
+                "assignee_ids": [str(seeded["human_id"]), str(seeded["agent1_id"]), str(seeded["agent2_id"])],
+            })
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert set(body["assignee_ids"]) == {
+                str(seeded["human_id"]), str(seeded["agent1_id"]), str(seeded["agent2_id"]),
+            }
+            assert set(body["agent_delegate_ids"]) == {str(seeded["agent1_id"]), str(seeded["agent2_id"])}
+            assert str(seeded["human_id"]) not in body["agent_delegate_ids"]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_human_owner_survives_agent_reassignment():
+    """AC 핵심 — "에이전트가 교체되어도 인간 책임과 승인 라인이 사라지지 않음". assignee_ids를
+    agent1→agent2로 교체(PATCH)해도 human_owner_member_id는 무변경."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/stories", json={
+                "project_id": str(seeded["project_id"]), "org_id": str(seeded["org_id"]),
+                "title": "Story",
+                "human_owner_member_id": str(seeded["human_id"]),
+                "assignee_ids": [str(seeded["agent1_id"])],
+            })
+            assert create_resp.status_code == 201, create_resp.text
+            story_id = create_resp.json()["id"]
+
+            patch_resp = await client.patch(f"/api/v2/stories/{story_id}", json={
+                "assignee_ids": [str(seeded["agent2_id"])],
+            })
+            assert patch_resp.status_code == 200, patch_resp.text
+            body = patch_resp.json()
+            assert body["human_owner_member_id"] == str(seeded["human_id"])  # 생존
+            assert body["assignee_ids"] == [str(seeded["agent2_id"])]
+            assert body["agent_delegate_ids"] == [str(seeded["agent2_id"])]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_story_agent_owner_400_and_original_owner_unchanged():
+    """PATCH로 human_owner_member_id를 agent로 바꾸려는 시도 → 400·기존 owner 무변경(부분실패 없음)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/stories", json={
+                "project_id": str(seeded["project_id"]), "org_id": str(seeded["org_id"]),
+                "title": "Story", "human_owner_member_id": str(seeded["human_id"]),
+            })
+            story_id = create_resp.json()["id"]
+
+            patch_resp = await client.patch(f"/api/v2/stories/{story_id}", json={
+                "human_owner_member_id": str(seeded["agent1_id"]),
+            })
+            assert patch_resp.status_code == 400, patch_resp.text
+
+            get_resp = await client.get(f"/api/v2/stories/{story_id}")
+            assert get_resp.json()["human_owner_member_id"] == str(seeded["human_id"])
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_human_owner_omitted_defaults_to_none_no_regression():
+    """human_owner_member_id 미지정 → None(기존 story 생성 흐름 회귀 0)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        await _setup_app(app, Session, seeded["caller_id"], seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/stories", json={
+                "project_id": str(seeded["project_id"]), "org_id": str(seeded["org_id"]),
+                "title": "Story",
+            })
+            assert resp.status_code == 201, resp.text
+            assert resp.json()["human_owner_member_id"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_stories.py
+++ b/backend/tests/test_stories.py
@@ -19,6 +19,10 @@ def _mock_story(status: str = "backlog") -> MagicMock:
     s.epic_id = None
     s.sprint_id = None
     s.assignee_id = None
+    # P0-03(doc trust-pipeline-be-design §5): 신규 필드 — MagicMock 반환 MagicMock이 Pydantic UUID
+    # 검증 실패하므로 명시 세팅(위 outcome 필드와 동일 이유).
+    s.human_owner_member_id = None
+    s.agent_delegate_ids = []
     s.meeting_id = None
     s.title = "Story 1"
     s.status = status


### PR DESCRIPTION
## Summary
- doc `trust-pipeline-be-design` §5 구현(story 23b9bdac). "에이전트가 교체되어도 인간 책임과 승인 라인이 사라지지 않음."
- 신규 컬럼 **1개만**: `stories.human_owner_member_id`(nullable, migration 0176, additive) — FK 미부여(assignee_id와 동일 이유: member 참조는 `team_members` VIEW(members⋈project_access/agent_project_profiles)/`org_members` 양쪽 걸쳐 해소되는 값이라 단일 물리 테이블 FK가 성립하지 않음).
- write-time 강제: `resolve_member_identity` 재사용 — 지정 member가 human이 아니면 400(body-claimed 금지·evidence_service의 gate_approval SOUL-LOCK choke-point와 동일 규율 재사용).
- `agent_delegate_ids`(응답 전용, 신규 저장 0): 기존 `assignee_ids`를 `lookup_members_by_ids`로 배치 조회해 `Member.type=="agent"`만 필터한 파생 뷰. `_attach_agent_delegate_ids` 헬퍼로 GET/PATCH/POST 전 경로 공통 배선.
- `assignee_id`/`assignee_ids` 기존 동작 완전 무변경(regression 0).

## Test plan
- [x] realdb 6 pass: human 지정→201·agent 지정→400·`agent_delegate_ids` 파생(human 제외)·에이전트 교체(PATCH) 후 human_owner 생존·PATCH로 agent owner 시도→400+원본 유지·미지정 시 None.
- [x] 기존 story/epic/task 라우터 회귀 스위트(290+ tests, 로컬 PG alembic head 0176) 전부 green — 2개 mock 픽스처(test_stories.py·test_e_cage_referee_p1_exclusion.py)에 신규 필드 None 명시(기존 outcome 필드 패턴과 동형).
- [x] ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)