### PR TITLE
feat(auth): E-AUTH-REBUILD Phase1-S1 — Firebase 부가 스키마+feature flag 스캐폴드

### DIFF
--- a/backend/alembic/versions/0188_auth_identities_migrations.py
+++ b/backend/alembic/versions/0188_auth_identities_migrations.py
@@ -1,0 +1,82 @@
+"""story b07ad526(E-AUTH-REBUILD M2 Phase1-S1): auth_identities/auth_migrations/
+auth_migration_events additive 스키마(doc firebase-auth-identity-platform-migration-poc §3.2).
+
+Revision ID: 0188
+Revises: 0187
+Create Date: 2026-07-15
+
+전부 additive — 기존 스키마 무회귀. 신규 테이블만 신설, 기존 users/auth 경로 무변경.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0188"
+down_revision = "0187"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "auth_identities",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("issuer", sa.Text(), nullable=False),
+        sa.Column("tenant_id", sa.Text(), nullable=True),
+        sa.Column("subject", sa.Text(), nullable=False),
+        sa.Column("provider_id", sa.Text(), nullable=True),
+        sa.Column("provider_subject", sa.Text(), nullable=True),
+        sa.Column("email_at_link", sa.Text(), nullable=True),
+        sa.Column("email_verified_at_link", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("linked_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("unlinked_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_auth_identities_user_id", "auth_identities", ["user_id"])
+    op.create_unique_constraint("uq_auth_identities_issuer_subject", "auth_identities", ["issuer", "subject"])
+    op.create_index(
+        "uq_auth_identities_issuer_provider_subject",
+        "auth_identities",
+        ["issuer", "provider_id", "provider_subject"],
+        unique=True,
+        postgresql_where=sa.text("unlinked_at IS NULL"),
+    )
+
+    op.create_table(
+        "auth_migrations",
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("state", sa.Text(), nullable=False, server_default="legacy"),
+        sa.Column("method", sa.Text(), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("firebase_uid", sa.Text(), nullable=True),
+        sa.Column("legacy_auth_allowed_until", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("mfa_reenroll_required", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("last_error_code", sa.Text(), nullable=True),
+        sa.Column("attempt_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+
+    op.create_table(
+        "auth_migration_events",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("from_state", sa.Text(), nullable=True),
+        sa.Column("to_state", sa.Text(), nullable=False),
+        sa.Column("method", sa.Text(), nullable=True),
+        sa.Column("reason_code", sa.Text(), nullable=True),
+        sa.Column("request_id", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index("ix_auth_migration_events_user_id", "auth_migration_events", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("auth_migration_events")
+    op.drop_table("auth_migrations")
+    op.drop_index("uq_auth_identities_issuer_provider_subject", table_name="auth_identities")
+    op.drop_constraint("uq_auth_identities_issuer_subject", "auth_identities", type_="unique")
+    op.drop_index("ix_auth_identities_user_id", table_name="auth_identities")
+    op.drop_table("auth_identities")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -156,6 +156,21 @@ class Settings(BaseSettings):
     rate_limit_backend: str = "memory"  # "memory" | "redis"
     redis_url: str = "redis://localhost:6379/0"
 
+    # E-AUTH-REBUILD M2 Phase 1(story b07ad526·doc firebase-auth-identity-platform-migration-poc
+    # §10.1): Firebase Auth/Identity Platform 이행 플래그. 전부 default off — Phase 1 스키마+검증기
+    # 구현은 이 플래그들 뒤에서 dead code로 존재(prod 무영향). LEGACY_AUTH_ISSUE/VERIFY만 on이
+    # 기본이라 기존 self-issued JWT 로그인/세션이 그대로 SSOT.
+    firebase_auth_accept_id: bool = False        # native/direct 경로에서 Firebase ID token 수락
+    firebase_auth_accept_session: bool = False   # Firebase 세션쿠키(__Host-sp_fs) 수락
+    firebase_auth_issue_session: bool = False    # 신규 Firebase 세션쿠키 발급
+    firebase_auth_reset_cutover: bool = False    # Phase 4 coordinated forced-reset 전이 허용
+    firebase_auth_cohort_percent: int = 0        # Phase 5 점진 롤아웃 비율(0~100)
+    firebase_auth_mobile_issue: bool = False     # M2 모바일 native bootstrap 발급
+    legacy_auth_issue: bool = True               # 기존 self-issued JWT 로그인/refresh 발급
+    legacy_auth_verify: bool = True              # 기존 self-issued JWT 검증(proxy.ts·FastAPI)
+
+    firebase_project_id: str = ""  # Firebase/Identity Platform GCP 프로젝트 ID(dev/prod 분리)
+
     @property
     def is_ee_enabled(self) -> bool:
         return self.license_consent.lower() == "agreed"

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -5,6 +5,7 @@ from app.models.agent_deployment import AgentAuditLog, AgentDeployment, AgentPer
 from app.models.agent_routing_rule import AgentRoutingRule
 from app.models.agent_run import AgentRun
 from app.models.agent_session import AgentSession
+from app.models.auth_identity import AuthIdentity, AuthMigration, AuthMigrationEvent
 from app.models.bridge import BridgeChannelMapping, BridgeUserMapping
 from app.models.deletion_audit import DeletionAuditLog
 from app.models.dependency import ItemDependency
@@ -63,6 +64,9 @@ from app.models.visual_artifact import ArtifactNode, ArtifactVersion, VisualArti
 __all__ = [
     "RoleTemplate",
     "OrgMemberTrustSnapshot",
+    "AuthIdentity",
+    "AuthMigration",
+    "AuthMigrationEvent",
     "ArtifactNode",
     "ArtifactVersion",
     "VisualArtifact",

--- a/backend/app/models/auth_identity.py
+++ b/backend/app/models/auth_identity.py
@@ -1,0 +1,82 @@
+"""E-AUTH-REBUILD M2 Phase 1(story b07ad526·doc firebase-auth-identity-platform-migration-poc
+§3.2): Firebase/Identity Platform 신원 매핑 — additive, 기존 users.id가 여전히 business identity.
+
+ID 토큰/세션쿠키/legacy 평문 비밀번호/provider access token/TOTP 시크릿은 이 테이블에 저장
+금지(doc §3.2 명시)."""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Text, UniqueConstraint, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class AuthIdentity(Base):
+    __tablename__ = "auth_identities"
+    __table_args__ = (
+        UniqueConstraint("issuer", "subject", name="uq_auth_identities_issuer_subject"),
+        Index(
+            "uq_auth_identities_issuer_provider_subject",
+            "issuer", "provider_id", "provider_subject",
+            unique=True,
+            postgresql_where=text("unlinked_at IS NULL"),
+        ),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    issuer: Mapped[str] = mapped_column(Text, nullable=False)
+    tenant_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    subject: Mapped[str] = mapped_column(Text, nullable=False)
+    provider_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    provider_subject: Mapped[str | None] = mapped_column(Text, nullable=True)
+    email_at_link: Mapped[str | None] = mapped_column(Text, nullable=True)
+    email_verified_at_link: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    linked_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    unlinked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class AuthMigration(Base):
+    """user 1행 — 현재 마이그 상태(doc §3.2). state: legacy|provisioning|firebase|reset_required|
+    rollback_hold. method: forced_reset|provider_import|new_user|rollback."""
+    __tablename__ = "auth_migrations"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    state: Mapped[str] = mapped_column(Text, nullable=False, default="legacy", server_default="legacy")
+    method: Mapped[str | None] = mapped_column(Text, nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    firebase_uid: Mapped[str | None] = mapped_column(Text, nullable=True)
+    legacy_auth_allowed_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    mfa_reenroll_required: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    last_error_code: Mapped[str | None] = mapped_column(Text, nullable=True)
+    attempt_count: Mapped[int] = mapped_column(nullable=False, default=0)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )
+
+
+class AuthMigrationEvent(Base):
+    """auth_migrations 상태 전이 감사 로그 — append-only(doc §3.2 optional table)."""
+    __tablename__ = "auth_migration_events"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    from_state: Mapped[str | None] = mapped_column(Text, nullable=True)
+    to_state: Mapped[str] = mapped_column(Text, nullable=False)
+    method: Mapped[str | None] = mapped_column(Text, nullable=True)
+    reason_code: Mapped[str | None] = mapped_column(Text, nullable=True)
+    request_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/tests/test_e_auth_rebuild_phase1_s1_schema_realdb.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s1_schema_realdb.py
@@ -1,0 +1,192 @@
+"""story b07ad526(E-AUTH-REBUILD M2 Phase1-S1) 게이트: auth_identities/auth_migrations/
+auth_migration_events 스키마 실 PG 왕복 + 제약 실증. 전부 additive — 기존 인증 스위트는
+별도로 무회귀 확認(플래그 전부 off라 동작 변화 0)."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_user(session):
+    from app.core.security import hash_password
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    session.add(User(
+        id=user_id, email=f"authreb-{user_id.hex[:8]}@test.com",
+        hashed_password=hash_password("x"), is_active=True, email_verified=True,
+    ))
+    await session.commit()
+    return user_id
+
+
+@pytest.mark.anyio
+async def test_auth_identity_insert_and_unique_issuer_subject_realdb():
+    from app.models.auth_identity import AuthIdentity
+    from sqlalchemy.exc import IntegrityError
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_user(s)
+            issuer = f"https://session.firebase.google.com/test-{uuid.uuid4().hex[:6]}"
+            s.add(AuthIdentity(
+                id=uuid.uuid4(), user_id=user_id, issuer=issuer, subject=str(user_id),
+                provider_id="password", email_at_link="a@test.com",
+            ))
+            await s.commit()
+
+        # 동일 (issuer, subject) 재삽입 — UNIQUE 위반.
+        async with Session() as s:
+            s.add(AuthIdentity(
+                id=uuid.uuid4(), user_id=user_id, issuer=issuer, subject=str(user_id),
+                provider_id="google.com",
+            ))
+            with pytest.raises(IntegrityError):
+                await s.commit()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_auth_identity_partial_unique_provider_subject_only_active_realdb():
+    """까심: unlinked_at IS NOT NULL(해제된 링크)은 partial unique에서 제외 — 재연동 가능해야 함.
+    동시에 두 개의 linked(unlinked_at IS NULL) 행이 같은 provider 조합을 가지면 거부돼야 함."""
+    from app.models.auth_identity import AuthIdentity
+    from sqlalchemy.exc import IntegrityError
+    from datetime import datetime, timezone
+
+    engine, Session = await _session_factory()
+    try:
+        issuer = f"https://session.firebase.google.com/test-{uuid.uuid4().hex[:6]}"
+        provider_subject = f"google-sub-{uuid.uuid4().hex[:8]}"
+
+        async with Session() as s:
+            user_a = await _seed_user(s)
+            user_b = await _seed_user(s)
+
+        # user_a가 이 provider_subject를 링크했다가 해제(unlinked_at 설정).
+        async with Session() as s:
+            s.add(AuthIdentity(
+                id=uuid.uuid4(), user_id=user_a, issuer=issuer, subject=f"a-{user_a}",
+                provider_id="google.com", provider_subject=provider_subject,
+                unlinked_at=datetime.now(timezone.utc),
+            ))
+            await s.commit()
+
+        # user_b가 같은 provider_subject를 새로 링크(active) — 해제된 링크와 충돌하지 않아야 함.
+        async with Session() as s:
+            s.add(AuthIdentity(
+                id=uuid.uuid4(), user_id=user_b, issuer=issuer, subject=f"b-{user_b}",
+                provider_id="google.com", provider_subject=provider_subject,
+            ))
+            await s.commit()
+
+        # 이제 user_a가 동일 provider_subject를 다시 active로 링크 시도 — 이미 user_b가
+        # active 보유 중이라 partial unique 위반.
+        async with Session() as s:
+            s.add(AuthIdentity(
+                id=uuid.uuid4(), user_id=user_a, issuer=issuer, subject=f"a2-{user_a}",
+                provider_id="google.com", provider_subject=provider_subject,
+            ))
+            with pytest.raises(IntegrityError):
+                await s.commit()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_auth_migration_default_state_legacy_realdb():
+    from app.models.auth_identity import AuthMigration
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_user(s)
+            s.add(AuthMigration(user_id=user_id))
+            await s.commit()
+
+        async with Session() as s:
+            row = (await s.execute(
+                select(AuthMigration).where(AuthMigration.user_id == user_id)
+            )).scalar_one()
+            assert row.state == "legacy"
+            assert row.attempt_count == 0
+            assert row.mfa_reenroll_required is False
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_auth_migration_event_append_only_realdb():
+    from app.models.auth_identity import AuthMigrationEvent
+    from sqlalchemy import select
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_user(s)
+            s.add(AuthMigrationEvent(
+                id=uuid.uuid4(), user_id=user_id, from_state="legacy", to_state="provisioning",
+                method="forced_reset", reason_code="cutover_start",
+            ))
+            await s.commit()
+
+        async with Session() as s:
+            rows = (await s.execute(
+                select(AuthMigrationEvent).where(AuthMigrationEvent.user_id == user_id)
+            )).scalars().all()
+            assert len(rows) == 1
+            assert rows[0].to_state == "provisioning"
+    finally:
+        await engine.dispose()
+
+
+def test_firebase_auth_flags_default_off_except_legacy():
+    """story b07ad526 AC2: 8개 플래그 default가 doc §10.1과 일치 — LEGACY_AUTH_ISSUE/VERIFY만 true."""
+    from app.core.config import Settings
+
+    s = Settings(_env_file=None)
+    assert s.firebase_auth_accept_id is False
+    assert s.firebase_auth_accept_session is False
+    assert s.firebase_auth_issue_session is False
+    assert s.firebase_auth_reset_cutover is False
+    assert s.firebase_auth_cohort_percent == 0
+    assert s.firebase_auth_mobile_issue is False
+    assert s.legacy_auth_issue is True
+    assert s.legacy_auth_verify is True


### PR DESCRIPTION
## Summary
Story `b07ad526`([E-AUTH-REBUILD Phase1-S1]) — 산티아고 이행 설계 doc(`firebase-auth-identity-platform-migration-poc-2026-07-15`) §3.2·§10.1 그대로 구현. 전부 additive — 8개 feature flag 전부 default off(`LEGACY_AUTH_ISSUE`/`LEGACY_AUTH_VERIFY`만 true)라 기존 self-issued JWT 로그인/세션이 그대로 SSOT. 동작 변화 0.

- alembic 0188: `auth_identities`(UNIQUE(issuer,subject)+partial UNIQUE(issuer,provider_id,provider_subject) WHERE unlinked_at IS NULL)·`auth_migrations`(state machine)·`auth_migration_events`(append-only 감사) 신설
- `app/core/config.py`: `FIREBASE_AUTH_ACCEPT_ID`/`ACCEPT_SESSION`/`ISSUE_SESSION`/`RESET_CUTOVER`/`COHORT_PERCENT`/`MOBILE_ISSUE`(전부 false) + `LEGACY_AUTH_ISSUE`/`VERIFY`(전부 true)
- `app/models/auth_identity.py`: SQLAlchemy 모델 3종, 마이그와 1:1 대응

⛔ 스코프 밖: 실 Firebase 프로젝트 연동·검증기 로직·엔드포인트(Phase1-S2/S3에서) — 순수 스키마+설정 뼈대만.

## Test plan
- [x] 신선 DB 마이그 upgrade+downgrade 왕복
- [x] realdb 5건 — UNIQUE 위반 실증 2건 포함(partial unique가 `unlinked_at IS NULL` 행에만 적용됨을 실제 `IntegrityError`로 증명: 해제된 링크는 재점유 허용, active 링크끼리만 충돌)
- [x] 플래그 default값 단위 테스트(doc §10.1과 정확히 일치)
- [x] 전체 스위트(`-m "not destructive_schema"`): 3262 passed / 7 failed(develop 기준선과 동일 재현되는 환경 의존 사전 실패뿐, 오늘 여러 PR에서 이미 확인된 동일 실패군 — 본 PR과 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)