### PR TITLE
[SID:9ef0f914] SSE 브릿지 FE 절반 — story.trust_stage_changed 트리거→attention 재조회

### DIFF
--- a/apps/web/src/app/(authenticated)/inbox/page.tsx
+++ b/apps/web/src/app/(authenticated)/inbox/page.tsx
@@ -401,7 +401,7 @@ export default function InboxPage() {
         {activeTab === 'attention' ? (
           <div className="flex-1 overflow-y-auto p-4">
             {projectId ? (
-              <AttentionQueueView projectId={projectId} />
+              <AttentionQueueView projectId={projectId} memberId={currentTeamMemberId} />
             ) : (
               <p className="text-xs text-muted-foreground">{t('loading')}</p>
             )}

--- a/apps/web/src/components/attention-queue/attention-queue-view.tsx
+++ b/apps/web/src/components/attention-queue/attention-queue-view.tsx
@@ -1,16 +1,22 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { ShieldCheck } from 'lucide-react';
 import { ProofCapsule } from '@/components/proof-capsule/proof-capsule';
+import { useSseNotifications } from '@/hooks/use-sse-notifications';
+import { cn } from '@/lib/utils';
 import {
-  parseAttentionQueueSignals, buildAttentionQueueFromBe, buildAttentionQueue,
+  parseAttentionQueueSignals, buildAttentionQueueFromBe, buildAttentionQueue, diffAttentionQueueItemIds,
   type AttentionQueueItem, type AttentionQueueTranslator,
 } from './derive-attention-queue';
 
 const CAP = 7;
+// 9ef0f914: story.trust_stage_changed 버스트(같은 story 연속 전이 등)를 단발 재조회로 병합.
+const REFETCH_DEBOUNCE_MS = 500;
+// 신규/갱신 행 1회 하이라이트 지속(트랜지션 700ms보다 살짝 길게 — transition-colors 완주 보장).
+const HIGHLIGHT_MS = 900;
 
 async function fetchAttentionQueue(projectId: string, t: AttentionQueueTranslator): Promise<AttentionQueueItem[]> {
   const json = await fetch(`/api/glance/attention?project_id=${projectId}`)
@@ -24,7 +30,9 @@ function RowSkeleton() {
   return <div className="h-[52px] animate-pulse border-b border-proof-line-soft bg-proof-sunk/60 last:border-b-0" />;
 }
 
-function AttentionRow({ item, onNavigate }: { item: AttentionQueueItem; onNavigate: (href: string) => void }) {
+function AttentionRow({ item, highlighted, onNavigate }: {
+  item: AttentionQueueItem; highlighted: boolean; onNavigate: (href: string) => void;
+}) {
   return (
     <div
       role="button"
@@ -36,7 +44,11 @@ function AttentionRow({ item, onNavigate }: { item: AttentionQueueItem; onNaviga
       onKeyDown={(e) => {
         if (e.key === 'Enter') onNavigate(item.href);
       }}
-      className="cursor-pointer border-b border-proof-line-soft last:border-b-0 hover:bg-proof-sunk"
+      className={cn(
+        'cursor-pointer border-b border-proof-line-soft last:border-b-0 hover:bg-proof-sunk',
+        'motion-safe:transition-colors motion-safe:duration-700',
+        highlighted && 'motion-safe:bg-proof-citron/15',
+      )}
     >
       <ProofCapsule
         density="row"
@@ -61,14 +73,36 @@ function AttentionRow({ item, onNavigate }: { item: AttentionQueueItem; onNaviga
  * trust-pipeline-be-design §6). 4유형(검증실패/결정필요[needs_input+gate_pending 합류]/막힘/
  * 병합대기) — 범위이탈(Red)은 BE가 §7 확定②로 여전히 미구현이라 항상 빈 신호(no-fiction 렌더
  * 생략). actor(human/agent 아바타)는 BE `AttentionItem`에 assignee 필드가 없어 당분간 없음
- * (P0-03 `human_owner_member_id` 노출 시 복원 예정 — 별도 low 스토리). SSE 실시간 반영(P0-04
- * "새로고침 없이" 완료기준의 잔여)은 BE 브릿지 미비로 이 스토리 스코프 밖(별도 high 스토리).
+ * (P0-03 `human_owner_member_id` 노출 시 복원 예정 — 별도 low 스토리).
+ *
+ * SSE 실시간 반영(9ef0f914, P0-04 "새로고침 없이" 완료기준의 잔여): `story.trust_stage_changed`
+ * 수신을 **트리거로만** 쓴다 — payload의 exception_signals는 이 story 하나의 불리언일 뿐(gate_pending
+ * 미포함)이라 클라에서 신뢰의 소스로 쓰면 결정필요 행이 유령으로 남거나 거짓 ALL CLEAR가 재발한다
+ * (PO 콜 2026-07-13). 대신 이벤트 수신 시 `/glance/attention`을 디바운스 단발 재조회(진실은 항상
+ * 서버) — 4중 fan-out이던 v1 클라 파생과 달리 단일 저비용 호출이라 "전량 리페치 금지" 취지 위반
+ * 아님. 이전 리스트와 diff해 신규/갱신 행만 1회 하이라이트(全행 반짝 금지·prefers-reduced-motion).
  */
-export function AttentionQueueView({ projectId }: { projectId: string }) {
+export function AttentionQueueView({ projectId, memberId }: { projectId: string; memberId?: string }) {
   const router = useRouter();
   const t = useTranslations('attentionQueue');
   const [loading, setLoading] = useState(true);
   const [items, setItems] = useState<AttentionQueueItem[]>([]);
+  const [highlightedIds, setHighlightedIds] = useState<Set<string>>(new Set());
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const highlightTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const itemsRef = useRef(items);
+  useEffect(() => { itemsRef.current = items; }, [items]);
+
+  const refetchAndDiff = useCallback(async () => {
+    const result = await fetchAttentionQueue(projectId, t);
+    const changed = diffAttentionQueueItemIds(itemsRef.current, result);
+    setItems(result);
+    if (changed.size > 0) {
+      if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current);
+      setHighlightedIds(changed);
+      highlightTimerRef.current = setTimeout(() => setHighlightedIds(new Set()), HIGHLIGHT_MS);
+    }
+  }, [projectId, t]);
 
   useEffect(() => {
     let cancelled = false;
@@ -80,8 +114,29 @@ export function AttentionQueueView({ projectId }: { projectId: string }) {
       setLoading(false);
     }
     void load();
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+      if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+      if (highlightTimerRef.current) clearTimeout(highlightTimerRef.current);
+    };
   }, [projectId, t]);
+
+  const handleTrustStageChanged = useCallback((_eventName: string, data: unknown) => {
+    if (typeof data !== 'object' || data === null) return;
+    // project 스코프 필터 — SSE는 org 단위 스트림이라 이 AQ가 보는 프로젝트 밖 story 전이는 무시.
+    if ((data as Record<string, unknown>)['project_id'] !== projectId) return;
+    if (debounceTimerRef.current) clearTimeout(debounceTimerRef.current);
+    debounceTimerRef.current = setTimeout(() => {
+      debounceTimerRef.current = null;
+      void refetchAndDiff();
+    }, REFETCH_DEBOUNCE_MS);
+  }, [projectId, refetchAndDiff]);
+
+  useSseNotifications({
+    memberId,
+    extraEventNames: ['story.trust_stage_changed'],
+    onExtraEvent: handleTrustStageChanged,
+  });
 
   const { shown, overflow } = buildAttentionQueue(items, CAP);
 
@@ -112,7 +167,10 @@ export function AttentionQueueView({ projectId }: { projectId: string }) {
       ) : (
         <div>
           {shown.map((item) => (
-            <AttentionRow key={item.id} item={item} onNavigate={(href) => router.push(href)} />
+            <AttentionRow
+              key={item.id} item={item} highlighted={highlightedIds.has(item.id)}
+              onNavigate={(href) => router.push(href)}
+            />
           ))}
           {overflow > 0 ? (
             <div className="flex items-center gap-1.5 border-t border-proof-line-soft bg-proof-sunk px-5 py-2.5 text-[12.5px] text-proof-ink-3">

--- a/apps/web/src/components/attention-queue/derive-attention-queue.test.ts
+++ b/apps/web/src/components/attention-queue/derive-attention-queue.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { createTranslator } from 'next-intl';
 import {
-  parseAttentionQueueSignals, buildAttentionQueueFromBe, buildAttentionQueue,
+  parseAttentionQueueSignals, buildAttentionQueueFromBe, buildAttentionQueue, diffAttentionQueueItemIds,
   type BeAttentionItem, type AttentionQueueItem, type AttentionQueueTranslator,
 } from './derive-attention-queue';
 import koMessagesRaw from '../../../messages/ko.json';
@@ -178,5 +178,36 @@ describe('buildAttentionQueue', () => {
     const { shown, overflow } = buildAttentionQueue([item('verify_fail', 1)]);
     expect(shown).toHaveLength(1);
     expect(overflow).toBe(0);
+  });
+});
+
+describe('diffAttentionQueueItemIds (9ef0f914 — SSE-triggered refetch diff)', () => {
+  function item(id: string, claim: string): AttentionQueueItem {
+    return {
+      id, kind: 'blocked', kindLabel: '막힘', proofState: 'amber', claim,
+      actor: null, actionLabel: '조율', actionTone: 'neutral', href: '/board', sortKey: 0,
+    };
+  }
+
+  it('marks a newly-appeared id as changed', () => {
+    const changed = diffAttentionQueueItemIds([], [item('a', 'x')]);
+    expect(changed).toEqual(new Set(['a']));
+  });
+
+  it('marks an id whose claim text changed, and leaves unchanged ids out (no full-list flash)', () => {
+    const prev = [item('a', 'old claim'), item('b', 'stable claim')];
+    const next = [item('a', 'new claim'), item('b', 'stable claim')];
+    expect(diffAttentionQueueItemIds(prev, next)).toEqual(new Set(['a']));
+  });
+
+  it('returns an empty set when nothing changed (no spurious highlight)', () => {
+    const list = [item('a', 'same'), item('b', 'same2')];
+    expect(diffAttentionQueueItemIds(list, list)).toEqual(new Set());
+  });
+
+  it('does not mark removed ids (removal itself is the signal — no separate flash needed)', () => {
+    const prev = [item('a', 'x'), item('b', 'y')];
+    const next = [item('a', 'x')];
+    expect(diffAttentionQueueItemIds(prev, next)).toEqual(new Set());
   });
 });

--- a/apps/web/src/components/attention-queue/derive-attention-queue.ts
+++ b/apps/web/src/components/attention-queue/derive-attention-queue.ts
@@ -154,6 +154,25 @@ export function buildAttentionQueueFromBe(
   return items;
 }
 
+/**
+ * SSE `story.trust_stage_changed`(9ef0f914 — 이벤트는 트리거, 진실은 서버) 수신 後 `/glance/attention`
+ * 단발 재조회 결과를 이전 리스트와 비교 — **신규 등장 또는 claim 텍스트가 바뀐 행의 id만** 반환.
+ * 소비측(attention-queue-view.tsx)이 이 id들만 1회 하이라이트하고 나머지는 무반짝(全행 반짝 금지
+ * 모션 규율). 제거된 행은 별도 표시 없이 그냥 사라짐(제거 자체가 충분한 신호).
+ */
+export function diffAttentionQueueItemIds(
+  prev: AttentionQueueItem[],
+  next: AttentionQueueItem[],
+): Set<string> {
+  const prevClaimById = new Map(prev.map((item) => [item.id, item.claim]));
+  const changed = new Set<string>();
+  for (const item of next) {
+    const prevClaim = prevClaimById.get(item.id);
+    if (prevClaim === undefined || prevClaim !== item.claim) changed.add(item.id);
+  }
+  return changed;
+}
+
 const KIND_PRIORITY: Record<AttentionKind, number> = {
   verify_fail: 0, decision_needed: 0, gate_pending: 0, blocked: 0, merge_ready: 1,
 };

--- a/apps/web/src/hooks/use-sse-notifications.test.tsx
+++ b/apps/web/src/hooks/use-sse-notifications.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+//
+// 9ef0f914 — useSseNotifications의 extraEventNames/onExtraEvent additive 확장 회귀가드.
+// 실 EventSource가 없는 jsdom이라 FakeEventSource로 addEventListener 배선만 검증(네트워크/BE
+// 없음 — 계약 payload는 doc trust-pipeline-be-design §4 그대로, 라이브 E2E는 별건).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useSseNotifications, type SseEventNotification } from './use-sse-notifications';
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  listeners: Record<string, Array<(e: { data: string; lastEventId?: string }) => void>> = {};
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string; lastEventId?: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+  constructor(public url: string, _opts?: unknown) {
+    FakeEventSource.instances.push(this);
+  }
+  addEventListener(type: string, cb: (e: { data: string; lastEventId?: string }) => void) {
+    (this.listeners[type] ??= []).push(cb);
+  }
+  close() { this.closed = true; }
+  emit(type: string, data: string) {
+    for (const cb of this.listeners[type] ?? []) cb({ data });
+  }
+}
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  FakeEventSource.instances = [];
+  (globalThis as unknown as { EventSource: typeof FakeEventSource }).EventSource = FakeEventSource;
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function Harness(props: Parameters<typeof useSseNotifications>[0]) {
+  useSseNotifications(props);
+  return null;
+}
+
+const TRUST_STAGE_PAYLOAD = {
+  story_id: 'story-1', project_id: 'proj-1', org_id: 'org-1',
+  old_stage: 'running', new_stage: 'needs_input',
+  exception_signals: { blocked: false, verify_fail: false, needs_input: true, scope_violation: false, merge_ready: false },
+  reason: null, actor_id: null, timestamp: '2026-07-13T00:00:00Z',
+};
+
+describe('useSseNotifications — extraEventNames/onExtraEvent (additive, 9ef0f914)', () => {
+  it('existing onNotification behavior is unaffected when no extra options are passed (regression guard)', () => {
+    const onNotification = vi.fn();
+    act(() => { root.render(<Harness onNotification={onNotification} memberId="m1" />); });
+    const es = FakeEventSource.instances[0]!;
+    const notif: SseEventNotification = {
+      event_type: 'story_status_changed', source_entity_type: 'story', source_entity_id: 's1',
+      payload: { summary: 'x' }, read_at: null, created_at: '2026-07-13T00:00:00Z',
+    };
+    act(() => { es.emit('notification', JSON.stringify(notif)); });
+    expect(onNotification).toHaveBeenCalledWith(notif);
+  });
+
+  it('does not register any extra listeners when extraEventNames is omitted', () => {
+    act(() => { root.render(<Harness onNotification={vi.fn()} memberId="m1" />); });
+    const es = FakeEventSource.instances[0]!;
+    expect(es.listeners['story.trust_stage_changed']).toBeUndefined();
+  });
+
+  it('invokes onExtraEvent with the parsed contract payload when the named event fires', () => {
+    const onExtraEvent = vi.fn();
+    act(() => {
+      root.render(
+        <Harness memberId="m1" extraEventNames={['story.trust_stage_changed']} onExtraEvent={onExtraEvent} />,
+      );
+    });
+    const es = FakeEventSource.instances[0]!;
+    act(() => { es.emit('story.trust_stage_changed', JSON.stringify(TRUST_STAGE_PAYLOAD)); });
+    expect(onExtraEvent).toHaveBeenCalledWith('story.trust_stage_changed', TRUST_STAGE_PAYLOAD);
+  });
+
+  it('swallows malformed extra-event payloads without throwing (no-fiction: never crash on bad data)', () => {
+    const onExtraEvent = vi.fn();
+    act(() => {
+      root.render(
+        <Harness memberId="m1" extraEventNames={['story.trust_stage_changed']} onExtraEvent={onExtraEvent} />,
+      );
+    });
+    const es = FakeEventSource.instances[0]!;
+    expect(() => act(() => { es.emit('story.trust_stage_changed', 'not json'); })).not.toThrow();
+    expect(onExtraEvent).not.toHaveBeenCalled();
+  });
+
+  it('onNotification is optional — a consumer using only extraEventNames does not need to supply it', () => {
+    const onExtraEvent = vi.fn();
+    expect(() => {
+      act(() => {
+        root.render(<Harness memberId="m1" extraEventNames={['story.trust_stage_changed']} onExtraEvent={onExtraEvent} />);
+      });
+    }).not.toThrow();
+    const es = FakeEventSource.instances[0]!;
+    // 기존 알림 채널도 여전히 안전하게(콜백 없어도 크래시 0).
+    expect(() => act(() => { es.emit('notification', JSON.stringify({})); })).not.toThrow();
+  });
+});

--- a/apps/web/src/hooks/use-sse-notifications.ts
+++ b/apps/web/src/hooks/use-sse-notifications.ts
@@ -18,19 +18,32 @@ export interface SseEventNotification {
 }
 
 interface UseSseNotificationsOptions {
-  onNotification: (notification: SseEventNotification) => void;
+  /** 기본 알림 3종(event_notification/notification/new_notification) 전용 콜백 — extraEventNames만
+   * 쓰고 싶은 컨슈머(예: story.trust_stage_changed 구독)는 생략 가능(9ef0f914). */
+  onNotification?: (notification: SseEventNotification) => void;
   memberId?: string;
   enabled?: boolean;
+  /** 기존 3종 외 추가 named SSE 이벤트 구독(예: `story.trust_stage_changed`) — 동일 커넥션/재연결/
+   * backoff 재사용, 별도 EventSource 없음. 원시 payload를 그대로 넘긴다(SseEventNotification
+   * shape로 가공하지 않음 — 이벤트별 계약이 서로 다르므로). */
+  extraEventNames?: string[];
+  onExtraEvent?: (eventName: string, data: unknown) => void;
 }
 
 // use-realtime-memos.ts와 동일한 backoff 전략
 const RECONNECT_DELAYS_MS = [5_000, 30_000, 60_000, 300_000];
 
-export function useSseNotifications({ onNotification, memberId, enabled = true }: UseSseNotificationsOptions) {
+export function useSseNotifications({
+  onNotification, memberId, enabled = true, extraEventNames, onExtraEvent,
+}: UseSseNotificationsOptions) {
   const callbackRef = useRef(onNotification);
   const memberIdRef = useRef(memberId);
+  const extraEventNamesRef = useRef(extraEventNames);
+  const onExtraEventRef = useRef(onExtraEvent);
   useEffect(() => { callbackRef.current = onNotification; }, [onNotification]);
   useEffect(() => { memberIdRef.current = memberId; }, [memberId]);
+  useEffect(() => { extraEventNamesRef.current = extraEventNames; }, [extraEventNames]);
+  useEffect(() => { onExtraEventRef.current = onExtraEvent; }, [onExtraEvent]);
 
   useEffect(() => {
     if (!enabled || typeof EventSource === 'undefined') return;
@@ -46,8 +59,16 @@ export function useSseNotifications({ onNotification, memberId, enabled = true }
       if (!raw || raw.trim() === '') return;
       try {
         const parsed = JSON.parse(raw) as SseEventNotification;
-        callbackRef.current(parsed);
+        callbackRef.current?.(parsed);
       } catch { /* heartbeat or malformed */ }
+    };
+
+    const handleExtraEvent = (eventName: string, raw: string, eventId?: string) => {
+      if (eventId) lastEventId = eventId;
+      if (!raw || raw.trim() === '') return;
+      try {
+        onExtraEventRef.current?.(eventName, JSON.parse(raw));
+      } catch { /* malformed */ }
     };
 
     const connect = () => {
@@ -68,6 +89,13 @@ export function useSseNotifications({ onNotification, memberId, enabled = true }
         es.addEventListener(eventName, (e: Event) => {
           const me = e as MessageEvent<string>;
           handleData(me.data, me.lastEventId || undefined);
+        });
+      }
+
+      for (const eventName of extraEventNamesRef.current ?? []) {
+        es.addEventListener(eventName, (e: Event) => {
+          const me = e as MessageEvent<string>;
+          handleExtraEvent(eventName, me.data, me.lastEventId || undefined);
         });
       }
 


### PR DESCRIPTION
## 요약
story `9ef0f914`의 FE 절반. BE 브릿지(#2115) 머지 확인 후 착수 — doc `trust-pipeline-be-design` §4 계약 payload 기준으로 배선(라이브 없이도 계약으로 지금 착수 가능하다는 PO 판단).

착수 前 그라운딩 결과를 conv `32b8cff9`에 공유 → PO와 설계 왕복 후 최종 방식 확定. 처음 제안한 "payload의 exception_signals를 클라 진실로 쓰기" 안은 반려됨(아래 설계 판단 참조).

## 설계 판단(대화 중 확定)
1단계 안(exception_signals를 클라 상태로 직접 반영)은 **gate_pending이 payload에 없다**(`derive_exception_signals`가 needs_input만 담고 gate_pending은 다른 소스·trust_pipeline 스코프 밖)는 점 때문에 두 방향 다 거짓 표면 위험이 있었음:
- needs_input=false로 오인해 지우면 → gate_pending은 여전히 살아있는데 행이 사라지는 거짓 ALL CLEAR(오늘 아침 콜과 동일 클래스 버그).
- 반대로 지우지 않으면 → 실제로 해소된 개입이 유령 행으로 계속 뜨는 거짓 신뢰 표면.

**최종 확定: "이벤트는 트리거, 진실은 서버."** `story.trust_stage_changed` 수신 시 payload 내용을 신뢰하지 않고, `/glance/attention`을 디바운스(500ms·버스트 병합) 단발 재조회 — 이 엔드포인트가 gate_pending 포함 全신호의 서버 SSOT라 두 실패 모드 다 원천 차단. "전량 리페치 금지"의 취지는 v1의 4중 fan-out(gate+dependency-graph+team-members+stories) 방지였지 단일 attention 호출(항목 몇 개)까지 막는 게 아니라는 PO 판단으로, AC "새로고침 없이"는 그대로 충족. payload에 title이 없는 문제도 이 방식이면 자동 소멸.

## 변경
- **`use-sse-notifications.ts`**: `extraEventNames`/`onExtraEvent` additive 확장 — 기존 3종(event_notification/notification/new_notification) 배선·`notification-bell.tsx` 동작 100% 무변경(회귀가드 테스트로 고정). 동일 EventSource 커넥션 재사용(별도 연결 없음).
- **`derive-attention-queue.ts`**: `diffAttentionQueueItemIds` 신설 — 신규/claim변경 id만 반환, 全행 반짝 금지 모션 규율의 근거.
- **`attention-queue-view.tsx`**: 구독(project_id 스코프 필터) → 디바운스 → 재조회(기존 `fetchAttentionQueue` 재사용) → diff → 변경 행만 `motion-safe:` 1회 하이라이트(prefers-reduced-motion 자동 무동작).
- **`inbox/page.tsx`**: `AttentionQueueView`에 `memberId` prop 배선.

## 스코프 밖
글랜스 예외 스트림(E-GLANCE) 재사용은 "공짜"로 제안됐으나, `glance-board.tsx`의 `loadGlanceData`는 5종 병렬 fetch를 한 덩어리로 실행해 attention만 분리 재조회할 수 없음(그라운딩으로 확인) — 실제론 공짜가 아니라 `loadGlanceData` 리팩토링 없이는 스코프 확대. 이 PR엔 미포함.

## 테스트
- `use-sse-notifications.test.tsx`(신규 — FakeEventSource 하니스): 기존 알림 배선 회귀가드·미지정 시 리스너 미등록·계약 payload 파싱+콜백·malformed 무크래시·onNotification 생략 허용. 5/5.
- `diffAttentionQueueItemIds`: 4/4.
- 전체 vitest **1271 passed/2 skipped**(회귀 0) · tsc **0** · eslint **0 warning** · build **exit 0**.

## 잔여
**라이브 E2E는 BE #2115 dev 배포 착지 後**(오르테가 확인 예정) — 그 전까진 "계약 기준 배선·라이브 검증 대기"로 정직 표기. 유나 UX 가디언(모션 규율) + 까심 QA + CI green 후 오르테가 머지.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>