### PR TITLE
fix(mcp): standup_missing 툴그룹 오분류 수정 (story 205e6831)

### DIFF
--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 #       notifications/webhooks/rewards/audit/agent_runs/canvas/admin/core
 _GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
     ("rewards", ("reward", "wallet", "leaderboard")),
-    ("analytics", ("velocity", "health", "dashboard", "overview", "stats", "standup_missing",
+    ("analytics", ("velocity", "health", "dashboard", "overview", "stats",
                    "sprint_summary", "recent_activity", "agent_stats", "blocked_stories",
                    "unassigned_stories", "member_workload", "overdue", "epic_progress")),
     ("agent_runs", ("agent_run", "run_status", "update_run")),

--- a/backend/tests/test_e_mcp_s2_toolset.py
+++ b/backend/tests/test_e_mcp_s2_toolset.py
@@ -37,6 +37,15 @@ def test_destructive_detection():
     assert not is_destructive("sprintable_list_stories")
 
 
+def test_standup_missing_grouped_with_standup_not_analytics():
+    """story 205e6831: standup_missing이 analytics 키워드 그룹에 잘못 묶여 있었음 — scrum-master
+    role_template처럼 'standup' scope는 있지만 'analytics'는 없는 키가 자기 핵심 업무 도구인
+    standup_missing을 호출하지 못하던 실버그. standup 그룹으로 재분류."""
+    assert tool_group("sprintable_standup_missing") == "standup"
+    assert is_tool_allowed("sprintable_standup_missing", ["standup"])
+    assert not is_tool_allowed("sprintable_standup_missing", ["analytics"])
+
+
 def test_lock_unlock_reclassified_non_destructive():
     """S17: lock_files/unlock_files 는 file_locks.py 확인 결과 org/project-scoped advisory 조율
     도구(데이터 삭제/변경 아님) — is_destructive/admin 그룹 오분류를 근본수정. 진짜 파괴 작업


### PR DESCRIPTION
## Summary
- 대표(고객) FR "MCP 스탠드업 tool이 빠져있다" 조사(story 205e6831) 진행 중 확인: 5개 스탠드업 tool(`sprintable_get_standup`/`save_standup`/`list_standup_entries`/`standup_history`/`standup_missing`) 전부 서버 tool 레지스트리(`ALL_TOOL_NAMES`, `app/services/mcp_toolset.py`)에 존재하고 배포되어 있음 — **배포 갭 아님**.
- 조사 중 별개의 실버그 발견: `sprintable_standup_missing`이 키워드 매칭 순서상 `standup` 그룹이 아니라 `analytics` 그룹으로 분류되고 있었음. `role_templates` 시드를 대조한 결과 **`scrum-master` role은 `default_tool_groups`에 `standup`만 있고 `analytics`는 없음** — 스탠드업 운영이 본업인 role이 정작 "누가/어느 날짜 스탠드업 누락했는지" 확인하는 자기 핵심 도구를 호출하지 못하는 상태였음.
- `standup_missing` 키워드를 `analytics` 그룹 키워드 목록에서 제거 → `standup` 그룹으로 자연 낙하하도록 수정(`app/services/mcp_toolset.py`).

## Blast radius 확인
- `pm` role: `standup`+`analytics` 둘 다 보유 → 영향 없음.
- `scrum-master` role: `standup`만 보유 → 이번 수정으로 접근 **확대**(버그 수정).
- `analytics`만 보유하고 `standup`은 없는 다른 role(다수, backend/qa/marketing 계열 등): 이번 수정으로 `standup_missing` 접근을 **잃음** — 하지만 이 role들은 애초 "standup"을 명시적으로 부여받지 않았으므로 standup 관련 도구를 의도적으로 필요로 한 적이 없었음(analytics 그룹의 곁다리 노출이었을 뿐). 회귀 아님.

## 남은 스코프(story 205e6831 계속 진행)
이 PR은 발견 즉시 수정한 독립 버그 하나. 원래 이슈("대표 에이전트가 스탠드업 tool을 못 본다")의 진짜 근본원인은 **대표 에이전트의 실제 role_template/API key scope 실측**(PO lane, prod 접근 필요)으로 별도 확인 중 — 그 결과에 따라 해당 role의 `default_tool_groups`에 `standup` 추가가 필요할 수 있음(배포 불요, 데이터 조치).

## Test plan
- [x] 신규 회귀 테스트 `test_standup_missing_grouped_with_standup_not_analytics`(`tests/test_e_mcp_s2_toolset.py`).
- [x] `tests/test_e_mcp_s2_toolset.py` + `test_toolset_catalog.py` + `test_byoa_toolgroup_scope.py` + `test_be_scope_enforce_7b63c226.py` + `mcp/test_contract.py` + role-template 스위트: `77 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)