### PR TITLE
fix(push): push_devices.platform optional화 — v0.2.4 register 422 fast-path

### DIFF
--- a/backend/alembic/versions/0197_push_devices_platform_optional.py
+++ b/backend/alembic/versions/0197_push_devices_platform_optional.py
@@ -1,0 +1,35 @@
+"""story 1935(급건): push_devices.platform NOT NULL→nullable. v0.2.4 앱이 platform 없이
+`POST /api/v2/push/devices`를 register해 422로 막히던 실 갭 — register가 진짜로 platform을
+모를 수 있게(fake default 아닌 진짜 NULL) 스키마를 완화한다. Expo Push API 자체는 payload에
+platform을 안 쓰므로(ee/services/expo_push.py) 발송기 영향 없음.
+
+Revision ID: 0197
+Revises: 0196
+Create Date: 2026-07-16
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0197"
+down_revision = "0196"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint("push_devices_platform_check", "push_devices", type_="check")
+    op.alter_column("push_devices", "platform", existing_type=sa.Text(), nullable=True)
+    op.create_check_constraint(
+        "push_devices_platform_check", "push_devices",
+        "platform IS NULL OR platform IN ('ios', 'android')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("push_devices_platform_check", "push_devices", type_="check")
+    op.alter_column("push_devices", "platform", existing_type=sa.Text(), nullable=False)
+    op.create_check_constraint(
+        "push_devices_platform_check", "push_devices", "platform IN ('ios', 'android')",
+    )

--- a/backend/app/models/push_device.py
+++ b/backend/app/models/push_device.py
@@ -19,7 +19,12 @@ class PushDevice(Base):
     __table_args__ = (
         # 재등록(같은 디바이스 토큰) = upsert 자연 멱등 — on_conflict 타깃.
         UniqueConstraint("expo_push_token", name="uq_push_devices_expo_push_token"),
-        CheckConstraint("platform IN ('ios', 'android')", name="push_devices_platform_check"),
+        # story 1935: v0.2.4 앱이 platform 없이 register해 422→row 미생성이던 실 갭 수정 —
+        # NULL 허용(미보고=아직 모름, fake default 아님). Expo Push API 자체가 platform을
+        # 안 쓰므로(expo_push.py) 발송기 영향 없음.
+        CheckConstraint(
+            "platform IS NULL OR platform IN ('ios', 'android')", name="push_devices_platform_check"
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -30,7 +35,7 @@ class PushDevice(Base):
     # org_id AND member_id 필터로 강제(repo list/get_owned/delete).
     member_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
     expo_push_token: Mapped[str] = mapped_column(Text, nullable=False)  # ExponentPushToken[...] (UNIQUE)
-    platform: Mapped[str] = mapped_column(Text, nullable=False)  # ios | android (CHECK)
+    platform: Mapped[str | None] = mapped_column(Text, nullable=True)  # ios | android | 미보고(CHECK)
     device_id: Mapped[str | None] = mapped_column(Text, nullable=True)  # 앱 설치 단위 식별(관측용, 선택)
     app_version: Mapped[str | None] = mapped_column(Text, nullable=True)  # 관측용
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)  # DeviceNotRegistered→false(S3)

--- a/backend/app/repositories/push_device.py
+++ b/backend/app/repositories/push_device.py
@@ -48,7 +48,7 @@ class PushDeviceRepository:
         self,
         member_id: uuid.UUID,
         expo_push_token: str,
-        platform: str,
+        platform: str | None,
         device_id: str | None = None,
         app_version: str | None = None,
     ) -> PushDevice:
@@ -57,25 +57,29 @@ class PushDeviceRepository:
         같은 디바이스가 재등록(앱 재설치·토큰 회전·기기 이관)하면 토큰 충돌 → 소유 org/멤버·플랫폼·메타·
         last_seen 갱신 + is_active 복구(True). crux §3: 발송기가 DeviceNotRegistered 수신 시 is_active=false
         로 내리므로 재등록이 활성 복구를 겸한다. org_id 도 set_ 에 포함 — 기기 이관 시 새 org 로 re-home
-        (get() 재조회가 self.org_id 스코프라 조용한 500 방지)."""
+        (get() 재조회가 self.org_id 스코프라 조용한 500 방지).
+
+        story 1935: platform은 COALESCE(신규값, 기존값) — 구버전 앱(platform 미전송, None)이
+        재등록해도 이전에 알려진 platform을 지우지 않는다(v0.2.5가 이미 보고한 값을 v0.2.4
+        재등록이 덮어써 잃어버리는 회귀 방지)."""
         now = func.now()
+        insert_stmt = pg_insert(PushDevice).values(
+            org_id=self.org_id,
+            member_id=member_id,
+            expo_push_token=expo_push_token,
+            platform=platform,
+            device_id=device_id,
+            app_version=app_version,
+            is_active=True,
+        )
         stmt = (
-            pg_insert(PushDevice)
-            .values(
-                org_id=self.org_id,
-                member_id=member_id,
-                expo_push_token=expo_push_token,
-                platform=platform,
-                device_id=device_id,
-                app_version=app_version,
-                is_active=True,
-            )
+            insert_stmt
             .on_conflict_do_update(
                 index_elements=["expo_push_token"],
                 set_={
                     "org_id": self.org_id,
                     "member_id": member_id,
-                    "platform": platform,
+                    "platform": func.coalesce(insert_stmt.excluded.platform, PushDevice.platform),
                     "device_id": device_id,
                     "app_version": app_version,
                     "is_active": True,

--- a/backend/app/schemas/push_device.py
+++ b/backend/app/schemas/push_device.py
@@ -15,7 +15,10 @@ class RegisterPushDevice(BaseModel):
     """디바이스 등록 요청. member_id 는 body 에 없음 — auth context 서 산출(IDOR: 타 멤버 등록 불가)."""
 
     expo_push_token: str
-    platform: Literal["ios", "android"]
+    # story 1935: v0.2.4 앱이 platform 없이 register하는 실 케이스 발견 — optional화(fake
+    # default 아닌 진짜 미보고). 신 버전이 보내면 그대로 저장, 안 보내면 NULL(repo가 기존
+    # 값을 덮어쓰지 않음 — upsert COALESCE).
+    platform: Literal["ios", "android"] | None = None
     device_id: str | None = None
     app_version: str | None = None
 
@@ -35,7 +38,7 @@ class PushDeviceResponse(BaseModel):
     org_id: uuid.UUID
     member_id: uuid.UUID
     expo_push_token: str
-    platform: str
+    platform: str | None = None
     device_id: str | None = None
     app_version: str | None = None
     is_active: bool

--- a/backend/tests/test_push_devices_realdb.py
+++ b/backend/tests/test_push_devices_realdb.py
@@ -167,3 +167,80 @@ async def test_push_device_register_list_revoke_round_trip_realdb():
             await s.execute(text("DELETE FROM organizations WHERE id=:o"), {"o": str(ORG)})  # cascade → devices
             await s.commit()
         await engine.dispose()
+
+
+TOKEN_C = "ExponentPushToken[s2-round-trip-CCCC]"
+
+
+@pytest.mark.anyio
+async def test_push_device_register_without_platform_realdb():
+    """story 1935: v0.2.4 앱(platform 필드 없이 {expo_push_token}만 전송)이 422 없이 등록되고
+    (platform=None 저장), 이후 v0.2.5류 재등록이 platform을 채우면 저장되며, 그 뒤 다시
+    platform 없는 재등록이 와도 기존 값을 지우지 않는지(COALESCE) 실증."""
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.dependencies.auth import get_verified_org_id
+    from app.dependencies.database import get_db
+    from ee.routers import push_devices as pd
+
+    app = FastAPI()
+    app.include_router(pd.router, prefix="/api/v2/push")
+
+    engine = create_async_engine(_async_url())
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with SessionLocal() as s:
+        await s.execute(text("DELETE FROM push_devices WHERE org_id=:o"), {"o": str(ORG)})
+        await s.execute(text("DELETE FROM organizations WHERE id=:o"), {"o": str(ORG)})
+        await s.execute(
+            text("INSERT INTO organizations (id,name,slug,plan) VALUES (:o,'S2 Org','s2-mobile','free')"),
+            {"o": str(ORG)},
+        )
+        await s.commit()
+
+    async def _override_db():
+        async with SessionLocal() as sess:
+            yield sess
+            await sess.commit()
+
+    def _make_caller_override(member_id: uuid.UUID):
+        async def _override():
+            return member_id
+        return _override
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_verified_org_id] = lambda: ORG
+    app.dependency_overrides[pd._get_caller_member_id] = _make_caller_override(MEMBER_X)
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            with _ee_on():
+                # 1) v0.2.4류 register — platform 필드 자체가 없음 → 422 아니라 200, platform=None.
+                r = await client.post("/api/v2/push/devices", json={"expo_push_token": TOKEN_C})
+                assert r.status_code == 200, r.text
+                assert r.json()["platform"] is None
+                dev_id = r.json()["id"]
+
+                # 2) 같은 토큰 재등록, 이번엔 platform 포함(v0.2.5류) → platform 채워짐.
+                r = await client.post(
+                    "/api/v2/push/devices", json={"expo_push_token": TOKEN_C, "platform": "android"},
+                )
+                assert r.status_code == 200, r.text
+                assert r.json()["id"] == dev_id
+                assert r.json()["platform"] == "android"
+
+                # 3) 다시 platform 없이 재등록(v0.2.4 재실행 등) → 기존 android 값 유지(COALESCE,
+                # 덮어써서 잃어버리지 않음).
+                r = await client.post("/api/v2/push/devices", json={"expo_push_token": TOKEN_C})
+                assert r.status_code == 200, r.text
+                assert r.json()["id"] == dev_id
+                assert r.json()["platform"] == "android"
+    finally:
+        app.dependency_overrides.clear()
+        async with SessionLocal() as s:
+            await s.execute(text("DELETE FROM organizations WHERE id=:o"), {"o": str(ORG)})
+            await s.commit()
+        await engine.dispose()


### PR DESCRIPTION
## Summary
- 오르테가군 백엔드 로그+재현 실측: v0.2.4 앱이 `{expo_push_token}`만 전송하는데 register 스키마가 `platform` 필수라 422 → row 미생성. 새 EAS 빌드 없이 즉시 착지시키는 fast-path.
- fake default 대신 진짜 nullable로 처리(`platform IS NULL OR platform IN (...)`), upsert는 COALESCE로 구버전 재등록이 이미 알려진 platform을 지우지 않게 함.
- Expo Push API 자체는 payload에 platform을 안 써서(`expo_push.py`) 발송기 무변경.

## Test plan
- [x] 신규 realdb 테스트: platform 없는 register → 200(+platform=None 저장), platform 포함 재등록 → 값 채워짐, 다시 platform 없는 재등록 → 기존 값 유지(COALESCE)
- [x] 기존 push_devices/expo_push 테스트 15개 무회귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)