### PR TITLE
[SID:9449da0e] 캔버스 휴먼 진입점 — 산출물 빈 상태 1급화 + "그리기" 생성 딸깍

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3535,6 +3535,11 @@
     "concurrencyMerge": "Merge onto mine",
     "exportAction": "Export",
     "editAction": "Edit",
-    "editAsNewVersionAction": "Edit as new version"
+    "editAsNewVersionAction": "Edit as new version",
+    "sectionLabel": "Artifacts",
+    "emptyTitle": "No artifacts yet",
+    "emptyHint": "Draw one yourself, or hand it to an agent.",
+    "createCta": "Draw artifact",
+    "untitledArtifact": "Untitled"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3535,6 +3535,11 @@
     "concurrencyMerge": "내 편집 위에 병합",
     "exportAction": "내보내기",
     "editAction": "편집",
-    "editAsNewVersionAction": "새 버전으로 편집"
+    "editAsNewVersionAction": "새 버전으로 편집",
+    "sectionLabel": "산출물",
+    "emptyTitle": "아직 산출물이 없는",
+    "emptyHint": "직접 그리거나, 에이전트에게 맡겨 만들 수 있는",
+    "createCta": "산출물 그리기",
+    "untitledArtifact": "제목 없는 산출물"
   }
 }

--- a/apps/web/src/app/api/visual-artifacts/route.test.ts
+++ b/apps/web/src/app/api/visual-artifacts/route.test.ts
@@ -4,11 +4,11 @@ const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({ getAuthContext: v
 vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
 vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
-import { GET } from './route';
+import { GET, POST } from './route';
 
 const agent = () => ({ id: 'a', type: 'agent' });
-const enveloped = (data: unknown) =>
-  new Response(JSON.stringify({ data, error: null, meta: null }), { status: 200, headers: { 'content-type': 'application/json' } });
+const enveloped = (data: unknown, status = 200) =>
+  new Response(JSON.stringify({ data, error: null, meta: null }), { status, headers: { 'content-type': 'application/json' } });
 const req = () => new Request('http://localhost/api/visual-artifacts?story_id=s1');
 
 describe('GET /api/visual-artifacts (BE _ok() 이중 봉투 unwrap 회귀가드)', () => {
@@ -39,5 +39,34 @@ describe('GET /api/visual-artifacts (BE _ok() 이중 봉투 unwrap 회귀가드)
   it('passes through proxy errors (e.g. 404 when BE route unavailable)', async () => {
     proxyToFastapi.mockResolvedValue(new Response('not found', { status: 404 }));
     expect((await GET(req())).status).toBe(404);
+  });
+});
+
+const postReq = (body: unknown) =>
+  new Request('http://localhost/api/visual-artifacts', {
+    method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body),
+  });
+
+describe('POST /api/visual-artifacts (story 9449da0e — 캔버스 휴먼 진입점 생성 딸깍, BE _ok() unwrap 회귀가드)', () => {
+  beforeEach(() => { getAuthContext.mockReset(); proxyToFastapi.mockReset(); getAuthContext.mockResolvedValue(agent()); });
+
+  it('401 when unauthenticated', async () => {
+    getAuthContext.mockResolvedValue(null);
+    expect((await POST(postReq({ story_id: 's1', title: 'X', nodes: [] }))).status).toBe(401);
+    expect(proxyToFastapi).not.toHaveBeenCalled();
+  });
+
+  it('unwraps the FastAPI _ok() envelope — the created detail lands directly on .data, not .data.data, with 201', async () => {
+    const detail = { id: 'a1', title: '제목 없는 산출물', story_id: 's1', epic_id: null, doc_id: null, source: 'created', latest_version_number: 1, anchor_version: null, created_by: 'm1', created_at: '2026-07-13T00:00:00Z', version_number: 1, version_summary: null, nodes: [] };
+    proxyToFastapi.mockResolvedValue(enveloped(detail, 201));
+    const res = await POST(postReq({ story_id: 's1', title: '제목 없는 산출물', nodes: [] }));
+    expect(res.status).toBe(201);
+    const json = await res.json() as { data: unknown };
+    expect(json.data).toEqual(detail);
+  });
+
+  it('passes through proxy errors (e.g. 404 for a story outside the caller project)', async () => {
+    proxyToFastapi.mockResolvedValue(new Response('not found', { status: 404 }));
+    expect((await POST(postReq({ story_id: 's-other-project', title: 'X', nodes: [] }))).status).toBe(404);
   });
 });

--- a/apps/web/src/app/api/visual-artifacts/route.ts
+++ b/apps/web/src/app/api/visual-artifacts/route.ts
@@ -22,3 +22,19 @@ export async function GET(request: Request) {
     return apiSuccess(json.data ?? []);
   } catch (err: unknown) { return handleApiError(err); }
 }
+
+/**
+ * POST /api/visual-artifacts — 캔버스 휴먼 진입점(story 9449da0e) "그리기" 생성 딸깍 커밋.
+ * MCP `create_artifact`와 **동일 BE 엔드포인트**(`POST /api/v2/visual-artifacts`)로 프록시 —
+ * 신규 BE 로직 0(순수 plumbing). GET과 동일하게 BE `_ok()` 이중 봉투를 벗겨 재포장.
+ */
+export async function POST(request: Request) {
+  try {
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    const _r = await proxyToFastapi(request, '/api/v2/visual-artifacts');
+    if (!_r.ok) return _r;
+    const json = (await _r.json()) as { data?: unknown };
+    return apiSuccess(json.data ?? null, undefined, 201);
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/components/canvas/artifact-section.test.tsx
+++ b/apps/web/src/components/canvas/artifact-section.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+//
+// 9449da0e — 캔버스 휴먼 진입점 회귀가드. 선생님 prod 지적("완료했다더니 하나도 보이지 않는·
+// 진입점도 없는") 직결: 산출물 0일 때 `return null`이던 걸 1급 빈 상태 + "그리기" 생성 딸깍으로
+// 대체한 부분만 검증(기존 items>0 렌더 경로는 이 diff가 손대지 않음 — 구조적 회귀 0).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { ArtifactSection } from './artifact-section';
+import koMessagesRaw from '../../../messages/ko.json';
+import enMessagesRaw from '../../../messages/en.json';
+
+type LooseMessages = { [key: string]: string | LooseMessages };
+const koMessages = koMessagesRaw as unknown as LooseMessages;
+const enMessages = enMessagesRaw as unknown as LooseMessages;
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  // 빈 목록 — GET /api/visual-artifacts?story_id= → {data: []}(story 귀속 산출물 0).
+  fetchMock = vi.fn(async () => ({
+    ok: true, status: 200, json: async () => ({ data: [] }),
+  })) as unknown as ReturnType<typeof vi.fn>;
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+async function mount(locale: 'ko' | 'en' = 'ko') {
+  const messages = locale === 'ko' ? koMessages : enMessages;
+  await act(async () => {
+    root.render(
+      <NextIntlClientProvider locale={locale} messages={messages} timeZone="Asia/Seoul">
+        <ArtifactSection storyId="story-1" />
+      </NextIntlClientProvider>,
+    );
+  });
+  // 산출물 목록 fetch(useEffect) 완료까지 마이크로태스크 플러시.
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('ArtifactSection — 빈 상태 1급화 (story 9449da0e)', () => {
+  it('renders a first-class empty state instead of returning null when there are 0 artifacts (ko)', async () => {
+    await mount('ko');
+    expect(container.textContent).toContain('산출물'); // 섹션 라벨 상시 노출
+    expect(container.textContent).toContain('아직 산출물이 없는');
+    expect(container.textContent).toContain('직접 그리거나, 에이전트에게 맡겨 만들 수 있는');
+    expect(container.querySelector('button')?.textContent).toBe('산출물 그리기');
+  });
+
+  it('renders the same empty state in English (ko/en parity, AC3)', async () => {
+    await mount('en');
+    expect(container.textContent).toContain('Artifacts');
+    expect(container.textContent).toContain('No artifacts yet');
+    expect(container.textContent).toContain('Draw one yourself, or hand it to an agent.');
+    expect(container.querySelector('button')?.textContent).toBe('Draw artifact');
+  });
+
+  it('clicking "Draw artifact" enters create mode — mounts the real ArtifactEditor (no mock)', async () => {
+    await mount('ko');
+    const cta = container.querySelector('button');
+    expect(cta).not.toBeNull();
+    await act(async () => { cta!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    // 빈 상태는 사라지고 편집기(CommitBar의 "버전으로 저장" 액션)가 뜬다 — mock 0, 실 컴포넌트.
+    expect(container.textContent).not.toContain('아직 산출물이 없는');
+    expect(container.textContent).toContain('버전으로 저장');
+  });
+});

--- a/apps/web/src/components/canvas/artifact-section.tsx
+++ b/apps/web/src/components/canvas/artifact-section.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { PenLine } from 'lucide-react';
 import { ArtifactViewer } from './artifact-viewer';
 import { ArtifactEditor } from './artifact-editor';
 import {
-  adaptArtifactDetail, editArtifact, type ArtifactVersion, type BeArtifactVersionSummary, type MemberRef,
-  type VisualArtifact, type BeVisualArtifactDetail, type BeVisualArtifactSummary,
+  adaptArtifactDetail, createArtifact, editArtifact, type ArtifactVersion, type BeArtifactVersionSummary,
+  type MemberRef, type VisualArtifact, type BeVisualArtifactDetail, type BeVisualArtifactSummary,
 } from '@/services/canvas';
 import { adaptComments, type BeArtifactComment, type CommentThread } from '@/services/canvas-comments';
 import { derivePendingCanonicalizeVersion, type CanonicalizeGateLookup } from '@/services/canvas-canonicalize';
@@ -63,10 +65,13 @@ async function loadPendingCanonicalizeVersion(artifactId: string): Promise<numbe
  * (선생님 slop 지적 반영 원칙 계승).
  */
 export function ArtifactSection({ storyId, memberMap = {}, className }: ArtifactSectionProps) {
+  const t = useTranslations('canvas');
   const [items, setItems] = useState<ArtifactItem[]>([]);
   // C3-S7 휴먼 딸깍 편집 — 어느 artifact가 편집 모드인지(tree만 진입·viewer가 게이트). 커밋 성공
   // 후 종료해 fresh 재로드(BE가 버전마다 node.id 리매핑하므로 stale id 재사용 원천 차단).
   const [editingArtifactId, setEditingArtifactId] = useState<string | null>(null);
+  // 9449da0e 캔버스 휴먼 진입점 — 빈 상태 "그리기" 딸깍 → create 모드(initialNodes=[]).
+  const [creating, setCreating] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -145,7 +150,61 @@ export function ArtifactSection({ storyId, memberMap = {}, className }: Artifact
     setEditingArtifactId(null);
   }
 
-  if (items.length === 0) return null;
+  /**
+   * "그리기" 생성 딸깍 커밋(9449da0e) — 빈 편집기(initialNodes=[])의 최종 노드셋을 story 귀속
+   * v1으로 생성. micro-decision (A) 확定: 제목은 항상 기본값("제목 없는 산출물"/"Untitled") —
+   * rename은 후속(갤러리 트랙). 성공 시 뷰어로 전환(fresh items). 실패는 silent 금지 — 로깅 +
+   * 생성 모드 유지(handleCommitEdit과 동일 규율).
+   */
+  async function handleCreateCommit(nodes: ArtifactNode[], summary: string) {
+    const detail = await createArtifact(storyId, t('untitledArtifact'), nodes, summary || undefined);
+    if (!detail) {
+      console.error('[canvas-create] artifact create commit failed', storyId);
+      return;
+    }
+    const { artifact, versions } = adaptArtifactDetail(detail);
+    const [threads, pendingCanonicalizeVersion] = await Promise.all([
+      loadArtifactThreads(artifact.id, detail.nodes),
+      loadPendingCanonicalizeVersion(artifact.id),
+    ]);
+    setItems((cur) => [...cur, { artifact, versions, threads, nodes: detail.nodes, pendingCanonicalizeVersion }]);
+    setCreating(false);
+  }
+
+  if (items.length === 0 && !creating) {
+    return (
+      <div className={className}>
+        <div className="flex flex-col items-center gap-3 rounded-lg border border-border bg-card px-6 py-9 text-center">
+          <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            {t('sectionLabel')}
+          </div>
+          <PenLine className="size-6 text-muted-foreground/60" aria-hidden="true" />
+          <p className="text-sm font-medium text-foreground">{t('emptyTitle')}</p>
+          <p className="max-w-sm text-xs text-muted-foreground">{t('emptyHint')}</p>
+          <button
+            type="button"
+            onClick={() => setCreating(true)}
+            className="mt-1 rounded-md bg-primary px-4 py-2 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            {t('createCta')}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (creating) {
+    return (
+      <div className={className}>
+        <ArtifactEditor
+          title={t('untitledArtifact')}
+          initialNodes={[]}
+          onCommit={(committed, summary) => void handleCreateCommit(committed, summary)}
+          onDone={() => setCreating(false)}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className={className}>

--- a/apps/web/src/services/canvas.ts
+++ b/apps/web/src/services/canvas.ts
@@ -200,6 +200,29 @@ export function adaptArtifactDetail(detail: BeVisualArtifactDetail): { artifact:
 }
 
 /**
+ * 캔버스 휴먼 진입점(story 9449da0e) — 빈 스토리에서 "그리기" 생성 딸깍 커밋. MCP `create_artifact`와
+ * **동일 BE 엔드포인트**(`POST /api/v2/visual-artifacts`·같은 서비스 `create_artifact`·신규 BE 0).
+ * story 귀속 v1을 만들고 생성된 detail을 반환 — 실패는 null(호출부가 편집 모드 유지 + 로깅, 빈
+ * catch 금지 계열).
+ */
+export async function createArtifact(
+  storyId: string, title: string, nodes: ArtifactNode[], summary?: string,
+): Promise<BeVisualArtifactDetail | null> {
+  try {
+    const res = await fetch('/api/visual-artifacts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ story_id: storyId, title, nodes, summary: summary ?? null }),
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as { data?: BeVisualArtifactDetail };
+    return json.data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * 딸깍 편집 커밋(C3-S7 휴먼 절반) — MCP `sprintable_edit_artifact`와 **동일 BE 엔드포인트**
  * (`POST /api/v2/visual-artifacts/{id}/edit`·같은 서비스 `_apply_artifact_edit`·신규 BE 0).
  * operations diff를 적용해 새 버전을 만들고 갱신된 detail을 반환한다. `artifact.updated` 이벤트


### PR DESCRIPTION
## 요약
critical — 선생님 prod 실사용 지적(2026-07-13 "완료했다더니 하나도 보이지 않는·진입점도 없는") 직결. 유나 경량 스펙 `canvas-human-entry-spec` 그대로 구현, 신규 BE 0(POST 프록시 plumbing만).

## 배경 (그라운딩 확인)
① `artifact-section.tsx:150`(`if (items.length === 0) return null`) — 산출물 0인 스토리는 섹션 자체가 렌더 안 돼 기능 존재를 알 길이 없었음. ② FE에 create_artifact 호출 0건 — 생성=에이전트 MCP 전용, 휴먼은 기존 산출물 편집만 가능했음. ③ prod 산출물 0 → 인간 사용자에게 E-CANVAS가 완전 invisible. "발견성도 완성 기준"(교훈 계열).

## 변경
1. **빈 상태 1급화**: `return null` 제거 → 중립 초대 톤 빈 상태(섹션 라벨 "산출물" 상시 노출·dual-path 안내 1줄·단일 CTA "산출물 그리기"). 결핍/경보 프레이밍 0.
2. **생성 딸깍**: `ArtifactEditor` create 모드(`initialNodes=[]`) 인플레이스 마운트 재사용 → 커밋 시 `createArtifact()`(canvas.ts, `editArtifact`와 동형 패턴) → **FE 프록시 `POST /api/visual-artifacts` 신설**(BE는 MCP `create_artifact`와 동일 서비스 실존 확인 — `[id]/edit/route.ts` 패턴 그대로 미러, BE `_ok()` 이중 봉투 unwrap 포함) → v1 생성·뷰어 전환.
3. **micro-decision (A) 확定**: 기본 제목("제목 없는 산출물"/"Untitled")으로 딸깍 1클릭 보존 — rename은 갤러리 트랙(story `44ad5540`) 후속.
4. 생성 실패는 silent 금지 — `console.error` + 편집 모드 유지(기존 `handleCommitEdit` 실패 처리와 동일 규율).
5. i18n `canvas` ns 5키(sectionLabel/emptyTitle/emptyHint/createCta/untitledArtifact) ko/en 1:1.

## 회귀 경계
기존 산출물 보유 스토리(`items.length > 0`) 렌더 경로는 이 diff가 전혀 건드리지 않음 — `items.length === 0` 분기에만 개입.

## 정직 고지(스펙 대비 갭)
스펙 §2가 "artifact.created 이벤트 전파(기존 C0 체인)"를 언급하나, BE `create_artifact`(`visual_artifacts.py:82`) 실코드 그라운딩 결과 **생성 시 알림/이벤트 dispatch가 없음**(`event_taxonomy.py`에도 `artifact.created` 미등록) — edit/comment/canonicalize와 달리 create는 `dispatch_notification` 호출이 없음. "신규 BE 0" 제약상 내가 추가할 수 있는 영역이 아니며, 생성 당사자 화면은 FE 상태 갱신만으로 즉시 반영되어 critical 완화(빈 상태→가시성)에는 영향 없음 — 타 사용자 실시간 전파가 필요하면 별도 판단 요청.

## 테스트
- `artifact-section.test.tsx`(신규): 빈 상태 렌더(ko/en 파리티)·CTA 클릭 시 실 ArtifactEditor 마운트(mock 0), 3/3.
- `route.test.ts`(POST 추가): 401·`_ok()` 이중봉투 unwrap+201·proxy 에러 전달, 3/3 신규.
- 전체 vitest **1277 passed/2 skipped**(회귀 0) · tsc **0** · eslint **0 warning** · build **exit 0**.

## 잔여
유나 UX 가디언 GREEN + 까심 QA + CI green 후 오르테가 머지 → dev/prod 라이브 확인(빈 상태 가시성 자체가 done-gate).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>