### PR TITLE
prod 승격: E-EVENTBUS wake 무음 fix (cherry-pick #2157·BE-only·마이그0)

### DIFF
--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict, field_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,6 +13,7 @@ from app.dependencies.auth import get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.doc import Doc
 from app.models.gate import Gate, is_valid_transition
+from app.routers.agent_gateway import wake_agent
 from app.services.gate_service import (
     create_gate,
     hold_gate,
@@ -22,6 +23,22 @@ from app.services.gate_service import (
 )
 from app.services.member_resolver import resolve_member
 from app.services.project_auth import has_project_access, is_org_owner, is_org_owner_or_admin
+
+
+def _schedule_pending_deliveries(
+    background_tasks: BackgroundTasks, pending_deliveries: list[dict],
+) -> None:
+    """ccbcd9da(A-1): transition_gate/override_gate 가 모은 wake/delivery 페이로드를 commit 후
+    발화(#1364/relay_agent_handoff 선례 동형 — recipient_seq 확정 commit 후 wake 불변식)."""
+    from app.services.conversation_webhook import deliver_injected_event_webhook
+
+    for payload in pending_deliveries:
+        agent_wake = payload.get("agent_wake")
+        if agent_wake:
+            wake_agent(agent_wake["recipient_id"], agent_wake["recipient_seq"])
+        delivery = payload.get("delivery")
+        if delivery:
+            background_tasks.add_task(deliver_injected_event_webhook, **delivery)
 
 logger = logging.getLogger(__name__)
 
@@ -245,6 +262,7 @@ async def list_gates(
 async def transition_gate_endpoint(
     id: uuid.UUID,
     body: GateTransitionRequest,
+    background_tasks: BackgroundTasks,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth=Depends(get_current_user),
@@ -286,9 +304,15 @@ async def transition_gate_endpoint(
     # ⭐S23 RC① + RC#1(방어심층): resolver_id 를 **전 status 무조건 인증 caller 로 강제**(body 무시).
     # body 조작(타인 UUID)으로 SoD(approver≠owner) 우회·confirmed_by_member_id 위조 차단.
     _resolver_id = resolved.id
+    _pending_deliveries: list[dict] = []
     try:
-        gate = await transition_gate(session, org_id, id, body.status, _resolver_id, body.note)
+        gate = await transition_gate(
+            session, org_id, id, body.status, _resolver_id, body.note,
+            pending_deliveries=_pending_deliveries,
+        )
         await session.commit()
+        # ccbcd9da(A-1): doc/epic 자동재개 wake — commit(recipient_seq 확정) 후 발화(이중전달 방지).
+        _schedule_pending_deliveries(background_tasks, _pending_deliveries)
         return GateResponse.model_validate(gate)
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))
@@ -474,6 +498,7 @@ async def _require_gate_owner(session, auth, org_id):
 async def override_gate_endpoint(
     id: uuid.UUID,
     body: GateOverrideRequest,
+    background_tasks: BackgroundTasks,
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth=Depends(get_current_user),
@@ -482,9 +507,15 @@ async def override_gate_endpoint(
     reason 필수·owner_id=인증 caller 강제(S23 RC①)·정상 결재(quorum/SoD) 우회. 가장 민감한 액션."""
     from app.services.gate_service import override_gate
     resolved = await _require_gate_owner(session, auth, org_id)
+    _pending_deliveries: list[dict] = []
     try:
-        gate = await override_gate(session, org_id, id, resolved.id, body.decision, body.reason)
+        gate = await override_gate(
+            session, org_id, id, resolved.id, body.decision, body.reason,
+            pending_deliveries=_pending_deliveries,
+        )
         await session.commit()
+        # ccbcd9da(A-1): override 도 transition_gate 재사용 경로라 동일하게 doc/epic wake 대상.
+        _schedule_pending_deliveries(background_tasks, _pending_deliveries)
         return GateResponse.model_validate(gate)
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e))

--- a/backend/app/services/agent_dispatch.py
+++ b/backend/app/services/agent_dispatch.py
@@ -116,6 +116,95 @@ async def _fetch_entity(
     return r[0], r[1], r[2], r[3]
 
 
+async def _finalize_dispatch(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID | None,
+    entity_type: str,
+    entity_id: uuid.UUID,
+    recipient_id: uuid.UUID,
+    member_type: str,
+    sender_id: uuid.UUID | None,
+    payload: dict[str, Any],
+    content: str,
+    title: str,
+    message: str | None,
+    commit: bool,
+    hypothesis_anchor: dict[str, Any] | None = None,
+    context_pack: str | None = None,
+) -> tuple[DispatchResponse, dict[str, Any] | None]:
+    """ccbcd9da(A-2): Event 생성+flush+seq+활동추출+notification+(commit 시)wake 의 **단일 공통 경로**.
+
+    ``dispatch_entity_to_assignee``/``dispatch_payload_to_member`` 두 형제함수가 이 로직을 각자
+    따로 구현해온 것 자체가 재발 원인(#1364 는 한쪽만 고쳐짐 — [[project_dispatch_payload_to_member_silent_gap]]).
+    이후 이 경로를 고치면 두 형제 모두 자동 반영돼 재이원화가 구조적으로 불가능해진다.
+
+    commit=False 면 여기서 commit/wake 하지 않는다(호출자 트랜잭션 합류·P1-2) — 단 delivery 는
+    **항상** 반환하므로 호출자가 자기 commit 후 스케줄한다(#1364 선례와 동일 계약).
+    """
+    event = Event(
+        project_id=project_id,
+        org_id=org_id,
+        event_type=EventType.dispatched.value,
+        source_entity_type=entity_type,
+        source_entity_id=entity_id,
+        sender_id=sender_id,
+        recipient_id=recipient_id,
+        recipient_type=member_type,
+        payload=payload,
+        status="pending",
+    )
+    db.add(event)
+    await db.flush()
+    if member_type == "agent":
+        await assign_recipient_seq(db, event)
+
+    await extract_activities_best_effort(db, [event.id])
+
+    if member_type != "agent":
+        await dispatch_notification(
+            db,
+            org_id=org_id,
+            event_type="dispatched",
+            target_member_ids=[recipient_id],
+            title=title,
+            body=message or None,
+            reference_type=entity_type,
+            reference_id=entity_id,
+        )
+
+    if commit:
+        await db.commit()  # commit 후 seq 확정
+        if member_type == "agent":
+            if event.recipient_seq is not None:
+                wake_agent(str(recipient_id), event.recipient_seq)
+            else:
+                _push_to_agent(str(recipient_id), _event_to_payload(event))
+
+    response = DispatchResponse(
+        dispatched=True,
+        event_id=event.id,
+        assignee_id=recipient_id,
+        assignee_type=member_type,
+        recipient_seq=event.recipient_seq,
+        reason="ok",
+    )
+    # 1f01c1ad: CC 릴레이(member webhook) 주입 파라미터 — 호출자가 스케줄(commit=True 도 delivery
+    # 는 항상 반환·라우터가 background_tasks 로 스케줄하는 기존 계약 유지).
+    delivery = {
+        "org_id": org_id,
+        "recipient_id": recipient_id,
+        "content": content,
+        "event_type": "dispatched",
+        "source_entity_type": entity_type,
+        "source_entity_id": entity_id,
+        "hypothesis_anchor": hypothesis_anchor,
+        "context_pack": context_pack,
+    }
+    return response, delivery
+
+
 async def dispatch_entity_to_assignee(
     db: AsyncSession,
     org_id: uuid.UUID,
@@ -185,71 +274,26 @@ async def dispatch_entity_to_assignee(
     if trigger_metadata is not None:
         payload["trigger_metadata"] = trigger_metadata  # AC③: L2 트리거 출처 additive
 
-    event = Event(
-        project_id=project_id,
-        org_id=org_id,
-        event_type=EventType.dispatched.value,
-        source_entity_type=entity_type,
-        source_entity_id=entity_id,
-        sender_id=sender_id,
-        recipient_id=assignee_id,
-        recipient_type=member_type,
-        payload=payload,
-        status="pending",
-    )
-    db.add(event)
-    await db.flush()
-    # per-recipient dense seq 발급 (agent recipient만 — commit 순서 직렬화 보장)
-    if member_type == "agent":
-        await assign_recipient_seq(db, event)
-
-    # L1 BE-3: direct dispatch event → activity_events 1행(best-effort·delivery 무영향).
-    await extract_activities_best_effort(db, [event.id])
-
-    if member_type != "agent":
-        await dispatch_notification(
-            db,
-            org_id=org_id,
-            event_type="dispatched",
-            target_member_ids=[assignee_id],
-            title=f"[{entity_type}] {title}",
-            body=message or (description or "")[:200] or None,
-            reference_type=entity_type,
-            reference_id=entity_id,
-        )
-
     # E-DG S7: commit=False면 호출자 트랜잭션에 합류 — 여기서 commit/wake 하지 않는다(P1-2
     # partial-failure 방지). 호출자가 status/step_run/event 를 한 트랜잭션으로 commit 한 뒤 wake 한다
-    # (recipient_seq 확정 commit 후 wake 불변식). event.id/recipient_seq 는 위 flush 로 이미 확정.
-    if commit:
-        await db.commit()  # commit 후 seq 확정
-        # agent: commit 후 wake (gateway_seq 확정 보장, 이중전달 방지)
-        if member_type == "agent":
-            if event.recipient_seq is not None:
-                wake_agent(str(assignee_id), event.recipient_seq)
-            else:
-                _push_to_agent(str(assignee_id), _event_to_payload(event))
-
-    response = DispatchResponse(
-        dispatched=True,
-        event_id=event.id,
-        assignee_id=assignee_id,
-        assignee_type=member_type,
-        recipient_seq=event.recipient_seq,
-        reason="ok",
+    # (recipient_seq 확정 commit 후 wake 불변식).
+    return await _finalize_dispatch(
+        db,
+        org_id=org_id,
+        project_id=project_id,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        recipient_id=assignee_id,
+        member_type=member_type,
+        sender_id=sender_id,
+        payload=payload,
+        content=content,
+        title=f"[{entity_type}] {title}",
+        message=message or (description or "")[:200] or None,
+        commit=commit,
+        hypothesis_anchor=hypothesis_anchor,
+        context_pack=context_pack,
     )
-    # 1f01c1ad: CC 릴레이(member webhook) 주입 파라미터 — 호출자가 스케줄(라우터=background_tasks).
-    delivery = {
-        "org_id": org_id,
-        "recipient_id": assignee_id,
-        "content": content,
-        "event_type": "dispatched",
-        "source_entity_type": entity_type,
-        "source_entity_id": entity_id,
-        "hypothesis_anchor": hypothesis_anchor,
-        "context_pack": context_pack,
-    }
-    return response, delivery
 
 
 async def dispatch_payload_to_member(
@@ -266,14 +310,18 @@ async def dispatch_payload_to_member(
     trigger_metadata: dict[str, Any] | None = None,
     sender_id: uuid.UUID | None = None,
     commit: bool = True,
-) -> DispatchResponse:
+) -> tuple[DispatchResponse, dict[str, Any] | None]:
     """S22: entity assignee 와 무관하게 **특정 member**(예: doc author=created_by)에게 dispatched
-    이벤트 생성 + (agent) wake. ``dispatch_entity_to_assignee`` 의 member-dispatch core 를 author-wake
-    용으로 분리한 lower-level helper(assignee 고정 우회). 순서/불변식 동일(flush→seq→commit 후 wake).
-    ⚠️ commit=False 면 호출자 트랜잭션 합류(여기서 commit/wake 안 함·P1-2)."""
+    이벤트 생성 + notification(human) + (agent) wake. ``dispatch_entity_to_assignee`` 와 동일한
+    ``_finalize_dispatch`` 공통 경로 사용(ccbcd9da A-2 — 형제함수 이원화가 #1364 부분수정 재발 원인).
+
+    반환: (DispatchResponse, delivery) — ``dispatch_entity_to_assignee`` 와 동형 계약. delivery 는
+    commit 여부와 무관하게 dispatched=True 일 때 항상 반환되므로, commit=False 호출자는 **자기
+    commit 후** delivery 로 wake/webhook 을 스케줄해야 한다(전엔 이 반환 자체가 없어 무음이었음).
+    ⚠️ commit=False 면 여기서 commit/wake 하지 않는다(호출자 트랜잭션 합류·P1-2)."""
     member = await resolve_member_identity(member_id, org_id, db)
     if member is None:
-        return DispatchResponse(dispatched=False, assignee_id=member_id, reason="unresolved_member")
+        return DispatchResponse(dispatched=False, assignee_id=member_id, reason="unresolved_member"), None
     member_type = member.type
 
     payload: dict[str, Any] = {
@@ -287,32 +335,18 @@ async def dispatch_payload_to_member(
     if trigger_metadata is not None:
         payload["trigger_metadata"] = trigger_metadata  # 새 event type 금지·trigger_metadata additive
 
-    event = Event(
-        project_id=project_id,
+    return await _finalize_dispatch(
+        db,
         org_id=org_id,
-        event_type=EventType.dispatched.value,
-        source_entity_type=source_entity_type,
-        source_entity_id=source_entity_id,
-        sender_id=sender_id,
+        project_id=project_id,
+        entity_type=source_entity_type,
+        entity_id=source_entity_id,
         recipient_id=member_id,
-        recipient_type=member_type,
+        member_type=member_type,
+        sender_id=sender_id,
         payload=payload,
-        status="pending",
-    )
-    db.add(event)
-    await db.flush()
-    if member_type == "agent":
-        await assign_recipient_seq(db, event)
-    await extract_activities_best_effort(db, [event.id])
-
-    if commit:
-        await db.commit()
-        if member_type == "agent":
-            if event.recipient_seq is not None:
-                wake_agent(str(member_id), event.recipient_seq)
-            else:
-                _push_to_agent(str(member_id), _event_to_payload(event))
-    return DispatchResponse(
-        dispatched=True, event_id=event.id, assignee_id=member_id,
-        assignee_type=member_type, recipient_seq=event.recipient_seq, reason="ok",
+        content=content,
+        title=title,
+        message=message,
+        commit=commit,
     )

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -111,8 +111,14 @@ async def transition_gate(
     new_status: str,
     resolver_id: uuid.UUID | None = None,
     note: str | None = None,
+    *,
+    pending_deliveries: list[dict[str, Any]] | None = None,
 ) -> Gate:
-    """게이트 상태 전이 — 불법 전이 시 ValueError 발생."""
+    """게이트 상태 전이 — 불법 전이 시 ValueError 발생.
+
+    ``pending_deliveries``(ccbcd9da A-1, additive): 넘기면 line resolution(doc/epic 자동재개)이 만든
+    wake/delivery 페이로드를 append — 호출자가 자기 commit 후 wake_agent/webhook 스케줄(#1364 선례
+    동형). 생략(기존 호출자 전부)은 무변경(수집 안 함·이 함수 자체는 commit 하지 않음)."""
     gate_r = await session.execute(
         select(Gate).where(Gate.id == gate_id, Gate.org_id == org_id)
     )
@@ -158,7 +164,11 @@ async def transition_gate(
 
     _line_step_run_id = await find_active_step_run_for_gate(session, org_id, gate.id)
     if _line_step_run_id is not None:
-        await apply_workflow_line_resolution(session, _line_step_run_id, new_status, resolver_id=resolver_id)
+        _wake_payload = await apply_workflow_line_resolution(
+            session, _line_step_run_id, new_status, resolver_id=resolver_id
+        )
+        if _wake_payload is not None and pending_deliveries is not None:
+            pending_deliveries.append(_wake_payload)
     else:
         # H1-FIX-2: merge 게이트 approve → work item 스토리를 done으로 진행(_preflight 재평가 우회).
         await _advance_story_on_merge_approve(session, gate, new_status)
@@ -607,6 +617,8 @@ async def override_gate(
     owner_id: uuid.UUID,
     decision: str,
     reason: str,
+    *,
+    pending_deliveries: list[dict[str, Any]] | None = None,
 ) -> Gate:
     """⭐E-DG S33 owner force-resolve: owner(최종권한자)가 막힌/긴급 gate 를 **강제 결정**한다.
 
@@ -653,7 +665,10 @@ async def override_gate(
         )).scalar_one_or_none()
 
     # ⭐force-resolve: quorum/SoD 우회·S6 hook 라인전이 자동 적용.
-    await transition_gate(session, org_id, gate_id, decision, resolver_id=owner_id, note=reason)
+    await transition_gate(
+        session, org_id, gate_id, decision, resolver_id=owner_id, note=reason,
+        pending_deliveries=pending_deliveries,
+    )
 
     # parallel approver row 닫기(overridden·강제 닫힘이지 승인 아님·dangling/SLA 방지).
     now = datetime.now(timezone.utc)

--- a/backend/app/services/workflow_line_resolution.py
+++ b/backend/app/services/workflow_line_resolution.py
@@ -114,9 +114,44 @@ async def _apply_hypothesis_active(
     await session.flush()
 
 
+async def _schedule_member_dispatch(
+    session: AsyncSession, org_id: uuid.UUID, member_id: uuid.UUID, *,
+    title: str, content: str, source_entity_type: str, source_entity_id: uuid.UUID,
+    project_id: uuid.UUID | None, trigger_metadata: dict[str, Any],
+) -> dict[str, Any] | None:
+    """ccbcd9da(A-1): dispatch_payload_to_member(commit=False) 호출을 SAVEPOINT 로 격리하고
+    delivery/agent_wake 페이로드를 호출자(gates.py commit 지점)에게 반환 — #1364/relay_agent_handoff
+    선례와 동형(발명 0). 실패해도 gate 승인 자체는 비차단(fail-open·[[feedback_savepoint_failopen_session_poison]])."""
+    from app.services.agent_dispatch import dispatch_payload_to_member
+
+    try:
+        async with session.begin_nested():
+            resp, delivery = await dispatch_payload_to_member(
+                session, org_id, member_id,
+                title=title, content=content,
+                source_entity_type=source_entity_type, source_entity_id=source_entity_id,
+                project_id=project_id, trigger_metadata=trigger_metadata, commit=False,
+            )
+    except Exception:  # noqa: BLE001 — dispatch 실패도 gate 승인 비차단(fail-open).
+        logger.warning(
+            "workflow_line dispatch 실패(비중단) org=%s member=%s entity=%s/%s",
+            org_id, member_id, source_entity_type, source_entity_id, exc_info=True,
+        )
+        return None
+    if not resp.dispatched:
+        return None
+    return {
+        "agent_wake": (
+            {"recipient_id": str(resp.assignee_id), "recipient_seq": resp.recipient_seq}
+            if resp.assignee_type == "agent" and resp.recipient_seq is not None else None
+        ),
+        "delivery": delivery,
+    }
+
+
 async def _apply_doc_confirmed(
     session: AsyncSession, sr: WorkflowLineStepRun, resolver_id: uuid.UUID | None
-) -> None:
+) -> dict[str, Any] | None:
     """S22: doc draft→confirmed gate 승인 적용. native ``transition_doc`` 재사용(parallel 0). ⭐SoD:
     approver ≠ doc.created_by(author·자기 doc 자기 confirm 차단). 승인 후 author(created_by) 자동재개
     wake(commit=False·gate 트랜잭션 합류·§6 dispatch tx commit 0)."""
@@ -131,17 +166,17 @@ async def _apply_doc_confirmed(
         sr.status = "approved"
         sr.resolved_at = _now()
         await session.flush()
-        return
+        return None
     if doc.status == "confirmed":  # 멱등: 이미 confirmed → no-op.
         sr.status = "applied"
         sr.resolved_at = _now()
         await session.flush()
-        return
+        return None
     if doc.status != "draft":  # stale: draft 아니면 미적용.
         sr.status = "skipped"
         sr.resolved_at = _now()
         await session.flush()
-        return
+        return None
     # ⭐SoD(RC②): approver 미상 OR author 불명(created_by None) OR author 자신이면 차단. ⚠️created_by
     # None 을 fail-closed 로 막지 않으면 created_by=null doc 생성 후 self-confirm 으로 SoD 우회([[feedback_actor_type_failclosed]]).
     if resolver_id is None or doc.created_by is None or resolver_id == doc.created_by:
@@ -151,30 +186,31 @@ async def _apply_doc_confirmed(
         logger.warning(
             "doc_confirm_sod_block sr=%s approver=%s author=%s", sr.id, resolver_id, doc.created_by,
         )
-        return
+        return None
     approver = ResolvedMember(
         id=resolver_id, user_id=None, name="gate_approver", type="human", role="member",
         org_id=sr.org_id,
     )
     await transition_doc(session, sr.org_id, approver, doc.id, "confirmed", via_gate=True)
-    # author 자동재개(success_hypothesis): created_by 에게 dispatched 이벤트(commit=False → gate
-    # 트랜잭션 합류·gates.py:137 commit 후 agent 가 consume·새 event type 0·trigger_metadata만).
+    # author 자동재개(ccbcd9da): created_by 에게 dispatched 이벤트(commit=False → gate 트랜잭션 합류·
+    # gates.py commit 후 호출자가 wake/webhook 스케줄·새 event type 0·trigger_metadata만).
+    wake_payload = None
     if doc.created_by is not None:
-        from app.services.agent_dispatch import dispatch_payload_to_member
-        await dispatch_payload_to_member(
+        wake_payload = await _schedule_member_dispatch(
             session, sr.org_id, doc.created_by,
             title=doc.title or "doc", content=f"[doc confirmed] {doc.title or ''}".strip(),
             source_entity_type="doc", source_entity_id=doc.id, project_id=doc.project_id,
-            trigger_metadata={"source": "workflow_line", "reason": "doc_confirmed"}, commit=False,
+            trigger_metadata={"source": "workflow_line", "reason": "doc_confirmed"},
         )
     sr.status = "applied"
     sr.resolved_at = _now()
     await session.flush()
+    return wake_payload
 
 
 async def _apply_epic_transition(
     session: AsyncSession, sr: WorkflowLineStepRun, resolver_id: uuid.UUID | None
-) -> None:
+) -> dict[str, Any] | None:
     """S25: epic draft→active / active→done gate 승인 적용. native ``transition_epic``(via_gate) 재사용
     (parallel 0). ⭐SoD(draft→active activation 만): approver ≠ epic.assignee_id(owner proxy·fail-closed).
     ⚠️epic assignee 흔히 null→enforcing 시 과차단 — enforcing 전 SoD 대상 project owner 로 정교화 필요
@@ -190,17 +226,17 @@ async def _apply_epic_transition(
         sr.status = "approved"
         sr.resolved_at = _now()
         await session.flush()
-        return
+        return None
     if epic.status == sr.to_status:  # 멱등
         sr.status = "applied"
         sr.resolved_at = _now()
         await session.flush()
-        return
+        return None
     if sr.from_status is not None and epic.status != sr.from_status:  # stale
         sr.status = "skipped"
         sr.resolved_at = _now()
         await session.flush()
-        return
+        return None
     # ⭐SoD(RC#2): activation(draft→active)만·approver ≠ **project owner** 강제(self-activation 차단·
     # fail-closed). epic.assignee_id(흔히 null→과차단·line 180 주석) 대신 project_auth SSOT relay-owner
     # 사용(null-의존 제거·robust). [[feedback_relay_owner_project_auth_ssot]].
@@ -215,24 +251,26 @@ async def _apply_epic_transition(
                 "epic_activation_sod_block sr=%s approver=%s owner=%s",
                 sr.id, resolver_id, _sod_owner,
             )
-            return
+            return None
     approver = ResolvedMember(
         id=resolver_id, user_id=None, name="gate_approver", type="human", role="member",
         org_id=sr.org_id,
     )
     await transition_epic(session, sr.org_id, approver, epic.id, sr.to_status, via_gate=True)
-    # assignee 자동재개: epic assignee 에게 dispatched(commit=False·gate 트랜잭션 합류·§6 tx commit 0).
+    # assignee 자동재개(ccbcd9da): epic assignee 에게 dispatched(commit=False·gate 트랜잭션 합류·
+    # 호출자가 commit 후 wake/webhook 스케줄).
+    wake_payload = None
     if epic.assignee_id is not None:
-        from app.services.agent_dispatch import dispatch_payload_to_member
-        await dispatch_payload_to_member(
+        wake_payload = await _schedule_member_dispatch(
             session, sr.org_id, epic.assignee_id,
             title=epic.title or "epic", content=f"[epic {sr.to_status}] {epic.title or ''}".strip(),
             source_entity_type="epic", source_entity_id=epic.id, project_id=epic.project_id,
-            trigger_metadata={"source": "workflow_line", "reason": f"epic_{sr.to_status}"}, commit=False,
+            trigger_metadata={"source": "workflow_line", "reason": f"epic_{sr.to_status}"},
         )
     sr.status = "applied"
     sr.resolved_at = _now()
     await session.flush()
+    return wake_payload
 
 
 async def _apply_sprint_transition(
@@ -283,23 +321,26 @@ async def _apply_sprint_transition(
 async def apply_workflow_line_resolution(
     session: AsyncSession, step_run_id: uuid.UUID, new_status: str,
     resolver_id: uuid.UUID | None = None,
-) -> None:
+) -> dict[str, Any] | None:
     """gate 해소(approved|rejected)를 line step_run 정책대로 적용.
 
     approve + ``on_approve.apply_transition=true`` → story 를 step_run.to_status 로 전이(H1 과 동일
     ``emit_story_status_changed`` 경로). reject → Phase1 기본 in-review 유지(status set/relay 안 함).
     row lock + stale from_status 미적용(P1-1).
+
+    반환(ccbcd9da A-1): doc/epic 자동재개가 만든 wake/delivery 페이로드(``{agent_wake, delivery}``)
+    또는 None(dispatch 없음). 호출자(``transition_gate``)가 commit 후 wake/webhook 스케줄한다.
     """
     sr = (await session.execute(
         select(WorkflowLineStepRun).where(WorkflowLineStepRun.id == step_run_id).with_for_update()
     )).scalar_one_or_none()
     if sr is None:
-        return
+        return None
     # S21: story 외 엔티티는 readiness matrix gating_eligible 로 판정(현 story 만)·미지원은 로그+no-op.
     _desc = get_readiness(sr.entity_type)
     if _desc is None or not _desc.gating_eligible:
         record_unsupported_entity_attempt(sr.entity_type, sr.from_status, sr.to_status, sr.entity_id)
-        return
+        return None
     step = await _step_config(session, sr)
 
     if new_status == "rejected":
@@ -307,31 +348,29 @@ async def apply_workflow_line_resolution(
         sr.status = "rejected"
         sr.resolved_at = _now()
         await session.flush()
-        return
+        return None
 
     if new_status != "approved":
-        return
+        return None
 
     on_approve = step.get("on_approve") if isinstance(step.get("on_approve"), dict) else {}
     if not on_approve.get("apply_transition"):  # AC⑤: 명시 true 일 때만 status 변경.
         sr.status = "approved"
         sr.resolved_at = _now()
         await session.flush()
-        return
+        return None
 
     # S23/S22: hypothesis/doc 는 native FSM 재사용(transition_*·parallel 0). story 는 기존 inline.
     if sr.entity_type == "hypothesis":
         await _apply_hypothesis_active(session, sr, resolver_id)
-        return
+        return None
     if sr.entity_type == "doc":
-        await _apply_doc_confirmed(session, sr, resolver_id)
-        return
+        return await _apply_doc_confirmed(session, sr, resolver_id)
     if sr.entity_type == "epic":
-        await _apply_epic_transition(session, sr, resolver_id)
-        return
+        return await _apply_epic_transition(session, sr, resolver_id)
     if sr.entity_type == "sprint":
         await _apply_sprint_transition(session, sr, resolver_id)
-        return
+        return None
 
     from app.models.pm import Story  # 순환 회피 lazy import.
 
@@ -342,7 +381,7 @@ async def apply_workflow_line_resolution(
         sr.status = "approved"
         sr.resolved_at = _now()
         await session.flush()
-        return
+        return None
 
     # 이미 목표 status 면 멱등 applied(다른 경로로 도달했어도 결과 동일). 그 외 stale from_status
     # (story 가 제3 status 로 이동)면 미적용(P1-1). 순서: 멱등 우선 → stale.
@@ -350,12 +389,12 @@ async def apply_workflow_line_resolution(
         sr.status = "applied"
         sr.resolved_at = _now()
         await session.flush()
-        return
+        return None
     if sr.from_status is not None and story.status != sr.from_status:
         sr.status = "skipped"
         sr.resolved_at = _now()
         await session.flush()
-        return
+        return None
 
     old_status = story.status
     story.status = sr.to_status

--- a/backend/tests/test_ccbcd9da_gate_wake_wiring_realdb.py
+++ b/backend/tests/test_ccbcd9da_gate_wake_wiring_realdb.py
@@ -1,0 +1,238 @@
+"""ccbcd9da: 게이트 자동재개 wake 무음 근본 fix — E2E 배선 검증(실 PG).
+
+0f428e1e 그라운딩 근본: doc/epic gate 승인 후 자동재개(_apply_doc_confirmed/_apply_epic_transition
+→ dispatch_payload_to_member(commit=False))가 delivery/agent_wake 를 반환하지 않아 gates.py 가 commit
+후 wake_agent/webhook 을 스케줄할 방법이 없었다(무음). A-1 은 형제함수 dispatch_entity_to_assignee 와
+동형(delivery 반환)으로 맞추고 gates.py commit 지점을 배선한다. A-2 는 두 형제함수의 Event/wake/
+notification 로직을 _finalize_dispatch 공통 경로로 수렴(재발 방지).
+
+이 파일은 (a) 실제(비-mock) dispatch_payload_to_member 를 태워 gate_service.transition_gate 가
+pending_deliveries 를 정확히 채우는지, (b) gates.py 라우터 엔드포인트가 commit 후 wake_agent/webhook
+을 실제로 호출하는지(전엔 무음), (c) A-2 회귀 — human 저자도 이제 dispatch_notification 을 받는지
+검증한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+# story 8236bbc3: create_all(+drop_all)로 자체 스키마를 직접 다룸 — 공유 alembic-migrated
+# DB 오염 방지 위해 격리 DB 전용(conftest.py 가드가 마커 누락을 자동 검출).
+pytestmark = pytest.mark.destructive_schema
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _session():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    import app.models.participation  # noqa: F401
+    import app.models.workflow_line  # noqa: F401
+    import app.models.event  # noqa: F401
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_doc_gate_line(s, *, author_type="agent"):
+    """org/project/author(agent TeamMember)/doc(draft)/gate(pending)/published line + step_run(gate_pending)."""
+    from app.models.doc import Doc
+    from app.models.gate import Gate
+    from app.models.project import Project
+    from app.models.team import TeamMember
+    from app.models.workflow_line import (
+        WorkflowLineDefinition, WorkflowLineDefinitionVersion, WorkflowLineStepRun,
+    )
+
+    org, proj = uuid.uuid4(), uuid.uuid4()
+    s.add(Project(id=proj, org_id=org, name="p"))
+    await s.flush()
+
+    author = TeamMember(
+        id=uuid.uuid4(), org_id=org, project_id=proj, type=author_type,
+        name="author", role="member", is_active=True,
+    )
+    s.add(author)
+    await s.flush()
+
+    doc = Doc(org_id=org, project_id=proj, created_by=author.id, title="문서", slug=f"d-{uuid.uuid4().hex[:8]}",
+               content="", status="draft")
+    s.add(doc)
+    await s.flush()
+
+    gate = Gate(org_id=org, work_item_id=doc.id, work_item_type="doc", gate_type="custom_review",
+                status="pending")
+    s.add(gate)
+    await s.flush()
+
+    defn = WorkflowLineDefinition(org_id=org, project_id=proj, entity_type="doc", name="L",
+                                   is_active=True, version=1)
+    s.add(defn)
+    await s.flush()
+    s.add(WorkflowLineDefinitionVersion(
+        line_definition_id=defn.id, org_id=org, project_id=proj, entity_type="doc", version=1,
+        status="published", config_hash="h", created_by_member_id=uuid.uuid4(),
+        config={"steps": [{"from_status": "draft", "to_status": "confirmed",
+                            "on_approve": {"apply_transition": True}}]},
+    ))
+    sr = WorkflowLineStepRun(
+        org_id=org, project_id=proj, line_definition_id=defn.id, entity_type="doc", entity_id=doc.id,
+        from_status="draft", to_status="confirmed", status="gate_pending", mode="enforcing",
+        gate_id=gate.id, correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex,
+    )
+    s.add(sr)
+    await s.commit()
+    return {"org": org, "proj": proj, "author": author.id, "doc": doc.id, "gate": gate.id}
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_transition_gate_real_dispatch_collects_agent_wake_payload():
+    """(a) mock 0 — 실제 dispatch_payload_to_member 를 태워 transition_gate 가 pending_deliveries 를
+    채우는지 검증(agent 저자 → recipient_seq 확정된 agent_wake)."""
+    from app.services.gate_service import transition_gate
+    engine, Session = await _session()
+    async with Session() as s:
+        seeded = await _seed_doc_gate_line(s, author_type="agent")
+        approver = uuid.uuid4()
+        pending: list = []
+        gate = await transition_gate(
+            s, seeded["org"], seeded["gate"], "approved", resolver_id=approver,
+            pending_deliveries=pending,
+        )
+        await s.commit()
+        assert gate.status == "approved"
+        # ⭐핵심: 전엔 이 리스트가 항상 빈 채로 남았다(dispatch_payload_to_member 반환 자체가 없었음).
+        assert len(pending) == 1
+        payload = pending[0]
+        assert payload["agent_wake"] is not None
+        assert payload["agent_wake"]["recipient_id"] == str(seeded["author"])
+        assert isinstance(payload["agent_wake"]["recipient_seq"], int)
+        assert payload["delivery"]["recipient_id"] == seeded["author"]
+        assert payload["delivery"]["source_entity_type"] == "doc"
+
+        # doc 이 실제로 confirmed 로 전이됐는지도 side-effect 로 확인.
+        from sqlalchemy import text as sa_text
+        st = (await s.execute(
+            sa_text("SELECT status FROM docs WHERE id=:i"), {"i": seeded["doc"]}
+        )).scalar()
+        assert st == "confirmed"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_transition_gate_endpoint_wakes_after_commit(monkeypatch):
+    """(b) gates.py 라우터 E2E — commit 후 wake_agent + deliver_injected_event_webhook(background_tasks)
+    가 실제로 호출되는지 검증(전엔 무호출=무음)."""
+    from fastapi import BackgroundTasks
+    from app.routers import gates as gates_mod
+    from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
+    from app.services.member_resolver import ResolvedMember
+    from unittest.mock import AsyncMock, patch
+
+    engine, Session = await _session()
+    try:
+        async with Session() as s:
+            seeded = await _seed_doc_gate_line(s, author_type="agent")
+
+        woken = {}
+        scheduled = {}
+
+        def _fake_wake_agent(recipient_id, recipient_seq):
+            woken["recipient_id"] = recipient_id
+            woken["recipient_seq"] = recipient_seq
+
+        async def _fake_deliver(**kw):
+            scheduled.update(kw)
+
+        approver = ResolvedMember(
+            id=uuid.uuid4(), user_id=uuid.uuid4(), name="h", type="human", role="member",
+            org_id=seeded["org"],
+        )
+        async with Session() as s2:
+            with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=approver)), \
+                 patch.object(gates_mod, "wake_agent", _fake_wake_agent), \
+                 patch("app.services.conversation_webhook.deliver_injected_event_webhook", _fake_deliver):
+                bg = BackgroundTasks()
+                await transition_gate_endpoint(
+                    id=seeded["gate"], body=GateTransitionRequest(status="approved"),
+                    background_tasks=bg,
+                    session=s2, org_id=seeded["org"],
+                    auth=type("A", (), {"user_id": str(uuid.uuid4())})(),
+                )
+                # 라우터는 background_tasks.add_task 로 스케줄만 함 — 테스트에서 직접 실행해 검증.
+                for task in bg.tasks:
+                    await task()
+
+        assert woken.get("recipient_id") == str(seeded["author"])
+        assert scheduled.get("recipient_id") == seeded["author"]
+        assert scheduled.get("source_entity_type") == "doc"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_apply_doc_confirmed_notifies_human_author(monkeypatch):
+    """(c) A-2 회귀: human 저자도 dispatch_notification 대상(전엔 dispatch_payload_to_member 가
+    non-agent notification 을 아예 호출하지 않아 human 저자는 총 무통지였음)."""
+    from app.services.workflow_line_resolution import _apply_doc_confirmed
+    import app.services.agent_dispatch as ad
+    from app.models.doc import Doc
+    from app.models.project import Project
+    from app.models.team import TeamMember
+    from app.models.workflow_line import WorkflowLineStepRun
+
+    captured = {}
+
+    async def _fake_notify(db, *, org_id, event_type, target_member_ids, title, body, **kw):
+        captured["target_member_ids"] = target_member_ids
+        captured["event_type"] = event_type
+
+    monkeypatch.setattr(ad, "dispatch_notification", _fake_notify)
+
+    engine, Session = await _session()
+    async with Session() as s:
+        org, proj = uuid.uuid4(), uuid.uuid4()
+        s.add(Project(id=proj, org_id=org, name="p"))
+        await s.flush()
+        author = TeamMember(id=uuid.uuid4(), org_id=org, project_id=proj, type="human",
+                             name="h", role="member", is_active=True)
+        s.add(author)
+        await s.flush()
+        doc = Doc(org_id=org, project_id=proj, created_by=author.id, title="d",
+                   slug=f"d-{uuid.uuid4().hex[:8]}", content="", status="draft")
+        s.add(doc)
+        await s.flush()
+        sr = WorkflowLineStepRun(
+            org_id=org, project_id=proj, entity_type="doc", entity_id=doc.id,
+            from_status="draft", to_status="confirmed", status="gate_pending", mode="enforcing",
+            correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex,
+        )
+        s.add(sr)
+        await s.flush()
+        wake_payload = await _apply_doc_confirmed(s, sr, resolver_id=uuid.uuid4())
+        await s.commit()
+        assert sr.status == "applied"
+        # ⭐A-2 핵심: human 저자 → dispatch_notification 실제 호출(전엔 미호출).
+        assert captured.get("target_member_ids") == [author.id]
+        assert captured.get("event_type") == "dispatched"
+        # human 은 wake_agent 대상이 아니므로 agent_wake=None 이 정상(webhook/notification 만 대상).
+        assert wake_payload is not None
+        assert wake_payload["agent_wake"] is None
+    await engine.dispose()

--- a/backend/tests/test_edg_s22_doc_overlay.py
+++ b/backend/tests/test_edg_s22_doc_overlay.py
@@ -128,7 +128,11 @@ async def test_apply_sod_blocks_author_self_confirm():
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
 async def test_apply_different_approver_confirms_and_wakes_author(monkeypatch):
-    """approver ≠ author → confirmed + author(created_by) 자동재개 wake 호출(member_id=author)."""
+    """approver ≠ author → confirmed + author(created_by) 자동재개 wake 호출(member_id=author).
+
+    ccbcd9da(A-1): dispatch_payload_to_member 는 이제 (DispatchResponse, delivery) 튜플 반환·
+    _apply_doc_confirmed 도 그 delivery/agent_wake 를 **반환**해야 gates.py 가 commit 후 wake 스케줄
+    가능(전엔 반환 자체가 없어 무음이었음) — 이 반환값 자체를 검증한다."""
     from app.services.workflow_line_resolution import _apply_doc_confirmed
     from app.models.project import Project
     from sqlalchemy import text as sa_text
@@ -139,7 +143,16 @@ async def test_apply_different_approver_confirms_and_wakes_author(monkeypatch):
         captured["member_id"] = member_id
         captured["commit"] = kw.get("commit")
         from app.services.agent_dispatch import DispatchResponse
-        return DispatchResponse(dispatched=True, reason="ok")
+        resp = DispatchResponse(
+            dispatched=True, assignee_id=member_id, assignee_type="agent",
+            recipient_seq=7, reason="ok",
+        )
+        delivery = {
+            "org_id": org_id, "recipient_id": member_id, "content": kw.get("content"),
+            "event_type": "dispatched", "source_entity_type": kw.get("source_entity_type"),
+            "source_entity_id": kw.get("source_entity_id"),
+        }
+        return resp, delivery
 
     monkeypatch.setattr(ad, "dispatch_payload_to_member", _fake_wake)
     engine, Session = await _session()
@@ -149,12 +162,16 @@ async def test_apply_different_approver_confirms_and_wakes_author(monkeypatch):
         await s.flush()
         doc = await _seed_doc(s, org, proj, author)
         sr = await _seed_sr(s, org, proj, doc.id)
-        await _apply_doc_confirmed(s, sr, resolver_id=approver)
+        wake_payload = await _apply_doc_confirmed(s, sr, resolver_id=approver)
         await s.commit()
         st = (await s.execute(sa_text("SELECT status FROM docs WHERE id=:i"), {"i": doc.id})).scalar()
         assert st == "confirmed" and sr.status == "applied"
         # ⭐author 자동재개: created_by 대상 wake·commit=False(gate 트랜잭션 합류·§6).
         assert captured["member_id"] == author and captured["commit"] is False
+        # ⭐A-1 핵심: 호출자(gates.py)가 commit 후 wake_agent/webhook 스케줄할 수 있게 페이로드 반환.
+        assert wake_payload is not None
+        assert wake_payload["agent_wake"] == {"recipient_id": str(author), "recipient_seq": 7}
+        assert wake_payload["delivery"]["recipient_id"] == author
     await engine.dispose()
 
 

--- a/backend/tests/test_edg_s23_hypothesis_overlay.py
+++ b/backend/tests/test_edg_s23_hypothesis_overlay.py
@@ -33,7 +33,7 @@ async def test_gate_transition_forces_resolver_id_to_caller(monkeypatch):
     caller_id, spoofed = uuid.uuid4(), uuid.uuid4()
     captured = {}
 
-    async def _fake_transition(session, org_id, gid, status, resolver_id, note):
+    async def _fake_transition(session, org_id, gid, status, resolver_id, note, *, pending_deliveries=None):
         captured["resolver_id"] = resolver_id
         return MagicMock()
 
@@ -50,8 +50,10 @@ async def test_gate_transition_forces_resolver_id_to_caller(monkeypatch):
     _g.gate_type = "merge"
     _gr.scalar_one_or_none.return_value = _g
     _sess.execute = AsyncMock(return_value=_gr)
+    from fastapi import BackgroundTasks
     await gm.transition_gate_endpoint(
-        uuid.uuid4(), body, session=_sess, org_id=uuid.uuid4(), auth=MagicMock())
+        uuid.uuid4(), body, background_tasks=BackgroundTasks(),
+        session=_sess, org_id=uuid.uuid4(), auth=MagicMock())
     assert captured["resolver_id"] == caller_id  # ⭐조작된 spoofed 가 아니라 인증 caller
     assert captured["resolver_id"] != spoofed
 

--- a/backend/tests/test_edg_s25_epic_overlay.py
+++ b/backend/tests/test_edg_s25_epic_overlay.py
@@ -139,6 +139,60 @@ async def test_default_off_agent_activation_blocked():
 
 @pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
 @pytest.mark.anyio
+async def test_apply_active_done_wakes_assignee(monkeypatch):
+    """ccbcd9da(A-1): active→done(SoD 무관) 승인 → epic.assignee_id 자동재개 wake 페이로드가
+    _apply_epic_transition 반환값으로 전파(전엔 dispatch_payload_to_member 반환 자체가 없어 무음)."""
+    from app.services.workflow_line_resolution import _apply_epic_transition
+    from app.models.pm import Epic
+    from app.models.workflow_line import WorkflowLineStepRun
+    from app.models.project import Project
+    import app.services.agent_dispatch as ad
+    captured = {}
+
+    async def _fake_wake(db, org_id, member_id, **kw):
+        captured["member_id"] = member_id
+        captured["commit"] = kw.get("commit")
+        from app.services.agent_dispatch import DispatchResponse
+        resp = DispatchResponse(
+            dispatched=True, assignee_id=member_id, assignee_type="agent",
+            recipient_seq=3, reason="ok",
+        )
+        delivery = {
+            "org_id": org_id, "recipient_id": member_id, "content": kw.get("content"),
+            "event_type": "dispatched", "source_entity_type": kw.get("source_entity_type"),
+            "source_entity_id": kw.get("source_entity_id"),
+        }
+        return resp, delivery
+
+    monkeypatch.setattr(ad, "dispatch_payload_to_member", _fake_wake)
+    engine, Session = await _session()
+    async with Session() as s:
+        org, proj, assignee, approver = uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        s.add(Project(id=proj, org_id=org, name="p"))
+        await s.flush()
+        epic = Epic(org_id=org, project_id=proj, title="e", status="active", assignee_id=assignee)
+        s.add(epic)
+        await s.flush()
+        sr = WorkflowLineStepRun(
+            org_id=org, project_id=proj, entity_type="epic", entity_id=epic.id,
+            from_status="active", to_status="done", status="gate_pending", mode="enforcing",
+            correlation_id=uuid.uuid4(), transition_id=uuid.uuid4().hex,
+        )
+        s.add(sr)
+        await s.flush()
+        wake_payload = await _apply_epic_transition(s, sr, resolver_id=approver)
+        await s.commit()
+        assert sr.status == "applied"
+        assert captured["member_id"] == assignee and captured["commit"] is False
+        # ⭐A-1 핵심: 호출자(gates.py)가 commit 후 wake_agent/webhook 스케줄할 수 있게 페이로드 반환.
+        assert wake_payload is not None
+        assert wake_payload["agent_wake"] == {"recipient_id": str(assignee), "recipient_seq": 3}
+        assert wake_payload["delivery"]["recipient_id"] == assignee
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
 async def test_resolver_epic_aggregate_included():
     """⭐active→done routing material: resolver 가 epic 산하 story aggregate 포함(advisory)."""
     from app.services.workflow_line_resolver import resolve_routing_context

--- a/backend/tests/test_edg_s33_override.py
+++ b/backend/tests/test_edg_s33_override.py
@@ -177,7 +177,7 @@ async def test_override_endpoint_non_owner_403():
     """admin이어도 owner 아니면 403(override는 owner-only·admin보다 좁음)."""
     from types import SimpleNamespace
     from unittest.mock import AsyncMock, patch
-    from fastapi import HTTPException
+    from fastapi import BackgroundTasks, HTTPException
     from app.routers import gates as gates_mod
     from app.routers.gates import GateOverrideRequest, override_gate_endpoint
     with patch.object(gates_mod, "resolve_member", AsyncMock(return_value=_resolved_owner())), \
@@ -185,6 +185,7 @@ async def test_override_endpoint_non_owner_403():
         with pytest.raises(HTTPException) as ei:
             await override_gate_endpoint(
                 id=uuid.uuid4(), body=GateOverrideRequest(decision="approved", reason="x"),
+                background_tasks=BackgroundTasks(),
                 session=AsyncMock(), org_id=uuid.uuid4(),
                 auth=SimpleNamespace(user_id=str(uuid.uuid4())))
     assert ei.value.status_code == 403

--- a/backend/tests/test_gate_can_approve_48f064e5.py
+++ b/backend/tests/test_gate_can_approve_48f064e5.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import HTTPException
+from fastapi import BackgroundTasks, HTTPException
 
 from app.routers import gates as gates_mod
 from app.routers.gates import (
@@ -66,6 +66,7 @@ async def _call(resolved, *, execute_results, has_access=None, status="approved"
             stack.enter_context(p)
         result = await transition_gate_endpoint(
             id=uuid.uuid4(), body=GateTransitionRequest(status=status),
+            background_tasks=BackgroundTasks(),
             session=session, org_id=uuid.uuid4(), auth=auth,
         )
     return result, transition
@@ -85,6 +86,7 @@ async def test_doc_gate_self_approval_forbidden():
         with pytest.raises(HTTPException) as ei:
             await transition_gate_endpoint(
                 id=uuid.uuid4(), body=GateTransitionRequest(status="approved"),
+                background_tasks=BackgroundTasks(),
                 session=session, org_id=uuid.uuid4(), auth=auth,
             )
     assert ei.value.status_code == 403
@@ -104,6 +106,7 @@ async def test_doc_gate_missing_requester_fail_closed():
         with pytest.raises(HTTPException) as ei:
             await transition_gate_endpoint(
                 id=uuid.uuid4(), body=GateTransitionRequest(status="approved"),
+                background_tasks=BackgroundTasks(),
                 session=session, org_id=uuid.uuid4(), auth=auth,
             )
     assert ei.value.status_code == 403
@@ -125,6 +128,7 @@ async def test_doc_gate_no_project_access_forbidden():
         with pytest.raises(HTTPException) as ei:
             await transition_gate_endpoint(
                 id=uuid.uuid4(), body=GateTransitionRequest(status="approved"),
+                background_tasks=BackgroundTasks(),
                 session=session, org_id=uuid.uuid4(), auth=auth,
             )
     assert ei.value.status_code == 403
@@ -145,6 +149,7 @@ async def test_doc_gate_deleted_doc_forbidden():
         with pytest.raises(HTTPException) as ei:
             await transition_gate_endpoint(
                 id=uuid.uuid4(), body=GateTransitionRequest(status="approved"),
+                background_tasks=BackgroundTasks(),
                 session=session, org_id=uuid.uuid4(), auth=auth,
             )
     assert ei.value.status_code == 403

--- a/backend/tests/test_gate_transition_human_only.py
+++ b/backend/tests/test_gate_transition_human_only.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import HTTPException
+from fastapi import BackgroundTasks, HTTPException
 
 from app.routers import gates as gates_mod
 from app.routers.gates import GateTransitionRequest, transition_gate_endpoint
@@ -43,7 +43,8 @@ async def _call(status: str, member_type: str):
          patch.object(gates_mod, "transition_gate", transition), \
          patch.object(gates_mod.GateResponse, "model_validate", lambda g: "OK"):
         result = await transition_gate_endpoint(
-            id=uuid.uuid4(), body=body, session=session, org_id=org_id, auth=SimpleNamespace(),
+            id=uuid.uuid4(), body=body, background_tasks=BackgroundTasks(),
+            session=session, org_id=org_id, auth=SimpleNamespace(),
         )
     return result, transition
 
@@ -73,6 +74,7 @@ async def test_agent_approve_does_not_call_transition():
         with pytest.raises(HTTPException):
             await transition_gate_endpoint(
                 id=uuid.uuid4(), body=GateTransitionRequest(status="approved"),
+                background_tasks=BackgroundTasks(),
                 session=AsyncMock(), org_id=uuid.uuid4(), auth=SimpleNamespace(),
             )
     transition.assert_not_awaited()

--- a/backend/tests/test_rc1_body_trust_actor.py
+++ b/backend/tests/test_rc1_body_trust_actor.py
@@ -56,7 +56,7 @@ async def test_transition_forces_resolver_ignoring_body():
     forged = uuid.uuid4()  # 타인 UUID
     captured = {}
 
-    async def _fake_transition(session, org_id, gate_id, status, resolver_id, note):
+    async def _fake_transition(session, org_id, gate_id, status, resolver_id, note, *, pending_deliveries=None):
         captured["resolver_id"] = resolver_id
         return SimpleNamespace(id=gate_id, org_id=org_id, work_item_id=uuid.uuid4(),
                                work_item_type="story", gate_type="merge", status=status,
@@ -66,10 +66,12 @@ async def test_transition_forces_resolver_ignoring_body():
                                created_at=__import__("datetime").datetime.now(),
                                updated_at=__import__("datetime").datetime.now())
 
+    from fastapi import BackgroundTasks
     with patch.object(mod, "resolve_member", AsyncMock(return_value=caller)), \
          patch.object(mod, "transition_gate", _fake_transition):
         await transition_gate_endpoint(
             id=uuid.uuid4(), body=GateTransitionRequest(status="approved", resolver_id=forged),
+            background_tasks=BackgroundTasks(),
             session=_non_doc_gate_session(), org_id=uuid.uuid4(),
             auth=SimpleNamespace(user_id=str(uuid.uuid4())))
     assert captured["resolver_id"] == caller.id     # caller 강제
@@ -85,10 +87,12 @@ async def test_transition_agent_rejected_403():
     from fastapi import HTTPException
     agent = ResolvedMember(id=uuid.uuid4(), user_id=None, name="a", type="agent",
                            role="member", org_id=uuid.uuid4())
+    from fastapi import BackgroundTasks
     with patch.object(mod, "resolve_member", AsyncMock(return_value=agent)):
         with pytest.raises(HTTPException) as ei:
             await transition_gate_endpoint(
                 id=uuid.uuid4(), body=GateTransitionRequest(status="approved"),
+                background_tasks=BackgroundTasks(),
                 session=AsyncMock(), org_id=uuid.uuid4(),
                 auth=SimpleNamespace(user_id=str(uuid.uuid4())))
     assert ei.value.status_code == 403


### PR DESCRIPTION
선생님 GO(wake fix 승격). #2157(ccbcd9da)만 selective 승격·BE-only·마이그 0·billing 무관.

근본: 게이트 승인 후 담당자 자동재개(dispatch_payload_to_member commit=False)가 wake 완전 무음이던 #1364 부분수정 갭. 두 형제함수를 _finalize_dispatch 단일 경로 통합(재발 구조 차단)+gates.py commit후 wake_agent+webhook 스케줄. 부수: human 저자 무통지 갭 동반 해소.

검증(develop): 까심 QA — non-mock realdb(실 transition_gate→실 wake/webhook 호출·전엔 무호출)+sabotage+회귀 377건 스윕. 마이그 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)