### PR TITLE
[SID:5f0c322e] UX writing 정정 — 관형형 종결어미(PO 말투) 유출 4건 소거

### DIFF
--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1627,7 +1627,7 @@
     "count": "<b>{count}</b>건 · 로그 안 열고 판단",
     "allClear": "ALL CLEAR",
     "emptyTitle": "지금 개입할 것 없음",
-    "emptyBody": "모든 작업이 흐르고 있는. 예외가 생기면 여기 올라오는.",
+    "emptyBody": "모든 작업이 흐르고 있습니다. 예외가 생기면 여기에 표시됩니다.",
     "flowDemoted": "나머지는 흐르는 중 — {overflow}건은 여기 안 올림",
     "kindVerifyFail": "검증 실패",
     "kindDecisionNeeded": "결정 필요",
@@ -2303,7 +2303,7 @@
     "workflowSaveErrorTitle": "워크플로우 저장 실패",
     "workflowSaveErrorBody": "워크플로우 저장에 실패했습니다.",
     "workflowNodeAddedTitle": "노드 추가 완료",
-    "workflowNodeAddedBody": "{name} 노드를 캔버스에 추가한",
+    "workflowNodeAddedBody": "{name} 노드를 캔버스에 추가했습니다",
     "workflowNodeAlreadyPlacedTitle": "이미 배치된 노드입니다.",
     "workflowNodeAlreadyPlacedBody": "{name} 노드는 이미 있어서 기존 노드를 재사용한",
     "workflowHumanSourceTitle": "에이전트 소스 필요",
@@ -3537,8 +3537,8 @@
     "editAction": "편집",
     "editAsNewVersionAction": "새 버전으로 편집",
     "sectionLabel": "산출물",
-    "emptyTitle": "아직 산출물이 없는",
-    "emptyHint": "직접 그리거나, 에이전트에게 맡겨 만들 수 있는",
+    "emptyTitle": "아직 산출물이 없습니다",
+    "emptyHint": "직접 그리거나 에이전트에게 맡겨 만들 수 있습니다",
     "createCta": "산출물 그리기",
     "untitledArtifact": "제목 없는 산출물"
   }

--- a/apps/web/src/components/canvas/artifact-section.test.tsx
+++ b/apps/web/src/components/canvas/artifact-section.test.tsx
@@ -56,8 +56,8 @@ describe('ArtifactSection — 빈 상태 1급화 (story 9449da0e)', () => {
   it('renders a first-class empty state instead of returning null when there are 0 artifacts (ko)', async () => {
     await mount('ko');
     expect(container.textContent).toContain('산출물'); // 섹션 라벨 상시 노출
-    expect(container.textContent).toContain('아직 산출물이 없는');
-    expect(container.textContent).toContain('직접 그리거나, 에이전트에게 맡겨 만들 수 있는');
+    expect(container.textContent).toContain('아직 산출물이 없습니다');
+    expect(container.textContent).toContain('직접 그리거나 에이전트에게 맡겨 만들 수 있습니다');
     expect(container.querySelector('button')?.textContent).toBe('산출물 그리기');
   });
 
@@ -75,7 +75,7 @@ describe('ArtifactSection — 빈 상태 1급화 (story 9449da0e)', () => {
     expect(cta).not.toBeNull();
     await act(async () => { cta!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
     // 빈 상태는 사라지고 편집기(CommitBar의 "버전으로 저장" 액션)가 뜬다 — mock 0, 실 컴포넌트.
-    expect(container.textContent).not.toContain('아직 산출물이 없는');
+    expect(container.textContent).not.toContain('아직 산출물이 없습니다');
     expect(container.textContent).toContain('버전으로 저장');
   });
 });


### PR DESCRIPTION
## 요약
선생님 지적(2026-07-13) 정정 소품. "아직 산출물이 없는"류 관형형("~는/~은")은 문장이 안 끝난 것(뒤에 명사가 와야 함) — PO 오르테가 페르소나 말투("~하는"으로 문장 종결)가 제품 UI 카피에 유출된 것. 유나 정정본 그대로 `ko.json` 4키 값 교체만, 로직/구조 0.

## 변경 (ko만, en 무변경 — 이미 완결형)
| key | before | after |
|---|---|---|
| `canvas.emptyTitle` | 아직 산출물이 없는 | 아직 산출물이 없습니다 |
| `canvas.emptyHint` | 직접 그리거나, 에이전트에게 맡겨 만들 수 있는 | 직접 그리거나 에이전트에게 맡겨 만들 수 있습니다 |
| `attentionQueue.emptyBody` | 모든 작업이 흐르고 있는. 예외가 생기면 여기 올라오는. | 모든 작업이 흐르고 있습니다. 예외가 생기면 여기에 표시됩니다. |
| `agents.workflowNodeAddedBody` | {name} 노드를 캔버스에 추가한 | {name} 노드를 캔버스에 추가했습니다 |

4번째는 유나 전수 감사가 추가 적출(관형형 종결 유출 동종).

`artifact-section.test.tsx`(내가 PR#2119에서 작성)의 두 케이스가 구 ko 카피를 하드코딩 단언 중이라 신 카피로 갱신 — 회귀 아님, 같은 테스트 케이스 유지.

## 테스트
전체 vitest **1277 passed/2 skipped**(회귀 0) · tsc **0** · eslint **0 warning** · build **exit 0**.

## 잔여
유나 카피 가디언 GREEN + CI green → 오르테가 머지 → dev 라이브 렌더 확인.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>