### PR TITLE
feat(auth): E-AUTH-REBUILD 활성화게이트 C2 — iOS App Attest verifier

### DIFF
--- a/backend/app/services/apple_app_attest.py
+++ b/backend/app/services/apple_app_attest.py
@@ -1,0 +1,328 @@
+"""story 20f49099(E-AUTH-REBUILD 활성화게이트][C2]·doc e-mobile-per-install-proof-feasibility
+§7.4·산티아고 §7.4 SSOT 2026-07-16): Apple App Attest attestation/assertion 서버측 검증.
+
+⚠️§7.0 명시 경고 — 공개 패키지 `expo-app-integrity@0.3.0`을 구현 기반으로 삼지 않는다: 그
+패키지는 iOS raw CBOR를 UTF-8 문자열로 변환하는 손실 버그가 있어 서버 검증용 원문 보존을
+불보장한다. 이 모듈의 입력 계약은 **무손실 원문 바이트**(attestation object/assertion의
+CBOR bytes 그대로, key_id/client_data_hash도 raw bytes)를 전제로 한다 — base64 등 wire
+인코딩/디코딩은 호출부(C4 엔드포인트) 책임.
+
+**검증 알고리즘 출처**: Apple Developer Documentation "Validating apps that connect to your
+server"(App Attest)의 공식 attestation/assertion 검증 절차를 그대로 구현한다.
+
+⛔**이 모듈이 하지 않는 것**: Apple receipt 검증(attStmt의 `receipt` 필드 — Apple 서버 왕복이
+필요한 별도 flow, 이 스토리 스코프 밖). register/consume 엔드포인트 배선·DB 원자적 counter
+compare-and-set(C4 스코프 — 이 모듈은 counter가 "이전보다 크다"는 순수 검증만 반환하고,
+동시 요청 간 원자성 보장은 호출부의 DB UPDATE...WHERE...RETURNING 책임).
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import cbor2
+from cryptography import x509
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+logger = logging.getLogger(__name__)
+
+
+class AppAttestVerificationError(Exception):
+    """검증 실패 — 메시지는 로그 전용(enumeration 방지는 호출부가 통일된 401로 흡수)."""
+
+
+# Apple이 공식 배포하는 App Attestation Root CA(https://www.apple.com/certificateauthority/
+# Apple_App_Attestation_Root_CA.pem) — P-384/ECDSA-SHA384, 2020-03-18 발급, 2045-03-15 만료.
+# 이 상수를 절대 x5c 체인 안의 값으로 대체하지 않는다(아래 _verify_chain_to_apple_root의
+# 핵심 불변조건 — x5c가 자칭하는 root는 신뢰하지 않고 항상 이 고정 anchor로 종료 검증).
+APPLE_APP_ATTEST_ROOT_CA_PEM = b"""-----BEGIN CERTIFICATE-----
+MIICITCCAaegAwIBAgIQC/O+DvHN0uD7jG5yH2IXmDAKBggqhkjOPQQDAzBSMSYw
+JAYDVQQDDB1BcHBsZSBBcHAgQXR0ZXN0YXRpb24gUm9vdCBDQTETMBEGA1UECgwK
+QXBwbGUgSW5jLjETMBEGA1UECAwKQ2FsaWZvcm5pYTAeFw0yMDAzMTgxODMyNTNa
+Fw00NTAzMTUwMDAwMDBaMFIxJjAkBgNVBAMMHUFwcGxlIEFwcCBBdHRlc3RhdGlv
+biBSb290IENBMRMwEQYDVQQKDApBcHBsZSBJbmMuMRMwEQYDVQQIDApDYWxpZm9y
+bmlhMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERTHhmLW07ATaFQIEVwTtT4dyctdh
+NbJhFs/Ii2FdCgAHGbpphY3+d8qjuDngIN3WVhQUBHAoMeQ/cLiP1sOUtgjqK9au
+Yen1mMEvRq9Sk3Jm5X8U62H+xTD3FE9TgS41o0IwQDAPBgNVHRMBAf8EBTADAQH/
+MB0GA1UdDgQWBBSskRBTM72+aEH/pwyp5frq5eWKoTAOBgNVHQ8BAf8EBAMCAQYw
+CgYIKoZIzj0EAwMDaAAwZQIwQgFGnByvsiVbpTKwSga0kP0e8EeDS4+sQmTvb7vn
+53O5+FRXgeLhpJ06ysC5PrOyAjEAp5U4xDgEgllF7En3VcE3iexZZtKeYnpqtijV
+oyFraWVIyd/dganmrduC1bmTBGwD
+-----END CERTIFICATE-----
+"""
+
+_NONCE_EXTENSION_OID = x509.ObjectIdentifier("1.2.840.113635.100.8.2")
+
+ENV_PRODUCTION = "production"
+ENV_DEVELOPMENT = "development"
+
+# App Attest AAGUID — production은 "appattest"+7 null bytes, development는 정확히
+# "appattestdevelop"(둘 다 16바이트). 산티아고 §7.4: "production은 production AAGUID만
+# 허용(dev AAGUID는 별도 dev namespace 전용)" — 아래 verify_attestation()의
+# expected_environment 강제 일치가 이를 구현한다.
+_AAGUID_BY_ENVIRONMENT = {
+    ENV_PRODUCTION: b"appattest" + b"\x00" * 7,
+    ENV_DEVELOPMENT: b"appattestdevelop",
+}
+assert all(len(v) == 16 for v in _AAGUID_BY_ENVIRONMENT.values())
+
+
+@dataclass
+class ParsedAuthData:
+    rp_id_hash: bytes
+    flags: int
+    counter: int
+    aaguid: bytes | None
+    credential_id: bytes | None
+
+
+def _parse_auth_data(auth_data: bytes) -> ParsedAuthData:
+    """WebAuthn authenticatorData 고정 레이아웃(App Attest도 동일 포맷 재사용): rpIdHash[32]+
+    flags[1]+counter[4](big-endian)+선택적 attestedCredentialData(aaguid[16]+credIdLen[2]+
+    credId[N])."""
+    if len(auth_data) < 37:
+        raise AppAttestVerificationError("auth_data_too_short")
+    rp_id_hash = auth_data[0:32]
+    flags = auth_data[32]
+    counter = int.from_bytes(auth_data[33:37], "big")
+    aaguid: bytes | None = None
+    credential_id: bytes | None = None
+    if len(auth_data) > 37:
+        if len(auth_data) < 37 + 16 + 2:
+            raise AppAttestVerificationError("auth_data_attested_credential_truncated")
+        aaguid = auth_data[37:53]
+        cred_id_len = int.from_bytes(auth_data[53:55], "big")
+        cred_id_start = 55
+        cred_id_end = cred_id_start + cred_id_len
+        if len(auth_data) < cred_id_end:
+            raise AppAttestVerificationError("auth_data_credential_id_truncated")
+        credential_id = auth_data[cred_id_start:cred_id_end]
+    return ParsedAuthData(rp_id_hash=rp_id_hash, flags=flags, counter=counter, aaguid=aaguid, credential_id=credential_id)
+
+
+def _verify_cert_signed_by(child: x509.Certificate, parent_public_key) -> bool:
+    try:
+        parent_public_key.verify(
+            child.signature,
+            child.tbs_certificate_bytes,
+            ec.ECDSA(child.signature_hash_algorithm),
+        )
+        return True
+    except InvalidSignature:
+        return False
+    except Exception:
+        # 파싱 불가한 서명/알고리즘 불일치 등 — 전부 검증 실패로 수렴(fail-closed).
+        return False
+
+
+def _verify_chain_to_apple_root(x5c_der: list[bytes]) -> x509.Certificate:
+    """x5c_der[0]=leaf, x5c_der[1:]=intermediate(들). **x5c가 자칭하는 root는 절대 신뢰하지
+    않는다** — 체인의 마지막 원소가 우리 자신의 고정 `APPLE_APP_ATTEST_ROOT_CA_PEM` 공개키로
+    서명됐는지까지 검증해야 성공. 실패 시 AppAttestVerificationError."""
+    if not x5c_der:
+        raise AppAttestVerificationError("empty_certificate_chain")
+    try:
+        certs = [x509.load_der_x509_certificate(c) for c in x5c_der]
+    except ValueError as exc:
+        raise AppAttestVerificationError("malformed_certificate_in_chain") from exc
+
+    now = datetime.now(timezone.utc)
+    for c in certs:
+        if c.not_valid_before_utc > now or c.not_valid_after_utc < now:
+            raise AppAttestVerificationError("certificate_expired_or_not_yet_valid")
+
+    for i in range(len(certs) - 1):
+        if not _verify_cert_signed_by(certs[i], certs[i + 1].public_key()):
+            raise AppAttestVerificationError("chain_signature_invalid")
+
+    trusted_root = x509.load_pem_x509_certificate(APPLE_APP_ATTEST_ROOT_CA_PEM)
+    if not _verify_cert_signed_by(certs[-1], trusted_root.public_key()):
+        raise AppAttestVerificationError("chain_does_not_terminate_at_apple_root")
+
+    return certs[0]  # leaf
+
+
+def _der_length(data: bytes, offset: int) -> tuple[int, int]:
+    first = data[offset]
+    offset += 1
+    if first & 0x80 == 0:
+        return first, offset
+    num_bytes = first & 0x7F
+    length = int.from_bytes(data[offset:offset + num_bytes], "big")
+    return length, offset + num_bytes
+
+
+def _extract_nonce_extension(cert: x509.Certificate) -> bytes:
+    """OID 1.2.840.113635.100.8.2 확장값 — DER `SEQUENCE { [1] OCTET STRING nonce }`을
+    직접 파싱한다(cryptography가 인식 못 하는 Apple 전용 확장이라 UnrecognizedExtension의
+    원시 DER bytes를 수동 파싱)."""
+    try:
+        ext = cert.extensions.get_extension_for_oid(_NONCE_EXTENSION_OID)
+    except x509.ExtensionNotFound as exc:
+        raise AppAttestVerificationError("nonce_extension_missing") from exc
+
+    raw = ext.value.value if hasattr(ext.value, "value") else bytes(ext.value)
+    try:
+        if raw[0] != 0x30:
+            raise ValueError("expected SEQUENCE")
+        _seq_len, offset = _der_length(raw, 1)
+        if raw[offset] != 0xA1:
+            raise ValueError("expected context [1]")
+        offset += 1
+        _ctx_len, offset = _der_length(raw, offset)
+        if raw[offset] != 0x04:
+            raise ValueError("expected OCTET STRING")
+        offset += 1
+        octet_len, offset = _der_length(raw, offset)
+        return raw[offset:offset + octet_len]
+    except (IndexError, ValueError) as exc:
+        raise AppAttestVerificationError("nonce_extension_malformed") from exc
+
+
+@dataclass
+class VerifiedAttestation:
+    key_id: bytes  # SHA256(leaf 공개키 raw uncompressed point) — authData credentialId와 동일
+    public_key_der: bytes  # SubjectPublicKeyInfo DER(assertion 검증 시 재로드용으로 저장)
+    environment: str  # ENV_PRODUCTION | ENV_DEVELOPMENT
+    counter: int  # 최초 attestation은 항상 0
+
+
+def verify_attestation(
+    *,
+    attestation_object: bytes,
+    key_id: bytes,
+    client_data_hash: bytes,
+    expected_team_id: str,
+    expected_bundle_id: str,
+    expected_environment: str,
+) -> VerifiedAttestation:
+    """Apple 공식 attestation 검증 절차(Validating apps that connect to your server) —
+    실패 시 AppAttestVerificationError, 성공 시 저장할 공개키+환경+초기 counter 반환.
+
+    호출부(C4)가 이 함수 호출 전에 반드시 마쳐야 하는 것(§7.3 3대 증거 중 나머지 2개,
+    이 함수 스코프 밖): 최근 Firebase 재인증 확인·앱ID-allowlisted App Check 검증·
+    서버측 challenge 발급/바인딩(client_data_hash는 그 challenge의 canonical transcript
+    해시여야 함 — C1의 device_proof_challenges가 이미 이 인프라를 제공)."""
+    try:
+        decoded = cbor2.loads(attestation_object)
+    except Exception as exc:
+        raise AppAttestVerificationError("attestation_object_not_valid_cbor") from exc
+
+    if not isinstance(decoded, dict):
+        raise AppAttestVerificationError("attestation_object_not_a_map")
+
+    if decoded.get("fmt") != "apple-appattest":
+        raise AppAttestVerificationError("unexpected_fmt")
+
+    att_stmt = decoded.get("attStmt")
+    auth_data = decoded.get("authData")
+    if not isinstance(att_stmt, dict) or not isinstance(auth_data, bytes):
+        raise AppAttestVerificationError("attestation_object_missing_fields")
+
+    x5c = att_stmt.get("x5c")
+    if not isinstance(x5c, list) or not all(isinstance(c, bytes) for c in x5c):
+        raise AppAttestVerificationError("x5c_missing_or_malformed")
+
+    leaf = _verify_chain_to_apple_root(x5c)
+
+    nonce = hashlib.sha256(auth_data + client_data_hash).digest()
+    cert_nonce = _extract_nonce_extension(leaf)
+    if cert_nonce != nonce:
+        raise AppAttestVerificationError("nonce_mismatch")
+
+    leaf_public_key = leaf.public_key()
+    if not isinstance(leaf_public_key, ec.EllipticCurvePublicKey) or leaf_public_key.curve.name != "secp256r1":
+        raise AppAttestVerificationError("leaf_key_not_p256")
+
+    public_key_raw = leaf_public_key.public_bytes(
+        encoding=serialization.Encoding.X962, format=serialization.PublicFormat.UncompressedPoint
+    )
+    computed_key_id = hashlib.sha256(public_key_raw).digest()
+    if computed_key_id != key_id:
+        raise AppAttestVerificationError("key_id_mismatch")
+
+    parsed = _parse_auth_data(auth_data)
+    if parsed.credential_id != computed_key_id:
+        raise AppAttestVerificationError("auth_data_credential_id_mismatch")
+
+    expected_rp_id_hash = hashlib.sha256(f"{expected_team_id}.{expected_bundle_id}".encode()).digest()
+    if parsed.rp_id_hash != expected_rp_id_hash:
+        raise AppAttestVerificationError("rp_id_hash_mismatch")
+
+    if parsed.counter != 0:
+        raise AppAttestVerificationError("initial_counter_not_zero")
+
+    if expected_environment not in _AAGUID_BY_ENVIRONMENT:
+        raise AppAttestVerificationError("unknown_expected_environment")
+    if parsed.aaguid != _AAGUID_BY_ENVIRONMENT[expected_environment]:
+        raise AppAttestVerificationError("aaguid_environment_mismatch")
+
+    public_key_der = leaf_public_key.public_bytes(
+        encoding=serialization.Encoding.DER, format=serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+
+    logger.info("apple_app_attest.verify_attestation success environment=%s", expected_environment)
+    return VerifiedAttestation(
+        key_id=computed_key_id, public_key_der=public_key_der, environment=expected_environment, counter=0
+    )
+
+
+@dataclass
+class VerifiedAssertion:
+    counter: int
+
+
+def verify_assertion(
+    *,
+    assertion: bytes,
+    client_data_hash: bytes,
+    stored_public_key_der: bytes,
+    stored_counter: int,
+    expected_team_id: str,
+    expected_bundle_id: str,
+) -> VerifiedAssertion:
+    """Apple 공식 assertion 검증 — 서명은 등록 시 저장한 공개키로, counter는 저장값보다
+    **엄격히 커야**(gap 허용, 동일/역행=replay/clone 의심) 통과. ⚠️여기서의 counter 비교는
+    순수 암호검증 계층 판단이다 — 동시 요청 간 진짜 원자성(compare-and-set)은 호출부가 DB
+    `UPDATE...WHERE last_sign_count < :new_count RETURNING`으로 별도 보장해야 한다(이 함수
+    호출 하나만으로는 TOCTOU를 못 막는다 — check_then_insert_toctou 계열 함정과 동일 원리)."""
+    try:
+        decoded = cbor2.loads(assertion)
+    except Exception as exc:
+        raise AppAttestVerificationError("assertion_not_valid_cbor") from exc
+
+    if not isinstance(decoded, dict):
+        raise AppAttestVerificationError("assertion_not_a_map")
+
+    signature = decoded.get("signature")
+    auth_data = decoded.get("authenticatorData")
+    if not isinstance(signature, bytes) or not isinstance(auth_data, bytes):
+        raise AppAttestVerificationError("assertion_missing_fields")
+
+    try:
+        public_key = serialization.load_der_public_key(stored_public_key_der)
+    except Exception as exc:
+        raise AppAttestVerificationError("stored_public_key_malformed") from exc
+    if not isinstance(public_key, ec.EllipticCurvePublicKey):
+        raise AppAttestVerificationError("stored_public_key_not_ec")
+
+    nonce = hashlib.sha256(auth_data + client_data_hash).digest()
+    try:
+        public_key.verify(signature, nonce, ec.ECDSA(hashes.SHA256()))
+    except InvalidSignature as exc:
+        raise AppAttestVerificationError("assertion_signature_invalid") from exc
+
+    parsed = _parse_auth_data(auth_data)
+    expected_rp_id_hash = hashlib.sha256(f"{expected_team_id}.{expected_bundle_id}".encode()).digest()
+    if parsed.rp_id_hash != expected_rp_id_hash:
+        raise AppAttestVerificationError("rp_id_hash_mismatch")
+
+    if parsed.counter <= stored_counter:
+        raise AppAttestVerificationError("counter_not_strictly_increasing")
+
+    logger.info("apple_app_attest.verify_assertion success counter=%d", parsed.counter)
+    return VerifiedAssertion(counter=parsed.counter)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -37,6 +37,13 @@ dependencies = [
     # E-AUTH-REBUILD M2 Phase1-S4: ADC 액세스 토큰(Identity Toolkit createSessionCookie 호출).
     # google-cloud-storage의 전이 의존성으로 이미 설치돼 있었으나 직접 import하므로 명시 선언.
     "google-auth>=2.30.0",
+    # E-AUTH-REBUILD 활성화게이트 C2(story 20f49099·산티아고 §7.4): Apple App Attest
+    # attestation object는 CBOR(fmt/attStmt/authData) — stdlib에 CBOR 디코더가 없고, 손실
+    # 없는 정확한 바이트 파싱이 보안 요구사항(§7.0: expo-app-integrity@0.3.0의 CBOR→UTF-8
+    # 손실 버그를 명시적으로 피하는 게 이 스토리의 존재 이유) — 직접 파서 구현은 미묘한
+    # CBOR 엣지케이스(indefinite-length map/array 등) 오파싱 리스크가 crypto 검증 우회로
+    # 이어질 수 있어 검증된 라이브러리 사용.
+    "cbor2>=5.6.0",
 ]
 
 [dependency-groups]

--- a/backend/tests/test_20f49099_c2_apple_app_attest.py
+++ b/backend/tests/test_20f49099_c2_apple_app_attest.py
@@ -1,0 +1,439 @@
+"""story 20f49099(E-AUTH-REBUILD 활성화게이트][C2]·산티아고 §7.4 SSOT) 게이트: Apple App
+Attest attestation/assertion 서버측 검증 — 정상/전수 음성 케이스.
+
+실 Apple 인증서는 당연히 없으므로, 모듈이 신뢰하는 root anchor(`APPLE_APP_ATTEST_ROOT_CA_PEM`)
+를 테스트 전용 self-signed root로 monkeypatch해 **동일한 검증 알고리즘**을 테스트 root
+기준으로 실증한다 — 알고리즘 자체(체인 검증·nonce 확장 파싱·rpIdHash·AAGUID·counter)는
+실 Apple root든 테스트 root든 완전히 동일한 코드 경로를 탄다.
+"""
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timedelta, timezone
+
+import cbor2
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from app.services.apple_app_attest import (
+    ENV_DEVELOPMENT,
+    ENV_PRODUCTION,
+    AppAttestVerificationError,
+    verify_assertion,
+    verify_attestation,
+)
+
+TEAM_ID = "ABCDE12345"
+BUNDLE_ID = "com.sprintable.app"
+NONCE_OID = x509.ObjectIdentifier("1.2.840.113635.100.8.2")
+
+_AAGUID_PRODUCTION = b"appattest" + b"\x00" * 7
+_AAGUID_DEVELOPMENT = b"appattestdevelop"
+
+
+def _self_signed_root():
+    key = ec.generate_private_key(ec.SECP384R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Test App Attestation Root CA")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name).issuer_name(name).public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=3650))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(key, hashes.SHA384())
+    )
+    return key, cert
+
+
+def _signed_intermediate(root_key, root_cert):
+    key = ec.generate_private_key(ec.SECP384R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Test App Attestation CA 1")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name).issuer_name(root_cert.subject).public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=3650))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        .sign(root_key, hashes.SHA384())
+    )
+    return key, cert
+
+
+def _nonce_extension_der(nonce: bytes) -> bytes:
+    """DER SEQUENCE { [1] OCTET STRING nonce } — 손으로 인코딩(짧고 고정된 구조)."""
+    octet = bytes([0x04, len(nonce)]) + nonce
+    ctx = bytes([0xA1, len(octet)]) + octet
+    seq = bytes([0x30, len(ctx)]) + ctx
+    return seq
+
+
+def _leaf_cert_with_nonce(intermediate_key, intermediate_cert, nonce: bytes):
+    leaf_key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Test App Attest Leaf")])
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(name).issuer_name(intermediate_cert.subject).public_key(leaf_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
+        .add_extension(
+            x509.UnrecognizedExtension(NONCE_OID, _nonce_extension_der(nonce)), critical=False
+        )
+    )
+    cert = builder.sign(intermediate_key, hashes.SHA256())
+    return leaf_key, cert
+
+
+def _auth_data(rp_id_hash: bytes, counter: int, aaguid: bytes | None, credential_id: bytes | None) -> bytes:
+    flags = 0x40 if aaguid is not None else 0x00  # attested-credential-data flag
+    out = rp_id_hash + bytes([flags]) + counter.to_bytes(4, "big")
+    if aaguid is not None:
+        out += aaguid + len(credential_id).to_bytes(2, "big") + credential_id
+    return out
+
+
+def _rp_id_hash(team_id: str = TEAM_ID, bundle_id: str = BUNDLE_ID) -> bytes:
+    return hashlib.sha256(f"{team_id}.{bundle_id}".encode()).digest()
+
+
+def _build_valid_attestation(monkeypatch, *, environment: str = ENV_PRODUCTION, counter: int = 0, tamper_nonce: bool = False):
+    root_key, root_cert = _self_signed_root()
+    import app.services.apple_app_attest as module
+    monkeypatch.setattr(
+        module, "APPLE_APP_ATTEST_ROOT_CA_PEM", root_cert.public_bytes(serialization.Encoding.PEM)
+    )
+    intermediate_key, intermediate_cert = _signed_intermediate(root_key, root_cert)
+
+    client_data_hash = hashlib.sha256(b"challenge-transcript").digest()
+    aaguid = _AAGUID_PRODUCTION if environment == ENV_PRODUCTION else _AAGUID_DEVELOPMENT
+
+    # nonce는 authData+clientDataHash에 의존하는데 authData의 credentialId는 leaf 공개키에
+    # 의존한다 — 먼저 임시 키로 공개키를 얻은 뒤 authData/nonce/leaf cert를 순서대로 구성.
+    probe_key = ec.generate_private_key(ec.SECP256R1())
+    probe_pub_raw = probe_key.public_key().public_bytes(
+        serialization.Encoding.X962, serialization.PublicFormat.UncompressedPoint
+    )
+    key_id = hashlib.sha256(probe_pub_raw).digest()
+
+    auth_data = _auth_data(_rp_id_hash(), counter, aaguid, key_id)
+    nonce = hashlib.sha256(auth_data + client_data_hash).digest()
+    if tamper_nonce:
+        nonce = b"\x00" * 32
+
+    # probe_key를 그대로 leaf 개인키로 재사용(공개키가 key_id/credentialId와 반드시 일치해야 함).
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Test App Attest Leaf")])
+    leaf_cert = (
+        x509.CertificateBuilder()
+        .subject_name(name).issuer_name(intermediate_cert.subject).public_key(probe_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
+        .add_extension(x509.UnrecognizedExtension(NONCE_OID, _nonce_extension_der(nonce)), critical=False)
+        .sign(intermediate_key, hashes.SHA256())
+    )
+
+    x5c = [
+        leaf_cert.public_bytes(serialization.Encoding.DER),
+        intermediate_cert.public_bytes(serialization.Encoding.DER),
+    ]
+    attestation_object = cbor2.dumps({
+        "fmt": "apple-appattest",
+        "attStmt": {"x5c": x5c, "receipt": b"opaque-receipt-not-verified-here"},
+        "authData": auth_data,
+    })
+    return {
+        "attestation_object": attestation_object,
+        "key_id": key_id,
+        "client_data_hash": client_data_hash,
+        "leaf_key": probe_key,
+    }
+
+
+# ─── verify_attestation ──────────────────────────────────────────────────────
+
+def test_valid_attestation_accepted(monkeypatch):
+    fx = _build_valid_attestation(monkeypatch)
+    result = verify_attestation(
+        attestation_object=fx["attestation_object"], key_id=fx["key_id"],
+        client_data_hash=fx["client_data_hash"], expected_team_id=TEAM_ID, expected_bundle_id=BUNDLE_ID,
+        expected_environment=ENV_PRODUCTION,
+    )
+    assert result.key_id == fx["key_id"]
+    assert result.environment == ENV_PRODUCTION
+    assert result.counter == 0
+    assert result.public_key_der
+
+
+def test_wrong_team_id_rejected(monkeypatch):
+    fx = _build_valid_attestation(monkeypatch)
+    with pytest.raises(AppAttestVerificationError, match="rp_id_hash_mismatch"):
+        verify_attestation(
+            attestation_object=fx["attestation_object"], key_id=fx["key_id"],
+            client_data_hash=fx["client_data_hash"], expected_team_id="WRONGTEAMID", expected_bundle_id=BUNDLE_ID,
+            expected_environment=ENV_PRODUCTION,
+        )
+
+
+def test_wrong_bundle_id_rejected(monkeypatch):
+    fx = _build_valid_attestation(monkeypatch)
+    with pytest.raises(AppAttestVerificationError, match="rp_id_hash_mismatch"):
+        verify_attestation(
+            attestation_object=fx["attestation_object"], key_id=fx["key_id"],
+            client_data_hash=fx["client_data_hash"], expected_team_id=TEAM_ID, expected_bundle_id="com.wrong.app",
+            expected_environment=ENV_PRODUCTION,
+        )
+
+
+def test_dev_aaguid_rejected_in_production(monkeypatch):
+    fx = _build_valid_attestation(monkeypatch, environment=ENV_DEVELOPMENT)
+    with pytest.raises(AppAttestVerificationError, match="aaguid_environment_mismatch"):
+        verify_attestation(
+            attestation_object=fx["attestation_object"], key_id=fx["key_id"],
+            client_data_hash=fx["client_data_hash"], expected_team_id=TEAM_ID, expected_bundle_id=BUNDLE_ID,
+            expected_environment=ENV_PRODUCTION,
+        )
+
+
+def test_development_environment_accepts_dev_aaguid(monkeypatch):
+    fx = _build_valid_attestation(monkeypatch, environment=ENV_DEVELOPMENT)
+    result = verify_attestation(
+        attestation_object=fx["attestation_object"], key_id=fx["key_id"],
+        client_data_hash=fx["client_data_hash"], expected_team_id=TEAM_ID, expected_bundle_id=BUNDLE_ID,
+        expected_environment=ENV_DEVELOPMENT,
+    )
+    assert result.environment == ENV_DEVELOPMENT
+
+
+def test_forged_chain_not_terminating_at_trusted_root_rejected(monkeypatch):
+    """attacker가 자체 root/intermediate로 완결된 체인을 들이밀어도(자체 서명 정합은 맞음)
+    우리 고정 trusted root로 안 끝나면 거부 — x5c 안의 아무 root도 신뢰하지 않는 불변조건."""
+    # monkeypatch로 진짜 trusted root를 심지 않고(기본값=실 Apple root 유지), attacker 자신의
+    # 가짜 root/intermediate/leaf로 내부적으로는 정합한 체인을 구성 — 실 Apple root와 무관.
+    fake_root_key, fake_root_cert = _self_signed_root()
+    fake_intermediate_key, fake_intermediate_cert = _signed_intermediate(fake_root_key, fake_root_cert)
+
+    client_data_hash = hashlib.sha256(b"x").digest()
+    probe_key = ec.generate_private_key(ec.SECP256R1())
+    probe_pub_raw = probe_key.public_key().public_bytes(
+        serialization.Encoding.X962, serialization.PublicFormat.UncompressedPoint
+    )
+    key_id = hashlib.sha256(probe_pub_raw).digest()
+    auth_data = _auth_data(_rp_id_hash(), 0, _AAGUID_PRODUCTION, key_id)
+    nonce = hashlib.sha256(auth_data + client_data_hash).digest()
+
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Attacker Leaf")])
+    leaf_cert = (
+        x509.CertificateBuilder()
+        .subject_name(name).issuer_name(fake_intermediate_cert.subject).public_key(probe_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
+        .add_extension(x509.UnrecognizedExtension(NONCE_OID, _nonce_extension_der(nonce)), critical=False)
+        .sign(fake_intermediate_key, hashes.SHA256())
+    )
+    x5c = [
+        leaf_cert.public_bytes(serialization.Encoding.DER),
+        fake_intermediate_cert.public_bytes(serialization.Encoding.DER),
+    ]
+    attestation_object = cbor2.dumps({
+        "fmt": "apple-appattest", "attStmt": {"x5c": x5c, "receipt": b"x"}, "authData": auth_data,
+    })
+
+    with pytest.raises(AppAttestVerificationError, match="chain_does_not_terminate_at_apple_root"):
+        verify_attestation(
+            attestation_object=attestation_object, key_id=key_id, client_data_hash=client_data_hash,
+            expected_team_id=TEAM_ID, expected_bundle_id=BUNDLE_ID, expected_environment=ENV_PRODUCTION,
+        )
+
+
+def test_nonce_mismatch_rejected(monkeypatch):
+    fx = _build_valid_attestation(monkeypatch, tamper_nonce=True)
+    with pytest.raises(AppAttestVerificationError, match="nonce_mismatch"):
+        verify_attestation(
+            attestation_object=fx["attestation_object"], key_id=fx["key_id"],
+            client_data_hash=fx["client_data_hash"], expected_team_id=TEAM_ID, expected_bundle_id=BUNDLE_ID,
+            expected_environment=ENV_PRODUCTION,
+        )
+
+
+def test_key_id_mismatch_rejected(monkeypatch):
+    fx = _build_valid_attestation(monkeypatch)
+    with pytest.raises(AppAttestVerificationError, match="key_id_mismatch"):
+        verify_attestation(
+            attestation_object=fx["attestation_object"], key_id=b"\x00" * 32,
+            client_data_hash=fx["client_data_hash"], expected_team_id=TEAM_ID, expected_bundle_id=BUNDLE_ID,
+            expected_environment=ENV_PRODUCTION,
+        )
+
+
+def test_initial_counter_nonzero_rejected(monkeypatch):
+    fx = _build_valid_attestation(monkeypatch, counter=1)
+    with pytest.raises(AppAttestVerificationError, match="initial_counter_not_zero"):
+        verify_attestation(
+            attestation_object=fx["attestation_object"], key_id=fx["key_id"],
+            client_data_hash=fx["client_data_hash"], expected_team_id=TEAM_ID, expected_bundle_id=BUNDLE_ID,
+            expected_environment=ENV_PRODUCTION,
+        )
+
+
+def test_not_apple_appattest_fmt_rejected(monkeypatch):
+    fx = _build_valid_attestation(monkeypatch)
+    decoded = cbor2.loads(fx["attestation_object"])
+    decoded["fmt"] = "packed"
+    tampered = cbor2.dumps(decoded)
+    with pytest.raises(AppAttestVerificationError, match="unexpected_fmt"):
+        verify_attestation(
+            attestation_object=tampered, key_id=fx["key_id"], client_data_hash=fx["client_data_hash"],
+            expected_team_id=TEAM_ID, expected_bundle_id=BUNDLE_ID, expected_environment=ENV_PRODUCTION,
+        )
+
+
+def test_malformed_cbor_rejected(monkeypatch):
+    # \xa5 = "map with 5 key/value pairs follows" 헤더만 있고 실제 데이터가 없는 truncated
+    # CBOR — 진짜 디코드 에러(CBORDecodeEOF)를 유발한다.
+    with pytest.raises(AppAttestVerificationError, match="attestation_object_not_valid_cbor"):
+        verify_attestation(
+            attestation_object=b"\xa5", key_id=b"\x00" * 32, client_data_hash=b"\x00" * 32,
+            expected_team_id=TEAM_ID, expected_bundle_id=BUNDLE_ID, expected_environment=ENV_PRODUCTION,
+        )
+
+
+def test_non_map_cbor_rejected(monkeypatch):
+    """CBOR 자체는 유효하지만 최상위가 map이 아니면(예: 정수 하나) 거부."""
+    with pytest.raises(AppAttestVerificationError, match="attestation_object_not_a_map"):
+        verify_attestation(
+            attestation_object=cbor2.dumps(42), key_id=b"\x00" * 32, client_data_hash=b"\x00" * 32,
+            expected_team_id=TEAM_ID, expected_bundle_id=BUNDLE_ID, expected_environment=ENV_PRODUCTION,
+        )
+
+
+def test_empty_x5c_rejected(monkeypatch):
+    root_key, root_cert = _self_signed_root()
+    import app.services.apple_app_attest as module
+    monkeypatch.setattr(module, "APPLE_APP_ATTEST_ROOT_CA_PEM", root_cert.public_bytes(serialization.Encoding.PEM))
+    attestation_object = cbor2.dumps({
+        "fmt": "apple-appattest", "attStmt": {"x5c": [], "receipt": b"x"}, "authData": b"\x00" * 37,
+    })
+    with pytest.raises(AppAttestVerificationError, match="empty_certificate_chain"):
+        verify_attestation(
+            attestation_object=attestation_object, key_id=b"\x00" * 32, client_data_hash=b"\x00" * 32,
+            expected_team_id=TEAM_ID, expected_bundle_id=BUNDLE_ID, expected_environment=ENV_PRODUCTION,
+        )
+
+
+# ─── verify_assertion ────────────────────────────────────────────────────────
+
+def _assertion_cbor(auth_data: bytes, signing_key, client_data_hash: bytes) -> bytes:
+    nonce = hashlib.sha256(auth_data + client_data_hash).digest()
+    signature = signing_key.sign(nonce, ec.ECDSA(hashes.SHA256()))
+    return cbor2.dumps({"signature": signature, "authenticatorData": auth_data})
+
+
+def test_valid_assertion_accepted(monkeypatch):
+    fx = _build_valid_attestation(monkeypatch)
+    leaf_key = fx["leaf_key"]
+    public_key_der = leaf_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    client_data_hash = hashlib.sha256(b"assertion-challenge").digest()
+    auth_data = _auth_data(_rp_id_hash(), 1, None, None)
+    assertion = _assertion_cbor(auth_data, leaf_key, client_data_hash)
+
+    result = verify_assertion(
+        assertion=assertion, client_data_hash=client_data_hash, stored_public_key_der=public_key_der,
+        stored_counter=0, expected_team_id=TEAM_ID, expected_bundle_id=BUNDLE_ID,
+    )
+    assert result.counter == 1
+
+
+def test_assertion_counter_equal_rejected(monkeypatch):
+    fx = _build_valid_attestation(monkeypatch)
+    leaf_key = fx["leaf_key"]
+    public_key_der = leaf_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    client_data_hash = hashlib.sha256(b"assertion-challenge").digest()
+    auth_data = _auth_data(_rp_id_hash(), 5, None, None)
+    assertion = _assertion_cbor(auth_data, leaf_key, client_data_hash)
+
+    with pytest.raises(AppAttestVerificationError, match="counter_not_strictly_increasing"):
+        verify_assertion(
+            assertion=assertion, client_data_hash=client_data_hash, stored_public_key_der=public_key_der,
+            stored_counter=5, expected_team_id=TEAM_ID, expected_bundle_id=BUNDLE_ID,
+        )
+
+
+def test_assertion_counter_regression_rejected(monkeypatch):
+    fx = _build_valid_attestation(monkeypatch)
+    leaf_key = fx["leaf_key"]
+    public_key_der = leaf_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    client_data_hash = hashlib.sha256(b"assertion-challenge").digest()
+    auth_data = _auth_data(_rp_id_hash(), 3, None, None)
+    assertion = _assertion_cbor(auth_data, leaf_key, client_data_hash)
+
+    with pytest.raises(AppAttestVerificationError, match="counter_not_strictly_increasing"):
+        verify_assertion(
+            assertion=assertion, client_data_hash=client_data_hash, stored_public_key_der=public_key_der,
+            stored_counter=5, expected_team_id=TEAM_ID, expected_bundle_id=BUNDLE_ID,
+        )
+
+
+def test_assertion_counter_gap_allowed(monkeypatch):
+    """산티아고 §7.4: "gap 허용" — signCount는 엄격히 증가하기만 하면 되고 연속일 필요 없다."""
+    fx = _build_valid_attestation(monkeypatch)
+    leaf_key = fx["leaf_key"]
+    public_key_der = leaf_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    client_data_hash = hashlib.sha256(b"assertion-challenge").digest()
+    auth_data = _auth_data(_rp_id_hash(), 100, None, None)
+    assertion = _assertion_cbor(auth_data, leaf_key, client_data_hash)
+
+    result = verify_assertion(
+        assertion=assertion, client_data_hash=client_data_hash, stored_public_key_der=public_key_der,
+        stored_counter=1, expected_team_id=TEAM_ID, expected_bundle_id=BUNDLE_ID,
+    )
+    assert result.counter == 100
+
+
+def test_assertion_wrong_signing_key_rejected(monkeypatch):
+    """다른(등록되지 않은) 키로 서명하면 저장된 공개키로 검증 실패 — 키 탈취/클론 방지."""
+    fx = _build_valid_attestation(monkeypatch)
+    leaf_key = fx["leaf_key"]
+    public_key_der = leaf_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    imposter_key = ec.generate_private_key(ec.SECP256R1())
+    client_data_hash = hashlib.sha256(b"assertion-challenge").digest()
+    auth_data = _auth_data(_rp_id_hash(), 1, None, None)
+    assertion = _assertion_cbor(auth_data, imposter_key, client_data_hash)
+
+    with pytest.raises(AppAttestVerificationError, match="assertion_signature_invalid"):
+        verify_assertion(
+            assertion=assertion, client_data_hash=client_data_hash, stored_public_key_der=public_key_der,
+            stored_counter=0, expected_team_id=TEAM_ID, expected_bundle_id=BUNDLE_ID,
+        )
+
+
+def test_assertion_rp_id_hash_mismatch_rejected(monkeypatch):
+    fx = _build_valid_attestation(monkeypatch)
+    leaf_key = fx["leaf_key"]
+    public_key_der = leaf_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    client_data_hash = hashlib.sha256(b"assertion-challenge").digest()
+    auth_data = _auth_data(_rp_id_hash(team_id="OTHERTEAM"), 1, None, None)
+    assertion = _assertion_cbor(auth_data, leaf_key, client_data_hash)
+
+    with pytest.raises(AppAttestVerificationError, match="rp_id_hash_mismatch"):
+        verify_assertion(
+            assertion=assertion, client_data_hash=client_data_hash, stored_public_key_der=public_key_der,
+            stored_counter=0, expected_team_id=TEAM_ID, expected_bundle_id=BUNDLE_ID,
+        )

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -239,6 +239,46 @@ wheels = [
 ]
 
 [[package]]
+name = "cbor2"
+version = "6.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/6f/07b4af8da8bd27f640362b1ac8271d80895407f2ede0c2bcc9433c06e1ca/cbor2-6.1.3.tar.gz", hash = "sha256:8d70680acb55c04ea5b5ad86da094f9612b53d5a8a65d0f5b3aafc3ce917ecbb", size = 89503, upload-time = "2026-07-04T10:36:48.793Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/16/cff14259c3d19a7f0ae88b6996fe4c85f6ff1764dad889ac8a39e843e39c/cbor2-6.1.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3d939f55097c21e032f5a2d67592fcc57298986281f219356e2f519e4466f4ea", size = 412779, upload-time = "2026-07-04T10:36:04.975Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6c/f3641d19b7b85a63cb2756c10164131489c2cb46b379ec51ae22283fefb9/cbor2-6.1.3-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b025009478d644dab407164fd60e3ef4381af284f5af6966df94c663756d949e", size = 457781, upload-time = "2026-07-04T10:36:06.349Z" },
+    { url = "https://files.pythonhosted.org/packages/55/85/0c55a66f3037056bfb8e1c7184168085fdea67ae5830404498bcf466233b/cbor2-6.1.3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2226d32e102e375737656ad5d141ad8c6ae3e705e04e263f24756f0eb379c6c1", size = 468373, upload-time = "2026-07-04T10:36:07.769Z" },
+    { url = "https://files.pythonhosted.org/packages/46/74/40f7db3e0d880560193916a5c9b744fcf299558bed7113f77c28237c7c29/cbor2-6.1.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e61d465244d66ffed36492eef3b44d43795d76a2bba0663a2f15c186af7f7513", size = 523844, upload-time = "2026-07-04T10:36:09.404Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a1/b5e07d6a08441c3a552fe2ae48ccb7e9dfc5065b9f6a3bae9879b4f0fbc0/cbor2-6.1.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87fe7be8fab6ec4796aa127c1a52e09e79dbafd2aa31caf809cf04b8080a5975", size = 536238, upload-time = "2026-07-04T10:36:10.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/99/e166be0fd74bf3a91f5a0d103e34883efbc438d970f72cc8200e274787e5/cbor2-6.1.3-cp312-cp312-win32.whl", hash = "sha256:da25d345f01e6a40b2e5c57ef96b4dcff7be69394fb62f0f70e07f437f2376a9", size = 279858, upload-time = "2026-07-04T10:36:12.247Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1b/90b4a121e40aba189c55a5822dd3c698eaf487e1d4a780ab18c804a5ef1c/cbor2-6.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:d5514f693db6fa6f433b4096e9b604e6a7bf151c9ef1d2db86d0858e4c5e768f", size = 300929, upload-time = "2026-07-04T10:36:13.564Z" },
+    { url = "https://files.pythonhosted.org/packages/19/db/52c58a8d33464927389dde8103997b3fa51b081ce29b347ac2cc4fd0dfbf/cbor2-6.1.3-cp312-cp312-win_arm64.whl", hash = "sha256:3d43183d7beb3d3cd198d69b31bd2ee487ed704a1150c75cb0a66d6ad63d8c1a", size = 290908, upload-time = "2026-07-04T10:36:14.857Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/8c/5024d623dcf3f2057ec8c991f584b939ba5f9025a5ce8c31f6fac067137a/cbor2-6.1.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:21c74b8ab67977c8b87b727247eeb730145b0068ad6d47f71e9f80f6b48c65f8", size = 412334, upload-time = "2026-07-04T10:36:16.299Z" },
+    { url = "https://files.pythonhosted.org/packages/61/f3/e50654203c3b746166a96bea680eb6463b20c2c160cc14dfbe43f215ef6c/cbor2-6.1.3-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:f291a0ae4c1ed96eadb0afa9752568c7424f7d6fa818676d5e33005fcd22ddd9", size = 457125, upload-time = "2026-07-04T10:36:17.684Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/6ef007f0d4f7afba90a80cb1657984de542e7474d2afaa7e920ac9860df3/cbor2-6.1.3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:dc8e44c7bf172687195dcd428157885bc00ea06efc0ea30fb371163b92bef733", size = 467651, upload-time = "2026-07-04T10:36:19.007Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f4/b5aa27813c02f37e03eb86bd908163562edd6fc7f99665bc7bbb25ef5e6c/cbor2-6.1.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8ccf4d263983d830dd429d2b01f27be58ac02ba7c790c45d861f767eb63963e5", size = 523296, upload-time = "2026-07-04T10:36:20.504Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/46/e17b2bce2efdc26bfa045b4f6168f02923ac5f0e79732a1b3c42ce9ca9de/cbor2-6.1.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8719a7a2a2a82168844533389957b8f617a139f5f40e4d0ad7ed905fd3abebd1", size = 535537, upload-time = "2026-07-04T10:36:21.761Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bc/add350acf37f367ae429f997f2e047b042f2d5ef9ca62461c923fbb0f3c3/cbor2-6.1.3-cp313-cp313-win32.whl", hash = "sha256:c73b54ce09dd8d522f3c1540426e36172ba0f34abf3d89eb93909a5e14590003", size = 279233, upload-time = "2026-07-04T10:36:23.071Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/6f/1bbfce3b3131e4e03e8a86966a38ff92ebb72215fcf36aeecea1547f3e4b/cbor2-6.1.3-cp313-cp313-win_amd64.whl", hash = "sha256:b77df56c462c10eb3444db8ef78d8c3e71d9ef8d021ea92e97c1f9e3aa918690", size = 300585, upload-time = "2026-07-04T10:36:24.563Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/65/3945702dd84b6e5b7800c9c7f1ada038d33d12d0042de10e38164cc03dfd/cbor2-6.1.3-cp313-cp313-win_arm64.whl", hash = "sha256:b144be2ab3e9584ee7b6359d2a92fee0a5bec1d00dbd34c215ccc2040ac0b2ab", size = 290357, upload-time = "2026-07-04T10:36:25.983Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/40/04ad7d34182b27487a1824422b361b32d2607727ef20e563056eba62d12a/cbor2-6.1.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3f3167ca9920b90db4ff72652db109dfd93b56ee0d583aca12f3a5d9a7019477", size = 414615, upload-time = "2026-07-04T10:36:27.299Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/29/94238c61f90653a606535e7509a2af312089fe10dafcb4cf82d6905a7a1a/cbor2-6.1.3-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:48c677971e4b71e685491e1a267d9924dc205e7ddbe3f34fd2562f16c0f6bfca", size = 459084, upload-time = "2026-07-04T10:36:28.717Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6bd33461e8be8ded7ebb0fa38994a63752aefae2b4fcd1b2cc71ee3c06f1/cbor2-6.1.3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ad4f3c6dfc6b83331eb04c6975efb2839ab65a3aa81502bc2b3f7945d4c4aa44", size = 469310, upload-time = "2026-07-04T10:36:30.136Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d1/94195bcd8fcc1030ecaf22a7a825faa08891b5bb2d3553e465e50fe115f5/cbor2-6.1.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bcd609eab4a39745123bfb28e73311abba3d14975a87f5906e0e8b910d918ac", size = 524287, upload-time = "2026-07-04T10:36:31.453Z" },
+    { url = "https://files.pythonhosted.org/packages/06/55/57178fbf2d1206af5299c688f9c917b83f30636694c8f932dc89c6652545/cbor2-6.1.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:672727ecb27d7fb3ca0bf8a58fc489d5374ab1fee680ed3d0348a11d9d3ca78f", size = 537031, upload-time = "2026-07-04T10:36:32.769Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/01/beefe26258d66ce39a9b057b679bc67dba81698d5a63e0ada5b4752a5c87/cbor2-6.1.3-cp314-cp314-win32.whl", hash = "sha256:1413cef2aa7f478a38298cd3492a055e8e8e45d17fb53bbe103e79ca15c33f3c", size = 286256, upload-time = "2026-07-04T10:36:34.078Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/2d/79eb513a2586a2053a6f18b33693beda65e2c766820d99676a306573fed5/cbor2-6.1.3-cp314-cp314-win_amd64.whl", hash = "sha256:59df264d4a508ba61daaa0bf3c2f92d63275509549a0875c1fa38176f651e4f8", size = 313744, upload-time = "2026-07-04T10:36:35.58Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c7/ab9828e4efc26badf89f1397f866f3ef03ef65cdcd55518254b84bdaf86e/cbor2-6.1.3-cp314-cp314-win_arm64.whl", hash = "sha256:b62b5d80a0eb4305cd5f0217faa4d7747bd64fe0dff9b88415e7be3782f8249b", size = 304280, upload-time = "2026-07-04T10:36:36.865Z" },
+    { url = "https://files.pythonhosted.org/packages/33/cf/54a497ad1026833c1c92d482edbda0bdebb48314b51563d2fcea24ab89b4/cbor2-6.1.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:856ab525bfc599588b8d2a45babb7c3400c693ea0bb574d818467d997102fe24", size = 409638, upload-time = "2026-07-04T10:36:38.089Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/03/efdecd0848b9c9e43242537f6dd8ac5d441a077d362e5e6954c7775b866a/cbor2-6.1.3-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a076f35abf1dd0a4de6e2f7f4d4932abafc951a26275b6aa4a3b370c2fd3bbf4", size = 452193, upload-time = "2026-07-04T10:36:39.56Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bf/b5f43c75dc5f0ca3127919d3273d8671917932aa3e90767da63867e0f06f/cbor2-6.1.3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:37ccab1d0bd3f57ff536a41e44165d0c99cb166ac6e5ffb8b93c42304b56e48d", size = 466614, upload-time = "2026-07-04T10:36:40.936Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ee/e85b2ddd46b3b43e39a986704353b433efab0881234e1b4d824229fc2a75/cbor2-6.1.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:76d257ce797e651fa430b0269e8e8c43549c54ce8b0d12860569b3709bf1326f", size = 518503, upload-time = "2026-07-04T10:36:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/60/13/c740c0002f127dc3e9e87b61a5d1285dd3b71aa11d8e0f6a408fc1f36173/cbor2-6.1.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4af35baadb66f7c9cbb3998eab469767c04641552416c1c69dd4d3d183797119", size = 534236, upload-time = "2026-07-04T10:36:43.641Z" },
+    { url = "https://files.pythonhosted.org/packages/73/cd/a57d97177f3777c96f3406efb0ad60794fdbf249d497ec24559bfd1d0328/cbor2-6.1.3-cp314-cp314t-win32.whl", hash = "sha256:61c92661665bccfed4ffa69d1fe10097f2c820d262f56a8cf909a5ebf9f6d8c6", size = 282446, upload-time = "2026-07-04T10:36:44.888Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c8/dd54878589df22c863d526cb82e1bb20e953d40223436449a52481c49804/cbor2-6.1.3-cp314-cp314t-win_amd64.whl", hash = "sha256:dc6bcd030bf5043662b84b0ca0f0ca942491bf509105db30cedca6e2ce82d158", size = 310300, upload-time = "2026-07-04T10:36:46.212Z" },
+    { url = "https://files.pythonhosted.org/packages/05/d0/b0780a396d145e3356bfdc48578d021ade1818a6c7d7842a3d6bc6f16fbb/cbor2-6.1.3-cp314-cp314t-win_arm64.whl", hash = "sha256:da98a5e0ae9487bed497ac74e2c850b49975a3b7b5314b76c3843e2c83a6c8c4", size = 299391, upload-time = "2026-07-04T10:36:47.629Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -1783,8 +1823,10 @@ dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },
     { name = "boto3" },
+    { name = "cbor2" },
     { name = "fastapi" },
     { name = "google-analytics-data" },
+    { name = "google-auth" },
     { name = "google-cloud-storage" },
     { name = "google-genai" },
     { name = "httpx" },
@@ -1821,8 +1863,10 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "boto3", specifier = ">=1.34.0" },
+    { name = "cbor2", specifier = ">=5.6.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "google-analytics-data", specifier = ">=0.18.0" },
+    { name = "google-auth", specifier = ">=2.30.0" },
     { name = "google-cloud-storage", specifier = ">=2.18.0" },
     { name = "google-genai", specifier = ">=1.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },


### PR DESCRIPTION
## Summary
story 20f49099(E-AUTH-REBUILD 활성화게이트 C2) — 산티아고 §7.4 SSOT(Apple Developer Documentation 공식 attestation/assertion 검증 절차) 그대로 구현.

- `app/services/apple_app_attest.py`: attestation(등록) + assertion(사용) 서버측 암호검증
  - x5c 체인이 우리 고정 Apple App Attestation Root CA로 종료하는지 검증(x5c 안의 어떤 root도 신뢰 안 함)
  - nonce 확장(OID 1.2.840.113635.100.8.2) DER 직접 파싱 + SHA256(authData||clientDataHash) 일치 검증
  - leaf 공개키 SHA256 = key_id = authData credentialId 삼중 일치, rpIdHash = SHA256(TeamID.BundleID)
  - AAGUID로 production/development 환경 정확히 구분(dev AAGUID가 prod로 통과 차단)
  - assertion: 저장 공개키로 서명 검증, counter는 저장값보다 엄격히 커야 통과(gap 허용, 동일/역행 거부)
- **신규 의존성**: `cbor2` — §7.0 명시 경고(expo-app-integrity@0.3.0의 CBOR→UTF-8 손실 버그)를 피하려면 정확한 CBOR 파싱이 불가피

**스코프 밖**(story 명시): register/consume 엔드포인트 배선 + DB 원자 counter compare-and-set(C4), 모바일 셸(민 lane).

## Test plan
- [x] 19개 테스트 green: 정상 attestation/assertion·wrong TeamID/BundleID·dev AAGUID in prod·counter 역행/동일/gap 허용·forged chain(우리 root로 안 끝남)·nonce mismatch·key_id mismatch·초기 counter≠0·malformed CBOR·empty x5c·assertion 서명위조 등 전수
- [x] 실 Apple 인증서 없이 trusted root anchor를 테스트 self-signed root로 monkeypatch — 동일 검증 알고리즘을 테스트 root 기준으로 실증
- [x] 체인-종료 검증 + counter 엄격증가 가드 mutation self-check(정확히 타깃 테스트만 RED 확인 후 복구)
- [x] cbor2 추가 후 `uv sync`로 의존성 동기화, 관련 82개 테스트(account_resolve/C1/C2/Story A 인접) green — 무회귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)