### PR TITLE
feat(stories): GET /api/v2/stories?ids= 배치 앵커 조회 — 갤러리 잔여② (story ca37b2b0)

### DIFF
--- a/backend/app/repositories/story.py
+++ b/backend/app/repositories/story.py
@@ -23,6 +23,21 @@ class StoryRepository(BaseRepository[Story]):
     def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
         super().__init__(Story, session, org_id)
 
+    async def list_by_ids(self, ids: list[uuid.UUID]) -> list[Story]:
+        """배치 앵커 조회(story ca37b2b0 ② — 갤러리 등 정확한 story 집합 필요 소비자용).
+
+        org-scoped exact-id IN 조회. ORDER BY 없음 — 호출자가 id 집합 그대로를 필요로 하는
+        용도(base.list()의 "첫 N건" 비결정 순서 문제와 무관, id 정확 매칭이라 순서 개념 자체가 없음).
+        """
+        if not ids:
+            return []
+        result = await self.session.execute(
+            select(Story).where(
+                self._org_filter(), Story.id.in_(ids), Story.deleted_at.is_(None),
+            )
+        )
+        return list(result.scalars().all())
+
     async def list_board(
         self,
         project_id: uuid.UUID,

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -88,12 +88,35 @@ async def list_stories(
     assignee_id: uuid.UUID | None = Query(default=None),
     status_filter: str | None = Query(default=None, alias="status"),
     no_sprint: bool = Query(default=False, description="sprint 미배정 스토리만 반환"),
+    ids: str | None = Query(default=None, description="comma-separated story ids — 배치 앵커 조회(정확한 집합, ORDER BY/limit 무관)"),
     limit: int = Query(default=1000, ge=1, le=2000),
     cursor: str | None = Query(default=None, description="Cursor: ISO 8601 created_at, fetch before this time"),
     response: Response = None,  # type: ignore[assignment]
     repo: StoryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> list[StoryResponse]:
     from datetime import datetime
+
+    if ids is not None:
+        # story ca37b2b0 ②: 갤러리 등 정확한 story 집합이 필요한 소비자용 — base.list()의
+        # ORDER BY 부재(별건 d8787fa6)와 무관하게 요청한 id를 전부(또는 접근권 있는 만큼) 반환.
+        try:
+            story_ids = [uuid.UUID(x) for x in ids.split(",") if x.strip()]
+        except ValueError:
+            raise HTTPException(status_code=422, detail="invalid story id in ids")
+        if not story_ids:
+            return []
+        if len(story_ids) > 200:  # 워크플로우-라인 배치와 동형 방어(과대 IN 금지).
+            raise HTTPException(status_code=422, detail="too many ids (max 200)")
+        stories = await repo.list_by_ids(story_ids)
+        # 인가 스코프: org 소속이어도 caller가 접근 못 하는 project의 story는 조용히 필터링
+        # (타 project id가 섞여 들어와도 유출 0 — has_project_access와 동일 SSOT 배치 버전 재사용).
+        from app.services.project_auth import accessible_project_ids_in_org
+        accessible = await accessible_project_ids_in_org(repo.session, uuid.UUID(auth.user_id), repo.org_id)
+        stories = [s for s in stories if s.project_id in accessible]
+        await _attach_assignee_ids(repo.session, repo.org_id, stories)
+        await _attach_has_evidence(repo.session, stories)
+        return [StoryResponse.model_validate(s) for s in stories]
 
     if no_sprint and project_id:
         stories = await repo.list_backlog(project_id, limit=limit)

--- a/backend/tests/test_ca37b2b0_stories_ids_batch_realdb.py
+++ b/backend/tests/test_ca37b2b0_stories_ids_batch_realdb.py
@@ -1,0 +1,173 @@
+"""[E-CANVAS][갤러리 잔여②·BE] story ca37b2b0 — `GET /api/v2/stories?ids=` 배치 앵커 조회. 실 PG.
+
+`BaseRepository.list()`(ORDER BY 없음·별건 d8787fa6)에 기대지 않고 정확한 id 집합을 해소 —
+갤러리처럼 특정 스토리들(산출물 앵커)만 필요한 소비자용. 인가 스코프: 접근 못 하는 project의
+id가 섞여도 조용히 필터링(유출 0)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _auth(agent_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(agent_id), email=None, claims={"app_metadata": {}})
+
+
+async def _seed(session):
+    """org + project_a(agent 접근)/project_b(agent 무접근) + 각 project 스토리 2개씩.
+
+    project_a 스토리는 일부러 과거(오래된 created_at)로 시드 — base.list()의 "첫 N건"이
+    최신순이 아님을 알 수 있게(ORDER BY 부재 문제와 무관함을 대조로 보여줌)."""
+    from datetime import datetime, timedelta, timezone
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent")
+    session.add(agent)
+    await session.commit()
+    session.add(ProjectAccess(id=uuid.uuid4(), project_id=project_a.id, member_id=agent.id, permission="granted"))
+    await session.commit()
+
+    old_ts = datetime.now(timezone.utc) - timedelta(days=90)
+    story_a1 = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="A1", status="backlog", created_at=old_ts)
+    story_a2 = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, title="A2", status="backlog", created_at=old_ts)
+    story_b1 = Story(id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, title="B1", status="backlog")
+    session.add_all([story_a1, story_a2, story_b1])
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_a": project_a.id, "project_b": project_b.id, "agent_id": agent.id,
+        "story_a1": story_a1.id, "story_a2": story_a2.id, "story_b1": story_b1.id,
+    }
+
+
+async def _call_list_stories(session, org_id, agent_id, ids_param):
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import list_stories
+
+    repo = StoryRepository(session, org_id)
+    return await list_stories(
+        ids=ids_param,
+        repo=repo,
+        auth=_auth(agent_id),
+    )
+
+
+async def test_ids_batch_returns_exact_set_regardless_of_creation_order():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            ids_param = f"{seeded['story_a1']},{seeded['story_a2']}"
+            result = await _call_list_stories(s, seeded["org_id"], seeded["agent_id"], ids_param)
+            returned_ids = {r.id for r in result}
+            assert returned_ids == {seeded["story_a1"], seeded["story_a2"]}
+    finally:
+        await engine.dispose()
+
+
+async def test_ids_batch_filters_cross_project_ids_silently():
+    """접근권 없는 project_b의 story id가 섞여 들어와도 유출 0 — 에러 아닌 조용한 필터링."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            ids_param = f"{seeded['story_a1']},{seeded['story_b1']}"
+            result = await _call_list_stories(s, seeded["org_id"], seeded["agent_id"], ids_param)
+            returned_ids = {r.id for r in result}
+            assert returned_ids == {seeded["story_a1"]}  # story_b1은 조용히 빠짐.
+    finally:
+        await engine.dispose()
+
+
+async def test_ids_batch_malformed_id_422():
+    from fastapi import HTTPException
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await _call_list_stories(s, seeded["org_id"], seeded["agent_id"], "not-a-uuid")
+            assert exc_info.value.status_code == 422
+    finally:
+        await engine.dispose()
+
+
+async def test_ids_batch_oversized_422():
+    from fastapi import HTTPException
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            ids_param = ",".join(str(uuid.uuid4()) for _ in range(201))
+            with pytest.raises(HTTPException) as exc_info:
+                await _call_list_stories(s, seeded["org_id"], seeded["agent_id"], ids_param)
+            assert exc_info.value.status_code == 422
+    finally:
+        await engine.dispose()
+
+
+async def test_ids_batch_empty_string_returns_empty_list():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            result = await _call_list_stories(s, seeded["org_id"], seeded["agent_id"], "")
+            assert result == []
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- story `ca37b2b0` 잔여② — 산출물 갤러리 에픽 탭 전건 무소속의 두 번째 근본(까심 QA 실측): 갤러리 lookup이 `/api/v2/stories?limit=100`인데 무파라미터 `list_stories`가 `BaseRepository.list()`(ORDER BY 없음)로 떨어져 "첫 100건"이 비결정 — dev 실측 기준 4월 스토리 100건만 반환돼 산출물 앵커(최근 스토리)가 전부 lookup 밖.
- **fix(대증 아닌 배치 해소)**: `list_stories`에 `ids`(comma-separated, 기존 `/workflow-line/status`와 동일 계약) 추가 — 정확한 story 집합만 요청/반환. `limit` 상향이나 `ORDER BY` 추가는 다른 소비자 파급이 있는 대증이라 배제(ORDER BY 부재 자체는 이미 별건 `d8787fa6`로 등재돼 있어 중복 구현 금지).
- 인가 스코프: 접근권 없는 project의 id가 섞여도 `accessible_project_ids_in_org` 배치 재사용으로 조용히 필터링(유출 0, 에러 아님).
- 신규 `StoryRepository.list_by_ids()` — org-scoped exact-id IN 조회(순서 개념이 없어 ORDER BY 이슈와 무관).

## Non-goals
- `BaseRepository.list()`의 ORDER BY 부재 자체 — 별건 `d8787fa6` 스코프.
- FE 픽업(갤러리 fetch를 `ids` 호출로 전환) — 미르코 lane(additive라 선머지 무해).

## Test plan
- [x] 신규 realdb 5건 — 정확한 집합 반환(과거 created_at으로 시드해 ORDER BY 무관 실증) · cross-project id 조용한 필터링 · malformed 422 · oversized(201개) 422 · 빈 문자열 → 빈 리스트.
- [x] 기존 stories/board/security 스위트 76건 무회귀.
- [x] 마이그 0.

Story: `ca37b2b0`