### PR TITLE
[SID:1948d19d] fix — 캔버스 휠 pan/줌이 페이지 스크롤·네이티브 줌으로 새는 crux 수정

### DIFF
--- a/apps/web/src/components/canvas/artifact-stage.test.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.test.tsx
@@ -166,6 +166,44 @@ describe('ArtifactStage — 캔버스 뷰포트(story 1948d19d)', () => {
     addSpy.mockRestore();
   });
 
+  it('plain wheel over a [data-canvas-scrollable] region with real overflow yields to native inner scroll instead of panning (까심 QA 발견, PR#2138)', async () => {
+    await mount({
+      overlay: (
+        <div data-canvas-scrollable data-testid="scroll-region">
+          <button type="button" data-testid="node">node</button>
+        </div>
+      ),
+    });
+    const scrollRegion = container.querySelector('[data-canvas-scrollable]') as HTMLElement;
+    Object.defineProperty(scrollRegion, 'scrollHeight', { value: 2000, configurable: true });
+    Object.defineProperty(scrollRegion, 'clientHeight', { value: 400, configurable: true });
+    const node = container.querySelector('[data-testid="node"]') as HTMLElement;
+    const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+    const before = readTransform(content);
+
+    await act(async () => { press(node, 'wheel', { deltaX: 0, deltaY: 50, ctrlKey: false }); });
+    expect(readTransform(content)).toEqual(before);
+  });
+
+  it('ctrl/meta+wheel over the same overflowing region still zooms (줌 의도는 무조건 소비 — 네이티브 페이지 줌 누출 방지가 어디서도 안 깨짐)', async () => {
+    await mount({
+      overlay: (
+        <div data-canvas-scrollable data-testid="scroll-region">
+          <button type="button" data-testid="node">node</button>
+        </div>
+      ),
+    });
+    const scrollRegion = container.querySelector('[data-canvas-scrollable]') as HTMLElement;
+    Object.defineProperty(scrollRegion, 'scrollHeight', { value: 2000, configurable: true });
+    Object.defineProperty(scrollRegion, 'clientHeight', { value: 400, configurable: true });
+    const node = container.querySelector('[data-testid="node"]') as HTMLElement;
+    const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+    const before = readTransform(content);
+
+    await act(async () => { press(node, 'wheel', { deltaY: -100, ctrlKey: true, clientX: 10, clientY: 10 }); });
+    expect(readTransform(content).scale).toBeGreaterThan(before.scale);
+  });
+
   it('renders the fit and actual-size chrome buttons plus a live zoom percentage — no v1~v2.1 scrollbar/space chrome', async () => {
     await mount();
     expect(container.textContent).toContain('전체 보기');

--- a/apps/web/src/components/canvas/artifact-stage.test.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.test.tsx
@@ -157,6 +157,15 @@ describe('ArtifactStage — 캔버스 뷰포트(story 1948d19d)', () => {
     expect(readTransform(content).scale).toBe(1);
   });
 
+  it('attaches wheel via a native non-passive listener (crux — React onWheel silently no-ops preventDefault, leaking to page scroll/native ctrl-wheel zoom)', async () => {
+    const addSpy = vi.spyOn(HTMLElement.prototype, 'addEventListener');
+    await mount();
+    const wheelCall = addSpy.mock.calls.find((call) => call[0] === 'wheel');
+    expect(wheelCall).toBeDefined();
+    expect(wheelCall?.[2]).toMatchObject({ passive: false });
+    addSpy.mockRestore();
+  });
+
   it('renders the fit and actual-size chrome buttons plus a live zoom percentage — no v1~v2.1 scrollbar/space chrome', async () => {
     await mount();
     expect(container.textContent).toContain('전체 보기');

--- a/apps/web/src/components/canvas/artifact-stage.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.tsx
@@ -200,7 +200,14 @@ function CanvasViewport({ format, content, title, canvasBounds, overlay, mode = 
     setIsDragging(false);
   }
 
-  function handleWheel(e: React.WheelEvent) {
+  // crux(선생님 실사용 즉시지적) — React onWheel은 루트에 passive 위임으로 붙어 e.preventDefault()가
+  // 조용히 무효화된다(React 17+ 표준 동작). 그 결과 우리 pan/줌이 실행되는 **동시에** 브라우저
+  // 네이티브 스크롤(휠)과 네이티브 Ctrl+휠 페이지 줌이 함께 새어나갔다("휠=pan 배타 소비" 계약
+  // 위반). 해법은 표준적으로 known: ref에 네이티브 `addEventListener('wheel', h, {passive:false})`를
+  // 직접 붙여야 preventDefault()가 실제로 먹는다 — React 합성 이벤트 prop으로는 안 됨.
+  const handleWheelRef = useRef<(e: WheelEvent) => void>(() => {});
+
+  function handleWheel(e: WheelEvent) {
     e.preventDefault();
     const rect = viewportRef.current?.getBoundingClientRect();
     if (!rect) return;
@@ -222,6 +229,15 @@ function CanvasViewport({ format, content, title, canvasBounds, overlay, mode = 
       });
     }
   }
+  handleWheelRef.current = handleWheel;
+
+  useEffect(() => {
+    const el = viewportRef.current;
+    if (!el) return;
+    const listener = (e: WheelEvent) => handleWheelRef.current(e);
+    el.addEventListener('wheel', listener, { passive: false });
+    return () => el.removeEventListener('wheel', listener);
+  }, []);
 
   return (
     <div className="flex h-full w-full flex-col">
@@ -234,7 +250,6 @@ function CanvasViewport({ format, content, title, canvasBounds, overlay, mode = 
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
         onPointerCancel={handlePointerUp}
-        onWheel={handleWheel}
       >
         <div
           data-artifact-canvas-content

--- a/apps/web/src/components/canvas/artifact-stage.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.tsx
@@ -208,6 +208,16 @@ function CanvasViewport({ format, content, title, canvasBounds, overlay, mode = 
   const handleWheelRef = useRef<(e: WheelEvent) => void>(() => {});
 
   function handleWheel(e: WheelEvent) {
+    if (!(e.ctrlKey || e.metaKey)) {
+      // story 1948d19d §3(PR#2137 까심 QA 비차단 발견, 이 fix로 preventDefault가 실제로 먹기
+      // 시작하면서 노출됨) — 편집 캔버스의 긴 노드트리(overflow-auto)는 자체 내부 스크롤이
+      // 있다. plain wheel(=pan 의도)이 실제로 넘칠 내용이 있는 스크롤 가능 영역 위에서
+      // 시작됐으면 캔버스 pan 대신 네이티브 내부 스크롤에 양보한다(우리가 소비 안 함).
+      // ctrl/meta+wheel(=줌 의도)은 무조건 우리가 소비 — 그래야 네이티브 페이지 줌 누출
+      // 방지(이 PR의 crux)가 전 영역에서 안 깨진다.
+      const scrollable = (e.target as HTMLElement | null)?.closest?.('[data-canvas-scrollable]') as HTMLElement | null;
+      if (scrollable && scrollable.scrollHeight > scrollable.clientHeight) return;
+    }
     e.preventDefault();
     const rect = viewportRef.current?.getBoundingClientRect();
     if (!rect) return;

--- a/apps/web/src/components/canvas/edit-canvas.test.tsx
+++ b/apps/web/src/components/canvas/edit-canvas.test.tsx
@@ -55,4 +55,10 @@ describe('EditCanvas (C3 §2 — 클릭 선택만, 중첩 트리 재귀 렌더, 
     expect(markup).toContain('전체 보기');
     expect(markup).toContain('실제 크기');
   });
+
+  it('marks the node list as data-canvas-scrollable (PR#2138 — 긴 트리 내부 스크롤을 캔버스 pan에서 양보받는 마커)', () => {
+    const tree: ResolvedNode[] = [{ id: 'n1', type: 'Card', props: {}, parent_id: null, sort_order: 0, children: [] }];
+    const markup = renderToStaticMarkup(wrap(<EditCanvas tree={tree} selectedId={null} onSelect={vi.fn()} />));
+    expect(markup).toContain('data-canvas-scrollable');
+  });
 });

--- a/apps/web/src/components/canvas/edit-canvas.tsx
+++ b/apps/web/src/components/canvas/edit-canvas.tsx
@@ -41,7 +41,9 @@ function NodeBox({ node, selectedId, onSelect }: { node: ResolvedNode; selectedI
  * 좌표 이동보다 select→속성패널이 더 정합한 MVP 선택, PR A 이전부터의 기존 결정 유지).
  * 노드 트리는 문서 플로우 그대로라 개별 좌표 계산이 필요 없어 오버레이 박스 안에서
  * overflow-auto로 내부 스크롤(캔버스 bounds 자체를 콘텐츠 높이에 맞춰 동적 산정하지 않음
- * — MVP 단순화, 정직 고지).
+ * — MVP 단순화, 정직 고지). `data-canvas-scrollable` — 까심 QA 비차단 발견(PR#2137) 대응
+ * (PR#2138): 긴 트리(>800px) 위에서의 plain wheel은 캔버스 pan 대신 이 내부 스크롤에 양보한다
+ * (ArtifactStage의 wheel 핸들러가 이 마커+실제 overflow 존재를 확인하고 pass-through).
  */
 export function EditCanvas({ tree, selectedId, onSelect, className }: EditCanvasProps) {
   return (
@@ -52,7 +54,7 @@ export function EditCanvas({ tree, selectedId, onSelect, className }: EditCanvas
         title=""
         mode="edit"
         overlay={
-          <div className="h-full w-full space-y-2 overflow-auto rounded-lg border border-dashed border-border bg-background p-3">
+          <div data-canvas-scrollable className="h-full w-full space-y-2 overflow-auto rounded-lg border border-dashed border-border bg-background p-3">
             {tree.map((node) => <NodeBox key={node.id} node={node} selectedId={selectedId} onSelect={onSelect} />)}
           </div>
         }


### PR DESCRIPTION
## 배경
선생님 실사용 즉시 지적(story `1948d19d` 스코프 내 긴급): 캔버스 뷰포트 위에서 휠을 굴리면 우리 pan 계산과 **동시에** 브라우저 페이지 스크롤도 함께 움직인다. ctrl+휠(트랙패드 핀치)도 마찬가지로 우리 커서중심 줌과 **동시에** 브라우저 네이티브 페이지 줌이 발동한다. "휠=pan 배타 소비" 계약(§2)이 새고 있었다.

## 근본원인(그라운딩으로 확定)
`ArtifactStage`는 `onWheel={handleWheel}`(React 합성 이벤트 prop)로 휠을 소비하고 내부에서 `e.preventDefault()`를 호출했다. **React 17부터 `onWheel`/`onTouchStart`/`onTouchMove`는 루트에 passive listener로 위임 부착된다** — 즉 `preventDefault()` 호출이 조용히 무효화된다(React 공식 동작, 브라우저 스크롤 성능 보호 목적). 그 결과:
- 일반 휠 → 우리 pan은 실행되지만 브라우저 네이티브 스크롤도 함께 일어남(문서/부모 스크롤 컨테이너가 있다면 그쪽으로).
- ctrl/⌘+휠 → 우리 커서중심 줌은 실행되지만 브라우저 네이티브 Ctrl+휠 페이지 줌도 함께 발동.

## 수정
- `viewportRef`에 네이티브 `addEventListener('wheel', handler, { passive: false })`를 직접 부착(마운트 1회, cleanup 포함). React `onWheel` prop 제거.
- 핸들러 클로저가 항상 최신 상태(`transform`/`viewportSize`/`clampPan`)를 읽도록 `handleWheelRef` 패턴으로 감쌌다(이펙트 재부착 없이 안전).
- 회귀가드: `addEventListener`가 `'wheel'`을 `{ passive: false }`로 붙였는지 직접 검증하는 테스트 추가 — `onWheel` prop으로의 재발을 구조적으로 봉쇄.

## 스코프
`fix/canvas-wheel-passive-leak`는 `origin/develop`(6ffd4614, PR A 머지 시점)에서 분기 — PR B(#2137, 편집 캔버스 통합, 아직 open)와 겹치는 파일(`artifact-stage.tsx`)이 있어 이 fix가 먼저 머지되면 PR B는 rebase가 필요함(예상된 순서, 처리 예정).

## 게이트
- vitest 1511 GREEN(회귀 0, 신규 wheel-passive 회귀가드 1건 포함)
- tsc --noEmit clean
- eslint 0
- next build EXIT=0

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>