### PR TITLE
[SID:933248fa] 웹훅 설정 GET도 admin override — write_ok≠read_success 반쪽 fix 완결

### DIFF
--- a/apps/web/src/app/(authenticated)/agents/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/agents/[id]/page.tsx
@@ -162,7 +162,12 @@ export default function AgentDetailPage() {
   }, []);
 
   const fetchWebhookConfigs = useCallback(async (projectId: string) => {
-    const res = await fetch(`/api/webhooks/config?project_id=${encodeURIComponent(projectId)}`);
+    // story 933248fa 재오픈: GET은 기본 caller-scope라 project_id만으로는 "내(caller) 웹훅"만
+    // 돌아온다 — admin이 타 멤버(id) 상세를 보는 중이면 ?member_id=로 그 타깃을 명시 조회해야
+    // BE의 admin override(list_webhook_configs)가 실제로 작동한다(write_ok≠read_success).
+    const res = await fetch(
+      `/api/webhooks/config?project_id=${encodeURIComponent(projectId)}&member_id=${encodeURIComponent(id)}`,
+    );
     if (!res.ok) return;
     const json = await res.json() as { data: WebhookConfig[] };
     const agentConfigs = (json.data ?? []).filter((c) => c.member_id === id);

--- a/backend/app/routers/webhooks.py
+++ b/backend/app/routers/webhooks.py
@@ -94,11 +94,33 @@ async def _resolve_target_member_id(
 @router.get("/config", response_model=list[WebhookConfigResponse])
 async def list_webhook_configs(
     project_id: uuid.UUID | None = Query(default=None),
+    member_id: uuid.UUID | None = Query(default=None),
     repo: WebhookConfigRepository = Depends(_get_repo),
     caller_member_id: uuid.UUID = Depends(_get_caller_member_id),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    session: AsyncSession = Depends(get_db),
 ) -> list[WebhookConfigResponse]:
-    # IDOR(산티아고): caller member-scope — org_id 만이면 same-org 타 멤버 config(URL) 가 leak.
-    items = await repo.list(member_id=caller_member_id, project_id=project_id)
+    """story 933248fa 재오픈 fix — PUT은 admin override가 있었지만 GET은 caller-scope 그대로라
+    admin이 방금 저장한 타 멤버 webhook이 목록에 안 보였다(write_ok≠read_success).
+
+    IDOR(산티아고) 원 방어는 **바이트 단위로 그대로 유지**: `?member_id=` 미지정 시 caller
+    member-scope(org_id 만으로 same-org 타 멤버 config 전체가 leak되는 것 차단), 비-admin은
+    `?member_id=`를 보내도 무조건 caller-scope로 강제(자기 자신 조회로 취급) — PUT과 동일
+    SEC 규율②(admin/owner role 필수, JWT app_metadata.role — 서버 검증된 클레임).
+    """
+    scope_member_id = caller_member_id
+    if member_id is not None:
+        target_member_id = await _resolve_target_member_id(member_id, org_id, session)
+        if target_member_id != caller_member_id:
+            role = auth.claims.get("app_metadata", {}).get("role", "member")
+            if role not in ("admin", "owner"):
+                raise HTTPException(
+                    status_code=403,
+                    detail="Admin role required to view another member's webhook config",
+                )
+        scope_member_id = target_member_id
+    items = await repo.list(member_id=scope_member_id, project_id=project_id)
     return [WebhookConfigResponse.model_validate(i) for i in items]
 
 

--- a/backend/tests/test_notif_trust_testsend.py
+++ b/backend/tests/test_notif_trust_testsend.py
@@ -136,15 +136,71 @@ async def test_test_send_uses_owned_scope_with_caller_member():
     assert repo.get_owned.await_args.args[1] == caller  # caller member 로 소유 검증
 
 
+def _dummy_auth(role: str = "member") -> SimpleNamespace:
+    return SimpleNamespace(user_id=str(uuid.uuid4()), email=None, claims={"app_metadata": {"role": role}})
+
+
 @pytest.mark.anyio
 async def test_list_is_member_scoped():
-    """list 는 caller member-scope — org-wide leak 차단."""
+    """list 는 caller member-scope(member_id 쿼리 미지정) — org-wide leak 차단. 무회귀."""
     from app.routers.webhooks import list_webhook_configs
     repo = AsyncMock()
     repo.list = AsyncMock(return_value=[])
     caller = uuid.uuid4()
-    await list_webhook_configs(project_id=None, repo=repo, caller_member_id=caller)
+    await list_webhook_configs(
+        project_id=None, member_id=None, repo=repo, caller_member_id=caller,
+        auth=_dummy_auth(), org_id=uuid.uuid4(), session=AsyncMock(),
+    )
     assert repo.list.await_args.kwargs["member_id"] == caller
+
+
+@pytest.mark.anyio
+async def test_list_member_id_self_is_noop():
+    """story 933248fa 재오픈: ?member_id=자기자신 이면 role 무관 무회귀(자기서비스)."""
+    from app.routers.webhooks import list_webhook_configs
+    repo = AsyncMock()
+    repo.list = AsyncMock(return_value=[])
+    caller = uuid.uuid4()
+    with patch("app.routers.webhooks._resolve_target_member_id", new=AsyncMock(return_value=caller)):
+        await list_webhook_configs(
+            project_id=None, member_id=caller, repo=repo, caller_member_id=caller,
+            auth=_dummy_auth("member"), org_id=uuid.uuid4(), session=AsyncMock(),
+        )
+    assert repo.list.await_args.kwargs["member_id"] == caller
+
+
+@pytest.mark.anyio
+async def test_list_non_admin_cross_member_403_no_silent_scope_widen():
+    """story 933248fa 재오픈 — GET에도 PUT과 동형 방어: 비-admin이 ?member_id=타멤버 요청하면
+    caller-scope로 침묵 대체하지 않고 명시 403(+repo.list 자체 미호출까지 확認)."""
+    from fastapi import HTTPException
+    from app.routers.webhooks import list_webhook_configs
+    repo = AsyncMock()
+    caller, other = uuid.uuid4(), uuid.uuid4()
+    with patch("app.routers.webhooks._resolve_target_member_id", new=AsyncMock(return_value=other)):
+        with pytest.raises(HTTPException) as exc:
+            await list_webhook_configs(
+                project_id=None, member_id=other, repo=repo, caller_member_id=caller,
+                auth=_dummy_auth("member"), org_id=uuid.uuid4(), session=AsyncMock(),
+            )
+    assert exc.value.status_code == 403
+    repo.list.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_list_admin_can_view_another_members_config():
+    """story 933248fa 재오픈 fix — admin이 ?member_id=타멤버로 조회하면 그 타깃 스코프로 반환
+    (PUT admin override의 GET 대칭 — write_ok≠read_success 재발 방지)."""
+    from app.routers.webhooks import list_webhook_configs
+    repo = AsyncMock()
+    repo.list = AsyncMock(return_value=[])
+    caller, other = uuid.uuid4(), uuid.uuid4()
+    with patch("app.routers.webhooks._resolve_target_member_id", new=AsyncMock(return_value=other)):
+        await list_webhook_configs(
+            project_id=None, member_id=other, repo=repo, caller_member_id=caller,
+            auth=_dummy_auth("admin"), org_id=uuid.uuid4(), session=AsyncMock(),
+        )
+    assert repo.list.await_args.kwargs["member_id"] == other
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_webhook_config_target_member_realdb.py
+++ b/backend/tests/test_webhook_config_target_member_realdb.py
@@ -1,4 +1,4 @@
-"""story 933248fa — webhook config PUT의 admin-scoped target override + IDOR sabotage 방어 realdb.
+"""story 933248fa(+재오픈) — webhook config PUT/GET의 admin-scoped target override + IDOR sabotage 방어 realdb.
 
 근본: 산티아고의 원 IDOR 방어(caller-only, body.member_id 완전 무시)가 admin의 정당한 타 멤버
 설정 요구까지 침묵으로 caller 자신에 덮어썼다("200인데 미반영" + 실제 부작용=caller 자기 config
@@ -241,5 +241,88 @@ async def test_cross_org_target_404_not_body_claimed():
         async with Session() as s:
             assert await _webhook_row(s, OTHER_ORG, OTHER_ORG_AGENT) is None
             assert await _webhook_row(s, ORG, ADMIN_OM) is None  # admin 자신에게도 침묵 저장 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_admin_get_sees_target_member_config_after_admin_put():
+    """933248fa 재오픈 근본 — write_ok≠read_success: PUT의 admin override는 있었지만 GET이
+    caller-scope 그대로라 admin이 방금 저장한 타 멤버 config가 목록에 안 보였다(선생님 라이브
+    재현). admin이 PUT 후 같은 admin이 GET ?member_id=target 하면 실제로 보여야 한다."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.repositories.webhook_config import WebhookConfigRepository
+    from app.routers.webhooks import _get_caller_member_id, list_webhook_configs, upsert_webhook_config
+    from app.schemas.webhook_config import UpsertWebhookConfig
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            auth = _admin_auth()
+            caller_member_id = await _get_caller_member_id(auth=auth, org_id=ORG, session=s)
+            body = UpsertWebhookConfig(member_id=AGENT_TARGET, url="https://example.com/read-after-write")
+            await upsert_webhook_config(
+                body=body, repo=WebhookConfigRepository(s, ORG),
+                caller_member_id=caller_member_id, auth=auth, org_id=ORG, session=s,
+            )
+            await s.commit()
+
+        async with Session() as s:
+            auth = _admin_auth()
+            caller_member_id = await _get_caller_member_id(auth=auth, org_id=ORG, session=s)
+            items = await list_webhook_configs(
+                project_id=None, member_id=AGENT_TARGET,
+                repo=WebhookConfigRepository(s, ORG),
+                caller_member_id=caller_member_id, auth=auth, org_id=ORG, session=s,
+            )
+            assert len(items) == 1
+            assert items[0].member_id == AGENT_TARGET
+            assert items[0].url == "https://example.com/read-after-write"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_non_admin_get_cross_member_403_and_own_scope_unaffected():
+    """비-admin이 ?member_id=타멤버로 GET하면 caller-scope로 침묵 대체하지 않고 403 —
+    ?member_id= 자체를 아예 안 보낸 자기 조회는 기존 그대로 캐치(무회귀)."""
+    from fastapi import HTTPException
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.repositories.webhook_config import WebhookConfigRepository
+    from app.routers.webhooks import _get_caller_member_id, list_webhook_configs
+
+    engine = create_async_engine(_ASYNC)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            auth = _member_auth()
+            caller_member_id = await _get_caller_member_id(auth=auth, org_id=ORG, session=s)
+            assert caller_member_id == MEMBER_OM
+            with pytest.raises(HTTPException) as exc:
+                await list_webhook_configs(
+                    project_id=None, member_id=AGENT_TARGET,
+                    repo=WebhookConfigRepository(s, ORG),
+                    caller_member_id=caller_member_id, auth=auth, org_id=ORG, session=s,
+                )
+            assert exc.value.status_code == 403
+
+        async with Session() as s:
+            auth = _member_auth()
+            caller_member_id = await _get_caller_member_id(auth=auth, org_id=ORG, session=s)
+            items = await list_webhook_configs(
+                project_id=None, member_id=None,
+                repo=WebhookConfigRepository(s, ORG),
+                caller_member_id=caller_member_id, auth=auth, org_id=ORG, session=s,
+            )
+            assert items == []  # 자기 config 0건인 것 확인(존재 자체를 안 만든 케이스), 예외 없이 통과
     finally:
         await engine.dispose()


### PR DESCRIPTION
## Summary
- story 933248fa 재오픈(선생님 라이브 재현): PUT은 #2167로 정확히 동작했지만 GET `/api/v2/webhooks/config`가 caller-scope 고정이라, admin이 방금 저장한 타 멤버(민) webhook config가 목록에 안 보였다.
- `list_webhook_configs`에 `?member_id=` 쿼리 + admin/owner override 추가 (PUT과 동일 SEC 규율: 미지정=기존 caller-scope 무회귀, 타 멤버 지정은 admin/owner 필수 아니면 403).
- FE `agents/[id]/page.tsx`의 `fetchWebhookConfigs`가 `?member_id=`를 실제로 전달하도록 수정 (BE 지원이 있어도 FE가 요청 안 하면 무용지물이었음).
- realdb round-trip 테스트 추가: admin PUT → 같은 admin GET이 실제로 그 행을 보는지(저장→조회→반영 왕복 전체) + 비-admin 403.

## 그라운딩: "events: [] 문제"는 실제 버그 아님
PO가 함께 요청한 두 번째 항목("events 빈 배열이면 발송이 영원히 0")은 코드 전수 조사 결과 사실이 아니었다:
- `conversation_webhook.py:104,154`, `webhook_dispatch.py:70`, `deployment_lifecycle.py:70` — 발송 필터 4곳 전부 `not events or event_type in events` 동일 패턴.
- `events: []`(falsy)는 조건을 항상 False로 만들어 **필터링 자체를 건너뛴다 = 와일드카드(전체 이벤트 수신)**이지, 침묵 미발송이 아니다.
- 제안된 "기본 이벤트 프리셀렉트" fix를 그대로 넣으면 신규 config의 기본 수신범위를 현재(전체)보다 좁히는 **역행 회귀**가 된다. 별도 chat으로 이 그라운딩을 보고하고 승인을 기다리는 중.

## Test plan
- [x] backend: `test_notif_trust_testsend.py` + `test_s34.py` + `test_webhook_config_target_member_realdb.py` + `test_webhook_config_upsert_realdb.py` — 35/35 실제 마이그레이션된 DB에서 PASS (collect 아닌 실행 확인)
- [x] backend: ruff clean
- [x] frontend: tsc --noEmit clean
- [x] frontend: eslint clean
- [x] frontend: vitest (apps/web + root 양쪽 스코프) — 1654 tests passed, 0 failed
- [x] frontend: next build EXIT=0
- [ ] 배포 후 라이브 픽셀: admin이 타 멤버 webhook PUT→GET 왕복 반영 확인 (write_ok≠read_success 재발 방지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)