### PR TITLE
[SID:1957] P2-S1 breakpoint SSOT 수렴 (1024=데스크톱)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,12 @@ jobs:
       - name: Type Check
         run: pnpm type-check
 
+      # story #1957(P2-S1) breakpoint SSOT 회귀가드: md:(768) 신규 사용은 useIsMobile()의
+      # 1024 기준과 어긋나는 route 내 md·lg 혼재를 재도입한다. 기존 사용은 grandfather
+      # allowlist로 통과, 새 파일/allowlist 밖 파일에서만 실패.
+      - name: Verify no new md: breakpoint (story #1957 regression guard)
+        run: pnpm --filter web verify:no-new-md-breakpoint
+
       - name: Test
         # set -o pipefail so vitest's non-zero exit propagates through `| tail` instead
         # of being masked by tail's 0 — without it the unit-test gate was a no-op

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,7 @@ jobs:
       # story #1957(P2-S1) breakpoint SSOT 회귀가드: md:(768) 신규 사용은 useIsMobile()의
       # 1024 기준과 어긋나는 route 내 md·lg 혼재를 재도입한다. 기존 사용은 grandfather
       # allowlist로 통과, 새 파일/allowlist 밖 파일에서만 실패.
-      - name: Verify no new md: breakpoint (story #1957 regression guard)
+      - name: "Verify no new md: breakpoint (story #1957 regression guard)"
         run: pnpm --filter web verify:no-new-md-breakpoint
 
       - name: Test

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "runtime:worker": "tsx scripts/background-runtime-worker.ts",
     "dispatch:slack-outbound": "tsx scripts/slack-outbound-dispatcher.ts",
     "verify:build-schema-integrity": "tsx scripts/verify-build-schema-integrity.ts",
+    "verify:no-new-md-breakpoint": "tsx scripts/verify-no-new-md-breakpoint.ts",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
     "e2e:report": "playwright show-report"

--- a/apps/web/scripts/verify-no-new-md-breakpoint.test.ts
+++ b/apps/web/scripts/verify-no-new-md-breakpoint.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { hasMdPrefix } from './verify-no-new-md-breakpoint';
+
+describe('hasMdPrefix (story #1957 regression guard)', () => {
+  it('flags a plain md: utility', () => {
+    expect(hasMdPrefix('<div className="flex md:hidden" />')).toBe(true);
+  });
+
+  // 까심 QA 지적(2026-07-17): 화이트리스트 lead-in이 복합 variant 체인에서 md: 직전 문자가
+  // `:`인 경우를 놓쳤다 — 가드 존재 목적 자체가 무력화되는 구멍이었다.
+  it('flags md: chained after another variant (dark:md:hidden)', () => {
+    expect(hasMdPrefix('<div className="dark:md:hidden" />')).toBe(true);
+  });
+
+  it('flags md: chained after a state variant (group-hover:md:flex)', () => {
+    expect(hasMdPrefix('<div className="group-hover:md:flex" />')).toBe(true);
+  });
+
+  it('flags md: inside a template literal', () => {
+    expect(hasMdPrefix('className={`flex ${x ? "md:hidden" : "flex"}`}')).toBe(true);
+  });
+
+  it('flags an arbitrary-variant-adjacent md: at string start', () => {
+    expect(hasMdPrefix('"md:opacity-0"')).toBe(true);
+  });
+
+  it('does not flag a JS object property key (colon followed by space)', () => {
+    // 오탐 실측: lib/parse-design-tokens.ts SM_LG_MAP, components/chat/presence-dot.tsx SIZE_CLASS
+    expect(hasMdPrefix("const SIZE_CLASS = { sm: 'size-2.5', md: 'size-3' } as const;")).toBe(false);
+  });
+
+  it('does not flag "md:" as a trailing substring of a longer identifier', () => {
+    expect(hasMdPrefix('const amd:never = 1;')).toBe(false);
+  });
+
+  it('does not flag unrelated text without md:', () => {
+    expect(hasMdPrefix('<div className="flex lg:hidden" />')).toBe(false);
+  });
+});

--- a/apps/web/scripts/verify-no-new-md-breakpoint.ts
+++ b/apps/web/scripts/verify-no-new-md-breakpoint.ts
@@ -14,12 +14,10 @@
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
 
-const SRC_ROOT = path.resolve(process.cwd(), 'src');
-
 // P2-S1 시점(2026-07-17) 기존 md: 사용 파일 — route별 전환 전까지 grandfather.
 // GNB(components/ui/sidebar.tsx·components/nav/top-bar.tsx)는 이번 스토리에서 lg:로
 // 전환 완료돼 있어야 하므로 의도적으로 목록에 없다(재도입 시 이 스크립트가 잡는다).
-const ALLOWLIST = new Set([
+export const ALLOWLIST = new Set([
   'app/(authenticated)/[ws]/[proj]/docs/[slug]/page.tsx',
   'app/(authenticated)/[ws]/[proj]/mockups/page.tsx',
   'app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx',
@@ -49,11 +47,19 @@ const ALLOWLIST = new Set([
   'components/ui/page-skeleton.tsx',
 ]);
 
-// Tailwind 반응형 접두사만 매칭 — 콜론 뒤 공백 없이 바로 유틸리티가 붙는 형태(md:hidden 등)만
-// 잡는다. 콜론 뒤 공백이 오는 `{ md: 'rounded-md' }` 같은 JS 객체 프로퍼티 오탐을 이 lookahead로
-// 배제(오탐 실측: lib/parse-design-tokens.ts의 SM_LG_MAP). arbitrary-variant 등 극단 케이스는
-// 스코프 밖.
-const MD_PREFIX = /(^|[\s"'`{])md:(?=[a-zA-Z[])/;
+// Tailwind 반응형 접두사만 매칭. 까심 QA 지적(2026-07-17) 반영 — 앞쪽 조건을 화이트리스트
+// (공백/따옴표/중괄호)에서 "직전 문자가 식별자 문자가 아님" 네거티브 lookbehind로 교체했다.
+// 화이트리스트 방식은 `dark:md:hidden`·`group-hover:md:flex` 같은 복합 variant 체인에서
+// `md:` 직전 문자가 `:`라 매치를 놓쳤다(가드 존재 목적 자체가 무력화되는 구멍). lookbehind는
+// 식별자 문자(A-Za-z0-9_-)가 아니기만 하면 무엇이 앞에 오든 잡는다. 뒤쪽 lookahead는 그대로
+// 유지 — `{ md: 'rounded-md' }` 같은 JS 객체 프로퍼티(콜론 뒤 공백)는 계속 걸러진다(오탐 실측:
+// lib/parse-design-tokens.ts의 SM_LG_MAP, components/chat/presence-dot.tsx의 SIZE_CLASS).
+export const MD_PREFIX = /(?<![A-Za-z0-9_-])md:(?=[a-zA-Z[])/;
+
+export function hasMdPrefix(content: string): boolean {
+  return MD_PREFIX.test(content);
+}
+
 const EXT_RE = /\.(tsx?|jsx?)$/;
 const TEST_RE = /\.test\.[tj]sx?$/;
 
@@ -69,24 +75,33 @@ function walk(dir: string, out: string[]): void {
   }
 }
 
-const files: string[] = [];
-walk(SRC_ROOT, files);
+function main(): void {
+  const srcRoot = path.resolve(process.cwd(), 'src');
+  const files: string[] = [];
+  walk(srcRoot, files);
 
-const violations: string[] = [];
-for (const abs of files) {
-  const rel = path.relative(SRC_ROOT, abs).split(path.sep).join('/');
-  if (ALLOWLIST.has(rel)) continue;
-  const content = readFileSync(abs, 'utf8');
-  if (MD_PREFIX.test(content)) violations.push(rel);
+  const violations: string[] = [];
+  for (const abs of files) {
+    const rel = path.relative(srcRoot, abs).split(path.sep).join('/');
+    if (ALLOWLIST.has(rel)) continue;
+    const content = readFileSync(abs, 'utf8');
+    if (hasMdPrefix(content)) violations.push(rel);
+  }
+
+  if (violations.length > 0) {
+    console.error('FAIL: 새 `md:` breakpoint 사용 발견(P2-S1 SSOT=lg:1024 위반):');
+    for (const v of violations) console.error(`  - ${v}`);
+    console.error(
+      '\nP2-S1(mobile-p2-p1a-story-breakdown) breakpoint SSOT: `lg:`(1024)만 신규 레이아웃 분기에 사용.',
+    );
+    process.exit(1);
+  }
+
+  console.log(`OK: md: breakpoint 신규 회귀 0건 (grandfather ${ALLOWLIST.size}개 파일 제외 전수 검사)`);
 }
 
-if (violations.length > 0) {
-  console.error('FAIL: 새 `md:` breakpoint 사용 발견(P2-S1 SSOT=lg:1024 위반):');
-  for (const v of violations) console.error(`  - ${v}`);
-  console.error(
-    '\nP2-S1(mobile-p2-p1a-story-breakdown) breakpoint SSOT: `lg:`(1024)만 신규 레이아웃 분기에 사용.',
-  );
-  process.exit(1);
+// 직접 실행(tsx scripts/verify-no-new-md-breakpoint.ts)일 때만 파일시스템 스캔 — vitest가
+// hasMdPrefix/MD_PREFIX를 import할 때는 이 부작용이 돌지 않아야 한다.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
 }
-
-console.log(`OK: md: breakpoint 신규 회귀 0건 (grandfather ${ALLOWLIST.size}개 파일 제외 전수 검사)`);

--- a/apps/web/scripts/verify-no-new-md-breakpoint.ts
+++ b/apps/web/scripts/verify-no-new-md-breakpoint.ts
@@ -33,7 +33,6 @@ const ALLOWLIST = new Set([
   'components/agents/agent-persona-composer.tsx',
   'components/agents/agent-run-detail.tsx',
   'components/agents/agents-dashboard.tsx',
-  'components/chat/presence-dot.tsx',
   'components/dashboard/dashboard-skeleton.tsx',
   'components/dispatch/entity-dispatch-panel.tsx',
   'components/docs/doc-editor.tsx',

--- a/apps/web/scripts/verify-no-new-md-breakpoint.ts
+++ b/apps/web/scripts/verify-no-new-md-breakpoint.ts
@@ -1,0 +1,93 @@
+/**
+ * story #1957(P2-S1, mobile-p2-p1a-story-breakdown SSOT) 회귀가드 — breakpoint SSOT는
+ * 390/768/834=모바일, 1024=데스크톱(Tailwind `lg`)으로 수렴했다. `md:`(768) 접두사로 새
+ * 레이아웃 분기를 추가하면 `useIsMobile()`(1024 기준)과 어긋나는 "route 내 md·lg 혼재"가
+ * 재발한다.
+ *
+ * 기존 `md:` 사용 파일은 route 단위 원자 전환 원칙(빅뱅 전환 금지 — blueprint §3.6)에 따라
+ * ALLOWLIST로 grandfather한다. 이 스크립트는 ALLOWLIST 밖의 파일에서 새로 `md:`가 발견되면
+ * 실패한다 — 신규 회귀만 잡고 기존 부채는 개별 스토리(route별 전환)가 처리한다.
+ *
+ * ALLOWLIST에서 파일을 뺐는데 그 파일이 lg:로 완전 전환됐다면 그대로 통과한다(더는 md: 없음).
+ * 아직 md:가 남아있는데 뺐다면 이 스크립트가 실패로 잡아준다 — 안전한 방향의 실수.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+const SRC_ROOT = path.resolve(process.cwd(), 'src');
+
+// P2-S1 시점(2026-07-17) 기존 md: 사용 파일 — route별 전환 전까지 grandfather.
+// GNB(components/ui/sidebar.tsx·components/nav/top-bar.tsx)는 이번 스토리에서 lg:로
+// 전환 완료돼 있어야 하므로 의도적으로 목록에 없다(재도입 시 이 스크립트가 잡는다).
+const ALLOWLIST = new Set([
+  'app/(authenticated)/[ws]/[proj]/docs/[slug]/page.tsx',
+  'app/(authenticated)/[ws]/[proj]/mockups/page.tsx',
+  'app/(authenticated)/[ws]/[proj]/retro/[id]/page.tsx',
+  'app/(authenticated)/[ws]/[proj]/standup/standup-client.tsx',
+  'app/(authenticated)/inbox/page.tsx',
+  'app/(authenticated)/settings/page.tsx',
+  'app/internal-dogfood/page.tsx',
+  'components/agents/agent-deployment-verification-step.tsx',
+  'components/agents/agent-deployment-wizard.tsx',
+  'components/agents/agent-hitl-policy-editor.tsx',
+  'components/agents/agent-persona-composer.tsx',
+  'components/agents/agent-run-detail.tsx',
+  'components/agents/agents-dashboard.tsx',
+  'components/chat/presence-dot.tsx',
+  'components/dashboard/dashboard-skeleton.tsx',
+  'components/dispatch/entity-dispatch-panel.tsx',
+  'components/docs/doc-editor.tsx',
+  'components/docs/doc-url-chip.tsx',
+  'components/epics/epics-skeleton.tsx',
+  'components/landing/landing-page.tsx',
+  'components/retro/sprint-close-cockpit.tsx',
+  'components/settings/org-members-section.tsx',
+  'components/settings/slack-integration-settings.tsx',
+  'components/settings/workflow-trigger-types-section.tsx',
+  'components/standup/standup-feedback-dialog.tsx',
+  'components/ui/input.tsx',
+  'components/ui/page-header.tsx',
+  'components/ui/page-skeleton.tsx',
+]);
+
+// Tailwind 반응형 접두사만 매칭 — 콜론 뒤 공백 없이 바로 유틸리티가 붙는 형태(md:hidden 등)만
+// 잡는다. 콜론 뒤 공백이 오는 `{ md: 'rounded-md' }` 같은 JS 객체 프로퍼티 오탐을 이 lookahead로
+// 배제(오탐 실측: lib/parse-design-tokens.ts의 SM_LG_MAP). arbitrary-variant 등 극단 케이스는
+// 스코프 밖.
+const MD_PREFIX = /(^|[\s"'`{])md:(?=[a-zA-Z[])/;
+const EXT_RE = /\.(tsx?|jsx?)$/;
+const TEST_RE = /\.test\.[tj]sx?$/;
+
+function walk(dir: string, out: string[]): void {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      walk(full, out);
+    } else if (EXT_RE.test(entry) && !TEST_RE.test(entry)) {
+      out.push(full);
+    }
+  }
+}
+
+const files: string[] = [];
+walk(SRC_ROOT, files);
+
+const violations: string[] = [];
+for (const abs of files) {
+  const rel = path.relative(SRC_ROOT, abs).split(path.sep).join('/');
+  if (ALLOWLIST.has(rel)) continue;
+  const content = readFileSync(abs, 'utf8');
+  if (MD_PREFIX.test(content)) violations.push(rel);
+}
+
+if (violations.length > 0) {
+  console.error('FAIL: 새 `md:` breakpoint 사용 발견(P2-S1 SSOT=lg:1024 위반):');
+  for (const v of violations) console.error(`  - ${v}`);
+  console.error(
+    '\nP2-S1(mobile-p2-p1a-story-breakdown) breakpoint SSOT: `lg:`(1024)만 신규 레이아웃 분기에 사용.',
+  );
+  process.exit(1);
+}
+
+console.log(`OK: md: breakpoint 신규 회귀 0건 (grandfather ${ALLOWLIST.size}개 파일 제외 전수 검사)`);

--- a/apps/web/src/components/nav/top-bar.tsx
+++ b/apps/web/src/components/nav/top-bar.tsx
@@ -24,7 +24,7 @@ export function TopBar({ className }: TopBarProps) {
         className,
       )}
     >
-      <SidebarTrigger className="mr-2 md:hidden" />
+      <SidebarTrigger className="mr-2 lg:hidden" />
       <div className="flex min-w-0 flex-1 items-center gap-2">
         {title}
       </div>

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -207,7 +207,7 @@ function Sidebar({
 
   return (
     <div
-      className="group peer hidden text-sidebar-foreground md:block"
+      className="group peer hidden text-sidebar-foreground lg:block"
       data-state={state}
       data-collapsible={state === "collapsed" ? collapsible : ""}
       data-variant={variant}
@@ -230,7 +230,7 @@ function Sidebar({
         data-slot="sidebar-container"
         data-side={side}
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] lg:flex",
           !isResizing && "transition-[left,right,width] duration-200 ease-linear",
           variant === "floating" || variant === "inset"
             ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
@@ -345,7 +345,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "relative flex w-full flex-1 flex-col bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        "relative flex w-full flex-1 flex-col bg-background lg:peer-data-[variant=inset]:m-2 lg:peer-data-[variant=inset]:ml-0 lg:peer-data-[variant=inset]:rounded-xl lg:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className
       )}
       {...props}
@@ -462,7 +462,7 @@ function SidebarGroupAction({
     props: mergeProps<"button">(
       {
         className: cn(
-          "absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+          "absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 lg:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
           className
         ),
       },
@@ -602,9 +602,9 @@ function SidebarMenuAction({
     props: mergeProps<"button">(
       {
         className: cn(
-          "absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+          "absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 lg:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
           showOnHover &&
-            "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-active/menu-button:text-sidebar-accent-foreground aria-expanded:opacity-100 md:opacity-0",
+            "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-active/menu-button:text-sidebar-accent-foreground aria-expanded:opacity-100 lg:opacity-0",
           className
         ),
       },

--- a/apps/web/src/hooks/use-mobile.ts
+++ b/apps/web/src/hooks/use-mobile.ts
@@ -1,6 +1,8 @@
 import * as React from "react"
 
-const MOBILE_BREAKPOINT = 768
+// P2-S1(mobile-p2-p1a-story-breakdown SSOT): 1024=데스크톱 IA 경계로 수렴(Tailwind lg와 정합).
+// GNB(components/ui/sidebar.tsx)도 동일 경계로 md:→lg: 전환 완료 — 이 값과 항상 같이 움직인다.
+const MOBILE_BREAKPOINT = 1024
 
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)


### PR DESCRIPTION
## Summary
- SSOT: doc `mobile-p2-p1a-story-breakdown` [P2-S1] — 390/768/834=모바일 IA, 1024=데스크톱 IA로 breakpoint 경계 확定
- `hooks/use-mobile.ts`: `MOBILE_BREAKPOINT` 768→1024
- GNB(`components/ui/sidebar.tsx`+`components/nav/top-bar.tsx`): `md:` 전량 `lg:`로 전환(6개소) — JS(`useIsMobile`)와 CSS 브레이크포인트를 같은 경계로 정합. 기존엔 이 둘이 어긋나 있었음(모바일 audit `mobile-ui-render-audit-fe-grounding`에서 최초 적출: 팀 규칙="lg:hidden과 일치"·실 GNB 구현="md:768").
- `components/chat/chat-view.tsx`는 무변경 — `useIsMobile`이 placeholder 카피 선택에만 쓰이고 실 레이아웃 분기는 이미 `lg:` 기준이라, 이번 변경으로 768~1023px 구간의 카피/레이아웃 불일치가 부수적으로 해소됨(확인 완료, 별도 수정 불요).

## 빅뱅 전환 금지(blueprint §3.6)
기존 `md:` 사용 28개 파일은 route 단위 개별 전환 원칙에 따라 이번 스코프 밖. `apps/web/scripts/verify-no-new-md-breakpoint.ts` 신설 — grandfather allowlist(28개 파일) 방식으로 **신규** `md:` 사용만 CI 차단. `sidebar.tsx`/`top-bar.tsx`는 이번에 `lg:`로 전환됐으므로 의도적으로 목록에서 제외(재도입 시 즉시 회귀 잡힘). CI(`ci.yml`)에 Type Check 직후 스텝으로 편입.

## Test plan
- [x] `tsc --noEmit` — 0 errors
- [x] `eslint` — 0 warnings
- [x] `pnpm build` — EXIT 0
- [x] `vitest run` 전체 — 1674 passed, 0 failed
- [x] `pnpm verify:no-new-md-breakpoint` — 통과(가짜양성 2건 lookahead로 해소: 자체 주석의 "md:" 문자열·`lib/parse-design-tokens.ts`의 JS 객체 키 `md:` 오탐)
- [ ] dev 배포 후 라이브 4해상도(390/768/834/1024) 캡처 — GNB collapse/펼침 경계가 1024에서 정확히 갈리는지, 1024에서 기존 사이드바 UI 무회귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)