### PR TITLE
feat(ee): push_devices 테이블 + 디바이스 등록/조회/폐기 API (E-MOBILE M0·S2, story 588d7e9a)

### DIFF
--- a/backend/alembic/versions/0184_add_push_devices.py
+++ b/backend/alembic/versions/0184_add_push_devices.py
@@ -1,0 +1,51 @@
+"""add push_devices table for E-MOBILE push registration (E-MOBILE M0·S2)
+
+webhook_configs 동형: member-owned·org/project 무관 member-global. EE 라우터가 소비하나 테이블/모델/
+마이그는 core 체인에 선형 append(기존 EE 테이블 plan_tier_limits·pricing 동형) — 별도 EE 헤드 분기는
+0146(ee_pricing) 에서 dual-head prod 승격 깨져 0162 에서 되돌린 선례라 재도입 금지. branch_labels=None.
+
+Revision ID: 0184
+Revises: 0183
+Create Date: 2026-07-15
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0184"
+down_revision = "0183"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "push_devices",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column(
+            "org_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("organizations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        # member_id: webhook_configs(0079) 선례로 FK 미부착(grant-only write 500 해소). 소유 스코프는
+        # 쿼리시점 org_id AND member_id 로 강제.
+        sa.Column("member_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("expo_push_token", sa.Text, nullable=False),
+        sa.Column("platform", sa.Text, nullable=False),
+        sa.Column("device_id", sa.Text, nullable=True),
+        sa.Column("app_version", sa.Text, nullable=True),
+        sa.Column("is_active", sa.Boolean, nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.CheckConstraint("platform IN ('ios', 'android')", name="push_devices_platform_check"),
+        sa.UniqueConstraint("expo_push_token", name="uq_push_devices_expo_push_token"),
+    )
+    op.create_index("idx_push_devices_member", "push_devices", ["member_id"])
+    op.create_index("idx_push_devices_org", "push_devices", ["org_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_push_devices_org", table_name="push_devices")
+    op.drop_index("idx_push_devices_member", table_name="push_devices")
+    op.drop_table("push_devices")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -245,3 +245,6 @@ app.include_router(ws_chat.router)
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]
     app.include_router(billing.router, prefix="/api/v2/billing")
+
+    from ee.routers import push_devices  # type: ignore[import]
+    app.include_router(push_devices.router, prefix="/api/v2/push")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -23,6 +23,7 @@ from app.models.plan_tier_limit import PlanTierLimit
 from app.models.policy_document import PolicyDocument
 from app.models.audit import AuditLog
 from app.models.webhook_config import WebhookConfig
+from app.models.push_device import PushDevice
 from app.models.doc import Doc, DocShareToken, DocSlugAlias
 from app.models.meeting import Meeting
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
@@ -98,6 +99,7 @@ __all__ = [
     "PolicyDocument",
     "AuditLog",
     "WebhookConfig",
+    "PushDevice",
     "Doc",
     "Epic",
     "Hypothesis",

--- a/backend/app/models/push_device.py
+++ b/backend/app/models/push_device.py
@@ -1,0 +1,42 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, CheckConstraint, DateTime, ForeignKey, Text, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class PushDevice(Base):
+    """모바일 푸시 디바이스 등록 (E-MOBILE M0·S2).
+
+    webhook_configs 동형 패턴(멤버-소유·org/project 무관 member-global). 공식 앱(EE)이 Expo push
+    토큰을 등록하고, 발송기(S3)가 이 테이블을 대상 디바이스 목록으로 쓴다. crux §3 스키마.
+    """
+
+    __tablename__ = "push_devices"
+    __table_args__ = (
+        # 재등록(같은 디바이스 토큰) = upsert 자연 멱등 — on_conflict 타깃.
+        UniqueConstraint("expo_push_token", name="uq_push_devices_expo_push_token"),
+        CheckConstraint("platform IN ('ios', 'android')", name="push_devices_platform_check"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    # webhook_configs(0079) 선례: member_id FK 완화(grant-only write 500 해소). 소유 스코프는 쿼리시점
+    # org_id AND member_id 필터로 강제(repo list/get_owned/delete).
+    member_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    expo_push_token: Mapped[str] = mapped_column(Text, nullable=False)  # ExponentPushToken[...] (UNIQUE)
+    platform: Mapped[str] = mapped_column(Text, nullable=False)  # ios | android (CHECK)
+    device_id: Mapped[str | None] = mapped_column(Text, nullable=True)  # 앱 설치 단위 식별(관측용, 선택)
+    app_version: Mapped[str | None] = mapped_column(Text, nullable=True)  # 관측용
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)  # DeviceNotRegistered→false(S3)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    last_seen_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/repositories/push_device.py
+++ b/backend/app/repositories/push_device.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.push_device import PushDevice
+
+
+class PushDeviceRepository:
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        self.session = session
+        self.org_id = org_id
+
+    async def list(self, member_id: uuid.UUID) -> list[PushDevice]:
+        # IDOR: push_device 는 멤버-소유 리소스 — org_id 만이면 same-org 타 멤버 디바이스 토큰이 leak.
+        # caller member-scope 강제(webhook_config 선례 동형).
+        q = (
+            select(PushDevice)
+            .where(PushDevice.org_id == self.org_id, PushDevice.member_id == member_id)
+            .order_by(PushDevice.last_seen_at.desc())
+        )
+        result = await self.session.execute(q)
+        return list(result.scalars().all())
+
+    async def get(self, id: uuid.UUID) -> PushDevice | None:
+        """org-scope 조회 — **내부용**(upsert 직후 자기 행 재조회). 외부 노출 경로는 get_owned 사용."""
+        result = await self.session.execute(
+            select(PushDevice).where(PushDevice.id == id, PushDevice.org_id == self.org_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_owned(self, id: uuid.UUID, member_id: uuid.UUID) -> PushDevice | None:
+        """소유 검증 조회 — id + org + **member**. same-org 타 멤버 device_id 를 알아도 None(IDOR 차단).
+        폐기 등 외부 노출 경로의 표준 조회."""
+        result = await self.session.execute(
+            select(PushDevice).where(
+                PushDevice.id == id,
+                PushDevice.org_id == self.org_id,
+                PushDevice.member_id == member_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def upsert(
+        self,
+        member_id: uuid.UUID,
+        expo_push_token: str,
+        platform: str,
+        device_id: str | None = None,
+        app_version: str | None = None,
+    ) -> PushDevice:
+        """디바이스 등록 — expo_push_token UNIQUE 기준 upsert(재등록 자연 멱등).
+
+        같은 디바이스가 재등록(앱 재설치·토큰 회전·기기 이관)하면 토큰 충돌 → 소유 org/멤버·플랫폼·메타·
+        last_seen 갱신 + is_active 복구(True). crux §3: 발송기가 DeviceNotRegistered 수신 시 is_active=false
+        로 내리므로 재등록이 활성 복구를 겸한다. org_id 도 set_ 에 포함 — 기기 이관 시 새 org 로 re-home
+        (get() 재조회가 self.org_id 스코프라 조용한 500 방지)."""
+        now = func.now()
+        stmt = (
+            pg_insert(PushDevice)
+            .values(
+                org_id=self.org_id,
+                member_id=member_id,
+                expo_push_token=expo_push_token,
+                platform=platform,
+                device_id=device_id,
+                app_version=app_version,
+                is_active=True,
+            )
+            .on_conflict_do_update(
+                index_elements=["expo_push_token"],
+                set_={
+                    "org_id": self.org_id,
+                    "member_id": member_id,
+                    "platform": platform,
+                    "device_id": device_id,
+                    "app_version": app_version,
+                    "is_active": True,
+                    "last_seen_at": now,
+                },
+            )
+            .returning(PushDevice.id)
+        )
+        result = await self.session.execute(stmt)
+        device_pk = result.scalar_one()
+        await self.session.flush()
+
+        device = await self.get(device_pk)
+        assert device is not None  # noqa: S101 — 방금 upsert한 행, 동일 org 스코프
+        await self.session.refresh(device)
+        return device
+
+    async def delete(self, id: uuid.UUID, member_id: uuid.UUID) -> bool:
+        # IDOR: 소유 검증(get_owned) — 타 멤버 device_id 로 폐기 차단.
+        device = await self.get_owned(id, member_id)
+        if device is None:
+            return False
+        await self.session.delete(device)
+        return True

--- a/backend/app/schemas/push_device.py
+++ b/backend/app/schemas/push_device.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+# Expo push 토큰 포맷: ExponentPushToken[...] 또는 ExpoPushToken[...] (crux §2: 클라 제출값 방어적 검증).
+_EXPO_TOKEN_RE = re.compile(r"^Expo(nent)?PushToken\[[^\[\]\s]+\]$")
+
+
+class RegisterPushDevice(BaseModel):
+    """디바이스 등록 요청. member_id 는 body 에 없음 — auth context 서 산출(IDOR: 타 멤버 등록 불가)."""
+
+    expo_push_token: str
+    platform: Literal["ios", "android"]
+    device_id: str | None = None
+    app_version: str | None = None
+
+    @field_validator("expo_push_token")
+    @classmethod
+    def token_must_be_expo_format(cls, v: str) -> str:
+        v = v.strip()
+        if not _EXPO_TOKEN_RE.match(v):
+            raise ValueError("expo_push_token must be an ExponentPushToken[...] value")
+        return v
+
+
+class PushDeviceResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    member_id: uuid.UUID
+    expo_push_token: str
+    platform: str
+    device_id: str | None = None
+    app_version: str | None = None
+    is_active: bool
+    created_at: datetime
+    last_seen_at: datetime

--- a/backend/ee/routers/push_devices.py
+++ b/backend/ee/routers/push_devices.py
@@ -1,0 +1,94 @@
+"""EE Push Devices API — 모바일 푸시 디바이스 등록/조회/폐기 (E-MOBILE M0·S2).
+
+이 라우터는 is_ee_enabled 환경에서만 main.py 에 등록됨(공식 앱=EE 전용·OSS=generic 웹훅 BYO).
+OSS 빌드에서는 import 되지 않으나 _require_ee 로 이중 방어(billing 동형).
+
+디바이스는 **멤버-소유** 리소스 — 조회/폐기는 본인 것만(IDOR). 등록 member_id 는 body 가 아니라
+auth context 에서 산출(타 멤버 디바이스 등록 불가). webhook_configs 소유 스코프 패턴 동형.
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.repositories.push_device import PushDeviceRepository
+from app.schemas.push_device import PushDeviceResponse, RegisterPushDevice
+
+router = APIRouter(tags=["push-devices-ee"])
+
+
+def _require_ee() -> None:
+    """EE 비활성화 환경에서 호출 시 403 (방어적 guard)."""
+    if not settings.is_ee_enabled:
+        raise HTTPException(status_code=403, detail="Enterprise Edition not enabled")
+
+
+def _get_repo(
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> PushDeviceRepository:
+    return PushDeviceRepository(session, org_id)
+
+
+async def _get_caller_member_id(
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    session: AsyncSession = Depends(get_db),
+) -> uuid.UUID:
+    """caller 의 canonical member_id(resolve_member) — 디바이스 소유 스코프.
+
+    휴먼=org_member.id·에이전트=team_member.id. webhook-config 와 동일 축.
+    ⚠️ canonicalize_member_id(auth.user_id) 금지(축 버그): 휴먼은 auth.user_id=users.id 라 no-op →
+    잘못된 축으로 스코프됨. resolve_member 가 양쪽 정합 보장.
+    """
+    from app.services.member_resolver import resolve_member
+    resolved = await resolve_member(auth, org_id, session)
+    return resolved.id
+
+
+@router.post("/devices", response_model=PushDeviceResponse, status_code=200)
+async def register_push_device(
+    body: RegisterPushDevice,
+    repo: PushDeviceRepository = Depends(_get_repo),
+    caller_member_id: uuid.UUID = Depends(_get_caller_member_id),
+    _ee: None = Depends(_require_ee),
+) -> PushDeviceResponse:
+    """디바이스 등록/재등록(upsert) — expo_push_token UNIQUE 멱등. member_id 는 caller 로 강제."""
+    device = await repo.upsert(
+        member_id=caller_member_id,
+        expo_push_token=body.expo_push_token,
+        platform=body.platform,
+        device_id=body.device_id,
+        app_version=body.app_version,
+    )
+    return PushDeviceResponse.model_validate(device)
+
+
+@router.get("/devices", response_model=list[PushDeviceResponse])
+async def list_push_devices(
+    repo: PushDeviceRepository = Depends(_get_repo),
+    caller_member_id: uuid.UUID = Depends(_get_caller_member_id),
+    _ee: None = Depends(_require_ee),
+) -> list[PushDeviceResponse]:
+    # IDOR: caller member-scope — org_id 만이면 same-org 타 멤버 디바이스 토큰 leak.
+    items = await repo.list(member_id=caller_member_id)
+    return [PushDeviceResponse.model_validate(i) for i in items]
+
+
+@router.delete("/devices/{id}", status_code=200)
+async def revoke_push_device(
+    id: uuid.UUID,
+    repo: PushDeviceRepository = Depends(_get_repo),
+    caller_member_id: uuid.UUID = Depends(_get_caller_member_id),
+    _ee: None = Depends(_require_ee),
+) -> dict:
+    # IDOR: 소유 검증 폐기 — 타 멤버/없는 id 면 0행 → 404. (id = push_devices.id 행 PK)
+    ok = await repo.delete(id, caller_member_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="PushDevice not found")
+    return {"ok": True}

--- a/backend/tests/test_push_devices_ee.py
+++ b/backend/tests/test_push_devices_ee.py
@@ -1,0 +1,166 @@
+"""E-MOBILE M0·S2: push_devices EE 라우터 단위 계약 테스트.
+
+DB 불요(AsyncMock repo·router 함수 직접 호출) — webhook test_notif_trust_testsend 동형 스타일.
+핵심 계약: ①등록 member_id = caller 강제(body 없음·IDOR) ②list/delete member-scope ③delete 404
+④_get_caller_member_id = resolve_member().id ⑤토큰 포맷/platform 검증. realdb 왕복(등록→조회→폐기)은
+PR 본문 curl 증거로 별도 첨부.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.push_device import RegisterPushDevice
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _device_ns(member_id: uuid.UUID, org_id: uuid.UUID | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        org_id=org_id or uuid.uuid4(),
+        member_id=member_id,
+        expo_push_token="ExponentPushToken[abc123]",
+        platform="ios",
+        device_id=None,
+        app_version=None,
+        is_active=True,
+        created_at=datetime(2026, 7, 15, tzinfo=timezone.utc),
+        last_seen_at=datetime(2026, 7, 15, tzinfo=timezone.utc),
+    )
+
+
+# ─── 스키마 검증(토큰 포맷·platform) ──────────────────────────────────────────
+
+def test_register_schema_accepts_valid_expo_token():
+    body = RegisterPushDevice(expo_push_token="ExponentPushToken[xxxYYY-123_.]", platform="ios")
+    assert body.expo_push_token == "ExponentPushToken[xxxYYY-123_.]"
+    assert body.platform == "ios"
+
+
+def test_register_schema_accepts_short_expo_prefix():
+    body = RegisterPushDevice(expo_push_token="ExpoPushToken[abc]", platform="android")
+    assert body.expo_push_token == "ExpoPushToken[abc]"
+
+
+def test_register_schema_rejects_non_expo_token():
+    with pytest.raises(ValidationError):
+        RegisterPushDevice(expo_push_token="not-a-token", platform="ios")
+
+
+def test_register_schema_rejects_raw_fcm_token():
+    # crux §2: 클라 제출값 방어적 검증 — ExponentPushToken 포맷 아니면 거부.
+    with pytest.raises(ValidationError):
+        RegisterPushDevice(expo_push_token="fGx9:APA91bH_rawFcmToken", platform="android")
+
+
+def test_register_schema_rejects_bad_platform():
+    with pytest.raises(ValidationError):
+        RegisterPushDevice(expo_push_token="ExponentPushToken[abc]", platform="windows")
+
+
+# ─── 등록: member_id = caller 강제(IDOR·body 무신뢰) ──────────────────────────
+
+@pytest.mark.anyio
+async def test_register_forces_caller_member_id():
+    from ee.routers.push_devices import register_push_device
+    caller = uuid.uuid4()
+    repo = AsyncMock()
+    repo.upsert = AsyncMock(return_value=_device_ns(caller))
+    body = RegisterPushDevice(expo_push_token="ExponentPushToken[abc]", platform="ios")
+
+    out = await register_push_device(body, repo=repo, caller_member_id=caller, _ee=None)
+
+    # member_id 는 caller 로 강제(body 에 member_id 아예 없음).
+    assert repo.upsert.await_args.kwargs["member_id"] == caller
+    assert repo.upsert.await_args.kwargs["expo_push_token"] == "ExponentPushToken[abc]"
+    assert repo.upsert.await_args.kwargs["platform"] == "ios"
+    assert out.member_id == caller  # 응답도 caller 소유
+
+
+# ─── 조회: member-scope(org-wide leak 차단) ───────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_is_member_scoped():
+    from ee.routers.push_devices import list_push_devices
+    caller = uuid.uuid4()
+    repo = AsyncMock()
+    repo.list = AsyncMock(return_value=[_device_ns(caller)])
+
+    out = await list_push_devices(repo=repo, caller_member_id=caller, _ee=None)
+
+    assert repo.list.await_args.kwargs["member_id"] == caller  # caller member-scope
+    assert len(out) == 1
+    assert out[0].member_id == caller
+
+
+# ─── 폐기: 소유 검증(get_owned 기반)·타 멤버/없는 id 404 ──────────────────────
+
+@pytest.mark.anyio
+async def test_revoke_is_member_scoped_and_404_for_other():
+    from fastapi import HTTPException
+
+    from ee.routers.push_devices import revoke_push_device
+    caller = uuid.uuid4()
+    repo = AsyncMock()
+    repo.delete = AsyncMock(return_value=False)  # 타 멤버/없는 id → 0행
+
+    with pytest.raises(HTTPException) as ei:
+        await revoke_push_device(id=uuid.uuid4(), repo=repo, caller_member_id=caller, _ee=None)
+
+    assert ei.value.status_code == 404
+    assert repo.delete.await_args.args[1] == caller  # caller member 로 소유 검증
+
+
+@pytest.mark.anyio
+async def test_revoke_ok_when_owned():
+    from ee.routers.push_devices import revoke_push_device
+    caller = uuid.uuid4()
+    repo = AsyncMock()
+    repo.delete = AsyncMock(return_value=True)
+
+    out = await revoke_push_device(id=uuid.uuid4(), repo=repo, caller_member_id=caller, _ee=None)
+
+    assert out == {"ok": True}
+
+
+# ─── 멤버 축 정합: _get_caller_member_id = resolve_member().id ─────────────────
+
+@pytest.mark.anyio
+async def test_caller_member_id_uses_resolve_member_not_user_id():
+    """webhook 동형 — resolve_member().id(휴먼=org_member.id·에이전트=team_member.id). users.id 축 아님."""
+    from ee.routers.push_devices import _get_caller_member_id
+    org_member_id = uuid.uuid4()
+    users_id = uuid.uuid4()
+    auth = SimpleNamespace(user_id=str(users_id))
+    with patch("app.services.member_resolver.resolve_member",
+               new=AsyncMock(return_value=SimpleNamespace(id=org_member_id))):
+        out = await _get_caller_member_id(auth=auth, org_id=uuid.uuid4(), session=AsyncMock())
+    assert out == org_member_id
+    assert out != users_id
+
+
+# ─── EE 가드: 비활성 환경 403 ─────────────────────────────────────────────────
+
+def test_require_ee_raises_when_disabled():
+    from fastapi import HTTPException
+
+    from ee.routers.push_devices import _require_ee
+    with patch("ee.routers.push_devices.settings", SimpleNamespace(is_ee_enabled=False)):
+        with pytest.raises(HTTPException) as ei:
+            _require_ee()
+    assert ei.value.status_code == 403
+
+
+def test_require_ee_passes_when_enabled():
+    from ee.routers.push_devices import _require_ee
+    with patch("ee.routers.push_devices.settings", SimpleNamespace(is_ee_enabled=True)):
+        assert _require_ee() is None

--- a/backend/tests/test_push_devices_realdb.py
+++ b/backend/tests/test_push_devices_realdb.py
@@ -3,18 +3,19 @@
 실 Postgres(PARITY/ALEMBIC_DATABASE_URL·alembic upgrade heads 적용)에 실 앱(ASGI)을 붙여
 등록→조회→재등록(멱등)→폐기 왕복 + IDOR(타 멤버 미노출/미폐기)을 실증. DB env 없으면 skip.
 
-resolve_member 축은 unit(test_push_devices_ee) 커버 — 여기선 _get_caller_member_id 를 오버라이드해
+⚠️EE 활성화(까심 QA #2168): module-level env(LICENSE_CONSENT)는 pytest 공유 세션에서 app.main이
+먼저 import되면 라우터 미등록으로 고정돼 신뢰 불가. 그래서 **테스트 scope에서 프레시 앱에 EE 라우터를
+명시 마운트**(import-order 무관)하고, EE 게이트(`settings.is_ee_enabled` property)는 patch로 결정적으로
+켠다. resolve_member 축은 unit(test_push_devices_ee)이 커버 — 여기선 _get_caller_member_id 오버라이드로
 push_devices 데이터 경로(UNIQUE upsert·member-scope·FK)만 실 DB 로 검증한다.
 """
 from __future__ import annotations
 
 import os
 import uuid
+from unittest.mock import patch
 
 import pytest
-
-# EE 라우터는 is_ee_enabled 일 때만 마운트 — app import 前에 설정. (이 파일은 단독 실행 권장)
-os.environ.setdefault("LICENSE_CONSENT", "agreed")
 
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
@@ -42,16 +43,26 @@ def _async_url() -> str:
     return url
 
 
+def _ee_on():
+    """is_ee_enabled property 를 결정적으로 True 로 — env/import-order 무관(까심 QA #2168)."""
+    from app.core.config import settings
+    return patch.object(type(settings), "is_ee_enabled", property(lambda self: True))
+
+
 @pytest.mark.anyio
 async def test_push_device_register_list_revoke_round_trip_realdb():
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
     from sqlalchemy import text
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-    from httpx import ASGITransport, AsyncClient
 
     from app.dependencies.auth import get_verified_org_id
     from app.dependencies.database import get_db
-    from app.main import app
-    from ee.routers.push_devices import _get_caller_member_id
+    from ee.routers import push_devices as pd
+
+    # 프레시 앱에 EE 라우터 명시 마운트 — app.main import-order 에 의존하지 않음(결정적).
+    app = FastAPI()
+    app.include_router(pd.router, prefix="/api/v2/push")
 
     engine = create_async_engine(_async_url())
     SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
@@ -78,73 +89,78 @@ async def test_push_device_register_list_revoke_round_trip_realdb():
 
     app.dependency_overrides[get_db] = _override_db
     app.dependency_overrides[get_verified_org_id] = lambda: ORG
-    app.dependency_overrides[_get_caller_member_id] = _make_caller_override(MEMBER_X)
+    app.dependency_overrides[pd._get_caller_member_id] = _make_caller_override(MEMBER_X)
 
     try:
         async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            # 1) 등록(caller=X, token A/ios) → 200, member=X, is_active=True
+            # 0) EE 게이트 네거티브: EE off 면 _require_ee 403(게이트 실작동 증명).
             r = await client.post("/api/v2/push/devices", json={"expo_push_token": TOKEN_A, "platform": "ios"})
-            assert r.status_code == 200, r.text
-            dev_a = r.json()
-            assert dev_a["member_id"] == str(MEMBER_X)
-            assert dev_a["expo_push_token"] == TOKEN_A
-            assert dev_a["platform"] == "ios"
-            assert dev_a["is_active"] is True
-            dev_a_id = dev_a["id"]
+            assert r.status_code == 403, r.text
 
-            # 2) 같은 토큰 재등록(멱등·app_version 갱신) → 200, 새 행 안 생김
-            r = await client.post(
-                "/api/v2/push/devices",
-                json={"expo_push_token": TOKEN_A, "platform": "ios", "app_version": "1.2.3"},
-            )
-            assert r.status_code == 200, r.text
-            assert r.json()["id"] == dev_a_id  # 동일 행(UNIQUE upsert)
-            assert r.json()["app_version"] == "1.2.3"
+            with _ee_on():
+                # 1) 등록(caller=X, token A/ios) → 200, member=X, is_active=True
+                r = await client.post("/api/v2/push/devices", json={"expo_push_token": TOKEN_A, "platform": "ios"})
+                assert r.status_code == 200, r.text
+                dev_a = r.json()
+                assert dev_a["member_id"] == str(MEMBER_X)
+                assert dev_a["expo_push_token"] == TOKEN_A
+                assert dev_a["platform"] == "ios"
+                assert dev_a["is_active"] is True
+                dev_a_id = dev_a["id"]
 
-            # 3) 조회(X) → 정확히 1건(중복 없음)
-            r = await client.get("/api/v2/push/devices")
-            assert r.status_code == 200, r.text
-            assert len(r.json()) == 1
-            assert r.json()[0]["expo_push_token"] == TOKEN_A
+                # 2) 같은 토큰 재등록(멱등·app_version 갱신) → 200, 새 행 안 생김
+                r = await client.post(
+                    "/api/v2/push/devices",
+                    json={"expo_push_token": TOKEN_A, "platform": "ios", "app_version": "1.2.3"},
+                )
+                assert r.status_code == 200, r.text
+                assert r.json()["id"] == dev_a_id  # 동일 행(UNIQUE upsert)
+                assert r.json()["app_version"] == "1.2.3"
 
-            # 4) 두 번째 디바이스 등록(token B/android) → 조회 2건
-            r = await client.post("/api/v2/push/devices", json={"expo_push_token": TOKEN_B, "platform": "android"})
-            assert r.status_code == 200, r.text
-            r = await client.get("/api/v2/push/devices")
-            assert len(r.json()) == 2
+                # 3) 조회(X) → 정확히 1건(중복 없음)
+                r = await client.get("/api/v2/push/devices")
+                assert r.status_code == 200, r.text
+                assert len(r.json()) == 1
+                assert r.json()[0]["expo_push_token"] == TOKEN_A
 
-            # 5) 잘못된 토큰 포맷 → 422(방어적 검증)
-            r = await client.post("/api/v2/push/devices", json={"expo_push_token": "raw-fcm-xyz", "platform": "ios"})
-            assert r.status_code == 422, r.text
+                # 4) 두 번째 디바이스 등록(token B/android) → 조회 2건
+                r = await client.post("/api/v2/push/devices", json={"expo_push_token": TOKEN_B, "platform": "android"})
+                assert r.status_code == 200, r.text
+                r = await client.get("/api/v2/push/devices")
+                assert len(r.json()) == 2
 
-            # ── IDOR: caller=Y ──
-            app.dependency_overrides[_get_caller_member_id] = _make_caller_override(MEMBER_Y)
+                # 5) 잘못된 토큰 포맷 → 422(방어적 검증)
+                r = await client.post("/api/v2/push/devices", json={"expo_push_token": "raw-fcm-xyz", "platform": "ios"})
+                assert r.status_code == 422, r.text
 
-            # 6) Y 조회 → 0건(X 디바이스 미노출)
-            r = await client.get("/api/v2/push/devices")
-            assert r.status_code == 200, r.text
-            assert r.json() == []
+                # ── IDOR: caller=Y ──
+                app.dependency_overrides[pd._get_caller_member_id] = _make_caller_override(MEMBER_Y)
 
-            # 7) Y 가 X 디바이스 폐기 시도 → 404(소유 아님)
-            r = await client.delete(f"/api/v2/push/devices/{dev_a_id}")
-            assert r.status_code == 404, r.text
+                # 6) Y 조회 → 0건(X 디바이스 미노출)
+                r = await client.get("/api/v2/push/devices")
+                assert r.status_code == 200, r.text
+                assert r.json() == []
 
-            # ── 다시 X: 폐기 왕복 ──
-            app.dependency_overrides[_get_caller_member_id] = _make_caller_override(MEMBER_X)
+                # 7) Y 가 X 디바이스 폐기 시도 → 404(소유 아님)
+                r = await client.delete(f"/api/v2/push/devices/{dev_a_id}")
+                assert r.status_code == 404, r.text
 
-            # 8) X 가 폐기 → 200
-            r = await client.delete(f"/api/v2/push/devices/{dev_a_id}")
-            assert r.status_code == 200, r.text
-            assert r.json() == {"ok": True}
+                # ── 다시 X: 폐기 왕복 ──
+                app.dependency_overrides[pd._get_caller_member_id] = _make_caller_override(MEMBER_X)
 
-            # 9) 폐기 후 조회 → token B 만 남음(1건·폐기 반영)
-            r = await client.get("/api/v2/push/devices")
-            assert len(r.json()) == 1
-            assert r.json()[0]["expo_push_token"] == TOKEN_B
+                # 8) X 가 폐기 → 200
+                r = await client.delete(f"/api/v2/push/devices/{dev_a_id}")
+                assert r.status_code == 200, r.text
+                assert r.json() == {"ok": True}
 
-            # 10) 이미 폐기한 id 재폐기 → 404(멱등적 부재)
-            r = await client.delete(f"/api/v2/push/devices/{dev_a_id}")
-            assert r.status_code == 404, r.text
+                # 9) 폐기 후 조회 → token B 만 남음(1건·폐기 반영)
+                r = await client.get("/api/v2/push/devices")
+                assert len(r.json()) == 1
+                assert r.json()[0]["expo_push_token"] == TOKEN_B
+
+                # 10) 이미 폐기한 id 재폐기 → 404(멱등적 부재)
+                r = await client.delete(f"/api/v2/push/devices/{dev_a_id}")
+                assert r.status_code == 404, r.text
     finally:
         app.dependency_overrides.clear()
         async with SessionLocal() as s:

--- a/backend/tests/test_push_devices_realdb.py
+++ b/backend/tests/test_push_devices_realdb.py
@@ -1,0 +1,153 @@
+"""E-MOBILE M0·S2: push_devices 등록→조회→폐기 왕복 real-DB 통합 (AC1 curl 왕복 재현).
+
+실 Postgres(PARITY/ALEMBIC_DATABASE_URL·alembic upgrade heads 적용)에 실 앱(ASGI)을 붙여
+등록→조회→재등록(멱등)→폐기 왕복 + IDOR(타 멤버 미노출/미폐기)을 실증. DB env 없으면 skip.
+
+resolve_member 축은 unit(test_push_devices_ee) 커버 — 여기선 _get_caller_member_id 를 오버라이드해
+push_devices 데이터 경로(UNIQUE upsert·member-scope·FK)만 실 DB 로 검증한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+# EE 라우터는 is_ee_enabled 일 때만 마운트 — app import 前에 설정. (이 파일은 단독 실행 권장)
+os.environ.setdefault("LICENSE_CONSENT", "agreed")
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(
+    not _REAL_DB_URL, reason="real-DB URL(PARITY/ALEMBIC_DATABASE_URL) 미설정 — skip"
+)
+
+ORG = uuid.UUID("d0000000-0000-0000-0000-0000000000e1")
+MEMBER_X = uuid.UUID("d0000000-0000-0000-0000-0000000000a1")
+MEMBER_Y = uuid.UUID("d0000000-0000-0000-0000-0000000000a2")
+TOKEN_A = "ExponentPushToken[s2-round-trip-AAAA]"
+TOKEN_B = "ExponentPushToken[s2-round-trip-BBBB]"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+@pytest.mark.anyio
+async def test_push_device_register_list_revoke_round_trip_realdb():
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from httpx import ASGITransport, AsyncClient
+
+    from app.dependencies.auth import get_verified_org_id
+    from app.dependencies.database import get_db
+    from app.main import app
+    from ee.routers.push_devices import _get_caller_member_id
+
+    engine = create_async_engine(_async_url())
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+    # ── 시드: org 1개(org_id FK). member_id 는 FK 없음 → 시드 불요. ──
+    async with SessionLocal() as s:
+        await s.execute(text("DELETE FROM push_devices WHERE org_id=:o"), {"o": str(ORG)})
+        await s.execute(text("DELETE FROM organizations WHERE id=:o"), {"o": str(ORG)})
+        await s.execute(
+            text("INSERT INTO organizations (id,name,slug,plan) VALUES (:o,'S2 Org','s2-mobile','free')"),
+            {"o": str(ORG)},
+        )
+        await s.commit()
+
+    async def _override_db():
+        async with SessionLocal() as sess:
+            yield sess
+            await sess.commit()
+
+    def _make_caller_override(member_id: uuid.UUID):
+        async def _override():
+            return member_id
+        return _override
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_verified_org_id] = lambda: ORG
+    app.dependency_overrides[_get_caller_member_id] = _make_caller_override(MEMBER_X)
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            # 1) 등록(caller=X, token A/ios) → 200, member=X, is_active=True
+            r = await client.post("/api/v2/push/devices", json={"expo_push_token": TOKEN_A, "platform": "ios"})
+            assert r.status_code == 200, r.text
+            dev_a = r.json()
+            assert dev_a["member_id"] == str(MEMBER_X)
+            assert dev_a["expo_push_token"] == TOKEN_A
+            assert dev_a["platform"] == "ios"
+            assert dev_a["is_active"] is True
+            dev_a_id = dev_a["id"]
+
+            # 2) 같은 토큰 재등록(멱등·app_version 갱신) → 200, 새 행 안 생김
+            r = await client.post(
+                "/api/v2/push/devices",
+                json={"expo_push_token": TOKEN_A, "platform": "ios", "app_version": "1.2.3"},
+            )
+            assert r.status_code == 200, r.text
+            assert r.json()["id"] == dev_a_id  # 동일 행(UNIQUE upsert)
+            assert r.json()["app_version"] == "1.2.3"
+
+            # 3) 조회(X) → 정확히 1건(중복 없음)
+            r = await client.get("/api/v2/push/devices")
+            assert r.status_code == 200, r.text
+            assert len(r.json()) == 1
+            assert r.json()[0]["expo_push_token"] == TOKEN_A
+
+            # 4) 두 번째 디바이스 등록(token B/android) → 조회 2건
+            r = await client.post("/api/v2/push/devices", json={"expo_push_token": TOKEN_B, "platform": "android"})
+            assert r.status_code == 200, r.text
+            r = await client.get("/api/v2/push/devices")
+            assert len(r.json()) == 2
+
+            # 5) 잘못된 토큰 포맷 → 422(방어적 검증)
+            r = await client.post("/api/v2/push/devices", json={"expo_push_token": "raw-fcm-xyz", "platform": "ios"})
+            assert r.status_code == 422, r.text
+
+            # ── IDOR: caller=Y ──
+            app.dependency_overrides[_get_caller_member_id] = _make_caller_override(MEMBER_Y)
+
+            # 6) Y 조회 → 0건(X 디바이스 미노출)
+            r = await client.get("/api/v2/push/devices")
+            assert r.status_code == 200, r.text
+            assert r.json() == []
+
+            # 7) Y 가 X 디바이스 폐기 시도 → 404(소유 아님)
+            r = await client.delete(f"/api/v2/push/devices/{dev_a_id}")
+            assert r.status_code == 404, r.text
+
+            # ── 다시 X: 폐기 왕복 ──
+            app.dependency_overrides[_get_caller_member_id] = _make_caller_override(MEMBER_X)
+
+            # 8) X 가 폐기 → 200
+            r = await client.delete(f"/api/v2/push/devices/{dev_a_id}")
+            assert r.status_code == 200, r.text
+            assert r.json() == {"ok": True}
+
+            # 9) 폐기 후 조회 → token B 만 남음(1건·폐기 반영)
+            r = await client.get("/api/v2/push/devices")
+            assert len(r.json()) == 1
+            assert r.json()[0]["expo_push_token"] == TOKEN_B
+
+            # 10) 이미 폐기한 id 재폐기 → 404(멱등적 부재)
+            r = await client.delete(f"/api/v2/push/devices/{dev_a_id}")
+            assert r.status_code == 404, r.text
+    finally:
+        app.dependency_overrides.clear()
+        async with SessionLocal() as s:
+            await s.execute(text("DELETE FROM organizations WHERE id=:o"), {"o": str(ORG)})  # cascade → devices
+            await s.commit()
+        await engine.dispose()


### PR DESCRIPTION
## 무엇 (E-MOBILE M0·S2 · ee·BE · story `588d7e9a`)

모바일 푸시 디바이스 **등록/조회/폐기 API + `push_devices` 테이블**. webhook_configs 동형 패턴(멤버-소유·org/project 무관 member-global). 무계정 트랙 — 앱/툴체인 불요, curl 왕복으로 검증.

- **테이블** `push_devices`: `expo_push_token` UNIQUE(재등록 upsert 자연 멱등)·`platform` CHECK(`ios`|`android`)·`org_id` FK CASCADE·`member_id` FK 미부착(webhook_configs 0079 선례)·`is_active`(S3 `DeviceNotRegistered` 대비)·`device_id`/`app_version`(관측)·`created_at`/`last_seen_at`.
- **API** (`ee/routers/push_devices.py`, `is_ee_enabled` 게이트 + `_require_ee` 이중 방어):
  - `POST /api/v2/push/devices` — 등록/재등록(upsert). `member_id` 는 **auth context 서 산출**(body 없음·불신).
  - `GET  /api/v2/push/devices` — 본인 디바이스만(member-scope).
  - `DELETE /api/v2/push/devices/{id}` — 소유 검증 폐기(타 멤버 id → 404).
- **NotificationSetting 재사용**(channel-agnostic) — 신규 설정 테이블 **0**. 알림 종류/DND는 기존 필터 그대로.

## ee 경계 판단 (핵심·그라운딩 실측)

`ee/` 는 **라우터/서비스만** — 기존 EE 테이블(OrgSubscription·PricingVersion·PlanTierLimit)도 모델/마이그가 전부 core `app/` 에 산다. 따라서 **모델/스키마/repo/마이그 = core, 라우터만 `ee/routers/`(feature-flag)**.

마이그 `0184` = **단일 head `0183` 선형 append**(`branch_labels=None`). 별도 EE 헤드 분기(`branch_labels`)는 `0146`(ee_pricing)에서 dual-head 로 **prod 승격이 깨져 `0162`에서 되돌린 선례**라 재도입 금지. 선형 append 가 곧 "기존 ee 패턴 동형 + core 마이그 체인 오염 금지"의 방식(`alembic heads` = `0184 (head)` 단일 확認). "nobilling" 은 코드 0히트(외부 배포 경계 이름).

## 증거 (실측)

- **단위 12** (`test_push_devices_ee.py`·DB 불요): 등록 caller 강제(IDOR)·list/delete member-scope·404·토큰 포맷/platform 검증·EE 가드 403.
- **realdb 왕복 1** (`test_push_devices_realdb.py`·실 PG): 등록→멱등 재등록(동일 행·app_version 갱신)→조회(member-scope)→2번째 등록→잘못된 토큰 422→**IDOR**(타 멤버 미노출·타 멤버 폐기 404)→폐기(200)→폐기 반영→재폐기 404.
- **마이그 실적용**: fresh PG 에 baseline→`0184` 적용 성공·`alembic current` = `0184 (head)` 단일·테이블 형상(UNIQUE/CHECK/FK/인덱스) 확認.
- **literal curl 왕복**(실 uvicorn+실 PG): `POST`(200·전체 JSON)→`GET`(반영)→bad token `422`→`DELETE`(`{"ok":true}`)→`GET`(`[]`)→재`DELETE`(`404`).

## 셀프 게이트 (pr-self-gate-checklist 통과)

- **어서션 뮤테이션(class1)**: repo member-scope 필터 제거 → realdb 테스트 **RED** 실측 후 원복(공허 아님).
- **IDOR target-side(class8)**: 조회/폐기 repo-레벨 member-scope·`member_id` body 불신(auth 산출).
- **마이그 안전(class11)**: additive `create_table`만·DROP/RENAME 0·baseline 무편집·downgrade 존재·단일 head(core 무오염).
- **실사용(class5)**: 실 DB curl 왕복·422/404 에러 경로 실행.

## 게이트

까심 QA(권한 경계·토큰 UNIQUE·마이그 경계) + CI → PO 머지 → 라이브(curl 왕복). S1(승인자 갭·디디군 lane) 병렬 · S3(Expo 발송기)은 이 S2 다음 순차(`_deliver_expo_push()`가 이 테이블 소비).

🤖 Generated with [Claude Code](https://claude.com/claude-code)