### PR TITLE
갤러리 스토리 피커 실검색 BE(story 083176e8·까심 #2148 QA 적출)

### DIFF
--- a/backend/app/repositories/story.py
+++ b/backend/app/repositories/story.py
@@ -23,6 +23,20 @@ class StoryRepository(BaseRepository[Story]):
     def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
         super().__init__(Story, session, org_id)
 
+    async def list(self, limit: int = 1000, *, q: str | None = None, **filters) -> list[Story]:
+        """story 083176e8(까심 #2148 QA 적출): 갤러리 피커 실검색 — `q`는 title ILIKE 부분일치로
+        기존 동등비교 필터(**filters, base.list() 상속)와 AND 결합. BaseRepository.list()는
+        범용(모든 리포지토리 공유)이라 q ILIKE 개념을 거기 얹지 않고 story 전용으로 오버라이드
+        (list_board/list_by_ids와 동일하게 자체 쿼리 구성 — 기존 관례).
+        """
+        query = select(Story).where(self._org_filter(), Story.deleted_at.is_(None))
+        for attr, val in filters.items():
+            query = query.where(getattr(Story, attr) == val)
+        if q:
+            query = query.where(Story.title.ilike(f"%{q}%"))
+        result = await self.session.execute(query.limit(limit))
+        return list(result.scalars().all())
+
     async def list_by_ids(self, ids: list[uuid.UUID]) -> list[Story]:
         """배치 앵커 조회(story ca37b2b0 ② — 갤러리 등 정확한 story 집합 필요 소비자용).
 

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -89,6 +89,7 @@ async def list_stories(
     status_filter: str | None = Query(default=None, alias="status"),
     no_sprint: bool = Query(default=False, description="sprint 미배정 스토리만 반환"),
     ids: str | None = Query(default=None, description="comma-separated story ids — 배치 앵커 조회(정확한 집합, ORDER BY/limit 무관)"),
+    q: str | None = Query(default=None, description="title 부분검색(ILIKE) — 기존 필터와 AND 결합"),
     limit: int = Query(default=1000, ge=1, le=2000),
     cursor: str | None = Query(default=None, description="Cursor: ISO 8601 created_at, fetch before this time"),
     response: Response = None,  # type: ignore[assignment]
@@ -154,7 +155,7 @@ async def list_stories(
         filters["assignee_id"] = assignee_id
     if status_filter:
         filters["status"] = status_filter
-    stories = await repo.list(limit=limit, **filters)
+    stories = await repo.list(limit=limit, q=q, **filters)
     await _attach_assignee_ids(repo.session, repo.org_id, stories)
     await _attach_has_evidence(repo.session, stories)
     return [StoryResponse.model_validate(s) for s in stories]

--- a/backend/tests/test_083176e8_story_search_q_realdb.py
+++ b/backend/tests/test_083176e8_story_search_q_realdb.py
@@ -1,0 +1,183 @@
+"""갤러리 스토리 피커 실검색 BE(story 083176e8·까심 #2148 QA 적출) — 실 PG.
+
+`GET /api/v2/stories?q=` — title ILIKE 부분일치, 기존 필터(project_id 등)와 AND 결합.
+BaseRepository.list()는 범용 동등비교만 지원해 q ILIKE를 못 얹으므로 StoryRepository.list()를
+오버라이드(list_board/list_by_ids와 동형 관례). d8787fa6(ORDER BY 부재)와는 별개 트랙 — 여기선
+q 검색 정확성만 검증, 정렬 결정론은 스코프 밖."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _auth(agent_id: uuid.UUID):
+    from app.dependencies.auth import AuthContext
+    return AuthContext(user_id=str(agent_id), email=None, claims={"app_metadata": {}})
+
+
+async def _seed(session):
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.pm import Story
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent")
+    session.add(agent)
+    await session.commit()
+    session.add(ProjectAccess(id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted"))
+    await session.commit()
+
+    story_login = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Login page redesign", status="backlog")
+    story_dash = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Dashboard widget refresh", status="backlog")
+    story_logout = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="Logout flow cleanup", status="backlog")
+    session.add_all([story_login, story_dash, story_logout])
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id, "agent_id": agent.id,
+        "story_login": story_login.id, "story_dash": story_dash.id, "story_logout": story_logout.id,
+    }
+
+
+async def _call_list_stories(session, org_id, agent_id, **kwargs):
+    """list_stories를 직접 호출 — FastAPI Query() 기본값은 실제 요청 경유 없인 unwrap 안 되므로
+    (라우터 함수를 직접 부르면 Query(...) 객체 그대로 남아 truthy 오판) 관련 파라미터 전부 명시
+    None/False로 채운다(test_ca37b2b0가 ids만 명시해도 되던 건 조기 return이라 나머지 분기에
+    안 들어가서였을 뿐 — 이 파일은 일반 분기까지 타야 해서 전부 필요)."""
+    from app.repositories.story import StoryRepository
+    from app.routers.stories import list_stories
+
+    repo = StoryRepository(session, org_id)
+    params = dict(
+        project_id=None, epic_id=None, sprint_id=None, assignee_id=None,
+        status_filter=None, no_sprint=False, ids=None, q=None, limit=1000,
+        cursor=None, response=None,
+    )
+    params.update(kwargs)
+    return await list_stories(repo=repo, auth=_auth(agent_id), **params)
+
+
+async def test_q_full_title_match():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            result = await _call_list_stories(s, seeded["org_id"], seeded["agent_id"], q="Login page redesign")
+            assert {r.id for r in result} == {seeded["story_login"]}
+    finally:
+        await engine.dispose()
+
+
+async def test_q_partial_case_insensitive_match():
+    """ILIKE 부분일치 — 대소문자 무관, 여러 건 매치("log"가 Login·Logout 둘 다 히트)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            result = await _call_list_stories(s, seeded["org_id"], seeded["agent_id"], q="LOG")
+            returned_ids = {r.id for r in result}
+            assert returned_ids == {seeded["story_login"], seeded["story_logout"]}
+            assert seeded["story_dash"] not in returned_ids
+    finally:
+        await engine.dispose()
+
+
+async def test_q_no_match_returns_empty():
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            result = await _call_list_stories(s, seeded["org_id"], seeded["agent_id"], q="nonexistent-xyz")
+            assert result == []
+    finally:
+        await engine.dispose()
+
+
+async def test_q_unspecified_returns_all_no_regression():
+    """무회귀: q 미지정 시 기존 동작 그대로(전체 반환)."""
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        async with Session() as s:
+            result = await _call_list_stories(s, seeded["org_id"], seeded["agent_id"])
+            returned_ids = {r.id for r in result}
+            assert returned_ids == {seeded["story_login"], seeded["story_dash"], seeded["story_logout"]}
+    finally:
+        await engine.dispose()
+
+
+async def test_q_combined_with_project_id_filter_and_not_or():
+    """q와 기존 필터(project_id)가 AND 결합 — 다른 project의 동일 title 매치는 제외."""
+    from app.models.pm import Story
+    from app.models.project import Project
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            other_project = Project(id=uuid.uuid4(), org_id=seeded["org_id"], name="Other")
+            s.add(other_project)
+            await s.commit()
+            other_story = Story(
+                id=uuid.uuid4(), org_id=seeded["org_id"], project_id=other_project.id,
+                title="Login page in other project", status="backlog",
+            )
+            s.add(other_story)
+            await s.commit()
+
+        async with Session() as s:
+            result = await _call_list_stories(
+                s, seeded["org_id"], seeded["agent_id"], q="Login", project_id=seeded["project_id"],
+            )
+            returned_ids = {r.id for r in result}
+            assert returned_ids == {seeded["story_login"]}
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
`GET /api/v2/stories`가 `q` 파라미터 자체를 몰라 FastAPI가 조용히 버리고 있었다 — 갤러리 빈상태 피커의 검색창이 장식이었던 근본(무필터 전체 목록만 반환, 까심 #2148 QA 적출).

## Changes
- `app/routers/stories.py`: `q: str | None = Query(...)` 신설 — title 부분검색(ILIKE), 기존 `project_id`/`epic_id`/`sprint_id`/`assignee_id`/`status` 필터와 AND 결합.
- `app/repositories/story.py`: `StoryRepository.list()` 오버라이드 — `BaseRepository.list()`는 전 리포지토리 공유 범용(동등비교 `**filters`만 지원)이라 ILIKE 개념을 얹을 수 없어, `list_board`/`list_by_ids`와 동일한 기존 관례로 story 전용 오버라이드(자체 쿼리 구성 + `q` 있을 때만 `title.ilike(f"%{q}%")` 추가). 이스케이프는 `assets.py`의 기존 검색 구현(동일 `f"%{q}%"` 패턴)과 정합 — 이 코드베이스의 기존 관례.
- `ids`-batch / `no_sprint`+backlog / `status`+board 등 다른 조기-return 분기는 스코프 밖(`q`는 일반 filters 분기에만 배선 — 과확대 금지).
- `d8787fa6`(BaseRepository ORDER BY 부재)와는 별개 트랙 — 여기선 `q` 검색 정확성만, 정렬 결정론은 건드리지 않음.
- **migration 불요**: 라우터 파라미터 + 코드 레벨 쿼리 구성, 스키마/데이터 무변경.

## Test plan
- [x] realdb 신규 5건(`tests/test_083176e8_story_search_q_realdb.py`): 전체일치 · 부분/대소문자무관 매치(다중 히트) · 무매치 빈배열 · `q` 미지정 무회귀 · `project_id`와 AND 결합(다른 project의 동일 title 매치 제외) 검증.
- [x] 기존 stories 스위트 무회귀: `test_ca37b2b0_stories_ids_batch_realdb.py`(5건) + `test_stories.py`(32건).
- [x] `python3 -m py_compile` 전 수정 파일.

미르코 FE 픽업(갤러리 피커를 `q` 호출로 재배선)은 별도.

🤖 Generated with [Claude Code](https://claude.com/claude-code)