### PR TITLE
feat(auth): E-AUTH-REBUILD 활성화게이트 C1 — per-install 스키마+challenge 발급 인프라

### DIFF
--- a/backend/alembic/versions/0190_device_installations_proof_challenges.py
+++ b/backend/alembic/versions/0190_device_installations_proof_challenges.py
@@ -1,0 +1,133 @@
+"""story 822817a0(E-AUTH-REBUILD 활성화게이트][C1]·doc e-mobile-per-install-proof-feasibility
+§7.1/§7.2·산티아고 §7 SSOT 2026-07-16): per-installation attestation protocol v1 스키마.
+
+`device_installations` — 서버-authoritative 설치별 공개키/attestation 메타데이터.
+`device_proof_challenges` — 1회용 챌린지(raw nonce 미저장, SHA-256 hash만). purpose:
+register|bootstrap_issue|bootstrap_redeem.
+
+additive — 기존 스키마 무회귀. FIREBASE_AUTH_MOBILE_ISSUE는 여전히 모든 non-test 환경에서
+off 유지(§7.7 활성화 게이트 미완— C1은 스키마+챌린지 발급만, 검증기는 C2/C3, 배선은 C4).
+
+Revision ID: 0190
+Revises: 0189
+Create Date: 2026-07-16
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0190"
+down_revision = "0189"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "device_installations",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("firebase_uid", sa.Text(), nullable=False),
+        # 산티아고 §7.1: exact project/tenant/environment/app 바인딩 — 크로스 환경 설치 재생 방지.
+        sa.Column("project_id", sa.Text(), nullable=False),
+        sa.Column("tenant_id", sa.Text(), nullable=True),
+        sa.Column("environment", sa.Text(), nullable=False),
+        sa.Column("platform", sa.Text(), nullable=False),  # ios|android
+        sa.Column("app_id", sa.Text(), nullable=False),  # exact bundle id / package name
+        sa.Column("release_cert_digest", sa.Text(), nullable=True),  # Android 서명 인증서 digest
+        sa.Column("key_version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("key_id", sa.Text(), nullable=True),  # iOS App Attest keyId
+        sa.Column("public_key_fingerprint", sa.Text(), nullable=False),
+        sa.Column("public_key_der", sa.LargeBinary(), nullable=False),
+        sa.Column("attestation_type", sa.Text(), nullable=False),  # app_attest|key_attestation
+        sa.Column("attestation_environment", sa.Text(), nullable=True),  # iOS AAGUID env(production|sandbox)
+        sa.Column("security_level", sa.Text(), nullable=True),  # Android: tee|strongbox
+        sa.Column("last_sign_count", sa.BigInteger(), nullable=True),  # iOS assertion signCount CAS
+        sa.Column("last_server_seq", sa.BigInteger(), nullable=True),  # Android server_seq CAS
+        sa.Column("status", sa.Text(), nullable=False, server_default="active"),  # active|revoked|quarantined
+        sa.Column("attested_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoke_reason", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index("ix_device_installations_user_id", "device_installations", ["user_id"])
+    op.create_unique_constraint(
+        "uq_device_installations_key_fingerprint",
+        "device_installations",
+        ["project_id", "public_key_fingerprint"],
+    )
+    # §7.3: bounded N(초기 5) active installations/user — 애플리케이션 레벨 카운트 가드(C4)를
+    # 위한 부분 인덱스. status='active' 행만 빠르게 카운트.
+    op.create_index(
+        "ix_device_installations_user_active",
+        "device_installations",
+        ["user_id"],
+        postgresql_where=sa.text("status = 'active'"),
+    )
+
+    op.create_table(
+        "device_proof_challenges",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        # raw nonce는 절대 저장하지 않는다(§7.2) — SHA-256 hex만.
+        sa.Column("nonce_hash", sa.Text(), nullable=False),
+        sa.Column("purpose", sa.Text(), nullable=False),  # register|bootstrap_issue|bootstrap_redeem
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("firebase_uid", sa.Text(), nullable=False),
+        sa.Column("project_id", sa.Text(), nullable=False),
+        sa.Column("tenant_id", sa.Text(), nullable=True),
+        sa.Column("environment", sa.Text(), nullable=False),
+        sa.Column("app_id", sa.Text(), nullable=False),
+        sa.Column("platform", sa.Text(), nullable=False),
+        # register 챌린지 발급 시점엔 설치가 아직 없으므로 NULL 허용.
+        sa.Column(
+            "installation_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("device_installations.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column("key_version", sa.Integer(), nullable=True),
+        sa.Column("server_seq", sa.BigInteger(), nullable=True),  # Android CAS 챌린지 바인딩
+        sa.Column("web_origin", sa.Text(), nullable=False),
+        sa.Column("request_body_hash", sa.Text(), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_unique_constraint(
+        "uq_device_proof_challenges_nonce_hash", "device_proof_challenges", ["nonce_hash"]
+    )
+    op.create_index("ix_device_proof_challenges_user_id", "device_proof_challenges", ["user_id"])
+    op.create_index("ix_device_proof_challenges_installation_id", "device_proof_challenges", ["installation_id"])
+    # §7.1: purpose당 설치당 active challenge 1개 — register는 installation_id NULL이라
+    # user_id+purpose로, 이후 구매/redeem류는 installation_id+purpose로 부분 유니크.
+    op.create_index(
+        "uq_device_proof_challenges_active_by_installation",
+        "device_proof_challenges",
+        ["installation_id", "purpose"],
+        unique=True,
+        postgresql_where=sa.text("consumed_at IS NULL AND installation_id IS NOT NULL"),
+    )
+    op.create_index(
+        "uq_device_proof_challenges_active_register_by_user",
+        "device_proof_challenges",
+        ["user_id", "purpose"],
+        unique=True,
+        postgresql_where=sa.text("consumed_at IS NULL AND installation_id IS NULL AND purpose = 'register'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_device_proof_challenges_active_register_by_user", table_name="device_proof_challenges")
+    op.drop_index("uq_device_proof_challenges_active_by_installation", table_name="device_proof_challenges")
+    op.drop_index("ix_device_proof_challenges_installation_id", table_name="device_proof_challenges")
+    op.drop_index("ix_device_proof_challenges_user_id", table_name="device_proof_challenges")
+    op.drop_constraint("uq_device_proof_challenges_nonce_hash", "device_proof_challenges", type_="unique")
+    op.drop_table("device_proof_challenges")
+
+    op.drop_index("ix_device_installations_user_active", table_name="device_installations")
+    op.drop_constraint("uq_device_installations_key_fingerprint", "device_installations", type_="unique")
+    op.drop_index("ix_device_installations_user_id", table_name="device_installations")
+    op.drop_table("device_installations")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -61,7 +61,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import a2a, account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import a2a, account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, device_installations, dispatch, docs, entities, epics, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 # 도메인 축 B(org-1st-class-surface-ia-design-b §3): OpenAPI 태그 조직-우선 위계.
 # 개별 라우터는 기존 세부 tag(예 "stories")를 그대로 유지하고 이 4축 태그를 추가로 보유(다중
@@ -244,6 +244,7 @@ app.include_router(bridge.router)
 app.include_router(cron.router)
 app.include_router(auth_firebase_internal.router)
 app.include_router(auth_native_bootstrap.router)
+app.include_router(device_installations.router)
 app.include_router(hitl.router)
 app.include_router(integrations.router)
 app.include_router(workflow_versions.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -10,6 +10,7 @@ from app.models.auth_native_bootstrap import AuthNativeBootstrapCode
 from app.models.bridge import BridgeChannelMapping, BridgeUserMapping
 from app.models.deletion_audit import DeletionAuditLog
 from app.models.dependency import ItemDependency
+from app.models.device_installation import DeviceInstallation, DeviceProofChallenge
 from app.models.entity_slug_history import EntitySlugHistory
 from app.models.embedding import Embedding
 from app.models.evidence import Evidence
@@ -69,6 +70,8 @@ __all__ = [
     "AuthMigration",
     "AuthMigrationEvent",
     "AuthNativeBootstrapCode",
+    "DeviceInstallation",
+    "DeviceProofChallenge",
     "ArtifactNode",
     "ArtifactVersion",
     "VisualArtifact",

--- a/backend/app/models/device_installation.py
+++ b/backend/app/models/device_installation.py
@@ -1,0 +1,72 @@
+"""story 822817a0(E-AUTH-REBUILD 활성화게이트][C1]·doc e-mobile-per-install-proof-feasibility
+§7.1/§7.2·산티아고 §7 SSOT 2026-07-16): per-installation attestation protocol v1 스키마.
+
+`DeviceInstallation` — 서버-authoritative. public_key는 서버가 attestation에서 추출한 값만
+신뢰(클라이언트 제공 공개키는 절대 그대로 신뢰하지 않는다 — §7.3). `DeviceProofChallenge` —
+raw nonce는 어디에도 저장하지 않는다(hash만)."""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Integer, LargeBinary, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class DeviceInstallation(Base):
+    __tablename__ = "device_installations"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    firebase_uid: Mapped[str] = mapped_column(Text, nullable=False)
+    project_id: Mapped[str] = mapped_column(Text, nullable=False)
+    tenant_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    environment: Mapped[str] = mapped_column(Text, nullable=False)
+    platform: Mapped[str] = mapped_column(Text, nullable=False)
+    app_id: Mapped[str] = mapped_column(Text, nullable=False)
+    release_cert_digest: Mapped[str | None] = mapped_column(Text, nullable=True)
+    key_version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    key_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    public_key_fingerprint: Mapped[str] = mapped_column(Text, nullable=False)
+    public_key_der: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    attestation_type: Mapped[str] = mapped_column(Text, nullable=False)
+    attestation_environment: Mapped[str | None] = mapped_column(Text, nullable=True)
+    security_level: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_sign_count: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    last_server_seq: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="active", server_default="active")
+    attested_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    revoke_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
+class DeviceProofChallenge(Base):
+    __tablename__ = "device_proof_challenges"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    nonce_hash: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    purpose: Mapped[str] = mapped_column(Text, nullable=False)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    firebase_uid: Mapped[str] = mapped_column(Text, nullable=False)
+    project_id: Mapped[str] = mapped_column(Text, nullable=False)
+    tenant_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    environment: Mapped[str] = mapped_column(Text, nullable=False)
+    app_id: Mapped[str] = mapped_column(Text, nullable=False)
+    platform: Mapped[str] = mapped_column(Text, nullable=False)
+    installation_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("device_installations.id", ondelete="CASCADE"), nullable=True, index=True
+    )
+    key_version: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    server_seq: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    web_origin: Mapped[str] = mapped_column(Text, nullable=False)
+    request_body_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    consumed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/backend/app/routers/auth_native_bootstrap.py
+++ b/backend/app/routers/auth_native_bootstrap.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
@@ -25,9 +26,17 @@ from app.core.config import settings
 from app.core.rate_limit import limiter
 from app.dependencies.database import get_db
 from app.models.auth_identity import AuthIdentity
+from app.models.device_installation import DeviceInstallation
 from app.models.user import User
+from app.services.device_proof import (
+    PURPOSE_BOOTSTRAP_ISSUE,
+    TTL_BOOTSTRAP_ISSUE_SECONDS,
+    ChallengeAlreadyActiveError,
+    issue_challenge,
+)
 from app.services.firebase_verifier import verify_app_check_token, verify_firebase_id_token
 from app.services.native_bootstrap import DEFAULT_TTL_SECONDS, issue_bootstrap_code
+from app.services.native_request_auth import verify_native_request
 
 logger = logging.getLogger(__name__)
 
@@ -131,3 +140,87 @@ async def native_bootstrap(
     )
     logger.info("auth.native_bootstrap success")
     return NativeBootstrapResponse(code=code, expires_in=DEFAULT_TTL_SECONDS)
+
+
+# story 822817a0(C1·doc §7.1/§7.5): bootstrap_issue 챌린지 발급 — §7.5 2단계 원자 트랜잭션의
+# 1단계 준비물(실제 원자 issue+redeem-challenge 동시생성 배선은 C4). 여기서는 이미 등록된
+# active 설치가 자신의 것임을 확인하고 챌린지만 발급한다. App Check는 필수(구 위 엔드포인트의
+# optional 스킴과 다름 — §7 신규 프로토콜은 강제).
+class NativeBootstrapChallengeRequest(BaseModel):
+    app_check_token: str | None = None
+    installation_id: str
+
+
+class NativeBootstrapChallengeResponse(BaseModel):
+    challenge_id: str
+    client_data_b64url: str
+    expires_in: int
+
+
+@router.post("/native-bootstrap/challenges", response_model=NativeBootstrapChallengeResponse)
+@limiter.limit("10/minute")
+async def native_bootstrap_challenge(
+    request: Request,
+    body: NativeBootstrapChallengeRequest,
+    response: Response,
+    authorization: str | None = Header(default=None),
+    x_firebase_appcheck: str | None = Header(default=None),
+    db: AsyncSession = Depends(get_db),
+) -> NativeBootstrapChallengeResponse:
+    response.headers["Cache-Control"] = "no-store"
+
+    if not settings.firebase_auth_mobile_issue:
+        raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="Native bootstrap not enabled")
+
+    app_check_token = body.app_check_token or x_firebase_appcheck
+    verified = await verify_native_request(
+        authorization=authorization,
+        app_check_token=app_check_token,
+        db=db,
+        log_prefix="auth.native_bootstrap.challenge",
+    )
+
+    try:
+        installation_uuid = uuid.UUID(body.installation_id)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unknown installation")
+
+    installation = await db.get(DeviceInstallation, installation_uuid)
+    # 존재하지 않음/타인 소유/미활성/project 불일치 — 전부 동일하게 401(enumeration 방지,
+    # native_bootstrap.py 소비부 기존 관례와 동일).
+    if (
+        installation is None
+        or installation.user_id != verified.user_id
+        or installation.status != "active"
+        or installation.project_id != settings.firebase_project_id
+    ):
+        logger.warning("auth.native_bootstrap.challenge rejected reason=installation_not_eligible")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unknown installation")
+
+    try:
+        issued = await issue_challenge(
+            db,
+            purpose=PURPOSE_BOOTSTRAP_ISSUE,
+            user_id=verified.user_id,
+            firebase_uid=verified.firebase_uid,
+            project_id=settings.firebase_project_id,
+            tenant_id=None,
+            environment=installation.environment,
+            platform=installation.platform,
+            app_id=installation.app_id,
+            http_method="POST",
+            route="/api/v2/auth/native-bootstrap",
+            web_origin=str(request.base_url).rstrip("/"),
+            ttl_seconds=TTL_BOOTSTRAP_ISSUE_SECONDS,
+            installation_id=installation.id,
+            key_version=installation.key_version,
+        )
+    except ChallengeAlreadyActiveError:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Bootstrap challenge already active")
+
+    logger.info("auth.native_bootstrap.challenge success")
+    return NativeBootstrapChallengeResponse(
+        challenge_id=issued.challenge_id,
+        client_data_b64url=issued.client_data_b64url,
+        expires_in=TTL_BOOTSTRAP_ISSUE_SECONDS,
+    )

--- a/backend/app/routers/device_installations.py
+++ b/backend/app/routers/device_installations.py
@@ -1,0 +1,94 @@
+"""story 822817a0(E-AUTH-REBUILD 활성화게이트][C1]·doc e-mobile-per-install-proof-feasibility
+§7.1/§7.3): 설치 등록 챌린지 발급. 이 스토리는 발급만 — 실제 등록(register, 플랫폼 attestation
+검증 포함)은 C2(iOS)/C3(Android) 검증기 완성 후 C4가 배선한다.
+
+기본 비활성(`firebase_auth_mobile_issue=False`가 모든 non-test 환경 기본값) — S1~S5·Story A와
+동일 패턴."""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.rate_limit import limiter
+from app.dependencies.database import get_db
+from app.services.device_proof import (
+    PURPOSE_REGISTER,
+    TTL_REGISTER_SECONDS,
+    ChallengeAlreadyActiveError,
+    issue_challenge,
+)
+from app.services.native_request_auth import verify_native_request
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v2/auth/device-installations", tags=["auth", "firebase", "mobile", "device-install"])
+
+
+class RegistrationChallengeRequest(BaseModel):
+    app_check_token: str | None = None
+    platform: str  # ios|android
+    app_id: str
+    environment: str
+
+
+class RegistrationChallengeResponse(BaseModel):
+    challenge_id: str
+    client_data_b64url: str
+    expires_in: int
+
+
+@router.post("/registration-challenges", response_model=RegistrationChallengeResponse)
+@limiter.limit("10/minute")
+async def registration_challenge(
+    request: Request,
+    body: RegistrationChallengeRequest,
+    response: Response,
+    authorization: str | None = Header(default=None),
+    x_firebase_appcheck: str | None = Header(default=None),
+    db: AsyncSession = Depends(get_db),
+) -> RegistrationChallengeResponse:
+    response.headers["Cache-Control"] = "no-store"
+
+    if not settings.firebase_auth_mobile_issue:
+        raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="Device installation not enabled")
+
+    if body.platform not in ("ios", "android"):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Unsupported platform")
+
+    app_check_token = body.app_check_token or x_firebase_appcheck
+    verified = await verify_native_request(
+        authorization=authorization,
+        app_check_token=app_check_token,
+        db=db,
+        log_prefix="auth.device_installations.registration_challenge",
+    )
+
+    try:
+        issued = await issue_challenge(
+            db,
+            purpose=PURPOSE_REGISTER,
+            user_id=verified.user_id,
+            firebase_uid=verified.firebase_uid,
+            project_id=settings.firebase_project_id,
+            tenant_id=None,
+            environment=body.environment,
+            platform=body.platform,
+            app_id=body.app_id,
+            http_method="POST",
+            route="/api/v2/auth/device-installations/register",
+            web_origin=str(request.base_url).rstrip("/"),
+            ttl_seconds=TTL_REGISTER_SECONDS,
+        )
+    except ChallengeAlreadyActiveError:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Registration challenge already active")
+
+    logger.info("auth.device_installations.registration_challenge success")
+    return RegistrationChallengeResponse(
+        challenge_id=issued.challenge_id,
+        client_data_b64url=issued.client_data_b64url,
+        expires_in=TTL_REGISTER_SECONDS,
+    )

--- a/backend/app/services/device_proof.py
+++ b/backend/app/services/device_proof.py
@@ -1,0 +1,201 @@
+"""story 822817a0(E-AUTH-REBUILD 활성화게이트][C1]·doc e-mobile-per-install-proof-feasibility
+§7.1/§7.2·산티아고 §7 SSOT 2026-07-16): per-installation attestation protocol v1 — 챌린지
+발급 + canonical transcript 구성.
+
+**canonical transcript(§7.2)**: 서버가 payload를 직접 구성한다(클라이언트 재직렬화를 절대
+신뢰하지 않는다). 도메인분리+버전 태그(`SP_DEVICE_PROOF_V1`)를 포함한 결정적(sorted-key)
+JSON을 base64url로 인코딩해 `client_data_b64url`로 반환 — 네이티브 클라이언트는 이 바이트를
+그대로 서명/CBOR에 바인딩만 하고 재구성하지 않는다.
+
+**챌린지 소비(원자적 1회)는 이 스토리 스코프 밖**이다 — register/native-bootstrap 엔드포인트
+본체(C4)가 attestation/assertion 검증(C2/C3)과 함께 단일 트랜잭션에서 처리한다. 여기서는
+발급(issue)만 구현한다.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import logging
+import secrets
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.device_installation import DeviceProofChallenge
+
+logger = logging.getLogger(__name__)
+
+TRANSCRIPT_VERSION = "SP_DEVICE_PROOF_V1"
+
+# 산티아고 §7 SSOT 확정 TTL(2026-07-16).
+TTL_REGISTER_SECONDS = 120
+TTL_BOOTSTRAP_ISSUE_SECONDS = 60
+TTL_BOOTSTRAP_REDEEM_SECONDS = 45
+
+PURPOSE_REGISTER = "register"
+PURPOSE_BOOTSTRAP_ISSUE = "bootstrap_issue"
+PURPOSE_BOOTSTRAP_REDEEM = "bootstrap_redeem"
+
+
+class ChallengeAlreadyActiveError(Exception):
+    """purpose당 설치(또는 register는 user)당 active 챌린지 1개 제약(부분 유니크 인덱스)
+    위반 — 호출부는 409로 매핑."""
+
+
+def _canonical_json(payload: dict) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+@dataclass
+class TranscriptContext:
+    purpose: str
+    challenge_id: str
+    raw_nonce: str
+    user_id: str
+    firebase_uid: str
+    project_id: str
+    tenant_id: str | None
+    environment: str
+    platform: str
+    app_id: str
+    installation_id: str | None
+    key_version: int | None
+    http_method: str
+    route: str
+    web_origin: str
+    body_sha256: str | None
+    bootstrap_code_sha256: str | None = None
+
+
+def build_canonical_transcript(ctx: TranscriptContext) -> bytes:
+    """§7.2: 도메인분리+버전 태그 포함 결정적 payload. bootstrap redeem은
+    `bootstrap_code_sha256`(SHA256(raw bootstrap code))을 반드시 포함(§7.5) — 그 외
+    purpose는 이 필드를 아예 생략(포함 유무 자체가 purpose 구분 신호이자, None 값을 넣어
+    직렬화하면 redeem 위조 시 easy-guess 필드가 되는 것을 피한다)."""
+    payload = {
+        "v": TRANSCRIPT_VERSION,
+        "purpose": ctx.purpose,
+        "challenge_id": ctx.challenge_id,
+        "nonce": ctx.raw_nonce,
+        "user_id": ctx.user_id,
+        "firebase_uid": ctx.firebase_uid,
+        "project_id": ctx.project_id,
+        "tenant_id": ctx.tenant_id,
+        "environment": ctx.environment,
+        "platform": ctx.platform,
+        "app_id": ctx.app_id,
+        "installation_id": ctx.installation_id,
+        "key_version": ctx.key_version,
+        "method": ctx.http_method,
+        "route": ctx.route,
+        "origin": ctx.web_origin,
+        "body_sha256": ctx.body_sha256,
+    }
+    if ctx.bootstrap_code_sha256 is not None:
+        payload["bootstrap_code_sha256"] = ctx.bootstrap_code_sha256
+    return _canonical_json(payload)
+
+
+def client_data_b64url(transcript: bytes) -> str:
+    return _b64url(transcript)
+
+
+def sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+@dataclass
+class IssuedChallenge:
+    challenge_id: str
+    client_data_b64url: str
+    expires_at: datetime
+
+
+async def issue_challenge(
+    db: AsyncSession,
+    *,
+    purpose: str,
+    user_id,
+    firebase_uid: str,
+    project_id: str,
+    tenant_id: str | None,
+    environment: str,
+    platform: str,
+    app_id: str,
+    http_method: str,
+    route: str,
+    web_origin: str,
+    ttl_seconds: int,
+    installation_id=None,
+    key_version: int | None = None,
+    server_seq: int | None = None,
+    request_body_hash: str | None = None,
+) -> IssuedChallenge:
+    """raw nonce는 반환값에 별도로 노출되지 않는다 — canonical transcript 안에 이미
+    인코딩되어 `client_data_b64url`로만 나간다. `ChallengeAlreadyActiveError`는 purpose당
+    설치(또는 user, register 한정)당 이미 미소비 챌린지가 있을 때 발생 — 호출부가 409로
+    매핑한다(§7.1: "One active challenge per purpose per installation")."""
+    raw_nonce = secrets.token_hex(32)  # 256bit CSPRNG(§7.1)
+    challenge_id = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+
+    row = DeviceProofChallenge(
+        id=challenge_id,
+        nonce_hash=sha256_hex(raw_nonce.encode()),
+        purpose=purpose,
+        user_id=user_id,
+        firebase_uid=firebase_uid,
+        project_id=project_id,
+        tenant_id=tenant_id,
+        environment=environment,
+        app_id=app_id,
+        platform=platform,
+        installation_id=installation_id,
+        key_version=key_version,
+        server_seq=server_seq,
+        web_origin=web_origin,
+        request_body_hash=request_body_hash,
+        expires_at=now + timedelta(seconds=ttl_seconds),
+        created_at=now,
+    )
+    db.add(row)
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        logger.warning("device_proof.issue_challenge rejected reason=already_active purpose=%s", purpose)
+        raise ChallengeAlreadyActiveError() from exc
+
+    transcript = build_canonical_transcript(
+        TranscriptContext(
+            purpose=purpose,
+            challenge_id=str(challenge_id),
+            raw_nonce=raw_nonce,
+            user_id=str(user_id),
+            firebase_uid=firebase_uid,
+            project_id=project_id,
+            tenant_id=tenant_id,
+            environment=environment,
+            platform=platform,
+            app_id=app_id,
+            installation_id=str(installation_id) if installation_id else None,
+            key_version=key_version,
+            http_method=http_method,
+            route=route,
+            web_origin=web_origin,
+            body_sha256=request_body_hash,
+        )
+    )
+    return IssuedChallenge(
+        challenge_id=str(challenge_id),
+        client_data_b64url=client_data_b64url(transcript),
+        expires_at=row.expires_at,
+    )

--- a/backend/app/services/native_request_auth.py
+++ b/backend/app/services/native_request_auth.py
@@ -1,0 +1,107 @@
+"""story 822817a0(E-AUTH-REBUILD 활성화게이트][C1]·doc §7 SSOT 서두): §7 신규 public native
+엔드포인트(챌린지 발급 2종, 이후 register/consume은 C4)가 공유하는 전처리 —
+exact Firebase Bearer ID token(auth_time<=5m) + exact App Check(REQUIRED, optional 아님 —
+구 S5 `native_bootstrap.py` 스킴과의 차이) + eligible migration state.
+
+⚠️`auth_valid_after` cutover 재확인(story bea25062·PR #2206)은 이 헬퍼에 아직 없다 —
+Story A가 이 브랜치 기준(origin/develop)엔 아직 머지되지 않았다(PR #2206 오픈·산티아고
+리뷰 대기). 이 엔드포인트들은 `firebase_auth_mobile_issue` 플래그가 모든 non-test 환경에서
+False로 유지되는 한 501로 완전 비활성 상태이므로 라이브 보안 영향은 없다 — Story A 머지 후
+후속 소패치로 `_reject_if_before_cutover` 호출을 추가한다(C4 활성화 게이트 §7.7 체크리스트
+항목)."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.auth_identity import AuthIdentity, AuthMigration
+from app.models.user import User
+from app.services.firebase_verifier import verify_app_check_token, verify_firebase_id_token
+
+logger = logging.getLogger(__name__)
+
+_AUTH_TIME_MAX_AGE_SECONDS = 5 * 60
+
+
+@dataclass
+class VerifiedNativeRequest:
+    user_id: object
+    firebase_uid: str
+    app_check_app_id: str
+
+
+def extract_bearer(authorization: str | None) -> str | None:
+    if not authorization or not authorization.startswith("Bearer "):
+        return None
+    return authorization[len("Bearer "):]
+
+
+def allowed_app_ids() -> frozenset[str]:
+    raw = settings.firebase_app_check_allowed_app_ids
+    return frozenset(x.strip() for x in raw.split(",") if x.strip())
+
+
+async def verify_native_request(
+    *,
+    authorization: str | None,
+    app_check_token: str | None,
+    db: AsyncSession,
+    log_prefix: str,
+) -> VerifiedNativeRequest:
+    """실패 시 항상 401(enumeration 방지 — 사유는 로그에만). 순서: ID token → auth_time →
+    App Check(필수) → identity 매핑 → user active → migration state 적격."""
+    id_token = extract_bearer(authorization)
+    if id_token is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing Firebase ID token")
+
+    verified = await verify_firebase_id_token(id_token, settings.firebase_project_id)
+    if verified is None:
+        logger.warning("%s rejected reason=id_token_invalid", log_prefix)
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid Firebase ID token")
+
+    now = datetime.now(timezone.utc).timestamp()
+    if now - verified.auth_time > _AUTH_TIME_MAX_AGE_SECONDS:
+        logger.warning("%s rejected reason=auth_time_stale", log_prefix)
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication too old")
+
+    if not app_check_token:
+        logger.warning("%s rejected reason=app_check_missing", log_prefix)
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="App Check token required")
+
+    app_check = await verify_app_check_token(app_check_token, settings.firebase_project_number, allowed_app_ids())
+    if app_check is None:
+        logger.warning("%s rejected reason=app_check_invalid", log_prefix)
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid App Check token")
+
+    identity_row = (
+        await db.execute(
+            select(AuthIdentity).where(
+                AuthIdentity.issuer == verified.issuer,
+                AuthIdentity.subject == verified.firebase_uid,
+                AuthIdentity.unlinked_at.is_(None),
+            )
+        )
+    ).scalar_one_or_none()
+    if identity_row is None:
+        logger.warning("%s rejected reason=unmapped_identity", log_prefix)
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unmapped Firebase identity")
+
+    user = await db.get(User, identity_row.user_id)
+    if user is None or not user.is_active:
+        logger.warning("%s rejected reason=inactive_or_missing_user", log_prefix)
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid user")
+
+    migration = await db.get(AuthMigration, identity_row.user_id)
+    if migration is None or migration.state not in ("provisioning", "firebase"):
+        logger.warning("%s rejected reason=ineligible_migration_state", log_prefix)
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Account not eligible")
+
+    return VerifiedNativeRequest(
+        user_id=identity_row.user_id, firebase_uid=verified.firebase_uid, app_check_app_id=app_check.app_id
+    )

--- a/backend/tests/test_822817a0_c1_device_installations_realdb.py
+++ b/backend/tests/test_822817a0_c1_device_installations_realdb.py
@@ -1,0 +1,480 @@
+"""story 822817a0(E-AUTH-REBUILD 활성화게이트][C1]·doc e-mobile-per-install-proof-feasibility
+§7.1/§7.2·산티아고 §7 SSOT 2026-07-16) 게이트: 스키마+canonical transcript+챌린지 발급
+2종(registration-challenges·native-bootstrap/challenges) 실증. 플랫폼 attestation 검증
+(C2/C3)·register/consume 본체(C4)는 이 스토리 스코프 밖 — 여기선 발급 인프라만.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import HTTPException, Response
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+]
+
+PROJECT_ID = "test-project"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_after():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+class _FakeRequest:
+    base_url = "http://testserver/"
+
+
+def _setup_common(monkeypatch):
+    from app.core.config import settings
+    monkeypatch.setattr(settings, "firebase_auth_mobile_issue", True)
+    monkeypatch.setattr(settings, "firebase_project_id", PROJECT_ID)
+    monkeypatch.setattr(settings, "firebase_project_number", "123456")
+    monkeypatch.setattr(settings, "firebase_app_check_allowed_app_ids", "1:123456:ios:approved")
+
+
+def _mock_verifiers(monkeypatch, *, firebase_uid: str, auth_time: int | None = None):
+    from app.services.firebase_verifier import VerifiedAppCheck, VerifiedFirebaseIdToken
+    import app.services.native_request_auth as nra_mod
+
+    if auth_time is None:
+        auth_time = int(datetime.now(timezone.utc).timestamp())
+
+    async def fake_verify_id_token(token, project_id):
+        if token != "valid-id-token":
+            return None
+        return VerifiedFirebaseIdToken(
+            issuer=f"https://securetoken.google.com/{PROJECT_ID}",
+            firebase_uid=firebase_uid, email="u@test.com", auth_time=auth_time,
+        )
+
+    async def fake_verify_app_check(token, project_number, allowed_app_ids):
+        if token != "valid-app-check":
+            return None
+        return VerifiedAppCheck(issuer="https://firebaseappcheck.googleapis.com/123456", app_id="1:123456:ios:approved")
+
+    monkeypatch.setattr(nra_mod, "verify_firebase_id_token", fake_verify_id_token)
+    monkeypatch.setattr(nra_mod, "verify_app_check_token", fake_verify_app_check)
+
+
+async def _seed_eligible_user(session, *, state="firebase"):
+    from app.core.security import hash_password
+    from app.models.auth_identity import AuthIdentity, AuthMigration
+    from app.models.user import User
+
+    user_id = uuid.uuid4()
+    firebase_uid = f"fb-uid-{user_id.hex[:8]}"
+    session.add(User(
+        id=user_id, email=f"c1-{user_id.hex[:8]}@test.com",
+        hashed_password=hash_password("x"), is_active=True, email_verified=True,
+    ))
+    await session.commit()
+    session.add(AuthMigration(user_id=user_id, state=state))
+    session.add(AuthIdentity(
+        id=uuid.uuid4(), user_id=user_id,
+        issuer=f"https://securetoken.google.com/{PROJECT_ID}", subject=firebase_uid,
+        provider_id="password",
+    ))
+    await session.commit()
+    return user_id, firebase_uid
+
+
+async def _seed_installation(session, *, user_id, status="active", environment="production", platform="ios", app_id="com.sprintable.app"):
+    from app.models.device_installation import DeviceInstallation
+
+    installation = DeviceInstallation(
+        id=uuid.uuid4(), user_id=user_id, firebase_uid=f"fb-uid-{user_id.hex[:8]}",
+        project_id=PROJECT_ID, environment=environment, platform=platform, app_id=app_id,
+        key_version=1, public_key_fingerprint=f"fp-{uuid.uuid4().hex[:12]}", public_key_der=b"\x00\x01\x02",
+        attestation_type="app_attest", status=status, attested_at=datetime.now(timezone.utc),
+        created_at=datetime.now(timezone.utc),
+    )
+    session.add(installation)
+    await session.commit()
+    return installation.id
+
+
+# ─── canonical transcript 순수 로직 ─────────────────────────────────────────
+
+def test_canonical_transcript_deterministic():
+    from app.services.device_proof import TranscriptContext, build_canonical_transcript
+
+    ctx = TranscriptContext(
+        purpose="register", challenge_id="chal-1", raw_nonce="nonce-abc", user_id="user-1",
+        firebase_uid="fb-1", project_id=PROJECT_ID, tenant_id=None, environment="production",
+        platform="ios", app_id="com.sprintable.app", installation_id=None, key_version=None,
+        http_method="POST", route="/api/v2/auth/device-installations/register",
+        web_origin="https://sprintable.app", body_sha256=None,
+    )
+    t1 = build_canonical_transcript(ctx)
+    t2 = build_canonical_transcript(ctx)
+    assert t1 == t2
+    assert b"SP_DEVICE_PROOF_V1" in t1
+    assert b"register" in t1
+
+
+def test_canonical_transcript_redeem_includes_bootstrap_code_hash():
+    from app.services.device_proof import TranscriptContext, build_canonical_transcript
+
+    base_kwargs = dict(
+        purpose="bootstrap_redeem", challenge_id="chal-2", raw_nonce="nonce-xyz", user_id="user-1",
+        firebase_uid="fb-1", project_id=PROJECT_ID, tenant_id=None, environment="production",
+        platform="android", app_id="com.sprintable.app", installation_id="inst-1", key_version=1,
+        http_method="POST", route="/auth/native", web_origin="https://sprintable.app", body_sha256=None,
+    )
+    without_code = build_canonical_transcript(TranscriptContext(**base_kwargs))
+    with_code = build_canonical_transcript(TranscriptContext(**base_kwargs, bootstrap_code_sha256="a" * 64))
+    assert b"bootstrap_code_sha256" not in without_code
+    assert b"bootstrap_code_sha256" in with_code
+
+
+def test_client_data_b64url_roundtrip_decodable():
+    import base64
+    from app.services.device_proof import TranscriptContext, build_canonical_transcript, client_data_b64url
+
+    ctx = TranscriptContext(
+        purpose="register", challenge_id="chal-3", raw_nonce="n", user_id="u", firebase_uid="fb",
+        project_id=PROJECT_ID, tenant_id=None, environment="production", platform="ios", app_id="app",
+        installation_id=None, key_version=None, http_method="POST", route="/x",
+        web_origin="https://sprintable.app", body_sha256=None,
+    )
+    transcript = build_canonical_transcript(ctx)
+    encoded = client_data_b64url(transcript)
+    # urlsafe_b64decode requires padding restored
+    padded = encoded + "=" * (-len(encoded) % 4)
+    assert base64.urlsafe_b64decode(padded) == transcript
+
+
+# ─── issue_challenge() 서비스 계약 ──────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_issue_challenge_creates_row_matching_ttl():
+    from app.services.device_proof import PURPOSE_REGISTER, issue_challenge
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id, firebase_uid = await _seed_eligible_user(s)
+        async with Session() as s:
+            issued = await issue_challenge(
+                s, purpose=PURPOSE_REGISTER, user_id=user_id, firebase_uid=firebase_uid,
+                project_id=PROJECT_ID, tenant_id=None, environment="production", platform="ios",
+                app_id="com.sprintable.app", http_method="POST", route="/register",
+                web_origin="https://sprintable.app", ttl_seconds=120,
+            )
+        assert issued.challenge_id
+        assert issued.client_data_b64url
+        delta = (issued.expires_at - datetime.now(timezone.utc)).total_seconds()
+        assert 110 < delta <= 120
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_issue_challenge_duplicate_active_raises():
+    from app.services.device_proof import ChallengeAlreadyActiveError, PURPOSE_REGISTER, issue_challenge
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id, firebase_uid = await _seed_eligible_user(s)
+
+        kwargs = dict(
+            purpose=PURPOSE_REGISTER, user_id=user_id, firebase_uid=firebase_uid, project_id=PROJECT_ID,
+            tenant_id=None, environment="production", platform="ios", app_id="com.sprintable.app",
+            http_method="POST", route="/register", web_origin="https://sprintable.app", ttl_seconds=120,
+        )
+        async with Session() as s:
+            await issue_challenge(s, **kwargs)
+        async with Session() as s:
+            with pytest.raises(ChallengeAlreadyActiveError):
+                await issue_challenge(s, **kwargs)
+    finally:
+        await engine.dispose()
+
+
+# ─── POST /api/v2/auth/device-installations/registration-challenges ────────
+
+@pytest.mark.anyio
+async def test_registration_challenge_default_off_501(monkeypatch):
+    from app.routers.device_installations import RegistrationChallengeRequest, registration_challenge
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc:
+                await registration_challenge(
+                    _FakeRequest(),
+                    RegistrationChallengeRequest(app_check_token="x", platform="ios", app_id="a", environment="production"),
+                    Response(), authorization="Bearer valid-id-token", x_firebase_appcheck="valid-app-check", db=s,
+                )
+            assert exc.value.status_code == 501
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_registration_challenge_missing_bearer_401(monkeypatch):
+    from app.routers.device_installations import RegistrationChallengeRequest, registration_challenge
+
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc:
+                await registration_challenge(
+                    _FakeRequest(),
+                    RegistrationChallengeRequest(app_check_token="valid-app-check", platform="ios", app_id="a", environment="production"),
+                    Response(), authorization=None, x_firebase_appcheck="valid-app-check", db=s,
+                )
+            assert exc.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_registration_challenge_missing_app_check_401(monkeypatch):
+    from app.routers.device_installations import RegistrationChallengeRequest, registration_challenge
+
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id, firebase_uid = await _seed_eligible_user(s)
+        _mock_verifiers(monkeypatch, firebase_uid=firebase_uid)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc:
+                await registration_challenge(
+                    _FakeRequest(),
+                    RegistrationChallengeRequest(app_check_token=None, platform="ios", app_id="a", environment="production"),
+                    Response(), authorization="Bearer valid-id-token", x_firebase_appcheck=None, db=s,
+                )
+            assert exc.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_registration_challenge_success(monkeypatch):
+    from app.routers.device_installations import RegistrationChallengeRequest, registration_challenge
+
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id, firebase_uid = await _seed_eligible_user(s)
+        _mock_verifiers(monkeypatch, firebase_uid=firebase_uid)
+        async with Session() as s:
+            result = await registration_challenge(
+                _FakeRequest(),
+                RegistrationChallengeRequest(app_check_token="valid-app-check", platform="ios", app_id="com.sprintable.app", environment="production"),
+                Response(), authorization="Bearer valid-id-token", x_firebase_appcheck=None, db=s,
+            )
+        assert result.challenge_id
+        assert result.client_data_b64url
+        assert result.expires_in == 120
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_registration_challenge_unsupported_platform_400(monkeypatch):
+    from app.routers.device_installations import RegistrationChallengeRequest, registration_challenge
+
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc:
+                await registration_challenge(
+                    _FakeRequest(),
+                    RegistrationChallengeRequest(app_check_token="x", platform="windows", app_id="a", environment="production"),
+                    Response(), authorization="Bearer valid-id-token", x_firebase_appcheck="valid-app-check", db=s,
+                )
+            assert exc.value.status_code == 400
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_registration_challenge_ineligible_migration_state_401(monkeypatch):
+    from app.routers.device_installations import RegistrationChallengeRequest, registration_challenge
+
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id, firebase_uid = await _seed_eligible_user(s, state="reset_required")
+        _mock_verifiers(monkeypatch, firebase_uid=firebase_uid)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc:
+                await registration_challenge(
+                    _FakeRequest(),
+                    RegistrationChallengeRequest(app_check_token="valid-app-check", platform="ios", app_id="a", environment="production"),
+                    Response(), authorization="Bearer valid-id-token", x_firebase_appcheck=None, db=s,
+                )
+            assert exc.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+# ─── POST /api/v2/auth/native-bootstrap/challenges ──────────────────────────
+
+@pytest.mark.anyio
+async def test_native_bootstrap_challenge_default_off_501(monkeypatch):
+    from app.routers.auth_native_bootstrap import NativeBootstrapChallengeRequest, native_bootstrap_challenge
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc:
+                await native_bootstrap_challenge(
+                    _FakeRequest(),
+                    NativeBootstrapChallengeRequest(app_check_token="x", installation_id=str(uuid.uuid4())),
+                    Response(), authorization="Bearer valid-id-token", x_firebase_appcheck="valid-app-check", db=s,
+                )
+            assert exc.value.status_code == 501
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_native_bootstrap_challenge_unknown_installation_401(monkeypatch):
+    from app.routers.auth_native_bootstrap import NativeBootstrapChallengeRequest, native_bootstrap_challenge
+
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id, firebase_uid = await _seed_eligible_user(s)
+        _mock_verifiers(monkeypatch, firebase_uid=firebase_uid)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc:
+                await native_bootstrap_challenge(
+                    _FakeRequest(),
+                    NativeBootstrapChallengeRequest(app_check_token="valid-app-check", installation_id=str(uuid.uuid4())),
+                    Response(), authorization="Bearer valid-id-token", x_firebase_appcheck=None, db=s,
+                )
+            assert exc.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_native_bootstrap_challenge_foreign_installation_401(monkeypatch):
+    """다른 사용자 소유 installation_id를 대면 401 — IDOR 방지."""
+    from app.routers.auth_native_bootstrap import NativeBootstrapChallengeRequest, native_bootstrap_challenge
+
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id, firebase_uid = await _seed_eligible_user(s)
+            other_user_id, _ = await _seed_eligible_user(s)
+            other_installation_id = await _seed_installation(s, user_id=other_user_id)
+        _mock_verifiers(monkeypatch, firebase_uid=firebase_uid)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc:
+                await native_bootstrap_challenge(
+                    _FakeRequest(),
+                    NativeBootstrapChallengeRequest(app_check_token="valid-app-check", installation_id=str(other_installation_id)),
+                    Response(), authorization="Bearer valid-id-token", x_firebase_appcheck=None, db=s,
+                )
+            assert exc.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_native_bootstrap_challenge_revoked_installation_401(monkeypatch):
+    from app.routers.auth_native_bootstrap import NativeBootstrapChallengeRequest, native_bootstrap_challenge
+
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id, firebase_uid = await _seed_eligible_user(s)
+            installation_id = await _seed_installation(s, user_id=user_id, status="revoked")
+        _mock_verifiers(monkeypatch, firebase_uid=firebase_uid)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc:
+                await native_bootstrap_challenge(
+                    _FakeRequest(),
+                    NativeBootstrapChallengeRequest(app_check_token="valid-app-check", installation_id=str(installation_id)),
+                    Response(), authorization="Bearer valid-id-token", x_firebase_appcheck=None, db=s,
+                )
+            assert exc.value.status_code == 401
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_native_bootstrap_challenge_success(monkeypatch):
+    from app.routers.auth_native_bootstrap import NativeBootstrapChallengeRequest, native_bootstrap_challenge
+
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id, firebase_uid = await _seed_eligible_user(s)
+            installation_id = await _seed_installation(s, user_id=user_id, status="active")
+        _mock_verifiers(monkeypatch, firebase_uid=firebase_uid)
+        async with Session() as s:
+            result = await native_bootstrap_challenge(
+                _FakeRequest(),
+                NativeBootstrapChallengeRequest(app_check_token="valid-app-check", installation_id=str(installation_id)),
+                Response(), authorization="Bearer valid-id-token", x_firebase_appcheck=None, db=s,
+            )
+        assert result.challenge_id
+        assert result.client_data_b64url
+        assert result.expires_in == 60
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_native_bootstrap_challenge_duplicate_active_409(monkeypatch):
+    from app.routers.auth_native_bootstrap import NativeBootstrapChallengeRequest, native_bootstrap_challenge
+
+    _setup_common(monkeypatch)
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            user_id, firebase_uid = await _seed_eligible_user(s)
+            installation_id = await _seed_installation(s, user_id=user_id, status="active")
+        _mock_verifiers(monkeypatch, firebase_uid=firebase_uid)
+        body = NativeBootstrapChallengeRequest(app_check_token="valid-app-check", installation_id=str(installation_id))
+        async with Session() as s:
+            await native_bootstrap_challenge(_FakeRequest(), body, Response(), authorization="Bearer valid-id-token", x_firebase_appcheck=None, db=s)
+        async with Session() as s:
+            with pytest.raises(HTTPException) as exc:
+                await native_bootstrap_challenge(_FakeRequest(), body, Response(), authorization="Bearer valid-id-token", x_firebase_appcheck=None, db=s)
+            assert exc.value.status_code == 409
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary
story 822817a0(E-AUTH-REBUILD 활성화게이트 C1) — 산티아고 §7 SSOT(per-installation attestation protocol v1, 2026-07-16) BE 4스토리 분해(C1~C4)의 첫 단계.

- `device_installations`/`device_proof_challenges` 테이블(0190, additive)
- canonical transcript 빌더(`SP_DEVICE_PROOF_V1` 도메인분리+버전태그, 서버 직접 구성)
- 챌린지 발급 엔드포인트 2종: `POST /api/v2/auth/device-installations/registration-challenges`(TTL 120s), `POST /api/v2/auth/native-bootstrap/challenges`(TTL 60s)
- 둘 다 `FIREBASE_AUTH_MOBILE_ISSUE` 기본 off인 한 501 — default-off inert 병합(S1~S5/Story A와 동일 패턴)

**스코프 밖(별도 스토리)**: 플랫폼 attestation 검증(iOS App Attest=C2, Android Key Attestation+Play Integrity=C3), register/consume 본체+§7.5 2단계 원자 트랜잭션(C4).

**⚠️알려진 제약**: Story A(`auth_valid_after` cutover epoch, PR #2206)가 아직 develop에 미merge라 챌린지 발급 전처리(`native_request_auth.py`)엔 cutover 재검증이 아직 없음. 두 엔드포인트가 default-off로 완전 비활성인 동안은 라이브 영향 0 — Story A 머지 후 소패치로 추가 예정.

## Test plan
- [x] 실 PG 테스트 17종 green: canonical transcript 결정성/버전태그/redeem-only 필드, `issue_challenge()` TTL+중복거부(부분 유니크 인덱스), 두 엔드포인트 default-off(501)/401(bearer 누락·App Check 누락·부적격 state)/400(미지원 platform)/409(중복 활성 챌린지)/success
- [x] IDOR 가드(foreign installation 401) mutation self-check — 가드 비활성화 시 정확히 타깃 테스트만 RED, 복구 후 재확인
- [x] `python -m pytest -k "auth or firebase or native_bootstrap or device_install or bea25062 or 822817a0"` 303 passed(관련 5개 실패는 team_members FK — `-k` 필터가 다른 도메인 seed fixture 순서를 깨는 무관 노이즈, canvas/attachment/GA4/project_authz)

🤖 Generated with [Claude Code](https://claude.com/claude-code)