### PR TITLE
fix(slug): workspace slug denylist에 FE 플랫 최상위 라우트명 전체 반영

### DIFF
--- a/backend/app/services/entity_slug.py
+++ b/backend/app/services/entity_slug.py
@@ -26,9 +26,25 @@ def is_valid_slug_format(slug: str) -> bool:
 
 # 유나 doc org-1st-class-surface-ia-design-b §2a — root bare workspace slug라 앱 라우트와
 # 충돌 방지(GitHub org 예약어 관례). project slug는 workspace 하위(non-root)라 denylist 불요.
+#
+# 미르코 S-route-project 그라운딩 발견(근본 강화, 2026-07-15): §2a denylist가 FE 플랫
+# 최상위 라우트명(apps/web/src/app 실측)을 전부 커버하지 않아 ws slug="board" 같은 생성이
+# 허용되고 있었다 — /{ws}/... 마이그 이후 /board/...가 workspace로 오배정될 여지. 실측
+# 근거(apps/web/src/app 디렉토리 직접 대조, 두 그룹 모두 반영 — 발견은 (authenticated) 하위
+# 리소스 라우트만 지목했으나, 동일 충돌 메커니즘이 그 바깥 top-level 페이지(auth/dashboard 등)
+# 에도 적용돼 함께 봉합):
+#   (authenticated)/*: activity·artifacts·board·channel·chats·docs·epics·glance·inbox·
+#     loops·meetings·mockups·org-briefing·retro·rewards·sprints·standup·storage
+#   app/* top-level: auth·dashboard·forgot-password·internal-dogfood·invite·mfa·privacy·
+#     register·reset-password·share·terms·verify-email
 RESERVED_WORKSPACE_SLUGS: frozenset[str] = frozenset({
     "api", "login", "logout", "onboarding", "settings", "organization", "o", "admin",
     "help", "static", "_next", "404",
+    "activity", "artifacts", "board", "channel", "chats", "docs", "epics", "glance",
+    "inbox", "loops", "meetings", "mockups", "org-briefing", "retro", "rewards",
+    "sprints", "standup", "storage",
+    "auth", "dashboard", "forgot-password", "internal-dogfood", "invite", "mfa",
+    "privacy", "register", "reset-password", "share", "terms", "verify-email",
 })
 
 

--- a/backend/tests/test_139d2405_slug_infra_realdb.py
+++ b/backend/tests/test_139d2405_slug_infra_realdb.py
@@ -139,6 +139,21 @@ def test_reserved_workspace_slugs_exact_denylist():
     assert "moonklabs" not in RESERVED_WORKSPACE_SLUGS
 
 
+def test_reserved_workspace_slugs_covers_fe_flat_resource_routes():
+    """미르코 S-route-project 그라운딩 발견(2026-07-15) 후속 봉합 — apps/web/src/app 실측
+    최상위 라우트명 전체가 denylist에 있어야 /{ws}/... 마이그 이후 오배정이 없다."""
+    from app.services.entity_slug import RESERVED_WORKSPACE_SLUGS
+
+    for w in (
+        "activity", "artifacts", "board", "channel", "chats", "docs", "epics", "glance",
+        "inbox", "loops", "meetings", "mockups", "org-briefing", "retro", "rewards",
+        "sprints", "standup", "storage",
+        "auth", "dashboard", "forgot-password", "internal-dogfood", "invite", "mfa",
+        "privacy", "register", "reset-password", "share", "terms", "verify-email",
+    ):
+        assert w in RESERVED_WORKSPACE_SLUGS, f"{w} 라우트명이 denylist에 없음"
+
+
 @pytest.mark.anyio
 async def test_resolve_unique_workspace_slug_skips_reserved_and_collision():
     from app.services.entity_slug import resolve_unique_workspace_slug


### PR DESCRIPTION
## Summary
- 미르코 S-route-project 그라운딩 발견(근본 강화) — 유나 doc §2a workspace slug denylist가 FE 리소스 라우트명(board·docs·sprints 등)을 커버하지 않아 ws slug="board" 같은 생성이 가능했음. `/{ws}/...` 마이그 이후 `/board/...`가 workspace로 오배정될 구조적 충돌 여지.
- `apps/web/src/app` 직접 실측 대조 — PO가 지목한 `(authenticated)` 하위 리소스 라우트뿐 아니라, 동일 충돌 메커니즘이 적용되는 그 바깥 top-level 페이지(auth/dashboard/invite 등)도 함께 발견해 봉합(발견 범위를 스스로 넓힘).
- `RESERVED_WORKSPACE_SLUGS` 단일 상수 확장만 — create/rename/auto-derive suffix 3개 write 경로가 이미 이 상수를 참조해 자동 봉합(코드 변경 0, 마이그 0).
- **스토리 미등재**(소품 판단, PO가 판단을 위임했음) — 단일 파일 additive 변경, 신규 퍼시스턴스 없음.

## Test plan
- [x] 신규 테스트 1건(`test_reserved_workspace_slugs_covers_fe_flat_resource_routes`) — 추가된 30개 항목 전체 멤버십 확인
- [x] 뮤테이션 자가검증: `board` 1개 항목 제거 → 신규 테스트만 정확히 RED(클린 DB로 재확인 — 공유 테스트 DB 오염으로 인한 무관 실패 6건을 먼저 걸러내고 클린 상태에서 재검증), 원복 후 clean 확인
- [x] slug 스위트(`test_139d2405_slug_infra_realdb.py`) 18 passed
- [x] 전체 스위트(`-m "not destructive_schema"`): 3262 passed / 7 failed(develop 기준선과 동일 재현되는 환경 의존 사전 실패뿐, 이전 PR들에서 이미 확인된 동일 실패군 — 본 PR과 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)