### PR TITLE
[SID:a539c649] S1 — workspace/project resolve 미들웨어 인프라(회귀 0·flat 라우트 무영향)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -78,7 +78,7 @@
     "zoneOrganization": "Organization",
     "orgMembers": "Members",
     "workforce": "Workforce",
-    "orgRoles": "Roles",
+    "orgRoles": "Permissions",
     "orgTrust": "Trust",
     "orgMemory": "Memory"
   },
@@ -332,7 +332,7 @@
     "workforceEmpty": "No active work right now"
   },
   "organization": {
-    "rolesTitle": "Roles",
+    "rolesTitle": "Permissions",
     "rolesDescription": "View and change organization members' roles, grouped by role.",
     "roleGroupOwner": "Owner",
     "roleGroupAdmin": "Admin",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -78,7 +78,7 @@
     "zoneOrganization": "조직",
     "orgMembers": "구성원",
     "workforce": "워크포스",
-    "orgRoles": "역할",
+    "orgRoles": "권한",
     "orgTrust": "신뢰",
     "orgMemory": "기억"
   },
@@ -332,7 +332,7 @@
     "workforceEmpty": "진행 중인 작업이 없습니다"
   },
   "organization": {
-    "rolesTitle": "역할",
+    "rolesTitle": "권한",
     "rolesDescription": "조직 구성원의 역할을 그룹별로 확인하고 변경합니다.",
     "roleGroupOwner": "소유자",
     "roleGroupAdmin": "관리자",

--- a/apps/web/src/lib/route-resolve.test.ts
+++ b/apps/web/src/lib/route-resolve.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SignJWT } from 'jose';
+import {
+  fetchResolve,
+  looksLikeWorkspaceSegment,
+  RESERVED_FIRST_SEGMENTS,
+  signResolveCache,
+  verifyResolveCache,
+} from './route-resolve';
+
+const JWT_SECRET = 'test-secret-for-route-resolve-tests';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+beforeEach(() => {
+  process.env['JWT_SECRET'] = JWT_SECRET;
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  delete process.env['JWT_SECRET'];
+});
+
+describe('looksLikeWorkspaceSegment', () => {
+  it('rejects every current live flat-route literal (S1 회귀 0 가드)', () => {
+    // story a539c649 S1 핵심 안전장치 — 이 목록의 어느 하나라도 workspace slug로 오인되면
+    // 그 라우트 전체가 즉시 장애난다(오르테가군 승인 스코프: reserved 가드로 flat 라우트 무회귀).
+    for (const segment of RESERVED_FIRST_SEGMENTS) {
+      expect(looksLikeWorkspaceSegment(segment)).toBe(false);
+    }
+  });
+
+  it('accepts a plausible kebab-case workspace slug not in the reserved list', () => {
+    expect(looksLikeWorkspaceSegment('moonklabs')).toBe(true);
+    expect(looksLikeWorkspaceSegment('acme-corp')).toBe(true);
+  });
+
+  it('rejects empty/undefined/malformed segments', () => {
+    expect(looksLikeWorkspaceSegment(undefined)).toBe(false);
+    expect(looksLikeWorkspaceSegment(null)).toBe(false);
+    expect(looksLikeWorkspaceSegment('')).toBe(false);
+    expect(looksLikeWorkspaceSegment('Has-Upper')).toBe(false);
+    expect(looksLikeWorkspaceSegment('snake_case')).toBe(false);
+    expect(looksLikeWorkspaceSegment('-leading-hyphen')).toBe(false);
+    expect(looksLikeWorkspaceSegment('trailing-hyphen-')).toBe(false);
+  });
+});
+
+describe('signResolveCache / verifyResolveCache', () => {
+  const context = { orgId: 'org-1', orgSlug: 'moonklabs', orgRole: 'admin', projectId: 'proj-1', projectSlug: 'sprintable' };
+
+  it('round-trips a signed cache token for the matching slug pair', async () => {
+    const token = await signResolveCache('moonklabs', 'sprintable', context);
+    const verified = await verifyResolveCache(token, 'moonklabs', 'sprintable');
+    expect(verified).toEqual(context);
+  });
+
+  it('rejects a token whose workspace slug no longer matches the URL', async () => {
+    const token = await signResolveCache('moonklabs', 'sprintable', context);
+    const verified = await verifyResolveCache(token, 'different-ws', 'sprintable');
+    expect(verified).toBeNull();
+  });
+
+  it('rejects a token whose project slug no longer matches the URL', async () => {
+    const token = await signResolveCache('moonklabs', 'sprintable', context);
+    const verified = await verifyResolveCache(token, 'moonklabs', 'different-proj');
+    expect(verified).toBeNull();
+  });
+
+  it('rejects an expired token', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    const expired = await new SignJWT({ wsSlug: 'moonklabs', projSlug: 'sprintable', ...context })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setIssuedAt(now - 120)
+      .setExpirationTime(now - 60)
+      .sign(new TextEncoder().encode(JWT_SECRET));
+    const verified = await verifyResolveCache(expired, 'moonklabs', 'sprintable');
+    expect(verified).toBeNull();
+  });
+
+  it('rejects a tampered/forged token (다른 시크릿으로 서명 — 위조 불가 증명)', async () => {
+    const forged = await new SignJWT({ wsSlug: 'moonklabs', projSlug: 'sprintable', ...context, orgRole: 'owner' })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setIssuedAt()
+      .setExpirationTime('50s')
+      .sign(new TextEncoder().encode('wrong-secret'));
+    const verified = await verifyResolveCache(forged, 'moonklabs', 'sprintable');
+    expect(verified).toBeNull();
+  });
+});
+
+describe('fetchResolve', () => {
+  it('returns ok with the org/project context on a plain 200', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ org_id: 'org-1', org_slug: 'moonklabs', org_role: 'admin', project_id: 'proj-1', project_slug: 'sprintable' }),
+    });
+    const outcome = await fetchResolve('http://localhost:8000', 'moonklabs', 'sprintable', 'access-token');
+    expect(outcome).toEqual({
+      kind: 'ok',
+      context: { orgId: 'org-1', orgSlug: 'moonklabs', orgRole: 'admin', projectId: 'proj-1', projectSlug: 'sprintable' },
+    });
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:8000/api/v2/resolve?workspace=moonklabs&project=sprintable',
+      { headers: { Authorization: 'Bearer access-token' } },
+    );
+  });
+
+  it('returns redirect when the BE response carries a redirect field (옛 slug rename-chase)', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ org_id: 'org-1', org_slug: 'new-slug', org_role: 'member', redirect: { workspace: 'new-slug' } }),
+    });
+    const outcome = await fetchResolve('http://localhost:8000', 'old-slug', undefined, 'access-token');
+    expect(outcome).toEqual({ kind: 'redirect', workspace: 'new-slug', project: undefined });
+  });
+
+  it('returns not_found on a non-ok response (org/project not found or no access)', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404, json: async () => ({}) });
+    const outcome = await fetchResolve('http://localhost:8000', 'ghost-ws', undefined, 'access-token');
+    expect(outcome).toEqual({ kind: 'not_found' });
+  });
+
+  it('returns not_found on a network error (fail-closed, never throws)', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('network down'));
+    const outcome = await fetchResolve('http://localhost:8000', 'moonklabs', undefined, 'access-token');
+    expect(outcome).toEqual({ kind: 'not_found' });
+  });
+});

--- a/apps/web/src/lib/route-resolve.ts
+++ b/apps/web/src/lib/route-resolve.ts
@@ -1,0 +1,153 @@
+/**
+ * story a539c649(S-route-project) S1 — workspace/project slug 단일 resolve(BE story ddac96fd,
+ * `GET /api/v2/resolve?workspace=&project=`) 소비 유틸. proxy.ts(Edge 미들웨어)가 쓴다.
+ *
+ * S1 스코프(오르테가군 확定 2026-07-15): 이 모듈은 resolve+캐시+redirect-chase 를 완성하되,
+ * **활성화는 RESERVED_FIRST_SEGMENTS 와 겹치지 않는 첫 세그먼트에만** 국한한다 — 현존 flat
+ * 라우트(`/board`·`/docs`...)의 첫 세그먼트를 workspace slug 로 오인해 전면 장애가 나는 것을
+ * 막는다(회귀 0). flat→path 301 은 여기서 켜지 않는다 — 목적지 페이지(`/{ws}/{proj}/{resource}`)
+ * 가 아직 없어(S2/S3 몫) 301 을 걸면 즉시 404 만 유발한다. S1 은 미들웨어 단(실 ws slug 진입 시
+ * resolve 성공+캐시+301-chase 동작)만 증명한다.
+ */
+import { SignJWT, jwtVerify } from 'jose';
+
+export const SP_RESOLVE_CACHE_COOKIE = 'sp_resolve_cache';
+
+/** 디디 실측(30~60s 판단 — slug UNIQUE 제약상 rename 즉시 재점유 가능해 긴 캐시=오배정 리스크,
+ * "느려서"가 아니다). BE Cache-Control max-age=60s 보다 여유 두고 하회. */
+export const RESOLVE_CACHE_TTL_SECONDS = 50;
+
+/**
+ * 현재 라이브 flat 라우트 첫 세그먼트 전부(2026-07-15 grounding, apps/web/src/app/ 실측) — 이
+ * 목록과 겹치는 첫 세그먼트는 workspace slug 시도 자체를 스킵한다. S2/S3 가 리소스를
+ * `/{ws}/{proj}/{resource}` 로 이관하며 여기서 하나씩 제거해나간다(그 리소스가 이사하면 첫
+ * 세그먼트가 더는 flat 라우트가 아니게 되므로).
+ */
+export const RESERVED_FIRST_SEGMENTS = new Set([
+  'activity', 'api', 'artifacts', 'auth', 'board', 'channel', 'chats', 'dashboard',
+  'docs', 'epics', 'favicon.ico', 'forgot-password', 'glance', 'icon.svg', 'inbox',
+  'internal-dogfood', 'invite', 'login', 'loops', 'meetings', 'mfa', 'mockups',
+  'onboarding', 'org-briefing', 'organization', 'privacy', 'register', 'reset-password',
+  'retro', 'rewards', 'settings', 'share', 'sprints', 'standup', 'storage', 'terms',
+  'verify-email',
+]);
+
+/** BE entity_slug 규칙과 동형(kebab·lowercase·영숫자+하이픈) — 형식부터 안 맞으면 fetch 자체 생략. */
+const SLUG_FORMAT = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+export function looksLikeWorkspaceSegment(segment: string | undefined | null): segment is string {
+  if (!segment) return false;
+  if (RESERVED_FIRST_SEGMENTS.has(segment)) return false;
+  return SLUG_FORMAT.test(segment);
+}
+
+export interface ResolvedContext {
+  orgId: string;
+  orgSlug: string;
+  orgRole: string;
+  projectId?: string;
+  projectSlug?: string;
+}
+
+interface ResolveApiResponse {
+  org_id: string;
+  org_slug: string;
+  org_role: string;
+  project_id?: string;
+  project_slug?: string;
+  redirect?: { workspace?: string; project?: string };
+}
+
+export type ResolveOutcome =
+  | { kind: 'ok'; context: ResolvedContext }
+  | { kind: 'redirect'; workspace?: string; project?: string }
+  | { kind: 'not_found' };
+
+function getResolveCacheSecret(): Uint8Array {
+  const secret = process.env['JWT_SECRET'] ?? '';
+  return new TextEncoder().encode(secret);
+}
+
+/**
+ * 캐시 쿠키 서명 — resolve 응답을 HttpOnly JWT 로 감싸 위조 불가+만료(exp) 자연 처리(proxy.ts
+ * 기존 sp_at/sp_rt 와 동일 JWT_SECRET 재사용 — 신규 시크릿 프로비저닝 불요).
+ *
+ * ⚠️보안 경계(PO 승인 확定 — 회귀 방지 고정): 이 쿠키의 org_role 은 **UX 라우팅 힌트일 뿐 권한
+ * 판단이 아니다.** BE mutation 은 여전히 x-project-id/x-org-id 헤더를 서버측에서 독립
+ * 재검증한다 — 이 캐시가 위조/오염돼도 실 데이터 변경은 막힌다. TTL(50s) 중 접근권이 회수돼도
+ * UX 라우팅만 최대 50s 지연 반영·실 데이터는 BE 서버검증이 즉시 차단하므로 안전(디디
+ * 30~60s 판단과 정합, PO 승인 트레이드오프).
+ */
+export async function signResolveCache(
+  wsSlug: string,
+  projSlug: string | undefined,
+  context: ResolvedContext,
+): Promise<string> {
+  return new SignJWT({ wsSlug, projSlug: projSlug ?? null, ...context })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime(`${RESOLVE_CACHE_TTL_SECONDS}s`)
+    .sign(getResolveCacheSecret());
+}
+
+/** 캐시 쿠키 검증 — 서명·만료·요청 slug 일치(URL이 바뀌었으면 캐시 무효) 전부 통과해야 hit. */
+export async function verifyResolveCache(
+  token: string,
+  wsSlug: string,
+  projSlug: string | undefined,
+): Promise<ResolvedContext | null> {
+  try {
+    const { payload } = await jwtVerify(token, getResolveCacheSecret());
+    if (payload['wsSlug'] !== wsSlug) return null;
+    if ((payload['projSlug'] ?? null) !== (projSlug ?? null)) return null;
+    const { orgId, orgSlug, orgRole, projectId, projectSlug } = payload;
+    if (typeof orgId !== 'string' || typeof orgSlug !== 'string' || typeof orgRole !== 'string') return null;
+    return {
+      orgId,
+      orgSlug,
+      orgRole,
+      ...(typeof projectId === 'string' ? { projectId } : {}),
+      ...(typeof projectSlug === 'string' ? { projectSlug } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * BE 단일 resolve 엔드포인트 호출(story ddac96fd) — 캐시 미스일 때만. `redirect` 필드는 raw
+ * HTTP 301 이 아니라 JSON 필드(BE 의도적 설계 — fetch() 호출 미들웨어 입장에서 조건 없는 301은
+ * 왕복 낭비) — 이 함수가 그 필드를 그대로 outcome 으로 승격해, 호출부(proxy.ts)가 자체 301을
+ * 낸다.
+ */
+export async function fetchResolve(
+  fastapiUrl: string,
+  wsSlug: string,
+  projSlug: string | undefined,
+  accessToken: string,
+): Promise<ResolveOutcome> {
+  const params = new URLSearchParams({ workspace: wsSlug });
+  if (projSlug) params.set('project', projSlug);
+  try {
+    const res = await fetch(`${fastapiUrl}/api/v2/resolve?${params.toString()}`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    if (!res.ok) return { kind: 'not_found' };
+    const json = await res.json() as ResolveApiResponse;
+    if (json.redirect) {
+      return { kind: 'redirect', workspace: json.redirect.workspace, project: json.redirect.project };
+    }
+    return {
+      kind: 'ok',
+      context: {
+        orgId: json.org_id,
+        orgSlug: json.org_slug,
+        orgRole: json.org_role,
+        ...(json.project_id ? { projectId: json.project_id } : {}),
+        ...(json.project_slug ? { projectSlug: json.project_slug } : {}),
+      },
+    };
+  } catch {
+    return { kind: 'not_found' };
+  }
+}

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -140,3 +140,73 @@ describe('proxy', () => {
     expect(response.status).toBe(403);
   });
 });
+
+describe('proxy — resolve (story a539c649 S-route-project S1)', () => {
+  beforeEach(() => {
+    process.env['JWT_SECRET'] = JWT_SECRET;
+    process.env['NEXT_PUBLIC_FASTAPI_URL'] = 'http://localhost:8000';
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    delete process.env['JWT_SECRET'];
+  });
+
+  it('reserved 첫 세그먼트(현존 flat 라우트)는 resolve fetch 자체를 시도 안 함 — 회귀 0 핵심 증명', async () => {
+    const token = await makeAccessToken();
+    const response = await middleware(makeRequest('/dashboard', { sp_at: token }));
+    expect(response.status).toBe(200);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('실 ws slug(reserved 아님) 진입 시 resolve 성공 → 200 + sp_resolve_cache 쿠키 세팅', async () => {
+    const token = await makeAccessToken();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ org_id: 'org-1', org_slug: 'moonklabs', org_role: 'admin', project_id: 'proj-1', project_slug: 'sprintable' }),
+    });
+    const response = await middleware(makeRequest('/moonklabs/sprintable/board', { sp_at: token }));
+    expect(response.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v2/resolve?workspace=moonklabs&project=sprintable'),
+      expect.any(Object),
+    );
+    const setCookie = response.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain('sp_resolve_cache=');
+  });
+
+  it('resolve 실패(미존재/미소속) → 개입 없이 통과(200) — Next 자체 404 렌더에 위임', async () => {
+    const token = await makeAccessToken();
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404, json: async () => ({}) });
+    const response = await middleware(makeRequest('/ghost-workspace/proj/board', { sp_at: token }));
+    expect(response.status).toBe(200);
+    const setCookie = response.headers.get('set-cookie') ?? '';
+    expect(setCookie).not.toContain('sp_resolve_cache=');
+  });
+
+  it('옛 slug(rename 이력) → BE redirect 필드를 미들웨어가 자체 301로 승격', async () => {
+    const token = await makeAccessToken();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ org_id: 'org-1', org_slug: 'new-moonklabs', org_role: 'admin', redirect: { workspace: 'new-moonklabs' } }),
+    });
+    const response = await middleware(makeRequest('/old-moonklabs/board', { sp_at: token }));
+    expect(response.status).toBe(301);
+    expect(response.headers.get('location')).toBe('https://app.example.com/new-moonklabs/board');
+  });
+
+  it('캐시 hit(유효 sp_resolve_cache 쿠키+동일 slug) → resolve fetch 생략', async () => {
+    const token = await makeAccessToken();
+    const cacheToken = await new SignJWT({
+      wsSlug: 'moonklabs', projSlug: null,
+      orgId: 'org-1', orgSlug: 'moonklabs', orgRole: 'admin',
+    })
+      .setProtectedHeader({ alg: 'HS256' })
+      .setIssuedAt()
+      .setExpirationTime('50s')
+      .sign(new TextEncoder().encode(JWT_SECRET));
+    const response = await middleware(makeRequest('/moonklabs/board', { sp_at: token, sp_resolve_cache: cacheToken }));
+    expect(response.status).toBe(200);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -3,6 +3,14 @@ import { NextResponse, type NextRequest } from 'next/server';
 import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 import { SESSION_EXPIRED_REASON } from '@/lib/auth/session-redirect';
 import { isRecentlySuperseded } from '@/lib/auth/switch-epoch';
+import {
+  fetchResolve,
+  looksLikeWorkspaceSegment,
+  RESOLVE_CACHE_TTL_SECONDS,
+  signResolveCache,
+  SP_RESOLVE_CACHE_COOKIE,
+  verifyResolveCache,
+} from '@/lib/route-resolve';
 
 const PUBLIC_EXACT = [
   '/',
@@ -230,7 +238,18 @@ export async function proxy(request: NextRequest) {
   const now = Math.floor(Date.now() / 1000);
   const fwdHeaders = new Headers(request.headers);
   fwdHeaders.set('x-pathname', pathname + request.nextUrl.search);
+
+  // story a539c649(S-route-project) S1 — path 위계 resolve. fwdHeaders 를 response 구성 *전에*
+  // 채워야 downstream RSC/route handler 가 x-resolved-* 를 실제로 읽을 수 있다(x-pathname 과
+  // 동일 관례 — response.headers.set 은 브라우저행 응답 헤더일 뿐 forwarded request 에 안 실림).
+  const resolved = await resolveWorkspaceProject(request, pathname, accessToken, fwdHeaders);
+  if (resolved.kind === 'redirect') return resolved.response;
+
   const response = NextResponse.next({ request: { headers: fwdHeaders } });
+  if (resolved.kind === 'set-cache') {
+    response.cookies.set(SP_RESOLVE_CACHE_COOKIE, resolved.token, { ...cookieBase(), maxAge: RESOLVE_CACHE_TTL_SECONDS });
+  }
+
   if (claims.exp !== undefined && claims.exp - now < 300) {
     const tokens = await singleFlightRefresh(request);
     // RC2: stale refresh(다른 계정)면 적용 안 함 — 현 active 세션 유지.
@@ -246,6 +265,65 @@ export async function proxy(request: NextRequest) {
   }
 
   return response;
+}
+
+type ResolveWiringResult =
+  | { kind: 'skip' }
+  | { kind: 'set-cache'; token: string }
+  | { kind: 'redirect'; response: NextResponse };
+
+/**
+ * story a539c649(S-route-project) S1 — `/{ws}/{proj}/...` path 위계 resolve. RESERVED_FIRST_
+ * SEGMENTS 와 안 겹치는 첫 세그먼트에만 시도해 기존 flat 라우트 전부 무회귀 통과시킨다(오르테가군
+ * 확定 스코프). flat→path 301 은 여기서 안 켠다 — 목적지 페이지가 아직 없어(S2/S3 몫) 걸면 즉시
+ * 404. S1 은 미들웨어 단(캐시 hit/miss·resolve 성공/실패·구 slug 301-chase)만 증명한다.
+ *
+ * `fwdHeaders` 를 직접 mutate 해 downstream 으로 x-resolved-* 를 실어 보낸다(캐시 hit 이어도
+ * 매 요청 동일하게 — 헤더가 fetch 왕복에 안 걸리므로 hit/miss 무관 항상 채운다).
+ */
+async function resolveWorkspaceProject(
+  request: NextRequest,
+  pathname: string,
+  accessToken: string,
+  fwdHeaders: Headers,
+): Promise<ResolveWiringResult> {
+  const segments = pathname.split('/').filter(Boolean);
+  const wsSlug = segments[0];
+  if (!looksLikeWorkspaceSegment(wsSlug)) return { kind: 'skip' };
+  const projSlug = looksLikeWorkspaceSegment(segments[1]) ? segments[1] : undefined;
+
+  const cached = request.cookies.get(SP_RESOLVE_CACHE_COOKIE)?.value;
+  if (cached) {
+    const hit = await verifyResolveCache(cached, wsSlug, projSlug);
+    if (hit) {
+      setResolvedHeaders(fwdHeaders, hit);
+      return { kind: 'skip' }; // 캐시 hit — fetch 생략, 쿠키 재설정 불요(아직 유효)
+    }
+  }
+
+  const fastapiUrl = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+  const outcome = await fetchResolve(fastapiUrl, wsSlug, projSlug, accessToken);
+
+  if (outcome.kind === 'not_found') return { kind: 'skip' }; // resolve 실패 — 개입 없이 통과(Next 자체 404)
+
+  if (outcome.kind === 'redirect') {
+    const url = request.nextUrl.clone();
+    const nextSegments = [...segments];
+    if (outcome.workspace) nextSegments[0] = outcome.workspace;
+    if (outcome.project && nextSegments.length > 1) nextSegments[1] = outcome.project;
+    url.pathname = '/' + nextSegments.join('/');
+    return { kind: 'redirect', response: NextResponse.redirect(url, 301) };
+  }
+
+  setResolvedHeaders(fwdHeaders, outcome.context);
+  const token = await signResolveCache(wsSlug, projSlug, outcome.context);
+  return { kind: 'set-cache', token };
+}
+
+function setResolvedHeaders(fwdHeaders: Headers, context: { orgId: string; orgRole: string; projectId?: string }): void {
+  fwdHeaders.set('x-resolved-org-id', context.orgId);
+  fwdHeaders.set('x-resolved-org-role', context.orgRole);
+  if (context.projectId) fwdHeaders.set('x-resolved-project-id', context.projectId);
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- doc `org-1st-class-surface-ia-design-b` §2b·§2e-3 — S-route-project 3단 슬라이스 중 S1(미들웨어 인프라).
- 디디 resolve 엔드포인트(story ddac96fd, `GET /api/v2/resolve?workspace=&project=`) 소비.
- **스코프(착수 전 오르테가군 승인)**: `/{ws}/{proj}/{resource}` 페이지는 아직 없음(S2 docs·S3 나머지 몫). resolve 활성화는 `RESERVED_FIRST_SEGMENTS`(현존 flat 라우트 전부)와 안 겹치는 첫 세그먼트에만 국한 — 전면 오인매치 장애 방지(회귀 0 핵심). flat→path 301은 S1서 안 킴(목적지 없어 걸면 즉시 404).
- `route-resolve.ts`(신규): reserved 가드·JWT 서명 캐시쿠키(jose, 기존 JWT_SECRET 재사용)·resolve 호출+redirect 필드 승격.
- `proxy.ts`: resolve 성공 시 `x-resolved-org-id`/`-org-role`/`-project-id`를 forwarded request 헤더에 주입(x-pathname과 동일 관례).
- **보안 경계(PO 승인 고정)**: 캐시 쿠키의 role은 UX 라우팅 힌트일 뿐 — BE mutation은 여전히 `x-project-id`/`x-org-id` 서버 재검증. TTL(50s) 중 접근권 회수 지연은 UX만 영향, 실 데이터는 즉시 차단.
- "역할"→"권한" 라벨 4곳(nav.orgRoles·organization.rolesTitle, ko/en) 동승.

## Test plan
- [x] tsc --noEmit clean
- [x] eslint clean(무관 사전경고 3건 제외)
- [x] vitest apps/web — 231 files, 1497 passed(신규 17건: route-resolve 단위 12건+proxy 통합 5건)
- [x] vitest root — 247 files, 1671 passed
- [x] next build EXIT=0
- [x] 핵심 회귀가드 뮤테이션 셀프체크(reserved-segment guard 제거→RED 확인→원복)
- [ ] 배포 후 라이브 #12 왕복: 실 ws slug 진입(resolve+캐시 동작·최종 렌더는 Next 기본 404)·미존재 ws 404·구 slug 301·기존 flat 라우트 전부 무회귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)