### PR TITLE
[졷버그·fix] admin이 타 멤버 웹훅 설정 가능 — 침묵 caller-저장 제거

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -842,6 +842,7 @@
     "webhookHelperEmpty": "This agent uses the in-app fakechat channel for notifications. Enable the webhook to forward to external systems.",
     "webhookHelperActive": "Events are forwarded to the configured URL. In-app fakechat is not used.",
     "webhookHelperPaused": "The webhook URL is preserved but currently inactive. Re-enable the toggle to resume.",
+    "webhookAdminOnly": "Only admins can configure another member's webhook.",
     "webhookUrlRequired": "Enter a URL first.",
     "webhookListTitle": "My webhooks",
     "webhookScopeGlobal": "Global",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -842,6 +842,7 @@
     "webhookHelperEmpty": "이 에이전트는 앱 내장 fakechat 채널로 알림을 받습니다. 웹훅을 켜서 외부 시스템으로 전달하세요.",
     "webhookHelperActive": "이벤트는 설정된 URL로 전송됩니다. 앱 내장 fakechat은 사용되지 않습니다.",
     "webhookHelperPaused": "웹훅 URL은 보존되어 있으나 현재 비활성. 토글을 다시 켜면 즉시 재개.",
+    "webhookAdminOnly": "관리자만 다른 멤버의 웹훅을 설정할 수 있습니다.",
     "webhookUrlRequired": "URL을 먼저 입력하세요.",
     "webhookListTitle": "내 webhook",
     "webhookScopeGlobal": "글로벌",

--- a/apps/web/src/app/(authenticated)/agents/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/agents/[id]/page.tsx
@@ -327,6 +327,10 @@ export default function AgentDetailPage() {
     (currentUserId !== null && agent.created_by === currentUserId) ||
     orgRole === 'admin' ||
     orgRole === 'owner';
+  // story 933248fa — 타 멤버 웹훅 설정은 BE가 admin/owner role만 허용(creator 단독은 불가, 산티아고
+  // IDOR 방어 유지). canEdit(creator 포함)보다 엄격하게 별도 게이트 — 아니면 편집 UI가 "가능해 보이는데
+  // 실제로 실패"하는 정직하지 않은 상태가 재발한다(§673 프로젝트 grant 게이트와 동일 패턴).
+  const canEditWebhook = orgRole === 'admin' || orgRole === 'owner';
 
   const handleSaveRuntime = async () => {
     setSavingRuntime(true);
@@ -549,6 +553,9 @@ export default function AgentDetailPage() {
               </div>
             </SectionCardHeader>
             <SectionCardBody className="space-y-3">
+              {!canEditWebhook ? (
+                <p className="text-xs text-muted-foreground">{t('webhookAdminOnly')}</p>
+              ) : null}
               <div className="flex items-center justify-between gap-4">
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium">{t('webhookEnabledToggle')}</p>
@@ -557,7 +564,7 @@ export default function AgentDetailPage() {
                 <Switch
                   checked={webhookActive}
                   onCheckedChange={(next) => void handleToggle(next)}
-                  disabled={savingWebhook}
+                  disabled={savingWebhook || !canEditWebhook}
                 />
               </div>
               <div className="flex gap-2">
@@ -567,13 +574,13 @@ export default function AgentDetailPage() {
                   onChange={(e) => setWebhookUrl(e.target.value)}
                   placeholder="https://your-agent.example.com/webhook"
                   className="flex-1 font-mono text-xs"
-                  disabled={!webhookActive}
+                  disabled={!webhookActive || !canEditWebhook}
                 />
                 <Button
                   variant="hero"
                   size="sm"
                   onClick={() => void handleSaveWebhook()}
-                  disabled={savingWebhook || !webhookActive || !webhookUrl.trim()}
+                  disabled={savingWebhook || !webhookActive || !webhookUrl.trim() || !canEditWebhook}
                 >
                   {savingWebhook ? '...' : tc('save')}
                 </Button>

--- a/backend/app/routers/webhooks.py
+++ b/backend/app/routers/webhooks.py
@@ -8,6 +8,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.conversation_webhook_delivery import ConversationWebhookDelivery
+from app.models.project import OrgMember
+from app.models.team import TeamMember
 from app.repositories.webhook_config import WebhookConfigRepository
 from app.schemas.webhook_config import UpsertWebhookConfig, WebhookConfigResponse
 
@@ -54,6 +56,41 @@ async def _get_caller_member_id(
     return resolved.id
 
 
+async def _resolve_target_member_id(
+    target_id: uuid.UUID,
+    org_id: uuid.UUID,
+    session: AsyncSession,
+) -> uuid.UUID:
+    """story 933248fa — admin이 지정한 target(FE가 항상 보내는 TeamMember.id, 자기서비스 org-members-
+    only 폴백 경로만 예외적으로 OrgMember.id)를 webhook_configs.member_id 정규형(휴먼=org_member.id·
+    에이전트=team_member.id, `_get_caller_member_id`와 동일 축)으로 **서버측 재해소**한다.
+
+    ⚠️SEC 규율①(PO 2026-07-15 확定): org 소속은 body의 org_id가 아니라 **caller의 검증된 org_id**로
+    쿼리해 판정한다(body-claimed 금지) — target_id가 caller org 밖 것이면 그냥 못 찾은 것처럼 404
+    (기존 get_owned/list IDOR 패턴과 동형, 존재 여부 누설 없음).
+    """
+    tm = (await session.execute(
+        select(TeamMember).where(TeamMember.id == target_id, TeamMember.org_id == org_id)
+    )).scalars().first()
+    if tm is not None:
+        if tm.type == "agent":
+            return tm.id
+        om = (await session.execute(
+            select(OrgMember).where(OrgMember.user_id == tm.user_id, OrgMember.org_id == org_id)
+        )).scalar_one_or_none()
+        if om is None:
+            raise HTTPException(status_code=404, detail="Member not found")
+        return om.id
+    # TeamMember.id가 아니면(자기서비스 org-members-only 폴백 — /me가 org_member.id를 직접 반환하는
+    # 경로), target_id 자체가 OrgMember.id일 수 있다 — 동일 org 스코프로 재시도.
+    om = (await session.execute(
+        select(OrgMember).where(OrgMember.id == target_id, OrgMember.org_id == org_id)
+    )).scalar_one_or_none()
+    if om is None:
+        raise HTTPException(status_code=404, detail="Member not found")
+    return om.id
+
+
 @router.get("/config", response_model=list[WebhookConfigResponse])
 async def list_webhook_configs(
     project_id: uuid.UUID | None = Query(default=None),
@@ -70,11 +107,33 @@ async def upsert_webhook_config(
     body: UpsertWebhookConfig,
     repo: WebhookConfigRepository = Depends(_get_repo),
     caller_member_id: uuid.UUID = Depends(_get_caller_member_id),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    session: AsyncSession = Depends(get_db),
 ) -> WebhookConfigResponse:
-    # IDOR(산티아고): member_id 는 **auth context 서 산출**(body.member_id 불신·무시) — caller 는 자기
-    # 소유 config 만 생성/수정한다. body 에 타 멤버 id 를 넣어도 caller 로 강제되어 무해(타 멤버 설정 불가).
+    """story 933248fa fix — 산티아고의 원 IDOR 방어(caller-only)는 비-admin 경로에 **바이트 단위로
+    그대로 유지**한다. 추가된 것은 admin-scoped override 1개뿐:
+
+    1. body.member_id(FE가 항상 보내는 TeamMember.id)를 caller org 스코프로 서버측 재해소해
+       webhook_configs 정규 축(휴먼=org_member.id·에이전트=team_member.id)으로 변환한다
+       (`_resolve_target_member_id` — body-claimed org 신뢰 금지, SEC 규율①).
+    2. 해소된 target 이 caller 자신이면(자기서비스, 지금까지처럼) 그대로 진행 — 무회귀.
+    3. target 이 caller 와 다르면(타 멤버 대상) **admin/owner role 필수**(SEC 규율②, JWT
+       app_metadata.role — 서버 검증된 클레임, body 아님) — 아니면 **명시 403**(예전처럼 caller
+       로 침묵 강제 저장하지 않는다. 그 침묵 저장이 이번 버그의 실제 부작용이었다).
+    """
+    target_member_id = await _resolve_target_member_id(body.member_id, org_id, session)
+
+    if target_member_id != caller_member_id:
+        role = auth.claims.get("app_metadata", {}).get("role", "member")
+        if role not in ("admin", "owner"):
+            raise HTTPException(
+                status_code=403,
+                detail="Admin role required to configure another member's webhook",
+            )
+
     config = await repo.upsert(
-        member_id=caller_member_id,
+        member_id=target_member_id,
         url=body.url,
         project_id=body.project_id,
         events=body.events,

--- a/backend/tests/test_notif_trust_testsend.py
+++ b/backend/tests/test_notif_trust_testsend.py
@@ -161,23 +161,74 @@ async def test_delete_is_member_scoped_404_for_other():
     assert repo.delete.await_args.args[1] == caller
 
 
-@pytest.mark.anyio
-async def test_upsert_uses_caller_member_ignoring_body():
-    """PUT 은 body.member_id 를 무시하고 **caller_member_id 로 강제** upsert(타 멤버 설정 불가)."""
-    from app.routers.webhooks import upsert_webhook_config
-    repo = AsyncMock()
-    repo.upsert = AsyncMock(return_value=SimpleNamespace(
-        id=uuid.uuid4(), org_id=uuid.uuid4(), member_id=uuid.uuid4(), project_id=None,
+def _mock_response_for(member_id: uuid.UUID) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(), org_id=uuid.uuid4(), member_id=member_id, project_id=None,
         url="https://x/h", events=[], channel="generic", is_active=True,
         created_at=__import__("datetime").datetime(2026, 1, 1), secret=None,
-    ))
+    )
+
+
+def _auth(role: str) -> SimpleNamespace:
+    return SimpleNamespace(user_id=str(uuid.uuid4()), email=None, claims={"app_metadata": {"role": role}})
+
+
+@pytest.mark.anyio
+async def test_upsert_self_service_bypasses_admin_check():
+    """story 933248fa fix: target(재해소된 body.member_id)==caller 면 role 무관 무회귀(자기서비스)."""
+    from app.routers.webhooks import upsert_webhook_config
+    repo = AsyncMock()
+    caller = uuid.uuid4()
+    repo.upsert = AsyncMock(return_value=_mock_response_for(caller))
+    body = SimpleNamespace(
+        member_id=caller, url="https://x/h", project_id=None, events=[], is_active=True, secret=None
+    )
+    with patch("app.routers.webhooks._resolve_target_member_id", new=AsyncMock(return_value=caller)):
+        await upsert_webhook_config(
+            body, repo=repo, caller_member_id=caller,
+            auth=_auth("member"), org_id=uuid.uuid4(), session=AsyncMock(),
+        )
+    assert repo.upsert.await_args.kwargs["member_id"] == caller
+
+
+@pytest.mark.anyio
+async def test_upsert_non_admin_cross_member_403_no_silent_fallback():
+    """story 933248fa fix — 이번 버그의 핵심: 비-admin이 타 멤버(재해소된 target!=caller)를 노리면
+    예전처럼 caller 로 침묵 강제 upsert 하지 않는다. 명시 403 **AND repo.upsert 자체가 호출되지
+    않음**까지 확認(부작용 0 직접 증명 — realdb IDOR sabotage 테스트의 단위테스트 짝)."""
+    from fastapi import HTTPException
+    from app.routers.webhooks import upsert_webhook_config
+    repo = AsyncMock()
     caller, other = uuid.uuid4(), uuid.uuid4()
     body = SimpleNamespace(
         member_id=other, url="https://x/h", project_id=None, events=[], is_active=True, secret=None
     )
-    await upsert_webhook_config(body, repo=repo, caller_member_id=caller)
-    # body.member_id(other) 가 아니라 caller 로 upsert — 타 멤버 설정 불가
-    assert repo.upsert.await_args.kwargs["member_id"] == caller
+    with patch("app.routers.webhooks._resolve_target_member_id", new=AsyncMock(return_value=other)):
+        with pytest.raises(HTTPException) as exc:
+            await upsert_webhook_config(
+                body, repo=repo, caller_member_id=caller,
+                auth=_auth("member"), org_id=uuid.uuid4(), session=AsyncMock(),
+            )
+    assert exc.value.status_code == 403
+    repo.upsert.assert_not_awaited()  # ⭐caller 에게도 침묵 저장 0(이번 버그의 실제 부작용 재발 방지)
+
+
+@pytest.mark.anyio
+async def test_upsert_admin_can_target_another_member():
+    """story 933248fa fix: admin(JWT role)이면 재해소된 target(!=caller)으로 upsert 허용."""
+    from app.routers.webhooks import upsert_webhook_config
+    repo = AsyncMock()
+    caller, other = uuid.uuid4(), uuid.uuid4()
+    repo.upsert = AsyncMock(return_value=_mock_response_for(other))
+    body = SimpleNamespace(
+        member_id=other, url="https://x/h", project_id=None, events=[], is_active=True, secret=None
+    )
+    with patch("app.routers.webhooks._resolve_target_member_id", new=AsyncMock(return_value=other)):
+        await upsert_webhook_config(
+            body, repo=repo, caller_member_id=caller,
+            auth=_auth("admin"), org_id=uuid.uuid4(), session=AsyncMock(),
+        )
+    assert repo.upsert.await_args.kwargs["member_id"] == other
 
 
 # ─── 멤버 축 정합: _get_caller_member_id = resolve_member().id (산티아고/PO hotfix) ──

--- a/backend/tests/test_s34.py
+++ b/backend/tests/test_s34.py
@@ -98,7 +98,12 @@ async def test_upsert_config_create_200():
     client, session, app = await _client()
     try:
         with patch("app.schemas.webhook_config.validate_webhook_url"), \
-             patch("app.repositories.webhook_config.WebhookConfigRepository.upsert", new_callable=AsyncMock) as mock_upsert:
+             patch("app.repositories.webhook_config.WebhookConfigRepository.upsert", new_callable=AsyncMock) as mock_upsert, \
+             patch("app.routers.webhooks._resolve_target_member_id", new=AsyncMock(return_value=MEMBER_ID)):
+            # story 933248fa: body.member_id==MEMBER_ID(=overridden caller)라 자기서비스 경로 —
+            # 신규 target 재해소(_resolve_target_member_id, 실 DB 쿼리)는 이 단위테스트 스코프 밖이라
+            # mock. CRUD 200 계약만 검증(target-resolution 자체는 test_webhook_config_target_member_
+            # realdb.py가 커버).
             mock_upsert.return_value = _mock_config()
 
             async with client as c:
@@ -121,7 +126,8 @@ async def test_upsert_config_update_200():
     try:
         updated = _mock_config(is_active=False)
         with patch("app.schemas.webhook_config.validate_webhook_url"), \
-             patch("app.repositories.webhook_config.WebhookConfigRepository.upsert", new_callable=AsyncMock) as mock_upsert:
+             patch("app.repositories.webhook_config.WebhookConfigRepository.upsert", new_callable=AsyncMock) as mock_upsert, \
+             patch("app.routers.webhooks._resolve_target_member_id", new=AsyncMock(return_value=MEMBER_ID)):
             mock_upsert.return_value = updated
 
             async with client as c:

--- a/backend/tests/test_webhook_config_target_member_realdb.py
+++ b/backend/tests/test_webhook_config_target_member_realdb.py
@@ -1,0 +1,245 @@
+"""story 933248fa — webhook config PUT의 admin-scoped target override + IDOR sabotage 방어 realdb.
+
+근본: 산티아고의 원 IDOR 방어(caller-only, body.member_id 완전 무시)가 admin의 정당한 타 멤버
+설정 요구까지 침묵으로 caller 자신에 덮어썼다("200인데 미반영" + 실제 부작용=caller 자기 config
+오염). fix = admin+same-org(서버 재해소)만 예외 허용, 비-admin은 기존 IDOR 방어 바이트 단위 유지+
+거짓 200 제거(명시 403).
+
+**IDOR sabotage 필수(PO 2026-07-15 지시)**: 비-admin이 body.member_id로 타 멤버를 노려도 ①차단되고
+②caller 자신에게로도 침묵 저장되지 않는지(이번 버그의 실제 부작용 재발 방지) 둘 다 실DB로 증명한다.
+realdb 필수 — team_members는 0088부터 members/agent_project_profiles 기반 projection VIEW라 mock으론
+join 시맨틱을 재현 못 한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import text
+
+_RAW = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("PARITY_TEST_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _RAW, reason="real-DB URL 미설정 — skip")
+
+ORG = uuid.UUID("cf000000-0000-0000-0000-000000000001")
+OTHER_ORG = uuid.UUID("cf000000-0000-0000-0000-0000000000f0")
+PROJ = uuid.UUID("cf000000-0000-0000-0000-000000000002")
+ADMIN_USER = uuid.UUID("cf000000-0000-0000-0000-0000000000a1")
+ADMIN_OM = uuid.UUID("cf000000-0000-0000-0000-0000000000a2")
+MEMBER_USER = uuid.UUID("cf000000-0000-0000-0000-0000000000b1")
+MEMBER_OM = uuid.UUID("cf000000-0000-0000-0000-0000000000b2")
+AGENT_TARGET = uuid.UUID("cf000000-0000-0000-0000-0000000000c1")
+OTHER_ORG_AGENT = uuid.UUID("cf000000-0000-0000-0000-0000000000d1")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _admin_auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(ADMIN_USER), email=None,
+        claims={"app_metadata": {"role": "admin", "org_id": str(ORG)}}, org_id=str(ORG),
+    )
+
+
+def _member_auth():
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(MEMBER_USER), email=None,
+        claims={"app_metadata": {"role": "member", "org_id": str(ORG)}}, org_id=str(ORG),
+    )
+
+
+def _agent_auth(agent_id: uuid.UUID, org: uuid.UUID = ORG):
+    # 에이전트 API 키: auth.user_id = members.id(=team_member.id), app_metadata.api_key_id 존재.
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(agent_id), email=None,
+        claims={"app_metadata": {"role": "member", "org_id": str(org), "api_key_id": "fake-key"}},
+        org_id=str(org),
+    )
+
+
+async def _seed(s):
+    for sql in [
+        f"DELETE FROM webhook_configs WHERE org_id IN ('{ORG}','{OTHER_ORG}')",
+        f"DELETE FROM agent_project_profiles WHERE member_id IN ('{AGENT_TARGET}','{OTHER_ORG_AGENT}')",
+        f"DELETE FROM members WHERE org_id IN ('{ORG}','{OTHER_ORG}')",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id IN ('{ORG}','{OTHER_ORG}')",
+        f"DELETE FROM users WHERE id IN ('{ADMIN_USER}','{MEMBER_USER}')",
+        f"DELETE FROM organizations WHERE id IN ('{ORG}','{OTHER_ORG}')",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','CF','cforg','free')",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{OTHER_ORG}','CF2','cforg2','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{ADMIN_USER}','admin@cf.test','x','Admin',true,true,0,false,0)",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,"
+        f"login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{MEMBER_USER}','member@cf.test','x','Member',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{ADMIN_OM}','{ORG}','{ADMIN_USER}','admin')",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{MEMBER_OM}','{ORG}','{MEMBER_USER}','member')",
+        f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ}','{ORG}','P')",
+        f"INSERT INTO members (id,org_id,type,name,is_active) VALUES ('{AGENT_TARGET}','{ORG}','agent','Agent',true)",
+        f"INSERT INTO agent_project_profiles (id,member_id,project_id) VALUES (gen_random_uuid(),'{AGENT_TARGET}','{PROJ}')",
+        # cross-org 축: 같은 UUID 형식이지만 다른 org 소속 agent — target 검증이 body-claimed 아닌
+        # caller org로 실제 재해소하는지 증명(SEC 규율①).
+        f"INSERT INTO members (id,org_id,type,name,is_active) VALUES ('{OTHER_ORG_AGENT}','{OTHER_ORG}','agent','Other',true)",
+    ]:
+        await s.execute(text(sql))
+    await s.commit()
+
+
+async def _webhook_row(s, org, member_id):
+    return (await s.execute(text(
+        f"SELECT url FROM webhook_configs WHERE org_id='{org}' AND member_id='{member_id}'"
+    ))).scalar_one_or_none()
+
+
+@pytest.mark.anyio
+async def test_admin_can_configure_another_members_webhook():
+    """admin이 body.member_id=AGENT_TARGET으로 PUT → AGENT_TARGET 행에 실제 반영(admin 자신 행 아님)."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.repositories.webhook_config import WebhookConfigRepository
+    from app.routers.webhooks import _get_caller_member_id, upsert_webhook_config
+    from app.schemas.webhook_config import UpsertWebhookConfig
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            auth = _admin_auth()
+            caller_member_id = await _get_caller_member_id(auth=auth, org_id=ORG, session=s)
+            assert caller_member_id == ADMIN_OM  # 그라운딩: admin 캐스팅이 예상 축과 일치
+
+            body = UpsertWebhookConfig(member_id=AGENT_TARGET, url="https://hooks.example.com/agent-target")
+            result = await upsert_webhook_config(
+                body=body, repo=WebhookConfigRepository(s, ORG),
+                caller_member_id=caller_member_id, auth=auth, org_id=ORG, session=s,
+            )
+            await s.commit()
+            assert result.member_id == AGENT_TARGET  # admin 자신(ADMIN_OM) 아닌 target에 반영
+
+        async with Session() as s:
+            assert await _webhook_row(s, ORG, AGENT_TARGET) == "https://hooks.example.com/agent-target"
+            assert await _webhook_row(s, ORG, ADMIN_OM) is None  # admin 자신 행은 생성 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_non_admin_cross_member_blocked_no_silent_self_write():
+    """비-admin이 body.member_id=AGENT_TARGET(타 멤버)로 PUT → 403, **AND** caller 자기 config도 미생성
+    (이번 버그의 실제 부작용 — 침묵 caller-저장 — 이 재발 안 함을 직접 증명·IDOR sabotage)."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.repositories.webhook_config import WebhookConfigRepository
+    from app.routers.webhooks import _get_caller_member_id, upsert_webhook_config
+    from app.schemas.webhook_config import UpsertWebhookConfig
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            auth = _member_auth()
+            caller_member_id = await _get_caller_member_id(auth=auth, org_id=ORG, session=s)
+            assert caller_member_id == MEMBER_OM
+
+            body = UpsertWebhookConfig(member_id=AGENT_TARGET, url="https://hooks.example.com/sabotage-attempt")
+            with pytest.raises(HTTPException) as exc:
+                await upsert_webhook_config(
+                    body=body, repo=WebhookConfigRepository(s, ORG),
+                    caller_member_id=caller_member_id, auth=auth, org_id=ORG, session=s,
+                )
+            assert exc.value.status_code == 403
+            await s.rollback()
+
+        async with Session() as s:
+            assert await _webhook_row(s, ORG, AGENT_TARGET) is None  # target 미반영(당연)
+            assert await _webhook_row(s, ORG, MEMBER_OM) is None  # ⭐caller 자신도 침묵 저장 0(sabotage 방어)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_self_service_unaffected_agent_caller():
+    """target==caller(자기서비스)는 role 무관 그대로 통과 — 무회귀 증명."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.repositories.webhook_config import WebhookConfigRepository
+    from app.routers.webhooks import _get_caller_member_id, upsert_webhook_config
+    from app.schemas.webhook_config import UpsertWebhookConfig
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            auth = _agent_auth(AGENT_TARGET)
+            caller_member_id = await _get_caller_member_id(auth=auth, org_id=ORG, session=s)
+            assert caller_member_id == AGENT_TARGET
+
+            body = UpsertWebhookConfig(member_id=AGENT_TARGET, url="https://hooks.example.com/self")
+            result = await upsert_webhook_config(
+                body=body, repo=WebhookConfigRepository(s, ORG),
+                caller_member_id=caller_member_id, auth=auth, org_id=ORG, session=s,
+            )
+            await s.commit()
+            assert result.member_id == AGENT_TARGET
+
+        async with Session() as s:
+            assert await _webhook_row(s, ORG, AGENT_TARGET) == "https://hooks.example.com/self"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_cross_org_target_404_not_body_claimed():
+    """target이 caller org 밖(타 org agent)이면 404 — org 소속은 body가 아닌 caller의 검증된 org로 판정."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.repositories.webhook_config import WebhookConfigRepository
+    from app.routers.webhooks import _get_caller_member_id, upsert_webhook_config
+    from app.schemas.webhook_config import UpsertWebhookConfig
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            auth = _admin_auth()
+            caller_member_id = await _get_caller_member_id(auth=auth, org_id=ORG, session=s)
+
+            body = UpsertWebhookConfig(member_id=OTHER_ORG_AGENT, url="https://hooks.example.com/cross-org")
+            with pytest.raises(HTTPException) as exc:
+                await upsert_webhook_config(
+                    body=body, repo=WebhookConfigRepository(s, ORG),
+                    caller_member_id=caller_member_id, auth=auth, org_id=ORG, session=s,
+                )
+            assert exc.value.status_code == 404
+            await s.rollback()
+
+        async with Session() as s:
+            assert await _webhook_row(s, OTHER_ORG, OTHER_ORG_AGENT) is None
+            assert await _webhook_row(s, ORG, ADMIN_OM) is None  # admin 자신에게도 침묵 저장 0
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_webhook_config_target_member_realdb.py
+++ b/backend/tests/test_webhook_config_target_member_realdb.py
@@ -124,7 +124,7 @@ async def test_admin_can_configure_another_members_webhook():
             caller_member_id = await _get_caller_member_id(auth=auth, org_id=ORG, session=s)
             assert caller_member_id == ADMIN_OM  # 그라운딩: admin 캐스팅이 예상 축과 일치
 
-            body = UpsertWebhookConfig(member_id=AGENT_TARGET, url="https://hooks.example.com/agent-target")
+            body = UpsertWebhookConfig(member_id=AGENT_TARGET, url="https://example.com/agent-target")
             result = await upsert_webhook_config(
                 body=body, repo=WebhookConfigRepository(s, ORG),
                 caller_member_id=caller_member_id, auth=auth, org_id=ORG, session=s,
@@ -133,7 +133,7 @@ async def test_admin_can_configure_another_members_webhook():
             assert result.member_id == AGENT_TARGET  # admin 자신(ADMIN_OM) 아닌 target에 반영
 
         async with Session() as s:
-            assert await _webhook_row(s, ORG, AGENT_TARGET) == "https://hooks.example.com/agent-target"
+            assert await _webhook_row(s, ORG, AGENT_TARGET) == "https://example.com/agent-target"
             assert await _webhook_row(s, ORG, ADMIN_OM) is None  # admin 자신 행은 생성 0
     finally:
         await engine.dispose()
@@ -160,7 +160,7 @@ async def test_non_admin_cross_member_blocked_no_silent_self_write():
             caller_member_id = await _get_caller_member_id(auth=auth, org_id=ORG, session=s)
             assert caller_member_id == MEMBER_OM
 
-            body = UpsertWebhookConfig(member_id=AGENT_TARGET, url="https://hooks.example.com/sabotage-attempt")
+            body = UpsertWebhookConfig(member_id=AGENT_TARGET, url="https://example.com/sabotage-attempt")
             with pytest.raises(HTTPException) as exc:
                 await upsert_webhook_config(
                     body=body, repo=WebhookConfigRepository(s, ORG),
@@ -196,7 +196,7 @@ async def test_self_service_unaffected_agent_caller():
             caller_member_id = await _get_caller_member_id(auth=auth, org_id=ORG, session=s)
             assert caller_member_id == AGENT_TARGET
 
-            body = UpsertWebhookConfig(member_id=AGENT_TARGET, url="https://hooks.example.com/self")
+            body = UpsertWebhookConfig(member_id=AGENT_TARGET, url="https://example.com/self")
             result = await upsert_webhook_config(
                 body=body, repo=WebhookConfigRepository(s, ORG),
                 caller_member_id=caller_member_id, auth=auth, org_id=ORG, session=s,
@@ -205,7 +205,7 @@ async def test_self_service_unaffected_agent_caller():
             assert result.member_id == AGENT_TARGET
 
         async with Session() as s:
-            assert await _webhook_row(s, ORG, AGENT_TARGET) == "https://hooks.example.com/self"
+            assert await _webhook_row(s, ORG, AGENT_TARGET) == "https://example.com/self"
     finally:
         await engine.dispose()
 
@@ -229,7 +229,7 @@ async def test_cross_org_target_404_not_body_claimed():
             auth = _admin_auth()
             caller_member_id = await _get_caller_member_id(auth=auth, org_id=ORG, session=s)
 
-            body = UpsertWebhookConfig(member_id=OTHER_ORG_AGENT, url="https://hooks.example.com/cross-org")
+            body = UpsertWebhookConfig(member_id=OTHER_ORG_AGENT, url="https://example.com/cross-org")
             with pytest.raises(HTTPException) as exc:
                 await upsert_webhook_config(
                     body=body, repo=WebhookConfigRepository(s, ORG),


### PR DESCRIPTION
## 요약
- story `933248fa`(high) — ⛔프로덕션 데이터 오염 버그. 선생님이 웹(dev-app)에서 민 멤버의 웹훅을 설정하려 `PUT /api/v2/webhooks/config` → 200 OK인데 실제 반영 안 됨.

## 근본원인 (코드 그라운딩, 추측 0)
- **BE**: `upsert_webhook_config`가 `body.member_id`를 완전 무시하고 **항상 caller 자신**에게 강제 저장(산티아고의 의도적 IDOR 방어 — "caller는 자기 config만"). 그런데 admin이 타 멤버를 설정하려는 **정당한** 시도까지 침묵으로 caller 자신의 config를 덮어썼다.
- **FE**: `agents/[id]/page.tsx`가 `{member_id: id, ...}`(대상 에이전트/멤버 id)를 명시적으로 실어 PUT — BE가 그 필드를 완전 무시하는 걸 FE는 모르는 상태로 설계돼 있었다.
- **부작용**: `fetchWebhookConfigs`가 `c.member_id === id`로 필터하는데 실제 저장은 caller 소유로 되니 필터 결과가 **항상 빈 배열** — 저장 직후 URL 입력란이 비어보임("200인데 미반영"의 정확한 재현 메커니즘). 그리고 **저장 시도한 사람 본인의 webhook config가 조용히 오염**되는 게 실제 부작용(민 대상으로 저장 시도 = 본인 config가 민의 URL로 덮임).

## fix (PO 승인 SEC 규율 2개)
1. **①target 검증 = resource-actual**(body-claimed 아님): `_resolve_target_member_id`가 caller의 **서버 검증된 org_id**로 target을 재해소한다 — body의 org 주장을 신뢰하지 않는다(SEC-S8 계보).
2. **②비-admin 경로 = 기존 IDOR 방어 바이트 단위 그대로**(산티아고 결정 보존) — 단 **거짓 200 제거**: 예전처럼 caller에 침묵 저장하는 대신 **명시 403**.

`body.member_id`(FE가 항상 보내는 `TeamMember.id`)를 caller org 스코프로 재해소해 `webhook_configs` 정규 축(휴먼=`org_member.id`·에이전트=`team_member.id`)으로 변환. 해소된 target이 caller 자신이면 **무회귀**(자기서비스 그대로 통과, role 무관). target이 다르면 **admin/owner role**(JWT 서버검증 클레임, body 아님) 필수.

## FE
`agents/[id]/page.tsx` — admin/owner가 아니면 웹훅 편집 UI(토글·입력·저장 버튼) 비활성 + 안내 문구(`webhookAdminOnly`). 실제 보안 경계는 BE 403이지만, 비-admin이 우발적으로 **자기 config를 오염시키는** 재발 자체를 UI 단에서 차단(이번 버그의 실제 부작용 재발 방지).

## IDOR sabotage 테스트 (PO 지시 — 4건 신규)
`test_webhook_config_target_member_realdb.py`:
- admin이 타 멤버(에이전트) 웹훅 설정 → 성공, target 행에 반영(admin 자신 행 아님).
- **비-admin이 body.member_id로 타 멤버를 노림 → 403 AND caller 자신에게도 침묵 저장 안 됨**(이번 버그의 실제 부작용 재발 방지 직접 증명 — sabotage 방어).
- target==caller(자기서비스) → role 무관 무회귀.
- cross-org target → 404(body-claimed 아닌 caller org로 판정).

⚠️**정직 고지**: 로컬 dev DB(docker compose, 6주 무재시작)가 최근 마이그(`team_members` 뷰 전환 0088 등) 미반영 + `alembic_version` 상태 불일치라 로컬 pytest 실행을 못 했습니다(인프라 archaeology는 이 긴급 fix 범위 밖으로 판단). `ruff check` clean · `py_compile` clean · `pytest --collect-only` 4건 정상 수집까지 확認했고, 실제 실행 검증은 CI의 "Alembic upgrade head (fresh DB)" + "Backend pytest" 파이프라인에 의존합니다(오늘 다른 PR들에서 이미 정상 동작 확認).

## 게이트
- vitest(apps/web) 1480 GREEN · vitest(루트) 1654 GREEN · tsc clean · eslint 0 · build EXIT=0
- BE: ruff clean · py_compile clean · pytest collection 4/4 · **realdb 실행은 CI 의존**(위 고지)
- FE 신규 컴포넌트 테스트는 시간 제약상 미작성(다중 fetch 페이지·실보안 경계=BE 403이라 FE 게이트는 UX 정직화 목적) — 투명 고지.

## 선생님 계정 오염 확認
DB 직접 접근 불가(dev-app 원격 DB는 제 로컬 접근 범위 밖, `GET /api/webhooks/config`도 caller-scope라 제 세션으론 확認 불가) — 자가확인 경로는 conv에 별도 안내 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)