### PR TITLE
fix(security): API-key write-scope 배선 — read-only 키의 mutation 우회 차단 (story d764522c)

### DIFF
--- a/backend/app/dependencies/project_scope.py
+++ b/backend/app/dependencies/project_scope.py
@@ -24,14 +24,24 @@ _AMBIGUOUS_MESSAGE = (
 
 
 def enforce_write_scope(auth: AuthContext, request: Request) -> None:
-    """API-key write-scope 강제(story d764522c·산티아고 SME finding).
+    """API-key write-scope 강제(story d764522c·산티아고 SME 2차 finding).
 
-    `_check_api_key_scope`(app/dependencies/auth.py)는 보통 `get_verified_org_id` 경유로만
-    실행되는데, 이 모듈의 project_id 재해소를 쓰는 라우터들은 org_id를 자체 해소하고
-    `get_verified_org_id`를 거치지 않아 그 실행점이 빠져 있었다 — read-only API key가 mutation을
-    호출할 수 있던 갭. JWT(human) 경로는 `_check_api_key_scope` 내부에서 자동 스킵."""
-    from app.dependencies.auth import _check_api_key_scope
-    _check_api_key_scope(auth, request.method, request.url.path)
+    ⚠️`_check_api_key_scope`(app/dependencies/auth.py) 그대로 위임하지 않는다 — 그 함수의
+    Stage 1(레거시 read/write coarse 게이트)은 `set(scope) & _LEGACY_SCOPES`일 때만 발동하고,
+    explicit toolset-scope 키(예: `scope=['docs']`)는 Stage 1을 건너뛰어 Stage 2(path→toolgroup)
+    만 적용된다. 그런데 `agent_routing_rules`/`hitl`은 어떤 toolset group에도 대응하지 않는
+    admin-adjacent 설정 표면이라 `_PATH_GROUP_PREFIXES`에 없고, 미매핑 path는 "core 취급 허용"이
+    기본값(`path_allowed_for_scope`의 over-block 방지 설계)이라 **어떤 toolgroup-scope 키든
+    무제한 통과**했다(산티아고 실DB 실증 — `scope=['docs']`로 6개 mutation 전부 성공).
+
+    이 6라우트는 toolgroup 개념이 아예 없으므로, scope 타입 불문 **레거시 'write' 토큰 명시 보유**
+    만 통과시킨다(path-group 우회 경로 자체를 안 탐 — 가장 보수적 근본). JWT(human) 경로는
+    api_key_id 부재로 자동 스킵(기존 `_check_api_key_scope`와 동일 관례)."""
+    if not auth.claims.get("app_metadata", {}).get("api_key_id"):
+        return  # JWT(human) 경로 — 스킵.
+    scope: list[str] = auth.claims.get("app_metadata", {}).get("scope") or ["read", "write"]
+    if "write" not in scope:
+        raise HTTPException(status_code=403, detail="API Key scope 'write' required")
 
 
 async def resolve_required_project_id(

--- a/backend/app/dependencies/project_scope.py
+++ b/backend/app/dependencies/project_scope.py
@@ -23,6 +23,17 @@ _AMBIGUOUS_MESSAGE = (
 )
 
 
+def enforce_write_scope(auth: AuthContext, request: Request) -> None:
+    """API-key write-scope 강제(story d764522c·산티아고 SME finding).
+
+    `_check_api_key_scope`(app/dependencies/auth.py)는 보통 `get_verified_org_id` 경유로만
+    실행되는데, 이 모듈의 project_id 재해소를 쓰는 라우터들은 org_id를 자체 해소하고
+    `get_verified_org_id`를 거치지 않아 그 실행점이 빠져 있었다 — read-only API key가 mutation을
+    호출할 수 있던 갭. JWT(human) 경로는 `_check_api_key_scope` 내부에서 자동 스킵."""
+    from app.dependencies.auth import _check_api_key_scope
+    _check_api_key_scope(auth, request.method, request.url.path)
+
+
 async def resolve_required_project_id(
     session: AsyncSession,
     request: Request,

--- a/backend/app/routers/agent_routing_rules.py
+++ b/backend/app/routers/agent_routing_rules.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
-from app.dependencies.project_scope import resolve_required_project_id
+from app.dependencies.project_scope import enforce_write_scope, resolve_required_project_id
 from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
 from app.schemas.agent_routing_rule import (
     CreateRoutingRuleRequest,
@@ -61,10 +61,15 @@ async def list_or_get_rules(
 
 @router.post("")
 async def create_rule(
+    request: Request,
     body: CreateRoutingRuleRequest,
     auth: AuthContext = Depends(get_current_user),
     repo: AgentRoutingRuleRepository = Depends(_repo),
 ) -> JSONResponse:
+    try:
+        enforce_write_scope(auth, request)
+    except HTTPException as exc:
+        return _err("FORBIDDEN", str(exc.detail), exc.status_code)
     org_id, project_id = _get_org_project(auth)
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
@@ -97,6 +102,10 @@ async def replace_or_update_rules(
     auth: AuthContext = Depends(get_current_user),
     repo: AgentRoutingRuleRepository = Depends(_repo),
 ) -> JSONResponse:
+    try:
+        enforce_write_scope(auth, request)
+    except HTTPException as exc:
+        return _err("FORBIDDEN", str(exc.detail), exc.status_code)
     # ⚠️org_id는 project_id와 독립적으로 먼저 해소(story f0c99070·reorder_or_disable_rules와 동일 이유).
     org_id_str = auth.claims.get("app_metadata", {}).get("org_id")
     if not org_id_str:
@@ -109,9 +118,14 @@ async def replace_or_update_rules(
         # (PR #2120)이 body.project_id를 명시 실어보내므로 최우선 소스로 소비(무회귀).
         explicit = body.get("project_id")
         try:
+            explicit_project_id = uuid.UUID(str(explicit)) if explicit else None
+        except ValueError:
+            # story d764522c LOW: malformed project_id가 500으로 새던 것 — 명시 400.
+            return _err("BAD_REQUEST", "Invalid project_id format", 400)
+        try:
             replace_project_id = await resolve_required_project_id(
                 repo.session, request, auth, org_id,
-                explicit_project_id=uuid.UUID(str(explicit)) if explicit else None,
+                explicit_project_id=explicit_project_id,
             )
         except HTTPException as exc:
             return _err(
@@ -170,6 +184,10 @@ async def reorder_or_disable_rules(
     auth: AuthContext = Depends(get_current_user),
     repo: AgentRoutingRuleRepository = Depends(_repo),
 ) -> JSONResponse:
+    try:
+        enforce_write_scope(auth, request)
+    except HTTPException as exc:
+        return _err("FORBIDDEN", str(exc.detail), exc.status_code)
     # ⚠️org_id는 project_id와 독립적으로 먼저 해소(story f0c99070) — 기존 `_get_org_project`는
     # project_id도 함께 없으면 org_id까지 None으로 뭉개(둘 다 app_metadata 필수 가정), 멀티프로젝트+
     # 미설정(정당 ambiguous) 에이전트가 "org_id required" 403으로 오판정된다(reorder-items 분기는
@@ -198,9 +216,14 @@ async def reorder_or_disable_rules(
     # Tier 1 fail-closed였지만, FE가 body.project_id를 이제 명시 실어보내므로 최우선 소스로 소비.
     explicit = body.get("project_id")
     try:
+        explicit_project_id = uuid.UUID(str(explicit)) if explicit else None
+    except ValueError:
+        # story d764522c LOW: malformed project_id가 500으로 새던 것 — 명시 400.
+        return _err("BAD_REQUEST", "Invalid project_id format", 400)
+    try:
         reorder_project_id = await resolve_required_project_id(
             repo.session, request, auth, org_id,
-            explicit_project_id=uuid.UUID(str(explicit)) if explicit else None,
+            explicit_project_id=explicit_project_id,
         )
     except HTTPException as exc:
         return _err(
@@ -216,10 +239,15 @@ async def reorder_or_disable_rules(
 
 @router.delete("")
 async def delete_rule(
+    request: Request,
     id: uuid.UUID = Query(...),
     auth: AuthContext = Depends(get_current_user),
     repo: AgentRoutingRuleRepository = Depends(_repo),
 ) -> JSONResponse:
+    try:
+        enforce_write_scope(auth, request)
+    except HTTPException as exc:
+        return _err("FORBIDDEN", str(exc.detail), exc.status_code)
     org_id, project_id = _get_org_project(auth)
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)

--- a/backend/app/routers/agent_routing_rules.py
+++ b/backend/app/routers/agent_routing_rules.py
@@ -116,12 +116,16 @@ async def replace_or_update_rules(
         # E-MCP-OPT 후속(story f0c99070·doc legacy-project-fallback-sweep-audit §2.2 2단계): id 없이
         # (org_id,project_id)만으로 기존 룰 전부 soft-delete+재삽입 — fail-closed 앵커 0. FE 선행배선
         # (PR #2120)이 body.project_id를 명시 실어보내므로 최우선 소스로 소비(무회귀).
+        # story d764522c LOW: `if explicit`(truthy) 대신 `is not None`(존재 여부) 기준 — ""/0/False
+        # 같은 falsy 값을 "미지정"으로 오인해 malformed를 조용히 통과시키지 않는다.
         explicit = body.get("project_id")
-        try:
-            explicit_project_id = uuid.UUID(str(explicit)) if explicit else None
-        except ValueError:
-            # story d764522c LOW: malformed project_id가 500으로 새던 것 — 명시 400.
-            return _err("BAD_REQUEST", "Invalid project_id format", 400)
+        if explicit is not None:
+            try:
+                explicit_project_id = uuid.UUID(str(explicit))
+            except ValueError:
+                return _err("BAD_REQUEST", "Invalid project_id format", 400)
+        else:
+            explicit_project_id = None
         try:
             replace_project_id = await resolve_required_project_id(
                 repo.session, request, auth, org_id,
@@ -214,12 +218,16 @@ async def reorder_or_disable_rules(
 
     # reorder-items 분기(story f0c99070·PO 확定 — FE 선행배선 PR #2120 착지 後 강제): id 매치라
     # Tier 1 fail-closed였지만, FE가 body.project_id를 이제 명시 실어보내므로 최우선 소스로 소비.
+    # story d764522c LOW: `if explicit`(truthy) 대신 `is not None`(존재 여부) 기준 — ""/0/False
+    # 같은 falsy 값을 "미지정"으로 오인해 malformed를 조용히 통과시키지 않는다.
     explicit = body.get("project_id")
-    try:
-        explicit_project_id = uuid.UUID(str(explicit)) if explicit else None
-    except ValueError:
-        # story d764522c LOW: malformed project_id가 500으로 새던 것 — 명시 400.
-        return _err("BAD_REQUEST", "Invalid project_id format", 400)
+    if explicit is not None:
+        try:
+            explicit_project_id = uuid.UUID(str(explicit))
+        except ValueError:
+            return _err("BAD_REQUEST", "Invalid project_id format", 400)
+    else:
+        explicit_project_id = None
     try:
         reorder_project_id = await resolve_required_project_id(
             repo.session, request, auth, org_id,

--- a/backend/app/routers/hitl.py
+++ b/backend/app/routers/hitl.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
-from app.dependencies.project_scope import resolve_required_project_id
+from app.dependencies.project_scope import enforce_write_scope, resolve_required_project_id
 from app.repositories.hitl import HitlRepository
 from app.schemas.hitl import PatchHitlPolicyRequest, ResolveHitlRequestBody
 
@@ -53,6 +53,10 @@ async def update_hitl_policy(
     auth: AuthContext = Depends(get_current_user),
     repo: HitlRepository = Depends(_repo),
 ) -> JSONResponse:
+    try:
+        enforce_write_scope(auth, request)
+    except HTTPException as exc:
+        return _err("FORBIDDEN", str(exc.detail), exc.status_code)
     # E-MCP-OPT 후속(story f0c99070·doc legacy-project-fallback-sweep-audit §2.2 2단계): 이 라우트는
     # project_id 단독(org_id도 미검사) singleton upsert라 fail-closed 앵커가 없다 — 요청시점 재해소
     # 강제(무헤더 direct REST 실호출처 0 실측 확인, 즉시 강제 안전).
@@ -97,9 +101,14 @@ async def list_hitl_requests(
 async def resolve_hitl_request(
     request_id: uuid.UUID,
     body: ResolveHitlRequestBody,
+    request: Request,
     auth: AuthContext = Depends(get_current_user),
     repo: HitlRepository = Depends(_repo),
 ) -> JSONResponse:
+    try:
+        enforce_write_scope(auth, request)
+    except HTTPException as exc:
+        return _err("FORBIDDEN", str(exc.detail), exc.status_code)
     org_id, project_id = _get_org_project(auth)
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)

--- a/backend/tests/test_d764522c_apikey_writescope_realdb.py
+++ b/backend/tests/test_d764522c_apikey_writescope_realdb.py
@@ -7,6 +7,12 @@ open_api_keys.py는 이미 `get_verified_org_id` 사용 중이라 스코프 밖(
 
 각 라우트: read-key(scope=['read'])=403·write-key(scope=['read','write'])=200 무회귀.
 + replace/reorder의 malformed body project_id UUID → 400(500 아님) 2건.
+
+산티아고 2차 finding(2026-07-13): `_check_api_key_scope`의 Stage 1(레거시 read/write coarse
+게이트)은 explicit toolset-scope 키(예 `scope=['docs']`)엔 스킵되고, Stage 2(path→toolgroup)는
+이 6라우트가 어떤 toolgroup에도 안 걸려(_PATH_GROUP_PREFIXES 미매핑) "미매핑=core=허용"으로
+무제한 통과시켰다 — `enforce_write_scope`가 이제 `_check_api_key_scope`에 위임하지 않고 scope
+타입 불문 레거시 'write' 토큰 명시 보유만 통과시킨다. toolgroup-scope sabotage 6건 추가.
 """
 from __future__ import annotations
 
@@ -426,5 +432,157 @@ async def test_resolve_hitl_request_write_key_200_no_regression():
                 repo=HitlRepository(s),
             )
             assert resp.status_code == 200
+    finally:
+        await engine.dispose()
+
+
+# ── 산티아고 2차 finding: toolgroup-scope(scope=['docs']) sabotage — 6라우트 전부 403 ─────
+
+async def test_create_rule_toolgroup_scope_403_no_bypass():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+        async with Session() as s:
+            from app.routers.agent_routing_rules import create_rule
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+            from app.schemas.agent_routing_rule import CreateRoutingRuleRequest
+
+            resp = await create_rule(
+                request=_request("/api/v2/agent-routing-rules", "POST"),
+                body=CreateRoutingRuleRequest(agent_id=seeded["agent_id"], name="r"),
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["docs"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 403
+    finally:
+        await engine.dispose()
+
+
+async def test_replace_rules_toolgroup_scope_403_no_bypass():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+            await _seed_rule(s, seeded["org_id"], seeded["project_id"], seeded["agent_id"])
+        async with Session() as s:
+            from app.routers.agent_routing_rules import replace_or_update_rules
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await replace_or_update_rules(
+                request=_request("/api/v2/agent-routing-rules", "PUT"),
+                body={"items": [{"agent_id": str(seeded["agent_id"]), "name": "new"}], "project_id": str(seeded["project_id"])},
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["docs"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 403
+    finally:
+        await engine.dispose()
+
+
+async def test_disable_all_toolgroup_scope_403_no_bypass():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+        async with Session() as s:
+            from app.routers.agent_routing_rules import reorder_or_disable_rules
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await reorder_or_disable_rules(
+                request=_request("/api/v2/agent-routing-rules", "PATCH"),
+                body={"disable_all": True},
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["docs"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 403
+    finally:
+        await engine.dispose()
+
+
+async def test_delete_rule_toolgroup_scope_403_no_bypass():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+            rule_id = await _seed_rule(s, seeded["org_id"], seeded["project_id"], seeded["agent_id"])
+        async with Session() as s:
+            from app.routers.agent_routing_rules import delete_rule
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await delete_rule(
+                request=_request("/api/v2/agent-routing-rules", "DELETE"),
+                id=rule_id,
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["docs"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 403
+    finally:
+        await engine.dispose()
+
+
+async def test_update_hitl_policy_toolgroup_scope_403_no_bypass():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+        async with Session() as s:
+            from app.routers.hitl import update_hitl_policy
+            from app.repositories.hitl import HitlRepository
+            from app.schemas.hitl import PatchHitlPolicyRequest
+
+            resp = await update_hitl_policy(
+                request=_request("/api/v2/hitl/policy", "PATCH"),
+                body=PatchHitlPolicyRequest(approval_rules=[], timeout_classes=[]),
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["docs"]),
+                repo=HitlRepository(s),
+            )
+            assert resp.status_code == 403
+    finally:
+        await engine.dispose()
+
+
+async def test_resolve_hitl_request_toolgroup_scope_403_no_bypass():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+            req_id = await _seed_hitl_request(s, seeded["org_id"], seeded["project_id"], seeded["agent_id"])
+        async with Session() as s:
+            from app.routers.hitl import resolve_hitl_request
+            from app.repositories.hitl import HitlRepository
+            from app.schemas.hitl import ResolveHitlRequestBody
+
+            resp = await resolve_hitl_request(
+                request_id=req_id,
+                body=ResolveHitlRequestBody(status="approved"),
+                request=_request("/api/v2/hitl/requests/x", "PATCH"),
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["docs"]),
+                repo=HitlRepository(s),
+            )
+            assert resp.status_code == 403
+    finally:
+        await engine.dispose()
+
+
+# ── malformed-vs-unspecified project_id(falsy 값 오인 방지) ───────────────────
+
+async def test_replace_rules_empty_string_project_id_400_not_treated_as_unspecified():
+    """`project_id: ""`(falsy지만 명시 제공)는 미지정이 아닌 malformed로 400 처리돼야 함."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+        async with Session() as s:
+            from app.routers.agent_routing_rules import replace_or_update_rules
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await replace_or_update_rules(
+                request=_request("/api/v2/agent-routing-rules", "PUT"),
+                body={"items": [{"agent_id": str(seeded["agent_id"]), "name": "new"}], "project_id": ""},
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["read", "write"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 400
     finally:
         await engine.dispose()

--- a/backend/tests/test_d764522c_apikey_writescope_realdb.py
+++ b/backend/tests/test_d764522c_apikey_writescope_realdb.py
@@ -1,0 +1,430 @@
+"""[SEC][HIGH·BE] story d764522c(산티아고 SME finding, PR #2121 검토 中 발견) — 실 PG.
+
+`agent_routing_rules.py`(create/replace/reorder/delete)·`hitl.py`(update_policy/resolve_request)
+6개 mutation 라우트가 `get_current_user`만 쓰고 `get_verified_org_id`(API-key scope check 실행점)를
+거치지 않아 read-only 키가 mutation을 호출할 수 있던 갭 — `enforce_write_scope()` 배선 실증.
+open_api_keys.py는 이미 `get_verified_org_id` 사용 중이라 스코프 밖(산티아고+PO 확定).
+
+각 라우트: read-key(scope=['read'])=403·write-key(scope=['read','write'])=200 무회귀.
++ replace/reorder의 malformed body project_id UUID → 400(500 아님) 2건.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _auth(agent_id: uuid.UUID, org_id: uuid.UUID, project_id: uuid.UUID, *, scope: list[str]):
+    """API-key AuthContext — api_key_id 마커가 있어야 _check_api_key_scope가 게이트를 적용한다.
+
+    project_id도 claims에 실어야 함 — create_rule/delete_rule/resolve_hitl_request는 이번 스토리
+    스코프 밖(Tier 0/1)이라 여전히 `_get_org_project`(project_id 동반 필수)를 쓴다."""
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {
+            "org_id": str(org_id), "project_id": str(project_id),
+            "api_key_id": str(uuid.uuid4()), "scope": scope,
+        }},
+        org_id=str(org_id),
+    )
+
+
+def _request(path: str, method: str):
+    req = MagicMock()
+    req.headers.get = lambda key, default=None: default
+    req.method = method
+    req.url.path = path
+    return req
+
+
+async def _seed_single_project_agent(session):
+    """org + project(단일) + agent(project_access grant) — 앰비규어스 없이 단일 접근으로 resolve."""
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent")
+    session.add(agent)
+    await session.commit()
+    session.add(ProjectAccess(id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted"))
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "agent_id": agent.id}
+
+
+async def _seed_rule(session, org_id, project_id, agent_id):
+    from app.models.agent_routing_rule import AgentRoutingRule
+    rule = AgentRoutingRule(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, agent_id=agent_id,
+        name="r", priority=100, match_type="event", conditions={"memo_type": []},
+        action={"auto_reply_mode": "process_and_report", "forward_to_agent_id": None},
+        is_enabled=True,
+    )
+    session.add(rule)
+    await session.commit()
+    return rule.id
+
+
+async def _seed_hitl_request(session, org_id, project_id, agent_id):
+    from app.models.hitl import HitlRequest
+    req = HitlRequest(
+        id=uuid.uuid4(), org_id=org_id, project_id=project_id, agent_id=agent_id,
+        request_type="approval", title="t", prompt="p", requested_for=agent_id, status="pending",
+    )
+    session.add(req)
+    await session.commit()
+    return req.id
+
+
+# ── agent_routing_rules::create_rule(POST) ────────────────────────────────────
+
+async def test_create_rule_read_key_403():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+        async with Session() as s:
+            from app.routers.agent_routing_rules import create_rule
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+            from app.schemas.agent_routing_rule import CreateRoutingRuleRequest
+
+            resp = await create_rule(
+                request=_request("/api/v2/agent-routing-rules", "POST"),
+                body=CreateRoutingRuleRequest(agent_id=seeded["agent_id"], name="r"),
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["read"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 403
+    finally:
+        await engine.dispose()
+
+
+async def test_create_rule_write_key_201_no_regression():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+        async with Session() as s:
+            from app.routers.agent_routing_rules import create_rule
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+            from app.schemas.agent_routing_rule import CreateRoutingRuleRequest
+
+            resp = await create_rule(
+                request=_request("/api/v2/agent-routing-rules", "POST"),
+                body=CreateRoutingRuleRequest(agent_id=seeded["agent_id"], name="r"),
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["read", "write"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 201
+    finally:
+        await engine.dispose()
+
+
+# ── agent_routing_rules::replace_or_update_rules(PUT bulk-replace) ────────────
+
+async def test_replace_rules_read_key_403():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+            await _seed_rule(s, seeded["org_id"], seeded["project_id"], seeded["agent_id"])
+        async with Session() as s:
+            from app.routers.agent_routing_rules import replace_or_update_rules
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await replace_or_update_rules(
+                request=_request("/api/v2/agent-routing-rules", "PUT"),
+                body={"items": [{"agent_id": str(seeded["agent_id"]), "name": "new"}], "project_id": str(seeded["project_id"])},
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["read"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 403
+    finally:
+        await engine.dispose()
+
+
+async def test_replace_rules_write_key_200_no_regression():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+            await _seed_rule(s, seeded["org_id"], seeded["project_id"], seeded["agent_id"])
+        async with Session() as s:
+            from app.routers.agent_routing_rules import replace_or_update_rules
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await replace_or_update_rules(
+                request=_request("/api/v2/agent-routing-rules", "PUT"),
+                body={"items": [{"agent_id": str(seeded["agent_id"]), "name": "new"}], "project_id": str(seeded["project_id"])},
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["read", "write"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 200
+    finally:
+        await engine.dispose()
+
+
+async def test_replace_rules_malformed_project_id_400_not_500():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+        async with Session() as s:
+            from app.routers.agent_routing_rules import replace_or_update_rules
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await replace_or_update_rules(
+                request=_request("/api/v2/agent-routing-rules", "PUT"),
+                body={"items": [{"agent_id": str(seeded["agent_id"]), "name": "new"}], "project_id": "not-a-uuid"},
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["read", "write"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 400
+    finally:
+        await engine.dispose()
+
+
+# ── agent_routing_rules::reorder_or_disable_rules(PATCH) ──────────────────────
+
+async def test_disable_all_read_key_403():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+        async with Session() as s:
+            from app.routers.agent_routing_rules import reorder_or_disable_rules
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await reorder_or_disable_rules(
+                request=_request("/api/v2/agent-routing-rules", "PATCH"),
+                body={"disable_all": True},
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["read"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 403
+    finally:
+        await engine.dispose()
+
+
+async def test_reorder_items_write_key_200_no_regression():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+            rule_id = await _seed_rule(s, seeded["org_id"], seeded["project_id"], seeded["agent_id"])
+        async with Session() as s:
+            from app.routers.agent_routing_rules import reorder_or_disable_rules
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await reorder_or_disable_rules(
+                request=_request("/api/v2/agent-routing-rules", "PATCH"),
+                body={"items": [{"id": str(rule_id), "priority": 5}], "project_id": str(seeded["project_id"])},
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["read", "write"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 200
+    finally:
+        await engine.dispose()
+
+
+async def test_reorder_items_malformed_project_id_400_not_500():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+            rule_id = await _seed_rule(s, seeded["org_id"], seeded["project_id"], seeded["agent_id"])
+        async with Session() as s:
+            from app.routers.agent_routing_rules import reorder_or_disable_rules
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await reorder_or_disable_rules(
+                request=_request("/api/v2/agent-routing-rules", "PATCH"),
+                body={"items": [{"id": str(rule_id), "priority": 5}], "project_id": "not-a-uuid"},
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["read", "write"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 400
+    finally:
+        await engine.dispose()
+
+
+# ── agent_routing_rules::delete_rule(DELETE) ──────────────────────────────────
+
+async def test_delete_rule_read_key_403():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+            rule_id = await _seed_rule(s, seeded["org_id"], seeded["project_id"], seeded["agent_id"])
+        async with Session() as s:
+            from app.routers.agent_routing_rules import delete_rule
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await delete_rule(
+                request=_request("/api/v2/agent-routing-rules", "DELETE"),
+                id=rule_id,
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["read"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 403
+    finally:
+        await engine.dispose()
+
+
+async def test_delete_rule_write_key_200_no_regression():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+            rule_id = await _seed_rule(s, seeded["org_id"], seeded["project_id"], seeded["agent_id"])
+        async with Session() as s:
+            from app.routers.agent_routing_rules import delete_rule
+            from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+
+            resp = await delete_rule(
+                request=_request("/api/v2/agent-routing-rules", "DELETE"),
+                id=rule_id,
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["read", "write"]),
+                repo=AgentRoutingRuleRepository(s),
+            )
+            assert resp.status_code == 200
+    finally:
+        await engine.dispose()
+
+
+# ── hitl::update_hitl_policy(PATCH /policy) ───────────────────────────────────
+
+async def test_update_hitl_policy_read_key_403():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+        async with Session() as s:
+            from app.routers.hitl import update_hitl_policy
+            from app.repositories.hitl import HitlRepository
+            from app.schemas.hitl import PatchHitlPolicyRequest
+
+            resp = await update_hitl_policy(
+                request=_request("/api/v2/hitl/policy", "PATCH"),
+                body=PatchHitlPolicyRequest(approval_rules=[], timeout_classes=[]),
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["read"]),
+                repo=HitlRepository(s),
+            )
+            assert resp.status_code == 403
+    finally:
+        await engine.dispose()
+
+
+async def test_update_hitl_policy_write_key_200_no_regression():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+        async with Session() as s:
+            from app.routers.hitl import update_hitl_policy
+            from app.repositories.hitl import HitlRepository
+            from app.schemas.hitl import PatchHitlPolicyRequest
+
+            resp = await update_hitl_policy(
+                request=_request("/api/v2/hitl/policy", "PATCH"),
+                body=PatchHitlPolicyRequest(approval_rules=[], timeout_classes=[]),
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["read", "write"]),
+                repo=HitlRepository(s),
+            )
+            assert resp.status_code == 200
+    finally:
+        await engine.dispose()
+
+
+# ── hitl::resolve_hitl_request(PATCH /requests/{id}) ──────────────────────────
+
+async def test_resolve_hitl_request_read_key_403():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+            req_id = await _seed_hitl_request(s, seeded["org_id"], seeded["project_id"], seeded["agent_id"])
+        async with Session() as s:
+            from app.routers.hitl import resolve_hitl_request
+            from app.repositories.hitl import HitlRepository
+            from app.schemas.hitl import ResolveHitlRequestBody
+
+            resp = await resolve_hitl_request(
+                request_id=req_id,
+                body=ResolveHitlRequestBody(status="approved"),
+                request=_request("/api/v2/hitl/requests/x", "PATCH"),
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["read"]),
+                repo=HitlRepository(s),
+            )
+            assert resp.status_code == 403
+    finally:
+        await engine.dispose()
+
+
+async def test_resolve_hitl_request_write_key_200_no_regression():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_single_project_agent(s)
+            req_id = await _seed_hitl_request(s, seeded["org_id"], seeded["project_id"], seeded["agent_id"])
+        async with Session() as s:
+            from app.routers.hitl import resolve_hitl_request
+            from app.repositories.hitl import HitlRepository
+            from app.schemas.hitl import ResolveHitlRequestBody
+
+            resp = await resolve_hitl_request(
+                request_id=req_id,
+                body=ResolveHitlRequestBody(status="approved"),
+                request=_request("/api/v2/hitl/requests/x", "PATCH"),
+                auth=_auth(seeded["agent_id"], seeded["org_id"], seeded["project_id"], scope=["read", "write"]),
+                repo=HitlRepository(s),
+            )
+            assert resp.status_code == 200
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- story `d764522c`(산티아고 SME finding, PR #2121 검토 中 발견·high) — `agent_routing_rules.py`/`hitl.py`의 mutation 라우트가 `get_current_user`만 dependency로 써서 `_check_api_key_scope()`가 걸리는 `get_verified_org_id`를 거치지 않았음. #2121이 교차-프로젝트 오선택은 막았으나, **접근 가능한 프로젝트 "안"에서는 read-only API key로도 파괴적 mutation을 호출할 수 있는 write-scope 갭**이 남아 있었음.
- **스코프 확장(PO 승인)**: 산티아고가 예시로 든 3라우트(`replace_or_update_rules` PUT·`reorder_or_disable_rules` PATCH·`update_hitl_policy` PATCH)뿐 아니라 같은 파일의 형제 mutation(`create_rule` POST·`delete_rule` DELETE·`resolve_hitl_request` PATCH)도 동일 갭이라 **6라우트 전부 원자적으로** 닫음(`open_api_keys.py`는 이미 `get_verified_org_id` 사용 중이라 스코프 밖 — 산티아고+PO 확定).
- 신규 `app/dependencies/project_scope.py::enforce_write_scope` — `_check_api_key_scope`를 6라우트에서 직접 호출.
- 부수 LOW: `replace_or_update_rules`/`reorder_or_disable_rules`의 malformed body `project_id` UUID 파싱이 unhandled `ValueError`→500으로 새던 것을 400 명시 에러로.

## Test plan
- [x] 신규 realdb 14건(`test_d764522c_apikey_writescope_realdb.py`) — 6라우트 각각 read-key(`scope=["read"]`)=403 + write-key(`scope=["read","write"]`)=200(무회귀) + malformed project_id=400 2건.
- [x] 기존 118건(hitl/routing_rules/api_key/authz 스위트) + f0c99070 realdb 11건 무회귀 재확인(총 132건, 전부 통과).
- [x] FE/MCP 무회귀 확인: MCP 툴셋은 이 라우트들을 노출 안 함(grep 0건) · FE 프록시는 human JWT 경로(scope check no-op) · `AgentRoutingRuleService`(서버측) write 호출은 read-only 키로 쓸 이유가 구조적으로 없음.
- [x] 마이그 0(로직 fix)·CI green(대기).

**게이트**: 까심 QA → 산티아고 최종 검증(finding 제기자) → PO 머지.

Story: `d764522c`