### PR TITLE
fix(security): 교차 테넌트 파괴 벡터 4건 차단 — project_id 요청시점 재해소 강제 (story f0c99070)

### DIFF
--- a/backend/app/dependencies/project_scope.py
+++ b/backend/app/dependencies/project_scope.py
@@ -1,0 +1,67 @@
+"""E-MCP-OPT 후속(story f0c99070·doc legacy-project-fallback-sweep-audit §2.1) — 요청시점
+project_id 재해소.
+
+`_resolve_api_key`가 API key/agent 인증마다 토큰 해소 시점에 구워 넣는 `app_metadata.project_id`
+(`ORDER BY project_id ASC LIMIT 1` 임의값)는 매 요청 갱신되지 않는다 — 이 모듈은 그 굽힌 값을
+신뢰하지 않고 **매 요청 재해소**한다: 명시(path/body/query) > X-Project-Id 헤더(has_project_access
+검증) > member.default_project_id(요청 시점 재조회) > 단일 접근가능 프로젝트 > 명시 에러(400).
+MCP `SprintableClient.require_project_id()`(sprintable_mcp/api_client.py)와 동일 계약 재사용
+(신규 발명 금지) — 문구만 REST 호출자에 맞게 조정(`PATCH /api/v2/auth/me/default-project` 참조).
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import HTTPException, Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext
+
+_AMBIGUOUS_MESSAGE = (
+    "여러 프로젝트에 접근 가능한 키입니다. 요청에 project_id를 지정하거나 "
+    "PATCH /api/v2/auth/me/default-project로 기본 프로젝트를 설정하세요."
+)
+
+
+async def resolve_required_project_id(
+    session: AsyncSession,
+    request: Request,
+    auth: AuthContext,
+    org_id: uuid.UUID,
+    *,
+    explicit_project_id: uuid.UUID | None = None,
+) -> uuid.UUID:
+    """이 요청이 스코프할 project_id를 재해소. 해소 불가(멀티프로젝트+미설정+무지정)면 400."""
+    from app.services.project_auth import has_project_access
+
+    member_id = auth.user_id if isinstance(auth.user_id, uuid.UUID) else uuid.UUID(str(auth.user_id))
+
+    if explicit_project_id is not None:
+        if not await has_project_access(session, member_id, explicit_project_id, org_id):
+            raise HTTPException(status_code=403, detail="No access to the specified project")
+        return explicit_project_id
+
+    header = request.headers.get("X-Project-Id") if request is not None else None
+    if header:
+        try:
+            header_project_id = uuid.UUID(header)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid X-Project-Id format")
+        if not await has_project_access(session, member_id, header_project_id, org_id):
+            raise HTTPException(status_code=403, detail="No access to the specified project")
+        return header_project_id
+
+    from app.routers.auth import _resolve_project_default
+    resolved, _ambiguous, accessible_ids = await _resolve_project_default(session, member_id, org_id)
+    if resolved is not None:
+        return uuid.UUID(resolved)
+    if not accessible_ids:
+        raise HTTPException(status_code=403, detail="No accessible project for this member")
+    raise HTTPException(
+        status_code=400,
+        detail={
+            "code": "PROJECT_ID_REQUIRED",
+            "message": _AMBIGUOUS_MESSAGE,
+            "accessible_project_ids": accessible_ids,
+        },
+    )

--- a/backend/app/repositories/hitl.py
+++ b/backend/app/repositories/hitl.py
@@ -130,8 +130,13 @@ class HitlRepository:
         }
         now = datetime.now(timezone.utc)
 
+        # E-MCP-OPT 후속(story f0c99070 AC1) — org_id도 함께 필터(기존엔 project_id 단독이라 org_id
+        # 미검사 갭). project_id가 이미 project→org 1:1이라 실질 동작 변화는 없으나, WHERE 절 자체가
+        # org 경계를 명시하지 않는 건 감사 관점에서 결함이라 명시 필터로 고정한다.
         existing = await self.session.execute(
-            select(HitlPolicy).where(HitlPolicy.project_id == project_id)
+            select(HitlPolicy).where(
+                HitlPolicy.org_id == org_id, HitlPolicy.project_id == project_id,
+            )
         )
         row = existing.scalar_one_or_none()
 
@@ -148,7 +153,7 @@ class HitlRepository:
         else:
             await self.session.execute(
                 update(HitlPolicy)
-                .where(HitlPolicy.project_id == project_id)
+                .where(HitlPolicy.org_id == org_id, HitlPolicy.project_id == project_id)
                 .values(config=config, updated_by=actor_id, updated_at=now)
             )
         await self.session.commit()

--- a/backend/app/routers/agent_routing_rules.py
+++ b/backend/app/routers/agent_routing_rules.py
@@ -92,15 +92,33 @@ async def create_rule(
 
 @router.put("")
 async def replace_or_update_rules(
+    request: Request,
     body: dict,
     auth: AuthContext = Depends(get_current_user),
     repo: AgentRoutingRuleRepository = Depends(_repo),
 ) -> JSONResponse:
-    org_id, project_id = _get_org_project(auth)
-    if not org_id:
+    # ⚠️org_id는 project_id와 독립적으로 먼저 해소(story f0c99070·reorder_or_disable_rules와 동일 이유).
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id")
+    if not org_id_str:
         return _err("FORBIDDEN", "org_id required", 403)
+    org_id = uuid.UUID(str(org_id_str))
 
     if "items" in body:
+        # E-MCP-OPT 후속(story f0c99070·doc legacy-project-fallback-sweep-audit §2.2 2단계): id 없이
+        # (org_id,project_id)만으로 기존 룰 전부 soft-delete+재삽입 — fail-closed 앵커 0. FE 선행배선
+        # (PR #2120)이 body.project_id를 명시 실어보내므로 최우선 소스로 소비(무회귀).
+        explicit = body.get("project_id")
+        try:
+            replace_project_id = await resolve_required_project_id(
+                repo.session, request, auth, org_id,
+                explicit_project_id=uuid.UUID(str(explicit)) if explicit else None,
+            )
+        except HTTPException as exc:
+            return _err(
+                exc.detail.get("code", "PROJECT_ID_REQUIRED") if isinstance(exc.detail, dict) else "FORBIDDEN",
+                exc.detail.get("message", str(exc.detail)) if isinstance(exc.detail, dict) else str(exc.detail),
+                exc.status_code,
+            )
         req = ReplaceRulesRequest.model_validate(body)
         items = [
             {
@@ -121,11 +139,15 @@ async def replace_or_update_rules(
             for item in req.items
         ]
         try:
-            rules = await repo.replace(org_id, project_id, uuid.UUID(auth.user_id), items)
+            rules = await repo.replace(org_id, replace_project_id, uuid.UUID(auth.user_id), items)
         except ValueError as exc:
             return _err("BAD_REQUEST", str(exc), 400)
         return _ok([r.model_dump(mode="json") for r in rules])
 
+    # 단일-룰 update 분기: 기존 raw project_id 폴백 그대로(Tier 1 fail-closed — id 매치 요구라
+    # 이번 스토리 스코프 아님, doc §2.2 4단계 후속).
+    project_id_str = auth.claims.get("app_metadata", {}).get("project_id")
+    project_id = uuid.UUID(str(project_id_str)) if project_id_str else None
     req_update = UpdateRoutingRuleRequest.model_validate(body)
     try:
         rule = await repo.update(
@@ -172,13 +194,23 @@ async def reorder_or_disable_rules(
         rules = await repo.disable_all(org_id, disable_project_id)
         return _ok([r.model_dump(mode="json") for r in rules])
 
-    # reorder-items 분기: 기존 raw project_id 폴백 그대로(Tier 1 fail-closed — id 매치 요구라
-    # 이번 스토리 스코프 아님, doc §2.2 4단계 후속).
-    project_id_str = auth.claims.get("app_metadata", {}).get("project_id")
-    project_id = uuid.UUID(str(project_id_str)) if project_id_str else None
+    # reorder-items 분기(story f0c99070·PO 확定 — FE 선행배선 PR #2120 착지 後 강제): id 매치라
+    # Tier 1 fail-closed였지만, FE가 body.project_id를 이제 명시 실어보내므로 최우선 소스로 소비.
+    explicit = body.get("project_id")
+    try:
+        reorder_project_id = await resolve_required_project_id(
+            repo.session, request, auth, org_id,
+            explicit_project_id=uuid.UUID(str(explicit)) if explicit else None,
+        )
+    except HTTPException as exc:
+        return _err(
+            exc.detail.get("code", "PROJECT_ID_REQUIRED") if isinstance(exc.detail, dict) else "FORBIDDEN",
+            exc.detail.get("message", str(exc.detail)) if isinstance(exc.detail, dict) else str(exc.detail),
+            exc.status_code,
+        )
     req = ReorderRulesRequest.model_validate(body)
     items = [{"id": str(item.id), "priority": item.priority} for item in req.items]
-    rules = await repo.reorder(org_id, project_id, items)
+    rules = await repo.reorder(org_id, reorder_project_id, items)
     return _ok([r.model_dump(mode="json") for r in rules])
 
 

--- a/backend/app/routers/agent_routing_rules.py
+++ b/backend/app/routers/agent_routing_rules.py
@@ -1,12 +1,13 @@
 import uuid
 from typing import Any
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
+from app.dependencies.project_scope import resolve_required_project_id
 from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
 from app.schemas.agent_routing_rule import (
     CreateRoutingRuleRequest,
@@ -142,18 +143,39 @@ async def replace_or_update_rules(
 
 @router.patch("")
 async def reorder_or_disable_rules(
+    request: Request,
     body: dict,
     auth: AuthContext = Depends(get_current_user),
     repo: AgentRoutingRuleRepository = Depends(_repo),
 ) -> JSONResponse:
-    org_id, project_id = _get_org_project(auth)
-    if not org_id:
+    # ⚠️org_id는 project_id와 독립적으로 먼저 해소(story f0c99070) — 기존 `_get_org_project`는
+    # project_id도 함께 없으면 org_id까지 None으로 뭉개(둘 다 app_metadata 필수 가정), 멀티프로젝트+
+    # 미설정(정당 ambiguous) 에이전트가 "org_id required" 403으로 오판정된다(reorder-items 분기는
+    # 기존 raw project_id 폴백을 그대로 보존 — 무회귀).
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id")
+    if not org_id_str:
         return _err("FORBIDDEN", "org_id required", 403)
+    org_id = uuid.UUID(str(org_id_str))
 
     if body.get("disable_all") is True:
-        rules = await repo.disable_all(org_id, project_id)
+        # E-MCP-OPT 후속(story f0c99070·doc legacy-project-fallback-sweep-audit §2.2 2단계): id 없이
+        # (org_id,project_id)만으로 전 룰 비활성화 — fail-closed 앵커 0. FE는 이 HTTP 분기를 안 타고
+        # Supabase 직접쓰기(disableRules())로 우회하므로(실측 확인) 무회귀·즉시 강제 안전.
+        try:
+            disable_project_id = await resolve_required_project_id(repo.session, request, auth, org_id)
+        except HTTPException as exc:
+            return _err(
+                exc.detail.get("code", "PROJECT_ID_REQUIRED") if isinstance(exc.detail, dict) else "FORBIDDEN",
+                exc.detail.get("message", str(exc.detail)) if isinstance(exc.detail, dict) else str(exc.detail),
+                exc.status_code,
+            )
+        rules = await repo.disable_all(org_id, disable_project_id)
         return _ok([r.model_dump(mode="json") for r in rules])
 
+    # reorder-items 분기: 기존 raw project_id 폴백 그대로(Tier 1 fail-closed — id 매치 요구라
+    # 이번 스토리 스코프 아님, doc §2.2 4단계 후속).
+    project_id_str = auth.claims.get("app_metadata", {}).get("project_id")
+    project_id = uuid.UUID(str(project_id_str)) if project_id_str else None
     req = ReorderRulesRequest.model_validate(body)
     items = [{"id": str(item.id), "priority": item.priority} for item in req.items]
     rules = await repo.reorder(org_id, project_id, items)

--- a/backend/app/routers/hitl.py
+++ b/backend/app/routers/hitl.py
@@ -1,11 +1,12 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
+from app.dependencies.project_scope import resolve_required_project_id
 from app.repositories.hitl import HitlRepository
 from app.schemas.hitl import PatchHitlPolicyRequest, ResolveHitlRequestBody
 
@@ -47,13 +48,26 @@ async def get_hitl_policy(
 
 @router.patch("/policy")
 async def update_hitl_policy(
+    request: Request,
     body: PatchHitlPolicyRequest,
     auth: AuthContext = Depends(get_current_user),
     repo: HitlRepository = Depends(_repo),
 ) -> JSONResponse:
-    org_id, project_id = _get_org_project(auth)
-    if not org_id:
+    # E-MCP-OPT 후속(story f0c99070·doc legacy-project-fallback-sweep-audit §2.2 2단계): 이 라우트는
+    # project_id 단독(org_id도 미검사) singleton upsert라 fail-closed 앵커가 없다 — 요청시점 재해소
+    # 강제(무헤더 direct REST 실호출처 0 실측 확인, 즉시 강제 안전).
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id")
+    if not org_id_str:
         return _err("FORBIDDEN", "org_id required", 403)
+    org_id = uuid.UUID(str(org_id_str))
+    try:
+        project_id = await resolve_required_project_id(repo.session, request, auth, org_id)
+    except HTTPException as exc:
+        return _err(
+            exc.detail.get("code", "PROJECT_ID_REQUIRED") if isinstance(exc.detail, dict) else "FORBIDDEN",
+            exc.detail.get("message", str(exc.detail)) if isinstance(exc.detail, dict) else str(exc.detail),
+            exc.status_code,
+        )
     snapshot = await repo.save_policy(
         org_id=org_id,
         project_id=project_id,

--- a/backend/app/routers/open_api_keys.py
+++ b/backend/app/routers/open_api_keys.py
@@ -1,10 +1,11 @@
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id, require_admin
 from app.dependencies.database import get_db
+from app.dependencies.project_scope import resolve_required_project_id
 from app.repositories.project_api_key import ProjectApiKeyRepository
 from app.schemas.project_api_key import (
     CreateProjectApiKeyRequest,
@@ -31,16 +32,17 @@ def _get_project_id(auth: AuthContext = Depends(get_current_user)) -> uuid.UUID:
 
 @router.post("/api-keys", response_model=ProjectApiKeyCreatedResponse, status_code=201)
 async def create_project_api_key(
+    request: Request,
     body: CreateProjectApiKeyRequest,
     auth: AuthContext = Depends(require_admin),
-    # QA RC HIGH②(#1549): get_verified_org_id 가 X-Project-Id override 로 claims.project_id 를
-    # 갱신하므로, claims 를 읽는 _get_project_id 보다 **먼저** 선언해야(의존성 해소 순서=선언 순서)
-    # stale JWT project_id 대신 override 된 값을 캡처한다.
     _org_id: uuid.UUID = Depends(get_verified_org_id),
-    project_id: uuid.UUID = Depends(_get_project_id),
     repo: ProjectApiKeyRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
 ) -> ProjectApiKeyCreatedResponse:
+    # E-MCP-OPT 후속(story f0c99070·doc legacy-project-fallback-sweep-audit §2.2 2단계): sole-source
+    # CREATE(project-scoped 크리덴셜 발급)라 project_id 오판정=지속 피해. 무헤더 direct REST 실호출처
+    # 0 실측 확인(즉시 강제 안전) — 요청시점 재해소(_get_project_id의 JWT-only 폴백 대체).
+    project_id = await resolve_required_project_id(session, request, auth, _org_id)
     created_by = uuid.UUID(auth.user_id) if auth.user_id else None
     key, plaintext = await repo.create(
         project_id=project_id,

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -116,8 +116,6 @@ _FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
         "설계상 안전(SEC-S8 BB 정리) — non-admin은 target_agent_id==member_id로 self-scope, admin은 org 전체 권한으로 통과",
     "app.routers.visual_artifacts:list_artifacts":
         "이전 SEC-S8 finding(G/N)으로 이미 봉인 — project_id가 클라 파라미터가 아니라 auth 컨텍스트에서 서버파생(_get_org_project)",
-    "app.routers.open_api_keys:create_project_api_key":
-        "require_admin 가드 + project_id가 클라 파라미터가 아니라 JWT app_metadata에서 서버파생(_get_project_id)",
     "app.routers.open_api_keys:list_project_api_keys":
         "동일 require_admin + JWT-derived project_id",
     "app.routers.open_api_keys:revoke_project_api_key":

--- a/backend/tests/test_f0c99070_critical_project_scope_realdb.py
+++ b/backend/tests/test_f0c99070_critical_project_scope_realdb.py
@@ -384,3 +384,147 @@ async def test_create_project_api_key_default_project_id_scopes_correctly():
             assert await _key_count(s, seeded["project_b"]) == 0  # 형제 project 무변경.
     finally:
         await engine.dispose()
+
+
+# ── agent_routing_rules::replace_or_update_rules(bulk-replace, FE 선행배선 後) ─
+
+async def _rule_deleted(session, rule_id) -> bool:
+    from sqlalchemy import select
+    from app.models.agent_routing_rule import AgentRoutingRule
+    deleted_at = (await session.execute(
+        select(AgentRoutingRule.deleted_at).where(AgentRoutingRule.id == rule_id)
+    )).scalar_one()
+    return deleted_at is not None
+
+
+async def _active_rule_count(session, project_id) -> int:
+    from sqlalchemy import func, select
+    from app.models.agent_routing_rule import AgentRoutingRule
+    return (await session.execute(
+        select(func.count()).select_from(AgentRoutingRule).where(
+            AgentRoutingRule.project_id == project_id, AgentRoutingRule.deleted_at.is_(None),
+        )
+    )).scalar_one()
+
+
+async def test_bulk_replace_explicit_body_project_id_scopes_correctly_sibling_untouched():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_project_agent(s)
+            rule_a = await _seed_rule(s, seeded["org_id"], seeded["project_a"], seeded["agent_id"])
+            rule_b = await _seed_rule(s, seeded["org_id"], seeded["project_b"], seeded["agent_id"])
+
+        async with Session() as s:
+            from app.routers.agent_routing_rules import replace_or_update_rules
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await replace_or_update_rules(
+                request=_request(None),
+                body={
+                    "items": [{"agent_id": str(seeded["agent_id"]), "name": "new-rule"}],
+                    "project_id": str(seeded["project_a"]),
+                },
+                auth=_auth(seeded["agent_id"], seeded["org_id"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 200
+            await s.commit()
+
+        async with Session() as s:
+            assert await _rule_deleted(s, rule_a) is True    # project_a 구 룰 replace로 소실(의도됨).
+            assert await _rule_deleted(s, rule_b) is False   # project_b는 완전 무변경 — 교차테넌트 파괴 0.
+            assert await _active_rule_count(s, seeded["project_a"]) == 1  # 신규 룰 1개.
+            assert await _active_rule_count(s, seeded["project_b"]) == 1  # rule_b 그대로.
+    finally:
+        await engine.dispose()
+
+
+async def test_bulk_replace_ambiguous_no_project_id_400_no_mutation():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_project_agent(s)
+            rule_a = await _seed_rule(s, seeded["org_id"], seeded["project_a"], seeded["agent_id"])
+            rule_b = await _seed_rule(s, seeded["org_id"], seeded["project_b"], seeded["agent_id"])
+
+        async with Session() as s:
+            from app.routers.agent_routing_rules import replace_or_update_rules
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await replace_or_update_rules(
+                request=_request(None),
+                body={"items": [{"agent_id": str(seeded["agent_id"]), "name": "new-rule"}]},
+                auth=_auth(seeded["agent_id"], seeded["org_id"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 400
+
+        async with Session() as s:
+            assert await _rule_deleted(s, rule_a) is False
+            assert await _rule_deleted(s, rule_b) is False
+    finally:
+        await engine.dispose()
+
+
+# ── agent_routing_rules::reorder_or_disable_rules(reorder-items, FE 선행배선 後) ─
+
+async def _rule_priority(session, rule_id) -> int:
+    from sqlalchemy import select
+    from app.models.agent_routing_rule import AgentRoutingRule
+    return (await session.execute(
+        select(AgentRoutingRule.priority).where(AgentRoutingRule.id == rule_id)
+    )).scalar_one()
+
+
+async def test_reorder_items_explicit_body_project_id_scopes_correctly_sibling_untouched():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_project_agent(s)
+            rule_a = await _seed_rule(s, seeded["org_id"], seeded["project_a"], seeded["agent_id"])
+            rule_b = await _seed_rule(s, seeded["org_id"], seeded["project_b"], seeded["agent_id"])
+
+        async with Session() as s:
+            from app.routers.agent_routing_rules import reorder_or_disable_rules
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await reorder_or_disable_rules(
+                request=_request(None),
+                body={"items": [{"id": str(rule_a), "priority": 5}], "project_id": str(seeded["project_a"])},
+                auth=_auth(seeded["agent_id"], seeded["org_id"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 200
+            await s.commit()
+
+        async with Session() as s:
+            assert await _rule_priority(s, rule_a) == 5
+            assert await _rule_priority(s, rule_b) == 100  # 형제 project 무변경.
+    finally:
+        await engine.dispose()
+
+
+async def test_reorder_items_ambiguous_no_project_id_400_no_mutation():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_project_agent(s)
+            rule_a = await _seed_rule(s, seeded["org_id"], seeded["project_a"], seeded["agent_id"])
+
+        async with Session() as s:
+            from app.routers.agent_routing_rules import reorder_or_disable_rules
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await reorder_or_disable_rules(
+                request=_request(None),
+                body={"items": [{"id": str(rule_a), "priority": 5}]},
+                auth=_auth(seeded["agent_id"], seeded["org_id"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 400
+
+        async with Session() as s:
+            assert await _rule_priority(s, rule_a) == 100  # 무변경.
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_f0c99070_critical_project_scope_realdb.py
+++ b/backend/tests/test_f0c99070_critical_project_scope_realdb.py
@@ -1,0 +1,386 @@
+"""[SEC][CRITICAL·BE] story f0c99070(doc legacy-project-fallback-sweep-audit §2.2 2단계) — 실 PG.
+
+교차 테넌트 파괴 벡터 3.5건(즉시강제 트랙)의 요청시점 재해소 강제 실증:
+- `hitl::update_hitl_policy`(project_id 단독 singleton upsert — org_id 갭도 검증)
+- `agent_routing_rules::reorder_or_disable_rules`의 disable_all 분기(id 없이 bulk 비활성화)
+- `open_api_keys::create_project_api_key`(project-scoped 크리덴셜 발급)
+
+각 라우트에 대해 (a)멀티프로젝트+미설정+무헤더=400·양쪽 project 무변경 (b)default_project_id 설정 시
+정확히 그 project만 스코프(형제 project 무변경) (c)X-Project-Id 헤더로도 정확히 스코프됨을 실증.
+`resolve_required_project_id`를 라우터 함수 직접 호출로 검증(HTTP 레이어 우회 — auth 레이어는
+AuthContext 직접 구성으로 격리).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _auth(agent_id: uuid.UUID, org_id: uuid.UUID, *, role: str = "member"):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {"org_id": str(org_id), "role": role}},
+        org_id=str(org_id),
+    )
+
+
+def _request(project_id_header: str | None = None):
+    req = MagicMock()
+    req.headers.get = lambda key, default=None: (
+        project_id_header if key == "X-Project-Id" else default
+    )
+    return req
+
+
+async def _seed_two_project_agent(session, *, default_project_id: uuid.UUID | None = None):
+    """org + project_a/project_b + agent(양쪽 project_access grant, 멀티프로젝트 앰비규어스)."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    agent = Member(
+        id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent",
+        default_project_id=default_project_id,
+    )
+    session.add(agent)
+    await session.commit()
+    session.add_all([
+        ProjectAccess(id=uuid.uuid4(), project_id=project_a.id, member_id=agent.id, permission="granted"),
+        ProjectAccess(id=uuid.uuid4(), project_id=project_b.id, member_id=agent.id, permission="granted"),
+    ])
+    await session.commit()
+
+    return {"org_id": org.id, "project_a": project_a.id, "project_b": project_b.id, "agent_id": agent.id}
+
+
+# ── hitl::update_hitl_policy ──────────────────────────────────────────────────
+
+async def _seed_hitl_policy(session, org_id, project_id, config_marker: str):
+    from app.models.hitl import HitlPolicy
+    policy = HitlPolicy(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id,
+        config={"schema_version": 1, "approval_rules": [], "timeout_classes": [], "marker": config_marker},
+    )
+    session.add(policy)
+    await session.commit()
+
+
+async def _get_hitl_config(session, project_id):
+    from sqlalchemy import select
+    from app.models.hitl import HitlPolicy
+    row = (await session.execute(
+        select(HitlPolicy.config).where(HitlPolicy.project_id == project_id)
+    )).scalar_one_or_none()
+    return row
+
+
+async def test_hitl_ambiguous_no_default_400_no_mutation():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_project_agent(s)
+            await _seed_hitl_policy(s, seeded["org_id"], seeded["project_a"], "orig_a")
+            await _seed_hitl_policy(s, seeded["org_id"], seeded["project_b"], "orig_b")
+
+        async with Session() as s:
+            from app.routers.hitl import update_hitl_policy
+            from app.repositories.hitl import HitlRepository
+            from app.schemas.hitl import PatchHitlPolicyRequest
+
+            resp = await update_hitl_policy(
+                request=_request(None),
+                body=PatchHitlPolicyRequest(approval_rules=[], timeout_classes=[]),
+                auth=_auth(seeded["agent_id"], seeded["org_id"]),
+                repo=HitlRepository(s),
+            )
+            assert resp.status_code == 400
+
+        async with Session() as s:
+            assert (await _get_hitl_config(s, seeded["project_a"]))["marker"] == "orig_a"
+            assert (await _get_hitl_config(s, seeded["project_b"]))["marker"] == "orig_b"
+    finally:
+        await engine.dispose()
+
+
+async def test_hitl_default_project_id_scopes_correctly_sibling_untouched():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_project_agent(s)
+            # default_project_id는 Member 생성 後 별도 update(FK가 같은 트랜잭션 내 순서 문제 회피).
+            from sqlalchemy import update as sa_update
+            from app.models.member import Member
+            await s.execute(
+                sa_update(Member).where(Member.id == seeded["agent_id"]).values(default_project_id=seeded["project_a"])
+            )
+            await s.commit()
+            await _seed_hitl_policy(s, seeded["org_id"], seeded["project_a"], "orig_a")
+            await _seed_hitl_policy(s, seeded["org_id"], seeded["project_b"], "orig_b")
+
+        async with Session() as s:
+            from app.routers.hitl import update_hitl_policy
+            from app.repositories.hitl import HitlRepository
+            from app.schemas.hitl import PatchHitlPolicyRequest
+
+            resp = await update_hitl_policy(
+                request=_request(None),
+                body=PatchHitlPolicyRequest(approval_rules=[], timeout_classes=[]),
+                auth=_auth(seeded["agent_id"], seeded["org_id"]),
+                repo=HitlRepository(s),
+            )
+            assert resp.status_code == 200
+            await s.commit()
+
+        async with Session() as s:
+            a_config = await _get_hitl_config(s, seeded["project_a"])
+            b_config = await _get_hitl_config(s, seeded["project_b"])
+            assert "marker" not in (a_config or {})  # project_a는 정책 갱신됨(merge 후 marker 소실).
+            assert b_config["marker"] == "orig_b"  # project_b는 완전 무변경 — 교차테넌트 파괴 0 실증.
+    finally:
+        await engine.dispose()
+
+
+async def test_hitl_header_scopes_correctly():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_project_agent(s)
+            await _seed_hitl_policy(s, seeded["org_id"], seeded["project_a"], "orig_a")
+            await _seed_hitl_policy(s, seeded["org_id"], seeded["project_b"], "orig_b")
+
+        async with Session() as s:
+            from app.routers.hitl import update_hitl_policy
+            from app.repositories.hitl import HitlRepository
+            from app.schemas.hitl import PatchHitlPolicyRequest
+
+            resp = await update_hitl_policy(
+                request=_request(str(seeded["project_b"])),
+                body=PatchHitlPolicyRequest(approval_rules=[], timeout_classes=[]),
+                auth=_auth(seeded["agent_id"], seeded["org_id"]),
+                repo=HitlRepository(s),
+            )
+            assert resp.status_code == 200
+            await s.commit()
+
+        async with Session() as s:
+            assert (await _get_hitl_config(s, seeded["project_a"]))["marker"] == "orig_a"  # 무변경.
+            assert "marker" not in (await _get_hitl_config(s, seeded["project_b"]) or {})  # 헤더 지정분만 변경.
+    finally:
+        await engine.dispose()
+
+
+# ── agent_routing_rules::reorder_or_disable_rules(disable_all) ───────────────
+
+async def _seed_rule(session, org_id, project_id, agent_id):
+    from app.models.agent_routing_rule import AgentRoutingRule
+    rule = AgentRoutingRule(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, agent_id=agent_id,
+        name="r", priority=100, match_type="event", conditions={"memo_type": []},
+        action={"auto_reply_mode": "process_and_report", "forward_to_agent_id": None},
+        is_enabled=True,
+    )
+    session.add(rule)
+    await session.commit()
+    return rule.id
+
+
+async def _rule_enabled(session, rule_id) -> bool:
+    from sqlalchemy import select
+    from app.models.agent_routing_rule import AgentRoutingRule
+    return (await session.execute(
+        select(AgentRoutingRule.is_enabled).where(AgentRoutingRule.id == rule_id)
+    )).scalar_one()
+
+
+async def test_disable_all_ambiguous_400_no_mutation():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_project_agent(s)
+            rule_a = await _seed_rule(s, seeded["org_id"], seeded["project_a"], seeded["agent_id"])
+            rule_b = await _seed_rule(s, seeded["org_id"], seeded["project_b"], seeded["agent_id"])
+
+        async with Session() as s:
+            from app.routers.agent_routing_rules import reorder_or_disable_rules
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await reorder_or_disable_rules(
+                request=_request(None),
+                body={"disable_all": True},
+                auth=_auth(seeded["agent_id"], seeded["org_id"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 400
+
+        async with Session() as s:
+            assert await _rule_enabled(s, rule_a) is True
+            assert await _rule_enabled(s, rule_b) is True
+    finally:
+        await engine.dispose()
+
+
+async def test_disable_all_default_project_id_scopes_correctly_sibling_untouched():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_project_agent(s)
+            from sqlalchemy import update as sa_update
+            from app.models.member import Member
+            await s.execute(
+                sa_update(Member).where(Member.id == seeded["agent_id"]).values(default_project_id=seeded["project_a"])
+            )
+            await s.commit()
+            rule_a = await _seed_rule(s, seeded["org_id"], seeded["project_a"], seeded["agent_id"])
+            rule_b = await _seed_rule(s, seeded["org_id"], seeded["project_b"], seeded["agent_id"])
+
+        async with Session() as s:
+            from app.routers.agent_routing_rules import reorder_or_disable_rules
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await reorder_or_disable_rules(
+                request=_request(None),
+                body={"disable_all": True},
+                auth=_auth(seeded["agent_id"], seeded["org_id"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 200
+            await s.commit()
+
+        async with Session() as s:
+            assert await _rule_enabled(s, rule_a) is False  # 스코프된 project만 비활성화.
+            assert await _rule_enabled(s, rule_b) is True   # 형제 project 무변경 — 교차테넌트 파괴 0.
+    finally:
+        await engine.dispose()
+
+
+# ── open_api_keys::create_project_api_key ─────────────────────────────────────
+
+async def _key_count(session, project_id) -> int:
+    from sqlalchemy import func, select
+    from app.models.project_api_key import ProjectApiKey
+    return (await session.execute(
+        select(func.count()).select_from(ProjectApiKey).where(ProjectApiKey.project_id == project_id)
+    )).scalar_one()
+
+
+async def _seed_two_project_agent_with_user_row(session, *, default_project_id: uuid.UUID | None = None):
+    """create_project_api_key의 created_by FK(→users.id)를 만족시키기 위해 동일 id의 User도 시드."""
+    from app.models.user import User
+
+    seeded = await _seed_two_project_agent(session, default_project_id=default_project_id)
+    session.add(User(
+        id=seeded["agent_id"], email=f"{seeded['agent_id']}@test.local", hashed_password="x",
+    ))
+    await session.commit()
+    return seeded
+
+
+async def test_create_project_api_key_ambiguous_400_no_key_created():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_project_agent_with_user_row(s)
+
+        async with Session() as s:
+            from app.routers.open_api_keys import create_project_api_key
+            from app.repositories.project_api_key import ProjectApiKeyRepository
+            from app.schemas.project_api_key import CreateProjectApiKeyRequest
+
+            with pytest.raises(HTTPException) as exc_info:
+                await create_project_api_key(
+                    request=_request(None),
+                    body=CreateProjectApiKeyRequest(name="k"),
+                    auth=_auth(seeded["agent_id"], seeded["org_id"], role="admin"),
+                    _org_id=seeded["org_id"],
+                    repo=ProjectApiKeyRepository(s),
+                    session=s,
+                )
+            assert exc_info.value.status_code == 400
+
+        async with Session() as s:
+            assert await _key_count(s, seeded["project_a"]) == 0
+            assert await _key_count(s, seeded["project_b"]) == 0
+    finally:
+        await engine.dispose()
+
+
+async def test_create_project_api_key_default_project_id_scopes_correctly():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_two_project_agent_with_user_row(s)
+            from sqlalchemy import update as sa_update
+            from app.models.member import Member
+            await s.execute(
+                sa_update(Member).where(Member.id == seeded["agent_id"]).values(default_project_id=seeded["project_a"])
+            )
+            await s.commit()
+
+        async with Session() as s:
+            from app.routers.open_api_keys import create_project_api_key
+            from app.repositories.project_api_key import ProjectApiKeyRepository
+            from app.schemas.project_api_key import CreateProjectApiKeyRequest
+
+            result = await create_project_api_key(
+                request=_request(None),
+                body=CreateProjectApiKeyRequest(name="k"),
+                auth=_auth(seeded["agent_id"], seeded["org_id"], role="admin"),
+                _org_id=seeded["org_id"],
+                repo=ProjectApiKeyRepository(s),
+                session=s,
+            )
+            assert result.project_id == seeded["project_a"]
+
+        async with Session() as s:
+            assert await _key_count(s, seeded["project_a"]) == 1
+            assert await _key_count(s, seeded["project_b"]) == 0  # 형제 project 무변경.
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_s43.py
+++ b/backend/tests/test_s43.py
@@ -112,9 +112,15 @@ async def test_create_rule_201():
 async def test_replace_rules_200():
     client, session, app = await _client()
     try:
-        with patch("app.repositories.agent_routing_rule.AgentRoutingRuleRepository.replace", new_callable=AsyncMock) as mock_replace:
+        # story f0c99070: bulk-replace 분기도 이제 요청시점 재해소를 거친다 — body에 project_id를
+        # 실어보내(FE PR #2120과 동일 계약) explicit 경로로 단락, has_project_access만 mock.
+        with patch("app.repositories.agent_routing_rule.AgentRoutingRuleRepository.replace", new_callable=AsyncMock) as mock_replace, \
+             patch("app.services.project_auth.has_project_access", new_callable=AsyncMock, return_value=True):
             mock_replace.return_value = [_make_rule()]
-            payload = {"items": [{"agent_id": str(AGENT_ID), "name": "Test Rule"}]}
+            payload = {
+                "items": [{"agent_id": str(AGENT_ID), "name": "Test Rule"}],
+                "project_id": str(PROJECT_ID),
+            }
             async with client as c:
                 resp = await c.put("/api/v2/agent-routing-rules", json=payload)
             assert resp.status_code == 200
@@ -144,9 +150,12 @@ async def test_update_rule_200():
 async def test_reorder_rules_200():
     client, session, app = await _client()
     try:
-        with patch("app.repositories.agent_routing_rule.AgentRoutingRuleRepository.reorder", new_callable=AsyncMock) as mock_reorder:
+        # story f0c99070: reorder-items 분기도 이제 요청시점 재해소를 거친다 — body에 project_id를
+        # 실어보내(FE PR #2120과 동일 계약) explicit 경로로 단락.
+        with patch("app.repositories.agent_routing_rule.AgentRoutingRuleRepository.reorder", new_callable=AsyncMock) as mock_reorder, \
+             patch("app.services.project_auth.has_project_access", new_callable=AsyncMock, return_value=True):
             mock_reorder.return_value = [_make_rule()]
-            payload = {"items": [{"id": str(RULE_ID), "priority": 5}]}
+            payload = {"items": [{"id": str(RULE_ID), "priority": 5}], "project_id": str(PROJECT_ID)}
             async with client as c:
                 resp = await c.patch("/api/v2/agent-routing-rules", json=payload)
             assert resp.status_code == 200

--- a/backend/tests/test_s43.py
+++ b/backend/tests/test_s43.py
@@ -158,6 +158,11 @@ async def test_reorder_rules_200():
 async def test_disable_all_200():
     client, session, app = await _client()
     try:
+        # story f0c99070: disable_all 분기가 이제 요청시점 재해소(resolve_required_project_id)를
+        # 거친다 — accessible_project_ids_in_org의 단일-접근-프로젝트 단축 경로를 태우도록 mock.
+        _accessible_result = MagicMock()
+        _accessible_result.all.return_value = [(PROJECT_ID,)]
+        session.execute = AsyncMock(return_value=_accessible_result)
         with patch("app.repositories.agent_routing_rule.AgentRoutingRuleRepository.disable_all", new_callable=AsyncMock) as mock_disable:
             disabled = _make_rule()
             disabled.is_enabled = False

--- a/backend/tests/test_s45.py
+++ b/backend/tests/test_s45.py
@@ -111,6 +111,11 @@ async def test_patch_hitl_policy_saves_and_returns():
     try:
         snapshot = MagicMock()
         snapshot.model_dump.return_value = _make_snapshot_dict()
+        # story f0c99070: update_hitl_policy가 이제 요청시점 재해소(resolve_required_project_id)를
+        # 거친다 — accessible_project_ids_in_org의 단일-접근-프로젝트 단축 경로를 태우도록 mock.
+        _accessible_result = MagicMock()
+        _accessible_result.all.return_value = [(PROJECT_ID,)]
+        session.execute = AsyncMock(return_value=_accessible_result)
         with patch("app.repositories.hitl.HitlRepository.save_policy", new_callable=AsyncMock) as mock_save:
             mock_save.return_value = snapshot
             payload = {


### PR DESCRIPTION
## Summary
- story `f0c99070` (design SSOT: doc `legacy-project-fallback-sweep-audit` §2.1/§2.2, PO 검수 GREEN, 선생님 보안 우선순위 상향) — 감사에서 발견한 CRITICAL 교차 테넌트 파괴 벡터 4개를 `app_metadata.project_id`(토큰 해소 시점에 구워진 `ORDER BY project_id ASC LIMIT 1` 임의값) 대신 **요청시점 재해소**(신규 `app/dependencies/project_scope.py::resolve_required_project_id` — 명시 param > X-Project-Id 헤더 > `member.default_project_id` > 단일 접근가능 프로젝트 > 명시 400 에러, MCP `require_project_id()`와 동일 계약 재사용)로 차단.
- **`hitl::update_hitl_policy`** — project_id 단독(org_id도 미검사) singleton upsert. org_id 미검사 갭도 같은 커밋에서 닫음(`HitlRepository.save_policy`의 SELECT/UPDATE 양쪽에 org_id 필터 추가).
- **`open_api_keys::create_project_api_key`** — project-scoped API 키를 잘못된 project에 발급 가능했던 sole-source CREATE.
- **`agent_routing_rules::reorder_or_disable_rules`의 `disable_all` 분기** — id 없이 `(org_id,project_id)`만으로 전체 룰 비활성화. FE 실호출 0(Supabase 직접쓰기로 우회) 실측 확인 후 즉시 강제.
- **`agent_routing_rules::replace_or_update_rules`(PUT bulk-replace)·`reorder_or_disable_rules`(PATCH reorder-items)** — 착수 前 선행 실측에서 Next.js 서버측 `AgentRoutingRuleService`(브라우저 X-Project-Id 인터셉터 미적용, 6개 실사용 서비스가 호출)가 무헤더로 직호출함을 발견 → FE 선행 배선 PR #2120(develop `6298f32f`, body에 `project_id` 명시 추가) 착지 확인 후 이번 PR에서 BE 강제.

## Non-goals (별건 후속)
- Tier 1(id-anchored fail-closed, ~26라우트) 헬퍼 통합 — 보안 임팩트 없어 별도 위생 스토리로 분리(PO 확定).
- `replace_or_update_rules`의 단일-룰 update 분기 — 기존 id-anchored fail-closed 그대로(무변경).
- 레거시 `_resolve_api_key`의 `ORDER BY` 폴백 자체 삭제·`test_sweep_multiproject_teammember_orderby.py`(ws_chat 형제 패턴) — doc §2.2 4~5단계 후속.

## Test plan
- [x] 신규 realdb 테스트 11건(`test_f0c99070_critical_project_scope_realdb.py`) — 4개 라우트 각각 (a) 명시 project_id 정확 스코프 + 형제 project 완전 무변경(교차테넌트 sabotage 네거티브) (b) 멀티프로젝트+미설정+무헤더 = 400 + 양쪽 project 무변경.
- [x] 기존 hitl/agent_routing_rules/open_api_keys/authz-ratchet 스위트(118건, mock 갭 3건 수정 — `test_s43.py`/`test_s45.py`가 요청시점 재해소 신규 DB 조회를 반영 못 하던 부분, `test_authz_project_scope_coverage.py`의 baseline stale entry 정리) 전부 통과.
- [x] 전체 백엔드 스위트(mcp 패키지 환경이슈·pre-existing 무관 실패 제외, 대조군으로 격리 재검증 완료) 무회귀 확인.
- [x] 마이그레이션 0(순수 로직 fix).

Story: `f0c99070`