### PR TITLE
feat(eventbus): 채팅 메시지 단건 원문 조회 API 신설 (story 3cf50d90)

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -926,20 +926,14 @@ async def get_conversation(
     return resp
 
 
-@router.get("/{conversation_id}/messages")
-async def list_messages(
+async def _authorize_message_read(
     conversation_id: uuid.UUID,
-    limit: int = Query(default=30, le=200),
-    before: str | None = Query(default=None),
-    thread_id: uuid.UUID | None = Query(default=None),
-    db: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    org_id: uuid.UUID = Depends(get_verified_org_id),
-) -> dict:
-    """GET /api/v2/conversations/{id}/messages — cursor 기반 페이지네이션.
-
-    thread_id 미지정: top-level 메시지만 반환 (thread_id IS NULL).
-    thread_id 지정: 해당 thread의 reply 목록 반환.
+    db: AsyncSession,
+    auth: AuthContext,
+    org_id: uuid.UUID,
+) -> uuid.UUID:
+    """메시지 조회(목록/단건/리플) 공용 인가. #1262: admin-bypass=agent-only 대화 한정 —
+    휴먼 참가 대화(=private)는 participant only. 반환: conversation.project_id.
     """
     conv_project_id = (await db.execute(
         select(Conversation.project_id).where(Conversation.id == conversation_id, Conversation.org_id == org_id)
@@ -947,7 +941,6 @@ async def list_messages(
     if conv_project_id is None:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
-    # #1262: admin-bypass=agent-only 대화 한정 — 휴먼 참가 대화(=private)는 participant only.
     # owner/admin: org-level 조회(project 소속 무관 접근), member: project-level 유지
     sender = await _resolve_member(auth, org_id, db, project_id=None)
 
@@ -967,6 +960,25 @@ async def list_messages(
         )).scalar_one_or_none()
         if participant is None:
             raise HTTPException(status_code=403, detail="Not a participant")
+    return conv_project_id
+
+
+@router.get("/{conversation_id}/messages")
+async def list_messages(
+    conversation_id: uuid.UUID,
+    limit: int = Query(default=30, le=200),
+    before: str | None = Query(default=None),
+    thread_id: uuid.UUID | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """GET /api/v2/conversations/{id}/messages — cursor 기반 페이지네이션.
+
+    thread_id 미지정: top-level 메시지만 반환 (thread_id IS NULL).
+    thread_id 지정: 해당 thread의 reply 목록 반환.
+    """
+    await _authorize_message_read(conversation_id, db, auth, org_id)
 
     if thread_id is None:
         thread_filter = ConversationMessage.thread_id.is_(None)
@@ -976,6 +988,81 @@ async def list_messages(
     stmt = (
         select(ConversationMessage)
         .where(ConversationMessage.conversation_id == conversation_id, thread_filter)
+        .order_by(ConversationMessage.created_at.desc())
+        .limit(limit + 1)
+    )
+    if before:
+        try:
+            before_dt = datetime.fromisoformat(before)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid cursor format")
+        stmt = stmt.where(ConversationMessage.created_at < before_dt)
+
+    rows = (await db.execute(stmt)).scalars().all()
+    has_more = len(rows) > limit
+    msgs = list(reversed(rows[:limit]))
+
+    sender_ids = {m.sender_id for m in msgs if m.sender_id}
+    member_map = await lookup_members_by_ids(sender_ids, db)
+
+    data = [_msg_payload(m, member_map.get(m.sender_id)) for m in msgs]
+    next_cursor = msgs[0].created_at.isoformat() if has_more and msgs else None
+
+    return {"data": data, "meta": {"next_cursor": next_cursor, "has_more": has_more}}
+
+
+@router.get("/{conversation_id}/messages/{message_id}")
+async def get_message(
+    conversation_id: uuid.UUID,
+    message_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """GET /api/v2/conversations/{id}/messages/{message_id} — 단건 원문 조회(최상위+리플 공용).
+
+    story 3cf50d90: 게이트/QA 리플이 웹훅 payload 잘림으로 도달하면 원문 재조회 경로가 없어
+    "잘렸다·재발신" 왕복이 반복됐다. 인가는 list_messages와 동형(참여자 전용·admin-bypass는
+    agent-only 대화 한정).
+    """
+    await _authorize_message_read(conversation_id, db, auth, org_id)
+
+    msg = (await db.execute(
+        select(ConversationMessage).where(
+            ConversationMessage.id == message_id,
+            ConversationMessage.conversation_id == conversation_id,
+        )
+    )).scalar_one_or_none()
+    if msg is None:
+        raise HTTPException(status_code=404, detail="Message not found")
+
+    sender_map = await lookup_members_by_ids({msg.sender_id} if msg.sender_id else set(), db)
+    return _msg_payload(msg, sender_map.get(msg.sender_id))
+
+
+@router.get("/{conversation_id}/messages/{message_id}/replies")
+async def list_message_replies(
+    conversation_id: uuid.UUID,
+    message_id: uuid.UUID,
+    limit: int = Query(default=30, le=200),
+    before: str | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """GET /api/v2/conversations/{id}/messages/{message_id}/replies — 이 메시지의 리플 목록.
+
+    story 3cf50d90: list_messages의 `?thread_id=` 파라미터와 동형 필터(discoverability용 전용
+    서브리소스 — 호출자가 thread_id 쿼리파라미터의 존재를 몰라도 원문 리플 왕복이 가능하도록).
+    """
+    await _authorize_message_read(conversation_id, db, auth, org_id)
+
+    stmt = (
+        select(ConversationMessage)
+        .where(
+            ConversationMessage.conversation_id == conversation_id,
+            ConversationMessage.thread_id == message_id,
+        )
         .order_by(ConversationMessage.created_at.desc())
         .limit(limit + 1)
     )

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -281,6 +281,7 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_get_standup", "sprintable_get_task", "sprintable_get_unassigned_stories",
     "sprintable_get_velocity", "sprintable_get_wallet", "sprintable_get_workflow_guide",
     "sprintable_give_reward", "sprintable_list_audit_logs", "sprintable_list_backlog",
+    "sprintable_get_chat_message",
     "sprintable_list_chat_messages", "sprintable_list_docs", "sprintable_list_epics",
     "sprintable_list_meetings", "sprintable_list_my_tasks", "sprintable_list_retro_sessions",
     "sprintable_list_sprints", "sprintable_list_standup_entries", "sprintable_list_stories",

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -1,4 +1,4 @@
-"""Sprintable MCP 서버 — 92개 도구 등록 (flat schema)."""
+"""Sprintable MCP 서버 — 106개 도구 등록 (flat schema)."""
 from __future__ import annotations
 
 import asyncio
@@ -80,8 +80,8 @@ from .tools.meetings import (
     trigger_ai_summary, update_meeting,
 )
 from .tools.chat import (
-    CreateConversationInput, ListChatMessagesInput, SendChatInput,
-    create_conversation, list_chat_messages, send_chat_message,
+    CreateConversationInput, GetChatMessageInput, ListChatMessagesInput, SendChatInput,
+    create_conversation, get_chat_message, list_chat_messages, send_chat_message,
 )
 from .tools.notifications import (
     CheckNotificationsInput, MarkAllNotificationsReadInput, MarkNotificationReadInput,
@@ -564,7 +564,7 @@ _TOOL_DEFS: list[tuple] = [
      "이 버전을 정본으로 제안(게이트 생성) — 제안만, 승인/반려는 항상 휴먼. ⭐이 버전이 확定될"
      " 준비가 됐다고 판단될 때 휴먼 승인을 요청.",
      ProposeCanonicalInput, propose_canonical_version),
-    # Chat (3)
+    # Chat (4)
     ("sprintable_send_chat_message",
      "conversation thread에 채팅 메시지 발송.",
      SendChatInput, send_chat_message),
@@ -574,6 +574,11 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_list_chat_messages",
      "conversation thread 메시지 목록 조회.",
      ListChatMessagesInput, list_chat_messages),
+    ("sprintable_get_chat_message",
+     "conversation thread 내 메시지 단건 원문 조회(message_id로 즉시 픽업). ⭐웹훅 payload가"
+     " 잘렸거나 원문이 의심될 때 재발신 요청 대신 이걸로 먼저 확인 — thread_id=conversation_id,"
+     " message_id=조회할 메시지 id(top-level·리플 공용).",
+     GetChatMessageInput, get_chat_message),
     # Meetings (6)
     ("sprintable_list_meetings",
      "프로젝트 미팅 목록 조회.",

--- a/backend/sprintable_mcp/tools/chat.py
+++ b/backend/sprintable_mcp/tools/chat.py
@@ -35,6 +35,11 @@ class ListChatMessagesInput(SprintableInput):
     before: str | None = None
 
 
+class GetChatMessageInput(SprintableInput):
+    thread_id: str  # conversation_id — send/list_chat_message와 동일 네이밍 관례
+    message_id: str
+
+
 async def send_chat_message(args: SendChatInput) -> list[TextContent]:
     """conversation thread에 채팅 메시지 발송."""
     payload: dict = {"content": args.content}
@@ -97,5 +102,13 @@ async def list_chat_messages(args: ListChatMessagesInput) -> list[TextContent]:
         params["before"] = args.before
     try:
         return ok(await client.get(f"/api/v2/conversations/{args.thread_id}/messages", params=params))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def get_chat_message(args: GetChatMessageInput) -> list[TextContent]:
+    """메시지 단건 원문 조회 — 웹훅 payload가 잘렸을 때 message_id로 즉시 원문 픽업."""
+    try:
+        return ok(await client.get(f"/api/v2/conversations/{args.thread_id}/messages/{args.message_id}"))
     except Exception as exc:
         return err(str(exc))

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -49,8 +49,9 @@ EXPECTED_TOOLS = {
     # core (4) — E-MCP-OPT(story ff6cb90d): list_projects/set_default_project 2종 추가.
     "sprintable_list_team_members", "sprintable_my_dashboard",
     "sprintable_list_projects", "sprintable_set_default_project",
-    # chat (3)
+    # chat (4) — story 3cf50d90: get_chat_message(단건 원문 조회) 추가.
     "sprintable_send_chat_message", "sprintable_create_conversation", "sprintable_list_chat_messages",
+    "sprintable_get_chat_message",
     # meetings (6)
     "sprintable_list_meetings", "sprintable_get_meeting", "sprintable_create_meeting",
     "sprintable_update_meeting", "sprintable_delete_meeting", "sprintable_trigger_ai_summary",
@@ -102,7 +103,8 @@ def test_total_tool_count():
     # C1-S3(e50563b4): sprintable_list_artifacts 추가로 98→99... +1=100.
     # E-MCP-OPT(story ff6cb90d): list_projects/set_default_project 2종 추가 — 100→102.
     # 편집 캔버스 핀 저작(story 7fe16274): spec pin 4종 추가 — 102→106.
-    assert len(_TOOLS) == 106
+    # story 3cf50d90: get_chat_message(단건 원문 조회) 추가 — 106→107.
+    assert len(_TOOLS) == 107
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_3cf50d90_message_get_replies_realdb.py
+++ b/backend/tests/test_3cf50d90_message_get_replies_realdb.py
@@ -1,0 +1,304 @@
+"""story 3cf50d90: 채팅 메시지 단건 원문 조회(GET /messages/{id})·리플 서브리소스
+(GET /messages/{id}/replies) 실증 — 인가(참여자 전용) + 타 conversation 격리.
+
+근본: 게이트/QA 리플이 웹훅 payload 잘림으로 도달하면 원문을 재조회할 경로가 없어
+"잘렸다·재발신" 왕복이 반복됐다(도그푸딩 실사용 갭). list_messages의 `?thread_id=`는
+있었지만 단건 GET(top-level+리플 공용)과 discoverable한 replies 서브리소스가 부재했다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_human(session, org_id, project_id):
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    user = User(id=user_id, email=f"human-{user_id.hex[:8]}@test.com", hashed_password="x")
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user_id, role="member")
+    session.add(om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_id, org_member_id=om.id, permission="granted",
+    ))
+    await session.commit()
+    return user_id, om.id
+
+
+async def _seed(session):
+    """org + project + human_a(conv_1 참가자) + human_b(project 접근권만·conv_1 비참가자).
+
+    conv_1: top-level 메시지 1 + 그 리플 1(human_a 발신).
+    conv_2: human_b 소유 대화의 메시지 1(cross-conversation 격리 검증용).
+    """
+    from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="3cf50d90 Org", slug=f"3cf50d90-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    user_a, om_a_id = await _seed_human(session, org.id, project.id)
+    user_b, om_b_id = await _seed_human(session, org.id, project.id)
+
+    conv_1 = Conversation(
+        id=uuid.uuid4(), project_id=project.id, org_id=org.id, type="group", created_by=om_a_id,
+    )
+    session.add(conv_1)
+    await session.flush()
+    session.add(ConversationParticipant(conversation_id=conv_1.id, member_id=om_a_id))
+    await session.commit()
+
+    conv_2 = Conversation(
+        id=uuid.uuid4(), project_id=project.id, org_id=org.id, type="group", created_by=om_b_id,
+    )
+    session.add(conv_2)
+    await session.flush()
+    session.add(ConversationParticipant(conversation_id=conv_2.id, member_id=om_b_id))
+    await session.commit()
+
+    top = ConversationMessage(
+        id=uuid.uuid4(), conversation_id=conv_1.id, sender_id=om_a_id, content="원문 최상위 메시지",
+    )
+    session.add(top)
+    await session.flush()
+    reply = ConversationMessage(
+        id=uuid.uuid4(), conversation_id=conv_1.id, sender_id=om_a_id, content="원문 리플 메시지",
+        thread_id=top.id,
+    )
+    session.add(reply)
+    await session.commit()
+
+    other_msg = ConversationMessage(
+        id=uuid.uuid4(), conversation_id=conv_2.id, sender_id=om_b_id, content="다른 대화의 메시지",
+    )
+    session.add(other_msg)
+    await session.commit()
+
+    return {
+        "org_id": org.id, "project_id": project.id,
+        "user_a": user_a, "user_b": user_b,
+        "conv_1_id": conv_1.id, "conv_2_id": conv_2.id,
+        "top_id": top.id, "reply_id": reply.id, "other_msg_id": other_msg.id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_get_message_200_top_level_participant():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["user_a"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/conversations/{seeded['conv_1_id']}/messages/{seeded['top_id']}"
+            )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["content"] == "원문 최상위 메시지"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_message_200_reply_participant():
+    """핵심 회귀: 리플 메시지도 단건 GET으로 원문 조회 가능(기존엔 404)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["user_a"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/conversations/{seeded['conv_1_id']}/messages/{seeded['reply_id']}"
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["content"] == "원문 리플 메시지"
+            assert body["thread_id"] == str(seeded["top_id"])
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_message_403_non_participant():
+    """human_b는 project 접근권은 있으나 conv_1 참가자가 아님 → 403(project-access 통과 후 참가자 체크에서 차단)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["user_b"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/conversations/{seeded['conv_1_id']}/messages/{seeded['top_id']}"
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_message_404_cross_conversation():
+    """other_msg는 conv_2 소속 — conv_1 URL로 조회하면 404(권한 경계: 타 conversation 차단)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["user_a"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/conversations/{seeded['conv_1_id']}/messages/{seeded['other_msg_id']}"
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_message_replies_200_returns_only_replies():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["user_a"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/conversations/{seeded['conv_1_id']}/messages/{seeded['top_id']}/replies"
+            )
+            assert resp.status_code == 200, resp.text
+            data = resp.json()["data"]
+            assert len(data) == 1
+            assert data[0]["id"] == str(seeded["reply_id"])
+            assert data[0]["content"] == "원문 리플 메시지"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_list_message_replies_403_non_participant():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["user_b"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/conversations/{seeded['conv_1_id']}/messages/{seeded['top_id']}/replies"
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_mcp_get_chat_message_3cf50d90.py
+++ b/backend/tests/test_mcp_get_chat_message_3cf50d90.py
@@ -1,0 +1,72 @@
+"""story 3cf50d90: MCP sprintable_get_chat_message — 웹훅 payload 잘림 시 message_id로
+즉시 원문 픽업(재발신 요청 왕복 대체)."""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_get_chat_message_returns_content_and_calls_single_message_path():
+    from sprintable_mcp.tools.chat import GetChatMessageInput, get_chat_message
+
+    thread_id = "11111111-1111-1111-1111-111111111111"
+    message_id = "22222222-2222-2222-2222-222222222222"
+    msg_resp = {
+        "id": message_id, "conversation_id": thread_id, "thread_id": None,
+        "content": "원문 전체 내용 — 잘리지 않음",
+        "sender": {"id": "s", "name": "디디", "type": "agent"},
+    }
+    calls: list[str] = []
+
+    async def fake_get(path, params=None):
+        calls.append(path)
+        return msg_resp
+
+    with patch("sprintable_mcp.tools.chat.client") as mock_client:
+        mock_client.get = AsyncMock(side_effect=fake_get)
+        out = await get_chat_message(GetChatMessageInput(thread_id=thread_id, message_id=message_id))
+
+    parsed = json.loads(out[0].text)
+    assert parsed["content"] == "원문 전체 내용 — 잘리지 않음"
+    assert calls == [f"/api/v2/conversations/{thread_id}/messages/{message_id}"]
+
+
+@pytest.mark.anyio
+async def test_get_chat_message_reply_also_resolves():
+    """리플 메시지도 동일 엔드포인트로 조회(top-level/리플 공용 회귀 가드)."""
+    from sprintable_mcp.tools.chat import GetChatMessageInput, get_chat_message
+
+    thread_id = "11111111-1111-1111-1111-111111111111"
+    parent_id = "33333333-3333-3333-3333-333333333333"
+    reply_id = "44444444-4444-4444-4444-444444444444"
+    reply_resp = {
+        "id": reply_id, "conversation_id": thread_id, "thread_id": parent_id,
+        "content": "리플 원문", "sender": {"id": "s", "name": "디디", "type": "agent"},
+    }
+
+    with patch("sprintable_mcp.tools.chat.client") as mock_client:
+        mock_client.get = AsyncMock(return_value=reply_resp)
+        out = await get_chat_message(GetChatMessageInput(thread_id=thread_id, message_id=reply_id))
+
+    parsed = json.loads(out[0].text)
+    assert parsed["content"] == "리플 원문"
+    assert parsed["thread_id"] == parent_id
+
+
+@pytest.mark.anyio
+async def test_get_chat_message_error_surfaces():
+    from sprintable_mcp.tools.chat import GetChatMessageInput, get_chat_message
+
+    with patch("sprintable_mcp.tools.chat.client") as mock_client:
+        mock_client.get = AsyncMock(side_effect=Exception("404 Not Found"))
+        out = await get_chat_message(GetChatMessageInput(thread_id="x", message_id="y"))
+
+    assert "error" in out[0].text.lower()


### PR DESCRIPTION
## Summary
- 게이트/QA 리플이 웹훅 payload 잘림으로 도달할 때 원문을 재조회할 경로가 없어 "잘렸다·재발신" 왕복이 반복되던 도그푸딩 갭 해소(선생님 지적 계기).
- `GET /api/v2/conversations/{id}/messages/{message_id}` — 단건 원문 조회(top-level + 리플 공용, 기존 404).
- `GET /api/v2/conversations/{id}/messages/{message_id}/replies` — 리플 목록 discoverable 서브리소스(기존 `?thread_id=`와 동형 필터, 새로 발견 가능하게).
- `list_messages`와 동형 인가 로직을 `_authorize_message_read` 헬퍼로 공용화(참여자 전용·admin-bypass는 agent-only 대화 한정, 회귀 0).
- MCP 신규 툴 `sprintable_get_chat_message` — 웹훅 message_id로 즉시 원문 픽업.

## Scope 확인
- 발명 최소: 기존 모델(`ConversationMessage.thread_id`)·기존 권한 로직 재사용, 신규 테이블/컬럼 0 — 마이그레이션 불요.
- `app/services/mcp_toolset.py`의 `ALL_TOOL_NAMES` SSOT + `tests/mcp/test_contract.py`의 양방향 계약(EXPECTED_TOOLS↔registered) 갱신(106→107).

## Test plan
- [x] `tests/test_3cf50d90_message_get_replies_realdb.py`(신규, realdb) — 참여자 200(top-level+리플)·비참여자 403·타 conversation 메시지 조회 404·replies 서브리소스 200/403.
- [x] `tests/test_mcp_get_chat_message_3cf50d90.py`(신규) — MCP 툴 단건 조회 성공/에러 경로.
- [x] `tests/mcp/test_contract.py` — 도구 수/EXPECTED_TOOLS 양방향 갱신 후 27/27 통과.
- [x] 기존 회귀 스윕: `test_conversations.py`·SEC-S8 conversation admin-bypass realdb·`test_conv_human_participant_realdb.py`·`test_e_mcp_s3_boot_filter.py` 전부 무회귀(63/63 통과, 로컬 PG16 실DB).
- [ ] 까심 QA + CI green 대기.

## 완료선 참고
⚠️ MCP 신규 툴 추가 — 머지 후 `backend/scripts/deploy_mcp_dev.sh`(Cloud Run 재배포)가 필요(호스팅 MCP에 `sprintable_get_chat_message` 반영). 이건 인프라 조치라 PO 판단/실행 요청.

🤖 Generated with [Claude Code](https://claude.com/claude-code)