### PR TITLE
[SID:e38d634f] 문서 first-touch 지식 explainer 파일럿

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1570,6 +1570,8 @@
     "assigneeUnassigned": "Assign owner",
     "noProject": "No project selected",
     "selectDoc": "Select a document",
+    "emptyTitle": "No docs yet",
+    "emptyDescription": "Docs are where your org's knowledge, decisions, and context build up. The more that piles up, the easier the next decision gets.",
     "lastUpdated": "Last updated",
     "newDoc": "New Document",
     "save": "Save",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1570,6 +1570,8 @@
     "assigneeUnassigned": "담당자 배정",
     "noProject": "프로젝트가 선택되지 않았습니다",
     "selectDoc": "문서를 선택하세요",
+    "emptyTitle": "아직 쌓인 문서가 없어요",
+    "emptyDescription": "문서는 조직의 지식과 결정, 맥락이 쌓이는 곳입니다. 쌓일수록 다음 결정이 더 쉬워집니다.",
     "lastUpdated": "최종 수정",
     "newDoc": "새 문서",
     "save": "저장",

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-empty-view.test.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-empty-view.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+//
+// story e38d634f(doc resource-view-firsttouch-identity-pattern §4 "문서" 행): tree.length===0
+// (진짜 빈 프로젝트)일 때만 지식 정체성 explainer가 뜨고, tree.length>0(문서 있음·미선택)이면
+// 기존 "문서를 선택하세요" 카피가 완전 무변화로 유지되는지(가장 흔한 케이스라 이게 깨지면
+// 임팩트가 큼) 왕복 검증한다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../../../../messages/ko.json';
+
+const { useDocsLayoutMock } = vi.hoisted(() => ({
+  useDocsLayoutMock: vi.fn(),
+}));
+
+vi.mock('./docs-context', () => ({
+  useDocsLayout: () => useDocsLayoutMock(),
+}));
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => { root.unmount(); });
+  container.remove();
+  vi.resetModules();
+});
+
+async function mount() {
+  const { DocsEmptyView } = await import('./docs-empty-view');
+  await act(async () => { root.render(wrap(<DocsEmptyView />)); });
+}
+
+describe('DocsEmptyView — 문서 first-touch 정체성', () => {
+  it('tree가 진짜 빈 프로젝트(0건)면 지식 정체성 explainer가 렌더된다', async () => {
+    useDocsLayoutMock.mockReturnValue({ handleNewDoc: vi.fn(), tree: [] });
+    await mount();
+    const html = container.innerHTML;
+    expect(html).toContain('아직 쌓인 문서가 없어요');
+    expect(html).toContain('문서는 조직의 지식과 결정, 맥락이 쌓이는 곳입니다');
+    expect(html).toContain('새 문서');
+    expect(html).not.toContain('문서를 선택하세요'); // 이 케이스에선 안 뜸
+  });
+
+  it('tree에 문서가 있으면(미선택 상태) 기존 "문서를 선택하세요" 카피가 완전 무변화로 유지된다 — 가장 흔한 케이스', async () => {
+    useDocsLayoutMock.mockReturnValue({
+      handleNewDoc: vi.fn(),
+      tree: [{ id: 'd1', parent_id: null, title: '기획 문서', slug: 'plan', icon: null, sort_order: 0 }],
+    });
+    await mount();
+    const html = container.innerHTML;
+    expect(html).toContain('문서를 선택하세요');
+    // 정체성 explainer(진짜빈 전용 카피)는 여기 새면 안 됨 — 문서가 실재하는데 "아직 없어요"는 거짓.
+    expect(html).not.toContain('아직 쌓인 문서가 없어요');
+  });
+
+  it('CTA(새 문서) 클릭 시 기존 handleNewDoc이 호출된다(신규 다이얼로그 없음) — 진짜빈 케이스', async () => {
+    const handleNewDoc = vi.fn();
+    useDocsLayoutMock.mockReturnValue({ handleNewDoc, tree: [] });
+    await mount();
+    const ctaButton = [...container.querySelectorAll('button')].find((b) => b.textContent?.includes('새 문서'));
+    expect(ctaButton).not.toBeUndefined();
+    await act(async () => { ctaButton!.dispatchEvent(new MouseEvent('click', { bubbles: true })); });
+    expect(handleNewDoc).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-empty-view.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/docs-empty-view.tsx
@@ -1,14 +1,38 @@
 'use client';
 
-import { Plus } from 'lucide-react';
+import { Plus, BookOpen } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import { useTranslations } from 'next-intl';
 import { useDocsLayout } from './docs-context';
 
+// story e38d634f(doc resource-view-firsttouch-identity-pattern §4 "문서" 행 — visual=선택
+// 없음): `/docs` 인덱스는 특정 문서 미선택 시 항상 뜨는 뷰라(문서 50개 있어도 동일) — 정체성
+// explainer는 tree.length===0(진짜 빈 프로젝트)에만. tree.length>0(문서 있음·미선택)은 기존
+// "문서를 선택하세요" 완전 무변화(에픽 PR#2209·보드 PR#2211에서 확립한 필터빈/미선택 vs
+// 진짜빈 구분 재사용 — 이 뷰는 그 구분이 없으면 가장 흔하게 거짓 메시지가 뜰 뻔한 케이스).
 export function DocsEmptyView() {
   const t = useTranslations('docs');
-  const { handleNewDoc } = useDocsLayout();
+  const { handleNewDoc, tree } = useDocsLayout();
+
+  if (tree.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center p-4 lg:p-6">
+        <EmptyState
+          icon={<BookOpen className="size-8" />}
+          title={t('emptyTitle')}
+          description={t('emptyDescription')}
+          className="w-full max-w-lg bg-background/70"
+          action={
+            <Button size="sm" onClick={handleNewDoc}>
+              <Plus className="mr-1 h-4 w-4" />
+              {t('newDoc')}
+            </Button>
+          }
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-full items-center justify-center p-4 lg:p-6">


### PR DESCRIPTION
## Summary
doc `resource-view-firsttouch-identity-pattern` §4 "문서" 행 적용 — 진짜 빈 프로젝트일 때만 지식 정체성 explainer, 그 외(문서 있음·미선택)는 기존 동작 완전 무변화.

### ⚠️ 이 뷰가 가장 조심스러웠던 이유
`/docs` 인덱스 라우트(`page.tsx` → `DocsEmptyView`)는 **특정 문서를 선택하지 않았을 때 항상 뜨는 뷰**입니다 — 문서가 50개 있어도 방금 "문서" 탭을 클릭했다면 동일하게 이 뷰가 뜹니다. 여기에 무조건 "아직 문서가 없어요" 류 정체성 explainer를 씌우면, 에픽(#2209)·보드(#2211)에서 발견한 것보다 **더 흔한 케이스**에서 거짓 메시지가 뜨게 됩니다(문서를 여러 개 가진 프로젝트가 신규 프로젝트보다 훨씬 많을 것이므로).

`useDocsLayout().tree`(전체 문서 트리 배열)로 `tree.length === 0`(진짜 빈 프로젝트)만 정체성 explainer, `tree.length > 0`(문서 있음·미선택)은 기존 `"문서를 선택하세요"` 완전 무변화로 분리했습니다. 뮤테이션 셀프체크로 이 분기 자체를 검증했습니다(무력화하니 정확히 "문서 실재하는데 아직 없다"는 거짓 메시지가 재현됨).

### 적용 요소
1. **아이콘+headline(해요체):** `BookOpen` 아이콘 + "아직 쌓인 문서가 없어요".
2. **정체성 explainer(합니다체):** "문서는 조직의 지식과 결정, 맥락이 쌓이는 곳입니다. 쌓일수록 다음 결정이 더 쉬워집니다." — §4 "조직의 지식·결정과 맥락이 쌓이는 곳(복리)" 방향.
3. **visual:** 템플릿상 "선택 없음" 지정이라 생략.
4. **CTA:** 기존 `handleNewDoc` 재사용(신규 다이얼로그 없음). AI hint는 코드베이스에 실 AI-문서-초안 기능이 없음을 grep 확인해 no-fiction상 생략.

## 규율 준수
- C2a 신뢰 표면 무접촉.
- 문서 있음·미선택 케이스 완전 무변화(회귀 0).

## Test plan
- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm exec vitest run` (apps/web scope) — 243 files / 1597 passed, 무회귀
- [x] `pnpm exec vitest run` (repo-root scope) — 259 files / 1771 passed, 무회귀
- [x] `NEXT_TELEMETRY_DISABLED=1 pnpm build` — genuine EXIT=0
- [x] 뮤테이션 셀프체크: `tree.length === 0` 분기 조건을 `true`로 무력화 → "문서 있음" 테스트가 정확히 RED(거짓 정체성 카피 노출) 확인 후 원복
- [x] 신규 테스트 3건: 진짜빈 5요소 렌더+구카피 미노출·문서있음 시 기존 카피 완전 무변화(가장 흔한 케이스)·CTA 클릭 시 기존 handleNewDoc 호출

🤖 Generated with [Claude Code](https://claude.com/claude-code)