### PR TITLE
[SID:26170479] proxy.ts PUBLIC 목록에 /auth/native 추가 — auth 통합검증 블로커 fix

### DIFF
--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -61,6 +61,23 @@ describe('proxy', () => {
     expect(response.status).toBe(200);
   });
 
+  it('treats /auth/native as public — no 307-to-login (story 26170479, 민군 축c 실측 발견)', async () => {
+    // /auth/native는 세션을 만드는 공개 엔드포인트라 호출 시점엔 세션이 없는 게 정상 — PUBLIC
+    // 목록 누락 시 보호 라우트로 오인돼 /login 307로 튕겨나간다(실 왕복 통합검증에서 잡힌
+    // 크로스레이어 갭, route.ts 단위테스트로는 안 잡힘). no-cookie 요청으로 그 정확한 실패
+    // 모드를 재현·가드.
+    const response = await middleware(makeRequest('/auth/native'));
+    expect(response.status).toBe(200);
+  });
+
+  it('does not accidentally widen the guard to all of /auth/* — /auth/reset-required stays protected', async () => {
+    // 스코프 정확성 회귀가드 — "/auth/native만 열고 /auth/ 전체는 열지 않는다"는 명시 요구를
+    // 실제로 지켰는지 확인. /auth/reset-required는 보호 라우트로 남아있어야 함.
+    mockFetch.mockResolvedValue({ ok: false, json: async () => ({ error: { code: 'TOKEN_REVOKED' } }) });
+    const response = await middleware(makeRequest('/auth/reset-required'));
+    expect(response.status).toBe(307);
+  });
+
   it('passes all /api/* paths without JWT check', async () => {
     const apiPaths = [
       '/api/v1/bridge/slack/interactions',

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -41,6 +41,9 @@ const PUBLIC_PREFIX = [
   '/verify-email',
   '/auth/callback',
   '/auth/login',
+  // story 26170479: 세션을 만드는 공개 엔드포인트(호출 시점엔 세션이 없는 게 정상) — 누락
+  // 시 위 인증가드가 보호 라우트로 오인해 /login 307(민군 축c 실측으로 발견).
+  '/auth/native',
   '/invite',
   '/internal-dogfood',
   '/terms',


### PR DESCRIPTION
## 요약
- story `26170479` · epic E-AUTH-REBUILD
- 민군이 축c(non-prod Firebase) 실 왕복 통합검증 중 발견한 auth 완성 블로커

## 근본원인
`POST /auth/native`(PR#2218)는 세션을 만드는 **공개 엔드포인트**(호출 시점엔 세션이 없는 게 정상)인데, `apps/web/src/proxy.ts` 인증가드의 `PUBLIC_EXACT`/`PUBLIC_PREFIX`에 등록이 안 돼있어 **보호 라우트로 오인돼 `/login?reason=session_expired` 307로 가로채졌다**. proxy.ts:22의 기존 주석이 정확히 이 실패 패턴을 경고하고 있었다.

## 변경
`/auth/callback`·`/auth/login`과 동일하게 `PUBLIC_PREFIX`에 `/auth/native` 추가. **스코프 정확성**: `/auth/native`만 공개 처리 — `/auth/` 전체를 여는 실수 방지를 회귀가드 테스트(`/auth/reset-required`는 여전히 protected)로 고정.

## 왜 #2218 단위테스트가 못 잡았나
route.ts 자체 로직(CSRF/세션도출/303/오픈리다이렉트)만 검증했지, 그 앞단의 `proxy.ts` 인증가드 레이어는 스코프 밖이었다 — 크로스레이어 갭이라 단위테스트로는 원천적으로 안 잡히고, 민군의 실 왕복 통합검증이 잡아냈다.

## 테스트
- ✅ `tsc --noEmit` 클린
- ✅ `pnpm lint` 0 error
- ✅ `pnpm build` EXIT 0
- ✅ `pnpm test`(vitest, 루트) 263 files / 1801 passed / 0 failed(신규 2케이스 포함)
- ✅ 뮤테이션 자체검증: `/auth/native` 문자열을 무력화 → 신규 테스트가 정확히 307로 RED(민군이 실측한 원버그 재현) 확認 후 되돌림