### PR TITLE
feat(mcp): 스탠드업 5종 core 편입 — role_template 무관 범용 접근 (story 205e6831)

### DIFF
--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -81,6 +81,14 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # 조작이라 파괴적이지 않음(has_project_access로 대상 검증). vendored 사본과 동기화 필수
     # (sprintable_mcp/toolset.py).
     "sprintable_list_projects", "sprintable_set_default_project",
+    # story 205e6831(FR·대표요청): 대표 role이 불명확(role_template 22개 중 어느 것이든 될 수
+    # 있음) — 개별 role의 default_tool_groups를 고치는 대신 스탠드업을 범용 업무로 core 편입
+    # (선생님 방향: 스탠드업은 직무 무관 공통 업무). tool_group()은 여전히 "standup" 그룹으로
+    # 분류하지만(피커 UI 라벨용), is_tool_allowed는 이 목록을 먼저 체크해 그룹/scope 무관 항상
+    # 허용 — role_template.default_tool_groups에 "standup" 유무와 무관하게 모든 role이 호출
+    # 가능해진다(pm/scrum-master 전용이던 걸 22개 role 전체로 확대 = 회귀 아닌 기능 추가).
+    "sprintable_get_standup", "sprintable_save_standup", "sprintable_list_standup_entries",
+    "sprintable_standup_history", "sprintable_standup_missing",
 })
 
 # scope 토큰: 그룹명 외에 read/write(레거시·전체 비파괴 의미), admin/destructive(파괴적 허용)
@@ -189,11 +197,16 @@ _ALWAYS_ALLOWED_PATH_PREFIXES: tuple[str, ...] = (
     # E-VERIFY V0-S1: evidence는 story/task 어느 쪽이든 첨부되는 cross-cutting 자기증명이라
     # 단일 도메인 그룹에 안 묶임(_ALWAYS_ALLOWED의 sprintable_add_evidence와 동일 근거).
     "/api/v2/evidence",
+    # story 205e6831(FR·대표요청): MCP _ALWAYS_ALLOWED에 스탠드업 5종을 core 편입했는데 여기(REST
+    # path scope)를 같이 안 고치면 canvas 선례(b4027b2e)와 동일한 "도구는 보이는데 호출은 403"
+    # 불일치가 재발한다 — tools/list는 항상 노출하지만 실제 HTTP 호출은 _check_api_key_scope가
+    # 여전히 "standup" 그룹 미보유 키를 막았을 것. 아래 _PATH_GROUP_PREFIXES의 standup 매핑도 같이
+    # 제거(이 prefix가 먼저 매치돼 always-allowed로 빠지므로 그 매핑은 이제 도달 불가 dead 항목).
+    "/api/v2/standups",
 )
 
 # path-prefix → toolset group(라우터 리소스 정렬). 모든 group 은 ALL_GROUPS 소속이어야 함.
 _PATH_GROUP_PREFIXES: tuple[tuple[str, str], ...] = (
-    ("/api/v2/standups", "standup"),
     ("/api/v2/rewards", "rewards"),
     ("/api/v2/wallet", "rewards"),
     ("/api/v2/leaderboard", "rewards"),
@@ -317,9 +330,15 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
 )
 
 # picker 표시 순서(비파괴 먼저). order 필드 힌트 + 배열 순서 둘 다 이 순서.
+# story 205e6831: "standup"을 여기서 제거 — 스탠드업 5종 전부가 _ALWAYS_ALLOWED(core)로 편입돼
+# build_toolset_catalog()의 always-allowed 제외 로직상 이 그룹은 영구적으로 tools=[]가 된다
+# (모든 그룹은 멤버를 가져야 하는 카탈로그 계약 위반). "standup"은 _GROUP_KEYWORDS/ALL_GROUPS엔
+# 그대로 남겨둔다 — pm/scrum-master role_template.default_tool_groups가 여전히 이 literal
+# 토큰을 갖고 있어 제거 시 validate_tool_groups()가 unknown-group ValueError를 던진다(그
+# 토큰 자체는 이제 no-op이지만 seed seed 마이그 없이 여길 건드리면 recruit/rotate가 깨진다).
 _CATALOG_DISPLAY_ORDER: tuple[str, ...] = (
     "stories", "tasks", "sprints", "epics", "hypotheses", "chat", "docs", "analytics", "retro",
-    "standup", "meetings", "notifications", "webhooks", "rewards", "audit", "agent_runs", "canvas",
+    "meetings", "notifications", "webhooks", "rewards", "audit", "agent_runs", "canvas",
 )
 
 

--- a/backend/sprintable_mcp/toolset.py
+++ b/backend/sprintable_mcp/toolset.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 
 _GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
     ("rewards", ("reward", "wallet", "leaderboard")),
-    ("analytics", ("velocity", "health", "dashboard", "overview", "stats", "standup_missing",
+    # story 205e6831: "standup_missing" 키워드를 여기서 제거 — 백엔드 SSOT(app/services/
+    # mcp_toolset.py)와 동기화(standup_missing이 이제 core 편입돼 그룹 분류 자체는 무관해졌지만,
+    # tool_group() 피커 라벨 정합을 위해 analytics 오분류를 남겨두지 않는다).
+    ("analytics", ("velocity", "health", "dashboard", "overview", "stats",
                    "sprint_summary", "recent_activity", "agent_stats", "blocked_stories",
                    "unassigned_stories", "member_workload", "overdue", "epic_progress")),
     ("agent_runs", ("agent_run", "run_status", "update_run")),
@@ -67,6 +70,10 @@ _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     # story b4027b2e(SEC): story 7fe16274가 여기 심었던 visual_artifacts 11종 always-allow는
     # 이 스토리에서 "canvas" 전용 그룹(_GROUP_KEYWORDS)으로 대체(상위 mcp_toolset.py 커밋 참고) —
     # always-allow에 남기면 REST 쪽 canvas 그룹 신설과 불일치(도구는 보이는데 REST는 403).
+    # story 205e6831(FR·대표요청): 스탠드업 5종을 core 편입(백엔드 SSOT와 동기화, 사유는
+    # app/services/mcp_toolset.py 참고 — role_template 특정 대신 범용 업무로 core 승격).
+    "sprintable_get_standup", "sprintable_save_standup", "sprintable_list_standup_entries",
+    "sprintable_standup_history", "sprintable_standup_missing",
 })
 
 _LEGACY_SCOPES: frozenset[str] = frozenset({"read", "write"})

--- a/backend/tests/test_be_scope_enforce_7b63c226.py
+++ b/backend/tests/test_be_scope_enforce_7b63c226.py
@@ -15,8 +15,6 @@ from app.services.mcp_toolset import path_allowed_for_scope, path_to_tool_group
 
 
 def test_path_to_tool_group_resource_prefixes():
-    assert path_to_tool_group("/api/v2/standups") == "standup"
-    assert path_to_tool_group("/api/v2/standups/missing") == "standup"
     assert path_to_tool_group("/api/v2/rewards/give") == "rewards"
     assert path_to_tool_group("/api/v2/wallet") == "rewards"
     assert path_to_tool_group("/api/v2/audit-logs") == "audit"
@@ -30,15 +28,27 @@ def test_path_to_tool_group_always_allowed_and_unmapped_none():
     assert path_to_tool_group("/api/v2/dashboard") is None
     assert path_to_tool_group("/api/v2/team-members") is None
     assert path_to_tool_group("/api/v2/events/pending") is None
+    # story 205e6831: 스탠드업이 core 편입(MCP _ALWAYS_ALLOWED와 짝) — group-scoped 키도
+    # "standup" 그룹 보유 여부와 무관하게 항상 통과해야 하므로 이제 always-allowed(None).
+    assert path_to_tool_group("/api/v2/standups") is None
+    assert path_to_tool_group("/api/v2/standups/missing") is None
     # 미매핑 → None(core)
     assert path_to_tool_group("/api/v2/projects") is None
 
 
 def test_path_allowed_group_key():
     scope = ["read", "write", "standup"]
-    assert path_allowed_for_scope("/api/v2/standups", scope) is True       # 자기 그룹
+    assert path_allowed_for_scope("/api/v2/standups", scope) is True       # always-allowed(core)
     assert path_allowed_for_scope("/api/v2/rewards/give", scope) is False   # 타 그룹 차단
     assert path_allowed_for_scope("/api/v2/notifications", scope) is True   # always-allowed
+
+
+def test_path_allowed_standup_group_absent_still_allowed():
+    """story 205e6831: "standup" 그룹이 scope에 아예 없는 좁은 키도 core 편입 후에는 통과해야
+    한다 — 대표 에이전트처럼 role이 불명확해 default_tool_groups에 standup이 없을 수 있는
+    상황을 정확히 커버."""
+    assert path_allowed_for_scope("/api/v2/standups", ["stories", "tasks"]) is True
+    assert path_allowed_for_scope("/api/v2/standups", []) is True
 
 
 def test_path_allowed_full_key_no_regression():
@@ -62,7 +72,8 @@ def test_check_scope_group_key_blocks_other_group():
 
 
 def test_check_scope_group_key_allows_own_group():
-    # standup 그룹키 → standup 엔드포인트 → 통과(예외 없음)
+    # standup 그룹키(또는 story 205e6831 이후로는 어떤 그룹키든) → standup 엔드포인트 always-allowed
+    # 통과(예외 없음)
     _check_api_key_scope(_api_auth(["read", "write", "standup"]), "GET", "/api/v2/standups")
 
 

--- a/backend/tests/test_e_mcp_s2_toolset.py
+++ b/backend/tests/test_e_mcp_s2_toolset.py
@@ -38,12 +38,11 @@ def test_destructive_detection():
 
 
 def test_standup_missing_grouped_with_standup_not_analytics():
-    """story 205e6831: standup_missing이 analytics 키워드 그룹에 잘못 묶여 있었음 — scrum-master
-    role_template처럼 'standup' scope는 있지만 'analytics'는 없는 키가 자기 핵심 업무 도구인
-    standup_missing을 호출하지 못하던 실버그. standup 그룹으로 재분류."""
+    """story 205e6831: standup_missing이 analytics 키워드 그룹에 잘못 묶여 있었음(피커 라벨
+    오분류) — standup 그룹으로 재분류. 이후 스탠드업 5종이 core(_ALWAYS_ALLOWED)로 편입돼
+    is_tool_allowed는 scope 무관 항상 True가 됐지만(별도 테스트), tool_group()의 분류 자체는
+    여전히 "analytics"가 아닌 "standup"이어야 한다(피커 UI 라벨 정합)."""
     assert tool_group("sprintable_standup_missing") == "standup"
-    assert is_tool_allowed("sprintable_standup_missing", ["standup"])
-    assert not is_tool_allowed("sprintable_standup_missing", ["analytics"])
 
 
 def test_lock_unlock_reclassified_non_destructive():

--- a/backend/tests/test_mcp_loop_context_e_loop_ledger_p1_s12.py
+++ b/backend/tests/test_mcp_loop_context_e_loop_ledger_p1_s12.py
@@ -74,3 +74,24 @@ def test_vendored_drift_fixed_workflow_guide_team_members_poll_events_also_alway
     for tool in ("sprintable_get_workflow_guide", "sprintable_list_team_members", "sprintable_poll_events"):
         assert tool in ssot_always
         assert tool in vendored_always
+
+
+def test_standup_tools_core_promoted_ssot_and_vendored():
+    """story 205e6831(FR·대표요청): 대표 role 불명확 → role_template 개별 수정 대신 스탠드업
+    5종을 core(_ALWAYS_ALLOWED) 편입(선생님 방향). 어떤 scope를 줘도 항상 허용돼야 하고,
+    SSOT/vendored 양쪽 드리프트 없어야 한다."""
+    from app.services.mcp_toolset import _ALWAYS_ALLOWED as ssot_always, is_tool_allowed as ssot_allowed
+    from sprintable_mcp.toolset import _ALWAYS_ALLOWED as vendored_always, is_tool_allowed as vendored_allowed
+
+    standup_tools = (
+        "sprintable_get_standup", "sprintable_save_standup", "sprintable_list_standup_entries",
+        "sprintable_standup_history", "sprintable_standup_missing",
+    )
+    for tool in standup_tools:
+        assert tool in ssot_always
+        assert tool in vendored_always
+        # role_template의 default_tool_groups에 "standup"이 전혀 없어도(narrow scope) 항상 허용.
+        assert ssot_allowed(tool, ["stories", "tasks"])
+        assert vendored_allowed(tool, ["stories", "tasks"])
+        assert ssot_allowed(tool, [])
+        assert vendored_allowed(tool, [])

--- a/backend/tests/test_toolset_catalog.py
+++ b/backend/tests/test_toolset_catalog.py
@@ -30,8 +30,10 @@ def test_catalog_structure_and_contract_fields():
     cat = build_toolset_catalog()
     assert set(cat.keys()) == {"groups"}
     groups = cat["groups"]
-    # core + 17 비파괴(story b4027b2e: canvas 그룹 추가) + admin = 19
-    assert len(groups) == 19
+    # core + 16 비파괴(story b4027b2e: canvas 그룹 추가·story 205e6831: standup이 core로 전량
+    # 흡수돼 카탈로그 그룹 목록에서 제거 — _GROUP_KEYWORDS/ALL_GROUPS엔 여전히 존재, 여긴 picker
+    # 표시 목록만) + admin = 18
+    assert len(groups) == 18
     for g in groups:
         assert set(g.keys()) == _CONTRACT_FIELDS, f"{g['key']} 필드 계약 불일치"
         assert isinstance(g["key"], str) and g["key"]
@@ -39,8 +41,8 @@ def test_catalog_structure_and_contract_fields():
         assert isinstance(g["is_core"], bool) and isinstance(g["is_destructive"], bool)
         assert isinstance(g["order"], int)
         assert g["tools"], f"{g['key']} 빈 그룹 — 모든 그룹은 멤버 보유"
-    # order = 배열 순서와 일치(0..18 단조)
-    assert [g["order"] for g in groups] == list(range(19))
+    # order = 배열 순서와 일치(0..17 단조)
+    assert [g["order"] for g in groups] == list(range(18))
 
 
 def test_core_first_admin_last_flags():
@@ -54,10 +56,13 @@ def test_core_first_admin_last_flags():
 
 def test_group_keys_match_mcp_toolset_ssot():
     keys = [g["key"] for g in build_toolset_catalog()["groups"]]
-    # core + admin + ALL_GROUPS 비-core = 전체
+    # core + admin + ALL_GROUPS 비-core = 전체 — story 205e6831 예외: "standup"은 ALL_GROUPS엔
+    # 남아있지만(pm/scrum-master role_template.default_tool_groups 하위호환용 literal 토큰,
+    # validate_tool_groups unknown-group 방지) 스탠드업 5종 전부가 core로 흡수돼 카탈로그엔
+    # 빈 그룹으로 안 나타난다("standup" != core 그러나 catalog엔 미표시).
     assert "core" in keys and "admin" in keys
     non_core_admin = {k for k in keys if k not in ("core", "admin")}
-    assert non_core_admin == {g for g in ALL_GROUPS if g != "core"}  # 16 비파괴 그룹
+    assert non_core_admin == {g for g in ALL_GROUPS if g not in ("core", "standup")}
 
 
 def test_every_tool_covered_exactly_once():


### PR DESCRIPTION
## Summary
- 선생님 방향 확定(2026-07-16): 대표 에이전트가 어떤 role_template인지 불명확 — 개별 role의 `default_tool_groups`를 특정해 고치는 대신, 스탠드업을 직무 무관 공통 업무로 판단해 **core tool 그룹에 편입**.
- role_template 24개 중 `standup` 그룹 보유는 `pm`·`scrum-master` 2개뿐이었으나, 이 PR 이후 **role_template 수정/재배포 없이** 22개 role 전체가 스탠드업 5종(`get_standup`/`save_standup`/`list_standup_entries`/`standup_history`/`standup_missing`)을 사용 가능해짐(기능 확대, 회귀 아님).
- `app/services/mcp_toolset.py`(SSOT)와 `sprintable_mcp/toolset.py`(vendored 사본 — 독립 PyPI 패키지라 import 불가, 드리프트 금지 규율 준수) 양쪽 `_ALWAYS_ALLOWED`에 동일 추가.
- **REST path-level 게이트도 동시 수정**: `_PATH_GROUP_PREFIXES`의 `/api/v2/standups` → `"standup"` 그룹 매핑을 제거해 always-allowed로 이관. MCP tool만 core로 편입하고 이 REST 게이트를 안 맞추면 canvas 선례(b4027b2e)와 동일한 "도구는 tools/list에 보이는데 실제 호출은 403" 불일치가 재발했을 것.
- `build_toolset_catalog()`의 picker 표시 목록(`_CATALOG_DISPLAY_ORDER`)에서 `"standup"` 제거 — 스탠드업 5종 전부가 core로 흡수돼 이 그룹이 영구적으로 `tools=[]`가 되어 "모든 그룹은 멤버 보유" 카탈로그 계약을 위반하게 됨. `"standup"` 토큰 자체는 `ALL_GROUPS`에 남겨둠(pm/scrum-master `role_template.default_tool_groups`가 여전히 이 literal을 갖고 있어 제거 시 `validate_tool_groups()`가 unknown-group으로 recruit/rotate를 거부).

## 배포 경로 (PO 확인 요청분)
이건 **코드 변경**이지 role_template 데이터/시드 마이그레이션이 아님 — 표준 백엔드 배포 경로(dev/prod)로 반영됨. 디디는 prod 접근 0(dev 전용)이라 prod 배포 확인은 PO/산티아고 lane.

## Test plan
- [x] 신규 회귀 `test_standup_tools_core_promoted_ssot_and_vendored`(SSOT+vendored 양쪽, narrow scope로도 항상 허용 확인).
- [x] `test_path_to_tool_group_always_allowed_and_unmapped_none`/`test_path_allowed_standup_group_absent_still_allowed` — REST path 게이트도 함께 확인.
- [x] `test_catalog_structure_and_contract_fields`/`test_group_keys_match_mcp_toolset_ssot` — 카탈로그 그룹 수(19→18) + SSOT-vs-catalog 의도적 예외(`standup`) 조정.
- [x] 관련 스위트 전체(toolset/scope/catalog/recruit): `144 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)