### PR TITLE
[SID:3db5b0dc] story_number FE 렌더링 — 보드 카드·리스트·상세·⌘K #N 표기

### DIFF
--- a/apps/web/src/components/command-palette/command-palette.test.tsx
+++ b/apps/web/src/components/command-palette/command-palette.test.tsx
@@ -20,10 +20,10 @@ vi.mock('next/navigation', () => ({ useRouter: () => ({ push: pushMock }) }));
 let container: HTMLDivElement;
 let root: Root;
 
-function stubFetch() {
+function stubFetch(storyOverrides: Record<string, unknown> = {}) {
   return vi.fn(async (url: string) => {
     if (url.startsWith('/api/stories/')) {
-      return { ok: true, status: 200, json: async () => ({ data: { id: 's1', title: '웰컴 이메일 시안' } }) };
+      return { ok: true, status: 200, json: async () => ({ data: { id: 's1', title: '웰컴 이메일 시안', ...storyOverrides } }) };
     }
     return { ok: true, status: 200, json: async () => ({ data: [] }) };
   }) as unknown as typeof fetch;
@@ -80,6 +80,19 @@ describe('CommandPalette — action commands (story 4f991165)', () => {
     await mount({ contextStoryId: 's1' });
     expect(document.body.textContent).toContain('웰컴 이메일 시안 · 스토리');
     expect(document.body.textContent).toContain('웰컴 이메일 시안 위임하기');
+  });
+
+  it('story 9ac9b80f — context chip prefixes the human-readable #N when story_number is present', async () => {
+    vi.stubGlobal('fetch', stubFetch({ story_number: 42 }));
+    await mount({ contextStoryId: 's1' });
+    expect(document.body.textContent).toContain('#42 웰컴 이메일 시안 · 스토리');
+  });
+
+  it('story 9ac9b80f — omits the #N prefix when story_number is null (pre-backfill story, no-fiction)', async () => {
+    vi.stubGlobal('fetch', stubFetch({ story_number: null }));
+    await mount({ contextStoryId: 's1' });
+    expect(document.body.textContent).toContain('웰컴 이메일 시안 · 스토리');
+    expect(document.body.textContent).not.toContain('#null');
   });
 
   it('flags the gate-decision command as a sensitive/danger pill (amber, not red — learning-signal)', async () => {

--- a/apps/web/src/components/command-palette/command-palette.test.tsx
+++ b/apps/web/src/components/command-palette/command-palette.test.tsx
@@ -85,14 +85,20 @@ describe('CommandPalette — action commands (story 4f991165)', () => {
   it('story 9ac9b80f — context chip prefixes the human-readable #N when story_number is present', async () => {
     vi.stubGlobal('fetch', stubFetch({ story_number: 42 }));
     await mount({ contextStoryId: 's1' });
-    expect(document.body.textContent).toContain('#42 웰컴 이메일 시안 · 스토리');
+    const chip = document.querySelector('.border-b.border-border\\/60.bg-muted\\/30');
+    expect(chip).toBeDefined();
+    expect(chip!.textContent).toBe('◆#42 웰컴 이메일 시안 · 스토리');
   });
 
   it('story 9ac9b80f — omits the #N prefix when story_number is null (pre-backfill story, no-fiction)', async () => {
     vi.stubGlobal('fetch', stubFetch({ story_number: null }));
     await mount({ contextStoryId: 's1' });
-    expect(document.body.textContent).toContain('웰컴 이메일 시안 · 스토리');
-    expect(document.body.textContent).not.toContain('#null');
+    // 까심 QA(#2227 RC): '#null' 문자열만 부재 확認으론 '#undefined'류 인접 버그를 못 잡는다 —
+    // 칩 엘리먼트 자체의 정확한 텍스트를 assert해 어떤 형태의 조작된 '#...' 접두도 차단.
+    const chip = document.querySelector('.border-b.border-border\\/60.bg-muted\\/30');
+    expect(chip).toBeDefined();
+    expect(chip!.textContent).toBe('◆웰컴 이메일 시안 · 스토리');
+    expect(chip!.textContent).not.toMatch(/#/);
   });
 
   it('flags the gate-decision command as a sensitive/danger pill (amber, not red — learning-signal)', async () => {

--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -41,6 +41,7 @@ interface DocResult {
 interface StoryTitleResult {
   id: string;
   title: string;
+  story_number?: number | null;
 }
 
 // story a539c649 S2: 'go-docs' 의 href 는 컴포넌트 내부에서 실 ws/proj slug 로 override 된다
@@ -105,8 +106,8 @@ export function CommandPalette({ open, onOpenChange, projectId, contextStoryId }
       try {
         const res = await fetch(`/api/stories/${contextStoryId}`);
         if (!res.ok) return;
-        const json = (await res.json()) as { data?: { id: string; title: string } };
-        if (!cancelled && json.data) setContextStory({ id: json.data.id, title: json.data.title });
+        const json = (await res.json()) as { data?: { id: string; title: string; story_number?: number | null } };
+        if (!cancelled && json.data) setContextStory({ id: json.data.id, title: json.data.title, story_number: json.data.story_number });
       } catch { /* no-fiction: 조회 실패면 그냥 context 없음과 동일 취급 */ }
     })();
     return () => { cancelled = true; };
@@ -262,7 +263,7 @@ export function CommandPalette({ open, onOpenChange, projectId, contextStoryId }
           {contextStory ? (
             <div className="flex items-center gap-1.5 border-b border-border/60 bg-muted/30 px-3 py-1.5 text-[11px] text-muted-foreground">
               <span className="text-info" aria-hidden="true">◆</span>
-              {t('contextChip', { title: contextStory.title })}
+              {t('contextChip', { title: contextStory.story_number ? `#${contextStory.story_number} ${contextStory.title}` : contextStory.title })}
             </div>
           ) : null}
 

--- a/apps/web/src/components/kanban/kanban-list-view.tsx
+++ b/apps/web/src/components/kanban/kanban-list-view.tsx
@@ -69,7 +69,10 @@ function ListStoryRow({ story, epicMap, memberMap, onStoryClick, onChangeStatus 
             <span className="text-[10px] text-muted-foreground">{t('storyPointsBadge', { count: story.story_points })}</span>
           )}
         </div>
-        <p className="mt-1 text-sm font-medium text-foreground line-clamp-2 relative z-10">{story.title}</p>
+        <p className="mt-1 text-sm font-medium text-foreground line-clamp-2 relative z-10">
+          {story.story_number ? <span className="mr-1 text-muted-foreground">#{story.story_number}</span> : null}
+          {story.title}
+        </p>
         {story.assignee_id && memberMap[story.assignee_id] && (
           <div className="mt-1 flex items-center gap-2 relative z-10">
             <p className="text-xs text-muted-foreground">{memberMap[story.assignee_id].name}</p>

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -243,7 +243,7 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
       {...listeners}
       onClick={onClick}
       onContextMenu={handleContextMenu}
-      title={`#${story.id.slice(0, 6)}`}
+      title={story.story_number ? `#${story.story_number}` : `#${story.id.slice(0, 6)}`}
       className="group relative cursor-pointer transition"
     >
       {/* E-UI-DAEGBYEON P0 — Board card = Proof Capsule(card density, #bf9037cb). 시각 셸만
@@ -255,7 +255,7 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
         density="card"
         proofState={proofState}
         stateLabel={proofStateLabel}
-        claim={story.title}
+        claim={story.story_number ? `#${story.story_number} ${story.title}` : story.title}
         footer={
           <div className="mt-2">
             {/* E-MODERN A: 에픽 = 작은 색 dot + muted 라벨(일관 식별·랜덤 채움배지 퇴출) */}

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -243,7 +243,7 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
       {...listeners}
       onClick={onClick}
       onContextMenu={handleContextMenu}
-      title={story.story_number ? `#${story.story_number}` : `#${story.id.slice(0, 6)}`}
+      title={story.story_number ? `#${story.story_number}` : story.title}
       className="group relative cursor-pointer transition"
     >
       {/* E-UI-DAEGBYEON P0 — Board card = Proof Capsule(card density, #bf9037cb). 시각 셸만

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -736,6 +736,9 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
       <div className="flex h-full flex-col">
         <div className="flex items-start justify-between border-b border-border p-5">
           <div className="flex-1 space-y-2 pr-3">
+            {story.story_number ? (
+              <span className="block text-xs font-medium text-muted-foreground">#{story.story_number}</span>
+            ) : null}
             {editingTitle ? (
               <div className="space-y-2">
                 <input

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -3,6 +3,8 @@ import type { SendAttachment } from '@/hooks/use-chat-sse';
 
 export interface KanbanStory {
   id: string;
+  // story 9ac9b80f: 프로젝트 내 사람-읽는 순차 #N. 서버 채번, 백필 전 구스토리는 null 가능.
+  story_number?: number | null;
   title: string;
   status: string;
   priority: string;

--- a/packages/core-storage/src/interfaces/IStoryRepository.ts
+++ b/packages/core-storage/src/interfaces/IStoryRepository.ts
@@ -9,6 +9,9 @@ export interface Story {
   epic_id: string | null;
   sprint_id: string | null;
   assignee_id: string | null;
+  // story 9ac9b80f(BE #2222): 프로젝트 내 사람-읽는 순차 #N. 서버 채번(allocate_story_number)
+  // 전용, client-settable 아님. 구 스토리는 백필 전이면 null일 수 있음(정직 미표시).
+  story_number: number | null;
   title: string;
   status: string;
   priority: string;


### PR DESCRIPTION
## 요약
BE PR#2222(story 9ac9b80f)로 `story_number`(프로젝트별 사람-읽는 순차 #N)가 API/prod에 이미 서빙 중이었으나 FE 어디에도 렌더되지 않던 갭. 선생님이 prod 직접 대면 확認해 발견 — 전 세션이 BE만 짓고 done 마킹한 실책 재발 방지가 이번 스토리의 핵심 목적.

## 변경
- `packages/core-storage`: `Story` 인터페이스에 `story_number: number | null` 필드 선언 추가. `ApiStoryRepository`는 BE 원본 JSON을 그대로 통과시키는 구조라(필드별 매핑 없음) 타입 선언만으로 충분 — repository/route 레이어 무변경.
- `KanbanStory` 타입에도 동일 필드 추가(optional).
- 렌더 표면 4곳:
  1. 칸반 보드 스토리 카드 — claim(제목) 앞에 `#N ` 접두, hover tooltip도 구 UUID slice 대신 `#N`
  2. 스토리 상세 패널 — 제목 위 뮤트 라벨로 `#N`
  3. 리스트뷰(kanban-list-view) 행 — 제목 앞 `#N`
  4. ⌘K 커맨드 팔레트 — 스토리 컨텍스트 칩에 `#N` 포함
- `story_number`가 null(백필 전 구스토리)이면 `#N` 완전 생략 — no-fiction.
- breadcrumb/story-search: 그라운딩 결과 현재 FE에 별도 story breadcrumb·story search 서페이스 자체가 존재하지 않아(존재하지 않는 걸 만들지 않음) 해당 없음.

## 게이트
- `tsc --noEmit`: 0 error
- `pnpm lint`: 0 error
- `pnpm build`: exit 0
- `vitest`: 263 files / 1803 tests all green — command-palette에 신규 테스트 2건(#N 표기 + null 생략) 추가

## done-gate (⚠️ 중요)
데이터/게이트 레벨 확認만으로는 done 아님 — dev 배포 후 실 UI 스크린샷으로 카드에 `#N`이 실제로 뜨는 것 확認 예정. 까심 QA도 육안 UI 검수 요청.

🤖 Generated with [Claude Code](https://claude.com/claude-code)