### PR TITLE
feat(hypotheses): story fca4723d(C1) — list_hypotheses project_id 옵셔널화

### DIFF
--- a/backend/app/repositories/hypothesis.py
+++ b/backend/app/repositories/hypothesis.py
@@ -29,7 +29,7 @@ class HypothesisRepository(BaseRepository[Hypothesis]):
     async def list_filtered(
         self,
         *,
-        project_id: uuid.UUID,
+        project_id: uuid.UUID | None,
         status: str | None = None,
         owner_member_id: uuid.UUID | None = None,
         epic_id: uuid.UUID | None = None,
@@ -37,10 +37,11 @@ class HypothesisRepository(BaseRepository[Hypothesis]):
         sprint_id: uuid.UUID | None = None,
         limit: int = 100,
     ) -> list[Hypothesis]:
-        q = select(Hypothesis).where(
-            Hypothesis.org_id == self.org_id,
-            Hypothesis.project_id == project_id,
-        )
+        # story fca4723d(C1): project_id 생략 시 org 전체(모든 project) 조회 — 접근권 후필터는
+        # 호출자(router)의 책임(retro list_sessions와 동형 분업).
+        q = select(Hypothesis).where(Hypothesis.org_id == self.org_id)
+        if project_id is not None:
+            q = q.where(Hypothesis.project_id == project_id)
         if status is not None:
             q = q.where(Hypothesis.status == status)
         if owner_member_id is not None:

--- a/backend/app/routers/hypotheses.py
+++ b/backend/app/routers/hypotheses.py
@@ -108,7 +108,8 @@ async def draft(
 @router.get("", response_model=list[HypothesisResponse])
 async def list_hypotheses(
     response: Response,
-    project_id: uuid.UUID = Query(...),
+    auth: AuthContext = Depends(get_current_user),
+    project_id: uuid.UUID | None = Query(default=None),
     epic_id: uuid.UUID | None = Query(default=None),
     story_id: uuid.UUID | None = Query(default=None),
     sprint_id: uuid.UUID | None = Query(default=None),
@@ -118,11 +119,21 @@ async def list_hypotheses(
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_project_scoped_org_id),
 ) -> list[HypothesisResponse]:
+    """story fca4723d(C1): project_id 생략 시 org 전체 가설 조회 — retro list_sessions와
+    동형 패턴(app/routers/retros.py). org-wide 조회는 각 항목의 실제 project 접근권으로
+    후필터(비접근 project의 가설 비노출 — 존재 자체를 숨기는 404류 원칙과 정합)."""
     items = await svc.list_hypotheses(
         session, org_id, project_id,
         status=status_filter, owner_member_id=owner_member_id,
         epic_id=epic_id, story_id=story_id, sprint_id=sprint_id, limit=limit,
     )
+    if project_id is None:
+        user_id = uuid.UUID(auth.user_id)
+        accessible = [
+            item for item in items
+            if await has_project_access(session, user_id, item.project_id, org_id)
+        ]
+        items = accessible
     response.headers["X-Total-Count"] = str(len(items))
     return items
 

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -208,7 +208,7 @@ async def get_hypothesis(
 async def list_hypotheses(
     session: AsyncSession,
     org_id: uuid.UUID,
-    project_id: uuid.UUID,
+    project_id: uuid.UUID | None,
     *,
     status: str | None = None,
     owner_member_id: uuid.UUID | None = None,

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -370,7 +370,8 @@ _TOOL_DEFS: list[tuple] = [
      UpdateEpicInput, update_epic),
     # Hypotheses (6)
     ("sprintable_list_hypotheses",
-     "[일감] 가설 목록 조회 (compact). epic_id/story_id/status/owner_member_id 필터.",
+     "[일감] 가설 목록 조회 (compact). epic_id/story_id/status/owner_member_id 필터."
+     " all_projects=true면 project_id 대신 org 전체(접근 가능한 모든 project)에서 조회.",
      ListHypothesesInput, list_hypotheses),
     ("sprintable_get_hypothesis",
      "[일감] 가설 단건 조회 (full).",

--- a/backend/sprintable_mcp/tools/hypotheses.py
+++ b/backend/sprintable_mcp/tools/hypotheses.py
@@ -23,6 +23,10 @@ class ListHypothesesInput(SprintableInput):
     status: HypothesisStatus | None = None
     owner_member_id: str | None = None
     limit: int | None = None
+    # story fca4723d(C1): True면 project_id를 안 실어 org 전체(모든 접근 가능 project) 조회
+    # (REST가 project_id 생략 시 org-wide+접근권 후필터를 지원 — app/routers/hypotheses.py).
+    # 기본 False = 기존 동작(client 기본/현재 project로 스코프) 무회귀.
+    all_projects: bool = False
 
 
 class GetHypothesisInput(SprintableInput):
@@ -66,6 +70,8 @@ def _compact(h: dict) -> dict:
     md = h.get("metric_definition") or {}
     return {
         "id": h.get("id"),
+        # story fca4723d(C1): all_projects=true(org-wide) 조회 시 어느 project 소속인지 식별 필요.
+        "project_id": h.get("project_id"),
         "status": h.get("status"),
         "statement": h.get("statement"),
         "metric": md.get("metric"),
@@ -78,9 +84,10 @@ def _compact(h: dict) -> dict:
 
 
 async def list_hypotheses(args: ListHypothesesInput) -> list[TextContent]:
-    """가설 목록(compact). epic_id/story_id/status/owner_member_id/limit 필터."""
+    """가설 목록(compact). epic_id/story_id/status/owner_member_id/limit 필터.
+    all_projects=true면 org 전체(접근 가능한 모든 project) 조회."""
     try:
-        params: dict = {"project_id": client.require_project_id()}
+        params: dict = {} if args.all_projects else {"project_id": client.require_project_id()}
         if args.epic_id:
             params["epic_id"] = args.epic_id
         if args.story_id:

--- a/backend/sprintable_mcp/tools/retro.py
+++ b/backend/sprintable_mcp/tools/retro.py
@@ -54,7 +54,7 @@ class ExportRetroInput(SprintableInput):
 async def list_retro_sessions(args: ListRetroSessionsInput) -> list[TextContent]:
     """레트로 세션 목록 조회."""
     try:
-        return ok(await client.get("/api/v2/retro-sessions", params={"project_id": client.require_project_id()}))
+        return ok(await client.get("/api/v2/retros", params={"project_id": client.require_project_id()}))
     except Exception as exc:
         return err(str(exc))
 
@@ -70,7 +70,7 @@ async def create_retro_session(args: CreateRetroSessionInput) -> list[TextConten
         }
         if args.sprint_id:
             body["sprint_id"] = args.sprint_id
-        return ok(await client.post("/api/v2/retro-sessions", json=body))
+        return ok(await client.post("/api/v2/retros", json=body))
     except Exception as exc:
         return err(str(exc))
 
@@ -80,7 +80,7 @@ async def vote_retro_item(args: VoteRetroItemInput) -> list[TextContent]:
     try:
         return ok(await client.request(
             "POST",
-            f"/api/v2/retro-sessions/{args.session_id}/items/{args.item_id}/vote",
+            f"/api/v2/retros/{args.session_id}/items/{args.item_id}/vote",
             json={"voter_id": args.voter_id},
             params={"project_id": client.require_project_id()},
         ))
@@ -96,7 +96,7 @@ async def add_retro_action(args: AddRetroActionInput) -> list[TextContent]:
     try:
         return ok(await client.request(
             "POST",
-            f"/api/v2/retro-sessions/{args.session_id}/actions",
+            f"/api/v2/retros/{args.session_id}/actions",
             json=body,
             params={"project_id": client.require_project_id()},
         ))
@@ -109,7 +109,7 @@ async def change_retro_phase(args: ChangeRetroPhaseInput) -> list[TextContent]:
     try:
         return ok(await client.request(
             "PATCH",
-            f"/api/v2/retro-sessions/{args.session_id}",
+            f"/api/v2/retros/{args.session_id}/phase",
             json={"phase": args.phase},
             params={"project_id": client.require_project_id()},
         ))
@@ -122,7 +122,7 @@ async def add_retro_item(args: AddRetroItemInput) -> list[TextContent]:
     try:
         return ok(await client.request(
             "POST",
-            f"/api/v2/retro-sessions/{args.session_id}/items",
+            f"/api/v2/retros/{args.session_id}/items",
             json={"category": args.category, "text": args.text, "author_id": args.author_id},
             params={"project_id": client.require_project_id()},
         ))
@@ -133,6 +133,6 @@ async def add_retro_item(args: AddRetroItemInput) -> list[TextContent]:
 async def export_retro(args: ExportRetroInput) -> list[TextContent]:
     """레트로 마크다운 내보내기."""
     try:
-        return ok(await client.get(f"/api/v2/retro-sessions/{args.session_id}/export", params={"project_id": client.require_project_id()}))
+        return ok(await client.get(f"/api/v2/retros/{args.session_id}/export", params={"project_id": client.require_project_id()}))
     except Exception as exc:
         return err(str(exc))

--- a/backend/tests/test_fca4723d_hypotheses_org_wide.py
+++ b/backend/tests/test_fca4723d_hypotheses_org_wide.py
@@ -1,0 +1,124 @@
+"""story fca4723d(C1): list_hypotheses project_id 옵셔널화 — retro list_sessions와 동형
+패턴(app/routers/retros.py) 복제. project_id 생략 시 org 전체 조회 후 호출자의 실제
+project 접근권으로 후필터(비접근 project의 가설 비노출 — 존재 자체를 숨기는 원칙과 정합).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.schemas.hypothesis import HypothesisResponse
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+OTHER_PROJECT_ID = uuid.uuid4()
+
+
+def _hyp(project_id: uuid.UUID, statement: str = "test") -> HypothesisResponse:
+    now = datetime(2026, 7, 15, tzinfo=timezone.utc)
+    return HypothesisResponse(
+        id=uuid.uuid4(), org_id=ORG_ID, project_id=project_id, owner_member_id=uuid.uuid4(),
+        statement=statement, metric_definition={"metric": "x", "source": "manual", "target": 1, "direction": "up"},
+        measure_after=now, status="proposed", human_accounting={}, gate_contract={},
+        created_at=now, updated_at=now,
+    )
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.mark.anyio
+async def test_list_hypotheses_project_id_still_supported():
+    """회귀 0: project_id 지정 시 기존 동작 그대로(access 체크 없이 svc 결과 그대로 반환)."""
+    from app.dependencies.auth import get_project_scoped_org_id
+
+    client, _session, app = await _client()
+    try:
+        # get_project_scoped_org_id 자체 로직(project→org 조회)은 이 테스트 대상이 아님 —
+        # 라우터가 project_id 지정 시 기존 동작을 그대로 보존하는지만 확인.
+        app.dependency_overrides[get_project_scoped_org_id] = lambda: ORG_ID
+        with patch(
+            "app.routers.hypotheses.svc.list_hypotheses",
+            new=AsyncMock(return_value=[_hyp(PROJECT_ID)]),
+        ):
+            async with client as c:
+                resp = await c.get(f"/api/v2/hypotheses?project_id={PROJECT_ID}")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_hypotheses_no_project_id_filters_by_access():
+    """핵심 회귀(C1): project_id 생략 → org 전체 svc 조회 후 has_project_access 통과분만."""
+    client, _session, app = await _client()
+    try:
+        accessible = _hyp(PROJECT_ID, statement="accessible")
+        inaccessible = _hyp(OTHER_PROJECT_ID, statement="inaccessible")
+
+        async def fake_access(_db, _user_id, project_id, _org_id):
+            return project_id == PROJECT_ID
+
+        with patch(
+            "app.routers.hypotheses.svc.list_hypotheses",
+            new=AsyncMock(return_value=[accessible, inaccessible]),
+        ), patch("app.routers.hypotheses.has_project_access", new=AsyncMock(side_effect=fake_access)):
+            async with client as c:
+                resp = await c.get("/api/v2/hypotheses")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body) == 1
+        assert body[0]["project_id"] == str(PROJECT_ID)
+        assert body[0]["statement"] == "accessible"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_hypotheses_no_project_id_all_inaccessible_returns_empty():
+    """비접근 project만 있으면 빈 리스트(존재 비노출 — 404가 아니라 200+빈배열, retro와 동형)."""
+    client, _session, app = await _client()
+    try:
+        with patch(
+            "app.routers.hypotheses.svc.list_hypotheses",
+            new=AsyncMock(return_value=[_hyp(OTHER_PROJECT_ID)]),
+        ), patch("app.routers.hypotheses.has_project_access", new=AsyncMock(return_value=False)):
+            async with client as c:
+                resp = await c.get("/api/v2/hypotheses")
+        assert resp.status_code == 200
+        assert resp.json() == []
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_fca4723d_hypotheses_org_wide_realdb.py
+++ b/backend/tests/test_fca4723d_hypotheses_org_wide_realdb.py
@@ -1,0 +1,168 @@
+"""story fca4723d(C1) 게이트: 접근권 sabotage 실증 — project_id 생략(org-wide) 조회 시
+비접근 project의 가설이 실제로 노출되지 않는지 realdb로 확인(mock has_project_access가
+아니라 진짜 project_access/team_members 데이터 기반)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed(session):
+    """org + project_a(caller 접근권 有) + project_b(caller 접근권 無) + 각 프로젝트에 가설 1개씩."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.hypothesis import Hypothesis
+    from app.models.user import User
+    from datetime import datetime, timezone
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="A")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="B")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    user_id = uuid.uuid4()
+    session.add(User(id=user_id, email=f"caller-{user_id.hex[:8]}@test.com", hashed_password="x"))
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=user_id, role="member")
+    session.add(om)
+    await session.commit()
+    # caller는 project_a에만 grant — project_b는 접근권 없음(IDOR 축).
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=om.id, permission="granted",
+    ))
+    await session.commit()
+
+    now = datetime(2026, 7, 15, tzinfo=timezone.utc)
+    hyp_a = Hypothesis(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_a.id, owner_member_id=om.id,
+        statement="접근 가능 project의 가설", metric_definition={"metric": "x", "source": "manual", "target": 1, "direction": "up"},
+        measure_after=now, status="proposed",
+    )
+    hyp_b = Hypothesis(
+        id=uuid.uuid4(), org_id=org.id, project_id=project_b.id, owner_member_id=om.id,
+        statement="비접근 project의 가설 — 노출되면 안 됨", metric_definition={"metric": "y", "source": "manual", "target": 1, "direction": "up"},
+        measure_after=now, status="proposed",
+    )
+    session.add_all([hyp_a, hyp_b])
+    await session.commit()
+
+    return {
+        "org_id": org.id, "user_id": user_id,
+        "project_a_id": project_a.id, "project_b_id": project_b.id,
+        "hyp_a_id": hyp_a.id, "hyp_b_id": hyp_b.id,
+    }
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_org_wide_hypotheses_hides_inaccessible_project_realdb():
+    """까심 sabotage 케이스: project_id 생략 시 비접근 project(B)의 가설이 응답에 없어야 한다."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/hypotheses")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            ids = {h["id"] for h in body}
+            assert str(seeded["hyp_a_id"]) in ids, "접근 가능 project(A)의 가설은 보여야 함"
+            assert str(seeded["hyp_b_id"]) not in ids, "비접근 project(B)의 가설이 노출됨 — sabotage 실패"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_project_scoped_query_still_requires_access_realdb():
+    """회귀 0: project_id 명시 시(project_b) 기존 접근권 검증 그대로 — 403."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/hypotheses?project_id={seeded['project_b_id']}")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()

--- a/backend/tests/test_mcp_hypotheses.py
+++ b/backend/tests/test_mcp_hypotheses.py
@@ -30,6 +30,7 @@ def _client(**methods):
 def test_compact_excludes_long_fields_and_flattens_metric():
     full = {
         "id": "h1", "status": "active", "statement": "s",
+        "project_id": "p1",
         "metric_definition": {"metric": "signups", "target": 100, "direction": "up", "source": "manual"},
         "measure_after": "2026-07-01T00:00:00Z", "epic_ids": ["e1"], "story_ids": ["s1"],
         "outcome_result": {"big": "x"}, "source_snapshot": {"y": "z"}, "human_accounting": {},
@@ -37,6 +38,8 @@ def test_compact_excludes_long_fields_and_flattens_metric():
     c = h._compact(full)
     assert c == {
         "id": "h1", "status": "active", "statement": "s",
+        # story fca4723d(C1): all_projects 조회 시 소속 project 식별용으로 노출.
+        "project_id": "p1",
         "metric": "signups", "target": 100, "direction": "up",
         "measure_after": "2026-07-01T00:00:00Z", "epic_ids": ["e1"], "story_ids": ["s1"],
     }

--- a/backend/tests/test_mcp_retro_paths.py
+++ b/backend/tests/test_mcp_retro_paths.py
@@ -1,0 +1,76 @@
+"""fca4723d(C1) MCP 파라미터 동형 확인 중 발견: retro MCP 도구가 존재하지 않는
+`/api/v2/retro-sessions` 경로를 호출하던 버그(실 라우터 prefix는 `/api/v2/retros` —
+app/routers/retros.py:38) 회귀 방지. 기존에 이 모듈을 커버하는 테스트가 전무했음.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from sprintable_mcp.tools import retro as r
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _client(**methods):
+    c = MagicMock()
+    c.project_id = "proj-1"
+    c.org_id = "org-1"
+    c.member_id = "member-1"
+    c.require_project_id = MagicMock(return_value="proj-1")
+    for name, ret in methods.items():
+        setattr(c, name, AsyncMock(return_value=ret))
+    return c
+
+
+async def test_list_retro_sessions_calls_real_path():
+    client = _client(get=[])
+    with patch.object(r, "client", client):
+        await r.list_retro_sessions(r.ListRetroSessionsInput())
+    assert client.get.call_args.args[0] == "/api/v2/retros"
+
+
+async def test_create_retro_session_calls_real_path():
+    client = _client(post={"id": "s1"})
+    with patch.object(r, "client", client):
+        await r.create_retro_session(r.CreateRetroSessionInput(title="t"))
+    assert client.post.call_args.args[0] == "/api/v2/retros"
+
+
+async def test_vote_retro_item_calls_real_path():
+    client = _client(request={"id": "v1"})
+    with patch.object(r, "client", client):
+        await r.vote_retro_item(r.VoteRetroItemInput(session_id="s1", item_id="i1", voter_id="u1"))
+    assert client.request.call_args.args[1] == "/api/v2/retros/s1/items/i1/vote"
+
+
+async def test_add_retro_action_calls_real_path():
+    client = _client(request={"id": "a1"})
+    with patch.object(r, "client", client):
+        await r.add_retro_action(r.AddRetroActionInput(session_id="s1", title="t"))
+    assert client.request.call_args.args[1] == "/api/v2/retros/s1/actions"
+
+
+async def test_change_retro_phase_calls_real_path_with_phase_suffix():
+    client = _client(request={"id": "s1"})
+    with patch.object(r, "client", client):
+        await r.change_retro_phase(r.ChangeRetroPhaseInput(session_id="s1", phase="vote"))
+    assert client.request.call_args.args[1] == "/api/v2/retros/s1/phase"
+
+
+async def test_add_retro_item_calls_real_path():
+    client = _client(request={"id": "i1"})
+    with patch.object(r, "client", client):
+        await r.add_retro_item(r.AddRetroItemInput(session_id="s1", category="good", text="t", author_id="u1"))
+    assert client.request.call_args.args[1] == "/api/v2/retros/s1/items"
+
+
+async def test_export_retro_calls_real_path():
+    client = _client(get={"markdown": ""})
+    with patch.object(r, "client", client):
+        await r.export_retro(r.ExportRetroInput(session_id="s1"))
+    assert client.get.call_args.args[0] == "/api/v2/retros/s1/export"


### PR DESCRIPTION
## Summary
- Story `fca4723d`(C1, Organization 실체 보강 트랙): `GET /api/v2/hypotheses`에서 `project_id`를 옵셔널화 — retro `list_sessions`(app/routers/retros.py)와 동형 패턴 복제. 생략 시 org 전체 조회 후 각 항목의 실제 project 접근권(`has_project_access`)으로 후필터.
- 비접근 project의 가설은 존재 자체를 숨김(404 아닌 200+빈배열 — retro와 동일 시맨틱, 명시 `project_id`+무권한은 기존대로 403 유지).
- MCP 도구(`sprintable_mcp/tools/hypotheses.py`): `all_projects=true` 파라미터 추가, `_compact()`에 `project_id` 노출.
- 발견 즉시 수정(side-fix): `sprintable_mcp/tools/retro.py`가 존재하지 않는 `/api/v2/retro-sessions` 경로를 호출하던 버그(실 라우터는 `/api/v2/retros`) + `change_retro_phase`의 `/phase` suffix 누락. 이 모듈은 기존 테스트가 전무해 미검출 — `tests/test_mcp_retro_paths.py` 신규 추가로 커버리지 확보.
- `/organization/memory` 데이터 계약 확인: `GET /hypotheses` + `GET /retros`(둘 다 project_id 생략) 모두 동일 org-wide 패턴(post-filter·200+빈배열·명시 project_id 403)과 항목별 `project_id`/`org_id` 노출을 공유 — 향후 FE 조합에 추가 lookup 불요.

발명 0 · 마이그레이션 0(스토리 스펙대로).

## Test plan
- [x] 신규 mocked 테스트 3종(`test_fca4723d_hypotheses_org_wide.py`): project_id 지정 시 기존 동작 보존, 생략 시 접근권 필터, 전량 비접근 시 빈 배열
- [x] 까심 게이트: realdb 접근권 sabotage 2종(`test_fca4723d_hypotheses_org_wide_realdb.py`) — 비접근 project(B) 가설 org-wide 응답에서 미노출 실증(라이브 PG), 명시 project_id=B는 403 회귀 확인
- [x] 셀프 게이트 #12(왕복): project 생략 조회 → org 전체 반영 확인(realdb 테스트로 실증)
- [x] 뮤테이션 자가검증: 라우터 접근권 필터 조건을 임시로 무력화 → 예상 3개 테스트만 RED 확인 후 원복
- [x] retro.py 경로 수정: 신규 7종 경로-단언 테스트 추가, 수정 전/후 diff로 캐치 가능함 확인
- [x] 회귀: `test_hypotheses_router.py`, `test_mcp_hypotheses.py`(project_id 필드 추가로 인한 기존 exact-equality 테스트 수정 포함), `test_mcp_phase1.py`, `test_authz_project_scope_coverage.py`, `test_retros.py` 전체 green
- [x] 전체 스위트(`-m "not destructive_schema"`): 3258 passed / 7 failed(모두 develop 기준선에서도 동일 재현되는 환경 의존 사전 실패 — MCP 인스턴스/tool count DoD 체크, 본 PR과 무관 확인)
- [x] MCP 서버 106개 도구 정상 로드, `app.main` import 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)