### PR TITLE
mute+webhook 동시보유 에이전트 총 무전달 재판정(story 75570ab8·E-CANVAS 잔여 BE)

### DIFF
--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -22,6 +22,28 @@ from app.services.webhook_targeting import active_webhook_member_ids
 logger = logging.getLogger(__name__)
 
 
+async def _query_muted_member_ids(
+    db: AsyncSession, member_ids: list[uuid.UUID],
+) -> set[uuid.UUID]:
+    """story 75570ab8: global mute(채널 막론) 멤버 집합 — 단일 조회로 SSOT화(이전엔
+    `_deliver_personal_webhooks`만 알고 있어서, mute+webhook 동시보유 에이전트가 Event-skip
+    판정(webhook이 커버한다고 가정)과 webhook mute-skip 둘 다에 걸려 **총 무전달**이었다).
+    호출자가 이 결과를 Event-skip 판정에도 반영해야 무음 조합이 사라진다."""
+    if not member_ids:
+        return set()
+    from app.models.notification_preference import NotificationPreference
+
+    rows = await db.execute(
+        select(NotificationPreference.member_id).where(
+            NotificationPreference.member_id.in_(member_ids),
+            NotificationPreference.scope_type == "global",
+            NotificationPreference.scope_id.is_(None),
+            NotificationPreference.level == "mute",
+        )
+    )
+    return {m for m in rows.scalars().all()}
+
+
 async def _deliver_personal_webhooks(
     db: AsyncSession,
     org_id: uuid.UUID,
@@ -33,6 +55,7 @@ async def _deliver_personal_webhooks(
     reference_type: str | None = None,
     reference_id: uuid.UUID | None = None,
     context: dict | None = None,
+    muted_member_ids: set[uuid.UUID] | None = None,
 ) -> None:
     """96af343e: 활성 개인(member-scoped) WebhookConfig 보유 휴먼에게 알림 webhook POST.
 
@@ -40,11 +63,14 @@ async def _deliver_personal_webhooks(
     (채널 막론 mute 우선). SSRF 검증·HMAC 서명·Discord URL 포맷·retry 는
     dispatch_router._post_with_retry / app.core.ssrf 재사용. agent SSE 경로
     (route_dispatch_event)는 미변경(무회귀). 개별 POST 실패는 swallow → in-app 무영향.
+
+    muted_member_ids: story 75570ab8 — 호출자(dispatch_notification)가 이미 계산한 mute
+    집합을 넘기면 재조회 생략(Event-skip 판정과 동일 SSOT 재사용, 드리프트 방지). None이면
+    이 함수가 자체 조회(단독 호출 하위호환).
     """
     if not member_ids:
         return
     from app.core.ssrf import validate_webhook_url_async
-    from app.models.notification_preference import NotificationPreference
     from app.services.dispatch_router import _post_with_retry
 
     wh_rows = await db.execute(
@@ -60,15 +86,10 @@ async def _deliver_personal_webhooks(
         return
 
     # global mute 멤버 skip (CP②: 채널 막론 mute 우선)
-    muted_rows = await db.execute(
-        select(NotificationPreference.member_id).where(
-            NotificationPreference.member_id.in_([c.member_id for c in configs]),
-            NotificationPreference.scope_type == "global",
-            NotificationPreference.scope_id.is_(None),
-            NotificationPreference.level == "mute",
-        )
-    )
-    muted = {m for m in muted_rows.scalars().all()}
+    if muted_member_ids is None:
+        muted = await _query_muted_member_ids(db, [c.member_id for c in configs])
+    else:
+        muted = muted_member_ids
 
     for cfg in configs:
         if cfg.member_id in muted:
@@ -163,6 +184,15 @@ async def dispatch_notification(
         webhook_member_ids = await active_webhook_member_ids(
             db, org_id, enabled_member_ids
         )
+        # story 75570ab8: mute+webhook 동시보유 재판정 — active_webhook_member_ids는 mute를
+        # 모른다. 그래서 muted 에이전트가 "webhook이 커버한다"고 오판돼 Event insert도 스킵되고,
+        # 뒤이어 _deliver_personal_webhooks 자체 mute 체크로 webhook도 스킵돼 **총 무전달**이었다
+        # (그라운딩 0f428e1e 때 확인한 dispatch_notification 경로 지식 재사용). mute의 옳은
+        # 의미론 = "능동 push(webhook)만 끔" — 수동 backlog(Event/poll_events로 나중에 발견 가능)
+        # 까지 지우면 안 됨(webhook_targeting.py 자체가 명시한 "silent loss 방지" 설계 철학과
+        # 정합). 따라서 muted 멤버는 webhook-covered 취급에서 제외해 Event insert 경로로 폴백.
+        muted_member_ids = await _query_muted_member_ids(db, list(webhook_member_ids))
+        event_skip_member_ids = webhook_member_ids - muted_member_ids
 
         # BUG-2 수정: user_id.isnot(None) 필터 제거 — agent는 user_id=NULL이므로 제외됐던 문제
         # type 및 project_id도 함께 조회
@@ -215,8 +245,9 @@ async def dispatch_notification(
         created_events: list[Event] = []  # L1 BE-3: fan-out 수렴용 event 수집
         for member_row in members:
             if member_row.type == "agent":
-                # 활성 웹훅 있는 에이전트 → 외부 채널로 전달되므로 내장 Event 스킵
-                if member_row.id in webhook_member_ids:
+                # 활성 웹훅 있는 에이전트 → 외부 채널로 전달되므로 내장 Event 스킵(단, muted면
+                # webhook도 안 나가므로 Event insert로 폴백 — 위 event_skip_member_ids 참고).
+                if member_row.id in event_skip_member_ids:
                     logger.debug(
                         "dispatch_notification: skip agent %s — has active webhook", member_row.id
                     )
@@ -301,6 +332,7 @@ async def dispatch_notification(
         await _deliver_personal_webhooks(
             db, org_id, webhook_deliver_ids, title=title, body=body, event_type=event_type,
             reference_type=reference_type, reference_id=reference_id, context=context,
+            muted_member_ids=muted_member_ids,
         )
 
     except Exception:

--- a/backend/tests/test_75570ab8_mute_webhook_edge_realdb.py
+++ b/backend/tests/test_75570ab8_mute_webhook_edge_realdb.py
@@ -1,0 +1,228 @@
+"""mute+webhook 동시보유 에이전트 총 무전달 재판정(story 75570ab8·E-CANVAS 잔여 BE). 실 PG.
+
+그라운딩(0f428e1e에서 확인한 dispatch_notification 경로 지식 재사용): `active_webhook_member_ids`는
+mute를 모른다 — muted 에이전트가 "webhook이 커버한다"고 오판돼 Event insert가 스킵되고,
+`_deliver_personal_webhooks`의 자체 mute 체크로 webhook도 스킵돼 **총 무전달**이었다.
+mute의 옳은 의미론 = 능동 push(webhook)만 끔·수동 backlog(Event)는 남겨 poll_events로 나중에
+발견 가능해야 함(webhook_targeting.py 자체가 명시한 "silent loss 방지" 철학과 정합)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project_agent(session):
+    from app.models.member import Member
+    from app.models.organization import Organization
+    from app.models.project import Project
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    agent = Member(id=uuid.uuid4(), org_id=org.id, type="agent", name="Agent", is_active=True)
+    session.add(agent)
+    await session.commit()
+    session.add(ProjectAccess(id=uuid.uuid4(), project_id=project.id, member_id=agent.id, permission="granted"))
+    await session.commit()
+
+    return {"org_id": org.id, "project_id": project.id, "agent_id": agent.id}
+
+
+async def _add_webhook(session, org_id, member_id, *, active=True):
+    from app.models.webhook_config import WebhookConfig
+    cfg = WebhookConfig(
+        id=uuid.uuid4(), org_id=org_id, member_id=member_id,
+        url="https://discord.com/api/webhooks/123/abc", channel="discord", is_active=active,
+    )
+    session.add(cfg)
+    await session.commit()
+    return cfg.id
+
+
+async def _add_global_mute(session, member_id):
+    from app.models.notification_preference import NotificationPreference
+    pref = NotificationPreference(
+        id=uuid.uuid4(), member_id=member_id, scope_type="global", scope_id=None,
+        channel="discord", level="mute",
+    )
+    session.add(pref)
+    await session.commit()
+    return pref.id
+
+
+@pytest.mark.anyio
+async def test_muted_agent_with_webhook_still_gets_event_fallback():
+    """핵심 회귀 케이스: mute+webhook 동시보유 → Event(pending)는 남아야 함(총 무전달 금지)."""
+    from sqlalchemy import select
+
+    from app.models.event import Event
+    from app.services.notification_dispatch import dispatch_notification
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_agent(s)
+            await _add_webhook(s, seeded["org_id"], seeded["agent_id"])
+            await _add_global_mute(s, seeded["agent_id"])
+
+        async with Session() as s:
+            await dispatch_notification(
+                s, org_id=seeded["org_id"], event_type="comment.created",
+                target_member_ids=[seeded["agent_id"]], title="T", body="B",
+                source_project_id=seeded["project_id"],
+            )
+            await s.commit()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Event).where(
+                    Event.org_id == seeded["org_id"], Event.recipient_id == seeded["agent_id"],
+                )
+            )).scalars().all()
+            assert len(rows) == 1, "muted+webhook 조합에서 Event 폴백이 없음 — 총 무전달 회귀"
+            assert rows[0].status == "pending"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unmuted_agent_with_webhook_skips_event_as_before():
+    """무회귀: mute 없는 webhook-agent는 기존대로 Event insert 스킵(webhook이 실제로 커버)."""
+    from sqlalchemy import select
+
+    from app.models.event import Event
+    from app.services.notification_dispatch import dispatch_notification
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_agent(s)
+            await _add_webhook(s, seeded["org_id"], seeded["agent_id"])
+
+        async with Session() as s:
+            await dispatch_notification(
+                s, org_id=seeded["org_id"], event_type="comment.created",
+                target_member_ids=[seeded["agent_id"]], title="T", body="B",
+                source_project_id=seeded["project_id"],
+            )
+            await s.commit()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Event).where(
+                    Event.org_id == seeded["org_id"], Event.recipient_id == seeded["agent_id"],
+                )
+            )).scalars().all()
+            assert rows == [], "webhook-only(무음소거) 에이전트는 Event insert 스킵이 기존 동작"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_muted_agent_without_webhook_still_gets_event_no_regression():
+    """무회귀: webhook 자체가 없는 muted 에이전트는 원래도 Event insert(mute가 이 경로엔
+    영향 없었음 — 이 케이스가 깨지면 내 변경이 범위를 넘어선 것)."""
+    from sqlalchemy import select
+
+    from app.models.event import Event
+    from app.services.notification_dispatch import dispatch_notification
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_agent(s)
+            await _add_global_mute(s, seeded["agent_id"])
+
+        async with Session() as s:
+            await dispatch_notification(
+                s, org_id=seeded["org_id"], event_type="comment.created",
+                target_member_ids=[seeded["agent_id"]], title="T", body="B",
+                source_project_id=seeded["project_id"],
+            )
+            await s.commit()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Event).where(
+                    Event.org_id == seeded["org_id"], Event.recipient_id == seeded["agent_id"],
+                )
+            )).scalars().all()
+            assert len(rows) == 1
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_inactive_webhook_treated_as_no_webhook_muted_agent_gets_event():
+    """비활성 webhook(is_active=False)은 애초 webhook_member_ids 밖 — muted 여부와 무관하게
+    Event insert(경계 확인)."""
+    from sqlalchemy import select
+
+    from app.models.event import Event
+    from app.services.notification_dispatch import dispatch_notification
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_project_agent(s)
+            await _add_webhook(s, seeded["org_id"], seeded["agent_id"], active=False)
+            await _add_global_mute(s, seeded["agent_id"])
+
+        async with Session() as s:
+            await dispatch_notification(
+                s, org_id=seeded["org_id"], event_type="comment.created",
+                target_member_ids=[seeded["agent_id"]], title="T", body="B",
+                source_project_id=seeded["project_id"],
+            )
+            await s.commit()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(Event).where(
+                    Event.org_id == seeded["org_id"], Event.recipient_id == seeded["agent_id"],
+                )
+            )).scalars().all()
+            assert len(rows) == 1
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
`active_webhook_member_ids`는 mute를 모른다 — muted 에이전트가 "webhook이 커버한다"고 오판돼 `dispatch_notification`의 Event insert가 스킵되고, 뒤이어 `_deliver_personal_webhooks`의 자체 mute 체크로 webhook도 스킵돼 **총 무전달**이었다(story `0f428e1e` 그라운딩에서 확인한 `dispatch_notification` 경로 지식 재사용).

**의미론 재판정**: mute = "능동 push(webhook)만 끔"이어야지 "이벤트 전달 자체를 지움"이면 안 됨 — 수동 backlog(Event → `poll_events`로 나중에 발견 가능)까지 지우면 워처·연결 관련자가 그 이벤트를 영구히 알 방법이 없어짐(`webhook_targeting.py` 자체가 명시한 "silent loss 방지" 설계 철학과 정합하는 선택).

## Changes
- `_query_muted_member_ids` 신설(`app/services/notification_dispatch.py`) — 기존 `_deliver_personal_webhooks` 인라인 mute 쿼리를 추출(SSOT화, 호출자와 결과 공유로 드리프트 방지).
- `dispatch_notification`이 `webhook_member_ids` 중 muted를 제외한 `event_skip_member_ids`로 Event-insert-skip 판정 — muted 에이전트는 webhook-covered 취급에서 빠져 Event insert 경로로 폴백.
- `_deliver_personal_webhooks`에 `muted_member_ids` 선택 파라미터 추가(호출자가 이미 계산한 결과를 재사용 — 재조회 생략. `None`이면 기존처럼 자체 조회해 단독 호출 하위호환).

## Test plan
- [x] realdb 신규 4건(`tests/test_75570ab8_mute_webhook_edge_realdb.py`): mute+webhook 동시보유 → Event 폴백 실증(핵심 회귀 케이스) · webhook만(mute 없음)은 기존대로 Event skip 무회귀 · webhook 자체 없는 muted 에이전트는 원래도 Event라 무회귀 · 비활성 webhook+muted 경계 확인.
- [x] 기존 스위트 무회귀: `test_personal_webhook_96af343e.py`(7건) · `test_notification_dispatch.py`(9건) · `test_webhook_targeting.py`(6건) · `test_e_canvas_c3_s7_artifact_edit_realdb.py`/`test_04e059e5_artifact_created_event_realdb.py`(dispatch_notification 실사용 AC4 케이스들, 무회귀 확인).
- [x] `python3 -m py_compile` 전 수정 파일.
- migration 불요(순수 로직 변경, 스키마/데이터 무변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)