### PR TITLE
feat(auth): E-AUTH-REBUILD Phase1-S2 — FastAPI dual-verifier + AuthContext role mapping

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -209,6 +209,66 @@ async def _resolve_api_key(
     )
 
 
+async def _resolve_firebase_session(token: str, db: AsyncSession) -> AuthContext:
+    """story 455e528d(doc §3.3): Firebase 세션 검증 후 resource-actual AuthContext 구성.
+
+    (issuer, sub) → auth_identities → 실 users.id 매핑. disabled/deleted/unmapped 거부.
+
+    ⚠️발견 즉시 수정: get_org_scope/require_role/require_admin이 전부 auth.claims의
+    app_metadata.role/org_id를 읽는다(legacy JWT는 로그인 시점에 이 claim을 정적으로 굽는다).
+    Firebase 세션쿠키는 이 필드를 안 실어(doc §3.3 명시 — custom claim에 org/role 안 옮김)
+    role을 안 채우면 require_role/require_admin이 전부 기본값 "member"로 평가돼 실제 admin도
+    권한 거부당한다 — **매 요청 실 DB에서 org role을 조회**해 채운다(legacy처럼 로그인 시점
+    1회 굽는 게 아니라 요청마다 live 조회라 오히려 stale 위험이 legacy보다 낮음. _build_app_
+    metadata() 전체는 재사용 안 함 — 그건 invite 자동수락 등 로그인 전용 side effect가 있어
+    매 요청 호출에 부적합, 여기선 role만 순수 조회).
+    """
+    from app.core.config import settings as _settings
+    from app.models.auth_identity import AuthIdentity
+    from app.models.project import OrgMember
+    from app.models.user import User
+    from app.services.firebase_verifier import verify_firebase_session
+
+    verified = await verify_firebase_session(token, _settings.firebase_project_id)
+    if verified is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    identity_row = (await db.execute(
+        select(AuthIdentity).where(
+            AuthIdentity.issuer == verified.issuer,
+            AuthIdentity.subject == verified.firebase_uid,
+            AuthIdentity.unlinked_at.is_(None),
+        )
+    )).scalar_one_or_none()
+    if identity_row is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unmapped Firebase identity")
+
+    user = await db.get(User, identity_row.user_id)
+    if user is None or not user.is_active:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    org_id = str(user.last_org_id) if user.last_org_id else None
+    app_metadata: dict = {}
+    if org_id:
+        app_metadata["org_id"] = org_id
+        role = (await db.execute(
+            select(OrgMember.role).where(
+                OrgMember.org_id == user.last_org_id,
+                OrgMember.user_id == user.id,
+                OrgMember.deleted_at.is_(None),
+            ).limit(1)
+        )).scalar_one_or_none()
+        if role:
+            app_metadata["role"] = role
+
+    return AuthContext(
+        user_id=str(user.id),
+        email=user.email,
+        claims={"auth_issuer": verified.issuer, "app_metadata": app_metadata},
+        org_id=org_id,
+    )
+
+
 async def get_current_user(
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
     x_agent_api_key: str | None = Header(default=None, alias="x-agent-api-key"),
@@ -227,6 +287,15 @@ async def get_current_user(
     # sk_live_* prefix → API key 경로 (DB 조회)
     if token.startswith("sk_live_"):
         return await _resolve_api_key(token, db, transport=x_mcp_transport)
+
+    # story 455e528d(E-AUTH-REBUILD Phase1-S2·doc §4.2): Firebase 세션(RS256)은 alg 헤더로
+    # 정확 분기 — 순차 fallback 아님. FIREBASE_AUTH_ACCEPT_SESSION=false(기본)면 이 분기는
+    # 절대 안 타므로(alg 판정과 무관하게) 기존 동작 100% 유지 — dead code.
+    from app.core.config import settings as _settings
+    from app.services.firebase_verifier import looks_like_rs256
+
+    if _settings.firebase_auth_accept_session and looks_like_rs256(token):
+        return await _resolve_firebase_session(token, db)
 
     # JWT 경로 (기존)
     try:
@@ -625,6 +694,16 @@ async def get_current_user_streaming(
     if token.startswith("sk_live_"):
         async with async_session_factory() as db:
             return await _resolve_api_key(token, db)
+
+    # story 455e528d(doc §4.3 "mirror the dual verifier in get_current_user_streaming"):
+    # get_current_user와 동일하게 alg 헤더로 정확 분기(순차 fallback 아님). 단명 세션으로
+    # 매핑만 수행 후 즉시 close(스트림 yield 구간에 커넥션 미점유, 기존 API key 경로와 동형).
+    from app.core.config import settings as _settings
+    from app.services.firebase_verifier import looks_like_rs256
+
+    if _settings.firebase_auth_accept_session and looks_like_rs256(token):
+        async with async_session_factory() as db:
+            return await _resolve_firebase_session(token, db)
 
     try:
         payload = decode_jwt(token)

--- a/backend/app/services/firebase_verifier.py
+++ b/backend/app/services/firebase_verifier.py
@@ -1,0 +1,151 @@
+"""story 455e528d(E-AUTH-REBUILD M2 Phase1-S2·doc firebase-auth-identity-platform-migration-poc
+§4.2): Firebase 세션쿠키 정확 검증 — python-jose 재사용(신규 의존성 0, FE의 jose와 동형 설계).
+
+Firebase 세션쿠키 공개키는 JWKS 표준이 아닌 kid→X.509 PEM 맵이라(FE firebase-session.ts와
+동일 이유) cryptography로 인증서를 직접 파싱해 공개키를 뽑는다.
+
+⛔순차 fallback 금지 — alg/iss/aud/kid 전부 정확 매칭만 통과. 실패 시 None(호출부가 legacy로
+다운그레이드하면 안 됨, doc §4.1).
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import httpx
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+from cryptography.x509 import load_pem_x509_certificate
+from jose import jwt as jose_jwt
+from jose.exceptions import JWTError
+from jose.utils import long_to_base64
+
+# Firebase 공식 문서(doc §14): 세션쿠키 검증용 공개키 — ID token용 URL과 다르다(혼동 시 issuer
+# confusion — doc §4.2 명시 위험).
+FIREBASE_SESSION_PUBLIC_KEYS_URL = "https://www.googleapis.com/identitytoolkit/v3/relyingparty/publicKeys"
+_DEFAULT_KEY_CACHE_SECONDS = 60 * 60  # 1시간(Cache-Control 헤더 없을 때 폴백)
+_MAX_KEY_CACHE_SECONDS = 24 * 60 * 60
+
+_key_cache: dict[str, str] = {}
+_key_cache_expires_at: float = 0.0
+
+
+def _reset_key_cache_for_tests() -> None:
+    """테스트 전용 — 모듈 레벨 키 캐시가 테스트 간 상태를 누출하지 않도록 초기화."""
+    global _key_cache, _key_cache_expires_at
+    _key_cache = {}
+    _key_cache_expires_at = 0.0
+
+
+async def _fetch_public_keys() -> dict[str, str]:
+    global _key_cache, _key_cache_expires_at
+    now = time.time()
+    if _key_cache and _key_cache_expires_at > now:
+        return _key_cache
+
+    async with httpx.AsyncClient() as client:
+        res = await client.get(FIREBASE_SESSION_PUBLIC_KEYS_URL)
+    if res.status_code != 200:
+        raise RuntimeError("firebase_public_keys_fetch_failed")
+    keys: dict[str, str] = res.json()
+
+    cache_control = res.headers.get("cache-control", "")
+    max_age = _DEFAULT_KEY_CACHE_SECONDS
+    for part in cache_control.split(","):
+        part = part.strip()
+        if part.startswith("max-age="):
+            try:
+                max_age = min(int(part.split("=", 1)[1]), _MAX_KEY_CACHE_SECONDS)
+            except ValueError:
+                pass
+
+    _key_cache = keys
+    _key_cache_expires_at = now + max_age
+    return keys
+
+
+def _rsa_public_key_to_jwk(pem_cert: str, kid: str) -> dict:
+    """X.509 CERTIFICATE PEM → RSA 공개키 → python-jose가 받는 JWK dict로 변환."""
+    cert = load_pem_x509_certificate(pem_cert.encode())
+    public_key = cert.public_key()
+    if not isinstance(public_key, RSAPublicKey):
+        raise ValueError("non_rsa_key")
+    numbers = public_key.public_numbers()
+    return {
+        "kty": "RSA",
+        "kid": kid,
+        "use": "sig",
+        "alg": "RS256",
+        "n": long_to_base64(numbers.n).decode(),
+        "e": long_to_base64(numbers.e).decode(),
+    }
+
+
+def looks_like_rs256(token: str) -> bool:
+    """서명 검증 前 헤더만 peek — get_current_user가 legacy(HS256) vs Firebase(RS256)를
+    정확 alg 기준으로 분기하기 위한 저비용 판정(순차 fallback 아님, doc §4.2)."""
+    try:
+        header = jose_jwt.get_unverified_header(token)
+    except JWTError:
+        return False
+    return header.get("alg") == "RS256"
+
+
+@dataclass
+class VerifiedFirebaseSession:
+    issuer: str
+    firebase_uid: str
+    email: str | None
+    auth_time: int
+
+
+async def verify_firebase_session(session_cookie: str, project_id: str) -> VerifiedFirebaseSession | None:
+    """doc §4.2 정확 검증: alg=RS256·kid∈Google 공개키셋·iss=정확히 session issuer·
+    aud=정확히 projectId·sub 비어있지 않음·auth_time/iat/exp 유효. 순차 fallback 없음."""
+    try:
+        header = jose_jwt.get_unverified_header(session_cookie)
+    except JWTError:
+        return None
+
+    kid = header.get("kid")
+    if not kid:
+        return None
+
+    try:
+        keys = await _fetch_public_keys()
+    except RuntimeError:
+        return None
+
+    pem_cert = keys.get(kid)
+    if pem_cert is None:
+        return None
+
+    try:
+        jwk = _rsa_public_key_to_jwk(pem_cert, kid)
+    except ValueError:
+        return None
+
+    expected_issuer = f"https://session.firebase.google.com/{project_id}"
+    try:
+        payload = jose_jwt.decode(
+            session_cookie,
+            jwk,
+            algorithms=["RS256"],
+            audience=project_id,
+            issuer=expected_issuer,
+        )
+    except JWTError:
+        return None
+
+    sub = payload.get("sub")
+    if not sub:
+        return None
+    auth_time = payload.get("auth_time")
+    if not isinstance(auth_time, int):
+        return None
+
+    return VerifiedFirebaseSession(
+        issuer=str(payload.get("iss")),
+        firebase_uid=sub,
+        email=payload.get("email"),
+        auth_time=auth_time,
+    )

--- a/backend/tests/test_e_auth_rebuild_phase1_s2_authcontext_realdb.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s2_authcontext_realdb.py
@@ -1,0 +1,319 @@
+"""story 455e528d(E-AUTH-REBUILD M2 Phase1-S2) 게이트: Firebase 세션 인증이 resource-actual
+AuthContext를 만드는지 realdb로 실증 — doc §3.3 핵심 경고("never trust a stale Firebase
+claim list")를 지키면서도 require_role/require_admin/get_org_scope/SSE 스트리밍이 실 DB
+membership으로 정확히 동작하는지 매트릭스로 확認한다(발견 즉시 수정 — role 미주입 갭 포함).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+from fastapi.security import HTTPAuthorizationCredentials
+from jose import jwt as jose_jwt
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+PROJECT_ID = "test-project"
+KID = "test-kid-1"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    from app.services import firebase_verifier as fv
+    fv._reset_key_cache_for_tests()
+    yield
+    fv._reset_key_cache_for_tests()
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _make_self_signed_cert() -> tuple[str, str]:
+    with tempfile.TemporaryDirectory() as d:
+        key_path = Path(d) / "key.pem"
+        cert_path = Path(d) / "cert.pem"
+        subprocess.run(
+            ["openssl", "req", "-x509", "-newkey", "rsa:2048", "-keyout", str(key_path),
+             "-out", str(cert_path), "-days", "1", "-nodes", "-subj", "/CN=test"],
+            check=True, capture_output=True,
+        )
+        return key_path.read_text(), cert_path.read_text()
+
+
+def _make_session_cookie(key_pem: str, sub: str) -> str:
+    now = int(time.time())
+    claims = {
+        "sub": sub, "email": "user@test.com", "auth_time": now, "iat": now, "exp": now + 3600,
+        "iss": f"https://session.firebase.google.com/{PROJECT_ID}", "aud": PROJECT_ID,
+    }
+    return jose_jwt.encode(claims, key_pem, algorithm="RS256", headers={"kid": KID})
+
+
+async def _seed(session, *, org_role: str = "admin", user_active: bool = True):
+    from app.core.security import hash_password
+    from app.models.auth_identity import AuthIdentity
+    from app.models.organization import Organization
+    from app.models.project import OrgMember
+    from app.models.user import User
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    user_id = uuid.uuid4()
+    session.add(User(
+        id=user_id, email=f"authreb-s2-{user_id.hex[:8]}@test.com",
+        hashed_password=hash_password("x"), is_active=user_active, email_verified=True,
+        last_org_id=org.id,
+    ))
+    await session.commit()
+
+    session.add(OrgMember(id=uuid.uuid4(), org_id=org.id, user_id=user_id, role=org_role))
+    await session.commit()
+
+    firebase_uid = f"fb-uid-{uuid.uuid4().hex[:8]}"
+    issuer = f"https://session.firebase.google.com/{PROJECT_ID}"
+    session.add(AuthIdentity(
+        id=uuid.uuid4(), user_id=user_id, issuer=issuer, subject=firebase_uid,
+        provider_id="password",
+    ))
+    await session.commit()
+
+    return {"org_id": org.id, "user_id": user_id, "firebase_uid": firebase_uid}
+
+
+@pytest.mark.anyio
+async def test_admin_firebase_user_gets_real_role_not_default_member_realdb(monkeypatch):
+    """⭐발견 즉시 수정 회귀 가드: Firebase 인증 admin이 require_admin/require_role을 통과해야
+    한다(claims에 role을 안 채우면 전부 기본값 "member"로 평가돼 실제 admin도 거부당하던 갭)."""
+    from app.core.config import settings
+    from app.dependencies.auth import get_current_user, require_admin, require_role
+
+    monkeypatch.setattr(settings, "firebase_auth_accept_session", True)
+    monkeypatch.setattr(settings, "firebase_project_id", PROJECT_ID)
+
+    key_pem, cert_pem = _make_self_signed_cert()
+    from app.services import firebase_verifier as fv
+    async def fake_fetch():
+        return {KID: cert_pem}
+    monkeypatch.setattr(fv, "_fetch_public_keys", fake_fetch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, org_role="admin")
+
+        cookie = _make_session_cookie(key_pem, seeded["firebase_uid"])
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=cookie)
+
+        async with Session() as s:
+            auth = await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
+
+        assert auth.user_id == str(seeded["user_id"])
+        assert auth.org_id == str(seeded["org_id"])
+        assert auth.claims["app_metadata"]["role"] == "admin"
+
+        # require_admin/require_role — Firebase claim이 아니라 이 resource-actual AuthContext로 평가.
+        result = require_admin(auth)
+        assert result.user_id == auth.user_id
+        checked = require_role("admin", "owner")(auth)
+        assert checked.user_id == auth.user_id
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_member_firebase_user_rejected_by_require_admin_realdb(monkeypatch):
+    """까심: member role Firebase 사용자가 require_admin을 통과하면 IDOR급 권한 상승."""
+    from app.core.config import settings
+    from app.dependencies.auth import get_current_user, require_admin
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(settings, "firebase_auth_accept_session", True)
+    monkeypatch.setattr(settings, "firebase_project_id", PROJECT_ID)
+
+    key_pem, cert_pem = _make_self_signed_cert()
+    from app.services import firebase_verifier as fv
+    async def fake_fetch():
+        return {KID: cert_pem}
+    monkeypatch.setattr(fv, "_fetch_public_keys", fake_fetch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, org_role="member")
+
+        cookie = _make_session_cookie(key_pem, seeded["firebase_uid"])
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=cookie)
+
+        async with Session() as s:
+            auth = await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
+
+        assert auth.claims["app_metadata"]["role"] == "member"
+        with pytest.raises(HTTPException) as exc_info:
+            require_admin(auth)
+        assert exc_info.value.status_code == 403
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_org_scope_reads_live_org_id_realdb(monkeypatch):
+    from app.core.config import settings
+    from app.dependencies.auth import get_current_user, get_org_scope
+
+    monkeypatch.setattr(settings, "firebase_auth_accept_session", True)
+    monkeypatch.setattr(settings, "firebase_project_id", PROJECT_ID)
+
+    key_pem, cert_pem = _make_self_signed_cert()
+    from app.services import firebase_verifier as fv
+    async def fake_fetch():
+        return {KID: cert_pem}
+    monkeypatch.setattr(fv, "_fetch_public_keys", fake_fetch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, org_role="member")
+
+        cookie = _make_session_cookie(key_pem, seeded["firebase_uid"])
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=cookie)
+
+        async with Session() as s:
+            auth = await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
+
+        org_id = get_org_scope(auth=auth, x_org_id=None)
+        assert str(org_id) == str(seeded["org_id"])
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_disabled_user_rejected_despite_valid_firebase_token_realdb(monkeypatch):
+    """doc §3.3: disabled/deleted Sprintable user는 유효한 Firebase 토큰이어도 거부."""
+    from app.core.config import settings
+    from app.dependencies.auth import get_current_user
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(settings, "firebase_auth_accept_session", True)
+    monkeypatch.setattr(settings, "firebase_project_id", PROJECT_ID)
+
+    key_pem, cert_pem = _make_self_signed_cert()
+    from app.services import firebase_verifier as fv
+    async def fake_fetch():
+        return {KID: cert_pem}
+    monkeypatch.setattr(fv, "_fetch_public_keys", fake_fetch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, user_active=False)
+
+        cookie = _make_session_cookie(key_pem, seeded["firebase_uid"])
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=cookie)
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unmapped_firebase_identity_rejected_realdb():
+    """(issuer, sub)가 auth_identities에 없으면(=미프로비저닝 Firebase 사용자) 거부."""
+    from app.core.config import settings
+    from app.dependencies.auth import get_current_user
+    from fastapi import HTTPException
+
+    engine, Session = await _session_factory()
+    try:
+        from app.services import firebase_verifier as fv
+
+        key_pem, cert_pem = _make_self_signed_cert()
+
+        async def fake_fetch():
+            return {KID: cert_pem}
+
+        import pytest as _pytest  # local monkeypatch without fixture param name clash
+        mp = _pytest.MonkeyPatch()
+        mp.setattr(settings, "firebase_auth_accept_session", True)
+        mp.setattr(settings, "firebase_project_id", PROJECT_ID)
+        mp.setattr(fv, "_fetch_public_keys", fake_fetch)
+        try:
+            cookie = _make_session_cookie(key_pem, "never-provisioned-uid")
+            credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=cookie)
+            async with Session() as s:
+                with pytest.raises(HTTPException) as exc_info:
+                    await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
+                assert exc_info.value.status_code == 401
+        finally:
+            mp.undo()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_sse_streaming_variant_mirrors_dual_verifier_realdb(monkeypatch):
+    """doc §4.3: get_current_user_streaming도 동일하게 Firebase 세션을 처리해야 한다.
+
+    이 경로는 내부적으로 자체 단명 세션(async_session_factory())을 여는데(API key 경로와
+    동형 — 스트림 yield 구간에 커넥션 미점유), 그 이름이 app.dependencies.auth 모듈에
+    `from ... import async_session_factory`로 바인딩돼 있어 그 모듈 속성을 패치해야
+    실제로 이 테스트의 realdb 세션팩토리를 쓴다(app.core.database 쪽을 패치해도 이미
+    바인딩된 이름엔 영향 없음 — 기존 test_eventbus_s3.py는 dependency_overrides로
+    이 함수 자체를 우회해 이 이슈를 안 겪었을 뿐, 직접 호출 시엔 실제로 필요)."""
+    from app.core.config import settings
+    import app.dependencies.auth as auth_module
+
+    monkeypatch.setattr(settings, "firebase_auth_accept_session", True)
+    monkeypatch.setattr(settings, "firebase_project_id", PROJECT_ID)
+
+    key_pem, cert_pem = _make_self_signed_cert()
+    from app.services import firebase_verifier as fv
+    async def fake_fetch():
+        return {KID: cert_pem}
+    monkeypatch.setattr(fv, "_fetch_public_keys", fake_fetch)
+
+    engine, Session = await _session_factory()
+    monkeypatch.setattr(auth_module, "async_session_factory", Session)
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, org_role="admin")
+
+        cookie = _make_session_cookie(key_pem, seeded["firebase_uid"])
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=cookie)
+
+        auth = await auth_module.get_current_user_streaming(credentials=credentials, x_agent_api_key=None)
+        assert auth.user_id == str(seeded["user_id"])
+        assert auth.claims["app_metadata"]["role"] == "admin"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_e_auth_rebuild_phase1_s2_firebase_verifier.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s2_firebase_verifier.py
@@ -1,0 +1,153 @@
+"""story 455e528d(E-AUTH-REBUILD M2 Phase1-S2) 계약 테스트: verify_firebase_session() 정확
+검증(doc §4.2) — 6개 실패 카테고리 전부 실 self-signed X.509 인증서로 서명까지 실증(raw SPKI
+PEM 사용 시 importX509류가 파싱 자체에 실패해 거짓양성 나던 FE(#2193) 함정을 처음부터 회피).
+"""
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+from jose import jwt as jose_jwt
+
+from app.services import firebase_verifier as fv
+
+PROJECT_ID = "test-project"
+KID = "test-kid-1"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    fv._reset_key_cache_for_tests()
+    yield
+    fv._reset_key_cache_for_tests()
+
+
+def _make_self_signed_cert() -> tuple[str, str]:
+    with tempfile.TemporaryDirectory() as d:
+        key_path = Path(d) / "key.pem"
+        cert_path = Path(d) / "cert.pem"
+        subprocess.run(
+            ["openssl", "req", "-x509", "-newkey", "rsa:2048", "-keyout", str(key_path),
+             "-out", str(cert_path), "-days", "1", "-nodes", "-subj", "/CN=test"],
+            check=True, capture_output=True,
+        )
+        return key_path.read_text(), cert_path.read_text()
+
+
+def _make_session_cookie(
+    key_pem: str, *, iss: str | None = None, aud: str | None = None, sub: str = "firebase-uid-1",
+    auth_time: int | None = None, kid: str = KID, exp_delta: int = 3600,
+) -> str:
+    now = int(time.time())
+    claims = {
+        "sub": sub,
+        "email": "user@test.com",
+        "auth_time": auth_time if auth_time is not None else now,
+        "iat": now,
+        "exp": now + exp_delta,
+        "iss": iss or f"https://session.firebase.google.com/{PROJECT_ID}",
+        "aud": aud or PROJECT_ID,
+    }
+    return jose_jwt.encode(claims, key_pem, algorithm="RS256", headers={"kid": kid})
+
+
+def _patch_fetch(monkeypatch, keys: dict[str, str]) -> None:
+    async def fake_fetch():
+        return keys
+    monkeypatch.setattr(fv, "_fetch_public_keys", fake_fetch)
+
+
+@pytest.mark.anyio
+async def test_accepts_correctly_signed_session(monkeypatch):
+    key_pem, cert_pem = _make_self_signed_cert()
+    _patch_fetch(monkeypatch, {KID: cert_pem})
+    cookie = _make_session_cookie(key_pem)
+    result = await fv.verify_firebase_session(cookie, PROJECT_ID)
+    assert result is not None
+    assert result.firebase_uid == "firebase-uid-1"
+    assert result.email == "user@test.com"
+
+
+@pytest.mark.anyio
+async def test_rejects_issuer_confusion_id_token_issuer(monkeypatch):
+    """ID token issuer(securetoken.google.com)를 세션 issuer로 오인 수락하면 안 됨(doc §4.2)."""
+    key_pem, cert_pem = _make_self_signed_cert()
+    _patch_fetch(monkeypatch, {KID: cert_pem})
+    cookie = _make_session_cookie(key_pem, iss=f"https://securetoken.google.com/{PROJECT_ID}")
+    result = await fv.verify_firebase_session(cookie, PROJECT_ID)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_rejects_wrong_project_audience_mismatch(monkeypatch):
+    key_pem, cert_pem = _make_self_signed_cert()
+    _patch_fetch(monkeypatch, {KID: cert_pem})
+    cookie = _make_session_cookie(key_pem, aud="other-project")
+    result = await fv.verify_firebase_session(cookie, PROJECT_ID)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_rejects_wrong_algorithm_hs256_forged(monkeypatch):
+    """alg=HS256로 위조(권장 RS256 대신) — jose가 RS256 공개키로 HS256 서명을 절대 검증 못 함."""
+    key_pem, cert_pem = _make_self_signed_cert()
+    _patch_fetch(monkeypatch, {KID: cert_pem})
+    now = int(time.time())
+    forged = jose_jwt.encode(
+        {"sub": "firebase-uid-1", "auth_time": now, "iat": now, "exp": now + 3600,
+         "iss": f"https://session.firebase.google.com/{PROJECT_ID}", "aud": PROJECT_ID},
+        "attacker-guessed-secret", algorithm="HS256", headers={"kid": KID},
+    )
+    result = await fv.verify_firebase_session(forged, PROJECT_ID)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_rejects_missing_kid(monkeypatch):
+    key_pem, cert_pem = _make_self_signed_cert()
+    _patch_fetch(monkeypatch, {KID: cert_pem})
+    now = int(time.time())
+    no_kid = jose_jwt.encode(
+        {"sub": "firebase-uid-1", "auth_time": now, "iat": now, "exp": now + 3600,
+         "iss": f"https://session.firebase.google.com/{PROJECT_ID}", "aud": PROJECT_ID},
+        key_pem, algorithm="RS256",  # headers 미지정 — kid 없음
+    )
+    result = await fv.verify_firebase_session(no_kid, PROJECT_ID)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_rejects_unknown_kid(monkeypatch):
+    key_pem, cert_pem = _make_self_signed_cert()
+    _patch_fetch(monkeypatch, {"some-other-kid": cert_pem})  # KID가 published set에 없음
+    cookie = _make_session_cookie(key_pem, kid=KID)
+    result = await fv.verify_firebase_session(cookie, PROJECT_ID)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_rejects_expired_token(monkeypatch):
+    key_pem, cert_pem = _make_self_signed_cert()
+    _patch_fetch(monkeypatch, {KID: cert_pem})
+    cookie = _make_session_cookie(key_pem, exp_delta=-3600)  # 이미 만료
+    result = await fv.verify_firebase_session(cookie, PROJECT_ID)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_rejects_forged_signature_untrusted_key(monkeypatch):
+    """까심: 공격자가 자기 키로 서명하고 신뢰된 kid를 사칭 — 서버는 published cert로만 검증."""
+    _key_pem, cert_pem = _make_self_signed_cert()  # published(서버가 신뢰하는) cert
+    attacker_key_pem, _attacker_cert = _make_self_signed_cert()  # 공격자 자신의 키
+    _patch_fetch(monkeypatch, {KID: cert_pem})
+    forged = _make_session_cookie(attacker_key_pem, kid=KID)  # 공격자 키로 서명, published kid 사칭
+    result = await fv.verify_firebase_session(forged, PROJECT_ID)
+    assert result is None


### PR DESCRIPTION
## Summary
story 455e528d — E-AUTH-REBUILD M2 Phase1-S2. doc `firebase-auth-identity-platform-migration-poc-2026-07-15` §4.2/§4.3 구현. FE S3(#2193)의 `firebase-session.ts`와 동형 설계로 BE 측 dual-verifier를 배선.

- **`app/services/firebase_verifier.py`(신규)**: Firebase 세션쿠키 RS256 정확검증. `python-jose` 재사용(신규 의존성 0). kid→X.509 PEM 맵(표준 JWKS 아님)을 `cryptography`로 직접 파싱. alg=RS256/iss(세션 issuer, ID token issuer와 혼동 금지)/aud(projectId)/kid 전부 정확 매칭만 통과 — 순차 fallback 없음(실패 시 `None`, 호출부가 legacy로 다운그레이드하면 안 됨).
- **`app/dependencies/auth.py`**: `_resolve_firebase_session()` 신설, `get_current_user` + `get_current_user_streaming`(SSE) 양쪽에 배선. `looks_like_rs256()`으로 legacy HS256과 alg 기준 정확 분기.

### ⚠️자체 발견 보안 갭(구현 중 발견, 별도 리포트 없음)
`require_role`/`require_admin`/`get_org_scope`는 전부 `auth.claims["app_metadata"]`의 `org_id`+`role`을 읽는다. 최초 구현은 `org_id`만 채우고 `role`을 비워둬 Firebase 인증 사용자는 실제 DB role과 무관하게 전부 기본값 `"member"`로 평가됨 — 관리자도 조용히 권한 거부당하는 실제 접근제어 버그. 경량 `OrgMember.role` 단건 조회로 수정. 무거운 `_build_app_metadata()`는 invite 자동수락 등 로그인 전용 부작용이 있어 요청당 호출에 부적합해 의도적으로 회피.

### 테스트 (14종, 전부 실 openssl self-signed X.509 인증서 사용)
- `test_e_auth_rebuild_phase1_s2_firebase_verifier.py`(8): raw SPKI PEM은 파싱 단계에서 실패해 거짓양성 나던 FE #2193 함정을 처음부터 회피. issuer 혼동/aud 불일치/alg 위조/kid 누락·미상/만료/서명위조.
- `test_e_auth_rebuild_phase1_s2_authcontext_realdb.py`(6): admin/member role 매핑, disabled user 거부, unmapped identity 거부, `get_org_scope` live-DB 조회, SSE streaming variant가 동일 dual-verifier 미러링(별도 세션 팩토리를 테스트 DB로 monkeypatch — from-import 바인딩이라 소비 모듈 `app.dependencies.auth.async_session_factory` patch 필요).

### 뮤테이션 자체검증
- issuer 체크 비활성화 → 정확히 1건 RED
- role 주입 라인 비활성화 → role 의존 3건만 RED, 나머지 3건(org_scope/disabled/unmapped)은 GREEN 유지

전체 회귀: 3270 passed, 814 skipped, 8 xfailed, 7 failed(기존 무관 mcp-tooling/DOD 체크 — 오늘 전 PR과 동일 7건, 신규 회귀 0).

## Test plan
- [x] 14 신규 계약 테스트 전부 통과
- [x] 전체 회귀 스위트 통과(신규 실패 0)
- [x] 뮤테이션 자체검증 2건(issuer/role) 정확히 예상 범위만 RED
- [ ] 까심 QA
🤖 Generated with [Claude Code](https://claude.com/claude-code)