### PR TITLE
[SID:360dcdf9] getServerSession() Firebase dual-verifier 라우팅

### DIFF
--- a/apps/web/src/lib/db/server.test.ts
+++ b/apps/web/src/lib/db/server.test.ts
@@ -4,15 +4,35 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SignJWT } from 'jose';
 
-const { cookiesGetMock } = vi.hoisted(() => ({
+const { cookiesGetMock, verifySprintableSessionMock } = vi.hoisted(() => ({
   cookiesGetMock: vi.fn(),
+  verifySprintableSessionMock: vi.fn(),
 }));
 
 vi.mock('next/headers', () => ({
   cookies: vi.fn(async () => ({ get: cookiesGetMock })),
 }));
 
+vi.mock('@/lib/auth/firebase-session', () => ({
+  SP_FS_COOKIE: '__Host-sp_fs',
+  verifySprintableSession: (...args: unknown[]) => verifySprintableSessionMock(...args),
+}));
+
 const JWT_SECRET = 'test-secret-7d6b770b';
+
+// story 360dcdf9: cookies().get(name)이 이제 SP_FS_COOKIE(__Host-sp_fs)도 조회하므로, 기존처럼
+// 인자 무관 단일 mockReturnValue를 쓰면 sp_at 테스트들이 firebase 분기로 오탐 라우팅된다 —
+// 키별로 분기하는 헬퍼로 교체(기존 테스트 의미는 완전히 동일하게 유지).
+function mockSpAtCookie(token: string): void {
+  cookiesGetMock.mockImplementation((name: string) => (name === 'sp_at' ? { value: token } : undefined));
+}
+
+function mockCookies(byName: Record<string, string | undefined>): void {
+  cookiesGetMock.mockImplementation((name: string) => {
+    const value = byName[name];
+    return value === undefined ? undefined : { value };
+  });
+}
 
 async function signAccessToken(payload: Record<string, unknown>): Promise<string> {
   const secretBytes = new TextEncoder().encode(JWT_SECRET);
@@ -39,7 +59,7 @@ describe('getServerSession — JWT app_metadata org_id/project_id claim', () => 
       email: 'u@test.com',
       app_metadata: { org_id: 'org-1', project_id: 'proj-1' },
     });
-    cookiesGetMock.mockReturnValue({ value: token });
+    mockSpAtCookie(token);
 
     const { getServerSession } = await import('./server');
     const session = await getServerSession();
@@ -52,7 +72,7 @@ describe('getServerSession — JWT app_metadata org_id/project_id claim', () => 
 
   it('app_metadata 없음 → org_id/project_id null(fail-closed, /me fallback 유도)', async () => {
     const token = await signAccessToken({ email: 'u@test.com' });
-    cookiesGetMock.mockReturnValue({ value: token });
+    mockSpAtCookie(token);
 
     const { getServerSession } = await import('./server');
     const session = await getServerSession();
@@ -64,7 +84,7 @@ describe('getServerSession — JWT app_metadata org_id/project_id claim', () => 
 
   it('app_metadata가 malformed(배열/원시값)여도 null(크래시 아님)', async () => {
     const token = await signAccessToken({ email: 'u@test.com', app_metadata: ['not', 'an', 'object'] });
-    cookiesGetMock.mockReturnValue({ value: token });
+    mockSpAtCookie(token);
 
     const { getServerSession } = await import('./server');
     const session = await getServerSession();
@@ -85,7 +105,7 @@ describe('getServerSession — JWT app_metadata org_id/project_id claim', () => 
       .setIssuedAt(Math.floor(Date.now() / 1000) - 3600)
       .setExpirationTime(Math.floor(Date.now() / 1000) - 1800)
       .sign(secretBytes);
-    cookiesGetMock.mockReturnValue({ value: expiredToken });
+    mockSpAtCookie(expiredToken);
 
     const { getServerSession } = await import('./server');
     const session = await getServerSession();
@@ -104,7 +124,7 @@ describe('getServerSession — JWT app_metadata org_id/project_id claim', () => 
       .setIssuedAt()
       .setExpirationTime('15m')
       .sign(wrongSecretBytes);
-    cookiesGetMock.mockReturnValue({ value: tamperedToken });
+    mockSpAtCookie(tamperedToken);
 
     const { getServerSession } = await import('./server');
     const session = await getServerSession();
@@ -119,5 +139,122 @@ describe('getServerSession — JWT app_metadata org_id/project_id claim', () => 
     const session = await getServerSession();
 
     expect(session).toBeNull();
+  });
+});
+
+// story 360dcdf9(E-AUTH-REBUILD Phase2-FE-S2·doc §4.1/§4.3): __Host-sp_fs 존재 시 Firebase
+// 경로만 시도(legacy 폴백 절대 금지) → 성공하면 FastAPI GET /api/v2/me로 user_id/org_id/
+// project_id 해석. React.cache()의 요청스코프 dedup 자체는 Next.js 렌더 디스패처가 있어야
+// 동작하는 프로퍼티라(실측: 순수 node/vitest 환경에서 cache()는 매 호출마다 재실행됨 — 이
+// 저장소의 기존 선례 auth-helpers.ts::getAuthContext도 동일 이유로 dedup을 유닛테스트하지
+// 않는다) 여기서도 함수 자체의 정확성만 검증하고 dedup은 라이브/Next 요청 컨텍스트에서만
+// 실측 가능하다고 명시한다(no-fiction — vitest로 증명 불가한 걸 증명한 척 안 함).
+describe('getServerSession — Firebase 세션쿠키(__Host-sp_fs) 라우팅', () => {
+  const ORIGINAL_FETCH = global.fetch;
+
+  beforeEach(() => {
+    cookiesGetMock.mockReset();
+    verifySprintableSessionMock.mockReset();
+    process.env['JWT_SECRET'] = JWT_SECRET;
+    process.env['NEXT_PUBLIC_FIREBASE_PROJECT_ID'] = 'test-project';
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    global.fetch = ORIGINAL_FETCH;
+  });
+
+  it('__Host-sp_fs 쿠키가 있으면 sp_at이 있어도 Firebase 경로를 우선한다', async () => {
+    mockCookies({ '__Host-sp_fs': 'fs-cookie-value', sp_at: 'should-be-ignored' });
+    verifySprintableSessionMock.mockResolvedValue({
+      issuer: 'https://session.firebase.google.com/test-project',
+      firebaseUid: 'fb-uid-1',
+      email: 'fb-user@test.com',
+      authTime: 1700000000,
+    });
+    global.fetch = vi.fn(async () => new Response(
+      JSON.stringify({ member_id: 'sprintable-user-1', org_id: 'org-9', project_id: 'proj-9', resolved_default_project_id: null }),
+      { status: 200 },
+    )) as unknown as typeof fetch;
+
+    const { getServerSession } = await import('./server');
+    const session = await getServerSession();
+
+    expect(session).toEqual({
+      user_id: 'sprintable-user-1',
+      email: 'fb-user@test.com',
+      access_token: '',
+      org_id: 'org-9',
+      project_id: 'proj-9',
+    });
+    // legacy jwtVerify 경로로 안 샜는지 확인 — sp_at 쿠키가 아예 안 읽혔어야 함은 라우팅 순서로 보장.
+    expect(verifySprintableSessionMock).toHaveBeenCalledWith('fs-cookie-value', 'test-project');
+  });
+
+  it('Firebase 검증 실패 시 legacy 폴백 없이 null을 반환한다(다운그레이드 금지)', async () => {
+    // sp_at을 실제로 유효한(정상 서명된) legacy 토큰으로 둬야 "폴백이 있었다면 성공했을 것"이
+    // 판별 가능하다 — 무효 문자열이면 폴백이 있어도 어차피 null이라 이 테스트가 무력화된다.
+    const validLegacyToken = await signAccessToken({
+      email: 'legacy@test.com',
+      app_metadata: { org_id: 'org-legacy', project_id: 'proj-legacy' },
+    });
+    mockCookies({ '__Host-sp_fs': 'invalid-fs-cookie', sp_at: validLegacyToken });
+    verifySprintableSessionMock.mockResolvedValue(null);
+    const fetchSpy = vi.fn();
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { getServerSession } = await import('./server');
+    const session = await getServerSession();
+
+    expect(session).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled(); // 검증 실패면 /me도 호출 안 함(불필요 왕복 방지).
+  });
+
+  it('GET /api/v2/me 호출이 실패(!ok)하면 null을 반환한다', async () => {
+    mockCookies({ '__Host-sp_fs': 'fs-cookie-value' });
+    verifySprintableSessionMock.mockResolvedValue({
+      issuer: 'https://session.firebase.google.com/test-project',
+      firebaseUid: 'fb-uid-1',
+      email: 'fb-user@test.com',
+      authTime: 1700000000,
+    });
+    global.fetch = vi.fn(async () => new Response('{}', { status: 500 })) as unknown as typeof fetch;
+
+    const { getServerSession } = await import('./server');
+    const session = await getServerSession();
+
+    expect(session).toBeNull();
+  });
+
+  it('NEXT_PUBLIC_FIREBASE_PROJECT_ID 미설정이면 verifySprintableSession조차 호출하지 않고 null(config 부재 무해)', async () => {
+    delete process.env['NEXT_PUBLIC_FIREBASE_PROJECT_ID'];
+    mockCookies({ '__Host-sp_fs': 'fs-cookie-value' });
+    const fetchSpy = vi.fn();
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { getServerSession } = await import('./server');
+    const session = await getServerSession();
+
+    expect(session).toBeNull();
+    expect(verifySprintableSessionMock).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('__Host-sp_fs 쿠키가 없으면 legacy 경로는 Firebase 검증/네트워크 호출 0회로 완전 무변화한다', async () => {
+    const token = await signAccessToken({
+      email: 'legacy@test.com',
+      app_metadata: { org_id: 'org-legacy', project_id: 'proj-legacy' },
+    });
+    mockCookies({ sp_at: token });
+    const fetchSpy = vi.fn();
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const { getServerSession } = await import('./server');
+    const session = await getServerSession();
+
+    expect(session?.user_id).toBe('user-1');
+    expect(session?.org_id).toBe('org-legacy');
+    expect(verifySprintableSessionMock).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/db/server.ts
+++ b/apps/web/src/lib/db/server.ts
@@ -1,8 +1,12 @@
 import { cookies } from 'next/headers';
 import { jwtVerify } from 'jose';
+import { cache } from 'react';
+import { verifySprintableSession, SP_FS_COOKIE } from '@/lib/auth/firebase-session';
 
 export const SP_AT_COOKIE = 'sp_at';
 export const SP_RT_COOKIE = 'sp_rt';
+
+const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
 export interface ServerSession {
   user_id: string;
@@ -38,8 +42,63 @@ function readAppMetadataClaims(payload: Record<string, unknown>): Pick<ServerSes
   };
 }
 
+interface AuthMeResponse {
+  member_id: string;
+  org_id: string | null;
+  project_id: string | null;
+  resolved_default_project_id: string | null;
+}
+
+/**
+ * story 360dcdf9(E-AUTH-REBUILD Phase2-FE-S2·doc §4.1/§4.3): Firebase 세션쿠키 검증 후
+ * Sprintable user_id/org_id/project_id 해석. 로컬 firebaseUid만으로는 이 값들을 알 수 없다 —
+ * 디디군 dual-verifier 설계(PR#2197)가 custom claims를 신뢰하지 않고 매번 live DB에서
+ * 재조회하기 때문(§3.3 resource-actual 원칙, staleness 방지). 그래서 legacy 경로(순수 로컬
+ * JWT 디코드)와 달리 이 경로는 FastAPI `GET /api/v2/me` 왕복 1회가 필연적이다.
+ *
+ * `React.cache()`로 요청 스코프 memoize(오르테가군 권고) — 같은 요청 내 getServerSession()이
+ * 여러 번 호출돼도 /me 왕복은 1회로 묶인다.
+ *
+ * ⚠️알려진 후속 갭(이 스토리 스코프 밖, 별도 스토리 필요): 리턴하는 `access_token`은 빈 문자열이다
+ * — Firebase 세션은 Bearer 토큰 개념이 없고 `__Host-sp_fs` 쿠키 자체가 자격이기 때문. 그런데
+ * `fastapi-proxy.ts::resolveAuthHeader()`는 현재 `access_token`으로 Bearer 헤더만 구성하고
+ * 쿠키를 forward하지 않는다 — 즉 Firebase 세션 사용자가 실제로 `proxyToFastapi` 경유 API를
+ * 호출하려면 그 쪽도 `__Host-sp_fs` 쿠키 forwarding을 배우게 하는 별도 슬라이스가 필요하다.
+ * 오늘은 플래그/쿠키 부재로 이 분기 자체가 미도달이라 무해하지만, 활성화 전 반드시 짚어야 한다.
+ */
+const resolveFirebaseServerSession = cache(async (sessionCookie: string): Promise<ServerSession | null> => {
+  const projectId = process.env['NEXT_PUBLIC_FIREBASE_PROJECT_ID'] ?? '';
+  if (!projectId) return null;
+
+  const verified = await verifySprintableSession(sessionCookie, projectId);
+  if (!verified) return null; // doc §4.1: 검증 실패 시 legacy 폴백 절대 금지 — 그냥 미인증 처리.
+
+  const res = await fetch(`${FASTAPI_URL()}/api/v2/me`, {
+    headers: { Cookie: `${SP_FS_COOKIE}=${sessionCookie}` },
+  }).catch(() => null);
+  if (!res || !res.ok) return null;
+
+  const me = await res.json().catch(() => null) as AuthMeResponse | null;
+  if (!me?.member_id) return null;
+
+  return {
+    user_id: me.member_id,
+    email: verified.email ?? '',
+    access_token: '',
+    org_id: me.org_id,
+    project_id: me.project_id ?? me.resolved_default_project_id,
+  };
+});
+
 export async function getServerSession(): Promise<ServerSession | null> {
   const cookieStore = await cookies();
+
+  // doc §4.1 라우팅 순서: Firebase 세션쿠키가 있으면 그 경로만 시도한다(legacy 폴백 금지).
+  const firebaseSessionCookie = cookieStore.get(SP_FS_COOKIE)?.value;
+  if (firebaseSessionCookie) {
+    return resolveFirebaseServerSession(firebaseSessionCookie);
+  }
+
   const token = cookieStore.get(SP_AT_COOKIE)?.value;
   if (!token) return null;
   try {


### PR DESCRIPTION
## Summary
- E-AUTH-REBUILD Phase2-FE-S2 (story `360dcdf9`) — Next.js BFF 요청인증 경로(`lib/db/server.ts::getServerSession()`, 26개 파일 소비)에 Firebase 세션쿠키(`__Host-sp_fs`) dual-verifier 라우팅 배선.
- `__Host-sp_fs` 쿠키 존재 시에만 Firebase 경로 진입, `verifySprintableSession()` 검증 실패 시 legacy 폴백 절대 없음(doc §4.1 downgrade 차단 설계 정합, 유나 `firebase-cutover-user-journey-blueprint` §17d와 1:1 확認) — null 리턴.
- 검증 성공 시 FastAPI `GET /api/v2/me`(디디 S2·PR#2197 dual-verifier가 이미 Firebase UID→Sprintable user_id/org/role 매핑 커버)를 서버사이드로 직접 호출해 `user_id`/`org_id`/`project_id` 채움 — Firebase 세션쿠키 자체엔 이 값들이 없음(custom claims 신뢰 금지, resource-actual 원칙).
- `React.cache()`로 요청스코프 memoize(오르테가군 최적화 권고) — 동일 요청 내 `getServerSession()` 다회 호출 시 `/me` 왕복 1회로 묶임.

## 무해성 근거(디디 재확認 — 클레임보다 강한 보장)
`__Host-sp_fs` 쿠키가 없는 한(오늘 100% 케이스) legacy 로컬 JWT 디코드 경로는 완전 무변화. 애초에 이 쿠키는 **오늘 물리적으로 생성 불가**하다는 것을 디디군이 `setFirebaseSessionCookie()` 호출부 전수 grep으로 확認: `POST /api/auth/firebase/session`의 실 발급 로직이 아직 TODO 스텁이라 `FIREBASE_AUTH_ISSUE_SESSION` 플래그를 켜도 항상 501 — 즉 BE 게이팅(`FIREBASE_AUTH_ACCEPT_SESSION` 등)에 의존하는 게 아니라 발급 코드 자체가 존재하지 않아서 쿠키가 생성될 수 없음(BE 게이팅과 무관한 독립 레이어 보장). ⚠️§4.4 실구현(S4)이 붙으면 이 가드는 사라지므로 그 시점엔 재검증 필요.

## 알려진 후속 갭(스코프 밖, 별도 슬라이스 필요)
Firebase 세션의 `access_token`은 빈 문자열 — Bearer 토큰 개념이 없고 `__Host-sp_fs` 쿠키 자체가 자격이기 때문. `fastapi-proxy.ts::resolveAuthHeader()`는 현재 Bearer 헤더만 구성하고 쿠키를 forward하지 않아, Firebase 세션 사용자가 `proxyToFastapi` 경유 API를 실제로 호출하려면 그쪽에도 `__Host-sp_fs` 쿠키 forwarding이 필요함 — 코드 내 명시 주석으로 남김. 오늘은 이 분기 자체가 미도달이라 무해.

## 리뷰 현황
- ✅ 유나(디자인/계약 가디언): §17d 다운그레이드 차단 설계 1:1 확認, 구조 건전 지지. authoritative 런타임 무해성 판정은 까심(QA)+디디(BE 계약)로 명시적 defer.
- 🔄 까심 QA: 진행 중(PO 오르테가 킥 캐노니컬 스레드).
- ✅ 디디: BE 게이팅 재확認 완료(위 무해성 근거 참고).

## Test plan
- [x] `pnpm run type-check` (apps/web) — clean
- [x] `pnpm run lint` (apps/web) — 0 errors (기존 무관 warning 5건만)
- [x] `pnpm exec vitest run` (apps/web scope) — 237 files / 1566 passed, 무회귀
- [x] `pnpm exec vitest run` (repo-root scope) — 253 files / 1740 passed, 무회귀
- [x] `NEXT_TELEMETRY_DISABLED=1 pnpm build` — genuine EXIT=0, Compiled successfully
- [x] 뮤테이션 셀프체크: "legacy 폴백 금지" 가드(early `return`) 무력화 → 관련 테스트 2건 RED 확인 후 원복
- [x] 신규 유닛테스트 5건: Firebase 경로 우선순위, 검증실패시 null(폴백없음), `/me` 실패시 null, config 부재시 무해, legacy 경로 네트워크 0회 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)