### PR TITLE
[PROD] P0 로그인 풀림 근본 봉합 (route.ts 갭·#2185 cherry-pick)

### DIFF
--- a/apps/web/src/app/api/auth/refresh/route.test.ts
+++ b/apps/web/src/app/api/auth/refresh/route.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// story e5225c0a(P0) 재진단: 이 route는 proxy.ts PUBLIC_PREFIX('/api/auth/')라 미들웨어의
+// stale-cookie cleanup을 안 거친다 — 별도 실패 경로에서 쿠키를 지우는지 직접 검증.
+const h = vi.hoisted(() => ({
+  cookieGet: vi.fn(),
+  csrfCheck: vi.fn(),
+}));
+vi.mock('@/lib/auth/csrf', () => ({ verifyCsrfOrigin: h.csrfCheck }));
+vi.mock('next/headers', () => ({ cookies: vi.fn(async () => ({ get: h.cookieGet })) }));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { POST } from './route';
+
+function makeRequest(): Request {
+  return new Request('http://localhost/api/auth/refresh', { method: 'POST', body: '{}' });
+}
+
+describe('POST /api/auth/refresh', () => {
+  beforeEach(() => {
+    h.cookieGet.mockReset();
+    h.csrfCheck.mockReset().mockReturnValue(null); // CSRF 통과
+    mockFetch.mockReset();
+    h.cookieGet.mockImplementation((name: string) => (name === 'sp_rt' ? { value: 'stale-rt' } : undefined));
+  });
+
+  it('no refresh token cookie → 401, no fastapi call', async () => {
+    h.cookieGet.mockReturnValue(undefined);
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(401);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('BE refresh 성공 → 200 + sp_at/sp_rt 신규 값 set', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { access_token: 'new-at', refresh_token: 'new-rt' } }),
+    });
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain('sp_at=new-at');
+    expect(setCookie).toContain('sp_rt=new-rt');
+  });
+
+  it('BE refresh 실패(401) → sp_at/sp_rt 쿠키 삭제(무한 재생산 차단 — 핵심 회귀 가드)', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: { code: 'TOKEN_REVOKED', message: 'revoked' } }),
+    });
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(401);
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain('sp_at=;');
+    expect(setCookie).toContain('sp_rt=;');
+  });
+});

--- a/apps/web/src/app/api/auth/refresh/route.ts
+++ b/apps/web/src/app/api/auth/refresh/route.ts
@@ -25,7 +25,18 @@ export async function POST(request: Request) {
 
   const json = await fastapiRes.json() as { data?: { access_token: string; refresh_token: string }; error?: { code: string; message: string } };
   if (!fastapiRes.ok || !json.data) {
-    return NextResponse.json({ error: json.error ?? { code: 'REFRESH_FAILED', message: 'Token refresh failed' } }, { status: fastapiRes.status });
+    // story e5225c0a(P0) 재진단: 이 route는 PUBLIC_PREFIX('/api/auth/')라 proxy.ts 미들웨어의
+    // stale-cookie cleanup을 안 거친다 — 별도 실패 경로라 여기서도 동일하게 지워야 한다. 안 지우면
+    // 클라이언트 401-인터셉터(fetchWithAuth)가 폴링 컴포넌트(예: dashboard-activity-timeline.tsx
+    // 60s 간격)가 재요청할 때마다 이 route를 다시 때려 죽은 sp_rt로 무한 재시도(산티아고 prod 실측:
+    // b0b55886 배포 후에도 /auth/refresh 401이 09:03~09:13 60s 간격 지속 — proxy.ts fix만으론 갭).
+    const res = NextResponse.json(
+      { error: json.error ?? { code: 'REFRESH_FAILED', message: 'Token refresh failed' } },
+      { status: fastapiRes.status },
+    );
+    res.cookies.delete(SP_AT_COOKIE);
+    res.cookies.delete(SP_RT_COOKIE);
+    return res;
   }
 
   const { access_token, refresh_token } = json.data;


### PR DESCRIPTION
선생님 오전 P0 prod GO 계보. #2181(오전 승격)이 proxy.ts만 고친 반쪽 fix라 실제 폴러 경로(/api/auth/refresh route.ts) 미커버 → PO의 prod 401 미소멸 관측이 갭 적발 → #2185 근본 봉합.

**내용**: /api/auth/refresh route.ts에도 proxy.ts 동형 쿠키 삭제(refresh 최종 실패 시 sp_at/sp_rt clear). 폴러 401→쿠키 삭제→폴링 중단.
**scope**: route.ts+테스트·**마이그 0**·billing 무관.
**done-gate**: prod 배포 후 관측성 로그로 /auth/refresh 401 무한반복 실제 소멸 확認(오전 반쪽 승격이 이걸 못 닫음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)