### PR TITLE
🚨 fix(auth): story e5225c0a(P0) 3차 근본 — prod 쿠키 domain 불일치로 삭제 no-op

### DIFF
--- a/apps/web/src/app/api/auth/refresh/route.test.ts
+++ b/apps/web/src/app/api/auth/refresh/route.test.ts
@@ -57,4 +57,24 @@ describe('POST /api/auth/refresh', () => {
     expect(setCookie).toContain('sp_at=;');
     expect(setCookie).toContain('sp_rt=;');
   });
+
+  it('domain-scoped 환경(NEXT_PUBLIC_COOKIE_DOMAIN 설정)에서도 삭제에 Domain이 실림 — prod 근본 회귀 가드(3차)', async () => {
+    process.env['NEXT_PUBLIC_APP_URL'] = 'https://app.sprintable.ai';
+    process.env['NEXT_PUBLIC_COOKIE_DOMAIN'] = 'app.sprintable.ai';
+    try {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: async () => ({ error: { code: 'TOKEN_REVOKED', message: 'revoked' } }),
+      });
+      const res = await POST(makeRequest());
+      expect(res.status).toBe(401);
+      const setCookie = res.headers.get('set-cookie') ?? '';
+      const domainCount = (setCookie.match(/Domain=app\.sprintable\.ai/g) ?? []).length;
+      expect(domainCount).toBe(2);
+    } finally {
+      delete process.env['NEXT_PUBLIC_APP_URL'];
+      delete process.env['NEXT_PUBLIC_COOKIE_DOMAIN'];
+    }
+  });
 });

--- a/apps/web/src/app/api/auth/refresh/route.ts
+++ b/apps/web/src/app/api/auth/refresh/route.ts
@@ -25,17 +25,21 @@ export async function POST(request: Request) {
 
   const json = await fastapiRes.json() as { data?: { access_token: string; refresh_token: string }; error?: { code: string; message: string } };
   if (!fastapiRes.ok || !json.data) {
-    // story e5225c0a(P0) 재진단: 이 route는 PUBLIC_PREFIX('/api/auth/')라 proxy.ts 미들웨어의
-    // stale-cookie cleanup을 안 거친다 — 별도 실패 경로라 여기서도 동일하게 지워야 한다. 안 지우면
-    // 클라이언트 401-인터셉터(fetchWithAuth)가 폴링 컴포넌트(예: dashboard-activity-timeline.tsx
-    // 60s 간격)가 재요청할 때마다 이 route를 다시 때려 죽은 sp_rt로 무한 재시도(산티아고 prod 실측:
-    // b0b55886 배포 후에도 /auth/refresh 401이 09:03~09:13 60s 간격 지속 — proxy.ts fix만으론 갭).
+    // story e5225c0a(P0) 3차 재진단(산티아고 prod gcloud 실측 근본 확定): 이 route는
+    // PUBLIC_PREFIX('/api/auth/')라 proxy.ts 미들웨어를 안 거쳐 별도 실패 경로다(1차 갭, #2185에서
+    // 봉합) — 그런데 그 #2185 자체도 `res.cookies.delete(name)`(bare form, domain 없음)를 썼다.
+    // prod FE Cloud Run엔 `NEXT_PUBLIC_COOKIE_DOMAIN=app.sprintable.ai`가 Secret Manager로
+    // 설정돼 있어(dev엔 없음 — dev 검증이 못 잡은 이유) cookieBase()가 SET 시 Domain 속성을
+    // 붙인다. 삭제가 그 Domain 없이 나가면 브라우저가 "다른 쿠키"로 취급해 **삭제가 조용히
+    // no-op** — 죽은 sp_rt가 그대로 남아 매분 재시도·401 무한 재생산이 지속됐다(2차 근본).
+    // fix: SET과 완전히 동일한 속성(...cookieBase())으로 값만 빈 문자열+maxAge=0 — 브라우저가
+    // 반드시 동일 쿠키로 매칭해 덮어쓰게 한다(bare delete()의 domain drift 클래스 자체를 제거).
     const res = NextResponse.json(
       { error: json.error ?? { code: 'REFRESH_FAILED', message: 'Token refresh failed' } },
       { status: fastapiRes.status },
     );
-    res.cookies.delete(SP_AT_COOKIE);
-    res.cookies.delete(SP_RT_COOKIE);
+    res.cookies.set(SP_AT_COOKIE, '', { ...cookieBase(), maxAge: 0 });
+    res.cookies.set(SP_RT_COOKIE, '', { ...cookieBase(), maxAge: 0 });
     return res;
   }
 

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -115,6 +115,29 @@ describe('proxy', () => {
     expect(setCookie).toContain('sp_at=;');
   });
 
+  it('clears cookies with matching Domain attribute when NEXT_PUBLIC_COOKIE_DOMAIN is set (prod root cause — story e5225c0a 3차)', async () => {
+    // 산티아고 gcloud 실측 근본: prod FE Cloud Run엔 NEXT_PUBLIC_COOKIE_DOMAIN=app.sprintable.ai가
+    // Secret Manager로 설정돼있다(dev엔 없어 이 시나리오가 dev 검증을 통과했던 이유). SET 시 Domain이
+    // 붙는데 delete가 Domain 없이 나가면 브라우저가 다른 쿠키로 취급해 삭제가 조용히 no-op된다 —
+    // 이 테스트는 그 domain-scoped 환경을 시뮬레이트해 삭제 Set-Cookie에 Domain이 실려야 함을 고정한다.
+    process.env['NEXT_PUBLIC_APP_URL'] = 'https://app.sprintable.ai';
+    process.env['NEXT_PUBLIC_COOKIE_DOMAIN'] = 'app.sprintable.ai';
+    try {
+      mockFetch.mockResolvedValue({ ok: false, json: async () => ({ error: { code: 'TOKEN_REVOKED' } }) });
+      const response = await middleware(makeRequest('/dashboard', { sp_rt: 'stale-rt-domain' }));
+      expect(response.status).toBe(307);
+      const setCookie = response.headers.get('set-cookie') ?? '';
+      expect(setCookie).toContain('Domain=app.sprintable.ai');
+      // 두 쿠키 모두에 Domain이 실렸는지(하나만 고치는 회귀 방지) — sp_at/sp_rt 각각의 Set-Cookie
+      // 청크에 Domain이 붙어있어야 하므로 개수로 확인.
+      const domainCount = (setCookie.match(/Domain=app\.sprintable\.ai/g) ?? []).length;
+      expect(domainCount).toBe(2);
+    } finally {
+      delete process.env['NEXT_PUBLIC_APP_URL'];
+      delete process.env['NEXT_PUBLIC_COOKIE_DOMAIN'];
+    }
+  });
+
   it('does NOT clear cookies when refresh succeeds but is suppressed for a different active account (RC2 regression guard)', async () => {
     // refreshMatchesActive=false 는 refresh 자체가 실패한 게 아니라(다른 계정의 늦은 refresh를
     // 의도적으로 무시하는 것) — clearAuthCookies 를 호출하면 안 된다. sp_active_account 포인터를

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -220,9 +220,17 @@ function applyTokenCookies(
 // prod 로그 실측: /auth/refresh 239건 중 230건 401). RC2(refreshMatchesActive=false, 다른/
 // superseded 계정의 late refresh 억제)와는 다른 경우 — 그건 refresh 자체는 성공했으므로
 // 쿠키를 유지해야 한다(clearAuthCookies 를 이 경우엔 호출하지 않음).
+//
+// ⚠️3차 재진단(산티아고 prod gcloud 실측 근본 확定): prod FE Cloud Run엔
+// `NEXT_PUBLIC_COOKIE_DOMAIN=app.sprintable.ai`가 Secret Manager로 설정돼(dev엔 없음)
+// cookieBase() SET 시 Domain 속성이 붙는다. bare `response.cookies.delete(name)`는 Domain
+// 없이 나가 브라우저가 다른 쿠키로 취급 — 삭제가 조용히 no-op되고 죽은 sp_rt가 남아 401이
+// 무한 재생산됐다(1·2차 fix가 못 잡은 진짜 근본). SET과 완전히 동일한 속성(...cookieBase())
+// 으로 값 빈 문자열+maxAge=0 — 반드시 동일 쿠키로 매칭되게 한다.
 function clearAuthCookies(response: NextResponse): void {
-  response.cookies.delete(SP_AT_COOKIE);
-  response.cookies.delete(SP_RT_COOKIE);
+  const base = cookieBase();
+  response.cookies.set(SP_AT_COOKIE, '', { ...base, maxAge: 0 });
+  response.cookies.set(SP_RT_COOKIE, '', { ...base, maxAge: 0 });
 }
 
 /** Rebuild request headers with updated sp_at/sp_rt so route handlers see fresh tokens */


### PR DESCRIPTION
## Summary — P0 3차 근본(#2181/#2185 배포 후에도 지속되던 원인 최종 확定)
산티아고 prod gcloud 실측: FE Cloud Run에 **`NEXT_PUBLIC_COOKIE_DOMAIN=app.sprintable.ai`가 Secret Manager로 설정**돼 있다(dev엔 없음 — dev 검증이 이 시나리오를 못 잡은 이유).

### 근본
`cookieBase()`가 SET 시 이 Domain 속성을 붙이는데, #2181(`proxy.ts`)/#2185(`route.ts`) 둘 다 `response.cookies.delete(name)`(bare form)을 썼다 — 이건 Domain 없이 나가 브라우저가 **다른 쿠키로 취급, 삭제가 조용히 no-op**된다. 죽은 `sp_rt`가 그대로 남아 401이 계속 재생산됐다.

### fix
`proxy.ts`의 `clearAuthCookies()`와 `route.ts`의 실패 분기 모두 bare `delete()` 대신 `.set(name, '', { ...cookieBase(), maxAge: 0 })`로 — SET과 완전히 동일한 속성(Domain 포함)으로 나가 브라우저가 반드시 같은 쿠키로 매칭하게 한다. 개별 domain 옵션을 손으로 다시 맞추는 대신 `cookieBase()` 단일 소스를 재사용해 이 클래스의 버그(SET/DELETE 속성 drift) 자체를 제거.

## Test plan
- [x] **뮤테이션 자가검증으로 실제 버그를 직접 재현**: bare `delete()`로 되돌리자 —
  - `proxy.ts`: Set-Cookie에 `Domain` 문자열 자체가 아예 없음 확인(신규 domain 테스트 RED)
  - `route.ts`: 기대 Domain 매칭 2건 vs 실제 0건(신규 domain 테스트 RED)
  - 둘 다 원복 후 clean — **PO 진단이 정확했음을 코드 레벨로 재확인**
- [x] 신규 domain-시뮬레이션 테스트 2건(`NEXT_PUBLIC_COOKIE_DOMAIN=app.sprintable.ai` 설정 후 삭제 Set-Cookie에 `Domain=app.sprintable.ai`가 sp_at/sp_rt 양쪽 모두 실리는지 확인)
- [x] 기존 회귀 스위트(proxy.test.ts 33건 + route.test.ts 4건) 전부 통과 — bare `delete()`와 `.set('', {maxAge:0})`가 domain-less(dev/test) 환경에서는 동일한 `sp_rt=;` 출력을 만들어 기존 단언이 그대로 유효함을 확인
- [x] FE 전체 스위트(vitest): 1469 passed(기존 `html2canvas-pro` 미설치 무관 4파일 제외)

## 배포 흐름
⚠️ 이번이 진짜 근본으로 판단 — prod 승격 후 **401 무한반복 실제 소멸**까지 라이브 관측으로 확인할 예정("배포=done" 아니라 "401 반복 실제 소멸"이 done-gate, 오늘 세 번째 시도의 교훈).

🤖 Generated with [Claude Code](https://claude.com/claude-code)