### PR TITLE
feat(sse): trust_stage_changed org publish → FE event-stream 브릿지 (story 9ef0f914)

### DIFF
--- a/backend/app/services/project_auth.py
+++ b/backend/app/services/project_auth.py
@@ -441,3 +441,29 @@ async def accessible_project_ids_in_org(
         {"user_id": user_id, "org_id": org_id},
     )
     return [uuid.UUID(str(r[0])) for r in rows.all()]
+
+
+async def project_accessible_member_ids(
+    session: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID,
+) -> set[uuid.UUID]:
+    """E-UI-DAEGBYEON P0-04 후속(story 9ef0f914) — `accessible_project_ids_in_org`의 역방향
+    (project 고정 → 접근 가능 member_id 집합). `team_members`(VIEW, human+agent grant를 이미
+    member_id 공간으로 통합)만 조회 — 단일 쿼리 배치(N+1 없음).
+
+    ⚠️ org owner/admin의 암묵 org-wide 접근 분기(has_project_access 3번째 조건)는 **의도적으로
+    제외**한다 — 이 함수는 실시간 SSE push 수신자 해소 전용이라, 명시 project 소속이 없는 admin에게
+    안 밀리는 쪽(false negative)이 잘못 밀리는 쪽(false positive·cross-project 누설)보다 안전.
+    write 인가(has_project_access)는 이 함수를 쓰지 않는다 — 그쪽은 기존 3-branch 그대로."""
+    rows = await session.execute(
+        text(
+            """
+            SELECT tm.id
+            FROM team_members tm
+            WHERE tm.project_id = :project_id
+              AND tm.org_id = :org_id
+              AND tm.is_active = true
+            """
+        ),
+        {"project_id": project_id, "org_id": org_id},
+    )
+    return {uuid.UUID(str(r[0])) for r in rows.all()}

--- a/backend/app/services/trust_pipeline.py
+++ b/backend/app/services/trust_pipeline.py
@@ -12,6 +12,7 @@ glance/attention·glance/hero와 동일한 기존 파생 패턴의 확장(이중
 """
 from __future__ import annotations
 
+import logging
 import uuid
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
@@ -24,6 +25,8 @@ from app.models.dependency import ItemDependency
 from app.models.gate import Gate
 from app.models.pm import Story
 from app.services.evidence_service import batch_human_verified
+
+logger = logging.getLogger(__name__)
 
 TRUST_STAGES = ("queued", "running", "needs_input", "claimed_done", "verified", "merge_ready")
 
@@ -174,7 +177,7 @@ async def _maybe_emit(
         return  # 변경 없음 — 이벤트 폭주 방지(doc §4).
     from app.routers.events import publish_event  # lazy import — service→router 순환 회피.
 
-    publish_event(str(org_id), "story.trust_stage_changed", {
+    event_data = {
         "story_id": str(story_id),
         "project_id": str(after.project_id),
         "org_id": str(org_id),
@@ -183,7 +186,27 @@ async def _maybe_emit(
         "exception_signals": new_signals,
         "actor_id": str(actor_id) if actor_id else None,
         "timestamp": datetime.now(timezone.utc).isoformat(),
-    })
+    }
+    publish_event(str(org_id), "story.trust_stage_changed", event_data)
+
+    # E-UI-DAEGBYEON P0-04 후속(story 9ef0f914): org publish는 `_subscribers[org_id]`(구독
+    # 엔드포인트 없음 — 실측 확인)로만 가고 FE가 실제로 붙는 `_agent_connections[member_id]`에는
+    # 안 닿는다 — "레지스트리 통합"이 아니라 project 인가 필터를 낀 포워딩으로 그 갭을 메운다.
+    # 순수 transient push(Event row 생성 0 — 오프라인 백필 불필요·PO 가드레일)·연결 안 된 멤버는
+    # _push_to_agent 자체가 조용히 no-op.
+    try:
+        from app.routers.events import _push_to_agent
+        from app.services.project_auth import project_accessible_member_ids
+
+        member_ids = await project_accessible_member_ids(session, org_id, after.project_id)
+        sse_payload = {"event_type": "story.trust_stage_changed", **event_data}
+        for member_id in member_ids:
+            _push_to_agent(str(member_id), dict(sse_payload))
+    except Exception:
+        logger.warning(
+            "trust_stage_changed SSE 포워딩 실패(story=%s project=%s) — org publish는 이미 발행됨",
+            story_id, after.project_id, exc_info=True,
+        )
 
 
 async def maybe_emit_trust_stage_changed(

--- a/backend/tests/test_e_ui_daegbyeon_9ef0f914_sse_bridge_realdb.py
+++ b/backend/tests/test_e_ui_daegbyeon_9ef0f914_sse_bridge_realdb.py
@@ -1,0 +1,208 @@
+"""E-UI-DAEGBYEON [P0-04 후속](story 9ef0f914) — story.trust_stage_changed org publish → FE
+event-stream(`_agent_connections[member_id]`) 브릿지. 실 PG.
+
+PO 가드레일(2026-07-13): ①Event row 생성 0(순수 transient push) ②멤버 해소는 단일 배치 쿼리.
+crux = 인가 경계 — project 접근 가능 member만 수신, cross-project 미수신은 하드 게이트.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+def _clear_agent_connections():
+    """모듈 전역 레지스트리 — 테스트 간 격리(누수 0)."""
+    from app.routers import events as ev
+    ev._agent_connections.clear()
+    yield
+    ev._agent_connections.clear()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org + project_a/project_b + human member_a(project_a grant)·member_b(project_b grant) +
+    story(in-review, project_a) + gate(merge, pending) — approve 트리거로 trust_stage 전환."""
+    from app.models.gate import Gate
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    member_a = Member(id=uuid.uuid4(), org_id=org.id, type="human", name="Member A")
+    member_b = Member(id=uuid.uuid4(), org_id=org.id, type="human", name="Member B")
+    session.add_all([member_a, member_b])
+    await session.commit()
+    session.add_all([
+        ProjectAccess(id=uuid.uuid4(), project_id=project_a.id, member_id=member_a.id, permission="granted"),
+        ProjectAccess(id=uuid.uuid4(), project_id=project_b.id, member_id=member_b.id, permission="granted"),
+    ])
+    await session.commit()
+
+    from app.models.pm import Story
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="S", status="in-review")
+    session.add(story)
+    await session.commit()
+    gate = Gate(
+        id=uuid.uuid4(), org_id=org.id, work_item_id=story.id, work_item_type="story",
+        gate_type="merge", status="pending",
+    )
+    session.add(gate)
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a": project_a.id, "project_b": project_b.id,
+        "member_a": member_a.id, "member_b": member_b.id,
+        "story_id": story.id, "gate_id": gate.id, "resolver_id": member_a.id,
+    }
+
+
+@pytest.mark.anyio
+async def test_project_scoped_member_receives_transient_push_no_event_row():
+    """project_a 접근 member_a(연결 中)는 story.trust_stage_changed를 큐로 직접 수신 —
+    Event row 생성 0(가드레일①)."""
+    from app.models.event import Event
+    from app.routers import events as ev
+    from app.services.gate_service import transition_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        queue_a: asyncio.Queue = asyncio.Queue()
+        ev._agent_connections[str(seeded["member_a"])].add(queue_a)
+
+        async with Session() as s:
+            await transition_gate(s, seeded["org_id"], seeded["gate_id"], "approved", resolver_id=seeded["resolver_id"])
+            await s.commit()
+
+        assert not queue_a.empty(), "member_a(project_a 접근)가 push를 못 받음"
+        payload = queue_a.get_nowait()
+        assert payload["event_type"] == "story.trust_stage_changed"
+        assert payload["story_id"] == str(seeded["story_id"])
+        assert payload["project_id"] == str(seeded["project_a"])
+
+        # 가드레일①: 이 story에 대한 Event row가 생성되지 않았어야 함(순수 transient push).
+        async with Session() as s:
+            rows = (await s.execute(
+                Event.__table__.select().where(Event.event_type == "story.trust_stage_changed")
+            )).all()
+            assert rows == [], f"Event row가 생성됨(가드레일①위반): {rows}"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cross_project_member_does_not_receive_push_hard_gate():
+    """하드 게이트(PO 지시) — project_b 접근 member_b는 project_a 이벤트를 절대 못 받는다."""
+    from app.routers import events as ev
+    from app.services.gate_service import transition_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        queue_a: asyncio.Queue = asyncio.Queue()
+        queue_b: asyncio.Queue = asyncio.Queue()
+        ev._agent_connections[str(seeded["member_a"])].add(queue_a)
+        ev._agent_connections[str(seeded["member_b"])].add(queue_b)
+
+        async with Session() as s:
+            await transition_gate(s, seeded["org_id"], seeded["gate_id"], "approved", resolver_id=seeded["resolver_id"])
+            await s.commit()
+
+        assert not queue_a.empty()
+        assert queue_b.empty(), "cross-project 누설 — member_b(project_b)가 project_a 이벤트를 받음"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_disconnected_member_silently_skipped_no_crash():
+    """project_a 접근이지만 연결 안 된 member(큐 미등록) — 조용히 스킵(예외 없음)."""
+    from app.services.gate_service import transition_gate
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        # _agent_connections에 아무도 등록 안 함 — 전원 미연결.
+        async with Session() as s:
+            gate = await transition_gate(s, seeded["org_id"], seeded["gate_id"], "approved", resolver_id=seeded["resolver_id"])
+            await s.commit()
+        assert gate.status == "approved"  # 크래시 없이 정상 완료.
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_batch_member_resolution_single_query():
+    """가드레일② — project_accessible_member_ids가 단일 쿼리(N+1 아님)로 배치 해소."""
+    from unittest.mock import patch
+
+    from app.services.project_auth import project_accessible_member_ids
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        async with Session() as s:
+            call_count = {"n": 0}
+            _orig_execute = s.execute
+
+            async def _counting_execute(*args, **kwargs):
+                call_count["n"] += 1
+                return await _orig_execute(*args, **kwargs)
+
+            with patch.object(s, "execute", side_effect=_counting_execute):
+                result = await project_accessible_member_ids(s, seeded["org_id"], seeded["project_a"])
+            assert call_count["n"] == 1, f"단일 쿼리여야 함(실측 {call_count['n']}회)"
+            assert result == {seeded["member_a"]}
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- E-UI-DAEGBYEON P0-04 완료 기준("SSE 이벤트가... 새로고침 없이 다음 인간 행동이 드러남")의 잔여 해소. story 9ef0f914.
- **갭**: `publish_event`가 org단위 `_subscribers[org_id]`로 발행하지만 그 레지스트리를 구독하는 엔드포인트가 없음(실측 확인) — FE가 실제로 붙는 `GET /api/v2/events/stream`은 별도 `_agent_connections[member_id]`를 읽어 완전 독립된 레지스트리. 두 세계는 존재 이유가 달라 "통합"이 아니라 **"인가 필터를 낀 포워딩"**으로 브릿지(PO 판정).
- 신규 `project_accessible_member_ids(session, org_id, project_id)`(`app/services/project_auth.py`) — `team_members` VIEW(human+agent grant가 이미 member_id 공간으로 통합돼 있음) 단일 쿼리 배치(N+1 없음, PO 가드레일②). org owner/admin의 암묵 전역접근 분기는 의도적 제외 — 실시간 push는 명시 grant 기반만(false negative가 cross-project 누설[false positive]보다 안전).
- `trust_pipeline._maybe_emit`이 `publish_event` 직후 이 배치로 project 접근 멤버를 해소해 각자에게 기존 `_push_to_agent(member_id, payload)`로 개별 전달 — **Event row 생성 0**(순수 transient push, PO 가드레일① — 이 이벤트엔 오프라인 백필이 불필요하고 per-member Event INSERT는 과거 backfill landmine을 재소환하므로 금지). 연결 안 된 멤버는 `_push_to_agent` 자체가 조용히 no-op. 포워딩 실패는 org publish 자체를 깨지 않도록 try/except로 격리.

## Test plan
- [x] realdb 4 pass: project 접근 멤버가 transient push 수신 + Event row 미생성 실증 · **cross-project 미수신 하드게이트**(PO 지시) · 미연결 멤버 무크래시 · 배치 쿼리 단일 회 실측(N+1 없음).
- [x] 기존 gate/trust-pipeline 회귀 42개 green(로컬 PG alembic head 0176).
- [x] ruff clean.

## Note
FE 절반(`useSseNotifications`이 현재 하드코딩 3종 named-event만 인식 — `story.trust_stage_changed` 리스닝 확장 필요 + AQ 뷰의 SSE 구독 배선 자체가 아직 없음, 현재 1회성 fetch만)은 미르코 스코프로 별도 트래킹.

🤖 Generated with [Claude Code](https://claude.com/claude-code)