### PR TITLE
feat(ee): Expo 푸시 발송기 _deliver_expo_push 파이프라인 배선 (E-MOBILE M0·S3, story 6069153d)

### DIFF
--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -335,6 +335,18 @@ async def dispatch_notification(
             muted_member_ids=muted_member_ids,
         )
 
+        # E-MOBILE M0·S3: EE 푸시 채널(웹훅과 나란한 별개 채널) — 등록 push_devices 로 Expo 발송.
+        # 대상 = enabled(설정 통과) − mute 멤버(deliver_expo_push 내부 필터). 웹훅 유무와 독립.
+        # EE 게이트(비-EE 무동작·core 무영향)·best-effort(발송 실패가 파이프라인 안 되돌림).
+        from app.core.config import settings as _settings
+        if _settings.is_ee_enabled:
+            from ee.services.expo_push import deliver_expo_push
+            await deliver_expo_push(
+                db, org_id, enabled_member_ids, title=title, body=body, event_type=event_type,
+                reference_type=reference_type, reference_id=reference_id, context=context,
+                muted_member_ids=muted_member_ids,
+            )
+
     except Exception:
         # BUG-1 수정: 에러 삼킴 제거 → 스택 트레이스 로깅
         logger.exception("dispatch_notification failed org_id=%s event_type=%s", org_id, event_type)

--- a/backend/ee/services/expo_push.py
+++ b/backend/ee/services/expo_push.py
@@ -1,0 +1,145 @@
+"""EE Expo Push 발송기 (E-MOBILE M0·S3).
+
+dispatch_notification(core)의 채널 확장 지점에서 호출됨 — push_devices(활성) 소비 → Expo Push
+API 발송. 파이프라인 무변경(발송기는 별개 채널·best-effort). is_ee_enabled 환경에서만 core 훅이
+이 모듈을 import/호출(비-EE 무동작).
+
+crux §2 계약: POST exp.host/--/api/v2/push/send · 배치 ≤100/req · 메시지 ≤4096B · 신규 패키지 0
+(httpx JSON POST) · 재시도/백오프 = dispatch_router 패턴 재사용 · DeviceNotRegistered → is_active=false.
+receipt(getReceipts) 기반 지연 확인은 M1(관측)로 미룸 — M0은 send 응답 ticket 의 즉시 에러로 만료 판정.
+"""
+from __future__ import annotations
+
+import asyncio
+import json as _json
+import logging
+import uuid
+
+import httpx
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.push_device import PushDevice
+
+# 재시도/백오프 = dispatch_router._post_with_retry 와 동일 정책(단일 SSOT 재사용).
+from app.services.dispatch_router import _WEBHOOK_BACKOFF_BASE, _WEBHOOK_MAX_RETRIES
+
+logger = logging.getLogger(__name__)
+
+_EXPO_SEND_URL = "https://exp.host/--/api/v2/push/send"
+_EXPO_MAX_BATCH = 100  # crux §2: 최대 100개/요청
+
+
+async def _expo_send_chunk(messages: list[dict]) -> list[dict]:
+    """단일 청크(≤100) 발송 → ticket 리스트(응답 data) 반환. 5xx/429 는 backoff 재시도.
+
+    _post_with_retry(bool 반환·HMAC 서명)와 달리 ticket 응답을 파싱해야 DeviceNotRegistered 를
+    잡으므로 별도 함수 — 단 재시도 상수(_WEBHOOK_MAX_RETRIES/BACKOFF)는 그대로 재사용.
+    """
+    body = _json.dumps(messages)
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    for attempt in range(_WEBHOOK_MAX_RETRIES):
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                resp = await client.post(_EXPO_SEND_URL, content=body, headers=headers)
+            # 429(MessageRateExceeded)·5xx 는 재시도, 그 외(2xx/4xx)는 응답 파싱.
+            if resp.status_code != 429 and resp.status_code < 500:
+                data = resp.json()
+                return data.get("data", []) if isinstance(data, dict) else []
+        except Exception:
+            logger.warning(
+                "expo push attempt %d/%d failed", attempt + 1, _WEBHOOK_MAX_RETRIES, exc_info=True
+            )
+        if attempt < _WEBHOOK_MAX_RETRIES - 1:
+            await asyncio.sleep(_WEBHOOK_BACKOFF_BASE * (2 ** attempt))
+    logger.warning("expo push all retries exhausted (%d msgs)", len(messages))
+    return []
+
+
+async def deliver_expo_push(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    member_ids: list[uuid.UUID],
+    *,
+    title: str,
+    body: str | None,
+    event_type: str,
+    reference_type: str | None = None,
+    reference_id: uuid.UUID | None = None,
+    context: dict | None = None,
+    muted_member_ids: set[uuid.UUID] | None = None,
+) -> None:
+    """활성 push_devices 로 Expo push 발송(웹훅과 나란한 별개 채널).
+
+    - 대상 = enabled 멤버(설정 통과) − global mute(능동 push off). 웹훅 유무와 독립.
+    - 디바이스당 1발(이중발송 0). 배치 ≤100·메시지 최소화(≤4096B).
+    - best-effort: 어떤 실패도 알림 파이프라인으로 전파 안 함(발송 실패가 in-app/Event 안 되돌림).
+    - DeviceNotRegistered ticket → 그 토큰 is_active=false(자동 만료). 재발송 대상서 제외됨.
+    """
+    try:
+        if not member_ids:
+            return
+        muted = muted_member_ids or set()
+        targets = [m for m in member_ids if m not in muted]
+        if not targets:
+            return
+
+        rows = await db.execute(
+            select(PushDevice).where(
+                PushDevice.org_id == org_id,
+                PushDevice.member_id.in_(targets),
+                PushDevice.is_active.is_(True),
+            )
+        )
+        devices = list(rows.scalars().all())
+        if not devices:
+            return
+
+        # 딥링크용 data(4096B 상한 고려 최소 필드만 — 탭→화면 착지에 필요한 것).
+        data_payload: dict = {"event_type": event_type}
+        if reference_type:
+            data_payload["reference_type"] = reference_type
+        if reference_id:
+            data_payload["reference_id"] = str(reference_id)
+
+        messages = [
+            {
+                "to": d.expo_push_token,
+                "title": title,
+                "body": body or "",
+                "data": data_payload,
+                "sound": "default",
+                "priority": "high",
+            }
+            for d in devices
+        ]
+
+        dead_tokens: list[str] = []
+        for i in range(0, len(messages), _EXPO_MAX_BATCH):
+            chunk = messages[i : i + _EXPO_MAX_BATCH]
+            chunk_devices = devices[i : i + _EXPO_MAX_BATCH]
+            tickets = await _expo_send_chunk(chunk)
+            # ticket 은 메시지와 동순서. 개수 불일치(부분 응답) 시 zip 이 짧은 쪽 기준(안전).
+            for dev, ticket in zip(chunk_devices, tickets):
+                if isinstance(ticket, dict) and ticket.get("status") == "error":
+                    err = (ticket.get("details") or {}).get("error")
+                    if err == "DeviceNotRegistered":
+                        dead_tokens.append(dev.expo_push_token)
+
+        if dead_tokens:
+            await db.execute(
+                update(PushDevice)
+                .where(
+                    PushDevice.org_id == org_id,
+                    PushDevice.expo_push_token.in_(dead_tokens),
+                )
+                .values(is_active=False)
+            )
+            await db.flush()
+            logger.info("expo push: deactivated %d DeviceNotRegistered token(s)", len(dead_tokens))
+    except Exception:
+        # best-effort — 발송 실패가 알림 파이프라인을 되돌리지 않는다(AC: 비중단).
+        logger.warning(
+            "deliver_expo_push failed (swallowed·best-effort) org=%s event=%s",
+            org_id, event_type, exc_info=True,
+        )

--- a/backend/tests/test_expo_push_ee.py
+++ b/backend/tests/test_expo_push_ee.py
@@ -1,0 +1,158 @@
+"""E-MOBILE M0·S3: Expo 발송기 단위 테스트 (DB 불요·AsyncMock).
+
+발송기 로직: ticket 파싱·배치(≤100)·DeviceNotRegistered→is_active=false·mute 필터·best-effort.
+dispatch_notification 경로 실구동은 test_expo_push_realdb 가 커버.
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import ee.services.expo_push as expo
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class _Resp:
+    def __init__(self, status_code: int, payload: dict | None = None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+def _client_cm(post_mock):
+    client = AsyncMock()
+    client.post = post_mock
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=client)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+def _mock_db(devices: list) -> AsyncMock:
+    """db.execute: 1st=select(devices), 이후=update(AsyncMock). flush=AsyncMock."""
+    sel = MagicMock()
+    sel.scalars.return_value.all.return_value = devices
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[sel] + [AsyncMock() for _ in range(5)])
+    db.flush = AsyncMock()
+    return db
+
+
+def _dev(token: str, member_id: uuid.UUID | None = None):
+    return SimpleNamespace(expo_push_token=token, member_id=member_id or uuid.uuid4())
+
+
+# ─── _expo_send_chunk (ticket 파싱·재시도) ────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_send_chunk_returns_tickets_on_200():
+    payload = {"data": [{"status": "ok", "id": "t1"}]}
+    with patch("ee.services.expo_push.httpx.AsyncClient",
+               return_value=_client_cm(AsyncMock(return_value=_Resp(200, payload)))):
+        tickets = await expo._expo_send_chunk([{"to": "ExponentPushToken[a]"}])
+    assert tickets == [{"status": "ok", "id": "t1"}]
+
+
+@pytest.mark.anyio
+async def test_send_chunk_retries_on_5xx_then_empty():
+    post = AsyncMock(return_value=_Resp(500))
+    with patch("ee.services.expo_push.httpx.AsyncClient", return_value=_client_cm(post)), \
+         patch("ee.services.expo_push.asyncio.sleep", new=AsyncMock()):
+        tickets = await expo._expo_send_chunk([{"to": "ExponentPushToken[a]"}])
+    assert tickets == []
+    assert post.await_count == expo._WEBHOOK_MAX_RETRIES  # 전량 재시도 소진
+
+
+# ─── deliver_expo_push (배치·만료·mute·best-effort) ───────────────────────────
+
+@pytest.mark.anyio
+async def test_batches_over_100():
+    devices = [_dev(f"ExponentPushToken[{i}]") for i in range(250)]
+    db = _mock_db(devices)
+    sizes: list[int] = []
+
+    async def _fake_chunk(msgs):
+        sizes.append(len(msgs))
+        return [{"status": "ok"} for _ in msgs]
+
+    with patch("ee.services.expo_push._expo_send_chunk", new=_fake_chunk):
+        await expo.deliver_expo_push(
+            db, uuid.uuid4(), [devices[0].member_id], title="T", body="B", event_type="e",
+        )
+    assert sizes == [100, 100, 50]  # 250 → 100/100/50 청크
+
+
+@pytest.mark.anyio
+async def test_deactivates_device_not_registered():
+    good = _dev("ExponentPushToken[GOOD]")
+    bad = _dev("ExponentPushToken[BAD]")
+    db = _mock_db([good, bad])
+
+    async def _fake_chunk(msgs):
+        # good=ok, bad=DeviceNotRegistered
+        out = []
+        for m in msgs:
+            if m["to"] == "ExponentPushToken[BAD]":
+                out.append({"status": "error", "details": {"error": "DeviceNotRegistered"}})
+            else:
+                out.append({"status": "ok", "id": "t"})
+        return out
+
+    with patch("ee.services.expo_push._expo_send_chunk", new=_fake_chunk):
+        await expo.deliver_expo_push(
+            db, uuid.uuid4(), [good.member_id, bad.member_id], title="T", body=None, event_type="e",
+        )
+    # select 1 + update 1 = execute 2회, flush 1회(만료 반영)
+    assert db.execute.await_count == 2
+    db.flush.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_no_deactivation_when_all_ok():
+    dev = _dev("ExponentPushToken[GOOD]")
+    db = _mock_db([dev])
+    with patch("ee.services.expo_push._expo_send_chunk", new=AsyncMock(return_value=[{"status": "ok"}])):
+        await expo.deliver_expo_push(db, uuid.uuid4(), [dev.member_id], title="T", body="B", event_type="e")
+    # dead 없음 → update/flush 미실행(select 1회만)
+    assert db.execute.await_count == 1
+    db.flush.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_skips_when_all_muted():
+    m = uuid.uuid4()
+    db = _mock_db([])
+    sent = AsyncMock()
+    with patch("ee.services.expo_push._expo_send_chunk", new=sent):
+        await expo.deliver_expo_push(
+            db, uuid.uuid4(), [m], title="T", body="B", event_type="e", muted_member_ids={m},
+        )
+    # 전원 mute → 조기 return: device 조회도 발송도 없음
+    db.execute.assert_not_awaited()
+    sent.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_no_send_when_no_devices():
+    db = _mock_db([])  # select → 0 devices
+    sent = AsyncMock()
+    with patch("ee.services.expo_push._expo_send_chunk", new=sent):
+        await expo.deliver_expo_push(db, uuid.uuid4(), [uuid.uuid4()], title="T", body="B", event_type="e")
+    sent.assert_not_awaited()  # 디바이스 0 → 발송 없음
+
+
+@pytest.mark.anyio
+async def test_best_effort_swallows_exceptions():
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=RuntimeError("db down"))
+    # 예외가 전파되면 알림 파이프라인이 되돌려짐 — best-effort 로 삼켜야 함(예외 안 남).
+    await expo.deliver_expo_push(db, uuid.uuid4(), [uuid.uuid4()], title="T", body="B", event_type="e")

--- a/backend/tests/test_expo_push_realdb.py
+++ b/backend/tests/test_expo_push_realdb.py
@@ -12,8 +12,6 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-os.environ.setdefault("LICENSE_CONSENT", "agreed")  # EE 게이트 on (app import 前·단독 실행 권장)
-
 _REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
 pytestmark = pytest.mark.skipif(
@@ -37,6 +35,16 @@ def _async_url() -> str:
         if url.startswith(prefix):
             return "postgresql+asyncpg://" + url[len(prefix):]
     return url
+
+
+def _ee_on():
+    """is_ee_enabled property 를 결정적으로 True 로 — env/import-order 무관(까심 QA #2168 동일 클래스 fix).
+
+    core 훅(dispatch_notification)이 런타임에 `settings.is_ee_enabled`를 읽으므로, module-level env 대신
+    호출 구간을 이 patch 로 감싸 결정적으로 EE 를 켠다.
+    """
+    from app.core.config import settings
+    return patch.object(type(settings), "is_ee_enabled", property(lambda self: True))
 
 
 class _Resp:
@@ -107,7 +115,7 @@ async def test_dispatch_notification_sends_expo_and_expires_dead_token_realdb():
 
         # dispatch_notification 실구동(EE on) — Expo HTTP 만 mock.
         async with SessionLocal() as s:
-            with patch("ee.services.expo_push.httpx.AsyncClient", new=fake):
+            with _ee_on(), patch("ee.services.expo_push.httpx.AsyncClient", new=fake):
                 await dispatch_notification(
                     s, org_id=ORG, event_type="gate_pending",
                     target_member_ids=[MEMBER_X], title="게이트 대기", body="승인 필요",

--- a/backend/tests/test_expo_push_realdb.py
+++ b/backend/tests/test_expo_push_realdb.py
@@ -1,0 +1,134 @@
+"""E-MOBILE M0·S3: Expo 발송 real-DB 왕복 — dispatch_notification 경로 실구동 + mock Expo.
+
+AC1(dispatch_notification 경로 발송·비-EE 무동작) + AC2(DeviceNotRegistered→is_active=false 왕복).
+실 PG + 실 파이프라인(dispatch_notification) 구동, Expo HTTP 만 mock(토큰별 ticket 반환). DB env 없으면 skip.
+"""
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.setdefault("LICENSE_CONSENT", "agreed")  # EE 게이트 on (app import 前·단독 실행 권장)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(
+    not _REAL_DB_URL, reason="real-DB URL(PARITY/ALEMBIC_DATABASE_URL) 미설정 — skip"
+)
+
+ORG = uuid.UUID("d3000000-0000-0000-0000-0000000000e1")
+MEMBER_X = uuid.UUID("d3000000-0000-0000-0000-0000000000a1")
+TOKEN_GOOD = "ExponentPushToken[s3-good-0001]"
+TOKEN_BAD = "ExponentPushToken[s3-bad-0002]"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+class _Resp:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _FakeExpo:
+    """Expo send mock: 요청 body(messages)를 캡처하고 토큰별 ticket(good=ok·bad=DeviceNotRegistered) 반환."""
+    def __init__(self):
+        self.posted_tokens: list[str] = []
+        self.posted_titles: list[str] = []
+
+    def __call__(self, *a, **k):
+        cm = AsyncMock()
+        cm.__aenter__ = AsyncMock(return_value=self)
+        cm.__aexit__ = AsyncMock(return_value=False)
+        return cm
+
+    async def post(self, url, content=None, headers=None):
+        messages = json.loads(content)
+        tickets = []
+        for m in messages:
+            self.posted_tokens.append(m["to"])
+            self.posted_titles.append(m.get("title"))
+            if m["to"] == TOKEN_BAD:
+                tickets.append({"status": "error", "details": {"error": "DeviceNotRegistered"}})
+            else:
+                tickets.append({"status": "ok", "id": "ticket-1"})
+        return _Resp(200, {"data": tickets})
+
+
+@pytest.mark.anyio
+async def test_dispatch_notification_sends_expo_and_expires_dead_token_realdb():
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.services.notification_dispatch import dispatch_notification
+
+    engine = create_async_engine(_async_url())
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def _seed():
+        async with SessionLocal() as s:
+            await s.execute(text("DELETE FROM push_devices WHERE org_id=:o"), {"o": str(ORG)})
+            await s.execute(text("DELETE FROM organizations WHERE id=:o"), {"o": str(ORG)})
+            await s.execute(
+                text("INSERT INTO organizations (id,name,slug,plan) VALUES (:o,'S3 Org','s3-expo','free')"),
+                {"o": str(ORG)},
+            )
+            for tok in (TOKEN_GOOD, TOKEN_BAD):
+                await s.execute(
+                    text(
+                        "INSERT INTO push_devices (id,org_id,member_id,expo_push_token,platform,is_active) "
+                        "VALUES (gen_random_uuid(),:o,:m,:t,'ios',true)"
+                    ),
+                    {"o": str(ORG), "m": str(MEMBER_X), "t": tok},
+                )
+            await s.commit()
+
+    fake = _FakeExpo()
+    try:
+        await _seed()
+
+        # dispatch_notification 실구동(EE on) — Expo HTTP 만 mock.
+        async with SessionLocal() as s:
+            with patch("ee.services.expo_push.httpx.AsyncClient", new=fake):
+                await dispatch_notification(
+                    s, org_id=ORG, event_type="gate_pending",
+                    target_member_ids=[MEMBER_X], title="게이트 대기", body="승인 필요",
+                )
+            await s.commit()
+
+        # 발송 실증: 두 토큰 모두 페이로드에 실림 + 제목 전달
+        assert set(fake.posted_tokens) == {TOKEN_GOOD, TOKEN_BAD}
+        assert "게이트 대기" in fake.posted_titles
+
+        # DeviceNotRegistered 만료 왕복: BAD=비활성·GOOD=활성 유지
+        async with SessionLocal() as s:
+            rows = (await s.execute(
+                text("SELECT expo_push_token, is_active FROM push_devices WHERE org_id=:o"),
+                {"o": str(ORG)},
+            )).all()
+        state = {tok: active for tok, active in rows}
+        assert state[TOKEN_BAD] is False, "DeviceNotRegistered 토큰이 만료(is_active=false) 안 됨"
+        assert state[TOKEN_GOOD] is True, "정상 토큰이 잘못 만료됨"
+    finally:
+        async with SessionLocal() as s:
+            await s.execute(text("DELETE FROM organizations WHERE id=:o"), {"o": str(ORG)})  # cascade
+            await s.commit()
+        await engine.dispose()


### PR DESCRIPTION
> ⚠️ **스택 PR** — base=`feat/e-mobile-m0-s2-push-devices`(#2168). S3는 S2의 `push_devices`를 소비하므로 스택. #2168 머지되면 base를 develop로 자동 재타깃(GitHub)·S2 diff는 자연 소멸. **머지 순서: #2168 먼저 → 이 PR.**

## 무엇 (E-MOBILE M0·S3 · ee·BE · story `6069153d`)

`dispatch_notification`(core)의 채널 확장 지점에서 등록 `push_devices`로 **Expo push 발송** — `_deliver_personal_webhooks`와 **나란한 별개 채널**. 파이프라인 무변경(훅은 최소 배선).

- **발송기** `ee/services/expo_push.py`: 활성 `push_devices` 소비 → `POST exp.host/--/api/v2/push/send`(httpx JSON·**신규 패키지 0**)·배치 **≤100/req**·메시지 최소화(≤4096B)·`sound`/`priority`·딥링크 `data`(event_type·reference).
  - **재시도/백오프** = `dispatch_router._post_with_retry`의 상수(`_WEBHOOK_MAX_RETRIES`/`_BACKOFF`) 재사용. 단 ticket 응답을 파싱해 `DeviceNotRegistered`를 잡아야 해서 bool 반환인 그 함수를 직접 안 쓰고 동일 정책의 사이드 함수(`_expo_send_chunk`)로 응답 반환·429/5xx 재시도.
  - **`DeviceNotRegistered`** ticket → 그 토큰 `is_active=false` 자동 만료(재발송 대상서 제외).
- **core 훅**(최소 배선·`app/services/notification_dispatch.py`): `_deliver_personal_webhooks(...)` 옆에 `if settings.is_ee_enabled:` 가드 호출(비-EE **무동작**·core 무영향·main.py EE 마운트와 동형). 대상 = `enabled`(설정 통과) − `mute` 멤버(내부 필터)·웹훅 유무 독립·디바이스당 1발(**이중발송 0**)·**best-effort**(발송 실패가 알림 파이프라인 안 되돌림).

## ee 경계 (S2 동형·스토리 스코프 노트 그대로)

발송 서비스 로직=`ee/services/`, core 파이프라인 훅은 EE 게이트 한 곳. 모델/마이그 신규 **0**(S2 `push_devices` 재사용). `NotificationSetting`(기존)로 필터 후 채널만 추가 — 신규 설정 테이블 0.

## 증거 (실측)

- **단위 8** (`test_expo_push_ee.py`·DB 불요): ticket 파싱·5xx 재시도 소진·**배치 250→100/100/50**·`DeviceNotRegistered`→만료(update+flush)·전원 mute 조기 return·디바이스 0 무발송·**best-effort 예외 삼킴**.
- **realdb 왕복 1** (`test_expo_push_realdb.py`·실 PG + 실 `dispatch_notification` 구동·Expo HTTP만 mock): 두 토큰 모두 발송 페이로드에 실림·제목 전달·**`DeviceNotRegistered`→BAD `is_active=false`·GOOD 활성 유지**.
- **무회귀 47 passed**: 기존 dispatch/webhook 테스트(비-EE 기본·내 훅 스킵) 전부 그린 — core 변경 무영향.
- **비-EE 무동작**: `LICENSE_CONSENT` 미설정 시 훅 스킵(기본 경로 불변).

## 셀프 게이트 (pr-self-gate-checklist 통과)

- **어서션 뮤테이션(class1·AC3)**: core EE 훅 `if False`로 죽임 → realdb **RED**(posted_tokens 빈 집합) 실측 후 원복. 훅이 발송의 실원인·테스트 비공허 증명.
- **무회귀(class5)**: 기존 dispatch 47 passed.
- **wiring(class9)**: EE 훅 실배선 + realdb로 실발송 확認.
- **마이그(class11)**: 신규 DDL **0**(S2 테이블 재사용).

## 게이트

까심 QA(발송 경계·`DeviceNotRegistered` 만료·best-effort·이중발송 0·비-EE 무동작) + CI → PO 머지(#2168 후) → 라이브. receipt(getReceipts) 기반 지연 만료는 M1(관측)로 명시적 유보 — M0은 send 응답 ticket 즉시 만료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)