### PR TITLE
feat(i18n): Proof Capsule 컴포넌트 전면 국제화 — EN 로케일 한국어 하드코딩 fix

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -281,6 +281,31 @@
     "sprintCycleProgress": "Time elapsed",
     "agentsActive": "{count} active"
   },
+  "proofCapsule": {
+    "claim": {
+      "label": "Claim · Agent says done",
+      "executor": "By {name}",
+      "now": "Now: <b>{now}</b>",
+      "running": "Running"
+    },
+    "evidence": {
+      "label": "Evidence · Against requirements",
+      "acMet": "AC {met}/{total} met",
+      "autoPassed": "Auto-check passed",
+      "autoFailed": "Auto-check failed",
+      "count": "{count} evidence"
+    },
+    "gate": {
+      "label": "Human gate · Human is accountable",
+      "owner": "Owned by <b>{name}</b>",
+      "risk": "Risk: {risk}"
+    },
+    "risk": {
+      "low": "Low",
+      "medium": "Medium",
+      "high": "High"
+    }
+  },
   "orgBriefing": {
     "title": "Org Briefing",
     "subtitle": "What's come to you, what we're learning, and who's on what — at a glance.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -281,6 +281,31 @@
     "sprintCycleProgress": "기간 진행",
     "agentsActive": "{count}명 활성"
   },
+  "proofCapsule": {
+    "claim": {
+      "label": "Claim · 에이전트 완료 주장",
+      "executor": "실행 {name}",
+      "now": "지금: <b>{now}</b>",
+      "running": "실행 중"
+    },
+    "evidence": {
+      "label": "Evidence · 요구 대조",
+      "acMet": "AC {met}/{total} 충족",
+      "autoPassed": "자동검증 passed",
+      "autoFailed": "자동검증 failed",
+      "count": "증거 {count}건"
+    },
+    "gate": {
+      "label": "Human gate · 인간이 책임집니다",
+      "owner": "책임 <b>{name}</b>",
+      "risk": "위험도 {risk}"
+    },
+    "risk": {
+      "low": "낮음",
+      "medium": "보통",
+      "high": "높음"
+    }
+  },
   "orgBriefing": {
     "title": "조직 브리핑",
     "subtitle": "내게 온 요청, 우리가 배우는 것, 누가 무엇을 맡고 있는지 — 한눈에.",

--- a/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.test.tsx
@@ -2,11 +2,20 @@ import { describe, expect, it } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { NextIntlClientProvider } from 'next-intl';
 import koMessages from '../../../messages/ko.json';
+import enMessages from '../../../messages/en.json';
 import { ProofCapsule, type ProofCapsuleProps, type ProofState } from './proof-capsule';
 
 function renderWithIntl(node: React.ReactNode) {
   return renderToStaticMarkup(
     <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>,
+  );
+}
+
+function renderWithIntlEn(node: React.ReactNode) {
+  return renderToStaticMarkup(
+    <NextIntlClientProvider locale="en" messages={enMessages} timeZone="Asia/Seoul">
       {node}
     </NextIntlClientProvider>,
   );
@@ -30,14 +39,14 @@ const STATES: { state: ProofState; label: string }[] = [
 describe('ProofCapsule (density variants)', () => {
   it('renders the claim text in all four density variants', () => {
     for (const density of ['full', 'card', 'row', 'audit'] as const) {
-      const markup = renderToStaticMarkup(<ProofCapsule {...BASE} density={density} />);
+      const markup = renderWithIntl(<ProofCapsule {...BASE} density={density} />);
       expect(markup).toContain(BASE.claim);
     }
   });
 
   it('applies a clip-path cut-corner on full/card/row (not a plain rounded-full pill anywhere)', () => {
     for (const density of ['full', 'card', 'row'] as const) {
-      const markup = renderToStaticMarkup(<ProofCapsule {...BASE} density={density} />);
+      const markup = renderWithIntl(<ProofCapsule {...BASE} density={density} />);
       expect(markup).toContain('polygon(');
     }
   });
@@ -46,7 +55,7 @@ describe('ProofCapsule (density variants)', () => {
 describe('ProofCapsule (4 proof states — 색만으로 의미 전달 금지, stateLabel 텍스트 항상 병기)', () => {
   for (const { state, label } of STATES) {
     it(`renders the "${label}" text alongside the ${state} state (not color-only)`, () => {
-      const markup = renderToStaticMarkup(<ProofCapsule {...BASE} proofState={state} stateLabel={label} density="full" />);
+      const markup = renderWithIntl(<ProofCapsule {...BASE} proofState={state} stateLabel={label} density="full" />);
       expect(markup).toContain(label);
     });
   }
@@ -54,14 +63,14 @@ describe('ProofCapsule (4 proof states — 색만으로 의미 전달 금지, st
 
 describe('ProofCapsule (optional fields — evidence/gate/agent 없이도 정직하게 렌더)', () => {
   it('renders without evidence, gate, or agent fields present (no "undefined" leaking into markup)', () => {
-    const markup = renderToStaticMarkup(<ProofCapsule {...BASE} density="full" />);
+    const markup = renderWithIntl(<ProofCapsule {...BASE} density="full" />);
     expect(markup).not.toContain('undefined');
     expect(markup).not.toContain('Evidence');
     expect(markup).not.toContain('Human gate');
   });
 
   it('renders the agent avatar distinctly from the human avatar when an agent is present', () => {
-    const markup = renderToStaticMarkup(
+    const markup = renderWithIntl(
       <ProofCapsule {...BASE} agent={{ name: '미르코', initial: '미' }} density="full" />,
     );
     expect(markup).toContain('실행 미르코');
@@ -69,7 +78,7 @@ describe('ProofCapsule (optional fields — evidence/gate/agent 없이도 정직
   });
 
   it('renders evidence and gate sections only when those props are provided', () => {
-    const markup = renderToStaticMarkup(
+    const markup = renderWithIntl(
       <ProofCapsule
         {...BASE}
         evidence={{ acMet: 4, acTotal: 4, autoVerify: 'passed', diff: { add: 142, del: 18 } }}
@@ -86,7 +95,7 @@ describe('ProofCapsule (optional fields — evidence/gate/agent 없이도 정직
 
 describe('ProofCapsule (안티패턴 자체 체크 — 도크트린 준수 회귀가드)', () => {
   it('never renders raw activity-log-style vocabulary or a KPI-style numeric-only summary', () => {
-    const markup = renderToStaticMarkup(
+    const markup = renderWithIntl(
       <ProofCapsule
         {...BASE}
         evidence={{ acMet: 4, acTotal: 4, proofCount: 3 }}
@@ -99,7 +108,7 @@ describe('ProofCapsule (안티패턴 자체 체크 — 도크트린 준수 회�
   });
 
   it('does not use a fully-rounded (999px pill) shape for the gate action button (small circular status dots are fine, buttons are not)', () => {
-    const markup = renderToStaticMarkup(
+    const markup = renderWithIntl(
       <ProofCapsule {...BASE} gate={{ risk: '보통', action: '결재 →' }} density="row" />,
     );
     const gateButtonMatch = markup.match(/<a class="([^"]*)"/);
@@ -109,7 +118,7 @@ describe('ProofCapsule (안티패턴 자체 체크 — 도크트린 준수 회�
   });
 
   it('supports a human/agent avatar + tone-varied gate button in row density (Attention Queue 재사용, 5f25c615)', () => {
-    const markup = renderToStaticMarkup(
+    const markup = renderWithIntl(
       <ProofCapsule
         {...BASE}
         density="row"
@@ -127,7 +136,7 @@ describe('ProofCapsule (human optional — Board card 확산, bf9037cb) — 다�
   it('renders full/audit density without a human prop, omitting the human-dependent UI instead of crashing or leaking "undefined"', () => {
     for (const density of ['full', 'audit'] as const) {
       const { human: _human, ...withoutHuman } = BASE;
-      const markup = renderToStaticMarkup(<ProofCapsule {...withoutHuman} density={density} />);
+      const markup = renderWithIntl(<ProofCapsule {...withoutHuman} density={density} />);
       expect(markup).not.toContain('undefined');
       expect(markup).not.toContain('책임');
     }
@@ -135,7 +144,7 @@ describe('ProofCapsule (human optional — Board card 확산, bf9037cb) — 다�
 
   it('omits the Human gate section when gate is provided but human is not (도크트린⑤ — 책임자 없이 게이트 없음)', () => {
     const { human: _human, ...withoutHuman } = BASE;
-    const markup = renderToStaticMarkup(
+    const markup = renderWithIntl(
       <ProofCapsule {...withoutHuman} gate={{ risk: '낮음', action: 'Merge gate 열기' }} density="full" />,
     );
     expect(markup).not.toContain('Human gate');
@@ -145,7 +154,7 @@ describe('ProofCapsule (human optional — Board card 확산, bf9037cb) — 다�
 
 describe('ProofCapsule (footer slot — card density, Board card 확산 실기능 이관)', () => {
   it('renders arbitrary footer content below the claim/evidence in card density', () => {
-    const markup = renderToStaticMarkup(
+    const markup = renderWithIntl(
       <ProofCapsule
         {...BASE}
         density="card"
@@ -157,7 +166,7 @@ describe('ProofCapsule (footer slot — card density, Board card 확산 실기�
 
   it('ignores the footer prop on non-card densities (no accidental leak)', () => {
     for (const density of ['full', 'row', 'audit'] as const) {
-      const markup = renderToStaticMarkup(
+      const markup = renderWithIntl(
         <ProofCapsule {...BASE} density={density} footer={<span>카드 전용 마커</span>} />,
       );
       expect(markup).not.toContain('카드 전용 마커');
@@ -213,5 +222,51 @@ describe('ProofCapsule (trustSeal slot — claimed-vs-verified-spec-handoff, ful
     const markup = renderWithIntl(<ProofCapsule {...BASE} density="full" />);
     expect(markup).not.toContain('책임 서명');
     expect(markup).not.toContain('검증 대기');
+  });
+});
+
+describe('ProofCapsule (EN locale — regression: 전면 하드코딩 한국어였던 것 i18n 배선, 유나 ko/en 카피 13키)', () => {
+  it('renders claim/evidence/gate/risk entirely in English, no raw Korean or raw i18n key leaking through', () => {
+    const markup = renderWithIntlEn(
+      <ProofCapsule
+        {...BASE}
+        agent={{ name: 'Alex', initial: 'A' }}
+        now="2h ago"
+        evidence={{ acMet: 4, acTotal: 4, autoVerify: 'passed', proofCount: 3 }}
+        gate={{ risk: '낮음', action: 'Open merge gate' }}
+        density="full"
+      />,
+    );
+    expect(markup).toContain('Claim · Agent says done');
+    expect(markup).toContain('By Alex');
+    expect(markup).toContain('Now: <b>2h ago</b>');
+    expect(markup).toContain('Evidence · Against requirements');
+    expect(markup).toContain('AC 4/4 met');
+    expect(markup).toContain('Auto-check passed');
+    expect(markup).toContain('3 evidence');
+    expect(markup).toContain('Human gate · Human is accountable');
+    expect(markup).toContain('Owned by');
+    expect(markup).toContain('Risk: Low');
+    // former hardcoded-Korean UI chrome must not survive in EN render (test fixture data like
+    // stateLabel/human.name is expected to stay whatever language the caller passes — only the
+    // component's own chrome strings are in scope here).
+    for (const formerHardcoded of ['실행', '책임', '위험도', '자동검증', '지금:', '증거', 'Human gate · 인간']) {
+      expect(markup).not.toContain(formerHardcoded);
+    }
+    expect(markup).not.toContain('proofCapsule.');
+  });
+
+  it('translates all three risk levels correctly (canonical ko literal -> EN label, not passthrough)', () => {
+    const cases = [
+      { risk: '낮음' as const, expected: 'Risk: Low' },
+      { risk: '보통' as const, expected: 'Risk: Medium' },
+      { risk: '높음' as const, expected: 'Risk: High' },
+    ];
+    for (const { risk, expected } of cases) {
+      const markup = renderWithIntlEn(
+        <ProofCapsule {...BASE} gate={{ risk, action: 'Review' }} density="full" />,
+      );
+      expect(markup).toContain(expected);
+    }
   });
 });

--- a/apps/web/src/components/proof-capsule/proof-capsule.tsx
+++ b/apps/web/src/components/proof-capsule/proof-capsule.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { startTransition, useEffect, useRef, useState, type ReactNode } from 'react';
+import { useTranslations } from 'next-intl';
 import { ArrowRight, Check, ChevronDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { initials } from '@/lib/storage/format';
@@ -29,7 +30,8 @@ export interface ProofCapsuleEvidence {
 }
 
 export interface ProofCapsuleGate {
-  /** full 밀도(Human gate)만 사용 — Attention Queue의 row 밀도는 위험도 표시가 없어 생략 가능. */
+  /** full 밀도(Human gate)만 사용 — Attention Queue의 row 밀도는 위험도 표시가 없어 생략 가능.
+   * 값 자체는 canonical(비-i18n) 식별자 — 표시 시점에 `proofCapsule.risk.*` 로 번역(§RISK_KEY). */
   risk?: '낮음' | '보통' | '높음';
   action: string;
   href?: string;
@@ -145,7 +147,13 @@ export function ProofAvatar({ label, isAgent, size = 19 }: { label: string; isAg
   );
 }
 
+/** canonical(비-i18n) risk 식별자 → `proofCapsule.risk.*` 번역키. */
+const RISK_KEY: Record<NonNullable<ProofCapsuleGate['risk']>, 'low' | 'medium' | 'high'> = {
+  '낮음': 'low', '보통': 'medium', '높음': 'high',
+};
+
 function EvidenceRow({ evidence, sweep }: { evidence: ProofCapsuleEvidence; sweep: boolean }) {
+  const t = useTranslations('proofCapsule');
   return (
     <div className="relative mt-3.5 border-t border-proof-line-soft pt-3">
       {sweep ? (
@@ -155,23 +163,23 @@ function EvidenceRow({ evidence, sweep }: { evidence: ProofCapsuleEvidence; swee
         />
       ) : null}
       <div className="mb-2 text-[8.5px] font-bold uppercase tracking-[0.12em] text-proof-faint">
-        Evidence · 요구 대조
+        {t('evidence.label')}
       </div>
       <div className="flex flex-wrap items-center gap-3.5 text-[13px] leading-[1.45] text-proof-ink-2">
         {evidence.acMet != null && evidence.acTotal != null ? (
           <span className="inline-flex items-center gap-1">
             <Check className="motion-safe:animate-proof-check-in size-3.5 text-proof-green" strokeWidth={3} aria-hidden="true" />
-            AC {evidence.acMet}/{evidence.acTotal} 충족
+            {t('evidence.acMet', { met: evidence.acMet, total: evidence.acTotal })}
           </span>
         ) : null}
         {evidence.autoVerify === 'passed' ? (
           <span className="inline-flex items-center gap-1">
             <Check className="motion-safe:animate-proof-check-in size-3.5 text-proof-green" strokeWidth={3} aria-hidden="true" />
-            자동검증 passed
+            {t('evidence.autoPassed')}
           </span>
         ) : null}
         {evidence.autoVerify === 'failed' ? (
-          <span className="text-proof-red">자동검증 failed</span>
+          <span className="text-proof-red">{t('evidence.autoFailed')}</span>
         ) : null}
         {evidence.diff ? (
           <span className="font-mono text-[11px] text-proof-ink-3">diff +{evidence.diff.add} / −{evidence.diff.del}</span>
@@ -180,7 +188,7 @@ function EvidenceRow({ evidence, sweep }: { evidence: ProofCapsuleEvidence; swee
       {evidence.proofCount != null ? (
         <div className="mt-2 inline-flex items-center gap-1 text-[11px] text-proof-ink-3">
           <ChevronDown className="size-3" aria-hidden="true" />
-          증거 {evidence.proofCount}건
+          {t('evidence.count', { count: evidence.proofCount })}
         </div>
       ) : null}
     </div>
@@ -188,14 +196,17 @@ function EvidenceRow({ evidence, sweep }: { evidence: ProofCapsuleEvidence; swee
 }
 
 function GateRow({ gate, human }: { gate: ProofCapsuleGate; human: ProofCapsuleHuman }) {
+  const t = useTranslations('proofCapsule');
   return (
     <div className="mt-3.5 border-t border-proof-line-soft pt-3">
       <div className="mb-2 text-[8.5px] font-bold uppercase tracking-[0.12em] text-proof-faint">
-        Human gate · 인간 = 책임 주체
+        {t('gate.label')}
       </div>
       <div className="flex flex-wrap items-center gap-3.5 text-[13px] text-proof-ink-2">
-        <span>책임 <b className="text-proof-ink">{human.name}</b></span>
-        {gate.risk ? <span className="font-mono text-[10.5px]">위험도 {gate.risk}</span> : null}
+        <span>{t.rich('gate.owner', { name: human.name, b: (chunks) => <b className="text-proof-ink">{chunks}</b> })}</span>
+        {gate.risk ? (
+          <span className="font-mono text-[10.5px]">{t('gate.risk', { risk: t(`risk.${RISK_KEY[gate.risk]}`) })}</span>
+        ) : null}
         <a
           href={gate.href}
           className="ml-auto inline-flex items-center gap-1 rounded-[6px] border border-proof-blue bg-proof-blue-soft px-3 py-1 text-[11.5px] font-semibold text-proof-blue transition-colors duration-[140ms] hover:bg-proof-blue hover:text-white"
@@ -227,27 +238,34 @@ function useEvidenceSweep(evidence: ProofCapsuleEvidence | undefined) {
 function FullVariant({
   proofState, stateLabel, claim, human, agent, now, evidence, gate, trustSeal, className,
 }: Omit<ProofCapsuleProps, 'density'>) {
+  const t = useTranslations('proofCapsule');
   const sweep = useEvidenceSweep(evidence);
   return (
     <CutCornerShell state={proofState} cut={24} className={className}>
       <div className="min-w-0 flex-1 px-4.5 py-4">
         <StateHeader state={proofState} label={stateLabel} />
         <div className="mb-1 mt-3 text-[8.5px] font-bold uppercase tracking-[0.12em] text-proof-faint">
-          Claim · 에이전트 완료 주장
+          {t('claim.label')}
         </div>
         <div className="text-[19px] font-bold leading-[1.25] tracking-[-0.012em] text-proof-ink">{claim}</div>
         <div className="mt-2.5 flex flex-wrap items-center gap-3 text-[11px] text-proof-ink-3">
           {human ? (
-            <span className="inline-flex items-center gap-1.5"><ProofAvatar label={initials(human.name)} />책임 {human.name}</span>
+            <span className="inline-flex items-center gap-1.5">
+              <ProofAvatar label={initials(human.name)} />
+              {t.rich('gate.owner', { name: human.name, b: (chunks) => <>{chunks}</> })}
+            </span>
           ) : null}
           {agent ? (
-            <span className="inline-flex items-center gap-1.5"><ProofAvatar label={agent.initial} isAgent />실행 {agent.name}</span>
+            <span className="inline-flex items-center gap-1.5">
+              <ProofAvatar label={agent.initial} isAgent />
+              {t('claim.executor', { name: agent.name })}
+            </span>
           ) : null}
-          {now ? <span className="text-proof-ink-2">지금: <b>{now}</b></span> : null}
+          {now ? <span className="text-proof-ink-2">{t.rich('claim.now', { now, b: (chunks) => <b>{chunks}</b> })}</span> : null}
           {proofState === 'blue' ? (
             <span className="inline-flex items-center gap-1.5 text-[10px] text-proof-ink-3">
               <span className="motion-safe:animate-proof-pulse size-1.5 rounded-full bg-proof-citron" aria-hidden="true" />
-              실행 중
+              {t('claim.running')}
             </span>
           ) : null}
         </div>

--- a/apps/web/src/components/workcell/workcell.test.tsx
+++ b/apps/web/src/components/workcell/workcell.test.tsx
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
 import { Workcell, type WorkcellProps } from './workcell';
 
 const BASE: WorkcellProps = {
@@ -78,16 +80,20 @@ describe('Workcell Evidence layer (Proof Capsule 재사용 · null=정직한 빈
   });
 
   it('renders the actual ProofCapsule component when evidence is provided', () => {
+    // ProofCapsule의 FullVariant/EvidenceRow/GateRow가 proofCapsule i18n 배선(useTranslations)을
+    // 쓰므로 NextIntlClientProvider 필수(다른 Workcell 테스트는 evidence=null이라 이 경로를 안 탐).
     const markup = renderToStaticMarkup(
-      <Workcell
-        {...BASE}
-        evidence={{
-          proofState: 'green', stateLabel: '증명 완료', claim: '재시도 로직 구현 완료',
-          human: { name: '윤재', role: 'human' }, density: 'full',
-          evidence: { acMet: 4, acTotal: 4, autoVerify: 'passed' },
-          gate: { risk: '낮음', action: 'Merge gate 열기' },
-        }}
-      />,
+      <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+        <Workcell
+          {...BASE}
+          evidence={{
+            proofState: 'green', stateLabel: '증명 완료', claim: '재시도 로직 구현 완료',
+            human: { name: '윤재', role: 'human' }, density: 'full',
+            evidence: { acMet: 4, acTotal: 4, autoVerify: 'passed' },
+            gate: { risk: '낮음', action: 'Merge gate 열기' },
+          }}
+        />
+      </NextIntlClientProvider>,
     );
     expect(markup).toContain('재시도 로직 구현 완료');
     expect(markup).toContain('AC 4/4');


### PR DESCRIPTION
## Summary
- `proof-capsule.tsx`(Sprintable 시그니처 신뢰 표면 — Claim/Evidence/Human gate)가 **전 UI 텍스트를 하드코딩 한국어로 렌더**하고 있었음(`t()` 호출 자체가 없어 로케일 무관 항상 한국어) — 실 EN 프로덕션 버그. 랜딩 증빙 스샷(EN mock) 렌더 검증 중 발견.
- `proofCapsule` 신규 i18n 네임스페이스(ko/en, 유나 홀름 카피 13키) 추가 + `FullVariant`/`EvidenceRow`/`GateRow`에 `useTranslations` 배선.
- `risk` prop 타입(`'낮음'|'보통'|'높음'`)은 **canonical 값 그대로 유지**(기존 호출부 무변경, breaking change 회피) — 표시 시점에만 `RISK_KEY` 매핑으로 번역.
- `gate.owner`/`claim.now` 등 name-bold 서식은 `t.rich()`로 보존.

## 회귀 방지
- 기존 `proof-capsule.test.tsx`(20개) + `workcell.test.tsx`(evidence 케이스 1개)가 `NextIntlClientProvider` 없이 렌더하고 있어 신규 `useTranslations()` 호출과 충돌 — 전부 프로바이더로 래핑(텍스트 값은 무변경이라 assertion 그대로 통과 확인).
- EN 로케일 회귀테스트 2건 신설: ① 전 UI chrome 텍스트가 실제 영문으로 렌더되고 구 하드코딩 한국어/raw i18n 키가 남지 않는지, ② risk 3단(낮음/보통/높음→Low/Medium/High) 매핑이 정확한지(뮤테이션 셀프체크로 검증 — 매핑 깨면 테스트 실패 확인 후 원복).

## Test plan
- [x] `pnpm run type-check` — 0 에러
- [x] `pnpm run lint` — 0 에러(기존 무관 warning만)
- [x] `pnpm run build` — EXIT 0
- [x] `vitest` 전체 스위트 — 252 test files / 1672 tests 전부 PASS(회귀 0)
- [x] 뮤테이션 셀프체크(risk 매핑) — 신규 테스트가 실제로 깨진 로직을 잡는지 확인 후 원복

🤖 Generated with [Claude Code](https://claude.com/claude-code)