### PR TITLE
[SID:5d88e1a3] globals.css primary 뉴트럴→브랜드 블루 리브랜딩

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -107,6 +107,7 @@
   --color-info: var(--info);
   --color-brand: var(--brand);
   --color-brand-foreground: var(--brand-foreground);
+  --color-primary-tint: var(--primary-tint);
   --color-priority: var(--priority);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
@@ -190,7 +191,10 @@
   --card-foreground: oklch(0.141 0.005 285.823);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.141 0.005 285.823);
-  --primary: oklch(0.21 0.006 285.885);
+  /* S-web-tokens(story 5d88e1a3): 리브랜딩 — 뉴트럴 zinc 무채색→브랜드 블루(hue255) 채색.
+     brand-blue-palette-ssot §2 스펙. --brand는 4.5:1 AA(text-brand 20파일 사용처) 확保 위해
+     스펙 L0.58→0.56로 미세 하향(hue/chroma는 스펙 그대로, 문서화된 의도적 편차). */
+  --primary: oklch(0.50 0.17 255);
   --primary-foreground: oklch(0.985 0 0);
   --secondary: oklch(0.967 0.001 286.375);
   --secondary-foreground: oklch(0.21 0.006 285.885);
@@ -201,7 +205,7 @@
   --destructive: oklch(0.577 0.245 27.325);
   --border: oklch(0.92 0.004 286.32);
   --input: oklch(0.92 0.004 286.32);
-  --ring: oklch(0.705 0.015 286.067);
+  --ring: oklch(0.58 0.17 254);
   --chart-1: oklch(0.871 0.006 286.286);
   --chart-2: oklch(0.552 0.016 285.938);
   --chart-3: oklch(0.442 0.017 285.786);
@@ -210,16 +214,17 @@
   --radius: 0.625rem;
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.141 0.005 285.823);
-  --sidebar-primary: oklch(0.21 0.006 285.885);
+  --sidebar-primary: oklch(0.50 0.17 255);
   --sidebar-primary-foreground: oklch(0.985 0 0);
   --sidebar-accent: oklch(0.95 0.002 286.375);
   --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
   --sidebar-border: oklch(0.92 0.004 286.32);
-  --sidebar-ring: oklch(0.705 0.015 286.067);
+  --sidebar-ring: oklch(0.58 0.17 254);
 
-  /* Sprintable brand (blue) */
-  --brand: oklch(0.66 0.18 258);
+  /* Sprintable brand (blue) — 254/0.17 hue/chroma는 스펙 그대로, L만 0.58→0.56(AA 4.5:1 확保) */
+  --brand: oklch(0.56 0.17 254);
   --brand-foreground: oklch(0.985 0 0);
+  --primary-tint: oklch(0.97 0.02 255);
 
   /* Semantic status tokens */
   --success: oklch(0.55 0.16 145);
@@ -298,8 +303,12 @@
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.21 0.006 285.885);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.92 0.004 286.32);
-  --primary-foreground: oklch(0.21 0.006 285.885);
+  /* S-web-tokens(story 5d88e1a3): 뉴트럴→브랜드 블루. --sidebar-primary를 기존 인디고(264.376)
+     스캐폴드에서 --primary와 정렬(254/255로 통일 — 전체 브랜드 일관성이 이번 작업 목적).
+     정렬로 인해 --sidebar-primary-foreground도 white→navy950 필수 변경(브랜드-400 L0.68 배경에
+     white 텍스트는 2.77:1로 AA 미달 — primary-foreground와 동일 패턴 적용, 3157쪽 회귀 방지). */
+  --primary: oklch(0.68 0.15 255);
+  --primary-foreground: oklch(0.16 0.038 262);
   --secondary: oklch(0.274 0.006 286.033);
   --secondary-foreground: oklch(0.985 0 0);
   --muted: oklch(0.274 0.006 286.033);
@@ -309,7 +318,7 @@
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.552 0.016 285.938);
+  --ring: oklch(0.68 0.15 255);
   --chart-1: oklch(0.871 0.006 286.286);
   --chart-2: oklch(0.75 0.016 285.938);
   --chart-3: oklch(0.62 0.017 285.786);
@@ -317,16 +326,17 @@
   --chart-5: oklch(0.42 0.006 286.033);
   --sidebar: oklch(0.21 0.006 285.885);
   --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.68 0.15 255);
+  --sidebar-primary-foreground: oklch(0.16 0.038 262);
   --sidebar-accent: oklch(0.274 0.006 286.033);
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.552 0.016 285.938);
+  --sidebar-ring: oklch(0.68 0.15 255);
 
-  /* Sprintable brand (blue, lighter for dark) */
-  --brand: oklch(0.70 0.18 258);
+  /* Sprintable brand (blue, lighter for dark) — hue/chroma 스펙 그대로, L은 라이트와 동일 규칙 */
+  --brand: oklch(0.64 0.17 254);
   --brand-foreground: oklch(0.985 0 0);
+  --primary-tint: oklch(0.28 0.075 260);
 
   /* Semantic status tokens */
   --success: oklch(0.65 0.15 145);


### PR DESCRIPTION
## 요약
- `brand-blue-palette-ssot`(유나) §2 스펙에 따라 웹 앱 `globals.css` 색 토큰을 뉴트럴(zinc)→브랜드 블루(hue255)로 전환
- story `5d88e1a3` · epic [E-UI-DAEGBYEON]

## 그라운딩(doc §0/§4/§5는 이 발견 반영해 정정됨)
현재 `--primary`는 인디고가 아니라 chroma 0.006/0.004의 사실상 무채색(zinc 뉴트럴, shadcn 기본값)이었음. 브랜드 블루는 이미 `--brand`(hue258)·`--info`(hue250)에만 존재. 이번 작업은 "미세 hue 회전"이 아니라 "무채색 primary를 브랜드 블루로 처음 채색"(chroma 0→0.17).

## 변경 사항
- `--primary`: 라이트 brand-600 `oklch(0.50 0.17 255)` · 다크 brand-400 `oklch(0.68 0.15 255)`
- `--primary-foreground`: 다크는 navy950 계열로 변경(대비 확保)
- `--ring`: brand-500(라이트)/brand-400(다크)
- `--brand`: 258/0.18→254/0.17, **L만 스펙(0.58)에서 0.56으로 미세 하향** — `text-brand` 사용 20파일의 AA 4.5:1 확保(스펙 그대로면 4.32:1로 미달)
- `--primary-tint`(신규): brand-50(라이트)/brand-900(다크), `@theme inline`에 유틸리티 매핑 추가
- `--sidebar-primary`: 기존 인디고(264.376) 스캐폴드 → `--primary`와 정렬(254/255 통일)
- ⚠️ **동반 필수 변경**: `--sidebar-primary-foreground`(다크) white→navy950 — 정렬만 하고 그대로 뒀으면 white 텍스트가 새 brand-400(L0.68) 배경 위에서 2.77:1로 AA 미달했을 것(사전 계산으로 발견·수정)

## 스코프 확정
`bg-primary`/`text-primary`/`border-primary`/`ring-primary` 사용 102파일은 전부 Tailwind 유틸리티 클래스라 루트 토큰 변경만으로 자동 캐스케이드 — 파일별 수정 불필요. 하드코딩 색리터럴 grep 결과 primary 대체 후보 0건(Google 로고·유저라벨 팔레트·QR·SVG fallback·랜딩페이지 bespoke 배색 전부 무관). `landing-page.tsx`는 완전 별도 bespoke 배색이라 스코프 밖.

## 대비(AA) 검증 — OKLCH→sRGB 수동 계산(Björn Ottosson 공식)
| 조합 | 대비 |
|---|---|
| 라이트 primary(브랜드-600) vs 화이트 bg | 6.08:1 |
| 라이트 primary-foreground(화이트) vs primary bg | 5.91:1 |
| 다크 primary(브랜드-400) vs 다크 bg | 6.51:1 |
| 다크 primary-foreground(navy950) vs primary bg | 6.72:1 |
| 라이트 --brand(L0.56 조정) vs 화이트 | 4.70:1 (스펙 그대로 L0.58이면 4.32:1로 미달) |
| 다크 --brand(L0.64) vs 다크 bg | 5.56:1 |

전부 AA(4.5:1) 이상. 유나군 S-web-verify 가디언 리뷰로 최종 확인 부탁.

## 테스트
- ✅ `tsc --noEmit` 클린
- ✅ `pnpm lint` 0 error(경고 5건은 무관 파일·이번 변경과 무관한 기존 debt)
- ✅ `pnpm build` EXIT 0
- ✅ `pnpm test`(vitest, 루트) 262 test files / 1780 passed / 2 skipped / 0 failed
- ✅ 라이브 dev서버(puppeteer) 라이트/다크 양쪽 /login 페이지 실렌더 스크린샷 확인 — 버튼/링크/포커스링 브랜드 블루 정상 렌더, 텍스트 가독성 확인

## 스코프 밖(후속 후보, 이번 PR에 미포함)
- `--brand-soft`/`--brand-strong`/`--brand-contrast`·tiptap 에디터 하드코딩 blue(258) 리터럴 — 이번 AC 범위 밖, 필요시 별도 슬라이스
- `landing-page.tsx` bespoke 배색 — 별도 슬라이스 대상