### PR TITLE
[SID:74d6047e] 모바일 터치 — 2-finger 핀치 줌 + 더블탭 fit/100% 토글

### DIFF
--- a/apps/web/src/components/canvas/artifact-stage.test.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.test.tsx
@@ -254,4 +254,203 @@ describe('ArtifactStage — 캔버스 뷰포트(story 1948d19d)', () => {
       expect(readTransform(content).scale).toBeCloseTo(0.5, 5);
     });
   });
+
+  describe('모바일 터치(story 74d6047e) — 2-finger 핀치 줌·더블탭 fit/100% 토글, 데스크톱 회귀 0', () => {
+    let rectSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+        x: 0, y: 0, left: 0, top: 0, right: 640, bottom: 480, width: 640, height: 480, toJSON() { return {}; },
+      } as DOMRect);
+    });
+    afterEach(() => { rectSpy.mockRestore(); });
+
+    function touchDown(el: EventTarget, pointerId: number, clientX: number, clientY: number) {
+      press(el, 'pointerdown', { pointerId, pointerType: 'touch', clientX, clientY, button: 0 });
+    }
+    function touchMove(el: EventTarget, pointerId: number, clientX: number, clientY: number) {
+      press(el, 'pointermove', { pointerId, pointerType: 'touch', clientX, clientY });
+    }
+    function touchUp(el: EventTarget, pointerId: number, clientX: number, clientY: number) {
+      press(el, 'pointerup', { pointerId, pointerType: 'touch', clientX, clientY });
+    }
+
+    it('two fingers moving apart (distance ratio) zoom in, anchored at the pinch midpoint', async () => {
+      await mount();
+      const viewport = container.querySelector('[data-artifact-canvas-viewport]') as HTMLDivElement;
+      const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+      const before = readTransform(content);
+
+      await act(async () => {
+        touchDown(viewport, 1, 100, 100);
+        touchDown(viewport, 2, 200, 100); // baseline distance = 100
+      });
+      await act(async () => {
+        touchMove(viewport, 1, 50, 100);
+        touchMove(viewport, 2, 250, 100); // distance = 200 → 2x baseline
+      });
+
+      const after = readTransform(content);
+      expect(after.scale).toBeCloseTo(before.scale * 2, 3);
+    });
+
+    it('pinch midpoint moving (without changing distance) pans simultaneously (Figma 표준 — 핀치+pan 동시)', async () => {
+      await mount();
+      const viewport = container.querySelector('[data-artifact-canvas-viewport]') as HTMLDivElement;
+      const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+
+      await act(async () => {
+        touchDown(viewport, 1, 100, 100);
+        touchDown(viewport, 2, 200, 100); // baseline midpoint = (150,100)
+      });
+      const afterBaseline = readTransform(content);
+
+      await act(async () => {
+        // same distance(100), midpoint shifted +50 in x
+        touchMove(viewport, 1, 150, 100);
+        touchMove(viewport, 2, 250, 100); // new midpoint = (200,100)
+      });
+      const after = readTransform(content);
+
+      expect(after.scale).toBeCloseTo(afterBaseline.scale, 5); // distance unchanged → no zoom
+      expect(after.tx).toBeCloseTo(afterBaseline.tx + 50, 3); // midpoint moved +50 → pan +50
+    });
+
+    it('crux — capturing a 2nd finger mid-drag re-baselines instead of jumping (1→2 전이)', async () => {
+      await mount();
+      const viewport = container.querySelector('[data-artifact-canvas-viewport]') as HTMLDivElement;
+      const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+      const before = readTransform(content);
+
+      await act(async () => {
+        touchDown(viewport, 1, 100, 100);
+        touchMove(viewport, 1, 130, 100); // 1-finger pan by +30 (past 4px threshold)
+      });
+      const afterOneFingerPan = readTransform(content);
+      expect(afterOneFingerPan.tx).toBeCloseTo(before.tx + 30, 3);
+
+      // 2nd finger touches down at the SAME position as finger 1 currently is + a fixed offset —
+      // baseline should capture from THIS moment, not jump based on finger 1's original down position.
+      await act(async () => { touchDown(viewport, 2, 230, 100); });
+      const afterSecondDown = readTransform(content);
+      expect(afterSecondDown).toEqual(afterOneFingerPan); // pointerdown alone never mutates transform
+
+      await act(async () => {
+        touchMove(viewport, 1, 130, 100); // no movement from baseline
+        touchMove(viewport, 2, 230, 100); // no movement from baseline
+      });
+      const afterNoMovePinch = readTransform(content);
+      expect(afterNoMovePinch).toEqual(afterSecondDown); // zero delta from a fresh baseline = zero change (no jump)
+    });
+
+    it('crux — lifting one finger mid-pinch re-baselines pan for the remaining finger (2→1 전이, no jump)', async () => {
+      await mount();
+      const viewport = container.querySelector('[data-artifact-canvas-viewport]') as HTMLDivElement;
+      const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+
+      await act(async () => {
+        touchDown(viewport, 1, 100, 100);
+        touchDown(viewport, 2, 300, 100); // baseline distance = 200
+      });
+      await act(async () => {
+        touchMove(viewport, 1, 150, 100);
+        touchMove(viewport, 2, 350, 100); // distance still 200 (both shifted +50) → pan only, no zoom
+      });
+      const afterPinchPan = readTransform(content);
+
+      await act(async () => { touchUp(viewport, 1, 150, 100); }); // lift finger 1, finger 2 (at 350,100) remains
+      await act(async () => { touchMove(viewport, 2, 350, 100); }); // no movement yet from the fresh baseline
+      expect(readTransform(content)).toEqual(afterPinchPan); // no jump immediately after the finger-count transition
+
+      await act(async () => { touchMove(viewport, 2, 380, 100); }); // now drag the remaining finger +30
+      const afterResumedPan = readTransform(content);
+      expect(afterResumedPan.tx).toBeCloseTo(afterPinchPan.tx + 30, 3);
+      expect(afterResumedPan.scale).toBeCloseTo(afterPinchPan.scale, 5); // single remaining finger never zooms
+    });
+
+    it('clamps pinch zoom to the same 10%~400% range as desktop', async () => {
+      await mount();
+      const viewport = container.querySelector('[data-artifact-canvas-viewport]') as HTMLDivElement;
+      const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+
+      await act(async () => {
+        touchDown(viewport, 1, 300, 100);
+        touchDown(viewport, 2, 320, 100); // baseline distance = 20 (tiny)
+      });
+      await act(async () => {
+        touchMove(viewport, 1, 0, 100);
+        touchMove(viewport, 2, 640, 100); // distance = 640 → 32x baseline, way past 400%
+      });
+      expect(readTransform(content).scale).toBeLessThanOrEqual(4);
+    });
+
+    it('a single tap (no follow-up within the window) does not toggle zoom', async () => {
+      const nowSpy = vi.spyOn(performance, 'now').mockReturnValue(1000);
+      await mount();
+      const viewport = container.querySelector('[data-artifact-canvas-viewport]') as HTMLDivElement;
+      const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+      const before = readTransform(content);
+
+      await act(async () => {
+        touchDown(viewport, 1, 100, 100);
+        touchUp(viewport, 1, 100, 100);
+      });
+      expect(readTransform(content)).toEqual(before);
+      nowSpy.mockRestore();
+    });
+
+    it('double-tap within the time/distance window toggles zoom, centered on the tap point', async () => {
+      const nowSpy = vi.spyOn(performance, 'now');
+      await mount();
+      const viewport = container.querySelector('[data-artifact-canvas-viewport]') as HTMLDivElement;
+      const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+      const before = readTransform(content);
+
+      nowSpy.mockReturnValue(1000);
+      await act(async () => { touchDown(viewport, 1, 100, 100); touchUp(viewport, 1, 100, 100); }); // 1st tap
+      nowSpy.mockReturnValue(1150); // within DOUBLE_TAP_MS(300) window
+      await act(async () => { touchDown(viewport, 1, 105, 102); touchUp(viewport, 1, 105, 102); }); // 2nd tap, close position
+
+      const after = readTransform(content);
+      expect(after.scale).not.toBeCloseTo(before.scale, 3); // toggled to the other target scale
+      nowSpy.mockRestore();
+    });
+
+    it('two taps outside the time window are treated as two independent single taps (no toggle)', async () => {
+      const nowSpy = vi.spyOn(performance, 'now');
+      await mount();
+      const viewport = container.querySelector('[data-artifact-canvas-viewport]') as HTMLDivElement;
+      const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+      const before = readTransform(content);
+
+      nowSpy.mockReturnValue(1000);
+      await act(async () => { touchDown(viewport, 1, 100, 100); touchUp(viewport, 1, 100, 100); });
+      nowSpy.mockReturnValue(2000); // 1000ms later, past the 300ms window
+      await act(async () => { touchDown(viewport, 1, 100, 100); touchUp(viewport, 1, 100, 100); });
+
+      expect(readTransform(content)).toEqual(before);
+      nowSpy.mockRestore();
+    });
+
+    it('mouse pointer events are entirely unaffected by the touch branch (pointerType gate — 데스크톱 회귀 0)', async () => {
+      await mount();
+      const viewport = container.querySelector('[data-artifact-canvas-viewport]') as HTMLDivElement;
+      const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+      const before = readTransform(content);
+
+      // a 2nd "pointer" with pointerType='mouse' must never be treated as a pinch partner.
+      await act(async () => { press(viewport, 'pointerdown', { pointerId: 1, pointerType: 'mouse', clientX: 100, clientY: 100, button: 0 }); });
+      await act(async () => { press(viewport, 'pointermove', { pointerId: 1, pointerType: 'mouse', clientX: 160, clientY: 130 }); });
+      const after = readTransform(content);
+      expect(after.tx).toBe(before.tx + 60);
+      expect(after.ty).toBe(before.ty + 30);
+      expect(after.scale).toBe(before.scale); // pan only, never zoom — single mouse pointer isn't a pinch
+    });
+
+    it('keeps touch-action:none (touch-none) on the viewport — 네이티브 핀치줌/스크롤 위임 없음, 우리 transform이 유일 소비자', async () => {
+      await mount();
+      const viewport = container.querySelector('[data-artifact-canvas-viewport]') as HTMLDivElement;
+      expect(viewport.className).toContain('touch-none');
+    });
+  });
 });

--- a/apps/web/src/components/canvas/artifact-stage.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.tsx
@@ -20,6 +20,13 @@ import type { ArtifactFormat } from '@/services/canvas';
  *   `pointer-events:auto`로 상호작용 가능 — 이동-임계값(4px) 초과 드래그 중엔 오버레이도
  *   pointer-events:none으로 전환해 "핀 위에서 시작한 드래그가 pan으로 해석"을 순수 CSS로
  *   구현한다(핀 자체의 onClick은 무변경 — 임계 미달=일반 클릭이 그대로 발화).
+ *
+ * story 74d6047e — 모바일 터치(2-finger 핀치 줌·더블탭 fit/100% 토글) 추가. 1-finger는 이미
+ * 제네릭 Pointer Events pan 경로가 그대로 작동해 신규 로직 불필요(선생님 실사용 지적으로
+ * 발견된 갭은 핀치뿐). `touch-none`(touch-action:none)은 그대로 유지 — 우리 transform이
+ * 유일 소비자라 브라우저 네이티브 핀치줌/스크롤로의 위임이 애초에 없다(휠 배타성 #2138과
+ * 동일 원칙이지만, wheel의 React onWheel passive 문제와 달리 touch-action:none은 CSS
+ * 네이티브 옵트아웃이라 preventDefault 트릭이 따로 필요 없다).
  */
 
 // 문서형 기본 아트보드 — canvas_bounds 미선언 폴백(§4, 가짜 추정 아님·명시된 규약). export —
@@ -31,6 +38,8 @@ const MAX_SCALE = 4;
 const DRAG_THRESHOLD_PX = 4;
 const PAN_MARGIN_PX = 120; // soft bound — 콘텐츠가 이 여백 밖으로 완전히 사라지진 않게
 const WHEEL_ZOOM_SENSITIVITY = 0.0015;
+const DOUBLE_TAP_MS = 300; // story 74d6047e §4 — 더블탭 판정 시간 창(지도/사진 앱 관례)
+const DOUBLE_TAP_PX = 40; // 손가락은 마우스만큼 정밀하지 않아 클릭보다 넓은 허용 반경
 
 function clamp(v: number, min: number, max: number) {
   return Math.min(max, Math.max(min, v));
@@ -119,6 +128,11 @@ function CanvasViewport({ format, content, title, canvasBounds, overlay, mode = 
   const [imageBounds, setImageBounds] = useState<{ w: number; h: number } | null>(null);
   const dragRef = useRef({ startX: 0, startY: 0, startTx: 0, startTy: 0, movedPast: false, pointerId: -1 });
   const firedFitRef = useRef(false);
+  // story 74d6047e — 2-finger 핀치 줌. 활성 터치 포인터 위치 추적 + 핀치 baseline(포인터 수가
+  // 바뀔 때마다 재캡처 — crux: delta는 항상 "이 순간"의 baseline 대비라 점프가 없다).
+  const touchPointersRef = useRef(new Map<number, { x: number; y: number }>());
+  const pinchBaselineRef = useRef<{ distance: number; midX: number; midY: number; scale: number; tx: number; ty: number } | null>(null);
+  const lastTapRef = useRef<{ time: number; x: number; y: number } | null>(null);
 
   // image=실측 우선(로드 후 자연 크기가 선언보다 정확) → 그 다음 선언된 canvas_bounds(§4,
   // BE #2135) → 마지막 포맷별 기본 아트보드(가짜 추정 아님·명시된 폴백 규약).
@@ -167,6 +181,23 @@ function CanvasViewport({ format, content, title, canvasBounds, overlay, mode = 
     setTransform({ tx, ty, scale: 1 });
   }, [viewportSize, bounds.w, bounds.h]);
 
+  // story 74d6047e §4 — 더블탭=fit↔100% 토글(탭 지점 중심, 지도/사진 앱 관례). ⌘/Ctrl+휠 커서중심
+  // 줌과 동일한 수학(고정 화면점 아래 콘텐츠점을 유지) — 목표 scale만 연속값 대신 두 값 중 토글.
+  const toggleZoomAtPoint = useCallback((screenX: number, screenY: number) => {
+    const rect = viewportRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const localX = screenX - rect.left;
+    const localY = screenY - rect.top;
+    const fitScale = clamp(Math.min(viewportSize.w / bounds.w, viewportSize.h / bounds.h), MIN_SCALE, MAX_SCALE);
+    setTransform((cur) => {
+      const nextScale = Math.abs(cur.scale - 1) < 0.02 ? fitScale : 1;
+      const contentX = (localX - cur.tx) / cur.scale;
+      const contentY = (localY - cur.ty) / cur.scale;
+      const next = clampPan(localX - contentX * nextScale, localY - contentY * nextScale, nextScale, viewportSize.w, viewportSize.h);
+      return { ...next, scale: nextScale };
+    });
+  }, [viewportSize, bounds.w, bounds.h, clampPan]);
+
   // 최초 진입 = fit(콘텐츠 전체가 즉시 보이는 것이 재설계의 근본 목적 — "잘림 상태 부존재").
   useEffect(() => {
     if (firedFitRef.current) return;
@@ -177,6 +208,27 @@ function CanvasViewport({ format, content, title, canvasBounds, overlay, mode = 
   }, [viewportSize.w, viewportSize.h]);
 
   function handlePointerDown(e: React.PointerEvent) {
+    // story 74d6047e — 1-finger는 이미 pointer 이벤트 제네릭 pan 경로가 그대로 작동한다(터치
+    // 전용 신규 로직 불필요, 아래 공유 코드로 진행). 2-finger째만 핀치로 분기.
+    if (e.pointerType === 'touch') {
+      touchPointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      if (touchPointersRef.current.size === 2) {
+        const el = e.currentTarget as HTMLElement;
+        if (typeof el.setPointerCapture === 'function') el.setPointerCapture(e.pointerId);
+        // crux — 포인터 수 1→2 전이 시 baseline 재캡처(delta는 항상 이 순간 기준) — 점프 방지.
+        // midpoint는 viewport-local로 변환(transform.tx/ty와 같은 좌표계라야 아래 공식이 맞다 —
+        // touchPointersRef 자체는 dragRef와 동형으로 raw client 유지, 여기서만 rect 보정).
+        const rect = el.getBoundingClientRect();
+        const [p1, p2] = [...touchPointersRef.current.values()];
+        pinchBaselineRef.current = {
+          distance: Math.hypot(p2.x - p1.x, p2.y - p1.y),
+          midX: (p1.x + p2.x) / 2 - rect.left, midY: (p1.y + p2.y) / 2 - rect.top,
+          scale: transform.scale, tx: transform.tx, ty: transform.ty,
+        };
+        dragRef.current.pointerId = -1; // 1-터치 pan 경로 무력화 — 핀치와 동시 구동 방지
+        return;
+      }
+    }
     if (e.button !== 0) return;
     dragRef.current = { startX: e.clientX, startY: e.clientY, startTx: transform.tx, startTy: transform.ty, movedPast: false, pointerId: e.pointerId };
     const el = e.currentTarget as HTMLElement;
@@ -186,6 +238,28 @@ function CanvasViewport({ format, content, title, canvasBounds, overlay, mode = 
   }
 
   function handlePointerMove(e: React.PointerEvent) {
+    if (e.pointerType === 'touch' && touchPointersRef.current.has(e.pointerId)) {
+      touchPointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+      if (touchPointersRef.current.size === 2 && pinchBaselineRef.current) {
+        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+        const [p1, p2] = [...touchPointersRef.current.values()];
+        const baseline = pinchBaselineRef.current;
+        const newDistance = Math.hypot(p2.x - p1.x, p2.y - p1.y); // rect-invariant(차분이라 보정 불필요)
+        const newMidX = (p1.x + p2.x) / 2 - rect.left; // baseline과 동일 좌표계(viewport-local)로 변환
+        const newMidY = (p1.y + p2.y) / 2 - rect.top;
+        // 거리비=scale(baseline 대비) — 클램프는 데스크톱과 동일 10~400%.
+        const nextScale = clamp(baseline.scale * (newDistance / baseline.distance), MIN_SCALE, MAX_SCALE);
+        // baseline midpoint 아래 있던 콘텐츠 점을 구해, 그 점이 "지금" midpoint(이동했을 수 있음)
+        // 아래 있도록 재배치 — 줌(거리비)과 pan(midpoint 이동)이 한 수식으로 동시에 풀린다.
+        const contentX = (baseline.midX - baseline.tx) / baseline.scale;
+        const contentY = (baseline.midY - baseline.ty) / baseline.scale;
+        const next = clampPan(newMidX - contentX * nextScale, newMidY - contentY * nextScale, nextScale, viewportSize.w, viewportSize.h);
+        setIsDragging(true); // 핀치 중엔 오버레이(핀 등) pointer-events:none — 기존 드래그 규약 재사용
+        setTransform({ ...next, scale: nextScale });
+        return;
+      }
+      // 1터치째는 여기서 return하지 않고 아래 공유 pan 로직으로 그대로 진행(신규 로직 0).
+    }
     const d = dragRef.current;
     if (d.pointerId !== e.pointerId) return;
     const dx = e.clientX - d.startX;
@@ -201,6 +275,46 @@ function CanvasViewport({ format, content, title, canvasBounds, overlay, mode = 
   }
 
   function handlePointerUp(e: React.PointerEvent) {
+    if (e.pointerType === 'touch') {
+      const wasPinching = touchPointersRef.current.size === 2;
+      const liftedPos = touchPointersRef.current.get(e.pointerId);
+      touchPointersRef.current.delete(e.pointerId);
+      const el = e.currentTarget as HTMLElement;
+      if (typeof el.releasePointerCapture === 'function') el.releasePointerCapture(e.pointerId);
+      const remaining = [...touchPointersRef.current.entries()];
+
+      if (wasPinching && remaining.length === 1) {
+        // crux — 2→1 전이 시 남은 손가락 기준 pan baseline 재캡처(delta 0부터) — 점프 방지.
+        const [remainingId, remainingPos] = remaining[0]!;
+        dragRef.current = {
+          startX: remainingPos.x, startY: remainingPos.y, startTx: transform.tx, startTy: transform.ty,
+          movedPast: true, pointerId: remainingId,
+        };
+        pinchBaselineRef.current = null;
+        return;
+      }
+      if (remaining.length === 0) {
+        pinchBaselineRef.current = null;
+        // 더블탭 판정 — 핀치의 일부였던 리프트(wasPinching)는 탭이 아니다. 순수 탭(이동<임계값)만.
+        const d = dragRef.current;
+        const wasTap = !wasPinching && d.pointerId === e.pointerId && !d.movedPast;
+        if (wasTap && liftedPos) {
+          const now = performance.now();
+          const last = lastTapRef.current;
+          const isDoubleTap = !!last && now - last.time < DOUBLE_TAP_MS
+            && Math.hypot(liftedPos.x - last.x, liftedPos.y - last.y) < DOUBLE_TAP_PX;
+          if (isDoubleTap) {
+            lastTapRef.current = null;
+            toggleZoomAtPoint(liftedPos.x, liftedPos.y);
+          } else {
+            lastTapRef.current = { time: now, x: liftedPos.x, y: liftedPos.y };
+          }
+        }
+        dragRef.current.pointerId = -1;
+        setIsDragging(false);
+      }
+      return;
+    }
     const d = dragRef.current;
     if (d.pointerId !== e.pointerId) return;
     const el = e.currentTarget as HTMLElement;


### PR DESCRIPTION
## story
`74d6047e` — 선생님 모바일 실사용 지적("모바일에서 줌인 줌아웃 어떻게 하는지? 아예 안 되는 거 아닌지 의심"). 코드 실측 확定: 캔버스 뷰포트가 줌을 wheel 이벤트로만 처리해 모바일 핀치 줌 핸들러가 전무했음(1-finger pan은 이미 제네릭 Pointer Events라 정상 작동 — 갭은 순수하게 핀치뿐).

## 구현
- **핀치 줌**: 두 터치 거리비=scale · 핀치 중점(baseline 기준 viewport-local 변환)=줌 센터 · 중점 이동=동시 pan(Figma 표준). ⌘+휠 커서중심 줌과 동일 공식을 baseline-anchored 형태로 일반화 — 연속 이벤트에 걸친 drift 없이 항상 캡처된 baseline 대비로 재계산. clamp 10~400%는 데스크톱과 동일.
- **crux — 포인터 수 변할 때 baseline 재캡처**: 1→2(둘째 손가락 down)에 그 순간의 거리/중점/transform을 baseline으로 재설정(delta 0부터) — 안 하면 오래된 기준점 대비 델타가 튀어 순간 점프가 남. 2→1(한 손 lift)에 남은 손가락 기준으로 pan baseline 재설정. 회귀 테스트 2건으로 두 전이 모두 "전이 직후 delta=0 → transform 불변"을 실측.
- **touch-action:none 유지**: 기존 `touch-none`(PR A부터)이 이미 CSS 네이티브 옵트아웃이라 네이티브 핀치줌/스크롤 위임이 애초에 없습니다 — wheel의 React onWheel passive 문제(#2138)와 달리 preventDefault 트릭이 필요 없다는 점을 그라운딩으로 확定했습니다.
- **더블탭**: fit↔100% 토글(탭 지점 중심, ⌘+휠과 동일 커서중심 줌 공식 재사용). fit/100% 버튼은 그대로 유지.
- **데스크톱 회귀 0**: 모든 신규 로직이 `pointerType === 'touch'` 게이트 뒤에만 있음 — 마우스 경로(핸들러 본문·wheel 핸들러)는 한 줄도 안 건드렸습니다.

## 구현 중 자체 발견·수정한 버그
`handlePointerMove`의 터치 분기에 무조건 `return`이 있어서 1-finger 터치가 (핀치 조건 불충족 시에도) 기존 pan 로직으로 폴스루하지 못하는 버그를 자체 테스트로 잡았습니다(1-finger 터치 pan이 아예 안 움직이는 회귀) — `return`을 핀치 활성 분기 안으로만 좁혀 수정.

## 게이트
- vitest 1557 GREEN(회귀 0, 신규 핀치/더블탭/전이-crux/데스크톱-무회귀 테스트 10건 포함)
- tsc --noEmit clean
- eslint 0
- next build EXIT=0

## 잔여
유나 가디언+까심 QA+CI → PO 머지 → 라이브 done-gate(모바일 뷰포트/디바이스 에뮬레이션 핀치 줌 실측, 데스크톱 무회귀).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>