### PR TITLE
[SID:5e7904fe] S-reset-flow — TOTP 재등록 유도 hook (이중 게이팅·무해)

### DIFF
--- a/apps/web/src/app/reset-password/page.tsx
+++ b/apps/web/src/app/reset-password/page.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
+import { FIREBASE_AUTH_ENABLED } from '@/lib/auth/firebase-client';
+import { shouldPromptTotpReenroll } from '@/lib/auth/totp-reenroll';
 
 function checkPasswordRules(pw: string) {
   return {
@@ -25,6 +27,12 @@ export default function ResetPasswordPage() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [done, setDone] = useState(false);
+  // doc firebase-auth-login-ux-blueprint §2 S3 4번(TOTP 재등록 유도) — 이중 게이팅으로 오늘
+  // 완전 무해: ①클라 플래그 off(기본)면 절대 안 읽음 ②BE가 아직 totp_enabled 필드를 반환하지
+  // 않아(그라운딩 확認, backend/app/routers/auth.py reset_password 현재 {"message":...}만
+  // 반환) 플래그 on이어도 undefined→false로 폴백. BE가 필드를 추가하기 전까지 이 분기는
+  // 절대 렌더되지 않는다 — no-fiction(없는 신호를 있는 것처럼 배선 안 함) + 라이브 무영향.
+  const [totpReenrollNeeded, setTotpReenrollNeeded] = useState(false);
 
   const rules = checkPasswordRules(password);
   const categoriesMet = [rules.upper, rules.lower, rules.digit, rules.special].filter(Boolean).length;
@@ -41,11 +49,12 @@ export default function ResetPasswordPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ token, new_password: password }),
       });
-      const json = await res.json() as { data?: { message: string }; error?: { message: string } };
+      const json = await res.json() as { data?: { message: string; totp_enabled?: boolean }; error?: { message: string } };
       if (!res.ok) {
         setError(json.error?.message ?? 'Failed to reset password');
         return;
       }
+      setTotpReenrollNeeded(shouldPromptTotpReenroll(FIREBASE_AUTH_ENABLED, json.data?.totp_enabled));
       setDone(true);
     } catch {
       setError('Failed to reset password. Please try again.');
@@ -76,6 +85,9 @@ export default function ResetPasswordPage() {
         {done ? (
           <div className="space-y-4 text-center">
             <p className="text-sm text-muted-foreground">비밀번호가 변경되었습니다.</p>
+            {totpReenrollNeeded && (
+              <p className="text-sm text-muted-foreground">2단계 인증을 다시 등록해 주세요.</p>
+            )}
             <button
               onClick={() => router.push('/login')}
               className="flex w-full min-h-[44px] items-center justify-center rounded-lg bg-brand px-4 py-3 text-sm font-medium text-brand-foreground transition hover:bg-brand/90"

--- a/apps/web/src/lib/auth/totp-reenroll.test.ts
+++ b/apps/web/src/lib/auth/totp-reenroll.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { shouldPromptTotpReenroll } from './totp-reenroll';
+
+describe('shouldPromptTotpReenroll (doc firebase-auth-login-ux-blueprint §2 S3 4번 — 이중 게이팅)', () => {
+  it('is false when the client flag is off, even if BE says totp_enabled=true', () => {
+    expect(shouldPromptTotpReenroll(false, true)).toBe(false);
+  });
+
+  it('is false when BE has not returned totp_enabled at all (undefined — current live state)', () => {
+    expect(shouldPromptTotpReenroll(true, undefined)).toBe(false);
+  });
+
+  it('is false when BE explicitly says totp_enabled=false', () => {
+    expect(shouldPromptTotpReenroll(true, false)).toBe(false);
+  });
+
+  it('is true only when both the flag is on AND BE explicitly confirms totp_enabled=true', () => {
+    expect(shouldPromptTotpReenroll(true, true)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/auth/totp-reenroll.ts
+++ b/apps/web/src/lib/auth/totp-reenroll.ts
@@ -1,0 +1,9 @@
+/**
+ * doc firebase-auth-login-ux-blueprint §2 S3 4번(TOTP 재등록 유도) 판정 — 이중 게이팅:
+ * 클라 플래그(NEXT_PUBLIC_FIREBASE_AUTH_ENABLED)가 꺼져있거나, BE가 totp_enabled 필드를
+ * 아직 반환하지 않으면(undefined) 절대 true를 반환하지 않는다. TOTP 미사용자에게 잘못
+ * "2단계 인증 재등록" 메시지를 보여주지 않도록 엄격히 boolean true만 신뢰한다.
+ */
+export function shouldPromptTotpReenroll(flagEnabled: boolean, totpEnabled: boolean | undefined): boolean {
+  return flagEnabled && totpEnabled === true;
+}


### PR DESCRIPTION
## Summary
- E-AUTH-REBUILD Phase2-FE (story `5e7904fe`) S-reset-flow 슬라이스 — `/reset-password` 성공 화면에 TOTP 재등록 안내 메시지 추가(doc `firebase-auth-login-ux-blueprint` §2 S3 4번).
- 순수 판정 로직을 `shouldPromptTotpReenroll(flagEnabled, totpEnabled)`로 추출 — `flagEnabled && totpEnabled === true`만 true.

## 이중 게이팅(오늘 100% 무해)
1. 클라 플래그 `NEXT_PUBLIC_FIREBASE_AUTH_ENABLED`(기본 off).
2. BE `reset_password`(`backend/app/routers/auth.py`)가 아직 `totp_enabled` 필드 자체를 반환하지 않음(현재 응답은 `{"message": "Password reset successfully"}`뿐 — 그라운딩 재확인 완료, S4 머지 이후에도 이 핸들러는 무변경).

두 조건 중 하나만 깨져도 새 UI는 렌더되지 않음 — BE가 필드를 추가하기 전까지 이 분기는 구조적으로 도달 불가.

## Test plan
- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — 0 errors (기존 무관 warning 5건만)
- [x] `pnpm exec vitest run` (apps/web scope) — 238 files / 1576 passed, 무회귀
- [x] `pnpm exec vitest run` (repo-root scope) — 254 files / 1750 passed, 무회귀
- [x] `NEXT_TELEMETRY_DISABLED=1 pnpm build` — genuine EXIT=0
- [x] 뮤테이션 셀프체크: `&&`→`||` 변형 시 관련 테스트 3/4건 RED 확인 후 원복

🤖 Generated with [Claude Code](https://claude.com/claude-code)