### PR TITLE
[SID:f755b1a9] BFF /auth/native 라우트 — 네이티브 부트스트랩 소비

### DIFF
--- a/apps/web/src/app/auth/native/route.test.ts
+++ b/apps/web/src/app/auth/native/route.test.ts
@@ -1,0 +1,205 @@
+// story f755b1a9: /auth/native BFF 라우트 — logged-out login-CSRF(story 6ae1ecac AC#2) 핵심은
+// existing_session_user_id를 절대 클라 입력(body/query)에서 읽지 않고 서버검증 __Host-sp_fs
+// 세션에서만 도출하는 것 — 이 파일의 "클라 위조값 무시" 테스트가 그 불변식을 고정한다.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  csrfCheck: vi.fn(),
+  cookiesGetMock: vi.fn(),
+  resolveFirebaseServerSessionMock: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/csrf', () => ({ verifyCsrfOrigin: h.csrfCheck }));
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(async () => ({ get: h.cookiesGetMock })),
+}));
+vi.mock('@/lib/db/server', () => ({
+  SP_AT_COOKIE: 'sp_at',
+  SP_RT_COOKIE: 'sp_rt',
+  resolveFirebaseServerSession: (...args: unknown[]) => h.resolveFirebaseServerSessionMock(...args),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+import { POST } from './route';
+
+function makeJsonRequest(body: unknown): Request {
+  return new Request('http://localhost/auth/native', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+function makeUrlencodedRequest(fields: Record<string, string>): Request {
+  return new Request('http://localhost/auth/native', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams(fields).toString(),
+  });
+}
+
+const ENV_KEYS = ['FIREBASE_AUTH_MOBILE_ISSUE', 'FIREBASE_BFF_INTERNAL_SECRET', 'NEXT_PUBLIC_FASTAPI_URL'];
+
+describe('POST /auth/native', () => {
+  beforeEach(() => {
+    h.csrfCheck.mockReset().mockReturnValue(null);
+    h.cookiesGetMock.mockReset().mockReturnValue(undefined); // 기본: 기존 세션 없음
+    h.resolveFirebaseServerSessionMock.mockReset();
+    mockFetch.mockReset();
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+
+  it('returns 501 when FIREBASE_AUTH_MOBILE_ISSUE is unset (default off)', async () => {
+    const res = await POST(makeJsonRequest({ code: 'abc' }));
+    expect(res.status).toBe(501);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns csrf error passthrough when flag on but CSRF fails', async () => {
+    process.env['FIREBASE_AUTH_MOBILE_ISSUE'] = 'true';
+    const csrfResponse = new Response('csrf', { status: 403 });
+    h.csrfCheck.mockReturnValue(csrfResponse);
+    const res = await POST(makeJsonRequest({ code: 'abc' }));
+    expect(res.status).toBe(403);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when code is missing from body', async () => {
+    process.env['FIREBASE_AUTH_MOBILE_ISSUE'] = 'true';
+    const res = await POST(makeJsonRequest({}));
+    expect(res.status).toBe(401);
+    expect((await res.json()).error.code).toBe('NATIVE_BOOTSTRAP_FAILED');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('parses application/x-www-form-urlencoded body (native postUrl payload format)', async () => {
+    process.env['FIREBASE_AUTH_MOBILE_ISSUE'] = 'true';
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ session_cookie: 'cookie-val' }) });
+    const res = await POST(makeUrlencodedRequest({ code: 'the-code' }));
+    expect(res.status).toBe(303);
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const sentBody = JSON.parse(opts.body as string) as { code: string };
+    expect(sentBody.code).toBe('the-code');
+  });
+
+  it('returns 401 when internal consume call fails', async () => {
+    process.env['FIREBASE_AUTH_MOBILE_ISSUE'] = 'true';
+    mockFetch.mockResolvedValue({ ok: false, status: 401, json: async () => ({}) });
+    const res = await POST(makeJsonRequest({ code: 'bad-code' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when internal consume call throws (network error)', async () => {
+    process.env['FIREBASE_AUTH_MOBILE_ISSUE'] = 'true';
+    mockFetch.mockRejectedValue(new Error('network down'));
+    const res = await POST(makeJsonRequest({ code: 'x' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when consume response is malformed (no session_cookie)', async () => {
+    process.env['FIREBASE_AUTH_MOBILE_ISSUE'] = 'true';
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ unexpected: 'shape' }) });
+    const res = await POST(makeJsonRequest({ code: 'x' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('on success: sets __Host-sp_fs, clears sp_at/sp_rt, 303s to default safe path, no-store + no-referrer headers', async () => {
+    process.env['FIREBASE_AUTH_MOBILE_ISSUE'] = 'true';
+    process.env['FIREBASE_BFF_INTERNAL_SECRET'] = 'shared-secret';
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ session_cookie: 'super-secret-cookie' }) });
+
+    const res = await POST(makeJsonRequest({ code: 'valid-code' }));
+    expect(res.status).toBe(303);
+    expect(res.headers.get('location')).toBe('http://localhost/inbox'); // safeNextPath 기본 폴백
+    expect(res.headers.get('cache-control')).toBe('no-store');
+    expect(res.headers.get('referrer-policy')).toBe('no-referrer');
+
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain('__Host-sp_fs=super-secret-cookie');
+    expect(setCookie).not.toContain('Domain=');
+
+    const allCookies = res.cookies.getAll();
+    expect(allCookies.find((c) => c.name === 'sp_at')?.maxAge).toBe(0);
+    expect(allCookies.find((c) => c.name === 'sp_rt')?.maxAge).toBe(0);
+
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect((opts.headers as Record<string, string>)['Authorization']).toBe('Bearer shared-secret');
+  });
+
+  it('on success with a valid redirect_path: 303s to that exact path (딥링크 복귀)', async () => {
+    process.env['FIREBASE_AUTH_MOBILE_ISSUE'] = 'true';
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ session_cookie: 'c' }) });
+    const res = await POST(makeJsonRequest({ code: 'x', redirect_path: '/board/abc123' }));
+    expect(res.headers.get('location')).toBe('http://localhost/board/abc123');
+  });
+
+  it('on success with an unsafe redirect_path(open-redirect attempt): falls back to safe default, never redirects externally', async () => {
+    process.env['FIREBASE_AUTH_MOBILE_ISSUE'] = 'true';
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ session_cookie: 'c' }) });
+    const res = await POST(makeJsonRequest({ code: 'x', redirect_path: '//evil.com/phish' }));
+    expect(res.headers.get('location')).toBe('http://localhost/inbox');
+    expect(res.headers.get('location')).not.toContain('evil.com');
+  });
+
+  it('no existing __Host-sp_fs session: existing_session_user_id is omitted from the consume call', async () => {
+    process.env['FIREBASE_AUTH_MOBILE_ISSUE'] = 'true';
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ session_cookie: 'c' }) });
+    h.cookiesGetMock.mockReturnValue(undefined);
+    await POST(makeJsonRequest({ code: 'x' }));
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const sentBody = JSON.parse(opts.body as string) as { existing_session_user_id?: string };
+    expect(sentBody.existing_session_user_id).toBeUndefined();
+    expect(h.resolveFirebaseServerSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('no existing __Host-sp_fs session AND client body claims a UID anyway: forged value is never forwarded (login-CSRF core guard)', async () => {
+    process.env['FIREBASE_AUTH_MOBILE_ISSUE'] = 'true';
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ session_cookie: 'c' }) });
+    h.cookiesGetMock.mockReturnValue(undefined); // 쿠키 자체가 없음 — 서버검증 경로가 아예 안 돎.
+    await POST(makeJsonRequest({ code: 'x', existing_session_user_id: 'attacker-forged-uid-no-cookie' }));
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const sentBody = JSON.parse(opts.body as string) as { existing_session_user_id?: string };
+    expect(sentBody.existing_session_user_id).toBeUndefined();
+  });
+
+  it('existing valid __Host-sp_fs session: existing_session_user_id is derived from the SERVER-verified session, not any client input', async () => {
+    process.env['FIREBASE_AUTH_MOBILE_ISSUE'] = 'true';
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ session_cookie: 'c' }) });
+    h.cookiesGetMock.mockImplementation((name: string) =>
+      name === '__Host-sp_fs' ? { value: 'existing-cookie-value' } : undefined,
+    );
+    h.resolveFirebaseServerSessionMock.mockResolvedValue({
+      user_id: 'server-verified-user-id', email: 'a@b.com', access_token: 'x', org_id: null, project_id: null,
+    });
+
+    // 클라가 body에 다른(위조) UID를 실어 보내도 — 애초에 그 필드를 읽지 않으므로 무시됨.
+    await POST(makeJsonRequest({ code: 'x', existing_session_user_id: 'attacker-forged-uid' }));
+
+    expect(h.resolveFirebaseServerSessionMock).toHaveBeenCalledWith('existing-cookie-value');
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const sentBody = JSON.parse(opts.body as string) as { existing_session_user_id?: string };
+    expect(sentBody.existing_session_user_id).toBe('server-verified-user-id');
+    expect(sentBody.existing_session_user_id).not.toBe('attacker-forged-uid');
+  });
+
+  it('existing __Host-sp_fs cookie present but fails server verification: existing_session_user_id stays omitted (no silent trust)', async () => {
+    process.env['FIREBASE_AUTH_MOBILE_ISSUE'] = 'true';
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ session_cookie: 'c' }) });
+    h.cookiesGetMock.mockImplementation((name: string) =>
+      name === '__Host-sp_fs' ? { value: 'invalid-or-expired-cookie' } : undefined,
+    );
+    h.resolveFirebaseServerSessionMock.mockResolvedValue(null);
+
+    await POST(makeJsonRequest({ code: 'x' }));
+
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const sentBody = JSON.parse(opts.body as string) as { existing_session_user_id?: string };
+    expect(sentBody.existing_session_user_id).toBeUndefined();
+  });
+});

--- a/apps/web/src/app/auth/native/route.test.ts
+++ b/apps/web/src/app/auth/native/route.test.ts
@@ -88,6 +88,41 @@ describe('POST /auth/native', () => {
     expect(sentBody.code).toBe('the-code');
   });
 
+  // story cbd578d4(C4·§7.5) 계약: redeem 증명 필드는 BFF가 검증/서명하지 않고 그대로
+  // 내부 consume 호출에 전달만 한다 — 이 테스트는 그 pass-through 자체를 고정한다.
+  it('forwards all C4 redeem-proof fields (installation_id/challenge_id/client_data_b64url/key_version/assertion|signature) unmodified to the internal consume call', async () => {
+    process.env['FIREBASE_AUTH_MOBILE_ISSUE'] = 'true';
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ session_cookie: 'c' }) });
+    await POST(makeJsonRequest({
+      code: 'the-code',
+      installation_id: 'install-uuid-1',
+      challenge_id: 'challenge-uuid-1',
+      client_data_b64url: 'ZXhhbXBsZQ',
+      key_version: 2,
+      assertion_b64: 'YXNzZXJ0aW9u',
+    }));
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const sentBody = JSON.parse(opts.body as string) as Record<string, unknown>;
+    expect(sentBody).toMatchObject({
+      code: 'the-code',
+      installation_id: 'install-uuid-1',
+      challenge_id: 'challenge-uuid-1',
+      client_data_b64url: 'ZXhhbXBsZQ',
+      key_version: 2,
+      assertion_b64: 'YXNzZXJ0aW9u',
+    });
+  });
+
+  it('forwards Android signature_b64 in place of iOS assertion_b64 (platform-dependent field, both optional)', async () => {
+    process.env['FIREBASE_AUTH_MOBILE_ISSUE'] = 'true';
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ session_cookie: 'c' }) });
+    await POST(makeJsonRequest({ code: 'x', signature_b64: 'c2lnbmF0dXJl' }));
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const sentBody = JSON.parse(opts.body as string) as Record<string, unknown>;
+    expect(sentBody['signature_b64']).toBe('c2lnbmF0dXJl');
+    expect(sentBody['assertion_b64']).toBeUndefined();
+  });
+
   it('returns 401 when internal consume call fails', async () => {
     process.env['FIREBASE_AUTH_MOBILE_ISSUE'] = 'true';
     mockFetch.mockResolvedValue({ ok: false, status: 401, json: async () => ({}) });

--- a/apps/web/src/app/auth/native/route.ts
+++ b/apps/web/src/app/auth/native/route.ts
@@ -1,0 +1,141 @@
+/**
+ * story f755b1a9(E-AUTH-REBUILD M2 활성화 게이트 6ae1ecac 하위·doc §9.1): `POST /auth/native` —
+ * 네이티브 WebView가 단회 부트스트랩 코드를 들고 오는 착지 라우트. code+device_binding_hash를
+ * **exact-origin POST body로만** 받는다(query 사용 금지 — PO 확定, doc §9.1의 `?code=`
+ * best-known을 대체). 내부 atomic-consume API(`/api/v2/internal/auth/native-bootstrap/consume`,
+ * S4와 동일 공유시크릿 패턴)를 호출해 `__Host-sp_fs` 세션쿠키를 받아 그대로 심고, 원래 딥링크
+ * 경로로 303 리다이렉트한다.
+ *
+ * ⚠️logged-out login-CSRF(story 6ae1ecac AC#2): BE `existing_session_user_id` 비교는 이미
+ * 머지돼있다(#2202 finding3) — 이 라우트의 책임은 그 값을 **클라이언트가 body/query로 보낸
+ * 값을 절대 신뢰하지 않고, 서버가 직접 검증한 `__Host-sp_fs` 세션에서만 도출**하는 것이다.
+ * 완전한 "로그아웃 상태 피해자에게 공격자 code 소비" 방어(per-installation attestation)는 이
+ * 라우트만으론 봉쇄 불가 — story 6ae1ecac condition①(별도 스코프)로 명시 분리한다.
+ *
+ * WebView 네비게이션 계약(민군 wire 합의, 2026-07-16): top-level POST 네비게이션(Android
+ * `postUrl`/자동제출 form)이어야 303+Set-Cookie가 WebView 자체 쿠키저장소에 축적된다 — 순수
+ * fetch()는 페이지 네비게이션이 아니라 이 계약을 만족하지 못한다. Content-Type은 JSON 또는
+ * urlencoded 둘 다 파싱(민군 postUrl 페이로드 형식 자유도).
+ */
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { verifyCsrfOrigin } from '@/lib/auth/csrf';
+import { setFirebaseSessionCookie, SP_FS_COOKIE } from '@/lib/auth/firebase-session';
+import { safeNextPath } from '@/lib/auth/session-redirect';
+import { cookieBase } from '@/lib/auth/cookies';
+import { SP_AT_COOKIE, SP_RT_COOKIE, resolveFirebaseServerSession } from '@/lib/db/server';
+
+const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+
+function logBootstrapFailure(reason: string): void {
+  // doc §9.1: code/쿼리/원문 절대 로그 금지 — reason enum만.
+  console.warn(`auth.native.consume 실패 reason=${reason}`);
+}
+
+function bootstrapFailedResponse(): NextResponse {
+  return NextResponse.json(
+    { error: { code: 'NATIVE_BOOTSTRAP_FAILED', message: 'Native bootstrap failed' } },
+    { status: 401, headers: { 'Cache-Control': 'no-store', 'Referrer-Policy': 'no-referrer' } },
+  );
+}
+
+interface NativeBootstrapBody {
+  code?: unknown;
+  device_binding_hash?: unknown;
+  redirect_path?: unknown;
+}
+
+async function parseBody(request: Request): Promise<NativeBootstrapBody | null> {
+  const contentType = request.headers.get('content-type') ?? '';
+  try {
+    if (contentType.includes('application/json')) {
+      return (await request.json()) as NativeBootstrapBody;
+    }
+    // application/x-www-form-urlencoded(자동제출 form/native postUrl 페이로드) 지원.
+    const raw = await request.text();
+    const params = new URLSearchParams(raw);
+    return {
+      code: params.get('code') ?? undefined,
+      device_binding_hash: params.get('device_binding_hash') ?? undefined,
+      redirect_path: params.get('redirect_path') ?? undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function POST(request: Request) {
+  if (process.env['FIREBASE_AUTH_MOBILE_ISSUE'] !== 'true') {
+    logBootstrapFailure('not_enabled');
+    return NextResponse.json(
+      { error: { code: 'NOT_ENABLED', message: 'Native bootstrap is not enabled' } },
+      { status: 501 },
+    );
+  }
+
+  const csrfError = verifyCsrfOrigin(request);
+  if (csrfError) {
+    logBootstrapFailure('csrf_rejected');
+    return csrfError;
+  }
+
+  const body = await parseBody(request);
+  if (!body || typeof body.code !== 'string' || body.code.length === 0) {
+    logBootstrapFailure('missing_code');
+    return bootstrapFailedResponse();
+  }
+  const code = body.code;
+  const deviceBindingHash = typeof body.device_binding_hash === 'string' ? body.device_binding_hash : undefined;
+  const redirectPathInput = typeof body.redirect_path === 'string' ? body.redirect_path : undefined;
+
+  // logged-out login-CSRF(story 6ae1ecac AC#2): existing_session_user_id는 client body/query
+  // 값을 절대 쓰지 않는다 — 여기서 서버가 직접 __Host-sp_fs를 검증해 도출한 값만 사용.
+  const cookieStore = await cookies();
+  const existingFirebaseSessionCookie = cookieStore.get(SP_FS_COOKIE)?.value;
+  let existingSessionUserId: string | undefined;
+  if (existingFirebaseSessionCookie) {
+    const existingSession = await resolveFirebaseServerSession(existingFirebaseSessionCookie);
+    if (existingSession) existingSessionUserId = existingSession.user_id;
+  }
+
+  const internalSecret = process.env['FIREBASE_BFF_INTERNAL_SECRET'];
+  const consumeRes = await fetch(`${FASTAPI_URL()}/api/v2/internal/auth/native-bootstrap/consume`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(internalSecret ? { Authorization: `Bearer ${internalSecret}` } : {}),
+    },
+    body: JSON.stringify({
+      code,
+      device_binding_hash: deviceBindingHash,
+      existing_session_user_id: existingSessionUserId,
+    }),
+  }).catch(() => null);
+
+  if (!consumeRes || !consumeRes.ok) {
+    logBootstrapFailure('consume_failed');
+    return bootstrapFailedResponse();
+  }
+
+  const consumeJson = (await consumeRes.json().catch(() => null)) as { session_cookie?: unknown } | null;
+  if (!consumeJson || typeof consumeJson.session_cookie !== 'string' || consumeJson.session_cookie.length === 0) {
+    logBootstrapFailure('malformed_consume_response');
+    return bootstrapFailedResponse();
+  }
+
+  // doc §9.1 6단계: 303 + 원래 딥링크 경로(허용목록 검증) + no-store + Referrer-Policy: no-referrer
+  // (code가 이 응답 이전 요청의 body에만 있었으므로 여기선 이미 무관 — 그래도 방어적으로 설정).
+  const target = safeNextPath(redirectPathInput);
+  const res = NextResponse.redirect(new URL(target, request.url), 303);
+  res.headers.set('Cache-Control', 'no-store');
+  res.headers.set('Referrer-Policy', 'no-referrer');
+  setFirebaseSessionCookie(res, consumeJson.session_cookie);
+
+  // /api/auth/firebase/session/route.ts와 동형 패턴: 세션 확립 성공 후 레거시 쿠키 정리.
+  const clearBase = { ...cookieBase(), maxAge: 0 };
+  res.cookies.set(SP_AT_COOKIE, '', clearBase);
+  res.cookies.set(SP_RT_COOKIE, '', clearBase);
+
+  console.info('auth.native.consume success');
+  return res;
+}

--- a/apps/web/src/app/auth/native/route.ts
+++ b/apps/web/src/app/auth/native/route.ts
@@ -1,10 +1,19 @@
 /**
  * story f755b1a9(E-AUTH-REBUILD M2 활성화 게이트 6ae1ecac 하위·doc §9.1): `POST /auth/native` —
- * 네이티브 WebView가 단회 부트스트랩 코드를 들고 오는 착지 라우트. code+device_binding_hash를
+ * 네이티브 WebView가 단회 부트스트랩 코드를 들고 오는 착지 라우트. code+redeem 증명 필드를
  * **exact-origin POST body로만** 받는다(query 사용 금지 — PO 확定, doc §9.1의 `?code=`
  * best-known을 대체). 내부 atomic-consume API(`/api/v2/internal/auth/native-bootstrap/consume`,
  * S4와 동일 공유시크릿 패턴)를 호출해 `__Host-sp_fs` 세션쿠키를 받아 그대로 심고, 원래 딥링크
  * 경로로 303 리다이렉트한다.
+ *
+ * ⚠️story cbd578d4(C4·§7.5) 계약 갱신 반영: consume 요청 필드가 `device_binding_hash`(구)에서
+ * `installation_id`/`challenge_id`/`client_data_b64url`/`key_version`/`assertion_b64|
+ * signature_b64`(신, per-installation redeem 증명)로 전면 재구성됐다. 이 값들은 네이티브
+ * 앱이 **설치 바인딩 키**(Android Keystore/iOS Secure Enclave — 기기 밖으로 절대 안 나옴)로
+ * 직접 서명해 `/auth/native` POST body에 실어 보내는 것 — **BFF는 이 필드들을 검증도 서명도
+ * 하지 않고 그대로 내부 consume 호출에 전달만 한다**(실 검증은 전부 BE `consume_native_
+ * bootstrap`의 단일 트랜잭션 안에서 수행). 흐름 로직(existing_session_user_id 서버도출·303·
+ * open-redirect·로그위생·동일401)은 이 계약 갱신과 무관하게 그대로 유효(까심 QA 1차 검증분).
  *
  * ⚠️logged-out login-CSRF(story 6ae1ecac AC#2): BE `existing_session_user_id` 비교는 이미
  * 머지돼있다(#2202 finding3) — 이 라우트의 책임은 그 값을 **클라이언트가 body/query로 보낸
@@ -41,9 +50,18 @@ function bootstrapFailedResponse(): NextResponse {
 
 interface NativeBootstrapBody {
   code?: unknown;
-  device_binding_hash?: unknown;
+  installation_id?: unknown;
+  challenge_id?: unknown;
+  client_data_b64url?: unknown;
+  key_version?: unknown;
+  assertion_b64?: unknown;
+  signature_b64?: unknown;
   redirect_path?: unknown;
 }
+
+const PASSTHROUGH_STRING_FIELDS = [
+  'code', 'installation_id', 'challenge_id', 'client_data_b64url', 'assertion_b64', 'signature_b64',
+] as const;
 
 async function parseBody(request: Request): Promise<NativeBootstrapBody | null> {
   const contentType = request.headers.get('content-type') ?? '';
@@ -54,11 +72,11 @@ async function parseBody(request: Request): Promise<NativeBootstrapBody | null> 
     // application/x-www-form-urlencoded(자동제출 form/native postUrl 페이로드) 지원.
     const raw = await request.text();
     const params = new URLSearchParams(raw);
-    return {
-      code: params.get('code') ?? undefined,
-      device_binding_hash: params.get('device_binding_hash') ?? undefined,
-      redirect_path: params.get('redirect_path') ?? undefined,
-    };
+    const body: NativeBootstrapBody = { redirect_path: params.get('redirect_path') ?? undefined };
+    for (const field of PASSTHROUGH_STRING_FIELDS) body[field] = params.get(field) ?? undefined;
+    const keyVersionRaw = params.get('key_version');
+    body.key_version = keyVersionRaw === null ? undefined : Number(keyVersionRaw);
+    return body;
   } catch {
     return null;
   }
@@ -85,7 +103,16 @@ export async function POST(request: Request) {
     return bootstrapFailedResponse();
   }
   const code = body.code;
-  const deviceBindingHash = typeof body.device_binding_hash === 'string' ? body.device_binding_hash : undefined;
+  // story cbd578d4(C4·§7.5) redeem 증명 필드 — BFF는 검증도 서명도 하지 않고 그대로
+  // 전달만 한다(installation-바인딩 키는 기기 밖으로 안 나옴). 필드별 필수/선택 검증은
+  // 의도적으로 BE(consume_native_bootstrap 단일 트랜잭션)에만 둔다 — 여기서 중복 검증하면
+  // 두 계층이 계약 드리프트할 위험만 커진다(BE가 authoritative).
+  const installationId = typeof body.installation_id === 'string' ? body.installation_id : undefined;
+  const challengeId = typeof body.challenge_id === 'string' ? body.challenge_id : undefined;
+  const clientDataB64Url = typeof body.client_data_b64url === 'string' ? body.client_data_b64url : undefined;
+  const keyVersion = typeof body.key_version === 'number' && Number.isFinite(body.key_version) ? body.key_version : undefined;
+  const assertionB64 = typeof body.assertion_b64 === 'string' ? body.assertion_b64 : undefined;
+  const signatureB64 = typeof body.signature_b64 === 'string' ? body.signature_b64 : undefined;
   const redirectPathInput = typeof body.redirect_path === 'string' ? body.redirect_path : undefined;
 
   // logged-out login-CSRF(story 6ae1ecac AC#2): existing_session_user_id는 client body/query
@@ -107,7 +134,12 @@ export async function POST(request: Request) {
     },
     body: JSON.stringify({
       code,
-      device_binding_hash: deviceBindingHash,
+      installation_id: installationId,
+      challenge_id: challengeId,
+      client_data_b64url: clientDataB64Url,
+      key_version: keyVersion,
+      assertion_b64: assertionB64,
+      signature_b64: signatureB64,
       existing_session_user_id: existingSessionUserId,
     }),
   }).catch(() => null);

--- a/apps/web/src/lib/db/server.ts
+++ b/apps/web/src/lib/db/server.ts
@@ -70,7 +70,7 @@ interface AuthMeResponse {
  * 이 재검증에서 실제 BE 계약과 어긋남이 확인되어 정정 — 플래그/발급로직 부재로 오늘은
  * 미도달이라 무해했지만 활성화됐다면 항상 401로 실패했을 것이다.)
  */
-const resolveFirebaseServerSession = cache(async (sessionCookie: string): Promise<ServerSession | null> => {
+export const resolveFirebaseServerSession = cache(async (sessionCookie: string): Promise<ServerSession | null> => {
   const projectId = process.env['NEXT_PUBLIC_FIREBASE_PROJECT_ID'] ?? '';
   if (!projectId) return null;
 


### PR DESCRIPTION
## 요약
- story `f755b1a9` · epic E-AUTH-REBUILD · 스토리 `6ae1ecac`(M2 활성화 게이트) 필수조건 2·3 담당
- `default-off` 플래그(`FIREBASE_AUTH_MOBILE_ISSUE`) 뒤 — 기존 로그인 무회귀

## 그라운딩(착수 전 완료, doc §9.1 + PR#2202 실코드 + sprintable-mobile 스캐폴드 대조)
BE 소비 계약(develop `backend/app/routers/auth_firebase_internal.py::consume_native_bootstrap`)을 실코드로 확認. `existing_session_user_id` 클라 위조 방지 메커니즘(finding3)은 이미 BE에 머지돼 있음 — 이 PR의 책임은 그 값을 **서버검증 `__Host-sp_fs` 세션에서만 도출**하는 것.

## 변경 사항
`apps/web/src/app/auth/native/route.ts`(신규):
- `code`/`device_binding_hash`/`redirect_path`를 exact-origin POST body로만 수신(query 미사용 — PO 확定, doc §9.1의 `?code=` best-known을 대체). JSON+urlencoded 둘 다 파싱.
- 기존 `__Host-sp_fs` 있으면 `resolveFirebaseServerSession()`(export 추가, `apps/web/src/lib/db/server.ts`)으로 서버검증 → `existing_session_user_id`로 내부 consume 호출에 포함. **클라 body/query의 어떤 UID 값도 절대 읽지 않음**(필드 자체가 파싱 인터페이스에 없음).
- 내부 `POST /api/v2/internal/auth/native-bootstrap/consume` 호출(S4와 동일 공유시크릿 패턴).
- 성공: `__Host-sp_fs` Set-Cookie(`setFirebaseSessionCookie` 재사용)+`sp_at`/`sp_rt` 정리+303(`redirect_path`는 기존 `safeNextPath()` 오픈리다이렉트 가드 재사용 — 신규 유틸 안 만듦, 기본 폴백 `/inbox`)+`Cache-Control: no-store`+`Referrer-Policy: no-referrer`.
- 실패(사유 불문): 동일 401 `NATIVE_BOOTSTRAP_FAILED`(neutral, enumeration 방지 — 기존 `/api/auth/firebase/session` 패턴과 동형).

## 크로스레포 wire 계약(민군 확認 완료, PO 경유)
WebView는 fetch()가 아니라 **top-level POST 네비게이션**(Android `postUrl`/자동제출 form)으로 이 라우트를 열어야 303+Set-Cookie가 WebView 자체 쿠키저장소에 정상 축적됨 — 순수 JS fetch는 페이지 네비게이션이 아니라 이 계약을 만족 못함. 민군 모바일 스캐폴드도 `?code=` 쿼리 방식에서 이 계약으로 동시 전환 중.

## 정직 고지(스코프 밖)
"로그아웃 상태 피해자 WebView에 공격자가 자기 계정으로 정당 발급받은 code를 심는" 잔여 시나리오는 이 BFF만으론 완전 봉쇄 불가 — 완전한 per-installation attestation(story 6ae1ecac condition①)이 필요하며, 별도 스코프로 산티아고와 후속 조율 예정. 이 PR은 그 잔여 리스크를 늘리지 않는 것(서버검증 UID만 사용)까지가 책임.

## 뮤테이션 자체검증(값진 발견)
`existing_session_user_id` 초기값을 클라 입력으로 바꿔치기하는 뮤테이션을 적용했더니, **기존 테스트 13개가 전부 통과**했다 — "쿠키 있음" 케이스는 이후 로직이 덮어써서 뮤테이션이 가려졌고, "쿠키 없음" 케이스는 애초에 body에 위조 필드를 안 보내는 테스트라 우연히 무해했다. 전용 테스트("쿠키 없음 + 클라가 UID 위조 시도")를 추가한 뒤 뮤테이션을 재적용하니 그 테스트만 정확히 RED — 되돌린 후 14개 전부 그린. 뮤테이션 자체검증이 실제로 커버리지 갭을 찾아낸 사례.

## 테스트
- ✅ `tsc --noEmit` 클린
- ✅ `pnpm lint` 0 error(경고 5건 무관 파일)
- ✅ `pnpm build` EXIT 0, `/auth/native` 라우트 빌드 출력에서 확認
- ✅ `pnpm test`(vitest, 루트) 263 test files / 1797 passed / 2 skipped / 0 failed(신규 14케이스 포함)
- ✅ 뮤테이션 자체검증(위 서술) — 실제 커버리지 갭 발견+수정

## 이 PR 스코프 밖
- `sprintable-mobile` 측 wire 전환(민군 별도 트랙, 진행 중)
- 완전한 per-installation device attestation(story 6ae1ecac condition①)
- distributed rate limiter·expired-row cleanup(story 6ae1ecac condition④⑤, 디디/BE 소관)