### PR TITLE
[SID:3d888ba2] 갤러리에서 산출물 실물 열람 — 클릭→뷰어 모달 + 그리드 시각 프리뷰

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3567,6 +3567,10 @@
     "galleryLazyHint": "Expanding loads earlier versions.",
     "galleryVersionsUnavailable": "Couldn't load earlier versions.",
     "viewerExpandAction": "Expand view",
-    "viewerPanHint": "Drag to move"
+    "viewerPanHint": "Drag to move",
+    "galleryFormatHtml": "Web page",
+    "galleryFormatImage": "Image",
+    "galleryFormatTree": "Layout",
+    "galleryOpenArtifactAction": "Open artifact"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3567,6 +3567,10 @@
     "galleryLazyHint": "펼치면 이전 버전을 불러옵니다",
     "galleryVersionsUnavailable": "이전 버전을 불러올 수 없습니다",
     "viewerExpandAction": "크게 보기",
-    "viewerPanHint": "끌어서 이동"
+    "viewerPanHint": "끌어서 이동",
+    "galleryFormatHtml": "웹 페이지",
+    "galleryFormatImage": "이미지",
+    "galleryFormatTree": "레이아웃",
+    "galleryOpenArtifactAction": "산출물 열기"
   }
 }

--- a/apps/web/src/app/api/visual-artifacts/[id]/versions/[versionNumber]/route.ts
+++ b/apps/web/src/app/api/visual-artifacts/[id]/versions/[versionNumber]/route.ts
@@ -1,0 +1,24 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string; versionNumber: string }> };
+
+/**
+ * GET /api/visual-artifacts/{id}/versions/{versionNumber} — story 3d888ba2. 특정 버전의
+ * nodes 포함 상세(신규 BE 0 — `GET /api/v2/visual-artifacts/{id}/versions/{version_number}`은
+ * 이미 존재, `[id]/route.ts`의 최신 버전 조회와 동일 `_load_detail` 함수를 버전 지정으로 씀).
+ * 갤러리 변천사에서 특정 버전 클릭→그 버전 실물 렌더에 쓰인다.
+ */
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id, versionNumber } = await params;
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    const _r = await proxyToFastapi(request, `/api/v2/visual-artifacts/${id}/versions/${versionNumber}`);
+    if (!_r.ok) return _r;
+    const json = (await _r.json()) as { data?: unknown };
+    return apiSuccess(json.data ?? null);
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/components/canvas/artifact-expand-dialog.tsx
+++ b/apps/web/src/components/canvas/artifact-expand-dialog.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
+import { cn } from '@/lib/utils';
+import { ArtifactStage } from './artifact-stage';
+import type { ArtifactFormat } from '@/services/canvas';
+
+interface ArtifactExpandDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  format: ArtifactFormat;
+  content: string;
+}
+
+/**
+ * "크게 보기" 모달(story d425dccc 원조·story 3d888ba2에서 스토리 상세 뷰어와 갤러리가 공유하도록
+ * 추출) — 큰 표면(≈90vw×85vh)에서 ArtifactStage를 `fill` 모드로 재렌더(html=실제 크기+직접
+ * 드래그 pan, image/tree=해당 포맷 그대로). 신규 뷰어 0 — 기존 컴포넌트 재사용.
+ */
+export function ArtifactExpandDialog({ open, onOpenChange, title, format, content }: ArtifactExpandDialogProps) {
+  const t = useTranslations('canvas');
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Backdrop className="fixed inset-0 z-50 bg-black/40 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
+        <DialogPrimitive.Popup
+          className={cn(
+            'fixed top-1/2 left-1/2 z-50 flex h-[85vh] w-[90vw] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden',
+            'rounded-xl bg-card shadow-lg ring-1 ring-foreground/10 outline-none',
+            'data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95',
+            'data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          )}
+        >
+          <div className="flex items-center gap-2 border-b border-border px-4 py-2.5">
+            <DialogPrimitive.Title className="truncate text-sm font-semibold text-foreground">
+              {title}
+            </DialogPrimitive.Title>
+            <DialogPrimitive.Close
+              className="ml-auto rounded-md border border-border px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              {t('closeAction')}
+            </DialogPrimitive.Close>
+          </div>
+          <div className="min-h-0 flex-1 overflow-hidden p-4">
+            <ArtifactStage format={format} content={content} title={title} fill />
+          </div>
+        </DialogPrimitive.Popup>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/apps/web/src/components/canvas/artifact-gallery-timeline.tsx
+++ b/apps/web/src/components/canvas/artifact-gallery-timeline.tsx
@@ -12,6 +12,8 @@ export interface GalleryTimelineVersion {
 interface ArtifactGalleryTimelineProps {
   versions: GalleryTimelineVersion[];
   className?: string;
+  /** story 3d888ba2 — 변천사에서 특정 버전 클릭→그 버전 실물 열람. 생략 시 정적 라벨(회귀 0). */
+  onSelectVersion?: (versionNumber: number) => void;
 }
 
 /**
@@ -21,14 +23,14 @@ interface ArtifactGalleryTimelineProps {
  * 더 엄격함 — **주어는 산출물/버전의 진화**뿐, 작성자·편집 횟수·경과시간은 렌더 자체가 없다.
  * anchor(정본)=success 톤 노드, 그 외=info 톤 — 빨강 0.
  */
-export function ArtifactGalleryTimeline({ versions, className }: ArtifactGalleryTimelineProps) {
+export function ArtifactGalleryTimeline({ versions, className, onSelectVersion }: ArtifactGalleryTimelineProps) {
   const t = useTranslations('canvas');
   return (
     <div className={cn('flex items-start gap-0 overflow-x-auto', className)}>
       {versions.map((v, i) => {
         const isLast = i === versions.length - 1;
-        return (
-          <div key={v.versionNumber} className={cn('min-w-0', isLast ? 'flex-none' : 'flex-1 pr-3.5')}>
+        const label = (
+          <>
             <div className="mb-1.5 flex items-center gap-0">
               <span
                 className={cn(
@@ -44,6 +46,15 @@ export function ArtifactGalleryTimeline({ versions, className }: ArtifactGallery
               {v.isAnchor ? <span className="ml-1 font-medium">{t('versionAnchorTag')}</span> : null}
             </p>
             {v.summary ? <p className="mt-0.5 truncate text-[11.5px] text-muted-foreground">{v.summary}</p> : null}
+          </>
+        );
+        return (
+          <div key={v.versionNumber} className={cn('min-w-0', isLast ? 'flex-none' : 'flex-1 pr-3.5')}>
+            {onSelectVersion ? (
+              <button type="button" onClick={() => onSelectVersion(v.versionNumber)} className="w-full text-left hover:opacity-80">
+                {label}
+              </button>
+            ) : label}
           </div>
         );
       })}

--- a/apps/web/src/components/canvas/artifact-gallery-view.test.tsx
+++ b/apps/web/src/components/canvas/artifact-gallery-view.test.tsx
@@ -2,6 +2,12 @@
 //
 // story a15cea4f — 산출물 갤러리 회귀가드. fetch를 4축 lookup + artifacts로 스텁해 실 렌더를
 // 검증(mock 컴포넌트 없음, useDashboardContext만 스텁 — 라우팅 컨텍스트 무관하게 projectId 고정).
+//
+// story 3d888ba2 — 썸네일(exports/version-detail)이 추가되며 URL 매칭 정밀도가 중요해짐:
+// `/api/visual-artifacts/{id}/versions/{n}`(단일 객체)과 `/api/visual-artifacts/{id}/versions`
+// (배열)·`/api/visual-artifacts/{id}/exports`(배열)를 startsWith만으로 구분 못 하면 엉뚱한
+// shape가 detail 자리에 들어가 `adaptArtifactDetail`이 크래시한다(1차 구현 때 실제로 겪음) —
+// 정규식으로 정밀 매칭.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
@@ -30,12 +36,42 @@ const ARTIFACTS = [
   { id: 'a2', title: '배너 세트 A', story_id: null, epic_id: null, doc_id: null, source: 'created', latest_version_number: 1, anchor_version: null, created_by: 'm1', created_at: '2026-07-01T00:00:00Z' },
 ];
 
-function stubFetch() {
+const HTML_NODE = { id: 'n1', type: 'html_blob', props: { html: '<div>실물 콘텐츠</div>' } };
+
+function versionDetail(artifactId: string, versionNumber: number, nodes: unknown[] = [HTML_NODE]) {
+  return {
+    id: artifactId, title: '웰컴 이메일 시안', story_id: null, epic_id: 'e1', doc_id: null,
+    source: 'created', latest_version_number: 3, anchor_version: 3, created_by: 'm1',
+    created_at: '2026-07-01T00:00:00Z', version_number: versionNumber, version_summary: null, nodes,
+  };
+}
+
+interface StubOverrides {
+  artifacts?: unknown[];
+  stories?: unknown[];
+  exportsByArtifact?: Record<string, unknown[]>;
+  versionDetailByArtifact?: Record<string, unknown>;
+}
+
+function stubFetch(overrides: StubOverrides = {}) {
   return vi.fn(async (url: string) => {
-    if (url.startsWith('/api/visual-artifacts/')) return jsonRes([{ id: 'v1', version_number: 1, summary: '초안 레이아웃', created_by: 'm1', created_at: '', source_comment_id: null }]);
-    if (url.startsWith('/api/visual-artifacts')) return jsonRes(ARTIFACTS);
+    const versionMatch = /^\/api\/visual-artifacts\/([^/]+)\/versions\/(\d+)/.exec(url);
+    if (versionMatch) {
+      const [, artifactId, versionNumber] = versionMatch;
+      const byVersion = overrides.versionDetailByArtifact?.[`${artifactId}:${versionNumber}`];
+      const byArtifact = overrides.versionDetailByArtifact?.[artifactId!];
+      return jsonRes(byVersion ?? byArtifact ?? null);
+    }
+    if (/^\/api\/visual-artifacts\/[^/]+\/versions/.exec(url)) {
+      return jsonRes([{ id: 'v1', version_number: 1, summary: '초안 레이아웃', created_by: 'm1', created_at: '', source_comment_id: null }]);
+    }
+    const exportsMatch = /^\/api\/visual-artifacts\/([^/]+)\/exports/.exec(url);
+    if (exportsMatch) {
+      return jsonRes(overrides.exportsByArtifact?.[exportsMatch[1]!] ?? []);
+    }
+    if (url.startsWith('/api/visual-artifacts')) return jsonRes(overrides.artifacts ?? ARTIFACTS);
     if (url.startsWith('/api/epics')) return jsonRes([{ id: 'e1', title: '온보딩 캠페인' }]);
-    if (url.startsWith('/api/stories')) return jsonRes([]);
+    if (url.startsWith('/api/stories')) return jsonRes(overrides.stories ?? []);
     if (url.startsWith('/api/sprints')) return jsonRes([]);
     if (url.startsWith('/api/docs')) return jsonRes([]);
     return jsonRes(null);
@@ -54,6 +90,12 @@ afterEach(async () => {
   container.remove();
   vi.unstubAllGlobals();
 });
+
+// 썸네일도 'live' 상태면 자기 iframe[srcdoc]을 갖는다(container 안) — 모달은 base-ui
+// Portal로 document.body에 형제로 렌더되니, container 밖의 것만 골라야 모달 iframe이 잡힌다.
+function findDialogIframe(): HTMLIFrameElement | undefined {
+  return [...document.body.querySelectorAll('iframe[srcdoc]')].find((el) => !container.contains(el)) as HTMLIFrameElement | undefined;
+}
 
 async function mount() {
   await act(async () => {
@@ -101,17 +143,12 @@ describe('ArtifactGalleryView (story a15cea4f)', () => {
   // story ca37b2b0 — dev 실데이터 재현: 산출물은 story_id만 있고 epic_id는 NULL(에이전트 저작
   // 산출물 기본형). story 경유 유도가 없으면 에픽 탭이 전건 무소속으로 떨어지던 근본원인.
   it('resolves the epic through the artifact\'s story when the artifact has no direct epic_id (스토리 경유 유도)', async () => {
-    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
-      if (url.startsWith('/api/visual-artifacts/')) return jsonRes([]);
-      if (url.startsWith('/api/visual-artifacts')) return jsonRes([
+    vi.stubGlobal('fetch', stubFetch({
+      artifacts: [
         { id: 'a1', title: '스토리 앵커 산출물', story_id: 's1', epic_id: null, doc_id: null, source: 'created', latest_version_number: 1, anchor_version: null, created_by: 'm1', created_at: '2026-07-01T00:00:00Z' },
-      ]);
-      if (url.startsWith('/api/epics')) return jsonRes([{ id: 'e1', title: '온보딩 캠페인' }]);
-      if (url.startsWith('/api/stories')) return jsonRes([{ id: 's1', title: '웰컴 이메일 스토리', sprint_id: null, epic_id: 'e1' }]);
-      if (url.startsWith('/api/sprints')) return jsonRes([]);
-      if (url.startsWith('/api/docs')) return jsonRes([]);
-      return jsonRes(null);
-    }) as unknown as typeof fetch);
+      ],
+      stories: [{ id: 's1', title: '웰컴 이메일 스토리', sprint_id: null, epic_id: 'e1' }],
+    }));
     await mount();
     expect(container.textContent).toContain('온보딩 캠페인');
     expect(container.textContent).toContain('스토리 앵커 산출물');
@@ -120,11 +157,68 @@ describe('ArtifactGalleryView (story a15cea4f)', () => {
   });
 
   it('renders the empty state when the project has no artifacts at all', async () => {
-    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
-      if (url.startsWith('/api/visual-artifacts')) return jsonRes([]);
-      return jsonRes([]);
-    }) as unknown as typeof fetch);
+    vi.stubGlobal('fetch', stubFetch({ artifacts: [] }));
     await mount();
     expect(container.textContent).toContain('아직 모인 산출물이 없습니다');
+  });
+});
+
+describe('ArtifactGalleryView — story 3d888ba2 (실물 열람 + 그리드 시각 프리뷰)', () => {
+  it('clicking the thumbnail opens the expand dialog with the real anchor/latest version content', async () => {
+    vi.stubGlobal('fetch', stubFetch({
+      versionDetailByArtifact: { a1: versionDetail('a1', 3) },
+    }));
+    await mount();
+    const thumbBtn = container.querySelector('[title="산출물 열기"]') as HTMLButtonElement;
+    expect(thumbBtn).not.toBeNull();
+    await act(async () => { thumbBtn.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+    // srcDoc은 별도 문서라 document.body.textContent에 안 잡힌다 — iframe 자신의 srcdoc으로 확인.
+    const dialogIframe = findDialogIframe();
+    expect(dialogIframe).not.toBeUndefined();
+    expect(dialogIframe!.srcdoc).toContain('실물 콘텐츠');
+  });
+
+  it('clicking a specific version in the timeline opens that version, not the default one', async () => {
+    vi.stubGlobal('fetch', stubFetch({
+      // 기본(anchor v3) 열람과 명시적으로 다른 응답을 v1(타임라인 클릭 대상)에만 배선 —
+      // 버전 번호가 실제로 URL에 실려 구분됐는지 검증하는 게 이 테스트의 핵심.
+      versionDetailByArtifact: {
+        'a1:1': versionDetail('a1', 1, [{ id: 'n2', type: 'html_blob', props: { html: '<div>버전1 콘텐츠</div>' } }]),
+        'a1:3': versionDetail('a1', 3, [{ id: 'n1', type: 'html_blob', props: { html: '<div>기본(앵커) 콘텐츠</div>' } }]),
+      },
+    }));
+    await mount();
+    const row = container.querySelector('[role="button"]');
+    await act(async () => { row!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    const versionBtn = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('v1'));
+    expect(versionBtn).toBeDefined();
+    await act(async () => { versionBtn!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); });
+    const dialogIframe = findDialogIframe();
+    expect(dialogIframe).not.toBeUndefined();
+    expect(dialogIframe!.srcdoc).toContain('버전1 콘텐츠');
+    expect(dialogIframe!.srcdoc).not.toContain('기본(앵커) 콘텐츠');
+  });
+
+  it('thumbnail prefers a PNG export over live content when one exists (no live iframe rendered)', async () => {
+    vi.stubGlobal('fetch', stubFetch({
+      exportsByArtifact: { a1: [{ id: 'exp1', artifact_id: 'a1', version_id: 'v1', version_number: 3, format: 'png', created_by: 'm1', created_at: '', asset_id: 'asset1', download_url: 'https://cdn.example.com/a1.png' }] },
+      versionDetailByArtifact: { a1: versionDetail('a1', 3) },
+    }));
+    await mount();
+    const thumb = container.querySelector('[data-artifact-thumbnail]');
+    expect(thumb?.querySelector('img')?.getAttribute('src')).toBe('https://cdn.example.com/a1.png');
+    expect(thumb?.querySelector('iframe')).toBeNull();
+  });
+
+  it('shows a neutral format placeholder — never a fake "preparing" state — when nothing is renderable', async () => {
+    vi.stubGlobal('fetch', stubFetch()); // no exports, no version detail configured → both miss
+    await mount();
+    const thumb = container.querySelector('[data-artifact-thumbnail]');
+    expect(thumb?.querySelector('img')).toBeNull();
+    expect(thumb?.querySelector('iframe')).toBeNull();
+    expect(thumb?.textContent).not.toMatch(/준비 중|불러오는 중/);
   });
 });

--- a/apps/web/src/components/canvas/artifact-gallery-view.tsx
+++ b/apps/web/src/components/canvas/artifact-gallery-view.tsx
@@ -5,12 +5,17 @@ import { useTranslations } from 'next-intl';
 import { ChevronDown, ChevronRight, Frame } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
-import type { BeVisualArtifactSummary, BeArtifactVersionSummary } from '@/services/canvas';
+import {
+  adaptArtifactDetail, getArtifactVersionDetail,
+  type ArtifactFormat, type BeVisualArtifactSummary, type BeArtifactVersionSummary,
+} from '@/services/canvas';
 import {
   buildGalleryGroups, GALLERY_AXES,
   type GalleryAxis, type GalleryGroup, type GalleryLookups,
 } from '@/services/artifact-gallery';
 import { ArtifactGalleryTimeline, type GalleryTimelineVersion } from './artifact-gallery-timeline';
+import { ArtifactThumbnail } from './artifact-thumbnail';
+import { ArtifactExpandDialog } from './artifact-expand-dialog';
 
 async function fetchJson<T>(url: string): Promise<T | null> {
   try {
@@ -72,7 +77,7 @@ function GroupListSkeleton() {
 }
 
 function ArtifactRow({
-  artifact, axisT, expanded, versions, versionsLoading, onToggle,
+  artifact, axisT, expanded, versions, versionsLoading, onToggle, onOpen, onOpenVersion,
 }: {
   artifact: GalleryGroup['artifacts'][number];
   axisT: ReturnType<typeof useTranslations>;
@@ -80,6 +85,10 @@ function ArtifactRow({
   versions: GalleryTimelineVersion[] | undefined;
   versionsLoading: boolean;
   onToggle: () => void;
+  /** story 3d888ba2 — 썸네일 클릭→실물 열람(기본 버전=anchor??latest). 행 전체 클릭(onToggle)과
+   * 별개 클릭 타깃(stopPropagation)이라 기존 펼침 토글 회귀 0. */
+  onOpen: () => void;
+  onOpenVersion: (versionNumber: number) => void;
 }) {
   return (
     <div className="border-t border-border/60 first:border-t-0">
@@ -90,7 +99,19 @@ function ArtifactRow({
         onKeyDown={(e) => { if (e.key === 'Enter') onToggle(); }}
         className="flex cursor-pointer items-center gap-3 px-1 py-3"
       >
-        <span className="h-[22px] w-[30px] shrink-0 rounded border border-border bg-muted/50" aria-hidden="true" />
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onOpen(); }}
+          title={axisT('galleryOpenArtifactAction')}
+          className="shrink-0 rounded transition-opacity hover:opacity-80"
+        >
+          <ArtifactThumbnail
+            artifactId={artifact.id}
+            latestVersionNumber={artifact.latestVersionNumber}
+            anchorVersion={artifact.anchorVersion}
+            className="h-10 w-14"
+          />
+        </button>
         <span className="min-w-0 flex-1 truncate text-[13.5px] font-semibold text-foreground">
           {artifact.title}
         </span>
@@ -105,12 +126,12 @@ function ArtifactRow({
         {expanded ? <ChevronDown className="size-3 shrink-0 text-muted-foreground" /> : <ChevronRight className="size-3 shrink-0 text-muted-foreground" />}
       </div>
       {expanded ? (
-        <div className="pb-4 pl-[41px] pr-1">
+        <div className="pb-4 pl-[68px] pr-1">
           <p className="mb-2 text-[9.5px] tracking-wide text-muted-foreground/70">{axisT('galleryLazyHint')}</p>
           {versionsLoading ? (
             <div className="h-10 animate-pulse rounded bg-muted/50" />
           ) : versions && versions.length > 0 ? (
-            <ArtifactGalleryTimeline versions={versions} />
+            <ArtifactGalleryTimeline versions={versions} onSelectVersion={onOpenVersion} />
           ) : (
             <p className="text-[11.5px] text-muted-foreground">{axisT('galleryVersionsUnavailable')}</p>
           )}
@@ -138,6 +159,7 @@ export function ArtifactGalleryView() {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [versionsByArtifact, setVersionsByArtifact] = useState<Record<string, GalleryTimelineVersion[]>>({});
   const [versionsLoadingId, setVersionsLoadingId] = useState<string | null>(null);
+  const [expandTarget, setExpandTarget] = useState<{ format: ArtifactFormat; content: string; title: string } | null>(null);
 
   useEffect(() => {
     if (!projectId) return;
@@ -179,6 +201,20 @@ export function ArtifactGalleryView() {
       .map((v) => ({ versionNumber: v.version_number, summary: v.summary, isAnchor: v.version_number === detail?.anchorVersion }));
     setVersionsByArtifact((cur) => ({ ...cur, [artifactId]: mapped }));
     setVersionsLoadingId(null);
+  }
+
+  /**
+   * story 3d888ba2 — 실물 열람. 갤러리 요약엔 format이 없어(BE 계약상 nodes 파생) 버전 상세를
+   * 열 때마다 받아야 한다 — 실패(삭제된 버전 등)면 조용히 아무것도 안 함(no-fiction: 깨진/빈
+   * 모달을 여는 것보다 아무 반응 없는 게 정직).
+   */
+  async function handleOpenArtifact(artifactId: string, versionNumber: number, title: string) {
+    const detail = await getArtifactVersionDetail(artifactId, versionNumber);
+    if (!detail) return;
+    const { artifact, versions } = adaptArtifactDetail(detail);
+    const content = versions[0]?.content;
+    if (!content) return;
+    setExpandTarget({ format: artifact.format, content, title });
   }
 
   const axisLabel = (a: GalleryAxis) => t(`galleryAxis${a[0]!.toUpperCase()}${a.slice(1)}`);
@@ -267,6 +303,8 @@ export function ArtifactGalleryView() {
                     versions={versionsByArtifact[artifact.id]}
                     versionsLoading={versionsLoadingId === artifact.id}
                     onToggle={() => void handleToggleExpand(artifact.id)}
+                    onOpen={() => void handleOpenArtifact(artifact.id, artifact.anchorVersion ?? artifact.latestVersionNumber, artifact.title)}
+                    onOpenVersion={(versionNumber) => void handleOpenArtifact(artifact.id, versionNumber, artifact.title)}
                   />
                 ))}
               </>
@@ -274,6 +312,15 @@ export function ArtifactGalleryView() {
           </div>
         </div>
       )}
+      {expandTarget ? (
+        <ArtifactExpandDialog
+          open={expandTarget !== null}
+          onOpenChange={(next) => { if (!next) setExpandTarget(null); }}
+          title={expandTarget.title}
+          format={expandTarget.format}
+          content={expandTarget.content}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/components/canvas/artifact-thumbnail.tsx
+++ b/apps/web/src/components/canvas/artifact-thumbnail.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { FileCode2, Image as ImageIcon, Workflow } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+import { adaptArtifactDetail, getArtifactVersionDetail, type ArtifactFormat } from '@/services/canvas';
+import { listArtifactExports } from '@/services/canvas-export';
+
+const THUMB_CANVAS_WIDTH = 480;
+const THUMB_CANVAS_HEIGHT = 280;
+
+type ThumbnailState =
+  | { kind: 'loading' }
+  | { kind: 'image'; url: string }
+  | { kind: 'live'; content: string }
+  | { kind: 'placeholder'; format: ArtifactFormat };
+
+const FORMAT_ICON: Record<ArtifactFormat, typeof FileCode2> = {
+  html: FileCode2,
+  image: ImageIcon,
+  tree: Workflow,
+};
+
+interface ArtifactThumbnailProps {
+  artifactId: string;
+  latestVersionNumber: number;
+  anchorVersion: number | null;
+  className?: string;
+}
+
+/**
+ * story 3d888ba2 — 갤러리 그리드 시각 프리뷰. no-fiction 원칙상 가짜 프리뷰(스켈레톤을 "준비 중"
+ * 텍스트로 위장 등)는 절대 금지 — 실제로 보여줄 게 없으면 중립 포맷 아이콘으로 정직 표기한다.
+ * 우선순위(PO 확定): ① export PNG 있으면 그걸 썸네일(가장 저비용·안정적, 포맷 무관) ② 없으면
+ * 실 콘텐츠를 축소 렌더(html=iframe 스케일다운·image=원본 그대로) ③ tree는 PNG 없으면 렌더
+ * 수단이 없어 placeholder(트리 미니어처 렌더러는 스코프 밖). 갤러리 요약 목록에는 format이
+ * 없어(BE `VisualArtifactSummary`에 필드 자체가 없음 — nodes 기반 파생이라 버전 상세에서만
+ * 나옴) PNG 조회와 버전 상세를 병렬로 같이 받아 판정한다. 둘 다 뷰포트 진입 시에만(lazy) —
+ * 항목 多 갤러리에서 동시 다발 iframe/fetch를 피한다.
+ */
+export function ArtifactThumbnail({ artifactId, latestVersionNumber, anchorVersion, className }: ArtifactThumbnailProps) {
+  const t = useTranslations('canvas');
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const stageRef = useRef<HTMLDivElement>(null);
+  // IntersectionObserver 미지원 환경(구형 브라우저)은 lazy 게이트 없이 즉시 in-view로
+  // 시작(기능 저하 없이 성능만 양보, 크래시보다 나음) — effect 안에서 동기 setState하는
+  // 대신 초기값 자체를 분기해 cascading render를 피한다.
+  const [inView, setInView] = useState(() => typeof IntersectionObserver === 'undefined');
+  const [state, setState] = useState<ThumbnailState>({ kind: 'loading' });
+  const [scale, setScale] = useState(1);
+
+  useEffect(() => {
+    if (typeof IntersectionObserver === 'undefined') return;
+    const el = wrapperRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0]?.isIntersecting) { setInView(true); observer.disconnect(); }
+    }, { rootMargin: '200px' });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!inView) return;
+    let cancelled = false;
+    void (async () => {
+      const targetVersion = anchorVersion ?? latestVersionNumber;
+      const [exports, detail] = await Promise.all([
+        listArtifactExports(artifactId, targetVersion),
+        getArtifactVersionDetail(artifactId, targetVersion),
+      ]);
+      if (cancelled) return;
+
+      const png = (exports ?? []).find((e) => e.format === 'png' && e.download_url);
+      if (png?.download_url) { setState({ kind: 'image', url: png.download_url }); return; }
+
+      if (!detail) { setState({ kind: 'placeholder', format: 'tree' }); return; }
+      const { artifact, versions } = adaptArtifactDetail(detail);
+      const content = versions[0]?.content;
+      if (artifact.format === 'tree' || !content) { setState({ kind: 'placeholder', format: artifact.format }); return; }
+      setState(artifact.format === 'image' ? { kind: 'image', url: content } : { kind: 'live', content });
+    })();
+    return () => { cancelled = true; };
+  }, [inView, artifactId, anchorVersion, latestVersionNumber]);
+
+  useEffect(() => {
+    if (state.kind !== 'live') return;
+    const el = stageRef.current;
+    if (!el) return;
+    const measure = () => setScale(Math.min(1, el.clientWidth / THUMB_CANVAS_WIDTH));
+    measure();
+    // ResizeObserver 미지원 환경 — 초기 측정값(또는 fallback 1)으로 정적 유지, 크래시 방지.
+    if (typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [state.kind]);
+
+  return (
+    <div
+      ref={wrapperRef}
+      data-artifact-thumbnail
+      className={cn('shrink-0 overflow-hidden rounded border border-border bg-muted/40', className)}
+    >
+      {state.kind === 'loading' ? (
+        <div className="size-full animate-pulse bg-muted/60" />
+      ) : state.kind === 'image' ? (
+        // eslint-disable-next-line @next/next/no-img-element -- PNG export/artifact content는 외부·동적 URL이라 next/image 도메인 화이트리스트와 안 맞음.
+        <img src={state.url} alt="" className="size-full object-cover" />
+      ) : state.kind === 'live' ? (
+        <div ref={stageRef} className="pointer-events-none size-full" style={{ height: THUMB_CANVAS_HEIGHT * scale }}>
+          <iframe
+            title=""
+            aria-hidden="true"
+            tabIndex={-1}
+            srcDoc={state.content}
+            sandbox=""
+            style={{
+              width: THUMB_CANVAS_WIDTH, height: THUMB_CANVAS_HEIGHT,
+              transform: `scale(${scale})`, transformOrigin: 'top left',
+            }}
+          />
+        </div>
+      ) : (
+        (() => {
+          const Icon = FORMAT_ICON[state.format];
+          return (
+            <div className="flex size-full flex-col items-center justify-center gap-0.5 text-muted-foreground/60">
+              <Icon className="size-4" aria-hidden />
+              <span className="text-[8px] font-semibold uppercase tracking-wide">
+                {t(`galleryFormat${state.format[0]!.toUpperCase()}${state.format.slice(1)}`)}
+              </span>
+            </div>
+          );
+        })()
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/canvas/artifact-viewer.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.tsx
@@ -3,9 +3,8 @@
 import { useRef, useState } from 'react';
 import { Check, Clock, Download, Maximize2, MessageCircle, Pencil, Sparkles } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
-import { cn } from '@/lib/utils';
 import { ArtifactStage } from './artifact-stage';
+import { ArtifactExpandDialog } from './artifact-expand-dialog';
 import { ArtifactVersionRail } from './artifact-version-rail';
 import { AnchorPin } from './anchor-pin';
 import { CommentThreadCard } from './comment-thread-card';
@@ -208,33 +207,13 @@ export function ArtifactViewer({
         artifactFormat={artifact.format}
       />
       {activeVersion && artifact.format === 'html' ? (
-        <DialogPrimitive.Root open={expandOpen} onOpenChange={setExpandOpen}>
-          <DialogPrimitive.Portal>
-            <DialogPrimitive.Backdrop className="fixed inset-0 z-50 bg-black/40 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
-            <DialogPrimitive.Popup
-              className={cn(
-                'fixed top-1/2 left-1/2 z-50 flex h-[85vh] w-[90vw] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden',
-                'rounded-xl bg-card shadow-lg ring-1 ring-foreground/10 outline-none',
-                'data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95',
-                'data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
-              )}
-            >
-              <div className="flex items-center gap-2 border-b border-border px-4 py-2.5">
-                <DialogPrimitive.Title className="truncate text-sm font-semibold text-foreground">
-                  {artifact.title}
-                </DialogPrimitive.Title>
-                <DialogPrimitive.Close
-                  className="ml-auto rounded-md border border-border px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
-                >
-                  {t('closeAction')}
-                </DialogPrimitive.Close>
-              </div>
-              <div className="min-h-0 flex-1 overflow-hidden p-4">
-                <ArtifactStage format={artifact.format} content={activeVersion.content} title={artifact.title} fill />
-              </div>
-            </DialogPrimitive.Popup>
-          </DialogPrimitive.Portal>
-        </DialogPrimitive.Root>
+        <ArtifactExpandDialog
+          open={expandOpen}
+          onOpenChange={setExpandOpen}
+          title={artifact.title}
+          format={artifact.format}
+          content={activeVersion.content}
+        />
       ) : null}
     </div>
   );

--- a/apps/web/src/services/canvas.ts
+++ b/apps/web/src/services/canvas.ts
@@ -200,6 +200,25 @@ export function adaptArtifactDetail(detail: BeVisualArtifactDetail): { artifact:
 }
 
 /**
+ * story 3d888ba2 — 갤러리 변천사에서 특정 버전 실물 열람. `GET /{id}/versions/{versionNumber}`
+ * 는 `[id]`(최신 버전)와 동일 shape(`BeVisualArtifactDetail`)를 버전 지정으로 반환 — 신규 BE
+ * 0(이미 존재하는 엔드포인트, FE 프록시만 신설). `adaptArtifactDetail`을 그대로 재사용해
+ * format/content를 뽑아낼 수 있다.
+ */
+export async function getArtifactVersionDetail(
+  artifactId: string, versionNumber: number,
+): Promise<BeVisualArtifactDetail | null> {
+  try {
+    const res = await fetch(`/api/visual-artifacts/${artifactId}/versions/${versionNumber}`);
+    if (!res.ok) return null;
+    const json = (await res.json()) as { data?: BeVisualArtifactDetail };
+    return json.data ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * 캔버스 휴먼 진입점(story 9449da0e) — 빈 스토리에서 "그리기" 생성 딸깍 커밋. MCP `create_artifact`와
  * **동일 BE 엔드포인트**(`POST /api/v2/visual-artifacts`·같은 서비스 `create_artifact`·신규 BE 0).
  * story 귀속 v1을 만들고 생성된 detail을 반환 — 실패는 null(호출부가 편집 모드 유지 + 로깅, 빈


### PR DESCRIPTION
## 변경 사항
story `3d888ba2` — 선생님 지적("이딴 페이지는 왜 존재해야 하는지??"). 갤러리(#2124)가 4축 그룹핑+제목+변천사 타임라인만 렌더하고 **산출물 콘텐츠를 보는 수단이 0**이었던 갭을 해소합니다.

## 구현
**클릭→실물 열람**: "크게 보기" 모달(story d425dccc 원조)을 `ArtifactViewer`와 갤러리가 공유하도록 `artifact-expand-dialog.tsx`로 추출(신규 뷰어 0, 배선만).
- 행 썸네일 클릭 → anchor/latest 버전 열람
- 변천사에서 특정 버전 클릭 → 그 버전 실물 열람
- 둘 다 신규 FE 프록시 `GET /api/visual-artifacts/{id}/versions/{versionNumber}` 소비 — **BE 엔드포인트는 이미 존재**(`[id]`의 최신-버전 조회와 동일 `_load_detail` 함수를 버전 지정으로 호출), 신규 BE 0.

**그리드 시각 프리뷰**(`artifact-thumbnail.tsx`, 신규) — 우선순위(PO 확定):
1. export PNG 있으면 그걸 썸네일(가장 저비용·포맷 무관)
2. 없으면 실 콘텐츠 축소 렌더(html=iframe scale-down·image=원본 그대로)
3. tree는 PNG 없으면 렌더 수단이 없어 **중립 placeholder**(포맷 아이콘+라벨) — **가짜 프리뷰 절대 0**(no-fiction, "준비 중" 낚시 카피 없음)

둘 다 `IntersectionObserver`로 뷰포트 진입 시에만 lazy fetch — 항목 多 갤러리에서 동시 다발 iframe/fetch를 피합니다.

## 스코프 판단(정직 고지)
기존 행-리스트 레이아웃은 그대로 유지했습니다(AC의 "회귀 0·추가지 대체 아님"을 그대로 해석) — "그리드 카드"로의 전면 레이아웃 재구성(다열 카드 그리드)은 이 PR 스코프 밖으로 뒀습니다. 대신 썸네일을 행 좌측에 추가(기존 22×30 아이콘 스와치 → 40×56 실물 프리뷰)하고 클릭 타깃을 분리(`stopPropagation`)해 기존 "행 전체 클릭=타임라인 토글"이 그대로 동작하도록 했습니다. 만약 PO/유나가 원했던 게 리터럴 카드 그리드 재구성이었다면 별도 후속으로 분리해주시면 좋겠습니다.

## 자체 발견
- 갤러리 요약 목록엔 `format` 필드가 없습니다(BE `VisualArtifactSummary`가 nodes 파생값이라 요약 응답에 미포함) — 열람/썸네일 둘 다 버전 상세를 fetch해야만 format을 알 수 있어, prop으로 미리 넘길 수 없고 각 컴포넌트가 자체 fetch하도록 설계했습니다.
- 이 프로젝트의 vitest/jsdom 환경엔 `IntersectionObserver`·`ResizeObserver` 둘 다 전역으로 없다는 걸 발견 — 방어 가드를 추가했는데, 이게 구형 브라우저 폴백(기능 저하 없이 즉시 로드/정적 스케일)과 테스트 크래시 방지를 동시에 해결합니다.

## 테스트
- 신규 4건(`artifact-gallery-view.test.tsx`): 썸네일 클릭→실물 열람·타임라인에서 버전별로 다른 콘텐츠가 열리는지 실증(URL에 버전 번호가 정확히 실리는지까지)·PNG 우선순위(썸네일이 iframe 아닌 img로 렌더)·가짜 프리뷰 미노출("준비 중" 등 낚시 카피 렌더 안 됨)
- 기존 fetch 스텁의 URL 매칭 정밀도 강화 — `exports`/`versions`/`versions/{n}` 3종 경로가 정규식으로 정확히 구분되도록(1차 구현 때 실제로 shape 충돌 크래시를 겪고 수정함)
- 전체 `pnpm vitest run`: **1329 passed | 2 skipped**, 회귀 0
- `tsc --noEmit`: clean
- `eslint`: 0 warning
- `pnpm build`: EXIT=0

## 반응형/스크린샷
실 렌더 확인은 라이브 픽셀에서만 가능한 영역(썸네일 우선순위별 실제 표시·모달 실렌더)이라, dev 배포 후 오르테가군 라이브 done-gate에서 실측 예정.