### PR TITLE
feat(auth): auth_valid_after 코어 인프라 — cutover epoch 강제 (story bea25062, closes 6ae1ecac AC#2)

### DIFF
--- a/backend/alembic/versions/0190_auth_valid_after_cutover_epoch.py
+++ b/backend/alembic/versions/0190_auth_valid_after_cutover_epoch.py
@@ -1,0 +1,29 @@
+"""story bea25062(E-AUTH-REBUILD auth_valid_after 코어 인프라): auth_migrations.auth_valid_after
+컬럼(doc firebase-poc-q12-didi-measurements §17d-1 cutover epoch authority).
+
+Revision ID: 0190
+Revises: 0189
+Create Date: 2026-07-15
+
+additive — 기본 NULL(제약 없음)이라 기존 스키마/동작 무회귀.
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0190"
+down_revision = "0189"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "auth_migrations",
+        sa.Column("auth_valid_after", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("auth_migrations", "auth_valid_after")

--- a/backend/alembic/versions/0191_auth_native_bootstrap_codes_auth_time.py
+++ b/backend/alembic/versions/0191_auth_native_bootstrap_codes_auth_time.py
@@ -1,0 +1,34 @@
+"""story bea25062(§17d-1 RED 포워딩 BLOCKER 2·산티아고 2026-07-16): auth_native_bootstrap_codes에
+원본 Firebase ID token `auth_time` 보존 컬럼 추가.
+
+⚠️`created_at`(코드 발급 시각)과 `auth_time`(그 코드를 발급받기 위해 제시된 ID token이 실제로
+Firebase에 인증된 시각)은 다른 값이다 — revoke 이후 예전(pre-cutover) ID token으로 새 코드를
+발급받으면 `created_at`은 revoke보다 늦지만 `auth_time`은 여전히 revoke 이전이라 cutover
+우회가 가능했다(BLOCKER 2). 이 컬럼이 issue/consume 양쪽에서 cutover 재검증의 기준이 된다.
+
+additive — nullable(기존 행 없음, 아직 활성화 전 default-off 상태).
+
+Revision ID: 0191
+Revises: 0190
+Create Date: 2026-07-16
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0191"
+down_revision = "0190"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "auth_native_bootstrap_codes",
+        sa.Column("auth_time", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("auth_native_bootstrap_codes", "auth_time")

--- a/backend/alembic/versions/0191_auth_valid_after_cutover_epoch.py
+++ b/backend/alembic/versions/0191_auth_valid_after_cutover_epoch.py
@@ -1,19 +1,22 @@
 """story bea25062(E-AUTH-REBUILD auth_valid_after 코어 인프라): auth_migrations.auth_valid_after
 컬럼(doc firebase-poc-q12-didi-measurements §17d-1 cutover epoch authority).
 
-Revision ID: 0190
-Revises: 0189
+Revision ID: 0191
+Revises: 0190
 Create Date: 2026-07-15
 
 additive — 기본 NULL(제약 없음)이라 기존 스키마/동작 무회귀.
+
+⚠️renumber(2026-07-16, PO 채번 조율 실패 정정): #2213(C1·device_installations)이 develop
+0190을 먼저 선점해 머지돼 이 마이그가 0191로 밀렸다 — 로직 무변, 파일번호+down_revision만.
 """
 from __future__ import annotations
 
 from alembic import op
 import sqlalchemy as sa
 
-revision = "0190"
-down_revision = "0189"
+revision = "0191"
+down_revision = "0190"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/0192_auth_native_bootstrap_codes_auth_time.py
+++ b/backend/alembic/versions/0192_auth_native_bootstrap_codes_auth_time.py
@@ -8,17 +8,20 @@ Firebase에 인증된 시각)은 다른 값이다 — revoke 이후 예전(pre-c
 
 additive — nullable(기존 행 없음, 아직 활성화 전 default-off 상태).
 
-Revision ID: 0191
-Revises: 0190
+Revision ID: 0192
+Revises: 0191
 Create Date: 2026-07-16
+
+⚠️renumber(2026-07-16, PO 채번 조율 실패 정정): #2213(C1) develop 0190 선점으로 밀림 —
+로직 무변, 파일번호+down_revision만.
 """
 from __future__ import annotations
 
 from alembic import op
 import sqlalchemy as sa
 
-revision = "0191"
-down_revision = "0190"
+revision = "0192"
+down_revision = "0191"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -209,6 +209,29 @@ async def _resolve_api_key(
     )
 
 
+async def _reject_if_before_cutover(user_id: str, unix_timestamp: int | None, db: AsyncSession) -> None:
+    """story bea25062(§17d-1 cutover epoch authority): legacy iat/Firebase auth_time이
+    이 사용자의 auth_valid_after 이전(또는 동일)이면 거부. AuthMigration 행이 없거나
+    auth_valid_after가 NULL이면(현재 대부분의 사용자) 제약 없음 — 기존 동작 100% 무변화.
+
+    ⚠️전역 존재-캐시(`check_any_cutover_epoch_exists()`)를 먼저 본다 — revoke가 시스템
+    전체에 단 한 번도 없었다면(오늘의 현실) 이 요청의 `db`/`user_id`를 전혀 건드리지 않고
+    즉시 반환한다. 이게 없으면 legacy JWT 검증(원래 DB 완전 무접촉)이 인증된 모든 요청마다
+    DB 왕복 1건을 영구히 추가하게 되고, `db=None`/`AsyncMock()`으로 이 경로를 호출하는
+    기존 단위 테스트들도 깨진다(자체 발견 — auth_cutover.py 모듈 docstring 참조)."""
+    if unix_timestamp is None:
+        return
+    from app.services.auth_cutover import check_any_cutover_epoch_exists, get_auth_valid_after, is_before_cutover
+
+    if not await check_any_cutover_epoch_exists():
+        return
+
+    auth_valid_after = await get_auth_valid_after(db, uuid.UUID(user_id))
+    reference_time = datetime.fromtimestamp(unix_timestamp, tz=timezone.utc)
+    if is_before_cutover(auth_valid_after, reference_time):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Session revoked")
+
+
 async def _resolve_firebase_session(token: str, db: AsyncSession) -> AuthContext:
     """story 455e528d(doc §3.3): Firebase 세션 검증 후 resource-actual AuthContext 구성.
 
@@ -246,6 +269,8 @@ async def _resolve_firebase_session(token: str, db: AsyncSession) -> AuthContext
     user = await db.get(User, identity_row.user_id)
     if user is None or not user.is_active:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    await _reject_if_before_cutover(str(user.id), verified.auth_time, db)
 
     org_id = str(user.last_org_id) if user.last_org_id else None
     app_metadata: dict = {}
@@ -315,6 +340,8 @@ async def get_current_user(
     user_id: str | None = payload.get("sub")
     if not user_id:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token missing sub claim")
+
+    await _reject_if_before_cutover(user_id, payload.get("iat"), db)
 
     org_id: str | None = payload.get("app_metadata", {}).get("org_id")
 
@@ -718,6 +745,11 @@ async def get_current_user_streaming(
     user_id: str | None = payload.get("sub")
     if not user_id:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token missing sub claim")
+
+    # story bea25062: legacy 경로도 cutover epoch 검사 필요 — API key/Firebase 경로와 동형으로
+    # 단명 세션(async with)만 이 검사를 위해 열고 즉시 close(스트림 yield 구간 미점유 유지).
+    async with async_session_factory() as db:
+        await _reject_if_before_cutover(user_id, payload.get("iat"), db)
 
     return AuthContext(
         user_id=user_id,

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -209,26 +209,41 @@ async def _resolve_api_key(
     )
 
 
-async def _reject_if_before_cutover(user_id: str, unix_timestamp: int | None, db: AsyncSession) -> None:
+async def _reject_if_before_cutover(user_id: str | uuid.UUID, unix_timestamp: int | None, db: AsyncSession) -> None:
     """story bea25062(§17d-1 cutover epoch authority): legacy iat/Firebase auth_time이
-    이 사용자의 auth_valid_after 이전(또는 동일)이면 거부. AuthMigration 행이 없거나
-    auth_valid_after가 NULL이면(현재 대부분의 사용자) 제약 없음 — 기존 동작 100% 무변화.
+    이 사용자의 auth_valid_after 이전(또는 동일)이거나, migration.state가 강제 재설정
+    대상(`reset_required`)이면 거부. AuthMigration 행이 없으면(Phase 1~3 cohort 미편입
+    대부분의 현재 사용자) 제약 없음 — 기존 동작 100% 무변화.
 
-    ⚠️전역 존재-캐시(`check_any_cutover_epoch_exists()`)를 먼저 본다 — revoke가 시스템
-    전체에 단 한 번도 없었다면(오늘의 현실) 이 요청의 `db`/`user_id`를 전혀 건드리지 않고
-    즉시 반환한다. 이게 없으면 legacy JWT 검증(원래 DB 완전 무접촉)이 인증된 모든 요청마다
-    DB 왕복 1건을 영구히 추가하게 되고, `db=None`/`AsyncMock()`으로 이 경로를 호출하는
-    기존 단위 테스트들도 깨진다(자체 발견 — auth_cutover.py 모듈 docstring 참조)."""
-    if unix_timestamp is None:
+    ⚠️산티아고 RED 조건 ①③(2026-07-16): 이전엔 전역 존재-캐시로 DB 조회를 생략했으나 —
+    다른 인스턴스의 캐시 지연·DB 장애 시 기본값 반환이 전부 fail-open이었다(BLOCKER 1).
+    캐시를 제거하고 **매 호출마다 무조건** `AuthMigration`을 PK 조회한다 — DB 조회가
+    실패하면 예외를 그대로 전파해(auth 요청 실패) fail-closed를 유지한다.
+
+    ⚠️조건 ②: `auth_valid_after`만 보면 `reset_required`인데 아직 epoch가 안 채워진(또는
+    부분 커밋된) 사용자가 그냥 통과한다 — state 자체도 함께 거부 조건에 넣는다.
+
+    ⚠️조건 ③: iat/auth_time이 없거나 정수가 아니면(위조/손상 클레임) 예전엔 "제약 없음"으로
+    통과시켰다 — 이제 fail-closed(401)로 뒤집는다. 정상 발급 토큰은 항상 iat/auth_time을
+    갖고 있어 무회귀.
+
+    ⚠️까심 결함 A(2026-07-16): `uuid.UUID(user_id)`가 user_id를 항상 str로 가정해 이미
+    `uuid.UUID` 객체인 호출부에서 `ValueError`. isinstance로 방어해 4 verifier 전 경로에서
+    타입 일관 처리."""
+    if not isinstance(unix_timestamp, int):
+        logger.warning("auth.cutover.reject reason=missing_or_invalid_timestamp")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid authentication timestamp")
+
+    from app.models.auth_identity import AuthMigration
+    from app.services.auth_cutover import is_before_cutover
+
+    user_uuid = user_id if isinstance(user_id, uuid.UUID) else uuid.UUID(user_id)
+    migration = await db.get(AuthMigration, user_uuid)
+    if migration is None:
         return
-    from app.services.auth_cutover import check_any_cutover_epoch_exists, get_auth_valid_after, is_before_cutover
 
-    if not await check_any_cutover_epoch_exists():
-        return
-
-    auth_valid_after = await get_auth_valid_after(db, uuid.UUID(user_id))
     reference_time = datetime.fromtimestamp(unix_timestamp, tz=timezone.utc)
-    if is_before_cutover(auth_valid_after, reference_time):
+    if migration.state == "reset_required" or is_before_cutover(migration.auth_valid_after, reference_time):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Session revoked")
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,6 +28,11 @@ async def lifespan(app: FastAPI):
     check_listen_config()  # ee7794eb ③ fail-closed: DB_PGBOUNCER on + DATABASE_URL_DIRECT 없으면 startup raise.
     check_internal_secret_config()  # 산티아고 §9 finding 4: non-local + 시크릿 미설정 fail-closed.
     check_mobile_app_check_config()  # 산티아고 §9 finding 1: mobile 발급 on + App Check 미필수 fail-closed.
+    # story bea25062: cutover 존재-캐시는 의도적으로 startup에서 warm 안 함(자체 발견 —
+    # TestClient(app)로 lifespan을 태우는 기존 SSE 테스트들이 라우트 전용으로 짜둔 유한한
+    # mock db.execute() 순서-큐를 startup 시점의 이 캐시 조회가 몰래 하나 소비해 실패시켰다).
+    # 지연 초기화(첫 실 요청에서 채워짐)만으로 충분 — check_any_cutover_epoch_exists() 자체가
+    # DB 접속 불가/미준비 시에도 fail-safe라 startup에서 먼저 확인해둘 실익이 크지 않다.
     task = asyncio.create_task(listen_loop())
     # E-L2 S5: 휴리스틱 트리거 워커는 default-off — 명시 활성화 시에만 task 생성(AC①).
     l2_task = None

--- a/backend/app/models/auth_identity.py
+++ b/backend/app/models/auth_identity.py
@@ -62,6 +62,10 @@ class AuthMigration(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
     )
+    # story bea25062(§17d-1 cutover epoch authority): NULL=제약 없음(기본, 기존 동작 무변화).
+    # 값이 있으면 그 시각 이전에 발급된 자격증명(iat/auth_time)은 전부 거부 — 단일 사용자
+    # revoke나 Phase 4 대량 cutover 둘 다 이 컬럼 하나로 표현된다.
+    auth_valid_after: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
 
 class AuthMigrationEvent(Base):

--- a/backend/app/models/auth_native_bootstrap.py
+++ b/backend/app/models/auth_native_bootstrap.py
@@ -22,6 +22,10 @@ class AuthNativeBootstrapCode(Base):
     project_id: Mapped[str] = mapped_column(Text, nullable=False)
     code_hash: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
     device_binding_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # story bea25062(§17d-1 BLOCKER 2): 이 코드 발급의 근거가 된 원본 Firebase ID token의
+    # auth_time — created_at(코드 발급 시각)과 다르다. cutover 재검증은 항상 이 값을 기준으로
+    # 한다(revoke 이후 예전 ID token으로 새 코드를 발급받는 우회 차단).
+    auth_time: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     consumed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routers/auth_firebase_internal.py
+++ b/backend/app/routers/auth_firebase_internal.py
@@ -26,6 +26,7 @@ from app.core.config import settings
 from app.dependencies.database import get_db
 from app.models.auth_identity import AuthIdentity, AuthMigration
 from app.models.user import User
+from app.services.auth_cutover import is_before_cutover
 from app.services.firebase_session_mint import mint_session_cookie, mint_session_cookie_for_uid
 from app.services.firebase_verifier import verify_firebase_id_token
 from app.services.native_bootstrap import consume_bootstrap_code
@@ -222,6 +223,15 @@ async def consume_native_bootstrap(
             migration.state if migration else None,
         )
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Account not eligible for Firebase session")
+
+    # 산티아고 #2202 3차 재검토 orphan finding(story bea25062로 종결): 코드 발급 후 45초
+    # 이내 revoke가 발생해도(user-wide Firebase revoke는 이미 발급된 custom-token 재생성
+    # 경로를 자동 차단하지 않음) 코드 자체는 아직 안 만료됐으면 여기까지 통과해버렸다.
+    # consumed.created_at(코드 발급 시각)을 cutover epoch와 비교해 발급 이후 revoke가
+    # 있었으면 거부 — §17d-1과 동일 기준, native-bootstrap 소비 시점에 재적용.
+    if is_before_cutover(migration.auth_valid_after, consumed.created_at):
+        logger.warning("auth.native_bootstrap.consume rejected reason=revoked_after_issuance")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Session revoked")
 
     valid_duration_seconds = 5 * 24 * 60 * 60
     session_cookie = await mint_session_cookie_for_uid(

--- a/backend/app/routers/auth_firebase_internal.py
+++ b/backend/app/routers/auth_firebase_internal.py
@@ -224,13 +224,38 @@ async def consume_native_bootstrap(
         )
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Account not eligible for Firebase session")
 
-    # 산티아고 #2202 3차 재검토 orphan finding(story bea25062로 종결): 코드 발급 후 45초
-    # 이내 revoke가 발생해도(user-wide Firebase revoke는 이미 발급된 custom-token 재생성
-    # 경로를 자동 차단하지 않음) 코드 자체는 아직 안 만료됐으면 여기까지 통과해버렸다.
-    # consumed.created_at(코드 발급 시각)을 cutover epoch와 비교해 발급 이후 revoke가
-    # 있었으면 거부 — §17d-1과 동일 기준, native-bootstrap 소비 시점에 재적용.
-    if is_before_cutover(migration.auth_valid_after, consumed.created_at):
+    # 산티아고 #2202 3차 재검토 orphan finding + BLOCKER 2 시정(story bea25062·2026-07-16):
+    # 이전엔 consumed.created_at(코드 발급 시각)을 cutover epoch와 비교했는데, revoke 이후에도
+    # 예전(pre-cutover) Firebase ID token으로 여전히 새 코드를 "발급"받을 수 있었다(당시 issue
+    # 엔드포인트가 cutover를 안 봤다) — created_at은 revoke보다 늦지만 그 코드의 근거가 된
+    # 실제 인증(auth_time)은 revoke 이전이라 우회가 가능했다. 이제 issue 엔드포인트도 발급
+    # 시점에 cutover를 검사하지만(방어 심화), 여기 consume 재검증은 항상 원본 auth_time
+    # 기준으로 다시 본다 — 발급~소비 사이(최대 45초)에 새로 revoke가 발생했을 수 있어서다.
+    # auth_time이 없으면(데이터 무결성 문제) fail-closed.
+    if consumed.auth_time is None:
+        logger.warning("auth.native_bootstrap.consume rejected reason=missing_auth_time")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Session revoked")
+
+    if is_before_cutover(migration.auth_valid_after, consumed.auth_time):
         logger.warning("auth.native_bootstrap.consume rejected reason=revoked_after_issuance")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Session revoked")
+
+    # 산티아고 RED 조건 ⑤(consume/mint 중간 revoke TOCTOU): 위 검사와 실제 mint(Firebase
+    # 네트워크 왕복 포함) 사이에도 revoke가 끼어들 수 있다 — mint 직전에 migration을 다시
+    # 읽어 동일 기준(state+원본 auth_time)으로 재확인해 창을 최대한 좁힌다. 별도 revoke
+    # 트랜잭션과 이 요청 사이의 완전한 원자성은 분산 락 없이는 불가능하지만, 재확인 시점을
+    # mint 직전까지 당겨 잔여 창을 실질적으로 최소화한다.
+    # ⚠️자체 발견: `Session.get()`은 동일 세션의 identity map에 이미 로드된 행이면 SQL을
+    # 아예 다시 안 날리고 캐시된 in-memory 객체를 그대로 반환한다(문서화된 기본 동작) — 위
+    # 첫 `migration` 조회와 같은 PK라 `populate_existing=True` 없인 이 재확인이 완전히
+    # 무력한 no-op이 된다(재조회처럼 보이지만 실제론 DB를 안 건드림). 반드시 강제 재조회.
+    migration_at_mint = await db.get(AuthMigration, consumed.user_id, populate_existing=True)
+    if (
+        migration_at_mint is None
+        or migration_at_mint.state not in ("provisioning", "firebase")
+        or is_before_cutover(migration_at_mint.auth_valid_after, consumed.auth_time)
+    ):
+        logger.warning("auth.native_bootstrap.consume rejected reason=revoked_before_mint")
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Session revoked")
 
     valid_duration_seconds = 5 * 24 * 60 * 60

--- a/backend/app/routers/auth_firebase_internal.py
+++ b/backend/app/routers/auth_firebase_internal.py
@@ -126,6 +126,19 @@ async def mint_firebase_session(
         logger.warning("auth.firebase.session_mint rejected reason=inactive_or_missing_user")
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid user")
 
+    # 산티아고 #2206 갱신 재검토(2026-07-16): 이 엔드포인트는 5분 freshness만 보고 migration
+    # state/cutover epoch를 전혀 안 봤다(§17d-1 위반) — native issue와 동일 guard를
+    # session-cookie mint 전에도 강제. reset_required/rollback_hold나 revoke 이후 예전 ID
+    # token으로도 여기선 세션쿠키가 그대로 발급될 수 있었다.
+    auth_time_dt = datetime.fromtimestamp(verified.auth_time, tz=timezone.utc)
+    migration = await db.get(AuthMigration, identity_row.user_id)
+    if migration is None or migration.state not in ("provisioning", "firebase"):
+        logger.warning("auth.firebase.session_mint rejected reason=ineligible_migration_state")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Account not eligible")
+    if is_before_cutover(migration.auth_valid_after, auth_time_dt):
+        logger.warning("auth.firebase.session_mint rejected reason=before_cutover")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Session revoked")
+
     valid_duration_seconds = 5 * 24 * 60 * 60
     session_cookie = await mint_session_cookie(
         body.id_token, settings.firebase_project_id, valid_duration_seconds
@@ -133,6 +146,17 @@ async def mint_firebase_session(
     if session_cookie is None:
         logger.warning("auth.firebase.session_mint failed reason=mint_failed")
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Session cookie mint failed")
+
+    # native consume과 동일 이유(Firebase 네트워크 왕복 중 revoke TOCTOU) — cookie 반환 직전
+    # 세 번째 authoritative 재조회. 실패 시 이미 mint된 cookie는 반환하지 않는다.
+    migration_after_mint = await db.get(AuthMigration, identity_row.user_id, populate_existing=True)
+    if (
+        migration_after_mint is None
+        or migration_after_mint.state not in ("provisioning", "firebase")
+        or is_before_cutover(migration_after_mint.auth_valid_after, auth_time_dt)
+    ):
+        logger.warning("auth.firebase.session_mint rejected reason=revoked_during_mint")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Session revoked")
 
     logger.info("auth.firebase.session_mint success")
     return FirebaseSessionMintResponse(session_cookie=session_cookie, expires_in=valid_duration_seconds)
@@ -265,6 +289,26 @@ async def consume_native_bootstrap(
     if session_cookie is None:
         logger.warning("auth.native_bootstrap.consume failed reason=mint_failed")
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Session cookie mint failed")
+
+    # 산티아고 #2206 갱신 재검토(2026-07-16) — mint 직전 재확인만으론 여전히 Firebase 네트워크
+    # 왕복(custom-token 발급→signInWithCustomToken→createSessionCookie, 수백ms~초 단위) 도중의
+    # revoke를 못 잡는다(probe: revoke_during_mint_cookie_returned=True). 분산 락 없이 이 창을
+    # 완전히 닫는 산티아고의 정확한 해법 — **cookie를 반환하기 직전 세 번째 authoritative
+    # 재조회**. revoke가 mint 이전/도중에 커밋됐으면 이 조회가 잡고, 만에 하나 이 조회 "이후"에
+    # revoke가 커밋되더라도 방금 mint된 Firebase 세션쿠키 자체의 auth_time은 여전히 revoke
+    # 이전이므로 이후 모든 요청에서 통상 verifier(`_resolve_firebase_session`)가 거부한다 —
+    # 즉 네트워크 구간 전체가 이 시점 기준으로 닫힌다. 재확인 실패 시 이미 mint된 cookie는
+    # 폐기(반환하지 않는다 — Firebase 측에 남은 세션 자체는 최초 auth_valid_after 갱신 시의
+    # best-effort user-wide revoke가 이미 정리를 시도했었고, 로컬이 어차피 이 값을 안 돌려주면
+    # 클라이언트가 쓸 수 없다).
+    migration_after_mint = await db.get(AuthMigration, consumed.user_id, populate_existing=True)
+    if (
+        migration_after_mint is None
+        or migration_after_mint.state not in ("provisioning", "firebase")
+        or is_before_cutover(migration_after_mint.auth_valid_after, consumed.auth_time)
+    ):
+        logger.warning("auth.native_bootstrap.consume rejected reason=revoked_during_mint")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Session revoked")
 
     logger.info("auth.native_bootstrap.consume success")
     return NativeBootstrapConsumeResponse(session_cookie=session_cookie, expires_in=valid_duration_seconds)

--- a/backend/app/routers/auth_native_bootstrap.py
+++ b/backend/app/routers/auth_native_bootstrap.py
@@ -25,9 +25,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.core.rate_limit import limiter
 from app.dependencies.database import get_db
-from app.models.auth_identity import AuthIdentity
+from app.models.auth_identity import AuthIdentity, AuthMigration
 from app.models.device_installation import DeviceInstallation
 from app.models.user import User
+from app.services.auth_cutover import is_before_cutover
 from app.services.device_proof import (
     PURPOSE_BOOTSTRAP_ISSUE,
     TTL_BOOTSTRAP_ISSUE_SECONDS,
@@ -114,6 +115,21 @@ async def native_bootstrap(
         logger.warning("auth.native_bootstrap rejected reason=inactive_or_missing_user")
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid user")
 
+    # story bea25062(§17d-1 RED 조건 ②⑥): 이전엔 이 issue 엔드포인트가 migration state/cutover
+    # epoch를 전혀 안 봤다(consume에만 있던 검사) — provisioning/firebase가 아닌 사용자(예:
+    # reset_required)도 코드를 발급받을 수 있었고, revoke 이후 예전 ID token으로도 발급이
+    # 통과했다(BLOCKER 2 공격의 첫 단계). issue 시점에도 consume과 동일한 state+cutover
+    # 검사를 강제 — auth_time은 이 코드에 원본 값으로 저장돼 consume 시 재검증된다.
+    migration = await db.get(AuthMigration, identity_row.user_id)
+    if migration is None or migration.state not in ("provisioning", "firebase"):
+        logger.warning("auth.native_bootstrap rejected reason=ineligible_migration_state")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Account not eligible")
+
+    auth_time_dt = datetime.fromtimestamp(verified.auth_time, tz=timezone.utc)
+    if is_before_cutover(migration.auth_valid_after, auth_time_dt):
+        logger.warning("auth.native_bootstrap rejected reason=before_cutover")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Session revoked")
+
     device_binding_hash: str | None = None
     if settings.firebase_auth_mobile_app_check_required and not body.app_check_token:
         logger.warning("auth.native_bootstrap rejected reason=app_check_required_missing")
@@ -137,6 +153,7 @@ async def native_bootstrap(
         project_id=settings.firebase_project_id,
         device_binding_hash=device_binding_hash,
         ttl_seconds=DEFAULT_TTL_SECONDS,
+        auth_time=auth_time_dt,
     )
     logger.info("auth.native_bootstrap success")
     return NativeBootstrapResponse(code=code, expires_in=DEFAULT_TTL_SECONDS)

--- a/backend/app/services/auth_cutover.py
+++ b/backend/app/services/auth_cutover.py
@@ -18,79 +18,31 @@ defense-in-depth" — 순서가 중요하다. 로컬 auth_valid_after 기록+leg
 재시도(Firebase 쪽 user-wide revoke가 끝내 실패해 남아있는 상태를 감지/재시도)는 Phase 4
 대량 cutover 운영 도구(Story B) 스코프다.
 
-⚠️**성능 트레이드오프(자체 발견, Santiago 리뷰에서 판단 필요)**: `_reject_if_before_cutover`가
-매 legacy/Firebase 요청마다 DB를 직접 조회하면, revoke가 단 한 번도 없는 정상 상태(오늘의
-현실 — 사용자 전원)에서도 **인증된 모든 요청에 DB 왕복 1회가 영구히 추가**된다(원래 legacy
-JWT 검증은 서명/exp만 보고 DB를 전혀 안 건드렸다). `check_any_cutover_epoch_exists()`로
-"지금까지 단 한 명이라도 revoke된 적 있는가"를 프로세스 전역 짧은 캐시(기본 30초)로 먼저
-확인해 — **없으면(현재 100% 상태) DB를 아예 안 건드리고 즉시 통과**, 있으면(실제 보안
-이벤트 발생 후) 그때부터 사용자별 정밀 검사로 전환한다. `revoke_user_sessions()` 호출
-즉시 같은 프로세스의 캐시는 True로 갱신되지만, **다른 Cloud Run 인스턴스는 캐시 TTL(최대
-30초)까지 갱신이 늦을 수 있다** — 이는 §17d-1이 요구하는 "즉시" fail-closed보다 느슨한
-근사치다. 다만 legacy refresh_tokens 일괄 revoke는 이 캐시와 무관하게 즉시 커밋되므로
-"revoke된 사용자가 신규 refresh는 절대 못 받는다"는 이미 즉시 보장되고, 이 캐시가 관장하는
-건 "이미 발급된, 아직 안 만료된 access token(최대 60분)"의 즉시성뿐이다 — 캐시 없는 현재
-설계(access token은 revoke 개념 자체가 아예 없음, doc H2 finding)보다는 명백히 개선.
+⚠️**HEAD 98d65136 RED 포워딩(산티아고·2026-07-16) BLOCKER 1 시정**: 최초 구현은 여기에
+프로세스-전역 30초 negative existence-cache를 뒀다("revoke가 한 번도 없으면 DB 무접촉") —
+산티아고 직접 probe로 (a) 다른 Cloud Run 인스턴스는 revoke 후 최대 30초까지 캐시가 갱신 안
+돼 이미 발급된 pre-cutover 토큰이 통과하고 (b) 콜드 스타트/캐시 만료 중 DB 조회 실패 시
+기본값 False를 반환해 **fail-open**(§17d-1이 요구하는 "즉시 local fail-closed authority"의
+정면 위반)임을 실증했다. **캐시를 완전히 제거**한다 — `_reject_if_before_cutover`는 매
+legacy/Firebase/SSE 요청마다 `AuthMigration`을 PK(user_id) 인덱스 조회로 직접 확인하고,
+DB 조회 자체가 실패하면 예외를 그대로 전파해(auth 요청 실패) 절대 "허용"으로 떨어지지
+않는다. 매 인증 요청에 DB 왕복 1회가 영구히 추가되는 성능 트레이드오프를 감수한다 —
+산티아고가 명시적으로 이 최적화를 기각(공유 authoritative 캐시 없인 process-local TTL
+불가 판정).
 """
 from __future__ import annotations
 
 import logging
-import time
 from datetime import datetime, timezone
 
-from sqlalchemy import select, update
+from sqlalchemy import func, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.auth_identity import AuthMigration
 from app.models.user import RefreshToken
 
 logger = logging.getLogger(__name__)
-
-_ANY_CUTOVER_CACHE_SECONDS = 30
-_any_cutover_epoch_exists: bool = False
-_any_cutover_cache_expires_at: float = 0.0
-
-
-def _reset_cutover_existence_cache_for_tests() -> None:
-    """테스트 전용 — 프로세스 전역 캐시가 테스트 간 상태를 누출하지 않도록 초기화."""
-    global _any_cutover_epoch_exists, _any_cutover_cache_expires_at
-    _any_cutover_epoch_exists = False
-    _any_cutover_cache_expires_at = 0.0
-
-
-async def check_any_cutover_epoch_exists() -> bool:
-    """전역 짧은-TTL 캐시 — auth_migrations에 auth_valid_after가 채워진 행이 하나라도
-    있는지. False(현재 사실상 항상 이 값)면 호출부가 사용자별 DB 조회를 완전히 생략할 수
-    있다. 요청의 db 세션을 재사용하지 않고 자체 단명 세션을 연다(캐시 값은 어느 요청과도
-    무관한 프로세스 전역 상태라 특정 요청의 db 객체에 의존하면 안 됨 — mock/None db로
-    호출되는 기존 단위 테스트들과도 독립적이어야 하는 이유)."""
-    global _any_cutover_epoch_exists, _any_cutover_cache_expires_at
-    now = time.time()
-    if _any_cutover_cache_expires_at > now:
-        return _any_cutover_epoch_exists
-
-    from app.core.database import async_session_factory
-
-    try:
-        async with async_session_factory() as db:
-            exists = (
-                await db.execute(
-                    select(AuthMigration.user_id).where(AuthMigration.auth_valid_after.is_not(None)).limit(1)
-                )
-            ).scalar_one_or_none() is not None
-    except Exception:
-        # DB 접속 불가 시 이 존재-확인 자체를 실패로 raise하면, 원래 DB를 전혀 안 건드리던
-        # legacy JWT 검증 경로가 이 최적화 캐시 하나 때문에 죽는다(자체 발견 — mock/None db
-        # 단위 테스트뿐 아니라 실 배포에서도 DB 일시 장애가 무관한 인증 전체를 막으면 안 됨).
-        # 직전 캐시값을 그대로 유지하고(콜드 스타트면 기본 False=과거 100% 동작과 동일) 짧게
-        # 재시도하도록 만료시각만 소폭 미룬다.
-        logger.warning("auth.cutover.check_any_cutover_epoch_exists db_unavailable_fallback")
-        _any_cutover_cache_expires_at = now + _ANY_CUTOVER_CACHE_SECONDS
-        return _any_cutover_epoch_exists
-
-    _any_cutover_epoch_exists = exists
-    _any_cutover_cache_expires_at = now + _ANY_CUTOVER_CACHE_SECONDS
-    return exists
 
 
 def is_before_cutover(auth_valid_after: datetime | None, reference_time: datetime) -> bool:
@@ -112,18 +64,25 @@ async def revoke_user_sessions(db: AsyncSession, user_id, *, firebase_uid: str |
     """단일 사용자 revoke primitive(§17d-1 ①②③, 대량 코호트 버전 아님 — Story B).
 
     1. auth_valid_after=now() 기록(행 없으면 생성) — **먼저 커밋**, 이게 즉시 fail-closed 통제.
+       ⚠️산티아고 RED 조건 ⑦: ORM `get()`+조건부 mutate는 (a) 동시 두 revoke가 모두 "행 없음"을
+       보고 동시 insert 시도하는 race, (b) 늦게 커밋된 오래된 epoch가 이미 기록된 더 최신
+       epoch를 덮어쓰는 monotonicity 위반 둘 다에 취약하다. 단일 원자 UPSERT
+       (`INSERT...ON CONFLICT(user_id) DO UPDATE SET auth_valid_after=GREATEST(...)`)로 교체 —
+       PG가 충돌 시 row-level lock으로 직렬화하고, GREATEST가 "이 revoke가 기존 epoch보다
+       늦더라도 절대 앞당겨지지 않는다"를 보장한다(NULL은 GREATEST가 무시 — 최초 삽입도 그대로
+       동작).
     2. 해당 사용자 live legacy refresh_tokens 일괄 revoked_at=now().
     3. (커밋 후, best-effort) Firebase user-wide revoke — 실패해도 1·2가 이미 효력이 있어
        접근 허용으로 이어지지 않는다.
     """
     epoch = datetime.now(timezone.utc)
 
-    migration = await db.get(AuthMigration, user_id)
-    if migration is None:
-        migration = AuthMigration(user_id=user_id, state="legacy", auth_valid_after=epoch)
-        db.add(migration)
-    else:
-        migration.auth_valid_after = epoch
+    upsert = pg_insert(AuthMigration).values(user_id=user_id, state="legacy", auth_valid_after=epoch)
+    upsert = upsert.on_conflict_do_update(
+        index_elements=[AuthMigration.user_id],
+        set_={"auth_valid_after": func.greatest(AuthMigration.auth_valid_after, upsert.excluded.auth_valid_after)},
+    ).returning(AuthMigration.auth_valid_after)
+    stored_epoch = (await db.execute(upsert)).scalar_one()
 
     await db.execute(
         update(RefreshToken)
@@ -132,12 +91,6 @@ async def revoke_user_sessions(db: AsyncSession, user_id, *, firebase_uid: str |
     )
     await db.commit()
     logger.info("auth.cutover.revoke_user_sessions local_committed")
-
-    # 이 프로세스는 즉시 정밀검사 모드로 전환(다른 인스턴스는 캐시 TTL까지 지연 — 모듈
-    # 상단 docstring의 성능/즉시성 트레이드오프 설명 참조).
-    global _any_cutover_epoch_exists, _any_cutover_cache_expires_at
-    _any_cutover_epoch_exists = True
-    _any_cutover_cache_expires_at = time.time() + _ANY_CUTOVER_CACHE_SECONDS
 
     if firebase_uid:
         from app.core.config import settings
@@ -150,4 +103,7 @@ async def revoke_user_sessions(db: AsyncSession, user_id, *, firebase_uid: str |
         except Exception:
             logger.warning("auth.cutover.revoke_user_sessions firebase_revoke_exception")
 
-    return epoch
+    # stored_epoch(DB의 최종 authoritative 값)를 반환 — 동시 revoke 중 이 호출보다 늦게
+    # 커밋된 더 최신 epoch가 이미 있었다면 GREATEST가 그걸 보존했을 수 있어 epoch와 다를
+    # 수 있다(monotonicity 보장의 직접적 증거).
+    return stored_epoch

--- a/backend/app/services/auth_cutover.py
+++ b/backend/app/services/auth_cutover.py
@@ -1,0 +1,153 @@
+"""story bea25062(E-AUTH-REBUILD auth_valid_after 코어 인프라·doc firebase-poc-q12-didi-
+measurements §17d-1): cutover epoch authority — 활성화 게이트(6ae1ecac AC#2)와 Phase 4
+coordinated forced reset의 공통 근본. 산티아고 §17d-1 "판정: 정합하다"를 그대로 구현한다.
+
+**한 컬럼(`auth_migrations.auth_valid_after`)으로 두 용도를 표현**: 단일 사용자 보안 이벤트
+revoke(이 모듈의 `revoke_user_sessions()`)와 Phase 4 대량 코호트 cutover(Story B, 별도)가
+같은 검사 로직(`is_before_cutover`)을 공유한다.
+
+⚠️§17d-1 명시: "로컬 epoch/state가 즉시 fail-closed 통제, Firebase revoke는 user-wide
+defense-in-depth" — 순서가 중요하다. 로컬 auth_valid_after 기록+legacy RT revoke를 먼저
+커밋해 즉시 효력을 발생시킨 뒤, Firebase revoke는 그 바깥에서 best-effort로 시도한다
+(Firebase API 실패가 로컬 fail-closed를 막으면 안 됨 — DB 트랜잭션 안에 넣지 않는 이유).
+
+**이번 스코프 축소 표기**: §17d-1이 요구하는 "idempotent outbox/retry"의 완전한 영속 재시도
+큐(실패 시 나중에 자동 재시도)는 이 스토리엔 없다 — Firebase 호출은 1회 best-effort이고
+실패는 로그만 남긴다. 로컬 epoch가 이미 authoritative fail-closed 통제이므로 이것만으로도
+§17d-1의 "Firebase 실패가 접근 허용으로 이어지지 않는다" 요구는 충족되지만, 진짜 영속
+재시도(Firebase 쪽 user-wide revoke가 끝내 실패해 남아있는 상태를 감지/재시도)는 Phase 4
+대량 cutover 운영 도구(Story B) 스코프다.
+
+⚠️**성능 트레이드오프(자체 발견, Santiago 리뷰에서 판단 필요)**: `_reject_if_before_cutover`가
+매 legacy/Firebase 요청마다 DB를 직접 조회하면, revoke가 단 한 번도 없는 정상 상태(오늘의
+현실 — 사용자 전원)에서도 **인증된 모든 요청에 DB 왕복 1회가 영구히 추가**된다(원래 legacy
+JWT 검증은 서명/exp만 보고 DB를 전혀 안 건드렸다). `check_any_cutover_epoch_exists()`로
+"지금까지 단 한 명이라도 revoke된 적 있는가"를 프로세스 전역 짧은 캐시(기본 30초)로 먼저
+확인해 — **없으면(현재 100% 상태) DB를 아예 안 건드리고 즉시 통과**, 있으면(실제 보안
+이벤트 발생 후) 그때부터 사용자별 정밀 검사로 전환한다. `revoke_user_sessions()` 호출
+즉시 같은 프로세스의 캐시는 True로 갱신되지만, **다른 Cloud Run 인스턴스는 캐시 TTL(최대
+30초)까지 갱신이 늦을 수 있다** — 이는 §17d-1이 요구하는 "즉시" fail-closed보다 느슨한
+근사치다. 다만 legacy refresh_tokens 일괄 revoke는 이 캐시와 무관하게 즉시 커밋되므로
+"revoke된 사용자가 신규 refresh는 절대 못 받는다"는 이미 즉시 보장되고, 이 캐시가 관장하는
+건 "이미 발급된, 아직 안 만료된 access token(최대 60분)"의 즉시성뿐이다 — 캐시 없는 현재
+설계(access token은 revoke 개념 자체가 아예 없음, doc H2 finding)보다는 명백히 개선.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timezone
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.auth_identity import AuthMigration
+from app.models.user import RefreshToken
+
+logger = logging.getLogger(__name__)
+
+_ANY_CUTOVER_CACHE_SECONDS = 30
+_any_cutover_epoch_exists: bool = False
+_any_cutover_cache_expires_at: float = 0.0
+
+
+def _reset_cutover_existence_cache_for_tests() -> None:
+    """테스트 전용 — 프로세스 전역 캐시가 테스트 간 상태를 누출하지 않도록 초기화."""
+    global _any_cutover_epoch_exists, _any_cutover_cache_expires_at
+    _any_cutover_epoch_exists = False
+    _any_cutover_cache_expires_at = 0.0
+
+
+async def check_any_cutover_epoch_exists() -> bool:
+    """전역 짧은-TTL 캐시 — auth_migrations에 auth_valid_after가 채워진 행이 하나라도
+    있는지. False(현재 사실상 항상 이 값)면 호출부가 사용자별 DB 조회를 완전히 생략할 수
+    있다. 요청의 db 세션을 재사용하지 않고 자체 단명 세션을 연다(캐시 값은 어느 요청과도
+    무관한 프로세스 전역 상태라 특정 요청의 db 객체에 의존하면 안 됨 — mock/None db로
+    호출되는 기존 단위 테스트들과도 독립적이어야 하는 이유)."""
+    global _any_cutover_epoch_exists, _any_cutover_cache_expires_at
+    now = time.time()
+    if _any_cutover_cache_expires_at > now:
+        return _any_cutover_epoch_exists
+
+    from app.core.database import async_session_factory
+
+    try:
+        async with async_session_factory() as db:
+            exists = (
+                await db.execute(
+                    select(AuthMigration.user_id).where(AuthMigration.auth_valid_after.is_not(None)).limit(1)
+                )
+            ).scalar_one_or_none() is not None
+    except Exception:
+        # DB 접속 불가 시 이 존재-확인 자체를 실패로 raise하면, 원래 DB를 전혀 안 건드리던
+        # legacy JWT 검증 경로가 이 최적화 캐시 하나 때문에 죽는다(자체 발견 — mock/None db
+        # 단위 테스트뿐 아니라 실 배포에서도 DB 일시 장애가 무관한 인증 전체를 막으면 안 됨).
+        # 직전 캐시값을 그대로 유지하고(콜드 스타트면 기본 False=과거 100% 동작과 동일) 짧게
+        # 재시도하도록 만료시각만 소폭 미룬다.
+        logger.warning("auth.cutover.check_any_cutover_epoch_exists db_unavailable_fallback")
+        _any_cutover_cache_expires_at = now + _ANY_CUTOVER_CACHE_SECONDS
+        return _any_cutover_epoch_exists
+
+    _any_cutover_epoch_exists = exists
+    _any_cutover_cache_expires_at = now + _ANY_CUTOVER_CACHE_SECONDS
+    return exists
+
+
+def is_before_cutover(auth_valid_after: datetime | None, reference_time: datetime) -> bool:
+    """reference_time(토큰 iat/auth_time/코드 발급시각)이 cutover epoch 이전(또는 동일)이면
+    True(거부 대상). auth_valid_after가 None이면 제약 없음(False, 항상 통과)."""
+    if auth_valid_after is None:
+        return False
+    return reference_time <= auth_valid_after
+
+
+async def get_auth_valid_after(db: AsyncSession, user_id) -> datetime | None:
+    """AuthMigration 행이 없으면(Phase 1~3 cohort 미편입 대부분의 현재 사용자) None —
+    제약 없음과 동일하게 취급(기존 동작 무변화)."""
+    migration = await db.get(AuthMigration, user_id)
+    return migration.auth_valid_after if migration is not None else None
+
+
+async def revoke_user_sessions(db: AsyncSession, user_id, *, firebase_uid: str | None = None) -> datetime:
+    """단일 사용자 revoke primitive(§17d-1 ①②③, 대량 코호트 버전 아님 — Story B).
+
+    1. auth_valid_after=now() 기록(행 없으면 생성) — **먼저 커밋**, 이게 즉시 fail-closed 통제.
+    2. 해당 사용자 live legacy refresh_tokens 일괄 revoked_at=now().
+    3. (커밋 후, best-effort) Firebase user-wide revoke — 실패해도 1·2가 이미 효력이 있어
+       접근 허용으로 이어지지 않는다.
+    """
+    epoch = datetime.now(timezone.utc)
+
+    migration = await db.get(AuthMigration, user_id)
+    if migration is None:
+        migration = AuthMigration(user_id=user_id, state="legacy", auth_valid_after=epoch)
+        db.add(migration)
+    else:
+        migration.auth_valid_after = epoch
+
+    await db.execute(
+        update(RefreshToken)
+        .where(RefreshToken.user_id == user_id, RefreshToken.revoked_at.is_(None))
+        .values(revoked_at=epoch)
+    )
+    await db.commit()
+    logger.info("auth.cutover.revoke_user_sessions local_committed")
+
+    # 이 프로세스는 즉시 정밀검사 모드로 전환(다른 인스턴스는 캐시 TTL까지 지연 — 모듈
+    # 상단 docstring의 성능/즉시성 트레이드오프 설명 참조).
+    global _any_cutover_epoch_exists, _any_cutover_cache_expires_at
+    _any_cutover_epoch_exists = True
+    _any_cutover_cache_expires_at = time.time() + _ANY_CUTOVER_CACHE_SECONDS
+
+    if firebase_uid:
+        from app.core.config import settings
+        from app.services.firebase_session_mint import revoke_firebase_refresh_tokens
+
+        try:
+            ok = await revoke_firebase_refresh_tokens(firebase_uid, settings.firebase_project_id)
+            if not ok:
+                logger.warning("auth.cutover.revoke_user_sessions firebase_revoke_failed")
+        except Exception:
+            logger.warning("auth.cutover.revoke_user_sessions firebase_revoke_exception")
+
+    return epoch

--- a/backend/app/services/firebase_session_mint.py
+++ b/backend/app/services/firebase_session_mint.py
@@ -35,6 +35,7 @@ _SIGN_IN_WITH_CUSTOM_TOKEN_URL_TEMPLATE = (
 _CUSTOM_TOKEN_AUDIENCE = (
     "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit"
 )
+_ACCOUNTS_UPDATE_URL_TEMPLATE = "https://identitytoolkit.googleapis.com/v1/projects/{project_id}/accounts:update"
 
 
 def _get_access_token() -> str:
@@ -192,3 +193,40 @@ async def mint_session_cookie_for_uid(
     if id_token is None:
         return None
     return await mint_session_cookie(id_token, project_id, valid_duration_seconds)
+
+
+async def _call_accounts_update_valid_since(access_token: str, uid: str, project_id: str) -> httpx.Response:
+    """실 Google REST 호출 지점 — 테스트에서 모킹. `validSince`를 현재 시각으로 설정하면
+    그 이전에 발급된 모든 refresh token이 무효화된다(Admin SDK `revokeRefreshTokens(uid)`와
+    동등한 REST 형태 — 공식 문서: https://firebase.google.com/docs/auth/admin/manage-sessions)."""
+    url = _ACCOUNTS_UPDATE_URL_TEMPLATE.format(project_id=project_id)
+    async with httpx.AsyncClient() as client:
+        return await client.post(
+            url,
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={"localId": uid, "validSince": str(int(time.time()))},
+        )
+
+
+async def revoke_firebase_refresh_tokens(firebase_uid: str, project_id: str) -> bool:
+    """story bea25062(§17d-1 ③): Firebase user-wide refresh token revoke. best-effort —
+    실패해도 로컬 auth_valid_after가 이미 authoritative fail-closed 통제이므로 호출부가
+    이 결과로 접근을 허용/거부하지 않는다(로깅만). ⛔uid/응답 값은 로그에 남기지 않는다."""
+    try:
+        access_token = _get_access_token()
+    except Exception:
+        logger.warning("auth.firebase.revoke failed reason=adc_token_unavailable")
+        return False
+
+    try:
+        response = await _call_accounts_update_valid_since(access_token, firebase_uid, project_id)
+    except httpx.HTTPError:
+        logger.warning("auth.firebase.revoke failed reason=network_error")
+        return False
+
+    if response.status_code != 200:
+        logger.warning("auth.firebase.revoke failed reason=google_rejected status=%d", response.status_code)
+        return False
+
+    logger.info("auth.firebase.revoke success")
+    return True

--- a/backend/app/services/native_bootstrap.py
+++ b/backend/app/services/native_bootstrap.py
@@ -61,6 +61,7 @@ async def issue_bootstrap_code(
 class ConsumedBootstrapCode:
     user_id: object
     firebase_uid: str
+    created_at: datetime  # story bea25062: 발급 시각 — cutover epoch 비교의 기준 시점
 
 
 async def consume_bootstrap_code(
@@ -93,11 +94,15 @@ async def consume_bootstrap_code(
         update(AuthNativeBootstrapCode)
         .where(*conditions)
         .values(consumed_at=now)
-        .returning(AuthNativeBootstrapCode.user_id, AuthNativeBootstrapCode.firebase_uid)
+        .returning(
+            AuthNativeBootstrapCode.user_id,
+            AuthNativeBootstrapCode.firebase_uid,
+            AuthNativeBootstrapCode.created_at,
+        )
     )
     result = await db.execute(stmt)
     row = result.first()
     await db.commit()
     if row is None:
         return None
-    return ConsumedBootstrapCode(user_id=row[0], firebase_uid=row[1])
+    return ConsumedBootstrapCode(user_id=row[0], firebase_uid=row[1], created_at=row[2])

--- a/backend/app/services/native_bootstrap.py
+++ b/backend/app/services/native_bootstrap.py
@@ -38,9 +38,15 @@ async def issue_bootstrap_code(
     project_id: str,
     device_binding_hash: str | None = None,
     ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    auth_time: datetime | None = None,
 ) -> str:
     """raw code를 반환 — 이 함수 반환 이후로는 raw code가 어디에도 다시 나타나지 않는다
-    (DB엔 hash만, 로그에도 절대 남기지 않는다 — 호출부 책임)."""
+    (DB엔 hash만, 로그에도 절대 남기지 않는다 — 호출부 책임).
+
+    ⚠️story bea25062(§17d-1 BLOCKER 2): `auth_time`은 이 코드 발급의 근거가 된 원본 Firebase
+    ID token의 실제 인증 시각 — 호출부(`native_bootstrap()` 엔드포인트)가 반드시 검증된
+    토큰에서 뽑아 전달해야 한다(전달하지 않으면 이후 cutover 재검증이 무력화된다 — 호출부
+    책임이라 여기선 required 취급을 강제하지 않되 auth_native_bootstrap.py는 항상 채워 넣는다)."""
     code = secrets.token_urlsafe(32)  # 256bit 이상 엔트로피
     now = datetime.now(timezone.utc)
     row = AuthNativeBootstrapCode(
@@ -49,6 +55,7 @@ async def issue_bootstrap_code(
         project_id=project_id,
         code_hash=_hash_code(code),
         device_binding_hash=device_binding_hash,
+        auth_time=auth_time,
         created_at=now,
         expires_at=now + timedelta(seconds=ttl_seconds),
     )
@@ -61,7 +68,8 @@ async def issue_bootstrap_code(
 class ConsumedBootstrapCode:
     user_id: object
     firebase_uid: str
-    created_at: datetime  # story bea25062: 발급 시각 — cutover epoch 비교의 기준 시점
+    created_at: datetime  # 코드 발급 시각(TTL/감사용) — cutover 비교엔 쓰지 않는다.
+    auth_time: datetime | None  # story bea25062: 원본 ID token 인증 시각 — cutover 비교 기준.
 
 
 async def consume_bootstrap_code(
@@ -98,6 +106,7 @@ async def consume_bootstrap_code(
             AuthNativeBootstrapCode.user_id,
             AuthNativeBootstrapCode.firebase_uid,
             AuthNativeBootstrapCode.created_at,
+            AuthNativeBootstrapCode.auth_time,
         )
     )
     result = await db.execute(stmt)
@@ -105,4 +114,4 @@ async def consume_bootstrap_code(
     await db.commit()
     if row is None:
         return None
-    return ConsumedBootstrapCode(user_id=row[0], firebase_uid=row[1], created_at=row[2])
+    return ConsumedBootstrapCode(user_id=row[0], firebase_uid=row[1], created_at=row[2], auth_time=row[3])

--- a/backend/tests/test_bea25062_auth_cutover_service.py
+++ b/backend/tests/test_bea25062_auth_cutover_service.py
@@ -1,0 +1,185 @@
+"""story bea25062(E-AUTH-REBUILD auth_valid_after 코어 인프라·doc §17d-1) 계약 테스트:
+is_before_cutover() 순수함수+get_auth_valid_after()/revoke_user_sessions() realdb.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark_realdb = pytest.mark.skipif(
+    not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_is_before_cutover_none_epoch_always_false():
+    from app.services.auth_cutover import is_before_cutover
+    now = datetime.now(timezone.utc)
+    assert is_before_cutover(None, now) is False
+
+
+def test_is_before_cutover_reference_before_epoch_true():
+    from app.services.auth_cutover import is_before_cutover
+    epoch = datetime.now(timezone.utc)
+    before = epoch - timedelta(seconds=1)
+    assert is_before_cutover(epoch, before) is True
+
+
+def test_is_before_cutover_reference_equal_epoch_true():
+    """§17d-1: iat/auth_time <= auth_valid_after면 거부(동일 시각 포함)."""
+    from app.services.auth_cutover import is_before_cutover
+    epoch = datetime.now(timezone.utc)
+    assert is_before_cutover(epoch, epoch) is True
+
+
+def test_is_before_cutover_reference_after_epoch_false():
+    from app.services.auth_cutover import is_before_cutover
+    epoch = datetime.now(timezone.utc)
+    after = epoch + timedelta(seconds=1)
+    assert is_before_cutover(epoch, after) is False
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            url = "postgresql+asyncpg://" + url[len(prefix):]
+            break
+    engine = create_async_engine(url)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_user_with_refresh_tokens(session, *, n_tokens: int = 2):
+    from app.core.security import hash_password
+    from app.models.user import RefreshToken, User
+
+    user_id = uuid.uuid4()
+    session.add(User(
+        id=user_id, email=f"cutover-{user_id.hex[:8]}@test.com",
+        hashed_password=hash_password("x"), is_active=True, email_verified=True,
+    ))
+    await session.commit()
+
+    now = datetime.now(timezone.utc)
+    for i in range(n_tokens):
+        session.add(RefreshToken(
+            id=uuid.uuid4(), user_id=user_id, token_hash=f"hash-{user_id.hex[:8]}-{i}",
+            expires_at=now + timedelta(days=30),
+        ))
+    await session.commit()
+    return user_id
+
+
+@pytestmark_realdb
+@pytest.mark.anyio
+async def test_get_auth_valid_after_none_when_no_migration_row():
+    from app.services.auth_cutover import get_auth_valid_after
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            result = await get_auth_valid_after(s, uuid.uuid4())
+        assert result is None
+    finally:
+        await engine.dispose()
+
+
+@pytestmark_realdb
+@pytest.mark.anyio
+async def test_revoke_user_sessions_creates_migration_row_and_revokes_refresh_tokens(monkeypatch):
+    from sqlalchemy import select
+    from app.models.auth_identity import AuthMigration
+    from app.models.user import RefreshToken
+    from app.services.auth_cutover import get_auth_valid_after, revoke_user_sessions
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_user_with_refresh_tokens(s, n_tokens=3)
+
+        async with Session() as s:
+            epoch = await revoke_user_sessions(s, user_id, firebase_uid=None)
+        assert epoch is not None
+
+        async with Session() as s:
+            stored = await get_auth_valid_after(s, user_id)
+            assert stored is not None
+            assert abs((stored - epoch).total_seconds()) < 1
+
+            live_count = (await s.execute(
+                select(RefreshToken).where(RefreshToken.user_id == user_id, RefreshToken.revoked_at.is_(None))
+            )).scalars().all()
+            assert len(live_count) == 0
+
+            revoked_count = (await s.execute(
+                select(RefreshToken).where(RefreshToken.user_id == user_id, RefreshToken.revoked_at.is_not(None))
+            )).scalars().all()
+            assert len(revoked_count) == 3
+
+            migration_row = await s.get(AuthMigration, user_id)
+            assert migration_row is not None
+    finally:
+        await engine.dispose()
+
+
+@pytestmark_realdb
+@pytest.mark.anyio
+async def test_revoke_user_sessions_updates_existing_migration_row():
+    from app.models.auth_identity import AuthMigration
+    from app.services.auth_cutover import revoke_user_sessions
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_user_with_refresh_tokens(s, n_tokens=0)
+            s.add(AuthMigration(user_id=user_id, state="firebase"))
+            await s.commit()
+
+        async with Session() as s:
+            epoch = await revoke_user_sessions(s, user_id, firebase_uid=None)
+
+        async with Session() as s:
+            migration_row = await s.get(AuthMigration, user_id)
+            assert migration_row.state == "firebase"  # revoke가 state를 안 건드림
+            assert migration_row.auth_valid_after is not None
+            assert abs((migration_row.auth_valid_after - epoch).total_seconds()) < 1
+    finally:
+        await engine.dispose()
+
+
+@pytestmark_realdb
+@pytest.mark.anyio
+async def test_revoke_user_sessions_local_commit_survives_firebase_failure(monkeypatch):
+    """§17d-1: Firebase revoke 실패해도 로컬 auth_valid_after+RT revoke는 이미 커밋됨(순서 보장)."""
+    from app.services.auth_cutover import get_auth_valid_after, revoke_user_sessions
+
+    async def fake_revoke_firebase(firebase_uid, project_id):
+        raise RuntimeError("simulated Firebase outage")
+    monkeypatch.setattr(
+        "app.services.firebase_session_mint.revoke_firebase_refresh_tokens", fake_revoke_firebase
+    )
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_user_with_refresh_tokens(s, n_tokens=1)
+
+        async with Session() as s:
+            epoch = await revoke_user_sessions(s, user_id, firebase_uid="fb-uid-1")
+        assert epoch is not None
+
+        async with Session() as s:
+            stored = await get_auth_valid_after(s, user_id)
+            assert stored is not None
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_bea25062_auth_cutover_service.py
+++ b/backend/tests/test_bea25062_auth_cutover_service.py
@@ -159,6 +159,65 @@ async def test_revoke_user_sessions_updates_existing_migration_row():
 
 @pytestmark_realdb
 @pytest.mark.anyio
+async def test_revoke_user_sessions_epoch_monotonic_under_out_of_order_commits():
+    """산티아고 RED 조건 ⑦: 늦게 커밋된(하지만 논리적으로 더 이른) epoch가 이미 기록된
+    더 최신 epoch를 절대 되돌리지 않는다 — atomic UPSERT+GREATEST 실증. 실제 asyncio 동시
+    실행 대신, "먼저 더 최신 epoch를 커밋 → 그다음 더 이른 epoch로 재호출"의 역순 시나리오로
+    GREATEST의 단조성 보장을 직접 증명한다(진짜 동시성 인터리빙과 동일한 SQL 레벨 보장)."""
+    from app.services.auth_cutover import get_auth_valid_after, revoke_user_sessions
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_user_with_refresh_tokens(s, n_tokens=0)
+
+        # 1차: "최신" epoch를 먼저 커밋(마치 나중 이벤트가 먼저 도착한 것처럼).
+        async with Session() as s:
+            later_epoch = await revoke_user_sessions(s, user_id, firebase_uid=None)
+
+        # 2차: 그보다 "이른" epoch로 재호출 — DB의 GREATEST가 이미 기록된 later_epoch를
+        # 지켜야 한다(단순 대입이었다면 이 호출이 epoch를 되돌렸을 것).
+        async def fake_revoke_firebase(firebase_uid, project_id):
+            return True
+        import app.services.firebase_session_mint as mint_mod
+        original = mint_mod.revoke_firebase_refresh_tokens
+        mint_mod.revoke_firebase_refresh_tokens = fake_revoke_firebase
+        try:
+            async with Session() as s:
+                # revoke_user_sessions는 항상 datetime.now()를 쓰므로, 이 두번째 호출의 raw
+                # epoch는 실제로는 later_epoch보다 "늦다"(시간은 항상 전진) — 진짜 역전을
+                # 시뮬레이션하려면 DB에 직접 더 이른 값으로 먼저 심어두고 upsert로 검증한다.
+                from app.models.auth_identity import AuthMigration
+                stale_earlier = later_epoch - timedelta(seconds=30)
+                from sqlalchemy import func
+                from sqlalchemy.dialects.postgresql import insert as pg_insert
+                stmt = pg_insert(AuthMigration).values(
+                    user_id=user_id, state="legacy", auth_valid_after=stale_earlier
+                ).on_conflict_do_update(
+                    index_elements=[AuthMigration.user_id],
+                    set_={"auth_valid_after": func.greatest(
+                        AuthMigration.auth_valid_after,
+                        pg_insert(AuthMigration).values(
+                            user_id=user_id, state="legacy", auth_valid_after=stale_earlier
+                        ).excluded.auth_valid_after,
+                    )},
+                )
+                await s.execute(stmt)
+                await s.commit()
+        finally:
+            mint_mod.revoke_firebase_refresh_tokens = original
+
+        async with Session() as s:
+            final = await get_auth_valid_after(s, user_id)
+            # stale_earlier(later_epoch보다 30초 이른 값)를 upsert 시도해도 GREATEST가
+            # 기존 later_epoch를 지켰어야 한다 — 절대 되돌아가지 않는다.
+            assert final == later_epoch
+    finally:
+        await engine.dispose()
+
+
+@pytestmark_realdb
+@pytest.mark.anyio
 async def test_revoke_user_sessions_local_commit_survives_firebase_failure(monkeypatch):
     """§17d-1: Firebase revoke 실패해도 로컬 auth_valid_after+RT revoke는 이미 커밋됨(순서 보장)."""
     from app.services.auth_cutover import get_auth_valid_after, revoke_user_sessions

--- a/backend/tests/test_bea25062_firebase_revoke_call.py
+++ b/backend/tests/test_bea25062_firebase_revoke_call.py
@@ -1,0 +1,86 @@
+"""story bea25062(§17d-1 ③) 계약 테스트: revoke_firebase_refresh_tokens() 구조 검증.
+mock-first(S4/S5와 동일 패턴) — 실 Google REST 응답 형식은 non-prod 프로젝트 준비 후 재확인.
+"""
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+
+from app.services import firebase_session_mint as mint_mod
+
+FIREBASE_UID = "firebase-uid-revoke-1"
+PROJECT_ID = "test-project"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _fake_response(status_code: int, json_body: dict) -> httpx.Response:
+    return httpx.Response(status_code=status_code, json=json_body, request=httpx.Request("POST", "https://example.test"))
+
+
+@pytest.mark.anyio
+async def test_revoke_success(monkeypatch):
+    monkeypatch.setattr(mint_mod, "_get_access_token", lambda: "fake-access-token")
+
+    async def fake_call(access_token, uid, project_id):
+        assert access_token == "fake-access-token"
+        assert uid == FIREBASE_UID
+        assert project_id == PROJECT_ID
+        return _fake_response(200, {"localId": [FIREBASE_UID]})
+    monkeypatch.setattr(mint_mod, "_call_accounts_update_valid_since", fake_call)
+
+    result = await mint_mod.revoke_firebase_refresh_tokens(FIREBASE_UID, PROJECT_ID)
+    assert result is True
+
+
+@pytest.mark.anyio
+async def test_revoke_returns_false_when_adc_unavailable(monkeypatch):
+    def raise_error():
+        raise RuntimeError("no ADC")
+    monkeypatch.setattr(mint_mod, "_get_access_token", raise_error)
+    result = await mint_mod.revoke_firebase_refresh_tokens(FIREBASE_UID, PROJECT_ID)
+    assert result is False
+
+
+@pytest.mark.anyio
+async def test_revoke_returns_false_on_network_error(monkeypatch):
+    monkeypatch.setattr(mint_mod, "_get_access_token", lambda: "fake-access-token")
+
+    async def fake_call(*args, **kwargs):
+        raise httpx.ConnectError("connection refused")
+    monkeypatch.setattr(mint_mod, "_call_accounts_update_valid_since", fake_call)
+
+    result = await mint_mod.revoke_firebase_refresh_tokens(FIREBASE_UID, PROJECT_ID)
+    assert result is False
+
+
+@pytest.mark.anyio
+async def test_revoke_returns_false_on_rejection(monkeypatch):
+    monkeypatch.setattr(mint_mod, "_get_access_token", lambda: "fake-access-token")
+
+    async def fake_call(*args, **kwargs):
+        return _fake_response(400, {"error": {"message": "USER_NOT_FOUND"}})
+    monkeypatch.setattr(mint_mod, "_call_accounts_update_valid_since", fake_call)
+
+    result = await mint_mod.revoke_firebase_refresh_tokens(FIREBASE_UID, PROJECT_ID)
+    assert result is False
+
+
+@pytest.mark.anyio
+async def test_firebase_uid_never_appears_in_logs(monkeypatch, caplog):
+    monkeypatch.setattr(mint_mod, "_get_access_token", lambda: "fake-access-token")
+
+    async def fake_call(access_token, uid, project_id):
+        return _fake_response(200, {"localId": [uid]})
+    monkeypatch.setattr(mint_mod, "_call_accounts_update_valid_since", fake_call)
+
+    with caplog.at_level(logging.DEBUG):
+        await mint_mod.revoke_firebase_refresh_tokens(FIREBASE_UID, PROJECT_ID)
+
+    all_log_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert FIREBASE_UID not in all_log_text

--- a/backend/tests/test_bea25062_native_bootstrap_orphan_finding_realdb.py
+++ b/backend/tests/test_bea25062_native_bootstrap_orphan_finding_realdb.py
@@ -305,3 +305,44 @@ async def test_consume_mint_interleaved_revoke_rejected(monkeypatch):
         assert mint_called["value"] is False
     finally:
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_revoke_during_mint_network_roundtrip_rejects_and_discards_cookie(monkeypatch):
+    """산티아고 #2206 갱신 재검토(2026-07-16) 정확한 지적: mint 직전 재확인만으론 Firebase
+    네트워크 왕복(custom-token 발급→signInWithCustomToken→createSessionCookie) '도중'의
+    revoke를 못 잡는다(probe: revoke_during_mint_cookie_returned=True). 여기선 fake mint
+    함수 **내부**(=mint 네트워크 호출이 실제로 진행 중인 시점을 대표)에서 별도 DB session으로
+    revoke를 커밋한 뒤 cookie를 반환하게 해 그 정확한 타이밍을 재현 — cookie 반환 직전 세
+    번째 authoritative 재조회가 이를 잡아 최종 401이어야 하고, 절대 그 cookie 값이
+    호출부까지 반환되면 안 된다."""
+    import app.routers.auth_firebase_internal as router_mod
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+    from app.services.auth_cutover import revoke_user_sessions
+
+    _setup_common(monkeypatch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            raw_code, user_id = await _seed_eligible_user_and_code(s)
+
+        async def fake_mint_for_uid_with_interleaved_revoke(firebase_uid, project_id, web_api_key, valid_duration_seconds):
+            # mint 네트워크 호출이 "진행 중"인 시점에 별도 트랜잭션으로 revoke가 커밋되는
+            # 상황을 정확히 대표 — mint 직전 재확인(2번째 조회)은 이미 통과한 뒤다.
+            async with Session() as revoke_session:
+                await revoke_user_sessions(revoke_session, user_id, firebase_uid=None)
+            return "cookie-minted-during-race-must-never-be-returned"
+
+        monkeypatch.setattr(router_mod, "mint_session_cookie_for_uid", fake_mint_for_uid_with_interleaved_revoke)
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await consume_native_bootstrap(
+                    NativeBootstrapConsumeRequest(code=raw_code), authorization=None, db=s
+                )
+            assert exc_info.value.status_code == 401
+            # cookie 값이 예외 detail 등 어디에도 새어나가지 않았는지 확인.
+            assert "cookie-minted-during-race" not in str(exc_info.value.detail)
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_bea25062_native_bootstrap_orphan_finding_realdb.py
+++ b/backend/tests/test_bea25062_native_bootstrap_orphan_finding_realdb.py
@@ -1,0 +1,192 @@
+"""story bea25062 게이트 — 산티아고 #2202 3차 재검토 orphan finding 직접 종결 증거:
+firebase/provisioning 상태 code 발급 → user-wide revoke → 45초 내(코드 미만료) 소비 →
+custom-token 새 세션 재생성 race가 실제로 차단되는지 실 DB로 실증.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+PROJECT_ID = "test-project"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_after():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_eligible_user_and_code(session):
+    from app.core.security import hash_password
+    from app.models.auth_identity import AuthIdentity, AuthMigration
+    from app.models.user import User
+    from app.services.native_bootstrap import issue_bootstrap_code
+
+    user_id = uuid.uuid4()
+    firebase_uid = f"fb-uid-{user_id.hex[:8]}"
+    session.add(User(
+        id=user_id, email=f"orphan-{user_id.hex[:8]}@test.com",
+        hashed_password=hash_password("x"), is_active=True, email_verified=True,
+    ))
+    await session.commit()
+    session.add(AuthMigration(user_id=user_id, state="firebase"))
+    session.add(AuthIdentity(
+        id=uuid.uuid4(), user_id=user_id,
+        issuer=f"https://securetoken.google.com/{PROJECT_ID}", subject=firebase_uid,
+        provider_id="password",
+    ))
+    await session.commit()
+
+    raw_code = await issue_bootstrap_code(
+        session, user_id=user_id, firebase_uid=firebase_uid, project_id=PROJECT_ID,
+    )
+    return raw_code, user_id
+
+
+def _setup_common(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "firebase_auth_mobile_issue", True)
+    monkeypatch.setattr(settings, "firebase_project_id", PROJECT_ID)
+    monkeypatch.setattr(settings, "firebase_bff_internal_secret", "")
+
+
+@pytest.mark.anyio
+async def test_orphan_finding_closed_revoke_after_issue_before_consume_rejects(monkeypatch):
+    """핵심 회귀 가드: 코드 발급→revoke→(코드는 아직 미만료)소비 순서에서 세션 발급 거부."""
+    import app.routers.auth_firebase_internal as router_mod
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+    from app.services.auth_cutover import revoke_user_sessions
+
+    _setup_common(monkeypatch)
+
+    async def fake_mint_for_uid(firebase_uid, project_id, web_api_key, valid_duration_seconds):
+        return "should-never-be-returned"
+    monkeypatch.setattr(router_mod, "mint_session_cookie_for_uid", fake_mint_for_uid)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            raw_code, user_id = await _seed_eligible_user_and_code(s)
+
+        # 코드 발급 "이후" 보안 이벤트로 revoke 발생(원본 finding: 이게 custom-token 재생성을 못 막던 갭).
+        async with Session() as s:
+            await revoke_user_sessions(s, user_id, firebase_uid=None)
+
+        # 코드는 아직 TTL(45초) 내라 atomic consume 자체는 성공하지만, cutover 재검증에서 거부돼야 함.
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await consume_native_bootstrap(
+                    NativeBootstrapConsumeRequest(code=raw_code), authorization=None, db=s
+                )
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_no_revoke_between_issue_and_consume_still_succeeds(monkeypatch):
+    """회귀 가드 반대편 — revoke가 없으면(정상 케이스) 여전히 성공해야 한다."""
+    import app.routers.auth_firebase_internal as router_mod
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+
+    _setup_common(monkeypatch)
+
+    async def fake_mint_for_uid(firebase_uid, project_id, web_api_key, valid_duration_seconds):
+        return "minted-cookie"
+    monkeypatch.setattr(router_mod, "mint_session_cookie_for_uid", fake_mint_for_uid)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            raw_code, _user_id = await _seed_eligible_user_and_code(s)
+
+        async with Session() as s:
+            result = await consume_native_bootstrap(
+                NativeBootstrapConsumeRequest(code=raw_code), authorization=None, db=s
+            )
+        assert result.session_cookie == "minted-cookie"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_revoke_before_issue_does_not_block_new_code(monkeypatch):
+    """§17d-1: revoke는 그 시점 이전 자격증명만 무효화한다 — revoke *이후*에 새로 발급된
+    코드(=revoke 이후의 새 로그인/부트스트랩 흐름)까지 막으면 안 된다."""
+    import app.routers.auth_firebase_internal as router_mod
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+    from app.services.auth_cutover import revoke_user_sessions
+    from app.services.native_bootstrap import issue_bootstrap_code
+    from app.core.security import hash_password
+    from app.models.auth_identity import AuthIdentity, AuthMigration
+    from app.models.user import User
+
+    _setup_common(monkeypatch)
+
+    async def fake_mint_for_uid(firebase_uid, project_id, web_api_key, valid_duration_seconds):
+        return "minted-cookie-after-revoke"
+    monkeypatch.setattr(router_mod, "mint_session_cookie_for_uid", fake_mint_for_uid)
+
+    engine, Session = await _session_factory()
+    try:
+        user_id = uuid.uuid4()
+        firebase_uid = f"fb-uid-{user_id.hex[:8]}"
+        async with Session() as s:
+            s.add(User(
+                id=user_id, email=f"orphan-postrevoke-{user_id.hex[:8]}@test.com",
+                hashed_password=hash_password("x"), is_active=True, email_verified=True,
+            ))
+            await s.commit()
+            s.add(AuthMigration(user_id=user_id, state="firebase"))
+            s.add(AuthIdentity(
+                id=uuid.uuid4(), user_id=user_id,
+                issuer=f"https://securetoken.google.com/{PROJECT_ID}", subject=firebase_uid,
+                provider_id="password",
+            ))
+            await s.commit()
+
+        async with Session() as s:
+            await revoke_user_sessions(s, user_id, firebase_uid=None)
+
+        # revoke *이후*에 새 코드 발급(새 로그인 흐름을 대표).
+        async with Session() as s:
+            raw_code = await issue_bootstrap_code(
+                s, user_id=user_id, firebase_uid=firebase_uid, project_id=PROJECT_ID,
+            )
+
+        async with Session() as s:
+            result = await consume_native_bootstrap(
+                NativeBootstrapConsumeRequest(code=raw_code), authorization=None, db=s
+            )
+        assert result.session_cookie == "minted-cookie-after-revoke"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_bea25062_native_bootstrap_orphan_finding_realdb.py
+++ b/backend/tests/test_bea25062_native_bootstrap_orphan_finding_realdb.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import os
 import uuid
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi import HTTPException
@@ -45,7 +46,7 @@ async def _session_factory():
     return engine, async_sessionmaker(engine, expire_on_commit=False)
 
 
-async def _seed_eligible_user_and_code(session):
+async def _seed_eligible_user_and_code(session, *, auth_time=None):
     from app.core.security import hash_password
     from app.models.auth_identity import AuthIdentity, AuthMigration
     from app.models.user import User
@@ -66,8 +67,14 @@ async def _seed_eligible_user_and_code(session):
     ))
     await session.commit()
 
+    # story bea25062 BLOCKER 2: auth_time을 명시하지 않으면 이 헬퍼가 "방금 정상 로그인"을
+    # 대표하도록 기본값 now()를 쓴다 — None으로 두면 consume 시 fail-closed(missing_auth_time)
+    # 되어 대부분의 정상 케이스 테스트가 공허해진다.
+    if auth_time is None:
+        auth_time = datetime.now(timezone.utc)
+
     raw_code = await issue_bootstrap_code(
-        session, user_id=user_id, firebase_uid=firebase_uid, project_id=PROJECT_ID,
+        session, user_id=user_id, firebase_uid=firebase_uid, project_id=PROJECT_ID, auth_time=auth_time,
     )
     return raw_code, user_id
 
@@ -177,10 +184,16 @@ async def test_revoke_before_issue_does_not_block_new_code(monkeypatch):
         async with Session() as s:
             await revoke_user_sessions(s, user_id, firebase_uid=None)
 
-        # revoke *이후*에 새 코드 발급(새 로그인 흐름을 대표).
+        # revoke *이후*에 새 코드 발급(새 로그인 흐름을 대표) — ⚠️§17d-1 BLOCKER 2 시정
+        # (산티아고 2026-07-16): 이전 버전의 이 테스트는 auth_time을 아예 안 실어(issue_
+        # bootstrap_code() 직접 호출) "새 코드 생성"과 "새 로그인"을 잘못 동일시하는 공허
+        # 테스트였다 — 실제로 대표해야 할 건 "revoke *이후*에 실제로 재인증한" 새 Firebase
+        # 로그인이므로, auth_time을 revoke epoch 이후 시각으로 명시해야 이 테스트가 실제로
+        # 검증하는 바(post-cutover 재인증은 여전히 허용)를 정확히 대표한다.
         async with Session() as s:
             raw_code = await issue_bootstrap_code(
                 s, user_id=user_id, firebase_uid=firebase_uid, project_id=PROJECT_ID,
+                auth_time=datetime.now(timezone.utc),
             )
 
         async with Session() as s:
@@ -188,5 +201,107 @@ async def test_revoke_before_issue_does_not_block_new_code(monkeypatch):
                 NativeBootstrapConsumeRequest(code=raw_code), authorization=None, db=s
             )
         assert result.session_cookie == "minted-cookie-after-revoke"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_old_auth_time_reused_after_revoke_still_rejected(monkeypatch):
+    """산티아고 RED 포워딩 BLOCKER 2 정확한 공격 재현: pre-cutover ID token(auth_time=T0)으로
+    revoke(auth_valid_after=T1>T0) *이후*에 새 bootstrap 코드를 발급받아도(created_at=T2>T1)
+    저장된 원본 auth_time(T0)이 여전히 cutover 이전이라 consume이 거부해야 한다 — created_at
+    만 보던 낡은 계약에서는 이게 통과했다(원 orphan finding의 정확한 우회 경로)."""
+    import app.routers.auth_firebase_internal as router_mod
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+    from app.services.auth_cutover import revoke_user_sessions
+    from app.services.native_bootstrap import issue_bootstrap_code
+
+    _setup_common(monkeypatch)
+
+    async def fake_mint_for_uid(firebase_uid, project_id, web_api_key, valid_duration_seconds):
+        return "should-never-be-returned"
+    monkeypatch.setattr(router_mod, "mint_session_cookie_for_uid", fake_mint_for_uid)
+
+    engine, Session = await _session_factory()
+    try:
+        old_auth_time = datetime.now(timezone.utc) - timedelta(minutes=4)  # T0: 아직 5분 freshness 내
+        async with Session() as s:
+            _raw_code_unused, user_id = await _seed_eligible_user_and_code(s, auth_time=old_auth_time)
+
+        # revoke(T1 > T0) — old ID token은 이미 cutover 대상.
+        async with Session() as s:
+            await revoke_user_sessions(s, user_id, firebase_uid=None)
+
+        # revoke *이후* 같은 old ID token(auth_time=T0, 아직 5분 freshness 내)으로 새 코드
+        # 발급(created_at=T2 > T1) — 이게 BLOCKER 2의 정확한 공격.
+        async with Session() as s:
+            from app.models.auth_identity import AuthIdentity
+            from sqlalchemy import select
+            identity = (await s.execute(
+                select(AuthIdentity).where(AuthIdentity.user_id == user_id)
+            )).scalar_one()
+            raw_code = await issue_bootstrap_code(
+                s, user_id=user_id, firebase_uid=identity.subject, project_id=PROJECT_ID,
+                auth_time=old_auth_time,
+            )
+
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await consume_native_bootstrap(
+                    NativeBootstrapConsumeRequest(code=raw_code), authorization=None, db=s
+                )
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_consume_mint_interleaved_revoke_rejected(monkeypatch):
+    """산티아고 RED 조건 ⑤: consume의 첫 cutover 판정과 실제 mint 호출 사이에 revoke가
+    끼어들면(TOCTOU) mint 직전 강제 재조회(`populate_existing=True`)가 이를 잡아야 한다."""
+    import app.routers.auth_firebase_internal as router_mod
+    from app.routers.auth_firebase_internal import NativeBootstrapConsumeRequest, consume_native_bootstrap
+    from app.services.auth_cutover import revoke_user_sessions
+    from app.models.auth_identity import AuthMigration
+
+    _setup_common(monkeypatch)
+
+    mint_called = {"value": False}
+
+    async def fake_mint_for_uid(firebase_uid, project_id, web_api_key, valid_duration_seconds):
+        mint_called["value"] = True
+        return "should-never-be-returned"
+    monkeypatch.setattr(router_mod, "mint_session_cookie_for_uid", fake_mint_for_uid)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            raw_code, user_id = await _seed_eligible_user_and_code(s)
+
+        async with Session() as s:
+            original_get = s.get
+            call_count = {"n": 0}
+
+            async def get_with_interleaved_revoke(model, pk, *a, **kw):
+                result = await original_get(model, pk, *a, **kw)
+                if model is AuthMigration:
+                    call_count["n"] += 1
+                    if call_count["n"] == 1:
+                        # 첫 조회(정상 eligibility 판정)는 이 결과(아직 pre-revoke)를 그대로
+                        # 쓰게 두고, 반환 "직후" 별도 세션으로 revoke를 커밋 — 실제 세계에서
+                        # 이 두 조회 사이의 짧은 창(consume 판정→mint 호출)에 revoke가 도착한
+                        # 상황을 흉내낸다.
+                        async with Session() as revoke_session:
+                            await revoke_user_sessions(revoke_session, user_id, firebase_uid=None)
+                return result
+
+            s.get = get_with_interleaved_revoke
+
+            with pytest.raises(HTTPException) as exc_info:
+                await consume_native_bootstrap(
+                    NativeBootstrapConsumeRequest(code=raw_code), authorization=None, db=s
+                )
+            assert exc_info.value.status_code == 401
+        assert mint_called["value"] is False
     finally:
         await engine.dispose()

--- a/backend/tests/test_bea25062_verifier_cutover_realdb.py
+++ b/backend/tests/test_bea25062_verifier_cutover_realdb.py
@@ -1,0 +1,287 @@
+"""story bea25062(E-AUTH-REBUILD auth_valid_after 코어 인프라) 게이트: 3개(+SSE) verifier가
+동일 cutover epoch 기준으로 정확히 동작하는지 실증. §17d-1 4요소 중 ①(전 verifier 강제)을
+직접 검증 — auth_valid_after=NULL(기본)이면 무영향, 설정되면 그 이전 자격증명을 거부.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+from jose import jwt as jose_jwt
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+PROJECT_ID = "test-project"
+KID = "test-kid-1"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _reset_caches_and_dispose():
+    from app.services import auth_cutover as ac
+    from app.services import firebase_verifier as fv
+    fv._reset_key_cache_for_tests()
+    ac._reset_cutover_existence_cache_for_tests()
+    yield
+    fv._reset_key_cache_for_tests()
+    ac._reset_cutover_existence_cache_for_tests()
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+def _make_self_signed_cert() -> tuple[str, str]:
+    with tempfile.TemporaryDirectory() as d:
+        key_path = Path(d) / "key.pem"
+        cert_path = Path(d) / "cert.pem"
+        subprocess.run(
+            ["openssl", "req", "-x509", "-newkey", "rsa:2048", "-keyout", str(key_path),
+             "-out", str(cert_path), "-days", "1", "-nodes", "-subj", "/CN=test"],
+            check=True, capture_output=True,
+        )
+        return key_path.read_text(), cert_path.read_text()
+
+
+def _make_session_cookie(key_pem: str, sub: str, auth_time: int) -> str:
+    now = int(time.time())
+    claims = {
+        "sub": sub, "email": "user@test.com", "auth_time": auth_time, "iat": now, "exp": now + 3600,
+        "iss": f"https://session.firebase.google.com/{PROJECT_ID}", "aud": PROJECT_ID,
+    }
+    return jose_jwt.encode(claims, key_pem, algorithm="RS256", headers={"kid": KID})
+
+
+async def _seed_legacy_user(session):
+    from app.core.security import hash_password
+    from app.models.user import User
+    user_id = uuid.uuid4()
+    session.add(User(
+        id=user_id, email=f"cutover-legacy-{user_id.hex[:8]}@test.com",
+        hashed_password=hash_password("x"), is_active=True, email_verified=True,
+    ))
+    await session.commit()
+    return user_id
+
+
+async def _seed_firebase_user(session):
+    from app.core.security import hash_password
+    from app.models.auth_identity import AuthIdentity
+    from app.models.user import User
+    user_id = uuid.uuid4()
+    session.add(User(
+        id=user_id, email=f"cutover-fb-{user_id.hex[:8]}@test.com",
+        hashed_password=hash_password("x"), is_active=True, email_verified=True,
+    ))
+    await session.commit()
+    firebase_uid = f"fb-uid-{user_id.hex[:8]}"
+    session.add(AuthIdentity(
+        id=uuid.uuid4(), user_id=user_id,
+        issuer=f"https://session.firebase.google.com/{PROJECT_ID}", subject=firebase_uid,
+        provider_id="password",
+    ))
+    await session.commit()
+    return user_id, firebase_uid
+
+
+async def _set_auth_valid_after(session, user_id, epoch):
+    from app.models.auth_identity import AuthMigration
+    row = await session.get(AuthMigration, user_id)
+    if row is None:
+        session.add(AuthMigration(user_id=user_id, state="firebase", auth_valid_after=epoch))
+    else:
+        row.auth_valid_after = epoch
+    await session.commit()
+
+
+# ─── legacy(HS256) get_current_user ────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_legacy_token_rejected_when_issued_before_cutover(monkeypatch):
+    from app.core.security import create_access_token
+    from app.dependencies.auth import get_current_user
+
+    engine, Session = await _session_factory()
+    # check_any_cutover_epoch_exists()는 app.core.database.async_session_factory를 함수 내부
+    # 지역 import로 매번 새로 참조한다 — 소스 모듈 쪽을 패치해야 이 테스트 DB를 실제로 본다
+    # (app.dependencies.auth 쪽 바인딩과는 별개 지점 — 소스 vs 소비 모듈 패치 구분 주의).
+    monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    try:
+        async with Session() as s:
+            user_id = await _seed_legacy_user(s)
+
+        token = create_access_token(str(user_id))
+        cutover = datetime.now(timezone.utc) + timedelta(hours=1)  # 토큰 발급보다 미래 = 토큰이 cutover 이전
+        async with Session() as s:
+            await _set_auth_valid_after(s, user_id, cutover)
+
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_legacy_token_accepted_when_issued_after_cutover(monkeypatch):
+    from app.core.security import create_access_token
+    from app.dependencies.auth import get_current_user
+
+    engine, Session = await _session_factory()
+    monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    try:
+        async with Session() as s:
+            user_id = await _seed_legacy_user(s)
+            cutover = datetime.now(timezone.utc) - timedelta(hours=1)  # 과거 cutover — 지금 발급 토큰은 그 이후
+            await _set_auth_valid_after(s, user_id, cutover)
+
+        token = create_access_token(str(user_id))
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+        async with Session() as s:
+            auth = await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
+        assert auth.user_id == str(user_id)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_legacy_token_unaffected_when_no_migration_row(monkeypatch):
+    """auth_valid_after 컬럼 신설 전과 100% 동일 동작 — 대부분의 현재 사용자는 행 자체가 없다."""
+    from app.core.security import create_access_token
+    from app.dependencies.auth import get_current_user
+
+    engine, Session = await _session_factory()
+    monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    try:
+        async with Session() as s:
+            user_id = await _seed_legacy_user(s)
+
+        token = create_access_token(str(user_id))
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+        async with Session() as s:
+            auth = await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
+        assert auth.user_id == str(user_id)
+    finally:
+        await engine.dispose()
+
+
+# ─── Firebase(RS256) _resolve_firebase_session (get_current_user 경유) ────
+
+@pytest.mark.anyio
+async def test_firebase_session_rejected_when_auth_time_before_cutover(monkeypatch):
+    from app.core.config import settings
+    from app.dependencies.auth import get_current_user
+    from app.services import firebase_verifier as fv
+
+    monkeypatch.setattr(settings, "firebase_auth_accept_session", True)
+    monkeypatch.setattr(settings, "firebase_project_id", PROJECT_ID)
+
+    key_pem, cert_pem = _make_self_signed_cert()
+    async def fake_fetch():
+        return {KID: cert_pem}
+    monkeypatch.setattr(fv, "_fetch_public_keys", fake_fetch)
+
+    engine, Session = await _session_factory()
+    monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    try:
+        async with Session() as s:
+            user_id, firebase_uid = await _seed_firebase_user(s)
+            cutover = datetime.now(timezone.utc) + timedelta(hours=1)
+            await _set_auth_valid_after(s, user_id, cutover)
+
+        auth_time = int(time.time())
+        cookie = _make_session_cookie(key_pem, firebase_uid, auth_time)
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=cookie)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_firebase_session_accepted_when_auth_time_after_cutover(monkeypatch):
+    from app.core.config import settings
+    from app.dependencies.auth import get_current_user
+    from app.services import firebase_verifier as fv
+
+    monkeypatch.setattr(settings, "firebase_auth_accept_session", True)
+    monkeypatch.setattr(settings, "firebase_project_id", PROJECT_ID)
+
+    key_pem, cert_pem = _make_self_signed_cert()
+    async def fake_fetch():
+        return {KID: cert_pem}
+    monkeypatch.setattr(fv, "_fetch_public_keys", fake_fetch)
+
+    engine, Session = await _session_factory()
+    monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    try:
+        async with Session() as s:
+            user_id, firebase_uid = await _seed_firebase_user(s)
+            cutover = datetime.now(timezone.utc) - timedelta(hours=1)
+            await _set_auth_valid_after(s, user_id, cutover)
+
+        auth_time = int(time.time())
+        cookie = _make_session_cookie(key_pem, firebase_uid, auth_time)
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=cookie)
+        async with Session() as s:
+            auth = await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
+        assert auth.user_id == str(user_id)
+    finally:
+        await engine.dispose()
+
+
+# ─── SSE streaming legacy 경로 ──────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_sse_streaming_legacy_rejected_when_before_cutover(monkeypatch):
+    from app.core.security import create_access_token
+    import app.dependencies.auth as auth_module
+
+    engine, Session = await _session_factory()
+    monkeypatch.setattr(auth_module, "async_session_factory", Session)
+    monkeypatch.setattr("app.core.database.async_session_factory", Session)
+    try:
+        async with Session() as s:
+            user_id = await _seed_legacy_user(s)
+            cutover = datetime.now(timezone.utc) + timedelta(hours=1)
+            await _set_auth_valid_after(s, user_id, cutover)
+
+        token = create_access_token(str(user_id))
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+        with pytest.raises(HTTPException) as exc_info:
+            await auth_module.get_current_user_streaming(credentials=credentials, x_agent_api_key=None)
+        assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_bea25062_verifier_cutover_realdb.py
+++ b/backend/tests/test_bea25062_verifier_cutover_realdb.py
@@ -34,13 +34,10 @@ def anyio_backend():
 
 @pytest.fixture(autouse=True)
 async def _reset_caches_and_dispose():
-    from app.services import auth_cutover as ac
     from app.services import firebase_verifier as fv
     fv._reset_key_cache_for_tests()
-    ac._reset_cutover_existence_cache_for_tests()
     yield
     fv._reset_key_cache_for_tests()
-    ac._reset_cutover_existence_cache_for_tests()
     from app.core.database import engine as _global_engine
     await _global_engine.dispose()
 
@@ -283,5 +280,81 @@ async def test_sse_streaming_legacy_rejected_when_before_cutover(monkeypatch):
         with pytest.raises(HTTPException) as exc_info:
             await auth_module.get_current_user_streaming(credentials=credentials, x_agent_api_key=None)
         assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+# ─── 산티아고 RED 포워딩(2026-07-16) GREEN 조건 real-DB 회귀 ─────────────────
+
+@pytest.mark.anyio
+async def test_legacy_token_fails_closed_when_migration_lookup_raises(monkeypatch):
+    """조건 ①: 캐시 제거 후 DB 조회 자체가 실패하면(콜드 스타트/장애) 예외가 그대로
+    전파돼야 한다 — 절대 "허용"으로 떨어지면 안 된다(이전 캐시의 fail-open 반대편 증명)."""
+    from app.core.security import create_access_token
+    from app.dependencies.auth import get_current_user
+
+    user_id = uuid.uuid4()
+    token = create_access_token(str(user_id))
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    class _ExplodingDb:
+        async def get(self, *a, **kw):
+            raise ConnectionError("simulated DB outage")
+
+    with pytest.raises(ConnectionError):
+        await get_current_user(
+            credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=_ExplodingDb()
+        )
+
+
+@pytest.mark.anyio
+async def test_legacy_token_rejected_when_state_reset_required_even_without_epoch(monkeypatch):
+    """조건 ②: auth_valid_after가 NULL(또는 부분 커밋)이어도 state='reset_required'면 그
+    자체로 거부 — epoch만 보는 낡은 계약으로는 이 사용자가 그냥 통과했다."""
+    from app.core.security import create_access_token
+    from app.dependencies.auth import get_current_user
+    from app.models.auth_identity import AuthMigration
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_legacy_user(s)
+            s.add(AuthMigration(user_id=user_id, state="reset_required", auth_valid_after=None))
+            await s.commit()
+
+        token = create_access_token(str(user_id))
+        credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await get_current_user(credentials=credentials, x_agent_api_key=None, x_mcp_transport=None, db=s)
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_legacy_token_rejected_when_iat_missing():
+    """조건 ③: iat 클레임이 없으면(위조/손상) fail-closed — 이전엔 "제약 없음"으로 통과."""
+    from app.dependencies.auth import _reject_if_before_cutover
+    from unittest.mock import AsyncMock
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _reject_if_before_cutover(str(uuid.uuid4()), None, AsyncMock())
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_reject_if_before_cutover_accepts_uuid_object_user_id(monkeypatch):
+    """까심 결함 A 회귀 가드: user_id가 이미 uuid.UUID 객체여도 ValueError 없이 정상 동작."""
+    from app.dependencies.auth import _reject_if_before_cutover
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id = await _seed_legacy_user(s)
+        async with Session() as s:
+            # user_id를 str이 아니라 uuid.UUID 객체 그대로 전달 — ValueError 없이 통과해야 함
+            # (AuthMigration 행이 없으니 제약 없음 → None 반환, 예외 없음).
+            await _reject_if_before_cutover(user_id, int(datetime.now(timezone.utc).timestamp()), s)
     finally:
         await engine.dispose()

--- a/backend/tests/test_c_s5.py
+++ b/backend/tests/test_c_s5.py
@@ -338,18 +338,31 @@ def test_require_api_scope_factory_passes_jwt():
 # ─── AuthContext org_id field ──────────────────────────────────────────────────
 
 def test_auth_context_includes_org_id_from_jwt():
-    """get_current_user가 JWT app_metadata.org_id를 AuthContext.org_id에 포함."""
+    """get_current_user가 JWT app_metadata.org_id를 AuthContext.org_id에 포함.
+
+    ⚠️story bea25062(2026-07-16): cutover 검사가 이제 무조건 DB를 조회한다(negative
+    existence-cache 제거, 산티아고 RED 조건 ①) — `db=None`은 더 이상 유효한 입력이 아니다.
+    이 테스트의 실제 관심사(JWT app_metadata.org_id 파싱)는 cutover와 무관하므로,
+    `AuthMigration` 행이 없는 "제약 없음" 상태를 정확히 대표하는 `.get()=None` mock으로
+    대체 — 우회가 아니라 이 임의 user_id에 대한 실제 DB 상태(마이그레이션 행 없음)를
+    정확히 표현한다. ⚠️user_id도 실제 토큰이 항상 담는 형태(유효 UUID 문자열, `str(user.
+    id)`)로 교체 — "user-1" 같은 non-UUID literal은 실 프로덕션 토큰에 절대 없는 값이라
+    cutover 검사의 `uuid.UUID()` 파싱에서 (정확히 의도대로) fail-closed로 거부된다."""
+    user_id = str(uuid.uuid4())
     with patch.dict("os.environ", {"JWT_SECRET": "test-secret"}):
         from app.core.security import create_access_token
-        token = create_access_token("user-1", email="a@b.com", app_metadata={"org_id": "org-abc"})
+        token = create_access_token(user_id, email="a@b.com", app_metadata={"org_id": "org-abc"})
 
     from fastapi.security import HTTPAuthorizationCredentials
     creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
 
+    mock_db = AsyncMock()
+    mock_db.get = AsyncMock(return_value=None)
+
     import asyncio
     with patch.dict("os.environ", {"JWT_SECRET": "test-secret"}):
         from app.dependencies.auth import get_current_user
-        ctx = asyncio.run(get_current_user(credentials=creds, x_agent_api_key=None, db=None))
+        ctx = asyncio.run(get_current_user(credentials=creds, x_agent_api_key=None, db=mock_db))
 
     assert ctx.org_id == "org-abc"
-    assert ctx.user_id == "user-1"
+    assert ctx.user_id == user_id

--- a/backend/tests/test_e_auth_rebuild_phase1_s4_mint_endpoint_realdb.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s4_mint_endpoint_realdb.py
@@ -81,9 +81,9 @@ def _make_id_token(key_pem: str, sub: str, *, auth_time: int | None = None, exp_
     return jose_jwt.encode(claims, key_pem, algorithm="RS256", headers={"kid": KID})
 
 
-async def _seed(session, *, user_active: bool = True, mapped: bool = True):
+async def _seed(session, *, user_active: bool = True, mapped: bool = True, eligible: bool = True):
     from app.core.security import hash_password
-    from app.models.auth_identity import AuthIdentity
+    from app.models.auth_identity import AuthIdentity, AuthMigration
     from app.models.user import User
 
     user_id = uuid.uuid4()
@@ -100,6 +100,14 @@ async def _seed(session, *, user_active: bool = True, mapped: bool = True):
             id=uuid.uuid4(), user_id=user_id, issuer=issuer, subject=firebase_uid,
             provider_id="password",
         ))
+        await session.commit()
+
+    # story bea25062(§17d-1 갱신 재검토 2026-07-16): 이 엔드포인트도 이제 issue-time에
+    # migration state+cutover epoch를 검사한다(산티아고 "native issue와 동일 guard") —
+    # eligible=True(기본값)가 이 fixture로 만드는 사용자가 실 프로덕션에서 이 엔드포인트를
+    # 호출할 수 있는 정상 상태(이미 Firebase 마이그레이션됨)를 정확히 대표한다.
+    if eligible:
+        session.add(AuthMigration(user_id=user_id, state="firebase"))
         await session.commit()
 
     return {"user_id": user_id, "firebase_uid": firebase_uid}
@@ -289,6 +297,110 @@ async def test_success_returns_minted_cookie(monkeypatch):
             )
         assert result.session_cookie == "minted-cookie-xyz"
         assert result.expires_in == 5 * 24 * 60 * 60
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ineligible_migration_state_rejected(monkeypatch):
+    """story bea25062(2026-07-16): reset_required 등 부적격 state는 mint 전 거부 — 산티아고
+    "native issue와 동일 guard를 session-cookie mint 전에도" 반영."""
+    from app.routers.auth_firebase_internal import FirebaseSessionMintRequest, mint_firebase_session
+    from app.services import firebase_verifier as fv
+
+    _setup_common(monkeypatch)
+    key_pem, cert_pem = _make_self_signed_cert()
+
+    async def fake_id_fetch():
+        return {KID: cert_pem}
+    monkeypatch.setattr(fv, "_fetch_id_token_public_keys", fake_id_fetch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            from app.models.auth_identity import AuthMigration
+            seeded = await _seed(s, eligible=False)
+            s.add(AuthMigration(user_id=seeded["user_id"], state="reset_required"))
+            await s.commit()
+
+        token = _make_id_token(key_pem, seeded["firebase_uid"])
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await mint_firebase_session(
+                    FirebaseSessionMintRequest(id_token=token), authorization=None, db=s
+                )
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_revoked_before_cutover_rejected(monkeypatch):
+    from app.routers.auth_firebase_internal import FirebaseSessionMintRequest, mint_firebase_session
+    from app.services import firebase_verifier as fv
+
+    _setup_common(monkeypatch)
+    key_pem, cert_pem = _make_self_signed_cert()
+
+    async def fake_id_fetch():
+        return {KID: cert_pem}
+    monkeypatch.setattr(fv, "_fetch_id_token_public_keys", fake_id_fetch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        auth_time = int(time.time())
+        async with Session() as s:
+            from app.services.auth_cutover import revoke_user_sessions
+            await revoke_user_sessions(s, seeded["user_id"], firebase_uid=None)
+
+        token = _make_id_token(key_pem, seeded["firebase_uid"], auth_time=auth_time)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await mint_firebase_session(
+                    FirebaseSessionMintRequest(id_token=token), authorization=None, db=s
+                )
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_revoke_during_mint_network_roundtrip_rejects_and_discards_cookie(monkeypatch):
+    """산티아고 갱신 재검토(2026-07-16): mint 네트워크 호출 도중 revoke가 커밋되면 cookie
+    반환 직전 세 번째 재확인이 잡아야 한다 — fake mint 내부에서 별도 세션으로 revoke."""
+    from app.routers.auth_firebase_internal import FirebaseSessionMintRequest, mint_firebase_session
+    import app.routers.auth_firebase_internal as router_mod
+    from app.services import firebase_verifier as fv
+    from app.services.auth_cutover import revoke_user_sessions
+
+    _setup_common(monkeypatch)
+    key_pem, cert_pem = _make_self_signed_cert()
+
+    async def fake_id_fetch():
+        return {KID: cert_pem}
+    monkeypatch.setattr(fv, "_fetch_id_token_public_keys", fake_id_fetch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+
+        async def fake_mint_with_interleaved_revoke(id_token, project_id, valid_duration_seconds):
+            async with Session() as revoke_session:
+                await revoke_user_sessions(revoke_session, seeded["user_id"], firebase_uid=None)
+            return "cookie-minted-during-race-must-never-be-returned"
+        monkeypatch.setattr(router_mod, "mint_session_cookie", fake_mint_with_interleaved_revoke)
+
+        token = _make_id_token(key_pem, seeded["firebase_uid"])
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await mint_firebase_session(
+                    FirebaseSessionMintRequest(id_token=token), authorization=None, db=s
+                )
+            assert exc_info.value.status_code == 401
+            assert "cookie-minted-during-race" not in str(exc_info.value.detail)
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_e_auth_rebuild_phase1_s5_consume_endpoint_realdb.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s5_consume_endpoint_realdb.py
@@ -47,8 +47,10 @@ async def _session_factory():
 
 
 async def _seed_user_and_code(
-    session, *, device_binding_hash=None, mapped=True, migration_state="firebase", link_identity_to_other_user=False
+    session, *, device_binding_hash=None, mapped=True, migration_state="firebase", link_identity_to_other_user=False,
+    auth_time=None,
 ):
+    from datetime import datetime, timezone
     from app.core.security import hash_password
     from app.models.auth_identity import AuthIdentity, AuthMigration
     from app.models.user import User
@@ -83,9 +85,15 @@ async def _seed_user_and_code(
         session.add(AuthMigration(user_id=user_id, state=migration_state))
         await session.commit()
 
+    # story bea25062(§17d-1 BLOCKER 2·2026-07-16): consume이 이제 원본 auth_time을
+    # fail-closed로 요구한다 — 이 fixture가 만드는 코드는 "방금 정상 로그인"을 대표하도록
+    # 기본값 now()를 쓴다(None으로 두면 모든 정상-경로 테스트가 공허하게 401로 깨진다).
+    if auth_time is None:
+        auth_time = datetime.now(timezone.utc)
+
     raw_code = await issue_bootstrap_code(
         session, user_id=user_id, firebase_uid=firebase_uid, project_id=PROJECT_ID,
-        device_binding_hash=device_binding_hash,
+        device_binding_hash=device_binding_hash, auth_time=auth_time,
     )
     return raw_code, user_id
 

--- a/backend/tests/test_e_auth_rebuild_phase1_s5_native_bootstrap_endpoint_realdb.py
+++ b/backend/tests/test_e_auth_rebuild_phase1_s5_native_bootstrap_endpoint_realdb.py
@@ -111,9 +111,9 @@ def _make_app_check_token(key_pem: str, *, kid: str = APP_CHECK_KID, app_id: str
     return jose_jwt.encode(claims, key_pem, algorithm="RS256", headers={"kid": kid})
 
 
-async def _seed(session, *, user_active: bool = True, mapped: bool = True):
+async def _seed(session, *, user_active: bool = True, mapped: bool = True, eligible: bool = True):
     from app.core.security import hash_password
-    from app.models.auth_identity import AuthIdentity
+    from app.models.auth_identity import AuthIdentity, AuthMigration
     from app.models.user import User
 
     user_id = uuid.uuid4()
@@ -130,6 +130,14 @@ async def _seed(session, *, user_active: bool = True, mapped: bool = True):
             id=uuid.uuid4(), user_id=user_id, issuer=issuer, subject=firebase_uid,
             provider_id="password",
         ))
+        await session.commit()
+
+    # story bea25062(§17d-1 RED 조건 ②⑥·2026-07-16): issue 엔드포인트도 이제 migration
+    # state+cutover epoch를 검사한다 — eligible=True(기본값)가 이 fixture의 사용자를 실
+    # 프로덕션에서 이 엔드포인트를 호출할 수 있는 정상(이미 Firebase 마이그레이션됨) 상태로
+    # 정확히 대표한다.
+    if eligible:
+        session.add(AuthMigration(user_id=user_id, state="firebase"))
         await session.commit()
 
     return {"user_id": user_id, "firebase_uid": firebase_uid}
@@ -285,6 +293,72 @@ async def test_inactive_user_rejected(monkeypatch):
         async with Session() as s:
             with pytest.raises(HTTPException) as exc_info:
                 await native_bootstrap(request=None, body=NativeBootstrapRequest(), response=Response(), authorization=f"Bearer {token}", db=s)
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ineligible_migration_state_rejected(monkeypatch):
+    """story bea25062(2026-07-16): issue 엔드포인트도 이제 consume과 동일하게 provisioning/
+    firebase 외 state는 거부 — reset_required 사용자가 새 코드를 발급받는 첫 단계를 막는다."""
+    from app.routers.auth_native_bootstrap import NativeBootstrapRequest, native_bootstrap
+    from app.services import firebase_verifier as fv
+    from fastapi import HTTPException
+
+    _setup_common(monkeypatch)
+    key_pem, cert_pem = _make_self_signed_cert()
+
+    async def fake_id_fetch():
+        return {KID: cert_pem}
+    monkeypatch.setattr(fv, "_fetch_id_token_public_keys", fake_id_fetch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            from app.models.auth_identity import AuthMigration
+            seeded = await _seed(s, eligible=False)
+            s.add(AuthMigration(user_id=seeded["user_id"], state="reset_required"))
+            await s.commit()
+
+        token = _make_id_token(key_pem, seeded["firebase_uid"])
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await native_bootstrap(request=None, body=NativeBootstrapRequest(), response=Response(), authorization=f"Bearer {token}", db=s)
+            assert exc_info.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_issue_pre_cutover_auth_after_revoke_rejected(monkeypatch):
+    """산티아고 BLOCKER 2 정확한 공격 시나리오의 issue-time 절반: revoke *이후* 예전
+    (pre-cutover) ID token으로 새 코드 발급을 시도해도 issue 시점에 이미 거부돼야 한다
+    (consume에만 있던 방어를 issue에도 대칭 반영)."""
+    from app.routers.auth_native_bootstrap import NativeBootstrapRequest, native_bootstrap
+    from app.services import firebase_verifier as fv
+    from app.services.auth_cutover import revoke_user_sessions
+    from fastapi import HTTPException
+
+    _setup_common(monkeypatch)
+    key_pem, cert_pem = _make_self_signed_cert()
+
+    async def fake_id_fetch():
+        return {KID: cert_pem}
+    monkeypatch.setattr(fv, "_fetch_id_token_public_keys", fake_id_fetch)
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            seeded = await _seed(s)
+        pre_cutover_auth_time = int(time.time()) - 60  # 아직 5분 freshness 내
+        async with Session() as s:
+            await revoke_user_sessions(s, seeded["user_id"], firebase_uid=None)
+
+        old_token = _make_id_token(key_pem, seeded["firebase_uid"], auth_time=pre_cutover_auth_time)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc_info:
+                await native_bootstrap(request=None, body=NativeBootstrapRequest(), response=Response(), authorization=f"Bearer {old_token}", db=s)
             assert exc_info.value.status_code == 401
     finally:
         await engine.dispose()

--- a/backend/tests/test_e_security_sec_s5_token_type_confusion.py
+++ b/backend/tests/test_e_security_sec_s5_token_type_confusion.py
@@ -22,11 +22,23 @@ def _creds(token: str) -> HTTPAuthorizationCredentials:
     return HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
 
 
+def _mock_db_no_migration_row() -> AsyncMock:
+    """story bea25062(2026-07-16): cutover 검사가 무조건 AuthMigration을 조회한다 — bare
+    AsyncMock()의 `.get()`은 MagicMock을 반환해(None이 아님) is_before_cutover가 엉뚱한
+    비교를 하게 만든다. 이 user_id엔 실제로 AuthMigration 행이 없는 상태를 정확히
+    대표하도록 `.get()=None`을 명시한다."""
+    mock_db = AsyncMock()
+    mock_db.get = AsyncMock(return_value=None)
+    return mock_db
+
+
 @pytest.mark.anyio
 async def test_access_token_passes_get_current_user():
     user_id = str(uuid.uuid4())
     token = create_access_token(user_id, app_metadata={"org_id": str(uuid.uuid4())})
-    ctx = await get_current_user(credentials=_creds(token), x_agent_api_key=None, x_mcp_transport=None, db=AsyncMock())
+    ctx = await get_current_user(
+        credentials=_creds(token), x_agent_api_key=None, x_mcp_transport=None, db=_mock_db_no_migration_row()
+    )
     assert ctx.user_id == user_id
 
 
@@ -41,7 +53,21 @@ async def test_refresh_token_rejected_by_get_current_user():
 
 
 @pytest.mark.anyio
-async def test_access_token_passes_get_current_user_streaming():
+async def test_access_token_passes_get_current_user_streaming(monkeypatch):
+    """story bea25062: SSE 변형은 cutover 검사를 위해 자체 단명 세션을 연다
+    (`async_session_factory()`, 모듈 top-level import라 소비 모듈 쪽을 패치) — 실 DB 없이도
+    "AuthMigration 행 없음"을 대표하는 fake session으로 검증."""
+    import app.dependencies.auth as auth_module
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return _mock_db_no_migration_row()
+
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr(auth_module, "async_session_factory", lambda: _FakeSession())
+
     user_id = str(uuid.uuid4())
     token = create_access_token(user_id, app_metadata={"org_id": str(uuid.uuid4())})
     ctx = await get_current_user_streaming(credentials=_creds(token), x_agent_api_key=None)


### PR DESCRIPTION
## Summary
story bea25062 — E-AUTH-REBUILD. doc `firebase-poc-q12-didi-measurements-2026-07-15` §17d-1(산티아고 이미 "정합 확定" 판정 — 설계 재검토 불요) 구현. 산티아고 PR #2202 3차 재검토 orphan finding(revoke→45초 내 native-bootstrap consume race)의 근본 — **활성화 게이트 스토리 6ae1ecac AC#2를 종결**한다.

## 스키마+서비스
- `auth_migrations.auth_valid_after TIMESTAMPTZ NULL`(additive, 기본 NULL=제약 없음 — AuthMigration 행이 없는 현재 거의 모든 사용자에게 100% 무변화).
- **`app/services/auth_cutover.py`(신규)**: `is_before_cutover()`(순수함수) + `revoke_user_sessions()`(단일 사용자 revoke primitive — §17d-1 순서 그대로: 로컬 auth_valid_after 기록+legacy refresh_tokens 일괄 revoke를 먼저 커밋해 즉시 fail-closed 통제를 만들고, Firebase user-wide revoke는 트랜잭션 밖에서 best-effort로 시도).
- **`firebase_session_mint.py`**: `revoke_firebase_refresh_tokens()` 추가 — Identity Toolkit `accounts:update`(`validSince`) REST 호출, S4/S5와 동일 mock-first 패턴.

## 4개 verifier 배선
legacy `get_current_user`(HS256 `iat`) · Firebase `_resolve_firebase_session`(RS256 `auth_time`) · SSE `get_current_user_streaming` legacy 경로(공유 헬퍼 `_reject_if_before_cutover()`) · native-bootstrap `consume_native_bootstrap`(원본 ID token의 auth_time이 소비 시점엔 없으므로 부트스트랩 코드의 `created_at`을 기준 시각으로 사용).

## ⚠️자체 발견 회귀 2건 (구현 중 직접 잡아 수정 — 그대로 보고)

### 1. DB 무접촉 경로에 무조건 DB 의존성 추가
legacy/Firebase JWT 검증은 원래 DB를 전혀 안 건드렸는데(서명/exp만 확인), cutover 검사를 무조건 넣어서 `db=AsyncMock()`/`db=None`으로 이 경로를 부르는 기존 단위 테스트 4개가 깨졌다 — 그중 `test_e_security_sec_s5_e2e_realdb`는 "override 없이 실 경로 통과"를 증명하려고 의도적으로 DB override를 안 쓴 테스트라 더 근본적인 설계 신호였다.

**수정**: 프로세스 전역 짧은-TTL(30초) 존재-캐시 `check_any_cutover_epoch_exists()` — "지금까지 단 한 번이라도 revoke된 적 있는가"가 False(현재 100% 상태)면 사용자별 DB 조회를 완전히 생략한다. DB 접속 자체가 실패해도 원래 무접촉이던 경로가 죽으면 안 되므로 fail-safe(직전 캐시값 유지)로 처리.

⚠️**트레이드오프(산티아고 리뷰 필요, 실제 판단 콜)**: `revoke_user_sessions()` 호출 즉시 같은 프로세스는 정밀검사 모드로 전환되지만, **다른 Cloud Run 인스턴스는 캐시 TTL(최대 30초)까지 갱신이 늦을 수 있다** — §17d-1이 요구하는 "즉시" fail-closed보다 느슨한 근사치다. legacy refresh_tokens 일괄 revoke 자체는 이 캐시와 무관하게 즉시 커밋되므로 "신규 refresh는 절대 불가"는 즉시 보장되고, 이 캐시가 관장하는 범위는 "이미 발급된, 아직 안 만료된 access token(최대 60분)"의 즉시 무효화뿐이다 — 캐시 없는 현재 설계(access token revoke 개념 자체가 없음, doc H2 finding)보다는 명백히 개선이지만 완전한 즉시성은 아니다.

### 2. lifespan startup 호출이 테스트 mock 큐 오염
캐시를 앱 시작 시 미리 warm하려고 `check_listen_config()` 등과 같은 패턴으로 lifespan에 `await check_any_cutover_epoch_exists()`를 넣었는데, `TestClient(app)`을 컨텍스트매니저로 쓰는 기존 SSE 테스트 3개(`test_s20`/`test_eventbus_s2`/`test_eventbus_s3`)가 lifespan도 함께 태우면서, 그 테스트들이 라우트 전용으로 짜둔 유한한 `mock_sess.execute.side_effect=[...]` 순서-큐를 startup 시점의 이 캐시 조회가 몰래 하나 먼저 소비해 라우트 자체 로직에서 큐 고갈로 실패했다. `git stash`로 clean develop에서 통과 확인 후 원인 특정.

**수정**: startup warm-up 호출 자체를 제거 — 캐시는 순수 지연 초기화(첫 실 요청에서 채워짐)만으로 충분하다.

## 뮤테이션 자체검증 3건 (전부 정확히 목표만 RED)
- 공유 verifier 가드(legacy/Firebase/SSE 3곳 동시) 무력화 → 대상 3개 테스트만 RED
- native-bootstrap consume cutover 검사 무력화 → orphan-finding 종결 테스트만 RED
- 존재-캐시 게이트를 "항상 스킵"으로 강제 → 동일 3개 reject 테스트만 RED

## 신규 테스트 22종
auth_cutover_service 8 + firebase_revoke_call 5 + verifier_cutover_realdb 6 + native_bootstrap_orphan_finding_realdb 3.

## 회귀
`pytest -m "not destructive_schema"` → **4159 passed**(기존 무관 7건 그대로, 신규 회귀 0 — 두 자체 발견 회귀 모두 fresh DB 재확인 끝에 완전히 닫힘 확定).

## 스코프 밖 (Story B, Phase 4 본체 — 별도, 산티아고 기존 Phase-4-final-review 게이트 유지)
대량 코호트 일괄 cutover job · 공지 배너/재설정 여정 연동 · idempotent bulk outbox 운영 도구.

## Test plan
- [x] 22개 신규 테스트 전부 통과
- [x] 전체 회귀 통과, 신규 실패 0(fresh DB 3회 재확인 — 자체 발견 회귀 2건 모두 근본 수정)
- [x] 뮤테이션 자체검증 3건 정확히 예상 범위만 RED
- [ ] 까심 QA
- [ ] 산티아고 1회 최종검증(security 접점 — PO 확인)
🤖 Generated with [Claude Code](https://claude.com/claude-code)