### PR TITLE
feat(mobile): 딥링크 계약 CI 게이트 (story #1952, P1a-S2)

### DIFF
--- a/backend/app/schemas/deeplink_manifest.py
+++ b/backend/app/schemas/deeplink_manifest.py
@@ -475,16 +475,27 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
         ),
 
         # --- visual artifact 계열 ---
+        # target_promotion_pending=True(이 섹션 전체 5개 엔트리 공통): story #1952(P1a-S2)
+        # FE 라우트 대조 CI 조사에서 확인 — `apps/web/src/components/canvas/
+        # artifact-gallery-view.tsx`(및 `[ws]/[proj]/artifacts/page.tsx`) 전수 확인 결과
+        # "artifact_detail"로 직접 딥링크 가능한 웹 라우트가 없다(useSearchParams/동적
+        # `[id]` 서브라우트 0건 — `ArtifactExpandDialog`는 순수 클라이언트 인메모리 상태로만
+        # 열림). S1 초안 당시엔 "미확인"으로만 표시됐던 항목(doc `draft-1951-deeplink-manifest-v1`
+        # §2)이 이번 조사로 실제 GAP으로 확인됨 — gate_detail(P1a-S4 승격 예정)과 동일 패턴으로
+        # target_promotion_pending=True 표시(target 문자열 자체는 유지, hypothesis처럼 "now"로
+        # 낮추지 않음 — 승격 스토리 슬롯은 후속 결정 필요). AC3(target 실존 원칙) CI 체크
+        # 대상에서 이 플래그로 제외됨.
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="comment.created", entity_type="visual_artifact", target="artifact_detail",
-                parent_tab=ParentTab.all,
+                parent_tab=ParentTab.all, target_promotion_pending=True,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
         ),
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="artifact.created", target="artifact_detail", parent_tab=ParentTab.all,
+                target_promotion_pending=True,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
@@ -492,6 +503,7 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="artifact.exported", target="artifact_detail", parent_tab=ParentTab.all,
+                target_promotion_pending=True,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
@@ -499,6 +511,7 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="artifact.updated", target="artifact_detail", parent_tab=ParentTab.all,
+                target_promotion_pending=True,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),
@@ -506,6 +519,7 @@ DEEPLINK_MANIFEST = DeepLinkManifest(
         DeepLinkManifestEntry(
             app=DeepLinkAppFields(
                 type="artifact.canonicalized", target="artifact_detail", parent_tab=ParentTab.all,
+                target_promotion_pending=True,
             ),
             payload=DeepLinkPayloadFields(required_payload=["reference_id"]),
             channel=DeepLinkChannelFields(channel_grade=ChannelGrade.b),

--- a/backend/tests/deeplink_contract_lib.py
+++ b/backend/tests/deeplink_contract_lib.py
@@ -1,0 +1,415 @@
+"""story #1952 (E-MOBILE P1a-S2): 딥링크 계약 CI 스캐너.
+
+story #1951이 만든 `DEEPLINK_MANIFEST` SSOT(app/schemas/deeplink_manifest.py)를 실제 CI
+게이트로 승격한다. 이 모듈은 두 축을 정적으로 검증하는 유틸을 제공한다:
+
+  AC1/AC2 — `dispatch_notification()` 실제 호출부가 발화 가능한 (event_type, entity_type)
+  조합과 그 payload kwarg를 **소스에서 AST로 직접 추출**해 매니페스트와 대조한다. S1의 draft
+  테스트(`test_manifest_covers_all_24_dispatch_notification_event_types`)는 하드코딩된
+  "기대 집합" 문자열 리터럴과 매니페스트를 대조했다 — 이건 회귀 고정(regression-lock)으로는
+  유용하지만, **신규 dispatch_notification() 호출부가 코드에 추가되고 그 하드코딩 집합도
+  매니페스트도 갱신되지 않으면 조용히 통과한다**(이 스토리가 존재하는 이유 자체를 무력화).
+  이 모듈은 소스를 직접 훑어 "실제 코드가 무엇을 발화하는지"를 스스로 재구성하므로, 신규
+  호출부가 생기면 매니페스트 갱신 없이는 자동으로 CI가 실패한다.
+
+  AC3 — 매니페스트 `target`이 실제 `apps/web` 웹 라우트에 대응하는지 파일시스템으로 대조.
+
+설계 근거(authz_coverage_lib.py 패턴 재사용, S20/SEC-S8): AST 바디 스캔 + **1-hop 래퍼 해소만**
+(재귀 콜그래프 분석 없음) — 대상 규모가 작아(호출부 24곳) 이 제약이 안전하다는 판단도 동일하게
+적용한다. 새로운 래퍼 계층이 추가되면(2-hop 이상) 이 스캐너가 `UnresolvedDispatchCallError`로
+fail-closed 처리한다 — 조용히 놓치지 않는다.
+
+## 스캔 알고리즘
+
+1. `backend/app`+`backend/ee` 전 `.py` 파일을 AST 파싱, `dispatch_notification(...)` 호출
+   노드를 전수 수집한다(각 노드 = 코드상 물리적 호출 지점 하나, 현재 24곳).
+2. 각 호출 노드의 `event_type=`/`reference_type=` kwarg를 리터럴로 직접 해석 시도:
+   - 문자열 리터럴 → 그대로.
+   - `X.replace(a, b)` 형태(단순 1단계 메서드 호출) → `X`를 재귀 해석 후 변환 적용.
+   - 이름(Name)이 **감싸는 함수의 파라미터**와 일치 → 그 함수를 "래퍼"로 등록하고, 코드베이스
+     전체에서 그 함수를 호출하는 지점(현재 known 래퍼: `_notify`·`_emit`)을 찾아 인자 값을
+     역추적한다(1-hop만).
+   - 그래도 리터럴로 못 좁히면(예: `sr.entity_type`·`entity_type` 파라미터) — 이름이
+     `entity_type` 패턴에 매치하면 `WORKFLOW_ENTITY_DOMAIN`(READINESS_MATRIX의
+     dispatch_capable 5종, SSOT 재사용 — 하드코딩 금지)으로 전개한다. 그 외 미해결
+     동적 표현식은 `UnresolvedDispatchCallError`.
+3. 래퍼 호출부가 게이팅 `if <param>:` 안에서만 실제 `dispatch_notification`에 도달하는 경우
+   (예: `goal_events.py:_emit`의 `if notify_ids:`) — 호출자가 그 파라미터에 falsy 리터럴
+   (`None`/`False`)을 넘기면 해당 호출은 "도달 불가"로 스킵한다(정적으로 판별 가능한 경우만 —
+   `emit_goal_removed`가 `notify_member_id=None`을 넘겨 `epic.removed`가 실제로는
+   `dispatch_notification`에 절대 도달하지 않는 케이스가 실측 사례).
+"""
+from __future__ import annotations
+
+import ast
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+BACKEND_DIR = _HERE.parents[1]
+REPO_ROOT = BACKEND_DIR.parent
+APPS_WEB_APP_DIR = REPO_ROOT / "apps" / "web" / "src" / "app"
+
+SCAN_ROOTS = [BACKEND_DIR / "app", BACKEND_DIR / "ee"]
+
+_DISPATCH_FUNC_NAME = "dispatch_notification"
+
+
+class UnresolvedDispatchCallError(RuntimeError):
+    """정적으로 event_type/reference_type을 리터럴 또는 알려진 도메인으로 못 좁힌 호출부.
+
+    fail-closed — 새 동적 패턴이 생기면 이 스캐너를 갱신해야 한다는 신호로 의도적으로 raise."""
+
+
+@dataclass(frozen=True)
+class DispatchCallSite:
+    """`dispatch_notification(...)` 물리적 호출 노드 1개 = 소스상 위치 1곳."""
+
+    file: str
+    lineno: int
+    kwarg_names: frozenset[str]
+    resolved_event_types: tuple[str, ...]
+    resolved_reference_types: tuple[str | None, ...]
+
+
+def _iter_py_files(roots: list[Path]):
+    for root in roots:
+        for dirpath, _dirnames, filenames in os.walk(root):
+            for fn in filenames:
+                if fn.endswith(".py"):
+                    yield Path(dirpath) / fn
+
+
+def _parse(path: Path) -> ast.Module | None:
+    try:
+        src = path.read_text()
+        return ast.parse(src, filename=str(path))
+    except (OSError, SyntaxError):
+        return None
+
+
+def _is_dispatch_call(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    f = node.func
+    if isinstance(f, ast.Name):
+        return f.id == _DISPATCH_FUNC_NAME
+    if isinstance(f, ast.Attribute):
+        return f.attr == _DISPATCH_FUNC_NAME
+    return False
+
+
+def _kwarg_value(call: ast.Call, name: str) -> ast.AST | None:
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+    return None
+
+
+def _func_positional_params(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    return [a.arg for a in (fn.args.posonlyargs + fn.args.args)]
+
+
+def _func_kwonly_params(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    return [a.arg for a in fn.args.kwonlyargs]
+
+
+def _find_enclosing_function(
+    module: ast.Module, target: ast.AST,
+) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    """target 노드를 body(재귀)로 포함하는 가장 안쪽 FunctionDef/AsyncFunctionDef.
+
+    parent-pointer 없이 각 함수 정의를 후보로 놓고 `ast.walk`로 포함 여부(identity)를 검사—
+    authz_coverage_lib.py와 달리 여기선 여러 함수가 중첩될 수 있어 "가장 작은(안쪽)" 함수를
+    고른다(walk된 노드 수가 가장 적은 후보)."""
+    best: ast.FunctionDef | ast.AsyncFunctionDef | None = None
+    best_size = None
+    for node in ast.walk(module):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            contained = list(ast.walk(node))
+            if any(n is target for n in contained):
+                if best_size is None or len(contained) < best_size:
+                    best = node
+                    best_size = len(contained)
+    return best
+
+
+def _alias_source_param(
+    fn: ast.FunctionDef | ast.AsyncFunctionDef, local_name: str, params: list[str],
+) -> str | None:
+    """local_name이 fn 파라미터가 아니면, fn 바디에서 `local_name = <X> if <param> else ...`
+    형태(3항 연산)의 대입을 찾아 그 조건절 파라미터 이름을 반환한다.
+
+    (goal_events.py `_emit`: `notify_ids = {notify_member_id} if notify_member_id else None`
+    — 게이팅 검사가 `if notify_ids:`를 보지만 실제 truthy 근원은 파라미터 `notify_member_id`.)
+    """
+    if local_name in params:
+        return local_name
+    for node in ast.walk(fn):
+        targets: list[ast.AST] = []
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+            value = node.value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            targets = [node.target]
+            value = node.value
+        else:
+            continue
+        if not any(isinstance(t, ast.Name) and t.id == local_name for t in targets):
+            continue
+        if isinstance(value, ast.IfExp) and isinstance(value.test, ast.Name):
+            if value.test.id in params:
+                return value.test.id
+    return None
+
+
+def _gating_param_name(
+    fn: ast.FunctionDef | ast.AsyncFunctionDef, call: ast.Call, params: list[str],
+) -> str | None:
+    """call이 fn 바디 안에서 `if <Name>:` 의 then-분기에만 있으면, 그 Name이 실제로
+    가리키는 파라미터 이름을 반환(직접 파라미터거나, 3항연산 별칭을 통한 간접 참조 — 위
+    `_alias_source_param` 참고).
+
+    (goal_events.py `_emit`의 `if notify_ids: ... dispatch_notification(...)` 패턴 검출용
+    — 호출자가 그 근원 파라미터에 falsy 리터럴을 넘기면 dispatch_notification에 도달 못 함.)
+    """
+    for node in ast.walk(fn):
+        if isinstance(node, ast.If) and isinstance(node.test, ast.Name):
+            contained_in_body = [n for stmt in node.body for n in ast.walk(stmt)]
+            if any(n is call for n in contained_in_body):
+                return _alias_source_param(fn, node.test.id, params)
+    return None
+
+
+def _literal_str(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _is_falsy_literal(node: ast.AST) -> bool:
+    if isinstance(node, ast.Constant):
+        return node.value in (None, False, 0, "")
+    return False
+
+
+def _resolve_replace_transform(node: ast.AST) -> tuple[str, str, str] | None:
+    """`X.replace("a", "b")` 형태면 (base_name, old, new) 반환, 아니면 None."""
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "replace"
+        and isinstance(node.func.value, ast.Name)
+        and len(node.args) == 2
+    ):
+        old = _literal_str(node.args[0])
+        new = _literal_str(node.args[1])
+        if old is not None and new is not None:
+            return node.func.value.id, old, new
+    return None
+
+
+def _find_wrapper_call_sites(all_modules: dict[Path, ast.Module], func_name: str):
+    """코드베이스 전체에서 `func_name(...)` 을 호출하는 ast.Call 노드 전부(파일 무관)."""
+    for path, module in all_modules.items():
+        for node in ast.walk(module):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == func_name
+            ):
+                yield path, node
+
+
+def _bound_arg(
+    call: ast.Call, params: list[str], kwonly: list[str], name: str,
+) -> ast.AST | None:
+    if name in params:
+        idx = params.index(name)
+        if idx < len(call.args):
+            return call.args[idx]
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+    return None
+
+
+def scan_dispatch_notification_call_sites() -> list[DispatchCallSite]:
+    """`dispatch_notification()` 실제 물리 호출부 전수 스캔 + event_type/reference_type 해석.
+
+    resolved_event_types/resolved_reference_types는 각각 이 호출부가 실제로 발화 가능한 값의
+    전체 집합(카티전 곱은 호출자 쪽에서 필요시 구성) — 보통 1개, 동적 entity_type 도메인
+    전개 시 여러 개(예: `dispatched`는 5개 reference_type)."""
+    from app.services.workflow_readiness_matrix import READINESS_MATRIX
+
+    workflow_entity_domain = tuple(
+        sorted(k for k, v in READINESS_MATRIX.items() if v.dispatch_capable)
+    )
+
+    all_modules: dict[Path, ast.Module] = {}
+    for path in _iter_py_files(SCAN_ROOTS):
+        module = _parse(path)
+        if module is not None:
+            all_modules[path] = module
+
+    sites: list[DispatchCallSite] = []
+
+    for path, module in all_modules.items():
+        for node in ast.walk(module):
+            if not _is_dispatch_call(node):
+                continue
+            kwarg_names = frozenset(kw.arg for kw in node.keywords if kw.arg is not None)
+
+            event_types = _resolve_field(
+                node, "event_type", module, all_modules, workflow_entity_domain,
+                file=path, lineno=node.lineno,
+            )
+            reference_types = _resolve_field(
+                node, "reference_type", module, all_modules, workflow_entity_domain,
+                file=path, lineno=node.lineno, allow_none=True,
+            )
+
+            sites.append(DispatchCallSite(
+                file=str(path.relative_to(REPO_ROOT)),
+                lineno=node.lineno,
+                kwarg_names=kwarg_names,
+                resolved_event_types=tuple(event_types),
+                resolved_reference_types=tuple(reference_types),
+            ))
+
+    return sites
+
+
+def _resolve_field(
+    call: ast.Call, field_name: str, module: ast.Module,
+    all_modules: dict[Path, ast.Module], workflow_entity_domain: tuple[str, ...],
+    *, file: Path, lineno: int, allow_none: bool = False,
+) -> list[str | None]:
+    value = _kwarg_value(call, field_name)
+    if value is None:
+        if allow_none:
+            return [None]
+        raise UnresolvedDispatchCallError(
+            f"{file}:{lineno} dispatch_notification() 호출에 {field_name}= kwarg가 없음"
+        )
+
+    lit = _literal_str(value)
+    if lit is not None:
+        return [lit]
+
+    if isinstance(value, ast.Constant) and value.value is None and allow_none:
+        return [None]
+
+    # entity_type 패턴(Name 또는 Attribute) → 워크플로 엔티티 도메인 전개.
+    if isinstance(value, ast.Name) and value.id == "entity_type":
+        return list(workflow_entity_domain)
+    if isinstance(value, ast.Attribute) and value.attr == "entity_type":
+        return list(workflow_entity_domain)
+
+    transform = _resolve_replace_transform(value)
+    if transform is not None:
+        base_name, old, new = transform
+        resolved = _resolve_name_via_wrapper(
+            call, base_name, module, all_modules, file=file, lineno=lineno,
+        )
+        return [r.replace(old, new) if r is not None else None for r in resolved]
+
+    if isinstance(value, ast.Name):
+        resolved = _resolve_name_via_wrapper(
+            call, value.id, module, all_modules, file=file, lineno=lineno,
+        )
+        return resolved
+
+    raise UnresolvedDispatchCallError(
+        f"{file}:{lineno} dispatch_notification({field_name}=...) 표현식을 정적으로 "
+        f"해석 못 함(ast dump: {ast.dump(value)}) — 신규 동적 패턴이면 "
+        f"deeplink_contract_lib.py 스캐너를 갱신할 것."
+    )
+
+
+def _resolve_name_via_wrapper(
+    call: ast.Call, param_name: str, module: ast.Module,
+    all_modules: dict[Path, ast.Module], *, file: Path, lineno: int,
+) -> list[str | None]:
+    """call이 속한 함수(래퍼)의 파라미터 param_name을 코드베이스 전체 호출부에서 역추적."""
+    fn = _find_enclosing_function(module, call)
+    if fn is None or param_name not in (_func_positional_params(fn) + _func_kwonly_params(fn)):
+        raise UnresolvedDispatchCallError(
+            f"{file}:{lineno} '{param_name}'이 감싸는 함수의 파라미터가 아님 — "
+            f"신규 동적 패턴이면 스캐너 갱신 필요."
+        )
+
+    params = _func_positional_params(fn)
+    kwonly = _func_kwonly_params(fn)
+    gating_param = _gating_param_name(fn, call, params + kwonly)
+
+    resolved: list[str | None] = []
+    for _caller_path, caller_call in _find_wrapper_call_sites(all_modules, fn.name):
+        if gating_param is not None:
+            gate_value = _bound_arg(caller_call, params, kwonly, gating_param)
+            if gate_value is not None and _is_falsy_literal(gate_value):
+                continue  # 정적으로 도달 불가 판정(예: emit_goal_removed의 notify_member_id=None).
+
+        bound = _bound_arg(caller_call, params, kwonly, param_name)
+        if bound is None:
+            raise UnresolvedDispatchCallError(
+                f"{fn.name}() 호출부가 '{param_name}' 인자를 안 넘김 — 정적 해석 실패."
+            )
+        lit = _literal_str(bound)
+        if lit is None:
+            raise UnresolvedDispatchCallError(
+                f"{fn.name}() 호출부의 '{param_name}' 인자가 리터럴이 아님(ast dump: "
+                f"{ast.dump(bound)}) — 신규 동적 패턴이면 스캐너 갱신 필요."
+            )
+        resolved.append(lit)
+    return resolved
+
+
+# ============================================================================
+# AC3 — 매니페스트 target ↔ apps/web 실제 라우트 대조.
+# ============================================================================
+
+# S1 doc(`draft-1951-deeplink-manifest-v1` §2) 확인 4건(goal/sprint/chat/team_member) +
+# 이 스토리(#1952) 착수 전 GATE1 확장 조사 결과.
+#
+# story_detail: `apps/web/.../[ws]/[proj]/board/board-client.tsx`가 쓰는
+#   `kanban-board.tsx`가 `searchParams.get('story')`로 StoryDetailPanel을 연다(실측) — 별도
+#   `[id]` 서브라우트가 아니라 board 페이지의 쿼리파람 소비 방식(sprint_detail과 동형).
+# doc_detail: `docs/[slug]/page.tsx` 동적 라우트 존재(id→slug 변환은 §7 기존 GET
+#   /docs/{id} 응답 필드로 해소 — 라우트 자체는 실존).
+# artifact_detail: **GAP으로 확인**(`apps/web/src/components/canvas/artifact-gallery-view.tsx`
+#   전수 확인 — `useSearchParams`/URL 기반 상세 오픈 로직 0건, `ArtifactExpandDialog`는
+#   순수 클라이언트 인메모리 상태로만 열림 — 딥링크로 직접 도달 불가). gate_detail/
+#   hypothesis 패턴과 동일하게 매니페스트 쪽에서 `target_promotion_pending=True`로 표시해
+#   이 AC3 체크 대상에서 제외(별도 커밋으로 매니페스트 수정 — 근거는 최종 보고 참고).
+TARGET_ROUTE_GLOBS: dict[str, tuple[str, ...]] = {
+    "goal_detail": ("(authenticated)/[ws]/[proj]/goals/[id]/page.tsx",),
+    "sprint_detail": ("(authenticated)/[ws]/[proj]/sprints/page.tsx",),
+    "chat_thread": ("(authenticated)/chats/[conversation_id]/page.tsx",),
+    "team_member_detail": ("(authenticated)/organization/workforce/[id]/page.tsx",),
+    "doc_detail": ("(authenticated)/[ws]/[proj]/docs/[slug]/page.tsx",),
+    "story_detail": ("(authenticated)/[ws]/[proj]/board/page.tsx",),
+}
+
+
+def resolve_target_route(target: str) -> tuple[str, ...] | None:
+    """target(논리적 화면 식별자 또는 `/board?story=`류 리터럴 경로)을 apps/web 파일시스템
+    후보 경로들로 변환. 매핑이 없으면 None(호출자가 fail-closed 처리)."""
+    if target in TARGET_ROUTE_GLOBS:
+        return TARGET_ROUTE_GLOBS[target]
+    if target.startswith("/"):
+        # task_completed의 "/board?story=" 같은 팀 기존 폴백 컨벤션 — 쿼리스트링 제거 후
+        # 첫 경로 세그먼트를 프로젝트-스코프 라우트로 매핑.
+        path_part = target.split("?", 1)[0].strip("/")
+        segment = path_part.split("/", 1)[0] if path_part else ""
+        if segment:
+            return (f"(authenticated)/[ws]/[proj]/{segment}/page.tsx",)
+    return None
+
+
+def target_route_exists(target: str) -> bool:
+    candidates = resolve_target_route(target)
+    if not candidates:
+        return False
+    return any((APPS_WEB_APP_DIR / c).exists() for c in candidates)

--- a/backend/tests/test_deeplink_manifest_contract.py
+++ b/backend/tests/test_deeplink_manifest_contract.py
@@ -1,24 +1,47 @@
-"""story #1951 (E-MOBILE P1a-S1) DRAFT fixture — 딥링크 계약 매니페스트 v1 초안 검증.
+"""story #1951/#1952 (E-MOBILE P1a-S1/S2) — 딥링크 계약 매니페스트 v1 CI 게이트.
 
-⚠️ 이 테스트는 3자 검토(디디+유나+미르코) 전 로컬 실행 확인용이다. CI에 정식 편입하는 건
-story #1952(P1a-S2) 스코프 — 이번 스토리는 draft 브랜치에만 존재하고 PR도 열지 않는다.
+story #1951이 만든 `DEEPLINK_MANIFEST` SSOT(3자 검토 확정)를 story #1952가 실제 CI 게이트로
+승격한다. `test_deeplink_manifest_draft.py`(3자 검토 전 로컬 검증용)를 이 파일로 rename —
+기존 13개 테스트(정상 4·위반 4·무결성 3·불변식 1 + 엔드포인트 2 — 엔드포인트는
+`test_deeplink_manifest_endpoint.py`로 별도 승격) 커버리지는 그대로 유지하고, 아래 신규
+섹션에 AC1~AC3 CI 불변식을 추가한다:
+
+- AC1 (미등재 발송 코드 차단): `dispatch_notification()` 실제 호출부를 AST로 정적 스캔해
+  발화 가능한 (event_type, entity_type) 조합을 재구성하고, `DEEPLINK_MANIFEST.find()`
+  (프로덕션이 실제로 쓰는 그 룩업 함수 — 재구현 금지)로 전부 등재됐는지 대조한다.
+  (`deeplink_contract_lib.py` 참고 — 하드코딩된 기대 집합이 아니라 소스를 직접 훑으므로
+  신규 dispatch_notification() 호출부가 생기면 매니페스트 갱신 없이 자동으로 실패한다.)
+- AC2 (필수 target 식별자 누락 차단): 매치된 매니페스트 엔트리의 `required_payload`가
+  요구하는 kwarg가 실제 호출부 소스에 없으면 실패.
+- AC3 (target 실존 원칙): `target_promotion_pending=False`인 엔트리의 `target`이
+  `apps/web`에 대응 라우트가 없으면 실패.
+- AC4 (유나 불변식 재사용): `test_same_target_implies_same_parent_tab` — 이 파일에 원래
+  있던 걸 그대로 유지(신규 구현 아님, story #1952 지시에 따라 "재사용/승격" 확인 완료).
 
 정상 케이스 ≥1 + 위반 케이스(미등재 타입 1건·필수 필드 누락 1건) 각 ≥1을 로컬에서
 pass/fail(의도된 실패)로 실증한다.
 """
 from __future__ import annotations
 
+import sys
 import uuid
+from pathlib import Path
 
 import pytest
 
-from app.schemas.deeplink_manifest import (
+sys.path.insert(0, str(Path(__file__).parent))
+
+from app.schemas.deeplink_manifest import (  # noqa: E402
     DEEPLINK_MANIFEST,
     MANIFEST_SCHEMA_VERSION,
     MissingRequiredDeepLinkPayloadError,
     ParentTab,
     UnregisteredDeepLinkTypeError,
     validate_push_payload,
+)
+from deeplink_contract_lib import (  # noqa: E402
+    scan_dispatch_notification_call_sites,
+    target_route_exists,
 )
 
 
@@ -148,8 +171,8 @@ def test_same_target_implies_same_parent_tab():
     한다 — "same target ⇒ same parentTab". 같은 착지 화면이 알림 타입에 따라 소속 탭이
     갈리면 4탭 공간 모델과 합성 history(P2-S3) 전제가 깨진다.
 
-    이 테스트는 draft 파일에만 존재하지만(story #1951 스코프), story #1952(P1a-S2 계약
-    CI)에서 정식 CI 불변식으로 편입될 예정이다 — 유나 지시로 지금 여기 넣어둔다.
+    story #1951 draft 시절부터 있던 테스트를 story #1952가 그대로 재사용/승격한다(유나 지시
+    — 신규 구현 아님, AC4 요구사항 그대로 이관).
 
     전체 레지스트리를 target으로 grouping해서 그룹 내 parentTab이 유일한지 확인한다
     (양방향: 그룹이 2개 이상의 서로 다른 parentTab을 가지면 실패)."""
@@ -161,4 +184,89 @@ def test_same_target_implies_same_parent_tab():
     assert not violations, (
         f"target이 서로 다른 parentTab을 가리키는 위반 발견(same target ⇒ same parentTab "
         f"불변식 깨짐): {violations}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# story #1952(P1a-S2) CI 편입 — AC1/AC2: dispatch_notification() 실제 발송 코드 대조.
+# ---------------------------------------------------------------------------
+
+def test_ac1_every_dispatched_event_type_is_registered():
+    """AC1: 미등재 알림 발송 코드 = CI 실패.
+
+    `deeplink_contract_lib.scan_dispatch_notification_call_sites()`가 소스(backend/app +
+    backend/ee)를 AST로 직접 훑어 실제 `dispatch_notification()` 호출부가 발화 가능한
+    (event_type, reference_type) 조합을 재구성한다(하드코딩된 기대 집합 아님 — 신규 호출부가
+    추가되면 이 테스트가 자동으로 그 조합을 알아채고 매니페스트 대조를 강제한다).
+
+    각 조합을 프로덕션이 실제로 쓰는 `DEEPLINK_MANIFEST.find()`(재구현 아님, S1 산출물
+    재사용)로 조회 — 등재 안 됐으면 실패."""
+    sites = scan_dispatch_notification_call_sites()
+    unregistered = []
+    for site in sites:
+        for event_type in site.resolved_event_types:
+            for reference_type in site.resolved_reference_types:
+                if DEEPLINK_MANIFEST.find(event_type, reference_type) is None:
+                    unregistered.append((site.file, site.lineno, event_type, reference_type))
+    assert not unregistered, (
+        "매니페스트에 없는 실 발송 (event_type, reference_type) 조합 발견 — "
+        "DEEPLINK_MANIFEST에 등재할 것:\n" + "\n".join(
+            f"  {f}:{ln} event_type={et!r} reference_type={rt!r}"
+            for f, ln, et, rt in unregistered
+        )
+    )
+
+
+def test_ac2_every_dispatch_call_site_supplies_required_payload_fields():
+    """AC2: 필수 target 식별자 누락 차단.
+
+    매치된 매니페스트 엔트리의 `required_payload`(예: `reference_id`)가 실제
+    `dispatch_notification()` 호출부 소스에 kwarg로 없으면 실패 — payload 값 자체가 아니라
+    "호출부가 그 kwarg를 아예 안 넘긴다"는 소스-레벨 누락을 잡는다(런타임 값 검증은
+    `validate_push_payload`/`test_missing_required_reference_id_fails_closed`가 이미
+    커버)."""
+    sites = scan_dispatch_notification_call_sites()
+    missing_by_site = []
+    for site in sites:
+        # DeepLinkManifestEntry.payload.required_payload가 list라 엔트리 자체는 unhashable —
+        # lookup_key(hashable 튜플)로 중복 제거.
+        entries_by_key: dict[tuple[str, str | None], object] = {}
+        for event_type in site.resolved_event_types:
+            for reference_type in site.resolved_reference_types:
+                entry = DEEPLINK_MANIFEST.find(event_type, reference_type)
+                if entry is not None:
+                    entries_by_key[entry.lookup_key] = entry
+        for entry in entries_by_key.values():
+            missing = [f for f in entry.payload.required_payload if f not in site.kwarg_names]
+            if missing:
+                missing_by_site.append((site.file, site.lineno, entry.app.type, missing))
+    assert not missing_by_site, (
+        "dispatch_notification() 호출부가 매니페스트 required_payload를 안 채움:\n"
+        + "\n".join(
+            f"  {f}:{ln} type={t!r} missing={m}" for f, ln, t, m in missing_by_site
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# story #1952(P1a-S2) CI 편입 — AC3: 매니페스트 target ↔ apps/web 실제 웹 라우트 대조.
+# ---------------------------------------------------------------------------
+
+def test_ac3_active_targets_have_existing_web_routes():
+    """AC3: 매니페스트 target이 미존재 웹 라우트면 실패.
+
+    `target_promotion_pending=True`(승격 대기 — 아직 라우트 없음을 스스로 선언한 엔트리,
+    예: gate_detail(P1a-S4)·hypothesis "now" 폴백(P1a-S3)·artifact_detail(이번 스토리
+    조사로 확인된 GAP))는 이 체크에서 제외한다 — 그 플래그 자체가 "아직 없다"는 선언이라
+    실존 검증 대상이 아니다.
+
+    나머지(target_promotion_pending=False, "이미 실존한다"고 선언한 엔트리)는
+    `deeplink_contract_lib.target_route_exists()`(apps/web 파일시스템 직접 스캔)로 대조."""
+    active_targets = {
+        e.app.target for e in DEEPLINK_MANIFEST.entries if not e.app.target_promotion_pending
+    }
+    missing = sorted(t for t in active_targets if not target_route_exists(t))
+    assert not missing, (
+        "target_promotion_pending=False인데 apps/web에 대응 라우트가 없는 target — "
+        "라우트를 만들거나 target_promotion_pending=True로 표시할 것: " + str(missing)
     )

--- a/backend/tests/test_deeplink_manifest_endpoint.py
+++ b/backend/tests/test_deeplink_manifest_endpoint.py
@@ -1,8 +1,10 @@
-"""story #1951 (E-MOBILE P1a-S1) DRAFT fixture — GET /api/v2/deeplink-manifest 서빙 엔드포인트.
+"""story #1951 (E-MOBILE P1a-S1) — GET /api/v2/deeplink-manifest 서빙 엔드포인트.
 
-PO 재정(3자 검토 스코프 확장)으로 이번 스토리에 추가된 런타임 API. mcp.py의
-/api/v2/mcp/manifest 테스트 패턴(test_e_mcp_s2_toolset.py)을 그대로 따른다 — 이 파일도
-draft(3자 검토 전 로컬 실행 확인용)이고, CI 정식 편입은 story #1952 스코프.
+PO 재정(3자 검토 스코프 확장)으로 story #1951에서 추가된 런타임 API. mcp.py의
+/api/v2/mcp/manifest 테스트 패턴(test_e_mcp_s2_toolset.py)을 그대로 따른다.
+
+story #1952(P1a-S2)에서 CI 정식 편입 — "draft" 딱지 제거(`test_deeplink_manifest_endpoint_draft.py`
+→ 이 파일). 로직 변경 없음(3자 검토 확정 산출물 그대로 승격).
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- story #1951(PR #2245, develop 머지 완료)이 만든 `DEEPLINK_MANIFEST` SSOT를 실제 CI
  게이트로 승격.
- `backend/tests/deeplink_contract_lib.py`(신규): `dispatch_notification()` 실제 호출부를
  AST로 정적 스캔해 발화 가능한 `(event_type, entity_type)` 조합과 필수 payload kwarg를
  소스에서 직접 재구성한다(하드코딩된 기대 집합 아님 — 신규 호출부가 추가돼도 매니페스트
  갱신 없이는 자동으로 CI가 RED). `apps/web` 파일시스템 대조로 매니페스트 `target`의 실제
  웹 라우트 존재 여부도 검증.
- `test_deeplink_manifest_draft.py` → `test_deeplink_manifest_contract.py`,
  `test_deeplink_manifest_endpoint_draft.py` → `test_deeplink_manifest_endpoint.py`로
  승격(rename) — 기존 13개 테스트 커버리지 유지 + AC1(미등재 발송 코드 차단)·AC2(필수
  payload 누락 차단)·AC3(target 실존 원칙) 3종 CI 불변식 신규 추가. AC4(same target ⇒
  same parentTab)는 S1이 만든 기존 테스트를 그대로 재사용(신규 구현 아님).
- `backend/app/schemas/deeplink_manifest.py`: 이번 CI 조사 중 발견한 실 GAP 수정 —
  `artifact_detail`(5개 엔트리)이 `apps/web`에 대응하는 웹 라우트가 없음을 코드 실측으로
  확인(`artifact-gallery-view.tsx`에 `useSearchParams`/동적 라우트 소비 0건,
  `ArtifactExpandDialog`는 순수 클라이언트 인메모리 상태로만 열림). `gate_detail`과 동일
  패턴으로 `target_promotion_pending=True` 표시 — AC3 체크 대상에서 제외됨.
- CI 워크플로우 yaml **변경 없음** — 신규 테스트 파일이 기존 "Backend pytest"
  job(`cd backend && uv run pytest`)에 자동으로 편입됨(순수 로직 테스트, DB/네트워크 불요).

## Test plan
- [x] `uv run pytest tests/test_deeplink_manifest_contract.py
      tests/test_deeplink_manifest_endpoint.py` — 16개 전부 PASS.
- [x] done-gate: AC1(미등재 event_type 발송 코드 주입) → RED 확인 → 원복 → GREEN 재확인.
- [x] done-gate: AC2(필수 `reference_id` payload 누락 주입) → RED 확인 → 원복 → GREEN
      재확인.
- [x] done-gate: AC3(존재하지 않는 라우트에 `target_promotion_pending=False` 강등 주입) →
      RED 확인 → 원복 → GREEN 재확인.
- [x] `uv run pytest -q -m "not destructive_schema"` 전체 스윕 — 3395 passed, 7 pre-existing
      unrelated failures(MCP tool count/python path — `origin/develop` HEAD에서도 동일하게
      실패함을 `git stash` 대조로 확인, 이 PR과 무관).

🤖 Generated with [Claude Code](https://claude.com/claude-code)