### PR TITLE
[SID:a15cea4f] E-CANVAS 산출물 갤러리 — 4축 그룹핑 + 요약 그리드 + lazy 변천사

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -52,6 +52,7 @@
     "standup": "Standup",
     "retro": "Retro",
     "docs": "Docs",
+    "artifacts": "Artifacts",
     "rewards": "Rewards",
     "inbox": "Inbox",
     "mockup": "Mockups",
@@ -3540,6 +3541,22 @@
     "emptyTitle": "No artifacts yet",
     "emptyHint": "Draw one yourself, or hand it to an agent.",
     "createCta": "Draw artifact",
-    "untitledArtifact": "Untitled"
+    "untitledArtifact": "Untitled",
+    "galleryTitle": "Artifacts",
+    "gallerySubtitle": "Grouped together, so you can see how each one evolved.",
+    "galleryAxisEpic": "Epic",
+    "galleryAxisStory": "Story",
+    "galleryAxisSprint": "Sprint",
+    "galleryAxisDoc": "Doc",
+    "galleryAxisFeature": "Feature",
+    "galleryFeatureAxisUnsupported": "Grouping by feature isn't supported yet.",
+    "galleryUnassignedGroup": "Unassigned",
+    "galleryEmptyTitle": "No artifacts have been collected yet.",
+    "galleryEmptyHint": "Artifacts will show up here once they're created.",
+    "galleryGroupEmpty": "This group doesn't have any artifacts yet.",
+    "galleryAnchorPill": "Anchor v{version}",
+    "galleryLatestChip": "Up to v{version}",
+    "galleryLazyHint": "Expanding loads earlier versions.",
+    "galleryVersionsUnavailable": "Couldn't load earlier versions."
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -52,6 +52,7 @@
     "standup": "스탠드업",
     "retro": "회고",
     "docs": "문서",
+    "artifacts": "산출물",
     "rewards": "리워드",
     "inbox": "인박스",
     "mockup": "목업",
@@ -3540,6 +3541,22 @@
     "emptyTitle": "아직 산출물이 없습니다",
     "emptyHint": "직접 그리거나 에이전트에게 맡겨 만들 수 있습니다",
     "createCta": "산출물 그리기",
-    "untitledArtifact": "제목 없는 산출물"
+    "untitledArtifact": "제목 없는 산출물",
+    "galleryTitle": "산출물",
+    "gallerySubtitle": "그룹으로 모아 변천사를 봅니다",
+    "galleryAxisEpic": "에픽",
+    "galleryAxisStory": "스토리",
+    "galleryAxisSprint": "스프린트",
+    "galleryAxisDoc": "문서",
+    "galleryAxisFeature": "기능",
+    "galleryFeatureAxisUnsupported": "기능별 모아보기는 아직 지원하지 않습니다",
+    "galleryUnassignedGroup": "무소속",
+    "galleryEmptyTitle": "아직 모인 산출물이 없습니다",
+    "galleryEmptyHint": "산출물이 만들어지면 여기에 모입니다",
+    "galleryGroupEmpty": "이 그룹에는 아직 산출물이 없습니다",
+    "galleryAnchorPill": "정본 v{version}",
+    "galleryLatestChip": "v{version}까지",
+    "galleryLazyHint": "펼치면 이전 버전을 불러옵니다",
+    "galleryVersionsUnavailable": "이전 버전을 불러올 수 없습니다"
   }
 }

--- a/apps/web/src/app/(authenticated)/artifacts/page.tsx
+++ b/apps/web/src/app/(authenticated)/artifacts/page.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { ArtifactGalleryView } from '@/components/canvas/artifact-gallery-view';
+
+export default function ArtifactsPage() {
+  return <ArtifactGalleryView />;
+}

--- a/apps/web/src/components/canvas/artifact-gallery-timeline.tsx
+++ b/apps/web/src/components/canvas/artifact-gallery-timeline.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+
+export interface GalleryTimelineVersion {
+  versionNumber: number;
+  summary: string | null;
+  isAnchor: boolean;
+}
+
+interface ArtifactGalleryTimelineProps {
+  versions: GalleryTimelineVersion[];
+  className?: string;
+}
+
+/**
+ * 산출물 갤러리 변천사 타임라인(story a15cea4f) — v1→vN 가로 시간축. `ArtifactVersionRail`
+ * (스토리 상세 편집 사이드바)과 의도적으로 다른 컴포넌트: 그쪽은 작성자를 보여주는 게 맞는 문맥
+ * (인-스토리 협업 이력)이지만, 갤러리는 doc `artifact-gallery-design` §3의 감시 금지 경계가
+ * 더 엄격함 — **주어는 산출물/버전의 진화**뿐, 작성자·편집 횟수·경과시간은 렌더 자체가 없다.
+ * anchor(정본)=success 톤 노드, 그 외=info 톤 — 빨강 0.
+ */
+export function ArtifactGalleryTimeline({ versions, className }: ArtifactGalleryTimelineProps) {
+  const t = useTranslations('canvas');
+  return (
+    <div className={cn('flex items-start gap-0 overflow-x-auto', className)}>
+      {versions.map((v, i) => {
+        const isLast = i === versions.length - 1;
+        return (
+          <div key={v.versionNumber} className={cn('min-w-0', isLast ? 'flex-none' : 'flex-1 pr-3.5')}>
+            <div className="mb-1.5 flex items-center gap-0">
+              <span
+                className={cn(
+                  'h-[11px] w-[11px] shrink-0 rounded-full border-2',
+                  v.isAnchor ? 'border-success bg-success' : 'border-info bg-background',
+                )}
+                aria-hidden="true"
+              />
+              {!isLast ? <span className="h-0.5 flex-1 bg-border" aria-hidden="true" /> : null}
+            </div>
+            <p className={cn('text-[11px] font-bold tabular-nums', v.isAnchor ? 'text-success' : 'text-foreground')}>
+              v{v.versionNumber}
+              {v.isAnchor ? <span className="ml-1 font-medium">{t('versionAnchorTag')}</span> : null}
+            </p>
+            {v.summary ? <p className="mt-0.5 truncate text-[11.5px] text-muted-foreground">{v.summary}</p> : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/canvas/artifact-gallery-view.test.tsx
+++ b/apps/web/src/components/canvas/artifact-gallery-view.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+//
+// story a15cea4f — 산출물 갤러리 회귀가드. fetch를 4축 lookup + artifacts로 스텁해 실 렌더를
+// 검증(mock 컴포넌트 없음, useDashboardContext만 스텁 — 라우팅 컨텍스트 무관하게 projectId 고정).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { ArtifactGalleryView } from './artifact-gallery-view';
+import koMessagesRaw from '../../../messages/ko.json';
+
+type LooseMessages = { [key: string]: string | LooseMessages };
+const koMessages = koMessagesRaw as unknown as LooseMessages;
+
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => ({ projectId: 'proj-1' }),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function jsonRes(data: unknown) {
+  return { ok: true, status: 200, json: async () => ({ data }) };
+}
+
+const ARTIFACTS = [
+  { id: 'a1', title: '웰컴 이메일 시안', story_id: null, epic_id: 'e1', doc_id: null, source: 'created', latest_version_number: 3, anchor_version: 3, created_by: 'm1', created_at: '2026-07-01T00:00:00Z' },
+  { id: 'a2', title: '배너 세트 A', story_id: null, epic_id: null, doc_id: null, source: 'created', latest_version_number: 1, anchor_version: null, created_by: 'm1', created_at: '2026-07-01T00:00:00Z' },
+];
+
+function stubFetch() {
+  return vi.fn(async (url: string) => {
+    if (url.startsWith('/api/visual-artifacts/')) return jsonRes([{ id: 'v1', version_number: 1, summary: '초안 레이아웃', created_by: 'm1', created_at: '', source_comment_id: null }]);
+    if (url.startsWith('/api/visual-artifacts')) return jsonRes(ARTIFACTS);
+    if (url.startsWith('/api/epics')) return jsonRes([{ id: 'e1', title: '온보딩 캠페인' }]);
+    if (url.startsWith('/api/stories')) return jsonRes([]);
+    if (url.startsWith('/api/sprints')) return jsonRes([]);
+    if (url.startsWith('/api/docs')) return jsonRes([]);
+    return jsonRes(null);
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.stubGlobal('fetch', stubFetch());
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function mount() {
+  await act(async () => {
+    root.render(
+      <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+        <ArtifactGalleryView />
+      </NextIntlClientProvider>,
+    );
+  });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('ArtifactGalleryView (story a15cea4f)', () => {
+  it('renders the epic axis by default with real group labels and summary chips (no mock data)', async () => {
+    await mount();
+    expect(container.textContent).toContain('온보딩 캠페인');
+    expect(container.textContent).toContain('무소속'); // a2(epic_id=null) 그룹
+    expect(container.textContent).toContain('웰컴 이메일 시안');
+  });
+
+  it('shows the disabled feature-axis segment with an honest unsupported note (no-fiction — not hidden)', async () => {
+    await mount();
+    const featureBtn = [...container.querySelectorAll('button')].find((b) => b.textContent === '기능');
+    expect(featureBtn).toBeDefined();
+    expect(featureBtn?.hasAttribute('disabled')).toBe(true);
+    expect(featureBtn?.getAttribute('title')).toBe('기능별 모아보기는 아직 지원하지 않습니다');
+  });
+
+  it('shows the anchor pill only for artifacts that actually have an anchor version (no fabricated anchors)', async () => {
+    await mount();
+    expect(container.textContent).toContain('정본 v3');
+  });
+
+  it('expanding a row lazily fetches and renders the version timeline (no author, no counts, no elapsed time)', async () => {
+    await mount();
+    const row = container.querySelector('[role="button"]');
+    expect(row).not.toBeNull();
+    await act(async () => { row!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    expect(container.textContent).toContain('초안 레이아웃');
+    // 감시 금지: 작성자/횟수/경과시간이 렌더되지 않는다.
+    expect(container.textContent).not.toContain('m1');
+  });
+
+  it('renders the empty state when the project has no artifacts at all', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.startsWith('/api/visual-artifacts')) return jsonRes([]);
+      return jsonRes([]);
+    }) as unknown as typeof fetch);
+    await mount();
+    expect(container.textContent).toContain('아직 모인 산출물이 없습니다');
+  });
+});

--- a/apps/web/src/components/canvas/artifact-gallery-view.tsx
+++ b/apps/web/src/components/canvas/artifact-gallery-view.tsx
@@ -1,0 +1,267 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { ChevronDown, ChevronRight, Frame } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+import type { BeVisualArtifactSummary, BeArtifactVersionSummary } from '@/services/canvas';
+import {
+  buildGalleryGroups, GALLERY_AXES,
+  type GalleryAxis, type GalleryGroup, type GalleryLookups,
+} from '@/services/artifact-gallery';
+import { ArtifactGalleryTimeline, type GalleryTimelineVersion } from './artifact-gallery-timeline';
+
+async function fetchJson<T>(url: string): Promise<T | null> {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const json = (await res.json()) as { data?: T };
+    return json.data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+interface StoryListItem { id: string; title: string; sprint_id: string | null }
+interface EpicListItem { id: string; title: string }
+interface SprintListItem { id: string; title: string }
+interface DocListItem { id: string; title: string }
+
+async function fetchGalleryData(projectId: string): Promise<{ artifacts: BeVisualArtifactSummary[]; lookups: GalleryLookups }> {
+  const [artifacts, epics, stories, sprints, docs] = await Promise.all([
+    // 무쿼리 호출=project-wide(BE가 JWT/API키 컨텍스트의 project_id로 항상 스코프 — 클라 지정
+    // 불가 SEC-S8 가드). 기존 프록시 쿼리 forward 그대로라 신규 프록시 0(doc §5).
+    fetchJson<BeVisualArtifactSummary[]>('/api/visual-artifacts'),
+    fetchJson<EpicListItem[]>(`/api/epics?project_id=${projectId}&limit=100`),
+    fetchJson<StoryListItem[]>(`/api/stories?project_id=${projectId}&limit=100`),
+    fetchJson<SprintListItem[]>(`/api/sprints?project_id=${projectId}`),
+    fetchJson<DocListItem[]>(`/api/docs?project_id=${projectId}&limit=100`),
+  ]);
+  return {
+    artifacts: artifacts ?? [],
+    lookups: {
+      epics: (epics ?? []).map((e) => ({ id: e.id, title: e.title })),
+      stories: (stories ?? []).map((s) => ({ id: s.id, title: s.title, sprint_id: s.sprint_id })),
+      sprints: (sprints ?? []).map((s) => ({ id: s.id, title: s.title })),
+      docs: (docs ?? []).map((d) => ({ id: d.id, title: d.title })),
+    },
+  };
+}
+
+function GroupListSkeleton() {
+  return (
+    <div className="space-y-1.5 p-1.5">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="h-9 animate-pulse rounded-lg bg-muted/60" />
+      ))}
+    </div>
+  );
+}
+
+function ArtifactRow({
+  artifact, axisT, expanded, versions, versionsLoading, onToggle,
+}: {
+  artifact: GalleryGroup['artifacts'][number];
+  axisT: ReturnType<typeof useTranslations>;
+  expanded: boolean;
+  versions: GalleryTimelineVersion[] | undefined;
+  versionsLoading: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div className="border-t border-border/60 first:border-t-0">
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={onToggle}
+        onKeyDown={(e) => { if (e.key === 'Enter') onToggle(); }}
+        className="flex cursor-pointer items-center gap-3 px-1 py-3"
+      >
+        <span className="h-[22px] w-[30px] shrink-0 rounded border border-border bg-muted/50" aria-hidden="true" />
+        <span className="min-w-0 flex-1 truncate text-[13.5px] font-semibold text-foreground">
+          {artifact.title}
+        </span>
+        {artifact.anchorVersion != null ? (
+          <span className="shrink-0 rounded border border-success px-1.5 py-0.5 text-[9px] font-extrabold text-success">
+            {axisT('galleryAnchorPill', { version: artifact.anchorVersion })}
+          </span>
+        ) : null}
+        <span className="shrink-0 rounded border border-border bg-muted/60 px-1.5 py-0.5 text-[11px] font-bold tabular-nums text-muted-foreground">
+          {axisT('galleryLatestChip', { version: artifact.latestVersionNumber })}
+        </span>
+        {expanded ? <ChevronDown className="size-3 shrink-0 text-muted-foreground" /> : <ChevronRight className="size-3 shrink-0 text-muted-foreground" />}
+      </div>
+      {expanded ? (
+        <div className="pb-4 pl-[41px] pr-1">
+          <p className="mb-2 text-[9.5px] tracking-wide text-muted-foreground/70">{axisT('galleryLazyHint')}</p>
+          {versionsLoading ? (
+            <div className="h-10 animate-pulse rounded bg-muted/50" />
+          ) : versions && versions.length > 0 ? (
+            <ArtifactGalleryTimeline versions={versions} />
+          ) : (
+            <p className="text-[11.5px] text-muted-foreground">{axisT('galleryVersionsUnavailable')}</p>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * E-CANVAS 산출물 갤러리(story a15cea4f) — 스토리 상세 ArtifactSection(인-스토리 증거)과 별개인
+ * 발견 표면. 설계 SSOT: doc `artifact-gallery-design`. 4축(에픽·스토리·스프린트·문서)으로 모아
+ * 요약 그리드(1콜)를 보여주고, 펼침 시에만 변천사 상세를 lazy load(GET /{id}/versions) — 전량
+ * 선fetch 0. "기능" 축은 데이터 모델에 연결 필드가 없어 미지원(no-fiction) — 토글에 비활성
+ * 세그먼트로 정직 표기(숨기지 않음).
+ */
+export function ArtifactGalleryView() {
+  const t = useTranslations('canvas');
+  const { projectId } = useDashboardContext();
+  const [loading, setLoading] = useState(true);
+  const [artifacts, setArtifacts] = useState<BeVisualArtifactSummary[]>([]);
+  const [lookups, setLookups] = useState<GalleryLookups>({ epics: [], stories: [], sprints: [], docs: [] });
+  const [axis, setAxis] = useState<GalleryAxis>('epic');
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [versionsByArtifact, setVersionsByArtifact] = useState<Record<string, GalleryTimelineVersion[]>>({});
+  const [versionsLoadingId, setVersionsLoadingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!projectId) return;
+    let cancelled = false;
+    void (async () => {
+      setLoading(true);
+      const result = await fetchGalleryData(projectId);
+      if (cancelled) return;
+      setArtifacts(result.artifacts);
+      setLookups(result.lookups);
+      setLoading(false);
+    })();
+    return () => { cancelled = true; };
+  }, [projectId]);
+
+  const groups = useMemo(
+    () => buildGalleryGroups(axis, artifacts, lookups, t('galleryUnassignedGroup')),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- t는 로케일 불변 함수
+    [axis, artifacts, lookups],
+  );
+
+  useEffect(() => {
+    setSelectedGroupId(groups[0]?.id ?? null);
+    setExpandedId(null);
+  }, [axis, groups.length]); // eslint-disable-line react-hooks/exhaustive-deps -- 축 전환 시에만 초기화
+
+  const selectedGroup = groups.find((g) => g.id === selectedGroupId) ?? null;
+
+  async function handleToggleExpand(artifactId: string) {
+    if (expandedId === artifactId) { setExpandedId(null); return; }
+    setExpandedId(artifactId);
+    if (versionsByArtifact[artifactId]) return;
+    setVersionsLoadingId(artifactId);
+    const detail = selectedGroup?.artifacts.find((a) => a.id === artifactId);
+    const list = await fetchJson<BeArtifactVersionSummary[]>(`/api/visual-artifacts/${artifactId}/versions`);
+    const mapped: GalleryTimelineVersion[] = (list ?? [])
+      .slice()
+      .sort((a, b) => a.version_number - b.version_number)
+      .map((v) => ({ versionNumber: v.version_number, summary: v.summary, isAnchor: v.version_number === detail?.anchorVersion }));
+    setVersionsByArtifact((cur) => ({ ...cur, [artifactId]: mapped }));
+    setVersionsLoadingId(null);
+  }
+
+  const axisLabel = (a: GalleryAxis) => t(`galleryAxis${a[0]!.toUpperCase()}${a.slice(1)}`);
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-6">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <h1 className="text-[20px] font-extrabold tracking-tight text-foreground">{t('galleryTitle')}</h1>
+          <p className="mt-0.5 text-xs text-muted-foreground">{t('gallerySubtitle')}</p>
+        </div>
+        <div className="flex shrink-0 gap-0.5 rounded-lg border border-border bg-muted/40 p-0.5">
+          {GALLERY_AXES.map((a) => (
+            <button
+              key={a}
+              type="button"
+              onClick={() => setAxis(a)}
+              className={cn(
+                'rounded-md px-2.5 py-1.5 text-xs font-semibold transition-colors',
+                axis === a ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {axisLabel(a)}
+            </button>
+          ))}
+          <button
+            type="button"
+            disabled
+            title={t('galleryFeatureAxisUnsupported')}
+            className="cursor-not-allowed rounded-md px-2.5 py-1.5 text-xs font-semibold text-muted-foreground/40"
+          >
+            {t('galleryAxisFeature')}
+          </button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="grid grid-cols-[200px_1fr] gap-3.5">
+          <GroupListSkeleton />
+          <div className="h-40 animate-pulse rounded-xl bg-muted/40" />
+        </div>
+      ) : artifacts.length === 0 ? (
+        <div className="flex flex-col items-center gap-2 rounded-xl border border-border bg-card px-6 py-12 text-center">
+          <Frame className="size-6 text-muted-foreground/60" aria-hidden="true" />
+          <p className="text-sm font-medium text-foreground">{t('galleryEmptyTitle')}</p>
+          <p className="max-w-sm text-xs text-muted-foreground">{t('galleryEmptyHint')}</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-[200px_1fr] gap-3.5">
+          <div className="h-fit rounded-xl border border-border bg-card p-1.5">
+            {groups.map((g) => (
+              <button
+                key={g.id}
+                type="button"
+                onClick={() => { setSelectedGroupId(g.id); setExpandedId(null); }}
+                className={cn(
+                  'flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-[13px] transition-colors',
+                  selectedGroupId === g.id ? 'bg-muted/70' : 'hover:bg-muted/40',
+                )}
+              >
+                <span className={cn('size-1.5 shrink-0 rounded-full', selectedGroupId === g.id ? 'bg-info' : 'bg-muted-foreground/40')} aria-hidden="true" />
+                <span className={cn('min-w-0 flex-1 truncate font-medium', g.unassigned ? 'italic text-muted-foreground' : 'text-foreground')}>
+                  {g.label}
+                </span>
+                <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">{g.artifacts.length}</span>
+              </button>
+            ))}
+          </div>
+
+          <div
+            className="overflow-hidden rounded-xl border border-border bg-card px-5 py-4"
+            style={{ clipPath: 'polygon(0 0, calc(100% - 22px) 0, 100% 22px, 100% 100%, 0 100%)' }}
+          >
+            <div className="mb-3 text-[11px] font-bold uppercase tracking-wide text-muted-foreground">{axisLabel(axis)}</div>
+            {!selectedGroup || selectedGroup.artifacts.length === 0 ? (
+              <p className="py-8 text-center text-[12.5px] text-muted-foreground">{t('galleryGroupEmpty')}</p>
+            ) : (
+              <>
+                <h2 className="mb-2 text-[16px] font-extrabold text-foreground">{selectedGroup.label}</h2>
+                {selectedGroup.artifacts.map((artifact) => (
+                  <ArtifactRow
+                    key={artifact.id}
+                    artifact={artifact}
+                    axisT={t}
+                    expanded={expandedId === artifact.id}
+                    versions={versionsByArtifact[artifact.id]}
+                    versionsLoading={versionsLoadingId === artifact.id}
+                    onToggle={() => void handleToggleExpand(artifact.id)}
+                  />
+                ))}
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -11,6 +11,7 @@ import {
   CircleHelp,
   ClipboardList,
   FolderKanban,
+  GalleryVerticalEnd,
   Gauge,
   HardDrive,
   Inbox,
@@ -300,7 +301,8 @@ export function AppSidebar({
           </SidebarGroupContent>
         </SidebarGroup>
 
-        {/* ④ 지식 / Knowledge — 팀 기억(문서·스토리지·에이전트). ia-4zone SSOT 확定. */}
+        {/* ④ 지식 / Knowledge — 팀 기억(문서·산출물·스토리지·에이전트). ia-4zone SSOT 확定.
+            산출물(story a15cea4f) — 스토리 귀속 ArtifactSection과 별개인 모아보기 발견 표면. */}
         <SidebarGroup>
           <SidebarGroupLabel>{t('zoneKnowledge')}</SidebarGroupLabel>
           <SidebarGroupContent>
@@ -313,6 +315,16 @@ export function AppSidebar({
                 >
                   <BookOpen />
                   <span>{t('docs')}</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/artifacts" />}
+                  isActive={isActive('/artifacts')}
+                  tooltip={t('artifacts')}
+                >
+                  <GalleryVerticalEnd />
+                  <span>{t('artifacts')}</span>
                 </SidebarMenuButton>
               </SidebarMenuItem>
               <SidebarMenuItem>

--- a/apps/web/src/services/artifact-gallery.test.ts
+++ b/apps/web/src/services/artifact-gallery.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { buildGalleryGroups, GALLERY_AXES, type GalleryLookups } from './artifact-gallery';
+import type { BeVisualArtifactSummary } from './canvas';
+
+const UNASSIGNED = '무소속';
+
+function artifact(overrides: Partial<BeVisualArtifactSummary> = {}): BeVisualArtifactSummary {
+  return {
+    id: 'a1', title: '웰컴 이메일 시안', story_id: null, epic_id: null, doc_id: null,
+    source: 'created', latest_version_number: 1, anchor_version: null, created_by: 'm1',
+    created_at: '2026-07-13T00:00:00Z', ...overrides,
+  };
+}
+
+const lookups: GalleryLookups = {
+  epics: [{ id: 'e1', title: '온보딩 캠페인' }, { id: 'e2', title: '브랜드 리뉴얼' }],
+  stories: [
+    { id: 's1', title: '웰컴 이메일', sprint_id: 'sp1' },
+    { id: 's2', title: '랜딩 히어로', sprint_id: null },
+  ],
+  sprints: [{ id: 'sp1', title: 'Sprint 24' }, { id: 'sp2', title: 'Sprint 23' }],
+  docs: [{ id: 'd1', title: '브랜드 가이드' }],
+};
+
+describe('GALLERY_AXES', () => {
+  it('exposes exactly the 4 supported axes (feature is not among them — no-fiction)', () => {
+    expect(GALLERY_AXES).toEqual(['epic', 'story', 'sprint', 'doc']);
+  });
+});
+
+describe('buildGalleryGroups — epic axis', () => {
+  it('groups artifacts by epic_id, using the real epic title', () => {
+    const groups = buildGalleryGroups('epic', [
+      artifact({ id: 'a1', epic_id: 'e1' }),
+      artifact({ id: 'a2', epic_id: 'e1' }),
+      artifact({ id: 'a3', epic_id: 'e2' }),
+    ], lookups, UNASSIGNED);
+    expect(groups.map((g) => [g.label, g.artifacts.length])).toEqual([
+      ['온보딩 캠페인', 2], ['브랜드 리뉴얼', 1],
+    ]);
+  });
+
+  it('buckets artifacts with no epic_id (or an unresolvable epic_id) as unassigned, last, without fabricating a label', () => {
+    const groups = buildGalleryGroups('epic', [
+      artifact({ id: 'a1', epic_id: 'e1' }),
+      artifact({ id: 'a2', epic_id: null }),
+      artifact({ id: 'a3', epic_id: 'deleted-epic' }),
+    ], lookups, UNASSIGNED);
+    expect(groups.at(-1)).toEqual(expect.objectContaining({ id: 'unassigned', label: UNASSIGNED, unassigned: true }));
+    expect(groups.at(-1)!.artifacts).toHaveLength(2);
+  });
+});
+
+describe('buildGalleryGroups — story/doc axes (direct FK)', () => {
+  it('groups by story_id', () => {
+    const groups = buildGalleryGroups('story', [artifact({ story_id: 's1' })], lookups, UNASSIGNED);
+    expect(groups).toEqual([expect.objectContaining({ id: 's1', label: '웰컴 이메일' })]);
+  });
+
+  it('groups by doc_id', () => {
+    const groups = buildGalleryGroups('doc', [artifact({ doc_id: 'd1' })], lookups, UNASSIGNED);
+    expect(groups).toEqual([expect.objectContaining({ id: 'd1', label: '브랜드 가이드' })]);
+  });
+});
+
+describe('buildGalleryGroups — sprint axis (1-hop join via story.sprint_id)', () => {
+  it('resolves the sprint through the artifact\'s story, not a direct FK', () => {
+    const groups = buildGalleryGroups('sprint', [artifact({ story_id: 's1' })], lookups, UNASSIGNED);
+    expect(groups).toEqual([expect.objectContaining({ id: 'sp1', label: 'Sprint 24' })]);
+  });
+
+  it('is unassigned when the story itself has no sprint_id', () => {
+    const groups = buildGalleryGroups('sprint', [artifact({ story_id: 's2' })], lookups, UNASSIGNED);
+    expect(groups).toEqual([expect.objectContaining({ id: 'unassigned', unassigned: true })]);
+  });
+
+  it('is unassigned when the artifact has no story_id at all (independent artifact)', () => {
+    const groups = buildGalleryGroups('sprint', [artifact({ story_id: null })], lookups, UNASSIGNED);
+    expect(groups).toEqual([expect.objectContaining({ id: 'unassigned', unassigned: true })]);
+  });
+});
+
+describe('buildGalleryGroups — summary fields (no extra fetch needed)', () => {
+  it('carries latestVersionNumber and anchorVersion straight from the list_artifacts summary', () => {
+    const groups = buildGalleryGroups('epic', [
+      artifact({ id: 'a1', epic_id: 'e1', latest_version_number: 3, anchor_version: 2 }),
+    ], lookups, UNASSIGNED);
+    expect(groups[0]!.artifacts[0]).toEqual({ id: 'a1', title: '웰컴 이메일 시안', latestVersionNumber: 3, anchorVersion: 2 });
+  });
+
+  it('anchorVersion is null when nothing has been anchored yet (no fabricated anchor)', () => {
+    const groups = buildGalleryGroups('epic', [artifact({ id: 'a1', epic_id: 'e1', anchor_version: null })], lookups, UNASSIGNED);
+    expect(groups[0]!.artifacts[0]!.anchorVersion).toBeNull();
+  });
+});

--- a/apps/web/src/services/artifact-gallery.ts
+++ b/apps/web/src/services/artifact-gallery.ts
@@ -1,0 +1,100 @@
+/**
+ * E-CANVAS 산출물 갤러리(story a15cea4f) — 순수 데이터 계층. 설계 SSOT: doc
+ * `artifact-gallery-design`. 스토리 상세 ArtifactSection(인-스토리 증거)과 별개인 발견 표면 —
+ * 4축(에픽·스토리·스프린트·문서)으로 산출물을 모아 변천사를 본다. "기능" 축은 데이터 모델에
+ * 연결 필드 자체가 없어 미지원(no-fiction — 억지 축을 만들지 않고 UI에 정직 표기).
+ */
+import type { BeVisualArtifactSummary } from './canvas';
+
+export type GalleryAxis = 'epic' | 'story' | 'sprint' | 'doc';
+
+export const GALLERY_AXES: GalleryAxis[] = ['epic', 'story', 'sprint', 'doc'];
+
+export interface GalleryArtifactSummary {
+  id: string;
+  title: string;
+  latestVersionNumber: number;
+  anchorVersion: number | null;
+}
+
+export interface GalleryGroup {
+  /** 엔티티 id, 무소속 그룹은 'unassigned'. */
+  id: string;
+  label: string;
+  unassigned: boolean;
+  artifacts: GalleryArtifactSummary[];
+}
+
+interface EntityRef {
+  id: string;
+  title: string;
+}
+
+interface StoryRef {
+  id: string;
+  title: string;
+  sprint_id: string | null;
+}
+
+export interface GalleryLookups {
+  epics: EntityRef[];
+  stories: StoryRef[];
+  sprints: EntityRef[];
+  docs: EntityRef[];
+}
+
+function toSummary(a: BeVisualArtifactSummary): GalleryArtifactSummary {
+  return { id: a.id, title: a.title, latestVersionNumber: a.latest_version_number, anchorVersion: a.anchor_version };
+}
+
+function groupBy(
+  artifacts: BeVisualArtifactSummary[],
+  entities: EntityRef[],
+  keyOf: (a: BeVisualArtifactSummary) => string | null,
+  unassignedLabel: string,
+): GalleryGroup[] {
+  const titleById = new Map(entities.map((e) => [e.id, e.title]));
+  const byKey = new Map<string, BeVisualArtifactSummary[]>();
+  const unassigned: BeVisualArtifactSummary[] = [];
+
+  for (const a of artifacts) {
+    const key = keyOf(a);
+    // no-fiction: key가 있어도 해당 엔티티를 못 찾으면(삭제 등) 지어낸 라벨 대신 무소속으로.
+    if (!key || !titleById.has(key)) { unassigned.push(a); continue; }
+    (byKey.get(key) ?? byKey.set(key, []).get(key)!).push(a);
+  }
+
+  const groups: GalleryGroup[] = [...byKey.entries()]
+    .map(([id, items]) => ({ id, label: titleById.get(id)!, unassigned: false, artifacts: items.map(toSummary) }))
+    .sort((a, b) => b.artifacts.length - a.artifacts.length || a.label.localeCompare(b.label));
+
+  if (unassigned.length > 0) {
+    groups.push({ id: 'unassigned', label: unassignedLabel, unassigned: true, artifacts: unassigned.map(toSummary) });
+  }
+  return groups;
+}
+
+/**
+ * 축별 그룹핑. 스프린트만 간접(artifact.story_id → Story.sprint_id 1홉, FE join) — 나머지는
+ * artifact의 직접 FK. story_id가 NULL이거나 해당 story의 sprint_id가 NULL이면 무소속.
+ */
+export function buildGalleryGroups(
+  axis: GalleryAxis,
+  artifacts: BeVisualArtifactSummary[],
+  lookups: GalleryLookups,
+  unassignedLabel: string,
+): GalleryGroup[] {
+  if (axis === 'epic') return groupBy(artifacts, lookups.epics, (a) => a.epic_id, unassignedLabel);
+  if (axis === 'doc') return groupBy(artifacts, lookups.docs, (a) => a.doc_id, unassignedLabel);
+  if (axis === 'story') {
+    const storyRefs: EntityRef[] = lookups.stories.map((s) => ({ id: s.id, title: s.title }));
+    return groupBy(artifacts, storyRefs, (a) => a.story_id, unassignedLabel);
+  }
+  // sprint: story_id → sprint_id 1홉 join.
+  const sprintIdByStoryId = new Map(lookups.stories.map((s) => [s.id, s.sprint_id]));
+  return groupBy(
+    artifacts, lookups.sprints,
+    (a) => (a.story_id ? sprintIdByStoryId.get(a.story_id) ?? null : null),
+    unassignedLabel,
+  );
+}


### PR DESCRIPTION
## 요약
선생님 기지시(GROUP BY 변천사 + 비개발 도메인 온보딩) 본류. 유나 설계 SSOT(`artifact-gallery-design`+`artifact-gallery-mockup-render`) 그대로 구현 — 신규 BE 0(디디 확定).

## 구현
- **진입점**: 지식 존 nav "산출물" 1급 메뉴(문서 옆, IA 4→여전히 ≤7)·라우트 `/artifacts`(project-scoped, `useDashboardContext` 패턴 — storage 페이지 선례 그대로). 스토리 상세 ArtifactSection과 별개 발견 표면.
- **4축 그룹핑**(`artifact-gallery.ts`, 순수 함수): 에픽·스토리·문서=artifact의 직접 FK. 스프린트만 `artifact.story_id → Story.sprint_id` 1홉 FE join. story_id NULL이거나 참조 엔티티를 lookup에서 못 찾으면(삭제 등) 지어낸 라벨 대신 "무소속" 버킷(no-fiction). **"기능" 축은 데이터 모델에 연결 필드 자체가 없어 토글에 비활성 세그먼트로 정직 표기**(숨기지 않음·tooltip="기능별 모아보기는 아직 지원하지 않습니다").
- **요약 그리드 1콜 + lazy 변천사**: `GET /api/visual-artifacts`를 무쿼리 호출(project_id 쿼리조차 안 붙임 — BE가 JWT/API키 컨텍스트로 항상 스코프하는 SEC-S8 가드 실코드 확인·기존 프록시 그대로라 신규 프록시 0) 1콜로 `latest_version_number`/`anchor_version`까지 받아 요약 렌더. 펼침(▸→▾) 시에만 `GET /{id}/versions`로 lazy load — 전량 선fetch 0.
- **감시 금지**: `artifact-gallery-timeline.tsx` 신설 — 기존 `ArtifactVersionRail`(스토리 상세 편집 사이드바)은 작성자를 보여주는 게 정확한 문맥(인-스토리 협업 이력)이라 그대로 재사용하면 갤러리의 더 엄격한 감시 금지 경계를 깨서, 순수 프레젠테이션 컴포넌트를 새로 뽑음(신규 컴포넌트 최소 원칙 검토 결과). 작성자·편집 횟수·경과시간 렌더 0 — anchor=success 톤 노드, 나머지=info 톤, 빨강 0.
- **비개발 도메인 카피**: 개발 용어 0(mockup의 `.note` 텍스트는 "1콜"·"GET /{id}/versions" 같은 dev 주석이라 그대로 옮기지 않고 실 제품 문구로 재작성 — 예: "펼치면 이전 버전을 불러옵니다"). 빈상태/전 카피 합니다체·관형형 종결 0(오늘 UX writing 정정 규율 그대로).

## 규율 준수 확인(구현 중 자체 적발)
mockup의 artifact-row "클릭→상세페이지 이동" 유혹을 자체 검토로 제거 — 설계 doc에 없는 동선이라 dead-link가 될 뻔한 걸 구현 중 스스로 적발, 전체 행이 펼침 토글만 하도록 정정(mockup 인터랙션 모델과 일치).

## 테스트
- `artifact-gallery.test.ts`: 4축 그룹핑(직접FK 3종+1홉 join)·무소속 버킷(null key·unresolvable id)·요약 필드 그대로 전달, 10/10.
- `artifact-gallery-view.test.tsx`(실 fetch mock, mock 컴포넌트 0): 기본 축 렌더·기능축 비활성+tooltip·anchor pill 조건부·펼침 lazy fetch+감시 금지(작성자 문자열 미노출)·빈 프로젝트 빈상태, 5/5.
- 전체 vitest **1292 passed/2 skipped**(회귀 0) · tsc **0** · eslint **0 warning** · build **exit 0**(`/artifacts` 라우트 등록 확인).

## 잔여
유나 UX 가디언 GREEN + 까심 QA + CI green 후 오르테가 머지 → dev 라이브 done-gate(4축 전환·요약/변천사 실렌더).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>