### PR TITLE
fix(push): 앱 푸시 디바이스 등록 BFF 라우트 신설

### DIFF
--- a/apps/web/src/app/api/push/devices/route.test.ts
+++ b/apps/web/src/app/api/push/devices/route.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// story: 앱 push register가 /api/v2/push/devices 직접 POST(Bearer 미첨부)해 401 —
+// 웹 인증 API 관례(/api/<resource> BFF → proxyToFastapi → 백엔드)에 맞춰 신설.
+const { proxyToFastapi } = vi.hoisted(() => ({ proxyToFastapi: vi.fn() }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
+
+import { GET, POST } from './route';
+
+const PATH = '/api/v2/push/devices';
+const okRes = (b: unknown = { ok: 1 }) =>
+  new Response(JSON.stringify(b), { status: 200, headers: { 'content-type': 'application/json' } });
+const req = (m = 'GET') => new Request('http://localhost/x', { method: m });
+
+describe('/api/push/devices (proxy 위임)', () => {
+  beforeEach(() => proxyToFastapi.mockReset());
+  for (const [name, fn] of [['GET', GET], ['POST', POST]] as const) {
+    it(`${name}: delegates to ${PATH} and wraps`, async () => {
+      proxyToFastapi.mockResolvedValue(okRes());
+      const res = await fn(req(name));
+      expect(res.status).toBe(200);
+      expect(proxyToFastapi).toHaveBeenCalledWith(expect.anything(), PATH);
+      expect((await res.json()).data).toMatchObject({ ok: 1 });
+    });
+    it(`${name}: passes through proxy errors`, async () => {
+      proxyToFastapi.mockResolvedValue(new Response('e', { status: 500 }));
+      expect((await fn(req(name))).status).toBe(500);
+    });
+  }
+});

--- a/apps/web/src/app/api/push/devices/route.ts
+++ b/apps/web/src/app/api/push/devices/route.ts
@@ -1,0 +1,21 @@
+import { apiSuccess } from '@/lib/api-response';
+import { handleApiError } from '@/lib/api-error';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function GET(request: Request) {
+  try {
+    const _r = await proxyToFastapi(request, '/api/v2/push/devices');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
+  } catch (error) { return handleApiError(error); }
+}
+
+export async function POST(request: Request) {
+  try {
+    const _r = await proxyToFastapi(request, '/api/v2/push/devices');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
+  } catch (error) { return handleApiError(error); }
+}


### PR DESCRIPTION
## Summary
- 앱(민, A2) push register가 `/api/v2/push/devices` 백엔드를 직접 POST — 웹 인증 API 관례(`/api/<resource>` BFF → `proxyToFastapi`(Bearer 첨부) → 백엔드)를 안 거쳐 401.
- `apps/web/src/app/api/push/devices/route.ts` 신설: GET(self-list)/POST(register) 둘 다 `/api/v2/push/devices`로 프록시 위임(기존 `agent-runs/route.ts` 패턴 동일 적용).
- backend `ee/routers/push_devices.py` 확認: `GET/POST /devices`, `DELETE /devices/{id}` (EE 게이트, `is_ee_enabled` 시에만 등록) — 이번 fix는 GET/POST만(DELETE는 요청 스코프 밖, 필요시 후속).

## Test plan
- [x] `pnpm run type-check` — 0 에러
- [x] `pnpm run lint` — 0 에러(기존 무관 warning 5개만)
- [x] `pnpm run build` — EXIT 0, `/api/push/devices` 라우트 등록 확認
- [x] `vitest` — 4/4 PASS (GET/POST × delegates+error-passthrough)
- [ ] 배포 후 민(A2) 실기기 register/self-list 라운드트립 확認 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)