### PR TITLE
[SID:6d0a0e3a] 갤러리 GROUP BY 배치 fix — 축 선택 좌측 레일 통합

### DIFF
--- a/apps/web/src/components/canvas/artifact-gallery-view.test.tsx
+++ b/apps/web/src/components/canvas/artifact-gallery-view.test.tsx
@@ -136,6 +136,28 @@ describe('ArtifactGalleryView (story a15cea4f)', () => {
     expect(container.textContent).toContain('정본 v3');
   });
 
+  it('story 6d0a0e3a — GROUP BY(axis segment + group list) is integrated into the same left rail container, not split into a header-top tab row (목업 0d852d24 배치 SSOT)', async () => {
+    await mount();
+    // 둘 다 같은 좌 레일 컨테이너 안에 있다(desktop lg:block 사본 기준) — 서로 다른 컨테이너로
+    // 쪼개져 있던 #2124 이래의 배치 오류(우측 상단 탭)가 아니다.
+    const desktopRail = container.querySelector('.hidden.h-fit.lg\\:block');
+    expect(desktopRail).not.toBeNull();
+    const epicBtn = [...(desktopRail?.querySelectorAll('button') ?? [])].find((b) => b.textContent === '에픽');
+    const groupBtn = [...(desktopRail?.querySelectorAll('button') ?? [])].find((b) => b.textContent?.includes('온보딩 캠페인'));
+    expect(epicBtn).toBeDefined();
+    expect(groupBtn).toBeDefined();
+  });
+
+  it('story 6d0a0e3a — provides a native collapsible top selector for narrow viewports (details/summary), in addition to the always-visible desktop rail', async () => {
+    await mount();
+    const details = container.querySelector('details.lg\\:hidden');
+    expect(details).not.toBeNull();
+    expect(details?.querySelector('summary')).not.toBeNull();
+    // 접이식 셀렉터 안에도 동일한 축 세그먼트+그룹 목록이 있다(데스크톱 사본과 동일 내용).
+    const collapsibleEpicBtn = [...(details?.querySelectorAll('button') ?? [])].find((b) => b.textContent === '에픽');
+    expect(collapsibleEpicBtn).toBeDefined();
+  });
+
   it('story 39313b40 — renders artifacts as a responsive multi-column card grid, not a row list (doc §3, no row/grid toggle in v1)', async () => {
     await mount();
     const grid = container.querySelector('.grid.grid-cols-\\[repeat\\(auto-fill\\,minmax\\(220px\\,1fr\\)\\)\\]');

--- a/apps/web/src/components/canvas/artifact-gallery-view.tsx
+++ b/apps/web/src/components/canvas/artifact-gallery-view.tsx
@@ -195,40 +195,65 @@ export function ArtifactGalleryView() {
 
   const axisLabel = (a: GalleryAxis) => t(`galleryAxis${a[0]!.toUpperCase()}${a.slice(1)}`);
 
+  // story 6d0a0e3a — GROUP BY(축 선택+그룹 목록) 배치를 목업(0d852d24) SSOT대로 좌측 레일에
+  // 통합(#2124 이래 우측 상단 탭으로 어긋나 있던 걸 정정). 로직은 완전 무변경 — axis/setAxis·
+  // groups·selectedGroupId 전부 그대로, 렌더 "위치"만 옮긴다(AC "배치만 변경").
+  const railContent = (
+    <>
+      <div className="flex flex-wrap gap-0.5 border-b border-border p-1.5">
+        {GALLERY_AXES.map((a) => (
+          <button
+            key={a}
+            type="button"
+            onClick={() => setAxis(a)}
+            className={cn(
+              'rounded-md px-2.5 py-1.5 text-xs font-semibold transition-colors',
+              axis === a ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            {axisLabel(a)}
+          </button>
+        ))}
+        <button
+          type="button"
+          disabled
+          title={t('galleryFeatureAxisUnsupported')}
+          className="cursor-not-allowed rounded-md px-2.5 py-1.5 text-xs font-semibold text-muted-foreground/40"
+        >
+          {t('galleryAxisFeature')}
+        </button>
+      </div>
+      <div className="space-y-1.5 p-1.5">
+        {groups.map((g) => (
+          <button
+            key={g.id}
+            type="button"
+            onClick={() => setSelectedGroupId(g.id)}
+            className={cn(
+              'flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-[13px] transition-colors',
+              selectedGroupId === g.id ? 'bg-muted/70' : 'hover:bg-muted/40',
+            )}
+          >
+            <span className={cn('size-1.5 shrink-0 rounded-full', selectedGroupId === g.id ? 'bg-info' : 'bg-muted-foreground/40')} aria-hidden="true" />
+            <span className={cn('min-w-0 flex-1 truncate font-medium', g.unassigned ? 'italic text-muted-foreground' : 'text-foreground')}>
+              {g.label}
+            </span>
+            <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">{g.artifacts.length}</span>
+          </button>
+        ))}
+      </div>
+    </>
+  );
+
   return (
     <div className="mx-auto max-w-5xl px-4 py-6">
-      <div className="mb-4 flex items-center justify-between gap-3">
-        <div>
-          <h1 className="text-[20px] font-extrabold tracking-tight text-foreground">{t('galleryTitle')}</h1>
-          <p className="mt-0.5 text-xs text-muted-foreground">{t('gallerySubtitle')}</p>
-        </div>
-        <div className="flex shrink-0 gap-0.5 rounded-lg border border-border bg-muted/40 p-0.5">
-          {GALLERY_AXES.map((a) => (
-            <button
-              key={a}
-              type="button"
-              onClick={() => setAxis(a)}
-              className={cn(
-                'rounded-md px-2.5 py-1.5 text-xs font-semibold transition-colors',
-                axis === a ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground',
-              )}
-            >
-              {axisLabel(a)}
-            </button>
-          ))}
-          <button
-            type="button"
-            disabled
-            title={t('galleryFeatureAxisUnsupported')}
-            className="cursor-not-allowed rounded-md px-2.5 py-1.5 text-xs font-semibold text-muted-foreground/40"
-          >
-            {t('galleryAxisFeature')}
-          </button>
-        </div>
+      <div className="mb-4">
+        <h1 className="text-[20px] font-extrabold tracking-tight text-foreground">{t('galleryTitle')}</h1>
+        <p className="mt-0.5 text-xs text-muted-foreground">{t('gallerySubtitle')}</p>
       </div>
 
       {loading ? (
-        <div className="grid grid-cols-[200px_1fr] gap-3.5">
+        <div className="grid grid-cols-1 gap-3.5 lg:grid-cols-[200px_1fr]">
           <GroupListSkeleton />
           <div className="h-40 animate-pulse rounded-xl bg-muted/40" />
         </div>
@@ -239,25 +264,17 @@ export function ArtifactGalleryView() {
           <p className="max-w-sm text-xs text-muted-foreground">{t('galleryEmptyHint')}</p>
         </div>
       ) : (
-        <div className="grid grid-cols-[200px_1fr] gap-3.5">
-          <div className="h-fit rounded-xl border border-border bg-card p-1.5">
-            {groups.map((g) => (
-              <button
-                key={g.id}
-                type="button"
-                onClick={() => setSelectedGroupId(g.id)}
-                className={cn(
-                  'flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-[13px] transition-colors',
-                  selectedGroupId === g.id ? 'bg-muted/70' : 'hover:bg-muted/40',
-                )}
-              >
-                <span className={cn('size-1.5 shrink-0 rounded-full', selectedGroupId === g.id ? 'bg-info' : 'bg-muted-foreground/40')} aria-hidden="true" />
-                <span className={cn('min-w-0 flex-1 truncate font-medium', g.unassigned ? 'italic text-muted-foreground' : 'text-foreground')}>
-                  {g.label}
-                </span>
-                <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">{g.artifacts.length}</span>
-              </button>
-            ))}
+        <div className="grid grid-cols-1 gap-3.5 lg:grid-cols-[200px_1fr]">
+          {/* 반응형(유나 판정 위임 — 목업은 데스크톱만 명시): 좁은 화면=상단 접이식 셀렉터로
+           * collapse(네이티브 details/summary — 접근성 기본 제공), lg+=상시 노출 레일 유지. */}
+          <details className="rounded-xl border border-border bg-card lg:hidden">
+            <summary className="cursor-pointer select-none rounded-xl px-3 py-2.5 text-[13px] font-semibold text-foreground">
+              {axisLabel(axis)} · {selectedGroup?.label ?? ''}
+            </summary>
+            {railContent}
+          </details>
+          <div className="hidden h-fit rounded-xl border border-border bg-card lg:block">
+            {railContent}
           </div>
 
           <div


### PR DESCRIPTION
## story
`6d0a0e3a` — 선생님 실사용 지적(스크린샷) + PO 목업↔구현 puppeteer 대조 확定. doc `artifact-gallery-design` §3 목업(`0d852d24`) SSOT: 축 선택(에픽/스토리/스프린트/문서)은 좌측 레일 상단, 그 아래 선택 축의 그룹 인스턴스 목록이 같은 레일 — "GROUP BY 한 곳". 실제 구현은 #2124(최초 갤러리 구현)부터 축 선택을 우측 상단 탭으로 분리해왔던 배치 편차입니다.

## 구현 — 순수 배치 변경(로직 무변경)
- 우측 상단 탭 행 제거, 축 세그먼트 + 그룹 목록을 `railContent`로 묶어 좌측 레일에 함께 렌더.
- `axis`/`setAxis`·`groups` 계산·`selectedGroupId`·에픽 1홉 유도·ids 배치 조회·카드 그리드·모달 열람·변천사 탭 — 전부 무변경, 렌더 "위치"만 이동.

## 반응형(판단, 목업은 데스크톱만 명시)
좁은 화면은 네이티브 `<details>/<summary>`로 좌 레일 전체(축+그룹)를 상단 접이식 셀렉터로 collapse(접근성 기본 제공) — `lg+`는 상시 노출 레일 유지. 데스크톱/모바일 두 사본을 렌더하고 Tailwind `lg:hidden`/`hidden lg:block`으로 전환합니다.

## 게이트
- vitest 1562 GREEN(회귀 0, 신규 배치 회귀가드 2건 포함)
- tsc --noEmit clean
- eslint 0
- next build EXIT=0

## 잔여
유나 가디언(목업 픽셀 1:1 대조 명시)+까심 QA+CI → PO 머지 → 라이브 done-gate(GROUP BY 좌측 통합 실렌더·목업 대조).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>