### PR TITLE
[SID:1959] 웹 스택·딥링크 합성 history — parentTab 루트 선주입·BACK 계약

### DIFF
--- a/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/[ws]/[proj]/docs/[slug]/page.tsx
@@ -25,6 +25,7 @@ import {
 import { useDocsLayout } from '../docs-context';
 import { DocAssigneeControl } from '@/components/docs/doc-assignee-control';
 import { DocBreadcrumb } from '@/components/docs/doc-breadcrumb';
+import { useSyntheticParentTabHistory } from '@/hooks/use-synthetic-parent-tab-history';
 
 interface DocDetail {
   id: string;
@@ -118,6 +119,9 @@ function InlineSaveIndicator({
 export default function DocSlugPage() {
   const params = useParams();
   const slug = typeof params.slug === 'string' ? params.slug : '';
+  // story #1959(P2-S3): 딥링크 매니페스트(doc_detail→parentTab=all) — 콜드 진입 시 "전체"
+  // 탭 루트를 BACK 대상으로 선주입. 목록에서 클릭해 온 경우(history.length>1)는 no-op.
+  useSyntheticParentTabHistory('/more');
   const router = useRouter();
   const t = useTranslations('docs');
   const tc = useTranslations('common');

--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
@@ -8,6 +8,7 @@ import { ChatView } from '@/components/chat/chat-view';
 import type { PresenceStatus } from '@/components/chat/presence-dot';
 import { AddParticipantModal } from '@/components/chat/add-participant-modal';
 import { useDashboardContext } from '../../../dashboard/dashboard-shell';
+import { useSyntheticParentTabHistory } from '@/hooks/use-synthetic-parent-tab-history';
 
 interface Participant {
   member_id: string;
@@ -40,6 +41,9 @@ function formatHeaderTitle(meta: ConversationMeta, currentMemberId: string): str
 export default function ConversationPage() {
   const { conversation_id } = useParams<{ conversation_id: string }>();
   const router = useRouter();
+  // story #1959(P2-S3): 딥링크 매니페스트(chat_thread→parentTab=chat) — 콜드 진입 시 "채팅"
+  // 탭 루트를 BACK 대상으로 선주입. 목록에서 클릭해 온 경우(history.length>1)는 no-op.
+  useSyntheticParentTabHistory('/chats');
   // Deeplink (ade2d6d5): /chats/{id}?messageId={uuid} → ChatView scrolls to + highlights it.
   // ChatView has key={conversation_id} so this is read fresh per conversation.
   const searchParams = useSearchParams();

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -52,7 +52,9 @@ export default function LoginPage() {
         setError(result.error.message);
         return;
       }
-      router.push(safeNextPath(nextParam));
+      // story #1959(P2-S3) AC: 로그인 복귀 후 /login history 잔존 0 — push 는 스택에 남아
+      // 복귀 화면에서 BACK 1회가 로그인 폼으로 돌아가 버린다(재제출 위험). replace 로 스왑.
+      router.replace(safeNextPath(nextParam));
       router.refresh();
     } finally {
       setFirebaseLoading(false);
@@ -74,7 +76,8 @@ export default function LoginPage() {
         setError(result.error.message);
         return;
       }
-      router.push(safeNextPath(nextParam));
+      // story #1959(P2-S3): 위와 동일 사유 — replace 로 /login history 잔존 방지.
+      router.replace(safeNextPath(nextParam));
       router.refresh();
     } catch {
       setError(t('loginFailed'));

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -36,6 +36,7 @@ import {
   DialogFooter, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog';
 import { ToastContainer, useToast } from '@/components/ui/toast';
+import { useSyntheticParentTabHistory } from '@/hooks/use-synthetic-parent-tab-history';
 
 interface Task {
   id: string;
@@ -115,6 +116,9 @@ function DescriptionViewer({ description }: { description: string }) {
 
 export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loadingMoreTasks = false, onLoadMoreTasks, onClose, onStoryUpdate, onDeleteSuccess, memberMap = {}, members = [], storyMap = {}, epicMap = {}, sprintMap = {}, onNavigate, projectId }: StoryDetailPanelProps) {
   const t = useTranslations('board');
+  // story #1959(P2-S3): 딥링크 매니페스트(story_detail→parentTab=all) — 콜드 진입 시 "전체"
+  // 탭 루트를 BACK 대상으로 선주입. 카드 클릭으로 연 경우(history.length>1)는 no-op.
+  useSyntheticParentTabHistory('/more');
   const { toasts, addToast, dismissToast } = useToast();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleting, setDeleting] = useState(false);

--- a/apps/web/src/components/nav/mobile-tab-bar.tsx
+++ b/apps/web/src/components/nav/mobile-tab-bar.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from 'next-intl';
 import { CircleDot, Inbox, MessageSquare, Grid2x2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import type { GateItem } from '@/components/kanban/types';
+import { MOBILE_BREAKPOINT } from '@/hooks/use-mobile';
 
 // story #1958(P2-S2, mobile-p2-p1a-story-breakdown SSOT) — 모바일 4탭 셸. <1024(lg 미만)에서만
 // 렌더되고 데스크톱 GNB(AppSidebar)를 대체한다(P2-S1의 lg:1024 SSOT와 동일 경계 — route 내
@@ -43,6 +44,13 @@ export function MobileTabBar() {
   const [pendingCount, setPendingCount] = useState(0);
 
   useEffect(() => {
+    // 유나 가디언 지적(#2249 병합 처리) — 탭바 자체는 `lg:hidden`(CSS 시각 게이팅)이지만
+    // CSS hidden은 DOM 마운트/effect 실행을 막지 않는다. 배지 fetch는 <1024에서만 필요하니
+    // 데스크톱에서도 매번 나가던 것을 막는다. useIsMobile()의 mount-시 undefined→effect
+    // 확定 타이밍 레이스(유나 지적)를 피하려 여기서도 use-synthetic-parent-tab-history.ts와
+    // 동일하게 window.innerWidth를 effect 내부에서 동기 판정한다(첫 렌더 즉시 정확한 값).
+    if (typeof window === 'undefined' || window.innerWidth >= MOBILE_BREAKPOINT) return;
+
     let cancelled = false;
     void (async () => {
       try {

--- a/apps/web/src/hooks/use-mobile.ts
+++ b/apps/web/src/hooks/use-mobile.ts
@@ -2,7 +2,7 @@ import * as React from "react"
 
 // P2-S1(mobile-p2-p1a-story-breakdown SSOT): 1024=데스크톱 IA 경계로 수렴(Tailwind lg와 정합).
 // GNB(components/ui/sidebar.tsx)도 동일 경계로 md:→lg: 전환 완료 — 이 값과 항상 같이 움직인다.
-const MOBILE_BREAKPOINT = 1024
+export const MOBILE_BREAKPOINT = 1024
 
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)

--- a/apps/web/src/hooks/use-synthetic-parent-tab-history.test.tsx
+++ b/apps/web/src/hooks/use-synthetic-parent-tab-history.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+//
+// story #1959(P2-S3) — useSyntheticParentTabHistory 콜드/내부진입 분기·멱등 가드 회귀 테스트.
+// 실 브라우저 세션 history 대신 window.history.pushState/replaceState를 spy로 관찰(네비게이션
+// 발생 없음 — jsdom 제약이 아니라 이 훅 자체가 raw history API만 건드리므로 이 검증으로 충분).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useSyntheticParentTabHistory } from './use-synthetic-parent-tab-history';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+let pushSpy: ReturnType<typeof vi.spyOn>;
+let replaceSpy: ReturnType<typeof vi.spyOn>;
+
+function setHistoryLength(n: number) {
+  Object.defineProperty(window.history, 'length', { value: n, configurable: true });
+}
+
+function setHistoryState(state: unknown) {
+  Object.defineProperty(window.history, 'state', { value: state, configurable: true });
+}
+
+function TestComp({ parentTabHref }: { parentTabHref: string }) {
+  useSyntheticParentTabHistory(parentTabHref);
+  return null;
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  pushSpy = vi.spyOn(window.history, 'pushState');
+  replaceSpy = vi.spyOn(window.history, 'replaceState');
+  setHistoryState(null);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  pushSpy.mockRestore();
+  replaceSpy.mockRestore();
+});
+
+describe('useSyntheticParentTabHistory', () => {
+  it('콜드 진입(history.length===1)이면 parentTab 루트를 선주입한다', () => {
+    setHistoryLength(1);
+    act(() => root.render(<TestComp parentTabHref="/more" />));
+
+    expect(replaceSpy).toHaveBeenCalledTimes(1);
+    expect(replaceSpy.mock.calls[0][2]).toBe('/more');
+    expect(pushSpy).toHaveBeenCalledTimes(1);
+    // target = 현재 jsdom 기본 URL(pathname+search) 그대로 재푸시
+    expect(pushSpy.mock.calls[0][2]).toBe(window.location.pathname + window.location.search);
+  });
+
+  it('SPA 내부 진입(history.length>1)이면 아무것도 하지 않는다', () => {
+    setHistoryLength(2);
+    act(() => root.render(<TestComp parentTabHref="/more" />));
+
+    expect(replaceSpy).not.toHaveBeenCalled();
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+
+  it('이미 합성된 상태(history.state 마커)면 재실행하지 않는다 — 새로고침 재마운트 멱등', () => {
+    setHistoryLength(1);
+    setHistoryState({ _sprintableSyntheticRoot: true });
+    act(() => root.render(<TestComp parentTabHref="/more" />));
+
+    expect(replaceSpy).not.toHaveBeenCalled();
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+
+  it('현재 URL이 이미 parentTab 루트 자체면 합성하지 않는다', () => {
+    setHistoryLength(1);
+    const originalHref = window.location.href;
+    window.history.pushState(null, '', '/more');
+    pushSpy.mockClear();
+
+    act(() => root.render(<TestComp parentTabHref="/more" />));
+
+    expect(replaceSpy).not.toHaveBeenCalled();
+    expect(pushSpy).not.toHaveBeenCalled();
+
+    window.history.pushState(null, '', originalHref);
+  });
+});

--- a/apps/web/src/hooks/use-synthetic-parent-tab-history.test.tsx
+++ b/apps/web/src/hooks/use-synthetic-parent-tab-history.test.tsx
@@ -23,6 +23,10 @@ function setHistoryState(state: unknown) {
   Object.defineProperty(window.history, 'state', { value: state, configurable: true });
 }
 
+function setViewportWidth(w: number) {
+  Object.defineProperty(window, 'innerWidth', { value: w, configurable: true, writable: true });
+}
+
 function TestComp({ parentTabHref }: { parentTabHref: string }) {
   useSyntheticParentTabHistory(parentTabHref);
   return null;
@@ -35,6 +39,7 @@ beforeEach(() => {
   pushSpy = vi.spyOn(window.history, 'pushState');
   replaceSpy = vi.spyOn(window.history, 'replaceState');
   setHistoryState(null);
+  setViewportWidth(390); // 기본값 = 모바일. 데스크톱 게이팅 테스트만 개별 override.
 });
 
 afterEach(() => {
@@ -85,5 +90,23 @@ describe('useSyntheticParentTabHistory', () => {
     expect(pushSpy).not.toHaveBeenCalled();
 
     window.history.pushState(null, '', originalHref);
+  });
+
+  it('데스크톱(≥1024)이면 콜드 진입이어도 합성하지 않는다 — 탭 IA 자체가 없음(까심 QA #2249 지적)', () => {
+    setViewportWidth(1024);
+    setHistoryLength(1);
+    act(() => root.render(<TestComp parentTabHref="/more" />));
+
+    expect(replaceSpy).not.toHaveBeenCalled();
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+
+  it('경계값 1023(모바일)은 정상 합성, 1024(데스크톱)는 no-op — MOBILE_BREAKPOINT SSOT 경계 확인', () => {
+    setViewportWidth(1023);
+    setHistoryLength(1);
+    act(() => root.render(<TestComp parentTabHref="/more" />));
+
+    expect(replaceSpy).toHaveBeenCalledTimes(1);
+    expect(pushSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/hooks/use-synthetic-parent-tab-history.ts
+++ b/apps/web/src/hooks/use-synthetic-parent-tab-history.ts
@@ -1,10 +1,20 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
+import { MOBILE_BREAKPOINT } from './use-mobile';
 
 // story #1959(P2-S3): 딥링크로 상세 화면에 직접 진입("콜드 진입")했을 때 뒤로가기 1회로
 // 소속 탭 루트(parentTab, #1951 매니페스트 SSOT)에 복귀하도록 루트 history entry 를
 // 선주입한다.
+//
+// 뷰포트 게이팅(까심 QA 지적, #2249 재작업) — 이 합성은 <1024(모바일 4탭 IA, #1957 SSOT
+// `MOBILE_BREAKPOINT` 재사용) 에서만 동작한다. ≥1024(데스크톱)는 탭바 자체가 없어(lg:hidden)
+// "탭 루트"라는 개념이 없다 — 게이팅 없이 전역 실행하면 데스크톱 콜드 진입(공유 링크·새 탭)
+// 후 BACK 이 모바일 전용 스텁(`/more`)으로 튀는 오동작이 난다. `useIsMobile()`(React state,
+// 초기 렌더 false→effect 후 실측)를 그대로 합성하면 그 첫 렌더의 false 가 doneRef 를 조기
+// 소모해 실측 후 재시도가 막히므로, 여기서는 effect 내부에서 `window.innerWidth` 를
+// 직접(동기) 읽는다 — 이 effect 자체가 client-only·mount 1회이므로 SSR/하이드레이션
+// 불일치 우려가 없다.
 //
 // 콜드 진입 판별 = 이 페이지가 mount 된 시점의 `window.history.length`. 새 탭에서 상세
 // URL 을 직접 열면(딥링크·북마크·주소창 입력) 이 페이지가 그 탭의 첫 entry 라 length===1.
@@ -18,8 +28,10 @@ import { useEffect, useRef } from 'react';
 //
 // window.history.back() 은 호출하지 않는다 — Next.js App Router 내부 history 스택과
 // 충돌해 이후 router.push() 가 깨지는 회귀가 있었다([[feedback-history-back-nextjs]]).
-// 대신 replaceState+pushState 로 raw history API 만 건드리는 chat-view.tsx
-// openThread/popstate 패턴과 동형.
+// 대신 replaceState+pushState 로 raw history API 만 건드린다(chat-view.tsx 의
+// openThread 도 같은 이유로 pushState 를 직접 쓰지만, popstate 시 pushState 로만
+// 되돌리는 단방향 패턴이라 이 훅의 replaceState+pushState 조합과 완전히 동일하지는
+// 않다 — 같은 "raw history API, router 비개입" 원칙을 공유하는 것으로 이해할 것).
 const SYNTHESIZED_MARKER = '_sprintableSyntheticRoot';
 
 interface SyntheticHistoryState {
@@ -33,6 +45,7 @@ export function useSyntheticParentTabHistory(parentTabHref: string) {
     if (doneRef.current) return;
     doneRef.current = true;
     if (typeof window === 'undefined') return;
+    if (window.innerWidth >= MOBILE_BREAKPOINT) return; // 데스크톱 — 탭 IA 없음, no-op
 
     const state = window.history.state as SyntheticHistoryState | null;
     if (state?.[SYNTHESIZED_MARKER]) return; // 새로고침 후 재마운트 — 이미 합성됨(멱등 가드)

--- a/apps/web/src/hooks/use-synthetic-parent-tab-history.ts
+++ b/apps/web/src/hooks/use-synthetic-parent-tab-history.ts
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+// story #1959(P2-S3): 딥링크로 상세 화면에 직접 진입("콜드 진입")했을 때 뒤로가기 1회로
+// 소속 탭 루트(parentTab, #1951 매니페스트 SSOT)에 복귀하도록 루트 history entry 를
+// 선주입한다.
+//
+// 콜드 진입 판별 = 이 페이지가 mount 된 시점의 `window.history.length`. 새 탭에서 상세
+// URL 을 직접 열면(딥링크·북마크·주소창 입력) 이 페이지가 그 탭의 첫 entry 라 length===1.
+// 반대로 앱 내부에서 목록→상세로 이동한 경우엔 그 이동 자체가 이미 router.push 로 entry
+// 를 만든 뒤라 length>=2 — 이 훅은 그때 no-op 하므로 AC "SPA 내부 진입=기존 스택 순서
+// 유지" 를 별도 분기 없이 만족한다(목록이 이미 진짜 back 대상이 되어 있다).
+//
+// history.state 에 심는 마커로 멱등 처리 — pushState 로 만든 entry 는 새로고침해도
+// 사라지지 않으므로(AC "새로고침에도 target·parentTab 보존") 재마운트 시 중복 합성만
+// 막으면 된다.
+//
+// window.history.back() 은 호출하지 않는다 — Next.js App Router 내부 history 스택과
+// 충돌해 이후 router.push() 가 깨지는 회귀가 있었다([[feedback-history-back-nextjs]]).
+// 대신 replaceState+pushState 로 raw history API 만 건드리는 chat-view.tsx
+// openThread/popstate 패턴과 동형.
+const SYNTHESIZED_MARKER = '_sprintableSyntheticRoot';
+
+interface SyntheticHistoryState {
+  [SYNTHESIZED_MARKER]?: boolean;
+}
+
+export function useSyntheticParentTabHistory(parentTabHref: string) {
+  const doneRef = useRef(false);
+
+  useEffect(() => {
+    if (doneRef.current) return;
+    doneRef.current = true;
+    if (typeof window === 'undefined') return;
+
+    const state = window.history.state as SyntheticHistoryState | null;
+    if (state?.[SYNTHESIZED_MARKER]) return; // 새로고침 후 재마운트 — 이미 합성됨(멱등 가드)
+    if (window.history.length > 1) return; // SPA 내부 진입 — 이미 진짜 상위 entry 존재
+
+    const targetUrl = window.location.pathname + window.location.search;
+    if (targetUrl === parentTabHref) return; // 이미 탭 루트 자체(합성 불필요)
+
+    window.history.replaceState({ [SYNTHESIZED_MARKER]: true }, '', parentTabHref);
+    window.history.pushState({ [SYNTHESIZED_MARKER]: true }, '', targetUrl);
+  }, [parentTabHref]);
+}


### PR DESCRIPTION
## Summary
- `useSyntheticParentTabHistory(parentTabHref)` 훅 신설: 딥링크 상세 화면에 콜드 진입(새 탭에서 URL 직접 열기 — `history.length===1`)했을 때 소속 parentTab 루트를 `replaceState`+`pushState`로 선주입해 **BACK 1회=탭 루트 복귀**를 보장.
- SPA 내부 진입(목록→상세, 이미 `router.push`로 entry 존재·`history.length>1`)은 no-op — 기존 스택 순서 그대로 보존(AC).
- `history.state` 마커로 멱등 처리 — pushState entry는 새로고침으로 사라지지 않으므로 재마운트 시 target·parentTab 그대로 보존(AC).
- `window.history.back()` 직접 호출 없음 — Next.js App Router 내부 history 스택과 충돌하는 기지 회귀 패턴([[feedback-history-back-nextjs]]) 회피. "raw history API 직접 조작, Next 라우터 비개입" 원칙만 공유(chat-view.tsx의 openThread는 pushState만 쓰고 replaceState는 안 씀 — "동형" 아님, 새 조합).

## 뷰포트 게이팅(까심 QA #2249 1차 재작업 — CRITICAL)
- `useSyntheticParentTabHistory`가 애초 뷰포트 무관 항상 실행돼 데스크톱(≥1024) 콜드 진입 후 BACK이 모바일 전용 스텁 `/more`로 튀는 결함이 있었음. `MOBILE_BREAKPOINT`(#1957 SSOT, `use-mobile.ts`에서 export)를 재사용해 `window.innerWidth` 동기 판정으로 `<1024`에서만 합성, `≥1024`는 no-op.
- `useIsMobile()`을 그대로 쓰지 않은 이유: mount 시 `undefined→effect로 확定`되는 비동기 패턴이라 확定 전 구간에 잘못 합성/합성 누락되는 레이스가 생김(유나 지적). effect 자체가 client-only·mount 1회·DOM 페인트 후 실행이라 `window.innerWidth`를 그 자리서 동기로 읽으면 이 레이스가 아예 없음.
- 동류 결함 병합 수정(유나 선제 적출): `MobileTabBar`의 결재 배지 fetch(`/api/gates?status=pending`)도 같은 클래스 — 탭바는 `lg:hidden`(CSS 시각 게이팅)뿐이라 DOM 마운트·effect 실행은 안 막혀 데스크톱에서도 매번 fetch가 나가고 있었음(무해하나 동일 결함군). 동일한 게이팅 적용.
- 유닛테스트 2건 추가(경계값 1023 모바일 합성 / 1024 데스크톱 no-op).

## 배선 (실 라우트 존재 확인분만, #1951 매니페스트 기준)
- `story_detail` → `story-detail-panel.tsx`(board 패널), parentTab=all→`/more`
- `doc_detail` → `docs/[slug]/page.tsx`, parentTab=all→`/more`
- `chat_thread` → `chats/[conversation_id]/page.tsx`, parentTab=chat→`/chats`
- `gate_detail`·`artifact_detail` 등은 #1951 매니페스트상 `target_promotion_pending=true`(실 라우트 미존재, P1a-S4/추후 스토리) — 스코프 밖.

## 부수 발견·fix
- `login/page.tsx`: 로그인 성공 후 `router.push(safeNextPath(...))`로 복귀하면 `/login`이 history에 남아 복귀 화면에서 BACK 1회가 로그인 폼으로 돌아가 버림(AC "로그인 복귀 후 로그인 화면 history 잔존 0" 위반). `router.replace`로 수정(2곳: 일반 로그인·Firebase 로그인).

## Test plan
- [x] 유닛테스트 6건 GREEN(콜드 진입 합성·내부진입 no-op·멱등·이미루트 no-op·경계값 1023 합성·1024 데스크톱 no-op)
- [x] 전체 스위트 254 files / 1688 tests GREEN(회귀 0)
- [x] `npx tsc --noEmit` PASS
- [x] `pnpm build` EXIT 0
- [x] `pnpm --filter web verify:no-new-md-breakpoint` PASS
- [ ] 배포 후 라이브 3종(콜드 URL 직접 진입·로그인 만료 모사·내부 push) BACK 실측 — done-gate 별도 진행 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)