### PR TITLE
🚨 fix(auth): story e5225c0a(P0) — prod 로그인 풀림 근본 fix

### DIFF
--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -95,6 +95,45 @@ describe('proxy', () => {
     expect(loc).toContain('reason=session_expired');
   });
 
+  it('clears sp_at/sp_rt cookies on definitive refresh failure — UI path (story e5225c0a P0)', async () => {
+    // 산티아고 실측: refresh 실패 시 쿠키를 안 지워 30일 sp_rt 가 401 무한 재생산. 이 테스트는
+    // 그 정확한 실패 모드를 재현하고 수정을 고정한다.
+    mockFetch.mockResolvedValue({ ok: false, json: async () => ({ error: { code: 'TOKEN_REVOKED' } }) });
+    const response = await middleware(makeRequest('/dashboard', { sp_rt: 'stale-rt-ui' }));
+    expect(response.status).toBe(307);
+    const setCookie = response.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain('sp_rt=;');
+    expect(setCookie).toContain('sp_at=;');
+  });
+
+  it('clears sp_at/sp_rt cookies on definitive refresh failure — API path (story e5225c0a P0)', async () => {
+    mockFetch.mockResolvedValue({ ok: false, json: async () => ({ error: { code: 'TOKEN_REVOKED' } }) });
+    const response = await middleware(makeRequest('/api/notifications', { sp_rt: 'stale-rt-api' }));
+    expect(response.status).toBe(200); // handler 가 401 반환하도록 통과
+    const setCookie = response.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain('sp_rt=;');
+    expect(setCookie).toContain('sp_at=;');
+  });
+
+  it('does NOT clear cookies when refresh succeeds but is suppressed for a different active account (RC2 regression guard)', async () => {
+    // refreshMatchesActive=false 는 refresh 자체가 실패한 게 아니라(다른 계정의 늦은 refresh를
+    // 의도적으로 무시하는 것) — clearAuthCookies 를 호출하면 안 된다. sp_active_account 포인터를
+    // 새 토큰의 sub('user-123')와 다르게 둬서 이 분기를 트리거.
+    const now = Math.floor(Date.now() / 1000);
+    const newAt = await makeAccessToken({ exp: now + 900 });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { access_token: newAt, refresh_token: 'new-rt' } }),
+    });
+    const response = await middleware(
+      makeRequest('/dashboard', { sp_rt: 'rc2-suppressed-rt', sp_active_account: 'someone-else' }),
+    );
+    expect(response.status).toBe(307); // 이 요청 자체는 여전히 미인증(다른 계정) — 로그인 리다이렉트
+    const setCookie = response.headers.get('set-cookie') ?? '';
+    expect(setCookie).not.toContain('sp_rt=;');
+    expect(setCookie).not.toContain('sp_at=;');
+  });
+
   it('allows access with valid sp_at cookie', async () => {
     const token = await makeAccessToken();
     const response = await middleware(makeRequest('/dashboard', { sp_at: token }));

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -194,6 +194,16 @@ function applyTokenCookies(
   response.cookies.set(SP_RT_COOKIE, refreshToken, { ...base, maxAge: 30 * 24 * 60 * 60 });
 }
 
+// story e5225c0a(P0): refresh 최종 실패(BE 가 401 반환·rotation 실패) 시 sp_at/sp_rt 를 지운다.
+// 안 지우면 30일 sp_rt 쿠키가 매 요청마다 실패한 refresh 를 재시도해 401 무한 재생산(산티아고
+// prod 로그 실측: /auth/refresh 239건 중 230건 401). RC2(refreshMatchesActive=false, 다른/
+// superseded 계정의 late refresh 억제)와는 다른 경우 — 그건 refresh 자체는 성공했으므로
+// 쿠키를 유지해야 한다(clearAuthCookies 를 이 경우엔 호출하지 않음).
+function clearAuthCookies(response: NextResponse): void {
+  response.cookies.delete(SP_AT_COOKIE);
+  response.cookies.delete(SP_RT_COOKIE);
+}
+
 /** Rebuild request headers with updated sp_at/sp_rt so route handlers see fresh tokens */
 function buildRefreshedHeaders(
   request: NextRequest,
@@ -218,6 +228,16 @@ function loginRedirect(request: NextRequest): NextResponse {
   url.searchParams.set('next', nextTarget); // searchParams.set 이 encode
   url.searchParams.set('reason', SESSION_EXPIRED_REASON);
   return NextResponse.redirect(url);
+}
+
+// story e5225c0a(P0): refresh 시도 후 세션을 못 살렸을 때의 공통 응답. `refreshFailed`=true
+// (singleFlightRefresh 자체가 null — BE 401/rotation 실패)일 때만 clearAuthCookies 호출.
+// refreshMatchesActive=false(RC2, superseded 계정의 늦은 refresh)는 refresh 자체는 성공이므로
+// 쿠키를 그대로 둔다 — 두 실패 사유를 여기서 한 번만 구분해 양쪽 호출부의 분기를 통일한다.
+function handleUnauthenticated(request: NextRequest, isApiPath: boolean, refreshFailed: boolean): NextResponse {
+  const response = isApiPath ? NextResponse.next({ request }) : loginRedirect(request);
+  if (refreshFailed) clearAuthCookies(response);
+  return response;
 }
 
 export async function proxy(request: NextRequest) {
@@ -247,10 +267,10 @@ export async function proxy(request: NextRequest) {
 
   if (!accessToken) {
     const tokens = await singleFlightRefresh(request);
-    // RC2: stale refresh(다른 계정)면 적용 안 함 — 잘못된 계정으로 복귀 방지.
-    if (!tokens || !(await refreshMatchesActive(request, tokens.accessToken))) {
-      if (isApiPath) return NextResponse.next({ request }); // let handler return 401
-      return loginRedirect(request);
+    if (!tokens) return handleUnauthenticated(request, isApiPath, true);
+    // RC2: stale refresh(다른 계정)면 적용 안 함 — 잘못된 계정으로 복귀 방지(쿠키는 유지).
+    if (!(await refreshMatchesActive(request, tokens.accessToken))) {
+      return handleUnauthenticated(request, isApiPath, false);
     }
     const headers = buildRefreshedHeaders(request, tokens);
     const response = NextResponse.next({ request: { headers } });
@@ -263,10 +283,10 @@ export async function proxy(request: NextRequest) {
   if (!claims) {
     // access token invalid/expired — try refresh
     const tokens = await singleFlightRefresh(request);
-    // RC2: stale refresh(다른 계정)면 적용 안 함 — 잘못된 계정으로 복귀 방지.
-    if (!tokens || !(await refreshMatchesActive(request, tokens.accessToken))) {
-      if (isApiPath) return NextResponse.next({ request }); // let handler return 401
-      return loginRedirect(request);
+    if (!tokens) return handleUnauthenticated(request, isApiPath, true);
+    // RC2: stale refresh(다른 계정)면 적용 안 함 — 잘못된 계정으로 복귀 방지(쿠키는 유지).
+    if (!(await refreshMatchesActive(request, tokens.accessToken))) {
+      return handleUnauthenticated(request, isApiPath, false);
     }
     const headers = buildRefreshedHeaders(request, tokens);
     const response = NextResponse.next({ request: { headers } });

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -748,34 +748,42 @@ async def refresh_token(
     try:
         payload = decode_jwt(body.refresh_token)
     except JWTError:
+        logger.warning("auth.refresh 실패 reason=invalid_jwt")
         return _err("INVALID_TOKEN", "Invalid refresh token", 401)
 
     if payload.get("type") != "refresh":
+        logger.warning("auth.refresh 실패 reason=not_refresh_type sub=%s", payload.get("sub"))
         return _err("INVALID_TOKEN", "Not a refresh token", 401)
 
     token_hash = hash_token(body.refresh_token)
-    result = await session.execute(
-        select(RefreshToken).where(
+    correlation_key = token_hash[:12]  # story e5225c0a: 산티아고 관측성 요구 — 로그 상관키(PII 아님)
+
+    # ⚠️story e5225c0a(P0): switch_account(위)와 동형의 원자 rotation. 기존 SELECT→별도 UPDATE는
+    # 비원자라 Cloud Run 멀티 인스턴스 간 동시 refresh가 둘 다 "아직 안 revoke"로 통과하는 race의
+    # 근본 원인이었다(산티아고 prod 로그 실측: /auth/refresh 239건 중 230건 401). 검증+revoke를
+    # 단일 UPDATE...WHERE revoked_at IS NULL...RETURNING으로 묶어 동시 요청 중 정확히 1건만 매치.
+    revoked_user_id = (await session.execute(
+        update(RefreshToken)
+        .where(
             RefreshToken.token_hash == token_hash,
             RefreshToken.revoked_at.is_(None),
             RefreshToken.expires_at > datetime.now(timezone.utc),
         )
-    )
-    stored = result.scalar_one_or_none()
-    if not stored:
+        .values(revoked_at=datetime.now(timezone.utc))
+        .returning(RefreshToken.user_id)
+    )).scalar_one_or_none()
+    if revoked_user_id is None:
+        logger.warning(
+            "auth.refresh 실패 reason=token_not_found_or_revoked_or_expired key=%s", correlation_key,
+        )
         return _err("TOKEN_REVOKED", "Refresh token revoked or expired", 401)
 
-    user_id = uuid.UUID(payload["sub"])
-    user = await _get_user_by_id(session, user_id)
+    user = await _get_user_by_id(session, revoked_user_id)
     if not user:
+        logger.warning(
+            "auth.refresh 실패 reason=user_not_found key=%s user_id=%s", correlation_key, revoked_user_id,
+        )
         return _err("USER_NOT_FOUND", "User not found", 401)
-
-    # 기존 토큰 무효화 (rotation)
-    await session.execute(
-        update(RefreshToken)
-        .where(RefreshToken.token_hash == token_hash)
-        .values(revoked_at=datetime.now(timezone.utc))
-    )
 
     _md = await _build_app_metadata(user, session)
     if settings.build_app_metadata_defallback:

--- a/backend/tests/test_e5225c0a_refresh_atomic_realdb.py
+++ b/backend/tests/test_e5225c0a_refresh_atomic_realdb.py
@@ -1,0 +1,213 @@
+"""story e5225c0a(P0): prod 로그인 풀림 근본 fix — /auth/refresh 원자화 realdb 게이트.
+
+산티아고 실측: SELECT→UPDATE 비원자 rotation이 Cloud Run 멀티 인스턴스 간 race를 유발해
+/auth/refresh 239건 중 230건 401(30일 sp_rt 쿠키가 실패를 무한 재생산). 이 테스트는 동일
+refresh_token으로 동시 2요청을 쏴 정확히 1건만 성공(switch_account 선례와 동형 single-use
+원자 rotation)함을 라이브 PG로 실증한다.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _client_for(app):
+    from httpx import AsyncClient, ASGITransport
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def _seed_user_with_refresh_token(session):
+    from app.core.security import create_refresh_token, hash_token, hash_password
+    from app.models.user import RefreshToken, User
+
+    user_id = uuid.uuid4()
+    user = User(
+        id=user_id, email=f"e5225c0a-{user_id.hex[:8]}@test.com",
+        hashed_password=hash_password("x"), is_active=True, email_verified=True,
+    )
+    session.add(user)
+    await session.commit()
+
+    raw_refresh, exp = create_refresh_token(str(user_id))
+    session.add(RefreshToken(
+        id=uuid.uuid4(), user_id=user_id, token_hash=hash_token(raw_refresh),
+        expires_at=exp, revoked_at=None,
+    ))
+    await session.commit()
+
+    return {"user_id": user_id, "raw_refresh": raw_refresh}
+
+
+async def _setup_app(app, Session):
+    from app.dependencies.database import get_db
+
+    async def _db():
+        async with Session() as s:
+            try:
+                yield s
+                await s.commit()
+            except Exception:
+                await s.rollback()
+                raise
+
+    app.dependency_overrides[get_db] = _db
+
+
+@pytest.mark.anyio
+async def test_concurrent_refresh_same_token_exactly_one_succeeds_realdb():
+    """까심 race 재현: 동일 refresh_token으로 동시 2요청 → 정확히 1건 200, 1건 401(TOKEN_REVOKED)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_user_with_refresh_token(s)
+
+        await _setup_app(app, Session)
+        client = _client_for(app)
+        try:
+            results = await asyncio.gather(
+                client.post("/api/v2/auth/refresh", json={"refresh_token": seeded["raw_refresh"]}),
+                client.post("/api/v2/auth/refresh", json={"refresh_token": seeded["raw_refresh"]}),
+            )
+            statuses = sorted(r.status_code for r in results)
+            assert statuses == [200, 401], (
+                f"원자성 실패 — 동시 2요청 결과가 [200,401]이 아님: {statuses} "
+                f"(둘 다 200이면 double-spend race 재발)"
+            )
+            failed = next(r for r in results if r.status_code == 401)
+            assert failed.json()["error"]["code"] == "TOKEN_REVOKED"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_refresh_already_revoked_token_401_realdb():
+    """회귀 0: 이미 사용된(revoked) 토큰 재사용 → 401(단발성 rotation 유지 확인)."""
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_user_with_refresh_token(s)
+
+        await _setup_app(app, Session)
+        client = _client_for(app)
+        try:
+            first = await client.post("/api/v2/auth/refresh", json={"refresh_token": seeded["raw_refresh"]})
+            assert first.status_code == 200, first.text
+            second = await client.post("/api/v2/auth/refresh", json={"refresh_token": seeded["raw_refresh"]})
+            assert second.status_code == 401
+            assert second.json()["error"]["code"] == "TOKEN_REVOKED"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_refresh_failure_logs_reason_and_correlation_key_realdb(caplog):
+    """산티아고 관측성 요구(item 3): 실패 시 reason+상관키가 로그에 남는지 실증."""
+    import logging
+    from app.main import app
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed_user_with_refresh_token(s)
+
+        await _setup_app(app, Session)
+        client = _client_for(app)
+        try:
+            first = await client.post("/api/v2/auth/refresh", json={"refresh_token": seeded["raw_refresh"]})
+            assert first.status_code == 200
+
+            with caplog.at_level(logging.WARNING, logger="app.routers.auth"):
+                second = await client.post(
+                    "/api/v2/auth/refresh", json={"refresh_token": seeded["raw_refresh"]},
+                )
+            assert second.status_code == 401
+            assert any(
+                "reason=token_not_found_or_revoked_or_expired" in r.message and "key=" in r.message
+                for r in caplog.records
+            ), f"관측성 로그 누락: {[r.message for r in caplog.records]}"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_refresh_expired_token_401_realdb():
+    from app.main import app
+    from app.core.security import create_refresh_token, hash_token, hash_password
+    from app.models.user import RefreshToken, User
+
+    engine, Session = await _session_factory()
+    try:
+        user_id = uuid.uuid4()
+        async with Session() as s:
+            s.add(User(
+                id=user_id, email=f"e5225c0a-exp-{user_id.hex[:8]}@test.com",
+                hashed_password=hash_password("x"), is_active=True, email_verified=True,
+            ))
+            await s.commit()
+            raw_refresh, _ = create_refresh_token(str(user_id))
+            s.add(RefreshToken(
+                id=uuid.uuid4(), user_id=user_id, token_hash=hash_token(raw_refresh),
+                expires_at=datetime.now(timezone.utc) - timedelta(days=1), revoked_at=None,
+            ))
+            await s.commit()
+
+        await _setup_app(app, Session)
+        client = _client_for(app)
+        try:
+            resp = await client.post("/api/v2/auth/refresh", json={"refresh_token": raw_refresh})
+            assert resp.status_code == 401
+            assert resp.json()["error"]["code"] == "TOKEN_REVOKED"
+        finally:
+            await client.aclose()
+    finally:
+        app.dependency_overrides.clear()
+        await engine.dispose()


### PR DESCRIPTION
## Summary — P0, 실사용자 영향
- 산티아고 prod 로그 실측: `/auth/refresh` 239건 중 **230건 401** — refresh 실패 시 API는 통과시키면서 `sp_rt`/`sp_at` 쿠키를 안 지워 30일 쿠키가 401을 무한 재생산. 최초 트리거는 비원자 SELECT→UPDATE rotation의 Cloud Run 인스턴스 간 race.

### fix 1(FE, `apps/web/src/proxy.ts`)
refresh 최종 실패(BE 401/rotation 실패) 시에만 `sp_at`/`sp_rt` 쿠키 삭제. RC2(`refreshMatchesActive=false` — superseded 계정의 늦은 refresh 억제)는 refresh 자체가 성공이므로 쿠키를 유지 — 두 실패 사유를 `handleUnauthenticated()`로 통합해 명시적으로 구분.

### fix 2(BE, `app/routers/auth.py::refresh_token`)
`switch_account`(같은 파일, 이미 원자 rotation 선례)와 동형으로 SELECT+별도UPDATE를 단일 `UPDATE...WHERE revoked_at IS NULL...RETURNING`으로 원자화. 동시 요청 중 정확히 1건만 매치(까심 TOCTOU 제거).

### fix 3(BE, 관측성)
4개 실패 분기(`invalid_jwt`/`not_refresh_type`/`token_not_found_or_revoked_or_expired`/`user_not_found`) 각각에 reason+correlation_key(token_hash 앞 12자, PII 아님) 로깅 추가 — 산티아고 필수 요구.

⚠️ 산티아고 doc의 마이그/구현비용 질문 6건(Firebase 전환 판단 재료)은 이 P0 fix 범위 밖 — 별도 후속.

## Test plan
- [x] BE realdb 4건(`test_e5225c0a_refresh_atomic_realdb.py`, 라이브 PG): 동시 2요청 정확히 `[200,401]`(double-spend 아님) — **원자화 fix를 임시로 원복해 실측 `[200,200]` double-spend 재현까지 확인한 뒤 원복**, 이미-revoked 토큰 재사용 401, 만료 토큰 401, 실패 시 로그(reason+key) 검증
- [x] FE 신규 3건(`proxy.test.ts`): UI/API 경로 각각 쿠키 삭제 확인 + RC2 회귀 가드(쿠키 유지 확인)
- [x] 뮤테이션 셀프체크: FE 쿠키클리어 조건 무력화(2건 정확히 RED)+항상클리어(RC2 가드 1건 정확히 RED), BE 원자화 원복(더블스펜드 재현 — 위 참고), 모두 원복 후 clean
- [x] BE 관련 스위트(`test_c_s1`/`test_auth_11`/switch 계열) 53 passed 무회귀
- [x] BE 전체 스위트(`-m "not destructive_schema"`): 3262 passed / 7 failed(develop 기준선과 동일 재현되는 환경 의존 사전 실패뿐, 이전 PR들에서 이미 확인된 동일 실패군 — 본 PR과 무관)
- [x] FE 전체 스위트(vitest): 1456 passed / 4개 파일 import 실패(pre-existing `html2canvas-pro` 미설치 — canvas/artifact 기능, auth와 무관 확인)

## 배포 흐름
셀프 게이트(완료, 위)→까심 QA→PO 머지→**prod 승격은 선생님 GO 필요**(P0이지만 prod 배포는 별도 승인 게이트).

🤖 Generated with [Claude Code](https://claude.com/claude-code)