### PR TITLE
feat(mcp): 멀티프로젝트 연결 3종 해소 (story ff6cb90d)

### DIFF
--- a/backend/alembic/versions/0177_member_default_project_id.py
+++ b/backend/alembic/versions/0177_member_default_project_id.py
@@ -1,0 +1,38 @@
+"""E-MCP-OPT(story ff6cb90d·doc mcp-multiproject-scoping-design §3) — members.default_project_id.
+
+Revision ID: 0177
+Revises: 0176
+Create Date: 2026-07-13
+
+멀티프로젝트 MCP 키의 "기본 프로젝트" 서버 저장(감사 가능). 순수 additive nullable FK —
+기존 member 전부 무영향. FK 부여(P0-03의 human_owner_member_id와 달리 이번엔 타당 — projects는
+VIEW/멀티테이블 해소가 아닌 안정된 단일 물리 테이블, member_id도 anchor로 안정).
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0177"
+down_revision = "0176"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "members",
+        sa.Column("default_project_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_members_default_project_id_projects",
+        "members", "projects",
+        ["default_project_id"], ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_members_default_project_id_projects", "members", type_="foreignkey")
+    op.drop_column("members", "default_project_id")

--- a/backend/app/models/member.py
+++ b/backend/app/models/member.py
@@ -53,6 +53,11 @@ class Member(Base):
     # registry(app.services.agent_runtime) lookup 키. 휴먼/미설정은 NULL(= 커맨드 미지원).
     # 9 enum 은 앱 레이어에서 강제(네이티브 PG enum 미사용 — 신규 런타임 확장 용이).
     runtime_type: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # E-MCP-OPT(story ff6cb90d·doc mcp-multiproject-scoping-design §3): 멀티프로젝트 MCP 키의
+    # 명시 기본 프로젝트(0177 additive). 미설정=암묵 선택 금지(무인자 콜은 명시 에러로 가이드).
+    default_project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="SET NULL"), nullable=True
+    )
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta, timezone
 from urllib.parse import urlencode
 
 import httpx
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 import re
 
@@ -50,7 +50,9 @@ from app.core.security import (
 )
 from app.core.rate_limit import limiter
 from app.dependencies.auth import AuthContext, get_current_user
-from app.services.project_auth import has_project_access, first_accessible_project_id
+from app.services.project_auth import (
+    accessible_project_ids_in_org, first_accessible_project_id, has_project_access,
+)
 from app.dependencies.database import get_db
 from app.models.member import Member
 from app.models.org_invite import OrgInvite
@@ -1396,16 +1398,112 @@ class AuthMeResponse(BaseModel):
     member_id: str
     org_id: str | None
     project_id: str | None
+    # E-MCP-OPT(story ff6cb90d·doc mcp-multiproject-scoping-design §0/§1): 위 project_id(레거시,
+    # _resolve_api_key의 ORDER BY 임의 기본값)는 무변경 유지(기존 48개 mutation 라우트가 항상 값이
+    # 있다고 가정하는 blast radius 회피) — 아래 3필드가 근본 정의한 신규 계약. 무인자 기본값을
+    # "정확히" 판정: 단일 접근가능 프로젝트 or 명시 default_project_id만 신뢰, 그 외엔 추측 0(null).
+    resolved_default_project_id: str | None = None
+    is_project_ambiguous: bool = False
+    accessible_project_ids: list[str] = []
+
+
+async def _resolve_project_default(
+    session: AsyncSession, member_id: uuid.UUID, org_id: uuid.UUID,
+) -> tuple[str | None, bool, list[str]]:
+    """doc mcp-multiproject-scoping-design §1 — 신규 근본 판정(추측 금지).
+
+    단일 접근가능 프로젝트면 그대로(무회귀·에러 불필요) · 2개 이상이면 명시 default_project_id가
+    여전히 접근가능할 때만 사용 · 그 외(2개 이상 + 미설정/무효)엔 resolved=None + ambiguous=True로
+    호출자가 명시하게 한다(암묵 first-project 선택 금지)."""
+    accessible = await accessible_project_ids_in_org(session, member_id, org_id)
+    accessible_ids = [str(p) for p in accessible]
+    if len(accessible_ids) == 1:
+        return accessible_ids[0], False, accessible_ids
+    if not accessible_ids:
+        return None, False, accessible_ids  # 접근 가능 프로젝트 자체가 0 — 별개 문제(ambiguous 아님).
+    member_row = (await session.execute(
+        select(Member.default_project_id).where(Member.id == member_id)
+    )).scalar_one_or_none()
+    if member_row is not None and str(member_row) in accessible_ids:
+        return str(member_row), False, accessible_ids
+    return None, True, accessible_ids
 
 
 @router.get("/me", response_model=AuthMeResponse)
 async def get_auth_me(
     auth: AuthContext = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
 ) -> AuthMeResponse:
-    """API Key Bearer 인증으로 바인딩된 member_id, org_id, project_id 반환."""
+    """API Key Bearer 인증으로 바인딩된 member_id, org_id, project_id 반환.
+
+    E-MCP-OPT: agent API 키(멀티프로젝트 가능)에 한해 resolved_default_project_id/
+    is_project_ambiguous/accessible_project_ids를 근본 판정(§1)해 추가 — human JWT 경로는
+    무변경(기본값 그대로, 이 스토리 스코프 밖)."""
     meta = auth.claims.get("app_metadata", {})
+    resolved: str | None = None
+    ambiguous = False
+    accessible_ids: list[str] = []
+    if meta.get("api_key_id"):
+        try:
+            member_id = uuid.UUID(auth.user_id)
+            org_id = uuid.UUID(str(auth.org_id or meta.get("org_id")))
+            resolved, ambiguous, accessible_ids = await _resolve_project_default(db, member_id, org_id)
+        except Exception:
+            logger.warning("get_auth_me: 신규 project default 판정 실패 — 레거시 필드만 반환", exc_info=True)
     return AuthMeResponse(
         member_id=auth.user_id,
         org_id=auth.org_id or meta.get("org_id"),
         project_id=meta.get("project_id"),
+        resolved_default_project_id=resolved,
+        is_project_ambiguous=ambiguous,
+        accessible_project_ids=accessible_ids,
+    )
+
+
+class SetDefaultProjectRequest(BaseModel):
+    project_id: uuid.UUID
+
+
+@router.patch("/me/default-project", response_model=AuthMeResponse)
+async def set_default_project(
+    body: SetDefaultProjectRequest,
+    auth: AuthContext = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> AuthMeResponse:
+    """E-MCP-OPT(story ff6cb90d §3) — 멀티프로젝트 키의 기본 프로젝트 서버 저장(감사 가능).
+
+    write-time 강제: 지정 project_id가 caller의 accessible 집합 안에 있어야 함(cross-org/무권한
+    프로젝트 지정 차단·body-claimed 금지)."""
+    meta = auth.claims.get("app_metadata", {})
+    member_id = uuid.UUID(auth.user_id)
+    org_id = uuid.UUID(str(auth.org_id or meta.get("org_id")))
+    if not await has_project_access(db, member_id, body.project_id, org_id):
+        raise HTTPException(status_code=403, detail="No access to the specified project")
+
+    member = (await db.execute(select(Member).where(Member.id == member_id))).scalar_one_or_none()
+    if member is None:
+        raise HTTPException(status_code=404, detail="Member not found")
+
+    old_default = member.default_project_id
+    member.default_project_id = body.project_id
+    await db.flush()
+
+    from app.routers.events import publish_event
+    publish_event(str(org_id), "member.default_project_changed", {
+        "member_id": str(member_id),
+        "org_id": str(org_id),
+        "old_default_project_id": str(old_default) if old_default else None,
+        "new_default_project_id": str(body.project_id),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    })
+    await db.commit()
+
+    resolved, ambiguous, accessible_ids = await _resolve_project_default(db, member_id, org_id)
+    return AuthMeResponse(
+        member_id=str(member_id),
+        org_id=str(org_id),
+        project_id=meta.get("project_id"),
+        resolved_default_project_id=resolved,
+        is_project_ambiguous=ambiguous,
+        accessible_project_ids=accessible_ids,
     )

--- a/backend/app/services/event_taxonomy.py
+++ b/backend/app/services/event_taxonomy.py
@@ -86,6 +86,15 @@ EVENT_TAXONOMY: dict[str, list[EventParam]] = {
         EventParam("actor_id", "uuid", False, "실행자 member UUID"),
         EventParam("timestamp", "str", True, "ISO 8601 UTC 타임스탬프"),
     ],
+    # E-MCP-OPT(story ff6cb90d·doc mcp-multiproject-scoping-design §3/§7②): 멀티프로젝트 MCP 키의
+    # 기본 프로젝트 전환 — updated_at만으론 "무엇→무엇"이 안 남아 감사 목적 신규 이벤트로 보강.
+    "member.default_project_changed": [
+        EventParam("member_id", "uuid", True, "멤버 UUID"),
+        EventParam("org_id", "uuid", True, "조직 UUID"),
+        EventParam("old_default_project_id", "uuid", False, "변경 전 기본 프로젝트(미설정이면 null)"),
+        EventParam("new_default_project_id", "uuid", True, "변경 후 기본 프로젝트"),
+        EventParam("timestamp", "str", True, "ISO 8601 UTC 타임스탬프"),
+    ],
 }
 
 

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -71,6 +71,12 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     "sprintable_create_artifact", "sprintable_get_artifact", "sprintable_list_artifacts",
     "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
     "sprintable_edit_artifact", "sprintable_propose_canonical_version",
+    # E-MCP-OPT(story ff6cb90d): list_projects/set_default_project — 키 자기 신원/스코프 조회·전환
+    # 유틸(sprintable_my_dashboard·sprintable_ping과 동형: 특정 비즈니스 도메인 아닌 self-scope
+    # 도구). set_default_project는 write지만 caller 자신의 기본 프로젝트 설정만 바꾸는 self-scope
+    # 조작이라 파괴적이지 않음(has_project_access로 대상 검증). vendored 사본과 동기화 필수
+    # (sprintable_mcp/toolset.py).
+    "sprintable_list_projects", "sprintable_set_default_project",
 })
 
 # scope 토큰: 그룹명 외에 read/write(레거시·전체 비파괴 의미), admin/destructive(파괴적 허용)
@@ -294,6 +300,8 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_create_artifact", "sprintable_get_artifact", "sprintable_list_artifacts",
     "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
     "sprintable_edit_artifact", "sprintable_propose_canonical_version",
+    # projects (E-MCP-OPT story ff6cb90d)
+    "sprintable_list_projects", "sprintable_set_default_project",
 )
 
 # picker 표시 순서(비파괴 먼저). order 필드 힌트 + 배열 순서 둘 다 이 순서.

--- a/backend/sprintable_mcp/api_client.py
+++ b/backend/sprintable_mcp/api_client.py
@@ -159,6 +159,11 @@ class SprintableClient:
         self._member_id: str = ""
         self._org_id: str = ""
         self._project_id: str = ""
+        # E-MCP-OPT(story ff6cb90d): auth/me의 근본 판정(resolved_default_project_id 계열) 미러 —
+        # self._project_id 는 그 판정의 project_id(단일/명시 default)를 그대로 담고(ambiguous면 빈
+        # 문자열), 아래 두 필드는 ambiguous일 때 require_project_id()가 가이드 메시지를 만드는 재료.
+        self._project_id_ambiguous: bool = False
+        self._accessible_project_ids: list[str] = []
 
     def configure(self, api_url: str, api_key: str) -> None:
         if not api_url:
@@ -169,14 +174,21 @@ class SprintableClient:
         self._api_key = api_key
 
     async def resolve_auth_context(self) -> dict[str, str]:
-        """GET /api/v2/auth/me → org_id/project_id/member_id 캐시(stdio 부팅 시 1회)."""
+        """GET /api/v2/auth/me → org_id/project_id/member_id 캐시(stdio 부팅 시 1회).
+
+        E-MCP-OPT(story ff6cb90d §1): project_id 는 이제 근본 판정 필드
+        (resolved_default_project_id)에서 채운다 — 단일 접근가능 프로젝트 또는 명시
+        default_project_id 일 때만 값이 있고, 멀티프로젝트+미설정(ambiguous)이면 빈 문자열(추측
+        0). require_project_id() 가 이 ambiguous 상태를 감지해 가이드 에러를 낸다."""
         data = await self.get("/api/v2/auth/me")
         self._member_id = data.get("member_id") or ""
         self._org_id = data.get("org_id") or ""
-        self._project_id = data.get("project_id") or ""
+        self._project_id = data.get("resolved_default_project_id") or ""
+        self._project_id_ambiguous = bool(data.get("is_project_ambiguous"))
+        self._accessible_project_ids = data.get("accessible_project_ids") or []
         logger.info(
-            "auth context resolved member_id=%s org_id=%s project_id=%s",
-            self._member_id, self._org_id, self._project_id,
+            "auth context resolved member_id=%s org_id=%s project_id=%s ambiguous=%s",
+            self._member_id, self._org_id, self._project_id, self._project_id_ambiguous,
         )
         return {
             "member_id": self._member_id,
@@ -189,11 +201,13 @@ class SprintableClient:
         1회 해소·캐시. http 미들웨어가 요청경계서 호출 → 명시 project_id 없는 툴 호출도 그 키의 default 로
         해소(stdio resolve_auth_context 와 parity·422 제거). 싱글톤 self._* 는 건드리지 않아 테넌트 격리.
 
-        멀티프로젝트 키: /api/v2/auth/me 가 주는 server-canonical default project_id 를 그대로 사용
-        (클라 임의선택 0). default 가 비면 빈 채로 둬 호출자가 project_id 를 명시하게 한다(추측 금지).
+        멀티프로젝트 키: /api/v2/auth/me 가 주는 server-canonical **근본 판정**(resolved_default_
+        project_id, ff6cb90d §1)을 그대로 사용(클라 임의선택 0). ambiguous 면 project_id 빈 채로
+        둬 호출자가 명시하게 한다(require_project_id() 가 이 상태를 감지해 가이드 에러).
 
         캐시 수명 = 프로세스. 키의 default project 가 런타임 중 바뀌면 stale 할 수 있으나(재기동 시 해소),
-        parity 가 목표라 TTL 은 의도적으로 두지 않는다(over-engineer 회피).
+        parity 가 목표라 TTL 은 의도적으로 두지 않는다(over-engineer 회피). set_default_project 툴이
+        성공 시 이 캐시를 직접 갱신해 재기동 없이도 반영한다.
         """
         if not api_key:
             return {}
@@ -204,7 +218,9 @@ class SprintableClient:
         ctx = {
             "member_id": data.get("member_id") or "",
             "org_id": data.get("org_id") or "",
-            "project_id": data.get("project_id") or "",
+            "project_id": data.get("resolved_default_project_id") or "",
+            "is_project_ambiguous": bool(data.get("is_project_ambiguous")),
+            "accessible_project_ids": data.get("accessible_project_ids") or [],
         }
         _auth_ctx_cache[api_key] = ctx
         return ctx
@@ -235,6 +251,24 @@ class SprintableClient:
             _project_override.get()
             or self._project_id
             or self._effective_ctx().get("project_id", "")
+        )
+
+    def require_project_id(self) -> str:
+        """E-MCP-OPT(story ff6cb90d §1) — **무인자 콜 + 기본값 미설정 = 명시 에러**가 실제로 나가는
+        지점. project_id 가 필요한 대다수 툴은 이 메서드를 쓴다(org-level 이 의도인 chat/일부
+        standup 툴만 project_id 프로퍼티를 직접 써 무회귀). override/single-project/명시 default
+        중 하나로 해소되면 그 값을 반환·전부 없으면(ambiguous) 접근 가능 프로젝트 목록을 담아
+        SprintableApiError 를 던진다 — 툴 함수의 기존 try/except 가 그대로 잡아 err() 로 노출."""
+        pid = self.project_id
+        if pid:
+            return pid
+        ctx = self._effective_ctx()
+        accessible = ctx.get("accessible_project_ids") or self._accessible_project_ids
+        raise SprintableApiError(
+            400,
+            "여러 프로젝트에 접근 가능한 키입니다. project_id를 지정하거나 "
+            "sprintable_set_default_project로 기본 프로젝트를 설정하세요.",
+            body={"accessible_project_ids": accessible},
         )
 
     async def request(

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -53,6 +53,9 @@ from .tools.core import (
     claim_story, get_workflow_guide, list_team_members, lock_files,
     my_dashboard, unclaim_story, unlock_files,
 )
+from .tools.projects import (
+    ListProjectsInput, SetDefaultProjectInput, list_projects, set_default_project,
+)
 from .tools.docs import (
     CreateDocInput, GetDocInput, ListDocsInput,
     SearchDocsInput, UpdateDocInput,
@@ -460,13 +463,20 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_get_project_health",
      "프로젝트 전체 건강도 조회.",
      SprintableInput, get_project_health),
-    # Core (4)
+    # Core (6) — E-MCP-OPT(story ff6cb90d): list_projects/set_default_project 2종 추가.
     ("sprintable_list_team_members",
      "프로젝트 팀 멤버 목록 조회.",
      SprintableInput, list_team_members),
     ("sprintable_my_dashboard",
      "팀원 대시보드 요약 조회.",
      DashboardInput, my_dashboard),
+    ("sprintable_list_projects",
+     "이 키(멤버)가 접근 가능한 프로젝트 목록 조회(id·이름·org) — 무권한/타조직 미노출.",
+     ListProjectsInput, list_projects),
+    ("sprintable_set_default_project",
+     "이 키의 기본 프로젝트를 서버에 저장(감사 가능) — project_id 없는 후속 호출이 이 프로젝트로"
+     " 해소됨. 지정 project_id에 접근권 없으면 403.",
+     SetDefaultProjectInput, set_default_project),
     ("sprintable_claim_story",
      "현재 작업 중인 스토리를 claim — active_story_id 갱신, 중복 배정 방지.",
      ClaimStoryInput, claim_story),

--- a/backend/sprintable_mcp/tools/agent_runs.py
+++ b/backend/sprintable_mcp/tools/agent_runs.py
@@ -46,13 +46,16 @@ class PollEventsInput(SprintableInput):
 
 async def emit_event(args: EmitEventInput) -> list[TextContent]:
     """에이전트 런 이벤트 발행."""
-    body: dict = {"agent_id": args.agent_id, "trigger": args.trigger, "project_id": client.project_id}
-    for field in ("model", "story_id", "memo_id", "result_summary", "status",
-                  "error_message", "input_tokens", "output_tokens", "started_at", "finished_at"):
-        val = getattr(args, field)
-        if val is not None:
-            body[field] = val
     try:
+        body: dict = {
+            "agent_id": args.agent_id, "trigger": args.trigger,
+            "project_id": client.require_project_id(),  # E-MCP-OPT ff6cb90d: try 안에서 호출(가이드 에러 캡처).
+        }
+        for field in ("model", "story_id", "memo_id", "result_summary", "status",
+                      "error_message", "input_tokens", "output_tokens", "started_at", "finished_at"):
+            val = getattr(args, field)
+            if val is not None:
+                body[field] = val
         return ok(await client.post("/api/v2/agent-runs", json=body))
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/analytics.py
+++ b/backend/sprintable_mcp/tools/analytics.py
@@ -43,7 +43,7 @@ class SearchStoriesInput(SprintableInput):
 async def get_project_overview(args: SprintableInput) -> list[TextContent]:
     """프로젝트 개요 통계 조회."""
     try:
-        return ok(await client.get("/api/v2/analytics/overview", params={"project_id": client.project_id}))
+        return ok(await client.get("/api/v2/analytics/overview", params={"project_id": client.require_project_id()}))
     except Exception as exc:
         return err(str(exc))
 
@@ -51,7 +51,7 @@ async def get_project_overview(args: SprintableInput) -> list[TextContent]:
 async def get_member_workload(args: WorkloadInput) -> list[TextContent]:
     """팀원 워크로드 조회."""
     try:
-        return ok(await client.get("/api/v2/analytics/workload", params={"project_id": client.project_id, "member_id": args.member_id}))
+        return ok(await client.get("/api/v2/analytics/workload", params={"project_id": client.require_project_id(), "member_id": args.member_id}))
     except Exception as exc:
         return err(str(exc))
 
@@ -59,7 +59,7 @@ async def get_member_workload(args: WorkloadInput) -> list[TextContent]:
 async def get_sprint_velocity_history(args: SprintableInput) -> list[TextContent]:
     """스프린트 벨로시티 히스토리 조회."""
     try:
-        return ok(await client.get("/api/v2/analytics/velocity-history", params={"project_id": client.project_id}))
+        return ok(await client.get("/api/v2/analytics/velocity-history", params={"project_id": client.require_project_id()}))
     except Exception as exc:
         return err(str(exc))
 
@@ -67,17 +67,17 @@ async def get_sprint_velocity_history(args: SprintableInput) -> list[TextContent
 async def search_stories(args: SearchStoriesInput) -> list[TextContent]:
     """스토리 제목 검색."""
     try:
-        return ok(await client.get("/api/v2/stories", params={"project_id": client.project_id, "q": args.query}))
+        return ok(await client.get("/api/v2/stories", params={"project_id": client.require_project_id(), "q": args.query}))
     except Exception as exc:
         return err(str(exc))
 
 
 async def get_blocked_stories(args: SprintFilterInput) -> list[TextContent]:
     """in-review 상태 스토리 목록 (블로킹 스토리)."""
-    params: dict = {"project_id": client.project_id, "status": "in-review"}
-    if args.sprint_id:
-        params["sprint_id"] = args.sprint_id
     try:
+        params: dict = {"project_id": client.require_project_id(), "status": "in-review"}
+        if args.sprint_id:
+            params["sprint_id"] = args.sprint_id
         return ok(await client.get("/api/v2/stories", params=params))
     except Exception as exc:
         return err(str(exc))
@@ -85,10 +85,10 @@ async def get_blocked_stories(args: SprintFilterInput) -> list[TextContent]:
 
 async def get_unassigned_stories(args: SprintFilterInput) -> list[TextContent]:
     """담당자 미지정 스토리 목록."""
-    params: dict = {"project_id": client.project_id, "unassigned": "true"}
-    if args.sprint_id:
-        params["sprint_id"] = args.sprint_id
     try:
+        params: dict = {"project_id": client.require_project_id(), "unassigned": "true"}
+        if args.sprint_id:
+            params["sprint_id"] = args.sprint_id
         return ok(await client.get("/api/v2/stories", params=params))
     except Exception as exc:
         return err(str(exc))
@@ -96,10 +96,10 @@ async def get_unassigned_stories(args: SprintFilterInput) -> list[TextContent]:
 
 async def get_overdue_tasks(args: OverdueMemberInput) -> list[TextContent]:
     """미완료 태스크 목록."""
-    params: dict = {"project_id": client.project_id, "status_ne": "done"}
-    if args.member_id:
-        params["assignee_id"] = args.member_id
     try:
+        params: dict = {"project_id": client.require_project_id(), "status_ne": "done"}
+        if args.member_id:
+            params["assignee_id"] = args.member_id
         return ok(await client.get("/api/v2/tasks", params=params))
     except Exception as exc:
         return err(str(exc))
@@ -107,10 +107,10 @@ async def get_overdue_tasks(args: OverdueMemberInput) -> list[TextContent]:
 
 async def get_recent_activity(args: ActivityInput) -> list[TextContent]:
     """최근 프로젝트 활동 조회."""
-    params: dict = {"project_id": client.project_id}
-    if args.limit is not None:
-        params["limit"] = str(args.limit)
     try:
+        params: dict = {"project_id": client.require_project_id()}
+        if args.limit is not None:
+            params["limit"] = str(args.limit)
         return ok(await client.get("/api/v2/analytics/activity", params=params))
     except Exception as exc:
         return err(str(exc))
@@ -119,7 +119,7 @@ async def get_recent_activity(args: ActivityInput) -> list[TextContent]:
 async def get_epic_progress(args: EpicProgressInput) -> list[TextContent]:
     """에픽 진행 현황 조회."""
     try:
-        return ok(await client.get("/api/v2/analytics/epic-progress", params={"project_id": client.project_id, "epic_id": args.epic_id}))
+        return ok(await client.get("/api/v2/analytics/epic-progress", params={"project_id": client.require_project_id(), "epic_id": args.epic_id}))
     except Exception as exc:
         return err(str(exc))
 
@@ -127,7 +127,7 @@ async def get_epic_progress(args: EpicProgressInput) -> list[TextContent]:
 async def get_agent_stats(args: AgentStatsInput) -> list[TextContent]:
     """에이전트 성과 통계 조회."""
     try:
-        return ok(await client.get("/api/v2/analytics/agent-stats", params={"project_id": client.project_id, "agent_id": args.agent_id}))
+        return ok(await client.get("/api/v2/analytics/agent-stats", params={"project_id": client.require_project_id(), "agent_id": args.agent_id}))
     except Exception as exc:
         return err(str(exc))
 
@@ -135,6 +135,6 @@ async def get_agent_stats(args: AgentStatsInput) -> list[TextContent]:
 async def get_project_health(args: SprintableInput) -> list[TextContent]:
     """프로젝트 전체 건강도 조회."""
     try:
-        return ok(await client.get("/api/v2/analytics/health", params={"project_id": client.project_id}))
+        return ok(await client.get("/api/v2/analytics/health", params={"project_id": client.require_project_id()}))
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/chat.py
+++ b/backend/sprintable_mcp/tools/chat.py
@@ -73,16 +73,14 @@ async def send_chat_message(args: SendChatInput) -> list[TextContent]:
 
 async def create_conversation(args: CreateConversationInput) -> list[TextContent]:
     """새 conversation thread 생성."""
-    if not client.project_id:
-        return err("project_id not set — agent must be bound to a project before creating conversations")
-    body: dict = {
-        "type": "group",
-        "participant_ids": args.participant_ids,
-        "project_id": client.project_id,
-    }
-    if args.title:
-        body["title"] = args.title
     try:
+        body: dict = {
+            "type": "group",
+            "participant_ids": args.participant_ids,
+            "project_id": client.require_project_id(),  # E-MCP-OPT ff6cb90d: 무인자+ambiguous 명시 에러.
+        }
+        if args.title:
+            body["title"] = args.title
         conv = await client.post("/api/v2/conversations", json=body)
         conv_id = conv.get("id") if isinstance(conv, dict) else None
         return ok({"conversation_id": conv_id, **(conv if isinstance(conv, dict) else {})})

--- a/backend/sprintable_mcp/tools/core.py
+++ b/backend/sprintable_mcp/tools/core.py
@@ -27,8 +27,8 @@ class UnlockFilesInput(SprintableInput):
 
 async def list_team_members(args: SprintableInput) -> list[TextContent]:
     """프로젝트 팀 멤버 목록 조회."""
-    params: dict = {"project_id": client.project_id}
     try:
+        params: dict = {"project_id": client.require_project_id()}
         return ok(await client.get("/api/v2/members", params=params))
     except Exception as exc:
         return err(str(exc))
@@ -36,9 +36,9 @@ async def list_team_members(args: SprintableInput) -> list[TextContent]:
 
 async def my_dashboard(args: DashboardInput) -> list[TextContent]:
     """팀원 대시보드 요약 조회."""
-    member = args.member_id or client.member_id
-    params: dict = {"member_id": member, "project_id": client.project_id}
     try:
+        member = args.member_id or client.member_id
+        params: dict = {"member_id": member, "project_id": client.require_project_id()}
         return ok(await client.get("/api/v2/dashboard", params=params))
     except Exception as exc:
         return err(str(exc))
@@ -94,7 +94,7 @@ async def get_workflow_guide(args: SprintableInput) -> list[TextContent]:
     try:
         recipes = await client.get(
             "/api/v2/workflow-recipes",
-            params={"project_id": client.project_id},
+            params={"project_id": client.require_project_id()},
         )
         if not recipes:
             return ok({"guide": "등록된 워크플로우 레시피가 없습니다.", "recipes": []})

--- a/backend/sprintable_mcp/tools/docs.py
+++ b/backend/sprintable_mcp/tools/docs.py
@@ -55,12 +55,12 @@ class UpdateDocInput(SprintableInput):
 
 async def list_docs(args: ListDocsInput) -> list[TextContent]:
     """프로젝트 문서 목록 조회 (tree 또는 tag 필터)."""
-    params: dict = {"project_id": client.project_id}
-    if args.tags:
-        params["tags"] = ",".join(args.tags)
-    else:
-        params["view"] = "tree"
     try:
+        params: dict = {"project_id": client.require_project_id()}
+        if args.tags:
+            params["tags"] = ",".join(args.tags)
+        else:
+            params["view"] = "tree"
         return ok(await client.get("/api/v2/docs", params=params))
     except Exception as exc:
         return err(str(exc))
@@ -76,7 +76,7 @@ async def get_doc(args: GetDocInput) -> list[TextContent]:
     """
     try:
         summaries = await client.get(
-            "/api/v2/docs", params={"project_id": client.project_id, "slug": args.slug}
+            "/api/v2/docs", params={"project_id": client.require_project_id(), "slug": args.slug}
         )
         if not summaries:
             return err(f"Doc not found: {args.slug}")
@@ -88,10 +88,10 @@ async def get_doc(args: GetDocInput) -> list[TextContent]:
 
 async def search_docs(args: SearchDocsInput) -> list[TextContent]:
     """문서 제목/본문 검색 (tag 필터 선택)."""
-    params: dict = {"project_id": client.project_id, "q": args.query}
-    if args.tags:
-        params["tags"] = ",".join(args.tags)
     try:
+        params: dict = {"project_id": client.require_project_id(), "q": args.query}
+        if args.tags:
+            params["tags"] = ",".join(args.tags)
         return ok(await client.get("/api/v2/docs", params=params))
     except Exception as exc:
         return err(str(exc))
@@ -99,16 +99,16 @@ async def search_docs(args: SearchDocsInput) -> list[TextContent]:
 
 async def create_doc(args: CreateDocInput) -> list[TextContent]:
     """문서 생성."""
-    body: dict = {"title": args.title, "slug": args.slug, "project_id": client.project_id}
-    for field in ("content", "content_format", "parent_id", "icon"):
-        val = getattr(args, field)
-        if val is not None:
-            body[field] = val
-    if args.is_folder is not None:
-        body["is_folder"] = args.is_folder
-    if args.tags is not None:
-        body["tags"] = args.tags
     try:
+        body: dict = {"title": args.title, "slug": args.slug, "project_id": client.require_project_id()}
+        for field in ("content", "content_format", "parent_id", "icon"):
+            val = getattr(args, field)
+            if val is not None:
+                body[field] = val
+        if args.is_folder is not None:
+            body["is_folder"] = args.is_folder
+        if args.tags is not None:
+            body["tags"] = args.tags
         return ok(await client.post("/api/v2/docs", json=body))
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/epics.py
+++ b/backend/sprintable_mcp/tools/epics.py
@@ -38,23 +38,23 @@ class UpdateEpicInput(SprintableInput):
 async def list_epics(args: ListEpicsInput) -> list[TextContent]:
     """에픽 목록 조회."""
     try:
-        return ok(await client.get("/api/v2/epics", params={"project_id": client.project_id}))
+        return ok(await client.get("/api/v2/epics", params={"project_id": client.require_project_id()}))
     except Exception as exc:
         return err(str(exc))
 
 
 async def add_epic(args: AddEpicInput) -> list[TextContent]:
     """에픽 생성."""
-    body: dict = {"title": args.title, "project_id": client.project_id}
-    if args.priority:
-        body["priority"] = args.priority.value
-    for field in ("description", "objective", "success_criteria", "target_date"):
-        val = getattr(args, field)
-        if val is not None:
-            body[field] = val
-    if args.target_sp is not None:
-        body["target_sp"] = args.target_sp
     try:
+        body: dict = {"title": args.title, "project_id": client.require_project_id()}
+        if args.priority:
+            body["priority"] = args.priority.value
+        for field in ("description", "objective", "success_criteria", "target_date"):
+            val = getattr(args, field)
+            if val is not None:
+                body[field] = val
+        if args.target_sp is not None:
+            body["target_sp"] = args.target_sp
         return ok(await client.post("/api/v2/epics", json=body))
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/hypotheses.py
+++ b/backend/sprintable_mcp/tools/hypotheses.py
@@ -79,18 +79,18 @@ def _compact(h: dict) -> dict:
 
 async def list_hypotheses(args: ListHypothesesInput) -> list[TextContent]:
     """가설 목록(compact). epic_id/story_id/status/owner_member_id/limit 필터."""
-    params: dict = {"project_id": client.project_id}
-    if args.epic_id:
-        params["epic_id"] = args.epic_id
-    if args.story_id:
-        params["story_id"] = args.story_id
-    if args.status is not None:
-        params["status"] = args.status.value
-    if args.owner_member_id:
-        params["owner_member_id"] = args.owner_member_id
-    if args.limit is not None:
-        params["limit"] = args.limit
     try:
+        params: dict = {"project_id": client.require_project_id()}
+        if args.epic_id:
+            params["epic_id"] = args.epic_id
+        if args.story_id:
+            params["story_id"] = args.story_id
+        if args.status is not None:
+            params["status"] = args.status.value
+        if args.owner_member_id:
+            params["owner_member_id"] = args.owner_member_id
+        if args.limit is not None:
+            params["limit"] = args.limit
         rows = await client.get("/api/v2/hypotheses", params=params)
         return ok([_compact(h) for h in (rows or [])])
     except Exception as exc:
@@ -124,17 +124,17 @@ async def create_hypothesis(args: CreateHypothesisInput) -> list[TextContent]:
     임의 휴먼을 추측-주입하는 것은 owner 의미를 왜곡한다. 따라서 여기서는 default를 만들지 않고,
     개선된 에러 표면화(api_client._extract_error_message)로 사유를 명확히 전달하는 쪽을 택한다.
     """
-    body: dict = {
-        "project_id": client.project_id,
-        "statement": args.statement,
-        "metric_definition": args.metric_definition,
-        "measure_after": args.measure_after,
-    }
-    for field in ("owner_member_id", "epic_ids", "story_ids", "source_type", "source_id"):
-        val = getattr(args, field)
-        if val is not None:
-            body[field] = val
     try:
+        body: dict = {
+            "project_id": client.require_project_id(),
+            "statement": args.statement,
+            "metric_definition": args.metric_definition,
+            "measure_after": args.measure_after,
+        }
+        for field in ("owner_member_id", "epic_ids", "story_ids", "source_type", "source_id"):
+            val = getattr(args, field)
+            if val is not None:
+                body[field] = val
         return ok(await client.post("/api/v2/hypotheses", json=body))
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/meetings.py
+++ b/backend/sprintable_mcp/tools/meetings.py
@@ -47,16 +47,16 @@ class UpdateMeetingInput(SprintableInput):
 
 async def list_meetings(args: ListMeetingsInput) -> list[TextContent]:
     """프로젝트 미팅 목록 조회."""
-    params: dict = {"project_id": client.project_id}
-    if args.meeting_type:
-        params["meeting_type"] = args.meeting_type
-    if args.date_from:
-        params["date_from"] = args.date_from
-    if args.date_to:
-        params["date_to"] = args.date_to
-    if args.limit is not None:
-        params["limit"] = str(args.limit)
     try:
+        params: dict = {"project_id": client.require_project_id()}
+        if args.meeting_type:
+            params["meeting_type"] = args.meeting_type
+        if args.date_from:
+            params["date_from"] = args.date_from
+        if args.date_to:
+            params["date_to"] = args.date_to
+        if args.limit is not None:
+            params["limit"] = str(args.limit)
         return ok(await client.get("/api/v2/meetings", params=params))
     except Exception as exc:
         return err(str(exc))
@@ -72,12 +72,12 @@ async def get_meeting(args: MeetingIdInput) -> list[TextContent]:
 
 async def create_meeting(args: CreateMeetingInput) -> list[TextContent]:
     """미팅 생성."""
-    body: dict = {"title": args.title, "project_id": client.project_id}
-    for field in ("meeting_type", "date", "duration_min", "participants", "created_by"):
-        val = getattr(args, field)
-        if val is not None:
-            body[field] = val
     try:
+        body: dict = {"title": args.title, "project_id": client.require_project_id()}
+        for field in ("meeting_type", "date", "duration_min", "participants", "created_by"):
+            val = getattr(args, field)
+            if val is not None:
+                body[field] = val
         return ok(await client.post("/api/v2/meetings", json=body))
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/projects.py
+++ b/backend/sprintable_mcp/tools/projects.py
@@ -1,0 +1,51 @@
+"""E-MCP-OPT(story ff6cb90d·doc mcp-multiproject-scoping-design) — 멀티프로젝트 연결 3종 중 ②③.
+
+①(무인자 기본값 근본 판정)은 백엔드 GET /api/v2/auth/me가 SSOT(app/routers/auth.py)."""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from ..api_client import _api_key_override, _auth_ctx_cache, client
+from ..response import err, ok
+
+
+class ListProjectsInput(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+
+async def list_projects(_args: ListProjectsInput) -> list:
+    """caller 키(member)가 접근 가능한 프로젝트 열거(id·이름·org) — 무권한/타조직 프로젝트는
+    미노출(존재 유출 오라클 0). 신규 BE 로직 0 — 기존 GET /api/v2/projects(정책B) 얇은 래핑."""
+    try:
+        result = await client.get("/api/v2/projects")
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))
+
+
+class SetDefaultProjectInput(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    project_id: str
+
+
+async def set_default_project(args: SetDefaultProjectInput) -> list:
+    """멀티프로젝트 키의 기본 프로젝트를 서버에 저장(감사 가능 — member.default_project_changed
+    이벤트). 지정 project_id가 caller의 접근 가능 집합 밖이면 403. 설정 직후 무인자 콜부터 이
+    프로젝트로 해소되도록 캐시를 갱신한다."""
+    try:
+        result = await client.patch(
+            "/api/v2/auth/me/default-project", json={"project_id": args.project_id}
+        )
+        # 캐시 갱신 — 프로세스 수명 캐시(ee2f4e58)라 재기동 없이도 이후 무인자 콜이 신규 기본값을
+        # 즉시 보게 한다(설정했는데 계속 예전 값/에러 나오면 도구의 존재 의미가 없음). effective
+        # 키(_effective_ctx와 동형 — override 있으면 그 키, 없으면 stdio 단일 env 키)만 갱신·
+        # 다른 테넌트 키 오염 금지.
+        new_default = result.get("resolved_default_project_id")
+        if new_default:
+            client._project_id = new_default  # stdio(override 無) 경로.
+            _key = _api_key_override.get() or client._api_key
+            if _key in _auth_ctx_cache:
+                _auth_ctx_cache[_key]["project_id"] = new_default
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))

--- a/backend/sprintable_mcp/tools/projects.py
+++ b/backend/sprintable_mcp/tools/projects.py
@@ -43,9 +43,11 @@ async def set_default_project(args: SetDefaultProjectInput) -> list:
         new_default = result.get("resolved_default_project_id")
         if new_default:
             client._project_id = new_default  # stdio(override 無) 경로.
+            client._project_id_ambiguous = False
             _key = _api_key_override.get() or client._api_key
             if _key in _auth_ctx_cache:
                 _auth_ctx_cache[_key]["project_id"] = new_default
+                _auth_ctx_cache[_key]["is_project_ambiguous"] = False
         return ok(result)
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/retro.py
+++ b/backend/sprintable_mcp/tools/retro.py
@@ -54,22 +54,22 @@ class ExportRetroInput(SprintableInput):
 async def list_retro_sessions(args: ListRetroSessionsInput) -> list[TextContent]:
     """레트로 세션 목록 조회."""
     try:
-        return ok(await client.get("/api/v2/retro-sessions", params={"project_id": client.project_id}))
+        return ok(await client.get("/api/v2/retro-sessions", params={"project_id": client.require_project_id()}))
     except Exception as exc:
         return err(str(exc))
 
 
 async def create_retro_session(args: CreateRetroSessionInput) -> list[TextContent]:
     """레트로 세션 생성."""
-    body: dict = {
-        "title": args.title,
-        "project_id": client.project_id,
-        "org_id": client.org_id,
-        "created_by": args.created_by or client.member_id,
-    }
-    if args.sprint_id:
-        body["sprint_id"] = args.sprint_id
     try:
+        body: dict = {
+            "title": args.title,
+            "project_id": client.require_project_id(),
+            "org_id": client.org_id,
+            "created_by": args.created_by or client.member_id,
+        }
+        if args.sprint_id:
+            body["sprint_id"] = args.sprint_id
         return ok(await client.post("/api/v2/retro-sessions", json=body))
     except Exception as exc:
         return err(str(exc))
@@ -82,7 +82,7 @@ async def vote_retro_item(args: VoteRetroItemInput) -> list[TextContent]:
             "POST",
             f"/api/v2/retro-sessions/{args.session_id}/items/{args.item_id}/vote",
             json={"voter_id": args.voter_id},
-            params={"project_id": client.project_id},
+            params={"project_id": client.require_project_id()},
         ))
     except Exception as exc:
         return err(str(exc))
@@ -98,7 +98,7 @@ async def add_retro_action(args: AddRetroActionInput) -> list[TextContent]:
             "POST",
             f"/api/v2/retro-sessions/{args.session_id}/actions",
             json=body,
-            params={"project_id": client.project_id},
+            params={"project_id": client.require_project_id()},
         ))
     except Exception as exc:
         return err(str(exc))
@@ -111,7 +111,7 @@ async def change_retro_phase(args: ChangeRetroPhaseInput) -> list[TextContent]:
             "PATCH",
             f"/api/v2/retro-sessions/{args.session_id}",
             json={"phase": args.phase},
-            params={"project_id": client.project_id},
+            params={"project_id": client.require_project_id()},
         ))
     except Exception as exc:
         return err(str(exc))
@@ -124,7 +124,7 @@ async def add_retro_item(args: AddRetroItemInput) -> list[TextContent]:
             "POST",
             f"/api/v2/retro-sessions/{args.session_id}/items",
             json={"category": args.category, "text": args.text, "author_id": args.author_id},
-            params={"project_id": client.project_id},
+            params={"project_id": client.require_project_id()},
         ))
     except Exception as exc:
         return err(str(exc))
@@ -133,6 +133,6 @@ async def add_retro_item(args: AddRetroItemInput) -> list[TextContent]:
 async def export_retro(args: ExportRetroInput) -> list[TextContent]:
     """레트로 마크다운 내보내기."""
     try:
-        return ok(await client.get(f"/api/v2/retro-sessions/{args.session_id}/export", params={"project_id": client.project_id}))
+        return ok(await client.get(f"/api/v2/retro-sessions/{args.session_id}/export", params={"project_id": client.require_project_id()}))
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/rewards.py
+++ b/backend/sprintable_mcp/tools/rewards.py
@@ -31,25 +31,25 @@ class GetLeaderboardInput(SprintableInput):
 async def get_wallet(args: GetWalletInput) -> list[TextContent]:
     """팀원 보상 잔액 조회."""
     try:
-        return ok(await client.get("/api/v2/rewards", params={"project_id": client.project_id, "member_id": args.member_id, "balance": "true"}))
+        return ok(await client.get("/api/v2/rewards", params={"project_id": client.require_project_id(), "member_id": args.member_id, "balance": "true"}))
     except Exception as exc:
         return err(str(exc))
 
 
 async def give_reward(args: GiveRewardInput) -> list[TextContent]:
     """팀원 보상/패널티 지급."""
-    body: dict = {
-        "project_id": client.project_id,
-        "member_id": args.member_id,
-        "amount": args.amount,
-        "reason": args.reason,
-        "granted_by": args.granted_by,
-    }
-    if args.reference_type:
-        body["reference_type"] = args.reference_type
-    if args.reference_id:
-        body["reference_id"] = args.reference_id
     try:
+        body: dict = {
+            "project_id": client.require_project_id(),
+            "member_id": args.member_id,
+            "amount": args.amount,
+            "reason": args.reason,
+            "granted_by": args.granted_by,
+        }
+        if args.reference_type:
+            body["reference_type"] = args.reference_type
+        if args.reference_id:
+            body["reference_id"] = args.reference_id
         return ok(await client.post("/api/v2/rewards", json=body))
     except Exception as exc:
         return err(str(exc))
@@ -57,12 +57,12 @@ async def give_reward(args: GiveRewardInput) -> list[TextContent]:
 
 async def get_leaderboard_v2(args: GetLeaderboardInput) -> list[TextContent]:
     """보상 리더보드 조회."""
-    params: dict = {"project_id": client.project_id, "type": "leaderboard"}
-    if args.period:
-        params["period"] = args.period
-    if args.limit is not None:
-        params["limit"] = str(args.limit)
     try:
+        params: dict = {"project_id": client.require_project_id(), "type": "leaderboard"}
+        if args.period:
+            params["period"] = args.period
+        if args.limit is not None:
+            params["limit"] = str(args.limit)
         return ok(await client.get("/api/v2/rewards", params=params))
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/sprints.py
+++ b/backend/sprintable_mcp/tools/sprints.py
@@ -34,10 +34,10 @@ class UpdateSprintInput(SprintableInput):
 
 async def list_sprints(args: ListSprintsInput) -> list[TextContent]:
     """스프린트 목록 조회."""
-    params: dict = {"project_id": client.project_id}
-    if args.status:
-        params["status"] = args.status.value
     try:
+        params: dict = {"project_id": client.require_project_id()}
+        if args.status:
+            params["status"] = args.status.value
         return ok(await client.get("/api/v2/sprints", params=params))
     except Exception as exc:
         return err(str(exc))
@@ -77,14 +77,14 @@ async def get_velocity(args: SprintIdInput) -> list[TextContent]:
 
 async def create_sprint(args: CreateSprintInput) -> list[TextContent]:
     """스프린트 생성."""
-    body: dict = {"title": args.title, "project_id": client.project_id}
-    if args.start_date:
-        body["start_date"] = args.start_date
-    if args.end_date:
-        body["end_date"] = args.end_date
-    if args.team_size is not None:
-        body["team_size"] = args.team_size
     try:
+        body: dict = {"title": args.title, "project_id": client.require_project_id()}
+        if args.start_date:
+            body["start_date"] = args.start_date
+        if args.end_date:
+            body["end_date"] = args.end_date
+        if args.team_size is not None:
+            body["team_size"] = args.team_size
         return ok(await client.post("/api/v2/sprints", json=body))
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/standup.py
+++ b/backend/sprintable_mcp/tools/standup.py
@@ -52,17 +52,17 @@ class CheckinSprintInput(SprintableInput):
 async def standup_missing(args: StandupDateInput) -> list[TextContent]:
     """스탠드업 미제출 멤버 조회."""
     try:
-        return ok(await client.get("/api/v2/standups/missing", params={"project_id": client.project_id, "date": args.date}))
+        return ok(await client.get("/api/v2/standups/missing", params={"project_id": client.require_project_id(), "date": args.date}))
     except Exception as exc:
         return err(str(exc))
 
 
 async def standup_history(args: StandupHistoryInput) -> list[TextContent]:
     """최근 스탠드업 히스토리 조회."""
-    params: dict = {"project_id": client.project_id}
-    if args.limit is not None:
-        params["limit"] = str(args.limit)
     try:
+        params: dict = {"project_id": client.require_project_id()}
+        if args.limit is not None:
+            params["limit"] = str(args.limit)
         return ok(await client.get("/api/v2/standups/history", params=params))
     except Exception as exc:
         return err(str(exc))
@@ -70,9 +70,9 @@ async def standup_history(args: StandupHistoryInput) -> list[TextContent]:
 
 async def get_standup(args: GetStandupInput) -> list[TextContent]:
     """멤버+날짜 기준 스탠드업 조회."""
-    # standups.py:34 author_id 파라미터 (MCP 입력은 member_id → author_id 매핑)
-    params: dict = {"author_id": args.member_id, "date": args.date, "project_id": client.project_id}
     try:
+        # standups.py:34 author_id 파라미터 (MCP 입력은 member_id → author_id 매핑)
+        params: dict = {"author_id": args.member_id, "date": args.date, "project_id": client.require_project_id()}
         return ok(await client.get("/api/v2/standups", params=params))
     except Exception as exc:
         return err(str(exc))
@@ -81,9 +81,10 @@ async def get_standup(args: GetStandupInput) -> list[TextContent]:
 async def save_standup(args: SaveStandupInput) -> list[TextContent]:
     """스탠드업 저장/업데이트.
 
-    1c2be9db: org-level 기본 — client.project_id 를 강제 주입하지 않는다(이전엔 project-level
+    1c2be9db: org-level 기본 — project_id를 강제 주입하지 않는다(이전엔 project-level
     행을 강제). project_id 생략 → BE 가 org-level 엔트리 1건으로 upsert 하고 작성자 접근
-    프로젝트로 자동 링크(projection). (org_id/author_id 는 BE 가 canonical 처리.)
+    프로젝트로 자동 링크(projection). (org_id/author_id 는 BE 가 canonical 처리.) 의도적으로
+    require_project_id()를 쓰지 않음(ambiguous 키도 org-level 저장은 가능해야 함).
     """
     body: dict = {"author_id": args.author_id, "date": args.date}
     for field in ("done", "plan", "blockers"):
@@ -99,19 +100,19 @@ async def save_standup(args: SaveStandupInput) -> list[TextContent]:
 async def list_standup_entries(args: ListStandupEntriesInput) -> list[TextContent]:
     """날짜 기준 스탠드업 목록 조회."""
     try:
-        return ok(await client.get("/api/v2/standups", params={"project_id": client.project_id, "date": args.date}))
+        return ok(await client.get("/api/v2/standups", params={"project_id": client.require_project_id(), "date": args.date}))
     except Exception as exc:
         return err(str(exc))
 
 
 async def get_retro_session(args: GetRetroSessionInput) -> list[TextContent]:
     """스프린트 레트로 세션 조회 (없으면 생성)."""
-    params: dict = {"project_id": client.project_id}
-    if args.org_id:
-        params["org_id"] = args.org_id
-    if args.initiator_id:
-        params["initiator_id"] = args.initiator_id
     try:
+        params: dict = {"project_id": client.require_project_id()}
+        if args.org_id:
+            params["org_id"] = args.org_id
+        if args.initiator_id:
+            params["initiator_id"] = args.initiator_id
         return ok(await client.get(f"/api/v2/retro/{args.sprint_id}", params=params))
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/stories.py
+++ b/backend/sprintable_mcp/tools/stories.py
@@ -61,20 +61,20 @@ class UpdateStoryStatusInput(SprintableInput):
 
 async def list_stories(args: ListStoriesInput) -> list[TextContent]:
     """프로젝트 스토리 목록 조회."""
-    params: dict = {"project_id": client.project_id}
-    if client.org_id:
-        params["org_id"] = client.org_id
-    if args.sprint_id:
-        params["sprint_id"] = args.sprint_id
-    if args.epic_id:
-        params["epic_id"] = args.epic_id
-    if args.status:
-        params["status"] = args.status.value
-    if args.priority:
-        params["priority"] = args.priority.value
-    if args.assignee_id:
-        params["assignee_id"] = args.assignee_id
     try:
+        params: dict = {"project_id": client.require_project_id()}
+        if client.org_id:
+            params["org_id"] = client.org_id
+        if args.sprint_id:
+            params["sprint_id"] = args.sprint_id
+        if args.epic_id:
+            params["epic_id"] = args.epic_id
+        if args.status:
+            params["status"] = args.status.value
+        if args.priority:
+            params["priority"] = args.priority.value
+        if args.assignee_id:
+            params["assignee_id"] = args.assignee_id
         return ok(await client.get("/api/v2/stories", params=params))
     except Exception as exc:
         return err(str(exc))
@@ -87,7 +87,7 @@ async def list_backlog(args: SprintableInput) -> list[TextContent]:
     # ⚠️ no_sprint 는 project_id 와 함께여야 backlog 분기 동작(stories.py list_stories).
     try:
         return ok(await client.get(
-            "/api/v2/stories", params={"project_id": client.project_id, "no_sprint": "true"}
+            "/api/v2/stories", params={"project_id": client.require_project_id(), "no_sprint": "true"}
         ))
     except Exception as exc:
         return err(str(exc))
@@ -95,22 +95,22 @@ async def list_backlog(args: SprintableInput) -> list[TextContent]:
 
 async def add_story(args: AddStoryInput) -> list[TextContent]:
     """스토리 생성."""
-    body: dict = {"title": args.title, "project_id": client.project_id}
-    if args.epic_id:
-        body["epic_id"] = args.epic_id
-    if args.sprint_id:
-        body["sprint_id"] = args.sprint_id
-    if args.assignee_id:
-        body["assignee_id"] = args.assignee_id
-    if args.priority:
-        body["priority"] = args.priority.value
-    if args.story_points:
-        body["story_points"] = args.story_points.value
-    if args.description:
-        body["description"] = args.description
-    if args.acceptance_criteria:
-        body["acceptance_criteria"] = args.acceptance_criteria
     try:
+        body: dict = {"title": args.title, "project_id": client.require_project_id()}
+        if args.epic_id:
+            body["epic_id"] = args.epic_id
+        if args.sprint_id:
+            body["sprint_id"] = args.sprint_id
+        if args.assignee_id:
+            body["assignee_id"] = args.assignee_id
+        if args.priority:
+            body["priority"] = args.priority.value
+        if args.story_points:
+            body["story_points"] = args.story_points.value
+        if args.description:
+            body["description"] = args.description
+        if args.acceptance_criteria:
+            body["acceptance_criteria"] = args.acceptance_criteria
         return ok(await client.post("/api/v2/stories", json=body))
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/tasks.py
+++ b/backend/sprintable_mcp/tools/tasks.py
@@ -45,14 +45,14 @@ class UpdateTaskStatusInput(SprintableInput):
 
 async def list_tasks(args: ListTasksInput) -> list[TextContent]:
     """태스크 목록 조회."""
-    params: dict = {"project_id": client.project_id}
-    if args.story_id:
-        params["story_id"] = args.story_id
-    if args.assignee_id:
-        params["assignee_id"] = args.assignee_id
-    if args.status:
-        params["status"] = args.status.value
     try:
+        params: dict = {"project_id": client.require_project_id()}
+        if args.story_id:
+            params["story_id"] = args.story_id
+        if args.assignee_id:
+            params["assignee_id"] = args.assignee_id
+        if args.status:
+            params["status"] = args.status.value
         return ok(await client.get("/api/v2/tasks", params=params))
     except Exception as exc:
         return err(str(exc))
@@ -60,9 +60,9 @@ async def list_tasks(args: ListTasksInput) -> list[TextContent]:
 
 async def list_my_tasks(args: ListMyTasksInput) -> list[TextContent]:
     """내 태스크 목록 조회."""
-    assignee = args.assignee_id or client.member_id
-    params: dict = {"assignee_id": assignee, "project_id": client.project_id}
     try:
+        assignee = args.assignee_id or client.member_id
+        params: dict = {"assignee_id": assignee, "project_id": client.require_project_id()}
         return ok(await client.get("/api/v2/tasks", params=params))
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/toolset.py
+++ b/backend/sprintable_mcp/toolset.py
@@ -54,6 +54,12 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # 유틸이라 단일 도메인 그룹에 못 묶음. link_gate_to_task와 동일 논리로 core 취급(백엔드
     # SSOT와 동기화, app/services/mcp_toolset.py 참고).
     "sprintable_add_evidence",
+    # E-MCP-OPT(story ff6cb90d): list_projects/set_default_project — 키 자기 신원/스코프 조회·전환
+    # 유틸(sprintable_my_dashboard·sprintable_ping과 동형: 특정 비즈니스 도메인 아닌 self-scope
+    # 도구). set_default_project는 write지만 caller 자신의 기본 프로젝트 설정만 바꾸는 self-scope
+    # 조작이라 파괴적이지 않음(has_project_access로 대상 검증). 백엔드 SSOT와 동기화 필수
+    # (app/services/mcp_toolset.py).
+    "sprintable_list_projects", "sprintable_set_default_project",
 })
 
 _LEGACY_SCOPES: frozenset[str] = frozenset({"read", "write"})

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -46,8 +46,9 @@ EXPECTED_TOOLS = {
     "sprintable_get_overdue_tasks", "sprintable_get_recent_activity",
     "sprintable_get_epic_progress", "sprintable_get_agent_stats",
     "sprintable_get_project_health",
-    # core (2)
+    # core (4) — E-MCP-OPT(story ff6cb90d): list_projects/set_default_project 2종 추가.
     "sprintable_list_team_members", "sprintable_my_dashboard",
+    "sprintable_list_projects", "sprintable_set_default_project",
     # chat (3)
     "sprintable_send_chat_message", "sprintable_create_conversation", "sprintable_list_chat_messages",
     # meetings (6)
@@ -96,7 +97,8 @@ EXPECTED_TOOLS = {
 
 def test_total_tool_count():
     # C1-S3(e50563b4): sprintable_list_artifacts 추가로 98→99... +1=100.
-    assert len(_TOOLS) == 100
+    # E-MCP-OPT(story ff6cb90d): list_projects/set_default_project 2종 추가 — 100→102.
+    assert len(_TOOLS) == 102
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_e_mcp_http_project_default_ee2f4e58.py
+++ b/backend/tests/test_e_mcp_http_project_default_ee2f4e58.py
@@ -35,17 +35,23 @@ def _fresh_client(api_url="https://be", api_key="envkey"):
 
 @pytest.mark.anyio
 async def test_ensure_auth_context_resolves_and_caches_per_key():
-    """키별 /auth/me 1회 해소·캐시(같은 키 재호출은 캐시 히트·다른 키는 새 fetch). 빈 키는 no-op."""
+    """키별 /auth/me 1회 해소·캐시(같은 키 재호출은 캐시 히트·다른 키는 새 fetch). 빈 키는 no-op.
+
+    E-MCP-OPT(ff6cb90d §1): project_id는 이제 resolved_default_project_id(근본 판정)에서 채운다."""
     c = _fresh_client()
     calls = {"n": 0}
 
     async def _fake_get(path, **kw):
         calls["n"] += 1
-        return {"member_id": "m1", "org_id": "o1", "project_id": "p1"}
+        return {"member_id": "m1", "org_id": "o1", "resolved_default_project_id": "p1",
+                "is_project_ambiguous": False, "accessible_project_ids": ["p1"]}
 
     with patch.object(c, "get", new=AsyncMock(side_effect=_fake_get)):
         ctx = await c.ensure_auth_context("keyA")
-        assert ctx == {"member_id": "m1", "org_id": "o1", "project_id": "p1"}
+        assert ctx == {
+            "member_id": "m1", "org_id": "o1", "project_id": "p1",
+            "is_project_ambiguous": False, "accessible_project_ids": ["p1"],
+        }
         await c.ensure_auth_context("keyA")            # 캐시 히트(추가 fetch X)
         assert calls["n"] == 1
         await c.ensure_auth_context("keyB")            # 다른 키 → 새 fetch
@@ -62,7 +68,8 @@ async def test_http_default_resolved_when_no_explicit_project():
     c._project_id = c._org_id = c._member_id = ""                # http 싱글톤 미해소 상태
 
     async def _fake_get(path, **kw):
-        return {"member_id": "mh", "org_id": "oh", "project_id": "ph"}
+        return {"member_id": "mh", "org_id": "oh", "resolved_default_project_id": "ph",
+                "is_project_ambiguous": False, "accessible_project_ids": ["ph"]}
 
     with patch.object(c, "get", new=AsyncMock(side_effect=_fake_get)):
         ktok = set_api_key_override("reqkeyA")
@@ -88,7 +95,8 @@ async def test_explicit_project_override_wins_poke_no_regression():
     c._project_id = ""
 
     async def _fake_get(path, **kw):
-        return {"member_id": "mh", "org_id": "oh", "project_id": "ph"}
+        return {"member_id": "mh", "org_id": "oh", "resolved_default_project_id": "ph",
+                "is_project_ambiguous": False, "accessible_project_ids": ["ph"]}
 
     with patch.object(c, "get", new=AsyncMock(side_effect=_fake_get)):
         ktok = set_api_key_override("reqkeyA")
@@ -121,7 +129,8 @@ async def test_override_none_falls_through_not_explicit_empty():
     c._project_id = ""
 
     async def _fake_get(path, **kw):
-        return {"member_id": "", "org_id": "", "project_id": "ph"}
+        return {"member_id": "", "org_id": "", "resolved_default_project_id": "ph",
+                "is_project_ambiguous": False, "accessible_project_ids": ["ph"]}
 
     with patch.object(c, "get", new=AsyncMock(side_effect=_fake_get)):
         ktok = set_api_key_override("reqkeyA")

--- a/backend/tests/test_e_mcp_opt_ff6cb90d_multiproject_scoping_realdb.py
+++ b/backend/tests/test_e_mcp_opt_ff6cb90d_multiproject_scoping_realdb.py
@@ -1,0 +1,308 @@
+"""E-MCP-OPT(story ff6cb90d·doc mcp-multiproject-scoping-design) — 실 PG.
+
+①무인자 기본값 근본 판정(GET /api/v2/auth/me 신규 필드) + ③set_default_project(PATCH
+/api/v2/auth/me/default-project) 실증. ②list_projects는 신규 BE 로직 0(기존 /api/v2/projects
+그대로) — 별도 realdb 불요.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _seed_agent_key(session, *, project_count: int):
+    """org + N project + agent(Member+AgentProjectProfile+ProjectAccess, project_count개 프로젝트
+    grant) + ApiKey(sk_live_ 원문 해시).
+
+    두 결이 서로 다른 테이블을 본다(실측으로 확인) — AgentProjectProfile은 team_members VIEW
+    backing(_resolve_api_key 레거시 기본 project_id 해소용), ProjectAccess(member_id, granted)는
+    accessible_project_ids_in_org의 에이전트 grant 분기(18073a52) 소스 — 둘 다 시드해야 두 함수가
+    일관되게 같은 프로젝트 집합을 본다."""
+    from app.core.security import hash_token
+    from app.models.api_key import ApiKey
+    from app.models.member import AgentProjectProfile, Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    projects = [Project(id=uuid.uuid4(), org_id=org.id, name=f"P{i}") for i in range(project_count)]
+    session.add_all(projects)
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent")
+    session.add(agent)
+    await session.commit()
+    session.add_all([
+        AgentProjectProfile(id=uuid.uuid4(), member_id=agent.id, project_id=p.id) for p in projects
+    ])
+    session.add_all([
+        ProjectAccess(id=uuid.uuid4(), project_id=p.id, member_id=agent.id, permission="granted")
+        for p in projects
+    ])
+    await session.commit()
+
+    raw_key = f"sk_live_{uuid.uuid4().hex}"
+    session.add(ApiKey(
+        id=uuid.uuid4(), team_member_id=agent.id, member_id=agent.id,
+        key_prefix=raw_key[:12], key_hash=hash_token(raw_key), scope=["read", "write"],
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "member_id": agent.id, "raw_key": raw_key,
+        "project_ids": [p.id for p in projects],
+    }
+
+
+def _client_with_key(app, raw_key: str):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+        headers={"Authorization": f"Bearer {raw_key}"},
+    )
+
+
+@pytest.mark.anyio
+async def test_single_project_key_resolves_unambiguously_no_regression():
+    """단일 프로젝트 키 — resolved_default_project_id=그 프로젝트·ambiguous=False(무회귀 핵심)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_agent_key(s, project_count=1)
+        app.dependency_overrides.clear()
+        from app.dependencies.database import get_db
+
+        async def _db():
+            async with Session() as sess:
+                try:
+                    yield sess
+                    await sess.commit()
+                except Exception:
+                    await sess.rollback()
+                    raise
+        app.dependency_overrides[get_db] = _db
+        client = _client_with_key(app, seeded["raw_key"])
+        try:
+            resp = await client.get("/api/v2/auth/me")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["resolved_default_project_id"] == str(seeded["project_ids"][0])
+            assert body["is_project_ambiguous"] is False
+            assert body["accessible_project_ids"] == [str(seeded["project_ids"][0])]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_multiproject_key_no_default_set_is_ambiguous_not_guessed():
+    """멀티프로젝트 키 + default_project_id 미설정 — resolved=None+ambiguous=True(암묵 추측 금지).
+    §0 핵심 발견(구 ORDER BY 임의값)의 회귀 방지 실증."""
+    from app.main import app
+    from app.dependencies.database import get_db
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_agent_key(s, project_count=3)
+
+        async def _db():
+            async with Session() as sess:
+                try:
+                    yield sess
+                    await sess.commit()
+                except Exception:
+                    await sess.rollback()
+                    raise
+        app.dependency_overrides[get_db] = _db
+        client = _client_with_key(app, seeded["raw_key"])
+        try:
+            resp = await client.get("/api/v2/auth/me")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["resolved_default_project_id"] is None
+            assert body["is_project_ambiguous"] is True
+            assert set(body["accessible_project_ids"]) == {str(p) for p in seeded["project_ids"]}
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_set_default_project_then_unambiguous_resolution():
+    """set_default_project 성공 → /auth/me가 그 프로젝트로 즉시 해소(ambiguous=False)."""
+    from app.main import app
+    from app.dependencies.database import get_db
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_agent_key(s, project_count=3)
+        target = seeded["project_ids"][1]
+
+        async def _db():
+            async with Session() as sess:
+                try:
+                    yield sess
+                    await sess.commit()
+                except Exception:
+                    await sess.rollback()
+                    raise
+        app.dependency_overrides[get_db] = _db
+        client = _client_with_key(app, seeded["raw_key"])
+        try:
+            patch_resp = await client.patch(
+                "/api/v2/auth/me/default-project", json={"project_id": str(target)},
+            )
+            assert patch_resp.status_code == 200, patch_resp.text
+            body = patch_resp.json()
+            assert body["resolved_default_project_id"] == str(target)
+            assert body["is_project_ambiguous"] is False
+
+            me_resp = await client.get("/api/v2/auth/me")
+            assert me_resp.json()["resolved_default_project_id"] == str(target)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_set_default_project_rejects_inaccessible_project_403():
+    """접근권 없는 프로젝트(다른 org) 지정 → 403·member.default_project_id 무변경(body-claimed 금지)."""
+    from app.main import app
+    from app.dependencies.database import get_db
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_agent_key(s, project_count=2)
+            other_org = Organization(id=uuid.uuid4(), name="Other", slug=f"other-{uuid.uuid4().hex[:8]}")
+            s.add(other_org)
+            await s.commit()
+            foreign_project = Project(id=uuid.uuid4(), org_id=other_org.id, name="Foreign")
+            s.add(foreign_project)
+            await s.commit()
+            foreign_project_id = foreign_project.id
+
+        async def _db():
+            async with Session() as sess:
+                try:
+                    yield sess
+                    await sess.commit()
+                except Exception:
+                    await sess.rollback()
+                    raise
+        app.dependency_overrides[get_db] = _db
+        client = _client_with_key(app, seeded["raw_key"])
+        try:
+            resp = await client.patch(
+                "/api/v2/auth/me/default-project", json={"project_id": str(foreign_project_id)},
+            )
+            assert resp.status_code == 403, resp.text
+
+            # 무변경 확認 — 여전히 ambiguous(설정 안 됨).
+            me_resp = await client.get("/api/v2/auth/me")
+            assert me_resp.json()["is_project_ambiguous"] is True
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_default_project_changed_event_emitted():
+    """set_default_project 성공 시 member.default_project_changed(old/new) emit — 감사 가능성 실증."""
+    from unittest.mock import MagicMock, patch as mock_patch
+
+    from app.main import app
+    from app.dependencies.database import get_db
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_agent_key(s, project_count=2)
+        target = seeded["project_ids"][0]
+
+        async def _db():
+            async with Session() as sess:
+                try:
+                    yield sess
+                    await sess.commit()
+                except Exception:
+                    await sess.rollback()
+                    raise
+        app.dependency_overrides[get_db] = _db
+        client = _client_with_key(app, seeded["raw_key"])
+        try:
+            publish = MagicMock()
+            with mock_patch("app.routers.events.publish_event", publish):
+                resp = await client.patch(
+                    "/api/v2/auth/me/default-project", json={"project_id": str(target)},
+                )
+                assert resp.status_code == 200, resp.text
+            publish.assert_called_once()
+            args, _ = publish.call_args
+            assert args[1] == "member.default_project_changed"
+            payload = args[2]
+            assert payload["member_id"] == str(seeded["member_id"])
+            assert payload["old_default_project_id"] is None
+            assert payload["new_default_project_id"] == str(target)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_mcp_opt_ff6cb90d_require_project_id_enforcement.py
+++ b/backend/tests/test_e_mcp_opt_ff6cb90d_require_project_id_enforcement.py
@@ -1,0 +1,103 @@
+"""E-MCP-OPT(story ff6cb90d) — 까심 QA 지적(conv ac49f871) 반영: "무인자+ambiguous=명시 에러"가
+실제로 나가는 지점 실증. `SprintableClient.require_project_id()`가 그 지점이고, 개별 MCP 툴
+함수가 이를 호출해 자기 try/except로 잡아 err() TextContent로 노출한다(신규 플러밍 불요 —
+기존 에러 표면화 관용구 그대로 재사용)."""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    import sprintable_mcp.api_client as ac
+    ac._auth_ctx_cache.clear()
+    yield
+    ac._auth_ctx_cache.clear()
+
+
+def _fresh_client(api_key="envkey"):
+    from sprintable_mcp.api_client import SprintableClient
+    c = SprintableClient()
+    c.configure("https://be", api_key)
+    return c
+
+
+def test_require_project_id_returns_value_when_resolved():
+    """단일/명시 default로 해소된 경우 — 그냥 값 반환(에러 없음)."""
+    c = _fresh_client()
+    c._project_id = "p1"
+    assert c.require_project_id() == "p1"
+
+
+def test_require_project_id_raises_guided_error_when_ambiguous():
+    """무인자+ambiguous(멀티프로젝트+미설정) — SprintableApiError로 가이드 메시지+접근가능 목록."""
+    from sprintable_mcp.api_client import SprintableApiError
+
+    c = _fresh_client()
+    c._project_id = ""
+    c._accessible_project_ids = ["pa", "pb", "pc"]
+
+    with pytest.raises(SprintableApiError) as exc_info:
+        c.require_project_id()
+    err = exc_info.value
+    assert "project_id" in str(err) or "프로젝트" in str(err)
+    assert "set_default_project" in str(err)
+    assert err.body["accessible_project_ids"] == ["pa", "pb", "pc"]
+
+
+def test_require_project_id_override_wins_even_when_ambiguous():
+    """per-call override(85429ee0)가 있으면 ambiguous 상태여도 에러 없이 그 값 사용(회귀 방지)."""
+    from sprintable_mcp.api_client import reset_project_override, set_project_override
+
+    c = _fresh_client()
+    c._project_id = ""
+    c._accessible_project_ids = ["pa", "pb"]
+    tok = set_project_override("explicit-P")
+    try:
+        assert c.require_project_id() == "explicit-P"
+    finally:
+        reset_project_override(tok)
+
+
+@pytest.mark.anyio
+async def test_tool_call_surfaces_guided_error_as_text_content():
+    """실제 MCP 툴(list_stories) 호출 — ambiguous 상태에서 err() TextContent로 가이드 메시지 노출
+    (새 플러밍 없이 기존 try/except가 그대로 잡음 — 까심 QA가 확인하려는 정확한 지점)."""
+    from sprintable_mcp.api_client import client
+    from sprintable_mcp.tools.stories import ListStoriesInput, list_stories
+
+    client._project_id = ""
+    client._accessible_project_ids = ["proj-a", "proj-b"]
+    try:
+        result = await list_stories(ListStoriesInput())
+        assert len(result) == 1
+        text = result[0].text
+        assert text.startswith("Error:")
+        assert "set_default_project" in text
+    finally:
+        client._project_id = ""
+        client._accessible_project_ids = []
+
+
+@pytest.mark.anyio
+async def test_tool_call_succeeds_when_unambiguous():
+    """단일/명시 default 상태 — require_project_id()가 정상 값을 반환해 백엔드 호출까지 도달."""
+    from sprintable_mcp.api_client import client
+    from sprintable_mcp.tools.stories import ListStoriesInput, list_stories
+
+    client._project_id = "proj-a"
+    with patch.object(client, "get", new=AsyncMock(return_value=[{"id": "s1"}])):
+        try:
+            result = await list_stories(ListStoriesInput())
+        finally:
+            client._project_id = ""
+    body = json.loads(result[0].text)
+    assert body == [{"id": "s1"}]

--- a/backend/tests/test_mcp_hypotheses.py
+++ b/backend/tests/test_mcp_hypotheses.py
@@ -19,6 +19,7 @@ def anyio_backend():
 def _client(**methods):
     c = MagicMock()
     c.project_id = "proj-1"
+    c.require_project_id = MagicMock(return_value="proj-1")  # E-MCP-OPT ff6cb90d
     for name, ret in methods.items():
         setattr(c, name, AsyncMock(return_value=ret))
     return c

--- a/backend/tests/test_mcp_list_backlog_b5870c4c.py
+++ b/backend/tests/test_mcp_list_backlog_b5870c4c.py
@@ -17,6 +17,9 @@ async def test_list_backlog_targets_existing_endpoint_with_no_sprint(monkeypatch
         project_id = "proj-1"
         org_id = None
 
+        def require_project_id(self):  # E-MCP-OPT ff6cb90d: 툴이 이제 이 메서드를 씀.
+            return self.project_id
+
         async def get(self, path, params=None):
             captured["path"] = path
             captured["params"] = params or {}

--- a/backend/tests/test_mcp_phase1.py
+++ b/backend/tests/test_mcp_phase1.py
@@ -60,7 +60,10 @@ async def test_resolve_auth_context_caches_ids():
     mock_resp.json.return_value = {
         "member_id": member_id,
         "org_id": org_id,
-        "project_id": project_id,
+        # E-MCP-OPT(ff6cb90d §1): 근본 판정 필드 — 단일 접근가능 프로젝트라 가정(ambiguous=False).
+        "resolved_default_project_id": project_id,
+        "is_project_ambiguous": False,
+        "accessible_project_ids": [project_id],
     }
 
     with patch("httpx.AsyncClient.request", new_callable=AsyncMock, return_value=mock_resp):


### PR DESCRIPTION
## Summary
- doc `mcp-multiproject-scoping-design`(design-first·PO 승인) 구현. story ff6cb90d.
- **①무인자 기본값 근본 판정**: `GET /api/v2/auth/me`에 `resolved_default_project_id`/`is_project_ambiguous`/`accessible_project_ids` 신규 필드 — 단일 접근가능 프로젝트면 그대로(무회귀), 2개 이상이면 명시 `Member.default_project_id`만 신뢰, 그 외엔 추측 0(null+ambiguous). §0 그라운딩 발견: 기존 `project_id`(레거시)는 `_resolve_api_key`가 매 요청 `ORDER BY project_id ASC LIMIT 1`로 재계산하는 임의값이었음 — 이 필드는 48개 기존 mutation 라우트가 항상 값 있다고 가정하는 blast radius라 **완전 무변경 유지**, 대신 새 필드를 additive 병행.
- **②`list_projects` MCP 툴**: 신규 BE 로직 0 — 기존 `GET /api/v2/projects`(정책B) 얇은 래핑.
- **③`set_default_project` MCP 툴**: `members.default_project_id`(additive 마이그 0177, FK→projects — P0-03의 human_owner_member_id와 달리 이번엔 FK 타당: projects는 단일 안정 물리 테이블). write-time `has_project_access` 강제(cross-org/무권한 차단) + `member.default_project_changed` 이벤트 emit(감사 가능) + MCP 클라이언트 캐시 즉시 갱신.
- PO 확定 사항 반영: org owner/admin 키도 동일 규율(의도된 강화) · 감사 이벤트 필요(updated_at만으론 부족) · **구 ORDER BY 계약을 고정한 3개 테스트 파일(`test_org_agent_apikey_project_ids.py` 등)은 additive-only 설계 덕에 실제로는 무변경 확인**(design doc 승인 당시 예상과 달리 impl 단계에서 48-라우트 blast radius를 발견해 더 안전한 접근으로 정제 — PR 코멘트로 상세 설명 예정).

## Test plan
- [x] realdb 5 pass: 단일프로젝트 키 무회귀 · 멀티프로젝트+미설정=ambiguous(암묵 추측 없음 실증) · set_default_project 후 즉시 해소 · 무권한 프로젝트 지정 403+무변경 · `member.default_project_changed` 이벤트 emit(payload old/new 검증).
- [x] MCP 계약(tests/mcp/test_contract.py) 100→102 tool·bidirectional EXPECTED_TOOLS 갱신.
- [x] 회귀 400+ green: auth 관련 24파일·toolset/scope 6파일·recruit/role_template 10파일·구 ORDER BY 계약 3파일(전부 무변경 확인) — 로컬 PG(alembic head 0177).
- [x] ruff clean(신규 파일 전부·수정 파일은 pre-existing 문제만, 신규 위반 0).

## Note
`list_projects`/`set_default_project` 벤더드 사본(`sprintable_mcp/toolset.py`)과 백엔드 SSOT(`app/services/mcp_toolset.py`) 둘 다 동기화(`_ALWAYS_ALLOWED` + `ALL_TOOL_NAMES`) — 드리프트 금지 규율 준수.

머지 후 **hosted MCP dev 재배포는 PO lane**(tools/list 실측까지 라이브).

🤖 Generated with [Claude Code](https://claude.com/claude-code)