### PR TITLE
feat(trust): story 91404248(C2a) — org_member_trust_snapshots 영속화

### DIFF
--- a/backend/alembic/versions/0187_org_member_trust_snapshots.py
+++ b/backend/alembic/versions/0187_org_member_trust_snapshots.py
@@ -1,0 +1,48 @@
+"""story 91404248(C2a): org_member_trust_snapshots 테이블 신설(org-c2-trust-persistence-design §1).
+
+Revision ID: 0187
+Revises: 0186
+Create Date: 2026-07-15
+
+member×role 신뢰 스냅샷 append-only 이력(entity_slug_history와 동형: update 없음).
+compute_member_trust_scores()의 role별 score dict를 metrics JSONB로 verbatim 저장 —
+산식 불변·저장만 추가(compute_and_snapshot() wrapper가 lazy write-through로 적재).
+순수 additive — 기존 스키마 무회귀.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0187"
+down_revision = "0186"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "org_member_trust_snapshots",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("member_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("role_key", sa.String(length=50), nullable=False),
+        sa.Column("window_days", sa.Integer(), nullable=False),
+        sa.Column("metrics", postgresql.JSONB(), nullable=False),
+        sa.Column("computed_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index("ix_org_member_trust_snapshots_org_id", "org_member_trust_snapshots", ["org_id"])
+    op.create_index("ix_org_member_trust_snapshots_member_id", "org_member_trust_snapshots", ["member_id"])
+    op.create_index(
+        "ix_org_member_trust_snapshots_computed_at", "org_member_trust_snapshots", ["computed_at"]
+    )
+    op.create_index(
+        "ix_trust_snapshot_member_role_time",
+        "org_member_trust_snapshots",
+        ["org_id", "member_id", "role_key", "computed_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("org_member_trust_snapshots")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -57,10 +57,12 @@ from app.models.activity_event import ActivityEvent
 from app.models.asset import Asset, AssetFolder, AssetLink
 from app.models.release_note import ReleaseNote
 from app.models.role_template import RoleTemplate
+from app.models.trust_snapshot import OrgMemberTrustSnapshot
 from app.models.visual_artifact import ArtifactNode, ArtifactVersion, VisualArtifact
 
 __all__ = [
     "RoleTemplate",
+    "OrgMemberTrustSnapshot",
     "ArtifactNode",
     "ArtifactVersion",
     "VisualArtifact",

--- a/backend/app/models/trust_snapshot.py
+++ b/backend/app/models/trust_snapshot.py
@@ -1,0 +1,32 @@
+"""story 91404248(C2a): member×role 신뢰 스냅샷 — org-c2-trust-persistence-design §1.
+
+append-only(entity_slug_history와 동형: update 없음·upsert 없음). metrics는
+compute_member_trust_scores()의 role별 score dict를 verbatim 저장(산식 불변·
+저장만 추가 — 산식이 바뀌어도 이 테이블은 컬럼 마이그 불요)."""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Index, Integer, String, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+from app.models.base import OrgScopedMixin
+
+
+class OrgMemberTrustSnapshot(Base, OrgScopedMixin):
+    __tablename__ = "org_member_trust_snapshots"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    # FK 없음 — Participation.member_id와 동일하게 canonicalize 패턴(team_members=VIEW, 직접 FK 불가).
+    member_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    role_key: Mapped[str] = mapped_column(String(50), nullable=False)
+    window_days: Mapped[int] = mapped_column(Integer, nullable=False, default=90)
+    metrics: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    computed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
+    )
+
+    __table_args__ = (
+        Index("ix_trust_snapshot_member_role_time", "org_id", "member_id", "role_key", "computed_at"),
+    )

--- a/backend/app/routers/trust_scores.py
+++ b/backend/app/routers/trust_scores.py
@@ -1,13 +1,15 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.dependencies.ownership import _is_org_admin
+from app.models.trust_snapshot import OrgMemberTrustSnapshot
 from app.services.member_resolver import is_caller_member
-from app.services.trust_score import DEFAULT_WINDOW_DAYS, compute_member_trust_scores
+from app.services.trust_score import DEFAULT_WINDOW_DAYS, compute_and_snapshot
 
 router = APIRouter(prefix="/api/v2/trust-scores", tags=["trust-scores", "Organization"])
 
@@ -22,6 +24,12 @@ async def _assert_self_or_org_admin(
     raise HTTPException(status_code=403, detail="Not authorized for this member")
 
 
+async def _assert_org_admin(session: AsyncSession, org_id: uuid.UUID, auth: AuthContext) -> None:
+    if await _is_org_admin(session, org_id, uuid.UUID(auth.user_id)):
+        return
+    raise HTTPException(status_code=403, detail="Not authorized — org admin only")
+
+
 @router.get("")
 async def get_trust_scores(
     member_id: uuid.UUID = Query(...),
@@ -34,10 +42,96 @@ async def get_trust_scores(
     # S20 전수스캔 findings #11: member_id에 caller-ownership 확인이 전혀 없어 임의 org member가
     # 다른 member의 신뢰점수(성과 유사 민감정보)를 열람할 수 있었다 — rewards.get_balance와 동형.
     await _assert_self_or_org_admin(member_id, auth, session, org_id)
-    return await compute_member_trust_scores(
+    # story 91404248(C2a): compute_member_trust_scores() 산식은 불변 — lazy write-through로
+    # org_member_trust_snapshots에 부수효과 저장만 추가(응답 계약 100% 동일).
+    return await compute_and_snapshot(
         session=session,
         org_id=org_id,
         member_id=member_id,
         role_key=role,
         window_days=window_days,
     )
+
+
+@router.get("/org-summary")
+async def get_trust_org_summary(
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    """story 91404248(C2a): org-c2-trust-persistence-design §4a — 조직 로스터 현재값.
+
+    member×role별 최신 스냅샷 1건. admin-only(로스터 전체 열람은 self 예외 없음 — 다른
+    member 신뢰점수를 보는 행위 자체가 이미 admin 전용 시맨틱, trust-scores 기존 판단 계승).
+    스냅샷이 아예 없는 member×role은 목록에서 생략(부분 목록 — 콜드스타트, IDOR 아님).
+    """
+    await _assert_org_admin(session, org_id, auth)
+
+    latest_ids_subq = (
+        select(
+            OrgMemberTrustSnapshot.member_id,
+            OrgMemberTrustSnapshot.role_key,
+            func.max(OrgMemberTrustSnapshot.computed_at).label("max_computed_at"),
+        )
+        .where(OrgMemberTrustSnapshot.org_id == org_id)
+        .group_by(OrgMemberTrustSnapshot.member_id, OrgMemberTrustSnapshot.role_key)
+        .subquery()
+    )
+    q = select(OrgMemberTrustSnapshot).join(
+        latest_ids_subq,
+        (OrgMemberTrustSnapshot.member_id == latest_ids_subq.c.member_id)
+        & (OrgMemberTrustSnapshot.role_key == latest_ids_subq.c.role_key)
+        & (OrgMemberTrustSnapshot.computed_at == latest_ids_subq.c.max_computed_at),
+    ).where(OrgMemberTrustSnapshot.org_id == org_id)
+    rows = (await session.execute(q)).scalars().all()
+
+    return {
+        "members": [
+            {
+                "member_id": str(row.member_id),
+                "role_key": row.role_key,
+                "role_label": row.metrics.get("role_label"),
+                "hit_rate": row.metrics.get("hit_rate"),
+                "resolved": row.metrics.get("resolved"),
+                "computed_at": row.computed_at.isoformat(),
+            }
+            for row in rows
+        ]
+    }
+
+
+@router.get("/history")
+async def get_trust_history(
+    member_id: uuid.UUID = Query(...),
+    role: str = Query(...),
+    limit: int = Query(default=50, ge=1, le=500),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    """story 91404248(C2a): org-c2-trust-persistence-design §4b — 멤버 드릴다운 추이.
+
+    self-or-admin(본인 추이는 볼 수 있어야 함 — 기존 GET /trust-scores 권한 재사용).
+    """
+    await _assert_self_or_org_admin(member_id, auth, session, org_id)
+
+    q = (
+        select(OrgMemberTrustSnapshot)
+        .where(
+            OrgMemberTrustSnapshot.org_id == org_id,
+            OrgMemberTrustSnapshot.member_id == member_id,
+            OrgMemberTrustSnapshot.role_key == role,
+        )
+        .order_by(OrgMemberTrustSnapshot.computed_at.desc())
+        .limit(limit)
+    )
+    rows = (await session.execute(q)).scalars().all()
+
+    return {
+        "member_id": str(member_id),
+        "role_key": role,
+        "snapshots": [
+            {"computed_at": row.computed_at.isoformat(), **row.metrics}
+            for row in rows
+        ],
+    }

--- a/backend/app/services/trust_score.py
+++ b/backend/app/services/trust_score.py
@@ -41,9 +41,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.participation import Participation, ParticipationRole
 from app.models.pm import Story
+from app.models.trust_snapshot import OrgMemberTrustSnapshot
 from app.models.verdict import Verdict
 
 DEFAULT_WINDOW_DAYS = 90
+SNAPSHOT_DEDUP_HOURS = 24
 
 # HO-S5: 신뢰의 1차(primary) source = 가설 outcome verdict(가설 적중 이력=substance).
 # 기본 집계는 이 source들만 trust로 환산하고 CI/pr/qa/design은 제외(legacy clean_pass는
@@ -230,3 +232,39 @@ async def compute_member_trust_scores(
         "pending": total_pending,
         "source_breakdown": source_breakdown,
     }
+
+
+async def compute_and_snapshot(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    member_id: uuid.UUID,
+    role_key: str | None = None,
+    window_days: int = DEFAULT_WINDOW_DAYS,
+    *,
+    include_legacy: bool = False,
+) -> dict[str, Any]:
+    """story 91404248(C2a): compute_member_trust_scores()의 lazy write-through wrapper.
+
+    org-c2-trust-persistence-design §2 — 산식은 완전 불변(compute_member_trust_scores 그대로
+    호출), role별 score dict를 metrics JSONB로 verbatim 저장만 추가한다. 동일 (org_id,
+    member_id, role_key)의 최신 스냅샷이 SNAPSHOT_DEDUP_HOURS 이내면 skip(write 증폭 방지).
+    """
+    result = await compute_member_trust_scores(
+        session, org_id, member_id, role_key, window_days, include_legacy=include_legacy,
+    )
+    dedup_cutoff = datetime.now(timezone.utc) - timedelta(hours=SNAPSHOT_DEDUP_HOURS)
+    for score in result["scores"]:
+        recent = await session.execute(
+            select(OrgMemberTrustSnapshot.id).where(
+                OrgMemberTrustSnapshot.org_id == org_id,
+                OrgMemberTrustSnapshot.member_id == member_id,
+                OrgMemberTrustSnapshot.role_key == score["role_key"],
+                OrgMemberTrustSnapshot.computed_at >= dedup_cutoff,
+            ).limit(1)
+        )
+        if recent.scalar_one_or_none() is None:
+            session.add(OrgMemberTrustSnapshot(
+                org_id=org_id, member_id=member_id, role_key=score["role_key"],
+                window_days=window_days, metrics=score,
+            ))
+    return result

--- a/backend/tests/test_c2a_trust_snapshots.py
+++ b/backend/tests/test_c2a_trust_snapshots.py
@@ -1,0 +1,80 @@
+"""story 91404248(C2a): compute_and_snapshot() lazy write-through 단위 테스트
+(org-c2-trust-persistence-design §2/§3). compute_member_trust_scores()는 완전 불변 —
+이 파일은 wrapper의 부수효과(session.add 호출 여부·dedup skip)만 검증한다."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import trust_score as ts
+
+ORG_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _fake_compute_result(scores):
+    return {
+        "member_id": str(MEMBER_ID), "scores": scores, "window_days": 90,
+        "primary_source": "hypothesis_outcome", "hypothesis_hit_rate": None,
+        "resolved": 0, "hit": 0, "pending": 0, "source_breakdown": {},
+    }
+
+
+@pytest.mark.anyio
+async def test_no_scores_no_snapshot_write():
+    """scores=[] (cold-start) → session.add 호출 없음."""
+    session = AsyncMock()
+    with patch.object(ts, "compute_member_trust_scores", new=AsyncMock(return_value=_fake_compute_result([]))):
+        result = await ts.compute_and_snapshot(session, ORG_ID, MEMBER_ID)
+    session.add.assert_not_called()
+    assert result["scores"] == []
+
+
+@pytest.mark.anyio
+async def test_snapshot_written_when_no_recent_row():
+    """최근 24h 내 스냅샷 없음 → session.add로 신규 행 적재."""
+    session = AsyncMock()
+    no_recent = MagicMock()
+    no_recent.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=no_recent)
+    score = {"role_key": "dev", "role_label": "개발", "hit_rate": 0.8, "resolved": 5}
+    with patch.object(ts, "compute_member_trust_scores", new=AsyncMock(return_value=_fake_compute_result([score]))):
+        await ts.compute_and_snapshot(session, ORG_ID, MEMBER_ID)
+    session.add.assert_called_once()
+    added = session.add.call_args.args[0]
+    assert added.org_id == ORG_ID and added.member_id == MEMBER_ID
+    assert added.role_key == "dev" and added.metrics == score
+
+
+@pytest.mark.anyio
+async def test_dedup_skips_write_within_24h():
+    """24h 내 동일 (org,member,role) 스냅샷 존재 → session.add 호출 없음(dedup)."""
+    session = AsyncMock()
+    recent = MagicMock()
+    recent.scalar_one_or_none.return_value = uuid.uuid4()  # 최근 행 존재
+    session.execute = AsyncMock(return_value=recent)
+    score = {"role_key": "dev", "role_label": "개발", "hit_rate": 0.8, "resolved": 5}
+    with patch.object(ts, "compute_member_trust_scores", new=AsyncMock(return_value=_fake_compute_result([score]))):
+        await ts.compute_and_snapshot(session, ORG_ID, MEMBER_ID)
+    session.add.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_compute_member_trust_scores_formula_untouched():
+    """산식 불변 회귀 — compute_and_snapshot이 compute_member_trust_scores에 정확한 인자를 그대로 전달."""
+    session = AsyncMock()
+    no_recent = MagicMock()
+    no_recent.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=no_recent)
+    inner = AsyncMock(return_value=_fake_compute_result([]))
+    with patch.object(ts, "compute_member_trust_scores", new=inner):
+        await ts.compute_and_snapshot(session, ORG_ID, MEMBER_ID, role_key="dev", window_days=30, include_legacy=True)
+    inner.assert_awaited_once_with(session, ORG_ID, MEMBER_ID, "dev", 30, include_legacy=True)

--- a/backend/tests/test_c2a_trust_snapshots_realdb.py
+++ b/backend/tests/test_c2a_trust_snapshots_realdb.py
@@ -1,0 +1,286 @@
+"""story 91404248(C2a) 게이트: org_member_trust_snapshots 실 PG 왕복 —
+lazy write-through 적재·24h dedup·org-summary(admin-only·최신1건)·history(self-or-admin·추이)."""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _seed_org_and_members(session):
+    """org + admin(caller) + regular member(target). 신뢰 계산용 participation/story/verdict 1건.
+
+    team_members VIEW(members ⋈ project_access, [[feedback_team_members_view_human_drop]])
+    해소를 위해 Member+ProjectAccess(member_id=target_om.id)도 함께 시드 — is_caller_member가
+    TeamMember(뷰).id==member_id AND .user_id==caller로 axis-safe 비교하므로 필요."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.pm import Story
+    from app.models.participation import Participation, ParticipationRole
+    from app.models.verdict import Verdict
+    from app.models.user import User
+    from app.models.member import Member
+    from app.models.project_access import ProjectAccess
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+    session.add(project)
+    await session.commit()
+
+    admin_user_id = uuid.uuid4()
+    member_user_id = uuid.uuid4()
+    session.add_all([
+        User(id=admin_user_id, email=f"admin-{admin_user_id.hex[:8]}@test.com", hashed_password="x"),
+        User(id=member_user_id, email=f"member-{member_user_id.hex[:8]}@test.com", hashed_password="x"),
+    ])
+    await session.commit()
+
+    admin_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=admin_user_id, role="admin")
+    target_om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=member_user_id, role="member")
+    session.add_all([admin_om, target_om])
+    await session.commit()
+
+    # target_om.id를 members.id로도 재사용 — Participation/snapshot의 member_id와
+    # team_members 뷰 axis를 단일 id로 통일(테스트 seed 편의, 실 앱의 canonicalize 경로와 무관).
+    session.add(Member(
+        id=target_om.id, org_id=org.id, type="human", user_id=member_user_id, name="Target",
+    ))
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project.id, org_member_id=target_om.id,
+        member_id=target_om.id, permission="granted",
+    ))
+    await session.commit()
+
+    role = ParticipationRole(id=uuid.uuid4(), org_id=org.id, key="dev", label="개발", is_default=True)
+    session.add(role)
+    await session.commit()
+
+    story = Story(id=uuid.uuid4(), org_id=org.id, project_id=project.id, title="S", status="done")
+    session.add(story)
+    await session.commit()
+
+    participation = Participation(
+        id=uuid.uuid4(), org_id=org.id, story_id=story.id, member_id=target_om.id, role_id=role.id,
+    )
+    session.add(participation)
+    await session.commit()
+
+    verdict = Verdict(
+        id=uuid.uuid4(), org_id=org.id, participation_id=participation.id,
+        source="hypothesis_outcome_execution", result="pass", rounds=0,
+    )
+    session.add(verdict)
+    await session.commit()
+
+    return {
+        "org_id": org.id, "admin_user_id": admin_user_id, "member_user_id": member_user_id,
+        "target_member_id": target_om.id,
+    }
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_get_trust_scores_writes_snapshot_and_dedups_within_24h_realdb():
+    from app.main import app
+    from app.models.trust_snapshot import OrgMemberTrustSnapshot
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_and_members(s)
+
+        await _setup_app(app, Session, seeded["admin_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/trust-scores?member_id={seeded['target_member_id']}")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["scores"][0]["role_key"] == "dev"
+            assert body["scores"][0]["hit_rate"] == 1.0
+
+            # 두 번째 호출(24h 내) — dedup으로 신규 행 없어야 함.
+            resp2 = await client.get(f"/api/v2/trust-scores?member_id={seeded['target_member_id']}")
+            assert resp2.status_code == 200
+        finally:
+            await client.aclose()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(OrgMemberTrustSnapshot).where(
+                    OrgMemberTrustSnapshot.org_id == seeded["org_id"],
+                    OrgMemberTrustSnapshot.member_id == seeded["target_member_id"],
+                )
+            )).scalars().all()
+            assert len(rows) == 1, "dedup 실패 — 24h 내 중복 스냅샷 적재됨"
+            assert rows[0].metrics["hit_rate"] == 1.0
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_org_summary_admin_only_latest_per_member_role_realdb():
+    from app.main import app
+    from app.models.trust_snapshot import OrgMemberTrustSnapshot
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_and_members(s)
+            older = OrgMemberTrustSnapshot(
+                id=uuid.uuid4(), org_id=seeded["org_id"], member_id=seeded["target_member_id"],
+                role_key="dev", window_days=90, metrics={"role_label": "개발", "hit_rate": 0.5, "resolved": 2},
+                computed_at=datetime.now(timezone.utc) - timedelta(days=2),
+            )
+            newer = OrgMemberTrustSnapshot(
+                id=uuid.uuid4(), org_id=seeded["org_id"], member_id=seeded["target_member_id"],
+                role_key="dev", window_days=90, metrics={"role_label": "개발", "hit_rate": 0.9, "resolved": 9},
+                computed_at=datetime.now(timezone.utc),
+            )
+            s.add_all([older, newer])
+            await s.commit()
+
+        # admin — 최신(0.9)만 반환.
+        await _setup_app(app, Session, seeded["admin_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/trust-scores/org-summary")
+            assert resp.status_code == 200, resp.text
+            members = resp.json()["members"]
+            assert len(members) == 1
+            assert members[0]["hit_rate"] == 0.9
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+
+        # 까심: 비-admin(target 본인)은 org-summary 403.
+        await _setup_app(app, Session, seeded["member_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get("/api/v2/trust-scores/org-summary")
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_history_self_or_admin_ordered_desc_realdb():
+    from app.main import app
+    from app.models.trust_snapshot import OrgMemberTrustSnapshot
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_org_and_members(s)
+            for i, hit_rate in enumerate([0.5, 0.7, 0.9]):
+                s.add(OrgMemberTrustSnapshot(
+                    id=uuid.uuid4(), org_id=seeded["org_id"], member_id=seeded["target_member_id"],
+                    role_key="dev", window_days=90, metrics={"hit_rate": hit_rate},
+                    computed_at=datetime.now(timezone.utc) - timedelta(days=3 - i),
+                ))
+            await s.commit()
+
+        # self(target 본인) 조회 허용.
+        await _setup_app(app, Session, seeded["member_user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/trust-scores/history?member_id={seeded['target_member_id']}&role=dev"
+            )
+            assert resp.status_code == 200, resp.text
+            snaps = resp.json()["snapshots"]
+            assert [s["hit_rate"] for s in snaps] == [0.9, 0.7, 0.5], "computed_at DESC 정렬 실패"
+        finally:
+            await client.aclose()
+        app.dependency_overrides.clear()
+
+        # 까심: 제3자(admin 아닌 타인 — 여기선 admin이 아닌 새 유저)는 403.
+        stranger_user_id = uuid.uuid4()
+        from app.models.user import User
+        async with Session() as s:
+            s.add(User(id=stranger_user_id, email=f"stranger-{stranger_user_id.hex[:8]}@test.com", hashed_password="x"))
+            from app.models.project import OrgMember
+            s.add(OrgMember(id=uuid.uuid4(), org_id=seeded["org_id"], user_id=stranger_user_id, role="member"))
+            await s.commit()
+
+        await _setup_app(app, Session, stranger_user_id, seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/trust-scores/history?member_id={seeded['target_member_id']}&role=dev"
+            )
+            assert resp.status_code == 403, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- Story `91404248`(C2a, Organization 실체 보강 트랙) — 승인된 설계 doc `org-c2-trust-persistence-design` 그대로 구현.
- `compute_member_trust_scores()` 산식은 완전 불변 — 신규 wrapper `compute_and_snapshot()`이 role별 score dict를 `org_member_trust_snapshots.metrics`(JSONB)로 verbatim 저장만 추가(lazy write-through, 동일 (org_id, member_id, role_key)의 24h 내 최신 스냅샷 존재 시 skip).
- `GET /api/v2/trust-scores` 내부만 `compute_and_snapshot()`으로 교체 — 응답 계약 100% 동일.
- 신규 엔드포인트 2개:
  - `GET /trust-scores/org-summary` — member×role 최신 스냅샷(admin-only, self 예외 없음 — 로스터 전체 열람은 이미 "성과 유사 민감정보" admin 전용 시맨틱, 기존 판단 계승)
  - `GET /trust-scores/history` — 멤버 드릴다운 추이(self-or-admin, 기존 권한 재사용)
- 신규 인프라 0(cron 미채택 — 이 배포엔 주기적 작업 인프라가 전무하다는 실측 근거, doc §0.2/§2).
- B(이벤트소싱 원장) 이행 경로를 스키마로 보장(doc §5) — B 채택 시에도 스냅샷 테이블·두 엔드포인트·FE 계약은 무변경 유지, A가 막다른 길이 되지 않음.

⛔ 산식 재설계(C2b·이벤트소싱)는 스코프 밖 — 별도 스토리.

## Test plan
- [x] 마이그레이션: 신선 DB 0186→0187 전구간 upgrade + downgrade/upgrade 왕복, 단일 head 확인
- [x] mocked wrapper 단위 4건(`test_c2a_trust_snapshots.py`): cold-start 무기록, 신규 스냅샷 적재, 24h dedup skip, 산식 인자 불변 회귀
- [x] realdb 왕복 3건(`test_c2a_trust_snapshots_realdb.py`, 라이브 PG):
  - `GET /trust-scores` 실호출 → 스냅샷 1건 적재 실증 + 즉시 재호출 시 dedup(행 수 불변) 실증
  - 까심: `org-summary` 최신 1건만 반환(구/신 스냅샷 중) + 비-admin 403
  - 까심: `history` self 허용(추이 desc 정렬) + 제3자(admin 아님) 403
- [x] 뮤테이션 자가검증 3건: dedup 조건 무력화 → 예상 2개 테스트 정확히 RED, admin 가드 무력화 → 예상 1개 테스트 정확히 RED, 모두 원복 확인
- [x] 기존 `trust-scores` 회귀 스위트(`test_e_cage_referee_p2_trust_score.py` 등) 무변경 통과 — 라우터 응답 계약 그대로임을 실증
- [x] 전체 스위트(`-m "not destructive_schema"`): 3262 passed / 7 failed(develop 기준선과 동일 재현되는 환경 의존 사전 실패뿐, 본 PR과 무관 — 직전 fca4723d PR에서 이미 stash 대조로 확인된 동일 실패군)

🤖 Generated with [Claude Code](https://claude.com/claude-code)