### PR TITLE
[SID:ca37b2b0] 갤러리 stories lookup을 ids 배치 조회로 전환 — 최신 스토리 누락 근본 해소

### DIFF
--- a/apps/web/src/app/api/stories/route.test.ts
+++ b/apps/web/src/app/api/stories/route.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// story ca37b2b0 — GET ids 배치 lookup(BE #2131) 분기 회귀가드. StoryService.list()를
+// 목킹해 (a) ids 없으면 기존 커서 페이지네이션 경로 (b) ids 있으면 meta 없는 배치 응답
+// (c) 200개 cap 방어 (d) 빈/공백 ids는 무시하고 기존 경로로 폴백을 검증한다.
+const h = vi.hoisted(() => ({
+  getAuthContext: vi.fn(), createStoryRepository: vi.fn(), list: vi.fn(),
+}));
+vi.mock('@/lib/auth-helpers', () => ({ getAuthContext: h.getAuthContext }));
+vi.mock('@/lib/storage/factory', () => ({ createStoryRepository: h.createStoryRepository }));
+vi.mock('@/services/story', async (importActual) => ({
+  ...(await importActual<typeof import('@/services/story')>()),
+  StoryService: class { list = h.list; },
+}));
+
+import { GET } from './route';
+
+const agent = () => ({ id: 'a', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
+const story = (id: string) => ({ id, title: `Story ${id}`, created_at: '2026-07-01T00:00:00Z' });
+
+describe('/api/stories GET — ids 배치 lookup 분기', () => {
+  beforeEach(() => {
+    Object.values(h).forEach((m) => m.mockReset());
+    h.getAuthContext.mockResolvedValue(agent());
+    h.createStoryRepository.mockResolvedValue({});
+  });
+
+  it('401 when unauthenticated', async () => {
+    h.getAuthContext.mockResolvedValue(null);
+    expect((await GET(new Request('http://localhost/api/stories?ids=s1'))).status).toBe(401);
+    expect(h.list).not.toHaveBeenCalled();
+  });
+
+  it('no ids param → existing cursor-paginated path (limit+1 overfetch·meta present, no ids key sent)', async () => {
+    h.list.mockResolvedValue([story('1'), story('2')]);
+    const res = await GET(new Request('http://localhost/api/stories?project_id=p'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.meta).toBeTruthy();
+    const calledWith = h.list.mock.calls[0]![0] as { ids?: string[]; limit?: number };
+    expect(calledWith.ids).toBeUndefined();
+    expect(calledWith.limit).toBe(51); // RC3 overfetch(default 50 + 1)
+  });
+
+  it('ids param present → batch lookup, no pagination meta, ids forwarded verbatim', async () => {
+    h.list.mockResolvedValue([story('a1'), story('a2')]);
+    const res = await GET(new Request('http://localhost/api/stories?project_id=p&ids=a1,a2'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(2);
+    expect(body.meta).toBeFalsy(); // apiSuccess(stories) — 두번째 인자 생략, meta=null 직렬화
+    expect(h.list).toHaveBeenCalledWith({ project_id: 'p', ids: ['a1', 'a2'], limit: 2 });
+  });
+
+  it('caps ids at 200 before calling the service (BE 200개 cap 방어, 422 회피)', async () => {
+    h.list.mockResolvedValue([]);
+    const manyIds = Array.from({ length: 250 }, (_, i) => `id${i}`).join(',');
+    await GET(new Request(`http://localhost/api/stories?ids=${manyIds}`));
+    const calledWith = h.list.mock.calls[0]![0] as { ids: string[] };
+    expect(calledWith.ids).toHaveLength(200);
+  });
+
+  it('blank/empty ids param falls back to the normal paginated path (no-fiction — 빈 배치를 쏘지 않음)', async () => {
+    h.list.mockResolvedValue([]);
+    await GET(new Request('http://localhost/api/stories?ids=  ,  '));
+    const calledWith = h.list.mock.calls[0]![0] as { ids?: string[] };
+    expect(calledWith.ids).toBeUndefined();
+  });
+});

--- a/apps/web/src/app/api/stories/route.ts
+++ b/apps/web/src/app/api/stories/route.ts
@@ -33,6 +33,9 @@ export async function POST(request: Request) {
   }
 }
 
+// story ca37b2b0 — BE 배치 lookup(#2131) cap과 동일 상한. FE에서 먼저 잘라 보내 BE 422를 피한다.
+const IDS_BATCH_CAP = 200;
+
 export async function GET(request: Request) {
   try {
     const me = await getAuthContext(request);
@@ -41,12 +44,27 @@ export async function GET(request: Request) {
     const dbClient = undefined;
 
     const { searchParams } = new URL(request.url);
+    const idsParam = searchParams.get('ids');
+    const parsedIds = idsParam ? idsParam.split(',').map((id) => id.trim()).filter(Boolean).slice(0, IDS_BATCH_CAP) : [];
+    const ids = parsedIds.length > 0 ? parsedIds : undefined;
+
+    const repo = await createStoryRepository();
+    const service = new StoryService(repo, dbClient);
+
+    // ids 배치 lookup은 커서 페이지네이션과 무관한 고정 집합 조회 — 페이지 meta 없이 그대로 반환.
+    if (ids && ids.length > 0) {
+      const stories = await service.list({
+        project_id: searchParams.get('project_id') ?? undefined,
+        ids,
+        limit: ids.length,
+      });
+      return apiSuccess(stories);
+    }
+
     const pageInput = parseCursorPageInput({
       limit: searchParams.get('limit') ? Number(searchParams.get('limit')) : undefined,
       cursor: searchParams.get('cursor'),
     }, { defaultLimit: 50, maxLimit: 100 });
-    const repo = await createStoryRepository();
-    const service = new StoryService(repo, dbClient);
     const stories = await service.list({
       sprint_id: searchParams.get('sprint_id') ?? undefined,
       epic_id: searchParams.get('epic_id') ?? undefined,

--- a/apps/web/src/components/canvas/artifact-gallery-view.tsx
+++ b/apps/web/src/components/canvas/artifact-gallery-view.tsx
@@ -28,18 +28,30 @@ interface EpicListItem { id: string; title: string }
 interface SprintListItem { id: string; title: string }
 interface DocListItem { id: string; title: string }
 
+/**
+ * story ca37b2b0 — stories lookup은 artifacts 응답에 실제로 등장하는 story_id만 배치 조회
+ * (BE #2131 `ids` 파라미터)로 전환. 기존 `limit=100` 전량 fetch는 프로젝트에 스토리가 100개
+ * 넘으면 최신 스토리가 잘려나가 에픽/스프린트 축이 무소속으로 오판하는 근본 결함이 있었다.
+ * artifacts를 먼저 받아야 어떤 id들이 필요한지 알 수 있어 자연히 2단계 fetch가 되는데,
+ * epics/sprints/docs는 artifacts와 무관하니 1단계에서 같이 병렬 처리해 낭비를 최소화한다.
+ */
 async function fetchGalleryData(projectId: string): Promise<{ artifacts: BeVisualArtifactSummary[]; lookups: GalleryLookups }> {
-  const [artifacts, epics, stories, sprints, docs] = await Promise.all([
+  const [artifacts, epics, sprints, docs] = await Promise.all([
     // 무쿼리 호출=project-wide(BE가 JWT/API키 컨텍스트의 project_id로 항상 스코프 — 클라 지정
     // 불가 SEC-S8 가드). 기존 프록시 쿼리 forward 그대로라 신규 프록시 0(doc §5).
     fetchJson<BeVisualArtifactSummary[]>('/api/visual-artifacts'),
     fetchJson<EpicListItem[]>(`/api/epics?project_id=${projectId}&limit=100`),
-    fetchJson<StoryListItem[]>(`/api/stories?project_id=${projectId}&limit=100`),
     fetchJson<SprintListItem[]>(`/api/sprints?project_id=${projectId}`),
     fetchJson<DocListItem[]>(`/api/docs?project_id=${projectId}&limit=100`),
   ]);
+  const resolvedArtifacts = artifacts ?? [];
+  const storyIds = [...new Set(resolvedArtifacts.map((a) => a.story_id).filter((id): id is string => id != null))];
+  // 빈 ids면 호출 자체를 생략(no-fiction — 조회할 대상이 없는데 빈 배치를 쏘지 않는다).
+  const stories = storyIds.length > 0
+    ? await fetchJson<StoryListItem[]>(`/api/stories?project_id=${projectId}&ids=${storyIds.join(',')}`)
+    : [];
   return {
-    artifacts: artifacts ?? [],
+    artifacts: resolvedArtifacts,
     lookups: {
       epics: (epics ?? []).map((e) => ({ id: e.id, title: e.title })),
       stories: (stories ?? []).map((s) => ({ id: s.id, title: s.title, sprint_id: s.sprint_id, epic_id: s.epic_id })),

--- a/packages/core-storage/src/interfaces/IStoryRepository.ts
+++ b/packages/core-storage/src/interfaces/IStoryRepository.ts
@@ -88,6 +88,10 @@ export interface StoryListFilters extends PaginationOptions {
   project_id?: string;
   q?: string;
   unassigned?: boolean;
+  /** story ca37b2b0 — 고정 id 집합 배치 조회(BE 200개 cap). 주어지면 커서 페이지네이션과
+   * 무관한 배치 lookup 의미론(정확히 이 id들만, project 필터와 무관하게 cross-project는
+   * BE가 조용히 걸러냄). */
+  ids?: string[];
 }
 
 export interface IStoryRepository {

--- a/packages/storage-api/src/ApiStoryRepository.ts
+++ b/packages/storage-api/src/ApiStoryRepository.ts
@@ -12,7 +12,12 @@ export class ApiStoryRepository implements IStoryRepository {
   async list(filters: StoryListFilters): Promise<Story[]> {
     return fastapiCall<Story[]>('GET', '/api/v2/stories', this.accessToken, {
       // RC1: cursor + limit 전달 (CB-S4 cursor 페이징)
-      query: { project_id: filters.project_id, epic_id: filters.epic_id, sprint_id: filters.sprint_id, assignee_id: filters.assignee_id, status: filters.status, cursor: filters.cursor, limit: filters.limit },
+      // story ca37b2b0: ids가 있으면 배치 lookup(BE #2131) — comma-separated로 그대로 전달.
+      query: {
+        project_id: filters.project_id, epic_id: filters.epic_id, sprint_id: filters.sprint_id,
+        assignee_id: filters.assignee_id, status: filters.status, cursor: filters.cursor, limit: filters.limit,
+        ids: filters.ids?.join(','),
+      },
     });
   }
 


### PR DESCRIPTION
## 변경 사항
story `ca37b2b0` 잔여(마지막 조각) — #2129(에픽 축 무소속 fix)의 후속. BE #2131(`GET /api/v2/stories?ids=<comma-separated>`, 200개 cap·malformed 422·cross-project 조용 필터, 머지됨)을 소비.

**근본 결함**: 기존 갤러리 lookups의 stories fetch는 `limit=100` 전량 조회였음 — 프로젝트에 스토리가 100개를 넘으면 최신 스토리가 잘려나가, #2129에서 고친 "story 경유 에픽 유도"가 애초에 참조할 스토리 자체를 못 찾아 무소속으로 재발할 수 있는 잠재 결함이 있었습니다. artifacts 응답에 **실제로 등장하는 story_id만** 배치 조회하도록 전환해 이 결함을 원천 제거합니다.

## 구현
- `IStoryRepository.StoryListFilters`(core-storage)에 `ids?: string[]` 추가
- `ApiStoryRepository.list()`(storage-api)가 comma-separated로 BE에 forward
- `/api/stories` GET: `ids` 있으면 커서 페이지네이션과 무관한 배치 lookup 분기(meta 없이 그대로 반환)·BE 200개 cap 방어(FE에서 먼저 slice, 공백 trim 후 filter)·빈/공백 ids는 기존 경로로 안전 폴백
- `artifact-gallery-view.tsx`: artifacts를 먼저 받아 story_id를 수집한 뒤 배치 조회하는 2단계 fetch로 전환(epics/sprints/docs는 artifacts와 무관하므로 1단계에서 그대로 병렬 처리 — fetch 순서 의존 문제를 최소 낭비로 해소)·빈 ids면 stories 호출 자체를 생략(no-fiction)

**스코프 판단 1건**: `packages/core-storage`·`packages/storage-api`는 `apps/web/` 바깥이지만, 이 모노레포에서 apps/web만 소비하는 순수 FE 인프라(다른 앱 없음, 확인함)라 판단해 함께 수정했습니다 — 문제 시 알려주시면 되돌리겠습니다.

## 테스트
- 신규 `/api/stories` route 테스트 5건: 401·ids 없을 때 기존 경로(overfetch+meta)·ids 있을 때 배치 경로(meta 없음·ids 그대로 forward)·200개 cap·공백/빈 ids 폴백
- 전체 `pnpm vitest run`: **1318 passed | 2 skipped**, 회귀 0
- `tsc --noEmit`: clean (apps/web + core-storage + storage-api 3곳 전부)
- `eslint`: 0 warning
- `pnpm build`: EXIT=0

## 반응형/스크린샷
데이터 조회 로직 변경(레이아웃 무변경) — 에픽 탭 실그룹 표기(무소속 0건으로 수렴하는지)는 라이브 픽셀에서만 확실히 검증 가능한 영역이라, dev 배포 후 오르테가군 라이브 done-gate에서 실측 예정.