### PR TITLE
[SID:04377271-선행] 목표 화면 하드코딩 "에픽" 잔존 8곳 소거

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/[id]/page.tsx
@@ -222,12 +222,12 @@ export default function EpicDetailPage() {
       const res = await fetch(`/api/goals/${epic.id}`, { method: 'DELETE' });
       if (!res.ok) {
         const json = await res.json().catch(() => null) as { error?: { message?: string } } | null;
-        addToast({ type: 'error', title: json?.error?.message ?? '에픽 삭제에 실패했습니다.' });
+        addToast({ type: 'error', title: json?.error?.message ?? '목표 삭제에 실패했습니다.' });
         return;
       }
       router.replace(`/${wsSlug}/${projSlug}/goals`);
     } catch {
-      addToast({ type: 'error', title: '에픽 삭제에 실패했습니다.' });
+      addToast({ type: 'error', title: '목표 삭제에 실패했습니다.' });
     } finally {
       setDeleting(false);
       setShowDeleteConfirm(false);
@@ -264,7 +264,7 @@ export default function EpicDetailPage() {
           <div className="flex items-center gap-2">
             <Link href={`/${wsSlug}/${projSlug}/goals`} className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
               <ArrowLeft className="h-3.5 w-3.5" />
-              에픽 목록
+              목표 목록
             </Link>
             <span className="text-muted-foreground">/</span>
             <span className="text-sm font-medium truncate max-w-[200px]">{epic.title}</span>
@@ -290,7 +290,7 @@ export default function EpicDetailPage() {
                 type="button"
                 onClick={() => setShowDeleteConfirm(true)}
                 className="flex items-center gap-1.5 rounded-lg border border-destructive/40 px-2.5 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10 transition-colors"
-                aria-label="에픽 삭제"
+                aria-label="목표 삭제"
               >
                 <Trash2 className="h-3.5 w-3.5" />
                 삭제
@@ -433,9 +433,9 @@ export default function EpicDetailPage() {
       <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>에픽을 삭제하시겠습니까?</DialogTitle>
+            <DialogTitle>목표를 삭제하시겠습니까?</DialogTitle>
             <DialogDescription>
-              이 작업은 되돌릴 수 없습니다. 에픽에 포함된 스토리는 연결이 해제됩니다.
+              이 작업은 되돌릴 수 없습니다. 목표에 포함된 스토리는 연결이 해제됩니다.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/goals/goals-client.tsx
@@ -254,7 +254,7 @@ function GoalCreateForm({ projectId, orgId, onCreated, onCancel }: GoalCreateFor
       await wireDeclarations(data.id);
       onCreated(data);
     } catch {
-      setError('에픽 생성에 실패했습니다. 다시 시도해 주세요.');
+      setError('목표 생성에 실패했습니다. 다시 시도해 주세요.');
     } finally {
       setSubmitting(false);
     }
@@ -391,7 +391,7 @@ function GoalEditForm({ epic, onSaved, onCancel }: GoalEditFormProps) {
       const { data } = await res.json() as { data: Goal };
       onSaved({ ...data, stories: epic.stories });
     } catch {
-      setError('에픽 수정에 실패했습니다. 다시 시도해 주세요.');
+      setError('목표 수정에 실패했습니다. 다시 시도해 주세요.');
     } finally {
       setSubmitting(false);
     }
@@ -934,11 +934,11 @@ export function GoalsClient({ projectId, orgId }: GoalsClientProps) {
       const res = await fetch(`/api/goals/${id}`, { method: 'DELETE' });
       if (!res.ok) {
         const json = await res.json().catch(() => null) as { error?: { message?: string } } | null;
-        addToast({ type: 'error', title: json?.error?.message ?? '에픽 삭제에 실패했습니다.' });
+        addToast({ type: 'error', title: json?.error?.message ?? '목표 삭제에 실패했습니다.' });
         void fetchGoals();
       }
     } catch {
-      addToast({ type: 'error', title: '에픽 삭제에 실패했습니다.' });
+      addToast({ type: 'error', title: '목표 삭제에 실패했습니다.' });
       void fetchGoals();
     } finally {
       setDeleting(false);
@@ -1156,9 +1156,9 @@ export function GoalsClient({ projectId, orgId }: GoalsClientProps) {
       <Dialog open={!!deleteConfirmId} onOpenChange={(open) => { if (!open) setDeleteConfirmId(null); }}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>에픽을 삭제하시겠습니까?</DialogTitle>
+            <DialogTitle>목표를 삭제하시겠습니까?</DialogTitle>
             <DialogDescription>
-              이 작업은 되돌릴 수 없습니다. 에픽에 포함된 스토리는 연결이 해제됩니다.
+              이 작업은 되돌릴 수 없습니다. 목표에 포함된 스토리는 연결이 해제됩니다.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>


### PR DESCRIPTION
## 요약
B1(#2226) 라벨 sweep이 `messages/ko.json` 경유 i18n 카피만 잡아, `goals-client.tsx`/`[id]/page.tsx`에 하드코딩된 리터럴 문자열은 놓쳤음. 오르테가 라이브검증에서 breadcrumb 1건("에픽 목록") 발견 → 동일 파일 grep으로 나머지 7건 추가 확認, 전량 즉시 수정.

## 변경
- `[id]/page.tsx`: breadcrumb "에픽 목록"→"목표 목록", 삭제 에러토스트 2건, aria-label, 삭제확인 다이얼로그 제목/본문
- `goals-client.tsx`: 생성/수정/삭제 에러토스트 4건, 삭제확인 다이얼로그 제목/본문

작은 후속정리 성격이라 04377271과 별개로 지금 바로 처리(오르테가 승인).

## 게이트
- tsc: 0 error / lint: 0 error / vitest: 263 files·1807 tests 전체 그린

🤖 Generated with [Claude Code](https://claude.com/claude-code)