### PR TITLE
feat(resolve): story ddac96fd(S-resolve) — workspace+project 단일 slug resolve

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,7 +57,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import a2a, account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, retros, rewards, role_templates, runtime_capabilities, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import a2a, account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, gate_config, gate_metrics, attachments, audit_logs, auth, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 # 도메인 축 B(org-1st-class-surface-ia-design-b §3): OpenAPI 태그 조직-우선 위계.
 # 개별 라우터는 기존 세부 tag(예 "stories")를 그대로 유지하고 이 4축 태그를 추가로 보유(다중
@@ -216,6 +216,7 @@ app.include_router(runtime_capabilities.router)
 app.include_router(members.router)
 app.include_router(merge_gate.router)
 app.include_router(organizations.router)
+app.include_router(resolve.router)
 app.include_router(org_invites.router)
 app.include_router(invite_accept.router)
 app.include_router(me.router)

--- a/backend/app/routers/resolve.py
+++ b/backend/app/routers/resolve.py
@@ -1,0 +1,131 @@
+"""story ddac96fd(S-resolve): workspace+project slug 단일 resolve — S-route-project FE
+미들웨어 소비용(오르테가군 조율 87ed7c68/956d2f36). 발명 0 — /organizations/resolve+
+/projects/resolve의 기존 lookup을 한 요청으로 합성(요청당 2 fetch→1).
+
+캐싱: slug UNIQUE 제약(organizations 전역·projects org-scope)상 rename 즉시 옛 slug가
+다른 entity에 재점유 가능 — "느려서"가 아니라 오배정 정합성 리스크라 긴 캐시 금지, 짧은
+Cache-Control(30~60s)+ETag(If-None-Match 304)만 사용. 옛 slug 요청은 entity_slug_history
+(139d2405, 향후 301 redirect용으로 설계된 그 테이블)에서 canonical slug를 찾아 redirect
+필드에 실어 반환 — 미들웨어가 그 필드를 보고 브라우저에 자체 301을 낸다(백엔드가 raw HTTP
+301을 내지 않는 이유: JSON API를 fetch()로 호출하는 미들웨어 입장에서 조건 없는 301은
+추가 라운드트립을 부르므로, 판단 가능한 JSON 필드가 더 저렴하다).
+"""
+from __future__ import annotations
+
+import hashlib
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.models.entity_slug_history import EntitySlugHistory
+from app.models.organization import Organization
+from app.models.project import Project
+from app.repositories.organization import OrganizationRepository
+from app.services.project_auth import has_project_access
+
+router = APIRouter(prefix="/api/v2/resolve", tags=["resolve", "Organization"])
+
+_CACHE_CONTROL = "private, max-age=60"
+
+
+async def _find_org_by_history(session: AsyncSession, old_slug: str) -> Organization | None:
+    """옛 workspace slug → 가장 최근 rename 이력의 entity → 그 entity의 현재(canonical) 행.
+
+    changed_at DESC LIMIT 1: 다회 rename(A→B→C)이어도 entity_id만 얻으면 그 entity의 현재
+    slug를 다시 조회하므로 체이닝 불요. slug가 그사이 다른 org에 재점유됐어도 그 org는
+    현재 slug 직접조회(1차 시도)에서 이미 걸렸을 것이므로 이 분기엔 도달하지 않는다.
+    """
+    row = await session.execute(
+        select(EntitySlugHistory.entity_id)
+        .where(EntitySlugHistory.entity_type == "organization", EntitySlugHistory.old_slug == old_slug)
+        .order_by(EntitySlugHistory.changed_at.desc())
+        .limit(1)
+    )
+    entity_id = row.scalar_one_or_none()
+    if entity_id is None:
+        return None
+    return await session.get(Organization, entity_id)
+
+
+async def _find_project_by_history(
+    session: AsyncSession, org_id: uuid.UUID, old_slug: str,
+) -> Project | None:
+    row = await session.execute(
+        select(EntitySlugHistory.entity_id)
+        .where(
+            EntitySlugHistory.entity_type == "project",
+            EntitySlugHistory.org_id == org_id,
+            EntitySlugHistory.old_slug == old_slug,
+        )
+        .order_by(EntitySlugHistory.changed_at.desc())
+        .limit(1)
+    )
+    entity_id = row.scalar_one_or_none()
+    if entity_id is None:
+        return None
+    project = await session.get(Project, entity_id)
+    if project is None or project.deleted_at is not None:
+        return None
+    return project
+
+
+def _etag_for(result: dict) -> str:
+    key = f"{result.get('org_id')}:{result.get('project_id')}:{result.get('redirect')}"
+    return '"' + hashlib.sha1(key.encode()).hexdigest() + '"'
+
+
+@router.get("", response_model=None)
+async def resolve_workspace_project(
+    request: Request,
+    response: Response,
+    workspace: str = Query(...),
+    project: str | None = Query(default=None),
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> Response | dict:
+    repo = OrganizationRepository(session)
+    redirect: dict = {}
+
+    org = await repo.get_by_slug(workspace)
+    if org is None:
+        org = await _find_org_by_history(session, workspace)
+        if org is not None:
+            redirect["workspace"] = org.slug
+    if org is None:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    role = await repo.get_member_role(org_id=org.id, user_id=uuid.UUID(auth.user_id))
+    if role is None:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    result: dict = {"org_id": str(org.id), "org_slug": org.slug, "org_role": role}
+
+    if project is not None:
+        proj_row = await session.execute(
+            select(Project).where(
+                Project.org_id == org.id, Project.slug == project, Project.deleted_at.is_(None),
+            )
+        )
+        proj = proj_row.scalar_one_or_none()
+        if proj is None:
+            proj = await _find_project_by_history(session, org.id, project)
+            if proj is not None:
+                redirect["project"] = proj.slug
+        if proj is None or not await has_project_access(session, uuid.UUID(auth.user_id), proj.id, org.id):
+            raise HTTPException(status_code=404, detail="Project not found")
+        result["project_id"] = str(proj.id)
+        result["project_slug"] = proj.slug
+
+    if redirect:
+        result["redirect"] = redirect
+
+    etag = _etag_for(result)
+    response.headers["Cache-Control"] = _CACHE_CONTROL
+    response.headers["ETag"] = etag
+    if request.headers.get("if-none-match") == etag:
+        return Response(status_code=304, headers=dict(response.headers))
+    return result

--- a/backend/tests/test_s_resolve_ddac96fd_realdb.py
+++ b/backend/tests/test_s_resolve_ddac96fd_realdb.py
@@ -1,0 +1,309 @@
+"""story ddac96fd(S-resolve) 게이트: GET /api/v2/resolve?workspace=&project= 실 PG 왕복.
+
+단일 합성 resolve + 옛 slug(rename 이력) redirect + 접근권 404(비노출) + 캐시 헤더(ETag/304)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _seed(session):
+    """org(멤버=caller) + project(caller 접근권 有) + project_b(caller 접근권 無)."""
+    from app.models.organization import Organization
+    from app.models.project import OrgMember, Project
+    from app.models.project_access import ProjectAccess
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_a = Project(id=uuid.uuid4(), org_id=org.id, name="A", slug=f"proj-a-{uuid.uuid4().hex[:6]}")
+    project_b = Project(id=uuid.uuid4(), org_id=org.id, name="B", slug=f"proj-b-{uuid.uuid4().hex[:6]}")
+    session.add_all([project_a, project_b])
+    await session.commit()
+
+    user_id = uuid.uuid4()
+    session.add(User(id=user_id, email=f"caller-{user_id.hex[:8]}@test.com", hashed_password="x"))
+    await session.commit()
+    om = OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=user_id, role="member")
+    session.add(om)
+    await session.commit()
+    session.add(ProjectAccess(
+        id=uuid.uuid4(), project_id=project_a.id, org_member_id=om.id, permission="granted",
+    ))
+    await session.commit()
+
+    return {
+        "org_id": org.id, "org_slug": org.slug, "user_id": user_id,
+        "project_a_id": project_a.id, "project_a_slug": project_a.slug,
+        "project_b_id": project_b.id, "project_b_slug": project_b.slug,
+    }
+
+
+async def _setup_app(app, Session, user_id, org_id):
+    from app.dependencies.auth import AuthContext, get_current_user
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    async def _auth():
+        return AuthContext(
+            user_id=str(user_id), email="caller@test",
+            claims={"app_metadata": {"org_id": str(org_id)}},
+        )
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+
+
+@pytest.mark.anyio
+async def test_resolve_workspace_and_project_realdb():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/resolve?workspace={seeded['org_slug']}&project={seeded['project_a_slug']}"
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["org_id"] == str(seeded["org_id"])
+            assert body["project_id"] == str(seeded["project_a_id"])
+            assert "redirect" not in body
+            assert resp.headers["cache-control"] == "private, max-age=60"
+            assert resp.headers.get("etag")
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_resolve_workspace_only_realdb():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/resolve?workspace={seeded['org_slug']}")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["org_id"] == str(seeded["org_id"])
+            assert "project_id" not in body
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_etag_if_none_match_returns_304_realdb():
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp1 = await client.get(f"/api/v2/resolve?workspace={seeded['org_slug']}")
+            etag = resp1.headers["etag"]
+            resp2 = await client.get(
+                f"/api/v2/resolve?workspace={seeded['org_slug']}",
+                headers={"If-None-Match": etag},
+            )
+            assert resp2.status_code == 304
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_old_workspace_slug_redirects_via_history_realdb():
+    """rename 이력(A→B→C) — 옛 slug 'A' 요청 시 단일-hop lookup으로 최종 C까지 정확히 해소."""
+    from app.main import app
+    from app.models.entity_slug_history import EntitySlugHistory
+    from datetime import datetime, timedelta, timezone
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            org_id = seeded["org_id"]
+            old_slug_a = f"old-a-{uuid.uuid4().hex[:6]}"
+            mid_slug_b = f"old-b-{uuid.uuid4().hex[:6]}"
+            now = datetime.now(timezone.utc)
+            s.add_all([
+                EntitySlugHistory(
+                    id=uuid.uuid4(), org_id=org_id, entity_type="organization", entity_id=org_id,
+                    old_slug=old_slug_a, new_slug=mid_slug_b, changed_at=now - timedelta(days=2),
+                ),
+                EntitySlugHistory(
+                    id=uuid.uuid4(), org_id=org_id, entity_type="organization", entity_id=org_id,
+                    old_slug=mid_slug_b, new_slug=seeded["org_slug"], changed_at=now - timedelta(days=1),
+                ),
+            ])
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/resolve?workspace={old_slug_a}")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["org_id"] == str(seeded["org_id"])
+            assert body["org_slug"] == seeded["org_slug"]
+            assert body["redirect"]["workspace"] == seeded["org_slug"]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_old_project_slug_redirects_via_history_realdb():
+    from app.main import app
+    from app.models.entity_slug_history import EntitySlugHistory
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            old_proj_slug = f"old-proj-{uuid.uuid4().hex[:6]}"
+            s.add(EntitySlugHistory(
+                id=uuid.uuid4(), org_id=seeded["org_id"], entity_type="project",
+                entity_id=seeded["project_a_id"], old_slug=old_proj_slug,
+                new_slug=seeded["project_a_slug"],
+            ))
+            await s.commit()
+
+        await _setup_app(app, Session, seeded["user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/resolve?workspace={seeded['org_slug']}&project={old_proj_slug}"
+            )
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert body["project_id"] == str(seeded["project_a_id"])
+            assert body["redirect"]["project"] == seeded["project_a_slug"]
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_non_member_gets_404_not_403_realdb():
+    """까심: org 비멤버는 404(존재 비노출) — 다른 org 기존 판단과 정합."""
+    from app.main import app
+    from app.models.user import User
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+            stranger_id = uuid.uuid4()
+            s.add(User(id=stranger_id, email=f"stranger-{stranger_id.hex[:8]}@test.com", hashed_password="x"))
+            await s.commit()
+
+        await _setup_app(app, Session, stranger_id, seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(f"/api/v2/resolve?workspace={seeded['org_slug']}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_project_access_gets_404_realdb():
+    """까심: org 멤버지만 project_b 접근권 없음 — 404(IDOR 차단)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        await _setup_app(app, Session, seeded["user_id"], seeded["org_id"])
+        client = _client_for(app)
+        try:
+            resp = await client.get(
+                f"/api/v2/resolve?workspace={seeded['org_slug']}&project={seeded['project_b_slug']}"
+            )
+            assert resp.status_code == 404, resp.text
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- Story `ddac96fd`(S-resolve) — 오르테가군 조율(미르코 S-route-project FE 미들웨어가 URL path를 id로 풀 때 요청당 2 순차 fetch가 필요해 Edge 지연/콜드스타트 전가 우려)에 대한 판단을 그대로 구현. 발명 0.
- `GET /api/v2/resolve?workspace=&project=` 신설 — `/organizations/resolve`+`/projects/resolve`의 기존 lookup을 한 요청으로 합성(요청당 2 fetch→1). 신규 영속화 0.
- 옛 slug(rename 이력) 요청 시 `redirect` 필드에 canonical slug를 실어 반환 — `entity_slug_history`(139d2405, 애초에 "향후 301 redirect용"으로 설계된 테이블)를 changed_at DESC 단일-hop 조회 후 entity의 현재 slug를 재조회(다회 rename A→B→C도 체이닝 없이 정확히 해소, 미들웨어가 이 필드를 보고 브라우저에 자체 301).
- `Cache-Control: private, max-age=60`(짧게) — "느려서"가 아니라 slug UNIQUE 제약(organizations 전역·projects org-scope)상 rename 즉시 옛 slug가 다른 entity에 재점유 가능해 긴 캐시는 오배정 정합성 리스크이기 때문(조율 시 실측 근거로 제시, PO 승인).
- ETag + `If-None-Match` → 304.
- 접근권: org 비멤버/project 미접근 모두 404(존재 비노출 — 기존 개별 resolve 엔드포인트 판단 계승, IDOR 방지).

## Test plan
- [x] realdb 7건(라이브 PG, `test_s_resolve_ddac96fd_realdb.py`): 단일 합성 200(workspace+project), workspace-only, ETag/304 왕복, 다회 rename 체이닝 redirect(워크스페이스+프로젝트 각 1건), 까심 비멤버 404, 까심 project 미접근 404(IDOR)
- [x] 뮤테이션 자가검증 3건: history redirect 무력화 → 예상 1건 정확히 RED, project access 가드 무력화 → 예상 1건 정확히 RED, if-none-match 무력화 → 예상 1건 정확히 RED. 모두 원복 확인
- [x] slug/organizations/projects 관련 스위트 227 passed 무회귀
- [x] 전체 스위트(`-m "not destructive_schema"`): 3262 passed / 7 failed(develop 기준선과 동일 재현되는 환경 의존 사전 실패뿐, 이전 두 PR에서 이미 stash 대조로 확인된 동일 실패군 — 본 PR과 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)