### PR TITLE
fix(auth): oauth-handoff redirect Cloud Run 내부 bind(0.0.0.0:3000) 버그 — resolveAppUrl 사용 (선생님 라이브 3번째 에러)

### DIFF
--- a/apps/web/src/app/auth/oauth-handoff/route.test.ts
+++ b/apps/web/src/app/auth/oauth-handoff/route.test.ts
@@ -148,7 +148,7 @@ describe('POST /auth/oauth-handoff', () => {
 
     const res = await POST(makeJsonRequest({ code: 'valid-code', code_verifier: 'valid-verifier' }));
     expect(res.status).toBe(303);
-    expect(res.headers.get('location')).toBe('http://localhost/glance');
+    expect(res.headers.get('location')).toBe('http://localhost:3108/glance');
     expect(res.headers.get('cache-control')).toBe('no-store');
     expect(res.headers.get('referrer-policy')).toBe('no-referrer');
 
@@ -168,6 +168,6 @@ describe('POST /auth/oauth-handoff', () => {
     process.env['FIREBASE_OAUTH_HANDOFF_ENABLED'] = 'true';
     mockFetch.mockResolvedValue({ ok: true, json: async () => ({ access_token: 'at', refresh_token: 'rt' }) });
     const res = await POST(makeJsonRequest({ code: 'c', code_verifier: 'v', redirect_path: '//evil.com/phish' }));
-    expect(res.headers.get('location')).toBe('http://localhost/glance');
+    expect(res.headers.get('location')).toBe('http://localhost:3108/glance');
   });
 });

--- a/apps/web/src/app/auth/oauth-handoff/route.ts
+++ b/apps/web/src/app/auth/oauth-handoff/route.ts
@@ -25,6 +25,7 @@ import { NextResponse } from 'next/server';
 import { verifyCsrfOrigin } from '@/lib/auth/csrf';
 import { cookieBase, SP_AT_MAX_AGE_SECONDS } from '@/lib/auth/cookies';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
+import { resolveAppUrl } from '@/services/app-url';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -108,7 +109,11 @@ export async function POST(request: Request) {
 
   // §10.9: 리다이렉트 목적지는 상대경로 고정(/glance) — client-supplied redirect_path 없음
   // (attested /auth/native와 달리 이 흐름엔 그런 파라미터 자체가 계약에 없다).
-  const res = NextResponse.redirect(new URL('/glance', request.url), 303);
+  // ⚠️base는 request.url이 아니라 resolveAppUrl()이어야 한다 — Cloud Run에서 request.url의
+  // origin이 내부 bind 주소(0.0.0.0:PORT)로 해석돼 웹뷰가 unreachable host로 리다이렉트되는
+  // 사고를 오르테가 실측으로 잡았다(선생님 3번째 에러 근본원인). /api/auth/callback/[provider]
+  // 의 origin(=resolveAppUrl(null)) 패턴과 동일하게 맞춘다.
+  const res = NextResponse.redirect(`${resolveAppUrl(null)}/glance`, 303);
   res.headers.set('Cache-Control', 'no-store');
   res.headers.set('Referrer-Policy', 'no-referrer');
   res.cookies.set(SP_AT_COOKIE, consumeJson.access_token, { ...cookieBase(), maxAge: SP_AT_MAX_AGE_SECONDS });


### PR DESCRIPTION
선생님 실기기 OAuth 로그인 3번째 에러 `0.0.0.0:3000 연결불가` 근본원인 fix.

**버그**: `oauth-handoff/route.ts:111` `NextResponse.redirect(new URL('/glance', request.url), 303)` — Cloud Run에서 `request.url`의 origin이 컨테이너 내부 bind(0.0.0.0:PORT)로 해석돼 웹뷰가 unreachable host로 리다이렉트.

**fix**: base를 `resolveAppUrl(null)`(=NEXT_PUBLIC_APP_URL=`https://dev-app.sprintable.ai`)로 — callback route의 origin 패턴과 통일. +테스트 갱신.

미르코 원커밋(c133b4d0·#2230 머지 후 추가분)을 develop로 cherry-pick. 오르테가 grep 교차검증+diff 리뷰 완. 배포 후 미르코 curl로 issue→consume→redirect Location=dev-app 전 구간 실증 예정. `/auth/native:161` 동일 패턴은 후속(457fea6d).

🤖 Generated with [Claude Code](https://claude.com/claude-code)