### PR TITLE
[SID:1958] 768~1023 콘텐츠 640 중앙 밀도(태블릿 프레임) fast-follow

### DIFF
--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -9,6 +9,7 @@ import {
   setEffectiveProjectId,
 } from '@/lib/project-context-client';
 import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
 import { RealtimeProvider } from '@/components/realtime-provider';
 import { SessionExpiredDialog } from '@/components/auth/session-expired-dialog';
 import { AppSidebar } from '@/components/nav/app-sidebar';
@@ -53,7 +54,16 @@ interface DashboardShellProps extends DashboardContext {
   children: React.ReactNode;
 }
 
-function ScrollShell({ showTopBar, children }: { showTopBar: boolean; children: React.ReactNode }) {
+// story #1958(P2-S2) 유나 노트⑶: 768~1023(태블릿, lg 미만)은 모바일 IA를 유지하되 콘텐츠만
+// 640 중앙폭으로 밀도 조정(시안 511bc035 v2 "태블릿 세로 768" 프레임 — `.tablet .content{max-width:640px}`).
+// 2단 그리드 미도입 — 4탭 루트(지금·결재함·채팅·전체)에만 적용, /board 등 기존 데스크톱 페이지는 제외.
+const TAB_ROOT_PREFIXES = ['/glance', '/inbox', '/chats', '/more'];
+
+function isTabRootPage(pathname: string): boolean {
+  return TAB_ROOT_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`));
+}
+
+function ScrollShell({ showTopBar, tabletCentered, children }: { showTopBar: boolean; tabletCentered: boolean; children: React.ReactNode }) {
   const { setScrollContainer } = useTopBar();
   const setRef = useCallback((el: HTMLDivElement | null) => {
     setScrollContainer(el);
@@ -90,7 +100,10 @@ function ScrollShell({ showTopBar, children }: { showTopBar: boolean; children: 
           className="min-h-0 flex-1"
           inlineColumnsClassName="2xl:grid-cols-[minmax(0,1fr)_320px]"
           panelClassName="2xl:col-start-2 2xl:row-start-1"
-          contentClassName="flex min-h-0 min-w-0 flex-col 2xl:col-start-1 2xl:row-start-1"
+          contentClassName={cn(
+            'flex min-h-0 min-w-0 flex-col 2xl:col-start-1 2xl:row-start-1',
+            tabletCentered && 'min-[768px]:mx-auto min-[768px]:w-full min-[768px]:max-w-[640px] lg:max-w-none lg:mx-0',
+          )}
         >
           {children}
         </ContextualPanelLayout>
@@ -165,6 +178,7 @@ export function DashboardShell({
 }: DashboardShellProps) {
   const pathname = usePathname();
   const showTopBar = !pathname.startsWith('/settings');
+  const tabletCentered = isTabRootPage(pathname);
 
   // R2: URL `?p=` = 탭별 SSOT. 서버 prop 대신 effective 를 컨텍스트/사이드바에 공급.
   const effectiveProjectId = useProjectSsot(projectId, projectMemberships);
@@ -188,7 +202,7 @@ export function DashboardShell({
               orgMemberships={orgMemberships}
               userName={userName}
             />
-            <ScrollShell showTopBar={showTopBar}>
+            <ScrollShell showTopBar={showTopBar} tabletCentered={tabletCentered}>
               {children}
             </ScrollShell>
           </SidebarProvider>


### PR DESCRIPTION
## Summary
- story #1958(P2-S2) 유나 가디언 노트⑶ AC — "768~1023=콘텐츠 최대폭 640 중앙·2단 미도입" — 가 실 배포 코드에 빠져 있던 것을 라이브 픽셀 재확인 중 자체 발견(768/834에서 콘텐츠 풀블리드 확인).
- 시안 `511bc035` v2 "태블릿 세로 768" 프레임(`.tablet .content{max-width:640px;margin:0 auto}`) 그대로 반영.
- 스코프 = 4탭 루트(`/glance` `/inbox` `/chats` `/more`)만 — `/board` 등 기존 데스크톱 페이지는 제외(2단 그리드 미도입 원칙 유지, 스와임레인 등 풀폭이 필요한 화면 회귀 방지).
- `min-[768px]:` arbitrary breakpoint 사용(`md:` 금지 — story #1957 회귀가드 `verify:no-new-md-breakpoint` 통과 확인).

## Test plan
- [x] `pnpm --filter web verify:no-new-md-breakpoint` PASS(신규 회귀 0)
- [x] `npx tsc --noEmit` PASS
- [x] `pnpm build` EXIT 0
- [ ] dev 배포 후 라이브 768/834 스크린샷으로 640 중앙 확인(이전 라이브 확인에서 풀블리드였던 것과 대조)

🤖 Generated with [Claude Code](https://claude.com/claude-code)