### PR TITLE
E-CANVAS 편집 캔버스 핀 저작(story 7fe16274): 스펙 핀 엔티티 BE

### DIFF
--- a/backend/alembic/versions/0180_artifact_spec_pins.py
+++ b/backend/alembic/versions/0180_artifact_spec_pins.py
@@ -1,0 +1,67 @@
+"""편집 캔버스 핀 저작(story 7fe16274·doc artifact-pin-authoring-spec §2) — artifact_spec_pins.
+
+Revision ID: 0180
+Revises: 0179
+Create Date: 2026-07-13
+
+그라운딩(§2·기존 코멘트 앵커 모델 재사용 vs 신설 — 디디 판단): 신설. ArtifactComment와 같은
+캔버스 핀 레이어를 공유하지만(FE 시각 구분) 생명주기가 근본적으로 다르다 —
+  · 버전 스코프(canvas_bounds·artifact_nodes와 동형) — 코멘트는 artifact 레벨 영속, 스펙 핀은
+    그 버전 레이아웃의 스냅샷이라 edit마다 carry-forward(무-mutate 버전 원칙).
+  · 스레드/resolve 없음(단일값 description) — 코멘트 전용 컬럼을 스펙 핀 행에 방치하지 않으려
+    분리.
+  · anchor_type 명시 판별자 + CHECK — 코멘트의 암묵적 nullable 타이핑과 달리 anchor 오타입
+    no-op 함정을 스키마 레벨에서 차단.
+  · 감시금지(doc §4) — created_by 등 attribution 컬럼 자체를 두지 않음(ArtifactNode와 동형).
+
+신규 테이블(신설 — 기존 테이블 변경 없음, additive).
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0180"
+down_revision = "0179"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "artifact_spec_pins",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "artifact_id", postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("visual_artifacts.id", ondelete="CASCADE"), nullable=False,
+        ),
+        sa.Column(
+            "version_id", postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("artifact_versions.id", ondelete="CASCADE"), nullable=False,
+        ),
+        sa.Column("anchor_type", sa.Text(), nullable=False),
+        sa.Column("anchor_x", sa.Float(), nullable=True),
+        sa.Column("anchor_y", sa.Float(), nullable=True),
+        sa.Column(
+            "node_id", postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("artifact_nodes.id", ondelete="CASCADE"), nullable=True,
+        ),
+        sa.Column("description", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.CheckConstraint(
+            "(anchor_type = 'coord' AND anchor_x IS NOT NULL AND anchor_y IS NOT NULL AND node_id IS NULL) OR "
+            "(anchor_type = 'node' AND node_id IS NOT NULL AND anchor_x IS NULL AND anchor_y IS NULL)",
+            name="ck_artifact_spec_pins_anchor_consistency",
+        ),
+    )
+    op.create_index("ix_artifact_spec_pins_artifact_id", "artifact_spec_pins", ["artifact_id"])
+    op.create_index("ix_artifact_spec_pins_version_id", "artifact_spec_pins", ["version_id"])
+    op.create_index("ix_artifact_spec_pins_node_id", "artifact_spec_pins", ["node_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_artifact_spec_pins_node_id", table_name="artifact_spec_pins")
+    op.drop_index("ix_artifact_spec_pins_version_id", table_name="artifact_spec_pins")
+    op.drop_index("ix_artifact_spec_pins_artifact_id", table_name="artifact_spec_pins")
+    op.drop_table("artifact_spec_pins")

--- a/backend/app/models/visual_artifact.py
+++ b/backend/app/models/visual_artifact.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Integer, Text, UniqueConstraint, func
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Integer, Text, UniqueConstraint, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -132,6 +132,53 @@ class ArtifactComment(Base):
     resolved_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_by: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+
+ARTIFACT_SPEC_PIN_ANCHOR_TYPES = frozenset({"coord", "node"})
+
+
+class ArtifactSpecPin(Base):
+    """편집 캔버스 핀 저작(story 7fe16274·doc artifact-pin-authoring-spec §2) — 요소/좌표 스펙
+    앵커(description pane 저작 입구). ArtifactComment(코멘트 핀)와 같은 캔버스 핀 레이어를
+    공유하되(FE §4 시각 구분) 별도 엔티티로 분리한 이유(그라운딩·재사용 대신 신설 판단):
+      · **버전 스코프**(canvas_bounds·ArtifactNode와 동형) — 코멘트는 artifact 레벨로 버전과
+        무관하게 영속되지만(node_id가 있어도 carry-forward 안 됨·구버전 참조로 방치), 스펙 핀은
+        그 버전 레이아웃(좌표/노드)의 스냅샷이라 edit마다 함께 carry-forward한다
+        (_apply_artifact_edit — 무-mutate 버전 원칙·reflow-safe 계승).
+      · **스레드/resolve 없음** — 단일값 description(재편집=덮어씀). 코멘트의 토론형(parent_id
+        스레드·resolved 상태)과 근본적으로 다른 생명주기라 같은 테이블에 넣으면 코멘트 전용
+        컬럼이 스펙 핀 행마다 의미 없이 방치됨.
+      · **anchor_type 명시 판별자** — 코멘트의 암묵적 nullable 타이핑(node_id 있으면 노드,
+        anchor_x/y 있으면 좌표)과 달리 명시 컬럼 + CHECK로 고정. anchor 테이블 오타입 no-op
+        함정(암묵 타이핑 시 잘못된 조합이 조용히 통과) 회피.
+      · **감시금지**(doc §4) — created_by/created_at 등 작성자·시간 속성을 아예 갖지 않는다
+        (ArtifactNode와 동형 — attribution 노출 0을 스키마 레벨에서 강제).
+    """
+    __tablename__ = "artifact_spec_pins"
+    __table_args__ = (
+        CheckConstraint(
+            "(anchor_type = 'coord' AND anchor_x IS NOT NULL AND anchor_y IS NOT NULL AND node_id IS NULL) OR "
+            "(anchor_type = 'node' AND node_id IS NOT NULL AND anchor_x IS NULL AND anchor_y IS NULL)",
+            name="ck_artifact_spec_pins_anchor_consistency",
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    artifact_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("visual_artifacts.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    version_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("artifact_versions.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    anchor_type: Mapped[str] = mapped_column(Text, nullable=False)
+    anchor_x: Mapped[float | None] = mapped_column(nullable=True)
+    anchor_y: Mapped[float | None] = mapped_column(nullable=True)
+    node_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("artifact_nodes.id", ondelete="CASCADE"), nullable=True, index=True
+    )
+    # description=null 금지 계보(doc §3 — 빈 스펙 저장 차단, 핸드오프 계약 규율).
+    description: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
 

--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -11,7 +11,7 @@ from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
 from app.models.asset import Asset
 from app.models.visual_artifact import (
-    ArtifactComment, ArtifactExport, ArtifactNode, ArtifactVersion, VisualArtifact,
+    ArtifactComment, ArtifactExport, ArtifactNode, ArtifactSpecPin, ArtifactVersion, VisualArtifact,
 )
 from app.schemas.visual_artifact import (
     ArtifactCommentResponse,
@@ -23,9 +23,12 @@ from app.schemas.visual_artifact import (
     CompleteExportRequest,
     CreateArtifactCommentRequest,
     CreateArtifactRequest,
+    CreateSpecPinRequest,
     EditArtifactRequest,
     ExportUploadUrlRequest,
     ExportUploadUrlResponse,
+    SpecPinResponse,
+    UpdateSpecPinRequest,
     VisualArtifactDetail,
     VisualArtifactSummary,
 )
@@ -396,6 +399,132 @@ async def resolve_artifact_comment(
     await session.flush()
     await session.refresh(comment)
     return _ok(ArtifactCommentResponse.model_validate(comment).model_dump(mode="json"))
+
+
+# ─── Spec pins (편집 캔버스 핀 저작, story 7fe16274) ──────────────────────────
+# 그라운딩(디디): ArtifactComment(코멘트 핀)와 캔버스 핀 레이어를 공유하되(FE 시각 구분) 신설
+# 엔티티로 분리 — 버전 스코프(carry-forward 필요)·스레드/resolve 없음·명시 anchor_type 판별자가
+# 코멘트 모델과 근본적으로 달라 재사용 시 무의미한 컬럼이 방치됨(ArtifactSpecPin 클래스 docstring
+# 참조). 스펙 핀은 항상 artifact의 **latest version**을 대상으로 조회/생성/수정/삭제한다(과거
+# 버전의 핀은 그 버전 스냅샷으로 고정·불변 — carry-forward는 _apply_artifact_edit에서만 발생).
+
+
+@router.get("/{id}/pins")
+async def list_spec_pins(
+    id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id or not project_id:
+        return _err("FORBIDDEN", "org_id/project_id required", 403)
+    artifact = await _get_artifact_or_404(session, org_id, project_id, id)
+    if artifact is None:
+        return _err("NOT_FOUND", "Artifact not found", 404)
+    latest = await _get_version_or_404(session, artifact.id, artifact.latest_version_number)
+    if latest is None:
+        return _err("NOT_FOUND", "Artifact version not found", 404)
+    rows = (await session.execute(
+        select(ArtifactSpecPin).where(ArtifactSpecPin.version_id == latest.id)
+        .order_by(ArtifactSpecPin.created_at.asc())
+    )).scalars().all()
+    return _ok([SpecPinResponse.model_validate(r).model_dump(mode="json") for r in rows])
+
+
+@router.post("/{id}/pins", status_code=201)
+async def create_spec_pin(
+    id: uuid.UUID,
+    body: CreateSpecPinRequest,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id or not project_id:
+        return _err("FORBIDDEN", "org_id/project_id required", 403)
+    artifact = await _get_artifact_or_404(session, org_id, project_id, id)
+    if artifact is None:
+        return _err("NOT_FOUND", "Artifact not found", 404)
+    latest = await _get_version_or_404(session, artifact.id, artifact.latest_version_number)
+    if latest is None:
+        return _err("NOT_FOUND", "Artifact version not found", 404)
+
+    if body.anchor_type == "node":
+        # cross-artifact 위조 차단 동형(source_comment_id·comment.node_id 패턴) + node는 반드시
+        # **latest version** 소속이어야 함(구버전 node는 이번 edit 스냅샷 밖 — carry-forward
+        # id_remap 대상이 아니라 즉시 stale).
+        node_owner = (await session.execute(
+            select(ArtifactNode.artifact_id).where(
+                ArtifactNode.id == body.node_id, ArtifactNode.version_id == latest.id,
+            )
+        )).scalar_one_or_none()
+        if node_owner != artifact.id:
+            return _err("NOT_FOUND", "Node not found on the artifact's latest version", 404)
+
+    pin = ArtifactSpecPin(
+        id=uuid.uuid4(), artifact_id=artifact.id, version_id=latest.id,
+        anchor_type=body.anchor_type, anchor_x=body.anchor_x, anchor_y=body.anchor_y,
+        node_id=body.node_id, description=body.description,
+    )
+    session.add(pin)
+    await session.flush()
+    return _ok(SpecPinResponse.model_validate(pin).model_dump(mode="json"), status=201)
+
+
+async def _get_latest_spec_pin_or_404(
+    session: AsyncSession, artifact: VisualArtifact, pin_id: uuid.UUID,
+) -> ArtifactSpecPin | None:
+    latest = await _get_version_or_404(session, artifact.id, artifact.latest_version_number)
+    if latest is None:
+        return None
+    return (await session.execute(
+        select(ArtifactSpecPin).where(
+            ArtifactSpecPin.id == pin_id, ArtifactSpecPin.artifact_id == artifact.id,
+            ArtifactSpecPin.version_id == latest.id,
+        )
+    )).scalar_one_or_none()
+
+
+@router.patch("/{id}/pins/{pin_id}")
+async def update_spec_pin(
+    id: uuid.UUID,
+    pin_id: uuid.UUID,
+    body: UpdateSpecPinRequest,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id or not project_id:
+        return _err("FORBIDDEN", "org_id/project_id required", 403)
+    artifact = await _get_artifact_or_404(session, org_id, project_id, id)
+    if artifact is None:
+        return _err("NOT_FOUND", "Artifact not found", 404)
+    pin = await _get_latest_spec_pin_or_404(session, artifact, pin_id)
+    if pin is None:
+        return _err("NOT_FOUND", "Spec pin not found on the artifact's latest version", 404)
+    pin.description = body.description
+    await session.flush()
+    return _ok(SpecPinResponse.model_validate(pin).model_dump(mode="json"))
+
+
+@router.delete("/{id}/pins/{pin_id}")
+async def delete_spec_pin(
+    id: uuid.UUID,
+    pin_id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id or not project_id:
+        return _err("FORBIDDEN", "org_id/project_id required", 403)
+    artifact = await _get_artifact_or_404(session, org_id, project_id, id)
+    if artifact is None:
+        return _err("NOT_FOUND", "Artifact not found", 404)
+    pin = await _get_latest_spec_pin_or_404(session, artifact, pin_id)
+    if pin is None:
+        return _err("NOT_FOUND", "Spec pin not found on the artifact's latest version", 404)
+    await session.delete(pin)
+    await session.flush()
+    return _ok({"ok": True, "id": str(pin_id)})
 
 
 # ─── Export (E-CANVAS C1-S5, story 1f365e33) ──────────────────────────────────
@@ -772,6 +901,29 @@ async def _apply_artifact_edit(
             type=data["type"], props=data["props"], parent_id=remapped_parent_id,
             sort_order=data["sort_order"], description=data["description"],
         ))
+
+    # 스펙 핀 carry-forward(story 7fe16274) — node와 동형 이유로 새 버전이 자기 소유 pin row
+    # 세트를 갖는다. coord 앵커는 그대로 계승·node 앵커는 id_remap으로 재해석(reflow-safe).
+    # 이번 edit에서 삭제된 노드를 가리키던 pin은 계승 안 함(no-fiction — 죽은 앵커를 이어가지
+    # 않음, 조용히 drop).
+    existing_pins = (await session.execute(
+        select(ArtifactSpecPin).where(ArtifactSpecPin.version_id == latest.id)
+    )).scalars().all()
+    for pin in existing_pins:
+        if pin.anchor_type == "node":
+            new_node_id = id_remap.get(pin.node_id)
+            if new_node_id is None:
+                continue
+            session.add(ArtifactSpecPin(
+                id=uuid.uuid4(), artifact_id=artifact.id, version_id=new_version.id,
+                anchor_type="node", node_id=new_node_id, description=pin.description,
+            ))
+        else:
+            session.add(ArtifactSpecPin(
+                id=uuid.uuid4(), artifact_id=artifact.id, version_id=new_version.id,
+                anchor_type="coord", anchor_x=pin.anchor_x, anchor_y=pin.anchor_y,
+                description=pin.description,
+            ))
 
     artifact.latest_version_number = new_version_number
     artifact.canvas_bounds = new_canvas_bounds

--- a/backend/app/schemas/visual_artifact.py
+++ b/backend/app/schemas/visual_artifact.py
@@ -156,6 +156,77 @@ class ArtifactCommentResponse(BaseModel):
     created_at: datetime
 
 
+_SPEC_PIN_ANCHOR_TYPES = ("coord", "node")
+
+
+class CreateSpecPinRequest(BaseModel):
+    """편집 캔버스 핀 저작(story 7fe16274) — anchor_type이 좌표/노드 중 무엇이든 description은
+    non-null 강제(doc §3 — 빈 스펙 커밋 차단)."""
+    anchor_type: str
+    anchor_x: float | None = None
+    anchor_y: float | None = None
+    node_id: uuid.UUID | None = None
+    description: str
+
+    @field_validator("anchor_type")
+    @classmethod
+    def _validate_anchor_type(cls, v: str) -> str:
+        if v not in _SPEC_PIN_ANCHOR_TYPES:
+            raise ValueError("anchor_type must be 'coord' or 'node'")
+        return v
+
+    @field_validator("description")
+    @classmethod
+    def _description_non_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("description must not be empty")
+        return v
+
+    @model_validator(mode="after")
+    def _validate_anchor_consistency(self) -> "CreateSpecPinRequest":
+        # DB CHECK(ck_artifact_spec_pins_anchor_consistency)와 동형 — API 레벨에서 먼저 422로 거름.
+        if self.anchor_type == "coord":
+            if self.anchor_x is None or self.anchor_y is None:
+                raise ValueError("coord anchor requires both anchor_x and anchor_y")
+            if self.node_id is not None:
+                raise ValueError("coord anchor must not set node_id")
+            if self.anchor_x < 0 or self.anchor_y < 0:
+                raise ValueError("anchor_x/anchor_y must be non-negative")
+        else:  # node
+            if self.node_id is None:
+                raise ValueError("node anchor requires node_id")
+            if self.anchor_x is not None or self.anchor_y is not None:
+                raise ValueError("node anchor must not set anchor_x/anchor_y")
+        return self
+
+
+class UpdateSpecPinRequest(BaseModel):
+    description: str
+
+    @field_validator("description")
+    @classmethod
+    def _description_non_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("description must not be empty")
+        return v
+
+
+class SpecPinResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    artifact_id: uuid.UUID
+    version_id: uuid.UUID
+    anchor_type: str
+    anchor_x: float | None = None
+    anchor_y: float | None = None
+    node_id: uuid.UUID | None = None
+    description: str
+    # ⛔감시금지(doc §4): created_by/created_at 미노출 — 모델 자체에 attribution 컬럼이 없음
+    # (ArtifactNode와 동형).
+
+
 class ExportUploadUrlRequest(BaseModel):
     content_type: str = "image/png"
 

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -71,6 +71,9 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     "sprintable_create_artifact", "sprintable_get_artifact", "sprintable_list_artifacts",
     "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
     "sprintable_edit_artifact", "sprintable_propose_canonical_version",
+    # 편집 캔버스 핀 저작(story 7fe16274) — 위 6개와 동형 cross-cutting(artifact 하위 자원).
+    "sprintable_list_spec_pins", "sprintable_create_spec_pin", "sprintable_update_spec_pin",
+    "sprintable_delete_spec_pin",
     # E-MCP-OPT(story ff6cb90d): list_projects/set_default_project — 키 자기 신원/스코프 조회·전환
     # 유틸(sprintable_my_dashboard·sprintable_ping과 동형: 특정 비즈니스 도메인 아닌 self-scope
     # 도구). set_default_project는 write지만 caller 자신의 기본 프로젝트 설정만 바꾸는 self-scope
@@ -300,6 +303,8 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_create_artifact", "sprintable_get_artifact", "sprintable_list_artifacts",
     "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
     "sprintable_edit_artifact", "sprintable_propose_canonical_version",
+    "sprintable_list_spec_pins", "sprintable_create_spec_pin", "sprintable_update_spec_pin",
+    "sprintable_delete_spec_pin",
     # projects (E-MCP-OPT story ff6cb90d)
     "sprintable_list_projects", "sprintable_set_default_project",
 )

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -30,10 +30,12 @@ from .toolset import is_tool_allowed
 from .tools.a2a import LinkGateToTaskInput, link_gate_to_task
 from .tools.evidence import AddEvidenceInput, add_evidence
 from .tools.visual_artifacts import (
-    AddArtifactCommentInput, CreateArtifactInput, EditArtifactInput, GetArtifactInput,
-    ListArtifactCommentsInput, ListArtifactsInput, ProposeCanonicalInput,
-    add_artifact_comment, create_artifact, edit_artifact, get_artifact, list_artifact_comments,
-    list_artifacts, propose_canonical_version,
+    AddArtifactCommentInput, CreateArtifactInput, CreateSpecPinInput, DeleteSpecPinInput,
+    EditArtifactInput, GetArtifactInput, ListArtifactCommentsInput, ListArtifactsInput,
+    ListSpecPinsInput, ProposeCanonicalInput, UpdateSpecPinInput,
+    add_artifact_comment, create_artifact, create_spec_pin, delete_spec_pin, edit_artifact,
+    get_artifact, list_artifact_comments, list_artifacts, list_spec_pins,
+    propose_canonical_version, update_spec_pin,
 )
 from .tools.agent_runs import (
     EmitEventInput, PollEventsInput, UpdateRunStatusInput,
@@ -505,7 +507,8 @@ _TOOL_DEFS: list[tuple] = [
      "done을 스스로 증명하는 자기 서명 첨부(PR·배포·지표·발행물 링크 등) — story/task에 evidence"
      " 남김. 선택제(첨부 안 해도 무불이익).",
      AddEvidenceInput, add_evidence),
-    # Visual artifacts (7) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안)
+    # Visual artifacts (11) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안) +
+    # 핀 저작(story 7fe16274)
     ("sprintable_create_artifact",
      "시각 산출물 생성(에이전트 생성 입구) — 트리(nodes[])로 구조화. 임포트된 raw HTML/이미지는"
      " type=\"html_blob\" 노드 하나로 감싸도 됨. canvas_bounds{w,h}(선택): 렌더 자기 프레임 크기"
@@ -531,6 +534,23 @@ _TOOL_DEFS: list[tuple] = [
      " 프레임 크기 재선언 — 미지정 시 직전 버전 값 유지·operations 비우고 이것만 보내도 유효"
      "(둘 다 비면 오류).",
      EditArtifactInput, edit_artifact),
+    ("sprintable_list_spec_pins",
+     "artifact 최신 버전의 스펙 핀 목록 조회(description pane 저작 대상 — 코멘트와 별개 레이어)."
+     " 작성자/시간 미노출(감시금지).",
+     ListSpecPinsInput, list_spec_pins),
+    ("sprintable_create_spec_pin",
+     "artifact에 스펙 핀 추가 — 요소/좌표에 description(핸드오프 스펙)을 앵커. anchor_type="
+     "\"coord\"면 anchor_x/anchor_y(canvas_bounds 좌표계, 0 이상) 둘 다 필수·node_id 금지."
+     " \"node\"면 node_id(get_artifact의 node.id) 필수·좌표 금지. description은 non-empty 강제"
+     "(빈 스펙 저장 불가). 핀은 최신 버전에 붙고 이후 edit_artifact마다 자동 계승(node 앵커는"
+     " 그 노드가 삭제되면 핀도 함께 소멸).",
+     CreateSpecPinInput, create_spec_pin),
+    ("sprintable_update_spec_pin",
+     "스펙 핀 description 재저작(덮어씀·스레드/이력 없음) — 최신 버전 소속 핀만 대상.",
+     UpdateSpecPinInput, update_spec_pin),
+    ("sprintable_delete_spec_pin",
+     "스펙 핀 삭제(최신 버전 소속만 대상).",
+     DeleteSpecPinInput, delete_spec_pin),
     ("sprintable_propose_canonical_version",
      "이 버전을 정본으로 제안(게이트 생성) — 제안만, 승인/반려는 항상 휴먼.",
      ProposeCanonicalInput, propose_canonical_version),

--- a/backend/sprintable_mcp/tools/visual_artifacts.py
+++ b/backend/sprintable_mcp/tools/visual_artifacts.py
@@ -80,6 +80,32 @@ class EditArtifactInput(SprintableInput):
     canvas_bounds: CanvasBoundsInput | None = None
 
 
+class ListSpecPinsInput(SprintableInput):
+    artifact_id: str
+
+
+class CreateSpecPinInput(SprintableInput):
+    """편집 캔버스 핀 저작(story 7fe16274) — description pane 저작 입구. 항상 artifact의
+    **최신 버전**에 붙는다(과거 버전 핀은 그때 스냅샷으로 불변)."""
+    artifact_id: str
+    anchor_type: str  # "coord"(좌표 — v1 기본) | "node"(구조화 노드 참조 — reflow-safe)
+    anchor_x: float | None = None  # anchor_type="coord" 필수(canvas_bounds 좌표계, 0 이상)
+    anchor_y: float | None = None  # anchor_type="coord" 필수
+    node_id: str | None = None  # anchor_type="node" 필수(get_artifact의 node.id·최신 버전 소속)
+    description: str  # non-empty 강제 — 빈 스펙 커밋 차단(핸드오프 계약 규율)
+
+
+class UpdateSpecPinInput(SprintableInput):
+    artifact_id: str
+    pin_id: str
+    description: str  # non-empty 강제
+
+
+class DeleteSpecPinInput(SprintableInput):
+    artifact_id: str
+    pin_id: str
+
+
 class ProposeCanonicalInput(SprintableInput):
     artifact_id: str
     version_number: int
@@ -200,6 +226,58 @@ async def edit_artifact(args: EditArtifactInput) -> list[TextContent]:
         if args.canvas_bounds:
             body["canvas_bounds"] = args.canvas_bounds.model_dump(exclude_none=True)
         result = await client.post(f"/api/v2/visual-artifacts/{args.artifact_id}/edit", json=body)
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def list_spec_pins(args: ListSpecPinsInput) -> list[TextContent]:
+    """artifact 최신 버전의 스펙 핀 목록 조회(description pane 저작 대상) — 코멘트와 달리
+    작성자/시간 속성 없음(감시금지)."""
+    try:
+        result = await client.get(f"/api/v2/visual-artifacts/{args.artifact_id}/pins")
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def create_spec_pin(args: CreateSpecPinInput) -> list[TextContent]:
+    """artifact에 스펙 핀 추가 — 요소/좌표에 description(핸드오프 스펙)을 앵커. `anchor_type`이
+    "coord"면 `anchor_x`/`anchor_y`(canvas_bounds 좌표계, 0 이상) 둘 다 필수·`node_id` 금지.
+    "node"면 `node_id`(get_artifact의 node.id) 필수·좌표 금지. `description`은 non-empty
+    강제(빈 스펙 저장 불가). 핀은 최신 버전에 붙고, 이후 편집(edit_artifact)마다 자동으로
+    새 버전에 계승된다(node 앵커는 그 노드가 살아있는 한 재해석·삭제되면 핀도 함께 소멸)."""
+    try:
+        body: dict = {"anchor_type": args.anchor_type, "description": args.description}
+        if args.anchor_x is not None:
+            body["anchor_x"] = args.anchor_x
+        if args.anchor_y is not None:
+            body["anchor_y"] = args.anchor_y
+        if args.node_id:
+            body["node_id"] = args.node_id
+        result = await client.post(f"/api/v2/visual-artifacts/{args.artifact_id}/pins", json=body)
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def update_spec_pin(args: UpdateSpecPinInput) -> list[TextContent]:
+    """스펙 핀의 description 재저작(팝오버 재개와 동형 — 덮어씀, 스레드/이력 없음). 최신 버전
+    소속 핀만 대상(과거 버전 핀은 불변 스냅샷이라 수정 불가 → 404)."""
+    try:
+        result = await client.patch(
+            f"/api/v2/visual-artifacts/{args.artifact_id}/pins/{args.pin_id}",
+            json={"description": args.description},
+        )
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def delete_spec_pin(args: DeleteSpecPinInput) -> list[TextContent]:
+    """스펙 핀 삭제(최신 버전 소속만 대상)."""
+    try:
+        result = await client.delete(f"/api/v2/visual-artifacts/{args.artifact_id}/pins/{args.pin_id}")
         return ok(result)
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/toolset.py
+++ b/backend/sprintable_mcp/toolset.py
@@ -60,6 +60,17 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # 조작이라 파괴적이지 않음(has_project_access로 대상 검증). 백엔드 SSOT와 동기화 필수
     # (app/services/mcp_toolset.py).
     "sprintable_list_projects", "sprintable_set_default_project",
+    # story 7fe16274 발견·즉시 수정: E-CANVAS visual_artifacts 그룹(C1-S3~C4-S8) 전체가 이
+    # vendored 사본의 _ALWAYS_ALLOWED에 처음부터 누락돼 있었다 — "artifact"/"pin"/"canvas"가
+    # 어떤 _GROUP_KEYWORDS와도 매칭 안 돼 tool_group()이 기본값 `_CORE`로 떨어지고, 명시 scope를
+    # 지정한 키(예: scope=['docs'])는 "core"를 별도로 안 넣는 한 이 도구들을 전혀 못 쓰는 상태였다
+    # (백엔드 SSOT app/services/mcp_toolset.py는 처음부터 always-allow였음 — 드리프트). 백엔드
+    # SSOT와 동기화(7개 기존 + 4개 신규 핀 도구).
+    "sprintable_create_artifact", "sprintable_get_artifact", "sprintable_list_artifacts",
+    "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
+    "sprintable_edit_artifact", "sprintable_propose_canonical_version",
+    "sprintable_list_spec_pins", "sprintable_create_spec_pin", "sprintable_update_spec_pin",
+    "sprintable_delete_spec_pin",
 })
 
 _LEGACY_SCOPES: frozenset[str] = frozenset({"read", "write"})

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -86,10 +86,13 @@ EXPECTED_TOOLS = {
     "sprintable_link_gate_to_task",
     # evidence (1) — E-VERIFY V0-S1
     "sprintable_add_evidence",
-    # visual artifacts (7) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안)
+    # visual artifacts (11) — E-CANVAS C1-S3 + C2-S6(코멘트) + C3-S7(편집) + C4-S8(정본 제안) +
+    # 핀 저작(story 7fe16274)
     "sprintable_create_artifact", "sprintable_get_artifact", "sprintable_list_artifacts",
     "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
     "sprintable_edit_artifact", "sprintable_propose_canonical_version",
+    "sprintable_list_spec_pins", "sprintable_create_spec_pin", "sprintable_update_spec_pin",
+    "sprintable_delete_spec_pin",
     # smoke
     "ping",
 }
@@ -98,7 +101,8 @@ EXPECTED_TOOLS = {
 def test_total_tool_count():
     # C1-S3(e50563b4): sprintable_list_artifacts 추가로 98→99... +1=100.
     # E-MCP-OPT(story ff6cb90d): list_projects/set_default_project 2종 추가 — 100→102.
-    assert len(_TOOLS) == 102
+    # 편집 캔버스 핀 저작(story 7fe16274): spec pin 4종 추가 — 102→106.
+    assert len(_TOOLS) == 106
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_authz_project_scope_coverage.py
+++ b/backend/tests/test_authz_project_scope_coverage.py
@@ -216,6 +216,11 @@ _ID_MUTATION_FALSE_POSITIVE_ALLOWLIST: dict[str, str] = {
     "app.routers.mockups:update_mockup": "동일 JWT project_id 스코프",
     "app.routers.mockups:update_scenario": "동일 JWT project_id 스코프",
     "app.routers.visual_artifacts:delete_artifact": "JWT project_id 스코프+creator gate",
+    "app.routers.visual_artifacts:update_spec_pin": (
+        "JWT project_id 스코프로 artifact(_get_artifact_or_404) 선조회 후 pin_id를 그 artifact.id로"
+        " 재스코프(_get_latest_spec_pin_or_404) — delete_artifact와 동일 non-spoofable 패턴"
+    ),
+    "app.routers.visual_artifacts:delete_spec_pin": "동일 JWT project_id 스코프+artifact-scoped pin_id 재스코프",
     # caller-self / participant / recipient / creator — SELF_DERIVED
     "app.routers.conversations:set_conversation_mute": "participant-membership gate(caller 참가 대화만)",
     "app.routers.conversations:update_conversation": "participant-membership gate",

--- a/backend/tests/test_e_canvas_7fe16274_spec_pin_realdb.py
+++ b/backend/tests/test_e_canvas_7fe16274_spec_pin_realdb.py
@@ -1,0 +1,552 @@
+"""편집 캔버스 핀 저작(story 7fe16274·doc artifact-pin-authoring-spec §2): ArtifactSpecPin 실증.
+그라운딩(디디, 재사용 대신 신설): 버전 스코프(carry-forward 필요)·스레드/resolve 없음·명시
+anchor_type 판별자가 ArtifactComment와 근본적으로 달라 별도 엔티티로 분리했다. crux: coord/node
+앵커 양쪽 수용·description non-null 강제·edit마다 carry-forward(node 삭제 시 pin도 소멸)·
+cross-artifact node 위조 차단·과거 버전 pin 불변(최신 버전만 수정/삭제 가능)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id}
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, org_id, project_id, user_id=None):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id or uuid.uuid4()), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_create_coord_pin_and_list():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Pinned"})
+            artifact_id = create_resp.json()["data"]["id"]
+
+            pin_resp = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/pins",
+                json={"anchor_type": "coord", "anchor_x": 10.5, "anchor_y": 20.0, "description": "브랜드 프라이머리"},
+            )
+            assert pin_resp.status_code == 201, pin_resp.text
+            body = pin_resp.json()["data"]
+            assert body["anchor_type"] == "coord"
+            assert body["anchor_x"] == 10.5 and body["anchor_y"] == 20.0
+            assert body["node_id"] is None
+            assert body["description"] == "브랜드 프라이머리"
+            assert "created_by" not in body and "created_at" not in body  # 감시금지 — attribution 미노출
+
+            list_resp = await client.get(f"/api/v2/visual-artifacts/{artifact_id}/pins")
+            assert list_resp.status_code == 200
+            assert len(list_resp.json()["data"]) == 1
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_node_pin_valid_target():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Node Pinned", "nodes": [{"type": "text", "props": {"content": "hello"}}]},
+            )
+            artifact_id = create_resp.json()["data"]["id"]
+            node_id = create_resp.json()["data"]["nodes"][0]["id"]
+
+            pin_resp = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/pins",
+                json={"anchor_type": "node", "node_id": node_id, "description": "이 텍스트는 높이 52px"},
+            )
+            assert pin_resp.status_code == 201, pin_resp.text
+            body = pin_resp.json()["data"]
+            assert body["anchor_type"] == "node"
+            assert body["node_id"] == node_id
+            assert body["anchor_x"] is None and body["anchor_y"] is None
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_node_pin_cross_artifact_forgery_blocked():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            other_resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Other", "nodes": [{"type": "text", "props": {}}]},
+            )
+            other_node_id = other_resp.json()["data"]["nodes"][0]["id"]
+
+            target_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target"})
+            target_id = target_resp.json()["data"]["id"]
+
+            pin_resp = await client.post(
+                f"/api/v2/visual-artifacts/{target_id}/pins",
+                json={"anchor_type": "node", "node_id": other_node_id, "description": "위조 시도"},
+            )
+            assert pin_resp.status_code == 404, pin_resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("body", [
+    {"anchor_type": "coord", "anchor_x": 10.0, "description": "y 없음"},
+    {"anchor_type": "coord", "anchor_x": -1.0, "anchor_y": 5.0, "description": "음수 좌표"},
+    {"anchor_type": "coord", "anchor_x": 5.0, "anchor_y": 5.0, "node_id": str(uuid.uuid4()), "description": "coord인데 node_id"},
+    {"anchor_type": "node", "description": "node_id 없음"},
+    {"anchor_type": "node", "node_id": str(uuid.uuid4()), "anchor_x": 1.0, "description": "node인데 좌표"},
+    {"anchor_type": "invalid", "anchor_x": 1.0, "anchor_y": 1.0, "description": "잘못된 타입"},
+])
+async def test_create_pin_malformed_anchor_422(body):
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Malformed"})
+            artifact_id = create_resp.json()["data"]["id"]
+
+            resp = await client.post(f"/api/v2/visual-artifacts/{artifact_id}/pins", json=body)
+            assert resp.status_code == 422, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_pin_empty_description_422():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Empty Desc"})
+            artifact_id = create_resp.json()["data"]["id"]
+
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/pins",
+                json={"anchor_type": "coord", "anchor_x": 1.0, "anchor_y": 1.0, "description": "   "},
+            )
+            assert resp.status_code == 422, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_pin_description():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Editable"})
+            artifact_id = create_resp.json()["data"]["id"]
+            pin_resp = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/pins",
+                json={"anchor_type": "coord", "anchor_x": 1.0, "anchor_y": 1.0, "description": "초안"},
+            )
+            pin_id = pin_resp.json()["data"]["id"]
+
+            update_resp = await client.patch(
+                f"/api/v2/visual-artifacts/{artifact_id}/pins/{pin_id}", json={"description": "확定 스펙"},
+            )
+            assert update_resp.status_code == 200, update_resp.text
+            assert update_resp.json()["data"]["description"] == "확定 스펙"
+
+            update_empty_resp = await client.patch(
+                f"/api/v2/visual-artifacts/{artifact_id}/pins/{pin_id}", json={"description": ""},
+            )
+            assert update_empty_resp.status_code == 422
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_delete_pin():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Deletable"})
+            artifact_id = create_resp.json()["data"]["id"]
+            pin_resp = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/pins",
+                json={"anchor_type": "coord", "anchor_x": 1.0, "anchor_y": 1.0, "description": "삭제 대상"},
+            )
+            pin_id = pin_resp.json()["data"]["id"]
+
+            del_resp = await client.delete(f"/api/v2/visual-artifacts/{artifact_id}/pins/{pin_id}")
+            assert del_resp.status_code == 200, del_resp.text
+
+            list_resp = await client.get(f"/api/v2/visual-artifacts/{artifact_id}/pins")
+            assert list_resp.json()["data"] == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_edit_artifact_carries_coord_pin_forward():
+    """무-mutate 버전 원칙: 편집(노드 추가)이 기존 coord 핀을 새 버전에 그대로 계승한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Carry"})
+            artifact_id = create_resp.json()["data"]["id"]
+            await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/pins",
+                json={"anchor_type": "coord", "anchor_x": 42.0, "anchor_y": 7.0, "description": "고정 스펙"},
+            )
+
+            edit_resp = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/edit",
+                json={"operations": [{"op": "add", "type": "text", "props": {}}]},
+            )
+            assert edit_resp.status_code == 201, edit_resp.text
+            assert edit_resp.json()["data"]["version_number"] == 2
+
+            list_resp = await client.get(f"/api/v2/visual-artifacts/{artifact_id}/pins")
+            pins = list_resp.json()["data"]
+            assert len(pins) == 1
+            assert pins[0]["anchor_x"] == 42.0 and pins[0]["description"] == "고정 스펙"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_edit_artifact_carries_node_pin_forward_with_remapped_id():
+    """reflow-safe 실증: node 앵커 핀이 edit 후 id_remap된 새 node_id로 재해석된다(구 node_id
+    아님 — ArtifactNode.id는 테이블 전역 PK라 매 버전 새 row)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "Reflow", "nodes": [{"type": "text", "props": {"content": "keep"}}]},
+            )
+            artifact_id = create_resp.json()["data"]["id"]
+            old_node_id = create_resp.json()["data"]["nodes"][0]["id"]
+
+            await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/pins",
+                json={"anchor_type": "node", "node_id": old_node_id, "description": "노드 스펙"},
+            )
+
+            edit_resp = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/edit",
+                json={"operations": [{"op": "add", "type": "button", "props": {}}]},
+            )
+            assert edit_resp.status_code == 201, edit_resp.text
+            new_nodes = edit_resp.json()["data"]["nodes"]
+            new_text_node_id = next(n["id"] for n in new_nodes if n["type"] == "text")
+            assert new_text_node_id != old_node_id  # id_remap — 새 PK
+
+            list_resp = await client.get(f"/api/v2/visual-artifacts/{artifact_id}/pins")
+            pins = list_resp.json()["data"]
+            assert len(pins) == 1
+            assert pins[0]["node_id"] == new_text_node_id
+            assert pins[0]["description"] == "노드 스펙"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_edit_artifact_deleting_anchor_node_drops_the_pin():
+    """no-fiction: 앵커 노드가 삭제되면 핀은 계승 안 되고 조용히 소멸(죽은 앵커 방치 금지)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post(
+                "/api/v2/visual-artifacts",
+                json={"title": "DropOnDelete", "nodes": [{"type": "text", "props": {}}]},
+            )
+            artifact_id = create_resp.json()["data"]["id"]
+            node_id = create_resp.json()["data"]["nodes"][0]["id"]
+
+            await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/pins",
+                json={"anchor_type": "node", "node_id": node_id, "description": "곧 사라질 핀"},
+            )
+
+            edit_resp = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/edit",
+                json={"operations": [{"op": "delete", "id": node_id}]},
+            )
+            assert edit_resp.status_code == 201, edit_resp.text
+
+            list_resp = await client.get(f"/api/v2/visual-artifacts/{artifact_id}/pins")
+            assert list_resp.json()["data"] == []
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_previous_version_pin_immutable_and_not_editable():
+    """무-mutate: 구버전 핀 row는 그대로 남되(과거 스냅샷), 최신 버전 스코프 밖이라 update/delete
+    대상은 아니다(404) — canvas_bounds/node와 동일한 버전 스냅샷 원칙."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Snapshot"})
+            artifact_id = create_resp.json()["data"]["id"]
+            pin_resp = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/pins",
+                json={"anchor_type": "coord", "anchor_x": 1.0, "anchor_y": 1.0, "description": "v1 핀"},
+            )
+            old_pin_id = pin_resp.json()["data"]["id"]
+
+            await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/edit",
+                json={"operations": [{"op": "add", "type": "text", "props": {}}]},
+            )
+
+            # 구버전 pin_id(v1의 row)로 update 시도 — 최신 버전(v2)엔 다른 새 id의 계승 row가 있음.
+            update_resp = await client.patch(
+                f"/api/v2/visual-artifacts/{artifact_id}/pins/{old_pin_id}", json={"description": "수정 시도"},
+            )
+            assert update_resp.status_code == 404, update_resp.text
+
+            list_resp = await client.get(f"/api/v2/visual-artifacts/{artifact_id}/pins")
+            pins = list_resp.json()["data"]
+            assert len(pins) == 1
+            assert pins[0]["id"] != old_pin_id
+            assert pins[0]["description"] == "v1 핀"  # 계승된 내용은 동일
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mcp_create_and_list_spec_pin_roundtrip():
+    """AC4 동형: MCP sprintable_create_spec_pin → sprintable_list_spec_pins 왕복."""
+    import json
+    import os as _os
+
+    import httpx
+
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["org_id"], seeded["project_id"])
+
+        _os.environ.setdefault("SPRINTABLE_API_URL", "http://test")
+        _os.environ.setdefault("AGENT_API_KEY", "sk_test")
+
+        from sprintable_mcp import api_client as api_client_mod
+        from sprintable_mcp.tools.visual_artifacts import (
+            CreateArtifactInput, CreateSpecPinInput, ListSpecPinsInput,
+            create_artifact, create_spec_pin, list_spec_pins,
+        )
+
+        transport = httpx.ASGITransport(app=app)
+        real_client = api_client_mod.client
+        test_http_client = httpx.AsyncClient(transport=transport, base_url="http://test")
+
+        async def _post(path, **kwargs):
+            r = await test_http_client.post(path, **kwargs)
+            r.raise_for_status()
+            return r.json()["data"]
+
+        async def _get(path, **kwargs):
+            r = await test_http_client.get(path, **kwargs)
+            r.raise_for_status()
+            return r.json()["data"]
+
+        orig_post, orig_get = real_client.post, real_client.get
+        real_client.post = _post
+        real_client.get = _get
+        try:
+            created = json.loads((await create_artifact(CreateArtifactInput(title="MCP Pinned")))[0].text)
+
+            pin_created = json.loads((await create_spec_pin(CreateSpecPinInput(
+                artifact_id=created["id"], anchor_type="coord", anchor_x=3.0, anchor_y=4.0,
+                description="MCP 저작 스펙",
+            )))[0].text)
+            assert pin_created["description"] == "MCP 저작 스펙"
+
+            pins = json.loads((await list_spec_pins(ListSpecPinsInput(artifact_id=created["id"])))[0].text)
+            assert len(pins) == 1
+            assert pins[0]["id"] == pin_created["id"]
+        finally:
+            real_client.post, real_client.get = orig_post, orig_get
+            await test_http_client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- story `7fe16274`(편집 캔버스 핀 저작) BE 조각 — 스펙 SSOT `artifact-pin-authoring-spec` §2.
- **그라운딩 결론(기존 `ArtifactComment` 앵커 재사용 vs 신설 — 위임된 판단): 신설(`ArtifactSpecPin`)**. 같은 캔버스 핀 레이어를 FE에서 공유하지만(§4 시각/페이로드 구분) BE 생명주기가 근본적으로 다름:
  - **버전 스코프**(`canvas_bounds`·`artifact_nodes`와 동형) — 코멘트는 artifact 레벨 영속이라 carry-forward가 없어 `node_id`가 edit 후 stale해지는 기존 quirk가 있지만, 스펙 핀은 그 버전 레이아웃의 스냅샷이라 매 edit마다 함께 carry-forward한다(`_apply_artifact_edit` 확장 — node 앵커는 기존 `id_remap`으로 새 버전 노드에 재해석·reflow-safe. 앵커 노드가 삭제되면 핀도 함께 소멸, no-fiction).
  - **스레드/resolve 없음**(단일값 description, 재편집=덮어씀) — 코멘트의 토론형 모델과 달라 같은 테이블에 넣으면 무의미한 컬럼(parent_id/resolved 등)이 방치됨.
  - **anchor_type 명시 판별자 + DB CHECK** — 코멘트의 암묵적 nullable 타이핑(node_id 있으면 노드, 없으면 좌표)과 달리 anchor 오타입 no-op 함정을 스키마 레벨에서 차단.
  - **감시금지**(doc §4) — created_by/created_at 등 attribution 컬럼 자체가 없음(`ArtifactNode`와 동형·API 응답에도 미노출).
- REST: `POST/GET/PATCH/DELETE /api/v2/visual-artifacts/{id}/pins` — 항상 artifact의 **latest version** 대상(과거 버전 핀은 불변 스냅샷·수정/삭제 시 404). `description` non-null 강제, coord(`anchor_x`+`anchor_y`)/node(`node_id`) 앵커 상호배타 검증(422), cross-artifact node 위조 차단(기존 `source_comment_id` 패턴 동형).
- MCP: `sprintable_list_spec_pins`/`sprintable_create_spec_pin`/`sprintable_update_spec_pin`/`sprintable_delete_spec_pin` 4종.
- Migration `0180`: 신규 테이블 `artifact_spec_pins`(additive).
- **부수 발견·즉시 수정**: `sprintable_mcp/toolset.py`(독립 패키지 vendored 사본)에 visual_artifacts 그룹 전체(기존 7개 + 신규 4개)가 애초부터 `_ALWAYS_ALLOWED`에 누락돼 있었음 — "artifact"/"pin" 키워드가 `_GROUP_KEYWORDS` 어디에도 안 걸려 `tool_group()`이 기본 `_CORE`로 떨어지고, explicit scope를 지정한 키(예: `scope=['docs']`)는 이 도구들을 전혀 못 쓰는 드리프트였음. 백엔드 SSOT(`app/services/mcp_toolset.py`)와 동기화.

## Test plan
- [x] realdb 신규 17건(`tests/test_e_canvas_7fe16274_spec_pin_realdb.py`): coord/node 앵커 생성, cross-artifact node 위조 차단, malformed anchor 6종 422, 빈 description 422, description 재저작, 삭제, edit 시 coord/node 핀 carry-forward(node는 id_remap 재해석 실증), 앵커 노드 삭제 시 핀 소멸, 구버전 핀 불변(update 404), MCP create→list 왕복.
- [x] 기존 visual_artifacts 스위트(32건: C1-S3 6 + C3-S7 9 + canvas_bounds 12 + SEC-S8-Q 5) 무회귀.
- [x] toolset 스위트(21건: `test_toolset_catalog.py` + `test_e_mcp_s2_toolset.py`) 무회귀 — `_ALWAYS_ALLOWED` 확장 후에도 전부 pass.
- [x] `python3 -m py_compile` 전 수정 파일.

🤖 Generated with [Claude Code](https://claude.com/claude-code)