### PR TITLE
[조직OS] README 자기서술 재작성 — 조직 OS 포지셔닝(LLM 리트머스 갭 클로징)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,21 @@
 # Sprintable
 
-**The delivery ledger for coding agent teams — know when agent work is actually done, and safe to merge.**
+**The operating system for hybrid teams — where humans and AI agents run real sprints: hypothesis → execution → verification → learning.**
 
-Spawning parallel coding agents is easy now — every harness does that natively. What's still unsolved: knowing when an agent's "done" is real, whether its diff is actually safe to merge, and reconstructing what happened when three agents touched the same files overnight. Sprintable is a self-hostable, vendor-neutral layer above your harness — each agent works a scoped ticket, "done" hits a human merge-safety gate before anything lands, and every claim, handoff, and decision is written to one auditable ledger.
+AI made individual work faster, but team delivery didn't move — because the bottleneck was never the work. It's the organization: deciding what to try, verifying what's actually done, and learning from what shipped. Most teams never run a real sprint — no hypothesis, no measurement, no looking back — so AI's speed never becomes the organization's growth.
+
+Sprintable makes an organization *sprint-able*. Every initiative starts as a hypothesis. Every "done" — human or agent — passes a human decision gate before it counts. Every result, proven or disproven, becomes learning the organization keeps. Humans and AI agents are first-class members of the same org, working one loop, on one auditable record.
+
+## What makes it an operating system
+
+**Learning — the org gets smarter, not just busier.**
+Sprints are bundles of hypotheses under test, not bags of tickets. Each one resolves to achieved or disproven — and a disproven hypothesis is learning, not failure, written into the organization's memory for the next loop.
+
+**Trust — a "done" is a claim until a human signs it.**
+When an agent reports work complete, that is *claimed*, not verified. Only a human sign-off makes it *verified*. Sprintable keeps claimed and verified as distinct, first-class states — so you always know which "done" you can trust.
+
+**Governance — nothing consequential lands on a claim.**
+Work parks at review; a human decision gate (`Gate` — a first-class object with an audited pending → approved / rejected state machine) is what moves it forward. A code merge is one kind of gate; any consequential decision can be one.
 
 Bring any agent: Claude Code, Codex, Cursor, Gemini, Grok, Hermes, OpenClaw, OpenCode, Pi, or your own — first-class support across MCP-native config and gateway-connector adapters. Sprintable doesn't lock you into a framework or a vendor — it's the neutral layer that sits above all of them.
 
@@ -12,22 +25,20 @@ Bring any agent: Claude Code, Codex, Cursor, Gemini, Grok, Hermes, OpenClaw, Ope
 
 ---
 
-## Why Not Linear + MCP?
+## Where Sprintable sits
 
-You could wire an MCP server into Linear and point one agent at it. For a single agent, that's enough.
+Three kinds of tools each own one piece. None owns the whole:
 
-Sprintable solves a different problem: **knowing when a team of agents is actually done, and safe to merge** — especially once agents come from different vendors and touch the same repo.
-
-| | Linear / Jira | n8n + webhooks | Terminal wrappers / agent visualizers | Sprintable |
+|  | PM tools (Linear, Jira) | Human org OS (Rippling, flex) | AI-workforce tools (Frontier, Workday) | **Sprintable** |
 |---|---|---|---|---|
-| Done-criteria gate before merge | No — a status field, not enforced | Custom build | No — shows activity, doesn't gate it | **agents park work at `in-review` — only a human-resolved merge gate moves it to `done`** |
-| Merge-safety gate (pending/approved/rejected) | Not modeled | Custom build | Not modeled | **First-class `Gate` object with an audited state machine** |
-| Ticket-per-agent scoping | Manual assignment | Workflow nodes, not tickets | Not modeled | **Each agent claims one story and locks its own files** |
-| Cross-vendor mutual review | Manual or glue code | Possible, no PM data model | Not modeled | **Claude Code writes, Codex reviews — one ledger tracks both** |
-| Audit ledger (claim → lock → status → gate → merge) | Partial (issue history) | Not a PM tool | No — terminal scrollback isn't a record | **Every action logged, queryable over MCP** |
-| Real-time SSE delivery to agents | No | Polling-based | N/A (local process) | **SSE EventBus — push, not poll** |
+| First-class citizen | Tickets & tasks | The org (people, roles, approvals) | AI co-workers (hire, onboard) | **A hybrid org running real sprints** |
+| Humans + AI as equal members | AI bolted on | Humans only | AI-centric | **Both, first-class, in one org** |
+| Methodology — *how* you work | You bring your own | — | — | **Sprint-able, built in: hypothesis → execute → verify → learn** |
+| Governance — *who* decides | A status field | HR approval chains | — | **Human decision gates on any consequential step** |
+| Trust — is "done" real? | — | — | Whatever the AI claims | **Claimed vs. human-verified, as a first-class state** |
+| Learning — does the org compound? | — | — | — | **Hypotheses verified or disproven → organizational memory** |
 
-The short version: Linear/Jira are human PM tools bolting on AI features. Terminal wrappers make parallel agents visible but don't decide anything. Sprintable is the layer that decides — and remembers.
+PM tools track the work but not the organization. Human org OSes model the organization but not agents, method, or learning. AI-workforce tools hire agents but not *how the org works and learns*. Sprintable is the seat no one is in: the organization, its human and AI members, the method that makes it sprint-able, and the trust and learning loops that let it compound.
 
 ---
 


### PR DESCRIPTION
## 요약
- story `6e3f3126`(선생님 "반드시" 지시) — LLM 재실험 리트머스 잔존 갭 ⓐ 클로징. 2모델 판정이 거버넌스/오케스트레이션까지 왔으나 여전히 "coding agent" 프레임인 원인 = README 태그라인 "The delivery ledger for coding agent teams" 등 소스 자기서술이 개발 전용이었기 때문.
- SSOT = 유나 doc `readme-org-os-positioning-rewrite`(PO 방향서 대조 nod 완·EN 정본). markdown 블록 **1:1 그대로**(자기서술은 카피 그 자체라 임의 수정 0) — README.md 단일 파일 변경.

## 변경
1. **태그라인+인트로 교체**: "The delivery ledger for coding agent teams" → "The operating system for hybrid teams — where humans and AI agents run real sprints: hypothesis → execution → verification → learning." founding intent 캐논(방향서 §0/§1) 그대로.
2. **신규 1급 섹션 "What makes it an operating system"**(인트로 직후 삽입) — 3축(learning/trust/governance). **순서는 오르테가 강화점 반영**: doc은 governance→trust→learning 순이었으나, governance를 앞세우면 리트머스에서 Claude가 이미 "governance"에 앵커했으니 여전히 "governance platform"으로 읽힐 위험이 있어 **Learning→Trust→Governance**로 재배열(내용 무변경·순서만) — 방향서 §3 기준 진짜 빈 자리는 "조직이 배우는 루프 1급=아무도 없음"이라 learning을 선두 배치.
3. **"Why Not Linear + MCP?"(개발 축 표) → "Where Sprintable sits"**(방향서 §3 3진영: PM 툴/휴먼 조직 OS/AI 워크포스 프레임으로 재정렬).
4. **BYOA 섹션**: 무변경(grep 확認 — "coding agent" 문구가 이미 없어 어휘 교체 대상 자체가 없었음).
5. **"How It Works — SSE EventBus" 섹션**: 무변경. doc이 요구한 "Under the hood" 이관 대상(merge gate·cross-vendor review·audit ledger·SSE·file locking)을 확認해보니 **이미 이 섹션(Tickets/Gates/Conversations/MCP Actions 4계층)에 구체 증거로 전부 존재**했음 — 별도 이관 없이 그대로 보존.
6. **License·설치**: 무변경.

## 과장 감사 (doc §5 claim↔실존 대조)
전 claim이 실존 기능 기반: `Gate` 객체+상태머신=E-DECISION-GATE, claimed/verified 1급 상태=E-VERIFY, 가설→검증→반증=학습=hypothesis 1급 엔티티(E-SPRINT-LOOP). 신규 기능 주장 0.

## 게이트
README.md 단일 마크다운 파일 변경 — 애플리케이션 코드/빌드 파이프라인에 영향 없음. `git diff`로 의도한 정확히 그 4개 블록만 변경됐음을 직접 확認.

🤖 Generated with [Claude Code](https://claude.com/claude-code)