### PR TITLE
[SID:385eb89a] 산출물 뷰어 가로 오버플로 대책 — html 고정폭 잘림 해소

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3557,6 +3557,8 @@
     "galleryAnchorPill": "Anchor v{version}",
     "galleryLatestChip": "Up to v{version}",
     "galleryLazyHint": "Expanding loads earlier versions.",
-    "galleryVersionsUnavailable": "Couldn't load earlier versions."
+    "galleryVersionsUnavailable": "Couldn't load earlier versions.",
+    "viewerFitToggleFit": "Fit to view",
+    "viewerFitToggleActual": "Actual size"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3557,6 +3557,8 @@
     "galleryAnchorPill": "정본 v{version}",
     "galleryLatestChip": "v{version}까지",
     "galleryLazyHint": "펼치면 이전 버전을 불러옵니다",
-    "galleryVersionsUnavailable": "이전 버전을 불러올 수 없습니다"
+    "galleryVersionsUnavailable": "이전 버전을 불러올 수 없습니다",
+    "viewerFitToggleFit": "전체 보기",
+    "viewerFitToggleActual": "실제 크기"
   }
 }

--- a/apps/web/src/components/canvas/artifact-stage.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.tsx
@@ -1,5 +1,17 @@
+import { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import type { ArtifactFormat } from '@/services/canvas';
+
+/**
+ * story 385eb89a — 고정 넓이 html_blob 잘림 대책. sandbox=""(allow-same-origin 없음)라 iframe
+ * 내부 문서 폭을 측정할 수 없어(cross-origin) 실 콘텐츠 폭을 알 방법이 없다 — 대신 iframe 자체
+ * 박스를 이 고정 "캔버스" 폭으로 렌더해 내용이 접히지 않게 하고, wrapper가 스크롤(실제 크기)
+ * 하거나 wrapper 자기 자신의 폭(우리가 소유한 DOM이라 측정 가능)에 맞춰 transform:scale로
+ * 축소(전체 보기)한다 — html_blob 내부 측정은 여전히 0(보안 트레이드오프 유지, canvas-export.ts
+ * §PNG export 제외 결정과 동일 원칙).
+ */
+const HTML_STAGE_WIDTH = 1200;
+const HTML_STAGE_HEIGHT = 280;
 
 /**
  * E-CANVAS C1 — tree 포맷 최소 노드 shape. BE 계약(디디 C1-S3) 착지 전 잠정 — 실 계약이
@@ -44,6 +56,8 @@ interface ArtifactStageProps {
   format: ArtifactFormat;
   content: string;
   title: string;
+  /** html 포맷 전체보기(fit) 토글 — tree/image는 이 prop을 무시(토글 자체가 미노출). */
+  fitToView?: boolean;
 }
 
 /**
@@ -53,17 +67,44 @@ interface ArtifactStageProps {
  * 잠금이 안전(CSS 렌더링은 sandbox 플래그와 무관하게 항상 동작함)·image=바운드 img·
  * tree=경량 노드 렌더(전신 componentCatalog의 리치 렌더는 후속 — 지금은 shell 준비 단계).
  */
-export function ArtifactStage({ format, content, title }: ArtifactStageProps) {
+export function ArtifactStage({ format, content, title, fitToView = false }: ArtifactStageProps) {
   const t = useTranslations('canvas');
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [fitRatio, setFitRatio] = useState(1);
+
+  useEffect(() => {
+    if (format !== 'html' || !fitToView) return;
+    const el = wrapperRef.current;
+    if (!el) return;
+    const measure = () => setFitRatio(Math.min(1, el.clientWidth / HTML_STAGE_WIDTH));
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [format, fitToView]);
 
   if (format === 'html') {
     return (
-      <iframe
-        title={title}
-        srcDoc={content}
-        sandbox=""
-        className="h-full min-h-[280px] w-full rounded-lg border border-border bg-background"
-      />
+      <div
+        ref={wrapperRef}
+        className="w-full rounded-lg border border-border bg-background"
+        style={fitToView
+          ? { height: HTML_STAGE_HEIGHT * fitRatio, overflow: 'hidden' }
+          : { overflowX: 'auto' }}
+      >
+        <iframe
+          title={title}
+          srcDoc={content}
+          sandbox=""
+          className="rounded-lg"
+          style={{
+            width: HTML_STAGE_WIDTH,
+            height: HTML_STAGE_HEIGHT,
+            transform: fitToView ? `scale(${fitRatio})` : undefined,
+            transformOrigin: 'top left',
+          }}
+        />
+      </div>
     );
   }
 

--- a/apps/web/src/components/canvas/artifact-viewer.test.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.test.tsx
@@ -3,7 +3,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
 import { ArtifactViewer } from './artifact-viewer';
-import { MOCK_ARTIFACT, MOCK_VERSIONS, MOCK_MEMBERS } from '@/services/canvas';
+import { MOCK_ARTIFACT, MOCK_EDITABLE_ARTIFACT, MOCK_VERSIONS, MOCK_MEMBERS } from '@/services/canvas';
 import { MOCK_THREADS } from '@/services/canvas-comments';
 
 function wrap(node: React.ReactNode) {
@@ -90,5 +90,36 @@ describe('ArtifactViewer (SSR snapshot)', () => {
     );
     expect(markup).not.toContain('정본으로 제안');
     expect(markup).not.toContain('정본 제안 대기 중');
+  });
+
+  describe('story 385eb89a — 고정 넓이 html 잘림 대책', () => {
+    it('renders the html stage bounded to a fixed canvas width instead of forcing 100%(잘림 원인 제거)', () => {
+      const markup = renderToStaticMarkup(
+        wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+      );
+      expect(markup).toContain('width:1200px');
+    });
+
+    it('shows the fit/actual-size toggle only for html format', () => {
+      const htmlMarkup = renderToStaticMarkup(
+        wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+      );
+      expect(htmlMarkup).toContain('전체 보기');
+      expect(htmlMarkup).toContain('실제 크기');
+
+      const treeMarkup = renderToStaticMarkup(
+        wrap(<ArtifactViewer artifact={MOCK_EDITABLE_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+      );
+      expect(treeMarkup).not.toContain('전체 보기');
+      expect(treeMarkup).not.toContain('실제 크기');
+    });
+
+    it('tree format render is unaffected (회귀 0 — placeholder path untouched)', () => {
+      const markup = renderToStaticMarkup(
+        wrap(<ArtifactViewer artifact={MOCK_EDITABLE_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+      );
+      expect(markup).toContain('트리 렌더는 준비 중');
+      expect(markup).not.toContain('width:1200px');
+    });
   });
 });

--- a/apps/web/src/components/canvas/artifact-viewer.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.tsx
@@ -51,6 +51,7 @@ export function ArtifactViewer({
 }: ArtifactViewerProps) {
   const t = useTranslations('canvas');
   const [selectedVersion, setSelectedVersion] = useState(artifact.current_version);
+  const [fitToView, setFitToView] = useState(false);
   const isViewingAnchor = selectedVersion === artifact.anchor_version;
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
   const [exportOpen, setExportOpen] = useState(false);
@@ -79,6 +80,28 @@ export function ArtifactViewer({
               <option key={v.id} value={v.version}>v{v.version}</option>
             ))}
           </select>
+          {/* story 385eb89a v1+ — 고정 넓이 html 전용 전체보기/실제크기 토글. tree/image는
+           * 이미 컨테이너에 맞춰 렌더돼 토글 자체가 무의미해 노출하지 않는다. */}
+          {artifact.format === 'html' ? (
+            <div className="flex items-center rounded-md border border-border text-[11px] font-medium text-muted-foreground">
+              <button
+                type="button"
+                onClick={() => setFitToView(true)}
+                aria-pressed={fitToView}
+                className={`rounded-l-md px-1.5 py-0.5 ${fitToView ? 'bg-accent text-accent-foreground' : 'hover:bg-muted'}`}
+              >
+                {t('viewerFitToggleFit')}
+              </button>
+              <button
+                type="button"
+                onClick={() => setFitToView(false)}
+                aria-pressed={!fitToView}
+                className={`rounded-r-md px-1.5 py-0.5 ${!fitToView ? 'bg-accent text-accent-foreground' : 'hover:bg-muted'}`}
+              >
+                {t('viewerFitToggleActual')}
+              </button>
+            </div>
+          ) : null}
           {artifact.anchor_version != null ? (
             <span className="inline-flex items-center gap-1 text-[11px] font-semibold text-success/85">
               <Check className="h-3 w-3" strokeWidth={2.6} aria-hidden />
@@ -133,10 +156,10 @@ export function ArtifactViewer({
           </span>
         </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-[1fr_232px]">
-          <div ref={captureTargetRef} className="relative bg-muted/20 p-4">
+        <div className="grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_232px]">
+          <div ref={captureTargetRef} className="relative min-w-0 bg-muted/20 p-4">
             {activeVersion ? (
-              <ArtifactStage format={artifact.format} content={activeVersion.content} title={artifact.title} />
+              <ArtifactStage format={artifact.format} content={activeVersion.content} title={artifact.title} fitToView={fitToView} />
             ) : null}
             {/* C2 §1 — 좌표 앵커 스레드만 오버레이(element 앵커는 실 artifact tree 좌표 유도 필요, 후속). */}
             {threads?.filter((th) => th.anchor.kind === 'coordinate').map((th) => (


### PR DESCRIPTION
## 변경 사항
story `385eb89a` — 선생님 직접 지적 건(prod/dev 스크린샷, 뷰어에서 고정 넓이 html 목업 우측이 잘림). 설계 SSOT: 유나 doc `artifact-viewer-overflow-spec`.

**스코프 = html iframe만**(image/tree는 대상 밖, 무변경).

- `ArtifactStage`(스토리 상세 `ArtifactSection`이 소비하는 공유 컴포넌트)의 html 분기: iframe을 `w-full`(뷰포트 폭에 강제로 눌림) 대신 고정 "캔버스" 폭(1200px)으로 렌더 — 콘텐츠가 안 접히게 하고, wrapper가 `overflow-x: auto`로 가로 스크롤 제공(**v1**)
- `ArtifactViewer`의 그리드 `1fr` 트랙을 `minmax(0,1fr)` + 자식 `min-w-0`으로 — 클래식 CSS grid 오버플로 함정(그리드 트랙 `min-width: auto` 기본값이 콘텐츠 크기로 트랙을 밀어붙이는 문제) 봉쇄. 이게 없으면 wrapper의 `overflow-x:auto`가 실제로 트리거되지 않음
- 툴바 "전체 보기(fit) ↔ 실제 크기(100%)" 토글(**v1+**): fit = wrapper 자기 폭(우리가 소유한 DOM이라 측정 가능) 대비 `transform: scale(fitRatio)`, `fitRatio ≤ 1`로 클램프(확대 없음)
- html_blob **내부** 콘텐츠 폭은 `sandbox=""`(allow-same-origin 없음) 특성상 cross-origin이라 측정 불가 — 측정을 시도하지 않고 wrapper 자기 폭만 사용. `canvas-export.ts`가 PNG export에서 이미 "sandbox 완화는 선택지에서 제외"로 판단한 것과 동일 보안 기준 유지(이번에도 완화 안 함)
- image/tree 포맷은 분기 자체를 안 건드림(회귀 0 축), 토글도 html에서만 노출
- Figma식 space+drag pan은 스펙대로 이 PR에 얹지 않음(후속 defer)

## 정직 고지
"갤러리 펼침 뷰어" 표면은 그라운딩 결과 **현재 `ArtifactStage`를 전혀 렌더하지 않음**(갤러리 펼침은 lazy 변천사 타임라인만 렌더, 실제 콘텐츠 프리뷰 없음). `ArtifactStage`는 공유 컴포넌트라 그 표면이 생기면 자동 커버되지만, 지금 시점엔 적용 대상 자체가 없어 별도 배선을 얹지 않았습니다.

## 테스트
- SSR 마크업 회귀가드 3건 추가(`artifact-viewer.test.tsx`): 고정폭(1200px) 렌더 확인·포맷별 토글 노출(html만)·tree 포맷 완전 무변경
- 전체 `pnpm vitest run`: **1295 passed | 2 skipped**, 회귀 0
- `tsc --noEmit`: clean
- `eslint`: 0 warning
- `pnpm build`: EXIT=0

## 반응형/스크린샷
텍스트/로직 검증은 SSR 마크업으로 커버. 실제 클리핑 해소 여부(가로 스크롤 동작·fit 토글 스케일)는 라이브 픽셀에서만 확실히 검증 가능한 영역이라, dev 배포 후 오르테가군 라이브 done-gate에서 실측 예정.