### PR TITLE
[SID:64b9a879] 조직 브리핑 first-touch 우아함 심화

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -284,6 +284,8 @@
   "orgBriefing": {
     "title": "Org Briefing",
     "subtitle": "What's come to you, what we're learning, and who's on what — at a glance.",
+    "greeting": "Hi {name}, here's your org today",
+    "nowHeroBadge": "Now",
     "nowTitle": "Requests",
     "nowNote": "{count} to review",
     "nowFoot": "Everything else lives below in Lab and Workforce — only decisions surface here",
@@ -322,14 +324,15 @@
     "loopPhraseUnderway": "Underway",
     "loopPhraseAlmostThere": "Almost there",
     "loopPhraseWrappingUp": "Wrapping up",
-    "loopEmpty": "No hypotheses under test right now",
+    "loopEmpty": "Set a hypothesis and the whole path to verifying it shows up here",
+    "loopEmptyCta": "Start your first hypothesis",
     "workforceTitle": "Workforce",
     "workforceSubject": "Who's on what",
     "workforceTrustVerified": "Human verified",
     "workforceTrustClaimed": "Agent-reported · awaiting review",
     "workforceTogether": "Working together",
     "workforceUnassigned": "Not yet assigned",
-    "workforceEmpty": "No active work right now"
+    "workforceEmpty": "Work that people and AI take on together shows up here"
   },
   "organization": {
     "rolesTitle": "Permissions",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -284,6 +284,8 @@
   "orgBriefing": {
     "title": "조직 브리핑",
     "subtitle": "내게 온 요청, 우리가 배우는 것, 누가 무엇을 맡고 있는지 — 한눈에.",
+    "greeting": "{name}님, 오늘 조직의 지금이에요",
+    "nowHeroBadge": "지금",
     "nowTitle": "받은 요청",
     "nowNote": "확인할 {count}건",
     "nowFoot": "나머지 진행 상황은 아래 실험실·워크포스에 있습니다 · 결정이 필요한 일만 여기 모입니다",
@@ -322,14 +324,15 @@
     "loopPhraseUnderway": "진행 중",
     "loopPhraseAlmostThere": "거의 다 왔습니다",
     "loopPhraseWrappingUp": "막바지",
-    "loopEmpty": "검증 중인 가설이 없습니다",
+    "loopEmpty": "가설을 세우면 검증까지 이어지는 과정이 여기 모입니다",
+    "loopEmptyCta": "첫 가설 만들기",
     "workforceTitle": "워크포스",
     "workforceSubject": "누가 무엇을 맡고 있는지",
     "workforceTrustVerified": "사람이 확인함",
     "workforceTrustClaimed": "에이전트 완료 · 검토 대기",
     "workforceTogether": "함께 일하는 중",
     "workforceUnassigned": "아직 배정 전입니다",
-    "workforceEmpty": "진행 중인 작업이 없습니다"
+    "workforceEmpty": "사람과 AI가 함께 맡은 일이 여기 모입니다"
   },
   "organization": {
     "rolesTitle": "권한",

--- a/apps/web/src/components/org-briefing/loop-face.test.tsx
+++ b/apps/web/src/components/org-briefing/loop-face.test.tsx
@@ -86,13 +86,28 @@ describe('LoopFace', () => {
     expect(container.innerHTML).not.toContain('text-destructive');
   });
 
-  it('excludes killed/archived hypotheses (forward-only) and renders the calm empty state when nothing qualifies', async () => {
+  it('excludes killed/archived hypotheses (forward-only) and renders the identity-forward empty state when nothing qualifies', async () => {
     stubFetch(
       { data: [{ id: 'h1', status: 'killed', statement: '중단된 가설', epic_ids: [], created_at: '2026-07-01T00:00:00Z' }] },
       { data: { project_status: { epics: [] } } },
     );
     await mount();
-    expect(container.innerHTML).toContain('검증 중인 가설이 없습니다');
+    // story 64b9a879: "없습니다" 부재형이 아니라 "~하면 여기 모입니다" 발견성 카피로 전환.
+    expect(container.innerHTML).toContain('가설을 세우면 검증까지 이어지는 과정이 여기 모입니다');
     expect(container.innerHTML).not.toContain('중단된 가설');
+  });
+
+  it('빈상태에서 C1 학습 루프(/loops) 진입점이 gentle 텍스트 링크로 노출된다', async () => {
+    stubFetch({ data: [] }, { data: { project_status: { epics: [] } } });
+    await mount();
+    const link = container.querySelector('a[href$="/loops"]');
+    expect(link).not.toBeNull();
+    expect(link?.textContent).toContain('첫 가설 만들기');
+  });
+
+  it('타이틀 옆에 파란 dot(bg-info)이 렌더된다', async () => {
+    stubFetch({ data: [] }, { data: { project_status: { epics: [] } } });
+    await mount();
+    expect(container.innerHTML).toContain('bg-info');
   });
 });

--- a/apps/web/src/components/org-briefing/loop-face.tsx
+++ b/apps/web/src/components/org-briefing/loop-face.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import {
   buildLoopFace, parseEpicProgress, parseHypotheses,
   type LoopFaceItem, type LoopFaceTranslator,
@@ -11,6 +13,10 @@ import {
 
 // story 6b707960 — 조직 브리핑 "루프" 면. S1 셸의 스켈레톤 자리에 배치 이동 없이 증분 장착
 // (org-briefing-shell.tsx의 duo grid 첫 칸, 목업 Frame A 배치 1:1).
+// story 64b9a879: 빈상태를 "가설을 세우면 검증까지 이어지는 과정이 여기 모입니다"로 전환하고
+// C1 학습 루프 진입점(/loops)을 gentle 텍스트 링크로 자연 노출(과CTA 금지 — 버튼 아닌 링크).
+// 슬러그 폴백은 app-sidebar.tsx::resourceLink()와 동형(직접 path 우선·없으면 bare path를
+// 미들웨어 쿠키 기반 301이 받는다).
 const REFRESH_MS = 60_000;
 
 async function loadLoopFace(projectId: string, t: LoopFaceTranslator): Promise<LoopFaceItem[]> {
@@ -55,6 +61,9 @@ function RowSkeleton() {
 export function LoopFace({ projectId }: { projectId: string }) {
   const t = useTranslations('orgBriefing');
   const [items, setItems] = useState<LoopFaceItem[] | null>(null);
+  const { orgId, orgMemberships, currentProjectSlug } = useDashboardContext();
+  const orgSlug = orgMemberships.find((o) => o.orgId === orgId)?.orgSlug;
+  const loopsHref = orgSlug && currentProjectSlug ? `/${orgSlug}/${currentProjectSlug}/loops` : '/loops';
 
   useEffect(() => {
     const load = async () => {
@@ -67,8 +76,9 @@ export function LoopFace({ projectId }: { projectId: string }) {
   }, [projectId, t]);
 
   return (
-    <div className="rounded-2xl border border-border bg-card p-4">
+    <div className="rounded-2xl border border-border bg-card p-4 transition-shadow hover:shadow-sm">
       <div className="mb-3 flex items-baseline gap-2.5">
+        <span className="size-1.5 shrink-0 rounded-full bg-info" aria-hidden="true" />
         <h2 className="text-sm font-semibold text-foreground">{t('loopTitle')}</h2>
         <span className="text-[11px] text-muted-foreground">{t('loopSubject')}</span>
       </div>
@@ -78,7 +88,12 @@ export function LoopFace({ projectId }: { projectId: string }) {
           <RowSkeleton />
         </>
       ) : items.length === 0 ? (
-        <p className="py-6 text-center text-xs text-muted-foreground">{t('loopEmpty')}</p>
+        <div className="space-y-2 py-6 text-center">
+          <p className="text-xs text-muted-foreground">{t('loopEmpty')}</p>
+          <Link href={loopsHref} className="text-xs font-medium text-info hover:underline">
+            {t('loopEmptyCta')} →
+          </Link>
+        </div>
       ) : (
         items.map((item) => <LoopRow key={item.id} item={item} />)
       )}

--- a/apps/web/src/components/org-briefing/now-face.test.tsx
+++ b/apps/web/src/components/org-briefing/now-face.test.tsx
@@ -112,4 +112,11 @@ describe('NowFace', () => {
     await mount();
     expect(container.innerHTML).not.toMatch(/\d+\s*(분|시간|일)(?!건)/);
   });
+
+  it('story 64b9a879 — "지금" hero 뱃지가 타이틀 옆에 렌더된다(정보 위계 강조)', async () => {
+    stubFetch({ action_queue: { items: [] }, attention: { items: [] } }, { data: [] });
+    await mount();
+    const badge = [...container.querySelectorAll('span')].find((s) => s.textContent === '지금');
+    expect(badge).not.toBeUndefined();
+  });
 });

--- a/apps/web/src/components/org-briefing/now-face.tsx
+++ b/apps/web/src/components/org-briefing/now-face.tsx
@@ -84,12 +84,15 @@ export function NowFace() {
   return (
     <section aria-label={t('nowTitle')}>
       <div className="mb-2.5 flex items-baseline gap-2.5">
+        <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10.5px] font-semibold uppercase tracking-wide text-primary">
+          {t('nowHeroBadge')}
+        </span>
         <h2 className="text-sm font-semibold text-foreground">{t('nowTitle')}</h2>
         {items && items.length > 0 ? (
           <span className="ml-auto text-[11px] text-muted-foreground">{t('nowNote', { count: items.length })}</span>
         ) : null}
       </div>
-      <div className="rounded-2xl border border-border bg-card">
+      <div className="rounded-2xl border border-border bg-card transition-shadow hover:shadow-sm">
         {items === null ? (
           Array.from({ length: 3 }).map((_, i) => <RowSkeleton key={i} />)
         ) : list.length === 0 ? (

--- a/apps/web/src/components/org-briefing/org-briefing-shell.test.tsx
+++ b/apps/web/src/components/org-briefing/org-briefing-shell.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+//
+// story 64b9a879 — OrgBriefingShell first-touch 온기 greeting 회귀가드. userName 있으면
+// "{name}님, 오늘 조직의 지금이에요" · 없으면(로딩 중 등) 기존 정적 타이틀로 안전 폴백
+// ("undefined님" 같은 어색한 렌더 방지).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+
+const { useDashboardContextMock } = vi.hoisted(() => ({
+  useDashboardContextMock: vi.fn(),
+}));
+
+vi.mock('@/app/dashboard/dashboard-shell', () => ({
+  useDashboardContext: () => useDashboardContextMock(),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ data: [] }) })));
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+async function mount() {
+  const { OrgBriefingShell } = await import('./org-briefing-shell');
+  await act(async () => { root.render(wrap(<OrgBriefingShell />)); });
+  await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+}
+
+describe('OrgBriefingShell greeting', () => {
+  it('userName이 있으면 "{name}님, 오늘 조직의 지금이에요" greeting을 h1로 렌더한다', async () => {
+    useDashboardContextMock.mockReturnValue({ projectMemberships: [], orgMemberships: [], userName: 'sellerking' });
+    await mount();
+    const h1 = container.querySelector('h1');
+    expect(h1?.textContent).toBe('sellerking님, 오늘 조직의 지금이에요');
+  });
+
+  it('userName이 없으면(로딩 중 등) 기존 정적 타이틀로 안전 폴백한다 — "undefined님" 렌더 안 함', async () => {
+    useDashboardContextMock.mockReturnValue({ projectMemberships: [], orgMemberships: [] });
+    await mount();
+    const h1 = container.querySelector('h1');
+    expect(h1?.textContent).toBe('조직 브리핑');
+    expect(container.innerHTML).not.toContain('undefined');
+  });
+});

--- a/apps/web/src/components/org-briefing/org-briefing-shell.tsx
+++ b/apps/web/src/components/org-briefing/org-briefing-shell.tsx
@@ -6,10 +6,14 @@ import { NowFace } from './now-face';
 import { LoopFace } from './loop-face';
 import { WorkforceFace } from './workforce-face';
 
-// story ded31cb3(S1)+6b707960(S2)+09fa254e(S3) — 조직 브리핑 셸. 목업 Frame A 배치 1:1: ①지금
-// (hero·상단·폭 전체) → ②루프|③워크포스(2단·하단, lg 미만 스택 — GNB lg:hidden과 일치, md 사용 금지).
-// 유나 보강(conv 32b8cff9 11:42:42): 루프/워크포스는 S1에서 레이아웃 골격만 확定 — 자리 이동 없이
-// 데이터만 증분 장착(루프=S2, 워크포스=이번). 헤더 인사말/시간대 카피는 근거 없는 장식이라 생략(no-fiction).
+// story ded31cb3(S1)+6b707960(S2)+09fa254e(S3)+64b9a879(우아함 심화) — 조직 브리핑 셸. 목업
+// Frame A 배치 1:1: ①지금(hero·상단·폭 전체) → ②루프|③워크포스(2단·하단, lg 미만 스택 —
+// GNB lg:hidden과 일치, md 사용 금지).
+// 64b9a879: first-touch 온기 greeting 추가 — 로그인 직후 첫 화면=조직 OS 정체성 접점이라는
+// 근거가 이번 스토리로 명시됐다(이전 "근거 없는 장식이라 생략" 판단은 그 근거가 없던 시점 것 —
+// no-fiction 판단 자체는 유지, 근거가 새로 생겨 뒤집힌 것). userName 없으면 기존 정적 타이틀로
+// 안전하게 폴백(빈 이름+"님" 어색함 방지).
+// 3면 순차 fade-in stagger(lagom — clutter 추가 아닌 절제된 진입 리듬).
 
 function FaceSkeletonPanel({ title, subject }: { title: string; subject: string }) {
   return (
@@ -34,20 +38,28 @@ function FaceSkeletonPanel({ title, subject }: { title: string; subject: string 
 
 export function OrgBriefingShell() {
   const t = useTranslations('orgBriefing');
-  const { projectId } = useDashboardContext();
+  const { projectId, userName } = useDashboardContext();
 
   return (
-    <div className="mx-auto max-w-7xl space-y-5 p-4 lg:p-6">
+    <div className="mx-auto max-w-7xl space-y-6 p-4 lg:p-6">
       <div>
-        <h1 className="text-lg font-semibold tracking-tight text-foreground">{t('title')}</h1>
+        <h1 className="text-lg font-semibold tracking-tight text-foreground">
+          {userName ? t('greeting', { name: userName }) : t('title')}
+        </h1>
         <p className="mt-1 text-sm text-muted-foreground">{t('subtitle')}</p>
       </div>
 
-      <NowFace />
+      <div className="animate-in fade-in slide-in-from-bottom-1 duration-300">
+        <NowFace />
+      </div>
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-        {projectId ? <LoopFace projectId={projectId} /> : <FaceSkeletonPanel title={t('loopTitle')} subject={t('loopSubject')} />}
-        {projectId ? <WorkforceFace projectId={projectId} /> : <FaceSkeletonPanel title={t('workforceTitle')} subject={t('workforceSubject')} />}
+        <div className="animate-in fade-in slide-in-from-bottom-1 duration-300 [animation-delay:75ms] [animation-fill-mode:backwards]">
+          {projectId ? <LoopFace projectId={projectId} /> : <FaceSkeletonPanel title={t('loopTitle')} subject={t('loopSubject')} />}
+        </div>
+        <div className="animate-in fade-in slide-in-from-bottom-1 duration-300 [animation-delay:150ms] [animation-fill-mode:backwards]">
+          {projectId ? <WorkforceFace projectId={projectId} /> : <FaceSkeletonPanel title={t('workforceTitle')} subject={t('workforceSubject')} />}
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/org-briefing/workforce-face.test.tsx
+++ b/apps/web/src/components/org-briefing/workforce-face.test.tsx
@@ -81,6 +81,14 @@ describe('WorkforceFace', () => {
     expect(container.innerHTML).toContain('아직 배정 전입니다');
   });
 
+  it('story 64b9a879 — 활성 에픽 자체가 없으면 인간+AI 하이브리드 정체성 빈상태(Users+Bot 아이콘·발견성 카피)를 렌더한다', async () => {
+    stubFetch({ data: { project_status: { epics: [] } } }, {}, MEMBERS);
+    await mount();
+    expect(container.innerHTML).toContain('사람과 AI가 함께 맡은 일이 여기 모입니다');
+    // lucide 아이콘은 svg로 렌더 — Users+Bot 2개가 정확히 뜨는지(가벼운 아이콘 2개, 무거운 일러스트 아님).
+    expect(container.querySelectorAll('svg').length).toBe(2);
+  });
+
   it('never renders a per-person count, ranking, or elapsed-time string alongside the actual rendered row (collaboration-map.test.tsx parity — highest surveillance-risk surface)', async () => {
     // 까심 REQUEST_CHANGES(#2161) — S2(425085b4)와 동일 공허-통과 클래스: negative 정규식만 걸면
     // 컴포넌트가 통째로 빈 화면을 뱉어도 항상 통과한다. 같은 mount·같은 DOM에서 실제 아바타/씰이

--- a/apps/web/src/components/org-briefing/workforce-face.tsx
+++ b/apps/web/src/components/org-briefing/workforce-face.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { Users, Bot } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import {
   buildWorkforceFace, parseActiveEpics, parseEpicStories, parseTeamMembers,
@@ -10,6 +11,8 @@ import {
 
 // story 09fa254e — 조직 브리핑 "워크포스" 면. S1 셸의 스켈레톤 자리에 배치 이동 없이 증분 장착.
 // 아바타 클러스터는 collaboration-map.tsx(E-GLANCE §5)와 동일 스타일(숫자 배지 0, presence만).
+// story 64b9a879: 빈상태를 "사람과 AI가 함께 맡은 일이 여기 모입니다"로 전환·Users+Bot 아이콘
+// 페어로 인간+AI 하이브리드 정체성을 gentle하게 신호(무거운 일러스트 아닌 절제된 아이콘 2개).
 const REFRESH_MS = 60_000;
 
 interface WorkforceData {
@@ -93,8 +96,9 @@ export function WorkforceFace({ projectId }: { projectId: string }) {
   }, [projectId, t]);
 
   return (
-    <div className="rounded-2xl border border-border bg-card p-4">
+    <div className="rounded-2xl border border-border bg-card p-4 transition-shadow hover:shadow-sm">
       <div className="mb-3 flex items-baseline gap-2.5">
+        <span className="size-1.5 shrink-0 rounded-full bg-success" aria-hidden="true" />
         <h2 className="text-sm font-semibold text-foreground">{t('workforceTitle')}</h2>
         <span className="text-[11px] text-muted-foreground">{t('workforceSubject')}</span>
       </div>
@@ -104,7 +108,13 @@ export function WorkforceFace({ projectId }: { projectId: string }) {
           <RowSkeleton />
         </>
       ) : data.items.length === 0 ? (
-        <p className="py-6 text-center text-xs text-muted-foreground">{t('workforceEmpty')}</p>
+        <div className="space-y-2 py-6 text-center">
+          <div className="flex items-center justify-center gap-1.5 text-muted-foreground/50" aria-hidden="true">
+            <Users className="size-4" />
+            <Bot className="size-4" />
+          </div>
+          <p className="text-xs text-muted-foreground">{t('workforceEmpty')}</p>
+        </div>
       ) : (
         data.items.map((item) => <WorkforceRow key={item.id} item={item} memberNames={data.memberNames} t={t} />)
       )}


### PR DESCRIPTION
## Summary
- doc `org-briefing-hypothesis-grammar-blueprint`(S1~S3 셸) 위에 겹쳐 적용하는 first-touch 우아함 심화 PR — 레이아웃/데이터 구조는 무변경, 정체성·위계·온기·마이크로인터랙션만 추가.

### ① 정보 위계
- `NowFace` 타이틀 옆 "지금" hero 뱃지(hero 강조).
- 실험실/워크포스 타이틀 앞 파랑/초록 dot(`bg-info`/`bg-success`, `inbox/page.tsx`의 기존 dot 패턴 재사용).

### ② first-touch 온기
- `userName` 있으면 `"{name}님, 오늘 조직의 지금이에요"`(해요체) greeting을 h1로. 없으면(로딩 중 등) 기존 정적 타이틀 `"조직 브리핑"`으로 안전 폴백 — `"undefined님"` 렌더 방지를 테스트로 고정.

### ③ 빈상태 정체성 전환("없습니다" → "~하면 여기 모입니다")
- 실험실: `"가설을 세우면 검증까지 이어지는 과정이 여기 모입니다"` + `/loops`(C1 학습 루프) gentle 텍스트 링크("첫 가설 만들기 →", 버튼 아님 — 과CTA 금지). 슬러그 라우팅은 `app-sidebar.tsx::resourceLink()`와 동형 폴백(직접 path 우선·없으면 bare path).
- 워크포스: `"사람과 AI가 함께 맡은 일이 여기 모입니다"` + `Users`+`Bot` 아이콘 페어(인간+AI 하이브리드 정체성, 가벼운 아이콘 2개 — 무거운 일러스트 아님).

### ④ 마이크로인터랙션(lagom)
- 3면 순차 stagger fade-in(0/75/150ms 지연, 기존 `tw-animate-css` 컨벤션 재사용 — `hypothesis-verdict-card.tsx`와 동일 패턴, 신규 의존성 0).
- 카드 hover 시 subtle shadow.

## 신규 템플릿 doc 확認
`resource-view-firsttouch-identity-pattern`(작성 시점: 이 PR 작업 도중) 확認 — 그 뷰별 가이드표는 `/loops`·`/glance` 등 **별도 풀페이지 리소스뷰**를 대상으로 하고, org-briefing 자체는 그 템플릿의 "원류" 파일럿이라 표에 없음 — 이 PR과 충돌 없음.

## 규율 준수
- C2a 신뢰 표면 무접촉(강제 노출 0).
- 과CTA 0 — 신규 링크 1개(실험실 빈상태)뿐, 워크포스는 순수 정체성 신호만.
- 관형형 방언 0·반증(falsified)=info 유지(빨강 미사용, 기존 soul-lock 무변경).
- 회귀 0 — 레이아웃/데이터 로직 무변경, 순수 추가.

## Test plan
- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm exec vitest run` (apps/web scope) — 240 files / 1588 passed, 무회귀
- [x] `pnpm exec vitest run` (repo-root scope) — 256 files / 1762 passed, 무회귀
- [x] `NEXT_TELEMETRY_DISABLED=1 pnpm build` — genuine EXIT=0
- [x] 뮤테이션 셀프체크 2건: greeting 폴백 로직·loops 링크 href 폴백 로직 각각 무력화 → 관련 테스트 RED 확인 후 원복
- [x] 신규/갱신 테스트 7건(그리팅 2건·hero뱃지·dot색·loops링크·워크포스 아이콘 페어·기존 loop 빈상태 어서션 갱신)
- [ ] 라이브 픽셀 검증 — org-briefing은 인증 게이트 라우트라 로컬 미검증, dev 배포 후 확인 예정(기존 컨벤션)

🤖 Generated with [Claude Code](https://claude.com/claude-code)