### PR TITLE
feat(auth): E-AUTH-REBUILD 활성화게이트 C3 — Android Key Attestation + Play Integrity verifier

### DIFF
--- a/backend/app/services/android_key_attestation.py
+++ b/backend/app/services/android_key_attestation.py
@@ -1,0 +1,452 @@
+"""story 20da6347(E-AUTH-REBUILD 활성화게이트][C3]·doc e-mobile-per-install-proof-feasibility
+§7.4·산티아고 §7.4 SSOT 2026-07-16): Android Key Attestation 서버측 검증.
+
+**검증 알고리즘 출처**: Android 공식 문서(source.android.com/docs/security/features/keystore/
+attestation)의 Key Attestation 인증서 확장(OID 1.3.6.1.4.1.11129.2.1.17, KeyDescription) 스키마.
+
+⚠️Android엔 iOS signCount 상당 개념이 없다 — 이 모듈은 "등록"(key attestation chain+
+KeyDescription 검증)과 "부트스트랩 서명"(Keystore private key로 canonical bytes ECDSA
+서명 검증)만 다룬다. `server_seq`/challenge 원자적 compare-and-set은 DB 트랜잭션 책임이라
+C4 스코프 — 이 모듈은 순수 암호검증만.
+
+⛔이 모듈이 하지 않는 것: Play Integrity 토큰 검증(별도 모듈 `play_integrity.py`)·revocation
+list의 실제 HTTP 페치(mock-first — `RevocationChecker` 프로토콜을 호출부가 주입, S4/S5
+패턴과 동일 원칙)·register/consume 엔드포인트 배선(C4).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Callable
+
+from cryptography import x509
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+KEY_DESCRIPTION_OID = x509.ObjectIdentifier("1.3.6.1.4.1.11129.2.1.17")
+
+# Google 공식 배포 Hardware Attestation Root — 두 세대 모두 유효(신규 리프는 2026-02-01부터
+# EC root, 기존 기기는 여전히 RSA root 체인을 낼 수 있어 양쪽 다 신뢰 anchor로 유지).
+# 출처: https://developer.android.com/privacy-and-security/security-key-attestation ·
+# https://android.googleapis.com/attestation/root
+GOOGLE_HARDWARE_ATTESTATION_ROOT_RSA_PEM = b"""-----BEGIN CERTIFICATE-----
+MIIFHDCCAwSgAwIBAgIJAPHBcqaZ6vUdMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNV
+BAUTEGY5MjAwOWU4NTNiNmIwNDUwHhcNMjIwMzIwMTgwNzQ4WhcNNDIwMzE1MTgw
+NzQ4WjAbMRkwFwYDVQQFExBmOTIwMDllODUzYjZiMDQ1MIICIjANBgkqhkiG9w0B
+AQEFAAOCAg8AMIICCgKCAgEAr7bHgiuxpwHsK7Qui8xUFmOr75gvMsd/dTEDDJdS
+Sxtf6An7xyqpRR90PL2abxM1dEqlXnf2tqw1Ne4Xwl5jlRfdnJLmN0pTy/4lj4/7
+tv0Sk3iiKkypnEUtR6WfMgH0QZfKHM1+di+y9TFRtv6y//0rb+T+W8a9nsNL/ggj
+nar86461qO0rOs2cXjp3kOG1FEJ5MVmFmBGtnrKpa73XpXyTqRxB/M0n1n/W9nGq
+C4FSYa04T6N5RIZGBN2z2MT5IKGbFlbC8UrW0DxW7AYImQQcHtGl/m00QLVWutHQ
+oVJYnFPlXTcHYvASLu+RhhsbDmxMgJJ0mcDpvsC4PjvB+TxywElgS70vE0XmLD+O
+JtvsBslHZvPBKCOdT0MS+tgSOIfga+z1Z1g7+DVagf7quvmag8jfPioyKvxnK/Eg
+sTUVi2ghzq8wm27ud/mIM7AY2qEORR8Go3TVB4HzWQgpZrt3i5MIlCaY504LzSRi
+igHCzAPlHws+W0rB5N+er5/2pJKnfBSDiCiFAVtCLOZ7gLiMm0jhO2B6tUXHI/+M
+RPjy02i59lINMRRev56GKtcd9qO/0kUJWdZTdA2XoS82ixPvZtXQpUpuL12ab+9E
+aDK8Z4RHJYYfCT3Q5vNAXaiWQ+8PTWm2QgBR/bkwSWc+NpUFgNPN9PvQi8WEg5Um
+AGMCAwEAAaNjMGEwHQYDVR0OBBYEFDZh4QB8iAUJUYtEbEf/GkzJ6k8SMB8GA1Ud
+IwQYMBaAFDZh4QB8iAUJUYtEbEf/GkzJ6k8SMA8GA1UdEwEB/wQFMAMBAf8wDgYD
+VR0PAQH/BAQDAgIEMA0GCSqGSIb3DQEBCwUAA4ICAQB8cMqTllHc8U+qCrOlg3H7
+174lmaCsbo/bJ0C17JEgMLb4kvrqsXZs01U3mB/qABg/1t5Pd5AORHARs1hhqGIC
+W/nKMav574f9rZN4PC2ZlufGXb7sIdJpGiO9ctRhiLuYuly10JccUZGEHpHSYM2G
+tkgYbZba6lsCPYAAP83cyDV+1aOkTf1RCp/lM0PKvmxYN10RYsK631jrleGdcdkx
+oSK//mSQbgcWnmAEZrzHoF1/0gso1HZgIn0YLzVhLSA/iXCX4QT2h3J5z3znluKG
+1nv8NQdxei2DIIhASWfu804CA96cQKTTlaae2fweqXjdN1/v2nqOhngNyz1361mF
+mr4XmaKH/ItTwOe72NI9ZcwS1lVaCvsIkTDCEXdm9rCNPAY10iTunIHFXRh+7KPz
+lHGewCq/8TOohBRn0/NNfh7uRslOSZ/xKbN9tMBtw37Z8d2vvnXq/YWdsm1+JLVw
+n6yYD/yacNJBlwpddla8eaVMjsF6nBnIgQOf9zKSe06nSTqvgwUHosgOECZJZ1Eu
+zbH4yswbt02tKtKEFhx+v+OTge/06V+jGsqTWLsfrOCNLuA8H++z+pUENmpqnnHo
+vaI47gC+TNpkgYGkkBT6B/m/U01BuOBBTzhIlMEZq9qkDWuM2cA5kW5V3FJUcfHn
+w1IdYIg2Wxg7yHcQZemFQg==
+-----END CERTIFICATE-----
+"""
+GOOGLE_HARDWARE_ATTESTATION_ROOT_EC_PEM = b"""-----BEGIN CERTIFICATE-----
+MIICIjCCAaigAwIBAgIRAISp0Cl7DrWK5/8OgN52BgUwCgYIKoZIzj0EAwMwUjEc
+MBoGA1UEAwwTS2V5IEF0dGVzdGF0aW9uIENBMTEQMA4GA1UECwwHQW5kcm9pZDET
+MBEGA1UECgwKR29vZ2xlIExMQzELMAkGA1UEBhMCVVMwHhcNMjUwNzE3MjIzMjE4
+WhcNMzUwNzE1MjIzMjE4WjBSMRwwGgYDVQQDDBNLZXkgQXR0ZXN0YXRpb24gQ0Ex
+MRAwDgYDVQQLDAdBbmRyb2lkMRMwEQYDVQQKDApHb29nbGUgTExDMQswCQYDVQQG
+EwJVUzB2MBAGByqGSM49AgEGBSuBBAAiA2IABCPaI3FO3z5bBQo8cuiEas4HjqCt
+G/mLFfRT0MsIssPBEEU5Cfbt6sH5yOAxqEi5QagpU1yX4HwnGb7OtBYpDTB57uH5
+Eczm34A5FNijV3s0/f0UPl7zbJcTx6xwqMIRq6NCMEAwDwYDVR0TAQH/BAUwAwEB
+/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFFIyuyz7RkOb3NaBqQ5lZuA0QepA
+MAoGCCqGSM49BAMDA2gAMGUCMETfjPO/HwqReR2CS7p0ZWoD/LHs6hDi422opifH
+EUaYLxwGlT9SLdjkVpz0UUOR5wIxAIoGyxGKRHVTpqpGRFiJtQEOOTp/+s1GcxeY
+uR2zh/80lQyu9vAFCj6E4AXc+osmRg==
+-----END CERTIFICATE-----
+"""
+
+SECURITY_LEVEL_SOFTWARE = 0
+SECURITY_LEVEL_TRUSTED_ENVIRONMENT = 1
+SECURITY_LEVEL_STRONGBOX = 2
+
+VERIFIED_BOOT_STATE_VERIFIED = 0
+VERIFIED_BOOT_STATE_SELF_SIGNED = 1
+VERIFIED_BOOT_STATE_UNVERIFIED = 2
+VERIFIED_BOOT_STATE_FAILED = 3
+
+ORIGIN_GENERATED = 0
+KM_PURPOSE_SIGN = 2
+KM_DIGEST_SHA_2_256 = 4
+
+# AuthorizationList의 context-tag 번호(Android Keystore Attestation 스키마, source.android.com).
+_TAG_PURPOSE = 1
+_TAG_DIGEST = 5
+_TAG_ORIGIN = 702
+_TAG_ROOT_OF_TRUST = 704
+_TAG_ATTESTATION_APPLICATION_ID = 709
+
+
+class AndroidAttestationVerificationError(Exception):
+    """검증 실패 — 메시지는 로그 전용(enumeration 방지는 호출부 401 통일 책임)."""
+
+
+# ─── 최소 범용 DER TLV 파서(§7.0 정신과 동일 이유 — KeyDescription의 깊은 중첩 구조를
+# 정확히 파싱 못 하면 crypto 검증 자체가 우회될 수 있어 pyasn1 같은 검증된 저수준 프리미티브
+# 대신 이 스토리 스코프에 정확히 필요한 필드만 손으로 정밀 파싱한다) ────────────────────
+
+@dataclass
+class _DerTlv:
+    tag_class: int  # 0=universal,1=application,2=context,3=private
+    constructed: bool
+    tag_number: int
+    content: bytes
+
+
+def _read_der_length(data: bytes, offset: int) -> tuple[int, int]:
+    first = data[offset]
+    offset += 1
+    if first & 0x80 == 0:
+        return first, offset
+    num_bytes = first & 0x7F
+    if num_bytes == 0:
+        raise AndroidAttestationVerificationError("der_indefinite_length_unsupported")
+    length = int.from_bytes(data[offset:offset + num_bytes], "big")
+    return length, offset + num_bytes
+
+
+def _read_der_tlv(data: bytes, offset: int) -> tuple[_DerTlv, int]:
+    tag_byte = data[offset]
+    tag_class = (tag_byte >> 6) & 0x03
+    constructed = bool(tag_byte & 0x20)
+    tag_number = tag_byte & 0x1F
+    pos = offset + 1
+    if tag_number == 0x1F:
+        tag_number = 0
+        while True:
+            b = data[pos]
+            pos += 1
+            tag_number = (tag_number << 7) | (b & 0x7F)
+            if not (b & 0x80):
+                break
+    length, pos = _read_der_length(data, pos)
+    content = data[pos:pos + length]
+    return _DerTlv(tag_class=tag_class, constructed=constructed, tag_number=tag_number, content=content), pos + length
+
+
+def _read_der_sequence_items(content: bytes) -> list[_DerTlv]:
+    items = []
+    pos = 0
+    while pos < len(content):
+        item, pos = _read_der_tlv(content, pos)
+        items.append(item)
+    return items
+
+
+def _der_integer(tlv: _DerTlv) -> int:
+    return int.from_bytes(tlv.content, "big", signed=False) if tlv.content else 0
+
+
+def _find_context_tag(items: list[_DerTlv], tag_number: int) -> _DerTlv | None:
+    for item in items:
+        if item.tag_class == 2 and item.tag_number == tag_number:
+            return item
+    return None
+
+
+def _unwrap_explicit(tlv: _DerTlv) -> _DerTlv:
+    """AuthorizationList 필드는 전부 `[N] EXPLICIT <type>` — context tag의 content가 그
+    자체로 완전한 하나의 내부 TLV를 담는다(IMPLICIT 아님)."""
+    inner, _ = _read_der_tlv(tlv.content, 0)
+    return inner
+
+
+@dataclass
+class ParsedRootOfTrust:
+    verified_boot_key: bytes
+    device_locked: bool
+    verified_boot_state: int
+
+
+@dataclass
+class ParsedAttestationApplicationId:
+    package_names: set[bytes] = field(default_factory=set)
+    signature_digests: set[bytes] = field(default_factory=set)
+
+
+@dataclass
+class ParsedKeyDescription:
+    attestation_version: int
+    attestation_security_level: int
+    keymaster_security_level: int
+    attestation_challenge: bytes
+    purposes: set[int]
+    digests: set[int]
+    origin: int | None
+    root_of_trust: ParsedRootOfTrust | None
+    attestation_application_id: ParsedAttestationApplicationId | None
+
+
+def _parse_authorization_list(content: bytes) -> tuple[set[int], set[int], int | None, ParsedRootOfTrust | None, ParsedAttestationApplicationId | None]:
+    items = _read_der_sequence_items(content)
+
+    purposes: set[int] = set()
+    purpose_tag = _find_context_tag(items, _TAG_PURPOSE)
+    if purpose_tag is not None:
+        purpose_set = _unwrap_explicit(purpose_tag)
+        purposes = {_der_integer(t) for t in _read_der_sequence_items(purpose_set.content)}
+
+    digests: set[int] = set()
+    digest_tag = _find_context_tag(items, _TAG_DIGEST)
+    if digest_tag is not None:
+        digest_set = _unwrap_explicit(digest_tag)
+        digests = {_der_integer(t) for t in _read_der_sequence_items(digest_set.content)}
+
+    origin: int | None = None
+    origin_tag = _find_context_tag(items, _TAG_ORIGIN)
+    if origin_tag is not None:
+        origin = _der_integer(_unwrap_explicit(origin_tag))
+
+    root_of_trust: ParsedRootOfTrust | None = None
+    rot_tag = _find_context_tag(items, _TAG_ROOT_OF_TRUST)
+    if rot_tag is not None:
+        rot_seq = _unwrap_explicit(rot_tag)
+        rot_items = _read_der_sequence_items(rot_seq.content)
+        if len(rot_items) < 3:
+            raise AndroidAttestationVerificationError("root_of_trust_truncated")
+        verified_boot_key = rot_items[0].content
+        device_locked = rot_items[1].content != b"\x00"
+        verified_boot_state = _der_integer(rot_items[2])
+        root_of_trust = ParsedRootOfTrust(
+            verified_boot_key=verified_boot_key, device_locked=device_locked, verified_boot_state=verified_boot_state
+        )
+
+    attestation_application_id: ParsedAttestationApplicationId | None = None
+    aai_tag = _find_context_tag(items, _TAG_ATTESTATION_APPLICATION_ID)
+    if aai_tag is not None:
+        # [709] EXPLICIT OCTET STRING — 그 OCTET STRING의 content 자체가 다시 하나의 완전한
+        # DER SEQUENCE(AttestationApplicationId, 이중 인코딩)라 한 번 더 파싱해야 한다.
+        octet_tlv = _unwrap_explicit(aai_tag)
+        aai_seq, _ = _read_der_tlv(octet_tlv.content, 0)
+        aai_items = _read_der_sequence_items(aai_seq.content)
+        if len(aai_items) < 2:
+            raise AndroidAttestationVerificationError("attestation_application_id_truncated")
+        package_records = _read_der_sequence_items(aai_items[0].content)
+        package_names = set()
+        for record in package_records:
+            record_items = _read_der_sequence_items(record.content)
+            if not record_items:
+                continue
+            package_names.add(record_items[0].content)
+        signature_digest_items = _read_der_sequence_items(aai_items[1].content)
+        signature_digests = {t.content for t in signature_digest_items}
+        attestation_application_id = ParsedAttestationApplicationId(
+            package_names=package_names, signature_digests=signature_digests
+        )
+
+    return purposes, digests, origin, root_of_trust, attestation_application_id
+
+
+def parse_key_description(extension_der: bytes) -> ParsedKeyDescription:
+    """OID 1.3.6.1.4.1.11129.2.1.17 확장값(전체 KeyDescription DER)을 파싱. 스토리 스코프에
+    필요한 필드만(purpose/digest/origin/rootOfTrust/attestationApplicationId) hardwareEnforced
+    에서 추출 — softwareEnforced는 신뢰 anchor가 아니므로 안 본다(공격자가 software-enforced
+    필드는 자유롭게 조작 가능)."""
+    top, _ = _read_der_tlv(extension_der, 0)
+    items = _read_der_sequence_items(top.content)
+    if len(items) < 8:
+        raise AndroidAttestationVerificationError("key_description_truncated")
+
+    attestation_version = _der_integer(items[0])
+    attestation_security_level = _der_integer(items[1])
+    keymaster_security_level = _der_integer(items[3])
+    attestation_challenge = items[4].content
+    hardware_enforced = items[7]
+
+    purposes, digests, origin, root_of_trust, attestation_application_id = _parse_authorization_list(
+        hardware_enforced.content
+    )
+
+    return ParsedKeyDescription(
+        attestation_version=attestation_version,
+        attestation_security_level=attestation_security_level,
+        keymaster_security_level=keymaster_security_level,
+        attestation_challenge=attestation_challenge,
+        purposes=purposes,
+        digests=digests,
+        origin=origin,
+        root_of_trust=root_of_trust,
+        attestation_application_id=attestation_application_id,
+    )
+
+
+# ─── 인증서 체인 검증 ─────────────────────────────────────────────────────────
+
+def _verify_cert_signed_by(child: x509.Certificate, parent_public_key) -> bool:
+    try:
+        if isinstance(parent_public_key, ec.EllipticCurvePublicKey):
+            parent_public_key.verify(child.signature, child.tbs_certificate_bytes, ec.ECDSA(child.signature_hash_algorithm))
+        else:
+            from cryptography.hazmat.primitives.asymmetric import padding
+            parent_public_key.verify(
+                child.signature, child.tbs_certificate_bytes, padding.PKCS1v15(), child.signature_hash_algorithm
+            )
+        return True
+    except InvalidSignature:
+        return False
+    except Exception:
+        return False
+
+
+def _trusted_roots() -> list[x509.Certificate]:
+    return [
+        x509.load_pem_x509_certificate(GOOGLE_HARDWARE_ATTESTATION_ROOT_RSA_PEM),
+        x509.load_pem_x509_certificate(GOOGLE_HARDWARE_ATTESTATION_ROOT_EC_PEM),
+    ]
+
+
+RevocationChecker = Callable[[x509.Certificate], bool]
+"""cert → True면 폐기됨. 실 HTTP 페치(https://android.googleapis.com/attestation/status)는
+호출부 책임(mock-first) — 이 모듈은 검사 시점(now)에 주어진 checker를 체인의 모든 인증서에
+적용만 한다."""
+
+
+def _verify_chain_to_google_root(
+    chain_der: list[bytes], *, trusted_roots: list[x509.Certificate] | None = None,
+    revocation_checker: RevocationChecker | None = None,
+) -> x509.Certificate:
+    if not chain_der:
+        raise AndroidAttestationVerificationError("empty_certificate_chain")
+    try:
+        certs = [x509.load_der_x509_certificate(c) for c in chain_der]
+    except ValueError as exc:
+        raise AndroidAttestationVerificationError("malformed_certificate_in_chain") from exc
+
+    now = datetime.now(timezone.utc)
+    for c in certs:
+        if c.not_valid_before_utc > now or c.not_valid_after_utc < now:
+            raise AndroidAttestationVerificationError("certificate_expired_or_not_yet_valid")
+
+    if revocation_checker is not None:
+        for c in certs:
+            if revocation_checker(c):
+                raise AndroidAttestationVerificationError("certificate_revoked")
+
+    for i in range(len(certs) - 1):
+        if not _verify_cert_signed_by(certs[i], certs[i + 1].public_key()):
+            raise AndroidAttestationVerificationError("chain_signature_invalid")
+
+    roots = trusted_roots if trusted_roots is not None else _trusted_roots()
+    if not any(_verify_cert_signed_by(certs[-1], root.public_key()) for root in roots):
+        raise AndroidAttestationVerificationError("chain_does_not_terminate_at_google_root")
+
+    return certs[0]  # leaf
+
+
+@dataclass
+class VerifiedKeyAttestation:
+    public_key_der: bytes
+    security_level: str  # "hardware" | "strongbox"
+
+
+def verify_key_attestation(
+    *,
+    certificate_chain: list[bytes],
+    expected_challenge: bytes,
+    expected_package_name: bytes,
+    expected_signing_cert_digest: bytes,
+    trusted_roots: list[x509.Certificate] | None = None,
+    revocation_checker: RevocationChecker | None = None,
+) -> VerifiedKeyAttestation:
+    """산티아고 §7.4 Android 등록 검증 — 실패 시 AndroidAttestationVerificationError.
+
+    호출부(C4)가 이 함수 전에 마쳐야 하는 것: 서버 challenge 발급(§7.2 Android 특수 순서 —
+    challenge 먼저 발급 후 그 해시를 `setAttestationChallenge`로 키 생성에 사용, 키 생성
+    후에는 challenge 교체 불가), Play Integrity Standard token 검증(별도 모듈)."""
+    leaf = _verify_chain_to_google_root(certificate_chain, trusted_roots=trusted_roots, revocation_checker=revocation_checker)
+
+    try:
+        ext = leaf.extensions.get_extension_for_oid(KEY_DESCRIPTION_OID)
+    except x509.ExtensionNotFound as exc:
+        raise AndroidAttestationVerificationError("key_description_extension_missing") from exc
+    raw = ext.value.value if hasattr(ext.value, "value") else bytes(ext.value)
+    parsed = parse_key_description(raw)
+
+    if parsed.attestation_challenge != expected_challenge:
+        raise AndroidAttestationVerificationError("attestation_challenge_mismatch")
+
+    if parsed.attestation_security_level == SECURITY_LEVEL_SOFTWARE:
+        raise AndroidAttestationVerificationError("not_hardware_backed")
+    if parsed.attestation_security_level not in (SECURITY_LEVEL_TRUSTED_ENVIRONMENT, SECURITY_LEVEL_STRONGBOX):
+        raise AndroidAttestationVerificationError("unknown_security_level")
+
+    if parsed.origin != ORIGIN_GENERATED:
+        raise AndroidAttestationVerificationError("key_origin_not_generated")
+    if KM_PURPOSE_SIGN not in parsed.purposes:
+        raise AndroidAttestationVerificationError("purpose_sign_not_present")
+    if KM_DIGEST_SHA_2_256 not in parsed.digests:
+        raise AndroidAttestationVerificationError("digest_sha256_not_present")
+
+    if parsed.root_of_trust is None:
+        raise AndroidAttestationVerificationError("root_of_trust_missing")
+    if parsed.root_of_trust.verified_boot_state != VERIFIED_BOOT_STATE_VERIFIED:
+        raise AndroidAttestationVerificationError("verified_boot_state_not_verified")
+    if not parsed.root_of_trust.device_locked:
+        raise AndroidAttestationVerificationError("device_not_locked")
+
+    if parsed.attestation_application_id is None:
+        raise AndroidAttestationVerificationError("attestation_application_id_missing")
+    if expected_package_name not in parsed.attestation_application_id.package_names:
+        raise AndroidAttestationVerificationError("package_name_mismatch")
+    if expected_signing_cert_digest not in parsed.attestation_application_id.signature_digests:
+        raise AndroidAttestationVerificationError("signing_cert_digest_mismatch")
+
+    leaf_public_key = leaf.public_key()
+    if not isinstance(leaf_public_key, ec.EllipticCurvePublicKey) or leaf_public_key.curve.name != "secp256r1":
+        raise AndroidAttestationVerificationError("leaf_key_not_p256")
+
+    public_key_der = leaf_public_key.public_bytes(
+        encoding=serialization.Encoding.DER, format=serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    security_level = "strongbox" if parsed.attestation_security_level == SECURITY_LEVEL_STRONGBOX else "hardware"
+    return VerifiedKeyAttestation(public_key_der=public_key_der, security_level=security_level)
+
+
+# ─── 부트스트랩 서명 검증(server_seq 챌린지 응답) ────────────────────────────
+
+@dataclass
+class VerifiedBootstrapSignature:
+    verified: bool = True
+
+
+def verify_bootstrap_signature(
+    *, signed_bytes: bytes, signature: bytes, stored_public_key_der: bytes
+) -> VerifiedBootstrapSignature:
+    """Android엔 signCount가 없다 — 매 요청 Keystore private key로 canonical bytes(서버가
+    구성한 challenge transcript)에 ECDSA-SHA256 서명한 것을 등록된 공개키로 검증만 한다.
+    `server_seq`+challenge 원자성(재사용 방지)은 DB 트랜잭션(C4) 책임 — 이 함수 자체는
+    같은 (signed_bytes, signature) 쌍의 replay를 못 막는다(순수 서명 유효성만 판단)."""
+    try:
+        public_key = serialization.load_der_public_key(stored_public_key_der)
+    except Exception as exc:
+        raise AndroidAttestationVerificationError("stored_public_key_malformed") from exc
+    if not isinstance(public_key, ec.EllipticCurvePublicKey):
+        raise AndroidAttestationVerificationError("stored_public_key_not_ec")
+
+    try:
+        public_key.verify(signature, signed_bytes, ec.ECDSA(hashes.SHA256()))
+    except InvalidSignature as exc:
+        raise AndroidAttestationVerificationError("bootstrap_signature_invalid") from exc
+
+    return VerifiedBootstrapSignature()

--- a/backend/app/services/play_integrity.py
+++ b/backend/app/services/play_integrity.py
@@ -1,0 +1,123 @@
+"""story 20da6347(E-AUTH-REBUILD 활성화게이트][C3]·산티아고 §7.4 SSOT 2026-07-16): Play
+Integrity **Standard** token 서버측 검증 — Google Play Integrity API `decodeIntegrityToken`
+호출.
+
+⚠️mock-first 계약(S4 `firebase_session_mint.py`의 `_call_create_session_cookie` 패턴과
+동일 원칙): 실 Google REST 왕복은 `_call_decode_integrity_token()` 한 지점으로 분리해
+테스트가 모킹할 수 있게 한다 — non-prod Google Cloud 프로젝트 프로비저닝 전까지는 이
+구조(호출 순서·실패 처리·응답 파싱)만 계약테스트로 검증한다.
+
+**verdict 정책**(§7.4 명시): `appRecognitionVerdict=PLAY_RECOGNIZED`+exact package/cert/
+version + 최소 `MEETS_DEVICE_INTEGRITY`. `MEETS_STRONG_INTEGRITY`는 이 스토리 스코프가
+아닌 고위험 작업 강화정책용(호출부가 반환된 verdict 목록을 보고 자체 판단)."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import google.auth
+import google.auth.transport.requests
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_PLAY_INTEGRITY_SCOPE = "https://www.googleapis.com/auth/playintegrity"
+_DECODE_URL_TEMPLATE = "https://playintegrity.googleapis.com/v1/{package_name}:decodeIntegrityToken"
+
+MEETS_DEVICE_INTEGRITY = "MEETS_DEVICE_INTEGRITY"
+MEETS_STRONG_INTEGRITY = "MEETS_STRONG_INTEGRITY"
+
+
+class PlayIntegrityVerificationError(Exception):
+    """검증 실패 — 메시지는 로그 전용(enumeration 방지는 호출부 401 통일 책임)."""
+
+
+def _get_access_token() -> str:
+    """ADC로 Play Integrity API 스코프 액세스 토큰 획득 — 테스트에서 모킹하는 지점
+    (S4 firebase_session_mint._get_access_token과 동일 패턴)."""
+    credentials, _project = google.auth.default(scopes=[_PLAY_INTEGRITY_SCOPE])
+    request = google.auth.transport.requests.Request()
+    credentials.refresh(request)
+    return credentials.token
+
+
+async def _call_decode_integrity_token(access_token: str, package_name: str, integrity_token: str) -> httpx.Response:
+    """실 Google REST 호출 지점 — 테스트에서 모킹."""
+    url = _DECODE_URL_TEMPLATE.format(package_name=package_name)
+    async with httpx.AsyncClient() as client:
+        return await client.post(
+            url,
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={"integrity_token": integrity_token},
+        )
+
+
+@dataclass
+class VerifiedPlayIntegrity:
+    device_recognition_verdicts: list[str]
+
+
+async def verify_play_integrity_token(
+    *,
+    integrity_token: str,
+    expected_package_name: str,
+    expected_cert_sha256_digest_b64: str,
+    minimum_version_code: int,
+    request_hash: str,
+) -> VerifiedPlayIntegrity:
+    """실패 시 PlayIntegrityVerificationError. `request_hash`는 클라이언트가 토큰 요청 시
+    바인딩한 canonical request hash — 서버가 기대하는 값과 정확히 일치해야 한다(다른
+    요청 맥락의 토큰 재사용 방지, 이 세션의 canonical-transcript-binding 원칙과 동일)."""
+    try:
+        access_token = _get_access_token()
+    except Exception as exc:
+        logger.warning("play_integrity.verify failed reason=adc_token_unavailable")
+        raise PlayIntegrityVerificationError("adc_token_unavailable") from exc
+
+    try:
+        response = await _call_decode_integrity_token(access_token, expected_package_name, integrity_token)
+    except httpx.HTTPError as exc:
+        logger.warning("play_integrity.verify failed reason=network_error")
+        raise PlayIntegrityVerificationError("network_error") from exc
+
+    if response.status_code != 200:
+        logger.warning("play_integrity.verify failed reason=google_rejected status=%d", response.status_code)
+        raise PlayIntegrityVerificationError("google_rejected")
+
+    body = response.json()
+    payload = body.get("tokenPayloadExternal")
+    if not isinstance(payload, dict):
+        logger.warning("play_integrity.verify failed reason=malformed_response")
+        raise PlayIntegrityVerificationError("malformed_response")
+
+    request_details = payload.get("requestDetails") or {}
+    if request_details.get("requestPackageName") != expected_package_name:
+        raise PlayIntegrityVerificationError("request_package_name_mismatch")
+    if request_details.get("requestHash") != request_hash:
+        raise PlayIntegrityVerificationError("request_hash_mismatch")
+
+    app_integrity = payload.get("appIntegrity") or {}
+    if app_integrity.get("appRecognitionVerdict") != "PLAY_RECOGNIZED":
+        raise PlayIntegrityVerificationError("app_not_play_recognized")
+    if app_integrity.get("packageName") != expected_package_name:
+        raise PlayIntegrityVerificationError("app_package_name_mismatch")
+    cert_digests = app_integrity.get("certificateSha256Digest") or []
+    if expected_cert_sha256_digest_b64 not in cert_digests:
+        raise PlayIntegrityVerificationError("cert_digest_mismatch")
+
+    version_code = app_integrity.get("versionCode")
+    try:
+        version_code_int = int(version_code)
+    except (TypeError, ValueError) as exc:
+        raise PlayIntegrityVerificationError("version_code_malformed") from exc
+    if version_code_int < minimum_version_code:
+        raise PlayIntegrityVerificationError("version_code_below_minimum")
+
+    device_integrity = payload.get("deviceIntegrity") or {}
+    verdicts = device_integrity.get("deviceRecognitionVerdict") or []
+    if MEETS_DEVICE_INTEGRITY not in verdicts:
+        logger.warning("play_integrity.verify rejected reason=device_integrity_insufficient")
+        raise PlayIntegrityVerificationError("device_integrity_insufficient")
+
+    logger.info("play_integrity.verify success")
+    return VerifiedPlayIntegrity(device_recognition_verdicts=list(verdicts))

--- a/backend/tests/test_20da6347_c3_android_key_attestation.py
+++ b/backend/tests/test_20da6347_c3_android_key_attestation.py
@@ -1,0 +1,426 @@
+"""story 20da6347(E-AUTH-REBUILD 활성화게이트][C3]·산티아고 §7.4 SSOT) 게이트: Android Key
+Attestation X.509 chain+KeyDescription 검증 — 정상/전수 음성 케이스.
+
+실 Google 인증서는 당연히 없으므로, 모듈이 신뢰하는 root anchor를 테스트 전용 self-signed
+root로 주입(`trusted_roots=` 파라미터)해 **동일 검증 알고리즘**을 실증한다. KeyDescription
+확장은 DER TLV를 손으로 정확히 인코딩해 구성 — 파서(app 코드)와 완전히 독립적인 인코더로
+검증해야 파서의 숨은 가정을 우연히 안 맞춰주는 진짜 라운드트립 테스트가 된다.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from app.services.android_key_attestation import (
+    KEY_DESCRIPTION_OID,
+    AndroidAttestationVerificationError,
+    verify_bootstrap_signature,
+    verify_key_attestation,
+)
+
+PACKAGE_NAME = b"com.sprintable.app"
+CERT_DIGEST = bytes(range(32))  # 가짜 SHA-256 다이제스트 형태(32바이트)
+CHALLENGE = b"server-issued-256bit-challenge-x"[:32]
+
+
+# ─── 최소 DER 인코더(파서와 독립 구현) ───────────────────────────────────────
+
+def _der_length_bytes(length: int) -> bytes:
+    if length < 0x80:
+        return bytes([length])
+    length_bytes = length.to_bytes((length.bit_length() + 7) // 8, "big")
+    return bytes([0x80 | len(length_bytes)]) + length_bytes
+
+
+def _encode_tag_number(tag_number: int) -> bytes:
+    parts = [tag_number & 0x7F]
+    n = tag_number >> 7
+    while n:
+        parts.append((n & 0x7F) | 0x80)
+        n >>= 7
+    parts.reverse()
+    return bytes(parts)
+
+
+def _der_tag_and_length(tag_class: int, constructed: bool, tag_number: int, content_len: int) -> bytes:
+    first_byte = (tag_class << 6) | (0x20 if constructed else 0x00)
+    if tag_number < 31:
+        tag_bytes = bytes([first_byte | tag_number])
+    else:
+        tag_bytes = bytes([first_byte | 0x1F]) + _encode_tag_number(tag_number)
+    return tag_bytes + _der_length_bytes(content_len)
+
+
+def _der_universal(tag_number: int, constructed: bool, content: bytes) -> bytes:
+    return _der_tag_and_length(0, constructed, tag_number, len(content)) + content
+
+
+def _der_context_explicit(tag_number: int, inner: bytes) -> bytes:
+    return _der_tag_and_length(2, True, tag_number, len(inner)) + inner
+
+
+def _integer(value: int) -> bytes:
+    if value == 0:
+        content = b"\x00"
+    else:
+        nbytes = (value.bit_length() + 7) // 8
+        content = value.to_bytes(nbytes, "big")
+        if content[0] & 0x80:
+            content = b"\x00" + content
+    return _der_universal(0x02, False, content)
+
+
+def _octet_string(data: bytes) -> bytes:
+    return _der_universal(0x04, False, data)
+
+
+def _boolean(value: bool) -> bytes:
+    return _der_universal(0x01, False, b"\xff" if value else b"\x00")
+
+
+def _enumerated(value: int) -> bytes:
+    return _der_universal(0x0A, False, bytes([value]))
+
+
+def _sequence(*items: bytes) -> bytes:
+    return _der_universal(0x10, True, b"".join(items))
+
+
+def _set_of(*items: bytes) -> bytes:
+    return _der_universal(0x11, True, b"".join(items))
+
+
+def _build_authorization_list(
+    *, purposes=None, digests=None, origin=None, root_of_trust=None, package_name=None, version=1, cert_digest=None,
+):
+    fields = []
+    if purposes is not None:
+        fields.append(_der_context_explicit(1, _set_of(*[_integer(p) for p in purposes])))
+    if digests is not None:
+        fields.append(_der_context_explicit(5, _set_of(*[_integer(d) for d in digests])))
+    if origin is not None:
+        fields.append(_der_context_explicit(702, _integer(origin)))
+    if root_of_trust is not None:
+        verified_boot_key, device_locked, verified_boot_state = root_of_trust
+        rot_seq = _sequence(_octet_string(verified_boot_key), _boolean(device_locked), _enumerated(verified_boot_state))
+        fields.append(_der_context_explicit(704, rot_seq))
+    if package_name is not None:
+        pkg_record = _sequence(_octet_string(package_name), _integer(version))
+        aai_seq = _sequence(_set_of(pkg_record), _set_of(_octet_string(cert_digest)))
+        fields.append(_der_context_explicit(709, _octet_string(aai_seq)))
+    return _sequence(*fields)
+
+
+def _build_key_description(
+    *, challenge, security_level=1, keymaster_security_level=1, hardware_enforced_der,
+):
+    return _sequence(
+        _integer(200), _enumerated(security_level), _integer(200), _enumerated(keymaster_security_level),
+        _octet_string(challenge), _octet_string(b""), _sequence(), hardware_enforced_der,
+    )
+
+
+def _default_hardware_enforced(**overrides) -> bytes:
+    kwargs = dict(
+        purposes=[2], digests=[4], origin=0,
+        root_of_trust=(b"\x01" * 32, True, 0),
+        package_name=PACKAGE_NAME, version=1, cert_digest=CERT_DIGEST,
+    )
+    kwargs.update(overrides)
+    return _build_authorization_list(**kwargs)
+
+
+# ─── 인증서 체인 빌더 ────────────────────────────────────────────────────────
+
+def _self_signed_root():
+    key = ec.generate_private_key(ec.SECP384R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Test Key Attestation Root")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name).issuer_name(name).public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=3650))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(key, hashes.SHA384())
+    )
+    return key, cert
+
+
+def _signed_intermediate(root_key, root_cert):
+    key = ec.generate_private_key(ec.SECP384R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Test Key Attestation CA1")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name).issuer_name(root_cert.subject).public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=3650))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        .sign(root_key, hashes.SHA384())
+    )
+    return key, cert
+
+
+def _leaf_with_key_description(intermediate_key, intermediate_cert, key_description_der: bytes):
+    leaf_key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Test Key Attestation Leaf")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name).issuer_name(intermediate_cert.subject).public_key(leaf_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
+        .add_extension(x509.UnrecognizedExtension(KEY_DESCRIPTION_OID, key_description_der), critical=False)
+        .sign(intermediate_key, hashes.SHA256())
+    )
+    return leaf_key, cert
+
+
+def _build_chain(*, hardware_enforced_kwargs=None, security_level=1, challenge=CHALLENGE):
+    root_key, root_cert = _self_signed_root()
+    intermediate_key, intermediate_cert = _signed_intermediate(root_key, root_cert)
+
+    hw_kwargs = hardware_enforced_kwargs or {}
+    hardware_enforced = _default_hardware_enforced(**hw_kwargs)
+    key_description = _build_key_description(
+        challenge=challenge, security_level=security_level, keymaster_security_level=security_level,
+        hardware_enforced_der=hardware_enforced,
+    )
+    leaf_key, leaf_cert = _leaf_with_key_description(intermediate_key, intermediate_cert, key_description)
+
+    chain_der = [
+        leaf_cert.public_bytes(serialization.Encoding.DER),
+        intermediate_cert.public_bytes(serialization.Encoding.DER),
+    ]
+    return {"chain_der": chain_der, "leaf_key": leaf_key, "trusted_roots": [root_cert]}
+
+
+# ─── verify_key_attestation ─────────────────────────────────────────────────
+
+def test_valid_attestation_accepted():
+    fx = _build_chain()
+    result = verify_key_attestation(
+        certificate_chain=fx["chain_der"], expected_challenge=CHALLENGE,
+        expected_package_name=PACKAGE_NAME, expected_signing_cert_digest=CERT_DIGEST,
+        trusted_roots=fx["trusted_roots"],
+    )
+    assert result.security_level == "hardware"
+    assert result.public_key_der
+
+
+def test_strongbox_security_level_recorded():
+    fx = _build_chain(security_level=2)
+    result = verify_key_attestation(
+        certificate_chain=fx["chain_der"], expected_challenge=CHALLENGE,
+        expected_package_name=PACKAGE_NAME, expected_signing_cert_digest=CERT_DIGEST,
+        trusted_roots=fx["trusted_roots"],
+    )
+    assert result.security_level == "strongbox"
+
+
+def test_software_security_level_rejected():
+    fx = _build_chain(security_level=0)
+    with pytest.raises(AndroidAttestationVerificationError, match="not_hardware_backed"):
+        verify_key_attestation(
+            certificate_chain=fx["chain_der"], expected_challenge=CHALLENGE,
+            expected_package_name=PACKAGE_NAME, expected_signing_cert_digest=CERT_DIGEST,
+            trusted_roots=fx["trusted_roots"],
+        )
+
+
+def test_wrong_package_name_rejected():
+    fx = _build_chain()
+    with pytest.raises(AndroidAttestationVerificationError, match="package_name_mismatch"):
+        verify_key_attestation(
+            certificate_chain=fx["chain_der"], expected_challenge=CHALLENGE,
+            expected_package_name=b"com.wrong.app", expected_signing_cert_digest=CERT_DIGEST,
+            trusted_roots=fx["trusted_roots"],
+        )
+
+
+def test_wrong_cert_digest_rejected():
+    fx = _build_chain()
+    with pytest.raises(AndroidAttestationVerificationError, match="signing_cert_digest_mismatch"):
+        verify_key_attestation(
+            certificate_chain=fx["chain_der"], expected_challenge=CHALLENGE,
+            expected_package_name=PACKAGE_NAME, expected_signing_cert_digest=b"\x99" * 32,
+            trusted_roots=fx["trusted_roots"],
+        )
+
+
+def test_challenge_mismatch_rejected():
+    fx = _build_chain(challenge=CHALLENGE)
+    with pytest.raises(AndroidAttestationVerificationError, match="attestation_challenge_mismatch"):
+        verify_key_attestation(
+            certificate_chain=fx["chain_der"], expected_challenge=b"different-challenge-bytes-here!!",
+            expected_package_name=PACKAGE_NAME, expected_signing_cert_digest=CERT_DIGEST,
+            trusted_roots=fx["trusted_roots"],
+        )
+
+
+def test_key_origin_not_generated_rejected():
+    fx = _build_chain(hardware_enforced_kwargs={"origin": 1})  # 1=IMPORTED, not GENERATED
+    with pytest.raises(AndroidAttestationVerificationError, match="key_origin_not_generated"):
+        verify_key_attestation(
+            certificate_chain=fx["chain_der"], expected_challenge=CHALLENGE,
+            expected_package_name=PACKAGE_NAME, expected_signing_cert_digest=CERT_DIGEST,
+            trusted_roots=fx["trusted_roots"],
+        )
+
+
+def test_purpose_not_sign_rejected():
+    fx = _build_chain(hardware_enforced_kwargs={"purposes": [0]})  # 0=ENCRYPT, not SIGN
+    with pytest.raises(AndroidAttestationVerificationError, match="purpose_sign_not_present"):
+        verify_key_attestation(
+            certificate_chain=fx["chain_der"], expected_challenge=CHALLENGE,
+            expected_package_name=PACKAGE_NAME, expected_signing_cert_digest=CERT_DIGEST,
+            trusted_roots=fx["trusted_roots"],
+        )
+
+
+def test_digest_not_sha256_rejected():
+    fx = _build_chain(hardware_enforced_kwargs={"digests": [1]})  # 1=SHA1, not SHA256
+    with pytest.raises(AndroidAttestationVerificationError, match="digest_sha256_not_present"):
+        verify_key_attestation(
+            certificate_chain=fx["chain_der"], expected_challenge=CHALLENGE,
+            expected_package_name=PACKAGE_NAME, expected_signing_cert_digest=CERT_DIGEST,
+            trusted_roots=fx["trusted_roots"],
+        )
+
+
+def test_verified_boot_state_not_verified_rejected():
+    fx = _build_chain(hardware_enforced_kwargs={"root_of_trust": (b"\x01" * 32, True, 2)})  # Unverified
+    with pytest.raises(AndroidAttestationVerificationError, match="verified_boot_state_not_verified"):
+        verify_key_attestation(
+            certificate_chain=fx["chain_der"], expected_challenge=CHALLENGE,
+            expected_package_name=PACKAGE_NAME, expected_signing_cert_digest=CERT_DIGEST,
+            trusted_roots=fx["trusted_roots"],
+        )
+
+
+def test_device_not_locked_rejected():
+    fx = _build_chain(hardware_enforced_kwargs={"root_of_trust": (b"\x01" * 32, False, 0)})
+    with pytest.raises(AndroidAttestationVerificationError, match="device_not_locked"):
+        verify_key_attestation(
+            certificate_chain=fx["chain_der"], expected_challenge=CHALLENGE,
+            expected_package_name=PACKAGE_NAME, expected_signing_cert_digest=CERT_DIGEST,
+            trusted_roots=fx["trusted_roots"],
+        )
+
+
+def test_forged_chain_not_terminating_at_trusted_root_rejected():
+    """attacker가 자체 root로 완결된(내부 정합은 맞는) 체인을 들이밀어도 우리 trusted_roots
+    파라미터로 안 끝나면 거부."""
+    attacker_root_key, attacker_root_cert = _self_signed_root()
+    attacker_intermediate_key, attacker_intermediate_cert = _signed_intermediate(attacker_root_key, attacker_root_cert)
+    hardware_enforced = _default_hardware_enforced()
+    key_description = _build_key_description(
+        challenge=CHALLENGE, security_level=1, keymaster_security_level=1, hardware_enforced_der=hardware_enforced,
+    )
+    _leaf_key, leaf_cert = _leaf_with_key_description(attacker_intermediate_key, attacker_intermediate_cert, key_description)
+    chain_der = [
+        leaf_cert.public_bytes(serialization.Encoding.DER),
+        attacker_intermediate_cert.public_bytes(serialization.Encoding.DER),
+    ]
+    real_root_key, real_root_cert = _self_signed_root()
+
+    with pytest.raises(AndroidAttestationVerificationError, match="chain_does_not_terminate_at_google_root"):
+        verify_key_attestation(
+            certificate_chain=chain_der, expected_challenge=CHALLENGE,
+            expected_package_name=PACKAGE_NAME, expected_signing_cert_digest=CERT_DIGEST,
+            trusted_roots=[real_root_cert],  # attacker root와 무관한 별도 trusted root
+        )
+
+
+def test_revoked_certificate_rejected():
+    fx = _build_chain()
+
+    def revoked_checker(cert):
+        return True  # 모든 인증서를 폐기된 것으로 취급
+
+    with pytest.raises(AndroidAttestationVerificationError, match="certificate_revoked"):
+        verify_key_attestation(
+            certificate_chain=fx["chain_der"], expected_challenge=CHALLENGE,
+            expected_package_name=PACKAGE_NAME, expected_signing_cert_digest=CERT_DIGEST,
+            trusted_roots=fx["trusted_roots"], revocation_checker=revoked_checker,
+        )
+
+
+def test_empty_chain_rejected():
+    with pytest.raises(AndroidAttestationVerificationError, match="empty_certificate_chain"):
+        verify_key_attestation(
+            certificate_chain=[], expected_challenge=CHALLENGE,
+            expected_package_name=PACKAGE_NAME, expected_signing_cert_digest=CERT_DIGEST,
+        )
+
+
+def test_missing_key_description_extension_rejected():
+    root_key, root_cert = _self_signed_root()
+    intermediate_key, intermediate_cert = _signed_intermediate(root_key, root_cert)
+    leaf_key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "No KeyDescription Leaf")])
+    leaf_cert = (
+        x509.CertificateBuilder()
+        .subject_name(name).issuer_name(intermediate_cert.subject).public_key(leaf_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now(timezone.utc) - timedelta(days=1))
+        .not_valid_after(datetime.now(timezone.utc) + timedelta(days=365))
+        .sign(intermediate_key, hashes.SHA256())
+    )
+    chain_der = [
+        leaf_cert.public_bytes(serialization.Encoding.DER),
+        intermediate_cert.public_bytes(serialization.Encoding.DER),
+    ]
+    with pytest.raises(AndroidAttestationVerificationError, match="key_description_extension_missing"):
+        verify_key_attestation(
+            certificate_chain=chain_der, expected_challenge=CHALLENGE,
+            expected_package_name=PACKAGE_NAME, expected_signing_cert_digest=CERT_DIGEST,
+            trusted_roots=[root_cert],
+        )
+
+
+# ─── verify_bootstrap_signature ──────────────────────────────────────────────
+
+def test_valid_bootstrap_signature_accepted():
+    fx = _build_chain()
+    leaf_key = fx["leaf_key"]
+    public_key_der = leaf_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    signed_bytes = b"canonical-challenge-transcript-bytes"
+    signature = leaf_key.sign(signed_bytes, ec.ECDSA(hashes.SHA256()))
+
+    result = verify_bootstrap_signature(signed_bytes=signed_bytes, signature=signature, stored_public_key_der=public_key_der)
+    assert result.verified is True
+
+
+def test_bootstrap_signature_wrong_key_rejected():
+    fx = _build_chain()
+    leaf_key = fx["leaf_key"]
+    public_key_der = leaf_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    imposter_key = ec.generate_private_key(ec.SECP256R1())
+    signed_bytes = b"canonical-challenge-transcript-bytes"
+    signature = imposter_key.sign(signed_bytes, ec.ECDSA(hashes.SHA256()))
+
+    with pytest.raises(AndroidAttestationVerificationError, match="bootstrap_signature_invalid"):
+        verify_bootstrap_signature(signed_bytes=signed_bytes, signature=signature, stored_public_key_der=public_key_der)
+
+
+def test_bootstrap_signature_tampered_bytes_rejected():
+    fx = _build_chain()
+    leaf_key = fx["leaf_key"]
+    public_key_der = leaf_key.public_key().public_bytes(
+        serialization.Encoding.DER, serialization.PublicFormat.SubjectPublicKeyInfo
+    )
+    signature = leaf_key.sign(b"original-bytes", ec.ECDSA(hashes.SHA256()))
+
+    with pytest.raises(AndroidAttestationVerificationError, match="bootstrap_signature_invalid"):
+        verify_bootstrap_signature(signed_bytes=b"tampered-bytes", signature=signature, stored_public_key_der=public_key_der)

--- a/backend/tests/test_20da6347_c3_play_integrity.py
+++ b/backend/tests/test_20da6347_c3_play_integrity.py
@@ -1,0 +1,185 @@
+"""story 20da6347(C3·산티아고 §7.4) mock-first 계약테스트: Play Integrity Standard token
+검증 — S4 firebase_session_mint.py 패턴과 동일 원칙(실 Google 왕복은 non-prod 프로젝트
+프로비저닝 후 별도 라이브 검증, 여기선 호출 순서/실패 처리/응답 파싱 구조만)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.play_integrity import (
+    MEETS_DEVICE_INTEGRITY,
+    PlayIntegrityVerificationError,
+    verify_play_integrity_token,
+)
+
+PACKAGE_NAME = "com.sprintable.app"
+CERT_DIGEST_B64 = "abcdef0123456789=="
+REQUEST_HASH = "sha256-of-canonical-request"
+
+
+def _valid_payload(**overrides) -> dict:
+    payload = {
+        "requestDetails": {"requestPackageName": PACKAGE_NAME, "requestHash": REQUEST_HASH},
+        "appIntegrity": {
+            "appRecognitionVerdict": "PLAY_RECOGNIZED",
+            "packageName": PACKAGE_NAME,
+            "certificateSha256Digest": [CERT_DIGEST_B64],
+            "versionCode": "42",
+        },
+        "deviceIntegrity": {"deviceRecognitionVerdict": [MEETS_DEVICE_INTEGRITY]},
+    }
+    payload.update(overrides)
+    return {"tokenPayloadExternal": payload}
+
+
+def _mock_response(status_code: int, json_body: dict):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_body
+    return resp
+
+
+@pytest.mark.anyio
+async def test_valid_token_accepted(monkeypatch):
+    import app.services.play_integrity as module
+    monkeypatch.setattr(module, "_get_access_token", lambda: "fake-access-token")
+    monkeypatch.setattr(module, "_call_decode_integrity_token", AsyncMock(return_value=_mock_response(200, _valid_payload())))
+
+    result = await verify_play_integrity_token(
+        integrity_token="x", expected_package_name=PACKAGE_NAME, expected_cert_sha256_digest_b64=CERT_DIGEST_B64,
+        minimum_version_code=10, request_hash=REQUEST_HASH,
+    )
+    assert result.device_recognition_verdicts == [MEETS_DEVICE_INTEGRITY]
+
+
+@pytest.mark.anyio
+async def test_adc_unavailable_rejected(monkeypatch):
+    import app.services.play_integrity as module
+
+    def fail_adc():
+        raise RuntimeError("no ADC")
+    monkeypatch.setattr(module, "_get_access_token", fail_adc)
+
+    with pytest.raises(PlayIntegrityVerificationError, match="adc_token_unavailable"):
+        await verify_play_integrity_token(
+            integrity_token="x", expected_package_name=PACKAGE_NAME, expected_cert_sha256_digest_b64=CERT_DIGEST_B64,
+            minimum_version_code=10, request_hash=REQUEST_HASH,
+        )
+
+
+@pytest.mark.anyio
+async def test_google_rejects_non_200(monkeypatch):
+    import app.services.play_integrity as module
+    monkeypatch.setattr(module, "_get_access_token", lambda: "fake-access-token")
+    monkeypatch.setattr(module, "_call_decode_integrity_token", AsyncMock(return_value=_mock_response(400, {})))
+
+    with pytest.raises(PlayIntegrityVerificationError, match="google_rejected"):
+        await verify_play_integrity_token(
+            integrity_token="x", expected_package_name=PACKAGE_NAME, expected_cert_sha256_digest_b64=CERT_DIGEST_B64,
+            minimum_version_code=10, request_hash=REQUEST_HASH,
+        )
+
+
+@pytest.mark.anyio
+async def test_not_play_recognized_rejected(monkeypatch):
+    import app.services.play_integrity as module
+    monkeypatch.setattr(module, "_get_access_token", lambda: "fake-access-token")
+    payload = _valid_payload()
+    payload["tokenPayloadExternal"]["appIntegrity"]["appRecognitionVerdict"] = "UNRECOGNIZED_VERSION"
+    monkeypatch.setattr(module, "_call_decode_integrity_token", AsyncMock(return_value=_mock_response(200, payload)))
+
+    with pytest.raises(PlayIntegrityVerificationError, match="app_not_play_recognized"):
+        await verify_play_integrity_token(
+            integrity_token="x", expected_package_name=PACKAGE_NAME, expected_cert_sha256_digest_b64=CERT_DIGEST_B64,
+            minimum_version_code=10, request_hash=REQUEST_HASH,
+        )
+
+
+@pytest.mark.anyio
+async def test_package_name_mismatch_rejected(monkeypatch):
+    import app.services.play_integrity as module
+    monkeypatch.setattr(module, "_get_access_token", lambda: "fake-access-token")
+    payload = _valid_payload()
+    payload["tokenPayloadExternal"]["appIntegrity"]["packageName"] = "com.attacker.app"
+    monkeypatch.setattr(module, "_call_decode_integrity_token", AsyncMock(return_value=_mock_response(200, payload)))
+
+    with pytest.raises(PlayIntegrityVerificationError, match="app_package_name_mismatch"):
+        await verify_play_integrity_token(
+            integrity_token="x", expected_package_name=PACKAGE_NAME, expected_cert_sha256_digest_b64=CERT_DIGEST_B64,
+            minimum_version_code=10, request_hash=REQUEST_HASH,
+        )
+
+
+@pytest.mark.anyio
+async def test_cert_digest_mismatch_rejected(monkeypatch):
+    import app.services.play_integrity as module
+    monkeypatch.setattr(module, "_get_access_token", lambda: "fake-access-token")
+    payload = _valid_payload()
+    payload["tokenPayloadExternal"]["appIntegrity"]["certificateSha256Digest"] = ["wrong-digest"]
+    monkeypatch.setattr(module, "_call_decode_integrity_token", AsyncMock(return_value=_mock_response(200, payload)))
+
+    with pytest.raises(PlayIntegrityVerificationError, match="cert_digest_mismatch"):
+        await verify_play_integrity_token(
+            integrity_token="x", expected_package_name=PACKAGE_NAME, expected_cert_sha256_digest_b64=CERT_DIGEST_B64,
+            minimum_version_code=10, request_hash=REQUEST_HASH,
+        )
+
+
+@pytest.mark.anyio
+async def test_version_code_below_minimum_rejected(monkeypatch):
+    import app.services.play_integrity as module
+    monkeypatch.setattr(module, "_get_access_token", lambda: "fake-access-token")
+    payload = _valid_payload()
+    payload["tokenPayloadExternal"]["appIntegrity"]["versionCode"] = "5"
+    monkeypatch.setattr(module, "_call_decode_integrity_token", AsyncMock(return_value=_mock_response(200, payload)))
+
+    with pytest.raises(PlayIntegrityVerificationError, match="version_code_below_minimum"):
+        await verify_play_integrity_token(
+            integrity_token="x", expected_package_name=PACKAGE_NAME, expected_cert_sha256_digest_b64=CERT_DIGEST_B64,
+            minimum_version_code=10, request_hash=REQUEST_HASH,
+        )
+
+
+@pytest.mark.anyio
+async def test_device_integrity_insufficient_rejected(monkeypatch):
+    import app.services.play_integrity as module
+    monkeypatch.setattr(module, "_get_access_token", lambda: "fake-access-token")
+    payload = _valid_payload()
+    payload["tokenPayloadExternal"]["deviceIntegrity"]["deviceRecognitionVerdict"] = []
+    monkeypatch.setattr(module, "_call_decode_integrity_token", AsyncMock(return_value=_mock_response(200, payload)))
+
+    with pytest.raises(PlayIntegrityVerificationError, match="device_integrity_insufficient"):
+        await verify_play_integrity_token(
+            integrity_token="x", expected_package_name=PACKAGE_NAME, expected_cert_sha256_digest_b64=CERT_DIGEST_B64,
+            minimum_version_code=10, request_hash=REQUEST_HASH,
+        )
+
+
+@pytest.mark.anyio
+async def test_request_hash_mismatch_rejected(monkeypatch):
+    """다른 요청 맥락에서 발급된 토큰을 재사용하는 시나리오 — request_hash 불일치는 거부."""
+    import app.services.play_integrity as module
+    monkeypatch.setattr(module, "_get_access_token", lambda: "fake-access-token")
+    payload = _valid_payload()
+    payload["tokenPayloadExternal"]["requestDetails"]["requestHash"] = "different-request-hash"
+    monkeypatch.setattr(module, "_call_decode_integrity_token", AsyncMock(return_value=_mock_response(200, payload)))
+
+    with pytest.raises(PlayIntegrityVerificationError, match="request_hash_mismatch"):
+        await verify_play_integrity_token(
+            integrity_token="x", expected_package_name=PACKAGE_NAME, expected_cert_sha256_digest_b64=CERT_DIGEST_B64,
+            minimum_version_code=10, request_hash=REQUEST_HASH,
+        )
+
+
+@pytest.mark.anyio
+async def test_malformed_response_rejected(monkeypatch):
+    import app.services.play_integrity as module
+    monkeypatch.setattr(module, "_get_access_token", lambda: "fake-access-token")
+    monkeypatch.setattr(module, "_call_decode_integrity_token", AsyncMock(return_value=_mock_response(200, {})))
+
+    with pytest.raises(PlayIntegrityVerificationError, match="malformed_response"):
+        await verify_play_integrity_token(
+            integrity_token="x", expected_package_name=PACKAGE_NAME, expected_cert_sha256_digest_b64=CERT_DIGEST_B64,
+            minimum_version_code=10, request_hash=REQUEST_HASH,
+        )


### PR DESCRIPTION
## Summary
story 20da6347(E-AUTH-REBUILD 활성화게이트 C3) — 산티아고 §7.4 SSOT(Android 공식 Key Attestation 스키마 + Play Integrity Standard token) 그대로 구현.

**Key Attestation** (`app/services/android_key_attestation.py`):
- x5c 체인이 Google 공식 Hardware Attestation Root(RSA·EC 두 세대)로 종료하는지 검증(x5c 안의 어떤 root도 신뢰 안 함) + revocation 콜백 주입(mock-first, 실 HTTP 페치는 호출부 책임)
- KeyDescription 확장(OID 1.3.6.1.4.1.11129.2.1.17)을 최소 범용 DER TLV 파서로 직접 파싱 — hardwareEnforced의 purpose/digest/origin/rootOfTrust/attestationApplicationId만(softwareEnforced는 공격자 조작 가능이라 신뢰 안 함)
- attestationChallenge exact match·origin=GENERATED·purpose=SIGN·digest=SHA-256·verifiedBootState=Verified+deviceLocked·package name+signing-cert digest exact allowlist·TEE 최소 요구(StrongBox는 보너스 신호)
- 부트스트랩 서명: Android엔 signCount가 없어 canonical bytes ECDSA-SHA256 서명만 검증(server_seq CAS는 C4 스코프)

**Play Integrity** (`app/services/play_integrity.py`):
- decodeIntegrityToken REST 호출 mock-first(S4 firebase_session_mint 패턴과 동일 원칙)
- PLAY_RECOGNIZED + exact package/cert digest/version policy + request_hash(재사용 방지) + 최소 MEETS_DEVICE_INTEGRITY

**신규 의존성 0** — pyasn1 검토했으나 hand-rolled 최소 DER 파서로 충분해 의존성 표면 최소화.

**스코프 밖**(story 명시): register/consume 엔드포인트 배선 + DB 원자 server_seq CAS(C4), 모바일 셸(민 lane).

## Test plan
- [x] Key Attestation 18개 테스트 green: 정상/StrongBox/software-거부/wrong package·cert/challenge mismatch/origin≠generated/purpose≠sign/digest≠sha256/verified-boot-state≠verified/device-not-locked/forged-chain/revoked/empty-chain/extension-missing/부트스트랩 서명 정상·위조키·변조바이트
- [x] Play Integrity 10개 테스트 green: 정상/ADC불가/google거부/미인식/package·cert·version·request-hash mismatch/device-integrity 부족/malformed
- [x] 체인종료 + challenge-mismatch 2개 최핵심 가드 mutation self-check(정확히 타깃 테스트만 RED 확인 후 복구)
- [x] 관련 258개 테스트(auth/firebase/attest/integrity 스윕) green — 무회귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)