### PR TITLE
feat(stories): 프로젝트별 사람-읽는 sequential #N 채번 — BE 몫 (story 9ac9b80f)

### DIFF
--- a/backend/alembic/versions/0194_stories_sequential_number.py
+++ b/backend/alembic/versions/0194_stories_sequential_number.py
@@ -1,0 +1,55 @@
+"""story 9ac9b80f(FR·대표요청): stories에 프로젝트 스코프 사람-읽는 sequential #N 추가.
+
+id(UUID)는 canonical PK로 그대로 유지 — story_number는 additive 참조 편의 컬럼
+(project_id 내에서만 유일, PR/GitHub issue 넘버링과 동형). 신규 write는
+app.repositories.story.allocate_story_number(advisory xact lock 기반 race-safe
+채번)가 채운다.
+
+기존 행 백필: (project_id, created_at, id) 순서로 프로젝트별 1부터 연속 채번(soft-delete된
+행도 포함 — 번호는 GitHub issue처럼 재사용/스킵 없이 생성순 그대로 유지). set-based 단일
+UPDATE(윈도우 함수)라 대상 규모와 무관하게 안전.
+
+⚠️ nullable=True 유지(NOT NULL로 안 조인다): Story를 StoryRepository.create()/oss_seed 우회해
+직접 ORM construct하는 기존 테스트 fixture가 리포지토리 전역에 51개 존재(이 스토리와 무관한
+다른 에픽들) — NOT NULL로 조이면 전부 깨진다. 실 생성 경로(REST API·oss_seed) 둘 다 이미
+allocate_story_number를 항상 호출하므로 실 데이터는 전부 non-null. Postgres UNIQUE는 NULL을
+서로 다른 값으로 취급해 다건 NULL과 무충돌 공존(non-null 값끼리는 여전히 프로젝트 내 유일 강제).
+
+Revision ID: 0194
+Revises: 0193
+Create Date: 2026-07-16
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0194"
+down_revision = "0193"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("stories", sa.Column("story_number", sa.Integer(), nullable=True))
+
+    op.execute(
+        """
+        UPDATE stories s
+        SET story_number = sub.rn
+        FROM (
+            SELECT id, ROW_NUMBER() OVER (PARTITION BY project_id ORDER BY created_at, id) AS rn
+            FROM stories
+        ) sub
+        WHERE s.id = sub.id
+        """
+    )
+
+    op.create_unique_constraint(
+        "uq_stories_project_id_story_number", "stories", ["project_id", "story_number"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_stories_project_id_story_number", "stories", type_="unique")
+    op.drop_column("stories", "story_number")

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -1,7 +1,9 @@
 import uuid
 from datetime import date, datetime
 
-from sqlalchemy import BigInteger, Boolean, Date, DateTime, ForeignKey, Integer, String, Text, func, text
+from sqlalchemy import (
+    BigInteger, Boolean, Date, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint, func, text,
+)
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -85,11 +87,25 @@ class Epic(Base, OrgScopedMixin, TimestampMixin):
 
 class Story(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     __tablename__ = "stories"
+    __table_args__ = (
+        # story 9ac9b80f(FR·대표요청): 프로젝트별 사람-읽는 sequential #N — race-safe 채번은
+        # app.repositories.story.allocate_story_number(advisory xact lock)이 보장, 이 제약은
+        # 그 보장이 깨졌을 때(버그·우회 write) 조용히 중복 채번되는 걸 막는 최후 방어선.
+        UniqueConstraint("project_id", "story_number", name="uq_stories_project_id_story_number"),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     project_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
     )
+    # story 9ac9b80f: 프로젝트 스코프 sequential 사람-읽는 ID(#N) — UUID(id)는 그대로 canonical
+    # PK 유지, 이건 additive 참조 편의 컬럼. 서버(allocate_story_number)만 채번, client-settable
+    # 아님(StoryCreate에 없음). 실 생성 경로(StoryRepository.create·oss_seed) 둘 다 항상 채번하므로
+    # 실 데이터는 전부 non-null — nullable=True는 스키마 관용이 아니라, 이 모델을 직접 ORM
+    # construct하는 기존 테스트 fixture 51개(레포지토리 우회, 이 스토리와 무관한 다른 에픽들)를
+    # 강제 개조하지 않기 위함. Postgres UNIQUE는 NULL을 서로 다른 값으로 취급해 다건 NULL과
+    # 충돌 없이 공존(제약 무력화 아님 — non-null 값끼리는 여전히 프로젝트 내 유일 강제).
+    story_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
     epic_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("epics.id", ondelete="SET NULL"), nullable=True
     )

--- a/backend/app/repositories/story.py
+++ b/backend/app/repositories/story.py
@@ -19,9 +19,33 @@ _PRIORITY_ORDER = case(
 )
 
 
+async def allocate_story_number(session: AsyncSession, project_id: uuid.UUID) -> int:
+    """story 9ac9b80f(FR·대표요청): 프로젝트별 race-safe sequential #N 채번.
+
+    advisory xact lock으로 동일 project_id 동시생성을 직렬화(recruit_service.
+    acquire_agent_mutation_lock과 동형 관례) — MAX()+1은 잠금 없이는 TOCTOU(두 트랜잭션이
+    같은 max를 읽어 같은 번호를 계산)에 취약하지만, 잠금이 이 함수 호출부터 caller의 커밋/롤백
+    까지 동일 project_id 락을 직렬화하므로 안전. 별도 unlock 불요(트랜잭션 종료 시 자동 해제).
+    caller는 이 호출과 실제 INSERT를 **같은 트랜잭션**(같은 session, 중간 commit 없음)에서
+    수행해야 한다."""
+    await session.execute(
+        select(func.pg_advisory_xact_lock(func.hashtext(f"story_number:{project_id}")))
+    )
+    result = await session.execute(
+        select(func.coalesce(func.max(Story.story_number), 0)).where(Story.project_id == project_id)
+    )
+    return int(result.scalar_one()) + 1
+
+
 class StoryRepository(BaseRepository[Story]):
     def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
         super().__init__(Story, session, org_id)
+
+    async def create(self, **data) -> Story:
+        """story 9ac9b80f: story_number는 client-settable 아님 — 항상 서버가 project_id로
+        allocate_story_number 호출해 채번한다(BaseRepository.create 전 오버라이드)."""
+        story_number = await allocate_story_number(self.session, data["project_id"])
+        return await super().create(story_number=story_number, **data)
 
     async def list(self, limit: int = 1000, *, q: str | None = None, **filters) -> list[Story]:
         """story 083176e8(까심 #2148 QA 적출): 갤러리 피커 실검색 — `q`는 title ILIKE 부분일치로

--- a/backend/app/routers/oss.py
+++ b/backend/app/routers/oss.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.pm import Story
+from app.repositories.story import allocate_story_number
 from app.services.project_auth import has_project_access
 
 router = APIRouter(prefix="/api/v2/oss", tags=["oss", "Organization"])
@@ -42,10 +43,14 @@ async def oss_seed(
         return {"seeded": False, "reason": "already_has_data"}
 
     for story_data in _SAMPLE_STORIES:
+        # story 9ac9b80f: StoryRepository.create()를 거치지 않는 직접 ORM 구성 경로 —
+        # allocate_story_number를 여기서도 명시 호출해야 story_number NOT NULL을 채운다.
+        story_number = await allocate_story_number(session, project_id)
         session.add(
             Story(
                 project_id=project_id,
                 org_id=org_id,
+                story_number=story_number,
                 title=story_data["title"],
                 status=story_data["status"],
                 priority=story_data["priority"],

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -89,6 +89,7 @@ async def list_stories(
     status_filter: str | None = Query(default=None, alias="status"),
     no_sprint: bool = Query(default=False, description="sprint 미배정 스토리만 반환"),
     ids: str | None = Query(default=None, description="comma-separated story ids — 배치 앵커 조회(정확한 집합, ORDER BY/limit 무관)"),
+    story_number: int | None = Query(default=None, description="프로젝트 내 사람-읽는 #N(project_id와 함께 사용 — N은 project 내에서만 유일)"),
     q: str | None = Query(default=None, description="title 부분검색(ILIKE) — 기존 필터와 AND 결합"),
     limit: int = Query(default=1000, ge=1, le=2000),
     cursor: str | None = Query(default=None, description="Cursor: ISO 8601 created_at, fetch before this time"),
@@ -155,6 +156,8 @@ async def list_stories(
         filters["assignee_id"] = assignee_id
     if status_filter:
         filters["status"] = status_filter
+    if story_number is not None:
+        filters["story_number"] = story_number
     stories = await repo.list(limit=limit, q=q, **filters)
     await _attach_assignee_ids(repo.session, repo.org_id, stories)
     await _attach_has_evidence(repo.session, stories)

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -179,6 +179,11 @@ class StoryResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: uuid.UUID
+    # story 9ac9b80f(FR·대표요청): 프로젝트 스코프 사람-읽는 #N — id(UUID)는 canonical 유지,
+    # 이건 additive 참조 편의 필드(project_id 내에서만 유일, 서버 채번·client-settable 아님).
+    # int | None: 실 생성 경로(REST API·oss_seed)는 항상 채번하지만, 레포지토리를 우회해 직접
+    # ORM construct하는 기존 테스트 fixture(이 스토리와 무관한 다른 에픽들) 행은 null일 수 있다.
+    story_number: int | None = None
     project_id: uuid.UUID
     org_id: uuid.UUID
     epic_id: uuid.UUID | None = None

--- a/backend/tests/test_083176e8_story_search_q_realdb.py
+++ b/backend/tests/test_083176e8_story_search_q_realdb.py
@@ -94,7 +94,7 @@ async def _call_list_stories(session, org_id, agent_id, **kwargs):
     repo = StoryRepository(session, org_id)
     params = dict(
         project_id=None, epic_id=None, sprint_id=None, assignee_id=None,
-        status_filter=None, no_sprint=False, ids=None, q=None, limit=1000,
+        status_filter=None, no_sprint=False, ids=None, story_number=None, q=None, limit=1000,
         cursor=None, response=None,
     )
     params.update(kwargs)

--- a/backend/tests/test_9ac9b80f_story_number_realdb.py
+++ b/backend/tests/test_9ac9b80f_story_number_realdb.py
@@ -1,0 +1,277 @@
+"""story 9ac9b80f(FR·대표요청): 프로젝트별 사람-읽는 sequential #N 채번 — 실 PG.
+
+allocate_story_number(advisory xact lock 기반)의 race-safety·프로젝트별 독립성·
+oss_seed 배선·응답 노출·#N 조회 필터를 검증한다."""
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+pytestmark = [
+    pytest.mark.skipif(not _REAL_DB_URL, reason="통합 테스트는 실 PG(PARITY/ALEMBIC_DATABASE_URL) 필요"),
+    pytest.mark.anyio,
+]
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+async def _dispose_global_engine_after_test():
+    yield
+    from app.core.database import engine as _global_engine
+    await _global_engine.dispose()
+
+
+def _async_url() -> str:
+    url = _REAL_DB_URL
+    for prefix in ("postgresql+psycopg2://", "postgresql+asyncpg://", "postgresql://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix):]
+    return url
+
+
+async def _session_factory():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    engine = create_async_engine(_async_url())
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _seed_org_project(session, n_projects: int = 1):
+    from app.models.organization import Organization
+    from app.models.project import Project
+
+    org = Organization(id=uuid.uuid4(), name="Org", slug=f"org-{uuid.uuid4().hex[:8]}")
+    session.add(org)
+    await session.commit()
+
+    project_ids = []
+    for _ in range(n_projects):
+        project = Project(id=uuid.uuid4(), org_id=org.id, name="P")
+        session.add(project)
+        await session.commit()
+        project_ids.append(project.id)
+
+    return org.id, project_ids
+
+
+@pytest.mark.anyio
+async def test_sequential_numbers_start_at_1_and_increment():
+    from app.repositories.story import StoryRepository
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, [project_id] = await _seed_org_project(s)
+            repo = StoryRepository(s, org_id)
+            first = await repo.create(project_id=project_id, title="A", status="backlog", priority="medium")
+            second = await repo.create(project_id=project_id, title="B", status="backlog", priority="medium")
+            third = await repo.create(project_id=project_id, title="C", status="backlog", priority="medium")
+        assert (first.story_number, second.story_number, third.story_number) == (1, 2, 3)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_different_projects_have_independent_counters():
+    from app.repositories.story import StoryRepository
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, [proj_a, proj_b] = await _seed_org_project(s, n_projects=2)
+            repo = StoryRepository(s, org_id)
+            a1 = await repo.create(project_id=proj_a, title="A1", status="backlog", priority="medium")
+            b1 = await repo.create(project_id=proj_b, title="B1", status="backlog", priority="medium")
+            a2 = await repo.create(project_id=proj_a, title="A2", status="backlog", priority="medium")
+        # 서로 다른 프로젝트는 독립적으로 1부터 채번 — proj_b의 첫 스토리도 #1.
+        assert a1.story_number == 1
+        assert b1.story_number == 1
+        assert a2.story_number == 2
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_concurrent_create_race_safe_no_duplicate_or_gap():
+    """산티아고 §스토리: 동시 N개 생성이 advisory xact lock으로 직렬화되어 중복/누락 없는
+    연속 번호를 받아야 한다."""
+    from app.repositories.story import StoryRepository
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, [project_id] = await _seed_org_project(s)
+
+        N = 8
+
+        async def _create_one(i: int):
+            async with Session() as s2:
+                repo = StoryRepository(s2, org_id)
+                story = await repo.create(
+                    project_id=project_id, title=f"Concurrent {i}", status="backlog", priority="medium",
+                )
+                await s2.commit()
+                return story.story_number
+
+        numbers = await asyncio.gather(*[_create_one(i) for i in range(N)])
+        assert sorted(numbers) == list(range(1, N + 1)), f"중복/누락 발생: {sorted(numbers)}"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_project_scoped_unique_constraint_enforced_at_db_level():
+    """advisory lock을 우회해 동일 (project_id, story_number)를 직접 삽입하면 DB 제약이 막는다
+    (allocate_story_number가 깨졌을 때의 최후 방어선)."""
+    from sqlalchemy.exc import IntegrityError
+    from app.models.pm import Story
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, [project_id] = await _seed_org_project(s)
+            s.add(Story(
+                id=uuid.uuid4(), org_id=org_id, project_id=project_id, story_number=1,
+                title="First", status="backlog", priority="medium",
+            ))
+            await s.commit()
+
+        async with Session() as s:
+            s.add(Story(
+                id=uuid.uuid4(), org_id=org_id, project_id=project_id, story_number=1,
+                title="Duplicate number", status="backlog", priority="medium",
+            ))
+            with pytest.raises(IntegrityError):
+                await s.commit()
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_oss_seed_assigns_sequential_numbers():
+    from httpx import ASGITransport, AsyncClient
+    from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+    from app.main import app
+    from app.models.member import Member
+    from app.models.project_access import ProjectAccess
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, [project_id] = await _seed_org_project(s)
+            user_id = uuid.uuid4()
+            human = Member(id=user_id, org_id=org_id, type="human", name="U")
+            s.add(human)
+            await s.commit()
+            s.add(ProjectAccess(id=uuid.uuid4(), project_id=project_id, member_id=user_id, permission="granted"))
+            await s.commit()
+
+        async def _override_db():
+            # app.core.database.get_db와 동형으로 yield 後 commit — 안 그러면 라우터가 flush만
+            # 하고 커밋 안 된 채 응답, 이후 별도 세션으로 재조회 시 0행으로 보인다.
+            async with Session() as s:
+                yield s
+                await s.commit()
+
+        async def _override_auth():
+            return AuthContext(user_id=str(user_id), email=None, claims={"app_metadata": {}})
+
+        async def _override_org():
+            return org_id
+
+        app.dependency_overrides[get_db] = _override_db
+        app.dependency_overrides[get_current_user] = _override_auth
+        app.dependency_overrides[get_verified_org_id] = _override_org
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.post(f"/api/v2/oss/seed?project_id={project_id}")
+            assert resp.status_code == 200
+            assert resp.json()["seeded"] is True
+        finally:
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.pm import Story
+            rows = (await s.execute(
+                select(Story).where(Story.project_id == project_id).order_by(Story.story_number)
+            )).scalars().all()
+        assert [r.story_number for r in rows] == [1, 2, 3]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_response_exposes_story_number_and_filter_lookup_works():
+    from httpx import ASGITransport, AsyncClient
+    from app.dependencies.auth import AuthContext, get_current_user, get_project_scoped_org_id, get_verified_org_id
+    from app.dependencies.database import get_db
+    from app.main import app
+    from app.models.member import Member
+    from app.models.project_access import ProjectAccess
+
+    engine, Session = await _session_factory()
+    try:
+        async with Session() as s:
+            org_id, [project_id] = await _seed_org_project(s)
+            user_id = uuid.uuid4()
+            human = Member(id=user_id, org_id=org_id, type="human", name="U")
+            s.add(human)
+            await s.commit()
+            s.add(ProjectAccess(id=uuid.uuid4(), project_id=project_id, member_id=user_id, permission="granted"))
+            await s.commit()
+
+        async def _override_db():
+            # app.core.database.get_db와 동형으로 yield 後 commit — 안 그러면 라우터가 flush만
+            # 하고 커밋 안 된 채 응답, 이후 별도 세션으로 재조회 시 0행으로 보인다.
+            async with Session() as s:
+                yield s
+                await s.commit()
+
+        async def _override_auth():
+            return AuthContext(user_id=str(user_id), email=None, claims={"app_metadata": {}})
+
+        async def _override_org():
+            return org_id
+
+        app.dependency_overrides[get_db] = _override_db
+        app.dependency_overrides[get_current_user] = _override_auth
+        app.dependency_overrides[get_verified_org_id] = _override_org
+        # list_stories의 _get_repo는 get_verified_org_id가 아닌 get_project_scoped_org_id에
+        # 의존(내부적으로 get_verified_org_id를 FastAPI DI 밖에서 직접 함수호출하므로 위 override가
+        # 안 먹는다) — 별도로 오버라이드해야 한다.
+        app.dependency_overrides[get_project_scoped_org_id] = _override_org
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                create_resp = await c.post("/api/v2/stories", json={
+                    "project_id": str(project_id), "org_id": str(org_id), "title": "Findable",
+                })
+                assert create_resp.status_code == 201
+                created = create_resp.json()
+                assert created["story_number"] == 1
+
+                lookup_resp = await c.get(
+                    f"/api/v2/stories?project_id={project_id}&story_number=1"
+                )
+                assert lookup_resp.status_code == 200
+                found = lookup_resp.json()
+                assert len(found) == 1
+                assert found[0]["id"] == created["id"]
+
+                miss_resp = await c.get(
+                    f"/api/v2/stories?project_id={project_id}&story_number=999"
+                )
+                assert miss_resp.json() == []
+        finally:
+            app.dependency_overrides.clear()
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_e_cage_referee_p1_participation_api.py
+++ b/backend/tests/test_e_cage_referee_p1_participation_api.py
@@ -22,6 +22,8 @@ def _mock_story_obj(assignee_id=None):
     s.id = STORY_ID
     s.org_id = ORG_ID
     s.project_id = PROJECT_ID
+    # story 9ac9b80f: MagicMock 자동 속성은 Pydantic int|None 검증 실패 — 명시 세팅.
+    s.story_number = 1
     s.epic_id = None
     s.sprint_id = None
     s.assignee_id = assignee_id
@@ -101,7 +103,10 @@ async def test_create_story_with_assignee_auto_creates_participation():
 
     client, app = await _make_client(mock_session)
     try:
-        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create, \
+        # story 9ac9b80f: StoryRepository.create()가 이제 BaseRepository.create() 前에
+        # allocate_story_number()(실 DB 쿼리)를 먼저 호출한다 — 서브클래스 레벨을 patch해야
+        # mock 세션에 그 호출까지 안 부딪힌다(test_stories.py와 동형 수정).
+        with patch("app.repositories.story.StoryRepository.create", new_callable=AsyncMock) as mock_create, \
              patch("app.routers.stories._upsert_assignee_participation", new_callable=AsyncMock) as mock_upsert:
             mock_create.return_value = story
             async with client as c:
@@ -129,7 +134,10 @@ async def test_create_story_without_assignee_no_participation():
 
     client, app = await _make_client(mock_session)
     try:
-        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create, \
+        # story 9ac9b80f: StoryRepository.create()가 이제 BaseRepository.create() 前에
+        # allocate_story_number()(실 DB 쿼리)를 먼저 호출한다 — 서브클래스 레벨을 patch해야
+        # mock 세션에 그 호출까지 안 부딪힌다(test_stories.py와 동형 수정).
+        with patch("app.repositories.story.StoryRepository.create", new_callable=AsyncMock) as mock_create, \
              patch("app.routers.stories._upsert_assignee_participation", new_callable=AsyncMock) as mock_upsert:
             mock_create.return_value = story
             async with client as c:
@@ -251,7 +259,7 @@ async def test_create_story_without_assignee_still_201():
 
     client, app = await _make_client(mock_session)
     try:
-        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+        with patch("app.repositories.story.StoryRepository.create", new_callable=AsyncMock) as mock_create:
             mock_create.return_value = story
             async with client as c:
                 resp = await c.post("/api/v2/stories", json={

--- a/backend/tests/test_stories.py
+++ b/backend/tests/test_stories.py
@@ -16,6 +16,8 @@ def _mock_story(status: str = "backlog") -> MagicMock:
     s.id = STORY_ID
     s.org_id = ORG_ID
     s.project_id = PROJECT_ID
+    # story 9ac9b80f: MagicMock 자동 속성은 Pydantic int|None 검증 실패 — 명시 세팅.
+    s.story_number = 1
     s.epic_id = None
     s.sprint_id = None
     s.assignee_id = None
@@ -101,7 +103,12 @@ async def test_create_story_201():
     client, session, app = await _client()
     try:
         story = _mock_story()
-        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+        # story 9ac9b80f: StoryRepository.create()가 이제 BaseRepository.create() 前에
+        # allocate_story_number()(실 DB advisory lock+MAX 쿼리)를 먼저 호출한다 — mock 세션에
+        # 그 호출까지 재현하지 않고 라우터 wiring만 검증하려면 서브클래스 레벨(StoryRepository.create)
+        # 을 patch해야 한다(BaseRepository.create만 patch하면 allocate_story_number가 mock
+        # session.execute()에 그대로 부딪혀 TypeError).
+        with patch("app.repositories.story.StoryRepository.create", new_callable=AsyncMock) as mock_create:
             mock_create.return_value = story
 
             async with client as c:
@@ -377,7 +384,12 @@ async def test_create_story_with_intent_fields_201():
         story.metric_definition = _VALID_METRIC
         story.measure_after = datetime(2026, 7, 1, tzinfo=timezone.utc)
 
-        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+        # story 9ac9b80f: StoryRepository.create()가 이제 BaseRepository.create() 前에
+        # allocate_story_number()(실 DB advisory lock+MAX 쿼리)를 먼저 호출한다 — mock 세션에
+        # 그 호출까지 재현하지 않고 라우터 wiring만 검증하려면 서브클래스 레벨(StoryRepository.create)
+        # 을 patch해야 한다(BaseRepository.create만 patch하면 allocate_story_number가 mock
+        # session.execute()에 그대로 부딪혀 TypeError).
+        with patch("app.repositories.story.StoryRepository.create", new_callable=AsyncMock) as mock_create:
             mock_create.return_value = story
 
             async with client as c:
@@ -441,7 +453,12 @@ async def test_create_story_outcome_fields_ignored():
     client, session, app = await _client()
     try:
         story = _mock_story()
-        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+        # story 9ac9b80f: StoryRepository.create()가 이제 BaseRepository.create() 前에
+        # allocate_story_number()(실 DB advisory lock+MAX 쿼리)를 먼저 호출한다 — mock 세션에
+        # 그 호출까지 재현하지 않고 라우터 wiring만 검증하려면 서브클래스 레벨(StoryRepository.create)
+        # 을 patch해야 한다(BaseRepository.create만 patch하면 allocate_story_number가 mock
+        # session.execute()에 그대로 부딪혀 TypeError).
+        with patch("app.repositories.story.StoryRepository.create", new_callable=AsyncMock) as mock_create:
             mock_create.return_value = story
 
             async with client as c:


### PR DESCRIPTION
## Summary
- 실 고객(대표) Feature Request: "이슈 ID 넘버링: 이게 없으니 Agent와 이슈 Followup 시키기 불편하네요~" (원문 story `934d10a1`). UUID만으로는 사람/agent가 "이 이슈 봐줘"라 참조·followup하기 불편 — GitHub issue 같은 짧은 프로젝트-스코프 sequential `#N`을 부여한다.
- **이 PR은 BE 몫**(시퀀스 채번+마이그+API 노출). FE 표기(`#123 제목` UI)는 미르코 lane.
- `stories.story_number`(Integer, nullable) 추가 — `id`(UUID)는 canonical PK 그대로, additive 참조 편의 컬럼. `UniqueConstraint(project_id, story_number)`로 프로젝트 내 유일성 강제.
- `allocate_story_number()`(`app/repositories/story.py`): `pg_advisory_xact_lock` 기반 race-safe 채번 — `recruit_service.acquire_agent_mutation_lock`과 동형 관례. MAX()+1을 락 없이 하면 TOCTOU(두 동시 트랜잭션이 같은 max를 읽어 같은 번호 계산)에 취약한데, advisory lock이 이 함수 호출부터 caller의 커밋/롤백까지 동일 project_id 락을 직렬화해 방지.
- 실 생성 경로 **전수** 배선(제약 추가 시 write 경로 전수 감사 원칙): `StoryRepository.create()` 오버라이드(REST API `POST /api/v2/stories`) + `oss_seed()`(신규 프로젝트 데모 시드 — `StoryRepository`를 우회하는 유일한 직접-ORM write 경로, grep으로 확인) 둘 다 채번.
- `GET /api/v2/stories?project_id=&story_number=` 필터로 `#N` 조회 가능 — MCP `sprintable_list_stories`는 REST를 그대로 프록시하는 얇은 계층이라 별도 MCP 측 변경 불요.
- 마이그레이션 0194: 기존 행을 `(project_id, created_at, id)` 순서로 set-based 윈도우 함수 백필(soft-delete 포함 — GitHub issue처럼 번호 재사용/스킵 없이 생성순 유지).

## nullable 설계 결정 (얕은 타협 아님)
`story_number`를 NOT NULL로 조이면 `StoryRepository`를 우회해 직접 `Story(...)` ORM construct하는 기존 테스트 fixture가 **레포지토리 전역 51개 파일**(이 스토리와 무관한 다른 에픽들)에서 전부 깨진다. 실 생성 경로(REST API·`oss_seed`)는 이미 항상 채번하므로 **실 데이터는 100% non-null**이고, Postgres `UNIQUE`는 NULL을 서로 다른 값으로 취급해 다건 NULL과 무충돌 공존(non-null 값끼리는 여전히 프로젝트 내 유일 강제) — 51개 무관 파일을 강제 개조하지 않으면서 실 데이터 완전성을 100% 보장하는 선택.

## Test plan
- [x] 신규 `tests/test_9ac9b80f_story_number_realdb.py`(6개): 순차 채번(1,2,3…)·프로젝트별 독립 카운터·`asyncio.gather` 8-way 동시생성 race-safety(중복/누락 0)·DB-level UNIQUE 제약(advisory lock 우회 시 최후 방어선)·`oss_seed` 채번 배선·응답 필드+`#N` 조회 필터.
- [x] 기존 51개 무관 fixture 파일 무회귀 확인(nullable 설계로 원천 차단·대표 샘플 배치 재확인).
- [x] `test_stories.py`/`test_e_cage_referee_p1_participation_api.py` mock 세션 patch 대상을 `BaseRepository.create`→`StoryRepository.create`로 조정(새 채번 pre-step이 mock 세션에 직접 부딪히지 않도록) — 3개 파일 회귀 확인, `60 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)