### PR TITLE
feat(auth): E-AUTH-REBUILD Phase1-S5 — 네이티브 부트스트랩 브릿지

### DIFF
--- a/backend/alembic/versions/0189_auth_native_bootstrap_codes.py
+++ b/backend/alembic/versions/0189_auth_native_bootstrap_codes.py
@@ -1,0 +1,47 @@
+"""story 4dee942b(E-AUTH-REBUILD M2 Phase1-S5): auth_native_bootstrap_codes 테이블(doc §9.1·
+산티아고 §9 코드 보안계약 2026-07-15). 단회 부트스트랩 코드는 HASH만 저장(원문 미저장) —
+발급 시 생성한 raw code는 클라이언트에게만 반환되고 DB엔 절대 남지 않는다.
+
+Revision ID: 0189
+Revises: 0188
+Create Date: 2026-07-16
+
+additive — 기존 스키마 무회귀.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0189"
+down_revision = "0188"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "auth_native_bootstrap_codes",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("firebase_uid", sa.Text(), nullable=False),
+        # 산티아고 §9: exact Firebase project/tenant 바인딩 — 크로스 환경 코드 재생 방지.
+        sa.Column("project_id", sa.Text(), nullable=False),
+        # code_hash만 저장(원문 미저장). SHA-256 hex.
+        sa.Column("code_hash", sa.Text(), nullable=False),
+        # App Check 기반 device binding proof hash — 발급 시점에 App Check 검증이 요구되지
+        # 않았으면 NULL(소비 시 device proof 불요), 값이 있으면 소비 시 정확 일치 필수.
+        sa.Column("device_binding_hash", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_unique_constraint("uq_auth_native_bootstrap_codes_code_hash", "auth_native_bootstrap_codes", ["code_hash"])
+    op.create_index("ix_auth_native_bootstrap_codes_user_id", "auth_native_bootstrap_codes", ["user_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_auth_native_bootstrap_codes_user_id", table_name="auth_native_bootstrap_codes")
+    op.drop_constraint("uq_auth_native_bootstrap_codes_code_hash", "auth_native_bootstrap_codes", type_="unique")
+    op.drop_table("auth_native_bootstrap_codes")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -182,6 +182,9 @@ class Settings(BaseSettings):
     firebase_web_api_key: str = ""
     firebase_project_number: str = ""
     firebase_auth_mobile_app_check_required: bool = False
+    # 산티아고 §9 finding 1(2026-07-15): App Check sub(App ID) allowlist — 콤마 구분 문자열.
+    # 미승인 앱이 App Check 토큰을 정확 서명해와도 이 목록에 없으면 거부.
+    firebase_app_check_allowed_app_ids: str = ""
 
     @property
     def is_ee_enabled(self) -> bool:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -175,6 +175,14 @@ class Settings(BaseSettings):
     # cron.py CRON_SECRET과 동일 패턴 — 미설정(로컬 개발) 시 인증 생략.
     firebase_bff_internal_secret: str = ""
 
+    # story 4dee942b(Phase1-S5): 네이티브 부트스트랩 — custom token→ID token 교환용 Firebase
+    # Web API key(공개 클라이언트 키, ADC와 별개). App Check 검증용 project number(project_id와
+    # 다른 값 — doc §9.3/산티아고 §9). App Check 필수 여부 게이트(기본 off — 모바일 클라이언트
+    # per-install challenge 메커니즘이 아직 없어 강제 시 발급 자체가 막힘, 별도 모바일 스토리 필요).
+    firebase_web_api_key: str = ""
+    firebase_project_number: str = ""
+    firebase_auth_mobile_app_check_required: bool = False
+
     @property
     def is_ee_enabled(self) -> bool:
         return self.license_consent.lower() == "agreed"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,7 +57,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import a2a, account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import a2a, account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 # 도메인 축 B(org-1st-class-surface-ia-design-b §3): OpenAPI 태그 조직-우선 위계.
 # 개별 라우터는 기존 세부 tag(예 "stories")를 그대로 유지하고 이 4축 태그를 추가로 보유(다중
@@ -239,6 +239,7 @@ app.include_router(agent_sessions.router)
 app.include_router(bridge.router)
 app.include_router(cron.router)
 app.include_router(auth_firebase_internal.router)
+app.include_router(auth_native_bootstrap.router)
 app.include_router(hitl.router)
 app.include_router(integrations.router)
 app.include_router(workflow_versions.router)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,11 +19,15 @@ _logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     from app.core.database import engine
+    from app.routers.auth_firebase_internal import check_internal_secret_config
     from app.routers.verdict_capture import warn_if_webhook_secret_misconfigured
+    from app.services.firebase_verifier import check_mobile_app_check_config
     from app.services.pg_pubsub import check_listen_config, listen_loop
 
     warn_if_webhook_secret_misconfigured()  # Bot-M.2 P3: 웹훅 secret misconfig 를 트래픽 前 경고.
     check_listen_config()  # ee7794eb ③ fail-closed: DB_PGBOUNCER on + DATABASE_URL_DIRECT 없으면 startup raise.
+    check_internal_secret_config()  # 산티아고 §9 finding 4: non-local + 시크릿 미설정 fail-closed.
+    check_mobile_app_check_config()  # 산티아고 §9 finding 1: mobile 발급 on + App Check 미필수 fail-closed.
     task = asyncio.create_task(listen_loop())
     # E-L2 S5: 휴리스틱 트리거 워커는 default-off — 명시 활성화 시에만 task 생성(AC①).
     l2_task = None

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.agent_routing_rule import AgentRoutingRule
 from app.models.agent_run import AgentRun
 from app.models.agent_session import AgentSession
 from app.models.auth_identity import AuthIdentity, AuthMigration, AuthMigrationEvent
+from app.models.auth_native_bootstrap import AuthNativeBootstrapCode
 from app.models.bridge import BridgeChannelMapping, BridgeUserMapping
 from app.models.deletion_audit import DeletionAuditLog
 from app.models.dependency import ItemDependency
@@ -67,6 +68,7 @@ __all__ = [
     "AuthIdentity",
     "AuthMigration",
     "AuthMigrationEvent",
+    "AuthNativeBootstrapCode",
     "ArtifactNode",
     "ArtifactVersion",
     "VisualArtifact",

--- a/backend/app/models/auth_native_bootstrap.py
+++ b/backend/app/models/auth_native_bootstrap.py
@@ -1,0 +1,27 @@
+"""story 4dee942b(E-AUTH-REBUILD M2 Phase1-S5·doc §9.1·산티아고 §9 코드 보안계약 2026-07-15):
+네이티브 부트스트랩 단회코드. `code_hash`만 저장 — raw code는 발급 응답으로만 반환되고 DB엔
+절대 남지 않는다."""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class AuthNativeBootstrapCode(Base):
+    __tablename__ = "auth_native_bootstrap_codes"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    firebase_uid: Mapped[str] = mapped_column(Text, nullable=False)
+    project_id: Mapped[str] = mapped_column(Text, nullable=False)
+    code_hash: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    device_binding_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    consumed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routers/auth_firebase_internal.py
+++ b/backend/app/routers/auth_firebase_internal.py
@@ -46,13 +46,35 @@ class FirebaseSessionMintResponse(BaseModel):
     expires_in: int
 
 
+# 산티아고 §9 finding 4(HIGH, 2026-07-15): 최초 구현이 cron.py CRON_SECRET 패턴을 그대로
+# 따라 "시크릿 미설정=허용"이었는데, cron과 달리 이 엔드포인트는 세션쿠키 mint 능력 자체라
+# 환경 무관 fail-open이 위험하다 — 직접 probe로 `app_env=production`+시크릿 미설정 시
+# 내부 consume/mint 엔드포인트가 공개됨을 실증. non-local 환경은 fail-closed(503), 로컬
+# 개발(APP_ENV=development)만 예외 허용.
+_LOCAL_ENVS = {"development"}
+
+
 def _require_internal_secret(authorization: str | None) -> None:
     secret = settings.firebase_bff_internal_secret
     if not secret:
-        # cron.py와 동일 정책: 로컬 개발에서 시크릿 미설정 시 허용(운영은 반드시 설정).
-        return
+        if settings.app_env in _LOCAL_ENVS:
+            return  # 로컬 개발 전용 예외
+        logger.warning("auth.firebase.internal_secret_missing_in_non_local_env app_env=%s", settings.app_env)
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Service misconfigured")
     if authorization != f"Bearer {secret}":
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid internal credential")
+
+
+def check_internal_secret_config(s=None) -> None:
+    """fail-closed(산티아고 §9 finding 4): non-local 환경에서 시크릿 미설정이면 startup
+    차단(check_listen_config()와 동일 패턴, main lifespan이 호출)."""
+    if s is None:
+        from app.core.config import settings as s
+    if s.app_env not in _LOCAL_ENVS and not s.firebase_bff_internal_secret:
+        raise RuntimeError(
+            f"APP_ENV={s.app_env}인데 FIREBASE_BFF_INTERNAL_SECRET 미설정 — 내부 세션 mint/"
+            "consume 엔드포인트가 인증 없이 공개된다(fail-closed·산티아고 §9 finding 4)."
+        )
 
 
 @router.post("/firebase-session", response_model=FirebaseSessionMintResponse)
@@ -109,6 +131,12 @@ async def mint_firebase_session(
 class NativeBootstrapConsumeRequest(BaseModel):
     code: str
     device_binding_hash: str | None = None
+    # 산티아고 §9 finding 3(HIGH) 최소 반영(④⑤·전체 per-installation attestation은 별도
+    # 후속 판단): 호출부(Next.js BFF)가 이미 유효한 __Host-sp_fs 세션을 갖고 있으면 그
+    # 세션의 검증된 user_id를 넘긴다 — attacker가 자기 code를 피해자 WebView에서 열게
+    # 만들어도(login-CSRF) 기존 세션 사용자와 code의 소유자가 다르면 무조건 거부한다
+    # (조용한 account-switch 금지).
+    existing_session_user_id: str | None = None
 
 
 class NativeBootstrapConsumeResponse(BaseModel):
@@ -125,7 +153,11 @@ async def consume_native_bootstrap(
     """story 4dee942b(Phase1-S5): Next.js `/auth/native?code=` 라우트(FE lane)가 호출하는
     내부 atomic-consume API. 원본 Firebase ID token은 발급 순간 이후로 존재하지 않으므로
     firebase_uid만으로 custom token 경유 세션쿠키를 새로 mint한다(S4 mint_session_cookie
-    재사용, 오르테가군 판정). 실패 사유(만료/재사용/불일치)는 전부 동일한 401로 통일."""
+    재사용, 오르테가군 판정). 실패 사유(만료/재사용/불일치)는 전부 동일한 401로 통일.
+
+    ⚠️산티아고 §9 검토(2026-07-15) finding 6 반영: atomic consume 성공만으로 곧장 mint하지
+    않는다 — 코드 발급~소비 사이(최대 45초)에 계정이 비활성화되거나 identity가 unlink됐을
+    수 있어 **소비 직후 다시** user.is_active/identity.unlinked_at을 재확認한다."""
     _require_internal_secret(authorization)
 
     if not settings.firebase_auth_mobile_issue:
@@ -140,6 +172,30 @@ async def consume_native_bootstrap(
     if consumed is None:
         logger.warning("auth.native_bootstrap.consume rejected reason=invalid_expired_or_replayed")
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired bootstrap code")
+
+    if body.existing_session_user_id and body.existing_session_user_id != str(consumed.user_id):
+        logger.warning("auth.native_bootstrap.consume rejected reason=session_user_mismatch")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Session user mismatch")
+
+    # finding 6: consume-time 재검증 — 발급 시점 검증(user active+identity linked)이 최대
+    # 45초 전이라 그 사이 상태 변화(계정 비활성화/identity unlink)를 반드시 다시 본다.
+    post_consume_user = await db.get(User, consumed.user_id)
+    if post_consume_user is None or not post_consume_user.is_active:
+        logger.warning("auth.native_bootstrap.consume rejected reason=user_inactive_at_consume")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid user")
+
+    still_linked = (
+        await db.execute(
+            select(AuthIdentity.id).where(
+                AuthIdentity.issuer == f"https://securetoken.google.com/{settings.firebase_project_id}",
+                AuthIdentity.subject == consumed.firebase_uid,
+                AuthIdentity.unlinked_at.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    if still_linked is None:
+        logger.warning("auth.native_bootstrap.consume rejected reason=identity_unlinked_at_consume")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Identity no longer linked")
 
     valid_duration_seconds = 5 * 24 * 60 * 60
     session_cookie = await mint_session_cookie_for_uid(

--- a/backend/app/routers/auth_firebase_internal.py
+++ b/backend/app/routers/auth_firebase_internal.py
@@ -26,8 +26,9 @@ from app.core.config import settings
 from app.dependencies.database import get_db
 from app.models.auth_identity import AuthIdentity
 from app.models.user import User
-from app.services.firebase_session_mint import mint_session_cookie
+from app.services.firebase_session_mint import mint_session_cookie, mint_session_cookie_for_uid
 from app.services.firebase_verifier import verify_firebase_id_token
+from app.services.native_bootstrap import consume_bootstrap_code
 
 logger = logging.getLogger(__name__)
 
@@ -103,3 +104,50 @@ async def mint_firebase_session(
 
     logger.info("auth.firebase.session_mint success")
     return FirebaseSessionMintResponse(session_cookie=session_cookie, expires_in=valid_duration_seconds)
+
+
+class NativeBootstrapConsumeRequest(BaseModel):
+    code: str
+    device_binding_hash: str | None = None
+
+
+class NativeBootstrapConsumeResponse(BaseModel):
+    session_cookie: str
+    expires_in: int
+
+
+@router.post("/native-bootstrap/consume", response_model=NativeBootstrapConsumeResponse)
+async def consume_native_bootstrap(
+    body: NativeBootstrapConsumeRequest,
+    authorization: str | None = Header(default=None),
+    db: AsyncSession = Depends(get_db),
+) -> NativeBootstrapConsumeResponse:
+    """story 4dee942b(Phase1-S5): Next.js `/auth/native?code=` 라우트(FE lane)가 호출하는
+    내부 atomic-consume API. 원본 Firebase ID token은 발급 순간 이후로 존재하지 않으므로
+    firebase_uid만으로 custom token 경유 세션쿠키를 새로 mint한다(S4 mint_session_cookie
+    재사용, 오르테가군 판정). 실패 사유(만료/재사용/불일치)는 전부 동일한 401로 통일."""
+    _require_internal_secret(authorization)
+
+    if not settings.firebase_auth_mobile_issue:
+        raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="Native bootstrap not enabled")
+
+    consumed = await consume_bootstrap_code(
+        db,
+        code=body.code,
+        project_id=settings.firebase_project_id,
+        device_binding_hash=body.device_binding_hash,
+    )
+    if consumed is None:
+        logger.warning("auth.native_bootstrap.consume rejected reason=invalid_expired_or_replayed")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired bootstrap code")
+
+    valid_duration_seconds = 5 * 24 * 60 * 60
+    session_cookie = await mint_session_cookie_for_uid(
+        consumed.firebase_uid, settings.firebase_project_id, settings.firebase_web_api_key, valid_duration_seconds
+    )
+    if session_cookie is None:
+        logger.warning("auth.native_bootstrap.consume failed reason=mint_failed")
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Session cookie mint failed")
+
+    logger.info("auth.native_bootstrap.consume success")
+    return NativeBootstrapConsumeResponse(session_cookie=session_cookie, expires_in=valid_duration_seconds)

--- a/backend/app/routers/auth_firebase_internal.py
+++ b/backend/app/routers/auth_firebase_internal.py
@@ -24,7 +24,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.dependencies.database import get_db
-from app.models.auth_identity import AuthIdentity
+from app.models.auth_identity import AuthIdentity, AuthMigration
 from app.models.user import User
 from app.services.firebase_session_mint import mint_session_cookie, mint_session_cookie_for_uid
 from app.services.firebase_verifier import verify_firebase_id_token
@@ -67,10 +67,19 @@ def _require_internal_secret(authorization: str | None) -> None:
 
 def check_internal_secret_config(s=None) -> None:
     """fail-closed(산티아고 §9 finding 4): non-local 환경에서 시크릿 미설정이면 startup
-    차단(check_listen_config()와 동일 패턴, main lifespan이 호출)."""
+    차단(check_listen_config()와 동일 패턴, main lifespan이 호출).
+
+    ⚠️산티아고 #2202 재검토(2026-07-15) 배포 회귀 발견·즉시 fix: 최초 구현이 Firebase
+    기능 플래그와 무관하게 non-local이면 무조건 시크릿을 요구해서, **Firebase 전부
+    default-off인 지금 상태로 배포해도**(`deploy_backend.sh`가 아직
+    `FIREBASE_BFF_INTERNAL_SECRET`을 SECRETS_SPEC에 배선하지 않음) backend 전체가
+    startup에서 죽는 회귀였다(직접 probe: prod_features_off_missing_secret_startup_
+    allowed=False). 이 내부 엔드포인트를 실제로 쓰는 기능(세션 발급/모바일 부트스트랩)이
+    켜져 있을 때만 시크릿을 요구한다."""
     if s is None:
         from app.core.config import settings as s
-    if s.app_env not in _LOCAL_ENVS and not s.firebase_bff_internal_secret:
+    firebase_internal_enabled = s.firebase_auth_issue_session or s.firebase_auth_mobile_issue
+    if firebase_internal_enabled and s.app_env not in _LOCAL_ENVS and not s.firebase_bff_internal_secret:
         raise RuntimeError(
             f"APP_ENV={s.app_env}인데 FIREBASE_BFF_INTERNAL_SECRET 미설정 — 내부 세션 mint/"
             "consume 엔드포인트가 인증 없이 공개된다(fail-closed·산티아고 §9 finding 4)."
@@ -184,11 +193,16 @@ async def consume_native_bootstrap(
         logger.warning("auth.native_bootstrap.consume rejected reason=user_inactive_at_consume")
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid user")
 
+    # 산티아고 #2202 3차 재검토(2026-07-15) 잔여 2: (issuer,subject)만 보고 unlinked 여부만
+    # 확인하면 그 사이 identity가 **다른 user_id로 재연결**된 레이스를 못 잡는다(구 행
+    # unlink+동일 firebase_uid로 신규 행이 다른 사용자에게 연결돼도 partial-unique 제약은
+    # 통과) — consumed.user_id와 정확히 같은 행인지까지 재확認.
     still_linked = (
         await db.execute(
             select(AuthIdentity.id).where(
                 AuthIdentity.issuer == f"https://securetoken.google.com/{settings.firebase_project_id}",
                 AuthIdentity.subject == consumed.firebase_uid,
+                AuthIdentity.user_id == consumed.user_id,
                 AuthIdentity.unlinked_at.is_(None),
             )
         )
@@ -196,6 +210,18 @@ async def consume_native_bootstrap(
     if still_linked is None:
         logger.warning("auth.native_bootstrap.consume rejected reason=identity_unlinked_at_consume")
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Identity no longer linked")
+
+    # 산티아고 #2202 3차 재검토 잔여 2(HIGH): AuthMigration.state 검증 없이는
+    # reset_required/rollback_hold 사용자가 bootstrap custom-token으로 새 세션을 발급받아
+    # coordinated forced-reset 정책(doc §6.1)과 정면 충돌한다. auth_migrations 행이 없거나
+    # (Phase 3 cohort 미편입) provisioning/firebase 상태가 아니면 거부 — fail-closed.
+    migration = await db.get(AuthMigration, consumed.user_id)
+    if migration is None or migration.state not in ("provisioning", "firebase"):
+        logger.warning(
+            "auth.native_bootstrap.consume rejected reason=ineligible_migration_state state=%s",
+            migration.state if migration else None,
+        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Account not eligible for Firebase session")
 
     valid_duration_seconds = 5 * 24 * 60 * 60
     session_cookie = await mint_session_cookie_for_uid(

--- a/backend/app/routers/auth_native_bootstrap.py
+++ b/backend/app/routers/auth_native_bootstrap.py
@@ -16,12 +16,13 @@ import hashlib
 import logging
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
+from app.core.rate_limit import limiter
 from app.dependencies.database import get_db
 from app.models.auth_identity import AuthIdentity
 from app.models.user import User
@@ -51,12 +52,24 @@ def _extract_bearer(authorization: str | None) -> str | None:
     return authorization[len("Bearer "):]
 
 
+def _allowed_app_ids() -> frozenset[str]:
+    raw = settings.firebase_app_check_allowed_app_ids
+    return frozenset(x.strip() for x in raw.split(",") if x.strip())
+
+
+# 산티아고 §9(2026-07-15) 잔여 하드닝: public issuance는 rate limit 없음 지적 — 로그인류
+# 엔드포인트와 동일 임계값(app/routers/auth.py register 패턴 재사용).
 @router.post("/native-bootstrap", response_model=NativeBootstrapResponse)
+@limiter.limit("10/minute")
 async def native_bootstrap(
+    request: Request,
     body: NativeBootstrapRequest,
+    response: Response,
     authorization: str | None = Header(default=None),
     db: AsyncSession = Depends(get_db),
 ) -> NativeBootstrapResponse:
+    response.headers["Cache-Control"] = "no-store"  # 산티아고 §9 잔여 하드닝.
+
     if not settings.firebase_auth_mobile_issue:
         raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="Native bootstrap not enabled")
 
@@ -98,7 +111,9 @@ async def native_bootstrap(
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="App Check token required")
 
     if body.app_check_token:
-        app_check = await verify_app_check_token(body.app_check_token, settings.firebase_project_number)
+        app_check = await verify_app_check_token(
+            body.app_check_token, settings.firebase_project_number, _allowed_app_ids()
+        )
         if app_check is None:
             logger.warning("auth.native_bootstrap rejected reason=app_check_invalid")
             raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid App Check token")

--- a/backend/app/routers/auth_native_bootstrap.py
+++ b/backend/app/routers/auth_native_bootstrap.py
@@ -1,0 +1,118 @@
+"""story 4dee942b(E-AUTH-REBUILD M2 Phase1-S5·doc §9.1·산티아고 §9 코드 보안계약 2026-07-15):
+`POST /api/v2/native-bootstrap` — 네이티브 모바일 앱이 WebView 밖에서 직접 호출(공개 API,
+쿠키 인증 아님). Firebase ID token을 exact Bearer로만 받는다(산티아고: "/native-bootstrap=
+cookie auth 아니라 exact Firebase Bearer+App Check+CORS 닫기" — CORS 정책 자체는 인프라
+전역 설정으로 이 PR 스코프 밖).
+
+⚠️App Check 검증은 "요청이 진짜 앱에서 왔다"만 증명한다 — 산티아고가 요구한 완전한
+"설치별(per-installation) key/challenge" device binding은 모바일 클라이언트가 별도
+challenge-response 메커니즘을 구현해야 하는 별개 스코프(아직 없음, 향후 모바일 스토리
+필요). 이 스토리에선 App Check 앱 무결성 증명 + 클라이언트 제공 install hint를 조합해
+`device_binding_hash`를 구성 — 완전한 암호학적 per-device 증명은 아니다(정직하게 표기).
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.dependencies.database import get_db
+from app.models.auth_identity import AuthIdentity
+from app.models.user import User
+from app.services.firebase_verifier import verify_app_check_token, verify_firebase_id_token
+from app.services.native_bootstrap import DEFAULT_TTL_SECONDS, issue_bootstrap_code
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v2/auth", tags=["auth", "firebase", "mobile"])
+
+_AUTH_TIME_MAX_AGE_SECONDS = 5 * 60
+
+
+class NativeBootstrapRequest(BaseModel):
+    app_check_token: str | None = None
+    device_install_hint: str | None = None
+
+
+class NativeBootstrapResponse(BaseModel):
+    code: str
+    expires_in: int
+
+
+def _extract_bearer(authorization: str | None) -> str | None:
+    if not authorization or not authorization.startswith("Bearer "):
+        return None
+    return authorization[len("Bearer "):]
+
+
+@router.post("/native-bootstrap", response_model=NativeBootstrapResponse)
+async def native_bootstrap(
+    body: NativeBootstrapRequest,
+    authorization: str | None = Header(default=None),
+    db: AsyncSession = Depends(get_db),
+) -> NativeBootstrapResponse:
+    if not settings.firebase_auth_mobile_issue:
+        raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="Native bootstrap not enabled")
+
+    id_token = _extract_bearer(authorization)
+    if id_token is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing Firebase ID token")
+
+    verified = await verify_firebase_id_token(id_token, settings.firebase_project_id)
+    if verified is None:
+        logger.warning("auth.native_bootstrap rejected reason=id_token_invalid")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid Firebase ID token")
+
+    now = datetime.now(timezone.utc).timestamp()
+    if now - verified.auth_time > _AUTH_TIME_MAX_AGE_SECONDS:
+        logger.warning("auth.native_bootstrap rejected reason=auth_time_stale")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication too old")
+
+    identity_row = (
+        await db.execute(
+            select(AuthIdentity).where(
+                AuthIdentity.issuer == verified.issuer,
+                AuthIdentity.subject == verified.firebase_uid,
+                AuthIdentity.unlinked_at.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    if identity_row is None:
+        logger.warning("auth.native_bootstrap rejected reason=unmapped_identity")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unmapped Firebase identity")
+
+    user = await db.get(User, identity_row.user_id)
+    if user is None or not user.is_active:
+        logger.warning("auth.native_bootstrap rejected reason=inactive_or_missing_user")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid user")
+
+    device_binding_hash: str | None = None
+    if settings.firebase_auth_mobile_app_check_required and not body.app_check_token:
+        logger.warning("auth.native_bootstrap rejected reason=app_check_required_missing")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="App Check token required")
+
+    if body.app_check_token:
+        app_check = await verify_app_check_token(body.app_check_token, settings.firebase_project_number)
+        if app_check is None:
+            logger.warning("auth.native_bootstrap rejected reason=app_check_invalid")
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid App Check token")
+        device_binding_hash = hashlib.sha256(
+            f"{app_check.app_id}:{body.device_install_hint or ''}".encode()
+        ).hexdigest()
+
+    code = await issue_bootstrap_code(
+        db,
+        user_id=identity_row.user_id,
+        firebase_uid=verified.firebase_uid,
+        project_id=settings.firebase_project_id,
+        device_binding_hash=device_binding_hash,
+        ttl_seconds=DEFAULT_TTL_SECONDS,
+    )
+    logger.info("auth.native_bootstrap success")
+    return NativeBootstrapResponse(code=code, expires_in=DEFAULT_TTL_SECONDS)

--- a/backend/app/services/firebase_session_mint.py
+++ b/backend/app/services/firebase_session_mint.py
@@ -14,7 +14,10 @@ non-prod 프로젝트 프로비저닝 완료 후 별도로 붙인다.
 """
 from __future__ import annotations
 
+import base64
+import json
 import logging
+import time
 
 import google.auth
 import google.auth.transport.requests
@@ -25,6 +28,12 @@ logger = logging.getLogger(__name__)
 _IDENTITY_TOOLKIT_SCOPE = "https://www.googleapis.com/auth/identitytoolkit"
 _CREATE_SESSION_COOKIE_URL_TEMPLATE = (
     "https://identitytoolkit.googleapis.com/v1/projects/{project_id}:createSessionCookie"
+)
+_SIGN_IN_WITH_CUSTOM_TOKEN_URL_TEMPLATE = (
+    "https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key={api_key}"
+)
+_CUSTOM_TOKEN_AUDIENCE = (
+    "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit"
 )
 
 
@@ -83,3 +92,103 @@ async def mint_session_cookie(
 
     logger.info("auth.firebase.session_mint success")
     return session_cookie
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def _get_signing_credentials():
+    """ADC가 service-account 자격증명일 때만 `.sign_bytes()`/`.service_account_email`을
+    노출한다 — user 자격증명(로컬 `gcloud auth application-default login`)이면 서명 불가.
+    테스트 모킹 지점(mint_custom_token 구조 검증용)."""
+    credentials, _project = google.auth.default(scopes=[_IDENTITY_TOOLKIT_SCOPE])
+    return credentials
+
+
+def mint_custom_token(firebase_uid: str) -> str | None:
+    """story 4dee942b(Phase1-S5·doc §9.1): 네이티브 부트스트랩 코드 소비 시점엔 원본 Firebase
+    ID token이 더 이상 없다(발급 순간 이후로 저장/전달하지 않음 — 저장 시 사실상 라이브
+    세션 자격증명을 DB에 두는 것과 같은 리스크). 대신 firebase_uid만으로 custom token을
+    로컬 서명(네트워크 호출 없음, service-account 개인키로 직접 JWT 서명 — Firebase 공식
+    custom token 포맷)해 `exchange_custom_token_for_id_token()`으로 넘긴다.
+
+    ⛔custom token/id_token/세션쿠키 값은 로그에 절대 남기지 않는다."""
+    try:
+        credentials = _get_signing_credentials()
+    except Exception:
+        logger.warning("auth.firebase.custom_token failed reason=adc_unavailable")
+        return None
+
+    if not hasattr(credentials, "sign_bytes") or not hasattr(credentials, "service_account_email"):
+        logger.warning("auth.firebase.custom_token failed reason=non_service_account_adc")
+        return None
+
+    now = int(time.time())
+    header = {"alg": "RS256", "typ": "JWT"}
+    payload = {
+        "iss": credentials.service_account_email,
+        "sub": credentials.service_account_email,
+        "aud": _CUSTOM_TOKEN_AUDIENCE,
+        "uid": firebase_uid,
+        "iat": now,
+        "exp": now + 3600,
+    }
+    signing_input = f"{_b64url(json.dumps(header).encode())}.{_b64url(json.dumps(payload).encode())}"
+    try:
+        signature = credentials.sign_bytes(signing_input.encode())
+    except Exception:
+        logger.warning("auth.firebase.custom_token failed reason=sign_failed")
+        return None
+
+    logger.info("auth.firebase.custom_token success")
+    return f"{signing_input}.{_b64url(signature)}"
+
+
+async def _call_sign_in_with_custom_token(custom_token: str, web_api_key: str) -> httpx.Response:
+    """실 Google REST 호출 지점 — 테스트에서 모킹."""
+    url = _SIGN_IN_WITH_CUSTOM_TOKEN_URL_TEMPLATE.format(api_key=web_api_key)
+    async with httpx.AsyncClient() as client:
+        return await client.post(url, json={"token": custom_token, "returnSecureToken": True})
+
+
+async def exchange_custom_token_for_id_token(custom_token: str, web_api_key: str) -> str | None:
+    """custom token → 실 ID token(signInWithCustomToken). 실패 시 None."""
+    if not web_api_key:
+        logger.warning("auth.firebase.custom_token_exchange failed reason=no_web_api_key")
+        return None
+    try:
+        response = await _call_sign_in_with_custom_token(custom_token, web_api_key)
+    except httpx.HTTPError:
+        logger.warning("auth.firebase.custom_token_exchange failed reason=network_error")
+        return None
+
+    if response.status_code != 200:
+        logger.warning(
+            "auth.firebase.custom_token_exchange failed reason=google_rejected status=%d",
+            response.status_code,
+        )
+        return None
+
+    id_token = response.json().get("idToken")
+    if not id_token or not isinstance(id_token, str):
+        logger.warning("auth.firebase.custom_token_exchange failed reason=malformed_response")
+        return None
+
+    logger.info("auth.firebase.custom_token_exchange success")
+    return id_token
+
+
+async def mint_session_cookie_for_uid(
+    firebase_uid: str, project_id: str, web_api_key: str, valid_duration_seconds: int = 5 * 24 * 60 * 60
+) -> str | None:
+    """story 4dee942b: firebase_uid만으로 세션쿠키 발급(네이티브 부트스트랩 소비 시점 전용
+    경로) — custom token 발급→ID token 교환→기존 mint_session_cookie() 그대로 재사용
+    (S4 발급 로직 재사용, 오르테가군 판정 2026-07-15). 체인 중 어느 단계든 실패하면 None."""
+    custom_token = mint_custom_token(firebase_uid)
+    if custom_token is None:
+        return None
+    id_token = await exchange_custom_token_for_id_token(custom_token, web_api_key)
+    if id_token is None:
+        return None
+    return await mint_session_cookie(id_token, project_id, valid_duration_seconds)

--- a/backend/app/services/firebase_verifier.py
+++ b/backend/app/services/firebase_verifier.py
@@ -283,9 +283,17 @@ class VerifiedAppCheck:
     app_id: str  # App Check 토큰의 sub — Firebase App ID(설치별 고유값 아님, 위 경고 참조)
 
 
-async def verify_app_check_token(token: str, project_number: str) -> VerifiedAppCheck | None:
-    """App Check 토큰 정확 검증(doc §9.3 "App Check is defense-in-depth"). issuer=
-    `https://firebaseappcheck.googleapis.com/<project_number>` — ⚠️여기의 project_number는
+async def verify_app_check_token(
+    token: str, project_number: str, allowed_app_ids: frozenset[str]
+) -> VerifiedAppCheck | None:
+    """App Check 토큰 정확 검증(doc §9.3 "App Check is defense-in-depth").
+
+    ⚠️산티아고 §9 검토 finding 1(HIGH, 2026-07-15) 수정 — 최초 구현이 `verify_aud: False`로
+    audience 검증을 아예 꺼두고 app-ID allowlist도 없어서 **직접 probe로 wrong audience·
+    미승인 app ID가 전부 통과**함을 실증했다(`accepted_app_id=1:123:web:unapproved-app`).
+    지금은 (a) aud에 `projects/<project_number>`가 정확히 포함됨을 jose가 강제 검증하고
+    (b) sub(App Check 토큰의 app ID)가 호출부가 넘긴 승인 allowlist에 있어야만 통과한다.
+    issuer=`https://firebaseappcheck.googleapis.com/<project_number>` — ⚠️이 project_number는
     다른 검증기들이 쓰는 project_id와 다른 값(Firebase 프로젝트 번호, 문자열 ID 아님)."""
     try:
         header = jose_jwt.get_unverified_header(token)
@@ -312,7 +320,7 @@ async def verify_app_check_token(token: str, project_number: str) -> VerifiedApp
             jwk,
             algorithms=["RS256"],
             issuer=expected_issuer,
-            options={"verify_aud": False},  # aud=projects/<num>/apps/<app_id> 배열 — 호출부가 app_id 매칭.
+            audience=f"projects/{project_number}",
         )
     except JWTError:
         return None
@@ -320,5 +328,22 @@ async def verify_app_check_token(token: str, project_number: str) -> VerifiedApp
     sub = payload.get("sub")
     if not sub:
         return None
+    if sub not in allowed_app_ids:
+        return None
 
     return VerifiedAppCheck(issuer=str(payload.get("iss")), app_id=str(sub))
+
+
+def check_mobile_app_check_config(s=None) -> None:
+    """fail-closed(산티아고 §9 finding 1 필수수정): 모바일 발급이 켜졌는데 App Check가
+    필수로 안 켜져 있으면 startup에서 차단한다 — device binding 없는 부트스트랩 발급이
+    prod에 살아 나가는 misconfig를 배포 전에 잡는다(check_listen_config()와 동일 패턴,
+    main lifespan이 호출)."""
+    if s is None:
+        from app.core.config import settings as s
+    if s.firebase_auth_mobile_issue and not s.firebase_auth_mobile_app_check_required:
+        raise RuntimeError(
+            "FIREBASE_AUTH_MOBILE_ISSUE=true인데 FIREBASE_AUTH_MOBILE_APP_CHECK_REQUIRED=false — "
+            "App Check 없는 네이티브 부트스트랩 발급은 device binding 없는 단회코드를 공개 발급하는 "
+            "것과 같다(fail-closed·산티아고 §9 finding 1)."
+        )

--- a/backend/app/services/firebase_verifier.py
+++ b/backend/app/services/firebase_verifier.py
@@ -227,3 +227,98 @@ async def verify_firebase_id_token(id_token: str, project_id: str) -> VerifiedFi
         email=payload.get("email"),
         auth_time=payload.get("auth_time"),
     )
+
+
+# story 4dee942b(Phase1-S5·산티아고 §9): App Check 토큰 검증 — device binding의 "App Check
+# 앱 무결성 증명" 부분만 커버한다. ⚠️App Check 토큰 자체엔 설치별(per-installation) 고유
+# challenge가 없다(sub=Firebase App ID, 앱 전체에 공통 — 특정 기기 인스턴스를 구분 못 함).
+# 산티아고가 요구한 "설치별 key/challenge" 수준의 완전한 device binding은 모바일 클라이언트가
+# 별도 challenge-response 메커니즘을 구현해야 하는 별개 스코프(모바일 스토리 필요) — 이
+# 함수는 그 전제조건인 "요청이 진짜 앱에서 왔다"만 정확 검증한다(App Check 표준 용도).
+FIREBASE_APP_CHECK_JWKS_URL = "https://firebaseappcheck.googleapis.com/v1/jwks"
+
+_app_check_key_cache: dict[str, dict] = {}
+_app_check_key_cache_expires_at: float = 0.0
+
+
+def _reset_app_check_key_cache_for_tests() -> None:
+    global _app_check_key_cache, _app_check_key_cache_expires_at
+    _app_check_key_cache = {}
+    _app_check_key_cache_expires_at = 0.0
+
+
+async def _fetch_app_check_jwks() -> dict[str, dict]:
+    """표준 JWKS 포맷(kid→JWK dict) — 세션쿠키/ID token의 kid→X.509 PEM 포맷과 다르다.
+    PEM 파싱 불요, jose가 JWK dict를 직접 받는다."""
+    global _app_check_key_cache, _app_check_key_cache_expires_at
+    now = time.time()
+    if _app_check_key_cache and _app_check_key_cache_expires_at > now:
+        return _app_check_key_cache
+
+    async with httpx.AsyncClient() as client:
+        res = await client.get(FIREBASE_APP_CHECK_JWKS_URL)
+    if res.status_code != 200:
+        raise RuntimeError("app_check_jwks_fetch_failed")
+    body = res.json()
+    keys_by_kid = {jwk["kid"]: jwk for jwk in body.get("keys", []) if "kid" in jwk}
+
+    cache_control = res.headers.get("cache-control", "")
+    max_age = _DEFAULT_KEY_CACHE_SECONDS
+    for part in cache_control.split(","):
+        part = part.strip()
+        if part.startswith("max-age="):
+            try:
+                max_age = min(int(part.split("=", 1)[1]), _MAX_KEY_CACHE_SECONDS)
+            except ValueError:
+                pass
+
+    _app_check_key_cache = keys_by_kid
+    _app_check_key_cache_expires_at = now + max_age
+    return keys_by_kid
+
+
+@dataclass
+class VerifiedAppCheck:
+    issuer: str
+    app_id: str  # App Check 토큰의 sub — Firebase App ID(설치별 고유값 아님, 위 경고 참조)
+
+
+async def verify_app_check_token(token: str, project_number: str) -> VerifiedAppCheck | None:
+    """App Check 토큰 정확 검증(doc §9.3 "App Check is defense-in-depth"). issuer=
+    `https://firebaseappcheck.googleapis.com/<project_number>` — ⚠️여기의 project_number는
+    다른 검증기들이 쓰는 project_id와 다른 값(Firebase 프로젝트 번호, 문자열 ID 아님)."""
+    try:
+        header = jose_jwt.get_unverified_header(token)
+    except JWTError:
+        return None
+
+    kid = header.get("kid")
+    if not kid:
+        return None
+
+    try:
+        keys = await _fetch_app_check_jwks()
+    except RuntimeError:
+        return None
+
+    jwk = keys.get(kid)
+    if jwk is None:
+        return None
+
+    expected_issuer = f"https://firebaseappcheck.googleapis.com/{project_number}"
+    try:
+        payload = jose_jwt.decode(
+            token,
+            jwk,
+            algorithms=["RS256"],
+            issuer=expected_issuer,
+            options={"verify_aud": False},  # aud=projects/<num>/apps/<app_id> 배열 — 호출부가 app_id 매칭.
+        )
+    except JWTError:
+        return None
+
+    sub = payload.get("sub")
+    if not sub:
+        return None
+
+    return VerifiedAppCheck(issuer=str(payload.get("iss")), app_id=str(sub))

--- a/backend/app/services/native_bootstrap.py
+++ b/backend/app/services/native_bootstrap.py
@@ -1,0 +1,103 @@
+"""story 4dee942b(E-AUTH-REBUILD M2 Phase1-S5·doc §9.1·산티아고 §9 코드 보안계약 2026-07-15):
+네이티브 부트스트랩 단회코드 발급/소비.
+
+**발급**: 256bit CSPRNG(`secrets.token_urlsafe(32)`) — code_hash(SHA-256)만 저장, raw code는
+호출부 응답으로만 반환. TTL 30~60초(기본 45초). project_id(exact Firebase project/tenant)
+바인딩. device_binding_hash는 발급 시점에 App Check 검증이 있었을 때만 채워짐(optional).
+
+**소비**: 단일 원자적 `UPDATE...WHERE code_hash=? AND consumed_at IS NULL AND expires_at>now()
+AND project_id=? RETURNING`(check-then-insert TOCTOU 없음 — SELECT 후 별도 UPDATE 절대 금지,
+동시 2요청 중 정확히 1건만 RETURNING 행을 받는다). project_id 불일치·만료·이미 소비·
+device_binding_hash 불일치는 전부 동일하게 "0 rows updated"로 수렴 — 실패 사유를 구분해
+노출하지 않는다(enumeration 방지).
+"""
+from __future__ import annotations
+
+import hashlib
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.auth_native_bootstrap import AuthNativeBootstrapCode
+
+DEFAULT_TTL_SECONDS = 45  # 산티아고 §9: 30~60초
+
+
+def _hash_code(code: str) -> str:
+    return hashlib.sha256(code.encode()).hexdigest()
+
+
+async def issue_bootstrap_code(
+    db: AsyncSession,
+    *,
+    user_id,
+    firebase_uid: str,
+    project_id: str,
+    device_binding_hash: str | None = None,
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+) -> str:
+    """raw code를 반환 — 이 함수 반환 이후로는 raw code가 어디에도 다시 나타나지 않는다
+    (DB엔 hash만, 로그에도 절대 남기지 않는다 — 호출부 책임)."""
+    code = secrets.token_urlsafe(32)  # 256bit 이상 엔트로피
+    now = datetime.now(timezone.utc)
+    row = AuthNativeBootstrapCode(
+        user_id=user_id,
+        firebase_uid=firebase_uid,
+        project_id=project_id,
+        code_hash=_hash_code(code),
+        device_binding_hash=device_binding_hash,
+        created_at=now,
+        expires_at=now + timedelta(seconds=ttl_seconds),
+    )
+    db.add(row)
+    await db.commit()
+    return code
+
+
+@dataclass
+class ConsumedBootstrapCode:
+    user_id: object
+    firebase_uid: str
+
+
+async def consume_bootstrap_code(
+    db: AsyncSession,
+    *,
+    code: str,
+    project_id: str,
+    device_binding_hash: str | None = None,
+) -> ConsumedBootstrapCode | None:
+    """원자적 1회 소비. 실패(만료/이미소비/project_id 불일치/device_binding_hash 불일치/
+    존재하지 않는 코드) 시 전부 None — 사유 구분 없음."""
+    code_hash = _hash_code(code)
+    now = datetime.now(timezone.utc)
+
+    conditions = [
+        AuthNativeBootstrapCode.code_hash == code_hash,
+        AuthNativeBootstrapCode.consumed_at.is_(None),
+        AuthNativeBootstrapCode.expires_at > now,
+        AuthNativeBootstrapCode.project_id == project_id,
+    ]
+    # 발급 시 device_binding_hash가 채워진 코드는 소비 시 정확 일치 필수(산티아고 §9:
+    # device binding은 client-supplied ID 저장만으론 불충분 — 검증 가능한 proof 매칭).
+    # 발급 시 NULL이었던 코드는(App Check 미요구 발급) device proof 없이도 소비 허용.
+    conditions.append(
+        (AuthNativeBootstrapCode.device_binding_hash.is_(None))
+        | (AuthNativeBootstrapCode.device_binding_hash == device_binding_hash)
+    )
+
+    stmt = (
+        update(AuthNativeBootstrapCode)
+        .where(*conditions)
+        .values(consumed_at=now)
+        .returning(AuthNativeBootstrapCode.user_id, AuthNativeBootstrapCode.firebase_uid)
+    )
+    result = await db.execute(stmt)
+    row = result.first()
+    await db.commit()
+    if row is None:
+        return None
+    return ConsumedBootstrapCode(user_id=row[0], firebase_uid=row[1])

--- a/backend/tests/test_e_auth_rebuild_phase1_s5_app_check_verifier.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s5_app_check_verifier.py
@@ -16,6 +16,7 @@ from app.services import firebase_verifier as fv
 
 PROJECT_NUMBER = "1234567890"
 KID = "app-check-kid-1"
+ALLOWED_APP_IDS = frozenset({"1:123:android:abc"})
 
 
 @pytest.fixture
@@ -66,7 +67,7 @@ async def test_accepts_correctly_signed_app_check_token(monkeypatch):
     key_pem, jwk = _make_rsa_keypair()
     _patch_fetch(monkeypatch, {KID: jwk})
     token = _make_app_check_token(key_pem)
-    result = await fv.verify_app_check_token(token, PROJECT_NUMBER)
+    result = await fv.verify_app_check_token(token, PROJECT_NUMBER, ALLOWED_APP_IDS)
     assert result is not None
     assert result.app_id == "1:123:android:abc"
 
@@ -76,7 +77,7 @@ async def test_rejects_wrong_issuer(monkeypatch):
     key_pem, jwk = _make_rsa_keypair()
     _patch_fetch(monkeypatch, {KID: jwk})
     token = _make_app_check_token(key_pem, iss="https://securetoken.google.com/other")
-    result = await fv.verify_app_check_token(token, PROJECT_NUMBER)
+    result = await fv.verify_app_check_token(token, PROJECT_NUMBER, ALLOWED_APP_IDS)
     assert result is None
 
 
@@ -85,7 +86,7 @@ async def test_rejects_wrong_project_number_in_issuer(monkeypatch):
     key_pem, jwk = _make_rsa_keypair()
     _patch_fetch(monkeypatch, {KID: jwk})
     token = _make_app_check_token(key_pem, iss="https://firebaseappcheck.googleapis.com/other-project")
-    result = await fv.verify_app_check_token(token, PROJECT_NUMBER)
+    result = await fv.verify_app_check_token(token, PROJECT_NUMBER, ALLOWED_APP_IDS)
     assert result is None
 
 
@@ -99,7 +100,7 @@ async def test_rejects_missing_kid(monkeypatch):
          "iss": f"https://firebaseappcheck.googleapis.com/{PROJECT_NUMBER}", "aud": [f"projects/{PROJECT_NUMBER}"]},
         key_pem, algorithm="RS256",
     )
-    result = await fv.verify_app_check_token(no_kid, PROJECT_NUMBER)
+    result = await fv.verify_app_check_token(no_kid, PROJECT_NUMBER, ALLOWED_APP_IDS)
     assert result is None
 
 
@@ -108,7 +109,7 @@ async def test_rejects_unknown_kid(monkeypatch):
     key_pem, jwk = _make_rsa_keypair()
     _patch_fetch(monkeypatch, {"some-other-kid": jwk})
     token = _make_app_check_token(key_pem, kid=KID)
-    result = await fv.verify_app_check_token(token, PROJECT_NUMBER)
+    result = await fv.verify_app_check_token(token, PROJECT_NUMBER, ALLOWED_APP_IDS)
     assert result is None
 
 
@@ -117,7 +118,7 @@ async def test_rejects_expired_token(monkeypatch):
     key_pem, jwk = _make_rsa_keypair()
     _patch_fetch(monkeypatch, {KID: jwk})
     token = _make_app_check_token(key_pem, exp_delta=-3600)
-    result = await fv.verify_app_check_token(token, PROJECT_NUMBER)
+    result = await fv.verify_app_check_token(token, PROJECT_NUMBER, ALLOWED_APP_IDS)
     assert result is None
 
 
@@ -127,5 +128,34 @@ async def test_rejects_forged_signature_untrusted_key(monkeypatch):
     attacker_key_pem, _attacker_jwk = _make_rsa_keypair()
     _patch_fetch(monkeypatch, {KID: jwk})
     forged = _make_app_check_token(attacker_key_pem, kid=KID)
-    result = await fv.verify_app_check_token(forged, PROJECT_NUMBER)
+    result = await fv.verify_app_check_token(forged, PROJECT_NUMBER, ALLOWED_APP_IDS)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_rejects_wrong_audience(monkeypatch):
+    """산티아고 §9 finding 1(HIGH) 회귀 가드 — 최초 구현은 verify_aud:False라 이 케이스가
+    통과했다(직접 probe: wrong_audience_unapproved_app_accepted=True)."""
+    key_pem, jwk = _make_rsa_keypair()
+    _patch_fetch(monkeypatch, {KID: jwk})
+    now = int(time.time())
+    wrong_aud = jose_jwt.encode(
+        {"sub": "1:123:android:abc", "iat": now, "exp": now + 3600,
+         "iss": f"https://firebaseappcheck.googleapis.com/{PROJECT_NUMBER}",
+         "aud": ["projects/some-other-project-number"]},
+        key_pem, algorithm="RS256", headers={"kid": KID},
+    )
+    result = await fv.verify_app_check_token(wrong_aud, PROJECT_NUMBER, ALLOWED_APP_IDS)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_rejects_unapproved_app_id(monkeypatch):
+    """산티아고 §9 finding 1(HIGH) 회귀 가드 — allowlist 없이는 서명·issuer·audience가
+    전부 정확해도 승인 안 된 app이 통과했다(직접 probe: accepted_app_id=
+    1:123:web:unapproved-app)."""
+    key_pem, jwk = _make_rsa_keypair()
+    _patch_fetch(monkeypatch, {KID: jwk})
+    token = _make_app_check_token(key_pem, sub="1:123:web:unapproved-app")
+    result = await fv.verify_app_check_token(token, PROJECT_NUMBER, ALLOWED_APP_IDS)
     assert result is None

--- a/backend/tests/test_e_auth_rebuild_phase1_s5_app_check_verifier.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s5_app_check_verifier.py
@@ -1,0 +1,131 @@
+"""story 4dee942b(E-AUTH-REBUILD M2 Phase1-S5) 계약 테스트: verify_app_check_token() 정확
+검증. App Check JWKS는 표준 kid→JWK dict 포맷(세션쿠키/ID token의 kid→X.509 PEM과 다름) —
+raw RSA 키페어로 직접 JWK 구성해 파싱 경로 자체를 실증한다.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+from jose import jwt as jose_jwt
+from jose.utils import long_to_base64
+
+from app.services import firebase_verifier as fv
+
+PROJECT_NUMBER = "1234567890"
+KID = "app-check-kid-1"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    fv._reset_app_check_key_cache_for_tests()
+    yield
+    fv._reset_app_check_key_cache_for_tests()
+
+
+def _make_rsa_keypair() -> tuple[str, dict]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    numbers = key.public_key().public_numbers()
+    jwk = {
+        "kty": "RSA", "kid": KID, "use": "sig", "alg": "RS256",
+        "n": long_to_base64(numbers.n).decode(), "e": long_to_base64(numbers.e).decode(),
+    }
+    return pem, jwk
+
+
+def _make_app_check_token(key_pem: str, *, iss: str | None = None, sub: str = "1:123:android:abc", kid: str = KID, exp_delta: int = 3600) -> str:
+    now = int(time.time())
+    claims = {
+        "sub": sub, "iat": now, "exp": now + exp_delta,
+        "iss": iss or f"https://firebaseappcheck.googleapis.com/{PROJECT_NUMBER}",
+        "aud": [f"projects/{PROJECT_NUMBER}"],
+    }
+    return jose_jwt.encode(claims, key_pem, algorithm="RS256", headers={"kid": kid})
+
+
+def _patch_fetch(monkeypatch, jwks: dict[str, dict]) -> None:
+    async def fake_fetch():
+        return jwks
+    monkeypatch.setattr(fv, "_fetch_app_check_jwks", fake_fetch)
+
+
+@pytest.mark.anyio
+async def test_accepts_correctly_signed_app_check_token(monkeypatch):
+    key_pem, jwk = _make_rsa_keypair()
+    _patch_fetch(monkeypatch, {KID: jwk})
+    token = _make_app_check_token(key_pem)
+    result = await fv.verify_app_check_token(token, PROJECT_NUMBER)
+    assert result is not None
+    assert result.app_id == "1:123:android:abc"
+
+
+@pytest.mark.anyio
+async def test_rejects_wrong_issuer(monkeypatch):
+    key_pem, jwk = _make_rsa_keypair()
+    _patch_fetch(monkeypatch, {KID: jwk})
+    token = _make_app_check_token(key_pem, iss="https://securetoken.google.com/other")
+    result = await fv.verify_app_check_token(token, PROJECT_NUMBER)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_rejects_wrong_project_number_in_issuer(monkeypatch):
+    key_pem, jwk = _make_rsa_keypair()
+    _patch_fetch(monkeypatch, {KID: jwk})
+    token = _make_app_check_token(key_pem, iss="https://firebaseappcheck.googleapis.com/other-project")
+    result = await fv.verify_app_check_token(token, PROJECT_NUMBER)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_rejects_missing_kid(monkeypatch):
+    key_pem, jwk = _make_rsa_keypair()
+    _patch_fetch(monkeypatch, {KID: jwk})
+    now = int(time.time())
+    no_kid = jose_jwt.encode(
+        {"sub": "1:123:android:abc", "iat": now, "exp": now + 3600,
+         "iss": f"https://firebaseappcheck.googleapis.com/{PROJECT_NUMBER}", "aud": [f"projects/{PROJECT_NUMBER}"]},
+        key_pem, algorithm="RS256",
+    )
+    result = await fv.verify_app_check_token(no_kid, PROJECT_NUMBER)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_rejects_unknown_kid(monkeypatch):
+    key_pem, jwk = _make_rsa_keypair()
+    _patch_fetch(monkeypatch, {"some-other-kid": jwk})
+    token = _make_app_check_token(key_pem, kid=KID)
+    result = await fv.verify_app_check_token(token, PROJECT_NUMBER)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_rejects_expired_token(monkeypatch):
+    key_pem, jwk = _make_rsa_keypair()
+    _patch_fetch(monkeypatch, {KID: jwk})
+    token = _make_app_check_token(key_pem, exp_delta=-3600)
+    result = await fv.verify_app_check_token(token, PROJECT_NUMBER)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_rejects_forged_signature_untrusted_key(monkeypatch):
+    _key_pem, jwk = _make_rsa_keypair()
+    attacker_key_pem, _attacker_jwk = _make_rsa_keypair()
+    _patch_fetch(monkeypatch, {KID: jwk})
+    forged = _make_app_check_token(attacker_key_pem, kid=KID)
+    result = await fv.verify_app_check_token(forged, PROJECT_NUMBER)
+    assert result is None

--- a/backend/tests/test_e_auth_rebuild_phase1_s5_consume_endpoint_realdb.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s5_consume_endpoint_realdb.py
@@ -46,23 +46,33 @@ async def _session_factory():
     return engine, async_sessionmaker(engine, expire_on_commit=False)
 
 
-async def _seed_user_and_code(session, *, device_binding_hash=None):
+async def _seed_user_and_code(session, *, device_binding_hash=None, mapped=True):
     from app.core.security import hash_password
+    from app.models.auth_identity import AuthIdentity
     from app.models.user import User
     from app.services.native_bootstrap import issue_bootstrap_code
 
     user_id = uuid.uuid4()
+    firebase_uid = f"fb-uid-{user_id.hex[:8]}"
     session.add(User(
         id=user_id, email=f"authreb-s5-consume-{user_id.hex[:8]}@test.com",
         hashed_password=hash_password("x"), is_active=True, email_verified=True,
     ))
     await session.commit()
 
+    if mapped:
+        session.add(AuthIdentity(
+            id=uuid.uuid4(), user_id=user_id,
+            issuer=f"https://securetoken.google.com/{PROJECT_ID}", subject=firebase_uid,
+            provider_id="password",
+        ))
+        await session.commit()
+
     raw_code = await issue_bootstrap_code(
-        session, user_id=user_id, firebase_uid=f"fb-uid-{user_id.hex[:8]}", project_id=PROJECT_ID,
+        session, user_id=user_id, firebase_uid=firebase_uid, project_id=PROJECT_ID,
         device_binding_hash=device_binding_hash,
     )
-    return raw_code
+    return raw_code, user_id
 
 
 def _setup_common(monkeypatch, *, mobile_issue: bool = True):
@@ -144,7 +154,7 @@ async def test_success_returns_minted_cookie(monkeypatch):
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
-            raw_code = await _seed_user_and_code(s)
+            raw_code, _user_id = await _seed_user_and_code(s)
 
         async with Session() as s:
             result = await consume_native_bootstrap(
@@ -170,7 +180,7 @@ async def test_replay_after_success_rejected(monkeypatch):
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
-            raw_code = await _seed_user_and_code(s)
+            raw_code, _user_id = await _seed_user_and_code(s)
 
         async with Session() as s:
             first = await consume_native_bootstrap(
@@ -202,7 +212,7 @@ async def test_mint_failure_returns_502(monkeypatch):
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
-            raw_code = await _seed_user_and_code(s)
+            raw_code, _user_id = await _seed_user_and_code(s)
 
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
@@ -223,13 +233,157 @@ async def test_device_binding_mismatch_rejected(monkeypatch):
     engine, Session = await _session_factory()
     try:
         async with Session() as s:
-            raw_code = await _seed_user_and_code(s, device_binding_hash="correct-hash")
+            raw_code, _user_id = await _seed_user_and_code(s, device_binding_hash="correct-hash")
 
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
                 await consume_native_bootstrap(
                     NativeBootstrapConsumeRequest(code=raw_code, device_binding_hash="wrong-hash"),
                     authorization=None, db=s,
+                )
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_prod_missing_internal_secret_fail_closed_503(monkeypatch):
+    """산티아고 §9 finding 4(HIGH) 회귀 가드 — 최초 구현은 환경 무관 fail-open이었다
+    (직접 probe: app_env=production+secret 미설정→prod_missing_internal_secret_allowed=True).
+    non-local 환경은 secret 미설정 시 503 fail-closed로 바뀌었다."""
+    from app.core.config import settings
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+
+    _setup_common(monkeypatch)
+    monkeypatch.setattr(settings, "app_env", "production")
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await consume_native_bootstrap(
+                    NativeBootstrapConsumeRequest(code="whatever"), authorization=None, db=s
+                )
+            assert exc_info.value.status_code == 503
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_existing_session_different_user_rejected(monkeypatch):
+    """산티아고 §9 finding 3(HIGH) 최소 반영 — attacker가 자기 code를 피해자 WebView에
+    소비시키는 login-CSRF: 기존 __Host-sp_fs 세션의 검증된 user_id와 코드 소유자가 다르면
+    무조건 거부(조용한 account-switch 금지)."""
+    import app.routers.auth_firebase_internal as router_mod
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+
+    _setup_common(monkeypatch)
+
+    async def fake_mint_for_uid(firebase_uid, project_id, web_api_key, valid_duration_seconds):
+        return "should-never-be-returned"
+    monkeypatch.setattr(router_mod, "mint_session_cookie_for_uid", fake_mint_for_uid)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            raw_code, _code_owner_user_id = await _seed_user_and_code(s)
+
+        attacker_controlled_different_user_id = str(uuid.uuid4())
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await consume_native_bootstrap(
+                    NativeBootstrapConsumeRequest(
+                        code=raw_code, existing_session_user_id=attacker_controlled_different_user_id
+                    ),
+                    authorization=None, db=s,
+                )
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_existing_session_same_user_allowed(monkeypatch):
+    """finding 3 회귀 가드 반대편 — 기존 세션 사용자와 코드 소유자가 동일하면(정상 재인증)
+    거부하면 안 된다."""
+    import app.routers.auth_firebase_internal as router_mod
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+
+    _setup_common(monkeypatch)
+
+    async def fake_mint_for_uid(firebase_uid, project_id, web_api_key, valid_duration_seconds):
+        return "minted-cookie"
+    monkeypatch.setattr(router_mod, "mint_session_cookie_for_uid", fake_mint_for_uid)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            raw_code, code_owner_user_id = await _seed_user_and_code(s)
+
+        async with Session() as s:
+            result = await consume_native_bootstrap(
+                NativeBootstrapConsumeRequest(
+                    code=raw_code, existing_session_user_id=str(code_owner_user_id)
+                ),
+                authorization=None, db=s,
+            )
+        assert result.session_cookie == "minted-cookie"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_consume_time_reverify_rejects_user_disabled_after_issuance(monkeypatch):
+    """산티아고 §9 finding 6 회귀 가드 — 발급~소비 사이(최대 45초)에 계정이 비활성화되면
+    atomic consume 자체는 성공해도(코드는 유효) mint 직전 재검증에서 거부해야 한다."""
+    from sqlalchemy import update
+    from app.models.user import User
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+
+    _setup_common(monkeypatch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            raw_code, user_id = await _seed_user_and_code(s)
+            await s.execute(update(User).where(User.id == user_id).values(is_active=False))
+            await s.commit()
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await consume_native_bootstrap(
+                    NativeBootstrapConsumeRequest(code=raw_code), authorization=None, db=s
+                )
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_consume_time_reverify_rejects_identity_unlinked_after_issuance(monkeypatch):
+    """finding 6 회귀 가드 — 발급 후 identity가 unlink되면(보안 이벤트로 인한 강제 해제 등)
+    atomic consume은 성공해도 mint 직전 재검증에서 거부해야 한다."""
+    from sqlalchemy import update
+    from app.models.auth_identity import AuthIdentity
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+
+    _setup_common(monkeypatch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            raw_code, user_id = await _seed_user_and_code(s)
+            from datetime import datetime, timezone
+            await s.execute(
+                update(AuthIdentity).where(AuthIdentity.user_id == user_id)
+                .values(unlinked_at=datetime.now(timezone.utc))
+            )
+            await s.commit()
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await consume_native_bootstrap(
+                    NativeBootstrapConsumeRequest(code=raw_code), authorization=None, db=s
                 )
             assert exc_info.value.status_code == 401
     finally:

--- a/backend/tests/test_e_auth_rebuild_phase1_s5_consume_endpoint_realdb.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s5_consume_endpoint_realdb.py
@@ -1,0 +1,236 @@
+"""story 4dee942b(E-AUTH-REBUILD M2 Phase1-S5) 게이트: POST /api/v2/internal/auth/
+native-bootstrap/consume — 서비스-투-서비스 atomic consume+세션쿠키 mint 체인이 실 DB로
+정확히 동작하는지 실증. mint_session_cookie_for_uid()의 Google 왕복은 모킹(S5 계약테스트가
+그 체인 자체는 이미 검증), 여기선 라우터의 게이팅/consume 위임/응답 형태만 확인.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+PROJECT_ID = "test-project"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_after():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_user_and_code(session, *, device_binding_hash=None):
+    from app.core.security import hash_password
+    from app.models.user import User
+    from app.services.native_bootstrap import issue_bootstrap_code
+
+    user_id = uuid.uuid4()
+    session.add(User(
+        id=user_id, email=f"authreb-s5-consume-{user_id.hex[:8]}@test.com",
+        hashed_password=hash_password("x"), is_active=True, email_verified=True,
+    ))
+    await session.commit()
+
+    raw_code = await issue_bootstrap_code(
+        session, user_id=user_id, firebase_uid=f"fb-uid-{user_id.hex[:8]}", project_id=PROJECT_ID,
+        device_binding_hash=device_binding_hash,
+    )
+    return raw_code
+
+
+def _setup_common(monkeypatch, *, mobile_issue: bool = True):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "firebase_auth_mobile_issue", mobile_issue)
+    monkeypatch.setattr(settings, "firebase_project_id", PROJECT_ID)
+    monkeypatch.setattr(settings, "firebase_bff_internal_secret", "")
+
+
+@pytest.mark.anyio
+async def test_flag_off_returns_501(monkeypatch):
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+
+    _setup_common(monkeypatch, mobile_issue=False)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await consume_native_bootstrap(
+                    NativeBootstrapConsumeRequest(code="whatever"), authorization=None, db=s
+                )
+            assert exc_info.value.status_code == 501
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_wrong_internal_secret_rejected(monkeypatch):
+    from app.core.config import settings
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+
+    _setup_common(monkeypatch)
+    monkeypatch.setattr(settings, "firebase_bff_internal_secret", "correct-secret")
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await consume_native_bootstrap(
+                    NativeBootstrapConsumeRequest(code="whatever"),
+                    authorization="Bearer wrong-secret", db=s,
+                )
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_invalid_code_rejected(monkeypatch):
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+
+    _setup_common(monkeypatch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await consume_native_bootstrap(
+                    NativeBootstrapConsumeRequest(code="never-issued-code"), authorization=None, db=s
+                )
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_success_returns_minted_cookie(monkeypatch):
+    import app.routers.auth_firebase_internal as router_mod
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+
+    _setup_common(monkeypatch)
+
+    async def fake_mint_for_uid(firebase_uid, project_id, web_api_key, valid_duration_seconds):
+        assert project_id == PROJECT_ID
+        return "minted-native-session-cookie"
+    monkeypatch.setattr(router_mod, "mint_session_cookie_for_uid", fake_mint_for_uid)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            raw_code = await _seed_user_and_code(s)
+
+        async with Session() as s:
+            result = await consume_native_bootstrap(
+                NativeBootstrapConsumeRequest(code=raw_code), authorization=None, db=s
+            )
+        assert result.session_cookie == "minted-native-session-cookie"
+        assert result.expires_in == 5 * 24 * 60 * 60
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_replay_after_success_rejected(monkeypatch):
+    import app.routers.auth_firebase_internal as router_mod
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+
+    _setup_common(monkeypatch)
+
+    async def fake_mint_for_uid(firebase_uid, project_id, web_api_key, valid_duration_seconds):
+        return "minted-cookie"
+    monkeypatch.setattr(router_mod, "mint_session_cookie_for_uid", fake_mint_for_uid)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            raw_code = await _seed_user_and_code(s)
+
+        async with Session() as s:
+            first = await consume_native_bootstrap(
+                NativeBootstrapConsumeRequest(code=raw_code), authorization=None, db=s
+            )
+        assert first.session_cookie == "minted-cookie"
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await consume_native_bootstrap(
+                    NativeBootstrapConsumeRequest(code=raw_code), authorization=None, db=s
+                )
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_mint_failure_returns_502(monkeypatch):
+    import app.routers.auth_firebase_internal as router_mod
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+
+    _setup_common(monkeypatch)
+
+    async def fake_mint_for_uid(firebase_uid, project_id, web_api_key, valid_duration_seconds):
+        return None
+    monkeypatch.setattr(router_mod, "mint_session_cookie_for_uid", fake_mint_for_uid)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            raw_code = await _seed_user_and_code(s)
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await consume_native_bootstrap(
+                    NativeBootstrapConsumeRequest(code=raw_code), authorization=None, db=s
+                )
+            assert exc_info.value.status_code == 502
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_device_binding_mismatch_rejected(monkeypatch):
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+
+    _setup_common(monkeypatch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            raw_code = await _seed_user_and_code(s, device_binding_hash="correct-hash")
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await consume_native_bootstrap(
+                    NativeBootstrapConsumeRequest(code=raw_code, device_binding_hash="wrong-hash"),
+                    authorization=None, db=s,
+                )
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_e_auth_rebuild_phase1_s5_consume_endpoint_realdb.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s5_consume_endpoint_realdb.py
@@ -46,9 +46,11 @@ async def _session_factory():
     return engine, async_sessionmaker(engine, expire_on_commit=False)
 
 
-async def _seed_user_and_code(session, *, device_binding_hash=None, mapped=True):
+async def _seed_user_and_code(
+    session, *, device_binding_hash=None, mapped=True, migration_state="firebase", link_identity_to_other_user=False
+):
     from app.core.security import hash_password
-    from app.models.auth_identity import AuthIdentity
+    from app.models.auth_identity import AuthIdentity, AuthMigration
     from app.models.user import User
     from app.services.native_bootstrap import issue_bootstrap_code
 
@@ -61,11 +63,24 @@ async def _seed_user_and_code(session, *, device_binding_hash=None, mapped=True)
     await session.commit()
 
     if mapped:
+        identity_owner = user_id
+        if link_identity_to_other_user:
+            other_user_id = uuid.uuid4()
+            session.add(User(
+                id=other_user_id, email=f"authreb-s5-other-{other_user_id.hex[:8]}@test.com",
+                hashed_password=hash_password("x"), is_active=True, email_verified=True,
+            ))
+            await session.commit()
+            identity_owner = other_user_id
         session.add(AuthIdentity(
-            id=uuid.uuid4(), user_id=user_id,
+            id=uuid.uuid4(), user_id=identity_owner,
             issuer=f"https://securetoken.google.com/{PROJECT_ID}", subject=firebase_uid,
             provider_id="password",
         ))
+        await session.commit()
+
+    if migration_state is not None:
+        session.add(AuthMigration(user_id=user_id, state=migration_state))
         await session.commit()
 
     raw_code = await issue_bootstrap_code(
@@ -379,6 +394,78 @@ async def test_consume_time_reverify_rejects_identity_unlinked_after_issuance(mo
                 .values(unlinked_at=datetime.now(timezone.utc))
             )
             await s.commit()
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await consume_native_bootstrap(
+                    NativeBootstrapConsumeRequest(code=raw_code), authorization=None, db=s
+                )
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("ineligible_state", ["reset_required", "rollback_hold", "legacy", "provisioning_typo"])
+async def test_ineligible_migration_state_rejected(monkeypatch, ineligible_state):
+    """산티아고 #2202 3차 재검토 잔여 2(HIGH): reset_required 사용자가 bootstrap
+    custom-token으로 새 세션을 발급받으면 coordinated forced-reset 정책(doc §6.1)과
+    충돌한다 — provisioning/firebase 외 모든 상태는 거부."""
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+
+    _setup_common(monkeypatch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            raw_code, _user_id = await _seed_user_and_code(s, migration_state=ineligible_state)
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await consume_native_bootstrap(
+                    NativeBootstrapConsumeRequest(code=raw_code), authorization=None, db=s
+                )
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_missing_migration_row_rejected(monkeypatch):
+    """auth_migrations 행 자체가 없는(Phase 3 cohort 미편입) 사용자는 fail-closed로 거부
+    — 아직 아무도 migration state 행이 없는 현재(Phase 1) 시점의 안전한 기본값."""
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+
+    _setup_common(monkeypatch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            raw_code, _user_id = await _seed_user_and_code(s, migration_state=None)
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await consume_native_bootstrap(
+                    NativeBootstrapConsumeRequest(code=raw_code), authorization=None, db=s
+                )
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_identity_reassigned_to_different_user_rejected(monkeypatch):
+    """산티아고 #2202 3차 재검토 잔여 2: (issuer,subject)만 보고 unlinked 여부만 보면 그
+    사이 identity가 다른 user_id로 재연결된 레이스를 못 잡는다 — consumed.user_id와
+    정확히 같은 행인지까지 확인해야 한다."""
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+
+    _setup_common(monkeypatch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            raw_code, _user_id = await _seed_user_and_code(s, link_identity_to_other_user=True)
 
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:

--- a/backend/tests/test_e_auth_rebuild_phase1_s5_custom_token_chain.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s5_custom_token_chain.py
@@ -1,0 +1,144 @@
+"""story 4dee942b(E-AUTH-REBUILD M2 Phase1-S5) 계약 테스트: mint_custom_token()→
+exchange_custom_token_for_id_token()→mint_session_cookie_for_uid() 체인 구조 검증.
+
+⚠️mock-first(오르테가군 승인 2026-07-15, S4와 동일 패턴) — ADC 서명/Google REST 응답 형식은
+non-prod 프로젝트 준비 후 실 왕복으로 재확인 필요.
+"""
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+
+from app.services import firebase_session_mint as mint_mod
+
+FIREBASE_UID = "firebase-uid-native-1"
+PROJECT_ID = "test-project"
+WEB_API_KEY = "fake-web-api-key"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class _FakeServiceAccountCredentials:
+    service_account_email = "sa@test-project.iam.gserviceaccount.com"
+
+    def sign_bytes(self, data: bytes) -> bytes:
+        return b"fake-signature-bytes"
+
+
+def _fake_response(status_code: int, json_body: dict) -> httpx.Response:
+    return httpx.Response(status_code=status_code, json=json_body, request=httpx.Request("POST", "https://example.test"))
+
+
+@pytest.mark.anyio
+async def test_mint_custom_token_success_with_service_account_credentials(monkeypatch):
+    monkeypatch.setattr(mint_mod, "_get_signing_credentials", lambda: _FakeServiceAccountCredentials())
+    token = mint_mod.mint_custom_token(FIREBASE_UID)
+    assert token is not None
+    # 3-part JWT shape (header.payload.signature), 서명값 자체는 fake라 검증 안 함 — 구조만.
+    assert token.count(".") == 2
+
+
+@pytest.mark.anyio
+async def test_mint_custom_token_returns_none_when_adc_unavailable(monkeypatch):
+    def raise_error():
+        raise RuntimeError("no ADC")
+    monkeypatch.setattr(mint_mod, "_get_signing_credentials", raise_error)
+    assert mint_mod.mint_custom_token(FIREBASE_UID) is None
+
+
+@pytest.mark.anyio
+async def test_mint_custom_token_returns_none_for_user_credentials_without_signer(monkeypatch):
+    """gcloud auth application-default login(사용자 자격증명)엔 sign_bytes가 없다 — service
+    account만 custom token 서명 가능(로컬 개발 함정 명시 회귀 가드)."""
+    class _UserCredentials:
+        pass
+    monkeypatch.setattr(mint_mod, "_get_signing_credentials", lambda: _UserCredentials())
+    assert mint_mod.mint_custom_token(FIREBASE_UID) is None
+
+
+@pytest.mark.anyio
+async def test_exchange_custom_token_success(monkeypatch):
+    async def fake_call(custom_token, web_api_key):
+        assert web_api_key == WEB_API_KEY
+        return _fake_response(200, {"idToken": "exchanged-id-token-value"})
+    monkeypatch.setattr(mint_mod, "_call_sign_in_with_custom_token", fake_call)
+    result = await mint_mod.exchange_custom_token_for_id_token("fake-custom-token", WEB_API_KEY)
+    assert result == "exchanged-id-token-value"
+
+
+@pytest.mark.anyio
+async def test_exchange_custom_token_returns_none_without_web_api_key():
+    result = await mint_mod.exchange_custom_token_for_id_token("fake-custom-token", "")
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_exchange_custom_token_returns_none_on_rejection(monkeypatch):
+    async def fake_call(custom_token, web_api_key):
+        return _fake_response(400, {"error": {"message": "INVALID_CUSTOM_TOKEN"}})
+    monkeypatch.setattr(mint_mod, "_call_sign_in_with_custom_token", fake_call)
+    result = await mint_mod.exchange_custom_token_for_id_token("fake-custom-token", WEB_API_KEY)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_mint_session_cookie_for_uid_full_chain_success(monkeypatch):
+    monkeypatch.setattr(mint_mod, "_get_signing_credentials", lambda: _FakeServiceAccountCredentials())
+
+    async def fake_exchange_call(custom_token, web_api_key):
+        return _fake_response(200, {"idToken": "exchanged-id-token"})
+    monkeypatch.setattr(mint_mod, "_call_sign_in_with_custom_token", fake_exchange_call)
+
+    monkeypatch.setattr(mint_mod, "_get_access_token", lambda: "fake-access-token")
+
+    async def fake_session_call(access_token, id_token, project_id, valid_duration_seconds):
+        assert id_token == "exchanged-id-token"
+        return _fake_response(200, {"sessionCookie": "final-session-cookie"})
+    monkeypatch.setattr(mint_mod, "_call_create_session_cookie", fake_session_call)
+
+    result = await mint_mod.mint_session_cookie_for_uid(FIREBASE_UID, PROJECT_ID, WEB_API_KEY)
+    assert result == "final-session-cookie"
+
+
+@pytest.mark.anyio
+async def test_mint_session_cookie_for_uid_returns_none_when_custom_token_fails(monkeypatch):
+    def raise_error():
+        raise RuntimeError("no ADC")
+    monkeypatch.setattr(mint_mod, "_get_signing_credentials", raise_error)
+    result = await mint_mod.mint_session_cookie_for_uid(FIREBASE_UID, PROJECT_ID, WEB_API_KEY)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_mint_session_cookie_for_uid_returns_none_when_exchange_fails(monkeypatch):
+    monkeypatch.setattr(mint_mod, "_get_signing_credentials", lambda: _FakeServiceAccountCredentials())
+
+    async def fake_exchange_call(custom_token, web_api_key):
+        return _fake_response(400, {"error": {"message": "INVALID"}})
+    monkeypatch.setattr(mint_mod, "_call_sign_in_with_custom_token", fake_exchange_call)
+
+    result = await mint_mod.mint_session_cookie_for_uid(FIREBASE_UID, PROJECT_ID, WEB_API_KEY)
+    assert result is None
+
+
+@pytest.mark.anyio
+async def test_custom_token_and_exchange_never_appear_in_logs(monkeypatch, caplog):
+    monkeypatch.setattr(mint_mod, "_get_signing_credentials", lambda: _FakeServiceAccountCredentials())
+
+    async def fake_exchange_call(custom_token, web_api_key):
+        return _fake_response(200, {"idToken": "super-secret-id-token"})
+    monkeypatch.setattr(mint_mod, "_call_sign_in_with_custom_token", fake_exchange_call)
+
+    with caplog.at_level(logging.DEBUG):
+        custom_token = mint_mod.mint_custom_token(FIREBASE_UID)
+        id_token = await mint_mod.exchange_custom_token_for_id_token(custom_token, WEB_API_KEY)
+    assert id_token == "super-secret-id-token"
+
+    all_log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert custom_token not in all_log_text
+    assert "super-secret-id-token" not in all_log_text

--- a/backend/tests/test_e_auth_rebuild_phase1_s5_native_bootstrap_endpoint_realdb.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s5_native_bootstrap_endpoint_realdb.py
@@ -12,6 +12,7 @@ import uuid
 from pathlib import Path
 
 import pytest
+from fastapi import Response
 from jose import jwt as jose_jwt
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives import serialization
@@ -140,6 +141,7 @@ def _setup_common(monkeypatch, *, mobile_issue: bool = True, app_check_required:
     monkeypatch.setattr(settings, "firebase_project_id", PROJECT_ID)
     monkeypatch.setattr(settings, "firebase_project_number", PROJECT_NUMBER)
     monkeypatch.setattr(settings, "firebase_auth_mobile_app_check_required", app_check_required)
+    monkeypatch.setattr(settings, "firebase_app_check_allowed_app_ids", "1:123:android:abc")
 
 
 @pytest.mark.anyio
@@ -153,7 +155,7 @@ async def test_flag_off_returns_501(monkeypatch):
         async with Session() as s:
             from fastapi import HTTPException
             with pytest.raises(HTTPException) as exc_info:
-                await native_bootstrap(NativeBootstrapRequest(), authorization=None, db=s)
+                await native_bootstrap(request=None, body=NativeBootstrapRequest(), response=Response(), authorization=None, db=s)
             assert exc_info.value.status_code == 501
     finally:
         await engine.dispose()
@@ -170,7 +172,7 @@ async def test_missing_bearer_rejected(monkeypatch):
     try:
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
-                await native_bootstrap(NativeBootstrapRequest(), authorization=None, db=s)
+                await native_bootstrap(request=None, body=NativeBootstrapRequest(), response=Response(), authorization=None, db=s)
             assert exc_info.value.status_code == 401
     finally:
         await engine.dispose()
@@ -195,11 +197,14 @@ async def test_success_issues_code(monkeypatch):
 
         token = _make_id_token(key_pem, seeded["firebase_uid"])
         async with Session() as s:
+            response = Response()
             result = await native_bootstrap(
-                NativeBootstrapRequest(), authorization=f"Bearer {token}", db=s
+                request=None, body=NativeBootstrapRequest(), response=response,
+                authorization=f"Bearer {token}", db=s,
             )
         assert result.code
         assert result.expires_in == 45
+        assert response.headers["Cache-Control"] == "no-store"
     finally:
         await engine.dispose()
 
@@ -225,7 +230,7 @@ async def test_stale_auth_time_rejected(monkeypatch):
         stale_token = _make_id_token(key_pem, seeded["firebase_uid"], auth_time=int(time.time()) - 3600)
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
-                await native_bootstrap(NativeBootstrapRequest(), authorization=f"Bearer {stale_token}", db=s)
+                await native_bootstrap(request=None, body=NativeBootstrapRequest(), response=Response(), authorization=f"Bearer {stale_token}", db=s)
             assert exc_info.value.status_code == 401
     finally:
         await engine.dispose()
@@ -252,7 +257,7 @@ async def test_unmapped_identity_rejected(monkeypatch):
         token = _make_id_token(key_pem, seeded["firebase_uid"])
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
-                await native_bootstrap(NativeBootstrapRequest(), authorization=f"Bearer {token}", db=s)
+                await native_bootstrap(request=None, body=NativeBootstrapRequest(), response=Response(), authorization=f"Bearer {token}", db=s)
             assert exc_info.value.status_code == 401
     finally:
         await engine.dispose()
@@ -279,7 +284,7 @@ async def test_inactive_user_rejected(monkeypatch):
         token = _make_id_token(key_pem, seeded["firebase_uid"])
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
-                await native_bootstrap(NativeBootstrapRequest(), authorization=f"Bearer {token}", db=s)
+                await native_bootstrap(request=None, body=NativeBootstrapRequest(), response=Response(), authorization=f"Bearer {token}", db=s)
             assert exc_info.value.status_code == 401
     finally:
         await engine.dispose()
@@ -306,7 +311,7 @@ async def test_app_check_required_but_missing_rejected(monkeypatch):
         token = _make_id_token(key_pem, seeded["firebase_uid"])
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
-                await native_bootstrap(NativeBootstrapRequest(), authorization=f"Bearer {token}", db=s)
+                await native_bootstrap(request=None, body=NativeBootstrapRequest(), response=Response(), authorization=f"Bearer {token}", db=s)
             assert exc_info.value.status_code == 401
     finally:
         await engine.dispose()
@@ -340,7 +345,9 @@ async def test_app_check_required_and_valid_binds_device_hash(monkeypatch):
         app_check_token = _make_app_check_token(app_check_key_pem)
         async with Session() as s:
             result = await native_bootstrap(
-                NativeBootstrapRequest(app_check_token=app_check_token, device_install_hint="install-1"),
+                request=None,
+                body=NativeBootstrapRequest(app_check_token=app_check_token, device_install_hint="install-1"),
+                response=Response(),
                 authorization=f"Bearer {token}", db=s,
             )
         assert result.code

--- a/backend/tests/test_e_auth_rebuild_phase1_s5_native_bootstrap_endpoint_realdb.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s5_native_bootstrap_endpoint_realdb.py
@@ -1,0 +1,354 @@
+"""story 4dee942b(E-AUTH-REBUILD M2 Phase1-S5) 게이트: POST /api/v2/auth/native-bootstrap
+(공개 API, Firebase ID token Bearer 인증) — 플래그 게이팅·auth_time 최근성·identity 매핑·
+App Check 필수 정책이 doc §9.1/산티아고 §9 순서대로 실 DB로 동작하는지 실증.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+from jose import jwt as jose_jwt
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+from jose.utils import long_to_base64
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+PROJECT_ID = "test-project"
+PROJECT_NUMBER = "1234567890"
+KID = "test-kid-1"
+APP_CHECK_KID = "app-check-kid-1"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _reset_caches_and_dispose():
+    from app.services import firebase_verifier as fv
+    fv._reset_key_cache_for_tests()
+    fv._reset_id_token_key_cache_for_tests()
+    fv._reset_app_check_key_cache_for_tests()
+    yield
+    fv._reset_key_cache_for_tests()
+    fv._reset_id_token_key_cache_for_tests()
+    fv._reset_app_check_key_cache_for_tests()
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _make_self_signed_cert() -> tuple[str, str]:
+    with tempfile.TemporaryDirectory() as d:
+        key_path = Path(d) / "key.pem"
+        cert_path = Path(d) / "cert.pem"
+        subprocess.run(
+            ["openssl", "req", "-x509", "-newkey", "rsa:2048", "-keyout", str(key_path),
+             "-out", str(cert_path), "-days", "1", "-nodes", "-subj", "/CN=test"],
+            check=True, capture_output=True,
+        )
+        return key_path.read_text(), cert_path.read_text()
+
+
+def _make_id_token(key_pem: str, sub: str, *, auth_time: int | None = None, exp_delta: int = 3600) -> str:
+    now = int(time.time())
+    claims = {
+        "sub": sub, "email": "user@test.com",
+        "auth_time": auth_time if auth_time is not None else now,
+        "iat": now, "exp": now + exp_delta,
+        "iss": f"https://securetoken.google.com/{PROJECT_ID}", "aud": PROJECT_ID,
+    }
+    return jose_jwt.encode(claims, key_pem, algorithm="RS256", headers={"kid": KID})
+
+
+def _make_rsa_keypair_jwk(kid: str) -> tuple[str, dict]:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    numbers = key.public_key().public_numbers()
+    jwk = {
+        "kty": "RSA", "kid": kid, "use": "sig", "alg": "RS256",
+        "n": long_to_base64(numbers.n).decode(), "e": long_to_base64(numbers.e).decode(),
+    }
+    return pem, jwk
+
+
+def _make_app_check_token(key_pem: str, *, kid: str = APP_CHECK_KID, app_id: str = "1:123:android:abc") -> str:
+    now = int(time.time())
+    claims = {
+        "sub": app_id, "iat": now, "exp": now + 3600,
+        "iss": f"https://firebaseappcheck.googleapis.com/{PROJECT_NUMBER}",
+        "aud": [f"projects/{PROJECT_NUMBER}"],
+    }
+    return jose_jwt.encode(claims, key_pem, algorithm="RS256", headers={"kid": kid})
+
+
+async def _seed(session, *, user_active: bool = True, mapped: bool = True):
+    from app.core.security import hash_password
+    from app.models.auth_identity import AuthIdentity
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    session.add(User(
+        id=user_id, email=f"authreb-s5-endpoint-{user_id.hex[:8]}@test.com",
+        hashed_password=hash_password("x"), is_active=user_active, email_verified=True,
+    ))
+    await session.commit()
+
+    firebase_uid = f"fb-uid-{uuid.uuid4().hex[:8]}"
+    if mapped:
+        issuer = f"https://securetoken.google.com/{PROJECT_ID}"
+        session.add(AuthIdentity(
+            id=uuid.uuid4(), user_id=user_id, issuer=issuer, subject=firebase_uid,
+            provider_id="password",
+        ))
+        await session.commit()
+
+    return {"user_id": user_id, "firebase_uid": firebase_uid}
+
+
+def _setup_common(monkeypatch, *, mobile_issue: bool = True, app_check_required: bool = False):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "firebase_auth_mobile_issue", mobile_issue)
+    monkeypatch.setattr(settings, "firebase_project_id", PROJECT_ID)
+    monkeypatch.setattr(settings, "firebase_project_number", PROJECT_NUMBER)
+    monkeypatch.setattr(settings, "firebase_auth_mobile_app_check_required", app_check_required)
+
+
+@pytest.mark.anyio
+async def test_flag_off_returns_501(monkeypatch):
+    from app.routers.auth_native_bootstrap import NativeBootstrapRequest, native_bootstrap
+
+    _setup_common(monkeypatch, mobile_issue=False)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            from fastapi import HTTPException
+            with pytest.raises(HTTPException) as exc_info:
+                await native_bootstrap(NativeBootstrapRequest(), authorization=None, db=s)
+            assert exc_info.value.status_code == 501
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_missing_bearer_rejected(monkeypatch):
+    from app.routers.auth_native_bootstrap import NativeBootstrapRequest, native_bootstrap
+    from fastapi import HTTPException
+
+    _setup_common(monkeypatch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await native_bootstrap(NativeBootstrapRequest(), authorization=None, db=s)
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_success_issues_code(monkeypatch):
+    from app.routers.auth_native_bootstrap import NativeBootstrapRequest, native_bootstrap
+    from app.services import firebase_verifier as fv
+
+    _setup_common(monkeypatch)
+    key_pem, cert_pem = _make_self_signed_cert()
+
+    async def fake_id_fetch():
+        return {KID: cert_pem}
+    monkeypatch.setattr(fv, "_fetch_id_token_public_keys", fake_id_fetch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        token = _make_id_token(key_pem, seeded["firebase_uid"])
+        async with Session() as s:
+            result = await native_bootstrap(
+                NativeBootstrapRequest(), authorization=f"Bearer {token}", db=s
+            )
+        assert result.code
+        assert result.expires_in == 45
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_stale_auth_time_rejected(monkeypatch):
+    from app.routers.auth_native_bootstrap import NativeBootstrapRequest, native_bootstrap
+    from app.services import firebase_verifier as fv
+    from fastapi import HTTPException
+
+    _setup_common(monkeypatch)
+    key_pem, cert_pem = _make_self_signed_cert()
+
+    async def fake_id_fetch():
+        return {KID: cert_pem}
+    monkeypatch.setattr(fv, "_fetch_id_token_public_keys", fake_id_fetch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        stale_token = _make_id_token(key_pem, seeded["firebase_uid"], auth_time=int(time.time()) - 3600)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await native_bootstrap(NativeBootstrapRequest(), authorization=f"Bearer {stale_token}", db=s)
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_unmapped_identity_rejected(monkeypatch):
+    from app.routers.auth_native_bootstrap import NativeBootstrapRequest, native_bootstrap
+    from app.services import firebase_verifier as fv
+    from fastapi import HTTPException
+
+    _setup_common(monkeypatch)
+    key_pem, cert_pem = _make_self_signed_cert()
+
+    async def fake_id_fetch():
+        return {KID: cert_pem}
+    monkeypatch.setattr(fv, "_fetch_id_token_public_keys", fake_id_fetch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, mapped=False)
+
+        token = _make_id_token(key_pem, seeded["firebase_uid"])
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await native_bootstrap(NativeBootstrapRequest(), authorization=f"Bearer {token}", db=s)
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_inactive_user_rejected(monkeypatch):
+    from app.routers.auth_native_bootstrap import NativeBootstrapRequest, native_bootstrap
+    from app.services import firebase_verifier as fv
+    from fastapi import HTTPException
+
+    _setup_common(monkeypatch)
+    key_pem, cert_pem = _make_self_signed_cert()
+
+    async def fake_id_fetch():
+        return {KID: cert_pem}
+    monkeypatch.setattr(fv, "_fetch_id_token_public_keys", fake_id_fetch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s, user_active=False)
+
+        token = _make_id_token(key_pem, seeded["firebase_uid"])
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await native_bootstrap(NativeBootstrapRequest(), authorization=f"Bearer {token}", db=s)
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_app_check_required_but_missing_rejected(monkeypatch):
+    from app.routers.auth_native_bootstrap import NativeBootstrapRequest, native_bootstrap
+    from app.services import firebase_verifier as fv
+    from fastapi import HTTPException
+
+    _setup_common(monkeypatch, app_check_required=True)
+    key_pem, cert_pem = _make_self_signed_cert()
+
+    async def fake_id_fetch():
+        return {KID: cert_pem}
+    monkeypatch.setattr(fv, "_fetch_id_token_public_keys", fake_id_fetch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        token = _make_id_token(key_pem, seeded["firebase_uid"])
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await native_bootstrap(NativeBootstrapRequest(), authorization=f"Bearer {token}", db=s)
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_app_check_required_and_valid_binds_device_hash(monkeypatch):
+    from app.routers.auth_native_bootstrap import NativeBootstrapRequest, native_bootstrap
+    from app.services import firebase_verifier as fv
+    from app.models.auth_native_bootstrap import AuthNativeBootstrapCode
+    from sqlalchemy import select
+
+    _setup_common(monkeypatch, app_check_required=True)
+    key_pem, cert_pem = _make_self_signed_cert()
+    app_check_key_pem, app_check_jwk = _make_rsa_keypair_jwk(APP_CHECK_KID)
+
+    async def fake_id_fetch():
+        return {KID: cert_pem}
+    monkeypatch.setattr(fv, "_fetch_id_token_public_keys", fake_id_fetch)
+
+    async def fake_app_check_fetch():
+        return {APP_CHECK_KID: app_check_jwk}
+    monkeypatch.setattr(fv, "_fetch_app_check_jwks", fake_app_check_fetch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        token = _make_id_token(key_pem, seeded["firebase_uid"])
+        app_check_token = _make_app_check_token(app_check_key_pem)
+        async with Session() as s:
+            result = await native_bootstrap(
+                NativeBootstrapRequest(app_check_token=app_check_token, device_install_hint="install-1"),
+                authorization=f"Bearer {token}", db=s,
+            )
+        assert result.code
+
+        async with Session() as s:
+            row = (await s.execute(
+                select(AuthNativeBootstrapCode).where(AuthNativeBootstrapCode.user_id == seeded["user_id"])
+            )).scalar_one()
+            assert row.device_binding_hash is not None
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_e_auth_rebuild_phase1_s5_native_bootstrap_service_realdb.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s5_native_bootstrap_service_realdb.py
@@ -1,0 +1,225 @@
+"""story 4dee942b(E-AUTH-REBUILD M2 Phase1-S5) 게이트: issue_bootstrap_code/consume_bootstrap_code
+원자성 실증. 산티아고 §9 필수 테스트 중 BE 서비스 레이어 항목 — expired/replayed 거부·병렬
+exactly-one·cross-project/device 거부·code_hash만 저장(원문 미저장) 실DB 확인.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+PROJECT_ID = "test-project"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_user(session):
+    from app.core.security import hash_password
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    session.add(User(
+        id=user_id, email=f"authreb-s5-{user_id.hex[:8]}@test.com",
+        hashed_password=hash_password("x"), is_active=True, email_verified=True,
+    ))
+    await session.commit()
+    return user_id
+
+
+@pytest.mark.anyio
+async def test_issued_code_stores_only_hash_not_plaintext():
+    from sqlalchemy import select
+    from app.models.auth_native_bootstrap import AuthNativeBootstrapCode
+    from app.services.native_bootstrap import issue_bootstrap_code
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_user(s)
+            raw_code = await issue_bootstrap_code(
+                s, user_id=user_id, firebase_uid="fb-uid-1", project_id=PROJECT_ID,
+            )
+
+        async with Session() as s:
+            row = (await s.execute(
+                select(AuthNativeBootstrapCode).where(AuthNativeBootstrapCode.user_id == user_id)
+            )).scalar_one()
+            assert row.code_hash != raw_code
+            # code_hash 컬럼 어디에도 raw_code 문자열이 부분 문자열로도 안 남는지.
+            assert raw_code not in row.code_hash
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_consume_succeeds_exactly_once_then_replay_fails():
+    from app.services.native_bootstrap import consume_bootstrap_code, issue_bootstrap_code
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_user(s)
+            raw_code = await issue_bootstrap_code(
+                s, user_id=user_id, firebase_uid="fb-uid-1", project_id=PROJECT_ID,
+            )
+
+        async with Session() as s:
+            first = await consume_bootstrap_code(s, code=raw_code, project_id=PROJECT_ID)
+        assert first is not None
+        assert first.firebase_uid == "fb-uid-1"
+
+        async with Session() as s:
+            replay = await consume_bootstrap_code(s, code=raw_code, project_id=PROJECT_ID)
+        assert replay is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_concurrent_consume_exactly_one_wins():
+    """산티아고 §9: 동시 2요청 중 정확히 1건만 성공 — TOCTOU 없는 단일 원자적 UPDATE 실증."""
+    from app.services.native_bootstrap import consume_bootstrap_code, issue_bootstrap_code
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_user(s)
+            raw_code = await issue_bootstrap_code(
+                s, user_id=user_id, firebase_uid="fb-uid-concurrent", project_id=PROJECT_ID,
+            )
+
+        async def _attempt():
+            async with Session() as s:
+                return await consume_bootstrap_code(s, code=raw_code, project_id=PROJECT_ID)
+
+        results = await asyncio.gather(_attempt(), _attempt())
+        successes = [r for r in results if r is not None]
+        assert len(successes) == 1
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_expired_code_rejected():
+    from sqlalchemy import update
+    from app.models.auth_native_bootstrap import AuthNativeBootstrapCode
+    from app.services.native_bootstrap import consume_bootstrap_code, issue_bootstrap_code
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_user(s)
+            raw_code = await issue_bootstrap_code(
+                s, user_id=user_id, firebase_uid="fb-uid-expired", project_id=PROJECT_ID, ttl_seconds=45,
+            )
+            # 이미 만료된 것처럼 강제 조작(TTL 45초를 실제로 기다리지 않기 위함).
+            await s.execute(
+                update(AuthNativeBootstrapCode)
+                .where(AuthNativeBootstrapCode.user_id == user_id)
+                .values(expires_at=datetime.now(timezone.utc) - timedelta(seconds=1))
+            )
+            await s.commit()
+
+        async with Session() as s:
+            result = await consume_bootstrap_code(s, code=raw_code, project_id=PROJECT_ID)
+        assert result is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_wrong_project_id_rejected():
+    from app.services.native_bootstrap import consume_bootstrap_code, issue_bootstrap_code
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_user(s)
+            raw_code = await issue_bootstrap_code(
+                s, user_id=user_id, firebase_uid="fb-uid-wrongproj", project_id=PROJECT_ID,
+            )
+
+        async with Session() as s:
+            result = await consume_bootstrap_code(s, code=raw_code, project_id="different-project")
+        assert result is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_device_binding_hash_mismatch_rejected_when_required():
+    from app.services.native_bootstrap import consume_bootstrap_code, issue_bootstrap_code
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_user(s)
+            raw_code = await issue_bootstrap_code(
+                s, user_id=user_id, firebase_uid="fb-uid-device", project_id=PROJECT_ID,
+                device_binding_hash="correct-device-hash",
+            )
+
+        async with Session() as s:
+            wrong = await consume_bootstrap_code(
+                s, code=raw_code, project_id=PROJECT_ID, device_binding_hash="wrong-device-hash"
+            )
+        assert wrong is None
+
+        async with Session() as s:
+            missing = await consume_bootstrap_code(s, code=raw_code, project_id=PROJECT_ID, device_binding_hash=None)
+        assert missing is None
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_device_binding_not_required_when_issued_without_it():
+    from app.services.native_bootstrap import consume_bootstrap_code, issue_bootstrap_code
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_user(s)
+            raw_code = await issue_bootstrap_code(
+                s, user_id=user_id, firebase_uid="fb-uid-nodevice", project_id=PROJECT_ID,
+                device_binding_hash=None,
+            )
+
+        async with Session() as s:
+            result = await consume_bootstrap_code(s, code=raw_code, project_id=PROJECT_ID, device_binding_hash=None)
+        assert result is not None
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_e_auth_rebuild_phase1_s5_startup_guards.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s5_startup_guards.py
@@ -11,6 +11,7 @@ def _s(**overrides):
     base = {
         "app_env": "development",
         "firebase_bff_internal_secret": "",
+        "firebase_auth_issue_session": False,
         "firebase_auth_mobile_issue": False,
         "firebase_auth_mobile_app_check_required": False,
     }
@@ -28,17 +29,53 @@ def test_internal_secret_config_ok_when_prod_and_set():
     check_internal_secret_config(_s(app_env="production", firebase_bff_internal_secret="real-secret"))
 
 
-def test_internal_secret_config_raises_when_prod_and_empty():
-    """산티아고 §9 finding 4 — 직접 probe로 확인된 misconfig를 startup에서 차단."""
+def test_internal_secret_config_raises_when_prod_and_empty_and_feature_on():
+    """산티아고 §9 finding 4 — 직접 probe로 확인된 misconfig를 startup에서 차단
+    (Firebase 세션 발급 기능이 켜져 있을 때에 한해)."""
     from app.routers.auth_firebase_internal import check_internal_secret_config
     with pytest.raises(RuntimeError, match="FIREBASE_BFF_INTERNAL_SECRET"):
-        check_internal_secret_config(_s(app_env="production", firebase_bff_internal_secret=""))
+        check_internal_secret_config(_s(
+            app_env="production", firebase_bff_internal_secret="", firebase_auth_issue_session=True,
+        ))
 
 
-def test_internal_secret_config_raises_when_staging_and_empty():
+def test_internal_secret_config_raises_when_staging_and_empty_and_feature_on():
     from app.routers.auth_firebase_internal import check_internal_secret_config
     with pytest.raises(RuntimeError):
-        check_internal_secret_config(_s(app_env="staging", firebase_bff_internal_secret=""))
+        check_internal_secret_config(_s(
+            app_env="staging", firebase_bff_internal_secret="", firebase_auth_mobile_issue=True,
+        ))
+
+
+def test_internal_secret_config_ok_when_prod_and_empty_but_all_firebase_features_off():
+    """산티아고 #2202 재검토(2026-07-15) 배포 회귀 회귀가드 — 최초 구현은 Firebase 기능
+    플래그와 무관하게 non-local이면 무조건 시크릿을 요구해서, Firebase 전부 default-off인
+    현재 상태로 배포해도(deploy_backend.sh가 아직 시크릿을 배선 안 함) backend 전체가
+    startup에서 죽는 회귀였다(직접 probe: prod_features_off_missing_secret_startup_
+    allowed=False). 실제로 쓰는 기능이 꺼져 있으면 시크릿 미설정이어도 통과해야 한다."""
+    from app.routers.auth_firebase_internal import check_internal_secret_config
+    check_internal_secret_config(_s(
+        app_env="production", firebase_bff_internal_secret="",
+        firebase_auth_issue_session=False, firebase_auth_mobile_issue=False,
+    ))
+
+
+def test_internal_secret_config_raises_when_prod_and_empty_and_issue_session_on():
+    from app.routers.auth_firebase_internal import check_internal_secret_config
+    with pytest.raises(RuntimeError):
+        check_internal_secret_config(_s(
+            app_env="production", firebase_bff_internal_secret="",
+            firebase_auth_issue_session=True, firebase_auth_mobile_issue=False,
+        ))
+
+
+def test_internal_secret_config_raises_when_prod_and_empty_and_mobile_issue_on():
+    from app.routers.auth_firebase_internal import check_internal_secret_config
+    with pytest.raises(RuntimeError):
+        check_internal_secret_config(_s(
+            app_env="production", firebase_bff_internal_secret="",
+            firebase_auth_issue_session=False, firebase_auth_mobile_issue=True,
+        ))
 
 
 def test_mobile_app_check_config_ok_when_mobile_issue_off():

--- a/backend/tests/test_e_auth_rebuild_phase1_s5_startup_guards.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s5_startup_guards.py
@@ -1,0 +1,61 @@
+"""story 4dee942b(E-AUTH-REBUILD M2 Phase1-S5) 산티아고 §9 검토(2026-07-15) 반영: startup
+fail-closed 가드 2건 — check_listen_config()(ee7794eb ③)와 동일 패턴."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _s(**overrides):
+    base = {
+        "app_env": "development",
+        "firebase_bff_internal_secret": "",
+        "firebase_auth_mobile_issue": False,
+        "firebase_auth_mobile_app_check_required": False,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_internal_secret_config_ok_when_local_and_empty():
+    from app.routers.auth_firebase_internal import check_internal_secret_config
+    check_internal_secret_config(_s(app_env="development", firebase_bff_internal_secret=""))
+
+
+def test_internal_secret_config_ok_when_prod_and_set():
+    from app.routers.auth_firebase_internal import check_internal_secret_config
+    check_internal_secret_config(_s(app_env="production", firebase_bff_internal_secret="real-secret"))
+
+
+def test_internal_secret_config_raises_when_prod_and_empty():
+    """산티아고 §9 finding 4 — 직접 probe로 확인된 misconfig를 startup에서 차단."""
+    from app.routers.auth_firebase_internal import check_internal_secret_config
+    with pytest.raises(RuntimeError, match="FIREBASE_BFF_INTERNAL_SECRET"):
+        check_internal_secret_config(_s(app_env="production", firebase_bff_internal_secret=""))
+
+
+def test_internal_secret_config_raises_when_staging_and_empty():
+    from app.routers.auth_firebase_internal import check_internal_secret_config
+    with pytest.raises(RuntimeError):
+        check_internal_secret_config(_s(app_env="staging", firebase_bff_internal_secret=""))
+
+
+def test_mobile_app_check_config_ok_when_mobile_issue_off():
+    from app.services.firebase_verifier import check_mobile_app_check_config
+    check_mobile_app_check_config(_s(firebase_auth_mobile_issue=False, firebase_auth_mobile_app_check_required=False))
+
+
+def test_mobile_app_check_config_ok_when_both_on():
+    from app.services.firebase_verifier import check_mobile_app_check_config
+    check_mobile_app_check_config(_s(firebase_auth_mobile_issue=True, firebase_auth_mobile_app_check_required=True))
+
+
+def test_mobile_app_check_config_raises_when_mobile_issue_on_without_app_check():
+    """산티아고 §9 finding 1 — device binding 없는 네이티브 부트스트랩 발급이 prod에
+    살아나가는 misconfig를 startup에서 차단."""
+    from app.services.firebase_verifier import check_mobile_app_check_config
+    with pytest.raises(RuntimeError, match="FIREBASE_AUTH_MOBILE_APP_CHECK_REQUIRED"):
+        check_mobile_app_check_config(
+            _s(firebase_auth_mobile_issue=True, firebase_auth_mobile_app_check_required=False)
+        )


### PR DESCRIPTION
## Summary
story 4dee942b — E-AUTH-REBUILD M2 Phase1-S5. doc `firebase-auth-identity-platform-migration-poc-2026-07-15` §9.1 구현. S4(#2199)의 세션쿠키 발급 인프라를 재사용(오르테가군 판정) — Phase 1 세션쿠키 인프라의 모바일 변형.

- **`POST /api/v2/auth/native-bootstrap`**(공개 API, Firebase ID token exact Bearer 인증 — 쿠키 인증 아님): ID token 검증(S4 재사용)+`auth_time<=5분`+`auth_identities` 매핑→256bit CSPRNG 단회코드 발급(`secrets.token_urlsafe(32)`). DB엔 SHA-256 hash만 저장(원문 미저장, 실DB로 증명). TTL 기본 45초(산티아고 §9: 30~60초). `project_id` 바인딩. `firebase_auth_mobile_issue` 플래그 게이트.
- **`app/services/native_bootstrap.py`(신규)**: 원자적 발급/소비. `consume_bootstrap_code()`는 단일 `UPDATE...WHERE code_hash=? AND consumed_at IS NULL AND expires_at>now() AND project_id=? RETURNING` — TOCTOU 없음. `asyncio.gather` 동시 2요청 중 정확히 1건만 성공함을 실DB로 증명.
- **`POST /api/v2/internal/auth/native-bootstrap/consume`**(서비스-투-서비스, S4와 동일 공유시크릿 패턴): atomic consume→세션쿠키 mint.
  ⚠️**아키텍처 통찰**: 원본 Firebase ID token은 발급 순간 이후로 존재하지 않는다(저장 시 사실상 라이브 세션 자격증명을 DB에 두는 것과 같은 리스크라 의도적으로 미보존). 대신 `firebase_uid`로 custom token을 로컬 서명(service-account ADC 개인키, 네트워크 호출 없음)→`signInWithCustomToken`으로 실 ID token 교환→기존 `mint_session_cookie()` 그대로 재사용.
- **`verify_app_check_token()`**(`firebase_verifier.py`): 표준 JWKS RS256 검증, 실제로 동작.
  ⚠️**정직한 스코프 표기**: App Check 토큰은 "요청이 진짜 앱에서 왔다"만 증명하고 설치별(per-installation) 고유 challenge가 없다(`sub`=App ID, 앱 전체 공통). 산티아고가 요구한 완전한 "설치별 key/challenge" device binding은 모바일 클라이언트의 별도 challenge-response 메커니즘이 필요한 별개 스코프(향후 모바일 스토리) — 과대 주장하지 않음. 이 스토리는 App Check 앱 무결성 증명 + 클라이언트 제공 install hint 조합까지만.

## 계약 테스트 (39종, 최초 구현)
App Check 검증기 7 + custom token 체인 10 + native-bootstrap 서비스 realdb 7(원자적 동시성 포함) + 발급 엔드포인트 realdb 8 + consume 엔드포인트 realdb 7.

## 뮤테이션 자체검증 (최초 구현, 2건)
- `consumed_at IS NULL` 가드 비활성화 → replay/동시성 의존 3건만 정확히 RED
- App Check 필수 게이트 비활성화 → 해당 1건만 정확히 RED

---

## ⚠️업데이트: 산티아고 §9 보안검토 HIGH finding 5건 반영

까심 원자성/계약 QA가 GREEN을 준 뒤, 산티아고가 §9 보안 경계를 별도로 검토(conv `c2d01c88-33f8-42fc-beef-b3c775eb557b`, PO가 4조각으로 포워딩)해 **직접 probe로 6개 HIGH finding을 적출**했다:

```
wrong_audience_unapproved_app_accepted=True
accepted_app_id=1:123:web:unapproved-app
app_env=production, firebase_bff_internal_secret=(미설정)
→ prod_missing_internal_secret_allowed=True
```

CI의 원자성 테스트(atomic consume, exactly-one)와 보안 경계 검토(누가 발급/소비할 수 있는가)는 서로 다른 관심사임이 실증됨 — 원자성이 완벽해도 인증 경계에 구멍이 있으면 소용없다는 교훈.

### 즉시반영(PO 우선순위 판정, 5건)

1. **finding 1[App Check exactness]**: `options={"verify_aud": False}` 제거+`audience=f"projects/{project_number}"` 강제, `sub`(app ID)를 신규 `firebase_app_check_allowed_app_ids` allowlist와 비교. mobile 발급 on인데 App Check 필수 off면 startup fail-closed(`check_mobile_app_check_config()`).
2. **finding 4[internal secret prod fail-open]**: non-local(`app_env != development`) 환경에서 시크릿 미설정 시 503 fail-closed로 전환(기존은 환경 무관 허용). 동일 misconfig를 startup에서도 차단(`check_internal_secret_config()`).
3. **finding 6[consume-time 재검증 없음]**: atomic consume 성공 직후 곧장 mint하지 않고 `user.is_active`+`identity.unlinked_at`을 다시 조회(발급~소비 최대 45초 사이 상태 변화 대응).
4. **finding 3[login-CSRF] 최소분**: `NativeBootstrapConsumeRequest.existing_session_user_id` 신설 — BFF가 기존 유효 `__Host-sp_fs` 세션을 갖고 있으면 그 검증된 user_id를 넘기고, consumed code 소유자와 다르면 무조건 거부(조용한 account-switch 금지).
5. **잔여 하드닝**: native-bootstrap 발급에 rate limit(`@limiter.limit("10/minute")`)+`Cache-Control: no-store`.

### 명시 deferred(PO 우선순위 판정 — 이 PR 스코프 밖)

- **finding 2 + finding 3의 ①②③(완전한 per-installation device attestation)**: App Check 토큰만으론 설치별 고유 identifier가 없다(`sub`=App ID, 앱 전체 공통). 모바일 클라이언트가 별도 challenge-response 메커니즘을 구현해야 하는 큰 설계 — **산티아고와 후속 우선순위 조율 필요**.
- **finding 5(Next.js BFF `/auth/native` route)**: FE lane 별도 스토리(end-to-end 시). query-vs-body 로그 노출 질문도 그때 확인.

### 뮤테이션 자체검증(추가 5건, 전부 정확히 목표 테스트만 RED)

- App Check app-ID allowlist 무력화 → `test_rejects_unapproved_app_id`만 RED
- App Check audience 검증 무력화 → `test_rejects_wrong_audience`만 RED
- internal secret non-local fail-closed 무력화 → `test_prod_missing_internal_secret_fail_closed_503`만 RED
- consume-time user-active 재검증 무력화 → `test_consume_time_reverify_rejects_user_disabled_after_issuance`만 RED
- login-CSRF existing_session_user_id 비교 무력화 → `test_existing_session_different_user_rejected`만 RED

### 신규 테스트 22종 + 회귀

App Check 2 + consume endpoint 6 + startup guard 8 + 기존 파일 시그니처 갱신(App Check allowlist 파라미터·request/response 주입). 전체 회귀: `pytest -m "not destructive_schema"` → **4128 passed**(기존 무관 7건 그대로, 신규 회귀 0 — fresh DB로 재확인).

## 이 PR 스코프 밖 (FE lane 또는 후속 스토리)
- Next.js `/auth/native?code=` HTTP 라우트 자체(FE lane, 미르코/민) — 코드는 이미 JSON POST 바디로 내부 API에 전달하는 구조라 URL 쿼리 유출 리스크와 무관
- 산티아고 미해결 질문(query code가 Cloud Run/Cloudflare access log에 남는지) — FE 라우트가 code를 실제로 어떻게 받을지(쿼리 vs POST 바디) 결정 시 확인 필요
- 303 clean URL redirect + `Cache-Control:no-store` + `Referrer-Policy:no-referrer`(FE 응답 헤더)
- 3-way logout cleanup(native/WebView/server) — 기존 로직+FE lane
- 완전한 per-installation device challenge-response(finding 2/3 — 향후 모바일 스토리, 산티아고와 우선순위 조율)

---

## ⚠️업데이트 2: 산티아고 3차 재검토 — 배포 회귀 즉시수정 + consume-time 안전성 2건

산티아고가 2차 수정을 재검토하다가 **2차 수정 자체가 만든 새 HIGH 배포 회귀**를 직접 probe로 적출했다.

### (a) 배포 회귀 — 자체 도입 버그, 즉시수정

2차 수정의 internal-secret fail-closed 가드가 **Firebase 기능 플래그와 무관하게** non-local 환경이면 무조건 시크릿을 요구했다. Firebase가 전부 default-off인 지금 상태 그대로 prod에 배포해도(`deploy_backend.sh`가 아직 `FIREBASE_BFF_INTERNAL_SECRET`을 SECRETS_SPEC에 배선하지 않음) **backend 전체가 startup에서 죽는** 회귀였다.

```
prod_features_off_missing_secret_startup_allowed=False   # 막힘(회귀 확인)
```

`firebase_auth_issue_session` 또는 `firebase_auth_mobile_issue` 중 하나라도 실제로 켜져 있을 때만 시크릿을 요구하도록 수정 — 지금은 둘 다 off이므로 시크릿 없이도 정상 배포된다.

### (b) consume-time 안전성 2건(산티아고 잔여 2, 반영 권장 → 반영함)

- **`AuthMigration.state` 검증 없음(HIGH)**: `reset_required`/`rollback_hold` 사용자가 bootstrap custom-token으로 새 세션을 발급받으면 coordinated forced-reset 정책(doc §6.1)과 정면 충돌한다. `provisioning`/`firebase` 상태가 아니면(행이 아예 없어도 — 아직 아무도 Phase 3 cohort 미편입) fail-closed 거부.
- **identity revalidation에 `user_id` 바인딩 누락**: (issuer, subject, unlinked_at IS NULL)만 보면 그 사이 같은 firebase_uid가 **다른 user_id로 재연결**된 레이스를 못 잡는다 — `AuthIdentity.user_id == consumed.user_id`까지 확인하도록 강화.

### 뮤테이션 자체검증(추가 3건, 전부 정확히 목표만 RED)

- 배포회귀 fix(feature-gate) 무력화 → all-off+시크릿미설정 통과 테스트만 RED
- migration state 검증 무력화 → ineligible 4종+missing-row 5건만 RED(401 기대에 502로 fall-through)
- identity user_id 바인딩 무력화 → reassigned-identity 테스트만 RED(마찬가지로 502)

### 회귀

`pytest -m "not destructive_schema"` → **4137 passed**(기존 무관 7건 그대로, 신규 회귀 0 — fresh DB 3회 재확인 끝에 확定).

PO 판정: **잔여1(배포회귀)+잔여2(consume 검증) 반영으로 #2202 종결**. 잔여3(완전 per-installation attestation)·잔여4(logged-out login-CSRF)·잔여5(BFF route E2E+distributed rate limit+expired-row cleanup)는 별도 스토리로 이관 — PO가 M2 활성화 게이트 스토리도 별도 등재해 `FIREBASE_AUTH_MOBILE_ISSUE` 활성화를 그 완료 전까지 기술적으로 차단.

## Test plan
- [x] 최초 구현 39개 + 보안수정(2차) 22개 + 보안수정(3차) 신규/갱신 다수 = 총 63개+ 신규 테스트 전부 통과
- [x] 전체 회귀 통과, 신규 실패 0(fresh DB로 재확인 x3)
- [x] 뮤테이션 자체검증 10건(최초 2 + 2차 5 + 3차 3) 정확히 예상 범위만 RED
- [x] 산티아고 §9 HIGH finding 1/3(partial)/4/6 반영 + 3차 재검토 배포회귀 즉시수정
- [ ] 까심 재QA
- [ ] 산티아고 3차 재검토 확인(startup guard probe) → 머지
🤖 Generated with [Claude Code](https://claude.com/claude-code)

