### PR TITLE
prod P0 hotfix: docs 프로젝트 불일치 영구 고립 (cherry-pick #2154)

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { DocGateSection } from '@/components/docs/doc-gate-section';
 import { DocUrlChip } from '@/components/docs/doc-url-chip';
 import { DocUrlDialog, type SlugSubmitResult } from '@/components/docs/doc-url-dialog';
 import { slugifyDocTitle, isUntitledSlug } from '@/components/docs/lib/doc-slug';
+import { docsListUrl } from '@/components/docs/lib/doc-project-url';
 import { useDocSync, unwrapDocResponse, type SaveStatus } from '@/components/docs/use-doc-sync';
 import { htmlToMarkdown } from '@/components/docs/lib/content-converter';
 import Link from 'next/link';
@@ -185,13 +186,19 @@ export default function DocSlugPage() {
       // re-seeds the editor with an outdated baseline and can re-trigger an overwrite.
       const res = await fetch(`/api/docs?project_id=${projectId}&slug=${slug}`, { cache: 'no-store' });
       if (!res.ok) {
-        setSelectedDoc(null);
+        // prod P0(2026-07-14) — 이전엔 setSelectedDoc(null)만 하고 끝나 이 슬러그가 현재
+        // project_id에 없는(삭제됐든, project 전환 레이스로 어긋났든) 모든 경우가 회복 경로
+        // 없는 "문서를 찾을 수 없습니다" 정적 화면에 영구 고립됐다 — 새로고침도 같은
+        // project_id+slug 조합을 그대로 재질의할 뿐이라 무효(라이브 재현 완료). 이 slug가
+        // 지금 projectId엔 없다는 사실은 원인이 뭐든 동일하므로, 살아있는 목록으로 되돌려
+        // 회복 경로를 준다(진짜 없는 문서를 억지로 보여주지 않으면서도 dead-end는 피한다).
+        router.replace(docsListUrl(projectId));
         return;
       }
       const json = await res.json();
       const data = json?.data ?? null;
       if (!data) {
-        setSelectedDoc(null);
+        router.replace(docsListUrl(projectId));
         return;
       }
       setSelectedDoc(data);

--- a/apps/web/src/app/(authenticated)/docs/docs-client-layout.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-client-layout.tsx
@@ -21,6 +21,7 @@ import { ChevronDown, ChevronLeft, ChevronRight, FileText, Plus, X } from 'lucid
 import { useDashboardContext } from '../../dashboard/dashboard-shell';
 import { DocsLayoutContext, type Doc, type DocUpdate } from './docs-context';
 import { useSwipeDrawer } from '@/lib/use-swipe-drawer';
+import { newDocUrl, docUrl } from '@/components/docs/lib/doc-project-url';
 
 export function DocsClientLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
@@ -102,9 +103,11 @@ export function DocsClientLayout({ children }: { children: React.ReactNode }) {
 
   const handleSelectDoc = useCallback((slug: string) => {
     pushRecent(slug);
-    router.push(`/docs/${slug}`);
+    // prod P0(2026-07-14) — createDoc과 같은 버그 클래스(doc-project-url.ts 헤더 참고).
+    // projectId가 아직 해소 전(극단 엣지)이면 구 동작(?p= 없이 push)으로 안전 폴백.
+    router.push(projectId ? docUrl(slug, projectId) : `/docs/${slug}`);
     setTreeDrawerOpen(false);
-  }, [router, pushRecent]);
+  }, [router, pushRecent, projectId]);
 
   const handleReorder = useCallback(async (docId: string, newSortOrder: number) => {
     setTree((prev) => prev.map((doc) => (doc.id === docId ? { ...doc, sort_order: newSortOrder } : doc)));
@@ -161,7 +164,8 @@ export function DocsClientLayout({ children }: { children: React.ReactNode }) {
       if (!res.ok) throw new Error('Failed to create doc');
       const { data } = await res.json();
       setTree((prev) => [{ id: data.id, parent_id: data.parent_id || null, title: data.title, slug: data.slug, icon: data.icon || null, sort_order: data.sort_order || 0, is_folder: data.is_folder || false }, ...prev]);
-      router.push(`/docs/${data.slug}?new=1`);
+      // prod P0(2026-07-14) — doc-project-url.ts 헤더 코멘트 참고(레이스 근본).
+      router.push(newDocUrl(data.slug, projectId));
     } catch {
       addToast({ title: t('createFailed'), type: 'error' });
     } finally {

--- a/apps/web/src/components/docs/lib/doc-project-url.test.ts
+++ b/apps/web/src/components/docs/lib/doc-project-url.test.ts
@@ -1,0 +1,38 @@
+// prod P0(2026-07-14) — 실측 근본 회귀가드. `docs-client-layout.tsx`의 createDoc·
+// handleSelectDoc과 `[slug]/page.tsx`의 fetchDoc이 각각 이 세 헬퍼로 URL을 만든다 — 셋 다
+// `?p=`를 명시하는지가 정확히 이번 버그의 crux(생략하면 useProjectSsot의 fallback 체인이
+// 다시 태워져 다른 project로 재질의될 수 있음, dev 크로스-org 전환으로 라이브 재현 완료).
+import { describe, expect, it } from 'vitest';
+import { newDocUrl, docUrl, docsListUrl } from './doc-project-url';
+
+describe('newDocUrl — 신규 문서 생성 직후 이동 URL', () => {
+  it('includes ?p= with the exact project the doc was created under (레이스 근본 봉쇄)', () => {
+    expect(newDocUrl('untitled-123', 'proj-a')).toBe('/docs/untitled-123?new=1&p=proj-a');
+  });
+
+  it('never omits p= even for a project id that looks like a query-string edge case', () => {
+    const url = newDocUrl('untitled-999', 'proj-b');
+    const params = new URL(url, 'http://x').searchParams;
+    expect(params.get('p')).toBe('proj-b');
+    expect(params.get('new')).toBe('1');
+  });
+});
+
+describe('docUrl — 트리에서 기존 문서 선택 이동 URL (PO 스코프 확장 — createDoc과 같은 버그 클래스)', () => {
+  it('includes ?p= for the current project, without the new=1 auto-focus flag', () => {
+    expect(docUrl('existing-doc', 'proj-a')).toBe('/docs/existing-doc?p=proj-a');
+  });
+
+  it('never carries new=1 (would incorrectly re-trigger new-doc auto-focus for an existing doc)', () => {
+    const url = docUrl('existing-doc', 'proj-b');
+    const params = new URL(url, 'http://x').searchParams;
+    expect(params.get('p')).toBe('proj-b');
+    expect(params.has('new')).toBe(false);
+  });
+});
+
+describe('docsListUrl — not-found 회복 리다이렉트 URL', () => {
+  it('points back to the docs list scoped to the current (correct) project', () => {
+    expect(docsListUrl('proj-c')).toBe('/docs?p=proj-c');
+  });
+});

--- a/apps/web/src/components/docs/lib/doc-project-url.ts
+++ b/apps/web/src/components/docs/lib/doc-project-url.ts
@@ -1,0 +1,24 @@
+/**
+ * prod P0(2026-07-14) — `?p=`(useProjectSsot의 탭별 SSOT)를 안 실은 채 `/docs/*`로 push하면
+ * urlProjectId가 없다고 판단한 자가치유 effect가 fallback 체인(sessionStorage→serverProjectId)을
+ * 다시 태운다. 그 fallback이 지금 이 탭이 실제로 쓰던 project와 항상 같다는 보장이 없어
+ * (특히 org 전환 직후 — accessibleIds가 서버 prop 기반이라 새 project를 아직 못 담고 있을 수
+ * 있음), 방금 만든/보던 문서와 다른 project로 재질의돼 "문서를 찾을 수 없습니다"에 빠질 수
+ * 있다(dev 크로스-org 전환으로 라이브 재현 완료). 세 호출부(신규 문서 생성 이동·트리에서
+ * 기존 문서 선택 이동·not-found 회복 이동) 모두 `?p=`를 명시해 이 fallback 자체가 발동하지
+ * 않게 한다(PO 지시 — createDoc만 고치고 형제 경로인 handleSelectDoc을 남기면 같은 버그
+ * 클래스의 부분수정=재발 씨앗). 순수 함수로 뽑아 세 지점에서 동일 규약을 강제하고 단위
+ * 테스트로 직접 검증한다.
+ */
+export function newDocUrl(slug: string, projectId: string): string {
+  return `/docs/${slug}?new=1&p=${projectId}`;
+}
+
+/** 트리에서 기존 문서를 선택할 때 — newDocUrl과 달리 `new=1`(자동 포커스 트리거)을 안 싣는다. */
+export function docUrl(slug: string, projectId: string): string {
+  return `/docs/${slug}?p=${projectId}`;
+}
+
+export function docsListUrl(projectId: string): string {
+  return `/docs?p=${projectId}`;
+}


### PR DESCRIPTION
prod P0 핫픽스 — selective 승격(#2154만·FE-only·마이그 0).

근본: docs 프로젝트 컨텍스트 stale — 새 문서 생성/기존 문서 선택 URL에 ?p= 누락 + 프로젝트 불일치 시 [slug] 페이지 복구 가드 부재로 '문서를 찾을 수 없습니다' 영구 고립·새로고침 유실.

fix: createDoc·handleSelectDoc·fetchDoc 회복 3 진입점이 doc-project-url.ts 순수 함수(newDocUrl/docUrl/docsListUrl) 규약 공유(?p= 보존) + fetchDoc 실패 시 /docs 목록 리다이렉트.

검증: 유나 UX 가디언 GREEN + 까심 QA APPROVE(?p= 보존 sabotage 2건·회귀 0) + dev E2E PASS(새 문서 ?p= 보존·불일치 slug→목록 복귀).

A(unified-switcher 전역 pathname 보존)는 별건(f401139e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)