### PR TITLE
feat(auth): E-AUTH-REBUILD Phase1-S3 — Next.js BFF 검증기+세션 발급 엔드포인트 스캐폴드

### DIFF
--- a/apps/web/src/app/api/auth/firebase/session/route.test.ts
+++ b/apps/web/src/app/api/auth/firebase/session/route.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({ csrfCheck: vi.fn() }));
+vi.mock('@/lib/auth/csrf', () => ({ verifyCsrfOrigin: h.csrfCheck }));
+
+import { NextResponse } from 'next/server';
+import { POST, setFirebaseSessionCookie } from './route';
+
+function makeRequest(): Request {
+  return new Request('http://localhost/api/auth/firebase/session', { method: 'POST', body: '{}' });
+}
+
+describe('POST /api/auth/firebase/session', () => {
+  beforeEach(() => {
+    h.csrfCheck.mockReset().mockReturnValue(null);
+    delete process.env['FIREBASE_AUTH_ISSUE_SESSION'];
+  });
+
+  afterEach(() => {
+    delete process.env['FIREBASE_AUTH_ISSUE_SESSION'];
+  });
+
+  it('returns 501 when FIREBASE_AUTH_ISSUE_SESSION is unset (default off)', async () => {
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(501);
+    expect((await res.json()).error.code).toBe('NOT_ENABLED');
+  });
+
+  it('returns 501 when FIREBASE_AUTH_ISSUE_SESSION is explicitly false', async () => {
+    process.env['FIREBASE_AUTH_ISSUE_SESSION'] = 'false';
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(501);
+  });
+
+  it('still 501(not-implemented) even when flag is true — scaffold only, no live exchange yet', async () => {
+    process.env['FIREBASE_AUTH_ISSUE_SESSION'] = 'true';
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(501);
+    expect((await res.json()).error.code).toBe('NOT_IMPLEMENTED');
+  });
+});
+
+describe('setFirebaseSessionCookie — __Host-sp_fs domain-less regression guard (story e5225c0a 3차 근본 재발 방지)', () => {
+  it('sets the cookie WITHOUT a Domain attribute even when NEXT_PUBLIC_COOKIE_DOMAIN is configured', () => {
+    process.env['NEXT_PUBLIC_APP_URL'] = 'https://app.sprintable.ai';
+    process.env['NEXT_PUBLIC_COOKIE_DOMAIN'] = 'app.sprintable.ai';
+    try {
+      const response = NextResponse.json({ data: { ok: true } });
+      setFirebaseSessionCookie(response, 'fake-session-cookie-value');
+      const setCookie = response.headers.get('set-cookie') ?? '';
+      expect(setCookie).toContain('__Host-sp_fs=fake-session-cookie-value');
+      expect(setCookie).not.toContain('Domain=');
+      expect(setCookie).toContain('Path=/');
+      expect(setCookie).toContain('HttpOnly');
+    } finally {
+      delete process.env['NEXT_PUBLIC_APP_URL'];
+      delete process.env['NEXT_PUBLIC_COOKIE_DOMAIN'];
+    }
+  });
+});

--- a/apps/web/src/app/api/auth/firebase/session/route.test.ts
+++ b/apps/web/src/app/api/auth/firebase/session/route.test.ts
@@ -3,8 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const h = vi.hoisted(() => ({ csrfCheck: vi.fn() }));
 vi.mock('@/lib/auth/csrf', () => ({ verifyCsrfOrigin: h.csrfCheck }));
 
-import { NextResponse } from 'next/server';
-import { POST, setFirebaseSessionCookie } from './route';
+import { POST } from './route';
 
 function makeRequest(): Request {
   return new Request('http://localhost/api/auth/firebase/session', { method: 'POST', body: '{}' });
@@ -37,24 +36,5 @@ describe('POST /api/auth/firebase/session', () => {
     const res = await POST(makeRequest());
     expect(res.status).toBe(501);
     expect((await res.json()).error.code).toBe('NOT_IMPLEMENTED');
-  });
-});
-
-describe('setFirebaseSessionCookie — __Host-sp_fs domain-less regression guard (story e5225c0a 3차 근본 재발 방지)', () => {
-  it('sets the cookie WITHOUT a Domain attribute even when NEXT_PUBLIC_COOKIE_DOMAIN is configured', () => {
-    process.env['NEXT_PUBLIC_APP_URL'] = 'https://app.sprintable.ai';
-    process.env['NEXT_PUBLIC_COOKIE_DOMAIN'] = 'app.sprintable.ai';
-    try {
-      const response = NextResponse.json({ data: { ok: true } });
-      setFirebaseSessionCookie(response, 'fake-session-cookie-value');
-      const setCookie = response.headers.get('set-cookie') ?? '';
-      expect(setCookie).toContain('__Host-sp_fs=fake-session-cookie-value');
-      expect(setCookie).not.toContain('Domain=');
-      expect(setCookie).toContain('Path=/');
-      expect(setCookie).toContain('HttpOnly');
-    } finally {
-      delete process.env['NEXT_PUBLIC_APP_URL'];
-      delete process.env['NEXT_PUBLIC_COOKIE_DOMAIN'];
-    }
   });
 });

--- a/apps/web/src/app/api/auth/firebase/session/route.ts
+++ b/apps/web/src/app/api/auth/firebase/session/route.ts
@@ -3,14 +3,14 @@
  * FIREBASE_AUTH_ISSUE_SESSION=false(기본) 동안은 501 — Firebase Admin SDK 초기화/실 ID token
  * 검증/identity resolve 로직은 이 플래그가 켜지고 Firebase 프로젝트가 준비된 후 Phase 2+에서
  * 채운다(doc §5 Phase 1 스코프=검증기+스키마까지, 실 발급은 Phase 2 shadow 이후).
+ *
+ * ⚠️까심 REQUEST_CHANGES(2026-07-15, 정당한 build blocker): Next.js route.ts는 HTTP 메서드
+ * (GET/POST/...)+route segment config만 export 허용 — 임의 심볼 export는 next build 타입
+ * 에러. 쿠키 상수/헬퍼(SP_FS_COOKIE·setFirebaseSessionCookie 등)는 lib/auth/firebase-session.ts
+ * 로 이관, 여기선 import만.
  */
 import { NextResponse } from 'next/server';
 import { verifyCsrfOrigin } from '@/lib/auth/csrf';
-import { cookieBase } from '@/lib/auth/cookies';
-
-export const SP_FS_COOKIE = '__Host-sp_fs';
-// doc §1.1: Firebase 세션쿠키 수명 5분~2주 공식 허용, POC는 5일 고정(prod 상향은 별도 결정 필요·14일 상한).
-export const FIREBASE_SESSION_MAX_AGE_SECONDS = 5 * 24 * 60 * 60;
 
 // doc §5 Phase1 항목5(issuer별 metrics+neutral failure reason) — 실 issuer 처리 로직이 아직
 // 없는 스캐폴드 단계라 지금은 reason만 중립 로깅. Phase 2+에서 issuer/firebase_uid 축으로 확장.
@@ -35,29 +35,12 @@ export async function POST(request: Request) {
 
   // TODO(Phase 2+): ID token 검증(verifySprintableSession 계열은 세션쿠키 전용이라 별도 ID-token
   // 검증기 필요)+CSRF 이중제출+auth_time<=5분+identity resolve/provision+Firebase Admin SDK
-  // 세션쿠키 실 발급+__Host-sp_fs set+sp_at/sp_rt/vault 쿠키 정리(doc §4.4 10단계) — Firebase
-  // 프로젝트 프로비저닝(PO 인프라 lane) 후 채운다. 지금은 플래그가 이미 false라 여기 도달 불가.
+  // 세션쿠키 실 발급+setFirebaseSessionCookie() 호출+sp_at/sp_rt/vault 쿠키 정리(doc §4.4 10단계)
+  // — Firebase 프로젝트 프로비저닝(PO 인프라 lane) 후 채운다. 지금은 플래그가 이미 false라
+  // 여기 도달 불가.
   logSessionFailure('not_implemented');
   return NextResponse.json(
     { error: { code: 'NOT_IMPLEMENTED', message: 'Session exchange implementation pending' } },
     { status: 501 },
   );
-}
-
-/**
- * ⚠️story e5225c0a 3차 근본(prod 쿠키 domain 불일치로 삭제 no-op) 재발 방지 — `__Host-` prefix
- * 쿠키는 브라우저 스펙(RFC 6265bis)상 Domain 속성이 있으면 Set-Cookie 자체가 거부된다. 즉
- * cookieBase()의 domain을 여기서 절대 쓰면 안 되고(써도 브라우저가 무시/거부), 그 제약이 오히려
- * 이 쿠키를 domain-drift 클래스 버그로부터 구조적으로 안전하게 만든다.
- */
-export function setFirebaseSessionCookie(response: NextResponse, sessionCookieValue: string): void {
-  const { secure } = cookieBase();
-  response.cookies.set(SP_FS_COOKIE, sessionCookieValue, {
-    httpOnly: true,
-    secure,
-    sameSite: 'lax',
-    path: '/',
-    maxAge: FIREBASE_SESSION_MAX_AGE_SECONDS,
-    // domain 의도적 생략 — __Host- prefix 요건.
-  });
 }

--- a/apps/web/src/app/api/auth/firebase/session/route.ts
+++ b/apps/web/src/app/api/auth/firebase/session/route.ts
@@ -1,0 +1,63 @@
+/**
+ * story 386a8b56(E-AUTH-REBUILD M2 Phase1-S3·doc §4.4): POST /api/auth/firebase/session 스캐폴드.
+ * FIREBASE_AUTH_ISSUE_SESSION=false(기본) 동안은 501 — Firebase Admin SDK 초기화/실 ID token
+ * 검증/identity resolve 로직은 이 플래그가 켜지고 Firebase 프로젝트가 준비된 후 Phase 2+에서
+ * 채운다(doc §5 Phase 1 스코프=검증기+스키마까지, 실 발급은 Phase 2 shadow 이후).
+ */
+import { NextResponse } from 'next/server';
+import { verifyCsrfOrigin } from '@/lib/auth/csrf';
+import { cookieBase } from '@/lib/auth/cookies';
+
+export const SP_FS_COOKIE = '__Host-sp_fs';
+// doc §1.1: Firebase 세션쿠키 수명 5분~2주 공식 허용, POC는 5일 고정(prod 상향은 별도 결정 필요·14일 상한).
+export const FIREBASE_SESSION_MAX_AGE_SECONDS = 5 * 24 * 60 * 60;
+
+// doc §5 Phase1 항목5(issuer별 metrics+neutral failure reason) — 실 issuer 처리 로직이 아직
+// 없는 스캐폴드 단계라 지금은 reason만 중립 로깅. Phase 2+에서 issuer/firebase_uid 축으로 확장.
+function logSessionFailure(reason: string): void {
+  console.warn(`auth.firebase.session 실패 reason=${reason}`);
+}
+
+export async function POST(request: Request) {
+  if (process.env['FIREBASE_AUTH_ISSUE_SESSION'] !== 'true') {
+    logSessionFailure('not_enabled');
+    return NextResponse.json(
+      { error: { code: 'NOT_ENABLED', message: 'Firebase session issuance is not enabled' } },
+      { status: 501 },
+    );
+  }
+
+  const csrfError = verifyCsrfOrigin(request);
+  if (csrfError) {
+    logSessionFailure('csrf_rejected');
+    return csrfError;
+  }
+
+  // TODO(Phase 2+): ID token 검증(verifySprintableSession 계열은 세션쿠키 전용이라 별도 ID-token
+  // 검증기 필요)+CSRF 이중제출+auth_time<=5분+identity resolve/provision+Firebase Admin SDK
+  // 세션쿠키 실 발급+__Host-sp_fs set+sp_at/sp_rt/vault 쿠키 정리(doc §4.4 10단계) — Firebase
+  // 프로젝트 프로비저닝(PO 인프라 lane) 후 채운다. 지금은 플래그가 이미 false라 여기 도달 불가.
+  logSessionFailure('not_implemented');
+  return NextResponse.json(
+    { error: { code: 'NOT_IMPLEMENTED', message: 'Session exchange implementation pending' } },
+    { status: 501 },
+  );
+}
+
+/**
+ * ⚠️story e5225c0a 3차 근본(prod 쿠키 domain 불일치로 삭제 no-op) 재발 방지 — `__Host-` prefix
+ * 쿠키는 브라우저 스펙(RFC 6265bis)상 Domain 속성이 있으면 Set-Cookie 자체가 거부된다. 즉
+ * cookieBase()의 domain을 여기서 절대 쓰면 안 되고(써도 브라우저가 무시/거부), 그 제약이 오히려
+ * 이 쿠키를 domain-drift 클래스 버그로부터 구조적으로 안전하게 만든다.
+ */
+export function setFirebaseSessionCookie(response: NextResponse, sessionCookieValue: string): void {
+  const { secure } = cookieBase();
+  response.cookies.set(SP_FS_COOKIE, sessionCookieValue, {
+    httpOnly: true,
+    secure,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: FIREBASE_SESSION_MAX_AGE_SECONDS,
+    // domain 의도적 생략 — __Host- prefix 요건.
+  });
+}

--- a/apps/web/src/lib/auth/firebase-session.test.ts
+++ b/apps/web/src/lib/auth/firebase-session.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SignJWT, importPKCS8 } from 'jose';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { _resetKeyCacheForTests, verifySprintableSession } from './firebase-session';
+
+const PROJECT_ID = 'test-project';
+const KID = 'test-kid-1';
+
+// Firebase 세션쿠키 공개키 엔드포인트는 X.509 CERTIFICATE PEM을 반환한다(raw SPKI 아님) —
+// jose importX509()가 실제로 요구하는 포맷과 정확히 맞춰 테스트해야 signature 검증 로직 자체를
+// 실증한다(raw public key PEM으로는 importX509가 애초에 파싱 실패해 거짓양성 위험 — 직접 확인함).
+function makeSelfSignedCert(): { keyPem: string; certPem: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'fs-session-test-'));
+  const keyPath = join(dir, 'key.pem');
+  const certPath = join(dir, 'cert.pem');
+  execFileSync('openssl', [
+    'req', '-x509', '-newkey', 'rsa:2048', '-keyout', keyPath, '-out', certPath,
+    '-days', '1', '-nodes', '-subj', '/CN=test',
+  ], { stdio: 'pipe' });
+  return { keyPem: readFileSync(keyPath, 'utf8'), certPem: readFileSync(certPath, 'utf8') };
+}
+
+async function makeSessionCookie(
+  keyPem: string,
+  overrides: { iss?: string; aud?: string; sub?: string; authTime?: number; kid?: string } = {},
+): Promise<string> {
+  const privateKey = await importPKCS8(keyPem, 'RS256');
+  const now = Math.floor(Date.now() / 1000);
+  return new SignJWT({ auth_time: overrides.authTime ?? now, email: 'user@test.com' })
+    .setProtectedHeader({ alg: 'RS256', kid: overrides.kid ?? KID })
+    .setIssuer(overrides.iss ?? `https://session.firebase.google.com/${PROJECT_ID}`)
+    .setAudience(overrides.aud ?? PROJECT_ID)
+    .setSubject(overrides.sub ?? 'firebase-uid-1')
+    .setIssuedAt(now)
+    .setExpirationTime(now + 3600)
+    .sign(privateKey);
+}
+
+describe('verifySprintableSession', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    _resetKeyCacheForTests();
+  });
+
+  it('accepts a correctly signed session cookie with matching iss/aud/kid', async () => {
+    const { keyPem, certPem } = makeSelfSignedCert();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      headers: new Headers({ 'cache-control': 'max-age=3600' }),
+      json: async () => ({ [KID]: certPem }),
+    });
+    const cookie = await makeSessionCookie(keyPem);
+    const result = await verifySprintableSession(cookie, PROJECT_ID);
+    expect(result).not.toBeNull();
+    expect(result?.firebaseUid).toBe('firebase-uid-1');
+    expect(result?.email).toBe('user@test.com');
+  });
+
+  it('rejects wrong issuer (issuer confusion — ID token issuer instead of session issuer)', async () => {
+    const { keyPem, certPem } = makeSelfSignedCert();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+      json: async () => ({ [KID]: certPem }),
+    });
+    const cookie = await makeSessionCookie(keyPem, {
+      iss: `https://securetoken.google.com/${PROJECT_ID}`, // ID token issuer, not session
+    });
+    const result = await verifySprintableSession(cookie, PROJECT_ID);
+    expect(result).toBeNull();
+  });
+
+  it('rejects wrong project (audience mismatch)', async () => {
+    const { keyPem, certPem } = makeSelfSignedCert();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+      json: async () => ({ [KID]: certPem }),
+    });
+    const cookie = await makeSessionCookie(keyPem, { aud: 'other-project' });
+    const result = await verifySprintableSession(cookie, PROJECT_ID);
+    expect(result).toBeNull();
+  });
+
+  it('rejects unknown kid (key not in published set)', async () => {
+    const { keyPem, certPem } = makeSelfSignedCert();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+      json: async () => ({ 'some-other-kid': certPem }),
+    });
+    const cookie = await makeSessionCookie(keyPem, { kid: KID });
+    const result = await verifySprintableSession(cookie, PROJECT_ID);
+    expect(result).toBeNull();
+  });
+
+  it('rejects expired token', async () => {
+    const { keyPem, certPem } = makeSelfSignedCert();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+      json: async () => ({ [KID]: certPem }),
+    });
+    const privateKey = await importPKCS8(keyPem, 'RS256');
+    const now = Math.floor(Date.now() / 1000);
+    const expired = await new SignJWT({ auth_time: now - 7200 })
+      .setProtectedHeader({ alg: 'RS256', kid: KID })
+      .setIssuer(`https://session.firebase.google.com/${PROJECT_ID}`)
+      .setAudience(PROJECT_ID)
+      .setSubject('firebase-uid-1')
+      .setIssuedAt(now - 7200)
+      .setExpirationTime(now - 3600)
+      .sign(privateKey);
+    const result = await verifySprintableSession(expired, PROJECT_ID);
+    expect(result).toBeNull();
+  });
+
+  it('rejects a token signed with a different (untrusted) key — wrong signature', async () => {
+    const { certPem } = makeSelfSignedCert(); // published cert
+    const { keyPem: attackerKeyPem } = makeSelfSignedCert(); // attacker's own keypair, different cert
+    mockFetch.mockResolvedValue({
+      ok: true,
+      headers: new Headers(),
+      json: async () => ({ [KID]: certPem }), // server only trusts the real published cert
+    });
+    const forged = await makeSessionCookie(attackerKeyPem); // signed with attacker key, claims trusted kid
+    const result = await verifySprintableSession(forged, PROJECT_ID);
+    expect(result).toBeNull();
+  });
+});

--- a/apps/web/src/lib/auth/firebase-session.test.ts
+++ b/apps/web/src/lib/auth/firebase-session.test.ts
@@ -8,7 +8,12 @@ import { join } from 'node:path';
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
-import { _resetKeyCacheForTests, verifySprintableSession } from './firebase-session';
+import { NextResponse } from 'next/server';
+import {
+  _resetKeyCacheForTests,
+  setFirebaseSessionCookie,
+  verifySprintableSession,
+} from './firebase-session';
 
 const PROJECT_ID = 'test-project';
 const KID = 'test-kid-1';
@@ -133,5 +138,24 @@ describe('verifySprintableSession', () => {
     const forged = await makeSessionCookie(attackerKeyPem); // signed with attacker key, claims trusted kid
     const result = await verifySprintableSession(forged, PROJECT_ID);
     expect(result).toBeNull();
+  });
+});
+
+describe('setFirebaseSessionCookie — __Host-sp_fs domain-less regression guard (story e5225c0a 3차 근본 재발 방지)', () => {
+  it('sets the cookie WITHOUT a Domain attribute even when NEXT_PUBLIC_COOKIE_DOMAIN is configured', () => {
+    process.env['NEXT_PUBLIC_APP_URL'] = 'https://app.sprintable.ai';
+    process.env['NEXT_PUBLIC_COOKIE_DOMAIN'] = 'app.sprintable.ai';
+    try {
+      const response = NextResponse.json({ data: { ok: true } });
+      setFirebaseSessionCookie(response, 'fake-session-cookie-value');
+      const setCookie = response.headers.get('set-cookie') ?? '';
+      expect(setCookie).toContain('__Host-sp_fs=fake-session-cookie-value');
+      expect(setCookie).not.toContain('Domain=');
+      expect(setCookie).toContain('Path=/');
+      expect(setCookie).toContain('HttpOnly');
+    } finally {
+      delete process.env['NEXT_PUBLIC_APP_URL'];
+      delete process.env['NEXT_PUBLIC_COOKIE_DOMAIN'];
+    }
   });
 });

--- a/apps/web/src/lib/auth/firebase-session.ts
+++ b/apps/web/src/lib/auth/firebase-session.ts
@@ -8,6 +8,33 @@
  * 표준 포맷이 아닌 kid→PEM X.509 맵이라 jose의 커스텀 JWTVerifyGetKey로 직접 캐시+해석한다.
  */
 import { importX509, jwtVerify, type JWTVerifyGetKey } from 'jose';
+import type { NextResponse } from 'next/server';
+import { cookieBase } from '@/lib/auth/cookies';
+
+// story 386a8b56 까심 REQUEST_CHANGES(2026-07-15): Next.js route.ts는 HTTP 메서드+route
+// segment config만 export 허용 — 임의 심볼 export는 next build 타입 에러(smoke-test FAIL).
+// 쿠키 상수/헬퍼를 route.ts 밖 이 모듈로 분리.
+export const SP_FS_COOKIE = '__Host-sp_fs';
+// doc §1.1: Firebase 세션쿠키 수명 5분~2주 공식 허용, POC는 5일 고정(prod 상향은 별도 결정 필요·14일 상한).
+export const FIREBASE_SESSION_MAX_AGE_SECONDS = 5 * 24 * 60 * 60;
+
+/**
+ * ⚠️story e5225c0a 3차 근본(prod 쿠키 domain 불일치로 삭제 no-op) 재발 방지 — `__Host-` prefix
+ * 쿠키는 브라우저 스펙(RFC 6265bis)상 Domain 속성이 있으면 Set-Cookie 자체가 거부된다. 즉
+ * cookieBase()의 domain을 여기서 절대 쓰면 안 되고(써도 브라우저가 무시/거부), 그 제약이 오히려
+ * 이 쿠키를 domain-drift 클래스 버그로부터 구조적으로 안전하게 만든다.
+ */
+export function setFirebaseSessionCookie(response: NextResponse, sessionCookieValue: string): void {
+  const { secure } = cookieBase();
+  response.cookies.set(SP_FS_COOKIE, sessionCookieValue, {
+    httpOnly: true,
+    secure,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: FIREBASE_SESSION_MAX_AGE_SECONDS,
+    // domain 의도적 생략 — __Host- prefix 요건.
+  });
+}
 
 // Firebase 공식 문서(doc §14): 세션쿠키 검증용 공개키 — ID token용 URL과 다르다(혼동 시 issuer
 // confusion — doc §4.2 명시 위험).

--- a/apps/web/src/lib/auth/firebase-session.ts
+++ b/apps/web/src/lib/auth/firebase-session.ts
@@ -1,0 +1,85 @@
+/**
+ * story 386a8b56(E-AUTH-REBUILD M2 Phase1-S3·doc firebase-auth-identity-platform-migration-poc
+ * §4.3): Firebase 세션쿠키 검증 — Node 런타임 전용(API route/layout). Edge(proxy.ts)에서 절대
+ * import하지 않는다 — Edge는 라우팅 힌트만, 권위 검증은 여기(doc §4.3 명시 배치).
+ *
+ * jose 사용(firebase-admin 아님) — doc §4.3 "otherwise use jose" 경로. 이미 proxy.ts가 legacy
+ * HS256 검증에 jose를 쓰고 있어 신규 의존성 0(발명 최소). Firebase 세션쿠키 공개키는 JWKS
+ * 표준 포맷이 아닌 kid→PEM X.509 맵이라 jose의 커스텀 JWTVerifyGetKey로 직접 캐시+해석한다.
+ */
+import { importX509, jwtVerify, type JWTVerifyGetKey } from 'jose';
+
+// Firebase 공식 문서(doc §14): 세션쿠키 검증용 공개키 — ID token용 URL과 다르다(혼동 시 issuer
+// confusion — doc §4.2 명시 위험).
+const FIREBASE_SESSION_PUBLIC_KEYS_URL = 'https://www.googleapis.com/identitytoolkit/v3/relyingparty/publicKeys';
+const DEFAULT_KEY_CACHE_MS = 60 * 60 * 1000; // 1시간(Cache-Control 헤더 없을 때 폴백)
+const MAX_KEY_CACHE_MS = 24 * 60 * 60 * 1000;
+
+let _keyCache: { keys: Record<string, string>; expiresAt: number } | null = null;
+
+/** 테스트 전용 — 모듈 레벨 키 캐시가 테스트 간 상태를 누출하지 않도록 초기화. */
+export function _resetKeyCacheForTests(): void {
+  _keyCache = null;
+}
+
+async function fetchPublicKeys(): Promise<Record<string, string>> {
+  const now = Date.now();
+  if (_keyCache && _keyCache.expiresAt > now) return _keyCache.keys;
+
+  const res = await fetch(FIREBASE_SESSION_PUBLIC_KEYS_URL);
+  if (!res.ok) throw new Error('firebase_public_keys_fetch_failed');
+  const keys = await res.json() as Record<string, string>;
+
+  const cacheControl = res.headers.get('cache-control') ?? '';
+  const maxAgeMatch = /max-age=(\d+)/.exec(cacheControl);
+  const maxAgeMs = maxAgeMatch
+    ? Math.min(Number(maxAgeMatch[1]) * 1000, MAX_KEY_CACHE_MS)
+    : DEFAULT_KEY_CACHE_MS;
+
+  _keyCache = { keys, expiresAt: now + maxAgeMs };
+  return keys;
+}
+
+const getKey: JWTVerifyGetKey = async (header) => {
+  if (!header.kid) throw new Error('missing_kid');
+  const keys = await fetchPublicKeys();
+  const pem = keys[header.kid];
+  if (!pem) throw new Error('unknown_kid');
+  return importX509(pem, 'RS256');
+};
+
+export interface VerifiedFirebaseSession {
+  issuer: string;
+  firebaseUid: string;
+  email: string | null;
+  authTime: number;
+}
+
+/**
+ * doc §4.2 정확 검증: alg=RS256(jose가 강제)·kid∈Google 공개키셋·iss=정확히 session issuer·
+ * aud=정확히 projectId·sub 비어있지 않음·auth_time/iat/exp 유효. 순차 fallback 없음 — 실패 시
+ * null(legacy로 다운그레이드 절대 금지, 호출부가 그렇게 처리해야 함 — doc §4.1).
+ */
+export async function verifySprintableSession(
+  sessionCookie: string,
+  projectId: string,
+): Promise<VerifiedFirebaseSession | null> {
+  try {
+    const { payload } = await jwtVerify(sessionCookie, getKey, {
+      issuer: `https://session.firebase.google.com/${projectId}`,
+      audience: projectId,
+      algorithms: ['RS256'],
+    });
+    if (!payload.sub) return null;
+    const authTime = typeof payload['auth_time'] === 'number' ? payload['auth_time'] : null;
+    if (authTime === null) return null;
+    return {
+      issuer: String(payload.iss),
+      firebaseUid: payload.sub,
+      email: typeof payload['email'] === 'string' ? payload['email'] : null,
+      authTime,
+    };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
Story `386a8b56`([E-AUTH-REBUILD Phase1-S3]) — 산티아고 이행 설계 doc §4.3(verification placement)·§4.4(session creation endpoint) 그대로 구현. `FIREBASE_AUTH_ISSUE_SESSION=false`(기본) 뒤에 게이트 — 기존 로그인/세션 흐름(`sp_at`/`sp_rt`) 무변경.

- `lib/auth/firebase-session.ts`: `verifySprintableSession()` — Node 런타임 전용(`jose` 재사용, 신규 의존성 0). doc §4.2 정확 검증(alg=RS256·kid∈공개키셋·iss=세션 issuer 정확매칭·aud=projectId·auth_time/iat/exp) — 순차 fallback 없음. Firebase 세션쿠키 공개키는 JWKS 표준이 아닌 kid→X.509 PEM 맵이라 커스텀 `JWTVerifyGetKey`로 캐시+해석.
- ⚠️ `proxy.ts`(Edge 미들웨어)에서 이 함수를 import하지 않음 — Edge는 기존대로 `jose`로 legacy만 처리, 권위 검증은 Node BFF에만(doc §4.3 명시 배치). **`proxy.ts`/`proxy.test.ts` 완전 무변경.**
- `app/api/auth/firebase/session/route.ts`: `POST` 스캐폴드(플래그 off=501)+`setFirebaseSessionCookie()` — `__Host-sp_fs`는 Domain 속성 **의도적 생략**(story e5225c0a 3차 근본 재발 방지 — `__Host-` prefix 자체가 구조적으로 Domain을 금지하므로 이 쿠키는 domain-drift 클래스 버그로부터 안전).

## Test plan
- [x] `verifySprintableSession` 6건 — 실 self-signed X.509 인증서로 서명 검증까지 실증(raw SPKI PEM이 아닌 `openssl`로 발급한 실제 CERTIFICATE PEM 사용 — **최초 시도 시 raw SPKI PEM을 잘못 써서 `importX509`가 파싱 자체에 실패하며 "정상 케이스"가 거짓으로 null을 반환하는 거짓양성을 직접 발견해 수정**함)
- [x] route 4건 — 플래그 off/on 시 501 게이트, `__Host-sp_fs` 쿠키 계약(Domain 없음·Secure·HttpOnly·Path=/)
- [x] 뮤테이션 자가검증 2건 — issuer 검증 무력화 → 정확히 그 테스트만 RED, cookie에 domain 포함 → 정확히 그 테스트만 RED. **둘 다 처음엔 모듈-레벨 키 캐시가 테스트 간 상태를 누출하는 테스트 격리 버그 때문에 거짓양성으로 통과했던 것을 발견해 `_resetKeyCacheForTests()`로 수정한 뒤에야 제대로 작동함을 확인**(proxy.test.ts의 `inflightRefresh` 캐시에서 이미 겪었던 동일 클래스 함정 재발 방지)
- [x] FE 전체 스위트(vitest): 1483 passed(기존 `html2canvas-pro` 미설치로 인한 무관 4파일 제외)
- [x] `proxy.ts`/`proxy.test.ts` git diff 0(완전 무변경 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)