### PR TITLE
fix(tests): per-test unique installation_id — uq_github_installation_installation_id 격리 결함 해소

### DIFF
--- a/backend/tests/test_e_ui_daegbyeon_174be6bc_scope_violation_realdb.py
+++ b/backend/tests/test_e_ui_daegbyeon_174be6bc_scope_violation_realdb.py
@@ -78,7 +78,7 @@ async def _seed(session, *, declared_scope_paths=None, org_id=None):
     ).scalar_one_or_none()
     if inst is None:
         inst = GithubInstallation(
-            id=uuid.uuid4(), org_id=org, installation_id=90000 + abs(hash(str(org))) % 1000,
+            id=uuid.uuid4(), org_id=org, installation_id=uuid.uuid4().int % (10**9) + 1,
             account_login="moonklabs", account_type="Organization", suspended_at=None,
         )
         session.add(inst)


### PR DESCRIPTION
## 문제

`test_e_ui_daegbyeon_174be6bc_scope_violation_realdb.py` `_seed()`의 `installation_id` 계산:

```python
installation_id=90000 + abs(hash(str(org))) % 1000
```

범위가 90000–90999(1 000가지)뿐이라 병렬/재실행 시 `uq_github_installation_installation_id` unique constraint가 충돌, Alembic CI fail을 유발함. 리소스뷰 PR (#2207/#2208/#2209) 머지를 막는 develop 격리 결함(1e43d6bf).

## Fix

```python
installation_id=uuid.uuid4().int % (10**9) + 1
```

호출마다 [1, 10^9] 범위의 난수를 생성 → 충돌 확률 무시 가능. `uuid` 모듈은 이미 import됨.

## 검증

- diff 1줄 · 기존 로직 무변화
- 이 파일은 realdb 통합 테스트라 CI realdb 재실행으로 green 실증 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)