### PR TITLE
feat(trust-pipeline): scope-violation 신호 실체화 — declared_scope_paths + PR diff 판정 (story 174be6bc)

### DIFF
--- a/backend/alembic/versions/0178_story_declared_scope_paths.py
+++ b/backend/alembic/versions/0178_story_declared_scope_paths.py
@@ -1,0 +1,31 @@
+"""E-UI-DAEGBYEON P0-05 후속(story 174be6bc·doc scope-violation-signal-design §3) — stories.declared_scope_paths.
+
+Revision ID: 0178
+Revises: 0177
+Create Date: 2026-07-13
+
+scope-violation 신호의 판정 기반 — 작업 착수 시점 선언한 파일-경로 글롭 배열(list[str]). additive
+nullable JSONB, FK 없음(스칼라 값 배열이라 FK 대상 자체가 없음 — P0-03/ff6cb90d와는 다른 이유로 무FK).
+미설정(None)이면 판정 로직이 항상 무신호(§2 결정 그대로) — 기존 스토리 전부 무회귀.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0178"
+down_revision = "0177"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "stories",
+        sa.Column("declared_scope_paths", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("stories", "declared_scope_paths")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -11,6 +11,7 @@ from app.models.dependency import ItemDependency
 from app.models.embedding import Embedding
 from app.models.evidence import Evidence
 from app.models.gate import Gate
+from app.models.github_installation import GithubInstallation, GithubInstallNonce, GithubWebhookDelivery
 from app.models.hitl import HitlPolicy, HitlRequest
 from app.models.mockup import MockupComponent, MockupPage, MockupScenario, MockupVersion, UsageMeter
 from app.models.user import RefreshToken, User
@@ -40,6 +41,7 @@ from app.models.loop import LoopRun
 from app.models.story_assignee import StoryAssignee
 from app.models.project import OrgMember, Project
 from app.models.project_setting import ProjectSetting
+from app.models.pull_request_story_link import PullRequestStoryLink
 from app.models.retro import RetroAction, RetroItem, RetroSession, RetroVote
 from app.models.reward import RewardLedger
 from app.models.login_audit_log import LoginAuditLog
@@ -78,6 +80,9 @@ __all__ = [
     "BridgeUserMapping",
     "Embedding",
     "Gate",
+    "GithubInstallation",
+    "GithubInstallNonce",
+    "GithubWebhookDelivery",
     "HitlPolicy",
     "HitlRequest",
     "ItemDependency",
@@ -115,6 +120,7 @@ __all__ = [
     "Organization",
     "Project",
     "ProjectSetting",
+    "PullRequestStoryLink",
     "RetroAction",
     "RetroItem",
     "RetroSession",

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -109,6 +109,9 @@ class Story(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     human_owner_member_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True
     )
+    # P0-05 후속(doc scope-violation-signal-design §3·story 174be6bc): 작업 착수 시점 자발적 선언
+    # 파일-경로 글롭 배열(0178 additive). None/빈 배열 = 판정 무신호(scope_violation 항상 False 유지).
+    declared_scope_paths: Mapped[list | None] = mapped_column(JSONB, nullable=True)
     meeting_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("meetings.id", ondelete="SET NULL"), nullable=True
     )

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 from datetime import datetime, timezone
 
@@ -370,6 +371,7 @@ async def create_story(
         sprint_id=body.sprint_id,
         assignee_id=primary_assignee,
         human_owner_member_id=body.human_owner_member_id,
+        declared_scope_paths=body.declared_scope_paths,
         meeting_id=body.meeting_id,
         status=body.status,
         priority=body.priority,
@@ -949,6 +951,24 @@ async def update_story(
                 await db.flush()
             except Exception:
                 pass
+
+    # P0-05 후속(doc scope-violation-signal-design §1 확定): declared_scope_paths 변경(설정/해제)
+    # 감사 이벤트 — 선언 주체 제한 없음(자기신고 허용)이라 도중 축소/해제의 회피 억지력.
+    if "declared_scope_paths" in data and _story_for_access.declared_scope_paths != story.declared_scope_paths:
+        publish_event(str(repo.org_id), "story.declared_scope_changed", {
+            "story_id": str(id),
+            "project_id": str(story.project_id),
+            "org_id": str(repo.org_id),
+            "old_declared_scope_paths": (
+                json.dumps(_story_for_access.declared_scope_paths)
+                if _story_for_access.declared_scope_paths else None
+            ),
+            "new_declared_scope_paths": (
+                json.dumps(story.declared_scope_paths) if story.declared_scope_paths else None
+            ),
+            "actor_id": str(actor_id) if actor_id else None,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        })
 
     # S-C2: story_updated — actor가 agent인 경우 기록 (AC2, AC6)
     if actor_id:

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -26,11 +26,13 @@ from app.models.github_installation import GithubInstallation, GithubWebhookDeli
 from app.models.pm import Story
 from app.routers.cron import CRON_SECRET, _err, _ok, verify_cron
 from app.services.github_app import get_installation_token
-from app.services.pr_story_link import resolve_story_for_pr
+from app.services.pr_story_link import merge_link_evidence, resolve_story_for_pr
 from app.services.story_status_events import advance_story_to_done
 from app.services.verdict_capture import (
     capture_pr_ci_verdict,
     capture_review_verdict,
+    check_scope_violation,
+    fetch_pr_changed_files,
     fetch_status_check_rollup,
     parse_story_id,
 )
@@ -277,10 +279,14 @@ async def _process_webhook_event(
     추론 금지·resolve 先). **legacy**=resolver 가 SID 전역→story.org_id(무회귀). story 해소=resolver 체인
     (explicit>auto high>SID>text). **close-on-merge**=should_auto_close(confident)+merge → advance_story_to_done
     (단일 idempotent 헬퍼). native CI(Bot-M.1)=installation 토큰. caller 가 동일 트랜잭션으로 commit/rollback.
+
+    P0-05 후속(doc scope-violation-signal-design §2): scope-violation 판정은 머지/CI 액션가능신호와
+    **독립**(PR 자체 이벤트에서 판정) — resolver를 그 skip보다 먼저 실행해 두 판정이 서로를 막지 않게 한다.
     """
     texts = _candidate_texts(payload)
     repo = (payload.get("repository") or {}).get("full_name") or ""
     pr_number, merged, ci_conclusion, head_sha = _extract_pr_ci(event, payload)
+    pr_action = payload.get("action") if event == "pull_request" else None
 
     installation: GithubInstallation | None = None
     org_id: uuid.UUID | None = None
@@ -301,17 +307,29 @@ async def _process_webhook_event(
         org_id = installation.org_id
         delivery.org_id = org_id
 
-    # 행동 가능한 신호(머지 또는 CI 완료)가 없으면 skip(in_progress 등) — resolve/side-effect 前.
-    if not merged and ci_conclusion is None:
-        return {"skipped_reason": "no_actionable_signal", "recorded": []}, "ignored"
-
     # Bot-L.1 resolver 체인: explicit>auto high>SID>text. app=org-scoped(org 알려짐)·legacy=SID 전역→story.org_id.
+    # ⚠️행동가능신호(merged/ci) skip **前**에 실행 — scope-check(§2)가 그 신호와 무관하게 판정돼야 함.
     rl = await resolve_story_for_pr(session, org_id, repo, pr_number, texts)
     if rl.story_id is None:
         return {"skipped_reason": rl.reason, "recorded": []}, "ignored"  # no_match/auto suggestion 등.
     story_id = rl.story_id
     org_id = rl.org_id  # app=입력 org·legacy=story.org_id(resolver 검증). 단일 진실원.
     delivery.org_id = org_id
+
+    # P0-05 후속(doc scope-violation-signal-design §2·§3): PR 자체 이벤트(opened/synchronize/reopened)
+    # + confident link(should_auto_close 동일 신뢰 등급)일 때만 판정. 3중 침묵 조건은 헬퍼 내부.
+    scope_result: dict | None = None
+    if pr_action in ("opened", "synchronize", "reopened") and rl.should_auto_close:
+        scope_result = await _maybe_check_scope_violation(
+            session, org_id, story_id, repo, pr_number, installation, rl,
+        )
+
+    # 행동 가능한 신호(머지 또는 CI 완료)가 없으면 verdict capture는 skip — scope_result는 이미 반영됐다.
+    if not merged and ci_conclusion is None:
+        result: dict = {"skipped_reason": "no_actionable_signal", "recorded": []}
+        if scope_result is not None:
+            result["scope_check"] = scope_result
+        return result, ("processed" if scope_result is not None else "ignored")
 
     # Bot-M.1: native CI 채움 — **installation 토큰**(org-scope)으로 statusCheckRollup pull(⚠️PAT fallback 없음).
     # app source 는 위서 resolve된 installation(suspended 제외) 직접 사용·legacy 는 org→installation resolve.
@@ -371,7 +389,65 @@ async def _process_webhook_event(
             **result,
             "auto_close": {"closed": closed, "source": rl.source, "confidence": rl.confidence},
         }
+    if scope_result is not None:
+        result = {**result, "scope_check": scope_result}
     return result, "processed"
+
+
+async def _maybe_check_scope_violation(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    story_id: uuid.UUID,
+    repo: str,
+    pr_number: int,
+    installation: GithubInstallation | None,
+    rl,
+) -> dict | None:
+    """P0-05 후속(doc scope-violation-signal-design §2·§4) — 3중 침묵 조건 집행.
+
+    ①declared_scope_paths 미설정 → None(fetch 자체 안 함). ②installation/토큰/changed-files fetch
+    실패 → None(추측 금지 — "판정 불가"≠"위반 아님"). ③실제 판정(위반 여부 무관하게 결과를 evidence에
+    기록 — violated=False도 유효한 판정 결과). merge_link_evidence로 dict-merge(기존 evidence 키 보존).
+    """
+    story = await session.get(Story, story_id)
+    if story is None or story.org_id != org_id:
+        return None
+    declared = story.declared_scope_paths
+    if not declared:
+        return None  # 침묵①: 미선언.
+
+    inst = installation
+    if inst is None:  # legacy(app 미상): org→installation resolve(suspended 제외).
+        inst = (
+            await session.execute(
+                select(GithubInstallation).where(
+                    GithubInstallation.org_id == org_id,
+                    GithubInstallation.suspended_at.is_(None),
+                )
+            )
+        ).scalar_one_or_none()
+    if inst is None:
+        return None  # 침묵②: installation 없음.
+
+    token = await get_installation_token(inst.installation_id)
+    if not token:
+        return None  # 침묵②: 토큰 발급 실패.
+
+    changed_files = await fetch_pr_changed_files(repo, pr_number, token)
+    if changed_files is None:
+        return None  # 침묵②: fetch 실패/판정불가(추측 금지).
+
+    violated, out_of_scope = check_scope_violation(declared, changed_files)
+    await merge_link_evidence(
+        session, org_id, story_id, repo, pr_number,
+        link_source=rl.source or "auto_match", confidence=rl.confidence or "low",
+        patch={"scope_check": {
+            "violated": violated,
+            "out_of_scope_files": out_of_scope,
+            "checked_at": datetime.now(timezone.utc).isoformat(),
+        }},
+    )
+    return {"violated": violated, "out_of_scope_files": out_of_scope}
 
 
 @router.post("/github-webhook")

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -104,6 +104,9 @@ class StoryCreate(BaseModel):
     # P0-03(doc trust-pipeline-be-design §5): Human owner(assignee와 별도 책임 필드). 라우터가
     # write-time에 human 강제(비-human 지정 시 400).
     human_owner_member_id: uuid.UUID | None = None
+    # P0-05 후속(doc scope-violation-signal-design §3): 착수 시점 자발적 선언 파일-경로 글롭.
+    # 미지정(None) = 판정 무신호(scope_violation 항상 False).
+    declared_scope_paths: list[str] | None = None
     # E-FILE S4: 보드 스토리 첨부 (기본 [], 최대 10).
     attachments: list[StoryAttachment] = []
     meeting_id: uuid.UUID | None = None
@@ -138,6 +141,9 @@ class StoryUpdate(BaseModel):
     assignee_ids: list[uuid.UUID] | None = None
     # P0-03(doc trust-pipeline-be-design §5): Human owner. 미지정(exclude_unset)이면 변경 안 함.
     human_owner_member_id: uuid.UUID | None = None
+    # P0-05 후속(doc scope-violation-signal-design §3): exclude_unset이면 변경 안 함. 명시 []/null로
+    # 해제 가능(story.declared_scope_changed 감사 이벤트가 라우터에서 old/new 기록).
+    declared_scope_paths: list[str] | None = None
     # E-FILE S4: 보드 스토리 첨부. 미지정(None)이면 변경 안 함(back-compat).
     attachments: list[StoryAttachment] | None = None
     meeting_id: uuid.UUID | None = None
@@ -182,6 +188,13 @@ class StoryResponse(BaseModel):
     assignee_ids: list[uuid.UUID] = []
     # P0-03(doc trust-pipeline-be-design §5): Human owner — 실 컬럼(ORM 그대로 노출).
     human_owner_member_id: uuid.UUID | None = None
+    # P0-05 후속(doc scope-violation-signal-design §3): 실 컬럼(ORM 그대로 노출).
+    declared_scope_paths: list[str] | None = None
+
+    @field_validator("declared_scope_paths", mode="before")
+    @classmethod
+    def _coerce_declared_scope_paths(cls, v):
+        return v if isinstance(v, list) else None
     # agent_delegate_ids: assignee_ids를 Member.type=="agent"로 필터한 파생 뷰(신규 저장 0) —
     # ORM 컬럼 아님·라우터가 model_validate 前 transient attr로 세팅(assignee_ids 패턴 동형).
     agent_delegate_ids: list[uuid.UUID] = []

--- a/backend/app/services/event_taxonomy.py
+++ b/backend/app/services/event_taxonomy.py
@@ -95,6 +95,17 @@ EVENT_TAXONOMY: dict[str, list[EventParam]] = {
         EventParam("new_default_project_id", "uuid", True, "변경 후 기본 프로젝트"),
         EventParam("timestamp", "str", True, "ISO 8601 UTC 타임스탬프"),
     ],
+    # P0-05 후속(story 174be6bc·doc scope-violation-signal-design §1 확定): 선언 주체 제한 없음(자기신고
+    # 허용)이라 도중 축소/해제 회피 경로가 있음 — 이 감사 이벤트가 그 억지력(PO 필수 채택 지시).
+    "story.declared_scope_changed": [
+        EventParam("story_id", "uuid", True, "스토리 UUID"),
+        EventParam("project_id", "uuid", True, "프로젝트 UUID"),
+        EventParam("org_id", "uuid", True, "조직 UUID"),
+        EventParam("old_declared_scope_paths", "str", False, "변경 전 글롭 배열(JSON 직렬화, 미설정 null)"),
+        EventParam("new_declared_scope_paths", "str", False, "변경 후 글롭 배열(JSON 직렬화, 해제 시 null)"),
+        EventParam("actor_id", "uuid", False, "실행자 member UUID"),
+        EventParam("timestamp", "str", True, "ISO 8601 UTC 타임스탬프"),
+    ],
 }
 
 

--- a/backend/app/services/pr_story_link.py
+++ b/backend/app/services/pr_story_link.py
@@ -239,3 +239,42 @@ async def upsert_link(
     session.add(link)
     await session.flush()
     return link
+
+
+async def merge_link_evidence(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    story_id: uuid.UUID,
+    repo_full_name: str,
+    pr_number: int,
+    *,
+    link_source: str,
+    confidence: str,
+    patch: dict,
+) -> PullRequestStoryLink:
+    """E-UI-DAEGBYEON P0-05 후속(doc scope-violation-signal-design §3·§4) — evidence **dict-merge**
+    upsert(덮어쓰기 금지). `upsert_link`는 explicit-link API 전용(evidence 전체 교체가 맞는 의미론)이라
+    별도 — 여기는 auto_match/sid로 **아직 행이 없을 수 있는** confident link에 scope_check 같은 신규
+    키를 안전하게 얹기 위함(기존 evidence의 다른 키 보존). 행 없으면 patch만으로 신규 생성."""
+    repo = normalize_repo(repo_full_name)
+    existing = (
+        await session.execute(
+            select(PullRequestStoryLink).where(
+                PullRequestStoryLink.org_id == org_id,
+                PullRequestStoryLink.repo_full_name == repo,
+                PullRequestStoryLink.pr_number == pr_number,
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        existing.evidence = {**(existing.evidence or {}), **patch}
+        existing.deleted_at = None
+        await session.flush()
+        return existing
+    link = PullRequestStoryLink(
+        org_id=org_id, story_id=story_id, repo_full_name=repo, pr_number=pr_number,
+        link_source=link_source, confidence=confidence, evidence=dict(patch),
+    )
+    session.add(link)
+    await session.flush()
+    return link

--- a/backend/app/services/trust_pipeline.py
+++ b/backend/app/services/trust_pipeline.py
@@ -6,7 +6,8 @@ glance/attention·glance/hero와 동일한 기존 파생 패턴의 확장(이중
 
 오픈 질문 4건 확定(오르테가·선생님 GO 2026-07-13):
 ①needs_input = 기존 Gate(requires_human=True, status=pending) — 신규 gate_type 없이 시작.
-②scope_violation = 이번 스코프 미구현·항상 빈 신호(정직한 미가용·후속 스토리 174be6bc 분리).
+②scope_violation = 이번 스코프 미구현·항상 빈 신호(정직한 미가용·후속 스토리 174be6bc 분리) —
+  **174be6bc(doc scope-violation-signal-design)에서 실체화 완료. 아래 batch_scope_violation 참조.**
 ③신규 이벤트 = dot 표기(story.trust_stage_changed) — 기존 dot/underscore 혼재 정리는 별건(ab9de360).
 ④done = 파이프라인 뷰 스코프 밖(None).
 """
@@ -17,13 +18,14 @@ import uuid
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 
-from sqlalchemy import select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
 from app.models.dependency import ItemDependency
 from app.models.gate import Gate
 from app.models.pm import Story
+from app.models.pull_request_story_link import PullRequestStoryLink
 from app.services.evidence_service import batch_human_verified
 
 logger = logging.getLogger(__name__)
@@ -41,6 +43,7 @@ class TrustFacts:
     has_pending_human_gate: bool  # needs_input 신호원(§7 확定①)
     has_verify_fail: bool  # verify_fail 신호원
     has_unresolved_blocker: bool  # blocked 신호원
+    has_scope_violation: bool  # scope_violation 신호원(174be6bc 실체화)
 
 
 def derive_trust_stage(facts: TrustFacts) -> str | None:
@@ -59,13 +62,14 @@ def derive_trust_stage(facts: TrustFacts) -> str | None:
 
 
 def derive_exception_signals(facts: TrustFacts) -> dict[str, bool]:
-    """doc §3·§6 — AQ 5신호(attention-queue-fe-spec-handoff §6 계약). scope_violation은 §7 확定②로
-    이번 스코프 미구현·항상 False(정직한 미가용 — 실체화는 후속 스토리)."""
+    """doc §3·§6 — AQ 5신호(attention-queue-fe-spec-handoff §6 계약). scope_violation은 174be6bc
+    (doc scope-violation-signal-design)에서 실체화 — declared_scope_paths 미선언 story는 항상
+    has_scope_violation=False(무신호 원칙 계승, §7 확定②와 동형)."""
     return {
         "blocked": facts.has_unresolved_blocker,
         "verify_fail": facts.has_verify_fail,
         "needs_input": facts.has_pending_human_gate,
-        "scope_violation": False,
+        "scope_violation": facts.has_scope_violation,
         "merge_ready": derive_trust_stage(facts) == "merge_ready",
     }
 
@@ -131,6 +135,40 @@ async def batch_unresolved_blocker(
     return set(result.scalars().all())
 
 
+async def batch_scope_violation(
+    session: AsyncSession, org_id: uuid.UUID, story_ids: list[uuid.UUID]
+) -> set[uuid.UUID]:
+    """scope_violation 신호원(174be6bc 실체화) — story별 **최신** confident PullRequestStoryLink의
+    evidence->scope_check->violated=true story_id 집합(배치). confident = should_auto_close와 동일
+    신뢰 등급(explicit 또는 auto_match/sid+confidence=high) — 오매치 링크 기준 오탐 방지."""
+    if not story_ids:
+        return set()
+    latest = (
+        select(PullRequestStoryLink.story_id, PullRequestStoryLink.evidence)
+        .distinct(PullRequestStoryLink.story_id)
+        .where(
+            PullRequestStoryLink.org_id == org_id,
+            PullRequestStoryLink.story_id.in_(story_ids),
+            PullRequestStoryLink.deleted_at.is_(None),
+            or_(
+                PullRequestStoryLink.link_source == "explicit",
+                and_(
+                    PullRequestStoryLink.link_source.in_(("auto_match", "sid")),
+                    PullRequestStoryLink.confidence == "high",
+                ),
+            ),
+        )
+        .order_by(PullRequestStoryLink.story_id, PullRequestStoryLink.updated_at.desc())
+        .subquery()
+    )
+    result = await session.execute(
+        select(latest.c.story_id).where(
+            latest.c.evidence["scope_check"]["violated"].astext == "true"
+        )
+    )
+    return set(result.scalars().all())
+
+
 async def compute_trust_facts(
     session: AsyncSession, org_id: uuid.UUID, story_id: uuid.UUID
 ) -> TrustFacts | None:
@@ -150,6 +188,7 @@ async def compute_trust_facts(
     pending_gate_ids = await batch_pending_human_gate(session, org_id, ids)
     verify_fail_ids = await batch_verify_fail(session, org_id, ids)
     blocker_ids = await batch_unresolved_blocker(session, org_id, ids)
+    scope_violation_ids = await batch_scope_violation(session, org_id, ids)
     return TrustFacts(
         status=status,
         project_id=project_id,
@@ -157,6 +196,7 @@ async def compute_trust_facts(
         has_pending_human_gate=story_id in pending_gate_ids,
         has_verify_fail=story_id in verify_fail_ids,
         has_unresolved_blocker=story_id in blocker_ids,
+        has_scope_violation=story_id in scope_violation_ids,
     )
 
 

--- a/backend/app/services/verdict_capture.py
+++ b/backend/app/services/verdict_capture.py
@@ -6,6 +6,7 @@ SID/participation 없으면 skip(거짓기록 금지). garbage-in 차단.
 """
 from __future__ import annotations
 
+import fnmatch
 import logging
 import os
 import re
@@ -145,6 +146,70 @@ async def fetch_status_check_rollup(repo: str, head_sha: str, token: str) -> tup
     except Exception as exc:  # noqa: BLE001
         logger.warning("statusCheckRollup fetch failed repo=%s sha=%s: %s", repo, head_sha, exc)
         return None, "api_error"
+
+
+_PR_FILES_PAGE_SIZE = 100
+_PR_FILES_MAX_PAGES = 3  # 상한 300개 변경파일 — 그 이상은 판정 포기(무신호, 비용 상한).
+
+
+async def fetch_pr_changed_files(repo: str, pr_number: int, token: str) -> list[str] | None:
+    """E-UI-DAEGBYEON P0-05 후속(doc scope-violation-signal-design §2·§3) — PR 변경 파일 목록 조회.
+
+    GitHub REST `GET /repos/{repo}/pulls/{pr_number}/files`(**신규 GitHub API 호출 — fetch_status_
+    check_rollup과 같은 installation-token+httpx 패턴 재사용이나 새 능력**). 실패/토큰없음/입력오류는
+    **None**(빈 리스트 아님 — "변경 파일 0건"과 "조회 실패"를 구분해야 §2의 3중 침묵 조건①이 성립).
+    페이지 상한(300개)을 넘는 PR은 판정 포기(None) — 완벽한 커버리지보다 정직한 미가용이 우선.
+    """
+    if not token:
+        return None
+    if not repo or "/" not in repo or not pr_number:
+        return None
+    files: list[str] = []
+    try:
+        import httpx
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            for page in range(1, _PR_FILES_MAX_PAGES + 1):
+                resp = await client.get(
+                    f"https://api.github.com/repos/{repo}/pulls/{pr_number}/files",
+                    headers={
+                        "Authorization": f"Bearer {token}",
+                        "Accept": "application/vnd.github+json",
+                    },
+                    params={"per_page": _PR_FILES_PAGE_SIZE, "page": page},
+                )
+                if resp.status_code != 200:
+                    return None
+                batch = resp.json()
+                if not isinstance(batch, list):
+                    return None
+                files.extend(f.get("filename") for f in batch if isinstance(f, dict) and f.get("filename"))
+                if len(batch) < _PR_FILES_PAGE_SIZE:
+                    return files  # 마지막 페이지 도달.
+        # 상한 페이지까지 꽉 찼다 — 완전한 목록이 아님(부분 목록으로 오탐 방지 위해 포기).
+        logger.warning("PR changed-files 상한 초과(> %d) repo=%s pr=%d — 판정 포기", _PR_FILES_MAX_PAGES * _PR_FILES_PAGE_SIZE, repo, pr_number)
+        return None
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("PR changed-files fetch failed repo=%s pr=%d: %s", repo, pr_number, exc)
+        return None
+
+
+def check_scope_violation(declared_paths: list[str], changed_files: list[str]) -> tuple[bool, list[str]]:
+    """E-UI-DAEGBYEON P0-05 후속(doc scope-violation-signal-design §2·§3) — 순수 함수 글롭 판정.
+
+    ⭐`dir/**` 계약: 하위 디렉토리 전체(임의 depth)를 커버하는 것이 이 함수의 **명시 계약**이다
+    (fnmatch 원생 동작에 우연히 의존하지 않음 — `*`가 `/`를 매칭하는 현재 fnmatch 동작이 바뀌어도
+    이 계약은 테스트로 고정돼 회귀를 잡는다). 매칭 안 되는 파일 = out-of-scope.
+
+    반환 (violated, out_of_scope_files) — declared_paths/changed_files 둘 중 하나라도 비면
+    (False, [])(호출자가 §2 3중 침묵 조건을 먼저 걸러야 하나, 순수함수 자체도 안전하게 무신호).
+    """
+    if not declared_paths or not changed_files:
+        return False, []
+    out_of_scope = [
+        f for f in changed_files
+        if not any(fnmatch.fnmatch(f, pattern) for pattern in declared_paths)
+    ]
+    return bool(out_of_scope), out_of_scope
 
 
 async def capture_pr_ci_verdict(

--- a/backend/sprintable_mcp/tools/stories.py
+++ b/backend/sprintable_mcp/tools/stories.py
@@ -28,6 +28,9 @@ class AddStoryInput(SprintableInput):
     story_points: StoryPoints | None = None
     description: str | None = None
     acceptance_criteria: str | None = None
+    # P0-05 후속(doc scope-violation-signal-design §1 확定): 선언 주체 제한 없음 — 에이전트
+    # 자기신고 착수시점 파일-경로 글롭 선언(예: ["backend/app/routers/stories.py", "backend/tests/**"]).
+    declared_scope_paths: list[str] | None = None
 
 
 class UpdateStoryInput(SprintableInput):
@@ -39,6 +42,8 @@ class UpdateStoryInput(SprintableInput):
     acceptance_criteria: str | None = None
     assignee_id: str | None = None
     epic_id: str | None = None
+    # P0-05 후속: 도중 재선언/축소/해제(빈 배열)도 가능 — story.declared_scope_changed 감사 이벤트로 기록.
+    declared_scope_paths: list[str] | None = None
     # [{content_base64, name, content_type}, ...] — 스샷/작은 문서(최대 5개·파일당 2MiB·총 6MiB).
     # 기존 첨부에 **추가**된다(PATCH attachments 는 서버측 full-replace 라 update_story 가 먼저 기존
     # 첨부를 읽어 병합 — 새 첨부가 기존 걸 지우지 않는다).
@@ -111,6 +116,8 @@ async def add_story(args: AddStoryInput) -> list[TextContent]:
             body["description"] = args.description
         if args.acceptance_criteria:
             body["acceptance_criteria"] = args.acceptance_criteria
+        if args.declared_scope_paths is not None:
+            body["declared_scope_paths"] = args.declared_scope_paths
         return ok(await client.post("/api/v2/stories", json=body))
     except Exception as exc:
         return err(str(exc))
@@ -133,6 +140,8 @@ async def update_story(args: UpdateStoryInput) -> list[TextContent]:
         updates["assignee_id"] = args.assignee_id
     if args.epic_id is not None:
         updates["epic_id"] = args.epic_id
+    if args.declared_scope_paths is not None:
+        updates["declared_scope_paths"] = args.declared_scope_paths
     try:
         if args.attachments:
             uploaded = await upload_attachments(

--- a/backend/tests/test_e_ui_daegbyeon_174be6bc_scope_violation_realdb.py
+++ b/backend/tests/test_e_ui_daegbyeon_174be6bc_scope_violation_realdb.py
@@ -1,0 +1,319 @@
+"""E-UI-DAEGBYEON P0-05 후속(story 174be6bc·doc scope-violation-signal-design) — scope-violation
+신호 실체화 realdb 통합. 실 PG.
+
+크루=3중 침묵 조건(①미선언 ②fetch실패 ③전원범위내)·synchronize 재판정·evidence dict-merge
+비파괴·cross-org 미해소·trust_pipeline 배선(has_scope_violation→derive_exception_signals).
+GitHub API(fetch_pr_changed_files)·installation 토큰은 patch(네트워크 0 접촉).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session, *, declared_scope_paths=None, org_id=None):
+    from app.models.github_installation import GithubInstallation
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import Project
+
+    org = org_id
+    if org is None:
+        o = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+        session.add(o)
+        await session.commit()
+        org = o.id
+
+    project = Project(id=uuid.uuid4(), org_id=org, name="P")
+    session.add(project)
+    await session.commit()
+
+    story = Story(
+        id=uuid.uuid4(), org_id=org, project_id=project.id, title="S",
+        status="in-progress", declared_scope_paths=declared_scope_paths,
+    )
+    session.add(story)
+    await session.commit()
+
+    inst = (
+        await session.execute(
+            __import__("sqlalchemy").select(GithubInstallation).where(GithubInstallation.org_id == org)
+        )
+    ).scalar_one_or_none()
+    if inst is None:
+        inst = GithubInstallation(
+            id=uuid.uuid4(), org_id=org, installation_id=90000 + abs(hash(str(org))) % 1000,
+            account_login="moonklabs", account_type="Organization", suspended_at=None,
+        )
+        session.add(inst)
+        await session.commit()
+
+    return {"org_id": org, "project_id": project.id, "story_id": story.id, "installation_id": inst.installation_id}
+
+
+def _delivery(source="app"):
+    from app.models.github_installation import GithubWebhookDelivery
+    return GithubWebhookDelivery(
+        id=uuid.uuid4(), source=source, delivery_id=f"dlv-{uuid.uuid4().hex[:8]}",
+        event="pull_request", status="received",
+    )
+
+
+def _pr_payload(*, action, story_id, installation_id, pr_number=1, repo="moonklabs/sprintable"):
+    return {
+        "action": action,
+        "installation": {"id": installation_id},
+        "repository": {"full_name": repo},
+        "pull_request": {
+            "number": pr_number,
+            "title": f"feat: work [SID:{story_id}]",
+            "body": "",
+            "merged": False,
+            "head": {"sha": "sha1", "ref": "feat-branch"},
+        },
+    }
+
+
+async def _process(session, payload, installation_id, *, changed_files):
+    """공통 헬퍼 — installation 토큰·changed-files fetch만 patch(네트워크 0)."""
+    from app.routers import verdict_capture as mod
+
+    with patch.object(mod, "get_installation_token", new=AsyncMock(return_value="tok")), \
+         patch.object(mod, "fetch_pr_changed_files", new=AsyncMock(return_value=changed_files)):
+        result, status_label = await mod._process_webhook_event(
+            session, "app", "pull_request", payload, installation_id, _delivery(),
+        )
+        await session.commit()
+    return result, status_label
+
+
+async def _link_evidence(session, org_id, story_id):
+    from app.models.pull_request_story_link import PullRequestStoryLink
+    from sqlalchemy import select
+    link = (
+        await session.execute(
+            select(PullRequestStoryLink).where(
+                PullRequestStoryLink.org_id == org_id, PullRequestStoryLink.story_id == story_id,
+            )
+        )
+    ).scalar_one_or_none()
+    return link
+
+
+# ── 선언+이탈=true ────────────────────────────────────────────────────────────
+
+async def test_declared_and_out_of_scope_file_violates():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, declared_scope_paths=["backend/app/routers/stories.py"])
+        async with Session() as s:
+            payload = _pr_payload(action="opened", story_id=seeded["story_id"], installation_id=seeded["installation_id"])
+            result, status_label = await _process(s, payload, seeded["installation_id"], changed_files=["backend/app/other.py"])
+        assert status_label == "processed"
+        assert result["scope_check"] == {"violated": True, "out_of_scope_files": ["backend/app/other.py"]}
+
+        async with Session() as s:
+            link = await _link_evidence(s, seeded["org_id"], seeded["story_id"])
+            assert link is not None
+            assert link.evidence["scope_check"]["violated"] is True
+            assert link.evidence["scope_check"]["out_of_scope_files"] == ["backend/app/other.py"]
+
+        # trust_pipeline 배선 확인 — has_scope_violation=True → derive_exception_signals 반영.
+        async with Session() as s:
+            from app.services.trust_pipeline import compute_trust_facts, derive_exception_signals
+            facts = await compute_trust_facts(s, seeded["org_id"], seeded["story_id"])
+            assert facts.has_scope_violation is True
+            assert derive_exception_signals(facts)["scope_violation"] is True
+    finally:
+        await engine.dispose()
+
+
+# ── 3중 침묵 조건 ─────────────────────────────────────────────────────────────
+
+async def test_silence_no_declaration_skips_fetch_entirely():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, declared_scope_paths=None)
+        async with Session() as s:
+            from app.routers import verdict_capture as mod
+            fetch_mock = AsyncMock(return_value=["irrelevant.py"])
+            with patch.object(mod, "get_installation_token", new=AsyncMock(return_value="tok")), \
+                 patch.object(mod, "fetch_pr_changed_files", new=fetch_mock):
+                payload = _pr_payload(action="opened", story_id=seeded["story_id"], installation_id=seeded["installation_id"])
+                result, status_label = await mod._process_webhook_event(
+                    s, "app", "pull_request", payload, seeded["installation_id"], _delivery(),
+                )
+                await s.commit()
+            fetch_mock.assert_not_awaited()  # 침묵① — fetch 자체를 안 함.
+        assert "scope_check" not in result
+        assert status_label == "ignored"  # 다른 액션가능신호도 없어 순수 ignore.
+
+        async with Session() as s:
+            link = await _link_evidence(s, seeded["org_id"], seeded["story_id"])
+            assert link is None  # 행 자체가 생성 안 됨.
+    finally:
+        await engine.dispose()
+
+
+async def test_silence_fetch_failure_writes_nothing():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, declared_scope_paths=["backend/app/**"])
+        async with Session() as s:
+            payload = _pr_payload(action="synchronize", story_id=seeded["story_id"], installation_id=seeded["installation_id"])
+            result, status_label = await _process(s, payload, seeded["installation_id"], changed_files=None)
+        assert "scope_check" not in result
+        async with Session() as s:
+            link = await _link_evidence(s, seeded["org_id"], seeded["story_id"])
+            assert link is None  # 판정불가는 추측 금지 — 행도 안 남김.
+    finally:
+        await engine.dispose()
+
+
+async def test_silence_all_files_in_scope_violated_false():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, declared_scope_paths=["backend/app/**"])
+        async with Session() as s:
+            payload = _pr_payload(action="opened", story_id=seeded["story_id"], installation_id=seeded["installation_id"])
+            result, _ = await _process(s, payload, seeded["installation_id"], changed_files=["backend/app/x.py"])
+        assert result["scope_check"] == {"violated": False, "out_of_scope_files": []}
+        async with Session() as s:
+            link = await _link_evidence(s, seeded["org_id"], seeded["story_id"])
+            assert link is not None
+            assert link.evidence["scope_check"]["violated"] is False
+    finally:
+        await engine.dispose()
+
+
+# ── synchronize 재판정 ────────────────────────────────────────────────────────
+
+async def test_synchronize_rejudges_and_updates_same_link_row():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, declared_scope_paths=["backend/app/**"])
+
+        async with Session() as s:
+            payload = _pr_payload(action="opened", story_id=seeded["story_id"], installation_id=seeded["installation_id"])
+            r1, _ = await _process(s, payload, seeded["installation_id"], changed_files=["backend/app/x.py"])
+        assert r1["scope_check"]["violated"] is False
+
+        async with Session() as s:
+            payload = _pr_payload(action="synchronize", story_id=seeded["story_id"], installation_id=seeded["installation_id"])
+            r2, _ = await _process(s, payload, seeded["installation_id"], changed_files=["backend/app/x.py", "frontend/y.ts"])
+        assert r2["scope_check"]["violated"] is True
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.pull_request_story_link import PullRequestStoryLink
+            rows = (
+                await s.execute(
+                    select(PullRequestStoryLink).where(
+                        PullRequestStoryLink.org_id == seeded["org_id"],
+                        PullRequestStoryLink.story_id == seeded["story_id"],
+                    )
+                )
+            ).scalars().all()
+            assert len(rows) == 1  # 재판정=같은 행 갱신(신규 행 중복 생성 아님).
+            assert rows[0].evidence["scope_check"]["violated"] is True
+    finally:
+        await engine.dispose()
+
+
+# ── evidence dict-merge 비파괴 ────────────────────────────────────────────────
+
+async def test_existing_evidence_keys_preserved_on_merge():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, declared_scope_paths=["backend/app/**"])
+            from app.services.pr_story_link import upsert_link
+            await upsert_link(
+                s, seeded["org_id"], seeded["story_id"], "moonklabs/sprintable", 1,
+                link_source="explicit", confidence="high", evidence={"by": "explicit_api"},
+            )
+            await s.commit()
+
+        async with Session() as s:
+            payload = _pr_payload(action="opened", story_id=seeded["story_id"], installation_id=seeded["installation_id"])
+            await _process(s, payload, seeded["installation_id"], changed_files=["backend/app/other_out.py"])
+
+        async with Session() as s:
+            link = await _link_evidence(s, seeded["org_id"], seeded["story_id"])
+            assert link.evidence["by"] == "explicit_api"  # 기존 키 보존.
+            assert "scope_check" in link.evidence          # 신규 키 병합.
+    finally:
+        await engine.dispose()
+
+
+# ── cross-org 미해소 ──────────────────────────────────────────────────────────
+
+async def test_cross_org_story_not_resolved_no_scope_check():
+    """installation=org_a인데 SID가 org_b story를 가리키면 org-scoped resolver가 미해소 — scope-check 0."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            from app.models.organization import Organization
+            org_a = Organization(id=uuid.uuid4(), name="A", slug=f"a-{uuid.uuid4().hex[:8]}")
+            org_b = Organization(id=uuid.uuid4(), name="B", slug=f"b-{uuid.uuid4().hex[:8]}")
+            s.add_all([org_a, org_b])
+            await s.commit()
+            seeded_a = await _seed(s, org_id=org_a.id)  # installation for org_a
+            seeded_b = await _seed(s, declared_scope_paths=["backend/app/**"], org_id=org_b.id)
+
+        async with Session() as s:
+            payload = _pr_payload(
+                action="opened", story_id=seeded_b["story_id"], installation_id=seeded_a["installation_id"],
+            )
+            result, status_label = await _process(
+                s, payload, seeded_a["installation_id"], changed_files=["backend/app/other.py"],
+            )
+        assert "scope_check" not in result
+        assert result.get("skipped_reason") in ("story_not_found", "no_sid_tag")
+
+        async with Session() as s:
+            link = await _link_evidence(s, seeded_b["org_id"], seeded_b["story_id"])
+            assert link is None
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_e_ui_daegbyeon_174be6bc_scope_violation_unit.py
+++ b/backend/tests/test_e_ui_daegbyeon_174be6bc_scope_violation_unit.py
@@ -1,0 +1,135 @@
+"""E-UI-DAEGBYEON P0-05 후속(story 174be6bc·doc scope-violation-signal-design) — 순수함수 단위 테스트.
+
+check_scope_violation(글롭 판정, dir/** 계약 고정) + fetch_pr_changed_files(신규 GitHub API,
+graceful None on failure) 커버. DB 무의존."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.verdict_capture import check_scope_violation, fetch_pr_changed_files
+
+pytestmark = [pytest.mark.anyio]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── check_scope_violation: 순수함수 글롭 판정 ────────────────────────────────
+
+def test_no_declared_paths_no_violation():
+    assert check_scope_violation([], ["backend/app/x.py"]) == (False, [])
+    assert check_scope_violation(None, ["backend/app/x.py"]) == (False, [])
+
+
+def test_no_changed_files_no_violation():
+    assert check_scope_violation(["backend/app/**"], []) == (False, [])
+
+
+def test_exact_file_match_in_scope():
+    violated, out = check_scope_violation(
+        ["backend/app/routers/stories.py"], ["backend/app/routers/stories.py"]
+    )
+    assert violated is False
+    assert out == []
+
+
+def test_file_outside_declared_globs_violates():
+    violated, out = check_scope_violation(
+        ["backend/app/routers/stories.py"], ["backend/app/other.py"]
+    )
+    assert violated is True
+    assert out == ["backend/app/other.py"]
+
+
+def test_mixed_in_and_out_of_scope_files():
+    declared = ["backend/app/routers/stories.py"]
+    changed = ["backend/app/routers/stories.py", "backend/app/other.py", "frontend/x.ts"]
+    violated, out = check_scope_violation(declared, changed)
+    assert violated is True
+    assert out == ["backend/app/other.py", "frontend/x.ts"]
+
+
+def test_dir_double_star_covers_arbitrary_depth():
+    """⭐dir/** 계약(doc §2 오픈질문③ 확定) — 임의 depth 하위 파일까지 커버가 명시 계약."""
+    declared = ["backend/tests/**"]
+    changed = [
+        "backend/tests/test_x.py",
+        "backend/tests/sub/test_y.py",
+        "backend/tests/sub/deep/nested/test_z.py",
+    ]
+    violated, out = check_scope_violation(declared, changed)
+    assert violated is False
+    assert out == []
+
+
+def test_dir_double_star_does_not_leak_to_sibling_dir():
+    declared = ["backend/tests/**"]
+    violated, out = check_scope_violation(declared, ["backend/app/routers/stories.py"])
+    assert violated is True
+    assert out == ["backend/app/routers/stories.py"]
+
+
+def test_multiple_declared_globs_any_match_in_scope():
+    declared = ["backend/app/routers/stories.py", "backend/tests/**"]
+    changed = ["backend/app/routers/stories.py", "backend/tests/sub/test_y.py"]
+    violated, out = check_scope_violation(declared, changed)
+    assert violated is False
+    assert out == []
+
+
+# ── fetch_pr_changed_files: 신규 GitHub API 호출(graceful None) ─────────────
+
+async def test_no_token_returns_none():
+    assert await fetch_pr_changed_files("o/r", 1, "") is None
+
+
+async def test_bad_repo_or_pr_number_returns_none():
+    assert await fetch_pr_changed_files("badrepo", 1, "tok") is None
+    assert await fetch_pr_changed_files("o/r", 0, "tok") is None
+
+
+def _files_resp(status, filenames):
+    r = MagicMock()
+    r.status_code = status
+    r.json.return_value = [{"filename": f} for f in filenames]
+    return r
+
+
+async def test_single_page_success():
+    import httpx
+    with patch.object(httpx.AsyncClient, "get", new=AsyncMock(return_value=_files_resp(200, ["a.py", "b.py"]))):
+        result = await fetch_pr_changed_files("moonklabs/sprintable", 42, "inst-tok")
+    assert result == ["a.py", "b.py"]
+
+
+async def test_non_200_returns_none():
+    import httpx
+    with patch.object(httpx.AsyncClient, "get", new=AsyncMock(return_value=_files_resp(404, []))):
+        assert await fetch_pr_changed_files("moonklabs/sprintable", 42, "inst-tok") is None
+
+
+async def test_pagination_across_pages():
+    import httpx
+    page1 = _files_resp(200, [f"f{i}.py" for i in range(100)])
+    page2 = _files_resp(200, ["last.py"])
+    with patch.object(httpx.AsyncClient, "get", new=AsyncMock(side_effect=[page1, page2])):
+        result = await fetch_pr_changed_files("moonklabs/sprintable", 42, "inst-tok")
+    assert result == [f"f{i}.py" for i in range(100)] + ["last.py"]
+
+
+async def test_exceeds_page_cap_gives_up_none():
+    """상한(3페이지×100) 초과 — 부분 목록으로 오탐 방지 위해 판정 포기(None)."""
+    import httpx
+    full_page = _files_resp(200, [f"f{i}.py" for i in range(100)])
+    with patch.object(httpx.AsyncClient, "get", new=AsyncMock(return_value=full_page)):
+        assert await fetch_pr_changed_files("moonklabs/sprintable", 42, "inst-tok") is None
+
+
+async def test_network_exception_returns_none():
+    import httpx
+    with patch.object(httpx.AsyncClient, "get", new=AsyncMock(side_effect=RuntimeError("boom"))):
+        assert await fetch_pr_changed_files("moonklabs/sprintable", 42, "inst-tok") is None

--- a/backend/tests/test_e_ui_daegbyeon_p0_04_trust_pipeline_realdb.py
+++ b/backend/tests/test_e_ui_daegbyeon_p0_04_trust_pipeline_realdb.py
@@ -175,7 +175,8 @@ async def test_attention_merge_ready_strict_and_new_kinds():
             verify_fail_ids = {i["story_id"] for i in items if i["kind"] == "verify_fail"}
             assert str(seeded["story_verify_fail"]) in verify_fail_ids
 
-            # scope_violation: §7 확定②로 이번 스코프 미구현 — 어떤 item도 이 kind로 안 나옴.
+            # scope_violation(174be6bc 실체화 後): 이 시드엔 declared_scope_paths/PR 링크가 없어
+            # 무신호(§2 침묵①) — 어떤 item도 이 kind로 안 나옴(기존 무회귀 확인).
             assert not any(i["kind"] == "scope_violation" for i in items)
         finally:
             await client.aclose()

--- a/backend/tests/test_trust_pipeline_unit.py
+++ b/backend/tests/test_trust_pipeline_unit.py
@@ -22,6 +22,7 @@ def _facts(
     has_pending_human_gate: bool = False,
     has_verify_fail: bool = False,
     has_unresolved_blocker: bool = False,
+    has_scope_violation: bool = False,
     project_id: uuid.UUID | None = None,
 ) -> TrustFacts:
     return TrustFacts(
@@ -31,6 +32,7 @@ def _facts(
         has_pending_human_gate=has_pending_human_gate,
         has_verify_fail=has_verify_fail,
         has_unresolved_blocker=has_unresolved_blocker,
+        has_scope_violation=has_scope_violation,
     )
 
 
@@ -105,8 +107,8 @@ def test_exception_signals_needs_input():
     assert signals["merge_ready"] is False
 
 
-def test_scope_violation_always_false():
-    """§7 확定② — 이번 스코프 미구현, 어떤 facts 조합이든 항상 False(정직한 미가용)."""
+def test_scope_violation_false_when_no_signal():
+    """174be6bc 실체화 — has_scope_violation=False(미선언/무신호)이면 다른 facts 조합과 무관하게 항상 False."""
     for status in ("backlog", "ready-for-dev", "in-progress", "in-review", "done"):
         for hv in (True, False):
             for gate in (True, False):
@@ -117,6 +119,12 @@ def test_scope_violation_always_false():
                             has_verify_fail=vf, has_unresolved_blocker=blocker,
                         )
                         assert derive_exception_signals(facts)["scope_violation"] is False
+
+
+def test_scope_violation_true_passthrough():
+    """174be6bc 실체화 — has_scope_violation=True는 다른 facts와 무관하게 신호 그대로 통과."""
+    facts = _facts("in-review", human_verified=True, has_scope_violation=True)
+    assert derive_exception_signals(facts)["scope_violation"] is True
 
 
 # ── _maybe_emit: 변경시에만 emit(이벤트 폭주 방지·doc §4) ───────────────────


### PR DESCRIPTION
## Summary
- story `174be6bc` (design doc `scope-violation-signal-design`, PO 승인 GO) 구현 — trust_pipeline의 5번째 AQ 예외신호 `scope_violation`을 실체화(P0-04 §7 확定②의 항상-False 스텁 대체).
- `stories.declared_scope_paths`(JSONB, 신규 마이그 0178, additive/FK 없음) — 작업 착수 시점 자발적 선언 파일-경로 글롭 배열. 선언 없으면 항상 무신호(기존 무회귀).
- GitHub PR 이벤트(`opened`/`synchronize`/`reopened`) 수신 시점, confident link(explicit/auto-high/sid — `should_auto_close`와 동일 신뢰 등급)일 때만 신규 GitHub API(`GET .../pulls/{n}/files`)로 실 변경파일을 가져와 선언 글롭과 대조.
- 3중 침묵 조건(①미선언 ②fetch 실패/installation·토큰 없음 ③전 파일 범위 내)으로 오탐을 구조적으로 배제 — 판정 불가와 위반-아님을 구분(추측 금지).
- 판정 결과는 신규 컬럼 없이 `PullRequestStoryLink.evidence` JSONB에 `scope_check` 키로 **dict-merge**(기존 키 보존, 덮어쓰기 금지) 저장.
- `story.declared_scope_changed` 감사 이벤트(dot 표기, event_taxonomy 추가) — 선언 주체 제한 없음(자기신고 허용)이라 도중 축소/해제 회피 경로에 대한 억지력.
- BE(`StoryCreate`/`StoryUpdate`/`StoryResponse`) + MCP(`add_story`/`update_story`) 양쪽에서 선언 가능.
- `trust_pipeline.batch_scope_violation` — 최신 confident link의 `evidence.scope_check.violated` 배치 조회, `derive_exception_signals`에 배선.

## Test plan
- [x] 신규 유닛 테스트 15건(`test_e_ui_daegbyeon_174be6bc_scope_violation_unit.py`) — `check_scope_violation`(글롭 판정·`dir/**` 재귀 계약 고정) + `fetch_pr_changed_files`(페이지네이션·실패·상한).
- [x] 신규 realdb 테스트 7건(`test_e_ui_daegbyeon_174be6bc_scope_violation_realdb.py`, 실 PG) — 선언+이탈=true, 3중 침묵 각각, synchronize 재판정(동일 행 갱신), evidence dict-merge 비파괴, cross-org 미해소.
- [x] `test_trust_pipeline_unit.py`/`test_e_ui_daegbyeon_p0_04_trust_pipeline_realdb.py` 기존 스위트(P0-04/P0-03/9ef0f914/ff6cb90d 포함 49건 realdb) 무회귀 재확인.
- [x] 전체 백엔드 스위트(mcp 패키지 환경 이슈 제외) 3103 passed — 실패 21건은 독립 실행 시 전부 통과(pre-existing 스위트 간 상태누수, 본 PR과 무관 확인).

Story: `174be6bc`