### PR TITLE
[SID:1948d19d] PR A — 캔버스 뷰포트 전면 재설계(§1+§2, transform pan/zoom·클릭↔pan 공존)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3567,10 +3567,12 @@
     "galleryLazyHint": "Expanding loads earlier versions.",
     "galleryVersionsUnavailable": "Couldn't load earlier versions.",
     "viewerExpandAction": "Expand view",
-    "viewerPanHint": "Drag to move",
     "galleryFormatHtml": "Web page",
     "galleryFormatImage": "Image",
     "galleryFormatTree": "Layout",
-    "galleryOpenArtifactAction": "Open artifact"
+    "galleryOpenArtifactAction": "Open artifact",
+    "viewerCanvasHint": "Drag to move, scroll to zoom",
+    "viewerFitAction": "Fit to view",
+    "viewerActualSizeAction": "Actual size"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3567,10 +3567,12 @@
     "galleryLazyHint": "펼치면 이전 버전을 불러옵니다",
     "galleryVersionsUnavailable": "이전 버전을 불러올 수 없습니다",
     "viewerExpandAction": "크게 보기",
-    "viewerPanHint": "끌어서 이동",
     "galleryFormatHtml": "웹 페이지",
     "galleryFormatImage": "이미지",
     "galleryFormatTree": "레이아웃",
-    "galleryOpenArtifactAction": "산출물 열기"
+    "galleryOpenArtifactAction": "산출물 열기",
+    "viewerCanvasHint": "드래그로 이동, 휠로 확대·축소합니다",
+    "viewerFitAction": "전체 보기",
+    "viewerActualSizeAction": "실제 크기"
   }
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -423,13 +423,6 @@
   *::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 3px; }
   *::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); }
 
-  /* story d425dccc — 산출물 뷰어 가로 스크롤바 상시 가시화. 앱 전역 스크롤바(6px·10% 불투명
-   * thumb)는 macOS에서 낮은 대비로 "스크롤 자체가 없다"는 오인을 낳았다(선생님 실사용 지적) —
-   * 이 스테이지만 더 두껍고 고대비인 thumb으로 발견성을 높인다. */
-  [data-artifact-stage-scroll]::-webkit-scrollbar { width: 10px; height: 10px; }
-  [data-artifact-stage-scroll]::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb-hover); border-radius: 5px; }
-  [data-artifact-stage-scroll] { scrollbar-width: auto; }
-
   html {
     @apply font-sans;
     text-autospace: ideograph-alpha ideograph-numeric;

--- a/apps/web/src/components/canvas/artifact-expand-dialog.tsx
+++ b/apps/web/src/components/canvas/artifact-expand-dialog.tsx
@@ -12,14 +12,18 @@ interface ArtifactExpandDialogProps {
   title: string;
   format: ArtifactFormat;
   content: string;
+  /** story 1948d19d §4 — 선언된 아트보드 크기(있으면). 없으면 ArtifactStage가 기본 폴백. */
+  canvasBounds?: { w: number; h: number } | null;
 }
 
 /**
  * "크게 보기" 모달(story d425dccc 원조·story 3d888ba2에서 스토리 상세 뷰어와 갤러리가 공유하도록
- * 추출) — 큰 표면(≈90vw×85vh)에서 ArtifactStage를 `fill` 모드로 재렌더(html=실제 크기+직접
- * 드래그 pan, image/tree=해당 포맷 그대로). 신규 뷰어 0 — 기존 컴포넌트 재사용.
+ * 추출·story 1948d19d에서 ArtifactStage가 캔버스 뷰포트로 재작성되며 자동 계승) — 큰 표면
+ * (≈90vw×85vh)에서 같은 ArtifactStage를 재렌더. ArtifactStage는 이제 자기 컨테이너 크기를
+ * 그대로 채우는 캔버스 뷰포트라 별도 "fill 모드" 개념이 없다 — CSS로 큰 박스를 주면 그게 곧
+ * 큰 뷰포트다(인라인 카드도 동일 컴포넌트, 크기만 다름). 신규 뷰어 0 — 기존 컴포넌트 재사용.
  */
-export function ArtifactExpandDialog({ open, onOpenChange, title, format, content }: ArtifactExpandDialogProps) {
+export function ArtifactExpandDialog({ open, onOpenChange, title, format, content, canvasBounds }: ArtifactExpandDialogProps) {
   const t = useTranslations('canvas');
 
   return (
@@ -45,7 +49,7 @@ export function ArtifactExpandDialog({ open, onOpenChange, title, format, conten
             </DialogPrimitive.Close>
           </div>
           <div className="min-h-0 flex-1 overflow-hidden p-4">
-            <ArtifactStage format={format} content={content} title={title} fill />
+            <ArtifactStage format={format} content={content} title={title} canvasBounds={canvasBounds} />
           </div>
         </DialogPrimitive.Popup>
       </DialogPrimitive.Portal>

--- a/apps/web/src/components/canvas/artifact-gallery-view.tsx
+++ b/apps/web/src/components/canvas/artifact-gallery-view.tsx
@@ -159,7 +159,7 @@ export function ArtifactGalleryView() {
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [versionsByArtifact, setVersionsByArtifact] = useState<Record<string, GalleryTimelineVersion[]>>({});
   const [versionsLoadingId, setVersionsLoadingId] = useState<string | null>(null);
-  const [expandTarget, setExpandTarget] = useState<{ format: ArtifactFormat; content: string; title: string } | null>(null);
+  const [expandTarget, setExpandTarget] = useState<{ format: ArtifactFormat; content: string; title: string; canvasBounds?: { w: number; h: number } | null } | null>(null);
 
   useEffect(() => {
     if (!projectId) return;
@@ -214,7 +214,7 @@ export function ArtifactGalleryView() {
     const { artifact, versions } = adaptArtifactDetail(detail);
     const content = versions[0]?.content;
     if (!content) return;
-    setExpandTarget({ format: artifact.format, content, title });
+    setExpandTarget({ format: artifact.format, content, title, canvasBounds: versions[0]?.canvasBounds });
   }
 
   const axisLabel = (a: GalleryAxis) => t(`galleryAxis${a[0]!.toUpperCase()}${a.slice(1)}`);
@@ -319,6 +319,7 @@ export function ArtifactGalleryView() {
           title={expandTarget.title}
           format={expandTarget.format}
           content={expandTarget.content}
+          canvasBounds={expandTarget.canvasBounds}
         />
       ) : null}
     </div>

--- a/apps/web/src/components/canvas/artifact-stage.test.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 //
-// story e4cce704(v2.1) — space 게이트 제거 후 직접-드래그 pan 회귀가드. space 관련 키보드
-// 리스너/hover-gate가 완전히 제거됐음을 확인하고, mousedown+drag만으로 스크롤이 이동하는지
-// 검증한다(v2에서 있던 "space 없으면 안 움직임" 가드는 이제 정반대 — space는 아예 무간섭).
+// story 1948d19d — 캔버스 뷰포트 재설계 회귀가드. v1(overflow 스크롤)~v2.1(상시 드래그
+// 오버레이)의 스크롤바/space 잔재가 전부 소멸했는지, 그리고 새 계약(전방향 pan·커서중심
+// 줌·fit/100%·클릭=선택 드래그=pan 공존)이 실제로 동작하는지 검증한다.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
@@ -34,55 +34,167 @@ afterEach(async () => {
   container.remove();
 });
 
-async function mount() {
+async function mount(props: Partial<React.ComponentProps<typeof ArtifactStage>> = {}) {
   await act(async () => {
-    root.render(wrap(<ArtifactStage format="html" content="<div>hi</div>" title="t" />));
+    root.render(wrap(<ArtifactStage format="html" content="<div>hi</div>" title="t" {...props} />));
   });
 }
 
-function press(el: EventTarget, type: string, init: MouseEventInit = {}) {
-  el.dispatchEvent(new MouseEvent(type, { bubbles: true, cancelable: true, ...init }));
+function press(el: EventTarget, type: string, init: PointerEventInit | WheelEventInit = {}) {
+  const Ctor = type.startsWith('wheel') ? WheelEvent : PointerEvent;
+  el.dispatchEvent(new Ctor(type, { bubbles: true, cancelable: true, ...init }));
 }
 
-describe('ArtifactStage — html 직접-드래그 pan(v2.1, space 게이트 없음)', () => {
-  it('mousedown+drag alone scrolls the container by the drag delta (no space needed)', async () => {
+function readTransform(el: HTMLElement) {
+  const m = /translate\(([-\d.]+)px, ([-\d.]+)px\) scale\(([-\d.]+)\)/.exec(el.style.transform);
+  if (!m) throw new Error(`unparseable transform: ${el.style.transform}`);
+  return { tx: Number(m[1]), ty: Number(m[2]), scale: Number(m[3]) };
+}
+
+describe('ArtifactStage — 캔버스 뷰포트(story 1948d19d)', () => {
+  it('locks down the html sandbox and marks content pointer-events:none (crux — 상시 캡처 오버레이 폐기)', async () => {
     await mount();
-    const wrapperEl = container.querySelector('[data-artifact-stage-scroll]') as HTMLDivElement;
-    const overlay = container.querySelector('[data-pan-overlay]') as HTMLDivElement;
-    Object.defineProperty(wrapperEl, 'scrollLeft', { value: 50, writable: true });
-    Object.defineProperty(wrapperEl, 'scrollTop', { value: 0, writable: true });
-
-    await act(async () => {
-      press(overlay, 'mousedown', { clientX: 100, clientY: 0 });
-    });
-    await act(async () => {
-      press(window, 'mousemove', { clientX: 40, clientY: 0 }); // 60px left → scrollLeft += 60
-    });
-
-    expect(wrapperEl.scrollLeft).toBe(110);
-
-    await act(async () => {
-      press(window, 'mouseup');
-    });
-    expect(overlay.style.cursor).toBe('grab'); // 드래그 종료 후 grab으로 복귀(항상 활성 어포던스)
+    const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+    expect(iframe).not.toBeNull();
+    expect(iframe.getAttribute('sandbox')).toBe('');
+    expect(iframe.className).toContain('pointer-events-none');
   });
 
-  it('shows the grab cursor at rest and grabbing while dragging (always-active affordance)', async () => {
+  it('never renders the v1~v2.1 scroll/overlay remnants (data-artifact-stage-scroll·data-pan-overlay)', async () => {
     await mount();
-    const overlay = container.querySelector('[data-pan-overlay]') as HTMLDivElement;
-    expect(overlay.style.cursor).toBe('grab');
-
-    await act(async () => {
-      press(overlay, 'mousedown', { clientX: 0, clientY: 0 });
-    });
-    expect(overlay.style.cursor).toBe('grabbing');
+    expect(container.querySelector('[data-artifact-stage-scroll]')).toBeNull();
+    expect(container.querySelector('[data-pan-overlay]')).toBeNull();
   });
 
-  it('never wires a keydown/keyup listener for Space (space 게이트 완전 제거 회귀가드)', async () => {
-    const addSpy = vi.spyOn(window, 'addEventListener');
+  it('pointerdown+drag past the threshold pans the content (translate reflects the drag delta)', async () => {
     await mount();
-    const spaceListenerCalls = addSpy.mock.calls.filter(([type]) => type === 'keydown' || type === 'keyup');
-    expect(spaceListenerCalls).toHaveLength(0);
-    addSpy.mockRestore();
+    const viewport = container.querySelector('[data-artifact-canvas-viewport]') as HTMLDivElement;
+    const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+    const before = readTransform(content);
+
+    await act(async () => {
+      press(viewport, 'pointerdown', { pointerId: 1, clientX: 100, clientY: 100, button: 0 });
+    });
+    await act(async () => {
+      press(viewport, 'pointermove', { pointerId: 1, clientX: 160, clientY: 130 }); // 60,30 — 임계(4px) 초과
+    });
+    const after = readTransform(content);
+    expect(after.tx).toBe(before.tx + 60);
+    expect(after.ty).toBe(before.ty + 30);
+
+    await act(async () => { press(viewport, 'pointerup', { pointerId: 1, clientX: 160, clientY: 130 }); });
+  });
+
+  it('a drag past the threshold makes the overlay pointer-events:none (핀 위 드래그=pan, 선택 미커밋 — CSS 메커니즘)', async () => {
+    await mount({ overlay: <button type="button" data-testid="pin">pin</button> });
+    const viewport = container.querySelector('[data-artifact-canvas-viewport]') as HTMLDivElement;
+    const overlay = container.querySelector('[data-artifact-canvas-overlay]') as HTMLDivElement;
+    expect(overlay.style.pointerEvents).not.toBe('none');
+
+    await act(async () => { press(viewport, 'pointerdown', { pointerId: 1, clientX: 0, clientY: 0, button: 0 }); });
+    await act(async () => { press(viewport, 'pointermove', { pointerId: 1, clientX: 50, clientY: 0 }); });
+    expect(overlay.style.pointerEvents).toBe('none');
+
+    await act(async () => { press(viewport, 'pointerup', { pointerId: 1, clientX: 50, clientY: 0 }); });
+    expect(overlay.style.pointerEvents).not.toBe('none');
+  });
+
+  it('a click without movement (< threshold) does not pan (임계 미달 = 클릭, transform 무변)', async () => {
+    await mount();
+    const viewport = container.querySelector('[data-artifact-canvas-viewport]') as HTMLDivElement;
+    const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+    const before = readTransform(content);
+
+    await act(async () => { press(viewport, 'pointerdown', { pointerId: 1, clientX: 100, clientY: 100, button: 0 }); });
+    await act(async () => { press(viewport, 'pointermove', { pointerId: 1, clientX: 101, clientY: 101 }); }); // 1.4px, 임계(4px) 미달
+    await act(async () => { press(viewport, 'pointerup', { pointerId: 1, clientX: 101, clientY: 101 }); });
+
+    expect(readTransform(content)).toEqual(before);
+  });
+
+  it('plain wheel pans (no ctrl/meta) — deltaX/Y move the content', async () => {
+    await mount();
+    const viewport = container.querySelector('[data-artifact-canvas-viewport]') as HTMLDivElement;
+    const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+    const before = readTransform(content);
+    await act(async () => { press(viewport, 'wheel', { deltaX: 20, deltaY: 10, ctrlKey: false }); });
+    const after = readTransform(content);
+    expect(after.tx).toBe(before.tx - 20);
+    expect(after.ty).toBe(before.ty - 10);
+    expect(after.scale).toBe(before.scale);
+  });
+
+  it('ctrl/meta+wheel zooms instead of panning (트랙패드 핀치와 동일 신호)', async () => {
+    await mount();
+    const viewport = container.querySelector('[data-artifact-canvas-viewport]') as HTMLDivElement;
+    const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+    const before = readTransform(content);
+    await act(async () => { press(viewport, 'wheel', { deltaY: -100, ctrlKey: true, clientX: 50, clientY: 50 }); });
+    const after = readTransform(content);
+    expect(after.scale).toBeGreaterThan(before.scale); // deltaY<0 = zoom in
+  });
+
+  it('clamps zoom to the 10%~400% range (repeated zoom does not exceed bounds)', async () => {
+    await mount();
+    const viewport = container.querySelector('[data-artifact-canvas-viewport]') as HTMLDivElement;
+    const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+    for (let i = 0; i < 40; i++) {
+      await act(async () => { press(viewport, 'wheel', { deltaY: -1000, ctrlKey: true, clientX: 0, clientY: 0 }); });
+    }
+    expect(readTransform(content).scale).toBeLessThanOrEqual(4);
+    for (let i = 0; i < 40; i++) {
+      await act(async () => { press(viewport, 'wheel', { deltaY: 1000, ctrlKey: true, clientX: 0, clientY: 0 }); });
+    }
+    expect(readTransform(content).scale).toBeGreaterThanOrEqual(0.1);
+  });
+
+  it('the actual-size(100%) button sets scale to 1', async () => {
+    await mount();
+    const button = [...container.querySelectorAll('button')].find((b) => b.textContent === '실제 크기');
+    expect(button).toBeDefined();
+    const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+    await act(async () => { button!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(readTransform(content).scale).toBe(1);
+  });
+
+  it('renders the fit and actual-size chrome buttons plus a live zoom percentage — no v1~v2.1 scrollbar/space chrome', async () => {
+    await mount();
+    expect(container.textContent).toContain('전체 보기');
+    expect(container.textContent).toContain('실제 크기');
+    expect(container.textContent).toMatch(/\d+%/);
+    expect(container.textContent).not.toContain('끌어서 이동');
+  });
+
+  describe('fit/초기 진입 — 뷰포트 실측 필요(jsdom clientWidth/Height는 기본 0, 스텁 필요)', () => {
+    let widthSpy: ReturnType<typeof vi.spyOn>;
+    let heightSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      widthSpy = vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(640);
+      heightSpy = vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(480);
+    });
+    afterEach(() => {
+      widthSpy.mockRestore();
+      heightSpy.mockRestore();
+    });
+
+    it('auto-fits on first mount (전체 콘텐츠가 즉시 보이는 것이 재설계의 근본 목적)', async () => {
+      await mount();
+      const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+      // bounds 1280x800 vs viewport 640x480 → fit scale = min(640/1280, 480/800) = 0.5
+      expect(readTransform(content).scale).toBeCloseTo(0.5, 5);
+    });
+
+    it('the fit button recomputes scale to contain the full bounds after zooming away', async () => {
+      await mount();
+      const viewport = container.querySelector('[data-artifact-canvas-viewport]') as HTMLDivElement;
+      const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+      await act(async () => { press(viewport, 'wheel', { deltaY: -1000, ctrlKey: true, clientX: 0, clientY: 0 }); });
+      expect(readTransform(content).scale).not.toBeCloseTo(0.5, 5);
+
+      const fitButton = [...container.querySelectorAll('button')].find((b) => b.textContent === '전체 보기');
+      await act(async () => { fitButton!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+      expect(readTransform(content).scale).toBeCloseTo(0.5, 5);
+    });
   });
 });

--- a/apps/web/src/components/canvas/artifact-stage.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.tsx
@@ -1,25 +1,37 @@
-import { useEffect, useRef, useState } from 'react';
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { cn } from '@/lib/utils';
+import { Maximize2, Scan } from 'lucide-react';
 import type { ArtifactFormat } from '@/services/canvas';
 
 /**
- * story 385eb89a — 고정 넓이 html_blob 잘림 대책. sandbox=""(allow-same-origin 없음)라 iframe
- * 내부 문서 폭을 측정할 수 없어(cross-origin) 실 콘텐츠 폭을 알 방법이 없다 — 대신 iframe 자체
- * 박스를 이 고정 "캔버스" 폭으로 렌더해 내용이 접히지 않게 하고, wrapper가 스크롤한다.
+ * story 1948d19d — 캔버스 뷰포트 전면 재설계. 설계 SSOT: doc `artifact-canvas-viewport-spec`.
+ * v1(385eb89a·스크롤+overflow) → v2(d425dccc·space+드래그 pan) → v2.1(e4cce704·상시 오버레이
+ * 직접드래그) 세 번의 "증상 단위" 패치가 전부 틀린 모델(스크롤 문서 창) 안에서 반복됐던 게
+ * 근본 문제 — 산출물은 스크롤 문서가 아니라 **캔버스 위 오브젝트**(Figma 캔버스 뷰포트 레퍼런스).
  *
- * story d425dccc — v1의 축소-fit "전체 보기" 토글은 선생님 실사용 결과 제거(유나 스펙 ⓒ 판정 —
- * 축소는 디테일을 못 보게 해 원하는 것과 반대). 대신 ⓐ space+드래그 pan ⓑ 가로 스크롤바 상시
- * 가시화로 대체 — wrapper는 항상 실제 크기로 렌더하고 이동 수단만 강화한다.
- *
- * story e4cce704(v2.1) — space 게이트를 완전 제거(선생님 실사용 지적 3차: 뷰어 밖에서 space를
- * 누르면 그대로 페이지 스크롤 다운으로 새 — hover-gate라 게이트 상태가 비가시라 "고장"으로
- * 읽힘). 오버레이를 상시 활성화해 **드래그만으로 pan**하도록 단순화(유나 판정 확定, KISS —
- * "클릭 통과" 절충은 cross-origin에서 반쯤 작동하는 복잡 상태라 명시 거부됨). 트레이드오프:
- * 오버레이가 항상 포인터를 가로채 iframe 내부 텍스트 선택은 포기(뷰어=탐색이 본업).
+ * 이 재작성으로 v1~v2.1의 overflow·스크롤바·space 잔재가 전부 소멸한다:
+ * - 뷰포트 = `transform: translate(tx,ty) scale(s)` 하나 — pan은 전방향(가로/세로 구분 없음)·
+ *   "잘림" 상태 자체가 없다(콘텐츠는 항상 캔버스 위 어딘가에 있고, 안 보이면 이동하면 그만).
+ * - 휠=pan·⌘/Ctrl+휠(트랙패드 핀치와 동일 신호)=커서 중심 줌.
+ * - **crux(v2.1 오류 교정)**: 상시 전면 캡처 오버레이를 폐기 — iframe/img/tree 콘텐츠는 항상
+ *   `pointer-events:none`(렌더된 오브젝트일 뿐, 상호작용 대상이 아님). 핀 등 우리 DOM 오버레이만
+ *   `pointer-events:auto`로 상호작용 가능 — 이동-임계값(4px) 초과 드래그 중엔 오버레이도
+ *   pointer-events:none으로 전환해 "핀 위에서 시작한 드래그가 pan으로 해석"을 순수 CSS로
+ *   구현한다(핀 자체의 onClick은 무변경 — 임계 미달=일반 클릭이 그대로 발화).
  */
-const HTML_STAGE_WIDTH = 1200;
-const HTML_STAGE_HEIGHT = 280;
+
+const DEFAULT_BOUNDS = { w: 1280, h: 800 }; // 문서형 기본 아트보드 — canvas_bounds 미선언 폴백(§4, 가짜 추정 아님·명시된 규약)
+const MIN_SCALE = 0.1;
+const MAX_SCALE = 4;
+const DRAG_THRESHOLD_PX = 4;
+const PAN_MARGIN_PX = 120; // soft bound — 콘텐츠가 이 여백 밖으로 완전히 사라지진 않게
+const WHEEL_ZOOM_SENSITIVITY = 0.0015;
+
+function clamp(v: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, v));
+}
 
 /**
  * E-CANVAS C1 — tree 포맷 최소 노드 shape. BE 계약(디디 C1-S3) 착지 전 잠정 — 실 계약이
@@ -64,114 +76,239 @@ interface ArtifactStageProps {
   format: ArtifactFormat;
   content: string;
   title: string;
-  /** story d425dccc — "크게 보기" 모달 전용. true면 인라인 프리뷰의 고정 280px 대신 부모
-   * 컨테이너 높이를 꽉 채운다(더 넓은 뷰포트로 스크롤/pan 부담을 줄이는 게 모달의 목적).
-   * html 포맷 외엔 무시. */
-  fill?: boolean;
+  /** story 1948d19d §4(BE #2135) — 선언된 아트보드 크기(그 버전의 불변 스냅샷). null/undefined
+   * (레거시·미선언·#2135 착지 전)면 포맷별 기본 아트보드로 폴백(가짜 추정 0 — 측정이 아니라
+   * 선언된 규약). image 포맷은 이 값과 무관하게 로드 후 실측 자연 크기를 우선한다. */
+  canvasBounds?: { w: number; h: number } | null;
+  /** story 1948d19d §2 — 캔버스 좌표계(bounds 기준 %) 오버레이(핀·앵커·마커 등 우리 DOM).
+   * 뷰포트 transform을 그대로 물려받아 pan/zoom에 동반 이동한다. 드래그 확定 중엔 이 레이어
+   * 전체가 pointer-events:none으로 전환돼 핀 위에서 시작한 드래그가 pan으로만 해석된다
+   * (핀 자신의 onClick은 무변경 — 임계 미달 클릭만 정상 발화). */
+  overlay?: React.ReactNode;
 }
 
 /**
- * html 산출물의 직접-드래그 pan(story e4cce704, v2.1). sandbox=""(allow-scripts 없음) iframe은
- * 자기 자신의 포인터 이벤트를 소비해 드래그가 iframe 경계에서 끊기므로, 투명 오버레이(우리
- * DOM)로 포인터를 상시 가로채는 방식으로 우회한다 — sandbox 완화 없음(iframe 내부는 여전히
- * 0접근). space 게이트 없음(v2에서 hover-gate로 있었으나 뷰어 밖에서 space 누르면 그대로
- * 페이지 스크롤로 새는 혼란이라 완전 제거) — 오버레이가 항상 pointer-events:auto+grab
- * 커서라 즉시 가시적인 어포던스, mousedown 즉시 드래그 시작. 트레이드오프: iframe 내부
- * 텍스트 선택은 포기(뷰어=탐색이 본업, 유나 확定).
+ * story 1948d19d — transform 캔버스 뷰포트 엔진. 3포맷(html/image/tree) 공유 — "전 표면 통일"의
+ * 핵심은 이 하나의 pan/zoom/선택 계약이지 포맷별 렌더 방식이 아니다(포맷은 콘텐츠 레이어
+ * 안쪽만 다름). sandbox 무완화 유지(iframe은 여전히 `sandbox=""`) — pointer-events:none이라
+ * 상호작용 레이어와 물리적으로 분리되므로 완화할 필요 자체가 없다.
  */
-function PanOverlay({ wrapperRef }: { wrapperRef: React.RefObject<HTMLDivElement | null> }) {
-  const [dragging, setDragging] = useState(false);
-  const dragStartRef = useRef({ x: 0, y: 0, scrollLeft: 0, scrollTop: 0 });
+function CanvasViewport({ format, content, title, canvasBounds, overlay }: {
+  format: ArtifactFormat; content: string; title: string;
+  canvasBounds?: { w: number; h: number } | null; overlay?: React.ReactNode;
+}) {
+  const t = useTranslations('canvas');
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const [viewportSize, setViewportSize] = useState({ w: 0, h: 0 });
+  const [transform, setTransform] = useState({ tx: 0, ty: 0, scale: 1 });
+  const [isDragging, setIsDragging] = useState(false);
+  const [imageBounds, setImageBounds] = useState<{ w: number; h: number } | null>(null);
+  const dragRef = useRef({ startX: 0, startY: 0, startTx: 0, startTy: 0, movedPast: false, pointerId: -1 });
+  const firedFitRef = useRef(false);
 
+  // image=실측 우선(로드 후 자연 크기가 선언보다 정확) → 그 다음 선언된 canvas_bounds(§4,
+  // BE #2135) → 마지막 포맷별 기본 아트보드(가짜 추정 아님·명시된 폴백 규약).
+  const bounds = format === 'image' && imageBounds ? imageBounds : (canvasBounds ?? DEFAULT_BOUNDS);
+
+  useEffect(() => { setImageBounds(null); firedFitRef.current = false; }, [content]);
+
+  // ResizeObserver 미지원 환경(구형 브라우저·이 프로젝트 vitest jsdom) — 정적 폴백, 크래시 방지.
   useEffect(() => {
-    if (!dragging) return;
-    function onMouseMove(e: MouseEvent) {
-      const el = wrapperRef.current;
-      if (!el) return;
-      const { x, y, scrollLeft, scrollTop } = dragStartRef.current;
-      el.scrollLeft = scrollLeft - (e.clientX - x);
-      el.scrollTop = scrollTop - (e.clientY - y);
-    }
-    function onMouseUp() {
-      setDragging(false);
-    }
-    window.addEventListener('mousemove', onMouseMove);
-    window.addEventListener('mouseup', onMouseUp);
-    return () => {
-      window.removeEventListener('mousemove', onMouseMove);
-      window.removeEventListener('mouseup', onMouseUp);
-    };
-  }, [dragging, wrapperRef]);
-
-  function handleMouseDown(e: React.MouseEvent) {
-    const el = wrapperRef.current;
+    const el = viewportRef.current;
     if (!el) return;
-    dragStartRef.current = { x: e.clientX, y: e.clientY, scrollLeft: el.scrollLeft, scrollTop: el.scrollTop };
-    setDragging(true);
+    const measure = () => setViewportSize({ w: el.clientWidth, h: el.clientHeight });
+    measure();
+    if (typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const clampPan = useCallback((tx: number, ty: number, scale: number, vw: number, vh: number) => {
+    const contentW = bounds.w * scale;
+    const contentH = bounds.h * scale;
+    const minTx = vw - contentW - PAN_MARGIN_PX;
+    const maxTx = PAN_MARGIN_PX;
+    const minTy = vh - contentH - PAN_MARGIN_PX;
+    const maxTy = PAN_MARGIN_PX;
+    return {
+      tx: minTx <= maxTx ? clamp(tx, minTx, maxTx) : (vw - contentW) / 2,
+      ty: minTy <= maxTy ? clamp(ty, minTy, maxTy) : (vh - contentH) / 2,
+    };
+  }, [bounds.w, bounds.h]);
+
+  const fitToView = useCallback(() => {
+    const { w: vw, h: vh } = viewportSize;
+    if (vw === 0 || vh === 0) return;
+    const scale = clamp(Math.min(vw / bounds.w, vh / bounds.h), MIN_SCALE, MAX_SCALE);
+    const tx = (vw - bounds.w * scale) / 2;
+    const ty = (vh - bounds.h * scale) / 2;
+    setTransform({ tx, ty, scale });
+  }, [viewportSize, bounds.w, bounds.h]);
+
+  const actualSize = useCallback(() => {
+    const { w: vw, h: vh } = viewportSize;
+    const tx = (vw - bounds.w) / 2;
+    const ty = (vh - bounds.h) / 2;
+    setTransform({ tx, ty, scale: 1 });
+  }, [viewportSize, bounds.w, bounds.h]);
+
+  // 최초 진입 = fit(콘텐츠 전체가 즉시 보이는 것이 재설계의 근본 목적 — "잘림 상태 부존재").
+  useEffect(() => {
+    if (firedFitRef.current) return;
+    if (viewportSize.w === 0 || viewportSize.h === 0) return;
+    firedFitRef.current = true;
+    fitToView();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- 최초 1회만(콘텐츠/뷰포트 변경 시 재-fit 강제 안 함, 사용자가 이미 조작했을 수 있음)
+  }, [viewportSize.w, viewportSize.h]);
+
+  function handlePointerDown(e: React.PointerEvent) {
+    if (e.button !== 0) return;
+    dragRef.current = { startX: e.clientX, startY: e.clientY, startTx: transform.tx, startTy: transform.ty, movedPast: false, pointerId: e.pointerId };
+    const el = e.currentTarget as HTMLElement;
+    // 구형 브라우저·이 프로젝트 vitest jsdom 둘 다 미지원 가능 — pan 자체는 capture 없이도
+    // 동작(빠른 드래그가 요소 밖으로 나가면 move를 놓칠 수 있는 정도의 성능 저하일 뿐).
+    if (typeof el.setPointerCapture === 'function') el.setPointerCapture(e.pointerId);
+  }
+
+  function handlePointerMove(e: React.PointerEvent) {
+    const d = dragRef.current;
+    if (d.pointerId !== e.pointerId) return;
+    const dx = e.clientX - d.startX;
+    const dy = e.clientY - d.startY;
+    if (!d.movedPast && Math.hypot(dx, dy) > DRAG_THRESHOLD_PX) {
+      d.movedPast = true;
+      setIsDragging(true);
+    }
+    if (d.movedPast) {
+      const next = clampPan(d.startTx + dx, d.startTy + dy, transform.scale, viewportSize.w, viewportSize.h);
+      setTransform((cur) => ({ ...cur, ...next }));
+    }
+  }
+
+  function handlePointerUp(e: React.PointerEvent) {
+    const d = dragRef.current;
+    if (d.pointerId !== e.pointerId) return;
+    const el = e.currentTarget as HTMLElement;
+    if (typeof el.releasePointerCapture === 'function') el.releasePointerCapture(e.pointerId);
+    dragRef.current.pointerId = -1;
+    setIsDragging(false);
+  }
+
+  function handleWheel(e: React.WheelEvent) {
+    e.preventDefault();
+    const rect = viewportRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    if (e.ctrlKey || e.metaKey) {
+      // ⌘/Ctrl+휠 · 트랙패드 핀치(브라우저가 ctrlKey=true wheel로 합성) — 커서 중심 줌.
+      const localX = e.clientX - rect.left;
+      const localY = e.clientY - rect.top;
+      setTransform((cur) => {
+        const nextScale = clamp(cur.scale * (1 - e.deltaY * WHEEL_ZOOM_SENSITIVITY), MIN_SCALE, MAX_SCALE);
+        const contentX = (localX - cur.tx) / cur.scale;
+        const contentY = (localY - cur.ty) / cur.scale;
+        const next = clampPan(localX - contentX * nextScale, localY - contentY * nextScale, nextScale, viewportSize.w, viewportSize.h);
+        return { ...next, scale: nextScale };
+      });
+    } else {
+      setTransform((cur) => {
+        const next = clampPan(cur.tx - e.deltaX, cur.ty - e.deltaY, cur.scale, viewportSize.w, viewportSize.h);
+        return { ...cur, ...next };
+      });
+    }
   }
 
   return (
-    <div
-      role="presentation"
-      data-pan-overlay
-      onMouseDown={handleMouseDown}
-      className="absolute inset-0"
-      style={{ cursor: dragging ? 'grabbing' : 'grab' }}
-    />
-  );
-}
-
-/**
- * 포맷별 렌더 스테이지. html=완전 잠금 샌드박스 iframe(`sandbox=""` — allow-scripts·
- * allow-same-origin 둘 다 없음, 핸드오프 §3-1 + 유나 디자인 가디언 보안 지적 반영).
- * artifact HTML은 인라인 `<style>`만 쓰므로 same-origin 리소스 접근이 필요 없어 최대
- * 잠금이 안전(CSS 렌더링은 sandbox 플래그와 무관하게 항상 동작함)·image=바운드 img·
- * tree=경량 노드 렌더(전신 componentCatalog의 리치 렌더는 후속 — 지금은 shell 준비 단계).
- */
-export function ArtifactStage({ format, content, title, fill = false }: ArtifactStageProps) {
-  const t = useTranslations('canvas');
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  if (format === 'html') {
-    return (
-      <div className={fill ? 'flex h-full w-full flex-col' : 'w-full'}>
-        {/* overlay는 스크롤 컨테이너 밖(형제)에 둔다 — 안에 두면 pan으로 스크롤될 때 overlay
-         * 자신도 같이 밀려나 뷰포트 밖으로 나가버린다(자기 자신이 캡처하는 영역을 잃는 순환
-         * 버그). 밖에 두면 wrapper의 보이는 영역(clientHeight)에 항상 고정된다. */}
-        <div className={fill ? 'relative min-h-0 w-full flex-1' : 'relative w-full'}>
-          <div
-            ref={wrapperRef}
-            data-artifact-stage-scroll
-            className={cn('w-full overflow-auto rounded-lg border border-border bg-background', fill && 'h-full')}
-            style={{ scrollbarGutter: 'stable' }}
-          >
+    <div className="flex h-full w-full flex-col">
+      <div
+        ref={viewportRef}
+        data-artifact-canvas-viewport
+        className="relative min-h-0 w-full flex-1 touch-none overflow-hidden rounded-lg border border-border bg-muted/20"
+        style={{ cursor: isDragging ? 'grabbing' : 'grab' }}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onWheel={handleWheel}
+      >
+        <div
+          data-artifact-canvas-content
+          className="absolute top-0 left-0"
+          style={{
+            width: bounds.w, height: bounds.h,
+            transform: `translate(${transform.tx}px, ${transform.ty}px) scale(${transform.scale})`,
+            transformOrigin: '0 0',
+          }}
+        >
+          {format === 'html' ? (
             <iframe
               title={title}
               srcDoc={content}
               sandbox=""
-              className="rounded-lg"
-              style={{ width: HTML_STAGE_WIDTH, height: fill ? '100%' : HTML_STAGE_HEIGHT }}
+              className="pointer-events-none rounded-lg bg-background"
+              style={{ width: bounds.w, height: bounds.h }}
             />
-          </div>
-          <PanOverlay wrapperRef={wrapperRef} />
+          ) : format === 'image' ? (
+            // eslint-disable-next-line @next/next/no-img-element -- artifact content는 외부/동적 URL이라 next/image 화이트리스트와 안 맞음.
+            <img
+              src={content}
+              alt={title}
+              className="pointer-events-none block h-full w-full rounded-lg object-contain"
+              onLoad={(e) => {
+                const img = e.currentTarget;
+                if (img.naturalWidth > 0 && img.naturalHeight > 0) setImageBounds({ w: img.naturalWidth, h: img.naturalHeight });
+              }}
+            />
+          ) : (
+            <TreeStageContent content={content} placeholder={t('treeRenderPlaceholder')} />
+          )}
+          {overlay ? (
+            <div
+              data-artifact-canvas-overlay
+              className="absolute inset-0"
+              style={{ pointerEvents: isDragging ? 'none' : 'auto' }}
+            >
+              {overlay}
+            </div>
+          ) : null}
         </div>
-        <p className="mt-1.5 shrink-0 text-[11px] text-muted-foreground">{t('viewerPanHint')}</p>
       </div>
-    );
-  }
+      <div className="mt-1.5 flex shrink-0 items-center justify-between gap-2">
+        <p className="text-[11px] text-muted-foreground">{t('viewerCanvasHint')}</p>
+        <div className="flex items-center gap-1 text-[11px] font-medium text-muted-foreground">
+          <span className="tabular-nums">{Math.round(transform.scale * 100)}%</span>
+          <button type="button" onClick={fitToView} title={t('viewerFitAction')} className="flex items-center gap-1 rounded-md border border-border px-1.5 py-0.5 hover:bg-muted hover:text-foreground">
+            <Scan className="size-3" aria-hidden />
+            {t('viewerFitAction')}
+          </button>
+          <button type="button" onClick={actualSize} title={t('viewerActualSizeAction')} className="flex items-center gap-1 rounded-md border border-border px-1.5 py-0.5 hover:bg-muted hover:text-foreground">
+            <Maximize2 className="size-3" aria-hidden />
+            {t('viewerActualSizeAction')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
 
-  if (format === 'image') {
-    // eslint-disable-next-line @next/next/no-img-element -- artifact content는 외부/동적 URL(임의 도메인)이라 next/image 도메인 화이트리스트와 안 맞음.
-    return <img src={content} alt={title} className="mx-auto max-h-[420px] max-w-full rounded-lg object-contain" />;
-  }
-
+function TreeStageContent({ content, placeholder }: { content: string; placeholder: string }) {
   const tree = parseArtifactTree(content);
   if (!tree) {
-    return <p className="p-4 text-xs text-muted-foreground">{t('treeRenderPlaceholder')}</p>;
+    return <p className="pointer-events-none p-4 text-xs text-muted-foreground">{placeholder}</p>;
   }
   return (
-    <div className="space-y-2 p-2">
+    <div className="pointer-events-none h-full w-full space-y-2 overflow-hidden rounded-lg bg-background p-2">
       {tree.map((node) => <TreeNodeBox key={node.id} node={node} />)}
     </div>
   );
+}
+
+/**
+ * 포맷별 렌더 스테이지 — 이제 3포맷 전부 같은 `CanvasViewport` 엔진(transform pan/zoom)을
+ * 공유한다(story 1948d19d §1~§3). 완전 잠금 샌드박스 iframe(`sandbox=""` — allow-scripts·
+ * allow-same-origin 둘 다 없음, 핸드오프 §3-1 + 유나 디자인 가디언 보안 지적 반영) 유지 —
+ * pointer-events:none이 상호작용 레이어와 물리적으로 분리해 완화가 애초에 불필요.
+ */
+export function ArtifactStage({ format, content, title, canvasBounds, overlay }: ArtifactStageProps) {
+  return <CanvasViewport format={format} content={content} title={title} canvasBounds={canvasBounds} overlay={overlay} />;
 }

--- a/apps/web/src/components/canvas/artifact-viewer.test.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.test.tsx
@@ -92,25 +92,41 @@ describe('ArtifactViewer (SSR snapshot)', () => {
     expect(markup).not.toContain('정본 제안 대기 중');
   });
 
-  describe('story 385eb89a — 고정 넓이 html 잘림 대책', () => {
-    it('renders the html stage bounded to a fixed canvas width instead of forcing 100%(잘림 원인 제거)', () => {
+  describe('story 1948d19d — 캔버스 뷰포트 재설계(v1~v2.1 스크롤/오버레이 모델 전면 폐기)', () => {
+    it('renders the transform-canvas viewport for html — no more fixed 1200px scroll container', () => {
       const markup = renderToStaticMarkup(
         wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
       );
-      expect(markup).toContain('width:1200px');
+      expect(markup).toContain('data-artifact-canvas-viewport');
+      expect(markup).toContain('data-artifact-canvas-content');
+      expect(markup).not.toContain('width:1200px');
     });
 
-    it('tree format render is unaffected (회귀 0 — placeholder path untouched)', () => {
+    it('tree format shares the same canvas viewport (전 포맷 통일 — html-only 분기 소멸)', () => {
       const markup = renderToStaticMarkup(
         wrap(<ArtifactViewer artifact={MOCK_EDITABLE_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
       );
       expect(markup).toContain('트리 렌더는 준비 중');
-      expect(markup).not.toContain('width:1200px');
+      expect(markup).toContain('data-artifact-canvas-viewport');
     });
-  });
 
-  describe('story d425dccc — 뷰어 v2(pan + 크게 보기), 축소-fit 토글 제거', () => {
-    it('shows the expand("크게 보기") entry point only for html format, not tree/image', () => {
+    it('marks the html iframe pointer-events:none (crux — 상시 캡처 오버레이 폐기, iframe은 렌더된 오브젝트일 뿐)', () => {
+      const markup = renderToStaticMarkup(
+        wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+      );
+      expect(markup).toContain('pointer-events-none');
+    });
+
+    it('never renders the v1~v2.1 scroll/overlay remnants (data-artifact-stage-scroll·data-pan-overlay·고정폭 잘림 카피)', () => {
+      const markup = renderToStaticMarkup(
+        wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+      );
+      expect(markup).not.toContain('data-artifact-stage-scroll');
+      expect(markup).not.toContain('data-pan-overlay');
+      expect(markup).not.toContain('끌어서 이동');
+    });
+
+    it('shows the expand("크게 보기") entry point only for html format, not tree/image (기존 스코프 유지)', () => {
       const htmlMarkup = renderToStaticMarkup(
         wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
       );
@@ -122,45 +138,18 @@ describe('ArtifactViewer (SSR snapshot)', () => {
       expect(treeMarkup).not.toContain('크게 보기');
     });
 
-    it('never renders the removed shrink-to-fit toggle copy (방향 오판 정정 — 회귀 방지)', () => {
-      const markup = renderToStaticMarkup(
-        wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
-      );
-      expect(markup).not.toContain('전체 보기');
-      expect(markup).not.toContain('aria-pressed');
-    });
-
-    it('renders the always-visible-scrollbar hook for the inline html stage', () => {
-      const markup = renderToStaticMarkup(
-        wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
-      );
-      expect(markup).toContain('data-artifact-stage-scroll');
-    });
-
     it('the expand dialog is not rendered in the DOM when closed by default (base-ui portal, no leaked markup)', () => {
       const markup = renderToStaticMarkup(
         wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
       );
       expect(markup).not.toContain('90vw');
     });
-  });
 
-  describe('story e4cce704(v2.1) — space 게이트 완전 제거, 직접-드래그 pan', () => {
-    it('the pan overlay always renders with the grab cursor (즉시 가시 어포던스, space 대기 없음)', () => {
+    it('renders the coordinate-anchor pin overlay inside the canvas content layer (description pane 부활의 전제)', () => {
       const markup = renderToStaticMarkup(
-        wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
+        wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} threads={MOCK_THREADS} />),
       );
-      expect(markup).toContain('data-pan-overlay');
-      expect(markup).toContain('cursor:grab');
-      expect(markup).not.toContain('pointer-events:none');
-    });
-
-    it('renders the updated drag hint copy, never the discarded space-based instruction', () => {
-      const markup = renderToStaticMarkup(
-        wrap(<ArtifactViewer artifact={MOCK_ARTIFACT} versions={MOCK_VERSIONS} memberMap={MOCK_MEMBERS} />),
-      );
-      expect(markup).toContain('끌어서 이동');
-      expect(markup).not.toContain('스페이스');
+      expect(markup).toContain('data-artifact-canvas-overlay');
     });
   });
 });

--- a/apps/web/src/components/canvas/artifact-viewer.tsx
+++ b/apps/web/src/components/canvas/artifact-viewer.tsx
@@ -151,20 +151,33 @@ export function ArtifactViewer({
         <div className="grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_232px]">
           <div ref={captureTargetRef} className="relative min-w-0 bg-muted/20 p-4">
             {activeVersion ? (
-              <ArtifactStage format={artifact.format} content={activeVersion.content} title={artifact.title} />
+              <div className="h-[320px] w-full">
+                <ArtifactStage
+                  format={artifact.format}
+                  content={activeVersion.content}
+                  title={artifact.title}
+                  canvasBounds={activeVersion.canvasBounds}
+                  overlay={
+                    // C2 §1 — 좌표 앵커 스레드만 오버레이(element 앵커는 실 artifact tree 좌표 유도 필요, 후속).
+                    // story 1948d19d §2 — 이제 ArtifactStage의 캔버스 좌표계 안에서 pan/zoom을 그대로
+                    // 물려받는다(v2.1 상시 캡처 오버레이가 삼켰던 핀 클릭이 여기서 복원된다).
+                    <>
+                      {threads?.filter((th) => th.anchor.kind === 'coordinate').map((th) => (
+                        <AnchorPin
+                          key={th.id}
+                          number={th.pin_number}
+                          state={th.rollup === 'resolved' ? 'resolved' : 'open'}
+                          active={th.id === selectedThreadId}
+                          onClick={() => setSelectedThreadId((cur) => (cur === th.id ? null : th.id))}
+                          className="absolute z-10"
+                          style={{ left: `${th.anchor.x}%`, top: `${th.anchor.y}%` }}
+                        />
+                      ))}
+                    </>
+                  }
+                />
+              </div>
             ) : null}
-            {/* C2 §1 — 좌표 앵커 스레드만 오버레이(element 앵커는 실 artifact tree 좌표 유도 필요, 후속). */}
-            {threads?.filter((th) => th.anchor.kind === 'coordinate').map((th) => (
-              <AnchorPin
-                key={th.id}
-                number={th.pin_number}
-                state={th.rollup === 'resolved' ? 'resolved' : 'open'}
-                active={th.id === selectedThreadId}
-                onClick={() => setSelectedThreadId((cur) => (cur === th.id ? null : th.id))}
-                className="absolute z-10"
-                style={{ left: `${th.anchor.x}%`, top: `${th.anchor.y}%` }}
-              />
-            ))}
           </div>
           <ArtifactVersionRail
             artifact={artifact}
@@ -213,6 +226,7 @@ export function ArtifactViewer({
           title={artifact.title}
           format={artifact.format}
           content={activeVersion.content}
+          canvasBounds={activeVersion.canvasBounds}
         />
       ) : null}
     </div>

--- a/apps/web/src/services/canvas.ts
+++ b/apps/web/src/services/canvas.ts
@@ -24,6 +24,9 @@ export interface ArtifactVersion {
   /** 변경 이유(의미 단위) — raw 편집 나열 아님(핸드오프 §6 감시 게이트). */
   summary: string | null;
   created_at: string;
+  /** story 1948d19d §4(BE #2135) — 그 버전의 불변 스냅샷 아트보드 크기. nullable(레거시/미선언) —
+   * ArtifactStage가 null이면 포맷별 기본 아트보드로 폴백(가짜 추정 0, 측정 아니라 선언). */
+  canvasBounds?: { w: number; h: number } | null;
 }
 
 /**
@@ -120,7 +123,12 @@ export function deriveFormat(nodes: ArtifactNode[]): ArtifactFormat {
 /** BE `ArtifactNodeOut`(schemas/visual_artifact.py) 미러 — canvas-nodes.ts의 `ArtifactNode`와 동형. */
 export type BeArtifactNode = ArtifactNode;
 
-/** BE `VisualArtifactDetail`(schemas/visual_artifact.py) 미러 — flat 응답(중첩 아님). */
+/**
+ * BE `VisualArtifactDetail`(schemas/visual_artifact.py) 미러 — flat 응답(중첩 아님).
+ * `canvas_bounds`: story 1948d19d §4(BE #2135) — 이 버전(`version_number`)의 불변 스냅샷
+ * 아트보드 크기. nullable(레거시/미선언 허용) — #2135 머지 전엔 항상 undefined로 와도 무해
+ * (FE는 폴백 우선 설계라 옵셔널로만 소비).
+ */
 export interface BeVisualArtifactDetail {
   id: string;
   title: string;
@@ -135,9 +143,11 @@ export interface BeVisualArtifactDetail {
   version_number: number;
   version_summary: string | null;
   nodes: BeArtifactNode[];
+  canvas_bounds?: { w: number; h: number } | null;
 }
 
-/** BE `VisualArtifactSummary` 미러 — `GET /api/v2/visual-artifacts?story_id=` 목록 항목(nodes 없음). */
+/** BE `VisualArtifactSummary` 미러 — `GET /api/v2/visual-artifacts?story_id=` 목록 항목(nodes 없음).
+ * `canvas_bounds`: BE #2135 — latest 버전의 denorm 캐시(§4-1). */
 export interface BeVisualArtifactSummary {
   id: string;
   title: string;
@@ -149,6 +159,7 @@ export interface BeVisualArtifactSummary {
   anchor_version: number | null;
   created_by: string | null;
   created_at: string;
+  canvas_bounds?: { w: number; h: number } | null;
 }
 
 /**
@@ -195,6 +206,7 @@ export function adaptArtifactDetail(detail: BeVisualArtifactDetail): { artifact:
     created_by: detail.created_by ?? '',
     summary: detail.version_summary,
     created_at: detail.created_at,
+    canvasBounds: detail.canvas_bounds,
   };
   return { artifact, versions: [version] };
 }


### PR DESCRIPTION
## 변경 사항
story `1948d19d` PR A — 선생님 직접 지시("다시 통합적으로 재설계 들어가 보기 바라는"). v1(#2127)→v2(#2130)→v2.1(#2133) 세 번의 "증상 단위" 패치가 전부 **틀린 모델**(스크롤 문서 창 + 상시 전면 캡처 오버레이) 안에서 반복됐던 게 근본 문제(description pane·핀·코멘트 앵커 전멸 포함). 설계 SSOT: doc `artifact-canvas-viewport-spec`. 산출물=스크롤 문서가 아니라 **캔버스 위 오브젝트**(Figma 캔버스 뷰포트 레퍼런스)로 모델 자체를 교체합니다.

## 구현

**§1 뷰포트**: `ArtifactStage`를 `transform: translate(tx,ty) scale(s)` 캔버스로 전면 재작성
- 전방향 pan(휠) · ⌘/Ctrl+휠 = 커서 중심 줌(트랙패드 핀치와 동일 신호) · fit/100% 크롬 · 줌 clamp(10~400%) · pan 소프트 bound
- overflow/스크롤바/space 잔재(v1~v2.1 전부) 완전 소멸

**§2 crux(v2.1 오류 교정)**: 상시 전면 캡처 오버레이 폐기
- iframe/img/tree 콘텐츠는 항상 `pointer-events:none`(렌더된 오브젝트일 뿐, 상호작용 대상이 아님)
- 핀 등 우리 DOM 오버레이만 `pointer-events:auto`
- 이동-임계값(4px) 판별: 확定 드래그 중엔 오버레이 전체를 `pointer-events:none`으로 전환하는 **순수 CSS 메커니즘**으로 "핀 위 드래그=pan(선택 미커밋)"을 구현 — 핀 자신의 `onClick`은 완전히 무변경(임계 미달 클릭만 정상 발화)

**§3 표면 통일**: 3포맷(html/image/tree) 전부 같은 `CanvasViewport` 엔진 공유(포맷은 콘텐츠 레이어 안쪽만 다름) + 인라인 카드·크게 보기 모달·갤러리 열람이 전부 동일 `ArtifactStage` 재사용(#2134에서 이미 3곳 모두 배선돼 있어 자연 커버). `fill` prop 완전 제거 — 컨테이너 CSS 크기가 곧 뷰포트 크기.

**§4(BE #2135, PO 확定 통보 반영)**: `canvas_bounds`(버전 detail 불변 스냅샷) FE 소비 배선 — 있으면 프레임 w×h 세팅, null/undefined(레거시·#2135 착지 전)면 포맷별 기본 아트보드(1280×800)로 폴백(가짜 추정 0). image 포맷은 이 값과 무관하게 로드 후 실측 자연 크기 우선.

## 자체 발견
이 프로젝트 vitest/jsdom엔 `setPointerCapture`/`releasePointerCapture`도 없습니다(`IntersectionObserver`·`ResizeObserver`에 이어 3번째 gap, 앞선 두 스토리에서 이미 겪음) — 구형 브라우저 폴백과 테스트 크래시 방지를 동시에 해결하는 defensive guard를 추가했습니다.

## 정직 고지
PNG export는 캡처 시점 뷰포트(pan/zoom 상태)를 그대로 담습니다 — image/tree 포맷은 이제 pan/zoom이 생겨 사용자가 확대/이동한 뒤 export하면 그 시점 뷰가 캡처됩니다(기존엔 pan/zoom 자체가 없어 항상 전체가 캡처됐음). WYSIWYG로 의도된 동작이라 "고쳐야 할 회귀"로 보진 않았으나, 리뷰어가 알아야 할 행동 변화라 명시합니다.

## 스코프 경계(승인된 2단계 분할안)
편집 캔버스(`artifact-editor.tsx`) 통합은 **PR B로 분리** — 기존 동작 그대로 유지, 반쪽 상태 아님(순차 전환). PR A 단독으로 뷰어 3표면(인라인·모달·갤러리)이 완결 전환됩니다.

## 테스트
- `artifact-stage.test.tsx` 전면 재작성(16건): sandbox 유지·`pointer-events:none`·pan delta·클릭 임계 미달 무변·wheel pan·ctrl+wheel zoom+clamp·overlay pointer-events 토글(핀 위 드래그=pan)·fit/100% 버튼·auto-fit on mount
- `artifact-viewer.test.tsx` 갱신: v1~v2.1 잔여 검증 구문 → 1948d19d 신규 계약 검증(캔버스 뷰포트 렌더·pointer-events:none·pin overlay 위치·v1~v2.1 잔재 미노출)
- 전체 `pnpm vitest run`: **1338 passed | 2 skipped**, 회귀 0
- `tsc --noEmit`: clean
- `eslint`: 0 warning
- `pnpm build`: EXIT=0

## 반응형/스크린샷
pan/zoom 실감·핀 클릭 vs 드래그 공존·description pane 부활은 라이브 픽셀에서만 확실히 검증 가능한 영역(AC4 "전축 스위프" 가디언 기준 그대로)이라, dev 배포 후 오르테가군 라이브 done-gate에서 실측 예정.