### PR TITLE
[SID:ca37b2b0] 산출물 갤러리 에픽 축 전부 무소속 fix — 스토리 경유 1홉 유도

### DIFF
--- a/apps/web/src/components/canvas/artifact-gallery-view.test.tsx
+++ b/apps/web/src/components/canvas/artifact-gallery-view.test.tsx
@@ -98,6 +98,27 @@ describe('ArtifactGalleryView (story a15cea4f)', () => {
     expect(container.textContent).not.toContain('m1');
   });
 
+  // story ca37b2b0 — dev 실데이터 재현: 산출물은 story_id만 있고 epic_id는 NULL(에이전트 저작
+  // 산출물 기본형). story 경유 유도가 없으면 에픽 탭이 전건 무소속으로 떨어지던 근본원인.
+  it('resolves the epic through the artifact\'s story when the artifact has no direct epic_id (스토리 경유 유도)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.startsWith('/api/visual-artifacts/')) return jsonRes([]);
+      if (url.startsWith('/api/visual-artifacts')) return jsonRes([
+        { id: 'a1', title: '스토리 앵커 산출물', story_id: 's1', epic_id: null, doc_id: null, source: 'created', latest_version_number: 1, anchor_version: null, created_by: 'm1', created_at: '2026-07-01T00:00:00Z' },
+      ]);
+      if (url.startsWith('/api/epics')) return jsonRes([{ id: 'e1', title: '온보딩 캠페인' }]);
+      if (url.startsWith('/api/stories')) return jsonRes([{ id: 's1', title: '웰컴 이메일 스토리', sprint_id: null, epic_id: 'e1' }]);
+      if (url.startsWith('/api/sprints')) return jsonRes([]);
+      if (url.startsWith('/api/docs')) return jsonRes([]);
+      return jsonRes(null);
+    }) as unknown as typeof fetch);
+    await mount();
+    expect(container.textContent).toContain('온보딩 캠페인');
+    expect(container.textContent).toContain('스토리 앵커 산출물');
+    // 스토리 경유로 해소됐으니 무소속 그룹 자체가 없어야 한다.
+    expect(container.textContent).not.toContain('무소속');
+  });
+
   it('renders the empty state when the project has no artifacts at all', async () => {
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
       if (url.startsWith('/api/visual-artifacts')) return jsonRes([]);

--- a/apps/web/src/components/canvas/artifact-gallery-view.tsx
+++ b/apps/web/src/components/canvas/artifact-gallery-view.tsx
@@ -23,7 +23,7 @@ async function fetchJson<T>(url: string): Promise<T | null> {
   }
 }
 
-interface StoryListItem { id: string; title: string; sprint_id: string | null }
+interface StoryListItem { id: string; title: string; sprint_id: string | null; epic_id: string | null }
 interface EpicListItem { id: string; title: string }
 interface SprintListItem { id: string; title: string }
 interface DocListItem { id: string; title: string }
@@ -42,7 +42,7 @@ async function fetchGalleryData(projectId: string): Promise<{ artifacts: BeVisua
     artifacts: artifacts ?? [],
     lookups: {
       epics: (epics ?? []).map((e) => ({ id: e.id, title: e.title })),
-      stories: (stories ?? []).map((s) => ({ id: s.id, title: s.title, sprint_id: s.sprint_id })),
+      stories: (stories ?? []).map((s) => ({ id: s.id, title: s.title, sprint_id: s.sprint_id, epic_id: s.epic_id })),
       sprints: (sprints ?? []).map((s) => ({ id: s.id, title: s.title })),
       docs: (docs ?? []).map((d) => ({ id: d.id, title: d.title })),
     },

--- a/apps/web/src/services/artifact-gallery.test.ts
+++ b/apps/web/src/services/artifact-gallery.test.ts
@@ -15,8 +15,8 @@ function artifact(overrides: Partial<BeVisualArtifactSummary> = {}): BeVisualArt
 const lookups: GalleryLookups = {
   epics: [{ id: 'e1', title: '온보딩 캠페인' }, { id: 'e2', title: '브랜드 리뉴얼' }],
   stories: [
-    { id: 's1', title: '웰컴 이메일', sprint_id: 'sp1' },
-    { id: 's2', title: '랜딩 히어로', sprint_id: null },
+    { id: 's1', title: '웰컴 이메일', sprint_id: 'sp1', epic_id: 'e2' },
+    { id: 's2', title: '랜딩 히어로', sprint_id: null, epic_id: null },
   ],
   sprints: [{ id: 'sp1', title: 'Sprint 24' }, { id: 'sp2', title: 'Sprint 23' }],
   docs: [{ id: 'd1', title: '브랜드 가이드' }],
@@ -48,6 +48,28 @@ describe('buildGalleryGroups — epic axis', () => {
     ], lookups, UNASSIGNED);
     expect(groups.at(-1)).toEqual(expect.objectContaining({ id: 'unassigned', label: UNASSIGNED, unassigned: true }));
     expect(groups.at(-1)!.artifacts).toHaveLength(2);
+  });
+
+  // story ca37b2b0 — dev 실데이터 전건 artifact.epic_id NULL(story_id는 실림)이라 에픽 탭이
+  // 구조적으로 영구 무소속이던 근본원인 회귀가드. 스프린트 축과 동일 수법(1홉 join).
+  it('resolves the epic through the artifact\'s story when epic_id is not set directly (스토리 경유 유도)', () => {
+    const groups = buildGalleryGroups('epic', [artifact({ story_id: 's1', epic_id: null })], lookups, UNASSIGNED);
+    expect(groups).toEqual([expect.objectContaining({ id: 'e2', label: '브랜드 리뉴얼' })]);
+  });
+
+  it('prefers a directly-set epic_id over the story-mediated one when both exist', () => {
+    const groups = buildGalleryGroups('epic', [artifact({ story_id: 's1', epic_id: 'e1' })], lookups, UNASSIGNED);
+    expect(groups).toEqual([expect.objectContaining({ id: 'e1', label: '온보딩 캠페인' })]);
+  });
+
+  it('is unassigned when neither the artifact nor its story has an epic (스토리도 무소속 에픽)', () => {
+    const groups = buildGalleryGroups('epic', [artifact({ story_id: 's2', epic_id: null })], lookups, UNASSIGNED);
+    expect(groups).toEqual([expect.objectContaining({ id: 'unassigned', unassigned: true })]);
+  });
+
+  it('is unassigned when the artifact has no story_id at all (independent artifact, no epic to derive)', () => {
+    const groups = buildGalleryGroups('epic', [artifact({ story_id: null, epic_id: null })], lookups, UNASSIGNED);
+    expect(groups).toEqual([expect.objectContaining({ id: 'unassigned', unassigned: true })]);
   });
 });
 

--- a/apps/web/src/services/artifact-gallery.ts
+++ b/apps/web/src/services/artifact-gallery.ts
@@ -34,6 +34,7 @@ interface StoryRef {
   id: string;
   title: string;
   sprint_id: string | null;
+  epic_id: string | null;
 }
 
 export interface GalleryLookups {
@@ -75,8 +76,11 @@ function groupBy(
 }
 
 /**
- * 축별 그룹핑. 스프린트만 간접(artifact.story_id → Story.sprint_id 1홉, FE join) — 나머지는
- * artifact의 직접 FK. story_id가 NULL이거나 해당 story의 sprint_id가 NULL이면 무소속.
+ * 축별 그룹핑. 에픽·스프린트는 간접 유도(artifact.story_id → Story.epic_id/sprint_id 1홉,
+ * FE join) — 에이전트/휴먼 저작 산출물은 항상 스토리에 앵커되고 artifact.epic_id를 직접
+ * 지정하는 경우가 드물어(story ca37b2b0 — dev 실데이터 전건 epic_id NULL), 직접 FK를
+ * 우선하되 없으면 스토리 경유로 유도한다. doc/story 축은 artifact의 직접 FK만(스토리 경유가
+ * 의미 없음). story_id가 NULL이거나 해당 story의 epic_id/sprint_id가 NULL이면 무소속.
  */
 export function buildGalleryGroups(
   axis: GalleryAxis,
@@ -84,11 +88,18 @@ export function buildGalleryGroups(
   lookups: GalleryLookups,
   unassignedLabel: string,
 ): GalleryGroup[] {
-  if (axis === 'epic') return groupBy(artifacts, lookups.epics, (a) => a.epic_id, unassignedLabel);
   if (axis === 'doc') return groupBy(artifacts, lookups.docs, (a) => a.doc_id, unassignedLabel);
   if (axis === 'story') {
     const storyRefs: EntityRef[] = lookups.stories.map((s) => ({ id: s.id, title: s.title }));
     return groupBy(artifacts, storyRefs, (a) => a.story_id, unassignedLabel);
+  }
+  if (axis === 'epic') {
+    const epicIdByStoryId = new Map(lookups.stories.map((s) => [s.id, s.epic_id]));
+    return groupBy(
+      artifacts, lookups.epics,
+      (a) => a.epic_id ?? (a.story_id ? epicIdByStoryId.get(a.story_id) ?? null : null),
+      unassignedLabel,
+    );
   }
   // sprint: story_id → sprint_id 1홉 join.
   const sprintIdByStoryId = new Map(lookups.stories.map((s) => [s.id, s.sprint_id]));


### PR DESCRIPTION
## 변경 사항
story `ca37b2b0` — 선생님 dev 실사용 지적(산출물 메뉴 에픽 탭 6건 전부 "무소속").

**근본원인(PO 라이브 실측 확定)**: dev 산출물 전건 `story_id`는 실리고 `epic_id`는 전부 NULL. 에이전트/휴먼 저작 산출물은 스토리에 앵커되는 게 기본형이라, `buildGalleryGroups`의 에픽 축이 `artifact.epic_id` 직접 FK만 읽으면 구조적으로 영구 무소속(스프린트 축은 이미 `story_id→sprint_id` 1홉 join을 하고 있었는데 에픽 축만 이 유도가 빠져 있었음).

## 구현
- 에픽 keyOf = `artifact.epic_id`(직접 지정 시 우선) `??` `epicIdByStoryId.get(artifact.story_id)`(스토리 경유 유도) — 스프린트 축과 동일 수법
- `StoryRef`에 `epic_id` 추가, `artifact-gallery-view.tsx`의 stories fetch가 픽업하도록 배선
- **실측 후 배선**(가짜 배선 금지 원칙): `/api/v2/stories` GET 응답이 실제로 `epic_id`를 싣는지 `packages/core-storage/src/interfaces/IStoryRepository.ts`의 `Story` 인터페이스로 확인 — `ApiStoryRepository`가 BE를 그대로 패스스루하므로 실 필드
- doc/story 축은 무변경(스토리 경유가 의미 없는 직접 FK), 스프린트 축도 무변경(회귀 0)

## 테스트
- 순수 로직 3건 추가(`artifact-gallery.test.ts`): 직접 epic_id 우선·스토리 경유 유도·둘 다 없으면 무소속
- 컴포넌트 회귀가드 1건 추가(`artifact-gallery-view.test.tsx`): dev 실데이터 재현(story_id만 있고 epic_id NULL) — 무소속 그룹 자체가 안 뜨고 실 에픽 그룹으로 표기됨을 확인
- 전체 `pnpm vitest run`: **1313 passed | 2 skipped**, 회귀 0
- `tsc --noEmit`: clean
- `eslint`: 0 warning
- `pnpm build`: EXIT=0

## 반응형/스크린샷
텍스트/그룹핑 로직 변경(레이아웃 무변경) — 실제 에픽 탭 실그룹 표기는 라이브 픽셀에서만 확실히 검증 가능한 영역이라, dev 배포 후 오르테가군 라이브 done-gate에서 실측 예정.