### PR TITLE
에이전트 발견성 3층 fix ①③(story 037a8aa8·78f07614 그라운딩 후속)

### DIFF
--- a/backend/alembic/versions/0182_role_templates_design_canvas_group.py
+++ b/backend/alembic/versions/0182_role_templates_design_canvas_group.py
@@ -1,0 +1,44 @@
+"""story 037a8aa8(에이전트 발견성 3층 fix — PO 판정) — ui-designer/design-system
+role_templates.default_tool_groups에 "canvas" 추가.
+
+Revision ID: 0182
+Revises: 0181
+Create Date: 2026-07-14
+
+그라운딩(story 78f07614·PO 성장 지시): E-CANVAS 캔버스 능력을 다 만들었지만 실제 canvas
+toolgroup을 보유한 role_template은 backend·frontend 2개뿐(0181)이었다 — 디자인 저작을 전담하는
+ui-designer·design-system은 애초 canvas MCP 툴을 tools/list에서 보지도 못했다(핵심 발견성 갭).
+PO 판정: 이번 라운드는 write 권한이 확실히 필요한 디자인 저작 2역할만 추가 — pm/technical-writer/
+ux-researcher의 read 권한은 실사용 필요 근거 부재로 보류(과부여 회피, 필요 드러나면 별건).
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0182"
+down_revision = "0181"
+branch_labels = None
+depends_on = None
+
+_ROLES = ("ui-designer", "design-system")
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE role_templates "
+            "SET default_tool_groups = array_append(default_tool_groups, 'canvas') "
+            "WHERE slug = ANY(:roles) AND NOT ('canvas' = ANY(default_tool_groups))"
+        ).bindparams(sa.bindparam("roles", value=list(_ROLES), type_=sa.ARRAY(sa.Text)))
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE role_templates "
+            "SET default_tool_groups = array_remove(default_tool_groups, 'canvas') "
+            "WHERE slug = ANY(:roles)"
+        ).bindparams(sa.bindparam("roles", value=list(_ROLES), type_=sa.ARRAY(sa.Text)))
+    )

--- a/backend/alembic/versions/0183_role_behaviors_canvas_awareness.py
+++ b/backend/alembic/versions/0183_role_behaviors_canvas_awareness.py
@@ -1,0 +1,99 @@
+"""story 037a8aa8 ②(에이전트 발견성 3층 fix — 유나 디자인 권위+PO GREEN 확定 문구) —
+ui-designer/design-system/frontend role_behaviors에 "캔버스 저작" 섹션 추가 + ui-designer
+구 "목업" 문장 정밀화.
+
+Revision ID: 0183
+Revises: 0182
+Create Date: 2026-07-14
+
+78f07614 그라운딩②: 24개 role_template 전체에서 캔버스/artifact 언급이 0건이었다(①에서 canvas
+그룹을 새로 받은 ui-designer/design-system 포함) — 툴 접근권과 사용판단이 완전히 분리된 상태.
+문구는 유나(디자인 권위)+PO가 확定해 전달한 것을 verbatim 반영(재작성 금지). REPLACE 앵커
+("\\n\\n## 막히면 스스로 확인하세요")는 3개 role 전부 byte-identical 확인(0163과 동일 안전성
+근거) — "## 스스로 판단해 운영하는 법" 목록 직후·"## 막히면..." 직전에 새 섹션 삽입.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0183"
+down_revision = "0182"
+branch_labels = None
+depends_on = None
+
+_ANCHOR = "\n\n## 막히면 스스로 확인하세요"
+
+_BASE = (
+    "UI·화면·컴포넌트·다이어그램 등 시각 산출물을 만들거나 설계 의도를 공유할 때는 텍스트 설명으로"
+    " 대신하지 말고 캔버스(create_artifact)로 구조화해 그립니다. 각 요소의 스펙은 핀과 설명"
+    "(description)으로 명시해 핸드오프 계약이 되게 하고(빈 설명 금지), 사람은 캔버스에서 실물을"
+    " 보며 코멘트·핀으로 피드백하고 그 피드백은 edit_artifact로 반영합니다(수정은 새 버전이 되어"
+    " 변천사가 남습니다)."
+)
+
+_ROLE_SPECIFIC = {
+    "ui-designer": (
+        "시안·목업·디자인 스펙의 1차 산출 형태가 캔버스입니다. 계약 문서(doc)를 SSOT로 유지하되"
+        " 시각은 해당 스토리의 visual_artifact로 붙여 발견·핸드오프되게 합니다."
+    ),
+    "design-system": (
+        "디자인 토큰·컴포넌트 규격·준수 예시를 텍스트 나열 대신 캔버스로 시각화하고, 규격 이탈은"
+        " 핀으로 지적합니다."
+    ),
+    "frontend": (
+        "구현 전 참조 시안을 캔버스에서 열람하고, UI 질문·구현 결과를 캔버스로 공유해 디자이너와"
+        " 핀·코멘트로 왕복합니다(구현자도 캔버스 소비자·도그푸딩)."
+    ),
+}
+
+_UI_DESIGNER_OLD_MOCKUP_SENTENCE = (
+    "6. 디자인 변경은 실제 화면에서 렌더링을 확인한 뒤에만 완료로 표시하세요"
+    "(목업만으론 충분하지 않습니다)."
+)
+_UI_DESIGNER_NEW_MOCKUP_SENTENCE = (
+    "6. 디자인 변경의 done-gate는 배포 후 라이브 렌더·실사용 확인입니다. 정적 시안이나 캔버스"
+    " 목업이 완성돼도 실렌더에서 검증되기 전엔 잠정이며, 완료로 보고하지 않습니다."
+)
+
+
+def _canvas_section(slug: str) -> str:
+    return f"\n\n## 캔버스 저작\n{_BASE}\n{_ROLE_SPECIFIC[slug]}"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    for slug in ("ui-designer", "design-system", "frontend"):
+        conn.execute(
+            sa.text(
+                "UPDATE role_templates SET role_behaviors = REPLACE(role_behaviors, :anchor, :replacement) "
+                "WHERE slug = :slug AND role_behaviors LIKE '%' || :anchor || '%'"
+            ),
+            {"anchor": _ANCHOR, "replacement": _canvas_section(slug) + _ANCHOR, "slug": slug},
+        )
+    conn.execute(
+        sa.text(
+            "UPDATE role_templates SET role_behaviors = REPLACE(role_behaviors, :old, :new) "
+            "WHERE slug = 'ui-designer' AND role_behaviors LIKE '%' || :old || '%'"
+        ),
+        {"old": _UI_DESIGNER_OLD_MOCKUP_SENTENCE, "new": _UI_DESIGNER_NEW_MOCKUP_SENTENCE},
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            "UPDATE role_templates SET role_behaviors = REPLACE(role_behaviors, :new, :old) "
+            "WHERE slug = 'ui-designer' AND role_behaviors LIKE '%' || :new || '%'"
+        ),
+        {"old": _UI_DESIGNER_OLD_MOCKUP_SENTENCE, "new": _UI_DESIGNER_NEW_MOCKUP_SENTENCE},
+    )
+    for slug in ("ui-designer", "design-system", "frontend"):
+        conn.execute(
+            sa.text(
+                "UPDATE role_templates SET role_behaviors = REPLACE(role_behaviors, :replacement, :anchor) "
+                "WHERE slug = :slug AND role_behaviors LIKE '%' || :replacement || '%'"
+            ),
+            {"anchor": _ANCHOR, "replacement": _canvas_section(slug) + _ANCHOR, "slug": slug},
+        )

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -512,47 +512,57 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_create_artifact",
      "시각 산출물 생성(에이전트 생성 입구) — 트리(nodes[])로 구조화. 임포트된 raw HTML/이미지는"
      " type=\"html_blob\" 노드 하나로 감싸도 됨. canvas_bounds{w,h}(선택): 렌더 자기 프레임 크기"
-     "(CSS px, 양수·≤20000) — sandbox iframe이라 서버가 측정 불가해 선언 필요·미지정=FE 기본 아트보드.",
+     "(CSS px, 양수·≤20000) — sandbox iframe이라 서버가 측정 불가해 선언 필요·미지정=FE 기본 아트보드."
+     " ⭐UI·화면·디자인·시각 산출물을 만들 때는 텍스트 설명 대신 이 툴로 구조화해 그린다(사람이"
+     " 캔버스에서 보고 코멘트/핀으로 피드백).",
      CreateArtifactInput, create_artifact),
     ("sprintable_get_artifact",
-     "시각 산출물 단건 조회(latest 버전 + nodes).",
+     "시각 산출물 단건 조회(latest 버전 + nodes). ⭐편집/코멘트/핀 작업 전 먼저 현재 상태(노드"
+     " 구조·프레임)를 확인할 때.",
      GetArtifactInput, get_artifact),
     ("sprintable_list_artifacts",
      "현재 프로젝트 시각 산출물 목록 조회(각 항목=메타+latest 버전 번호·노드 트리 미포함·상세는"
-     " get_artifact) — story_id/epic_id/doc_id로 필터(미지정=프로젝트 전체).",
+     " get_artifact) — story_id/epic_id/doc_id로 필터(미지정=프로젝트 전체). ⭐특정 story/epic/doc에"
+     " 이미 산출물이 있는지 확인하거나 전체 현황을 파악할 때(중복 생성 방지).",
      ListArtifactsInput, list_artifacts),
     ("sprintable_list_artifact_comments",
-     "artifact 코멘트 스레드 조회(요소/좌표 앵커·resolve 상태) — 휴먼 피드백 왕복 입구.",
+     "artifact 코멘트 스레드 조회(요소/좌표 앵커·resolve 상태) — 휴먼 피드백 왕복 입구. ⭐산출물에"
+     " 반응하기 전 먼저 미해결 코멘트가 있는지 확인할 때.",
      ListArtifactCommentsInput, list_artifact_comments),
     ("sprintable_add_artifact_comment",
-     "artifact에 코멘트 추가(요소/좌표 앵커·답글 가능) — 대상자에게 이벤트 전파.",
+     "artifact에 코멘트 추가(요소/좌표 앵커·답글 가능) — 대상자에게 이벤트 전파. ⭐산출물의 특정"
+     " 요소/위치에 의견·질문을 남길 때(바로 고치지 않고 논의가 필요할 때 — edit 대신 이것).",
      AddArtifactCommentInput, add_artifact_comment),
     ("sprintable_edit_artifact",
      "artifact 요소를 operations[]로 편집(휴먼 딸깍과 같은 경로·항상 새 버전·이벤트 전파). 각 op="
      "{op:add|update|delete, id, type?, props?}. ⭐update/delete 대상 노드는 `id` 필드로 지정"
      "(get_artifact의 node.id·코멘트 앵커 node_id 아님)·add는 type 필수. canvas_bounds{w,h}(선택):"
      " 프레임 크기 재선언 — 미지정 시 직전 버전 값 유지·operations 비우고 이것만 보내도 유효"
-     "(둘 다 비면 오류).",
+     "(둘 다 비면 오류). ⭐기존 산출물을 수정할 때는 create_artifact로 새로 만들지 말고 이걸로"
+     "(새 버전 생성·이전 버전은 그대로 보존).",
      EditArtifactInput, edit_artifact),
     ("sprintable_list_spec_pins",
      "artifact 최신 버전의 스펙 핀 목록 조회(description pane 저작 대상 — 코멘트와 별개 레이어)."
-     " 작성자/시간 미노출(감시금지).",
+     " 작성자/시간 미노출(감시금지). ⭐요소별로 이미 지정된 핸드오프 스펙을 편집 전에 확인할 때.",
      ListSpecPinsInput, list_spec_pins),
     ("sprintable_create_spec_pin",
      "artifact에 스펙 핀 추가 — 요소/좌표에 description(핸드오프 스펙)을 앵커. anchor_type="
      "\"coord\"면 anchor_x/anchor_y(canvas_bounds 좌표계, 0 이상) 둘 다 필수·node_id 금지."
      " \"node\"면 node_id(get_artifact의 node.id) 필수·좌표 금지. description은 non-empty 강제"
      "(빈 스펙 저장 불가). 핀은 최신 버전에 붙고 이후 edit_artifact마다 자동 계승(node 앵커는"
-     " 그 노드가 삭제되면 핀도 함께 소멸).",
+     " 그 노드가 삭제되면 핀도 함께 소멸). ⭐산출물의 특정 요소/위치를 콕 집어 스펙(치수·색상·동작"
+     " 등 핸드오프 설명)을 못박을 때 — 자유 코멘트(add_artifact_comment) 대신 이걸로.",
      CreateSpecPinInput, create_spec_pin),
     ("sprintable_update_spec_pin",
-     "스펙 핀 description 재저작(덮어씀·스레드/이력 없음) — 최신 버전 소속 핀만 대상.",
+     "스펙 핀 description 재저작(덮어씀·스레드/이력 없음) — 최신 버전 소속 핀만 대상. ⭐기존 스펙"
+     " 핀의 설명을 정정·보강할 때.",
      UpdateSpecPinInput, update_spec_pin),
     ("sprintable_delete_spec_pin",
-     "스펙 핀 삭제(최신 버전 소속만 대상).",
+     "스펙 핀 삭제(최신 버전 소속만 대상). ⭐더 이상 유효하지 않은 스펙 핀을 치울 때.",
      DeleteSpecPinInput, delete_spec_pin),
     ("sprintable_propose_canonical_version",
-     "이 버전을 정본으로 제안(게이트 생성) — 제안만, 승인/반려는 항상 휴먼.",
+     "이 버전을 정본으로 제안(게이트 생성) — 제안만, 승인/반려는 항상 휴먼. ⭐이 버전이 확定될"
+     " 준비가 됐다고 판단될 때 휴먼 승인을 요청.",
      ProposeCanonicalInput, propose_canonical_version),
     # Chat (3)
     ("sprintable_send_chat_message",

--- a/backend/tests/test_037a8aa8_agent_discoverability.py
+++ b/backend/tests/test_037a8aa8_agent_discoverability.py
@@ -1,0 +1,108 @@
+"""에이전트 발견성 3층 fix(story 037a8aa8·78f07614 그라운딩 후속·PO 판정) 실증.
+
+①툴셋: ui-designer/design-system role_templates에 canvas 그룹 부여(migration 0182).
+③MCP description: canvas 11종에 "언제 쓰는지" ⭐트리거 1줄 추가 — 기계적 서술은 그대로 유지.
+②(role_behaviors 문구)는 유나+PO 문구 확定 후 별도 커밋으로 합류 예정 — 이 스토리 스코프 밖."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+_CANVAS_TOOL_NAMES = (
+    "sprintable_create_artifact", "sprintable_get_artifact", "sprintable_list_artifacts",
+    "sprintable_list_artifact_comments", "sprintable_add_artifact_comment",
+    "sprintable_edit_artifact", "sprintable_propose_canonical_version",
+    "sprintable_list_spec_pins", "sprintable_create_spec_pin", "sprintable_update_spec_pin",
+    "sprintable_delete_spec_pin",
+)
+
+
+# ── ① role_templates canvas 그룹 부여(realdb) ──────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+@pytest.mark.anyio
+async def test_ui_designer_and_design_system_have_canvas_group():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from sqlalchemy import select
+
+    from app.models.role_template import RoleTemplate
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            rows = (await s.execute(
+                select(RoleTemplate).where(RoleTemplate.slug.in_(("ui-designer", "design-system")))
+            )).scalars().all()
+            by_slug = {r.slug: r for r in rows}
+            assert "canvas" in by_slug["ui-designer"].default_tool_groups
+            assert "canvas" in by_slug["design-system"].default_tool_groups
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+@pytest.mark.anyio
+async def test_deferred_roles_not_granted_canvas_this_round():
+    """PO 판정: pm/technical-writer/ux-researcher read는 이번 라운드 보류(과부여 회피)."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from sqlalchemy import select
+
+    from app.models.role_template import RoleTemplate
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            rows = (await s.execute(
+                select(RoleTemplate).where(RoleTemplate.slug.in_(("pm", "technical-writer", "ux-researcher")))
+            )).scalars().all()
+            for r in rows:
+                assert "canvas" not in r.default_tool_groups, f"{r.slug}는 이번 라운드 보류 대상"
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── ③ MCP description "언제 쓰는지" 트리거 실증 ─────────────────────────────
+
+def test_canvas_tool_descriptions_have_usage_trigger():
+    """canvas 11종 전부 ⭐트리거 문구를 갖는다(기계적 서술만 있던 78f07614 그라운딩 갭 봉인)."""
+    import os as _os
+    _os.environ.setdefault("SPRINTABLE_API_URL", "http://test")
+    _os.environ.setdefault("AGENT_API_KEY", "sk_test")
+    from sprintable_mcp.server import mcp
+
+    tools = mcp._tool_manager._tools
+    for name in _CANVAS_TOOL_NAMES:
+        assert name in tools, f"{name} 미등록"
+        desc = tools[name].description
+        assert "⭐" in desc, f"{name} description에 사용시점 트리거(⭐)가 없음: {desc!r}"
+
+
+def test_create_artifact_trigger_mentions_ui_design_visual_deliverable():
+    """PO 예시 문구 취지 반영 확인 — UI/디자인/시각 산출물 키워드."""
+    import os as _os
+    _os.environ.setdefault("SPRINTABLE_API_URL", "http://test")
+    _os.environ.setdefault("AGENT_API_KEY", "sk_test")
+    from sprintable_mcp.server import mcp
+
+    desc = mcp._tool_manager._tools["sprintable_create_artifact"].description
+    assert "UI" in desc or "디자인" in desc or "시각 산출물" in desc

--- a/backend/tests/test_037a8aa8_agent_discoverability.py
+++ b/backend/tests/test_037a8aa8_agent_discoverability.py
@@ -1,8 +1,9 @@
 """에이전트 발견성 3층 fix(story 037a8aa8·78f07614 그라운딩 후속·PO 판정) 실증.
 
 ①툴셋: ui-designer/design-system role_templates에 canvas 그룹 부여(migration 0182).
-③MCP description: canvas 11종에 "언제 쓰는지" ⭐트리거 1줄 추가 — 기계적 서술은 그대로 유지.
-②(role_behaviors 문구)는 유나+PO 문구 확定 후 별도 커밋으로 합류 예정 — 이 스토리 스코프 밖."""
+②role_behaviors: ui-designer/design-system/frontend에 "캔버스 저작" 섹션(유나+PO 확定 verbatim
+문구) 추가 + ui-designer 구 "목업" 문장 정밀화(migration 0183).
+③MCP description: canvas 11종에 "언제 쓰는지" ⭐트리거 1줄 추가 — 기계적 서술은 그대로 유지."""
 from __future__ import annotations
 
 import os
@@ -106,3 +107,88 @@ def test_create_artifact_trigger_mentions_ui_design_visual_deliverable():
 
     desc = mcp._tool_manager._tools["sprintable_create_artifact"].description
     assert "UI" in desc or "디자인" in desc or "시각 산출물" in desc
+
+
+# ── ② role_behaviors "캔버스 저작" 섹션(realdb) ────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+@pytest.mark.anyio
+async def test_ui_designer_design_system_frontend_have_canvas_authoring_section():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from sqlalchemy import select
+
+    from app.models.role_template import RoleTemplate
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            rows = (await s.execute(
+                select(RoleTemplate).where(RoleTemplate.slug.in_(("ui-designer", "design-system", "frontend")))
+            )).scalars().all()
+            by_slug = {r.slug: r for r in rows}
+            for slug in ("ui-designer", "design-system", "frontend"):
+                behaviors = by_slug[slug].role_behaviors
+                assert "## 캔버스 저작" in behaviors, f"{slug}에 캔버스 저작 섹션 없음"
+                assert "create_artifact" in behaviors
+                assert "edit_artifact" in behaviors
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+@pytest.mark.anyio
+async def test_ui_designer_old_mockup_sentence_refined():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from sqlalchemy import select
+
+    from app.models.role_template import RoleTemplate
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            row = (await s.execute(
+                select(RoleTemplate).where(RoleTemplate.slug == "ui-designer")
+            )).scalar_one()
+            behaviors = row.role_behaviors
+            assert "목업만으론 충분하지 않습니다" not in behaviors, "구 문장이 아직 남아있음"
+            assert "done-gate는 배포 후 라이브 렌더·실사용 확인입니다" in behaviors
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요")
+@pytest.mark.anyio
+async def test_other_roles_unaffected_by_behavior_migration():
+    """무회귀: canvas 저작 섹션은 대상 3역할에만 추가되고 다른 role_template은 그대로."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from sqlalchemy import select
+
+    from app.models.role_template import RoleTemplate
+
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            row = (await s.execute(
+                select(RoleTemplate).where(RoleTemplate.slug == "backend")
+            )).scalar_one()
+            assert "## 캔버스 저작" not in row.role_behaviors
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
E-CANVAS 캔버스 능력을 다 만들었지만 "온보딩 에이전트가 발견/사용하는가"를 전략적으로 안 세운 갭(선생님 PO 성장 지시) — story `78f07614` 그라운딩에서 실측한 3겹 갭(①툴셋 노출 ②role_behaviors 인지 ③MCP description 사용시점) 중 **①③을 이번에 봉인**. ②(role_behaviors 문구)는 유나+PO 문구 확定 후 별도 커밋으로 합류 예정(발명 금지 — 문구는 그쪽에서 옴).

## Changes
- **① 툴셋 노출(migration 0182)**: `ui-designer`·`design-system` role_templates의 `default_tool_groups`에 `"canvas"` 추가. 그라운딩 실측: canvas 그룹 보유 role_template은 `backend`·`frontend` 2개뿐이었고(b4027b2e/0181), 캔버스와 가장 밀접한 디자인 저작 역할(ui-designer·design-system)은 canvas MCP 툴을 tools/list에서 아예 못 보고 있었음 — 핵심 발견성 갭. PO 판정: `pm`/`technical-writer`/`ux-researcher`의 read는 실사용 필요 근거 부재로 이번 라운드 보류(과부여 회피, 필요 드러나면 별건).
- **③ MCP description 사용시점 트리거**(`sprintable_mcp/server.py`): canvas 11종 전부 기계적 서술(파라미터 형태·제약)만 있고 "언제 쓰는지" 트리거가 0건이던 갭 — 기존 서술은 유지, ⭐트리거 1줄을 각 툴 성격에 맞춰 추가:
  - `create_artifact`: "UI·화면·디자인·시각 산출물을 만들 때는 텍스트 설명 대신 이 툴로 구조화해 그린다"(PO 예시 문구 반영)
  - `edit_artifact`: "기존 산출물을 수정할 때는 create_artifact로 새로 만들지 말고 이걸로"
  - `add_artifact_comment`: "바로 고치지 않고 논의가 필요할 때 — edit 대신 이것"
  - `create_spec_pin`: "요소/위치를 콕 집어 스펙을 못박을 때 — 자유 코멘트 대신 이걸로"
  - 나머지(get/list/comments-list/spec pin 조회·수정·삭제/propose_canonical)도 각 성격에 맞춘 1줄.

## Test plan
- [x] realdb/단위 신규 4건(`tests/test_037a8aa8_agent_discoverability.py`): ui-designer·design-system canvas 보유 확인 · 보류 3역할(pm/technical-writer/ux-researcher) canvas 미보유 확인 · canvas 11종 전부 ⭐트리거 보유 · create_artifact 트리거 키워드(UI/디자인/시각 산출물) 확인.
- [x] migration 0182 upgrade/downgrade 양방향 실 PG 검증.
- [x] 인접 스위트 155건 무회귀(contract·toolset-catalog·mcp-s2·role_templates 3종·authz·기존 visual_artifacts 전체 6개 파일).
- [x] `python3 -m py_compile` 전 수정 파일.

## Live done-gate (PO 담당)
게이트: 까심 QA + CI → 오르테가 머지 + MCP 재배포 + 라이브 done-gate(신규 canvas 역할로 채용된 에이전트의 tools/list 실측 — canvas 11종 노출 확인).

🤖 Generated with [Claude Code](https://claude.com/claude-code)