### PR TITLE
[FR-only prod 승격] story_number FE #N 표기 — cherry-pick #2227 (리네이밍/OAuth 제외)

### DIFF
--- a/apps/web/src/components/command-palette/command-palette.test.tsx
+++ b/apps/web/src/components/command-palette/command-palette.test.tsx
@@ -20,10 +20,10 @@ vi.mock('next/navigation', () => ({ useRouter: () => ({ push: pushMock }) }));
 let container: HTMLDivElement;
 let root: Root;
 
-function stubFetch() {
+function stubFetch(storyOverrides: Record<string, unknown> = {}) {
   return vi.fn(async (url: string) => {
     if (url.startsWith('/api/stories/')) {
-      return { ok: true, status: 200, json: async () => ({ data: { id: 's1', title: '웰컴 이메일 시안' } }) };
+      return { ok: true, status: 200, json: async () => ({ data: { id: 's1', title: '웰컴 이메일 시안', ...storyOverrides } }) };
     }
     return { ok: true, status: 200, json: async () => ({ data: [] }) };
   }) as unknown as typeof fetch;
@@ -80,6 +80,25 @@ describe('CommandPalette — action commands (story 4f991165)', () => {
     await mount({ contextStoryId: 's1' });
     expect(document.body.textContent).toContain('웰컴 이메일 시안 · 스토리');
     expect(document.body.textContent).toContain('웰컴 이메일 시안 위임하기');
+  });
+
+  it('story 9ac9b80f — context chip prefixes the human-readable #N when story_number is present', async () => {
+    vi.stubGlobal('fetch', stubFetch({ story_number: 42 }));
+    await mount({ contextStoryId: 's1' });
+    const chip = document.querySelector('.border-b.border-border\\/60.bg-muted\\/30');
+    expect(chip).toBeDefined();
+    expect(chip!.textContent).toBe('◆#42 웰컴 이메일 시안 · 스토리');
+  });
+
+  it('story 9ac9b80f — omits the #N prefix when story_number is null (pre-backfill story, no-fiction)', async () => {
+    vi.stubGlobal('fetch', stubFetch({ story_number: null }));
+    await mount({ contextStoryId: 's1' });
+    // 까심 QA(#2227 RC): '#null' 문자열만 부재 확認으론 '#undefined'류 인접 버그를 못 잡는다 —
+    // 칩 엘리먼트 자체의 정확한 텍스트를 assert해 어떤 형태의 조작된 '#...' 접두도 차단.
+    const chip = document.querySelector('.border-b.border-border\\/60.bg-muted\\/30');
+    expect(chip).toBeDefined();
+    expect(chip!.textContent).toBe('◆웰컴 이메일 시안 · 스토리');
+    expect(chip!.textContent).not.toMatch(/#/);
   });
 
   it('flags the gate-decision command as a sensitive/danger pill (amber, not red — learning-signal)', async () => {

--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -40,6 +40,7 @@ interface DocResult {
 interface StoryTitleResult {
   id: string;
   title: string;
+  story_number?: number | null;
 }
 
 const ITEMS: CommandItem[] = [
@@ -87,8 +88,8 @@ export function CommandPalette({ open, onOpenChange, projectId, contextStoryId }
       try {
         const res = await fetch(`/api/stories/${contextStoryId}`);
         if (!res.ok) return;
-        const json = (await res.json()) as { data?: { id: string; title: string } };
-        if (!cancelled && json.data) setContextStory({ id: json.data.id, title: json.data.title });
+        const json = (await res.json()) as { data?: { id: string; title: string; story_number?: number | null } };
+        if (!cancelled && json.data) setContextStory({ id: json.data.id, title: json.data.title, story_number: json.data.story_number });
       } catch { /* no-fiction: 조회 실패면 그냥 context 없음과 동일 취급 */ }
     })();
     return () => { cancelled = true; };
@@ -244,7 +245,7 @@ export function CommandPalette({ open, onOpenChange, projectId, contextStoryId }
           {contextStory ? (
             <div className="flex items-center gap-1.5 border-b border-border/60 bg-muted/30 px-3 py-1.5 text-[11px] text-muted-foreground">
               <span className="text-info" aria-hidden="true">◆</span>
-              {t('contextChip', { title: contextStory.title })}
+              {t('contextChip', { title: contextStory.story_number ? `#${contextStory.story_number} ${contextStory.title}` : contextStory.title })}
             </div>
           ) : null}
 

--- a/apps/web/src/components/kanban/kanban-list-view.tsx
+++ b/apps/web/src/components/kanban/kanban-list-view.tsx
@@ -69,7 +69,10 @@ function ListStoryRow({ story, epicMap, memberMap, onStoryClick, onChangeStatus 
             <span className="text-[10px] text-muted-foreground">{t('storyPointsBadge', { count: story.story_points })}</span>
           )}
         </div>
-        <p className="mt-1 text-sm font-medium text-foreground line-clamp-2 relative z-10">{story.title}</p>
+        <p className="mt-1 text-sm font-medium text-foreground line-clamp-2 relative z-10">
+          {story.story_number ? <span className="mr-1 text-muted-foreground">#{story.story_number}</span> : null}
+          {story.title}
+        </p>
         {story.assignee_id && memberMap[story.assignee_id] && (
           <div className="mt-1 flex items-center gap-2 relative z-10">
             <p className="text-xs text-muted-foreground">{memberMap[story.assignee_id].name}</p>

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -243,7 +243,7 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
       {...listeners}
       onClick={onClick}
       onContextMenu={handleContextMenu}
-      title={`#${story.id.slice(0, 6)}`}
+      title={story.story_number ? `#${story.story_number}` : story.title}
       className="group relative cursor-pointer transition"
     >
       {/* E-UI-DAEGBYEON P0 — Board card = Proof Capsule(card density, #bf9037cb). 시각 셸만
@@ -255,7 +255,7 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
         density="card"
         proofState={proofState}
         stateLabel={proofStateLabel}
-        claim={story.title}
+        claim={story.story_number ? `#${story.story_number} ${story.title}` : story.title}
         footer={
           <div className="mt-2">
             {/* E-MODERN A: 에픽 = 작은 색 dot + muted 라벨(일관 식별·랜덤 채움배지 퇴출) */}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -736,6 +736,9 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
       <div className="flex h-full flex-col">
         <div className="flex items-start justify-between border-b border-border p-5">
           <div className="flex-1 space-y-2 pr-3">
+            {story.story_number ? (
+              <span className="block text-xs font-medium text-muted-foreground">#{story.story_number}</span>
+            ) : null}
             {editingTitle ? (
               <div className="space-y-2">
                 <input

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -3,6 +3,8 @@ import type { SendAttachment } from '@/hooks/use-chat-sse';
 
 export interface KanbanStory {
   id: string;
+  // story 9ac9b80f: 프로젝트 내 사람-읽는 순차 #N. 서버 채번, 백필 전 구스토리는 null 가능.
+  story_number?: number | null;
   title: string;
   status: string;
   priority: string;

--- a/packages/core-storage/src/interfaces/IStoryRepository.ts
+++ b/packages/core-storage/src/interfaces/IStoryRepository.ts
@@ -9,6 +9,9 @@ export interface Story {
   epic_id: string | null;
   sprint_id: string | null;
   assignee_id: string | null;
+  // story 9ac9b80f(BE #2222): 프로젝트 내 사람-읽는 순차 #N. 서버 채번(allocate_story_number)
+  // 전용, client-settable 아님. 구 스토리는 백필 전이면 null일 수 있음(정직 미표시).
+  story_number: number | null;
   title: string;
   status: string;
   priority: string;


### PR DESCRIPTION
근거: 선생님 지시(2026-07-16)·대표 FR(이슈 ID 넘버링)의 **FE 표기가 dev 완결인데 prod 미승격**(BE는 #2223로 이미 prod·FE만 누락→대표가 #N 못 봄).

**스코프**: #2227(story_number FE — 보드 카드·리스트·상세·⌘K 팔레트 #N 표기) 단독 cherry-pick(`f2b64da`). 리네이밍(에픽→목표)·OAuth **미포함**.

**격리 실측**: story 컴포넌트(kanban card/list/detail·command-palette)만 건드리고 goal-renamed 심볼 0건·FK `epic_id` 무변경분이라 #2226(리네이밍) **무의존** → clean cherry-pick(conflict 0·7 files·+39/-8). 마이그레이션 없음(FE-only).

**검증**: 오르테가 dev UI 실측 #N 렌더 확認 완(#1928·#1775 등). CI green 후 admin-merge→prod 배포→**prod app.sprintable.ai #N 실측**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)