### PR TITLE
[SID:3d0d60a3] 반응형 미리보기 재설계 — 뷰어 모달 브레이크포인트 셀렉터

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3578,6 +3578,9 @@
     "viewerCanvasHint": "Drag to move, scroll to zoom",
     "viewerCanvasHintTouch": "Move with one finger, zoom with two. Double-tap to fit.",
     "viewerFitAction": "Fit to view",
-    "viewerActualSizeAction": "Actual size"
+    "viewerActualSizeAction": "Actual size",
+    "responsivePreviewDesktop": "Desktop",
+    "responsivePreviewTablet": "Tablet",
+    "responsivePreviewMobile": "Mobile"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3578,6 +3578,9 @@
     "viewerCanvasHint": "드래그로 이동, 휠로 확대·축소합니다",
     "viewerCanvasHintTouch": "한 손가락으로 이동하고, 두 손가락으로 확대·축소합니다. 더블탭하면 화면에 맞춥니다.",
     "viewerFitAction": "전체 보기",
-    "viewerActualSizeAction": "실제 크기"
+    "viewerActualSizeAction": "실제 크기",
+    "responsivePreviewDesktop": "데스크톱",
+    "responsivePreviewTablet": "태블릿",
+    "responsivePreviewMobile": "모바일"
   }
 }

--- a/apps/web/src/components/canvas/artifact-expand-dialog.test.tsx
+++ b/apps/web/src/components/canvas/artifact-expand-dialog.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+//
+// story 3d0d60a3 — 반응형 미리보기 브레이크포인트 셀렉터. 셀렉터는 @media 판정이 참인 html
+// 포맷에서만 나타나고(고정폭·tree·image엔 부재 — disabled 아님), 클릭 시 ArtifactStage에
+// previewWidth를 흘려보내 실제 iframe 리플로우가 일어나는지까지 왕복 검증한다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import { ArtifactExpandDialog } from './artifact-expand-dialog';
+import koMessages from '../../../messages/ko.json';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const RESPONSIVE_HTML = '<style>@media (max-width: 600px) { .a { color: red } }</style><div class="a">hi</div>';
+const FIXED_HTML = '<div style="width:1280px">fixed</div>';
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+});
+
+async function mount(props: Partial<React.ComponentProps<typeof ArtifactExpandDialog>> = {}) {
+  await act(async () => {
+    root.render(wrap(
+      <ArtifactExpandDialog
+        open
+        onOpenChange={vi.fn()}
+        title="t"
+        format="html"
+        content={RESPONSIVE_HTML}
+        canvasBounds={{ w: 1280, h: 800 }}
+        {...props}
+      />,
+    ));
+  });
+}
+
+describe('ArtifactExpandDialog — 반응형 미리보기 브레이크포인트 셀렉터(story 3d0d60a3)', () => {
+  it('shows the breakpoint selector for @media-containing html content', async () => {
+    await mount();
+    const buttons = [...document.body.querySelectorAll('button')].map((b) => b.textContent);
+    expect(buttons).toContain('데스크톱');
+    expect(buttons).toContain('태블릿');
+    expect(buttons).toContain('모바일');
+  });
+
+  it('does not render the selector for fixed-width html (no @media — 부재, disabled 아님)', async () => {
+    await mount({ content: FIXED_HTML });
+    const buttons = [...document.body.querySelectorAll('button')].map((b) => b.textContent);
+    expect(buttons).not.toContain('태블릿');
+    expect(buttons).not.toContain('모바일');
+  });
+
+  it('does not render the selector for non-html formats even if the string happens to contain "@media"', async () => {
+    await mount({ format: 'tree', content: '[]' });
+    const buttons = [...document.body.querySelectorAll('button')].map((b) => b.textContent);
+    expect(buttons).not.toContain('태블릿');
+  });
+
+  it('clicking Mobile/Tablet swaps the rendered iframe width; Desktop restores the authored canvas_bounds width', async () => {
+    await mount();
+    const iframe = () => document.body.querySelector('iframe') as HTMLIFrameElement;
+    expect(iframe().style.width).toBe('1280px'); // 초기값=데스크톱(원본)
+
+    const mobileButton = [...document.body.querySelectorAll('button')].find((b) => b.textContent === '모바일')!;
+    await act(async () => { mobileButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(iframe().style.width).toBe('375px');
+
+    const tabletButton = [...document.body.querySelectorAll('button')].find((b) => b.textContent === '태블릿')!;
+    await act(async () => { tabletButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(iframe().style.width).toBe('768px');
+
+    const desktopButton = [...document.body.querySelectorAll('button')].find((b) => b.textContent === '데스크톱')!;
+    await act(async () => { desktopButton.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(iframe().style.width).toBe('1280px');
+  });
+});

--- a/apps/web/src/components/canvas/artifact-expand-dialog.tsx
+++ b/apps/web/src/components/canvas/artifact-expand-dialog.tsx
@@ -1,11 +1,14 @@
 'use client';
 
+import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
 import { cn } from '@/lib/utils';
-import { ArtifactStage } from './artifact-stage';
+import { ArtifactStage, isResponsiveHtml, RESPONSIVE_PREVIEW_BREAKPOINTS, type ResponsivePreviewBreakpoint } from './artifact-stage';
 import { ArtifactGalleryTimeline, type GalleryTimelineVersion } from './artifact-gallery-timeline';
 import type { ArtifactFormat } from '@/services/canvas';
+
+type PreviewBreakpoint = ResponsivePreviewBreakpoint | 'desktop';
 
 interface ArtifactExpandDialogProps {
   open: boolean;
@@ -35,6 +38,19 @@ export function ArtifactExpandDialog({
   open, onOpenChange, title, format, content, canvasBounds, versions, selectedVersion, onSelectVersion,
 }: ArtifactExpandDialogProps) {
   const t = useTranslations('canvas');
+  // story 3d0d60a3 — 반응형 미리보기. @media 판정=html 포맷에서만(유나 1순위·값싼 소스 파싱,
+  // 신규 BE 0). 판정 실패(고정폭)면 셀렉터 자체를 렌더하지 않는다(disabled 아님·부재 — no-fiction).
+  const showBreakpointSelector = format === 'html' && isResponsiveHtml(content);
+  const [breakpoint, setBreakpoint] = useState<PreviewBreakpoint>('desktop');
+  // 다른 버전/아트팩트로 전환되면 이전 브레이크포인트 선택이 새 콘텐츠에 그대로 남아있을
+  // 이유가 없다 — 매번 데스크톱(=원본 canvas_bounds)으로 리셋. effect가 아니라 렌더 중 조정
+  // (React 공식 "prop 변경 시 state 리셋" 패턴) — set-state-in-effect lint 대상이 아니다.
+  const [prevContent, setPrevContent] = useState(content);
+  if (content !== prevContent) {
+    setPrevContent(content);
+    setBreakpoint('desktop');
+  }
+  const previewWidth = breakpoint === 'desktop' ? undefined : RESPONSIVE_PREVIEW_BREAKPOINTS[breakpoint];
 
   return (
     <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
@@ -58,6 +74,23 @@ export function ArtifactExpandDialog({
               {t('closeAction')}
             </DialogPrimitive.Close>
           </div>
+          {showBreakpointSelector ? (
+            <div className="flex shrink-0 items-center gap-0.5 border-b border-border px-4 py-2">
+              {(['desktop', 'tablet', 'mobile'] as const).map((bp) => (
+                <button
+                  key={bp}
+                  type="button"
+                  onClick={() => setBreakpoint(bp)}
+                  className={cn(
+                    'rounded-md px-2.5 py-1.5 text-xs font-semibold transition-colors',
+                    breakpoint === bp ? 'bg-muted text-foreground' : 'text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  {t(`responsivePreview${bp[0]!.toUpperCase()}${bp.slice(1)}`)}
+                </button>
+              ))}
+            </div>
+          ) : null}
           {versions && versions.length > 1 ? (
             <ArtifactGalleryTimeline
               versions={versions}
@@ -67,7 +100,7 @@ export function ArtifactExpandDialog({
             />
           ) : null}
           <div className="min-h-0 flex-1 overflow-hidden p-4">
-            <ArtifactStage format={format} content={content} title={title} canvasBounds={canvasBounds} />
+            <ArtifactStage format={format} content={content} title={title} canvasBounds={canvasBounds} previewWidth={previewWidth} />
           </div>
         </DialogPrimitive.Popup>
       </DialogPrimitive.Portal>

--- a/apps/web/src/components/canvas/artifact-stage.test.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.test.tsx
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { NextIntlClientProvider } from 'next-intl';
-import { ArtifactStage } from './artifact-stage';
+import { ArtifactStage, isResponsiveHtml } from './artifact-stage';
 import koMessages from '../../../messages/ko.json';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
@@ -478,5 +478,37 @@ describe('ArtifactStage — 캔버스 뷰포트(story 1948d19d)', () => {
       expect(container.textContent).toContain('한 손가락으로 이동하고, 두 손가락으로 확대·축소합니다. 더블탭하면 화면에 맞춥니다.');
       expect(container.textContent).not.toContain('드래그로 이동, 휠로 확대·축소합니다');
     });
+  });
+
+  describe('반응형 미리보기(story 3d0d60a3) — previewWidth override는 iframe 자기 폭을 직접 교체한다(래퍼가 아니라, 구 토글 실패 원인 회피)', () => {
+    it('overrides both the content layer and the iframe itself to previewWidth, keeping the authored height', async () => {
+      await mount({ previewWidth: 375, canvasBounds: { w: 1280, h: 800 } });
+      const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+      const iframe = container.querySelector('iframe') as HTMLIFrameElement;
+      expect(content.style.width).toBe('375px');
+      expect(content.style.height).toBe('800px'); // 저작 높이 유지(cross-origin이라 리플로우 높이 측정 불가·정직 단순화)
+      expect(iframe.style.width).toBe('375px');
+      expect(iframe.style.height).toBe('800px');
+    });
+
+    it('falls back to the authored canvas_bounds width when previewWidth is absent (데스크톱=원본, override 부재)', async () => {
+      await mount({ canvasBounds: { w: 1280, h: 800 } });
+      const content = container.querySelector('[data-artifact-canvas-content]') as HTMLDivElement;
+      expect(content.style.width).toBe('1280px');
+    });
+  });
+});
+
+describe('isResponsiveHtml(story 3d0d60a3) — @media 소스 파싱(유나 1순위 판정, 신규 BE 0)', () => {
+  it('detects an actual @media rule with a body', () => {
+    expect(isResponsiveHtml('<style>@media (max-width: 600px) { .a { color: red } }</style>')).toBe(true);
+  });
+
+  it('does not false-positive on the bare word "@media" appearing without a rule body', () => {
+    expect(isResponsiveHtml('<p>이 문서는 @media 쿼리를 설명하는 글입니다</p>')).toBe(false);
+  });
+
+  it('returns false for fixed-width html with no media query at all (보수적 미노출, no-fiction)', () => {
+    expect(isResponsiveHtml('<div style="width:1280px">fixed</div>')).toBe(false);
   });
 });

--- a/apps/web/src/components/canvas/artifact-stage.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.tsx
@@ -57,6 +57,22 @@ export interface ArtifactTreeNode {
   children?: ArtifactTreeNode[];
 }
 
+// story 3d0d60a3 — 반응형 미리보기 브레이크포인트 프리셋. 데스크톱은 canvas_bounds.w 그대로라
+// 별도 프리셋이 없다(override 부재=데스크톱).
+export const RESPONSIVE_PREVIEW_BREAKPOINTS = { mobile: 375, tablet: 768 } as const;
+export type ResponsivePreviewBreakpoint = keyof typeof RESPONSIVE_PREVIEW_BREAKPOINTS;
+
+/**
+ * story 3d0d60a3 — 반응형 판정(유나 1순위: 소스 @media 파싱). html_blob은 iframe에 srcDoc으로
+ * 주입되기 전 우리 손 안의 문자열이라 cross-origin과 무관하게 값싸게 검사 가능(신규 BE 0).
+ * `@media` 뒤에 `{`가 오는지까지 확인해 "@media"라는 글자가 우연히 텍스트/주석에 등장하는
+ * false-positive를 줄인다. @media 없는 유동(flex/grid %) 레이아웃은 false-negative로 보수적
+ * 미노출 — PO/유나 확定(no-fiction: 과대 판정보다 과소 판정이 안전).
+ */
+export function isResponsiveHtml(content: string): boolean {
+  return /@media[^{}]*\{/i.test(content);
+}
+
 /** content 문자열을 tree 노드 배열로 안전 파싱 — 형태가 아니면 null(크래시 대신 폴백 렌더). */
 export function parseArtifactTree(content: string): ArtifactTreeNode[] | null {
   try {
@@ -107,6 +123,15 @@ interface ArtifactStageProps {
    * 이 ref로 캡처하면 자동으로 제외된다 — canvas_bounds 고정 width/height라 pan/zoom
    * transform만 캡처 직전 순간 정규화하면(canvas-export.ts) 아트보드 전체 프레임이 나온다. */
   contentRef?: React.RefObject<HTMLDivElement | null>;
+  /** story 3d0d60a3 — 반응형 미리보기 브레이크포인트 폭 override(html 포맷 전용, 뷰어 모달
+   * 브레이크포인트 셀렉터에서만 넘어온다). 넘어오면 `bounds.w`를 이 값으로 교체해 pan/zoom
+   * 엔진(fit/clampPan) 전부가 그대로 이 폭 기준으로 재계산되고, 콘텐츠 레이어와 iframe 자기
+   * 자신의 width가 함께 바뀌어 실제 리플로우가 일어난다(래퍼 폭만 바꾸던 구 토글의 실패
+   * 원인 회피 — 그라운딩 결론 그대로). 높이는 canvas_bounds.h 유지(iframe이 sandbox=""라
+   * 리플로우 후 실제 콘텐츠 높이를 부모가 측정할 방법이 없음 — cross-origin 격리, 정직 단순화).
+   * 저작 시점 canvasBounds 자체는 건드리지 않는다(핀 좌표·썸네일 등 다른 소비처와 무관).
+   */
+  previewWidth?: number;
 }
 
 /**
@@ -115,10 +140,11 @@ interface ArtifactStageProps {
  * 안쪽만 다름). sandbox 무완화 유지(iframe은 여전히 `sandbox=""`) — pointer-events:none이라
  * 상호작용 레이어와 물리적으로 분리되므로 완화할 필요 자체가 없다.
  */
-function CanvasViewport({ format, content, title, canvasBounds, overlay, mode = 'view', contentRef }: {
+function CanvasViewport({ format, content, title, canvasBounds, overlay, mode = 'view', contentRef, previewWidth }: {
   format: ArtifactFormat; content: string; title: string;
   canvasBounds?: { w: number; h: number } | null; overlay?: React.ReactNode; mode?: 'view' | 'edit';
   contentRef?: React.RefObject<HTMLDivElement | null>;
+  previewWidth?: number;
 }) {
   const t = useTranslations('canvas');
   // story 70a06b22 — 어제(74d6047e) 만든 터치 핀치/더블탭이 힌트 카피에 반영 안 된 발견성 갭
@@ -141,7 +167,10 @@ function CanvasViewport({ format, content, title, canvasBounds, overlay, mode = 
 
   // image=실측 우선(로드 후 자연 크기가 선언보다 정확) → 그 다음 선언된 canvas_bounds(§4,
   // BE #2135) → 마지막 포맷별 기본 아트보드(가짜 추정 아님·명시된 폴백 규약).
-  const bounds = format === 'image' && imageBounds ? imageBounds : (canvasBounds ?? DEFAULT_BOUNDS);
+  const authoredBounds = format === 'image' && imageBounds ? imageBounds : (canvasBounds ?? DEFAULT_BOUNDS);
+  // story 3d0d60a3 — previewWidth가 있으면 폭만 교체(높이는 저작 아트보드 그대로) — fit/pan/
+  // iframe 렌더 전부 이 하나의 bounds를 참조하므로 재계산 로직 추가 없이 재렌더가 성립한다.
+  const bounds = previewWidth != null ? { w: previewWidth, h: authoredBounds.h } : authoredBounds;
 
   useEffect(() => { setImageBounds(null); firedFitRef.current = false; }, [content]);
 
@@ -468,6 +497,6 @@ function TreeStageContent({ content, placeholder }: { content: string; placehold
  * allow-same-origin 둘 다 없음, 핸드오프 §3-1 + 유나 디자인 가디언 보안 지적 반영) 유지 —
  * pointer-events:none이 상호작용 레이어와 물리적으로 분리해 완화가 애초에 불필요.
  */
-export function ArtifactStage({ format, content, title, canvasBounds, overlay, mode, contentRef }: ArtifactStageProps) {
-  return <CanvasViewport format={format} content={content} title={title} canvasBounds={canvasBounds} overlay={overlay} mode={mode} contentRef={contentRef} />;
+export function ArtifactStage({ format, content, title, canvasBounds, overlay, mode, contentRef, previewWidth }: ArtifactStageProps) {
+  return <CanvasViewport format={format} content={content} title={title} canvasBounds={canvasBounds} overlay={overlay} mode={mode} contentRef={contentRef} previewWidth={previewWidth} />;
 }


### PR DESCRIPTION
## 요약
story `3d0d60a3` — doc `artifact-responsive-preview-spec` SSOT. #2139에서 무효화되어 제거했던 구 desktop/mobile 뷰포트 토글을, 실패 원인을 정확히 봉합한 새 설계로 부활.

**구 토글 실패 근본(그라운딩 확定)**: `el.style.width`를 캡처 대상 wrapper에 걸었지만, html iframe은 항상 자기 자신에 `style={{width: bounds.w}}`를 인라인 고정 선언하는 구조라 wrapper 폭 변경이 iframe까지 전파되지 않았다.

## 구현
- `ArtifactStage`/`CanvasViewport`에 `previewWidth?: number` prop 신설 — 넘어오면 `bounds.w`(iframe 자기 자신·pan/zoom fit·clampPan이 참조하는 단일 값)를 교체. 별도 재계산 없이 기존 pan/zoom 엔진 전체가 새 폭 기준으로 그대로 동작. 높이는 저작 canvas_bounds.h 유지(iframe sandbox=""라 리플로우 후 실제 높이를 부모가 측정 불가 — cross-origin 격리, 정직 단순화).
- `isResponsiveHtml()` — html_blob 소스에서 `@media ... {` 패턴 검사(cross-origin 무관, 신규 BE 0). @media 없으면 보수적 미노출(false-negative 수용, no-fiction).
- `ArtifactExpandDialog`에 브레이크포인트 셀렉터(데스크톱/태블릿/모바일 = 375/768/canvas_bounds.w) — html+반응형 판정 참인 콘텐츠에만 노출(고정폭엔 부재, disabled 아님).

## 정직 스코프 경계(PO 승인)
export 표면은 제외. PNG export가 html 포맷에 구조적으로 막힌 이유(`sandbox=""` cross-origin 격리)는 폭과 무관 — 브레이크포인트를 골라도 캡처는 여전히 불가능. sandbox 완화는 이미 배제된 보안 결정이라 LOW 스토리로 재고할 무게가 아님(그라운딩 단계에서 PO 확認 후 확定). HTML/PNG export 둘 다 현행 그대로, 회귀 0.

## 게이트
- vitest 1402 GREEN(회귀 0, 신규 9건)
- tsc --noEmit clean
- eslint 0
- `next build --webpack` EXIT=0(직접 캡처)

## 반응형 확인
셀렉터 UI는 모달 헤더 아래 새 row(기존 레이아웃 영향 0). previewWidth override는 뷰어 표면(모달)에만 적용되고 갤러리 카드 썸네일·인라인 뷰어 등 다른 ArtifactStage 소비처는 previewWidth를 넘기지 않아 무변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)