### PR TITLE
[SID:7ff12083] AQ 데이터 소스 클라 파생→BE 계약 스왑 — 2단계(P0 완주 마지막 조각)

### DIFF
--- a/apps/web/src/components/attention-queue/attention-queue-view.tsx
+++ b/apps/web/src/components/attention-queue/attention-queue-view.tsx
@@ -5,69 +5,19 @@ import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { ShieldCheck } from 'lucide-react';
 import { ProofCapsule } from '@/components/proof-capsule/proof-capsule';
-import type { GateItem, DependencyEdge } from '@/components/kanban/types';
 import {
-  deriveGateAttentionItems, deriveBlockedAttentionItems, buildAttentionQueue,
-  type AttentionStoryLite, type AttentionMember, type AttentionQueueItem, type AttentionQueueTranslator,
+  parseAttentionQueueSignals, buildAttentionQueueFromBe, buildAttentionQueue,
+  type AttentionQueueItem, type AttentionQueueTranslator,
 } from './derive-attention-queue';
 
-// 지금/Now 존(P0-06) 안 개입 후보 풀 — kanban 활성 상태만(done 제외).
-const ACTIVE_STATUSES = ['backlog', 'ready-for-dev', 'in-progress', 'in-review'];
 const CAP = 7;
 
-interface StoryListItem {
-  id: string;
-  title: string;
-  assignee_id: string | null;
-}
-
-interface TeamMemberItem {
-  id: string;
-  name: string | null;
-  type: 'human' | 'agent';
-}
-
-async function fetchActiveStories(projectId: string): Promise<StoryListItem[]> {
-  const results = await Promise.all(ACTIVE_STATUSES.map((status) => {
-    const params = new URLSearchParams({ project_id: projectId, status, limit: '100' });
-    return fetch(`/api/stories?${params}`)
-      .then((r) => (r.ok ? r.json() : null))
-      .then((json: { data?: StoryListItem[] } | null) => json?.data ?? [])
-      .catch(() => [] as StoryListItem[]);
-  }));
-  return results.flat();
-}
-
 async function fetchAttentionQueue(projectId: string, t: AttentionQueueTranslator): Promise<AttentionQueueItem[]> {
-  const [gatesJson, graphJson, membersJson, stories] = await Promise.all([
-    fetch('/api/gates?status=pending').then((r) => (r.ok ? r.json() : [])).catch(() => [] as GateItem[]),
-    fetch('/api/dependencies/graph?item_type=story')
-      .then((r) => (r.ok ? r.json() : null))
-      .catch(() => null as { edges?: DependencyEdge[] } | null),
-    fetch('/api/team-members')
-      .then((r) => (r.ok ? r.json() : { data: [] }))
-      .catch(() => ({ data: [] as TeamMemberItem[] })),
-    fetchActiveStories(projectId),
-  ]);
-
-  const gates = gatesJson as GateItem[];
-  const blockedByMap: Record<string, string[]> = {};
-  for (const edge of (graphJson as { edges?: DependencyEdge[] } | null)?.edges ?? []) {
-    if (edge.dep_type === 'blocks') (blockedByMap[edge.to_id] ??= []).push(edge.from_id);
-  }
-  const members = ((membersJson as { data?: TeamMemberItem[] }).data ?? []);
-
-  const storiesById = new Map<string, AttentionStoryLite>(
-    stories.map((s) => [s.id, { id: s.id, title: s.title, assignee_id: s.assignee_id }]),
-  );
-  const membersById = new Map<string, AttentionMember>(
-    members.map((m) => [m.id, { name: m.name, type: m.type }]),
-  );
-
-  return [
-    ...deriveGateAttentionItems(gates, storiesById, membersById, t),
-    ...deriveBlockedAttentionItems(blockedByMap, storiesById, membersById, t),
-  ];
+  const json = await fetch(`/api/glance/attention?project_id=${projectId}`)
+    .then((r) => (r.ok ? r.json() : null))
+    .catch(() => null);
+  const signals = parseAttentionQueueSignals(json);
+  return buildAttentionQueueFromBe(signals, t);
 }
 
 function RowSkeleton() {
@@ -107,9 +57,12 @@ function AttentionRow({ item, onNavigate }: { item: AttentionQueueItem; onNaviga
  * 원시 이벤트 나열 아니라 판단이 필요한 것만. Proof Capsule row density 재사용(신규 컴포넌트 아님).
  * 배치 = `/inbox?tab=attention`(지금/Now 존·기존 인박스 병행 — PO 확定 2026-07-13).
  *
- * 1단계 스코프: 5유형 중 4개만(검증실패/결정필요/막힘/병합대기) — 범위이탈(Red)은 BE에 "승인범위
- * 밖" 판정 신호가 아직 없어 no-fiction 원칙상 제외(P0-04 파이프라인 impl 착지 후 추가 예정).
- * 데이터 소스=클라 파생(derive-attention-queue.ts); 2단계에서 `/glance/attention` BE 계약으로 스왑.
+ * 2단계(BE 계약 스왑) 완료: 데이터 소스 = `/glance/attention`(P0-04 trust 파이프라인 파생, doc
+ * trust-pipeline-be-design §6). 4유형(검증실패/결정필요[needs_input+gate_pending 합류]/막힘/
+ * 병합대기) — 범위이탈(Red)은 BE가 §7 확定②로 여전히 미구현이라 항상 빈 신호(no-fiction 렌더
+ * 생략). actor(human/agent 아바타)는 BE `AttentionItem`에 assignee 필드가 없어 당분간 없음
+ * (P0-03 `human_owner_member_id` 노출 시 복원 예정 — 별도 low 스토리). SSE 실시간 반영(P0-04
+ * "새로고침 없이" 완료기준의 잔여)은 BE 브릿지 미비로 이 스토리 스코프 밖(별도 high 스토리).
  */
 export function AttentionQueueView({ projectId }: { projectId: string }) {
   const router = useRouter();

--- a/apps/web/src/components/attention-queue/derive-attention-queue.test.ts
+++ b/apps/web/src/components/attention-queue/derive-attention-queue.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { createTranslator } from 'next-intl';
 import {
-  deriveGateAttentionItems, deriveBlockedAttentionItems, buildAttentionQueue,
-  type AttentionStoryLite, type AttentionMember, type AttentionQueueItem, type AttentionQueueTranslator,
+  parseAttentionQueueSignals, buildAttentionQueueFromBe, buildAttentionQueue,
+  type BeAttentionItem, type AttentionQueueItem, type AttentionQueueTranslator,
 } from './derive-attention-queue';
-import type { GateItem } from '@/components/kanban/types';
 import koMessagesRaw from '../../../messages/ko.json';
 import enMessagesRaw from '../../../messages/en.json';
 
@@ -21,111 +20,132 @@ const enMessages = enMessagesRaw as unknown as LooseMessages;
 const t = createTranslator({ locale: 'ko', messages: koMessages, namespace: 'attentionQueue' }) as unknown as AttentionQueueTranslator;
 const tEn = createTranslator({ locale: 'en', messages: enMessages, namespace: 'attentionQueue' }) as unknown as AttentionQueueTranslator;
 
-function gate(overrides: Partial<GateItem> = {}): GateItem {
-  return {
-    id: 'gate-1', work_item_id: 'story-1', work_item_type: 'story', gate_type: 'merge',
-    status: 'pending', resolver_id: null, resolved_at: null, resolution_note: null,
-    neutral_facts: null, created_at: '2026-07-01T00:00:00Z', updated_at: '2026-07-01T00:00:00Z',
-    ...overrides,
-  };
+function beItem(overrides: Partial<BeAttentionItem> = {}): BeAttentionItem {
+  return { kind: 'verify_fail', story_id: 'story-1', title: '결제 복구 플로우', ref: {}, ...overrides };
 }
 
-const stories = new Map<string, AttentionStoryLite>([
-  ['story-1', { id: 'story-1', title: '결제 복구 플로우', assignee_id: 'm-1' }],
-  ['story-2', { id: 'story-2', title: '온보딩 위저드', assignee_id: null }],
-]);
+describe('parseAttentionQueueSignals', () => {
+  it('unwraps the double-wrapped {data:{items}} proxy envelope', () => {
+    const items = parseAttentionQueueSignals({ data: { items: [beItem()] } });
+    expect(items).toHaveLength(1);
+    expect(items[0]!.kind).toBe('verify_fail');
+  });
 
-const members = new Map<string, AttentionMember>([
-  ['m-1', { name: '미르코', type: 'agent' }],
-]);
+  it('unwraps the raw BE {items} shape (no proxy wrap)', () => {
+    const items = parseAttentionQueueSignals({ items: [beItem({ kind: 'blocked' })] });
+    expect(items).toHaveLength(1);
+  });
 
-describe('deriveGateAttentionItems', () => {
-  it('maps merge gate + ci_result=fail to verify_fail (amber, neutral tone)', () => {
-    const items = deriveGateAttentionItems(
-      [gate({ neutral_facts: { ci_result: 'fail' } })], stories, members, t,
-    );
+  it('returns [] for malformed shapes (no items array anywhere) — throw 0', () => {
+    expect(parseAttentionQueueSignals(null)).toEqual([]);
+    expect(parseAttentionQueueSignals(undefined)).toEqual([]);
+    expect(parseAttentionQueueSignals({ foo: 'bar' })).toEqual([]);
+    expect(parseAttentionQueueSignals('not an object')).toEqual([]);
+  });
+
+  it('keeps all 5 known BE kinds including gate_pending (PO 콜: 결정필요 버킷 합류)', () => {
+    const items = parseAttentionQueueSignals({
+      items: [
+        beItem({ kind: 'gate_pending' }),
+        beItem({ kind: 'blocked' }),
+        beItem({ kind: 'merge_ready' }),
+        beItem({ kind: 'needs_input' }),
+        beItem({ kind: 'verify_fail' }),
+      ],
+    });
+    expect(items).toHaveLength(5);
+  });
+
+  it('skips unknown/malformed kinds without crashing (no-fiction)', () => {
+    const items = parseAttentionQueueSignals({
+      items: [beItem(), { kind: 'scope_violation', story_id: 's', title: 't', ref: {} }, { kind: 123 }],
+    });
+    expect(items).toHaveLength(1);
+  });
+
+  it('skips items missing title or story_id (cannot fabricate claim/href)', () => {
+    const items = parseAttentionQueueSignals({
+      items: [
+        beItem({ title: null }),
+        beItem({ title: '' }),
+        beItem({ story_id: null }),
+      ],
+    });
+    expect(items).toHaveLength(0);
+  });
+});
+
+describe('buildAttentionQueueFromBe', () => {
+  it('maps verify_fail to an amber/neutral-tone item', () => {
+    const items = buildAttentionQueueFromBe([beItem({ kind: 'verify_fail' })], t);
     expect(items).toHaveLength(1);
     expect(items[0]!.kind).toBe('verify_fail');
     expect(items[0]!.proofState).toBe('amber');
     expect(items[0]!.actionTone).toBe('neutral');
     expect(items[0]!.claim).toContain('결제 복구 플로우');
+    expect(items[0]!.actor).toBeNull(); // BE AttentionItem엔 assignee 필드 없음(no-fiction)
+    expect(items[0]!.href).toBe('/board?story=story-1');
   });
 
-  it('maps merge gate + ci_result=pass to merge_ready (green, ready tone)', () => {
-    const items = deriveGateAttentionItems(
-      [gate({ neutral_facts: { ci_result: 'pass' } })], stories, members, t,
-    );
+  it('maps merge_ready to a green/ready-tone item', () => {
+    const items = buildAttentionQueueFromBe([beItem({ kind: 'merge_ready' })], t);
     expect(items[0]!.kind).toBe('merge_ready');
     expect(items[0]!.proofState).toBe('green');
     expect(items[0]!.actionTone).toBe('ready');
   });
 
-  it('maps loop_decision gate to decision_needed (amber, primary tone) regardless of ci_result', () => {
-    const items = deriveGateAttentionItems(
-      [gate({ gate_type: 'loop_decision', neutral_facts: null })], stories, members, t,
-    );
+  it('maps needs_input to internal decision_needed (amber/primary-tone)', () => {
+    const items = buildAttentionQueueFromBe([beItem({ kind: 'needs_input' })], t);
     expect(items[0]!.kind).toBe('decision_needed');
     expect(items[0]!.actionTone).toBe('primary');
   });
 
-  it('resolves the assignee as actor when present, omits when absent (no-fiction)', () => {
-    const withActor = deriveGateAttentionItems([gate({ neutral_facts: { ci_result: 'fail' } })], stories, members, t);
-    expect(withActor[0]!.actor).toEqual({ name: '미르코', isAgent: true });
-
-    const withoutActor = deriveGateAttentionItems(
-      [gate({ work_item_id: 'story-2', neutral_facts: { ci_result: 'fail' } })], stories, members, t,
-    );
-    expect(withoutActor[0]!.actor).toBeNull();
+  it('maps gate_pending to internal decision_needed too (PO 콜: 스킵 대신 결정필요 합류)', () => {
+    const items = buildAttentionQueueFromBe([beItem({ kind: 'gate_pending' })], t);
+    expect(items[0]!.kind).toBe('decision_needed');
   });
 
-  it('skips gates whose story is unknown (never fabricates a claim)', () => {
-    const items = deriveGateAttentionItems(
-      [gate({ work_item_id: 'story-unknown', neutral_facts: { ci_result: 'fail' } })], stories, members, t,
-    );
-    expect(items).toHaveLength(0);
+  it('merges gate_pending + needs_input on the same story into one decision_needed row', () => {
+    const items = buildAttentionQueueFromBe([
+      beItem({ kind: 'gate_pending', story_id: 'story-1' }),
+      beItem({ kind: 'needs_input', story_id: 'story-1' }),
+    ], t);
+    expect(items).toHaveLength(1);
+    expect(items[0]!.kind).toBe('decision_needed');
   });
 
-  it('skips non-story gates (e.g. doc_approval) and non-pending gates', () => {
-    const items = deriveGateAttentionItems(
-      [
-        gate({ work_item_type: 'doc', gate_type: 'doc_approval' }),
-        gate({ status: 'rejected', neutral_facts: { ci_result: 'fail' } }),
-        gate({ gate_type: 'merge', neutral_facts: { ci_result: null } }), // no honest signal → skip
-      ],
-      stories, members, t,
-    );
-    expect(items).toHaveLength(0);
+  it('keeps decision_needed rows for distinct stories separate', () => {
+    const items = buildAttentionQueueFromBe([
+      beItem({ kind: 'needs_input', story_id: 'story-1' }),
+      beItem({ kind: 'gate_pending', story_id: 'story-2', title: '온보딩 위저드' }),
+    ], t);
+    expect(items).toHaveLength(2);
   });
 
-  it('renders claim/kindLabel/actionLabel in English when given the en translator (ko/en parity)', () => {
-    const items = deriveGateAttentionItems(
-      [gate({ neutral_facts: { ci_result: 'fail' } })], stories, members, tEn,
-    );
-    expect(items[0]!.kindLabel).toBe('Verify failed');
-    expect(items[0]!.actionLabel).toBe('Send back');
-    expect(items[0]!.claim).toContain('CI check failed');
-    expect(items[0]!.claim).not.toContain('CI 검증 실패');
-  });
-});
-
-describe('deriveBlockedAttentionItems', () => {
-  it('maps a non-empty blockedByMap entry to a blocked item with the real blocker count', () => {
-    const items = deriveBlockedAttentionItems({ 'story-1': ['story-9', 'story-10'] }, stories, members, t);
+  it('aggregates multiple blocked edges for the same story into one row with the real blocker count', () => {
+    const items = buildAttentionQueueFromBe([
+      beItem({ kind: 'blocked', story_id: 'story-1' }),
+      beItem({ kind: 'blocked', story_id: 'story-1' }),
+    ], t);
     expect(items).toHaveLength(1);
     expect(items[0]!.kind).toBe('blocked');
     expect(items[0]!.claim).toContain('2건');
     expect(items[0]!.claim).toContain('결제 복구 플로우');
   });
 
-  it('skips empty blocker arrays and unknown story ids', () => {
-    const items = deriveBlockedAttentionItems(
-      { 'story-1': [], 'story-unknown': ['story-9'] }, stories, members, t,
-    );
-    expect(items).toHaveLength(0);
+  it('renders claim/kindLabel/actionLabel in English when given the en translator (ko/en parity)', () => {
+    const items = buildAttentionQueueFromBe([beItem({ kind: 'verify_fail' })], tEn);
+    expect(items[0]!.kindLabel).toBe('Verify failed');
+    expect(items[0]!.actionLabel).toBe('Send back');
+    expect(items[0]!.claim).toContain('CI check failed');
+    expect(items[0]!.claim).not.toContain('CI 검증 실패');
   });
 
   it('renders the blocked count in English when given the en translator', () => {
-    const items = deriveBlockedAttentionItems({ 'story-1': ['story-9', 'story-10'] }, stories, members, tEn);
+    const items = buildAttentionQueueFromBe([
+      beItem({ kind: 'blocked', story_id: 'story-1' }),
+      beItem({ kind: 'blocked', story_id: 'story-1' }),
+    ], tEn);
     expect(items[0]!.claim).toContain('blocked by 2');
   });
 });

--- a/apps/web/src/components/attention-queue/derive-attention-queue.ts
+++ b/apps/web/src/components/attention-queue/derive-attention-queue.ts
@@ -1,5 +1,4 @@
 import type { ProofState } from '@/components/proof-capsule/proof-capsule';
-import type { GateItem } from '@/components/kanban/types';
 
 export type AttentionKind = 'verify_fail' | 'decision_needed' | 'gate_pending' | 'blocked' | 'merge_ready';
 
@@ -18,20 +17,9 @@ export interface AttentionQueueItem {
   actionLabel: string;
   actionTone: 'primary' | 'neutral' | 'ready';
   href: string;
-  /** 정렬용 epoch ms. 실 타임스탬프가 없는 유형(예: 막힘 — 의존성 엣지엔 시각 필드 없음)은
-   * 0으로 정직하게 처리(지어낸 최신순 아님 — 동급 티어 내 안정적 후순위). */
+  /** 정렬용 epoch ms. BE `/glance/attention`(P0-04)이 신호에 타임스탬프를 안 실어(정직 미가용)
+   * 전부 0 — 동급 티어 내 안정적 후순위(지어낸 최신순 아님). */
   sortKey: number;
-}
-
-export interface AttentionStoryLite {
-  id: string;
-  title: string;
-  assignee_id: string | null;
-}
-
-export interface AttentionMember {
-  name: string | null;
-  type: 'human' | 'agent';
 }
 
 /** next-intl `useTranslations('attentionQueue')`의 `t` 표면만 뽑은 최소 구조 타입(call-signature) —
@@ -43,20 +31,59 @@ export interface AttentionQueueTranslator {
   (key: string, values?: Record<string, string | number>): string;
 }
 
-function actorFor(
-  story: AttentionStoryLite | undefined,
-  membersById: Map<string, AttentionMember>,
-): AttentionActor | null {
-  if (!story?.assignee_id) return null;
-  const m = membersById.get(story.assignee_id);
-  if (!m?.name) return null;
-  return { name: m.name, isAgent: m.type === 'agent' };
+/** BE `AttentionItem`(glance.py:36) 미러. scope_violation은 BE가 §7 확定②로 미구현이라 kind
+ * 자체가 절대 등장 X. */
+export type BeAttentionKind = 'gate_pending' | 'blocked' | 'merge_ready' | 'needs_input' | 'verify_fail';
+
+export interface BeAttentionItem {
+  kind: BeAttentionKind;
+  story_id: string | null;
+  title: string | null;
+  ref: Record<string, unknown>;
 }
 
-function toEpoch(iso: string | undefined): number {
-  if (!iso) return 0;
-  const t = new Date(iso).getTime();
-  return Number.isFinite(t) ? t : 0;
+/** AQ가 소비하는 kind 전체(scope_violation은 BE가 §7 확定②로 미구현이라 kind 자체가 절대 미등장 —
+ * 별도 필터 불요). `gate_pending`(pending blocking approval)도 "사람 판단 대기"의 대표격이라
+ * AQ 결정필요 버킷에 합류(PO 콜 2026-07-13 — 스킵 시 결재가 기다리는데 ALL CLEAR를 띄우는
+ * 거짓 표면이 됨). doc `trust-pipeline-be-design` §6 PO amend로 계약 SSOT 정합. */
+const KNOWN_KINDS = new Set<BeAttentionKind>(['gate_pending', 'blocked', 'merge_ready', 'needs_input', 'verify_fail']);
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** `{data:{items}}`(프록시 wrap) → `{items}`(raw BE) → 둘 다 아니면 그대로.
+ * derive-exception-signals.ts의 unwrapEnvelope와 동형(같은 프록시·같은 BE 응답 계약). */
+function unwrapEnvelope(json: unknown): unknown {
+  if (!isRecord(json)) return json;
+  const d = json['data'];
+  return d ?? json;
+}
+
+/**
+ * 실 payload → 검증된 신호 배열. 형상 불일치는 전부 조용히 생략(throw 0). 제목·story_id 없는
+ * 항목은 claim/href를 지어낼 수 없으니 제외(no-fiction). `gate_pending`과 미지 kind는
+ * KNOWN_KINDS 밖이라 자동 생략(exception-stream의 동일 원칙 재사용).
+ */
+export function parseAttentionQueueSignals(json: unknown): BeAttentionItem[] {
+  const inner = unwrapEnvelope(json);
+  const rawItems = Array.isArray(inner) ? inner : isRecord(inner) ? inner['items'] : null;
+  if (!Array.isArray(rawItems)) return [];
+
+  const signals: BeAttentionItem[] = [];
+  for (const raw of rawItems) {
+    if (!isRecord(raw)) continue;
+    const kind = raw['kind'];
+    if (typeof kind !== 'string' || !KNOWN_KINDS.has(kind as BeAttentionKind)) continue;
+    const title = typeof raw['title'] === 'string' ? (raw['title'] as string).trim() : '';
+    if (!title) continue;
+    const rawStoryId = raw['story_id'];
+    const story_id = typeof rawStoryId === 'string' && rawStoryId ? rawStoryId : null;
+    if (!story_id) continue; // href/집계 키를 지어낼 수 없으니 제외(no-fiction)
+    const ref = isRecord(raw['ref']) ? (raw['ref'] as Record<string, unknown>) : {};
+    signals.push({ kind: kind as BeAttentionKind, story_id, title, ref });
+  }
+  return signals;
 }
 
 const PROOF_STATE: Record<AttentionKind, ProofState> = {
@@ -68,74 +95,60 @@ const PROOF_STATE: Record<AttentionKind, ProofState> = {
 };
 
 /**
- * gate(type=merge)의 neutral_facts.ci_result로 검증실패/병합대기를 분기하고,
- * gate(type=loop_decision, 항상-수동)를 결정필요로 매핑한다. story 제목을 모르는 gate(=
- * storiesById에 없는 work_item_id)는 claim을 지어낼 수 없어 통째로 생략(no-fiction).
+ * 검증된 BE 신호 → AQ 렌더 항목. `needs_input`·`gate_pending` 둘 다 내부 `decision_needed`
+ * (기존 i18n 키/카피 무변경) 매핑 — 같은 story에 둘 다 뜨면 story_id 기준 1행으로 합침(개입
+ * 사유는 하나, PO 콜 2026-07-13). BE `AttentionItem`엔 assignee 필드가 없어 actor는 항상
+ * null(지어내지 않음 — derive-exception-signals.ts의 동일 선택 재사용). `blocked`도 BE가 차단
+ * 엣지 1개당 1행을 주므로 story_id별 집계해 실 차단 건수를 claim에 반영(v1 클라 파생과 동일
+ * UX·집계 지점만 이동).
  */
-export function deriveGateAttentionItems(
-  gates: GateItem[],
-  storiesById: Map<string, AttentionStoryLite>,
-  membersById: Map<string, AttentionMember>,
+export function buildAttentionQueueFromBe(
+  signals: BeAttentionItem[],
   t: AttentionQueueTranslator,
 ): AttentionQueueItem[] {
   const items: AttentionQueueItem[] = [];
-  for (const gate of gates) {
-    if (gate.work_item_type !== 'story' || gate.status !== 'pending') continue;
-    const story = storiesById.get(gate.work_item_id);
-    if (!story) continue;
-    const actor = actorFor(story, membersById);
-    const ciResult = gate.neutral_facts?.['ci_result'];
-    const base = { id: `gate-${gate.id}`, actor, href: `/board?story=${story.id}`, sortKey: toEpoch(gate.updated_at) };
+  const blockedByStory = new Map<string, { title: string; count: number }>();
+  const decisionNeededByStory = new Map<string, string>(); // story_id → title(첫 등장 것)
 
-    if (gate.gate_type === 'merge' && ciResult === 'fail') {
+  for (const sig of signals) {
+    if (!sig.title || !sig.story_id) continue; // 방어적 재확인(parseAttentionQueueSignals가 이미 보장하지만 직접호출 대비)
+    if (sig.kind === 'blocked') {
+      const entry = blockedByStory.get(sig.story_id) ?? { title: sig.title, count: 0 };
+      entry.count += 1;
+      blockedByStory.set(sig.story_id, entry);
+    } else if (sig.kind === 'needs_input' || sig.kind === 'gate_pending') {
+      if (!decisionNeededByStory.has(sig.story_id)) decisionNeededByStory.set(sig.story_id, sig.title);
+    } else if (sig.kind === 'verify_fail') {
       items.push({
-        ...base, kind: 'verify_fail', kindLabel: t('kindVerifyFail'),
-        proofState: PROOF_STATE.verify_fail, claim: t('claimVerifyFail', { title: story.title }),
-        actionLabel: t('actionRework'), actionTone: 'neutral',
+        id: `verify_fail-${sig.story_id}`, kind: 'verify_fail', kindLabel: t('kindVerifyFail'),
+        proofState: PROOF_STATE.verify_fail, claim: t('claimVerifyFail', { title: sig.title }),
+        actor: null, actionLabel: t('actionRework'), actionTone: 'neutral',
+        href: `/board?story=${sig.story_id}`, sortKey: 0,
       });
-    } else if (gate.gate_type === 'merge' && ciResult === 'pass') {
+    } else if (sig.kind === 'merge_ready') {
       items.push({
-        ...base, kind: 'merge_ready', kindLabel: t('kindMergeReady'),
-        proofState: PROOF_STATE.merge_ready, claim: t('claimMergeReady', { title: story.title }),
-        actionLabel: t('actionMerge'), actionTone: 'ready',
-      });
-    } else if (gate.gate_type === 'loop_decision') {
-      items.push({
-        ...base, kind: 'decision_needed', kindLabel: t('kindDecisionNeeded'),
-        proofState: PROOF_STATE.decision_needed, claim: t('claimDecisionNeeded', { title: story.title }),
-        actionLabel: t('actionDecide'), actionTone: 'primary',
+        id: `merge_ready-${sig.story_id}`, kind: 'merge_ready', kindLabel: t('kindMergeReady'),
+        proofState: PROOF_STATE.merge_ready, claim: t('claimMergeReady', { title: sig.title }),
+        actor: null, actionLabel: t('actionMerge'), actionTone: 'ready',
+        href: `/board?story=${sig.story_id}`, sortKey: 0,
       });
     }
   }
-  return items;
-}
 
-/**
- * 의존성 그래프(dep_type='blocks')에서 파생된 blockedByMap(to_id → from_id[])을 막힘 항목으로.
- * story.status==='held'가 아니라 실 차단 엣지 기반(그라운딩 정정) — story 제목 없으면 생략.
- */
-export function deriveBlockedAttentionItems(
-  blockedByMap: Record<string, string[]>,
-  storiesById: Map<string, AttentionStoryLite>,
-  membersById: Map<string, AttentionMember>,
-  t: AttentionQueueTranslator,
-): AttentionQueueItem[] {
-  const items: AttentionQueueItem[] = [];
-  for (const [storyId, blockers] of Object.entries(blockedByMap)) {
-    if (blockers.length === 0) continue;
-    const story = storiesById.get(storyId);
-    if (!story) continue;
+  for (const [storyId, { title, count }] of blockedByStory) {
     items.push({
-      id: `blocked-${storyId}`,
-      kind: 'blocked',
-      kindLabel: t('kindBlocked'),
-      proofState: PROOF_STATE.blocked,
-      claim: t('claimBlocked', { title: story.title, count: blockers.length }),
-      actor: actorFor(story, membersById),
-      actionLabel: t('actionCoordinate'),
-      actionTone: 'neutral',
-      href: `/board?story=${story.id}`,
-      sortKey: 0,
+      id: `blocked-${storyId}`, kind: 'blocked', kindLabel: t('kindBlocked'),
+      proofState: PROOF_STATE.blocked, claim: t('claimBlocked', { title, count }),
+      actor: null, actionLabel: t('actionCoordinate'), actionTone: 'neutral',
+      href: `/board?story=${storyId}`, sortKey: 0,
+    });
+  }
+  for (const [storyId, title] of decisionNeededByStory) {
+    items.push({
+      id: `decision_needed-${storyId}`, kind: 'decision_needed', kindLabel: t('kindDecisionNeeded'),
+      proofState: PROOF_STATE.decision_needed, claim: t('claimDecisionNeeded', { title }),
+      actor: null, actionLabel: t('actionDecide'), actionTone: 'primary',
+      href: `/board?story=${storyId}`, sortKey: 0,
     });
   }
   return items;


### PR DESCRIPTION
## 요약
E-UI-DAEGBYEON P0-05 story `7ff12083` 2단계(마지막 조각). P0-04 trust 파이프라인(#2111)·P0-03 human_owner(#2112) develop 착지 후 착수. AQ의 클라 파생(gate 폴링+dependency-graph+team-members+stories 4중 fetch)을 걷어내고 `/glance/attention`(BE `AttentionItem` 5-kind 계약) 단일 fetch로 스왑 — 스토리 AC4(실 데이터 배선) 충족.

착수 전 [접근법 그라운딩을 conv `32b8cff9`에 공유](https://github.com/moonklabs/sprintable) 후 PO 콜 받아 반영.

## 변경
- **`derive-attention-queue.ts`**: `parseAttentionQueueSignals`(envelope unwrap, `derive-exception-signals.ts`의 `unwrapEnvelope`와 동형) + `buildAttentionQueueFromBe` 신설. BE kind 리터럴 5종(`gate_pending|blocked|merge_ready|needs_input|verify_fail`) glance.py 실코드(36-192줄) 대조.
- **PO 콜(2026-07-13)**: `gate_pending`은 스킵 대신 내부 `decision_needed` 버킷에 `needs_input`과 함께 합류 — 스킵하면 결재 대기 중에 ALL CLEAR(거짓 표면)가 뜨는 문제 방지. 같은 story에 두 kind 다 뜨면 story_id 기준 1행으로 합침(개입 사유는 하나).
- **`blocked` 집계**: BE가 차단 엣지 1개당 1행을 주므로 story_id별로 묶어 실 차단 건수를 claim에 반영(v1 클라 파생과 동일 UX·집계 지점만 서버→클라 이동).
- **actor(아바타) 제거**: BE `AttentionItem`엔 assignee 필드가 없어 지어내지 않음(`derive-exception-signals.ts`의 동일 선택 재사용). `human_owner`(#2112) 노출 시 복원은 별도 low 스토리로 PO가 등재 예정.
- 클라 파생 함수(`deriveGateAttentionItems`/`deriveBlockedAttentionItems`) + 미사용 타입(`AttentionStoryLite`/`AttentionMember`) 제거.

## 스코프 밖(PO 확인 완료)
**SSE**(`story.trust_stage_changed` push 반영, P0-04 "새로고침 없이" 완료기준의 잔여) — 그라운딩 결과 BE `publish_event`가 쓰는 `_subscribers[org_id]`와 FE가 붙는 `agent_event_stream`이 읽는 `_agent_connections[member_id]`가 서로 다른 레지스트리라 브릿지가 코드에 없음을 확인. 지금 구독해도 이벤트가 실제로 안 와 가짜 배선이 될 위험이라 배제. 인터벌 리페치 폴백도 미부착(push 요건의 타협이라 PO가 명시적으로 배제). BE 브릿지=디디 lane, 별도 high 스토리로 트래킹 예정.

## 테스트
- `parseAttentionQueueSignals`: envelope unwrap(`{data:{items}}`/`{items}`)·malformed shape·unknown kind·title/story_id 누락 스킵.
- `buildAttentionQueueFromBe`: 5-kind 매핑(verify_fail/merge_ready/needs_input/gate_pending→decision_needed)·gate_pending+needs_input 병합·blocked 집계·en/ko 파리티.
- 18/18 green(신규 13건) · 전체 vitest **1262 passed/2 skipped**(회귀 0) · tsc **0** · eslint **0 warning** · build **exit 0**.

## 잔여
유나 UX 가디언 + 까심 QA + CI green 후 오르테가 머지 → **P0 완주**. dev 배포 후 라이브픽셀(양테마·실 gate_pending/needs_input/blocked/merge_ready 시나리오) done-gate.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>