### PR TITLE
[SID:1943] 게이트 승인 카드 근거 텍스트 31.86px 붕괴 수정

### DIFF
--- a/apps/web/src/components/cage/gate-inbox.tsx
+++ b/apps/web/src/components/cage/gate-inbox.tsx
@@ -214,7 +214,10 @@ export function GateInbox({ memberId }: GateInboxProps) {
         </div>
       ) : (
         activeGates.map((gate) => (
-          <div key={gate.id} className="flex items-start justify-between gap-3 rounded-xl border border-border bg-card px-4 py-3">
+          // #1943: 좁은 뷰포트(390px)에서 shrink-0 액션버튼열(문서에서 검토/승인/반려/⋯, 최대 4개)이
+          // min-w-0 flex-1 콘텐츠열을 31.86px까지 압착해 GateEvidence 근거 텍스트가 판독 불가했다.
+          // 액션열을 데스크톱 나란히 배치에서만 유지하고 모바일은 콘텐츠 아래 별도 줄로 내린다.
+          <div key={gate.id} className="flex flex-col gap-3 rounded-xl border border-border bg-card px-4 py-3 sm:flex-row sm:items-start sm:justify-between">
             <div className="min-w-0 flex-1 space-y-1">
               <div className="flex items-center gap-2">
                 <span className="shrink-0 text-xs font-medium text-foreground">{gate.gate_type}</span>
@@ -279,7 +282,7 @@ export function GateInbox({ memberId }: GateInboxProps) {
               ) : null}
             </div>
             {/* 액션 = requires_human 기준(block 제외·읽기전용·AC⑤). + S30 admin ⋯ 무효화(전 pending gate·admin only). */}
-            <div className="flex shrink-0 items-center gap-1.5">
+            <div className="flex flex-wrap shrink-0 items-center justify-end gap-1.5">
               {isHeld(gate) ? (
                 <>
                   {/* S31 보류중: ⏸ Pause(중립 secondary·재개가능)·SLA 일시정지 */}


### PR DESCRIPTION
## Summary
- `/inbox?tab=gates` 게이트 승인 카드에서 근거(evidence) 텍스트가 모바일(390px)에서 글자 단위 세로 wrap되어 판독 불가하던 버그 근본수정
- 원인: 카드 행이 좌(콘텐츠, `min-w-0 flex-1`)/우(액션버튼, `shrink-0`) 한 줄 배치인데, doc gate 등 액션버튼이 최대 4개(문서에서 검토/승인/반려/⋯)까지 늘어나면 액션열이 `shrink-0`라 절대 줄지 않고, 콘텐츠열이 남은 폭(실측 **31.86px**)까지 압착됨 — flex `min-width:0` 부재가 아니라 고정폭 형제 열이 원인
- fix: 카드 행을 모바일 `flex-col` / `sm:flex-row`로 전환(콘텐츠·액션이 더 이상 한 줄 폭을 다투지 않음), 액션열에 `flex-wrap` 추가(방어)
- 동일 rigid-row 패턴인 `decisions-waiting.tsx`도 확인 — 액션이 아이콘 버튼 1개뿐이라 이 결함 클래스 아님(무변경)

## Context
- 근거: story `1e650727-24e4-4602-87a6-af56b27729b1` (#1943), 감사 doc `mobile-ui-render-audit-fe-grounding`

## Test plan
- [x] `tsc --noEmit` — 0 errors
- [x] `eslint gate-inbox.tsx` — 0 warnings
- [ ] dev 배포 후 390px 라이브픽셀로 근거 텍스트 정상 판독 재검증(로컬 FE는 dev 백엔드 세션 인증 미스매치로 불가 — 알려진 제약)

🤖 Generated with [Claude Code](https://claude.com/claude-code)