### PR TITLE
[E-AUTH-REBUILD Phase2-FE-S1] Firebase 웹 로그인 UI+세션 교환 클라측 스캐폴드 (플래그 뒤·all off·무해)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -470,6 +470,7 @@
     "password": "Password",
     "signIn": "Sign in",
     "signingIn": "Signing in...",
+    "firebaseSignIn": "Sign in with Firebase",
     "totpPlaceholder": "6-digit authenticator code",
     "totpRequired": "Enter the 6-digit code from your authenticator app.",
     "loginFailed": "Login failed. Please try again.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -470,6 +470,7 @@
     "password": "비밀번호",
     "signIn": "로그인",
     "signingIn": "로그인 중...",
+    "firebaseSignIn": "Firebase로 로그인",
     "totpPlaceholder": "6자리 인증 코드",
     "totpRequired": "인증 앱의 6자리 코드를 입력하세요.",
     "loginFailed": "로그인에 실패했습니다. 다시 시도해 주세요.",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -47,6 +47,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dompurify": "^3.3.3",
+    "firebase": "^11.6.0",
     "framer-motion": "^12.38.0",
     "html2canvas-pro": "^2.2.3",
     "jose": "^6.2.3",

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -8,6 +8,8 @@ import { SprintableLogo } from '@/components/brand/sprintable-logo';
 import { loginWithPassword } from '@/lib/db/client';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { safeNextPath, SESSION_EXPIRED_REASON } from '@/lib/auth/session-redirect';
+import { FIREBASE_AUTH_ENABLED } from '@/lib/auth/firebase-client';
+import { signInAndExchangeFirebaseSession } from '@/lib/auth/firebase-login-flow';
 
 export default function LoginPage() {
   const t = useTranslations('login');
@@ -32,6 +34,27 @@ export default function LoginPage() {
     errorCode ? (oauthErrors[errorCode] ?? t('loginFailed')) : null
   );
   const [loading, setLoading] = useState(false);
+  const [firebaseLoading, setFirebaseLoading] = useState(false);
+
+  // story a0118204: 스캐폴드 — NEXT_PUBLIC_FIREBASE_AUTH_ENABLED가 꺼져있으면(기본) 버튼 자체가
+  // 안 보이니 호출 불가. 켜져 있어도 서버 플래그(FIREBASE_AUTH_ISSUE_SESSION)가 꺼져있으면
+  // BFF가 501을 반환 — 클라 플래그는 UX 노출 게이트일 뿐 실 발급 권위가 아니다.
+  const handleFirebaseLogin = async () => {
+    if (!email.trim() || !password.trim()) return;
+    setFirebaseLoading(true);
+    setError(null);
+    try {
+      const result = await signInAndExchangeFirebaseSession(email.trim(), password);
+      if (result.error) {
+        setError(result.error.message);
+        return;
+      }
+      router.push(safeNextPath(nextParam));
+      router.refresh();
+    } finally {
+      setFirebaseLoading(false);
+    }
+  };
 
   const handleLogin = async () => {
     if (!email.trim() || !password.trim()) return;
@@ -119,6 +142,15 @@ export default function LoginPage() {
           >
             {loading ? t('signingIn') : t('signIn')}
           </button>
+          {FIREBASE_AUTH_ENABLED && (
+            <button
+              onClick={handleFirebaseLogin}
+              disabled={firebaseLoading || !email.trim() || !password.trim()}
+              className="flex w-full min-h-[44px] items-center justify-center rounded-lg border border-border bg-background px-4 py-3 text-sm font-medium text-foreground/80 transition hover:bg-muted/50 disabled:opacity-50"
+            >
+              {firebaseLoading ? t('signingIn') : t('firebaseSignIn')}
+            </button>
+          )}
         </div>
 
         {process.env.NEXT_PUBLIC_OAUTH_ENABLED === 'true' && (

--- a/apps/web/src/lib/auth/firebase-client.test.ts
+++ b/apps/web/src/lib/auth/firebase-client.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const initializeAppMock = vi.fn((_config: unknown) => ({ name: 'test-app' }));
+const getAppsMock = vi.fn(() => [] as unknown[]);
+const setPersistenceMock = vi.fn((_auth: unknown, _persistence: unknown) => Promise.resolve(undefined));
+const getAuthMock = vi.fn((_app: unknown) => ({ name: 'test-auth' }));
+
+vi.mock('firebase/app', () => ({
+  initializeApp: (config: unknown) => initializeAppMock(config),
+  getApps: () => getAppsMock(),
+}));
+
+vi.mock('firebase/auth', () => ({
+  getAuth: (app: unknown) => getAuthMock(app),
+  setPersistence: (auth: unknown, persistence: unknown) => setPersistenceMock(auth, persistence),
+  inMemoryPersistence: 'in-memory',
+}));
+
+describe('getFirebaseAuth (story a0118204 — config 부재 시 무해, 절대 throw 안 함)', () => {
+  const ENV_KEYS = ['NEXT_PUBLIC_FIREBASE_API_KEY', 'NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN', 'NEXT_PUBLIC_FIREBASE_PROJECT_ID', 'NEXT_PUBLIC_FIREBASE_APP_ID'] as const;
+  const original: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) original[key] = process.env[key];
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (original[key] === undefined) delete process.env[key];
+      else process.env[key] = original[key];
+    }
+  });
+
+  it('returns null (not throw) when Firebase config env vars are entirely absent (PO 프로비저닝 전 상태)', async () => {
+    for (const key of ENV_KEYS) delete process.env[key];
+    const { getFirebaseAuth, _resetFirebaseAppForTests } = await import('./firebase-client');
+    _resetFirebaseAppForTests();
+    await expect(getFirebaseAuth()).resolves.toBeNull();
+    expect(initializeAppMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null when config is partially present (e.g. apiKey missing) — no partial init', async () => {
+    delete process.env['NEXT_PUBLIC_FIREBASE_API_KEY'];
+    process.env['NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN'] = 'x.firebaseapp.com';
+    process.env['NEXT_PUBLIC_FIREBASE_PROJECT_ID'] = 'x';
+    process.env['NEXT_PUBLIC_FIREBASE_APP_ID'] = 'x';
+    const { getFirebaseAuth, _resetFirebaseAppForTests } = await import('./firebase-client');
+    _resetFirebaseAppForTests();
+    await expect(getFirebaseAuth()).resolves.toBeNull();
+  });
+
+  it('initializes with inMemoryPersistence (server cookie is SSOT, never browserLocal) when config is complete', async () => {
+    process.env['NEXT_PUBLIC_FIREBASE_API_KEY'] = 'key';
+    process.env['NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN'] = 'x.firebaseapp.com';
+    process.env['NEXT_PUBLIC_FIREBASE_PROJECT_ID'] = 'x';
+    process.env['NEXT_PUBLIC_FIREBASE_APP_ID'] = 'x';
+    const { getFirebaseAuth, _resetFirebaseAppForTests } = await import('./firebase-client');
+    _resetFirebaseAppForTests();
+    const auth = await getFirebaseAuth();
+    expect(auth).not.toBeNull();
+    expect(setPersistenceMock).toHaveBeenCalledWith(expect.anything(), 'in-memory');
+  });
+});

--- a/apps/web/src/lib/auth/firebase-client.ts
+++ b/apps/web/src/lib/auth/firebase-client.ts
@@ -1,0 +1,56 @@
+'use client';
+
+/**
+ * story a0118204(E-AUTH-REBUILD Phase2-FE-S1·doc firebase-auth-identity-platform-migration-poc
+ * §1.1): Firebase 클라 SDK primary sign-in 초기화. **플래그 뒤·all off 시 무해** — Firebase
+ * 프로젝트 config(non-prod)가 아직 프로비저닝 전이라(오르테가군 확認), config 부재 시 절대
+ * throw하지 않고 null을 반환한다(호출부가 이 null을 "Firebase 비활성"으로 처리).
+ *
+ * doc §1.1 4번: 클라 persistence는 반드시 NONE — 서버 세션쿠키(`__Host-sp_fs`)가 SSOT이고
+ * 클라이언트 Firebase SDK 자체 세션을 남기지 않는다(교환 성공 직후 즉시 signOut, 호출부 책임).
+ */
+import { type FirebaseApp, initializeApp, getApps } from 'firebase/app';
+import { type Auth, getAuth, inMemoryPersistence, setPersistence } from 'firebase/auth';
+
+export const FIREBASE_AUTH_ENABLED = process.env['NEXT_PUBLIC_FIREBASE_AUTH_ENABLED'] === 'true';
+
+function readConfig(): Record<string, string> | null {
+  const apiKey = process.env['NEXT_PUBLIC_FIREBASE_API_KEY'];
+  const authDomain = process.env['NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN'];
+  const projectId = process.env['NEXT_PUBLIC_FIREBASE_PROJECT_ID'];
+  const appId = process.env['NEXT_PUBLIC_FIREBASE_APP_ID'];
+  if (!apiKey || !authDomain || !projectId || !appId) return null;
+  return { apiKey, authDomain, projectId, appId };
+}
+
+let _app: FirebaseApp | null | undefined;
+
+/** config 미프로비저닝(PO 인프라 lane 착지 전)이면 null — 절대 throw 안 함(스캐폴드 무해 원칙). */
+function getFirebaseApp(): FirebaseApp | null {
+  if (_app !== undefined) return _app;
+  const config = readConfig();
+  if (!config) {
+    _app = null;
+    return null;
+  }
+  _app = getApps()[0] ?? initializeApp(config);
+  return _app;
+}
+
+/**
+ * doc §1.1 4번(persistence=NONE)의 실제 구현 지점 — 서버 세션쿠키 SSOT 원칙상 브라우저에
+ * Firebase 자체 세션을 지속시키지 않는다. `inMemoryPersistence`가 Firebase SDK의 "세션 없음"
+ * 표현(로그인 도중 탭 이동 시에만 유지, 새로고침/재방문 시 소멸).
+ */
+export async function getFirebaseAuth(): Promise<Auth | null> {
+  const app = getFirebaseApp();
+  if (!app) return null;
+  const auth = getAuth(app);
+  await setPersistence(auth, inMemoryPersistence);
+  return auth;
+}
+
+// 테스트 전용 — 모듈 싱글톤이 테스트 간 상태를 누출하지 않도록.
+export function _resetFirebaseAppForTests(): void {
+  _app = undefined;
+}

--- a/apps/web/src/lib/auth/firebase-login-flow.test.ts
+++ b/apps/web/src/lib/auth/firebase-login-flow.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const signInWithEmailAndPasswordMock = vi.fn();
+const getFirebaseAuthMock = vi.fn();
+
+vi.mock('firebase/auth', () => ({
+  signInWithEmailAndPassword: (...args: unknown[]) => signInWithEmailAndPasswordMock(...args),
+}));
+
+vi.mock('./firebase-client', () => ({
+  getFirebaseAuth: () => getFirebaseAuthMock(),
+}));
+
+function mockAuth(signOut = vi.fn().mockResolvedValue(undefined)) {
+  return { signOut };
+}
+
+function mockFetchResponse(ok: boolean, status: number, body: unknown) {
+  return { ok, status, json: () => Promise.resolve(body) } as Response;
+}
+
+describe('signInAndExchangeFirebaseSession (story a0118204 — doc §1.1/§4.4 클라 오케스트레이션)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns FIREBASE_DISABLED without calling Firebase SDK when config is absent (getFirebaseAuth→null)', async () => {
+    getFirebaseAuthMock.mockResolvedValue(null);
+    const { signInAndExchangeFirebaseSession } = await import('./firebase-login-flow');
+    const result = await signInAndExchangeFirebaseSession('a@b.com', 'pw');
+    expect(result).toEqual({ ok: false, error: { code: 'FIREBASE_DISABLED', message: 'Firebase auth is not configured' } });
+    expect(signInWithEmailAndPasswordMock).not.toHaveBeenCalled();
+  });
+
+  it('does not call the session-exchange endpoint when Firebase sign-in itself fails (wrong password etc.)', async () => {
+    getFirebaseAuthMock.mockResolvedValue(mockAuth());
+    signInWithEmailAndPasswordMock.mockRejectedValue(new Error('auth/wrong-password'));
+    const { signInAndExchangeFirebaseSession } = await import('./firebase-login-flow');
+    const result = await signInAndExchangeFirebaseSession('a@b.com', 'wrong');
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe('FIREBASE_SIGNIN_FAILED');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('posts the ID token to /api/auth/firebase/session after successful Firebase sign-in', async () => {
+    const getIdToken = vi.fn().mockResolvedValue('id-token-123');
+    getFirebaseAuthMock.mockResolvedValue(mockAuth());
+    signInWithEmailAndPasswordMock.mockResolvedValue({ user: { getIdToken } });
+    vi.mocked(fetch).mockResolvedValue(mockFetchResponse(false, 501, { error: { code: 'NOT_ENABLED', message: 'not enabled' } }));
+    const { signInAndExchangeFirebaseSession } = await import('./firebase-login-flow');
+    await signInAndExchangeFirebaseSession('a@b.com', 'pw');
+    expect(fetch).toHaveBeenCalledWith('/api/auth/firebase/session', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ idToken: 'id-token-123' }),
+    }));
+  });
+
+  it('surfaces the server 501 (server flag still off) as a clean error — current expected state until Didi flips FIREBASE_AUTH_ISSUE_SESSION', async () => {
+    getFirebaseAuthMock.mockResolvedValue(mockAuth());
+    signInWithEmailAndPasswordMock.mockResolvedValue({ user: { getIdToken: vi.fn().mockResolvedValue('tok') } });
+    vi.mocked(fetch).mockResolvedValue(mockFetchResponse(false, 501, { error: { code: 'NOT_ENABLED', message: 'Firebase session issuance is not enabled' } }));
+    const { signInAndExchangeFirebaseSession } = await import('./firebase-login-flow');
+    const result = await signInAndExchangeFirebaseSession('a@b.com', 'pw');
+    expect(result).toEqual({ ok: false, error: { code: 'NOT_ENABLED', message: 'Firebase session issuance is not enabled' } });
+  });
+
+  it('clears client Firebase state (signOut) on exchange failure — never leaves a dangling client session', async () => {
+    const signOut = vi.fn().mockResolvedValue(undefined);
+    getFirebaseAuthMock.mockResolvedValue(mockAuth(signOut));
+    signInWithEmailAndPasswordMock.mockResolvedValue({ user: { getIdToken: vi.fn().mockResolvedValue('tok') } });
+    vi.mocked(fetch).mockResolvedValue(mockFetchResponse(false, 501, { error: { code: 'NOT_ENABLED', message: 'not enabled' } }));
+    const { signInAndExchangeFirebaseSession } = await import('./firebase-login-flow');
+    await signInAndExchangeFirebaseSession('a@b.com', 'pw');
+    expect(signOut).toHaveBeenCalledOnce();
+  });
+
+  it('clears client Firebase state (signOut) on exchange success — server __Host-sp_fs cookie becomes SSOT', async () => {
+    const signOut = vi.fn().mockResolvedValue(undefined);
+    getFirebaseAuthMock.mockResolvedValue(mockAuth(signOut));
+    signInWithEmailAndPasswordMock.mockResolvedValue({ user: { getIdToken: vi.fn().mockResolvedValue('tok') } });
+    vi.mocked(fetch).mockResolvedValue(mockFetchResponse(true, 200, {}));
+    const { signInAndExchangeFirebaseSession } = await import('./firebase-login-flow');
+    const result = await signInAndExchangeFirebaseSession('a@b.com', 'pw');
+    expect(result).toEqual({ ok: true, error: null });
+    expect(signOut).toHaveBeenCalledOnce();
+  });
+
+  it('returns NETWORK_ERROR (not a crash) when the fetch itself rejects', async () => {
+    getFirebaseAuthMock.mockResolvedValue(mockAuth());
+    signInWithEmailAndPasswordMock.mockResolvedValue({ user: { getIdToken: vi.fn().mockResolvedValue('tok') } });
+    vi.mocked(fetch).mockRejectedValue(new Error('offline'));
+    const { signInAndExchangeFirebaseSession } = await import('./firebase-login-flow');
+    const result = await signInAndExchangeFirebaseSession('a@b.com', 'pw');
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe('NETWORK_ERROR');
+  });
+});

--- a/apps/web/src/lib/auth/firebase-login-flow.ts
+++ b/apps/web/src/lib/auth/firebase-login-flow.ts
@@ -1,0 +1,59 @@
+'use client';
+
+/**
+ * story a0118204(E-AUTH-REBUILD Phase2-FE-S1·doc §1.1/§4.4): Firebase 클라 sign-in→ID토큰→
+ * BFF 세션교환(`POST /api/auth/firebase/session`, 디디 story 386a8b56 스캐폴드) 클라측 오케스트레이션.
+ *
+ * ⚠️서버 플래그(`FIREBASE_AUTH_ISSUE_SESSION`)가 꺼져있는 동안 BFF는 항상 501을 반환한다(디디
+ * route.ts 확認 — 이 파일이 아무리 호출돼도 실 세션 발급/legacy 쿠키 정리는 일어나지 않는다).
+ * 클라측 플래그(`NEXT_PUBLIC_FIREBASE_AUTH_ENABLED`)는 UX 노출(버튼 렌더) 게이트일 뿐 권한이
+ * 아니다 — 실 발급 권위는 서버 플래그(S1 쿠키캐시 설계 때 확立한 "UX 힌트≠권한" 패턴과 동형).
+ */
+import { signInWithEmailAndPassword } from 'firebase/auth';
+import { getFirebaseAuth } from './firebase-client';
+
+export interface FirebaseAuthResult {
+  ok: boolean;
+  error: { code: string; message: string } | null;
+}
+
+const DISABLED_ERROR = { code: 'FIREBASE_DISABLED', message: 'Firebase auth is not configured' } as const;
+
+/**
+ * doc §1.1 1-2번(클라 SDK sign-in+ID토큰 발급)+§4.4(세션교환 요청)+§1.1 5번(교환 성공 후
+ * persistence=NONE 하에서 signOut) 순서 그대로. 실패 시 어떤 단계든 signOut 없이 즉시 반환
+ * (교환 미완료 상태에서 로컬 Firebase 세션을 지속시키지 않기 위해 — Firebase SDK가
+ * inMemoryPersistence라 새로고침 시 어차피 소멸하지만, 명시적 정리가 정직함).
+ */
+export async function signInAndExchangeFirebaseSession(email: string, password: string): Promise<FirebaseAuthResult> {
+  const auth = await getFirebaseAuth();
+  if (!auth) return { ok: false, error: DISABLED_ERROR };
+
+  let idToken: string;
+  try {
+    const credential = await signInWithEmailAndPassword(auth, email, password);
+    idToken = await credential.user.getIdToken();
+  } catch {
+    return { ok: false, error: { code: 'FIREBASE_SIGNIN_FAILED', message: 'Firebase sign-in failed' } };
+  }
+
+  const res = await fetch('/api/auth/firebase/session', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ idToken }),
+  }).catch(() => null);
+
+  if (!res) return { ok: false, error: { code: 'NETWORK_ERROR', message: 'Session exchange request failed' } };
+
+  const json = await res.json().catch(() => null) as { error?: { code: string; message: string } } | null;
+
+  if (!res.ok) {
+    // doc §1.1 5번: 서버 세션쿠키 SSOT — 교환 실패 시 클라 Firebase 세션을 남기지 않는다.
+    await auth.signOut().catch(() => undefined);
+    return { ok: false, error: json?.error ?? { code: 'SESSION_EXCHANGE_FAILED', message: 'Session exchange failed' } };
+  }
+
+  // doc §1.1 5번: 교환 성공 후 즉시 signOut — 서버 __Host-sp_fs 쿠키가 SSOT.
+  await auth.signOut().catch(() => undefined);
+  return { ok: true, error: null };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       dompurify:
         specifier: ^3.3.3
         version: 3.3.3
+      firebase:
+        specifier: ^11.6.0
+        version: 11.10.0
       framer-motion:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1051,6 +1054,216 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@firebase/ai@1.4.1':
+    resolution: {integrity: sha512-bcusQfA/tHjUjBTnMx6jdoPMpDl3r8K15Z+snHz9wq0Foox0F/V+kNLXucEOHoTL2hTc9l+onZCyBJs2QoIC3g==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-types': 0.x
+
+  '@firebase/analytics-compat@0.2.23':
+    resolution: {integrity: sha512-3AdO10RN18G5AzREPoFgYhW6vWXr3u+OYQv6pl3CX6Fky8QRk0AHurZlY3Q1xkXO0TDxIsdhO3y65HF7PBOJDw==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/analytics-types@0.8.3':
+    resolution: {integrity: sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==}
+
+  '@firebase/analytics@0.10.17':
+    resolution: {integrity: sha512-n5vfBbvzduMou/2cqsnKrIes4auaBjdhg8QNA2ZQZ59QgtO2QiwBaXQZQE4O4sgB0Ds1tvLgUUkY+pwzu6/xEg==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/app-check-compat@0.3.26':
+    resolution: {integrity: sha512-PkX+XJMLDea6nmnopzFKlr+s2LMQGqdyT2DHdbx1v1dPSqOol2YzgpgymmhC67vitXVpNvS3m/AiWQWWhhRRPQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/app-check-interop-types@0.3.3':
+    resolution: {integrity: sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==}
+
+  '@firebase/app-check-types@0.5.3':
+    resolution: {integrity: sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==}
+
+  '@firebase/app-check@0.10.1':
+    resolution: {integrity: sha512-MgNdlms9Qb0oSny87pwpjKush9qUwCJhfmTJHDfrcKo4neLGiSeVE4qJkzP7EQTIUFKp84pbTxobSAXkiuQVYQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/app-compat@0.4.2':
+    resolution: {integrity: sha512-LssbyKHlwLeiV8GBATyOyjmHcMpX/tFjzRUCS1jnwGAew1VsBB4fJowyS5Ud5LdFbYpJeS+IQoC+RQxpK7eH3Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@firebase/app-types@0.9.3':
+    resolution: {integrity: sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==}
+
+  '@firebase/app@0.13.2':
+    resolution: {integrity: sha512-jwtMmJa1BXXDCiDx1vC6SFN/+HfYG53UkfJa6qeN5ogvOunzbFDO3wISZy5n9xgYFUrEP6M7e8EG++riHNTv9w==}
+    engines: {node: '>=18.0.0'}
+
+  '@firebase/auth-compat@0.5.28':
+    resolution: {integrity: sha512-HpMSo/cc6Y8IX7bkRIaPPqT//Jt83iWy5rmDWeThXQCAImstkdNo3giFLORJwrZw2ptiGkOij64EH1ztNJzc7Q==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/auth-interop-types@0.2.4':
+    resolution: {integrity: sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==}
+
+  '@firebase/auth-types@0.13.0':
+    resolution: {integrity: sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+
+  '@firebase/auth@1.10.8':
+    resolution: {integrity: sha512-GpuTz5ap8zumr/ocnPY57ZanX02COsXloY6Y/2LYPAuXYiaJRf6BAGDEdRq1BMjP93kqQnKNuKZUTMZbQ8MNYA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@react-native-async-storage/async-storage': ^1.18.1
+    peerDependenciesMeta:
+      '@react-native-async-storage/async-storage':
+        optional: true
+
+  '@firebase/component@0.6.18':
+    resolution: {integrity: sha512-n28kPCkE2dL2U28fSxZJjzPPVpKsQminJ6NrzcKXAI0E/lYC8YhfwpyllScqVEvAI3J2QgJZWYgrX+1qGI+SQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@firebase/data-connect@0.3.10':
+    resolution: {integrity: sha512-VMVk7zxIkgwlVQIWHOKFahmleIjiVFwFOjmakXPd/LDgaB/5vzwsB5DWIYo+3KhGxWpidQlR8geCIn39YflJIQ==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/database-compat@2.0.11':
+    resolution: {integrity: sha512-itEsHARSsYS95+udF/TtIzNeQ0Uhx4uIna0sk4E0wQJBUnLc/G1X6D7oRljoOuwwCezRLGvWBRyNrugv/esOEw==}
+    engines: {node: '>=18.0.0'}
+
+  '@firebase/database-types@1.0.15':
+    resolution: {integrity: sha512-XWHJ0VUJ0k2E9HDMlKxlgy/ZuTa9EvHCGLjaKSUvrQnwhgZuRU5N3yX6SZ+ftf2hTzZmfRkv+b3QRvGg40bKNw==}
+
+  '@firebase/database@1.0.20':
+    resolution: {integrity: sha512-H9Rpj1pQ1yc9+4HQOotFGLxqAXwOzCHsRSRjcQFNOr8lhUt6LeYjf0NSRL04sc4X0dWe8DsCvYKxMYvFG/iOJw==}
+    engines: {node: '>=18.0.0'}
+
+  '@firebase/firestore-compat@0.3.53':
+    resolution: {integrity: sha512-qI3yZL8ljwAYWrTousWYbemay2YZa+udLWugjdjju2KODWtLG94DfO4NALJgPLv8CVGcDHNFXoyQexdRA0Cz8Q==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/firestore-types@3.0.3':
+    resolution: {integrity: sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+
+  '@firebase/firestore@4.8.0':
+    resolution: {integrity: sha512-QSRk+Q1/CaabKyqn3C32KSFiOdZpSqI9rpLK5BHPcooElumOBooPFa6YkDdiT+/KhJtel36LdAacha9BptMj2A==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/functions-compat@0.3.26':
+    resolution: {integrity: sha512-A798/6ff5LcG2LTWqaGazbFYnjBW8zc65YfID/en83ALmkhu2b0G8ykvQnLtakbV9ajrMYPn7Yc/XcYsZIUsjA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/functions-types@0.6.3':
+    resolution: {integrity: sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==}
+
+  '@firebase/functions@0.12.9':
+    resolution: {integrity: sha512-FG95w6vjbUXN84Ehezc2SDjGmGq225UYbHrb/ptkRT7OTuCiQRErOQuyt1jI1tvcDekdNog+anIObihNFz79Lg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/installations-compat@0.2.18':
+    resolution: {integrity: sha512-aLFohRpJO5kKBL/XYL4tN+GdwEB/Q6Vo9eZOM/6Kic7asSUgmSfGPpGUZO1OAaSRGwF4Lqnvi1f/f9VZnKzChw==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/installations-types@0.5.3':
+    resolution: {integrity: sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+
+  '@firebase/installations@0.6.18':
+    resolution: {integrity: sha512-NQ86uGAcvO8nBRwVltRL9QQ4Reidc/3whdAasgeWCPIcrhOKDuNpAALa6eCVryLnK14ua2DqekCOX5uC9XbU/A==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/logger@0.4.4':
+    resolution: {integrity: sha512-mH0PEh1zoXGnaR8gD1DeGeNZtWFKbnz9hDO91dIml3iou1gpOnLqXQ2dJfB71dj6dpmUjcQ6phY3ZZJbjErr9g==}
+    engines: {node: '>=18.0.0'}
+
+  '@firebase/messaging-compat@0.2.22':
+    resolution: {integrity: sha512-5ZHtRnj6YO6f/QPa/KU6gryjmX4Kg33Kn4gRpNU6M1K47Gm8kcQwPkX7erRUYEH1mIWptfvjvXMHWoZaWjkU7A==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/messaging-interop-types@0.2.3':
+    resolution: {integrity: sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==}
+
+  '@firebase/messaging@0.12.22':
+    resolution: {integrity: sha512-GJcrPLc+Hu7nk+XQ70Okt3M1u1eRr2ZvpMbzbc54oTPJZySHcX9ccZGVFcsZbSZ6o1uqumm8Oc7OFkD3Rn1/og==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/performance-compat@0.2.20':
+    resolution: {integrity: sha512-XkFK5NmOKCBuqOKWeRgBUFZZGz9SzdTZp4OqeUg+5nyjapTiZ4XoiiUL8z7mB2q+63rPmBl7msv682J3rcDXIQ==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/performance-types@0.2.3':
+    resolution: {integrity: sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==}
+
+  '@firebase/performance@0.7.7':
+    resolution: {integrity: sha512-JTlTQNZKAd4+Q5sodpw6CN+6NmwbY72av3Lb6wUKTsL7rb3cuBIhQSrslWbVz0SwK3x0ZNcqX24qtRbwKiv+6w==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/remote-config-compat@0.2.18':
+    resolution: {integrity: sha512-YiETpldhDy7zUrnS8e+3l7cNs0sL7+tVAxvVYU0lu7O+qLHbmdtAxmgY+wJqWdW2c9nDvBFec7QiF58pEUu0qQ==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/remote-config-types@0.4.0':
+    resolution: {integrity: sha512-7p3mRE/ldCNYt8fmWMQ/MSGRmXYlJ15Rvs9Rk17t8p0WwZDbeK7eRmoI1tvCPaDzn9Oqh+yD6Lw+sGLsLg4kKg==}
+
+  '@firebase/remote-config@0.6.5':
+    resolution: {integrity: sha512-fU0c8HY0vrVHwC+zQ/fpXSqHyDMuuuglV94VF6Yonhz8Fg2J+KOowPGANM0SZkLvVOYpTeWp3ZmM+F6NjwWLnw==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/storage-compat@0.3.24':
+    resolution: {integrity: sha512-XHn2tLniiP7BFKJaPZ0P8YQXKiVJX+bMyE2j2YWjYfaddqiJnROJYqSomwW6L3Y+gZAga35ONXUJQju6MB6SOQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/storage-types@0.8.3':
+    resolution: {integrity: sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+
+  '@firebase/storage@0.13.14':
+    resolution: {integrity: sha512-xTq5ixxORzx+bfqCpsh+o3fxOsGoDjC1nO0Mq2+KsOcny3l7beyBhP/y1u5T6mgsFQwI1j6oAkbT5cWdDBx87g==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/util@1.12.1':
+    resolution: {integrity: sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==}
+    engines: {node: '>=18.0.0'}
+
+  '@firebase/webchannel-wrapper@1.0.3':
+    resolution: {integrity: sha512-2xCRM9q9FlzGZCdgDMJwc0gyUkWFtkosy7Xxr6sFgQwn+wMNIWd7xIvYNauU1r64B5L5rsGKy/n9TKJ0aAFeqQ==}
+
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
@@ -1099,6 +1312,15 @@ packages:
   '@google-cloud/storage@7.19.0':
     resolution: {integrity: sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==}
     engines: {node: '>=14'}
+
+  '@grpc/grpc-js@1.9.16':
+    resolution: {integrity: sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==}
+    engines: {node: ^8.13.0 || >=10.10.0}
+
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   '@hono/node-server@1.19.12':
     resolution: {integrity: sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==}
@@ -1555,6 +1777,33 @@ packages:
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
@@ -3740,6 +3989,10 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  faye-websocket@0.11.4:
+    resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
+    engines: {node: '>=0.8.0'}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -3772,6 +4025,9 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  firebase@11.10.0:
+    resolution: {integrity: sha512-nKBXoDzF0DrXTBQJlZa+sbC5By99ysYU1D6PkMRYknm0nCW7rJly47q492Ht7Ndz5MeYSBuboKuhS1e6mFC03w==}
 
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
@@ -4039,6 +4295,9 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  http-parser-js@0.5.10:
+    resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
+
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
@@ -4073,6 +4332,9 @@ packages:
 
   icu-minify@4.9.0:
     resolution: {integrity: sha512-9ev7MqkN29jcIelUAqJRfNCxzGOEkBJPnr+scYATMp2bfpU4Bm1eIwYU0/o5xRy8BBnSWMUjK58WTB3132P0bg==}
+
+  idb@7.1.1:
+    resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -4511,12 +4773,18 @@ packages:
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
     engines: {node: '>=18'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -5162,6 +5430,10 @@ packages:
 
   prosemirror-view@1.41.8:
     resolution: {integrity: sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==}
+
+  protobufjs@7.6.5:
+    resolution: {integrity: sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==}
+    engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
@@ -6039,12 +6311,23 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  web-vitals@4.2.4:
+    resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
+
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
+    engines: {node: '>=0.8.0'}
+
+  websocket-extensions@0.1.4:
+    resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
+    engines: {node: '>=0.8.0'}
 
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
@@ -6953,6 +7236,324 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 1.8.0
 
+  '@firebase/ai@1.4.1(@firebase/app-types@0.9.3)(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app': 0.13.2
+      '@firebase/app-check-interop-types': 0.3.3
+      '@firebase/app-types': 0.9.3
+      '@firebase/component': 0.6.18
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+
+  '@firebase/analytics-compat@0.2.23(@firebase/app-compat@0.4.2)(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/analytics': 0.10.17(@firebase/app@0.13.2)
+      '@firebase/analytics-types': 0.8.3
+      '@firebase/app-compat': 0.4.2
+      '@firebase/component': 0.6.18
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/analytics-types@0.8.3': {}
+
+  '@firebase/analytics@0.10.17(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app': 0.13.2
+      '@firebase/component': 0.6.18
+      '@firebase/installations': 0.6.18(@firebase/app@0.13.2)
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+
+  '@firebase/app-check-compat@0.3.26(@firebase/app-compat@0.4.2)(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app-check': 0.10.1(@firebase/app@0.13.2)
+      '@firebase/app-check-types': 0.5.3
+      '@firebase/app-compat': 0.4.2
+      '@firebase/component': 0.6.18
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/app-check-interop-types@0.3.3': {}
+
+  '@firebase/app-check-types@0.5.3': {}
+
+  '@firebase/app-check@0.10.1(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app': 0.13.2
+      '@firebase/component': 0.6.18
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+
+  '@firebase/app-compat@0.4.2':
+    dependencies:
+      '@firebase/app': 0.13.2
+      '@firebase/component': 0.6.18
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+
+  '@firebase/app-types@0.9.3': {}
+
+  '@firebase/app@0.13.2':
+    dependencies:
+      '@firebase/component': 0.6.18
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.12.1
+      idb: 7.1.1
+      tslib: 2.8.1
+
+  '@firebase/auth-compat@0.5.28(@firebase/app-compat@0.4.2)(@firebase/app-types@0.9.3)(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app-compat': 0.4.2
+      '@firebase/auth': 1.10.8(@firebase/app@0.13.2)
+      '@firebase/auth-types': 0.13.0(@firebase/app-types@0.9.3)(@firebase/util@1.12.1)
+      '@firebase/component': 0.6.18
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+      - '@firebase/app-types'
+      - '@react-native-async-storage/async-storage'
+
+  '@firebase/auth-interop-types@0.2.4': {}
+
+  '@firebase/auth-types@0.13.0(@firebase/app-types@0.9.3)(@firebase/util@1.12.1)':
+    dependencies:
+      '@firebase/app-types': 0.9.3
+      '@firebase/util': 1.12.1
+
+  '@firebase/auth@1.10.8(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app': 0.13.2
+      '@firebase/component': 0.6.18
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+
+  '@firebase/component@0.6.18':
+    dependencies:
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+
+  '@firebase/data-connect@0.3.10(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app': 0.13.2
+      '@firebase/auth-interop-types': 0.2.4
+      '@firebase/component': 0.6.18
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+
+  '@firebase/database-compat@2.0.11':
+    dependencies:
+      '@firebase/component': 0.6.18
+      '@firebase/database': 1.0.20
+      '@firebase/database-types': 1.0.15
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+
+  '@firebase/database-types@1.0.15':
+    dependencies:
+      '@firebase/app-types': 0.9.3
+      '@firebase/util': 1.12.1
+
+  '@firebase/database@1.0.20':
+    dependencies:
+      '@firebase/app-check-interop-types': 0.3.3
+      '@firebase/auth-interop-types': 0.2.4
+      '@firebase/component': 0.6.18
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.12.1
+      faye-websocket: 0.11.4
+      tslib: 2.8.1
+
+  '@firebase/firestore-compat@0.3.53(@firebase/app-compat@0.4.2)(@firebase/app-types@0.9.3)(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app-compat': 0.4.2
+      '@firebase/component': 0.6.18
+      '@firebase/firestore': 4.8.0(@firebase/app@0.13.2)
+      '@firebase/firestore-types': 3.0.3(@firebase/app-types@0.9.3)(@firebase/util@1.12.1)
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+      - '@firebase/app-types'
+
+  '@firebase/firestore-types@3.0.3(@firebase/app-types@0.9.3)(@firebase/util@1.12.1)':
+    dependencies:
+      '@firebase/app-types': 0.9.3
+      '@firebase/util': 1.12.1
+
+  '@firebase/firestore@4.8.0(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app': 0.13.2
+      '@firebase/component': 0.6.18
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.12.1
+      '@firebase/webchannel-wrapper': 1.0.3
+      '@grpc/grpc-js': 1.9.16
+      '@grpc/proto-loader': 0.7.15
+      tslib: 2.8.1
+
+  '@firebase/functions-compat@0.3.26(@firebase/app-compat@0.4.2)(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app-compat': 0.4.2
+      '@firebase/component': 0.6.18
+      '@firebase/functions': 0.12.9(@firebase/app@0.13.2)
+      '@firebase/functions-types': 0.6.3
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/functions-types@0.6.3': {}
+
+  '@firebase/functions@0.12.9(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app': 0.13.2
+      '@firebase/app-check-interop-types': 0.3.3
+      '@firebase/auth-interop-types': 0.2.4
+      '@firebase/component': 0.6.18
+      '@firebase/messaging-interop-types': 0.2.3
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+
+  '@firebase/installations-compat@0.2.18(@firebase/app-compat@0.4.2)(@firebase/app-types@0.9.3)(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app-compat': 0.4.2
+      '@firebase/component': 0.6.18
+      '@firebase/installations': 0.6.18(@firebase/app@0.13.2)
+      '@firebase/installations-types': 0.5.3(@firebase/app-types@0.9.3)
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+      - '@firebase/app-types'
+
+  '@firebase/installations-types@0.5.3(@firebase/app-types@0.9.3)':
+    dependencies:
+      '@firebase/app-types': 0.9.3
+
+  '@firebase/installations@0.6.18(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app': 0.13.2
+      '@firebase/component': 0.6.18
+      '@firebase/util': 1.12.1
+      idb: 7.1.1
+      tslib: 2.8.1
+
+  '@firebase/logger@0.4.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@firebase/messaging-compat@0.2.22(@firebase/app-compat@0.4.2)(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app-compat': 0.4.2
+      '@firebase/component': 0.6.18
+      '@firebase/messaging': 0.12.22(@firebase/app@0.13.2)
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/messaging-interop-types@0.2.3': {}
+
+  '@firebase/messaging@0.12.22(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app': 0.13.2
+      '@firebase/component': 0.6.18
+      '@firebase/installations': 0.6.18(@firebase/app@0.13.2)
+      '@firebase/messaging-interop-types': 0.2.3
+      '@firebase/util': 1.12.1
+      idb: 7.1.1
+      tslib: 2.8.1
+
+  '@firebase/performance-compat@0.2.20(@firebase/app-compat@0.4.2)(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app-compat': 0.4.2
+      '@firebase/component': 0.6.18
+      '@firebase/logger': 0.4.4
+      '@firebase/performance': 0.7.7(@firebase/app@0.13.2)
+      '@firebase/performance-types': 0.2.3
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/performance-types@0.2.3': {}
+
+  '@firebase/performance@0.7.7(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app': 0.13.2
+      '@firebase/component': 0.6.18
+      '@firebase/installations': 0.6.18(@firebase/app@0.13.2)
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+      web-vitals: 4.2.4
+
+  '@firebase/remote-config-compat@0.2.18(@firebase/app-compat@0.4.2)(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app-compat': 0.4.2
+      '@firebase/component': 0.6.18
+      '@firebase/logger': 0.4.4
+      '@firebase/remote-config': 0.6.5(@firebase/app@0.13.2)
+      '@firebase/remote-config-types': 0.4.0
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/remote-config-types@0.4.0': {}
+
+  '@firebase/remote-config@0.6.5(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app': 0.13.2
+      '@firebase/component': 0.6.18
+      '@firebase/installations': 0.6.18(@firebase/app@0.13.2)
+      '@firebase/logger': 0.4.4
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+
+  '@firebase/storage-compat@0.3.24(@firebase/app-compat@0.4.2)(@firebase/app-types@0.9.3)(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app-compat': 0.4.2
+      '@firebase/component': 0.6.18
+      '@firebase/storage': 0.13.14(@firebase/app@0.13.2)
+      '@firebase/storage-types': 0.8.3(@firebase/app-types@0.9.3)(@firebase/util@1.12.1)
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+      - '@firebase/app-types'
+
+  '@firebase/storage-types@0.8.3(@firebase/app-types@0.9.3)(@firebase/util@1.12.1)':
+    dependencies:
+      '@firebase/app-types': 0.9.3
+      '@firebase/util': 1.12.1
+
+  '@firebase/storage@0.13.14(@firebase/app@0.13.2)':
+    dependencies:
+      '@firebase/app': 0.13.2
+      '@firebase/component': 0.6.18
+      '@firebase/util': 1.12.1
+      tslib: 2.8.1
+
+  '@firebase/util@1.12.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@firebase/webchannel-wrapper@1.0.3': {}
+
   '@floating-ui/core@1.7.5':
     dependencies:
       '@floating-ui/utils': 0.2.11
@@ -7022,6 +7623,18 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@grpc/grpc-js@1.9.16':
+    dependencies:
+      '@grpc/proto-loader': 0.7.15
+      '@types/node': 22.19.17
+
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.6.5
+      yargs: 17.7.2
 
   '@hono/node-server@1.19.12(hono@4.12.9)':
     dependencies:
@@ -7440,6 +8053,26 @@ snapshots:
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.4)':
     dependencies:
@@ -9819,6 +10452,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  faye-websocket@0.11.4:
+    dependencies:
+      websocket-driver: 0.7.5
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -9855,6 +10492,39 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  firebase@11.10.0:
+    dependencies:
+      '@firebase/ai': 1.4.1(@firebase/app-types@0.9.3)(@firebase/app@0.13.2)
+      '@firebase/analytics': 0.10.17(@firebase/app@0.13.2)
+      '@firebase/analytics-compat': 0.2.23(@firebase/app-compat@0.4.2)(@firebase/app@0.13.2)
+      '@firebase/app': 0.13.2
+      '@firebase/app-check': 0.10.1(@firebase/app@0.13.2)
+      '@firebase/app-check-compat': 0.3.26(@firebase/app-compat@0.4.2)(@firebase/app@0.13.2)
+      '@firebase/app-compat': 0.4.2
+      '@firebase/app-types': 0.9.3
+      '@firebase/auth': 1.10.8(@firebase/app@0.13.2)
+      '@firebase/auth-compat': 0.5.28(@firebase/app-compat@0.4.2)(@firebase/app-types@0.9.3)(@firebase/app@0.13.2)
+      '@firebase/data-connect': 0.3.10(@firebase/app@0.13.2)
+      '@firebase/database': 1.0.20
+      '@firebase/database-compat': 2.0.11
+      '@firebase/firestore': 4.8.0(@firebase/app@0.13.2)
+      '@firebase/firestore-compat': 0.3.53(@firebase/app-compat@0.4.2)(@firebase/app-types@0.9.3)(@firebase/app@0.13.2)
+      '@firebase/functions': 0.12.9(@firebase/app@0.13.2)
+      '@firebase/functions-compat': 0.3.26(@firebase/app-compat@0.4.2)(@firebase/app@0.13.2)
+      '@firebase/installations': 0.6.18(@firebase/app@0.13.2)
+      '@firebase/installations-compat': 0.2.18(@firebase/app-compat@0.4.2)(@firebase/app-types@0.9.3)(@firebase/app@0.13.2)
+      '@firebase/messaging': 0.12.22(@firebase/app@0.13.2)
+      '@firebase/messaging-compat': 0.2.22(@firebase/app-compat@0.4.2)(@firebase/app@0.13.2)
+      '@firebase/performance': 0.7.7(@firebase/app@0.13.2)
+      '@firebase/performance-compat': 0.2.20(@firebase/app-compat@0.4.2)(@firebase/app@0.13.2)
+      '@firebase/remote-config': 0.6.5(@firebase/app@0.13.2)
+      '@firebase/remote-config-compat': 0.2.18(@firebase/app-compat@0.4.2)(@firebase/app@0.13.2)
+      '@firebase/storage': 0.13.14(@firebase/app@0.13.2)
+      '@firebase/storage-compat': 0.3.24(@firebase/app-compat@0.4.2)(@firebase/app-types@0.9.3)(@firebase/app@0.13.2)
+      '@firebase/util': 1.12.1
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
 
   flat-cache@4.0.1:
     dependencies:
@@ -10192,6 +10862,8 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-parser-js@0.5.10: {}
+
   http-proxy-agent@5.0.0:
     dependencies:
       '@tootallnate/once': 2.0.0
@@ -10231,6 +10903,8 @@ snapshots:
   icu-minify@4.9.0:
     dependencies:
       '@formatjs/icu-messageformat-parser': 3.5.3
+
+  idb@7.1.1: {}
 
   ignore@5.3.2: {}
 
@@ -10624,12 +11298,16 @@ snapshots:
 
   lodash-es@4.18.1: {}
 
+  lodash.camelcase@4.3.0: {}
+
   lodash.merge@4.6.2: {}
 
   log-symbols@6.0.0:
     dependencies:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
+
+  long@5.3.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -11580,6 +12258,20 @@ snapshots:
       prosemirror-model: 1.25.4
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
+
+  protobufjs@7.6.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 22.19.17
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:
@@ -12712,9 +13404,19 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  web-vitals@4.2.4: {}
+
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@8.0.1: {}
+
+  websocket-driver@0.7.5:
+    dependencies:
+      http-parser-js: 0.5.10
+      safe-buffer: 5.2.1
+      websocket-extensions: 0.1.4
+
+  websocket-extensions@0.1.4: {}
 
   whatwg-mimetype@5.0.0: {}
 


### PR DESCRIPTION
## 요약
story `a0118204`. 선생님 Firebase GO + 산티아고 doc `firebase-auth-identity-platform-migration-poc` §1.1/§4.4 웹 세션 설계 위. 디디 Phase1(S1 스키마+S3 BFF 검증기/세션발급 스캐폴드, #2192/#2193 머지 완료) 착지 위에 클라측을 쌓는다 — **S2(dual-verifier) 종속을 "스캐폴드로 우회"**(오르테가군 지시): 플래그 뒤에 실 코드를 미리 쌓아두고, 나중에 서버 플래그만 켜면 활성화되는 구조.

## 구현
- `lib/auth/firebase-client.ts`: Firebase 클라 SDK 초기화(app+auth 싱글톤). Firebase 프로젝트 config(non-prod)가 아직 프로비저닝 전이라 — config 부재 시 절대 throw 안 하고 `null` 반환(스캐폴드 무해 원칙). persistence=`inMemoryPersistence` 강제(doc §1.1 4번 — 서버 `__Host-sp_fs` 쿠키가 세션 SSOT, 클라 Firebase 세션을 지속시키지 않음).
- `lib/auth/firebase-login-flow.ts`: `signInAndExchangeFirebaseSession()` — Firebase 클라 sign-in→ID토큰→`POST /api/auth/firebase/session`(디디 story 386a8b56 스캐폴드 엔드포인트, 현재 서버 플래그 `FIREBASE_AUTH_ISSUE_SESSION` off라 항상 501 반환 = 기대되는 현재 상태)→성공/실패 무관 즉시 signOut(doc §1.1 5번, 서버 쿠키 SSOT 원칙).
- `app/login/page.tsx`: 기존 `NEXT_PUBLIC_OAUTH_ENABLED` 플래그 패턴 그대로 따라 `NEXT_PUBLIC_FIREBASE_AUTH_ENABLED`(클라 노출 게이트) 뒤에 버튼 추가 — **꺼져있으면(기본) 버튼 자체가 렌더 안 돼 기존 레거시 로그인 폼 100% 무변경**. ⚠️클라 플래그는 UX 노출 게이트일 뿐 권한이 아니다 — 실 세션 발급 권위는 서버 플래그(BFF가 독립적으로 재검증, S1 쿠키캐시 설계 때 확立한 "UX 힌트≠권한" 패턴과 동형).
- `package.json`: `firebase` npm 의존성 추가(Phase 2 진입점, doc §12 Q1 명시).

## 뮤테이션 셀프체크
signOut이 교환 실패 시에도 반드시 호출되는지(서버 쿠키 SSOT 원칙 — 클라에 dangling Firebase 세션 안 남김) 회귀가드를 되돌려 RED 확인 → 원복.

## 스코프 밖 (명시)
- Google/GitHub provider 연동(doc §7.3, 별도 4-7일 패키지).
- Apple(native-only, 웹 FE 아님 — 오르테가군 최초 지시를 그라운딩으로 정정받아 수용).
- 실 로그인 UI "전환"(레거시 폼 교체) 여부는 Phase2 shadow 검증 후 유나 UX 판단 필요 — 이번 스캐폴드는 **병존 버튼**(기존 OAuth 패턴 동형)으로 최소 리스크 선택. 플래그 on 시 실제 UX(교체 vs 병존)는 별도 결정.

## 게이트 (전부 실측)
- `tsc --noEmit`: 0 errors
- `eslint`: 0 errors (5개 사전 존재·무관 warning)
- `vitest run` (apps/web): 237 files / 1555 passed / 2 skipped
- `vitest run` (repo-root): 253 files / 1729 passed / 2 skipped
- `next build`(`NEXT_TELEMETRY_DISABLED=1`): **EXIT=0** — `/login` 컴파일, 플래그 off 상태에서 레거시 로그인 경로 무변경 확인

## 리뷰 요청
까심군 QA 부탁드리는(플래그 off 무해 확認 + 기존 legacy 로그인 무회귀) — 산티아고는 doc 승인 시점이라 이번 routine 리뷰는 불요(Phase4에서만 관여 예정, story 스코프 명시).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>