### PR TITLE
[SID:4f991165] ⌘K Command Palette 액션 확장

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -159,7 +159,15 @@
     "goAgents": "Go to Agents",
     "goDocs": "Go to Docs",
     "documents": "Documents",
-    "goSprints": "Go to Sprints"
+    "goSprints": "Go to Sprints",
+    "actionDelegateStory": "Delegate {title}",
+    "actionDelegateStoryImpact": "Delegates {title} to a teammate. Takes you to the story.",
+    "actionGateDecision": "Review a gate decision",
+    "actionGateDecisionImpact": "Takes you to the gate approval screen.",
+    "actionRecruitAgent": "Recruit an agent",
+    "actionRecruitAgentImpact": "Takes you to the recruiting wizard.",
+    "actionDangerPill": "Sensitive · goes through a confirm step",
+    "contextChip": "{title} · Story"
   },
   "channel": {
     "title": "Channel Chat",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -159,7 +159,15 @@
     "goAgents": "에이전트로 이동",
     "goDocs": "문서로 이동",
     "documents": "문서",
-    "goSprints": "스프린트로 이동"
+    "goSprints": "스프린트로 이동",
+    "actionDelegateStory": "{title} 위임하기",
+    "actionDelegateStoryImpact": "{title}을 담당자에게 위임합니다. 스토리 화면으로 이동합니다.",
+    "actionGateDecision": "게이트 결재하기",
+    "actionGateDecisionImpact": "게이트 결재 화면으로 이동합니다.",
+    "actionRecruitAgent": "에이전트 모집하기",
+    "actionRecruitAgentImpact": "채용 위저드로 이동합니다.",
+    "actionDangerPill": "위험 명령 · 확인 단계 경유",
+    "contextChip": "{title} · 스토리"
   },
   "channel": {
     "title": "채널 채팅",

--- a/apps/web/src/components/command-palette/command-palette-actions.test.ts
+++ b/apps/web/src/components/command-palette/command-palette-actions.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { createTranslator } from 'next-intl';
+import { buildActionCommands, type ActionCommandTranslator } from './command-palette-actions';
+import koMessagesRaw from '../../../messages/ko.json';
+import enMessagesRaw from '../../../messages/en.json';
+
+type LooseMessages = { [key: string]: string | LooseMessages };
+const koMessages = koMessagesRaw as unknown as LooseMessages;
+const enMessages = enMessagesRaw as unknown as LooseMessages;
+const t = createTranslator({ locale: 'ko', messages: koMessages, namespace: 'commandPalette' }) as unknown as ActionCommandTranslator;
+const tEn = createTranslator({ locale: 'en', messages: enMessages, namespace: 'commandPalette' }) as unknown as ActionCommandTranslator;
+
+describe('buildActionCommands — v1 inventory (route-first, no-fiction)', () => {
+  it('without a story context, only the 2 project-scoped commands exist (delegate has no valid target — omitted, not fabricated)', () => {
+    const items = buildActionCommands(t);
+    expect(items.map((i) => i.id)).toEqual(['action-gate-decision', 'action-recruit-agent']);
+  });
+
+  it('with a story context, the delegate command exists, ranked first, targeting the real story route', () => {
+    const items = buildActionCommands(t, { storyId: 's1', storyTitle: '웰컴 이메일 시안' });
+    expect(items[0]).toEqual(expect.objectContaining({
+      id: 'action-delegate-story', targetRoute: '/board?story=s1', danger: false,
+    }));
+    expect(items[0]!.label).toContain('웰컴 이메일 시안');
+    expect(items[0]!.impact).toContain('웰컴 이메일 시안');
+  });
+
+  it('gate decision routes to the gate inbox and is flagged as a danger (amber) command', () => {
+    const items = buildActionCommands(t);
+    const gate = items.find((i) => i.id === 'action-gate-decision')!;
+    expect(gate.targetRoute).toBe('/inbox?tab=gates');
+    expect(gate.danger).toBe(true);
+  });
+
+  it('recruit-agent routes to the recruiter wizard and is not a danger command', () => {
+    const items = buildActionCommands(t);
+    const recruit = items.find((i) => i.id === 'action-recruit-agent')!;
+    expect(recruit.targetRoute).toBe('/agents/recruiter');
+    expect(recruit.danger).toBe(false);
+  });
+
+  it('never fabricates the 3 unwired commands (stop run / re-collect evidence / STEER priority) — dead-path guard', () => {
+    const items = buildActionCommands(t, { storyId: 's1', storyTitle: 'x' });
+    const ids = items.map((i) => i.id);
+    expect(ids).not.toContain('action-stop-run');
+    expect(ids).not.toContain('action-recollect-evidence');
+    expect(ids).not.toContain('action-steer-priority');
+  });
+
+  it('renders in English when given the en translator (ko/en parity)', () => {
+    const items = buildActionCommands(tEn, { storyId: 's1', storyTitle: 'Welcome email draft' });
+    expect(items[0]!.label).toContain('Welcome email draft');
+    expect(items.find((i) => i.id === 'action-recruit-agent')!.label).not.toBe('');
+  });
+});

--- a/apps/web/src/components/command-palette/command-palette-actions.ts
+++ b/apps/web/src/components/command-palette/command-palette-actions.ts
@@ -1,0 +1,66 @@
+/**
+ * ⌘K Command Palette 액션 확장(story 4f991165) — 순수 명령 인벤토리 계층. 설계 SSOT: doc
+ * `command-palette-actions-design`. v1 = 실행 배선이 실존하는 3개뿐(위임·게이트 결재·에이전트
+ * 모집) — "실행 중단"·"증거 다시 수집"·"STEER 우선순위"는 배선 자체가 없어 no-fiction 원칙상
+ * 인벤토리에 넣지 않는다(dead-path 금지, 후속 스토리로 분리).
+ */
+
+export interface ActionCommandTranslator {
+  (key: string, values?: Record<string, string | number>): string;
+}
+
+export interface StoryContext {
+  storyId: string;
+  storyTitle: string;
+}
+
+export interface ActionCommand {
+  id: string;
+  group: 'action';
+  labelKey: 'actionDelegateStory' | 'actionGateDecision' | 'actionRecruitAgent';
+  label: string;
+  targetRoute: string;
+  impact: string;
+  /** 위험 명령(승인/반려) — 인라인 발사 없음, 게이트 결재 화면 경유가 곧 확인 단계.
+   * amber로만 표시(red는 진짜 kill 전용 — learning-signal 규율). */
+  danger: boolean;
+}
+
+/**
+ * 명령 인벤토리 v1. "이 스토리를 위임"은 story context가 있을 때만 유효한 대상을 가지므로
+ * context 없이는 지어내지 않고 생략한다(no-fiction) — context 있으면 맨 앞에 랭크.
+ * 나머지 2개(게이트 결재·에이전트 모집)는 프로젝트 범위 명령이라 항상 실존.
+ */
+export function buildActionCommands(t: ActionCommandTranslator, context?: StoryContext): ActionCommand[] {
+  const items: ActionCommand[] = [];
+  if (context) {
+    items.push({
+      id: 'action-delegate-story',
+      group: 'action',
+      labelKey: 'actionDelegateStory',
+      label: t('actionDelegateStory', { title: context.storyTitle }),
+      targetRoute: `/board?story=${context.storyId}`,
+      impact: t('actionDelegateStoryImpact', { title: context.storyTitle }),
+      danger: false,
+    });
+  }
+  items.push({
+    id: 'action-gate-decision',
+    group: 'action',
+    labelKey: 'actionGateDecision',
+    label: t('actionGateDecision'),
+    targetRoute: '/inbox?tab=gates',
+    impact: t('actionGateDecisionImpact'),
+    danger: true,
+  });
+  items.push({
+    id: 'action-recruit-agent',
+    group: 'action',
+    labelKey: 'actionRecruitAgent',
+    label: t('actionRecruitAgent'),
+    targetRoute: '/agents/recruiter',
+    impact: t('actionRecruitAgentImpact'),
+    danger: false,
+  });
+  return items;
+}

--- a/apps/web/src/components/command-palette/command-palette.test.tsx
+++ b/apps/web/src/components/command-palette/command-palette.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+//
+// story 4f991165 — ⌘K 액션 확장 회귀가드. 기존 이동/문서검색/키보드 nav 무변경 + 신규 명령 그룹
+// (route-first·context 랭킹·위험 pill·감시 금지)을 실 렌더로 검증(mock 컴포넌트 0).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { CommandPalette } from './command-palette';
+import koMessagesRaw from '../../../messages/ko.json';
+
+type LooseMessages = { [key: string]: string | LooseMessages };
+const koMessages = koMessagesRaw as unknown as LooseMessages;
+
+const pushMock = vi.fn();
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: pushMock }) }));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function stubFetch() {
+  return vi.fn(async (url: string) => {
+    if (url.startsWith('/api/stories/')) {
+      return { ok: true, status: 200, json: async () => ({ data: { id: 's1', title: '웰컴 이메일 시안' } }) };
+    }
+    return { ok: true, status: 200, json: async () => ({ data: [] }) };
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.stubGlobal('fetch', stubFetch());
+  pushMock.mockReset();
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+});
+
+async function mount(props: Partial<React.ComponentProps<typeof CommandPalette>> = {}) {
+  await act(async () => {
+    root.render(
+      <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+        <CommandPalette open onOpenChange={vi.fn()} {...props} />
+      </NextIntlClientProvider>,
+    );
+  });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('CommandPalette — existing navigate/search behavior (regression guard)', () => {
+  it('still renders all 7 navigate destinations with no context (existing behavior untouched)', async () => {
+    await mount();
+    expect(document.body.textContent).toContain('인박스로 이동');
+    expect(document.body.textContent).toContain('보드로 이동');
+    expect(document.body.textContent).toContain('문서로 이동');
+  });
+
+  it('shows no context chip when there is no contextStoryId', async () => {
+    await mount();
+    expect(document.body.textContent).not.toContain('◆');
+  });
+});
+
+describe('CommandPalette — action commands (story 4f991165)', () => {
+  it('without story context, only the 2 project-scoped commands render (delegate omitted — no valid target)', async () => {
+    await mount();
+    expect(document.body.textContent).toContain('게이트 결재하기');
+    expect(document.body.textContent).toContain('에이전트 모집하기');
+    expect(document.body.textContent).not.toContain('위임하기');
+  });
+
+  it('with a contextStoryId, fetches the story title and shows the context chip + delegate command', async () => {
+    await mount({ contextStoryId: 's1' });
+    expect(document.body.textContent).toContain('웰컴 이메일 시안 · 스토리');
+    expect(document.body.textContent).toContain('웰컴 이메일 시안 위임하기');
+  });
+
+  it('flags the gate-decision command as a sensitive/danger pill (amber, not red — learning-signal)', async () => {
+    await mount();
+    expect(document.body.textContent).toContain('위험 명령 · 확인 단계 경유');
+  });
+
+  it('selecting an action command routes (route-first) instead of performing an inline mutation', async () => {
+    await mount();
+    const recruitBtn = [...document.querySelectorAll('button')].find((b) => b.textContent?.includes('에이전트 모집하기'));
+    expect(recruitBtn).toBeDefined();
+    await act(async () => { recruitBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(pushMock).toHaveBeenCalledWith('/agents/recruiter');
+  });
+
+  it('does not render any command execution history/count/recency (surveillance-reframe guard)', async () => {
+    await mount({ contextStoryId: 's1' });
+    expect(document.body.textContent).not.toMatch(/\d+\s*(회|번|분 전|초 전)/);
+  });
+});

--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -9,13 +9,17 @@ import {
   Bot,
   CalendarRange,
   FolderKanban,
+  GitPullRequest,
   Inbox,
   LayoutDashboard,
   MessageSquareMore,
   Search,
+  UserPlus,
+  Users,
   type LucideIcon,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { buildActionCommands, type ActionCommand } from './command-palette-actions';
 
 interface CommandItem {
   id: string;
@@ -33,6 +37,11 @@ interface DocResult {
   icon: string | null;
 }
 
+interface StoryTitleResult {
+  id: string;
+  title: string;
+}
+
 const ITEMS: CommandItem[] = [
   { id: 'go-inbox', group: 'navigate', icon: Inbox, labelKey: 'goInbox', href: '/inbox', shortcut: ['G', 'I'] },
   { id: 'go-dashboard', group: 'navigate', icon: LayoutDashboard, labelKey: 'goDashboard', href: '/dashboard', shortcut: ['G', 'D'] },
@@ -43,26 +52,65 @@ const ITEMS: CommandItem[] = [
   { id: 'go-docs', group: 'navigate', icon: BookOpen, labelKey: 'goDocs', href: '/docs', shortcut: ['G', 'S'] },
 ];
 
+// 명령(action)당 아이콘 — command-palette-actions.ts는 순수 데이터만 다뤄 lucide 컴포넌트를
+// 안 들고 있으므로 여기서 labelKey로 매핑.
+const ACTION_ICONS: Record<ActionCommand['labelKey'], LucideIcon> = {
+  actionDelegateStory: UserPlus,
+  actionGateDecision: GitPullRequest,
+  actionRecruitAgent: Users,
+};
+
 export interface CommandPaletteProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   projectId?: string;
+  /** ⌘K 액션 확장(story 4f991165) — 현재 스토리 상세(`/board?story={id}`)에서 열렸을 때만
+   * 주입. 없으면 "이 스토리를 위임" 명령은 유효한 대상이 없어 인벤토리에서 생략(no-fiction). */
+  contextStoryId?: string;
 }
 
-export function CommandPalette({ open, onOpenChange, projectId }: CommandPaletteProps) {
+export function CommandPalette({ open, onOpenChange, projectId, contextStoryId }: CommandPaletteProps) {
   const router = useRouter();
   const t = useTranslations('commandPalette');
   const [query, setQuery] = useState('');
   const [activeIndex, setActiveIndex] = useState(0);
   const [docResults, setDocResults] = useState<DocResult[]>([]);
+  const [contextStory, setContextStory] = useState<StoryTitleResult | null>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const filtered = useMemo(() => {
+  // context 스토리 제목 lazy 조회 — 열릴 때만, contextStoryId 있을 때만(1콜).
+  useEffect(() => {
+    if (!open || !contextStoryId) { setContextStory(null); return; }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(`/api/stories/${contextStoryId}`);
+        if (!res.ok) return;
+        const json = (await res.json()) as { data?: { id: string; title: string } };
+        if (!cancelled && json.data) setContextStory({ id: json.data.id, title: json.data.title });
+      } catch { /* no-fiction: 조회 실패면 그냥 context 없음과 동일 취급 */ }
+    })();
+    return () => { cancelled = true; };
+  }, [open, contextStoryId]);
+
+  const actionItems = useMemo(
+    () => buildActionCommands(t, contextStory ? { storyId: contextStory.id, storyTitle: contextStory.title } : undefined),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- t는 로케일 불변 함수
+    [contextStory],
+  );
+
+  const filteredNavigate = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return ITEMS;
     return ITEMS.filter((item) => t(item.labelKey).toLowerCase().includes(q));
   }, [query, t]);
+
+  const filteredActions = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return actionItems;
+    return actionItems.filter((item) => item.label.toLowerCase().includes(q));
+  }, [query, actionItems]);
 
   // Docs search with debounce
   useEffect(() => {
@@ -92,12 +140,22 @@ export function CommandPalette({ open, onOpenChange, projectId }: CommandPalette
   // Gate doc results on active query to avoid showing stale results
   const displayedDocResults = useMemo(() => query.trim() ? docResults : [], [query, docResults]);
 
-  // Total items for keyboard navigation: navigate items first, then doc results
-  const totalCount = filtered.length + displayedDocResults.length;
+  // 그룹 순서 — story context 있으면 "이 스토리 명령"이 위로 랭크(doc §3): action 그룹이
+  // navigate 위로. context 없으면 기존 순서 그대로(회귀 0).
+  const sections = useMemo(() => {
+    const groups: Array<{ key: 'navigate' | 'action' | 'doc'; items: CommandItem[] | ActionCommand[] | DocResult[] }> = contextStory
+      ? [{ key: 'action', items: filteredActions }, { key: 'navigate', items: filteredNavigate }, { key: 'doc', items: displayedDocResults }]
+      : [{ key: 'navigate', items: filteredNavigate }, { key: 'action', items: filteredActions }, { key: 'doc', items: displayedDocResults }];
+    let offset = 0;
+    return groups.map((g) => {
+      const start = offset;
+      offset += g.items.length;
+      return { ...g, start };
+    });
+  }, [contextStory, filteredActions, filteredNavigate, displayedDocResults]);
 
-  // Clamp active index to total range during render (avoid cascading effects).
-  const clampedActiveIndex =
-    totalCount === 0 ? 0 : Math.min(Math.max(activeIndex, 0), totalCount - 1);
+  const totalCount = sections.reduce((sum, s) => sum + s.items.length, 0);
+  const clampedActiveIndex = totalCount === 0 ? 0 : Math.min(Math.max(activeIndex, 0), totalCount - 1);
 
   function handleOpenChange(next: boolean) {
     if (!next) {
@@ -113,9 +171,23 @@ export function CommandPalette({ open, onOpenChange, projectId }: CommandPalette
     handleOpenChange(false);
   }
 
+  function handleSelectAction(item: ActionCommand) {
+    router.push(item.targetRoute);
+    handleOpenChange(false);
+  }
+
   function handleSelectDoc(doc: DocResult) {
     router.push(`/docs/${doc.slug}`);
     handleOpenChange(false);
+  }
+
+  function selectAtIndex(index: number) {
+    const section = sections.find((s) => index >= s.start && index < s.start + s.items.length);
+    if (!section) return;
+    const localIndex = index - section.start;
+    if (section.key === 'navigate') handleSelectNav(section.items[localIndex] as CommandItem);
+    else if (section.key === 'action') handleSelectAction(section.items[localIndex] as ActionCommand);
+    else handleSelectDoc(section.items[localIndex] as DocResult);
   }
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
@@ -127,18 +199,11 @@ export function CommandPalette({ open, onOpenChange, projectId }: CommandPalette
       setActiveIndex(Math.max(0, clampedActiveIndex - 1));
     } else if (event.key === 'Enter') {
       event.preventDefault();
-      if (clampedActiveIndex < filtered.length) {
-        const item = filtered[clampedActiveIndex];
-        if (item) handleSelectNav(item);
-      } else {
-        const doc = displayedDocResults[clampedActiveIndex - filtered.length];
-        if (doc) handleSelectDoc(doc);
-      }
+      selectAtIndex(clampedActiveIndex);
     }
   }
 
-  const navigateItems = filtered.filter((item) => item.group === 'navigate');
-  const hasResults = navigateItems.length > 0 || displayedDocResults.length > 0;
+  const hasResults = totalCount > 0;
 
   return (
     <DialogPrimitive.Root open={open} onOpenChange={handleOpenChange}>
@@ -176,33 +241,58 @@ export function CommandPalette({ open, onOpenChange, projectId }: CommandPalette
             </DialogPrimitive.Close>
           </div>
 
+          {contextStory ? (
+            <div className="flex items-center gap-1.5 border-b border-border/60 bg-muted/30 px-3 py-1.5 text-[11px] text-muted-foreground">
+              <span className="text-info" aria-hidden="true">◆</span>
+              {t('contextChip', { title: contextStory.title })}
+            </div>
+          ) : null}
+
           <div ref={listRef} className="max-h-80 overflow-y-auto p-2">
             {!hasResults ? (
               <div className="px-3 py-6 text-center text-sm text-muted-foreground">
                 {t('noResults')}
               </div>
             ) : (
-              <>
-                {navigateItems.length > 0 && (
-                  <CommandGroup
-                    label={t('navigate')}
-                    items={navigateItems}
-                    activeIndex={clampedActiveIndex}
-                    filteredItems={filtered}
-                    onSelect={handleSelectNav}
-                    t={t}
-                  />
-                )}
-                {displayedDocResults.length > 0 && (
+              sections.map((section) => {
+                if (section.items.length === 0) return null;
+                if (section.key === 'navigate') {
+                  return (
+                    <CommandGroup
+                      key="navigate"
+                      label={t('navigate')}
+                      items={section.items as CommandItem[]}
+                      activeIndex={clampedActiveIndex}
+                      start={section.start}
+                      onSelect={handleSelectNav}
+                      t={t}
+                    />
+                  );
+                }
+                if (section.key === 'action') {
+                  return (
+                    <ActionGroup
+                      key="action"
+                      label={t('actions')}
+                      items={section.items as ActionCommand[]}
+                      activeIndex={clampedActiveIndex}
+                      start={section.start}
+                      onSelect={handleSelectAction}
+                      dangerPillLabel={t('actionDangerPill')}
+                    />
+                  );
+                }
+                return (
                   <DocGroup
+                    key="doc"
                     label={t('documents')}
-                    docs={displayedDocResults}
-                    activeIndexOffset={filtered.length}
+                    docs={section.items as DocResult[]}
+                    activeIndexOffset={section.start}
                     activeIndex={clampedActiveIndex}
                     onSelect={handleSelectDoc}
                   />
-                )}
-              </>
+                );
+              })
             )}
           </div>
         </DialogPrimitive.Popup>
@@ -214,31 +304,27 @@ export function CommandPalette({ open, onOpenChange, projectId }: CommandPalette
 interface CommandGroupProps {
   label: string;
   items: CommandItem[];
-  filteredItems: CommandItem[];
+  start: number;
   activeIndex: number;
   onSelect: (item: CommandItem) => void;
   t: (key: string) => string;
 }
 
-function CommandGroup({ label, items, filteredItems, activeIndex, onSelect, t }: CommandGroupProps) {
+function CommandGroup({ label, items, start, activeIndex, onSelect, t }: CommandGroupProps) {
   return (
     <div className="flex flex-col">
       <div className="px-2 pt-1.5 pb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
         {label}
       </div>
       <ul className="flex flex-col">
-        {items.map((item) => {
-          const idx = filteredItems.indexOf(item);
-          const active = idx === activeIndex;
+        {items.map((item, i) => {
+          const active = start + i === activeIndex;
           const Icon = item.icon;
           return (
             <li key={item.id}>
               <button
                 type="button"
                 onClick={() => onSelect(item)}
-                onMouseEnter={() => {
-                  /* hover does not change activeIndex to avoid mouse/keyboard fight */
-                }}
                 className={cn(
                   'flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm transition-colors',
                   active ? 'bg-accent text-accent-foreground' : 'text-foreground hover:bg-accent/60',
@@ -260,6 +346,63 @@ function CommandGroup({ label, items, filteredItems, activeIndex, onSelect, t }:
                   </span>
                 ) : null}
               </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+interface ActionGroupProps {
+  label: string;
+  items: ActionCommand[];
+  start: number;
+  activeIndex: number;
+  onSelect: (item: ActionCommand) => void;
+  dangerPillLabel: string;
+}
+
+/**
+ * 명령(action) 그룹(story 4f991165) — route-first: 선택하면 인라인 뮤테이션이 아니라 맥락
+ * 세팅된 실존 표면으로 딥링크만 한다. 활성 항목 아래에 영향 범위 프리뷰(약속 언어)를 렌더 —
+ * 위험 명령(승인/반려)은 amber pill로만 표시(red는 진짜 kill 전용, learning-signal 규율).
+ * 감시 금지: 명령 실행 이력/횟수/최근 사용 시각을 렌더하지 않는다.
+ */
+function ActionGroup({ label, items, start, activeIndex, onSelect, dangerPillLabel }: ActionGroupProps) {
+  return (
+    <div className="flex flex-col">
+      <div className="px-2 pt-1.5 pb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        {label}
+      </div>
+      <ul className="flex flex-col">
+        {items.map((item, i) => {
+          const active = start + i === activeIndex;
+          const Icon = ACTION_ICONS[item.labelKey];
+          return (
+            <li key={item.id}>
+              <button
+                type="button"
+                onClick={() => onSelect(item)}
+                className={cn(
+                  'flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm transition-colors',
+                  active ? 'bg-accent text-accent-foreground' : 'text-foreground hover:bg-accent/60',
+                )}
+                data-active={active || undefined}
+              >
+                <Icon className="size-4 shrink-0 text-muted-foreground" />
+                <span className="flex-1 truncate">{item.label}</span>
+                {item.danger ? (
+                  <span className="ml-auto shrink-0 rounded border border-warning/40 bg-warning/10 px-1.5 py-0.5 text-[9px] font-semibold text-warning">
+                    {dangerPillLabel}
+                  </span>
+                ) : null}
+              </button>
+              {active ? (
+                <p className="ml-8 mr-2 border-l-2 border-info/40 py-1 pl-2 text-[11px] leading-snug text-muted-foreground">
+                  {item.impact}
+                </p>
+              ) : null}
             </li>
           );
         })}

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import {
   BookOpen,
@@ -70,8 +70,11 @@ export function AppSidebar({
   userName,
 }: AppSidebarProps) {
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const t = useTranslations('nav');
   const { isMobile, setOpenMobile } = useSidebar();
+  // ⌘K 액션 확장(story 4f991165) — 스토리 상세(`/board?story={id}`)에서 열렸을 때만 context 주입.
+  const contextStoryId = pathname === '/board' ? (searchParams.get('story') ?? undefined) : undefined;
 
   // 4dad38d3: 모바일 nav 아이템 선택 후 드로어 auto-close. route 변경 시 닫는다(전 아이템 DRY 커버).
   // 데스크탑은 isMobile 가드로 no-op·백드롭 탭 닫기(Sheet onOpenChange)는 무영향.
@@ -390,7 +393,7 @@ export function AppSidebar({
       </SidebarFooter>
 
       <SidebarRail />
-      <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} projectId={projectId} />
+      <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} projectId={projectId} contextStoryId={contextStoryId} />
     </Sidebar>
   );
 }


### PR DESCRIPTION
## 변경 사항
story `4f991165` — ⌘K 팔레트에 이동/문서검색과 나란히 **명령(action) 그룹**을 신설.

- `command-palette-actions.ts`: 순수 `buildActionCommands(t, context?)` — v1 인벤토리는 실행 배선이 실존하는 3개(위임/게이트 결재/에이전트 모집)뿐. "실행 중단"·"증거 다시 수집"·"STEER 우선순위"는 배선 자체가 없어 no-fiction 원칙상 넣지 않음(dead-path 금지, 후속 스토리 분리 대상)
- "이 스토리를 위임" 명령은 `contextStoryId`(=`/board?story={id}`에서 열렸을 때만)가 있을 때만 유효한 대상을 가지므로, 없을 땐 지어내지 않고 생략
- 게이트 결재(→`/inbox?tab=gates`)·에이전트 모집(→`/agents/recruiter`)은 프로젝트 범위 상시 명령
- 전부 **route-first**: 선택해도 인라인 뮤테이션 없음, 기존 실존 표면으로 push만 (action-zone.tsx 선례와 동일 원칙)
- 위험 명령(승인/반려)은 amber pill로만 표시 — red는 진짜 kill 전용(learning-signal 규율)
- story context 있으면 action 그룹이 navigate 위로 랭크 + 상단 context chip 노출
- `app-sidebar.tsx`: `useSearchParams()`로 `/board?story={id}` 경로일 때만 `contextStoryId` 계산해 주입

## 테스트
- 순수 로직 6건(`command-palette-actions.test.ts`) — 이미 이전 커밋에서 그린
- 컴포넌트 회귀가드 7건(`command-palette.test.tsx`, 신규) — 기존 이동/문서검색 무변경 확인 포함, context 유무별 렌더, danger pill, route-first 클릭, 감시 금지(이력/횟수/최근시각 미노출) 가드
- 전체 `pnpm vitest run`: **1305 passed | 2 skipped**, 회귀 0
- `tsc --noEmit`: clean
- `eslint`: 0 warning
- `pnpm build`: EXIT=0

## 반응형/스크린샷
드롭다운형 오버레이 컴포넌트 — 기존 CommandPalette 레이아웃 그대로 재사용(변경 없음), 신규 시각요소(danger pill/context chip/impact preview)는 base-ui Dialog popup 내부 텍스트 레이어이며 뷰포트 breakpoint 분기 없음.