### PR TITLE
fix(push): Expo payload에 channelId 추가 — Android HIGH 채널 헤드업/소리 정합

### DIFF
--- a/backend/ee/services/expo_push.py
+++ b/backend/ee/services/expo_push.py
@@ -110,6 +110,12 @@ async def deliver_expo_push(
                 "data": data_payload,
                 "sound": "default",
                 "priority": "high",
+                # story 1934/1935 후속(2026-07-17): Android 8+는 notification channel의
+                # importance가 실제 헤드업/소리 여부를 결정(priority:"high"는 FCM 배달
+                # 우선순위일 뿐 UI 표시와 무관) — 민 앱이 HIGH importance로 등록하는 채널
+                # ID와 정확히 일치해야 한다(Expo 관례 "default"). 앱측 채널 ID가 다르면
+                # 여기도 맞춰야 함.
+                "channelId": "default",
             }
             for d in devices
         ]


### PR DESCRIPTION
## Summary
- 선생님 실기기 QA: 알림이 진동/소리 없이 조용히 옴.
- `deliver_expo_push` payload에 `sound`/`priority`는 이미 있었으나 `channelId`가 없었음 — Android 8+는 notification channel importance가 헤드업/소리 여부를 결정(priority는 FCM 배달 우선순위일 뿐 UI 표시와 무관).
- `channelId: "default"`(Expo 관례) 추가.

⚠️ **민의 앱측 HIGH importance 채널 등록 ID와 정확히 일치해야 실제로 해소됨** — 채널 ID가 다르면 이 값도 맞춰야 함. 앱측 채널 설정과 세트 배포 필요.

## Test plan
- [x] 기존 expo_push/push_devices 테스트 15개 무회귀
- [ ] 실기기 확인은 민의 앱측 채널 설정 완료 후 통합 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)