### PR TITLE
[SID:1946] 모바일 채팅 Enter=개행, 발송=전송 버튼

### DIFF
--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -132,6 +132,11 @@ interface ChatInputProps {
 
 export function ChatInput({ onSend, onUploadFile, disabled, placeholder, projectId, onMentionIdsChange, commandTargets }: ChatInputProps) {
   const t = useTranslations('chats');
+  // story 1946(PO 실기기 발견): 터치(가상 키보드)엔 Cmd/Shift 조합이 없어 Enter=발송이면 장문
+  // 지시 중 오발송이 잦다. 뷰포트가 아니라 입력 capability로 분기(물리 키보드 연결 태블릿은
+  // 데스크톱 거동이 자연스러움) — artifact-stage.tsx와 동형 패턴(`(pointer: coarse)` 1회 판정,
+  // SSR 안전 lazy initializer, 하이브리드 기기 중간 전환은 희귀 엣지케이스라 리스너 미부착).
+  const [isTouchDevice] = useState(() => typeof window !== 'undefined' && typeof window.matchMedia === 'function' && window.matchMedia('(pointer: coarse)').matches);
   const [text, setText] = useState('');
   const [pendingFiles, setPendingFiles] = useState<File[]>([]);
   const [uploadFailed, setUploadFailed] = useState(false);
@@ -352,7 +357,9 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
       if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); const m = mentionMembers[mentionIndex] ?? mentionMembers[0]; if (m) selectMention(m); return; }
       if (e.key === 'Escape') { setMentionQuery(null); setMentionMembers([]); return; }
     }
-    if (e.key === 'Enter' && !e.shiftKey) {
+    // 터치: Enter=개행(기본 textarea 동작 그대로 통과) · 발송=전송 버튼만(PO 방향, story 1946).
+    // 데스크톱: 기존 그대로 Enter=발송·Shift+Enter=개행.
+    if (e.key === 'Enter' && !e.shiftKey && !isTouchDevice) {
       e.preventDefault();
       void handleSend();
     }


### PR DESCRIPTION
## Summary
- PO 실기기 발견: 모바일에서 Enter가 개행이 아니라 즉시 발송돼 장문 지시 작성 중 오발송 발생
- **터치**: Enter=개행, 발송=전송 버튼만(Slack/WhatsApp/Discord 모바일 관례)
- **데스크톱**: Enter=발송·Shift+Enter=개행 그대로 유지(무변경)
- **분기 기준**: 뷰포트 아님 — 입력 capability `(pointer: coarse)`(물리 키보드 연결 태블릿은 데스크톱 거동이 자연스럽다는 PO 방향과 정합). `components/canvas/artifact-stage.tsx`의 기존 동형 패턴(SSR 안전 lazy initializer·1회 판정) 그대로 재사용 — 새 유틸/훅 신설 없음.
- 멘션/엔티티/커맨드 자동완성 선택용 Enter(별개 UX)는 변경 대상 아님.

## Context
- 근거: story `f9ea0299-87cc-4a90-8177-a83c73ce2dcc` (#1946)

## Test plan
- [x] `tsc --noEmit` — 0 errors
- [x] `eslint chat-input.tsx` — 0 warnings
- [x] `pnpm build` — EXIT 0
- [x] `vitest run` 전체 — 1674 passed, 0 failed(회귀 없음)
- [ ] dev 배포 후 라이브 실측: 모바일뷰포트+터치에뮬레이션 Enter=개행·전송버튼 발송 정상, 데스크톱 Enter=발송 무회귀(puppeteer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)