### PR TITLE
[SID:f0c99070] agent-routing-rule PUT/PATCH에 project_id 명시 배선 (보안 FE 절반)

### DIFF
--- a/apps/web/src/services/agent-routing-rule.test.ts
+++ b/apps/web/src/services/agent-routing-rule.test.ts
@@ -235,7 +235,7 @@ describe('AgentRoutingRuleService.reorderPriorities', () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining('/api/v2/agent-routing-rules'),
-      expect.objectContaining({ method: 'PATCH' }),
+      expect.objectContaining({ method: 'PATCH', body: expect.stringContaining('"project_id":"project-1"') }),
     );
     expect(result.map((rule) => rule.id)).toEqual(['rule-1', 'rule-2']);
     fetchMock.mockRestore();
@@ -332,7 +332,7 @@ describe('AgentRoutingRuleService.replaceRules', () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining('/api/v2/agent-routing-rules'),
-      expect.objectContaining({ method: 'PUT' }),
+      expect.objectContaining({ method: 'PUT', body: expect.stringContaining('"project_id":"project-1"') }),
     );
     expect(result.map((rule) => rule.id)).toEqual(['rule-1', 'rule-2']);
     fetchMock.mockRestore();

--- a/apps/web/src/services/agent-routing-rule.ts
+++ b/apps/web/src/services/agent-routing-rule.ts
@@ -641,7 +641,7 @@ export class AgentRoutingRuleService {
         'Content-Type': 'application/json',
         ...(this.accessToken ? { Authorization: `Bearer ${this.accessToken}` } : {}),
       },
-      body: JSON.stringify({ items: preparedItems }),
+      body: JSON.stringify({ items: preparedItems, project_id: input.projectId }),
     });
     if (!replaceRes.ok) {
       const body = await replaceRes.json().catch(() => ({}));
@@ -782,7 +782,7 @@ export class AgentRoutingRuleService {
         'Content-Type': 'application/json',
         ...(this.accessToken ? { Authorization: `Bearer ${this.accessToken}` } : {}),
       },
-      body: JSON.stringify({ items: cleaned }),
+      body: JSON.stringify({ items: cleaned, project_id: scope.projectId }),
     });
     if (!reorderRes.ok) {
       const body = await reorderRes.json().catch(() => ({}));


### PR DESCRIPTION
## 요약
E-SECURITY critical 교차 테넌트 파괴 벡터 3건 차단 트랙(선생님 우선순위 상향)의 FE 절반 소품. 순수 파라미터 배선(additive) — 로직/렌더 변경 0.

## 배경
`agent-routing-rule.ts`는 Next.js 서버측에서 `FASTAPI_URL()` 직호출(브라우저 X-Project-Id 인터셉터 미적용)이라 `project_id`를 body에 안 실어보내 JWT 임의 폴백에 의존하고 있었음 — 교차 테넌트 파괴 벡터의 실사용 경로.

## 변경
- `replaceRules()`(PUT `/api/v2/agent-routing-rules`): body에 `project_id: input.projectId` 추가.
- `reorderPriorities()`(PATCH `/api/v2/agent-routing-rules`): body에 `project_id: scope.projectId` 추가(파라미터명이 `scope`).

두 함수 모두 이미 스코프(`input.projectId`/`scope.projectId`)를 갖고 있어 실어보내기만 함. BE가 아직 관대해 먼저 머지해도 무해 — 이게 착지해야 BE가 명시 강제(400)를 타이밍 갭 없이 안전하게 켤 수 있음(FE 선행).

## 테스트
기존 `replaceRules`/`reorderPriorities` happy-path 테스트에 body가 `project_id`를 담는지 단언 추가(회귀가드). 16/16 green · 전체 vitest **1271 passed/2 skipped**(회귀 0) · tsc **0** · eslint **0 warning** · build **exit 0**.

## 잔여
까심 QA + CI green → 산티아고군 최종 검증 배석 → 오르테가 머지(story `f0c99070` 본 트랙은 디디 BE 담당, 이 PR은 그 FE 선행 절반).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>