### PR TITLE
[SID:1958] 모바일 4탭 셸 — 지금·결재함·채팅·전체

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -44,6 +44,14 @@
     "reloginRequired": "Re-login required",
     "capReached": "Account limit reached"
   },
+  "mobileTabBar": {
+    "navLabel": "Mobile tab navigation",
+    "now": "Now",
+    "approvals": "Approvals",
+    "chat": "Chat",
+    "more": "More",
+    "moreTempNotice": "Temporary list — will be replaced by the full screen soon."
+  },
   "nav": {
     "dashboard": "Dashboard",
     "sprintManagement": "Sprint Management",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -44,6 +44,14 @@
     "reloginRequired": "재로그인 필요",
     "capReached": "계정 한도에 도달했습니다"
   },
+  "mobileTabBar": {
+    "navLabel": "모바일 탭 내비게이션",
+    "now": "지금",
+    "approvals": "결재함",
+    "chat": "채팅",
+    "more": "전체",
+    "moreTempNotice": "임시 목록입니다 — 정식 화면으로 곧 교체됩니다."
+  },
   "nav": {
     "dashboard": "대시보드",
     "sprintManagement": "스프린트 관리",

--- a/apps/web/src/app/(authenticated)/more/page.tsx
+++ b/apps/web/src/app/(authenticated)/more/page.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import {
+  FolderKanban,
+  CalendarRange,
+  Layers,
+  Compass,
+  FlaskConical,
+  Users,
+  RotateCcw,
+  Activity,
+  FileText,
+  Image,
+  HardDrive,
+  Settings,
+} from 'lucide-react';
+
+// story #1958(P2-S2) "전체" 탭의 임시 스텁 — blueprint §3.2가 모바일 사이드바(Sheet·햄버거)
+// 폐기 방향이라 기존 GNB Sheet를 탭에 매달지 않고, 최소 목록 라우트로 대신한다. 정식 목록화는
+// P2-S9(story #1965)가 담당 — 이 페이지는 그때 교체된다(오르테가군 확定, 2026-07-17).
+// bare 경로만 씀 — 미들웨어의 bare→쿠키 default 해소 301 안전망이 ws/proj slug를 채운다
+// (app-sidebar.tsx의 resourceLink()와 동형 전제).
+const ITEMS = [
+  { href: '/board', icon: FolderKanban, labelKey: 'board' as const },
+  { href: '/sprints', icon: CalendarRange, labelKey: 'sprints' as const },
+  { href: '/goals', icon: Layers, labelKey: 'goals' as const },
+  { href: '/loops', icon: FlaskConical, labelKey: 'loops' as const },
+  { href: '/standup', icon: Users, labelKey: 'standup' as const },
+  { href: '/retro', icon: RotateCcw, labelKey: 'retro' as const },
+  { href: '/activity', icon: Activity, labelKey: 'activity' as const },
+  { href: '/docs', icon: FileText, labelKey: 'docs' as const },
+  { href: '/artifacts', icon: Image, labelKey: 'artifacts' as const },
+  { href: '/storage', icon: HardDrive, labelKey: 'storage' as const },
+  { href: '/dashboard', icon: Compass, labelKey: 'dashboard' as const },
+  { href: '/settings', icon: Settings, labelKey: 'settings' as const },
+] as const;
+
+export default function MorePage() {
+  const t = useTranslations('nav');
+  const tMore = useTranslations('mobileTabBar');
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-4">
+      <h1 className="mb-1 text-lg font-semibold text-foreground">{tMore('more')}</h1>
+      <p className="mb-4 text-xs text-muted-foreground">{tMore('moreTempNotice')}</p>
+      <ul className="divide-y divide-border rounded-xl border border-border">
+        {ITEMS.map(({ href, icon: Icon, labelKey }) => (
+          <li key={href}>
+            <Link
+              href={href}
+              className="flex min-h-12 items-center gap-3 px-4 py-3 text-sm text-foreground hover:bg-muted"
+            >
+              <Icon className="size-[18px] shrink-0 text-muted-foreground" strokeWidth={1.8} />
+              {t(labelKey)}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -12,6 +12,7 @@ import { useTranslations } from 'next-intl';
 import { RealtimeProvider } from '@/components/realtime-provider';
 import { SessionExpiredDialog } from '@/components/auth/session-expired-dialog';
 import { AppSidebar } from '@/components/nav/app-sidebar';
+import { MobileTabBar } from '@/components/nav/mobile-tab-bar';
 import { TopBar } from '@/components/nav/top-bar';
 import { TopBarProvider, useTopBar } from '@/components/nav/top-bar-context';
 import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
@@ -94,6 +95,10 @@ function ScrollShell({ showTopBar, children }: { showTopBar: boolean; children: 
           {children}
         </ContextualPanelLayout>
       </div>
+      {/* story #1958(P2-S2): <1024(lg 미만) 전용 하단 탭바 — SidebarInset의 flex-col 안에서
+          scroll 컨테이너의 형제(자식 아님)로 둬야 콘텐츠가 스크롤돼도 탭바가 자기 flex row를
+          유지한다(position:fixed 오버레이+패딩 보정 불요 — 시안 511bc035의 flex 레이아웃과 동형). */}
+      <MobileTabBar />
     </SidebarInset>
     </TeamPresenceToggleProvider>
     </ReleaseNotesProvider>

--- a/apps/web/src/components/nav/mobile-tab-bar.tsx
+++ b/apps/web/src/components/nav/mobile-tab-bar.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { CircleDot, Inbox, MessageSquare, Grid2x2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { GateItem } from '@/components/kanban/types';
+
+// story #1958(P2-S2, mobile-p2-p1a-story-breakdown SSOT) — 모바일 4탭 셸. <1024(lg 미만)에서만
+// 렌더되고 데스크톱 GNB(AppSidebar)를 대체한다(P2-S1의 lg:1024 SSOT와 동일 경계 — route 내
+// md·lg 혼재 금지 원칙 그대로 따름). 시안 511bc035 v2 기준.
+//
+// route 매핑(오르테가군 확定, 2026-07-17): "지금"·"결재함" 탭은 셸-우선 원칙에 따라 최종 콘텐츠
+// (지금 홈=S8/#1964, 결재함 통합큐=S4/#1960) 없이 기존 라우트를 그대로 가리킨다 — 후속 스토리가
+// 그 자리에서 콘텐츠만 원자적으로 교체한다(빅뱅 전환 금지).
+const TABS = [
+  { key: 'now', href: '/glance', icon: CircleDot, labelKey: 'now' as const },
+  { key: 'approvals', href: '/inbox', icon: Inbox, labelKey: 'approvals' as const },
+  { key: 'chat', href: '/chats', icon: MessageSquare, labelKey: 'chat' as const },
+  // "전체"는 시안상 정식 목록화 대상(S9/#1965) — 기존 모바일 GNB Sheet(햄버거) 재사용은
+  // blueprint §3.2 "모바일 사이드바 폐기" 방향과 충돌해 하지 않는다(오르테가군 확定). 이 스토리
+  // 에서는 최소 스텁 라우트로만 연결 — S9가 정식 목록으로 교체.
+  { key: 'more', href: '/more', icon: Grid2x2, labelKey: 'more' as const },
+] as const;
+
+function isTabActive(pathname: string, href: string): boolean {
+  if (href === '/inbox') {
+    // "결재함" 탭은 /inbox 루트만 자기 것으로 친다(하위 라우트 없음 — bare path 매치).
+    return pathname === '/inbox';
+  }
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+export function MobileTabBar() {
+  const t = useTranslations('mobileTabBar');
+  const pathname = usePathname();
+  // 결재함 배지 = 서명 대기 수(유나 §3.1 정합) — GateInbox가 이미 쓰는 것과 동일한
+  // `/api/gates?status=pending` 재사용(신규 집계 안 만듦). gate_overridden은 override 시
+  // approver row status가 "overridden"으로 전이돼(gate_service.py) pending 조회에서 자동 제외
+  // — 별도 필터 불요(백엔드 확認 완료).
+  const [pendingCount, setPendingCount] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch('/api/gates?status=pending');
+        if (!res.ok) return;
+        const gates = (await res.json()) as GateItem[];
+        if (!cancelled) setPendingCount(Array.isArray(gates) ? gates.length : 0);
+      } catch {
+        // 배지 카운트 실패는 치명적이지 않음 — 숫자 없이 탭만 정상 동작.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <nav
+      aria-label={t('navLabel')}
+      className="flex h-16 shrink-0 border-t border-border bg-card lg:hidden"
+    >
+      {TABS.map(({ key, href, icon: Icon, labelKey }) => {
+        const active = isTabActive(pathname, href);
+        const badge = key === 'approvals' && pendingCount > 0 ? pendingCount : null;
+        return (
+          <Link
+            key={key}
+            href={href}
+            aria-current={active ? 'page' : undefined}
+            className={cn(
+              'relative flex min-h-12 flex-1 flex-col items-center justify-center gap-0.5 text-[11px]',
+              active ? 'font-semibold text-primary' : 'text-muted-foreground',
+            )}
+          >
+            <span className="relative">
+              <Icon className="size-[22px]" strokeWidth={1.8} />
+              {badge !== null ? (
+                <span
+                  aria-hidden
+                  className="absolute -top-1 left-full ml-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-bold leading-none text-primary-foreground"
+                >
+                  {badge > 9 ? '9+' : badge}
+                </span>
+              ) : null}
+            </span>
+            {t(labelKey)}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/web/src/components/nav/top-bar.tsx
+++ b/apps/web/src/components/nav/top-bar.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { SidebarTrigger } from '@/components/ui/sidebar';
 import { cn } from '@/lib/utils';
 import { NotificationBell } from './notification-bell';
 import { WhatsNewButton } from '@/components/release-notes/whats-new-button';
@@ -24,7 +23,8 @@ export function TopBar({ className }: TopBarProps) {
         className,
       )}
     >
-      <SidebarTrigger className="mr-2 lg:hidden" />
+      {/* story #1958: 모바일 햄버거 트리거 제거 — 하단 탭바(MobileTabBar)가 <1024 내비게이션을
+          대신한다(blueprint §3.2 "모바일 사이드바 Sheet/햄버거 폐기" 방향, 오르테가군 확定). */}
       <div className="flex min-w-0 flex-1 items-center gap-2">
         {title}
       </div>


### PR DESCRIPTION
## Summary
- SSOT: doc `mobile-p2-p1a-story-breakdown` [P2-S2], 시안: artifact `511bc035` v2
- **셸-우선·콘텐츠-후속**(route 원자 전환): 이번 스토리는 하단 탭바 셸만 신설, 기존 라우트에 연결. "지금"·"결재함" 최종 콘텐츠는 S8(#1964)/S4(#1960)가 그 자리서 교체

## 라우팅 매핑 (오르테가군 확定)
- 지금 → `/glance`
- 결재함 → `/inbox`(파라미터 없음 — `?tab=gates` 하드코딩은 S4가 4유형 통합큐로 교체할 때 되돌려야 하는 부채라 지양)
- 채팅 → `/chats`
- 전체 → `/more`(신규 최소 스텁 — 기존 GNB Sheet 재사용은 blueprint §3.2 "모바일 사이드바 폐기" 방향과 충돌해 안 씀. S9(#1965)가 정식 목록화로 교체)

## 구현
- `mobile-tab-bar.tsx`: `<1024`(lg 미만)만 렌더(P2-S1 SSOT 경계와 동일). 결재함 배지=`/api/gates?status=pending`(GateInbox와 동일 소스 재사용, 신규 집계 없음) — `gate_overridden`은 override 시 approver row status가 `"overridden"`으로 전이돼(`gate_service.py`) pending 조회에서 자동 제외됨을 백엔드에서 확認. 탭 `min-h-12`(48px, AC 48dp+). SafeArea 추가 패딩 없음(Expo/RN WebView 셸이 이미 inset 처리 — 민 레 확認 사항, 웹 이중 패딩 금지).
- `top-bar.tsx`: 모바일 햄버거(`SidebarTrigger`) 제거 — 탭바가 대신함. `components/ui/sidebar.tsx`의 Sheet 인프라 자체는 안 건드림(트리거 없어 이제 미도달·공유 primitive라 과잉수정 회피, `settings/page.tsx`는 독자 트리거 소비 중이라 무영향).
- `/more` 페이지: 최소 스텁(bare 경로 — 미들웨어 bare→쿠키 default 301 안전망 전제, `app-sidebar.tsx`의 `resourceLink()`와 동형).

## Test plan
- [x] `tsc --noEmit` — 0 errors
- [x] `eslint` — 0 warnings
- [x] `pnpm build` — EXIT 0(`/more` 라우트 확認)
- [x] `vitest run` 전체 — 1682 passed, 0 failed
- [x] `verify:no-new-md-breakpoint` — 신규 회귀 0
- [ ] dev 배포 후 라이브: 실기기/에뮬 4탭 왕복 + 390/834/1024 시안(511bc035) 대조 + 활성탭·배지=URL/데이터 일치 확認(자네 done-gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)