### PR TITLE
[SID:d425dccc] 산출물 뷰어 v2 — space+드래그 pan + "크게 보기" 확대 뷰

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3566,7 +3566,7 @@
     "galleryLatestChip": "Up to v{version}",
     "galleryLazyHint": "Expanding loads earlier versions.",
     "galleryVersionsUnavailable": "Couldn't load earlier versions.",
-    "viewerFitToggleFit": "Fit to view",
-    "viewerFitToggleActual": "Actual size"
+    "viewerExpandAction": "Expand view",
+    "viewerPanHint": "Hold space and drag to pan"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3566,7 +3566,7 @@
     "galleryLatestChip": "v{version}까지",
     "galleryLazyHint": "펼치면 이전 버전을 불러옵니다",
     "galleryVersionsUnavailable": "이전 버전을 불러올 수 없습니다",
-    "viewerFitToggleFit": "전체 보기",
-    "viewerFitToggleActual": "실제 크기"
+    "viewerExpandAction": "크게 보기",
+    "viewerPanHint": "스페이스를 누른 채 드래그하면 이동합니다"
   }
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -423,6 +423,13 @@
   *::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 3px; }
   *::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); }
 
+  /* story d425dccc — 산출물 뷰어 가로 스크롤바 상시 가시화. 앱 전역 스크롤바(6px·10% 불투명
+   * thumb)는 macOS에서 낮은 대비로 "스크롤 자체가 없다"는 오인을 낳았다(선생님 실사용 지적) —
+   * 이 스테이지만 더 두껍고 고대비인 thumb으로 발견성을 높인다. */
+  [data-artifact-stage-scroll]::-webkit-scrollbar { width: 10px; height: 10px; }
+  [data-artifact-stage-scroll]::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb-hover); border-radius: 5px; }
+  [data-artifact-stage-scroll] { scrollbar-width: auto; }
+
   html {
     @apply font-sans;
     text-autospace: ideograph-alpha ideograph-numeric;

--- a/apps/web/src/components/canvas/artifact-stage.test.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+//
+// story d425dccc — space+드래그 pan 실동작 회귀가드. jsdom은 CSS pointer-events를 실제로
+// hit-test하지 않으므로(스타일 강제 무관하게 합성 이벤트가 그대로 전달됨), space 미보유 시
+// 드래그를 막는 JS 가드(`if (!spaceHeld) return`)가 실제 방어선임을 직접 검증한다.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { ArtifactStage } from './artifact-stage';
+import koMessages from '../../../messages/ko.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+async function mount() {
+  await act(async () => {
+    root.render(wrap(<ArtifactStage format="html" content="<div>hi</div>" title="t" />));
+  });
+}
+
+function press(el: EventTarget, type: string, init: MouseEventInit | KeyboardEventInit = {}) {
+  const Ctor = type.startsWith('key') ? KeyboardEvent : MouseEvent;
+  el.dispatchEvent(new Ctor(type, { bubbles: true, cancelable: true, ...init }));
+}
+
+describe('ArtifactStage — html space+drag pan', () => {
+  it('dragging the overlay without space held does not move the scroll container (JS guard, not just CSS)', async () => {
+    await mount();
+    const wrapperEl = container.querySelector('[data-artifact-stage-scroll]') as HTMLDivElement;
+    const overlay = container.querySelector('[data-pan-overlay]') as HTMLDivElement;
+    Object.defineProperty(wrapperEl, 'scrollLeft', { value: 0, writable: true });
+
+    await act(async () => {
+      press(overlay, 'mousedown', { clientX: 100, clientY: 0 });
+      press(window, 'mousemove', { clientX: 40, clientY: 0 });
+    });
+
+    expect(wrapperEl.scrollLeft).toBe(0);
+  });
+
+  it('space held (while hovering) + drag scrolls the container by the drag delta', async () => {
+    await mount();
+    const wrapperEl = container.querySelector('[data-artifact-stage-scroll]') as HTMLDivElement;
+    const overlay = container.querySelector('[data-pan-overlay]') as HTMLDivElement;
+    Object.defineProperty(wrapperEl, 'scrollLeft', { value: 50, writable: true });
+    Object.defineProperty(wrapperEl, 'scrollTop', { value: 0, writable: true });
+
+    await act(async () => {
+      press(wrapperEl, 'mouseenter');
+      press(window, 'keydown', { code: 'Space' });
+    });
+    expect(overlay.getAttribute('data-pan-active')).toBe('true');
+
+    await act(async () => {
+      press(overlay, 'mousedown', { clientX: 100, clientY: 0 });
+    });
+    await act(async () => {
+      press(window, 'mousemove', { clientX: 40, clientY: 0 }); // 60px left → scrollLeft += 60
+    });
+
+    expect(wrapperEl.scrollLeft).toBe(110);
+
+    await act(async () => {
+      press(window, 'keyup', { code: 'Space' });
+    });
+    expect(overlay.getAttribute('data-pan-active')).toBeNull();
+  });
+
+  it('space held while NOT hovering the stage does not arm the pan overlay (다른 페이지 요소 타이핑/스크롤 간섭 방지)', async () => {
+    await mount();
+    const overlay = container.querySelector('[data-pan-overlay]') as HTMLDivElement;
+
+    await act(async () => {
+      press(window, 'keydown', { code: 'Space' });
+    });
+
+    expect(overlay.getAttribute('data-pan-active')).toBeNull();
+  });
+});

--- a/apps/web/src/components/canvas/artifact-stage.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.tsx
@@ -1,14 +1,16 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
 import type { ArtifactFormat } from '@/services/canvas';
 
 /**
  * story 385eb89a — 고정 넓이 html_blob 잘림 대책. sandbox=""(allow-same-origin 없음)라 iframe
  * 내부 문서 폭을 측정할 수 없어(cross-origin) 실 콘텐츠 폭을 알 방법이 없다 — 대신 iframe 자체
- * 박스를 이 고정 "캔버스" 폭으로 렌더해 내용이 접히지 않게 하고, wrapper가 스크롤(실제 크기)
- * 하거나 wrapper 자기 자신의 폭(우리가 소유한 DOM이라 측정 가능)에 맞춰 transform:scale로
- * 축소(전체 보기)한다 — html_blob 내부 측정은 여전히 0(보안 트레이드오프 유지, canvas-export.ts
- * §PNG export 제외 결정과 동일 원칙).
+ * 박스를 이 고정 "캔버스" 폭으로 렌더해 내용이 접히지 않게 하고, wrapper가 스크롤한다.
+ *
+ * story d425dccc — v1의 축소-fit "전체 보기" 토글은 선생님 실사용 결과 제거(유나 스펙 ⓒ 판정 —
+ * 축소는 디테일을 못 보게 해 원하는 것과 반대). 대신 ⓐ space+드래그 pan ⓑ 가로 스크롤바 상시
+ * 가시화로 대체 — wrapper는 항상 실제 크기로 렌더하고 이동 수단만 강화한다.
  */
 const HTML_STAGE_WIDTH = 1200;
 const HTML_STAGE_HEIGHT = 280;
@@ -52,12 +54,111 @@ function TreeNodeBox({ node }: { node: ArtifactTreeNode }) {
   );
 }
 
+const TYPING_TAGS = new Set(['INPUT', 'TEXTAREA']);
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return TYPING_TAGS.has(target.tagName) || target.isContentEditable;
+}
+
 interface ArtifactStageProps {
   format: ArtifactFormat;
   content: string;
   title: string;
-  /** html 포맷 전체보기(fit) 토글 — tree/image는 이 prop을 무시(토글 자체가 미노출). */
-  fitToView?: boolean;
+  /** story d425dccc — "크게 보기" 모달 전용. true면 인라인 프리뷰의 고정 280px 대신 부모
+   * 컨테이너 높이를 꽉 채운다(더 넓은 뷰포트로 스크롤/pan 부담을 줄이는 게 모달의 목적).
+   * html 포맷 외엔 무시. */
+  fill?: boolean;
+}
+
+/**
+ * html 산출물의 space+드래그 pan(story d425dccc). sandbox=""(allow-scripts 없음) iframe은
+ * 자기 자신의 포인터 이벤트를 소비해 드래그가 iframe 경계에서 끊기므로, 투명 오버레이(우리
+ * DOM)로 포인터를 가로채는 방식으로 우회한다 — sandbox 완화 없음(iframe 내부는 여전히 0접근).
+ * space를 누르고 있을 때만 오버레이가 pointer-events를 받아 grab/grabbing 커서로 드래그하고,
+ * 뗄 때 원복(iframe 자체 상호작용에 지장 없음).
+ */
+function PanOverlay({ wrapperRef }: { wrapperRef: React.RefObject<HTMLDivElement | null> }) {
+  const [spaceHeld, setSpaceHeld] = useState(false);
+  const [dragging, setDragging] = useState(false);
+  const hoveringRef = useRef(false);
+  const dragStartRef = useRef({ x: 0, y: 0, scrollLeft: 0, scrollTop: 0 });
+
+  // hover 감지는 wrapper(스크롤 컨테이너)에 직접 건다 — 오버레이 자신은 space 안 눌렀을 때
+  // pointer-events:none이라 자기 위의 mouseenter/leave를 못 받는다(순환 의존 방지).
+  useEffect(() => {
+    const el = wrapperRef.current;
+    if (!el) return;
+    function onEnter() { hoveringRef.current = true; }
+    function onLeave() { hoveringRef.current = false; }
+    el.addEventListener('mouseenter', onEnter);
+    el.addEventListener('mouseleave', onLeave);
+    return () => {
+      el.removeEventListener('mouseenter', onEnter);
+      el.removeEventListener('mouseleave', onLeave);
+    };
+  }, [wrapperRef]);
+
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.code !== 'Space' || !hoveringRef.current || isTypingTarget(e.target)) return;
+      e.preventDefault(); // 페이지 스크롤(space=page down) 억제
+      setSpaceHeld(true);
+    }
+    function onKeyUp(e: KeyboardEvent) {
+      if (e.code !== 'Space') return;
+      setSpaceHeld(false);
+      setDragging(false);
+    }
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('keyup', onKeyUp);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('keyup', onKeyUp);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!dragging) return;
+    function onMouseMove(e: MouseEvent) {
+      const el = wrapperRef.current;
+      if (!el) return;
+      const { x, y, scrollLeft, scrollTop } = dragStartRef.current;
+      el.scrollLeft = scrollLeft - (e.clientX - x);
+      el.scrollTop = scrollTop - (e.clientY - y);
+    }
+    function onMouseUp() {
+      setDragging(false);
+    }
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', onMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+    };
+  }, [dragging, wrapperRef]);
+
+  function handleMouseDown(e: React.MouseEvent) {
+    if (!spaceHeld) return;
+    const el = wrapperRef.current;
+    if (!el) return;
+    dragStartRef.current = { x: e.clientX, y: e.clientY, scrollLeft: el.scrollLeft, scrollTop: el.scrollTop };
+    setDragging(true);
+  }
+
+  return (
+    <div
+      role="presentation"
+      data-pan-overlay
+      data-pan-active={spaceHeld || undefined}
+      onMouseDown={handleMouseDown}
+      className="absolute inset-0"
+      style={{
+        pointerEvents: spaceHeld ? 'auto' : 'none',
+        cursor: dragging ? 'grabbing' : spaceHeld ? 'grab' : undefined,
+      }}
+    />
+  );
 }
 
 /**
@@ -67,43 +168,34 @@ interface ArtifactStageProps {
  * 잠금이 안전(CSS 렌더링은 sandbox 플래그와 무관하게 항상 동작함)·image=바운드 img·
  * tree=경량 노드 렌더(전신 componentCatalog의 리치 렌더는 후속 — 지금은 shell 준비 단계).
  */
-export function ArtifactStage({ format, content, title, fitToView = false }: ArtifactStageProps) {
+export function ArtifactStage({ format, content, title, fill = false }: ArtifactStageProps) {
   const t = useTranslations('canvas');
   const wrapperRef = useRef<HTMLDivElement>(null);
-  const [fitRatio, setFitRatio] = useState(1);
-
-  useEffect(() => {
-    if (format !== 'html' || !fitToView) return;
-    const el = wrapperRef.current;
-    if (!el) return;
-    const measure = () => setFitRatio(Math.min(1, el.clientWidth / HTML_STAGE_WIDTH));
-    measure();
-    const ro = new ResizeObserver(measure);
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [format, fitToView]);
 
   if (format === 'html') {
     return (
-      <div
-        ref={wrapperRef}
-        className="w-full rounded-lg border border-border bg-background"
-        style={fitToView
-          ? { height: HTML_STAGE_HEIGHT * fitRatio, overflow: 'hidden' }
-          : { overflowX: 'auto' }}
-      >
-        <iframe
-          title={title}
-          srcDoc={content}
-          sandbox=""
-          className="rounded-lg"
-          style={{
-            width: HTML_STAGE_WIDTH,
-            height: HTML_STAGE_HEIGHT,
-            transform: fitToView ? `scale(${fitRatio})` : undefined,
-            transformOrigin: 'top left',
-          }}
-        />
+      <div className={fill ? 'flex h-full w-full flex-col' : 'w-full'}>
+        {/* overlay는 스크롤 컨테이너 밖(형제)에 둔다 — 안에 두면 pan으로 스크롤될 때 overlay
+         * 자신도 같이 밀려나 뷰포트 밖으로 나가버린다(자기 자신이 캡처하는 영역을 잃는 순환
+         * 버그). 밖에 두면 wrapper의 보이는 영역(clientHeight)에 항상 고정된다. */}
+        <div className={fill ? 'relative min-h-0 w-full flex-1' : 'relative w-full'}>
+          <div
+            ref={wrapperRef}
+            data-artifact-stage-scroll
+            className={cn('w-full overflow-auto rounded-lg border border-border bg-background', fill && 'h-full')}
+            style={{ scrollbarGutter: 'stable' }}
+          >
+            <iframe
+              title={title}
+              srcDoc={content}
+              sandbox=""
+              className="rounded-lg"
+              style={{ width: HTML_STAGE_WIDTH, height: fill ? '100%' : HTML_STAGE_HEIGHT }}
+            />
+          </div>
+          <PanOverlay wrapperRef={wrapperRef} />
+        </div>
+        <p className="mt-1.5 shrink-0 text-[11px] text-muted-foreground">{t('viewerPanHint')}</p>
       </div>
     );
   }

--- a/apps/web/src/components/canvas/artifact-viewer.test.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.test.tsx
@@ -100,26 +100,57 @@ describe('ArtifactViewer (SSR snapshot)', () => {
       expect(markup).toContain('width:1200px');
     });
 
-    it('shows the fit/actual-size toggle only for html format', () => {
-      const htmlMarkup = renderToStaticMarkup(
-        wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
-      );
-      expect(htmlMarkup).toContain('전체 보기');
-      expect(htmlMarkup).toContain('실제 크기');
-
-      const treeMarkup = renderToStaticMarkup(
-        wrap(<ArtifactViewer artifact={MOCK_EDITABLE_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
-      );
-      expect(treeMarkup).not.toContain('전체 보기');
-      expect(treeMarkup).not.toContain('실제 크기');
-    });
-
     it('tree format render is unaffected (회귀 0 — placeholder path untouched)', () => {
       const markup = renderToStaticMarkup(
         wrap(<ArtifactViewer artifact={MOCK_EDITABLE_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
       );
       expect(markup).toContain('트리 렌더는 준비 중');
       expect(markup).not.toContain('width:1200px');
+    });
+  });
+
+  describe('story d425dccc — 뷰어 v2(pan + 크게 보기), 축소-fit 토글 제거', () => {
+    it('shows the expand("크게 보기") entry point only for html format, not tree/image', () => {
+      const htmlMarkup = renderToStaticMarkup(
+        wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+      );
+      expect(htmlMarkup).toContain('크게 보기');
+
+      const treeMarkup = renderToStaticMarkup(
+        wrap(<ArtifactViewer artifact={MOCK_EDITABLE_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+      );
+      expect(treeMarkup).not.toContain('크게 보기');
+    });
+
+    it('never renders the removed shrink-to-fit toggle copy (방향 오판 정정 — 회귀 방지)', () => {
+      const markup = renderToStaticMarkup(
+        wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+      );
+      expect(markup).not.toContain('전체 보기');
+      expect(markup).not.toContain('aria-pressed');
+    });
+
+    it('renders the always-visible-scrollbar hook and pan hint copy for the inline html stage', () => {
+      const markup = renderToStaticMarkup(
+        wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+      );
+      expect(markup).toContain('data-artifact-stage-scroll');
+      expect(markup).toContain('스페이스를 누른 채 드래그하면 이동합니다');
+    });
+
+    it('the pan overlay starts inert (pointer-events:none) until space is held — no accidental capture', () => {
+      const markup = renderToStaticMarkup(
+        wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+      );
+      expect(markup).toContain('data-pan-overlay');
+      expect(markup).not.toContain('data-pan-active');
+    });
+
+    it('the expand dialog is not rendered in the DOM when closed by default (base-ui portal, no leaked markup)', () => {
+      const markup = renderToStaticMarkup(
+        wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+      );
+      expect(markup).not.toContain('90vw');
     });
   });
 });

--- a/apps/web/src/components/canvas/artifact-viewer.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useRef, useState } from 'react';
-import { Check, Clock, Download, MessageCircle, Pencil, Sparkles } from 'lucide-react';
+import { Check, Clock, Download, Maximize2, MessageCircle, Pencil, Sparkles } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
+import { cn } from '@/lib/utils';
 import { ArtifactStage } from './artifact-stage';
 import { ArtifactVersionRail } from './artifact-version-rail';
 import { AnchorPin } from './anchor-pin';
@@ -51,7 +53,7 @@ export function ArtifactViewer({
 }: ArtifactViewerProps) {
   const t = useTranslations('canvas');
   const [selectedVersion, setSelectedVersion] = useState(artifact.current_version);
-  const [fitToView, setFitToView] = useState(false);
+  const [expandOpen, setExpandOpen] = useState(false);
   const isViewingAnchor = selectedVersion === artifact.anchor_version;
   const [selectedThreadId, setSelectedThreadId] = useState<string | null>(null);
   const [exportOpen, setExportOpen] = useState(false);
@@ -80,27 +82,18 @@ export function ArtifactViewer({
               <option key={v.id} value={v.version}>v{v.version}</option>
             ))}
           </select>
-          {/* story 385eb89a v1+ — 고정 넓이 html 전용 전체보기/실제크기 토글. tree/image는
-           * 이미 컨테이너에 맞춰 렌더돼 토글 자체가 무의미해 노출하지 않는다. */}
+          {/* story d425dccc — 고정 넓이 html 전용 확대 뷰 진입점. v1의 축소-fit 토글은 방향
+           * 오판으로 제거(스펙 ⓒ 판정) — 대신 큰 표면에서 실제 크기+pan으로 본다.
+           * tree/image는 컨테이너에 맞춰 이미 렌더돼 대상이 아니다. */}
           {artifact.format === 'html' ? (
-            <div className="flex items-center rounded-md border border-border text-[11px] font-medium text-muted-foreground">
-              <button
-                type="button"
-                onClick={() => setFitToView(true)}
-                aria-pressed={fitToView}
-                className={`rounded-l-md px-1.5 py-0.5 ${fitToView ? 'bg-accent text-accent-foreground' : 'hover:bg-muted'}`}
-              >
-                {t('viewerFitToggleFit')}
-              </button>
-              <button
-                type="button"
-                onClick={() => setFitToView(false)}
-                aria-pressed={!fitToView}
-                className={`rounded-r-md px-1.5 py-0.5 ${!fitToView ? 'bg-accent text-accent-foreground' : 'hover:bg-muted'}`}
-              >
-                {t('viewerFitToggleActual')}
-              </button>
-            </div>
+            <button
+              type="button"
+              onClick={() => setExpandOpen(true)}
+              className="flex items-center gap-1 rounded-md border border-border px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <Maximize2 className="h-3 w-3" aria-hidden />
+              {t('viewerExpandAction')}
+            </button>
           ) : null}
           {artifact.anchor_version != null ? (
             <span className="inline-flex items-center gap-1 text-[11px] font-semibold text-success/85">
@@ -159,7 +152,7 @@ export function ArtifactViewer({
         <div className="grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_232px]">
           <div ref={captureTargetRef} className="relative min-w-0 bg-muted/20 p-4">
             {activeVersion ? (
-              <ArtifactStage format={artifact.format} content={activeVersion.content} title={artifact.title} fitToView={fitToView} />
+              <ArtifactStage format={artifact.format} content={activeVersion.content} title={artifact.title} />
             ) : null}
             {/* C2 §1 — 좌표 앵커 스레드만 오버레이(element 앵커는 실 artifact tree 좌표 유도 필요, 후속). */}
             {threads?.filter((th) => th.anchor.kind === 'coordinate').map((th) => (
@@ -214,6 +207,35 @@ export function ArtifactViewer({
         captureTargetRef={captureTargetRef}
         artifactFormat={artifact.format}
       />
+      {activeVersion && artifact.format === 'html' ? (
+        <DialogPrimitive.Root open={expandOpen} onOpenChange={setExpandOpen}>
+          <DialogPrimitive.Portal>
+            <DialogPrimitive.Backdrop className="fixed inset-0 z-50 bg-black/40 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
+            <DialogPrimitive.Popup
+              className={cn(
+                'fixed top-1/2 left-1/2 z-50 flex h-[85vh] w-[90vw] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden',
+                'rounded-xl bg-card shadow-lg ring-1 ring-foreground/10 outline-none',
+                'data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95',
+                'data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+              )}
+            >
+              <div className="flex items-center gap-2 border-b border-border px-4 py-2.5">
+                <DialogPrimitive.Title className="truncate text-sm font-semibold text-foreground">
+                  {artifact.title}
+                </DialogPrimitive.Title>
+                <DialogPrimitive.Close
+                  className="ml-auto rounded-md border border-border px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+                >
+                  {t('closeAction')}
+                </DialogPrimitive.Close>
+              </div>
+              <div className="min-h-0 flex-1 overflow-hidden p-4">
+                <ArtifactStage format={artifact.format} content={activeVersion.content} title={artifact.title} fill />
+              </div>
+            </DialogPrimitive.Popup>
+          </DialogPrimitive.Portal>
+        </DialogPrimitive.Root>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## 변경 사항
story `d425dccc` — v1(#2127)의 가로 스크롤이 실사용 결과 여전히 불편하다는 선생님 직접 지적 2차. 유나 스펙(`artifact-viewer-v2-pan-zoom-spec`, PO 대조 GREEN) 그대로 구현.

- **space+드래그 pan**: space를 누른 채(스테이지에 마우스가 올라가 있을 때만 무장 — 페이지 다른 곳에서 타이핑/스크롤 중이면 간섭 없음) 드래그하면 스크롤 컨테이너가 이동합니다. `sandbox=""` iframe은 자기 포인터 이벤트를 삼켜 드래그가 iframe 경계에서 끊기므로, 투명 오버레이(우리 DOM)로 캡처하는 방식으로 우회 — **sandbox 완화 없음**(iframe 내부는 여전히 0접근 유지).
  - 오버레이는 스크롤 컨테이너 **밖**(형제)에 둡니다 — 안에 두면 pan으로 스크롤될 때 오버레이 자신도 같이 밀려나 뷰포트 밖으로 나가버리는 순환 버그가 생겨서, 구조를 잡던 중 자체적으로 발견/수정했습니다.
- **"크게 보기" 버튼 → 큰 모달**(≈90vw×85vh, backdrop, ESC — base-ui Dialog): 같은 `ArtifactStage`를 `fill` 모드로 재렌더(고정 280px 대신 모달 높이를 꽉 채움) — 실제 크기 + 동일 pan으로 탐색.
- **v1의 축소-fit "전체 보기" 토글 제거**(방향 오판 정정, 스펙 ⓒ 판정) — 인라인 뷰어 default는 이제 항상 실제 크기입니다.
- **가로 스크롤바 상시 가시화**: 앱 전역 스크롤바(6px·10% 불투명 thumb)는 대비가 낮아 "스크롤 자체가 없다"는 오인을 낳았습니다(실제로는 커스텀 스크롤바가 이미 있었음 — 그라운딩으로 확인) — 이 스테이지만 10px·고대비 thumb으로 발견성을 강화했습니다.
- image/tree 완전 무변경(html만 대상), 양테마.

## 테스트
- 순수 pan 드래그 상호작용 3건(신규 `artifact-stage.test.tsx`, jsdom): space 없이 드래그해도 스크롤 안 움직임(JS 가드가 실제 방어선 — jsdom은 CSS `pointer-events`를 hit-test하지 않으므로 이게 유일한 실검증)·space+드래그 시 delta만큼 스크롤·스테이지 밖에서 space 눌러도 무장 안 됨
- SSR 회귀가드 5건 추가: 크게 보기 버튼 html 전용 노출·제거된 토글 카피 미노출·스크롤바 훅+힌트 카피 렌더·오버레이 초기 비활성(pointer-events:none)·모달 기본 미렌더(portal, DOM 누출 0)
- 전체 `pnpm vitest run`: **1315 passed | 2 skipped**, 회귀 0
- `tsc --noEmit`: clean
- `eslint`: 0 warning
- `pnpm build`: EXIT=0

## 반응형/스크린샷
pan 드래그 실감·스크롤바 가시성·모달 실렌더는 라이브 픽셀에서만 확실히 검증 가능한 영역이라, dev 배포 후 오르테가군 라이브 done-gate에서 실측 예정.