### PR TITLE
[SID:1da4cccf] 산출물 뷰어 빈 nodes 조용한 폴백 방지

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3637,6 +3637,7 @@
     "exportComingSoon": "Export arrives in C1-S5",
     "commentsComingSoon": "Comments arrive in C2",
     "treeRenderPlaceholder": "Tree rendering coming soon",
+    "canvasEmptyContent": "This artifact doesn't have any content yet",
     "descriptionPaneHeading": "description — visible PRD",
     "descriptionEmptyState": "Select a pin to see its element spec here",
     "rollupOpen": "open",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -3637,6 +3637,7 @@
     "exportComingSoon": "export는 C1-S5에서 제공 예정",
     "commentsComingSoon": "코멘트는 C2에서 제공 예정",
     "treeRenderPlaceholder": "트리 렌더는 준비 중",
+    "canvasEmptyContent": "이 산출물에는 아직 콘텐츠가 없습니다",
     "descriptionPaneHeading": "description — 보이는 PRD",
     "descriptionEmptyState": "핀을 선택하면 요소 스펙이 여기 표시됩니다",
     "rollupOpen": "열림",

--- a/apps/web/src/components/canvas/artifact-stage.test.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.test.tsx
@@ -497,6 +497,27 @@ describe('ArtifactStage — 캔버스 뷰포트(story 1948d19d)', () => {
       expect(content.style.width).toBe('1280px');
     });
   });
+
+  describe('tree 포맷 — nodes=[] 조용한 폴백 방지(story 1da4cccf, 산출물 8de4e981 진단에서 발견)', () => {
+    it('empty parsed tree("[]") shows an explicit "no content" placeholder, not a silent blank box', async () => {
+      await mount({ format: 'tree', content: '[]' });
+      expect(container.textContent).toContain('이 산출물에는 아직 콘텐츠가 없습니다');
+      expect(container.textContent).not.toContain('트리 렌더는 준비 중');
+    });
+
+    it('unparseable content still shows the original parse-failure placeholder (별도 문구, 원인이 다름)', async () => {
+      await mount({ format: 'tree', content: 'not json' });
+      expect(container.textContent).toContain('트리 렌더는 준비 중');
+      expect(container.textContent).not.toContain('이 산출물에는 아직 콘텐츠가 없습니다');
+    });
+
+    it('a non-empty tree renders its nodes as before (회귀 없음, 두 placeholder 모두 안 뜸)', async () => {
+      await mount({ format: 'tree', content: JSON.stringify([{ id: 'n1', type: 'text', props: { text: 'hello' } }]) });
+      expect(container.textContent).toContain('hello');
+      expect(container.textContent).not.toContain('이 산출물에는 아직 콘텐츠가 없습니다');
+      expect(container.textContent).not.toContain('트리 렌더는 준비 중');
+    });
+  });
 });
 
 describe('isResponsiveHtml(story 3d0d60a3) — @media 소스 파싱(유나 1순위 판정, 신규 BE 0)', () => {

--- a/apps/web/src/components/canvas/artifact-stage.tsx
+++ b/apps/web/src/components/canvas/artifact-stage.tsx
@@ -448,7 +448,7 @@ function CanvasViewport({ format, content, title, canvasBounds, overlay, mode = 
               }}
             />
           ) : mode === 'edit' ? null : (
-            <TreeStageContent content={content} placeholder={t('treeRenderPlaceholder')} />
+            <TreeStageContent content={content} placeholder={t('treeRenderPlaceholder')} emptyPlaceholder={t('canvasEmptyContent')} />
           )}
           {overlay ? (
             <div
@@ -479,10 +479,17 @@ function CanvasViewport({ format, content, title, canvasBounds, overlay, mode = 
   );
 }
 
-function TreeStageContent({ content, placeholder }: { content: string; placeholder: string }) {
+function TreeStageContent(
+  { content, placeholder, emptyPlaceholder }: { content: string; placeholder: string; emptyPlaceholder: string }
+) {
   const tree = parseArtifactTree(content);
   if (!tree) {
     return <p className="pointer-events-none p-4 text-xs text-muted-foreground">{placeholder}</p>;
+  }
+  // story 1da4cccf — nodes=[](html_blob 못 찾아 tree로 폴백 or 진짜 빈 tree) 둘 다 조용한 빈
+  // 화면 대신 명시적 안내. treeRenderPlaceholder(파싱 실패)와 원인이 달라 별도 문구.
+  if (tree.length === 0) {
+    return <p className="pointer-events-none p-4 text-xs text-muted-foreground">{emptyPlaceholder}</p>;
   }
   return (
     <div className="pointer-events-none h-full w-full space-y-2 overflow-hidden rounded-lg bg-background p-2">


### PR DESCRIPTION
## 요약
- story `1da4cccf` · epic E-CANVAS
- 선생님이 dogfooding으로 발견한 산출물(8de4e981) 빈 화면 버그 진단 결과, FE content-type 분기(html/image/tree) 자체는 정상 — 근본원인은 `create_artifact`가 `nodes` 없이 호출돼 `html_blob` 노드 없는 빈 artifact가 생성된 것(별도 BE 스토리 `e42bf6bf`)
- 다만 FE도 이 상태를 "조용히" 삼키는 갭이 있어 진단을 어렵게 만들었음 — 이 PR은 그 FE 갭만 다룸

## 근본원인
`apps/web/src/services/canvas.ts::deriveFormat(nodes)`가 `html_blob` 노드를 못 찾으면 무조건 `format='tree'`로 폴백 → `content=JSON.stringify(resolveNodeTree([]))="[]"` → `TreeStageContent`의 `parseArtifactTree("[]")`가 이걸 **유효한 빈 배열**로 파싱해 기존 파싱-실패 자리표시자(`treeRenderPlaceholder`)도 건너뛰고 빈 `<div>`만 렌더 — 에러도 안내도 없는 완전히 조용한 빈 화면.

## 변경 사항
`TreeStageContent`에 `tree.length === 0` 케이스를 명시적으로 감지해 새 자리표시자(`canvasEmptyContent`: "이 산출물에는 아직 콘텐츠가 없습니다")를 표시. 기존 파싱-실패 케이스(`treeRenderPlaceholder`)와는 원인이 다르므로 별도 문구로 구분.

## 스코프
- `apps/web/src/components/canvas/artifact-stage.tsx` — `TreeStageContent`에 빈-tree 분기 추가
- `apps/web/messages/{ko,en}.json` — `canvasEmptyContent` 키 추가
- 정상 케이스(html/image/노드 1개 이상 tree) 전부 회귀 없음

## 테스트
- ✅ `tsc --noEmit` 클린
- ✅ `pnpm lint` 0 error(경고 5건은 무관 파일)
- ✅ `pnpm build` EXIT 0
- ✅ `pnpm test`(vitest, 루트) 262 test files / 1783 passed / 2 skipped / 0 failed(신규 3케이스 포함)
- ✅ 뮤테이션 셀프체크: `tree.length === 0` 조건을 `false &&`로 무력화 → 신규 empty-state 테스트가 정확히 RED(원 버그 재현) 확認 후 되돌림

## 관련
- BE 후속: story `e42bf6bf`([BE] create_artifact 빈 nodes 검증) — 이 PR 스코프 밖, 디디 소관
- BE/MCP 후속: story `7ad58e24`([BE/MCP] delete_artifact 툴 부재) — 이 PR 스코프 밖
- 이번 건 실제 artifact(8de4e981)는 방치, 유나가 정확한 payload로 재발행한 `0f067bc5`가 정본(오르테가 확認 완료) — 8de4e981은 이 PR 머지 후 "콘텐츠 없음" 안내가 뜨게 됨