### PR TITLE
[SID:e4cce704] 산출물 뷰어 pan v2.1 — 스페이스 게이트 완전 제거, 직접 드래그=이동

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3567,6 +3567,6 @@
     "galleryLazyHint": "Expanding loads earlier versions.",
     "galleryVersionsUnavailable": "Couldn't load earlier versions.",
     "viewerExpandAction": "Expand view",
-    "viewerPanHint": "Hold space and drag to pan"
+    "viewerPanHint": "Drag to move"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3567,6 +3567,6 @@
     "galleryLazyHint": "펼치면 이전 버전을 불러옵니다",
     "galleryVersionsUnavailable": "이전 버전을 불러올 수 없습니다",
     "viewerExpandAction": "크게 보기",
-    "viewerPanHint": "스페이스를 누른 채 드래그하면 이동합니다"
+    "viewerPanHint": "끌어서 이동"
   }
 }

--- a/apps/web/src/components/canvas/artifact-stage.test.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
 //
-// story d425dccc — space+드래그 pan 실동작 회귀가드. jsdom은 CSS pointer-events를 실제로
-// hit-test하지 않으므로(스타일 강제 무관하게 합성 이벤트가 그대로 전달됨), space 미보유 시
-// 드래그를 막는 JS 가드(`if (!spaceHeld) return`)가 실제 방어선임을 직접 검증한다.
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+// story e4cce704(v2.1) — space 게이트 제거 후 직접-드래그 pan 회귀가드. space 관련 키보드
+// 리스너/hover-gate가 완전히 제거됐음을 확인하고, mousedown+drag만으로 스크롤이 이동하는지
+// 검증한다(v2에서 있던 "space 없으면 안 움직임" 가드는 이제 정반대 — space는 아예 무간섭).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
@@ -40,38 +40,17 @@ async function mount() {
   });
 }
 
-function press(el: EventTarget, type: string, init: MouseEventInit | KeyboardEventInit = {}) {
-  const Ctor = type.startsWith('key') ? KeyboardEvent : MouseEvent;
-  el.dispatchEvent(new Ctor(type, { bubbles: true, cancelable: true, ...init }));
+function press(el: EventTarget, type: string, init: MouseEventInit = {}) {
+  el.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, ...init }));
 }
 
-describe('ArtifactStage — html space+drag pan', () => {
-  it('dragging the overlay without space held does not move the scroll container (JS guard, not just CSS)', async () => {
-    await mount();
-    const wrapperEl = container.querySelector('[data-artifact-stage-scroll]') as HTMLDivElement;
-    const overlay = container.querySelector('[data-pan-overlay]') as HTMLDivElement;
-    Object.defineProperty(wrapperEl, 'scrollLeft', { value: 0, writable: true });
-
-    await act(async () => {
-      press(overlay, 'mousedown', { clientX: 100, clientY: 0 });
-      press(window, 'mousemove', { clientX: 40, clientY: 0 });
-    });
-
-    expect(wrapperEl.scrollLeft).toBe(0);
-  });
-
-  it('space held (while hovering) + drag scrolls the container by the drag delta', async () => {
+describe('ArtifactStage — html 직접-드래그 pan(v2.1, space 게이트 없음)', () => {
+  it('mousedown+drag alone scrolls the container by the drag delta (no space needed)', async () => {
     await mount();
     const wrapperEl = container.querySelector('[data-artifact-stage-scroll]') as HTMLDivElement;
     const overlay = container.querySelector('[data-pan-overlay]') as HTMLDivElement;
     Object.defineProperty(wrapperEl, 'scrollLeft', { value: 50, writable: true });
     Object.defineProperty(wrapperEl, 'scrollTop', { value: 0, writable: true });
-
-    await act(async () => {
-      press(wrapperEl, 'mouseenter');
-      press(window, 'keydown', { code: 'Space' });
-    });
-    expect(overlay.getAttribute('data-pan-active')).toBe('true');
 
     await act(async () => {
       press(overlay, 'mousedown', { clientX: 100, clientY: 0 });
@@ -83,19 +62,27 @@ describe('ArtifactStage — html space+drag pan', () => {
     expect(wrapperEl.scrollLeft).toBe(110);
 
     await act(async () => {
-      press(window, 'keyup', { code: 'Space' });
+      press(window, 'mouseup');
     });
-    expect(overlay.getAttribute('data-pan-active')).toBeNull();
+    expect(overlay.style.cursor).toBe('grab'); // 드래그 종료 후 grab으로 복귀(항상 활성 어포던스)
   });
 
-  it('space held while NOT hovering the stage does not arm the pan overlay (다른 페이지 요소 타이핑/스크롤 간섭 방지)', async () => {
+  it('shows the grab cursor at rest and grabbing while dragging (always-active affordance)', async () => {
     await mount();
     const overlay = container.querySelector('[data-pan-overlay]') as HTMLDivElement;
+    expect(overlay.style.cursor).toBe('grab');
 
     await act(async () => {
-      press(window, 'keydown', { code: 'Space' });
+      press(overlay, 'mousedown', { clientX: 0, clientY: 0 });
     });
+    expect(overlay.style.cursor).toBe('grabbing');
+  });
 
-    expect(overlay.getAttribute('data-pan-active')).toBeNull();
+  it('never wires a keydown/keyup listener for Space (space 게이트 완전 제거 회귀가드)', async () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    await mount();
+    const spaceListenerCalls = addSpy.mock.calls.filter(([type]) => type === 'keydown' || type === 'keyup');
+    expect(spaceListenerCalls).toHaveLength(0);
+    addSpy.mockRestore();
   });
 });

--- a/apps/web/src/components/canvas/artifact-stage.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.tsx
@@ -11,6 +11,12 @@ import type { ArtifactFormat } from '@/services/canvas';
  * story d425dccc — v1의 축소-fit "전체 보기" 토글은 선생님 실사용 결과 제거(유나 스펙 ⓒ 판정 —
  * 축소는 디테일을 못 보게 해 원하는 것과 반대). 대신 ⓐ space+드래그 pan ⓑ 가로 스크롤바 상시
  * 가시화로 대체 — wrapper는 항상 실제 크기로 렌더하고 이동 수단만 강화한다.
+ *
+ * story e4cce704(v2.1) — space 게이트를 완전 제거(선생님 실사용 지적 3차: 뷰어 밖에서 space를
+ * 누르면 그대로 페이지 스크롤 다운으로 새 — hover-gate라 게이트 상태가 비가시라 "고장"으로
+ * 읽힘). 오버레이를 상시 활성화해 **드래그만으로 pan**하도록 단순화(유나 판정 확定, KISS —
+ * "클릭 통과" 절충은 cross-origin에서 반쯤 작동하는 복잡 상태라 명시 거부됨). 트레이드오프:
+ * 오버레이가 항상 포인터를 가로채 iframe 내부 텍스트 선택은 포기(뷰어=탐색이 본업).
  */
 const HTML_STAGE_WIDTH = 1200;
 const HTML_STAGE_HEIGHT = 280;
@@ -54,13 +60,6 @@ function TreeNodeBox({ node }: { node: ArtifactTreeNode }) {
   );
 }
 
-const TYPING_TAGS = new Set(['INPUT', 'TEXTAREA']);
-
-function isTypingTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) return false;
-  return TYPING_TAGS.has(target.tagName) || target.isContentEditable;
-}
-
 interface ArtifactStageProps {
   format: ArtifactFormat;
   content: string;
@@ -72,51 +71,17 @@ interface ArtifactStageProps {
 }
 
 /**
- * html 산출물의 space+드래그 pan(story d425dccc). sandbox=""(allow-scripts 없음) iframe은
+ * html 산출물의 직접-드래그 pan(story e4cce704, v2.1). sandbox=""(allow-scripts 없음) iframe은
  * 자기 자신의 포인터 이벤트를 소비해 드래그가 iframe 경계에서 끊기므로, 투명 오버레이(우리
- * DOM)로 포인터를 가로채는 방식으로 우회한다 — sandbox 완화 없음(iframe 내부는 여전히 0접근).
- * space를 누르고 있을 때만 오버레이가 pointer-events를 받아 grab/grabbing 커서로 드래그하고,
- * 뗄 때 원복(iframe 자체 상호작용에 지장 없음).
+ * DOM)로 포인터를 상시 가로채는 방식으로 우회한다 — sandbox 완화 없음(iframe 내부는 여전히
+ * 0접근). space 게이트 없음(v2에서 hover-gate로 있었으나 뷰어 밖에서 space 누르면 그대로
+ * 페이지 스크롤로 새는 혼란이라 완전 제거) — 오버레이가 항상 pointer-events:auto+grab
+ * 커서라 즉시 가시적인 어포던스, mousedown 즉시 드래그 시작. 트레이드오프: iframe 내부
+ * 텍스트 선택은 포기(뷰어=탐색이 본업, 유나 확定).
  */
 function PanOverlay({ wrapperRef }: { wrapperRef: React.RefObject<HTMLDivElement | null> }) {
-  const [spaceHeld, setSpaceHeld] = useState(false);
   const [dragging, setDragging] = useState(false);
-  const hoveringRef = useRef(false);
   const dragStartRef = useRef({ x: 0, y: 0, scrollLeft: 0, scrollTop: 0 });
-
-  // hover 감지는 wrapper(스크롤 컨테이너)에 직접 건다 — 오버레이 자신은 space 안 눌렀을 때
-  // pointer-events:none이라 자기 위의 mouseenter/leave를 못 받는다(순환 의존 방지).
-  useEffect(() => {
-    const el = wrapperRef.current;
-    if (!el) return;
-    function onEnter() { hoveringRef.current = true; }
-    function onLeave() { hoveringRef.current = false; }
-    el.addEventListener('mouseenter', onEnter);
-    el.addEventListener('mouseleave', onLeave);
-    return () => {
-      el.removeEventListener('mouseenter', onEnter);
-      el.removeEventListener('mouseleave', onLeave);
-    };
-  }, [wrapperRef]);
-
-  useEffect(() => {
-    function onKeyDown(e: KeyboardEvent) {
-      if (e.code !== 'Space' || !hoveringRef.current || isTypingTarget(e.target)) return;
-      e.preventDefault(); // 페이지 스크롤(space=page down) 억제
-      setSpaceHeld(true);
-    }
-    function onKeyUp(e: KeyboardEvent) {
-      if (e.code !== 'Space') return;
-      setSpaceHeld(false);
-      setDragging(false);
-    }
-    window.addEventListener('keydown', onKeyDown);
-    window.addEventListener('keyup', onKeyUp);
-    return () => {
-      window.removeEventListener('keydown', onKeyDown);
-      window.removeEventListener('keyup', onKeyUp);
-    };
-  }, []);
 
   useEffect(() => {
     if (!dragging) return;
@@ -139,7 +104,6 @@ function PanOverlay({ wrapperRef }: { wrapperRef: React.RefObject<HTMLDivElement
   }, [dragging, wrapperRef]);
 
   function handleMouseDown(e: React.MouseEvent) {
-    if (!spaceHeld) return;
     const el = wrapperRef.current;
     if (!el) return;
     dragStartRef.current = { x: e.clientX, y: e.clientY, scrollLeft: el.scrollLeft, scrollTop: el.scrollTop };
@@ -150,13 +114,9 @@ function PanOverlay({ wrapperRef }: { wrapperRef: React.RefObject<HTMLDivElement
     <div
       role="presentation"
       data-pan-overlay
-      data-pan-active={spaceHeld || undefined}
       onMouseDown={handleMouseDown}
       className="absolute inset-0"
-      style={{
-        pointerEvents: spaceHeld ? 'auto' : 'none',
-        cursor: dragging ? 'grabbing' : spaceHeld ? 'grab' : undefined,
-      }}
+      style={{ cursor: dragging ? 'grabbing' : 'grab' }}
     />
   );
 }

--- a/apps/web/src/components/canvas/artifact-viewer.test.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.test.tsx
@@ -130,20 +130,11 @@ describe('ArtifactViewer (SSR snapshot)', () => {
       expect(markup).not.toContain('aria-pressed');
     });
 
-    it('renders the always-visible-scrollbar hook and pan hint copy for the inline html stage', () => {
+    it('renders the always-visible-scrollbar hook for the inline html stage', () => {
       const markup = renderToStaticMarkup(
         wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
       );
       expect(markup).toContain('data-artifact-stage-scroll');
-      expect(markup).toContain('스페이스를 누른 채 드래그하면 이동합니다');
-    });
-
-    it('the pan overlay starts inert (pointer-events:none) until space is held — no accidental capture', () => {
-      const markup = renderToStaticMarkup(
-        wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
-      );
-      expect(markup).toContain('data-pan-overlay');
-      expect(markup).not.toContain('data-pan-active');
     });
 
     it('the expand dialog is not rendered in the DOM when closed by default (base-ui portal, no leaked markup)', () => {
@@ -151,6 +142,25 @@ describe('ArtifactViewer (SSR snapshot)', () => {
         wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
       );
       expect(markup).not.toContain('90vw');
+    });
+  });
+
+  describe('story e4cce704(v2.1) — space 게이트 완전 제거, 직접-드래그 pan', () => {
+    it('the pan overlay always renders with the grab cursor (즉시 가시 어포던스, space 대기 없음)', () => {
+      const markup = renderToStaticMarkup(
+        wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+      );
+      expect(markup).toContain('data-pan-overlay');
+      expect(markup).toContain('cursor:grab');
+      expect(markup).not.toContain('pointer-events:none');
+    });
+
+    it('renders the updated drag hint copy, never the discarded space-based instruction', () => {
+      const markup = renderToStaticMarkup(
+        wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+      );
+      expect(markup).toContain('끌어서 이동');
+      expect(markup).not.toContain('스페이스');
     });
   });
 });


### PR DESCRIPTION
## 변경 사항
story `e4cce704` — 선생님 실사용 지적 3차("스페이스 누르면 스크롤 다운되는 ㅋㅋ 머하는지"). v2(#2130)의 hover-gate space pan은 뷰어 위에서는 의도대로 동작했지만, 게이트 상태가 비가시라 **뷰어 밖에서 space를 누르면 그대로 페이지 스크롤로 새는 게 "고장"으로 읽힘**. 유나 판정(KISS — "클릭 통과" 절충은 cross-origin에서 반쯤 작동하는 복잡 상태라 명시 거부)에 따라 space 의존을 완전히 제거했습니다.

## 구현
- `keydown`/`keyup` 리스너·`hoveringRef`·`spaceHeld`·`isTypingTarget` 전부 삭제 — space 키는 뷰어 안팎 어디서든 브라우저 기본 그대로(가로채기 0)
- 오버레이가 상시 `pointer-events:auto`+grab 커서(즉시 가시 어포던스) — mousedown 즉시 드래그 시작. 인라인/모달 동일(같은 `ArtifactStage` 재사용이라 자동 커버)
- pan 힌트 카피 "스페이스를 누른 채…" → "끌어서 이동"으로 갱신
- **트레이드오프 확定(유나)**: 오버레이가 상시 활성이라 iframe 내부 텍스트 선택은 불가 — 뷰어=탐색이 본업이라는 판단으로 수용
- image/tree 완전 무변경, 기존 가로 스크롤바 상시화·"크게 보기" 모달 회귀 0

## 테스트
- jsdom 직접-드래그 3건(신규 `artifact-stage.test.tsx`): mousedown+drag만으로 스크롤 이동·grab↔grabbing 커서 전환·`keydown`/`keyup` 리스너 자체가 0건임을 `addEventListener` spy로 확인(space 게이트 완전 제거 회귀가드)
- SSR 회귀가드 2건 교체(`artifact-viewer.test.tsx`): 오버레이 상시 grab 커서·`pointer-events:none` 문자열 자체가 마크업에 없음·갱신된 힌트 카피만 렌더(폐기된 스페이스 문구 미노출)
- 전체 `pnpm vitest run`: **1326 passed | 2 skipped**, 회귀 0
- `tsc --noEmit`: clean
- `eslint`: 0 warning
- `pnpm build`: EXIT=0

## 반응형/스크린샷
드래그 pan 실감·grab 커서 가시성은 라이브 픽셀에서만 확실히 검증 가능한 영역이라, dev 배포 후 오르테가군 라이브 done-gate에서 실측 예정(드래그 pan 실동작·space 무간섭).