### PR TITLE
🚨 fix(auth): story e5225c0a(P0) 재진단 — /api/auth/refresh route.ts 쿠키 미삭제 갭

### DIFF
--- a/apps/web/src/app/api/auth/refresh/route.test.ts
+++ b/apps/web/src/app/api/auth/refresh/route.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// story e5225c0a(P0) 재진단: 이 route는 proxy.ts PUBLIC_PREFIX('/api/auth/')라 미들웨어의
+// stale-cookie cleanup을 안 거친다 — 별도 실패 경로에서 쿠키를 지우는지 직접 검증.
+const h = vi.hoisted(() => ({
+  cookieGet: vi.fn(),
+  csrfCheck: vi.fn(),
+}));
+vi.mock('@/lib/auth/csrf', () => ({ verifyCsrfOrigin: h.csrfCheck }));
+vi.mock('next/headers', () => ({ cookies: vi.fn(async () => ({ get: h.cookieGet })) }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { POST } from './route';
+
+function makeRequest(): Request {
+  return new Request('http://localhost/api/auth/refresh', { method: 'POST', body: '{}' });
+}
+
+describe('POST /api/auth/refresh', () => {
+  beforeEach(() => {
+    h.cookieGet.mockReset();
+    h.csrfCheck.mockReset().mockReturnValue(null); // CSRF 통과
+    mockFetch.mockReset();
+    h.cookieGet.mockImplementation((name: string) => (name === 'sp_rt' ? { value: 'stale-rt' } : undefined));
+  });
+
+  it('no refresh token cookie → 401, no fastapi call', async () => {
+    h.cookieGet.mockReturnValue(undefined);
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(401);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('BE refresh 성공 → 200 + sp_at/sp_rt 신규 값 set', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { access_token: 'new-at', refresh_token: 'new-rt' } }),
+    });
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain('sp_at=new-at');
+    expect(setCookie).toContain('sp_rt=new-rt');
+  });
+
+  it('BE refresh 실패(401) → sp_at/sp_rt 쿠키 삭제(무한 재생산 차단 — 핵심 회귀 가드)', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: { code: 'TOKEN_REVOKED', message: 'revoked' } }),
+    });
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(401);
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain('sp_at=;');
+    expect(setCookie).toContain('sp_rt=;');
+  });
+});

--- a/apps/web/src/app/api/auth/refresh/route.ts
+++ b/apps/web/src/app/api/auth/refresh/route.ts
@@ -25,7 +25,18 @@ export async function POST(request: Request) {
 
   const json = await fastapiRes.json() as { data?: { access_token: string; refresh_token: string }; error?: { code: string; message: string } };
   if (!fastapiRes.ok || !json.data) {
-    return NextResponse.json({ error: json.error ?? { code: 'REFRESH_FAILED', message: 'Token refresh failed' } }, { status: fastapiRes.status });
+    // story e5225c0a(P0) 재진단: 이 route는 PUBLIC_PREFIX('/api/auth/')라 proxy.ts 미들웨어의
+    // stale-cookie cleanup을 안 거친다 — 별도 실패 경로라 여기서도 동일하게 지워야 한다. 안 지우면
+    // 클라이언트 401-인터셉터(fetchWithAuth)가 폴링 컴포넌트(예: dashboard-activity-timeline.tsx
+    // 60s 간격)가 재요청할 때마다 이 route를 다시 때려 죽은 sp_rt로 무한 재시도(산티아고 prod 실측:
+    // b0b55886 배포 후에도 /auth/refresh 401이 09:03~09:13 60s 간격 지속 — proxy.ts fix만으론 갭).
+    const res = NextResponse.json(
+      { error: json.error ?? { code: 'REFRESH_FAILED', message: 'Token refresh failed' } },
+      { status: fastapiRes.status },
+    );
+    res.cookies.delete(SP_AT_COOKIE);
+    res.cookies.delete(SP_RT_COOKIE);
+    return res;
   }
 
   const { access_token, refresh_token } = json.data;


### PR DESCRIPTION
## Summary — P0 재진단(#2181 배포 후에도 401 무한반복 지속)
산티아고 prod 재실측: PR #2181(b0b55886) 배포 후에도 `/auth/refresh` 401이 09:03~09:13 **60초 간격**으로 계속. `userAgent=node`·`IP=Cloud Run FE 대역` — FE 서버가 backend를 호출하는 경로.

### 근본 원인
#2181의 stale-cookie cleanup은 `proxy.ts`(Edge 미들웨어) 내부 refresh 로직만 고쳤다. 그런데 `apps/web/src/app/api/auth/refresh/route.ts`는 `proxy.ts`의 `PUBLIC_PREFIX`(`/api/auth/` — 인증 엔드포인트 자체라 열려있어야 하므로 **설계상 올바름**)에 걸려 **미들웨어를 아예 거치지 않는다**. 이건 완전히 별도의 독립 실패 경로였고, 여기엔 쿠키 삭제 로직이 처음부터 없었다.

### 재생 경로(실측 근거)
1. 브라우저의 `dashboard-activity-timeline.tsx`(`POLL_INTERVAL = 60_000` — 관측된 60초 주기와 정확히 일치)가 60초마다 폴링
2. `fetchWithAuth`의 401 인터셉터가 `refreshAuthTokens()` 호출 → `POST /api/auth/refresh`(이 route.ts)
3. BE가 401(토큰 이미 죽음) 반환
4. **route.ts가 쿠키를 안 지움** → 다음 60초 폴링에 동일한 죽은 `sp_rt`로 재시도 → 무한 반복

### fix
이 route도 refresh 실패 시 `sp_at`/`sp_rt`를 `proxy.ts`와 동형으로 삭제.

`switch-account/route.ts`도 대조 확인 — 그건 계정 전환 실패 시 **현재(전환 안 한) 세션은 그대로 유효**해야 하므로 쿠키를 유지하는 게 맞는 설계(동일 버그 아님, 확인만 하고 무변경).

## Test plan
- [x] 신규 3건(`route.test.ts`): 토큰 없음 → 401(BE 호출 없음), 성공 시 신규 토큰 set, **실패 시 쿠키 삭제 확인(핵심 회귀 가드)**
- [x] 뮤테이션 자가검증: 삭제 로직 무력화 → 해당 1건만 정확히 RED, 원복 확인
- [x] FE 전체 스위트(vitest): 1467 passed(기존 `html2canvas-pro` 미설치로 인한 무관 4파일 제외 — canvas/artifact 기능, auth와 무관)

## 배포 흐름
P0 계속 — 이 fix가 머지·prod 승격되어야 401 무한반복이 실제로 소멸한다(#2181만으론 갭 있었음, "배포=done" 아니라 "401 반복 실제 소멸"이 done-gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)