### PR TITLE
[SEC][HIGH] story b4027b2e: visual-artifacts REST/MCP canvas toolgroup 신설

### DIFF
--- a/backend/alembic/versions/0181_role_templates_canvas_group.py
+++ b/backend/alembic/versions/0181_role_templates_canvas_group.py
@@ -1,0 +1,47 @@
+"""story b4027b2e(SEC) 후속 데이터 정합 — backend/frontend role_templates.default_tool_groups에
+"canvas" 추가.
+
+Revision ID: 0181
+Revises: 0180
+Create Date: 2026-07-13
+
+이 스토리가 visual_artifacts REST/MCP를 cross-cutting always-allow에서 전용 "canvas" toolgroup으로
+재분류한다(app/services/mcp_toolset.py). `default_tool_groups`는 API key scope로 그대로 흘러가
+(role_template.py 주석 확인) 채용 시점에 구워진다 — "canvas"는 이 그룹 신설 전 seed(0156)라 어떤
+role_template에도 있을 수 없었고, backend/frontend 역할로 채용된 에이전트가 canvas 그룹-스코프
+키를 쓴다면 이 리클래스로 artifact/pin MCP 도구·REST 접근이 즉시 회귀한다(그라운딩에서 라이브
+키 분포는 ADC 재인증 함정으로 실측 불가 — 코드상 default_tool_groups→scope 직결 경로가 확인된
+가장 구체적인 실 사용처라 선제 반영). backend(E-CANVAS BE 저작 전담)·frontend(뷰어 구현·QA
+dogfooding) 두 역할만 추가 — qa/pm은 이 스토리 스코프 밖(필요 시 별건).
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0181"
+down_revision = "0180"
+branch_labels = None
+depends_on = None
+
+_ROLES = ("backend", "frontend")
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE role_templates "
+            "SET default_tool_groups = array_append(default_tool_groups, 'canvas') "
+            "WHERE slug = ANY(:roles) AND NOT ('canvas' = ANY(default_tool_groups))"
+        ).bindparams(sa.bindparam("roles", value=list(_ROLES), type_=sa.ARRAY(sa.Text)))
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE role_templates "
+            "SET default_tool_groups = array_remove(default_tool_groups, 'canvas') "
+            "WHERE slug = ANY(:roles)"
+        ).bindparams(sa.bindparam("roles", value=list(_ROLES), type_=sa.ARRAY(sa.Text)))
+    )

--- a/backend/app/routers/visual_artifacts.py
+++ b/backend/app/routers/visual_artifacts.py
@@ -7,7 +7,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.asset import Asset
 from app.models.visual_artifact import (
@@ -88,6 +88,7 @@ async def create_artifact(
     body: CreateArtifactRequest,
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
+    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
     org_id, project_id = _get_org_project(auth)
     if not org_id:
@@ -270,6 +271,7 @@ async def delete_artifact(
     id: uuid.UUID,
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
+    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
     """생성자만 삭제 가능(Evidence 패턴 계승 — "누가 주어인가"). soft delete."""
     org_id, project_id = _get_org_project(auth)
@@ -318,6 +320,7 @@ async def add_artifact_comment(
     body: CreateArtifactCommentRequest,
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
+    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
     org_id, project_id = _get_org_project(auth)
     if not org_id or not project_id:
@@ -378,6 +381,7 @@ async def resolve_artifact_comment(
     comment_id: uuid.UUID,
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
+    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
     org_id, project_id = _get_org_project(auth)
     if not org_id or not project_id:
@@ -437,6 +441,7 @@ async def create_spec_pin(
     body: CreateSpecPinRequest,
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
+    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
     org_id, project_id = _get_org_project(auth)
     if not org_id or not project_id:
@@ -491,6 +496,7 @@ async def update_spec_pin(
     body: UpdateSpecPinRequest,
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
+    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
     org_id, project_id = _get_org_project(auth)
     if not org_id or not project_id:
@@ -512,6 +518,7 @@ async def delete_spec_pin(
     pin_id: uuid.UUID,
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
+    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
     org_id, project_id = _get_org_project(auth)
     if not org_id or not project_id:
@@ -615,6 +622,7 @@ async def create_export_upload_url(
     body: ExportUploadUrlRequest,
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
+    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
     from datetime import datetime, timedelta, timezone
 
@@ -650,6 +658,7 @@ async def complete_png_export(
     body: CompleteExportRequest,
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
+    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
     from app.services.storage import get_storage_provider
 
@@ -706,6 +715,7 @@ async def create_html_export(
     version_number: int,
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
+    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
     """self-contained HTML export — 렌더 불요(nodes 트리를 BE가 직렬화), client-trust 이슈 없어
     즉시 put_object(유나 UX②: as-authored — 별도 재테마 없이 저장된 props 그대로 직렬화)."""
@@ -955,6 +965,7 @@ async def edit_artifact(
     body: EditArtifactRequest,
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
+    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
     """딸깍 편집(FE) + MCP 편집(에이전트) 공용 엔드포인트 — 요소 add/update/delete를 적용해
     새 버전을 만든다(무-mutate 버전 원칙 계승)."""
@@ -1009,6 +1020,7 @@ async def propose_canonical_version(
     version_number: int,
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
+    _write_scope_check: uuid.UUID = Depends(get_verified_org_id),
 ) -> JSONResponse:
     """정본으로 제안 — AI는 제안만(MCP도 동일 엔드포인트), 승인은 always-HITL(gate_service).
     이미 pending 제안이 있으면 멱등(create_gate 자체 멱등 재사용)."""

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 # ── toolset 그룹 키워드(tool 이름 부분일치, 위에서부터 우선) ──────────────────────
 # 그룹: stories/tasks/sprints/epics/chat/docs/analytics/retro/standup/meetings/
-#       notifications/webhooks/rewards/audit/agent_runs/admin/core
+#       notifications/webhooks/rewards/audit/agent_runs/canvas/admin/core
 _GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
     ("rewards", ("reward", "wallet", "leaderboard")),
     ("analytics", ("velocity", "health", "dashboard", "overview", "stats", "standup_missing",
@@ -31,6 +31,10 @@ _GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
     ("epics", ("epic",)),
     ("tasks", ("task",)),
     ("stories", ("story", "stories", "backlog", "claim", "checkin")),
+    # story b4027b2e: E-CANVAS visual_artifacts가 임계(11개 도구·전용 REST 도메인)에 도달해
+    # cross-cutting always-allow에서 전용 그룹으로 승격(C1-S3 당시 예고된 신설). "canonical_version"
+    # (propose_canonical_version은 "artifact" substring이 없음)·"spec_pin"(핀 4종)까지 포괄.
+    ("canvas", ("artifact", "canonical_version", "spec_pin")),
     ("admin", ("give_reward", "emit_event", "trigger_ai", "activate_sprint",
                "close_sprint", "create_sprint", "upsert_webhook", "delete_webhook")),
 ]
@@ -63,17 +67,14 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # 동형(자기 작업에 self-proof 첨부 = 데이터 파괴 아닌 협업/증명 유틸) — 어떤 역할의 working
     # agent든 default_tool_groups 무관하게 done 첨부해야 하므로 always-allow.
     "sprintable_add_evidence",
-    # E-CANVAS C1-S3(story 8bace49e): create_artifact/get_artifact — story/epic/doc 中 어디에도
-    # (또는 아무데도) 붙을 수 있는 시각 산출물 생성/조회. add_evidence와 동형(단일 도메인 그룹에
-    # 묶기 애매한 cross-cutting 자기생성 유틸). C2-S6(코멘트 2종)+C3-S7(edit 1종)+C4-S8(정본
-    # 제안 1종) 추가 — 6개(전신 C0~C5 트랙의 마지막 BE 배선). 여전히 story/epic/doc 무관
-    # cross-cutting이라 always-allow 유지(추가 성장 시 전용 "canvas" 그룹 신설 고려).
-    "sprintable_create_artifact", "sprintable_get_artifact", "sprintable_list_artifacts",
-    "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
-    "sprintable_edit_artifact", "sprintable_propose_canonical_version",
-    # 편집 캔버스 핀 저작(story 7fe16274) — 위 6개와 동형 cross-cutting(artifact 하위 자원).
-    "sprintable_list_spec_pins", "sprintable_create_spec_pin", "sprintable_update_spec_pin",
-    "sprintable_delete_spec_pin",
+    # story b4027b2e(SEC — 까심 #2140 QA④): E-CANVAS visual_artifacts 11종(원 6개 + 7fe16274
+    # 핀 4종 + list_spec_pins)을 여기서 제거하고 전용 "canvas" 그룹(_GROUP_KEYWORDS)으로 이관했다.
+    # 이전엔 cross-cutting always-allow였는데(C1-S3 당시 "추가 성장 시 전용 canvas 그룹 신설
+    # 고려" 예고), REST 쪽 `/api/v2/visual-artifacts`가 `_PATH_GROUP_PREFIXES` 미등록 + 라우터가
+    # scope 체크 의존성 자체를 안 씀 → toolgroup-제한(예 scope=['docs']) 키가 REST로 artifact
+    # mutation을 무제한 통과(까심 라이브 실증: POST→201). REST를 조이면서 MCP 쪽을 always-allow로
+    # 남기면 "도구는 보이는데 호출은 403"이 되므로 양쪽을 canvas 그룹으로 동시 이관(레거시
+    # read/write scope 키는 설계상 전 그룹 허용이라 무회귀).
     # E-MCP-OPT(story ff6cb90d): list_projects/set_default_project — 키 자기 신원/스코프 조회·전환
     # 유틸(sprintable_my_dashboard·sprintable_ping과 동형: 특정 비즈니스 도메인 아닌 self-scope
     # 도구). set_default_project는 write지만 caller 자신의 기본 프로젝트 설정만 바꾸는 self-scope
@@ -209,6 +210,11 @@ _PATH_GROUP_PREFIXES: tuple[tuple[str, str], ...] = (
     ("/api/v2/docs", "docs"),
     ("/api/v2/agent-runs", "agent_runs"),
     ("/api/v2/analytics", "analytics"),
+    # story b4027b2e(SEC): 미등록 시 permissive-unmapped 폴백으로 toolgroup-제한 키가 전부 통과
+    # (까심 라이브 실증). ⚠️ 등록만으론 불충분 — app/routers/visual_artifacts.py 라우터가
+    # `get_verified_org_id`(이 체크를 트리거하는 의존성)를 안 쓰면 이 매핑 자체가 무효라 라우터
+    # 쪽 의존성 배선도 함께 필요(이 변경과 짝).
+    ("/api/v2/visual-artifacts", "canvas"),
 )
 
 
@@ -299,7 +305,7 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_link_gate_to_task",
     # evidence (E-VERIFY V0-S1)
     "sprintable_add_evidence",
-    # visual artifacts (E-CANVAS C1-S3 + C2-S6 코멘트 + C3-S7 편집 + C4-S8 정본 제안)
+    # visual artifacts (E-CANVAS C1-S3 + C2-S6 코멘트 + C3-S7 편집 + C4-S8 정본 제안 + 핀 저작 story 7fe16274)
     "sprintable_create_artifact", "sprintable_get_artifact", "sprintable_list_artifacts",
     "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
     "sprintable_edit_artifact", "sprintable_propose_canonical_version",
@@ -312,7 +318,7 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
 # picker 표시 순서(비파괴 먼저). order 필드 힌트 + 배열 순서 둘 다 이 순서.
 _CATALOG_DISPLAY_ORDER: tuple[str, ...] = (
     "stories", "tasks", "sprints", "epics", "hypotheses", "chat", "docs", "analytics", "retro",
-    "standup", "meetings", "notifications", "webhooks", "rewards", "audit", "agent_runs",
+    "standup", "meetings", "notifications", "webhooks", "rewards", "audit", "agent_runs", "canvas",
 )
 
 

--- a/backend/sprintable_mcp/toolset.py
+++ b/backend/sprintable_mcp/toolset.py
@@ -28,6 +28,10 @@ _GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
     ("epics", ("epic",)),
     ("tasks", ("task",)),
     ("stories", ("story", "stories", "backlog", "claim", "checkin")),
+    # story b4027b2e(SEC): 백엔드 SSOT와 동기화 — E-CANVAS visual_artifacts가 전용 그룹으로 승격
+    # (app/services/mcp_toolset.py 참고. "canonical_version"은 propose_canonical_version에
+    # "artifact" substring이 없어 별도 키워드 필요, "spec_pin"은 핀 4종).
+    ("canvas", ("artifact", "canonical_version", "spec_pin")),
     ("admin", ("give_reward", "emit_event", "trigger_ai", "activate_sprint",
                "close_sprint", "delete_sprint", "create_sprint", "upsert_webhook", "delete_webhook")),
 ]
@@ -60,17 +64,9 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # 조작이라 파괴적이지 않음(has_project_access로 대상 검증). 백엔드 SSOT와 동기화 필수
     # (app/services/mcp_toolset.py).
     "sprintable_list_projects", "sprintable_set_default_project",
-    # story 7fe16274 발견·즉시 수정: E-CANVAS visual_artifacts 그룹(C1-S3~C4-S8) 전체가 이
-    # vendored 사본의 _ALWAYS_ALLOWED에 처음부터 누락돼 있었다 — "artifact"/"pin"/"canvas"가
-    # 어떤 _GROUP_KEYWORDS와도 매칭 안 돼 tool_group()이 기본값 `_CORE`로 떨어지고, 명시 scope를
-    # 지정한 키(예: scope=['docs'])는 "core"를 별도로 안 넣는 한 이 도구들을 전혀 못 쓰는 상태였다
-    # (백엔드 SSOT app/services/mcp_toolset.py는 처음부터 always-allow였음 — 드리프트). 백엔드
-    # SSOT와 동기화(7개 기존 + 4개 신규 핀 도구).
-    "sprintable_create_artifact", "sprintable_get_artifact", "sprintable_list_artifacts",
-    "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
-    "sprintable_edit_artifact", "sprintable_propose_canonical_version",
-    "sprintable_list_spec_pins", "sprintable_create_spec_pin", "sprintable_update_spec_pin",
-    "sprintable_delete_spec_pin",
+    # story b4027b2e(SEC): story 7fe16274가 여기 심었던 visual_artifacts 11종 always-allow는
+    # 이 스토리에서 "canvas" 전용 그룹(_GROUP_KEYWORDS)으로 대체(상위 mcp_toolset.py 커밋 참고) —
+    # always-allow에 남기면 REST 쪽 canvas 그룹 신설과 불일치(도구는 보이는데 REST는 403).
 })
 
 _LEGACY_SCOPES: frozenset[str] = frozenset({"read", "write"})

--- a/backend/tests/test_b4027b2e_visual_artifacts_scope_group_realdb.py
+++ b/backend/tests/test_b4027b2e_visual_artifacts_scope_group_realdb.py
@@ -1,0 +1,524 @@
+"""[SEC][HIGH] story b4027b2e(까심 #2140 QA④ 적출) — 실 PG.
+
+`/api/v2/visual-artifacts` write 라우트가 `_PATH_GROUP_PREFIXES` 미등록(permissive-unmapped
+폴백) **+ 라우터 자체가 `get_verified_org_id`(scope 체크 트리거)를 안 씀** 이중 갭으로, toolgroup
+제한(예 scope=['docs']) API 키가 mutation을 무제한 통과했다(까심 라이브 실증: docs키 POST→201,
+d764522c와 동형 계보). 이번 수정: `visual_artifacts.py`의 write 12라우트(원 9 + rebase 후 합류한
+핀 3종)에 `get_verified_org_id` 의존성 배선 + `_PATH_GROUP_PREFIXES`에 "canvas" 그룹 등록 + MCP
+쪽도 `_ALWAYS_ALLOWED`에서 "canvas" 그룹으로 재분류(양쪽 정합).
+
+각 라우트: toolgroup-scope(scope=['docs'], canvas 없음)=403 · canvas-scope(scope=['canvas'])=
+성공(over-block 방지) · 레거시(scope=['read','write'])=성공(무회귀) · JWT(human)=성공(무회귀,
+기존 스위트가 이미 커버하지만 이 파일에서도 1건 명시)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="Project")
+    session.add(project)
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id}
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app_api_key(app, Session, org_id, project_id, *, scope: list[str]):
+    """API-key AuthContext — api_key_id 마커가 있어야 _check_api_key_scope가 게이트를 적용."""
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(uuid.uuid4()), email=None,
+            claims={"app_metadata": {
+                "org_id": str(org_id), "project_id": str(project_id),
+                "api_key_id": str(uuid.uuid4()), "scope": scope,
+            }},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+async def _setup_app_jwt(app, Session, org_id, project_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(uuid.uuid4()), email="human@test",
+            claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ── create_artifact(POST) ───────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_artifact_toolgroup_scope_without_canvas_403():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_api_key(app, Session, seeded["org_id"], seeded["project_id"], scope=["docs"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/visual-artifacts", json={"title": "Sabotage"})
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_artifact_canvas_scope_201_no_overblock():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_api_key(app, Session, seeded["org_id"], seeded["project_id"], scope=["canvas"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/visual-artifacts", json={"title": "Legit"})
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_artifact_legacy_write_scope_201_no_regression():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_api_key(app, Session, seeded["org_id"], seeded["project_id"], scope=["read", "write"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/visual-artifacts", json={"title": "Legacy"})
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_artifact_jwt_human_201_no_regression():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_jwt(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/visual-artifacts", json={"title": "Human"})
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── edit_artifact(POST) ─────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_edit_artifact_toolgroup_scope_without_canvas_403():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_jwt(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target"})
+            artifact_id = create_resp.json()["data"]["id"]
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+
+        await _setup_app_api_key(app, Session, seeded["org_id"], seeded["project_id"], scope=["docs"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/edit",
+                json={"operations": [{"op": "add", "type": "text", "props": {}}]},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_edit_artifact_canvas_scope_201_no_overblock():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_jwt(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target"})
+            artifact_id = create_resp.json()["data"]["id"]
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+
+        await _setup_app_api_key(app, Session, seeded["org_id"], seeded["project_id"], scope=["canvas"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/edit",
+                json={"operations": [{"op": "add", "type": "text", "props": {}}]},
+            )
+            assert resp.status_code == 201, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── delete_artifact(DELETE) ─────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_delete_artifact_toolgroup_scope_without_canvas_403():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_jwt(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target"})
+            artifact_id = create_resp.json()["data"]["id"]
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+
+        await _setup_app_api_key(app, Session, seeded["org_id"], seeded["project_id"], scope=["docs"])
+        client = _client_for(app)
+        try:
+            resp = await client.delete(f"/api/v2/visual-artifacts/{artifact_id}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── add_artifact_comment(POST) ──────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_add_comment_toolgroup_scope_without_canvas_403():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_jwt(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target"})
+            artifact_id = create_resp.json()["data"]["id"]
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+
+        await _setup_app_api_key(app, Session, seeded["org_id"], seeded["project_id"], scope=["docs"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/comments", json={"content": "sabotage"},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── propose_canonical_version(POST) ─────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_propose_canonical_toolgroup_scope_without_canvas_403():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_jwt(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target"})
+            artifact_id = create_resp.json()["data"]["id"]
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+
+        await _setup_app_api_key(app, Session, seeded["org_id"], seeded["project_id"], scope=["docs"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(f"/api/v2/visual-artifacts/{artifact_id}/versions/1/canonicalize")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── read 라우트는 여전히 미가드(scope 무관 200) — 회귀축 명시(read는 이 스토리 스코프 밖) ──
+
+@pytest.mark.anyio
+async def test_get_artifact_read_route_unaffected_by_scope():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_jwt(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Readable"})
+            artifact_id = create_resp.json()["data"]["id"]
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+
+        await _setup_app_api_key(app, Session, seeded["org_id"], seeded["project_id"], scope=["docs"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/visual-artifacts/{artifact_id}")
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ── spec pin write 라우트(story 7fe16274·rebase 후 합류) — 동일 gap 대상 ────────
+
+@pytest.mark.anyio
+async def test_create_spec_pin_toolgroup_scope_without_canvas_403():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_jwt(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target"})
+            artifact_id = create_resp.json()["data"]["id"]
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+
+        await _setup_app_api_key(app, Session, seeded["org_id"], seeded["project_id"], scope=["docs"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/pins",
+                json={"anchor_type": "coord", "anchor_x": 1.0, "anchor_y": 1.0, "description": "sabotage"},
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_spec_pin_canvas_scope_201_no_overblock():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_jwt(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target"})
+            artifact_id = create_resp.json()["data"]["id"]
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+
+        await _setup_app_api_key(app, Session, seeded["org_id"], seeded["project_id"], scope=["canvas"])
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/pins",
+                json={"anchor_type": "coord", "anchor_x": 1.0, "anchor_y": 1.0, "description": "legit"},
+            )
+            assert resp.status_code == 201, resp.text
+            pin_id = resp.json()["data"]["id"]
+        finally:
+            await client.aclose()
+
+        # update/delete도 동일 canvas-scope로 성공(over-block 방지).
+        client = _client_for(app)
+        try:
+            upd = await client.patch(
+                f"/api/v2/visual-artifacts/{artifact_id}/pins/{pin_id}", json={"description": "edited"},
+            )
+            assert upd.status_code == 200, upd.text
+            deleted = await client.delete(f"/api/v2/visual-artifacts/{artifact_id}/pins/{pin_id}")
+            assert deleted.status_code == 200, deleted.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_delete_spec_pin_toolgroup_scope_without_canvas_403():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app_jwt(app, Session, seeded["org_id"], seeded["project_id"])
+        client = _client_for(app)
+        try:
+            create_resp = await client.post("/api/v2/visual-artifacts", json={"title": "Target"})
+            artifact_id = create_resp.json()["data"]["id"]
+            pin_resp = await client.post(
+                f"/api/v2/visual-artifacts/{artifact_id}/pins",
+                json={"anchor_type": "coord", "anchor_x": 1.0, "anchor_y": 1.0, "description": "existing"},
+            )
+            pin_id = pin_resp.json()["data"]["id"]
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+
+        await _setup_app_api_key(app, Session, seeded["org_id"], seeded["project_id"], scope=["docs"])
+        client = _client_for(app)
+        try:
+            upd = await client.patch(
+                f"/api/v2/visual-artifacts/{artifact_id}/pins/{pin_id}", json={"description": "sabotage"},
+            )
+            assert upd.status_code == 403, upd.text
+            deleted = await client.delete(f"/api/v2/visual-artifacts/{artifact_id}/pins/{pin_id}")
+            assert deleted.status_code == 403, deleted.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_recruit_s1_role_templates.py
+++ b/backend/tests/test_e_recruit_s1_role_templates.py
@@ -124,7 +124,8 @@ async def test_get_role_template_by_slug_includes_behaviors_realdb():
             out = await get_role_template("backend", session=s)
         assert out.slug == "backend"
         assert "sprintable_" in out.role_behaviors
-        assert out.default_tool_groups == ["stories", "tasks", "epics", "chat", "docs"]
+        # story b4027b2e(SEC): canvas 그룹 신설 후 backend 역할에 추가(0180) — E-CANVAS BE 저작 전담.
+        assert out.default_tool_groups == ["stories", "tasks", "epics", "chat", "docs", "canvas"]
         assert out.is_builtin is True
     finally:
         await eng.dispose()

--- a/backend/tests/test_toolset_catalog.py
+++ b/backend/tests/test_toolset_catalog.py
@@ -30,8 +30,8 @@ def test_catalog_structure_and_contract_fields():
     cat = build_toolset_catalog()
     assert set(cat.keys()) == {"groups"}
     groups = cat["groups"]
-    # core + 16 비파괴 + admin = 18 (E1-S5 hypotheses 그룹 추가)
-    assert len(groups) == 18
+    # core + 17 비파괴(story b4027b2e: canvas 그룹 추가) + admin = 19
+    assert len(groups) == 19
     for g in groups:
         assert set(g.keys()) == _CONTRACT_FIELDS, f"{g['key']} 필드 계약 불일치"
         assert isinstance(g["key"], str) and g["key"]
@@ -39,8 +39,8 @@ def test_catalog_structure_and_contract_fields():
         assert isinstance(g["is_core"], bool) and isinstance(g["is_destructive"], bool)
         assert isinstance(g["order"], int)
         assert g["tools"], f"{g['key']} 빈 그룹 — 모든 그룹은 멤버 보유"
-    # order = 배열 순서와 일치(0..17 단조)
-    assert [g["order"] for g in groups] == list(range(18))
+    # order = 배열 순서와 일치(0..18 단조)
+    assert [g["order"] for g in groups] == list(range(19))
 
 
 def test_core_first_admin_last_flags():


### PR DESCRIPTION
## Summary
까심 #2140 QA④ 적출(SEC): `/api/v2/visual-artifacts`가 `_PATH_GROUP_PREFIXES`에 미등록 → permissive-unmapped 폴백으로 toolgroup-제한(예 `scope=['docs']`) API 키가 mutation을 무제한 통과(라이브 실증: docs키 `POST→201`). story `d764522c`(#2121/#2125)와 동형 계보(REST판).

**그라운딩에서 PO 킥보다 한 겹 더 깊은 근본 발견**: `_PATH_GROUP_PREFIXES` 등록만으론 불충분 — `visual_artifacts.py`의 write 라우트 전체가 `_check_api_key_scope`를 트리거하는 `get_verified_org_id` 의존성 자체를 안 써서(`Depends(get_current_user)`만 사용), 체크 함수가 애초에 호출조차 안 됐음(`docs.py`/`stories.py`는 이미 이 의존성을 병행 사용 중). 두 겹을 동시에 닫아야 실제로 막힘.

## Changes
- **write 9라우트**(`create_artifact`·`delete_artifact`·`edit_artifact`·`add_artifact_comment`·`resolve_artifact_comment`·export 3종·`propose_canonical_version`)에 `get_verified_org_id` 의존성 배선 — 기존 `_get_org_project`가 도출한 org/project 값은 그대로 사용(순수 scope-체크 트리거 목적, 헤더 미사용 공통 경로에선 신규 DB 조회 없음, docs.py/stories.py와 동일 패턴).
- `_PATH_GROUP_PREFIXES`에 `/api/v2/visual-artifacts` → **"canvas"** 그룹 등록.
- **MCP 레이어 정합**: visual_artifacts 11종(create/get/list_artifacts·comments 2종·edit·propose_canonical + 핀 4종)을 기존 `_ALWAYS_ALLOWED`(cross-cutting, C1-S3 당시 "성장 시 전용 그룹 신설 고려" 예고 — 이제 임계 도달 판단)에서 "canvas" 그룹으로 재분류. REST만 조이고 MCP를 always-allow로 남기면 "도구는 보이는데 호출하면 403"이라는 불일치가 생기므로 양쪽 동시 처리. 백엔드 SSOT(`app/services/mcp_toolset.py`) + vendored 사본(`sprintable_mcp/toolset.py`) 동기화, toolset-catalog picker에도 반영.
- **데이터 정합(migration 0180)**: `role_templates`의 `backend`/`frontend` `default_tool_groups`에 "canvas" 추가 — 이 그룹이 신설 전(0156 seed 당시)이라 어떤 role_template에도 있을 수 없었고, `default_tool_groups`는 API key scope로 그대로 흘러가므로(코드 확인) 이 두 역할(E-CANVAS BE 저작 전담·FE 구현/QA dogfooding)로 채용된 에이전트가 canvas 그룹-스코프 키를 쓴다면 이 리클래스로 즉시 회귀했을 것 — 선제 반영. qa/pm은 스코프 밖(필요 시 별건).

## Risk assessment (그라운딩①)
레거시 `read`/`write` scope 키는 설계상 전 그룹 허용(코드 명시 보장 — `resolve_policy`의 "일반키 무회귀" 주석) → **무회귀**. JWT(human) 경로는 `_check_api_key_scope`가 애초 미적용 → **무회귀**. 영향은 실제 toolgroup-제한 키에만 국한.

실제 발급된 키들의 scope 분포를 dev Cloud SQL에서 라이브 확인하려 했으나 `cloud-sql-proxy`가 **ADC reauth 함정**(`invalid_rapt`)으로 막힘 — 오르테가 쪽 시도도 동형 실패 + project-scoped API로는 org 전체 분포 조회 불가. 선생님께 비차단 ADC 재인증 요청해뒀음(병합 게이트 전 되면 재확인, 안 되면 이 PR의 코드 근거로 갈음 — PO 승인 완료).

## Test plan
- [x] realdb 신규 10건(`tests/test_b4027b2e_visual_artifacts_scope_group_realdb.py`): toolgroup-scope(`docs`, canvas 없음) 403 · canvas-scope 성공(over-block 방지) · 레거시 `read+write` 성공(무회귀) · JWT human 성공(무회귀) · read 라우트는 scope 무관 200(이 스토리 스코프 밖 명시).
- [x] 인접 스위트 156건 무회귀: `test_toolset_catalog.py`(하드코딩 카운트 3건 canvas 반영 갱신) · `test_e_mcp_s2_toolset.py` · `mcp/test_contract.py` · `test_authz_project_scope_coverage.py` · `test_d764522c_apikey_writescope_realdb.py`(선례 회귀 가드) · `test_e_recruit_s1_role_templates.py`(backend 역할 `default_tool_groups` 갱신 반영) · `test_role_template_catalog_s1_schema.py` · `test_role_templates_marketing_roster.py` · 기존 visual_artifacts 스위트 전체(C1-S3·C3-S7·canvas_bounds·SEC-S8-Q/G).
- [x] migration 0180 upgrade/downgrade 양방향 실 PG 검증(role_templates 값 확인).
- [x] `python3 -m py_compile` 전 수정 파일.

🤖 Generated with [Claude Code](https://claude.com/claude-code)