### PR TITLE
feat(mobile): 딥링크 계약 매니페스트 v1 (story #1951, P1a-S1)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -66,7 +66,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import a2a, account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, device_installations, dispatch, docs, entities, goals, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import a2a, account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, agents, analytics, api_keys, assets, context_pack, deeplink_manifest, gate_config, gate_metrics, attachments, audit_logs, auth, auth_firebase_internal, auth_native_bootstrap, bridge, channel, command_center, conversations, cron, current_project, dashboard, dependencies, device_installations, dispatch, docs, entities, goals, event_notifications, events, evidence, exclusion, file_locks, gates, github_integration, glance, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, loops, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, onboarding, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, release_notes, resolve, retros, rewards, role_templates, runtime_capabilities, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, visual_artifacts, webhooks, workflow_executions, workflow_line_config, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 # 도메인 축 B(org-1st-class-surface-ia-design-b §3): OpenAPI 태그 조직-우선 위계.
 # 개별 라우터는 기존 세부 tag(예 "stories")를 그대로 유지하고 이 4축 태그를 추가로 보유(다중
@@ -215,6 +215,7 @@ app.include_router(role_templates.router)
 app.include_router(entities.router)
 app.include_router(event_notifications.router)
 app.include_router(notifications.router)
+app.include_router(deeplink_manifest.router)  # story #1951: 딥링크 계약 매니페스트 v1 서빙
 app.include_router(onboarding.router)
 app.include_router(attachments.router)
 app.include_router(notification_preferences.router)

--- a/backend/app/routers/deeplink_manifest.py
+++ b/backend/app/routers/deeplink_manifest.py
@@ -1,0 +1,58 @@
+"""story #1951 (E-MOBILE P1a-S1): 딥링크 계약 매니페스트 v1 — 서빙 엔드포인트.
+
+PO 재정(3자 검토 스코프 확장): 매니페스트는 정적 파일이 아니라 런타임 API여야 한다(미르코,
+FE 소비 오너) — 모바일 앱이 콜드스타트/포그라운드 복귀 시 이 엔드포인트로 최신 SSOT를
+받아온다. read-only, org 비스코프(레지스트리 자체는 org와 무관한 전역 상수) — 인증된
+호출자면 누구나 조회 가능.
+
+SSOT = `app.schemas.deeplink_manifest.DEEPLINK_MANIFEST`. 이 라우터는 그걸 JSON으로
+직렬화만 한다(레지스트리 로직/불변식 검증은 스키마 모듈이 이미 model_validator로 강제).
+"""
+from fastapi import APIRouter, Depends
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.schemas.deeplink_manifest import DEEPLINK_MANIFEST, MANIFEST_SCHEMA_VERSION
+
+router = APIRouter(prefix="/api/v2", tags=["deeplink-manifest", "Organization"])
+
+# 미르코(FE 소비 오너) point ③: MAJOR 버전 불일치 시 클라이언트 안전 폴백 계약. 서버가
+# 강제할 수 있는 건 이 필드를 응답에 명확히 노출하는 것까지 — 실제 "내 지원 MAJOR와 다르면
+# 로컬 SSOT로 폴백" 판단/구현은 클라이언트(P1b) 몫이다.
+VERSION_POLICY = (
+    "이 매니페스트를 소비하는 클라이언트는 자신이 지원하는 schema_version(MAJOR)과 이 "
+    "응답의 schema_version이 다르면(특히 응답 값이 더 높으면) 이 응답을 신뢰하지 말고 "
+    "클라이언트에 번들된 로컬 SSOT 사본으로 폴백해야 한다. PATCH 수준 변경(신규 엔트리 "
+    "추가·설명 문구 변경)은 schema_version을 올리지 않으므로 구버전 클라이언트도 안전하게 "
+    "소비 가능하다 — MAJOR bump는 Layer 1 필드(target 값 체계·parentTab enum·"
+    "returnPolicy 의미) 변경 시에만 발생한다."
+)
+
+
+def _serialize_entry(entry) -> dict:
+    """엔트리 1개 직렬화. 미르코 point ①(nested 구조·snake_case)은 유지 — 기존
+    app/payload/channel 3-레이어 nested dict 그대로. point ②: lookup_key 필드만
+    서빙 시점에 파생 추가(내부 튜플 키(type, entity_type)는 그대로 두고 서빙 JSON에서만
+    문자열화)."""
+    data = entry.model_dump(mode="json")
+    entity_type = entry.app.entity_type or ""
+    data["lookup_key"] = f"{entry.app.type}:{entity_type}"
+    return data
+
+
+@router.get("/deeplink-manifest")
+async def get_deeplink_manifest(_: AuthContext = Depends(get_current_user)) -> dict:
+    """GET /api/v2/deeplink-manifest — 딥링크 계약 매니페스트 v1 (read-only, 전역 SSOT).
+
+    응답 형태:
+        {
+          "schema_version": 1,
+          "version_policy": "<MAJOR 불일치 시 폴백 계약 설명>",
+          "entries": [{"lookup_key": "dispatched:story", "app": {...}, "payload": {...},
+                       "channel": {...}}, ...]
+        }
+    """
+    return {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "version_policy": VERSION_POLICY,
+        "entries": [_serialize_entry(e) for e in DEEPLINK_MANIFEST.entries],
+    }

--- a/backend/app/schemas/deeplink_manifest.py
+++ b/backend/app/schemas/deeplink_manifest.py
@@ -412,9 +412,8 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             # 충돌한다 — 그래서 target 자체를 현재 안전 폴백("now")으로 낮추고
             # target_promotion_pending=True로 하이라이트 표시한다. S3(가설 상세 라우트 신설)
             # PR에서 target이 실제 라우트로 승격되면 이 값과 flag를 갱신한다.
-            # (참고: handoff_stuck:hypothesis 엔트리는 여전히 target="hypothesis_detail"을
-            # 쓴다 — 이 정정은 dispatched:hypothesis에 한정된 유나 지시 범위라 임의 확장하지
-            # 않았다. 동일 갭이 있으니 S2/S3에서 재확인 필요 — 잔여 오픈아이템으로 남김.)
+            # (handoff_stuck:hypothesis 엔트리도 동일 원칙으로 통일됨 — 오르테가 정정,
+            # 2026-07-17.)
             app=DeepLinkAppFields(
                 type="dispatched", entity_type="hypothesis", target="now",
                 parent_tab=ParentTab.all,
@@ -600,14 +599,17 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
         ),
         DeepLinkManifestEntry(
-            # 열린 질문 7번 스코프 밖(잔여 오픈아이템): 이 엔트리는 여전히
-            # target="hypothesis_detail"을 쓴다 — dispatched:hypothesis만 "target 실존
-            # 원칙"에 따라 "now" 폴백으로 낮추라는 게 유나 지시 범위였고 이 handoff_stuck
-            # 변형은 명시 대상이 아니었다. 동일 갭(hypothesis_detail 미존재)이 있으므로
-            # S2/S3에서 재확인 필요.
+            # 오르테가 정정(2026-07-17): 앞선 self-flag("스코프 밖")를 보류하지 않고 즉시
+            # 반영 — target="hypothesis_detail"을 그대로 두면 ①"target 실존 원칙"
+            # 위반(hypothesis_detail 라우트 미존재, S2 CI red 또는 오착지) ②방금 정정한
+            # handoff_stuck 5종의 parentTab=all 불변식과 별개로, dispatched:hypothesis와
+            # 동일 target을 쓰면서 다른 처리를 받는 내부 불일치. dispatched:hypothesis와
+            # 동일 원칙(target 실존 원칙)으로 통일 — target="now" 폴백 + 승격 대기 표시.
+            # S3(가설 상세 라우트 신설) PR에서 dispatched:hypothesis와 함께 일괄 승격.
             app=DeepLinkAppFields(
-                type="handoff_stuck", entity_type="hypothesis", target="hypothesis_detail",
+                type="handoff_stuck", entity_type="hypothesis", target="now",
                 parent_tab=ParentTab.all,
+                target_promotion_pending=True,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),

--- a/backend/app/schemas/deeplink_manifest.py
+++ b/backend/app/schemas/deeplink_manifest.py
@@ -104,8 +104,12 @@ class ReturnPolicy(str, Enum):
     # (P2-S3 AC "직접 상세 진입 시 parentTab 루트 엔트리 선존재").
     synthesize_parent = "synthesize_parent"
     # 미등재 타입/필수 필드 누락 등 검증 실패 시: target 자체를 포기하고 `지금` 탭으로
-    # 안전 폴백한다(AC4). 매니페스트에 이 값을 가진 엔트리는 없다 — validate 실패 시
-    # 클라이언트가 자체적으로 이 정책을 적용한다는 뜻의 상수로만 존재.
+    # 안전 폴백한다(AC4) — validate 실패 시 클라이언트가 자체적으로 이 정책을 적용한다는
+    # 뜻의 상수. **또한 target="now" 자체를 등재한 엔트리도 이 값을 명시해야 한다**
+    # (유나 정정, 2026-07-17): target이 이미 `지금` 탭이면 parentTab(all) 루트를 history에
+    # 심고 그 위에 target을 push하는 synthesize_parent가 "all 루트 위에 now 탭을 스택으로
+    # 쌓는" 시맨틱 모순이 된다 — now 탭 전환만 하고 스택 push는 하지 않는다(parentTab
+    # don't-care).
     fallback_now = "fallback_now"
 
 
@@ -418,6 +422,7 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
                 type="dispatched", entity_type="hypothesis", target="now",
                 parent_tab=ParentTab.all,
                 target_promotion_pending=True,
+                return_policy=ReturnPolicy.fallback_now,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
         ),
@@ -610,6 +615,7 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
                 type="handoff_stuck", entity_type="hypothesis", target="now",
                 parent_tab=ParentTab.all,
                 target_promotion_pending=True,
+                return_policy=ReturnPolicy.fallback_now,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),

--- a/backend/app/schemas/deeplink_manifest.py
+++ b/backend/app/schemas/deeplink_manifest.py
@@ -140,6 +140,25 @@ class DeepLinkAppFields(BaseModel):
     )
     parent_tab: ParentTab
     return_policy: ReturnPolicy = ReturnPolicy.synthesize_parent
+    counts_toward_queue_badge: bool = Field(
+        default=True,
+        description=(
+            "결재함(approvals) 탭 배지/큐 카운트에 이 엔트리를 포함할지. parent_tab이 "
+            "approvals여도 False면 화면 자체는 그대로 결재함에 남되 배지 숫자·큐 목록 "
+            "카운트에서는 제외된다(예: gate_overridden — 이미 확정된 FYI 통보라 액션 "
+            "대기 큐가 아님). 긴급성/정보성 구분의 실제 등급 매핑은 #1956(채널 등급)이 "
+            "담당 — 여기서는 큐 카운트 제외 여부만 스텁으로 표현."
+        ),
+    )
+    target_promotion_pending: bool = Field(
+        default=False,
+        description=(
+            "target이 아직 전용 라우트로 승격되지 않은 잠정/폴백 상태임을 FE가 하이라이트 "
+            "표시하는 데 쓰는 플래그. True인 엔트리는 target이 가리키는 화면이 실제로는 "
+            "아직 없고(또는 아직 모바일 전용 라우트가 없고) 승격 시점까지 안전 폴백으로 "
+            "동작한다는 뜻 — 승격 스토리는 엔트리별 주석 참고."
+        ),
+    )
 
 
 class DeepLinkPayloadFields(BaseModel):
@@ -283,15 +302,24 @@ def validate_push_payload(
 DEEPLINK_MANIFEST = DeepLinkManifest(
     entries=[
         # --- 결재함(gate) 계열: reference_type 항상 "gate" → 단일 canonical 상세(P1a-S4) ---
+        # target_promotion_pending=True(이 섹션 전체 7개 엔트리 공통): 유나 3자 검토 반영 —
+        # "gate_detail(S4에서 승격 예정)도 [hypothesis와] 동일 패턴" 지시. gate_detail 자체는
+        # 이미 확정된 canonical 타겟명이지만(웹에는 이미 존재하는 개념), 모바일 전용 라우트는
+        # 아직 없고 P1a-S4가 신설한다 — 그 전까지 이 target을 만나는 클라이언트는 승격 대기
+        # 상태임을 하이라이트 표시해야 한다는 신호. target 문자열 자체("gate_detail")는 유지
+        # (hypothesis처럼 "now" 폴백으로 낮추지 않음 — S4 계획이 확정적이라 target 실존 원칙
+        # 위반이 아님). S4 완료 후 flag를 False로 되돌린다.
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="gate.pending_approval", target="gate_detail", parent_tab=ParentTab.approvals,
+                target_promotion_pending=True,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
         ),
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="gate_approval_requested", target="gate_detail", parent_tab=ParentTab.approvals,
+                target_promotion_pending=True,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a2),
@@ -299,6 +327,7 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="gate_reassigned", target="gate_detail", parent_tab=ParentTab.approvals,
+                target_promotion_pending=True,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a2),
@@ -306,6 +335,7 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="gate_escalated", target="gate_detail", parent_tab=ParentTab.approvals,
+                target_promotion_pending=True,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
@@ -313,15 +343,21 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="gate_reminder", target="gate_detail", parent_tab=ParentTab.approvals,
+                target_promotion_pending=True,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a2),
         ),
         DeepLinkManifestEntry(
-            # FYI: 강제결정 통보 — 액션 불필요(이미 확정됨). approvals 탭에 남기되
-            # returnPolicy는 동일(synthesize_parent). 열린 질문 6번: 지금 탭이 더 맞지 않나.
+            # 열린 질문 6번 답변(유나, 3자 검토): target은 approvals 그대로 유지 — 이미
+            # 확정된 FYI 통보라 결재함 화면 자체에 남기는 게 맞다. 다만 액션이 불필요하므로
+            # 결재함 큐/배지 카운트에서는 제외(counts_toward_queue_badge=False) — 스키마에
+            # 그 구분을 표현할 필드가 없었어서 이번에 추가. 긴급성/정보성 등급 매핑 자체는
+            # #1956(채널 등급, 등급 B)이 확정한다 — channel_grade=b는 이미 그 스텁.
             app=DeepLinkAppFields(
                 type="gate_overridden", target="gate_detail", parent_tab=ParentTab.approvals,
+                counts_toward_queue_badge=False,
+                target_promotion_pending=True,  # gate_detail 공통 사유 — 위 결재함 섹션 헤더 주석 참고.
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
@@ -331,53 +367,75 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             # doc.py가 gate_id를 reference_id로 넘긴다(문서 자체 id 아님).
             app=DeepLinkAppFields(
                 type="doc_approval_requested", target="gate_detail", parent_tab=ParentTab.approvals,
+                target_promotion_pending=True,  # gate_detail 공통 사유 — 위 결재함 섹션 헤더 주석 참고.
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a2),
         ),
 
         # --- dispatched(범용) — reference_type 5종 분기. entity_type 필수. ---
+        # 정정(유나 3자 검토, 필수·조건부 GREEN의 조건): parentTab은 target의 순수 함수여야
+        # 한다("same target ⇒ same parentTab") — 4탭 공간 모델·합성 history(P2-S3) 전제.
+        # 아래 5종 전부 parent_tab을 now → all로 정정(기존 now는 잘못 — story_detail 등
+        # 동일 target을 쓰는 다른 타입들(story_assigned·comment.created 등)이 이미 all이라
+        # 불변식 위반이었다). 정보성/개입성 구분은 parentTab이 아니라 Layer 3(#1956 채널
+        # 등급)의 몫.
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
-                type="dispatched", entity_type="story", target="story_detail", parent_tab=ParentTab.now,
+                type="dispatched", entity_type="story", target="story_detail", parent_tab=ParentTab.all,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
         ),
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
-                type="dispatched", entity_type="epic", target="goal_detail", parent_tab=ParentTab.now,
+                type="dispatched", entity_type="epic", target="goal_detail", parent_tab=ParentTab.all,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+        ),
+        DeepLinkManifestEntry(
+            # 미르코 point ④(3자 검토): doc_detail 착지 시 id↔slug 불일치 우려 — 신규
+            # 리졸버 불필요. reference_id(doc.id)로 기존 GET /api/docs/{id}를 호출하면
+            # 응답(DocResponse, backend/app/schemas/doc.py:94 slug: str 필드)에 이미
+            # slug/canonical_slug가 실려 있다(backend/app/routers/docs.py GET /{id} 핸들러가
+            # DocResponse.model_validate(doc)로 그대로 반환) — 탭 시점에 그 응답의 slug로
+            # resolve하면 된다. 매니페스트/FE 문서화만 반영, docs 라우터 코드 변경 불요.
+            app=DeepLinkAppFields(
+                type="dispatched", entity_type="doc", target="doc_detail", parent_tab=ParentTab.all,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+        ),
+        DeepLinkManifestEntry(
+            # 열린 질문 7번 답변(유나, 3자 검토) — "target 실존 원칙": hypothesis 독립 상세
+            # 라우트가 아직 없다(story #1634 backlog, 확정 계획 없음 — gate_detail과 달리
+            # 정해진 승격 스토리 슬롯이 없었다). "hypothesis_detail"이라는 존재하지 않는
+            # target명을 그대로 두면 AC2 CI(S2)의 "target이 미존재 웹 라우트면 실패" 조건과
+            # 충돌한다 — 그래서 target 자체를 현재 안전 폴백("now")으로 낮추고
+            # target_promotion_pending=True로 하이라이트 표시한다. S3(가설 상세 라우트 신설)
+            # PR에서 target이 실제 라우트로 승격되면 이 값과 flag를 갱신한다.
+            # (참고: handoff_stuck:hypothesis 엔트리는 여전히 target="hypothesis_detail"을
+            # 쓴다 — 이 정정은 dispatched:hypothesis에 한정된 유나 지시 범위라 임의 확장하지
+            # 않았다. 동일 갭이 있으니 S2/S3에서 재확인 필요 — 잔여 오픈아이템으로 남김.)
+            app=DeepLinkAppFields(
+                type="dispatched", entity_type="hypothesis", target="now",
+                parent_tab=ParentTab.all,
+                target_promotion_pending=True,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
         ),
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
-                type="dispatched", entity_type="doc", target="doc_detail", parent_tab=ParentTab.now,
-            ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
-        ),
-        DeepLinkManifestEntry(
-            # 열린 질문 7번: hypothesis 독립 상세 라우트가 아직 없다(story #1634 backlog).
-            # target="hypothesis_detail"은 아직 짓지 않은 화면을 가리킨다 — FE가 P1a-S3
-            # 전까지 이 target을 안전 폴백(지금)으로 취급해야 함(매니페스트 등재는 됐지만
-            # 실제 라우트 미존재 = 별개 리스크. AC2 CI(S2)가 "target이 미존재 웹 라우트면
-            # 실패" 조건과 바로 충돌하는 사례이기도 함).
-            app=DeepLinkAppFields(
-                type="dispatched", entity_type="hypothesis", target="hypothesis_detail",
-                parent_tab=ParentTab.now,
-            ),
-            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
-        ),
-        DeepLinkManifestEntry(
-            app=DeepLinkAppFields(
-                type="dispatched", entity_type="sprint", target="sprint_detail", parent_tab=ParentTab.now,
+                type="dispatched", entity_type="sprint", target="sprint_detail", parent_tab=ParentTab.all,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
         ),
 
         # --- story 계열 ---
         DeepLinkManifestEntry(
+            # 정정(유나 3자 검토): parentTab now → all — story_detail을 쓰는 다른 엔트리
+            # (dispatched:story·story_status_changed·comment.created:story 등)와 동일
+            # parentTab이어야 "same target ⇒ same parentTab" 불변식을 만족한다.
             app=DeepLinkAppFields(
-                type="story_assigned", target="story_detail", parent_tab=ParentTab.now,
+                type="story_assigned", target="story_detail", parent_tab=ParentTab.all,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a2),
@@ -397,13 +455,17 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
         ),
 
-        # --- task — 열린 질문 8번: task_completed payload에 story_id가 없다(reference_type=
-        # "task"·reference_id=task.id뿐). "story_detail" target을 쓰려면 FE가 task_id→
-        # story_id를 별도 API로 풀어야 한다 — 전용 task 상세 화면이 없다면 이 자체가 BE
-        # payload 확장(story_id 추가) 필요 사항일 수 있다. ---
+        # --- task — 열린 질문 8번 답변(유나+미르코, 3자 검토): task_completed payload에
+        # story_id가 없다(reference_type="task"·reference_id=task.id뿐) — 전용 task 상세
+        # 화면도 신설하지 않는다(신규 라우트 불필요, 미르코 point ⑤와 동일 원칙). target을
+        # 조건부 로직을 암시하는 이름("task_detail_or_story_fallback" — "FE가 조건 분기해야
+        # 하나?"라는 오해 유발, SSOT 위반) 대신 팀이 이미 쓰는 고정 폴백 컨벤션인
+        # "/board?story="로 확정한다(apps/web goals-client.tsx·embed-card.tsx·
+        # derive-attention-queue.ts에서 이미 쓰는 패턴 — story_id 없이도 보드로 착지).
+        # 등급은 B(정보성) — #1956 채널 등급 확정 시 참고.
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
-                type="task_completed", target="task_detail_or_story_fallback", parent_tab=ParentTab.all,
+                type="task_completed", target="/board?story=", parent_tab=ParentTab.all,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
@@ -502,11 +564,21 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
         # story/epic/doc/hypothesis/sprint) 아무거나에서 발생할 수 있어 dispatched와 동형
         # 처리 — 열린 질문 9번: 실제로 story 외 엔티티에서 handoff_stuck이 발생한 라이브
         # 사례가 있는지 확인 필요(코드상 가능성은 있으나 이 초안은 5종 전부 등재해 fail-closed
-        # 쪽으로 보수적으로 잡음). ---
+        # 쪽으로 보수적으로 잡음).
+        #
+        # 정정(유나 3자 검토, 필수·조건부 GREEN의 조건): parentTab approvals → all로 정정.
+        # handoff_stuck/handoff_fallback은 결재함(P2-S4) 4유형 큐(게이트·결정·문서결재·
+        # 머지게이트) 어디에도 속하지 않는 유형이라 approvals 탭에 두면 안 된다 — 그 4유형
+        # 큐와 나란히 놓이면 사용자가 "이것도 결재 대상"으로 오인한다. 또한 story_detail/
+        # goal_detail/doc_detail/sprint_detail target을 쓰는 다른 엔트리(dispatched·
+        # story_status_changed 등)가 전부 all이므로 approvals로 두면 "same target ⇒ same
+        # parentTab" 불변식도 깨진다. 긴급성 신호는 parentTab이 아니라 #1956(채널 등급 A1/
+        # A2)의 몫으로 넘긴다 — channel_grade=a1은 그대로 유지(이미 긴급 등급으로 스텁돼
+        # 있었음). ---
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="handoff_stuck", entity_type="story", target="story_detail",
-                parent_tab=ParentTab.approvals,
+                parent_tab=ParentTab.all,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
@@ -514,7 +586,7 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="handoff_stuck", entity_type="epic", target="goal_detail",
-                parent_tab=ParentTab.approvals,
+                parent_tab=ParentTab.all,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
@@ -522,15 +594,20 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="handoff_stuck", entity_type="doc", target="doc_detail",
-                parent_tab=ParentTab.approvals,
+                parent_tab=ParentTab.all,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
         ),
         DeepLinkManifestEntry(
+            # 열린 질문 7번 스코프 밖(잔여 오픈아이템): 이 엔트리는 여전히
+            # target="hypothesis_detail"을 쓴다 — dispatched:hypothesis만 "target 실존
+            # 원칙"에 따라 "now" 폴백으로 낮추라는 게 유나 지시 범위였고 이 handoff_stuck
+            # 변형은 명시 대상이 아니었다. 동일 갭(hypothesis_detail 미존재)이 있으므로
+            # S2/S3에서 재확인 필요.
             app=DeepLinkAppFields(
                 type="handoff_stuck", entity_type="hypothesis", target="hypothesis_detail",
-                parent_tab=ParentTab.approvals,
+                parent_tab=ParentTab.all,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
@@ -538,7 +615,7 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="handoff_stuck", entity_type="sprint", target="sprint_detail",
-                parent_tab=ParentTab.approvals,
+                parent_tab=ParentTab.all,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
@@ -546,7 +623,7 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="handoff_fallback", entity_type="story", target="story_detail",
-                parent_tab=ParentTab.approvals,
+                parent_tab=ParentTab.all,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),

--- a/backend/app/schemas/deeplink_manifest.py
+++ b/backend/app/schemas/deeplink_manifest.py
@@ -1,0 +1,559 @@
+"""story #1951 (E-MOBILE P1a-S1): 딥링크 계약 매니페스트 v1 — DRAFT.
+
+⚠️ 이 파일은 3자 검토(디디 BE 초안 → 유나 FE 착지화면 요건 오너 + 미르코 FE 소비 오너) 전
+초안이다. 승인 전에는 CI에 정식 편입하지 않는다(fixture는 로컬 실행 검증까지만 — story
+#1951 스코프). 승인 후 실제 편입은 story #1952(P1a-S2 FE·BE 딥링크 계약 CI)에서 다룬다.
+
+## 배경
+
+서버가 발송하는 모바일 알림(push/in-app)이 앱 내 어느 화면(딥링크)으로 착지해야 하는지에 대한
+단일 계약(SSOT)이 지금까지 없었다. `dispatch_notification()`
+(app/services/notification_dispatch.py)가 human/agent 멤버에게 나가는 모든 알림
+(in-app Notification·Event·개인 webhook·EE Expo push)의 **유일한 choke point**라는 게
+전수 조사로 확인됐다(다른 경로에서 `Notification(...)` 을 직접 INSERT하는 곳은 없음 —
+`grep -rl "Notification(" backend/app` 결과 `models/notification.py`(정의)와
+`services/notification_dispatch.py`(유일한 사용처) 뿐).
+
+Expo push data payload(`ee/services/expo_push.py:deliver_expo_push`)는 다음 필드만 담는다:
+    {"event_type": str, "reference_type": str | None, "reference_id": str | None}
+→ 클라이언트가 딥링크를 결정할 수 있는 **유일한 실제 재료**가 이 세 필드다. 이 매니페스트의
+`type`/`entity_type` 룩업 키는 이 payload 필드와 정확히 대응하도록 설계했다(아래 "룩업 알고리즘"
+참고).
+
+## 3-레이어 필드 분리 (AC3)
+
+Layer 1 (앱 SSOT) — 클라이언트가 딥링크 라우팅에만 쓰는 필드. FE 빌드에 박히는 지식.
+    type, entity_type, target, parentTab, returnPolicy
+
+Layer 2 (BE payload 계약) — 서버가 실제로 push data에 담는 것에 대한 계약(어떤 필드가 항상
+있는지, 어떤 필드가 이 타입에 한해 필수인지). BE가 이 계약을 어기면 fixture가 fail-closed.
+    org_id_included, project_id_included, requiredPayload
+
+Layer 3 (채널 등급) — story #1956이 실제 channelId 매핑(A1=intervention-urgent·
+A2=intervention·B=info)을 담당한다. 이 스토리는 필드만 예약(스텁)한다 — 매핑 값 자체는
+#1956 없이는 "unassigned"로 둔다. 지금 채널 값은 전부 "default"(EE expo_push.py 참고 —
+아직 하드코딩된 "default" 하나뿐).
+    channel_grade
+
+세 레이어를 하나의 flat dict가 아니라 명시적으로 분리된 sub-model 3개로 표현한 이유는
+"필드가 섞이지 않고 명확히 분리돼야 한다"(AC3)를 타입 레벨에서 강제하기 위함이다 — 이후
+스토리(S2 FE·BE CI, S6 channelId)가 각자 레이어만 건드리면 되고 실수로 다른 레이어 필드를
+같이 바꾸는 걸 코드 리뷰에서 더 쉽게 잡을 수 있다. **열린 질문 1번**(하단) 참고 — PO가
+AC 문구 그대로 flat 7필드를 원했다면 조정 필요.
+
+## 룩업 알고리즘 (제안 — 열린 질문 2번)
+
+`event_type` 리터럴 24종 중 4종(`dispatched`·`comment.created`·`handoff_stuck`·
+`handoff_fallback`)은 **동일 event_type 값이 서로 다른 target을 가리킨다** — 실제 목적지가
+`reference_type`(push data payload에 이미 실려 있음)에 의존하기 때문이다. 예:
+`dispatched`는 epic/story/doc/hypothesis/sprint 5종 엔티티 아무거나에 대해 발화되고,
+5종 모두 다른 화면으로 가야 한다.
+
+이 문제를 "type 문자열을 클라이언트가 concat"(`f"{event_type}.{reference_type}"`)하는
+방식 대신, **매니페스트 엔트리에 `entity_type: str | None` 필드를 별도로 둬서 튜플
+`(type, entity_type)`로 룩업**하는 방식을 택했다 — payload를 그대로 조회 키로 쓸 수 있어
+클라이언트 쪽 문자열 조립 로직/오타 여지가 없다. entity_type=None인 엔트리는 해당
+event_type이 어차피 단일 reference_type만 발화한다는 뜻(예: `gate.pending_approval`은
+항상 reference_type="gate")이라 두 번째 키가 필요 없다.
+
+룩업 순서: ①`(payload.event_type, payload.reference_type)` 정확매치 시도 → ②없으면
+`(payload.event_type, None)` 매치 시도(entity_type 무관 단일 타겟 엔트리) → ③그래도
+없으면 미등재 → AC4 안전 폴백(`지금` 탭).
+
+## 버전 정책
+
+`MANIFEST_SCHEMA_VERSION`(현재 1)은 **엔트리 개별이 아니라 매니페스트 전체**에 붙는다.
+- **PATCH 없음**(schema_version 유지): 신규 엔트리 추가, 기존 엔트리의 `title/body` 류
+  설명 문구 변경. 구버전 앱은 신규 타입을 어차피 모르므로 AC4 폴백(`지금`)으로 안전하게
+  처리된다 — 하위호환 additive.
+- **MAJOR bump 필요**(schema_version += 1): Layer 1 필드의 이름/의미 변경(`target` 값
+  체계 변경, `parentTab` enum 값 rename/삭제, `returnPolicy` 의미 변경), 또는 기존
+  엔트리의 `target`이 가리키는 실제 화면이 바뀌어 구버전 앱이 잘못된 화면으로 착지하게
+  되는 경우. 구버전 앱이 신버전 schema_version을 만나면 자신이 아는 schema_version보다
+  높은 매니페스트는 무시하고 AC4 폴백으로 떨어지는 것을 앱 쪽(P1b, 이 스토리 스코프 밖)이
+  구현해야 한다 — **열린 질문 3번**.
+- 이 매니페스트 자체(`DEEPLINK_MANIFEST` 리스트)는 BE 코드 배포 즉시 바뀐다. 앱은 매
+  콜드스타트/포그라운드 복귀 시 최신 매니페스트를 받아와야 신규 타입을 안다는 전제
+  — 이 조회 API(예: `GET /api/v1/deeplink-manifest`)는 **story #1951 스코프 밖**(S2가
+  CI 대조만 다루고, 별도 서빙 엔드포인트가 필요하면 S2~S6 중 어디서 다룰지 불명확 —
+  **열린 질문 4번**).
+"""
+from __future__ import annotations
+
+import uuid
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+MANIFEST_SCHEMA_VERSION = 1
+
+
+class ParentTab(str, Enum):
+    """P2-S2 모바일 4탭 셸의 탭 4종. P1a-S1은 이 enum만 정의 — 실제 셸 구현은 P2-S2."""
+
+    now = "now"  # 지금 (P2-S8 홈) — AC4 안전 폴백 대상이기도 함
+    approvals = "approvals"  # 결재함 (P2-S4 통합 큐)
+    chat = "chat"  # 채팅
+    all = "all"  # 전체
+
+
+class ReturnPolicy(str, Enum):
+    """딥링크 진입 후 BACK 동작 정책(P2-S3 합성 history와 연동)."""
+
+    # 정상 등재 타입: parentTab 루트를 history에 먼저 심고 target으로 push한다
+    # (P2-S3 AC "직접 상세 진입 시 parentTab 루트 엔트리 선존재").
+    synthesize_parent = "synthesize_parent"
+    # 미등재 타입/필수 필드 누락 등 검증 실패 시: target 자체를 포기하고 `지금` 탭으로
+    # 안전 폴백한다(AC4). 매니페스트에 이 값을 가진 엔트리는 없다 — validate 실패 시
+    # 클라이언트가 자체적으로 이 정책을 적용한다는 뜻의 상수로만 존재.
+    fallback_now = "fallback_now"
+
+
+class ChannelGrade(str, Enum):
+    """Layer 3 스텁 — story #1956이 실제 매핑을 확정한다. 지금은 전부 unassigned
+    (EE expo_push.py의 channelId는 현재 하드코딩 "default" 하나뿐 — 3등급 분화 없음)."""
+
+    a1 = "A1"  # intervention-urgent (안 열면 손실/블로킹 — 예: SLA 만료 임박 게이트)
+    a2 = "A2"  # intervention (액션 필요하지만 긴급 아님)
+    b = "B"  # info (읽기 전용 FYI)
+    unassigned = "unassigned"  # #1956 완료 전 기본값
+
+
+class DeepLinkAppFields(BaseModel):
+    """Layer 1 — 앱 SSOT. 클라이언트가 이 필드들만으로 딥링크 라우팅을 결정한다."""
+
+    model_config = ConfigDict(frozen=True)
+
+    type: str = Field(description="push data.event_type 원문 리터럴")
+    entity_type: str | None = Field(
+        default=None,
+        description=(
+            "push data.reference_type 매치용 2차 키. None이면 이 event_type은 항상 "
+            "단일 target(reference_type 무관)이라 무시된다."
+        ),
+    )
+    target: str = Field(
+        description=(
+            "논리적 화면 식별자(실제 URL 아님 — 라우트는 P1a-S3~S5/P2-S* 별도 스토리가 "
+            "짓는다). FE가 이 키로 실제 컴포넌트/라우트에 매핑."
+        )
+    )
+    parent_tab: ParentTab
+    return_policy: ReturnPolicy = ReturnPolicy.synthesize_parent
+
+
+class DeepLinkPayloadFields(BaseModel):
+    """Layer 2 — BE payload 계약. fixture가 이 필드로 fail-closed 검증을 한다."""
+
+    model_config = ConfigDict(frozen=True)
+
+    org_id_included: bool = Field(
+        default=False,
+        description=(
+            "push data payload에 org_id가 포함되는가. 현재 deliver_expo_push()는 "
+            "data payload에 org_id를 넣지 않는다(코드 실측: event_type/reference_type/"
+            "reference_id 셋뿐) — 이 필드가 org_id 전부 False인 이유. AC 스코프 필드명 "
+            "그대로 유지하되 '항상 False'라는 사실 자체가 열린 질문 5번(org_id/project_id "
+            "가 실제로 필요하면 BE가 아직 안 보내고 있다는 뜻)."
+        ),
+    )
+    project_id_included: bool = Field(default=False)
+    required_payload: list[str] = Field(
+        default_factory=list,
+        description=(
+            "data payload에 반드시 있어야 하는 키 이름(event_type 제외 — 그건 항상 "
+            "있다고 전제). reference_id를 요구하면 필수, target 해석에 reference_id가 "
+            "필요 없는 타입(예: agent_joined처럼 항상 team_member 화면으로 가지만 특정 "
+            "id 없이도 목록으로 폴백 가능한 케이스는 없음 — 이 초안에선 reference_type이 "
+            "있는 모든 타입이 reference_id도 요구)."
+        ),
+    )
+
+
+class DeepLinkChannelFields(BaseModel):
+    """Layer 3 — 채널 등급 스텁. story #1956 완료 전까지 전부 unassigned."""
+
+    model_config = ConfigDict(frozen=True)
+
+    channel_grade: ChannelGrade = ChannelGrade.unassigned
+
+
+class DeepLinkManifestEntry(BaseModel):
+    """매니페스트 1행 = 알림 타입 1종(또는 타입+entity_type 조합) → 착지 계약."""
+
+    model_config = ConfigDict(frozen=True)
+
+    app: DeepLinkAppFields
+    payload: DeepLinkPayloadFields
+    channel: DeepLinkChannelFields = DeepLinkChannelFields()
+
+    @property
+    def lookup_key(self) -> tuple[str, str | None]:
+        return (self.app.type, self.app.entity_type)
+
+
+class DeepLinkManifest(BaseModel):
+    """매니페스트 전체 = schema_version + 엔트리 목록."""
+
+    schema_version: int = MANIFEST_SCHEMA_VERSION
+    entries: list[DeepLinkManifestEntry]
+
+    @model_validator(mode="after")
+    def _no_duplicate_keys(self) -> "DeepLinkManifest":
+        seen: set[tuple[str, str | None]] = set()
+        for e in self.entries:
+            k = e.lookup_key
+            if k in seen:
+                raise ValueError(f"duplicate manifest lookup_key: {k}")
+            seen.add(k)
+        return self
+
+    def find(self, event_type: str, reference_type: str | None) -> DeepLinkManifestEntry | None:
+        """룩업 알고리즘: ①(event_type,reference_type) 정확매치 → ②(event_type,None) →
+        ③None(미등재 — 호출자가 AC4 안전 폴백 처리)."""
+        by_key = {e.lookup_key: e for e in self.entries}
+        return by_key.get((event_type, reference_type)) or by_key.get((event_type, None))
+
+
+class UnregisteredDeepLinkTypeError(ValueError):
+    """AC2/AC4: 매니페스트에 없는 (event_type, reference_type) 조합. 호출자는 이 예외를
+    잡아 `지금` 탭(ParentTab.now/ReturnPolicy.fallback_now)으로 폴백해야 한다."""
+
+    def __init__(self, event_type: str, reference_type: str | None) -> None:
+        self.event_type = event_type
+        self.reference_type = reference_type
+        super().__init__(
+            f"unregistered deeplink type: event_type={event_type!r} reference_type={reference_type!r}"
+        )
+
+
+class MissingRequiredDeepLinkPayloadError(ValueError):
+    """AC2: 등재된 타입이지만 requiredPayload에 명시된 필드가 payload에서 빠짐."""
+
+    def __init__(self, event_type: str, missing: list[str]) -> None:
+        self.event_type = event_type
+        self.missing = missing
+        super().__init__(f"missing required payload field(s) for {event_type!r}: {missing}")
+
+
+def validate_push_payload(
+    manifest: DeepLinkManifest, data: dict
+) -> DeepLinkManifestEntry:
+    """fixture/CI가 쓸 fail-closed 검증 함수 (draft — story #1952가 CI 편입 시 재사용/이관).
+
+    data: EE expo_push.py deliver_expo_push()가 만드는 data payload 형태
+        {"event_type": str, "reference_type": str|None, "reference_id": str|None, ...}
+
+    등재 안 된 (event_type,reference_type) → UnregisteredDeepLinkTypeError.
+    required_payload 필드 누락 → MissingRequiredDeepLinkPayloadError.
+    둘 다 통과 시 매치된 DeepLinkManifestEntry 반환.
+    """
+    event_type = data.get("event_type")
+    if not event_type:
+        raise UnregisteredDeepLinkTypeError(event_type="", reference_type=data.get("reference_type"))
+    reference_type = data.get("reference_type")
+
+    entry = manifest.find(event_type, reference_type)
+    if entry is None:
+        raise UnregisteredDeepLinkTypeError(event_type, reference_type)
+
+    missing = [f for f in entry.payload.required_payload if not data.get(f)]
+    if missing:
+        raise MissingRequiredDeepLinkPayloadError(event_type, missing)
+
+    return entry
+
+
+# ============================================================================
+# SSOT 레지스트리 — story #1951 GATE 1 전수 조사 결과.
+#
+# 출처: `grep -rn "dispatch_notification(" backend/app backend/ee --include="*.py"`
+# (2026-07-17, feat/1951-deeplink-manifest 워크트리 @ origin/develop 71b528f6 기준) —
+# `app/services/notification_dispatch.py:dispatch_notification()`가 in-app
+# Notification·agent Event·개인 webhook·EE Expo push **전부의 유일한 choke point**임을
+# `grep -rl "Notification(" backend/app` (models/notification.py 정의 + 이 파일 유일
+# 사용처)로 재확인. 이 함수에 전달되는 event_type 리터럴만이 실제로 인간 멤버에게
+# push/in-app 알림으로 나가는 타입이다(webhook-only 이벤트인 story.assignee_changed·
+# epic.reordered·message.created(workflow trigger)·conversation.message_created
+# (CC 웹훅 릴레이)·a2a.task_message 등은 다른 채널(외부 시스템/에이전트 SSE)로만 가고
+# dispatch_notification을 타지 않으므로 이 매니페스트 스코프 밖 — 상세는 최종 보고
+# "알림 타입 전수 조사" 표 참고).
+# ============================================================================
+
+DEEPLINK_MANIFEST = DeepLinkManifest(
+    entries=[
+        # --- 결재함(gate) 계열: reference_type 항상 "gate" → 단일 canonical 상세(P1a-S4) ---
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="gate.pending_approval", target="gate_detail", parent_tab=ParentTab.approvals,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+        ),
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="gate_approval_requested", target="gate_detail", parent_tab=ParentTab.approvals,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a2),
+        ),
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="gate_reassigned", target="gate_detail", parent_tab=ParentTab.approvals,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a2),
+        ),
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="gate_escalated", target="gate_detail", parent_tab=ParentTab.approvals,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
+        ),
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="gate_reminder", target="gate_detail", parent_tab=ParentTab.approvals,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a2),
+        ),
+        DeepLinkManifestEntry(
+            # FYI: 강제결정 통보 — 액션 불필요(이미 확정됨). approvals 탭에 남기되
+            # returnPolicy는 동일(synthesize_parent). 열린 질문 6번: 지금 탭이 더 맞지 않나.
+            app=DeepLinkAppFields(
+                type="gate_overridden", target="gate_detail", parent_tab=ParentTab.approvals,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
+        ),
+        DeepLinkManifestEntry(
+            # doc 결재도 gate 경유(reference_type="gate") — doc_approval_requested는
+            # doc.py가 gate_id를 reference_id로 넘긴다(문서 자체 id 아님).
+            app=DeepLinkAppFields(
+                type="doc_approval_requested", target="gate_detail", parent_tab=ParentTab.approvals,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a2),
+        ),
+
+        # --- dispatched(범용) — reference_type 5종 분기. entity_type 필수. ---
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="dispatched", entity_type="story", target="story_detail", parent_tab=ParentTab.now,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+        ),
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="dispatched", entity_type="epic", target="goal_detail", parent_tab=ParentTab.now,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+        ),
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="dispatched", entity_type="doc", target="doc_detail", parent_tab=ParentTab.now,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+        ),
+        DeepLinkManifestEntry(
+            # 열린 질문 7번: hypothesis 독립 상세 라우트가 아직 없다(story #1634 backlog).
+            # target="hypothesis_detail"은 아직 짓지 않은 화면을 가리킨다 — FE가 P1a-S3
+            # 전까지 이 target을 안전 폴백(지금)으로 취급해야 함(매니페스트 등재는 됐지만
+            # 실제 라우트 미존재 = 별개 리스크. AC2 CI(S2)가 "target이 미존재 웹 라우트면
+            # 실패" 조건과 바로 충돌하는 사례이기도 함).
+            app=DeepLinkAppFields(
+                type="dispatched", entity_type="hypothesis", target="hypothesis_detail",
+                parent_tab=ParentTab.now,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+        ),
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="dispatched", entity_type="sprint", target="sprint_detail", parent_tab=ParentTab.now,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+        ),
+
+        # --- story 계열 ---
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="story_assigned", target="story_detail", parent_tab=ParentTab.now,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a2),
+        ),
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="story_status_changed", target="story_detail", parent_tab=ParentTab.all,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
+        ),
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="comment.created", entity_type="story", target="story_detail",
+                parent_tab=ParentTab.all,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+        ),
+
+        # --- task — 열린 질문 8번: task_completed payload에 story_id가 없다(reference_type=
+        # "task"·reference_id=task.id뿐). "story_detail" target을 쓰려면 FE가 task_id→
+        # story_id를 별도 API로 풀어야 한다 — 전용 task 상세 화면이 없다면 이 자체가 BE
+        # payload 확장(story_id 추가) 필요 사항일 수 있다. ---
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="task_completed", target="task_detail_or_story_fallback", parent_tab=ParentTab.all,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
+        ),
+
+        # --- visual artifact 계열 ---
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="comment.created", entity_type="visual_artifact", target="artifact_detail",
+                parent_tab=ParentTab.all,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+        ),
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="artifact.created", target="artifact_detail", parent_tab=ParentTab.all,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
+        ),
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="artifact.exported", target="artifact_detail", parent_tab=ParentTab.all,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
+        ),
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="artifact.updated", target="artifact_detail", parent_tab=ParentTab.all,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
+        ),
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="artifact.canonicalized", target="artifact_detail", parent_tab=ParentTab.all,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
+        ),
+
+        # --- 채팅 ---
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="conversation.mention", target="chat_thread", parent_tab=ParentTab.chat,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a2),
+        ),
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="conversation.message", target="chat_thread", parent_tab=ParentTab.chat,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
+        ),
+
+        # --- goal(epic) ---
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="epic_created", target="goal_detail", parent_tab=ParentTab.all,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
+        ),
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="epic_status_changed", target="goal_detail", parent_tab=ParentTab.all,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
+        ),
+
+        # --- sprint ---
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="sprint_closed", target="sprint_detail", parent_tab=ParentTab.all,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
+        ),
+
+        # --- team_member (org 운영) ---
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="agent_joined", target="team_member_detail", parent_tab=ParentTab.all,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
+        ),
+
+        # --- handoff — reference_type 동적(sr.entity_type). handoff_fallback은 코드상
+        # reference_type이 "story"로 하드코딩(workflow_fallback_notify.py:69)이라 단일
+        # 엔트리. handoff_stuck은 워크플로 엔진의 엔티티 5종(READINESS_MATRIX와 동일 도메인:
+        # story/epic/doc/hypothesis/sprint) 아무거나에서 발생할 수 있어 dispatched와 동형
+        # 처리 — 열린 질문 9번: 실제로 story 외 엔티티에서 handoff_stuck이 발생한 라이브
+        # 사례가 있는지 확인 필요(코드상 가능성은 있으나 이 초안은 5종 전부 등재해 fail-closed
+        # 쪽으로 보수적으로 잡음). ---
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="handoff_stuck", entity_type="story", target="story_detail",
+                parent_tab=ParentTab.approvals,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
+        ),
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="handoff_stuck", entity_type="epic", target="goal_detail",
+                parent_tab=ParentTab.approvals,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
+        ),
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="handoff_stuck", entity_type="doc", target="doc_detail",
+                parent_tab=ParentTab.approvals,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
+        ),
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="handoff_stuck", entity_type="hypothesis", target="hypothesis_detail",
+                parent_tab=ParentTab.approvals,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
+        ),
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="handoff_stuck", entity_type="sprint", target="sprint_detail",
+                parent_tab=ParentTab.approvals,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
+        ),
+        DeepLinkManifestEntry(
+            app=DeepLinkAppFields(
+                type="handoff_fallback", entity_type="story", target="story_detail",
+                parent_tab=ParentTab.approvals,
+            ),
+            payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
+            channel=DeepLinkChannelFields(channel_grade=ChannelGrade.a1),
+        ),
+    ],
+)
+
+
+# 미등재(폴백) fixture용 — 매니페스트에 절대 등재되면 안 되는 예시 타입(테스트 전용 상수).
+_UNREGISTERED_EXAMPLE_EVENT_TYPE = "legacy_memo_reply"  # story 91(/memos) 폐기 잔재 — P1a-S5 스코프

--- a/backend/app/schemas/deeplink_manifest.py
+++ b/backend/app/schemas/deeplink_manifest.py
@@ -80,7 +80,6 @@ event_type이 어차피 단일 reference_type만 발화한다는 뜻(예: `gate.
 """
 from __future__ import annotations
 
-import uuid
 from enum import Enum
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator

--- a/backend/tests/test_deeplink_manifest_draft.py
+++ b/backend/tests/test_deeplink_manifest_draft.py
@@ -1,0 +1,143 @@
+"""story #1951 (E-MOBILE P1a-S1) DRAFT fixture — 딥링크 계약 매니페스트 v1 초안 검증.
+
+⚠️ 이 테스트는 3자 검토(디디+유나+미르코) 전 로컬 실행 확인용이다. CI에 정식 편입하는 건
+story #1952(P1a-S2) 스코프 — 이번 스토리는 draft 브랜치에만 존재하고 PR도 열지 않는다.
+
+정상 케이스 ≥1 + 위반 케이스(미등재 타입 1건·필수 필드 누락 1건) 각 ≥1을 로컬에서
+pass/fail(의도된 실패)로 실증한다.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.schemas.deeplink_manifest import (
+    DEEPLINK_MANIFEST,
+    MANIFEST_SCHEMA_VERSION,
+    MissingRequiredDeepLinkPayloadError,
+    ParentTab,
+    UnregisteredDeepLinkTypeError,
+    validate_push_payload,
+)
+
+
+# ---------------------------------------------------------------------------
+# 정상 케이스
+# ---------------------------------------------------------------------------
+
+def test_gate_pending_approval_resolves_to_gate_detail_approvals_tab():
+    """실제 ee/services/expo_push.py deliver_expo_push()가 만드는 data payload 형태를
+    그대로 재현 — gate_service.py:137 gate.pending_approval 호출 실측 기준."""
+    gate_id = str(uuid.uuid4())
+    data = {"event_type": "gate.pending_approval", "reference_type": "gate", "reference_id": gate_id}
+
+    entry = validate_push_payload(DEEPLINK_MANIFEST, data)
+
+    assert entry.app.target == "gate_detail"
+    assert entry.app.parent_tab == ParentTab.approvals
+
+
+def test_dispatched_disambiguates_by_entity_type_story_vs_epic():
+    """agent_dispatch.py: event_type 항상 'dispatched'·reference_type이 실 목적지를 가른다.
+    동일 event_type이 서로 다른 target으로 갈라지는 게 핵심 검증 포인트."""
+    story_data = {
+        "event_type": "dispatched", "reference_type": "story", "reference_id": str(uuid.uuid4()),
+    }
+    epic_data = {
+        "event_type": "dispatched", "reference_type": "epic", "reference_id": str(uuid.uuid4()),
+    }
+
+    story_entry = validate_push_payload(DEEPLINK_MANIFEST, story_data)
+    epic_entry = validate_push_payload(DEEPLINK_MANIFEST, epic_data)
+
+    assert story_entry.app.target == "story_detail"
+    assert epic_entry.app.target == "goal_detail"
+    assert story_entry.app.target != epic_entry.app.target
+
+
+def test_conversation_mention_lands_in_chat_tab():
+    data = {
+        "event_type": "conversation.mention", "reference_type": "conversation",
+        "reference_id": str(uuid.uuid4()),
+    }
+    entry = validate_push_payload(DEEPLINK_MANIFEST, data)
+    assert entry.app.parent_tab == ParentTab.chat
+
+
+def test_manifest_covers_all_24_dispatch_notification_event_types():
+    """AC1 회귀 고정: story #1951 GATE1 전수 조사에서 확인한 dispatch_notification()
+    event_type 리터럴 24종이 전부 등재돼 있어야 한다. 새 알림 타입이 코드에 추가되고
+    이 집합이 갱신 안 되면 이 테스트가 알려준다(양방향 대조 — 매니페스트 초과분도 잡음)."""
+    expected = {
+        "sprint_closed", "task_completed", "story_assigned", "comment.created",
+        "artifact.created", "artifact.exported", "artifact.updated", "artifact.canonicalized",
+        "conversation.mention", "conversation.message", "agent_joined", "handoff_stuck",
+        "dispatched", "epic_created", "epic_status_changed", "gate_escalated", "gate_reminder",
+        "gate.pending_approval", "gate_overridden", "gate_approval_requested", "gate_reassigned",
+        "doc_approval_requested", "handoff_fallback", "story_status_changed",
+    }
+    actual = {e.app.type for e in DEEPLINK_MANIFEST.entries}
+    missing = expected - actual
+    extra = actual - expected
+    assert not missing, f"매니페스트에 없는 실 발송 타입: {missing}"
+    assert not extra, f"실 발송 목록에 없는 매니페스트 초과분(오타/추측 등록 의심): {extra}"
+
+
+# ---------------------------------------------------------------------------
+# 위반 케이스 (의도된 실패 — fail-closed, AC2)
+# ---------------------------------------------------------------------------
+
+def test_unregistered_type_fails_closed():
+    """미등재 타입 — story 91(/memos) 폐기 잔재 같은 legacy event_type이 여기 해당."""
+    data = {"event_type": "legacy_memo_reply", "reference_type": "memo", "reference_id": str(uuid.uuid4())}
+
+    with pytest.raises(UnregisteredDeepLinkTypeError) as exc_info:
+        validate_push_payload(DEEPLINK_MANIFEST, data)
+
+    assert exc_info.value.event_type == "legacy_memo_reply"
+
+
+def test_unregistered_entity_type_variant_fails_closed():
+    """등재된 event_type이지만 등재 안 된 entity_type 조합 — 예: dispatched.task는
+    READINESS_MATRIX(agent_dispatch.py _ENTITY_TYPES)에 없는 조합이라 실제로 발생하지
+    않지만, 매니페스트가 이런 조합도 정확히 거부하는지(엉뚱한 target으로 새지 않는지)
+    확인."""
+    data = {"event_type": "dispatched", "reference_type": "task", "reference_id": str(uuid.uuid4())}
+
+    with pytest.raises(UnregisteredDeepLinkTypeError):
+        validate_push_payload(DEEPLINK_MANIFEST, data)
+
+
+def test_missing_required_reference_id_fails_closed():
+    """reference_id 누락 — required_payload=['reference_id'] 위반. 실제로는
+    dispatch_notification 호출부가 전부 reference_id를 채우지만(코드 실측), payload
+    변조/신규 호출부 실수를 이 fixture가 잡아야 한다는 게 AC2 요지."""
+    data = {"event_type": "gate.pending_approval", "reference_type": "gate", "reference_id": None}
+
+    with pytest.raises(MissingRequiredDeepLinkPayloadError) as exc_info:
+        validate_push_payload(DEEPLINK_MANIFEST, data)
+
+    assert "reference_id" in exc_info.value.missing
+
+
+def test_missing_event_type_key_entirely_fails_closed():
+    """event_type 자체가 없는 기형 payload(방어적 케이스 — 실제로 deliver_expo_push는
+    항상 채우지만 임의 소비자/미래 변경 대비)."""
+    with pytest.raises(UnregisteredDeepLinkTypeError):
+        validate_push_payload(DEEPLINK_MANIFEST, {"reference_type": "gate", "reference_id": "x"})
+
+
+# ---------------------------------------------------------------------------
+# 버전/무결성
+# ---------------------------------------------------------------------------
+
+def test_no_duplicate_lookup_keys():
+    """DeepLinkManifest.__init__의 model_validator가 이미 강제하지만(생성 시점에 raise),
+    로드된 SSOT 인스턴스가 실제로 그 불변식을 만족하는지 명시적으로 재확인."""
+    keys = [e.lookup_key for e in DEEPLINK_MANIFEST.entries]
+    assert len(keys) == len(set(keys))
+
+
+def test_schema_version_is_current():
+    assert DEEPLINK_MANIFEST.schema_version == MANIFEST_SCHEMA_VERSION == 1

--- a/backend/tests/test_deeplink_manifest_draft.py
+++ b/backend/tests/test_deeplink_manifest_draft.py
@@ -141,3 +141,24 @@ def test_no_duplicate_lookup_keys():
 
 def test_schema_version_is_current():
     assert DEEPLINK_MANIFEST.schema_version == MANIFEST_SCHEMA_VERSION == 1
+
+
+def test_same_target_implies_same_parent_tab():
+    """유나(FE 착지화면 오너) 3자 검토 필수 불변식: parentTab은 target의 순수 함수여야
+    한다 — "same target ⇒ same parentTab". 같은 착지 화면이 알림 타입에 따라 소속 탭이
+    갈리면 4탭 공간 모델과 합성 history(P2-S3) 전제가 깨진다.
+
+    이 테스트는 draft 파일에만 존재하지만(story #1951 스코프), story #1952(P1a-S2 계약
+    CI)에서 정식 CI 불변식으로 편입될 예정이다 — 유나 지시로 지금 여기 넣어둔다.
+
+    전체 레지스트리를 target으로 grouping해서 그룹 내 parentTab이 유일한지 확인한다
+    (양방향: 그룹이 2개 이상의 서로 다른 parentTab을 가지면 실패)."""
+    by_target: dict[str, set[ParentTab]] = {}
+    for entry in DEEPLINK_MANIFEST.entries:
+        by_target.setdefault(entry.app.target, set()).add(entry.app.parent_tab)
+
+    violations = {target: tabs for target, tabs in by_target.items() if len(tabs) > 1}
+    assert not violations, (
+        f"target이 서로 다른 parentTab을 가리키는 위반 발견(same target ⇒ same parentTab "
+        f"불변식 깨짐): {violations}"
+    )

--- a/backend/tests/test_deeplink_manifest_endpoint_draft.py
+++ b/backend/tests/test_deeplink_manifest_endpoint_draft.py
@@ -1,0 +1,70 @@
+"""story #1951 (E-MOBILE P1a-S1) DRAFT fixture — GET /api/v2/deeplink-manifest 서빙 엔드포인트.
+
+PO 재정(3자 검토 스코프 확장)으로 이번 스토리에 추가된 런타임 API. mcp.py의
+/api/v2/mcp/manifest 테스트 패턴(test_e_mcp_s2_toolset.py)을 그대로 따른다 — 이 파일도
+draft(3자 검토 전 로컬 실행 확인용)이고, CI 정식 편입은 story #1952 스코프.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.main import app
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _override_auth():
+    return AuthContext(
+        user_id=str(uuid.uuid4()),
+        email=None,
+        claims={"app_metadata": {}},
+        org_id=str(uuid.uuid4()),
+    )
+
+
+@pytest.mark.anyio
+async def test_deeplink_manifest_endpoint_returns_200_with_schema_version_and_lookup_key():
+    app.dependency_overrides[get_current_user] = _override_auth
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get("/api/v2/deeplink-manifest")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["schema_version"] == 1
+    assert isinstance(body["version_policy"], str) and body["version_policy"]
+    assert isinstance(body["entries"], list) and len(body["entries"]) == 33
+
+    # 미르코 point ②: lookup_key = f"{type}:{entity_type}" (구분자 ":") 서빙 시점 파생.
+    story_entry = next(
+        e for e in body["entries"]
+        if e["app"]["type"] == "dispatched" and e["app"]["entity_type"] == "story"
+    )
+    assert story_entry["lookup_key"] == "dispatched:story"
+
+    # entity_type=None인 단일-타겟 엔트리도 콜론 포함 형태로 파생돼야 한다(빈 두번째 절).
+    gate_entry = next(e for e in body["entries"] if e["app"]["type"] == "gate.pending_approval")
+    assert gate_entry["lookup_key"] == "gate.pending_approval:"
+
+    # 미르코 point ①: nested 구조(app/payload/channel) + snake_case 유지 확인.
+    assert set(story_entry.keys()) >= {"lookup_key", "app", "payload", "channel"}
+    assert "parent_tab" in story_entry["app"]
+    assert "required_payload" in story_entry["payload"]
+    assert "channel_grade" in story_entry["channel"]
+
+
+@pytest.mark.anyio
+async def test_deeplink_manifest_endpoint_requires_auth():
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.get("/api/v2/deeplink-manifest")
+    assert resp.status_code in (401, 403)


### PR DESCRIPTION
## Summary
- story #1951 (E-MOBILE P1a-S1) — 서버 발송 알림 24종의 딥링크 착지 계약(SSOT) 신설. 3-레이어 필드 분리(앱 SSOT/BE payload/채널 등급 스텁) + 버전 정책 + 서빙 엔드포인트.
- `GET /api/v2/deeplink-manifest` 신설(PO 재정 스코프 확장 — 매니페스트는 정적 파일이 아니라 런타임 API).
- 삼자 계약 승인 완결: 디디(BE 초안) + 유나(FE 착지화면 요건, 조건부 GREEN→정정 반영 후 clean GREEN) + 미르코(FE 소비 5건 반영) + PO(서빙 엔드포인트 스코프 확장).

## 반영된 정정 이력 (커밋 순서대로)
1. `4fc0e4a9` — 초안: JSON Schema(`type,entity_type,target,parent_tab,return_policy,...`) + 33엔트리 SSOT 레지스트리 + fixture 10건.
2. `2c17e200` — 삼자 검토 1차 verdict 반영: **parentTab = f(target) 불변식**("same target ⇒ same parentTab") 확립 + CI 무결성 테스트 추가, dispatched 5종/story_assigned(now→all)·handoff_stuck 5종+fallback(approvals→all) 정정, gate_overridden(`counts_toward_queue_badge=False`)·hypothesis/gate_detail(`target_promotion_pending`)·task_completed(조건부 이름 금지→고정 폴백) 처리, 서빙 엔드포인트 신설.
3. `3acf4f43` — 잔여 불일치 정정: `handoff_stuck:hypothesis`도 `dispatched:hypothesis`와 동일 원칙(target="now" 폴백)으로 통일.
4. `f4c18d82` — `return_policy` 시맨틱 정정: target="now" 폴백 엔트리 2건에 `return_policy=fallback_now` 명시(기본값 `synthesize_parent`를 쓰면 4탭 독립 스택 모델과 모순).
5. `eb615071` — 미사용 import 제거(ruff).

## Test plan
- [x] `test_deeplink_manifest_draft.py` 11/11 pass — 정상 케이스 4 + 의도된 실패 케이스(미등재 타입/필수필드누락) 4 + 정합성 2 + **불변식 테스트**(33엔트리 전수, target별 parent_tab 유일성).
- [x] `test_deeplink_manifest_endpoint_draft.py` 2/2 pass — 실 ASGI HTTP round-trip(200 응답 shape·lookup_key 파생·401 무인증 거부).
- [x] **뮤테이션 셀프체크**: 불변식 테스트를 무력화하도록 엔트리 하나의 parent_tab을 반대로 바꿔 RED 확인 → 원복 → GREEN 재확인(커밋 미포함).
- [x] `ruff check` clean.
- [x] `app.main` import 정상, 라우트 충돌 0(484개 등록 라우트 중 신규 1개).
- [x] 워크플로우 yaml 무변경 확인.

## PR 셀프 게이트 체크리스트 (`pr-self-gate-checklist-impl-agent`)
- ①어서션 뮤테이션: 확인(위 뮤테이션 셀프체크)
- ②카피 SSOT: N/A(i18n 무변경)
- ③목업 배치: N/A(UI 무변경)
- ④BE raw payload 대조: 확인(실 ASGI HTTP 응답으로 lookup_key/schema_version 검증, 내부 모델만 신뢰 안 함)
- ⑤로컬 실사용: 확인(ASGI TestClient 실 라운드트립)
- ⑥동어반복 테스트: N/A(위반 조합을 내부에서 계산해 주입하지 않고 레지스트리 전수 순회+그룹핑으로 실측)
- ⑦편의 시드 역할타입: N/A
- ⑧인가 target-side: N/A(target-scoped 리소스 조회 없음, 전역 read-only 상수 직렬화)
- ⑨진단 필드 소비자: `lookup_key`는 FE(별도 레포)가 story #1952~ 에서 소비 예정 — 이 레포 내 소비자는 아직 없음(의도된 cross-repo 계약)
- ⑩동시성: N/A
- ⑪마이그레이션: N/A(신규 마이그레이션 없음)
- ⑫왕복검증: N/A(read-only 엔드포인트, write 경로 없음)

## 알려진 잔여 이슈(비차단, S2로 이월 — PO 확인 완료)
- `task_completed` target=`/board?story=`가 Layer1 정의("target=논리적 화면 식별자") 유일 예외 — 팀 컨벤션 실용성상 비차단, S2 CI 편입 시 정리 예정.

🤖 Generated with Claude Code