### PR TITLE
feat(org-os-b): S-slug-infra — workspace/project slug 인프라 (story 139d2405)

### DIFF
--- a/backend/alembic/versions/0184_workspace_project_slug_infra.py
+++ b/backend/alembic/versions/0184_workspace_project_slug_infra.py
@@ -1,0 +1,81 @@
+"""story 139d2405(S-slug-infra): projects.slug additive+백필(이름 kebab 파생·org-scoped 유일) +
+entity_slug_history 테이블(rename 이력·향후 301용).
+
+Revision ID: 0184
+Revises: 0183
+Create Date: 2026-07-15
+
+organizations.slug는 이미 존재하는 컬럼(모델 unique=True 선언)·이 마이그와 무관 — 단, 실측
+결과 DB 레벨 UNIQUE 제약이 baseline부터 누락돼있던 별개 갭을 발견해 0185에서 봉합한다(발견
+즉시 수정). 순수 additive — 기존 스키마 무회귀. 백필: name→slugify(app.services.doc_slug와
+동일 유니코드 NFC 계약)·org 내 충돌은 `-2`,`-3`… suffix(생성 순서=created_at ASC로 결정적)로
+해소.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0184"
+down_revision = "0183"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "entity_slug_history",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("entity_type", sa.Text(), nullable=False),
+        sa.Column("entity_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("old_slug", sa.Text(), nullable=False),
+        sa.Column("new_slug", sa.Text(), nullable=False),
+        sa.Column("changed_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index("ix_entity_slug_history_org_id", "entity_slug_history", ["org_id"])
+    op.create_index("ix_entity_slug_history_entity_id", "entity_slug_history", ["entity_id"])
+
+    # ⚠️nullable 유지(NOT NULL 아님) — 이 리포 전역에 raw Project(...) 시더가 수백 곳(실DB 테스트)이라
+    # NOT NULL로 걸면 그 전부가 즉시 깨진다(실측: 666건). 백필은 여전히 기존 실 데이터를 채우고,
+    # 신규 API 경로는 항상 값을 채워 넣어 실질적으로 non-null. UNIQUE(org_id, slug)는 여러 NULL을
+    # 서로 다른 값으로 취급해 무해(app/models/project.py 주석 참고).
+    op.add_column("projects", sa.Column("slug", sa.Text(), nullable=True))
+
+    _backfill_project_slugs()
+
+    op.create_unique_constraint("uq_projects_org_slug", "projects", ["org_id", "slug"])
+
+
+def _backfill_project_slugs() -> None:
+    from app.services.doc_slug import slugify
+
+    conn = op.get_bind()
+    rows = conn.execute(
+        sa.text("SELECT id, org_id, name FROM projects ORDER BY created_at ASC")
+    ).fetchall()
+
+    used_per_org: dict[str, set[str]] = {}
+    for row in rows:
+        org_key = str(row.org_id)
+        used = used_per_org.setdefault(org_key, set())
+        base = slugify(row.name or "") or "project"
+        candidate = base
+        n = 2
+        while candidate in used:
+            candidate = f"{base}-{n}"
+            n += 1
+        used.add(candidate)
+        conn.execute(
+            sa.text("UPDATE projects SET slug = :slug WHERE id = :id"),
+            {"slug": candidate, "id": row.id},
+        )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_projects_org_slug", "projects", type_="unique")
+    op.drop_column("projects", "slug")
+    op.drop_index("ix_entity_slug_history_entity_id", table_name="entity_slug_history")
+    op.drop_index("ix_entity_slug_history_org_id", table_name="entity_slug_history")
+    op.drop_table("entity_slug_history")

--- a/backend/alembic/versions/0185_organizations_slug_unique_constraint.py
+++ b/backend/alembic/versions/0185_organizations_slug_unique_constraint.py
@@ -1,0 +1,58 @@
+"""story 139d2405(S-slug-infra) 후속 발견: organizations.slug UNIQUE 제약 누락 봉합.
+
+Revision ID: 0185
+Revises: 0184
+Create Date: 2026-07-15
+
+SQLAlchemy 모델(app/models/organization.py)은 `slug: Mapped[str] = mapped_column(..., unique=True)`
+로 선언돼 있었지만, baseline schema.sql부터 실제 DB엔 이 제약이 한 번도 반영된 적이 없었다
+(PRIMARY KEY(id)만 존재 — 실측 확인, alembic/baseline/schema.sql:1489-1497). 지금까지는
+`OrganizationRepository.create()`의 app-level `slug_exists()` 사전체크만으로 유일성을 지켜왔는데,
+이 슬라이스가 추가하는 workspace slug resolution API(전역 유일 전제)가 이 갭 위에 서면 안 되므로
+발견 즉시 봉합한다.
+
+방어적 적용: 제약 추가 전 기존 중복 slug가 있으면(이론상 가능 — DB 제약이 없었으므로) 나중에
+생성된 행부터 `-2`,`-3`… suffix로 결정적 해소한 뒤 제약을 건다(마이그레이션 자체가 dirty data로
+실패하지 않도록 — 8f15ae56/823f08cd류 prod 안전 선례와 동형: 실행 시점에 자가치유).
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0185"
+down_revision = "0184"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    _dedupe_organization_slugs()
+    op.create_unique_constraint("uq_organizations_slug", "organizations", ["slug"])
+
+
+def _dedupe_organization_slugs() -> None:
+    conn = op.get_bind()
+    rows = conn.execute(
+        sa.text("SELECT id, slug FROM organizations ORDER BY created_at ASC")
+    ).fetchall()
+
+    seen: set[str] = set()
+    for row in rows:
+        slug = row.slug
+        if slug not in seen:
+            seen.add(slug)
+            continue
+        n = 2
+        while f"{slug}-{n}" in seen:
+            n += 1
+        new_slug = f"{slug}-{n}"
+        seen.add(new_slug)
+        conn.execute(
+            sa.text("UPDATE organizations SET slug = :slug WHERE id = :id"),
+            {"slug": new_slug, "id": row.id},
+        )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_organizations_slug", "organizations", type_="unique")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -8,6 +8,7 @@ from app.models.agent_session import AgentSession
 from app.models.bridge import BridgeChannelMapping, BridgeUserMapping
 from app.models.deletion_audit import DeletionAuditLog
 from app.models.dependency import ItemDependency
+from app.models.entity_slug_history import EntitySlugHistory
 from app.models.embedding import Embedding
 from app.models.evidence import Evidence
 from app.models.gate import Gate
@@ -86,6 +87,7 @@ __all__ = [
     "HitlPolicy",
     "HitlRequest",
     "ItemDependency",
+    "EntitySlugHistory",
     "MockupComponent",
     "MockupPage",
     "MockupScenario",

--- a/backend/app/models/entity_slug_history.py
+++ b/backend/app/models/entity_slug_history.py
@@ -1,0 +1,27 @@
+"""story 139d2405(S-slug-infra): workspace/project slug rename 이력 — 향후 301 redirect(S-route-*)용."""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class EntitySlugHistory(Base):
+    """entity_type='organization'|'project'의 slug 변경 1건. old_slug→new_slug 조회로 301 해소.
+
+    org_id는 project 이력도 workspace 스코프로 바로 필터 가능하게 하는 denorm(조인 없이 조회)."""
+
+    __tablename__ = "entity_slug_history"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    entity_type: Mapped[str] = mapped_column(Text, nullable=False)  # 'organization' | 'project'
+    entity_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    old_slug: Mapped[str] = mapped_column(Text, nullable=False)
+    new_slug: Mapped[str] = mapped_column(Text, nullable=False)
+    changed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -12,9 +12,20 @@ from app.models.base import OrgScopedMixin, SoftDeleteMixin, TimestampMixin
 
 class Project(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     __tablename__ = "projects"
+    __table_args__ = (
+        UniqueConstraint("org_id", "slug", name="uq_projects_org_slug"),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name: Mapped[str] = mapped_column(Text, nullable=False)
+    # story 139d2405(S-slug-infra): workspace 내 유일(org-scoped) — 전역 유일인 organizations.slug와
+    # 다른 스코프(project는 root bare 경로가 아니라 `/{ws}/{proj}/...` 하위라 워크스페이스 내에서만
+    # 유일하면 됨). additive(0184 백필=이름 kebab 파생 — 기존 실 데이터는 채워짐). ⚠️nullable 유지
+    # (NOT NULL 아님): 이 리포 전역에 raw `Project(...)` 생성자를 직접 쓰는 실DB 테스트 시더가
+    # 수백 곳이라(slug 인지 0) NOT NULL로 걸면 그 전부가 즉시 깨진다(실측 확認 — 666건 NotNull
+    # violation). 신규 API 경로(app/routers/projects.py)는 항상 실값을 채워 넣어 실질적으로
+    # non-null이고, 유니크 제약(org_id, slug)은 NULL 여러 개를 서로 다른 값으로 취급해 무해하다.
+    slug: Mapped[str | None] = mapped_column(Text, nullable=True)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     # S3-2: warn(default) | block
     violation_level: Mapped[str] = mapped_column(String(10), nullable=False, default="warn")

--- a/backend/app/repositories/organization.py
+++ b/backend/app/repositories/organization.py
@@ -43,6 +43,13 @@ class OrganizationRepository:
         )
         return result.scalar_one_or_none() is not None
 
+    async def get_by_slug(self, slug: str) -> Organization | None:
+        """story 139d2405(S-slug-infra): workspace slug 해소용(slug 전역 유일)."""
+        result = await self.session.execute(
+            select(Organization).where(Organization.slug == slug)
+        )
+        return result.scalar_one_or_none()
+
     async def create(self, name: str, slug: str, owner_member_id: uuid.UUID | None) -> Organization | None:
         if await self.slug_exists(slug):
             return None

--- a/backend/app/routers/organizations.py
+++ b/backend/app/routers/organizations.py
@@ -10,6 +10,11 @@ from app.dependencies.database import get_db
 from app.models.user import User
 from app.repositories.organization import OrganizationRepository
 from app.services.agent_anchor_sync import ensure_human_member
+from app.services.entity_slug import (
+    RESERVED_WORKSPACE_SLUGS,
+    is_valid_slug_format,
+    is_workspace_slug_taken,
+)
 from app.schemas.organization import (
     CreateOrganization,
     DeleteOrganization,
@@ -57,6 +62,13 @@ async def create_organization(
         from ee.plan_limits import check_org_create_limit  # type: ignore[import]
         await check_org_create_limit(session, auth.user_id)
 
+    # story 139d2405(S-slug-infra): workspace slug=root bare 경로라 앱 라우트 예약어와 충돌
+    # 방지(형식도 함께 방어 — URL path segment).
+    if not is_valid_slug_format(body.slug):
+        raise HTTPException(status_code=400, detail="Invalid slug format")
+    if body.slug in RESERVED_WORKSPACE_SLUGS:
+        raise HTTPException(status_code=400, detail="Slug is reserved")
+
     org = await repo.create(name=body.name, slug=body.slug, owner_member_id=body.owner_member_id)
     if org is None:
         raise HTTPException(status_code=409, detail="Slug already exists")
@@ -90,6 +102,24 @@ async def create_organization(
     return OrganizationResponse.model_validate(org)
 
 
+@router.get("/resolve", response_model=MyOrganizationResponse)
+async def resolve_organization_by_slug(
+    slug: str,
+    auth: AuthContext = Depends(get_current_user),
+    repo: OrganizationRepository = Depends(_get_repo),
+) -> MyOrganizationResponse:
+    """story 139d2405(S-slug-infra): workspace slug → org 해소(S-route-workspace FE middleware가
+    소비 예정). 전역 유일이라 org_id 사전지정 불요. 비소속이면 404(존재 노출 금지 — get_organization
+    과 동형 원칙). ⚠️`/{id}` 라우트보다 먼저 등록해야 "resolve"가 UUID 파싱으로 새지 않는다."""
+    org = await repo.get_by_slug(slug)
+    if org is None:
+        raise HTTPException(status_code=404, detail="Organization not found")
+    role = await repo.get_member_role(org_id=org.id, user_id=uuid.UUID(auth.user_id))
+    if role is None:
+        raise HTTPException(status_code=404, detail="Organization not found")
+    return MyOrganizationResponse(id=org.id, name=org.name, slug=org.slug, plan=org.plan, role=role)
+
+
 @router.get("/{id}", response_model=OrganizationResponse)
 async def get_organization(
     id: uuid.UUID,
@@ -114,17 +144,38 @@ async def update_organization(
     repo: OrganizationRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
 ) -> OrganizationResponse:
-    """Organization 이름 수정 — owner/admin만 가능."""
+    """Organization 이름/슬러그 수정 — owner/admin만 가능."""
     role = await repo.get_member_role(org_id=id, user_id=uuid.UUID(auth.user_id))
     if role is None:
         raise HTTPException(status_code=404, detail="Organization not found")
     if role not in ("owner", "admin"):
         raise HTTPException(status_code=403, detail="owner or admin role required")
 
-    org = await repo.update_name(org_id=id, name=body.name)
+    org = await repo.get(id)
     if org is None:
         raise HTTPException(status_code=404, detail="Organization not found")
 
+    if body.name is not None:
+        org.name = body.name
+
+    # story 139d2405(S-slug-infra): workspace rename — 형식/예약어/전역 유일성(자기 제외) 검증 +
+    # 이력 기록(향후 S-route-workspace의 301 해소용). old==new(무변경 재전송)면 이력 skip.
+    if body.slug is not None and body.slug != org.slug:
+        if not is_valid_slug_format(body.slug):
+            raise HTTPException(status_code=400, detail="Invalid slug format")
+        if body.slug in RESERVED_WORKSPACE_SLUGS:
+            raise HTTPException(status_code=400, detail="Slug is reserved")
+        if await is_workspace_slug_taken(session, body.slug, exclude_org_id=id):
+            raise HTTPException(status_code=409, detail="Slug already exists")
+        from app.models.entity_slug_history import EntitySlugHistory
+        session.add(EntitySlugHistory(
+            org_id=id, entity_type="organization", entity_id=id,
+            old_slug=org.slug, new_slug=body.slug,
+        ))
+        org.slug = body.slug
+
+    await session.flush()
+    await session.refresh(org)
     await session.commit()
     return OrganizationResponse.model_validate(org)
 

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -11,6 +11,12 @@ from app.models.project import Project
 from app.repositories.project import ProjectRepository
 from app.schemas.project import ProjectCreate, ProjectResponse, ProjectUpdate
 from app.services.agent_anchor_sync import ensure_human_member
+from app.services.entity_slug import (
+    is_project_slug_taken,
+    is_valid_slug_format,
+    resolve_unique_project_slug,
+    slugify,
+)
 from app.services.project_auth import (
     accessible_project_ids_in_org,
     has_project_access,
@@ -53,7 +59,20 @@ async def create_project(
         from ee.plan_limits import check_project_create_limit  # type: ignore[import]
         await check_project_create_limit(session, org_id)
 
-    project = await repo.create(name=body.name, description=body.description)
+    # story 139d2405(S-slug-infra): 명시 지정 시 형식 검증 + org 내 유일성(충돌 시 409 — organizations
+    # create와 동형: 사용자가 명시한 값은 조용히 안 바꾼다). 미지정 시 name→kebab 파생 후 자동 유일화
+    # (충돌 -n suffix — 시스템 파생값이라 조용히 바꿔도 됨).
+    if body.slug is not None:
+        if not is_valid_slug_format(body.slug):
+            raise HTTPException(status_code=400, detail="Invalid slug format")
+        if await is_project_slug_taken(session, org_id, body.slug):
+            raise HTTPException(status_code=409, detail="Slug already exists")
+        slug = body.slug
+    else:
+        base_slug = slugify(body.name) or "project"
+        slug = await resolve_unique_project_slug(session, org_id, base_slug)
+
+    project = await repo.create(name=body.name, description=body.description, slug=slug)
 
     # project_memberships 테이블 미존재 — agent 자동 첨부는 agent 생성 시 project_id로 직접 연결.
     # Ensure the creating user is in org_members (S5: human type team_member 신규 생성 제거).
@@ -86,6 +105,27 @@ async def create_project(
     return ProjectResponse.model_validate(project)
 
 
+@router.get("/resolve", response_model=ProjectResponse)
+async def resolve_project_by_slug(
+    slug: str,
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    session: AsyncSession = Depends(get_db),
+) -> ProjectResponse:
+    """story 139d2405(S-slug-infra): project slug(workspace 내 유일) → project 해소(S-route-project
+    FE middleware가 소비 예정). org_id는 호출자 workspace 컨텍스트(get_verified_org_id)로 자동 스코프.
+    ⚠️`/{id}` 라우트보다 먼저 등록해야 "resolve"가 UUID 파싱으로 새지 않는다."""
+    row = await session.execute(
+        select(Project).where(
+            Project.org_id == org_id, Project.slug == slug, Project.deleted_at.is_(None),
+        )
+    )
+    project = row.scalar_one_or_none()
+    if project is None or not await has_project_access(session, uuid.UUID(auth.user_id), project.id, org_id):
+        raise HTTPException(status_code=404, detail="Project not found")
+    return ProjectResponse.model_validate(project)
+
+
 @router.get("/{id}", response_model=ProjectResponse)
 async def get_project(
     id: uuid.UUID,
@@ -111,11 +151,29 @@ async def update_project(
 ) -> ProjectResponse:
     repo = ProjectRepository(session, org_id)
     # 편집은 부여 멤버 ∪ owner/admin 만. 미접근은 404(비노출).
-    if await repo.get(id) is None or not await has_project_access(
+    existing = await repo.get(id)
+    if existing is None or not await has_project_access(
         session, uuid.UUID(auth.user_id), id, org_id
     ):
         raise HTTPException(status_code=404, detail="Project not found")
     data = body.model_dump(exclude_unset=True)
+
+    # story 139d2405(S-slug-infra): slug rename — 형식/org 내 유일성(자기 제외, 충돌 시 409 —
+    # organizations rename과 동형) 검증 + 이력 기록(향후 S-route-project의 301 해소용).
+    # old==new(무변경 재전송)면 이력 skip.
+    if "slug" in data and data["slug"] is not None and data["slug"] != existing.slug:
+        if not is_valid_slug_format(data["slug"]):
+            raise HTTPException(status_code=400, detail="Invalid slug format")
+        if await is_project_slug_taken(session, org_id, data["slug"], exclude_project_id=id):
+            raise HTTPException(status_code=409, detail="Slug already exists")
+        from app.models.entity_slug_history import EntitySlugHistory
+        session.add(EntitySlugHistory(
+            org_id=org_id, entity_type="project", entity_id=id,
+            old_slug=existing.slug, new_slug=data["slug"],
+        ))
+    elif "slug" in data and data["slug"] == existing.slug:
+        data.pop("slug")
+
     project = await repo.update(id, **data)
     if project is None:
         raise HTTPException(status_code=404, detail="Project not found")

--- a/backend/app/schemas/organization.py
+++ b/backend/app/schemas/organization.py
@@ -42,7 +42,9 @@ class MyOrganizationResponse(BaseModel):
 
 
 class UpdateOrganization(BaseModel):
-    name: str
+    name: str | None = None
+    # story 139d2405(S-slug-infra): workspace rename — 형식/예약어/유일성은 라우터에서(DB 조회 필요).
+    slug: str | None = None
 
 
 class OrgImpactResponse(BaseModel):

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -8,11 +8,15 @@ class ProjectCreate(BaseModel):
     org_id: uuid.UUID
     name: str
     description: str | None = None
+    # story 139d2405(S-slug-infra): 미지정 시 서버가 name→kebab 파생(org 내 유일 자동 해소).
+    # 지정 시 형식/유일성 검증(라우터에서 — DB 조회 필요라 pydantic validator 밖).
+    slug: str | None = None
 
 
 class ProjectUpdate(BaseModel):
     name: str | None = None
     description: str | None = None
+    slug: str | None = None
 
 
 class ProjectResponse(BaseModel):
@@ -21,6 +25,9 @@ class ProjectResponse(BaseModel):
     id: uuid.UUID
     org_id: uuid.UUID
     name: str
+    # story 139d2405(S-slug-infra): 모델과 동형 nullable — raw seed(테스트 등)로 만들어진 legacy
+    # project는 slug가 없을 수 있음(app/models/project.py 주석 참고). API로 생성된 project는 항상 값 有.
+    slug: str | None = None
     description: str | None = None
     created_at: datetime
     updated_at: datetime

--- a/backend/app/services/entity_slug.py
+++ b/backend/app/services/entity_slug.py
@@ -1,0 +1,109 @@
+"""story 139d2405(S-slug-infra): workspace(organization)/project slug 유일성·예약어·이력.
+
+slugify 자체는 app.services.doc_slug.slugify 재사용(유니코드 NFC 계약 동일·발명 0) — 여기선
+workspace(전역 유일)·project(org-scoped 유일) 두 스코프의 충돌 해소 + workspace 전용 예약어
+denylist만 추가한다.
+"""
+from __future__ import annotations
+
+import re
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.doc_slug import MAX_SLUG_LEN, slugify
+
+# 클라이언트가 직접 slug를 지정하는 경로(org/project 생성·rename) 용 형식 가드 — slugify()
+# 산출물과 동형 문자 집합(소문자 라틴+숫자+하이픈, 앞뒤 하이픈 금지)만 허용. 유니코드(한글 등)
+# slug는 auto-derive(slugify) 경로로만 나오게 하고 client raw 입력은 URL-safe ASCII로 제한
+# (workspace/project slug는 URL path segment라 인코딩 이슈 회피가 우선).
+_SLUG_FORMAT_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+
+def is_valid_slug_format(slug: str) -> bool:
+    return bool(slug) and bool(_SLUG_FORMAT_RE.match(slug))
+
+# 유나 doc org-1st-class-surface-ia-design-b §2a — root bare workspace slug라 앱 라우트와
+# 충돌 방지(GitHub org 예약어 관례). project slug는 workspace 하위(non-root)라 denylist 불요.
+RESERVED_WORKSPACE_SLUGS: frozenset[str] = frozenset({
+    "api", "login", "logout", "onboarding", "settings", "organization", "o", "admin",
+    "help", "static", "_next", "404",
+})
+
+
+class ReservedSlugError(ValueError):
+    """workspace slug가 예약어 denylist에 해당."""
+
+
+async def is_workspace_slug_taken(
+    session: AsyncSession, slug: str, exclude_org_id: uuid.UUID | None = None,
+) -> bool:
+    """workspace(organization) slug는 root bare 네임스페이스라 org 무관 전역 유일."""
+    from app.models.organization import Organization
+
+    conds = [Organization.slug == slug]
+    if exclude_org_id is not None:
+        conds.append(Organization.id != exclude_org_id)
+    row = await session.execute(select(func.count()).select_from(Organization).where(*conds))
+    return (row.scalar() or 0) > 0
+
+
+async def resolve_unique_workspace_slug(
+    session: AsyncSession, base: str, exclude_org_id: uuid.UUID | None = None,
+) -> str:
+    """base가 예약어거나 충돌이면 `-2`,`-3`… suffix로 유일 slug 산출.
+
+    base는 이미 slugify된 비어있지 않은 값 가정. 예약어인 base 자체는 무조건 suffix부터
+    시작(그래야 "admin"이 "admin-2"로 자동 우회되지 재시도 없이 400 나지 않는다).
+    """
+    n = 2
+    candidate = base
+    while candidate in RESERVED_WORKSPACE_SLUGS or await is_workspace_slug_taken(
+        session, candidate, exclude_org_id,
+    ):
+        suffix = f"-{n}"
+        trimmed = base[: MAX_SLUG_LEN - len(suffix)].rstrip("-")
+        candidate = f"{trimmed}{suffix}"
+        n += 1
+    return candidate
+
+
+async def is_project_slug_taken(
+    session: AsyncSession, org_id: uuid.UUID, slug: str, exclude_project_id: uuid.UUID | None = None,
+) -> bool:
+    """project slug는 workspace(org) 내 유일 — 다른 org의 동일 slug는 무관."""
+    from app.models.project import Project
+
+    conds = [Project.org_id == org_id, Project.slug == slug, Project.deleted_at.is_(None)]
+    if exclude_project_id is not None:
+        conds.append(Project.id != exclude_project_id)
+    row = await session.execute(select(func.count()).select_from(Project).where(*conds))
+    return (row.scalar() or 0) > 0
+
+
+async def resolve_unique_project_slug(
+    session: AsyncSession, org_id: uuid.UUID, base: str, exclude_project_id: uuid.UUID | None = None,
+) -> str:
+    if not await is_project_slug_taken(session, org_id, base, exclude_project_id):
+        return base
+    n = 2
+    while True:
+        suffix = f"-{n}"
+        trimmed = base[: MAX_SLUG_LEN - len(suffix)].rstrip("-")
+        candidate = f"{trimmed}{suffix}"
+        if not await is_project_slug_taken(session, org_id, candidate, exclude_project_id):
+            return candidate
+        n += 1
+
+
+__all__ = [
+    "slugify",
+    "is_valid_slug_format",
+    "RESERVED_WORKSPACE_SLUGS",
+    "ReservedSlugError",
+    "is_workspace_slug_taken",
+    "resolve_unique_workspace_slug",
+    "is_project_slug_taken",
+    "resolve_unique_project_slug",
+]

--- a/backend/tests/test_139d2405_slug_infra_realdb.py
+++ b/backend/tests/test_139d2405_slug_infra_realdb.py
@@ -1,0 +1,555 @@
+"""story 139d2405(S-slug-infra): workspace(organization)/project slug 인프라 — 생성·유일성·
+예약어·rename 이력·resolution API. 유나 doc org-1st-class-surface-ia-design-b §2a/§2e.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_human(session, org_id, project_id=None, *, role="member", grant_project=False):
+    from app.models.project import OrgMember
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    user = User(
+        id=user_id, email=f"human-{user_id.hex[:8]}@test.com", hashed_password="x",
+        email_verified=True,
+    )
+    session.add(user)
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org_id, user_id=user_id, role=role)
+    session.add(om)
+    await session.commit()
+    if grant_project and project_id is not None:
+        session.add(ProjectAccess(
+            id=uuid.uuid4(), project_id=project_id, org_member_id=om.id, permission="granted",
+        ))
+        await session.commit()
+    return user_id, om.id
+
+
+async def _seed_org(session, *, slug=None):
+    from app.models.organization import Organization
+
+    org = Organization(
+        id=uuid.uuid4(), name="Slug Test Org", slug=slug or f"org-{uuid.uuid4().hex[:8]}",
+    )
+    session.add(org)
+    await session.commit()
+    return org
+
+
+async def _seed_project(session, org_id, *, name="Roadmap", slug=None):
+    from app.models.project import Project
+
+    project = Project(
+        id=uuid.uuid4(), org_id=org_id, name=name, slug=slug or f"proj-{uuid.uuid4().hex[:8]}",
+    )
+    session.add(project)
+    await session.commit()
+    return project
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id=None):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    claims = {"app_metadata": {}}
+    if org_id is not None:
+        claims["app_metadata"]["org_id"] = str(org_id)
+
+    async def _auth():
+        return AuthContext(user_id=str(user_id), email="caller@test", claims=claims)
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+# ─── entity_slug.py 유닛 ────────────────────────────────────────────────────
+
+def test_is_valid_slug_format():
+    from app.services.entity_slug import is_valid_slug_format
+
+    assert is_valid_slug_format("moonklabs")
+    assert is_valid_slug_format("moonk-labs-2")
+    assert not is_valid_slug_format("")
+    assert not is_valid_slug_format("MoonkLabs")  # 대문자 금지
+    assert not is_valid_slug_format("-moonklabs")  # 앞 하이픈 금지
+    assert not is_valid_slug_format("moonklabs-")  # 뒤 하이픈 금지
+    assert not is_valid_slug_format("moonk_labs")  # 언더스코어 금지
+    assert not is_valid_slug_format("문서")  # 유니코드(클라이언트 명시 slug는 ASCII만)
+
+
+def test_reserved_workspace_slugs_exact_denylist():
+    from app.services.entity_slug import RESERVED_WORKSPACE_SLUGS
+
+    for w in ("api", "login", "logout", "onboarding", "settings", "organization", "o", "admin",
+              "help", "static", "_next", "404"):
+        assert w in RESERVED_WORKSPACE_SLUGS
+    assert "moonklabs" not in RESERVED_WORKSPACE_SLUGS
+
+
+@pytest.mark.anyio
+async def test_resolve_unique_workspace_slug_skips_reserved_and_collision():
+    from app.services.entity_slug import resolve_unique_workspace_slug
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _seed_org(s, slug="taken")
+            # 예약어는 base 그대로 못 나옴 — suffix로 우회.
+            reserved_result = await resolve_unique_workspace_slug(s, "admin")
+            assert reserved_result != "admin"
+            assert reserved_result not in ("api", "login")
+            # 충돌은 -n suffix.
+            taken_result = await resolve_unique_workspace_slug(s, "taken")
+            assert taken_result == "taken-2"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_resolve_unique_project_slug_scoped_per_org():
+    from app.services.entity_slug import resolve_unique_project_slug
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_a = await _seed_org(s)
+            org_b = await _seed_org(s)
+            await _seed_project(s, org_a.id, slug="roadmap")
+            # 같은 slug라도 다른 org면 충돌 아님.
+            result_b = await resolve_unique_project_slug(s, org_b.id, "roadmap")
+            assert result_b == "roadmap"
+            # 같은 org면 충돌 → suffix.
+            result_a = await resolve_unique_project_slug(s, org_a.id, "roadmap")
+            assert result_a == "roadmap-2"
+    finally:
+        await engine.dispose()
+
+
+# ─── organizations 라우터 ───────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_organization_reserved_slug_400():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            from app.models.user import User
+            user_id = uuid.uuid4()
+            s.add(User(id=user_id, email=f"u-{user_id.hex[:8]}@test.com", hashed_password="x",
+                       email_verified=True))
+            await s.commit()
+
+        await _setup_app(app, Session, user_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/organizations", json={"name": "Admin Org", "slug": "admin"})
+            assert resp.status_code == 400, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_organization_invalid_format_400():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            from app.models.user import User
+            user_id = uuid.uuid4()
+            s.add(User(id=user_id, email=f"u-{user_id.hex[:8]}@test.com", hashed_password="x",
+                       email_verified=True))
+            await s.commit()
+
+        await _setup_app(app, Session, user_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/organizations", json={"name": "Bad Org", "slug": "Not_Valid!"}
+            )
+            assert resp.status_code == 400, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_organization_valid_slug_201():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            from app.models.user import User
+            user_id = uuid.uuid4()
+            s.add(User(id=user_id, email=f"u-{user_id.hex[:8]}@test.com", hashed_password="x",
+                       email_verified=True))
+            await s.commit()
+
+        await _setup_app(app, Session, user_id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/organizations", json={"name": "Moonk Labs", "slug": "moonklabs-e2e"}
+            )
+            assert resp.status_code == 201, resp.text
+            assert resp.json()["slug"] == "moonklabs-e2e"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_organization_slug_rename_records_history():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _seed_org(s, slug="oldslug")
+            user_id, _om_id = await _seed_human(s, org.id, role="owner")
+
+        await _setup_app(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(f"/api/v2/organizations/{org.id}", json={"slug": "newslug"})
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["slug"] == "newslug"
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.entity_slug_history import EntitySlugHistory
+            rows = (await s.execute(
+                select(EntitySlugHistory).where(EntitySlugHistory.entity_id == org.id)
+            )).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].old_slug == "oldslug"
+            assert rows[0].new_slug == "newslug"
+            assert rows[0].entity_type == "organization"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_organization_slug_same_value_no_history():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _seed_org(s, slug="stableslug")
+            user_id, _om_id = await _seed_human(s, org.id, role="owner")
+
+        await _setup_app(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(f"/api/v2/organizations/{org.id}", json={"slug": "stableslug"})
+            assert resp.status_code == 200, resp.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.entity_slug_history import EntitySlugHistory
+            rows = (await s.execute(
+                select(EntitySlugHistory).where(EntitySlugHistory.entity_id == org.id)
+            )).scalars().all()
+            assert len(rows) == 0, "무변경 재전송은 이력 기록 안 함"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_organization_slug_collision_409():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org1 = await _seed_org(s, slug="taken-ws")
+            org2 = await _seed_org(s, slug="own-ws")
+            user_id, _om_id = await _seed_human(s, org2.id, role="owner")
+            _ = org1
+
+        await _setup_app(app, Session, user_id, org2.id)
+        client = _client_for(app)
+        try:
+            resp = await client.patch(f"/api/v2/organizations/{org2.id}", json={"slug": "taken-ws"})
+            assert resp.status_code == 409, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_resolve_organization_by_slug_member_200_nonmember_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _seed_org(s, slug="resolvable-ws")
+            member_id, _om = await _seed_human(s, org.id, role="member")
+            other_org = await _seed_org(s)
+            outsider_id, _om2 = await _seed_human(s, other_org.id, role="member")
+
+        # 소속 멤버 — 200
+        await _setup_app(app, Session, member_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/organizations/resolve", params={"slug": "resolvable-ws"})
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["id"] == str(org.id)
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+
+        # 비소속 — 404(존재 비노출)
+        await _setup_app(app, Session, outsider_id, other_org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/organizations/resolve", params={"slug": "resolvable-ws"})
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+# ─── projects 라우터 ────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_project_no_slug_auto_derives_from_name():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _seed_org(s)
+            user_id, _om = await _seed_human(s, org.id, role="owner")
+
+        await _setup_app(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/projects", json={"org_id": str(org.id), "name": "My Roadmap Q3"}
+            )
+            assert resp.status_code == 201, resp.text
+            assert resp.json()["slug"] == "my-roadmap-q3"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_project_duplicate_name_auto_suffixes():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _seed_org(s)
+            user_id, _om = await _seed_human(s, org.id, role="owner")
+
+        await _setup_app(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            body = {"org_id": str(org.id), "name": "Roadmap"}
+            r1 = await client.post("/api/v2/projects", json=body)
+            r2 = await client.post("/api/v2/projects", json=body)
+            assert r1.status_code == 201 and r2.status_code == 201
+            assert r1.json()["slug"] == "roadmap"
+            assert r2.json()["slug"] == "roadmap-2"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_create_project_explicit_slug_collision_409():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _seed_org(s)
+            user_id, _om = await _seed_human(s, org.id, role="owner")
+            await _seed_project(s, org.id, slug="explicit-slug")
+
+        await _setup_app(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.post(
+                "/api/v2/projects",
+                json={"org_id": str(org.id), "name": "Anything", "slug": "explicit-slug"},
+            )
+            assert resp.status_code == 409, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_update_project_slug_rename_records_history_and_collision_409():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _seed_org(s)
+            user_id, om_id = await _seed_human(s, org.id, role="owner")
+            proj = await _seed_project(s, org.id, slug="old-proj-slug")
+            other_proj = await _seed_project(s, org.id, slug="other-proj-slug")
+
+        await _setup_app(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            ok = await client.patch(f"/api/v2/projects/{proj.id}", json={"slug": "new-proj-slug"})
+            assert ok.status_code == 200, ok.text
+            assert ok.json()["slug"] == "new-proj-slug"
+
+            conflict = await client.patch(
+                f"/api/v2/projects/{proj.id}", json={"slug": "other-proj-slug"}
+            )
+            assert conflict.status_code == 409, conflict.text
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.entity_slug_history import EntitySlugHistory
+            rows = (await s.execute(
+                select(EntitySlugHistory).where(EntitySlugHistory.entity_id == proj.id)
+            )).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].old_slug == "old-proj-slug"
+            assert rows[0].new_slug == "new-proj-slug"
+            assert rows[0].entity_type == "project"
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_resolve_project_by_slug_scoped_to_caller_org():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_a = await _seed_org(s)
+            org_b = await _seed_org(s)
+            user_a, _om_a = await _seed_human(s, org_a.id, role="owner")
+            proj_a = await _seed_project(s, org_a.id, slug="shared-slug-name")
+            await _seed_project(s, org_b.id, slug="shared-slug-name")  # 다른 org의 동일 slug
+
+        # org_a 컨텍스트에서 조회 → org_a의 project만.
+        await _setup_app(app, Session, user_a, org_a.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/projects/resolve", params={"slug": "shared-slug-name"})
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["id"] == str(proj_a.id)
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_resolve_project_by_slug_no_access_404():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org = await _seed_org(s)
+            # grant_project=False — org 멤버지만 project 접근권 없음(정책B: 미부여 비노출).
+            user_id, _om = await _seed_human(s, org.id, role="member", grant_project=False)
+            await _seed_project(s, org.id, slug="restricted-proj")
+
+        await _setup_app(app, Session, user_id, org.id)
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/projects/resolve", params={"slug": "restricted-proj"})
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_e_onboarding_policyb_invite_grant.py
+++ b/backend/tests/test_e_onboarding_policyb_invite_grant.py
@@ -122,7 +122,7 @@ async def test_list_projects_returns_only_accessible(monkeypatch):
     from datetime import datetime, timezone
     _now = datetime(2026, 6, 5, tzinfo=timezone.utc)
     proj = MagicMock()
-    proj.id = P1; proj.org_id = ORG_ID; proj.name = "P1"
+    proj.id = P1; proj.org_id = ORG_ID; proj.name = "P1"; proj.slug = "p1"
     proj.description = None; proj.created_at = _now; proj.updated_at = _now; proj.deleted_at = None
     proj.violation_level = "warn"
     scalars = MagicMock(); scalars.all.return_value = [proj]

--- a/backend/tests/test_e_org_multi_s4_1_org_settings_be.py
+++ b/backend/tests/test_e_org_multi_s4_1_org_settings_be.py
@@ -83,7 +83,7 @@ async def test_owner_can_update_org_name():
 
         mock_repo = MagicMock()
         mock_repo.get_member_role = AsyncMock(return_value="owner")
-        mock_repo.update_name = AsyncMock(return_value=updated_org)
+        mock_repo.get = AsyncMock(return_value=updated_org)
 
         from app.routers.organizations import _get_repo
         app.dependency_overrides[_get_repo] = lambda: mock_repo
@@ -109,7 +109,7 @@ async def test_admin_can_update_org_name():
 
         mock_repo = MagicMock()
         mock_repo.get_member_role = AsyncMock(return_value="admin")
-        mock_repo.update_name = AsyncMock(return_value=updated_org)
+        mock_repo.get = AsyncMock(return_value=updated_org)
 
         from app.routers.organizations import _get_repo
         app.dependency_overrides[_get_repo] = lambda: mock_repo

--- a/backend/tests/test_onboarding_member_anchor_0b115f5d.py
+++ b/backend/tests/test_onboarding_member_anchor_0b115f5d.py
@@ -97,6 +97,7 @@ async def test_create_project_ensures_human_member():
     body = MagicMock()
     body.name = "Board"
     body.description = None
+    body.slug = None
 
     project_obj = MagicMock()
 
@@ -105,6 +106,7 @@ async def test_create_project_ensures_human_member():
 
     with patch.object(projs, "ProjectRepository", return_value=fake_repo), \
             patch.object(projs, "ensure_human_member", new=AsyncMock()) as ehm, \
+            patch.object(projs, "resolve_unique_project_slug", new=AsyncMock(return_value="board")), \
             patch.object(projs.ProjectResponse, "model_validate", return_value=MagicMock()):
         await projs.create_project(body=body, session=session, auth=auth, org_id=org_id)
 

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -15,6 +15,7 @@ def _mock_project(name: str = "Sprintable") -> MagicMock:
     p.id = PROJECT_ID
     p.org_id = ORG_ID
     p.name = name
+    p.slug = "sprintable"
     p.description = None
     p.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     p.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
@@ -95,7 +96,8 @@ async def test_create_project_201():
     client, session, app = await _client()
     try:
         with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create, \
-                patch("app.routers.projects.ensure_human_member", new_callable=AsyncMock):
+                patch("app.routers.projects.ensure_human_member", new_callable=AsyncMock), \
+                patch("app.routers.projects.resolve_unique_project_slug", new=AsyncMock(return_value="sprintable")):
             mock_create.return_value = _mock_project()
 
             async with client as c:

--- a/backend/tests/test_resolve_member_agent_project_idor_realdb.py
+++ b/backend/tests/test_resolve_member_agent_project_idor_realdb.py
@@ -67,7 +67,9 @@ async def _seed(s, *, legacy_team_member: bool = False):
         f"DELETE FROM projects WHERE org_id='{ORG}'",
         f"DELETE FROM users WHERE id='{HUMAN_OWNER}'",
         f"DELETE FROM organizations WHERE id='{ORG}'",
-        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','C1D','c1dorg','free')",
+        # story 139d2405: slug 전역 유일 제약 신설 — test_e_loop_ledger_p1_s12_context_pack_router_
+        # idor_realdb.py가 우연히 동일 slug 'c1dorg'를 다른 org id로 써서 충돌했다(발견 즉시 수정).
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','C1D','c1dorg-rm','free')",
         f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_A}','{ORG}','A')",
         f"INSERT INTO projects (id,org_id,name) VALUES ('{PROJ_B}','{ORG}','B')",
         f"INSERT INTO members (id,org_id,type,name,is_active) VALUES ('{AGENT}','{ORG}','agent','Ag',true)",


### PR DESCRIPTION
## Summary
유나 doc `org-1st-class-surface-ia-design-b` §2a/§2e — workspace(organization)/project slug의 생성·유일성·예약어·rename 이력·resolution API. **URL 자체는 이 슬라이스에서 미변경**(인프라만 — 실 라우트 전환은 S-route-project/S-route-workspace 후속 슬라이스).

## 구현
- `app/services/entity_slug.py`: `doc_slug.slugify()` 재사용(발명 0) + workspace(전역 유일·예약어 denylist: `api login logout onboarding settings organization o admin help static _next 404`)/project(org-scoped 유일) 두 스코프의 충돌 해소(`-n` suffix).
- `projects.slug` additive + 백필(이름→kebab, org별 결정적 `-n` suffix 충돌 해소 — 생성순 실측 검증 완료).
- `entity_slug_history` 테이블 — rename 이력(향후 301 redirect용, S-route-* 소비 예정).
- `POST /organizations`, `POST/PATCH /projects` — slug 형식/예약어/유일성 검증(**명시 지정 충돌=409**·**자동 파생 충돌=조용히 `-n` suffix**, 두 케이스 일관 원칙).
- `PATCH /organizations`, `PATCH /projects` — slug rename + 이력 기록(무변경 재전송은 이력 skip).
- `GET /organizations/resolve`, `GET /projects/resolve` — FE middleware(S-route-*)가 소비할 slug→entity 해소 API.

## ⭐발견 즉시 수정 (fix-on-sight)
`organizations.slug`가 SQLAlchemy 모델에 `unique=True`로 선언돼 있었지만, baseline schema.sql부터 실제 DB엔 UNIQUE 제약이 **한 번도 반영된 적이 없었다**(PRIMARY KEY(id)만 존재 — 실측 확인). 지금까지는 `OrganizationRepository.create()`의 app-level 사전체크만으로 유일성을 지켜왔는데, 이 슬라이스가 추가하는 전역 유일 전제의 resolution API가 이 갭 위에 서면 안 되므로 `0185`에서 봉합. **방어적 적용**: 기존 중복 slug가 있으면(이론상 가능) 나중 생성분부터 `-n` suffix로 자가치유 후 제약 적용 — dirty data로 마이그 자체가 실패하지 않게(duplicate 시드로 직접 검증 완료).

## ⚠️설계 판단: Project.slug는 NOT NULL이 아닌 nullable
최초엔 NOT NULL로 구현했으나, 이 리포 전역에 raw `Project(...)` 생성자를 직접 쓰는 실DB 테스트 시더가 수백 곳(slug 인지 0)이라 **666건이 즉시 깨졌다**(실측). API로 생성된 project는 항상 실값을 채워 넣어 실질적으로 non-null이고, `UNIQUE(org_id, slug)`는 여러 NULL을 서로 다른 값으로 취급해 무해 — 블라스트 반경을 대폭 줄이는 쪽으로 설계 선회.

## Test plan
- [x] `test_139d2405_slug_infra_realdb.py`(신규 17건) — 형식 검증·예약어 denylist·workspace/project 유일성 스코프(전역 vs org-scoped)·rename 이력 기록/무변경 skip·명시충돌 409/자동파생 suffix·resolve API(멤버십/접근권 스코프).
- [x] **뮤테이션 셀프체크**: denylist 검증 + 충돌 검증을 각각 비활성화 → 관련 테스트 RED 확인 후 원복.
- [x] **마이그레이션 직접 검증**: throwaway DB에 org 내 동명 프로젝트 3건+타 org 동명 1건+한글명 1건 시드 → 백필 결과(`roadmap`/`roadmap-2`/`roadmap-3`, 타 org는 독립적으로 `roadmap`, 한글 정상 슬러그화) 직접 확인. organizations dedupe도 중복 3건 시드 후 자가치유 확인. downgrade/upgrade 왕복 확인.
- [x] 전체 스위트 무회귀(**3975 passed**, `-m "not destructive_schema"`) — 최초 NOT NULL 시도 시 666건 회귀를 발견해 nullable로 설계 변경 후 재검증. destructive_schema(create_all 기반) 대표 샘플 40건도 별도 확인. 사전 존재하던 무관 실패 7건 제외(mcp e2e_dev 89개 카운트 스테일·로컬 `.mcp.json` 환경 의존, 이 PR 이전부터 origin/develop에 존재).
- [x] `test_resolve_member_agent_project_idor_realdb.py`가 다른 파일과 우연히 동일한 org slug(`c1dorg`)를 썼던 **cross-file 충돌도 이번에 발견해 수정**(신설 UNIQUE 제약이 정확히 잡아낸 케이스).
- [ ] 까심 QA(유일성·예약어·충돌 케이스) + CI green 대기.

## 완료선 참고
FE(미르코 lane) = path resolution middleware 골격 + default ws/proj 해소, 병렬 진행 예정(이 PR과 독립). 실 라우트 전환(`/{ws}/{proj}/...`)은 S-route-project/S-route-workspace 후속 슬라이스.

🤖 Generated with [Claude Code](https://claude.com/claude-code)