### PR TITLE
fix(e-decision-gate): parallel gate 승인자 알림 갭 봉합 (story c1475cb5)

### DIFF
--- a/backend/app/services/workflow_parallel_approval.py
+++ b/backend/app/services/workflow_parallel_approval.py
@@ -83,6 +83,7 @@ async def create_parallel_gate(
         "reject_policy": quorum.get("reject_policy", "any_reject_blocks"),
     }
 
+    blocking_approver_ids: list[uuid.UUID] = []
     for a in approvers:
         kind = a.get("kind", "approver")
         blocking = a.get("blocking", kind == "approver")
@@ -101,8 +102,43 @@ async def create_parallel_gate(
             implementation_member_id=implementation_member_id,
             role_key=a.get("role_key"), kind=kind, blocking=blocking, status="pending",
         ))
+        if blocking and aid not in blocking_approver_ids:
+            blocking_approver_ids.append(aid)
     await session.flush()
+
+    # story c1475cb5(E-MOBILE M0 S1): 승인자 알림 갭 봉합 — approver row는 만들면서 통지는 안 나가던
+    # 경로. doc.py `_notify_doc_approval_requested` 선례와 동형(best-effort·기존 dispatch_notification
+    # 파이프라인 재사용·신규 채널/테이블 0).
+    await _notify_parallel_gate_approvers(session, step_run, gate, blocking_approver_ids)
+
     return gate, group_id
+
+
+async def _notify_parallel_gate_approvers(
+    session: AsyncSession,
+    step_run: WorkflowLineStepRun,
+    gate: Gate,
+    approver_ids: list[uuid.UUID],
+) -> None:
+    """story c1475cb5: parallel gate 생성 시 blocking approver에게 pending 통지.
+
+    doc.py `_notify_doc_approval_requested`와 동형(best-effort·비중단 — 알림 실패가 게이트 생성을
+    막지 않음). consult/non-blocking approver는 quorum에 안 들어 의사결정 주체가 아니므로 제외.
+    """
+    if not approver_ids:
+        return
+    try:
+        from app.services.notification_dispatch import dispatch_notification
+        await dispatch_notification(
+            session, org_id=step_run.org_id, event_type="gate_approval_requested",
+            target_member_ids=approver_ids,
+            title="게이트 결재 요청",
+            body=f"{step_run.entity_type} 항목의 {gate.gate_type} 결재가 대기 중입니다.",
+            reference_type="gate", reference_id=gate.id,
+            source_project_id=step_run.project_id,
+        )
+    except Exception:  # noqa: BLE001 — 알림 실패는 게이트 생성 비중단.
+        logger.warning("parallel gate 승인자 알림 실패 gate=%s", gate.id, exc_info=True)
 
 
 async def _tally_blocking(session: AsyncSession, group_id: uuid.UUID) -> dict[str, int]:

--- a/backend/tests/test_edg_s9_parallel_quorum.py
+++ b/backend/tests/test_edg_s9_parallel_quorum.py
@@ -2,6 +2,7 @@
 
 핵심: 대표 Gate 1개 + approver row N개(orphan 0)·quorum all/any/count·any_reject_blocks·
 consult/non-blocking quorum 제외·SoD self-approval guard(생성 시 + 해소 시)·transition_gate 단일 rail.
+story c1475cb5: 승인자 알림 갭 봉합(blocking approver에게 dispatch_notification 배선).
 """
 from __future__ import annotations
 
@@ -300,4 +301,100 @@ async def test_sod_guard_at_resolution_and_foreign_resolver():
         await s.flush()
         with pytest.raises(SelfApprovalError):
             await record_parallel_decision(s, appr2.id, "approved", uuid.uuid4())
+    await engine.dispose()
+
+
+# ── story c1475cb5: 승인자 알림 갭 봉합 ──────────────────────────────────────
+
+async def _seed_org_member_approver(s, org):
+    """실제로 dispatch_notification이 해소 가능한 휴먼(User+OrgMember) — Notification 검증용.
+    project_access/team_members 뷰는 안 건드림(그 경로는 다른 회귀 스코프) — org_member 폴백
+    경로(OrgMember.id 직접 매칭)만으로 in-app Notification 생성 여부 검증에 충분하다.
+    반환: (org_member.id, user.id) — approver_member_id에는 전자, Notification.user_id 대조는 후자."""
+    from app.models.project import OrgMember
+    from app.models.user import User
+    user_id = uuid.uuid4()
+    s.add(User(id=user_id, email=f"approver-{user_id.hex[:8]}@test.com", hashed_password="x"))
+    await s.flush()
+    om = OrgMember(id=uuid.uuid4(), org_id=org, user_id=user_id, role="member")
+    s.add(om)
+    await s.flush()
+    return om.id, user_id
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_blocking_approver_gets_pending_notification():
+    """핵심 회귀: create_parallel_gate가 blocking approver에게 in-app Notification을 남긴다
+    (수정 전엔 approver row만 생기고 통지가 전혀 발생하지 않았다)."""
+    from app.services.workflow_parallel_approval import create_parallel_gate
+    from app.models.notification import Notification
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr = await _seed_step_run(s, org)
+        approver_id, approver_user_id = await _seed_org_member_approver(s, org)
+        gate, _group = await create_parallel_gate(
+            s, sr, approvers=[_approver(member_id=approver_id)], quorum={"type": "all"},
+            member_id=uuid.uuid4(), role_id=uuid.uuid4(),
+        )
+        await s.commit()
+        notifs = (await s.execute(
+            select(Notification).where(Notification.reference_id == gate.id)
+        )).scalars().all()
+        assert len(notifs) == 1, "blocking approver 1명 → Notification 정확히 1건"
+        assert notifs[0].reference_type == "gate"
+        assert notifs[0].type == "gate_approval_requested"
+        assert notifs[0].user_id == approver_user_id
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_consult_approver_not_notified():
+    """consult(non-blocking) approver는 의사결정 주체가 아니므로 알림 대상에서 제외."""
+    from app.services.workflow_parallel_approval import create_parallel_gate
+    from app.models.notification import Notification
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr = await _seed_step_run(s, org)
+        consult_id, _consult_user_id = await _seed_org_member_approver(s, org)
+        gate, _group = await create_parallel_gate(
+            s, sr, approvers=[_approver(member_id=consult_id, kind="consult", blocking=False)],
+            quorum={"type": "all"}, member_id=uuid.uuid4(), role_id=uuid.uuid4(),
+        )
+        await s.commit()
+        notifs = (await s.execute(
+            select(Notification).where(Notification.reference_id == gate.id)
+        )).scalars().all()
+        assert len(notifs) == 0, "consult(non-blocking)는 통지 대상 아님"
+    await engine.dispose()
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요")
+@pytest.mark.anyio
+async def test_multiple_blocking_approvers_each_notified_once():
+    """이중발송 0: blocking approver N명 → 각자 정확히 1건씩(N건), 중복 없음."""
+    from app.services.workflow_parallel_approval import create_parallel_gate
+    from app.models.notification import Notification
+    from sqlalchemy import select
+    engine, Session = await _session()
+    async with Session() as s:
+        org = uuid.uuid4()
+        sr = await _seed_step_run(s, org)
+        a1_id, a1_user_id = await _seed_org_member_approver(s, org)
+        a2_id, a2_user_id = await _seed_org_member_approver(s, org)
+        gate, _group = await create_parallel_gate(
+            s, sr, approvers=[_approver(member_id=a1_id), _approver(member_id=a2_id)],
+            quorum={"type": "all"}, member_id=uuid.uuid4(), role_id=uuid.uuid4(),
+        )
+        await s.commit()
+        notifs = (await s.execute(
+            select(Notification).where(Notification.reference_id == gate.id)
+        )).scalars().all()
+        assert len(notifs) == 2, "blocking approver 2명 → 정확히 2건(중복 0)"
+        assert {n.user_id for n in notifs} == {a1_user_id, a2_user_id}
     await engine.dispose()


### PR DESCRIPTION
## Summary
- E-MOBILE M0 S1 — crux 그라운딩(`e-mobile-m0-crux-grounding` doc)에서 발견한 근본 갭 봉합.
- `create_parallel_gate()`(merge/PR review류 다중 승인자 게이트)가 `WorkflowLineStepApproval.approver_member_id`로 승인자를 이미 명시적으로 갖고 있으면서도 `dispatch_notification`을 전혀 호출하지 않아 "게이트 pending" 통지 자체가 발생하지 않는 경로였음(단일-승인자 doc_approval류는 `doc.py`의 `_notify_doc_approval_requested`로 이미 대칭 배선돼 있었음 — 그 선례와 동형으로 맞춤).
- push 채널을 붙여도 이 갭은 저절로 안 풀리므로(채널 무관 근본 문제), E-MOBILE의 Expo push 파이프라인이 의미를 가지려면 선행돼야 하는 수정.

## 정직 고지
- `create_parallel_gate()`는 실측 결과 **현재 프로덕션 콜사이트가 0건**(테스트에서만 호출, 라우터/서비스 어디서도 아직 미배선 — E-DECISION-GATE S9 MVP 스캐폴딩). 즉 지금 당장 라이브 임팩트는 없으나, 향후 콜사이트가 붙는 순간(또는 M0 push 파이프라인이 이 경로를 소비하기 시작하는 순간) 통지가 나가도록 선행 배선하는 것.

## 변경
- `_notify_parallel_gate_approvers()` 신설(`workflow_parallel_approval.py`) — `doc.py`의 기존 패턴과 동형(best-effort·비중단·기존 `dispatch_notification` 파이프라인 재사용). blocking approver만 대상(consult/non-blocking은 quorum 비참여라 제외).
- 신규 테이블/채널/마이그레이션 0.

## Test plan
- [x] `test_blocking_approver_gets_pending_notification` — blocking approver 1명 → Notification 정확히 1건, reference_type=gate.
- [x] `test_consult_approver_not_notified` — consult(non-blocking)는 통지 대상 아님.
- [x] `test_multiple_blocking_approvers_each_notified_once` — blocking N명 → 중복 없이 N건.
- [x] **뮤테이션 셀프체크**: `_notify_parallel_gate_approvers` 호출을 주석 처리 → 위 3개 중 긍정 assert 테스트 2개가 RED로 정확히 실패하는 것 확인 후 원복(PR 전 셀프 게이트 doc §1 준수).
- [x] 기존 `test_edg_s9_parallel_quorum.py`(quorum all/any/count·any-reject·SoD·orphan-0) 전부 무회귀(12/12).
- [x] `test_edg_doc_gate_inbox.py`(doc_approval류) 무회귀(13/13) — 이 PR이 안 건드리는 별개 경로지만 대칭 선례라 확인.
- [ ] 까심 QA + CI green 대기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)