### PR TITLE
hotfix(alembic): 0184 dual-head 충돌 해소 — slug infra 마이그 0185/0186 renumber

### DIFF
--- a/backend/alembic/versions/0185_workspace_project_slug_infra.py
+++ b/backend/alembic/versions/0185_workspace_project_slug_infra.py
@@ -1,12 +1,16 @@
 """story 139d2405(S-slug-infra): projects.slug additive+백필(이름 kebab 파생·org-scoped 유일) +
 entity_slug_history 테이블(rename 이력·향후 301용).
 
-Revision ID: 0184
-Revises: 0183
+Revision ID: 0185
+Revises: 0184
 Create Date: 2026-07-15
 
+⚠️renumber(2026-07-15): 병렬 BE PR(#2168 push_devices)이 동시에 "0184"를 채번해 develop에
+dual-head가 발생 — 먼저 머지된 #2168의 0184(push_devices)를 선점으로 두고 이 마이그를
+0184→0185로 renumber(원 revision/down_revision은 각각 0184/0183였음). 내용 변경 없음.
+
 organizations.slug는 이미 존재하는 컬럼(모델 unique=True 선언)·이 마이그와 무관 — 단, 실측
-결과 DB 레벨 UNIQUE 제약이 baseline부터 누락돼있던 별개 갭을 발견해 0185에서 봉합한다(발견
+결과 DB 레벨 UNIQUE 제약이 baseline부터 누락돼있던 별개 갭을 발견해 0186에서 봉합한다(발견
 즉시 수정). 순수 additive — 기존 스키마 무회귀. 백필: name→slugify(app.services.doc_slug와
 동일 유니코드 NFC 계약)·org 내 충돌은 `-2`,`-3`… suffix(생성 순서=created_at ASC로 결정적)로
 해소.
@@ -17,8 +21,8 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
-revision = "0184"
-down_revision = "0183"
+revision = "0185"
+down_revision = "0184"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/0186_organizations_slug_unique_constraint.py
+++ b/backend/alembic/versions/0186_organizations_slug_unique_constraint.py
@@ -1,8 +1,12 @@
 """story 139d2405(S-slug-infra) 후속 발견: organizations.slug UNIQUE 제약 누락 봉합.
 
-Revision ID: 0185
-Revises: 0184
+Revision ID: 0186
+Revises: 0185
 Create Date: 2026-07-15
+
+⚠️renumber(2026-07-15): 병렬 BE PR(#2168 push_devices)이 동시에 "0184"를 채번해 develop에
+dual-head가 발생 — 이 마이그는 0185→0186으로 renumber(원 revision/down_revision은 각각
+0185/0184였음). 내용 변경 없음.
 
 SQLAlchemy 모델(app/models/organization.py)은 `slug: Mapped[str] = mapped_column(..., unique=True)`
 로 선언돼 있었지만, baseline schema.sql부터 실제 DB엔 이 제약이 한 번도 반영된 적이 없었다
@@ -20,8 +24,8 @@ from __future__ import annotations
 from alembic import op
 import sqlalchemy as sa
 
-revision = "0185"
-down_revision = "0184"
+revision = "0186"
+down_revision = "0185"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## 🚨 긴급 — develop Alembic dual-head 핫픽스

#2168(push_devices, `revision="0184"`)과 #2171(slug infra, `revision="0184"`)이 병렬로 동시에 "0184"를 채번 — 먼저 머지된 #2168이 선점하면서 develop이 dual-head 상태. dev migrate 빌드(`d8d353b9`) `run-migrate-job` 단계에서 실제로 FAILURE 확인.

## 실측 (안전성 확인)
- dev DB는 #2168의 `0184`까지만 성공적으로 적용된 상태(해당 빌드 `e60825e0` = SUCCESS).
- 내 슬라이스(#2171, 옛 0184/0185)를 실은 빌드는 migrate 단계에서 **실패**했으므로 dev DB엔 전혀 반영 안 됨(fail-closed로 deploy-backend도 안 돎).
- 따라서 **stamp/데이터 보정 불요** — 순수 파일 renumber만으로 충분.

## 변경
- `0184_workspace_project_slug_infra.py` → `0185_workspace_project_slug_infra.py`(revision/down_revision 갱신, 내용 변경 없음)
- `0185_organizations_slug_unique_constraint.py` → `0186_organizations_slug_unique_constraint.py`(revision/down_revision 갱신, 내용 변경 없음)
- 체인: `0183 → 0184(push_devices) → 0185(slug infra) → 0186(org unique)`, `alembic heads` = 단일(0186) 확인.

## Test plan
- [x] `alembic heads` 단일 확인.
- [x] 신선한 DB에서 `0183 → head` 전 구간 upgrade 성공(0184 push_devices → 0185 slug → 0186 org unique).
- [x] `downgrade 0183` → `upgrade head` 왕복 정상.
- [x] `test_139d2405_slug_infra_realdb.py` 17건 + `test_push_devices_realdb.py`/`test_push_devices_ee.py` 40건 + `mcp/test_contract.py` 무회귀.
- [ ] CI green → PO 즉시 머지(오르테가군 확인 완료, fast-track).

🤖 Generated with [Claude Code](https://claude.com/claude-code)