### PR TITLE
E-CANVAS 뷰어 통합 재설계(story 1948d19d): canvas_bounds 버전 SSOT

### DIFF
--- a/backend/alembic/versions/0179_visual_artifact_canvas_bounds.py
+++ b/backend/alembic/versions/0179_visual_artifact_canvas_bounds.py
@@ -1,0 +1,46 @@
+"""E-CANVAS 뷰어 통합 재설계(story 1948d19d·doc artifact-canvas-viewport-spec §4) — canvas_bounds.
+
+Revision ID: 0179
+Revises: 0178
+Create Date: 2026-07-13
+
+sandbox iframe이라 콘텐츠 크기를 내부 측정할 수 없어, 렌더 산출물이 자기 프레임 크기({w,h})를
+직접 선언하는 아트보드 프레임 규약으로 전환한다.
+
+배치(§4-1 스키마 판단 — 디디 확定): iframe 1개 = **버전 전체 node 합성 렌더**(단일 html_blob
+노드가 아니라 `_render_self_contained_html`이 그 버전의 nodes 전부를 하나의 self-contained
+문서로 합성) — 프레임 크기는 근본적으로 **버전 단위** 개념이다.
+
+- `artifact_versions.canvas_bounds`(SSOT) — 그 버전이 실제로 선언한 프레임(불변 스냅샷,
+  edit마다 새 버전이 자기 값을 갖거나 이전 버전 값을 이어받음).
+- `visual_artifacts.canvas_bounds`(denorm 캐시) — latest_version_number 컬럼과 동일 목적
+  (매 GET/list마다 버전 서브쿼리 회피). 항상 latest version의 값과 동기화.
+
+둘 다 additive nullable JSONB — 미선언(None)이면 FE가 기본 아트보드 규약으로 폴백(레거시 무회귀).
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0179"
+down_revision = "0178"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "visual_artifacts",
+        sa.Column("canvas_bounds", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+    op.add_column(
+        "artifact_versions",
+        sa.Column("canvas_bounds", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("artifact_versions", "canvas_bounds")
+    op.drop_column("visual_artifacts", "canvas_bounds")

--- a/backend/app/models/visual_artifact.py
+++ b/backend/app/models/visual_artifact.py
@@ -33,6 +33,11 @@ class VisualArtifact(Base):
     # 유나 §11 field-level 대조 갭①: 정본 버전 — set은 C4(승인 게이트)의 몫, C1은 컬럼만 마련
     # (null=정본 없음=뷰어 무표시·초안 중립). C4 착수 시 스키마 변경 없이 값만 채우면 됨.
     anchor_version: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # 뷰어 통합 재설계(story 1948d19d·doc artifact-canvas-viewport-spec §4): SSOT는
+    # ArtifactVersion.canvas_bounds(버전 단위 — iframe 1개=버전 전체 node 합성 렌더라 프레임
+    # 개념이 버전 스코프). 이 필드는 latest_version_number와 동일 목적의 **denorm 캐시**
+    # (매 GET/list마다 버전 서브쿼리 회피) — 새 버전 생성마다 그 버전 값과 동기화된다.
+    canvas_bounds: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
@@ -69,6 +74,10 @@ class ArtifactVersion(Base):
         ),
         nullable=True,
     )
+    # 뷰어 통합 재설계(story 1948d19d·doc artifact-canvas-viewport-spec §4): 이 버전이 선언한
+    # 프레임 크기(SSOT) — iframe 1개=버전 전체 node 합성 렌더(_render_self_contained_html)라
+    # 버전 단위 개념. 0179 additive nullable — 미선언(None)=FE 기본 아트보드 규약 폴백.
+    canvas_bounds: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
 

--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -19,6 +19,7 @@ from app.schemas.visual_artifact import (
     ArtifactNodeOperation,
     ArtifactNodeOut,
     ArtifactVersionSummary,
+    CanvasBounds,
     CompleteExportRequest,
     CreateArtifactCommentRequest,
     CreateArtifactRequest,
@@ -92,17 +93,21 @@ async def create_artifact(
     await _assert_link_target_in_scope(session, org_id, project_id, body)
 
     created_by = uuid.UUID(auth.user_id)
+    # 뷰어 통합 재설계(story 1948d19d): canvas_bounds SSOT=버전(아래 version.canvas_bounds).
+    # artifact.canvas_bounds는 latest_version_number와 동형 denorm 캐시 — 항상 최신 버전과 동기화.
+    canvas_bounds_dict = body.canvas_bounds.model_dump() if body.canvas_bounds else None
     artifact = VisualArtifact(
         id=uuid.uuid4(), org_id=org_id, project_id=project_id, title=body.title,
         story_id=body.story_id, epic_id=body.epic_id, doc_id=body.doc_id,
         source=body.source, latest_version_number=1, created_by=created_by,
+        canvas_bounds=canvas_bounds_dict,
     )
     session.add(artifact)
     await session.flush()
 
     version = ArtifactVersion(
         id=uuid.uuid4(), artifact_id=artifact.id, version_number=1, created_by=created_by,
-        summary=body.summary,
+        summary=body.summary, canvas_bounds=canvas_bounds_dict,
     )
     session.add(version)
     await session.flush()
@@ -125,7 +130,7 @@ async def create_artifact(
         anchor_version=artifact.anchor_version,
         created_by=artifact.created_by, created_at=artifact.created_at, updated_at=artifact.updated_at,
         version_number=version.version_number, version_summary=version.summary,
-        version_source_comment_id=version.source_comment_id,
+        version_source_comment_id=version.source_comment_id, canvas_bounds=version.canvas_bounds,
         nodes=[ArtifactNodeOut.model_validate(n) for n in nodes],
     )
     return _ok(detail.model_dump(mode="json"), status=201)
@@ -163,7 +168,7 @@ async def _load_detail(session: AsyncSession, artifact: VisualArtifact, version_
         anchor_version=artifact.anchor_version,
         created_by=artifact.created_by, created_at=artifact.created_at, updated_at=artifact.updated_at,
         version_number=version.version_number, version_summary=version.summary,
-        version_source_comment_id=version.source_comment_id,
+        version_source_comment_id=version.source_comment_id, canvas_bounds=version.canvas_bounds,
         nodes=[ArtifactNodeOut.model_validate(n) for n in node_rows],
     )
 
@@ -202,6 +207,8 @@ async def list_artifact_versions(
         select(ArtifactVersion).where(ArtifactVersion.artifact_id == id)
         .order_by(ArtifactVersion.version_number.desc())
     )).scalars().all()
+    # canvas_bounds는 이제 ArtifactVersion 실 컬럼(story 1948d19d §4 확定 — 버전 단위 SSOT)이라
+    # model_validate(from_attributes)가 그대로 픽업 — 별도 세팅 불요.
     return _ok([ArtifactVersionSummary.model_validate(r).model_dump(mode="json") for r in rows])
 
 
@@ -693,10 +700,15 @@ async def list_artifact_exports(
 async def _apply_artifact_edit(
     session: AsyncSession, artifact: VisualArtifact, operations: list[ArtifactNodeOperation],
     *, actor_id: uuid.UUID, summary: str | None, source_comment_id: uuid.UUID | None = None,
+    canvas_bounds: CanvasBounds | None = None,
 ) -> ArtifactVersion:
     latest = await _get_version_or_404(session, artifact.id, artifact.latest_version_number)
     if latest is None:
         raise ValueError("latest version not found — artifact 상태 비정상")
+
+    # 뷰어 통합 재설계(story 1948d19d): 프레임 크기는 버전 SSOT — 이번 edit에서 명시 재선언
+    # 안 하면 직전 버전 값을 그대로 이어받는다(node가 그대로 복제 계승되는 것과 동형).
+    new_canvas_bounds = canvas_bounds.model_dump() if canvas_bounds is not None else latest.canvas_bounds
 
     existing_rows = (await session.execute(
         select(ArtifactNode).where(ArtifactNode.version_id == latest.id)
@@ -739,6 +751,7 @@ async def _apply_artifact_edit(
     new_version = ArtifactVersion(
         id=uuid.uuid4(), artifact_id=artifact.id, version_number=new_version_number,
         created_by=actor_id, summary=summary, source_comment_id=source_comment_id,
+        canvas_bounds=new_canvas_bounds,
     )
     session.add(new_version)
     await session.flush()
@@ -761,6 +774,7 @@ async def _apply_artifact_edit(
         ))
 
     artifact.latest_version_number = new_version_number
+    artifact.canvas_bounds = new_canvas_bounds
     await session.flush()
     return new_version
 
@@ -809,10 +823,14 @@ async def edit_artifact(
             return _err("FORBIDDEN", "source_comment_id가 이 artifact 소속이 아닙니다", 403)
 
     actor_id = uuid.UUID(auth.user_id)
+
+    # 뷰어 통합 재설계(story 1948d19d): canvas_bounds는 버전 단위 SSOT — 무-mutate 버전 원칙대로
+    # operations 없이 canvas_bounds만 와도(model_validator가 둘 다 없는 요청은 거름) 새 버전을
+    # 만든다. 미지정 시 _apply_artifact_edit이 직전 버전 값을 이어받는다.
     try:
         new_version = await _apply_artifact_edit(
             session, artifact, body.operations, actor_id=actor_id, summary=body.summary,
-            source_comment_id=body.source_comment_id,
+            source_comment_id=body.source_comment_id, canvas_bounds=body.canvas_bounds,
         )
     except ValueError as exc:
         return _err("INVALID_OPERATION", str(exc), 422)

--- a/backend/app/schemas/visual_artifact.py
+++ b/backend/app/schemas/visual_artifact.py
@@ -4,7 +4,27 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
+# 뷰어 통합 재설계(story 1948d19d): 비정상 거대값 방어 상한. Figma류 대형 캔버스 툴의 실용 한계보다
+# 넉넉하되(20000px), 정수 오버플로/스토리지 남용성 값은 확실히 막는 값 — 특정 스펙 수치가 아니라
+# 방어 목적의 보수적 라운드 넘버(유나 스펙 doc 발행 시 필요하면 조정).
+_CANVAS_BOUND_MAX = 20000
+
+
+class CanvasBounds(BaseModel):
+    """artifact 자기 프레임 크기 선언(story 1948d19d) — sandbox iframe 내부 측정 불가라 필요."""
+    w: int
+    h: int
+
+    @field_validator("w", "h")
+    @classmethod
+    def _positive_and_bounded(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("must be a positive integer")
+        if v > _CANVAS_BOUND_MAX:
+            raise ValueError(f"must not exceed {_CANVAS_BOUND_MAX}")
+        return v
 
 
 class ArtifactNodeIn(BaseModel):
@@ -36,6 +56,8 @@ class CreateArtifactRequest(BaseModel):
     nodes: list[ArtifactNodeIn] = []
     # 유나 §11 갭②: 최초 버전의 변경 이유(보통 "초기 생성"류·선택제).
     summary: str | None = None
+    # 뷰어 통합 재설계(story 1948d19d): 생성 시점 프레임 크기 선언(선택 — 미선언=FE 기본 아트보드).
+    canvas_bounds: CanvasBounds | None = None
 
     @field_validator("source")
     @classmethod
@@ -54,6 +76,9 @@ class ArtifactVersionSummary(BaseModel):
     created_at: datetime
     # E-CANVAS C3-S7: 이 버전이 응답한 코멘트(closed-loop, 선택제).
     source_comment_id: uuid.UUID | None = None
+    # 뷰어 통합 재설계(story 1948d19d·doc artifact-canvas-viewport-spec §4): 이 버전이 선언한
+    # 프레임(SSOT — ArtifactVersion 실 컬럼, from_attributes로 그대로 픽업).
+    canvas_bounds: CanvasBounds | None = None
 
 
 class VisualArtifactSummary(BaseModel):
@@ -68,6 +93,9 @@ class VisualArtifactSummary(BaseModel):
     anchor_version: int | None = None
     created_by: uuid.UUID | None = None
     created_at: datetime
+    # denorm 캐시(latest_version_number와 동일 목적 — 버전 서브쿼리 회피). SSOT는
+    # ArtifactVersion.canvas_bounds, 이 값은 항상 최신 버전 값과 동기화된다.
+    canvas_bounds: CanvasBounds | None = None
 
 
 class VisualArtifactDetail(BaseModel):
@@ -88,6 +116,10 @@ class VisualArtifactDetail(BaseModel):
     version_summary: str | None = None
     # E-CANVAS C3-S7: 이 버전이 응답한 코멘트(closed-loop, 선택제).
     version_source_comment_id: uuid.UUID | None = None
+    # 뷰어 통합 재설계(story 1948d19d·doc artifact-canvas-viewport-spec §4): **이 detail이 로드한
+    # version_number 버전**이 선언한 프레임(과거 버전 조회 시 그 버전 당시 값 — artifact의 현재
+    # denorm 캐시가 아님).
+    canvas_bounds: CanvasBounds | None = None
     nodes: list[ArtifactNodeOut]
 
 
@@ -173,16 +205,19 @@ class ArtifactNodeOperation(BaseModel):
 
 
 class EditArtifactRequest(BaseModel):
-    operations: list[ArtifactNodeOperation]
+    operations: list[ArtifactNodeOperation] = []
     # 새 버전의 변경 이유(선택) — ArtifactVersion.summary와 동형(C1-S3 §11 갭②).
     summary: str | None = None
     # 이 편집 커밋이 어느 코멘트에 응답했는지(선택, closed-loop). op-level 아닌 request-level
     # — 편집=코멘트 응답 단위. auto-resolve 안 함(링크≠해결, 해결은 별도 명시 액션).
     source_comment_id: uuid.UUID | None = None
+    # 뷰어 통합 재설계(story 1948d19d): 프레임 크기 재선언(선택) — 버전 단위 SSOT라 이것만
+    # 바뀌어도 무-mutate 버전 원칙대로 새 버전이 생긴다(operations 없이 canvas_bounds만으로도
+    # 호출 가능, 아래 model_validator 참조). 미지정 시 직전 버전 값을 그대로 이어받는다.
+    canvas_bounds: CanvasBounds | None = None
 
-    @field_validator("operations")
-    @classmethod
-    def _non_empty_operations(cls, v: list) -> list:
-        if not v:
-            raise ValueError("operations must not be empty")
-        return v
+    @model_validator(mode="after")
+    def _require_at_least_one_change(self) -> "EditArtifactRequest":
+        if not self.operations and self.canvas_bounds is None:
+            raise ValueError("operations must not be empty (or provide canvas_bounds)")
+        return self

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -508,7 +508,8 @@ _TOOL_DEFS: list[tuple] = [
     # Visual artifacts (7) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안)
     ("sprintable_create_artifact",
      "시각 산출물 생성(에이전트 생성 입구) — 트리(nodes[])로 구조화. 임포트된 raw HTML/이미지는"
-     " type=\"html_blob\" 노드 하나로 감싸도 됨.",
+     " type=\"html_blob\" 노드 하나로 감싸도 됨. canvas_bounds{w,h}(선택): 렌더 자기 프레임 크기"
+     "(CSS px, 양수·≤20000) — sandbox iframe이라 서버가 측정 불가해 선언 필요·미지정=FE 기본 아트보드.",
      CreateArtifactInput, create_artifact),
     ("sprintable_get_artifact",
      "시각 산출물 단건 조회(latest 버전 + nodes).",
@@ -526,7 +527,9 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_edit_artifact",
      "artifact 요소를 operations[]로 편집(휴먼 딸깍과 같은 경로·항상 새 버전·이벤트 전파). 각 op="
      "{op:add|update|delete, id, type?, props?}. ⭐update/delete 대상 노드는 `id` 필드로 지정"
-     "(get_artifact의 node.id·코멘트 앵커 node_id 아님)·add는 type 필수.",
+     "(get_artifact의 node.id·코멘트 앵커 node_id 아님)·add는 type 필수. canvas_bounds{w,h}(선택):"
+     " 프레임 크기 재선언 — 미지정 시 직전 버전 값 유지·operations 비우고 이것만 보내도 유효"
+     "(둘 다 비면 오류).",
      EditArtifactInput, edit_artifact),
     ("sprintable_propose_canonical_version",
      "이 버전을 정본으로 제안(게이트 생성) — 제안만, 승인/반려는 항상 휴먼.",

--- a/backend/sprintable_mcp/tools/visual_artifacts.py
+++ b/backend/sprintable_mcp/tools/visual_artifacts.py
@@ -18,6 +18,14 @@ class ArtifactNodeInput(SprintableInput):
     description: str | None = None  # C2-S6: description pane(요소별 스펙)
 
 
+class CanvasBoundsInput(SprintableInput):
+    """뷰어 통합 재설계(story 1948d19d): sandbox iframe은 내부 콘텐츠 크기를 서버가 측정할 수
+    없어, 렌더 산출물이 자기 프레임 크기(CSS px)를 직접 선언한다. w/h는 양수·상한(20000px)
+    — 위반 시 서버가 422로 거절."""
+    w: int
+    h: int
+
+
 class CreateArtifactInput(SprintableInput):
     title: str
     story_id: str | None = None
@@ -26,6 +34,9 @@ class CreateArtifactInput(SprintableInput):
     source: str | None = None  # "created" | "imported" — 기본 created
     nodes: list[ArtifactNodeInput] | None = None
     summary: str | None = None  # 최초 버전 변경 이유(선택)
+    # 뷰어 통합 재설계(story 1948d19d): 생성 시점 프레임 크기(선택 — 미선언 시 FE가 기본
+    # 아트보드 규약으로 폴백). 최초 버전(version_number=1)에 저장된다.
+    canvas_bounds: CanvasBoundsInput | None = None
 
 
 class GetArtifactInput(SprintableInput):
@@ -58,9 +69,15 @@ class ArtifactNodeOperationInput(SprintableInput):
 
 class EditArtifactInput(SprintableInput):
     artifact_id: str
-    operations: list[ArtifactNodeOperationInput]
+    # 뷰어 통합 재설계(story 1948d19d): canvas_bounds만으로도 편집 호출 가능해져 operations가
+    # 선택제로 바뀌었다(둘 다 비면 서버가 422) — 프레임 크기만 갱신하는 호출도 유효.
+    operations: list[ArtifactNodeOperationInput] = []
     summary: str | None = None  # 새 버전 변경 이유(선택)
     source_comment_id: str | None = None  # 이 편집이 응답한 코멘트(선택, closed-loop)
+    # 프레임 크기 재선언(선택) — 버전 단위 SSOT라 이것만 바뀌어도 무-mutate 버전 원칙대로 새
+    # 버전이 생긴다. 미지정 시 직전 버전 값을 그대로 이어받는다(operations만으로 편집해도
+    # 프레임은 자동 보존됨 — 매 호출마다 재선언할 필요 없음).
+    canvas_bounds: CanvasBoundsInput | None = None
 
 
 class ProposeCanonicalInput(SprintableInput):
@@ -77,7 +94,9 @@ class ListArtifactsInput(SprintableInput):
 
 async def create_artifact(args: CreateArtifactInput) -> list[TextContent]:
     """시각 산출물 생성(에이전트 생성 입구, blueprint §F1) — 트리(nodes[])로 구조화해 전달.
-    임포트된 raw HTML/이미지는 type="html_blob" 노드 하나로 감싸도 된다."""
+    임포트된 raw HTML/이미지는 type="html_blob" 노드 하나로 감싸도 된다.
+    canvas_bounds{w,h}(선택): 렌더 결과의 자기 프레임 크기(CSS px) — sandbox iframe이라 서버가
+    내부 콘텐츠를 측정할 수 없어 호출자 선언이 필요. 미지정 시 FE가 기본 아트보드로 폴백."""
     try:
         body: dict = {"title": args.title}
         if args.story_id:
@@ -92,6 +111,8 @@ async def create_artifact(args: CreateArtifactInput) -> list[TextContent]:
             body["nodes"] = [n.model_dump(exclude_none=True) for n in args.nodes]
         if args.summary:
             body["summary"] = args.summary
+        if args.canvas_bounds:
+            body["canvas_bounds"] = args.canvas_bounds.model_dump(exclude_none=True)
         result = await client.post("/api/v2/visual-artifacts", json=body)
         return ok(result)
     except Exception as exc:
@@ -164,15 +185,20 @@ async def edit_artifact(args: EditArtifactInput) -> list[TextContent]:
       · op="add": 새 노드(type 필수·props 초기값·id 미지정 시 서버 생성).
       · op="update": **대상 노드 = `id`**(get_artifact의 node.id·`node_id` 아님)·props 지정 시 전체 교체.
       · op="delete": **대상 노드 = `id`**만.
-    (대상 요소는 항상 `id` 필드로 지정 — 코멘트 앵커의 node_id와 혼동 주의.)"""
+    (대상 요소는 항상 `id` 필드로 지정 — 코멘트 앵커의 node_id와 혼동 주의.)
+    canvas_bounds{w,h}(선택): 프레임 크기 재선언 — 버전 단위 SSOT라 미지정 시 직전 버전 값을
+    그대로 이어받는다(매 편집마다 재선언 불요). operations를 비우고 canvas_bounds만 보내
+    프레임 크기만 갱신하는 호출도 유효(둘 다 비면 서버가 422)."""
     try:
-        body = {
+        body: dict = {
             "operations": [op.model_dump(exclude_none=True) for op in args.operations],
         }
         if args.summary:
             body["summary"] = args.summary
         if args.source_comment_id:
             body["source_comment_id"] = args.source_comment_id
+        if args.canvas_bounds:
+            body["canvas_bounds"] = args.canvas_bounds.model_dump(exclude_none=True)
         result = await client.post(f"/api/v2/visual-artifacts/{args.artifact_id}/edit", json=body)
         return ok(result)
     except Exception as exc:

--- a/backend/tests/test_e_canvas_1948d19d_canvas_bounds_realdb.py
+++ b/backend/tests/test_e_canvas_1948d19d_canvas_bounds_realdb.py
@@ -1,0 +1,392 @@
+"""뷰어 통합 재설계(story 1948d19d·doc artifact-canvas-viewport-spec §4): canvas_bounds 실증.
+crux: 버전 단위 SSOT(artifact.canvas_bounds는 denorm 캐시)·미선언 시 직전 버전 값 carry-forward·
+operations 없이 canvas_bounds만으로도 새 버전 생성(무-mutate 버전 원칙 계승)·양수/상한 검증."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id}
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, project_id, user_id=None):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id or uuid.uuid4()), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_create_with_canvas_bounds_declared():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Framed", "canvas_bounds": {"w": 1200, "h": 800}},
+            )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()["data"]
+            assert body["canvas_bounds"] == {"w": 1200, "h": 800}
+            artifact_id = body["id"]
+
+            # list_artifacts summary도 denorm 캐시로 동일 값 노출.
+            list_resp = await client.get("/api/v2/visual-artifacts")
+            item = next(i for i in list_resp.json()["data"] if i["id"] == artifact_id)
+            assert item["canvas_bounds"] == {"w": 1200, "h": 800}
+
+            # versions summary도 동일 값(실 컬럼 from_attributes).
+            versions_resp = await client.get(f"/api/v2/visual-artifacts/{artifact_id}/versions")
+            assert versions_resp.json()["data"][0]["canvas_bounds"] == {"w": 1200, "h": 800}
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_without_canvas_bounds_is_null():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/visual-artifacts", json={"title": "Unframed"})
+            assert resp.status_code == 201, resp.text
+            assert resp.json()["data"]["canvas_bounds"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_edit_without_canvas_bounds_carries_forward():
+    """미지정 시 직전 버전 값을 그대로 이어받는다 — operations 편집이 프레임을 지우면 안 됨."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Carry", "canvas_bounds": {"w": 640, "h": 480}},
+            )
+            artifact_id = create_resp.json()["data"]["id"]
+
+            edit_resp = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/edit",
+                json={"operations": [{"op": "add", "type": "text", "props": {}}]},
+            )
+            assert edit_resp.status_code == 201, edit_resp.text
+            body = edit_resp.json()["data"]
+            assert body["version_number"] == 2
+            assert body["canvas_bounds"] == {"w": 640, "h": 480}
+
+            # artifact denorm 캐시도 최신 버전 값과 동기화돼야 함.
+            get_resp = await client.get(f"/api/v2/visual-artifacts/{artifact_id}")
+            assert get_resp.json()["data"]["canvas_bounds"] == {"w": 640, "h": 480}
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_edit_with_explicit_canvas_bounds_redeclares_and_bumps_version():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Redeclare", "canvas_bounds": {"w": 640, "h": 480}},
+            )
+            artifact_id = create_resp.json()["data"]["id"]
+
+            edit_resp = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/edit",
+                json={
+                    "operations": [{"op": "add", "type": "text", "props": {}}],
+                    "canvas_bounds": {"w": 1920, "h": 1080},
+                },
+            )
+            assert edit_resp.status_code == 201, edit_resp.text
+            body = edit_resp.json()["data"]
+            assert body["version_number"] == 2
+            assert body["canvas_bounds"] == {"w": 1920, "h": 1080}
+
+            # v1 스냅샷은 자기 선언 값 그대로 — 무-mutate 원칙.
+            v1_resp = await client.get(f"/api/v2/visual-artifacts/{artifact_id}/versions/1")
+            assert v1_resp.json()["data"]["canvas_bounds"] == {"w": 640, "h": 480}
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_edit_with_only_canvas_bounds_no_operations_creates_new_version():
+    """무-mutate 버전 원칙: 프레임만 바뀌어도 새 버전이 생기고, 기존 노드는 그대로 계승."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={
+                    "title": "Bounds Only", "canvas_bounds": {"w": 640, "h": 480},
+                    "nodes": [{"type": "text", "props": {"content": "hello"}}],
+                },
+            )
+            artifact_id = create_resp.json()["data"]["id"]
+
+            edit_resp = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/edit",
+                json={"canvas_bounds": {"w": 800, "h": 600}},
+            )
+            assert edit_resp.status_code == 201, edit_resp.text
+            body = edit_resp.json()["data"]
+            assert body["version_number"] == 2
+            assert body["canvas_bounds"] == {"w": 800, "h": 600}
+            assert len(body["nodes"]) == 1
+            assert body["nodes"][0]["props"]["content"] == "hello"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_edit_with_no_operations_and_no_canvas_bounds_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Empty Edit"})
+            artifact_id = create_resp.json()["data"]["id"]
+
+            resp = await client.post(f"/api/v2/visual-artifacts/{artifact_id}/edit", json={})
+            assert resp.status_code == 422, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("bounds", [
+    {"w": 0, "h": 100},
+    {"w": 100, "h": -5},
+    {"w": 20001, "h": 100},
+    {"w": 100, "h": 20001},
+])
+async def test_create_with_malformed_canvas_bounds_422(bounds):
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/visual-artifacts", json={"title": "Bad Bounds", "canvas_bounds": bounds},
+            )
+            assert resp.status_code == 422, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_with_missing_h_field_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/visual-artifacts", json={"title": "Partial Bounds", "canvas_bounds": {"w": 100}},
+            )
+            assert resp.status_code == 422, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mcp_create_and_edit_canvas_bounds_roundtrip():
+    """AC4 동형: MCP sprintable_create_artifact(canvas_bounds) → sprintable_edit_artifact
+    (canvas_bounds만 재선언) 왕복."""
+    import json
+    import os as _os
+
+    import httpx
+
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+
+        _os.environ.setdefault("SPRINTABLE_API_URL", "http://test")
+        _os.environ.setdefault("AGENT_API_KEY", "sk_test")
+
+        from sprintable_mcp import api_client as api_client_mod
+        from sprintable_mcp.tools.visual_artifacts import (
+            CanvasBoundsInput, CreateArtifactInput, EditArtifactInput,
+            create_artifact, edit_artifact,
+        )
+
+        transport = httpx.ASGITransport(app=app)
+        real_client = api_client_mod.client
+        test_http_client = httpx.AsyncClient(transport=transport, base_url="http://test")
+
+        async def _post(path, **kwargs):
+            r = await test_http_client.post(path, **kwargs)
+            r.raise_for_status()
+            return r.json()["data"]
+
+        orig_post = real_client.post
+        real_client.post = _post
+        try:
+            created = json.loads((await create_artifact(CreateArtifactInput(
+                title="MCP Framed", canvas_bounds=CanvasBoundsInput(w=1024, h=768),
+            )))[0].text)
+            assert created["canvas_bounds"] == {"w": 1024, "h": 768}
+
+            edited = json.loads((await edit_artifact(EditArtifactInput(
+                artifact_id=created["id"], canvas_bounds=CanvasBoundsInput(w=2048, h=1536),
+            )))[0].text)
+            assert edited["version_number"] == 2
+            assert edited["canvas_bounds"] == {"w": 2048, "h": 1536}
+        finally:
+            real_client.post = orig_post
+            await test_http_client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- story `1948d19d`(뷰어 통합 재설계, critical) BE 조각 — sandbox iframe 자기 프레임 크기(`canvas_bounds{w,h}`) 메타 추가.
- 스키마 배치(doc `artifact-canvas-viewport-spec` §4-1, 유나 위임): `_render_self_contained_html`이 **버전 전체 node 트리를 하나의 iframe으로 합성 렌더**하므로, 프레임 크기는 노드/artifact가 아닌 **버전 단위** 개념으로 결론.
  - `artifact_versions.canvas_bounds` — SSOT(불변 스냅샷, additive nullable JSONB).
  - `visual_artifacts.canvas_bounds` — `latest_version_number`와 동형의 denorm 캐시(서브쿼리 회피, 새 버전마다 동기화).
- `POST /edit`: `canvas_bounds` 미지정 시 직전 버전 값 carry-forward, 지정 시 재선언 — 어느 경우든 무-mutate 버전 원칙대로 새 버전 생성(operations 없이 canvas_bounds만으로도 유효 호출).
- `POST /` (create): 최초 버전에 선택적 선언, 미지정=null(FE 기본 아트보드 폴백).
- 검증: w/h 양수·상한 20000px(422).
- MCP `sprintable_create_artifact`/`sprintable_edit_artifact` 계약에 동형 반영(파라미터 설명 명시 — #2107 description-clarity 교훈 반영).
- Migration `0179`: 두 테이블 모두 additive nullable JSONB.

## Test plan
- [x] realdb 신규 12건(`tests/test_e_canvas_1948d19d_canvas_bounds_realdb.py`): 선언/미선언, edit carry-forward, edit 재선언(버전 스냅샷 불변 확인), operations 없이 canvas_bounds만 편집, 양쪽 다 없으면 422, malformed(0/음수/상한초과/필드누락) 422, MCP create→edit 왕복.
- [x] 기존 visual_artifacts realdb 스위트 회귀 없음(C1-S3 6건 + C3-S7 9건 + SEC-S8-Q 5건, 총 20건 전부 pass).
- [x] `python3 -m py_compile` 전 수정 파일.
- 참고: 로컬 realdb 전체 스위트(`tests/`) 실행 시 586건 실패 관측했으나, 모두 본 PR과 무관한 기존 갭(예: `webhook_configs` ON CONFLICT partial unique index 부재 — 에러 시그니처로 확인, 본 diff는 webhook_configs 미접촉)으로 판단.

🤖 Generated with [Claude Code](https://claude.com/claude-code)